### PR TITLE
Swift: Add taint reach to SummaryStats.ql.

### DIFF
--- a/swift/ql/src/queries/Summary/SummaryStats.ql
+++ b/swift/ql/src/queries/Summary/SummaryStats.ql
@@ -25,7 +25,7 @@ class TaintReachConfig extends TaintTracking::Configuration {
 
 float taintReach() {
   exists(TaintReachConfig config, int tainted, int total |
-    tainted = count(DataFlow::Node n | config.hasFlow(_, n)) and
+    tainted = count(DataFlow::Node n | config.hasFlowTo(n)) and
     total = count(DataFlow::Node n) and
     result = (tainted * 1000000.0) / total
   )

--- a/swift/ql/src/queries/Summary/SummaryStats.ql
+++ b/swift/ql/src/queries/Summary/SummaryStats.ql
@@ -9,19 +9,42 @@
 import swift
 import codeql.swift.dataflow.FlowSources
 import codeql.swift.security.SensitiveExprs
+import codeql.swift.dataflow.DataFlow
+import codeql.swift.dataflow.TaintTracking
 
-predicate statistic(string what, int value) {
-  what = "Files" and value = count(File f)
-  or
-  what = "Expressions" and value = count(Expr e | not e.getFile() instanceof UnknownFile)
-  or
-  what = "Local flow sources" and value = count(LocalFlowSource s)
-  or
-  what = "Remote flow sources" and value = count(RemoteFlowSource s)
-  or
-  what = "Sensitive expressions" and value = count(SensitiveExpr e)
+/**
+ * A taint configuration for tainted data reaching any node.
+ */
+class TaintReachConfig extends TaintTracking::Configuration {
+  TaintReachConfig() { this = "TaintReachConfig" }
+
+  override predicate isSource(DataFlow::Node node) { node instanceof FlowSource }
+
+  override predicate isSink(DataFlow::Node node) { any() }
 }
 
-from string what, int value
+float taintReach() {
+  exists(TaintReachConfig config, int tainted, int total |
+    tainted = count(DataFlow::Node n | config.hasFlow(_, n)) and
+    total = count(DataFlow::Node n) and
+    result = (tainted * 1000000.0) / total
+  )
+}
+
+predicate statistic(string what, string value) {
+  what = "Files" and value = count(File f).toString()
+  or
+  what = "Expressions" and value = count(Expr e | not e.getFile() instanceof UnknownFile).toString()
+  or
+  what = "Local flow sources" and value = count(LocalFlowSource s).toString()
+  or
+  what = "Remote flow sources" and value = count(RemoteFlowSource s).toString()
+  or
+  what = "Sensitive expressions" and value = count(SensitiveExpr e).toString()
+  or
+  what = "Taint reach (per million nodes)" and value = taintReach().toString()
+}
+
+from string what, string value
 where statistic(what, value)
 select what, value


### PR DESCRIPTION
I've been using a number I call "taint reach" to help measure our progress on taint flow modelling.  It seems useful enough we might as well add it to the `SummaryStats.ql` query so that its generally available.

"taint reach" is defined as the number of dataflow nodes that taint reaches, from a remote or local flow source, per million total dataflow nodes.