### PR TITLE
C++: Reintroduce `StdBasicStringIterator`

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/models/implementations/StdString.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/implementations/StdString.qll
@@ -16,6 +16,24 @@ private class StdBasicString extends ClassTemplateInstantiation {
 }
 
 /**
+ * The `std::basic_string::iterator` declaration.
+ *
+ * Intuitively, this class shouldn't be necessary as it's already captured
+ * by the `StdIterator` class. However, this class ensures that the typedef inside the
+ * body of the `std::string` class is also seen as an iterator.
+ *
+ * Eventually, we should be consistent about which of the following should be recognized as iterators:
+ * 1. The typedef type.
+ * 2. The template class of the resolved type.
+ * 3. Any instantiation of the resolved type.
+ */
+private class StdBasicStringIterator extends Iterator, Type {
+  StdBasicStringIterator() {
+    this.getEnclosingElement() instanceof StdBasicString and this.hasName("iterator")
+  }
+}
+
+/**
  * A `std::string` function for which taint should be propagated.
  */
 abstract private class StdStringTaintFunction extends TaintFunction {


### PR DESCRIPTION
Changing `StdBasicStringIterator` to a non-extending subtype (and afterwards deleting it) had unintended behavior on the use-use flow feature branch, and I couldn't come up with a simple fix without also breaking Coding Standards.

So for now I think it's best to just keep this class around.