### PR TITLE
Java: Bad summary.

### DIFF
--- a/java/ql/lib/ext/error.model.yml
+++ b/java/ql/lib/ext/error.model.yml
@@ -1,0 +1,9 @@
+# THIS FILE IS AN AUTO-GENERATED MODELS AS DATA FILE. DO NOT EDIT.
+# Definitions of models for the framework.
+
+extensions:
+  - addsTo:
+      pack: codeql/java-all
+      extensible: extSummaryModel
+    data:
+      - ["package0"]


### PR DESCRIPTION
This PR is a reproduction example for getting an error message in case the number of elements in the arrays provided as data extensions values do not match the arity of the extensible predicate.

To reproduce, checkout this branch and
```bash
codeql test run java/ql/test/library-tests/dataflow/external-models
```
This leads to the following error message.
```bash
Oops! A fatal internal error occurred.
java.lang.ArrayIndexOutOfBoundsException: Index 1 out of bounds for length 1
        at com.semmle.inmemory.caching.ExtensionalStoreBase.evaluate(ExtensionalStoreBase.java:84)
        at com.semmle.inmemory.scheduler.ExtensiblePredicateLayer.evaluate(ExtensiblePredicateLayer.java:65)
        at com.semmle.inmemory.scheduler.SimpleLayerTask.evaluate(SimpleLayerTask.java:89)
        at com.semmle.inmemory.scheduler.LayerTask.evaluate(LayerTask.java:251)
        at com.semmle.inmemory.scheduler.ComputingTask.doWork(ComputingTask.java:606)
        at com.semmle.inmemory.scheduler.ComputingTask.doWork(ComputingTask.java:62)
        at com.semmle.inmemory.scheduler.DemandableTask.doWork(DemandableTask.java:381)
        at com.semmle.inmemory.scheduler.ExecutionScheduler.runnerMain(ExecutionScheduler.java:568)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
        at java.base/java.lang.Thread.run(Unknown Source)
```

@aeisenberg: Would it somehow be possible to improve the error message?
