### PR TITLE
Swift: Fix RemoteFlowSource performance issue.

### DIFF
--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/WebView.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/WebView.qll
@@ -125,7 +125,8 @@ private class JsExportedSource extends RemoteFlowSource {
       base.getEnclosingDecl() instanceof JsExportedProto and
       adopter.getEnclosingDecl() instanceof JsExportedType
     |
-      this.asExpr().(MemberRefExpr).getMember() = adopter and adopter.getName() = base.getName()
+      this.asExpr().(MemberRefExpr).getMember() = adopter and
+      pragma[only_bind_out](adopter.getName()) = pragma[only_bind_out](base.getName())
     )
   }
 


### PR DESCRIPTION
Fix a `RemoteFlowSource` performance issue.  This was particularly visible on `freeotp-ios`, where evaluating `RemoteFlowSource` was taking twice as long due to this part blowing up.

Note that the case immediately above already has `pragma`s like the ones I introduce.

We should check DCA results before merging.