### PR TITLE
Introduce the security-extended CodeQL suite and experimental tag

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,7 @@ If you have an idea for a query that you would like to share with other CodeQL u
 
     Each language-specific directory contains further subdirectories that group queries based on their `@tags` or purpose.
     - Experimental queries and libraries are stored in the `experimental` subdirectory within each language-specific directory in the [CodeQL repository](https://github.com/github/codeql). For example, experimental Java queries and libraries are stored in `java/ql/src/experimental` and any corresponding tests in `java/ql/test/experimental`.
+    - Experimental queries need to include `experimental` in their `@tags`
     - The structure of an `experimental` subdirectory mirrors the structure of its parent directory.
     - Select or create an appropriate directory in `experimental` based on the existing directory structure of `experimental` or its parent directory.
 

--- a/cpp/ql/src/codeql-suites/cpp-security-experimental.qls
+++ b/cpp/ql/src/codeql-suites/cpp-security-experimental.qls
@@ -1,0 +1,5 @@
+- description: Extended and experimental security queries for C and C++
+- queries: .
+- apply: security-experimental-selectors.yml
+  from: codeql/suite-helpers
+- apply: codeql-suites/exclude-slow-queries.yml

--- a/cpp/ql/src/experimental/Likely Bugs/ArrayAccessProductFlow.ql
+++ b/cpp/ql/src/experimental/Likely Bugs/ArrayAccessProductFlow.ql
@@ -6,6 +6,7 @@
  * @id cpp/off-by-one-array-access
  * @tags reliability
  *       security
+ *       experimental
  */
 
 import cpp

--- a/cpp/ql/src/experimental/Likely Bugs/OverrunWriteProductFlow.ql
+++ b/cpp/ql/src/experimental/Likely Bugs/OverrunWriteProductFlow.ql
@@ -7,6 +7,7 @@
  * @id cpp/overrun-write
  * @tags reliability
  *       security
+ *       experimental
  *       external/cwe/cwe-119
  *       external/cwe/cwe-131
  */

--- a/cpp/ql/src/experimental/Likely Bugs/RedundantNullCheckParam.ql
+++ b/cpp/ql/src/experimental/Likely Bugs/RedundantNullCheckParam.ql
@@ -9,6 +9,7 @@
  * @tags reliability
  *       security
  *       external/cwe/cwe-476
+ *       experimental
  */
 
 import cpp

--- a/cpp/ql/src/experimental/Security/CWE/CWE-020/LateCheckOfFunctionArgument.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-020/LateCheckOfFunctionArgument.ql
@@ -9,6 +9,7 @@
  * @precision medium
  * @tags correctness
  *       security
+ *       experimental
  *       external/cwe/cwe-20
  */
 

--- a/cpp/ql/src/experimental/Security/CWE/CWE-020/NoCheckBeforeUnsafePutUser.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-020/NoCheckBeforeUnsafePutUser.ql
@@ -11,6 +11,7 @@
  * @problem.severity warning
  * @security-severity 7.5
  * @tags security
+ *       experimental
  *       external/cwe/cwe-020
  */
 

--- a/cpp/ql/src/experimental/Security/CWE/CWE-078/WordexpTainted.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-078/WordexpTainted.ql
@@ -8,6 +8,7 @@
  * @precision high
  * @id cpp/wordexp-injection
  * @tags security
+ *       experimental
  *       external/cwe/cwe-078
  */
 

--- a/cpp/ql/src/experimental/Security/CWE/CWE-1041/FindWrapperFunctions.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-1041/FindWrapperFunctions.ql
@@ -8,6 +8,7 @@
  * @tags correctness
  *       maintainability
  *       security
+ *       experimental
  *       external/cwe/cwe-1041
  */
 

--- a/cpp/ql/src/experimental/Security/CWE/CWE-1126/DeclarationOfVariableWithUnnecessarilyWideScope.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-1126/DeclarationOfVariableWithUnnecessarilyWideScope.ql
@@ -9,6 +9,7 @@
  * @precision medium
  * @tags correctness
  *       security
+ *       experimental
  *       external/cwe/cwe-1126
  */
 

--- a/cpp/ql/src/experimental/Security/CWE/CWE-120/MemoryUnsafeFunctionScan.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-120/MemoryUnsafeFunctionScan.ql
@@ -6,6 +6,7 @@
  * @id cpp/memory-unsafe-function-scan
  * @tags reliability
  *       security
+ *       experimental
  *       external/cwe/cwe-120
  */
 

--- a/cpp/ql/src/experimental/Security/CWE/CWE-125/DangerousWorksWithMultibyteOrWideCharacters.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-125/DangerousWorksWithMultibyteOrWideCharacters.ql
@@ -7,6 +7,7 @@
  * @precision medium
  * @tags correctness
  *       security
+ *       experimental
  *       external/cwe/cwe-125
  */
 

--- a/cpp/ql/src/experimental/Security/CWE/CWE-190/AllocMultiplicationOverflow.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-190/AllocMultiplicationOverflow.ql
@@ -6,6 +6,7 @@
  * @precision low
  * @tags security
  *       correctness
+ *       experimental
  *       external/cwe/cwe-190
  *       external/cwe/cwe-128
  * @id cpp/multiplication-overflow-in-alloc

--- a/cpp/ql/src/experimental/Security/CWE/CWE-190/DangerousUseOfTransformationAfterOperation.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-190/DangerousUseOfTransformationAfterOperation.ql
@@ -7,6 +7,7 @@
  * @precision medium
  * @tags correctness
  *       security
+ *       experimental
  *       external/cwe/cwe-190
  */
 

--- a/cpp/ql/src/experimental/Security/CWE/CWE-193/ConstantSizeArrayOffByOne.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-193/ConstantSizeArrayOffByOne.ql
@@ -7,6 +7,7 @@
  * @id cpp/constant-array-overflow
  * @tags reliability
  *       security
+ *       experimental
  */
 
 import experimental.semmle.code.cpp.semantic.analysis.RangeAnalysis

--- a/cpp/ql/src/experimental/Security/CWE/CWE-193/InvalidPointerDeref.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-193/InvalidPointerDeref.ql
@@ -8,6 +8,7 @@
  * @id cpp/invalid-pointer-deref
  * @tags reliability
  *       security
+ *       experimental
  *       external/cwe/cwe-119
  *       external/cwe/cwe-125
  *       external/cwe/cwe-193

--- a/cpp/ql/src/experimental/Security/CWE/CWE-200/ExposureSensitiveInformationUnauthorizedActor.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-200/ExposureSensitiveInformationUnauthorizedActor.ql
@@ -8,6 +8,7 @@
  * @tags correctness
  *       maintainability
  *       security
+ *       experimental
  *       external/cwe/cwe-200
  *       external/cwe/cwe-264
  */

--- a/cpp/ql/src/experimental/Security/CWE/CWE-243/IncorrectChangingWorkingDirectory.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-243/IncorrectChangingWorkingDirectory.ql
@@ -7,6 +7,7 @@
  * @precision medium
  * @tags correctness
  *       security
+ *       experimental
  *       external/cwe/cwe-243
  *       external/cwe/cwe-252
  */

--- a/cpp/ql/src/experimental/Security/CWE/CWE-266/IncorrectPrivilegeAssignment.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-266/IncorrectPrivilegeAssignment.ql
@@ -8,6 +8,7 @@
  * @tags correctness
  *       maintainability
  *       security
+ *       experimental
  *       external/cwe/cwe-266
  *       external/cwe/cwe-264
  *       external/cwe/cwe-200

--- a/cpp/ql/src/experimental/Security/CWE/CWE-273/PrivilegeDroppingOutoforder.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-273/PrivilegeDroppingOutoforder.ql
@@ -8,6 +8,7 @@
  * @problem.severity recommendation
  * @id cpp/drop-linux-privileges-outoforder
  * @tags security
+ *       experimental
  *       external/cwe/cwe-273
  * @precision medium
  */

--- a/cpp/ql/src/experimental/Security/CWE/CWE-285/PamAuthorization.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-285/PamAuthorization.ql
@@ -5,6 +5,7 @@
  * @problem.severity error
  * @id cpp/pam-auth-bypass
  * @tags security
+ *       experimental
  *       external/cwe/cwe-285
  */
 

--- a/cpp/ql/src/experimental/Security/CWE/CWE-359/PrivateCleartextWrite.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-359/PrivateCleartextWrite.ql
@@ -6,6 +6,7 @@
  * @problem.severity error
  * @id cpp/private-cleartext-write
  * @tags security
+ *       experimental
  *       external/cwe/cwe-359
  */
 

--- a/cpp/ql/src/experimental/Security/CWE/CWE-362/double-fetch.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-362/double-fetch.ql
@@ -11,6 +11,7 @@
  * @problem.severity warning
  * @security-severity 7.5
  * @tags security
+ *       experimental
  *       external/cwe/cwe-362
  */
 

--- a/cpp/ql/src/experimental/Security/CWE/CWE-377/InsecureTemporaryFile.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-377/InsecureTemporaryFile.ql
@@ -7,6 +7,7 @@
  * @precision medium
  * @tags correctness
  *       security
+ *       experimental
  *       external/cwe/cwe-377
  */
 

--- a/cpp/ql/src/experimental/Security/CWE/CWE-401/MemoryLeakOnFailedCallToRealloc.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-401/MemoryLeakOnFailedCallToRealloc.ql
@@ -8,6 +8,7 @@
  * @precision medium
  * @tags correctness
  *       security
+ *       experimental
  *       external/cwe/cwe-401
  */
 

--- a/cpp/ql/src/experimental/Security/CWE/CWE-415/DoubleFree.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-415/DoubleFree.ql
@@ -6,6 +6,7 @@
  * @problem.severity warning
  * @precision medium
  * @tags security
+ *       experimental
  *       external/cwe/cwe-415
  */
 

--- a/cpp/ql/src/experimental/Security/CWE/CWE-476/DangerousUseOfExceptionBlocks.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-476/DangerousUseOfExceptionBlocks.ql
@@ -7,6 +7,7 @@
  * @precision medium
  * @tags correctness
  *       security
+ *       experimental
  *       external/cwe/cwe-476
  *       external/cwe/cwe-415
  */

--- a/cpp/ql/src/experimental/Security/CWE/CWE-561/FindIncorrectlyUsedSwitch.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-561/FindIncorrectlyUsedSwitch.ql
@@ -8,6 +8,7 @@
  * @precision medium
  * @tags correctness
  *       security
+ *       experimental
  *       external/cwe/cwe-561
  *       external/cwe/cwe-691
  *       external/cwe/cwe-478

--- a/cpp/ql/src/experimental/Security/CWE/CWE-670/DangerousUseSSL_shutdown.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-670/DangerousUseSSL_shutdown.ql
@@ -7,6 +7,7 @@
  * @precision medium
  * @tags correctness
  *       security
+ *       experimental
  *       external/cwe/cwe-670
  */
 

--- a/cpp/ql/src/experimental/Security/CWE/CWE-675/DoubleRelease.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-675/DoubleRelease.ql
@@ -6,6 +6,7 @@
  * @problem.severity warning
  * @precision medium
  * @tags security
+ *       experimental
  *       external/cwe/cwe-675
  *       external/cwe/cwe-666
  */

--- a/cpp/ql/src/experimental/Security/CWE/CWE-691/InsufficientControlFlowManagementAfterRefactoringTheCode.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-691/InsufficientControlFlowManagementAfterRefactoringTheCode.ql
@@ -10,6 +10,7 @@
  * @precision medium
  * @tags correctness
  *       security
+ *       experimental
  *       external/cwe/cwe-691
  */
 

--- a/cpp/ql/src/experimental/Security/CWE/CWE-691/InsufficientControlFlowManagementWhenUsingBitOperations.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-691/InsufficientControlFlowManagementWhenUsingBitOperations.ql
@@ -8,6 +8,7 @@
  * @precision medium
  * @tags correctness
  *       security
+ *       experimental
  *       external/cwe/cwe-691
  */
 

--- a/cpp/ql/src/experimental/Security/CWE/CWE-703/FindIncorrectlyUsedExceptions.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-703/FindIncorrectlyUsedExceptions.ql
@@ -7,6 +7,7 @@
  * @precision medium
  * @tags correctness
  *       security
+ *       experimental
  *       external/cwe/cwe-703
  *       external/cwe/cwe-248
  *       external/cwe/cwe-390

--- a/cpp/ql/src/experimental/Security/CWE/CWE-754/ImproperCheckReturnValueScanf.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-754/ImproperCheckReturnValueScanf.ql
@@ -7,6 +7,7 @@
  * @precision medium
  * @tags correctness
  *       security
+ *       experimental
  *       external/cwe/cwe-754
  *       external/cwe/cwe-908
  */

--- a/cpp/ql/src/experimental/Security/CWE/CWE-758/UndefinedOrImplementationDefinedBehavior.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-758/UndefinedOrImplementationDefinedBehavior.ql
@@ -8,6 +8,7 @@
  * @problem.severity warning
  * @precision medium
  * @tags security
+ *       experimental
  *       external/cwe/cwe-758
  */
 

--- a/cpp/ql/src/experimental/Security/CWE/CWE-783/OperatorPrecedenceLogicErrorWhenUseBitwiseOrLogicalOperations.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-783/OperatorPrecedenceLogicErrorWhenUseBitwiseOrLogicalOperations.ql
@@ -8,6 +8,7 @@
  * @precision medium
  * @tags maintainability
  *       readability
+ *       experimental
  *       external/cwe/cwe-783
  *       external/cwe/cwe-480
  */

--- a/cpp/ql/src/experimental/Security/CWE/CWE-783/OperatorPrecedenceLogicErrorWhenUseBoolType.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-783/OperatorPrecedenceLogicErrorWhenUseBoolType.ql
@@ -8,6 +8,7 @@
  * @precision medium
  * @tags correctness
  *       security
+ *       experimental
  *       external/cwe/cwe-783
  *       external/cwe/cwe-480
  */

--- a/cpp/ql/src/experimental/Security/CWE/CWE-787/UnsignedToSignedPointerArith.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-787/UnsignedToSignedPointerArith.ql
@@ -6,6 +6,7 @@
  * @problem.severity warning
  * @tags reliability
  *       security
+ *       experimental
  *       external/cwe/cwe-787
  */
 

--- a/cpp/ql/src/experimental/Security/CWE/CWE-788/AccessOfMemoryLocationAfterEndOfBufferUsingStrlen.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-788/AccessOfMemoryLocationAfterEndOfBufferUsingStrlen.ql
@@ -8,6 +8,7 @@
  * @precision medium
  * @tags correctness
  *       security
+ *       experimental
  *       external/cwe/cwe-788
  */
 

--- a/csharp/ql/src/codeql-suites/csharp-security-experimental.qls
+++ b/csharp/ql/src/codeql-suites/csharp-security-experimental.qls
@@ -1,0 +1,4 @@
+- description: Extended and experimental security queries for C#
+- queries: .
+- apply: security-experimental-selectors.yml
+  from: codeql/suite-helpers

--- a/csharp/ql/src/experimental/CWE-099/TaintedWebClient.ql
+++ b/csharp/ql/src/experimental/CWE-099/TaintedWebClient.ql
@@ -7,6 +7,7 @@
  * @precision high
  * @id cs/webclient-path-injection
  * @tags security
+ *       experimental
  *       external/cwe/cwe-099
  *       external/cwe/cwe-023
  *       external/cwe/cwe-036

--- a/csharp/ql/src/experimental/CWE-918/RequestForgery.ql
+++ b/csharp/ql/src/experimental/CWE-918/RequestForgery.ql
@@ -6,6 +6,7 @@
  * @precision high
  * @id cs/request-forgery
  * @tags security
+ *       experimental
  *       external/cwe/cwe-918
  */
 

--- a/csharp/ql/src/experimental/Security Features/CWE-1004/CookieWithoutHttpOnly.ql
+++ b/csharp/ql/src/experimental/Security Features/CWE-1004/CookieWithoutHttpOnly.ql
@@ -9,6 +9,7 @@
  * @precision high
  * @id cs/web/cookie-httponly-not-set
  * @tags security
+ *       experimental
  *       external/cwe/cwe-1004
  */
 

--- a/csharp/ql/src/experimental/Security Features/CWE-327/Azure/UnsafeUsageOfClientSideEncryptionVersion.ql
+++ b/csharp/ql/src/experimental/Security Features/CWE-327/Azure/UnsafeUsageOfClientSideEncryptionVersion.ql
@@ -4,6 +4,7 @@
  * @kind problem
  * @tags security
  *       cryptography
+ *       experimental
  *       external/cwe/cwe-327
  * @id cs/azure-storage/unsafe-usage-of-client-side-encryption-version
  * @problem.severity error

--- a/csharp/ql/src/experimental/Security Features/CWE-614/CookieWithoutSecure.ql
+++ b/csharp/ql/src/experimental/Security Features/CWE-614/CookieWithoutSecure.ql
@@ -8,6 +8,7 @@
  * @precision high
  * @id cs/web/cookie-secure-not-set
  * @tags security
+ *       experimental
  *       external/cwe/cwe-319
  *       external/cwe/cwe-614
  */

--- a/csharp/ql/src/experimental/Security Features/CWE-759/HashWithoutSalt.ql
+++ b/csharp/ql/src/experimental/Security Features/CWE-759/HashWithoutSalt.ql
@@ -5,6 +5,7 @@
  * @problem.severity error
  * @id cs/hash-without-salt
  * @tags security
+ *       experimental
  *       external/cwe-759
  */
 

--- a/csharp/ql/src/experimental/Security Features/JsonWebTokenHandler/delegated-security-validations-always-return-true.ql
+++ b/csharp/ql/src/experimental/Security Features/JsonWebTokenHandler/delegated-security-validations-always-return-true.ql
@@ -4,6 +4,7 @@
  *   Higher precision version checks for exception throws, so less false positives are expected.
  * @kind problem
  * @tags security
+ *       experimental
  *       JsonWebTokenHandler
  *       manual-verification-required
  * @id cs/json-webtoken-handler/delegated-security-validations-always-return-true

--- a/csharp/ql/src/experimental/Security Features/JsonWebTokenHandler/security-validation-disabled.ql
+++ b/csharp/ql/src/experimental/Security Features/JsonWebTokenHandler/security-validation-disabled.ql
@@ -3,6 +3,7 @@
  * @description Check if security sensitive token validations for `JsonWebTokenHandler` are being disabled.
  * @kind problem
  * @tags security
+ *       experimental
  *       JsonWebTokenHandler
  *       manual-verification-required
  * @id cs/json-webtoken-handler/security-validations-disabled

--- a/csharp/ql/src/experimental/Security Features/Serialization/DefiningDatasetRelatedType.ql
+++ b/csharp/ql/src/experimental/Security Features/Serialization/DefiningDatasetRelatedType.ql
@@ -5,6 +5,7 @@
  * @problem.severity warning
  * @id cs/dataset-serialization/defining-dataset-related-type
  * @tags security
+ *       experimental
  */
 
 import csharp

--- a/csharp/ql/src/experimental/Security Features/Serialization/DefiningPotentiallyUnsafeXmlSerializer.ql
+++ b/csharp/ql/src/experimental/Security Features/Serialization/DefiningPotentiallyUnsafeXmlSerializer.ql
@@ -6,6 +6,7 @@
  * @precision medium
  * @id cs/dataset-serialization/defining-potentially-unsafe-xml-serializer
  * @tags security
+ *       experimental
  */
 
 import csharp

--- a/csharp/ql/src/experimental/Security Features/Serialization/UnsafeTypeUsedDataContractSerializer.ql
+++ b/csharp/ql/src/experimental/Security Features/Serialization/UnsafeTypeUsedDataContractSerializer.ql
@@ -6,6 +6,7 @@
  * @precision medium
  * @id cs/dataset-serialization/unsafe-type-used-data-contract-serializer
  * @tags security
+ *       experimental
  */
 
 import csharp

--- a/csharp/ql/src/experimental/Security Features/Serialization/XmlDeserializationWithDataSet.ql
+++ b/csharp/ql/src/experimental/Security Features/Serialization/XmlDeserializationWithDataSet.ql
@@ -6,6 +6,7 @@
  * @precision medium
  * @id cs/dataset-serialization/xml-deserialization-with-dataset
  * @tags security
+ *       experimental
  */
 
 import csharp

--- a/csharp/ql/src/experimental/Security Features/backdoor/DangerousNativeFunctionCall.ql
+++ b/csharp/ql/src/experimental/Security Features/backdoor/DangerousNativeFunctionCall.ql
@@ -6,6 +6,7 @@
  * @precision low
  * @id cs/backdoor/dangerous-native-functions
  * @tags security
+ *       experimental
  *       solorigate
  */
 

--- a/csharp/ql/src/experimental/Security Features/backdoor/PotentialTimeBomb.ql
+++ b/csharp/ql/src/experimental/Security Features/backdoor/PotentialTimeBomb.ql
@@ -6,6 +6,7 @@
  * @problem.severity warning
  * @id cs/backdoor/potential-time-bomb
  * @tags security
+ *       experimental
  *       solorigate
  */
 

--- a/csharp/ql/src/experimental/Security Features/backdoor/ProcessNameToHashTaintFlow.ql
+++ b/csharp/ql/src/experimental/Security Features/backdoor/ProcessNameToHashTaintFlow.ql
@@ -3,6 +3,7 @@
  * @description Flow from a function retrieving process name to a hash function.
  * @kind path-problem
  * @tags security
+ *       experimental
  *       solorigate
  * @problem.severity warning
  * @precision medium

--- a/docs/experimental.md
+++ b/docs/experimental.md
@@ -2,6 +2,8 @@
 
 In addition to [our supported queries and libraries](supported-queries.md), this repository also contains queries and libraries of a more experimental nature. Experimental queries and libraries can be improved incrementally and may eventually reach a sufficient maturity to be included in our supported queries and libraries.
 
+Experimental security queries are included in the `experimental` [CodeQL suite](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs). This suite is provided for testing purposes only, and should not be used in production code scanning workflows. 
+
 Experimental queries and libraries may not be actively maintained as the [supported](supported-queries.md) libraries evolve. They may also be changed in backwards-incompatible ways or may be removed entirely in the future without deprecation warnings.
 
 See [CONTRIBUTING.md](../CONTRIBUTING.md) for guidelines on submitting a new experimental query.

--- a/go/ql/src/codeql-suites/go-security-experimental.qls
+++ b/go/ql/src/codeql-suites/go-security-experimental.qls
@@ -1,0 +1,4 @@
+- description: Extended and experimental security queries for Go
+- queries: .
+- apply: security-experimental-selectors.yml
+  from: codeql/suite-helpers

--- a/go/ql/src/experimental/CWE-090/LDAPInjection.ql
+++ b/go/ql/src/experimental/CWE-090/LDAPInjection.ql
@@ -6,6 +6,7 @@
  * @problem.severity error
  * @id go/ldap-injection
  * @tags security
+ *       experimental
  *       external/cwe/cwe-90
  */
 

--- a/go/ql/src/experimental/CWE-1004/CookieWithoutHttpOnly.ql
+++ b/go/ql/src/experimental/CWE-1004/CookieWithoutHttpOnly.ql
@@ -9,6 +9,7 @@
  * @precision high
  * @id go/cookie-httponly-not-set
  * @tags security
+ *       experimental
  *       external/cwe/cwe-1004
  */
 

--- a/go/ql/src/experimental/CWE-285/PamAuthBypass.ql
+++ b/go/ql/src/experimental/CWE-285/PamAuthBypass.ql
@@ -6,6 +6,7 @@
  * @id go/pam-auth-bypass
  * @tags maintainability
  *       correctness
+ *       experimental
  *       external/cwe/cwe-561
  *       external/cwe/cwe-285
  * @precision very-high

--- a/go/ql/src/experimental/CWE-321/HardcodedKeys.ql
+++ b/go/ql/src/experimental/CWE-321/HardcodedKeys.ql
@@ -5,6 +5,7 @@
  * @problem.severity error
  * @id go/hardcoded-key
  * @tags security
+ *       experimental
  *       external/cwe/cwe-321
  */
 

--- a/go/ql/src/experimental/CWE-327/WeakCryptoAlgorithm.ql
+++ b/go/ql/src/experimental/CWE-327/WeakCryptoAlgorithm.ql
@@ -5,8 +5,9 @@
  * @problem.severity error
  * @id go/weak-crypto-algorithm
  * @tags security
- *         external/cwe/cwe-327
- *         external/cwe/cwe-328
+ *       experimental
+ *       external/cwe/cwe-327
+ *       external/cwe/cwe-328
  */
 
 import go

--- a/go/ql/src/experimental/CWE-369/DivideByZero.ql
+++ b/go/ql/src/experimental/CWE-369/DivideByZero.ql
@@ -5,6 +5,7 @@
  * @problem.severity error
  * @id go/divide-by-zero
  * @tags security
+ *       experimental
  *       external/cwe/cwe-369
  */
 

--- a/go/ql/src/experimental/CWE-400/DatabaseCallInLoop.ql
+++ b/go/ql/src/experimental/CWE-400/DatabaseCallInLoop.ql
@@ -6,6 +6,8 @@
  * @problem.severity warning
  * @precision high
  * @id go/examples/database-call-in-loop
+ * @tags security
+ *       experimental
  */
 
 import go

--- a/go/ql/src/experimental/CWE-79/HTMLTemplateEscapingPassthrough.ql
+++ b/go/ql/src/experimental/CWE-79/HTMLTemplateEscapingPassthrough.ql
@@ -6,6 +6,7 @@
  * @problem.severity warning
  * @id go/html-template-escaping-passthrough
  * @tags security
+ *       experimental
  *       external/cwe/cwe-79
  */
 

--- a/go/ql/src/experimental/CWE-807/SensitiveConditionBypass.ql
+++ b/go/ql/src/experimental/CWE-807/SensitiveConditionBypass.ql
@@ -8,6 +8,8 @@
  * @tags external/cwe/cwe-807
  *       external/cwe/cwe-247
  *       external/cwe/cwe-350
+ *       experimental
+ *       security
  */
 
 import go

--- a/go/ql/src/experimental/CWE-840/ConditionalBypass.ql
+++ b/go/ql/src/experimental/CWE-840/ConditionalBypass.ql
@@ -6,6 +6,8 @@
  * @kind problem
  * @problem.severity warning
  * @tags external/cwe/cwe-840
+ *       security
+ *       experimental
  */
 
 import go

--- a/go/ql/src/experimental/CWE-918/SSRF.ql
+++ b/go/ql/src/experimental/CWE-918/SSRF.ql
@@ -6,6 +6,7 @@
  * @problem.severity error
  * @precision high
  * @tags security
+ *       experimental
  *       external/cwe/cwe-918
  */
 

--- a/go/ql/src/experimental/CWE-942/CorsMisconfiguration.ql
+++ b/go/ql/src/experimental/CWE-942/CorsMisconfiguration.ql
@@ -7,6 +7,7 @@
  * @problem.severity warning
  * @id go/cors-misconfiguration
  * @tags security
+ *       experimental
  *       external/cwe/cwe-942
  *       external/cwe/cwe-346
  */

--- a/go/ql/src/experimental/Unsafe/WrongUsageOfUnsafe.ql
+++ b/go/ql/src/experimental/Unsafe/WrongUsageOfUnsafe.ql
@@ -6,6 +6,7 @@
  * @problem.severity error
  * @id go/wrong-usage-of-unsafe
  * @tags security
+ *       experimental
  *       external/cwe/cwe-119
  *       external/cwe/cwe-126
  */

--- a/java/ql/src/codeql-suites/java-security-experimental.qls
+++ b/java/ql/src/codeql-suites/java-security-experimental.qls
@@ -1,0 +1,4 @@
+- description: Extended and experimental security queries for Java and Kotlin
+- queries: .
+- apply: security-experimental-selectors.yml
+  from: codeql/suite-helpers

--- a/java/ql/src/experimental/Security/CWE/CWE-016/InsecureSpringActuatorConfig.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-016/InsecureSpringActuatorConfig.ql
@@ -7,6 +7,7 @@
  * @precision high
  * @id java/insecure-spring-actuator-config
  * @tags security
+ *       experimental
  *       external/cwe/cwe-016
  */
 

--- a/java/ql/src/experimental/Security/CWE/CWE-016/SpringBootActuators.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-016/SpringBootActuators.ql
@@ -7,6 +7,7 @@
  * @precision high
  * @id java/spring-boot-exposed-actuators
  * @tags security
+ *       experimental
  *       external/cwe/cwe-16
  */
 

--- a/java/ql/src/experimental/Security/CWE/CWE-020/Log4jJndiInjection.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-020/Log4jJndiInjection.ql
@@ -8,6 +8,7 @@
  * @precision high
  * @id java/log4j-injection
  * @tags security
+ *       experimental
  *       external/cwe/cwe-020
  *       external/cwe/cwe-074
  *       external/cwe/cwe-400

--- a/java/ql/src/experimental/Security/CWE/CWE-036/OpenStream.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-036/OpenStream.ql
@@ -7,6 +7,7 @@
  * @precision medium
  * @id java/openstream-called-on-tainted-url
  * @tags security
+ *       experimental
  *       external/cwe/cwe-036
  */
 

--- a/java/ql/src/experimental/Security/CWE/CWE-073/FilePathInjection.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-073/FilePathInjection.ql
@@ -8,6 +8,7 @@
  * @precision high
  * @id java/file-path-injection
  * @tags security
+ *       experimental
  *       external/cwe-073
  */
 

--- a/java/ql/src/experimental/Security/CWE/CWE-078/ExecTainted.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-078/ExecTainted.ql
@@ -7,6 +7,7 @@
  * @precision high
  * @id java/command-line-injection-experimental
  * @tags security
+ *       experimental
  *       external/cwe/cwe-078
  *       external/cwe/cwe-088
  */

--- a/java/ql/src/experimental/Security/CWE/CWE-089/MyBatisAnnotationSqlInjection.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-089/MyBatisAnnotationSqlInjection.ql
@@ -8,6 +8,7 @@
  * @precision high
  * @id java/mybatis-annotation-sql-injection
  * @tags security
+ *       experimental
  *       external/cwe/cwe-089
  */
 

--- a/java/ql/src/experimental/Security/CWE/CWE-089/MyBatisMapperXmlSqlInjection.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-089/MyBatisMapperXmlSqlInjection.ql
@@ -8,6 +8,7 @@
  * @precision high
  * @id java/mybatis-xml-sql-injection
  * @tags security
+ *       experimental
  *       external/cwe/cwe-089
  */
 

--- a/java/ql/src/experimental/Security/CWE/CWE-094/BeanShellInjection.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/BeanShellInjection.ql
@@ -7,6 +7,7 @@
  * @precision high
  * @id java/beanshell-injection
  * @tags security
+ *       experimental
  *       external/cwe/cwe-094
  */
 

--- a/java/ql/src/experimental/Security/CWE/CWE-094/InsecureDexLoading.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/InsecureDexLoading.ql
@@ -7,6 +7,7 @@
  * @precision high
  * @id java/android-insecure-dex-loading
  * @tags security
+ *       experimental
  *       external/cwe/cwe-094
  */
 

--- a/java/ql/src/experimental/Security/CWE/CWE-094/JShellInjection.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/JShellInjection.ql
@@ -7,6 +7,7 @@
  * @precision high
  * @id java/jshell-injection
  * @tags security
+ *       experimental
  *       external/cwe/cwe-094
  */
 

--- a/java/ql/src/experimental/Security/CWE/CWE-094/JakartaExpressionInjection.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/JakartaExpressionInjection.ql
@@ -7,6 +7,7 @@
  * @precision high
  * @id java/javaee-expression-injection
  * @tags security
+ *       experimental
  *       external/cwe/cwe-094
  */
 

--- a/java/ql/src/experimental/Security/CWE/CWE-094/JythonInjection.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/JythonInjection.ql
@@ -7,6 +7,7 @@
  * @precision high
  * @id java/jython-injection
  * @tags security
+ *       experimental
  *       external/cwe/cwe-094
  *       external/cwe/cwe-095
  */

--- a/java/ql/src/experimental/Security/CWE/CWE-094/ScriptInjection.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/ScriptInjection.ql
@@ -7,6 +7,7 @@
  * @precision high
  * @id java/unsafe-eval
  * @tags security
+ *       experimental
  *       external/cwe/cwe-094
  */
 

--- a/java/ql/src/experimental/Security/CWE/CWE-094/SpringImplicitViewManipulation.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/SpringImplicitViewManipulation.ql
@@ -6,6 +6,7 @@
  * @precision high
  * @id java/spring-view-manipulation-implicit
  * @tags security
+ *       experimental
  *       external/cwe/cwe-094
  */
 

--- a/java/ql/src/experimental/Security/CWE/CWE-094/SpringViewManipulation.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/SpringViewManipulation.ql
@@ -6,6 +6,7 @@
  * @precision high
  * @id java/spring-view-manipulation
  * @tags security
+ *       experimental
  *       external/cwe/cwe-094
  */
 

--- a/java/ql/src/experimental/Security/CWE/CWE-1004/InsecureTomcatConfig.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-1004/InsecureTomcatConfig.ql
@@ -6,6 +6,7 @@
  * @precision medium
  * @id java/tomcat-disabled-httponly
  * @tags security
+ *       experimental
  *       external/cwe/cwe-1004
  */
 

--- a/java/ql/src/experimental/Security/CWE/CWE-1004/SensitiveCookieNotHttpOnly.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-1004/SensitiveCookieNotHttpOnly.ql
@@ -7,6 +7,7 @@
  * @precision medium
  * @id java/sensitive-cookie-not-httponly
  * @tags security
+ *       experimental
  *       external/cwe/cwe-1004
  */
 

--- a/java/ql/src/experimental/Security/CWE/CWE-200/InsecureWebResourceResponse.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-200/InsecureWebResourceResponse.ql
@@ -6,6 +6,7 @@
  * @id java/insecure-webview-resource-response
  * @problem.severity error
  * @tags security
+ *       experimental
  *       external/cwe/cwe-200
  */
 

--- a/java/ql/src/experimental/Security/CWE/CWE-200/SensitiveAndroidFileLeak.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-200/SensitiveAndroidFileLeak.ql
@@ -6,6 +6,7 @@
  * @id java/sensitive-android-file-leak
  * @problem.severity warning
  * @tags security
+ *       experimental
  *       external/cwe/cwe-200
  */
 

--- a/java/ql/src/experimental/Security/CWE/CWE-208/PossibleTimingAttackAgainstSignature.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-208/PossibleTimingAttackAgainstSignature.ql
@@ -9,6 +9,7 @@
  * @precision medium
  * @id java/possible-timing-attack-against-signature
  * @tags security
+ *       experimental
  *       external/cwe/cwe-208
  */
 

--- a/java/ql/src/experimental/Security/CWE/CWE-208/TimingAttackAgainstHeader.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-208/TimingAttackAgainstHeader.ql
@@ -7,6 +7,7 @@
  * @precision high
  * @id java/timing-attack-against-headers-value
  * @tags security
+ *       experimental
  *       external/cwe/cwe-208
  */
 

--- a/java/ql/src/experimental/Security/CWE/CWE-208/TimingAttackAgainstSignature.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-208/TimingAttackAgainstSignature.ql
@@ -10,6 +10,7 @@
  * @precision high
  * @id java/timing-attack-against-signature
  * @tags security
+ *       experimental
  *       external/cwe/cwe-208
  */
 

--- a/java/ql/src/experimental/Security/CWE/CWE-295/JxBrowserWithoutCertValidation.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-295/JxBrowserWithoutCertValidation.ql
@@ -8,6 +8,7 @@
  * @precision medium
  * @id java/jxbrowser/disabled-certificate-validation
  * @tags security
+ *       experimental
  *       external/cwe/cwe-295
  */
 

--- a/java/ql/src/experimental/Security/CWE/CWE-297/IgnoredHostnameVerification.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-297/IgnoredHostnameVerification.ql
@@ -7,6 +7,7 @@
  * @precision high
  * @id java/ignored-hostname-verification
  * @tags security
+ *       experimental
  *       external/cwe/cwe-297
  */
 

--- a/java/ql/src/experimental/Security/CWE/CWE-297/InsecureLdapEndpoint.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-297/InsecureLdapEndpoint.ql
@@ -8,6 +8,7 @@
  * @precision medium
  * @id java/insecure-ldaps-endpoint
  * @tags security
+ *       experimental
  *       external/cwe/cwe-297
  */
 

--- a/java/ql/src/experimental/Security/CWE/CWE-299/DisabledRevocationChecking.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-299/DisabledRevocationChecking.ql
@@ -7,6 +7,7 @@
  * @precision high
  * @id java/disabled-certificate-revocation-checking
  * @tags security
+ *       experimental
  *       external/cwe/cwe-299
  */
 

--- a/java/ql/src/experimental/Security/CWE/CWE-321/HardcodedJwtKey.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-321/HardcodedJwtKey.ql
@@ -5,6 +5,7 @@
  * @problem.severity error
  * @id java/hardcoded-jwt-key
  * @tags security
+ *       experimental
  *       external/cwe/cwe-321
  */
 

--- a/java/ql/src/experimental/Security/CWE/CWE-327/UnsafeTlsVersion.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-327/UnsafeTlsVersion.ql
@@ -7,6 +7,7 @@
  * @precision high
  * @id java/unsafe-tls-version
  * @tags security
+ *       experimental
  *       external/cwe/cwe-327
  */
 

--- a/java/ql/src/experimental/Security/CWE/CWE-346/UnvalidatedCors.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-346/UnvalidatedCors.ql
@@ -6,6 +6,7 @@
  * @precision high
  * @id java/unvalidated-cors-origin-set
  * @tags security
+ *       experimental
  *       external/cwe/cwe-346
  */
 

--- a/java/ql/src/experimental/Security/CWE/CWE-348/ClientSuppliedIpUsedInSecurityCheck.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-348/ClientSuppliedIpUsedInSecurityCheck.ql
@@ -7,6 +7,7 @@
  * @precision high
  * @id java/ip-address-spoofing
  * @tags security
+ *       experimental
  *       external/cwe/cwe-348
  */
 

--- a/java/ql/src/experimental/Security/CWE/CWE-352/JsonpInjection.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-352/JsonpInjection.ql
@@ -7,6 +7,7 @@
  * @precision high
  * @id java/jsonp-injection
  * @tags security
+ *       experimental
  *       external/cwe/cwe-352
  */
 

--- a/java/ql/src/experimental/Security/CWE/CWE-400/ThreadResourceAbuse.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-400/ThreadResourceAbuse.ql
@@ -6,6 +6,7 @@
  * @id java/thread-resource-abuse
  * @problem.severity warning
  * @tags security
+ *       experimental
  *       external/cwe/cwe-400
  */
 

--- a/java/ql/src/experimental/Security/CWE/CWE-470/UnsafeReflection.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-470/UnsafeReflection.ql
@@ -7,6 +7,7 @@
  * @precision high
  * @id java/unsafe-reflection
  * @tags security
+ *       experimental
  *       external/cwe/cwe-470
  */
 

--- a/java/ql/src/experimental/Security/CWE/CWE-489/EJBMain.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-489/EJBMain.ql
@@ -6,6 +6,7 @@
  * @precision medium
  * @id java/main-method-in-enterprise-bean
  * @tags security
+ *       experimental
  *       external/cwe/cwe-489
  */
 

--- a/java/ql/src/experimental/Security/CWE/CWE-489/WebComponentMain.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-489/WebComponentMain.ql
@@ -6,6 +6,7 @@
  * @precision medium
  * @id java/main-method-in-web-components
  * @tags security
+ *       experimental
  *       external/cwe/cwe-489
  */
 

--- a/java/ql/src/experimental/Security/CWE/CWE-489/devMode.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-489/devMode.ql
@@ -7,6 +7,7 @@
  * @precision high
  * @id java/struts-development-mode
  * @tags security
+ *       experimental
  *       external/cwe/cwe-489
  */
 

--- a/java/ql/src/experimental/Security/CWE/CWE-502/UnsafeDeserializationRmi.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-502/UnsafeDeserializationRmi.ql
@@ -9,6 +9,7 @@
  * @precision high
  * @id java/unsafe-deserialization-rmi
  * @tags security
+ *       experimental
  *       external/cwe/cwe-502
  */
 

--- a/java/ql/src/experimental/Security/CWE/CWE-502/UnsafeSpringExporterInConfigurationClass.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-502/UnsafeSpringExporterInConfigurationClass.ql
@@ -8,6 +8,7 @@
  * @precision high
  * @id java/unsafe-deserialization-spring-exporter-in-configuration-class
  * @tags security
+ *       experimental
  *       external/cwe/cwe-502
  */
 

--- a/java/ql/src/experimental/Security/CWE/CWE-502/UnsafeSpringExporterInXMLConfiguration.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-502/UnsafeSpringExporterInXMLConfiguration.ql
@@ -8,6 +8,7 @@
  * @precision high
  * @id java/unsafe-deserialization-spring-exporter-in-xml-configuration
  * @tags security
+ *       experimental
  *       external/cwe/cwe-502
  */
 

--- a/java/ql/src/experimental/Security/CWE/CWE-522/InsecureLdapAuth.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-522/InsecureLdapAuth.ql
@@ -6,6 +6,7 @@
  * @precision medium
  * @id java/insecure-ldap-auth
  * @tags security
+ *       experimental
  *       external/cwe/cwe-522
  *       external/cwe/cwe-319
  */

--- a/java/ql/src/experimental/Security/CWE/CWE-548/InsecureDirectoryConfig.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-548/InsecureDirectoryConfig.ql
@@ -9,6 +9,7 @@
  * @precision medium
  * @id java/server-directory-listing
  * @tags security
+ *       experimental
  *       external/cwe/cwe-548
  */
 

--- a/java/ql/src/experimental/Security/CWE/CWE-552/UnsafeUrlForward.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-552/UnsafeUrlForward.ql
@@ -7,6 +7,7 @@
  * @precision high
  * @id java/unsafe-url-forward-dispatch-load
  * @tags security
+ *       experimental
  *       external/cwe-552
  */
 

--- a/java/ql/src/experimental/Security/CWE/CWE-555/CredentialsInPropertiesFile.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-555/CredentialsInPropertiesFile.ql
@@ -6,6 +6,7 @@
  * @precision high
  * @id java/credentials-in-properties
  * @tags security
+ *       experimental
  *       external/cwe/cwe-555
  *       external/cwe/cwe-256
  *       external/cwe/cwe-260

--- a/java/ql/src/experimental/Security/CWE/CWE-555/PasswordInConfigurationFile.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-555/PasswordInConfigurationFile.ql
@@ -6,6 +6,7 @@
  * @precision medium
  * @id java/password-in-configuration
  * @tags security
+ *       experimental
  *       external/cwe/cwe-555
  *       external/cwe/cwe-256
  *       external/cwe/cwe-260

--- a/java/ql/src/experimental/Security/CWE/CWE-598/SensitiveGetQuery.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-598/SensitiveGetQuery.ql
@@ -6,6 +6,7 @@
  * @precision medium
  * @id java/sensitive-query-with-get
  * @tags security
+ *       experimental
  *       external/cwe/cwe-598
  */
 

--- a/java/ql/src/experimental/Security/CWE/CWE-600/UncaughtServletException.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-600/UncaughtServletException.ql
@@ -9,6 +9,7 @@
  * @precision medium
  * @id java/uncaught-servlet-exception
  * @tags security
+ *       experimental
  *       external/cwe/cwe-600
  */
 

--- a/java/ql/src/experimental/Security/CWE/CWE-601/SpringUrlRedirect.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-601/SpringUrlRedirect.ql
@@ -7,6 +7,7 @@
  * @precision high
  * @id java/spring-unvalidated-url-redirection
  * @tags security
+ *       experimental
  *       external/cwe/cwe-601
  */
 

--- a/java/ql/src/experimental/Security/CWE/CWE-611/XXE.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-611/XXE.ql
@@ -8,6 +8,7 @@
  * @precision high
  * @id java/xxe-with-experimental-sinks
  * @tags security
+ *       experimental
  *       external/cwe/cwe-611
  */
 

--- a/java/ql/src/experimental/Security/CWE/CWE-611/XXELocal.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-611/XXELocal.ql
@@ -10,6 +10,7 @@
  * @precision medium
  * @id java/xxe-local-experimental-sinks
  * @tags security
+ *       experimental
  *       external/cwe/cwe-611
  */
 

--- a/java/ql/src/experimental/Security/CWE/CWE-625/PermissiveDotRegex.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-625/PermissiveDotRegex.ql
@@ -7,6 +7,7 @@
  * @precision high
  * @id java/permissive-dot-regex
  * @tags security
+ *       experimental
  *       external/cwe-625
  *       external/cwe-863
  */

--- a/java/ql/src/experimental/Security/CWE/CWE-652/XQueryInjection.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-652/XQueryInjection.ql
@@ -7,6 +7,7 @@
  * @precision high
  * @id java/xquery-injection
  * @tags security
+ *       experimental
  *       external/cwe/cwe-652
  */
 

--- a/java/ql/src/experimental/Security/CWE/CWE-665/InsecureRmiJmxEnvironmentConfiguration.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-665/InsecureRmiJmxEnvironmentConfiguration.ql
@@ -4,6 +4,7 @@
  * @kind problem
  * @problem.severity error
  * @tags security
+ *       experimental
  *       external/cwe/cwe-665
  * @precision high
  * @id java/insecure-rmi-jmx-server-initialization

--- a/java/ql/src/experimental/Security/CWE/CWE-755/NFEAndroidDoS.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-755/NFEAndroidDoS.ql
@@ -9,6 +9,7 @@
  * @precision medium
  * @id java/android/nfe-local-android-dos
  * @tags security
+ *       experimental
  *       external/cwe/cwe-755
  */
 

--- a/java/ql/src/experimental/Security/CWE/CWE-759/HashWithoutSalt.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-759/HashWithoutSalt.ql
@@ -6,6 +6,7 @@
  * @precision low
  * @id java/hash-without-salt
  * @tags security
+ *       experimental
  *       external/cwe/cwe-759
  */
 

--- a/java/ql/src/experimental/Security/CWE/CWE-939/IncorrectURLVerification.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-939/IncorrectURLVerification.ql
@@ -8,6 +8,7 @@
  * @precision medium
  * @id java/incorrect-url-verification
  * @tags security
+ *       experimental
  *       external/cwe/cwe-939
  */
 

--- a/javascript/ql/src/experimental/Security/CWE-094/UntrustedCheckout.ql
+++ b/javascript/ql/src/experimental/Security/CWE-094/UntrustedCheckout.ql
@@ -9,6 +9,7 @@
  * @id js/actions/pull-request-target
  * @tags actions
  *       security
+ *       experimental
  *       external/cwe/cwe-094
  */
 

--- a/javascript/ql/src/experimental/Security/CWE-340/TokenBuiltFromUUID.ql
+++ b/javascript/ql/src/experimental/Security/CWE-340/TokenBuiltFromUUID.ql
@@ -8,6 +8,7 @@
  * @security-severity 5
  * @id js/predictable-token
  * @tags security
+ *       experimental
  *       external/cwe/cwe-340
  */
 

--- a/javascript/ql/src/experimental/Security/CWE-918/SSRF.ql
+++ b/javascript/ql/src/experimental/Security/CWE-918/SSRF.ql
@@ -6,6 +6,7 @@
  * @problem.severity error
  * @precision medium
  * @tags security
+ *       experimental
  *       external/cwe/cwe-918
  */
 

--- a/misc/suite-helpers/security-experimental-selectors.yml
+++ b/misc/suite-helpers/security-experimental-selectors.yml
@@ -1,0 +1,45 @@
+- description: Selectors for selecting the security-extended and experimental security queries for a language
+- include:
+    kind:
+    - problem
+    - path-problem
+    precision:
+    - high
+    - very-high
+    tags contain:
+    - security
+- include:
+    kind:
+    - problem
+    - path-problem
+    precision:
+    - medium
+    problem.severity:
+    - error
+    - warning
+    tags contain:
+    - security
+- include:
+    kind:
+    - diagnostic
+- include:
+    kind:
+    - metric
+    tags contain:
+    - summary
+- exclude:
+    query path:
+      - /^experimental\/.*/
+- include:
+    tags contain all:
+      - security
+      - experimental
+- exclude:
+    deprecated: //
+- exclude:
+    query path:
+      - Metrics/Summaries/FrameworkCoverage.ql
+      - /Diagnostics/Internal/.*/
+- exclude:
+    tags contain:
+      - model-generator

--- a/python/ql/src/codeql-suites/python-security-experimental.qls
+++ b/python/ql/src/codeql-suites/python-security-experimental.qls
@@ -1,0 +1,4 @@
+- description: Extended and experimental security queries for Python
+- queries: .
+- apply: security-experimental-selectors.yml
+  from: codeql/suite-helpers

--- a/python/ql/src/experimental/Security/CWE-022/ZipSlip.ql
+++ b/python/ql/src/experimental/Security/CWE-022/ZipSlip.ql
@@ -9,6 +9,7 @@
  * @security-severity 7.5
  * @precision high
  * @tags security
+ *       experimental
  *       external/cwe/cwe-022
  */
 

--- a/python/ql/src/experimental/Security/CWE-022bis/TarSlipImprov.ql
+++ b/python/ql/src/experimental/Security/CWE-022bis/TarSlipImprov.ql
@@ -9,6 +9,7 @@
  * @security-severity 7.5
  * @precision high
  * @tags security
+ *       experimental
  *       external/cwe/cwe-022
  */
 

--- a/python/ql/src/experimental/Security/CWE-074/TemplateInjection.ql
+++ b/python/ql/src/experimental/Security/CWE-074/TemplateInjection.ql
@@ -6,6 +6,7 @@
  * @precision high
  * @id py/template-injection
  * @tags security
+ *       experimental
  *       external/cwe/cwe-074
  */
 

--- a/python/ql/src/experimental/Security/CWE-079/ReflectedXSS.ql
+++ b/python/ql/src/experimental/Security/CWE-079/ReflectedXSS.ql
@@ -8,6 +8,7 @@
  * @sub-severity high
  * @id py/reflective-xss-email
  * @tags security
+ *       experimental
  *       external/cwe/cwe-079
  *       external/cwe/cwe-116
  */

--- a/python/ql/src/experimental/Security/CWE-091/Xslt.ql
+++ b/python/ql/src/experimental/Security/CWE-091/Xslt.ql
@@ -7,6 +7,7 @@
  * @precision high
  * @id py/xslt-injection
  * @tags security
+ *       experimental
  *       external/cwe/cwe-643
  */
 

--- a/python/ql/src/experimental/Security/CWE-113/HeaderInjection.ql
+++ b/python/ql/src/experimental/Security/CWE-113/HeaderInjection.ql
@@ -6,6 +6,7 @@
  * @problem.severity error
  * @id py/header-injection
  * @tags security
+ *       experimental
  *       external/cwe/cwe-113
  *       external/cwe/cwe-079
  */

--- a/python/ql/src/experimental/Security/CWE-1236/CsvInjection.ql
+++ b/python/ql/src/experimental/Security/CWE-1236/CsvInjection.ql
@@ -6,6 +6,7 @@
  * @problem.severity error
  * @id py/csv-injection
  * @tags security
+ *       experimental
  *       external/cwe/cwe-1236
  */
 

--- a/python/ql/src/experimental/Security/CWE-287/ImproperLdapAuth.ql
+++ b/python/ql/src/experimental/Security/CWE-287/ImproperLdapAuth.ql
@@ -5,6 +5,7 @@
  * @problem.severity warning
  * @id py/improper-ldap-auth
  * @tags security
+ *       experimental
  *       external/cwe/cwe-287
  */
 

--- a/python/ql/src/experimental/Security/CWE-327/Azure/UnsafeUsageOfClientSideEncryptionVersion.ql
+++ b/python/ql/src/experimental/Security/CWE-327/Azure/UnsafeUsageOfClientSideEncryptionVersion.ql
@@ -3,6 +3,7 @@
  * @description Using version v1 of Azure Storage client-side encryption is insecure, and may enable an attacker to decrypt encrypted data
  * @kind problem
  * @tags security
+ *       experimental
  *       cryptography
  *       external/cwe/cwe-327
  * @id py/azure-storage/unsafe-client-side-encryption-in-use

--- a/python/ql/src/experimental/Security/CWE-338/InsecureRandomness.ql
+++ b/python/ql/src/experimental/Security/CWE-338/InsecureRandomness.ql
@@ -9,6 +9,7 @@
  * @precision high
  * @id py/insecure-randomness
  * @tags security
+ *       experimental
  *       external/cwe/cwe-338
  */
 

--- a/python/ql/src/experimental/Security/CWE-340/TokenBuiltFromUUID.ql
+++ b/python/ql/src/experimental/Security/CWE-340/TokenBuiltFromUUID.ql
@@ -8,6 +8,7 @@
  * @security-severity 5
  * @id py/predictable-token
  * @tags security
+ *       experimental
  *       external/cwe/cwe-340
  */
 

--- a/python/ql/src/experimental/Security/CWE-347/JWTEmptyKeyOrAlgorithm.ql
+++ b/python/ql/src/experimental/Security/CWE-347/JWTEmptyKeyOrAlgorithm.ql
@@ -5,6 +5,7 @@
  * @problem.severity warning
  * @id py/jwt-empty-secret-or-algorithm
  * @tags security
+ *       experimental
  */
 
 // determine precision above

--- a/python/ql/src/experimental/Security/CWE-347/JWTMissingSecretOrPublicKeyVerification.ql
+++ b/python/ql/src/experimental/Security/CWE-347/JWTMissingSecretOrPublicKeyVerification.ql
@@ -5,6 +5,7 @@
  * @problem.severity warning
  * @id py/jwt-missing-verification
  * @tags security
+ *       experimental
  *       external/cwe/cwe-347
  */
 

--- a/python/ql/src/experimental/Security/CWE-348/ClientSuppliedIpUsedInSecurityCheck.ql
+++ b/python/ql/src/experimental/Security/CWE-348/ClientSuppliedIpUsedInSecurityCheck.ql
@@ -7,6 +7,7 @@
  * @precision high
  * @id py/ip-address-spoofing
  * @tags security
+ *       experimental
  *       external/cwe/cwe-348
  */
 

--- a/python/ql/src/experimental/Security/CWE-522/LDAPInsecureAuth.ql
+++ b/python/ql/src/experimental/Security/CWE-522/LDAPInsecureAuth.ql
@@ -5,6 +5,7 @@
  * @problem.severity error
  * @id py/insecure-ldap-auth
  * @tags security
+ *       experimental
  *       external/cwe/cwe-522
  *       external/cwe/cwe-523
  */

--- a/python/ql/src/experimental/Security/CWE-611/SimpleXmlRpcServer.ql
+++ b/python/ql/src/experimental/Security/CWE-611/SimpleXmlRpcServer.ql
@@ -6,6 +6,7 @@
  * @precision high
  * @id py/simple-xml-rpc-server-dos
  * @tags security
+ *       experimental
  *       external/cwe/cwe-776
  */
 

--- a/python/ql/src/experimental/Security/CWE-614/CookieInjection.ql
+++ b/python/ql/src/experimental/Security/CWE-614/CookieInjection.ql
@@ -5,6 +5,7 @@
  * @problem.severity error
  * @id py/cookie-injection
  * @tags security
+ *       experimental
  *       external/cwe/cwe-614
  */
 

--- a/python/ql/src/experimental/Security/CWE-614/InsecureCookie.ql
+++ b/python/ql/src/experimental/Security/CWE-614/InsecureCookie.ql
@@ -8,6 +8,7 @@
  * @precision ???
  * @id py/insecure-cookie
  * @tags security
+ *       experimental
  *       external/cwe/cwe-614
  */
 

--- a/python/ql/src/experimental/Security/CWE-943/NoSQLInjection.ql
+++ b/python/ql/src/experimental/Security/CWE-943/NoSQLInjection.ql
@@ -6,6 +6,7 @@
  * @problem.severity error
  * @id py/nosql-injection
  * @tags security
+ *       experimental
  *       external/cwe/cwe-943
  */
 

--- a/ruby/ql/src/codeql-suites/ruby-security-experimental.qls
+++ b/ruby/ql/src/codeql-suites/ruby-security-experimental.qls
@@ -1,0 +1,4 @@
+- description: Extended and experimental security queries for Ruby
+- queries: .
+- apply: security-experimental-selectors.yml
+  from: codeql/suite-helpers

--- a/ruby/ql/src/experimental/cwe-807/ConditionalBypass.ql
+++ b/ruby/ql/src/experimental/cwe-807/ConditionalBypass.ql
@@ -7,6 +7,7 @@
  * @precision medium
  * @id rb/user-controlled-bypass
  * @tags security
+ *       experimental
  *       external/cwe/cwe-807
  *       external/cwe/cwe-290
  */

--- a/ruby/ql/src/experimental/decompression-api/DecompressionApi.ql
+++ b/ruby/ql/src/experimental/decompression-api/DecompressionApi.ql
@@ -6,7 +6,9 @@
  * @security-severity 7.8
  * @precision medium
  * @id rb/user-controlled-file-decompression
- * @tags security external/cwe/cwe-409
+ * @tags security
+ *       experimental
+ *       external/cwe/cwe-409
  */
 
 import codeql.ruby.AST

--- a/ruby/ql/src/experimental/improper-memoization/ImproperMemoization.ql
+++ b/ruby/ql/src/experimental/improper-memoization/ImproperMemoization.ql
@@ -5,6 +5,7 @@
  * @problem.severity warning
  * @precision high
  * @tags security
+ *       experimental
  * @id rb/improper-memoization
  */
 

--- a/ruby/ql/src/experimental/manually-check-http-verb/ManuallyCheckHttpVerb.ql
+++ b/ruby/ql/src/experimental/manually-check-http-verb/ManuallyCheckHttpVerb.ql
@@ -7,6 +7,7 @@
  * @precision low
  * @id rb/manually-checking-http-verb
  * @tags security
+ *       experimental
  */
 
 import codeql.ruby.AST

--- a/ruby/ql/src/experimental/weak-params/WeakParams.ql
+++ b/ruby/ql/src/experimental/weak-params/WeakParams.ql
@@ -7,6 +7,7 @@
  * @precision medium
  * @id rb/weak-params
  * @tags security
+ *       experimental
  */
 
 import codeql.ruby.AST

--- a/swift/ql/src/codeql-suites/swift-security-experimental.qls
+++ b/swift/ql/src/codeql-suites/swift-security-experimental.qls
@@ -1,0 +1,4 @@
+- description: Extended and experimental security queries for Swift
+- queries: .
+- apply: security-experimental-selectors.yml
+  from: codeql/suite-helpers


### PR DESCRIPTION
> **Note**
> 👋 all that have been pinged by this. This requires a (hopefully) short look, but a look nonetheless from all language teams. If you have any questions or want to discuss this, please use our internal Slack channels 🙂.

This PR implements the experimental CodeQL suite, by introducing a new suite selector `security-experimental` and suite implementations for all supported (and beta) languages. For more details and caveats, please see our internal roadmap item.

## Goal of the experimental suite

The `security-experimental` suite captures all queries captured by `security-extended`, but adds all existing queries that:

- were present in each language's `experimental` folder
- were tagged `security`

The experimental suite is **not** going to be advertised for use by code scanning users; not as part of the workflow, docs, neither the setup experience. It is meant as an internal or field testing shortcut. It **does not change our current support level** for experimental queries (which is "none"), and it does not impose any restrictions on contributions or experimental query writing, with the exception of adding a tag introduced by this PR.

## Structure of this change

I've structured this PR in three distinct commits:

1. [`4ec401a`](https://github.com/github/codeql/commit/4ec401a3f6d9bcd4976dc34779168af83c2544a5) introduces the tagging mechanism. Previously, experimental queries were just put into each language's experimental directory, each with a different structure. The standard suite selectors have excluded this directory by path, instead of metadata/tags. This commit adds a new `experimental` tag to all applicable queries (see Goal section above for criterion used) to allow for a change to select by tags instead
2. [`b35a1d4`](https://github.com/github/codeql/commit/b35a1d420638784c808064faa1e208b02a791b75) is a docs change and updates the [contribution guidelines](https://github.com/github/codeql/blob/main/CONTRIBUTING.md) to require the `experimental` tag, as well as the [experimental doc stub](https://github.com/github/codeql/blob/main/docs/experimental.md) to indicate the existence of the experimental suite
3. [`5fd5ebc`](https://github.com/github/codeql/commit/5fd5ebc26e1d94813d53df483ef311dd68abc3b6) finally creates the `security-experimental` suite selector, and implementations for all supported languages. Plus Swift, which doesn't have an experimental folder, but gets this change anyway in anticipation.

It's worth expanding on how the logic in 3. works: We still exclude everything in all experimental directories, but then explicitly re-include all queries tagged both security and experimental. This ignores quality, debugging, and other queries that shouldn't be considered for this and allows some amount of freedom of use of the experimental folder without every single query immediately ending up in this suite.

## Things to review in detail

While each single change is simple, the combination may cause complex consequences to arise, so please pay close attention to the following, in addition to the general review and comments 🙂 

- None of the changes in this PR should in any way affect the current `code-scanning`, `security-extended`, or `security-and-quality` suites, how users use them, and what results they produce. I'm somewhat confident that's the case, but I want to make sure.
- Have I tagged something by mistake (as in it's not **both** an experimental and a security query)?
- Have I forgotten to tag something?
- Does this accidentally include a query for which a better/promoted version already exists? Then this should be excluded again
- The query in question is known to cause issues (timeouts, crashes, blatantly wrong results). Note that these should be issues that massively degrade or block an analysis. It’s not required to apply the same standards that we have for our other suites (see Goal). For example, I've inherited the "slow queries" exclusion in the C++ query suite implementation, but may have missed that for other languages (or one needs to be created).
- The query doesn’t produce any actual information or help files don’t exist and would be required, then this should be removed for now.

## Timeline

I'll be offline until Dec 17 to Jan 9, but please do add your review and questions in the meantime if you are around. I'm aiming to address most of them within January so this can ship in the same timeframe.

cc @nickliffen