### PR TITLE
Remove references to lgtm.com in Go folder

### DIFF
--- a/go/CONTRIBUTING.md
+++ b/go/CONTRIBUTING.md
@@ -44,7 +44,7 @@ Follow the steps below to help other users understand what your query does, and 
 
 4. **Make sure the `select` statement is compatible with the query type**
 
-   The `select` statement of your query must be compatible with the query type (determined by the `@kind` metadata property) for alert or path results to be displayed correctly in LGTM and Visual Studio Code.
+   The `select` statement of your query must be compatible with the query type (determined by the `@kind` metadata property) for alert or path results to be displayed correctly in query results.
    For more information on `select` statement format, see [About CodeQL queries](https://codeql.github.com/docs/writing-codeql-queries/about-codeql-queries/#select-clause) on codeql.github.com.
 
 5. **Write a query help file**

--- a/go/README.md
+++ b/go/README.md
@@ -1,19 +1,13 @@
 # Go analysis support for CodeQL
 
-This open-source repository contains the extractor, CodeQL libraries, and queries that power Go
-support in [LGTM](https://lgtm.com) and the other CodeQL products that [GitHub](https://github.com)
-makes available to its customers worldwide.
+This sub-folder contains the extractor, CodeQL libraries, and queries that power Go
+support for CodeQL.
 
 It contains two major components:
   - an extractor, itself written in Go, that parses Go source code and converts it into a database
     that can be queried using CodeQL.
   - static analysis libraries and queries written in [CodeQL](https://codeql.github.com/docs/) that can be
     used to analyze such a database to find coding mistakes or security vulnerabilities.
-
-The goal of this project is to provide comprehensive static analysis support for Go in CodeQL.
-
-For the queries and libraries that power CodeQL support for other languages, visit [the CodeQL
-repository](https://github.com/github/codeql).
 
 ## Installation
 
@@ -30,14 +24,8 @@ Code workspace.
 
 To analyze a Go codebase, either use the [CodeQL command-line
 interface](https://codeql.github.com/docs/codeql-cli/) to create a database yourself, or
-download a pre-built database from [LGTM.com](https://lgtm.com/). You can then run any of the
+download a pre-built database from [GitHub.com](https://codeql.github.com/docs/codeql-cli/creating-codeql-databases/#downloading-databases-from-github-com). You can then run any of the
 queries contained in this repository either on the command line or using the VS Code extension.
-
-Note that the [lgtm.com](https://github.com/github/codeql/tree/lgtm.com) branch of this
-repository corresponds to the version of the queries that is currently deployed on LGTM.com.
-The [main](https://github.com/github/codeql/tree/main) branch may contain changes that
-have not been deployed yet, so you may need to upgrade databases downloaded from LGTM.com before
-running queries on them.
 
 ## Contributions
 


### PR DESCRIPTION
Removes references to lgtm.com within the "go" folder. This PR also includes some cleanup of the README file within the "go" folder. 