### PR TITLE
Java/C#: exclude parameterless static methods from `DataFlowTargetApi` and from `ExternalApi`

### DIFF
--- a/csharp/ql/src/Telemetry/ExternalApi.qll
+++ b/csharp/ql/src/Telemetry/ExternalApi.qll
@@ -26,8 +26,11 @@ class TestLibrary extends RefType {
 
 /** Holds if the given callable is not worth supporting. */
 private predicate isUninteresting(DotNet::Callable c) {
-  c.getDeclaringType() instanceof TestLibrary or
+  c.getDeclaringType() instanceof TestLibrary
+  or
   c.(Constructor).isParameterless()
+  or
+  c.(Method).isStatic() and c.hasNoParameters()
 }
 
 /**

--- a/csharp/ql/src/utils/modelgenerator/internal/CaptureModelsSpecific.qll
+++ b/csharp/ql/src/utils/modelgenerator/internal/CaptureModelsSpecific.qll
@@ -40,7 +40,8 @@ private predicate isRelevantForModels(CS::Callable api) {
   not api instanceof Util::MainMethod and
   not api instanceof CS::Destructor and
   not api instanceof CS::AnonymousFunctionExpr and
-  not api.(CS::Constructor).isParameterless()
+  not api.(CS::Constructor).isParameterless() and
+  not (api.(CS::Method).isStatic() and api.hasNoParameters())
 }
 
 /**

--- a/java/ql/src/Telemetry/ExternalApi.qll
+++ b/java/ql/src/Telemetry/ExternalApi.qll
@@ -33,8 +33,11 @@ private string containerAsJar(Container container) {
 
 /** Holds if the given callable is not worth supporting. */
 private predicate isUninteresting(Callable c) {
-  c.getDeclaringType() instanceof TestLibrary or
+  c.getDeclaringType() instanceof TestLibrary
+  or
   c.(Constructor).isParameterless()
+  or
+  c.isStatic() and c.hasNoParameters()
 }
 
 /**

--- a/java/ql/src/utils/modelgenerator/internal/CaptureModelsSpecific.qll
+++ b/java/ql/src/utils/modelgenerator/internal/CaptureModelsSpecific.qll
@@ -66,7 +66,8 @@ private predicate isRelevantForModels(J::Callable api) {
   not api instanceof J::MainMethod and
   not api instanceof J::StaticInitializer and
   not exists(J::FunctionalExpr funcExpr | api = funcExpr.asMethod()) and
-  not api.(J::Constructor).isParameterless()
+  not api.(J::Constructor).isParameterless() and
+  not (api.isStatic() and api.hasNoParameters())
 }
 
 /**


### PR DESCRIPTION
### Description
This PR excludes parameterless static methods from consideration for MaD models, based on a [suggestion](https://github.com/github/codeql/pull/11572#discussion_r1049415888) from @aschackmull. The exclusion is added to the `isRelevantForModels` predicate for `DataFlowTargetApi`.
The exclusion is also added to the `isUninteresting` predicate for `ExternalApi`.

### Consideration
- Let me know if adding this exclusion for C# is incorrect or needs any adjustment.