### PR TITLE
C++: `PostUpdateNode`s for const-pointer arguments

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternalsCommon.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternalsCommon.qll
@@ -4,6 +4,7 @@ import semmle.code.cpp.ir.internal.IRCppLanguage
 private import semmle.code.cpp.ir.implementation.raw.internal.SideEffects as SideEffects
 private import DataFlowImplCommon as DataFlowImplCommon
 private import DataFlowUtil
+private import semmle.code.cpp.models.interfaces.PointerWrapper
 private import DataFlowPrivate
 
 /**
@@ -137,7 +138,7 @@ abstract class Indirection extends Type {
   Type baseType;
 
   /** Gets the type of this indirection. */
-  final Type getType() { result = super.getUnspecifiedType() }
+  final Type getType() { result = this }
 
   /**
    * Gets the number of indirections supported by this type.
@@ -166,7 +167,7 @@ abstract class Indirection extends Type {
    *
    * For example, the base type of `int*&` is `int*`, and the base type of `int*` is `int`.
    */
-  final Type getBaseType() { result = baseType.getUnspecifiedType() }
+  final Type getBaseType() { result = baseType }
 
   /** Holds if there should be an additional taint step from `node1` to `node2`. */
   predicate isAdditionalTaintStep(Node node1, Node node2) { none() }
@@ -181,7 +182,9 @@ abstract class Indirection extends Type {
 private class PointerOrReferenceTypeIndirection extends Indirection instanceof PointerOrReferenceType {
   PointerOrReferenceTypeIndirection() { baseType = PointerOrReferenceType.super.getBaseType() }
 
-  override int getNumberOfIndirections() { result = 1 + countIndirections(this.getBaseType()) }
+  override int getNumberOfIndirections() {
+    result = 1 + countIndirections(this.getBaseType().getUnspecifiedType())
+  }
 
   override predicate isAdditionalDereference(Instruction deref, Operand address) { none() }
 
@@ -198,7 +201,9 @@ private module IteratorIndirections {
       not this instanceof PointerOrReferenceTypeIndirection and baseType = super.getValueType()
     }
 
-    override int getNumberOfIndirections() { result = 1 + countIndirections(this.getBaseType()) }
+    override int getNumberOfIndirections() {
+      result = 1 + countIndirections(this.getBaseType().getUnspecifiedType())
+    }
 
     override predicate isAdditionalDereference(Instruction deref, Operand address) {
       exists(CallInstruction call |
@@ -352,8 +357,9 @@ class BaseCallVariable extends BaseSourceVariable, TBaseCallVariable {
  * Holds if the value pointed to by `operand` can potentially be
  * modified be the caller.
  */
-predicate isModifiableByCall(ArgumentOperand operand) {
+predicate isModifiableByCall(ArgumentOperand operand, int indirectionIndex) {
   exists(CallInstruction call, int index, CppType type |
+    indirectionIndex = [1 .. countIndirectionsForCppType(type)] and
     type = getLanguageType(operand) and
     call.getArgumentOperand(index) = operand and
     if index = -1
@@ -385,13 +391,50 @@ predicate isModifiableByCall(ArgumentOperand operand) {
       else any()
     else
       // An argument is modifiable if it's a non-const pointer or reference type.
-      exists(Type t, boolean isGLValue | type.hasType(t, isGLValue) |
-        // If t is a glvalue it means that t is always a pointer-like type.
-        isGLValue = true
-        or
-        t instanceof PointerOrReferenceType and
-        not SideEffects::isConstPointerLike(t)
-      )
+      isModifiableAt(type, indirectionIndex)
+  )
+}
+
+/**
+ * Holds if `t` is a pointer or reference type that supports at least `indirectionIndex` number
+ * of indirections, and the `indirectionIndex` indirection cannot be modfiied by passing a
+ * value of `t` to a function.
+ */
+private predicate isModifiableAtImpl(CppType cppType, int indirectionIndex) {
+  indirectionIndex = [1 .. countIndirectionsForCppType(cppType)] and
+  (
+    exists(PointerOrReferenceType pointerType, Type base, Type t |
+      cppType.hasType(t, _) and
+      pointerType = t.getUnderlyingType() and
+      base = getTypeImpl(pointerType, indirectionIndex)
+    |
+      // The value cannot be modified if it has a const specifier,
+      not base.isConst()
+      or
+      // but in the case of a class type, it may be the case that
+      // one of the members were modified.
+      exists(base.stripType().(Cpp::Class).getAField())
+    )
+    or
+    // If the `indirectionIndex`'th dereference of a type can be modified
+    // then so can the  `indirectionIndex + 1`'th dereference.
+    isModifiableAtImpl(cppType, indirectionIndex - 1)
+  )
+}
+
+/**
+ * Holds if `t` is a type with at least `indirectionIndex` number of indirections,
+ * and the `indirectionIndex` indirection can be modified by passing a value of
+ * type `t` to a function function.
+ */
+bindingset[indirectionIndex]
+private predicate isModifiableAt(CppType cppType, int indirectionIndex) {
+  isModifiableAtImpl(cppType, indirectionIndex)
+  or
+  exists(PointerWrapper pw, Type t |
+    cppType.hasType(t, _) and
+    t.stripType() = pw and
+    not pw.pointsToConst()
   )
 }
 

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternalsCommon.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternalsCommon.qll
@@ -412,7 +412,7 @@ private predicate isModifiableAtImpl(CppType cppType, int indirectionIndex) {
       not base.isConst()
       or
       // but in the case of a class type, it may be the case that
-      // one of the members were modified.
+      // one of the members was modified.
       exists(base.stripType().(Cpp::Class).getAField())
     )
     or

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-190/AllocMultiplicationOverflow/AllocMultiplicationOverflow.expected
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-190/AllocMultiplicationOverflow/AllocMultiplicationOverflow.expected
@@ -6,6 +6,9 @@ edges
 | test.cpp:22:17:22:21 | ... * ... | test.cpp:23:33:23:37 | size1 |
 | test.cpp:37:24:37:27 | size | test.cpp:37:46:37:49 | size |
 | test.cpp:45:36:45:40 | ... * ... | test.cpp:37:24:37:27 | size |
+| test.cpp:45:36:45:40 | ... * ... | test.cpp:45:36:45:40 | ... * ... |
+| test.cpp:45:36:45:40 | ... * ... | test.cpp:45:36:45:40 | ... * ... |
+| test.cpp:46:36:46:40 | ... * ... | test.cpp:46:36:46:40 | ... * ... |
 nodes
 | test.cpp:13:33:13:37 | ... * ... | semmle.label | ... * ... |
 | test.cpp:13:33:13:37 | ... * ... | semmle.label | ... * ... |
@@ -25,6 +28,10 @@ nodes
 | test.cpp:37:46:37:49 | size | semmle.label | size |
 | test.cpp:45:36:45:40 | ... * ... | semmle.label | ... * ... |
 | test.cpp:45:36:45:40 | ... * ... | semmle.label | ... * ... |
+| test.cpp:45:36:45:40 | ... * ... | semmle.label | ... * ... |
+| test.cpp:45:36:45:40 | ... * ... | semmle.label | ... * ... |
+| test.cpp:46:36:46:40 | ... * ... | semmle.label | ... * ... |
+| test.cpp:46:36:46:40 | ... * ... | semmle.label | ... * ... |
 | test.cpp:46:36:46:40 | ... * ... | semmle.label | ... * ... |
 subpaths
 #select
@@ -42,5 +49,10 @@ subpaths
 | test.cpp:30:27:30:31 | ... * ... | test.cpp:30:27:30:31 | ... * ... | test.cpp:30:27:30:31 | ... * ... | Potentially overflowing value from $@ is used in the size of this allocation. | test.cpp:30:27:30:31 | ... * ... | multiplication |
 | test.cpp:31:27:31:31 | ... * ... | test.cpp:31:27:31:31 | ... * ... | test.cpp:31:27:31:31 | ... * ... | Potentially overflowing value from $@ is used in the size of this allocation. | test.cpp:31:27:31:31 | ... * ... | multiplication |
 | test.cpp:37:46:37:49 | size | test.cpp:45:36:45:40 | ... * ... | test.cpp:37:46:37:49 | size | Potentially overflowing value from $@ is used in the size of this allocation. | test.cpp:45:36:45:40 | ... * ... | multiplication |
+| test.cpp:37:46:37:49 | size | test.cpp:45:36:45:40 | ... * ... | test.cpp:37:46:37:49 | size | Potentially overflowing value from $@ is used in the size of this allocation. | test.cpp:45:36:45:40 | ... * ... | multiplication |
 | test.cpp:45:36:45:40 | ... * ... | test.cpp:45:36:45:40 | ... * ... | test.cpp:45:36:45:40 | ... * ... | Potentially overflowing value from $@ is used in the size of this allocation. | test.cpp:45:36:45:40 | ... * ... | multiplication |
+| test.cpp:45:36:45:40 | ... * ... | test.cpp:45:36:45:40 | ... * ... | test.cpp:45:36:45:40 | ... * ... | Potentially overflowing value from $@ is used in the size of this allocation. | test.cpp:45:36:45:40 | ... * ... | multiplication |
+| test.cpp:45:36:45:40 | ... * ... | test.cpp:45:36:45:40 | ... * ... | test.cpp:45:36:45:40 | ... * ... | Potentially overflowing value from $@ is used in the size of this allocation. | test.cpp:45:36:45:40 | ... * ... | multiplication |
+| test.cpp:46:36:46:40 | ... * ... | test.cpp:46:36:46:40 | ... * ... | test.cpp:46:36:46:40 | ... * ... | Potentially overflowing value from $@ is used in the size of this allocation. | test.cpp:46:36:46:40 | ... * ... | multiplication |
+| test.cpp:46:36:46:40 | ... * ... | test.cpp:46:36:46:40 | ... * ... | test.cpp:46:36:46:40 | ... * ... | Potentially overflowing value from $@ is used in the size of this allocation. | test.cpp:46:36:46:40 | ... * ... | multiplication |
 | test.cpp:46:36:46:40 | ... * ... | test.cpp:46:36:46:40 | ... * ... | test.cpp:46:36:46:40 | ... * ... | Potentially overflowing value from $@ is used in the size of this allocation. | test.cpp:46:36:46:40 | ... * ... | multiplication |

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/dataflow-consistency.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/dataflow-consistency.expected
@@ -96,6 +96,9 @@ postWithInFlow
 | test.cpp:519:3:519:15 | access to array [post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:520:3:520:12 | stackArray [inner post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:520:3:520:15 | access to array [post update] | PostUpdateNode should not be the target of local flow. |
+| test.cpp:526:3:526:4 | * ... [post update] | PostUpdateNode should not be the target of local flow. |
+| test.cpp:526:4:526:4 | e [inner post update] | PostUpdateNode should not be the target of local flow. |
+| test.cpp:531:40:531:40 | e [inner post update] | PostUpdateNode should not be the target of local flow. |
 viableImplInCallContextTooLarge
 uniqueParameterNodeAtPosition
 uniqueParameterNodePosition

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
@@ -520,3 +520,14 @@ void uncertain_definition() {
   stackArray[1] = clean;
   sink(stackArray[0]); // $ ast=519:19 ir SPURIOUS: ast=517:7
 }
+
+void set_through_const_pointer(int x, const int **e)
+{
+  *e = &x;
+}
+
+void test_set_through_const_pointer(int *e)
+{
+  set_through_const_pointer(source(), &e);
+  sink(*e); // $ ir MISSING: ast
+}

--- a/cpp/ql/test/library-tests/dataflow/fields/partial-definition-diff.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/partial-definition-diff.expected
@@ -153,6 +153,8 @@
 | by_reference.cpp:16:11:16:11 | a | AST only |
 | by_reference.cpp:32:15:32:15 | s | IR only |
 | by_reference.cpp:36:18:36:18 | this | IR only |
+| by_reference.cpp:44:26:44:29 | this | IR only |
+| by_reference.cpp:69:22:69:23 | & ... | IR only |
 | by_reference.cpp:84:10:84:10 | a | AST only |
 | by_reference.cpp:88:9:88:9 | a | AST only |
 | by_reference.cpp:92:3:92:5 | * ... | AST only |

--- a/cpp/ql/test/library-tests/dataflow/fields/partial-definition-ir.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/partial-definition-ir.expected
@@ -333,6 +333,7 @@
 | by_reference.cpp:32:12:32:12 | s |
 | by_reference.cpp:36:12:36:15 | this |
 | by_reference.cpp:40:12:40:15 | this |
+| by_reference.cpp:44:26:44:29 | this |
 | by_reference.cpp:50:3:50:3 | s |
 | by_reference.cpp:50:17:50:26 | call to user_input |
 | by_reference.cpp:51:8:51:8 | s |
@@ -348,6 +349,7 @@
 | by_reference.cpp:68:17:68:18 | & ... |
 | by_reference.cpp:68:21:68:30 | call to user_input |
 | by_reference.cpp:69:8:69:20 | call to nonMemberGetA |
+| by_reference.cpp:69:22:69:23 | & ... |
 | by_reference.cpp:84:3:84:7 | inner |
 | by_reference.cpp:88:3:88:7 | inner |
 | by_reference.cpp:102:21:102:39 | & ... |

--- a/cpp/ql/test/library-tests/dataflow/source-sink-tests/sources-and-sinks.cpp
+++ b/cpp/ql/test/library-tests/dataflow/source-sink-tests/sources-and-sinks.cpp
@@ -23,7 +23,7 @@ int readv(int, const struct iovec*, int);
 int writev(int, const struct iovec*, int);
 
 void test_readv_and_writev(iovec* iovs) {
-  readv(0, iovs, 16); // $ MISSING: remote_source
+  readv(0, iovs, 16); // $ remote_source
   writev(0, iovs, 16); // $ remote_sink
 }
 


### PR DESCRIPTION
Previously, we failed to identify that flow can come out of functions with a signature like [readv](https://man7.org/linux/man-pages/man2/readv.2.html). This PR fixes this.

Slightly more generally, this PR fixes problems related to getting flow out of a function like:
```cpp
void foo(const char** p);
```
since it's perfectly possible for `foo` to write to `*p`.

Luckily, everything in dataflow was already setup to handle the flow. We just didn't didn't add dataflow nodes representing the outgoing flow for such arguments.

There are a lot of new results (and no lost results 🎉!). I've checked all the SAMATE once, and they all seem to be in tests that we're expected to flag. Similarly, the results on real code also look like things the queries are expected to find (but which we didn't find previously because we had assumed flow couldn't exit through some `const` parameter).