### PR TITLE
Fix javascript syntax

### DIFF
--- a/javascript/ql/src/Security/CWE-754/examples/UnvalidatedDynamicMethodCallGood.js
+++ b/javascript/ql/src/Security/CWE-754/examples/UnvalidatedDynamicMethodCallGood.js
@@ -2,10 +2,10 @@ var express = require('express');
 var app = express();
 
 var actions = new Map();
-actions.put("play", function play(data) {
+actions.set("play", function play(data) {
   // ...
 });
-actions.put("pause", function pause(data) {
+actions.set("pause", function pause(data) {
   // ...
 });
 

--- a/javascript/ql/test/query-tests/Security/CWE-754/UnvalidatedDynamicMethodCall3.js
+++ b/javascript/ql/test/query-tests/Security/CWE-754/UnvalidatedDynamicMethodCall3.js
@@ -2,10 +2,10 @@ var express = require('express');
 var app = express();
 
 var actions = new Map();
-actions.put("play", function play(data) {
+actions.set("play", function play(data) {
     // ...
 });
-actions.put("pause", function pause(data) {
+actions.set("pause", function pause(data) {
     // ...
 });
 


### PR DESCRIPTION
The example used a method called `put`, but the correct method is `set` according to the [referenced MDN page](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map). Using `put` the code returns:
```
actions.put("play", function play(data) {
        ^

TypeError: actions.put is not a function
    at Object.<anonymous> (/Users/jacola/devel/tmpnodejs/index.js:5:9)
    at Module._compile (node:internal/modules/cjs/loader:1205:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1259:10)
    at Module.load (node:internal/modules/cjs/loader:1068:32)
    at Module._load (node:internal/modules/cjs/loader:909:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:82:12)
    at node:internal/main/run_main_module:23:47

Node.js v19.1.0
```