### PR TITLE
C++: Generalize the `ArgvSource` flow source

### DIFF
--- a/cpp/ql/lib/change-notes/2022-12-09-generalize-argv-source.md
+++ b/cpp/ql/lib/change-notes/2022-12-09-generalize-argv-source.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The `ArgvSource` flow source has been generalized to handle cases where the argument vector of `main` is not named `argv`.

--- a/cpp/ql/lib/semmle/code/cpp/security/FlowSources.qll
+++ b/cpp/ql/lib/semmle/code/cpp/security/FlowSources.qll
@@ -89,9 +89,9 @@ private class LocalParameterSource extends LocalFlowSource {
 
 private class ArgvSource extends LocalFlowSource {
   ArgvSource() {
-    exists(Parameter argv |
-      argv.hasName("argv") and
-      argv.getFunction().hasGlobalName("main") and
+    exists(Function main, Parameter argv |
+      main.hasGlobalName("main") and
+      main.getParameter(1) = argv and
       this.asExpr() = argv.getAnAccess()
     )
   }


### PR DESCRIPTION
This matches `isUserInput` and handles cases where `argv` has a different name, which is allowed.