### PR TITLE
C++: Remove omittable exists variables

### DIFF
--- a/cpp/ql/lib/definitions.qll
+++ b/cpp/ql/lib/definitions.qll
@@ -159,9 +159,9 @@ Top definitionOf(Top e, string kind) {
     // Multiple type mentions can be generated when a typedef is used, and
     // in such cases we want to exclude all but the originating typedef.
     not exists(Type secondary |
-      exists(TypeMention tm, File f, int startline, int startcol |
+      exists(File f, int startline, int startcol |
         typeMentionStartLoc(e, result, f, startline, startcol) and
-        typeMentionStartLoc(tm, secondary, f, startline, startcol) and
+        typeMentionStartLoc(_, secondary, f, startline, startcol) and
         (
           result = secondary.(TypedefType).getBaseType() or
           result = secondary.(TypedefType).getBaseType().(SpecifiedType).getBaseType()

--- a/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -876,9 +876,9 @@ private module Stage1 implements StageSig {
 
   pragma[nomagic]
   private predicate revFlowOut(ReturnPosition pos, Configuration config) {
-    exists(DataFlowCall call, NodeEx out |
+    exists(NodeEx out |
       revFlow(out, _, config) and
-      viableReturnPosOutNodeCandFwd1(call, pos, out, config)
+      viableReturnPosOutNodeCandFwd1(_, pos, out, config)
     )
   }
 
@@ -1731,8 +1731,8 @@ private module MkStage<StageSig PrevStage> {
       )
       or
       // flow through a callable
-      exists(DataFlowCall call, ParamNodeEx p, ReturnPosition pos, Ap innerReturnAp |
-        revFlowThrough(call, returnCtx, p, state, pos, returnAp, ap, innerReturnAp, config) and
+      exists(DataFlowCall call, ParamNodeEx p, Ap innerReturnAp |
+        revFlowThrough(call, returnCtx, p, state, _, returnAp, ap, innerReturnAp, config) and
         flowThroughIntoCall(call, node, p, _, ap, innerReturnAp, config)
       )
       or
@@ -1901,8 +1901,8 @@ private module MkStage<StageSig PrevStage> {
 
     pragma[nomagic]
     predicate parameterMayFlowThrough(ParamNodeEx p, Ap ap, Configuration config) {
-      exists(RetNodeEx ret, ReturnPosition pos |
-        returnFlowsThrough(ret, pos, _, _, p, ap, _, config) and
+      exists(ReturnPosition pos |
+        returnFlowsThrough(_, pos, _, _, p, ap, _, config) and
         parameterFlowsThroughRev(p, ap, pos, _, config)
       )
     }
@@ -1923,8 +1923,8 @@ private module MkStage<StageSig PrevStage> {
       DataFlowCall call, ArgNodeEx arg, FlowState state, ReturnCtx returnCtx, ApOption returnAp,
       Ap ap, Configuration config
     ) {
-      exists(ParamNodeEx p, ReturnPosition pos, Ap innerReturnAp |
-        revFlowThrough(call, returnCtx, p, state, pos, returnAp, ap, innerReturnAp, config) and
+      exists(ParamNodeEx p, Ap innerReturnAp |
+        revFlowThrough(call, returnCtx, p, state, _, returnAp, ap, innerReturnAp, config) and
         flowThroughIntoCall(call, arg, p, _, ap, innerReturnAp, config)
       )
     }
@@ -3749,8 +3749,8 @@ private predicate paramFlowsThrough(
   ReturnKindExt kind, FlowState state, CallContextCall cc, SummaryCtxSome sc, AccessPath ap,
   AccessPathApprox apa, Configuration config
 ) {
-  exists(PathNodeMid mid, RetNodeEx ret |
-    pathNode(mid, ret, state, cc, sc, ap, config, _) and
+  exists(RetNodeEx ret |
+    pathNode(_, ret, state, cc, sc, ap, config, _) and
     kind = ret.getKind() and
     apa = ap.getApprox() and
     parameterFlowThroughAllowed(sc.getParamNode(), kind)
@@ -4212,17 +4212,15 @@ private module FlowExploration {
       ap = TRevPartialNil() and
       exists(config.explorationLimit())
       or
-      exists(PartialPathNodeRev mid |
-        revPartialPathStep(mid, node, state, sc1, sc2, sc3, ap, config) and
-        not clearsContentEx(node, ap.getHead()) and
-        (
-          notExpectsContent(node) or
-          expectsContentEx(node, ap.getHead())
-        ) and
-        not fullBarrier(node, config) and
-        not stateBarrier(node, state, config) and
-        distSink(node.getEnclosingCallable(), config) <= config.explorationLimit()
-      )
+      revPartialPathStep(_, node, state, sc1, sc2, sc3, ap, config) and
+      not clearsContentEx(node, ap.getHead()) and
+      (
+        notExpectsContent(node) or
+        expectsContentEx(node, ap.getHead())
+      ) and
+      not fullBarrier(node, config) and
+      not stateBarrier(node, state, config) and
+      distSink(node.getEnclosingCallable(), config) <= config.explorationLimit()
     }
 
   pragma[nomagic]
@@ -4230,19 +4228,17 @@ private module FlowExploration {
     NodeEx node, FlowState state, CallContext cc, TSummaryCtx1 sc1, TSummaryCtx2 sc2,
     TSummaryCtx3 sc3, PartialAccessPath ap, Configuration config
   ) {
-    exists(PartialPathNodeFwd mid |
-      partialPathStep(mid, node, state, cc, sc1, sc2, sc3, ap, config) and
-      not fullBarrier(node, config) and
-      not stateBarrier(node, state, config) and
-      not clearsContentEx(node, ap.getHead().getContent()) and
-      (
-        notExpectsContent(node) or
-        expectsContentEx(node, ap.getHead().getContent())
-      ) and
-      if node.asNode() instanceof CastingNode
-      then compatibleTypes(node.getDataFlowType(), ap.getType())
-      else any()
-    )
+    partialPathStep(_, node, state, cc, sc1, sc2, sc3, ap, config) and
+    not fullBarrier(node, config) and
+    not stateBarrier(node, state, config) and
+    not clearsContentEx(node, ap.getHead().getContent()) and
+    (
+      notExpectsContent(node) or
+      expectsContentEx(node, ap.getHead().getContent())
+    ) and
+    if node.asNode() instanceof CastingNode
+    then compatibleTypes(node.getDataFlowType(), ap.getType())
+    else any()
   }
 
   /**

--- a/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -876,9 +876,9 @@ private module Stage1 implements StageSig {
 
   pragma[nomagic]
   private predicate revFlowOut(ReturnPosition pos, Configuration config) {
-    exists(DataFlowCall call, NodeEx out |
+    exists(NodeEx out |
       revFlow(out, _, config) and
-      viableReturnPosOutNodeCandFwd1(call, pos, out, config)
+      viableReturnPosOutNodeCandFwd1(_, pos, out, config)
     )
   }
 
@@ -1731,8 +1731,8 @@ private module MkStage<StageSig PrevStage> {
       )
       or
       // flow through a callable
-      exists(DataFlowCall call, ParamNodeEx p, ReturnPosition pos, Ap innerReturnAp |
-        revFlowThrough(call, returnCtx, p, state, pos, returnAp, ap, innerReturnAp, config) and
+      exists(DataFlowCall call, ParamNodeEx p, Ap innerReturnAp |
+        revFlowThrough(call, returnCtx, p, state, _, returnAp, ap, innerReturnAp, config) and
         flowThroughIntoCall(call, node, p, _, ap, innerReturnAp, config)
       )
       or
@@ -1901,8 +1901,8 @@ private module MkStage<StageSig PrevStage> {
 
     pragma[nomagic]
     predicate parameterMayFlowThrough(ParamNodeEx p, Ap ap, Configuration config) {
-      exists(RetNodeEx ret, ReturnPosition pos |
-        returnFlowsThrough(ret, pos, _, _, p, ap, _, config) and
+      exists(ReturnPosition pos |
+        returnFlowsThrough(_, pos, _, _, p, ap, _, config) and
         parameterFlowsThroughRev(p, ap, pos, _, config)
       )
     }
@@ -1923,8 +1923,8 @@ private module MkStage<StageSig PrevStage> {
       DataFlowCall call, ArgNodeEx arg, FlowState state, ReturnCtx returnCtx, ApOption returnAp,
       Ap ap, Configuration config
     ) {
-      exists(ParamNodeEx p, ReturnPosition pos, Ap innerReturnAp |
-        revFlowThrough(call, returnCtx, p, state, pos, returnAp, ap, innerReturnAp, config) and
+      exists(ParamNodeEx p, Ap innerReturnAp |
+        revFlowThrough(call, returnCtx, p, state, _, returnAp, ap, innerReturnAp, config) and
         flowThroughIntoCall(call, arg, p, _, ap, innerReturnAp, config)
       )
     }
@@ -3749,8 +3749,8 @@ private predicate paramFlowsThrough(
   ReturnKindExt kind, FlowState state, CallContextCall cc, SummaryCtxSome sc, AccessPath ap,
   AccessPathApprox apa, Configuration config
 ) {
-  exists(PathNodeMid mid, RetNodeEx ret |
-    pathNode(mid, ret, state, cc, sc, ap, config, _) and
+  exists(RetNodeEx ret |
+    pathNode(_, ret, state, cc, sc, ap, config, _) and
     kind = ret.getKind() and
     apa = ap.getApprox() and
     parameterFlowThroughAllowed(sc.getParamNode(), kind)
@@ -4212,17 +4212,15 @@ private module FlowExploration {
       ap = TRevPartialNil() and
       exists(config.explorationLimit())
       or
-      exists(PartialPathNodeRev mid |
-        revPartialPathStep(mid, node, state, sc1, sc2, sc3, ap, config) and
-        not clearsContentEx(node, ap.getHead()) and
-        (
-          notExpectsContent(node) or
-          expectsContentEx(node, ap.getHead())
-        ) and
-        not fullBarrier(node, config) and
-        not stateBarrier(node, state, config) and
-        distSink(node.getEnclosingCallable(), config) <= config.explorationLimit()
-      )
+      revPartialPathStep(_, node, state, sc1, sc2, sc3, ap, config) and
+      not clearsContentEx(node, ap.getHead()) and
+      (
+        notExpectsContent(node) or
+        expectsContentEx(node, ap.getHead())
+      ) and
+      not fullBarrier(node, config) and
+      not stateBarrier(node, state, config) and
+      distSink(node.getEnclosingCallable(), config) <= config.explorationLimit()
     }
 
   pragma[nomagic]
@@ -4230,19 +4228,17 @@ private module FlowExploration {
     NodeEx node, FlowState state, CallContext cc, TSummaryCtx1 sc1, TSummaryCtx2 sc2,
     TSummaryCtx3 sc3, PartialAccessPath ap, Configuration config
   ) {
-    exists(PartialPathNodeFwd mid |
-      partialPathStep(mid, node, state, cc, sc1, sc2, sc3, ap, config) and
-      not fullBarrier(node, config) and
-      not stateBarrier(node, state, config) and
-      not clearsContentEx(node, ap.getHead().getContent()) and
-      (
-        notExpectsContent(node) or
-        expectsContentEx(node, ap.getHead().getContent())
-      ) and
-      if node.asNode() instanceof CastingNode
-      then compatibleTypes(node.getDataFlowType(), ap.getType())
-      else any()
-    )
+    partialPathStep(_, node, state, cc, sc1, sc2, sc3, ap, config) and
+    not fullBarrier(node, config) and
+    not stateBarrier(node, state, config) and
+    not clearsContentEx(node, ap.getHead().getContent()) and
+    (
+      notExpectsContent(node) or
+      expectsContentEx(node, ap.getHead().getContent())
+    ) and
+    if node.asNode() instanceof CastingNode
+    then compatibleTypes(node.getDataFlowType(), ap.getType())
+    else any()
   }
 
   /**

--- a/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -876,9 +876,9 @@ private module Stage1 implements StageSig {
 
   pragma[nomagic]
   private predicate revFlowOut(ReturnPosition pos, Configuration config) {
-    exists(DataFlowCall call, NodeEx out |
+    exists(NodeEx out |
       revFlow(out, _, config) and
-      viableReturnPosOutNodeCandFwd1(call, pos, out, config)
+      viableReturnPosOutNodeCandFwd1(_, pos, out, config)
     )
   }
 
@@ -1731,8 +1731,8 @@ private module MkStage<StageSig PrevStage> {
       )
       or
       // flow through a callable
-      exists(DataFlowCall call, ParamNodeEx p, ReturnPosition pos, Ap innerReturnAp |
-        revFlowThrough(call, returnCtx, p, state, pos, returnAp, ap, innerReturnAp, config) and
+      exists(DataFlowCall call, ParamNodeEx p, Ap innerReturnAp |
+        revFlowThrough(call, returnCtx, p, state, _, returnAp, ap, innerReturnAp, config) and
         flowThroughIntoCall(call, node, p, _, ap, innerReturnAp, config)
       )
       or
@@ -1901,8 +1901,8 @@ private module MkStage<StageSig PrevStage> {
 
     pragma[nomagic]
     predicate parameterMayFlowThrough(ParamNodeEx p, Ap ap, Configuration config) {
-      exists(RetNodeEx ret, ReturnPosition pos |
-        returnFlowsThrough(ret, pos, _, _, p, ap, _, config) and
+      exists(ReturnPosition pos |
+        returnFlowsThrough(_, pos, _, _, p, ap, _, config) and
         parameterFlowsThroughRev(p, ap, pos, _, config)
       )
     }
@@ -1923,8 +1923,8 @@ private module MkStage<StageSig PrevStage> {
       DataFlowCall call, ArgNodeEx arg, FlowState state, ReturnCtx returnCtx, ApOption returnAp,
       Ap ap, Configuration config
     ) {
-      exists(ParamNodeEx p, ReturnPosition pos, Ap innerReturnAp |
-        revFlowThrough(call, returnCtx, p, state, pos, returnAp, ap, innerReturnAp, config) and
+      exists(ParamNodeEx p, Ap innerReturnAp |
+        revFlowThrough(call, returnCtx, p, state, _, returnAp, ap, innerReturnAp, config) and
         flowThroughIntoCall(call, arg, p, _, ap, innerReturnAp, config)
       )
     }
@@ -3749,8 +3749,8 @@ private predicate paramFlowsThrough(
   ReturnKindExt kind, FlowState state, CallContextCall cc, SummaryCtxSome sc, AccessPath ap,
   AccessPathApprox apa, Configuration config
 ) {
-  exists(PathNodeMid mid, RetNodeEx ret |
-    pathNode(mid, ret, state, cc, sc, ap, config, _) and
+  exists(RetNodeEx ret |
+    pathNode(_, ret, state, cc, sc, ap, config, _) and
     kind = ret.getKind() and
     apa = ap.getApprox() and
     parameterFlowThroughAllowed(sc.getParamNode(), kind)
@@ -4212,17 +4212,15 @@ private module FlowExploration {
       ap = TRevPartialNil() and
       exists(config.explorationLimit())
       or
-      exists(PartialPathNodeRev mid |
-        revPartialPathStep(mid, node, state, sc1, sc2, sc3, ap, config) and
-        not clearsContentEx(node, ap.getHead()) and
-        (
-          notExpectsContent(node) or
-          expectsContentEx(node, ap.getHead())
-        ) and
-        not fullBarrier(node, config) and
-        not stateBarrier(node, state, config) and
-        distSink(node.getEnclosingCallable(), config) <= config.explorationLimit()
-      )
+      revPartialPathStep(_, node, state, sc1, sc2, sc3, ap, config) and
+      not clearsContentEx(node, ap.getHead()) and
+      (
+        notExpectsContent(node) or
+        expectsContentEx(node, ap.getHead())
+      ) and
+      not fullBarrier(node, config) and
+      not stateBarrier(node, state, config) and
+      distSink(node.getEnclosingCallable(), config) <= config.explorationLimit()
     }
 
   pragma[nomagic]
@@ -4230,19 +4228,17 @@ private module FlowExploration {
     NodeEx node, FlowState state, CallContext cc, TSummaryCtx1 sc1, TSummaryCtx2 sc2,
     TSummaryCtx3 sc3, PartialAccessPath ap, Configuration config
   ) {
-    exists(PartialPathNodeFwd mid |
-      partialPathStep(mid, node, state, cc, sc1, sc2, sc3, ap, config) and
-      not fullBarrier(node, config) and
-      not stateBarrier(node, state, config) and
-      not clearsContentEx(node, ap.getHead().getContent()) and
-      (
-        notExpectsContent(node) or
-        expectsContentEx(node, ap.getHead().getContent())
-      ) and
-      if node.asNode() instanceof CastingNode
-      then compatibleTypes(node.getDataFlowType(), ap.getType())
-      else any()
-    )
+    partialPathStep(_, node, state, cc, sc1, sc2, sc3, ap, config) and
+    not fullBarrier(node, config) and
+    not stateBarrier(node, state, config) and
+    not clearsContentEx(node, ap.getHead().getContent()) and
+    (
+      notExpectsContent(node) or
+      expectsContentEx(node, ap.getHead().getContent())
+    ) and
+    if node.asNode() instanceof CastingNode
+    then compatibleTypes(node.getDataFlowType(), ap.getType())
+    else any()
   }
 
   /**

--- a/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -876,9 +876,9 @@ private module Stage1 implements StageSig {
 
   pragma[nomagic]
   private predicate revFlowOut(ReturnPosition pos, Configuration config) {
-    exists(DataFlowCall call, NodeEx out |
+    exists(NodeEx out |
       revFlow(out, _, config) and
-      viableReturnPosOutNodeCandFwd1(call, pos, out, config)
+      viableReturnPosOutNodeCandFwd1(_, pos, out, config)
     )
   }
 
@@ -1731,8 +1731,8 @@ private module MkStage<StageSig PrevStage> {
       )
       or
       // flow through a callable
-      exists(DataFlowCall call, ParamNodeEx p, ReturnPosition pos, Ap innerReturnAp |
-        revFlowThrough(call, returnCtx, p, state, pos, returnAp, ap, innerReturnAp, config) and
+      exists(DataFlowCall call, ParamNodeEx p, Ap innerReturnAp |
+        revFlowThrough(call, returnCtx, p, state, _, returnAp, ap, innerReturnAp, config) and
         flowThroughIntoCall(call, node, p, _, ap, innerReturnAp, config)
       )
       or
@@ -1901,8 +1901,8 @@ private module MkStage<StageSig PrevStage> {
 
     pragma[nomagic]
     predicate parameterMayFlowThrough(ParamNodeEx p, Ap ap, Configuration config) {
-      exists(RetNodeEx ret, ReturnPosition pos |
-        returnFlowsThrough(ret, pos, _, _, p, ap, _, config) and
+      exists(ReturnPosition pos |
+        returnFlowsThrough(_, pos, _, _, p, ap, _, config) and
         parameterFlowsThroughRev(p, ap, pos, _, config)
       )
     }
@@ -1923,8 +1923,8 @@ private module MkStage<StageSig PrevStage> {
       DataFlowCall call, ArgNodeEx arg, FlowState state, ReturnCtx returnCtx, ApOption returnAp,
       Ap ap, Configuration config
     ) {
-      exists(ParamNodeEx p, ReturnPosition pos, Ap innerReturnAp |
-        revFlowThrough(call, returnCtx, p, state, pos, returnAp, ap, innerReturnAp, config) and
+      exists(ParamNodeEx p, Ap innerReturnAp |
+        revFlowThrough(call, returnCtx, p, state, _, returnAp, ap, innerReturnAp, config) and
         flowThroughIntoCall(call, arg, p, _, ap, innerReturnAp, config)
       )
     }
@@ -3749,8 +3749,8 @@ private predicate paramFlowsThrough(
   ReturnKindExt kind, FlowState state, CallContextCall cc, SummaryCtxSome sc, AccessPath ap,
   AccessPathApprox apa, Configuration config
 ) {
-  exists(PathNodeMid mid, RetNodeEx ret |
-    pathNode(mid, ret, state, cc, sc, ap, config, _) and
+  exists(RetNodeEx ret |
+    pathNode(_, ret, state, cc, sc, ap, config, _) and
     kind = ret.getKind() and
     apa = ap.getApprox() and
     parameterFlowThroughAllowed(sc.getParamNode(), kind)
@@ -4212,17 +4212,15 @@ private module FlowExploration {
       ap = TRevPartialNil() and
       exists(config.explorationLimit())
       or
-      exists(PartialPathNodeRev mid |
-        revPartialPathStep(mid, node, state, sc1, sc2, sc3, ap, config) and
-        not clearsContentEx(node, ap.getHead()) and
-        (
-          notExpectsContent(node) or
-          expectsContentEx(node, ap.getHead())
-        ) and
-        not fullBarrier(node, config) and
-        not stateBarrier(node, state, config) and
-        distSink(node.getEnclosingCallable(), config) <= config.explorationLimit()
-      )
+      revPartialPathStep(_, node, state, sc1, sc2, sc3, ap, config) and
+      not clearsContentEx(node, ap.getHead()) and
+      (
+        notExpectsContent(node) or
+        expectsContentEx(node, ap.getHead())
+      ) and
+      not fullBarrier(node, config) and
+      not stateBarrier(node, state, config) and
+      distSink(node.getEnclosingCallable(), config) <= config.explorationLimit()
     }
 
   pragma[nomagic]
@@ -4230,19 +4228,17 @@ private module FlowExploration {
     NodeEx node, FlowState state, CallContext cc, TSummaryCtx1 sc1, TSummaryCtx2 sc2,
     TSummaryCtx3 sc3, PartialAccessPath ap, Configuration config
   ) {
-    exists(PartialPathNodeFwd mid |
-      partialPathStep(mid, node, state, cc, sc1, sc2, sc3, ap, config) and
-      not fullBarrier(node, config) and
-      not stateBarrier(node, state, config) and
-      not clearsContentEx(node, ap.getHead().getContent()) and
-      (
-        notExpectsContent(node) or
-        expectsContentEx(node, ap.getHead().getContent())
-      ) and
-      if node.asNode() instanceof CastingNode
-      then compatibleTypes(node.getDataFlowType(), ap.getType())
-      else any()
-    )
+    partialPathStep(_, node, state, cc, sc1, sc2, sc3, ap, config) and
+    not fullBarrier(node, config) and
+    not stateBarrier(node, state, config) and
+    not clearsContentEx(node, ap.getHead().getContent()) and
+    (
+      notExpectsContent(node) or
+      expectsContentEx(node, ap.getHead().getContent())
+    ) and
+    if node.asNode() instanceof CastingNode
+    then compatibleTypes(node.getDataFlowType(), ap.getType())
+    else any()
   }
 
   /**

--- a/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/DataFlowImplConsistency.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/DataFlowImplConsistency.qll
@@ -101,9 +101,7 @@ module Consistency {
     exists(int c |
       c =
         strictcount(Node n |
-          not exists(string filepath, int startline, int startcolumn, int endline, int endcolumn |
-            n.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
-          ) and
+          n.hasLocationInfo(_, _, _, _, _) and
           not any(ConsistencyConfiguration conf).missingLocationExclude(n)
         ) and
       msg = "Nodes without location: " + c

--- a/cpp/ql/lib/experimental/semmle/code/cpp/rangeanalysis/ArrayLengthAnalysis.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/rangeanalysis/ArrayLengthAnalysis.qll
@@ -218,7 +218,7 @@ private predicate allocation(Instruction array, Length length, int delta) {
           length.(VNLength).getInstruction().getConvertedResultExpression() = lengthExpr
         )
         or
-        not exists(int d | deconstructMallocSizeExpr(alloc.getSizeExpr(), _, d)) and
+        not deconstructMallocSizeExpr(alloc.getSizeExpr(), _, _) and
         length.(VNLength).getInstruction().getConvertedResultExpression() = alloc.getSizeExpr() and
         delta = 0
       )

--- a/cpp/ql/lib/experimental/semmle/code/cpp/rangeanalysis/RangeAnalysis.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/rangeanalysis/RangeAnalysis.qll
@@ -543,9 +543,7 @@ private predicate boundedPhiCand(
   PhiInstruction phi, boolean upper, Bound b, int delta, boolean fromBackEdge, int origdelta,
   Reason reason
 ) {
-  exists(PhiInputOperand op |
-    boundedPhiInp(phi, op, b, delta, upper, fromBackEdge, origdelta, reason)
-  )
+  boundedPhiInp(phi, _, b, delta, upper, fromBackEdge, origdelta, reason)
 }
 
 /**

--- a/cpp/ql/lib/experimental/semmle/code/cpp/semantic/analysis/RangeAnalysis.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/semantic/analysis/RangeAnalysis.qll
@@ -664,9 +664,7 @@ private predicate boundedPhiCand(
   SemSsaPhiNode phi, boolean upper, SemBound b, int delta, boolean fromBackEdge, int origdelta,
   SemReason reason
 ) {
-  exists(SemSsaVariable inp, SemSsaReadPositionPhiInputEdge edge |
-    boundedPhiInp(phi, inp, edge, b, delta, upper, fromBackEdge, origdelta, reason)
-  )
+  boundedPhiInp(phi, _, _, b, delta, upper, fromBackEdge, origdelta, reason)
 }
 
 /**

--- a/cpp/ql/lib/semmle/code/cpp/Function.qll
+++ b/cpp/ql/lib/semmle/code/cpp/Function.qll
@@ -318,7 +318,7 @@ class Function extends Declaration, ControlFlowNode, AccessHolder, @function {
   MetricFunction getMetrics() { result = this }
 
   /** Holds if this function calls the function `f`. */
-  predicate calls(Function f) { exists(Locatable l | this.calls(f, l)) }
+  predicate calls(Function f) { this.calls(f, _) }
 
   /**
    * Holds if this function calls the function `f` in the `FunctionCall`
@@ -335,7 +335,7 @@ class Function extends Declaration, ControlFlowNode, AccessHolder, @function {
   }
 
   /** Holds if this function accesses a function or variable or enumerator `a`. */
-  predicate accesses(Declaration a) { exists(Locatable l | this.accesses(a, l)) }
+  predicate accesses(Declaration a) { this.accesses(a, _) }
 
   /**
    * Holds if this function accesses a function or variable or enumerator `a`

--- a/cpp/ql/lib/semmle/code/cpp/commons/Dependency.qll
+++ b/cpp/ql/lib/semmle/code/cpp/commons/Dependency.qll
@@ -33,7 +33,7 @@ DependencyOptions getDependencyOptions() { any() }
 class DependsSource extends Element {
   DependsSource() {
     // not inside a template instantiation
-    not exists(Element other | this.isFromTemplateInstantiation(other)) or
+    not this.isFromTemplateInstantiation(_) or
     // allow DeclarationEntrys of template specializations
     this.(DeclarationEntry).getDeclaration().(Function).isConstructedFrom(_) or
     this.(DeclarationEntry).getDeclaration().(Class).isConstructedFrom(_)

--- a/cpp/ql/lib/semmle/code/cpp/commons/Exclusions.qll
+++ b/cpp/ql/lib/semmle/code/cpp/commons/Exclusions.qll
@@ -69,12 +69,9 @@ predicate functionContainsDisabledCode(Function f) {
  */
 predicate functionContainsPreprocCode(Function f) {
   // `f` contains a preprocessor branch
-  exists(
-    PreprocessorBranchDirective pbd, string file, int pbdStartLine, int fBlockStartLine,
-    int fBlockEndLine
-  |
+  exists(string file, int pbdStartLine, int fBlockStartLine, int fBlockEndLine |
     functionLocation(f, file, fBlockStartLine, fBlockEndLine) and
-    pbdLocation(pbd, file, pbdStartLine) and
+    pbdLocation(_, file, pbdStartLine) and
     pbdStartLine <= fBlockEndLine and
     pbdStartLine >= fBlockStartLine
   )

--- a/cpp/ql/lib/semmle/code/cpp/commons/Scanf.qll
+++ b/cpp/ql/lib/semmle/code/cpp/commons/Scanf.qll
@@ -244,9 +244,7 @@ class ScanfFormatLiteral extends Expr {
   /**
    * Gets the maximum width option of the nth input (empty string if none is given).
    */
-  string getMaxWidthOpt(int n) {
-    exists(string spec, string len, string conv | this.parseConvSpec(n, spec, result, len, conv))
-  }
+  string getMaxWidthOpt(int n) { this.parseConvSpec(n, _, result, _, _) }
 
   /**
    * Gets the maximum width of the nth input.
@@ -256,18 +254,12 @@ class ScanfFormatLiteral extends Expr {
   /**
    * Gets the length flag of the nth conversion specifier.
    */
-  string getLength(int n) {
-    exists(string spec, string width, string conv |
-      this.parseConvSpec(n, spec, width, result, conv)
-    )
-  }
+  string getLength(int n) { this.parseConvSpec(n, _, _, result, _) }
 
   /**
    * Gets the conversion character of the nth conversion specifier.
    */
-  string getConversionChar(int n) {
-    exists(string spec, string width, string len | this.parseConvSpec(n, spec, width, len, result))
-  }
+  string getConversionChar(int n) { this.parseConvSpec(n, _, _, _, result) }
 
   /**
    * Gets the maximum length of the string that can be produced by the nth

--- a/cpp/ql/lib/semmle/code/cpp/controlflow/SubBasicBlocks.qll
+++ b/cpp/ql/lib/semmle/code/cpp/controlflow/SubBasicBlocks.qll
@@ -54,7 +54,7 @@ class SubBasicBlock extends ControlFlowNodeBase {
    * only condition under which a `SubBasicBlock` may have multiple
    * predecessors.
    */
-  predicate firstInBB() { exists(BasicBlock bb | this.getRankInBasicBlock(bb) = 1) }
+  predicate firstInBB() { this.getRankInBasicBlock(_) = 1 }
 
   /**
    * Holds if this `SubBasicBlock` comes last in its basic block. This is the

--- a/cpp/ql/lib/semmle/code/cpp/controlflow/internal/ConstantExprs.qll
+++ b/cpp/ql/lib/semmle/code/cpp/controlflow/internal/ConstantExprs.qll
@@ -441,8 +441,8 @@ library class ExprEvaluator extends int {
       req = mid.(AssignExpr).getRValue()
     )
     or
-    exists(VariableAccess va, Variable v, boolean sub1 |
-      this.interestingVariableAccess(e, va, v, sub1) and
+    exists(Variable v, boolean sub1 |
+      this.interestingVariableAccess(e, _, v, sub1) and
       req = v.getAnAssignedValue() and
       (sub1 = true implies not this.ignoreVariableAssignment(e, v, req)) and
       sub = false
@@ -876,7 +876,7 @@ private predicate nonAnalyzableVariableDefinition(Variable v, StmtParent def) {
  * empirically to have effect only on a few rare and pathological examples.
  */
 private predicate tractableVariable(Variable v) {
-  not exists(StmtParent def | nonAnalyzableVariableDefinition(v, def)) or
+  not nonAnalyzableVariableDefinition(v, _) or
   strictcount(StmtParent def | nonAnalyzableVariableDefinition(v, def)) < 1000
 }
 

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -876,9 +876,9 @@ private module Stage1 implements StageSig {
 
   pragma[nomagic]
   private predicate revFlowOut(ReturnPosition pos, Configuration config) {
-    exists(DataFlowCall call, NodeEx out |
+    exists(NodeEx out |
       revFlow(out, _, config) and
-      viableReturnPosOutNodeCandFwd1(call, pos, out, config)
+      viableReturnPosOutNodeCandFwd1(_, pos, out, config)
     )
   }
 
@@ -1731,8 +1731,8 @@ private module MkStage<StageSig PrevStage> {
       )
       or
       // flow through a callable
-      exists(DataFlowCall call, ParamNodeEx p, ReturnPosition pos, Ap innerReturnAp |
-        revFlowThrough(call, returnCtx, p, state, pos, returnAp, ap, innerReturnAp, config) and
+      exists(DataFlowCall call, ParamNodeEx p, Ap innerReturnAp |
+        revFlowThrough(call, returnCtx, p, state, _, returnAp, ap, innerReturnAp, config) and
         flowThroughIntoCall(call, node, p, _, ap, innerReturnAp, config)
       )
       or
@@ -1901,8 +1901,8 @@ private module MkStage<StageSig PrevStage> {
 
     pragma[nomagic]
     predicate parameterMayFlowThrough(ParamNodeEx p, Ap ap, Configuration config) {
-      exists(RetNodeEx ret, ReturnPosition pos |
-        returnFlowsThrough(ret, pos, _, _, p, ap, _, config) and
+      exists(ReturnPosition pos |
+        returnFlowsThrough(_, pos, _, _, p, ap, _, config) and
         parameterFlowsThroughRev(p, ap, pos, _, config)
       )
     }
@@ -1923,8 +1923,8 @@ private module MkStage<StageSig PrevStage> {
       DataFlowCall call, ArgNodeEx arg, FlowState state, ReturnCtx returnCtx, ApOption returnAp,
       Ap ap, Configuration config
     ) {
-      exists(ParamNodeEx p, ReturnPosition pos, Ap innerReturnAp |
-        revFlowThrough(call, returnCtx, p, state, pos, returnAp, ap, innerReturnAp, config) and
+      exists(ParamNodeEx p, Ap innerReturnAp |
+        revFlowThrough(call, returnCtx, p, state, _, returnAp, ap, innerReturnAp, config) and
         flowThroughIntoCall(call, arg, p, _, ap, innerReturnAp, config)
       )
     }
@@ -3749,8 +3749,8 @@ private predicate paramFlowsThrough(
   ReturnKindExt kind, FlowState state, CallContextCall cc, SummaryCtxSome sc, AccessPath ap,
   AccessPathApprox apa, Configuration config
 ) {
-  exists(PathNodeMid mid, RetNodeEx ret |
-    pathNode(mid, ret, state, cc, sc, ap, config, _) and
+  exists(RetNodeEx ret |
+    pathNode(_, ret, state, cc, sc, ap, config, _) and
     kind = ret.getKind() and
     apa = ap.getApprox() and
     parameterFlowThroughAllowed(sc.getParamNode(), kind)
@@ -4212,17 +4212,15 @@ private module FlowExploration {
       ap = TRevPartialNil() and
       exists(config.explorationLimit())
       or
-      exists(PartialPathNodeRev mid |
-        revPartialPathStep(mid, node, state, sc1, sc2, sc3, ap, config) and
-        not clearsContentEx(node, ap.getHead()) and
-        (
-          notExpectsContent(node) or
-          expectsContentEx(node, ap.getHead())
-        ) and
-        not fullBarrier(node, config) and
-        not stateBarrier(node, state, config) and
-        distSink(node.getEnclosingCallable(), config) <= config.explorationLimit()
-      )
+      revPartialPathStep(_, node, state, sc1, sc2, sc3, ap, config) and
+      not clearsContentEx(node, ap.getHead()) and
+      (
+        notExpectsContent(node) or
+        expectsContentEx(node, ap.getHead())
+      ) and
+      not fullBarrier(node, config) and
+      not stateBarrier(node, state, config) and
+      distSink(node.getEnclosingCallable(), config) <= config.explorationLimit()
     }
 
   pragma[nomagic]
@@ -4230,19 +4228,17 @@ private module FlowExploration {
     NodeEx node, FlowState state, CallContext cc, TSummaryCtx1 sc1, TSummaryCtx2 sc2,
     TSummaryCtx3 sc3, PartialAccessPath ap, Configuration config
   ) {
-    exists(PartialPathNodeFwd mid |
-      partialPathStep(mid, node, state, cc, sc1, sc2, sc3, ap, config) and
-      not fullBarrier(node, config) and
-      not stateBarrier(node, state, config) and
-      not clearsContentEx(node, ap.getHead().getContent()) and
-      (
-        notExpectsContent(node) or
-        expectsContentEx(node, ap.getHead().getContent())
-      ) and
-      if node.asNode() instanceof CastingNode
-      then compatibleTypes(node.getDataFlowType(), ap.getType())
-      else any()
-    )
+    partialPathStep(_, node, state, cc, sc1, sc2, sc3, ap, config) and
+    not fullBarrier(node, config) and
+    not stateBarrier(node, state, config) and
+    not clearsContentEx(node, ap.getHead().getContent()) and
+    (
+      notExpectsContent(node) or
+      expectsContentEx(node, ap.getHead().getContent())
+    ) and
+    if node.asNode() instanceof CastingNode
+    then compatibleTypes(node.getDataFlowType(), ap.getType())
+    else any()
   }
 
   /**

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
@@ -876,9 +876,9 @@ private module Stage1 implements StageSig {
 
   pragma[nomagic]
   private predicate revFlowOut(ReturnPosition pos, Configuration config) {
-    exists(DataFlowCall call, NodeEx out |
+    exists(NodeEx out |
       revFlow(out, _, config) and
-      viableReturnPosOutNodeCandFwd1(call, pos, out, config)
+      viableReturnPosOutNodeCandFwd1(_, pos, out, config)
     )
   }
 
@@ -1731,8 +1731,8 @@ private module MkStage<StageSig PrevStage> {
       )
       or
       // flow through a callable
-      exists(DataFlowCall call, ParamNodeEx p, ReturnPosition pos, Ap innerReturnAp |
-        revFlowThrough(call, returnCtx, p, state, pos, returnAp, ap, innerReturnAp, config) and
+      exists(DataFlowCall call, ParamNodeEx p, Ap innerReturnAp |
+        revFlowThrough(call, returnCtx, p, state, _, returnAp, ap, innerReturnAp, config) and
         flowThroughIntoCall(call, node, p, _, ap, innerReturnAp, config)
       )
       or
@@ -1901,8 +1901,8 @@ private module MkStage<StageSig PrevStage> {
 
     pragma[nomagic]
     predicate parameterMayFlowThrough(ParamNodeEx p, Ap ap, Configuration config) {
-      exists(RetNodeEx ret, ReturnPosition pos |
-        returnFlowsThrough(ret, pos, _, _, p, ap, _, config) and
+      exists(ReturnPosition pos |
+        returnFlowsThrough(_, pos, _, _, p, ap, _, config) and
         parameterFlowsThroughRev(p, ap, pos, _, config)
       )
     }
@@ -1923,8 +1923,8 @@ private module MkStage<StageSig PrevStage> {
       DataFlowCall call, ArgNodeEx arg, FlowState state, ReturnCtx returnCtx, ApOption returnAp,
       Ap ap, Configuration config
     ) {
-      exists(ParamNodeEx p, ReturnPosition pos, Ap innerReturnAp |
-        revFlowThrough(call, returnCtx, p, state, pos, returnAp, ap, innerReturnAp, config) and
+      exists(ParamNodeEx p, Ap innerReturnAp |
+        revFlowThrough(call, returnCtx, p, state, _, returnAp, ap, innerReturnAp, config) and
         flowThroughIntoCall(call, arg, p, _, ap, innerReturnAp, config)
       )
     }
@@ -3749,8 +3749,8 @@ private predicate paramFlowsThrough(
   ReturnKindExt kind, FlowState state, CallContextCall cc, SummaryCtxSome sc, AccessPath ap,
   AccessPathApprox apa, Configuration config
 ) {
-  exists(PathNodeMid mid, RetNodeEx ret |
-    pathNode(mid, ret, state, cc, sc, ap, config, _) and
+  exists(RetNodeEx ret |
+    pathNode(_, ret, state, cc, sc, ap, config, _) and
     kind = ret.getKind() and
     apa = ap.getApprox() and
     parameterFlowThroughAllowed(sc.getParamNode(), kind)
@@ -4212,17 +4212,15 @@ private module FlowExploration {
       ap = TRevPartialNil() and
       exists(config.explorationLimit())
       or
-      exists(PartialPathNodeRev mid |
-        revPartialPathStep(mid, node, state, sc1, sc2, sc3, ap, config) and
-        not clearsContentEx(node, ap.getHead()) and
-        (
-          notExpectsContent(node) or
-          expectsContentEx(node, ap.getHead())
-        ) and
-        not fullBarrier(node, config) and
-        not stateBarrier(node, state, config) and
-        distSink(node.getEnclosingCallable(), config) <= config.explorationLimit()
-      )
+      revPartialPathStep(_, node, state, sc1, sc2, sc3, ap, config) and
+      not clearsContentEx(node, ap.getHead()) and
+      (
+        notExpectsContent(node) or
+        expectsContentEx(node, ap.getHead())
+      ) and
+      not fullBarrier(node, config) and
+      not stateBarrier(node, state, config) and
+      distSink(node.getEnclosingCallable(), config) <= config.explorationLimit()
     }
 
   pragma[nomagic]
@@ -4230,19 +4228,17 @@ private module FlowExploration {
     NodeEx node, FlowState state, CallContext cc, TSummaryCtx1 sc1, TSummaryCtx2 sc2,
     TSummaryCtx3 sc3, PartialAccessPath ap, Configuration config
   ) {
-    exists(PartialPathNodeFwd mid |
-      partialPathStep(mid, node, state, cc, sc1, sc2, sc3, ap, config) and
-      not fullBarrier(node, config) and
-      not stateBarrier(node, state, config) and
-      not clearsContentEx(node, ap.getHead().getContent()) and
-      (
-        notExpectsContent(node) or
-        expectsContentEx(node, ap.getHead().getContent())
-      ) and
-      if node.asNode() instanceof CastingNode
-      then compatibleTypes(node.getDataFlowType(), ap.getType())
-      else any()
-    )
+    partialPathStep(_, node, state, cc, sc1, sc2, sc3, ap, config) and
+    not fullBarrier(node, config) and
+    not stateBarrier(node, state, config) and
+    not clearsContentEx(node, ap.getHead().getContent()) and
+    (
+      notExpectsContent(node) or
+      expectsContentEx(node, ap.getHead().getContent())
+    ) and
+    if node.asNode() instanceof CastingNode
+    then compatibleTypes(node.getDataFlowType(), ap.getType())
+    else any()
   }
 
   /**

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
@@ -876,9 +876,9 @@ private module Stage1 implements StageSig {
 
   pragma[nomagic]
   private predicate revFlowOut(ReturnPosition pos, Configuration config) {
-    exists(DataFlowCall call, NodeEx out |
+    exists(NodeEx out |
       revFlow(out, _, config) and
-      viableReturnPosOutNodeCandFwd1(call, pos, out, config)
+      viableReturnPosOutNodeCandFwd1(_, pos, out, config)
     )
   }
 
@@ -1731,8 +1731,8 @@ private module MkStage<StageSig PrevStage> {
       )
       or
       // flow through a callable
-      exists(DataFlowCall call, ParamNodeEx p, ReturnPosition pos, Ap innerReturnAp |
-        revFlowThrough(call, returnCtx, p, state, pos, returnAp, ap, innerReturnAp, config) and
+      exists(DataFlowCall call, ParamNodeEx p, Ap innerReturnAp |
+        revFlowThrough(call, returnCtx, p, state, _, returnAp, ap, innerReturnAp, config) and
         flowThroughIntoCall(call, node, p, _, ap, innerReturnAp, config)
       )
       or
@@ -1901,8 +1901,8 @@ private module MkStage<StageSig PrevStage> {
 
     pragma[nomagic]
     predicate parameterMayFlowThrough(ParamNodeEx p, Ap ap, Configuration config) {
-      exists(RetNodeEx ret, ReturnPosition pos |
-        returnFlowsThrough(ret, pos, _, _, p, ap, _, config) and
+      exists(ReturnPosition pos |
+        returnFlowsThrough(_, pos, _, _, p, ap, _, config) and
         parameterFlowsThroughRev(p, ap, pos, _, config)
       )
     }
@@ -1923,8 +1923,8 @@ private module MkStage<StageSig PrevStage> {
       DataFlowCall call, ArgNodeEx arg, FlowState state, ReturnCtx returnCtx, ApOption returnAp,
       Ap ap, Configuration config
     ) {
-      exists(ParamNodeEx p, ReturnPosition pos, Ap innerReturnAp |
-        revFlowThrough(call, returnCtx, p, state, pos, returnAp, ap, innerReturnAp, config) and
+      exists(ParamNodeEx p, Ap innerReturnAp |
+        revFlowThrough(call, returnCtx, p, state, _, returnAp, ap, innerReturnAp, config) and
         flowThroughIntoCall(call, arg, p, _, ap, innerReturnAp, config)
       )
     }
@@ -3749,8 +3749,8 @@ private predicate paramFlowsThrough(
   ReturnKindExt kind, FlowState state, CallContextCall cc, SummaryCtxSome sc, AccessPath ap,
   AccessPathApprox apa, Configuration config
 ) {
-  exists(PathNodeMid mid, RetNodeEx ret |
-    pathNode(mid, ret, state, cc, sc, ap, config, _) and
+  exists(RetNodeEx ret |
+    pathNode(_, ret, state, cc, sc, ap, config, _) and
     kind = ret.getKind() and
     apa = ap.getApprox() and
     parameterFlowThroughAllowed(sc.getParamNode(), kind)
@@ -4212,17 +4212,15 @@ private module FlowExploration {
       ap = TRevPartialNil() and
       exists(config.explorationLimit())
       or
-      exists(PartialPathNodeRev mid |
-        revPartialPathStep(mid, node, state, sc1, sc2, sc3, ap, config) and
-        not clearsContentEx(node, ap.getHead()) and
-        (
-          notExpectsContent(node) or
-          expectsContentEx(node, ap.getHead())
-        ) and
-        not fullBarrier(node, config) and
-        not stateBarrier(node, state, config) and
-        distSink(node.getEnclosingCallable(), config) <= config.explorationLimit()
-      )
+      revPartialPathStep(_, node, state, sc1, sc2, sc3, ap, config) and
+      not clearsContentEx(node, ap.getHead()) and
+      (
+        notExpectsContent(node) or
+        expectsContentEx(node, ap.getHead())
+      ) and
+      not fullBarrier(node, config) and
+      not stateBarrier(node, state, config) and
+      distSink(node.getEnclosingCallable(), config) <= config.explorationLimit()
     }
 
   pragma[nomagic]
@@ -4230,19 +4228,17 @@ private module FlowExploration {
     NodeEx node, FlowState state, CallContext cc, TSummaryCtx1 sc1, TSummaryCtx2 sc2,
     TSummaryCtx3 sc3, PartialAccessPath ap, Configuration config
   ) {
-    exists(PartialPathNodeFwd mid |
-      partialPathStep(mid, node, state, cc, sc1, sc2, sc3, ap, config) and
-      not fullBarrier(node, config) and
-      not stateBarrier(node, state, config) and
-      not clearsContentEx(node, ap.getHead().getContent()) and
-      (
-        notExpectsContent(node) or
-        expectsContentEx(node, ap.getHead().getContent())
-      ) and
-      if node.asNode() instanceof CastingNode
-      then compatibleTypes(node.getDataFlowType(), ap.getType())
-      else any()
-    )
+    partialPathStep(_, node, state, cc, sc1, sc2, sc3, ap, config) and
+    not fullBarrier(node, config) and
+    not stateBarrier(node, state, config) and
+    not clearsContentEx(node, ap.getHead().getContent()) and
+    (
+      notExpectsContent(node) or
+      expectsContentEx(node, ap.getHead().getContent())
+    ) and
+    if node.asNode() instanceof CastingNode
+    then compatibleTypes(node.getDataFlowType(), ap.getType())
+    else any()
   }
 
   /**

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
@@ -876,9 +876,9 @@ private module Stage1 implements StageSig {
 
   pragma[nomagic]
   private predicate revFlowOut(ReturnPosition pos, Configuration config) {
-    exists(DataFlowCall call, NodeEx out |
+    exists(NodeEx out |
       revFlow(out, _, config) and
-      viableReturnPosOutNodeCandFwd1(call, pos, out, config)
+      viableReturnPosOutNodeCandFwd1(_, pos, out, config)
     )
   }
 
@@ -1731,8 +1731,8 @@ private module MkStage<StageSig PrevStage> {
       )
       or
       // flow through a callable
-      exists(DataFlowCall call, ParamNodeEx p, ReturnPosition pos, Ap innerReturnAp |
-        revFlowThrough(call, returnCtx, p, state, pos, returnAp, ap, innerReturnAp, config) and
+      exists(DataFlowCall call, ParamNodeEx p, Ap innerReturnAp |
+        revFlowThrough(call, returnCtx, p, state, _, returnAp, ap, innerReturnAp, config) and
         flowThroughIntoCall(call, node, p, _, ap, innerReturnAp, config)
       )
       or
@@ -1901,8 +1901,8 @@ private module MkStage<StageSig PrevStage> {
 
     pragma[nomagic]
     predicate parameterMayFlowThrough(ParamNodeEx p, Ap ap, Configuration config) {
-      exists(RetNodeEx ret, ReturnPosition pos |
-        returnFlowsThrough(ret, pos, _, _, p, ap, _, config) and
+      exists(ReturnPosition pos |
+        returnFlowsThrough(_, pos, _, _, p, ap, _, config) and
         parameterFlowsThroughRev(p, ap, pos, _, config)
       )
     }
@@ -1923,8 +1923,8 @@ private module MkStage<StageSig PrevStage> {
       DataFlowCall call, ArgNodeEx arg, FlowState state, ReturnCtx returnCtx, ApOption returnAp,
       Ap ap, Configuration config
     ) {
-      exists(ParamNodeEx p, ReturnPosition pos, Ap innerReturnAp |
-        revFlowThrough(call, returnCtx, p, state, pos, returnAp, ap, innerReturnAp, config) and
+      exists(ParamNodeEx p, Ap innerReturnAp |
+        revFlowThrough(call, returnCtx, p, state, _, returnAp, ap, innerReturnAp, config) and
         flowThroughIntoCall(call, arg, p, _, ap, innerReturnAp, config)
       )
     }
@@ -3749,8 +3749,8 @@ private predicate paramFlowsThrough(
   ReturnKindExt kind, FlowState state, CallContextCall cc, SummaryCtxSome sc, AccessPath ap,
   AccessPathApprox apa, Configuration config
 ) {
-  exists(PathNodeMid mid, RetNodeEx ret |
-    pathNode(mid, ret, state, cc, sc, ap, config, _) and
+  exists(RetNodeEx ret |
+    pathNode(_, ret, state, cc, sc, ap, config, _) and
     kind = ret.getKind() and
     apa = ap.getApprox() and
     parameterFlowThroughAllowed(sc.getParamNode(), kind)
@@ -4212,17 +4212,15 @@ private module FlowExploration {
       ap = TRevPartialNil() and
       exists(config.explorationLimit())
       or
-      exists(PartialPathNodeRev mid |
-        revPartialPathStep(mid, node, state, sc1, sc2, sc3, ap, config) and
-        not clearsContentEx(node, ap.getHead()) and
-        (
-          notExpectsContent(node) or
-          expectsContentEx(node, ap.getHead())
-        ) and
-        not fullBarrier(node, config) and
-        not stateBarrier(node, state, config) and
-        distSink(node.getEnclosingCallable(), config) <= config.explorationLimit()
-      )
+      revPartialPathStep(_, node, state, sc1, sc2, sc3, ap, config) and
+      not clearsContentEx(node, ap.getHead()) and
+      (
+        notExpectsContent(node) or
+        expectsContentEx(node, ap.getHead())
+      ) and
+      not fullBarrier(node, config) and
+      not stateBarrier(node, state, config) and
+      distSink(node.getEnclosingCallable(), config) <= config.explorationLimit()
     }
 
   pragma[nomagic]
@@ -4230,19 +4228,17 @@ private module FlowExploration {
     NodeEx node, FlowState state, CallContext cc, TSummaryCtx1 sc1, TSummaryCtx2 sc2,
     TSummaryCtx3 sc3, PartialAccessPath ap, Configuration config
   ) {
-    exists(PartialPathNodeFwd mid |
-      partialPathStep(mid, node, state, cc, sc1, sc2, sc3, ap, config) and
-      not fullBarrier(node, config) and
-      not stateBarrier(node, state, config) and
-      not clearsContentEx(node, ap.getHead().getContent()) and
-      (
-        notExpectsContent(node) or
-        expectsContentEx(node, ap.getHead().getContent())
-      ) and
-      if node.asNode() instanceof CastingNode
-      then compatibleTypes(node.getDataFlowType(), ap.getType())
-      else any()
-    )
+    partialPathStep(_, node, state, cc, sc1, sc2, sc3, ap, config) and
+    not fullBarrier(node, config) and
+    not stateBarrier(node, state, config) and
+    not clearsContentEx(node, ap.getHead().getContent()) and
+    (
+      notExpectsContent(node) or
+      expectsContentEx(node, ap.getHead().getContent())
+    ) and
+    if node.asNode() instanceof CastingNode
+    then compatibleTypes(node.getDataFlowType(), ap.getType())
+    else any()
   }
 
   /**

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplConsistency.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplConsistency.qll
@@ -101,9 +101,7 @@ module Consistency {
     exists(int c |
       c =
         strictcount(Node n |
-          not exists(string filepath, int startline, int startcolumn, int endline, int endcolumn |
-            n.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
-          ) and
+          n.hasLocationInfo(_, _, _, _, _) and
           not any(ConsistencyConfiguration conf).missingLocationExclude(n)
         ) and
       msg = "Nodes without location: " + c

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
@@ -876,9 +876,9 @@ private module Stage1 implements StageSig {
 
   pragma[nomagic]
   private predicate revFlowOut(ReturnPosition pos, Configuration config) {
-    exists(DataFlowCall call, NodeEx out |
+    exists(NodeEx out |
       revFlow(out, _, config) and
-      viableReturnPosOutNodeCandFwd1(call, pos, out, config)
+      viableReturnPosOutNodeCandFwd1(_, pos, out, config)
     )
   }
 
@@ -1731,8 +1731,8 @@ private module MkStage<StageSig PrevStage> {
       )
       or
       // flow through a callable
-      exists(DataFlowCall call, ParamNodeEx p, ReturnPosition pos, Ap innerReturnAp |
-        revFlowThrough(call, returnCtx, p, state, pos, returnAp, ap, innerReturnAp, config) and
+      exists(DataFlowCall call, ParamNodeEx p, Ap innerReturnAp |
+        revFlowThrough(call, returnCtx, p, state, _, returnAp, ap, innerReturnAp, config) and
         flowThroughIntoCall(call, node, p, _, ap, innerReturnAp, config)
       )
       or
@@ -1901,8 +1901,8 @@ private module MkStage<StageSig PrevStage> {
 
     pragma[nomagic]
     predicate parameterMayFlowThrough(ParamNodeEx p, Ap ap, Configuration config) {
-      exists(RetNodeEx ret, ReturnPosition pos |
-        returnFlowsThrough(ret, pos, _, _, p, ap, _, config) and
+      exists(ReturnPosition pos |
+        returnFlowsThrough(_, pos, _, _, p, ap, _, config) and
         parameterFlowsThroughRev(p, ap, pos, _, config)
       )
     }
@@ -1923,8 +1923,8 @@ private module MkStage<StageSig PrevStage> {
       DataFlowCall call, ArgNodeEx arg, FlowState state, ReturnCtx returnCtx, ApOption returnAp,
       Ap ap, Configuration config
     ) {
-      exists(ParamNodeEx p, ReturnPosition pos, Ap innerReturnAp |
-        revFlowThrough(call, returnCtx, p, state, pos, returnAp, ap, innerReturnAp, config) and
+      exists(ParamNodeEx p, Ap innerReturnAp |
+        revFlowThrough(call, returnCtx, p, state, _, returnAp, ap, innerReturnAp, config) and
         flowThroughIntoCall(call, arg, p, _, ap, innerReturnAp, config)
       )
     }
@@ -3749,8 +3749,8 @@ private predicate paramFlowsThrough(
   ReturnKindExt kind, FlowState state, CallContextCall cc, SummaryCtxSome sc, AccessPath ap,
   AccessPathApprox apa, Configuration config
 ) {
-  exists(PathNodeMid mid, RetNodeEx ret |
-    pathNode(mid, ret, state, cc, sc, ap, config, _) and
+  exists(RetNodeEx ret |
+    pathNode(_, ret, state, cc, sc, ap, config, _) and
     kind = ret.getKind() and
     apa = ap.getApprox() and
     parameterFlowThroughAllowed(sc.getParamNode(), kind)
@@ -4212,17 +4212,15 @@ private module FlowExploration {
       ap = TRevPartialNil() and
       exists(config.explorationLimit())
       or
-      exists(PartialPathNodeRev mid |
-        revPartialPathStep(mid, node, state, sc1, sc2, sc3, ap, config) and
-        not clearsContentEx(node, ap.getHead()) and
-        (
-          notExpectsContent(node) or
-          expectsContentEx(node, ap.getHead())
-        ) and
-        not fullBarrier(node, config) and
-        not stateBarrier(node, state, config) and
-        distSink(node.getEnclosingCallable(), config) <= config.explorationLimit()
-      )
+      revPartialPathStep(_, node, state, sc1, sc2, sc3, ap, config) and
+      not clearsContentEx(node, ap.getHead()) and
+      (
+        notExpectsContent(node) or
+        expectsContentEx(node, ap.getHead())
+      ) and
+      not fullBarrier(node, config) and
+      not stateBarrier(node, state, config) and
+      distSink(node.getEnclosingCallable(), config) <= config.explorationLimit()
     }
 
   pragma[nomagic]
@@ -4230,19 +4228,17 @@ private module FlowExploration {
     NodeEx node, FlowState state, CallContext cc, TSummaryCtx1 sc1, TSummaryCtx2 sc2,
     TSummaryCtx3 sc3, PartialAccessPath ap, Configuration config
   ) {
-    exists(PartialPathNodeFwd mid |
-      partialPathStep(mid, node, state, cc, sc1, sc2, sc3, ap, config) and
-      not fullBarrier(node, config) and
-      not stateBarrier(node, state, config) and
-      not clearsContentEx(node, ap.getHead().getContent()) and
-      (
-        notExpectsContent(node) or
-        expectsContentEx(node, ap.getHead().getContent())
-      ) and
-      if node.asNode() instanceof CastingNode
-      then compatibleTypes(node.getDataFlowType(), ap.getType())
-      else any()
-    )
+    partialPathStep(_, node, state, cc, sc1, sc2, sc3, ap, config) and
+    not fullBarrier(node, config) and
+    not stateBarrier(node, state, config) and
+    not clearsContentEx(node, ap.getHead().getContent()) and
+    (
+      notExpectsContent(node) or
+      expectsContentEx(node, ap.getHead().getContent())
+    ) and
+    if node.asNode() instanceof CastingNode
+    then compatibleTypes(node.getDataFlowType(), ap.getType())
+    else any()
   }
 
   /**

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/FlowVar.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/FlowVar.qll
@@ -450,10 +450,8 @@ module FlowVar_internal {
     }
 
     override string toString() {
-      exists(Expr e |
-        this.definedByExpr(e, _) and
-        result = "assignment to " + v
-      )
+      this.definedByExpr(_, _) and
+      result = "assignment to " + v
       or
       this.definedByInitialValue(_) and
       result = "initial value of " + v

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/SubBasicBlocks.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/SubBasicBlocks.qll
@@ -54,7 +54,7 @@ class SubBasicBlock extends ControlFlowNodeBase {
    * only condition under which a `SubBasicBlock` may have multiple
    * predecessors.
    */
-  predicate firstInBB() { exists(BasicBlock bb | this.getRankInBasicBlock(bb) = 1) }
+  predicate firstInBB() { this.getRankInBasicBlock(_) = 1 }
 
   /**
    * Holds if this `SubBasicBlock` comes last in its basic block. This is the

--- a/cpp/ql/lib/semmle/code/cpp/dispatch/VirtualDispatchPrototype.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dispatch/VirtualDispatchPrototype.qll
@@ -70,8 +70,8 @@ module VirtualDispatch {
    * that is, `c` or one of its supertypes overrides `f`.
    */
   private predicate cannotInherit(Class c, MemberFunction f) {
-    exists(Class overridingType, MemberFunction override |
-      cannotInheritHelper(c, f, overridingType, override) and
+    exists(MemberFunction override |
+      cannotInheritHelper(c, f, _, override) and
       override.overrides+(f)
     )
   }

--- a/cpp/ql/lib/semmle/code/cpp/exprs/Expr.qll
+++ b/cpp/ql/lib/semmle/code/cpp/exprs/Expr.qll
@@ -53,7 +53,7 @@ class Expr extends StmtParent, @expr {
   Declaration getEnclosingDeclaration() { result = exprEnclosingElement(this) }
 
   /** Gets a child of this expression. */
-  Expr getAChild() { exists(int n | result = this.getChild(n)) }
+  Expr getAChild() { result = this.getChild(_) }
 
   /** Gets the parent of this expression, if any. */
   Element getParent() { exprparents(underlyingElement(this), _, unresolveElement(result)) }

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -876,9 +876,9 @@ private module Stage1 implements StageSig {
 
   pragma[nomagic]
   private predicate revFlowOut(ReturnPosition pos, Configuration config) {
-    exists(DataFlowCall call, NodeEx out |
+    exists(NodeEx out |
       revFlow(out, _, config) and
-      viableReturnPosOutNodeCandFwd1(call, pos, out, config)
+      viableReturnPosOutNodeCandFwd1(_, pos, out, config)
     )
   }
 
@@ -1731,8 +1731,8 @@ private module MkStage<StageSig PrevStage> {
       )
       or
       // flow through a callable
-      exists(DataFlowCall call, ParamNodeEx p, ReturnPosition pos, Ap innerReturnAp |
-        revFlowThrough(call, returnCtx, p, state, pos, returnAp, ap, innerReturnAp, config) and
+      exists(DataFlowCall call, ParamNodeEx p, Ap innerReturnAp |
+        revFlowThrough(call, returnCtx, p, state, _, returnAp, ap, innerReturnAp, config) and
         flowThroughIntoCall(call, node, p, _, ap, innerReturnAp, config)
       )
       or
@@ -1901,8 +1901,8 @@ private module MkStage<StageSig PrevStage> {
 
     pragma[nomagic]
     predicate parameterMayFlowThrough(ParamNodeEx p, Ap ap, Configuration config) {
-      exists(RetNodeEx ret, ReturnPosition pos |
-        returnFlowsThrough(ret, pos, _, _, p, ap, _, config) and
+      exists(ReturnPosition pos |
+        returnFlowsThrough(_, pos, _, _, p, ap, _, config) and
         parameterFlowsThroughRev(p, ap, pos, _, config)
       )
     }
@@ -1923,8 +1923,8 @@ private module MkStage<StageSig PrevStage> {
       DataFlowCall call, ArgNodeEx arg, FlowState state, ReturnCtx returnCtx, ApOption returnAp,
       Ap ap, Configuration config
     ) {
-      exists(ParamNodeEx p, ReturnPosition pos, Ap innerReturnAp |
-        revFlowThrough(call, returnCtx, p, state, pos, returnAp, ap, innerReturnAp, config) and
+      exists(ParamNodeEx p, Ap innerReturnAp |
+        revFlowThrough(call, returnCtx, p, state, _, returnAp, ap, innerReturnAp, config) and
         flowThroughIntoCall(call, arg, p, _, ap, innerReturnAp, config)
       )
     }
@@ -3749,8 +3749,8 @@ private predicate paramFlowsThrough(
   ReturnKindExt kind, FlowState state, CallContextCall cc, SummaryCtxSome sc, AccessPath ap,
   AccessPathApprox apa, Configuration config
 ) {
-  exists(PathNodeMid mid, RetNodeEx ret |
-    pathNode(mid, ret, state, cc, sc, ap, config, _) and
+  exists(RetNodeEx ret |
+    pathNode(_, ret, state, cc, sc, ap, config, _) and
     kind = ret.getKind() and
     apa = ap.getApprox() and
     parameterFlowThroughAllowed(sc.getParamNode(), kind)
@@ -4212,17 +4212,15 @@ private module FlowExploration {
       ap = TRevPartialNil() and
       exists(config.explorationLimit())
       or
-      exists(PartialPathNodeRev mid |
-        revPartialPathStep(mid, node, state, sc1, sc2, sc3, ap, config) and
-        not clearsContentEx(node, ap.getHead()) and
-        (
-          notExpectsContent(node) or
-          expectsContentEx(node, ap.getHead())
-        ) and
-        not fullBarrier(node, config) and
-        not stateBarrier(node, state, config) and
-        distSink(node.getEnclosingCallable(), config) <= config.explorationLimit()
-      )
+      revPartialPathStep(_, node, state, sc1, sc2, sc3, ap, config) and
+      not clearsContentEx(node, ap.getHead()) and
+      (
+        notExpectsContent(node) or
+        expectsContentEx(node, ap.getHead())
+      ) and
+      not fullBarrier(node, config) and
+      not stateBarrier(node, state, config) and
+      distSink(node.getEnclosingCallable(), config) <= config.explorationLimit()
     }
 
   pragma[nomagic]
@@ -4230,19 +4228,17 @@ private module FlowExploration {
     NodeEx node, FlowState state, CallContext cc, TSummaryCtx1 sc1, TSummaryCtx2 sc2,
     TSummaryCtx3 sc3, PartialAccessPath ap, Configuration config
   ) {
-    exists(PartialPathNodeFwd mid |
-      partialPathStep(mid, node, state, cc, sc1, sc2, sc3, ap, config) and
-      not fullBarrier(node, config) and
-      not stateBarrier(node, state, config) and
-      not clearsContentEx(node, ap.getHead().getContent()) and
-      (
-        notExpectsContent(node) or
-        expectsContentEx(node, ap.getHead().getContent())
-      ) and
-      if node.asNode() instanceof CastingNode
-      then compatibleTypes(node.getDataFlowType(), ap.getType())
-      else any()
-    )
+    partialPathStep(_, node, state, cc, sc1, sc2, sc3, ap, config) and
+    not fullBarrier(node, config) and
+    not stateBarrier(node, state, config) and
+    not clearsContentEx(node, ap.getHead().getContent()) and
+    (
+      notExpectsContent(node) or
+      expectsContentEx(node, ap.getHead().getContent())
+    ) and
+    if node.asNode() instanceof CastingNode
+    then compatibleTypes(node.getDataFlowType(), ap.getType())
+    else any()
   }
 
   /**

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -876,9 +876,9 @@ private module Stage1 implements StageSig {
 
   pragma[nomagic]
   private predicate revFlowOut(ReturnPosition pos, Configuration config) {
-    exists(DataFlowCall call, NodeEx out |
+    exists(NodeEx out |
       revFlow(out, _, config) and
-      viableReturnPosOutNodeCandFwd1(call, pos, out, config)
+      viableReturnPosOutNodeCandFwd1(_, pos, out, config)
     )
   }
 
@@ -1731,8 +1731,8 @@ private module MkStage<StageSig PrevStage> {
       )
       or
       // flow through a callable
-      exists(DataFlowCall call, ParamNodeEx p, ReturnPosition pos, Ap innerReturnAp |
-        revFlowThrough(call, returnCtx, p, state, pos, returnAp, ap, innerReturnAp, config) and
+      exists(DataFlowCall call, ParamNodeEx p, Ap innerReturnAp |
+        revFlowThrough(call, returnCtx, p, state, _, returnAp, ap, innerReturnAp, config) and
         flowThroughIntoCall(call, node, p, _, ap, innerReturnAp, config)
       )
       or
@@ -1901,8 +1901,8 @@ private module MkStage<StageSig PrevStage> {
 
     pragma[nomagic]
     predicate parameterMayFlowThrough(ParamNodeEx p, Ap ap, Configuration config) {
-      exists(RetNodeEx ret, ReturnPosition pos |
-        returnFlowsThrough(ret, pos, _, _, p, ap, _, config) and
+      exists(ReturnPosition pos |
+        returnFlowsThrough(_, pos, _, _, p, ap, _, config) and
         parameterFlowsThroughRev(p, ap, pos, _, config)
       )
     }
@@ -1923,8 +1923,8 @@ private module MkStage<StageSig PrevStage> {
       DataFlowCall call, ArgNodeEx arg, FlowState state, ReturnCtx returnCtx, ApOption returnAp,
       Ap ap, Configuration config
     ) {
-      exists(ParamNodeEx p, ReturnPosition pos, Ap innerReturnAp |
-        revFlowThrough(call, returnCtx, p, state, pos, returnAp, ap, innerReturnAp, config) and
+      exists(ParamNodeEx p, Ap innerReturnAp |
+        revFlowThrough(call, returnCtx, p, state, _, returnAp, ap, innerReturnAp, config) and
         flowThroughIntoCall(call, arg, p, _, ap, innerReturnAp, config)
       )
     }
@@ -3749,8 +3749,8 @@ private predicate paramFlowsThrough(
   ReturnKindExt kind, FlowState state, CallContextCall cc, SummaryCtxSome sc, AccessPath ap,
   AccessPathApprox apa, Configuration config
 ) {
-  exists(PathNodeMid mid, RetNodeEx ret |
-    pathNode(mid, ret, state, cc, sc, ap, config, _) and
+  exists(RetNodeEx ret |
+    pathNode(_, ret, state, cc, sc, ap, config, _) and
     kind = ret.getKind() and
     apa = ap.getApprox() and
     parameterFlowThroughAllowed(sc.getParamNode(), kind)
@@ -4212,17 +4212,15 @@ private module FlowExploration {
       ap = TRevPartialNil() and
       exists(config.explorationLimit())
       or
-      exists(PartialPathNodeRev mid |
-        revPartialPathStep(mid, node, state, sc1, sc2, sc3, ap, config) and
-        not clearsContentEx(node, ap.getHead()) and
-        (
-          notExpectsContent(node) or
-          expectsContentEx(node, ap.getHead())
-        ) and
-        not fullBarrier(node, config) and
-        not stateBarrier(node, state, config) and
-        distSink(node.getEnclosingCallable(), config) <= config.explorationLimit()
-      )
+      revPartialPathStep(_, node, state, sc1, sc2, sc3, ap, config) and
+      not clearsContentEx(node, ap.getHead()) and
+      (
+        notExpectsContent(node) or
+        expectsContentEx(node, ap.getHead())
+      ) and
+      not fullBarrier(node, config) and
+      not stateBarrier(node, state, config) and
+      distSink(node.getEnclosingCallable(), config) <= config.explorationLimit()
     }
 
   pragma[nomagic]
@@ -4230,19 +4228,17 @@ private module FlowExploration {
     NodeEx node, FlowState state, CallContext cc, TSummaryCtx1 sc1, TSummaryCtx2 sc2,
     TSummaryCtx3 sc3, PartialAccessPath ap, Configuration config
   ) {
-    exists(PartialPathNodeFwd mid |
-      partialPathStep(mid, node, state, cc, sc1, sc2, sc3, ap, config) and
-      not fullBarrier(node, config) and
-      not stateBarrier(node, state, config) and
-      not clearsContentEx(node, ap.getHead().getContent()) and
-      (
-        notExpectsContent(node) or
-        expectsContentEx(node, ap.getHead().getContent())
-      ) and
-      if node.asNode() instanceof CastingNode
-      then compatibleTypes(node.getDataFlowType(), ap.getType())
-      else any()
-    )
+    partialPathStep(_, node, state, cc, sc1, sc2, sc3, ap, config) and
+    not fullBarrier(node, config) and
+    not stateBarrier(node, state, config) and
+    not clearsContentEx(node, ap.getHead().getContent()) and
+    (
+      notExpectsContent(node) or
+      expectsContentEx(node, ap.getHead().getContent())
+    ) and
+    if node.asNode() instanceof CastingNode
+    then compatibleTypes(node.getDataFlowType(), ap.getType())
+    else any()
   }
 
   /**

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -876,9 +876,9 @@ private module Stage1 implements StageSig {
 
   pragma[nomagic]
   private predicate revFlowOut(ReturnPosition pos, Configuration config) {
-    exists(DataFlowCall call, NodeEx out |
+    exists(NodeEx out |
       revFlow(out, _, config) and
-      viableReturnPosOutNodeCandFwd1(call, pos, out, config)
+      viableReturnPosOutNodeCandFwd1(_, pos, out, config)
     )
   }
 
@@ -1731,8 +1731,8 @@ private module MkStage<StageSig PrevStage> {
       )
       or
       // flow through a callable
-      exists(DataFlowCall call, ParamNodeEx p, ReturnPosition pos, Ap innerReturnAp |
-        revFlowThrough(call, returnCtx, p, state, pos, returnAp, ap, innerReturnAp, config) and
+      exists(DataFlowCall call, ParamNodeEx p, Ap innerReturnAp |
+        revFlowThrough(call, returnCtx, p, state, _, returnAp, ap, innerReturnAp, config) and
         flowThroughIntoCall(call, node, p, _, ap, innerReturnAp, config)
       )
       or
@@ -1901,8 +1901,8 @@ private module MkStage<StageSig PrevStage> {
 
     pragma[nomagic]
     predicate parameterMayFlowThrough(ParamNodeEx p, Ap ap, Configuration config) {
-      exists(RetNodeEx ret, ReturnPosition pos |
-        returnFlowsThrough(ret, pos, _, _, p, ap, _, config) and
+      exists(ReturnPosition pos |
+        returnFlowsThrough(_, pos, _, _, p, ap, _, config) and
         parameterFlowsThroughRev(p, ap, pos, _, config)
       )
     }
@@ -1923,8 +1923,8 @@ private module MkStage<StageSig PrevStage> {
       DataFlowCall call, ArgNodeEx arg, FlowState state, ReturnCtx returnCtx, ApOption returnAp,
       Ap ap, Configuration config
     ) {
-      exists(ParamNodeEx p, ReturnPosition pos, Ap innerReturnAp |
-        revFlowThrough(call, returnCtx, p, state, pos, returnAp, ap, innerReturnAp, config) and
+      exists(ParamNodeEx p, Ap innerReturnAp |
+        revFlowThrough(call, returnCtx, p, state, _, returnAp, ap, innerReturnAp, config) and
         flowThroughIntoCall(call, arg, p, _, ap, innerReturnAp, config)
       )
     }
@@ -3749,8 +3749,8 @@ private predicate paramFlowsThrough(
   ReturnKindExt kind, FlowState state, CallContextCall cc, SummaryCtxSome sc, AccessPath ap,
   AccessPathApprox apa, Configuration config
 ) {
-  exists(PathNodeMid mid, RetNodeEx ret |
-    pathNode(mid, ret, state, cc, sc, ap, config, _) and
+  exists(RetNodeEx ret |
+    pathNode(_, ret, state, cc, sc, ap, config, _) and
     kind = ret.getKind() and
     apa = ap.getApprox() and
     parameterFlowThroughAllowed(sc.getParamNode(), kind)
@@ -4212,17 +4212,15 @@ private module FlowExploration {
       ap = TRevPartialNil() and
       exists(config.explorationLimit())
       or
-      exists(PartialPathNodeRev mid |
-        revPartialPathStep(mid, node, state, sc1, sc2, sc3, ap, config) and
-        not clearsContentEx(node, ap.getHead()) and
-        (
-          notExpectsContent(node) or
-          expectsContentEx(node, ap.getHead())
-        ) and
-        not fullBarrier(node, config) and
-        not stateBarrier(node, state, config) and
-        distSink(node.getEnclosingCallable(), config) <= config.explorationLimit()
-      )
+      revPartialPathStep(_, node, state, sc1, sc2, sc3, ap, config) and
+      not clearsContentEx(node, ap.getHead()) and
+      (
+        notExpectsContent(node) or
+        expectsContentEx(node, ap.getHead())
+      ) and
+      not fullBarrier(node, config) and
+      not stateBarrier(node, state, config) and
+      distSink(node.getEnclosingCallable(), config) <= config.explorationLimit()
     }
 
   pragma[nomagic]
@@ -4230,19 +4228,17 @@ private module FlowExploration {
     NodeEx node, FlowState state, CallContext cc, TSummaryCtx1 sc1, TSummaryCtx2 sc2,
     TSummaryCtx3 sc3, PartialAccessPath ap, Configuration config
   ) {
-    exists(PartialPathNodeFwd mid |
-      partialPathStep(mid, node, state, cc, sc1, sc2, sc3, ap, config) and
-      not fullBarrier(node, config) and
-      not stateBarrier(node, state, config) and
-      not clearsContentEx(node, ap.getHead().getContent()) and
-      (
-        notExpectsContent(node) or
-        expectsContentEx(node, ap.getHead().getContent())
-      ) and
-      if node.asNode() instanceof CastingNode
-      then compatibleTypes(node.getDataFlowType(), ap.getType())
-      else any()
-    )
+    partialPathStep(_, node, state, cc, sc1, sc2, sc3, ap, config) and
+    not fullBarrier(node, config) and
+    not stateBarrier(node, state, config) and
+    not clearsContentEx(node, ap.getHead().getContent()) and
+    (
+      notExpectsContent(node) or
+      expectsContentEx(node, ap.getHead().getContent())
+    ) and
+    if node.asNode() instanceof CastingNode
+    then compatibleTypes(node.getDataFlowType(), ap.getType())
+    else any()
   }
 
   /**

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -876,9 +876,9 @@ private module Stage1 implements StageSig {
 
   pragma[nomagic]
   private predicate revFlowOut(ReturnPosition pos, Configuration config) {
-    exists(DataFlowCall call, NodeEx out |
+    exists(NodeEx out |
       revFlow(out, _, config) and
-      viableReturnPosOutNodeCandFwd1(call, pos, out, config)
+      viableReturnPosOutNodeCandFwd1(_, pos, out, config)
     )
   }
 
@@ -1731,8 +1731,8 @@ private module MkStage<StageSig PrevStage> {
       )
       or
       // flow through a callable
-      exists(DataFlowCall call, ParamNodeEx p, ReturnPosition pos, Ap innerReturnAp |
-        revFlowThrough(call, returnCtx, p, state, pos, returnAp, ap, innerReturnAp, config) and
+      exists(DataFlowCall call, ParamNodeEx p, Ap innerReturnAp |
+        revFlowThrough(call, returnCtx, p, state, _, returnAp, ap, innerReturnAp, config) and
         flowThroughIntoCall(call, node, p, _, ap, innerReturnAp, config)
       )
       or
@@ -1901,8 +1901,8 @@ private module MkStage<StageSig PrevStage> {
 
     pragma[nomagic]
     predicate parameterMayFlowThrough(ParamNodeEx p, Ap ap, Configuration config) {
-      exists(RetNodeEx ret, ReturnPosition pos |
-        returnFlowsThrough(ret, pos, _, _, p, ap, _, config) and
+      exists(ReturnPosition pos |
+        returnFlowsThrough(_, pos, _, _, p, ap, _, config) and
         parameterFlowsThroughRev(p, ap, pos, _, config)
       )
     }
@@ -1923,8 +1923,8 @@ private module MkStage<StageSig PrevStage> {
       DataFlowCall call, ArgNodeEx arg, FlowState state, ReturnCtx returnCtx, ApOption returnAp,
       Ap ap, Configuration config
     ) {
-      exists(ParamNodeEx p, ReturnPosition pos, Ap innerReturnAp |
-        revFlowThrough(call, returnCtx, p, state, pos, returnAp, ap, innerReturnAp, config) and
+      exists(ParamNodeEx p, Ap innerReturnAp |
+        revFlowThrough(call, returnCtx, p, state, _, returnAp, ap, innerReturnAp, config) and
         flowThroughIntoCall(call, arg, p, _, ap, innerReturnAp, config)
       )
     }
@@ -3749,8 +3749,8 @@ private predicate paramFlowsThrough(
   ReturnKindExt kind, FlowState state, CallContextCall cc, SummaryCtxSome sc, AccessPath ap,
   AccessPathApprox apa, Configuration config
 ) {
-  exists(PathNodeMid mid, RetNodeEx ret |
-    pathNode(mid, ret, state, cc, sc, ap, config, _) and
+  exists(RetNodeEx ret |
+    pathNode(_, ret, state, cc, sc, ap, config, _) and
     kind = ret.getKind() and
     apa = ap.getApprox() and
     parameterFlowThroughAllowed(sc.getParamNode(), kind)
@@ -4212,17 +4212,15 @@ private module FlowExploration {
       ap = TRevPartialNil() and
       exists(config.explorationLimit())
       or
-      exists(PartialPathNodeRev mid |
-        revPartialPathStep(mid, node, state, sc1, sc2, sc3, ap, config) and
-        not clearsContentEx(node, ap.getHead()) and
-        (
-          notExpectsContent(node) or
-          expectsContentEx(node, ap.getHead())
-        ) and
-        not fullBarrier(node, config) and
-        not stateBarrier(node, state, config) and
-        distSink(node.getEnclosingCallable(), config) <= config.explorationLimit()
-      )
+      revPartialPathStep(_, node, state, sc1, sc2, sc3, ap, config) and
+      not clearsContentEx(node, ap.getHead()) and
+      (
+        notExpectsContent(node) or
+        expectsContentEx(node, ap.getHead())
+      ) and
+      not fullBarrier(node, config) and
+      not stateBarrier(node, state, config) and
+      distSink(node.getEnclosingCallable(), config) <= config.explorationLimit()
     }
 
   pragma[nomagic]
@@ -4230,19 +4228,17 @@ private module FlowExploration {
     NodeEx node, FlowState state, CallContext cc, TSummaryCtx1 sc1, TSummaryCtx2 sc2,
     TSummaryCtx3 sc3, PartialAccessPath ap, Configuration config
   ) {
-    exists(PartialPathNodeFwd mid |
-      partialPathStep(mid, node, state, cc, sc1, sc2, sc3, ap, config) and
-      not fullBarrier(node, config) and
-      not stateBarrier(node, state, config) and
-      not clearsContentEx(node, ap.getHead().getContent()) and
-      (
-        notExpectsContent(node) or
-        expectsContentEx(node, ap.getHead().getContent())
-      ) and
-      if node.asNode() instanceof CastingNode
-      then compatibleTypes(node.getDataFlowType(), ap.getType())
-      else any()
-    )
+    partialPathStep(_, node, state, cc, sc1, sc2, sc3, ap, config) and
+    not fullBarrier(node, config) and
+    not stateBarrier(node, state, config) and
+    not clearsContentEx(node, ap.getHead().getContent()) and
+    (
+      notExpectsContent(node) or
+      expectsContentEx(node, ap.getHead().getContent())
+    ) and
+    if node.asNode() instanceof CastingNode
+    then compatibleTypes(node.getDataFlowType(), ap.getType())
+    else any()
   }
 
   /**

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImplConsistency.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImplConsistency.qll
@@ -101,9 +101,7 @@ module Consistency {
     exists(int c |
       c =
         strictcount(Node n |
-          not exists(string filepath, int startline, int startcolumn, int endline, int endcolumn |
-            n.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
-          ) and
+          n.hasLocationInfo(_, _, _, _, _) and
           not any(ConsistencyConfiguration conf).missingLocationExclude(n)
         ) and
       msg = "Nodes without location: " + c

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/Operand.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/Operand.qll
@@ -45,7 +45,7 @@ class Operand extends TStageOperand {
       this = reusedPhiOperand(use, def, predecessorBlock, _)
     )
     or
-    exists(Instruction use | this = chiOperand(use, _))
+    this = chiOperand(_, _)
   }
 
   /** Gets a textual representation of this element. */

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/internal/SSAConstruction.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/internal/SSAConstruction.qll
@@ -329,12 +329,12 @@ private module Cached {
   cached
   Instruction getChiInstructionTotalOperand(ChiInstruction chiInstr) {
     exists(
-      Alias::VirtualVariable vvar, OldInstruction oldInstr, Alias::MemoryLocation defLocation,
-      OldBlock defBlock, int defRank, int defOffset, OldBlock useBlock, int useRank
+      Alias::VirtualVariable vvar, OldInstruction oldInstr, OldBlock defBlock, int defRank,
+      int defOffset, OldBlock useBlock, int useRank
     |
       chiInstr = getChi(oldInstr) and
       vvar = Alias::getResultMemoryLocation(oldInstr).getVirtualVariable() and
-      hasDefinitionAtRank(vvar, defLocation, defBlock, defRank, defOffset) and
+      hasDefinitionAtRank(vvar, _, defBlock, defRank, defOffset) and
       hasUseAtRank(vvar, useBlock, useRank, oldInstr) and
       definitionReachesUse(vvar, defBlock, defRank, useBlock, useRank) and
       result = getDefinitionOrChiInstruction(defBlock, defOffset, vvar, _)

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/Operand.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/Operand.qll
@@ -45,7 +45,7 @@ class Operand extends TStageOperand {
       this = reusedPhiOperand(use, def, predecessorBlock, _)
     )
     or
-    exists(Instruction use | this = chiOperand(use, _))
+    this = chiOperand(_, _)
   }
 
   /** Gets a textual representation of this element. */

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/internal/TranslatedInitialization.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/internal/TranslatedInitialization.qll
@@ -298,11 +298,11 @@ class TranslatedStringLiteralInitialization extends TranslatedDirectInitializati
     opcode instanceof Opcode::Store and
     resultType = getTypeForPRValue(expr.getType())
     or
-    exists(int startIndex, int elementCount |
+    exists(int elementCount |
       // If the initializer string isn't large enough to fill the target, then
       // we have to generate another instruction sequence to store a constant
       // zero into the remainder of the array.
-      zeroInitRange(startIndex, elementCount) and
+      zeroInitRange(_, elementCount) and
       (
         // Create a constant zero whose size is the size of the remaining
         // space in the target array.

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/Operand.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/Operand.qll
@@ -45,7 +45,7 @@ class Operand extends TStageOperand {
       this = reusedPhiOperand(use, def, predecessorBlock, _)
     )
     or
-    exists(Instruction use | this = chiOperand(use, _))
+    this = chiOperand(_, _)
   }
 
   /** Gets a textual representation of this element. */

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
@@ -329,12 +329,12 @@ private module Cached {
   cached
   Instruction getChiInstructionTotalOperand(ChiInstruction chiInstr) {
     exists(
-      Alias::VirtualVariable vvar, OldInstruction oldInstr, Alias::MemoryLocation defLocation,
-      OldBlock defBlock, int defRank, int defOffset, OldBlock useBlock, int useRank
+      Alias::VirtualVariable vvar, OldInstruction oldInstr, OldBlock defBlock, int defRank,
+      int defOffset, OldBlock useBlock, int useRank
     |
       chiInstr = getChi(oldInstr) and
       vvar = Alias::getResultMemoryLocation(oldInstr).getVirtualVariable() and
-      hasDefinitionAtRank(vvar, defLocation, defBlock, defRank, defOffset) and
+      hasDefinitionAtRank(vvar, _, defBlock, defRank, defOffset) and
       hasUseAtRank(vvar, useBlock, useRank, oldInstr) and
       definitionReachesUse(vvar, defBlock, defRank, useBlock, useRank) and
       result = getDefinitionOrChiInstruction(defBlock, defOffset, vvar, _)

--- a/cpp/ql/lib/semmle/code/cpp/ir/internal/IRCppLanguage.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/internal/IRCppLanguage.qll
@@ -67,9 +67,7 @@ class Class = Cpp::Class; // Used for inheritance conversions
 
 predicate getIdentityString = Print::getIdentityString/1;
 
-predicate hasCaseEdge(string minValue, string maxValue) {
-  exists(Cpp::SwitchCase switchCase | hasCaseEdge(switchCase, minValue, maxValue))
-}
+predicate hasCaseEdge(string minValue, string maxValue) { hasCaseEdge(_, minValue, maxValue) }
 
 predicate hasPositionalArgIndex(int argIndex) {
   exists(Cpp::FunctionCall call | exists(call.getArgument(argIndex))) or

--- a/cpp/ql/lib/semmle/code/cpp/metrics/MetricClass.qll
+++ b/cpp/ql/lib/semmle/code/cpp/metrics/MetricClass.qll
@@ -99,10 +99,10 @@ class MetricClass extends Class {
   }
 
   /** Gets any method that accesses some local field. */
-  Function getAccessingMethod() { exists(Field f | this.accessesLocalField(result, f)) }
+  Function getAccessingMethod() { this.accessesLocalField(result, _) }
 
   /** Gets any field that is accessed by a local method. */
-  Field getAccessedField() { exists(Function func | this.accessesLocalField(func, result)) }
+  Field getAccessedField() { this.accessesLocalField(_, result) }
 
   /** Gets the Henderson-Sellers lack-of-cohesion metric. */
   float getLackOfCohesionHS() {
@@ -517,10 +517,10 @@ private predicate dependsOnClassSimple(Class source, Class dest) {
     )
     or
     // a class depends on classes for which a call to its member function is done from a function
-    exists(MemberFunction target, MemberFunction f, Locatable l |
+    exists(MemberFunction target, MemberFunction f |
       f.getDeclaringType() = source and
       f instanceof MemberFunction and
-      f.calls(target, l) and
+      f.calls(target, _) and
       target instanceof MemberFunction and
       target.getDeclaringType() = dest
     )

--- a/cpp/ql/lib/semmle/code/cpp/rangeanalysis/SimpleRangeAnalysis.qll
+++ b/cpp/ql/lib/semmle/code/cpp/rangeanalysis/SimpleRangeAnalysis.qll
@@ -296,7 +296,7 @@ private predicate analyzableExpr(Expr e) {
     or
     // Also allow variable accesses, provided that they have SSA
     // information.
-    exists(RangeSsaDefinition def, StackVariable v | e = def.getAUse(v))
+    exists(RangeSsaDefinition def | e = def.getAUse(_))
     or
     e instanceof UnsignedBitwiseAndExpr
     or

--- a/cpp/ql/lib/semmle/code/cpp/security/TaintTrackingImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/security/TaintTrackingImpl.qll
@@ -127,9 +127,9 @@ deprecated private predicate betweenFunctionsValueMoveTo(
   not unreachable(src) and
   not unreachable(dest) and
   (
-    exists(Call call, Function called, int i |
+    exists(Call call, int i |
       src = call.getArgument(i) and
-      resolveCallWithParam(call, called, i, dest) and
+      resolveCallWithParam(call, _, i, dest) and
       destFromArg = true
     )
     or
@@ -151,8 +151,8 @@ deprecated private predicate betweenFunctionsValueMoveTo(
     )
     or
     // If a parameter of type reference is tainted inside a function, taint the argument too
-    exists(Call call, Function f, int pi, Parameter p |
-      resolveCallWithParam(call, f, pi, p) and
+    exists(Call call, int pi, Parameter p |
+      resolveCallWithParam(call, _, pi, p) and
       p.getType() instanceof ReferenceType and
       src = p and
       dest = call.getArgument(pi) and

--- a/cpp/ql/lib/semmle/code/cpp/stmts/Stmt.qll
+++ b/cpp/ql/lib/semmle/code/cpp/stmts/Stmt.qll
@@ -34,7 +34,7 @@ class Stmt extends StmtParent, @stmt {
   }
 
   /** Gets a child of this statement. */
-  Element getAChild() { exists(int n | result = this.getChild(n)) }
+  Element getAChild() { result = this.getChild(_) }
 
   /** Gets the parent of this statement, if any. */
   StmtParent getParent() { stmtparents(underlyingElement(this), _, unresolveElement(result)) }

--- a/cpp/ql/lib/semmle/code/cpp/valuenumbering/HashCons.qll
+++ b/cpp/ql/lib/semmle/code/cpp/valuenumbering/HashCons.qll
@@ -475,9 +475,7 @@ private predicate mk_NonmemberFunctionCall(Function fcn, HC_Args args, FunctionC
   fc.getTarget() = fcn and
   analyzableNonmemberFunctionCall(fc) and
   (
-    exists(HashCons head, HC_Args tail |
-      mk_ArgConsInner(head, tail, fc.getNumberOfArguments() - 1, args, fc)
-    )
+    mk_ArgConsInner(_, _, fc.getNumberOfArguments() - 1, args, fc)
     or
     fc.getNumberOfArguments() = 0 and
     args = HC_EmptyArgs()
@@ -494,9 +492,7 @@ private predicate analyzableExprCall(ExprCall ec) {
 private predicate mk_ExprCall(HashCons hc, HC_Args args, ExprCall ec) {
   hc.getAnExpr() = ec.getExpr() and
   (
-    exists(HashCons head, HC_Args tail |
-      mk_ArgConsInner(head, tail, ec.getNumberOfArguments() - 1, args, ec)
-    )
+    mk_ArgConsInner(_, _, ec.getNumberOfArguments() - 1, args, ec)
     or
     ec.getNumberOfArguments() = 0 and
     args = HC_EmptyArgs()
@@ -516,9 +512,7 @@ private predicate mk_MemberFunctionCall(Function fcn, HashCons qual, HC_Args arg
   analyzableMemberFunctionCall(fc) and
   hashCons(fc.getQualifier().getFullyConverted()) = qual and
   (
-    exists(HashCons head, HC_Args tail |
-      mk_ArgConsInner(head, tail, fc.getNumberOfArguments() - 1, args, fc)
-    )
+    mk_ArgConsInner(_, _, fc.getNumberOfArguments() - 1, args, fc)
     or
     fc.getNumberOfArguments() = 0 and
     args = HC_EmptyArgs()
@@ -541,10 +535,8 @@ private predicate mk_ArgCons(HashCons hc, int i, HC_Args list, Call c) {
   analyzableCall(c) and
   hc = hashCons(c.getArgument(i).getFullyConverted()) and
   (
-    exists(HashCons head, HC_Args tail |
-      mk_ArgConsInner(head, tail, i - 1, list, c) and
-      i > 0
-    )
+    mk_ArgConsInner(_, _, i - 1, list, c) and
+    i > 0
     or
     i = 0 and
     list = HC_EmptyArgs()

--- a/cpp/ql/src/Best Practices/Magic Constants/JapaneseEraDate.ql
+++ b/cpp/ql/src/Best Practices/Magic Constants/JapaneseEraDate.ql
@@ -44,14 +44,11 @@ predicate eraDate(int year, int month, int day) {
 }
 
 predicate badStructInitialization(Element target, string message) {
-  exists(
-    StructLikeClass s, YearFieldAccess year, MonthFieldAccess month, DayFieldAccess day,
-    int yearValue, int monthValue, int dayValue
-  |
+  exists(StructLikeClass s, YearFieldAccess year, int yearValue, int monthValue, int dayValue |
     eraDate(yearValue, monthValue, dayValue) and
     assignedYear(s, year, yearValue) and
-    assignedMonth(s, month, monthValue) and
-    assignedDay(s, day, dayValue) and
+    assignedMonth(s, _, monthValue) and
+    assignedDay(s, _, dayValue) and
     target = year and
     message = "A time struct that is initialized with exact Japanese calendar era start date."
   )

--- a/cpp/ql/src/Best Practices/Magic Constants/MagicConstants.qll
+++ b/cpp/ql/src/Best Practices/Magic Constants/MagicConstants.qll
@@ -129,9 +129,7 @@ predicate literalIsEnumInitializer(Literal literal) {
   exists(EnumConstant ec | ec.getInitializer().getExpr() = literal)
 }
 
-predicate literalInArrayInitializer(Literal literal) {
-  exists(AggregateLiteral arrayInit | arrayInitializerChild(arrayInit, literal))
-}
+predicate literalInArrayInitializer(Literal literal) { arrayInitializerChild(_, literal) }
 
 predicate arrayInitializerChild(AggregateLiteral parent, Expr e) {
   e = parent

--- a/cpp/ql/src/Critical/DescriptorMayNotBeClosed.ql
+++ b/cpp/ql/src/Critical/DescriptorMayNotBeClosed.ql
@@ -29,7 +29,7 @@ predicate openDefinition(StackVariable v, ControlFlowNode def) {
 }
 
 predicate openReaches(ControlFlowNode def, ControlFlowNode node) {
-  exists(StackVariable v | openDefinition(v, def) and node = def.getASuccessor())
+  openDefinition(_, def) and node = def.getASuccessor()
   or
   exists(StackVariable v, ControlFlowNode mid |
     openDefinition(v, def) and

--- a/cpp/ql/src/Critical/NewDelete.qll
+++ b/cpp/ql/src/Critical/NewDelete.qll
@@ -159,8 +159,8 @@ predicate freeExprOrIndirect(Expr free, Expr freed, string kind) {
   freeExpr(free, freed, kind)
   or
   // indirect free via function call
-  exists(Expr internalFree, Expr internalFreed, int arg |
-    freeExprOrIndirect(internalFree, internalFreed, kind) and
+  exists(Expr internalFreed, int arg |
+    freeExprOrIndirect(_, internalFreed, kind) and
     free.(FunctionCall).getTarget().getParameter(arg) = internalFreed.(VariableAccess).getTarget() and
     free.(FunctionCall).getArgument(arg) = freed
   )

--- a/cpp/ql/src/Documentation/CommentedOutCode.qll
+++ b/cpp/ql/src/Documentation/CommentedOutCode.qll
@@ -119,7 +119,7 @@ class CommentBlock extends Comment {
     (
       this instanceof CppStyleComment
       implies
-      not exists(CppStyleComment pred, File f | lineInFile(pred, f) + 1 = lineInFile(this, f))
+      not exists(File f | lineInFile(_, f) + 1 = lineInFile(this, f))
     ) and
     // Ignore comments on the same line as a preprocessor directive.
     not exists(Location l |

--- a/cpp/ql/src/Likely Bugs/Format/NonConstantFormat.ql
+++ b/cpp/ql/src/Likely Bugs/Format/NonConstantFormat.ql
@@ -134,8 +134,8 @@ class NonConstFlow extends TaintTracking::Configuration {
 from FormattingFunctionCall call, Expr formatString
 where
   call.getArgument(call.getFormatParameterIndex()) = formatString and
-  exists(NonConstFlow cf, DataFlow::Node source, DataFlow::Node sink |
-    cf.hasFlow(source, sink) and
+  exists(NonConstFlow cf, DataFlow::Node sink |
+    cf.hasFlowTo(sink) and
     sink.asExpr() = formatString
   )
 select formatString,

--- a/cpp/ql/src/Likely Bugs/Protocols/TlsSettingsMisconfiguration.ql
+++ b/cpp/ql/src/Likely Bugs/Protocols/TlsSettingsMisconfiguration.ql
@@ -48,9 +48,7 @@ predicate isOptionSet(ConstructorCall cc, int flag, FunctionCall fcSetOptions) {
 }
 
 bindingset[flag]
-predicate isOptionNotSet(ConstructorCall cc, int flag) {
-  not exists(FunctionCall fcSetOptions | isOptionSet(cc, flag, fcSetOptions))
-}
+predicate isOptionNotSet(ConstructorCall cc, int flag) { not isOptionSet(cc, flag, _) }
 
 from
   BoostorgAsio::SslContextCallTlsProtocolConfig configConstructor, Expr protocolSource,

--- a/cpp/ql/src/Metrics/Dependencies/ExternalDependencies.qll
+++ b/cpp/ql/src/Metrics/Dependencies/ExternalDependencies.qll
@@ -28,8 +28,8 @@ private newtype LibraryT =
     lib.getVersion() = version
   } or
   LibraryTExternalPackage(@external_package ep, string name, string version) {
-    exists(string namespace, string package_name |
-      external_packages(ep, namespace, package_name, version) and
+    exists(string package_name |
+      external_packages(ep, _, package_name, version) and
       name = package_name
     )
   }
@@ -42,8 +42,8 @@ class Library extends LibraryT {
   string version;
 
   Library() {
-    exists(LibraryElement lib | this = LibraryTElement(lib, name, version)) or
-    exists(@external_package ep | this = LibraryTExternalPackage(ep, name, version))
+    this = LibraryTElement(_, name, version) or
+    this = LibraryTExternalPackage(_, name, version)
   }
 
   string getName() { result = name }

--- a/cpp/ql/src/Metrics/Files/ConditionalSegmentLines.ql
+++ b/cpp/ql/src/Metrics/Files/ConditionalSegmentLines.ql
@@ -54,7 +54,7 @@ private PreprocessorDirective next(PreprocessorDirective ppd) {
 
 private int level(PreprocessorDirective ppd) {
   relevantDirective(ppd, _, _) and
-  not exists(PreprocessorDirective previous | ppd = next(previous)) and
+  not ppd = next(_) and
   result = 0
   or
   exists(PreprocessorDirective previous |
@@ -101,8 +101,8 @@ predicate headerGuard(PreprocessorDirective notdef, File f) {
 }
 
 predicate headerGuardChild(PreprocessorDirective open) {
-  exists(File f, PreprocessorDirective headerGuard |
-    headerGuard(headerGuard, f) and
+  exists(File f |
+    headerGuard(_, f) and
     openWithDepth(1, f, open, _)
   )
 }

--- a/cpp/ql/src/Security/CWE/CWE-121/UnterminatedVarargsCall.ql
+++ b/cpp/ql/src/Security/CWE/CWE-121/UnterminatedVarargsCall.ql
@@ -64,7 +64,7 @@ class VarargsFunction extends Function {
     totalCount = this.totalCount() and
     100 * cnt / totalCount >= 80 and
     // terminator value is not used in a non-terminating position
-    not exists(FunctionCall fc, int index | this.nonTrailingVarArgValue(fc, index) = result)
+    not this.nonTrailingVarArgValue(_, _) = result
   }
 
   predicate isWhitelisted() { this.hasGlobalName(["open", "fcntl", "ptrace", "mremap"]) }

--- a/cpp/ql/src/Security/CWE/CWE-311/CleartextFileWrite.ql
+++ b/cpp/ql/src/Security/CWE/CWE-311/CleartextFileWrite.ql
@@ -54,8 +54,8 @@ predicate filenameOperation(FunctionCall op, Expr path) {
 }
 
 predicate isFileName(GVN gvn) {
-  exists(FunctionCall op, Expr path |
-    filenameOperation(op, path) and
+  exists(Expr path |
+    filenameOperation(_, path) and
     gvn = globalValueNumber(path)
   )
 }

--- a/cpp/ql/src/Security/CWE/CWE-367/TOCTOUFilesystemRace.ql
+++ b/cpp/ql/src/Security/CWE/CWE-367/TOCTOUFilesystemRace.ql
@@ -106,8 +106,8 @@ predicate checksPath(Expr check, Expr checkPath) {
   // access to a member variable on the stat buf
   // (morally, this should be a use-use pair, but it seems unlikely
   // that this variable will get reused in practice)
-  exists(Expr call, Expr e, Variable v |
-    statCallWithPointer(checkPath, call, e, v) and
+  exists(Expr e, Variable v |
+    statCallWithPointer(checkPath, _, e, v) and
     check.(VariableAccess).getTarget() = v and
     not e.getAChild*() = check // the call that writes to the pointer is not where the pointer is checked.
   )

--- a/cpp/ql/src/Security/CWE/CWE-428/UnsafeCreateProcessCall.ql
+++ b/cpp/ql/src/Security/CWE/CWE-428/UnsafeCreateProcessCall.ql
@@ -100,14 +100,14 @@ predicate isQuotedOrNoSpaceApplicationNameOnCmd(string s) {
 
 from CreateProcessFunctionCall call, string msg1, string msg2
 where
-  exists(Expr source, Expr appName, NullAppNameCreateProcessFunctionConfiguration nullAppConfig |
+  exists(Expr appName, NullAppNameCreateProcessFunctionConfiguration nullAppConfig |
     appName = call.getArgument(call.getApplicationNameArgumentId()) and
-    nullAppConfig.hasFlow(DataFlow2::exprNode(source), DataFlow2::exprNode(appName)) and
+    nullAppConfig.hasFlowToExpr(appName) and
     msg1 = call.toString() + " with lpApplicationName == NULL (" + appName + ")"
   ) and
-  exists(Expr source, Expr cmd, QuotedCommandInCreateProcessFunctionConfiguration quotedConfig |
+  exists(Expr cmd, QuotedCommandInCreateProcessFunctionConfiguration quotedConfig |
     cmd = call.getArgument(call.getCommandLineArgumentId()) and
-    quotedConfig.hasFlow(DataFlow2::exprNode(source), DataFlow2::exprNode(cmd)) and
+    quotedConfig.hasFlowToExpr(cmd) and
     msg2 =
       " and with an unquoted lpCommandLine (" + cmd +
         ") introduces a security vulnerability if the path contains spaces."

--- a/cpp/ql/src/Security/CWE/CWE-468/IncorrectPointerScalingCommon.qll
+++ b/cpp/ql/src/Security/CWE/CWE-468/IncorrectPointerScalingCommon.qll
@@ -100,7 +100,7 @@ Type baseType(Type t) {
  */
 predicate exprSourceType(Expr use, Type sourceType, Location sourceLoc) {
   // Reaching definitions.
-  if exists(SsaDefinition def, StackVariable v | use = def.getAUse(v))
+  if exists(SsaDefinition def | use = def.getAUse(_))
   then
     exists(SsaDefinition def, StackVariable v | use = def.getAUse(v) |
       defSourceType(def, v, sourceType, sourceLoc)

--- a/cpp/ql/src/Security/CWE/CWE-732/UnsafeDaclSecurityDescriptor.ql
+++ b/cpp/ql/src/Security/CWE/CWE-732/UnsafeDaclSecurityDescriptor.ql
@@ -83,16 +83,13 @@ where
     call.getArgument(2) = nullExpr
   )
   or
-  exists(
-    Expr constassign, VariableAccess var, NullDaclConfig nullDaclConfig,
-    NonNullDaclConfig nonNullDaclConfig
-  |
+  exists(VariableAccess var, NullDaclConfig nullDaclConfig, NonNullDaclConfig nonNullDaclConfig |
     message =
       "Setting a DACL to NULL in a SECURITY_DESCRIPTOR using variable " + var +
         " that is set to NULL will result in an unprotected object."
   |
     var = call.getArgument(2) and
-    nullDaclConfig.hasFlow(DataFlow::exprNode(constassign), DataFlow::exprNode(var)) and
-    not nonNullDaclConfig.hasFlow(_, DataFlow::exprNode(var))
+    nullDaclConfig.hasFlowToExpr(var) and
+    not nonNullDaclConfig.hasFlowToExpr(var)
   )
 select call, message

--- a/cpp/ql/src/experimental/Security/CWE/CWE-787/UnsignedToSignedPointerArith.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-787/UnsignedToSignedPointerArith.ql
@@ -20,8 +20,8 @@ where
   p.getUnspecifiedType().(IntegralType).isSigned() and
   call.getArgument(p.getIndex()).getUnspecifiedType().(IntegralType).isUnsigned() and
   pao.getAnOperand() = sink.asExpr() and
-  not exists(Operation a | guardedLesser(a, sink.asExpr())) and
-  not exists(Operation b | guardedGreater(b, call.getArgument(p.getIndex()))) and
+  not guardedLesser(_, sink.asExpr()) and
+  not guardedGreater(_, call.getArgument(p.getIndex())) and
   not call.getArgument(p.getIndex()).isConstant() and
   DataFlow::localFlow(DataFlow::parameterNode(p), sink) and
   p.getUnspecifiedType().getSize() < 8

--- a/cpp/ql/src/jsf/4.09 Style/Naming.qll
+++ b/cpp/ql/src/jsf/4.09 Style/Naming.qll
@@ -44,7 +44,7 @@ class Name extends string {
   /**
    * Gets a word in this identifier. Words are just portions separated by underscores.
    */
-  Word getAWord() { exists(int index | result = this.splitAt("_", index)) }
+  Word getAWord() { result = this.splitAt("_", _) }
 
   /**
    * Gets the `index`th word (starting at zero) in an identifier. Words are

--- a/cpp/ql/test/TestUtilities/InlineExpectationsTest.qll
+++ b/cpp/ql/test/TestUtilities/InlineExpectationsTest.qll
@@ -161,7 +161,7 @@ abstract class InlineExpectationsTest extends string {
     )
     or
     exists(ValidExpectation expectation |
-      not exists(ActualResult actualResult | expectation.matchesActualResult(actualResult)) and
+      not expectation.matchesActualResult(_) and
       expectation.getTag() = this.getARelevantTag() and
       element = expectation and
       (

--- a/cpp/ql/test/library-tests/dataflow/DefaultTaintTracking/annotate_path_to_sink/tainted.ql
+++ b/cpp/ql/test/library-tests/dataflow/DefaultTaintTracking/annotate_path_to_sink/tainted.ql
@@ -44,8 +44,8 @@ class IRDefaultTaintTrackingTest extends InlineExpectationsTest {
   override string getARelevantTag() { result = ["ir-path", "ir-sink"] }
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
-    exists(Element source, Element elem, TaintedWithPath::PathNode node, int n |
-      irTaint(source, node, tag) and
+    exists(Element elem, TaintedWithPath::PathNode node, int n |
+      irTaint(_, node, tag) and
       elem = getElementFromPathNode(node) and
       n = count(int startline | getAPredecessor(node).hasLocationInfo(_, startline, _, _, _)) and
       location = elem.getLocation() and

--- a/cpp/ql/test/library-tests/dataflow/DefaultTaintTracking/globals/global.ql
+++ b/cpp/ql/test/library-tests/dataflow/DefaultTaintTracking/globals/global.ql
@@ -18,9 +18,9 @@ class IRGlobalDefaultTaintTrackingTest extends InlineExpectationsTest {
   override string getARelevantTag() { result = "ir" }
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
-    exists(Expr source, Element tainted |
+    exists(Element tainted |
       tag = "ir" and
-      irTaint(source, tainted, value) and
+      irTaint(_, tainted, value) and
       location = tainted.getLocation() and
       element = tainted.toString()
     )
@@ -33,9 +33,9 @@ class AstGlobalDefaultTaintTrackingTest extends InlineExpectationsTest {
   override string getARelevantTag() { result = "ast" }
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
-    exists(Expr source, Element tainted |
+    exists(Element tainted |
       tag = "ast" and
-      astTaint(source, tainted, value) and
+      astTaint(_, tainted, value) and
       location = tainted.getLocation() and
       element = tainted.toString()
     )

--- a/cpp/ql/test/library-tests/types/integral_types/integral_type.ql
+++ b/cpp/ql/test/library-tests/types/integral_types/integral_type.ql
@@ -1,7 +1,7 @@
 import cpp
 
 string integralTypeKind(IntegralType t) {
-  if exists(int kind | builtintypes(unresolveElement(t), _, kind, _, _, _))
+  if builtintypes(unresolveElement(t), _, _, _, _, _)
   then
     exists(int kind | builtintypes(unresolveElement(t), _, kind, _, _, _) |
       result = (kind.toString() + " ").prefix(2)


### PR DESCRIPTION
Removes unneeded `exists` variables, as described in the QL-for-QL query created in https://github.com/github/codeql/pull/11770.