### PR TITLE
C++: Map more expressions to `OperandNode`s

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -770,32 +770,11 @@ class RawIndirectInstruction extends Node, TRawIndirectInstruction {
   }
 }
 
-private predicate isFullyConvertedArgument(Expr e) {
-  exists(Call call |
-    e = call.getAnArgument().getFullyConverted()
-    or
-    e = call.getQualifier().getFullyConverted()
-  )
-}
-
-private predicate isFullyConvertedCall(Expr e) { e = any(Call call).getFullyConverted() }
-
-/** Holds if `Node::asExpr` should map an some operand node to `e`. */
-private predicate convertedExprMustBeOperand(Expr e) {
-  isFullyConvertedArgument(e)
-  or
-  isFullyConvertedCall(e)
-}
-
 /** Holds if `node` is an `OperandNode` that should map `node.asExpr()` to `e`. */
 predicate exprNodeShouldBeOperand(OperandNode node, Expr e) {
-  exists(Operand operand |
-    node.getOperand() = operand and
-    e = operand.getDef().getConvertedResultExpression()
-  |
-    convertedExprMustBeOperand(e)
-    or
-    node.(IndirectOperand).isIRRepresentationOf(_, _)
+  exists(Instruction def |
+    unique( | | getAUse(def)) = node.getOperand() and
+    e = def.getConvertedResultExpression()
   )
 }
 

--- a/cpp/ql/test/library-tests/dataflow/fields/ir-path-flow.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/ir-path-flow.expected
@@ -33,8 +33,9 @@ edges
 | A.cpp:57:11:57:24 | new indirection [c] | A.cpp:28:8:28:10 | this indirection [c] |
 | A.cpp:57:11:57:24 | new indirection [c] | A.cpp:57:10:57:32 | call to get |
 | A.cpp:57:11:57:24 | new indirection [c] | A.cpp:57:11:57:24 | new indirection [c] |
-| A.cpp:57:17:57:23 | new | A.cpp:23:10:23:10 | c |
-| A.cpp:57:17:57:23 | new | A.cpp:57:11:57:24 | call to B [c] |
+| A.cpp:57:17:57:23 | Arg(0) | A.cpp:23:10:23:10 | c |
+| A.cpp:57:17:57:23 | Arg(0) | A.cpp:57:11:57:24 | call to B [c] |
+| A.cpp:57:17:57:23 | new | A.cpp:57:17:57:23 | Arg(0) |
 | A.cpp:64:10:64:15 | call to setOnB indirection [c] | A.cpp:66:10:66:11 | Load indirection [c] |
 | A.cpp:64:21:64:28 | new | A.cpp:64:10:64:15 | call to setOnB indirection [c] |
 | A.cpp:64:21:64:28 | new | A.cpp:64:21:64:28 | new |
@@ -74,8 +75,9 @@ edges
 | A.cpp:120:16:120:16 | FieldAddress indirection | A.cpp:120:12:120:16 | a |
 | A.cpp:120:16:120:16 | FieldAddress indirection | A.cpp:120:16:120:16 | a |
 | A.cpp:126:5:126:5 | set output argument [c] | A.cpp:131:8:131:8 | f7 output argument [c] |
-| A.cpp:126:12:126:18 | new | A.cpp:27:17:27:17 | c |
-| A.cpp:126:12:126:18 | new | A.cpp:126:5:126:5 | set output argument [c] |
+| A.cpp:126:12:126:18 | Arg(0) | A.cpp:27:17:27:17 | c |
+| A.cpp:126:12:126:18 | Arg(0) | A.cpp:126:5:126:5 | set output argument [c] |
+| A.cpp:126:12:126:18 | new | A.cpp:126:12:126:18 | Arg(0) |
 | A.cpp:131:8:131:8 | f7 output argument [c] | A.cpp:132:10:132:10 | Load indirection [c] |
 | A.cpp:132:10:132:10 | Load indirection [c] | A.cpp:132:10:132:13 | c |
 | A.cpp:132:10:132:10 | Load indirection [c] | A.cpp:132:13:132:13 | FieldAddress indirection |
@@ -279,8 +281,8 @@ edges
 | aliasing.cpp:9:3:9:22 | Store | aliasing.cpp:9:6:9:7 | Load indirection [post update] [m1] |
 | aliasing.cpp:9:6:9:7 | Load indirection [post update] [m1] | aliasing.cpp:25:17:25:19 | pointerSetter output argument [m1] |
 | aliasing.cpp:9:11:9:20 | call to user_input | aliasing.cpp:9:3:9:22 | Store |
-| aliasing.cpp:13:3:13:21 | Store | aliasing.cpp:13:5:13:6 | (reference dereference) indirection [post update] [m1] |
-| aliasing.cpp:13:5:13:6 | (reference dereference) indirection [post update] [m1] | aliasing.cpp:26:19:26:20 | referenceSetter output argument [m1] |
+| aliasing.cpp:13:3:13:21 | Store | aliasing.cpp:13:5:13:6 | CopyValue indirection [post update] [m1] |
+| aliasing.cpp:13:5:13:6 | CopyValue indirection [post update] [m1] | aliasing.cpp:26:19:26:20 | referenceSetter output argument [m1] |
 | aliasing.cpp:13:10:13:19 | call to user_input | aliasing.cpp:13:3:13:21 | Store |
 | aliasing.cpp:25:17:25:19 | pointerSetter output argument [m1] | aliasing.cpp:29:8:29:9 | s1 indirection [m1] |
 | aliasing.cpp:26:19:26:20 | referenceSetter output argument [m1] | aliasing.cpp:30:8:30:9 | s2 indirection [m1] |
@@ -478,11 +480,11 @@ edges
 | by_reference.cpp:84:10:84:10 | Load indirection [post update] [a] | by_reference.cpp:106:21:106:41 | taint_inner_a_ptr output argument [a] |
 | by_reference.cpp:84:10:84:10 | Load indirection [post update] [a] | by_reference.cpp:107:29:107:37 | taint_inner_a_ptr output argument [a] |
 | by_reference.cpp:84:14:84:23 | call to user_input | by_reference.cpp:84:3:84:25 | Store |
-| by_reference.cpp:88:3:88:24 | Store | by_reference.cpp:88:9:88:9 | (reference dereference) indirection [post update] [a] |
-| by_reference.cpp:88:9:88:9 | (reference dereference) indirection [post update] [a] | by_reference.cpp:122:21:122:38 | taint_inner_a_ref output argument [a] |
-| by_reference.cpp:88:9:88:9 | (reference dereference) indirection [post update] [a] | by_reference.cpp:123:21:123:36 | taint_inner_a_ref output argument [a] |
-| by_reference.cpp:88:9:88:9 | (reference dereference) indirection [post update] [a] | by_reference.cpp:126:21:126:40 | taint_inner_a_ref output argument [a] |
-| by_reference.cpp:88:9:88:9 | (reference dereference) indirection [post update] [a] | by_reference.cpp:127:21:127:38 | taint_inner_a_ref output argument [a] |
+| by_reference.cpp:88:3:88:24 | Store | by_reference.cpp:88:9:88:9 | CopyValue indirection [post update] [a] |
+| by_reference.cpp:88:9:88:9 | CopyValue indirection [post update] [a] | by_reference.cpp:122:21:122:38 | taint_inner_a_ref output argument [a] |
+| by_reference.cpp:88:9:88:9 | CopyValue indirection [post update] [a] | by_reference.cpp:123:21:123:36 | taint_inner_a_ref output argument [a] |
+| by_reference.cpp:88:9:88:9 | CopyValue indirection [post update] [a] | by_reference.cpp:126:21:126:40 | taint_inner_a_ref output argument [a] |
+| by_reference.cpp:88:9:88:9 | CopyValue indirection [post update] [a] | by_reference.cpp:127:21:127:38 | taint_inner_a_ref output argument [a] |
 | by_reference.cpp:88:13:88:22 | call to user_input | by_reference.cpp:88:3:88:24 | Store |
 | by_reference.cpp:91:25:91:26 | Load indirection | by_reference.cpp:104:15:104:22 | taint_a_ptr output argument |
 | by_reference.cpp:91:25:91:26 | Load indirection | by_reference.cpp:108:15:108:24 | taint_a_ptr output argument |
@@ -578,13 +580,13 @@ edges
 | complex.cpp:11:22:11:27 | Store | complex.cpp:11:22:11:23 | Load indirection [post update] [a_] |
 | complex.cpp:12:17:12:17 | b | complex.cpp:12:22:12:27 | Store |
 | complex.cpp:12:22:12:27 | Store | complex.cpp:12:22:12:23 | Load indirection [post update] [b_] |
-| complex.cpp:40:17:40:17 | b indirection [inner, f, a_] | complex.cpp:42:8:42:8 | (reference dereference) indirection [inner, f, a_] |
-| complex.cpp:40:17:40:17 | b indirection [inner, f, b_] | complex.cpp:43:8:43:8 | (reference dereference) indirection [inner, f, b_] |
-| complex.cpp:42:8:42:8 | (reference dereference) indirection [inner, f, a_] | complex.cpp:42:10:42:14 | inner indirection [f, a_] |
+| complex.cpp:40:17:40:17 | b indirection [inner, f, a_] | complex.cpp:42:8:42:8 | CopyValue indirection [inner, f, a_] |
+| complex.cpp:40:17:40:17 | b indirection [inner, f, b_] | complex.cpp:43:8:43:8 | CopyValue indirection [inner, f, b_] |
+| complex.cpp:42:8:42:8 | CopyValue indirection [inner, f, a_] | complex.cpp:42:10:42:14 | inner indirection [f, a_] |
 | complex.cpp:42:10:42:14 | inner indirection [f, a_] | complex.cpp:42:16:42:16 | f indirection [a_] |
 | complex.cpp:42:16:42:16 | f indirection [a_] | complex.cpp:9:7:9:7 | this indirection [a_] |
 | complex.cpp:42:16:42:16 | f indirection [a_] | complex.cpp:42:18:42:18 | call to a |
-| complex.cpp:43:8:43:8 | (reference dereference) indirection [inner, f, b_] | complex.cpp:43:10:43:14 | inner indirection [f, b_] |
+| complex.cpp:43:8:43:8 | CopyValue indirection [inner, f, b_] | complex.cpp:43:10:43:14 | inner indirection [f, b_] |
 | complex.cpp:43:10:43:14 | inner indirection [f, b_] | complex.cpp:43:16:43:16 | f indirection [b_] |
 | complex.cpp:43:16:43:16 | f indirection [b_] | complex.cpp:10:7:10:7 | this indirection [b_] |
 | complex.cpp:43:16:43:16 | f indirection [b_] | complex.cpp:43:18:43:18 | call to b |
@@ -628,12 +630,12 @@ edges
 | complex.cpp:62:7:62:8 | CopyValue indirection [inner, f, b_] | complex.cpp:40:17:40:17 | b indirection [inner, f, b_] |
 | complex.cpp:65:7:65:8 | CopyValue indirection [inner, f, a_] | complex.cpp:40:17:40:17 | b indirection [inner, f, a_] |
 | complex.cpp:65:7:65:8 | CopyValue indirection [inner, f, b_] | complex.cpp:40:17:40:17 | b indirection [inner, f, b_] |
-| conflated.cpp:10:3:10:22 | Store | conflated.cpp:10:7:10:7 | (reference dereference) indirection [post update] [p indirection] |
-| conflated.cpp:10:7:10:7 | (reference dereference) indirection [post update] [p indirection] | conflated.cpp:11:9:11:10 | (reference dereference) indirection [p indirection] |
+| conflated.cpp:10:3:10:22 | Store | conflated.cpp:10:7:10:7 | CopyValue indirection [post update] [p indirection] |
+| conflated.cpp:10:7:10:7 | CopyValue indirection [post update] [p indirection] | conflated.cpp:11:9:11:10 | CopyValue indirection [p indirection] |
 | conflated.cpp:10:11:10:20 | call to user_input | conflated.cpp:10:3:10:22 | Store |
-| conflated.cpp:11:9:11:10 | (reference dereference) indirection [p indirection] | conflated.cpp:11:8:11:12 | * ... |
-| conflated.cpp:11:9:11:10 | (reference dereference) indirection [p indirection] | conflated.cpp:11:12:11:12 | FieldAddress indirection |
-| conflated.cpp:11:9:11:10 | (reference dereference) indirection [p indirection] | conflated.cpp:11:12:11:12 | p indirection |
+| conflated.cpp:11:9:11:10 | CopyValue indirection [p indirection] | conflated.cpp:11:8:11:12 | * ... |
+| conflated.cpp:11:9:11:10 | CopyValue indirection [p indirection] | conflated.cpp:11:12:11:12 | FieldAddress indirection |
+| conflated.cpp:11:9:11:10 | CopyValue indirection [p indirection] | conflated.cpp:11:12:11:12 | p indirection |
 | conflated.cpp:11:12:11:12 | FieldAddress indirection | conflated.cpp:11:8:11:12 | * ... |
 | conflated.cpp:11:12:11:12 | p indirection | conflated.cpp:11:8:11:12 | * ... |
 | conflated.cpp:19:19:19:21 | argument_source output argument | conflated.cpp:20:8:20:10 | raw indirection |
@@ -709,7 +711,7 @@ edges
 | qualifiers.cpp:12:40:12:44 | value | qualifiers.cpp:12:49:12:64 | Store |
 | qualifiers.cpp:12:49:12:64 | Store | qualifiers.cpp:12:56:12:56 | Load indirection [post update] [a] |
 | qualifiers.cpp:13:42:13:46 | value | qualifiers.cpp:13:51:13:65 | Store |
-| qualifiers.cpp:13:51:13:65 | Store | qualifiers.cpp:13:57:13:57 | (reference dereference) indirection [post update] [a] |
+| qualifiers.cpp:13:51:13:65 | Store | qualifiers.cpp:13:57:13:57 | CopyValue indirection [post update] [a] |
 | qualifiers.cpp:22:5:22:9 | getInner output argument [inner indirection, a] | qualifiers.cpp:23:10:23:14 | outer indirection [inner indirection, a] |
 | qualifiers.cpp:22:5:22:38 | Store | qualifiers.cpp:22:23:22:23 | call to getInner indirection [post update] [a] |
 | qualifiers.cpp:22:23:22:23 | call to getInner indirection [post update] [a] | qualifiers.cpp:22:5:22:9 | getInner output argument [inner indirection, a] |
@@ -921,6 +923,7 @@ nodes
 | A.cpp:57:10:57:32 | call to get | semmle.label | call to get |
 | A.cpp:57:11:57:24 | call to B [c] | semmle.label | call to B [c] |
 | A.cpp:57:11:57:24 | new indirection [c] | semmle.label | new indirection [c] |
+| A.cpp:57:17:57:23 | Arg(0) | semmle.label | Arg(0) |
 | A.cpp:57:17:57:23 | new | semmle.label | new |
 | A.cpp:64:10:64:15 | call to setOnB indirection [c] | semmle.label | call to setOnB indirection [c] |
 | A.cpp:64:21:64:28 | new | semmle.label | new |
@@ -958,6 +961,7 @@ nodes
 | A.cpp:120:16:120:16 | FieldAddress indirection | semmle.label | FieldAddress indirection |
 | A.cpp:120:16:120:16 | a | semmle.label | a |
 | A.cpp:126:5:126:5 | set output argument [c] | semmle.label | set output argument [c] |
+| A.cpp:126:12:126:18 | Arg(0) | semmle.label | Arg(0) |
 | A.cpp:126:12:126:18 | new | semmle.label | new |
 | A.cpp:131:8:131:8 | f7 output argument [c] | semmle.label | f7 output argument [c] |
 | A.cpp:132:10:132:10 | Load indirection [c] | semmle.label | Load indirection [c] |
@@ -1151,7 +1155,7 @@ nodes
 | aliasing.cpp:9:6:9:7 | Load indirection [post update] [m1] | semmle.label | Load indirection [post update] [m1] |
 | aliasing.cpp:9:11:9:20 | call to user_input | semmle.label | call to user_input |
 | aliasing.cpp:13:3:13:21 | Store | semmle.label | Store |
-| aliasing.cpp:13:5:13:6 | (reference dereference) indirection [post update] [m1] | semmle.label | (reference dereference) indirection [post update] [m1] |
+| aliasing.cpp:13:5:13:6 | CopyValue indirection [post update] [m1] | semmle.label | CopyValue indirection [post update] [m1] |
 | aliasing.cpp:13:10:13:19 | call to user_input | semmle.label | call to user_input |
 | aliasing.cpp:25:17:25:19 | pointerSetter output argument [m1] | semmle.label | pointerSetter output argument [m1] |
 | aliasing.cpp:26:19:26:20 | referenceSetter output argument [m1] | semmle.label | referenceSetter output argument [m1] |
@@ -1333,7 +1337,7 @@ nodes
 | by_reference.cpp:84:10:84:10 | Load indirection [post update] [a] | semmle.label | Load indirection [post update] [a] |
 | by_reference.cpp:84:14:84:23 | call to user_input | semmle.label | call to user_input |
 | by_reference.cpp:88:3:88:24 | Store | semmle.label | Store |
-| by_reference.cpp:88:9:88:9 | (reference dereference) indirection [post update] [a] | semmle.label | (reference dereference) indirection [post update] [a] |
+| by_reference.cpp:88:9:88:9 | CopyValue indirection [post update] [a] | semmle.label | CopyValue indirection [post update] [a] |
 | by_reference.cpp:88:13:88:22 | call to user_input | semmle.label | call to user_input |
 | by_reference.cpp:91:25:91:26 | Load indirection | semmle.label | Load indirection |
 | by_reference.cpp:92:9:92:18 | call to user_input | semmle.label | call to user_input |
@@ -1427,11 +1431,11 @@ nodes
 | complex.cpp:12:22:12:27 | Store | semmle.label | Store |
 | complex.cpp:40:17:40:17 | b indirection [inner, f, a_] | semmle.label | b indirection [inner, f, a_] |
 | complex.cpp:40:17:40:17 | b indirection [inner, f, b_] | semmle.label | b indirection [inner, f, b_] |
-| complex.cpp:42:8:42:8 | (reference dereference) indirection [inner, f, a_] | semmle.label | (reference dereference) indirection [inner, f, a_] |
+| complex.cpp:42:8:42:8 | CopyValue indirection [inner, f, a_] | semmle.label | CopyValue indirection [inner, f, a_] |
 | complex.cpp:42:10:42:14 | inner indirection [f, a_] | semmle.label | inner indirection [f, a_] |
 | complex.cpp:42:16:42:16 | f indirection [a_] | semmle.label | f indirection [a_] |
 | complex.cpp:42:18:42:18 | call to a | semmle.label | call to a |
-| complex.cpp:43:8:43:8 | (reference dereference) indirection [inner, f, b_] | semmle.label | (reference dereference) indirection [inner, f, b_] |
+| complex.cpp:43:8:43:8 | CopyValue indirection [inner, f, b_] | semmle.label | CopyValue indirection [inner, f, b_] |
 | complex.cpp:43:10:43:14 | inner indirection [f, b_] | semmle.label | inner indirection [f, b_] |
 | complex.cpp:43:16:43:16 | f indirection [b_] | semmle.label | f indirection [b_] |
 | complex.cpp:43:18:43:18 | call to b | semmle.label | call to b |
@@ -1464,10 +1468,10 @@ nodes
 | complex.cpp:65:7:65:8 | CopyValue indirection [inner, f, a_] | semmle.label | CopyValue indirection [inner, f, a_] |
 | complex.cpp:65:7:65:8 | CopyValue indirection [inner, f, b_] | semmle.label | CopyValue indirection [inner, f, b_] |
 | conflated.cpp:10:3:10:22 | Store | semmle.label | Store |
-| conflated.cpp:10:7:10:7 | (reference dereference) indirection [post update] [p indirection] | semmle.label | (reference dereference) indirection [post update] [p indirection] |
+| conflated.cpp:10:7:10:7 | CopyValue indirection [post update] [p indirection] | semmle.label | CopyValue indirection [post update] [p indirection] |
 | conflated.cpp:10:11:10:20 | call to user_input | semmle.label | call to user_input |
 | conflated.cpp:11:8:11:12 | * ... | semmle.label | * ... |
-| conflated.cpp:11:9:11:10 | (reference dereference) indirection [p indirection] | semmle.label | (reference dereference) indirection [p indirection] |
+| conflated.cpp:11:9:11:10 | CopyValue indirection [p indirection] | semmle.label | CopyValue indirection [p indirection] |
 | conflated.cpp:11:12:11:12 | FieldAddress indirection | semmle.label | FieldAddress indirection |
 | conflated.cpp:11:12:11:12 | p indirection | semmle.label | p indirection |
 | conflated.cpp:19:19:19:21 | argument_source output argument | semmle.label | argument_source output argument |
@@ -1543,7 +1547,7 @@ nodes
 | qualifiers.cpp:12:56:12:56 | Load indirection [post update] [a] | semmle.label | Load indirection [post update] [a] |
 | qualifiers.cpp:13:42:13:46 | value | semmle.label | value |
 | qualifiers.cpp:13:51:13:65 | Store | semmle.label | Store |
-| qualifiers.cpp:13:57:13:57 | (reference dereference) indirection [post update] [a] | semmle.label | (reference dereference) indirection [post update] [a] |
+| qualifiers.cpp:13:57:13:57 | CopyValue indirection [post update] [a] | semmle.label | CopyValue indirection [post update] [a] |
 | qualifiers.cpp:22:5:22:9 | getInner output argument [inner indirection, a] | semmle.label | getInner output argument [inner indirection, a] |
 | qualifiers.cpp:22:5:22:38 | Store | semmle.label | Store |
 | qualifiers.cpp:22:23:22:23 | call to getInner indirection [post update] [a] | semmle.label | call to getInner indirection [post update] [a] |
@@ -1708,12 +1712,12 @@ subpaths
 | A.cpp:55:12:55:19 | new | A.cpp:27:17:27:17 | c | A.cpp:27:28:27:28 | Load indirection [post update] [c] | A.cpp:55:5:55:5 | set output argument [c] |
 | A.cpp:56:10:56:10 | Load indirection [c] | A.cpp:28:8:28:10 | this indirection [c] | A.cpp:28:8:28:10 | VariableAddress indirection | A.cpp:56:10:56:17 | call to get |
 | A.cpp:57:11:57:24 | new indirection [c] | A.cpp:28:8:28:10 | this indirection [c] | A.cpp:28:8:28:10 | VariableAddress indirection | A.cpp:57:10:57:32 | call to get |
-| A.cpp:57:17:57:23 | new | A.cpp:23:10:23:10 | c | A.cpp:25:13:25:13 | Load indirection [post update] [c] | A.cpp:57:11:57:24 | call to B [c] |
+| A.cpp:57:17:57:23 | Arg(0) | A.cpp:23:10:23:10 | c | A.cpp:25:13:25:13 | Load indirection [post update] [c] | A.cpp:57:11:57:24 | call to B [c] |
 | A.cpp:64:21:64:28 | new | A.cpp:85:26:85:26 | c | A.cpp:85:9:85:14 | VariableAddress indirection [c] | A.cpp:64:10:64:15 | call to setOnB indirection [c] |
 | A.cpp:73:25:73:32 | new | A.cpp:78:27:78:27 | c | A.cpp:78:6:78:15 | VariableAddress indirection [c] | A.cpp:73:10:73:19 | call to setOnBWrap indirection [c] |
 | A.cpp:81:21:81:21 | c | A.cpp:85:26:85:26 | c | A.cpp:85:9:85:14 | VariableAddress indirection [c] | A.cpp:81:10:81:15 | call to setOnB indirection [c] |
 | A.cpp:90:15:90:15 | c | A.cpp:27:17:27:17 | c | A.cpp:27:28:27:28 | Load indirection [post update] [c] | A.cpp:90:7:90:8 | set output argument [c] |
-| A.cpp:126:12:126:18 | new | A.cpp:27:17:27:17 | c | A.cpp:27:28:27:28 | Load indirection [post update] [c] | A.cpp:126:5:126:5 | set output argument [c] |
+| A.cpp:126:12:126:18 | Arg(0) | A.cpp:27:17:27:17 | c | A.cpp:27:28:27:28 | Load indirection [post update] [c] | A.cpp:126:5:126:5 | set output argument [c] |
 | A.cpp:151:18:151:18 | b | A.cpp:140:13:140:13 | b | A.cpp:143:13:143:13 | Load indirection [post update] [b] | A.cpp:151:12:151:24 | call to D [b] |
 | A.cpp:160:29:160:29 | b | A.cpp:181:15:181:21 | newHead | A.cpp:183:7:183:10 | Load indirection [post update] [head] | A.cpp:160:18:160:60 | call to MyList [head] |
 | A.cpp:161:38:161:39 | Load indirection [head] | A.cpp:181:32:181:35 | next indirection [head] | A.cpp:184:13:184:16 | Load indirection [post update] [next indirection, head] | A.cpp:161:18:161:40 | call to MyList [next indirection, head] |
@@ -1750,7 +1754,7 @@ subpaths
 | constructors.cpp:36:25:36:34 | call to user_input | constructors.cpp:23:20:23:20 | b | constructors.cpp:23:32:23:36 | this indirection [post update] [b_] | constructors.cpp:36:9:36:9 | call to Foo [b_] |
 | qualifiers.cpp:27:28:27:37 | call to user_input | qualifiers.cpp:9:21:9:25 | value | qualifiers.cpp:9:36:9:36 | Load indirection [post update] [a] | qualifiers.cpp:27:11:27:18 | setA output argument [a] |
 | qualifiers.cpp:32:35:32:44 | call to user_input | qualifiers.cpp:12:40:12:44 | value | qualifiers.cpp:12:56:12:56 | Load indirection [post update] [a] | qualifiers.cpp:32:23:32:30 | pointerSetA output argument [a] |
-| qualifiers.cpp:37:38:37:47 | call to user_input | qualifiers.cpp:13:42:13:46 | value | qualifiers.cpp:13:57:13:57 | (reference dereference) indirection [post update] [a] | qualifiers.cpp:37:19:37:35 | referenceSetA output argument [a] |
+| qualifiers.cpp:37:38:37:47 | call to user_input | qualifiers.cpp:13:42:13:46 | value | qualifiers.cpp:13:57:13:57 | CopyValue indirection [post update] [a] | qualifiers.cpp:37:19:37:35 | referenceSetA output argument [a] |
 | simple.cpp:28:10:28:10 | CopyValue indirection [a_] | simple.cpp:18:9:18:9 | this indirection [a_] | simple.cpp:18:9:18:9 | VariableAddress indirection | simple.cpp:28:12:28:12 | call to a |
 | simple.cpp:29:10:29:10 | CopyValue indirection [b_] | simple.cpp:19:9:19:9 | this indirection [b_] | simple.cpp:19:9:19:9 | VariableAddress indirection | simple.cpp:29:12:29:12 | call to b |
 | simple.cpp:39:12:39:21 | call to user_input | simple.cpp:20:19:20:19 | a | simple.cpp:20:24:20:25 | Load indirection [post update] [a_] | simple.cpp:39:5:39:5 | setA output argument [a_] |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-078/semmle/ExecTainted/ExecTainted.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-078/semmle/ExecTainted/ExecTainted.expected
@@ -15,17 +15,17 @@ edges
 | test.cpp:91:9:91:16 | fread output argument | test.cpp:93:17:93:24 | Convert indirection |
 | test.cpp:93:11:93:14 | strncat output argument | test.cpp:94:45:94:48 | Convert indirection |
 | test.cpp:93:17:93:24 | Convert indirection | test.cpp:93:11:93:14 | strncat output argument |
-| test.cpp:106:20:106:25 | call to getenv | test.cpp:107:33:107:36 | CopyValue indirection |
+| test.cpp:106:20:106:25 | Call | test.cpp:107:33:107:36 | CopyValue indirection |
 | test.cpp:106:20:106:38 | call to getenv indirection | test.cpp:107:33:107:36 | CopyValue indirection |
 | test.cpp:107:31:107:31 | Call | test.cpp:108:18:108:22 | call to c_str indirection |
 | test.cpp:107:33:107:36 | CopyValue indirection | test.cpp:107:31:107:31 | Call |
-| test.cpp:113:20:113:25 | call to getenv | test.cpp:114:19:114:22 | CopyValue indirection |
+| test.cpp:113:20:113:25 | Call | test.cpp:114:19:114:22 | CopyValue indirection |
 | test.cpp:113:20:113:38 | call to getenv indirection | test.cpp:114:19:114:22 | CopyValue indirection |
 | test.cpp:114:10:114:23 | Convert | test.cpp:114:25:114:29 | call to c_str indirection |
 | test.cpp:114:17:114:17 | call to operator+ | test.cpp:114:25:114:29 | call to c_str indirection |
 | test.cpp:114:19:114:22 | CopyValue indirection | test.cpp:114:10:114:23 | Convert |
 | test.cpp:114:19:114:22 | CopyValue indirection | test.cpp:114:17:114:17 | call to operator+ |
-| test.cpp:119:20:119:25 | call to getenv | test.cpp:120:19:120:22 | CopyValue indirection |
+| test.cpp:119:20:119:25 | Call | test.cpp:120:19:120:22 | CopyValue indirection |
 | test.cpp:119:20:119:38 | call to getenv indirection | test.cpp:120:19:120:22 | CopyValue indirection |
 | test.cpp:120:17:120:17 | call to operator+ | test.cpp:120:10:120:30 | call to data indirection |
 | test.cpp:120:19:120:22 | CopyValue indirection | test.cpp:120:17:120:17 | call to operator+ |
@@ -122,19 +122,19 @@ nodes
 | test.cpp:93:11:93:14 | strncat output argument | semmle.label | strncat output argument |
 | test.cpp:93:17:93:24 | Convert indirection | semmle.label | Convert indirection |
 | test.cpp:94:45:94:48 | Convert indirection | semmle.label | Convert indirection |
-| test.cpp:106:20:106:25 | call to getenv | semmle.label | call to getenv |
+| test.cpp:106:20:106:25 | Call | semmle.label | Call |
 | test.cpp:106:20:106:38 | call to getenv indirection | semmle.label | call to getenv indirection |
 | test.cpp:107:31:107:31 | Call | semmle.label | Call |
 | test.cpp:107:33:107:36 | CopyValue indirection | semmle.label | CopyValue indirection |
 | test.cpp:108:18:108:22 | call to c_str indirection | semmle.label | call to c_str indirection |
-| test.cpp:113:20:113:25 | call to getenv | semmle.label | call to getenv |
+| test.cpp:113:20:113:25 | Call | semmle.label | Call |
 | test.cpp:113:20:113:38 | call to getenv indirection | semmle.label | call to getenv indirection |
 | test.cpp:114:10:114:23 | Convert | semmle.label | Convert |
 | test.cpp:114:17:114:17 | call to operator+ | semmle.label | call to operator+ |
 | test.cpp:114:19:114:22 | CopyValue indirection | semmle.label | CopyValue indirection |
 | test.cpp:114:25:114:29 | call to c_str indirection | semmle.label | call to c_str indirection |
 | test.cpp:114:25:114:29 | call to c_str indirection | semmle.label | call to c_str indirection |
-| test.cpp:119:20:119:25 | call to getenv | semmle.label | call to getenv |
+| test.cpp:119:20:119:25 | Call | semmle.label | Call |
 | test.cpp:119:20:119:38 | call to getenv indirection | semmle.label | call to getenv indirection |
 | test.cpp:120:10:120:30 | call to data indirection | semmle.label | call to data indirection |
 | test.cpp:120:17:120:17 | call to operator+ | semmle.label | call to operator+ |
@@ -217,13 +217,13 @@ subpaths
 | test.cpp:65:10:65:16 | command | test.cpp:62:9:62:16 | fread output argument | test.cpp:65:10:65:16 | Convert indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to system(string). | test.cpp:62:9:62:16 | fread output argument | user input (string read by fread) | test.cpp:64:11:64:17 | strncat output argument | strncat output argument |
 | test.cpp:85:32:85:38 | command | test.cpp:82:9:82:16 | fread output argument | test.cpp:85:32:85:38 | Convert indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to execl. | test.cpp:82:9:82:16 | fread output argument | user input (string read by fread) | test.cpp:84:11:84:17 | strncat output argument | strncat output argument |
 | test.cpp:94:45:94:48 | path | test.cpp:91:9:91:16 | fread output argument | test.cpp:94:45:94:48 | Convert indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to execl. | test.cpp:91:9:91:16 | fread output argument | user input (string read by fread) | test.cpp:93:11:93:14 | strncat output argument | strncat output argument |
-| test.cpp:108:18:108:22 | call to c_str | test.cpp:106:20:106:25 | call to getenv | test.cpp:108:18:108:22 | call to c_str indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to system(string). | test.cpp:106:20:106:25 | call to getenv | user input (an environment variable) | test.cpp:107:31:107:31 | Call | Call |
+| test.cpp:108:18:108:22 | call to c_str | test.cpp:106:20:106:25 | Call | test.cpp:108:18:108:22 | call to c_str indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to system(string). | test.cpp:106:20:106:25 | Call | user input (an environment variable) | test.cpp:107:31:107:31 | Call | Call |
 | test.cpp:108:18:108:22 | call to c_str | test.cpp:106:20:106:38 | call to getenv indirection | test.cpp:108:18:108:22 | call to c_str indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to system(string). | test.cpp:106:20:106:38 | call to getenv indirection | user input (an environment variable) | test.cpp:107:31:107:31 | Call | Call |
-| test.cpp:114:25:114:29 | call to c_str | test.cpp:113:20:113:25 | call to getenv | test.cpp:114:25:114:29 | call to c_str indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to system(string). | test.cpp:113:20:113:25 | call to getenv | user input (an environment variable) | test.cpp:114:10:114:23 | Convert | Convert |
-| test.cpp:114:25:114:29 | call to c_str | test.cpp:113:20:113:25 | call to getenv | test.cpp:114:25:114:29 | call to c_str indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to system(string). | test.cpp:113:20:113:25 | call to getenv | user input (an environment variable) | test.cpp:114:17:114:17 | call to operator+ | call to operator+ |
+| test.cpp:114:25:114:29 | call to c_str | test.cpp:113:20:113:25 | Call | test.cpp:114:25:114:29 | call to c_str indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to system(string). | test.cpp:113:20:113:25 | Call | user input (an environment variable) | test.cpp:114:10:114:23 | Convert | Convert |
+| test.cpp:114:25:114:29 | call to c_str | test.cpp:113:20:113:25 | Call | test.cpp:114:25:114:29 | call to c_str indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to system(string). | test.cpp:113:20:113:25 | Call | user input (an environment variable) | test.cpp:114:17:114:17 | call to operator+ | call to operator+ |
 | test.cpp:114:25:114:29 | call to c_str | test.cpp:113:20:113:38 | call to getenv indirection | test.cpp:114:25:114:29 | call to c_str indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to system(string). | test.cpp:113:20:113:38 | call to getenv indirection | user input (an environment variable) | test.cpp:114:10:114:23 | Convert | Convert |
 | test.cpp:114:25:114:29 | call to c_str | test.cpp:113:20:113:38 | call to getenv indirection | test.cpp:114:25:114:29 | call to c_str indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to system(string). | test.cpp:113:20:113:38 | call to getenv indirection | user input (an environment variable) | test.cpp:114:17:114:17 | call to operator+ | call to operator+ |
-| test.cpp:120:25:120:28 | call to data | test.cpp:119:20:119:25 | call to getenv | test.cpp:120:10:120:30 | call to data indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to system(string). | test.cpp:119:20:119:25 | call to getenv | user input (an environment variable) | test.cpp:120:17:120:17 | call to operator+ | call to operator+ |
+| test.cpp:120:25:120:28 | call to data | test.cpp:119:20:119:25 | Call | test.cpp:120:10:120:30 | call to data indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to system(string). | test.cpp:119:20:119:25 | Call | user input (an environment variable) | test.cpp:120:17:120:17 | call to operator+ | call to operator+ |
 | test.cpp:120:25:120:28 | call to data | test.cpp:119:20:119:38 | call to getenv indirection | test.cpp:120:10:120:30 | call to data indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to system(string). | test.cpp:119:20:119:38 | call to getenv indirection | user input (an environment variable) | test.cpp:120:17:120:17 | call to operator+ | call to operator+ |
 | test.cpp:143:10:143:16 | command | test.cpp:140:9:140:11 | fread output argument | test.cpp:143:10:143:16 | Convert indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to system(string). | test.cpp:140:9:140:11 | fread output argument | user input (string read by fread) | test.cpp:142:11:142:17 | sprintf output argument | sprintf output argument |
 | test.cpp:183:32:183:38 | command | test.cpp:174:9:174:16 | fread output argument | test.cpp:183:32:183:38 | Convert indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to execl. | test.cpp:174:9:174:16 | fread output argument | user input (string read by fread) | test.cpp:177:13:177:17 | strncat output argument | strncat output argument |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-089/SqlTainted/SqlTainted.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-089/SqlTainted/SqlTainted.expected
@@ -5,6 +5,8 @@ edges
 | test.c:15:20:15:23 | argv | test.c:21:18:21:23 | query1 |
 | test.c:15:20:15:23 | argv | test.c:21:18:21:23 | query1 |
 | test.c:15:20:15:23 | argv | test.c:21:18:21:23 | query1 |
+| test.c:15:20:15:23 | argv | test.c:21:18:21:23 | query1 |
+| test.c:15:20:15:23 | argv | test.c:21:18:21:23 | query1 |
 | test.cpp:43:27:43:30 | argv | test.cpp:43:27:43:33 | access to array |
 | test.cpp:43:27:43:30 | argv | test.cpp:43:27:43:33 | access to array |
 | test.cpp:43:27:43:30 | argv | test.cpp:43:27:43:33 | access to array |
@@ -15,6 +17,7 @@ subpaths
 nodes
 | test.c:15:20:15:23 | argv | semmle.label | argv |
 | test.c:15:20:15:23 | argv | semmle.label | argv |
+| test.c:21:18:21:23 | query1 | semmle.label | query1 |
 | test.c:21:18:21:23 | query1 | semmle.label | query1 |
 | test.c:21:18:21:23 | query1 | semmle.label | query1 |
 | test.c:21:18:21:23 | query1 | semmle.label | query1 |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-114/semmle/UncontrolledProcessOperation/UncontrolledProcessOperation.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-114/semmle/UncontrolledProcessOperation/UncontrolledProcessOperation.expected
@@ -13,6 +13,8 @@ edges
 | test.cpp:56:12:56:17 | buffer | test.cpp:62:10:62:15 | buffer |
 | test.cpp:56:12:56:17 | buffer | test.cpp:62:10:62:15 | buffer |
 | test.cpp:56:12:56:17 | buffer | test.cpp:62:10:62:15 | buffer |
+| test.cpp:56:12:56:17 | buffer | test.cpp:62:10:62:15 | buffer |
+| test.cpp:56:12:56:17 | buffer | test.cpp:62:10:62:15 | buffer |
 | test.cpp:56:12:56:17 | buffer | test.cpp:63:10:63:13 | data |
 | test.cpp:56:12:56:17 | buffer | test.cpp:63:10:63:13 | data |
 | test.cpp:56:12:56:17 | buffer | test.cpp:63:10:63:13 | data |
@@ -36,6 +38,7 @@ edges
 | test.cpp:56:12:56:17 | fgets output argument | test.cpp:62:10:62:15 | buffer |
 | test.cpp:56:12:56:17 | fgets output argument | test.cpp:62:10:62:15 | buffer |
 | test.cpp:56:12:56:17 | fgets output argument | test.cpp:62:10:62:15 | buffer |
+| test.cpp:56:12:56:17 | fgets output argument | test.cpp:62:10:62:15 | buffer |
 | test.cpp:56:12:56:17 | fgets output argument | test.cpp:63:10:63:13 | data |
 | test.cpp:56:12:56:17 | fgets output argument | test.cpp:63:10:63:13 | data |
 | test.cpp:56:12:56:17 | fgets output argument | test.cpp:63:10:63:13 | data |
@@ -52,9 +55,14 @@ edges
 | test.cpp:76:12:76:17 | buffer | test.cpp:78:10:78:15 | buffer |
 | test.cpp:76:12:76:17 | buffer | test.cpp:78:10:78:15 | buffer |
 | test.cpp:76:12:76:17 | buffer | test.cpp:78:10:78:15 | buffer |
+| test.cpp:76:12:76:17 | buffer | test.cpp:78:10:78:15 | buffer |
+| test.cpp:76:12:76:17 | buffer | test.cpp:78:10:78:15 | buffer |
 | test.cpp:76:12:76:17 | fgets output argument | test.cpp:78:10:78:15 | buffer |
 | test.cpp:76:12:76:17 | fgets output argument | test.cpp:78:10:78:15 | buffer |
 | test.cpp:76:12:76:17 | fgets output argument | test.cpp:78:10:78:15 | buffer |
+| test.cpp:76:12:76:17 | fgets output argument | test.cpp:78:10:78:15 | buffer |
+| test.cpp:98:17:98:22 | buffer | test.cpp:99:15:99:20 | buffer |
+| test.cpp:98:17:98:22 | buffer | test.cpp:99:15:99:20 | buffer |
 | test.cpp:98:17:98:22 | buffer | test.cpp:99:15:99:20 | buffer |
 | test.cpp:98:17:98:22 | buffer | test.cpp:99:15:99:20 | buffer |
 | test.cpp:98:17:98:22 | buffer | test.cpp:99:15:99:20 | buffer |
@@ -64,12 +72,16 @@ edges
 | test.cpp:98:17:98:22 | recv output argument | test.cpp:99:15:99:20 | buffer |
 | test.cpp:98:17:98:22 | recv output argument | test.cpp:99:15:99:20 | buffer |
 | test.cpp:98:17:98:22 | recv output argument | test.cpp:99:15:99:20 | buffer |
+| test.cpp:98:17:98:22 | recv output argument | test.cpp:99:15:99:20 | buffer |
 | test.cpp:106:17:106:22 | buffer | test.cpp:107:15:107:20 | buffer |
 | test.cpp:106:17:106:22 | buffer | test.cpp:107:15:107:20 | buffer |
 | test.cpp:106:17:106:22 | buffer | test.cpp:107:15:107:20 | buffer |
 | test.cpp:106:17:106:22 | buffer | test.cpp:107:15:107:20 | buffer |
 | test.cpp:106:17:106:22 | buffer | test.cpp:107:15:107:20 | buffer |
 | test.cpp:106:17:106:22 | buffer | test.cpp:107:15:107:20 | buffer |
+| test.cpp:106:17:106:22 | buffer | test.cpp:107:15:107:20 | buffer |
+| test.cpp:106:17:106:22 | buffer | test.cpp:107:15:107:20 | buffer |
+| test.cpp:106:17:106:22 | recv output argument | test.cpp:107:15:107:20 | buffer |
 | test.cpp:106:17:106:22 | recv output argument | test.cpp:107:15:107:20 | buffer |
 | test.cpp:106:17:106:22 | recv output argument | test.cpp:107:15:107:20 | buffer |
 | test.cpp:106:17:106:22 | recv output argument | test.cpp:107:15:107:20 | buffer |
@@ -91,6 +103,7 @@ nodes
 | test.cpp:62:10:62:15 | buffer | semmle.label | buffer |
 | test.cpp:62:10:62:15 | buffer | semmle.label | buffer |
 | test.cpp:62:10:62:15 | buffer | semmle.label | buffer |
+| test.cpp:62:10:62:15 | buffer | semmle.label | buffer |
 | test.cpp:63:10:63:13 | data | semmle.label | data |
 | test.cpp:63:10:63:13 | data | semmle.label | data |
 | test.cpp:63:10:63:13 | data | semmle.label | data |
@@ -107,15 +120,18 @@ nodes
 | test.cpp:78:10:78:15 | buffer | semmle.label | buffer |
 | test.cpp:78:10:78:15 | buffer | semmle.label | buffer |
 | test.cpp:78:10:78:15 | buffer | semmle.label | buffer |
+| test.cpp:78:10:78:15 | buffer | semmle.label | buffer |
 | test.cpp:98:17:98:22 | buffer | semmle.label | buffer |
 | test.cpp:98:17:98:22 | buffer | semmle.label | buffer |
 | test.cpp:98:17:98:22 | recv output argument | semmle.label | recv output argument |
 | test.cpp:99:15:99:20 | buffer | semmle.label | buffer |
 | test.cpp:99:15:99:20 | buffer | semmle.label | buffer |
 | test.cpp:99:15:99:20 | buffer | semmle.label | buffer |
+| test.cpp:99:15:99:20 | buffer | semmle.label | buffer |
 | test.cpp:106:17:106:22 | buffer | semmle.label | buffer |
 | test.cpp:106:17:106:22 | buffer | semmle.label | buffer |
 | test.cpp:106:17:106:22 | recv output argument | semmle.label | recv output argument |
+| test.cpp:107:15:107:20 | buffer | semmle.label | buffer |
 | test.cpp:107:15:107:20 | buffer | semmle.label | buffer |
 | test.cpp:107:15:107:20 | buffer | semmle.label | buffer |
 | test.cpp:107:15:107:20 | buffer | semmle.label | buffer |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/argv/argvLocal.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/argv/argvLocal.expected
@@ -55,6 +55,10 @@ edges
 | argvLocal.c:115:13:115:16 | argv | argvLocal.c:116:9:116:10 | i3 |
 | argvLocal.c:115:13:115:16 | argv | argvLocal.c:116:9:116:10 | i3 |
 | argvLocal.c:115:13:115:16 | argv | argvLocal.c:116:9:116:10 | i3 |
+| argvLocal.c:115:13:115:16 | argv | argvLocal.c:116:9:116:10 | i3 |
+| argvLocal.c:115:13:115:16 | argv | argvLocal.c:116:9:116:10 | i3 |
+| argvLocal.c:115:13:115:16 | argv | argvLocal.c:117:15:117:16 | i3 |
+| argvLocal.c:115:13:115:16 | argv | argvLocal.c:117:15:117:16 | i3 |
 | argvLocal.c:115:13:115:16 | argv | argvLocal.c:117:15:117:16 | i3 |
 | argvLocal.c:115:13:115:16 | argv | argvLocal.c:117:15:117:16 | i3 |
 | argvLocal.c:115:13:115:16 | argv | argvLocal.c:117:15:117:16 | i3 |
@@ -77,10 +81,6 @@ edges
 | argvLocal.c:115:13:115:16 | argv | argvLocal.c:135:9:135:12 | ... ++ |
 | argvLocal.c:115:13:115:16 | argv | argvLocal.c:135:9:135:12 | ... ++ |
 | argvLocal.c:115:13:115:16 | argv | argvLocal.c:135:9:135:12 | ... ++ |
-| argvLocal.c:115:13:115:16 | argv | argvLocal.c:135:9:135:12 | ... ++ |
-| argvLocal.c:115:13:115:16 | argv | argvLocal.c:135:9:135:12 | ... ++ |
-| argvLocal.c:115:13:115:16 | argv | argvLocal.c:135:9:135:12 | ... ++ |
-| argvLocal.c:115:13:115:16 | argv | argvLocal.c:135:9:135:12 | ... ++ |
 | argvLocal.c:115:13:115:16 | argv | argvLocal.c:136:15:136:18 | -- ... |
 | argvLocal.c:115:13:115:16 | argv | argvLocal.c:136:15:136:18 | -- ... |
 | argvLocal.c:115:13:115:16 | argv | argvLocal.c:136:15:136:18 | -- ... |
@@ -95,6 +95,10 @@ edges
 | argvLocal.c:126:10:126:13 | argv | argvLocal.c:127:9:127:10 | i5 |
 | argvLocal.c:126:10:126:13 | argv | argvLocal.c:127:9:127:10 | i5 |
 | argvLocal.c:126:10:126:13 | argv | argvLocal.c:127:9:127:10 | i5 |
+| argvLocal.c:126:10:126:13 | argv | argvLocal.c:127:9:127:10 | i5 |
+| argvLocal.c:126:10:126:13 | argv | argvLocal.c:127:9:127:10 | i5 |
+| argvLocal.c:126:10:126:13 | argv | argvLocal.c:128:15:128:16 | i5 |
+| argvLocal.c:126:10:126:13 | argv | argvLocal.c:128:15:128:16 | i5 |
 | argvLocal.c:126:10:126:13 | argv | argvLocal.c:128:15:128:16 | i5 |
 | argvLocal.c:126:10:126:13 | argv | argvLocal.c:128:15:128:16 | i5 |
 | argvLocal.c:126:10:126:13 | argv | argvLocal.c:128:15:128:16 | i5 |
@@ -178,6 +182,8 @@ nodes
 | argvLocal.c:116:9:116:10 | i3 | semmle.label | i3 |
 | argvLocal.c:116:9:116:10 | i3 | semmle.label | i3 |
 | argvLocal.c:116:9:116:10 | i3 | semmle.label | i3 |
+| argvLocal.c:116:9:116:10 | i3 | semmle.label | i3 |
+| argvLocal.c:117:15:117:16 | i3 | semmle.label | i3 |
 | argvLocal.c:117:15:117:16 | i3 | semmle.label | i3 |
 | argvLocal.c:117:15:117:16 | i3 | semmle.label | i3 |
 | argvLocal.c:121:9:121:10 | i4 | semmle.label | i4 |
@@ -190,6 +196,8 @@ nodes
 | argvLocal.c:127:9:127:10 | i5 | semmle.label | i5 |
 | argvLocal.c:127:9:127:10 | i5 | semmle.label | i5 |
 | argvLocal.c:127:9:127:10 | i5 | semmle.label | i5 |
+| argvLocal.c:127:9:127:10 | i5 | semmle.label | i5 |
+| argvLocal.c:128:15:128:16 | i5 | semmle.label | i5 |
 | argvLocal.c:128:15:128:16 | i5 | semmle.label | i5 |
 | argvLocal.c:128:15:128:16 | i5 | semmle.label | i5 |
 | argvLocal.c:131:9:131:14 | ... + ... | semmle.label | ... + ... |
@@ -198,8 +206,6 @@ nodes
 | argvLocal.c:132:15:132:20 | ... + ... | semmle.label | ... + ... |
 | argvLocal.c:132:15:132:20 | ... + ... | semmle.label | ... + ... |
 | argvLocal.c:135:9:135:10 | i4 | semmle.label | i4 |
-| argvLocal.c:135:9:135:12 | ... ++ | semmle.label | ... ++ |
-| argvLocal.c:135:9:135:12 | ... ++ | semmle.label | ... ++ |
 | argvLocal.c:135:9:135:12 | ... ++ | semmle.label | ... ++ |
 | argvLocal.c:135:9:135:12 | ... ++ | semmle.label | ... ++ |
 | argvLocal.c:135:9:135:12 | ... ++ | semmle.label | ... ++ |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/funcs/funcsLocal.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/funcs/funcsLocal.expected
@@ -2,15 +2,21 @@ edges
 | funcsLocal.c:16:8:16:9 | fread output argument | funcsLocal.c:17:9:17:10 | i1 |
 | funcsLocal.c:16:8:16:9 | fread output argument | funcsLocal.c:17:9:17:10 | i1 |
 | funcsLocal.c:16:8:16:9 | fread output argument | funcsLocal.c:17:9:17:10 | i1 |
+| funcsLocal.c:16:8:16:9 | fread output argument | funcsLocal.c:17:9:17:10 | i1 |
 | funcsLocal.c:16:8:16:9 | fread output argument | funcsLocal.c:58:9:58:10 | e1 |
 | funcsLocal.c:16:8:16:9 | fread output argument | funcsLocal.c:58:9:58:10 | e1 |
 | funcsLocal.c:16:8:16:9 | fread output argument | funcsLocal.c:58:9:58:10 | e1 |
+| funcsLocal.c:16:8:16:9 | fread output argument | funcsLocal.c:58:9:58:10 | e1 |
 | funcsLocal.c:16:8:16:9 | i1 | funcsLocal.c:17:9:17:10 | i1 |
 | funcsLocal.c:16:8:16:9 | i1 | funcsLocal.c:17:9:17:10 | i1 |
 | funcsLocal.c:16:8:16:9 | i1 | funcsLocal.c:17:9:17:10 | i1 |
 | funcsLocal.c:16:8:16:9 | i1 | funcsLocal.c:17:9:17:10 | i1 |
 | funcsLocal.c:16:8:16:9 | i1 | funcsLocal.c:17:9:17:10 | i1 |
 | funcsLocal.c:16:8:16:9 | i1 | funcsLocal.c:17:9:17:10 | i1 |
+| funcsLocal.c:16:8:16:9 | i1 | funcsLocal.c:17:9:17:10 | i1 |
+| funcsLocal.c:16:8:16:9 | i1 | funcsLocal.c:17:9:17:10 | i1 |
+| funcsLocal.c:16:8:16:9 | i1 | funcsLocal.c:58:9:58:10 | e1 |
+| funcsLocal.c:16:8:16:9 | i1 | funcsLocal.c:58:9:58:10 | e1 |
 | funcsLocal.c:16:8:16:9 | i1 | funcsLocal.c:58:9:58:10 | e1 |
 | funcsLocal.c:16:8:16:9 | i1 | funcsLocal.c:58:9:58:10 | e1 |
 | funcsLocal.c:16:8:16:9 | i1 | funcsLocal.c:58:9:58:10 | e1 |
@@ -20,6 +26,9 @@ edges
 | funcsLocal.c:26:8:26:9 | fgets output argument | funcsLocal.c:27:9:27:10 | i3 |
 | funcsLocal.c:26:8:26:9 | fgets output argument | funcsLocal.c:27:9:27:10 | i3 |
 | funcsLocal.c:26:8:26:9 | fgets output argument | funcsLocal.c:27:9:27:10 | i3 |
+| funcsLocal.c:26:8:26:9 | fgets output argument | funcsLocal.c:27:9:27:10 | i3 |
+| funcsLocal.c:26:8:26:9 | i3 | funcsLocal.c:27:9:27:10 | i3 |
+| funcsLocal.c:26:8:26:9 | i3 | funcsLocal.c:27:9:27:10 | i3 |
 | funcsLocal.c:26:8:26:9 | i3 | funcsLocal.c:27:9:27:10 | i3 |
 | funcsLocal.c:26:8:26:9 | i3 | funcsLocal.c:27:9:27:10 | i3 |
 | funcsLocal.c:26:8:26:9 | i3 | funcsLocal.c:27:9:27:10 | i3 |
@@ -41,6 +50,9 @@ edges
 | funcsLocal.c:36:7:36:8 | gets output argument | funcsLocal.c:37:9:37:10 | i5 |
 | funcsLocal.c:36:7:36:8 | gets output argument | funcsLocal.c:37:9:37:10 | i5 |
 | funcsLocal.c:36:7:36:8 | gets output argument | funcsLocal.c:37:9:37:10 | i5 |
+| funcsLocal.c:36:7:36:8 | gets output argument | funcsLocal.c:37:9:37:10 | i5 |
+| funcsLocal.c:36:7:36:8 | i5 | funcsLocal.c:37:9:37:10 | i5 |
+| funcsLocal.c:36:7:36:8 | i5 | funcsLocal.c:37:9:37:10 | i5 |
 | funcsLocal.c:36:7:36:8 | i5 | funcsLocal.c:37:9:37:10 | i5 |
 | funcsLocal.c:36:7:36:8 | i5 | funcsLocal.c:37:9:37:10 | i5 |
 | funcsLocal.c:36:7:36:8 | i5 | funcsLocal.c:37:9:37:10 | i5 |
@@ -88,9 +100,11 @@ nodes
 | funcsLocal.c:17:9:17:10 | i1 | semmle.label | i1 |
 | funcsLocal.c:17:9:17:10 | i1 | semmle.label | i1 |
 | funcsLocal.c:17:9:17:10 | i1 | semmle.label | i1 |
+| funcsLocal.c:17:9:17:10 | i1 | semmle.label | i1 |
 | funcsLocal.c:26:8:26:9 | fgets output argument | semmle.label | fgets output argument |
 | funcsLocal.c:26:8:26:9 | i3 | semmle.label | i3 |
 | funcsLocal.c:26:8:26:9 | i3 | semmle.label | i3 |
+| funcsLocal.c:27:9:27:10 | i3 | semmle.label | i3 |
 | funcsLocal.c:27:9:27:10 | i3 | semmle.label | i3 |
 | funcsLocal.c:27:9:27:10 | i3 | semmle.label | i3 |
 | funcsLocal.c:27:9:27:10 | i3 | semmle.label | i3 |
@@ -104,6 +118,7 @@ nodes
 | funcsLocal.c:36:7:36:8 | gets output argument | semmle.label | gets output argument |
 | funcsLocal.c:36:7:36:8 | i5 | semmle.label | i5 |
 | funcsLocal.c:36:7:36:8 | i5 | semmle.label | i5 |
+| funcsLocal.c:37:9:37:10 | i5 | semmle.label | i5 |
 | funcsLocal.c:37:9:37:10 | i5 | semmle.label | i5 |
 | funcsLocal.c:37:9:37:10 | i5 | semmle.label | i5 |
 | funcsLocal.c:37:9:37:10 | i5 | semmle.label | i5 |
@@ -127,6 +142,7 @@ nodes
 | funcsLocal.c:53:9:53:11 | * ... | semmle.label | * ... |
 | funcsLocal.c:53:9:53:11 | * ... | semmle.label | * ... |
 | funcsLocal.c:53:9:53:11 | * ... | semmle.label | * ... |
+| funcsLocal.c:58:9:58:10 | e1 | semmle.label | e1 |
 | funcsLocal.c:58:9:58:10 | e1 | semmle.label | e1 |
 | funcsLocal.c:58:9:58:10 | e1 | semmle.label | e1 |
 | funcsLocal.c:58:9:58:10 | e1 | semmle.label | e1 |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/TaintedAllocationSize/TaintedAllocationSize.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/TaintedAllocationSize/TaintedAllocationSize.expected
@@ -17,20 +17,20 @@ edges
 | test.cpp:39:27:39:30 | argv indirection | test.cpp:50:26:50:29 | size |
 | test.cpp:39:27:39:30 | argv indirection | test.cpp:53:35:53:60 | ... * ... |
 | test.cpp:39:27:39:30 | argv indirection | test.cpp:53:35:53:60 | ... * ... |
-| test.cpp:124:18:124:23 | call to getenv | test.cpp:128:24:128:41 | ... * ... |
+| test.cpp:124:18:124:23 | Call | test.cpp:128:24:128:41 | ... * ... |
 | test.cpp:124:18:124:31 | call to getenv indirection | test.cpp:128:24:128:41 | ... * ... |
-| test.cpp:133:19:133:24 | call to getenv | test.cpp:135:10:135:27 | ... * ... |
+| test.cpp:133:19:133:24 | Call | test.cpp:135:10:135:27 | ... * ... |
 | test.cpp:133:19:133:32 | call to getenv indirection | test.cpp:135:10:135:27 | ... * ... |
-| test.cpp:148:20:148:25 | call to getenv | test.cpp:152:11:152:28 | ... * ... |
+| test.cpp:148:20:148:25 | Call | test.cpp:152:11:152:28 | ... * ... |
 | test.cpp:148:20:148:33 | call to getenv indirection | test.cpp:152:11:152:28 | ... * ... |
 | test.cpp:209:8:209:23 | VariableAddress indirection | test.cpp:241:9:241:24 | call to get_tainted_size |
-| test.cpp:211:14:211:19 | call to getenv | test.cpp:209:8:209:23 | VariableAddress indirection |
+| test.cpp:211:14:211:19 | Call | test.cpp:209:8:209:23 | VariableAddress indirection |
 | test.cpp:211:14:211:27 | call to getenv indirection | test.cpp:209:8:209:23 | VariableAddress indirection |
 | test.cpp:224:23:224:23 | s | test.cpp:225:21:225:21 | s |
 | test.cpp:230:21:230:21 | s | test.cpp:231:21:231:21 | s |
-| test.cpp:237:24:237:29 | call to getenv | test.cpp:239:9:239:18 | local_size |
-| test.cpp:237:24:237:29 | call to getenv | test.cpp:245:11:245:20 | local_size |
-| test.cpp:237:24:237:29 | call to getenv | test.cpp:247:10:247:19 | local_size |
+| test.cpp:237:24:237:29 | Call | test.cpp:239:9:239:18 | local_size |
+| test.cpp:237:24:237:29 | Call | test.cpp:245:11:245:20 | local_size |
+| test.cpp:237:24:237:29 | Call | test.cpp:247:10:247:19 | local_size |
 | test.cpp:237:24:237:37 | call to getenv indirection | test.cpp:239:9:239:18 | local_size |
 | test.cpp:237:24:237:37 | call to getenv indirection | test.cpp:245:11:245:20 | local_size |
 | test.cpp:237:24:237:37 | call to getenv indirection | test.cpp:247:10:247:19 | local_size |
@@ -38,13 +38,13 @@ edges
 | test.cpp:247:10:247:19 | local_size | test.cpp:230:21:230:21 | s |
 | test.cpp:250:20:250:27 | Load indirection | test.cpp:289:17:289:20 | get_size output argument |
 | test.cpp:250:20:250:27 | Load indirection | test.cpp:305:18:305:21 | get_size output argument |
-| test.cpp:251:18:251:23 | call to getenv | test.cpp:250:20:250:27 | Load indirection |
+| test.cpp:251:18:251:23 | Call | test.cpp:250:20:250:27 | Load indirection |
 | test.cpp:251:18:251:31 | call to getenv indirection | test.cpp:250:20:250:27 | Load indirection |
-| test.cpp:259:20:259:25 | call to getenv | test.cpp:263:11:263:29 | ... * ... |
+| test.cpp:259:20:259:25 | Call | test.cpp:263:11:263:29 | ... * ... |
 | test.cpp:259:20:259:33 | call to getenv indirection | test.cpp:263:11:263:29 | ... * ... |
 | test.cpp:289:17:289:20 | get_size output argument | test.cpp:291:11:291:28 | ... * ... |
 | test.cpp:305:18:305:21 | get_size output argument | test.cpp:308:10:308:27 | ... * ... |
-| test.cpp:338:19:338:24 | call to getenv | test.cpp:342:25:342:43 | ... * ... |
+| test.cpp:338:19:338:24 | Call | test.cpp:342:25:342:43 | ... * ... |
 | test.cpp:338:19:338:32 | call to getenv indirection | test.cpp:342:25:342:43 | ... * ... |
 nodes
 | test.cpp:39:27:39:30 | argv | semmle.label | argv |
@@ -56,39 +56,39 @@ nodes
 | test.cpp:49:32:49:35 | size | semmle.label | size |
 | test.cpp:50:26:50:29 | size | semmle.label | size |
 | test.cpp:53:35:53:60 | ... * ... | semmle.label | ... * ... |
-| test.cpp:124:18:124:23 | call to getenv | semmle.label | call to getenv |
+| test.cpp:124:18:124:23 | Call | semmle.label | Call |
 | test.cpp:124:18:124:31 | call to getenv indirection | semmle.label | call to getenv indirection |
 | test.cpp:128:24:128:41 | ... * ... | semmle.label | ... * ... |
-| test.cpp:133:19:133:24 | call to getenv | semmle.label | call to getenv |
+| test.cpp:133:19:133:24 | Call | semmle.label | Call |
 | test.cpp:133:19:133:32 | call to getenv indirection | semmle.label | call to getenv indirection |
 | test.cpp:135:10:135:27 | ... * ... | semmle.label | ... * ... |
-| test.cpp:148:20:148:25 | call to getenv | semmle.label | call to getenv |
+| test.cpp:148:20:148:25 | Call | semmle.label | Call |
 | test.cpp:148:20:148:33 | call to getenv indirection | semmle.label | call to getenv indirection |
 | test.cpp:152:11:152:28 | ... * ... | semmle.label | ... * ... |
 | test.cpp:209:8:209:23 | VariableAddress indirection | semmle.label | VariableAddress indirection |
-| test.cpp:211:14:211:19 | call to getenv | semmle.label | call to getenv |
+| test.cpp:211:14:211:19 | Call | semmle.label | Call |
 | test.cpp:211:14:211:27 | call to getenv indirection | semmle.label | call to getenv indirection |
 | test.cpp:224:23:224:23 | s | semmle.label | s |
 | test.cpp:225:21:225:21 | s | semmle.label | s |
 | test.cpp:230:21:230:21 | s | semmle.label | s |
 | test.cpp:231:21:231:21 | s | semmle.label | s |
-| test.cpp:237:24:237:29 | call to getenv | semmle.label | call to getenv |
+| test.cpp:237:24:237:29 | Call | semmle.label | Call |
 | test.cpp:237:24:237:37 | call to getenv indirection | semmle.label | call to getenv indirection |
 | test.cpp:239:9:239:18 | local_size | semmle.label | local_size |
 | test.cpp:241:9:241:24 | call to get_tainted_size | semmle.label | call to get_tainted_size |
 | test.cpp:245:11:245:20 | local_size | semmle.label | local_size |
 | test.cpp:247:10:247:19 | local_size | semmle.label | local_size |
 | test.cpp:250:20:250:27 | Load indirection | semmle.label | Load indirection |
-| test.cpp:251:18:251:23 | call to getenv | semmle.label | call to getenv |
+| test.cpp:251:18:251:23 | Call | semmle.label | Call |
 | test.cpp:251:18:251:31 | call to getenv indirection | semmle.label | call to getenv indirection |
-| test.cpp:259:20:259:25 | call to getenv | semmle.label | call to getenv |
+| test.cpp:259:20:259:25 | Call | semmle.label | Call |
 | test.cpp:259:20:259:33 | call to getenv indirection | semmle.label | call to getenv indirection |
 | test.cpp:263:11:263:29 | ... * ... | semmle.label | ... * ... |
 | test.cpp:289:17:289:20 | get_size output argument | semmle.label | get_size output argument |
 | test.cpp:291:11:291:28 | ... * ... | semmle.label | ... * ... |
 | test.cpp:305:18:305:21 | get_size output argument | semmle.label | get_size output argument |
 | test.cpp:308:10:308:27 | ... * ... | semmle.label | ... * ... |
-| test.cpp:338:19:338:24 | call to getenv | semmle.label | call to getenv |
+| test.cpp:338:19:338:24 | Call | semmle.label | Call |
 | test.cpp:338:19:338:32 | call to getenv indirection | semmle.label | call to getenv indirection |
 | test.cpp:342:25:342:43 | ... * ... | semmle.label | ... * ... |
 subpaths
@@ -111,25 +111,25 @@ subpaths
 | test.cpp:53:21:53:27 | call to realloc | test.cpp:39:27:39:30 | argv | test.cpp:53:35:53:60 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:39:27:39:30 | argv | user input (a command-line argument) |
 | test.cpp:53:21:53:27 | call to realloc | test.cpp:39:27:39:30 | argv indirection | test.cpp:53:35:53:60 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:39:27:39:30 | argv indirection | user input (a command-line argument) |
 | test.cpp:53:21:53:27 | call to realloc | test.cpp:39:27:39:30 | argv indirection | test.cpp:53:35:53:60 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:39:27:39:30 | argv indirection | user input (a command-line argument) |
-| test.cpp:128:17:128:22 | call to malloc | test.cpp:124:18:124:23 | call to getenv | test.cpp:128:24:128:41 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:124:18:124:23 | call to getenv | user input (an environment variable) |
+| test.cpp:128:17:128:22 | call to malloc | test.cpp:124:18:124:23 | Call | test.cpp:128:24:128:41 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:124:18:124:23 | Call | user input (an environment variable) |
 | test.cpp:128:17:128:22 | call to malloc | test.cpp:124:18:124:31 | call to getenv indirection | test.cpp:128:24:128:41 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:124:18:124:31 | call to getenv indirection | user input (an environment variable) |
-| test.cpp:135:3:135:8 | call to malloc | test.cpp:133:19:133:24 | call to getenv | test.cpp:135:10:135:27 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:133:19:133:24 | call to getenv | user input (an environment variable) |
+| test.cpp:135:3:135:8 | call to malloc | test.cpp:133:19:133:24 | Call | test.cpp:135:10:135:27 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:133:19:133:24 | Call | user input (an environment variable) |
 | test.cpp:135:3:135:8 | call to malloc | test.cpp:133:19:133:32 | call to getenv indirection | test.cpp:135:10:135:27 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:133:19:133:32 | call to getenv indirection | user input (an environment variable) |
-| test.cpp:152:4:152:9 | call to malloc | test.cpp:148:20:148:25 | call to getenv | test.cpp:152:11:152:28 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:148:20:148:25 | call to getenv | user input (an environment variable) |
+| test.cpp:152:4:152:9 | call to malloc | test.cpp:148:20:148:25 | Call | test.cpp:152:11:152:28 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:148:20:148:25 | Call | user input (an environment variable) |
 | test.cpp:152:4:152:9 | call to malloc | test.cpp:148:20:148:33 | call to getenv indirection | test.cpp:152:11:152:28 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:148:20:148:33 | call to getenv indirection | user input (an environment variable) |
-| test.cpp:225:14:225:19 | call to malloc | test.cpp:237:24:237:29 | call to getenv | test.cpp:225:21:225:21 | s | This allocation size is derived from $@ and might overflow. | test.cpp:237:24:237:29 | call to getenv | user input (an environment variable) |
+| test.cpp:225:14:225:19 | call to malloc | test.cpp:237:24:237:29 | Call | test.cpp:225:21:225:21 | s | This allocation size is derived from $@ and might overflow. | test.cpp:237:24:237:29 | Call | user input (an environment variable) |
 | test.cpp:225:14:225:19 | call to malloc | test.cpp:237:24:237:37 | call to getenv indirection | test.cpp:225:21:225:21 | s | This allocation size is derived from $@ and might overflow. | test.cpp:237:24:237:37 | call to getenv indirection | user input (an environment variable) |
-| test.cpp:231:14:231:19 | call to malloc | test.cpp:237:24:237:29 | call to getenv | test.cpp:231:21:231:21 | s | This allocation size is derived from $@ and might overflow. | test.cpp:237:24:237:29 | call to getenv | user input (an environment variable) |
+| test.cpp:231:14:231:19 | call to malloc | test.cpp:237:24:237:29 | Call | test.cpp:231:21:231:21 | s | This allocation size is derived from $@ and might overflow. | test.cpp:237:24:237:29 | Call | user input (an environment variable) |
 | test.cpp:231:14:231:19 | call to malloc | test.cpp:237:24:237:37 | call to getenv indirection | test.cpp:231:21:231:21 | s | This allocation size is derived from $@ and might overflow. | test.cpp:237:24:237:37 | call to getenv indirection | user input (an environment variable) |
-| test.cpp:239:2:239:7 | call to malloc | test.cpp:237:24:237:29 | call to getenv | test.cpp:239:9:239:18 | local_size | This allocation size is derived from $@ and might overflow. | test.cpp:237:24:237:29 | call to getenv | user input (an environment variable) |
+| test.cpp:239:2:239:7 | call to malloc | test.cpp:237:24:237:29 | Call | test.cpp:239:9:239:18 | local_size | This allocation size is derived from $@ and might overflow. | test.cpp:237:24:237:29 | Call | user input (an environment variable) |
 | test.cpp:239:2:239:7 | call to malloc | test.cpp:237:24:237:37 | call to getenv indirection | test.cpp:239:9:239:18 | local_size | This allocation size is derived from $@ and might overflow. | test.cpp:237:24:237:37 | call to getenv indirection | user input (an environment variable) |
-| test.cpp:241:2:241:7 | call to malloc | test.cpp:211:14:211:19 | call to getenv | test.cpp:241:9:241:24 | call to get_tainted_size | This allocation size is derived from $@ and might overflow. | test.cpp:211:14:211:19 | call to getenv | user input (an environment variable) |
+| test.cpp:241:2:241:7 | call to malloc | test.cpp:211:14:211:19 | Call | test.cpp:241:9:241:24 | call to get_tainted_size | This allocation size is derived from $@ and might overflow. | test.cpp:211:14:211:19 | Call | user input (an environment variable) |
 | test.cpp:241:2:241:7 | call to malloc | test.cpp:211:14:211:27 | call to getenv indirection | test.cpp:241:9:241:24 | call to get_tainted_size | This allocation size is derived from $@ and might overflow. | test.cpp:211:14:211:27 | call to getenv indirection | user input (an environment variable) |
-| test.cpp:263:4:263:9 | call to malloc | test.cpp:259:20:259:25 | call to getenv | test.cpp:263:11:263:29 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:259:20:259:25 | call to getenv | user input (an environment variable) |
+| test.cpp:263:4:263:9 | call to malloc | test.cpp:259:20:259:25 | Call | test.cpp:263:11:263:29 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:259:20:259:25 | Call | user input (an environment variable) |
 | test.cpp:263:4:263:9 | call to malloc | test.cpp:259:20:259:33 | call to getenv indirection | test.cpp:263:11:263:29 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:259:20:259:33 | call to getenv indirection | user input (an environment variable) |
-| test.cpp:291:4:291:9 | call to malloc | test.cpp:251:18:251:23 | call to getenv | test.cpp:291:11:291:28 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:251:18:251:23 | call to getenv | user input (an environment variable) |
+| test.cpp:291:4:291:9 | call to malloc | test.cpp:251:18:251:23 | Call | test.cpp:291:11:291:28 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:251:18:251:23 | Call | user input (an environment variable) |
 | test.cpp:291:4:291:9 | call to malloc | test.cpp:251:18:251:31 | call to getenv indirection | test.cpp:291:11:291:28 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:251:18:251:31 | call to getenv indirection | user input (an environment variable) |
-| test.cpp:308:3:308:8 | call to malloc | test.cpp:251:18:251:23 | call to getenv | test.cpp:308:10:308:27 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:251:18:251:23 | call to getenv | user input (an environment variable) |
+| test.cpp:308:3:308:8 | call to malloc | test.cpp:251:18:251:23 | Call | test.cpp:308:10:308:27 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:251:18:251:23 | Call | user input (an environment variable) |
 | test.cpp:308:3:308:8 | call to malloc | test.cpp:251:18:251:31 | call to getenv indirection | test.cpp:308:10:308:27 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:251:18:251:31 | call to getenv indirection | user input (an environment variable) |
-| test.cpp:342:18:342:23 | call to malloc | test.cpp:338:19:338:24 | call to getenv | test.cpp:342:25:342:43 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:338:19:338:24 | call to getenv | user input (an environment variable) |
+| test.cpp:342:18:342:23 | call to malloc | test.cpp:338:19:338:24 | Call | test.cpp:342:25:342:43 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:338:19:338:24 | Call | user input (an environment variable) |
 | test.cpp:342:18:342:23 | call to malloc | test.cpp:338:19:338:32 | call to getenv indirection | test.cpp:342:25:342:43 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:338:19:338:32 | call to getenv indirection | user input (an environment variable) |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextFileWrite.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextFileWrite.expected
@@ -1,9 +1,14 @@
 edges
 | test2.cpp:62:18:62:25 | password | test2.cpp:65:31:65:34 | cpy1 |
 | test2.cpp:72:15:72:24 | password | test2.cpp:73:30:73:32 | buf |
+| test2.cpp:72:15:72:24 | password | test2.cpp:73:30:73:32 | buf |
+| test2.cpp:72:15:72:24 | password | test2.cpp:76:30:76:32 | buf |
 | test2.cpp:72:15:72:24 | password | test2.cpp:76:30:76:32 | buf |
 | test2.cpp:72:17:72:24 | password | test2.cpp:73:30:73:32 | buf |
+| test2.cpp:72:17:72:24 | password | test2.cpp:73:30:73:32 | buf |
 | test2.cpp:72:17:72:24 | password | test2.cpp:76:30:76:32 | buf |
+| test2.cpp:72:17:72:24 | password | test2.cpp:76:30:76:32 | buf |
+| test2.cpp:98:45:98:52 | password | test2.cpp:99:27:99:32 | buffer |
 | test2.cpp:98:45:98:52 | password | test2.cpp:99:27:99:32 | buffer |
 | test.cpp:45:9:45:19 | thePassword | test.cpp:45:9:45:19 | thePassword |
 | test.cpp:45:9:45:19 | thePassword | test.cpp:45:9:45:19 | thePassword |
@@ -36,10 +41,13 @@ nodes
 | test2.cpp:72:15:72:24 | password | semmle.label | password |
 | test2.cpp:72:17:72:24 | password | semmle.label | password |
 | test2.cpp:73:30:73:32 | buf | semmle.label | buf |
+| test2.cpp:73:30:73:32 | buf | semmle.label | buf |
+| test2.cpp:76:30:76:32 | buf | semmle.label | buf |
 | test2.cpp:76:30:76:32 | buf | semmle.label | buf |
 | test2.cpp:86:36:86:43 | password | semmle.label | password |
 | test2.cpp:91:50:91:63 | passwd_config2 | semmle.label | passwd_config2 |
 | test2.cpp:98:45:98:52 | password | semmle.label | password |
+| test2.cpp:99:27:99:32 | buffer | semmle.label | buffer |
 | test2.cpp:99:27:99:32 | buffer | semmle.label | buffer |
 | test.cpp:45:9:45:19 | thePassword | semmle.label | thePassword |
 | test.cpp:45:9:45:19 | thePassword | semmle.label | thePassword |
@@ -64,9 +72,14 @@ subpaths
 | test2.cpp:57:2:57:8 | call to fprintf | test2.cpp:57:39:57:49 | call to getPassword | test2.cpp:57:39:57:49 | call to getPassword | This write into file 'log' may contain unencrypted data from $@. | test2.cpp:57:39:57:49 | call to getPassword | this source. |
 | test2.cpp:65:3:65:9 | call to fprintf | test2.cpp:62:18:62:25 | password | test2.cpp:65:31:65:34 | cpy1 | This write into file 'log' may contain unencrypted data from $@. | test2.cpp:62:18:62:25 | password | this source. |
 | test2.cpp:73:3:73:9 | call to fprintf | test2.cpp:72:15:72:24 | password | test2.cpp:73:30:73:32 | buf | This write into file 'log' may contain unencrypted data from $@. | test2.cpp:72:17:72:24 | password | this source. |
+| test2.cpp:73:3:73:9 | call to fprintf | test2.cpp:72:15:72:24 | password | test2.cpp:73:30:73:32 | buf | This write into file 'log' may contain unencrypted data from $@. | test2.cpp:72:17:72:24 | password | this source. |
+| test2.cpp:73:3:73:9 | call to fprintf | test2.cpp:72:17:72:24 | password | test2.cpp:73:30:73:32 | buf | This write into file 'log' may contain unencrypted data from $@. | test2.cpp:72:17:72:24 | password | this source. |
 | test2.cpp:73:3:73:9 | call to fprintf | test2.cpp:72:17:72:24 | password | test2.cpp:73:30:73:32 | buf | This write into file 'log' may contain unencrypted data from $@. | test2.cpp:72:17:72:24 | password | this source. |
 | test2.cpp:76:3:76:9 | call to fprintf | test2.cpp:72:15:72:24 | password | test2.cpp:76:30:76:32 | buf | This write into file 'log' may contain unencrypted data from $@. | test2.cpp:72:17:72:24 | password | this source. |
+| test2.cpp:76:3:76:9 | call to fprintf | test2.cpp:72:15:72:24 | password | test2.cpp:76:30:76:32 | buf | This write into file 'log' may contain unencrypted data from $@. | test2.cpp:72:17:72:24 | password | this source. |
 | test2.cpp:76:3:76:9 | call to fprintf | test2.cpp:72:17:72:24 | password | test2.cpp:76:30:76:32 | buf | This write into file 'log' may contain unencrypted data from $@. | test2.cpp:72:17:72:24 | password | this source. |
+| test2.cpp:76:3:76:9 | call to fprintf | test2.cpp:72:17:72:24 | password | test2.cpp:76:30:76:32 | buf | This write into file 'log' may contain unencrypted data from $@. | test2.cpp:72:17:72:24 | password | this source. |
+| test2.cpp:99:3:99:9 | call to fprintf | test2.cpp:98:45:98:52 | password | test2.cpp:99:27:99:32 | buffer | This write into file 'log' may contain unencrypted data from $@. | test2.cpp:98:45:98:52 | password | this source. |
 | test2.cpp:99:3:99:9 | call to fprintf | test2.cpp:98:45:98:52 | password | test2.cpp:99:27:99:32 | buffer | This write into file 'log' may contain unencrypted data from $@. | test2.cpp:98:45:98:52 | password | this source. |
 | test.cpp:45:3:45:7 | call to fputs | test.cpp:45:9:45:19 | thePassword | test.cpp:45:9:45:19 | thePassword | This write into file 'file' may contain unencrypted data from $@. | test.cpp:45:9:45:19 | thePassword | this source. |
 | test.cpp:45:3:45:7 | call to fputs | test.cpp:45:9:45:19 | thePassword | test.cpp:45:9:45:19 | thePassword | This write into file 'file' may contain unencrypted data from $@. | test.cpp:45:9:45:19 | thePassword | this source. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-497/SAMATE/PotentiallyExposedSystemData.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-497/SAMATE/PotentiallyExposedSystemData.expected
@@ -1,8 +1,11 @@
 edges
 | tests.c:57:21:57:28 | password | tests.c:70:70:70:77 | password |
+| tests.c:57:21:57:28 | password | tests.c:70:70:70:77 | password |
 nodes
 | tests.c:57:21:57:28 | password | semmle.label | password |
 | tests.c:70:70:70:77 | password | semmle.label | password |
+| tests.c:70:70:70:77 | password | semmle.label | password |
 subpaths
 #select
+| tests.c:70:70:70:77 | password | tests.c:57:21:57:28 | password | tests.c:70:70:70:77 | password | This operation potentially exposes sensitive system data from $@. | tests.c:57:21:57:28 | password | password |
 | tests.c:70:70:70:77 | password | tests.c:57:21:57:28 | password | tests.c:70:70:70:77 | password | This operation potentially exposes sensitive system data from $@. | tests.c:57:21:57:28 | password | password |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-497/semmle/tests/ExposedSystemData.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-497/semmle/tests/ExposedSystemData.expected
@@ -8,6 +8,7 @@ edges
 | tests2.cpp:66:13:66:18 | call to getenv | tests2.cpp:66:13:66:34 | call to getenv |
 | tests2.cpp:78:18:78:38 | call to mysql_get_client_info | tests2.cpp:81:14:81:19 | buffer |
 | tests2.cpp:78:18:78:38 | call to mysql_get_client_info | tests2.cpp:81:14:81:19 | buffer |
+| tests2.cpp:78:18:78:38 | call to mysql_get_client_info | tests2.cpp:81:14:81:19 | buffer |
 | tests2.cpp:82:14:82:20 | Load | tests2.cpp:82:14:82:20 | global1 |
 | tests2.cpp:91:42:91:45 | str1 | tests2.cpp:93:14:93:17 | str1 |
 | tests2.cpp:101:8:101:15 | call to getpwuid | tests2.cpp:102:14:102:15 | pw |
@@ -48,6 +49,7 @@ nodes
 | tests2.cpp:80:14:80:34 | call to mysql_get_client_info | semmle.label | call to mysql_get_client_info |
 | tests2.cpp:81:14:81:19 | buffer | semmle.label | buffer |
 | tests2.cpp:81:14:81:19 | buffer | semmle.label | buffer |
+| tests2.cpp:81:14:81:19 | buffer | semmle.label | buffer |
 | tests2.cpp:82:14:82:20 | Load | semmle.label | Load |
 | tests2.cpp:82:14:82:20 | global1 | semmle.label | global1 |
 | tests2.cpp:91:42:91:45 | str1 | semmle.label | str1 |
@@ -81,7 +83,6 @@ subpaths
 | tests2.cpp:65:13:65:18 | call to getenv | tests2.cpp:65:13:65:18 | call to getenv | tests2.cpp:65:13:65:18 | call to getenv | This operation exposes system data from $@. | tests2.cpp:65:13:65:18 | call to getenv | call to getenv |
 | tests2.cpp:66:13:66:18 | call to getenv | tests2.cpp:66:13:66:18 | call to getenv | tests2.cpp:66:13:66:18 | call to getenv | This operation exposes system data from $@. | tests2.cpp:66:13:66:18 | call to getenv | call to getenv |
 | tests2.cpp:80:14:80:34 | call to mysql_get_client_info | tests2.cpp:80:14:80:34 | call to mysql_get_client_info | tests2.cpp:80:14:80:34 | call to mysql_get_client_info | This operation exposes system data from $@. | tests2.cpp:80:14:80:34 | call to mysql_get_client_info | call to mysql_get_client_info |
-| tests2.cpp:81:14:81:19 | buffer | tests2.cpp:78:18:78:38 | call to mysql_get_client_info | tests2.cpp:81:14:81:19 | buffer | This operation exposes system data from $@. | tests2.cpp:78:18:78:38 | call to mysql_get_client_info | call to mysql_get_client_info |
 | tests2.cpp:81:14:81:19 | buffer | tests2.cpp:78:18:78:38 | call to mysql_get_client_info | tests2.cpp:81:14:81:19 | buffer | This operation exposes system data from $@. | tests2.cpp:78:18:78:38 | call to mysql_get_client_info | call to mysql_get_client_info |
 | tests2.cpp:82:14:82:20 | global1 | tests2.cpp:50:23:50:43 | call to mysql_get_client_info | tests2.cpp:82:14:82:20 | global1 | This operation exposes system data from $@. | tests2.cpp:50:23:50:43 | call to mysql_get_client_info | call to mysql_get_client_info |
 | tests2.cpp:93:14:93:17 | str1 | tests2.cpp:91:42:91:45 | str1 | tests2.cpp:93:14:93:17 | str1 | This operation exposes system data from $@. | tests2.cpp:91:42:91:45 | str1 | str1 |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-497/semmle/tests/PotentiallyExposedSystemData.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-497/semmle/tests/PotentiallyExposedSystemData.expected
@@ -18,6 +18,7 @@ edges
 | tests.cpp:107:30:107:32 | msg | tests.cpp:111:15:111:17 | tmp |
 | tests.cpp:114:30:114:32 | msg | tests.cpp:119:7:119:12 | buffer |
 | tests.cpp:114:30:114:32 | msg | tests.cpp:119:7:119:12 | buffer |
+| tests.cpp:114:30:114:32 | msg | tests.cpp:119:7:119:12 | buffer |
 | tests.cpp:122:30:122:32 | msg | tests.cpp:124:15:124:17 | msg |
 | tests.cpp:131:14:131:19 | call to getenv | tests.cpp:131:14:131:35 | call to getenv |
 | tests.cpp:131:14:131:35 | call to getenv | tests.cpp:107:30:107:32 | msg |
@@ -65,6 +66,7 @@ nodes
 | tests.cpp:114:30:114:32 | msg | semmle.label | msg |
 | tests.cpp:119:7:119:12 | buffer | semmle.label | buffer |
 | tests.cpp:119:7:119:12 | buffer | semmle.label | buffer |
+| tests.cpp:119:7:119:12 | buffer | semmle.label | buffer |
 | tests.cpp:122:30:122:32 | msg | semmle.label | msg |
 | tests.cpp:124:15:124:17 | msg | semmle.label | msg |
 | tests.cpp:131:14:131:19 | call to getenv | semmle.label | call to getenv |
@@ -98,6 +100,7 @@ subpaths
 | tests.cpp:97:13:97:18 | call to getenv | tests.cpp:97:13:97:18 | call to getenv | tests.cpp:97:13:97:18 | call to getenv | This operation potentially exposes sensitive system data from $@. | tests.cpp:97:13:97:18 | call to getenv | call to getenv |
 | tests.cpp:97:13:97:34 | call to getenv | tests.cpp:97:13:97:18 | call to getenv | tests.cpp:97:13:97:34 | call to getenv | This operation potentially exposes sensitive system data from $@. | tests.cpp:97:13:97:18 | call to getenv | call to getenv |
 | tests.cpp:111:15:111:17 | tmp | tests.cpp:131:14:131:19 | call to getenv | tests.cpp:111:15:111:17 | tmp | This operation potentially exposes sensitive system data from $@. | tests.cpp:131:14:131:19 | call to getenv | call to getenv |
+| tests.cpp:119:7:119:12 | buffer | tests.cpp:132:14:132:19 | call to getenv | tests.cpp:119:7:119:12 | buffer | This operation potentially exposes sensitive system data from $@. | tests.cpp:132:14:132:19 | call to getenv | call to getenv |
 | tests.cpp:119:7:119:12 | buffer | tests.cpp:132:14:132:19 | call to getenv | tests.cpp:119:7:119:12 | buffer | This operation potentially exposes sensitive system data from $@. | tests.cpp:132:14:132:19 | call to getenv | call to getenv |
 | tests.cpp:119:7:119:12 | buffer | tests.cpp:132:14:132:19 | call to getenv | tests.cpp:119:7:119:12 | buffer | This operation potentially exposes sensitive system data from $@. | tests.cpp:132:14:132:19 | call to getenv | call to getenv |
 | tests.cpp:124:15:124:17 | msg | tests.cpp:133:14:133:19 | call to getenv | tests.cpp:124:15:124:17 | msg | This operation potentially exposes sensitive system data from $@. | tests.cpp:133:14:133:19 | call to getenv | call to getenv |


### PR DESCRIPTION
This fixes a performance problem I observed on `cmake`. The problem happened in the `getBufferSize`'s predicate, where we have a case that searches backwards through expressions using `DataFlow::localExprFlowStep`. The code that exhibited the performance problem looked _something_ like:
```cpp
void foo() {
  int a[65536];

  a[0] = ...;
  a[1] = ...;
  ...
  a[65535] = ...;

  for(int i = 0; i < ...; ++i) {
    use(a[i]);
  }
}
```
and, while `DataFlow::localFlowStep` would handle this code perfectly well, the `DataFlow::localExprFlowStep` predicate (which has an additional transitive closure internally to step to the nearest `DataFlow::Node` that has an `asExpr()` result) would explode because the node that received flow from one assignment (i.e., `a[k] = ...;`) to the next (i.e., `a[k+1] = ...;`) wouldn't be the node that had a result for `asExpr()`.

This PR changes `asExpr` so that `Expr` flow will proceed as `a[0] = ...;` -> `a[1] = ...;` -> `...` -> `a[65536] = ...;` -> `use(a[i])`.