### PR TITLE
Add CONTRIBUTING.MD file for contributing to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ There is [extensive documentation](https://codeql.github.com/docs/) on getting s
 
 We welcome contributions to our standard library and standard checks. Do you have an idea for a new check, or how to improve an existing query? Then please go ahead and open a pull request! Before you do, though, please take the time to read our [contributing guidelines](CONTRIBUTING.md). You can also consult our [style guides](https://github.com/github/codeql/tree/main/docs) to learn how to format your code for consistency and clarity, how to write query metadata, and how to write query help documentation for your query.
 
+For information on contributing to CodeQL documentation, see "[the contributing guide](https://github.com/github/codeql/blob/main/docs/codeql/CONTRIBUTING.md)" for docs.
+
 ## License
 
 The code in this repository is licensed under the [MIT License](LICENSE) by [GitHub](https://github.com).

--- a/docs/codeql/CONTRIBUTING.MD
+++ b/docs/codeql/CONTRIBUTING.MD
@@ -1,0 +1,9 @@
+# Contributing to CodeQL docs
+
+We welcome contributions to our CodeQL docs. Want to improve existing docs or add new information you think would be helpful? Then please go ahead and open a pull request!
+
+**Note**: We have recently copied the CodeQL CLI documentation on [codeql.github.com](https://codeql.github.com/docs/codeql-cli/) to the public [github/docs](https://github.com/github/docs) repository so that they appear on the [GitHub Docs](https://docs.github.com/en/code-security/code-scanning) site. This includes all articles under "[Using the CodeQL CLI](https://codeql.github.com/docs/codeql-cli/using-the-codeql-cli/)" and "[CodeQL CLI reference](https://codeql.github.com/docs/codeql-cli/codeql-cli-reference/)" categories. To contribute to these docs, which are located in the [`code-security`](https://github.com/github/docs/tree/main/content/code-security/code-scanning) directory, please refer to the [CONTRIBUTING.md](https://github.com/github/docs/blob/main/CONTRIBUTING.md) file in the `docs` repository.
+
+## Contributing to docs on `codeql.github.com`
+
+To make changes to the remaining documentation on [codeql.github.com](https://codeql.github.com/docs/codeql-cli/), you can make changes to the documentation files using the GitHub UI, a codespace, or making changes locally, and then open a pull request for review. For more information about the format and structure of the CodeQL documentation on [codeql.github.com](https://codeql.github.com/docs/codeql-cli/), please see the [README](https://github.com/github/codeql/tree/main/docs/codeql#readme). 

--- a/docs/codeql/README.rst
+++ b/docs/codeql/README.rst
@@ -12,6 +12,8 @@ see https://docutils.sourceforge.io/rst.html.
 
 For more information on Sphinx, see https://www.sphinx-doc.org.
 
+For information on contributing to CodeQL documentation, see "[the contributing guide](/CONTRIBUTING.md)."
+
 Project structure
 *****************
 


### PR DESCRIPTION
Added a CONTRIBUTING.MD file in the docs directory in the CodeQL repo that contains information on how to contribute to the docs. 

As part of the effort to copy some of the documentation to the [docs](https://github.com/github/docs) repository so that it appears on docs.github.com, this file also contains information and links to how to contribute to the docs repository. Also includes links to this file from existing READMEs. 