### PR TITLE
QL: move queries folder instead of .cache folder now that we got .qlx

### DIFF
--- a/.github/workflows/ql-for-ql-build.yml
+++ b/.github/workflows/ql-for-ql-build.yml
@@ -145,7 +145,7 @@ jobs:
           tools: ${{ steps.find-latest-bundle.outputs.url }}
       - name: Move pack cache
         run: |
-          cp -r ${PACK}/.cache ql/ql/src/.cache
+          cp -r ${PACK}/queries ql/ql/src
         env:
           PACK: ${{ runner.temp }}/pack
 

--- a/.github/workflows/ql-for-ql-build.yml
+++ b/.github/workflows/ql-for-ql-build.yml
@@ -27,7 +27,7 @@ jobs:
         uses: ./.github/actions/find-latest-bundle
       - name: Find codeql
         id: find-codeql
-        uses: github/codeql-action/init@77a8d2d10c0b403a8b4aadbd223dc489ecd22683
+        uses: github/codeql-action/init@45955cb1830b640e2c1603ad72ad542a49d47b96
         with:
           languages: javascript # does not matter
           tools: ${{ steps.find-latest-bundle.outputs.url }}
@@ -137,7 +137,7 @@ jobs:
         env:
           CONF: ./ql-for-ql-config.yml
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@77a8d2d10c0b403a8b4aadbd223dc489ecd22683
+        uses: github/codeql-action/init@45955cb1830b640e2c1603ad72ad542a49d47b96
         with:
           languages: ql
           db-location: ${{ runner.temp }}/db
@@ -150,7 +150,7 @@ jobs:
           PACK: ${{ runner.temp }}/pack
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@77a8d2d10c0b403a8b4aadbd223dc489ecd22683
+        uses: github/codeql-action/analyze@45955cb1830b640e2c1603ad72ad542a49d47b96
         with:
           category: "ql-for-ql"
       - name: Copy sarif file to CWD

--- a/.github/workflows/ql-for-ql-build.yml
+++ b/.github/workflows/ql-for-ql-build.yml
@@ -143,7 +143,7 @@ jobs:
           db-location: ${{ runner.temp }}/db
           config-file: ./ql-for-ql-config.yml
           tools: ${{ steps.find-latest-bundle.outputs.url }}
-      - name: Move pack cache
+      - name: Move pack queries
         run: |
           cp -r ${PACK}/queries ql/ql/src
         env:

--- a/.github/workflows/ql-for-ql-dataset_measure.yml
+++ b/.github/workflows/ql-for-ql-dataset_measure.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Find codeql
         id: find-codeql
-        uses: github/codeql-action/init@77a8d2d10c0b403a8b4aadbd223dc489ecd22683
+        uses: github/codeql-action/init@45955cb1830b640e2c1603ad72ad542a49d47b96
         with:
           languages: javascript # does not matter
       - uses: actions/cache@v3

--- a/.github/workflows/ql-for-ql-tests.yml
+++ b/.github/workflows/ql-for-ql-tests.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Find codeql
         id: find-codeql
-        uses: github/codeql-action/init@77a8d2d10c0b403a8b4aadbd223dc489ecd22683
+        uses: github/codeql-action/init@45955cb1830b640e2c1603ad72ad542a49d47b96
         with:
           languages: javascript # does not matter
       - uses: actions/cache@v3


### PR DESCRIPTION
The codeql-action update was just cherry-picking the "all QL as a language"-commit on top of the latest `main`. 

---- 

With CodeQL 2.12.0 `codeql pack create` no longer creates a `.cache/` folder. 
It instead creates a `queries/` folder that contains `*.qlx` files that mirror the queries in `src/`.  
These are now placed next to the `.ql` files in `src/`.  
CodeQL still complains a bit, but everything seems to work 🤷 