### PR TITLE
Python: fix downgrade script

### DIFF
--- a/python/downgrades/503c0516fba2e5da9570f00eb34ef43025ecb8fb/py_exprs.ql
+++ b/python/downgrades/503c0516fba2e5da9570f00eb34ef43025ecb8fb/py_exprs.ql
@@ -23,15 +23,17 @@ class ExprParent_ extends @py_expr_parent {
  * New kinds have been inserted such that
  * `@py_Name` which used to have index 18 now has index 19.
  * Entries with lower indices are unchanged.
+ *
+ * Note that if `18 <= new_index < 19`, it does not correspond
+ * to an old index.
  */
 bindingset[new_index]
 int old_index(int new_index) {
-  if new_index < 18
-  then result = new_index
-  else
-    if new_index >= 19
-    then result + (19 - 18) = new_index
-    else none()
+  // before inserted range
+  new_index < 18 and result = new_index
+  or
+  // after inserted range
+  new_index >= 19 and result + (19 - 18) = new_index
 }
 
 // The schema for py_exprs is:

--- a/python/downgrades/503c0516fba2e5da9570f00eb34ef43025ecb8fb/py_exprs.ql
+++ b/python/downgrades/503c0516fba2e5da9570f00eb34ef43025ecb8fb/py_exprs.ql
@@ -26,7 +26,12 @@ class ExprParent_ extends @py_expr_parent {
  */
 bindingset[new_index]
 int old_index(int new_index) {
-  if new_index < 18 then result = new_index else result + (19 - 18) = new_index
+  if new_index < 18
+  then result = new_index
+  else
+    if new_index >= 19
+    then result + (19 - 18) = new_index
+    else none()
 }
 
 // The schema for py_exprs is:

--- a/python/downgrades/503c0516fba2e5da9570f00eb34ef43025ecb8fb/py_stmts.ql
+++ b/python/downgrades/503c0516fba2e5da9570f00eb34ef43025ecb8fb/py_stmts.ql
@@ -23,15 +23,17 @@ class StmtList_ extends @py_stmt_list {
  * New kinds have been inserted such that
  * `@py_Nonlocal` which used to have index 14 now has index 16.
  * Entries with lower indices are unchanged.
+ *
+ * Note that if `14 <= new_index < 16`, it does not correspond
+ * to an old index.
  */
 bindingset[new_index]
 int old_index(int new_index) {
-  if new_index < 14
-  then result = new_index
-  else
-    if new_index >= 16
-    then result + (16 - 14) = new_index
-    else none()
+  // before inserted range
+  new_index < 14 and result = new_index
+  or
+  // after inserted range
+  new_index >= 16 and result + (16 - 14) = new_index
 }
 
 // The schema for py_stmts is:

--- a/python/downgrades/503c0516fba2e5da9570f00eb34ef43025ecb8fb/py_stmts.ql
+++ b/python/downgrades/503c0516fba2e5da9570f00eb34ef43025ecb8fb/py_stmts.ql
@@ -26,7 +26,12 @@ class StmtList_ extends @py_stmt_list {
  */
 bindingset[new_index]
 int old_index(int new_index) {
-  if new_index < 14 then result = new_index else result + (16 - 14) = new_index
+  if new_index < 14
+  then result = new_index
+  else
+    if new_index >= 16
+    then result + (16 - 14) = new_index
+    else none()
 }
 
 // The schema for py_stmts is:


### PR DESCRIPTION
When new kinds are inserted, new indices exists that do not correspond to any old indices.
These were previously mapped, now they are not.

We need tests in this area...