### PR TITLE
QL/RB: make top TreeSitter.qll comment into a qldoc

### DIFF
--- a/ql/generator/src/main.rs
+++ b/ql/generator/src/main.rs
@@ -604,7 +604,7 @@ fn main() -> std::io::Result<()> {
     let mut ql_writer = LineWriter::new(File::create(ql_library_path)?);
     write!(
         ql_writer,
-        "/*\n\
+        "/**\n\
           * CodeQL library for {}
           * Automatically generated from the tree-sitter grammar; do not edit\n\
           */\n\n",

--- a/ql/ql/src/codeql_ql/ast/internal/TreeSitter.qll
+++ b/ql/ql/src/codeql_ql/ast/internal/TreeSitter.qll
@@ -1,4 +1,4 @@
-/*
+/**
  * CodeQL library for QL
  * Automatically generated from the tree-sitter grammar; do not edit
  */

--- a/ruby/generator/src/main.rs
+++ b/ruby/generator/src/main.rs
@@ -599,7 +599,7 @@ fn main() -> std::io::Result<()> {
     let mut ql_writer = LineWriter::new(File::create(ql_library_path)?);
     write!(
         ql_writer,
-        "/*\n\
+        "/**\n\
           * CodeQL library for {}
           * Automatically generated from the tree-sitter grammar; do not edit\n\
           */\n\n",

--- a/ruby/ql/lib/codeql/ruby/ast/internal/TreeSitter.qll
+++ b/ruby/ql/lib/codeql/ruby/ast/internal/TreeSitter.qll
@@ -1,4 +1,4 @@
-/*
+/**
  * CodeQL library for Ruby
  * Automatically generated from the tree-sitter grammar; do not edit
  */


### PR DESCRIPTION
QL-for-QL complained about it.  

It makes sense for the top-level comment to be a QLDoc instead of a block-comment, so I fixed it. 