### PR TITLE
Java: Fix new Android queries' IDs

### DIFF
--- a/java/ql/src/Security/CWE/CWE-079/AndroidWebViewAddJavascriptInterface.ql
+++ b/java/ql/src/Security/CWE/CWE-079/AndroidWebViewAddJavascriptInterface.ql
@@ -1,6 +1,6 @@
 /**
  * @name Access Java object methods through JavaScript exposure
- * @id java/android-webview-addjavascriptinterface
+ * @id java/android/webview-addjavascriptinterface
  * @description Exposing a Java object in a WebView with a JavaScript interface can lead to malicious JavaScript controlling the application.
  * @kind problem
  * @problem.severity warning

--- a/java/ql/src/Security/CWE/CWE-079/AndroidWebViewSettingsEnabledJavaScript.ql
+++ b/java/ql/src/Security/CWE/CWE-079/AndroidWebViewSettingsEnabledJavaScript.ql
@@ -2,7 +2,7 @@
  * @name Android WebView JavaScript settings
  * @description Enabling JavaScript execution in a WebView can result in cross-site scripting attacks.
  * @kind problem
- * @id java/android-websettings-javascript-enabled
+ * @id java/android/websettings-javascript-enabled
  * @problem.severity warning
  * @security-severity 6.1
  * @precision medium

--- a/java/ql/src/Security/CWE/CWE-200/AndroidWebViewSettingsFileAccess.ql
+++ b/java/ql/src/Security/CWE/CWE-200/AndroidWebViewSettingsFileAccess.ql
@@ -2,7 +2,7 @@
  * @name Android WebSettings file access
  * @kind problem
  * @description Enabling access to the file system in a WebView allows attackers to view sensitive information.
- * @id java/android-websettings-file-access
+ * @id java/android/websettings-file-access
  * @problem.severity warning
  * @security-severity 6.5
  * @precision medium


### PR DESCRIPTION
Use the `java/android/` prefix for the IDs of Android queries.

These haven't been part of any release yet, so the change shouldn't cause any trouble.