### PR TITLE
C++: Performance fix for cpp/cleartext-storage-buffer

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-311/CleartextBufferWrite.ql
+++ b/cpp/ql/src/Security/CWE/CWE-311/CleartextBufferWrite.ql
@@ -21,23 +21,18 @@ import DataFlow::PathGraph
 /**
  * A buffer write into a sensitive expression.
  */
-class SensitiveBufferWrite extends Expr {
-  BufferWrite::BufferWrite write;
-
-  SensitiveBufferWrite() {
-    this = write and
-    write.getDest() instanceof SensitiveExpr
-  }
+class SensitiveBufferWrite extends Expr instanceof BufferWrite::BufferWrite {
+  SensitiveBufferWrite() { super.getDest() instanceof SensitiveExpr }
 
   /**
    * Gets a data source of this operation.
    */
-  Expr getASource() { result = write.getASource() }
+  Expr getASource() { result = super.getASource() }
 
   /**
    * Gets the destination buffer of this operation.
    */
-  Expr getDest() { result = write.getDest() }
+  Expr getDest() { result = super.getDest() }
 }
 
 /**

--- a/cpp/ql/src/Security/CWE/CWE-311/CleartextBufferWrite.ql
+++ b/cpp/ql/src/Security/CWE/CWE-311/CleartextBufferWrite.ql
@@ -60,12 +60,11 @@ class ToBufferConfiguration extends TaintTracking::Configuration {
 
 from
   ToBufferConfiguration config, SensitiveBufferWrite w, DataFlow::PathNode sourceNode,
-  DataFlow::PathNode sinkNode, FlowSource source, SensitiveExpr dest
+  DataFlow::PathNode sinkNode, FlowSource source
 where
   config.hasFlowPath(sourceNode, sinkNode) and
   sourceNode.getNode() = source and
-  w.getASource() = sinkNode.getNode().asExpr() and
-  dest = w.getDest()
+  w.getASource() = sinkNode.getNode().asExpr()
 select w, sourceNode, sinkNode,
-  "This write into buffer '" + dest.toString() + "' may contain unencrypted data from $@.", source,
-  "user input (" + source.getSourceType() + ")"
+  "This write into buffer '" + w.getDest().toString() + "' may contain unencrypted data from $@.",
+  source, "user input (" + source.getSourceType() + ")"


### PR DESCRIPTION
Fix a performance issue with `cpp/cleartext-storage-buffer`, that was causing it to fail on several LGTM projects.  The issue was that one of the constraints on the sink (that the written buffer is a `SensitiveExpr`) was only expressed in the query, not in the dataflow configuration.  The solution is to define the sources properly.  Following that and a bit more cleanup, I also believe the result is more readable than what we had before.

Improves performance on `mruby_mruby` locally from ~750s to ~45s.

I will also do a DCA run on this pull request.