### PR TITLE
Go: Add and Modify Sanitizers For TaintedPath

### DIFF
--- a/go/ql/lib/change-notes/2023-10-08-addional-gopath-sanitizers.md
+++ b/go/ql/lib/change-notes/2023-10-08-addional-gopath-sanitizers.md
@@ -1,5 +1,0 @@
-
-* ---
-category: minorAnalysis
----
-* Added filepath.Base, strings.ReplaceAll, http.ParseMultipartForm sanitizers and remove path sanitizer.

--- a/go/ql/lib/change-notes/2023-10-08-addional-gopath-sanitizers.md
+++ b/go/ql/lib/change-notes/2023-10-08-addional-gopath-sanitizers.md
@@ -1,0 +1,5 @@
+
+* ---
+category: minorAnalysis
+---
+* Added filepath.Base, strings.ReplaceAll, http.ParseMultipartForm sanitizers and remove path sanitizer.

--- a/go/ql/lib/change-notes/2024-03-11-addional-gopath-sanitizers.md
+++ b/go/ql/lib/change-notes/2024-03-11-addional-gopath-sanitizers.md
@@ -1,0 +1,5 @@
+
+* ---
+category: minorAnalysis
+---
+* Added strings.ReplaceAll, http.ParseMultipartForm sanitizers and remove path sanitizer.

--- a/go/ql/lib/semmle/go/security/TaintedPathCustomizations.qll
+++ b/go/ql/lib/semmle/go/security/TaintedPathCustomizations.qll
@@ -88,7 +88,7 @@ module TaintedPath {
     }
   }
 
-  /**An call to ParseMultipartForm creates multipart.Form and cleans mutlpart.Form.FileHeader.Filename using path.Base() */
+  /**An call to ParseMultipartForm creates multipart.Form and cleans multipart.Form.FileHeader.Filename using path.Base() */
   class MultipartClean extends Sanitizer {
     MultipartClean() {
       exists(DataFlow::FieldReadNode frn |

--- a/go/ql/lib/semmle/go/security/TaintedPathCustomizations.qll
+++ b/go/ql/lib/semmle/go/security/TaintedPathCustomizations.qll
@@ -6,6 +6,7 @@
 import go
 import semmle.go.dataflow.barrierguardutil.RegexpCheck
 import DataFlow
+
 /**
  * Provides extension points for customizing the taint tracking configuration for reasoning about
  * path-traversal vulnerabilities.
@@ -79,15 +80,15 @@ module TaintedPath {
   class FilepathCleanSanitizer extends Sanitizer {
     FilepathCleanSanitizer() {
       exists(DataFlow::CallNode cleanCall, StringOps::Concatenation concatNode |
-        cleanCall =
-          any(Function f | f.hasQualifiedName("path/filepath", "Clean")).getACall() and
+        cleanCall = any(Function f | f.hasQualifiedName("path/filepath", "Clean")).getACall() and
         concatNode = cleanCall.getArgument(0) and
         concatNode.getOperand(0).asExpr().(StringLit).getValue() = "/" and
         this = cleanCall.getResult()
       )
     }
   }
-      /**
+
+  /**
    * A call to `filepath.Base(e)`, considered to sanitize `e` against path traversal.
    */
   class FilepathBaseSanitizer extends Sanitizer {
@@ -107,8 +108,8 @@ module TaintedPath {
         frn.getField().hasQualifiedName("mime/multipart", "FileHeader", "Filename") and
         this = frn
       )
-      }
     }
+  }
 
   /**
    * A check of the form `!strings.Contains(nd, "..")`, considered as a sanitizer guard for
@@ -127,15 +128,15 @@ module TaintedPath {
       branch = false
     }
   }
-/**
+
+  /**
    * A replacement of the form `!strings.ReplaceAll(nd, "..")` or `!strings.ReplaceAll(nd, ".")`, considered as a sanitizer for
    * path traversal.
    */
   class DotDotReplace extends Sanitizer {
     DotDotReplace() {
       exists(DataFlow::CallNode cleanCall, DataFlow::Node valueNode |
-        cleanCall =
-          any(Function f | f.hasQualifiedName("strings", "ReplaceAll")).getACall() and
+        cleanCall = any(Function f | f.hasQualifiedName("strings", "ReplaceAll")).getACall() and
         valueNode = cleanCall.getArgument(1) and
         valueNode.asExpr().(StringLit).getValue() = ["..", "."] and
         this = cleanCall.getResult()

--- a/go/ql/lib/semmle/go/security/TaintedPathCustomizations.qll
+++ b/go/ql/lib/semmle/go/security/TaintedPathCustomizations.qll
@@ -88,19 +88,6 @@ module TaintedPath {
     }
   }
 
-  /**
-   * A call to `filepath.Base(e)`, considered to sanitize `e` against path traversal.
-   */
-  class FilepathBaseSanitizer extends Sanitizer {
-    FilepathBaseSanitizer() {
-      exists(Function f, FunctionOutput outp |
-        f.hasQualifiedName("path/filepath", "Base") and
-        outp.isResult(0) and
-        this = outp.getNode(f.getACall())
-      )
-    }
-  }
-
   /**An call to ParseMultipartForm creates multipart.Form and cleans mutlpart.Form.FileHeader.Filename using path.Base() */
   class MultipartClean extends Sanitizer {
     MultipartClean() {

--- a/go/ql/test/query-tests/Security/CWE-022/TaintedPath.expected
+++ b/go/ql/test/query-tests/Security/CWE-022/TaintedPath.expected
@@ -1,28 +1,10 @@
 edges
-<<<<<<< HEAD
-<<<<<<< HEAD
 | TaintedPath.go:13:18:13:22 | selection of URL | TaintedPath.go:13:18:13:30 | call to Query | provenance |  |
 | TaintedPath.go:13:18:13:30 | call to Query | TaintedPath.go:16:29:16:40 | tainted_path | provenance |  |
 | TaintedPath.go:13:18:13:30 | call to Query | TaintedPath.go:20:57:20:68 | tainted_path | provenance |  |
+| TaintedPath.go:13:18:13:30 | call to Query | TaintedPath.go:67:39:67:56 | ...+... | provenance |  |
 | TaintedPath.go:20:57:20:68 | tainted_path | TaintedPath.go:20:28:20:69 | call to Join | provenance |  |
-| tst.go:14:2:14:39 | ... := ...[1] | tst.go:17:41:17:56 | selection of Filename | provenance |  |
-=======
-| TaintedPath.go:13:18:13:22 | selection of URL : pointer type | TaintedPath.go:16:29:16:40 | tainted_path |
-| TaintedPath.go:13:18:13:22 | selection of URL : pointer type | TaintedPath.go:20:28:20:69 | call to Join |
-| TaintedPath.go:13:18:13:22 | selection of URL : pointer type | TaintedPath.go:67:28:67:57 | call to Clean |
-| TaintedPath.go:13:18:13:22 | selection of URL : pointer type | TaintedPath.go:77:28:77:56 | call to Base |
-| tst.go:14:2:14:39 | ... := ...[1] : pointer type | tst.go:17:41:17:56 | selection of Filename |
->>>>>>> a45343fb6c (Add New Sanitizers and Modify Old Ones)
-=======
-| TaintedPath.go:13:18:13:22 | selection of URL | TaintedPath.go:13:18:13:30 | call to Query |
-| TaintedPath.go:13:18:13:30 | call to Query | TaintedPath.go:16:29:16:40 | tainted_path |
-| TaintedPath.go:13:18:13:30 | call to Query | TaintedPath.go:20:57:20:68 | tainted_path |
-| TaintedPath.go:13:18:13:30 | call to Query | TaintedPath.go:67:39:67:56 | ...+... |
-| TaintedPath.go:13:18:13:30 | call to Query | TaintedPath.go:77:38:77:55 | ...+... |
-| TaintedPath.go:20:57:20:68 | tainted_path | TaintedPath.go:20:28:20:69 | call to Join |
-| TaintedPath.go:67:39:67:56 | ...+... | TaintedPath.go:67:28:67:57 | call to Clean |
-| TaintedPath.go:77:38:77:55 | ...+... | TaintedPath.go:77:28:77:56 | call to Base |
->>>>>>> db14838a4f (resolve feedback)
+| TaintedPath.go:67:39:67:56 | ...+... | TaintedPath.go:67:28:67:57 | call to Clean | provenance |  |
 nodes
 | TaintedPath.go:13:18:13:22 | selection of URL | semmle.label | selection of URL |
 | TaintedPath.go:13:18:13:30 | call to Query | semmle.label | call to Query |
@@ -31,11 +13,8 @@ nodes
 | TaintedPath.go:20:57:20:68 | tainted_path | semmle.label | tainted_path |
 | TaintedPath.go:67:28:67:57 | call to Clean | semmle.label | call to Clean |
 | TaintedPath.go:67:39:67:56 | ...+... | semmle.label | ...+... |
-| TaintedPath.go:77:28:77:56 | call to Base | semmle.label | call to Base |
-| TaintedPath.go:77:38:77:55 | ...+... | semmle.label | ...+... |
 subpaths
 #select
 | TaintedPath.go:16:29:16:40 | tainted_path | TaintedPath.go:13:18:13:22 | selection of URL | TaintedPath.go:16:29:16:40 | tainted_path | This path depends on a $@. | TaintedPath.go:13:18:13:22 | selection of URL | user-provided value |
 | TaintedPath.go:20:28:20:69 | call to Join | TaintedPath.go:13:18:13:22 | selection of URL | TaintedPath.go:20:28:20:69 | call to Join | This path depends on a $@. | TaintedPath.go:13:18:13:22 | selection of URL | user-provided value |
 | TaintedPath.go:67:28:67:57 | call to Clean | TaintedPath.go:13:18:13:22 | selection of URL | TaintedPath.go:67:28:67:57 | call to Clean | This path depends on a $@. | TaintedPath.go:13:18:13:22 | selection of URL | user-provided value |
-| TaintedPath.go:77:28:77:56 | call to Base | TaintedPath.go:13:18:13:22 | selection of URL | TaintedPath.go:77:28:77:56 | call to Base | This path depends on a $@. | TaintedPath.go:13:18:13:22 | selection of URL | user-provided value |

--- a/go/ql/test/query-tests/Security/CWE-022/TaintedPath.expected
+++ b/go/ql/test/query-tests/Security/CWE-022/TaintedPath.expected
@@ -1,5 +1,6 @@
 edges
 <<<<<<< HEAD
+<<<<<<< HEAD
 | TaintedPath.go:13:18:13:22 | selection of URL | TaintedPath.go:13:18:13:30 | call to Query | provenance |  |
 | TaintedPath.go:13:18:13:30 | call to Query | TaintedPath.go:16:29:16:40 | tainted_path | provenance |  |
 | TaintedPath.go:13:18:13:30 | call to Query | TaintedPath.go:20:57:20:68 | tainted_path | provenance |  |
@@ -12,24 +13,29 @@ edges
 | TaintedPath.go:13:18:13:22 | selection of URL : pointer type | TaintedPath.go:77:28:77:56 | call to Base |
 | tst.go:14:2:14:39 | ... := ...[1] : pointer type | tst.go:17:41:17:56 | selection of Filename |
 >>>>>>> a45343fb6c (Add New Sanitizers and Modify Old Ones)
+=======
+| TaintedPath.go:13:18:13:22 | selection of URL | TaintedPath.go:13:18:13:30 | call to Query |
+| TaintedPath.go:13:18:13:30 | call to Query | TaintedPath.go:16:29:16:40 | tainted_path |
+| TaintedPath.go:13:18:13:30 | call to Query | TaintedPath.go:20:57:20:68 | tainted_path |
+| TaintedPath.go:13:18:13:30 | call to Query | TaintedPath.go:67:39:67:56 | ...+... |
+| TaintedPath.go:13:18:13:30 | call to Query | TaintedPath.go:77:38:77:55 | ...+... |
+| TaintedPath.go:20:57:20:68 | tainted_path | TaintedPath.go:20:28:20:69 | call to Join |
+| TaintedPath.go:67:39:67:56 | ...+... | TaintedPath.go:67:28:67:57 | call to Clean |
+| TaintedPath.go:77:38:77:55 | ...+... | TaintedPath.go:77:28:77:56 | call to Base |
+>>>>>>> db14838a4f (resolve feedback)
 nodes
 | TaintedPath.go:13:18:13:22 | selection of URL | semmle.label | selection of URL |
 | TaintedPath.go:13:18:13:30 | call to Query | semmle.label | call to Query |
 | TaintedPath.go:16:29:16:40 | tainted_path | semmle.label | tainted_path |
 | TaintedPath.go:20:28:20:69 | call to Join | semmle.label | call to Join |
-<<<<<<< HEAD
 | TaintedPath.go:20:57:20:68 | tainted_path | semmle.label | tainted_path |
-| tst.go:14:2:14:39 | ... := ...[1] | semmle.label | ... := ...[1] |
-=======
 | TaintedPath.go:67:28:67:57 | call to Clean | semmle.label | call to Clean |
+| TaintedPath.go:67:39:67:56 | ...+... | semmle.label | ...+... |
 | TaintedPath.go:77:28:77:56 | call to Base | semmle.label | call to Base |
-| tst.go:14:2:14:39 | ... := ...[1] : pointer type | semmle.label | ... := ...[1] : pointer type |
->>>>>>> a45343fb6c (Add New Sanitizers and Modify Old Ones)
-| tst.go:17:41:17:56 | selection of Filename | semmle.label | selection of Filename |
+| TaintedPath.go:77:38:77:55 | ...+... | semmle.label | ...+... |
 subpaths
 #select
-| TaintedPath.go:16:29:16:40 | tainted_path | TaintedPath.go:13:18:13:22 | selection of URL : pointer type | TaintedPath.go:16:29:16:40 | tainted_path | This path depends on a $@. | TaintedPath.go:13:18:13:22 | selection of URL | user-provided value |
-| TaintedPath.go:20:28:20:69 | call to Join | TaintedPath.go:13:18:13:22 | selection of URL : pointer type | TaintedPath.go:20:28:20:69 | call to Join | This path depends on a $@. | TaintedPath.go:13:18:13:22 | selection of URL | user-provided value |
-| TaintedPath.go:67:28:67:57 | call to Clean | TaintedPath.go:13:18:13:22 | selection of URL : pointer type | TaintedPath.go:67:28:67:57 | call to Clean | This path depends on a $@. | TaintedPath.go:13:18:13:22 | selection of URL | user-provided value |
-| TaintedPath.go:77:28:77:56 | call to Base | TaintedPath.go:13:18:13:22 | selection of URL : pointer type | TaintedPath.go:77:28:77:56 | call to Base | This path depends on a $@. | TaintedPath.go:13:18:13:22 | selection of URL | user-provided value |
-| tst.go:17:41:17:56 | selection of Filename | tst.go:14:2:14:39 | ... := ...[1] : pointer type | tst.go:17:41:17:56 | selection of Filename | This path depends on a $@. | tst.go:14:2:14:39 | ... := ...[1] | user-provided value |
+| TaintedPath.go:16:29:16:40 | tainted_path | TaintedPath.go:13:18:13:22 | selection of URL | TaintedPath.go:16:29:16:40 | tainted_path | This path depends on a $@. | TaintedPath.go:13:18:13:22 | selection of URL | user-provided value |
+| TaintedPath.go:20:28:20:69 | call to Join | TaintedPath.go:13:18:13:22 | selection of URL | TaintedPath.go:20:28:20:69 | call to Join | This path depends on a $@. | TaintedPath.go:13:18:13:22 | selection of URL | user-provided value |
+| TaintedPath.go:67:28:67:57 | call to Clean | TaintedPath.go:13:18:13:22 | selection of URL | TaintedPath.go:67:28:67:57 | call to Clean | This path depends on a $@. | TaintedPath.go:13:18:13:22 | selection of URL | user-provided value |
+| TaintedPath.go:77:28:77:56 | call to Base | TaintedPath.go:13:18:13:22 | selection of URL | TaintedPath.go:77:28:77:56 | call to Base | This path depends on a $@. | TaintedPath.go:13:18:13:22 | selection of URL | user-provided value |

--- a/go/ql/test/query-tests/Security/CWE-022/TaintedPath.expected
+++ b/go/ql/test/query-tests/Security/CWE-022/TaintedPath.expected
@@ -1,19 +1,35 @@
 edges
+<<<<<<< HEAD
 | TaintedPath.go:13:18:13:22 | selection of URL | TaintedPath.go:13:18:13:30 | call to Query | provenance |  |
 | TaintedPath.go:13:18:13:30 | call to Query | TaintedPath.go:16:29:16:40 | tainted_path | provenance |  |
 | TaintedPath.go:13:18:13:30 | call to Query | TaintedPath.go:20:57:20:68 | tainted_path | provenance |  |
 | TaintedPath.go:20:57:20:68 | tainted_path | TaintedPath.go:20:28:20:69 | call to Join | provenance |  |
 | tst.go:14:2:14:39 | ... := ...[1] | tst.go:17:41:17:56 | selection of Filename | provenance |  |
+=======
+| TaintedPath.go:13:18:13:22 | selection of URL : pointer type | TaintedPath.go:16:29:16:40 | tainted_path |
+| TaintedPath.go:13:18:13:22 | selection of URL : pointer type | TaintedPath.go:20:28:20:69 | call to Join |
+| TaintedPath.go:13:18:13:22 | selection of URL : pointer type | TaintedPath.go:67:28:67:57 | call to Clean |
+| TaintedPath.go:13:18:13:22 | selection of URL : pointer type | TaintedPath.go:77:28:77:56 | call to Base |
+| tst.go:14:2:14:39 | ... := ...[1] : pointer type | tst.go:17:41:17:56 | selection of Filename |
+>>>>>>> a45343fb6c (Add New Sanitizers and Modify Old Ones)
 nodes
 | TaintedPath.go:13:18:13:22 | selection of URL | semmle.label | selection of URL |
 | TaintedPath.go:13:18:13:30 | call to Query | semmle.label | call to Query |
 | TaintedPath.go:16:29:16:40 | tainted_path | semmle.label | tainted_path |
 | TaintedPath.go:20:28:20:69 | call to Join | semmle.label | call to Join |
+<<<<<<< HEAD
 | TaintedPath.go:20:57:20:68 | tainted_path | semmle.label | tainted_path |
 | tst.go:14:2:14:39 | ... := ...[1] | semmle.label | ... := ...[1] |
+=======
+| TaintedPath.go:67:28:67:57 | call to Clean | semmle.label | call to Clean |
+| TaintedPath.go:77:28:77:56 | call to Base | semmle.label | call to Base |
+| tst.go:14:2:14:39 | ... := ...[1] : pointer type | semmle.label | ... := ...[1] : pointer type |
+>>>>>>> a45343fb6c (Add New Sanitizers and Modify Old Ones)
 | tst.go:17:41:17:56 | selection of Filename | semmle.label | selection of Filename |
 subpaths
 #select
-| TaintedPath.go:16:29:16:40 | tainted_path | TaintedPath.go:13:18:13:22 | selection of URL | TaintedPath.go:16:29:16:40 | tainted_path | This path depends on a $@. | TaintedPath.go:13:18:13:22 | selection of URL | user-provided value |
-| TaintedPath.go:20:28:20:69 | call to Join | TaintedPath.go:13:18:13:22 | selection of URL | TaintedPath.go:20:28:20:69 | call to Join | This path depends on a $@. | TaintedPath.go:13:18:13:22 | selection of URL | user-provided value |
-| tst.go:17:41:17:56 | selection of Filename | tst.go:14:2:14:39 | ... := ...[1] | tst.go:17:41:17:56 | selection of Filename | This path depends on a $@. | tst.go:14:2:14:39 | ... := ...[1] | user-provided value |
+| TaintedPath.go:16:29:16:40 | tainted_path | TaintedPath.go:13:18:13:22 | selection of URL : pointer type | TaintedPath.go:16:29:16:40 | tainted_path | This path depends on a $@. | TaintedPath.go:13:18:13:22 | selection of URL | user-provided value |
+| TaintedPath.go:20:28:20:69 | call to Join | TaintedPath.go:13:18:13:22 | selection of URL : pointer type | TaintedPath.go:20:28:20:69 | call to Join | This path depends on a $@. | TaintedPath.go:13:18:13:22 | selection of URL | user-provided value |
+| TaintedPath.go:67:28:67:57 | call to Clean | TaintedPath.go:13:18:13:22 | selection of URL : pointer type | TaintedPath.go:67:28:67:57 | call to Clean | This path depends on a $@. | TaintedPath.go:13:18:13:22 | selection of URL | user-provided value |
+| TaintedPath.go:77:28:77:56 | call to Base | TaintedPath.go:13:18:13:22 | selection of URL : pointer type | TaintedPath.go:77:28:77:56 | call to Base | This path depends on a $@. | TaintedPath.go:13:18:13:22 | selection of URL | user-provided value |
+| tst.go:17:41:17:56 | selection of Filename | tst.go:14:2:14:39 | ... := ...[1] : pointer type | tst.go:17:41:17:56 | selection of Filename | This path depends on a $@. | tst.go:14:2:14:39 | ... := ...[1] | user-provided value |

--- a/go/ql/test/query-tests/Security/CWE-022/TaintedPath.go
+++ b/go/ql/test/query-tests/Security/CWE-022/TaintedPath.go
@@ -67,16 +67,6 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	data, _ = ioutil.ReadFile(path.Clean("/" + tainted_path))
 	w.Write(data)
 
-	// GOOD: Sanitized by filepath.Base with a prepended '/' forcing interpretation
-	// as an absolute path, so that Base will throw away any leading `..` components.
-	data, _ = ioutil.ReadFile(filepath.Base("/" + tainted_path))
-	w.Write(data)
-
-	// BAD: Sanitized by path.Base with a prepended '/' forcing interpretation
-	// as an absolute path, however is not sufficient for Windows paths.
-	data, _ = ioutil.ReadFile(path.Base("/" + tainted_path))
-	w.Write(data)
-
 	// GOOD: Multipart.Form.FileHeader.Filename sanitized by filepath.Base when calling ParseMultipartForm
 	r.ParseMultipartForm(32 << 20)
 	form := r.MultipartForm


### PR DESCRIPTION
This PR adds some additional sanitizers to the TaintedPath Customization due to a high number of false positives I have found after doing some research.
I have added:
filepath.Base
strings.ReplaceAll
http.ParseMultipartForm
I have also removed path.Clean as it does not sufficiently clean paths for software that can run on Windows.
Please see: https://github.com/labstack/echo/pull/1718 as an example.