### PR TITLE
C++: Accept dataflow consistency changes

### DIFF
--- a/cpp/ql/test/library-tests/syntax-zoo/dataflow-ir-consistency.expected
+++ b/cpp/ql/test/library-tests/syntax-zoo/dataflow-ir-consistency.expected
@@ -236,6 +236,6 @@ postWithInFlow
 | try_catch.cpp:7:8:7:8 | call to exception | PostUpdateNode should not be the target of local flow. |
 viableImplInCallContextTooLarge
 uniqueParameterNodeAtPosition
-| ir.cpp:724:6:724:13 | TryCatch | 0 | ir.cpp:735:22:735:22 | *s | Parameters with overlapping positions. |
-| ir.cpp:724:6:724:13 | TryCatch | 0 | ir.cpp:738:24:738:24 | *e | Parameters with overlapping positions. |
+| ir.cpp:724:6:724:13 | TryCatch | 0 indirection | ir.cpp:735:22:735:22 | s indirection | Parameters with overlapping positions. |
+| ir.cpp:724:6:724:13 | TryCatch | 0 indirection | ir.cpp:738:24:738:24 | e indirection | Parameters with overlapping positions. |
 uniqueParameterNodePosition


### PR DESCRIPTION
This new check was added in https://github.com/github/codeql/pull/11564, and the same failures are present on `main`. I suspect this is bad IR generation.