### PR TITLE
Go: Handle output from `go version` more gracefully

### DIFF
--- a/go/extractor/cli/go-autobuilder/go-autobuilder.go
+++ b/go/extractor/cli/go-autobuilder/go-autobuilder.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -56,9 +57,21 @@ func getEnvGoVersion() string {
 		if err != nil {
 			log.Fatalf("Unable to run the go command, is it installed?\nError: %s", err.Error())
 		}
-		goVersion = strings.Fields(string(gover))[2]
+		goVersion = parseGoVersion(string(gover))
 	}
 	return goVersion
+}
+
+// The 'go version' command may output warnings on separate lines before
+// the actual version string is printed. This function parses the output
+// to retrieve just the version string.
+func parseGoVersion(data string) string {
+	var lastLine string
+	sc := bufio.NewScanner(strings.NewReader(data))
+	for sc.Scan() {
+		lastLine = sc.Text()
+	}
+	return strings.Fields(lastLine)[2]
 }
 
 // Returns the current Go version in semver format, e.g. v1.14.4

--- a/go/extractor/cli/go-autobuilder/go-autobuilder_test.go
+++ b/go/extractor/cli/go-autobuilder/go-autobuilder_test.go
@@ -20,3 +20,16 @@ func TestGetImportPathFromRepoURL(t *testing.T) {
 		}
 	}
 }
+
+func TestParseGoVersion(t *testing.T) {
+	tests := map[string]string{
+		"go version go1.18.9 linux/amd64": "go1.18.9",
+		"warning: GOPATH set to GOROOT (/usr/local/go) has no effect\ngo version go1.18.9 linux/amd64": "go1.18.9",
+	}
+	for input, expected := range tests {
+		actual := parseGoVersion(input)
+		if actual != expected {
+			t.Errorf("Expected parseGoVersion(\"%s\") to be \"%s\", but got \"%s\".", input, expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
The `go version` command may output warnings prior to outputting the version string. For example, it may produce the following output
```
warning: GOPATH set to GOROOT (/usr/local/go) has no effect
go version go1.18.9 linux/amd64
```
if `GOPATH` is set to `GOROOT`. This currently causes the Go extractor to fail:
```
Expected 'go version' output of the form 'go1.2.3'; got 'set'
```
This PR changes the implementation of the `getEnvGoVersion` function so that it finds the last line of output from `go version` and uses that.