### PR TITLE
Swift/C++: Use instanceof in more places

### DIFF
--- a/cpp/ql/lib/experimental/semmle/code/cpp/semantic/SemanticExprSpecific.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/semantic/SemanticExprSpecific.qll
@@ -286,7 +286,15 @@ module SemanticExprConfig {
     )
   }
 
-  class Bound = IRBound::Bound;
+  class Bound instanceof IRBound::Bound {
+    string toString() { result = super.toString() }
+
+    final Location getLocation() { result = super.getLocation() }
+  }
+
+  private class ValueNumberBound extends Bound instanceof IRBound::ValueNumberBound {
+    override string toString() { result = IRBound::ValueNumberBound.super.toString() }
+  }
 
   predicate zeroBound(Bound bound) { bound instanceof IRBound::ZeroBound }
 

--- a/cpp/ql/lib/experimental/semmle/code/cpp/semantic/SemanticExprSpecific.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/semantic/SemanticExprSpecific.qll
@@ -286,19 +286,7 @@ module SemanticExprConfig {
     )
   }
 
-  class Bound instanceof IRBound::Bound {
-    string toString() { result = super.toString() }
-
-    final Location getLocation() { result = super.getLocation() }
-  }
-
-  private class ValueNumberBound extends Bound {
-    IRBound::ValueNumberBound bound;
-
-    ValueNumberBound() { bound = this }
-
-    override string toString() { result = bound.toString() }
-  }
+  class Bound = IRBound::Bound;
 
   predicate zeroBound(Bound bound) { bound instanceof IRBound::ZeroBound }
 

--- a/cpp/ql/lib/experimental/semmle/code/cpp/semantic/analysis/SignAnalysisCommon.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/semantic/analysis/SignAnalysisCommon.qll
@@ -33,23 +33,15 @@ abstract private class FlowSignDef extends SignDef {
 }
 
 /** An SSA definition whose sign is determined by the sign of that definitions source expression. */
-private class ExplicitSignDef extends FlowSignDef {
-  SemSsaExplicitUpdate update;
-
-  ExplicitSignDef() { update = this }
-
-  final override Sign getSign() { result = semExprSign(update.getSourceExpr()) }
+private class ExplicitSignDef extends FlowSignDef instanceof SemSsaExplicitUpdate {
+  final override Sign getSign() { result = semExprSign(super.getSourceExpr()) }
 }
 
 /** An SSA Phi definition, whose sign is the union of the signs of its inputs. */
-private class PhiSignDef extends FlowSignDef {
-  SemSsaPhiNode phi;
-
-  PhiSignDef() { phi = this }
-
+private class PhiSignDef extends FlowSignDef instanceof SemSsaPhiNode {
   final override Sign getSign() {
     exists(SemSsaVariable inp, SemSsaReadPositionPhiInputEdge edge |
-      edge.phiInput(phi, inp) and
+      edge.phiInput(this, inp) and
       result = semSsaSign(inp, edge)
     )
   }

--- a/cpp/ql/lib/semmle/code/cpp/commons/Printf.qll
+++ b/cpp/ql/lib/semmle/code/cpp/commons/Printf.qll
@@ -397,11 +397,8 @@ private int lengthInBase16(float f) {
 /**
  * A class to represent format strings that occur as arguments to invocations of formatting functions.
  */
-class FormatLiteral extends Literal {
-  FormatLiteral() {
-    exists(FormattingFunctionCall ffc | ffc.getFormat() = this) and
-    this instanceof StringLiteral
-  }
+class FormatLiteral extends Literal instanceof StringLiteral {
+  FormatLiteral() { exists(FormattingFunctionCall ffc | ffc.getFormat() = this) }
 
   /**
    * Gets the function call where this format string is used.

--- a/cpp/ql/lib/semmle/code/cpp/commons/Scanf.qll
+++ b/cpp/ql/lib/semmle/code/cpp/commons/Scanf.qll
@@ -30,15 +30,12 @@ abstract class ScanfFunction extends Function {
 /**
  * The standard function `scanf` (and variations).
  */
-class Scanf extends ScanfFunction {
+class Scanf extends ScanfFunction instanceof TopLevelFunction {
   Scanf() {
-    this instanceof TopLevelFunction and
-    (
-      this.hasGlobalOrStdOrBslName("scanf") or // scanf(format, args...)
-      this.hasGlobalOrStdOrBslName("wscanf") or // wscanf(format, args...)
-      this.hasGlobalName("_scanf_l") or // _scanf_l(format, locale, args...)
-      this.hasGlobalName("_wscanf_l") // _wscanf_l(format, locale, args...)
-    )
+    this.hasGlobalOrStdOrBslName("scanf") or // scanf(format, args...)
+    this.hasGlobalOrStdOrBslName("wscanf") or // wscanf(format, args...)
+    this.hasGlobalName("_scanf_l") or // _scanf_l(format, locale, args...)
+    this.hasGlobalName("_wscanf_l")
   }
 
   override int getInputParameterIndex() { none() }
@@ -49,15 +46,12 @@ class Scanf extends ScanfFunction {
 /**
  * The standard function `fscanf` (and variations).
  */
-class Fscanf extends ScanfFunction {
+class Fscanf extends ScanfFunction instanceof TopLevelFunction {
   Fscanf() {
-    this instanceof TopLevelFunction and
-    (
-      this.hasGlobalOrStdOrBslName("fscanf") or // fscanf(src_stream, format, args...)
-      this.hasGlobalOrStdOrBslName("fwscanf") or // fwscanf(src_stream, format, args...)
-      this.hasGlobalName("_fscanf_l") or // _fscanf_l(src_stream, format, locale, args...)
-      this.hasGlobalName("_fwscanf_l") // _fwscanf_l(src_stream, format, locale, args...)
-    )
+    this.hasGlobalOrStdOrBslName("fscanf") or // fscanf(src_stream, format, args...)
+    this.hasGlobalOrStdOrBslName("fwscanf") or // fwscanf(src_stream, format, args...)
+    this.hasGlobalName("_fscanf_l") or // _fscanf_l(src_stream, format, locale, args...)
+    this.hasGlobalName("_fwscanf_l")
   }
 
   override int getInputParameterIndex() { result = 0 }
@@ -68,15 +62,12 @@ class Fscanf extends ScanfFunction {
 /**
  * The standard function `sscanf` (and variations).
  */
-class Sscanf extends ScanfFunction {
+class Sscanf extends ScanfFunction instanceof TopLevelFunction {
   Sscanf() {
-    this instanceof TopLevelFunction and
-    (
-      this.hasGlobalOrStdOrBslName("sscanf") or // sscanf(src_stream, format, args...)
-      this.hasGlobalOrStdOrBslName("swscanf") or // swscanf(src, format, args...)
-      this.hasGlobalName("_sscanf_l") or // _sscanf_l(src, format, locale, args...)
-      this.hasGlobalName("_swscanf_l") // _swscanf_l(src, format, locale, args...)
-    )
+    this.hasGlobalOrStdOrBslName("sscanf") or // sscanf(src_stream, format, args...)
+    this.hasGlobalOrStdOrBslName("swscanf") or // swscanf(src, format, args...)
+    this.hasGlobalName("_sscanf_l") or // _sscanf_l(src, format, locale, args...)
+    this.hasGlobalName("_swscanf_l")
   }
 
   override int getInputParameterIndex() { result = 0 }
@@ -87,17 +78,12 @@ class Sscanf extends ScanfFunction {
 /**
  * The standard(ish) function `snscanf` (and variations).
  */
-class Snscanf extends ScanfFunction {
+class Snscanf extends ScanfFunction instanceof TopLevelFunction {
   Snscanf() {
-    this instanceof TopLevelFunction and
-    (
-      this.hasGlobalName("_snscanf") or // _snscanf(src, max_amount, format, args...)
-      this.hasGlobalName("_snwscanf") or // _snwscanf(src, max_amount, format, args...)
-      this.hasGlobalName("_snscanf_l") or // _snscanf_l(src, max_amount, format, locale, args...)
-      this.hasGlobalName("_snwscanf_l") // _snwscanf_l(src, max_amount, format, locale, args...)
-      // note that the max_amount is not a limit on the output length, it's an input length
-      // limit used with non null-terminated strings.
-    )
+    this.hasGlobalName("_snscanf") or // _snscanf(src, max_amount, format, args...)
+    this.hasGlobalName("_snwscanf") or // _snwscanf(src, max_amount, format, args...)
+    this.hasGlobalName("_snscanf_l") or // _snscanf_l(src, max_amount, format, locale, args...)
+    this.hasGlobalName("_snwscanf_l")
   }
 
   override int getInputParameterIndex() { result = 0 }

--- a/cpp/ql/src/JPL_C/LOC-4/Rule 23/MismatchedIfdefs.ql
+++ b/cpp/ql/src/JPL_C/LOC-4/Rule 23/MismatchedIfdefs.ql
@@ -66,9 +66,7 @@ class ElseDirective extends Directive {
   override predicate mismatched() { depth() < 1 }
 }
 
-class EndifDirective extends Directive {
-  EndifDirective() { this instanceof PreprocessorEndif }
-
+class EndifDirective extends Directive instanceof PreprocessorEndif {
   override int depthChange() { result = -1 }
 
   override predicate mismatched() { depth() < 0 }

--- a/cpp/ql/test/query-tests/Metrics/Dependencies/TestPackage.qll
+++ b/cpp/ql/test/query-tests/Metrics/Dependencies/TestPackage.qll
@@ -3,10 +3,8 @@ import Metrics.Dependencies.ExternalDependencies
 /**
  * Count directories as libraries for testing purposes.
  */
-class TestPackage extends LibraryElement {
-  TestPackage() { this instanceof Folder }
-
-  override string getName() { result = this.(Folder).getBaseName() }
+class TestPackage extends LibraryElement instanceof Folder {
+  override string getName() { result = super.getBaseName() }
 
   override string getVersion() { result = "1.0" }
 

--- a/swift/ql/lib/codeql/swift/elements/expr/ArithmeticOperation.qll
+++ b/swift/ql/lib/codeql/swift/elements/expr/ArithmeticOperation.qll
@@ -97,9 +97,7 @@ class RemExpr extends BinaryExpr {
  * -a
  * ```
  */
-class UnaryArithmeticOperation extends PrefixUnaryExpr {
-  UnaryArithmeticOperation() { this instanceof UnaryMinusExpr }
-}
+class UnaryArithmeticOperation extends PrefixUnaryExpr instanceof UnaryMinusExpr { }
 
 /**
  * A unary minus expression.

--- a/swift/ql/lib/codeql/swift/elements/expr/LogicalOperation.qll
+++ b/swift/ql/lib/codeql/swift/elements/expr/LogicalOperation.qll
@@ -30,9 +30,7 @@ class NotExpr extends PrefixUnaryExpr {
   NotExpr() { unaryHasName(this, "!(_:)") }
 }
 
-class UnaryLogicalOperation extends PrefixUnaryExpr {
-  UnaryLogicalOperation() { this instanceof NotExpr }
-}
+class UnaryLogicalOperation extends PrefixUnaryExpr instanceof NotExpr { }
 
 class LogicalOperation extends Expr {
   LogicalOperation() {


### PR DESCRIPTION
Uses `instanceof` clauses in more classes as preparation for enabling a QL-for-QL query that suggests using `instanceof`. 

Some of this was written automatically, some was written manually.  

Evaluations:  
 - [CPP](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/PR-11630-0-cpp/reports): There is some performance noise, but I can't replicate locally (I tried to replicate the `cpp/badly-bounded-write` regression reported by stage-timings, there was nothing), so I think we're good?    
 - [Swift](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/PR-11630-7-swift__2/reports): Some more performance noise, but in a positive direction, so that's good? 🤷 