### PR TITLE
Update annotations-in-java.rst

### DIFF
--- a/docs/codeql/codeql-language-guides/annotations-in-java.rst
+++ b/docs/codeql/codeql-language-guides/annotations-in-java.rst
@@ -185,7 +185,7 @@ For more information about the class ``Call``, see ":doc:`Navigating the call gr
 Improvements
 ~~~~~~~~~~~~
 
-The Java standard library provides another annotation type ``java.lang.SupressWarnings`` that can be used to suppress certain categories of warnings. In particular, it can be used to turn off warnings about calls to deprecated methods. Therefore, it makes sense to improve our query to ignore calls to deprecated methods from inside methods that are marked with ``@SuppressWarnings("deprecated")``.
+The Java standard library provides another annotation type ``java.lang.SupressWarnings`` that can be used to suppress certain categories of warnings. In particular, it can be used to turn off warnings about calls to deprecated methods. Therefore, it makes sense to improve our query to ignore calls to deprecated methods from inside methods that are marked with ``@SuppressWarnings("deprecation")``.
 
 For instance, consider this slightly updated example:
 
@@ -198,7 +198,7 @@ For instance, consider this slightly updated example:
            m();
        }
 
-       @SuppressWarnings("deprecated")
+       @SuppressWarnings("deprecation")
        void r() {
            m();
        }
@@ -206,7 +206,7 @@ For instance, consider this slightly updated example:
 
 Here, the programmer has explicitly suppressed warnings about deprecated calls in ``A.r``, so our query should not flag the call to ``A.m`` any more.
 
-To do so, we first introduce a class for representing all ``@SuppressWarnings`` annotations where the string ``deprecated`` occurs among the list of warnings to suppress:
+To do so, we first introduce a class for representing all ``@SuppressWarnings`` annotations where the string ``deprecation`` occurs among the list of warnings to suppress:
 
 .. code-block:: ql
 


### PR DESCRIPTION
A typo in the SuppressWarnings's annotation value, it should be `deprecation` and not `deprecated` , here is a full list of the possible values for this annotation:
- all: this is sort of a wildcard that suppresses all warnings
- boxing: suppresses warnings related to boxing/unboxing operations
- unused: suppresses warnings of unused code
- cast: suppresses warnings related to object cast operations
- deprecation: suppresses warnings related to deprecation, such as a deprecated class or method
- restriction: suppresses warnings related to the usage of discouraged or forbidden references
- dep-ann: suppresses warnings relative to deprecated annotations
- fallthrough: suppresses warnings related to missing break statements in switch statements
- finally: suppresses warnings related to finally blocks that don't return
- hiding: suppresses warnings relative to locals that hide variables
- incomplete-switch: suppresses warnings relative to missing entries in a switch statement (enum case)
- nls: suppresses warnings related to non-nls string literals
- null: suppresses warnings related to null analysis
- serial: suppresses warnings related to the missing serialVersionUID field, which is typically found in a Serializable class
- static-access: suppresses warnings related to incorrect static variable access
- synthetic-access: suppresses warnings related to unoptimized access from inner classes
- unchecked: suppresses warnings related to unchecked operations
- unqualified-field-access: suppresses warnings related to unqualified field access
- javadoc: suppresses warnings related to Javadoc
- rawtypes: suppresses warnings related to the usage of raw types
- resource: suppresses warnings related to the usage of resources of type Closeable
- super: suppresses warnings related to overriding a method without super invocations
- sync-override: suppresses warnings due to missing synchronize when overriding a synchronized method 
ref: https://www.baeldung.com/java-suppresswarnings-valid-names