### PR TITLE
Java: Add parameters of methods annotated @JavascriptInterface as remote flow sources

### DIFF
--- a/java/ql/lib/change-notes/2022-01-13-android-javascriptinterface-parameters-remote-sources.md
+++ b/java/ql/lib/change-notes/2022-01-13-android-javascriptinterface-parameters-remote-sources.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Added an external flow source for the parameters of methods annotated with `android.webkit.JavascriptInterface`.

--- a/java/ql/lib/semmle/code/java/dataflow/FlowSources.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/FlowSources.qll
@@ -298,3 +298,16 @@ class OnActivityResultIntentSource extends OnActivityResultIncomingIntent, Remot
 
   override string getSourceType() { result = "Android onActivityResult incoming Intent" }
 }
+
+/**
+ * A parameter of a method annotated with the `android.webkit.JavascriptInterface` method
+ */
+class AndroidJavascriptInterfaceMethodParameter extends RemoteFlowSource {
+  AndroidJavascriptInterfaceMethodParameter() {
+    exists(JavascriptInterfaceMethod m | this.asParameter() = m.getAParameter())
+  }
+
+  override string getSourceType() {
+    result = "Parameter of method with JavascriptInterface annotation"
+  }
+}

--- a/java/ql/lib/semmle/code/java/dataflow/FlowSources.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/FlowSources.qll
@@ -300,7 +300,7 @@ class OnActivityResultIntentSource extends OnActivityResultIncomingIntent, Remot
 }
 
 /**
- * A parameter of a method annotated with the `android.webkit.JavascriptInterface` method
+ * A parameter of a method annotated with the `android.webkit.JavascriptInterface` annotation.
  */
 class AndroidJavascriptInterfaceMethodParameter extends RemoteFlowSource {
   AndroidJavascriptInterfaceMethodParameter() {

--- a/java/ql/lib/semmle/code/java/frameworks/android/Android.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/android/Android.qll
@@ -127,3 +127,10 @@ class CreateFromParcelMethod extends Method {
     this.getEnclosingCallable().getDeclaringType().getAnAncestor() instanceof TypeParcelable
   }
 }
+
+/**
+ * A method annotated with the `android.webkit.JavascriptInterface` annotation.
+ */
+class JavascriptInterfaceMethod extends Method {
+  JavascriptInterfaceMethod() { this.hasAnnotation("android.webkit", "JavascriptInterface") }
+}

--- a/java/ql/lib/semmle/code/java/frameworks/android/Android.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/android/Android.qll
@@ -127,10 +127,3 @@ class CreateFromParcelMethod extends Method {
     this.getEnclosingCallable().getDeclaringType().getAnAncestor() instanceof TypeParcelable
   }
 }
-
-/**
- * A method annotated with the `android.webkit.JavascriptInterface` annotation.
- */
-class JavascriptInterfaceMethod extends Method {
-  JavascriptInterfaceMethod() { this.hasAnnotation("android.webkit", "JavascriptInterface") }
-}

--- a/java/ql/lib/semmle/code/java/frameworks/android/WebView.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/android/WebView.qll
@@ -85,3 +85,10 @@ class ShouldOverrideUrlLoading extends Method {
     this.hasName("shouldOverrideUrlLoading")
   }
 }
+
+/**
+ * A method annotated with the `android.webkit.JavascriptInterface` annotation.
+ */
+class JavascriptInterfaceMethod extends Method {
+  JavascriptInterfaceMethod() { this.hasAnnotation("android.webkit", "JavascriptInterface") }
+}

--- a/java/ql/test/library-tests/dataflow/taintsources/AndroidExposedObject.java
+++ b/java/ql/test/library-tests/dataflow/taintsources/AndroidExposedObject.java
@@ -1,0 +1,11 @@
+import android.webkit.JavascriptInterface;
+
+public class AndroidExposedObject {
+    public void sink(Object o) {
+    }
+
+    @JavascriptInterface
+    public void test(String arg) {
+        sink(arg); // $hasRemoteValueFlow
+    }
+}

--- a/java/ql/test/stubs/google-android-9.0.0/android/webkit/JavascriptInterface.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/webkit/JavascriptInterface.java
@@ -1,0 +1,7 @@
+package android.webkit;
+
+import java.lang.annotation.Annotation;
+
+public abstract @interface JavascriptInterface {
+
+}


### PR DESCRIPTION
In Android, methods annotated `android.webkit.JavascriptInterface` are exposed to the JavaScript running in the WebView.

Therefore, the parameters to the exposed methods may come from untrusted sources.