### PR TITLE
C++: Fix the expression kind in two of the downgrade scripts

### DIFF
--- a/cpp/downgrades/23f7cbb88a4eb29f30c3490363dc201bc054c5ff/exprs.ql
+++ b/cpp/downgrades/23f7cbb88a4eb29f30c3490363dc201bc054c5ff/exprs.ql
@@ -13,5 +13,5 @@ predicate isExprWithNewBuiltin(Expr expr) {
 from Expr expr, int kind, int kind_new, Location location
 where
   exprs(expr, kind, location) and
-  if isExprWithNewBuiltin(expr) then kind_new = 0 else kind_new = kind
+  if isExprWithNewBuiltin(expr) then kind_new = 1 else kind_new = kind
 select expr, kind_new, location

--- a/cpp/downgrades/73af5058c6899dcdb05754c27ca966aeb3a68c94/exprs.ql
+++ b/cpp/downgrades/73af5058c6899dcdb05754c27ca966aeb3a68c94/exprs.ql
@@ -9,5 +9,5 @@ class Location extends @location_expr {
 from Expr expr, int kind, int kind_new, Location location
 where
   exprs(expr, kind, location) and
-  if expr instanceof @blockassignexpr then kind_new = 0 else kind_new = kind
+  if expr instanceof @blockassignexpr then kind_new = 1 else kind_new = kind
 select expr, kind_new, location


### PR DESCRIPTION
A 0 value for the expression kind is not valid, as 0 does not occur in the relevant case split. This should have been the value of `@errorexpr`, which is 1.