### PR TITLE
C++: Flow through uncertain writes

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -718,7 +718,7 @@ class UninitializedNode extends Node {
   UninitializedNode() {
     exists(Ssa::Def def |
       def.getValue().asInstruction() instanceof UninitializedInstruction and
-      Ssa::nodeToDefOrUse(this, def) and
+      Ssa::nodeToDefOrUse(this, def, _) and
       v = def.getSourceVariable().getBaseVariable().(Ssa::BaseIRVariable).getIRVariable().getAst()
     )
   }

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
@@ -291,10 +291,13 @@ predicate outNodeHasAddressAndIndex(
   out.getIndirectionIndex() = indirectionIndex
 }
 
-private predicate defToNode(Node nodeFrom, Def def) {
-  nodeHasOperand(nodeFrom, def.getValue().asOperand(), def.getIndirectionIndex())
-  or
-  nodeHasInstruction(nodeFrom, def.getValue().asInstruction(), def.getIndirectionIndex())
+private predicate defToNode(Node nodeFrom, Def def, boolean uncertain) {
+  (
+    nodeHasOperand(nodeFrom, def.getValue().asOperand(), def.getIndirectionIndex())
+    or
+    nodeHasInstruction(nodeFrom, def.getValue().asInstruction(), def.getIndirectionIndex())
+  ) and
+  if def.isCertain() then uncertain = false else uncertain = true
 }
 
 /**
@@ -302,12 +305,13 @@ private predicate defToNode(Node nodeFrom, Def def) {
  *
  * Holds if `nodeFrom` is the node that correspond to the definition or use `defOrUse`.
  */
-predicate nodeToDefOrUse(Node nodeFrom, SsaDefOrUse defOrUse) {
+predicate nodeToDefOrUse(Node nodeFrom, SsaDefOrUse defOrUse, boolean uncertain) {
   // Node -> Def
-  defToNode(nodeFrom, defOrUse)
+  defToNode(nodeFrom, defOrUse, uncertain)
   or
   // Node -> Use
-  useToNode(defOrUse, nodeFrom)
+  useToNode(defOrUse, nodeFrom) and
+  uncertain = false
 }
 
 /**
@@ -316,7 +320,7 @@ predicate nodeToDefOrUse(Node nodeFrom, SsaDefOrUse defOrUse) {
  */
 private predicate indirectConversionFlowStep(Node nFrom, Node nTo) {
   not exists(UseOrPhi defOrUse |
-    nodeToDefOrUse(nTo, defOrUse) and
+    nodeToDefOrUse(nTo, defOrUse, _) and
     adjacentDefRead(defOrUse, _)
   ) and
   exists(Operand op1, Operand op2, int indirectionIndex, Instruction instr |
@@ -342,28 +346,57 @@ private predicate indirectConversionFlowStep(Node nFrom, Node nTo) {
  * So this predicate recurses back along conversions and `PointerArithmeticInstruction`s to find the
  * first use that has provides use-use flow, and uses that target as the target of the `nodeFrom`.
  */
-private predicate adjustForPointerArith(Node nodeFrom, UseOrPhi use) {
+private predicate adjustForPointerArith(Node nodeFrom, UseOrPhi use, boolean uncertain) {
   nodeFrom = any(PostUpdateNode pun).getPreUpdateNode() and
   exists(DefOrUse defOrUse, Node adjusted |
     indirectConversionFlowStep*(adjusted, nodeFrom) and
-    nodeToDefOrUse(adjusted, defOrUse) and
+    nodeToDefOrUse(adjusted, defOrUse, uncertain) and
     adjacentDefRead(defOrUse, use)
   )
 }
 
-/** Holds if there is def-use or use-use flow from `nodeFrom` to `nodeTo`. */
-predicate ssaFlow(Node nodeFrom, Node nodeTo) {
+private predicate ssaFlowImpl(Node nodeFrom, Node nodeTo, boolean uncertain) {
   // `nodeFrom = any(PostUpdateNode pun).getPreUpdateNode()` is implied by adjustedForPointerArith.
   exists(UseOrPhi use |
-    adjustForPointerArith(nodeFrom, use) and
+    adjustForPointerArith(nodeFrom, use, uncertain) and
     useToNode(use, nodeTo)
   )
   or
   not nodeFrom = any(PostUpdateNode pun).getPreUpdateNode() and
   exists(DefOrUse defOrUse1, UseOrPhi use |
-    nodeToDefOrUse(nodeFrom, defOrUse1) and
+    nodeToDefOrUse(nodeFrom, defOrUse1, uncertain) and
     adjacentDefRead(defOrUse1, use) and
     useToNode(use, nodeTo)
+  )
+}
+
+/**
+ * Holds if `def` is the corresponding definition of
+ * the SSA library's `definition`.
+ */
+private predicate ssaDefinition(Def def, Definition definition) {
+  exists(IRBlock block, int i, SourceVariable sv |
+    def.hasIndexInBlock(block, i, sv) and
+    definition.definesAt(sv, block, i)
+  )
+}
+
+/** Gets a node that represents the prior definition of `node`. */
+private Node getAPriorDefinition(Node node) {
+  exists(Def def, Definition definition, Definition inp, Def input |
+    defToNode(node, def, true) and
+    ssaDefinition(def, definition) and
+    uncertainWriteDefinitionInput(pragma[only_bind_into](definition), pragma[only_bind_into](inp)) and
+    ssaDefinition(input, inp) and
+    defToNode(result, input, _)
+  )
+}
+
+/** Holds if there is def-use or use-use flow from `nodeFrom` to `nodeTo`. */
+predicate ssaFlow(Node nodeFrom, Node nodeTo) {
+  exists(Node nFrom, boolean uncertain |
+    ssaFlowImpl(nFrom, nodeTo, uncertain) and
+    if uncertain = true then nodeFrom = [nFrom, getAPriorDefinition(nFrom)] else nodeFrom = nFrom
   )
 }
 
@@ -460,6 +493,11 @@ module SsaCached {
   predicate lastRefRedef(Definition def, IRBlock bb, int i, Definition next) {
     SsaImpl::lastRefRedef(def, bb, i, next)
   }
+
+  cached
+  predicate uncertainWriteDefinitionInput(SsaImpl::UncertainWriteDefinition def, Definition inp) {
+    SsaImpl::uncertainWriteDefinitionInput(def, inp)
+  }
 }
 
 cached
@@ -498,6 +536,10 @@ class DefOrUse extends TDefOrUse, SsaDefOrUse {
   final SourceVariable getSourceVariable() { result = defOrUse.getSourceVariable() }
 
   override string toString() { result = defOrUse.toString() }
+
+  predicate hasIndexInBlock(IRBlock block, int index, SourceVariable sv) {
+    defOrUse.hasIndexInBlock(block, index, sv)
+  }
 }
 
 class Phi extends TPhi, SsaDefOrUse {
@@ -541,6 +583,8 @@ class Def extends DefOrUse {
   }
 
   Node0Impl getValue() { result = defOrUse.getValue() }
+
+  predicate isCertain() { defOrUse.isCertain() }
 }
 
 private module SsaImpl = SsaImplCommon::Make<SsaInput>;
@@ -548,5 +592,7 @@ private module SsaImpl = SsaImplCommon::Make<SsaInput>;
 class PhiNode = SsaImpl::PhiNode;
 
 class Definition = SsaImpl::Definition;
+
+class UncertainWriteDefinition = SsaImpl::UncertainWriteDefinition;
 
 import SsaCached

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/ssa0/SsaInternals.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/ssa0/SsaInternals.qll
@@ -32,7 +32,7 @@ private newtype TDefOrUseImpl =
   TDefImpl(Operand address) { isDef(_, _, address, _, _, _) } or
   TUseImpl(Operand operand) {
     isUse(_, operand, _, _, _) and
-    not isDef(_, _, operand, _, _, _)
+    not isDef(true, _, operand, _, _, _)
   }
 
 abstract private class DefOrUseImpl extends TDefOrUseImpl {

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/clang.cpp
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/clang.cpp
@@ -48,5 +48,5 @@ void following_pointers(
 
   int stackArray[2] = { source(), source() };
   stackArray[0] = source();
-  sink(stackArray); // $ ast,ir
+  sink(stackArray); // $ ast ir ir=49:35 ir=50:19
 }

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/dataflow-consistency.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/dataflow-consistency.expected
@@ -92,6 +92,10 @@ postWithInFlow
 | test.cpp:506:3:506:4 | * ... [post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:506:4:506:4 | p [inner post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:512:35:512:35 | x [inner post update] | PostUpdateNode should not be the target of local flow. |
+| test.cpp:519:3:519:12 | stackArray [inner post update] | PostUpdateNode should not be the target of local flow. |
+| test.cpp:519:3:519:15 | access to array [post update] | PostUpdateNode should not be the target of local flow. |
+| test.cpp:520:3:520:12 | stackArray [inner post update] | PostUpdateNode should not be the target of local flow. |
+| test.cpp:520:3:520:15 | access to array [post update] | PostUpdateNode should not be the target of local flow. |
 viableImplInCallContextTooLarge
 uniqueParameterNodeAtPosition
 uniqueParameterNodePosition

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
@@ -512,3 +512,11 @@ void viaOutparamMissingReturn() {
   intOutparamSourceMissingReturn(&x);
   sink(x); // $ ast MISSING: ir
 }
+
+void uncertain_definition() {
+  int stackArray[2];
+  int clean = 0;
+  stackArray[0] = source();
+  stackArray[1] = clean;
+  sink(stackArray[0]); // $ ast=519:19 SPURIOUS: ast=517:7 MISSING: ir
+}

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
@@ -518,5 +518,5 @@ void uncertain_definition() {
   int clean = 0;
   stackArray[0] = source();
   stackArray[1] = clean;
-  sink(stackArray[0]); // $ ast=519:19 SPURIOUS: ast=517:7 MISSING: ir
+  sink(stackArray[0]); // $ ast=519:19 ir SPURIOUS: ast=517:7
 }

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/uninitialized.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/uninitialized.expected
@@ -34,3 +34,6 @@
 | test.cpp:448:7:448:11 | local | test.cpp:449:18:449:22 | local |
 | test.cpp:448:7:448:11 | local | test.cpp:450:8:450:12 | local |
 | test.cpp:448:7:448:11 | local | test.cpp:451:9:451:13 | local |
+| test.cpp:517:7:517:16 | stackArray | test.cpp:519:3:519:12 | stackArray |
+| test.cpp:517:7:517:16 | stackArray | test.cpp:520:3:520:12 | stackArray |
+| test.cpp:517:7:517:16 | stackArray | test.cpp:521:8:521:17 | stackArray |

--- a/cpp/ql/test/library-tests/dataflow/source-sink-tests/sources-and-sinks.cpp
+++ b/cpp/ql/test/library-tests/dataflow/source-sink-tests/sources-and-sinks.cpp
@@ -3,9 +3,9 @@ char *secure_getenv(const char *name);
 wchar_t *_wgetenv(const wchar_t *name);
 
 void test_getenv() {
-    void *var1 = getenv("VAR"); // $ local_source
-    void *var2 = secure_getenv("VAR"); // $ local_source
-    void *var3 = _wgetenv(L"VAR"); // $ local_source
+    void *var1 = getenv("VAR"); // $ local_source=6:18 local_source=6:18
+    void *var2 = secure_getenv("VAR"); // $ local_source=7:18 local_source=7:18
+    void *var3 = _wgetenv(L"VAR"); // $ local_source=8:18 local_source=8:18
 }
 
 int send(int, const void*, int, int);


### PR DESCRIPTION
Previously, we weren't getting flow in the following example on the use-use feature branch:
```cpp
char xs[2];
xs[0] = source();
xs[1] = 0;
sink(xs[0]);
```
because the assignment to `xs[1]` was seen as overwriting the contents of `xs`, and thus the assignment `xs[0] = source();` was dead according to SSA.

This PR fixes this by recognizing that some writes are "uncertain" (i.e., we don't know if they completely overwrite a piece of memory), and ensures that we have flow from uncertain definition's prior definition to the variable being defined.

I was actually planning on putting up this PR _after_ https://github.com/github/codeql/pull/11626 had been merged, but seeing as there are some performance issues with that PR I might as well put this on up now (as this PR is largely unrelated to iterators).