### PR TITLE
Swift: Data flow through optional binding

### DIFF
--- a/swift/ql/lib/codeql/swift/dataflow/Ssa.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/Ssa.qll
@@ -30,9 +30,16 @@ module Ssa {
         certain = true
       )
       or
-      exists(PatternBindingDecl decl, Pattern pattern |
+      // Any variable initialization through pattern matching. For example each `x*` in:
+      // ```
+      // var x1 = v
+      // let x2 = v
+      // let (x3, x4) = tuple
+      // if let x5 = optional { ... }
+      // guard let x6 = optional else { ... }
+      // ```
+      exists(Pattern pattern |
         bb.getNode(i).getNode().asAstNode() = pattern and
-        decl.getAPattern() = pattern and
         v.getParentPattern() = pattern and
         certain = true
       )

--- a/swift/ql/lib/codeql/swift/dataflow/Ssa.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/Ssa.qll
@@ -166,8 +166,8 @@ module Ssa {
         value.(PropertyGetterCfgNode).getRef() = init
       )
       or
-      exists(VarDecl var, SsaInput::BasicBlock bb, int blockIndex, ConditionElement ce, Expr init |
-        this.definesAt(var, bb, blockIndex) and
+      exists(SsaInput::BasicBlock bb, int blockIndex, ConditionElement ce, Expr init |
+        this.definesAt(_, bb, blockIndex) and
         ce.getPattern() = bb.getNode(blockIndex).getNode().asAstNode() and
         init = ce.getInitializer() and
         strictcount(Ssa::WriteDefinition alt | alt.definesAt(_, bb, blockIndex)) = 1 // exclude cases where there are multiple writes from the same pattern, this is at best taint flow.

--- a/swift/ql/lib/codeql/swift/dataflow/Ssa.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/Ssa.qll
@@ -169,7 +169,8 @@ module Ssa {
       exists(VarDecl var, SsaInput::BasicBlock bb, int blockIndex, ConditionElement ce, Expr init |
         this.definesAt(var, bb, blockIndex) and
         ce.getPattern() = bb.getNode(blockIndex).getNode().asAstNode() and
-        init = ce.getInitializer()
+        init = ce.getInitializer() and
+        strictcount(Ssa::WriteDefinition alt | alt.definesAt(_, bb, blockIndex)) = 1 // exclude cases where there are multiple writes from the same pattern, this is at best taint flow.
       |
         value.getNode().asAstNode() = init
       )

--- a/swift/ql/lib/codeql/swift/dataflow/Ssa.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/Ssa.qll
@@ -165,6 +165,14 @@ module Ssa {
         // TODO: We should probably enumerate more cfg nodes here.
         value.(PropertyGetterCfgNode).getRef() = init
       )
+      or
+      exists(VarDecl var, SsaInput::BasicBlock bb, int blockIndex, ConditionElement ce, Expr init |
+        this.definesAt(var, bb, blockIndex) and
+        ce.getPattern() = bb.getNode(blockIndex).getNode().asAstNode() and
+        init = ce.getInitializer()
+      |
+        value.getNode().asAstNode() = init
+      )
     }
   }
 

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPrivate.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPrivate.qll
@@ -119,6 +119,13 @@ private module Cached {
       def.(Ssa::WriteDefinition).assigns(nodeFrom.getCfgNode()) and
       nodeTo.asDefinition() = def
       or
+      // flow through optional binding `if let`, similarly to assignment
+      exists(ConditionElement ce |
+        ce.getInitializer() = nodeFrom.asExpr() and
+        ce.getPattern() = def.getSourceVariable().getParentPattern() and
+        nodeTo.asDefinition() = def
+      )
+      or
       // step from def to first read
       nodeFrom.asDefinition() = def and
       nodeTo.getCfgNode() = def.getAFirstRead() and
@@ -152,13 +159,6 @@ private module Cached {
     nodeFrom.asExpr() = nodeTo.asExpr().(BindOptionalExpr).getSubExpr()
     or
     nodeFrom.asExpr() = nodeTo.asExpr().(OptionalEvaluationExpr).getSubExpr()
-    or
-    // flow through optional binding `if let`
-    exists(ConditionElement ce, ConcreteVarDecl v |
-      ce.getInitializer() = nodeFrom.asExpr() and
-      ce.getPattern() = v.getParentPattern() and
-      nodeTo.asDefinition().getSourceVariable() = v
-    )
     or
     // flow through nil-coalescing operator `??`
     exists(BinaryExpr nco |

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPrivate.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPrivate.qll
@@ -153,6 +153,14 @@ private module Cached {
     or
     nodeFrom.asExpr() = nodeTo.asExpr().(OptionalEvaluationExpr).getSubExpr()
     or
+    // flow through optional binding `if let`
+    exists(ConditionElement ce, ConcreteVarDecl v |
+      ce.getInitializer() = nodeFrom.asExpr() and
+      ce.getPattern() = v.getParentPattern() and
+      //.(OptionalSomePattern).getSubPattern().(BindingPattern).getSubPattern().(NamedPattern) ?
+      nodeTo.asDefinition().getSourceVariable() = v
+    )
+    or
     // flow through nil-coalescing operator `??`
     exists(BinaryExpr nco |
       nco.getOperator().(FreeFunctionDecl).getName() = "??(_:_:)" and

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPrivate.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPrivate.qll
@@ -119,13 +119,6 @@ private module Cached {
       def.(Ssa::WriteDefinition).assigns(nodeFrom.getCfgNode()) and
       nodeTo.asDefinition() = def
       or
-      // flow through optional binding `if let`, similarly to assignment
-      exists(ConditionElement ce |
-        ce.getInitializer() = nodeFrom.asExpr() and
-        ce.getPattern() = def.getSourceVariable().getParentPattern() and
-        nodeTo.asDefinition() = def
-      )
-      or
       // step from def to first read
       nodeFrom.asDefinition() = def and
       nodeTo.getCfgNode() = def.getAFirstRead() and

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPrivate.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPrivate.qll
@@ -157,7 +157,6 @@ private module Cached {
     exists(ConditionElement ce, ConcreteVarDecl v |
       ce.getInitializer() = nodeFrom.asExpr() and
       ce.getPattern() = v.getParentPattern() and
-      //.(OptionalSomePattern).getSubPattern().(BindingPattern).getSubPattern().(NamedPattern) ?
       nodeTo.asDefinition().getSourceVariable() = v
     )
     or

--- a/swift/ql/test/library-tests/dataflow/dataflow/DataFlow.expected
+++ b/swift/ql/test/library-tests/dataflow/dataflow/DataFlow.expected
@@ -142,8 +142,6 @@ edges
 | test.swift:360:15:360:15 | t2 [Tuple element at index 0] :  | test.swift:360:15:360:18 | .0 |
 | test.swift:361:15:361:15 | t2 [Tuple element at index 1] :  | test.swift:361:15:361:18 | .1 |
 | test.swift:439:13:439:28 | call to optionalSource() :  | test.swift:442:19:442:19 | a |
-| test.swift:455:21:455:29 | call to source2() :  | test.swift:456:19:456:19 | x |
-| test.swift:455:21:455:29 | call to source2() :  | test.swift:457:19:457:19 | y |
 nodes
 | file://:0:0:0:0 | .a [x] :  | semmle.label | .a [x] :  |
 | file://:0:0:0:0 | .x :  | semmle.label | .x :  |
@@ -302,9 +300,6 @@ nodes
 | test.swift:361:15:361:18 | .1 | semmle.label | .1 |
 | test.swift:439:13:439:28 | call to optionalSource() :  | semmle.label | call to optionalSource() :  |
 | test.swift:442:19:442:19 | a | semmle.label | a |
-| test.swift:455:21:455:29 | call to source2() :  | semmle.label | call to source2() :  |
-| test.swift:456:19:456:19 | x | semmle.label | x |
-| test.swift:457:19:457:19 | y | semmle.label | y |
 subpaths
 | test.swift:75:21:75:22 | &... :  | test.swift:65:16:65:28 | arg1 :  | test.swift:65:1:70:1 | arg2[return] :  | test.swift:75:31:75:32 | [post] &... :  |
 | test.swift:114:19:114:19 | arg :  | test.swift:109:9:109:14 | arg :  | test.swift:110:12:110:12 | arg :  | test.swift:114:12:114:22 | call to ... :  |
@@ -386,5 +381,3 @@ subpaths
 | test.swift:360:15:360:18 | .0 | test.swift:351:18:351:25 | call to source() :  | test.swift:360:15:360:18 | .0 | result |
 | test.swift:361:15:361:18 | .1 | test.swift:351:31:351:38 | call to source() :  | test.swift:361:15:361:18 | .1 | result |
 | test.swift:442:19:442:19 | a | test.swift:259:12:259:19 | call to source() :  | test.swift:442:19:442:19 | a | result |
-| test.swift:456:19:456:19 | x | test.swift:455:21:455:29 | call to source2() :  | test.swift:456:19:456:19 | x | result |
-| test.swift:457:19:457:19 | y | test.swift:455:21:455:29 | call to source2() :  | test.swift:457:19:457:19 | y | result |

--- a/swift/ql/test/library-tests/dataflow/dataflow/DataFlow.expected
+++ b/swift/ql/test/library-tests/dataflow/dataflow/DataFlow.expected
@@ -100,7 +100,7 @@ edges
 | test.swift:225:14:225:21 | call to source() :  | test.swift:235:13:235:15 | .source_value |
 | test.swift:225:14:225:21 | call to source() :  | test.swift:238:13:238:15 | .source_value |
 | test.swift:259:12:259:19 | call to source() :  | test.swift:263:13:263:28 | call to optionalSource() :  |
-| test.swift:259:12:259:19 | call to source() :  | test.swift:437:13:437:28 | call to optionalSource() :  |
+| test.swift:259:12:259:19 | call to source() :  | test.swift:439:13:439:28 | call to optionalSource() :  |
 | test.swift:263:13:263:28 | call to optionalSource() :  | test.swift:265:15:265:15 | x |
 | test.swift:263:13:263:28 | call to optionalSource() :  | test.swift:267:15:267:16 | ...! |
 | test.swift:263:13:263:28 | call to optionalSource() :  | test.swift:271:15:271:16 | ...? :  |
@@ -141,7 +141,9 @@ edges
 | test.swift:357:15:357:15 | t1 [Tuple element at index 1] :  | test.swift:357:15:357:18 | .1 |
 | test.swift:360:15:360:15 | t2 [Tuple element at index 0] :  | test.swift:360:15:360:18 | .0 |
 | test.swift:361:15:361:15 | t2 [Tuple element at index 1] :  | test.swift:361:15:361:18 | .1 |
-| test.swift:437:13:437:28 | call to optionalSource() :  | test.swift:440:19:440:19 | a |
+| test.swift:439:13:439:28 | call to optionalSource() :  | test.swift:442:19:442:19 | a |
+| test.swift:455:21:455:29 | call to source2() :  | test.swift:456:19:456:19 | x |
+| test.swift:455:21:455:29 | call to source2() :  | test.swift:457:19:457:19 | y |
 nodes
 | file://:0:0:0:0 | .a [x] :  | semmle.label | .a [x] :  |
 | file://:0:0:0:0 | .x :  | semmle.label | .x :  |
@@ -298,8 +300,11 @@ nodes
 | test.swift:360:15:360:18 | .0 | semmle.label | .0 |
 | test.swift:361:15:361:15 | t2 [Tuple element at index 1] :  | semmle.label | t2 [Tuple element at index 1] :  |
 | test.swift:361:15:361:18 | .1 | semmle.label | .1 |
-| test.swift:437:13:437:28 | call to optionalSource() :  | semmle.label | call to optionalSource() :  |
-| test.swift:440:19:440:19 | a | semmle.label | a |
+| test.swift:439:13:439:28 | call to optionalSource() :  | semmle.label | call to optionalSource() :  |
+| test.swift:442:19:442:19 | a | semmle.label | a |
+| test.swift:455:21:455:29 | call to source2() :  | semmle.label | call to source2() :  |
+| test.swift:456:19:456:19 | x | semmle.label | x |
+| test.swift:457:19:457:19 | y | semmle.label | y |
 subpaths
 | test.swift:75:21:75:22 | &... :  | test.swift:65:16:65:28 | arg1 :  | test.swift:65:1:70:1 | arg2[return] :  | test.swift:75:31:75:32 | [post] &... :  |
 | test.swift:114:19:114:19 | arg :  | test.swift:109:9:109:14 | arg :  | test.swift:110:12:110:12 | arg :  | test.swift:114:12:114:22 | call to ... :  |
@@ -380,4 +385,6 @@ subpaths
 | test.swift:357:15:357:18 | .1 | test.swift:351:31:351:38 | call to source() :  | test.swift:357:15:357:18 | .1 | result |
 | test.swift:360:15:360:18 | .0 | test.swift:351:18:351:25 | call to source() :  | test.swift:360:15:360:18 | .0 | result |
 | test.swift:361:15:361:18 | .1 | test.swift:351:31:351:38 | call to source() :  | test.swift:361:15:361:18 | .1 | result |
-| test.swift:440:19:440:19 | a | test.swift:259:12:259:19 | call to source() :  | test.swift:440:19:440:19 | a | result |
+| test.swift:442:19:442:19 | a | test.swift:259:12:259:19 | call to source() :  | test.swift:442:19:442:19 | a | result |
+| test.swift:456:19:456:19 | x | test.swift:455:21:455:29 | call to source2() :  | test.swift:456:19:456:19 | x | result |
+| test.swift:457:19:457:19 | y | test.swift:455:21:455:29 | call to source2() :  | test.swift:457:19:457:19 | y | result |

--- a/swift/ql/test/library-tests/dataflow/dataflow/DataFlow.expected
+++ b/swift/ql/test/library-tests/dataflow/dataflow/DataFlow.expected
@@ -107,7 +107,11 @@ edges
 | test.swift:263:13:263:28 | call to optionalSource() :  | test.swift:275:15:275:27 | ... ??(_:_:) ... |
 | test.swift:263:13:263:28 | call to optionalSource() :  | test.swift:279:15:279:31 | ... ? ... : ... |
 | test.swift:263:13:263:28 | call to optionalSource() :  | test.swift:280:15:280:38 | ... ? ... : ... |
+| test.swift:263:13:263:28 | call to optionalSource() :  | test.swift:285:19:285:19 | z |
+| test.swift:263:13:263:28 | call to optionalSource() :  | test.swift:291:16:291:17 | ...? :  |
+| test.swift:263:13:263:28 | call to optionalSource() :  | test.swift:300:15:300:15 | z1 |
 | test.swift:263:13:263:28 | call to optionalSource() :  | test.swift:303:15:303:16 | ...! :  |
+| test.swift:263:13:263:28 | call to optionalSource() :  | test.swift:307:19:307:19 | z |
 | test.swift:270:15:270:22 | call to source() :  | file://:0:0:0:0 | [summary param] this in signum() :  |
 | test.swift:270:15:270:22 | call to source() :  | test.swift:270:15:270:31 | call to signum() |
 | test.swift:271:15:271:16 | ...? :  | file://:0:0:0:0 | [summary param] this in signum() :  |
@@ -115,6 +119,9 @@ edges
 | test.swift:271:15:271:25 | call to signum() :  | test.swift:271:15:271:25 | OptionalEvaluationExpr |
 | test.swift:280:31:280:38 | call to source() :  | test.swift:280:15:280:38 | ... ? ... : ... |
 | test.swift:282:31:282:38 | call to source() :  | test.swift:282:15:282:38 | ... ? ... : ... |
+| test.swift:291:16:291:17 | ...? :  | file://:0:0:0:0 | [summary param] this in signum() :  |
+| test.swift:291:16:291:17 | ...? :  | test.swift:291:16:291:26 | call to signum() :  |
+| test.swift:291:16:291:26 | call to signum() :  | test.swift:292:19:292:19 | z |
 | test.swift:303:15:303:16 | ...! :  | file://:0:0:0:0 | [summary param] this in signum() :  |
 | test.swift:303:15:303:16 | ...! :  | test.swift:303:15:303:25 | call to signum() |
 | test.swift:331:14:331:26 | (...) [Tuple element at index 1] :  | test.swift:335:15:335:15 | t1 [Tuple element at index 1] :  |
@@ -261,8 +268,14 @@ nodes
 | test.swift:280:31:280:38 | call to source() :  | semmle.label | call to source() :  |
 | test.swift:282:15:282:38 | ... ? ... : ... | semmle.label | ... ? ... : ... |
 | test.swift:282:31:282:38 | call to source() :  | semmle.label | call to source() :  |
+| test.swift:285:19:285:19 | z | semmle.label | z |
+| test.swift:291:16:291:17 | ...? :  | semmle.label | ...? :  |
+| test.swift:291:16:291:26 | call to signum() :  | semmle.label | call to signum() :  |
+| test.swift:292:19:292:19 | z | semmle.label | z |
+| test.swift:300:15:300:15 | z1 | semmle.label | z1 |
 | test.swift:303:15:303:16 | ...! :  | semmle.label | ...! :  |
 | test.swift:303:15:303:25 | call to signum() | semmle.label | call to signum() |
+| test.swift:307:19:307:19 | z | semmle.label | z |
 | test.swift:331:14:331:26 | (...) [Tuple element at index 1] :  | semmle.label | (...) [Tuple element at index 1] :  |
 | test.swift:331:18:331:25 | call to source() :  | semmle.label | call to source() :  |
 | test.swift:335:15:335:15 | t1 [Tuple element at index 1] :  | semmle.label | t1 [Tuple element at index 1] :  |
@@ -311,6 +324,7 @@ subpaths
 | test.swift:219:13:219:15 | .a [x] :  | test.swift:163:7:163:7 | self [x] :  | file://:0:0:0:0 | .x :  | test.swift:219:13:219:17 | .x |
 | test.swift:270:15:270:22 | call to source() :  | file://:0:0:0:0 | [summary param] this in signum() :  | file://:0:0:0:0 | [summary] to write: return (return) in signum() :  | test.swift:270:15:270:31 | call to signum() |
 | test.swift:271:15:271:16 | ...? :  | file://:0:0:0:0 | [summary param] this in signum() :  | file://:0:0:0:0 | [summary] to write: return (return) in signum() :  | test.swift:271:15:271:25 | call to signum() :  |
+| test.swift:291:16:291:17 | ...? :  | file://:0:0:0:0 | [summary param] this in signum() :  | file://:0:0:0:0 | [summary] to write: return (return) in signum() :  | test.swift:291:16:291:26 | call to signum() :  |
 | test.swift:303:15:303:16 | ...! :  | file://:0:0:0:0 | [summary param] this in signum() :  | file://:0:0:0:0 | [summary] to write: return (return) in signum() :  | test.swift:303:15:303:25 | call to signum() |
 #select
 | test.swift:7:15:7:15 | t1 | test.swift:6:19:6:26 | call to source() :  | test.swift:7:15:7:15 | t1 | result |
@@ -351,7 +365,11 @@ subpaths
 | test.swift:280:15:280:38 | ... ? ... : ... | test.swift:259:12:259:19 | call to source() :  | test.swift:280:15:280:38 | ... ? ... : ... | result |
 | test.swift:280:15:280:38 | ... ? ... : ... | test.swift:280:31:280:38 | call to source() :  | test.swift:280:15:280:38 | ... ? ... : ... | result |
 | test.swift:282:15:282:38 | ... ? ... : ... | test.swift:282:31:282:38 | call to source() :  | test.swift:282:15:282:38 | ... ? ... : ... | result |
+| test.swift:285:19:285:19 | z | test.swift:259:12:259:19 | call to source() :  | test.swift:285:19:285:19 | z | result |
+| test.swift:292:19:292:19 | z | test.swift:259:12:259:19 | call to source() :  | test.swift:292:19:292:19 | z | result |
+| test.swift:300:15:300:15 | z1 | test.swift:259:12:259:19 | call to source() :  | test.swift:300:15:300:15 | z1 | result |
 | test.swift:303:15:303:25 | call to signum() | test.swift:259:12:259:19 | call to source() :  | test.swift:303:15:303:25 | call to signum() | result |
+| test.swift:307:19:307:19 | z | test.swift:259:12:259:19 | call to source() :  | test.swift:307:19:307:19 | z | result |
 | test.swift:335:15:335:18 | .1 | test.swift:331:18:331:25 | call to source() :  | test.swift:335:15:335:18 | .1 | result |
 | test.swift:346:15:346:18 | .0 | test.swift:343:12:343:19 | call to source() :  | test.swift:346:15:346:18 | .0 | result |
 | test.swift:356:15:356:18 | .0 | test.swift:351:18:351:25 | call to source() :  | test.swift:356:15:356:18 | .0 | result |

--- a/swift/ql/test/library-tests/dataflow/dataflow/DataFlow.expected
+++ b/swift/ql/test/library-tests/dataflow/dataflow/DataFlow.expected
@@ -100,6 +100,7 @@ edges
 | test.swift:225:14:225:21 | call to source() :  | test.swift:235:13:235:15 | .source_value |
 | test.swift:225:14:225:21 | call to source() :  | test.swift:238:13:238:15 | .source_value |
 | test.swift:259:12:259:19 | call to source() :  | test.swift:263:13:263:28 | call to optionalSource() :  |
+| test.swift:259:12:259:19 | call to source() :  | test.swift:437:13:437:28 | call to optionalSource() :  |
 | test.swift:263:13:263:28 | call to optionalSource() :  | test.swift:265:15:265:15 | x |
 | test.swift:263:13:263:28 | call to optionalSource() :  | test.swift:267:15:267:16 | ...! |
 | test.swift:263:13:263:28 | call to optionalSource() :  | test.swift:271:15:271:16 | ...? :  |
@@ -140,6 +141,7 @@ edges
 | test.swift:357:15:357:15 | t1 [Tuple element at index 1] :  | test.swift:357:15:357:18 | .1 |
 | test.swift:360:15:360:15 | t2 [Tuple element at index 0] :  | test.swift:360:15:360:18 | .0 |
 | test.swift:361:15:361:15 | t2 [Tuple element at index 1] :  | test.swift:361:15:361:18 | .1 |
+| test.swift:437:13:437:28 | call to optionalSource() :  | test.swift:440:19:440:19 | a |
 nodes
 | file://:0:0:0:0 | .a [x] :  | semmle.label | .a [x] :  |
 | file://:0:0:0:0 | .x :  | semmle.label | .x :  |
@@ -296,6 +298,8 @@ nodes
 | test.swift:360:15:360:18 | .0 | semmle.label | .0 |
 | test.swift:361:15:361:15 | t2 [Tuple element at index 1] :  | semmle.label | t2 [Tuple element at index 1] :  |
 | test.swift:361:15:361:18 | .1 | semmle.label | .1 |
+| test.swift:437:13:437:28 | call to optionalSource() :  | semmle.label | call to optionalSource() :  |
+| test.swift:440:19:440:19 | a | semmle.label | a |
 subpaths
 | test.swift:75:21:75:22 | &... :  | test.swift:65:16:65:28 | arg1 :  | test.swift:65:1:70:1 | arg2[return] :  | test.swift:75:31:75:32 | [post] &... :  |
 | test.swift:114:19:114:19 | arg :  | test.swift:109:9:109:14 | arg :  | test.swift:110:12:110:12 | arg :  | test.swift:114:12:114:22 | call to ... :  |
@@ -376,3 +380,4 @@ subpaths
 | test.swift:357:15:357:18 | .1 | test.swift:351:31:351:38 | call to source() :  | test.swift:357:15:357:18 | .1 | result |
 | test.swift:360:15:360:18 | .0 | test.swift:351:18:351:25 | call to source() :  | test.swift:360:15:360:18 | .0 | result |
 | test.swift:361:15:361:18 | .1 | test.swift:351:31:351:38 | call to source() :  | test.swift:361:15:361:18 | .1 | result |
+| test.swift:440:19:440:19 | a | test.swift:259:12:259:19 | call to source() :  | test.swift:440:19:440:19 | a | result |

--- a/swift/ql/test/library-tests/dataflow/dataflow/DataFlow.expected
+++ b/swift/ql/test/library-tests/dataflow/dataflow/DataFlow.expected
@@ -107,6 +107,7 @@ edges
 | test.swift:263:13:263:28 | call to optionalSource() :  | test.swift:275:15:275:27 | ... ??(_:_:) ... |
 | test.swift:263:13:263:28 | call to optionalSource() :  | test.swift:279:15:279:31 | ... ? ... : ... |
 | test.swift:263:13:263:28 | call to optionalSource() :  | test.swift:280:15:280:38 | ... ? ... : ... |
+| test.swift:263:13:263:28 | call to optionalSource() :  | test.swift:303:15:303:16 | ...! :  |
 | test.swift:270:15:270:22 | call to source() :  | file://:0:0:0:0 | [summary param] this in signum() :  |
 | test.swift:270:15:270:22 | call to source() :  | test.swift:270:15:270:31 | call to signum() |
 | test.swift:271:15:271:16 | ...? :  | file://:0:0:0:0 | [summary param] this in signum() :  |
@@ -114,6 +115,8 @@ edges
 | test.swift:271:15:271:25 | call to signum() :  | test.swift:271:15:271:25 | OptionalEvaluationExpr |
 | test.swift:280:31:280:38 | call to source() :  | test.swift:280:15:280:38 | ... ? ... : ... |
 | test.swift:282:31:282:38 | call to source() :  | test.swift:282:15:282:38 | ... ? ... : ... |
+| test.swift:303:15:303:16 | ...! :  | file://:0:0:0:0 | [summary param] this in signum() :  |
+| test.swift:303:15:303:16 | ...! :  | test.swift:303:15:303:25 | call to signum() |
 | test.swift:331:14:331:26 | (...) [Tuple element at index 1] :  | test.swift:335:15:335:15 | t1 [Tuple element at index 1] :  |
 | test.swift:331:18:331:25 | call to source() :  | test.swift:331:14:331:26 | (...) [Tuple element at index 1] :  |
 | test.swift:335:15:335:15 | t1 [Tuple element at index 1] :  | test.swift:335:15:335:18 | .1 |
@@ -258,6 +261,8 @@ nodes
 | test.swift:280:31:280:38 | call to source() :  | semmle.label | call to source() :  |
 | test.swift:282:15:282:38 | ... ? ... : ... | semmle.label | ... ? ... : ... |
 | test.swift:282:31:282:38 | call to source() :  | semmle.label | call to source() :  |
+| test.swift:303:15:303:16 | ...! :  | semmle.label | ...! :  |
+| test.swift:303:15:303:25 | call to signum() | semmle.label | call to signum() |
 | test.swift:331:14:331:26 | (...) [Tuple element at index 1] :  | semmle.label | (...) [Tuple element at index 1] :  |
 | test.swift:331:18:331:25 | call to source() :  | semmle.label | call to source() :  |
 | test.swift:335:15:335:15 | t1 [Tuple element at index 1] :  | semmle.label | t1 [Tuple element at index 1] :  |
@@ -306,6 +311,7 @@ subpaths
 | test.swift:219:13:219:15 | .a [x] :  | test.swift:163:7:163:7 | self [x] :  | file://:0:0:0:0 | .x :  | test.swift:219:13:219:17 | .x |
 | test.swift:270:15:270:22 | call to source() :  | file://:0:0:0:0 | [summary param] this in signum() :  | file://:0:0:0:0 | [summary] to write: return (return) in signum() :  | test.swift:270:15:270:31 | call to signum() |
 | test.swift:271:15:271:16 | ...? :  | file://:0:0:0:0 | [summary param] this in signum() :  | file://:0:0:0:0 | [summary] to write: return (return) in signum() :  | test.swift:271:15:271:25 | call to signum() :  |
+| test.swift:303:15:303:16 | ...! :  | file://:0:0:0:0 | [summary param] this in signum() :  | file://:0:0:0:0 | [summary] to write: return (return) in signum() :  | test.swift:303:15:303:25 | call to signum() |
 #select
 | test.swift:7:15:7:15 | t1 | test.swift:6:19:6:26 | call to source() :  | test.swift:7:15:7:15 | t1 | result |
 | test.swift:9:15:9:15 | t1 | test.swift:6:19:6:26 | call to source() :  | test.swift:9:15:9:15 | t1 | result |
@@ -345,6 +351,7 @@ subpaths
 | test.swift:280:15:280:38 | ... ? ... : ... | test.swift:259:12:259:19 | call to source() :  | test.swift:280:15:280:38 | ... ? ... : ... | result |
 | test.swift:280:15:280:38 | ... ? ... : ... | test.swift:280:31:280:38 | call to source() :  | test.swift:280:15:280:38 | ... ? ... : ... | result |
 | test.swift:282:15:282:38 | ... ? ... : ... | test.swift:282:31:282:38 | call to source() :  | test.swift:282:15:282:38 | ... ? ... : ... | result |
+| test.swift:303:15:303:25 | call to signum() | test.swift:259:12:259:19 | call to source() :  | test.swift:303:15:303:25 | call to signum() | result |
 | test.swift:335:15:335:18 | .1 | test.swift:331:18:331:25 | call to source() :  | test.swift:335:15:335:18 | .1 | result |
 | test.swift:346:15:346:18 | .0 | test.swift:343:12:343:19 | call to source() :  | test.swift:346:15:346:18 | .0 | result |
 | test.swift:356:15:356:18 | .0 | test.swift:351:18:351:25 | call to source() :  | test.swift:356:15:356:18 | .0 | result |

--- a/swift/ql/test/library-tests/dataflow/dataflow/DataFlow.expected
+++ b/swift/ql/test/library-tests/dataflow/dataflow/DataFlow.expected
@@ -114,22 +114,22 @@ edges
 | test.swift:271:15:271:25 | call to signum() :  | test.swift:271:15:271:25 | OptionalEvaluationExpr |
 | test.swift:280:31:280:38 | call to source() :  | test.swift:280:15:280:38 | ... ? ... : ... |
 | test.swift:282:31:282:38 | call to source() :  | test.swift:282:15:282:38 | ... ? ... : ... |
-| test.swift:302:14:302:26 | (...) [Tuple element at index 1] :  | test.swift:306:15:306:15 | t1 [Tuple element at index 1] :  |
-| test.swift:302:18:302:25 | call to source() :  | test.swift:302:14:302:26 | (...) [Tuple element at index 1] :  |
-| test.swift:306:15:306:15 | t1 [Tuple element at index 1] :  | test.swift:306:15:306:18 | .1 |
-| test.swift:314:5:314:5 | [post] t1 [Tuple element at index 0] :  | test.swift:317:15:317:15 | t1 [Tuple element at index 0] :  |
-| test.swift:314:12:314:19 | call to source() :  | test.swift:314:5:314:5 | [post] t1 [Tuple element at index 0] :  |
-| test.swift:317:15:317:15 | t1 [Tuple element at index 0] :  | test.swift:317:15:317:18 | .0 |
-| test.swift:322:14:322:45 | (...) [Tuple element at index 0] :  | test.swift:327:15:327:15 | t1 [Tuple element at index 0] :  |
-| test.swift:322:14:322:45 | (...) [Tuple element at index 0] :  | test.swift:331:15:331:15 | t2 [Tuple element at index 0] :  |
-| test.swift:322:14:322:45 | (...) [Tuple element at index 1] :  | test.swift:328:15:328:15 | t1 [Tuple element at index 1] :  |
-| test.swift:322:14:322:45 | (...) [Tuple element at index 1] :  | test.swift:332:15:332:15 | t2 [Tuple element at index 1] :  |
-| test.swift:322:18:322:25 | call to source() :  | test.swift:322:14:322:45 | (...) [Tuple element at index 0] :  |
-| test.swift:322:31:322:38 | call to source() :  | test.swift:322:14:322:45 | (...) [Tuple element at index 1] :  |
-| test.swift:327:15:327:15 | t1 [Tuple element at index 0] :  | test.swift:327:15:327:18 | .0 |
-| test.swift:328:15:328:15 | t1 [Tuple element at index 1] :  | test.swift:328:15:328:18 | .1 |
-| test.swift:331:15:331:15 | t2 [Tuple element at index 0] :  | test.swift:331:15:331:18 | .0 |
-| test.swift:332:15:332:15 | t2 [Tuple element at index 1] :  | test.swift:332:15:332:18 | .1 |
+| test.swift:331:14:331:26 | (...) [Tuple element at index 1] :  | test.swift:335:15:335:15 | t1 [Tuple element at index 1] :  |
+| test.swift:331:18:331:25 | call to source() :  | test.swift:331:14:331:26 | (...) [Tuple element at index 1] :  |
+| test.swift:335:15:335:15 | t1 [Tuple element at index 1] :  | test.swift:335:15:335:18 | .1 |
+| test.swift:343:5:343:5 | [post] t1 [Tuple element at index 0] :  | test.swift:346:15:346:15 | t1 [Tuple element at index 0] :  |
+| test.swift:343:12:343:19 | call to source() :  | test.swift:343:5:343:5 | [post] t1 [Tuple element at index 0] :  |
+| test.swift:346:15:346:15 | t1 [Tuple element at index 0] :  | test.swift:346:15:346:18 | .0 |
+| test.swift:351:14:351:45 | (...) [Tuple element at index 0] :  | test.swift:356:15:356:15 | t1 [Tuple element at index 0] :  |
+| test.swift:351:14:351:45 | (...) [Tuple element at index 0] :  | test.swift:360:15:360:15 | t2 [Tuple element at index 0] :  |
+| test.swift:351:14:351:45 | (...) [Tuple element at index 1] :  | test.swift:357:15:357:15 | t1 [Tuple element at index 1] :  |
+| test.swift:351:14:351:45 | (...) [Tuple element at index 1] :  | test.swift:361:15:361:15 | t2 [Tuple element at index 1] :  |
+| test.swift:351:18:351:25 | call to source() :  | test.swift:351:14:351:45 | (...) [Tuple element at index 0] :  |
+| test.swift:351:31:351:38 | call to source() :  | test.swift:351:14:351:45 | (...) [Tuple element at index 1] :  |
+| test.swift:356:15:356:15 | t1 [Tuple element at index 0] :  | test.swift:356:15:356:18 | .0 |
+| test.swift:357:15:357:15 | t1 [Tuple element at index 1] :  | test.swift:357:15:357:18 | .1 |
+| test.swift:360:15:360:15 | t2 [Tuple element at index 0] :  | test.swift:360:15:360:18 | .0 |
+| test.swift:361:15:361:15 | t2 [Tuple element at index 1] :  | test.swift:361:15:361:18 | .1 |
 nodes
 | file://:0:0:0:0 | .a [x] :  | semmle.label | .a [x] :  |
 | file://:0:0:0:0 | .x :  | semmle.label | .x :  |
@@ -258,26 +258,26 @@ nodes
 | test.swift:280:31:280:38 | call to source() :  | semmle.label | call to source() :  |
 | test.swift:282:15:282:38 | ... ? ... : ... | semmle.label | ... ? ... : ... |
 | test.swift:282:31:282:38 | call to source() :  | semmle.label | call to source() :  |
-| test.swift:302:14:302:26 | (...) [Tuple element at index 1] :  | semmle.label | (...) [Tuple element at index 1] :  |
-| test.swift:302:18:302:25 | call to source() :  | semmle.label | call to source() :  |
-| test.swift:306:15:306:15 | t1 [Tuple element at index 1] :  | semmle.label | t1 [Tuple element at index 1] :  |
-| test.swift:306:15:306:18 | .1 | semmle.label | .1 |
-| test.swift:314:5:314:5 | [post] t1 [Tuple element at index 0] :  | semmle.label | [post] t1 [Tuple element at index 0] :  |
-| test.swift:314:12:314:19 | call to source() :  | semmle.label | call to source() :  |
-| test.swift:317:15:317:15 | t1 [Tuple element at index 0] :  | semmle.label | t1 [Tuple element at index 0] :  |
-| test.swift:317:15:317:18 | .0 | semmle.label | .0 |
-| test.swift:322:14:322:45 | (...) [Tuple element at index 0] :  | semmle.label | (...) [Tuple element at index 0] :  |
-| test.swift:322:14:322:45 | (...) [Tuple element at index 1] :  | semmle.label | (...) [Tuple element at index 1] :  |
-| test.swift:322:18:322:25 | call to source() :  | semmle.label | call to source() :  |
-| test.swift:322:31:322:38 | call to source() :  | semmle.label | call to source() :  |
-| test.swift:327:15:327:15 | t1 [Tuple element at index 0] :  | semmle.label | t1 [Tuple element at index 0] :  |
-| test.swift:327:15:327:18 | .0 | semmle.label | .0 |
-| test.swift:328:15:328:15 | t1 [Tuple element at index 1] :  | semmle.label | t1 [Tuple element at index 1] :  |
-| test.swift:328:15:328:18 | .1 | semmle.label | .1 |
-| test.swift:331:15:331:15 | t2 [Tuple element at index 0] :  | semmle.label | t2 [Tuple element at index 0] :  |
-| test.swift:331:15:331:18 | .0 | semmle.label | .0 |
-| test.swift:332:15:332:15 | t2 [Tuple element at index 1] :  | semmle.label | t2 [Tuple element at index 1] :  |
-| test.swift:332:15:332:18 | .1 | semmle.label | .1 |
+| test.swift:331:14:331:26 | (...) [Tuple element at index 1] :  | semmle.label | (...) [Tuple element at index 1] :  |
+| test.swift:331:18:331:25 | call to source() :  | semmle.label | call to source() :  |
+| test.swift:335:15:335:15 | t1 [Tuple element at index 1] :  | semmle.label | t1 [Tuple element at index 1] :  |
+| test.swift:335:15:335:18 | .1 | semmle.label | .1 |
+| test.swift:343:5:343:5 | [post] t1 [Tuple element at index 0] :  | semmle.label | [post] t1 [Tuple element at index 0] :  |
+| test.swift:343:12:343:19 | call to source() :  | semmle.label | call to source() :  |
+| test.swift:346:15:346:15 | t1 [Tuple element at index 0] :  | semmle.label | t1 [Tuple element at index 0] :  |
+| test.swift:346:15:346:18 | .0 | semmle.label | .0 |
+| test.swift:351:14:351:45 | (...) [Tuple element at index 0] :  | semmle.label | (...) [Tuple element at index 0] :  |
+| test.swift:351:14:351:45 | (...) [Tuple element at index 1] :  | semmle.label | (...) [Tuple element at index 1] :  |
+| test.swift:351:18:351:25 | call to source() :  | semmle.label | call to source() :  |
+| test.swift:351:31:351:38 | call to source() :  | semmle.label | call to source() :  |
+| test.swift:356:15:356:15 | t1 [Tuple element at index 0] :  | semmle.label | t1 [Tuple element at index 0] :  |
+| test.swift:356:15:356:18 | .0 | semmle.label | .0 |
+| test.swift:357:15:357:15 | t1 [Tuple element at index 1] :  | semmle.label | t1 [Tuple element at index 1] :  |
+| test.swift:357:15:357:18 | .1 | semmle.label | .1 |
+| test.swift:360:15:360:15 | t2 [Tuple element at index 0] :  | semmle.label | t2 [Tuple element at index 0] :  |
+| test.swift:360:15:360:18 | .0 | semmle.label | .0 |
+| test.swift:361:15:361:15 | t2 [Tuple element at index 1] :  | semmle.label | t2 [Tuple element at index 1] :  |
+| test.swift:361:15:361:18 | .1 | semmle.label | .1 |
 subpaths
 | test.swift:75:21:75:22 | &... :  | test.swift:65:16:65:28 | arg1 :  | test.swift:65:1:70:1 | arg2[return] :  | test.swift:75:31:75:32 | [post] &... :  |
 | test.swift:114:19:114:19 | arg :  | test.swift:109:9:109:14 | arg :  | test.swift:110:12:110:12 | arg :  | test.swift:114:12:114:22 | call to ... :  |
@@ -345,9 +345,9 @@ subpaths
 | test.swift:280:15:280:38 | ... ? ... : ... | test.swift:259:12:259:19 | call to source() :  | test.swift:280:15:280:38 | ... ? ... : ... | result |
 | test.swift:280:15:280:38 | ... ? ... : ... | test.swift:280:31:280:38 | call to source() :  | test.swift:280:15:280:38 | ... ? ... : ... | result |
 | test.swift:282:15:282:38 | ... ? ... : ... | test.swift:282:31:282:38 | call to source() :  | test.swift:282:15:282:38 | ... ? ... : ... | result |
-| test.swift:306:15:306:18 | .1 | test.swift:302:18:302:25 | call to source() :  | test.swift:306:15:306:18 | .1 | result |
-| test.swift:317:15:317:18 | .0 | test.swift:314:12:314:19 | call to source() :  | test.swift:317:15:317:18 | .0 | result |
-| test.swift:327:15:327:18 | .0 | test.swift:322:18:322:25 | call to source() :  | test.swift:327:15:327:18 | .0 | result |
-| test.swift:328:15:328:18 | .1 | test.swift:322:31:322:38 | call to source() :  | test.swift:328:15:328:18 | .1 | result |
-| test.swift:331:15:331:18 | .0 | test.swift:322:18:322:25 | call to source() :  | test.swift:331:15:331:18 | .0 | result |
-| test.swift:332:15:332:18 | .1 | test.swift:322:31:322:38 | call to source() :  | test.swift:332:15:332:18 | .1 | result |
+| test.swift:335:15:335:18 | .1 | test.swift:331:18:331:25 | call to source() :  | test.swift:335:15:335:18 | .1 | result |
+| test.swift:346:15:346:18 | .0 | test.swift:343:12:343:19 | call to source() :  | test.swift:346:15:346:18 | .0 | result |
+| test.swift:356:15:356:18 | .0 | test.swift:351:18:351:25 | call to source() :  | test.swift:356:15:356:18 | .0 | result |
+| test.swift:357:15:357:18 | .1 | test.swift:351:31:351:38 | call to source() :  | test.swift:357:15:357:18 | .1 | result |
+| test.swift:360:15:360:18 | .0 | test.swift:351:18:351:25 | call to source() :  | test.swift:360:15:360:18 | .0 | result |
+| test.swift:361:15:361:18 | .1 | test.swift:351:31:351:38 | call to source() :  | test.swift:361:15:361:18 | .1 | result |

--- a/swift/ql/test/library-tests/dataflow/dataflow/FlowConfig.qll
+++ b/swift/ql/test/library-tests/dataflow/dataflow/FlowConfig.qll
@@ -10,7 +10,7 @@ class TestConfiguration extends DataFlow::Configuration {
   TestConfiguration() { this = "TestConfiguration" }
 
   override predicate isSource(DataFlow::Node src) {
-    src.asExpr().(CallExpr).getStaticTarget().getName() = "source()"
+    src.asExpr().(CallExpr).getStaticTarget().getName().matches("source%()")
   }
 
   override predicate isSink(DataFlow::Node sink) {

--- a/swift/ql/test/library-tests/dataflow/dataflow/LocalFlow.expected
+++ b/swift/ql/test/library-tests/dataflow/dataflow/LocalFlow.expected
@@ -241,12 +241,22 @@
 | test.swift:282:26:282:26 | y | test.swift:287:16:287:16 | y |
 | test.swift:282:26:282:27 | ...! | test.swift:282:15:282:38 | ... ? ... : ... |
 | test.swift:282:31:282:38 | call to source() | test.swift:282:15:282:38 | ... ? ... : ... |
-| test.swift:284:16:284:16 | x | test.swift:290:16:290:16 | x |
-| test.swift:287:16:287:16 | y | test.swift:293:16:293:16 | y |
-| test.swift:290:16:290:16 | x | test.swift:290:16:290:17 | ...? |
-| test.swift:290:16:290:26 | call to signum() | test.swift:290:16:290:26 | OptionalEvaluationExpr |
-| test.swift:293:16:293:16 | y | test.swift:293:16:293:17 | ...? |
-| test.swift:293:16:293:26 | call to signum() | test.swift:293:16:293:26 | OptionalEvaluationExpr |
+| test.swift:284:16:284:16 | x | test.swift:291:16:291:16 | x |
+| test.swift:287:16:287:16 | y | test.swift:294:16:294:16 | y |
+| test.swift:291:16:291:16 | x | test.swift:291:16:291:17 | ...? |
+| test.swift:291:16:291:16 | x | test.swift:298:20:298:20 | x |
+| test.swift:291:16:291:26 | call to signum() | test.swift:291:16:291:26 | OptionalEvaluationExpr |
+| test.swift:294:16:294:16 | y | test.swift:294:16:294:17 | ...? |
+| test.swift:294:16:294:16 | y | test.swift:299:20:299:20 | y |
+| test.swift:294:16:294:26 | call to signum() | test.swift:294:16:294:26 | OptionalEvaluationExpr |
+| test.swift:298:20:298:20 | x | test.swift:303:15:303:15 | x |
+| test.swift:299:20:299:20 | y | test.swift:304:15:304:15 | y |
+| test.swift:303:15:303:15 | x | test.swift:303:15:303:16 | ...! |
+| test.swift:303:15:303:15 | x | test.swift:306:28:306:28 | x |
+| test.swift:304:15:304:15 | y | test.swift:304:15:304:16 | ...! |
+| test.swift:304:15:304:15 | y | test.swift:309:28:309:28 | y |
+| test.swift:306:28:306:28 | x | test.swift:313:12:313:12 | x |
+| test.swift:309:28:309:28 | y | test.swift:319:12:319:12 | y |
 | test.swift:331:9:331:9 | SSA def(t1) | test.swift:333:15:333:15 | t1 |
 | test.swift:331:14:331:26 | (...) | test.swift:331:9:331:9 | SSA def(t1) |
 | test.swift:333:15:333:15 | t1 | test.swift:334:15:334:15 | t1 |
@@ -288,3 +298,9 @@
 | test.swift:360:15:360:15 | t2 | test.swift:361:15:361:15 | t2 |
 | test.swift:361:15:361:15 | [post] t2 | test.swift:362:15:362:15 | t2 |
 | test.swift:361:15:361:15 | t2 | test.swift:362:15:362:15 | t2 |
+| test.swift:375:9:375:13 | SSA def(a) | test.swift:377:12:377:12 | a |
+| test.swift:375:22:375:23 | .myNone | test.swift:375:9:375:13 | SSA def(a) |
+| test.swift:387:9:387:13 | SSA def(b) | test.swift:389:12:389:12 | b |
+| test.swift:387:22:387:40 | call to ... | test.swift:387:9:387:13 | SSA def(b) |
+| test.swift:399:9:399:9 | SSA def(c) | test.swift:401:12:401:12 | c |
+| test.swift:399:13:399:38 | call to ... | test.swift:399:9:399:9 | SSA def(c) |

--- a/swift/ql/test/library-tests/dataflow/dataflow/LocalFlow.expected
+++ b/swift/ql/test/library-tests/dataflow/dataflow/LocalFlow.expected
@@ -241,22 +241,32 @@
 | test.swift:282:26:282:26 | y | test.swift:287:16:287:16 | y |
 | test.swift:282:26:282:27 | ...! | test.swift:282:15:282:38 | ... ? ... : ... |
 | test.swift:282:31:282:38 | call to source() | test.swift:282:15:282:38 | ... ? ... : ... |
+| test.swift:284:8:284:12 | SSA def(z) | test.swift:285:19:285:19 | z |
 | test.swift:284:16:284:16 | x | test.swift:291:16:291:16 | x |
+| test.swift:287:8:287:12 | SSA def(z) | test.swift:288:19:288:19 | z |
 | test.swift:287:16:287:16 | y | test.swift:294:16:294:16 | y |
+| test.swift:291:8:291:12 | SSA def(z) | test.swift:292:19:292:19 | z |
 | test.swift:291:16:291:16 | x | test.swift:291:16:291:17 | ...? |
 | test.swift:291:16:291:16 | x | test.swift:298:20:298:20 | x |
 | test.swift:291:16:291:26 | call to signum() | test.swift:291:16:291:26 | OptionalEvaluationExpr |
+| test.swift:294:8:294:12 | SSA def(z) | test.swift:295:19:295:19 | z |
 | test.swift:294:16:294:16 | y | test.swift:294:16:294:17 | ...? |
 | test.swift:294:16:294:16 | y | test.swift:299:20:299:20 | y |
 | test.swift:294:16:294:26 | call to signum() | test.swift:294:16:294:26 | OptionalEvaluationExpr |
+| test.swift:298:11:298:15 | SSA def(z1) | test.swift:300:15:300:15 | z1 |
 | test.swift:298:20:298:20 | x | test.swift:303:15:303:15 | x |
+| test.swift:299:11:299:15 | SSA def(z2) | test.swift:301:15:301:15 | z2 |
 | test.swift:299:20:299:20 | y | test.swift:304:15:304:15 | y |
 | test.swift:303:15:303:15 | x | test.swift:303:15:303:16 | ...! |
 | test.swift:303:15:303:15 | x | test.swift:306:28:306:28 | x |
 | test.swift:304:15:304:15 | y | test.swift:304:15:304:16 | ...! |
 | test.swift:304:15:304:15 | y | test.swift:309:28:309:28 | y |
+| test.swift:306:13:306:24 | SSA def(z) | test.swift:307:19:307:19 | z |
 | test.swift:306:28:306:28 | x | test.swift:313:12:313:12 | x |
+| test.swift:309:13:309:24 | SSA def(z) | test.swift:310:19:310:19 | z |
 | test.swift:309:28:309:28 | y | test.swift:319:12:319:12 | y |
+| test.swift:314:10:314:21 | SSA def(z) | test.swift:315:19:315:19 | z |
+| test.swift:320:10:320:21 | SSA def(z) | test.swift:321:19:321:19 | z |
 | test.swift:331:9:331:9 | SSA def(t1) | test.swift:333:15:333:15 | t1 |
 | test.swift:331:14:331:26 | (...) | test.swift:331:9:331:9 | SSA def(t1) |
 | test.swift:333:15:333:15 | t1 | test.swift:334:15:334:15 | t1 |
@@ -300,7 +310,16 @@
 | test.swift:361:15:361:15 | t2 | test.swift:362:15:362:15 | t2 |
 | test.swift:375:9:375:13 | SSA def(a) | test.swift:377:12:377:12 | a |
 | test.swift:375:22:375:23 | .myNone | test.swift:375:9:375:13 | SSA def(a) |
+| test.swift:380:10:380:25 | SSA def(a) | test.swift:381:19:381:19 | a |
+| test.swift:382:10:382:30 | SSA def(a) | test.swift:383:19:383:19 | a |
+| test.swift:382:10:382:30 | SSA def(b) | test.swift:384:19:384:19 | b |
 | test.swift:387:9:387:13 | SSA def(b) | test.swift:389:12:389:12 | b |
 | test.swift:387:22:387:40 | call to ... | test.swift:387:9:387:13 | SSA def(b) |
+| test.swift:392:10:392:25 | SSA def(a) | test.swift:393:19:393:19 | a |
+| test.swift:394:10:394:30 | SSA def(a) | test.swift:395:19:395:19 | a |
+| test.swift:394:10:394:30 | SSA def(b) | test.swift:396:19:396:19 | b |
 | test.swift:399:9:399:9 | SSA def(c) | test.swift:401:12:401:12 | c |
 | test.swift:399:13:399:38 | call to ... | test.swift:399:9:399:9 | SSA def(c) |
+| test.swift:404:10:404:25 | SSA def(a) | test.swift:405:19:405:19 | a |
+| test.swift:406:10:406:30 | SSA def(a) | test.swift:407:19:407:19 | a |
+| test.swift:406:10:406:30 | SSA def(b) | test.swift:408:19:408:19 | b |

--- a/swift/ql/test/library-tests/dataflow/dataflow/LocalFlow.expected
+++ b/swift/ql/test/library-tests/dataflow/dataflow/LocalFlow.expected
@@ -318,16 +318,55 @@
 | test.swift:361:15:361:15 | t2 | test.swift:362:15:362:15 | t2 |
 | test.swift:375:9:375:13 | SSA def(a) | test.swift:377:12:377:12 | a |
 | test.swift:375:22:375:23 | .myNone | test.swift:375:9:375:13 | SSA def(a) |
+| test.swift:377:12:377:12 | a | test.swift:387:32:387:32 | a |
 | test.swift:380:10:380:25 | SSA def(a) | test.swift:381:19:381:19 | a |
 | test.swift:382:10:382:30 | SSA def(a) | test.swift:383:19:383:19 | a |
 | test.swift:382:10:382:30 | SSA def(b) | test.swift:384:19:384:19 | b |
-| test.swift:387:9:387:13 | SSA def(b) | test.swift:389:12:389:12 | b |
-| test.swift:387:22:387:40 | call to ... | test.swift:387:9:387:13 | SSA def(b) |
-| test.swift:392:10:392:25 | SSA def(a) | test.swift:393:19:393:19 | a |
-| test.swift:394:10:394:30 | SSA def(a) | test.swift:395:19:395:19 | a |
-| test.swift:394:10:394:30 | SSA def(b) | test.swift:396:19:396:19 | b |
-| test.swift:399:9:399:9 | SSA def(c) | test.swift:401:12:401:12 | c |
-| test.swift:399:13:399:38 | call to ... | test.swift:399:9:399:9 | SSA def(c) |
-| test.swift:404:10:404:25 | SSA def(a) | test.swift:405:19:405:19 | a |
-| test.swift:406:10:406:30 | SSA def(a) | test.swift:407:19:407:19 | a |
-| test.swift:406:10:406:30 | SSA def(b) | test.swift:408:19:408:19 | b |
+| test.swift:387:13:387:28 | SSA def(x) | test.swift:388:19:388:19 | x |
+| test.swift:387:32:387:32 | a | test.swift:387:13:387:28 | SSA def(x) |
+| test.swift:387:32:387:32 | a | test.swift:390:37:390:37 | a |
+| test.swift:390:13:390:33 | SSA def(x) | test.swift:391:19:391:19 | x |
+| test.swift:390:13:390:33 | SSA def(y) | test.swift:392:19:392:19 | y |
+| test.swift:390:37:390:37 | a | test.swift:390:13:390:33 | SSA def(x) |
+| test.swift:390:37:390:37 | a | test.swift:390:13:390:33 | SSA def(y) |
+| test.swift:390:37:390:37 | a | test.swift:407:32:407:32 | a |
+| test.swift:395:9:395:13 | SSA def(b) | test.swift:397:12:397:12 | b |
+| test.swift:395:22:395:40 | call to ... | test.swift:395:9:395:13 | SSA def(b) |
+| test.swift:400:10:400:25 | SSA def(a) | test.swift:401:19:401:19 | a |
+| test.swift:402:10:402:30 | SSA def(a) | test.swift:403:19:403:19 | a |
+| test.swift:402:10:402:30 | SSA def(b) | test.swift:404:19:404:19 | b |
+| test.swift:407:13:407:28 | SSA def(x) | test.swift:408:19:408:19 | x |
+| test.swift:407:32:407:32 | a | test.swift:407:13:407:28 | SSA def(x) |
+| test.swift:407:32:407:32 | a | test.swift:410:37:410:37 | a |
+| test.swift:410:13:410:33 | SSA def(x) | test.swift:411:19:411:19 | x |
+| test.swift:410:13:410:33 | SSA def(y) | test.swift:412:19:412:19 | y |
+| test.swift:410:37:410:37 | a | test.swift:410:13:410:33 | SSA def(x) |
+| test.swift:410:37:410:37 | a | test.swift:410:13:410:33 | SSA def(y) |
+| test.swift:410:37:410:37 | a | test.swift:427:32:427:32 | a |
+| test.swift:415:9:415:9 | SSA def(c) | test.swift:417:12:417:12 | c |
+| test.swift:415:13:415:38 | call to ... | test.swift:415:9:415:9 | SSA def(c) |
+| test.swift:420:10:420:25 | SSA def(a) | test.swift:421:19:421:19 | a |
+| test.swift:422:10:422:30 | SSA def(a) | test.swift:423:19:423:19 | a |
+| test.swift:422:10:422:30 | SSA def(b) | test.swift:424:19:424:19 | b |
+| test.swift:427:13:427:28 | SSA def(x) | test.swift:428:19:428:19 | x |
+| test.swift:427:32:427:32 | a | test.swift:427:13:427:28 | SSA def(x) |
+| test.swift:427:32:427:32 | a | test.swift:430:37:430:37 | a |
+| test.swift:430:13:430:33 | SSA def(x) | test.swift:431:19:431:19 | x |
+| test.swift:430:13:430:33 | SSA def(y) | test.swift:432:19:432:19 | y |
+| test.swift:430:37:430:37 | a | test.swift:430:13:430:33 | SSA def(x) |
+| test.swift:430:37:430:37 | a | test.swift:430:13:430:33 | SSA def(y) |
+| test.swift:436:21:436:27 | SSA def(y) | test.swift:439:27:439:27 | y |
+| test.swift:436:21:436:27 | SSA def(y) | test.swift:444:22:444:22 | y |
+| test.swift:436:21:436:27 | y | test.swift:436:21:436:27 | SSA def(y) |
+| test.swift:437:9:437:9 | SSA def(x) | test.swift:439:16:439:16 | x |
+| test.swift:437:13:437:28 | call to optionalSource() | test.swift:437:9:437:9 | SSA def(x) |
+| test.swift:439:8:439:12 | SSA def(a) | test.swift:440:19:440:19 | a |
+| test.swift:439:16:439:16 | x | test.swift:439:8:439:12 | SSA def(a) |
+| test.swift:439:16:439:16 | x | test.swift:444:19:444:19 | x |
+| test.swift:439:19:439:23 | SSA def(b) | test.swift:441:19:441:19 | b |
+| test.swift:439:27:439:27 | y | test.swift:439:19:439:23 | SSA def(b) |
+| test.swift:439:27:439:27 | y | test.swift:444:22:444:22 | y |
+| test.swift:444:9:444:9 | SSA def(tuple1) | test.swift:445:12:445:12 | tuple1 |
+| test.swift:444:18:444:23 | (...) | test.swift:444:9:444:9 | SSA def(tuple1) |
+| test.swift:446:10:446:37 | SSA def(a) | test.swift:447:19:447:19 | a |
+| test.swift:446:10:446:37 | SSA def(b) | test.swift:448:19:448:19 | b |

--- a/swift/ql/test/library-tests/dataflow/dataflow/LocalFlow.expected
+++ b/swift/ql/test/library-tests/dataflow/dataflow/LocalFlow.expected
@@ -327,8 +327,6 @@
 | test.swift:387:32:387:32 | a | test.swift:390:37:390:37 | a |
 | test.swift:390:13:390:33 | SSA def(x) | test.swift:391:19:391:19 | x |
 | test.swift:390:13:390:33 | SSA def(y) | test.swift:392:19:392:19 | y |
-| test.swift:390:37:390:37 | a | test.swift:390:13:390:33 | SSA def(x) |
-| test.swift:390:37:390:37 | a | test.swift:390:13:390:33 | SSA def(y) |
 | test.swift:390:37:390:37 | a | test.swift:407:32:407:32 | a |
 | test.swift:395:9:395:13 | SSA def(b) | test.swift:397:12:397:12 | b |
 | test.swift:395:22:395:40 | call to ... | test.swift:395:9:395:13 | SSA def(b) |
@@ -340,8 +338,6 @@
 | test.swift:407:32:407:32 | a | test.swift:410:37:410:37 | a |
 | test.swift:410:13:410:33 | SSA def(x) | test.swift:411:19:411:19 | x |
 | test.swift:410:13:410:33 | SSA def(y) | test.swift:412:19:412:19 | y |
-| test.swift:410:37:410:37 | a | test.swift:410:13:410:33 | SSA def(x) |
-| test.swift:410:37:410:37 | a | test.swift:410:13:410:33 | SSA def(y) |
 | test.swift:410:37:410:37 | a | test.swift:427:32:427:32 | a |
 | test.swift:415:9:415:9 | SSA def(c) | test.swift:417:12:417:12 | c |
 | test.swift:415:13:415:38 | call to ... | test.swift:415:9:415:9 | SSA def(c) |
@@ -353,8 +349,6 @@
 | test.swift:427:32:427:32 | a | test.swift:430:37:430:37 | a |
 | test.swift:430:13:430:33 | SSA def(x) | test.swift:431:19:431:19 | x |
 | test.swift:430:13:430:33 | SSA def(y) | test.swift:432:19:432:19 | y |
-| test.swift:430:37:430:37 | a | test.swift:430:13:430:33 | SSA def(x) |
-| test.swift:430:37:430:37 | a | test.swift:430:13:430:33 | SSA def(y) |
 | test.swift:438:21:438:27 | SSA def(y) | test.swift:441:27:441:27 | y |
 | test.swift:438:21:438:27 | SSA def(y) | test.swift:446:22:446:22 | y |
 | test.swift:438:21:438:27 | y | test.swift:438:21:438:27 | SSA def(y) |
@@ -372,5 +366,3 @@
 | test.swift:448:10:448:37 | SSA def(b) | test.swift:450:19:450:19 | b |
 | test.swift:455:8:455:17 | SSA def(x) | test.swift:456:19:456:19 | x |
 | test.swift:455:8:455:17 | SSA def(y) | test.swift:457:19:457:19 | y |
-| test.swift:455:21:455:29 | call to source2() | test.swift:455:8:455:17 | SSA def(x) |
-| test.swift:455:21:455:29 | call to source2() | test.swift:455:8:455:17 | SSA def(y) |

--- a/swift/ql/test/library-tests/dataflow/dataflow/LocalFlow.expected
+++ b/swift/ql/test/library-tests/dataflow/dataflow/LocalFlow.expected
@@ -247,44 +247,44 @@
 | test.swift:290:16:290:26 | call to signum() | test.swift:290:16:290:26 | OptionalEvaluationExpr |
 | test.swift:293:16:293:16 | y | test.swift:293:16:293:17 | ...? |
 | test.swift:293:16:293:26 | call to signum() | test.swift:293:16:293:26 | OptionalEvaluationExpr |
-| test.swift:302:9:302:9 | SSA def(t1) | test.swift:304:15:304:15 | t1 |
-| test.swift:302:14:302:26 | (...) | test.swift:302:9:302:9 | SSA def(t1) |
-| test.swift:304:15:304:15 | t1 | test.swift:305:15:305:15 | t1 |
-| test.swift:305:15:305:15 | [post] t1 | test.swift:306:15:306:15 | t1 |
-| test.swift:305:15:305:15 | t1 | test.swift:306:15:306:15 | t1 |
-| test.swift:306:15:306:15 | [post] t1 | test.swift:308:5:308:5 | t1 |
-| test.swift:306:15:306:15 | t1 | test.swift:308:5:308:5 | t1 |
-| test.swift:308:5:308:5 | [post] t1 | test.swift:310:15:310:15 | t1 |
-| test.swift:308:5:308:5 | t1 | test.swift:310:15:310:15 | t1 |
-| test.swift:310:15:310:15 | t1 | test.swift:311:15:311:15 | t1 |
-| test.swift:311:15:311:15 | [post] t1 | test.swift:312:15:312:15 | t1 |
-| test.swift:311:15:311:15 | t1 | test.swift:312:15:312:15 | t1 |
-| test.swift:312:15:312:15 | [post] t1 | test.swift:314:5:314:5 | t1 |
-| test.swift:312:15:312:15 | t1 | test.swift:314:5:314:5 | t1 |
-| test.swift:314:5:314:5 | [post] t1 | test.swift:316:15:316:15 | t1 |
-| test.swift:314:5:314:5 | t1 | test.swift:316:15:316:15 | t1 |
-| test.swift:316:15:316:15 | t1 | test.swift:317:15:317:15 | t1 |
-| test.swift:317:15:317:15 | [post] t1 | test.swift:318:15:318:15 | t1 |
-| test.swift:317:15:317:15 | t1 | test.swift:318:15:318:15 | t1 |
-| test.swift:322:9:322:9 | SSA def(t1) | test.swift:323:14:323:14 | t1 |
-| test.swift:322:14:322:45 | (...) | test.swift:322:9:322:9 | SSA def(t1) |
-| test.swift:323:9:323:9 | SSA def(t2) | test.swift:330:15:330:15 | t2 |
-| test.swift:323:14:323:14 | t1 | test.swift:323:9:323:9 | SSA def(t2) |
-| test.swift:323:14:323:14 | t1 | test.swift:324:21:324:21 | t1 |
-| test.swift:324:9:324:17 | SSA def(a) | test.swift:334:15:334:15 | a |
-| test.swift:324:9:324:17 | SSA def(b) | test.swift:335:15:335:15 | b |
-| test.swift:324:9:324:17 | SSA def(c) | test.swift:336:15:336:15 | c |
-| test.swift:324:21:324:21 | t1 | test.swift:324:9:324:17 | SSA def(a) |
-| test.swift:324:21:324:21 | t1 | test.swift:324:9:324:17 | SSA def(b) |
-| test.swift:324:21:324:21 | t1 | test.swift:324:9:324:17 | SSA def(c) |
-| test.swift:324:21:324:21 | t1 | test.swift:326:15:326:15 | t1 |
-| test.swift:326:15:326:15 | t1 | test.swift:327:15:327:15 | t1 |
-| test.swift:327:15:327:15 | [post] t1 | test.swift:328:15:328:15 | t1 |
-| test.swift:327:15:327:15 | t1 | test.swift:328:15:328:15 | t1 |
-| test.swift:328:15:328:15 | [post] t1 | test.swift:329:15:329:15 | t1 |
-| test.swift:328:15:328:15 | t1 | test.swift:329:15:329:15 | t1 |
-| test.swift:330:15:330:15 | t2 | test.swift:331:15:331:15 | t2 |
-| test.swift:331:15:331:15 | [post] t2 | test.swift:332:15:332:15 | t2 |
-| test.swift:331:15:331:15 | t2 | test.swift:332:15:332:15 | t2 |
-| test.swift:332:15:332:15 | [post] t2 | test.swift:333:15:333:15 | t2 |
-| test.swift:332:15:332:15 | t2 | test.swift:333:15:333:15 | t2 |
+| test.swift:331:9:331:9 | SSA def(t1) | test.swift:333:15:333:15 | t1 |
+| test.swift:331:14:331:26 | (...) | test.swift:331:9:331:9 | SSA def(t1) |
+| test.swift:333:15:333:15 | t1 | test.swift:334:15:334:15 | t1 |
+| test.swift:334:15:334:15 | [post] t1 | test.swift:335:15:335:15 | t1 |
+| test.swift:334:15:334:15 | t1 | test.swift:335:15:335:15 | t1 |
+| test.swift:335:15:335:15 | [post] t1 | test.swift:337:5:337:5 | t1 |
+| test.swift:335:15:335:15 | t1 | test.swift:337:5:337:5 | t1 |
+| test.swift:337:5:337:5 | [post] t1 | test.swift:339:15:339:15 | t1 |
+| test.swift:337:5:337:5 | t1 | test.swift:339:15:339:15 | t1 |
+| test.swift:339:15:339:15 | t1 | test.swift:340:15:340:15 | t1 |
+| test.swift:340:15:340:15 | [post] t1 | test.swift:341:15:341:15 | t1 |
+| test.swift:340:15:340:15 | t1 | test.swift:341:15:341:15 | t1 |
+| test.swift:341:15:341:15 | [post] t1 | test.swift:343:5:343:5 | t1 |
+| test.swift:341:15:341:15 | t1 | test.swift:343:5:343:5 | t1 |
+| test.swift:343:5:343:5 | [post] t1 | test.swift:345:15:345:15 | t1 |
+| test.swift:343:5:343:5 | t1 | test.swift:345:15:345:15 | t1 |
+| test.swift:345:15:345:15 | t1 | test.swift:346:15:346:15 | t1 |
+| test.swift:346:15:346:15 | [post] t1 | test.swift:347:15:347:15 | t1 |
+| test.swift:346:15:346:15 | t1 | test.swift:347:15:347:15 | t1 |
+| test.swift:351:9:351:9 | SSA def(t1) | test.swift:352:14:352:14 | t1 |
+| test.swift:351:14:351:45 | (...) | test.swift:351:9:351:9 | SSA def(t1) |
+| test.swift:352:9:352:9 | SSA def(t2) | test.swift:359:15:359:15 | t2 |
+| test.swift:352:14:352:14 | t1 | test.swift:352:9:352:9 | SSA def(t2) |
+| test.swift:352:14:352:14 | t1 | test.swift:353:21:353:21 | t1 |
+| test.swift:353:9:353:17 | SSA def(a) | test.swift:363:15:363:15 | a |
+| test.swift:353:9:353:17 | SSA def(b) | test.swift:364:15:364:15 | b |
+| test.swift:353:9:353:17 | SSA def(c) | test.swift:365:15:365:15 | c |
+| test.swift:353:21:353:21 | t1 | test.swift:353:9:353:17 | SSA def(a) |
+| test.swift:353:21:353:21 | t1 | test.swift:353:9:353:17 | SSA def(b) |
+| test.swift:353:21:353:21 | t1 | test.swift:353:9:353:17 | SSA def(c) |
+| test.swift:353:21:353:21 | t1 | test.swift:355:15:355:15 | t1 |
+| test.swift:355:15:355:15 | t1 | test.swift:356:15:356:15 | t1 |
+| test.swift:356:15:356:15 | [post] t1 | test.swift:357:15:357:15 | t1 |
+| test.swift:356:15:356:15 | t1 | test.swift:357:15:357:15 | t1 |
+| test.swift:357:15:357:15 | [post] t1 | test.swift:358:15:358:15 | t1 |
+| test.swift:357:15:357:15 | t1 | test.swift:358:15:358:15 | t1 |
+| test.swift:359:15:359:15 | t2 | test.swift:360:15:360:15 | t2 |
+| test.swift:360:15:360:15 | [post] t2 | test.swift:361:15:361:15 | t2 |
+| test.swift:360:15:360:15 | t2 | test.swift:361:15:361:15 | t2 |
+| test.swift:361:15:361:15 | [post] t2 | test.swift:362:15:362:15 | t2 |
+| test.swift:361:15:361:15 | t2 | test.swift:362:15:362:15 | t2 |

--- a/swift/ql/test/library-tests/dataflow/dataflow/LocalFlow.expected
+++ b/swift/ql/test/library-tests/dataflow/dataflow/LocalFlow.expected
@@ -355,18 +355,22 @@
 | test.swift:430:13:430:33 | SSA def(y) | test.swift:432:19:432:19 | y |
 | test.swift:430:37:430:37 | a | test.swift:430:13:430:33 | SSA def(x) |
 | test.swift:430:37:430:37 | a | test.swift:430:13:430:33 | SSA def(y) |
-| test.swift:436:21:436:27 | SSA def(y) | test.swift:439:27:439:27 | y |
-| test.swift:436:21:436:27 | SSA def(y) | test.swift:444:22:444:22 | y |
-| test.swift:436:21:436:27 | y | test.swift:436:21:436:27 | SSA def(y) |
-| test.swift:437:9:437:9 | SSA def(x) | test.swift:439:16:439:16 | x |
-| test.swift:437:13:437:28 | call to optionalSource() | test.swift:437:9:437:9 | SSA def(x) |
-| test.swift:439:8:439:12 | SSA def(a) | test.swift:440:19:440:19 | a |
-| test.swift:439:16:439:16 | x | test.swift:439:8:439:12 | SSA def(a) |
-| test.swift:439:16:439:16 | x | test.swift:444:19:444:19 | x |
-| test.swift:439:19:439:23 | SSA def(b) | test.swift:441:19:441:19 | b |
-| test.swift:439:27:439:27 | y | test.swift:439:19:439:23 | SSA def(b) |
-| test.swift:439:27:439:27 | y | test.swift:444:22:444:22 | y |
-| test.swift:444:9:444:9 | SSA def(tuple1) | test.swift:445:12:445:12 | tuple1 |
-| test.swift:444:18:444:23 | (...) | test.swift:444:9:444:9 | SSA def(tuple1) |
-| test.swift:446:10:446:37 | SSA def(a) | test.swift:447:19:447:19 | a |
-| test.swift:446:10:446:37 | SSA def(b) | test.swift:448:19:448:19 | b |
+| test.swift:438:21:438:27 | SSA def(y) | test.swift:441:27:441:27 | y |
+| test.swift:438:21:438:27 | SSA def(y) | test.swift:446:22:446:22 | y |
+| test.swift:438:21:438:27 | y | test.swift:438:21:438:27 | SSA def(y) |
+| test.swift:439:9:439:9 | SSA def(x) | test.swift:441:16:441:16 | x |
+| test.swift:439:13:439:28 | call to optionalSource() | test.swift:439:9:439:9 | SSA def(x) |
+| test.swift:441:8:441:12 | SSA def(a) | test.swift:442:19:442:19 | a |
+| test.swift:441:16:441:16 | x | test.swift:441:8:441:12 | SSA def(a) |
+| test.swift:441:16:441:16 | x | test.swift:446:19:446:19 | x |
+| test.swift:441:19:441:23 | SSA def(b) | test.swift:443:19:443:19 | b |
+| test.swift:441:27:441:27 | y | test.swift:441:19:441:23 | SSA def(b) |
+| test.swift:441:27:441:27 | y | test.swift:446:22:446:22 | y |
+| test.swift:446:9:446:9 | SSA def(tuple1) | test.swift:447:12:447:12 | tuple1 |
+| test.swift:446:18:446:23 | (...) | test.swift:446:9:446:9 | SSA def(tuple1) |
+| test.swift:448:10:448:37 | SSA def(a) | test.swift:449:19:449:19 | a |
+| test.swift:448:10:448:37 | SSA def(b) | test.swift:450:19:450:19 | b |
+| test.swift:455:8:455:17 | SSA def(x) | test.swift:456:19:456:19 | x |
+| test.swift:455:8:455:17 | SSA def(y) | test.swift:457:19:457:19 | y |
+| test.swift:455:21:455:29 | call to source2() | test.swift:455:8:455:17 | SSA def(x) |
+| test.swift:455:21:455:29 | call to source2() | test.swift:455:8:455:17 | SSA def(y) |

--- a/swift/ql/test/library-tests/dataflow/dataflow/LocalFlow.expected
+++ b/swift/ql/test/library-tests/dataflow/dataflow/LocalFlow.expected
@@ -242,28 +242,36 @@
 | test.swift:282:26:282:27 | ...! | test.swift:282:15:282:38 | ... ? ... : ... |
 | test.swift:282:31:282:38 | call to source() | test.swift:282:15:282:38 | ... ? ... : ... |
 | test.swift:284:8:284:12 | SSA def(z) | test.swift:285:19:285:19 | z |
+| test.swift:284:16:284:16 | x | test.swift:284:8:284:12 | SSA def(z) |
 | test.swift:284:16:284:16 | x | test.swift:291:16:291:16 | x |
 | test.swift:287:8:287:12 | SSA def(z) | test.swift:288:19:288:19 | z |
+| test.swift:287:16:287:16 | y | test.swift:287:8:287:12 | SSA def(z) |
 | test.swift:287:16:287:16 | y | test.swift:294:16:294:16 | y |
 | test.swift:291:8:291:12 | SSA def(z) | test.swift:292:19:292:19 | z |
 | test.swift:291:16:291:16 | x | test.swift:291:16:291:17 | ...? |
 | test.swift:291:16:291:16 | x | test.swift:298:20:298:20 | x |
+| test.swift:291:16:291:26 | OptionalEvaluationExpr | test.swift:291:8:291:12 | SSA def(z) |
 | test.swift:291:16:291:26 | call to signum() | test.swift:291:16:291:26 | OptionalEvaluationExpr |
 | test.swift:294:8:294:12 | SSA def(z) | test.swift:295:19:295:19 | z |
 | test.swift:294:16:294:16 | y | test.swift:294:16:294:17 | ...? |
 | test.swift:294:16:294:16 | y | test.swift:299:20:299:20 | y |
+| test.swift:294:16:294:26 | OptionalEvaluationExpr | test.swift:294:8:294:12 | SSA def(z) |
 | test.swift:294:16:294:26 | call to signum() | test.swift:294:16:294:26 | OptionalEvaluationExpr |
 | test.swift:298:11:298:15 | SSA def(z1) | test.swift:300:15:300:15 | z1 |
+| test.swift:298:20:298:20 | x | test.swift:298:11:298:15 | SSA def(z1) |
 | test.swift:298:20:298:20 | x | test.swift:303:15:303:15 | x |
 | test.swift:299:11:299:15 | SSA def(z2) | test.swift:301:15:301:15 | z2 |
+| test.swift:299:20:299:20 | y | test.swift:299:11:299:15 | SSA def(z2) |
 | test.swift:299:20:299:20 | y | test.swift:304:15:304:15 | y |
 | test.swift:303:15:303:15 | x | test.swift:303:15:303:16 | ...! |
 | test.swift:303:15:303:15 | x | test.swift:306:28:306:28 | x |
 | test.swift:304:15:304:15 | y | test.swift:304:15:304:16 | ...! |
 | test.swift:304:15:304:15 | y | test.swift:309:28:309:28 | y |
 | test.swift:306:13:306:24 | SSA def(z) | test.swift:307:19:307:19 | z |
+| test.swift:306:28:306:28 | x | test.swift:306:13:306:24 | SSA def(z) |
 | test.swift:306:28:306:28 | x | test.swift:313:12:313:12 | x |
 | test.swift:309:13:309:24 | SSA def(z) | test.swift:310:19:310:19 | z |
+| test.swift:309:28:309:28 | y | test.swift:309:13:309:24 | SSA def(z) |
 | test.swift:309:28:309:28 | y | test.swift:319:12:319:12 | y |
 | test.swift:314:10:314:21 | SSA def(z) | test.swift:315:19:315:19 | z |
 | test.swift:320:10:320:21 | SSA def(z) | test.swift:321:19:321:19 | z |

--- a/swift/ql/test/library-tests/dataflow/dataflow/test.swift
+++ b/swift/ql/test/library-tests/dataflow/dataflow/test.swift
@@ -453,7 +453,7 @@ func testOptionals2(y: Int?) {
     }
 
     if let (x, y) = source2() {
-        sink(arg: x) // $ flow=455
-        sink(arg: y) // $ flow=455
+        sink(arg: x) // (taint but not data flow)
+        sink(arg: y) // (taint but not data flow)
     }
 }

--- a/swift/ql/test/library-tests/dataflow/dataflow/test.swift
+++ b/swift/ql/test/library-tests/dataflow/dataflow/test.swift
@@ -282,14 +282,14 @@ func test_optionals(y: Int?) {
     sink(arg: y != nil ? y! : source()) // $ flow=282
 
     if let z = x {
-        sink(arg: z) // $ MISSING: flow=259
+        sink(arg: z) // $ flow=259
     }
     if let z = y {
         sink(arg: z)
     }
 
-    if let z = x?.signum() { // $ MISSING: flow=259
-        sink(arg: z)
+    if let z = x?.signum() {
+        sink(arg: z) // $ flow=259
     }
     if let z = y?.signum() {
         sink(arg: z)
@@ -297,14 +297,14 @@ func test_optionals(y: Int?) {
 
     guard let z1 = x else { return }
     guard let z2 = y else { return }
-    sink(arg: z1) // $ MISSING: flow=259
+    sink(arg: z1) // $ flow=259
     sink(arg: z2)
 
     sink(arg: x!.signum()) // $ flow=259
     sink(arg: y!.signum())
 
     if case .some(let z) = x {
-        sink(arg: z) // $ MISSING: flow=259
+        sink(arg: z) // $ flow=259
     }
     if case .some(let z) = y {
         sink(arg: z)

--- a/swift/ql/test/library-tests/dataflow/dataflow/test.swift
+++ b/swift/ql/test/library-tests/dataflow/dataflow/test.swift
@@ -287,42 +287,42 @@ func test_optionals(y: Int?) {
     if let z = y {
         sink(arg: z)
     }
+
     if let z = x?.signum() { // $ MISSING: flow=259
         sink(arg: z)
     }
     if let z = y?.signum() {
         sink(arg: z)
     }
+
+    guard let z1 = x else { return }
+    guard let z2 = y else { return }
+    sink(arg: z1) // $ MISSING: flow=259
+    sink(arg: z2)
+
+    sink(arg: x!.signum()) // $ flow=259
+    sink(arg: y!.signum())
+
+    if case .some(let z) = x {
+        sink(arg: z) // $ MISSING: flow=259
+    }
+    if case .some(let z) = y {
+        sink(arg: z)
+    }
+
+    switch x {
+    case .some(let z):
+        sink(arg: z) // $ MISSING: flow=259
+    case .none:
+        ()
+    }
+    switch y {
+    case .some(let z):
+        sink(arg: z)
+    case .none:
+        ()
+    }
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 func sink(arg: (Int, Int)) {}
 func sink(arg: (Int, Int, Int)) {}
@@ -363,4 +363,72 @@ func testTuples2() {
     sink(arg: a) // $ MISSING: flow=351
     sink(arg: b) // $ MISSING: flow=351
     sink(arg: c)
+}
+
+enum MyEnum {
+    case myNone
+    case mySingle(Int)
+    case myPair(Int, Int)
+}
+
+func testEnums() {
+    let a : MyEnum = .myNone
+
+    switch a {
+    case .myNone:
+        ()
+    case .mySingle(let a):
+        sink(arg: a)
+    case .myPair(let a, let b):
+        sink(arg: a)
+        sink(arg: b)
+    }
+
+    if case .mySingle(let x) = a {
+        sink(arg: x)
+    }
+    if case .myPair(let x, let y) = a {
+        sink(arg: x)
+        sink(arg: y)
+    }
+
+    let b : MyEnum = .mySingle(source())
+
+    switch b {
+    case .myNone:
+        ()
+    case .mySingle(let a):
+        sink(arg: a) // $ MISSING: flow=395
+    case .myPair(let a, let b):
+        sink(arg: a)
+        sink(arg: b)
+    }
+
+    if case .mySingle(let x) = a {
+        sink(arg: x) // $ MISSING: flow=395
+    }
+    if case .myPair(let x, let y) = a {
+        sink(arg: x)
+        sink(arg: y)
+    }
+
+    let c = MyEnum.myPair(0, source())
+
+    switch c {
+    case .myNone:
+        ()
+    case .mySingle(let a):
+        sink(arg: a)
+    case .myPair(let a, let b):
+        sink(arg: a)
+        sink(arg: b) // $ MISSING: flow=415
+    }
+
+    if case .mySingle(let x) = a {
+        sink(arg: x)
+    }
+    if case .myPair(let x, let y) = a {
+        sink(arg: x)
+        sink(arg: y) // $ MISSING: flow=415
+    }
 }

--- a/swift/ql/test/library-tests/dataflow/dataflow/test.swift
+++ b/swift/ql/test/library-tests/dataflow/dataflow/test.swift
@@ -433,6 +433,8 @@ func testEnums() {
     }
 }
 
+func source2() -> (Int, Int)? { return nil }
+
 func testOptionals2(y: Int?) {
     let x = optionalSource()
 
@@ -448,5 +450,10 @@ func testOptionals2(y: Int?) {
         sink(arg: b)
     default:
         ()
+    }
+
+    if let (x, y) = source2() {
+        sink(arg: x) // $ flow=455
+        sink(arg: y) // $ flow=455
     }
 }

--- a/swift/ql/test/library-tests/dataflow/dataflow/test.swift
+++ b/swift/ql/test/library-tests/dataflow/dataflow/test.swift
@@ -432,3 +432,21 @@ func testEnums() {
         sink(arg: y) // $ MISSING: flow=415
     }
 }
+
+func testOptionals2(y: Int?) {
+    let x = optionalSource()
+
+    if let a = x, let b = y {
+        sink(arg: a) // $ flow=259
+        sink(arg: b)
+    }
+
+    let tuple1 = (x, y)
+    switch tuple1 {
+    case (.some(let a), .some(let b)):
+        sink(arg: a) // $ MISSING: flow=259
+        sink(arg: b)
+    default:
+        ()
+    }
+}

--- a/swift/ql/test/library-tests/dataflow/dataflow/test.swift
+++ b/swift/ql/test/library-tests/dataflow/dataflow/test.swift
@@ -295,6 +295,35 @@ func test_optionals(y: Int?) {
     }
 }
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 func sink(arg: (Int, Int)) {}
 func sink(arg: (Int, Int, Int)) {}
 
@@ -303,7 +332,7 @@ func testTuples() {
 
     sink(arg: t1)
     sink(arg: t1.0)
-    sink(arg: t1.1) // $ flow=302
+    sink(arg: t1.1) // $ flow=331
 
     t1.1 = 2
 
@@ -314,7 +343,7 @@ func testTuples() {
     t1.0 = source()
 
     sink(arg: t1)
-    sink(arg: t1.0) // $ flow=314
+    sink(arg: t1.0) // $ flow=343
     sink(arg: t1.1)
 }
 
@@ -324,14 +353,14 @@ func testTuples2() {
     let (a, b, c) = t1
 
     sink(arg: t1)
-    sink(arg: t1.x) // $ flow=322
-    sink(arg: t1.y) // $ flow=322
+    sink(arg: t1.x) // $ flow=351
+    sink(arg: t1.y) // $ flow=351
     sink(arg: t1.z)
     sink(arg: t2)
-    sink(arg: t2.x) // $ flow=322
-    sink(arg: t2.y) // $ flow=322
+    sink(arg: t2.x) // $ flow=351
+    sink(arg: t2.y) // $ flow=351
     sink(arg: t2.z)
-    sink(arg: a) // $ MISSING: flow=322
-    sink(arg: b) // $ MISSING: flow=322
+    sink(arg: a) // $ MISSING: flow=351
+    sink(arg: b) // $ MISSING: flow=351
     sink(arg: c)
 }

--- a/swift/ql/test/library-tests/dataflow/taint/LocalTaint.expected
+++ b/swift/ql/test/library-tests/dataflow/taint/LocalTaint.expected
@@ -1276,9 +1276,11 @@
 | url.swift:102:46:102:46 | [post] urlTainted | url.swift:120:46:120:46 | urlTainted |
 | url.swift:102:46:102:46 | urlTainted | url.swift:102:15:102:56 | call to URL.init(string:relativeTo:) |
 | url.swift:102:46:102:46 | urlTainted | url.swift:120:46:120:46 | urlTainted |
+| url.swift:104:5:104:9 | SSA def(x) | url.swift:105:13:105:13 | x |
 | url.swift:104:25:104:25 | [post] clean | url.swift:113:26:113:26 | clean |
 | url.swift:104:25:104:25 | clean | url.swift:104:13:104:30 | call to URL.init(string:) |
 | url.swift:104:25:104:25 | clean | url.swift:113:26:113:26 | clean |
+| url.swift:108:5:108:9 | SSA def(y) | url.swift:109:13:109:13 | y |
 | url.swift:108:25:108:25 | [post] tainted | url.swift:117:28:117:28 | tainted |
 | url.swift:108:25:108:25 | tainted | url.swift:108:13:108:32 | call to URL.init(string:) |
 | url.swift:108:25:108:25 | tainted | url.swift:117:28:117:28 | tainted |

--- a/swift/ql/test/library-tests/dataflow/taint/LocalTaint.expected
+++ b/swift/ql/test/library-tests/dataflow/taint/LocalTaint.expected
@@ -1277,10 +1277,12 @@
 | url.swift:102:46:102:46 | urlTainted | url.swift:102:15:102:56 | call to URL.init(string:relativeTo:) |
 | url.swift:102:46:102:46 | urlTainted | url.swift:120:46:120:46 | urlTainted |
 | url.swift:104:5:104:9 | SSA def(x) | url.swift:105:13:105:13 | x |
+| url.swift:104:13:104:30 | call to URL.init(string:) | url.swift:104:5:104:9 | SSA def(x) |
 | url.swift:104:25:104:25 | [post] clean | url.swift:113:26:113:26 | clean |
 | url.swift:104:25:104:25 | clean | url.swift:104:13:104:30 | call to URL.init(string:) |
 | url.swift:104:25:104:25 | clean | url.swift:113:26:113:26 | clean |
 | url.swift:108:5:108:9 | SSA def(y) | url.swift:109:13:109:13 | y |
+| url.swift:108:13:108:32 | call to URL.init(string:) | url.swift:108:5:108:9 | SSA def(y) |
 | url.swift:108:25:108:25 | [post] tainted | url.swift:117:28:117:28 | tainted |
 | url.swift:108:25:108:25 | tainted | url.swift:108:13:108:32 | call to URL.init(string:) |
 | url.swift:108:25:108:25 | tainted | url.swift:117:28:117:28 | tainted |

--- a/swift/ql/test/library-tests/dataflow/taint/Taint.expected
+++ b/swift/ql/test/library-tests/dataflow/taint/Taint.expected
@@ -326,6 +326,7 @@ edges
 | url.swift:43:2:46:55 | [summary param] 0 in dataTask(with:completionHandler:) :  | file://:0:0:0:0 | [summary] to write: argument 1.parameter 0 in dataTask(with:completionHandler:) :  |
 | url.swift:57:16:57:23 | call to source() :  | url.swift:59:31:59:31 | tainted :  |
 | url.swift:57:16:57:23 | call to source() :  | url.swift:83:24:83:24 | tainted :  |
+| url.swift:57:16:57:23 | call to source() :  | url.swift:108:25:108:25 | tainted :  |
 | url.swift:57:16:57:23 | call to source() :  | url.swift:117:28:117:28 | tainted :  |
 | url.swift:59:19:59:38 | call to URL.init(string:) :  | url.swift:62:12:62:12 | urlTainted |
 | url.swift:59:19:59:38 | call to URL.init(string:) :  | url.swift:64:12:64:23 | .absoluteURL |
@@ -419,6 +420,9 @@ edges
 | url.swift:102:15:102:56 | call to URL.init(string:relativeTo:) :  | url.swift:102:15:102:67 | ...! |
 | url.swift:102:46:102:46 | urlTainted :  | url.swift:9:2:9:43 | [summary param] 1 in URL.init(string:relativeTo:) :  |
 | url.swift:102:46:102:46 | urlTainted :  | url.swift:102:15:102:56 | call to URL.init(string:relativeTo:) :  |
+| url.swift:108:13:108:32 | call to URL.init(string:) :  | url.swift:109:13:109:13 | y |
+| url.swift:108:25:108:25 | tainted :  | url.swift:8:2:8:25 | [summary param] 0 in URL.init(string:) :  |
+| url.swift:108:25:108:25 | tainted :  | url.swift:108:13:108:32 | call to URL.init(string:) :  |
 | url.swift:117:16:117:35 | call to URL.init(string:) :  | url.swift:118:12:118:12 | ...! |
 | url.swift:117:28:117:28 | tainted :  | url.swift:8:2:8:25 | [summary param] 0 in URL.init(string:) :  |
 | url.swift:117:28:117:28 | tainted :  | url.swift:117:16:117:35 | call to URL.init(string:) :  |
@@ -1061,6 +1065,9 @@ nodes
 | url.swift:102:15:102:56 | call to URL.init(string:relativeTo:) :  | semmle.label | call to URL.init(string:relativeTo:) :  |
 | url.swift:102:15:102:67 | ...! | semmle.label | ...! |
 | url.swift:102:46:102:46 | urlTainted :  | semmle.label | urlTainted :  |
+| url.swift:108:13:108:32 | call to URL.init(string:) :  | semmle.label | call to URL.init(string:) :  |
+| url.swift:108:25:108:25 | tainted :  | semmle.label | tainted :  |
+| url.swift:109:13:109:13 | y | semmle.label | y |
 | url.swift:117:16:117:35 | call to URL.init(string:) :  | semmle.label | call to URL.init(string:) :  |
 | url.swift:117:28:117:28 | tainted :  | semmle.label | tainted :  |
 | url.swift:118:12:118:12 | ...! | semmle.label | ...! |
@@ -1261,6 +1268,7 @@ subpaths
 | url.swift:100:43:100:43 | urlTainted :  | url.swift:9:2:9:43 | [summary param] 1 in URL.init(string:relativeTo:) :  | file://:0:0:0:0 | [summary] to write: return (return) in URL.init(string:relativeTo:) :  | url.swift:100:12:100:53 | call to URL.init(string:relativeTo:) :  |
 | url.swift:101:46:101:46 | urlTainted :  | url.swift:9:2:9:43 | [summary param] 1 in URL.init(string:relativeTo:) :  | file://:0:0:0:0 | [summary] to write: return (return) in URL.init(string:relativeTo:) :  | url.swift:101:15:101:56 | call to URL.init(string:relativeTo:) :  |
 | url.swift:102:46:102:46 | urlTainted :  | url.swift:9:2:9:43 | [summary param] 1 in URL.init(string:relativeTo:) :  | file://:0:0:0:0 | [summary] to write: return (return) in URL.init(string:relativeTo:) :  | url.swift:102:15:102:56 | call to URL.init(string:relativeTo:) :  |
+| url.swift:108:25:108:25 | tainted :  | url.swift:8:2:8:25 | [summary param] 0 in URL.init(string:) :  | file://:0:0:0:0 | [summary] to write: return (return) in URL.init(string:) :  | url.swift:108:13:108:32 | call to URL.init(string:) :  |
 | url.swift:117:28:117:28 | tainted :  | url.swift:8:2:8:25 | [summary param] 0 in URL.init(string:) :  | file://:0:0:0:0 | [summary] to write: return (return) in URL.init(string:) :  | url.swift:117:16:117:35 | call to URL.init(string:) :  |
 | webview.swift:84:10:84:10 | source :  | webview.swift:36:5:36:41 | [summary param] this in toObject() :  | file://:0:0:0:0 | [summary] to write: return (return) in toObject() :  | webview.swift:84:10:84:26 | call to toObject() |
 | webview.swift:85:10:85:10 | source :  | webview.swift:37:5:37:55 | [summary param] this in toObjectOf(_:) :  | file://:0:0:0:0 | [summary] to write: return (return) in toObjectOf(_:) :  | webview.swift:85:10:85:41 | call to toObjectOf(_:) |
@@ -1422,6 +1430,7 @@ subpaths
 | url.swift:100:12:100:56 | .standardizedFileURL | url.swift:57:16:57:23 | call to source() :  | url.swift:100:12:100:56 | .standardizedFileURL | result |
 | url.swift:101:15:101:63 | ...! | url.swift:57:16:57:23 | call to source() :  | url.swift:101:15:101:63 | ...! | result |
 | url.swift:102:15:102:67 | ...! | url.swift:57:16:57:23 | call to source() :  | url.swift:102:15:102:67 | ...! | result |
+| url.swift:109:13:109:13 | y | url.swift:57:16:57:23 | call to source() :  | url.swift:109:13:109:13 | y | result |
 | url.swift:118:12:118:12 | ...! | url.swift:57:16:57:23 | call to source() :  | url.swift:118:12:118:12 | ...! | result |
 | url.swift:121:15:121:19 | ...! | url.swift:57:16:57:23 | call to source() :  | url.swift:121:15:121:19 | ...! | result |
 | webview.swift:77:10:77:41 | .body | webview.swift:77:11:77:18 | call to source() :  | webview.swift:77:10:77:41 | .body | result |

--- a/swift/ql/test/library-tests/dataflow/taint/url.swift
+++ b/swift/ql/test/library-tests/dataflow/taint/url.swift
@@ -106,7 +106,7 @@ func taintThroughURL() {
 	}
 
 	if let y = URL(string: tainted) {
-		sink(arg: y) // $ MISSING: tainted=57
+		sink(arg: y) // $ tainted=57
 	}
 
 	var urlClean2 : URL!


### PR DESCRIPTION
Data flow through optional binding, that is:
```
if let x = [optional expression] {
  ...
```

First there are lots of tests, because I was nervous about edge cases.  It turns out `switch case` has the trickiest cases, and we don't support that yet, `if let` wasn't so bad (I intend to come back to `switch case` at a later date).

The change itself, in `DataFlowPrivate.qll`, is straightforward.  I also had to generalize a case in `Ssa.qll`s `variableWrite` predicate, allowing all variables declared in patterns to be Ssa variables, not just those with an associated `PatternBindingDecl` (i.e. a top level `let x = y` or `var x = y` statement).  I think this is reasonable but I'd appreciate @MathiasVP s view.

TODO:
 - [x] check DCA run.
 - [x] create follow-up issue for `switch case`.