### PR TITLE
Swift: make compilation with newer STL possible

### DIFF
--- a/swift/extractor/infra/file/BUILD.bazel
+++ b/swift/extractor/infra/file/BUILD.bazel
@@ -3,7 +3,26 @@ load("//swift:rules.bzl", "swift_cc_library")
 swift_cc_library(
     name = "file",
     srcs = glob(["*.cpp"]),
-    hdrs = glob(["*.h"]),
+    hdrs = glob(["*.h"]) + [":path_hash_workaround"],
     visibility = ["//swift:__subpackages__"],
     deps = ["@picosha2"],
+)
+
+genrule(
+    name = "path_hash_workaround",
+    srcs = [
+        "PathHash.h.workaround",
+        "PathHash.h.fixed",
+    ],
+    outs = ["PathHash.h"],
+    # see if https://cplusplus.github.io/LWG/issue3657 is fixed with the current compiler or not
+    # if fixed, PathHash.h.workaround will not compile
+    cmd = "\n".join([
+        "if $(CC) -c -x c++ -std=c++17 $(rootpath PathHash.h.workaround) -o /dev/null &> /dev/null; then",
+        "  cp $(rootpath PathHash.h.workaround) $@",
+        "else",
+        "  cp $(rootpath PathHash.h.fixed) $@",
+        "fi",
+    ]),
+    toolchains = ["@bazel_tools//tools/cpp:current_cc_host_toolchain"],
 )

--- a/swift/extractor/infra/file/BUILD.bazel
+++ b/swift/extractor/infra/file/BUILD.bazel
@@ -18,7 +18,8 @@ genrule(
     # see if https://cplusplus.github.io/LWG/issue3657 is fixed with the current compiler or not
     # if fixed, PathHash.h.workaround will not compile
     cmd = "\n".join([
-        "if $(CC) -c -x c++ -std=c++17 $(rootpath PathHash.h.workaround) -o /dev/null &> /dev/null; then",
+        "if $(CC) -c -x c++ -std=c++17 -Wno-pragma-once-outside-header \\",
+        "    $(rootpath PathHash.h.workaround) -o /dev/null &> /dev/null; then",
         "  cp $(rootpath PathHash.h.workaround) $@",
         "else",
         "  cp $(rootpath PathHash.h.fixed) $@",

--- a/swift/extractor/infra/file/BUILD.bazel
+++ b/swift/extractor/infra/file/BUILD.bazel
@@ -18,12 +18,11 @@ genrule(
     # see if https://cplusplus.github.io/LWG/issue3657 is fixed with the current compiler or not
     # if fixed, PathHash.h.workaround will not compile
     cmd = "\n".join([
-        "if $(CC) -c -x c++ -std=c++17 -Wno-pragma-once-outside-header \\",
+        "if clang -c -x c++ -std=c++17 -Wno-pragma-once-outside-header \\",
         "    $(rootpath PathHash.h.workaround) -o /dev/null &> /dev/null; then",
         "  cp $(rootpath PathHash.h.workaround) $@",
         "else",
         "  cp $(rootpath PathHash.h.fixed) $@",
         "fi",
     ]),
-    toolchains = ["@bazel_tools//tools/cpp:current_cc_host_toolchain"],
 )

--- a/swift/extractor/infra/file/PathHash.h.fixed
+++ b/swift/extractor/infra/file/PathHash.h.fixed
@@ -1,0 +1,4 @@
+#pragma once
+
+#include <filesystem>
+#include <functional>

--- a/swift/extractor/infra/file/PathHash.h.workaround
+++ b/swift/extractor/infra/file/PathHash.h.workaround
@@ -8,8 +8,6 @@
 // but it works, and this is recognized as a defect of the standard.
 // Using a non-standard Hasher type would be a huge pain, as the automatic hash implementation of
 // std::variant would not kick in (we use std::filesystem::path in a variant used as a map key).
-// We can reconsider when the fix to the above issue hits clang, which might require a version check
-// here
 namespace std {
 template <>
 struct std::hash<std::filesystem::path> {

--- a/swift/extractor/infra/file/PathHash.h.workaround
+++ b/swift/extractor/infra/file/PathHash.h.workaround
@@ -10,7 +10,8 @@
 // std::variant would not kick in (we use std::filesystem::path in a variant used as a map key).
 namespace std {
 template <>
-struct std::hash<std::filesystem::path> {
-  std::size_t operator()(const std::filesystem::path& path) const { return hash_value(path); }
+struct hash<filesystem::path> {
+  size_t operator()(const filesystem::path& path) const { return hash_value(path); }
 };
+
 }  // namespace std


### PR DESCRIPTION
Previous to this patch the code contained a workaround for the standard
defect

https://cplusplus.github.io/LWG/issue3657

where `std::filesystem::path` did not have a `std::hash` implementation.

This patch allows compiling against versions of the STL that contain the
fix to the above issue. This is done by running the compiler against
code defining `std::hash<std::filesystem::path>`: if compilation
succeeds, it means the fix is not there and we need to use the
workaround, contained in `PathHash.h.workaround`. Otherwise, the fix is
there and we use `PathHash.h.fixed` instead, which only includes the
standard headers included by `PathHash.h.workaround`, so that one is a
drop-in replacement of the other.