### PR TITLE
C++: Recognize indirect `argv` accesses as flow sources for use-use dataflow

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/security/FlowSources.qll
+++ b/cpp/ql/lib/semmle/code/cpp/security/FlowSources.qll
@@ -53,7 +53,7 @@ private class ArgvSource extends LocalFlowSource {
     exists(Function main, Parameter argv |
       main.hasGlobalName("main") and
       main.getParameter(1) = argv and
-      this.asExpr() = argv.getAnAccess()
+      argv.getAnAccess() in [this.asExpr(), this.asIndirectExpr()]
     )
   }
 

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-078/semmle/ExecTainted/ExecTainted.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-078/semmle/ExecTainted/ExecTainted.expected
@@ -1,4 +1,8 @@
 edges
+| test.cpp:16:20:16:23 | argv indirection | test.cpp:22:45:22:52 | Load indirection |
+| test.cpp:16:20:16:23 | argv indirection | test.cpp:22:45:22:52 | Load indirection |
+| test.cpp:22:13:22:20 | sprintf output argument | test.cpp:23:12:23:19 | Convert indirection |
+| test.cpp:22:45:22:52 | Load indirection | test.cpp:22:13:22:20 | sprintf output argument |
 | test.cpp:47:21:47:26 | call to getenv indirection | test.cpp:50:35:50:43 | Load indirection |
 | test.cpp:50:11:50:17 | sprintf output argument | test.cpp:51:10:51:16 | Convert indirection |
 | test.cpp:50:35:50:43 | Load indirection | test.cpp:50:11:50:17 | sprintf output argument |
@@ -97,6 +101,11 @@ edges
 | test.cpp:220:19:220:26 | Convert indirection | test.cpp:220:10:220:16 | strncat output argument |
 | test.cpp:220:19:220:26 | Convert indirection | test.cpp:220:10:220:16 | strncat output argument |
 nodes
+| test.cpp:16:20:16:23 | argv indirection | semmle.label | argv indirection |
+| test.cpp:16:20:16:23 | argv indirection | semmle.label | argv indirection |
+| test.cpp:22:13:22:20 | sprintf output argument | semmle.label | sprintf output argument |
+| test.cpp:22:45:22:52 | Load indirection | semmle.label | Load indirection |
+| test.cpp:23:12:23:19 | Convert indirection | semmle.label | Convert indirection |
 | test.cpp:47:21:47:26 | call to getenv indirection | semmle.label | call to getenv indirection |
 | test.cpp:50:11:50:17 | sprintf output argument | semmle.label | sprintf output argument |
 | test.cpp:50:35:50:43 | Load indirection | semmle.label | Load indirection |
@@ -202,6 +211,8 @@ subpaths
 | test.cpp:196:26:196:33 | filename | test.cpp:186:47:186:54 | filename | test.cpp:187:11:187:15 | strncat output argument | test.cpp:196:19:196:23 | concat output argument |
 | test.cpp:196:26:196:33 | filename | test.cpp:186:47:186:54 | filename | test.cpp:188:11:188:17 | strncat output argument | test.cpp:196:10:196:16 | concat output argument |
 #select
+| test.cpp:23:12:23:19 | command1 | test.cpp:16:20:16:23 | argv indirection | test.cpp:23:12:23:19 | Convert indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to system(string). | test.cpp:16:20:16:23 | argv indirection | user input (a command-line argument) | test.cpp:22:13:22:20 | sprintf output argument | sprintf output argument |
+| test.cpp:23:12:23:19 | command1 | test.cpp:16:20:16:23 | argv indirection | test.cpp:23:12:23:19 | Convert indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to system(string). | test.cpp:16:20:16:23 | argv indirection | user input (a command-line argument) | test.cpp:22:13:22:20 | sprintf output argument | sprintf output argument |
 | test.cpp:51:10:51:16 | command | test.cpp:47:21:47:26 | call to getenv indirection | test.cpp:51:10:51:16 | Convert indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to system(string). | test.cpp:47:21:47:26 | call to getenv indirection | user input (an environment variable) | test.cpp:50:11:50:17 | sprintf output argument | sprintf output argument |
 | test.cpp:65:10:65:16 | command | test.cpp:62:9:62:16 | fread output argument | test.cpp:65:10:65:16 | Convert indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to system(string). | test.cpp:62:9:62:16 | fread output argument | user input (string read by fread) | test.cpp:64:11:64:17 | strncat output argument | strncat output argument |
 | test.cpp:85:32:85:38 | command | test.cpp:82:9:82:16 | fread output argument | test.cpp:85:32:85:38 | Convert indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to execl. | test.cpp:82:9:82:16 | fread output argument | user input (string read by fread) | test.cpp:84:11:84:17 | strncat output argument | strncat output argument |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-119/semmle/tests/OverflowDestination.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-119/semmle/tests/OverflowDestination.expected
@@ -1,5 +1,7 @@
 edges
 | overflowdestination.cpp:27:9:27:12 | argv | overflowdestination.cpp:30:17:30:20 | arg1 |
+| overflowdestination.cpp:27:9:27:12 | argv indirection | overflowdestination.cpp:30:17:30:20 | arg1 |
+| overflowdestination.cpp:27:9:27:12 | argv indirection | overflowdestination.cpp:30:17:30:20 | arg1 |
 | overflowdestination.cpp:43:8:43:10 | fgets output argument | overflowdestination.cpp:46:15:46:17 | src |
 | overflowdestination.cpp:50:52:50:54 | src | overflowdestination.cpp:52:9:52:12 | memcpy output argument |
 | overflowdestination.cpp:50:52:50:54 | src | overflowdestination.cpp:53:9:53:12 | memcpy output argument |
@@ -60,6 +62,8 @@ edges
 | overflowdestination.cpp:76:30:76:32 | src | overflowdestination.cpp:76:30:76:32 | overflowdest_test3 output argument |
 nodes
 | overflowdestination.cpp:27:9:27:12 | argv | semmle.label | argv |
+| overflowdestination.cpp:27:9:27:12 | argv indirection | semmle.label | argv indirection |
+| overflowdestination.cpp:27:9:27:12 | argv indirection | semmle.label | argv indirection |
 | overflowdestination.cpp:30:17:30:20 | arg1 | semmle.label | arg1 |
 | overflowdestination.cpp:43:8:43:10 | fgets output argument | semmle.label | fgets output argument |
 | overflowdestination.cpp:46:15:46:17 | src | semmle.label | src |
@@ -118,6 +122,8 @@ subpaths
 | overflowdestination.cpp:76:30:76:32 | src | overflowdestination.cpp:57:52:57:54 | src | overflowdestination.cpp:65:9:65:13 | memcpy output argument | overflowdestination.cpp:76:30:76:32 | overflowdest_test3 output argument |
 #select
 | overflowdestination.cpp:30:2:30:8 | call to strncpy | overflowdestination.cpp:27:9:27:12 | argv | overflowdestination.cpp:30:17:30:20 | arg1 | To avoid overflow, this operation should be bounded by destination-buffer size, not source-buffer size. |
+| overflowdestination.cpp:30:2:30:8 | call to strncpy | overflowdestination.cpp:27:9:27:12 | argv indirection | overflowdestination.cpp:30:17:30:20 | arg1 | To avoid overflow, this operation should be bounded by destination-buffer size, not source-buffer size. |
+| overflowdestination.cpp:30:2:30:8 | call to strncpy | overflowdestination.cpp:27:9:27:12 | argv indirection | overflowdestination.cpp:30:17:30:20 | arg1 | To avoid overflow, this operation should be bounded by destination-buffer size, not source-buffer size. |
 | overflowdestination.cpp:46:2:46:7 | call to memcpy | overflowdestination.cpp:43:8:43:10 | fgets output argument | overflowdestination.cpp:46:15:46:17 | src | To avoid overflow, this operation should be bounded by destination-buffer size, not source-buffer size. |
 | overflowdestination.cpp:53:2:53:7 | call to memcpy | overflowdestination.cpp:73:8:73:10 | fgets output argument | overflowdestination.cpp:53:15:53:17 | src | To avoid overflow, this operation should be bounded by destination-buffer size, not source-buffer size. |
 | overflowdestination.cpp:64:2:64:7 | call to memcpy | overflowdestination.cpp:73:8:73:10 | fgets output argument | overflowdestination.cpp:64:16:64:19 | src2 | To avoid overflow, this operation should be bounded by destination-buffer size, not source-buffer size. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-129/semmle/ImproperArrayIndexValidation/ImproperArrayIndexValidation.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-129/semmle/ImproperArrayIndexValidation/ImproperArrayIndexValidation.expected
@@ -3,6 +3,14 @@ edges
 | test1.c:8:16:8:19 | argv | test1.c:11:9:11:9 | i |
 | test1.c:8:16:8:19 | argv | test1.c:12:9:12:9 | i |
 | test1.c:8:16:8:19 | argv | test1.c:13:9:13:9 | i |
+| test1.c:8:16:8:19 | argv indirection | test1.c:9:9:9:9 | i |
+| test1.c:8:16:8:19 | argv indirection | test1.c:9:9:9:9 | i |
+| test1.c:8:16:8:19 | argv indirection | test1.c:11:9:11:9 | i |
+| test1.c:8:16:8:19 | argv indirection | test1.c:11:9:11:9 | i |
+| test1.c:8:16:8:19 | argv indirection | test1.c:12:9:12:9 | i |
+| test1.c:8:16:8:19 | argv indirection | test1.c:12:9:12:9 | i |
+| test1.c:8:16:8:19 | argv indirection | test1.c:13:9:13:9 | i |
+| test1.c:8:16:8:19 | argv indirection | test1.c:13:9:13:9 | i |
 | test1.c:9:9:9:9 | i | test1.c:16:16:16:16 | i |
 | test1.c:11:9:11:9 | i | test1.c:32:16:32:16 | i |
 | test1.c:12:9:12:9 | i | test1.c:40:16:40:16 | i |
@@ -13,6 +21,8 @@ edges
 | test1.c:48:16:48:16 | i | test1.c:53:15:53:15 | j |
 nodes
 | test1.c:8:16:8:19 | argv | semmle.label | argv |
+| test1.c:8:16:8:19 | argv indirection | semmle.label | argv indirection |
+| test1.c:8:16:8:19 | argv indirection | semmle.label | argv indirection |
 | test1.c:9:9:9:9 | i | semmle.label | i |
 | test1.c:11:9:11:9 | i | semmle.label | i |
 | test1.c:12:9:12:9 | i | semmle.label | i |
@@ -28,6 +38,14 @@ nodes
 subpaths
 #select
 | test1.c:18:16:18:16 | i | test1.c:8:16:8:19 | argv | test1.c:18:16:18:16 | i | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:8:16:8:19 | argv | a command-line argument |
+| test1.c:18:16:18:16 | i | test1.c:8:16:8:19 | argv indirection | test1.c:18:16:18:16 | i | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:8:16:8:19 | argv indirection | a command-line argument |
+| test1.c:18:16:18:16 | i | test1.c:8:16:8:19 | argv indirection | test1.c:18:16:18:16 | i | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:8:16:8:19 | argv indirection | a command-line argument |
 | test1.c:33:11:33:11 | i | test1.c:8:16:8:19 | argv | test1.c:33:11:33:11 | i | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:8:16:8:19 | argv | a command-line argument |
+| test1.c:33:11:33:11 | i | test1.c:8:16:8:19 | argv indirection | test1.c:33:11:33:11 | i | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:8:16:8:19 | argv indirection | a command-line argument |
+| test1.c:33:11:33:11 | i | test1.c:8:16:8:19 | argv indirection | test1.c:33:11:33:11 | i | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:8:16:8:19 | argv indirection | a command-line argument |
 | test1.c:41:11:41:11 | i | test1.c:8:16:8:19 | argv | test1.c:41:11:41:11 | i | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:8:16:8:19 | argv | a command-line argument |
+| test1.c:41:11:41:11 | i | test1.c:8:16:8:19 | argv indirection | test1.c:41:11:41:11 | i | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:8:16:8:19 | argv indirection | a command-line argument |
+| test1.c:41:11:41:11 | i | test1.c:8:16:8:19 | argv indirection | test1.c:41:11:41:11 | i | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:8:16:8:19 | argv indirection | a command-line argument |
 | test1.c:53:15:53:15 | j | test1.c:8:16:8:19 | argv | test1.c:53:15:53:15 | j | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:8:16:8:19 | argv | a command-line argument |
+| test1.c:53:15:53:15 | j | test1.c:8:16:8:19 | argv indirection | test1.c:53:15:53:15 | j | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:8:16:8:19 | argv indirection | a command-line argument |
+| test1.c:53:15:53:15 | j | test1.c:8:16:8:19 | argv indirection | test1.c:53:15:53:15 | j | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:8:16:8:19 | argv indirection | a command-line argument |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/TaintedAllocationSize/TaintedAllocationSize.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/TaintedAllocationSize/TaintedAllocationSize.expected
@@ -5,6 +5,18 @@ edges
 | test.cpp:40:21:40:24 | argv | test.cpp:49:32:49:35 | size |
 | test.cpp:40:21:40:24 | argv | test.cpp:50:26:50:29 | size |
 | test.cpp:40:21:40:24 | argv | test.cpp:53:35:53:60 | ... * ... |
+| test.cpp:40:21:40:24 | argv indirection | test.cpp:43:38:43:44 | tainted |
+| test.cpp:40:21:40:24 | argv indirection | test.cpp:43:38:43:44 | tainted |
+| test.cpp:40:21:40:24 | argv indirection | test.cpp:44:38:44:63 | ... * ... |
+| test.cpp:40:21:40:24 | argv indirection | test.cpp:44:38:44:63 | ... * ... |
+| test.cpp:40:21:40:24 | argv indirection | test.cpp:46:38:46:63 | ... + ... |
+| test.cpp:40:21:40:24 | argv indirection | test.cpp:46:38:46:63 | ... + ... |
+| test.cpp:40:21:40:24 | argv indirection | test.cpp:49:32:49:35 | size |
+| test.cpp:40:21:40:24 | argv indirection | test.cpp:49:32:49:35 | size |
+| test.cpp:40:21:40:24 | argv indirection | test.cpp:50:26:50:29 | size |
+| test.cpp:40:21:40:24 | argv indirection | test.cpp:50:26:50:29 | size |
+| test.cpp:40:21:40:24 | argv indirection | test.cpp:53:35:53:60 | ... * ... |
+| test.cpp:40:21:40:24 | argv indirection | test.cpp:53:35:53:60 | ... * ... |
 | test.cpp:124:18:124:23 | call to getenv | test.cpp:128:24:128:41 | ... * ... |
 | test.cpp:124:18:124:31 | call to getenv indirection | test.cpp:128:24:128:41 | ... * ... |
 | test.cpp:133:19:133:24 | call to getenv | test.cpp:135:10:135:27 | ... * ... |
@@ -36,6 +48,8 @@ edges
 | test.cpp:338:19:338:32 | call to getenv indirection | test.cpp:342:25:342:43 | ... * ... |
 nodes
 | test.cpp:40:21:40:24 | argv | semmle.label | argv |
+| test.cpp:40:21:40:24 | argv indirection | semmle.label | argv indirection |
+| test.cpp:40:21:40:24 | argv indirection | semmle.label | argv indirection |
 | test.cpp:43:38:43:44 | tainted | semmle.label | tainted |
 | test.cpp:44:38:44:63 | ... * ... | semmle.label | ... * ... |
 | test.cpp:46:38:46:63 | ... + ... | semmle.label | ... + ... |
@@ -80,11 +94,23 @@ nodes
 subpaths
 #select
 | test.cpp:43:31:43:36 | call to malloc | test.cpp:40:21:40:24 | argv | test.cpp:43:38:43:44 | tainted | This allocation size is derived from $@ and might overflow. | test.cpp:40:21:40:24 | argv | user input (a command-line argument) |
+| test.cpp:43:31:43:36 | call to malloc | test.cpp:40:21:40:24 | argv indirection | test.cpp:43:38:43:44 | tainted | This allocation size is derived from $@ and might overflow. | test.cpp:40:21:40:24 | argv indirection | user input (a command-line argument) |
+| test.cpp:43:31:43:36 | call to malloc | test.cpp:40:21:40:24 | argv indirection | test.cpp:43:38:43:44 | tainted | This allocation size is derived from $@ and might overflow. | test.cpp:40:21:40:24 | argv indirection | user input (a command-line argument) |
 | test.cpp:44:31:44:36 | call to malloc | test.cpp:40:21:40:24 | argv | test.cpp:44:38:44:63 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:40:21:40:24 | argv | user input (a command-line argument) |
+| test.cpp:44:31:44:36 | call to malloc | test.cpp:40:21:40:24 | argv indirection | test.cpp:44:38:44:63 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:40:21:40:24 | argv indirection | user input (a command-line argument) |
+| test.cpp:44:31:44:36 | call to malloc | test.cpp:40:21:40:24 | argv indirection | test.cpp:44:38:44:63 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:40:21:40:24 | argv indirection | user input (a command-line argument) |
 | test.cpp:46:31:46:36 | call to malloc | test.cpp:40:21:40:24 | argv | test.cpp:46:38:46:63 | ... + ... | This allocation size is derived from $@ and might overflow. | test.cpp:40:21:40:24 | argv | user input (a command-line argument) |
+| test.cpp:46:31:46:36 | call to malloc | test.cpp:40:21:40:24 | argv indirection | test.cpp:46:38:46:63 | ... + ... | This allocation size is derived from $@ and might overflow. | test.cpp:40:21:40:24 | argv indirection | user input (a command-line argument) |
+| test.cpp:46:31:46:36 | call to malloc | test.cpp:40:21:40:24 | argv indirection | test.cpp:46:38:46:63 | ... + ... | This allocation size is derived from $@ and might overflow. | test.cpp:40:21:40:24 | argv indirection | user input (a command-line argument) |
 | test.cpp:49:25:49:30 | call to malloc | test.cpp:40:21:40:24 | argv | test.cpp:49:32:49:35 | size | This allocation size is derived from $@ and might overflow. | test.cpp:40:21:40:24 | argv | user input (a command-line argument) |
+| test.cpp:49:25:49:30 | call to malloc | test.cpp:40:21:40:24 | argv indirection | test.cpp:49:32:49:35 | size | This allocation size is derived from $@ and might overflow. | test.cpp:40:21:40:24 | argv indirection | user input (a command-line argument) |
+| test.cpp:49:25:49:30 | call to malloc | test.cpp:40:21:40:24 | argv indirection | test.cpp:49:32:49:35 | size | This allocation size is derived from $@ and might overflow. | test.cpp:40:21:40:24 | argv indirection | user input (a command-line argument) |
 | test.cpp:50:17:50:30 | new[] | test.cpp:40:21:40:24 | argv | test.cpp:50:26:50:29 | size | This allocation size is derived from $@ and might overflow. | test.cpp:40:21:40:24 | argv | user input (a command-line argument) |
+| test.cpp:50:17:50:30 | new[] | test.cpp:40:21:40:24 | argv indirection | test.cpp:50:26:50:29 | size | This allocation size is derived from $@ and might overflow. | test.cpp:40:21:40:24 | argv indirection | user input (a command-line argument) |
+| test.cpp:50:17:50:30 | new[] | test.cpp:40:21:40:24 | argv indirection | test.cpp:50:26:50:29 | size | This allocation size is derived from $@ and might overflow. | test.cpp:40:21:40:24 | argv indirection | user input (a command-line argument) |
 | test.cpp:53:21:53:27 | call to realloc | test.cpp:40:21:40:24 | argv | test.cpp:53:35:53:60 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:40:21:40:24 | argv | user input (a command-line argument) |
+| test.cpp:53:21:53:27 | call to realloc | test.cpp:40:21:40:24 | argv indirection | test.cpp:53:35:53:60 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:40:21:40:24 | argv indirection | user input (a command-line argument) |
+| test.cpp:53:21:53:27 | call to realloc | test.cpp:40:21:40:24 | argv indirection | test.cpp:53:35:53:60 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:40:21:40:24 | argv indirection | user input (a command-line argument) |
 | test.cpp:128:17:128:22 | call to malloc | test.cpp:124:18:124:23 | call to getenv | test.cpp:128:24:128:41 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:124:18:124:23 | call to getenv | user input (an environment variable) |
 | test.cpp:128:17:128:22 | call to malloc | test.cpp:124:18:124:31 | call to getenv indirection | test.cpp:128:24:128:41 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:124:18:124:31 | call to getenv indirection | user input (an environment variable) |
 | test.cpp:135:3:135:8 | call to malloc | test.cpp:133:19:133:24 | call to getenv | test.cpp:135:10:135:27 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:133:19:133:24 | call to getenv | user input (an environment variable) |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextBufferWrite.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextBufferWrite.expected
@@ -1,13 +1,19 @@
 edges
 | test2.cpp:110:8:110:15 | gets output argument | test2.cpp:110:3:110:6 | call to gets |
 | test.cpp:54:17:54:20 | argv | test.cpp:58:25:58:29 | input |
+| test.cpp:54:17:54:20 | argv indirection | test.cpp:58:25:58:29 | input |
+| test.cpp:54:17:54:20 | argv indirection | test.cpp:58:25:58:29 | input |
 nodes
 | test2.cpp:110:3:110:6 | call to gets | semmle.label | call to gets |
 | test2.cpp:110:8:110:15 | gets output argument | semmle.label | gets output argument |
 | test.cpp:54:17:54:20 | argv | semmle.label | argv |
+| test.cpp:54:17:54:20 | argv indirection | semmle.label | argv indirection |
+| test.cpp:54:17:54:20 | argv indirection | semmle.label | argv indirection |
 | test.cpp:58:25:58:29 | input | semmle.label | input |
 subpaths
 #select
 | test2.cpp:110:3:110:6 | call to gets | test2.cpp:110:3:110:6 | call to gets | test2.cpp:110:3:110:6 | call to gets | This write into buffer 'password' may contain unencrypted data from $@. | test2.cpp:110:3:110:6 | call to gets | user input (string read by gets) |
 | test2.cpp:110:3:110:6 | call to gets | test2.cpp:110:8:110:15 | gets output argument | test2.cpp:110:3:110:6 | call to gets | This write into buffer 'password' may contain unencrypted data from $@. | test2.cpp:110:8:110:15 | gets output argument | user input (string read by gets) |
 | test.cpp:58:3:58:9 | call to sprintf | test.cpp:54:17:54:20 | argv | test.cpp:58:25:58:29 | input | This write into buffer 'passwd' may contain unencrypted data from $@. | test.cpp:54:17:54:20 | argv | user input (a command-line argument) |
+| test.cpp:58:3:58:9 | call to sprintf | test.cpp:54:17:54:20 | argv indirection | test.cpp:58:25:58:29 | input | This write into buffer 'passwd' may contain unencrypted data from $@. | test.cpp:54:17:54:20 | argv indirection | user input (a command-line argument) |
+| test.cpp:58:3:58:9 | call to sprintf | test.cpp:54:17:54:20 | argv indirection | test.cpp:58:25:58:29 | input | This write into buffer 'passwd' may contain unencrypted data from $@. | test.cpp:54:17:54:20 | argv indirection | user input (a command-line argument) |


### PR DESCRIPTION
This fixes the test regression on `cpp/command-line-injection`.