### PR TITLE
ATM: speedup the "ATM - Check query suite" CI job

### DIFF
--- a/.github/workflows/atm-check-query-suite.yml
+++ b/.github/workflows/atm-check-query-suite.yml
@@ -57,6 +57,7 @@ jobs:
 
           codeql database analyze \
             --threads=0 \
+            --ram 50000 \
             --format sarif-latest \
             --output "${SARIF_PATH}" \
             --sarif-group-rules-by-pack \

--- a/.github/workflows/atm-check-query-suite.yml
+++ b/.github/workflows/atm-check-query-suite.yml
@@ -56,6 +56,7 @@ jobs:
           echo "SARIF_PATH=${SARIF_PATH}" >> "${GITHUB_ENV}"
 
           codeql database analyze \
+            --threads=0 \
             --format sarif-latest \
             --output "${SARIF_PATH}" \
             --sarif-group-rules-by-pack \

--- a/.github/workflows/atm-check-query-suite.yml
+++ b/.github/workflows/atm-check-query-suite.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   atm-check-query-suite:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-xl
 
     steps:
       - uses: actions/checkout@v3
@@ -22,6 +22,12 @@ jobs:
         uses: ./.github/actions/fetch-codeql
         with:
           channel: release
+
+      - name: Cache compilation cache
+        id: query-cache
+        uses: ./.github/actions/cache-query-compilation
+        with: 
+          key: atm-suite
 
       - name: Install ATM model
         run: |
@@ -54,6 +60,7 @@ jobs:
             --output "${SARIF_PATH}" \
             --sarif-group-rules-by-pack \
             -vv \
+            --compilation-cache "${{ steps.query-cache.outputs.cache-dir }}" \
             -- \
             "${DB_PATH}" \
             "${QUERY_PACK}/${QUERY_SUITE}"


### PR DESCRIPTION
I just opened https://github.com/github/codeql/pull/11660, where I noticed that the `Check query suite` ATM check was the slowest ATM check.  

This should speed it up significantly.  