### PR TITLE
C++: Fix cpp/offset-use-before-range-check performance.

### DIFF
--- a/cpp/ql/src/Best Practices/Likely Errors/OffsetUseBeforeRangeCheck.ql
+++ b/cpp/ql/src/Best Practices/Likely Errors/OffsetUseBeforeRangeCheck.ql
@@ -15,6 +15,7 @@
 
 import cpp
 
+bindingset[v, before]
 predicate beforeArrayAccess(Variable v, ArrayExpr access, Expr before) {
   exists(LogicalAndExpr andexpr |
     access.getArrayOffset() = v.getAnAccess() and
@@ -23,6 +24,7 @@ predicate beforeArrayAccess(Variable v, ArrayExpr access, Expr before) {
   )
 }
 
+bindingset[v, after]
 predicate afterArrayAccess(Variable v, ArrayExpr access, Expr after) {
   exists(LogicalAndExpr andexpr |
     access.getArrayOffset() = v.getAnAccess() and

--- a/cpp/ql/src/Best Practices/Likely Errors/OffsetUseBeforeRangeCheck.ql
+++ b/cpp/ql/src/Best Practices/Likely Errors/OffsetUseBeforeRangeCheck.ql
@@ -15,7 +15,7 @@
 
 import cpp
 
-bindingset[v, before]
+pragma[nomagic]
 predicate beforeArrayAccess(Variable v, ArrayExpr access, Expr before) {
   exists(LogicalAndExpr andexpr |
     access.getArrayOffset() = v.getAnAccess() and
@@ -24,7 +24,7 @@ predicate beforeArrayAccess(Variable v, ArrayExpr access, Expr before) {
   )
 }
 
-bindingset[v, after]
+pragma[nomagic]
 predicate afterArrayAccess(Variable v, ArrayExpr access, Expr after) {
   exists(LogicalAndExpr andexpr |
     access.getArrayOffset() = v.getAnAccess() and


### PR DESCRIPTION
Fix performance of `cpp/offset-use-before-range-check` (showing up on `petsc/petsc`).  This was an easy fix, the issue lied with `beforeArrayAccess` and `afterArrayAccess` being explored in the wrong order.

I will start a DCA run on this pull request to confirm there are no unexpected side-effects.