### PR TITLE
Added clarifying example for `concat` in docs

### DIFF
--- a/docs/codeql/ql-language-reference/expressions.rst
+++ b/docs/codeql/ql-language-reference/expressions.rst
@@ -292,6 +292,12 @@ The following aggregates are available in QL:
   .. code-block:: ql
 
       concat(int i | i = [0 .. 3] | i.toString(), "|")
+  
+  To use ``order by`` and a separator together, ``order by`` should come after the separator. For example, the following aggregation returns ``"3|2|1|0"``:
+  
+  .. code-block:: ql
+  
+      concat(int i | i = [0 .. 3] | i.toString(), "|" order by i desc)
 
 .. index:: rank
 


### PR DESCRIPTION
The syntax for `concat` when using both `order by` and a separator is not intuitive. Here, an example in the documentation can clarify it.