### PR TITLE
Java: update `isJdkInternal`

### DIFF
--- a/java/ql/src/utils/modelgenerator/internal/CaptureModelsSpecific.qll
+++ b/java/ql/src/utils/modelgenerator/internal/CaptureModelsSpecific.qll
@@ -40,11 +40,11 @@ private predicate isJdkInternal(J::CompilationUnit cu) {
   cu.getPackage().getName().matches("java.awt%") or
   cu.getPackage().getName().matches("sun%") or
   cu.getPackage().getName().matches("jdk%") or
-  cu.getPackage().getName().matches("java2d.%") or
-  cu.getPackage().getName().matches("build.tools.%") or
+  cu.getPackage().getName().matches("java2d%") or
+  cu.getPackage().getName().matches("build.tools%") or
   cu.getPackage().getName().matches("propertiesparser%") or
-  cu.getPackage().getName().matches("org.jcp.%") or
-  cu.getPackage().getName().matches("org.w3c.%") or
+  cu.getPackage().getName().matches("org.jcp%") or
+  cu.getPackage().getName().matches("org.w3c%") or
   cu.getPackage().getName().matches("org.ietf.jgss%") or
   cu.getPackage().getName().matches("org.xml.sax%") or
   cu.getPackage().getName().matches("com.oracle%") or

--- a/java/ql/src/utils/modelgenerator/internal/CaptureModelsSpecific.qll
+++ b/java/ql/src/utils/modelgenerator/internal/CaptureModelsSpecific.qll
@@ -39,15 +39,20 @@ private predicate isJdkInternal(J::CompilationUnit cu) {
   cu.getPackage().getName().matches("javax.swing%") or
   cu.getPackage().getName().matches("java.awt%") or
   cu.getPackage().getName().matches("sun%") or
-  cu.getPackage().getName().matches("jdk.%") or
+  cu.getPackage().getName().matches("jdk%") or
   cu.getPackage().getName().matches("java2d.%") or
   cu.getPackage().getName().matches("build.tools.%") or
-  cu.getPackage().getName().matches("propertiesparser.%") or
+  cu.getPackage().getName().matches("propertiesparser%") or
   cu.getPackage().getName().matches("org.jcp.%") or
   cu.getPackage().getName().matches("org.w3c.%") or
-  cu.getPackage().getName().matches("org.ietf.jgss.%") or
+  cu.getPackage().getName().matches("org.ietf.jgss%") or
   cu.getPackage().getName().matches("org.xml.sax%") or
+  cu.getPackage().getName().matches("com.oracle%") or
+  cu.getPackage().getName().matches("org.omg%") or
+  cu.getPackage().getName().matches("org.relaxng%") or
   cu.getPackage().getName() = "compileproperties" or
+  cu.getPackage().getName() = "transparentruler" or
+  cu.getPackage().getName() = "genstubs" or
   cu.getPackage().getName() = "netscape.javascript" or
   cu.getPackage().getName() = ""
 }


### PR DESCRIPTION
This PR updates `isJdkInternal` in `CaptureModelsSpecific.qll` with additional packages.

These additions are based on the results of running the below query against jdk8 and jdk11 databases. 
Let me know if any of these updates look incorrect.
```
from DataFlowTargetApi dfta, string package
where package = dfta.getDeclaringType().getPackage().toString()
select package order by package
```
