### PR TITLE
Ruby: Add `SummarizedCallable::getParameter`

### DIFF
--- a/ruby/ql/lib/codeql/ruby/dataflow/FlowSummary.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/FlowSummary.qll
@@ -4,7 +4,9 @@ import codeql.ruby.AST
 import codeql.ruby.DataFlow
 private import internal.FlowSummaryImpl as Impl
 private import internal.DataFlowDispatch
+private import internal.DataFlowImplCommon as DataFlowImplCommon
 private import internal.DataFlowPrivate
+private import internal.FlowSummaryImplSpecific
 
 // import all instances below
 private module Summaries {
@@ -127,6 +129,17 @@ abstract class SummarizedCallable extends LibraryCallable, Impl::Public::Summari
    */
   pragma[nomagic]
   predicate propagatesFlowExt(string input, string output, boolean preservesValue) { none() }
+
+  /**
+   * Gets the synthesized parameter that results from an input specification
+   * that starts with `Argument[s]` for this library callable.
+   */
+  DataFlow::ParameterNode getParameter(string s) {
+    exists(ParameterPosition pos |
+      DataFlowImplCommon::parameterNode(result, TLibraryCallable(this), pos) and
+      s = getParameterPositionCsv(pos)
+    )
+  }
 }
 
 /**

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImplSpecific.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImplSpecific.qll
@@ -145,19 +145,32 @@ string getComponentSpecificCsv(SummaryComponent sc) { none() }
 
 /** Gets the textual representation of a parameter position in the format used for flow summaries. */
 string getParameterPositionCsv(ParameterPosition pos) {
-  pos.isSelf() and result = "self"
-  or
-  pos.isBlock() and result = "block"
-  or
   exists(int i |
     pos.isPositional(i) and
     result = i.toString()
+  )
+  or
+  exists(int i |
+    pos.isPositionalLowerBound(i) and
+    result = i + ".."
   )
   or
   exists(string name |
     pos.isKeyword(name) and
     result = name + ":"
   )
+  or
+  pos.isSelf() and
+  result = "self"
+  or
+  pos.isBlock() and
+  result = "block"
+  or
+  pos.isAny() and
+  result = "any"
+  or
+  pos.isAnyNamed() and
+  result = "any-named"
 }
 
 /** Gets the textual representation of an argument position in the format used for flow summaries. */


### PR DESCRIPTION
@alexrford needs something like this in order to define synthesized parameter nodes as flow barriers.