### PR TITLE
Java: Add query for leaking sensitive data through a ResultReceiver

### DIFF
--- a/java/ql/lib/semmle/code/java/security/SensitiveResultReceiverQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/SensitiveResultReceiverQuery.qll
@@ -42,6 +42,12 @@ private class SensitiveResultReceiverConf extends TaintTracking::Configuration {
       node.asExpr() = call.getSentData()
     )
   }
+
+  override predicate allowImplicitRead(DataFlow::Node node, DataFlow::ContentSet c) {
+    super.allowImplicitRead(node, c)
+    or
+    this.isSink(node)
+  }
 }
 
 predicate sensitiveResultReceiver(

--- a/java/ql/lib/semmle/code/java/security/SensitiveResultReceiverQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/SensitiveResultReceiverQuery.qll
@@ -1,0 +1,55 @@
+/** Definitions for the sensitive result receiver query. */
+
+import java
+import semmle.code.java.dataflow.TaintTracking2
+import semmle.code.java.dataflow.FlowSources
+import semmle.code.java.security.SensitiveActions
+
+private class ResultReceiverSendCall extends MethodAccess {
+  ResultReceiverSendCall() {
+    this.getMethod()
+        .getASourceOverriddenMethod*()
+        .hasQualifiedName("android.os", "ResultReceiver", "send")
+  }
+
+  Expr getReceiver() { result = this.getQualifier() }
+
+  Expr getSentData() { result = this.getArgument(1) }
+}
+
+private class UntrustedResultReceiverConf extends TaintTracking2::Configuration {
+  UntrustedResultReceiverConf() { this = "UntrustedResultReceiverConf" }
+
+  override predicate isSource(DataFlow::Node node) { node instanceof RemoteFlowSource }
+
+  override predicate isSink(DataFlow::Node node) {
+    node.asExpr() = any(ResultReceiverSendCall c).getReceiver()
+  }
+}
+
+private predicate untrustedResultReceiverSend(DataFlow::Node src, ResultReceiverSendCall call) {
+  any(UntrustedResultReceiverConf c).hasFlow(src, DataFlow::exprNode(call.getReceiver()))
+}
+
+private class SensitiveResultReceiverConf extends TaintTracking::Configuration {
+  SensitiveResultReceiverConf() { this = "SensitiveResultReceiverConf" }
+
+  override predicate isSource(DataFlow::Node node) { node.asExpr() instanceof SensitiveExpr }
+
+  override predicate isSink(DataFlow::Node node) {
+    exists(ResultReceiverSendCall call |
+      untrustedResultReceiverSend(_, call) and
+      node.asExpr() = call.getSentData()
+    )
+  }
+}
+
+predicate sensitiveResultReceiver(
+  DataFlow::PathNode src, DataFlow::PathNode sink, DataFlow::Node recSrc
+) {
+  exists(ResultReceiverSendCall call, SensitiveResultReceiverConf conf |
+    conf.hasFlowPath(src, sink) and
+    sink.getNode().asExpr() = call.getSentData() and
+    untrustedResultReceiverSend(recSrc, call)
+  )
+}

--- a/java/ql/lib/semmle/code/java/security/SensitiveResultReceiverQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/SensitiveResultReceiverQuery.qll
@@ -50,7 +50,7 @@ private class SensitiveResultReceiverConf extends TaintTracking::Configuration {
   }
 }
 
-/** Holds if there is a path from sensitive data at `src`` to a result receiver at `sink`, and the receiver was obtained from an untrusted source `recSrc`. */
+/** Holds if there is a path from sensitive data at `src` to a result receiver at `sink`, and the receiver was obtained from an untrusted source `recSrc`. */
 predicate sensitiveResultReceiver(
   DataFlow::PathNode src, DataFlow::PathNode sink, DataFlow::Node recSrc
 ) {

--- a/java/ql/lib/semmle/code/java/security/SensitiveResultReceiverQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/SensitiveResultReceiverQuery.qll
@@ -50,6 +50,7 @@ private class SensitiveResultReceiverConf extends TaintTracking::Configuration {
   }
 }
 
+/** Holds if there is a path from sensitive data at `src`` to a result receiver at `sink`, and the receiver was obtained from an untrusted source `recSrc`. */
 predicate sensitiveResultReceiver(
   DataFlow::PathNode src, DataFlow::PathNode sink, DataFlow::Node recSrc
 ) {

--- a/java/ql/src/Security/CWE/CWE-927/SensitiveResultReceiver.java
+++ b/java/ql/src/Security/CWE/CWE-927/SensitiveResultReceiver.java
@@ -1,0 +1,8 @@
+// BAD: Sensitive data is sent to an untrusted result receiver 
+void bad(String password) {
+    Intent intent = getIntent();
+    ResultReceiver rec = intent.getParcelableExtra("Receiver");
+    Bundle b = new Bundle();
+    b.putCharSequence("pass", password);
+    rec.send(0, b); 
+}

--- a/java/ql/src/Security/CWE/CWE-927/SensitiveResultReceiver.qhelp
+++ b/java/ql/src/Security/CWE/CWE-927/SensitiveResultReceiver.qhelp
@@ -13,11 +13,11 @@
   </recommendation>
 
   <example>
-    In the following (bad) example, sensitive data is sent to an untrusted <code>ResultReceiver</code>. 
+    <p>In the following (bad) example, sensitive data is sent to an untrusted <code>ResultReceiver</code>. </p>
     <sample src="SensitiveResultReceiver.java" />
   </example>
 
   <references>
-    <li>Oversecured: <a href=https://oversecured.com/vulnerabilities#Android/Passing_data_to_a_ResultReceiver_under_the_attacker%E2%80%99s_control>Passing data to a ResultReceiver under the attacker's control</a></li>
+    <li>Oversecured: <a href="https://oversecured.com/vulnerabilities#Android/Passing_data_to_a_ResultReceiver_under_the_attacker%E2%80%99s_control">Passing data to a ResultReceiver under the attacker's control</a></li>
   </references>
 </qhelp>

--- a/java/ql/src/Security/CWE/CWE-927/SensitiveResultReceiver.qhelp
+++ b/java/ql/src/Security/CWE/CWE-927/SensitiveResultReceiver.qhelp
@@ -18,6 +18,5 @@
   </example>
 
   <references>
-    <li>Oversecured: <a href="https://oversecured.com/vulnerabilities#Android/Passing_data_to_a_ResultReceiver_under_the_attacker%E2%80%99s_control">Passing data to a ResultReceiver under the attacker's control</a>.</li>
   </references>
 </qhelp>

--- a/java/ql/src/Security/CWE/CWE-927/SensitiveResultReceiver.qhelp
+++ b/java/ql/src/Security/CWE/CWE-927/SensitiveResultReceiver.qhelp
@@ -2,8 +2,8 @@
 <qhelp>
 
   <overview>
-    <p>If a <code>ResultReceiver</code> is obtained from an untrusted source, such as being unparcelled from an <code>Intent</code> that was received by an exported component, 
-    sensitive data such as passwords should not be sent to it. Otherwise, this sensitive information may be leaked to a malicious application.</p>
+    <p>If a <code>ResultReceiver</code> is obtained from an untrusted source, such as an <code>Intent</code> received by an exported component, 
+    do not send it sensitive data. Otherwise, the information may be leaked to a malicious application.</p>
   </overview>
 
   <recommendation>

--- a/java/ql/src/Security/CWE/CWE-927/SensitiveResultReceiver.qhelp
+++ b/java/ql/src/Security/CWE/CWE-927/SensitiveResultReceiver.qhelp
@@ -1,0 +1,23 @@
+<!DOCTYPE qhelp PUBLIC "-//Semmle//qhelp//EN" "qhelp.dtd">
+<qhelp>
+
+  <overview>
+    <p>If a <code>ResultReceiver</code> is obtained from an untrusted source, such as being unparcled from an <code>Intent</code>, 
+    sensitive data such as passwords should not be sent to it. Otherwise, this sensitive information may be leaked to a malicious application.</p>
+  </overview>
+
+  <recommendation>
+    <p> 
+      Do not send sensitive data to an untrusted <code>ResultReceiver</code>.
+    </p>
+  </recommendation>
+
+  <example>
+    In the following (bad) example, sensitive data is sent to an untrusted <code>ResultReceiver</code>. 
+    <sample src="SensitiveResultReceiver.java" />
+  </example>
+
+  <references>
+    <li>Oversecured: <a href=https://oversecured.com/vulnerabilities#Android/Passing_data_to_a_ResultReceiver_under_the_attacker%E2%80%99s_control>Passing data to a ResultReceiver under the attacker's control</a></li>
+  </references>
+</qhelp>

--- a/java/ql/src/Security/CWE/CWE-927/SensitiveResultReceiver.qhelp
+++ b/java/ql/src/Security/CWE/CWE-927/SensitiveResultReceiver.qhelp
@@ -2,7 +2,7 @@
 <qhelp>
 
   <overview>
-    <p>If a <code>ResultReceiver</code> is obtained from an untrusted source, such as being unparcled from an <code>Intent</code>, 
+    <p>If a <code>ResultReceiver</code> is obtained from an untrusted source, such as being unparcelled from an <code>Intent</code> that was received by an exported component, 
     sensitive data such as passwords should not be sent to it. Otherwise, this sensitive information may be leaked to a malicious application.</p>
   </overview>
 
@@ -18,6 +18,6 @@
   </example>
 
   <references>
-    <li>Oversecured: <a href="https://oversecured.com/vulnerabilities#Android/Passing_data_to_a_ResultReceiver_under_the_attacker%E2%80%99s_control">Passing data to a ResultReceiver under the attacker's control</a></li>
+    <li>Oversecured: <a href="https://oversecured.com/vulnerabilities#Android/Passing_data_to_a_ResultReceiver_under_the_attacker%E2%80%99s_control">Passing data to a ResultReceiver under the attacker's control</a>.</li>
   </references>
 </qhelp>

--- a/java/ql/src/Security/CWE/CWE-927/SensitiveResultReceiver.ql
+++ b/java/ql/src/Security/CWE/CWE-927/SensitiveResultReceiver.ql
@@ -1,7 +1,7 @@
 /**
  * @name Leaking sensitive information through a ResultReceiver
- * @description An Android application obtains a ResultReceiver from a
- *              third-party component and uses it to send sensitive data
+ * @description Sending sensitive data to a 'ResultReceiver' from an untrusted source
+ *              can allow malicious actors access to your information.
  * @kind path-problem
  * @problem.severity error
  * @security-severity 8.2

--- a/java/ql/src/Security/CWE/CWE-927/SensitiveResultReceiver.ql
+++ b/java/ql/src/Security/CWE/CWE-927/SensitiveResultReceiver.ql
@@ -5,7 +5,7 @@
  * @kind path-problem
  * @problem.severity error
  * @security-severity 8.2
- * @precision mediums
+ * @precision medium
  * @id java/android/sensitive-result-receiver
  * @tags security
  *       external/cwe/cwe-927

--- a/java/ql/src/Security/CWE/CWE-927/SensitiveResultReceiver.ql
+++ b/java/ql/src/Security/CWE/CWE-927/SensitiveResultReceiver.ql
@@ -1,6 +1,6 @@
 /**
  * @name Leaking sensitive information through a ResultReceiver
- * @description Sending sensitive data to a 'ResultReceiver' from an untrusted source
+ * @description Sending sensitive data to a 'ResultReceiver' obtained from an untrusted source
  *              can allow malicious actors access to your information.
  * @kind path-problem
  * @problem.severity error

--- a/java/ql/src/Security/CWE/CWE-927/SensitiveResultReceiver.ql
+++ b/java/ql/src/Security/CWE/CWE-927/SensitiveResultReceiver.ql
@@ -1,0 +1,21 @@
+/**
+ * @name Leaking sensitive information through a ResultReceiver
+ * @description An Android application obtains a ResultReceiver from a
+ *              third-party component and uses it to send sensitive data
+ * @kind path-problem
+ * @problem.severity error
+ * @security-severity 8.2
+ * @precision mediums
+ * @id java/android/sensitive-result-receiver
+ * @tags security
+ *       external/cwe/cwe-927
+ */
+
+import java
+import semmle.code.java.security.SensitiveResultReceiverQuery
+import DataFlow::PathGraph
+
+from DataFlow::PathNode src, DataFlow::PathNode sink, DataFlow::Node recSrc
+where sensitiveResultReceiver(src, sink, recSrc)
+select sink, src, sink, "This $@ is sent to a ResultReceiver obtained from $@.", src,
+  "sensitive information", recSrc, "this untrusted source"

--- a/java/ql/src/change-notes/2023-01-12-sensitive-result-receiver.md
+++ b/java/ql/src/change-notes/2023-01-12-sensitive-result-receiver.md
@@ -1,0 +1,4 @@
+---
+category: newQuery
+---
+* Added a new query, `java/android/sensitive-result-receiver`, to find instances of sensitive data being leaked to an untrusted `ResultReceiver`.

--- a/java/ql/test/query-tests/security/CWE-927/SensitiveResultReceiver.java
+++ b/java/ql/test/query-tests/security/CWE-927/SensitiveResultReceiver.java
@@ -1,0 +1,13 @@
+import android.os.Bundle;
+import android.os.ResultReceiver;
+
+class SensitiveResultReceiver {
+    <T> T source() { return null; }
+
+    void test1(String password) {
+        ResultReceiver rec = source();
+        Bundle b = new Bundle();
+        b.putCharSequence("pass", password);
+        rec.send(0, b); // $hasSensitiveResultReceiver
+    }
+}

--- a/java/ql/test/query-tests/security/CWE-927/SensitiveResultReceiver.java
+++ b/java/ql/test/query-tests/security/CWE-927/SensitiveResultReceiver.java
@@ -1,11 +1,13 @@
 import android.os.Bundle;
 import android.os.ResultReceiver;
+import android.content.Intent;
 
 class SensitiveResultReceiver {
     <T> T source() { return null; }
 
     void test1(String password) {
-        ResultReceiver rec = source();
+        Intent intent = source();
+        ResultReceiver rec = intent.getParcelableExtra("hi");
         Bundle b = new Bundle();
         b.putCharSequence("pass", password);
         rec.send(0, b); // $hasSensitiveResultReceiver

--- a/java/ql/test/query-tests/security/CWE-927/SensitiveResultReceiver.ql
+++ b/java/ql/test/query-tests/security/CWE-927/SensitiveResultReceiver.ql
@@ -14,8 +14,8 @@ class ResultReceiverTest extends InlineExpectationsTest {
   override string getARelevantTag() { result = "hasSensitiveResultReceiver" }
 
   override predicate hasActualResult(Location loc, string element, string tag, string value) {
-    exists(DataFlow::PathNode src, DataFlow::PathNode sink, DataFlow::Node recSrc |
-      sensitiveResultReceiver(src, sink, recSrc) and
+    exists(DataFlow::PathNode sink |
+      sensitiveResultReceiver(_, sink, _) and
       element = sink.toString() and
       loc = sink.getNode().getLocation() and
       tag = "hasSensitiveResultReceiver" and

--- a/java/ql/test/query-tests/security/CWE-927/SensitiveResultReceiver.ql
+++ b/java/ql/test/query-tests/security/CWE-927/SensitiveResultReceiver.ql
@@ -1,0 +1,25 @@
+import java
+import TestUtilities.InlineExpectationsTest
+import semmle.code.java.security.SensitiveResultReceiverQuery
+
+class TestSource extends RemoteFlowSource {
+  TestSource() { this.asExpr().(MethodAccess).getMethod().hasName("source") }
+
+  override string getSourceType() { result = "test" }
+}
+
+class ResultReceiverTest extends InlineExpectationsTest {
+  ResultReceiverTest() { this = "ResultReceiverTest" }
+
+  override string getARelevantTag() { result = "hasSensitiveResultReceiver" }
+
+  override predicate hasActualResult(Location loc, string element, string tag, string value) {
+    exists(DataFlow::PathNode src, DataFlow::PathNode sink, DataFlow::Node recSrc |
+      sensitiveResultReceiver(src, sink, recSrc) and
+      element = sink.toString() and
+      loc = sink.getNode().getLocation() and
+      tag = "hasSensitiveResultReceiver" and
+      value = ""
+    )
+  }
+}


### PR DESCRIPTION
Part of CWE-927. 

Covers cases in which a ResultReceiver is obtained from some untrusted source, and then sensitive data is sent through it.