### PR TITLE
C++: Prevent an `Expr` from stepping to itself in IR dataflow

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -1328,24 +1328,24 @@ predicate localInstructionFlow(Instruction e1, Instruction e2) {
 
 cached
 private module ExprFlowCached {
-/**
- * Holds if `n1.asExpr()` doesn't have a result and `n1` flows to `n2` in a single
- * dataflow step.
- */
-private predicate localStepFromNonExpr(Node n1, Node n2) {
-  not exists(n1.asExpr()) and
-  localFlowStep(n1, n2)
-}
+  /**
+   * Holds if `n1.asExpr()` doesn't have a result and `n1` flows to `n2` in a single
+   * dataflow step.
+   */
+  private predicate localStepFromNonExpr(Node n1, Node n2) {
+    not exists(n1.asExpr()) and
+    localFlowStep(n1, n2)
+  }
 
-/**
- * Holds if `n1.asExpr()` doesn't have a result, `n2.asExpr() = e2` and
- * `n2` is the first node reachable from `n1` such that `n2.asExpr()` exists.
- */
-pragma[nomagic]
-private predicate localStepsToExpr(Node n1, Node n2, Expr e2) {
-  localStepFromNonExpr*(n1, n2) and
-  e2 = n2.asExpr()
-}
+  /**
+   * Holds if `n1.asExpr()` doesn't have a result, `n2.asExpr() = e2` and
+   * `n2` is the first node reachable from `n1` such that `n2.asExpr()` exists.
+   */
+  pragma[nomagic]
+  private predicate localStepsToExpr(Node n1, Node n2, Expr e2) {
+    localStepFromNonExpr*(n1, n2) and
+    e2 = n2.asExpr()
+  }
 
   /**
    * Holds if `n1.asExpr() = e1` and `n2.asExpr() = e2` and `n2` is the first node
@@ -1353,10 +1353,10 @@ private predicate localStepsToExpr(Node n1, Node n2, Expr e2) {
    */
   private predicate localExprFlowSingleExprStep(Node n1, Expr e1, Node n2, Expr e2) {
     exists(Node mid |
-    localFlowStep(n1, mid) and
-    localStepsToExpr(mid, n2, e2) and
-    e1 = n1.asExpr()
-  )
+      localFlowStep(n1, mid) and
+      localStepsToExpr(mid, n2, e2) and
+      e1 = n1.asExpr()
+    )
   }
 
   /**
@@ -1384,6 +1384,23 @@ private predicate localStepsToExpr(Node n1, Node n2, Expr e2) {
 }
 
 import ExprFlowCached
+
+/**
+ * Holds if data can flow from `e1` to `e2` in one or more
+ * local (intra-procedural) steps.
+ */
+pragma[inline]
+private predicate localExprFlowPlus(Expr e1, Expr e2) = fastTC(localExprFlowStep/2)(e1, e2)
+
+/**
+ * Holds if data can flow from `e1` to `e2` in zero or more
+ * local (intra-procedural) steps.
+ */
+pragma[inline]
+predicate localExprFlow(Expr e1, Expr e2) {
+  e1 = e2
+  or
+  localExprFlowPlus(e1, e2)
 }
 
 cached


### PR DESCRIPTION
While investigating some query changes, I noticed that it can be the case that a single local step can step from a node `n1` representing the an expression, to a node `n2` that represents the expression's first conversion. Because `n.asExpr` then resolves to the unconverted expression, the result will be an expression `e` such that `localExprFlowStep(e, e)` holds 😱.

The fix is to add another level of recursion that ensures that we always step to a different expression. This is done in a3285653aebb514c4f31ac46b14dd8854654addb. 52bf39bcf93e07ff7d95edb9bdf9543a0955131b fixes a performance shown by the join-order detection in DCA. It turns out the `*` in the `localExprFlow` relation wasn't turned into a `fastTC` by the compiler, and it resulted in quite a few iterations that looked like:
```ql
Evaluated recursive predicate #DataFlowUtil#47741e1f::ExprFlowCached::localExprFlowStep#2Plus#bf@aafb49jn in 916ms on iteration 2 (delta size: 844629).
Evaluated relational algebra for predicate #DataFlowUtil#47741e1f::ExprFlowCached::localExprFlowStep#2Plus#bf@aafb49jn on iteration 2 running pipeline standard with tuple counts:
    923848     ~0%    {2} r1 = SCAN #DataFlowUtil#47741e1f::ExprFlowCached::localExprFlowStep#2Plus#bf#prev_delta OUTPUT In.1, In.0
  23112681  ~1725%    {2} r2 = JOIN r1 WITH DataFlowUtil#47741e1f::ExprFlowCached::localExprFlowStep#2#ff ON FIRST 1 OUTPUT Lhs.1, Rhs.1
    928088    ~14%    {2} r3 = r2 AND NOT #DataFlowUtil#47741e1f::ExprFlowCached::localExprFlowStep#2Plus#bf#prev(Lhs.0, Lhs.1)
                      return r3
```

So the last commit transforms that `*` into a `fastTC` manually.