### PR TITLE
Java: fix typos in MaD row `name` columns for `MappingSqlQuery` and `MappingSqlQueryWithParameters`

### DIFF
--- a/java/ql/lib/change-notes/2023-01-05-fix-mad-typos.md
+++ b/java/ql/lib/change-notes/2023-01-05-fix-mad-typos.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Added sink models for the constructors of `org.springframework.jdbc.object.MappingSqlQuery` and `org.springframework.jdbc.object.MappingSqlQueryWithParameters`.

--- a/java/ql/lib/ext/org.springframework.jdbc.object.model.yml
+++ b/java/ql/lib/ext/org.springframework.jdbc.object.model.yml
@@ -4,8 +4,8 @@ extensions:
       extensible: sinkModel
     data:
       - ["org.springframework.jdbc.object", "BatchSqlUpdate", False, "BatchSqlUpdate", "", "", "Argument[1]", "sql", "manual"]
-      - ["org.springframework.jdbc.object", "MappingSqlQuery", False, "BatchSqlUpdate", "", "", "Argument[1]", "sql", "manual"]
-      - ["org.springframework.jdbc.object", "MappingSqlQueryWithParameters", False, "BatchSqlUpdate", "", "", "Argument[1]", "sql", "manual"]
+      - ["org.springframework.jdbc.object", "MappingSqlQuery", False, "MappingSqlQuery", "", "", "Argument[1]", "sql", "manual"]
+      - ["org.springframework.jdbc.object", "MappingSqlQueryWithParameters", False, "MappingSqlQueryWithParameters", "", "", "Argument[1]", "sql", "manual"]
       - ["org.springframework.jdbc.object", "RdbmsOperation", True, "setSql", "", "", "Argument[0]", "sql", "manual"]
       - ["org.springframework.jdbc.object", "SqlCall", False, "SqlCall", "", "", "Argument[1]", "sql", "manual"]
       - ["org.springframework.jdbc.object", "SqlFunction", False, "SqlFunction", "", "", "Argument[1]", "sql", "manual"]


### PR DESCRIPTION
### Description
This PR fixes a couple typos in the MaD row `name` columns for `MappingSqlQuery` and `MappingSqlQueryWithParameters`.
The documentation for [`MappingSqlQuery`](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/jdbc/object/MappingSqlQuery.html) and for [`MappingSqlQueryWithParameters`](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/jdbc/object/MappingSqlQueryWithParameters.html) do not contain `BatchSqlUpdate` methods, but the constructors for each of these classes does take an “sql” argument as the second parameter.

### Consideration
Let me know if a change note is unneeded for this.