### PR TITLE
C++: Clarify Allocation.qll and Deallocation.qll

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/models/interfaces/Allocation.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/interfaces/Allocation.qll
@@ -12,38 +12,6 @@ import semmle.code.cpp.Function
 import semmle.code.cpp.models.Models
 
 /**
- * An allocation function such as `malloc`.
- */
-abstract class AllocationFunction extends Function {
-  /**
-   * Gets the index of the argument for the allocation size, if any. The actual
-   * allocation size is the value of this argument multiplied by the result of
-   * `getSizeMult()`, in bytes.
-   */
-  int getSizeArg() { none() }
-
-  /**
-   * Gets the index of an argument that multiplies the allocation size given by
-   * `getSizeArg`, if any.
-   */
-  int getSizeMult() { none() }
-
-  /**
-   * Gets the index of the input pointer argument to be reallocated, if this
-   * is a `realloc` function.
-   */
-  int getReallocPtrArg() { none() }
-
-  /**
-   * Whether or not this allocation requires a corresponding deallocation of
-   * some sort (most do, but `alloca` for example does not).  If it is unclear,
-   * we default to no (for example a placement `new` allocation may or may not
-   * require a corresponding `delete`).
-   */
-  predicate requiresDealloc() { any() }
-}
-
-/**
  * An allocation expression such as call to `malloc` or a `new` expression.
  */
 abstract class AllocationExpr extends Expr {
@@ -76,6 +44,41 @@ abstract class AllocationExpr extends Expr {
    * Gets the type of the elements that are allocated, if it can be determined.
    */
   Type getAllocatedElementType() { none() }
+
+  /**
+   * Whether or not this allocation requires a corresponding deallocation of
+   * some sort (most do, but `alloca` for example does not).  If it is unclear,
+   * we default to no (for example a placement `new` allocation may or may not
+   * require a corresponding `delete`).
+   */
+  predicate requiresDealloc() { any() }
+}
+
+/**
+ * An allocation function such as `malloc`.
+ *
+ * Note: `AllocationExpr` includes calls to allocation functions, so prefer
+ * to use that class unless you specifically need to reason about functions.
+ */
+abstract class AllocationFunction extends Function {
+  /**
+   * Gets the index of the argument for the allocation size, if any. The actual
+   * allocation size is the value of this argument multiplied by the result of
+   * `getSizeMult()`, in bytes.
+   */
+  int getSizeArg() { none() }
+
+  /**
+   * Gets the index of an argument that multiplies the allocation size given by
+   * `getSizeArg`, if any.
+   */
+  int getSizeMult() { none() }
+
+  /**
+   * Gets the index of the input pointer argument to be reallocated, if this
+   * is a `realloc` function.
+   */
+  int getReallocPtrArg() { none() }
 
   /**
    * Whether or not this allocation requires a corresponding deallocation of

--- a/cpp/ql/lib/semmle/code/cpp/models/interfaces/Deallocation.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/interfaces/Deallocation.qll
@@ -12,16 +12,6 @@ import semmle.code.cpp.Function
 import semmle.code.cpp.models.Models
 
 /**
- * A deallocation function such as `free`.
- */
-abstract class DeallocationFunction extends Function {
-  /**
-   * Gets the index of the argument that is freed by this function.
-   */
-  int getFreedArg() { none() }
-}
-
-/**
  * An deallocation expression such as call to `free` or a `delete` expression.
  */
 abstract class DeallocationExpr extends Expr {
@@ -29,6 +19,19 @@ abstract class DeallocationExpr extends Expr {
    * Gets the expression that is freed by this function.
    */
   Expr getFreedExpr() { none() }
+}
+
+/**
+ * A deallocation function such as `free`.
+ *
+ * Note: `DeallocationExpr` includes calls to deallocation functions, so prefer
+ * to use that class unless you specifically need to reason about functions.
+ */
+abstract class DeallocationFunction extends Function {
+  /**
+   * Gets the index of the argument that is freed by this function.
+   */
+  int getFreedArg() { none() }
 }
 
 /**


### PR DESCRIPTION
Clarify `Allocation.qll` and `Deallocation.qll` to encourage use of `AllocationExpr` / `DeallocationExpr` as the primary way to use these libraries.

The diff is messy because I've swapped the order of predicates so that `AllocationExpr` / `DeallocationExpr` come first (thus will be read first by someone browsing the QL from the top).  The only bit that's actually different is the addition of `Note:`... in two places.