### PR TITLE
Docs: Make river-crossing example comply with the CodeQL style guide

### DIFF
--- a/docs/codeql/writing-codeql-queries/river-answer-1-path.ql
+++ b/docs/codeql/writing-codeql-queries/river-answer-1-path.ql
@@ -13,7 +13,7 @@ class Cargo extends string {
     }
   }
   
-  /** One of two shores. */
+  /** A shore, named either `Left` or `Right`. */
   class Shore extends string {
     Shore() {
       this = "Left" or
@@ -93,7 +93,7 @@ class Cargo extends string {
       // Reachable by first following pathSoFar and then ferrying cargo
       exists(string pathSoFar, string visitedStatesSoFar, Cargo cargo |
         result = this.reachesVia(pathSoFar, visitedStatesSoFar).safeFerry(cargo) and
-        not exists(int i | i = visitedStatesSoFar.indexOf(result)) and // resulting state is not visited yet
+        not exists(visitedStatesSoFar.indexOf(result)) and // resulting state is not visited yet
         visitedStates = visitedStatesSoFar + "_" + result and
         path = pathSoFar + ",\nthen " + cargo + " is ferried " + result.towards()
       )

--- a/docs/codeql/writing-codeql-queries/river-answer-1-path.ql
+++ b/docs/codeql/writing-codeql-queries/river-answer-1-path.ql
@@ -6,10 +6,7 @@
 /** A possible cargo item. */
 class Cargo extends string {
     Cargo() {
-      this = "Nothing" or
-      this = "Goat" or
-      this = "Cabbage" or
-      this = "Wolf"
+      this = ["Nothing", "Goat", "Cabbage", "Wolf"]
     }
   }
   

--- a/docs/codeql/writing-codeql-queries/river-answer-2-abstract-class.ql
+++ b/docs/codeql/writing-codeql-queries/river-answer-2-abstract-class.ql
@@ -154,7 +154,7 @@ class Shore extends string {
     State reachesVia(string path) {
       exists(string pathSoFar |
         result = this.reachesVia(pathSoFar).transition() and
-        not exists(int i | i = pathSoFar.indexOf(result.toString())) and
+        not exists(pathSoFar.indexOf(result.toString())) and
         path = pathSoFar + "\n↓\n" + result
       )
     }
@@ -169,7 +169,7 @@ class Shore extends string {
     }
   
     override State reachesVia(string path) {
-      path = this + "\n↓\n" + result and result = transition()
+      path = this + "\n↓\n" + result and result = this.transition()
       or
       result = super.reachesVia(path)
     }

--- a/docs/codeql/writing-codeql-queries/river-answer-3-datatypes.ql
+++ b/docs/codeql/writing-codeql-queries/river-answer-3-datatypes.ql
@@ -118,7 +118,7 @@ class State extends TState {
   State reachesVia(string path) {
     exists(string pathSoFar |
       result = this.reachesVia(pathSoFar).transition() and
-      not exists(int i | i = pathSoFar.indexOf(result.toString())) and
+      not exists(pathSoFar.indexOf(result.toString())) and
       path = pathSoFar + "\n" + result
     )
   }
@@ -133,7 +133,7 @@ class InitialState extends State {
   }
 
   override State reachesVia(string path) {
-    path = this + "\n" + result and result = transition()
+    path = this + "\n" + result and result = this.transition()
     or
     result = super.reachesVia(path)
   }


### PR DESCRIPTION
I noticed ql-for-ql throw some style complaints during https://github.com/github/codeql/pull/11612 -- I guess we might as well show official-style-compliant (tm) CodeQL!

The docstring reword is a bit awkward, since usually classes are either singleton (document with `The ...`) or have potentially lots of entries (document with `A[n] ...`), whereas here there are exactly two shores, so `One of` is indeed more natural.