### PR TITLE
Java/C#/GO: Use instanceof in more places

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/commons/Assertions.qll
+++ b/csharp/ql/lib/semmle/code/csharp/commons/Assertions.qll
@@ -368,40 +368,32 @@ private Stmt getAnAssertingStmt(Assertion a) {
 }
 
 /** A method that forwards to a Boolean assertion method. */
-class ForwarderBooleanAssertMethod extends BooleanAssertMethod {
-  private ForwarderAssertMethod forwarder;
+class ForwarderBooleanAssertMethod extends BooleanAssertMethod instanceof ForwarderAssertMethod {
   private BooleanAssertMethod underlying;
 
-  ForwarderBooleanAssertMethod() {
-    forwarder = this and
-    underlying = forwarder.getUnderlyingAssertMethod()
-  }
+  ForwarderBooleanAssertMethod() { underlying = super.getUnderlyingAssertMethod() }
 
   override int getAnAssertionIndex(boolean b) {
-    forwarder.getAForwarderAssertionIndex(result) = underlying.getAnAssertionIndex(b)
+    super.getAForwarderAssertionIndex(result) = underlying.getAnAssertionIndex(b)
   }
 
   override AssertionFailure getAssertionFailure(int i) {
-    result = underlying.getAssertionFailure(forwarder.getAForwarderAssertionIndex(i))
+    result = underlying.getAssertionFailure(super.getAForwarderAssertionIndex(i))
   }
 }
 
 /** A method that forwards to a nullness assertion method. */
-class ForwarderNullnessAssertMethod extends NullnessAssertMethod {
-  private ForwarderAssertMethod forwarder;
+class ForwarderNullnessAssertMethod extends NullnessAssertMethod instanceof ForwarderAssertMethod {
   private NullnessAssertMethod underlying;
 
-  ForwarderNullnessAssertMethod() {
-    forwarder = this and
-    underlying = forwarder.getUnderlyingAssertMethod()
-  }
+  ForwarderNullnessAssertMethod() { underlying = super.getUnderlyingAssertMethod() }
 
   override int getAnAssertionIndex(boolean b) {
-    forwarder.getAForwarderAssertionIndex(result) = underlying.getAnAssertionIndex(b)
+    super.getAForwarderAssertionIndex(result) = underlying.getAnAssertionIndex(b)
   }
 
   override AssertionFailure getAssertionFailure(int i) {
-    result = underlying.getAssertionFailure(forwarder.getAForwarderAssertionIndex(i))
+    result = underlying.getAssertionFailure(super.getAForwarderAssertionIndex(i))
   }
 }
 

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/ContentDataFlow.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/ContentDataFlow.qll
@@ -222,18 +222,14 @@ module ContentDataFlow {
     )
   }
 
-  private class ConfigurationAdapter extends DF::Configuration {
-    private Configuration c;
-
-    ConfigurationAdapter() { this = c }
-
+  private class ConfigurationAdapter extends DF::Configuration instanceof Configuration {
     final override predicate isSource(Node source, DF::FlowState state) {
-      c.isSource(source) and
+      Configuration.super.isSource(source) and
       state.(InitState).decode(true)
     }
 
     final override predicate isSink(Node sink, DF::FlowState state) {
-      c.isSink(sink) and
+      Configuration.super.isSink(sink) and
       (
         state instanceof InitState or
         state instanceof StoreState or
@@ -249,9 +245,9 @@ module ContentDataFlow {
       additionalStep(node1, state1, node2, state2, this)
     }
 
-    final override predicate isBarrier(Node node) { c.isBarrier(node) }
+    final override predicate isBarrier(Node node) { Configuration.super.isBarrier(node) }
 
-    final override FlowFeature getAFeature() { result = c.getAFeature() }
+    final override FlowFeature getAFeature() { result = Configuration.super.getAFeature() }
 
     // needed to record reads/stores inside summarized callables
     final override predicate includeHiddenNodes() { any() }

--- a/csharp/ql/lib/semmle/code/csharp/frameworks/System.qll
+++ b/csharp/ql/lib/semmle/code/csharp/frameworks/System.qll
@@ -257,9 +257,7 @@ class SystemNullReferenceExceptionClass extends SystemClass {
 }
 
 /** The `System.Object` class. */
-class SystemObjectClass extends SystemClass {
-  SystemObjectClass() { this instanceof ObjectType }
-
+class SystemObjectClass extends SystemClass instanceof ObjectType {
   /** Gets the `Equals(object)` method. */
   Method getEqualsMethod() {
     result.getDeclaringType() = this and

--- a/csharp/ql/lib/semmle/code/csharp/security/dataflow/CleartextStorageQuery.qll
+++ b/csharp/ql/lib/semmle/code/csharp/security/dataflow/CleartextStorageQuery.qll
@@ -56,6 +56,4 @@ class ProtectSanitizer extends Sanitizer {
 /**
  * An external location sink.
  */
-class ExternalSink extends Sink {
-  ExternalSink() { this instanceof ExternalLocationSink }
-}
+class ExternalSink extends Sink instanceof ExternalLocationSink { }

--- a/csharp/ql/lib/semmle/code/csharp/security/dataflow/CodeInjectionQuery.qll
+++ b/csharp/ql/lib/semmle/code/csharp/security/dataflow/CodeInjectionQuery.qll
@@ -38,14 +38,10 @@ class TaintTrackingConfiguration extends TaintTracking::Configuration {
 }
 
 /** A source of remote user input. */
-class RemoteSource extends Source {
-  RemoteSource() { this instanceof RemoteFlowSource }
-}
+class RemoteSource extends Source instanceof RemoteFlowSource { }
 
 /** A source of local user input. */
-class LocalSource extends Source {
-  LocalSource() { this instanceof LocalFlowSource }
-}
+class LocalSource extends Source instanceof LocalFlowSource { }
 
 private class SimpleTypeSanitizer extends Sanitizer, SimpleTypeSanitizedExpr { }
 

--- a/csharp/ql/lib/semmle/code/csharp/security/dataflow/CommandInjectionQuery.qll
+++ b/csharp/ql/lib/semmle/code/csharp/security/dataflow/CommandInjectionQuery.qll
@@ -36,9 +36,7 @@ class TaintTrackingConfiguration extends TaintTracking::Configuration {
 }
 
 /** A source of remote user input. */
-class RemoteSource extends Source {
-  RemoteSource() { this instanceof RemoteFlowSource }
-}
+class RemoteSource extends Source instanceof RemoteFlowSource { }
 
 /**
  * A sink in `System.Diagnostic.Process` or its related classes.

--- a/csharp/ql/lib/semmle/code/csharp/security/dataflow/ConditionalBypassQuery.qll
+++ b/csharp/ql/lib/semmle/code/csharp/security/dataflow/ConditionalBypassQuery.qll
@@ -43,9 +43,7 @@ class Configuration extends TaintTracking::Configuration {
 }
 
 /** A source of remote user input. */
-class RemoteSource extends Source {
-  RemoteSource() { this instanceof RemoteFlowSource }
-}
+class RemoteSource extends Source instanceof RemoteFlowSource { }
 
 /** The result of a reverse dns may be user-controlled. */
 class ReverseDnsSource extends Source {

--- a/csharp/ql/lib/semmle/code/csharp/security/dataflow/ExposureOfPrivateInformationQuery.qll
+++ b/csharp/ql/lib/semmle/code/csharp/security/dataflow/ExposureOfPrivateInformationQuery.qll
@@ -39,6 +39,4 @@ private class PrivateDataSource extends Source {
   PrivateDataSource() { this.getExpr() instanceof PrivateDataExpr }
 }
 
-private class ExternalLocation extends Sink {
-  ExternalLocation() { this instanceof ExternalLocationSink }
-}
+private class ExternalLocation extends Sink instanceof ExternalLocationSink { }

--- a/csharp/ql/lib/semmle/code/csharp/security/dataflow/ExternalAPIsQuery.qll
+++ b/csharp/ql/lib/semmle/code/csharp/security/dataflow/ExternalAPIsQuery.qll
@@ -17,8 +17,7 @@ abstract class SafeExternalApiCallable extends Callable { }
 /** DEPRECATED: Alias for SafeExternalApiCallable */
 deprecated class SafeExternalAPICallable = SafeExternalApiCallable;
 
-private class SummarizedCallableSafe extends SafeExternalApiCallable {
-  SummarizedCallableSafe() { this instanceof SummarizedCallable }
+private class SummarizedCallableSafe extends SafeExternalApiCallable instanceof SummarizedCallable {
 }
 
 /** The default set of "safe" external APIs. */

--- a/csharp/ql/lib/semmle/code/csharp/security/dataflow/LDAPInjectionQuery.qll
+++ b/csharp/ql/lib/semmle/code/csharp/security/dataflow/LDAPInjectionQuery.qll
@@ -38,9 +38,7 @@ class TaintTrackingConfiguration extends TaintTracking::Configuration {
 }
 
 /** A source of remote user input. */
-class RemoteSource extends Source {
-  RemoteSource() { this instanceof RemoteFlowSource }
-}
+class RemoteSource extends Source instanceof RemoteFlowSource { }
 
 /**
  * An argument that sets the `Path` property of a `DirectoryEntry` object that is a sink for LDAP

--- a/csharp/ql/lib/semmle/code/csharp/security/dataflow/LogForgingQuery.qll
+++ b/csharp/ql/lib/semmle/code/csharp/security/dataflow/LogForgingQuery.qll
@@ -38,9 +38,7 @@ class TaintTrackingConfiguration extends TaintTracking::Configuration {
 }
 
 /** A source of remote user input. */
-private class RemoteSource extends Source {
-  RemoteSource() { this instanceof RemoteFlowSource }
-}
+private class RemoteSource extends Source instanceof RemoteFlowSource { }
 
 private class HtmlSanitizer extends Sanitizer {
   HtmlSanitizer() { this.asExpr() instanceof HtmlSanitizedExpr }

--- a/csharp/ql/lib/semmle/code/csharp/security/dataflow/MissingXMLValidationQuery.qll
+++ b/csharp/ql/lib/semmle/code/csharp/security/dataflow/MissingXMLValidationQuery.qll
@@ -43,9 +43,7 @@ class TaintTrackingConfiguration extends TaintTracking::Configuration {
 }
 
 /** A source of remote user input. */
-class RemoteSource extends Source {
-  RemoteSource() { this instanceof RemoteFlowSource }
-}
+class RemoteSource extends Source instanceof RemoteFlowSource { }
 
 /**
  * The input argument to a call to `XmlReader.Create` where the input will not be validated against

--- a/csharp/ql/lib/semmle/code/csharp/security/dataflow/ReDoSQuery.qll
+++ b/csharp/ql/lib/semmle/code/csharp/security/dataflow/ReDoSQuery.qll
@@ -38,9 +38,7 @@ class TaintTrackingConfiguration extends TaintTracking::Configuration {
 }
 
 /** A source of remote user input. */
-class RemoteSource extends Source {
-  RemoteSource() { this instanceof RemoteFlowSource }
-}
+class RemoteSource extends Source instanceof RemoteFlowSource { }
 
 /**
  * An expression that represents a regular expression with potential exponential behavior.

--- a/csharp/ql/lib/semmle/code/csharp/security/dataflow/RegexInjectionQuery.qll
+++ b/csharp/ql/lib/semmle/code/csharp/security/dataflow/RegexInjectionQuery.qll
@@ -37,9 +37,7 @@ class TaintTrackingConfiguration extends TaintTracking::Configuration {
 }
 
 /** A source of remote user input. */
-class RemoteSource extends Source {
-  RemoteSource() { this instanceof RemoteFlowSource }
-}
+class RemoteSource extends Source instanceof RemoteFlowSource { }
 
 /**
  * A `pattern` argument to a construction of a `Regex`.

--- a/csharp/ql/lib/semmle/code/csharp/security/dataflow/ResourceInjectionQuery.qll
+++ b/csharp/ql/lib/semmle/code/csharp/security/dataflow/ResourceInjectionQuery.qll
@@ -37,14 +37,10 @@ class TaintTrackingConfiguration extends TaintTracking::Configuration {
 }
 
 /** A source of remote user input. */
-class RemoteSource extends Source {
-  RemoteSource() { this instanceof RemoteFlowSource }
-}
+class RemoteSource extends Source instanceof RemoteFlowSource { }
 
 /** A source of local user input. */
-class LocalSource extends Source {
-  LocalSource() { this instanceof LocalFlowSource }
-}
+class LocalSource extends Source instanceof LocalFlowSource { }
 
 /** An argument to the `ConnectionString` property on a data connection class. */
 class SqlConnectionStringSink extends Sink {

--- a/csharp/ql/lib/semmle/code/csharp/security/dataflow/SqlInjectionQuery.qll
+++ b/csharp/ql/lib/semmle/code/csharp/security/dataflow/SqlInjectionQuery.qll
@@ -38,14 +38,10 @@ class TaintTrackingConfiguration extends TaintTracking::Configuration {
 }
 
 /** A source of remote user input. */
-class RemoteSource extends Source {
-  RemoteSource() { this instanceof RemoteFlowSource }
-}
+class RemoteSource extends Source instanceof RemoteFlowSource { }
 
 /** A source of local user input. */
-class LocalSource extends Source {
-  LocalSource() { this instanceof LocalFlowSource }
-}
+class LocalSource extends Source instanceof LocalFlowSource { }
 
 /** An SQL expression passed to an API call that executes SQL. */
 class SqlInjectionExprSink extends Sink {

--- a/csharp/ql/lib/semmle/code/csharp/security/dataflow/TaintedPathQuery.qll
+++ b/csharp/ql/lib/semmle/code/csharp/security/dataflow/TaintedPathQuery.qll
@@ -39,9 +39,7 @@ class TaintTrackingConfiguration extends TaintTracking::Configuration {
 }
 
 /** A source of remote user input. */
-class RemoteSource extends Source {
-  RemoteSource() { this instanceof RemoteFlowSource }
-}
+class RemoteSource extends Source instanceof RemoteFlowSource { }
 
 /**
  * A path argument to a `File` method call.

--- a/csharp/ql/lib/semmle/code/csharp/security/dataflow/UnsafeDeserializationQuery.qll
+++ b/csharp/ql/lib/semmle/code/csharp/security/dataflow/UnsafeDeserializationQuery.qll
@@ -44,9 +44,7 @@ abstract private class ConstructorOrStaticMethodSink extends Sink { }
  */
 abstract class Sanitizer extends DataFlow::Node { }
 
-private class RemoteSource extends Source {
-  RemoteSource() { this instanceof RemoteFlowSource }
-}
+private class RemoteSource extends Source instanceof RemoteFlowSource { }
 
 /**
  * User input to object method call deserialization flow tracking.

--- a/csharp/ql/lib/semmle/code/csharp/security/dataflow/UrlRedirectQuery.qll
+++ b/csharp/ql/lib/semmle/code/csharp/security/dataflow/UrlRedirectQuery.qll
@@ -50,9 +50,7 @@ class TaintTrackingConfiguration extends TaintTracking::Configuration {
 }
 
 /** A source of remote user input. */
-class RemoteSource extends Source {
-  RemoteSource() { this instanceof RemoteFlowSource }
-}
+class RemoteSource extends Source instanceof RemoteFlowSource { }
 
 /**
  * A URL argument to a call to `HttpResponse.Redirect()` or `Controller.Redirect()`, that is a

--- a/csharp/ql/lib/semmle/code/csharp/security/dataflow/XMLEntityInjectionQuery.qll
+++ b/csharp/ql/lib/semmle/code/csharp/security/dataflow/XMLEntityInjectionQuery.qll
@@ -14,9 +14,7 @@ private import semmle.code.csharp.security.Sanitizers
  */
 abstract class Source extends DataFlow::Node { }
 
-private class RemoteSource extends Source {
-  RemoteSource() { this instanceof RemoteFlowSource }
-}
+private class RemoteSource extends Source instanceof RemoteFlowSource { }
 
 /**
  * A data flow sink for untrusted user input used in XML processing.

--- a/csharp/ql/lib/semmle/code/csharp/security/dataflow/XPathInjectionQuery.qll
+++ b/csharp/ql/lib/semmle/code/csharp/security/dataflow/XPathInjectionQuery.qll
@@ -37,9 +37,7 @@ class TaintTrackingConfiguration extends TaintTracking::Configuration {
 }
 
 /** A source of remote user input. */
-class RemoteSource extends Source {
-  RemoteSource() { this instanceof RemoteFlowSource }
-}
+class RemoteSource extends Source instanceof RemoteFlowSource { }
 
 /** The `xpath` argument to an `XPathExpression.Compile(..)` call. */
 class XPathExpressionCompileSink extends Sink {

--- a/csharp/ql/lib/semmle/code/csharp/security/dataflow/XSSQuery.qll
+++ b/csharp/ql/lib/semmle/code/csharp/security/dataflow/XSSQuery.qll
@@ -149,9 +149,7 @@ class TaintTrackingConfiguration extends TaintTracking2::Configuration {
 }
 
 /** A source of remote user input. */
-private class RemoteSource extends Source {
-  RemoteSource() { this instanceof RemoteFlowSource }
-}
+private class RemoteSource extends Source instanceof RemoteFlowSource { }
 
 private class SimpleTypeSanitizer extends Sanitizer, SimpleTypeSanitizedExpr { }
 

--- a/csharp/ql/lib/semmle/code/csharp/security/dataflow/XSSSinks.qll
+++ b/csharp/ql/lib/semmle/code/csharp/security/dataflow/XSSSinks.qll
@@ -27,9 +27,7 @@ private class ExternalXssSink extends Sink {
   ExternalXssSink() { sinkNode(this, "xss") }
 }
 
-private class HtmlSinkSink extends Sink {
-  HtmlSinkSink() { this instanceof HtmlSink }
-
+private class HtmlSinkSink extends Sink instanceof HtmlSink {
   override string explanation() {
     this instanceof WebPageWriteLiteralSink and
     result = "System.Web.WebPages.WebPage.WriteLiteral() method"

--- a/csharp/ql/src/AlertSuppression.ql
+++ b/csharp/ql/src/AlertSuppression.ql
@@ -44,9 +44,7 @@ class SuppressionComment extends CommentLine {
 /**
  * The scope of an alert suppression comment.
  */
-class SuppressionScope extends @commentline {
-  SuppressionScope() { this instanceof SuppressionComment }
-
+class SuppressionScope extends @commentline instanceof SuppressionComment {
   /** Gets a suppression comment with this scope. */
   SuppressionComment getSuppressionComment() { result = this }
 
@@ -60,7 +58,7 @@ class SuppressionScope extends @commentline {
   predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    this.(SuppressionComment).covers(filepath, startline, startcolumn, endline, endcolumn)
+    super.covers(filepath, startline, startcolumn, endline, endcolumn)
   }
 
   /** Gets a textual representation of this element. */

--- a/csharp/ql/src/experimental/CWE-099/TaintedWebClientLib.qll
+++ b/csharp/ql/src/experimental/CWE-099/TaintedWebClientLib.qll
@@ -51,9 +51,7 @@ class TaintTrackingConfiguration extends TaintTracking::Configuration {
 }
 
 /** A source of remote user input. */
-class RemoteSource extends Source {
-  RemoteSource() { this instanceof RemoteFlowSource }
-}
+class RemoteSource extends Source instanceof RemoteFlowSource { }
 
 /**
  * A path argument to a `WebClient` method call that has an address argument.

--- a/csharp/ql/src/experimental/CWE-918/RequestForgery.qll
+++ b/csharp/ql/src/experimental/CWE-918/RequestForgery.qll
@@ -58,9 +58,7 @@ module RequestForgery {
    * A remote data flow source taken as a source
    * for Server Side Request Forgery(SSRF) Vulnerabilities.
    */
-  private class RemoteFlowSourceAsSource extends Source {
-    RemoteFlowSourceAsSource() { this instanceof RemoteFlowSource }
-  }
+  private class RemoteFlowSourceAsSource extends Source instanceof RemoteFlowSource { }
 
   /**
    * An url argument to a `HttpRequestMessage` constructor call

--- a/csharp/ql/test/library-tests/dataflow/global/TaintTracking.ql
+++ b/csharp/ql/test/library-tests/dataflow/global/TaintTracking.ql
@@ -1,14 +1,10 @@
 import csharp
 import Common
 
-class TTConfig extends TaintTracking::Configuration {
-  Config c;
+class TTConfig extends TaintTracking::Configuration instanceof Config {
+  override predicate isSource(DataFlow::Node source) { Config.super.isSource(source) }
 
-  TTConfig() { this = c }
-
-  override predicate isSource(DataFlow::Node source) { c.isSource(source) }
-
-  override predicate isSink(DataFlow::Node sink) { c.isSink(sink) }
+  override predicate isSink(DataFlow::Node sink) { Config.super.isSink(sink) }
 }
 
 from TTConfig c, DataFlow::Node source, DataFlow::Node sink

--- a/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.ql
+++ b/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.ql
@@ -6,14 +6,10 @@ import csharp
 import Common
 import DataFlow::PathGraph
 
-class TTConfig extends TaintTracking::Configuration {
-  Config c;
+class TTConfig extends TaintTracking::Configuration instanceof Config {
+  override predicate isSource(DataFlow::Node source) { Config.super.isSource(source) }
 
-  TTConfig() { this = c }
-
-  override predicate isSource(DataFlow::Node source) { c.isSource(source) }
-
-  override predicate isSink(DataFlow::Node sink) { c.isSink(sink) }
+  override predicate isSink(DataFlow::Node sink) { Config.super.isSink(sink) }
 }
 
 from TTConfig c, DataFlow::PathNode source, DataFlow::PathNode sink, string s

--- a/csharp/ql/test/library-tests/dataflow/library/FlowSummaries.ql
+++ b/csharp/ql/test/library-tests/dataflow/library/FlowSummaries.ql
@@ -6,11 +6,7 @@ private class IncludeAllSummarizedCallable extends IncludeSummarizedCallable {
   IncludeAllSummarizedCallable() { exists(this) }
 }
 
-private class IncludeNegativeSummarizedCallable extends RelevantNegativeSummarizedCallable {
-  IncludeNegativeSummarizedCallable() {
-    this instanceof FlowSummaryImpl::Public::NegativeSummarizedCallable
-  }
-
+private class IncludeNegativeSummarizedCallable extends RelevantNegativeSummarizedCallable instanceof FlowSummaryImpl::Public::NegativeSummarizedCallable {
   /** Gets a string representing the callable in semi-colon separated format for use in flow summaries. */
   final override string getCallableCsv() { result = Csv::asPartialNegativeModel(this) }
 }

--- a/csharp/ql/test/library-tests/dataflow/library/FlowSummariesFiltered.ql
+++ b/csharp/ql/test/library-tests/dataflow/library/FlowSummariesFiltered.ql
@@ -2,9 +2,7 @@ import shared.FlowSummaries
 private import semmle.code.csharp.dataflow.internal.DataFlowPrivate::Csv
 private import semmle.code.csharp.dataflow.ExternalFlow
 
-class IncludeFilteredSummarizedCallable extends IncludeSummarizedCallable {
-  IncludeFilteredSummarizedCallable() { this instanceof SummarizedCallable }
-
+class IncludeFilteredSummarizedCallable extends IncludeSummarizedCallable instanceof SummarizedCallable {
   /**
    * Holds if flow is propagated between `input` and `output` and
    * if there is no summary for a callable in a `base` class or interface
@@ -13,7 +11,7 @@ class IncludeFilteredSummarizedCallable extends IncludeSummarizedCallable {
   override predicate relevantSummary(
     SummaryComponentStack input, SummaryComponentStack output, boolean preservesValue
   ) {
-    this.(SummarizedCallable).propagatesFlow(input, output, preservesValue) and
+    super.propagatesFlow(input, output, preservesValue) and
     not exists(IncludeSummarizedCallable rsc |
       isBaseCallableOrPrototype(rsc) and
       rsc.(SummarizedCallable).propagatesFlow(input, output, preservesValue) and

--- a/csharp/ql/test/library-tests/frameworks/EntityFramework/FlowSummaries.ql
+++ b/csharp/ql/test/library-tests/frameworks/EntityFramework/FlowSummaries.ql
@@ -2,8 +2,7 @@ import semmle.code.csharp.frameworks.EntityFramework::EntityFramework
 import shared.FlowSummaries
 import semmle.code.csharp.dataflow.ExternalFlow as ExternalFlow
 
-private class IncludeEFSummarizedCallable extends IncludeSummarizedCallable {
-  IncludeEFSummarizedCallable() { this instanceof EFSummarizedCallable }
+private class IncludeEFSummarizedCallable extends IncludeSummarizedCallable instanceof EFSummarizedCallable {
 }
 
 query predicate sourceNode(DataFlow::Node node, string kind) {

--- a/go/ql/lib/semmle/go/controlflow/ControlFlowGraph.qll
+++ b/go/ql/lib/semmle/go/controlflow/ControlFlowGraph.qll
@@ -106,24 +106,20 @@ module ControlFlow {
    * A control-flow node that initializes or updates the value of a constant, a variable,
    * a field, or an (array, slice, or map) element.
    */
-  class WriteNode extends Node {
-    IR::WriteInstruction self;
-
-    WriteNode() { this = self }
-
+  class WriteNode extends Node instanceof IR::WriteInstruction {
     /** Gets the left-hand side of this write. */
-    IR::WriteTarget getLhs() { result = self.getLhs() }
+    IR::WriteTarget getLhs() { result = super.getLhs() }
 
     /** Gets the right-hand side of this write. */
-    DataFlow::Node getRhs() { self.getRhs() = result.asInstruction() }
+    DataFlow::Node getRhs() { super.getRhs() = result.asInstruction() }
 
     /** Holds if this node sets variable or constant `v` to `rhs`. */
-    predicate writes(ValueEntity v, DataFlow::Node rhs) { self.writes(v, rhs.asInstruction()) }
+    predicate writes(ValueEntity v, DataFlow::Node rhs) { super.writes(v, rhs.asInstruction()) }
 
     /** Holds if this node defines SSA variable `v` to be `rhs`. */
     predicate definesSsaVariable(SsaVariable v, DataFlow::Node rhs) {
-      self.getLhs().asSsaVariable() = v and
-      self.getRhs() = rhs.asInstruction()
+      super.getLhs().asSsaVariable() = v and
+      super.getRhs() = rhs.asInstruction()
     }
 
     /**
@@ -136,13 +132,13 @@ module ControlFlow {
      * node corresponding to `newWidth`.
      */
     predicate writesField(DataFlow::Node base, Field f, DataFlow::Node rhs) {
-      exists(IR::FieldTarget trg | trg = self.getLhs() |
+      exists(IR::FieldTarget trg | trg = super.getLhs() |
         (
           trg.getBase() = base.asInstruction() or
           trg.getBase() = MkImplicitDeref(base.asExpr())
         ) and
         trg.getField() = f and
-        self.getRhs() = rhs.asInstruction()
+        super.getRhs() = rhs.asInstruction()
       )
     }
 
@@ -156,13 +152,13 @@ module ControlFlow {
      * is the data-flow node corresponding to `base`.
      */
     predicate writesElement(DataFlow::Node base, DataFlow::Node index, DataFlow::Node rhs) {
-      exists(IR::ElementTarget trg | trg = self.getLhs() |
+      exists(IR::ElementTarget trg | trg = super.getLhs() |
         (
           trg.getBase() = base.asInstruction() or
           trg.getBase() = MkImplicitDeref(base.asExpr())
         ) and
         trg.getIndex() = index.asInstruction() and
-        self.getRhs() = rhs.asInstruction()
+        super.getRhs() = rhs.asInstruction()
       )
     }
 

--- a/go/ql/lib/semmle/go/security/CommandInjectionCustomizations.qll
+++ b/go/ql/lib/semmle/go/security/CommandInjectionCustomizations.qll
@@ -37,9 +37,7 @@ module CommandInjection {
   abstract deprecated class SanitizerGuard extends DataFlow::BarrierGuard { }
 
   /** A source of untrusted data, considered as a taint source for command injection. */
-  class UntrustedFlowAsSource extends Source {
-    UntrustedFlowAsSource() { this instanceof UntrustedFlowSource }
-  }
+  class UntrustedFlowAsSource extends Source instanceof UntrustedFlowSource { }
 
   /** A command name, considered as a taint sink for command injection. */
   class CommandNameAsSink extends Sink {

--- a/go/ql/lib/semmle/go/security/LogInjectionCustomizations.qll
+++ b/go/ql/lib/semmle/go/security/LogInjectionCustomizations.qll
@@ -33,9 +33,7 @@ module LogInjection {
   abstract deprecated class SanitizerGuard extends DataFlow::BarrierGuard { }
 
   /** A source of untrusted data, considered as a taint source for log injection. */
-  class UntrustedFlowAsSource extends Source {
-    UntrustedFlowAsSource() { this instanceof UntrustedFlowSource }
-  }
+  class UntrustedFlowAsSource extends Source instanceof UntrustedFlowSource { }
 
   /** An argument to a logging mechanism. */
   class LoggerSink extends Sink {

--- a/go/ql/lib/semmle/go/security/OpenUrlRedirectCustomizations.qll
+++ b/go/ql/lib/semmle/go/security/OpenUrlRedirectCustomizations.qll
@@ -117,9 +117,7 @@ module OpenUrlRedirect {
 }
 
 /** A sink for an open redirect, considered as a sink for safe URL flow. */
-private class SafeUrlSink extends SafeUrlFlow::Sink {
-  SafeUrlSink() { this instanceof OpenUrlRedirect::Sink }
-}
+private class SafeUrlSink extends SafeUrlFlow::Sink instanceof OpenUrlRedirect::Sink { }
 
 /**
  * A read of a field considered unsafe to redirect to, considered as a sanitizer for a safe

--- a/go/ql/lib/semmle/go/security/ReflectedXssCustomizations.qll
+++ b/go/ql/lib/semmle/go/security/ReflectedXssCustomizations.qll
@@ -27,9 +27,7 @@ module ReflectedXss {
   abstract deprecated class SanitizerGuard extends DataFlow::BarrierGuard { }
 
   /** A shared XSS sanitizer as a sanitizer for reflected XSS. */
-  private class SharedXssSanitizer extends Sanitizer {
-    SharedXssSanitizer() { this instanceof SharedXss::Sanitizer }
-  }
+  private class SharedXssSanitizer extends Sanitizer instanceof SharedXss::Sanitizer { }
 
   /** A shared XSS sanitizer guard as a sanitizer guard for reflected XSS. */
   deprecated private class SharedXssSanitizerGuard extends SanitizerGuard {
@@ -46,7 +44,5 @@ module ReflectedXss {
   class UntrustedFlowAsSource extends Source, UntrustedFlowSource { }
 
   /** An arbitrary XSS sink, considered as a flow sink for stored XSS. */
-  private class AnySink extends Sink {
-    AnySink() { this instanceof SharedXss::Sink }
-  }
+  private class AnySink extends Sink instanceof SharedXss::Sink { }
 }

--- a/go/ql/lib/semmle/go/security/RequestForgeryCustomizations.qll
+++ b/go/ql/lib/semmle/go/security/RequestForgeryCustomizations.qll
@@ -102,9 +102,7 @@ module RequestForgery {
 }
 
 /** A sink for request forgery, considered as a sink for safe URL flow. */
-private class SafeUrlSink extends SafeUrlFlow::Sink {
-  SafeUrlSink() { this instanceof RequestForgery::Sink }
-}
+private class SafeUrlSink extends SafeUrlFlow::Sink instanceof RequestForgery::Sink { }
 
 /**
  * A read of a field considered unsafe for request forgery, considered as a sanitizer for a safe

--- a/go/ql/lib/semmle/go/security/SqlInjectionCustomizations.qll
+++ b/go/ql/lib/semmle/go/security/SqlInjectionCustomizations.qll
@@ -33,17 +33,11 @@ module SqlInjection {
   abstract deprecated class SanitizerGuard extends DataFlow::BarrierGuard { }
 
   /** A source of untrusted data, considered as a taint source for SQL injection. */
-  class UntrustedFlowAsSource extends Source {
-    UntrustedFlowAsSource() { this instanceof UntrustedFlowSource }
-  }
+  class UntrustedFlowAsSource extends Source instanceof UntrustedFlowSource { }
 
   /** An SQL string, considered as a taint sink for SQL injection. */
-  class SqlQueryAsSink extends Sink {
-    SqlQueryAsSink() { this instanceof SQL::QueryString }
-  }
+  class SqlQueryAsSink extends Sink instanceof SQL::QueryString { }
 
   /** A NoSql query, considered as a taint sink for SQL injection. */
-  class NoSqlQueryAsSink extends Sink {
-    NoSqlQueryAsSink() { this instanceof NoSql::Query }
-  }
+  class NoSqlQueryAsSink extends Sink instanceof NoSql::Query { }
 }

--- a/go/ql/lib/semmle/go/security/StoredXssCustomizations.qll
+++ b/go/ql/lib/semmle/go/security/StoredXssCustomizations.qll
@@ -24,9 +24,7 @@ module StoredXss {
   abstract deprecated class SanitizerGuard extends DataFlow::BarrierGuard { }
 
   /** A shared XSS sanitizer as a sanitizer for stored XSS. */
-  private class SharedXssSanitizer extends Sanitizer {
-    SharedXssSanitizer() { this instanceof SharedXss::Sanitizer }
-  }
+  private class SharedXssSanitizer extends Sanitizer instanceof SharedXss::Sanitizer { }
 
   /** A shared XSS sanitizer guard as a sanitizer guard for stored XSS. */
   deprecated private class SharedXssSanitizerGuard extends SanitizerGuard {
@@ -59,7 +57,5 @@ module StoredXss {
   }
 
   /** An arbitrary XSS sink, considered as a flow sink for stored XSS. */
-  private class AnySink extends Sink {
-    AnySink() { this instanceof SharedXss::Sink }
-  }
+  private class AnySink extends Sink instanceof SharedXss::Sink { }
 }

--- a/go/ql/lib/semmle/go/security/TaintedPathCustomizations.qll
+++ b/go/ql/lib/semmle/go/security/TaintedPathCustomizations.qll
@@ -61,9 +61,7 @@ module TaintedPath {
   }
 
   /** A source of untrusted data, considered as a taint source for path traversal. */
-  class UntrustedFlowAsSource extends Source {
-    UntrustedFlowAsSource() { this instanceof UntrustedFlowSource }
-  }
+  class UntrustedFlowAsSource extends Source instanceof UntrustedFlowSource { }
 
   /** A path expression, considered as a taint sink for path traversal. */
   class PathAsSink extends Sink {

--- a/go/ql/lib/semmle/go/security/XPathInjectionCustomizations.qll
+++ b/go/ql/lib/semmle/go/security/XPathInjectionCustomizations.qll
@@ -32,12 +32,8 @@ module XPathInjection {
   abstract deprecated class SanitizerGuard extends DataFlow::BarrierGuard { }
 
   /** A source of untrusted data, used in an XPath expression. */
-  class UntrustedFlowAsSource extends Source {
-    UntrustedFlowAsSource() { this instanceof UntrustedFlowSource }
-  }
+  class UntrustedFlowAsSource extends Source instanceof UntrustedFlowSource { }
 
   /** An XPath expression string, considered as a taint sink for XPath injection. */
-  class XPathExpressionStringAsSink extends Sink {
-    XPathExpressionStringAsSink() { this instanceof XPath::XPathExpressionString }
-  }
+  class XPathExpressionStringAsSink extends Sink instanceof XPath::XPathExpressionString { }
 }

--- a/go/ql/lib/semmle/go/security/ZipSlipCustomizations.qll
+++ b/go/ql/lib/semmle/go/security/ZipSlipCustomizations.qll
@@ -73,9 +73,8 @@ module ZipSlip {
   }
 
   /** A path-traversal sink, considered as a taint sink for zip slip. */
-  class TaintedPathSinkAsSink extends Sink {
+  class TaintedPathSinkAsSink extends Sink instanceof TaintedPath::Sink {
     TaintedPathSinkAsSink() {
-      this instanceof TaintedPath::Sink and
       // Exclude `os.Symlink`, which is treated specifically in query `go/unsafe-unzip-symlink`.
       not exists(DataFlow::CallNode c | c.getTarget().hasQualifiedName("os", "Symlink") |
         this = c.getAnArgument()
@@ -84,9 +83,7 @@ module ZipSlip {
   }
 
   /** A path-traversal sanitizer, considered as a sanitizer for zip slip. */
-  class TaintedPathSanitizerAsSanitizer extends Sanitizer {
-    TaintedPathSanitizerAsSanitizer() { this instanceof TaintedPath::Sanitizer }
-  }
+  class TaintedPathSanitizerAsSanitizer extends Sanitizer instanceof TaintedPath::Sanitizer { }
 
   pragma[noinline]
   private predicate taintedPathGuardChecks(

--- a/go/ql/src/AlertSuppression.ql
+++ b/go/ql/src/AlertSuppression.ql
@@ -49,9 +49,7 @@ class SuppressionComment extends Locatable {
 /**
  * The scope of an alert suppression comment.
  */
-class SuppressionScope extends @locatable {
-  SuppressionScope() { this instanceof SuppressionComment }
-
+class SuppressionScope extends @locatable instanceof SuppressionComment {
   /** Gets a suppression comment with this scope. */
   SuppressionComment getSuppressionComment() { result = this }
 
@@ -65,7 +63,7 @@ class SuppressionScope extends @locatable {
   predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    this.(SuppressionComment).covers(filepath, startline, startcolumn, endline, endcolumn)
+    super.covers(filepath, startline, startcolumn, endline, endcolumn)
   }
 
   /** Gets a textual representation of this element. */

--- a/go/ql/src/Security/CWE-640/EmailInjectionCustomizations.qll
+++ b/go/ql/src/Security/CWE-640/EmailInjectionCustomizations.qll
@@ -17,14 +17,10 @@ module EmailInjection {
   abstract class Sink extends DataFlow::Node { }
 
   /** A source of untrusted data, considered as a taint source for email injection. */
-  class UntrustedFlowSourceAsSource extends Source {
-    UntrustedFlowSourceAsSource() { this instanceof UntrustedFlowSource }
-  }
+  class UntrustedFlowSourceAsSource extends Source instanceof UntrustedFlowSource { }
 
   /**
    * A data-flow node that becomes part of an email considered as a taint sink for email injection.
    */
-  class MailDataAsSink extends Sink {
-    MailDataAsSink() { this instanceof EmailData }
-  }
+  class MailDataAsSink extends Sink instanceof EmailData { }
 }

--- a/java/ql/lib/semmle/code/java/dataflow/FlowSources.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/FlowSources.qll
@@ -172,9 +172,7 @@ abstract class UserInput extends DataFlow::Node { }
 /**
  * Input that may be controlled by a remote user.
  */
-private class RemoteUserInput extends UserInput {
-  RemoteUserInput() { this instanceof RemoteFlowSource }
-}
+private class RemoteUserInput extends UserInput instanceof RemoteFlowSource { }
 
 /** A node with input that may be controlled by a local user. */
 abstract class LocalUserInput extends UserInput { }

--- a/java/ql/lib/semmle/code/java/deadcode/EntryPoints.qll
+++ b/java/ql/lib/semmle/code/java/deadcode/EntryPoints.qll
@@ -58,9 +58,7 @@ abstract class WhitelistedLiveCallable extends CallableEntryPoint { }
 /**
  * A `public static void main(String[] args)` method.
  */
-class MainMethodEntry extends CallableEntryPoint {
-  MainMethodEntry() { this instanceof MainMethod }
-}
+class MainMethodEntry extends CallableEntryPoint instanceof MainMethod { }
 
 /**
  * A method that overrides a library method -- the result is
@@ -96,9 +94,7 @@ abstract class ReflectivelyConstructedClass extends EntryPoint, Class {
 /**
  * Classes that are deserialized by Jackson are reflectively constructed.
  */
-library class JacksonReflectivelyConstructedClass extends ReflectivelyConstructedClass {
-  JacksonReflectivelyConstructedClass() { this instanceof JacksonDeserializableType }
-
+library class JacksonReflectivelyConstructedClass extends ReflectivelyConstructedClass instanceof JacksonDeserializableType {
   override Callable getALiveCallable() {
     // Constructors may be called by Jackson, if they are a no-arg, they have a suitable annotation,
     // or inherit a suitable annotation through a mixin.
@@ -312,8 +308,7 @@ class FacesAccessibleMethodEntryPoint extends CallableEntryPoint {
  * A Java Server Faces custom component, that is reflectively constructed by the framework when
  * used in a view (JSP or facelet).
  */
-class FacesComponentReflectivelyConstructedClass extends ReflectivelyConstructedClass {
-  FacesComponentReflectivelyConstructedClass() { this instanceof FacesComponent }
+class FacesComponentReflectivelyConstructedClass extends ReflectivelyConstructedClass instanceof FacesComponent {
 }
 
 /**
@@ -400,8 +395,7 @@ class JavaxManagedBeanReflectivelyConstructed extends ReflectivelyConstructedCla
  * Classes marked as Java persistence entities can be reflectively constructed when the data is
  * loaded.
  */
-class PersistentEntityEntryPoint extends ReflectivelyConstructedClass {
-  PersistentEntityEntryPoint() { this instanceof PersistentEntity }
+class PersistentEntityEntryPoint extends ReflectivelyConstructedClass instanceof PersistentEntity {
 }
 
 /**
@@ -465,6 +459,5 @@ class ArbitraryXmlEntryPoint extends ReflectivelyConstructedClass {
 deprecated class ArbitraryXMLEntryPoint = ArbitraryXmlEntryPoint;
 
 /** A Selenium PageObject, created by a call to PageFactory.initElements(..). */
-class SeleniumPageObjectEntryPoint extends ReflectivelyConstructedClass {
-  SeleniumPageObjectEntryPoint() { this instanceof SeleniumPageObject }
+class SeleniumPageObjectEntryPoint extends ReflectivelyConstructedClass instanceof SeleniumPageObject {
 }

--- a/java/ql/lib/semmle/code/java/deadcode/SpringEntryPoints.qll
+++ b/java/ql/lib/semmle/code/java/deadcode/SpringEntryPoints.qll
@@ -50,9 +50,7 @@ class SpringBeanAnnotatedMethod extends CallableEntryPoint {
 /**
  * A live entry point within a Spring controller.
  */
-class SpringControllerEntryPoint extends CallableEntryPoint {
-  SpringControllerEntryPoint() { this instanceof SpringControllerMethod }
-}
+class SpringControllerEntryPoint extends CallableEntryPoint instanceof SpringControllerMethod { }
 
 /**
  * A method that is accessible in a response, because it is part of the returned model,

--- a/java/ql/lib/semmle/code/java/deadcode/StrutsEntryPoints.qll
+++ b/java/ql/lib/semmle/code/java/deadcode/StrutsEntryPoints.qll
@@ -33,23 +33,18 @@ class Struts1ActionEntryPoint extends EntryPoint, Class {
 /**
  * A struts 2 action class that is reflectively constructed.
  */
-class Struts2ReflectivelyConstructedAction extends ReflectivelyConstructedClass {
-  Struts2ReflectivelyConstructedAction() { this instanceof Struts2ActionClass }
+class Struts2ReflectivelyConstructedAction extends ReflectivelyConstructedClass instanceof Struts2ActionClass {
 }
 
 /**
  * A method called on a struts 2 action class when the action is activated.
  */
-class Struts2ActionMethodEntryPoint extends CallableEntryPoint {
-  Struts2ActionMethodEntryPoint() { this instanceof Struts2ActionMethod }
-}
+class Struts2ActionMethodEntryPoint extends CallableEntryPoint instanceof Struts2ActionMethod { }
 
 /**
  * A method called on a struts 2 action class before an action is activated.
  */
-class Struts2PrepareMethodEntryPoint extends CallableEntryPoint {
-  Struts2PrepareMethodEntryPoint() { this instanceof Struts2PrepareMethod }
-}
+class Struts2PrepareMethodEntryPoint extends CallableEntryPoint instanceof Struts2PrepareMethod { }
 
 /**
  * A class which is accessible - directly or indirectly - from a struts action.

--- a/java/ql/lib/semmle/code/java/deadcode/TestEntryPoints.qll
+++ b/java/ql/lib/semmle/code/java/deadcode/TestEntryPoints.qll
@@ -78,13 +78,10 @@ class JUnitCategory extends WhitelistedLiveClass {
 /**
  * A listener that will be reflectively constructed by TestNG.
  */
-class TestNGReflectivelyConstructedListener extends ReflectivelyConstructedClass {
-  TestNGReflectivelyConstructedListener() {
-    // Consider any class that implements a TestNG listener interface to be live. Listeners can be
-    // specified on the command line, in `testng.xml` files and in Ant build files, so it is safest
-    // to assume that all such listeners are live.
-    this instanceof TestNGListenerImpl
-  }
+class TestNGReflectivelyConstructedListener extends ReflectivelyConstructedClass instanceof TestNGListenerImpl {
+  // Consider any class that implements a TestNG listener interface to be live. Listeners can be
+  // specified on the command line, in `testng.xml` files and in Ant build files, so it is safest
+  // to assume that all such listeners are live.
 }
 
 /**
@@ -99,9 +96,7 @@ class TestNGDataProvidersEntryPoint extends CallableEntryPoint {
 /**
  * A `@Factory` TestNG method or constructor which is live.
  */
-class TestNGFactoryEntryPoint extends CallableEntryPoint {
-  TestNGFactoryEntryPoint() { this instanceof TestNGFactoryCallable }
-}
+class TestNGFactoryEntryPoint extends CallableEntryPoint instanceof TestNGFactoryCallable { }
 
 class TestRefectivelyConstructedClass extends ReflectivelyConstructedClass {
   TestRefectivelyConstructedClass() {
@@ -159,6 +154,5 @@ class CucumberConstructedClass extends ReflectivelyConstructedClass {
 /**
  * A "step definition" that may be called by Cucumber when executing an acceptance test.
  */
-class CucumberStepDefinitionEntryPoint extends CallableEntryPoint {
-  CucumberStepDefinitionEntryPoint() { this instanceof CucumberStepDefinition }
+class CucumberStepDefinitionEntryPoint extends CallableEntryPoint instanceof CucumberStepDefinition {
 }

--- a/java/ql/lib/semmle/code/java/deadcode/WebEntryPoints.qll
+++ b/java/ql/lib/semmle/code/java/deadcode/WebEntryPoints.qll
@@ -7,17 +7,12 @@ import semmle.code.java.frameworks.Servlets
  * Any class which extends the `Servlet` interface is intended to be constructed reflectively by a
  * servlet container.
  */
-class ServletConstructedClass extends ReflectivelyConstructedClass {
+class ServletConstructedClass extends ReflectivelyConstructedClass instanceof ServletClass {
   ServletConstructedClass() {
-    this instanceof ServletClass and
     // If we have seen any `web.xml` files, this servlet will be considered to be live only if it is
     // referred to as a servlet-class in at least one. If no `web.xml` files are found, we assume
     // that XML extraction was not enabled, and therefore consider all `Servlet` classes as live.
-    (
-      isWebXmlIncluded()
-      implies
-      exists(WebServletClass servletClass | this = servletClass.getClass())
-    )
+    isWebXmlIncluded() implies exists(WebServletClass servletClass | this = servletClass.getClass())
   }
 }
 
@@ -112,6 +107,4 @@ class GwtUiBinderEntryPoint extends CallableEntryPoint {
 /**
  * Fields that may be reflectively read or written to by the UiBinder framework.
  */
-class GwtUiBinderReflectivelyReadField extends ReflectivelyReadField {
-  GwtUiBinderReflectivelyReadField() { this instanceof GwtUiField }
-}
+class GwtUiBinderReflectivelyReadField extends ReflectivelyReadField instanceof GwtUiField { }

--- a/java/ql/lib/semmle/code/java/frameworks/javaee/ejb/EJBRestrictions.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/javaee/ejb/EJBRestrictions.qll
@@ -75,14 +75,11 @@ class ForbiddenSecurityConfigurationCallable extends ForbiddenCallable {
 }
 
 /** A method or constructor involving serialization that may not be called by an EJB. */
-class ForbiddenSerializationCallable extends ForbiddenCallable {
-  ForbiddenSerializationCallable() { this instanceof ForbiddenSerializationMethod }
+class ForbiddenSerializationCallable extends ForbiddenCallable instanceof ForbiddenSerializationMethod {
 }
 
 /** A method or constructor involving network factory operations that may not be called by an EJB. */
-class ForbiddenSetFactoryCallable extends ForbiddenCallable {
-  ForbiddenSetFactoryCallable() { this instanceof ForbiddenSetFactoryMethod }
-}
+class ForbiddenSetFactoryCallable extends ForbiddenCallable instanceof ForbiddenSetFactoryMethod { }
 
 /** A method or constructor involving server socket operations that may not be called by an EJB. */
 class ForbiddenServerSocketCallable extends ForbiddenCallable {

--- a/java/ql/lib/semmle/code/java/frameworks/spring/SpringProfile.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/spring/SpringProfile.qll
@@ -73,9 +73,8 @@ abstract class AlwaysEnabledSpringProfile extends string {
  *
  * Includes all `SpringProfile`s that are not specified as always enabled or never enabled.
  */
-class SometimesEnabledSpringProfile extends string {
+class SometimesEnabledSpringProfile extends string instanceof SpringProfile {
   SometimesEnabledSpringProfile() {
-    this instanceof SpringProfile and
     not (
       this instanceof AlwaysEnabledSpringProfile or
       this instanceof NeverEnabledSpringProfile

--- a/java/ql/lib/semmle/code/java/security/Encryption.qll
+++ b/java/ql/lib/semmle/code/java/security/Encryption.qll
@@ -290,9 +290,7 @@ string getSecureAlgorithmRegex() {
  * algorithm. For example, methods returning ciphers, decryption methods,
  * constructors of cipher classes, etc.
  */
-abstract class CryptoAlgoSpec extends Top {
-  CryptoAlgoSpec() { this instanceof Call }
-
+abstract class CryptoAlgoSpec extends Top instanceof Call {
   abstract Expr getAlgoSpec();
 }
 

--- a/java/ql/lib/semmle/code/java/security/ResponseSplitting.qll
+++ b/java/ql/lib/semmle/code/java/security/ResponseSplitting.qll
@@ -15,9 +15,7 @@ private class DefaultHeaderSplittingSink extends HeaderSplittingSink {
 }
 
 /** A source that introduces data considered safe to use by a header splitting source. */
-abstract class SafeHeaderSplittingSource extends DataFlow::Node {
-  SafeHeaderSplittingSource() { this instanceof RemoteFlowSource }
-}
+abstract class SafeHeaderSplittingSource extends DataFlow::Node instanceof RemoteFlowSource { }
 
 /** A default source that introduces data considered safe to use by a header splitting source. */
 private class DefaultSafeHeaderSplittingSource extends SafeHeaderSplittingSource {

--- a/java/ql/src/AlertSuppression.ql
+++ b/java/ql/src/AlertSuppression.ql
@@ -53,9 +53,7 @@ class SuppressionComment extends Javadoc {
 /**
  * The scope of an alert suppression comment.
  */
-class SuppressionScope extends @javadoc {
-  SuppressionScope() { this instanceof SuppressionComment }
-
+class SuppressionScope extends @javadoc instanceof SuppressionComment {
   /** Gets a suppression comment with this scope. */
   SuppressionComment getSuppressionComment() { result = this }
 
@@ -69,7 +67,7 @@ class SuppressionScope extends @javadoc {
   predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    this.(SuppressionComment).covers(filepath, startline, startcolumn, endline, endcolumn)
+    super.covers(filepath, startline, startcolumn, endline, endcolumn)
   }
 
   /** Gets a textual representation of this element. */

--- a/java/ql/src/AlertSuppressionAnnotations.ql
+++ b/java/ql/src/AlertSuppressionAnnotations.ql
@@ -69,9 +69,7 @@ class SuppressionAnnotation extends SuppressWarningsAnnotation {
 /**
  * The scope of an alert suppression annotation.
  */
-class SuppressionScope extends @annotation {
-  SuppressionScope() { this instanceof SuppressionAnnotation }
-
+class SuppressionScope extends @annotation instanceof SuppressionAnnotation {
   /** Gets a suppression annotation with this scope. */
   SuppressionAnnotation getSuppressionAnnotation() { result = this }
 
@@ -85,7 +83,7 @@ class SuppressionScope extends @annotation {
   predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    this.(SuppressionAnnotation).covers(filepath, startline, startcolumn, endline, endcolumn)
+    super.covers(filepath, startline, startcolumn, endline, endcolumn)
   }
 
   /** Gets a textual representation of this element. */

--- a/java/ql/src/Security/CWE/CWE-190/ComparisonWithWiderType.ql
+++ b/java/ql/src/Security/CWE/CWE-190/ComparisonWithWiderType.ql
@@ -20,9 +20,7 @@ int leftWidth(ComparisonExpr e) { result = e.getLeftOperand().getType().(NumType
 
 int rightWidth(ComparisonExpr e) { result = e.getRightOperand().getType().(NumType).getWidthRank() }
 
-abstract class WideningComparison extends BinaryExpr {
-  WideningComparison() { this instanceof ComparisonExpr }
-
+abstract class WideningComparison extends BinaryExpr instanceof ComparisonExpr {
   abstract Expr getNarrower();
 
   abstract Expr getWider();

--- a/java/ql/src/experimental/Security/CWE/CWE-348/ClientSuppliedIpUsedInSecurityCheckLib.qll
+++ b/java/ql/src/experimental/Security/CWE/CWE-348/ClientSuppliedIpUsedInSecurityCheckLib.qll
@@ -81,8 +81,7 @@ private class CompareSink extends ClientSuppliedIpUsedInSecurityCheckSink {
 }
 
 /** A data flow sink for sql operation. */
-private class SqlOperationSink extends ClientSuppliedIpUsedInSecurityCheckSink {
-  SqlOperationSink() { this instanceof QueryInjectionSink }
+private class SqlOperationSink extends ClientSuppliedIpUsedInSecurityCheckSink instanceof QueryInjectionSink {
 }
 
 /** A method that split string. */

--- a/java/ql/src/utils/stub-generator/Stubs.qll
+++ b/java/ql/src/utils/stub-generator/Stubs.qll
@@ -499,11 +499,8 @@ private RefType getAReferencedType(RefType t) {
 }
 
 /** A top level type whose file should be stubbed */
-class GeneratedTopLevel extends TopLevelType {
-  GeneratedTopLevel() {
-    this = this.getSourceDeclaration() and
-    this instanceof GeneratedType
-  }
+class GeneratedTopLevel extends TopLevelType instanceof GeneratedType {
+  GeneratedTopLevel() { this = this.getSourceDeclaration() }
 
   private TopLevelType getAnImportedType() {
     result = getAReferencedType(this).getSourceDeclaration()
@@ -536,8 +533,6 @@ class GeneratedTopLevel extends TopLevelType {
 
   /** Creates a full stub for the file containing this type. */
   string stubFile() {
-    result =
-      this.stubComment() + this.stubPackage() + this.stubImports() + this.(GeneratedType).getStub() +
-        "\n"
+    result = this.stubComment() + this.stubPackage() + this.stubImports() + super.getStub() + "\n"
   }
 }

--- a/java/ql/test/library-tests/dataflow/taintsources/local.ql
+++ b/java/ql/test/library-tests/dataflow/taintsources/local.ql
@@ -2,11 +2,8 @@ import java
 import semmle.code.java.dataflow.FlowSources
 import TestUtilities.InlineExpectationsTest
 
-class LocalSource extends DataFlow::Node {
-  LocalSource() {
-    this instanceof UserInput and
-    not this instanceof RemoteFlowSource
-  }
+class LocalSource extends DataFlow::Node instanceof UserInput {
+  LocalSource() { not this instanceof RemoteFlowSource }
 }
 
 predicate isTestSink(DataFlow::Node n) {


### PR DESCRIPTION
Uses `instanceof` clauses in more classes as preparation for enabling a QL-for-QL query that suggests using `instanceof`. 

Some of this was written automatically, some was written manually.  