### PR TITLE
JS: handle rephined variable in access path

### DIFF
--- a/javascript/ql/lib/semmle/javascript/dataflow/internal/AccessPaths.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/internal/AccessPaths.qll
@@ -45,6 +45,8 @@ private PropAccess namedPropAccess(AccessPath base, PropertyName name, BasicBloc
 
 private SsaVariable getRefinedVariable(SsaVariable variable) {
   result = variable.getDefinition().(SsaRefinementNode).getAnInput()
+  or
+  result = variable.getDefinition().(SsaPhiNode).getRephinedVariable()
 }
 
 private SsaVariable getARefinementOf(SsaVariable variable) { variable = getRefinedVariable(result) }

--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
@@ -171,7 +171,6 @@ typeInferenceMismatch
 | promise.js:5:25:5:32 | source() | promise.js:5:8:5:33 | bluebir ... urce()) |
 | promise.js:10:24:10:31 | source() | promise.js:10:8:10:32 | Promise ... urce()) |
 | promise.js:12:20:12:27 | source() | promise.js:13:8:13:23 | resolver.promise |
-| refinement-sanitizer.js:19:17:19:24 | source() | refinement-sanitizer.js:33:10:33:21 | array.join() |
 | rxjs.js:3:1:3:8 | source() | rxjs.js:10:14:10:17 | data |
 | rxjs.js:13:1:13:8 | source() | rxjs.js:17:23:17:23 | x |
 | rxjs.js:13:1:13:8 | source() | rxjs.js:18:23:18:23 | x |

--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
@@ -171,6 +171,7 @@ typeInferenceMismatch
 | promise.js:5:25:5:32 | source() | promise.js:5:8:5:33 | bluebir ... urce()) |
 | promise.js:10:24:10:31 | source() | promise.js:10:8:10:32 | Promise ... urce()) |
 | promise.js:12:20:12:27 | source() | promise.js:13:8:13:23 | resolver.promise |
+| refinement-sanitizer.js:19:17:19:24 | source() | refinement-sanitizer.js:33:10:33:21 | array.join() |
 | rxjs.js:3:1:3:8 | source() | rxjs.js:10:14:10:17 | data |
 | rxjs.js:13:1:13:8 | source() | rxjs.js:17:23:17:23 | x |
 | rxjs.js:13:1:13:8 | source() | rxjs.js:18:23:18:23 | x |

--- a/javascript/ql/test/library-tests/TaintTracking/refinement-sanitizer.js
+++ b/javascript/ql/test/library-tests/TaintTracking/refinement-sanitizer.js
@@ -1,0 +1,34 @@
+import * as dummy from 'dummy';
+
+function oneUse() {
+    let taint = source();
+
+    if (!isSafe(taint)) {
+        return;
+    }
+
+    let array = [];
+    if (taint) {
+        array.push(taint);
+    }
+
+    sink(array.join()); // OK
+}
+
+function secondUse() {
+    let taint = source();
+
+    if (!isSafe(taint)) {
+        return;
+    }
+
+    let array = [];
+    if (taint) {
+        array.push(taint);
+    }
+    if (taint) {
+        array.push(taint);
+    }
+
+    sink(array.join()); // OK
+}


### PR DESCRIPTION
Fixes the strange behavior observed in https://github.com/github/codeql/issues/11488, where adding additional uses of a variable changes how it's sanitized.

[Evaluation](https://github.com/github/codeql-dca-main/issues/9071) looks quiet. A few tainted nodes disappeared in a context where they are guarded by `typeof v === 'number'`, so this fixes some spurious flow.