### PR TITLE
Swift: Remove workaround from swift/unsafe-js-eval

### DIFF
--- a/swift/ql/src/queries/Security/CWE-094/UnsafeJsEval.ql
+++ b/swift/ql/src/queries/Security/CWE-094/UnsafeJsEval.ql
@@ -127,9 +127,6 @@ class UnsafeJsEvalConfig extends TaintTracking::Configuration {
     )
     or
     exists(MemberRefExpr e, Expr self, VarDecl member |
-      self.getType().getName() = "String" and
-      member.getName() = ["utf8", "utf16", "utf8CString"]
-      or
       self.getType().getName().matches(["Unsafe%Buffer%", "Unsafe%Pointer%"]) and
       member.getName() = "baseAddress"
     |


### PR DESCRIPTION
Remove one of the workarounds from `swift/unsafe-js-eval`, that is covered by our general taint modelling since https://github.com/github/codeql/pull/11185 was merged.  The query already has adequate test coverage for these cases.

@d10c 