### PR TITLE
csharp: URI should be Uri in Owin.qll library.

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/frameworks/microsoft/Owin.qll
+++ b/csharp/ql/lib/semmle/code/csharp/frameworks/microsoft/Owin.qll
@@ -118,7 +118,7 @@ class MicrosoftOwinIOwinRequestClass extends Class {
     result.hasName("Scheme")
   }
 
-  /** Gets the `URI` property. */
+  /** Gets the `Uri` property. */
   Property getUriProperty() {
     result = this.getAProperty() and
     result.hasName("Uri")

--- a/csharp/ql/lib/semmle/code/csharp/frameworks/microsoft/Owin.qll
+++ b/csharp/ql/lib/semmle/code/csharp/frameworks/microsoft/Owin.qll
@@ -121,7 +121,7 @@ class MicrosoftOwinIOwinRequestClass extends Class {
   /** Gets the `URI` property. */
   Property getUriProperty() {
     result = this.getAProperty() and
-    result.hasName("URI")
+    result.hasName("Uri")
   }
 
   /** DEPRECATED: Alias for getUriProperty */

--- a/csharp/ql/src/change-notes/2022-12-05-owin-uri-fix.md
+++ b/csharp/ql/src/change-notes/2022-12-05-owin-uri-fix.md
@@ -1,0 +1,4 @@
+---
+category: fix
+---
+* Fixes a bug where the Owin.qll framework library will look for "URI" instead of "Uri" in the OwinRequest class.

--- a/csharp/ql/src/change-notes/2022-12-05-owin-uri-fix.md.
+++ b/csharp/ql/src/change-notes/2022-12-05-owin-uri-fix.md.
@@ -1,4 +1,0 @@
----
-category: fix
----
-* Fixes a bug where the Owin.qll framework library will look for "URI" instead of "Uri" in the OwinRequest class.

--- a/csharp/ql/src/change-notes/2022-12-05-owin-uri-fix.md.
+++ b/csharp/ql/src/change-notes/2022-12-05-owin-uri-fix.md.
@@ -1,0 +1,4 @@
+---
+category: fix
+---
+* Fixes a bug where the Owin.qll framework library will look for "URI" instead of "Uri" in the OwinRequest class.


### PR DESCRIPTION
As per the API documentation, OwinRequest Uri property should not be in all caps.
https://learn.microsoft.com/en-us/previous-versions/aspnet/mt152058(v=vs.113)
