### PR TITLE
C++: Use `asExpr` in `cpp/cleartext-transmission`

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-311/CleartextTransmission.ql
+++ b/cpp/ql/src/Security/CWE/CWE-311/CleartextTransmission.ql
@@ -224,7 +224,7 @@ predicate isSinkEncrypt(DataFlow::Node sink, Encrypted enc) {
  */
 predicate isSourceImpl(DataFlow::Node source) {
   exists(Expr e |
-    e = source.asIndirectConvertedExpr() and
+    e = source.asConvertedExpr() and
     e.getUnconverted().(VariableAccess).getTarget() instanceof SourceVariable and
     not e.hasConversion()
   )

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextTransmission.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextTransmission.expected
@@ -1,327 +1,154 @@
 edges
-| test3.cpp:20:28:20:36 | password1 indirection | test3.cpp:22:15:22:23 | password1 |
-| test3.cpp:20:28:20:36 | password1 indirection | test3.cpp:22:15:22:23 | password1 |
-| test3.cpp:22:15:22:23 | password1 indirection | test3.cpp:22:15:22:23 | password1 |
-| test3.cpp:22:33:22:41 | password1 indirection | test3.cpp:22:15:22:23 | password1 |
-| test3.cpp:22:33:22:41 | password1 indirection | test3.cpp:22:15:22:23 | password1 |
-| test3.cpp:26:15:26:23 | password2 indirection | test3.cpp:26:15:26:23 | password2 |
-| test3.cpp:26:33:26:41 | password2 indirection | test3.cpp:26:15:26:23 | password2 |
-| test3.cpp:26:33:26:41 | password2 indirection | test3.cpp:26:15:26:23 | password2 |
-| test3.cpp:47:15:47:22 | password indirection | test3.cpp:47:15:47:22 | password |
-| test3.cpp:55:15:55:22 | password indirection | test3.cpp:55:15:55:22 | password |
-| test3.cpp:74:21:74:29 | password1 indirection | test3.cpp:76:15:76:17 | ptr |
-| test3.cpp:81:15:81:22 | password indirection | test3.cpp:83:15:83:17 | ptr |
-| test3.cpp:101:12:101:19 | password indirection | test3.cpp:101:12:101:19 | password |
+| test3.cpp:74:21:74:29 | password1 | test3.cpp:76:15:76:17 | ptr |
+| test3.cpp:81:15:81:22 | password | test3.cpp:83:15:83:17 | ptr |
 | test3.cpp:112:20:112:25 | buffer | test3.cpp:114:14:114:19 | buffer |
-| test3.cpp:112:20:112:25 | buffer indirection | test3.cpp:114:14:114:19 | buffer |
-| test3.cpp:117:28:117:33 | buffer indirection | test3.cpp:117:13:117:14 | VariableAddress indirection |
-| test3.cpp:124:7:124:20 | VariableAddress indirection | test3.cpp:144:16:144:29 | call to get_global_str indirection |
 | test3.cpp:124:7:124:20 | VariableAddress indirection | test3.cpp:146:15:146:18 | data |
-| test3.cpp:126:9:126:23 | global_password indirection | test3.cpp:124:7:124:20 | VariableAddress indirection |
-| test3.cpp:126:9:126:23 | global_password indirection | test3.cpp:124:7:124:20 | VariableAddress indirection |
-| test3.cpp:134:11:134:18 | Convert indirection | test3.cpp:112:20:112:25 | buffer indirection |
+| test3.cpp:126:9:126:23 | global_password | test3.cpp:124:7:124:20 | VariableAddress indirection |
 | test3.cpp:134:11:134:18 | password | test3.cpp:112:20:112:25 | buffer |
-| test3.cpp:134:11:134:18 | password indirection | test3.cpp:134:11:134:18 | Convert indirection |
-| test3.cpp:134:11:134:18 | password indirection | test3.cpp:134:11:134:18 | password |
-| test3.cpp:138:21:138:22 | call to id indirection | test3.cpp:140:15:140:17 | ptr |
-| test3.cpp:138:24:138:32 | Load indirection | test3.cpp:117:28:117:33 | buffer indirection |
-| test3.cpp:138:24:138:32 | Load indirection | test3.cpp:138:21:138:22 | call to id indirection |
-| test3.cpp:138:24:138:32 | Load indirection | test3.cpp:140:15:140:17 | ptr |
 | test3.cpp:138:24:138:32 | password1 | test3.cpp:140:15:140:17 | ptr |
-| test3.cpp:138:24:138:32 | password1 indirection | test3.cpp:138:24:138:32 | Load indirection |
-| test3.cpp:138:24:138:32 | password1 indirection | test3.cpp:138:24:138:32 | password1 |
-| test3.cpp:138:24:138:32 | password1 indirection | test3.cpp:138:24:138:32 | password1 |
-| test3.cpp:144:16:144:29 | call to get_global_str indirection | test3.cpp:146:15:146:18 | data |
-| test3.cpp:157:19:157:26 | password indirection | test3.cpp:159:15:159:20 | buffer |
-| test3.cpp:157:19:157:26 | password indirection | test3.cpp:159:15:159:20 | buffer |
-| test3.cpp:173:15:173:22 | password indirection | test3.cpp:173:15:173:22 | password |
-| test3.cpp:181:15:181:22 | password indirection | test3.cpp:181:15:181:22 | password |
-| test3.cpp:191:15:191:22 | password indirection | test3.cpp:191:15:191:22 | password |
-| test3.cpp:199:19:199:26 | password indirection | test3.cpp:201:15:201:22 | password |
-| test3.cpp:201:15:201:22 | password indirection | test3.cpp:201:15:201:22 | password |
-| test3.cpp:201:32:201:39 | password indirection | test3.cpp:201:15:201:22 | password |
-| test3.cpp:207:19:207:26 | password indirection | test3.cpp:210:15:210:22 | password |
-| test3.cpp:208:3:208:10 | password indirection | test3.cpp:210:15:210:22 | password |
-| test3.cpp:210:15:210:22 | password indirection | test3.cpp:210:15:210:22 | password |
-| test3.cpp:210:32:210:39 | password indirection | test3.cpp:210:15:210:22 | password |
-| test3.cpp:219:15:219:26 | password_ptr indirection | test3.cpp:219:15:219:26 | password_ptr |
-| test3.cpp:219:36:219:47 | password_ptr indirection | test3.cpp:219:15:219:26 | password_ptr |
-| test3.cpp:227:22:227:29 | password indirection | test3.cpp:228:26:228:33 | password |
-| test3.cpp:228:26:228:33 | password indirection | test3.cpp:228:26:228:33 | password |
-| test3.cpp:241:8:241:15 | password indirection | test3.cpp:241:8:241:15 | password |
-| test3.cpp:254:15:254:23 | password1 indirection | test3.cpp:254:15:254:23 | password1 |
-| test3.cpp:262:32:262:40 | password2 indirection | test3.cpp:264:15:264:23 | password2 |
-| test3.cpp:264:15:264:23 | password2 indirection | test3.cpp:264:15:264:23 | password2 |
-| test3.cpp:264:33:264:41 | password2 indirection | test3.cpp:264:15:264:23 | password2 |
-| test3.cpp:270:16:270:23 | password indirection | test3.cpp:272:15:272:18 | data |
+| test3.cpp:157:19:157:26 | password | test3.cpp:159:15:159:20 | buffer |
+| test3.cpp:270:16:270:23 | password | test3.cpp:272:15:272:18 | data |
 | test3.cpp:278:20:278:23 | data | test3.cpp:280:14:280:17 | data |
-| test3.cpp:278:20:278:23 | data indirection | test3.cpp:280:14:280:17 | data |
 | test3.cpp:283:20:283:23 | data | test3.cpp:285:14:285:17 | data |
-| test3.cpp:283:20:283:23 | data indirection | test3.cpp:285:14:285:17 | data |
 | test3.cpp:288:20:288:23 | data | test3.cpp:290:14:290:17 | data |
-| test3.cpp:288:20:288:23 | data indirection | test3.cpp:290:14:290:17 | data |
 | test3.cpp:293:20:293:23 | data | test3.cpp:295:14:295:17 | data |
-| test3.cpp:293:20:293:23 | data indirection | test3.cpp:295:14:295:17 | data |
 | test3.cpp:298:20:298:23 | data | test3.cpp:300:14:300:17 | data |
-| test3.cpp:298:20:298:23 | data indirection | test3.cpp:300:14:300:17 | data |
-| test3.cpp:313:11:313:19 | Load indirection | test3.cpp:278:20:278:23 | data indirection |
 | test3.cpp:313:11:313:19 | password1 | test3.cpp:278:20:278:23 | data |
-| test3.cpp:313:11:313:19 | password1 indirection | test3.cpp:313:11:313:19 | Load indirection |
-| test3.cpp:313:11:313:19 | password1 indirection | test3.cpp:313:11:313:19 | password1 |
-| test3.cpp:313:11:313:19 | password1 indirection | test3.cpp:313:11:313:19 | password1 |
-| test3.cpp:314:11:314:19 | Load indirection | test3.cpp:283:20:283:23 | data indirection |
 | test3.cpp:314:11:314:19 | password1 | test3.cpp:283:20:283:23 | data |
-| test3.cpp:314:11:314:19 | password1 indirection | test3.cpp:314:11:314:19 | Load indirection |
-| test3.cpp:314:11:314:19 | password1 indirection | test3.cpp:314:11:314:19 | password1 |
-| test3.cpp:314:11:314:19 | password1 indirection | test3.cpp:314:11:314:19 | password1 |
-| test3.cpp:316:11:316:19 | Load indirection | test3.cpp:283:20:283:23 | data indirection |
 | test3.cpp:316:11:316:19 | password1 | test3.cpp:283:20:283:23 | data |
-| test3.cpp:316:11:316:19 | password1 indirection | test3.cpp:316:11:316:19 | Load indirection |
-| test3.cpp:316:11:316:19 | password1 indirection | test3.cpp:316:11:316:19 | password1 |
-| test3.cpp:316:11:316:19 | password1 indirection | test3.cpp:316:11:316:19 | password1 |
-| test3.cpp:317:11:317:19 | Load indirection | test3.cpp:288:20:288:23 | data indirection |
 | test3.cpp:317:11:317:19 | password1 | test3.cpp:288:20:288:23 | data |
-| test3.cpp:317:11:317:19 | password1 indirection | test3.cpp:317:11:317:19 | Load indirection |
-| test3.cpp:317:11:317:19 | password1 indirection | test3.cpp:317:11:317:19 | password1 |
-| test3.cpp:317:11:317:19 | password1 indirection | test3.cpp:317:11:317:19 | password1 |
-| test3.cpp:322:16:322:24 | password2 indirection | test3.cpp:324:11:324:14 | Load indirection |
-| test3.cpp:322:16:322:24 | password2 indirection | test3.cpp:324:11:324:14 | data |
-| test3.cpp:322:16:322:24 | password2 indirection | test3.cpp:325:11:325:14 | Load indirection |
-| test3.cpp:322:16:322:24 | password2 indirection | test3.cpp:325:11:325:14 | data |
-| test3.cpp:324:11:324:14 | Load indirection | test3.cpp:293:20:293:23 | data indirection |
+| test3.cpp:322:16:322:24 | password2 | test3.cpp:324:11:324:14 | data |
+| test3.cpp:322:16:322:24 | password2 | test3.cpp:325:11:325:14 | data |
 | test3.cpp:324:11:324:14 | data | test3.cpp:293:20:293:23 | data |
-| test3.cpp:325:11:325:14 | Load indirection | test3.cpp:298:20:298:23 | data indirection |
 | test3.cpp:325:11:325:14 | data | test3.cpp:298:20:298:23 | data |
-| test3.cpp:341:16:341:23 | password indirection | test3.cpp:341:16:341:23 | password |
-| test3.cpp:352:16:352:23 | password indirection | test3.cpp:352:16:352:23 | password |
-| test3.cpp:368:15:368:22 | password indirection | test3.cpp:368:15:368:22 | password |
-| test3.cpp:388:15:388:22 | password indirection | test3.cpp:388:15:388:22 | password |
-| test3.cpp:400:16:400:23 | password indirection | test3.cpp:400:15:400:23 | & ... |
-| test3.cpp:414:15:414:24 | password indirection | test3.cpp:414:15:414:24 | password |
-| test3.cpp:420:15:420:24 | password indirection | test3.cpp:420:15:420:24 | password |
-| test3.cpp:431:8:431:15 | password indirection | test3.cpp:431:8:431:15 | password |
-| test3.cpp:507:14:507:39 | social_security_number indirection | test3.cpp:507:14:507:39 | social_security_number |
-| test3.cpp:508:14:508:33 | socialSecurityNo indirection | test3.cpp:508:14:508:33 | socialSecurityNo |
-| test3.cpp:509:14:509:29 | homePostCode indirection | test3.cpp:509:14:509:29 | homePostCode |
-| test3.cpp:510:14:510:28 | my_zip_code indirection | test3.cpp:510:14:510:28 | my_zip_code |
-| test3.cpp:511:14:511:26 | telephone indirection | test3.cpp:511:14:511:26 | telephone |
-| test3.cpp:512:14:512:36 | mobile_phone_number indirection | test3.cpp:512:14:512:36 | mobile_phone_number |
-| test3.cpp:513:14:513:22 | email indirection | test3.cpp:513:14:513:22 | email |
-| test3.cpp:514:14:514:38 | my_credit_card_number indirection | test3.cpp:514:14:514:38 | my_credit_card_number |
-| test3.cpp:515:14:515:35 | my_bank_account_no indirection | test3.cpp:515:14:515:35 | my_bank_account_no |
-| test3.cpp:516:14:516:29 | employerName indirection | test3.cpp:516:14:516:29 | employerName |
-| test3.cpp:517:14:517:29 | medical_info indirection | test3.cpp:517:14:517:29 | medical_info |
-| test3.cpp:518:14:518:28 | license_key indirection | test3.cpp:518:14:518:28 | license_key |
-| test3.cpp:551:47:551:58 | salaryString indirection | test3.cpp:552:15:552:20 | buffer |
-| test3.cpp:556:19:556:30 | salaryString indirection | test3.cpp:559:15:559:20 | buffer |
+| test3.cpp:400:16:400:23 | password | test3.cpp:400:15:400:23 | & ... |
+| test3.cpp:526:44:526:54 | my_latitude | test3.cpp:527:15:527:20 | buffer |
+| test3.cpp:532:45:532:58 | home_longitude | test3.cpp:533:15:533:20 | buffer |
+| test3.cpp:551:47:551:58 | salaryString | test3.cpp:552:15:552:20 | buffer |
+| test3.cpp:556:19:556:30 | salaryString | test3.cpp:559:15:559:20 | buffer |
 | test3.cpp:571:8:571:21 | call to get_home_phone | test3.cpp:572:14:572:16 | str |
 | test3.cpp:577:8:577:23 | call to get_home_address | test3.cpp:578:14:578:16 | str |
 nodes
-| test3.cpp:20:28:20:36 | password1 indirection | semmle.label | password1 indirection |
-| test3.cpp:20:28:20:36 | password1 indirection | semmle.label | password1 indirection |
 | test3.cpp:22:15:22:23 | password1 | semmle.label | password1 |
-| test3.cpp:22:15:22:23 | password1 indirection | semmle.label | password1 indirection |
-| test3.cpp:22:33:22:41 | password1 indirection | semmle.label | password1 indirection |
-| test3.cpp:22:33:22:41 | password1 indirection | semmle.label | password1 indirection |
 | test3.cpp:26:15:26:23 | password2 | semmle.label | password2 |
-| test3.cpp:26:15:26:23 | password2 indirection | semmle.label | password2 indirection |
-| test3.cpp:26:33:26:41 | password2 indirection | semmle.label | password2 indirection |
-| test3.cpp:26:33:26:41 | password2 indirection | semmle.label | password2 indirection |
 | test3.cpp:47:15:47:22 | password | semmle.label | password |
-| test3.cpp:47:15:47:22 | password indirection | semmle.label | password indirection |
 | test3.cpp:55:15:55:22 | password | semmle.label | password |
-| test3.cpp:55:15:55:22 | password indirection | semmle.label | password indirection |
-| test3.cpp:74:21:74:29 | password1 indirection | semmle.label | password1 indirection |
+| test3.cpp:74:21:74:29 | password1 | semmle.label | password1 |
 | test3.cpp:76:15:76:17 | ptr | semmle.label | ptr |
-| test3.cpp:81:15:81:22 | password indirection | semmle.label | password indirection |
+| test3.cpp:81:15:81:22 | password | semmle.label | password |
 | test3.cpp:83:15:83:17 | ptr | semmle.label | ptr |
 | test3.cpp:101:12:101:19 | password | semmle.label | password |
-| test3.cpp:101:12:101:19 | password indirection | semmle.label | password indirection |
 | test3.cpp:112:20:112:25 | buffer | semmle.label | buffer |
-| test3.cpp:112:20:112:25 | buffer indirection | semmle.label | buffer indirection |
 | test3.cpp:114:14:114:19 | buffer | semmle.label | buffer |
-| test3.cpp:117:13:117:14 | VariableAddress indirection | semmle.label | VariableAddress indirection |
-| test3.cpp:117:28:117:33 | buffer indirection | semmle.label | buffer indirection |
 | test3.cpp:124:7:124:20 | VariableAddress indirection | semmle.label | VariableAddress indirection |
-| test3.cpp:124:7:124:20 | VariableAddress indirection | semmle.label | VariableAddress indirection |
-| test3.cpp:126:9:126:23 | global_password indirection | semmle.label | global_password indirection |
-| test3.cpp:134:11:134:18 | Convert indirection | semmle.label | Convert indirection |
+| test3.cpp:126:9:126:23 | global_password | semmle.label | global_password |
 | test3.cpp:134:11:134:18 | password | semmle.label | password |
-| test3.cpp:134:11:134:18 | password indirection | semmle.label | password indirection |
-| test3.cpp:138:21:138:22 | call to id indirection | semmle.label | call to id indirection |
-| test3.cpp:138:24:138:32 | Load indirection | semmle.label | Load indirection |
 | test3.cpp:138:24:138:32 | password1 | semmle.label | password1 |
-| test3.cpp:138:24:138:32 | password1 indirection | semmle.label | password1 indirection |
-| test3.cpp:138:24:138:32 | password1 indirection | semmle.label | password1 indirection |
 | test3.cpp:140:15:140:17 | ptr | semmle.label | ptr |
-| test3.cpp:144:16:144:29 | call to get_global_str indirection | semmle.label | call to get_global_str indirection |
 | test3.cpp:146:15:146:18 | data | semmle.label | data |
-| test3.cpp:157:19:157:26 | password indirection | semmle.label | password indirection |
-| test3.cpp:157:19:157:26 | password indirection | semmle.label | password indirection |
+| test3.cpp:157:19:157:26 | password | semmle.label | password |
 | test3.cpp:159:15:159:20 | buffer | semmle.label | buffer |
 | test3.cpp:173:15:173:22 | password | semmle.label | password |
-| test3.cpp:173:15:173:22 | password indirection | semmle.label | password indirection |
 | test3.cpp:181:15:181:22 | password | semmle.label | password |
-| test3.cpp:181:15:181:22 | password indirection | semmle.label | password indirection |
 | test3.cpp:191:15:191:22 | password | semmle.label | password |
-| test3.cpp:191:15:191:22 | password indirection | semmle.label | password indirection |
-| test3.cpp:199:19:199:26 | password indirection | semmle.label | password indirection |
 | test3.cpp:201:15:201:22 | password | semmle.label | password |
-| test3.cpp:201:15:201:22 | password indirection | semmle.label | password indirection |
-| test3.cpp:201:32:201:39 | password indirection | semmle.label | password indirection |
-| test3.cpp:207:19:207:26 | password indirection | semmle.label | password indirection |
-| test3.cpp:208:3:208:10 | password indirection | semmle.label | password indirection |
 | test3.cpp:210:15:210:22 | password | semmle.label | password |
-| test3.cpp:210:15:210:22 | password indirection | semmle.label | password indirection |
-| test3.cpp:210:32:210:39 | password indirection | semmle.label | password indirection |
 | test3.cpp:219:15:219:26 | password_ptr | semmle.label | password_ptr |
-| test3.cpp:219:15:219:26 | password_ptr indirection | semmle.label | password_ptr indirection |
-| test3.cpp:219:36:219:47 | password_ptr indirection | semmle.label | password_ptr indirection |
-| test3.cpp:227:22:227:29 | password indirection | semmle.label | password indirection |
 | test3.cpp:228:26:228:33 | password | semmle.label | password |
-| test3.cpp:228:26:228:33 | password indirection | semmle.label | password indirection |
 | test3.cpp:241:8:241:15 | password | semmle.label | password |
-| test3.cpp:241:8:241:15 | password indirection | semmle.label | password indirection |
 | test3.cpp:254:15:254:23 | password1 | semmle.label | password1 |
-| test3.cpp:254:15:254:23 | password1 indirection | semmle.label | password1 indirection |
-| test3.cpp:262:32:262:40 | password2 indirection | semmle.label | password2 indirection |
 | test3.cpp:264:15:264:23 | password2 | semmle.label | password2 |
-| test3.cpp:264:15:264:23 | password2 indirection | semmle.label | password2 indirection |
-| test3.cpp:264:33:264:41 | password2 indirection | semmle.label | password2 indirection |
-| test3.cpp:270:16:270:23 | password indirection | semmle.label | password indirection |
+| test3.cpp:270:16:270:23 | password | semmle.label | password |
 | test3.cpp:272:15:272:18 | data | semmle.label | data |
 | test3.cpp:278:20:278:23 | data | semmle.label | data |
-| test3.cpp:278:20:278:23 | data indirection | semmle.label | data indirection |
 | test3.cpp:280:14:280:17 | data | semmle.label | data |
 | test3.cpp:283:20:283:23 | data | semmle.label | data |
-| test3.cpp:283:20:283:23 | data indirection | semmle.label | data indirection |
 | test3.cpp:285:14:285:17 | data | semmle.label | data |
 | test3.cpp:288:20:288:23 | data | semmle.label | data |
-| test3.cpp:288:20:288:23 | data indirection | semmle.label | data indirection |
 | test3.cpp:290:14:290:17 | data | semmle.label | data |
 | test3.cpp:293:20:293:23 | data | semmle.label | data |
-| test3.cpp:293:20:293:23 | data indirection | semmle.label | data indirection |
 | test3.cpp:295:14:295:17 | data | semmle.label | data |
 | test3.cpp:298:20:298:23 | data | semmle.label | data |
-| test3.cpp:298:20:298:23 | data indirection | semmle.label | data indirection |
 | test3.cpp:300:14:300:17 | data | semmle.label | data |
-| test3.cpp:313:11:313:19 | Load indirection | semmle.label | Load indirection |
 | test3.cpp:313:11:313:19 | password1 | semmle.label | password1 |
-| test3.cpp:313:11:313:19 | password1 indirection | semmle.label | password1 indirection |
-| test3.cpp:313:11:313:19 | password1 indirection | semmle.label | password1 indirection |
-| test3.cpp:314:11:314:19 | Load indirection | semmle.label | Load indirection |
 | test3.cpp:314:11:314:19 | password1 | semmle.label | password1 |
-| test3.cpp:314:11:314:19 | password1 indirection | semmle.label | password1 indirection |
-| test3.cpp:314:11:314:19 | password1 indirection | semmle.label | password1 indirection |
-| test3.cpp:316:11:316:19 | Load indirection | semmle.label | Load indirection |
 | test3.cpp:316:11:316:19 | password1 | semmle.label | password1 |
-| test3.cpp:316:11:316:19 | password1 indirection | semmle.label | password1 indirection |
-| test3.cpp:316:11:316:19 | password1 indirection | semmle.label | password1 indirection |
-| test3.cpp:317:11:317:19 | Load indirection | semmle.label | Load indirection |
 | test3.cpp:317:11:317:19 | password1 | semmle.label | password1 |
-| test3.cpp:317:11:317:19 | password1 indirection | semmle.label | password1 indirection |
-| test3.cpp:317:11:317:19 | password1 indirection | semmle.label | password1 indirection |
-| test3.cpp:322:16:322:24 | password2 indirection | semmle.label | password2 indirection |
-| test3.cpp:324:11:324:14 | Load indirection | semmle.label | Load indirection |
+| test3.cpp:322:16:322:24 | password2 | semmle.label | password2 |
 | test3.cpp:324:11:324:14 | data | semmle.label | data |
-| test3.cpp:325:11:325:14 | Load indirection | semmle.label | Load indirection |
 | test3.cpp:325:11:325:14 | data | semmle.label | data |
 | test3.cpp:341:16:341:23 | password | semmle.label | password |
-| test3.cpp:341:16:341:23 | password indirection | semmle.label | password indirection |
 | test3.cpp:352:16:352:23 | password | semmle.label | password |
-| test3.cpp:352:16:352:23 | password indirection | semmle.label | password indirection |
 | test3.cpp:368:15:368:22 | password | semmle.label | password |
-| test3.cpp:368:15:368:22 | password indirection | semmle.label | password indirection |
 | test3.cpp:388:15:388:22 | password | semmle.label | password |
-| test3.cpp:388:15:388:22 | password indirection | semmle.label | password indirection |
 | test3.cpp:400:15:400:23 | & ... | semmle.label | & ... |
-| test3.cpp:400:16:400:23 | password indirection | semmle.label | password indirection |
+| test3.cpp:400:16:400:23 | password | semmle.label | password |
 | test3.cpp:414:15:414:24 | password | semmle.label | password |
-| test3.cpp:414:15:414:24 | password indirection | semmle.label | password indirection |
 | test3.cpp:420:15:420:24 | password | semmle.label | password |
-| test3.cpp:420:15:420:24 | password indirection | semmle.label | password indirection |
 | test3.cpp:431:8:431:15 | password | semmle.label | password |
-| test3.cpp:431:8:431:15 | password indirection | semmle.label | password indirection |
 | test3.cpp:507:14:507:39 | social_security_number | semmle.label | social_security_number |
-| test3.cpp:507:14:507:39 | social_security_number indirection | semmle.label | social_security_number indirection |
 | test3.cpp:508:14:508:33 | socialSecurityNo | semmle.label | socialSecurityNo |
-| test3.cpp:508:14:508:33 | socialSecurityNo indirection | semmle.label | socialSecurityNo indirection |
 | test3.cpp:509:14:509:29 | homePostCode | semmle.label | homePostCode |
-| test3.cpp:509:14:509:29 | homePostCode indirection | semmle.label | homePostCode indirection |
 | test3.cpp:510:14:510:28 | my_zip_code | semmle.label | my_zip_code |
-| test3.cpp:510:14:510:28 | my_zip_code indirection | semmle.label | my_zip_code indirection |
 | test3.cpp:511:14:511:26 | telephone | semmle.label | telephone |
-| test3.cpp:511:14:511:26 | telephone indirection | semmle.label | telephone indirection |
 | test3.cpp:512:14:512:36 | mobile_phone_number | semmle.label | mobile_phone_number |
-| test3.cpp:512:14:512:36 | mobile_phone_number indirection | semmle.label | mobile_phone_number indirection |
 | test3.cpp:513:14:513:22 | email | semmle.label | email |
-| test3.cpp:513:14:513:22 | email indirection | semmle.label | email indirection |
 | test3.cpp:514:14:514:38 | my_credit_card_number | semmle.label | my_credit_card_number |
-| test3.cpp:514:14:514:38 | my_credit_card_number indirection | semmle.label | my_credit_card_number indirection |
 | test3.cpp:515:14:515:35 | my_bank_account_no | semmle.label | my_bank_account_no |
-| test3.cpp:515:14:515:35 | my_bank_account_no indirection | semmle.label | my_bank_account_no indirection |
 | test3.cpp:516:14:516:29 | employerName | semmle.label | employerName |
-| test3.cpp:516:14:516:29 | employerName indirection | semmle.label | employerName indirection |
 | test3.cpp:517:14:517:29 | medical_info | semmle.label | medical_info |
-| test3.cpp:517:14:517:29 | medical_info indirection | semmle.label | medical_info indirection |
 | test3.cpp:518:14:518:28 | license_key | semmle.label | license_key |
-| test3.cpp:518:14:518:28 | license_key indirection | semmle.label | license_key indirection |
-| test3.cpp:551:47:551:58 | salaryString indirection | semmle.label | salaryString indirection |
+| test3.cpp:526:44:526:54 | my_latitude | semmle.label | my_latitude |
+| test3.cpp:527:15:527:20 | buffer | semmle.label | buffer |
+| test3.cpp:532:45:532:58 | home_longitude | semmle.label | home_longitude |
+| test3.cpp:533:15:533:20 | buffer | semmle.label | buffer |
+| test3.cpp:551:47:551:58 | salaryString | semmle.label | salaryString |
 | test3.cpp:552:15:552:20 | buffer | semmle.label | buffer |
-| test3.cpp:556:19:556:30 | salaryString indirection | semmle.label | salaryString indirection |
+| test3.cpp:556:19:556:30 | salaryString | semmle.label | salaryString |
 | test3.cpp:559:15:559:20 | buffer | semmle.label | buffer |
 | test3.cpp:571:8:571:21 | call to get_home_phone | semmle.label | call to get_home_phone |
 | test3.cpp:572:14:572:16 | str | semmle.label | str |
 | test3.cpp:577:8:577:23 | call to get_home_address | semmle.label | call to get_home_address |
 | test3.cpp:578:14:578:16 | str | semmle.label | str |
 subpaths
-| test3.cpp:138:24:138:32 | Load indirection | test3.cpp:117:28:117:33 | buffer indirection | test3.cpp:117:13:117:14 | VariableAddress indirection | test3.cpp:138:21:138:22 | call to id indirection |
 #select
-| test3.cpp:22:3:22:6 | call to send | test3.cpp:20:28:20:36 | password1 indirection | test3.cpp:22:15:22:23 | password1 | This operation transmits 'password1', which may contain unencrypted sensitive data from $@. | test3.cpp:20:28:20:36 | password1 indirection | password1 indirection |
-| test3.cpp:22:3:22:6 | call to send | test3.cpp:20:28:20:36 | password1 indirection | test3.cpp:22:15:22:23 | password1 | This operation transmits 'password1', which may contain unencrypted sensitive data from $@. | test3.cpp:20:28:20:36 | password1 indirection | password1 indirection |
-| test3.cpp:22:3:22:6 | call to send | test3.cpp:22:15:22:23 | password1 indirection | test3.cpp:22:15:22:23 | password1 | This operation transmits 'password1', which may contain unencrypted sensitive data from $@. | test3.cpp:22:15:22:23 | password1 indirection | password1 indirection |
-| test3.cpp:22:3:22:6 | call to send | test3.cpp:22:33:22:41 | password1 indirection | test3.cpp:22:15:22:23 | password1 | This operation transmits 'password1', which may contain unencrypted sensitive data from $@. | test3.cpp:22:33:22:41 | password1 indirection | password1 indirection |
-| test3.cpp:22:3:22:6 | call to send | test3.cpp:22:33:22:41 | password1 indirection | test3.cpp:22:15:22:23 | password1 | This operation transmits 'password1', which may contain unencrypted sensitive data from $@. | test3.cpp:22:33:22:41 | password1 indirection | password1 indirection |
-| test3.cpp:26:3:26:6 | call to send | test3.cpp:26:15:26:23 | password2 indirection | test3.cpp:26:15:26:23 | password2 | This operation transmits 'password2', which may contain unencrypted sensitive data from $@. | test3.cpp:26:15:26:23 | password2 indirection | password2 indirection |
-| test3.cpp:26:3:26:6 | call to send | test3.cpp:26:33:26:41 | password2 indirection | test3.cpp:26:15:26:23 | password2 | This operation transmits 'password2', which may contain unencrypted sensitive data from $@. | test3.cpp:26:33:26:41 | password2 indirection | password2 indirection |
-| test3.cpp:26:3:26:6 | call to send | test3.cpp:26:33:26:41 | password2 indirection | test3.cpp:26:15:26:23 | password2 | This operation transmits 'password2', which may contain unencrypted sensitive data from $@. | test3.cpp:26:33:26:41 | password2 indirection | password2 indirection |
-| test3.cpp:47:3:47:6 | call to recv | test3.cpp:47:15:47:22 | password indirection | test3.cpp:47:15:47:22 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@. | test3.cpp:47:15:47:22 | password indirection | password indirection |
-| test3.cpp:55:3:55:6 | call to recv | test3.cpp:55:15:55:22 | password indirection | test3.cpp:55:15:55:22 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@. | test3.cpp:55:15:55:22 | password indirection | password indirection |
-| test3.cpp:76:3:76:6 | call to send | test3.cpp:74:21:74:29 | password1 indirection | test3.cpp:76:15:76:17 | ptr | This operation transmits 'ptr', which may contain unencrypted sensitive data from $@. | test3.cpp:74:21:74:29 | password1 indirection | password1 indirection |
-| test3.cpp:83:3:83:6 | call to recv | test3.cpp:81:15:81:22 | password indirection | test3.cpp:83:15:83:17 | ptr | This operation receives into 'ptr', which may put unencrypted sensitive data into $@. | test3.cpp:81:15:81:22 | password indirection | password indirection |
-| test3.cpp:101:3:101:6 | call to read | test3.cpp:101:12:101:19 | password indirection | test3.cpp:101:12:101:19 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@. | test3.cpp:101:12:101:19 | password indirection | password indirection |
-| test3.cpp:114:2:114:5 | call to recv | test3.cpp:134:11:134:18 | password indirection | test3.cpp:114:14:114:19 | buffer | This operation receives into 'buffer', which may put unencrypted sensitive data into $@. | test3.cpp:134:11:134:18 | password indirection | password indirection |
-| test3.cpp:140:3:140:6 | call to send | test3.cpp:138:24:138:32 | password1 indirection | test3.cpp:140:15:140:17 | ptr | This operation transmits 'ptr', which may contain unencrypted sensitive data from $@. | test3.cpp:138:24:138:32 | password1 indirection | password1 indirection |
-| test3.cpp:140:3:140:6 | call to send | test3.cpp:138:24:138:32 | password1 indirection | test3.cpp:140:15:140:17 | ptr | This operation transmits 'ptr', which may contain unencrypted sensitive data from $@. | test3.cpp:138:24:138:32 | password1 indirection | password1 indirection |
-| test3.cpp:146:3:146:6 | call to send | test3.cpp:126:9:126:23 | global_password indirection | test3.cpp:146:15:146:18 | data | This operation transmits 'data', which may contain unencrypted sensitive data from $@. | test3.cpp:126:9:126:23 | global_password indirection | global_password indirection |
-| test3.cpp:159:3:159:6 | call to send | test3.cpp:157:19:157:26 | password indirection | test3.cpp:159:15:159:20 | buffer | This operation transmits 'buffer', which may contain unencrypted sensitive data from $@. | test3.cpp:157:19:157:26 | password indirection | password indirection |
-| test3.cpp:159:3:159:6 | call to send | test3.cpp:157:19:157:26 | password indirection | test3.cpp:159:15:159:20 | buffer | This operation transmits 'buffer', which may contain unencrypted sensitive data from $@. | test3.cpp:157:19:157:26 | password indirection | password indirection |
-| test3.cpp:228:2:228:5 | call to send | test3.cpp:227:22:227:29 | password indirection | test3.cpp:228:26:228:33 | password | This operation transmits 'password', which may contain unencrypted sensitive data from $@. | test3.cpp:227:22:227:29 | password indirection | password indirection |
-| test3.cpp:228:2:228:5 | call to send | test3.cpp:228:26:228:33 | password indirection | test3.cpp:228:26:228:33 | password | This operation transmits 'password', which may contain unencrypted sensitive data from $@. | test3.cpp:228:26:228:33 | password indirection | password indirection |
-| test3.cpp:241:2:241:6 | call to fgets | test3.cpp:241:8:241:15 | password indirection | test3.cpp:241:8:241:15 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@. | test3.cpp:241:8:241:15 | password indirection | password indirection |
-| test3.cpp:272:3:272:6 | call to send | test3.cpp:270:16:270:23 | password indirection | test3.cpp:272:15:272:18 | data | This operation transmits 'data', which may contain unencrypted sensitive data from $@. | test3.cpp:270:16:270:23 | password indirection | password indirection |
-| test3.cpp:290:2:290:5 | call to send | test3.cpp:317:11:317:19 | password1 indirection | test3.cpp:290:14:290:17 | data | This operation transmits 'data', which may contain unencrypted sensitive data from $@. | test3.cpp:317:11:317:19 | password1 indirection | password1 indirection |
-| test3.cpp:290:2:290:5 | call to send | test3.cpp:317:11:317:19 | password1 indirection | test3.cpp:290:14:290:17 | data | This operation transmits 'data', which may contain unencrypted sensitive data from $@. | test3.cpp:317:11:317:19 | password1 indirection | password1 indirection |
-| test3.cpp:295:2:295:5 | call to send | test3.cpp:322:16:322:24 | password2 indirection | test3.cpp:295:14:295:17 | data | This operation transmits 'data', which may contain unencrypted sensitive data from $@. | test3.cpp:322:16:322:24 | password2 indirection | password2 indirection |
-| test3.cpp:300:2:300:5 | call to send | test3.cpp:322:16:322:24 | password2 indirection | test3.cpp:300:14:300:17 | data | This operation transmits 'data', which may contain unencrypted sensitive data from $@. | test3.cpp:322:16:322:24 | password2 indirection | password2 indirection |
-| test3.cpp:341:4:341:7 | call to recv | test3.cpp:341:16:341:23 | password indirection | test3.cpp:341:16:341:23 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@. | test3.cpp:341:16:341:23 | password indirection | password indirection |
-| test3.cpp:388:3:388:6 | call to recv | test3.cpp:388:15:388:22 | password indirection | test3.cpp:388:15:388:22 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@. | test3.cpp:388:15:388:22 | password indirection | password indirection |
-| test3.cpp:414:3:414:6 | call to recv | test3.cpp:414:15:414:24 | password indirection | test3.cpp:414:15:414:24 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@. | test3.cpp:414:15:414:24 | password indirection | password indirection |
-| test3.cpp:420:3:420:6 | call to recv | test3.cpp:420:15:420:24 | password indirection | test3.cpp:420:15:420:24 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@. | test3.cpp:420:15:420:24 | password indirection | password indirection |
-| test3.cpp:431:2:431:6 | call to fgets | test3.cpp:431:8:431:15 | password indirection | test3.cpp:431:8:431:15 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@. | test3.cpp:431:8:431:15 | password indirection | password indirection |
-| test3.cpp:507:2:507:5 | call to send | test3.cpp:507:14:507:39 | social_security_number indirection | test3.cpp:507:14:507:39 | social_security_number | This operation transmits 'social_security_number', which may contain unencrypted sensitive data from $@. | test3.cpp:507:14:507:39 | social_security_number indirection | social_security_number indirection |
-| test3.cpp:508:2:508:5 | call to send | test3.cpp:508:14:508:33 | socialSecurityNo indirection | test3.cpp:508:14:508:33 | socialSecurityNo | This operation transmits 'socialSecurityNo', which may contain unencrypted sensitive data from $@. | test3.cpp:508:14:508:33 | socialSecurityNo indirection | socialSecurityNo indirection |
-| test3.cpp:509:2:509:5 | call to send | test3.cpp:509:14:509:29 | homePostCode indirection | test3.cpp:509:14:509:29 | homePostCode | This operation transmits 'homePostCode', which may contain unencrypted sensitive data from $@. | test3.cpp:509:14:509:29 | homePostCode indirection | homePostCode indirection |
-| test3.cpp:510:2:510:5 | call to send | test3.cpp:510:14:510:28 | my_zip_code indirection | test3.cpp:510:14:510:28 | my_zip_code | This operation transmits 'my_zip_code', which may contain unencrypted sensitive data from $@. | test3.cpp:510:14:510:28 | my_zip_code indirection | my_zip_code indirection |
-| test3.cpp:511:2:511:5 | call to send | test3.cpp:511:14:511:26 | telephone indirection | test3.cpp:511:14:511:26 | telephone | This operation transmits 'telephone', which may contain unencrypted sensitive data from $@. | test3.cpp:511:14:511:26 | telephone indirection | telephone indirection |
-| test3.cpp:512:2:512:5 | call to send | test3.cpp:512:14:512:36 | mobile_phone_number indirection | test3.cpp:512:14:512:36 | mobile_phone_number | This operation transmits 'mobile_phone_number', which may contain unencrypted sensitive data from $@. | test3.cpp:512:14:512:36 | mobile_phone_number indirection | mobile_phone_number indirection |
-| test3.cpp:513:2:513:5 | call to send | test3.cpp:513:14:513:22 | email indirection | test3.cpp:513:14:513:22 | email | This operation transmits 'email', which may contain unencrypted sensitive data from $@. | test3.cpp:513:14:513:22 | email indirection | email indirection |
-| test3.cpp:514:2:514:5 | call to send | test3.cpp:514:14:514:38 | my_credit_card_number indirection | test3.cpp:514:14:514:38 | my_credit_card_number | This operation transmits 'my_credit_card_number', which may contain unencrypted sensitive data from $@. | test3.cpp:514:14:514:38 | my_credit_card_number indirection | my_credit_card_number indirection |
-| test3.cpp:515:2:515:5 | call to send | test3.cpp:515:14:515:35 | my_bank_account_no indirection | test3.cpp:515:14:515:35 | my_bank_account_no | This operation transmits 'my_bank_account_no', which may contain unencrypted sensitive data from $@. | test3.cpp:515:14:515:35 | my_bank_account_no indirection | my_bank_account_no indirection |
-| test3.cpp:516:2:516:5 | call to send | test3.cpp:516:14:516:29 | employerName indirection | test3.cpp:516:14:516:29 | employerName | This operation transmits 'employerName', which may contain unencrypted sensitive data from $@. | test3.cpp:516:14:516:29 | employerName indirection | employerName indirection |
-| test3.cpp:517:2:517:5 | call to send | test3.cpp:517:14:517:29 | medical_info indirection | test3.cpp:517:14:517:29 | medical_info | This operation transmits 'medical_info', which may contain unencrypted sensitive data from $@. | test3.cpp:517:14:517:29 | medical_info indirection | medical_info indirection |
-| test3.cpp:518:2:518:5 | call to send | test3.cpp:518:14:518:28 | license_key indirection | test3.cpp:518:14:518:28 | license_key | This operation transmits 'license_key', which may contain unencrypted sensitive data from $@. | test3.cpp:518:14:518:28 | license_key indirection | license_key indirection |
-| test3.cpp:552:3:552:6 | call to send | test3.cpp:551:47:551:58 | salaryString indirection | test3.cpp:552:15:552:20 | buffer | This operation transmits 'buffer', which may contain unencrypted sensitive data from $@. | test3.cpp:551:47:551:58 | salaryString indirection | salaryString indirection |
-| test3.cpp:559:3:559:6 | call to send | test3.cpp:556:19:556:30 | salaryString indirection | test3.cpp:559:15:559:20 | buffer | This operation transmits 'buffer', which may contain unencrypted sensitive data from $@. | test3.cpp:556:19:556:30 | salaryString indirection | salaryString indirection |
+| test3.cpp:22:3:22:6 | call to send | test3.cpp:22:15:22:23 | password1 | test3.cpp:22:15:22:23 | password1 | This operation transmits 'password1', which may contain unencrypted sensitive data from $@. | test3.cpp:22:15:22:23 | password1 | password1 |
+| test3.cpp:26:3:26:6 | call to send | test3.cpp:26:15:26:23 | password2 | test3.cpp:26:15:26:23 | password2 | This operation transmits 'password2', which may contain unencrypted sensitive data from $@. | test3.cpp:26:15:26:23 | password2 | password2 |
+| test3.cpp:47:3:47:6 | call to recv | test3.cpp:47:15:47:22 | password | test3.cpp:47:15:47:22 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@. | test3.cpp:47:15:47:22 | password | password |
+| test3.cpp:55:3:55:6 | call to recv | test3.cpp:55:15:55:22 | password | test3.cpp:55:15:55:22 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@. | test3.cpp:55:15:55:22 | password | password |
+| test3.cpp:76:3:76:6 | call to send | test3.cpp:74:21:74:29 | password1 | test3.cpp:76:15:76:17 | ptr | This operation transmits 'ptr', which may contain unencrypted sensitive data from $@. | test3.cpp:74:21:74:29 | password1 | password1 |
+| test3.cpp:83:3:83:6 | call to recv | test3.cpp:81:15:81:22 | password | test3.cpp:83:15:83:17 | ptr | This operation receives into 'ptr', which may put unencrypted sensitive data into $@. | test3.cpp:81:15:81:22 | password | password |
+| test3.cpp:101:3:101:6 | call to read | test3.cpp:101:12:101:19 | password | test3.cpp:101:12:101:19 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@. | test3.cpp:101:12:101:19 | password | password |
+| test3.cpp:114:2:114:5 | call to recv | test3.cpp:134:11:134:18 | password | test3.cpp:114:14:114:19 | buffer | This operation receives into 'buffer', which may put unencrypted sensitive data into $@. | test3.cpp:134:11:134:18 | password | password |
+| test3.cpp:140:3:140:6 | call to send | test3.cpp:138:24:138:32 | password1 | test3.cpp:140:15:140:17 | ptr | This operation transmits 'ptr', which may contain unencrypted sensitive data from $@. | test3.cpp:138:24:138:32 | password1 | password1 |
+| test3.cpp:146:3:146:6 | call to send | test3.cpp:126:9:126:23 | global_password | test3.cpp:146:15:146:18 | data | This operation transmits 'data', which may contain unencrypted sensitive data from $@. | test3.cpp:126:9:126:23 | global_password | global_password |
+| test3.cpp:159:3:159:6 | call to send | test3.cpp:157:19:157:26 | password | test3.cpp:159:15:159:20 | buffer | This operation transmits 'buffer', which may contain unencrypted sensitive data from $@. | test3.cpp:157:19:157:26 | password | password |
+| test3.cpp:228:2:228:5 | call to send | test3.cpp:228:26:228:33 | password | test3.cpp:228:26:228:33 | password | This operation transmits 'password', which may contain unencrypted sensitive data from $@. | test3.cpp:228:26:228:33 | password | password |
+| test3.cpp:241:2:241:6 | call to fgets | test3.cpp:241:8:241:15 | password | test3.cpp:241:8:241:15 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@. | test3.cpp:241:8:241:15 | password | password |
+| test3.cpp:272:3:272:6 | call to send | test3.cpp:270:16:270:23 | password | test3.cpp:272:15:272:18 | data | This operation transmits 'data', which may contain unencrypted sensitive data from $@. | test3.cpp:270:16:270:23 | password | password |
+| test3.cpp:290:2:290:5 | call to send | test3.cpp:317:11:317:19 | password1 | test3.cpp:290:14:290:17 | data | This operation transmits 'data', which may contain unencrypted sensitive data from $@. | test3.cpp:317:11:317:19 | password1 | password1 |
+| test3.cpp:295:2:295:5 | call to send | test3.cpp:322:16:322:24 | password2 | test3.cpp:295:14:295:17 | data | This operation transmits 'data', which may contain unencrypted sensitive data from $@. | test3.cpp:322:16:322:24 | password2 | password2 |
+| test3.cpp:300:2:300:5 | call to send | test3.cpp:322:16:322:24 | password2 | test3.cpp:300:14:300:17 | data | This operation transmits 'data', which may contain unencrypted sensitive data from $@. | test3.cpp:322:16:322:24 | password2 | password2 |
+| test3.cpp:341:4:341:7 | call to recv | test3.cpp:341:16:341:23 | password | test3.cpp:341:16:341:23 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@. | test3.cpp:341:16:341:23 | password | password |
+| test3.cpp:388:3:388:6 | call to recv | test3.cpp:388:15:388:22 | password | test3.cpp:388:15:388:22 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@. | test3.cpp:388:15:388:22 | password | password |
+| test3.cpp:414:3:414:6 | call to recv | test3.cpp:414:15:414:24 | password | test3.cpp:414:15:414:24 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@. | test3.cpp:414:15:414:24 | password | password |
+| test3.cpp:420:3:420:6 | call to recv | test3.cpp:420:15:420:24 | password | test3.cpp:420:15:420:24 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@. | test3.cpp:420:15:420:24 | password | password |
+| test3.cpp:431:2:431:6 | call to fgets | test3.cpp:431:8:431:15 | password | test3.cpp:431:8:431:15 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@. | test3.cpp:431:8:431:15 | password | password |
+| test3.cpp:507:2:507:5 | call to send | test3.cpp:507:14:507:39 | social_security_number | test3.cpp:507:14:507:39 | social_security_number | This operation transmits 'social_security_number', which may contain unencrypted sensitive data from $@. | test3.cpp:507:14:507:39 | social_security_number | social_security_number |
+| test3.cpp:508:2:508:5 | call to send | test3.cpp:508:14:508:33 | socialSecurityNo | test3.cpp:508:14:508:33 | socialSecurityNo | This operation transmits 'socialSecurityNo', which may contain unencrypted sensitive data from $@. | test3.cpp:508:14:508:33 | socialSecurityNo | socialSecurityNo |
+| test3.cpp:509:2:509:5 | call to send | test3.cpp:509:14:509:29 | homePostCode | test3.cpp:509:14:509:29 | homePostCode | This operation transmits 'homePostCode', which may contain unencrypted sensitive data from $@. | test3.cpp:509:14:509:29 | homePostCode | homePostCode |
+| test3.cpp:510:2:510:5 | call to send | test3.cpp:510:14:510:28 | my_zip_code | test3.cpp:510:14:510:28 | my_zip_code | This operation transmits 'my_zip_code', which may contain unencrypted sensitive data from $@. | test3.cpp:510:14:510:28 | my_zip_code | my_zip_code |
+| test3.cpp:511:2:511:5 | call to send | test3.cpp:511:14:511:26 | telephone | test3.cpp:511:14:511:26 | telephone | This operation transmits 'telephone', which may contain unencrypted sensitive data from $@. | test3.cpp:511:14:511:26 | telephone | telephone |
+| test3.cpp:512:2:512:5 | call to send | test3.cpp:512:14:512:36 | mobile_phone_number | test3.cpp:512:14:512:36 | mobile_phone_number | This operation transmits 'mobile_phone_number', which may contain unencrypted sensitive data from $@. | test3.cpp:512:14:512:36 | mobile_phone_number | mobile_phone_number |
+| test3.cpp:513:2:513:5 | call to send | test3.cpp:513:14:513:22 | email | test3.cpp:513:14:513:22 | email | This operation transmits 'email', which may contain unencrypted sensitive data from $@. | test3.cpp:513:14:513:22 | email | email |
+| test3.cpp:514:2:514:5 | call to send | test3.cpp:514:14:514:38 | my_credit_card_number | test3.cpp:514:14:514:38 | my_credit_card_number | This operation transmits 'my_credit_card_number', which may contain unencrypted sensitive data from $@. | test3.cpp:514:14:514:38 | my_credit_card_number | my_credit_card_number |
+| test3.cpp:515:2:515:5 | call to send | test3.cpp:515:14:515:35 | my_bank_account_no | test3.cpp:515:14:515:35 | my_bank_account_no | This operation transmits 'my_bank_account_no', which may contain unencrypted sensitive data from $@. | test3.cpp:515:14:515:35 | my_bank_account_no | my_bank_account_no |
+| test3.cpp:516:2:516:5 | call to send | test3.cpp:516:14:516:29 | employerName | test3.cpp:516:14:516:29 | employerName | This operation transmits 'employerName', which may contain unencrypted sensitive data from $@. | test3.cpp:516:14:516:29 | employerName | employerName |
+| test3.cpp:517:2:517:5 | call to send | test3.cpp:517:14:517:29 | medical_info | test3.cpp:517:14:517:29 | medical_info | This operation transmits 'medical_info', which may contain unencrypted sensitive data from $@. | test3.cpp:517:14:517:29 | medical_info | medical_info |
+| test3.cpp:518:2:518:5 | call to send | test3.cpp:518:14:518:28 | license_key | test3.cpp:518:14:518:28 | license_key | This operation transmits 'license_key', which may contain unencrypted sensitive data from $@. | test3.cpp:518:14:518:28 | license_key | license_key |
+| test3.cpp:527:3:527:6 | call to send | test3.cpp:526:44:526:54 | my_latitude | test3.cpp:527:15:527:20 | buffer | This operation transmits 'buffer', which may contain unencrypted sensitive data from $@. | test3.cpp:526:44:526:54 | my_latitude | my_latitude |
+| test3.cpp:533:3:533:6 | call to send | test3.cpp:532:45:532:58 | home_longitude | test3.cpp:533:15:533:20 | buffer | This operation transmits 'buffer', which may contain unencrypted sensitive data from $@. | test3.cpp:532:45:532:58 | home_longitude | home_longitude |
+| test3.cpp:552:3:552:6 | call to send | test3.cpp:551:47:551:58 | salaryString | test3.cpp:552:15:552:20 | buffer | This operation transmits 'buffer', which may contain unencrypted sensitive data from $@. | test3.cpp:551:47:551:58 | salaryString | salaryString |
+| test3.cpp:559:3:559:6 | call to send | test3.cpp:556:19:556:30 | salaryString | test3.cpp:559:15:559:20 | buffer | This operation transmits 'buffer', which may contain unencrypted sensitive data from $@. | test3.cpp:556:19:556:30 | salaryString | salaryString |
 | test3.cpp:572:2:572:5 | call to send | test3.cpp:571:8:571:21 | call to get_home_phone | test3.cpp:572:14:572:16 | str | This operation transmits 'str', which may contain unencrypted sensitive data from $@. | test3.cpp:571:8:571:21 | call to get_home_phone | call to get_home_phone |
 | test3.cpp:578:2:578:5 | call to send | test3.cpp:577:8:577:23 | call to get_home_address | test3.cpp:578:14:578:16 | str | This operation transmits 'str', which may contain unencrypted sensitive data from $@. | test3.cpp:577:8:577:23 | call to get_home_address | call to get_home_address |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test3.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test3.cpp
@@ -524,13 +524,13 @@ void tests2(person_info *pi)
 		char buffer[1024];
 
 		snprintf(buffer, 1024, "lat = %f\n", pi->my_latitude);
-		send(val(), buffer, strlen(buffer), val()); // BAD [NOT DETECTED]
+		send(val(), buffer, strlen(buffer), val()); // BAD
 	}
 	{
 		char buffer[1024];
 
 		snprintf(buffer, 1024, "long = %f\n", pi->home_longitude);
-		send(val(), buffer, strlen(buffer), val()); // BAD [NOT DETECTED]
+		send(val(), buffer, strlen(buffer), val()); // BAD
 	}
 	{
 		char buffer[1024];


### PR DESCRIPTION
This fixes FNs _and_ reduces result duplication tremendously 🎉.

DCA looks fine.