### PR TITLE
Py/JS/RB: Use instanceof in more places

### DIFF
--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/TaintedPathATM.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/TaintedPathATM.qll
@@ -51,9 +51,7 @@ class TaintedPathAtmConfig extends AtmConfig {
  * of barrier guards, we port the barrier guards for the boosted query from the standard library to
  * sanitizer guards here.
  */
-private class BarrierGuardNodeAsSanitizerGuardNode extends TaintTracking::LabeledSanitizerGuardNode {
-  BarrierGuardNodeAsSanitizerGuardNode() { this instanceof TaintedPath::BarrierGuardNode }
-
+private class BarrierGuardNodeAsSanitizerGuardNode extends TaintTracking::LabeledSanitizerGuardNode instanceof TaintedPath::BarrierGuardNode {
   override predicate sanitizes(boolean outcome, Expr e) {
     blocks(outcome, e) or blocks(outcome, e, _)
   }

--- a/javascript/ql/lib/semmle/javascript/Closure.qll
+++ b/javascript/ql/lib/semmle/javascript/Closure.qll
@@ -75,8 +75,7 @@ module Closure {
   /**
    * A top-level call to `goog.provide`.
    */
-  class ClosureProvideCall extends ClosureNamespaceRef, DataFlow::MethodCallNode {
-    ClosureProvideCall() { this instanceof DefaultClosureProvideCall }
+  class ClosureProvideCall extends ClosureNamespaceRef, DataFlow::MethodCallNode instanceof DefaultClosureProvideCall {
   }
 
   /**
@@ -89,8 +88,7 @@ module Closure {
   /**
    * A call to `goog.require`.
    */
-  class ClosureRequireCall extends ClosureNamespaceAccess, DataFlow::MethodCallNode {
-    ClosureRequireCall() { this instanceof DefaultClosureRequireCall }
+  class ClosureRequireCall extends ClosureNamespaceAccess, DataFlow::MethodCallNode instanceof DefaultClosureRequireCall {
   }
 
   /**
@@ -106,8 +104,7 @@ module Closure {
   /**
    * A top-level call to `goog.module` or `goog.declareModuleId`.
    */
-  class ClosureModuleDeclaration extends ClosureNamespaceRef, DataFlow::MethodCallNode {
-    ClosureModuleDeclaration() { this instanceof DefaultClosureModuleDeclaration }
+  class ClosureModuleDeclaration extends ClosureNamespaceRef, DataFlow::MethodCallNode instanceof DefaultClosureModuleDeclaration {
   }
 
   private GlobalVariable googVariable() { variables(result, "goog", any(GlobalScope sc)) }

--- a/javascript/ql/lib/semmle/javascript/DOM.qll
+++ b/javascript/ql/lib/semmle/javascript/DOM.qll
@@ -138,16 +138,14 @@ module DOM {
   /**
    * A JSX attribute, viewed as an `AttributeDefinition`.
    */
-  private class JsxAttributeDefinition extends AttributeDefinition, @jsx_attribute {
-    JsxAttribute attr;
+  private class JsxAttributeDefinition extends AttributeDefinition, @jsx_attribute instanceof JsxAttribute {
+    override string getName() { result = JsxAttribute.super.getName() }
 
-    JsxAttributeDefinition() { this = attr }
+    override DataFlow::Node getValueNode() {
+      result = DataFlow::valueNode(JsxAttribute.super.getValue())
+    }
 
-    override string getName() { result = attr.getName() }
-
-    override DataFlow::Node getValueNode() { result = DataFlow::valueNode(attr.getValue()) }
-
-    override ElementDefinition getElement() { result = attr.getElement() }
+    override ElementDefinition getElement() { result = JsxAttribute.super.getElement() }
   }
 
   /**

--- a/javascript/ql/lib/semmle/javascript/DefUse.qll
+++ b/javascript/ql/lib/semmle/javascript/DefUse.qll
@@ -222,9 +222,7 @@ class VarDef extends ControlFlowNode {
  *
  * Some variable definitions are also uses, notably the operands of update expressions.
  */
-class VarUse extends ControlFlowNode, @varref {
-  VarUse() { this instanceof RValue }
-
+class VarUse extends ControlFlowNode, @varref instanceof RValue {
   /** Gets the variable this use refers to. */
   Variable getVariable() { result = this.(VarRef).getVariable() }
 

--- a/javascript/ql/lib/semmle/javascript/DefensiveProgramming.qll
+++ b/javascript/ql/lib/semmle/javascript/DefensiveProgramming.qll
@@ -384,16 +384,11 @@ module DefensiveExpressionTest {
    *
    * Example: `typeof x === "undefined"'.
    */
-  class TypeofUndefinedTest extends UndefinedNullTest {
-    TypeofTest test;
+  class TypeofUndefinedTest extends UndefinedNullTest instanceof TypeofTest {
+    TypeofUndefinedTest() { super.getTag() = "undefined" }
 
-    TypeofUndefinedTest() {
-      this = test and
-      test.getTag() = "undefined"
-    }
+    override boolean getTheTestResult() { result = TypeofTest.super.getTheTestResult() }
 
-    override boolean getTheTestResult() { result = test.getTheTestResult() }
-
-    override Expr getOperand() { result = test.getOperand() }
+    override Expr getOperand() { result = TypeofTest.super.getOperand() }
   }
 }

--- a/javascript/ql/lib/semmle/javascript/GeneratedCode.qll
+++ b/javascript/ql/lib/semmle/javascript/GeneratedCode.qll
@@ -16,8 +16,7 @@ abstract class GeneratedCodeMarkerComment extends Comment { }
 /**
  * A source mapping comment, viewed as a marker comment indicating generated code.
  */
-private class SourceMappingCommentMarkerComment extends GeneratedCodeMarkerComment {
-  SourceMappingCommentMarkerComment() { this instanceof SourceMappingComment }
+private class SourceMappingCommentMarkerComment extends GeneratedCodeMarkerComment instanceof SourceMappingComment {
 }
 
 /**

--- a/javascript/ql/lib/semmle/javascript/Routing.qll
+++ b/javascript/ql/lib/semmle/javascript/Routing.qll
@@ -508,9 +508,7 @@ module Routing {
     /**
      * An array which has been determined to be a route node, seen as a route node with arguments.
      */
-    private class ImpliedArrayRoute extends ValueNode::WithArguments, DataFlow::ArrayCreationNode {
-      ImpliedArrayRoute() { this instanceof ValueNode::UseSite }
-
+    private class ImpliedArrayRoute extends ValueNode::WithArguments, DataFlow::ArrayCreationNode instanceof ValueNode::UseSite {
       override DataFlow::Node getArgumentNode(int n) { result = this.getElement(n) }
     }
   }

--- a/javascript/ql/lib/semmle/javascript/dataflow/Nodes.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/Nodes.qll
@@ -298,9 +298,7 @@ class MethodCallNode extends CallNode instanceof DataFlow::Impl::MethodCallNodeD
  * new Array(16)
  * ```
  */
-class NewNode extends InvokeNode {
-  NewNode() { this instanceof DataFlow::Impl::NewNodeDef }
-}
+class NewNode extends InvokeNode instanceof DataFlow::Impl::NewNodeDef { }
 
 /**
  * A data flow node corresponding to the `this` parameter in a function or `this` at the top-level.

--- a/javascript/ql/lib/semmle/javascript/dataflow/TypeInference.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/TypeInference.qll
@@ -180,13 +180,9 @@ class AnalyzedValueNode extends AnalyzedNode, DataFlow::ValueNode { }
  * exports are modeled as property writes on `module.exports`, and imports
  * as property reads on any potential value of `module.exports`.
  */
-class AnalyzedModule extends TopLevel {
-  Module m;
-
-  AnalyzedModule() { this = m }
-
+class AnalyzedModule extends TopLevel instanceof Module {
   /** Gets the name of this module. */
-  string getName() { result = m.getName() }
+  string getName() { result = super.getName() }
 
   /**
    * Gets the abstract value representing this module's `module` object.
@@ -216,7 +212,7 @@ class AnalyzedModule extends TopLevel {
     exists(AbstractValue exports | exports = getAnExportsValue() |
       // CommonJS modules export `module.exports` as their `default`
       // export in an ES2015 setting
-      not m instanceof ES2015Module and
+      not this instanceof ES2015Module and
       name = "default" and
       result = exports
       or

--- a/javascript/ql/lib/semmle/javascript/dataflow/internal/PropertyTypeInference.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/internal/PropertyTypeInference.qll
@@ -120,15 +120,13 @@ abstract class AnalyzedPropertyWrite extends DataFlow::Node {
 /**
  * Flow analysis for property writes.
  */
-private class AnalyzedExplicitPropertyWrite extends AnalyzedPropertyWrite {
-  AnalyzedExplicitPropertyWrite() { this instanceof DataFlow::PropWrite }
-
+private class AnalyzedExplicitPropertyWrite extends AnalyzedPropertyWrite instanceof DataFlow::PropWrite {
   override predicate writes(AbstractValue base, string prop, DataFlow::AnalyzedNode source) {
     explicitPropertyWrite(this, base, prop, source)
   }
 
   override predicate baseIsIncomplete(DataFlow::Incompleteness reason) {
-    this.(DataFlow::PropWrite).getBase().isIncomplete(reason)
+    super.getBase().isIncomplete(reason)
   }
 }
 

--- a/javascript/ql/lib/semmle/javascript/dataflow/internal/VariableTypeInference.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/internal/VariableTypeInference.qll
@@ -144,9 +144,7 @@ class AnalyzedVarDef extends VarDef {
 /**
  * Flow analysis for simple parameters of selected functions.
  */
-private class AnalyzedParameterAsVarDef extends AnalyzedVarDef, @var_decl {
-  AnalyzedParameterAsVarDef() { this instanceof Parameter }
-
+private class AnalyzedParameterAsVarDef extends AnalyzedVarDef, @var_decl instanceof Parameter {
   override AbstractValue getAnRhsValue() {
     result = DataFlow::valueNode(this).(AnalyzedValueNode).getALocalValue()
   }
@@ -692,25 +690,20 @@ abstract private class CallWithAnalyzedParameters extends FunctionWithAnalyzedPa
 /**
  * Flow analysis for simple parameters of IIFEs.
  */
-private class IifeWithAnalyzedParameters extends CallWithAnalyzedParameters {
-  ImmediatelyInvokedFunctionExpr iife;
+private class IifeWithAnalyzedParameters extends CallWithAnalyzedParameters instanceof ImmediatelyInvokedFunctionExpr {
+  IifeWithAnalyzedParameters() { super.getInvocationKind() = "direct" }
 
-  IifeWithAnalyzedParameters() {
-    this = iife and
-    iife.getInvocationKind() = "direct"
-  }
-
-  override DataFlow::InvokeNode getAnInvocation() { result = iife.getInvocation().flow() }
+  override DataFlow::InvokeNode getAnInvocation() { result = super.getInvocation().flow() }
 
   override predicate isIncomplete(DataFlow::Incompleteness cause) {
     // if the IIFE has a name and that name is referenced, we conservatively
     // assume that there may be other calls than the direct one
-    exists(iife.getVariable().getAnAccess()) and cause = "call"
+    exists(ImmediatelyInvokedFunctionExpr.super.getVariable().getAnAccess()) and cause = "call"
     or
     // if the IIFE is non-strict and its `arguments` object is accessed, we
     // also assume that there may be other calls (through `arguments.callee`)
-    not iife.isStrict() and
-    exists(iife.getArgumentsVariable().getAnAccess()) and
+    not ImmediatelyInvokedFunctionExpr.super.isStrict() and
+    exists(ImmediatelyInvokedFunctionExpr.super.getArgumentsVariable().getAnAccess()) and
     cause = "call"
   }
 }
@@ -718,12 +711,8 @@ private class IifeWithAnalyzedParameters extends CallWithAnalyzedParameters {
 /**
  * Enables inter-procedural type inference for `LocalFunction`.
  */
-private class LocalFunctionWithAnalyzedParameters extends CallWithAnalyzedParameters {
-  LocalFunction local;
-
-  LocalFunctionWithAnalyzedParameters() { this = local }
-
-  override DataFlow::InvokeNode getAnInvocation() { result = local.getAnInvocation() }
+private class LocalFunctionWithAnalyzedParameters extends CallWithAnalyzedParameters instanceof LocalFunction {
+  override DataFlow::InvokeNode getAnInvocation() { result = LocalFunction.super.getAnInvocation() }
 
   override predicate isIncomplete(DataFlow::Incompleteness cause) { none() }
 }

--- a/javascript/ql/lib/semmle/javascript/dependencies/Dependencies.qll
+++ b/javascript/ql/lib/semmle/javascript/dependencies/Dependencies.qll
@@ -226,21 +226,17 @@ abstract class ScriptDependency extends Dependency {
 /**
  * An embedded JavaScript library included inside a `<script>` tag.
  */
-class InlineScriptDependency extends ScriptDependency, @toplevel {
-  FrameworkLibraryInstance fli;
-
-  InlineScriptDependency() { this = fli }
-
+class InlineScriptDependency extends ScriptDependency, @toplevel instanceof FrameworkLibraryInstance {
   override predicate info(string id, string v) {
     exists(FrameworkLibrary fl |
-      fli.info(fl, v) and
+      FrameworkLibraryInstance.super.info(fl, v) and
       id = fl.getId()
     )
   }
 
   override Expr getAnApiUse() {
     exists(FrameworkLibrary fl |
-      fli.info(fl, _) and
+      FrameworkLibraryInstance.super.info(fl, _) and
       propAccessOnGlobal(result, fl.getAnEntryPoint()) and
       result.getFile() = this.getFile() and
       result.getTopLevel() != this
@@ -252,21 +248,17 @@ class InlineScriptDependency extends ScriptDependency, @toplevel {
  * An external JavaScript library referenced via the `src` attribute
  * of a `<script>` tag.
  */
-class ExternalScriptDependency extends ScriptDependency, @xmlattribute {
-  FrameworkLibraryReference flr;
-
-  ExternalScriptDependency() { this = flr }
-
+class ExternalScriptDependency extends ScriptDependency, @xmlattribute instanceof FrameworkLibraryReference {
   override predicate info(string id, string v) {
     exists(FrameworkLibrary fl |
-      flr.info(fl, v) and
+      FrameworkLibraryReference.super.info(fl, v) and
       id = fl.getId()
     )
   }
 
   override Expr getAnApiUse() {
     exists(FrameworkLibrary fl |
-      flr.info(fl, _) and
+      FrameworkLibraryReference.super.info(fl, _) and
       propAccessOnGlobal(result, fl.getAnEntryPoint()) and
       result.getFile() = this.getFile()
     )
@@ -276,9 +268,7 @@ class ExternalScriptDependency extends ScriptDependency, @xmlattribute {
 /**
  * A dependency on GWT indicated by a GWT header script.
  */
-private class GwtDependency extends ScriptDependency {
-  GwtDependency() { this instanceof GwtHeader }
-
+private class GwtDependency extends ScriptDependency instanceof GwtHeader {
   override predicate info(string id, string v) {
     id = "gwt" and
     exists(GwtHeader h | h = this |

--- a/javascript/ql/lib/semmle/javascript/frameworks/AngularJS/AngularJSCore.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/AngularJS/AngularJSCore.qll
@@ -468,14 +468,10 @@ abstract class DirectiveTarget extends Locatable {
 /**
  * A DOM element, viewed as directive target.
  */
-private class DomElementAsElement extends DirectiveTarget {
-  DOM::ElementDefinition element;
+private class DomElementAsElement extends DirectiveTarget instanceof DOM::ElementDefinition {
+  override string getName() { result = DOM::ElementDefinition.super.getName() }
 
-  DomElementAsElement() { this = element }
-
-  override string getName() { result = element.getName() }
-
-  override DOM::ElementDefinition getElement() { result = element }
+  override DOM::ElementDefinition getElement() { result = this }
 
   override DirectiveTargetType getType() { result = E() }
 }
@@ -483,18 +479,16 @@ private class DomElementAsElement extends DirectiveTarget {
 /**
  * A DOM attribute, viewed as a directive target.
  */
-private class DomAttributeAsElement extends DirectiveTarget {
-  DOM::AttributeDefinition attr;
+private class DomAttributeAsElement extends DirectiveTarget instanceof DOM::AttributeDefinition {
+  override string getName() { result = DOM::AttributeDefinition.super.getName() }
 
-  DomAttributeAsElement() { this = attr }
-
-  override string getName() { result = attr.getName() }
-
-  override DOM::ElementDefinition getElement() { result = attr.getElement() }
+  override DOM::ElementDefinition getElement() {
+    result = DOM::AttributeDefinition.super.getElement()
+  }
 
   override DirectiveTargetType getType() { result = A() }
 
-  DOM::AttributeDefinition asAttribute() { result = attr }
+  DOM::AttributeDefinition asAttribute() { result = this }
 }
 
 /**
@@ -962,17 +956,13 @@ abstract class Controller extends DataFlow::Node {
 /**
  * A controller instantiated through a directive, e.g. `<div ngController="myController"/>`.
  */
-private class DirectiveController extends Controller {
-  ControllerDefinition def;
-
-  DirectiveController() { this = def }
-
+private class DirectiveController extends Controller instanceof ControllerDefinition {
   private predicate boundAnonymously(DOM::ElementDefinition elem) {
     exists(DirectiveInstance instance, DomAttributeAsElement attr |
       instance.getName() = "ngController" and
       instance.getATarget() = attr and
       elem = attr.getElement() and
-      attr.asAttribute().getStringValue() = def.getName()
+      attr.asAttribute().getStringValue() = super.getName()
     )
   }
 
@@ -989,28 +979,26 @@ private class DirectiveController extends Controller {
         attributeValue = attr.asAttribute().getStringValue() and
         pattern = "([^ ]+) +as +([^ ]+)"
       |
-        attributeValue.regexpCapture(pattern, 1) = def.getName() and
+        attributeValue.regexpCapture(pattern, 1) = ControllerDefinition.super.getName() and
         attributeValue.regexpCapture(pattern, 2) = alias
       )
     )
   }
 
-  override InjectableFunction getFactoryFunction() { result = def.getAFactoryFunction() }
+  override InjectableFunction getFactoryFunction() {
+    result = ControllerDefinition.super.getAFactoryFunction()
+  }
 }
 
 /**
  * A controller instantiated through routes, e.g. `$routeProvider.otherwise({controller: ...})`.
  */
-private class RouteInstantiatedController extends Controller {
-  RouteSetup setup;
-
-  RouteInstantiatedController() { this = setup }
-
-  override InjectableFunction getFactoryFunction() { result = setup.getController() }
+private class RouteInstantiatedController extends Controller instanceof RouteSetup {
+  override InjectableFunction getFactoryFunction() { result = super.getController() }
 
   override predicate boundTo(DOM::ElementDefinition elem) {
     exists(string url, HTML::HtmlFile template |
-      setup.getRouteParam("templateUrl").mayHaveStringValue(url) and
+      super.getRouteParam("templateUrl").mayHaveStringValue(url) and
       template.getAbsolutePath().regexpMatch(".*\\Q" + url + "\\E") and
       elem.getFile() = template
     )
@@ -1018,7 +1006,7 @@ private class RouteInstantiatedController extends Controller {
 
   override predicate boundToAs(DOM::ElementDefinition elem, string name) {
     this.boundTo(elem) and
-    setup.getRouteParam("controllerAs").mayHaveStringValue(name)
+    super.getRouteParam("controllerAs").mayHaveStringValue(name)
   }
 }
 

--- a/javascript/ql/lib/semmle/javascript/frameworks/AngularJS/AngularJSExpressions.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/AngularJS/AngularJSExpressions.qll
@@ -808,23 +808,19 @@ private import Parser
  *
  * Will eventually be a subtype of `DataFlow::Node`.
  */
-class NgDataFlowNode extends TNode {
-  NgAstNode astNode;
-
-  NgDataFlowNode() { this = astNode }
-
+class NgDataFlowNode extends TNode instanceof NgAstNode {
   /** Gets the AST node this node corresponds to. */
-  NgAstNode getAstNode() { result = astNode }
+  NgAstNode getAstNode() { result = this }
 
   /** Gets a textual representation of this element. */
-  string toString() { result = astNode.toString() }
+  string toString() { result = super.toString() }
 
   /**
    * Gets a scope object for this node.
    */
   AngularJS::AngularScope getAScope() {
     exists(NgToken token, NgSource source |
-      astNode.at(token, _) and
+      super.at(token, _) and
       token.at(source, _)
     |
       result.mayApplyTo(source.getProvider().getEnclosingElement())

--- a/javascript/ql/lib/semmle/javascript/frameworks/AngularJS/ServiceDefinitions.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/AngularJS/ServiceDefinitions.qll
@@ -473,27 +473,21 @@ abstract class ServiceRequestNode extends DataFlow::Node {
 /**
  * The request for a scope service in the form of the link-function of a directive.
  */
-private class LinkFunctionWithScopeInjection extends ServiceRequestNode {
-  LinkFunctionWithScopeInjection() { this instanceof LinkFunction }
-
+private class LinkFunctionWithScopeInjection extends ServiceRequestNode instanceof LinkFunction {
   override DataFlow::ParameterNode getDependencyParameter(ServiceReference service) {
     service instanceof ScopeServiceReference and
-    result = this.(LinkFunction).getScopeParameter()
+    result = super.getScopeParameter()
   }
 }
 
 /**
  * A request for a service, in the form of a dependency-injected function.
  */
-class InjectableFunctionServiceRequest extends ServiceRequestNode {
-  InjectableFunction injectedFunction;
-
-  InjectableFunctionServiceRequest() { injectedFunction = this }
-
+class InjectableFunctionServiceRequest extends ServiceRequestNode instanceof InjectableFunction {
   /**
    * Gets the function of this request.
    */
-  InjectableFunction getAnInjectedFunction() { result = injectedFunction }
+  InjectableFunction getAnInjectedFunction() { result = this }
 
   /**
    * Gets a name of a requested service.
@@ -512,7 +506,7 @@ class InjectableFunctionServiceRequest extends ServiceRequestNode {
   }
 
   override DataFlow::ParameterNode getDependencyParameter(ServiceReference service) {
-    service = injectedFunction.getAResolvedDependency(result)
+    service = super.getAResolvedDependency(result)
   }
 }
 
@@ -631,12 +625,8 @@ class ProviderRecipeDefinition extends RecipeDefinition {
   }
 }
 
-private class ProviderRecipeServiceInjection extends DependencyInjection {
-  ProviderRecipeServiceInjection() { this instanceof ProviderRecipeDefinition }
-
-  override DataFlow::Node getAnInjectableFunction() {
-    result = this.(ProviderRecipeDefinition).getAService()
-  }
+private class ProviderRecipeServiceInjection extends DependencyInjection instanceof ProviderRecipeDefinition {
+  override DataFlow::Node getAnInjectableFunction() { result = super.getAService() }
 }
 
 /**

--- a/javascript/ql/lib/semmle/javascript/frameworks/ClientRequests.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/ClientRequests.qll
@@ -762,14 +762,12 @@ module ClientRequest {
   /**
    * A shell execution of `curl` that downloads some file.
    */
-  class CurlDownload extends ClientRequest::Range {
-    SystemCommandExecution cmd;
-
+  class CurlDownload extends ClientRequest::Range instanceof SystemCommandExecution {
     CurlDownload() {
-      this = cmd and
       (
-        cmd.getACommandArgument().getStringValue() = "curl" or
-        cmd.getACommandArgument()
+        super.getACommandArgument().getStringValue() = "curl" or
+        super
+            .getACommandArgument()
             .(StringOps::ConcatenationRoot)
             .getConstantStringParts()
             .matches("curl %")
@@ -777,8 +775,8 @@ module ClientRequest {
     }
 
     override DataFlow::Node getUrl() {
-      result = cmd.getArgumentList().getALocalSource().getAPropertyWrite().getRhs() or
-      result = cmd.getACommandArgument().(StringOps::ConcatenationRoot).getALeaf()
+      result = super.getArgumentList().getALocalSource().getAPropertyWrite().getRhs() or
+      result = super.getACommandArgument().(StringOps::ConcatenationRoot).getALeaf()
     }
 
     override DataFlow::Node getHost() { none() }

--- a/javascript/ql/lib/semmle/javascript/frameworks/Electron.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Electron.qll
@@ -16,16 +16,12 @@ module Electron {
   /**
    * An instantiation of `BrowserWindow` or `BrowserView`.
    */
-  abstract private class NewBrowserObject extends BrowserObject {
-    DataFlow::NewNode self;
-
-    NewBrowserObject() { this = self }
-
+  abstract private class NewBrowserObject extends BrowserObject instanceof DataFlow::NewNode {
     /**
      * Gets the data flow node from which this instantiation takes its `webPreferences` object.
      */
     DataFlow::SourceNode getWebPreferences() {
-      result = self.getOptionArgument(0, "webPreferences").getALocalSource()
+      result = super.getOptionArgument(0, "webPreferences").getALocalSource()
     }
   }
 
@@ -182,8 +178,7 @@ module Electron {
   /**
    * A Node.js-style HTTP or HTTPS request made using an Electron module.
    */
-  class ElectronClientRequest extends NodeJSLib::NodeJSClientRequest {
-    ElectronClientRequest() { this instanceof ElectronClientRequest::Range }
+  class ElectronClientRequest extends NodeJSLib::NodeJSClientRequest instanceof ElectronClientRequest::Range {
   }
 
   module ElectronClientRequest {

--- a/javascript/ql/lib/semmle/javascript/frameworks/Express.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Express.qll
@@ -76,17 +76,11 @@ module Express {
     result = "del"
   }
 
-  private class RouterRange extends Routing::Router::Range {
-    RouterDefinition def;
-
-    RouterRange() { this = def }
-
-    override DataFlow::SourceNode getAReference() { result = def.ref() }
+  private class RouterRange extends Routing::Router::Range instanceof RouterDefinition {
+    override DataFlow::SourceNode getAReference() { result = super.ref() }
   }
 
-  private class RoutingTreeSetup extends Routing::RouteSetup::MethodCall {
-    RoutingTreeSetup() { this instanceof RouteSetup }
-
+  private class RoutingTreeSetup extends Routing::RouteSetup::MethodCall instanceof RouteSetup {
     override string getRelativePath() {
       not this.getMethodName() = "param" and // do not treat parameter name as a path
       result = this.getArgument(0).getStringValue()

--- a/javascript/ql/lib/semmle/javascript/frameworks/ExpressModules.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/ExpressModules.qll
@@ -18,9 +18,7 @@ module ExpressLibraries {
   /**
    * A header produced by a route handler of the "x-frame-options" module.
    */
-  class XFrameOptionsRouteHandlerHeader extends Http::ImplicitHeaderDefinition {
-    XFrameOptionsRouteHandlerHeader() { this instanceof XFrameOptionsRouteHandler }
-
+  class XFrameOptionsRouteHandlerHeader extends Http::ImplicitHeaderDefinition instanceof XFrameOptionsRouteHandler {
     override predicate defines(string headerName, string headerValue) {
       xFrameOptionsDefaultImplicitHeaderDefinition(headerName, headerValue)
     }
@@ -45,9 +43,7 @@ module ExpressLibraries {
   /**
    * A header produced by a route handler of the "frameguard" module.
    */
-  class FrameGuardRouteHandlerHeader extends Http::ImplicitHeaderDefinition {
-    FrameGuardRouteHandlerHeader() { this instanceof FrameGuardRouteHandler }
-
+  class FrameGuardRouteHandlerHeader extends Http::ImplicitHeaderDefinition instanceof FrameGuardRouteHandler {
     override predicate defines(string headerName, string headerValue) {
       xFrameOptionsDefaultImplicitHeaderDefinition(headerName, headerValue)
     }
@@ -70,9 +66,7 @@ module ExpressLibraries {
   /**
    * A header produced by a route handler of the "helmet" module.
    */
-  class HelmetRouteHandlerHeader extends Http::ImplicitHeaderDefinition {
-    HelmetRouteHandlerHeader() { this instanceof HelmetRouteHandler }
-
+  class HelmetRouteHandlerHeader extends Http::ImplicitHeaderDefinition instanceof HelmetRouteHandler {
     override predicate defines(string headerName, string headerValue) {
       xFrameOptionsDefaultImplicitHeaderDefinition(headerName, headerValue)
     }

--- a/javascript/ql/lib/semmle/javascript/frameworks/Fastify.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Fastify.qll
@@ -168,11 +168,8 @@ module Fastify {
     }
   }
 
-  private class ShorthandRoutingTreeSetup extends Routing::RouteSetup::MethodCall {
-    ShorthandRoutingTreeSetup() {
-      this instanceof RouteSetup and
-      not this.getMethodName() = "route"
-    }
+  private class ShorthandRoutingTreeSetup extends Routing::RouteSetup::MethodCall instanceof RouteSetup {
+    ShorthandRoutingTreeSetup() { not this.getMethodName() = "route" }
 
     override string getRelativePath() { result = this.getArgument(0).getStringValue() }
 
@@ -186,11 +183,8 @@ module Fastify {
           .splitAt(",", n)
   }
 
-  private class FullRoutingTreeSetup extends Routing::RouteSetup::MethodCall {
-    FullRoutingTreeSetup() {
-      this instanceof RouteSetup and
-      this.getMethodName() = "route"
-    }
+  private class FullRoutingTreeSetup extends Routing::RouteSetup::MethodCall instanceof RouteSetup {
+    FullRoutingTreeSetup() { this.getMethodName() = "route" }
 
     override string getRelativePath() { result = this.getOptionArgument(0, "url").getStringValue() }
 

--- a/javascript/ql/lib/semmle/javascript/frameworks/HTTP.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/HTTP.qll
@@ -156,19 +156,14 @@ module Http {
   /**
    * An expression that sets the `Set-Cookie` header of an HTTP response.
    */
-  class SetCookieHeader extends CookieDefinition {
-    HeaderDefinition header;
-
-    SetCookieHeader() {
-      this = header and
-      header.getAHeaderName() = "set-cookie"
-    }
+  class SetCookieHeader extends CookieDefinition instanceof HeaderDefinition {
+    SetCookieHeader() { super.getAHeaderName() = "set-cookie" }
 
     override DataFlow::Node getHeaderArgument() {
-      header.(ExplicitHeaderDefinition).definesHeaderValue("set-cookie", result)
+      this.(ExplicitHeaderDefinition).definesHeaderValue("set-cookie", result)
     }
 
-    override RouteHandler getRouteHandler() { result = header.getRouteHandler() }
+    override RouteHandler getRouteHandler() { result = HeaderDefinition.super.getRouteHandler() }
   }
 
   /**

--- a/javascript/ql/lib/semmle/javascript/frameworks/Templating.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Templating.qll
@@ -174,23 +174,19 @@ module Templating {
   /**
    * A place where a template is instantiated or rendered.
    */
-  class TemplateInstantiation extends DataFlow::Node {
-    TemplateInstantiation::Range range;
-
-    TemplateInstantiation() { this = range }
-
+  class TemplateInstantiation extends DataFlow::Node instanceof TemplateInstantiation::Range {
     /** Gets a data flow node that refers to the instantiated template string, if any. */
-    DataFlow::SourceNode getOutput() { result = range.getOutput() }
+    DataFlow::SourceNode getOutput() { result = super.getOutput() }
 
     /** Gets a data flow node that refers a template file to be instantiated, if any. */
-    DataFlow::Node getTemplateFileNode() { result = range.getTemplateFileNode() }
+    DataFlow::Node getTemplateFileNode() { result = super.getTemplateFileNode() }
 
     /** Gets a data flow node that refers to an object whose properties become variables in the template. */
-    DataFlow::Node getTemplateParamsNode() { result = range.getTemplateParamsNode() }
+    DataFlow::Node getTemplateParamsNode() { result = super.getTemplateParamsNode() }
 
     /** Gets a data flow node that provides the value for the template variable at the given access path. */
     DataFlow::Node getTemplateParamForValue(string accessPath) {
-      result = range.getTemplateParamForValue(accessPath)
+      result = super.getTemplateParamForValue(accessPath)
     }
 
     /** Gets the template file instantiated here, if any. */
@@ -203,7 +199,7 @@ module Templating {
      *
      * If not known, the relevant syntax will be determined by a heuristic.
      */
-    TemplateSyntax getTemplateSyntax() { result = range.getTemplateSyntax() }
+    TemplateSyntax getTemplateSyntax() { result = super.getTemplateSyntax() }
   }
 
   /** Companion module to the `TemplateInstantiation` class. */

--- a/javascript/ql/lib/semmle/javascript/heuristics/AdditionalRouteHandlers.qll
+++ b/javascript/ql/lib/semmle/javascript/heuristics/AdditionalRouteHandlers.qll
@@ -11,24 +11,19 @@ private import semmle.javascript.frameworks.ConnectExpressShared
  * Add `NodeJSLib::RouteHandlerCandidate` to the extent of `NodeJSLib::RouteHandler`.
  */
 private class PromotedNodeJSLibCandidate extends NodeJSLib::RouteHandler,
-  Http::Servers::StandardRouteHandler {
-  PromotedNodeJSLibCandidate() { this instanceof NodeJSLib::RouteHandlerCandidate }
-}
+  Http::Servers::StandardRouteHandler instanceof NodeJSLib::RouteHandlerCandidate { }
 
 /**
  * Add `Hapi::RouteHandlerCandidate` to the extent of `Hapi::RouteHandler`.
  */
-private class PromotedHapiCandidate extends Hapi::RouteHandler, Http::Servers::StandardRouteHandler {
-  PromotedHapiCandidate() { this instanceof Hapi::RouteHandlerCandidate }
+private class PromotedHapiCandidate extends Hapi::RouteHandler, Http::Servers::StandardRouteHandler instanceof Hapi::RouteHandlerCandidate {
 }
 
 /**
  * Add `ConnectExpressShared::RouteHandlerCandidate` to the extent of `Express::RouteHandler`.
  */
 private class PromotedExpressCandidate extends Express::RouteHandler,
-  Http::Servers::StandardRouteHandler {
-  PromotedExpressCandidate() { this instanceof ConnectExpressShared::RouteHandlerCandidate }
-
+  Http::Servers::StandardRouteHandler instanceof ConnectExpressShared::RouteHandlerCandidate {
   override DataFlow::ParameterNode getRouteHandlerParameter(string kind) {
     result = ConnectExpressShared::getRouteHandlerParameter(this, kind)
   }
@@ -38,9 +33,7 @@ private class PromotedExpressCandidate extends Express::RouteHandler,
  * Add `ConnectExpressShared::RouteHandlerCandidate` to the extent of `Connect::RouteHandler`.
  */
 private class PromotedConnectCandidate extends Connect::RouteHandler,
-  Http::Servers::StandardRouteHandler {
-  PromotedConnectCandidate() { this instanceof ConnectExpressShared::RouteHandlerCandidate }
-
+  Http::Servers::StandardRouteHandler instanceof ConnectExpressShared::RouteHandlerCandidate {
   override DataFlow::ParameterNode getRouteHandlerParameter(string kind) {
     result = ConnectExpressShared::getRouteHandlerParameter(this, kind)
   }

--- a/javascript/ql/lib/semmle/javascript/heuristics/AdditionalSources.qll
+++ b/javascript/ql/lib/semmle/javascript/heuristics/AdditionalSources.qll
@@ -27,9 +27,7 @@ private class RemoteFlowPassword extends HeuristicSource, RemoteFlowSource {
  * since it does not properly escape single quotes and dollar symbols.
  */
 private class JsonStringifyAsCommandInjectionSource extends HeuristicSource,
-  CommandInjection::Source {
-  JsonStringifyAsCommandInjectionSource() { this instanceof JsonStringifyCall }
-
+  CommandInjection::Source instanceof JsonStringifyCall {
   override string getSourceType() { result = "a string from JSON.stringify" }
 }
 

--- a/javascript/ql/lib/semmle/javascript/security/IncompleteBlacklistSanitizer.qll
+++ b/javascript/ql/lib/semmle/javascript/security/IncompleteBlacklistSanitizer.qll
@@ -38,9 +38,8 @@ string describeCharacters(string rep) {
  * A local sequence of calls to `String.prototype.replace`,
  * represented by the last call.
  */
-class StringReplaceCallSequence extends DataFlow::CallNode {
+class StringReplaceCallSequence extends DataFlow::CallNode instanceof StringReplaceCall {
   StringReplaceCallSequence() {
-    this instanceof StringReplaceCall and
     not exists(getAStringReplaceMethodCall(this)) // terminal
   }
 

--- a/javascript/ql/lib/semmle/javascript/security/UselessUseOfCat.qll
+++ b/javascript/ql/lib/semmle/javascript/security/UselessUseOfCat.qll
@@ -10,21 +10,17 @@ import Declarations.UnusedVariable
  * A call that executes a system command.
  * This class provides utility predicates for reasoning about command execution calls.
  */
-private class CommandCall extends DataFlow::InvokeNode {
-  SystemCommandExecution command;
-
-  CommandCall() { this = command }
-
+private class CommandCall extends DataFlow::InvokeNode instanceof SystemCommandExecution {
   /**
    * Holds if the call is synchronous (e.g. `execFileSync`).
    */
-  predicate isSync() { command.isSync() }
+  predicate isSync() { super.isSync() }
 
   /**
    * Gets a list that specifies the arguments given to the command.
    */
   DataFlow::ArrayCreationNode getArgumentList() {
-    result = command.getArgumentList().getALocalSource()
+    result = super.getArgumentList().getALocalSource()
   }
 
   /**
@@ -42,7 +38,7 @@ private class CommandCall extends DataFlow::InvokeNode {
   /**
    * Gets the data-flow node (if it exists) for an options argument for an `exec`-like call.
    */
-  DataFlow::Node getOptionsArg() { result = command.getOptionsArg() }
+  DataFlow::Node getOptionsArg() { result = super.getOptionsArg() }
 
   /**
    * Gets the constant-string parts that are not part of the command itself.
@@ -99,7 +95,6 @@ private string getConstantStringParts(DataFlow::Node node) {
  */
 class UselessCat extends CommandCall {
   UselessCat() {
-    this = command and
     this.isACallTo(getACatExecuteable()) and
     // There is a file to read, it's not just spawning `cat`.
     not (

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/CleartextStorageCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/CleartextStorageCustomizations.qll
@@ -40,9 +40,7 @@ module CleartextStorage {
   }
 
   /** A call to any function whose name suggests that it encodes or encrypts its arguments. */
-  class ProtectSanitizer extends Sanitizer {
-    ProtectSanitizer() { this instanceof ProtectCall }
-  }
+  class ProtectSanitizer extends Sanitizer instanceof ProtectCall { }
 
   /**
    * An expression set as a value on a cookie instance.

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/ClientSideUrlRedirectCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/ClientSideUrlRedirectCustomizations.qll
@@ -39,11 +39,8 @@ module ClientSideUrlRedirect {
   }
 
   /** A source of remote user input, considered as a flow source for unvalidated URL redirects. */
-  class RemoteFlowSourceAsSource extends Source {
-    RemoteFlowSourceAsSource() {
-      this instanceof RemoteFlowSource and
-      not this.(ClientSideRemoteFlowSource).getKind().isPath()
-    }
+  class RemoteFlowSourceAsSource extends Source instanceof RemoteFlowSource {
+    RemoteFlowSourceAsSource() { not this.(ClientSideRemoteFlowSource).getKind().isPath() }
 
     override DataFlow::FlowLabel getAFlowLabel() {
       if this.(ClientSideRemoteFlowSource).getKind().isUrl()

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/CodeInjectionCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/CodeInjectionCustomizations.qll
@@ -34,9 +34,7 @@ module CodeInjection {
   abstract class Sanitizer extends DataFlow::Node { }
 
   /** A source of remote user input, considered as a flow source for code injection. */
-  class RemoteFlowSourceAsSource extends Source {
-    RemoteFlowSourceAsSource() { this instanceof RemoteFlowSource }
-  }
+  class RemoteFlowSourceAsSource extends Source instanceof RemoteFlowSource { }
 
   /**
    * An expression which may be interpreted as an AngularJS expression.

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/CommandInjectionCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/CommandInjectionCustomizations.qll
@@ -26,11 +26,8 @@ module CommandInjection {
   abstract class Sanitizer extends DataFlow::Node { }
 
   /** A source of remote user input, considered as a flow source for command injection. */
-  class RemoteFlowSourceAsSource extends Source {
-    RemoteFlowSourceAsSource() {
-      this instanceof RemoteFlowSource and
-      not this instanceof ClientSideRemoteFlowSource
-    }
+  class RemoteFlowSourceAsSource extends Source instanceof RemoteFlowSource {
+    RemoteFlowSourceAsSource() { not this instanceof ClientSideRemoteFlowSource }
 
     override string getSourceType() { result = "a user-provided value" }
   }

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/ConditionalBypassCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/ConditionalBypassCustomizations.qll
@@ -32,9 +32,7 @@ module ConditionalBypass {
    * A source of remote user input, considered as a flow source for bypass of
    * sensitive action guards.
    */
-  class RemoteFlowSourceAsSource extends Source {
-    RemoteFlowSourceAsSource() { this instanceof RemoteFlowSource }
-  }
+  class RemoteFlowSourceAsSource extends Source instanceof RemoteFlowSource { }
 
   /**
    * Holds if `bb` dominates the basic block in which `action` occurs.

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/CorsMisconfigurationForCredentialsCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/CorsMisconfigurationForCredentialsCustomizations.qll
@@ -28,11 +28,8 @@ module CorsMisconfigurationForCredentials {
   abstract class Sanitizer extends DataFlow::Node { }
 
   /** A source of remote user input, considered as a flow source for CORS misconfiguration. */
-  class RemoteFlowSourceAsSource extends Source {
-    RemoteFlowSourceAsSource() {
-      this instanceof RemoteFlowSource and
-      not this instanceof ClientSideRemoteFlowSource
-    }
+  class RemoteFlowSourceAsSource extends Source instanceof RemoteFlowSource {
+    RemoteFlowSourceAsSource() { not this instanceof ClientSideRemoteFlowSource }
   }
 
   /**

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/DeepObjectResourceExhaustionCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/DeepObjectResourceExhaustionCustomizations.qll
@@ -19,15 +19,11 @@ module DeepObjectResourceExhaustion {
     DataFlow::FlowLabel getAFlowLabel() { result = TaintedObject::label() }
   }
 
-  private class TaintedObjectSourceAsSource extends Source {
-    TaintedObjectSourceAsSource() { this instanceof TaintedObject::Source }
-
+  private class TaintedObjectSourceAsSource extends Source instanceof TaintedObject::Source {
     override DataFlow::FlowLabel getAFlowLabel() { result = TaintedObject::label() }
   }
 
-  private class RemoteFlowSourceAsSource extends Source {
-    RemoteFlowSourceAsSource() { this instanceof RemoteFlowSource }
-
+  private class RemoteFlowSourceAsSource extends Source instanceof RemoteFlowSource {
     override DataFlow::FlowLabel getAFlowLabel() { result.isTaint() }
   }
 

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/DifferentKindsComparisonBypassCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/DifferentKindsComparisonBypassCustomizations.qll
@@ -30,19 +30,15 @@ module DifferentKindsComparisonBypass {
   /**
    * A HTTP request input that is suspicious to compare with another HTTP request input of a different kind.
    */
-  class RequestInputComparisonSource extends Source {
-    Http::RequestInputAccess input;
-
-    RequestInputComparisonSource() { input = this }
-
+  class RequestInputComparisonSource extends Source instanceof Http::RequestInputAccess {
     override predicate isSuspiciousToCompareWith(Source other) {
-      input.getKind() != other.(RequestInputComparisonSource).getInput().getKind()
+      super.getKind() != other.(RequestInputComparisonSource).getInput().getKind()
     }
 
     /**
      * Gets the HTTP request input of this source.
      */
-    private Http::RequestInputAccess getInput() { result = input }
+    private Http::RequestInputAccess getInput() { result = this }
   }
 
   /**

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/DomBasedXssCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/DomBasedXssCustomizations.qll
@@ -318,9 +318,7 @@ module DomBasedXss {
   }
 
   /** A source of remote user input, considered as a flow source for DOM-based XSS. */
-  class RemoteFlowSourceAsSource extends Source {
-    RemoteFlowSourceAsSource() { this instanceof RemoteFlowSource }
-  }
+  class RemoteFlowSourceAsSource extends Source instanceof RemoteFlowSource { }
 
   /**
    * A flow-label representing tainted values where the prefix is attacker controlled.

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/ExceptionXssCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/ExceptionXssCustomizations.qll
@@ -42,9 +42,7 @@ module ExceptionXss {
     NotYetThrown() { this = "NotYetThrown" }
   }
 
-  private class XssSourceAsSource extends Source {
-    XssSourceAsSource() { this instanceof Shared::Source }
-
+  private class XssSourceAsSource extends Source instanceof Shared::Source {
     override DataFlow::FlowLabel getAFlowLabel() { result instanceof NotYetThrown }
 
     override string getDescription() { result = "Exception text" }

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/ExternalAPIUsedWithUntrustedDataCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/ExternalAPIUsedWithUntrustedDataCustomizations.qll
@@ -55,9 +55,7 @@ module ExternalApiUsedWithUntrustedData {
    */
   abstract class Sanitizer extends DataFlow::Node { }
 
-  private class RemoteFlowAsSource extends Source {
-    RemoteFlowAsSource() { this instanceof RemoteFlowSource }
-  }
+  private class RemoteFlowAsSource extends Source instanceof RemoteFlowSource { }
 
   /**
    * A package name whose entire API is considered "safe" for the purpose of this query.

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/ExternalAPIUsedWithUntrustedDataQuery.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/ExternalAPIUsedWithUntrustedDataQuery.qll
@@ -59,9 +59,7 @@ class Configuration extends TaintTracking::Configuration {
 }
 
 /** A node representing data being passed to an external API. */
-class ExternalApiDataNode extends DataFlow::Node {
-  ExternalApiDataNode() { this instanceof Sink }
-}
+class ExternalApiDataNode extends DataFlow::Node instanceof Sink { }
 
 /** DEPRECATED: Alias for ExternalApiDataNode */
 deprecated class ExternalAPIDataNode = ExternalApiDataNode;

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/HardcodedDataInterpretedAsCodeCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/HardcodedDataInterpretedAsCodeCustomizations.qll
@@ -49,9 +49,7 @@ module HardcodedDataInterpretedAsCode {
   /**
    * A code injection sink; hard-coded data should not flow here.
    */
-  private class DefaultCodeInjectionSink extends Sink {
-    DefaultCodeInjectionSink() { this instanceof CodeInjection::Sink }
-
+  private class DefaultCodeInjectionSink extends Sink instanceof CodeInjection::Sink {
     override DataFlow::FlowLabel getLabel() { result.isTaint() }
 
     override string getKind() { result = "Code" }

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/HttpToFileAccessSpecific.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/HttpToFileAccessSpecific.qll
@@ -8,9 +8,7 @@ private import HttpToFileAccessCustomizations::HttpToFileAccess
 /**
  * An access to a user-controlled HTTP request input, considered as a flow source for writing user-controlled data to files
  */
-private class RequestInputAccessAsSource extends Source {
-  RequestInputAccessAsSource() { this instanceof Http::RequestInputAccess }
-}
+private class RequestInputAccessAsSource extends Source instanceof Http::RequestInputAccess { }
 
 /** A response from a server, considered as a flow source for writing user-controlled data to files. */
 private class ServerResponseAsSource extends Source {

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/ImproperCodeSanitizationCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/ImproperCodeSanitizationCustomizations.qll
@@ -28,16 +28,12 @@ module ImproperCodeSanitization {
   /**
    * A call to an HTML sanitizer seen as a source for improper code sanitization
    */
-  class HtmlSanitizerCallAsSource extends Source {
-    HtmlSanitizerCallAsSource() { this instanceof HtmlSanitizerCall }
-  }
+  class HtmlSanitizerCallAsSource extends Source instanceof HtmlSanitizerCall { }
 
   /**
    * A call to `JSON.stringify()` seen as a source for improper code sanitization
    */
-  class JsonStringifyAsSource extends Source {
-    JsonStringifyAsSource() { this instanceof JsonStringifyCall }
-  }
+  class JsonStringifyAsSource extends Source instanceof JsonStringifyCall { }
 
   /** DEPRECATED: Alias for JsonStringifyAsSource */
   deprecated class JSONStringifyAsSource = JsonStringifyAsSource;

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/IndirectCommandInjectionCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/IndirectCommandInjectionCustomizations.qll
@@ -25,8 +25,7 @@ module IndirectCommandInjection {
   /**
    * A source of user input from the command-line, considered as a flow source for command injection.
    */
-  private class CommandLineArgumentsArrayAsSource extends Source {
-    CommandLineArgumentsArrayAsSource() { this instanceof CommandLineArgumentsArray }
+  private class CommandLineArgumentsArrayAsSource extends Source instanceof CommandLineArgumentsArray {
   }
 
   /**

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/InsecureRandomnessCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/InsecureRandomnessCustomizations.qll
@@ -78,17 +78,13 @@ module InsecureRandomness {
    * A sensitive write, considered as a sink for random values that are not cryptographically
    * secure.
    */
-  class SensitiveWriteSink extends Sink {
-    SensitiveWriteSink() { this instanceof SensitiveWrite }
-  }
+  class SensitiveWriteSink extends Sink instanceof SensitiveWrite { }
 
   /**
    * A cryptographic key, considered as a sink for random values that are not cryptographically
    * secure.
    */
-  class CryptoKeySink extends Sink {
-    CryptoKeySink() { this instanceof CryptographicKey }
-  }
+  class CryptoKeySink extends Sink instanceof CryptographicKey { }
 
   /**
    * Holds if the step `pred` -> `succ` is an additional taint-step for random values that are not cryptographically secure.

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/LogInjectionQuery.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/LogInjectionQuery.qll
@@ -35,10 +35,8 @@ class LogInjectionConfiguration extends TaintTracking::Configuration {
 /**
  * A source of remote user controlled input.
  */
-class RemoteSource extends Source {
-  RemoteSource() {
-    this instanceof RemoteFlowSource and not this instanceof ClientSideRemoteFlowSource
-  }
+class RemoteSource extends Source instanceof RemoteFlowSource {
+  RemoteSource() { not this instanceof ClientSideRemoteFlowSource }
 }
 
 /**
@@ -60,9 +58,7 @@ class StringReplaceSanitizer extends Sanitizer {
 /**
  * A call to an HTML sanitizer is considered to sanitize the user input.
  */
-class HtmlSanitizer extends Sanitizer {
-  HtmlSanitizer() { this instanceof HtmlSanitizerCall }
-}
+class HtmlSanitizer extends Sanitizer instanceof HtmlSanitizerCall { }
 
 /**
  * A call to `JSON.stringify` or similar, seen as sanitizing log output.

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/LoopBoundInjectionCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/LoopBoundInjectionCustomizations.qll
@@ -169,9 +169,7 @@ module LoopBoundInjection {
   /**
    * A source of remote user input objects.
    */
-  class TaintedObjectSource extends Source {
-    TaintedObjectSource() { this instanceof TaintedObject::Source }
-  }
+  class TaintedObjectSource extends Source instanceof TaintedObject::Source { }
 
   /**
    * A sanitizer that blocks taint flow if the array is checked to be an array using an `isArray` function.

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/MissingRateLimiting.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/MissingRateLimiting.qll
@@ -80,30 +80,22 @@ abstract class ExpensiveAction extends DataFlow::Node {
 }
 
 /** A call to an authorization function, considered as an expensive action. */
-class AuthorizationCallAsExpensiveAction extends ExpensiveAction {
-  AuthorizationCallAsExpensiveAction() { this instanceof AuthorizationCall }
-
+class AuthorizationCallAsExpensiveAction extends ExpensiveAction instanceof AuthorizationCall {
   override string describe() { result = "authorization" }
 }
 
 /** A file system access, considered as an expensive action. */
-class FileSystemAccessAsExpensiveAction extends ExpensiveAction {
-  FileSystemAccessAsExpensiveAction() { this instanceof FileSystemAccess }
-
+class FileSystemAccessAsExpensiveAction extends ExpensiveAction instanceof FileSystemAccess {
   override string describe() { result = "a file system access" }
 }
 
 /** A system command execution, considered as an expensive action. */
-class SystemCommandExecutionAsExpensiveAction extends ExpensiveAction {
-  SystemCommandExecutionAsExpensiveAction() { this instanceof SystemCommandExecution }
-
+class SystemCommandExecutionAsExpensiveAction extends ExpensiveAction instanceof SystemCommandExecution {
   override string describe() { result = "a system command" }
 }
 
 /** A database access, considered as an expensive action. */
-class DatabaseAccessAsExpensiveAction extends ExpensiveAction {
-  DatabaseAccessAsExpensiveAction() { this instanceof DatabaseAccess }
-
+class DatabaseAccessAsExpensiveAction extends ExpensiveAction instanceof DatabaseAccess {
   override string describe() { result = "a database access" }
 }
 
@@ -208,8 +200,7 @@ class RateLimiterFlexibleRateLimiter extends DataFlow::FunctionNode {
 /**
  * A route-handler expression that is rate-limited by the `rate-limiter-flexible` package.
  */
-class RouteHandlerLimitedByRateLimiterFlexible extends RateLimitingMiddleware {
-  RouteHandlerLimitedByRateLimiterFlexible() { this instanceof RateLimiterFlexibleRateLimiter }
+class RouteHandlerLimitedByRateLimiterFlexible extends RateLimitingMiddleware instanceof RateLimiterFlexibleRateLimiter {
 }
 
 private class FastifyRateLimiter extends RateLimitingMiddleware {

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/NosqlInjectionCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/NosqlInjectionCustomizations.qll
@@ -31,9 +31,7 @@ module NosqlInjection {
   abstract class Sanitizer extends DataFlow::Node { }
 
   /** A source of remote user input, considered as a flow source for NoSql injection. */
-  class RemoteFlowSourceAsSource extends Source {
-    RemoteFlowSourceAsSource() { this instanceof RemoteFlowSource }
-  }
+  class RemoteFlowSourceAsSource extends Source instanceof RemoteFlowSource { }
 
   /** An expression interpreted as a NoSql query, viewed as a sink. */
   class NosqlQuerySink extends Sink instanceof NoSql::Query { }

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/PostMessageStarCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/PostMessageStarCustomizations.qll
@@ -44,9 +44,7 @@ module PostMessageStar {
   class SensitiveExprSource extends Source instanceof SensitiveNode { }
 
   /** A call to any function whose name suggests that it encodes or encrypts its arguments. */
-  class ProtectSanitizer extends Sanitizer {
-    ProtectSanitizer() { this instanceof ProtectCall }
-  }
+  class ProtectSanitizer extends Sanitizer instanceof ProtectCall { }
 
   /**
    * An expression sent using `postMessage` without restricting the target window origin.

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/PrototypePollutingAssignmentCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/PrototypePollutingAssignmentCustomizations.qll
@@ -57,9 +57,7 @@ module PrototypePollutingAssignment {
   }
 
   /** A remote flow source or location.{hash,search} as a taint source. */
-  private class DefaultSource extends Source {
-    DefaultSource() { this instanceof RemoteFlowSource }
-
+  private class DefaultSource extends Source instanceof RemoteFlowSource {
     override string describe() { result = "user controlled input" }
   }
 

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/PrototypePollutionCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/PrototypePollutionCustomizations.qll
@@ -68,18 +68,14 @@ module PrototypePollution {
    * Note that values from this type of source will need to flow through a `JSON.parse` call
    * in order to be flagged for prototype pollution.
    */
-  private class RemoteFlowAsSource extends Source {
-    RemoteFlowAsSource() { this instanceof RemoteFlowSource }
-
+  private class RemoteFlowAsSource extends Source instanceof RemoteFlowSource {
     override DataFlow::FlowLabel getAFlowLabel() { result.isTaint() }
   }
 
   /**
    * A source of user-controlled objects.
    */
-  private class TaintedObjectSource extends Source {
-    TaintedObjectSource() { this instanceof TaintedObject::Source }
-
+  private class TaintedObjectSource extends Source instanceof TaintedObject::Source {
     override DataFlow::FlowLabel getAFlowLabel() { result = TaintedObject::label() }
   }
 

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/RegExpInjectionCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/RegExpInjectionCustomizations.qll
@@ -26,11 +26,8 @@ module RegExpInjection {
    * A source of remote user input, considered as a flow source for regular
    * expression injection.
    */
-  class RemoteFlowSourceAsSource extends Source {
-    RemoteFlowSourceAsSource() {
-      this instanceof RemoteFlowSource and
-      not this instanceof ClientSideRemoteFlowSource
-    }
+  class RemoteFlowSourceAsSource extends Source instanceof RemoteFlowSource {
+    RemoteFlowSourceAsSource() { not this instanceof ClientSideRemoteFlowSource }
   }
 
   /**

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/RemotePropertyInjectionCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/RemotePropertyInjectionCustomizations.qll
@@ -34,9 +34,7 @@ module RemotePropertyInjection {
    * A source of remote user input, considered as a flow source for remote property
    * injection.
    */
-  class RemoteFlowSourceAsSource extends Source {
-    RemoteFlowSourceAsSource() { this instanceof RemoteFlowSource }
-  }
+  class RemoteFlowSourceAsSource extends Source instanceof RemoteFlowSource { }
 
   /**
    * A sink for property writes with dynamically computed property name.

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/ShellCommandInjectionFromEnvironmentCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/ShellCommandInjectionFromEnvironmentCustomizations.qll
@@ -27,9 +27,7 @@ module ShellCommandInjectionFromEnvironment {
   abstract class Sanitizer extends DataFlow::Node { }
 
   /** An file name from the local file system, considered as a flow source for command injection. */
-  class FileNameSourceAsSource extends Source {
-    FileNameSourceAsSource() { this instanceof FileNameSource }
-
+  class FileNameSourceAsSource extends Source instanceof FileNameSource {
     override string getSourceType() { result = "file name" }
   }
 

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/SqlInjectionCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/SqlInjectionCustomizations.qll
@@ -23,9 +23,7 @@ module SqlInjection {
   abstract class Sanitizer extends DataFlow::Node { }
 
   /** A source of remote user input, considered as a flow source for string based query injection. */
-  class RemoteFlowSourceAsSource extends Source {
-    RemoteFlowSourceAsSource() { this instanceof RemoteFlowSource }
-  }
+  class RemoteFlowSourceAsSource extends Source instanceof RemoteFlowSource { }
 
   /** An SQL expression passed to an API call that executes SQL. */
   class SqlInjectionExprSink extends Sink instanceof SQL::SqlString { }
@@ -36,9 +34,7 @@ module SqlInjection {
   }
 
   /** An GraphQL expression passed to an API call that executes GraphQL. */
-  class GraphqlInjectionSink extends Sink {
-    GraphqlInjectionSink() { this instanceof GraphQL::GraphQLString }
-  }
+  class GraphqlInjectionSink extends Sink instanceof GraphQL::GraphQLString { }
 
   /**
    * An LDAPjs sink.

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/StoredXssCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/StoredXssCustomizations.qll
@@ -27,13 +27,10 @@ module StoredXss {
   }
 
   /** A file name, considered as a flow source for stored XSS. */
-  class FileNameSourceAsSource extends Source {
-    FileNameSourceAsSource() { this instanceof FileNameSource }
-  }
+  class FileNameSourceAsSource extends Source instanceof FileNameSource { }
 
   /** An instance of user-controlled torrent information, considered as a flow source for stored XSS. */
-  class UserControlledTorrentInfoAsSource extends Source {
-    UserControlledTorrentInfoAsSource() { this instanceof ParseTorrent::UserControlledTorrentInfo }
+  class UserControlledTorrentInfoAsSource extends Source instanceof ParseTorrent::UserControlledTorrentInfo {
   }
 
   /**

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/TaintedPathCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/TaintedPathCustomizations.qll
@@ -345,21 +345,16 @@ module TaintedPath {
    *
    * This is relevant for paths that are known to be normalized.
    */
-  class StartsWithDotDotSanitizer extends BarrierGuardNode {
-    StringOps::StartsWith startsWith;
-
-    StartsWithDotDotSanitizer() {
-      this = startsWith and
-      isDotDotSlashPrefix(startsWith.getSubstring())
-    }
+  class StartsWithDotDotSanitizer extends BarrierGuardNode instanceof StringOps::StartsWith {
+    StartsWithDotDotSanitizer() { isDotDotSlashPrefix(super.getSubstring()) }
 
     override predicate blocks(boolean outcome, Expr e, DataFlow::FlowLabel label) {
       // Sanitize in the false case for:
       //   .startsWith(".")
       //   .startsWith("..")
       //   .startsWith("../")
-      outcome = startsWith.getPolarity().booleanNot() and
-      e = startsWith.getBaseString().asExpr() and
+      outcome = super.getPolarity().booleanNot() and
+      e = super.getBaseString().asExpr() and
       exists(Label::PosixPath posixPath | posixPath = label |
         posixPath.isNormalized() and
         posixPath.isRelative()

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/TemplateObjectInjectionCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/TemplateObjectInjectionCustomizations.qll
@@ -30,15 +30,11 @@ module TemplateObjectInjection {
    */
   abstract class Sanitizer extends DataFlow::Node { }
 
-  private class TaintedObjectSourceAsSource extends Source {
-    TaintedObjectSourceAsSource() { this instanceof TaintedObject::Source }
-
+  private class TaintedObjectSourceAsSource extends Source instanceof TaintedObject::Source {
     override DataFlow::FlowLabel getAFlowLabel() { result = TaintedObject::label() }
   }
 
-  private class RemoteFlowSourceAsSource extends Source {
-    RemoteFlowSourceAsSource() { this instanceof RemoteFlowSource }
-
+  private class RemoteFlowSourceAsSource extends Source instanceof RemoteFlowSource {
     override DataFlow::FlowLabel getAFlowLabel() { result.isTaint() }
   }
 

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/UnsafeDeserializationCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/UnsafeDeserializationCustomizations.qll
@@ -23,9 +23,7 @@ module UnsafeDeserialization {
   abstract class Sanitizer extends DataFlow::Node { }
 
   /** A source of remote user input, considered as a flow source for unsafe deserialization. */
-  class RemoteFlowSourceAsSource extends Source {
-    RemoteFlowSourceAsSource() { this instanceof RemoteFlowSource }
-  }
+  class RemoteFlowSourceAsSource extends Source instanceof RemoteFlowSource { }
 
   /**
    * An expression passed to one of the unsafe load functions of the `js-yaml` package.

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/UnsafeDynamicMethodAccessCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/UnsafeDynamicMethodAccessCustomizations.qll
@@ -54,9 +54,7 @@ module UnsafeDynamicMethodAccess {
   /**
    * A source of remote user input, considered as a source for unsafe dynamic method access.
    */
-  class RemoteFlowSourceAsSource extends Source {
-    RemoteFlowSourceAsSource() { this instanceof RemoteFlowSource }
-  }
+  class RemoteFlowSourceAsSource extends Source instanceof RemoteFlowSource { }
 
   /**
    * A function invocation of an unsafe function, as a sink for remote unsafe dynamic method access.

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/UnsafeJQueryPluginCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/UnsafeJQueryPluginCustomizations.qll
@@ -175,10 +175,8 @@ module UnsafeJQueryPlugin {
   /**
    * An argument that may act as an HTML fragment rather than a CSS selector, as a sink for remote unsafe jQuery plugins.
    */
-  class AmbiguousHtmlOrSelectorArgumentAsSink extends Sink {
-    AmbiguousHtmlOrSelectorArgumentAsSink() {
-      this instanceof AmbiguousHtmlOrSelectorArgument and not isLikelyIntentionalHtmlSink(this)
-    }
+  class AmbiguousHtmlOrSelectorArgumentAsSink extends Sink instanceof AmbiguousHtmlOrSelectorArgument {
+    AmbiguousHtmlOrSelectorArgumentAsSink() { not isLikelyIntentionalHtmlSink(this) }
   }
 
   /**

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/UnvalidatedDynamicMethodCallCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/UnvalidatedDynamicMethodCallCustomizations.qll
@@ -60,9 +60,7 @@ module UnvalidatedDynamicMethodCall {
   /**
    * A source of remote user input, considered as a source for unvalidated dynamic method calls.
    */
-  class RemoteFlowSourceAsSource extends Source {
-    RemoteFlowSourceAsSource() { this instanceof RemoteFlowSource }
-  }
+  class RemoteFlowSourceAsSource extends Source instanceof RemoteFlowSource { }
 
   /**
    * The page URL considered as a flow source for unvalidated dynamic method calls.

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/XmlBombCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/XmlBombCustomizations.qll
@@ -24,9 +24,7 @@ module XmlBomb {
   abstract class Sanitizer extends DataFlow::Node { }
 
   /** A source of remote user input, considered as a flow source for XML bomb vulnerabilities. */
-  class RemoteFlowSourceAsSource extends Source {
-    RemoteFlowSourceAsSource() { this instanceof RemoteFlowSource }
-  }
+  class RemoteFlowSourceAsSource extends Source instanceof RemoteFlowSource { }
 
   /**
    * An access to `document.location`, considered as a flow source for XML bomb vulnerabilities.

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/XpathInjectionCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/XpathInjectionCustomizations.qll
@@ -24,9 +24,7 @@ module XpathInjection {
   abstract class Sanitizer extends DataFlow::Node { }
 
   /** A source of remote user input, considered as a flow source for XPath injection. */
-  class RemoteSource extends Source {
-    RemoteSource() { this instanceof RemoteFlowSource }
-  }
+  class RemoteSource extends Source instanceof RemoteFlowSource { }
 
   /**
    * The `expression` argument to `xpath.parse` or `xpath.select` (and similar) from

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/XxeCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/XxeCustomizations.qll
@@ -24,9 +24,7 @@ module Xxe {
   abstract class Sanitizer extends DataFlow::Node { }
 
   /** A source of remote user input, considered as a flow source for XXE vulnerabilities. */
-  class RemoteFlowSourceAsSource extends Source {
-    RemoteFlowSourceAsSource() { this instanceof RemoteFlowSource }
-  }
+  class RemoteFlowSourceAsSource extends Source instanceof RemoteFlowSource { }
 
   /**
    * An access to `document.location`, considered as a flow source for XXE vulnerabilities.

--- a/javascript/ql/src/AlertSuppression.ql
+++ b/javascript/ql/src/AlertSuppression.ql
@@ -52,9 +52,7 @@ class SuppressionComment extends Locatable {
 /**
  * The scope of an alert suppression comment.
  */
-class SuppressionScope extends @locatable {
-  SuppressionScope() { this instanceof SuppressionComment }
-
+class SuppressionScope extends @locatable instanceof SuppressionComment {
   /** Gets a suppression comment with this scope. */
   SuppressionComment getSuppressionComment() { result = this }
 
@@ -68,7 +66,7 @@ class SuppressionScope extends @locatable {
   predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    this.(SuppressionComment).covers(filepath, startline, startcolumn, endline, endcolumn)
+    super.covers(filepath, startline, startcolumn, endline, endcolumn)
   }
 
   /** Gets a textual representation of this element. */

--- a/python/ql/lib/semmle/python/SpecialMethods.qll
+++ b/python/ql/lib/semmle/python/SpecialMethods.qll
@@ -11,9 +11,7 @@
 private import python
 
 /** A control flow node which might correspond to a special method call. */
-class PotentialSpecialMethodCallNode extends ControlFlowNode {
-  PotentialSpecialMethodCallNode() { this instanceof SpecialMethod::Potential }
-}
+class PotentialSpecialMethodCallNode extends ControlFlowNode instanceof SpecialMethod::Potential { }
 
 /**
  * Machinery for detecting special method calls.

--- a/python/ql/lib/semmle/python/dataflow/new/RemoteFlowSources.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/RemoteFlowSources.qll
@@ -15,13 +15,9 @@ private import semmle.python.Concepts
  * Extend this class to refine existing API models. If you want to model new APIs,
  * extend `RemoteFlowSource::Range` instead.
  */
-class RemoteFlowSource extends DataFlow::Node {
-  RemoteFlowSource::Range self;
-
-  RemoteFlowSource() { this = self }
-
+class RemoteFlowSource extends DataFlow::Node instanceof RemoteFlowSource::Range {
   /** Gets a string that describes the type of this remote flow source. */
-  string getSourceType() { result = self.getSourceType() }
+  string getSourceType() { result = super.getSourceType() }
 }
 
 /** Provides a class for modeling new sources of remote user input. */

--- a/python/ql/lib/semmle/python/dataflow/new/SensitiveDataSources.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/SensitiveDataSources.qll
@@ -21,11 +21,8 @@ module SensitiveDataClassification = SensitiveDataHeuristics::SensitiveDataClass
  * Extend this class to refine existing API models. If you want to model new APIs,
  * extend `SensitiveDataSource::Range` instead.
  */
-class SensitiveDataSource extends DataFlow::Node {
-  SensitiveDataSource::Range range;
-
+class SensitiveDataSource extends DataFlow::Node instanceof SensitiveDataSource::Range {
   SensitiveDataSource() {
-    this = range and
     // ignore sensitive password sources in getpass.py, that can escape through `getpass.getpass()` return value,
     // since `getpass.getpass()` is considered a source itself.
     not exists(Module getpass |
@@ -39,7 +36,7 @@ class SensitiveDataSource extends DataFlow::Node {
   /**
    * Gets the classification of the sensitive data.
    */
-  SensitiveDataClassification getClassification() { result = range.getClassification() }
+  SensitiveDataClassification getClassification() { result = super.getClassification() }
 }
 
 /** Provides a class for modeling new sources of sensitive data, such as secrets, certificates, or passwords. */

--- a/python/ql/lib/semmle/python/dataflow/new/internal/IterableUnpacking.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/IterableUnpacking.qll
@@ -207,16 +207,13 @@ class AssignmentTarget extends ControlFlowNode {
 }
 
 /** A direct (or top-level) target of an unpacking assignment. */
-class UnpackingAssignmentDirectTarget extends ControlFlowNode {
+class UnpackingAssignmentDirectTarget extends ControlFlowNode instanceof SequenceNode {
   Expr value;
 
   UnpackingAssignmentDirectTarget() {
-    this instanceof SequenceNode and
-    (
-      value = this.(AssignmentTarget).getValue()
-      or
-      value = this.(ForTarget).getSource()
-    )
+    value = this.(AssignmentTarget).getValue()
+    or
+    value = this.(ForTarget).getSource()
   }
 
   Expr getValue() { result = value }

--- a/python/ql/lib/semmle/python/dataflow/old/Implementation.qll
+++ b/python/ql/lib/semmle/python/dataflow/old/Implementation.qll
@@ -197,9 +197,7 @@ class TaintTrackingNode extends TTaintTrackingNode {
  * It is implemented as a separate class for clarity and to keep the code
  * in `TaintTracking::Configuration` simpler.
  */
-class TaintTrackingImplementation extends string {
-  TaintTrackingImplementation() { this instanceof TaintTracking::Configuration }
-
+class TaintTrackingImplementation extends string instanceof TaintTracking::Configuration {
   /**
    * Hold if there is a flow from `source`, which is a taint source, to
    * `sink`, which is a taint sink, with this configuration.
@@ -218,7 +216,7 @@ class TaintTrackingImplementation extends string {
   ) {
     context = TNoParam() and
     path = TNoAttribute() and
-    this.(TaintTracking::Configuration).isSource(node, kind)
+    super.isSource(node, kind)
   }
 
   /** Hold if `source` is a source of taint. */
@@ -234,7 +232,7 @@ class TaintTrackingImplementation extends string {
     exists(DataFlow::Node node, AttributePath path, TaintKind kind |
       sink = TTaintTrackingNode_(node, _, path, kind, this) and
       path = TNoAttribute() and
-      this.(TaintTracking::Configuration).isSink(node, kind)
+      super.isSink(node, kind)
     )
   }
 
@@ -259,11 +257,11 @@ class TaintTrackingImplementation extends string {
   ) {
     this.unprunedStep(src, node, context, path, kind, edgeLabel) and
     node.getBasicBlock().likelyReachable() and
-    not this.(TaintTracking::Configuration).isBarrier(node) and
+    not super.isBarrier(node) and
     (
       not path = TNoAttribute()
       or
-      not this.(TaintTracking::Configuration).isBarrier(node, kind) and
+      not super.isBarrier(node, kind) and
       exists(DataFlow::Node srcnode, TaintKind srckind |
         src = TTaintTrackingNode_(srcnode, _, _, srckind, this) and
         not this.prunedEdge(srcnode, node, srckind, kind)
@@ -274,9 +272,9 @@ class TaintTrackingImplementation extends string {
   private predicate prunedEdge(
     DataFlow::Node srcnode, DataFlow::Node destnode, TaintKind srckind, TaintKind destkind
   ) {
-    this.(TaintTracking::Configuration).isBarrierEdge(srcnode, destnode, srckind, destkind)
+    super.isBarrierEdge(srcnode, destnode, srckind, destkind)
     or
-    srckind = destkind and this.(TaintTracking::Configuration).isBarrierEdge(srcnode, destnode)
+    srckind = destkind and super.isBarrierEdge(srcnode, destnode)
   }
 
   private predicate unprunedStep(
@@ -314,14 +312,14 @@ class TaintTrackingImplementation extends string {
     this.legacyExtensionStep(src, node, context, path, kind, edgeLabel)
     or
     exists(DataFlow::Node srcnode, TaintKind srckind |
-      this.(TaintTracking::Configuration).isAdditionalFlowStep(srcnode, node, srckind, kind) and
+      super.isAdditionalFlowStep(srcnode, node, srckind, kind) and
       src = TTaintTrackingNode_(srcnode, context, path, srckind, this) and
       path.noAttribute() and
       edgeLabel = "additional with kind"
     )
     or
     exists(DataFlow::Node srcnode |
-      this.(TaintTracking::Configuration).isAdditionalFlowStep(srcnode, node) and
+      super.isAdditionalFlowStep(srcnode, node) and
       src = TTaintTrackingNode_(srcnode, context, path, kind, this) and
       path.noAttribute() and
       edgeLabel = "additional"
@@ -618,7 +616,7 @@ class TaintTrackingImplementation extends string {
     TaintKind kind, string edgeLabel
   ) {
     exists(TaintTracking::Extension extension, DataFlow::Node srcnode, TaintKind srckind |
-      this.(TaintTracking::Configuration).isExtension(extension) and
+      super.isExtension(extension) and
       src = TTaintTrackingNode_(srcnode, context, path, srckind, this) and
       srcnode.asCfgNode() = extension
     |
@@ -646,9 +644,7 @@ class TaintTrackingImplementation extends string {
  * Another taint-tracking class to help partition the code for clarity
  * This class handle tracking of ESSA variables.
  */
-private class EssaTaintTracking extends string {
-  EssaTaintTracking() { this instanceof TaintTracking::Configuration }
-
+private class EssaTaintTracking extends string instanceof TaintTracking::Configuration {
   pragma[noinline]
   predicate taintedDefinition(
     TaintTrackingNode src, EssaDefinition defn, TaintTrackingContext context, AttributePath path,
@@ -691,7 +687,7 @@ private class EssaTaintTracking extends string {
       defn = phi.asVariable().getDefinition() and
       predvar = defn.getInput(pred) and
       not pred.unlikelySuccessor(defn.getBasicBlock()) and
-      not this.(TaintTracking::Configuration).isBarrierEdge(srcnode, phi) and
+      not super.isBarrierEdge(srcnode, phi) and
       srcnode.asVariable() = predvar
     )
   }
@@ -781,7 +777,7 @@ private class EssaTaintTracking extends string {
     exists(DataFlow::Node srcnode |
       src = TTaintTrackingNode_(srcnode, context, path, kind, this) and
       srcnode.asVariable() = defn.getInput() and
-      not this.(TaintTracking::Configuration).isBarrierTest(defn.getTest(), defn.getSense())
+      not super.isBarrierTest(defn.getTest(), defn.getSense())
     )
   }
 
@@ -801,7 +797,7 @@ private class EssaTaintTracking extends string {
   ) {
     exists(DataFlow::Node srcnode, ControlFlowNode use |
       src = TTaintTrackingNode_(srcnode, context, path, kind, this) and
-      not this.(TaintTracking::Configuration).isBarrierTest(defn.getTest(), defn.getSense()) and
+      not super.isBarrierTest(defn.getTest(), defn.getSense()) and
       defn.getSense() = this.testEvaluates(defn, defn.getTest(), use, src)
     )
   }
@@ -815,7 +811,7 @@ private class EssaTaintTracking extends string {
       src = TTaintTrackingNode_(srcnode, context, path, kind, this) and
       piNodeTestAndUse(defn, test, use) and
       srcnode.asVariable() = defn.getInput() and
-      not this.(TaintTracking::Configuration).isBarrierTest(test, defn.getSense()) and
+      not super.isBarrierTest(test, defn.getSense()) and
       testEvaluatesMaybe(test, use)
     )
   }

--- a/python/ql/lib/semmle/python/essa/Definitions.qll
+++ b/python/ql/lib/semmle/python/essa/Definitions.qll
@@ -205,22 +205,19 @@ class BuiltinVariable extends SsaSourceVariable {
   override CallNode redefinedAtCallSite() { none() }
 }
 
-class ModuleVariable extends SsaSourceVariable {
+class ModuleVariable extends SsaSourceVariable instanceof GlobalVariable {
   ModuleVariable() {
-    this instanceof GlobalVariable and
-    (
-      exists(this.(Variable).getAStore())
-      or
-      this.(Variable).getId() = "__name__"
-      or
-      this.(Variable).getId() = "__package__"
-      or
-      exists(ImportStar is | is.getScope() = this.(Variable).getScope())
-    )
+    exists(this.(Variable).getAStore())
+    or
+    this.(Variable).getId() = "__name__"
+    or
+    this.(Variable).getId() = "__package__"
+    or
+    exists(ImportStar is | is.getScope() = this.(Variable).getScope())
   }
 
   pragma[nomagic]
-  private Scope scope_as_global_variable() { result = this.(GlobalVariable).getScope() }
+  private Scope scope_as_global_variable() { result = GlobalVariable.super.getScope() }
 
   pragma[noinline]
   CallNode global_variable_callnode() { result.getScope() = this.scope_as_global_variable() }
@@ -263,7 +260,7 @@ class ModuleVariable extends SsaSourceVariable {
       class_with_global_metaclass(s, this)
       or
       /* Variable is used in scope */
-      this.(GlobalVariable).getAUse().getScope() = s
+      GlobalVariable.super.getAUse().getScope() = s
     )
     or
     exists(ImportTimeScope scope | scope.entryEdge(_, result) |

--- a/python/ql/lib/semmle/python/frameworks/Aiohttp.qll
+++ b/python/ql/lib/semmle/python/frameworks/Aiohttp.qll
@@ -59,24 +59,24 @@ module AiohttpWebModel {
    * Extend this class to refine existing API models. If you want to model new APIs,
    * extend `AiohttpRouteSetup::Range` instead.
    */
-  class AiohttpRouteSetup extends Http::Server::RouteSetup::Range {
-    AiohttpRouteSetup::Range range;
-
-    AiohttpRouteSetup() { this = range }
-
+  class AiohttpRouteSetup extends Http::Server::RouteSetup::Range instanceof AiohttpRouteSetup::Range {
     override Parameter getARoutedParameter() { none() }
 
     override string getFramework() { result = "aiohttp.web" }
 
     /** Gets the argument specifying the handler (either a coroutine or a view-class). */
-    DataFlow::Node getHandlerArg() { result = range.getHandlerArg() }
+    DataFlow::Node getHandlerArg() { result = super.getHandlerArg() }
 
-    override DataFlow::Node getUrlPatternArg() { result = range.getUrlPatternArg() }
+    override DataFlow::Node getUrlPatternArg() {
+      result = AiohttpRouteSetup::Range.super.getUrlPatternArg()
+    }
 
     /** Gets the view-class that is referenced in the view-class handler argument, if any. */
-    Class getViewClass() { result = range.getViewClass() }
+    Class getViewClass() { result = super.getViewClass() }
 
-    override Function getARequestHandler() { result = range.getARequestHandler() }
+    override Function getARequestHandler() {
+      result = AiohttpRouteSetup::Range.super.getARequestHandler()
+    }
   }
 
   /** Provides a class for modeling new aiohttp.web route setups. */

--- a/python/ql/lib/semmle/python/frameworks/Django.qll
+++ b/python/ql/lib/semmle/python/frameworks/Django.qll
@@ -2526,11 +2526,10 @@ module PrivateDjango {
    *
    * Needs this subclass to be considered a RegexString.
    */
-  private class DjangoRouteRegex extends RegexString {
+  private class DjangoRouteRegex extends RegexString instanceof StrConst {
     DjangoRegexRouteSetup rePathCall;
 
     DjangoRouteRegex() {
-      this instanceof StrConst and
       rePathCall.getUrlPatternArg().getALocalSource() = DataFlow::exprNode(this)
     }
 

--- a/python/ql/lib/semmle/python/frameworks/Tornado.qll
+++ b/python/ql/lib/semmle/python/frameworks/Tornado.qll
@@ -385,13 +385,10 @@ module Tornado {
    *
    * Needs this subclass to be considered a RegexString.
    */
-  private class TornadoRouteRegex extends RegexString {
+  private class TornadoRouteRegex extends RegexString instanceof StrConst {
     TornadoRouteSetup setup;
 
-    TornadoRouteRegex() {
-      this instanceof StrConst and
-      setup.getUrlPatternArg().getALocalSource() = DataFlow::exprNode(this)
-    }
+    TornadoRouteRegex() { setup.getUrlPatternArg().getALocalSource() = DataFlow::exprNode(this) }
 
     TornadoRouteSetup getRouteSetup() { result = setup }
   }

--- a/python/ql/lib/semmle/python/security/dataflow/StackTraceExposureCustomizations.qll
+++ b/python/ql/lib/semmle/python/security/dataflow/StackTraceExposureCustomizations.qll
@@ -41,9 +41,7 @@ module StackTraceExposure {
   /**
    * A source of exception info, considered as a flow source.
    */
-  class ExceptionInfoAsSource extends Source {
-    ExceptionInfoAsSource() { this instanceof ExceptionInfo }
-  }
+  class ExceptionInfoAsSource extends Source instanceof ExceptionInfo { }
 
   /**
    * The body of a HTTP response that will be returned from a server, considered as a flow sink.

--- a/python/ql/lib/semmle/python/security/dataflow/XmlBombCustomizations.qll
+++ b/python/ql/lib/semmle/python/security/dataflow/XmlBombCustomizations.qll
@@ -30,9 +30,7 @@ module XmlBomb {
   abstract class Sanitizer extends DataFlow::Node { }
 
   /** A source of remote user input, considered as a flow source for XML bomb vulnerabilities. */
-  class RemoteFlowSourceAsSource extends Source {
-    RemoteFlowSourceAsSource() { this instanceof RemoteFlowSource }
-  }
+  class RemoteFlowSourceAsSource extends Source instanceof RemoteFlowSource { }
 
   /**
    * A call to an XML parser that is vulnerable to XML bombs.

--- a/python/ql/lib/semmle/python/security/dataflow/XxeCustomizations.qll
+++ b/python/ql/lib/semmle/python/security/dataflow/XxeCustomizations.qll
@@ -30,9 +30,7 @@ module Xxe {
   abstract class Sanitizer extends DataFlow::Node { }
 
   /** A source of remote user input, considered as a flow source for XXE vulnerabilities. */
-  class RemoteFlowSourceAsSource extends Source {
-    RemoteFlowSourceAsSource() { this instanceof RemoteFlowSource }
-  }
+  class RemoteFlowSourceAsSource extends Source instanceof RemoteFlowSource { }
 
   /**
    * A call to an XML parser that is vulnerable to XXE.

--- a/python/ql/src/analysis/AlertSuppression.ql
+++ b/python/ql/src/analysis/AlertSuppression.ql
@@ -80,9 +80,7 @@ class NoqaSuppressionComment extends LineSuppressionComment {
 /**
  * The scope of an alert suppression comment.
  */
-class SuppressionScope extends @py_comment {
-  SuppressionScope() { this instanceof SuppressionComment }
-
+class SuppressionScope extends @py_comment instanceof SuppressionComment {
   /**
    * Holds if this element is at the specified location.
    * The location spans column `startcolumn` of line `startline` to
@@ -93,7 +91,7 @@ class SuppressionScope extends @py_comment {
   predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    this.(SuppressionComment).covers(filepath, startline, startcolumn, endline, endcolumn)
+    super.covers(filepath, startline, startcolumn, endline, endcolumn)
   }
 
   /** Gets a textual representation of this element. */

--- a/python/ql/src/experimental/semmle/python/Concepts.qll
+++ b/python/ql/src/experimental/semmle/python/Concepts.qll
@@ -42,14 +42,10 @@ module CopyFile {
  * Extend this class to refine existing API models. If you want to model new APIs,
  * extend `CopyFile::Range` instead.
  */
-class CopyFile extends DataFlow::Node {
-  CopyFile::Range range;
+class CopyFile extends DataFlow::Node instanceof CopyFile::Range {
+  DataFlow::Node getAPathArgument() { result = super.getAPathArgument() }
 
-  CopyFile() { this = range }
-
-  DataFlow::Node getAPathArgument() { result = range.getAPathArgument() }
-
-  DataFlow::Node getfsrcArgument() { result = range.getfsrcArgument() }
+  DataFlow::Node getfsrcArgument() { result = super.getfsrcArgument() }
 }
 
 /** Provides classes for modeling log related APIs. */
@@ -74,12 +70,8 @@ module LogOutput {
  * Extend this class to refine existing API models. If you want to model new APIs,
  * extend `LogOutput::Range` instead.
  */
-class LogOutput extends DataFlow::Node {
-  LogOutput::Range range;
-
-  LogOutput() { this = range }
-
-  DataFlow::Node getAnInput() { result = range.getAnInput() }
+class LogOutput extends DataFlow::Node instanceof LogOutput::Range {
+  DataFlow::Node getAnInput() { result = super.getAnInput() }
 }
 
 /** Provides classes for modeling LDAP query execution-related APIs. */
@@ -107,15 +99,11 @@ deprecated module LDAPQuery = LdapQuery;
  * Extend this class to refine existing API models. If you want to model new APIs,
  * extend `LDAPQuery::Range` instead.
  */
-class LdapQuery extends DataFlow::Node {
-  LdapQuery::Range range;
-
-  LdapQuery() { this = range }
-
+class LdapQuery extends DataFlow::Node instanceof LdapQuery::Range {
   /**
    * Gets the argument containing the executed expression.
    */
-  DataFlow::Node getQuery() { result = range.getQuery() }
+  DataFlow::Node getQuery() { result = super.getQuery() }
 }
 
 /** DEPRECATED: Alias for LdapQuery */
@@ -146,15 +134,11 @@ deprecated module LDAPEscape = LdapEscape;
  * Extend this class to refine existing API models. If you want to model new APIs,
  * extend `LDAPEscape::Range` instead.
  */
-class LdapEscape extends DataFlow::Node {
-  LdapEscape::Range range;
-
-  LdapEscape() { this = range }
-
+class LdapEscape extends DataFlow::Node instanceof LdapEscape::Range {
   /**
    * Gets the argument containing the escaped expression.
    */
-  DataFlow::Node getAnInput() { result = range.getAnInput() }
+  DataFlow::Node getAnInput() { result = super.getAnInput() }
 }
 
 /** DEPRECATED: Alias for LdapEscape */
@@ -198,25 +182,21 @@ deprecated module LDAPBind = LdapBind;
  * Extend this class to refine existing API models. If you want to model new APIs,
  * extend `LDAPBind::Range` instead.
  */
-class LdapBind extends DataFlow::Node {
-  LdapBind::Range range;
-
-  LdapBind() { this = range }
-
+class LdapBind extends DataFlow::Node instanceof LdapBind::Range {
   /**
    * Gets the argument containing the binding host.
    */
-  DataFlow::Node getHost() { result = range.getHost() }
+  DataFlow::Node getHost() { result = super.getHost() }
 
   /**
    * Gets the argument containing the binding expression.
    */
-  DataFlow::Node getPassword() { result = range.getPassword() }
+  DataFlow::Node getPassword() { result = super.getPassword() }
 
   /**
    * Holds if the binding process use SSL.
    */
-  predicate useSsl() { range.useSsl() }
+  predicate useSsl() { super.useSsl() }
 
   /** DEPRECATED: Alias for useSsl */
   deprecated predicate useSSL() { useSsl() }
@@ -250,15 +230,11 @@ deprecated module SQLEscape = SqlEscape;
  * Extend this class to refine existing API models. If you want to model new APIs,
  * extend `SQLEscape::Range` instead.
  */
-class SqlEscape extends DataFlow::Node {
-  SqlEscape::Range range;
-
-  SqlEscape() { this = range }
-
+class SqlEscape extends DataFlow::Node instanceof SqlEscape::Range {
   /**
    * Gets the argument containing the raw SQL statement.
    */
-  DataFlow::Node getAnInput() { result = range.getAnInput() }
+  DataFlow::Node getAnInput() { result = super.getAnInput() }
 }
 
 /** DEPRECATED: Alias for SqlEscape */
@@ -287,13 +263,9 @@ deprecated module NoSQLQuery = NoSqlQuery;
  * Extend this class to refine existing API models. If you want to model new APIs,
  * extend `NoSQLQuery::Range` instead.
  */
-class NoSqlQuery extends DataFlow::Node {
-  NoSqlQuery::Range range;
-
-  NoSqlQuery() { this = range }
-
+class NoSqlQuery extends DataFlow::Node instanceof NoSqlQuery::Range {
   /** Gets the argument that specifies the NoSql query to be executed. */
-  DataFlow::Node getQuery() { result = range.getQuery() }
+  DataFlow::Node getQuery() { result = super.getQuery() }
 }
 
 /** DEPRECATED: Alias for NoSqlQuery */
@@ -322,13 +294,9 @@ deprecated module NoSQLSanitizer = NoSqlSanitizer;
  * Extend this class to model new APIs. If you want to refine existing API models,
  * extend `NoSQLSanitizer::Range` instead.
  */
-class NoSqlSanitizer extends DataFlow::Node {
-  NoSqlSanitizer::Range range;
-
-  NoSqlSanitizer() { this = range }
-
+class NoSqlSanitizer extends DataFlow::Node instanceof NoSqlSanitizer::Range {
   /** Gets the argument that specifies the NoSql query to be sanitized. */
-  DataFlow::Node getAnInput() { result = range.getAnInput() }
+  DataFlow::Node getAnInput() { result = super.getAnInput() }
 }
 
 /** DEPRECATED: Alias for NoSqlSanitizer */
@@ -361,20 +329,16 @@ module HeaderDeclaration {
  * Extend this class to refine existing API models. If you want to model new APIs,
  * extend `HeaderDeclaration::Range` instead.
  */
-class HeaderDeclaration extends DataFlow::Node {
-  HeaderDeclaration::Range range;
-
-  HeaderDeclaration() { this = range }
-
+class HeaderDeclaration extends DataFlow::Node instanceof HeaderDeclaration::Range {
   /**
    * Gets the argument containing the header name.
    */
-  DataFlow::Node getNameArg() { result = range.getNameArg() }
+  DataFlow::Node getNameArg() { result = super.getNameArg() }
 
   /**
    * Gets the argument containing the header value.
    */
-  DataFlow::Node getValueArg() { result = range.getValueArg() }
+  DataFlow::Node getValueArg() { result = super.getValueArg() }
 }
 
 /** Provides classes for modeling Csv writer APIs. */
@@ -399,15 +363,11 @@ module CsvWriter {
  * Extend this class to refine existing API models. If you want to model new APIs,
  * extend `CsvWriter::Range` instead.
  */
-class CsvWriter extends DataFlow::Node {
-  CsvWriter::Range range;
-
-  CsvWriter() { this = range }
-
+class CsvWriter extends DataFlow::Node instanceof CsvWriter::Range {
   /**
    * Get the parameter value of the csv writer function.
    */
-  DataFlow::Node getAnInput() { result = range.getAnInput() }
+  DataFlow::Node getAnInput() { result = super.getAnInput() }
 }
 
 /**

--- a/python/ql/src/experimental/semmle/python/CookieHeader.qll
+++ b/python/ql/src/experimental/semmle/python/CookieHeader.qll
@@ -28,7 +28,6 @@ import experimental.semmle.python.Concepts
  */
 class CookieHeader extends Cookie::Range instanceof HeaderDeclaration {
   CookieHeader() {
-    this instanceof HeaderDeclaration and
     exists(StrConst str |
       str.getText() = "Set-Cookie" and
       DataFlow::exprNode(str)

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
@@ -1289,9 +1289,7 @@ private module PostUpdateNodes {
 private import PostUpdateNodes
 
 /** A node that performs a type cast. */
-class CastNode extends Node {
-  CastNode() { this instanceof ReturningNode }
-}
+class CastNode extends Node instanceof ReturningNode { }
 
 class DataFlowExpr = CfgNodes::ExprCfgNode;
 

--- a/ruby/ql/lib/codeql/ruby/frameworks/http_clients/OpenURI.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/http_clients/OpenURI.qll
@@ -62,11 +62,8 @@ class OpenUriRequest extends Http::Client::Request::Range, DataFlow::CallNode {
  * Kernel.open("http://example.com").read
  * ```
  */
-class OpenUriKernelOpenRequest extends Http::Client::Request::Range, DataFlow::CallNode {
-  OpenUriKernelOpenRequest() {
-    this instanceof KernelMethodCall and
-    this.getMethodName() = "open"
-  }
+class OpenUriKernelOpenRequest extends Http::Client::Request::Range, DataFlow::CallNode instanceof KernelMethodCall {
+  OpenUriKernelOpenRequest() { this.getMethodName() = "open" }
 
   override DataFlow::Node getAUrlPart() { result = this.getArgument(0) }
 

--- a/ruby/ql/lib/codeql/ruby/security/CommandInjectionCustomizations.qll
+++ b/ruby/ql/lib/codeql/ruby/security/CommandInjectionCustomizations.qll
@@ -30,9 +30,7 @@ module CommandInjection {
   abstract class Sanitizer extends DataFlow::Node { }
 
   /** A source of remote user input, considered as a flow source for command injection. */
-  class RemoteFlowSourceAsSource extends Source {
-    RemoteFlowSourceAsSource() { this instanceof RemoteFlowSource }
-
+  class RemoteFlowSourceAsSource extends Source instanceof RemoteFlowSource {
     override string getSourceType() { result = "user-provided value" }
   }
 

--- a/ruby/ql/lib/codeql/ruby/security/ConditionalBypassCustomizations.qll
+++ b/ruby/ql/lib/codeql/ruby/security/ConditionalBypassCustomizations.qll
@@ -37,9 +37,7 @@ module ConditionalBypass {
    * A source of remote user input, considered as a flow source for bypass of
    * sensitive action guards.
    */
-  class RemoteFlowSourceAsSource extends Source {
-    RemoteFlowSourceAsSource() { this instanceof RemoteFlowSource }
-  }
+  class RemoteFlowSourceAsSource extends Source instanceof RemoteFlowSource { }
 
   /**
    * A conditional that guards a sensitive action, e.g. `ok` in `if (ok) login()`.

--- a/ruby/ql/lib/codeql/ruby/security/HardcodedDataInterpretedAsCodeCustomizations.qll
+++ b/ruby/ql/lib/codeql/ruby/security/HardcodedDataInterpretedAsCodeCustomizations.qll
@@ -87,9 +87,7 @@ module HardcodedDataInterpretedAsCode {
   /**
    * A code injection sink; hard-coded data should not flow here.
    */
-  private class DefaultCodeInjectionSink extends Sink {
-    DefaultCodeInjectionSink() { this instanceof CodeInjection::Sink }
-
+  private class DefaultCodeInjectionSink extends Sink instanceof CodeInjection::Sink {
     override string getKind() { result = "code" }
   }
 

--- a/ruby/ql/lib/codeql/ruby/security/ServerSideRequestForgeryCustomizations.qll
+++ b/ruby/ql/lib/codeql/ruby/security/ServerSideRequestForgeryCustomizations.qll
@@ -39,9 +39,7 @@ module ServerSideRequestForgery {
   abstract deprecated class SanitizerGuard extends DataFlow::BarrierGuard { }
 
   /** A source of remote user input, considered as a flow source for server side request forgery. */
-  class RemoteFlowSourceAsSource extends Source {
-    RemoteFlowSourceAsSource() { this instanceof RemoteFlowSource }
-  }
+  class RemoteFlowSourceAsSource extends Source instanceof RemoteFlowSource { }
 
   /** The URL of an HTTP request, considered as a sink. */
   class HttpRequestAsSink extends Sink {

--- a/ruby/ql/lib/codeql/ruby/security/UnsafeDeserializationCustomizations.qll
+++ b/ruby/ql/lib/codeql/ruby/security/UnsafeDeserializationCustomizations.qll
@@ -35,9 +35,7 @@ module UnsafeDeserialization {
   }
 
   /** A source of remote user input, considered as a flow source for unsafe deserialization. */
-  class RemoteFlowSourceAsSource extends Source {
-    RemoteFlowSourceAsSource() { this instanceof RemoteFlowSource }
-  }
+  class RemoteFlowSourceAsSource extends Source instanceof RemoteFlowSource { }
 
   /**
    * An argument in a call to `Marshal.load` or `Marshal.restore`, considered a

--- a/ruby/ql/src/AlertSuppression.ql
+++ b/ruby/ql/src/AlertSuppression.ql
@@ -52,9 +52,7 @@ private string commentText(Ruby::Comment comment) { result = comment.getValue().
 /**
  * The scope of an alert suppression comment.
  */
-class SuppressionScope extends @ruby_token_comment {
-  SuppressionScope() { this instanceof SuppressionComment }
-
+class SuppressionScope extends @ruby_token_comment instanceof SuppressionComment {
   /** Gets a suppression comment with this scope. */
   SuppressionComment getSuppressionComment() { result = this }
 
@@ -68,7 +66,7 @@ class SuppressionScope extends @ruby_token_comment {
   predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    this.(SuppressionComment).covers(filepath, startline, startcolumn, endline, endcolumn)
+    super.covers(filepath, startline, startcolumn, endline, endcolumn)
   }
 
   /** Gets a textual representation of this element. */


### PR DESCRIPTION
Uses `instanceof` clauses in more classes as preparation for enabling a QL-for-QL query that suggests using `instanceof`. 

Some of this was written automatically, some was written manually.  

Evaluations: ([Ruby](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/PR-11630-6-ruby/reports), [JavaScript](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/PR-11630-4-javascript/reports), [Python](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/PR-11630-5-python__1/reports)) were uneventful.  

I didn't touch `ObjectAPI.qll` in Python as that caused weird errors I didn't want to deal with.  