### PR TITLE
Swift: Add Cleartext Logging query

### DIFF
--- a/swift/ql/lib/codeql/swift/dataflow/ExternalFlow.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/ExternalFlow.qll
@@ -89,6 +89,7 @@ private module Frameworks {
   private import codeql.swift.frameworks.StandardLibrary.UrlSession
   private import codeql.swift.frameworks.StandardLibrary.WebView
   private import codeql.swift.frameworks.Alamofire.Alamofire
+  private import codeql.swift.security.CleartextLogging
   private import codeql.swift.security.PathInjection
   private import codeql.swift.security.PredicateInjection
 }

--- a/swift/ql/lib/codeql/swift/security/CleartextLogging.qll
+++ b/swift/ql/lib/codeql/swift/security/CleartextLogging.qll
@@ -1,0 +1,67 @@
+/** Provides classes and predicates to reason about cleartext logging of sensitive data vulnerabilities. */
+
+import swift
+private import codeql.swift.dataflow.DataFlow
+private import codeql.swift.dataflow.ExternalFlow
+private import codeql.swift.security.SensitiveExprs
+
+/** A data flow sink for cleartext logging of sensitive data vulnerabilities. */
+abstract class CleartextLoggingSink extends DataFlow::Node { }
+
+/** A sanitizer for cleartext logging of sensitive data vulnerabilities. */
+abstract class CleartextLoggingSanitizer extends DataFlow::Node { }
+
+/**
+ * A unit class for adding additional taint steps.
+ *
+ * Extend this class to add additional taint steps that should apply to paths related to
+ * cleartext logging of sensitive data vulnerabilities.
+ */
+class CleartextLoggingAdditionalTaintStep extends Unit {
+  /**
+   * Holds if the step from `n1` to `n2` should be considered a taint
+   * step for flows related to cleartext logging of sensitive data vulnerabilities.
+   */
+  abstract predicate step(DataFlow::Node n1, DataFlow::Node n2);
+}
+
+private class DefaultCleartextLoggingSink extends CleartextLoggingSink {
+  DefaultCleartextLoggingSink() { sinkNode(this, "logging") }
+}
+
+// TODO: Remove this. It shouldn't be necessary.
+private class EncryptionCleartextLoggingSanitizer extends CleartextLoggingSanitizer {
+  EncryptionCleartextLoggingSanitizer() { this.asExpr() instanceof EncryptedExpr }
+}
+
+/*
+ * TODO: Add a sanitizer for the OsLogMessage interpolation with .private/.sensitive privacy options,
+ * or restrict the sinks to require .public interpolation depending on what the default behavior is.
+ */
+
+private class LoggingSinks extends SinkModelCsv {
+  override predicate row(string row) {
+    row =
+      [
+        ";;false;print(_:separator:terminator:);;;Argument[0].ArrayElement;logging",
+        ";;false;print(_:separator:terminator:);;;Argument[1..2];logging",
+        ";;false;print(_:separator:terminator:toStream:);;;Argument[0].ArrayElement;logging",
+        ";;false;print(_:separator:terminator:toStream:);;;Argument[1..2];logging",
+        ";;false;NSLog(_:_:);;;Argument[0];logging",
+        ";;false;NSLog(_:_:);;;Argument[1].ArrayElement;logging",
+        ";;false;NSLogv(_:_:);;;Argument[0];logging",
+        ";;false;NSLogv(_:_:);;;Argument[1].ArrayElement;logging",
+        ";;false;vfprintf(_:_:_:);;;Agument[1..2];logging",
+        ";Logger;true;log(_:);;;Argument[0];logging",
+        ";Logger;true;log(level:_:);;;Argument[1];logging",
+        ";Logger;true;trace(_:);;;Argument[1];logging",
+        ";Logger;true;debug(_:);;;Argument[1];logging",
+        ";Logger;true;info(_:);;;Argument[1];logging",
+        ";Logger;true;notice(_:);;;Argument[1];logging",
+        ";Logger;true;warning(_:);;;Argument[1];logging",
+        ";Logger;true;error(_:);;;Argument[1];logging",
+        ";Logger;true;critical(_:);;;Argument[1];logging",
+        ";Logger;true;fault(_:);;;Argument[1];logging",
+      ]
+  }
+}

--- a/swift/ql/lib/codeql/swift/security/CleartextLogging.qll
+++ b/swift/ql/lib/codeql/swift/security/CleartextLogging.qll
@@ -53,7 +53,7 @@ private class OsLogPrivacyCleartextLoggingSanitizer extends CleartextLoggingSani
 /** A type that isn't redacted by default in an `OSLogMessage`. */
 private class OsLogNonRedactedType extends Type {
   OsLogNonRedactedType() {
-    this.getName() = [["", "U"] + "Int" + ["", "16", "32", "64"], "Double", "Float", "Bool"]
+    this.getName() = [["", "U"] + "Int" + ["", "8", "16", "32", "64"], "Double", "Float", "Bool"]
   }
 }
 

--- a/swift/ql/lib/codeql/swift/security/CleartextLogging.qll
+++ b/swift/ql/lib/codeql/swift/security/CleartextLogging.qll
@@ -31,8 +31,8 @@ private class DefaultCleartextLoggingSink extends CleartextLoggingSink {
 
 /**
  * A sanitizer for `OSLogMessage`s configured with the appropriate privacy option.
- * Numeric and boolean arguments aren't redacted unless the `public` option is used.
- * Arguments of other types are always redacted unless the `private` or `sensitive` options are used.
+ * Numeric and boolean arguments aren't redacted unless the `private` or `sensitive` options are used.
+ * Arguments of other types are always redacted unless the `public` option is used.
  */
 private class OsLogPrivacyCleartextLoggingSanitizer extends CleartextLoggingSanitizer {
   OsLogPrivacyCleartextLoggingSanitizer() {

--- a/swift/ql/lib/codeql/swift/security/CleartextLoggingQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/CleartextLoggingQuery.qll
@@ -1,0 +1,32 @@
+/**
+ * Provides a taint-tracking configuration for reasoning about cleartext logging of
+ * sensitive data vulnerabilities.
+ */
+
+import swift
+private import codeql.swift.dataflow.DataFlow
+private import codeql.swift.dataflow.TaintTracking
+private import codeql.swift.security.CleartextLogging
+private import codeql.swift.security.SensitiveExprs
+
+/**
+ * A taint-tracking configuration for cleartext logging of sensitive data vulnerabilities.
+ */
+class CleartextLoggingConfiguration extends TaintTracking::Configuration {
+  CleartextLoggingConfiguration() { this = "CleartextLoggingConfiguration" }
+
+  override predicate isSource(DataFlow::Node source) { source.asExpr() instanceof SensitiveExpr }
+
+  override predicate isSink(DataFlow::Node sink) { sink instanceof CleartextLoggingSink }
+
+  override predicate isSanitizer(DataFlow::Node sanitizer) {
+    sanitizer instanceof CleartextLoggingSanitizer
+  }
+
+  // Disregard paths that contain other paths. This helps with performance.
+  override predicate isSanitizerIn(DataFlow::Node node) { this.isSource(node) }
+
+  override predicate isAdditionalTaintStep(DataFlow::Node n1, DataFlow::Node n2) {
+    any(CleartextLoggingAdditionalTaintStep s).step(n1, n2)
+  }
+}

--- a/swift/ql/src/queries/Security/CWE-312/CleartextLogging.qhelp
+++ b/swift/ql/src/queries/Security/CWE-312/CleartextLogging.qhelp
@@ -1,0 +1,50 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+
+<overview>
+<p>
+Sensitive information that is logged unencrypted is accessible to an attacker
+who gains access to the logs.
+</p>
+</overview>
+
+<recommendation>
+<p>
+Ensure that sensitive information is always encrypted or obfuscated before being
+logged.
+</p>
+
+<p>
+In general, decrypt sensitive information only at the point where it is
+necessary for it to be used in cleartext.
+</p>
+
+<p>
+Be aware that external processes often store the standard out and
+standard error streams of the application, causing logged sensitive
+information to be stored.
+</p>
+</recommendation>
+
+<example>
+<p>
+The following example code logs user credentials (in this case, their password)
+in plain text:
+</p>
+<sample src="CleartextLoggingBad.swift"/>
+<p>
+Instead, the credentials should be encrypted, obfuscated, or omitted entirely:
+</p>
+<sample src="CleartextLoggingGood.swift"/>
+</example>
+
+<references>
+
+<li>M. Dowd, J. McDonald and J. Schuhm, <i>The Art of Software Security Assessment</i>, 1st Edition, Chapter 2 - 'Common Vulnerabilities of Encryption', p. 43. Addison Wesley, 2006.</li>
+<li>M. Howard and D. LeBlanc, <i>Writing Secure Code</i>, 2nd Edition, Chapter 9 - 'Protecting Secret Data', p. 299. Microsoft, 2002.</li>
+<li>OWASP: <a href="https://www.owasp.org/index.php/Password_Plaintext_Storage">Password Plaintext Storage</a>.</li>
+
+</references>
+</qhelp>

--- a/swift/ql/src/queries/Security/CWE-312/CleartextLogging.qhelp
+++ b/swift/ql/src/queries/Security/CWE-312/CleartextLogging.qhelp
@@ -5,37 +5,33 @@
 
 <overview>
 <p>
-Sensitive information that is logged unencrypted is accessible to an attacker
-who gains access to the logs.
+Attackers could gain access to sensitive information that is logged unencrypted.
 </p>
 </overview>
 
 <recommendation>
 <p>
-Ensure that sensitive information is always encrypted or obfuscated before being
-logged.
+Always make sure to encrypt or obfuscate sensitive information before you log it.
 </p>
 
 <p>
-In general, decrypt sensitive information only at the point where it is
-necessary for it to be used in cleartext.
+Generally, you should decrypt sensitive information only at the point where it is necessary for it to be used in cleartext.
 </p>
 
 <p>
-Be aware that external processes often store the standard out and
-standard error streams of the application, causing logged sensitive
-information to be stored.
+Be aware that external processes often store the standard output and
+standard error streams of the application. This will include logged sensitive information.
 </p>
 </recommendation>
 
 <example>
 <p>
 The following example code logs user credentials (in this case, their password)
-in plain text:
+in plaintext:
 </p>
 <sample src="CleartextLoggingBad.swift"/>
 <p>
-Instead, the credentials should be encrypted, obfuscated, or omitted entirely:
+Instead, you should encrypt or obfuscate the credentials, or omit them entirely:
 </p>
 <sample src="CleartextLoggingGood.swift"/>
 </example>

--- a/swift/ql/src/queries/Security/CWE-312/CleartextLogging.ql
+++ b/swift/ql/src/queries/Security/CWE-312/CleartextLogging.ql
@@ -1,0 +1,24 @@
+/**
+ * @name Clear-text logging of sensitive information
+ * @description Logging sensitive information without encryption or hashing can
+ *              expose it to an attacker.
+ * @kind path-problem
+ * @problem.severity error
+ * @security-severity 7.5
+ * @precision high
+ * @id swift/clear-text-logging
+ * @tags security
+ *       external/cwe/cwe-312
+ *       external/cwe/cwe-359
+ *       external/cwe/cwe-532
+ */
+
+import swift
+import codeql.swift.dataflow.DataFlow
+import codeql.swift.security.CleartextLoggingQuery
+import DataFlow::PathGraph
+
+from DataFlow::PathNode src, DataFlow::PathNode sink
+where any(CleartextLoggingConfiguration c).hasFlowPath(src, sink)
+select sink.getNode(), src, sink, "This $@ is written to a log file.", src.getNode(),
+  "potentially sensitive information"

--- a/swift/ql/src/queries/Security/CWE-312/CleartextLogging.ql
+++ b/swift/ql/src/queries/Security/CWE-312/CleartextLogging.ql
@@ -1,5 +1,5 @@
 /**
- * @name Clear-text logging of sensitive information
+ * @name Cleartext logging of sensitive information
  * @description Logging sensitive information in plaintext can
  *              expose it to an attacker.
  * @kind path-problem

--- a/swift/ql/src/queries/Security/CWE-312/CleartextLogging.ql
+++ b/swift/ql/src/queries/Security/CWE-312/CleartextLogging.ql
@@ -1,6 +1,6 @@
 /**
  * @name Clear-text logging of sensitive information
- * @description Logging sensitive information without encryption or hashing can
+ * @description Logging sensitive information in plaintext can
  *              expose it to an attacker.
  * @kind path-problem
  * @problem.severity error

--- a/swift/ql/src/queries/Security/CWE-312/CleartextLoggingBad.swift
+++ b/swift/ql/src/queries/Security/CWE-312/CleartextLoggingBad.swift
@@ -1,0 +1,2 @@
+let password = "P@ssw0rd"
+NSLog("User password changed to \(password)")

--- a/swift/ql/src/queries/Security/CWE-312/CleartextLoggingGood.swift
+++ b/swift/ql/src/queries/Security/CWE-312/CleartextLoggingGood.swift
@@ -1,0 +1,2 @@
+let password = "P@ssw0rd"
+NSLog("User password changed")

--- a/swift/ql/test/query-tests/Security/CWE-312/CleartextLoggingTest.ql
+++ b/swift/ql/test/query-tests/Security/CWE-312/CleartextLoggingTest.ql
@@ -1,0 +1,24 @@
+import swift
+import codeql.swift.dataflow.DataFlow
+import codeql.swift.security.CleartextLoggingQuery
+import TestUtilities.InlineExpectationsTest
+
+class CleartextLogging extends InlineExpectationsTest {
+  CleartextLogging() { this = "CleartextLogging" }
+
+  override string getARelevantTag() { result = "hasCleartextLogging" }
+
+  override predicate hasActualResult(Location location, string element, string tag, string value) {
+    exists(
+      CleartextLoggingConfiguration config, DataFlow::Node source, DataFlow::Node sink,
+      Expr sinkExpr
+    |
+      config.hasFlow(source, sink) and
+      sinkExpr = sink.asExpr() and
+      location = sinkExpr.getLocation() and
+      element = sinkExpr.toString() and
+      tag = "hasCleartextLogging" and
+      value = source.asExpr().getLocation().getStartLine().toString()
+    )
+  }
+}

--- a/swift/ql/test/query-tests/Security/CWE-312/cleartextLoggingTest.swift
+++ b/swift/ql/test/query-tests/Security/CWE-312/cleartextLoggingTest.swift
@@ -121,44 +121,26 @@ func test1(password: String, passwordHash : String) {
     log.critical("\(password, privacy: .public)") // $ MISSING: hasCleartextLogging=121
     log.fault("\(password, privacy: .public)") // $ MISSING: hasCleartextLogging=122
 }
-/*
+
 class MyClass {
 	var harmless = "abc"
 	var password = "123"
 }
 
+func getPassword() -> String { return "" }
+func doSomething(password: String) { }
+
 func test3(x: String) {
 	// alternative evidence of sensitivity...
 
-	UserDefaults.standard.set(x, forKey: "myKey") // $ MISSING: hasCleartextLogging
+	NSLog(x) // $ MISSING: hasCleartextLogging=137
 	doSomething(password: x);
-	UserDefaults.standard.set(x, forKey: "myKey") // $ hasCleartextLogging
+	NSLog(x) // $ hasCleartextLogging=137
 
 	let y = getPassword();
-	UserDefaults.standard.set(y, forKey: "myKey") // $ hasCleartextLogging
+	NSLog(y) // $ hasCleartextLogging=140
 
 	let z = MyClass()
-	UserDefaults.standard.set(z.harmless, forKey: "myKey") // Safe
-	UserDefaults.standard.set(z.password, forKey: "myKey") // $ hasCleartextLogging
+	NSLog(z.harmless) // Safe
+	NSLog(z.password) // $ hasCleartextLogging=145
 }
-
-func test4(passwd: String) {
-	// sanitizers...
-
-	var x = passwd;
-	var y = passwd;
-	var z = passwd;
-
-	UserDefaults.standard.set(x, forKey: "myKey") // $ hasCleartextLogging
-	UserDefaults.standard.set(y, forKey: "myKey") // $ hasCleartextLogging
-	UserDefaults.standard.set(z, forKey: "myKey") // $ hasCleartextLogging
-
-	x = encrypt(x);
-	hash(data: &y);
-	z = "";
-
-	UserDefaults.standard.set(x, forKey: "myKey") // Safe
-	UserDefaults.standard.set(y, forKey: "myKey") // Safe
-	UserDefaults.standard.set(z, forKey: "myKey") // Safe
-}
-*/

--- a/swift/ql/test/query-tests/Security/CWE-312/cleartextLoggingTest.swift
+++ b/swift/ql/test/query-tests/Security/CWE-312/cleartextLoggingTest.swift
@@ -2,6 +2,7 @@
 
 func NSLog(_ format: String, _ args: CVarArg...) {}
 func NSLogv(_ format: String, _ args: CVaListPointer) {}
+func getVaList(_ args: [CVarArg]) -> CVaListPointer { return CVaListPointer(_fromUnsafeMutablePointer: UnsafeMutablePointer(bitPattern: 0)!) }
 
 struct OSLogType : RawRepresentable {
     static let `default` = OSLogType(rawValue: 0)
@@ -83,19 +84,19 @@ struct Logger {
 // --- tests ---
 
 func test1(password: String, passwordHash : String) {
-	print(password) // $ MISSING: hasCleartextLogging=86
-	print(password, separator: "") // $ MISSING: $ hasCleartextLogging=97
-	print("", separator: password) // $ hasCleartextLogging=88
-	print(password, separator: "", terminator: "") // $ MISSING: hasCleartextLogging=89
-	print("", separator: password, terminator: "") // $ hasCleartextLogging=90
-	print("", separator: "", terminator: password) // $ hasCleartextLogging=91
+	print(password) // $ MISSING: hasCleartextLogging=87
+	print(password, separator: "") // $ MISSING: $ hasCleartextLogging=88
+	print("", separator: password) // $ hasCleartextLogging=89
+	print(password, separator: "", terminator: "") // $ MISSING: hasCleartextLogging=90
+	print("", separator: password, terminator: "") // $ hasCleartextLogging=91
+	print("", separator: "", terminator: password) // $ hasCleartextLogging=92
 
-    NSLog(password) // $ hasCleartextLogging=93
-    NSLog("%@", password as! CVarArg) // $ MISSING: hasCleartextLogging=94
-    NSLog("%@ %@", "" as! CVarArg, password as! CVarArg) // $ MISSING: hasCleartextLogging=95
-    NSLog("\(password)") // $ hasCleartextLogging=96
-    NSLogv("%@", getVaList([password as! CVarArg])) // $ MISSING: hasCleartextLogging=97
-    NSLogv("%@ %@", getVaList(["" as! CVarArg, password as! CVarArg])) // $ MISSING: hasCleartextLogging=98
+    NSLog(password) // $ hasCleartextLogging=94
+    NSLog("%@", password as! CVarArg) // $ MISSING: hasCleartextLogging=95
+    NSLog("%@ %@", "" as! CVarArg, password as! CVarArg) // $ MISSING: hasCleartextLogging=96
+    NSLog("\(password)") // $ hasCleartextLogging=97
+    NSLogv("%@", getVaList([password as! CVarArg])) // $ MISSING: hasCleartextLogging=98
+    NSLogv("%@ %@", getVaList(["" as! CVarArg, password as! CVarArg])) // $ MISSING: hasCleartextLogging=99
 
     let bankAccount: Int = 0
     let log = Logger()
@@ -103,22 +104,22 @@ func test1(password: String, passwordHash : String) {
     log.log("\(password)") // Safe
     log.log("\(password, privacy: .auto)") // Safe
     log.log("\(password, privacy: .private)") // Safe
-    log.log("\(password, privacy: .public)") // $ MISSING: hasCleartextLogging=106
+    log.log("\(password, privacy: .public)") // $ MISSING: hasCleartextLogging=107
     log.log("\(password, privacy: .sensitive)") // Safe
-    log.log("\(bankAccount)") // $ MISSING: hasCleartextLogging=108
-    log.log("\(bankAccount, privacy: .auto)") // $ MISSING: hasCleartextLogging=109
+    log.log("\(bankAccount)") // $ MISSING: hasCleartextLogging=109
+    log.log("\(bankAccount, privacy: .auto)") // $ MISSING: hasCleartextLogging=110
     log.log("\(bankAccount, privacy: .private)") // Safe
-    log.log("\(bankAccount, privacy: .public)") // $ MISSING: hasCleartextLogging=111
+    log.log("\(bankAccount, privacy: .public)") // $ MISSING: hasCleartextLogging=112
     log.log("\(bankAccount, privacy: .sensitive)") // Safe
-    log.log(level: .default, "\(password, privacy: .public)") // $ MISSING: hasCleartextLogging=113
-    log.trace("\(password, privacy: .public)") // $ MISSING: hasCleartextLogging=114
-    log.debug("\(password, privacy: .public)") // $ MISSING: hasCleartextLogging=115
-    log.info("\(password, privacy: .public)") // $ MISSING: hasCleartextLogging=116
-    log.notice("\(password, privacy: .public)") // $ MISSING: hasCleartextLogging=117
-    log.warning("\(password, privacy: .public)") // $ MISSING: hasCleartextLogging=118
-    log.error("\(password, privacy: .public)") // $ MISSING: hasCleartextLogging=119
-    log.critical("\(password, privacy: .public)") // $ MISSING: hasCleartextLogging=120
-    log.fault("\(password, privacy: .public)") // $ MISSING: hasCleartextLogging=121
+    log.log(level: .default, "\(password, privacy: .public)") // $ MISSING: hasCleartextLogging=114
+    log.trace("\(password, privacy: .public)") // $ MISSING: hasCleartextLogging=115
+    log.debug("\(password, privacy: .public)") // $ MISSING: hasCleartextLogging=116
+    log.info("\(password, privacy: .public)") // $ MISSING: hasCleartextLogging=117
+    log.notice("\(password, privacy: .public)") // $ MISSING: hasCleartextLogging=118
+    log.warning("\(password, privacy: .public)") // $ MISSING: hasCleartextLogging=119
+    log.error("\(password, privacy: .public)") // $ MISSING: hasCleartextLogging=120
+    log.critical("\(password, privacy: .public)") // $ MISSING: hasCleartextLogging=121
+    log.fault("\(password, privacy: .public)") // $ MISSING: hasCleartextLogging=122
 }
 /*
 class MyClass {

--- a/swift/ql/test/query-tests/Security/CWE-312/cleartextLoggingTest.swift
+++ b/swift/ql/test/query-tests/Security/CWE-312/cleartextLoggingTest.swift
@@ -1,0 +1,130 @@
+// --- stubs ---
+
+func NSLog(_ format: String, _ args: CVarArg...) {}
+func NSLogv(_ format: String, _ args: CVaListPointer) {}
+
+struct OSLogType : RawRepresentable {
+    static let `default` = OSLogType(rawValue: 0)
+    let rawValue: UInt8
+    init(rawValue: UInt8) { self.rawValue = rawValue}
+}
+
+struct OSLogStringAlignment {
+    static var none = OSLogStringAlignment()
+}
+
+struct OSLogPrivacy {
+    enum Mask { case none }
+    static var auto = OSLogPrivacy()
+    static var `private` = OSLogPrivacy()
+    static var sensitive = OSLogPrivacy()
+
+    static func auto(mask: OSLogPrivacy.Mask) -> OSLogPrivacy { return .auto }
+    static func `private`(mask: OSLogPrivacy.Mask) -> OSLogPrivacy { return .private }
+    static func `sensitive`(mask: OSLogPrivacy.Mask) -> OSLogPrivacy { return .sensitive }
+}
+
+struct OSLogInterpolation : StringInterpolationProtocol {
+    typealias StringLiteralType = String
+    init(literalCapacity: Int, interpolationCount: Int) {}
+    func appendLiteral(_: Self.StringLiteralType) {}
+    mutating func appendInterpolation(_ argumentString: @autoclosure @escaping () -> String, align: OSLogStringAlignment = .none, privacy: OSLogPrivacy = .auto) {}
+    mutating func appendInterpolation(_ argumentString: @autoclosure @escaping () -> String, align: OSLogStringAlignment = .none, privacy: OSLogPrivacy = .auto, attributes: String) {}
+}
+
+struct OSLogMessage : ExpressibleByStringInterpolation {
+    typealias StringInterpolation = OSLogInterpolation
+    typealias StringLiteralType = String
+    typealias ExtendedGraphemeClusterLiteralType = String
+    typealias UnicodeScalarLiteralType = String
+    init(stringInterpolation: OSLogInterpolation) {}
+    init(stringLiteral: String) {}
+    init(extendedGraphemeClusterLiteral: String) {}
+    init(unicodeScalarLiteral: String) {}
+}
+
+struct Logger {
+    func log(_ message: OSLogMessage) {}
+    func log(level: OSLogType, _ message: OSLogMessage) {}
+    func notice(_: OSLogMessage) {}
+    func debug(_: OSLogMessage) {}
+    func trace(_: OSLogMessage) {}
+    func info(_: OSLogMessage) {}
+    func error(_: OSLogMessage) {}
+    func warning(_: OSLogMessage) {}
+    func fault(_: OSLogMessage) {}
+    func critical(_: OSLogMessage) {}
+
+}
+
+// --- tests ---
+
+func test1(password: String, passwordHash : String) {
+	print(password) // $ MISSING: hasCleartextLogging=63
+	print(password, separator: "") // $ MISSING: $ hasCleartextLogging=64
+	print("", separator: password) // $ hasCleartextLogging=65
+	print(password, separator: "", terminator: "") // $ MISSING: hasCleartextLogging=66
+	print("", separator: password, terminator: "") // $ hasCleartextLogging=67
+	print("", separator: "", terminator: password) // $ hasCleartextLogging=68
+
+    NSLog(password) // $ hasCleartextLogging=70
+    NSLog("%@", password as! CVarArg) // $ MISSING: hasCleartextLogging=71
+    NSLog("%@ %@", "" as! CVarArg, password as! CVarArg) // $ MISSING: hasCleartextLogging=72
+    NSLog("\(password)") // $ hasCleartextLogging=73
+    NSLogv("%@", getVaList([password as! CVarArg])) // $ MISSING: hasCleartextLogging=74
+    NSLogv("%@ %@", getVaList(["" as! CVarArg, password as! CVarArg])) // $ MISSING: hasCleartextLogging=75
+
+    let log = Logger()
+    log.log("\(password)") // $ hasCleartextLogging=78
+    log.log("\(password, privacy: .private)") // Safe
+    log.log(level: .default, "\(password)") // $ hasCleartextLogging=80
+    log.trace("\(password)") // $ hasCleartextLogging=81
+    log.debug("\(password)") // $ hasCleartextLogging=82
+    log.info("\(password)") // $ hasCleartextLogging=83
+    log.notice("\(password)") // $ hasCleartextLogging=84
+    log.warning("\(password)") // $ hasCleartextLogging=85
+    log.error("\(password)") // $ hasCleartextLogging=86
+    log.critical("\(password)") // $ hasCleartextLogging=87
+    log.fault("\(password)") // $ hasCleartextLogging=88
+}
+/*
+class MyClass {
+	var harmless = "abc"
+	var password = "123"
+}
+
+func test3(x: String) {
+	// alternative evidence of sensitivity...
+
+	UserDefaults.standard.set(x, forKey: "myKey") // $ MISSING: hasCleartextLogging
+	doSomething(password: x);
+	UserDefaults.standard.set(x, forKey: "myKey") // $ hasCleartextLogging
+
+	let y = getPassword();
+	UserDefaults.standard.set(y, forKey: "myKey") // $ hasCleartextLogging
+
+	let z = MyClass()
+	UserDefaults.standard.set(z.harmless, forKey: "myKey") // Safe
+	UserDefaults.standard.set(z.password, forKey: "myKey") // $ hasCleartextLogging
+}
+
+func test4(passwd: String) {
+	// sanitizers...
+
+	var x = passwd;
+	var y = passwd;
+	var z = passwd;
+
+	UserDefaults.standard.set(x, forKey: "myKey") // $ hasCleartextLogging
+	UserDefaults.standard.set(y, forKey: "myKey") // $ hasCleartextLogging
+	UserDefaults.standard.set(z, forKey: "myKey") // $ hasCleartextLogging
+
+	x = encrypt(x);
+	hash(data: &y);
+	z = "";
+
+	UserDefaults.standard.set(x, forKey: "myKey") // Safe
+	UserDefaults.standard.set(y, forKey: "myKey") // Safe
+	UserDefaults.standard.set(z, forKey: "myKey") // Safe
+}
+*/

--- a/swift/ql/test/query-tests/Security/CWE-312/cleartextLoggingTest.swift
+++ b/swift/ql/test/query-tests/Security/CWE-312/cleartextLoggingTest.swift
@@ -90,13 +90,16 @@ func test1(password: String, passwordHash : String) {
 	print(password, separator: "", terminator: "") // $ MISSING: hasCleartextLogging=90
 	print("", separator: password, terminator: "") // $ hasCleartextLogging=91
 	print("", separator: "", terminator: password) // $ hasCleartextLogging=92
+    print(passwordHash) // Safe
 
-    NSLog(password) // $ hasCleartextLogging=94
-    NSLog("%@", password as! CVarArg) // $ MISSING: hasCleartextLogging=95
-    NSLog("%@ %@", "" as! CVarArg, password as! CVarArg) // $ MISSING: hasCleartextLogging=96
-    NSLog("\(password)") // $ hasCleartextLogging=97
-    NSLogv("%@", getVaList([password as! CVarArg])) // $ MISSING: hasCleartextLogging=98
-    NSLogv("%@ %@", getVaList(["" as! CVarArg, password as! CVarArg])) // $ MISSING: hasCleartextLogging=99
+    NSLog(password) // $ hasCleartextLogging=95
+    NSLog("%@", password as! CVarArg) // $ MISSING: hasCleartextLogging=96
+    NSLog("%@ %@", "" as! CVarArg, password as! CVarArg) // $ MISSING: hasCleartextLogging=97
+    NSLog("\(password)") // $ hasCleartextLogging=98
+    NSLogv("%@", getVaList([password as! CVarArg])) // $ MISSING: hasCleartextLogging=99
+    NSLogv("%@ %@", getVaList(["" as! CVarArg, password as! CVarArg])) // $ MISSING: hasCleartextLogging=100
+    NSLog(passwordHash) // SAfe
+    NSLogv("%@", getVaList([passwordHash as! CVarArg])) // Safe
 
     let bankAccount: Int = 0
     let log = Logger()
@@ -104,22 +107,31 @@ func test1(password: String, passwordHash : String) {
     log.log("\(password)") // Safe
     log.log("\(password, privacy: .auto)") // Safe
     log.log("\(password, privacy: .private)") // Safe
-    log.log("\(password, privacy: .public)") // $ MISSING: hasCleartextLogging=107
+    log.log("\(password, privacy: .public)") // $ MISSING: hasCleartextLogging=110
+    log.log("\(passwordHash, privacy: .public)") // Safe
     log.log("\(password, privacy: .sensitive)") // Safe
-    log.log("\(bankAccount)") // $ MISSING: hasCleartextLogging=109
-    log.log("\(bankAccount, privacy: .auto)") // $ MISSING: hasCleartextLogging=110
+    log.log("\(bankAccount)") // $ MISSING: hasCleartextLogging=113
+    log.log("\(bankAccount, privacy: .auto)") // $ MISSING: hasCleartextLogging=114
     log.log("\(bankAccount, privacy: .private)") // Safe
-    log.log("\(bankAccount, privacy: .public)") // $ MISSING: hasCleartextLogging=112
+    log.log("\(bankAccount, privacy: .public)") // $ MISSING: hasCleartextLogging=116
     log.log("\(bankAccount, privacy: .sensitive)") // Safe
-    log.log(level: .default, "\(password, privacy: .public)") // $ MISSING: hasCleartextLogging=114
-    log.trace("\(password, privacy: .public)") // $ MISSING: hasCleartextLogging=115
-    log.debug("\(password, privacy: .public)") // $ MISSING: hasCleartextLogging=116
-    log.info("\(password, privacy: .public)") // $ MISSING: hasCleartextLogging=117
-    log.notice("\(password, privacy: .public)") // $ MISSING: hasCleartextLogging=118
-    log.warning("\(password, privacy: .public)") // $ MISSING: hasCleartextLogging=119
-    log.error("\(password, privacy: .public)") // $ MISSING: hasCleartextLogging=120
-    log.critical("\(password, privacy: .public)") // $ MISSING: hasCleartextLogging=121
-    log.fault("\(password, privacy: .public)") // $ MISSING: hasCleartextLogging=122
+    log.log(level: .default, "\(password, privacy: .public)") // $ MISSING: hasCleartextLogging=118
+    log.trace("\(password, privacy: .public)") // $ MISSING: hasCleartextLogging=119
+    log.trace("\(passwordHash, privacy: .public)") // Safe
+    log.debug("\(password, privacy: .public)") // $ MISSING: hasCleartextLogging=121
+    log.debug("\(passwordHash, privacy: .public)") // Safe
+    log.info("\(password, privacy: .public)") // $ MISSING: hasCleartextLogging=123
+    log.info("\(passwordHash, privacy: .public)") // Safe
+    log.notice("\(password, privacy: .public)") // $ MISSING: hasCleartextLogging=125
+    log.notice("\(passwordHash, privacy: .public)") // Safe
+    log.warning("\(password, privacy: .public)") // $ MISSING: hasCleartextLogging=127
+    log.warning("\(passwordHash, privacy: .public)") // Safe
+    log.error("\(password, privacy: .public)") // $ MISSING: hasCleartextLogging=129
+    log.error("\(passwordHash, privacy: .public)") // Safe
+    log.critical("\(password, privacy: .public)") // $ MISSING: hasCleartextLogging=131
+    log.critical("\(passwordHash, privacy: .public)") // Safe
+    log.fault("\(password, privacy: .public)") // $ MISSING: hasCleartextLogging=133
+    log.fault("\(passwordHash, privacy: .public)") // Safe
 }
 
 class MyClass {
@@ -133,14 +145,14 @@ func doSomething(password: String) { }
 func test3(x: String) {
 	// alternative evidence of sensitivity...
 
-	NSLog(x) // $ MISSING: hasCleartextLogging=137
+	NSLog(x) // $ MISSING: hasCleartextLogging=148
 	doSomething(password: x);
-	NSLog(x) // $ hasCleartextLogging=137
+	NSLog(x) // $ hasCleartextLogging=149
 
 	let y = getPassword();
-	NSLog(y) // $ hasCleartextLogging=140
+	NSLog(y) // $ hasCleartextLogging=152
 
 	let z = MyClass()
 	NSLog(z.harmless) // Safe
-	NSLog(z.password) // $ hasCleartextLogging=145
+	NSLog(z.password) // $ hasCleartextLogging=157
 }

--- a/swift/ql/test/query-tests/Security/CWE-312/cleartextLoggingTest.swift
+++ b/swift/ql/test/query-tests/Security/CWE-312/cleartextLoggingTest.swift
@@ -13,10 +13,16 @@ struct OSLogStringAlignment {
     static var none = OSLogStringAlignment()
 }
 
+enum OSLogIntegerFormatting { case decimal }
+enum OSLogInt32ExtendedFormat { case none }
+enum OSLogFloatFormatting { case fixed }
+enum OSLogBoolFormat { case truth }
+
 struct OSLogPrivacy {
     enum Mask { case none }
     static var auto = OSLogPrivacy()
     static var `private` = OSLogPrivacy()
+    static var `public` = OSLogPrivacy()
     static var sensitive = OSLogPrivacy()
 
     static func auto(mask: OSLogPrivacy.Mask) -> OSLogPrivacy { return .auto }
@@ -30,6 +36,23 @@ struct OSLogInterpolation : StringInterpolationProtocol {
     func appendLiteral(_: Self.StringLiteralType) {}
     mutating func appendInterpolation(_ argumentString: @autoclosure @escaping () -> String, align: OSLogStringAlignment = .none, privacy: OSLogPrivacy = .auto) {}
     mutating func appendInterpolation(_ argumentString: @autoclosure @escaping () -> String, align: OSLogStringAlignment = .none, privacy: OSLogPrivacy = .auto, attributes: String) {}
+    mutating func appendInterpolation(_ number: @autoclosure @escaping () -> Int, format: OSLogIntegerFormatting = .decimal, align: OSLogStringAlignment = .none, privacy: OSLogPrivacy = .auto) {}
+    mutating func appendInterpolation(_ number: @autoclosure @escaping () -> Int8, format: OSLogIntegerFormatting = .decimal, align: OSLogStringAlignment = .none, privacy: OSLogPrivacy = .auto) {}
+    mutating func appendInterpolation(_ number: @autoclosure @escaping () -> Int16, format: OSLogIntegerFormatting = .decimal, align: OSLogStringAlignment = .none, privacy: OSLogPrivacy = .auto) {}
+    mutating func appendInterpolation(_ number: @autoclosure @escaping () -> Int32, format: OSLogInt32ExtendedFormat, privacy: OSLogPrivacy = .auto) {}
+    mutating func appendInterpolation(_ number: @autoclosure @escaping () -> Int32, format: OSLogInt32ExtendedFormat, privacy: OSLogPrivacy = .auto, attributes: String) {}
+    mutating func appendInterpolation(_ number: @autoclosure @escaping () -> Int32, format: OSLogIntegerFormatting = .decimal, align: OSLogStringAlignment = .none, privacy: OSLogPrivacy = .auto) {}
+    mutating func appendInterpolation(_ number: @autoclosure @escaping () -> Int64, format: OSLogIntegerFormatting = .decimal, align: OSLogStringAlignment = .none, privacy: OSLogPrivacy = .auto) {}
+    mutating func appendInterpolation(_ number: @autoclosure @escaping () -> UInt, format: OSLogIntegerFormatting = .decimal, align: OSLogStringAlignment = .none, privacy: OSLogPrivacy = .auto) {}
+    mutating func appendInterpolation(_ number: @autoclosure @escaping () -> UInt8, format: OSLogIntegerFormatting = .decimal, align: OSLogStringAlignment = .none, privacy: OSLogPrivacy = .auto) {}
+    mutating func appendInterpolation(_ number: @autoclosure @escaping () -> UInt16, format: OSLogIntegerFormatting = .decimal, align: OSLogStringAlignment = .none, privacy: OSLogPrivacy = .auto) {}
+    mutating func appendInterpolation(_ number: @autoclosure @escaping () -> UInt32, format: OSLogIntegerFormatting = .decimal, align: OSLogStringAlignment = .none, privacy: OSLogPrivacy = .auto) {}
+    mutating func appendInterpolation(_ number: @autoclosure @escaping () -> UInt64, format: OSLogIntegerFormatting = .decimal, align: OSLogStringAlignment = .none, privacy: OSLogPrivacy = .auto) {}
+    mutating func appendInterpolation(_ number: @autoclosure @escaping () -> Double, format: OSLogFloatFormatting = .fixed, align: OSLogStringAlignment = .none, privacy: OSLogPrivacy = .auto) {}
+    mutating func appendInterpolation(_ number: @autoclosure @escaping () -> Double, format: OSLogFloatFormatting = .fixed, align: OSLogStringAlignment = .none, privacy: OSLogPrivacy = .auto, attributes: String) {}
+    mutating func appendInterpolation(_ number: @autoclosure @escaping () -> Float,format: OSLogFloatFormatting = .fixed, align: OSLogStringAlignment = .none, privacy: OSLogPrivacy = .auto) {}
+    mutating func appendInterpolation(_ number: @autoclosure @escaping () -> Float, format: OSLogFloatFormatting = .fixed, align: OSLogStringAlignment = .none, privacy: OSLogPrivacy = .auto, attributes: String) {}
+    mutating func appendInterpolation(_ boolean: @autoclosure @escaping () -> Bool, format: OSLogBoolFormat = .truth, privacy: OSLogPrivacy = .auto) {}
 }
 
 struct OSLogMessage : ExpressibleByStringInterpolation {
@@ -60,32 +83,42 @@ struct Logger {
 // --- tests ---
 
 func test1(password: String, passwordHash : String) {
-	print(password) // $ MISSING: hasCleartextLogging=63
-	print(password, separator: "") // $ MISSING: $ hasCleartextLogging=64
-	print("", separator: password) // $ hasCleartextLogging=65
-	print(password, separator: "", terminator: "") // $ MISSING: hasCleartextLogging=66
-	print("", separator: password, terminator: "") // $ hasCleartextLogging=67
-	print("", separator: "", terminator: password) // $ hasCleartextLogging=68
+	print(password) // $ MISSING: hasCleartextLogging=86
+	print(password, separator: "") // $ MISSING: $ hasCleartextLogging=97
+	print("", separator: password) // $ hasCleartextLogging=88
+	print(password, separator: "", terminator: "") // $ MISSING: hasCleartextLogging=89
+	print("", separator: password, terminator: "") // $ hasCleartextLogging=90
+	print("", separator: "", terminator: password) // $ hasCleartextLogging=91
 
-    NSLog(password) // $ hasCleartextLogging=70
-    NSLog("%@", password as! CVarArg) // $ MISSING: hasCleartextLogging=71
-    NSLog("%@ %@", "" as! CVarArg, password as! CVarArg) // $ MISSING: hasCleartextLogging=72
-    NSLog("\(password)") // $ hasCleartextLogging=73
-    NSLogv("%@", getVaList([password as! CVarArg])) // $ MISSING: hasCleartextLogging=74
-    NSLogv("%@ %@", getVaList(["" as! CVarArg, password as! CVarArg])) // $ MISSING: hasCleartextLogging=75
+    NSLog(password) // $ hasCleartextLogging=93
+    NSLog("%@", password as! CVarArg) // $ MISSING: hasCleartextLogging=94
+    NSLog("%@ %@", "" as! CVarArg, password as! CVarArg) // $ MISSING: hasCleartextLogging=95
+    NSLog("\(password)") // $ hasCleartextLogging=96
+    NSLogv("%@", getVaList([password as! CVarArg])) // $ MISSING: hasCleartextLogging=97
+    NSLogv("%@ %@", getVaList(["" as! CVarArg, password as! CVarArg])) // $ MISSING: hasCleartextLogging=98
 
+    let bankAccount: Int = 0
     let log = Logger()
-    log.log("\(password)") // $ hasCleartextLogging=78
+    // These MISSING test cases will be fixed when we properly generate the CFG around autoclosures.
+    log.log("\(password)") // Safe
+    log.log("\(password, privacy: .auto)") // Safe
     log.log("\(password, privacy: .private)") // Safe
-    log.log(level: .default, "\(password)") // $ hasCleartextLogging=80
-    log.trace("\(password)") // $ hasCleartextLogging=81
-    log.debug("\(password)") // $ hasCleartextLogging=82
-    log.info("\(password)") // $ hasCleartextLogging=83
-    log.notice("\(password)") // $ hasCleartextLogging=84
-    log.warning("\(password)") // $ hasCleartextLogging=85
-    log.error("\(password)") // $ hasCleartextLogging=86
-    log.critical("\(password)") // $ hasCleartextLogging=87
-    log.fault("\(password)") // $ hasCleartextLogging=88
+    log.log("\(password, privacy: .public)") // $ MISSING: hasCleartextLogging=106
+    log.log("\(password, privacy: .sensitive)") // Safe
+    log.log("\(bankAccount)") // $ MISSING: hasCleartextLogging=108
+    log.log("\(bankAccount, privacy: .auto)") // $ MISSING: hasCleartextLogging=109
+    log.log("\(bankAccount, privacy: .private)") // Safe
+    log.log("\(bankAccount, privacy: .public)") // $ MISSING: hasCleartextLogging=111
+    log.log("\(bankAccount, privacy: .sensitive)") // Safe
+    log.log(level: .default, "\(password, privacy: .public)") // $ MISSING: hasCleartextLogging=113
+    log.trace("\(password, privacy: .public)") // $ MISSING: hasCleartextLogging=114
+    log.debug("\(password, privacy: .public)") // $ MISSING: hasCleartextLogging=115
+    log.info("\(password, privacy: .public)") // $ MISSING: hasCleartextLogging=116
+    log.notice("\(password, privacy: .public)") // $ MISSING: hasCleartextLogging=117
+    log.warning("\(password, privacy: .public)") // $ MISSING: hasCleartextLogging=118
+    log.error("\(password, privacy: .public)") // $ MISSING: hasCleartextLogging=119
+    log.critical("\(password, privacy: .public)") // $ MISSING: hasCleartextLogging=120
+    log.fault("\(password, privacy: .public)") // $ MISSING: hasCleartextLogging=121
 }
 /*
 class MyClass {


### PR DESCRIPTION
Currently we don't have flow through autoclosures in [`OsLogInterpolation`](https://developer.apple.com/documentation/os/osloginterpolation), hence the `MISSING` test cases.

Also, we don't support Array content flow yet, which means sinks that are elements of a varidic parameter cannot be modeled with MaD yet, causing a few more `MISSING` test cases in the `print` and `NSLog` functions.

Note that everything related to `OSLog` is declared in an `os` package in the real world, so we'll need to revisit its MaD rows and stubs when we can actually add support for packages/namespaces.