### PR TITLE
C#: nint/System.IntPtr and nuint/System.UIntPtr are indistinguishable…

### DIFF
--- a/csharp/ql/test/library-tests/csharp11/NativeInt.cs
+++ b/csharp/ql/test/library-tests/csharp11/NativeInt.cs
@@ -1,0 +1,11 @@
+public class NativeInt
+{
+    public void M1()
+    {
+        nint x1 = 0;
+        System.IntPtr x2 = (System.IntPtr)0;
+
+        nuint y1 = 0;
+        System.UIntPtr y2 = (System.UIntPtr)0;
+    }
+}

--- a/csharp/ql/test/library-tests/csharp11/nativeInt.expected
+++ b/csharp/ql/test/library-tests/csharp11/nativeInt.expected
@@ -1,0 +1,4 @@
+| NativeInt.cs:5:14:5:15 | x1 | NativeInt.cs:6:23:6:24 | x2 | System.IntPtr |
+| NativeInt.cs:6:23:6:24 | x2 | NativeInt.cs:5:14:5:15 | x1 | System.IntPtr |
+| NativeInt.cs:8:15:8:16 | y1 | NativeInt.cs:9:24:9:25 | y2 | System.UIntPtr |
+| NativeInt.cs:9:24:9:25 | y2 | NativeInt.cs:8:15:8:16 | y1 | System.UIntPtr |

--- a/csharp/ql/test/library-tests/csharp11/nativeInt.ql
+++ b/csharp/ql/test/library-tests/csharp11/nativeInt.ql
@@ -1,0 +1,12 @@
+import csharp
+import semmle.code.csharp.commons.QualifiedName
+
+from LocalVariable v1, LocalVariable v2, Type t, string qualifier, string name
+where
+  v1.getFile().getStem() = "NativeInt" and
+  v2.getFile().getStem() = "NativeInt" and
+  t = v1.getType() and
+  t = v2.getType() and
+  t.hasQualifiedName(qualifier, name) and
+  v1 != v2
+select v1, v2, getQualifiedName(qualifier, name)


### PR DESCRIPTION
In this PR we test that
- `nint`/`System.IntPtr` are both perceived as `System.IntPtr` by the extractor.
- `nuint`/`System.UIntPtr` are both perceived as `System.UIntPtr` by the extractor.
