### PR TITLE
Specify language names in extractor packs

### DIFF
--- a/csharp/codeql-extractor.yml
+++ b/csharp/codeql-extractor.yml
@@ -4,6 +4,10 @@ version: 1.22.1
 column_kind: "utf16"
 extra_env_vars:
   DOTNET_GENERATE_ASPNET_CERTIFICATE: "false"
+github_api_languages:
+  - C#
+scc_languages:
+  - C#
 file_types:
   - name: cs
     display_name: C# sources

--- a/go/codeql-extractor.yml
+++ b/go/codeql-extractor.yml
@@ -6,6 +6,10 @@ pull_request_triggers:
   - "**/glide.yaml"
   - "**/Gopkg.toml"
 column_kind: "utf8"
+github_api_languages:
+  - Go
+scc_languages:
+  - Go
 file_types:
   - name: go
     display_name: Go

--- a/ql/codeql-extractor.yml
+++ b/ql/codeql-extractor.yml
@@ -3,6 +3,10 @@ display_name: "QL"
 version: 0.0.1
 column_kind: "utf8"
 legacy_qltest_extraction: true
+github_api_languages:
+  - CodeQL
+scc_languages:
+  - CodeQL
 file_types:
   - name: ql
     display_name: QL query files

--- a/ruby/codeql-extractor.yml
+++ b/ruby/codeql-extractor.yml
@@ -3,6 +3,10 @@ display_name: "Ruby"
 version: 0.1.0
 column_kind: "utf8"
 legacy_qltest_extraction: true
+github_api_languages:
+  - Ruby
+scc_languages:
+  - Ruby
 file_types:
   - name: ruby
     display_name: Ruby files

--- a/swift/codeql-extractor.yml
+++ b/swift/codeql-extractor.yml
@@ -3,6 +3,10 @@ display_name: "Swift"
 version: 0.0.1
 column_kind: "utf8"
 legacy_qltest_extraction: true
+github_api_languages:
+  - Swift
+scc_languages:
+  - Swift
 file_types:
   - name: swift
     display_name: Swift files


### PR DESCRIPTION
This PR specifies GitHub API and SCC language names in the `codeql-extractor.yml` file for extractor packs defined within `github/semmle-code`.  These properties define how language autodetection and baseline information is computed.

This functionality was introduced in CodeQL CLI 2.11.4, and lets us avoid hardcoding this information in the CLI.  The overall goal is to minimise the number of places we need to modify to define a new language.