### PR TITLE
CI: use the new actions/cache@v3 instead of my own fork

### DIFF
--- a/.github/actions/cache-query-compilation/action.yml
+++ b/.github/actions/cache-query-compilation/action.yml
@@ -23,20 +23,19 @@ runs:
       run: |
         MERGE_BASE=$(git cat-file commit $GITHUB_SHA | grep '^parent ' | head -1 | cut -f 2 -d " ")
         echo "merge_base=$MERGE_BASE" >> $GITHUB_ENV
-    - name: Restore read-only cache (PR)
+    - name: Restore cache (PR)
       if: ${{ github.event_name == 'pull_request' }}
-      uses: erik-krogh/actions-cache@a88d0603fe5fb5606db9f002dfcadeb32b5f84c6
+      uses: actions/cache/restore@v3
       with:
         path: '**/.cache'
-        read-only: true
         key: codeql-compile-${{ inputs.key }}-pr-${{ github.sha }}
         restore-keys: |
           codeql-compile-${{ inputs.key }}-${{ github.base_ref }}-${{ env.merge_base }}
           codeql-compile-${{ inputs.key }}-${{ github.base_ref }}-
           codeql-compile-${{ inputs.key }}-main-
-    - name: Fill cache (push)
+    - name: Fill cache (only branch push)
       if: ${{ github.event_name != 'pull_request' }}
-      uses: erik-krogh/actions-cache@a88d0603fe5fb5606db9f002dfcadeb32b5f84c6
+      uses: actions/cache@v3
       with:
         path: '**/.cache'
         key: codeql-compile-${{ inputs.key }}-${{ github.ref_name }}-${{ github.sha }} # just fill on main

--- a/swift/actions/build-and-test/action.yml
+++ b/swift/actions/build-and-test/action.yml
@@ -21,10 +21,9 @@ runs:
         echo "merge_base=$MERGE_BASE" >> $GITHUB_ENV
     - name: Restore read-only cache (PR)
       if: ${{ github.event_name == 'pull_request' }}
-      uses: erik-krogh/actions-cache@a88d0603fe5fb5606db9f002dfcadeb32b5f84c6
+      uses: actions/cache/restore@v3
       with:
         path: 'bazel-cache'
-        read-only: true
         key: bazel-pr-${{ github.sha }}
         restore-keys: |
           bazel-${{ github.base_ref }}-${{ env.merge_base }}
@@ -32,7 +31,7 @@ runs:
           bazel-main-
     - name: Fill cache (push)
       if: ${{ github.event_name != 'pull_request' }}
-      uses: erik-krogh/actions-cache@a88d0603fe5fb5606db9f002dfcadeb32b5f84c6
+      uses: actions/cache@v3
       with:
         path: 'bazel-cache'
         key: bazel-${{ github.ref_name }}-${{ github.sha }} # just fill on main


### PR DESCRIPTION
`actions/cache@v3` has been released, and it supports a restore action, that just reads the cache without filling the cache.  
Which was exactly what I had implemented in my own fork, which is now no longer needed.  