### PR TITLE
Ruby: Reimplement flow through captured variables using field flow

### DIFF
--- a/ruby/ql/consistency-queries/DataFlowConsistency.ql
+++ b/ruby/ql/consistency-queries/DataFlowConsistency.ql
@@ -11,8 +11,6 @@ private module Input implements InputSig<RubyDataFlow> {
   predicate postWithInFlowExclude(Node n) { n instanceof FlowSummaryNode }
 
   predicate argHasPostUpdateExclude(ArgumentNode n) {
-    n instanceof BlockArgumentNode
-    or
     n instanceof FlowSummaryNode
     or
     n instanceof SynthHashSplatArgumentNode

--- a/ruby/ql/consistency-queries/VariablesConsistency.ql
+++ b/ruby/ql/consistency-queries/VariablesConsistency.ql
@@ -1,4 +1,5 @@
 import codeql.ruby.ast.Variable
+import codeql.ruby.dataflow.internal.DataFlowPrivate::VariableCapture::Flow::ConsistencyChecks
 
 query predicate ambiguousVariable(VariableAccess access, Variable variable) {
   access.getVariable() = variable and

--- a/ruby/ql/lib/change-notes/2023-08-23-variable-capture-flow.md
+++ b/ruby/ql/lib/change-notes/2023-08-23-variable-capture-flow.md
@@ -1,0 +1,4 @@
+---
+category: majorAnalysis
+---
+* Improved support for flow through captured variables that properly adheres to inter-procedural control flow.

--- a/ruby/ql/lib/codeql/ruby/ast/Call.qll
+++ b/ruby/ql/lib/codeql/ruby/ast/Call.qll
@@ -118,6 +118,17 @@ class MethodCall extends Call instanceof MethodCallImpl {
   final Block getBlock() { result = super.getBlockImpl() }
 
   /**
+   * Gets the block argument of this method call, if any.
+   * ```rb
+   * foo(&block)
+   * ```
+   */
+  final BlockArgument getBlockArgument() { result = this.getAnArgument() }
+
+  /** Holds if this method call has a block or block argument. */
+  final predicate hasBlock() { exists(this.getBlock()) or exists(this.getBlockArgument()) }
+
+  /**
    * Holds if the safe navigation operator (`&.`) is used in this call.
    * ```rb
    * foo&.empty?

--- a/ruby/ql/lib/codeql/ruby/controlflow/CfgNodes.qll
+++ b/ruby/ql/lib/codeql/ruby/controlflow/CfgNodes.qll
@@ -202,7 +202,10 @@ module ExprNodes {
     override LhsExpr getExpr() { result = super.getExpr() }
 
     /** Gets a variable used in (or introduced by) this LHS. */
-    Variable getAVariable() { result = e.(VariableAccess).getVariable() }
+    deprecated Variable getAVariable() { result = e.(VariableAccess).getVariable() }
+
+    /** Gets the variable used in (or introduced by) this LHS. */
+    Variable getVariable() { result = e.(VariableAccess).getVariable() }
   }
 
   private class AssignExprChildMapping extends ExprChildMapping, AssignExpr {

--- a/ruby/ql/lib/codeql/ruby/controlflow/CfgNodes.qll
+++ b/ruby/ql/lib/codeql/ruby/controlflow/CfgNodes.qll
@@ -201,7 +201,11 @@ module ExprNodes {
 
     override LhsExpr getExpr() { result = super.getExpr() }
 
-    /** Gets a variable used in (or introduced by) this LHS. */
+    /**
+     * DEPRECATED: use `getVariable` instead.
+     *
+     * Gets a variable used in (or introduced by) this LHS.
+     */
     deprecated Variable getAVariable() { result = e.(VariableAccess).getVariable() }
 
     /** Gets the variable used in (or introduced by) this LHS. */

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowDispatch.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowDispatch.qll
@@ -21,8 +21,7 @@ private class SelfLocalSourceNode extends DataFlow::LocalSourceNode {
   SelfLocalSourceNode() {
     self = this.(SelfParameterNodeImpl).getSelfVariable()
     or
-    self = this.(SsaSelfDefinitionNode).getVariable() and
-    not LocalFlow::localFlowSsaParamInput(_, this)
+    self = this.(SsaSelfDefinitionNode).getVariable()
   }
 
   /** Gets the `self` variable. */
@@ -424,6 +423,7 @@ private module Cached {
   cached
   newtype TArgumentPosition =
     TSelfArgumentPosition() or
+    TLambdaSelfArgumentPosition() or
     TBlockArgumentPosition() or
     TPositionalArgumentPosition(int pos) {
       exists(Call c | exists(c.getArgument(pos)))
@@ -446,6 +446,7 @@ private module Cached {
   cached
   newtype TParameterPosition =
     TSelfParameterPosition() or
+    TLambdaSelfParameterPosition() or
     TBlockParameterPosition() or
     TPositionalParameterPosition(int pos) {
       pos = any(Parameter p).getPosition()
@@ -941,20 +942,24 @@ private module TrackSingletonMethodOnInstanceInput implements CallGraphConstruct
   private predicate paramReturnFlow(
     DataFlow::Node nodeFrom, DataFlow::PostUpdateNode nodeTo, StepSummary summary
   ) {
-    exists(RelevantCall call, DataFlow::Node arg, DataFlow::ParameterNode p, Expr nodeFromPreExpr |
+    exists(
+      RelevantCall call, DataFlow::Node arg, DataFlow::ParameterNode p,
+      CfgNodes::ExprCfgNode nodeFromPreExpr
+    |
       TypeTrackerSpecific::callStep(call, arg, p) and
       nodeTo.getPreUpdateNode() = arg and
       summary.toString() = "return" and
       (
-        nodeFromPreExpr = nodeFrom.(DataFlow::PostUpdateNode).getPreUpdateNode().asExpr().getExpr()
+        nodeFromPreExpr = nodeFrom.(DataFlow::PostUpdateNode).getPreUpdateNode().asExpr()
         or
-        nodeFromPreExpr = nodeFrom.asExpr().getExpr() and
-        singletonMethodOnInstance(_, _, nodeFromPreExpr)
+        nodeFromPreExpr = nodeFrom.asExpr() and
+        singletonMethodOnInstance(_, _, nodeFromPreExpr.getExpr())
       )
     |
-      nodeFromPreExpr = p.getParameter().(NamedParameter).getVariable().getAnAccess()
+      nodeFromPreExpr =
+        LocalFlow::getParameterDefNode(p.getParameter()).getDefinitionExt().getARead()
       or
-      nodeFromPreExpr = p.(SelfParameterNodeImpl).getSelfVariable().getAnAccess()
+      nodeFromPreExpr = p.(SelfParameterNodeImpl).getSelfDefinition().getARead()
     )
   }
 
@@ -1276,6 +1281,9 @@ class ParameterPosition extends TParameterPosition {
   /** Holds if this position represents a `self` parameter. */
   predicate isSelf() { this = TSelfParameterPosition() }
 
+  /** Holds if this position represents a reference to a lambda itself. Only used for tracking flow through captured variables. */
+  predicate isLambdaSelf() { this = TLambdaSelfParameterPosition() }
+
   /** Holds if this position represents a block parameter. */
   predicate isBlock() { this = TBlockParameterPosition() }
 
@@ -1313,6 +1321,8 @@ class ParameterPosition extends TParameterPosition {
   string toString() {
     this.isSelf() and result = "self"
     or
+    this.isLambdaSelf() and result = "lambda self"
+    or
     this.isBlock() and result = "block"
     or
     exists(int pos | this.isPositional(pos) and result = "position " + pos)
@@ -1341,6 +1351,9 @@ class ParameterPosition extends TParameterPosition {
 class ArgumentPosition extends TArgumentPosition {
   /** Holds if this position represents a `self` argument. */
   predicate isSelf() { this = TSelfArgumentPosition() }
+
+  /** Holds if this position represents a lambda `self` argument. Only used for tracking flow through captured variables. */
+  predicate isLambdaSelf() { this = TLambdaSelfArgumentPosition() }
 
   /** Holds if this position represents a block argument. */
   predicate isBlock() { this = TBlockArgumentPosition() }
@@ -1374,6 +1387,8 @@ class ArgumentPosition extends TArgumentPosition {
   string toString() {
     this.isSelf() and result = "self"
     or
+    this.isLambdaSelf() and result = "lambda self"
+    or
     this.isBlock() and result = "block"
     or
     exists(int pos | this.isPositional(pos) and result = "position " + pos)
@@ -1393,15 +1408,23 @@ class ArgumentPosition extends TArgumentPosition {
 }
 
 pragma[nomagic]
-private predicate parameterPositionIsNotSelf(ParameterPosition ppos) { not ppos.isSelf() }
+private predicate parameterPositionIsNotSelf(ParameterPosition ppos) {
+  not ppos.isSelf() and
+  not ppos.isLambdaSelf()
+}
 
 pragma[nomagic]
-private predicate argumentPositionIsNotSelf(ArgumentPosition apos) { not apos.isSelf() }
+private predicate argumentPositionIsNotSelf(ArgumentPosition apos) {
+  not apos.isSelf() and
+  not apos.isLambdaSelf()
+}
 
 /** Holds if arguments at position `apos` match parameters at position `ppos`. */
 pragma[nomagic]
 predicate parameterMatch(ParameterPosition ppos, ArgumentPosition apos) {
   ppos.isSelf() and apos.isSelf()
+  or
+  ppos.isLambdaSelf() and apos.isLambdaSelf()
   or
   ppos.isBlock() and apos.isBlock()
   or
@@ -1441,8 +1464,6 @@ predicate parameterMatch(ParameterPosition ppos, ArgumentPosition apos) {
  * This is a temporary hook to support technical debt in the Go language; do not use.
  */
 pragma[inline]
-predicate golangSpecificParamArgFilter(
-  DataFlowCall call, DataFlow::ParameterNode p, ArgumentNode arg
-) {
+predicate golangSpecificParamArgFilter(DataFlowCall call, ParameterNodeImpl p, ArgumentNode arg) {
   any()
 }

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplSpecific.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplSpecific.qll
@@ -17,6 +17,9 @@ module RubyDataFlow implements InputSig {
   import Private
   import Public
 
+  // includes `LambdaSelfParameterNode`, which is not part of the public API
+  class ParameterNode = Private::ParameterNodeImpl;
+
   predicate isParameterNode(ParameterNode p, DataFlowCallable c, ParameterPosition pos) {
     Private::isParameterNode(p, c, pos)
   }

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplSpecific.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplSpecific.qll
@@ -17,7 +17,7 @@ module RubyDataFlow implements InputSig {
   import Private
   import Public
 
-  // includes `LambdaSelfParameterNode`, which is not part of the public API
+  // includes `LambdaSelfReferenceNode`, which is not part of the public API
   class ParameterNode = Private::ParameterNodeImpl;
 
   predicate isParameterNode(ParameterNode p, DataFlowCallable c, ParameterPosition pos) {

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPublic.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPublic.qll
@@ -568,6 +568,18 @@ module Content {
 
   /** Gets `AttributeNameContent` of the given name. */
   AttributeNameContent getAttributeName(string name) { result.getName() = name }
+
+  /** A captured variable. */
+  class CapturedVariableContent extends Content, TCapturedVariableContent {
+    private LocalVariable v;
+
+    CapturedVariableContent() { this = TCapturedVariableContent(v) }
+
+    /** Gets the captured variable. */
+    LocalVariable getVariable() { result = v }
+
+    override string toString() { result = "captured " + v }
+  }
 }
 
 /**
@@ -765,14 +777,14 @@ module BarrierGuard<guardChecksSig/3 guardChecks> {
    * This is restricted to calls where the variable is captured inside a
    * block.
    */
-  private Ssa::Definition getAMaybeGuardedCapturedDef() {
+  private Ssa::CapturedEntryDefinition getAMaybeGuardedCapturedDef() {
     exists(
       CfgNodes::ExprCfgNode g, boolean branch, CfgNodes::ExprCfgNode testedNode,
       Ssa::Definition def, CfgNodes::ExprNodes::CallCfgNode call
     |
       def.getARead() = testedNode and
       guardChecks(g, testedNode, branch) and
-      SsaImpl::captureFlowIn(call, def, result) and
+      def.getSourceVariable() = result.getSourceVariable() and
       guardControlsBlock(g, call.getBasicBlock(), branch) and
       result.getBasicBlock().getScope() = call.getExpr().(MethodCall).getBlock()
     )
@@ -830,14 +842,14 @@ abstract deprecated class BarrierGuard extends CfgNodes::ExprCfgNode {
    * This is restricted to calls where the variable is captured inside a
    * block.
    */
-  private Ssa::Definition getAMaybeGuardedCapturedDef() {
+  private Ssa::CapturedEntryDefinition getAMaybeGuardedCapturedDef() {
     exists(
       boolean branch, CfgNodes::ExprCfgNode testedNode, Ssa::Definition def,
       CfgNodes::ExprNodes::CallCfgNode call
     |
       def.getARead() = testedNode and
       this.checks(testedNode, branch) and
-      SsaImpl::captureFlowIn(call, def, result) and
+      def.getSourceVariable() = result.getSourceVariable() and
       this.controlsBlock(call.getBasicBlock(), branch) and
       result.getBasicBlock().getScope() = call.getExpr().(MethodCall).getBlock()
     )
@@ -1208,7 +1220,10 @@ class LhsExprNode extends ExprNode {
   LhsExpr asLhsExprAstNode() { result = lhsExprCfgNode.getExpr() }
 
   /** Gets a variable used in (or introduced by) this LHS. */
-  Variable getAVariable() { result = lhsExprCfgNode.getAVariable() }
+  deprecated Variable getAVariable() { result = lhsExprCfgNode.getAVariable() }
+
+  /** Gets the variable used in (or introduced by) this LHS. */
+  Variable getVariable() { result = lhsExprCfgNode.getVariable() }
 }
 
 /**

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPublic.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPublic.qll
@@ -1219,7 +1219,11 @@ class LhsExprNode extends ExprNode {
   /** Gets the underlying AST node as a `LhsExpr`. */
   LhsExpr asLhsExprAstNode() { result = lhsExprCfgNode.getExpr() }
 
-  /** Gets a variable used in (or introduced by) this LHS. */
+  /**
+   * DEPRECATED: use `getVariable` instead.
+   *
+   * Gets a variable used in (or introduced by) this LHS.
+   */
   deprecated Variable getAVariable() { result = lhsExprCfgNode.getAVariable() }
 
   /** Gets the variable used in (or introduced by) this LHS. */

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImplSpecific.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImplSpecific.qll
@@ -24,7 +24,7 @@ class NeutralCallableBase = string;
 DataFlowCallable inject(SummarizedCallable c) { result.asLibraryCallable() = c }
 
 /** Gets the parameter position representing a callback itself, if any. */
-ArgumentPosition callbackSelfParameterPosition() { none() } // disables implicit summary flow to `self` for callbacks
+ArgumentPosition callbackSelfParameterPosition() { result.isLambdaSelf() }
 
 /** Gets the synthesized data-flow call for `receiver`. */
 SummaryCall summaryDataFlowCall(SummaryNode receiver) { receiver = result.getReceiver() }
@@ -215,6 +215,9 @@ string getParameterPosition(ParameterPosition pos) {
   pos.isSelf() and
   result = "self"
   or
+  pos.isLambdaSelf() and
+  result = "lambda-self"
+  or
   pos.isBlock() and
   result = "block"
   or
@@ -231,6 +234,8 @@ string getParameterPosition(ParameterPosition pos) {
 /** Gets the textual representation of an argument position in the format used for flow summaries. */
 string getArgumentPosition(ArgumentPosition pos) {
   pos.isSelf() and result = "self"
+  or
+  pos.isLambdaSelf() and result = "lambda-self"
   or
   pos.isBlock() and result = "block"
   or
@@ -372,6 +377,9 @@ ArgumentPosition parseParamBody(string s) {
   s = "self" and
   result.isSelf()
   or
+  s = "lambda-self" and
+  result.isLambdaSelf()
+  or
   s = "block" and
   result.isBlock()
   or
@@ -401,6 +409,9 @@ ParameterPosition parseArgBody(string s) {
   or
   s = "self" and
   result.isSelf()
+  or
+  s = "lambda-self" and
+  result.isLambdaSelf()
   or
   s = "block" and
   result.isBlock()

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/SsaImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/SsaImpl.qll
@@ -363,96 +363,7 @@ private module Cached {
     )
   }
 
-  pragma[noinline]
-  private predicate defReachesCallReadInOuterScope(
-    Definition def, CallCfgNode call, LocalVariable v, Cfg::CfgScope scope
-  ) {
-    exists(Cfg::BasicBlock bb, int i |
-      Impl::ssaDefReachesRead(v, def, bb, i) and
-      capturedCallRead(call, bb, i, v) and
-      scope.getOuterCfgScope() = bb.getScope()
-    )
-  }
-
-  pragma[noinline]
-  private predicate hasCapturedEntryWrite(Definition entry, LocalVariable v, Cfg::CfgScope scope) {
-    exists(Cfg::BasicBlock bb, int i |
-      capturedEntryWrite(bb, i, v) and
-      entry.definesAt(v, bb, i) and
-      bb.getScope().getOuterCfgScope*() = scope
-    )
-  }
-
-  /**
-   * Holds if there is flow for a captured variable from the enclosing scope into a block.
-   * ```rb
-   * foo = 0
-   * bar {
-   *   puts foo
-   * }
-   * ```
-   */
-  cached
-  predicate captureFlowIn(CallCfgNode call, Definition def, Definition entry) {
-    exists(LocalVariable v, Cfg::CfgScope scope |
-      defReachesCallReadInOuterScope(def, call, v, scope) and
-      hasCapturedEntryWrite(entry, v, scope)
-    |
-      // If the read happens inside a block, we restrict to the call that
-      // contains the block
-      not scope instanceof Block
-      or
-      scope = call.getExpr().(MethodCall).getBlock()
-    )
-  }
-
   private import codeql.ruby.dataflow.SSA
-
-  pragma[noinline]
-  private predicate defReachesExitReadInInnerScope(
-    Definition def, LocalVariable v, Cfg::CfgScope scope
-  ) {
-    exists(Cfg::BasicBlock bb, int i |
-      Impl::ssaDefReachesRead(v, def, bb, i) and
-      capturedExitRead(bb, i, v) and
-      scope = bb.getScope().getOuterCfgScope*()
-    )
-  }
-
-  pragma[noinline]
-  private predicate hasCapturedExitRead(
-    Definition exit, CallCfgNode call, LocalVariable v, Cfg::CfgScope scope
-  ) {
-    exists(Cfg::BasicBlock bb, int i |
-      capturedCallWrite(call, bb, i, v) and
-      exit.definesAt(v, bb, i) and
-      bb.getScope() = scope.getOuterCfgScope()
-    )
-  }
-
-  /**
-   * Holds if there is outgoing flow for a captured variable that is updated in a block.
-   * ```rb
-   * foo = 0
-   * bar {
-   *   foo += 10
-   * }
-   * puts foo
-   * ```
-   */
-  cached
-  predicate captureFlowOut(CallCfgNode call, Definition def, Definition exit) {
-    exists(LocalVariable v, Cfg::CfgScope scope |
-      defReachesExitReadInInnerScope(def, v, scope) and
-      hasCapturedExitRead(exit, call, v, _)
-    |
-      // If the read happens inside a block, we restrict to the call that
-      // contains the block
-      not scope instanceof Block
-      or
-      scope = call.getExpr().(MethodCall).getBlock()
-    )
-  }
 
   cached
   Definition phiHasInputFromBlock(PhiNode phi, Cfg::BasicBlock bb) {
@@ -570,6 +481,8 @@ import Cached
  * Only intended for internal use.
  */
 class DefinitionExt extends Impl::DefinitionExt {
+  VariableReadAccessCfgNode getARead() { result = getARead(this) }
+
   override string toString() { result = this.(Ssa::Definition).toString() }
 
   /** Gets the location of this definition. */

--- a/ruby/ql/lib/codeql/ruby/frameworks/Sinatra.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/Sinatra.qll
@@ -285,7 +285,7 @@ module Sinatra {
   }
 
   /** Holds if `n` is a `self` parameter belonging to block `b`. */
-  private predicate blockSelfParameterNode(DataFlowPrivate::LambdaSelfParameterNode n, Block b) {
+  private predicate blockSelfParameterNode(DataFlowPrivate::LambdaSelfReferenceNode n, Block b) {
     n.getCallable() = b
   }
 }

--- a/ruby/ql/lib/codeql/ruby/frameworks/Sinatra.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/Sinatra.qll
@@ -273,39 +273,19 @@ module Sinatra {
         filter.getApp() = route.getApp() and
         // the filter applies to all routes
         not filter.hasPattern() and
-        selfPostUpdate(pred, filter.getApp(), filter.getBody().asExpr().getExpr()) and
-        blockCapturedSelfParameterNode(succ, route.getBody().asExpr().getExpr())
+        blockPostUpdate(pred, filter.getBody()) and
+        blockSelfParameterNode(succ, route.getBody().asExpr().getExpr())
       )
     }
   }
 
-  /**
-   * Holds if `n` is a post-update node for the `self` parameter of `app` in block `b`.
-   *
-   * In this example, `n` is the post-update node for `@foo = 1`.
-   * ```rb
-   * class MyApp < Sinatra::Base
-   *   before do
-   *     @foo = 1
-   *   end
-   * end
-   * ```
-   */
-  private predicate selfPostUpdate(DataFlow::PostUpdateNode n, App app, Block b) {
-    n.getPreUpdateNode().asExpr().getExpr() =
-      any(SelfVariableAccess self |
-        pragma[only_bind_into](b) = self.getEnclosingCallable() and
-        self.getVariable().getDeclaringScope() = app.getADeclaration()
-      )
+  /** Holds if `n` is a post-update node for the block `b`. */
+  private predicate blockPostUpdate(DataFlow::PostUpdateNode n, DataFlow::BlockNode b) {
+    n.getPreUpdateNode() = b
   }
 
-  /**
-   * Holds if `n` is a node representing the `self` parameter captured by block `b`.
-   */
-  private predicate blockCapturedSelfParameterNode(DataFlow::Node n, Block b) {
-    exists(Ssa::CapturedSelfDefinition d |
-      n.(DataFlowPrivate::SsaDefinitionExtNode).getDefinitionExt() = d and
-      d.getBasicBlock().getScope() = b
-    )
+  /** Holds if `n` is a `self` parameter belonging to block `b`. */
+  private predicate blockSelfParameterNode(DataFlowPrivate::LambdaSelfParameterNode n, Block b) {
+    n.getCallable() = b
   }
 }

--- a/ruby/ql/lib/codeql/ruby/frameworks/data/internal/ApiGraphModelsSpecific.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/data/internal/ApiGraphModelsSpecific.qll
@@ -243,7 +243,7 @@ predicate isExtraValidTokenArgumentInIdentifyingAccessPath(string name, string a
   or
   name = ["Argument", "Parameter"] and
   (
-    argument = ["self", "block", "any", "any-named"]
+    argument = ["self", "lambda-self", "block", "any", "any-named"]
     or
     argument.regexpMatch("\\w+:") // keyword argument
   )

--- a/ruby/ql/lib/codeql/ruby/typetracking/TypeTrackerSpecific.qll
+++ b/ruby/ql/lib/codeql/ruby/typetracking/TypeTrackerSpecific.qll
@@ -6,7 +6,6 @@ private import codeql.ruby.dataflow.internal.DataFlowImplCommon as DataFlowImplC
 private import codeql.ruby.dataflow.internal.DataFlowPublic as DataFlowPublic
 private import codeql.ruby.dataflow.internal.DataFlowPrivate as DataFlowPrivate
 private import codeql.ruby.dataflow.internal.DataFlowDispatch as DataFlowDispatch
-private import codeql.ruby.dataflow.internal.SsaImpl as SsaImpl
 private import codeql.ruby.dataflow.internal.FlowSummaryImpl as FlowSummaryImpl
 private import codeql.ruby.dataflow.internal.FlowSummaryImplSpecific as FlowSummaryImplSpecific
 private import codeql.ruby.dataflow.internal.AccessPathSyntax
@@ -74,7 +73,7 @@ predicate simpleLocalFlowStep = DataFlowPrivate::localFlowStepTypeTracker/2;
 /**
  * Holds if data can flow from `node1` to `node2` in a way that discards call contexts.
  */
-predicate jumpStep = DataFlowPrivate::jumpStepTypeTracker/2;
+predicate jumpStep = DataFlowPrivate::jumpStep/2;
 
 /** Holds if there is direct flow from `param` to a return. */
 pragma[nomagic]
@@ -180,6 +179,7 @@ private predicate argumentPositionMatch(
 ) {
   exists(DataFlowDispatch::ArgumentPosition apos |
     arg.sourceArgumentOf(call, apos) and
+    not apos.isLambdaSelf() and
     DataFlowDispatch::parameterMatch(ppos, apos)
   )
 }

--- a/ruby/ql/test/library-tests/dataflow/array-flow/array-flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/array-flow/array-flow.expected
@@ -450,10 +450,10 @@ edges
 | array_flow.rb:403:5:403:5 | a [element 2] | array_flow.rb:404:18:404:18 | a [element 2] |
 | array_flow.rb:403:16:403:25 | call to source | array_flow.rb:403:5:403:5 | a [element 2] |
 | array_flow.rb:404:5:404:5 | b [element 2] | array_flow.rb:408:10:408:10 | b [element 2] |
-| array_flow.rb:404:9:406:7 | __synth__0__1 | array_flow.rb:404:13:404:13 | x |
-| array_flow.rb:404:13:404:13 | x | array_flow.rb:405:14:405:14 | x |
-| array_flow.rb:404:13:404:13 | x | array_flow.rb:407:10:407:10 | x |
+| array_flow.rb:404:9:406:7 | [post] { ... } [captured x] | array_flow.rb:407:10:407:10 | x |
+| array_flow.rb:404:9:406:7 | __synth__0__1 | array_flow.rb:405:14:405:14 | x |
 | array_flow.rb:404:18:404:18 | a [element 2] | array_flow.rb:404:5:404:5 | b [element 2] |
+| array_flow.rb:404:18:404:18 | a [element 2] | array_flow.rb:404:9:406:7 | [post] { ... } [captured x] |
 | array_flow.rb:404:18:404:18 | a [element 2] | array_flow.rb:404:9:406:7 | __synth__0__1 |
 | array_flow.rb:408:10:408:10 | b [element 2] | array_flow.rb:408:10:408:13 | ...[...] |
 | array_flow.rb:412:5:412:5 | a [element 2] | array_flow.rb:413:5:413:5 | a [element 2] |
@@ -2609,8 +2609,8 @@ nodes
 | array_flow.rb:403:5:403:5 | a [element 2] | semmle.label | a [element 2] |
 | array_flow.rb:403:16:403:25 | call to source | semmle.label | call to source |
 | array_flow.rb:404:5:404:5 | b [element 2] | semmle.label | b [element 2] |
+| array_flow.rb:404:9:406:7 | [post] { ... } [captured x] | semmle.label | [post] { ... } [captured x] |
 | array_flow.rb:404:9:406:7 | __synth__0__1 | semmle.label | __synth__0__1 |
-| array_flow.rb:404:13:404:13 | x | semmle.label | x |
 | array_flow.rb:404:18:404:18 | a [element 2] | semmle.label | a [element 2] |
 | array_flow.rb:405:14:405:14 | x | semmle.label | x |
 | array_flow.rb:407:10:407:10 | x | semmle.label | x |

--- a/ruby/ql/test/library-tests/dataflow/call-sensitivity/call-sensitivity.expected
+++ b/ruby/ql/test/library-tests/dataflow/call-sensitivity/call-sensitivity.expected
@@ -32,7 +32,8 @@ edges
 | call_sensitivity.rb:66:20:66:20 | x | call_sensitivity.rb:67:24:67:24 | x |
 | call_sensitivity.rb:67:24:67:24 | x | call_sensitivity.rb:62:18:62:18 | y |
 | call_sensitivity.rb:70:30:70:30 | x | call_sensitivity.rb:71:10:71:10 | x |
-| call_sensitivity.rb:74:18:74:18 | y | call_sensitivity.rb:76:17:76:17 | y |
+| call_sensitivity.rb:74:18:74:18 | y | call_sensitivity.rb:75:20:77:7 | do ... end [captured y] |
+| call_sensitivity.rb:75:20:77:7 | do ... end [captured y] | call_sensitivity.rb:76:17:76:17 | y |
 | call_sensitivity.rb:76:17:76:17 | y | call_sensitivity.rb:50:15:50:15 | x |
 | call_sensitivity.rb:80:15:80:15 | x | call_sensitivity.rb:81:18:81:18 | x |
 | call_sensitivity.rb:81:18:81:18 | x | call_sensitivity.rb:50:15:50:15 | x |
@@ -121,6 +122,7 @@ nodes
 | call_sensitivity.rb:70:30:70:30 | x | semmle.label | x |
 | call_sensitivity.rb:71:10:71:10 | x | semmle.label | x |
 | call_sensitivity.rb:74:18:74:18 | y | semmle.label | y |
+| call_sensitivity.rb:75:20:77:7 | do ... end [captured y] | semmle.label | do ... end [captured y] |
 | call_sensitivity.rb:76:17:76:17 | y | semmle.label | y |
 | call_sensitivity.rb:80:15:80:15 | x | semmle.label | x |
 | call_sensitivity.rb:81:18:81:18 | x | semmle.label | x |

--- a/ruby/ql/test/library-tests/dataflow/global/Flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/global/Flow.expected
@@ -1,49 +1,115 @@
 testFailures
 edges
-| captured_variables.rb:9:24:9:24 | x | captured_variables.rb:10:20:10:20 | x |
+| captured_variables.rb:9:24:9:24 | x | captured_variables.rb:10:10:10:23 | -> { ... } [captured x] |
+| captured_variables.rb:9:24:9:24 | x | captured_variables.rb:11:5:11:6 | fn [captured x] |
+| captured_variables.rb:10:5:10:6 | fn [captured x] | captured_variables.rb:11:5:11:6 | fn [captured x] |
+| captured_variables.rb:10:10:10:23 | -> { ... } [captured x] | captured_variables.rb:10:5:10:6 | fn [captured x] |
+| captured_variables.rb:11:5:11:6 | fn [captured x] | captured_variables.rb:10:20:10:20 | x |
 | captured_variables.rb:13:20:13:29 | call to taint | captured_variables.rb:9:24:9:24 | x |
-| captured_variables.rb:29:33:29:33 | x | captured_variables.rb:31:14:31:14 | x |
+| captured_variables.rb:15:28:15:28 | x | captured_variables.rb:16:5:18:5 | -> { ... } [captured x] |
+| captured_variables.rb:20:1:20:35 | ( ... ) [captured x] | captured_variables.rb:17:14:17:14 | x |
+| captured_variables.rb:20:2:20:34 | call to capture_escape_return1 [captured x] | captured_variables.rb:20:1:20:35 | ( ... ) [captured x] |
+| captured_variables.rb:20:25:20:34 | call to taint | captured_variables.rb:15:28:15:28 | x |
+| captured_variables.rb:20:25:20:34 | call to taint | captured_variables.rb:20:2:20:34 | call to capture_escape_return1 [captured x] |
+| captured_variables.rb:22:28:22:28 | x | captured_variables.rb:23:5:25:5 | -> { ... } [captured x] |
+| captured_variables.rb:27:25:27:57 | call to capture_escape_return2 [captured x] | captured_variables.rb:24:14:24:14 | x |
+| captured_variables.rb:27:48:27:57 | call to taint | captured_variables.rb:22:28:22:28 | x |
+| captured_variables.rb:27:48:27:57 | call to taint | captured_variables.rb:27:25:27:57 | call to capture_escape_return2 [captured x] |
+| captured_variables.rb:29:33:29:33 | x | captured_variables.rb:30:10:32:5 | -> { ... } [captured x] |
+| captured_variables.rb:29:33:29:33 | x | captured_variables.rb:33:29:33:30 | fn [captured x] |
+| captured_variables.rb:30:5:30:6 | fn [captured x] | captured_variables.rb:33:29:33:30 | fn [captured x] |
+| captured_variables.rb:30:10:32:5 | -> { ... } [captured x] | captured_variables.rb:30:5:30:6 | fn [captured x] |
+| captured_variables.rb:33:29:33:30 | fn [captured x] | captured_variables.rb:31:14:31:14 | x |
 | captured_variables.rb:35:29:35:38 | call to taint | captured_variables.rb:29:33:29:33 | x |
-| captured_variables.rb:40:31:40:31 | x | captured_variables.rb:42:14:42:14 | x |
+| captured_variables.rb:37:13:37:14 | fn [captured x] | captured_variables.rb:38:5:38:6 | fn [captured x] |
+| captured_variables.rb:38:5:38:6 | fn [captured x] | captured_variables.rb:42:14:42:14 | x |
+| captured_variables.rb:40:31:40:31 | x | captured_variables.rb:41:10:43:5 | -> { ... } [captured x] |
+| captured_variables.rb:40:31:40:31 | x | captured_variables.rb:44:13:44:14 | fn [captured x] |
+| captured_variables.rb:41:5:41:6 | fn [captured x] | captured_variables.rb:44:13:44:14 | fn [captured x] |
+| captured_variables.rb:41:10:43:5 | -> { ... } [captured x] | captured_variables.rb:41:5:41:6 | fn [captured x] |
+| captured_variables.rb:44:13:44:14 | fn [captured x] | captured_variables.rb:37:13:37:14 | fn [captured x] |
 | captured_variables.rb:46:27:46:36 | call to taint | captured_variables.rb:40:31:40:31 | x |
-| captured_variables.rb:48:1:48:1 | x | captured_variables.rb:50:10:50:10 | x |
-| captured_variables.rb:48:5:48:12 | call to taint | captured_variables.rb:48:1:48:1 | x |
-| captured_variables.rb:51:5:51:5 | x | captured_variables.rb:54:6:54:6 | x |
-| captured_variables.rb:51:9:51:16 | call to taint | captured_variables.rb:51:5:51:5 | x |
+| captured_variables.rb:48:5:48:12 | call to taint | captured_variables.rb:49:16:52:3 | do ... end [captured x] |
+| captured_variables.rb:48:5:48:12 | call to taint | captured_variables.rb:54:6:54:6 | x |
+| captured_variables.rb:49:16:52:3 | [post] do ... end [captured x] | captured_variables.rb:54:6:54:6 | x |
+| captured_variables.rb:49:16:52:3 | do ... end [captured x] | captured_variables.rb:50:10:50:10 | x |
+| captured_variables.rb:51:9:51:16 | call to taint | captured_variables.rb:49:16:52:3 | [post] do ... end [captured x] |
 | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:58:18:58:18 | x |
 | captured_variables.rb:58:18:58:18 | x | captured_variables.rb:58:9:58:14 | [post] self [@field] |
 | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:16:61:21 | self [@field] |
 | captured_variables.rb:61:16:61:21 | @field | captured_variables.rb:61:9:61:21 | return |
 | captured_variables.rb:61:16:61:21 | self [@field] | captured_variables.rb:61:16:61:21 | @field |
+| captured_variables.rb:66:1:66:3 | [post] foo [@field] | captured_variables.rb:67:16:70:3 | do ... end [captured foo, @field] |
 | captured_variables.rb:66:1:66:3 | [post] foo [@field] | captured_variables.rb:72:6:72:8 | foo [@field] |
 | captured_variables.rb:66:15:66:22 | call to taint | captured_variables.rb:57:19:57:19 | x |
 | captured_variables.rb:66:15:66:22 | call to taint | captured_variables.rb:66:1:66:3 | [post] foo [@field] |
 | captured_variables.rb:66:15:66:22 | call to taint | instance_variables.rb:10:19:10:19 | x |
+| captured_variables.rb:67:16:70:3 | [post] do ... end [captured foo, @field] | captured_variables.rb:72:6:72:8 | foo [@field] |
+| captured_variables.rb:67:16:70:3 | do ... end [captured foo, @field] | captured_variables.rb:68:10:68:12 | foo [@field] |
+| captured_variables.rb:68:10:68:12 | foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] |
+| captured_variables.rb:68:10:68:12 | foo [@field] | captured_variables.rb:68:10:68:22 | call to get_field |
+| captured_variables.rb:68:10:68:12 | foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] |
+| captured_variables.rb:69:5:69:7 | [post] foo [@field] | captured_variables.rb:67:16:70:3 | [post] do ... end [captured foo, @field] |
+| captured_variables.rb:69:19:69:26 | call to taint | captured_variables.rb:57:19:57:19 | x |
+| captured_variables.rb:69:19:69:26 | call to taint | captured_variables.rb:69:5:69:7 | [post] foo [@field] |
+| captured_variables.rb:69:19:69:26 | call to taint | instance_variables.rb:10:19:10:19 | x |
 | captured_variables.rb:72:6:72:8 | foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] |
 | captured_variables.rb:72:6:72:8 | foo [@field] | captured_variables.rb:72:6:72:18 | call to get_field |
 | captured_variables.rb:72:6:72:8 | foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] |
-| captured_variables.rb:85:1:85:1 | y | captured_variables.rb:87:10:87:10 | y |
-| captured_variables.rb:85:5:85:12 | call to taint | captured_variables.rb:85:1:85:1 | y |
-| captured_variables.rb:88:5:88:5 | y | captured_variables.rb:87:10:87:10 | y |
-| captured_variables.rb:88:5:88:5 | y | captured_variables.rb:91:6:91:6 | y |
-| captured_variables.rb:88:9:88:16 | call to taint | captured_variables.rb:88:5:88:5 | y |
+| captured_variables.rb:78:20:80:7 | [post] do ... end [captured foo, @field] | captured_variables.rb:83:6:83:8 | foo [@field] |
+| captured_variables.rb:79:9:79:11 | [post] foo [@field] | captured_variables.rb:78:20:80:7 | [post] do ... end [captured foo, @field] |
+| captured_variables.rb:79:23:79:30 | call to taint | captured_variables.rb:57:19:57:19 | x |
+| captured_variables.rb:79:23:79:30 | call to taint | captured_variables.rb:79:9:79:11 | [post] foo [@field] |
+| captured_variables.rb:79:23:79:30 | call to taint | instance_variables.rb:10:19:10:19 | x |
+| captured_variables.rb:83:6:83:8 | foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] |
+| captured_variables.rb:83:6:83:8 | foo [@field] | captured_variables.rb:83:6:83:18 | call to get_field |
+| captured_variables.rb:83:6:83:8 | foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] |
+| captured_variables.rb:85:5:85:12 | call to taint | captured_variables.rb:86:6:89:1 | -> { ... } [captured y] |
+| captured_variables.rb:85:5:85:12 | call to taint | captured_variables.rb:90:1:90:2 | fn [captured y] |
+| captured_variables.rb:85:5:85:12 | call to taint | captured_variables.rb:91:6:91:6 | y |
+| captured_variables.rb:86:1:86:2 | fn [captured y] | captured_variables.rb:90:1:90:2 | fn [captured y] |
+| captured_variables.rb:86:6:89:1 | -> { ... } [captured y] | captured_variables.rb:86:1:86:2 | fn [captured y] |
+| captured_variables.rb:88:9:88:16 | call to taint | captured_variables.rb:90:1:90:2 | [post] fn [captured y] |
+| captured_variables.rb:90:1:90:2 | [post] fn [captured y] | captured_variables.rb:91:6:91:6 | y |
+| captured_variables.rb:90:1:90:2 | fn [captured y] | captured_variables.rb:87:10:87:10 | y |
+| captured_variables.rb:93:17:93:17 | x | captured_variables.rb:94:5:96:5 | -> { ... } [captured x] |
+| captured_variables.rb:98:1:98:21 | call to capture_arg [captured x] | captured_variables.rb:95:14:95:14 | x |
+| captured_variables.rb:98:13:98:20 | call to taint | captured_variables.rb:93:17:93:17 | x |
+| captured_variables.rb:98:13:98:20 | call to taint | captured_variables.rb:98:1:98:21 | call to capture_arg [captured x] |
 | captured_variables.rb:100:21:100:21 | x | captured_variables.rb:101:11:101:11 | x |
 | captured_variables.rb:101:11:101:11 | x | captured_variables.rb:104:31:104:31 | x |
 | captured_variables.rb:104:17:104:24 | call to taint | captured_variables.rb:100:21:100:21 | x |
 | captured_variables.rb:104:31:104:31 | x | captured_variables.rb:105:10:105:10 | x |
-| captured_variables.rb:109:5:109:5 | x | captured_variables.rb:112:18:112:18 | x |
-| captured_variables.rb:109:9:109:17 | call to taint | captured_variables.rb:109:5:109:5 | x |
-| captured_variables.rb:113:13:113:13 | x | captured_variables.rb:112:18:112:18 | x |
-| captured_variables.rb:113:13:113:13 | x | captured_variables.rb:118:10:118:10 | x |
-| captured_variables.rb:113:17:113:25 | call to taint | captured_variables.rb:113:13:113:13 | x |
+| captured_variables.rb:109:9:109:17 | call to taint | captured_variables.rb:110:14:116:5 | -> { ... } [captured x] |
+| captured_variables.rb:109:9:109:17 | call to taint | captured_variables.rb:117:5:117:10 | middle [captured x] |
+| captured_variables.rb:109:9:109:17 | call to taint | captured_variables.rb:118:10:118:10 | x |
+| captured_variables.rb:110:5:110:10 | middle [captured x] | captured_variables.rb:117:5:117:10 | middle [captured x] |
+| captured_variables.rb:110:14:116:5 | -> { ... } [captured x] | captured_variables.rb:110:5:110:10 | middle [captured x] |
+| captured_variables.rb:111:9:111:13 | inner [captured x] | captured_variables.rb:115:9:115:13 | inner [captured x] |
+| captured_variables.rb:111:17:114:9 | -> { ... } [captured x] | captured_variables.rb:111:9:111:13 | inner [captured x] |
+| captured_variables.rb:113:17:113:25 | call to taint | captured_variables.rb:115:9:115:13 | [post] inner [captured x] |
+| captured_variables.rb:115:9:115:13 | [post] inner [captured x] | captured_variables.rb:117:5:117:10 | [post] middle [captured x] |
+| captured_variables.rb:115:9:115:13 | inner [captured x] | captured_variables.rb:112:18:112:18 | x |
+| captured_variables.rb:117:5:117:10 | [post] middle [captured x] | captured_variables.rb:118:10:118:10 | x |
+| captured_variables.rb:117:5:117:10 | middle [captured x] | captured_variables.rb:111:17:114:9 | -> { ... } [captured x] |
+| captured_variables.rb:117:5:117:10 | middle [captured x] | captured_variables.rb:115:9:115:13 | inner [captured x] |
+| captured_variables.rb:147:5:147:6 | [post] self [@x] | captured_variables.rb:153:14:155:7 | do ... end [captured self, @x] |
+| captured_variables.rb:147:10:147:18 | call to taint | captured_variables.rb:147:5:147:6 | [post] self [@x] |
+| captured_variables.rb:149:5:151:7 | &block [captured self, @x] | captured_variables.rb:154:14:154:15 | self [@x] |
+| captured_variables.rb:153:14:155:7 | do ... end [captured self, @x] | captured_variables.rb:149:5:151:7 | &block [captured self, @x] |
+| captured_variables.rb:154:14:154:15 | self [@x] | captured_variables.rb:154:14:154:15 | @x |
 | captured_variables.rb:160:9:160:10 | [post] self [@x] | captured_variables.rb:174:1:174:24 | call to new [@x] |
 | captured_variables.rb:160:14:160:22 | call to taint | captured_variables.rb:160:9:160:10 | [post] self [@x] |
-| captured_variables.rb:167:5:171:7 | self in baz [@x] | captured_variables.rb:169:18:169:19 | self [@x] |
+| captured_variables.rb:163:5:165:7 | &block [captured self, @x] | captured_variables.rb:169:18:169:19 | self [@x] |
+| captured_variables.rb:167:5:171:7 | self in baz [@x] | captured_variables.rb:168:18:170:11 | do ... end [captured self, @x] |
+| captured_variables.rb:168:18:170:11 | do ... end [captured self, @x] | captured_variables.rb:163:5:165:7 | &block [captured self, @x] |
 | captured_variables.rb:169:18:169:19 | self [@x] | captured_variables.rb:169:18:169:19 | @x |
 | captured_variables.rb:174:1:174:24 | call to new [@x] | captured_variables.rb:167:5:171:7 | self in baz [@x] |
 | captured_variables.rb:178:9:178:10 | [post] self [@x] | captured_variables.rb:193:1:193:1 | [post] c [@x] |
 | captured_variables.rb:178:14:178:22 | call to taint | captured_variables.rb:178:9:178:10 | [post] self [@x] |
-| captured_variables.rb:185:5:189:7 | self in baz [@x] | captured_variables.rb:187:18:187:19 | self [@x] |
+| captured_variables.rb:181:5:183:7 | &block [captured self, @x] | captured_variables.rb:187:18:187:19 | self [@x] |
+| captured_variables.rb:185:5:189:7 | self in baz [@x] | captured_variables.rb:186:18:188:11 | do ... end [captured self, @x] |
+| captured_variables.rb:186:18:188:11 | do ... end [captured self, @x] | captured_variables.rb:181:5:183:7 | &block [captured self, @x] |
 | captured_variables.rb:187:18:187:19 | self [@x] | captured_variables.rb:187:18:187:19 | @x |
 | captured_variables.rb:193:1:193:1 | [post] c [@x] | captured_variables.rb:194:1:194:1 | c [@x] |
 | captured_variables.rb:194:1:194:1 | c [@x] | captured_variables.rb:185:5:189:7 | self in baz [@x] |
@@ -188,18 +254,40 @@ edges
 | instance_variables.rb:121:7:121:24 | call to new | instance_variables.rb:121:1:121:3 | bar |
 nodes
 | captured_variables.rb:9:24:9:24 | x | semmle.label | x |
+| captured_variables.rb:10:5:10:6 | fn [captured x] | semmle.label | fn [captured x] |
+| captured_variables.rb:10:10:10:23 | -> { ... } [captured x] | semmle.label | -> { ... } [captured x] |
 | captured_variables.rb:10:20:10:20 | x | semmle.label | x |
+| captured_variables.rb:11:5:11:6 | fn [captured x] | semmle.label | fn [captured x] |
 | captured_variables.rb:13:20:13:29 | call to taint | semmle.label | call to taint |
+| captured_variables.rb:15:28:15:28 | x | semmle.label | x |
+| captured_variables.rb:16:5:18:5 | -> { ... } [captured x] | semmle.label | -> { ... } [captured x] |
+| captured_variables.rb:17:14:17:14 | x | semmle.label | x |
+| captured_variables.rb:20:1:20:35 | ( ... ) [captured x] | semmle.label | ( ... ) [captured x] |
+| captured_variables.rb:20:2:20:34 | call to capture_escape_return1 [captured x] | semmle.label | call to capture_escape_return1 [captured x] |
+| captured_variables.rb:20:25:20:34 | call to taint | semmle.label | call to taint |
+| captured_variables.rb:22:28:22:28 | x | semmle.label | x |
+| captured_variables.rb:23:5:25:5 | -> { ... } [captured x] | semmle.label | -> { ... } [captured x] |
+| captured_variables.rb:24:14:24:14 | x | semmle.label | x |
+| captured_variables.rb:27:25:27:57 | call to capture_escape_return2 [captured x] | semmle.label | call to capture_escape_return2 [captured x] |
+| captured_variables.rb:27:48:27:57 | call to taint | semmle.label | call to taint |
 | captured_variables.rb:29:33:29:33 | x | semmle.label | x |
+| captured_variables.rb:30:5:30:6 | fn [captured x] | semmle.label | fn [captured x] |
+| captured_variables.rb:30:10:32:5 | -> { ... } [captured x] | semmle.label | -> { ... } [captured x] |
 | captured_variables.rb:31:14:31:14 | x | semmle.label | x |
+| captured_variables.rb:33:29:33:30 | fn [captured x] | semmle.label | fn [captured x] |
 | captured_variables.rb:35:29:35:38 | call to taint | semmle.label | call to taint |
+| captured_variables.rb:37:13:37:14 | fn [captured x] | semmle.label | fn [captured x] |
+| captured_variables.rb:38:5:38:6 | fn [captured x] | semmle.label | fn [captured x] |
 | captured_variables.rb:40:31:40:31 | x | semmle.label | x |
+| captured_variables.rb:41:5:41:6 | fn [captured x] | semmle.label | fn [captured x] |
+| captured_variables.rb:41:10:43:5 | -> { ... } [captured x] | semmle.label | -> { ... } [captured x] |
 | captured_variables.rb:42:14:42:14 | x | semmle.label | x |
+| captured_variables.rb:44:13:44:14 | fn [captured x] | semmle.label | fn [captured x] |
 | captured_variables.rb:46:27:46:36 | call to taint | semmle.label | call to taint |
-| captured_variables.rb:48:1:48:1 | x | semmle.label | x |
 | captured_variables.rb:48:5:48:12 | call to taint | semmle.label | call to taint |
+| captured_variables.rb:49:16:52:3 | [post] do ... end [captured x] | semmle.label | [post] do ... end [captured x] |
+| captured_variables.rb:49:16:52:3 | do ... end [captured x] | semmle.label | do ... end [captured x] |
 | captured_variables.rb:50:10:50:10 | x | semmle.label | x |
-| captured_variables.rb:51:5:51:5 | x | semmle.label | x |
 | captured_variables.rb:51:9:51:16 | call to taint | semmle.label | call to taint |
 | captured_variables.rb:54:6:54:6 | x | semmle.label | x |
 | captured_variables.rb:57:19:57:19 | x | semmle.label | x |
@@ -211,34 +299,68 @@ nodes
 | captured_variables.rb:61:16:61:21 | self [@field] | semmle.label | self [@field] |
 | captured_variables.rb:66:1:66:3 | [post] foo [@field] | semmle.label | [post] foo [@field] |
 | captured_variables.rb:66:15:66:22 | call to taint | semmle.label | call to taint |
+| captured_variables.rb:67:16:70:3 | [post] do ... end [captured foo, @field] | semmle.label | [post] do ... end [captured foo, @field] |
+| captured_variables.rb:67:16:70:3 | do ... end [captured foo, @field] | semmle.label | do ... end [captured foo, @field] |
+| captured_variables.rb:68:10:68:12 | foo [@field] | semmle.label | foo [@field] |
+| captured_variables.rb:68:10:68:22 | call to get_field | semmle.label | call to get_field |
+| captured_variables.rb:69:5:69:7 | [post] foo [@field] | semmle.label | [post] foo [@field] |
+| captured_variables.rb:69:19:69:26 | call to taint | semmle.label | call to taint |
 | captured_variables.rb:72:6:72:8 | foo [@field] | semmle.label | foo [@field] |
 | captured_variables.rb:72:6:72:18 | call to get_field | semmle.label | call to get_field |
-| captured_variables.rb:85:1:85:1 | y | semmle.label | y |
+| captured_variables.rb:78:20:80:7 | [post] do ... end [captured foo, @field] | semmle.label | [post] do ... end [captured foo, @field] |
+| captured_variables.rb:79:9:79:11 | [post] foo [@field] | semmle.label | [post] foo [@field] |
+| captured_variables.rb:79:23:79:30 | call to taint | semmle.label | call to taint |
+| captured_variables.rb:83:6:83:8 | foo [@field] | semmle.label | foo [@field] |
+| captured_variables.rb:83:6:83:18 | call to get_field | semmle.label | call to get_field |
 | captured_variables.rb:85:5:85:12 | call to taint | semmle.label | call to taint |
+| captured_variables.rb:86:1:86:2 | fn [captured y] | semmle.label | fn [captured y] |
+| captured_variables.rb:86:6:89:1 | -> { ... } [captured y] | semmle.label | -> { ... } [captured y] |
 | captured_variables.rb:87:10:87:10 | y | semmle.label | y |
-| captured_variables.rb:88:5:88:5 | y | semmle.label | y |
 | captured_variables.rb:88:9:88:16 | call to taint | semmle.label | call to taint |
+| captured_variables.rb:90:1:90:2 | [post] fn [captured y] | semmle.label | [post] fn [captured y] |
+| captured_variables.rb:90:1:90:2 | fn [captured y] | semmle.label | fn [captured y] |
 | captured_variables.rb:91:6:91:6 | y | semmle.label | y |
+| captured_variables.rb:93:17:93:17 | x | semmle.label | x |
+| captured_variables.rb:94:5:96:5 | -> { ... } [captured x] | semmle.label | -> { ... } [captured x] |
+| captured_variables.rb:95:14:95:14 | x | semmle.label | x |
+| captured_variables.rb:98:1:98:21 | call to capture_arg [captured x] | semmle.label | call to capture_arg [captured x] |
+| captured_variables.rb:98:13:98:20 | call to taint | semmle.label | call to taint |
 | captured_variables.rb:100:21:100:21 | x | semmle.label | x |
 | captured_variables.rb:101:11:101:11 | x | semmle.label | x |
 | captured_variables.rb:104:17:104:24 | call to taint | semmle.label | call to taint |
 | captured_variables.rb:104:31:104:31 | x | semmle.label | x |
 | captured_variables.rb:105:10:105:10 | x | semmle.label | x |
-| captured_variables.rb:109:5:109:5 | x | semmle.label | x |
 | captured_variables.rb:109:9:109:17 | call to taint | semmle.label | call to taint |
+| captured_variables.rb:110:5:110:10 | middle [captured x] | semmle.label | middle [captured x] |
+| captured_variables.rb:110:14:116:5 | -> { ... } [captured x] | semmle.label | -> { ... } [captured x] |
+| captured_variables.rb:111:9:111:13 | inner [captured x] | semmle.label | inner [captured x] |
+| captured_variables.rb:111:17:114:9 | -> { ... } [captured x] | semmle.label | -> { ... } [captured x] |
 | captured_variables.rb:112:18:112:18 | x | semmle.label | x |
-| captured_variables.rb:113:13:113:13 | x | semmle.label | x |
 | captured_variables.rb:113:17:113:25 | call to taint | semmle.label | call to taint |
+| captured_variables.rb:115:9:115:13 | [post] inner [captured x] | semmle.label | [post] inner [captured x] |
+| captured_variables.rb:115:9:115:13 | inner [captured x] | semmle.label | inner [captured x] |
+| captured_variables.rb:117:5:117:10 | [post] middle [captured x] | semmle.label | [post] middle [captured x] |
+| captured_variables.rb:117:5:117:10 | middle [captured x] | semmle.label | middle [captured x] |
 | captured_variables.rb:118:10:118:10 | x | semmle.label | x |
+| captured_variables.rb:147:5:147:6 | [post] self [@x] | semmle.label | [post] self [@x] |
+| captured_variables.rb:147:10:147:18 | call to taint | semmle.label | call to taint |
+| captured_variables.rb:149:5:151:7 | &block [captured self, @x] | semmle.label | &block [captured self, @x] |
+| captured_variables.rb:153:14:155:7 | do ... end [captured self, @x] | semmle.label | do ... end [captured self, @x] |
+| captured_variables.rb:154:14:154:15 | @x | semmle.label | @x |
+| captured_variables.rb:154:14:154:15 | self [@x] | semmle.label | self [@x] |
 | captured_variables.rb:160:9:160:10 | [post] self [@x] | semmle.label | [post] self [@x] |
 | captured_variables.rb:160:14:160:22 | call to taint | semmle.label | call to taint |
+| captured_variables.rb:163:5:165:7 | &block [captured self, @x] | semmle.label | &block [captured self, @x] |
 | captured_variables.rb:167:5:171:7 | self in baz [@x] | semmle.label | self in baz [@x] |
+| captured_variables.rb:168:18:170:11 | do ... end [captured self, @x] | semmle.label | do ... end [captured self, @x] |
 | captured_variables.rb:169:18:169:19 | @x | semmle.label | @x |
 | captured_variables.rb:169:18:169:19 | self [@x] | semmle.label | self [@x] |
 | captured_variables.rb:174:1:174:24 | call to new [@x] | semmle.label | call to new [@x] |
 | captured_variables.rb:178:9:178:10 | [post] self [@x] | semmle.label | [post] self [@x] |
 | captured_variables.rb:178:14:178:22 | call to taint | semmle.label | call to taint |
+| captured_variables.rb:181:5:183:7 | &block [captured self, @x] | semmle.label | &block [captured self, @x] |
 | captured_variables.rb:185:5:189:7 | self in baz [@x] | semmle.label | self in baz [@x] |
+| captured_variables.rb:186:18:188:11 | do ... end [captured self, @x] | semmle.label | do ... end [captured self, @x] |
 | captured_variables.rb:187:18:187:19 | @x | semmle.label | @x |
 | captured_variables.rb:187:18:187:19 | self [@x] | semmle.label | self [@x] |
 | captured_variables.rb:193:1:193:1 | [post] c [@x] | semmle.label | [post] c [@x] |
@@ -348,10 +470,21 @@ nodes
 | instance_variables.rb:121:7:121:24 | call to new | semmle.label | call to new |
 | instance_variables.rb:122:6:122:8 | bar | semmle.label | bar |
 subpaths
+| captured_variables.rb:20:25:20:34 | call to taint | captured_variables.rb:15:28:15:28 | x | captured_variables.rb:16:5:18:5 | -> { ... } [captured x] | captured_variables.rb:20:2:20:34 | call to capture_escape_return1 [captured x] |
+| captured_variables.rb:27:48:27:57 | call to taint | captured_variables.rb:22:28:22:28 | x | captured_variables.rb:23:5:25:5 | -> { ... } [captured x] | captured_variables.rb:27:25:27:57 | call to capture_escape_return2 [captured x] |
 | captured_variables.rb:66:15:66:22 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:58:9:58:14 | [post] self [@field] | captured_variables.rb:66:1:66:3 | [post] foo [@field] |
 | captured_variables.rb:66:15:66:22 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:11:9:11:14 | [post] self [@field] | captured_variables.rb:66:1:66:3 | [post] foo [@field] |
+| captured_variables.rb:68:10:68:12 | foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | captured_variables.rb:68:10:68:22 | call to get_field |
+| captured_variables.rb:68:10:68:12 | foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | captured_variables.rb:68:10:68:22 | call to get_field |
+| captured_variables.rb:69:19:69:26 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:58:9:58:14 | [post] self [@field] | captured_variables.rb:69:5:69:7 | [post] foo [@field] |
+| captured_variables.rb:69:19:69:26 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:11:9:11:14 | [post] self [@field] | captured_variables.rb:69:5:69:7 | [post] foo [@field] |
 | captured_variables.rb:72:6:72:8 | foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | captured_variables.rb:72:6:72:18 | call to get_field |
 | captured_variables.rb:72:6:72:8 | foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | captured_variables.rb:72:6:72:18 | call to get_field |
+| captured_variables.rb:79:23:79:30 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:58:9:58:14 | [post] self [@field] | captured_variables.rb:79:9:79:11 | [post] foo [@field] |
+| captured_variables.rb:79:23:79:30 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:11:9:11:14 | [post] self [@field] | captured_variables.rb:79:9:79:11 | [post] foo [@field] |
+| captured_variables.rb:83:6:83:8 | foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | captured_variables.rb:83:6:83:18 | call to get_field |
+| captured_variables.rb:83:6:83:8 | foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | captured_variables.rb:83:6:83:18 | call to get_field |
+| captured_variables.rb:98:13:98:20 | call to taint | captured_variables.rb:93:17:93:17 | x | captured_variables.rb:94:5:96:5 | -> { ... } [captured x] | captured_variables.rb:98:1:98:21 | call to capture_arg [captured x] |
 | instance_variables.rb:28:20:28:24 | field | instance_variables.rb:22:20:22:24 | field | instance_variables.rb:23:9:23:14 | [post] self [@field] | instance_variables.rb:28:9:28:25 | [post] self [@field] |
 | instance_variables.rb:33:13:33:13 | x | instance_variables.rb:22:20:22:24 | field | instance_variables.rb:23:9:23:14 | [post] self [@field] | instance_variables.rb:33:9:33:14 | call to new [@field] |
 | instance_variables.rb:36:10:36:23 | call to new [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:36:10:36:33 | call to get_field |
@@ -416,18 +549,26 @@ subpaths
 | instance_variables.rb:120:6:120:10 | foo16 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:120:6:120:20 | call to get_field |
 #select
 | captured_variables.rb:10:20:10:20 | x | captured_variables.rb:13:20:13:29 | call to taint | captured_variables.rb:10:20:10:20 | x | $@ | captured_variables.rb:13:20:13:29 | call to taint | call to taint |
+| captured_variables.rb:17:14:17:14 | x | captured_variables.rb:20:25:20:34 | call to taint | captured_variables.rb:17:14:17:14 | x | $@ | captured_variables.rb:20:25:20:34 | call to taint | call to taint |
+| captured_variables.rb:24:14:24:14 | x | captured_variables.rb:27:48:27:57 | call to taint | captured_variables.rb:24:14:24:14 | x | $@ | captured_variables.rb:27:48:27:57 | call to taint | call to taint |
 | captured_variables.rb:31:14:31:14 | x | captured_variables.rb:35:29:35:38 | call to taint | captured_variables.rb:31:14:31:14 | x | $@ | captured_variables.rb:35:29:35:38 | call to taint | call to taint |
 | captured_variables.rb:42:14:42:14 | x | captured_variables.rb:46:27:46:36 | call to taint | captured_variables.rb:42:14:42:14 | x | $@ | captured_variables.rb:46:27:46:36 | call to taint | call to taint |
 | captured_variables.rb:50:10:50:10 | x | captured_variables.rb:48:5:48:12 | call to taint | captured_variables.rb:50:10:50:10 | x | $@ | captured_variables.rb:48:5:48:12 | call to taint | call to taint |
+| captured_variables.rb:54:6:54:6 | x | captured_variables.rb:48:5:48:12 | call to taint | captured_variables.rb:54:6:54:6 | x | $@ | captured_variables.rb:48:5:48:12 | call to taint | call to taint |
 | captured_variables.rb:54:6:54:6 | x | captured_variables.rb:51:9:51:16 | call to taint | captured_variables.rb:54:6:54:6 | x | $@ | captured_variables.rb:51:9:51:16 | call to taint | call to taint |
+| captured_variables.rb:68:10:68:22 | call to get_field | captured_variables.rb:66:15:66:22 | call to taint | captured_variables.rb:68:10:68:22 | call to get_field | $@ | captured_variables.rb:66:15:66:22 | call to taint | call to taint |
 | captured_variables.rb:72:6:72:18 | call to get_field | captured_variables.rb:66:15:66:22 | call to taint | captured_variables.rb:72:6:72:18 | call to get_field | $@ | captured_variables.rb:66:15:66:22 | call to taint | call to taint |
+| captured_variables.rb:72:6:72:18 | call to get_field | captured_variables.rb:69:19:69:26 | call to taint | captured_variables.rb:72:6:72:18 | call to get_field | $@ | captured_variables.rb:69:19:69:26 | call to taint | call to taint |
+| captured_variables.rb:83:6:83:18 | call to get_field | captured_variables.rb:79:23:79:30 | call to taint | captured_variables.rb:83:6:83:18 | call to get_field | $@ | captured_variables.rb:79:23:79:30 | call to taint | call to taint |
 | captured_variables.rb:87:10:87:10 | y | captured_variables.rb:85:5:85:12 | call to taint | captured_variables.rb:87:10:87:10 | y | $@ | captured_variables.rb:85:5:85:12 | call to taint | call to taint |
-| captured_variables.rb:87:10:87:10 | y | captured_variables.rb:88:9:88:16 | call to taint | captured_variables.rb:87:10:87:10 | y | $@ | captured_variables.rb:88:9:88:16 | call to taint | call to taint |
+| captured_variables.rb:91:6:91:6 | y | captured_variables.rb:85:5:85:12 | call to taint | captured_variables.rb:91:6:91:6 | y | $@ | captured_variables.rb:85:5:85:12 | call to taint | call to taint |
 | captured_variables.rb:91:6:91:6 | y | captured_variables.rb:88:9:88:16 | call to taint | captured_variables.rb:91:6:91:6 | y | $@ | captured_variables.rb:88:9:88:16 | call to taint | call to taint |
+| captured_variables.rb:95:14:95:14 | x | captured_variables.rb:98:13:98:20 | call to taint | captured_variables.rb:95:14:95:14 | x | $@ | captured_variables.rb:98:13:98:20 | call to taint | call to taint |
 | captured_variables.rb:105:10:105:10 | x | captured_variables.rb:104:17:104:24 | call to taint | captured_variables.rb:105:10:105:10 | x | $@ | captured_variables.rb:104:17:104:24 | call to taint | call to taint |
 | captured_variables.rb:112:18:112:18 | x | captured_variables.rb:109:9:109:17 | call to taint | captured_variables.rb:112:18:112:18 | x | $@ | captured_variables.rb:109:9:109:17 | call to taint | call to taint |
-| captured_variables.rb:112:18:112:18 | x | captured_variables.rb:113:17:113:25 | call to taint | captured_variables.rb:112:18:112:18 | x | $@ | captured_variables.rb:113:17:113:25 | call to taint | call to taint |
+| captured_variables.rb:118:10:118:10 | x | captured_variables.rb:109:9:109:17 | call to taint | captured_variables.rb:118:10:118:10 | x | $@ | captured_variables.rb:109:9:109:17 | call to taint | call to taint |
 | captured_variables.rb:118:10:118:10 | x | captured_variables.rb:113:17:113:25 | call to taint | captured_variables.rb:118:10:118:10 | x | $@ | captured_variables.rb:113:17:113:25 | call to taint | call to taint |
+| captured_variables.rb:154:14:154:15 | @x | captured_variables.rb:147:10:147:18 | call to taint | captured_variables.rb:154:14:154:15 | @x | $@ | captured_variables.rb:147:10:147:18 | call to taint | call to taint |
 | captured_variables.rb:169:18:169:19 | @x | captured_variables.rb:160:14:160:22 | call to taint | captured_variables.rb:169:18:169:19 | @x | $@ | captured_variables.rb:160:14:160:22 | call to taint | call to taint |
 | captured_variables.rb:187:18:187:19 | @x | captured_variables.rb:178:14:178:22 | call to taint | captured_variables.rb:187:18:187:19 | @x | $@ | captured_variables.rb:178:14:178:22 | call to taint | call to taint |
 | instance_variables.rb:20:10:20:13 | @foo | instance_variables.rb:19:12:19:21 | call to taint | instance_variables.rb:20:10:20:13 | @foo | $@ | instance_variables.rb:19:12:19:21 | call to taint | call to taint |

--- a/ruby/ql/test/library-tests/dataflow/global/Flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/global/Flow.expected
@@ -1,11 +1,52 @@
 testFailures
 edges
-| captured_variables.rb:1:24:1:24 | x | captured_variables.rb:2:20:2:20 | x |
-| captured_variables.rb:5:20:5:30 | call to source | captured_variables.rb:1:24:1:24 | x |
-| captured_variables.rb:21:33:21:33 | x | captured_variables.rb:23:14:23:14 | x |
-| captured_variables.rb:27:29:27:39 | call to source | captured_variables.rb:21:33:21:33 | x |
-| captured_variables.rb:32:31:32:31 | x | captured_variables.rb:34:14:34:14 | x |
-| captured_variables.rb:38:27:38:37 | call to source | captured_variables.rb:32:31:32:31 | x |
+| captured_variables.rb:9:24:9:24 | x | captured_variables.rb:10:20:10:20 | x |
+| captured_variables.rb:13:20:13:29 | call to taint | captured_variables.rb:9:24:9:24 | x |
+| captured_variables.rb:29:33:29:33 | x | captured_variables.rb:31:14:31:14 | x |
+| captured_variables.rb:35:29:35:38 | call to taint | captured_variables.rb:29:33:29:33 | x |
+| captured_variables.rb:40:31:40:31 | x | captured_variables.rb:42:14:42:14 | x |
+| captured_variables.rb:46:27:46:36 | call to taint | captured_variables.rb:40:31:40:31 | x |
+| captured_variables.rb:48:1:48:1 | x | captured_variables.rb:50:10:50:10 | x |
+| captured_variables.rb:48:5:48:12 | call to taint | captured_variables.rb:48:1:48:1 | x |
+| captured_variables.rb:51:5:51:5 | x | captured_variables.rb:54:6:54:6 | x |
+| captured_variables.rb:51:9:51:16 | call to taint | captured_variables.rb:51:5:51:5 | x |
+| captured_variables.rb:57:19:57:19 | x | captured_variables.rb:58:18:58:18 | x |
+| captured_variables.rb:58:18:58:18 | x | captured_variables.rb:58:9:58:14 | [post] self [@field] |
+| captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:16:61:21 | self [@field] |
+| captured_variables.rb:61:16:61:21 | @field | captured_variables.rb:61:9:61:21 | return |
+| captured_variables.rb:61:16:61:21 | self [@field] | captured_variables.rb:61:16:61:21 | @field |
+| captured_variables.rb:66:1:66:3 | [post] foo [@field] | captured_variables.rb:72:6:72:8 | foo [@field] |
+| captured_variables.rb:66:15:66:22 | call to taint | captured_variables.rb:57:19:57:19 | x |
+| captured_variables.rb:66:15:66:22 | call to taint | captured_variables.rb:66:1:66:3 | [post] foo [@field] |
+| captured_variables.rb:66:15:66:22 | call to taint | instance_variables.rb:10:19:10:19 | x |
+| captured_variables.rb:72:6:72:8 | foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] |
+| captured_variables.rb:72:6:72:8 | foo [@field] | captured_variables.rb:72:6:72:18 | call to get_field |
+| captured_variables.rb:72:6:72:8 | foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] |
+| captured_variables.rb:85:1:85:1 | y | captured_variables.rb:87:10:87:10 | y |
+| captured_variables.rb:85:5:85:12 | call to taint | captured_variables.rb:85:1:85:1 | y |
+| captured_variables.rb:88:5:88:5 | y | captured_variables.rb:87:10:87:10 | y |
+| captured_variables.rb:88:5:88:5 | y | captured_variables.rb:91:6:91:6 | y |
+| captured_variables.rb:88:9:88:16 | call to taint | captured_variables.rb:88:5:88:5 | y |
+| captured_variables.rb:100:21:100:21 | x | captured_variables.rb:101:11:101:11 | x |
+| captured_variables.rb:101:11:101:11 | x | captured_variables.rb:104:31:104:31 | x |
+| captured_variables.rb:104:17:104:24 | call to taint | captured_variables.rb:100:21:100:21 | x |
+| captured_variables.rb:104:31:104:31 | x | captured_variables.rb:105:10:105:10 | x |
+| captured_variables.rb:109:5:109:5 | x | captured_variables.rb:112:18:112:18 | x |
+| captured_variables.rb:109:9:109:17 | call to taint | captured_variables.rb:109:5:109:5 | x |
+| captured_variables.rb:113:13:113:13 | x | captured_variables.rb:112:18:112:18 | x |
+| captured_variables.rb:113:13:113:13 | x | captured_variables.rb:118:10:118:10 | x |
+| captured_variables.rb:113:17:113:25 | call to taint | captured_variables.rb:113:13:113:13 | x |
+| captured_variables.rb:160:9:160:10 | [post] self [@x] | captured_variables.rb:174:1:174:24 | call to new [@x] |
+| captured_variables.rb:160:14:160:22 | call to taint | captured_variables.rb:160:9:160:10 | [post] self [@x] |
+| captured_variables.rb:167:5:171:7 | self in baz [@x] | captured_variables.rb:169:18:169:19 | self [@x] |
+| captured_variables.rb:169:18:169:19 | self [@x] | captured_variables.rb:169:18:169:19 | @x |
+| captured_variables.rb:174:1:174:24 | call to new [@x] | captured_variables.rb:167:5:171:7 | self in baz [@x] |
+| captured_variables.rb:178:9:178:10 | [post] self [@x] | captured_variables.rb:193:1:193:1 | [post] c [@x] |
+| captured_variables.rb:178:14:178:22 | call to taint | captured_variables.rb:178:9:178:10 | [post] self [@x] |
+| captured_variables.rb:185:5:189:7 | self in baz [@x] | captured_variables.rb:187:18:187:19 | self [@x] |
+| captured_variables.rb:187:18:187:19 | self [@x] | captured_variables.rb:187:18:187:19 | @x |
+| captured_variables.rb:193:1:193:1 | [post] c [@x] | captured_variables.rb:194:1:194:1 | c [@x] |
+| captured_variables.rb:194:1:194:1 | c [@x] | captured_variables.rb:185:5:189:7 | self in baz [@x] |
 | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:11:18:11:18 | x |
 | instance_variables.rb:11:18:11:18 | x | instance_variables.rb:11:9:11:14 | [post] self [@field] |
 | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:16:14:21 | self [@field] |
@@ -28,10 +69,12 @@ edges
 | instance_variables.rb:32:13:32:21 | call to taint | instance_variables.rb:48:20:48:20 | x |
 | instance_variables.rb:33:13:33:13 | x | instance_variables.rb:22:20:22:24 | field |
 | instance_variables.rb:33:13:33:13 | x | instance_variables.rb:33:9:33:14 | call to new [@field] |
+| instance_variables.rb:36:10:36:23 | call to new [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] |
 | instance_variables.rb:36:10:36:23 | call to new [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] |
 | instance_variables.rb:36:10:36:23 | call to new [@field] | instance_variables.rb:36:10:36:33 | call to get_field |
 | instance_variables.rb:36:14:36:22 | call to taint | instance_variables.rb:22:20:22:24 | field |
 | instance_variables.rb:36:14:36:22 | call to taint | instance_variables.rb:36:10:36:23 | call to new [@field] |
+| instance_variables.rb:39:6:39:23 | call to bar [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] |
 | instance_variables.rb:39:6:39:23 | call to bar [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] |
 | instance_variables.rb:39:6:39:23 | call to bar [@field] | instance_variables.rb:39:6:39:33 | call to get_field |
 | instance_variables.rb:39:14:39:22 | call to taint | instance_variables.rb:31:18:31:18 | x |
@@ -39,11 +82,14 @@ edges
 | instance_variables.rb:43:9:43:17 | call to taint | instance_variables.rb:121:7:121:24 | call to new |
 | instance_variables.rb:48:20:48:20 | x | instance_variables.rb:49:14:49:14 | x |
 | instance_variables.rb:54:1:54:3 | [post] foo [@field] | instance_variables.rb:55:6:55:8 | foo [@field] |
+| instance_variables.rb:54:15:54:23 | call to taint | captured_variables.rb:57:19:57:19 | x |
 | instance_variables.rb:54:15:54:23 | call to taint | instance_variables.rb:10:19:10:19 | x |
 | instance_variables.rb:54:15:54:23 | call to taint | instance_variables.rb:54:1:54:3 | [post] foo [@field] |
+| instance_variables.rb:55:6:55:8 | foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] |
 | instance_variables.rb:55:6:55:8 | foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] |
 | instance_variables.rb:55:6:55:8 | foo [@field] | instance_variables.rb:55:6:55:18 | call to get_field |
 | instance_variables.rb:58:1:58:3 | [post] bar [@field] | instance_variables.rb:59:6:59:8 | bar [@field] |
+| instance_variables.rb:58:15:58:22 | call to taint | captured_variables.rb:57:19:57:19 | x |
 | instance_variables.rb:58:15:58:22 | call to taint | instance_variables.rb:10:19:10:19 | x |
 | instance_variables.rb:58:15:58:22 | call to taint | instance_variables.rb:58:1:58:3 | [post] bar [@field] |
 | instance_variables.rb:59:6:59:8 | bar [@field] | instance_variables.rb:16:5:18:7 | self in inc_field [@field] |
@@ -53,83 +99,150 @@ edges
 | instance_variables.rb:63:6:63:9 | foo1 [@field] | instance_variables.rb:63:6:63:15 | call to field |
 | instance_variables.rb:66:1:66:4 | [post] foo2 [@field] | instance_variables.rb:67:6:67:9 | foo2 [@field] |
 | instance_variables.rb:66:14:66:22 | call to taint | instance_variables.rb:66:1:66:4 | [post] foo2 [@field] |
+| instance_variables.rb:67:6:67:9 | foo2 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] |
 | instance_variables.rb:67:6:67:9 | foo2 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] |
 | instance_variables.rb:67:6:67:9 | foo2 [@field] | instance_variables.rb:67:6:67:19 | call to get_field |
 | instance_variables.rb:70:1:70:4 | [post] foo3 [@field] | instance_variables.rb:71:6:71:9 | foo3 [@field] |
 | instance_variables.rb:70:1:70:4 | [post] foo3 [@field] | instance_variables.rb:83:6:83:9 | foo3 [@field] |
+| instance_variables.rb:70:16:70:24 | call to taint | captured_variables.rb:57:19:57:19 | x |
 | instance_variables.rb:70:16:70:24 | call to taint | instance_variables.rb:10:19:10:19 | x |
 | instance_variables.rb:70:16:70:24 | call to taint | instance_variables.rb:70:1:70:4 | [post] foo3 [@field] |
 | instance_variables.rb:71:6:71:9 | foo3 [@field] | instance_variables.rb:71:6:71:15 | call to field |
 | instance_variables.rb:78:2:78:5 | [post] foo5 [@field] | instance_variables.rb:79:6:79:9 | foo5 [@field] |
 | instance_variables.rb:78:2:78:5 | [post] foo5 [@field] | instance_variables.rb:84:6:84:9 | foo5 [@field] |
+| instance_variables.rb:78:18:78:26 | call to taint | captured_variables.rb:57:19:57:19 | x |
 | instance_variables.rb:78:18:78:26 | call to taint | instance_variables.rb:10:19:10:19 | x |
 | instance_variables.rb:78:18:78:26 | call to taint | instance_variables.rb:78:2:78:5 | [post] foo5 [@field] |
+| instance_variables.rb:79:6:79:9 | foo5 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] |
 | instance_variables.rb:79:6:79:9 | foo5 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] |
 | instance_variables.rb:79:6:79:9 | foo5 [@field] | instance_variables.rb:79:6:79:19 | call to get_field |
 | instance_variables.rb:82:15:82:18 | [post] foo6 [@field] | instance_variables.rb:85:6:85:9 | foo6 [@field] |
+| instance_variables.rb:82:32:82:40 | call to taint | captured_variables.rb:57:19:57:19 | x |
 | instance_variables.rb:82:32:82:40 | call to taint | instance_variables.rb:10:19:10:19 | x |
 | instance_variables.rb:82:32:82:40 | call to taint | instance_variables.rb:82:15:82:18 | [post] foo6 [@field] |
+| instance_variables.rb:83:6:83:9 | foo3 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] |
 | instance_variables.rb:83:6:83:9 | foo3 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] |
 | instance_variables.rb:83:6:83:9 | foo3 [@field] | instance_variables.rb:83:6:83:19 | call to get_field |
+| instance_variables.rb:84:6:84:9 | foo5 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] |
 | instance_variables.rb:84:6:84:9 | foo5 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] |
 | instance_variables.rb:84:6:84:9 | foo5 [@field] | instance_variables.rb:84:6:84:19 | call to get_field |
+| instance_variables.rb:85:6:85:9 | foo6 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] |
 | instance_variables.rb:85:6:85:9 | foo6 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] |
 | instance_variables.rb:85:6:85:9 | foo6 [@field] | instance_variables.rb:85:6:85:19 | call to get_field |
 | instance_variables.rb:89:15:89:18 | [post] foo7 [@field] | instance_variables.rb:90:6:90:9 | foo7 [@field] |
 | instance_variables.rb:89:25:89:28 | [post] foo8 [@field] | instance_variables.rb:91:6:91:9 | foo8 [@field] |
+| instance_variables.rb:89:45:89:53 | call to taint | captured_variables.rb:57:19:57:19 | x |
 | instance_variables.rb:89:45:89:53 | call to taint | instance_variables.rb:10:19:10:19 | x |
 | instance_variables.rb:89:45:89:53 | call to taint | instance_variables.rb:89:15:89:18 | [post] foo7 [@field] |
 | instance_variables.rb:89:45:89:53 | call to taint | instance_variables.rb:89:25:89:28 | [post] foo8 [@field] |
+| instance_variables.rb:90:6:90:9 | foo7 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] |
 | instance_variables.rb:90:6:90:9 | foo7 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] |
 | instance_variables.rb:90:6:90:9 | foo7 [@field] | instance_variables.rb:90:6:90:19 | call to get_field |
+| instance_variables.rb:91:6:91:9 | foo8 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] |
 | instance_variables.rb:91:6:91:9 | foo8 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] |
 | instance_variables.rb:91:6:91:9 | foo8 [@field] | instance_variables.rb:91:6:91:19 | call to get_field |
 | instance_variables.rb:95:22:95:25 | [post] foo9 [@field] | instance_variables.rb:96:6:96:9 | foo9 [@field] |
 | instance_variables.rb:95:32:95:36 | [post] foo10 [@field] | instance_variables.rb:97:6:97:10 | foo10 [@field] |
+| instance_variables.rb:95:53:95:61 | call to taint | captured_variables.rb:57:19:57:19 | x |
 | instance_variables.rb:95:53:95:61 | call to taint | instance_variables.rb:10:19:10:19 | x |
 | instance_variables.rb:95:53:95:61 | call to taint | instance_variables.rb:95:22:95:25 | [post] foo9 [@field] |
 | instance_variables.rb:95:53:95:61 | call to taint | instance_variables.rb:95:32:95:36 | [post] foo10 [@field] |
+| instance_variables.rb:96:6:96:9 | foo9 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] |
 | instance_variables.rb:96:6:96:9 | foo9 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] |
 | instance_variables.rb:96:6:96:9 | foo9 [@field] | instance_variables.rb:96:6:96:19 | call to get_field |
+| instance_variables.rb:97:6:97:10 | foo10 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] |
 | instance_variables.rb:97:6:97:10 | foo10 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] |
 | instance_variables.rb:97:6:97:10 | foo10 [@field] | instance_variables.rb:97:6:97:20 | call to get_field |
 | instance_variables.rb:100:5:100:5 | [post] x [@field] | instance_variables.rb:104:14:104:18 | [post] foo11 [@field] |
 | instance_variables.rb:100:5:100:5 | [post] x [@field] | instance_variables.rb:108:15:108:19 | [post] foo12 [@field] |
 | instance_variables.rb:100:5:100:5 | [post] x [@field] | instance_variables.rb:113:22:113:26 | [post] foo13 [@field] |
+| instance_variables.rb:100:17:100:25 | call to taint | captured_variables.rb:57:19:57:19 | x |
 | instance_variables.rb:100:17:100:25 | call to taint | instance_variables.rb:10:19:10:19 | x |
 | instance_variables.rb:100:17:100:25 | call to taint | instance_variables.rb:100:5:100:5 | [post] x [@field] |
 | instance_variables.rb:104:14:104:18 | [post] foo11 [@field] | instance_variables.rb:105:6:105:10 | foo11 [@field] |
+| instance_variables.rb:105:6:105:10 | foo11 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] |
 | instance_variables.rb:105:6:105:10 | foo11 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] |
 | instance_variables.rb:105:6:105:10 | foo11 [@field] | instance_variables.rb:105:6:105:20 | call to get_field |
 | instance_variables.rb:108:15:108:19 | [post] foo12 [@field] | instance_variables.rb:109:6:109:10 | foo12 [@field] |
+| instance_variables.rb:109:6:109:10 | foo12 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] |
 | instance_variables.rb:109:6:109:10 | foo12 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] |
 | instance_variables.rb:109:6:109:10 | foo12 [@field] | instance_variables.rb:109:6:109:20 | call to get_field |
 | instance_variables.rb:113:22:113:26 | [post] foo13 [@field] | instance_variables.rb:114:6:114:10 | foo13 [@field] |
+| instance_variables.rb:114:6:114:10 | foo13 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] |
 | instance_variables.rb:114:6:114:10 | foo13 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] |
 | instance_variables.rb:114:6:114:10 | foo13 [@field] | instance_variables.rb:114:6:114:20 | call to get_field |
 | instance_variables.rb:116:1:116:5 | foo15 [@field] | instance_variables.rb:117:6:117:10 | foo15 [@field] |
 | instance_variables.rb:116:9:116:26 | call to new [@field] | instance_variables.rb:116:1:116:5 | foo15 [@field] |
 | instance_variables.rb:116:17:116:25 | call to taint | instance_variables.rb:22:20:22:24 | field |
 | instance_variables.rb:116:17:116:25 | call to taint | instance_variables.rb:116:9:116:26 | call to new [@field] |
+| instance_variables.rb:117:6:117:10 | foo15 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] |
 | instance_variables.rb:117:6:117:10 | foo15 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] |
 | instance_variables.rb:117:6:117:10 | foo15 [@field] | instance_variables.rb:117:6:117:20 | call to get_field |
 | instance_variables.rb:119:6:119:10 | [post] foo16 [@field] | instance_variables.rb:120:6:120:10 | foo16 [@field] |
 | instance_variables.rb:119:28:119:36 | call to taint | instance_variables.rb:27:25:27:29 | field |
 | instance_variables.rb:119:28:119:36 | call to taint | instance_variables.rb:119:6:119:10 | [post] foo16 [@field] |
+| instance_variables.rb:120:6:120:10 | foo16 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] |
 | instance_variables.rb:120:6:120:10 | foo16 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] |
 | instance_variables.rb:120:6:120:10 | foo16 [@field] | instance_variables.rb:120:6:120:20 | call to get_field |
 | instance_variables.rb:121:1:121:3 | bar | instance_variables.rb:122:6:122:8 | bar |
 | instance_variables.rb:121:7:121:24 | call to new | instance_variables.rb:121:1:121:3 | bar |
 nodes
-| captured_variables.rb:1:24:1:24 | x | semmle.label | x |
-| captured_variables.rb:2:20:2:20 | x | semmle.label | x |
-| captured_variables.rb:5:20:5:30 | call to source | semmle.label | call to source |
-| captured_variables.rb:21:33:21:33 | x | semmle.label | x |
-| captured_variables.rb:23:14:23:14 | x | semmle.label | x |
-| captured_variables.rb:27:29:27:39 | call to source | semmle.label | call to source |
-| captured_variables.rb:32:31:32:31 | x | semmle.label | x |
-| captured_variables.rb:34:14:34:14 | x | semmle.label | x |
-| captured_variables.rb:38:27:38:37 | call to source | semmle.label | call to source |
+| captured_variables.rb:9:24:9:24 | x | semmle.label | x |
+| captured_variables.rb:10:20:10:20 | x | semmle.label | x |
+| captured_variables.rb:13:20:13:29 | call to taint | semmle.label | call to taint |
+| captured_variables.rb:29:33:29:33 | x | semmle.label | x |
+| captured_variables.rb:31:14:31:14 | x | semmle.label | x |
+| captured_variables.rb:35:29:35:38 | call to taint | semmle.label | call to taint |
+| captured_variables.rb:40:31:40:31 | x | semmle.label | x |
+| captured_variables.rb:42:14:42:14 | x | semmle.label | x |
+| captured_variables.rb:46:27:46:36 | call to taint | semmle.label | call to taint |
+| captured_variables.rb:48:1:48:1 | x | semmle.label | x |
+| captured_variables.rb:48:5:48:12 | call to taint | semmle.label | call to taint |
+| captured_variables.rb:50:10:50:10 | x | semmle.label | x |
+| captured_variables.rb:51:5:51:5 | x | semmle.label | x |
+| captured_variables.rb:51:9:51:16 | call to taint | semmle.label | call to taint |
+| captured_variables.rb:54:6:54:6 | x | semmle.label | x |
+| captured_variables.rb:57:19:57:19 | x | semmle.label | x |
+| captured_variables.rb:58:9:58:14 | [post] self [@field] | semmle.label | [post] self [@field] |
+| captured_variables.rb:58:18:58:18 | x | semmle.label | x |
+| captured_variables.rb:60:5:62:7 | self in get_field [@field] | semmle.label | self in get_field [@field] |
+| captured_variables.rb:61:9:61:21 | return | semmle.label | return |
+| captured_variables.rb:61:16:61:21 | @field | semmle.label | @field |
+| captured_variables.rb:61:16:61:21 | self [@field] | semmle.label | self [@field] |
+| captured_variables.rb:66:1:66:3 | [post] foo [@field] | semmle.label | [post] foo [@field] |
+| captured_variables.rb:66:15:66:22 | call to taint | semmle.label | call to taint |
+| captured_variables.rb:72:6:72:8 | foo [@field] | semmle.label | foo [@field] |
+| captured_variables.rb:72:6:72:18 | call to get_field | semmle.label | call to get_field |
+| captured_variables.rb:85:1:85:1 | y | semmle.label | y |
+| captured_variables.rb:85:5:85:12 | call to taint | semmle.label | call to taint |
+| captured_variables.rb:87:10:87:10 | y | semmle.label | y |
+| captured_variables.rb:88:5:88:5 | y | semmle.label | y |
+| captured_variables.rb:88:9:88:16 | call to taint | semmle.label | call to taint |
+| captured_variables.rb:91:6:91:6 | y | semmle.label | y |
+| captured_variables.rb:100:21:100:21 | x | semmle.label | x |
+| captured_variables.rb:101:11:101:11 | x | semmle.label | x |
+| captured_variables.rb:104:17:104:24 | call to taint | semmle.label | call to taint |
+| captured_variables.rb:104:31:104:31 | x | semmle.label | x |
+| captured_variables.rb:105:10:105:10 | x | semmle.label | x |
+| captured_variables.rb:109:5:109:5 | x | semmle.label | x |
+| captured_variables.rb:109:9:109:17 | call to taint | semmle.label | call to taint |
+| captured_variables.rb:112:18:112:18 | x | semmle.label | x |
+| captured_variables.rb:113:13:113:13 | x | semmle.label | x |
+| captured_variables.rb:113:17:113:25 | call to taint | semmle.label | call to taint |
+| captured_variables.rb:118:10:118:10 | x | semmle.label | x |
+| captured_variables.rb:160:9:160:10 | [post] self [@x] | semmle.label | [post] self [@x] |
+| captured_variables.rb:160:14:160:22 | call to taint | semmle.label | call to taint |
+| captured_variables.rb:167:5:171:7 | self in baz [@x] | semmle.label | self in baz [@x] |
+| captured_variables.rb:169:18:169:19 | @x | semmle.label | @x |
+| captured_variables.rb:169:18:169:19 | self [@x] | semmle.label | self [@x] |
+| captured_variables.rb:174:1:174:24 | call to new [@x] | semmle.label | call to new [@x] |
+| captured_variables.rb:178:9:178:10 | [post] self [@x] | semmle.label | [post] self [@x] |
+| captured_variables.rb:178:14:178:22 | call to taint | semmle.label | call to taint |
+| captured_variables.rb:185:5:189:7 | self in baz [@x] | semmle.label | self in baz [@x] |
+| captured_variables.rb:187:18:187:19 | @x | semmle.label | @x |
+| captured_variables.rb:187:18:187:19 | self [@x] | semmle.label | self [@x] |
+| captured_variables.rb:193:1:193:1 | [post] c [@x] | semmle.label | [post] c [@x] |
+| captured_variables.rb:194:1:194:1 | c [@x] | semmle.label | c [@x] |
 | instance_variables.rb:10:19:10:19 | x | semmle.label | x |
 | instance_variables.rb:11:9:11:14 | [post] self [@field] | semmle.label | [post] self [@field] |
 | instance_variables.rb:11:18:11:18 | x | semmle.label | x |
@@ -235,45 +348,88 @@ nodes
 | instance_variables.rb:121:7:121:24 | call to new | semmle.label | call to new |
 | instance_variables.rb:122:6:122:8 | bar | semmle.label | bar |
 subpaths
+| captured_variables.rb:66:15:66:22 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:58:9:58:14 | [post] self [@field] | captured_variables.rb:66:1:66:3 | [post] foo [@field] |
+| captured_variables.rb:66:15:66:22 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:11:9:11:14 | [post] self [@field] | captured_variables.rb:66:1:66:3 | [post] foo [@field] |
+| captured_variables.rb:72:6:72:8 | foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | captured_variables.rb:72:6:72:18 | call to get_field |
+| captured_variables.rb:72:6:72:8 | foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | captured_variables.rb:72:6:72:18 | call to get_field |
 | instance_variables.rb:28:20:28:24 | field | instance_variables.rb:22:20:22:24 | field | instance_variables.rb:23:9:23:14 | [post] self [@field] | instance_variables.rb:28:9:28:25 | [post] self [@field] |
 | instance_variables.rb:33:13:33:13 | x | instance_variables.rb:22:20:22:24 | field | instance_variables.rb:23:9:23:14 | [post] self [@field] | instance_variables.rb:33:9:33:14 | call to new [@field] |
+| instance_variables.rb:36:10:36:23 | call to new [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:36:10:36:33 | call to get_field |
 | instance_variables.rb:36:10:36:23 | call to new [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:36:10:36:33 | call to get_field |
 | instance_variables.rb:36:14:36:22 | call to taint | instance_variables.rb:22:20:22:24 | field | instance_variables.rb:23:9:23:14 | [post] self [@field] | instance_variables.rb:36:10:36:23 | call to new [@field] |
+| instance_variables.rb:39:6:39:23 | call to bar [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:39:6:39:33 | call to get_field |
 | instance_variables.rb:39:6:39:23 | call to bar [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:39:6:39:33 | call to get_field |
 | instance_variables.rb:39:14:39:22 | call to taint | instance_variables.rb:31:18:31:18 | x | instance_variables.rb:33:9:33:14 | call to new [@field] | instance_variables.rb:39:6:39:23 | call to bar [@field] |
+| instance_variables.rb:54:15:54:23 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:58:9:58:14 | [post] self [@field] | instance_variables.rb:54:1:54:3 | [post] foo [@field] |
 | instance_variables.rb:54:15:54:23 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:11:9:11:14 | [post] self [@field] | instance_variables.rb:54:1:54:3 | [post] foo [@field] |
+| instance_variables.rb:55:6:55:8 | foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:55:6:55:18 | call to get_field |
 | instance_variables.rb:55:6:55:8 | foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:55:6:55:18 | call to get_field |
+| instance_variables.rb:58:15:58:22 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:58:9:58:14 | [post] self [@field] | instance_variables.rb:58:1:58:3 | [post] bar [@field] |
 | instance_variables.rb:58:15:58:22 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:11:9:11:14 | [post] self [@field] | instance_variables.rb:58:1:58:3 | [post] bar [@field] |
 | instance_variables.rb:59:6:59:8 | bar [@field] | instance_variables.rb:16:5:18:7 | self in inc_field [@field] | instance_variables.rb:16:5:18:7 | self in inc_field [@field] | instance_variables.rb:59:6:59:18 | call to inc_field |
 | instance_variables.rb:59:6:59:8 | bar [@field] | instance_variables.rb:16:5:18:7 | self in inc_field [@field] | instance_variables.rb:17:9:17:14 | [post] self [@field] | instance_variables.rb:59:6:59:18 | call to inc_field |
+| instance_variables.rb:67:6:67:9 | foo2 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:67:6:67:19 | call to get_field |
 | instance_variables.rb:67:6:67:9 | foo2 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:67:6:67:19 | call to get_field |
+| instance_variables.rb:70:16:70:24 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:58:9:58:14 | [post] self [@field] | instance_variables.rb:70:1:70:4 | [post] foo3 [@field] |
 | instance_variables.rb:70:16:70:24 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:11:9:11:14 | [post] self [@field] | instance_variables.rb:70:1:70:4 | [post] foo3 [@field] |
+| instance_variables.rb:78:18:78:26 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:58:9:58:14 | [post] self [@field] | instance_variables.rb:78:2:78:5 | [post] foo5 [@field] |
 | instance_variables.rb:78:18:78:26 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:11:9:11:14 | [post] self [@field] | instance_variables.rb:78:2:78:5 | [post] foo5 [@field] |
+| instance_variables.rb:79:6:79:9 | foo5 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:79:6:79:19 | call to get_field |
 | instance_variables.rb:79:6:79:9 | foo5 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:79:6:79:19 | call to get_field |
+| instance_variables.rb:82:32:82:40 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:58:9:58:14 | [post] self [@field] | instance_variables.rb:82:15:82:18 | [post] foo6 [@field] |
 | instance_variables.rb:82:32:82:40 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:11:9:11:14 | [post] self [@field] | instance_variables.rb:82:15:82:18 | [post] foo6 [@field] |
+| instance_variables.rb:83:6:83:9 | foo3 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:83:6:83:19 | call to get_field |
 | instance_variables.rb:83:6:83:9 | foo3 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:83:6:83:19 | call to get_field |
+| instance_variables.rb:84:6:84:9 | foo5 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:84:6:84:19 | call to get_field |
 | instance_variables.rb:84:6:84:9 | foo5 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:84:6:84:19 | call to get_field |
+| instance_variables.rb:85:6:85:9 | foo6 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:85:6:85:19 | call to get_field |
 | instance_variables.rb:85:6:85:9 | foo6 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:85:6:85:19 | call to get_field |
+| instance_variables.rb:89:45:89:53 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:58:9:58:14 | [post] self [@field] | instance_variables.rb:89:15:89:18 | [post] foo7 [@field] |
+| instance_variables.rb:89:45:89:53 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:58:9:58:14 | [post] self [@field] | instance_variables.rb:89:25:89:28 | [post] foo8 [@field] |
 | instance_variables.rb:89:45:89:53 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:11:9:11:14 | [post] self [@field] | instance_variables.rb:89:15:89:18 | [post] foo7 [@field] |
 | instance_variables.rb:89:45:89:53 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:11:9:11:14 | [post] self [@field] | instance_variables.rb:89:25:89:28 | [post] foo8 [@field] |
+| instance_variables.rb:90:6:90:9 | foo7 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:90:6:90:19 | call to get_field |
 | instance_variables.rb:90:6:90:9 | foo7 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:90:6:90:19 | call to get_field |
+| instance_variables.rb:91:6:91:9 | foo8 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:91:6:91:19 | call to get_field |
 | instance_variables.rb:91:6:91:9 | foo8 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:91:6:91:19 | call to get_field |
+| instance_variables.rb:95:53:95:61 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:58:9:58:14 | [post] self [@field] | instance_variables.rb:95:22:95:25 | [post] foo9 [@field] |
+| instance_variables.rb:95:53:95:61 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:58:9:58:14 | [post] self [@field] | instance_variables.rb:95:32:95:36 | [post] foo10 [@field] |
 | instance_variables.rb:95:53:95:61 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:11:9:11:14 | [post] self [@field] | instance_variables.rb:95:22:95:25 | [post] foo9 [@field] |
 | instance_variables.rb:95:53:95:61 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:11:9:11:14 | [post] self [@field] | instance_variables.rb:95:32:95:36 | [post] foo10 [@field] |
+| instance_variables.rb:96:6:96:9 | foo9 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:96:6:96:19 | call to get_field |
 | instance_variables.rb:96:6:96:9 | foo9 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:96:6:96:19 | call to get_field |
+| instance_variables.rb:97:6:97:10 | foo10 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:97:6:97:20 | call to get_field |
 | instance_variables.rb:97:6:97:10 | foo10 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:97:6:97:20 | call to get_field |
+| instance_variables.rb:100:17:100:25 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:58:9:58:14 | [post] self [@field] | instance_variables.rb:100:5:100:5 | [post] x [@field] |
 | instance_variables.rb:100:17:100:25 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:11:9:11:14 | [post] self [@field] | instance_variables.rb:100:5:100:5 | [post] x [@field] |
+| instance_variables.rb:105:6:105:10 | foo11 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:105:6:105:20 | call to get_field |
 | instance_variables.rb:105:6:105:10 | foo11 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:105:6:105:20 | call to get_field |
+| instance_variables.rb:109:6:109:10 | foo12 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:109:6:109:20 | call to get_field |
 | instance_variables.rb:109:6:109:10 | foo12 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:109:6:109:20 | call to get_field |
+| instance_variables.rb:114:6:114:10 | foo13 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:114:6:114:20 | call to get_field |
 | instance_variables.rb:114:6:114:10 | foo13 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:114:6:114:20 | call to get_field |
 | instance_variables.rb:116:17:116:25 | call to taint | instance_variables.rb:22:20:22:24 | field | instance_variables.rb:23:9:23:14 | [post] self [@field] | instance_variables.rb:116:9:116:26 | call to new [@field] |
+| instance_variables.rb:117:6:117:10 | foo15 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:117:6:117:20 | call to get_field |
 | instance_variables.rb:117:6:117:10 | foo15 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:117:6:117:20 | call to get_field |
 | instance_variables.rb:119:28:119:36 | call to taint | instance_variables.rb:27:25:27:29 | field | instance_variables.rb:28:9:28:25 | [post] self [@field] | instance_variables.rb:119:6:119:10 | [post] foo16 [@field] |
+| instance_variables.rb:120:6:120:10 | foo16 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:120:6:120:20 | call to get_field |
 | instance_variables.rb:120:6:120:10 | foo16 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:120:6:120:20 | call to get_field |
 #select
-| captured_variables.rb:2:20:2:20 | x | captured_variables.rb:5:20:5:30 | call to source | captured_variables.rb:2:20:2:20 | x | $@ | captured_variables.rb:5:20:5:30 | call to source | call to source |
-| captured_variables.rb:23:14:23:14 | x | captured_variables.rb:27:29:27:39 | call to source | captured_variables.rb:23:14:23:14 | x | $@ | captured_variables.rb:27:29:27:39 | call to source | call to source |
-| captured_variables.rb:34:14:34:14 | x | captured_variables.rb:38:27:38:37 | call to source | captured_variables.rb:34:14:34:14 | x | $@ | captured_variables.rb:38:27:38:37 | call to source | call to source |
+| captured_variables.rb:10:20:10:20 | x | captured_variables.rb:13:20:13:29 | call to taint | captured_variables.rb:10:20:10:20 | x | $@ | captured_variables.rb:13:20:13:29 | call to taint | call to taint |
+| captured_variables.rb:31:14:31:14 | x | captured_variables.rb:35:29:35:38 | call to taint | captured_variables.rb:31:14:31:14 | x | $@ | captured_variables.rb:35:29:35:38 | call to taint | call to taint |
+| captured_variables.rb:42:14:42:14 | x | captured_variables.rb:46:27:46:36 | call to taint | captured_variables.rb:42:14:42:14 | x | $@ | captured_variables.rb:46:27:46:36 | call to taint | call to taint |
+| captured_variables.rb:50:10:50:10 | x | captured_variables.rb:48:5:48:12 | call to taint | captured_variables.rb:50:10:50:10 | x | $@ | captured_variables.rb:48:5:48:12 | call to taint | call to taint |
+| captured_variables.rb:54:6:54:6 | x | captured_variables.rb:51:9:51:16 | call to taint | captured_variables.rb:54:6:54:6 | x | $@ | captured_variables.rb:51:9:51:16 | call to taint | call to taint |
+| captured_variables.rb:72:6:72:18 | call to get_field | captured_variables.rb:66:15:66:22 | call to taint | captured_variables.rb:72:6:72:18 | call to get_field | $@ | captured_variables.rb:66:15:66:22 | call to taint | call to taint |
+| captured_variables.rb:87:10:87:10 | y | captured_variables.rb:85:5:85:12 | call to taint | captured_variables.rb:87:10:87:10 | y | $@ | captured_variables.rb:85:5:85:12 | call to taint | call to taint |
+| captured_variables.rb:87:10:87:10 | y | captured_variables.rb:88:9:88:16 | call to taint | captured_variables.rb:87:10:87:10 | y | $@ | captured_variables.rb:88:9:88:16 | call to taint | call to taint |
+| captured_variables.rb:91:6:91:6 | y | captured_variables.rb:88:9:88:16 | call to taint | captured_variables.rb:91:6:91:6 | y | $@ | captured_variables.rb:88:9:88:16 | call to taint | call to taint |
+| captured_variables.rb:105:10:105:10 | x | captured_variables.rb:104:17:104:24 | call to taint | captured_variables.rb:105:10:105:10 | x | $@ | captured_variables.rb:104:17:104:24 | call to taint | call to taint |
+| captured_variables.rb:112:18:112:18 | x | captured_variables.rb:109:9:109:17 | call to taint | captured_variables.rb:112:18:112:18 | x | $@ | captured_variables.rb:109:9:109:17 | call to taint | call to taint |
+| captured_variables.rb:112:18:112:18 | x | captured_variables.rb:113:17:113:25 | call to taint | captured_variables.rb:112:18:112:18 | x | $@ | captured_variables.rb:113:17:113:25 | call to taint | call to taint |
+| captured_variables.rb:118:10:118:10 | x | captured_variables.rb:113:17:113:25 | call to taint | captured_variables.rb:118:10:118:10 | x | $@ | captured_variables.rb:113:17:113:25 | call to taint | call to taint |
+| captured_variables.rb:169:18:169:19 | @x | captured_variables.rb:160:14:160:22 | call to taint | captured_variables.rb:169:18:169:19 | @x | $@ | captured_variables.rb:160:14:160:22 | call to taint | call to taint |
+| captured_variables.rb:187:18:187:19 | @x | captured_variables.rb:178:14:178:22 | call to taint | captured_variables.rb:187:18:187:19 | @x | $@ | captured_variables.rb:178:14:178:22 | call to taint | call to taint |
 | instance_variables.rb:20:10:20:13 | @foo | instance_variables.rb:19:12:19:21 | call to taint | instance_variables.rb:20:10:20:13 | @foo | $@ | instance_variables.rb:19:12:19:21 | call to taint | call to taint |
 | instance_variables.rb:36:10:36:33 | call to get_field | instance_variables.rb:36:14:36:22 | call to taint | instance_variables.rb:36:10:36:33 | call to get_field | $@ | instance_variables.rb:36:14:36:22 | call to taint | call to taint |
 | instance_variables.rb:39:6:39:33 | call to get_field | instance_variables.rb:39:14:39:22 | call to taint | instance_variables.rb:39:6:39:33 | call to get_field | $@ | instance_variables.rb:39:14:39:22 | call to taint | call to taint |

--- a/ruby/ql/test/library-tests/dataflow/global/TypeTrackingInlineTest.expected
+++ b/ruby/ql/test/library-tests/dataflow/global/TypeTrackingInlineTest.expected
@@ -1,13 +1,13 @@
 testFailures
-| captured_variables.rb:17:14:17:14 | x | Fixed missing result:hasValueFlow=1.2 |
-| captured_variables.rb:24:14:24:14 | x | Fixed missing result:hasValueFlow=1.3 |
 | captured_variables.rb:50:10:50:10 | x | Fixed missing result:hasValueFlow=2 |
-| captured_variables.rb:54:6:54:6 | x | Unexpected result: hasValueFlow=1 |
-| captured_variables.rb:72:21:72:75 | # $ MISSING: hasValueFlow=4 $ SPURIOUS: hasValueFlow=3  | Fixed spurious result:hasValueFlow=3 |
-| captured_variables.rb:91:6:91:6 | y | Unexpected result: hasValueFlow=6 |
-| captured_variables.rb:95:14:95:14 | x | Fixed missing result:hasValueFlow=8 |
-| captured_variables.rb:118:10:118:10 | x | Unexpected result: hasValueFlow=10 |
+| captured_variables.rb:68:25:68:68 | # $ hasValueFlow=3 $ MISSING: hasValueFlow=4 | Missing result:hasValueFlow=3 |
+| captured_variables.rb:72:21:72:66 | # $ hasValueFlow=4 $ SPURIOUS: hasValueFlow=3  | Fixed spurious result:hasValueFlow=3 |
+| captured_variables.rb:72:21:72:66 | # $ hasValueFlow=4 $ SPURIOUS: hasValueFlow=3  | Missing result:hasValueFlow=4 |
+| captured_variables.rb:83:21:83:38 | # $ hasValueFlow=5 | Missing result:hasValueFlow=5 |
+| captured_variables.rb:87:10:87:10 | y | Unexpected result: hasValueFlow=7 |
+| captured_variables.rb:112:18:112:18 | x | Unexpected result: hasValueFlow=11 |
 | captured_variables.rb:126:14:126:14 | x | Fixed missing result:hasValueFlow=12 |
+| captured_variables.rb:154:17:154:35 | # $ hasValueFlow=13 | Missing result:hasValueFlow=13 |
 | instance_variables.rb:20:16:20:33 | # $ hasValueFlow=7 | Missing result:hasValueFlow=7 |
 | instance_variables.rb:36:36:36:54 | # $ hasValueFlow=34 | Missing result:hasValueFlow=34 |
 | instance_variables.rb:39:36:39:54 | # $ hasValueFlow=35 | Missing result:hasValueFlow=35 |

--- a/ruby/ql/test/library-tests/dataflow/global/TypeTrackingInlineTest.expected
+++ b/ruby/ql/test/library-tests/dataflow/global/TypeTrackingInlineTest.expected
@@ -1,7 +1,13 @@
-failures
 testFailures
-| captured_variables.rb:9:14:9:14 | x | Fixed missing result:hasValueFlow=1.2 |
-| captured_variables.rb:16:14:16:14 | x | Fixed missing result:hasValueFlow=1.3 |
+| captured_variables.rb:17:14:17:14 | x | Fixed missing result:hasValueFlow=1.2 |
+| captured_variables.rb:24:14:24:14 | x | Fixed missing result:hasValueFlow=1.3 |
+| captured_variables.rb:50:10:50:10 | x | Fixed missing result:hasValueFlow=2 |
+| captured_variables.rb:54:6:54:6 | x | Unexpected result: hasValueFlow=1 |
+| captured_variables.rb:72:21:72:75 | # $ MISSING: hasValueFlow=4 $ SPURIOUS: hasValueFlow=3  | Fixed spurious result:hasValueFlow=3 |
+| captured_variables.rb:91:6:91:6 | y | Unexpected result: hasValueFlow=6 |
+| captured_variables.rb:95:14:95:14 | x | Fixed missing result:hasValueFlow=8 |
+| captured_variables.rb:118:10:118:10 | x | Unexpected result: hasValueFlow=10 |
+| captured_variables.rb:126:14:126:14 | x | Fixed missing result:hasValueFlow=12 |
 | instance_variables.rb:20:16:20:33 | # $ hasValueFlow=7 | Missing result:hasValueFlow=7 |
 | instance_variables.rb:36:36:36:54 | # $ hasValueFlow=34 | Missing result:hasValueFlow=34 |
 | instance_variables.rb:39:36:39:54 | # $ hasValueFlow=35 | Missing result:hasValueFlow=35 |
@@ -23,3 +29,4 @@ testFailures
 | instance_variables.rb:114:23:114:41 | # $ hasValueFlow=28 | Missing result:hasValueFlow=28 |
 | instance_variables.rb:117:23:117:41 | # $ hasValueFlow=29 | Missing result:hasValueFlow=29 |
 | instance_variables.rb:120:23:120:41 | # $ hasValueFlow=30 | Missing result:hasValueFlow=30 |
+failures

--- a/ruby/ql/test/library-tests/dataflow/global/captured_variables.rb
+++ b/ruby/ql/test/library-tests/dataflow/global/captured_variables.rb
@@ -14,14 +14,14 @@ capture_local_call taint(1.1)
 
 def capture_escape_return1 x
     -> {
-        sink(x) # $ MISSING: hasValueFlow=1.2
+        sink(x) # $ hasValueFlow=1.2
     }
 end
 (capture_escape_return1 taint(1.2)).call
 
 def capture_escape_return2 x
     -> {
-        sink(x) # $ MISSING: hasValueFlow=1.3
+        sink(x) # $ hasValueFlow=1.3
     }
 end
 Something.unknownMethod(capture_escape_return2 taint(1.3))
@@ -51,7 +51,7 @@ x = taint(1)
     x = taint(2)
 end
 
-sink x # $ hasValueFlow=2
+sink x # $ hasValueFlow=2 $ SPURIOUS: hasValueFlow=1
 
 class Foo
     def set_field x
@@ -65,11 +65,11 @@ end
 foo = Foo.new
 foo.set_field(taint(3))
 [1, 2, 3].each do |i|
-    sink(foo.get_field) # $ MISSING: hasValueFlow=3 $ MISSING: hasValueFlow=4
+    sink(foo.get_field) # $ hasValueFlow=3 $ MISSING: hasValueFlow=4
     foo.set_field(taint(4))
 end
 
-sink(foo.get_field) # $ MISSING: hasValueFlow=4 $ SPURIOUS: hasValueFlow=3 
+sink(foo.get_field) # $ hasValueFlow=4 $ SPURIOUS: hasValueFlow=3 
 
 foo = Foo.new
 if (rand() < 0) then
@@ -80,19 +80,19 @@ else
     end
 end
 
-sink(foo.get_field) # $ MISSING: hasValueFlow=5
+sink(foo.get_field) # $ hasValueFlow=5
 
 y = taint(6)
 fn = -> {
-    sink(y) # $ hasValueFlow=6 $ SPURIOUS: hasValueFlow=7
+    sink(y) # $ hasValueFlow=6
     y = taint(7)
 }
 fn.call
-sink(y) # $ hasValueFlow=7
+sink(y) # $ hasValueFlow=7 $ SPURIOUS: hasValueFlow=6
 
 def capture_arg x
     -> {
-        sink x # $ MISSING: hasValueFlow=8
+        sink x # $ hasValueFlow=8
     }
 end
 capture_arg(taint(8)).call
@@ -109,13 +109,13 @@ def capture_nested
     x = taint(10)
     middle = -> {
         inner = -> {
-            sink x # $ hasValueFlow=10 $ SPURIOUS: hasValueFlow=11
+            sink x # $ hasValueFlow=10
             x = taint(11)
         }
         inner.call
     }
     middle.call
-    sink x # $ hasValueFlow=11
+    sink x # $ hasValueFlow=11 $ SPURIOUS: hasValueFlow=10
 end
 capture_nested
 
@@ -151,7 +151,7 @@ module CaptureModuleSelf
     end
 
     self.foo do
-        sink @x # $ MISSING: hasValueFlow=13
+        sink @x # $ hasValueFlow=13
     end
 end
 

--- a/ruby/ql/test/library-tests/dataflow/global/captured_variables.rb
+++ b/ruby/ql/test/library-tests/dataflow/global/captured_variables.rb
@@ -1,22 +1,30 @@
+def taint x
+    x
+end
+
+def sink x
+    puts "SINK: #{x}"
+end
+
 def capture_local_call x
     fn = -> { sink(x) } # $ hasValueFlow=1.1
     fn.call
 end
-capture_local_call source(1.1)
+capture_local_call taint(1.1)
 
 def capture_escape_return1 x
     -> {
         sink(x) # $ MISSING: hasValueFlow=1.2
     }
 end
-(capture_escape_return1 source(1.2)).call
+(capture_escape_return1 taint(1.2)).call
 
 def capture_escape_return2 x
     -> {
         sink(x) # $ MISSING: hasValueFlow=1.3
     }
 end
-Something.unknownMethod(capture_escape_return2 source(1.3))
+Something.unknownMethod(capture_escape_return2 taint(1.3))
 
 def capture_escape_unknown_call x
     fn = -> {
@@ -24,7 +32,7 @@ def capture_escape_unknown_call x
     }
     Something.unknownMethod(fn)
 end
-capture_escape_unknown_call source(1.4)
+capture_escape_unknown_call taint(1.4)
 
 def call_it fn
     fn.call
@@ -35,4 +43,152 @@ def capture_escape_known_call x
     }
     call_it fn
 end
-capture_escape_known_call source(1.5)
+capture_escape_known_call taint(1.5)
+
+x = taint(1)
+[1, 2, 3].each do |i|
+    sink x # $ hasValueFlow=1 $ MISSING: hasValueFlow=2
+    x = taint(2)
+end
+
+sink x # $ hasValueFlow=2
+
+class Foo
+    def set_field x
+        @field = x
+    end
+    def get_field
+        return @field
+    end
+end
+
+foo = Foo.new
+foo.set_field(taint(3))
+[1, 2, 3].each do |i|
+    sink(foo.get_field) # $ MISSING: hasValueFlow=3 $ MISSING: hasValueFlow=4
+    foo.set_field(taint(4))
+end
+
+sink(foo.get_field) # $ MISSING: hasValueFlow=4 $ SPURIOUS: hasValueFlow=3 
+
+foo = Foo.new
+if (rand() < 0) then
+    foo = Foo.new
+else
+    [1, 2, 3].each do |i|
+        foo.set_field(taint(5))
+    end
+end
+
+sink(foo.get_field) # $ MISSING: hasValueFlow=5
+
+y = taint(6)
+fn = -> {
+    sink(y) # $ hasValueFlow=6 $ SPURIOUS: hasValueFlow=7
+    y = taint(7)
+}
+fn.call
+sink(y) # $ hasValueFlow=7
+
+def capture_arg x
+    -> {
+        sink x # $ MISSING: hasValueFlow=8
+    }
+end
+capture_arg(taint(8)).call
+
+def call_block_with x
+    yield x
+end
+
+call_block_with(taint(9)) do |x|
+    sink x # $ hasValueFlow=9
+end
+
+def capture_nested
+    x = taint(10)
+    middle = -> {
+        inner = -> {
+            sink x # $ hasValueFlow=10 $ SPURIOUS: hasValueFlow=11
+            x = taint(11)
+        }
+        inner.call
+    }
+    middle.call
+    sink x # $ hasValueFlow=11
+end
+capture_nested
+
+def lambdas
+    x = 123
+
+    fn1 = -> {
+        sink x # $ MISSING: hasValueFlow=12
+    }
+
+    fn3 = -> {
+        y = taint(12)
+
+        fn2 = -> {
+            x = y
+        }
+
+        fn2
+    }
+
+    fn4 = fn3.call()
+    fn4.call()
+    fn1.call()
+end
+
+lambdas
+
+module CaptureModuleSelf
+    @x = taint(13)
+
+    def self.foo
+        yield
+    end
+
+    self.foo do
+        sink @x # $ MISSING: hasValueFlow=13
+    end
+end
+
+class CaptureInstanceSelf1
+    def initialize
+        @x = taint(14)
+    end
+
+    def bar
+        yield
+    end
+
+    def baz
+        self.bar do
+            sink @x # $ hasValueFlow=14
+        end
+    end
+end
+
+CaptureInstanceSelf1.new.baz
+
+class CaptureInstanceSelf2
+    def foo
+        @x = taint(15)
+    end
+
+    def bar
+        yield
+    end
+
+    def baz
+        self.bar do
+            sink @x # $ hasValueFlow=15
+        end
+    end
+end
+
+c = CaptureInstanceSelf2.new
+c.foo
+c.baz

--- a/ruby/ql/test/library-tests/dataflow/summaries/Summaries.expected
+++ b/ruby/ql/test/library-tests/dataflow/summaries/Summaries.expected
@@ -1,59 +1,57 @@
 testFailures
 edges
-| summaries.rb:1:1:1:7 | tainted | summaries.rb:2:6:2:12 | tainted |
-| summaries.rb:1:1:1:7 | tainted | summaries.rb:2:6:2:12 | tainted |
-| summaries.rb:1:1:1:7 | tainted | summaries.rb:4:24:4:30 | tainted |
-| summaries.rb:1:1:1:7 | tainted | summaries.rb:4:24:4:30 | tainted |
-| summaries.rb:1:1:1:7 | tainted | summaries.rb:16:36:16:42 | tainted |
-| summaries.rb:1:1:1:7 | tainted | summaries.rb:16:36:16:42 | tainted |
-| summaries.rb:1:1:1:7 | tainted | summaries.rb:20:25:20:31 | tainted |
-| summaries.rb:1:1:1:7 | tainted | summaries.rb:26:31:26:37 | tainted |
-| summaries.rb:1:1:1:7 | tainted | summaries.rb:30:24:30:30 | tainted |
-| summaries.rb:1:1:1:7 | tainted | summaries.rb:31:27:31:33 | tainted |
-| summaries.rb:1:1:1:7 | tainted | summaries.rb:34:16:34:22 | tainted |
-| summaries.rb:1:1:1:7 | tainted | summaries.rb:34:16:34:22 | tainted |
-| summaries.rb:1:1:1:7 | tainted | summaries.rb:35:16:35:22 | tainted |
-| summaries.rb:1:1:1:7 | tainted | summaries.rb:35:16:35:22 | tainted |
-| summaries.rb:1:1:1:7 | tainted | summaries.rb:36:21:36:27 | tainted |
-| summaries.rb:1:1:1:7 | tainted | summaries.rb:36:21:36:27 | tainted |
-| summaries.rb:1:1:1:7 | tainted | summaries.rb:37:36:37:42 | tainted |
-| summaries.rb:1:1:1:7 | tainted | summaries.rb:37:36:37:42 | tainted |
-| summaries.rb:1:1:1:7 | tainted | summaries.rb:51:24:51:30 | tainted |
-| summaries.rb:1:1:1:7 | tainted | summaries.rb:56:22:56:28 | tainted |
-| summaries.rb:1:1:1:7 | tainted | summaries.rb:57:17:57:23 | tainted |
-| summaries.rb:1:1:1:7 | tainted | summaries.rb:59:27:59:33 | tainted |
-| summaries.rb:1:1:1:7 | tainted | summaries.rb:63:32:63:38 | tainted |
-| summaries.rb:1:1:1:7 | tainted | summaries.rb:65:23:65:29 | tainted |
-| summaries.rb:1:1:1:7 | tainted | summaries.rb:122:16:122:22 | tainted |
-| summaries.rb:1:1:1:7 | tainted | summaries.rb:128:14:128:20 | tainted |
-| summaries.rb:1:1:1:7 | tainted | summaries.rb:131:16:131:22 | tainted |
-| summaries.rb:1:1:1:7 | tainted | summaries.rb:131:16:131:22 | tainted |
-| summaries.rb:1:1:1:7 | tainted | summaries.rb:132:21:132:27 | tainted |
-| summaries.rb:1:1:1:7 | tainted | summaries.rb:132:21:132:27 | tainted |
-| summaries.rb:1:1:1:7 | tainted | summaries.rb:135:26:135:32 | tainted |
-| summaries.rb:1:1:1:7 | tainted | summaries.rb:135:26:135:32 | tainted |
-| summaries.rb:1:1:1:7 | tainted | summaries.rb:137:23:137:29 | tainted |
-| summaries.rb:1:1:1:7 | tainted | summaries.rb:137:23:137:29 | tainted |
-| summaries.rb:1:1:1:7 | tainted | summaries.rb:140:19:140:25 | tainted |
-| summaries.rb:1:1:1:7 | tainted | summaries.rb:140:19:140:25 | tainted |
-| summaries.rb:1:1:1:7 | tainted | summaries.rb:141:19:141:25 | tainted |
-| summaries.rb:1:1:1:7 | tainted | summaries.rb:141:19:141:25 | tainted |
-| summaries.rb:1:1:1:7 | tainted | summaries.rb:145:26:145:32 | tainted |
-| summaries.rb:1:1:1:7 | tainted | summaries.rb:145:26:145:32 | tainted |
-| summaries.rb:1:1:1:7 | tainted | summaries.rb:147:16:147:22 | tainted |
-| summaries.rb:1:1:1:7 | tainted | summaries.rb:147:16:147:22 | tainted |
-| summaries.rb:1:1:1:7 | tainted | summaries.rb:150:39:150:45 | tainted |
-| summaries.rb:1:1:1:7 | tainted | summaries.rb:150:39:150:45 | tainted |
-| summaries.rb:1:1:1:7 | tainted | summaries.rb:154:20:154:26 | tainted |
-| summaries.rb:1:1:1:7 | tainted | summaries.rb:154:20:154:26 | tainted |
-| summaries.rb:1:1:1:7 | tainted | summaries.rb:155:28:155:34 | tainted |
-| summaries.rb:1:1:1:7 | tainted | summaries.rb:155:28:155:34 | tainted |
-| summaries.rb:1:1:1:7 | tainted | summaries.rb:156:27:156:33 | tainted |
-| summaries.rb:1:1:1:7 | tainted | summaries.rb:156:27:156:33 | tainted |
-| summaries.rb:1:1:1:7 | tainted | summaries.rb:158:15:158:21 | tainted |
-| summaries.rb:1:1:1:7 | tainted | summaries.rb:158:15:158:21 | tainted |
-| summaries.rb:1:11:1:36 | call to identity | summaries.rb:1:1:1:7 | tainted |
-| summaries.rb:1:11:1:36 | call to identity | summaries.rb:1:1:1:7 | tainted |
+| summaries.rb:1:11:1:36 | call to identity | summaries.rb:2:6:2:12 | tainted |
+| summaries.rb:1:11:1:36 | call to identity | summaries.rb:2:6:2:12 | tainted |
+| summaries.rb:1:11:1:36 | call to identity | summaries.rb:4:24:4:30 | tainted |
+| summaries.rb:1:11:1:36 | call to identity | summaries.rb:4:24:4:30 | tainted |
+| summaries.rb:1:11:1:36 | call to identity | summaries.rb:16:36:16:42 | tainted |
+| summaries.rb:1:11:1:36 | call to identity | summaries.rb:16:36:16:42 | tainted |
+| summaries.rb:1:11:1:36 | call to identity | summaries.rb:20:25:20:31 | tainted |
+| summaries.rb:1:11:1:36 | call to identity | summaries.rb:26:31:26:37 | tainted |
+| summaries.rb:1:11:1:36 | call to identity | summaries.rb:30:24:30:30 | tainted |
+| summaries.rb:1:11:1:36 | call to identity | summaries.rb:31:27:31:33 | tainted |
+| summaries.rb:1:11:1:36 | call to identity | summaries.rb:34:16:34:22 | tainted |
+| summaries.rb:1:11:1:36 | call to identity | summaries.rb:34:16:34:22 | tainted |
+| summaries.rb:1:11:1:36 | call to identity | summaries.rb:35:16:35:22 | tainted |
+| summaries.rb:1:11:1:36 | call to identity | summaries.rb:35:16:35:22 | tainted |
+| summaries.rb:1:11:1:36 | call to identity | summaries.rb:36:21:36:27 | tainted |
+| summaries.rb:1:11:1:36 | call to identity | summaries.rb:36:21:36:27 | tainted |
+| summaries.rb:1:11:1:36 | call to identity | summaries.rb:37:36:37:42 | tainted |
+| summaries.rb:1:11:1:36 | call to identity | summaries.rb:37:36:37:42 | tainted |
+| summaries.rb:1:11:1:36 | call to identity | summaries.rb:51:24:51:30 | tainted |
+| summaries.rb:1:11:1:36 | call to identity | summaries.rb:56:22:56:28 | tainted |
+| summaries.rb:1:11:1:36 | call to identity | summaries.rb:57:17:57:23 | tainted |
+| summaries.rb:1:11:1:36 | call to identity | summaries.rb:59:27:59:33 | tainted |
+| summaries.rb:1:11:1:36 | call to identity | summaries.rb:63:32:63:38 | tainted |
+| summaries.rb:1:11:1:36 | call to identity | summaries.rb:65:23:65:29 | tainted |
+| summaries.rb:1:11:1:36 | call to identity | summaries.rb:122:16:122:22 | tainted |
+| summaries.rb:1:11:1:36 | call to identity | summaries.rb:128:14:128:20 | tainted |
+| summaries.rb:1:11:1:36 | call to identity | summaries.rb:131:16:131:22 | tainted |
+| summaries.rb:1:11:1:36 | call to identity | summaries.rb:131:16:131:22 | tainted |
+| summaries.rb:1:11:1:36 | call to identity | summaries.rb:132:21:132:27 | tainted |
+| summaries.rb:1:11:1:36 | call to identity | summaries.rb:132:21:132:27 | tainted |
+| summaries.rb:1:11:1:36 | call to identity | summaries.rb:135:26:135:32 | tainted |
+| summaries.rb:1:11:1:36 | call to identity | summaries.rb:135:26:135:32 | tainted |
+| summaries.rb:1:11:1:36 | call to identity | summaries.rb:137:23:137:29 | tainted |
+| summaries.rb:1:11:1:36 | call to identity | summaries.rb:137:23:137:29 | tainted |
+| summaries.rb:1:11:1:36 | call to identity | summaries.rb:140:19:140:25 | tainted |
+| summaries.rb:1:11:1:36 | call to identity | summaries.rb:140:19:140:25 | tainted |
+| summaries.rb:1:11:1:36 | call to identity | summaries.rb:141:19:141:25 | tainted |
+| summaries.rb:1:11:1:36 | call to identity | summaries.rb:141:19:141:25 | tainted |
+| summaries.rb:1:11:1:36 | call to identity | summaries.rb:145:26:145:32 | tainted |
+| summaries.rb:1:11:1:36 | call to identity | summaries.rb:145:26:145:32 | tainted |
+| summaries.rb:1:11:1:36 | call to identity | summaries.rb:147:16:147:22 | tainted |
+| summaries.rb:1:11:1:36 | call to identity | summaries.rb:147:16:147:22 | tainted |
+| summaries.rb:1:11:1:36 | call to identity | summaries.rb:150:39:150:45 | tainted |
+| summaries.rb:1:11:1:36 | call to identity | summaries.rb:150:39:150:45 | tainted |
+| summaries.rb:1:11:1:36 | call to identity | summaries.rb:154:20:154:26 | tainted |
+| summaries.rb:1:11:1:36 | call to identity | summaries.rb:154:20:154:26 | tainted |
+| summaries.rb:1:11:1:36 | call to identity | summaries.rb:155:28:155:34 | tainted |
+| summaries.rb:1:11:1:36 | call to identity | summaries.rb:155:28:155:34 | tainted |
+| summaries.rb:1:11:1:36 | call to identity | summaries.rb:156:27:156:33 | tainted |
+| summaries.rb:1:11:1:36 | call to identity | summaries.rb:156:27:156:33 | tainted |
+| summaries.rb:1:11:1:36 | call to identity | summaries.rb:157:14:160:3 | do ... end [captured tainted] |
+| summaries.rb:1:11:1:36 | call to identity | summaries.rb:157:14:160:3 | do ... end [captured tainted] |
 | summaries.rb:1:20:1:36 | call to source | summaries.rb:1:11:1:36 | call to identity |
 | summaries.rb:1:20:1:36 | call to source | summaries.rb:1:11:1:36 | call to identity |
 | summaries.rb:4:1:4:8 | tainted2 | summaries.rb:9:6:9:13 | tainted2 |
@@ -242,6 +240,7 @@ edges
 | summaries.rb:122:16:122:22 | [post] tainted | summaries.rb:154:20:154:26 | tainted |
 | summaries.rb:122:16:122:22 | [post] tainted | summaries.rb:155:28:155:34 | tainted |
 | summaries.rb:122:16:122:22 | [post] tainted | summaries.rb:156:27:156:33 | tainted |
+| summaries.rb:122:16:122:22 | [post] tainted | summaries.rb:157:14:160:3 | do ... end [captured tainted] |
 | summaries.rb:122:16:122:22 | tainted | summaries.rb:122:16:122:22 | [post] tainted |
 | summaries.rb:122:16:122:22 | tainted | summaries.rb:122:25:122:25 | [post] y |
 | summaries.rb:122:16:122:22 | tainted | summaries.rb:122:33:122:33 | [post] z |
@@ -249,9 +248,9 @@ edges
 | summaries.rb:122:33:122:33 | [post] z | summaries.rb:125:6:125:6 | z |
 | summaries.rb:128:1:128:1 | [post] x | summaries.rb:129:6:129:6 | x |
 | summaries.rb:128:14:128:20 | tainted | summaries.rb:128:1:128:1 | [post] x |
+| summaries.rb:157:14:160:3 | do ... end [captured tainted] | summaries.rb:158:15:158:21 | tainted |
+| summaries.rb:157:14:160:3 | do ... end [captured tainted] | summaries.rb:158:15:158:21 | tainted |
 nodes
-| summaries.rb:1:1:1:7 | tainted | semmle.label | tainted |
-| summaries.rb:1:1:1:7 | tainted | semmle.label | tainted |
 | summaries.rb:1:11:1:36 | call to identity | semmle.label | call to identity |
 | summaries.rb:1:11:1:36 | call to identity | semmle.label | call to identity |
 | summaries.rb:1:20:1:36 | call to source | semmle.label | call to source |
@@ -491,6 +490,8 @@ nodes
 | summaries.rb:155:28:155:34 | tainted | semmle.label | tainted |
 | summaries.rb:156:27:156:33 | tainted | semmle.label | tainted |
 | summaries.rb:156:27:156:33 | tainted | semmle.label | tainted |
+| summaries.rb:157:14:160:3 | do ... end [captured tainted] | semmle.label | do ... end [captured tainted] |
+| summaries.rb:157:14:160:3 | do ... end [captured tainted] | semmle.label | do ... end [captured tainted] |
 | summaries.rb:158:15:158:21 | tainted | semmle.label | tainted |
 | summaries.rb:158:15:158:21 | tainted | semmle.label | tainted |
 | summaries.rb:163:20:163:36 | call to source | semmle.label | call to source |

--- a/ruby/ql/test/library-tests/frameworks/sinatra/Sinatra.expected
+++ b/ruby/ql/test/library-tests/frameworks/sinatra/Sinatra.expected
@@ -43,51 +43,43 @@ filterPatterns
 | app.rb:106:3:108:5 | call to before | app.rb:106:10:106:23 | "/protected/*" |
 | app.rb:111:3:113:5 | call to after | app.rb:111:9:111:23 | "/create/:slug" |
 additionalFlowSteps
-| app.rb:85:5:85:9 | [post] self | app.rb:2:22:4:5 | <captured entry> self |
-| app.rb:85:5:85:9 | [post] self | app.rb:10:21:13:5 | <captured entry> self |
-| app.rb:85:5:85:9 | [post] self | app.rb:15:23:18:5 | <captured entry> self |
-| app.rb:85:5:85:9 | [post] self | app.rb:24:26:26:5 | <captured entry> self |
-| app.rb:85:5:85:9 | [post] self | app.rb:37:16:42:5 | <captured entry> self |
-| app.rb:85:5:85:9 | [post] self | app.rb:44:53:46:5 | <captured entry> self |
-| app.rb:85:5:85:9 | [post] self | app.rb:56:32:58:5 | <captured entry> self |
-| app.rb:85:5:85:9 | [post] self | app.rb:60:48:62:5 | <captured entry> self |
-| app.rb:85:5:85:9 | [post] self | app.rb:74:11:77:5 | <captured entry> self |
-| app.rb:85:5:85:9 | [post] self | app.rb:79:11:82:5 | <captured entry> self |
-| app.rb:85:5:85:9 | [post] self | app.rb:89:16:92:5 | <captured entry> self |
-| app.rb:85:5:85:9 | [post] self | app.rb:94:15:96:5 | <captured entry> self |
-| app.rb:86:5:86:11 | [post] self | app.rb:2:22:4:5 | <captured entry> self |
-| app.rb:86:5:86:11 | [post] self | app.rb:10:21:13:5 | <captured entry> self |
-| app.rb:86:5:86:11 | [post] self | app.rb:15:23:18:5 | <captured entry> self |
-| app.rb:86:5:86:11 | [post] self | app.rb:24:26:26:5 | <captured entry> self |
-| app.rb:86:5:86:11 | [post] self | app.rb:37:16:42:5 | <captured entry> self |
-| app.rb:86:5:86:11 | [post] self | app.rb:44:53:46:5 | <captured entry> self |
-| app.rb:86:5:86:11 | [post] self | app.rb:56:32:58:5 | <captured entry> self |
-| app.rb:86:5:86:11 | [post] self | app.rb:60:48:62:5 | <captured entry> self |
-| app.rb:86:5:86:11 | [post] self | app.rb:74:11:77:5 | <captured entry> self |
-| app.rb:86:5:86:11 | [post] self | app.rb:79:11:82:5 | <captured entry> self |
-| app.rb:86:5:86:11 | [post] self | app.rb:89:16:92:5 | <captured entry> self |
-| app.rb:86:5:86:11 | [post] self | app.rb:94:15:96:5 | <captured entry> self |
-| app.rb:103:5:103:9 | [post] self | app.rb:2:22:4:5 | <captured entry> self |
-| app.rb:103:5:103:9 | [post] self | app.rb:10:21:13:5 | <captured entry> self |
-| app.rb:103:5:103:9 | [post] self | app.rb:15:23:18:5 | <captured entry> self |
-| app.rb:103:5:103:9 | [post] self | app.rb:24:26:26:5 | <captured entry> self |
-| app.rb:103:5:103:9 | [post] self | app.rb:37:16:42:5 | <captured entry> self |
-| app.rb:103:5:103:9 | [post] self | app.rb:44:53:46:5 | <captured entry> self |
-| app.rb:103:5:103:9 | [post] self | app.rb:56:32:58:5 | <captured entry> self |
-| app.rb:103:5:103:9 | [post] self | app.rb:60:48:62:5 | <captured entry> self |
-| app.rb:103:5:103:9 | [post] self | app.rb:74:11:77:5 | <captured entry> self |
-| app.rb:103:5:103:9 | [post] self | app.rb:79:11:82:5 | <captured entry> self |
-| app.rb:103:5:103:9 | [post] self | app.rb:89:16:92:5 | <captured entry> self |
-| app.rb:103:5:103:9 | [post] self | app.rb:94:15:96:5 | <captured entry> self |
-| app.rb:103:13:103:22 | [post] self | app.rb:2:22:4:5 | <captured entry> self |
-| app.rb:103:13:103:22 | [post] self | app.rb:10:21:13:5 | <captured entry> self |
-| app.rb:103:13:103:22 | [post] self | app.rb:15:23:18:5 | <captured entry> self |
-| app.rb:103:13:103:22 | [post] self | app.rb:24:26:26:5 | <captured entry> self |
-| app.rb:103:13:103:22 | [post] self | app.rb:37:16:42:5 | <captured entry> self |
-| app.rb:103:13:103:22 | [post] self | app.rb:44:53:46:5 | <captured entry> self |
-| app.rb:103:13:103:22 | [post] self | app.rb:56:32:58:5 | <captured entry> self |
-| app.rb:103:13:103:22 | [post] self | app.rb:60:48:62:5 | <captured entry> self |
-| app.rb:103:13:103:22 | [post] self | app.rb:74:11:77:5 | <captured entry> self |
-| app.rb:103:13:103:22 | [post] self | app.rb:79:11:82:5 | <captured entry> self |
-| app.rb:103:13:103:22 | [post] self | app.rb:89:16:92:5 | <captured entry> self |
-| app.rb:103:13:103:22 | [post] self | app.rb:94:15:96:5 | <captured entry> self |
+| app.rb:84:10:87:5 | [post] do ... end | app.rb:2:22:4:5 | lambda self in do ... end |
+| app.rb:84:10:87:5 | [post] do ... end | app.rb:6:24:8:5 | lambda self in do ... end |
+| app.rb:84:10:87:5 | [post] do ... end | app.rb:10:21:13:5 | lambda self in do ... end |
+| app.rb:84:10:87:5 | [post] do ... end | app.rb:15:23:18:5 | lambda self in do ... end |
+| app.rb:84:10:87:5 | [post] do ... end | app.rb:20:23:22:5 | lambda self in do ... end |
+| app.rb:84:10:87:5 | [post] do ... end | app.rb:24:26:26:5 | lambda self in do ... end |
+| app.rb:84:10:87:5 | [post] do ... end | app.rb:28:26:31:5 | lambda self in do ... end |
+| app.rb:84:10:87:5 | [post] do ... end | app.rb:33:25:35:5 | lambda self in do ... end |
+| app.rb:84:10:87:5 | [post] do ... end | app.rb:37:16:42:5 | lambda self in do ... end |
+| app.rb:84:10:87:5 | [post] do ... end | app.rb:44:53:46:5 | lambda self in do ... end |
+| app.rb:84:10:87:5 | [post] do ... end | app.rb:48:14:50:5 | lambda self in do ... end |
+| app.rb:84:10:87:5 | [post] do ... end | app.rb:52:37:54:5 | lambda self in do ... end |
+| app.rb:84:10:87:5 | [post] do ... end | app.rb:56:32:58:5 | lambda self in do ... end |
+| app.rb:84:10:87:5 | [post] do ... end | app.rb:60:48:62:5 | lambda self in do ... end |
+| app.rb:84:10:87:5 | [post] do ... end | app.rb:66:41:68:5 | lambda self in do ... end |
+| app.rb:84:10:87:5 | [post] do ... end | app.rb:70:20:72:5 | lambda self in do ... end |
+| app.rb:84:10:87:5 | [post] do ... end | app.rb:74:11:77:5 | lambda self in do ... end |
+| app.rb:84:10:87:5 | [post] do ... end | app.rb:79:11:82:5 | lambda self in do ... end |
+| app.rb:84:10:87:5 | [post] do ... end | app.rb:89:16:92:5 | lambda self in do ... end |
+| app.rb:84:10:87:5 | [post] do ... end | app.rb:94:15:96:5 | lambda self in do ... end |
+| app.rb:102:10:104:5 | [post] do ... end | app.rb:2:22:4:5 | lambda self in do ... end |
+| app.rb:102:10:104:5 | [post] do ... end | app.rb:6:24:8:5 | lambda self in do ... end |
+| app.rb:102:10:104:5 | [post] do ... end | app.rb:10:21:13:5 | lambda self in do ... end |
+| app.rb:102:10:104:5 | [post] do ... end | app.rb:15:23:18:5 | lambda self in do ... end |
+| app.rb:102:10:104:5 | [post] do ... end | app.rb:20:23:22:5 | lambda self in do ... end |
+| app.rb:102:10:104:5 | [post] do ... end | app.rb:24:26:26:5 | lambda self in do ... end |
+| app.rb:102:10:104:5 | [post] do ... end | app.rb:28:26:31:5 | lambda self in do ... end |
+| app.rb:102:10:104:5 | [post] do ... end | app.rb:33:25:35:5 | lambda self in do ... end |
+| app.rb:102:10:104:5 | [post] do ... end | app.rb:37:16:42:5 | lambda self in do ... end |
+| app.rb:102:10:104:5 | [post] do ... end | app.rb:44:53:46:5 | lambda self in do ... end |
+| app.rb:102:10:104:5 | [post] do ... end | app.rb:48:14:50:5 | lambda self in do ... end |
+| app.rb:102:10:104:5 | [post] do ... end | app.rb:52:37:54:5 | lambda self in do ... end |
+| app.rb:102:10:104:5 | [post] do ... end | app.rb:56:32:58:5 | lambda self in do ... end |
+| app.rb:102:10:104:5 | [post] do ... end | app.rb:60:48:62:5 | lambda self in do ... end |
+| app.rb:102:10:104:5 | [post] do ... end | app.rb:66:41:68:5 | lambda self in do ... end |
+| app.rb:102:10:104:5 | [post] do ... end | app.rb:70:20:72:5 | lambda self in do ... end |
+| app.rb:102:10:104:5 | [post] do ... end | app.rb:74:11:77:5 | lambda self in do ... end |
+| app.rb:102:10:104:5 | [post] do ... end | app.rb:79:11:82:5 | lambda self in do ... end |
+| app.rb:102:10:104:5 | [post] do ... end | app.rb:89:16:92:5 | lambda self in do ... end |
+| app.rb:102:10:104:5 | [post] do ... end | app.rb:94:15:96:5 | lambda self in do ... end |

--- a/ruby/ql/test/query-tests/experimental/TemplateInjection/TemplateInjection.expected
+++ b/ruby/ql/test/query-tests/experimental/TemplateInjection/TemplateInjection.expected
@@ -7,15 +7,15 @@ edges
 | ErbInjection.rb:8:5:8:12 | bad_text | ErbInjection.rb:19:20:19:27 | bad_text |
 | ErbInjection.rb:8:16:11:14 | ... % ... | ErbInjection.rb:8:5:8:12 | bad_text |
 | ErbInjection.rb:11:11:11:14 | name | ErbInjection.rb:8:16:11:14 | ... % ... |
-| SlimInjection.rb:5:5:5:8 | name | SlimInjection.rb:8:5:8:12 | bad_text |
 | SlimInjection.rb:5:5:5:8 | name | SlimInjection.rb:11:11:11:14 | name |
-| SlimInjection.rb:5:5:5:8 | name | SlimInjection.rb:17:5:17:13 | bad2_text |
+| SlimInjection.rb:5:5:5:8 | name | SlimInjection.rb:14:23:14:34 | { ... } [captured bad_text] |
+| SlimInjection.rb:5:5:5:8 | name | SlimInjection.rb:23:23:23:35 | { ... } [captured bad2_text] |
 | SlimInjection.rb:5:12:5:17 | call to params | SlimInjection.rb:5:12:5:24 | ...[...] |
 | SlimInjection.rb:5:12:5:24 | ...[...] | SlimInjection.rb:5:5:5:8 | name |
-| SlimInjection.rb:8:5:8:12 | bad_text | SlimInjection.rb:14:25:14:32 | bad_text |
-| SlimInjection.rb:8:16:11:14 | ... % ... | SlimInjection.rb:8:5:8:12 | bad_text |
+| SlimInjection.rb:8:16:11:14 | ... % ... | SlimInjection.rb:14:23:14:34 | { ... } [captured bad_text] |
 | SlimInjection.rb:11:11:11:14 | name | SlimInjection.rb:8:16:11:14 | ... % ... |
-| SlimInjection.rb:17:5:17:13 | bad2_text | SlimInjection.rb:23:25:23:33 | bad2_text |
+| SlimInjection.rb:14:23:14:34 | { ... } [captured bad_text] | SlimInjection.rb:14:25:14:32 | bad_text |
+| SlimInjection.rb:23:23:23:35 | { ... } [captured bad2_text] | SlimInjection.rb:23:25:23:33 | bad2_text |
 nodes
 | ErbInjection.rb:5:5:5:8 | name | semmle.label | name |
 | ErbInjection.rb:5:12:5:17 | call to params | semmle.label | call to params |
@@ -28,11 +28,11 @@ nodes
 | SlimInjection.rb:5:5:5:8 | name | semmle.label | name |
 | SlimInjection.rb:5:12:5:17 | call to params | semmle.label | call to params |
 | SlimInjection.rb:5:12:5:24 | ...[...] | semmle.label | ...[...] |
-| SlimInjection.rb:8:5:8:12 | bad_text | semmle.label | bad_text |
 | SlimInjection.rb:8:16:11:14 | ... % ... | semmle.label | ... % ... |
 | SlimInjection.rb:11:11:11:14 | name | semmle.label | name |
+| SlimInjection.rb:14:23:14:34 | { ... } [captured bad_text] | semmle.label | { ... } [captured bad_text] |
 | SlimInjection.rb:14:25:14:32 | bad_text | semmle.label | bad_text |
-| SlimInjection.rb:17:5:17:13 | bad2_text | semmle.label | bad2_text |
+| SlimInjection.rb:23:23:23:35 | { ... } [captured bad2_text] | semmle.label | { ... } [captured bad2_text] |
 | SlimInjection.rb:23:25:23:33 | bad2_text | semmle.label | bad2_text |
 subpaths
 #select

--- a/ruby/ql/test/query-tests/security/cwe-022/PathInjection.expected
+++ b/ruby/ql/test/query-tests/security/cwe-022/PathInjection.expected
@@ -5,7 +5,9 @@ edges
 | ArchiveApiPathTraversal.rb:10:11:10:23 | ...[...] | ArchiveApiPathTraversal.rb:67:13:67:16 | file |
 | ArchiveApiPathTraversal.rb:15:9:15:14 | call to params | ArchiveApiPathTraversal.rb:15:9:15:25 | ...[...] |
 | ArchiveApiPathTraversal.rb:15:9:15:25 | ...[...] | ArchiveApiPathTraversal.rb:75:11:75:18 | filename |
-| ArchiveApiPathTraversal.rb:49:17:49:27 | destination | ArchiveApiPathTraversal.rb:52:38:52:48 | destination |
+| ArchiveApiPathTraversal.rb:49:17:49:27 | destination | ArchiveApiPathTraversal.rb:50:36:64:7 | do ... end [captured destination] |
+| ArchiveApiPathTraversal.rb:50:36:64:7 | do ... end [captured destination] | ArchiveApiPathTraversal.rb:51:16:63:9 | do ... end [captured destination] |
+| ArchiveApiPathTraversal.rb:51:16:63:9 | do ... end [captured destination] | ArchiveApiPathTraversal.rb:52:38:52:48 | destination |
 | ArchiveApiPathTraversal.rb:52:9:52:24 | destination_file | ArchiveApiPathTraversal.rb:59:21:59:36 | destination_file |
 | ArchiveApiPathTraversal.rb:52:28:52:67 | call to join | ArchiveApiPathTraversal.rb:52:9:52:24 | destination_file |
 | ArchiveApiPathTraversal.rb:52:38:52:48 | destination | ArchiveApiPathTraversal.rb:52:28:52:67 | call to join |
@@ -72,6 +74,8 @@ nodes
 | ArchiveApiPathTraversal.rb:15:9:15:14 | call to params | semmle.label | call to params |
 | ArchiveApiPathTraversal.rb:15:9:15:25 | ...[...] | semmle.label | ...[...] |
 | ArchiveApiPathTraversal.rb:49:17:49:27 | destination | semmle.label | destination |
+| ArchiveApiPathTraversal.rb:50:36:64:7 | do ... end [captured destination] | semmle.label | do ... end [captured destination] |
+| ArchiveApiPathTraversal.rb:51:16:63:9 | do ... end [captured destination] | semmle.label | do ... end [captured destination] |
 | ArchiveApiPathTraversal.rb:52:9:52:24 | destination_file | semmle.label | destination_file |
 | ArchiveApiPathTraversal.rb:52:28:52:67 | call to join | semmle.label | call to join |
 | ArchiveApiPathTraversal.rb:52:38:52:48 | destination | semmle.label | destination |

--- a/ruby/ql/test/query-tests/security/cwe-117/LogInjection.expected
+++ b/ruby/ql/test/query-tests/security/cwe-117/LogInjection.expected
@@ -4,14 +4,16 @@ edges
 | app/controllers/users_controller.rb:15:5:15:15 | unsanitized | app/controllers/users_controller.rb:23:20:23:30 | unsanitized |
 | app/controllers/users_controller.rb:15:19:15:24 | call to params | app/controllers/users_controller.rb:15:19:15:30 | ...[...] |
 | app/controllers/users_controller.rb:15:19:15:30 | ...[...] | app/controllers/users_controller.rb:15:5:15:15 | unsanitized |
-| app/controllers/users_controller.rb:23:5:23:16 | unsanitized2 | app/controllers/users_controller.rb:25:7:25:18 | unsanitized2 |
-| app/controllers/users_controller.rb:23:5:23:16 | unsanitized2 | app/controllers/users_controller.rb:27:16:27:39 | ... + ... |
 | app/controllers/users_controller.rb:23:20:23:30 | unsanitized | app/controllers/users_controller.rb:23:20:23:44 | call to sub |
-| app/controllers/users_controller.rb:23:20:23:44 | call to sub | app/controllers/users_controller.rb:23:5:23:16 | unsanitized2 |
-| app/controllers/users_controller.rb:33:5:33:15 | unsanitized | app/controllers/users_controller.rb:34:33:34:43 | unsanitized |
-| app/controllers/users_controller.rb:33:5:33:15 | unsanitized | app/controllers/users_controller.rb:35:33:35:55 | ... + ... |
+| app/controllers/users_controller.rb:23:20:23:44 | call to sub | app/controllers/users_controller.rb:24:18:26:7 | do ... end [captured unsanitized2] |
+| app/controllers/users_controller.rb:23:20:23:44 | call to sub | app/controllers/users_controller.rb:27:16:27:39 | ... + ... |
+| app/controllers/users_controller.rb:24:18:26:7 | do ... end [captured unsanitized2] | app/controllers/users_controller.rb:25:7:25:18 | unsanitized2 |
 | app/controllers/users_controller.rb:33:19:33:25 | call to cookies | app/controllers/users_controller.rb:33:19:33:31 | ...[...] |
-| app/controllers/users_controller.rb:33:19:33:31 | ...[...] | app/controllers/users_controller.rb:33:5:33:15 | unsanitized |
+| app/controllers/users_controller.rb:33:19:33:31 | ...[...] | app/controllers/users_controller.rb:34:31:34:45 | { ... } [captured unsanitized] |
+| app/controllers/users_controller.rb:33:19:33:31 | ...[...] | app/controllers/users_controller.rb:35:31:35:57 | { ... } [captured unsanitized] |
+| app/controllers/users_controller.rb:34:31:34:45 | { ... } [captured unsanitized] | app/controllers/users_controller.rb:34:33:34:43 | unsanitized |
+| app/controllers/users_controller.rb:35:31:35:57 | { ... } [captured unsanitized] | app/controllers/users_controller.rb:35:45:35:55 | unsanitized |
+| app/controllers/users_controller.rb:35:45:35:55 | unsanitized | app/controllers/users_controller.rb:35:33:35:55 | ... + ... |
 | app/controllers/users_controller.rb:49:19:49:24 | call to params | app/controllers/users_controller.rb:49:19:49:30 | ...[...] |
 nodes
 | app/controllers/users_controller.rb:15:5:15:15 | unsanitized | semmle.label | unsanitized |
@@ -19,16 +21,18 @@ nodes
 | app/controllers/users_controller.rb:15:19:15:30 | ...[...] | semmle.label | ...[...] |
 | app/controllers/users_controller.rb:16:19:16:29 | unsanitized | semmle.label | unsanitized |
 | app/controllers/users_controller.rb:17:19:17:41 | ... + ... | semmle.label | ... + ... |
-| app/controllers/users_controller.rb:23:5:23:16 | unsanitized2 | semmle.label | unsanitized2 |
 | app/controllers/users_controller.rb:23:20:23:30 | unsanitized | semmle.label | unsanitized |
 | app/controllers/users_controller.rb:23:20:23:44 | call to sub | semmle.label | call to sub |
+| app/controllers/users_controller.rb:24:18:26:7 | do ... end [captured unsanitized2] | semmle.label | do ... end [captured unsanitized2] |
 | app/controllers/users_controller.rb:25:7:25:18 | unsanitized2 | semmle.label | unsanitized2 |
 | app/controllers/users_controller.rb:27:16:27:39 | ... + ... | semmle.label | ... + ... |
-| app/controllers/users_controller.rb:33:5:33:15 | unsanitized | semmle.label | unsanitized |
 | app/controllers/users_controller.rb:33:19:33:25 | call to cookies | semmle.label | call to cookies |
 | app/controllers/users_controller.rb:33:19:33:31 | ...[...] | semmle.label | ...[...] |
+| app/controllers/users_controller.rb:34:31:34:45 | { ... } [captured unsanitized] | semmle.label | { ... } [captured unsanitized] |
 | app/controllers/users_controller.rb:34:33:34:43 | unsanitized | semmle.label | unsanitized |
+| app/controllers/users_controller.rb:35:31:35:57 | { ... } [captured unsanitized] | semmle.label | { ... } [captured unsanitized] |
 | app/controllers/users_controller.rb:35:33:35:55 | ... + ... | semmle.label | ... + ... |
+| app/controllers/users_controller.rb:35:45:35:55 | unsanitized | semmle.label | unsanitized |
 | app/controllers/users_controller.rb:49:19:49:24 | call to params | semmle.label | call to params |
 | app/controllers/users_controller.rb:49:19:49:30 | ...[...] | semmle.label | ...[...] |
 subpaths


### PR DESCRIPTION
This PR adopts the [shared variable capture flow library](https://github.com/github/codeql/pull/13478) in Ruby.

The new results reported by DCA are a result of the fact that we are now also able to track side-effects on captured variables, such as writes to instance fields inside blocks. The lost results (those that I have checked) are FPs resulting from the old jump-step based modeling, where data could flow in through one callable and out via another.

The implementation is similar to Java (see PR above), except I chose to distinguish "lambda `self`" from "normal `self`". This is because `self` can actually be referenced from within lambdas (as a captured variable):

```rb
class C
    def foo
        self.@x = taint # the `self.` is actually implicit in Ruby
    end

    def bar
        yield
    end

    def baz
        self.bar do
            sink self.@x # captured access to `self`
        end
    end
end

c = C.new
c.foo
c.baz
```