### PR TITLE
C#/Java: Rename externalflow extensible predicates

### DIFF
--- a/csharp/ql/lib/ext/Dapper.model.yml
+++ b/csharp/ql/lib/ext/Dapper.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["Dapper", "SqlMapper", False, "Execute", "(System.Data.IDbConnection,System.String,System.Object,System.Data.IDbTransaction,System.Nullable<System.Int32>,System.Nullable<System.Data.CommandType>)", "", "Argument[1]", "sql", "manual"]
       - ["Dapper", "SqlMapper", False, "ExecuteAsync", "(System.Data.IDbConnection,System.String,System.Object,System.Data.IDbTransaction,System.Nullable<System.Int32>,System.Nullable<System.Data.CommandType>)", "", "Argument[1]", "sql", "manual"]

--- a/csharp/ql/lib/ext/Microsoft.ApplicationBlocks.Data.model.yml
+++ b/csharp/ql/lib/ext/Microsoft.ApplicationBlocks.Data.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["Microsoft.ApplicationBlocks.Data", "SqlHelper", False, "ExecuteDataset", "(System.Data.SqlClient.SqlConnection,System.Data.CommandType,System.String)", "", "Argument[2]", "sql", "manual"]
       - ["Microsoft.ApplicationBlocks.Data", "SqlHelper", False, "ExecuteDataset", "(System.Data.SqlClient.SqlConnection,System.Data.CommandType,System.String,System.Data.SqlClient.SqlParameter[])", "", "Argument[2]", "sql", "manual"]

--- a/csharp/ql/lib/ext/Microsoft.EntityFrameworkCore.model.yml
+++ b/csharp/ql/lib/ext/Microsoft.EntityFrameworkCore.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["Microsoft.EntityFrameworkCore", "RelationalDatabaseFacadeExtensions", False, "ExecuteSqlRaw", "(Microsoft.EntityFrameworkCore.Infrastructure.DatabaseFacade,System.String,System.Collections.Generic.IEnumerable<System.Object>)", "", "Argument[1]", "sql", "manual"]
       - ["Microsoft.EntityFrameworkCore", "RelationalDatabaseFacadeExtensions", False, "ExecuteSqlRaw", "(Microsoft.EntityFrameworkCore.Infrastructure.DatabaseFacade,System.String,System.Object[])", "", "Argument[1]", "sql", "manual"]

--- a/csharp/ql/lib/ext/Microsoft.Extensions.Primitives.model.yml
+++ b/csharp/ql/lib/ext/Microsoft.Extensions.Primitives.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["Microsoft.Extensions.Primitives", "StringValues", False, "Add", "(System.String)", "", "Argument[0]", "ReturnValue", "taint", "manual"]
       - ["Microsoft.Extensions.Primitives", "StringValues", False, "Add", "(System.String)", "", "Argument[this]", "ReturnValue", "taint", "manual"]

--- a/csharp/ql/lib/ext/Microsoft.VisualBasic.model.yml
+++ b/csharp/ql/lib/ext/Microsoft.VisualBasic.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["Microsoft.VisualBasic", "Collection", False, "Clear", "()", "", "Argument[this].WithoutElement", "Argument[this]", "value", "manual"]
       - ["Microsoft.VisualBasic", "Collection", False, "GetEnumerator", "()", "", "Argument[this].Element", "ReturnValue.Property[System.Collections.IEnumerator.Current]", "value", "manual"]

--- a/csharp/ql/lib/ext/MySql.Data.MySqlClient.model.yml
+++ b/csharp/ql/lib/ext/MySql.Data.MySqlClient.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["MySql.Data.MySqlClient", "MySqlHelper", False, "ExecuteDataRow", "(System.String,System.String,MySql.Data.MySqlClient.MySqlParameter[])", "", "Argument[1]", "sql", "manual"]
       - ["MySql.Data.MySqlClient", "MySqlHelper", False, "ExecuteDataRowAsync", "(System.String,System.String,MySql.Data.MySqlClient.MySqlParameter[])", "", "Argument[1]", "sql", "manual"]

--- a/csharp/ql/lib/ext/Newtonsoft.Json.Linq.model.yml
+++ b/csharp/ql/lib/ext/Newtonsoft.Json.Linq.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["Newtonsoft.Json.Linq", "JArray", False, "get_Item", "(System.Object)", "", "Argument[this].Element", "ReturnValue", "value", "manual"]
       - ["Newtonsoft.Json.Linq", "JArray", False, "set_Item", "(System.Object,Newtonsoft.Json.Linq.JToken)", "", "Argument[1]", "Argument[this].Element", "value", "manual"]

--- a/csharp/ql/lib/ext/Newtonsoft.Json.model.yml
+++ b/csharp/ql/lib/ext/Newtonsoft.Json.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["Newtonsoft.Json", "JsonConvert", False, "DeserializeAnonymousType<>", "(System.String,T)", "", "Argument[0]", "ReturnValue", "taint", "manual"]
       - ["Newtonsoft.Json", "JsonConvert", False, "DeserializeAnonymousType<>", "(System.String,T,Newtonsoft.Json.JsonSerializerSettings)", "", "Argument[0]", "ReturnValue", "taint", "manual"]

--- a/csharp/ql/lib/ext/ServiceStack.OrmLite.model.yml
+++ b/csharp/ql/lib/ext/ServiceStack.OrmLite.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["ServiceStack.OrmLite", "IUntypedSqlExpression", True, "UnsafeAnd", "(System.String,System.Object[])", "", "Argument[0]", "sql", "manual"]
       - ["ServiceStack.OrmLite", "IUntypedSqlExpression", True, "UnsafeFrom", "(System.String)", "", "Argument[0]", "sql", "manual"]

--- a/csharp/ql/lib/ext/ServiceStack.Redis.model.yml
+++ b/csharp/ql/lib/ext/ServiceStack.Redis.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["ServiceStack.Redis", "IRedisClient", True, "Custom", "(System.Object[])", "", "Argument[0]", "code", "manual"]
       - ["ServiceStack.Redis", "IRedisClient", True, "ExecCachedLua", "(System.String,System.Func<System.String,T>)", "", "Argument[0]", "code", "manual"]

--- a/csharp/ql/lib/ext/ServiceStack.model.yml
+++ b/csharp/ql/lib/ext/ServiceStack.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["ServiceStack", "IOneWayClient", True, "SendAllOneWay", "(System.Collections.Generic.IEnumerable<System.Object>)", "", "Argument[1].Element", "remote", "manual"]
       - ["ServiceStack", "IOneWayClient", True, "SendOneWay", "(System.Object)", "", "Argument[0]", "remote", "manual"]
@@ -80,7 +80,7 @@ extensions:
       - ["ServiceStack", "ServiceClientBase", True, "Put", "(System.Object)", "", "Argument[0]", "remote", "manual"]
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["ServiceStack", "HttpResult", False, "HttpResult", "(System.Byte[],System.String)", "", "Argument[0]", "Argument[this]", "taint", "manual"]
       - ["ServiceStack", "HttpResult", False, "HttpResult", "(System.IO.Stream,System.String)", "", "Argument[0]", "Argument[this]", "taint", "manual"]

--- a/csharp/ql/lib/ext/System.CodeDom.model.yml
+++ b/csharp/ql/lib/ext/System.CodeDom.model.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["System.CodeDom", "CodeNamespaceImportCollection", False, "Clear", "()", "", "Argument[this].WithoutElement", "Argument[this]", "value", "manual"]

--- a/csharp/ql/lib/ext/System.Collections.Concurrent.model.yml
+++ b/csharp/ql/lib/ext/System.Collections.Concurrent.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["System.Collections.Concurrent", "BlockingCollection<>", False, "Add", "(T)", "", "Argument[0]", "Argument[this].Element", "value", "manual"]
       - ["System.Collections.Concurrent", "BlockingCollection<>", False, "CopyTo", "(T[],System.Int32)", "", "Argument[this].Element", "Argument[0].Element", "value", "manual"]

--- a/csharp/ql/lib/ext/System.Collections.Generic.model.yml
+++ b/csharp/ql/lib/ext/System.Collections.Generic.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["System.Collections.Generic", "Dictionary<,>", False, "Add", "(System.Collections.Generic.KeyValuePair<TKey,TValue>)", "", "Argument[0].Property[System.Collections.Generic.KeyValuePair<,>.Key]", "Argument[this].Element.Property[System.Collections.Generic.KeyValuePair<,>.Key]", "value", "manual"]
       - ["System.Collections.Generic", "Dictionary<,>", False, "Add", "(System.Collections.Generic.KeyValuePair<TKey,TValue>)", "", "Argument[0].Property[System.Collections.Generic.KeyValuePair<,>.Value]", "Argument[this].Element.Property[System.Collections.Generic.KeyValuePair<,>.Value]", "value", "manual"]

--- a/csharp/ql/lib/ext/System.Collections.Immutable.model.yml
+++ b/csharp/ql/lib/ext/System.Collections.Immutable.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["System.Collections.Immutable", "IImmutableDictionary<,>", True, "AddRange", "(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>)", "", "Argument[0].Element", "Argument[this].Element", "value", "manual"]
       - ["System.Collections.Immutable", "IImmutableDictionary<,>", True, "Clear", "()", "", "Argument[this].WithoutElement", "ReturnValue", "value", "manual"]

--- a/csharp/ql/lib/ext/System.Collections.ObjectModel.model.yml
+++ b/csharp/ql/lib/ext/System.Collections.ObjectModel.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["System.Collections.ObjectModel", "KeyedCollection<,>", False, "get_Item", "(TKey)", "", "Argument[this].Element", "ReturnValue", "value", "manual"]
       - ["System.Collections.ObjectModel", "ReadOnlyCollection<>", False, "get_Item", "(System.Int32)", "", "Argument[this].Element", "ReturnValue", "value", "manual"]

--- a/csharp/ql/lib/ext/System.Collections.Specialized.model.yml
+++ b/csharp/ql/lib/ext/System.Collections.Specialized.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["System.Collections.Specialized", "IOrderedDictionary", True, "get_Item", "(System.Int32)", "", "Argument[this].Element.Property[System.Collections.Generic.KeyValuePair<,>.Value]", "ReturnValue", "value", "manual"]
       - ["System.Collections.Specialized", "IOrderedDictionary", True, "set_Item", "(System.Int32,System.Object)", "", "Argument[0]", "Argument[this].Element.Property[System.Collections.Generic.KeyValuePair<,>.Key]", "value", "manual"]

--- a/csharp/ql/lib/ext/System.Collections.model.yml
+++ b/csharp/ql/lib/ext/System.Collections.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["System.Collections", "ArrayList", False, "AddRange", "(System.Collections.ICollection)", "", "Argument[0].Element", "Argument[this].Element", "value", "manual"]
       - ["System.Collections", "ArrayList", False, "Clone", "()", "", "Argument[0].Element", "ReturnValue.Element", "value", "manual"]

--- a/csharp/ql/lib/ext/System.ComponentModel.Design.model.yml
+++ b/csharp/ql/lib/ext/System.ComponentModel.Design.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["System.ComponentModel.Design", "DesignerCollection", False, "GetEnumerator", "()", "", "Argument[this].Element", "ReturnValue.Property[System.Collections.IEnumerator.Current]", "value", "manual"]
       - ["System.ComponentModel.Design", "DesignerOptionService+DesignerOptionCollection", False, "get_Item", "(System.Int32)", "", "Argument[this].Element", "ReturnValue", "value", "manual"]

--- a/csharp/ql/lib/ext/System.ComponentModel.model.yml
+++ b/csharp/ql/lib/ext/System.ComponentModel.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["System.ComponentModel", "AttributeCollection", False, "GetEnumerator", "()", "", "Argument[this].Element", "ReturnValue.Property[System.Collections.IEnumerator.Current]", "value", "manual"]
       - ["System.ComponentModel", "ComponentCollection", False, "CopyTo", "(System.ComponentModel.IComponent[],System.Int32)", "", "Argument[this].Element", "Argument[0].Element", "value", "manual"]

--- a/csharp/ql/lib/ext/System.Configuration.Provider.model.yml
+++ b/csharp/ql/lib/ext/System.Configuration.Provider.model.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["System.Configuration.Provider", "ProviderCollection", False, "Clear", "()", "", "Argument[this].WithoutElement", "Argument[this]", "value", "manual"]

--- a/csharp/ql/lib/ext/System.Configuration.model.yml
+++ b/csharp/ql/lib/ext/System.Configuration.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["System.Configuration", "CommaDelimitedStringCollection", False, "Clear", "()", "", "Argument[this].WithoutElement", "Argument[this]", "value", "manual"]
       - ["System.Configuration", "ConfigurationLockCollection", False, "Clear", "()", "", "Argument[this].WithoutElement", "Argument[this]", "value", "manual"]

--- a/csharp/ql/lib/ext/System.Data.Common.model.yml
+++ b/csharp/ql/lib/ext/System.Data.Common.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["System.Data.Common", "DataColumnMappingCollection", False, "AddRange", "(System.Array)", "", "Argument[0].Element", "Argument[this].Element", "value", "manual"]
       - ["System.Data.Common", "DataColumnMappingCollection", False, "AddRange", "(System.Data.Common.DataColumnMapping[])", "", "Argument[0].Element", "Argument[this].Element", "value", "manual"]

--- a/csharp/ql/lib/ext/System.Data.Entity.model.yml
+++ b/csharp/ql/lib/ext/System.Data.Entity.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["System.Data.Entity", "Database", False, "ExecuteSqlCommand", "(System.Data.Entity.TransactionalBehavior,System.String,System.Object[])", "", "Argument[1]", "sql", "manual"]
       - ["System.Data.Entity", "Database", False, "ExecuteSqlCommand", "(System.String,System.Object[])", "", "Argument[0]", "sql", "manual"]

--- a/csharp/ql/lib/ext/System.Data.EntityClient.model.yml
+++ b/csharp/ql/lib/ext/System.Data.EntityClient.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["System.Data.EntityClient", "EntityCommand", False, "EntityCommand", "(System.String)", "", "Argument[0]", "sql", "manual"]
       - ["System.Data.EntityClient", "EntityCommand", False, "EntityCommand", "(System.String,System.Data.EntityClient.EntityConnection)", "", "Argument[0]", "sql", "manual"]

--- a/csharp/ql/lib/ext/System.Data.Odbc.model.yml
+++ b/csharp/ql/lib/ext/System.Data.Odbc.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["System.Data.Odbc", "OdbcCommand", False, "OdbcCommand", "(System.String)", "", "Argument[0]", "sql", "manual"]
       - ["System.Data.Odbc", "OdbcCommand", False, "OdbcCommand", "(System.String,System.Data.Odbc.OdbcConnection)", "", "Argument[0]", "sql", "manual"]

--- a/csharp/ql/lib/ext/System.Data.OleDb.model.yml
+++ b/csharp/ql/lib/ext/System.Data.OleDb.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["System.Data.OleDb", "OleDbCommand", False, "OleDbCommand", "(System.String)", "", "Argument[0]", "sql", "manual"]
       - ["System.Data.OleDb", "OleDbCommand", False, "OleDbCommand", "(System.String,System.Data.OleDb.OleDbConnection)", "", "Argument[0]", "sql", "manual"]

--- a/csharp/ql/lib/ext/System.Data.SQLite.model.yml
+++ b/csharp/ql/lib/ext/System.Data.SQLite.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["System.Data.SQLite", "SQLiteCommand", False, "SQLiteCommand", "(System.String)", "", "Argument[0]", "sql", "manual"]
       - ["System.Data.SQLite", "SQLiteCommand", False, "SQLiteCommand", "(System.String,System.Data.SQLite.SQLiteConnection)", "", "Argument[0]", "sql", "manual"]
@@ -12,7 +12,7 @@ extensions:
       - ["System.Data.SQLite", "SQLiteDataAdapter", False, "SQLiteDataAdapter", "(System.String,System.String,System.Boolean)", "", "Argument[0]", "sql", "manual"]
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["System.Data.SQLite", "SQLiteCommand", False, "SQLiteCommand", "(System.String)", "", "Argument[0]", "Argument[this]", "taint", "manual"]
       - ["System.Data.SQLite", "SQLiteCommand", False, "SQLiteCommand", "(System.String,System.Data.SQLite.SQLiteConnection)", "", "Argument[0]", "Argument[this]", "taint", "manual"]

--- a/csharp/ql/lib/ext/System.Data.SqlClient.model.yml
+++ b/csharp/ql/lib/ext/System.Data.SqlClient.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["System.Data.SqlClient", "SqlCommand", False, "SqlCommand", "(System.String)", "", "Argument[0]", "sql", "manual"]
       - ["System.Data.SqlClient", "SqlCommand", False, "SqlCommand", "(System.String,System.Data.SqlClient.SqlConnection)", "", "Argument[0]", "sql", "manual"]
@@ -11,7 +11,7 @@ extensions:
       - ["System.Data.SqlClient", "SqlDataAdapter", False, "SqlDataAdapter", "(System.String,System.String)", "", "Argument[0]", "sql", "manual"]
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["System.Data.SqlClient", "SqlCommand", False, "SqlCommand", "(System.String)", "", "Argument[0]", "Argument[this]", "taint", "manual"]
       - ["System.Data.SqlClient", "SqlCommand", False, "SqlCommand", "(System.String,System.Data.SqlClient.SqlConnection)", "", "Argument[0]", "Argument[this]", "taint", "manual"]

--- a/csharp/ql/lib/ext/System.Data.model.yml
+++ b/csharp/ql/lib/ext/System.Data.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["System.Data", "ConstraintCollection", False, "Add", "(System.Data.Constraint)", "", "Argument[0]", "Argument[this].Element", "value", "manual"]
       - ["System.Data", "ConstraintCollection", False, "AddRange", "(System.Data.Constraint[])", "", "Argument[0].Element", "Argument[this].Element", "value", "manual"]

--- a/csharp/ql/lib/ext/System.Diagnostics.model.yml
+++ b/csharp/ql/lib/ext/System.Diagnostics.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["System.Diagnostics", "ActivityTagsCollection", False, "ActivityTagsCollection", "(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<System.String,System.Object>>)", "", "Argument[0].Element.Property[System.Collections.Generic.KeyValuePair<,>.Key]", "Argument[this].Element.Property[System.Collections.Generic.KeyValuePair<,>.Key]", "value", "manual"]
       - ["System.Diagnostics", "ActivityTagsCollection", False, "ActivityTagsCollection", "(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<System.String,System.Object>>)", "", "Argument[0].Element.Property[System.Collections.Generic.KeyValuePair<,>.Value]", "Argument[this].Element.Property[System.Collections.Generic.KeyValuePair<,>.Value]", "value", "manual"]

--- a/csharp/ql/lib/ext/System.Dynamic.model.yml
+++ b/csharp/ql/lib/ext/System.Dynamic.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["System.Dynamic", "ExpandoObject", False, "Add", "(System.Collections.Generic.KeyValuePair<System.String,System.Object>)", "", "Argument[0].Property[System.Collections.Generic.KeyValuePair<,>.Key]", "Argument[this].Element.Property[System.Collections.Generic.KeyValuePair<,>.Key]", "value", "manual"]
       - ["System.Dynamic", "ExpandoObject", False, "Add", "(System.Collections.Generic.KeyValuePair<System.String,System.Object>)", "", "Argument[0].Property[System.Collections.Generic.KeyValuePair<,>.Value]", "Argument[this].Element.Property[System.Collections.Generic.KeyValuePair<,>.Value]", "value", "manual"]

--- a/csharp/ql/lib/ext/System.IO.Compression.model.yml
+++ b/csharp/ql/lib/ext/System.IO.Compression.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["System.IO.Compression", "DeflateStream", False, "DeflateStream", "(System.IO.Stream,System.IO.Compression.CompressionLevel)", "", "Argument[0]", "Argument[this]", "taint", "manual"]
       - ["System.IO.Compression", "DeflateStream", False, "DeflateStream", "(System.IO.Stream,System.IO.Compression.CompressionLevel,System.Boolean)", "", "Argument[0]", "Argument[this]", "taint", "manual"]

--- a/csharp/ql/lib/ext/System.IO.model.yml
+++ b/csharp/ql/lib/ext/System.IO.model.yml
@@ -1,12 +1,12 @@
 extensions:
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSourceModel
+      extensible: sourceModel
     data:
       - ["System.IO", "FileStream", False, "FileStream", "", "", "Argument[this]", "file", "manual"]
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["System.IO", "FileStream", False, "FileStream", "(System.String,System.IO.FileMode)", "", "Argument[0]", "Argument[this]", "taint", "manual"]
       - ["System.IO", "FileStream", False, "FileStream", "(System.String,System.IO.FileMode,System.IO.FileAccess)", "", "Argument[0]", "Argument[this]", "taint", "manual"]
@@ -58,18 +58,18 @@ extensions:
       - ["System.IO", "Stream", False, "WriteAsync", "(System.Byte[],System.Int32,System.Int32)", "", "Argument[0].Element", "Argument[this]", "taint", "manual"]
       - ["System.IO", "Stream", True, "WriteAsync", "(System.Byte[],System.Int32,System.Int32,System.Threading.CancellationToken)", "", "Argument[0].Element", "Argument[this]", "taint", "manual"]
       - ["System.IO", "StreamReader", False, "StreamReader", "(System.IO.Stream)", "", "Argument[0]", "Argument[this]", "taint", "manual"]
-      - ["System.IO", "StreamReader", False, "StreamReader", "(System.String,System.Text.Encoding,System.Boolean,System.IO.FileStreamOptions)", "", "Argument[0]", "Argument[this]", "taint", "manual"]
-      - ["System.IO", "StreamReader", False, "StreamReader", "(System.String,System.Text.Encoding,System.Boolean,System.Int32)", "", "Argument[0]", "Argument[this]", "taint", "manual"]
+      - ["System.IO", "StreamReader", False, "StreamReader", "(System.IO.Stream,System.Boolean)", "", "Argument[0]", "Argument[this]", "taint", "manual"]
+      - ["System.IO", "StreamReader", False, "StreamReader", "(System.IO.Stream,System.Text.Encoding)", "", "Argument[0]", "Argument[this]", "taint", "manual"]
+      - ["System.IO", "StreamReader", False, "StreamReader", "(System.IO.Stream,System.Text.Encoding,System.Boolean)", "", "Argument[0]", "Argument[this]", "taint", "manual"]
       - ["System.IO", "StreamReader", False, "StreamReader", "(System.IO.Stream,System.Text.Encoding,System.Boolean,System.Int32)", "", "Argument[0]", "Argument[this]", "taint", "manual"]
       - ["System.IO", "StreamReader", False, "StreamReader", "(System.IO.Stream,System.Text.Encoding,System.Boolean,System.Int32,System.Boolean)", "", "Argument[0]", "Argument[this]", "taint", "manual"]
-      - ["System.IO", "StreamReader", False, "StreamReader", "(System.IO.Stream,System.Text.Encoding,System.Boolean)", "", "Argument[0]", "Argument[this]", "taint", "manual"]
-      - ["System.IO", "StreamReader", False, "StreamReader", "(System.String,System.Text.Encoding,System.Boolean)", "", "Argument[0]", "Argument[this]", "taint", "manual"]
-      - ["System.IO", "StreamReader", False, "StreamReader", "(System.String,System.IO.FileStreamOptions)", "", "Argument[0]", "Argument[this]", "taint", "manual"]
-      - ["System.IO", "StreamReader", False, "StreamReader", "(System.String,System.Boolean)", "", "Argument[0]", "Argument[this]", "taint", "manual"]
-      - ["System.IO", "StreamReader", False, "StreamReader", "(System.IO.Stream,System.Text.Encoding)", "", "Argument[0]", "Argument[this]", "taint", "manual"]
-      - ["System.IO", "StreamReader", False, "StreamReader", "(System.IO.Stream,System.Boolean)", "", "Argument[0]", "Argument[this]", "taint", "manual"]
       - ["System.IO", "StreamReader", False, "StreamReader", "(System.String)", "", "Argument[0]", "Argument[this]", "taint", "manual"]
+      - ["System.IO", "StreamReader", False, "StreamReader", "(System.String,System.Boolean)", "", "Argument[0]", "Argument[this]", "taint", "manual"]
+      - ["System.IO", "StreamReader", False, "StreamReader", "(System.String,System.IO.FileStreamOptions)", "", "Argument[0]", "Argument[this]", "taint", "manual"]
       - ["System.IO", "StreamReader", False, "StreamReader", "(System.String,System.Text.Encoding)", "", "Argument[0]", "Argument[this]", "taint", "manual"]
+      - ["System.IO", "StreamReader", False, "StreamReader", "(System.String,System.Text.Encoding,System.Boolean)", "", "Argument[0]", "Argument[this]", "taint", "manual"]
+      - ["System.IO", "StreamReader", False, "StreamReader", "(System.String,System.Text.Encoding,System.Boolean,System.IO.FileStreamOptions)", "", "Argument[0]", "Argument[this]", "taint", "manual"]
+      - ["System.IO", "StreamReader", False, "StreamReader", "(System.String,System.Text.Encoding,System.Boolean,System.Int32)", "", "Argument[0]", "Argument[this]", "taint", "manual"]
       - ["System.IO", "StringReader", False, "StringReader", "(System.String)", "", "Argument[0]", "Argument[this]", "taint", "manual"]
       - ["System.IO", "TextReader", True, "Read", "()", "", "Argument[this]", "ReturnValue", "taint", "manual"]
       - ["System.IO", "TextReader", True, "Read", "(System.Char[],System.Int32,System.Int32)", "", "Argument[this]", "ReturnValue", "taint", "manual"]

--- a/csharp/ql/lib/ext/System.Linq.model.yml
+++ b/csharp/ql/lib/ext/System.Linq.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["System.Linq", "Enumerable", False, "Aggregate<,,>", "(System.Collections.Generic.IEnumerable<TSource>,TAccumulate,System.Func<TAccumulate,TSource,TAccumulate>,System.Func<TAccumulate,TResult>)", "", "Argument[0].Element", "Argument[2].Parameter[1]", "value", "manual"]
       - ["System.Linq", "Enumerable", False, "Aggregate<,,>", "(System.Collections.Generic.IEnumerable<TSource>,TAccumulate,System.Func<TAccumulate,TSource,TAccumulate>,System.Func<TAccumulate,TResult>)", "", "Argument[1]", "Argument[2].Parameter[0]", "value", "manual"]

--- a/csharp/ql/lib/ext/System.Net.Http.Headers.model.yml
+++ b/csharp/ql/lib/ext/System.Net.Http.Headers.model.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["System.Net.Http.Headers", "HttpHeaders", False, "Clear", "()", "", "Argument[this].WithoutElement", "Argument[this]", "value", "manual"]

--- a/csharp/ql/lib/ext/System.Net.Http.model.yml
+++ b/csharp/ql/lib/ext/System.Net.Http.model.yml
@@ -1,12 +1,12 @@
 extensions:
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["System.Net.Http", "StringContent", False, "StringContent", "", "", "Argument[0]", "xss", "manual"]
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["System.Net.Http", "HttpRequestOptions", False, "Add", "(System.Collections.Generic.KeyValuePair<System.String,System.Object>)", "", "Argument[0].Property[System.Collections.Generic.KeyValuePair<,>.Key]", "Argument[this].Element.Property[System.Collections.Generic.KeyValuePair<,>.Key]", "value", "manual"]
       - ["System.Net.Http", "HttpRequestOptions", False, "Add", "(System.Collections.Generic.KeyValuePair<System.String,System.Object>)", "", "Argument[0].Property[System.Collections.Generic.KeyValuePair<,>.Value]", "Argument[this].Element.Property[System.Collections.Generic.KeyValuePair<,>.Value]", "value", "manual"]

--- a/csharp/ql/lib/ext/System.Net.Mail.model.yml
+++ b/csharp/ql/lib/ext/System.Net.Mail.model.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["System.Net.Mail", "MailAddressCollection", False, "Add", "(System.String)", "", "Argument[0]", "Argument[this].Element", "value", "manual"]

--- a/csharp/ql/lib/ext/System.Net.Sockets.model.yml
+++ b/csharp/ql/lib/ext/System.Net.Sockets.model.yml
@@ -1,0 +1,9 @@
+extensions:
+  - addsTo:
+      pack: codeql/csharp-all
+      extensible: sourceModel
+    data:
+      - ["System.Net.Sockets", "TcpClient", False, "GetStream", "", "", "ReturnValue", "remote", "manual"]
+      - ["System.Net.Sockets", "UpdClient", False, "EndReceive", "", "", "ReturnValue", "remote", "manual"]
+      - ["System.Net.Sockets", "UpdClient", False, "Receive", "", "", "ReturnValue", "remote", "manual"]
+      - ["System.Net.Sockets", "UpdClient", False, "ReceiveAsync", "", "", "ReturnValue", "remote", "manual"]

--- a/csharp/ql/lib/ext/System.Net.model.yml
+++ b/csharp/ql/lib/ext/System.Net.model.yml
@@ -1,15 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSourceModel
-    data:
-      - ["System.Net.Sockets", "TcpClient", False, "GetStream",    "", "", "ReturnValue", "remote", "manual"]
-      - ["System.Net.Sockets", "UpdClient", False, "EndReceive",   "", "", "ReturnValue", "remote", "manual"]
-      - ["System.Net.Sockets", "UpdClient", False, "Receive",      "", "", "ReturnValue", "remote", "manual"]
-      - ["System.Net.Sockets", "UpdClient", False, "ReceiveAsync", "", "", "ReturnValue", "remote", "manual"]
-  - addsTo:
-      pack: codeql/csharp-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["System.Net", "Cookie", False, "get_Value", "()", "", "Argument[this]", "ReturnValue", "taint", "manual"]
       - ["System.Net", "CookieCollection", False, "Add", "(System.Net.CookieCollection)", "", "Argument[0]", "Argument[this].Element", "value", "manual"]

--- a/csharp/ql/lib/ext/System.Runtime.CompilerServices.model.yml
+++ b/csharp/ql/lib/ext/System.Runtime.CompilerServices.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["System.Runtime.CompilerServices", "ConditionalWeakTable<,>", False, "Clear", "()", "", "Argument[this].WithoutElement", "Argument[this]", "value", "manual"]
       - ["System.Runtime.CompilerServices", "ConfiguredTaskAwaitable<>", False, "GetAwaiter", "()", "", "Argument[this].SyntheticField[m_configuredTaskAwaiter]", "ReturnValue", "value", "manual"]

--- a/csharp/ql/lib/ext/System.Security.Cryptography.X509Certificates.model.yml
+++ b/csharp/ql/lib/ext/System.Security.Cryptography.X509Certificates.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["System.Security.Cryptography.X509Certificates", "X509Certificate2Collection", False, "Add", "(System.Security.Cryptography.X509Certificates.X509Certificate2)", "", "Argument[0]", "Argument[this].Element", "value", "manual"]
       - ["System.Security.Cryptography.X509Certificates", "X509Certificate2Collection", False, "AddRange", "(System.Security.Cryptography.X509Certificates.X509Certificate2Collection)", "", "Argument[0].Element", "Argument[this].Element", "value", "manual"]

--- a/csharp/ql/lib/ext/System.Security.Cryptography.model.yml
+++ b/csharp/ql/lib/ext/System.Security.Cryptography.model.yml
@@ -1,14 +1,14 @@
 extensions:
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["System.Security.Cryptography", "SymmetricAlgorithm", True, "CreateDecryptor", "(System.Byte[],System.Byte[])", "", "Argument[0]", "encryption-decryptor", "manual"]
       - ["System.Security.Cryptography", "SymmetricAlgorithm", True, "CreateEncryptor", "(System.Byte[],System.Byte[])", "", "Argument[0]", "encryption-encryptor", "manual"]
       - ["System.Security.Cryptography", "SymmetricAlgorithm", True, "set_Key", "(System.Byte[])", "", "Argument[0]", "encryption-keyprop", "manual"]
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["System.Security.Cryptography", "AsnEncodedDataCollection", False, "Add", "(System.Security.Cryptography.AsnEncodedData)", "", "Argument[0]", "Argument[this].Element", "value", "manual"]
       - ["System.Security.Cryptography", "AsnEncodedDataCollection", False, "CopyTo", "(System.Security.Cryptography.AsnEncodedData[],System.Int32)", "", "Argument[this].Element", "Argument[0].Element", "value", "manual"]

--- a/csharp/ql/lib/ext/System.Security.Permissions.model.yml
+++ b/csharp/ql/lib/ext/System.Security.Permissions.model.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["System.Security.Permissions", "KeyContainerPermissionAccessEntryCollection", False, "Clear", "()", "", "Argument[this].WithoutElement", "Argument[this]", "value", "manual"]

--- a/csharp/ql/lib/ext/System.Security.Policy.model.yml
+++ b/csharp/ql/lib/ext/System.Security.Policy.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["System.Security.Policy", "ApplicationTrustCollection", False, "Clear", "()", "", "Argument[this].WithoutElement", "Argument[this]", "value", "manual"]
       - ["System.Security.Policy", "Evidence", False, "Clear", "()", "", "Argument[this].WithoutElement", "Argument[this]", "value", "manual"]

--- a/csharp/ql/lib/ext/System.Text.RegularExpressions.model.yml
+++ b/csharp/ql/lib/ext/System.Text.RegularExpressions.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["System.Text.RegularExpressions", "CaptureCollection", False, "get_Item", "(System.Int32)", "", "Argument[this].Element", "ReturnValue", "value", "manual"]
       - ["System.Text.RegularExpressions", "GroupCollection", False, "get_Item", "(System.Int32)", "", "Argument[this].Element", "ReturnValue", "value", "manual"]

--- a/csharp/ql/lib/ext/System.Text.model.yml
+++ b/csharp/ql/lib/ext/System.Text.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["System.Text", "Encoding", True, "GetBytes", "(System.Char*,System.Int32,System.Byte*,System.Int32)", "", "Argument[0]", "ReturnValue", "taint", "manual"]
       - ["System.Text", "Encoding", True, "GetBytes", "(System.Char[])", "", "Argument[0].Element", "ReturnValue", "taint", "manual"]

--- a/csharp/ql/lib/ext/System.Threading.Tasks.model.yml
+++ b/csharp/ql/lib/ext/System.Threading.Tasks.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["System.Threading.Tasks", "Task", False, "ContinueWith", "(System.Action<System.Threading.Tasks.Task,System.Object>,System.Object)", "", "Argument[1]", "Argument[0].Parameter[1]", "value", "manual"]
       - ["System.Threading.Tasks", "Task", False, "ContinueWith", "(System.Action<System.Threading.Tasks.Task,System.Object>,System.Object,System.Threading.CancellationToken)", "", "Argument[1]", "Argument[0].Parameter[1]", "value", "manual"]

--- a/csharp/ql/lib/ext/System.Web.UI.WebControls.model.yml
+++ b/csharp/ql/lib/ext/System.Web.UI.WebControls.model.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["System.Web.UI.WebControls", "TextBox", False, "get_Text", "()", "", "Argument[this]", "ReturnValue", "taint", "manual"]

--- a/csharp/ql/lib/ext/System.Web.model.yml
+++ b/csharp/ql/lib/ext/System.Web.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["System.Web", "HttpResponse", False, "BinaryWrite", "", "", "Argument[0]", "html", "manual"]
       - ["System.Web", "HttpResponse", False, "TransmitFile", "", "", "Argument[0]", "html", "manual"]
@@ -9,7 +9,7 @@ extensions:
       - ["System.Web", "HttpResponse", False, "WriteFile", "", "", "Argument[0]", "html", "manual"]
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["System.Web", "HttpCookie", False, "get_Value", "()", "", "Argument[this]", "ReturnValue", "taint", "manual"]
       - ["System.Web", "HttpCookie", False, "get_Values", "()", "", "Argument[this]", "ReturnValue", "taint", "manual"]

--- a/csharp/ql/lib/ext/System.Xml.Schema.model.yml
+++ b/csharp/ql/lib/ext/System.Xml.Schema.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["System.Xml.Schema", "XmlSchemaCollection", False, "Add", "(System.Xml.Schema.XmlSchema)", "", "Argument[0]", "Argument[this].Element", "value", "manual"]
       - ["System.Xml.Schema", "XmlSchemaCollection", False, "Add", "(System.Xml.Schema.XmlSchemaCollection)", "", "Argument[0]", "Argument[this].Element", "value", "manual"]

--- a/csharp/ql/lib/ext/System.Xml.Serialization.model.yml
+++ b/csharp/ql/lib/ext/System.Xml.Serialization.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["System.Xml.Serialization", "XmlAnyElementAttributes", False, "Add", "(System.Xml.Serialization.XmlAnyElementAttribute)", "", "Argument[0]", "Argument[this].Element", "value", "manual"]
       - ["System.Xml.Serialization", "XmlAnyElementAttributes", False, "CopyTo", "(System.Xml.Serialization.XmlAnyElementAttribute[],System.Int32)", "", "Argument[this].Element", "Argument[0].Element", "value", "manual"]

--- a/csharp/ql/lib/ext/System.Xml.model.yml
+++ b/csharp/ql/lib/ext/System.Xml.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["System.Xml", "XmlAttributeCollection", False, "CopyTo", "(System.Xml.XmlAttribute[],System.Int32)", "", "Argument[this].Element", "Argument[0].Element", "value", "manual"]
       - ["System.Xml", "XmlDocument", False, "Load", "(System.IO.Stream)", "", "Argument[0]", "Argument[this]", "taint", "manual"]

--- a/csharp/ql/lib/ext/System.model.yml
+++ b/csharp/ql/lib/ext/System.model.yml
@@ -1,14 +1,14 @@
 extensions:
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSourceModel
+      extensible: sourceModel
     data:
       - ["System", "Console", False, "Read", "", "", "ReturnValue", "local", "manual"]
       - ["System", "Console", False, "ReadKey", "", "", "ReturnValue", "local", "manual"]
       - ["System", "Console", False, "ReadLine", "", "", "ReturnValue", "local", "manual"]
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["System", "Array", False, "AsReadOnly<>", "(T[])", "", "Argument[0].Element", "ReturnValue.Element", "value", "manual"]
       - ["System", "Array", False, "Clear", "(System.Array)", "", "Argument[0].WithoutElement", "Argument[0]", "value", "manual"]

--- a/csharp/ql/lib/ext/Windows.Security.Cryptography.Core.model.yml
+++ b/csharp/ql/lib/ext/Windows.Security.Cryptography.Core.model.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["Windows.Security.Cryptography.Core", "SymmetricKeyAlgorithmProvider", False, "CreateSymmetricKey", "(Windows.Storage.Streams.IBuffer)", "", "Argument[0]", "encryption-symmetrickey", "manual"]

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/ExternalFlow.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/ExternalFlow.qll
@@ -82,6 +82,7 @@
  */
 
 import csharp
+private import ExternalFlowExtensions as Extensions
 private import internal.AccessPathSyntax
 private import internal.DataFlowDispatch
 private import internal.DataFlowPrivate
@@ -138,14 +139,6 @@ private predicate summaryModelInternal(string row) { any(SummaryModelCsvInternal
 
 private predicate sinkModelInternal(string row) { any(SinkModelCsvInternal s).row(row) }
 
-/**
- * Holds if a source model exists for the given parameters.
- */
-extensible predicate extSourceModel(
-  string namespace, string type, boolean subtypes, string name, string signature, string ext,
-  string output, string kind, string provenance
-);
-
 /** Holds if a source model exists for the given parameters. */
 predicate sourceModel(
   string namespace, string type, boolean subtypes, string name, string signature, string ext,
@@ -165,14 +158,8 @@ predicate sourceModel(
     row.splitAt(";", 8) = provenance
   )
   or
-  extSourceModel(namespace, type, subtypes, name, signature, ext, output, kind, provenance)
+  Extensions::sourceModel(namespace, type, subtypes, name, signature, ext, output, kind, provenance)
 }
-
-/** Holds if a sink model exists for the given parameters. */
-extensible predicate extSinkModel(
-  string namespace, string type, boolean subtypes, string name, string signature, string ext,
-  string input, string kind, string provenance
-);
 
 /** Holds if a sink model exists for the given parameters. */
 predicate sinkModel(
@@ -193,14 +180,8 @@ predicate sinkModel(
     row.splitAt(";", 8) = provenance
   )
   or
-  extSinkModel(namespace, type, subtypes, name, signature, ext, input, kind, provenance)
+  Extensions::sinkModel(namespace, type, subtypes, name, signature, ext, input, kind, provenance)
 }
-
-/** Holds if a summary model exists for the given parameters. */
-extensible predicate extSummaryModel(
-  string namespace, string type, boolean subtypes, string name, string signature, string ext,
-  string input, string output, string kind, string provenance
-);
 
 /** Holds if a summary model exists for the given parameters. */
 predicate summaryModel(
@@ -222,20 +203,12 @@ predicate summaryModel(
     row.splitAt(";", 9) = provenance
   )
   or
-  extSummaryModel(namespace, type, subtypes, name, signature, ext, input, output, kind, provenance)
+  Extensions::summaryModel(namespace, type, subtypes, name, signature, ext, input, output, kind,
+    provenance)
 }
 
 /** Holds if a model exists indicating there is no flow for the given parameters. */
-extensible predicate extNeutralModel(
-  string namespace, string type, string name, string signature, string provenance
-);
-
-/** Holds if a model exists indicating there is no flow for the given parameters. */
-predicate neutralModel(
-  string namespace, string type, string name, string signature, string provenance
-) {
-  extNeutralModel(namespace, type, name, signature, provenance)
-}
+predicate neutralModel = Extensions::neutralModel/5;
 
 private predicate relevantNamespace(string namespace) {
   sourceModel(namespace, _, _, _, _, _, _, _, _) or

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/ExternalFlowExtensions.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/ExternalFlowExtensions.qll
@@ -1,0 +1,34 @@
+/**
+ * This module provides extensible predicates for defining MaD models.
+ */
+
+/**
+ * Holds if a source model exists for the given parameters.
+ */
+extensible predicate sourceModel(
+  string namespace, string type, boolean subtypes, string name, string signature, string ext,
+  string output, string kind, string provenance
+);
+
+/**
+ * Holds if a sink model exists for the given parameters.
+ */
+extensible predicate sinkModel(
+  string namespace, string type, boolean subtypes, string name, string signature, string ext,
+  string input, string kind, string provenance
+);
+
+/**
+ * Holds if a summary model exists for the given parameters.
+ */
+extensible predicate summaryModel(
+  string namespace, string type, boolean subtypes, string name, string signature, string ext,
+  string input, string output, string kind, string provenance
+);
+
+/**
+ * Holds if a model exists indicating there is no flow for the given parameters.
+ */
+extensible predicate neutralModel(
+  string namespace, string type, string name, string signature, string provenance
+);

--- a/csharp/ql/src/change-notes/2022-12-15-rename-mad-extensibles.md
+++ b/csharp/ql/src/change-notes/2022-12-15-rename-mad-extensibles.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The extensible predicates for Models as Data have been renamed (the `ext` prefix has been removed). As an example `extSummaryModel` has been renamed to `summaryModel`.

--- a/csharp/ql/test/library-tests/dataflow/external-models/ext/test.model.yml
+++ b/csharp/ql/test/library-tests/dataflow/external-models/ext/test.model.yml
@@ -2,7 +2,7 @@ extensions:
 
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSourceModel
+      extensible: sourceModel
     data:
     # "namespace", "type", "overrides", "name", "signature", "ext", "spec", "kind", "provenance",
       - ["My.Qltest", "A", false, "Src1", "()", "", "ReturnValue", "local", "manual"]
@@ -22,7 +22,7 @@ extensions:
 
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
     # "namespace", "type", "overrides", "name", "signature", "ext", "spec", "kind", "provenance"
       - ["My.Qltest", "B", false, "Sink1", "(System.Object)", "", "Argument[0]", "code", "manual"]
@@ -34,7 +34,7 @@ extensions:
   # Summaries relevant for the ExternalFlow testcase.
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
     # "namespace", "type", "overrides", "name", "signature", "ext", "inputspec", "outputspec", "kind", "provenance"
       - ["My.Qltest", "D", false, "StepArgRes", "(System.Object)","", "Argument[0]", "ReturnValue", "taint", "manual"]
@@ -66,7 +66,7 @@ extensions:
   # Summaries relevant for the Steps testcase.
   - addsTo:
       pack: codeql/csharp-all
-      extensible: extSummaryModel
+      extensible: summaryModel
       # "namespace", "type", "overrides", "name", "signature", "ext", "inputspec", "outputspec", "kind", "provenance"
     data:
       - ["My.Qltest", "C", false, "StepArgRes", "(System.Object)", "", "Argument[0]", "ReturnValue", "taint", "manual"]

--- a/java/ql/integration-tests/all-platforms/kotlin/annotation-id-consistency/ext/test.model.yml
+++ b/java/ql/integration-tests/all-platforms/kotlin/annotation-id-consistency/ext/test.model.yml
@@ -1,5 +1,5 @@
 extensions:
   - addsTo:
       pack: integrationtest-annotation-id-consistency
-      extensible: extNegativeSummaryModel
+      extensible: negativeSummaryModel
     data: []

--- a/java/ql/integration-tests/all-platforms/kotlin/annotation-id-consistency/ext/test.model.yml
+++ b/java/ql/integration-tests/all-platforms/kotlin/annotation-id-consistency/ext/test.model.yml
@@ -1,5 +1,5 @@
 extensions:
   - addsTo:
       pack: integrationtest-annotation-id-consistency
-      extensible: negativeSummaryModel
+      extensible: neutralModel
     data: []

--- a/java/ql/integration-tests/all-platforms/kotlin/default-parameter-mad-flow/ext/test.model.yml
+++ b/java/ql/integration-tests/all-platforms/kotlin/default-parameter-mad-flow/ext/test.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: integrationtest-default-parameter-mad-flow
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["", "ConstructorWithDefaults", True, "ConstructorWithDefaults", "(int,int)", "", "Argument[0]", "Argument[-1]", "taint", "manual"]
       - ["", "LibKt", True, "topLevelWithDefaults", "(int,int)", "", "Argument[0]", "ReturnValue", "value", "manual"]
@@ -12,14 +12,14 @@ extensions:
       - ["", "LibClass", True, "multiParameterExtensionTest", "(int,int,int,int)", "", "Argument[0, 1]", "ReturnValue", "value", "manual"]
   - addsTo:
       pack: integrationtest-default-parameter-mad-flow
-      extensible: extSourceModel
+      extensible: sourceModel
     data:
       - ["", "LibKt", True, "topLevelArgSource", "(SomeToken,int)", "", "Argument[0]", "kotlinMadFlowTest", "manual"]
       - ["", "LibKt", True, "extensionArgSource", "(String,SomeToken,int)", "", "Argument[1]", "kotlinMadFlowTest", "manual"]
       - ["", "SourceClass", True, "memberArgSource", "(SomeToken,int)", "", "Argument[0]", "kotlinMadFlowTest", "manual"]
   - addsTo:
       pack: integrationtest-default-parameter-mad-flow
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["", "SinkClass", True, "SinkClass", "(int,int)", "", "Argument[0]", "kotlinMadFlowTest", "manual"]
       - ["", "LibKt", True, "topLevelSink", "(int,int)", "", "Argument[0]", "kotlinMadFlowTest", "manual"]

--- a/java/ql/lib/ext/android.app.model.yml
+++ b/java/ql/lib/ext/android.app.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["android.app", "Activity", True, "bindService", "", "", "Argument[0]", "intent-start", "manual"]
       - ["android.app", "Activity", True, "bindServiceAsUser", "", "", "Argument[0]", "intent-start", "manual"]
@@ -40,7 +40,7 @@ extensions:
       - ["android.app", "PendingIntent", False, "send", "(Context,int,Intent,OnFinished,Handler,String,Bundle)", "", "Argument[2]", "pending-intent-sent", "manual"]
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["android.app", "Notification$Action", True, "Action", "(int,CharSequence,PendingIntent)", "", "Argument[2]", "Argument[-1]", "taint", "manual"]
       - ["android.app", "Notification$Action", True, "getExtras", "", "", "Argument[-1].SyntheticField[android.content.Intent.extras]", "ReturnValue", "value", "manual"]

--- a/java/ql/lib/ext/android.content.model.yml
+++ b/java/ql/lib/ext/android.content.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSourceModel
+      extensible: sourceModel
     data:
       # ContentInterface models are here for backwards compatibility (it was removed in API 28)
       - ["android.content", "ContentInterface", True, "call", "(String,String,String,Bundle)", "", "Parameter[0..3]", "contentprovider", "manual"]
@@ -37,7 +37,7 @@ extensions:
       - ["android.content", "Context", True, "getExternalFilesDirs", "(String)", "", "ReturnValue", "android-external-storage-dir", "manual"]
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["android.content", "ContentProvider", True, "delete", "(Uri,String,String[])", "", "Argument[1]", "sql", "manual"]
       - ["android.content", "ContentProvider", True, "query", "(Uri,String[],String,String[],String)", "", "Argument[2]", "sql", "manual"]
@@ -65,7 +65,7 @@ extensions:
       - ["android.content", "Context", True, "startServiceAsUser", "", "", "Argument[0]", "intent-start", "manual"]
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["android.content", "ComponentName", False, "ComponentName", "(Context,Class)", "", "Argument[1]", "Argument[-1]", "taint", "manual"]
       - ["android.content", "ComponentName", False, "ComponentName", "(Context,String)", "", "Argument[1]", "Argument[-1]", "taint", "manual"]

--- a/java/ql/lib/ext/android.database.model.yml
+++ b/java/ql/lib/ext/android.database.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["android.database", "DatabaseUtils", False, "blobFileDescriptorForQuery", "(SQLiteDatabase,String,String[])", "", "Argument[1]", "sql", "manual"]
       - ["android.database", "DatabaseUtils", False, "createDbFromSqlStatements", "(Context,String,int,String)", "", "Argument[3]", "sql", "manual"]
@@ -12,7 +12,7 @@ extensions:
       - ["android.database", "DatabaseUtils", False, "stringForQuery", "(SQLiteDatabase,String,String[])", "", "Argument[1]", "sql", "manual"]
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["android.database", "Cursor", True, "copyStringToBuffer", "", "", "Argument[-1]", "Argument[1]", "taint", "manual"]
       - ["android.database", "Cursor", True, "getBlob", "", "", "Argument[-1]", "ReturnValue", "taint", "manual"]

--- a/java/ql/lib/ext/android.database.sqlite.model.yml
+++ b/java/ql/lib/ext/android.database.sqlite.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["android.database.sqlite", "SQLiteDatabase", False, "compileStatement", "(String)", "", "Argument[0]", "sql", "manual"]
       - ["android.database.sqlite", "SQLiteDatabase", False, "delete", "(String,String,String[])", "", "Argument[0..1]", "sql", "manual"]
@@ -57,7 +57,7 @@ extensions:
       - ["android.database.sqlite", "SQLiteQueryBuilder", True, "update", "(SQLiteDatabase,ContentValues,String,String[])", "", "Argument[2]", "sql", "manual"]
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["android.database.sqlite", "SQLiteQueryBuilder", True, "appendColumns", "(StringBuilder,String[])", "", "Argument[1].ArrayElement", "Argument[0]", "taint", "manual"]
       - ["android.database.sqlite", "SQLiteQueryBuilder", True, "appendWhere", "(CharSequence)", "", "Argument[0]", "Argument[-1]", "taint", "manual"]

--- a/java/ql/lib/ext/android.net.model.yml
+++ b/java/ql/lib/ext/android.net.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["android.net", "Uri", True, "buildUpon", "", "", "Argument[-1]", "ReturnValue", "taint", "manual"]
       - ["android.net", "Uri", False, "decode", "", "", "Argument[0]", "ReturnValue", "taint", "manual"]

--- a/java/ql/lib/ext/android.os.model.yml
+++ b/java/ql/lib/ext/android.os.model.yml
@@ -1,13 +1,13 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSourceModel
+      extensible: sourceModel
     data:
       - ["android.os", "Environment", False, "getExternalStorageDirectory", "()", "", "ReturnValue", "android-external-storage-dir", "manual"]
       - ["android.os", "Environment", False, "getExternalStoragePublicDirectory", "(String)", "", "ReturnValue", "android-external-storage-dir", "manual"]
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["android.os", "BaseBundle", True, "get", "(String)", "", "Argument[-1].MapValue", "ReturnValue", "value", "manual"]
       - ["android.os", "BaseBundle", True, "getString", "(String)", "", "Argument[-1].MapValue", "ReturnValue", "value", "manual"]

--- a/java/ql/lib/ext/android.support.v4.app.model.yml
+++ b/java/ql/lib/ext/android.support.v4.app.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["android.support.v4.app", "FragmentTransaction", True, "add", "(Class,Bundle,String)", "", "Argument[0]", "fragment-injection", "manual"]
       - ["android.support.v4.app", "FragmentTransaction", True, "add", "(Fragment,String)", "", "Argument[0]", "fragment-injection", "manual"]

--- a/java/ql/lib/ext/android.util.model.yml
+++ b/java/ql/lib/ext/android.util.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSourceModel
+      extensible: sourceModel
     data:
       - ["android.util", "AttributeSet", False, "getAttributeBooleanValue", "", "", "ReturnValue", "remote", "manual"]
       - ["android.util", "AttributeSet", False, "getAttributeCount", "", "", "ReturnValue", "remote", "manual"]
@@ -21,7 +21,7 @@ extensions:
       - ["android.util", "AttributeSet", False, "getStyleAttribute", "", "", "ReturnValue", "remote", "manual"]
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["android.util", "Log", True, "d", "", "", "Argument[1]", "logging", "manual"]
       - ["android.util", "Log", True, "e", "", "", "Argument[1]", "logging", "manual"]

--- a/java/ql/lib/ext/android.webkit.model.yml
+++ b/java/ql/lib/ext/android.webkit.model.yml
@@ -1,13 +1,13 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSourceModel
+      extensible: sourceModel
     data:
       - ["android.webkit", "WebView", False, "getOriginalUrl", "()", "", "ReturnValue", "remote", "manual"]
       - ["android.webkit", "WebView", False, "getUrl", "()", "", "ReturnValue", "remote", "manual"]
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       # Models representing methods susceptible to XSS attacks.
       - ["android.webkit", "WebView", False, "evaluateJavascript", "", "", "Argument[0]", "xss", "manual"]

--- a/java/ql/lib/ext/android.widget.model.yml
+++ b/java/ql/lib/ext/android.widget.model.yml
@@ -1,11 +1,11 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSourceModel
+      extensible: sourceModel
     data:
       - ["android.widget", "EditText", True, "getText", "", "", "ReturnValue", "android-widget", "manual"]
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["android.widget", "EditText", True, "getText", "", "", "Argument[-1]", "ReturnValue", "taint", "manual"]

--- a/java/ql/lib/ext/androidx.core.app.model.yml
+++ b/java/ql/lib/ext/androidx.core.app.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["androidx.core.app", "AlarmManagerCompat", True, "setAlarmClock", "", "", "Argument[2..3]", "pending-intent-sent", "manual"]
       - ["androidx.core.app", "AlarmManagerCompat", True, "setAndAllowWhileIdle", "", "", "Argument[3]", "pending-intent-sent", "manual"]
@@ -11,7 +11,7 @@ extensions:
       - ["androidx.core.app", "NotificationManagerCompat", True, "notify", "(int,Notification)", "", "Argument[1]", "pending-intent-sent", "manual"]
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["androidx.core.app", "NotificationCompat$Action", True, "Action", "(IconCompat,CharSequence,PendingIntent)", "", "Argument[2]", "Argument[-1]", "taint", "manual"]
       - ["androidx.core.app", "NotificationCompat$Action", True, "Action", "(int,CharSequence,PendingIntent)", "", "Argument[2]", "Argument[-1]", "taint", "manual"]

--- a/java/ql/lib/ext/androidx.fragment.app.model.yml
+++ b/java/ql/lib/ext/androidx.fragment.app.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["androidx.fragment.app", "FragmentTransaction", True, "add", "(Class,Bundle,String)", "", "Argument[0]", "fragment-injection", "manual"]
       - ["androidx.fragment.app", "FragmentTransaction", True, "add", "(Fragment,String)", "", "Argument[0]", "fragment-injection", "manual"]

--- a/java/ql/lib/ext/androidx.slice.builders.model.yml
+++ b/java/ql/lib/ext/androidx.slice.builders.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["androidx.slice.builders", "ListBuilder", True, "addAction", "", "", "Argument[-1]", "ReturnValue", "value", "manual"]
       - ["androidx.slice.builders", "ListBuilder", True, "addAction", "", "", "Argument[0].SyntheticField[androidx.slice.Slice.action]", "Argument[-1].SyntheticField[androidx.slice.Slice.action]", "taint", "manual"]

--- a/java/ql/lib/ext/androidx.slice.model.yml
+++ b/java/ql/lib/ext/androidx.slice.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSourceModel
+      extensible: sourceModel
     data:
       - ["androidx.slice", "SliceProvider", True, "onBindSlice", "", "", "Parameter[0]", "contentprovider", "manual"]
       - ["androidx.slice", "SliceProvider", True, "onCreatePermissionRequest", "", "", "Parameter[0]", "contentprovider", "manual"]
@@ -10,7 +10,7 @@ extensions:
       - ["androidx.slice", "SliceProvider", True, "onSliceUnpinned", "", "", "Parameter[0]", "contentprovider", "manual"]
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["androidx.slice", "SliceProvider", True, "onBindSlice", "", "", "ReturnValue", "pending-intent-sent", "manual"]
       - ["androidx.slice", "SliceProvider", True, "onCreatePermissionRequest", "", "", "ReturnValue", "pending-intent-sent", "manual"]

--- a/java/ql/lib/ext/cn.hutool.core.codec.model.yml
+++ b/java/ql/lib/ext/cn.hutool.core.codec.model.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["cn.hutool.core.codec", "Base64", True, "decode", "", "", "Argument[0]", "ReturnValue", "taint", "manual"]

--- a/java/ql/lib/ext/com.esotericsoftware.kryo.io.model.yml
+++ b/java/ql/lib/ext/com.esotericsoftware.kryo.io.model.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["com.esotericsoftware.kryo.io", "Input", False, "Input", "", "", "Argument[0]", "Argument[-1]", "taint", "manual"]

--- a/java/ql/lib/ext/com.esotericsoftware.kryo5.io.model.yml
+++ b/java/ql/lib/ext/com.esotericsoftware.kryo5.io.model.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["com.esotericsoftware.kryo5.io", "Input", False, "Input", "", "", "Argument[0]", "Argument[-1]", "taint", "manual"]

--- a/java/ql/lib/ext/com.fasterxml.jackson.core.model.yml
+++ b/java/ql/lib/ext/com.fasterxml.jackson.core.model.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["com.fasterxml.jackson.core", "JsonFactory", False, "createParser", "", "", "Argument[0]", "ReturnValue", "taint", "manual"]

--- a/java/ql/lib/ext/com.fasterxml.jackson.databind.model.yml
+++ b/java/ql/lib/ext/com.fasterxml.jackson.databind.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["com.fasterxml.jackson.databind", "ObjectMapper", True, "convertValue", "", "", "Argument[0]", "ReturnValue", "taint", "manual"]
       - ["com.fasterxml.jackson.databind", "ObjectMapper", False, "createParser", "", "", "Argument[0]", "ReturnValue", "taint", "manual"]

--- a/java/ql/lib/ext/com.google.common.base.model.yml
+++ b/java/ql/lib/ext/com.google.common.base.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["com.google.common.base", "Splitter", False, "onPattern", "(String)", "", "Argument[0]", "regex-use[]", "manual"]
       - ["com.google.common.base", "Splitter", False, "split", "(CharSequence)", "", "Argument[-1]", "regex-use[0]", "manual"]
@@ -9,7 +9,7 @@ extensions:
       - ["com.google.common.base", "Splitter$MapSplitter", False, "split", "(CharSequence)", "", "Argument[-1]", "regex-use[0]", "manual"]
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["com.google.common.base", "Ascii", False, "toLowerCase", "(CharSequence)", "", "Argument[0]", "ReturnValue", "taint", "manual"]
       - ["com.google.common.base", "Ascii", False, "toLowerCase", "(String)", "", "Argument[0]", "ReturnValue", "taint", "manual"]

--- a/java/ql/lib/ext/com.google.common.cache.model.yml
+++ b/java/ql/lib/ext/com.google.common.cache.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["com.google.common.cache", "Cache", True, "asMap", "()", "", "Argument[-1].MapKey", "ReturnValue.MapKey", "value", "manual"]
       - ["com.google.common.cache", "Cache", True, "asMap", "()", "", "Argument[-1].MapValue", "ReturnValue.MapValue", "value", "manual"]

--- a/java/ql/lib/ext/com.google.common.collect.model.yml
+++ b/java/ql/lib/ext/com.google.common.collect.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       # Methods depending on lambda flow are not currently modeled
       # Methods depending on stronger aliasing properties than we support are also not modeled.

--- a/java/ql/lib/ext/com.google.common.flogger.model.yml
+++ b/java/ql/lib/ext/com.google.common.flogger.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["com.google.common.flogger", "LoggingApi", True, "log", "", "", "Argument[0]", "logging", "manual"]
       - ["com.google.common.flogger", "LoggingApi", True, "log", "(String,Object)", "", "Argument[1]", "logging", "manual"]

--- a/java/ql/lib/ext/com.google.common.io.model.yml
+++ b/java/ql/lib/ext/com.google.common.io.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["com.google.common.io", "Resources", False, "asByteSource", "(URL)", "", "Argument[0]", "url-open-stream", "manual"]
       - ["com.google.common.io", "Resources", False, "asCharSource", "(URL,Charset)", "", "Argument[0]", "url-open-stream", "manual"]
@@ -11,7 +11,7 @@ extensions:
       - ["com.google.common.io", "Resources", False, "toString", "(URL,Charset)", "", "Argument[0]", "url-open-stream", "manual"]
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["com.google.common.io", "BaseEncoding", True, "decode", "(CharSequence)", "", "Argument[-1]", "ReturnValue", "taint", "manual"]
       - ["com.google.common.io", "BaseEncoding", True, "decode", "(CharSequence)", "", "Argument[0]", "ReturnValue", "taint", "manual"]

--- a/java/ql/lib/ext/com.hubspot.jinjava.model.yml
+++ b/java/ql/lib/ext/com.hubspot.jinjava.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["com.hubspot.jinjava", "Jinjava", True, "render", "", "", "Argument[0]", "ssti", "manual"]
       - ["com.hubspot.jinjava", "Jinjava", True, "renderForResult", "", "", "Argument[0]", "ssti", "manual"]

--- a/java/ql/lib/ext/com.mitchellbosecke.pebble.model.yml
+++ b/java/ql/lib/ext/com.mitchellbosecke.pebble.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["com.mitchellbosecke.pebble", "PebbleEngine", True, "getLiteralTemplate", "", "", "Argument[0]", "ssti", "manual"]
       - ["com.mitchellbosecke.pebble", "PebbleEngine", True, "getTemplate", "", "", "Argument[0]", "ssti", "manual"]

--- a/java/ql/lib/ext/com.opensymphony.xwork2.ognl.model.yml
+++ b/java/ql/lib/ext/com.opensymphony.xwork2.ognl.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["com.opensymphony.xwork2.ognl", "OgnlUtil", False, "callMethod", "", "", "Argument[0]", "ognl-injection", "manual"]
       - ["com.opensymphony.xwork2.ognl", "OgnlUtil", False, "getValue", "", "", "Argument[0]", "ognl-injection", "manual"]

--- a/java/ql/lib/ext/com.rabbitmq.client.impl.model.yml
+++ b/java/ql/lib/ext/com.rabbitmq.client.impl.model.yml
@@ -1,14 +1,14 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSourceModel
+      extensible: sourceModel
     data:
       - ["com.rabbitmq.client.impl", "Frame", True, "getInputStream", "()", "", "ReturnValue", "remote", "manual"]
       - ["com.rabbitmq.client.impl", "Frame", True, "getPayload", "()", "", "ReturnValue", "remote", "manual"]
       - ["com.rabbitmq.client.impl", "FrameHandler", True, "readFrame", "()", "", "ReturnValue", "remote", "manual"]
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["com.rabbitmq.client.impl", "Frame", False, "fromBodyFragment", "(int,byte[],int,int)", "", "Argument[1]", "ReturnValue", "taint", "manual"]
       - ["com.rabbitmq.client.impl", "Frame", False, "readFrom", "(DataInputStream)", "", "Argument[0]", "ReturnValue", "taint", "manual"]

--- a/java/ql/lib/ext/com.rabbitmq.client.model.yml
+++ b/java/ql/lib/ext/com.rabbitmq.client.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSourceModel
+      extensible: sourceModel
     data:
       - ["com.rabbitmq.client", "Command", True, "getContentBody", "()", "", "ReturnValue", "remote", "manual"]
       - ["com.rabbitmq.client", "Command", True, "getContentHeader", "()", "", "ReturnValue", "remote", "manual"]
@@ -23,7 +23,7 @@ extensions:
       - ["com.rabbitmq.client", "StringRpcServer", True, "handleStringCall", "", "", "Parameter[0]", "remote", "manual"]
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["com.rabbitmq.client", "GetResponse", True, "GetResponse", "", "", "Argument[2]", "Argument[-1]", "taint", "manual"]
       - ["com.rabbitmq.client", "GetResponse", True, "getBody", "()", "", "Argument[-1]", "ReturnValue", "taint", "manual"]

--- a/java/ql/lib/ext/com.unboundid.ldap.sdk.model.yml
+++ b/java/ql/lib/ext/com.unboundid.ldap.sdk.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["com.unboundid.ldap.sdk", "LDAPConnection", False, "asyncSearch", "", "", "Argument[0]", "ldap", "manual"]
       - ["com.unboundid.ldap.sdk", "LDAPConnection", False, "search", "(ReadOnlySearchRequest)", "", "Argument[0]", "ldap", "manual"]

--- a/java/ql/lib/ext/com.zaxxer.hikari.model.yml
+++ b/java/ql/lib/ext/com.zaxxer.hikari.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["com.zaxxer.hikari", "HikariConfig", False, "HikariConfig", "(Properties)", "", "Argument[0]", "jdbc-url", "manual"]
       - ["com.zaxxer.hikari", "HikariConfig", False, "setJdbcUrl", "(String)", "", "Argument[0]", "jdbc-url", "manual"]

--- a/java/ql/lib/ext/dummy.model.yml
+++ b/java/ql/lib/ext/dummy.model.yml
@@ -2,17 +2,17 @@ extensions:
   # Make sure that the extensible model predicates are at least defined as empty.
   - addsTo:
       pack: codeql/java-all
-      extensible: extSourceModel
+      extensible: sourceModel
     data: []
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data: []
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data: []
   - addsTo:
       pack: codeql/java-all
-      extensible: extNeutralModel
+      extensible: neutralModel
     data: []

--- a/java/ql/lib/ext/experimental/android.webkit.model.yml
+++ b/java/ql/lib/ext/experimental/android.webkit.model.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extExperimentalSummaryModel
+      extensible: experimentalSummaryModel
     data:
       - ["android.webkit", "WebResourceRequest", False, "getUrl", "", "", "Argument[-1]", "ReturnValue", "taint", "manual", "android-web-resource-response"]

--- a/java/ql/lib/ext/experimental/com.auth0.jwt.interfaces.model.yml
+++ b/java/ql/lib/ext/experimental/com.auth0.jwt.interfaces.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extExperimentalSummaryModel
+      extensible: experimentalSummaryModel
     data:
       - ["com.auth0.jwt.interfaces", "Verification", True, "acceptExpiresAt", "", "", "Argument[-1]", "ReturnValue", "value", "manual", "hardcoded-jwt-key"]
       - ["com.auth0.jwt.interfaces", "Verification", True, "acceptIssuedAt", "", "", "Argument[-1]", "ReturnValue", "value", "manual", "hardcoded-jwt-key"]

--- a/java/ql/lib/ext/experimental/com.jfinal.core.model.yml
+++ b/java/ql/lib/ext/experimental/com.jfinal.core.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extExperimentalSourceModel
+      extensible: experimentalSourceModel
     data:
       - ["com.jfinal.core", "Controller", True, "get", "", "", "ReturnValue", "remote", "manual", "file-path-injection"]
       - ["com.jfinal.core", "Controller", True, "getBoolean", "", "", "ReturnValue", "remote", "manual", "file-path-injection"]

--- a/java/ql/lib/ext/experimental/dummy.model.yml
+++ b/java/ql/lib/ext/experimental/dummy.model.yml
@@ -3,13 +3,13 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extExperimentalSourceModel
+      extensible: experimentalSourceModel
     data: []
   - addsTo:
       pack: codeql/java-all
-      extensible: extExperimentalSinkModel
+      extensible: experimentalSinkModel
     data: []
   - addsTo:
       pack: codeql/java-all
-      extensible: extExperimentalSummaryModel
+      extensible: experimentalSummaryModel
     data: []

--- a/java/ql/lib/ext/experimental/io.undertow.server.handlers.resource.model.yml
+++ b/java/ql/lib/ext/experimental/io.undertow.server.handlers.resource.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extExperimentalSummaryModel
+      extensible: experimentalSummaryModel
     data:
       - ["io.undertow.server.handlers.resource", "Resource", True, "getFile", "", "", "Argument[-1]", "ReturnValue", "taint", "manual", "unsafe-url-forward"]
       - ["io.undertow.server.handlers.resource", "Resource", True, "getFilePath", "", "", "Argument[-1]", "ReturnValue", "taint", "manual", "unsafe-url-forward"]

--- a/java/ql/lib/ext/experimental/jakarta.servlet.http.model.yml
+++ b/java/ql/lib/ext/experimental/jakarta.servlet.http.model.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extExperimentalSourceModel
+      extensible: experimentalSourceModel
     data:
       - ["jakarta.servlet.http", "HttpServletRequest", True, "getServletPath", "", "", "ReturnValue", "remote", "manual", "unsafe-url-forward"]

--- a/java/ql/lib/ext/experimental/java.io.model.yml
+++ b/java/ql/lib/ext/experimental/java.io.model.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extExperimentalSummaryModel
+      extensible: experimentalSummaryModel
     data:
       - ["java.io", "FileInputStream", True, "FileInputStream", "", "", "Argument[0]", "Argument[-1]", "taint", "manual", "android-web-resource-response"]

--- a/java/ql/lib/ext/experimental/java.lang.model.yml
+++ b/java/ql/lib/ext/experimental/java.lang.model.yml
@@ -1,12 +1,12 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extExperimentalSinkModel
+      extensible: experimentalSinkModel
     data:
       - ["java.lang", "Thread", True, "sleep", "", "", "Argument[0]", "thread-pause", "manual", "thread-resource-abuse"]
   - addsTo:
       pack: codeql/java-all
-      extensible: extExperimentalSummaryModel
+      extensible: experimentalSummaryModel
     data:
       - ["java.lang", "Math", False, "max", "", "", "Argument[0..1]", "ReturnValue", "value", "manual", "thread-resource-abuse"]
       - ["java.lang", "Math", False, "min", "", "", "Argument[0..1]", "ReturnValue", "value", "manual", "thread-resource-abuse"]

--- a/java/ql/lib/ext/experimental/java.nio.file.model.yml
+++ b/java/ql/lib/ext/experimental/java.nio.file.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extExperimentalSummaryModel
+      extensible: experimentalSummaryModel
     data:
       - ["java.nio.file", "Path", True, "normalize", "", "", "Argument[-1]", "ReturnValue", "taint", "manual", "unsafe-url-forward"]
       - ["java.nio.file", "Path", True, "resolve", "", "", "Argument[-1..0]", "ReturnValue", "taint", "manual", "unsafe-url-forward"]

--- a/java/ql/lib/ext/experimental/java.util.concurrent.model.yml
+++ b/java/ql/lib/ext/experimental/java.util.concurrent.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extExperimentalSinkModel
+      extensible: experimentalSinkModel
     data:
       - ["java.util.concurrent", "TimeUnit", True, "sleep", "", "", "Argument[0]", "thread-pause", "manual", "thread-resource-abuse"]
       - ["java.util.concurrent", "TimeUnit", True, "sleep", "", "", "Argument[0]", "thread-pause", "manual", "unsafe-url-forward"]

--- a/java/ql/lib/ext/experimental/javax.servlet.http.model.yml
+++ b/java/ql/lib/ext/experimental/javax.servlet.http.model.yml
@@ -1,12 +1,12 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extExperimentalSourceModel
+      extensible: experimentalSourceModel
     data:
       - ["javax.servlet.http", "HttpServletRequest", True, "getServletPath", "", "", "ReturnValue", "remote", "manual", "unsafe-url-forward"]
   - addsTo:
       pack: codeql/java-all
-      extensible: extExperimentalSourceModel
+      extensible: experimentalSourceModel
     data:
       - ["javax.servlet.http", "HttpServletRequest", False, "getPathInfo", "()", "", "ReturnValue", "uri-path", "manual", "permissive-dot-regex-query"]
       - ["javax.servlet.http", "HttpServletRequest", False, "getPathTranslated", "()", "", "ReturnValue", "uri-path", "manual", "permissive-dot-regex-query"]

--- a/java/ql/lib/ext/experimental/org.apache.logging.log4j.message.model.yml
+++ b/java/ql/lib/ext/experimental/org.apache.logging.log4j.message.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extExperimentalSummaryModel
+      extensible: experimentalSummaryModel
     data:
       - ["org.apache.logging.log4j.message", "MapMessage", True, "put", "", "", "Argument[1]", "Argument[-1]", "taint", "manual", "log4j-injection"]
       - ["org.apache.logging.log4j.message", "MapMessage", True, "putAll", "", "", "Argument[0].MapValue", "Argument[-1]", "taint", "manual", "log4j-injection"]

--- a/java/ql/lib/ext/experimental/org.apache.logging.log4j.model.yml
+++ b/java/ql/lib/ext/experimental/org.apache.logging.log4j.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extExperimentalSinkModel
+      extensible: experimentalSinkModel
     data:
       - ["org.apache.logging.log4j", "CloseableThreadContext", False, "put", "", "", "Argument[1]", "log4j", "manual", "log4j-injection"]
       - ["org.apache.logging.log4j", "CloseableThreadContext", False, "putAll", "", "", "Argument[0]", "log4j", "manual", "log4j-injection"]

--- a/java/ql/lib/ext/experimental/org.springframework.core.io.model.yml
+++ b/java/ql/lib/ext/experimental/org.springframework.core.io.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extExperimentalSinkModel
+      extensible: experimentalSinkModel
     data:
       - ["org.springframework.core.io", "ClassPathResource", True, "getFilename", "", "", "Argument[-1]", "get-resource", "manual", "unsafe-url-forward"]
       - ["org.springframework.core.io", "ClassPathResource", True, "getPath", "", "", "Argument[-1]", "get-resource", "manual", "unsafe-url-forward"]
@@ -9,7 +9,7 @@ extensions:
       - ["org.springframework.core.io", "ClassPathResource", True, "resolveURL", "", "", "Argument[-1]", "get-resource", "manual", "unsafe-url-forward"]
   - addsTo:
       pack: codeql/java-all
-      extensible: extExperimentalSummaryModel
+      extensible: experimentalSummaryModel
     data:
       - ["org.springframework.core.io", "ClassPathResource", False, "ClassPathResource", "", "", "Argument[0]", "Argument[-1]", "taint", "manual", "unsafe-url-forward"]
       - ["org.springframework.core.io", "Resource", True, "createRelative", "", "", "Argument[0]", "ReturnValue", "taint", "manual", "unsafe-url-forward"]

--- a/java/ql/lib/ext/flexjson.model.yml
+++ b/java/ql/lib/ext/flexjson.model.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["flexjson", "JSONDeserializer", True, "use", "", "", "Argument[-1]", "ReturnValue", "value", "manual"]

--- a/java/ql/lib/ext/freemarker.cache.model.yml
+++ b/java/ql/lib/ext/freemarker.cache.model.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["freemarker.cache", "StringTemplateLoader", True, "putTemplate", "", "", "Argument[1]", "ssti", "manual"]

--- a/java/ql/lib/ext/freemarker.template.model.yml
+++ b/java/ql/lib/ext/freemarker.template.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["freemarker.template", "Template", True, "Template", "(String,Reader)", "", "Argument[1]", "ssti", "manual"]
       - ["freemarker.template", "Template", True, "Template", "(String,Reader,Configuration)", "", "Argument[1]", "ssti", "manual"]

--- a/java/ql/lib/ext/generated/kotlinstdlib.model.yml
+++ b/java/ql/lib/ext/generated/kotlinstdlib.model.yml
@@ -4,7 +4,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["kotlin.io", "FilesKt", false, "appendBytes", "(File,byte[])", "", "Argument[0]", "create-file", "generated"]
       - ["kotlin.io", "FilesKt", false, "appendText", "(File,String,Charset)", "", "Argument[0]", "create-file", "generated"]
@@ -22,7 +22,7 @@ extensions:
 
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["kotlin.collections", "AbstractCollection", true, "toString", "()", "", "Argument[-1]", "ReturnValue", "taint", "generated"]
       - ["kotlin.collections", "ArrayDeque", false, "ArrayDeque", "(Collection)", "", "Argument[0].Element", "Argument[-1]", "taint", "generated"]
@@ -1861,7 +1861,7 @@ extensions:
 
   - addsTo:
       pack: codeql/java-all
-      extensible: extNeutralModel
+      extensible: neutralModel
     data:
       - ["kotlin.annotation", "AnnotationRetention", "valueOf", "(String)", "generated"]
       - ["kotlin.annotation", "AnnotationRetention", "values", "()", "generated"]

--- a/java/ql/lib/ext/generated/org.apache.commons.io.model.yml
+++ b/java/ql/lib/ext/generated/org.apache.commons.io.model.yml
@@ -4,7 +4,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["org.apache.commons.io.file", "PathFilter", true, "accept", "(Path,BasicFileAttributes)", "", "Argument[0]", "create-file", "generated"]
       - ["org.apache.commons.io.file", "PathUtils", false, "copyFile", "(URL,Path,CopyOption[])", "", "Argument[0]", "open-url", "generated"]
@@ -116,7 +116,7 @@ extensions:
 
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["org.apache.commons.io.charset", "CharsetDecoders", true, "toCharsetDecoder", "(CharsetDecoder)", "", "Argument[0]", "ReturnValue", "taint", "generated"]
       - ["org.apache.commons.io.charset", "CharsetEncoders", true, "toCharsetEncoder", "(CharsetEncoder)", "", "Argument[0]", "ReturnValue", "taint", "generated"]
@@ -676,7 +676,7 @@ extensions:
 
   - addsTo:
       pack: codeql/java-all
-      extensible: extNeutralModel
+      extensible: neutralModel
     data:
       - ["org.apache.commons.io.charset", "CharsetDecoders", "CharsetDecoders", "()", "generated"]
       - ["org.apache.commons.io.charset", "CharsetEncoders", "CharsetEncoders", "()", "generated"]

--- a/java/ql/lib/ext/groovy.lang.model.yml
+++ b/java/ql/lib/ext/groovy.lang.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["groovy.lang", "GroovyClassLoader", False, "parseClass", "(GroovyCodeSource)", "", "Argument[0]", "groovy", "manual"]
       - ["groovy.lang", "GroovyClassLoader", False, "parseClass", "(GroovyCodeSource,boolean)", "", "Argument[0]", "groovy", "manual"]

--- a/java/ql/lib/ext/groovy.util.model.yml
+++ b/java/ql/lib/ext/groovy.util.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["groovy.util", "Eval", False, "me", "(String)", "", "Argument[0]", "groovy", "manual"]
       - ["groovy.util", "Eval", False, "me", "(String,Object,String)", "", "Argument[2]", "groovy", "manual"]

--- a/java/ql/lib/ext/jakarta.faces.context.model.yml
+++ b/java/ql/lib/ext/jakarta.faces.context.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSourceModel
+      extensible: sourceModel
     data:
       - ["jakarta.faces.context", "ExternalContext", True, "getRequestCookieMap", "()", "", "ReturnValue", "remote", "manual"]
       - ["jakarta.faces.context", "ExternalContext", True, "getRequestHeaderMap", "()", "", "ReturnValue", "remote", "manual"]
@@ -12,7 +12,7 @@ extensions:
       - ["jakarta.faces.context", "ExternalContext", True, "getRequestPathInfo", "()", "", "ReturnValue", "remote", "manual"]
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["jakarta.faces.context", "ResponseStream", True, "write", "", "", "Argument[0]", "xss", "manual"]
       - ["jakarta.faces.context", "ResponseWriter", True, "write", "", "", "Argument[0]", "xss", "manual"]

--- a/java/ql/lib/ext/jakarta.json.model.yml
+++ b/java/ql/lib/ext/jakarta.json.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["jakarta.json", "Json", False, "createArrayBuilder", "(Collection)", "", "Argument[0].Element", "ReturnValue", "taint", "manual"]
       - ["jakarta.json", "Json", False, "createArrayBuilder", "(JsonArray)", "", "Argument[0]", "ReturnValue", "taint", "manual"]

--- a/java/ql/lib/ext/jakarta.json.stream.model.yml
+++ b/java/ql/lib/ext/jakarta.json.stream.model.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["jakarta.json.stream", "JsonParserFactory", False, "createParser", "", "", "Argument[0]", "ReturnValue", "taint", "manual"]

--- a/java/ql/lib/ext/jakarta.ws.rs.client.model.yml
+++ b/java/ql/lib/ext/jakarta.ws.rs.client.model.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["jakarta.ws.rs.client", "Client", True, "target", "", "", "Argument[0]", "open-url", "manual"]

--- a/java/ql/lib/ext/jakarta.ws.rs.container.model.yml
+++ b/java/ql/lib/ext/jakarta.ws.rs.container.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSourceModel
+      extensible: sourceModel
     data:
       - ["jakarta.ws.rs.container", "ContainerRequestContext", True, "getAcceptableLanguages", "", "", "ReturnValue", "remote", "manual"]
       - ["jakarta.ws.rs.container", "ContainerRequestContext", True, "getAcceptableMediaTypes", "", "", "ReturnValue", "remote", "manual"]

--- a/java/ql/lib/ext/jakarta.ws.rs.core.model.yml
+++ b/java/ql/lib/ext/jakarta.ws.rs.core.model.yml
@@ -1,13 +1,13 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["jakarta.ws.rs.core", "Response", True, "seeOther", "", "", "Argument[0]", "url-redirect", "manual"]
       - ["jakarta.ws.rs.core", "Response", True, "temporaryRedirect", "", "", "Argument[0]", "url-redirect", "manual"]
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["jakarta.ws.rs.core", "AbstractMultivaluedMap", False, "AbstractMultivaluedMap", "", "", "Argument[0].MapKey", "Argument[-1].MapKey", "value", "manual"]
       - ["jakarta.ws.rs.core", "AbstractMultivaluedMap", False, "AbstractMultivaluedMap", "", "", "Argument[0].MapValue", "Argument[-1].MapValue", "value", "manual"]

--- a/java/ql/lib/ext/java.beans.model.yml
+++ b/java/ql/lib/ext/java.beans.model.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["java.beans", "XMLDecoder", False, "XMLDecoder", "", "", "Argument[0]", "Argument[-1]", "taint", "manual"]

--- a/java/ql/lib/ext/java.io.model.yml
+++ b/java/ql/lib/ext/java.io.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["java.io", "FileOutputStream", False, "FileOutputStream", "", "", "Argument[0]", "create-file", "manual"]
       - ["java.io", "FileOutputStream", False, "write", "", "", "Argument[0]", "write-file", "manual"]
@@ -42,7 +42,7 @@ extensions:
       - ["java.io", "Writer", True, "write", "", "", "Argument[0]", "write-file", "manual"]
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["java.io", "BufferedInputStream", False, "BufferedInputStream", "", "", "Argument[0]", "Argument[-1]", "taint", "manual"]
       - ["java.io", "BufferedReader", False, "BufferedReader", "", "", "Argument[0]", "Argument[-1]", "taint", "manual"]

--- a/java/ql/lib/ext/java.lang.model.yml
+++ b/java/ql/lib/ext/java.lang.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["java.lang", "String", False, "matches", "(String)", "", "Argument[0]", "regex-use[f-1]", "manual"]
       - ["java.lang", "String", False, "replaceAll", "(String,String)", "", "Argument[0]", "regex-use[-1]", "manual"]
@@ -18,7 +18,7 @@ extensions:
       - ["java.lang", "System$Logger", True, "log", "(Level,String,Throwable)", "", "Argument[1]", "logging", "manual"]
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["java.lang", "AbstractStringBuilder", True, "AbstractStringBuilder", "(String)", "", "Argument[0]", "Argument[-1]", "taint", "manual"]
       - ["java.lang", "AbstractStringBuilder", True, "append", "", "", "Argument[-1]", "ReturnValue", "value", "manual"]

--- a/java/ql/lib/ext/java.net.http.model.yml
+++ b/java/ql/lib/ext/java.net.http.model.yml
@@ -1,12 +1,12 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSourceModel
+      extensible: sourceModel
     data:
       - ["java.net.http", "WebSocket$Listener", True, "onText", "(WebSocket,CharSequence,boolean)", "", "Parameter[1]", "remote", "manual"]
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["java.net.http", "HttpRequest", False, "newBuilder", "", "", "Argument[0]", "open-url", "manual"]
       - ["java.net.http", "HttpRequest$Builder", False, "uri", "", "", "Argument[0]", "open-url", "manual"]

--- a/java/ql/lib/ext/java.net.model.yml
+++ b/java/ql/lib/ext/java.net.model.yml
@@ -1,13 +1,13 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSourceModel
+      extensible: sourceModel
     data:
       - ["java.net", "Socket", False, "getInputStream", "()", "", "ReturnValue", "remote", "manual"]
       - ["java.net", "URLConnection", False, "getInputStream", "()", "", "ReturnValue", "remote", "manual"]
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["java.net", "URL", False, "openConnection", "", "", "Argument[-1]", "open-url", "manual"]
       - ["java.net", "URL", False, "openStream", "", "", "Argument[-1]", "open-url", "manual"]
@@ -19,7 +19,7 @@ extensions:
       - ["java.net", "URLClassLoader", False, "newInstance", "", "", "Argument[0]", "open-url", "manual"]
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["java.net", "URI", False, "URI", "(String)", "", "Argument[0]", "Argument[-1]", "taint", "manual"]
       - ["java.net", "URI", False, "create", "", "", "Argument[0]", "ReturnValue", "taint", "manual"]

--- a/java/ql/lib/ext/java.nio.channels.model.yml
+++ b/java/ql/lib/ext/java.nio.channels.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["java.nio.channels", "Channels", False, "newChannel", "(InputStream)", "", "Argument[0]", "ReturnValue", "taint", "manual"]
       - ["java.nio.channels", "ReadableByteChannel", True, "read", "(ByteBuffer)", "", "Argument[-1]", "Argument[0]", "taint", "manual"]

--- a/java/ql/lib/ext/java.nio.file.model.yml
+++ b/java/ql/lib/ext/java.nio.file.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["java.nio.file", "Files", False, "copy", "", "", "Argument[1]", "create-file", "manual"]
       - ["java.nio.file", "Files", False, "createDirectories", "", "", "Argument[0]", "create-file", "manual"]
@@ -20,7 +20,7 @@ extensions:
       - ["java.nio.file", "Files", False, "writeString", "", "", "Argument[1]", "write-file", "manual"]
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["java.nio.file", "FileSystem", True, "getPath", "", "", "Argument[0]", "ReturnValue", "taint", "manual"]
       - ["java.nio.file", "FileSystem", True, "getRootDirectories", "", "", "Argument[0]", "ReturnValue", "taint", "manual"]

--- a/java/ql/lib/ext/java.nio.model.yml
+++ b/java/ql/lib/ext/java.nio.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["java.nio", "ByteBuffer", False, "array", "()", "", "Argument[-1]", "ReturnValue", "taint", "manual"]
       - ["java.nio", "ByteBuffer", False, "get", "", "", "Argument[-1]", "ReturnValue", "taint", "manual"]

--- a/java/ql/lib/ext/java.sql.model.yml
+++ b/java/ql/lib/ext/java.sql.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["java.sql", "Connection", True, "prepareCall", "", "", "Argument[0]", "sql", "manual"]
       - ["java.sql", "Connection", True, "prepareStatement", "", "", "Argument[0]", "sql", "manual"]

--- a/java/ql/lib/ext/java.util.concurrent.model.yml
+++ b/java/ql/lib/ext/java.util.concurrent.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["java.util.concurrent", "BlockingDeque", True, "offerFirst", "(Object,long,TimeUnit)", "", "Argument[0]", "Argument[-1].Element", "value", "manual"]
       - ["java.util.concurrent", "BlockingDeque", True, "offerLast", "(Object,long,TimeUnit)", "", "Argument[0]", "Argument[-1].Element", "value", "manual"]

--- a/java/ql/lib/ext/java.util.function.model.yml
+++ b/java/ql/lib/ext/java.util.function.model.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["java.util.function", "Predicate", False, "test", "(Object)", "", "Argument[-1]", "regex-use[0]", "manual"]

--- a/java/ql/lib/ext/java.util.logging.model.yml
+++ b/java/ql/lib/ext/java.util.logging.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["java.util.logging", "Logger", True, "config", "", "", "Argument[0]", "logging", "manual"]
       - ["java.util.logging", "Logger", True, "entering", "(String,String)", "", "Argument[0..1]", "logging", "manual"]
@@ -39,6 +39,6 @@ extensions:
       - ["java.util.logging", "Logger", True, "warning", "", "", "Argument[0]", "logging", "manual"]
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["java.util.logging", "LogRecord", False, "LogRecord", "", "", "Argument[1]", "Argument[-1]", "taint", "manual"]

--- a/java/ql/lib/ext/java.util.model.yml
+++ b/java/ql/lib/ext/java.util.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["java.util", "AbstractMap$SimpleEntry", False, "SimpleEntry", "(Entry)", "", "Argument[0].MapKey", "Argument[-1].MapKey", "value", "manual"]
       - ["java.util", "AbstractMap$SimpleEntry", False, "SimpleEntry", "(Entry)", "", "Argument[0].MapValue", "Argument[-1].MapValue", "value", "manual"]

--- a/java/ql/lib/ext/java.util.regex.model.yml
+++ b/java/ql/lib/ext/java.util.regex.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["java.util.regex", "Matcher", False, "matches", "()", "", "Argument[-1]", "regex-use[f]", "manual"]
       - ["java.util.regex", "Pattern", False, "asMatchPredicate", "()", "", "Argument[-1]", "regex-use[f]", "manual"]
@@ -14,7 +14,7 @@ extensions:
       - ["java.util.regex", "Pattern", False, "splitAsStream", "(CharSequence)", "", "Argument[-1]", "regex-use[0]", "manual"]
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["java.util.regex", "Matcher", False, "group", "", "", "Argument[-1]", "ReturnValue", "taint", "manual"]
       - ["java.util.regex", "Matcher", False, "replaceAll", "", "", "Argument[-1]", "ReturnValue", "taint", "manual"]

--- a/java/ql/lib/ext/java.util.stream.model.yml
+++ b/java/ql/lib/ext/java.util.stream.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["java.util.stream", "BaseStream", True, "iterator", "()", "", "Argument[-1].Element", "ReturnValue.Element", "value", "manual"]
       - ["java.util.stream", "BaseStream", True, "onClose", "(Runnable)", "", "Argument[-1].Element", "ReturnValue.Element", "value", "manual"]

--- a/java/ql/lib/ext/java.util.zip.model.yml
+++ b/java/ql/lib/ext/java.util.zip.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["java.util.zip", "GZIPInputStream", False, "GZIPInputStream", "", "", "Argument[0]", "Argument[-1]", "taint", "manual"]
       - ["java.util.zip", "ZipInputStream", False, "ZipInputStream", "", "", "Argument[0]", "Argument[-1]", "taint", "manual"]

--- a/java/ql/lib/ext/javax.faces.context.model.yml
+++ b/java/ql/lib/ext/javax.faces.context.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSourceModel
+      extensible: sourceModel
     data:
       - ["javax.faces.context", "ExternalContext", True, "getRequestCookieMap", "()", "", "ReturnValue", "remote", "manual"]
       - ["javax.faces.context", "ExternalContext", True, "getRequestHeaderMap", "()", "", "ReturnValue", "remote", "manual"]
@@ -12,7 +12,7 @@ extensions:
       - ["javax.faces.context", "ExternalContext", True, "getRequestPathInfo", "()", "", "ReturnValue", "remote", "manual"]
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["javax.faces.context", "ResponseStream", True, "write", "", "", "Argument[0]", "xss", "manual"]
       - ["javax.faces.context", "ResponseWriter", True, "write", "", "", "Argument[0]", "xss", "manual"]

--- a/java/ql/lib/ext/javax.jms.model.yml
+++ b/java/ql/lib/ext/javax.jms.model.yml
@@ -6,7 +6,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSourceModel
+      extensible: sourceModel
     data:
       - ["javax.jms", "JMSConsumer", True, "receive", "", "", "ReturnValue", "remote", "manual"]
       - ["javax.jms", "JMSConsumer", True, "receiveBody", "", "", "ReturnValue", "remote", "manual"]
@@ -19,7 +19,7 @@ extensions:
       - ["javax.jms", "TopicRequestor", True, "request", "(Message)", "", "ReturnValue", "remote", "manual"]
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["javax.jms", "BytesMessage", True, "readBoolean", "()", "", "Argument[-1]", "ReturnValue", "taint", "manual"]
       - ["javax.jms", "BytesMessage", True, "readByte", "()", "", "Argument[-1]", "ReturnValue", "taint", "manual"]

--- a/java/ql/lib/ext/javax.json.model.yml
+++ b/java/ql/lib/ext/javax.json.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["javax.json", "Json", False, "createArrayBuilder", "(Collection)", "", "Argument[0].Element", "ReturnValue", "taint", "manual"]
       - ["javax.json", "Json", False, "createArrayBuilder", "(JsonArray)", "", "Argument[0]", "ReturnValue", "taint", "manual"]

--- a/java/ql/lib/ext/javax.json.stream.model.yml
+++ b/java/ql/lib/ext/javax.json.stream.model.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["javax.json.stream", "JsonParserFactory", False, "createParser", "", "", "Argument[0]", "ReturnValue", "taint", "manual"]

--- a/java/ql/lib/ext/javax.management.remote.model.yml
+++ b/java/ql/lib/ext/javax.management.remote.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["javax.management.remote", "JMXConnector", True, "connect", "", "", "Argument[-1]", "jndi-injection", "manual"]
       - ["javax.management.remote", "JMXConnectorFactory", False, "connect", "", "", "Argument[0]", "jndi-injection", "manual"]

--- a/java/ql/lib/ext/javax.naming.directory.model.yml
+++ b/java/ql/lib/ext/javax.naming.directory.model.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["javax.naming.directory", "DirContext", True, "search", "", "", "Argument[0..1]", "ldap", "manual"]

--- a/java/ql/lib/ext/javax.naming.model.yml
+++ b/java/ql/lib/ext/javax.naming.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["javax.naming", "Context", True, "list", "", "", "Argument[0]", "jndi-injection", "manual"]
       - ["javax.naming", "Context", True, "listBindings", "", "", "Argument[0]", "jndi-injection", "manual"]

--- a/java/ql/lib/ext/javax.net.ssl.model.yml
+++ b/java/ql/lib/ext/javax.net.ssl.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["javax.net.ssl", "HttpsURLConnection", True, "setDefaultHostnameVerifier", "", "", "Argument[0]", "set-hostname-verifier", "manual"]
       - ["javax.net.ssl", "HttpsURLConnection", True, "setHostnameVerifier", "", "", "Argument[0]", "set-hostname-verifier", "manual"]

--- a/java/ql/lib/ext/javax.script.model.yml
+++ b/java/ql/lib/ext/javax.script.model.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["javax.script", "CompiledScript", False, "eval", "", "", "Argument[-1]", "mvel", "manual"]

--- a/java/ql/lib/ext/javax.servlet.http.model.yml
+++ b/java/ql/lib/ext/javax.servlet.http.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSourceModel
+      extensible: sourceModel
     data:
       - ["javax.servlet.http", "Cookie", False, "getComment", "()", "", "ReturnValue", "remote", "manual"]
       - ["javax.servlet.http", "Cookie", False, "getName", "()", "", "ReturnValue", "remote", "manual"]
@@ -20,7 +20,7 @@ extensions:
       - ["javax.servlet.http", "HttpServletRequest", False, "getRequestURL", "()", "", "ReturnValue", "remote", "manual"]
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["javax.servlet.http", "HttpServletResponse", False, "addCookie", "", "", "Argument[0]", "header-splitting", "manual"]
       - ["javax.servlet.http", "HttpServletResponse", False, "addHeader", "", "", "Argument[0..1]", "header-splitting", "manual"]
@@ -28,7 +28,7 @@ extensions:
       - ["javax.servlet.http", "HttpServletResponse", False, "setHeader", "", "", "Argument[0..1]", "header-splitting", "manual"]
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["javax.servlet.http", "Cookie", False, "Cookie", "", "", "Argument[0]", "Argument[-1]", "taint", "manual"]
       - ["javax.servlet.http", "Cookie", False, "Cookie", "", "", "Argument[1]", "Argument[-1]", "taint", "manual"]

--- a/java/ql/lib/ext/javax.servlet.model.yml
+++ b/java/ql/lib/ext/javax.servlet.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSourceModel
+      extensible: sourceModel
     data:
       - ["javax.servlet", "ServletRequest", False, "getInputStream", "()", "", "ReturnValue", "remote", "manual"]
       - ["javax.servlet", "ServletRequest", False, "getParameter", "(String)", "", "ReturnValue", "remote", "manual"]

--- a/java/ql/lib/ext/javax.validation.model.yml
+++ b/java/ql/lib/ext/javax.validation.model.yml
@@ -1,11 +1,11 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSourceModel
+      extensible: sourceModel
     data:
       - ["javax.validation", "ConstraintValidator", True, "isValid", "", "", "Parameter[0]", "remote", "manual"]
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["javax.validation", "ConstraintValidatorContext", True, "buildConstraintViolationWithTemplate", "", "", "Argument[0]", "bean-validation", "manual"]

--- a/java/ql/lib/ext/javax.ws.rs.client.model.yml
+++ b/java/ql/lib/ext/javax.ws.rs.client.model.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["javax.ws.rs.client", "Client", True, "target", "", "", "Argument[0]", "open-url", "manual"]

--- a/java/ql/lib/ext/javax.ws.rs.container.model.yml
+++ b/java/ql/lib/ext/javax.ws.rs.container.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSourceModel
+      extensible: sourceModel
     data:
       - ["javax.ws.rs.container", "ContainerRequestContext", True, "getAcceptableLanguages", "", "", "ReturnValue", "remote", "manual"]
       - ["javax.ws.rs.container", "ContainerRequestContext", True, "getAcceptableMediaTypes", "", "", "ReturnValue", "remote", "manual"]

--- a/java/ql/lib/ext/javax.ws.rs.core.model.yml
+++ b/java/ql/lib/ext/javax.ws.rs.core.model.yml
@@ -1,14 +1,14 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["javax.ws.rs.core", "Response", True, "seeOther", "", "", "Argument[0]", "url-redirect", "manual"]
       - ["javax.ws.rs.core", "Response", True, "temporaryRedirect", "", "", "Argument[0]", "url-redirect", "manual"]
       - ["javax.ws.rs.core", "ResponseBuilder", False, "header", "", "", "Argument[1]", "header-splitting", "manual"]
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["javax.ws.rs.core", "AbstractMultivaluedMap", False, "AbstractMultivaluedMap", "", "", "Argument[0].MapKey", "Argument[-1].MapKey", "value", "manual"]
       - ["javax.ws.rs.core", "AbstractMultivaluedMap", False, "AbstractMultivaluedMap", "", "", "Argument[0].MapValue", "Argument[-1].MapValue", "value", "manual"]

--- a/java/ql/lib/ext/javax.xml.transform.model.yml
+++ b/java/ql/lib/ext/javax.xml.transform.model.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["javax.xml.transform", "Transformer", False, "transform", "", "", "Argument[-1]", "xslt", "manual"]

--- a/java/ql/lib/ext/javax.xml.transform.sax.model.yml
+++ b/java/ql/lib/ext/javax.xml.transform.sax.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["javax.xml.transform.sax", "SAXSource", False, "SAXSource", "(InputSource)", "", "Argument[0]", "Argument[-1]", "taint", "manual"]
       - ["javax.xml.transform.sax", "SAXSource", False, "SAXSource", "(XMLReader,InputSource)", "", "Argument[1]", "Argument[-1]", "taint", "manual"]

--- a/java/ql/lib/ext/javax.xml.transform.stream.model.yml
+++ b/java/ql/lib/ext/javax.xml.transform.stream.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["javax.xml.transform.stream", "StreamSource", False, "StreamSource", "", "", "Argument[0]", "Argument[-1]", "taint", "manual"]
       - ["javax.xml.transform.stream", "StreamSource", False, "getInputStream", "", "", "Argument[-1]", "ReturnValue", "taint", "manual"]

--- a/java/ql/lib/ext/javax.xml.xpath.model.yml
+++ b/java/ql/lib/ext/javax.xml.xpath.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["javax.xml.xpath", "XPath", True, "compile", "", "", "Argument[0]", "xpath", "manual"]
       - ["javax.xml.xpath", "XPath", True, "evaluate", "", "", "Argument[0]", "xpath", "manual"]

--- a/java/ql/lib/ext/jodd.json.model.yml
+++ b/java/ql/lib/ext/jodd.json.model.yml
@@ -7,7 +7,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["jodd.json", "JsonParser", False, "allowAllClasses", "", "", "Argument[-1]", "ReturnValue", "value", "manual"]
       - ["jodd.json", "JsonParser", False, "allowClass", "", "", "Argument[-1]", "ReturnValue", "value", "manual"]

--- a/java/ql/lib/ext/kotlin.collections.model.yml
+++ b/java/ql/lib/ext/kotlin.collections.model.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["kotlin.collections", "ArraysKt", False, "withIndex", "(Object[])", "", "Argument[0].ArrayElement", "ReturnValue", "taint", "manual"]

--- a/java/ql/lib/ext/kotlin.jvm.internal.model.yml
+++ b/java/ql/lib/ext/kotlin.jvm.internal.model.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["kotlin.jvm.internal", "ArrayIteratorKt", False, "iterator", "(Object[])", "", "Argument[0].ArrayElement", "ReturnValue.Element", "value", "manual"]

--- a/java/ql/lib/ext/net.sf.saxon.s9api.model.yml
+++ b/java/ql/lib/ext/net.sf.saxon.s9api.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["net.sf.saxon.s9api", "Xslt30Transformer", False, "applyTemplates", "", "", "Argument[-1]", "xslt", "manual"]
       - ["net.sf.saxon.s9api", "Xslt30Transformer", False, "callFunction", "", "", "Argument[-1]", "xslt", "manual"]

--- a/java/ql/lib/ext/ognl.enhance.model.yml
+++ b/java/ql/lib/ext/ognl.enhance.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["ognl.enhance", "ExpressionAccessor", True, "get", "", "", "Argument[-1]", "ognl-injection", "manual"]
       - ["ognl.enhance", "ExpressionAccessor", True, "set", "", "", "Argument[-1]", "ognl-injection", "manual"]

--- a/java/ql/lib/ext/ognl.model.yml
+++ b/java/ql/lib/ext/ognl.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["ognl", "Node", False, "getValue", "", "", "Argument[-1]", "ognl-injection", "manual"]
       - ["ognl", "Node", False, "setValue", "", "", "Argument[-1]", "ognl-injection", "manual"]

--- a/java/ql/lib/ext/okhttp3.model.yml
+++ b/java/ql/lib/ext/okhttp3.model.yml
@@ -1,13 +1,13 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["okhttp3", "Request", True, "Request", "", "", "Argument[0]", "open-url", "manual"]
       - ["okhttp3", "Request$Builder", True, "url", "", "", "Argument[0]", "open-url", "manual"]
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["okhttp3", "HttpUrl", False, "parse", "", "", "Argument[0]", "ReturnValue", "taint", "manual"]
       - ["okhttp3", "HttpUrl", False, "uri", "", "", "Argument[-1]", "ReturnValue", "taint", "manual"]

--- a/java/ql/lib/ext/org.apache.commons.codec.model.yml
+++ b/java/ql/lib/ext/org.apache.commons.codec.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["org.apache.commons.codec", "BinaryDecoder", True, "decode", "(byte[])", "", "Argument[0]", "ReturnValue", "taint", "manual"]
       - ["org.apache.commons.codec", "BinaryEncoder", True, "encode", "(byte[])", "", "Argument[0]", "ReturnValue", "taint", "manual"]

--- a/java/ql/lib/ext/org.apache.commons.collections.bag.model.yml
+++ b/java/ql/lib/ext/org.apache.commons.collections.bag.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       # Note that when lambdas are supported we should have more models for TransformedBag, TransformedSortedBag
       - ["org.apache.commons.collections.bag", "AbstractBagDecorator", True, "AbstractBagDecorator", "", "", "Argument[0].Element", "Argument[-1].Element", "value", "manual"]

--- a/java/ql/lib/ext/org.apache.commons.collections.bidimap.model.yml
+++ b/java/ql/lib/ext/org.apache.commons.collections.bidimap.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["org.apache.commons.collections.bidimap", "AbstractBidiMapDecorator", True, "AbstractBidiMapDecorator", "", "", "Argument[0].MapKey", "Argument[-1].MapKey", "value", "manual"]
       - ["org.apache.commons.collections.bidimap", "AbstractBidiMapDecorator", True, "AbstractBidiMapDecorator", "", "", "Argument[0].MapValue", "Argument[-1].MapValue", "value", "manual"]

--- a/java/ql/lib/ext/org.apache.commons.collections.collection.model.yml
+++ b/java/ql/lib/ext/org.apache.commons.collections.collection.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       # Note that when lambdas are supported we should have more models for TransformedCollection
       - ["org.apache.commons.collections.collection", "AbstractCollectionDecorator", True, "AbstractCollectionDecorator", "", "", "Argument[0].Element", "Argument[-1].Element", "value", "manual"]

--- a/java/ql/lib/ext/org.apache.commons.collections.iterators.model.yml
+++ b/java/ql/lib/ext/org.apache.commons.collections.iterators.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       # Note that when lambdas are supported we should have more models for TransformIterator
       - ["org.apache.commons.collections.iterators", "AbstractIteratorDecorator", True, "AbstractIteratorDecorator", "", "", "Argument[0].Element", "Argument[-1].Element", "value", "manual"]

--- a/java/ql/lib/ext/org.apache.commons.collections.keyvalue.model.yml
+++ b/java/ql/lib/ext/org.apache.commons.collections.keyvalue.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       # Note that when lambdas are supported we should model the package `org.apache.commons.collections4.functors`,
       # and when more general callable flow is supported we should model the package

--- a/java/ql/lib/ext/org.apache.commons.collections.list.model.yml
+++ b/java/ql/lib/ext/org.apache.commons.collections.list.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       # Note that when lambdas are supported we should have more models for TransformedList
       - ["org.apache.commons.collections.list", "AbstractLinkedList", True, "AbstractLinkedList", "", "", "Argument[0].Element", "Argument[-1].Element", "value", "manual"]

--- a/java/ql/lib/ext/org.apache.commons.collections.map.model.yml
+++ b/java/ql/lib/ext/org.apache.commons.collections.map.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       # Note that when lambdas are supported we should have more models for DefaultedMap, LazyMap, TransformedMap, TransformedSortedMap
       - ["org.apache.commons.collections.map", "AbstractHashedMap", True, "AbstractHashedMap", "(Map)", "", "Argument[0].MapKey", "Argument[-1].MapKey", "value", "manual"]

--- a/java/ql/lib/ext/org.apache.commons.collections.model.yml
+++ b/java/ql/lib/ext/org.apache.commons.collections.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       # Note that when lambdas are supported we should model things relating to Closure, Factory, Transformer, FluentIterable.forEach, FluentIterable.transform
       # Note that when lambdas are supported we should model the package `org.apache.commons.collections4.functors`,

--- a/java/ql/lib/ext/org.apache.commons.collections.multimap.model.yml
+++ b/java/ql/lib/ext/org.apache.commons.collections.multimap.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       # Note that when lambdas are supported we should have more models for TransformedMultiValuedMap
       - ["org.apache.commons.collections.multimap", "ArrayListValuedHashMap", True, "ArrayListValuedHashMap", "(Map)", "", "Argument[0].MapKey", "Argument[-1].MapKey", "value", "manual"]

--- a/java/ql/lib/ext/org.apache.commons.collections.multiset.model.yml
+++ b/java/ql/lib/ext/org.apache.commons.collections.multiset.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["org.apache.commons.collections.multiset", "HashMultiSet", True, "HashMultiSet", "", "", "Argument[0].Element", "Argument[-1].Element", "value", "manual"]
       - ["org.apache.commons.collections.multiset", "PredicatedMultiSet", True, "predicatedMultiSet", "", "", "Argument[0].Element", "ReturnValue.Element", "value", "manual"]

--- a/java/ql/lib/ext/org.apache.commons.collections.properties.model.yml
+++ b/java/ql/lib/ext/org.apache.commons.collections.properties.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["org.apache.commons.collections.properties", "AbstractPropertiesFactory", True, "load", "(ClassLoader,String)", "", "Argument[1]", "ReturnValue", "taint", "manual"]
       - ["org.apache.commons.collections.properties", "AbstractPropertiesFactory", True, "load", "(File)", "", "Argument[0]", "ReturnValue", "taint", "manual"]

--- a/java/ql/lib/ext/org.apache.commons.collections.queue.model.yml
+++ b/java/ql/lib/ext/org.apache.commons.collections.queue.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       # Note that when lambdas are supported we should have more models for TransformedQueue
       - ["org.apache.commons.collections.queue", "CircularFifoQueue", True, "CircularFifoQueue", "(Collection)", "", "Argument[0].Element", "Argument[-1].Element", "value", "manual"]

--- a/java/ql/lib/ext/org.apache.commons.collections.set.model.yml
+++ b/java/ql/lib/ext/org.apache.commons.collections.set.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       # Note that when lambdas are supported we should have more models for TransformedNavigableSet
       - ["org.apache.commons.collections.set", "AbstractNavigableSetDecorator", True, "AbstractNavigableSetDecorator", "", "", "Argument[0].Element", "Argument[-1].Element", "value", "manual"]

--- a/java/ql/lib/ext/org.apache.commons.collections.splitmap.model.yml
+++ b/java/ql/lib/ext/org.apache.commons.collections.splitmap.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       # Note that when lambdas are supported we should have more models for TransformedSplitMap
       - ["org.apache.commons.collections.splitmap", "AbstractIterableGetMapDecorator", True, "AbstractIterableGetMapDecorator", "", "", "Argument[0].MapKey", "Argument[-1].MapKey", "value", "manual"]

--- a/java/ql/lib/ext/org.apache.commons.collections.trie.model.yml
+++ b/java/ql/lib/ext/org.apache.commons.collections.trie.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       # Note that when lambdas are supported we should have more models for TransformedSplitMap
       - ["org.apache.commons.collections.trie", "AbstractPatriciaTrie", True, "select", "", "", "Argument[-1].MapKey", "ReturnValue.MapKey", "value", "manual"]

--- a/java/ql/lib/ext/org.apache.commons.collections4.bag.model.yml
+++ b/java/ql/lib/ext/org.apache.commons.collections4.bag.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       # Note that when lambdas are supported we should have more models for TransformedBag, TransformedSortedBag
       - ["org.apache.commons.collections4.bag", "AbstractBagDecorator", True, "AbstractBagDecorator", "", "", "Argument[0].Element", "Argument[-1].Element", "value", "manual"]

--- a/java/ql/lib/ext/org.apache.commons.collections4.bidimap.model.yml
+++ b/java/ql/lib/ext/org.apache.commons.collections4.bidimap.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["org.apache.commons.collections4.bidimap", "AbstractBidiMapDecorator", True, "AbstractBidiMapDecorator", "", "", "Argument[0].MapKey", "Argument[-1].MapKey", "value", "manual"]
       - ["org.apache.commons.collections4.bidimap", "AbstractBidiMapDecorator", True, "AbstractBidiMapDecorator", "", "", "Argument[0].MapValue", "Argument[-1].MapValue", "value", "manual"]

--- a/java/ql/lib/ext/org.apache.commons.collections4.collection.model.yml
+++ b/java/ql/lib/ext/org.apache.commons.collections4.collection.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       # Note that when lambdas are supported we should have more models for TransformedCollection
       - ["org.apache.commons.collections4.collection", "AbstractCollectionDecorator", True, "AbstractCollectionDecorator", "", "", "Argument[0].Element", "Argument[-1].Element", "value", "manual"]

--- a/java/ql/lib/ext/org.apache.commons.collections4.iterators.model.yml
+++ b/java/ql/lib/ext/org.apache.commons.collections4.iterators.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       # Note that when lambdas are supported we should have more models for TransformIterator
       - ["org.apache.commons.collections4.iterators", "AbstractIteratorDecorator", True, "AbstractIteratorDecorator", "", "", "Argument[0].Element", "Argument[-1].Element", "value", "manual"]

--- a/java/ql/lib/ext/org.apache.commons.collections4.keyvalue.model.yml
+++ b/java/ql/lib/ext/org.apache.commons.collections4.keyvalue.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       # Note that when lambdas are supported we should model the package `org.apache.commons.collections4.functors`,
       # and when more general callable flow is supported we should model the package

--- a/java/ql/lib/ext/org.apache.commons.collections4.list.model.yml
+++ b/java/ql/lib/ext/org.apache.commons.collections4.list.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       # Note that when lambdas are supported we should have more models for TransformedList
       - ["org.apache.commons.collections4.list", "AbstractLinkedList", True, "AbstractLinkedList", "", "", "Argument[0].Element", "Argument[-1].Element", "value", "manual"]

--- a/java/ql/lib/ext/org.apache.commons.collections4.map.model.yml
+++ b/java/ql/lib/ext/org.apache.commons.collections4.map.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       # Note that when lambdas are supported we should have more models for DefaultedMap, LazyMap, TransformedMap, TransformedSortedMap
       - ["org.apache.commons.collections4.map", "AbstractHashedMap", True, "AbstractHashedMap", "(Map)", "", "Argument[0].MapKey", "Argument[-1].MapKey", "value", "manual"]

--- a/java/ql/lib/ext/org.apache.commons.collections4.model.yml
+++ b/java/ql/lib/ext/org.apache.commons.collections4.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       # Note that when lambdas are supported we should model things relating to Closure, Factory, Transformer, FluentIterable.forEach, FluentIterable.transform
       # Note that when lambdas are supported we should model the package `org.apache.commons.collections4.functors`,

--- a/java/ql/lib/ext/org.apache.commons.collections4.multimap.model.yml
+++ b/java/ql/lib/ext/org.apache.commons.collections4.multimap.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       # Note that when lambdas are supported we should have more models for TransformedMultiValuedMap
       - ["org.apache.commons.collections4.multimap", "ArrayListValuedHashMap", True, "ArrayListValuedHashMap", "(Map)", "", "Argument[0].MapKey", "Argument[-1].MapKey", "value", "manual"]

--- a/java/ql/lib/ext/org.apache.commons.collections4.multiset.model.yml
+++ b/java/ql/lib/ext/org.apache.commons.collections4.multiset.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["org.apache.commons.collections4.multiset", "HashMultiSet", True, "HashMultiSet", "", "", "Argument[0].Element", "Argument[-1].Element", "value", "manual"]
       - ["org.apache.commons.collections4.multiset", "PredicatedMultiSet", True, "predicatedMultiSet", "", "", "Argument[0].Element", "ReturnValue.Element", "value", "manual"]

--- a/java/ql/lib/ext/org.apache.commons.collections4.properties.model.yml
+++ b/java/ql/lib/ext/org.apache.commons.collections4.properties.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["org.apache.commons.collections4.properties", "AbstractPropertiesFactory", True, "load", "(ClassLoader,String)", "", "Argument[1]", "ReturnValue", "taint", "manual"]
       - ["org.apache.commons.collections4.properties", "AbstractPropertiesFactory", True, "load", "(File)", "", "Argument[0]", "ReturnValue", "taint", "manual"]

--- a/java/ql/lib/ext/org.apache.commons.collections4.queue.model.yml
+++ b/java/ql/lib/ext/org.apache.commons.collections4.queue.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       # Note that when lambdas are supported we should have more models for TransformedQueue
       - ["org.apache.commons.collections4.queue", "CircularFifoQueue", True, "CircularFifoQueue", "(Collection)", "", "Argument[0].Element", "Argument[-1].Element", "value", "manual"]

--- a/java/ql/lib/ext/org.apache.commons.collections4.set.model.yml
+++ b/java/ql/lib/ext/org.apache.commons.collections4.set.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       # Note that when lambdas are supported we should have more models for TransformedNavigableSet
       - ["org.apache.commons.collections4.set", "AbstractNavigableSetDecorator", True, "AbstractNavigableSetDecorator", "", "", "Argument[0].Element", "Argument[-1].Element", "value", "manual"]

--- a/java/ql/lib/ext/org.apache.commons.collections4.splitmap.model.yml
+++ b/java/ql/lib/ext/org.apache.commons.collections4.splitmap.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       # Note that when lambdas are supported we should have more models for TransformedSplitMap
       - ["org.apache.commons.collections4.splitmap", "AbstractIterableGetMapDecorator", True, "AbstractIterableGetMapDecorator", "", "", "Argument[0].MapKey", "Argument[-1].MapKey", "value", "manual"]

--- a/java/ql/lib/ext/org.apache.commons.collections4.trie.model.yml
+++ b/java/ql/lib/ext/org.apache.commons.collections4.trie.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       # Note that when lambdas are supported we should have more models for TransformedSplitMap
       - ["org.apache.commons.collections4.trie", "AbstractPatriciaTrie", True, "select", "", "", "Argument[-1].MapKey", "ReturnValue.MapKey", "value", "manual"]

--- a/java/ql/lib/ext/org.apache.commons.io.model.yml
+++ b/java/ql/lib/ext/org.apache.commons.io.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       # Models that are not yet auto generated or where the generated summaries will
       # be ignored.

--- a/java/ql/lib/ext/org.apache.commons.jexl2.model.yml
+++ b/java/ql/lib/ext/org.apache.commons.jexl2.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["org.apache.commons.jexl2", "Expression", False, "callable", "", "", "Argument[-1]", "jexl", "manual"]
       - ["org.apache.commons.jexl2", "Expression", False, "evaluate", "", "", "Argument[-1]", "jexl", "manual"]

--- a/java/ql/lib/ext/org.apache.commons.jexl3.model.yml
+++ b/java/ql/lib/ext/org.apache.commons.jexl3.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["org.apache.commons.jexl3", "Expression", False, "callable", "", "", "Argument[-1]", "jexl", "manual"]
       - ["org.apache.commons.jexl3", "Expression", False, "evaluate", "", "", "Argument[-1]", "jexl", "manual"]

--- a/java/ql/lib/ext/org.apache.commons.lang3.builder.model.yml
+++ b/java/ql/lib/ext/org.apache.commons.lang3.builder.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["org.apache.commons.lang3.builder", "ToStringBuilder", False, "append", "", "", "Argument[-1]", "ReturnValue", "value", "manual"]
       - ["org.apache.commons.lang3.builder", "ToStringBuilder", False, "append", "(java.lang.Object)", "", "Argument[0]", "Argument[-1]", "taint", "manual"]

--- a/java/ql/lib/ext/org.apache.commons.lang3.model.yml
+++ b/java/ql/lib/ext/org.apache.commons.lang3.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["org.apache.commons.lang3", "RegExUtils", False, "removeAll", "(String,String)", "", "Argument[1]", "regex-use", "manual"]
       - ["org.apache.commons.lang3", "RegExUtils", False, "removeFirst", "(String,String)", "", "Argument[1]", "regex-use", "manual"]
@@ -11,7 +11,7 @@ extensions:
       - ["org.apache.commons.lang3", "RegExUtils", False, "replacePattern", "(String,String,String)", "", "Argument[1]", "regex-use", "manual"]
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["org.apache.commons.lang3", "ArrayUtils", False, "add", "", "", "Argument[0].ArrayElement", "ReturnValue.ArrayElement", "value", "manual"]
       - ["org.apache.commons.lang3", "ArrayUtils", False, "add", "", "", "Argument[2]", "ReturnValue.ArrayElement", "value", "manual"]

--- a/java/ql/lib/ext/org.apache.commons.lang3.mutable.model.yml
+++ b/java/ql/lib/ext/org.apache.commons.lang3.mutable.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["org.apache.commons.lang3.mutable", "Mutable", True, "getValue", "", "", "Argument[-1].SyntheticField[org.apache.commons.lang3.mutable.MutableObject.value]", "ReturnValue", "value", "manual"]
       - ["org.apache.commons.lang3.mutable", "Mutable", True, "setValue", "", "", "Argument[0]", "Argument[-1].SyntheticField[org.apache.commons.lang3.mutable.MutableObject.value]", "value", "manual"]

--- a/java/ql/lib/ext/org.apache.commons.lang3.text.model.yml
+++ b/java/ql/lib/ext/org.apache.commons.lang3.text.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["org.apache.commons.lang3.text", "StrBuilder", False, "StrBuilder", "(java.lang.String)", "", "Argument[0]", "Argument[-1]", "taint", "manual"]
       - ["org.apache.commons.lang3.text", "StrBuilder", False, "append", "", "", "Argument[-1]", "ReturnValue", "taint", "manual"]

--- a/java/ql/lib/ext/org.apache.commons.lang3.tuple.model.yml
+++ b/java/ql/lib/ext/org.apache.commons.lang3.tuple.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["org.apache.commons.lang3.tuple", "ImmutablePair", False, "ImmutablePair", "(java.lang.Object,java.lang.Object)", "", "Argument[0]", "Argument[-1].Field[org.apache.commons.lang3.tuple.ImmutablePair.left]", "value", "manual"]
       - ["org.apache.commons.lang3.tuple", "ImmutablePair", False, "ImmutablePair", "(java.lang.Object,java.lang.Object)", "", "Argument[1]", "Argument[-1].Field[org.apache.commons.lang3.tuple.ImmutablePair.right]", "value", "manual"]

--- a/java/ql/lib/ext/org.apache.commons.logging.model.yml
+++ b/java/ql/lib/ext/org.apache.commons.logging.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["org.apache.commons.logging", "Log", True, "debug", "", "", "Argument[0]", "logging", "manual"]
       - ["org.apache.commons.logging", "Log", True, "error", "", "", "Argument[0]", "logging", "manual"]

--- a/java/ql/lib/ext/org.apache.commons.ognl.enhance.model.yml
+++ b/java/ql/lib/ext/org.apache.commons.ognl.enhance.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["org.apache.commons.ognl.enhance", "ExpressionAccessor", True, "get", "", "", "Argument[-1]", "ognl-injection", "manual"]
       - ["org.apache.commons.ognl.enhance", "ExpressionAccessor", True, "set", "", "", "Argument[-1]", "ognl-injection", "manual"]

--- a/java/ql/lib/ext/org.apache.commons.ognl.model.yml
+++ b/java/ql/lib/ext/org.apache.commons.ognl.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["org.apache.commons.ognl", "Node", True, "getValue", "", "", "Argument[-1]", "ognl-injection", "manual"]
       - ["org.apache.commons.ognl", "Node", True, "setValue", "", "", "Argument[-1]", "ognl-injection", "manual"]

--- a/java/ql/lib/ext/org.apache.commons.text.lookup.model.yml
+++ b/java/ql/lib/ext/org.apache.commons.text.lookup.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["org.apache.commons.text.lookup", "StringLookup", True, "lookup", "", "", "Argument[-1]", "ReturnValue", "taint", "manual"]
       - ["org.apache.commons.text.lookup", "StringLookupFactory", False, "mapStringLookup", "", "", "Argument[0].MapValue", "ReturnValue", "taint", "manual"]

--- a/java/ql/lib/ext/org.apache.commons.text.model.yml
+++ b/java/ql/lib/ext/org.apache.commons.text.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["org.apache.commons.text", "StrBuilder", False, "StrBuilder", "(java.lang.String)", "", "Argument[0]", "Argument[-1]", "taint", "manual"]
       - ["org.apache.commons.text", "StrBuilder", False, "append", "", "", "Argument[-1]", "ReturnValue", "taint", "manual"]

--- a/java/ql/lib/ext/org.apache.directory.ldap.client.api.model.yml
+++ b/java/ql/lib/ext/org.apache.directory.ldap.client.api.model.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["org.apache.directory.ldap.client.api", "LdapConnection", True, "search", "", "", "Argument[0..2]", "ldap", "manual"]

--- a/java/ql/lib/ext/org.apache.hc.core5.function.model.yml
+++ b/java/ql/lib/ext/org.apache.hc.core5.function.model.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["org.apache.hc.core5.function", "Supplier", True, "get", "()", "", "Argument[-1]", "ReturnValue", "taint", "manual"]

--- a/java/ql/lib/ext/org.apache.hc.core5.http.io.entity.model.yml
+++ b/java/ql/lib/ext/org.apache.hc.core5.http.io.entity.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["org.apache.hc.core5.http.io.entity", "BasicHttpEntity", True, "BasicHttpEntity", "", "", "Argument[0]", "ReturnValue", "taint", "manual"]
       - ["org.apache.hc.core5.http.io.entity", "BufferedHttpEntity", True, "BufferedHttpEntity", "(HttpEntity)", "", "Argument[0]", "ReturnValue", "taint", "manual"]

--- a/java/ql/lib/ext/org.apache.hc.core5.http.io.model.yml
+++ b/java/ql/lib/ext/org.apache.hc.core5.http.io.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSourceModel
+      extensible: sourceModel
     data:
       - ["org.apache.hc.core5.http.io", "HttpRequestHandler", True, "handle", "(ClassicHttpRequest,ClassicHttpResponse,HttpContext)", "", "Parameter[0]", "remote", "manual"]
       - ["org.apache.hc.core5.http.io", "HttpServerRequestHandler", True, "handle", "(ClassicHttpRequest,ResponseTrigger,HttpContext)", "", "Parameter[0]", "remote", "manual"]

--- a/java/ql/lib/ext/org.apache.hc.core5.http.message.model.yml
+++ b/java/ql/lib/ext/org.apache.hc.core5.http.message.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["org.apache.hc.core5.http.message", "RequestLine", True, "RequestLine", "(HttpRequest)", "", "Argument[0]", "Argument[-1]", "taint", "manual"]
       - ["org.apache.hc.core5.http.message", "RequestLine", True, "RequestLine", "(String,String,ProtocolVersion)", "", "Argument[1]", "Argument[-1]", "taint", "manual"]

--- a/java/ql/lib/ext/org.apache.hc.core5.http.model.yml
+++ b/java/ql/lib/ext/org.apache.hc.core5.http.model.yml
@@ -1,12 +1,12 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["org.apache.hc.core5.http", "HttpEntityContainer", True, "setEntity", "(HttpEntity)", "", "Argument[0]", "xss", "manual"]
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["org.apache.hc.core5.http", "EntityDetails", True, "getContentEncoding", "()", "", "Argument[-1]", "ReturnValue", "taint", "manual"]
       - ["org.apache.hc.core5.http", "EntityDetails", True, "getContentType", "()", "", "Argument[-1]", "ReturnValue", "taint", "manual"]

--- a/java/ql/lib/ext/org.apache.hc.core5.net.model.yml
+++ b/java/ql/lib/ext/org.apache.hc.core5.net.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["org.apache.hc.core5.net", "URIAuthority", True, "getHostName", "()", "", "Argument[-1]", "ReturnValue", "taint", "manual"]
       - ["org.apache.hc.core5.net", "URIAuthority", True, "toString", "()", "", "Argument[-1]", "ReturnValue", "taint", "manual"]

--- a/java/ql/lib/ext/org.apache.hc.core5.util.model.yml
+++ b/java/ql/lib/ext/org.apache.hc.core5.util.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["org.apache.hc.core5.util", "Args", True, "containsNoBlanks", "(CharSequence,String)", "", "Argument[0]", "ReturnValue", "value", "manual"]
       - ["org.apache.hc.core5.util", "Args", True, "notBlank", "(CharSequence,String)", "", "Argument[0]", "ReturnValue", "value", "manual"]

--- a/java/ql/lib/ext/org.apache.http.client.methods.model.yml
+++ b/java/ql/lib/ext/org.apache.http.client.methods.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["org.apache.http.client.methods", "HttpDelete", False, "HttpDelete", "", "", "Argument[0]", "open-url", "manual"]
       - ["org.apache.http.client.methods", "HttpGet", False, "HttpGet", "", "", "Argument[0]", "open-url", "manual"]

--- a/java/ql/lib/ext/org.apache.http.entity.model.yml
+++ b/java/ql/lib/ext/org.apache.http.entity.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["org.apache.http.entity", "BasicHttpEntity", True, "setContent", "(InputStream)", "", "Argument[0]", "Argument[-1]", "taint", "manual"]
       - ["org.apache.http.entity", "BufferedHttpEntity", True, "BufferedHttpEntity", "(HttpEntity)", "", "Argument[0]", "ReturnValue", "taint", "manual"]

--- a/java/ql/lib/ext/org.apache.http.message.model.yml
+++ b/java/ql/lib/ext/org.apache.http.message.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["org.apache.http.message", "BasicHttpEntityEnclosingRequest", False, "BasicHttpEntityEnclosingRequest", "(RequestLine)", "", "Argument[0]", "open-url", "manual"]
       - ["org.apache.http.message", "BasicHttpEntityEnclosingRequest", False, "BasicHttpEntityEnclosingRequest", "(String,String)", "", "Argument[1]", "open-url", "manual"]
@@ -11,6 +11,6 @@ extensions:
       - ["org.apache.http.message", "BasicHttpRequest", False, "BasicHttpRequest", "(String,String,ProtocolVersion)", "", "Argument[1]", "open-url", "manual"]
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["org.apache.http.message", "BasicRequestLine", False, "BasicRequestLine", "", "", "Argument[1]", "Argument[-1]", "taint", "manual"]

--- a/java/ql/lib/ext/org.apache.http.model.yml
+++ b/java/ql/lib/ext/org.apache.http.model.yml
@@ -1,19 +1,19 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSourceModel
+      extensible: sourceModel
     data:
       - ["org.apache.http", "HttpEntity", False, "getContent", "()", "", "ReturnValue", "remote", "manual"]
       - ["org.apache.http", "HttpMessage", False, "getParams", "()", "", "ReturnValue", "remote", "manual"]
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["org.apache.http", "HttpRequest", True, "setURI", "", "", "Argument[0]", "open-url", "manual"]
       - ["org.apache.http", "HttpResponse", True, "setEntity", "(HttpEntity)", "", "Argument[0]", "xss", "manual"]
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["org.apache.http", "Header", True, "getElements", "()", "", "Argument[-1]", "ReturnValue", "taint", "manual"]
       - ["org.apache.http", "HeaderElement", True, "getName", "()", "", "Argument[-1]", "ReturnValue", "taint", "manual"]

--- a/java/ql/lib/ext/org.apache.http.params.model.yml
+++ b/java/ql/lib/ext/org.apache.http.params.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["org.apache.http.params", "HttpParams", True, "getDoubleParameter", "(String,double)", "", "Argument[-1]", "ReturnValue", "taint", "manual"]
       - ["org.apache.http.params", "HttpParams", True, "getDoubleParameter", "(String,double)", "", "Argument[1]", "ReturnValue", "value", "manual"]

--- a/java/ql/lib/ext/org.apache.http.protocol.model.yml
+++ b/java/ql/lib/ext/org.apache.http.protocol.model.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSourceModel
+      extensible: sourceModel
     data:
       - ["org.apache.http.protocol", "HttpRequestHandler", True, "handle", "(HttpRequest,HttpResponse,HttpContext)", "", "Parameter[0]", "remote", "manual"]

--- a/java/ql/lib/ext/org.apache.http.util.model.yml
+++ b/java/ql/lib/ext/org.apache.http.util.model.yml
@@ -1,12 +1,12 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["org.apache.http.util", "EntityUtils", True, "updateEntity", "(HttpResponse,HttpEntity)", "", "Argument[1]", "xss", "manual"]
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["org.apache.http.util", "Args", True, "containsNoBlanks", "(CharSequence,String)", "", "Argument[0]", "ReturnValue", "value", "manual"]
       - ["org.apache.http.util", "Args", True, "notBlank", "(CharSequence,String)", "", "Argument[0]", "ReturnValue", "value", "manual"]

--- a/java/ql/lib/ext/org.apache.ibatis.jdbc.model.yml
+++ b/java/ql/lib/ext/org.apache.ibatis.jdbc.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["org.apache.ibatis.jdbc", "SqlRunner", False, "delete", "(String,Object[])", "", "Argument[0]", "sql", "manual"]
       - ["org.apache.ibatis.jdbc", "SqlRunner", False, "insert", "(String,Object[])", "", "Argument[0]", "sql", "manual"]
@@ -11,7 +11,7 @@ extensions:
       - ["org.apache.ibatis.jdbc", "SqlRunner", False, "update", "(String,Object[])", "", "Argument[0]", "sql", "manual"]
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["org.apache.ibatis.jdbc", "AbstractSQL", True, "DELETE_FROM", "(String)", "", "Argument[0]", "Argument[-1]", "taint", "manual"]
       - ["org.apache.ibatis.jdbc", "AbstractSQL", True, "FETCH_FIRST_ROWS_ONLY", "(String)", "", "Argument[0]", "Argument[-1]", "taint", "manual"]

--- a/java/ql/lib/ext/org.apache.log4j.model.yml
+++ b/java/ql/lib/ext/org.apache.log4j.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["org.apache.log4j", "Category", True, "assertLog", "", "", "Argument[1]", "logging", "manual"]
       - ["org.apache.log4j", "Category", True, "debug", "", "", "Argument[0]", "logging", "manual"]

--- a/java/ql/lib/ext/org.apache.logging.log4j.model.yml
+++ b/java/ql/lib/ext/org.apache.logging.log4j.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["org.apache.logging.log4j", "LogBuilder", True, "log", "(CharSequence)", "", "Argument[0]", "logging", "manual"]
       - ["org.apache.logging.log4j", "LogBuilder", True, "log", "(Message)", "", "Argument[0]", "logging", "manual"]
@@ -364,7 +364,7 @@ extensions:
       - ["org.apache.logging.log4j", "Logger", True, "warn", "(Supplier,Throwable)", "", "Argument[0]", "logging", "manual"]
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["org.apache.logging.log4j", "Logger", True, "traceEntry", "(Message)", "", "Argument[0]", "ReturnValue", "taint", "manual"]
       - ["org.apache.logging.log4j", "Logger", True, "traceEntry", "(String,Object[])", "", "Argument[0..1]", "ReturnValue", "taint", "manual"]

--- a/java/ql/lib/ext/org.apache.shiro.codec.model.yml
+++ b/java/ql/lib/ext/org.apache.shiro.codec.model.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["org.apache.shiro.codec", "Base64", False, "decode", "(String)", "", "Argument[0]", "ReturnValue", "taint", "manual"]

--- a/java/ql/lib/ext/org.apache.shiro.jndi.model.yml
+++ b/java/ql/lib/ext/org.apache.shiro.jndi.model.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["org.apache.shiro.jndi", "JndiTemplate", False, "lookup", "", "", "Argument[0]", "jndi-injection", "manual"]

--- a/java/ql/lib/ext/org.apache.velocity.app.model.yml
+++ b/java/ql/lib/ext/org.apache.velocity.app.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["org.apache.velocity.app", "Velocity", True, "evaluate", "", "", "Argument[3]", "ssti", "manual"]
       - ["org.apache.velocity.app", "Velocity", True, "mergeTemplate", "", "", "Argument[2]", "ssti", "manual"]

--- a/java/ql/lib/ext/org.apache.velocity.runtime.model.yml
+++ b/java/ql/lib/ext/org.apache.velocity.runtime.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["org.apache.velocity.runtime", "RuntimeServices", True, "evaluate", "", "", "Argument[3]", "ssti", "manual"]
       - ["org.apache.velocity.runtime", "RuntimeServices", True, "parse", "", "", "Argument[0]", "ssti", "manual"]

--- a/java/ql/lib/ext/org.apache.velocity.runtime.resource.util.model.yml
+++ b/java/ql/lib/ext/org.apache.velocity.runtime.resource.util.model.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["org.apache.velocity.runtime.resource.util", "StringResourceRepository", True, "putStringResource", "", "", "Argument[1]", "ssti", "manual"]

--- a/java/ql/lib/ext/org.codehaus.groovy.control.model.yml
+++ b/java/ql/lib/ext/org.codehaus.groovy.control.model.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["org.codehaus.groovy.control", "CompilationUnit", False, "compile", "", "", "Argument[-1]", "groovy", "manual"]

--- a/java/ql/lib/ext/org.dom4j.model.yml
+++ b/java/ql/lib/ext/org.dom4j.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["org.dom4j", "DocumentFactory", True, "createPattern", "", "", "Argument[0]", "xpath", "manual"]
       - ["org.dom4j", "DocumentFactory", True, "createXPath", "", "", "Argument[0]", "xpath", "manual"]

--- a/java/ql/lib/ext/org.dom4j.tree.model.yml
+++ b/java/ql/lib/ext/org.dom4j.tree.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["org.dom4j.tree", "AbstractNode", True, "createPattern", "", "", "Argument[0]", "xpath", "manual"]
       - ["org.dom4j.tree", "AbstractNode", True, "createXPathFilter", "", "", "Argument[0]", "xpath", "manual"]

--- a/java/ql/lib/ext/org.dom4j.util.model.yml
+++ b/java/ql/lib/ext/org.dom4j.util.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["org.dom4j.util", "ProxyDocumentFactory", True, "createPattern", "", "", "Argument[0]", "xpath", "manual"]
       - ["org.dom4j.util", "ProxyDocumentFactory", True, "createXPath", "", "", "Argument[0]", "xpath", "manual"]

--- a/java/ql/lib/ext/org.hibernate.model.yml
+++ b/java/ql/lib/ext/org.hibernate.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["org.hibernate", "QueryProducer", True, "createNativeQuery", "", "", "Argument[0]", "sql", "manual"]
       - ["org.hibernate", "QueryProducer", True, "createQuery", "", "", "Argument[0]", "sql", "manual"]

--- a/java/ql/lib/ext/org.jboss.logging.model.yml
+++ b/java/ql/lib/ext/org.jboss.logging.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["org.jboss.logging", "BasicLogger", True, "debug", "(Object)", "", "Argument[0]", "logging", "manual"]
       - ["org.jboss.logging", "BasicLogger", True, "debug", "(Object,Object[])", "", "Argument[0..1]", "logging", "manual"]

--- a/java/ql/lib/ext/org.jdbi.v3.core.model.yml
+++ b/java/ql/lib/ext/org.jdbi.v3.core.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["org.jdbi.v3.core", "Jdbi", False, "create", "(String)", "", "Argument[0]", "jdbc-url", "manual"]
       - ["org.jdbi.v3.core", "Jdbi", False, "create", "(String,Properties)", "", "Argument[0]", "jdbc-url", "manual"]

--- a/java/ql/lib/ext/org.jooq.model.yml
+++ b/java/ql/lib/ext/org.jooq.model.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["org.jooq", "PlainSQL", False, "", "", "Annotated", "Argument[0]", "sql", "manual"]

--- a/java/ql/lib/ext/org.json.model.yml
+++ b/java/ql/lib/ext/org.json.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["org.json", "CDL", False, "rowToJSONArray", "", "", "Argument[0]", "ReturnValue", "taint", "manual"]
       - ["org.json", "CDL", False, "rowToJSONObject", "", "", "Argument[0..1]", "ReturnValue", "taint", "manual"]

--- a/java/ql/lib/ext/org.mvel2.compiler.model.yml
+++ b/java/ql/lib/ext/org.mvel2.compiler.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["org.mvel2.compiler", "Accessor", False, "getValue", "", "", "Argument[-1]", "mvel", "manual"]
       - ["org.mvel2.compiler", "CompiledAccExpression", False, "getValue", "", "", "Argument[-1]", "mvel", "manual"]

--- a/java/ql/lib/ext/org.mvel2.jsr223.model.yml
+++ b/java/ql/lib/ext/org.mvel2.jsr223.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["org.mvel2.jsr223", "MvelCompiledScript", False, "eval", "", "", "Argument[-1]", "mvel", "manual"]
       - ["org.mvel2.jsr223", "MvelScriptEngine", False, "eval", "", "", "Argument[0]", "mvel", "manual"]

--- a/java/ql/lib/ext/org.mvel2.model.yml
+++ b/java/ql/lib/ext/org.mvel2.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["org.mvel2", "MVEL", False, "eval", "", "", "Argument[0]", "mvel", "manual"]
       - ["org.mvel2", "MVEL", False, "evalToBoolean", "", "", "Argument[0]", "mvel", "manual"]

--- a/java/ql/lib/ext/org.mvel2.templates.model.yml
+++ b/java/ql/lib/ext/org.mvel2.templates.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["org.mvel2.templates", "TemplateRuntime", False, "eval", "", "", "Argument[0]", "mvel", "manual"]
       - ["org.mvel2.templates", "TemplateRuntime", False, "execute", "", "", "Argument[0]", "mvel", "manual"]

--- a/java/ql/lib/ext/org.scijava.log.model.yml
+++ b/java/ql/lib/ext/org.scijava.log.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["org.scijava.log", "Logger", True, "alwaysLog", "(int,Object,Throwable)", "", "Argument[1]", "logging", "manual"]
       - ["org.scijava.log", "Logger", True, "debug", "(Object)", "", "Argument[0]", "logging", "manual"]

--- a/java/ql/lib/ext/org.slf4j.model.yml
+++ b/java/ql/lib/ext/org.slf4j.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["org.slf4j", "Logger", True, "debug", "(Marker,String)", "", "Argument[1]", "logging", "manual"]
       - ["org.slf4j", "Logger", True, "debug", "(Marker,String,Object)", "", "Argument[1..2]", "logging", "manual"]

--- a/java/ql/lib/ext/org.slf4j.spi.model.yml
+++ b/java/ql/lib/ext/org.slf4j.spi.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["org.slf4j.spi", "LoggingEventBuilder", True, "log", "", "", "Argument[0]", "logging", "manual"]
       - ["org.slf4j.spi", "LoggingEventBuilder", True, "log", "(String,Object)", "", "Argument[0..1]", "logging", "manual"]
@@ -10,7 +10,7 @@ extensions:
       - ["org.slf4j.spi", "LoggingEventBuilder", True, "log", "(Supplier)", "", "Argument[0]", "logging", "manual"]
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["org.slf4j.spi", "LoggingEventBuilder", True, "addArgument", "", "", "Argument[-1]", "ReturnValue", "value", "manual"]
       - ["org.slf4j.spi", "LoggingEventBuilder", True, "addArgument", "", "", "Argument[1]", "Argument[-1]", "taint", "manual"]

--- a/java/ql/lib/ext/org.springframework.beans.model.yml
+++ b/java/ql/lib/ext/org.springframework.beans.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["org.springframework.beans", "MutablePropertyValues", True, "MutablePropertyValues", "(List)", "", "Argument[0].Element", "Argument[-1].Element", "value", "manual"]
       - ["org.springframework.beans", "MutablePropertyValues", True, "MutablePropertyValues", "(Map)", "", "Argument[0].MapKey", "Argument[-1].Element.MapKey", "value", "manual"]

--- a/java/ql/lib/ext/org.springframework.boot.jdbc.model.yml
+++ b/java/ql/lib/ext/org.springframework.boot.jdbc.model.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["org.springframework.boot.jdbc", "DataSourceBuilder", False, "url", "(String)", "", "Argument[0]", "jdbc-url", "manual"]

--- a/java/ql/lib/ext/org.springframework.cache.model.yml
+++ b/java/ql/lib/ext/org.springframework.cache.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["org.springframework.cache", "Cache", True, "get", "(Object)", "", "Argument[-1].MapValue", "ReturnValue.MapValue", "value", "manual"]
       - ["org.springframework.cache", "Cache", True, "get", "(Object,Callable)", "", "Argument[-1].MapValue", "ReturnValue", "value", "manual"]

--- a/java/ql/lib/ext/org.springframework.context.model.yml
+++ b/java/ql/lib/ext/org.springframework.context.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["org.springframework.context", "MessageSource", True, "getMessage", "(String,Object[],Locale)", "", "Argument[1].ArrayElement", "ReturnValue", "taint", "manual"]
       - ["org.springframework.context", "MessageSource", True, "getMessage", "(String,Object[],String,Locale)", "", "Argument[1].ArrayElement", "ReturnValue", "taint", "manual"]

--- a/java/ql/lib/ext/org.springframework.data.repository.model.yml
+++ b/java/ql/lib/ext/org.springframework.data.repository.model.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["org.springframework.data.repository", "CrudRepository", True, "save", "", "", "Argument[0]", "ReturnValue", "value", "manual"]

--- a/java/ql/lib/ext/org.springframework.http.model.yml
+++ b/java/ql/lib/ext/org.springframework.http.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["org.springframework.http", "RequestEntity", False, "RequestEntity", "(HttpMethod,URI)", "", "Argument[1]", "open-url", "manual"]
       - ["org.springframework.http", "RequestEntity", False, "RequestEntity", "(MultiValueMap,HttpMethod,URI)", "", "Argument[2]", "open-url", "manual"]
@@ -19,7 +19,7 @@ extensions:
       - ["org.springframework.http", "RequestEntity", False, "put", "", "", "Argument[0]", "open-url", "manual"]
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["org.springframework.http", "HttpEntity", True, "HttpEntity", "(MultiValueMap)", "", "Argument[0].MapKey", "Argument[-1]", "taint", "manual"]
       - ["org.springframework.http", "HttpEntity", True, "HttpEntity", "(MultiValueMap)", "", "Argument[0].MapValue.Element", "Argument[-1]", "taint", "manual"]

--- a/java/ql/lib/ext/org.springframework.jdbc.core.model.yml
+++ b/java/ql/lib/ext/org.springframework.jdbc.core.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["org.springframework.jdbc.core", "JdbcTemplate", False, "batchUpdate", "", "", "Argument[0]", "sql", "manual"]
       - ["org.springframework.jdbc.core", "JdbcTemplate", False, "batchUpdate", "(String[])", "", "Argument[0]", "sql", "manual"]

--- a/java/ql/lib/ext/org.springframework.jdbc.datasource.model.yml
+++ b/java/ql/lib/ext/org.springframework.jdbc.datasource.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["org.springframework.jdbc.datasource", "AbstractDriverBasedDataSource", False, "setUrl", "(String)", "", "Argument[0]", "jdbc-url", "manual"]
       - ["org.springframework.jdbc.datasource", "DriverManagerDataSource", False, "DriverManagerDataSource", "(String)", "", "Argument[0]", "jdbc-url", "manual"]

--- a/java/ql/lib/ext/org.springframework.jdbc.object.model.yml
+++ b/java/ql/lib/ext/org.springframework.jdbc.object.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["org.springframework.jdbc.object", "BatchSqlUpdate", False, "BatchSqlUpdate", "", "", "Argument[1]", "sql", "manual"]
       - ["org.springframework.jdbc.object", "MappingSqlQuery", False, "BatchSqlUpdate", "", "", "Argument[1]", "sql", "manual"]

--- a/java/ql/lib/ext/org.springframework.jndi.model.yml
+++ b/java/ql/lib/ext/org.springframework.jndi.model.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["org.springframework.jndi", "JndiTemplate", False, "lookup", "", "", "Argument[0]", "jndi-injection", "manual"]

--- a/java/ql/lib/ext/org.springframework.ldap.core.model.yml
+++ b/java/ql/lib/ext/org.springframework.ldap.core.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["org.springframework.ldap.core", "LdapOperations", True, "findByDn", "", "", "Argument[0]", "jndi-injection", "manual"]
       - ["org.springframework.ldap.core", "LdapOperations", True, "list", "", "", "Argument[0]", "jndi-injection", "manual"]

--- a/java/ql/lib/ext/org.springframework.ldap.model.yml
+++ b/java/ql/lib/ext/org.springframework.ldap.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["org.springframework.ldap", "LdapOperations", True, "findByDn", "", "", "Argument[0]", "jndi-injection", "manual"]
       - ["org.springframework.ldap", "LdapOperations", True, "list", "", "", "Argument[0]", "jndi-injection", "manual"]

--- a/java/ql/lib/ext/org.springframework.security.web.savedrequest.model.yml
+++ b/java/ql/lib/ext/org.springframework.security.web.savedrequest.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSourceModel
+      extensible: sourceModel
     data:
       - ["org.springframework.security.web.savedrequest", "SavedRequest", True, "getCookies", "", "", "ReturnValue", "remote", "manual"]
       - ["org.springframework.security.web.savedrequest", "SavedRequest", True, "getHeaderNames", "", "", "ReturnValue", "remote", "manual"]

--- a/java/ql/lib/ext/org.springframework.ui.model.yml
+++ b/java/ql/lib/ext/org.springframework.ui.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["org.springframework.ui", "ConcurrentModel", False, "ConcurrentModel", "(Object)", "", "Argument[0]", "Argument[-1].MapValue", "value", "manual"]
       - ["org.springframework.ui", "ConcurrentModel", False, "ConcurrentModel", "(String,Object)", "", "Argument[0]", "Argument[-1].MapKey", "value", "manual"]

--- a/java/ql/lib/ext/org.springframework.util.model.yml
+++ b/java/ql/lib/ext/org.springframework.util.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["org.springframework.util", "AntPathMatcher", False, "combine", "", "", "Argument[0..1]", "ReturnValue", "taint", "manual"]
       - ["org.springframework.util", "AntPathMatcher", False, "doMatch", "", "", "Argument[1]", "Argument[3].MapValue", "taint", "manual"]

--- a/java/ql/lib/ext/org.springframework.validation.model.yml
+++ b/java/ql/lib/ext/org.springframework.validation.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["org.springframework.validation", "Errors", True, "addAllErrors", "", "", "Argument[0]", "Argument[-1]", "taint", "manual"]
       - ["org.springframework.validation", "Errors", True, "getAllErrors", "", "", "Argument[-1]", "ReturnValue", "taint", "manual"]

--- a/java/ql/lib/ext/org.springframework.web.client.model.yml
+++ b/java/ql/lib/ext/org.springframework.web.client.model.yml
@@ -1,14 +1,14 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSourceModel
+      extensible: sourceModel
     data:
       - ["org.springframework.web.client", "RestTemplate", False, "exchange", "", "", "ReturnValue", "remote", "manual"]
       - ["org.springframework.web.client", "RestTemplate", False, "getForEntity", "", "", "ReturnValue", "remote", "manual"]
       - ["org.springframework.web.client", "RestTemplate", False, "postForEntity", "", "", "ReturnValue", "remote", "manual"]
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["org.springframework.web.client", "RestTemplate", False, "delete", "", "", "Argument[0]", "open-url", "manual"]
       - ["org.springframework.web.client", "RestTemplate", False, "doExecute", "", "", "Argument[0]", "open-url", "manual"]

--- a/java/ql/lib/ext/org.springframework.web.context.request.model.yml
+++ b/java/ql/lib/ext/org.springframework.web.context.request.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSourceModel
+      extensible: sourceModel
     data:
       - ["org.springframework.web.context.request", "WebRequest", False, "getDescription", "", "", "ReturnValue", "remote", "manual"]
       - ["org.springframework.web.context.request", "WebRequest", False, "getHeader", "", "", "ReturnValue", "remote", "manual"]

--- a/java/ql/lib/ext/org.springframework.web.multipart.model.yml
+++ b/java/ql/lib/ext/org.springframework.web.multipart.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSourceModel
+      extensible: sourceModel
     data:
       - ["org.springframework.web.multipart", "MultipartFile", True, "getBytes", "()", "", "ReturnValue", "remote", "manual"]
       - ["org.springframework.web.multipart", "MultipartFile", True, "getContentType", "()", "", "ReturnValue", "remote", "manual"]
@@ -17,7 +17,7 @@ extensions:
       - ["org.springframework.web.multipart", "MultipartRequest", True, "getMultipartContentType", "(String)", "", "ReturnValue", "remote", "manual"]
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["org.springframework.web.multipart", "MultipartFile", True, "getBytes", "", "", "Argument[-1]", "ReturnValue", "taint", "manual"]
       - ["org.springframework.web.multipart", "MultipartFile", True, "getInputStream", "", "", "Argument[-1]", "ReturnValue", "taint", "manual"]

--- a/java/ql/lib/ext/org.springframework.web.reactive.function.client.model.yml
+++ b/java/ql/lib/ext/org.springframework.web.reactive.function.client.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["org.springframework.web.reactive.function.client", "WebClient", False, "create", "", "", "Argument[0]", "open-url", "manual"]
       - ["org.springframework.web.reactive.function.client", "WebClient$Builder", False, "baseUrl", "", "", "Argument[0]", "open-url", "manual"]

--- a/java/ql/lib/ext/org.springframework.web.util.model.yml
+++ b/java/ql/lib/ext/org.springframework.web.util.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["org.springframework.web.util", "AbstractUriTemplateHandler", True, "getBaseUrl", "", "", "Argument[-1]", "ReturnValue", "taint", "manual"]
       - ["org.springframework.web.util", "AbstractUriTemplateHandler", True, "setBaseUrl", "", "", "Argument[0]", "Argument[-1]", "taint", "manual"]

--- a/java/ql/lib/ext/org.thymeleaf.model.yml
+++ b/java/ql/lib/ext/org.thymeleaf.model.yml
@@ -1,13 +1,13 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["org.thymeleaf", "ITemplateEngine", True, "process", "", "", "Argument[0]", "ssti", "manual"]
       - ["org.thymeleaf", "ITemplateEngine", True, "processThrottled", "", "", "Argument[0]", "ssti", "manual"]
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["org.thymeleaf", "TemplateSpec", False, "TemplateSpec", "", "", "Argument[0]", "Argument[-1]", "taint", "manual"]
       - ["org.thymeleaf", "TemplateSpec", False, "getTemplate", "", "", "Argument[-1]", "ReturnValue", "taint", "manual"]

--- a/java/ql/lib/ext/org.xml.sax.model.yml
+++ b/java/ql/lib/ext/org.xml.sax.model.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["org.xml.sax", "InputSource", False, "InputSource", "", "", "Argument[0]", "Argument[-1]", "taint", "manual"]

--- a/java/ql/lib/ext/org.xmlpull.v1.model.yml
+++ b/java/ql/lib/ext/org.xmlpull.v1.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSourceModel
+      extensible: sourceModel
     data:
       - ["org.xmlpull.v1", "XmlPullParser", False, "getName", "()", "", "ReturnValue", "remote", "manual"]
       - ["org.xmlpull.v1", "XmlPullParser", False, "getNamespace", "()", "", "ReturnValue", "remote", "manual"]

--- a/java/ql/lib/ext/play.mvc.model.yml
+++ b/java/ql/lib/ext/play.mvc.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSourceModel
+      extensible: sourceModel
     data:
       - ["play.mvc", "Http$RequestHeader", False, "getHeader", "", "", "ReturnValue", "remote", "manual"]
       - ["play.mvc", "Http$RequestHeader", False, "getQueryString", "", "", "ReturnValue", "remote", "manual"]

--- a/java/ql/lib/ext/ratpack.core.form.model.yml
+++ b/java/ql/lib/ext/ratpack.core.form.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["ratpack.core.form", "Form", True, "file", "", "", "Argument[-1]", "ReturnValue", "taint", "manual"]
       - ["ratpack.core.form", "Form", True, "files", "", "", "Argument[-1]", "ReturnValue", "taint", "manual"]

--- a/java/ql/lib/ext/ratpack.core.handling.model.yml
+++ b/java/ql/lib/ext/ratpack.core.handling.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSourceModel
+      extensible: sourceModel
     data:
       # All Context#parse methods that return a Promise are remote flow sources.
       - ["ratpack.core.handling", "Context", True, "parse", "(com.google.common.reflect.TypeToken)", "", "ReturnValue", "remote", "manual"]
@@ -12,7 +12,7 @@ extensions:
       - ["ratpack.core.handling", "Context", True, "parse", "(ratpack.parse.Parse)", "", "ReturnValue", "remote", "manual"]
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["ratpack.core.handling", "Context", True, "parse", "(ratpack.core.http.TypedData,ratpack.core.parse.Parse)", "", "Argument[0]", "ReturnValue", "taint", "manual"]
       - ["ratpack.core.handling", "Context", True, "parse", "(ratpack.core.http.TypedData,ratpack.core.parse.Parse)", "", "Argument[0]", "ReturnValue.MapKey", "taint", "manual"]

--- a/java/ql/lib/ext/ratpack.core.http.model.yml
+++ b/java/ql/lib/ext/ratpack.core.http.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSourceModel
+      extensible: sourceModel
     data:
       - ["ratpack.core.http", "Request", True, "getBody", "", "", "ReturnValue", "remote", "manual"]
       - ["ratpack.core.http", "Request", True, "getContentLength", "", "", "ReturnValue", "remote", "manual"]
@@ -15,7 +15,7 @@ extensions:
       - ["ratpack.core.http", "Request", True, "oneCookie", "", "", "ReturnValue", "remote", "manual"]
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["ratpack.core.http", "Headers", True, "asMultiValueMap", "", "", "Argument[-1]", "ReturnValue", "taint", "manual"]
       - ["ratpack.core.http", "Headers", True, "get", "", "", "Argument[-1]", "ReturnValue", "taint", "manual"]

--- a/java/ql/lib/ext/ratpack.exec.model.yml
+++ b/java/ql/lib/ext/ratpack.exec.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["ratpack.exec", "Promise", True, "apply", "", "", "Argument[-1].Element", "Argument[0].Parameter[0].Element", "value", "manual"]
       - ["ratpack.exec", "Promise", True, "apply", "", "", "Argument[0].ReturnValue.Element", "ReturnValue.Element", "value", "manual"]

--- a/java/ql/lib/ext/ratpack.form.model.yml
+++ b/java/ql/lib/ext/ratpack.form.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["ratpack.form", "Form", True, "file", "", "", "Argument[-1]", "ReturnValue", "taint", "manual"]
       - ["ratpack.form", "Form", True, "files", "", "", "Argument[-1]", "ReturnValue", "taint", "manual"]

--- a/java/ql/lib/ext/ratpack.func.model.yml
+++ b/java/ql/lib/ext/ratpack.func.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["ratpack.func", "MultiValueMap", True, "asMultimap", "", "", "Argument[-1].MapKey", "ReturnValue.MapKey", "value", "manual"]
       - ["ratpack.func", "MultiValueMap", True, "asMultimap", "", "", "Argument[-1].MapValue", "ReturnValue.MapValue", "value", "manual"]

--- a/java/ql/lib/ext/ratpack.handling.model.yml
+++ b/java/ql/lib/ext/ratpack.handling.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSourceModel
+      extensible: sourceModel
     data:
       # All Context#parse methods that return a Promise are remote flow sources.
       - ["ratpack.handling", "Context", True, "parse", "(com.google.common.reflect.TypeToken)", "", "ReturnValue", "remote", "manual"]
@@ -12,7 +12,7 @@ extensions:
       - ["ratpack.handling", "Context", True, "parse", "(ratpack.parse.Parse)", "", "ReturnValue", "remote", "manual"]
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["ratpack.handling", "Context", True, "parse", "(ratpack.core.http.TypedData,ratpack.core.parse.Parse)", "", "Argument[0]", "ReturnValue", "taint", "manual"]
       - ["ratpack.handling", "Context", True, "parse", "(ratpack.core.http.TypedData,ratpack.core.parse.Parse)", "", "Argument[0]", "ReturnValue.MapKey", "taint", "manual"]

--- a/java/ql/lib/ext/ratpack.http.model.yml
+++ b/java/ql/lib/ext/ratpack.http.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSourceModel
+      extensible: sourceModel
     data:
       - ["ratpack.http", "Request", True, "getBody", "", "", "ReturnValue", "remote", "manual"]
       - ["ratpack.http", "Request", True, "getContentLength", "", "", "ReturnValue", "remote", "manual"]
@@ -15,7 +15,7 @@ extensions:
       - ["ratpack.http", "Request", True, "oneCookie", "", "", "ReturnValue", "remote", "manual"]
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["ratpack.http", "Headers", True, "asMultiValueMap", "", "", "Argument[-1]", "ReturnValue", "taint", "manual"]
       - ["ratpack.http", "Headers", True, "get", "", "", "Argument[-1]", "ReturnValue", "taint", "manual"]

--- a/java/ql/lib/ext/ratpack.util.model.yml
+++ b/java/ql/lib/ext/ratpack.util.model.yml
@@ -1,7 +1,7 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["ratpack.util", "MultiValueMap", True, "asMultimap", "", "", "Argument[-1].MapKey", "ReturnValue.MapKey", "value", "manual"]
       - ["ratpack.util", "MultiValueMap", True, "asMultimap", "", "", "Argument[-1].MapValue", "ReturnValue.MapValue", "value", "manual"]

--- a/java/ql/lib/ext/retrofit2.model.yml
+++ b/java/ql/lib/ext/retrofit2.model.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
       pack: codeql/java-all
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["retrofit2", "Retrofit$Builder", True, "baseUrl", "", "", "Argument[0]", "open-url", "manual"]

--- a/java/ql/lib/semmle/code/java/dataflow/ExternalFlow.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/ExternalFlow.qll
@@ -78,6 +78,7 @@ private import internal.DataFlowPrivate
 private import internal.FlowSummaryImpl::Private::External
 private import internal.FlowSummaryImplSpecific as FlowSummaryImplSpecific
 private import internal.AccessPathSyntax
+private import ExternalFlowExtensions as Extensions
 private import FlowSummary
 
 /**
@@ -129,33 +130,6 @@ private predicate summaryModelInternal(string row) { any(SummaryModelCsvInternal
 private predicate sinkModelInternal(string row) { any(SinkModelCsvInternal s).row(row) }
 
 /**
- * Holds if an experimental source model exists for the given parameters.
- * This is only for experimental queries.
- */
-extensible predicate extExperimentalSourceModel(
-  string package, string type, boolean subtypes, string name, string signature, string ext,
-  string output, string kind, string provenance, string filter
-);
-
-/**
- * Holds if an experimental sink model exists for the given parameters.
- * This is only for experimental queries.
- */
-extensible predicate extExperimentalSinkModel(
-  string package, string type, boolean subtypes, string name, string signature, string ext,
-  string input, string kind, string provenance, string filter
-);
-
-/**
- * Holds if an experimental summary model exists for the given parameters.
- * This is only for experimental queries.
- */
-extensible predicate extExperimentalSummaryModel(
-  string package, string type, boolean subtypes, string name, string signature, string ext,
-  string input, string output, string kind, string provenance, string filter
-);
-
-/**
  * A class for activating additional model rows.
  *
  * Extend this class to include experimental model rows with `this` name
@@ -172,7 +146,7 @@ abstract class ActiveExperimentalModels extends string {
     string package, string type, boolean subtypes, string name, string signature, string ext,
     string output, string kind, string provenance
   ) {
-    extExperimentalSourceModel(package, type, subtypes, name, signature, ext, output, kind,
+    Extensions::experimentalSourceModel(package, type, subtypes, name, signature, ext, output, kind,
       provenance, this)
   }
 
@@ -183,7 +157,7 @@ abstract class ActiveExperimentalModels extends string {
     string package, string type, boolean subtypes, string name, string signature, string ext,
     string output, string kind, string provenance
   ) {
-    extExperimentalSinkModel(package, type, subtypes, name, signature, ext, output, kind,
+    Extensions::experimentalSinkModel(package, type, subtypes, name, signature, ext, output, kind,
       provenance, this)
   }
 
@@ -194,18 +168,10 @@ abstract class ActiveExperimentalModels extends string {
     string package, string type, boolean subtypes, string name, string signature, string ext,
     string input, string output, string kind, string provenance
   ) {
-    extExperimentalSummaryModel(package, type, subtypes, name, signature, ext, input, output, kind,
-      provenance, this)
+    Extensions::experimentalSummaryModel(package, type, subtypes, name, signature, ext, input,
+      output, kind, provenance, this)
   }
 }
-
-/**
- * Holds if a source model exists for the given parameters.
- */
-extensible predicate extSourceModel(
-  string package, string type, boolean subtypes, string name, string signature, string ext,
-  string output, string kind, string provenance
-);
 
 /** Holds if a source model exists for the given parameters. */
 predicate sourceModel(
@@ -226,17 +192,11 @@ predicate sourceModel(
     row.splitAt(";", 8) = provenance
   )
   or
-  extSourceModel(package, type, subtypes, name, signature, ext, output, kind, provenance)
+  Extensions::sourceModel(package, type, subtypes, name, signature, ext, output, kind, provenance)
   or
   any(ActiveExperimentalModels q)
       .sourceModel(package, type, subtypes, name, signature, ext, output, kind, provenance)
 }
-
-/** Holds if a sink model exists for the given parameters. */
-extensible predicate extSinkModel(
-  string package, string type, boolean subtypes, string name, string signature, string ext,
-  string input, string kind, string provenance
-);
 
 /** Holds if a sink model exists for the given parameters. */
 predicate sinkModel(
@@ -257,17 +217,11 @@ predicate sinkModel(
     row.splitAt(";", 8) = provenance
   )
   or
-  extSinkModel(package, type, subtypes, name, signature, ext, input, kind, provenance)
+  Extensions::sinkModel(package, type, subtypes, name, signature, ext, input, kind, provenance)
   or
   any(ActiveExperimentalModels q)
       .sinkModel(package, type, subtypes, name, signature, ext, input, kind, provenance)
 }
-
-/** Holds if a summary model exists for the given parameters. */
-extensible predicate extSummaryModel(
-  string package, string type, boolean subtypes, string name, string signature, string ext,
-  string input, string output, string kind, string provenance
-);
 
 /** Holds if a summary model exists for the given parameters. */
 predicate summaryModel(
@@ -289,21 +243,15 @@ predicate summaryModel(
     row.splitAt(";", 9) = provenance
   )
   or
-  extSummaryModel(package, type, subtypes, name, signature, ext, input, output, kind, provenance)
+  Extensions::summaryModel(package, type, subtypes, name, signature, ext, input, output, kind,
+    provenance)
   or
   any(ActiveExperimentalModels q)
       .summaryModel(package, type, subtypes, name, signature, ext, input, output, kind, provenance)
 }
 
 /** Holds if a neutral model exists indicating there is no flow for the given parameters. */
-extensible predicate extNeutralModel(
-  string package, string type, string name, string signature, string provenance
-);
-
-/** Holds if a neutral model exists indicating there is no flow for the given parameters. */
-predicate neutralModel(string package, string type, string name, string signature, string provenance) {
-  extNeutralModel(package, type, name, signature, provenance)
-}
+predicate neutralModel = Extensions::neutralModel/5;
 
 private predicate relevantPackage(string package) {
   sourceModel(package, _, _, _, _, _, _, _, _) or

--- a/java/ql/lib/semmle/code/java/dataflow/ExternalFlowExtensions.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/ExternalFlowExtensions.qll
@@ -1,0 +1,61 @@
+/**
+ * This module provides extensible predicates for defining MaD models.
+ */
+
+/**
+ * Holds if a source model exists for the given parameters.
+ */
+extensible predicate sourceModel(
+  string package, string type, boolean subtypes, string name, string signature, string ext,
+  string output, string kind, string provenance
+);
+
+/**
+ * Holds if a sink model exists for the given parameters.
+ */
+extensible predicate sinkModel(
+  string package, string type, boolean subtypes, string name, string signature, string ext,
+  string input, string kind, string provenance
+);
+
+/**
+ * Holds if a summary model exists for the given parameters.
+ */
+extensible predicate summaryModel(
+  string package, string type, boolean subtypes, string name, string signature, string ext,
+  string input, string output, string kind, string provenance
+);
+
+/**
+ * Holds if a neutral model exists indicating there is no flow for the given parameters.
+ */
+extensible predicate neutralModel(
+  string package, string type, string name, string signature, string provenance
+);
+
+/**
+ * Holds if an experimental source model exists for the given parameters.
+ * This is only for experimental queries.
+ */
+extensible predicate experimentalSourceModel(
+  string package, string type, boolean subtypes, string name, string signature, string ext,
+  string output, string kind, string provenance, string filter
+);
+
+/**
+ * Holds if an experimental sink model exists for the given parameters.
+ * This is only for experimental queries.
+ */
+extensible predicate experimentalSinkModel(
+  string package, string type, boolean subtypes, string name, string signature, string ext,
+  string input, string kind, string provenance, string filter
+);
+
+/**
+ * Holds if an experimental summary model exists for the given parameters.
+ * This is only for experimental queries.
+ */
+extensible predicate experimentalSummaryModel(
+  string package, string type, boolean subtypes, string name, string signature, string ext,
+  string input, string output, string kind, string provenance, string filter
+);

--- a/java/ql/src/change-notes/2022-12-15-rename-mad-extensibles.md
+++ b/java/ql/src/change-notes/2022-12-15-rename-mad-extensibles.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The extensible predicates for Models as Data have been renamed (the `ext` prefix has been removed). As an example `extSummaryModel` has been renamed to `summaryModel`.

--- a/java/ql/src/utils/flowtestcasegenerator/GenerateFlowTestCase.py
+++ b/java/ql/src/utils/flowtestcasegenerator/GenerateFlowTestCase.py
@@ -226,7 +226,7 @@ if len(supportModelRows) != 0:
         dataextensions = f"""extensions:
   - addsTo:
       pack: codeql/java-tests
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
 {models}
 """

--- a/java/ql/test/ext/test.model.yml
+++ b/java/ql/test/ext/test.model.yml
@@ -2,14 +2,14 @@ extensions:
   # Model(s) for Kotlin - dataflow/notnullexpr and dataflow/whenexpr test cases.
   - addsTo:
       pack: codeql/java-tests
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["", "Uri", False, "getQueryParameter", "", "", "Argument[-1]", "ReturnValue", "taint", "manual"]
 
   # Model(s) for Java - dataflow/callback-dispatch test case.
   - addsTo:
       pack: codeql/java-tests
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["my.callback.qltest", "A", False, "applyConsumer1", "(Object,Consumer1)", "", "Argument[0]", "Argument[1].Parameter[0]", "value", "manual"]
       - ["my.callback.qltest", "A", False, "applyConsumer1Field1Field2", "(A,A,Consumer1)", "", "Argument[0].Field[my.callback.qltest.A.field1]", "Argument[2].Parameter[0]", "value", "manual"]
@@ -27,7 +27,7 @@ extensions:
   # Model(s) for Java - dataflow/collections test case.
   - addsTo:
       pack: codeql/java-tests
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["", "B", False, "readElement", "(Spliterator)", "", "Argument[0].Element", "ReturnValue", "value", "manual"]
       - ["", "B", False, "readElement", "(Stream)", "", "Argument[0].Element", "ReturnValue", "value", "manual"]
@@ -35,7 +35,7 @@ extensions:
   # Model(s) for Java - dataflow/external-models test cases.
   - addsTo:
       pack: codeql/java-tests
-      extensible: extSourceModel
+      extensible: sourceModel
     data:
       - ["my.qltest", "A", False, "src1", "()", "", "ReturnValue", "qltest", "manual"]
       - ["my.qltest", "A", False, "src1", "(String)", "", "ReturnValue", "qltest", "manual"]
@@ -55,7 +55,7 @@ extensions:
       - ["my.qltest", "A", False, "srcTwoArg", "(java.lang.String,java.lang.String)", "", "ReturnValue", "qltest-longsig", "manual"]
   - addsTo:
       pack: codeql/java-tests
-      extensible: extSinkModel
+      extensible: sinkModel
     data:
       - ["my.qltest", "B", False, "sink1", "(Object)", "", "Argument[0]", "qltest", "manual"]
       - ["my.qltest", "B", False, "sinkMethod", "()", "", "ReturnValue", "qltest", "manual"]
@@ -64,7 +64,7 @@ extensions:
       - ["my.qltest", "B$Tag", False, "", "", "Annotated", "", "qltest-nospec", "manual"]
   - addsTo:
       pack: codeql/java-tests
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["my.qltest", "C", False, "stepArgRes", "(Object)", "", "Argument[0]", "ReturnValue", "taint", "manual"]
       - ["my.qltest", "C", False, "stepArgArg", "(Object,Object)", "", "Argument[0]", "Argument[1]", "taint", "manual"]
@@ -78,7 +78,7 @@ extensions:
   # Model(s) for Java - dataflow/synth-global test case.
   - addsTo:
       pack: codeql/java-tests
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["my.qltest.synth", "A", False, "storeInArray", "(String)", "", "Argument[0]", "SyntheticGlobal[db1].ArrayElement", "value", "manual"]
       - ["my.qltest.synth", "A", False, "storeTaintInArray", "(String)", "", "Argument[0]", "SyntheticGlobal[db1].ArrayElement", "taint", "manual"]
@@ -89,7 +89,7 @@ extensions:
   # Model(s) for Java - frameworks/android/content-provider-summaries test case.
   - addsTo:
       pack: codeql/java-tests
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["generatedtest", "Test", False, "newWithMapValueDefault", "(Object)", "", "Argument[0]", "ReturnValue.MapValue", "value", "manual"]
       - ["generatedtest", "Test", False, "newWithMapKeyDefault", "(Object)", "", "Argument[0]", "ReturnValue.MapKey", "value", "manual"]
@@ -99,7 +99,7 @@ extensions:
   # Model(s) for Java - frameworks/android/intent test case.
   - addsTo:
       pack: codeql/java-tests
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["generatedtest", "Test", False, "newBundleWithMapValue", "(Object)", "", "Argument[0]", "ReturnValue.MapValue", "value", "manual"]
       - ["generatedtest", "Test", False, "newPersistableBundleWithMapValue", "(Object)", "", "Argument[0]", "ReturnValue.MapValue", "value", "manual"]
@@ -109,14 +109,14 @@ extensions:
   # Model(s) for Java - frameworks/android/notification test case.
   - addsTo:
       pack: codeql/java-tests
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["generatedtest", "Test", False, "getMapKeyDefault", "(Bundle)", "", "Argument[0].MapKey", "ReturnValue", "value", "manual"]
 
   # Model(s) for Java - frameworks/apache-collections test case.
   - addsTo:
       pack: codeql/java-tests
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["generatedtest", "Test", False, "newRBWithMapValue", "", "", "Argument[0]", "ReturnValue.MapValue", "value", "manual"]
       - ["generatedtest", "Test", False, "newRBWithMapKey", "", "", "Argument[0]", "ReturnValue.MapKey", "value", "manual"]
@@ -124,7 +124,7 @@ extensions:
   # Model(s) for Java - frameworks/guave/generated/collect test case.
   - addsTo:
       pack: codeql/java-tests
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["generatedtest", "Test", False, "newWithElementDefault", "(Object)", "", "Argument[0]", "ReturnValue.Element", "value", "manual"]
       - ["generatedtest", "Test", False, "newWithMapKeyDefault", "(Object)", "", "Argument[0]", "ReturnValue.MapKey", "value", "manual"]
@@ -133,13 +133,13 @@ extensions:
   # Model(s) for Java - frameworks/stream test case.
   - addsTo:
       pack: codeql/java-tests
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["generatedtest", "Test", False, "getElementSpliterator", "(Spliterator)", "", "Argument[0].Element", "ReturnValue", "value", "manual"]
 
   # Model(s) for Java - frameworks/stream test case.
   - addsTo:
       pack: codeql/java-tests
-      extensible: extSummaryModel
+      extensible: summaryModel
     data:
       - ["generatedtest", "Test", False, "getStreamElement", "", "", "Argument[0].Element", "ReturnValue", "value", "manual"]

--- a/misc/scripts/models-as-data/helpers.py
+++ b/misc/scripts/models-as-data/helpers.py
@@ -4,10 +4,10 @@ import shutil
 import subprocess
 
 # Shared strings.
-summaryModelPredicate = "extSummaryModel"
-sinkModelPredicate = "extSinkModel"
-sourceModelPredicate = "extSourceModel"
-neutralModelPredicate = "extNeutralModel"
+summaryModelPredicate = "summaryModel"
+sinkModelPredicate = "sinkModel"
+sourceModelPredicate = "sourceModel"
+neutralModelPredicate = "neutralModel"
 addsToTemplate = """  - addsTo:
       pack: {0}
       extensible: {1}


### PR DESCRIPTION
In this PR we remove the `ext` prefix on all the external flow related extensible predicates.
This is to align with the dynamic languages team implementation.

- Note that the C# models has been re-converted which means that they have been moved around slightly due to sorting.
- It looks like an extensible was not renamed (could be due to it not being needed and merged after the rename PR). For consistency it has been renamed.