### PR TITLE
Ruby: Fix compile error in test

### DIFF
--- a/ruby/ql/test/library-tests/dataflow/flow-summaries/semantics.ql
+++ b/ruby/ql/test/library-tests/dataflow/flow-summaries/semantics.ql
@@ -11,9 +11,10 @@ private import codeql.ruby.dataflow.FlowSummary
 /**
  * A convenience class for defining value (c.f. taint) flow summaries.
  */
-bindingset[this]
 abstract private class Summary extends SimpleSummarizedCallable {
   bindingset[this]
+  Summary() { this = this }
+
   override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
     this.propagates(input, output) and preservesValue = true
   }

--- a/ruby/ql/test/library-tests/dataflow/flow-summaries/semantics.ql
+++ b/ruby/ql/test/library-tests/dataflow/flow-summaries/semantics.ql
@@ -13,7 +13,7 @@ private import codeql.ruby.dataflow.FlowSummary
  */
 abstract private class Summary extends SimpleSummarizedCallable {
   bindingset[this]
-  Summary() { this = this }
+  Summary() { any() }
 
   override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
     this.propagates(input, output) and preservesValue = true


### PR DESCRIPTION
We currently get this error on main: `This predicate has weaker binding sets than the predicate it overrides. The overridden predicate is declared by SummarizedCallable. (semantics.ql:17,22-39)`.  

I think it's a semantic merge conflict of some kind, because the PR that introduced that line compiles just fine: https://github.com/github/codeql/pull/10899 