### PR TITLE
JS: Sanitizer for `sanitizer(x) === true`

### DIFF
--- a/javascript/ql/lib/semmle/javascript/Expr.qll
+++ b/javascript/ql/lib/semmle/javascript/Expr.qll
@@ -379,7 +379,10 @@ class NullLiteral extends @null_literal, Literal { }
  * false
  * ```
  */
-class BooleanLiteral extends @boolean_literal, Literal { }
+class BooleanLiteral extends @boolean_literal, Literal {
+  /** Gets the value of this literal. */
+  boolean getBoolValue() { if this.getRawValue() = "true" then result = true else result = false }
+}
 
 /**
  * A numeric literal.

--- a/javascript/ql/test/query-tests/Security/CWE-078/UnsafeShellCommandConstruction/UnsafeShellCommandConstruction.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-078/UnsafeShellCommandConstruction/UnsafeShellCommandConstruction.expected
@@ -301,6 +301,16 @@ nodes
 | lib/lib.js:562:26:562:29 | name |
 | lib/lib.js:566:26:566:29 | name |
 | lib/lib.js:566:26:566:29 | name |
+| lib/lib.js:572:41:572:44 | name |
+| lib/lib.js:572:41:572:44 | name |
+| lib/lib.js:573:22:573:25 | name |
+| lib/lib.js:573:22:573:25 | name |
+| lib/lib.js:579:25:579:28 | name |
+| lib/lib.js:579:25:579:28 | name |
+| lib/lib.js:590:29:590:32 | name |
+| lib/lib.js:590:29:590:32 | name |
+| lib/lib.js:593:25:593:28 | name |
+| lib/lib.js:593:25:593:28 | name |
 | lib/subLib2/compiled-file.ts:3:26:3:29 | name |
 | lib/subLib2/compiled-file.ts:3:26:3:29 | name |
 | lib/subLib2/compiled-file.ts:4:25:4:28 | name |
@@ -703,6 +713,22 @@ edges
 | lib/lib.js:558:41:558:44 | name | lib/lib.js:566:26:566:29 | name |
 | lib/lib.js:558:41:558:44 | name | lib/lib.js:566:26:566:29 | name |
 | lib/lib.js:558:41:558:44 | name | lib/lib.js:566:26:566:29 | name |
+| lib/lib.js:572:41:572:44 | name | lib/lib.js:573:22:573:25 | name |
+| lib/lib.js:572:41:572:44 | name | lib/lib.js:573:22:573:25 | name |
+| lib/lib.js:572:41:572:44 | name | lib/lib.js:573:22:573:25 | name |
+| lib/lib.js:572:41:572:44 | name | lib/lib.js:573:22:573:25 | name |
+| lib/lib.js:572:41:572:44 | name | lib/lib.js:579:25:579:28 | name |
+| lib/lib.js:572:41:572:44 | name | lib/lib.js:579:25:579:28 | name |
+| lib/lib.js:572:41:572:44 | name | lib/lib.js:579:25:579:28 | name |
+| lib/lib.js:572:41:572:44 | name | lib/lib.js:579:25:579:28 | name |
+| lib/lib.js:572:41:572:44 | name | lib/lib.js:590:29:590:32 | name |
+| lib/lib.js:572:41:572:44 | name | lib/lib.js:590:29:590:32 | name |
+| lib/lib.js:572:41:572:44 | name | lib/lib.js:590:29:590:32 | name |
+| lib/lib.js:572:41:572:44 | name | lib/lib.js:590:29:590:32 | name |
+| lib/lib.js:572:41:572:44 | name | lib/lib.js:593:25:593:28 | name |
+| lib/lib.js:572:41:572:44 | name | lib/lib.js:593:25:593:28 | name |
+| lib/lib.js:572:41:572:44 | name | lib/lib.js:593:25:593:28 | name |
+| lib/lib.js:572:41:572:44 | name | lib/lib.js:593:25:593:28 | name |
 | lib/subLib2/compiled-file.ts:3:26:3:29 | name | lib/subLib2/compiled-file.ts:4:25:4:28 | name |
 | lib/subLib2/compiled-file.ts:3:26:3:29 | name | lib/subLib2/compiled-file.ts:4:25:4:28 | name |
 | lib/subLib2/compiled-file.ts:3:26:3:29 | name | lib/subLib2/compiled-file.ts:4:25:4:28 | name |
@@ -826,6 +852,10 @@ edges
 | lib/lib.js:560:14:560:29 | "rm -rf " + name | lib/lib.js:558:41:558:44 | name | lib/lib.js:560:26:560:29 | name | This string concatenation which depends on $@ is later used in a $@. | lib/lib.js:558:41:558:44 | name | library input | lib/lib.js:560:9:560:30 | exec("r ... + name) | shell command |
 | lib/lib.js:562:14:562:29 | "rm -rf " + name | lib/lib.js:558:41:558:44 | name | lib/lib.js:562:26:562:29 | name | This string concatenation which depends on $@ is later used in a $@. | lib/lib.js:558:41:558:44 | name | library input | lib/lib.js:562:9:562:30 | exec("r ... + name) | shell command |
 | lib/lib.js:566:14:566:29 | "rm -rf " + name | lib/lib.js:558:41:558:44 | name | lib/lib.js:566:26:566:29 | name | This string concatenation which depends on $@ is later used in a $@. | lib/lib.js:558:41:558:44 | name | library input | lib/lib.js:566:9:566:30 | exec("r ... + name) | shell command |
+| lib/lib.js:573:10:573:25 | "rm -rf " + name | lib/lib.js:572:41:572:44 | name | lib/lib.js:573:22:573:25 | name | This string concatenation which depends on $@ is later used in a $@. | lib/lib.js:572:41:572:44 | name | library input | lib/lib.js:573:2:573:26 | cp.exec ... + name) | shell command |
+| lib/lib.js:579:13:579:28 | "rm -rf " + name | lib/lib.js:572:41:572:44 | name | lib/lib.js:579:25:579:28 | name | This string concatenation which depends on $@ is later used in a $@. | lib/lib.js:572:41:572:44 | name | library input | lib/lib.js:579:5:579:29 | cp.exec ... + name) | shell command |
+| lib/lib.js:590:17:590:32 | "rm -rf " + name | lib/lib.js:572:41:572:44 | name | lib/lib.js:590:29:590:32 | name | This string concatenation which depends on $@ is later used in a $@. | lib/lib.js:572:41:572:44 | name | library input | lib/lib.js:590:9:590:33 | cp.exec ... + name) | shell command |
+| lib/lib.js:593:13:593:28 | "rm -rf " + name | lib/lib.js:572:41:572:44 | name | lib/lib.js:593:25:593:28 | name | This string concatenation which depends on $@ is later used in a $@. | lib/lib.js:572:41:572:44 | name | library input | lib/lib.js:593:5:593:29 | cp.exec ... + name) | shell command |
 | lib/subLib2/compiled-file.ts:4:13:4:28 | "rm -rf " + name | lib/subLib2/compiled-file.ts:3:26:3:29 | name | lib/subLib2/compiled-file.ts:4:25:4:28 | name | This string concatenation which depends on $@ is later used in a $@. | lib/subLib2/compiled-file.ts:3:26:3:29 | name | library input | lib/subLib2/compiled-file.ts:4:5:4:29 | cp.exec ... + name) | shell command |
 | lib/subLib2/special-file.js:4:10:4:25 | "rm -rf " + name | lib/subLib2/special-file.js:3:28:3:31 | name | lib/subLib2/special-file.js:4:22:4:25 | name | This string concatenation which depends on $@ is later used in a $@. | lib/subLib2/special-file.js:3:28:3:31 | name | library input | lib/subLib2/special-file.js:4:2:4:26 | cp.exec ... + name) | shell command |
 | lib/subLib3/my-file.ts:4:10:4:25 | "rm -rf " + name | lib/subLib3/my-file.ts:3:28:3:31 | name | lib/subLib3/my-file.ts:4:22:4:25 | name | This string concatenation which depends on $@ is later used in a $@. | lib/subLib3/my-file.ts:3:28:3:31 | name | library input | lib/subLib3/my-file.ts:4:2:4:26 | cp.exec ... + name) | shell command |

--- a/javascript/ql/test/query-tests/Security/CWE-078/UnsafeShellCommandConstruction/UnsafeShellCommandConstruction.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-078/UnsafeShellCommandConstruction/UnsafeShellCommandConstruction.expected
@@ -311,6 +311,14 @@ nodes
 | lib/lib.js:590:29:590:32 | name |
 | lib/lib.js:593:25:593:28 | name |
 | lib/lib.js:593:25:593:28 | name |
+| lib/lib.js:608:42:608:45 | name |
+| lib/lib.js:608:42:608:45 | name |
+| lib/lib.js:609:22:609:25 | name |
+| lib/lib.js:609:22:609:25 | name |
+| lib/lib.js:626:29:626:32 | name |
+| lib/lib.js:626:29:626:32 | name |
+| lib/lib.js:629:25:629:28 | name |
+| lib/lib.js:629:25:629:28 | name |
 | lib/subLib2/compiled-file.ts:3:26:3:29 | name |
 | lib/subLib2/compiled-file.ts:3:26:3:29 | name |
 | lib/subLib2/compiled-file.ts:4:25:4:28 | name |
@@ -729,6 +737,18 @@ edges
 | lib/lib.js:572:41:572:44 | name | lib/lib.js:593:25:593:28 | name |
 | lib/lib.js:572:41:572:44 | name | lib/lib.js:593:25:593:28 | name |
 | lib/lib.js:572:41:572:44 | name | lib/lib.js:593:25:593:28 | name |
+| lib/lib.js:608:42:608:45 | name | lib/lib.js:609:22:609:25 | name |
+| lib/lib.js:608:42:608:45 | name | lib/lib.js:609:22:609:25 | name |
+| lib/lib.js:608:42:608:45 | name | lib/lib.js:609:22:609:25 | name |
+| lib/lib.js:608:42:608:45 | name | lib/lib.js:609:22:609:25 | name |
+| lib/lib.js:608:42:608:45 | name | lib/lib.js:626:29:626:32 | name |
+| lib/lib.js:608:42:608:45 | name | lib/lib.js:626:29:626:32 | name |
+| lib/lib.js:608:42:608:45 | name | lib/lib.js:626:29:626:32 | name |
+| lib/lib.js:608:42:608:45 | name | lib/lib.js:626:29:626:32 | name |
+| lib/lib.js:608:42:608:45 | name | lib/lib.js:629:25:629:28 | name |
+| lib/lib.js:608:42:608:45 | name | lib/lib.js:629:25:629:28 | name |
+| lib/lib.js:608:42:608:45 | name | lib/lib.js:629:25:629:28 | name |
+| lib/lib.js:608:42:608:45 | name | lib/lib.js:629:25:629:28 | name |
 | lib/subLib2/compiled-file.ts:3:26:3:29 | name | lib/subLib2/compiled-file.ts:4:25:4:28 | name |
 | lib/subLib2/compiled-file.ts:3:26:3:29 | name | lib/subLib2/compiled-file.ts:4:25:4:28 | name |
 | lib/subLib2/compiled-file.ts:3:26:3:29 | name | lib/subLib2/compiled-file.ts:4:25:4:28 | name |
@@ -856,6 +876,9 @@ edges
 | lib/lib.js:579:13:579:28 | "rm -rf " + name | lib/lib.js:572:41:572:44 | name | lib/lib.js:579:25:579:28 | name | This string concatenation which depends on $@ is later used in a $@. | lib/lib.js:572:41:572:44 | name | library input | lib/lib.js:579:5:579:29 | cp.exec ... + name) | shell command |
 | lib/lib.js:590:17:590:32 | "rm -rf " + name | lib/lib.js:572:41:572:44 | name | lib/lib.js:590:29:590:32 | name | This string concatenation which depends on $@ is later used in a $@. | lib/lib.js:572:41:572:44 | name | library input | lib/lib.js:590:9:590:33 | cp.exec ... + name) | shell command |
 | lib/lib.js:593:13:593:28 | "rm -rf " + name | lib/lib.js:572:41:572:44 | name | lib/lib.js:593:25:593:28 | name | This string concatenation which depends on $@ is later used in a $@. | lib/lib.js:572:41:572:44 | name | library input | lib/lib.js:593:5:593:29 | cp.exec ... + name) | shell command |
+| lib/lib.js:609:10:609:25 | "rm -rf " + name | lib/lib.js:608:42:608:45 | name | lib/lib.js:609:22:609:25 | name | This string concatenation which depends on $@ is later used in a $@. | lib/lib.js:608:42:608:45 | name | library input | lib/lib.js:609:2:609:26 | cp.exec ... + name) | shell command |
+| lib/lib.js:626:17:626:32 | "rm -rf " + name | lib/lib.js:608:42:608:45 | name | lib/lib.js:626:29:626:32 | name | This string concatenation which depends on $@ is later used in a $@. | lib/lib.js:608:42:608:45 | name | library input | lib/lib.js:626:9:626:33 | cp.exec ... + name) | shell command |
+| lib/lib.js:629:13:629:28 | "rm -rf " + name | lib/lib.js:608:42:608:45 | name | lib/lib.js:629:25:629:28 | name | This string concatenation which depends on $@ is later used in a $@. | lib/lib.js:608:42:608:45 | name | library input | lib/lib.js:629:5:629:29 | cp.exec ... + name) | shell command |
 | lib/subLib2/compiled-file.ts:4:13:4:28 | "rm -rf " + name | lib/subLib2/compiled-file.ts:3:26:3:29 | name | lib/subLib2/compiled-file.ts:4:25:4:28 | name | This string concatenation which depends on $@ is later used in a $@. | lib/subLib2/compiled-file.ts:3:26:3:29 | name | library input | lib/subLib2/compiled-file.ts:4:5:4:29 | cp.exec ... + name) | shell command |
 | lib/subLib2/special-file.js:4:10:4:25 | "rm -rf " + name | lib/subLib2/special-file.js:3:28:3:31 | name | lib/subLib2/special-file.js:4:22:4:25 | name | This string concatenation which depends on $@ is later used in a $@. | lib/subLib2/special-file.js:3:28:3:31 | name | library input | lib/subLib2/special-file.js:4:2:4:26 | cp.exec ... + name) | shell command |
 | lib/subLib3/my-file.ts:4:10:4:25 | "rm -rf " + name | lib/subLib3/my-file.ts:3:28:3:31 | name | lib/subLib3/my-file.ts:4:22:4:25 | name | This string concatenation which depends on $@ is later used in a $@. | lib/subLib3/my-file.ts:3:28:3:31 | name | library input | lib/subLib3/my-file.ts:4:2:4:26 | cp.exec ... + name) | shell command |

--- a/javascript/ql/test/query-tests/Security/CWE-078/UnsafeShellCommandConstruction/lib/lib.js
+++ b/javascript/ql/test/query-tests/Security/CWE-078/UnsafeShellCommandConstruction/lib/lib.js
@@ -568,3 +568,27 @@ module.exports.badSanitizer = function (name) {
         exec("rm -rf " + name); // OK
     }
 }
+
+module.exports.safeWithBool = function (name) {
+	cp.exec("rm -rf " + name); // NOT OK
+
+	if (isSafeName(name)) {
+		cp.exec("rm -rf " + name); // OK
+	}
+
+    cp.exec("rm -rf " + name); // NOT OK
+
+    if (isSafeName(name) === true) {
+        cp.exec("rm -rf " + name); // OK
+    }
+
+    if (isSafeName(name) !== false) {
+        cp.exec("rm -rf " + name); // OK
+    }
+
+    if (isSafeName(name) == false) {
+        cp.exec("rm -rf " + name); // NOT OK
+    }
+
+    cp.exec("rm -rf " + name); // NOT OK
+}

--- a/javascript/ql/test/query-tests/Security/CWE-078/UnsafeShellCommandConstruction/lib/lib.js
+++ b/javascript/ql/test/query-tests/Security/CWE-078/UnsafeShellCommandConstruction/lib/lib.js
@@ -592,3 +592,39 @@ module.exports.safeWithBool = function (name) {
 
     cp.exec("rm -rf " + name); // NOT OK
 }
+
+function indirectThing(name) {
+    return isSafeName(name);
+}
+
+function indirectThing2(name) {
+    return isSafeName(name) === true;
+}
+
+function moreIndirect(name) {
+    return indirectThing2(name) !== false;
+}
+
+module.exports.veryIndeirect = function (name) {
+	cp.exec("rm -rf " + name); // NOT OK
+
+	if (indirectThing(name)) {
+        cp.exec("rm -rf " + name); // OK
+    }
+
+    if (indirectThing2(name)) {
+        cp.exec("rm -rf " + name); // OK
+    }
+
+    if (moreIndirect(name)) {
+        cp.exec("rm -rf " + name); // OK
+    }
+
+    if (moreIndirect(name) !== false) {
+        cp.exec("rm -rf " + name); // OK
+    } else {
+        cp.exec("rm -rf " + name); // NOT OK
+    }
+
+    cp.exec("rm -rf " + name); // NOT OK
+}

--- a/javascript/ql/test/query-tests/Security/CWE-089/untyped/SqlInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-089/untyped/SqlInjection.expected
@@ -68,17 +68,6 @@ nodes
 | json-schema-validator.js:59:22:59:26 | query |
 | json-schema-validator.js:61:22:61:26 | query |
 | json-schema-validator.js:61:22:61:26 | query |
-| koarouter.js:5:11:5:33 | version |
-| koarouter.js:5:13:5:19 | version |
-| koarouter.js:5:13:5:19 | version |
-| koarouter.js:11:11:11:28 | conditions |
-| koarouter.js:11:24:11:28 | ['1'] |
-| koarouter.js:14:25:14:46 | `versio ... rsion}` |
-| koarouter.js:14:38:14:44 | version |
-| koarouter.js:17:27:17:77 | `SELECT ... nd ')}` |
-| koarouter.js:17:27:17:77 | `SELECT ... nd ')}` |
-| koarouter.js:17:52:17:61 | conditions |
-| koarouter.js:17:52:17:75 | conditi ...  and ') |
 | ldap.js:20:7:20:34 | q |
 | ldap.js:20:11:20:34 | url.par ... , true) |
 | ldap.js:20:21:20:27 | req.url |
@@ -493,16 +482,6 @@ edges
 | json-schema-validator.js:50:23:50:48 | JSON.pa ... y.data) | json-schema-validator.js:50:15:50:48 | query |
 | json-schema-validator.js:50:34:50:47 | req.query.data | json-schema-validator.js:50:23:50:48 | JSON.pa ... y.data) |
 | json-schema-validator.js:50:34:50:47 | req.query.data | json-schema-validator.js:50:23:50:48 | JSON.pa ... y.data) |
-| koarouter.js:5:11:5:33 | version | koarouter.js:14:38:14:44 | version |
-| koarouter.js:5:13:5:19 | version | koarouter.js:5:11:5:33 | version |
-| koarouter.js:5:13:5:19 | version | koarouter.js:5:11:5:33 | version |
-| koarouter.js:11:11:11:28 | conditions | koarouter.js:17:52:17:61 | conditions |
-| koarouter.js:11:24:11:28 | ['1'] | koarouter.js:11:11:11:28 | conditions |
-| koarouter.js:14:25:14:46 | `versio ... rsion}` | koarouter.js:11:24:11:28 | ['1'] |
-| koarouter.js:14:38:14:44 | version | koarouter.js:14:25:14:46 | `versio ... rsion}` |
-| koarouter.js:17:52:17:61 | conditions | koarouter.js:17:52:17:75 | conditi ...  and ') |
-| koarouter.js:17:52:17:75 | conditi ...  and ') | koarouter.js:17:27:17:77 | `SELECT ... nd ')}` |
-| koarouter.js:17:52:17:75 | conditi ...  and ') | koarouter.js:17:27:17:77 | `SELECT ... nd ')}` |
 | ldap.js:20:7:20:34 | q | ldap.js:22:18:22:18 | q |
 | ldap.js:20:11:20:34 | url.par ... , true) | ldap.js:20:7:20:34 | q |
 | ldap.js:20:21:20:27 | req.url | ldap.js:20:11:20:34 | url.par ... , true) |
@@ -950,7 +929,6 @@ edges
 | json-schema-validator.js:55:22:55:26 | query | json-schema-validator.js:50:34:50:47 | req.query.data | json-schema-validator.js:55:22:55:26 | query | This query depends on a $@. | json-schema-validator.js:50:34:50:47 | req.query.data | user-provided value |
 | json-schema-validator.js:59:22:59:26 | query | json-schema-validator.js:50:34:50:47 | req.query.data | json-schema-validator.js:59:22:59:26 | query | This query depends on a $@. | json-schema-validator.js:50:34:50:47 | req.query.data | user-provided value |
 | json-schema-validator.js:61:22:61:26 | query | json-schema-validator.js:50:34:50:47 | req.query.data | json-schema-validator.js:61:22:61:26 | query | This query depends on a $@. | json-schema-validator.js:50:34:50:47 | req.query.data | user-provided value |
-| koarouter.js:17:27:17:77 | `SELECT ... nd ')}` | koarouter.js:5:13:5:19 | version | koarouter.js:17:27:17:77 | `SELECT ... nd ')}` | This query depends on a $@. | koarouter.js:5:13:5:19 | version | user-provided value |
 | ldap.js:28:30:28:34 | opts1 | ldap.js:20:21:20:27 | req.url | ldap.js:28:30:28:34 | opts1 | This query depends on a $@. | ldap.js:20:21:20:27 | req.url | user-provided value |
 | ldap.js:32:5:32:61 | { filte ... e}))` } | ldap.js:20:21:20:27 | req.url | ldap.js:32:5:32:61 | { filte ... e}))` } | This query depends on a $@. | ldap.js:20:21:20:27 | req.url | user-provided value |
 | ldap.js:66:30:66:53 | { filte ... ilter } | ldap.js:20:21:20:27 | req.url | ldap.js:66:30:66:53 | { filte ... ilter } | This query depends on a $@. | ldap.js:20:21:20:27 | req.url | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-089/untyped/SqlInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-089/untyped/SqlInjection.expected
@@ -68,6 +68,17 @@ nodes
 | json-schema-validator.js:59:22:59:26 | query |
 | json-schema-validator.js:61:22:61:26 | query |
 | json-schema-validator.js:61:22:61:26 | query |
+| koarouter.js:5:11:5:33 | version |
+| koarouter.js:5:13:5:19 | version |
+| koarouter.js:5:13:5:19 | version |
+| koarouter.js:11:11:11:28 | conditions |
+| koarouter.js:11:24:11:28 | ['1'] |
+| koarouter.js:14:25:14:46 | `versio ... rsion}` |
+| koarouter.js:14:38:14:44 | version |
+| koarouter.js:17:27:17:77 | `SELECT ... nd ')}` |
+| koarouter.js:17:27:17:77 | `SELECT ... nd ')}` |
+| koarouter.js:17:52:17:61 | conditions |
+| koarouter.js:17:52:17:75 | conditi ...  and ') |
 | ldap.js:20:7:20:34 | q |
 | ldap.js:20:11:20:34 | url.par ... , true) |
 | ldap.js:20:21:20:27 | req.url |
@@ -482,6 +493,16 @@ edges
 | json-schema-validator.js:50:23:50:48 | JSON.pa ... y.data) | json-schema-validator.js:50:15:50:48 | query |
 | json-schema-validator.js:50:34:50:47 | req.query.data | json-schema-validator.js:50:23:50:48 | JSON.pa ... y.data) |
 | json-schema-validator.js:50:34:50:47 | req.query.data | json-schema-validator.js:50:23:50:48 | JSON.pa ... y.data) |
+| koarouter.js:5:11:5:33 | version | koarouter.js:14:38:14:44 | version |
+| koarouter.js:5:13:5:19 | version | koarouter.js:5:11:5:33 | version |
+| koarouter.js:5:13:5:19 | version | koarouter.js:5:11:5:33 | version |
+| koarouter.js:11:11:11:28 | conditions | koarouter.js:17:52:17:61 | conditions |
+| koarouter.js:11:24:11:28 | ['1'] | koarouter.js:11:11:11:28 | conditions |
+| koarouter.js:14:25:14:46 | `versio ... rsion}` | koarouter.js:11:24:11:28 | ['1'] |
+| koarouter.js:14:38:14:44 | version | koarouter.js:14:25:14:46 | `versio ... rsion}` |
+| koarouter.js:17:52:17:61 | conditions | koarouter.js:17:52:17:75 | conditi ...  and ') |
+| koarouter.js:17:52:17:75 | conditi ...  and ') | koarouter.js:17:27:17:77 | `SELECT ... nd ')}` |
+| koarouter.js:17:52:17:75 | conditi ...  and ') | koarouter.js:17:27:17:77 | `SELECT ... nd ')}` |
 | ldap.js:20:7:20:34 | q | ldap.js:22:18:22:18 | q |
 | ldap.js:20:11:20:34 | url.par ... , true) | ldap.js:20:7:20:34 | q |
 | ldap.js:20:21:20:27 | req.url | ldap.js:20:11:20:34 | url.par ... , true) |
@@ -929,6 +950,7 @@ edges
 | json-schema-validator.js:55:22:55:26 | query | json-schema-validator.js:50:34:50:47 | req.query.data | json-schema-validator.js:55:22:55:26 | query | This query depends on a $@. | json-schema-validator.js:50:34:50:47 | req.query.data | user-provided value |
 | json-schema-validator.js:59:22:59:26 | query | json-schema-validator.js:50:34:50:47 | req.query.data | json-schema-validator.js:59:22:59:26 | query | This query depends on a $@. | json-schema-validator.js:50:34:50:47 | req.query.data | user-provided value |
 | json-schema-validator.js:61:22:61:26 | query | json-schema-validator.js:50:34:50:47 | req.query.data | json-schema-validator.js:61:22:61:26 | query | This query depends on a $@. | json-schema-validator.js:50:34:50:47 | req.query.data | user-provided value |
+| koarouter.js:17:27:17:77 | `SELECT ... nd ')}` | koarouter.js:5:13:5:19 | version | koarouter.js:17:27:17:77 | `SELECT ... nd ')}` | This query depends on a $@. | koarouter.js:5:13:5:19 | version | user-provided value |
 | ldap.js:28:30:28:34 | opts1 | ldap.js:20:21:20:27 | req.url | ldap.js:28:30:28:34 | opts1 | This query depends on a $@. | ldap.js:20:21:20:27 | req.url | user-provided value |
 | ldap.js:32:5:32:61 | { filte ... e}))` } | ldap.js:20:21:20:27 | req.url | ldap.js:32:5:32:61 | { filte ... e}))` } | This query depends on a $@. | ldap.js:20:21:20:27 | req.url | user-provided value |
 | ldap.js:66:30:66:53 | { filte ... ilter } | ldap.js:20:21:20:27 | req.url | ldap.js:66:30:66:53 | { filte ... ilter } | This query depends on a $@. | ldap.js:20:21:20:27 | req.url | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-089/untyped/koarouter.js
+++ b/javascript/ql/test/query-tests/Security/CWE-089/untyped/koarouter.js
@@ -1,0 +1,23 @@
+const Router = require('koa-router')
+const {Sequelize} = require("sequelize");
+
+new Router().get("/hello", (ctx) => {
+    const { version } = ctx.query;
+
+    if (version && validVersion(version) === false) {
+        throw new Error(`invalid version ${version}`);
+    }
+
+    const conditions = ['1'];
+
+    if (version) {
+        conditions.push(`version = ${version}`)
+    }
+
+    new Sequelize().query(`SELECT * FROM t WHERE ${conditions.join(' and ')}`, null); // OK - but still flagged [INCONSISTENCY]
+});
+
+function validVersion(version) {
+    const pattern = /^[a-zA-Z0-9]+$/;
+    return pattern.test(version);
+}

--- a/javascript/ql/test/query-tests/Security/CWE-089/untyped/koarouter.js
+++ b/javascript/ql/test/query-tests/Security/CWE-089/untyped/koarouter.js
@@ -14,7 +14,7 @@ new Router().get("/hello", (ctx) => {
         conditions.push(`version = ${version}`)
     }
 
-    new Sequelize().query(`SELECT * FROM t WHERE ${conditions.join(' and ')}`, null); // OK - but still flagged [INCONSISTENCY]
+    new Sequelize().query(`SELECT * FROM t WHERE ${conditions.join(' and ')}`, null); // OK
 });
 
 function validVersion(version) {


### PR DESCRIPTION
Fixes #11667

The `appliesTo` change didn't change the result of any tests, but that feels like a lucky coincidence (because the nodes were `instanceof DataFlow::BarrierGuardNode` anyway).  

Evaluations were uneventful:   
- [nightly on code-scanning with meta queries](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/moreSan__nightly-old__code-scanning__1/reports)
- [default on code-scanning](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/moreSan__default__code-scanning__2/reports)