### PR TITLE
JS: Update MissingCsrfMiddleware after 'csurf' deprecation

### DIFF
--- a/javascript/ql/src/Security/CWE-352/MissingCsrfMiddleware.qhelp
+++ b/javascript/ql/src/Security/CWE-352/MissingCsrfMiddleware.qhelp
@@ -25,7 +25,7 @@
 <recommendation>
 	<p>
 
-		Use a middleware package such as <code>csurf</code> to protect against CSRF attacks.
+		Use a middleware package such as <code>lusca.csrf</code> to protect against CSRF attacks.
 
 	</p>
 </recommendation>
@@ -58,6 +58,6 @@
 
 <references>
 	<li>OWASP: <a href="https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)">Cross-Site Request Forgery (CSRF)</a></li>
-	<li>NPM: <a href="https://www.npmjs.com/package/csurf">csurf</a></li>
+	<li>NPM: <a href="https://www.npmjs.com/package/lusca">lusca</a></li>
 </references>
 </qhelp>

--- a/javascript/ql/src/Security/CWE-352/MissingCsrfMiddleware.ql
+++ b/javascript/ql/src/Security/CWE-352/MissingCsrfMiddleware.ql
@@ -57,7 +57,7 @@ predicate hasCookieMiddleware(Routing::Node route, Http::CookieMiddlewareInstanc
  */
 DataFlow::SourceNode csrfMiddlewareCreation() {
   exists(DataFlow::SourceNode callee | result = callee.getACall() |
-    callee = DataFlow::moduleImport("csurf")
+    callee = DataFlow::moduleImport(["csurf", "tiny-csrf"])
     or
     callee = DataFlow::moduleImport("lusca") and
     exists(result.(DataFlow::CallNode).getOptionArgument(0, "csrf"))

--- a/javascript/ql/src/Security/CWE-352/examples/MissingCsrfMiddlewareBad.js
+++ b/javascript/ql/src/Security/CWE-352/examples/MissingCsrfMiddlewareBad.js
@@ -1,11 +1,16 @@
-var app = require("express")(),
+const app = require("express")(),
   cookieParser = require("cookie-parser"),
-  passport = require("passport");
+  bodyParser = require("body-parser"),
+  session = require("express-session");
 
 app.use(cookieParser());
-app.use(passport.authorize({ session: true }));
+app.use(bodyParser.urlencoded({ extended: false }));
+app.use(session({ secret: process.env['SECRET'], cookie: { maxAge: 60000 } }));
+
+// ...
 
 app.post("/changeEmail", function(req, res) {
-  let newEmail = req.cookies["newEmail"];
-  // ...
+  const userId = req.session.id;
+  const email = req.body["email"];
+  // ... update email associated with userId
 });

--- a/javascript/ql/src/Security/CWE-352/examples/MissingCsrfMiddlewareGood.js
+++ b/javascript/ql/src/Security/CWE-352/examples/MissingCsrfMiddlewareGood.js
@@ -1,12 +1,18 @@
-var app = require("express")(),
+const app = require("express")(),
   cookieParser = require("cookie-parser"),
-  passport = require("passport"),
-  csrf = require("csurf");
+  bodyParser = require("body-parser"),
+  session = require("express-session"),
+  csrf = require('lusca').csrf;
 
 app.use(cookieParser());
-app.use(passport.authorize({ session: true }));
-app.use(csrf({ cookie: true }));
+app.use(bodyParser.urlencoded({ extended: false }));
+app.use(session({ secret: process.env['SECRET'], cookie: { maxAge: 60000 } }));
+app.use(csrf());
+
+// ...
+
 app.post("/changeEmail", function(req, res) {
-  let newEmail = req.cookies["newEmail"];
-  // ...
+  const userId = req.session.id;
+  const email = req.body["email"];
+  // ... update email associated with userId
 });


### PR DESCRIPTION
Fixes https://github.com/github/codeql/issues/11682.

The `csurf` package has been deprecated, so it would be best not to use it in examples and recommendations. This PR replaces it with the `csrf` function from the `lusca` package.

Also updates the query to recognize [tiny-csrf](https://www.npmjs.com/package/tiny-csrf):
> This is a tiny csrf library meant to replace what csurf used to do [before it was deleted](https://github.com/expressjs/csurf). It is almost a drop-in replacement.

Given the low number of users for that package, I am hesitant to actually recommend it in the qhelp, which is why I went with the more popular `lusca` package.