### PR TITLE
JS: Fixup some problems in PrintAST

### DIFF
--- a/javascript/ql/lib/semmle/javascript/PrintAst.qll
+++ b/javascript/ql/lib/semmle/javascript/PrintAst.qll
@@ -30,11 +30,16 @@ private predicate shouldPrint(Locatable e, Location l) {
   exists(PrintAstConfiguration config | config.shouldPrint(e, l))
 }
 
-/** Holds if the given element does not need to be rendered in the AST, due to being the `TopLevel` for a file. */
+/**
+ * Holds if the given element does not need to be rendered in the AST.
+ * Either due to being the `TopLevel` for a file, or an internal node representing a decorator list.
+ */
 private predicate isNotNeeded(Locatable el) {
   el instanceof TopLevel and
   el.getLocation().getStartLine() = 0 and
   el.getLocation().getStartColumn() = 0
+  or
+  el instanceof @decorator_list // there is no public API for this.
   or
   // relaxing aggressive type inference.
   none()
@@ -500,9 +505,11 @@ private module PrintJavaScript {
     override Parameter element;
 
     override AstNode getChildNode(int childIndex) {
-      childIndex = 0 and result = element.getTypeAnnotation()
+      result = super.getChildNode(childIndex) // in case the parameter is a destructuring pattern
       or
-      childIndex = 1 and result = element.getDefault()
+      childIndex = -2 and result = element.getTypeAnnotation()
+      or
+      childIndex = -1 and result = element.getDefault()
     }
   }
 

--- a/javascript/ql/test/library-tests/AST/Decorators/printAst.expected
+++ b/javascript/ql/test/library-tests/AST/Decorators/printAst.expected
@@ -1,0 +1,138 @@
+nodes
+| file://:0:0:0:0 | (Arguments) | semmle.label | (Arguments) |
+| file://:0:0:0:0 | (Parameters) | semmle.label | (Parameters) |
+| tst.ts:1:1:1:22 | [DeclStmt] const Dec = ... | semmle.label | [DeclStmt] const Dec = ... |
+| tst.ts:1:1:1:22 | [DeclStmt] const Dec = ... | semmle.order | 1 |
+| tst.ts:1:7:1:9 | [VarDecl] Dec | semmle.label | [VarDecl] Dec |
+| tst.ts:1:7:1:21 | [VariableDeclarator] Dec: any = null | semmle.label | [VariableDeclarator] Dec: any = null |
+| tst.ts:1:12:1:14 | [KeywordTypeExpr] any | semmle.label | [KeywordTypeExpr] any |
+| tst.ts:1:18:1:21 | [Literal] null | semmle.label | [Literal] null |
+| tst.ts:3:1:3:6 | [Decorator] @Dec() | semmle.label | [Decorator] @Dec() |
+| tst.ts:3:2:3:4 | [VarRef] Dec | semmle.label | [VarRef] Dec |
+| tst.ts:3:2:3:6 | [CallExpr] Dec() | semmle.label | [CallExpr] Dec() |
+| tst.ts:4:1:8:1 | [ExportDeclaration] export ... id {} } | semmle.label | [ExportDeclaration] export ... id {} } |
+| tst.ts:4:1:8:1 | [ExportDeclaration] export ... id {} } | semmle.order | 2 |
+| tst.ts:4:8:8:1 | [ClassDefinition,TypeDefinition] class O ... id {} } | semmle.label | [ClassDefinition,TypeDefinition] class O ... id {} } |
+| tst.ts:4:14:4:30 | [VarDecl] OperatorResolvers | semmle.label | [VarDecl] OperatorResolvers |
+| tst.ts:4:32:4:31 | [BlockStmt] {} | semmle.label | [BlockStmt] {} |
+| tst.ts:4:32:4:31 | [ClassInitializedMember,ConstructorDefinition] constructor() {} | semmle.label | [ClassInitializedMember,ConstructorDefinition] constructor() {} |
+| tst.ts:4:32:4:31 | [FunctionExpr] () {} | semmle.label | [FunctionExpr] () {} |
+| tst.ts:4:32:4:31 | [Label] constructor | semmle.label | [Label] constructor |
+| tst.ts:5:3:5:8 | [Decorator] @Dec() | semmle.label | [Decorator] @Dec() |
+| tst.ts:5:4:5:6 | [VarRef] Dec | semmle.label | [VarRef] Dec |
+| tst.ts:5:4:5:8 | [CallExpr] Dec() | semmle.label | [CallExpr] Dec() |
+| tst.ts:6:3:6:8 | [Decorator] @Dec() | semmle.label | [Decorator] @Dec() |
+| tst.ts:6:4:6:6 | [VarRef] Dec | semmle.label | [VarRef] Dec |
+| tst.ts:6:4:6:8 | [CallExpr] Dec() | semmle.label | [CallExpr] Dec() |
+| tst.ts:7:3:7:11 | [Label] operators | semmle.label | [Label] operators |
+| tst.ts:7:3:7:22 | [ClassInitializedMember,MethodDefinition] operators(): void {} | semmle.label | [ClassInitializedMember,MethodDefinition] operators(): void {} |
+| tst.ts:7:3:7:22 | [FunctionExpr] operators(): void {} | semmle.label | [FunctionExpr] operators(): void {} |
+| tst.ts:7:16:7:19 | [KeywordTypeExpr] void | semmle.label | [KeywordTypeExpr] void |
+| tst.ts:7:21:7:22 | [BlockStmt] {} | semmle.label | [BlockStmt] {} |
+| tst.ts:10:1:10:41 | [DeclStmt] const createMethodDecorator = ... | semmle.label | [DeclStmt] const createMethodDecorator = ... |
+| tst.ts:10:1:10:41 | [DeclStmt] const createMethodDecorator = ... | semmle.order | 3 |
+| tst.ts:10:7:10:27 | [VarDecl] createMethodDecorator | semmle.label | [VarDecl] createMethodDecorator |
+| tst.ts:10:7:10:40 | [VariableDeclarator] createM ... = null | semmle.label | [VariableDeclarator] createM ... = null |
+| tst.ts:10:31:10:33 | [KeywordTypeExpr] any | semmle.label | [KeywordTypeExpr] any |
+| tst.ts:10:37:10:40 | [Literal] null | semmle.label | [Literal] null |
+| tst.ts:12:1:12:21 | [VarRef] createMethodDecorator | semmle.label | [VarRef] createMethodDecorator |
+| tst.ts:12:1:14:2 | [CallExpr] createM ... { }) | semmle.label | [CallExpr] createM ... { }) |
+| tst.ts:12:1:14:3 | [ExprStmt] createM ... }); | semmle.label | [ExprStmt] createM ... }); |
+| tst.ts:12:1:14:3 | [ExprStmt] createM ... }); | semmle.order | 4 |
+| tst.ts:12:23:14:1 | [ArrowFunctionExpr] ({ args ... { } | semmle.label | [ArrowFunctionExpr] ({ args ... { } |
+| tst.ts:12:24:12:40 | [ObjectPattern,Parameter] { args, context } | semmle.label | [ObjectPattern,Parameter] { args, context } |
+| tst.ts:12:26:12:29 | [Label] args | semmle.label | [Label] args |
+| tst.ts:12:26:12:29 | [PropertyPattern] args | semmle.label | [PropertyPattern] args |
+| tst.ts:12:26:12:29 | [VarDecl] args | semmle.label | [VarDecl] args |
+| tst.ts:12:32:12:38 | [Label] context | semmle.label | [Label] context |
+| tst.ts:12:32:12:38 | [PropertyPattern] context | semmle.label | [PropertyPattern] context |
+| tst.ts:12:32:12:38 | [VarDecl] context | semmle.label | [VarDecl] context |
+| tst.ts:12:43:12:46 | [SimpleParameter] next | semmle.label | [SimpleParameter] next |
+| tst.ts:12:52:14:1 | [BlockStmt] { } | semmle.label | [BlockStmt] { } |
+edges
+| file://:0:0:0:0 | (Arguments) | tst.ts:12:23:14:1 | [ArrowFunctionExpr] ({ args ... { } | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | tst.ts:12:23:14:1 | [ArrowFunctionExpr] ({ args ... { } | semmle.order | 0 |
+| file://:0:0:0:0 | (Parameters) | tst.ts:12:24:12:40 | [ObjectPattern,Parameter] { args, context } | semmle.label | 0 |
+| file://:0:0:0:0 | (Parameters) | tst.ts:12:24:12:40 | [ObjectPattern,Parameter] { args, context } | semmle.order | 0 |
+| file://:0:0:0:0 | (Parameters) | tst.ts:12:43:12:46 | [SimpleParameter] next | semmle.label | 1 |
+| file://:0:0:0:0 | (Parameters) | tst.ts:12:43:12:46 | [SimpleParameter] next | semmle.order | 1 |
+| tst.ts:1:1:1:22 | [DeclStmt] const Dec = ... | tst.ts:1:7:1:21 | [VariableDeclarator] Dec: any = null | semmle.label | 1 |
+| tst.ts:1:1:1:22 | [DeclStmt] const Dec = ... | tst.ts:1:7:1:21 | [VariableDeclarator] Dec: any = null | semmle.order | 1 |
+| tst.ts:1:7:1:21 | [VariableDeclarator] Dec: any = null | tst.ts:1:7:1:9 | [VarDecl] Dec | semmle.label | 1 |
+| tst.ts:1:7:1:21 | [VariableDeclarator] Dec: any = null | tst.ts:1:7:1:9 | [VarDecl] Dec | semmle.order | 1 |
+| tst.ts:1:7:1:21 | [VariableDeclarator] Dec: any = null | tst.ts:1:12:1:14 | [KeywordTypeExpr] any | semmle.label | 2 |
+| tst.ts:1:7:1:21 | [VariableDeclarator] Dec: any = null | tst.ts:1:12:1:14 | [KeywordTypeExpr] any | semmle.order | 2 |
+| tst.ts:1:7:1:21 | [VariableDeclarator] Dec: any = null | tst.ts:1:18:1:21 | [Literal] null | semmle.label | 3 |
+| tst.ts:1:7:1:21 | [VariableDeclarator] Dec: any = null | tst.ts:1:18:1:21 | [Literal] null | semmle.order | 3 |
+| tst.ts:3:1:3:6 | [Decorator] @Dec() | tst.ts:3:2:3:6 | [CallExpr] Dec() | semmle.label | 1 |
+| tst.ts:3:1:3:6 | [Decorator] @Dec() | tst.ts:3:2:3:6 | [CallExpr] Dec() | semmle.order | 1 |
+| tst.ts:3:2:3:6 | [CallExpr] Dec() | tst.ts:3:2:3:4 | [VarRef] Dec | semmle.label | 0 |
+| tst.ts:3:2:3:6 | [CallExpr] Dec() | tst.ts:3:2:3:4 | [VarRef] Dec | semmle.order | 0 |
+| tst.ts:4:1:8:1 | [ExportDeclaration] export ... id {} } | tst.ts:4:8:8:1 | [ClassDefinition,TypeDefinition] class O ... id {} } | semmle.label | 1 |
+| tst.ts:4:1:8:1 | [ExportDeclaration] export ... id {} } | tst.ts:4:8:8:1 | [ClassDefinition,TypeDefinition] class O ... id {} } | semmle.order | 1 |
+| tst.ts:4:8:8:1 | [ClassDefinition,TypeDefinition] class O ... id {} } | tst.ts:3:1:3:6 | [Decorator] @Dec() | semmle.label | 1 |
+| tst.ts:4:8:8:1 | [ClassDefinition,TypeDefinition] class O ... id {} } | tst.ts:3:1:3:6 | [Decorator] @Dec() | semmle.order | 1 |
+| tst.ts:4:8:8:1 | [ClassDefinition,TypeDefinition] class O ... id {} } | tst.ts:4:14:4:30 | [VarDecl] OperatorResolvers | semmle.label | 2 |
+| tst.ts:4:8:8:1 | [ClassDefinition,TypeDefinition] class O ... id {} } | tst.ts:4:14:4:30 | [VarDecl] OperatorResolvers | semmle.order | 2 |
+| tst.ts:4:8:8:1 | [ClassDefinition,TypeDefinition] class O ... id {} } | tst.ts:4:32:4:31 | [ClassInitializedMember,ConstructorDefinition] constructor() {} | semmle.label | 3 |
+| tst.ts:4:8:8:1 | [ClassDefinition,TypeDefinition] class O ... id {} } | tst.ts:4:32:4:31 | [ClassInitializedMember,ConstructorDefinition] constructor() {} | semmle.order | 3 |
+| tst.ts:4:8:8:1 | [ClassDefinition,TypeDefinition] class O ... id {} } | tst.ts:7:3:7:22 | [ClassInitializedMember,MethodDefinition] operators(): void {} | semmle.label | 4 |
+| tst.ts:4:8:8:1 | [ClassDefinition,TypeDefinition] class O ... id {} } | tst.ts:7:3:7:22 | [ClassInitializedMember,MethodDefinition] operators(): void {} | semmle.order | 4 |
+| tst.ts:4:32:4:31 | [ClassInitializedMember,ConstructorDefinition] constructor() {} | tst.ts:4:32:4:31 | [FunctionExpr] () {} | semmle.label | 2 |
+| tst.ts:4:32:4:31 | [ClassInitializedMember,ConstructorDefinition] constructor() {} | tst.ts:4:32:4:31 | [FunctionExpr] () {} | semmle.order | 2 |
+| tst.ts:4:32:4:31 | [ClassInitializedMember,ConstructorDefinition] constructor() {} | tst.ts:4:32:4:31 | [Label] constructor | semmle.label | 1 |
+| tst.ts:4:32:4:31 | [ClassInitializedMember,ConstructorDefinition] constructor() {} | tst.ts:4:32:4:31 | [Label] constructor | semmle.order | 1 |
+| tst.ts:4:32:4:31 | [FunctionExpr] () {} | tst.ts:4:32:4:31 | [BlockStmt] {} | semmle.label | 5 |
+| tst.ts:4:32:4:31 | [FunctionExpr] () {} | tst.ts:4:32:4:31 | [BlockStmt] {} | semmle.order | 5 |
+| tst.ts:5:3:5:8 | [Decorator] @Dec() | tst.ts:5:4:5:8 | [CallExpr] Dec() | semmle.label | 1 |
+| tst.ts:5:3:5:8 | [Decorator] @Dec() | tst.ts:5:4:5:8 | [CallExpr] Dec() | semmle.order | 1 |
+| tst.ts:5:4:5:8 | [CallExpr] Dec() | tst.ts:5:4:5:6 | [VarRef] Dec | semmle.label | 0 |
+| tst.ts:5:4:5:8 | [CallExpr] Dec() | tst.ts:5:4:5:6 | [VarRef] Dec | semmle.order | 0 |
+| tst.ts:6:3:6:8 | [Decorator] @Dec() | tst.ts:6:4:6:8 | [CallExpr] Dec() | semmle.label | 1 |
+| tst.ts:6:3:6:8 | [Decorator] @Dec() | tst.ts:6:4:6:8 | [CallExpr] Dec() | semmle.order | 1 |
+| tst.ts:6:4:6:8 | [CallExpr] Dec() | tst.ts:6:4:6:6 | [VarRef] Dec | semmle.label | 0 |
+| tst.ts:6:4:6:8 | [CallExpr] Dec() | tst.ts:6:4:6:6 | [VarRef] Dec | semmle.order | 0 |
+| tst.ts:7:3:7:22 | [ClassInitializedMember,MethodDefinition] operators(): void {} | tst.ts:5:3:5:8 | [Decorator] @Dec() | semmle.label | 1 |
+| tst.ts:7:3:7:22 | [ClassInitializedMember,MethodDefinition] operators(): void {} | tst.ts:5:3:5:8 | [Decorator] @Dec() | semmle.order | 1 |
+| tst.ts:7:3:7:22 | [ClassInitializedMember,MethodDefinition] operators(): void {} | tst.ts:6:3:6:8 | [Decorator] @Dec() | semmle.label | 2 |
+| tst.ts:7:3:7:22 | [ClassInitializedMember,MethodDefinition] operators(): void {} | tst.ts:6:3:6:8 | [Decorator] @Dec() | semmle.order | 2 |
+| tst.ts:7:3:7:22 | [ClassInitializedMember,MethodDefinition] operators(): void {} | tst.ts:7:3:7:11 | [Label] operators | semmle.label | 3 |
+| tst.ts:7:3:7:22 | [ClassInitializedMember,MethodDefinition] operators(): void {} | tst.ts:7:3:7:11 | [Label] operators | semmle.order | 3 |
+| tst.ts:7:3:7:22 | [ClassInitializedMember,MethodDefinition] operators(): void {} | tst.ts:7:3:7:22 | [FunctionExpr] operators(): void {} | semmle.label | 4 |
+| tst.ts:7:3:7:22 | [ClassInitializedMember,MethodDefinition] operators(): void {} | tst.ts:7:3:7:22 | [FunctionExpr] operators(): void {} | semmle.order | 4 |
+| tst.ts:7:3:7:22 | [FunctionExpr] operators(): void {} | tst.ts:7:16:7:19 | [KeywordTypeExpr] void | semmle.label | 4 |
+| tst.ts:7:3:7:22 | [FunctionExpr] operators(): void {} | tst.ts:7:16:7:19 | [KeywordTypeExpr] void | semmle.order | 4 |
+| tst.ts:7:3:7:22 | [FunctionExpr] operators(): void {} | tst.ts:7:21:7:22 | [BlockStmt] {} | semmle.label | 5 |
+| tst.ts:7:3:7:22 | [FunctionExpr] operators(): void {} | tst.ts:7:21:7:22 | [BlockStmt] {} | semmle.order | 5 |
+| tst.ts:10:1:10:41 | [DeclStmt] const createMethodDecorator = ... | tst.ts:10:7:10:40 | [VariableDeclarator] createM ... = null | semmle.label | 1 |
+| tst.ts:10:1:10:41 | [DeclStmt] const createMethodDecorator = ... | tst.ts:10:7:10:40 | [VariableDeclarator] createM ... = null | semmle.order | 1 |
+| tst.ts:10:7:10:40 | [VariableDeclarator] createM ... = null | tst.ts:10:7:10:27 | [VarDecl] createMethodDecorator | semmle.label | 1 |
+| tst.ts:10:7:10:40 | [VariableDeclarator] createM ... = null | tst.ts:10:7:10:27 | [VarDecl] createMethodDecorator | semmle.order | 1 |
+| tst.ts:10:7:10:40 | [VariableDeclarator] createM ... = null | tst.ts:10:31:10:33 | [KeywordTypeExpr] any | semmle.label | 2 |
+| tst.ts:10:7:10:40 | [VariableDeclarator] createM ... = null | tst.ts:10:31:10:33 | [KeywordTypeExpr] any | semmle.order | 2 |
+| tst.ts:10:7:10:40 | [VariableDeclarator] createM ... = null | tst.ts:10:37:10:40 | [Literal] null | semmle.label | 3 |
+| tst.ts:10:7:10:40 | [VariableDeclarator] createM ... = null | tst.ts:10:37:10:40 | [Literal] null | semmle.order | 3 |
+| tst.ts:12:1:14:2 | [CallExpr] createM ... { }) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| tst.ts:12:1:14:2 | [CallExpr] createM ... { }) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| tst.ts:12:1:14:2 | [CallExpr] createM ... { }) | tst.ts:12:1:12:21 | [VarRef] createMethodDecorator | semmle.label | 0 |
+| tst.ts:12:1:14:2 | [CallExpr] createM ... { }) | tst.ts:12:1:12:21 | [VarRef] createMethodDecorator | semmle.order | 0 |
+| tst.ts:12:1:14:3 | [ExprStmt] createM ... }); | tst.ts:12:1:14:2 | [CallExpr] createM ... { }) | semmle.label | 1 |
+| tst.ts:12:1:14:3 | [ExprStmt] createM ... }); | tst.ts:12:1:14:2 | [CallExpr] createM ... { }) | semmle.order | 1 |
+| tst.ts:12:23:14:1 | [ArrowFunctionExpr] ({ args ... { } | file://:0:0:0:0 | (Parameters) | semmle.label | 1 |
+| tst.ts:12:23:14:1 | [ArrowFunctionExpr] ({ args ... { } | file://:0:0:0:0 | (Parameters) | semmle.order | 1 |
+| tst.ts:12:23:14:1 | [ArrowFunctionExpr] ({ args ... { } | tst.ts:12:52:14:1 | [BlockStmt] { } | semmle.label | 5 |
+| tst.ts:12:23:14:1 | [ArrowFunctionExpr] ({ args ... { } | tst.ts:12:52:14:1 | [BlockStmt] { } | semmle.order | 5 |
+| tst.ts:12:24:12:40 | [ObjectPattern,Parameter] { args, context } | tst.ts:12:26:12:29 | [PropertyPattern] args | semmle.label | 1 |
+| tst.ts:12:24:12:40 | [ObjectPattern,Parameter] { args, context } | tst.ts:12:26:12:29 | [PropertyPattern] args | semmle.order | 1 |
+| tst.ts:12:24:12:40 | [ObjectPattern,Parameter] { args, context } | tst.ts:12:32:12:38 | [PropertyPattern] context | semmle.label | 2 |
+| tst.ts:12:24:12:40 | [ObjectPattern,Parameter] { args, context } | tst.ts:12:32:12:38 | [PropertyPattern] context | semmle.order | 2 |
+| tst.ts:12:26:12:29 | [PropertyPattern] args | tst.ts:12:26:12:29 | [Label] args | semmle.label | 1 |
+| tst.ts:12:26:12:29 | [PropertyPattern] args | tst.ts:12:26:12:29 | [Label] args | semmle.order | 1 |
+| tst.ts:12:26:12:29 | [PropertyPattern] args | tst.ts:12:26:12:29 | [VarDecl] args | semmle.label | 2 |
+| tst.ts:12:26:12:29 | [PropertyPattern] args | tst.ts:12:26:12:29 | [VarDecl] args | semmle.order | 2 |
+| tst.ts:12:32:12:38 | [PropertyPattern] context | tst.ts:12:32:12:38 | [Label] context | semmle.label | 1 |
+| tst.ts:12:32:12:38 | [PropertyPattern] context | tst.ts:12:32:12:38 | [Label] context | semmle.order | 1 |
+| tst.ts:12:32:12:38 | [PropertyPattern] context | tst.ts:12:32:12:38 | [VarDecl] context | semmle.label | 2 |
+| tst.ts:12:32:12:38 | [PropertyPattern] context | tst.ts:12:32:12:38 | [VarDecl] context | semmle.order | 2 |
+graphProperties
+| semmle.graphKind | tree |

--- a/javascript/ql/test/library-tests/AST/Decorators/printAst.ql
+++ b/javascript/ql/test/library-tests/AST/Decorators/printAst.ql
@@ -1,0 +1,2 @@
+import javascript
+import semmle.javascript.PrintAst

--- a/javascript/ql/test/library-tests/AST/Decorators/tsconfig.json
+++ b/javascript/ql/test/library-tests/AST/Decorators/tsconfig.json
@@ -1,0 +1,7 @@
+{
+    "compilerOptions": {
+        "experimentalDecorators": true
+    },
+    "include": ["**/*.ts"],
+    "lib": ["es2015", "dom"]
+}

--- a/javascript/ql/test/library-tests/AST/Decorators/tst.ts
+++ b/javascript/ql/test/library-tests/AST/Decorators/tst.ts
@@ -1,0 +1,14 @@
+const Dec: any = null;
+
+@Dec()
+export class OperatorResolvers {
+  @Dec()
+  @Dec()
+  operators(): void {}
+}
+
+const createMethodDecorator : any = null;
+
+createMethodDecorator(({ args, context }, next) => {
+		
+});

--- a/javascript/ql/test/library-tests/TypeScript/TypeAnnotations/printAst.expected
+++ b/javascript/ql/test/library-tests/TypeScript/TypeAnnotations/printAst.expected
@@ -1292,16 +1292,16 @@ edges
 | tst.ts:24:3:24:46 | [MethodSignature] takeNum ... umber); | tst.ts:24:3:24:18 | [Label] takeNumberMethod | semmle.order | 1 |
 | tst.ts:24:3:24:46 | [MethodSignature] takeNum ... umber); | tst.ts:24:3:24:46 | [FunctionExpr] takeNum ... umber); | semmle.label | 2 |
 | tst.ts:24:3:24:46 | [MethodSignature] takeNum ... umber); | tst.ts:24:3:24:46 | [FunctionExpr] takeNum ... umber); | semmle.order | 2 |
-| tst.ts:24:20:24:36 | [SimpleParameter] numberMethodParam | tst.ts:24:39:24:44 | [KeywordTypeExpr] number | semmle.label | 0 |
-| tst.ts:24:20:24:36 | [SimpleParameter] numberMethodParam | tst.ts:24:39:24:44 | [KeywordTypeExpr] number | semmle.order | 0 |
+| tst.ts:24:20:24:36 | [SimpleParameter] numberMethodParam | tst.ts:24:39:24:44 | [KeywordTypeExpr] number | semmle.label | -2 |
+| tst.ts:24:20:24:36 | [SimpleParameter] numberMethodParam | tst.ts:24:39:24:44 | [KeywordTypeExpr] number | semmle.order | -2 |
 | tst.ts:25:3:25:55 | [FunctionExpr] takeInt ... rface); | file://:0:0:0:0 | (Parameters) | semmle.label | 1 |
 | tst.ts:25:3:25:55 | [FunctionExpr] takeInt ... rface); | file://:0:0:0:0 | (Parameters) | semmle.order | 1 |
 | tst.ts:25:3:25:55 | [MethodSignature] takeInt ... rface); | tst.ts:25:3:25:21 | [Label] takeInterfaceMethod | semmle.label | 1 |
 | tst.ts:25:3:25:55 | [MethodSignature] takeInt ... rface); | tst.ts:25:3:25:21 | [Label] takeInterfaceMethod | semmle.order | 1 |
 | tst.ts:25:3:25:55 | [MethodSignature] takeInt ... rface); | tst.ts:25:3:25:55 | [FunctionExpr] takeInt ... rface); | semmle.label | 2 |
 | tst.ts:25:3:25:55 | [MethodSignature] takeInt ... rface); | tst.ts:25:3:25:55 | [FunctionExpr] takeInt ... rface); | semmle.order | 2 |
-| tst.ts:25:23:25:42 | [SimpleParameter] interfaceMethodParam | tst.ts:25:45:25:53 | [LocalTypeAccess] Interface | semmle.label | 0 |
-| tst.ts:25:23:25:42 | [SimpleParameter] interfaceMethodParam | tst.ts:25:45:25:53 | [LocalTypeAccess] Interface | semmle.order | 0 |
+| tst.ts:25:23:25:42 | [SimpleParameter] interfaceMethodParam | tst.ts:25:45:25:53 | [LocalTypeAccess] Interface | semmle.label | -2 |
+| tst.ts:25:23:25:42 | [SimpleParameter] interfaceMethodParam | tst.ts:25:45:25:53 | [LocalTypeAccess] Interface | semmle.order | -2 |
 | tst.ts:28:1:28:28 | [DeclStmt] var interfaceVar = ... | tst.ts:28:5:28:27 | [VariableDeclarator] interfa ... terface | semmle.label | 1 |
 | tst.ts:28:1:28:28 | [DeclStmt] var interfaceVar = ... | tst.ts:28:5:28:27 | [VariableDeclarator] interfa ... terface | semmle.order | 1 |
 | tst.ts:28:5:28:27 | [VariableDeclarator] interfa ... terface | tst.ts:28:5:28:16 | [VarDecl] interfaceVar | semmle.label | 1 |
@@ -1344,30 +1344,30 @@ edges
 | tst.ts:33:1:33:59 | [FunctionDeclStmt] functio ... ber) {} | tst.ts:33:10:33:27 | [VarDecl] takeNumberFunction | semmle.order | 0 |
 | tst.ts:33:1:33:59 | [FunctionDeclStmt] functio ... ber) {} | tst.ts:33:58:33:59 | [BlockStmt] {} | semmle.label | 5 |
 | tst.ts:33:1:33:59 | [FunctionDeclStmt] functio ... ber) {} | tst.ts:33:58:33:59 | [BlockStmt] {} | semmle.order | 5 |
-| tst.ts:33:29:33:47 | [SimpleParameter] numberFunctionParam | tst.ts:33:50:33:55 | [KeywordTypeExpr] number | semmle.label | 0 |
-| tst.ts:33:29:33:47 | [SimpleParameter] numberFunctionParam | tst.ts:33:50:33:55 | [KeywordTypeExpr] number | semmle.order | 0 |
+| tst.ts:33:29:33:47 | [SimpleParameter] numberFunctionParam | tst.ts:33:50:33:55 | [KeywordTypeExpr] number | semmle.label | -2 |
+| tst.ts:33:29:33:47 | [SimpleParameter] numberFunctionParam | tst.ts:33:50:33:55 | [KeywordTypeExpr] number | semmle.order | -2 |
 | tst.ts:34:1:34:67 | [FunctionDeclStmt] functio ... ace) {} | file://:0:0:0:0 | (Parameters) | semmle.label | 1 |
 | tst.ts:34:1:34:67 | [FunctionDeclStmt] functio ... ace) {} | file://:0:0:0:0 | (Parameters) | semmle.order | 1 |
 | tst.ts:34:1:34:67 | [FunctionDeclStmt] functio ... ace) {} | tst.ts:34:10:34:30 | [VarDecl] takeInterfaceFunction | semmle.label | 0 |
 | tst.ts:34:1:34:67 | [FunctionDeclStmt] functio ... ace) {} | tst.ts:34:10:34:30 | [VarDecl] takeInterfaceFunction | semmle.order | 0 |
 | tst.ts:34:1:34:67 | [FunctionDeclStmt] functio ... ace) {} | tst.ts:34:66:34:67 | [BlockStmt] {} | semmle.label | 5 |
 | tst.ts:34:1:34:67 | [FunctionDeclStmt] functio ... ace) {} | tst.ts:34:66:34:67 | [BlockStmt] {} | semmle.order | 5 |
-| tst.ts:34:32:34:52 | [SimpleParameter] interaceFunctionParam | tst.ts:34:55:34:63 | [LocalTypeAccess] Interface | semmle.label | 0 |
-| tst.ts:34:32:34:52 | [SimpleParameter] interaceFunctionParam | tst.ts:34:55:34:63 | [LocalTypeAccess] Interface | semmle.order | 0 |
+| tst.ts:34:32:34:52 | [SimpleParameter] interaceFunctionParam | tst.ts:34:55:34:63 | [LocalTypeAccess] Interface | semmle.label | -2 |
+| tst.ts:34:32:34:52 | [SimpleParameter] interaceFunctionParam | tst.ts:34:55:34:63 | [LocalTypeAccess] Interface | semmle.order | -2 |
 | tst.ts:36:1:36:70 | [FunctionDeclStmt] functio ... '2') {} | file://:0:0:0:0 | (Parameters) | semmle.label | 1 |
 | tst.ts:36:1:36:70 | [FunctionDeclStmt] functio ... '2') {} | file://:0:0:0:0 | (Parameters) | semmle.order | 1 |
 | tst.ts:36:1:36:70 | [FunctionDeclStmt] functio ... '2') {} | tst.ts:36:10:36:25 | [VarDecl] typesAndDefaults | semmle.label | 0 |
 | tst.ts:36:1:36:70 | [FunctionDeclStmt] functio ... '2') {} | tst.ts:36:10:36:25 | [VarDecl] typesAndDefaults | semmle.order | 0 |
 | tst.ts:36:1:36:70 | [FunctionDeclStmt] functio ... '2') {} | tst.ts:36:69:36:70 | [BlockStmt] {} | semmle.label | 5 |
 | tst.ts:36:1:36:70 | [FunctionDeclStmt] functio ... '2') {} | tst.ts:36:69:36:70 | [BlockStmt] {} | semmle.order | 5 |
-| tst.ts:36:27:36:32 | [SimpleParameter] param1 | tst.ts:36:35:36:40 | [KeywordTypeExpr] number | semmle.label | 0 |
-| tst.ts:36:27:36:32 | [SimpleParameter] param1 | tst.ts:36:35:36:40 | [KeywordTypeExpr] number | semmle.order | 0 |
-| tst.ts:36:27:36:32 | [SimpleParameter] param1 | tst.ts:36:44:36:44 | [Literal] 1 | semmle.label | 1 |
-| tst.ts:36:27:36:32 | [SimpleParameter] param1 | tst.ts:36:44:36:44 | [Literal] 1 | semmle.order | 1 |
-| tst.ts:36:47:36:52 | [SimpleParameter] param2 | tst.ts:36:55:36:60 | [KeywordTypeExpr] string | semmle.label | 0 |
-| tst.ts:36:47:36:52 | [SimpleParameter] param2 | tst.ts:36:55:36:60 | [KeywordTypeExpr] string | semmle.order | 0 |
-| tst.ts:36:47:36:52 | [SimpleParameter] param2 | tst.ts:36:64:36:66 | [Literal] '2' | semmle.label | 1 |
-| tst.ts:36:47:36:52 | [SimpleParameter] param2 | tst.ts:36:64:36:66 | [Literal] '2' | semmle.order | 1 |
+| tst.ts:36:27:36:32 | [SimpleParameter] param1 | tst.ts:36:35:36:40 | [KeywordTypeExpr] number | semmle.label | -2 |
+| tst.ts:36:27:36:32 | [SimpleParameter] param1 | tst.ts:36:35:36:40 | [KeywordTypeExpr] number | semmle.order | -2 |
+| tst.ts:36:27:36:32 | [SimpleParameter] param1 | tst.ts:36:44:36:44 | [Literal] 1 | semmle.label | -1 |
+| tst.ts:36:27:36:32 | [SimpleParameter] param1 | tst.ts:36:44:36:44 | [Literal] 1 | semmle.order | -1 |
+| tst.ts:36:47:36:52 | [SimpleParameter] param2 | tst.ts:36:55:36:60 | [KeywordTypeExpr] string | semmle.label | -2 |
+| tst.ts:36:47:36:52 | [SimpleParameter] param2 | tst.ts:36:55:36:60 | [KeywordTypeExpr] string | semmle.order | -2 |
+| tst.ts:36:47:36:52 | [SimpleParameter] param2 | tst.ts:36:64:36:66 | [Literal] '2' | semmle.label | -1 |
+| tst.ts:36:47:36:52 | [SimpleParameter] param2 | tst.ts:36:64:36:66 | [Literal] '2' | semmle.order | -1 |
 | tst.ts:38:1:38:23 | [DeclStmt] var arrayType = ... | tst.ts:38:5:38:23 | [VariableDeclarator] arrayType: string[] | semmle.label | 1 |
 | tst.ts:38:1:38:23 | [DeclStmt] var arrayType = ... | tst.ts:38:5:38:23 | [VariableDeclarator] arrayType: string[] | semmle.order | 1 |
 | tst.ts:38:5:38:23 | [VariableDeclarator] arrayType: string[] | tst.ts:38:5:38:13 | [VarDecl] arrayType | semmle.label | 1 |
@@ -1734,8 +1734,8 @@ edges
 | tst.ts:80:1:80:73 | [FunctionDeclStmt] functio ... alse; } | tst.ts:80:36:80:55 | [IsTypeExpr] x is Generic<Leaf[]> | semmle.order | 4 |
 | tst.ts:80:1:80:73 | [FunctionDeclStmt] functio ... alse; } | tst.ts:80:57:80:73 | [BlockStmt] { return false; } | semmle.label | 5 |
 | tst.ts:80:1:80:73 | [FunctionDeclStmt] functio ... alse; } | tst.ts:80:57:80:73 | [BlockStmt] { return false; } | semmle.order | 5 |
-| tst.ts:80:24:80:24 | [SimpleParameter] x | tst.ts:80:27:80:32 | [KeywordTypeExpr] number | semmle.label | 0 |
-| tst.ts:80:24:80:24 | [SimpleParameter] x | tst.ts:80:27:80:32 | [KeywordTypeExpr] number | semmle.order | 0 |
+| tst.ts:80:24:80:24 | [SimpleParameter] x | tst.ts:80:27:80:32 | [KeywordTypeExpr] number | semmle.label | -2 |
+| tst.ts:80:24:80:24 | [SimpleParameter] x | tst.ts:80:27:80:32 | [KeywordTypeExpr] number | semmle.order | -2 |
 | tst.ts:80:36:80:55 | [IsTypeExpr] x is Generic<Leaf[]> | tst.ts:80:36:80:36 | [LocalVarTypeAccess] x | semmle.label | 1 |
 | tst.ts:80:36:80:55 | [IsTypeExpr] x is Generic<Leaf[]> | tst.ts:80:36:80:36 | [LocalVarTypeAccess] x | semmle.order | 1 |
 | tst.ts:80:36:80:55 | [IsTypeExpr] x is Generic<Leaf[]> | tst.ts:80:41:80:55 | [GenericTypeExpr] Generic<Leaf[]> | semmle.label | 2 |
@@ -1758,8 +1758,8 @@ edges
 | tst.ts:81:1:81:66 | [FunctionDeclStmt] functio ... true } | tst.ts:81:38:81:50 | [IsTypeExpr] x is typeof x | semmle.order | 4 |
 | tst.ts:81:1:81:66 | [FunctionDeclStmt] functio ... true } | tst.ts:81:52:81:66 | [BlockStmt] { return true } | semmle.label | 5 |
 | tst.ts:81:1:81:66 | [FunctionDeclStmt] functio ... true } | tst.ts:81:52:81:66 | [BlockStmt] { return true } | semmle.order | 5 |
-| tst.ts:81:24:81:24 | [SimpleParameter] x | tst.ts:81:27:81:34 | [ArrayTypeExpr] string[] | semmle.label | 0 |
-| tst.ts:81:24:81:24 | [SimpleParameter] x | tst.ts:81:27:81:34 | [ArrayTypeExpr] string[] | semmle.order | 0 |
+| tst.ts:81:24:81:24 | [SimpleParameter] x | tst.ts:81:27:81:34 | [ArrayTypeExpr] string[] | semmle.label | -2 |
+| tst.ts:81:24:81:24 | [SimpleParameter] x | tst.ts:81:27:81:34 | [ArrayTypeExpr] string[] | semmle.order | -2 |
 | tst.ts:81:27:81:34 | [ArrayTypeExpr] string[] | tst.ts:81:27:81:32 | [KeywordTypeExpr] string | semmle.label | 1 |
 | tst.ts:81:27:81:34 | [ArrayTypeExpr] string[] | tst.ts:81:27:81:32 | [KeywordTypeExpr] string | semmle.order | 1 |
 | tst.ts:81:38:81:50 | [IsTypeExpr] x is typeof x | tst.ts:81:38:81:38 | [LocalVarTypeAccess] x | semmle.label | 1 |
@@ -1832,8 +1832,8 @@ edges
 | tst.ts:88:20:88:44 | [FunctionExpr] (param: ... number | tst.ts:88:39:88:44 | [KeywordTypeExpr] number | semmle.order | 4 |
 | tst.ts:88:20:88:44 | [FunctionTypeExpr] (param: ... number | tst.ts:88:20:88:44 | [FunctionExpr] (param: ... number | semmle.label | 1 |
 | tst.ts:88:20:88:44 | [FunctionTypeExpr] (param: ... number | tst.ts:88:20:88:44 | [FunctionExpr] (param: ... number | semmle.order | 1 |
-| tst.ts:88:21:88:25 | [SimpleParameter] param | tst.ts:88:28:88:33 | [KeywordTypeExpr] string | semmle.label | 0 |
-| tst.ts:88:21:88:25 | [SimpleParameter] param | tst.ts:88:28:88:33 | [KeywordTypeExpr] string | semmle.order | 0 |
+| tst.ts:88:21:88:25 | [SimpleParameter] param | tst.ts:88:28:88:33 | [KeywordTypeExpr] string | semmle.label | -2 |
+| tst.ts:88:21:88:25 | [SimpleParameter] param | tst.ts:88:28:88:33 | [KeywordTypeExpr] string | semmle.order | -2 |
 | tst.ts:89:1:89:38 | [DeclStmt] var functionType3 = ... | tst.ts:89:5:89:37 | [VariableDeclarator] functio ... T) => T | semmle.label | 1 |
 | tst.ts:89:1:89:38 | [DeclStmt] var functionType3 = ... | tst.ts:89:5:89:37 | [VariableDeclarator] functio ... T) => T | semmle.order | 1 |
 | tst.ts:89:5:89:37 | [VariableDeclarator] functio ... T) => T | tst.ts:89:5:89:17 | [VarDecl] functionType3 | semmle.label | 1 |
@@ -1850,8 +1850,8 @@ edges
 | tst.ts:89:20:89:37 | [FunctionTypeExpr] <T>(param: T) => T | tst.ts:89:20:89:37 | [FunctionExpr] <T>(param: T) => T | semmle.order | 1 |
 | tst.ts:89:21:89:21 | [TypeParameter] T | tst.ts:89:21:89:21 | [Identifier] T | semmle.label | 1 |
 | tst.ts:89:21:89:21 | [TypeParameter] T | tst.ts:89:21:89:21 | [Identifier] T | semmle.order | 1 |
-| tst.ts:89:24:89:28 | [SimpleParameter] param | tst.ts:89:31:89:31 | [LocalTypeAccess] T | semmle.label | 0 |
-| tst.ts:89:24:89:28 | [SimpleParameter] param | tst.ts:89:31:89:31 | [LocalTypeAccess] T | semmle.order | 0 |
+| tst.ts:89:24:89:28 | [SimpleParameter] param | tst.ts:89:31:89:31 | [LocalTypeAccess] T | semmle.label | -2 |
+| tst.ts:89:24:89:28 | [SimpleParameter] param | tst.ts:89:31:89:31 | [LocalTypeAccess] T | semmle.order | -2 |
 | tst.ts:90:1:90:39 | [DeclStmt] var constructorType1 = ... | tst.ts:90:5:90:38 | [VariableDeclarator] constru ... Object | semmle.label | 1 |
 | tst.ts:90:1:90:39 | [DeclStmt] var constructorType1 = ... | tst.ts:90:5:90:38 | [VariableDeclarator] constru ... Object | semmle.order | 1 |
 | tst.ts:90:5:90:38 | [VariableDeclarator] constru ... Object | tst.ts:90:5:90:20 | [VarDecl] constructorType1 | semmle.label | 1 |
@@ -1874,8 +1874,8 @@ edges
 | tst.ts:91:23:91:51 | [FunctionExpr] new (pa ... Object | tst.ts:91:46:91:51 | [LocalTypeAccess] Object | semmle.order | 4 |
 | tst.ts:91:23:91:51 | [FunctionTypeExpr] new (pa ... Object | tst.ts:91:23:91:51 | [FunctionExpr] new (pa ... Object | semmle.label | 1 |
 | tst.ts:91:23:91:51 | [FunctionTypeExpr] new (pa ... Object | tst.ts:91:23:91:51 | [FunctionExpr] new (pa ... Object | semmle.order | 1 |
-| tst.ts:91:28:91:32 | [SimpleParameter] param | tst.ts:91:35:91:40 | [KeywordTypeExpr] string | semmle.label | 0 |
-| tst.ts:91:28:91:32 | [SimpleParameter] param | tst.ts:91:35:91:40 | [KeywordTypeExpr] string | semmle.order | 0 |
+| tst.ts:91:28:91:32 | [SimpleParameter] param | tst.ts:91:35:91:40 | [KeywordTypeExpr] string | semmle.label | -2 |
+| tst.ts:91:28:91:32 | [SimpleParameter] param | tst.ts:91:35:91:40 | [KeywordTypeExpr] string | semmle.order | -2 |
 | tst.ts:92:1:92:50 | [DeclStmt] var constructorType3 = ... | tst.ts:92:5:92:49 | [VariableDeclarator] constru ... Object | semmle.label | 1 |
 | tst.ts:92:1:92:50 | [DeclStmt] var constructorType3 = ... | tst.ts:92:5:92:49 | [VariableDeclarator] constru ... Object | semmle.order | 1 |
 | tst.ts:92:5:92:49 | [VariableDeclarator] constru ... Object | tst.ts:92:5:92:20 | [VarDecl] constructorType3 | semmle.label | 1 |
@@ -1892,8 +1892,8 @@ edges
 | tst.ts:92:23:92:49 | [FunctionTypeExpr] new <T> ... Object | tst.ts:92:23:92:49 | [FunctionExpr] new <T> ... Object | semmle.order | 1 |
 | tst.ts:92:28:92:28 | [TypeParameter] T | tst.ts:92:28:92:28 | [Identifier] T | semmle.label | 1 |
 | tst.ts:92:28:92:28 | [TypeParameter] T | tst.ts:92:28:92:28 | [Identifier] T | semmle.order | 1 |
-| tst.ts:92:31:92:35 | [SimpleParameter] param | tst.ts:92:38:92:38 | [LocalTypeAccess] T | semmle.label | 0 |
-| tst.ts:92:31:92:35 | [SimpleParameter] param | tst.ts:92:38:92:38 | [LocalTypeAccess] T | semmle.order | 0 |
+| tst.ts:92:31:92:35 | [SimpleParameter] param | tst.ts:92:38:92:38 | [LocalTypeAccess] T | semmle.label | -2 |
+| tst.ts:92:31:92:35 | [SimpleParameter] param | tst.ts:92:38:92:38 | [LocalTypeAccess] T | semmle.order | -2 |
 | tst.ts:94:1:94:37 | [FunctionDeclStmt] functio ... rn x; } | file://:0:0:0:0 | (Parameters) | semmle.label | 1 |
 | tst.ts:94:1:94:37 | [FunctionDeclStmt] functio ... rn x; } | file://:0:0:0:0 | (Parameters) | semmle.order | 1 |
 | tst.ts:94:1:94:37 | [FunctionDeclStmt] functio ... rn x; } | file://:0:0:0:0 | (TypeParameters) | semmle.label | 2 |
@@ -1906,8 +1906,8 @@ edges
 | tst.ts:94:1:94:37 | [FunctionDeclStmt] functio ... rn x; } | tst.ts:94:25:94:37 | [BlockStmt] { return x; } | semmle.order | 5 |
 | tst.ts:94:13:94:13 | [TypeParameter] S | tst.ts:94:13:94:13 | [Identifier] S | semmle.label | 1 |
 | tst.ts:94:13:94:13 | [TypeParameter] S | tst.ts:94:13:94:13 | [Identifier] S | semmle.order | 1 |
-| tst.ts:94:16:94:16 | [SimpleParameter] x | tst.ts:94:19:94:19 | [LocalTypeAccess] S | semmle.label | 0 |
-| tst.ts:94:16:94:16 | [SimpleParameter] x | tst.ts:94:19:94:19 | [LocalTypeAccess] S | semmle.order | 0 |
+| tst.ts:94:16:94:16 | [SimpleParameter] x | tst.ts:94:19:94:19 | [LocalTypeAccess] S | semmle.label | -2 |
+| tst.ts:94:16:94:16 | [SimpleParameter] x | tst.ts:94:19:94:19 | [LocalTypeAccess] S | semmle.order | -2 |
 | tst.ts:94:25:94:37 | [BlockStmt] { return x; } | tst.ts:94:27:94:35 | [ReturnStmt] return x; | semmle.label | 1 |
 | tst.ts:94:25:94:37 | [BlockStmt] { return x; } | tst.ts:94:27:94:35 | [ReturnStmt] return x; | semmle.order | 1 |
 | tst.ts:94:27:94:35 | [ReturnStmt] return x; | tst.ts:94:34:94:34 | [VarRef] x | semmle.label | 1 |
@@ -1926,10 +1926,10 @@ edges
 | tst.ts:95:13:95:13 | [TypeParameter] S | tst.ts:95:13:95:13 | [Identifier] S | semmle.order | 1 |
 | tst.ts:95:15:95:15 | [TypeParameter] T | tst.ts:95:15:95:15 | [Identifier] T | semmle.label | 1 |
 | tst.ts:95:15:95:15 | [TypeParameter] T | tst.ts:95:15:95:15 | [Identifier] T | semmle.order | 1 |
-| tst.ts:95:18:95:18 | [SimpleParameter] x | tst.ts:95:21:95:21 | [LocalTypeAccess] S | semmle.label | 0 |
-| tst.ts:95:18:95:18 | [SimpleParameter] x | tst.ts:95:21:95:21 | [LocalTypeAccess] S | semmle.order | 0 |
-| tst.ts:95:24:95:24 | [SimpleParameter] y | tst.ts:95:27:95:27 | [LocalTypeAccess] T | semmle.label | 0 |
-| tst.ts:95:24:95:24 | [SimpleParameter] y | tst.ts:95:27:95:27 | [LocalTypeAccess] T | semmle.order | 0 |
+| tst.ts:95:18:95:18 | [SimpleParameter] x | tst.ts:95:21:95:21 | [LocalTypeAccess] S | semmle.label | -2 |
+| tst.ts:95:18:95:18 | [SimpleParameter] x | tst.ts:95:21:95:21 | [LocalTypeAccess] S | semmle.order | -2 |
+| tst.ts:95:24:95:24 | [SimpleParameter] y | tst.ts:95:27:95:27 | [LocalTypeAccess] T | semmle.label | -2 |
+| tst.ts:95:24:95:24 | [SimpleParameter] y | tst.ts:95:27:95:27 | [LocalTypeAccess] T | semmle.order | -2 |
 | tst.ts:95:31:95:35 | [TupleTypeExpr] [S,T] | tst.ts:95:32:95:32 | [LocalTypeAccess] S | semmle.label | 1 |
 | tst.ts:95:31:95:35 | [TupleTypeExpr] [S,T] | tst.ts:95:32:95:32 | [LocalTypeAccess] S | semmle.order | 1 |
 | tst.ts:95:31:95:35 | [TupleTypeExpr] [S,T] | tst.ts:95:34:95:34 | [LocalTypeAccess] T | semmle.label | 2 |
@@ -1956,8 +1956,8 @@ edges
 | tst.ts:96:13:96:28 | [TypeParameter] S extends number | tst.ts:96:13:96:13 | [Identifier] S | semmle.order | 1 |
 | tst.ts:96:13:96:28 | [TypeParameter] S extends number | tst.ts:96:23:96:28 | [KeywordTypeExpr] number | semmle.label | 2 |
 | tst.ts:96:13:96:28 | [TypeParameter] S extends number | tst.ts:96:23:96:28 | [KeywordTypeExpr] number | semmle.order | 2 |
-| tst.ts:96:31:96:31 | [SimpleParameter] x | tst.ts:96:34:96:34 | [LocalTypeAccess] S | semmle.label | 0 |
-| tst.ts:96:31:96:31 | [SimpleParameter] x | tst.ts:96:34:96:34 | [LocalTypeAccess] S | semmle.order | 0 |
+| tst.ts:96:31:96:31 | [SimpleParameter] x | tst.ts:96:34:96:34 | [LocalTypeAccess] S | semmle.label | -2 |
+| tst.ts:96:31:96:31 | [SimpleParameter] x | tst.ts:96:34:96:34 | [LocalTypeAccess] S | semmle.order | -2 |
 | tst.ts:96:40:96:52 | [BlockStmt] { return x; } | tst.ts:96:42:96:50 | [ReturnStmt] return x; | semmle.label | 1 |
 | tst.ts:96:40:96:52 | [BlockStmt] { return x; } | tst.ts:96:42:96:50 | [ReturnStmt] return x; | semmle.order | 1 |
 | tst.ts:96:42:96:50 | [ReturnStmt] return x; | tst.ts:96:49:96:49 | [VarRef] x | semmle.label | 1 |
@@ -2132,10 +2132,10 @@ edges
 | tst.ts:116:1:116:58 | [FunctionDeclStmt] functio ... ing) {} | tst.ts:116:29:116:32 | [KeywordTypeExpr] void | semmle.order | 3 |
 | tst.ts:116:1:116:58 | [FunctionDeclStmt] functio ... ing) {} | tst.ts:116:57:116:58 | [BlockStmt] {} | semmle.label | 5 |
 | tst.ts:116:1:116:58 | [FunctionDeclStmt] functio ... ing) {} | tst.ts:116:57:116:58 | [BlockStmt] {} | semmle.order | 5 |
-| tst.ts:116:35:116:35 | [SimpleParameter] x | tst.ts:116:38:116:43 | [KeywordTypeExpr] number | semmle.label | 0 |
-| tst.ts:116:35:116:35 | [SimpleParameter] x | tst.ts:116:38:116:43 | [KeywordTypeExpr] number | semmle.order | 0 |
-| tst.ts:116:46:116:46 | [SimpleParameter] y | tst.ts:116:49:116:54 | [KeywordTypeExpr] string | semmle.label | 0 |
-| tst.ts:116:46:116:46 | [SimpleParameter] y | tst.ts:116:49:116:54 | [KeywordTypeExpr] string | semmle.order | 0 |
+| tst.ts:116:35:116:35 | [SimpleParameter] x | tst.ts:116:38:116:43 | [KeywordTypeExpr] number | semmle.label | -2 |
+| tst.ts:116:35:116:35 | [SimpleParameter] x | tst.ts:116:38:116:43 | [KeywordTypeExpr] number | semmle.order | -2 |
+| tst.ts:116:46:116:46 | [SimpleParameter] y | tst.ts:116:49:116:54 | [KeywordTypeExpr] string | semmle.label | -2 |
+| tst.ts:116:46:116:46 | [SimpleParameter] y | tst.ts:116:49:116:54 | [KeywordTypeExpr] string | semmle.order | -2 |
 | tst.ts:118:1:120:1 | [InterfaceDeclaration,TypeDefinition] interfa ... ram); } | tst.ts:118:11:118:32 | [Identifier] InterfaceWithThisParam | semmle.label | 1 |
 | tst.ts:118:1:120:1 | [InterfaceDeclaration,TypeDefinition] interfa ... ram); } | tst.ts:118:11:118:32 | [Identifier] InterfaceWithThisParam | semmle.order | 1 |
 | tst.ts:118:1:120:1 | [InterfaceDeclaration,TypeDefinition] interfa ... ram); } | tst.ts:119:3:119:45 | [MethodSignature] hasThis ... Param); | semmle.label | 2 |
@@ -2326,10 +2326,10 @@ edges
 | tst.ts:142:1:146:1 | [FunctionDeclStmt] functio ... ) } } | tst.ts:142:48:142:64 | [PredicateTypeExpr] asserts condition | semmle.order | 4 |
 | tst.ts:142:1:146:1 | [FunctionDeclStmt] functio ... ) } } | tst.ts:142:66:146:1 | [BlockStmt] { if ... ) } } | semmle.label | 5 |
 | tst.ts:142:1:146:1 | [FunctionDeclStmt] functio ... ) } } | tst.ts:142:66:146:1 | [BlockStmt] { if ... ) } } | semmle.order | 5 |
-| tst.ts:142:17:142:25 | [SimpleParameter] condition | tst.ts:142:28:142:30 | [KeywordTypeExpr] any | semmle.label | 0 |
-| tst.ts:142:17:142:25 | [SimpleParameter] condition | tst.ts:142:28:142:30 | [KeywordTypeExpr] any | semmle.order | 0 |
-| tst.ts:142:33:142:35 | [SimpleParameter] msg | tst.ts:142:39:142:44 | [KeywordTypeExpr] string | semmle.label | 0 |
-| tst.ts:142:33:142:35 | [SimpleParameter] msg | tst.ts:142:39:142:44 | [KeywordTypeExpr] string | semmle.order | 0 |
+| tst.ts:142:17:142:25 | [SimpleParameter] condition | tst.ts:142:28:142:30 | [KeywordTypeExpr] any | semmle.label | -2 |
+| tst.ts:142:17:142:25 | [SimpleParameter] condition | tst.ts:142:28:142:30 | [KeywordTypeExpr] any | semmle.order | -2 |
+| tst.ts:142:33:142:35 | [SimpleParameter] msg | tst.ts:142:39:142:44 | [KeywordTypeExpr] string | semmle.label | -2 |
+| tst.ts:142:33:142:35 | [SimpleParameter] msg | tst.ts:142:39:142:44 | [KeywordTypeExpr] string | semmle.order | -2 |
 | tst.ts:142:48:142:64 | [PredicateTypeExpr] asserts condition | tst.ts:142:56:142:64 | [LocalVarTypeAccess] condition | semmle.label | 1 |
 | tst.ts:142:48:142:64 | [PredicateTypeExpr] asserts condition | tst.ts:142:56:142:64 | [LocalVarTypeAccess] condition | semmle.order | 1 |
 | tst.ts:142:66:146:1 | [BlockStmt] { if ... ) } } | tst.ts:143:3:145:3 | [IfStmt] if (!co ... sg) } | semmle.label | 1 |
@@ -2356,8 +2356,8 @@ edges
 | tst.ts:148:1:152:1 | [FunctionDeclStmt] functio ... ; } } | tst.ts:148:36:148:56 | [IsTypeExpr] asserts ... string | semmle.order | 4 |
 | tst.ts:148:1:152:1 | [FunctionDeclStmt] functio ... ; } } | tst.ts:148:58:152:1 | [BlockStmt] { if ... ; } } | semmle.label | 5 |
 | tst.ts:148:1:152:1 | [FunctionDeclStmt] functio ... ; } } | tst.ts:148:58:152:1 | [BlockStmt] { if ... ; } } | semmle.order | 5 |
-| tst.ts:148:25:148:27 | [SimpleParameter] val | tst.ts:148:30:148:32 | [KeywordTypeExpr] any | semmle.label | 0 |
-| tst.ts:148:25:148:27 | [SimpleParameter] val | tst.ts:148:30:148:32 | [KeywordTypeExpr] any | semmle.order | 0 |
+| tst.ts:148:25:148:27 | [SimpleParameter] val | tst.ts:148:30:148:32 | [KeywordTypeExpr] any | semmle.label | -2 |
+| tst.ts:148:25:148:27 | [SimpleParameter] val | tst.ts:148:30:148:32 | [KeywordTypeExpr] any | semmle.order | -2 |
 | tst.ts:148:36:148:56 | [IsTypeExpr] asserts ... string | tst.ts:148:44:148:46 | [LocalVarTypeAccess] val | semmle.label | 1 |
 | tst.ts:148:36:148:56 | [IsTypeExpr] asserts ... string | tst.ts:148:44:148:46 | [LocalVarTypeAccess] val | semmle.order | 1 |
 | tst.ts:148:36:148:56 | [IsTypeExpr] asserts ... string | tst.ts:148:51:148:56 | [KeywordTypeExpr] string | semmle.label | 2 |
@@ -2396,8 +2396,8 @@ edges
 | tst.ts:157:15:157:29 | [TypeParameter] T extends any[] | tst.ts:157:25:157:29 | [ArrayTypeExpr] any[] | semmle.order | 2 |
 | tst.ts:157:25:157:29 | [ArrayTypeExpr] any[] | tst.ts:157:25:157:27 | [KeywordTypeExpr] any | semmle.label | 1 |
 | tst.ts:157:25:157:29 | [ArrayTypeExpr] any[] | tst.ts:157:25:157:27 | [KeywordTypeExpr] any | semmle.order | 1 |
-| tst.ts:157:32:157:34 | [SimpleParameter] arr | tst.ts:157:37:157:56 | [ReadonlyTypeExpr] readonly [any, ...T] | semmle.label | 0 |
-| tst.ts:157:32:157:34 | [SimpleParameter] arr | tst.ts:157:37:157:56 | [ReadonlyTypeExpr] readonly [any, ...T] | semmle.order | 0 |
+| tst.ts:157:32:157:34 | [SimpleParameter] arr | tst.ts:157:37:157:56 | [ReadonlyTypeExpr] readonly [any, ...T] | semmle.label | -2 |
+| tst.ts:157:32:157:34 | [SimpleParameter] arr | tst.ts:157:37:157:56 | [ReadonlyTypeExpr] readonly [any, ...T] | semmle.order | -2 |
 | tst.ts:157:37:157:56 | [ReadonlyTypeExpr] readonly [any, ...T] | tst.ts:157:46:157:56 | [TupleTypeExpr] [any, ...T] | semmle.label | 1 |
 | tst.ts:157:37:157:56 | [ReadonlyTypeExpr] readonly [any, ...T] | tst.ts:157:46:157:56 | [TupleTypeExpr] [any, ...T] | semmle.order | 1 |
 | tst.ts:157:46:157:56 | [TupleTypeExpr] [any, ...T] | tst.ts:157:47:157:49 | [KeywordTypeExpr] any | semmle.label | 1 |
@@ -2448,10 +2448,10 @@ edges
 | tst.ts:164:32:164:44 | [TypeParameter] U extends Arr | tst.ts:164:32:164:32 | [Identifier] U | semmle.order | 1 |
 | tst.ts:164:32:164:44 | [TypeParameter] U extends Arr | tst.ts:164:42:164:44 | [LocalTypeAccess] Arr | semmle.label | 2 |
 | tst.ts:164:32:164:44 | [TypeParameter] U extends Arr | tst.ts:164:42:164:44 | [LocalTypeAccess] Arr | semmle.order | 2 |
-| tst.ts:164:47:164:50 | [SimpleParameter] arr1 | tst.ts:164:53:164:53 | [LocalTypeAccess] T | semmle.label | 0 |
-| tst.ts:164:47:164:50 | [SimpleParameter] arr1 | tst.ts:164:53:164:53 | [LocalTypeAccess] T | semmle.order | 0 |
-| tst.ts:164:56:164:59 | [SimpleParameter] arr2 | tst.ts:164:62:164:62 | [LocalTypeAccess] U | semmle.label | 0 |
-| tst.ts:164:56:164:59 | [SimpleParameter] arr2 | tst.ts:164:62:164:62 | [LocalTypeAccess] U | semmle.order | 0 |
+| tst.ts:164:47:164:50 | [SimpleParameter] arr1 | tst.ts:164:53:164:53 | [LocalTypeAccess] T | semmle.label | -2 |
+| tst.ts:164:47:164:50 | [SimpleParameter] arr1 | tst.ts:164:53:164:53 | [LocalTypeAccess] T | semmle.order | -2 |
+| tst.ts:164:56:164:59 | [SimpleParameter] arr2 | tst.ts:164:62:164:62 | [LocalTypeAccess] U | semmle.label | -2 |
+| tst.ts:164:56:164:59 | [SimpleParameter] arr2 | tst.ts:164:62:164:62 | [LocalTypeAccess] U | semmle.order | -2 |
 | tst.ts:164:66:164:77 | [TupleTypeExpr] [...T, ...U] | tst.ts:164:67:164:70 | [RestTypeExpr] ...T | semmle.label | 1 |
 | tst.ts:164:66:164:77 | [TupleTypeExpr] [...T, ...U] | tst.ts:164:67:164:70 | [RestTypeExpr] ...T | semmle.order | 1 |
 | tst.ts:164:66:164:77 | [TupleTypeExpr] [...T, ...U] | tst.ts:164:73:164:76 | [RestTypeExpr] ...U | semmle.label | 2 |
@@ -2480,8 +2480,8 @@ edges
 | tst.ts:169:1:172:1 | [FunctionDeclStmt] functio ... + b; } | tst.ts:169:68:169:73 | [KeywordTypeExpr] number | semmle.order | 4 |
 | tst.ts:169:1:172:1 | [FunctionDeclStmt] functio ... + b; } | tst.ts:169:75:172:1 | [BlockStmt] { let ... + b; } | semmle.label | 5 |
 | tst.ts:169:1:172:1 | [FunctionDeclStmt] functio ... + b; } | tst.ts:169:75:172:1 | [BlockStmt] { let ... + b; } | semmle.order | 5 |
-| tst.ts:169:31:169:31 | [SimpleParameter] x | tst.ts:169:34:169:64 | [TupleTypeExpr] [first: ... number] | semmle.label | 0 |
-| tst.ts:169:31:169:31 | [SimpleParameter] x | tst.ts:169:34:169:64 | [TupleTypeExpr] [first: ... number] | semmle.order | 0 |
+| tst.ts:169:31:169:31 | [SimpleParameter] x | tst.ts:169:34:169:64 | [TupleTypeExpr] [first: ... number] | semmle.label | -2 |
+| tst.ts:169:31:169:31 | [SimpleParameter] x | tst.ts:169:34:169:64 | [TupleTypeExpr] [first: ... number] | semmle.order | -2 |
 | tst.ts:169:34:169:64 | [TupleTypeExpr] [first: ... number] | tst.ts:169:35:169:39 | [Identifier] first | semmle.label | 1 |
 | tst.ts:169:34:169:64 | [TupleTypeExpr] [first: ... number] | tst.ts:169:35:169:39 | [Identifier] first | semmle.order | 1 |
 | tst.ts:169:34:169:64 | [TupleTypeExpr] [first: ... number] | tst.ts:169:42:169:47 | [KeywordTypeExpr] number | semmle.label | 2 |
@@ -2622,8 +2622,8 @@ edges
 | tst.ts:192:1:194:1 | [FunctionDeclStmt] functio ... rn x; } | tst.ts:192:47:192:70 | [TupleTypeExpr] [number ... number] | semmle.order | 4 |
 | tst.ts:192:1:194:1 | [FunctionDeclStmt] functio ... rn x; } | tst.ts:192:72:194:1 | [BlockStmt] { return x; } | semmle.label | 5 |
 | tst.ts:192:1:194:1 | [FunctionDeclStmt] functio ... rn x; } | tst.ts:192:72:194:1 | [BlockStmt] { return x; } | semmle.order | 5 |
-| tst.ts:192:18:192:18 | [SimpleParameter] x | tst.ts:192:21:192:43 | [TupleTypeExpr] [first: ... number] | semmle.label | 0 |
-| tst.ts:192:18:192:18 | [SimpleParameter] x | tst.ts:192:21:192:43 | [TupleTypeExpr] [first: ... number] | semmle.order | 0 |
+| tst.ts:192:18:192:18 | [SimpleParameter] x | tst.ts:192:21:192:43 | [TupleTypeExpr] [first: ... number] | semmle.label | -2 |
+| tst.ts:192:18:192:18 | [SimpleParameter] x | tst.ts:192:21:192:43 | [TupleTypeExpr] [first: ... number] | semmle.order | -2 |
 | tst.ts:192:21:192:43 | [TupleTypeExpr] [first: ... number] | tst.ts:192:22:192:26 | [Identifier] first | semmle.label | 1 |
 | tst.ts:192:21:192:43 | [TupleTypeExpr] [first: ... number] | tst.ts:192:22:192:26 | [Identifier] first | semmle.order | 1 |
 | tst.ts:192:21:192:43 | [TupleTypeExpr] [first: ... number] | tst.ts:192:29:192:34 | [KeywordTypeExpr] number | semmle.label | 2 |

--- a/javascript/ql/test/library-tests/TypeScript/Types/printAst.expected
+++ b/javascript/ql/test/library-tests/TypeScript/Types/printAst.expected
@@ -2155,10 +2155,10 @@ edges
 | tst.ts:14:1:14:63 | [FunctionDeclStmt] functio ... + y; } | tst.ts:14:40:14:45 | [KeywordTypeExpr] string | semmle.order | 4 |
 | tst.ts:14:1:14:63 | [FunctionDeclStmt] functio ... + y; } | tst.ts:14:47:14:63 | [BlockStmt] { return x + y; } | semmle.label | 5 |
 | tst.ts:14:1:14:63 | [FunctionDeclStmt] functio ... + y; } | tst.ts:14:47:14:63 | [BlockStmt] { return x + y; } | semmle.order | 5 |
-| tst.ts:14:17:14:17 | [SimpleParameter] x | tst.ts:14:20:14:25 | [KeywordTypeExpr] string | semmle.label | 0 |
-| tst.ts:14:17:14:17 | [SimpleParameter] x | tst.ts:14:20:14:25 | [KeywordTypeExpr] string | semmle.order | 0 |
-| tst.ts:14:28:14:28 | [SimpleParameter] y | tst.ts:14:31:14:36 | [KeywordTypeExpr] string | semmle.label | 0 |
-| tst.ts:14:28:14:28 | [SimpleParameter] y | tst.ts:14:31:14:36 | [KeywordTypeExpr] string | semmle.order | 0 |
+| tst.ts:14:17:14:17 | [SimpleParameter] x | tst.ts:14:20:14:25 | [KeywordTypeExpr] string | semmle.label | -2 |
+| tst.ts:14:17:14:17 | [SimpleParameter] x | tst.ts:14:20:14:25 | [KeywordTypeExpr] string | semmle.order | -2 |
+| tst.ts:14:28:14:28 | [SimpleParameter] y | tst.ts:14:31:14:36 | [KeywordTypeExpr] string | semmle.label | -2 |
+| tst.ts:14:28:14:28 | [SimpleParameter] y | tst.ts:14:31:14:36 | [KeywordTypeExpr] string | semmle.order | -2 |
 | tst.ts:14:47:14:63 | [BlockStmt] { return x + y; } | tst.ts:14:49:14:61 | [ReturnStmt] return x + y; | semmle.label | 1 |
 | tst.ts:14:47:14:63 | [BlockStmt] { return x + y; } | tst.ts:14:49:14:61 | [ReturnStmt] return x + y; | semmle.order | 1 |
 | tst.ts:14:49:14:61 | [ReturnStmt] return x + y; | tst.ts:14:56:14:60 | [BinaryExpr] x + y | semmle.label | 1 |
@@ -2175,10 +2175,10 @@ edges
 | tst.ts:16:1:16:60 | [FunctionDeclStmt] functio ... + y; } | tst.ts:16:37:16:42 | [KeywordTypeExpr] number | semmle.order | 4 |
 | tst.ts:16:1:16:60 | [FunctionDeclStmt] functio ... + y; } | tst.ts:16:44:16:60 | [BlockStmt] { return x + y; } | semmle.label | 5 |
 | tst.ts:16:1:16:60 | [FunctionDeclStmt] functio ... + y; } | tst.ts:16:44:16:60 | [BlockStmt] { return x + y; } | semmle.order | 5 |
-| tst.ts:16:14:16:14 | [SimpleParameter] x | tst.ts:16:17:16:22 | [KeywordTypeExpr] number | semmle.label | 0 |
-| tst.ts:16:14:16:14 | [SimpleParameter] x | tst.ts:16:17:16:22 | [KeywordTypeExpr] number | semmle.order | 0 |
-| tst.ts:16:25:16:25 | [SimpleParameter] y | tst.ts:16:28:16:33 | [KeywordTypeExpr] number | semmle.label | 0 |
-| tst.ts:16:25:16:25 | [SimpleParameter] y | tst.ts:16:28:16:33 | [KeywordTypeExpr] number | semmle.order | 0 |
+| tst.ts:16:14:16:14 | [SimpleParameter] x | tst.ts:16:17:16:22 | [KeywordTypeExpr] number | semmle.label | -2 |
+| tst.ts:16:14:16:14 | [SimpleParameter] x | tst.ts:16:17:16:22 | [KeywordTypeExpr] number | semmle.order | -2 |
+| tst.ts:16:25:16:25 | [SimpleParameter] y | tst.ts:16:28:16:33 | [KeywordTypeExpr] number | semmle.label | -2 |
+| tst.ts:16:25:16:25 | [SimpleParameter] y | tst.ts:16:28:16:33 | [KeywordTypeExpr] number | semmle.order | -2 |
 | tst.ts:16:44:16:60 | [BlockStmt] { return x + y; } | tst.ts:16:46:16:58 | [ReturnStmt] return x + y; | semmle.label | 1 |
 | tst.ts:16:44:16:60 | [BlockStmt] { return x + y; } | tst.ts:16:46:16:58 | [ReturnStmt] return x + y; | semmle.order | 1 |
 | tst.ts:16:46:16:58 | [ReturnStmt] return x + y; | tst.ts:16:53:16:57 | [BinaryExpr] x + y | semmle.label | 1 |
@@ -2207,8 +2207,8 @@ edges
 | tst.ts:20:1:20:53 | [FunctionDeclStmt] functio ... + y; } | tst.ts:20:10:20:21 | [VarDecl] partialTyped | semmle.order | 0 |
 | tst.ts:20:1:20:53 | [FunctionDeclStmt] functio ... + y; } | tst.ts:20:37:20:53 | [BlockStmt] { return x + y; } | semmle.label | 5 |
 | tst.ts:20:1:20:53 | [FunctionDeclStmt] functio ... + y; } | tst.ts:20:37:20:53 | [BlockStmt] { return x + y; } | semmle.order | 5 |
-| tst.ts:20:26:20:26 | [SimpleParameter] y | tst.ts:20:29:20:34 | [KeywordTypeExpr] string | semmle.label | 0 |
-| tst.ts:20:26:20:26 | [SimpleParameter] y | tst.ts:20:29:20:34 | [KeywordTypeExpr] string | semmle.order | 0 |
+| tst.ts:20:26:20:26 | [SimpleParameter] y | tst.ts:20:29:20:34 | [KeywordTypeExpr] string | semmle.label | -2 |
+| tst.ts:20:26:20:26 | [SimpleParameter] y | tst.ts:20:29:20:34 | [KeywordTypeExpr] string | semmle.order | -2 |
 | tst.ts:20:37:20:53 | [BlockStmt] { return x + y; } | tst.ts:20:39:20:51 | [ReturnStmt] return x + y; | semmle.label | 1 |
 | tst.ts:20:37:20:53 | [BlockStmt] { return x + y; } | tst.ts:20:39:20:51 | [ReturnStmt] return x + y; | semmle.order | 1 |
 | tst.ts:20:39:20:51 | [ReturnStmt] return x + y; | tst.ts:20:46:20:50 | [BinaryExpr] x + y | semmle.label | 1 |
@@ -2573,8 +2573,8 @@ edges
 | tst.ts:75:5:75:47 | [SetterMethodSignature] set siz ... olean); | tst.ts:75:5:75:47 | [FunctionExpr] set siz ... olean); | semmle.order | 1 |
 | tst.ts:75:5:75:47 | [SetterMethodSignature] set siz ... olean); | tst.ts:75:9:75:12 | [Label] size | semmle.label | 2 |
 | tst.ts:75:5:75:47 | [SetterMethodSignature] set siz ... olean); | tst.ts:75:9:75:12 | [Label] size | semmle.order | 2 |
-| tst.ts:75:14:75:18 | [SimpleParameter] value | tst.ts:75:21:75:45 | [UnionTypeExpr] number ... boolean | semmle.label | 0 |
-| tst.ts:75:14:75:18 | [SimpleParameter] value | tst.ts:75:21:75:45 | [UnionTypeExpr] number ... boolean | semmle.order | 0 |
+| tst.ts:75:14:75:18 | [SimpleParameter] value | tst.ts:75:21:75:45 | [UnionTypeExpr] number ... boolean | semmle.label | -2 |
+| tst.ts:75:14:75:18 | [SimpleParameter] value | tst.ts:75:21:75:45 | [UnionTypeExpr] number ... boolean | semmle.order | -2 |
 | tst.ts:75:21:75:45 | [UnionTypeExpr] number ... boolean | tst.ts:75:21:75:26 | [KeywordTypeExpr] number | semmle.label | 1 |
 | tst.ts:75:21:75:45 | [UnionTypeExpr] number ... boolean | tst.ts:75:21:75:26 | [KeywordTypeExpr] number | semmle.order | 1 |
 | tst.ts:75:21:75:45 | [UnionTypeExpr] number ... boolean | tst.ts:75:30:75:35 | [KeywordTypeExpr] string | semmle.label | 2 |
@@ -2629,8 +2629,8 @@ edges
 | tst.ts:85:5:87:5 | [FunctionExpr] set siz ... ; } | file://:0:0:0:0 | (Parameters) | semmle.order | 1 |
 | tst.ts:85:5:87:5 | [FunctionExpr] set siz ... ; } | tst.ts:85:48:87:5 | [BlockStmt] { ... ; } | semmle.label | 5 |
 | tst.ts:85:5:87:5 | [FunctionExpr] set siz ... ; } | tst.ts:85:48:87:5 | [BlockStmt] { ... ; } | semmle.order | 5 |
-| tst.ts:85:14:85:18 | [SimpleParameter] value | tst.ts:85:21:85:45 | [UnionTypeExpr] string ... boolean | semmle.label | 0 |
-| tst.ts:85:14:85:18 | [SimpleParameter] value | tst.ts:85:21:85:45 | [UnionTypeExpr] string ... boolean | semmle.order | 0 |
+| tst.ts:85:14:85:18 | [SimpleParameter] value | tst.ts:85:21:85:45 | [UnionTypeExpr] string ... boolean | semmle.label | -2 |
+| tst.ts:85:14:85:18 | [SimpleParameter] value | tst.ts:85:21:85:45 | [UnionTypeExpr] string ... boolean | semmle.order | -2 |
 | tst.ts:85:21:85:45 | [UnionTypeExpr] string ... boolean | tst.ts:85:21:85:26 | [KeywordTypeExpr] string | semmle.label | 1 |
 | tst.ts:85:21:85:45 | [UnionTypeExpr] string ... boolean | tst.ts:85:21:85:26 | [KeywordTypeExpr] string | semmle.order | 1 |
 | tst.ts:85:21:85:45 | [UnionTypeExpr] string ... boolean | tst.ts:85:30:85:35 | [KeywordTypeExpr] number | semmle.label | 2 |
@@ -2733,8 +2733,8 @@ edges
 | tst.ts:104:3:107:3 | [FunctionDeclStmt] functio ... }`; } | tst.ts:104:28:104:44 | [TemplateLiteralTypeExpr] `hello ${string}` | semmle.order | 4 |
 | tst.ts:104:3:107:3 | [FunctionDeclStmt] functio ... }`; } | tst.ts:104:46:107:3 | [BlockStmt] { / ... }`; } | semmle.label | 5 |
 | tst.ts:104:3:107:3 | [FunctionDeclStmt] functio ... }`; } | tst.ts:104:46:107:3 | [BlockStmt] { / ... }`; } | semmle.order | 5 |
-| tst.ts:104:16:104:16 | [SimpleParameter] s | tst.ts:104:19:104:24 | [KeywordTypeExpr] string | semmle.label | 0 |
-| tst.ts:104:16:104:16 | [SimpleParameter] s | tst.ts:104:19:104:24 | [KeywordTypeExpr] string | semmle.order | 0 |
+| tst.ts:104:16:104:16 | [SimpleParameter] s | tst.ts:104:19:104:24 | [KeywordTypeExpr] string | semmle.label | -2 |
+| tst.ts:104:16:104:16 | [SimpleParameter] s | tst.ts:104:19:104:24 | [KeywordTypeExpr] string | semmle.order | -2 |
 | tst.ts:104:28:104:44 | [TemplateLiteralTypeExpr] `hello ${string}` | tst.ts:104:29:104:34 | [LiteralTypeExpr] hello  | semmle.label | 1 |
 | tst.ts:104:28:104:44 | [TemplateLiteralTypeExpr] `hello ${string}` | tst.ts:104:29:104:34 | [LiteralTypeExpr] hello  | semmle.order | 1 |
 | tst.ts:104:28:104:44 | [TemplateLiteralTypeExpr] `hello ${string}` | tst.ts:104:37:104:42 | [KeywordTypeExpr] string | semmle.label | 2 |
@@ -2877,8 +2877,8 @@ edges
 | tst.ts:133:3:138:3 | [FunctionDeclStmt] functio ... } } | tst.ts:133:12:133:14 | [VarDecl] foo | semmle.order | 0 |
 | tst.ts:133:3:138:3 | [FunctionDeclStmt] functio ... } } | tst.ts:133:30:138:3 | [BlockStmt] { c ... } } | semmle.label | 5 |
 | tst.ts:133:3:138:3 | [FunctionDeclStmt] functio ... } } | tst.ts:133:30:138:3 | [BlockStmt] { c ... } } | semmle.order | 5 |
-| tst.ts:133:16:133:18 | [SimpleParameter] arg | tst.ts:133:21:133:27 | [KeywordTypeExpr] unknown | semmle.label | 0 |
-| tst.ts:133:16:133:18 | [SimpleParameter] arg | tst.ts:133:21:133:27 | [KeywordTypeExpr] unknown | semmle.order | 0 |
+| tst.ts:133:16:133:18 | [SimpleParameter] arg | tst.ts:133:21:133:27 | [KeywordTypeExpr] unknown | semmle.label | -2 |
+| tst.ts:133:16:133:18 | [SimpleParameter] arg | tst.ts:133:21:133:27 | [KeywordTypeExpr] unknown | semmle.order | -2 |
 | tst.ts:133:30:138:3 | [BlockStmt] { c ... } } | tst.ts:134:5:134:48 | [DeclStmt] const argIsString = ... | semmle.label | 1 |
 | tst.ts:133:30:138:3 | [BlockStmt] { c ... } } | tst.ts:134:5:134:48 | [DeclStmt] const argIsString = ... | semmle.order | 1 |
 | tst.ts:133:30:138:3 | [BlockStmt] { c ... } } | tst.ts:135:5:137:5 | [IfStmt] if (arg ... ; } | semmle.label | 2 |
@@ -2953,8 +2953,8 @@ edges
 | tst.ts:144:3:149:3 | [FunctionDeclStmt] functio ... ; } } | tst.ts:144:32:144:37 | [KeywordTypeExpr] number | semmle.order | 4 |
 | tst.ts:144:3:149:3 | [FunctionDeclStmt] functio ... ; } } | tst.ts:144:39:149:3 | [BlockStmt] { ... ; } } | semmle.label | 5 |
 | tst.ts:144:3:149:3 | [FunctionDeclStmt] functio ... ; } } | tst.ts:144:39:149:3 | [BlockStmt] { ... ; } } | semmle.order | 5 |
-| tst.ts:144:17:144:21 | [SimpleParameter] shape | tst.ts:144:24:144:28 | [LocalTypeAccess] Shape | semmle.label | 0 |
-| tst.ts:144:17:144:21 | [SimpleParameter] shape | tst.ts:144:24:144:28 | [LocalTypeAccess] Shape | semmle.order | 0 |
+| tst.ts:144:17:144:21 | [SimpleParameter] shape | tst.ts:144:24:144:28 | [LocalTypeAccess] Shape | semmle.label | -2 |
+| tst.ts:144:17:144:21 | [SimpleParameter] shape | tst.ts:144:24:144:28 | [LocalTypeAccess] Shape | semmle.order | -2 |
 | tst.ts:144:39:149:3 | [BlockStmt] { ... ; } } | tst.ts:145:7:145:29 | [DeclStmt] const { ... shape; | semmle.label | 1 |
 | tst.ts:144:39:149:3 | [BlockStmt] { ... ; } } | tst.ts:145:7:145:29 | [DeclStmt] const { ... shape; | semmle.order | 1 |
 | tst.ts:144:39:149:3 | [BlockStmt] { ... ; } } | tst.ts:147:7:148:39 | [IfStmt] if (kin ... ngth; } | semmle.label | 2 |
@@ -3025,24 +3025,24 @@ edges
 | tst.ts:153:7:153:28 | [FunctionExpr] [sym: s ... number; | tst.ts:153:22:153:27 | [KeywordTypeExpr] number | semmle.order | 4 |
 | tst.ts:153:7:153:28 | [IndexSignature] [sym: s ... number; | tst.ts:153:7:153:28 | [FunctionExpr] [sym: s ... number; | semmle.label | 1 |
 | tst.ts:153:7:153:28 | [IndexSignature] [sym: s ... number; | tst.ts:153:7:153:28 | [FunctionExpr] [sym: s ... number; | semmle.order | 1 |
-| tst.ts:153:8:153:10 | [SimpleParameter] sym | tst.ts:153:13:153:18 | [KeywordTypeExpr] symbol | semmle.label | 0 |
-| tst.ts:153:8:153:10 | [SimpleParameter] sym | tst.ts:153:13:153:18 | [KeywordTypeExpr] symbol | semmle.order | 0 |
+| tst.ts:153:8:153:10 | [SimpleParameter] sym | tst.ts:153:13:153:18 | [KeywordTypeExpr] symbol | semmle.label | -2 |
+| tst.ts:153:8:153:10 | [SimpleParameter] sym | tst.ts:153:13:153:18 | [KeywordTypeExpr] symbol | semmle.order | -2 |
 | tst.ts:154:7:154:28 | [FunctionExpr] [key: s ... string; | file://:0:0:0:0 | (Parameters) | semmle.label | 1 |
 | tst.ts:154:7:154:28 | [FunctionExpr] [key: s ... string; | file://:0:0:0:0 | (Parameters) | semmle.order | 1 |
 | tst.ts:154:7:154:28 | [FunctionExpr] [key: s ... string; | tst.ts:154:22:154:27 | [KeywordTypeExpr] string | semmle.label | 4 |
 | tst.ts:154:7:154:28 | [FunctionExpr] [key: s ... string; | tst.ts:154:22:154:27 | [KeywordTypeExpr] string | semmle.order | 4 |
 | tst.ts:154:7:154:28 | [IndexSignature] [key: s ... string; | tst.ts:154:7:154:28 | [FunctionExpr] [key: s ... string; | semmle.label | 1 |
 | tst.ts:154:7:154:28 | [IndexSignature] [key: s ... string; | tst.ts:154:7:154:28 | [FunctionExpr] [key: s ... string; | semmle.order | 1 |
-| tst.ts:154:8:154:10 | [SimpleParameter] key | tst.ts:154:13:154:18 | [KeywordTypeExpr] string | semmle.label | 0 |
-| tst.ts:154:8:154:10 | [SimpleParameter] key | tst.ts:154:13:154:18 | [KeywordTypeExpr] string | semmle.order | 0 |
+| tst.ts:154:8:154:10 | [SimpleParameter] key | tst.ts:154:13:154:18 | [KeywordTypeExpr] string | semmle.label | -2 |
+| tst.ts:154:8:154:10 | [SimpleParameter] key | tst.ts:154:13:154:18 | [KeywordTypeExpr] string | semmle.order | -2 |
 | tst.ts:155:7:155:29 | [FunctionExpr] [num: n ... oolean; | file://:0:0:0:0 | (Parameters) | semmle.label | 1 |
 | tst.ts:155:7:155:29 | [FunctionExpr] [num: n ... oolean; | file://:0:0:0:0 | (Parameters) | semmle.order | 1 |
 | tst.ts:155:7:155:29 | [FunctionExpr] [num: n ... oolean; | tst.ts:155:22:155:28 | [KeywordTypeExpr] boolean | semmle.label | 4 |
 | tst.ts:155:7:155:29 | [FunctionExpr] [num: n ... oolean; | tst.ts:155:22:155:28 | [KeywordTypeExpr] boolean | semmle.order | 4 |
 | tst.ts:155:7:155:29 | [IndexSignature] [num: n ... oolean; | tst.ts:155:7:155:29 | [FunctionExpr] [num: n ... oolean; | semmle.label | 1 |
 | tst.ts:155:7:155:29 | [IndexSignature] [num: n ... oolean; | tst.ts:155:7:155:29 | [FunctionExpr] [num: n ... oolean; | semmle.order | 1 |
-| tst.ts:155:8:155:10 | [SimpleParameter] num | tst.ts:155:13:155:18 | [KeywordTypeExpr] number | semmle.label | 0 |
-| tst.ts:155:8:155:10 | [SimpleParameter] num | tst.ts:155:13:155:18 | [KeywordTypeExpr] number | semmle.order | 0 |
+| tst.ts:155:8:155:10 | [SimpleParameter] num | tst.ts:155:13:155:18 | [KeywordTypeExpr] number | semmle.label | -2 |
+| tst.ts:155:8:155:10 | [SimpleParameter] num | tst.ts:155:13:155:18 | [KeywordTypeExpr] number | semmle.order | -2 |
 | tst.ts:158:5:158:28 | [DeclStmt] let colors = ... | tst.ts:158:9:158:27 | [VariableDeclarator] colors: Colors = {} | semmle.label | 1 |
 | tst.ts:158:5:158:28 | [DeclStmt] let colors = ... | tst.ts:158:9:158:27 | [VariableDeclarator] colors: Colors = {} | semmle.order | 1 |
 | tst.ts:158:9:158:27 | [VariableDeclarator] colors: Colors = {} | tst.ts:158:9:158:14 | [VarDecl] colors | semmle.label | 1 |
@@ -3111,8 +3111,8 @@ edges
 | tst.ts:166:7:166:37 | [FunctionExpr] [key: ` ... number; | tst.ts:166:31:166:36 | [KeywordTypeExpr] number | semmle.order | 4 |
 | tst.ts:166:7:166:37 | [IndexSignature] [key: ` ... number; | tst.ts:166:7:166:37 | [FunctionExpr] [key: ` ... number; | semmle.label | 1 |
 | tst.ts:166:7:166:37 | [IndexSignature] [key: ` ... number; | tst.ts:166:7:166:37 | [FunctionExpr] [key: ` ... number; | semmle.order | 1 |
-| tst.ts:166:8:166:10 | [SimpleParameter] key | tst.ts:166:13:166:27 | [TemplateLiteralTypeExpr] `foo-${number}` | semmle.label | 0 |
-| tst.ts:166:8:166:10 | [SimpleParameter] key | tst.ts:166:13:166:27 | [TemplateLiteralTypeExpr] `foo-${number}` | semmle.order | 0 |
+| tst.ts:166:8:166:10 | [SimpleParameter] key | tst.ts:166:13:166:27 | [TemplateLiteralTypeExpr] `foo-${number}` | semmle.label | -2 |
+| tst.ts:166:8:166:10 | [SimpleParameter] key | tst.ts:166:13:166:27 | [TemplateLiteralTypeExpr] `foo-${number}` | semmle.order | -2 |
 | tst.ts:166:13:166:27 | [TemplateLiteralTypeExpr] `foo-${number}` | tst.ts:166:14:166:17 | [LiteralTypeExpr] foo- | semmle.label | 1 |
 | tst.ts:166:13:166:27 | [TemplateLiteralTypeExpr] `foo-${number}` | tst.ts:166:14:166:17 | [LiteralTypeExpr] foo- | semmle.order | 1 |
 | tst.ts:166:13:166:27 | [TemplateLiteralTypeExpr] `foo-${number}` | tst.ts:166:20:166:25 | [KeywordTypeExpr] number | semmle.label | 2 |
@@ -3147,8 +3147,8 @@ edges
 | tst.ts:172:7:172:42 | [FunctionExpr] [optNam ... oolean; | tst.ts:172:35:172:41 | [KeywordTypeExpr] boolean | semmle.order | 4 |
 | tst.ts:172:7:172:42 | [IndexSignature] [optNam ... oolean; | tst.ts:172:7:172:42 | [FunctionExpr] [optNam ... oolean; | semmle.label | 1 |
 | tst.ts:172:7:172:42 | [IndexSignature] [optNam ... oolean; | tst.ts:172:7:172:42 | [FunctionExpr] [optNam ... oolean; | semmle.order | 1 |
-| tst.ts:172:8:172:14 | [SimpleParameter] optName | tst.ts:172:17:172:31 | [UnionTypeExpr] string \| symbol | semmle.label | 0 |
-| tst.ts:172:8:172:14 | [SimpleParameter] optName | tst.ts:172:17:172:31 | [UnionTypeExpr] string \| symbol | semmle.order | 0 |
+| tst.ts:172:8:172:14 | [SimpleParameter] optName | tst.ts:172:17:172:31 | [UnionTypeExpr] string \| symbol | semmle.label | -2 |
+| tst.ts:172:8:172:14 | [SimpleParameter] optName | tst.ts:172:17:172:31 | [UnionTypeExpr] string \| symbol | semmle.order | -2 |
 | tst.ts:172:17:172:31 | [UnionTypeExpr] string \| symbol | tst.ts:172:17:172:22 | [KeywordTypeExpr] string | semmle.label | 1 |
 | tst.ts:172:17:172:31 | [UnionTypeExpr] string \| symbol | tst.ts:172:17:172:22 | [KeywordTypeExpr] string | semmle.order | 1 |
 | tst.ts:172:17:172:31 | [UnionTypeExpr] string \| symbol | tst.ts:172:26:172:31 | [KeywordTypeExpr] symbol | semmle.label | 2 |
@@ -3343,8 +3343,8 @@ edges
 | tst.ts:215:10:220:3 | [FunctionDeclStmt] functio ... } } | tst.ts:215:19:215:25 | [VarDecl] handler | semmle.order | 0 |
 | tst.ts:215:10:220:3 | [FunctionDeclStmt] functio ... } } | tst.ts:215:47:220:3 | [BlockStmt] { ... } } | semmle.label | 5 |
 | tst.ts:215:10:220:3 | [FunctionDeclStmt] functio ... } } | tst.ts:215:47:220:3 | [BlockStmt] { ... } } | semmle.order | 5 |
-| tst.ts:215:27:215:27 | [SimpleParameter] r | tst.ts:215:30:215:44 | [UnionTypeExpr] Success \| Error | semmle.label | 0 |
-| tst.ts:215:27:215:27 | [SimpleParameter] r | tst.ts:215:30:215:44 | [UnionTypeExpr] Success \| Error | semmle.order | 0 |
+| tst.ts:215:27:215:27 | [SimpleParameter] r | tst.ts:215:30:215:44 | [UnionTypeExpr] Success \| Error | semmle.label | -2 |
+| tst.ts:215:27:215:27 | [SimpleParameter] r | tst.ts:215:30:215:44 | [UnionTypeExpr] Success \| Error | semmle.order | -2 |
 | tst.ts:215:30:215:44 | [UnionTypeExpr] Success \| Error | tst.ts:215:30:215:36 | [LocalTypeAccess] Success | semmle.label | 1 |
 | tst.ts:215:30:215:44 | [UnionTypeExpr] Success \| Error | tst.ts:215:30:215:36 | [LocalTypeAccess] Success | semmle.order | 1 |
 | tst.ts:215:30:215:44 | [UnionTypeExpr] Success \| Error | tst.ts:215:40:215:44 | [LocalTypeAccess] Error | semmle.label | 2 |
@@ -3395,8 +3395,8 @@ edges
 | tst.ts:224:5:226:5 | [FunctionExpr] constru ... ; } | file://:0:0:0:0 | (Parameters) | semmle.order | 1 |
 | tst.ts:224:5:226:5 | [FunctionExpr] constru ... ; } | tst.ts:224:31:226:5 | [BlockStmt] { ... ; } | semmle.label | 5 |
 | tst.ts:224:5:226:5 | [FunctionExpr] constru ... ; } | tst.ts:224:31:226:5 | [BlockStmt] { ... ; } | semmle.order | 5 |
-| tst.ts:224:17:224:20 | [SimpleParameter] name | tst.ts:224:23:224:28 | [KeywordTypeExpr] string | semmle.label | 0 |
-| tst.ts:224:17:224:20 | [SimpleParameter] name | tst.ts:224:23:224:28 | [KeywordTypeExpr] string | semmle.order | 0 |
+| tst.ts:224:17:224:20 | [SimpleParameter] name | tst.ts:224:23:224:28 | [KeywordTypeExpr] string | semmle.label | -2 |
+| tst.ts:224:17:224:20 | [SimpleParameter] name | tst.ts:224:23:224:28 | [KeywordTypeExpr] string | semmle.order | -2 |
 | tst.ts:224:31:226:5 | [BlockStmt] { ... ; } | tst.ts:225:9:225:26 | [ExprStmt] this.#name = name; | semmle.label | 1 |
 | tst.ts:224:31:226:5 | [BlockStmt] { ... ; } | tst.ts:225:9:225:26 | [ExprStmt] this.#name = name; | semmle.order | 1 |
 | tst.ts:225:9:225:18 | [DotExpr] this.#name | tst.ts:225:9:225:12 | [ThisExpr] this | semmle.label | 1 |
@@ -3417,8 +3417,8 @@ edges
 | tst.ts:228:5:233:5 | [FunctionExpr] equals( ... . } | file://:0:0:0:0 | (Parameters) | semmle.order | 1 |
 | tst.ts:228:5:233:5 | [FunctionExpr] equals( ... . } | tst.ts:228:28:233:5 | [BlockStmt] { ... . } | semmle.label | 5 |
 | tst.ts:228:5:233:5 | [FunctionExpr] equals( ... . } | tst.ts:228:28:233:5 | [BlockStmt] { ... . } | semmle.order | 5 |
-| tst.ts:228:12:228:16 | [SimpleParameter] other | tst.ts:228:19:228:25 | [KeywordTypeExpr] unknown | semmle.label | 0 |
-| tst.ts:228:12:228:16 | [SimpleParameter] other | tst.ts:228:19:228:25 | [KeywordTypeExpr] unknown | semmle.order | 0 |
+| tst.ts:228:12:228:16 | [SimpleParameter] other | tst.ts:228:19:228:25 | [KeywordTypeExpr] unknown | semmle.label | -2 |
+| tst.ts:228:12:228:16 | [SimpleParameter] other | tst.ts:228:19:228:25 | [KeywordTypeExpr] unknown | semmle.order | -2 |
 | tst.ts:228:28:233:5 | [BlockStmt] { ... . } | tst.ts:229:9:232:39 | [ReturnStmt] return ... .#name; | semmle.label | 1 |
 | tst.ts:228:28:233:5 | [BlockStmt] { ... . } | tst.ts:229:9:232:39 | [ReturnStmt] return ... .#name; | semmle.order | 1 |
 | tst.ts:229:9:232:39 | [ReturnStmt] return ... .#name; | tst.ts:229:16:232:38 | [BinaryExpr] other & ... r.#name | semmle.label | 1 |
@@ -3579,8 +3579,8 @@ edges
 | tst.ts:256:3:263:3 | [FunctionDeclStmt] functio ... } } | tst.ts:256:12:256:24 | [VarDecl] processAction | semmle.order | 0 |
 | tst.ts:256:3:263:3 | [FunctionDeclStmt] functio ... } } | tst.ts:256:42:263:3 | [BlockStmt] { c ... } } | semmle.label | 5 |
 | tst.ts:256:3:263:3 | [FunctionDeclStmt] functio ... } } | tst.ts:256:42:263:3 | [BlockStmt] { c ... } } | semmle.order | 5 |
-| tst.ts:256:26:256:31 | [SimpleParameter] action | tst.ts:256:34:256:39 | [LocalTypeAccess] Action | semmle.label | 0 |
-| tst.ts:256:26:256:31 | [SimpleParameter] action | tst.ts:256:34:256:39 | [LocalTypeAccess] Action | semmle.order | 0 |
+| tst.ts:256:26:256:31 | [SimpleParameter] action | tst.ts:256:34:256:39 | [LocalTypeAccess] Action | semmle.label | -2 |
+| tst.ts:256:26:256:31 | [SimpleParameter] action | tst.ts:256:34:256:39 | [LocalTypeAccess] Action | semmle.order | -2 |
 | tst.ts:256:42:263:3 | [BlockStmt] { c ... } } | tst.ts:257:5:257:37 | [DeclStmt] const { ... action; | semmle.label | 1 |
 | tst.ts:256:42:263:3 | [BlockStmt] { c ... } } | tst.ts:257:5:257:37 | [DeclStmt] const { ... action; | semmle.order | 1 |
 | tst.ts:256:42:263:3 | [BlockStmt] { c ... } } | tst.ts:258:5:262:5 | [IfStmt] if (kin ... g } | semmle.label | 2 |
@@ -3719,8 +3719,8 @@ edges
 | tst.ts:274:10:274:32 | [FunctionExpr] (p: Typ ... => void | tst.ts:274:29:274:32 | [KeywordTypeExpr] void | semmle.order | 4 |
 | tst.ts:274:10:274:32 | [FunctionTypeExpr] (p: Typ ... => void | tst.ts:274:10:274:32 | [FunctionExpr] (p: Typ ... => void | semmle.label | 1 |
 | tst.ts:274:10:274:32 | [FunctionTypeExpr] (p: Typ ... => void | tst.ts:274:10:274:32 | [FunctionExpr] (p: Typ ... => void | semmle.order | 1 |
-| tst.ts:274:11:274:11 | [SimpleParameter] p | tst.ts:274:14:274:23 | [IndexedAccessTypeExpr] TypeMap[K] | semmle.label | 0 |
-| tst.ts:274:11:274:11 | [SimpleParameter] p | tst.ts:274:14:274:23 | [IndexedAccessTypeExpr] TypeMap[K] | semmle.order | 0 |
+| tst.ts:274:11:274:11 | [SimpleParameter] p | tst.ts:274:14:274:23 | [IndexedAccessTypeExpr] TypeMap[K] | semmle.label | -2 |
+| tst.ts:274:11:274:11 | [SimpleParameter] p | tst.ts:274:14:274:23 | [IndexedAccessTypeExpr] TypeMap[K] | semmle.order | -2 |
 | tst.ts:274:14:274:23 | [IndexedAccessTypeExpr] TypeMap[K] | tst.ts:274:14:274:20 | [LocalTypeAccess] TypeMap | semmle.label | 1 |
 | tst.ts:274:14:274:23 | [IndexedAccessTypeExpr] TypeMap[K] | tst.ts:274:14:274:20 | [LocalTypeAccess] TypeMap | semmle.order | 1 |
 | tst.ts:274:14:274:23 | [IndexedAccessTypeExpr] TypeMap[K] | tst.ts:274:22:274:22 | [LocalTypeAccess] K | semmle.label | 2 |
@@ -3739,8 +3739,8 @@ edges
 | tst.ts:278:26:278:48 | [TypeParameter] K exten ... TypeMap | tst.ts:278:36:278:48 | [KeyofTypeExpr] keyof TypeMap | semmle.order | 2 |
 | tst.ts:278:36:278:48 | [KeyofTypeExpr] keyof TypeMap | tst.ts:278:42:278:48 | [LocalTypeAccess] TypeMap | semmle.label | 1 |
 | tst.ts:278:36:278:48 | [KeyofTypeExpr] keyof TypeMap | tst.ts:278:42:278:48 | [LocalTypeAccess] TypeMap | semmle.order | 1 |
-| tst.ts:278:51:278:56 | [SimpleParameter] record | tst.ts:278:59:278:72 | [GenericTypeExpr] UnionRecord<K> | semmle.label | 0 |
-| tst.ts:278:51:278:56 | [SimpleParameter] record | tst.ts:278:59:278:72 | [GenericTypeExpr] UnionRecord<K> | semmle.order | 0 |
+| tst.ts:278:51:278:56 | [SimpleParameter] record | tst.ts:278:59:278:72 | [GenericTypeExpr] UnionRecord<K> | semmle.label | -2 |
+| tst.ts:278:51:278:56 | [SimpleParameter] record | tst.ts:278:59:278:72 | [GenericTypeExpr] UnionRecord<K> | semmle.order | -2 |
 | tst.ts:278:59:278:72 | [GenericTypeExpr] UnionRecord<K> | tst.ts:278:59:278:69 | [LocalTypeAccess] UnionRecord | semmle.label | 1 |
 | tst.ts:278:59:278:72 | [GenericTypeExpr] UnionRecord<K> | tst.ts:278:59:278:69 | [LocalTypeAccess] UnionRecord | semmle.order | 1 |
 | tst.ts:278:59:278:72 | [GenericTypeExpr] UnionRecord<K> | tst.ts:278:71:278:71 | [LocalTypeAccess] K | semmle.label | 2 |
@@ -3811,8 +3811,8 @@ edges
 | tst.ts:289:15:289:62 | [FunctionExpr] (...arg ... => void | tst.ts:289:59:289:62 | [KeywordTypeExpr] void | semmle.order | 4 |
 | tst.ts:289:15:289:62 | [FunctionTypeExpr] (...arg ... => void | tst.ts:289:15:289:62 | [FunctionExpr] (...arg ... => void | semmle.label | 1 |
 | tst.ts:289:15:289:62 | [FunctionTypeExpr] (...arg ... => void | tst.ts:289:15:289:62 | [FunctionExpr] (...arg ... => void | semmle.order | 1 |
-| tst.ts:289:19:289:22 | [SimpleParameter] args | tst.ts:289:25:289:53 | [UnionTypeExpr] ["a", n ... string] | semmle.label | 0 |
-| tst.ts:289:19:289:22 | [SimpleParameter] args | tst.ts:289:25:289:53 | [UnionTypeExpr] ["a", n ... string] | semmle.order | 0 |
+| tst.ts:289:19:289:22 | [SimpleParameter] args | tst.ts:289:25:289:53 | [UnionTypeExpr] ["a", n ... string] | semmle.label | -2 |
+| tst.ts:289:19:289:22 | [SimpleParameter] args | tst.ts:289:25:289:53 | [UnionTypeExpr] ["a", n ... string] | semmle.order | -2 |
 | tst.ts:289:25:289:37 | [TupleTypeExpr] ["a", number] | tst.ts:289:26:289:28 | [LiteralTypeExpr] "a" | semmle.label | 1 |
 | tst.ts:289:25:289:37 | [TupleTypeExpr] ["a", number] | tst.ts:289:26:289:28 | [LiteralTypeExpr] "a" | semmle.order | 1 |
 | tst.ts:289:25:289:37 | [TupleTypeExpr] ["a", number] | tst.ts:289:31:289:36 | [KeywordTypeExpr] number | semmle.label | 2 |
@@ -3947,8 +3947,8 @@ edges
 | tst.ts:313:1:316:10 | [FunctionDeclStmt] functio ... void {} | tst.ts:316:9:316:10 | [BlockStmt] {} | semmle.order | 5 |
 | tst.ts:313:12:313:12 | [TypeParameter] T | tst.ts:313:12:313:12 | [Identifier] T | semmle.label | 1 |
 | tst.ts:313:12:313:12 | [TypeParameter] T | tst.ts:313:12:313:12 | [Identifier] T | semmle.order | 1 |
-| tst.ts:313:15:313:17 | [SimpleParameter] arg | tst.ts:313:20:315:27 | [InterfaceTypeExpr] { pro ... void } | semmle.label | 0 |
-| tst.ts:313:15:313:17 | [SimpleParameter] arg | tst.ts:313:20:315:27 | [InterfaceTypeExpr] { pro ... void } | semmle.order | 0 |
+| tst.ts:313:15:313:17 | [SimpleParameter] arg | tst.ts:313:20:315:27 | [InterfaceTypeExpr] { pro ... void } | semmle.label | -2 |
+| tst.ts:313:15:313:17 | [SimpleParameter] arg | tst.ts:313:20:315:27 | [InterfaceTypeExpr] { pro ... void } | semmle.order | -2 |
 | tst.ts:313:20:315:27 | [InterfaceTypeExpr] { pro ... void } | tst.ts:314:3:314:28 | [FieldDeclaration] produce ... ) => T, | semmle.label | 1 |
 | tst.ts:313:20:315:27 | [InterfaceTypeExpr] { pro ... void } | tst.ts:314:3:314:28 | [FieldDeclaration] produce ... ) => T, | semmle.order | 1 |
 | tst.ts:313:20:315:27 | [InterfaceTypeExpr] { pro ... void } | tst.ts:315:3:315:25 | [FieldDeclaration] consume ... => void | semmle.label | 2 |
@@ -3963,8 +3963,8 @@ edges
 | tst.ts:314:12:314:27 | [FunctionExpr] (n: string) => T | tst.ts:314:27:314:27 | [LocalTypeAccess] T | semmle.order | 4 |
 | tst.ts:314:12:314:27 | [FunctionTypeExpr] (n: string) => T | tst.ts:314:12:314:27 | [FunctionExpr] (n: string) => T | semmle.label | 1 |
 | tst.ts:314:12:314:27 | [FunctionTypeExpr] (n: string) => T | tst.ts:314:12:314:27 | [FunctionExpr] (n: string) => T | semmle.order | 1 |
-| tst.ts:314:13:314:13 | [SimpleParameter] n | tst.ts:314:16:314:21 | [KeywordTypeExpr] string | semmle.label | 0 |
-| tst.ts:314:13:314:13 | [SimpleParameter] n | tst.ts:314:16:314:21 | [KeywordTypeExpr] string | semmle.order | 0 |
+| tst.ts:314:13:314:13 | [SimpleParameter] n | tst.ts:314:16:314:21 | [KeywordTypeExpr] string | semmle.label | -2 |
+| tst.ts:314:13:314:13 | [SimpleParameter] n | tst.ts:314:16:314:21 | [KeywordTypeExpr] string | semmle.order | -2 |
 | tst.ts:315:3:315:25 | [FieldDeclaration] consume ... => void | tst.ts:315:3:315:9 | [Label] consume | semmle.label | 1 |
 | tst.ts:315:3:315:25 | [FieldDeclaration] consume ... => void | tst.ts:315:3:315:9 | [Label] consume | semmle.order | 1 |
 | tst.ts:315:3:315:25 | [FieldDeclaration] consume ... => void | tst.ts:315:12:315:25 | [FunctionTypeExpr] (x: T) => void | semmle.label | 2 |
@@ -3975,8 +3975,8 @@ edges
 | tst.ts:315:12:315:25 | [FunctionExpr] (x: T) => void | tst.ts:315:22:315:25 | [KeywordTypeExpr] void | semmle.order | 4 |
 | tst.ts:315:12:315:25 | [FunctionTypeExpr] (x: T) => void | tst.ts:315:12:315:25 | [FunctionExpr] (x: T) => void | semmle.label | 1 |
 | tst.ts:315:12:315:25 | [FunctionTypeExpr] (x: T) => void | tst.ts:315:12:315:25 | [FunctionExpr] (x: T) => void | semmle.order | 1 |
-| tst.ts:315:13:315:13 | [SimpleParameter] x | tst.ts:315:16:315:16 | [LocalTypeAccess] T | semmle.label | 0 |
-| tst.ts:315:13:315:13 | [SimpleParameter] x | tst.ts:315:16:315:16 | [LocalTypeAccess] T | semmle.order | 0 |
+| tst.ts:315:13:315:13 | [SimpleParameter] x | tst.ts:315:16:315:16 | [LocalTypeAccess] T | semmle.label | -2 |
+| tst.ts:315:13:315:13 | [SimpleParameter] x | tst.ts:315:16:315:16 | [LocalTypeAccess] T | semmle.order | -2 |
 | tst.ts:318:1:321:2 | [CallExpr] f({ p ... se() }) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
 | tst.ts:318:1:321:2 | [CallExpr] f({ p ... se() }) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
 | tst.ts:318:1:321:2 | [CallExpr] f({ p ... se() }) | tst.ts:318:1:318:1 | [VarRef] f | semmle.label | 0 |
@@ -4113,8 +4113,8 @@ edges
 | tst.ts:344:8:344:25 | [FunctionExpr] (value: T) => void | tst.ts:344:22:344:25 | [KeywordTypeExpr] void | semmle.order | 4 |
 | tst.ts:344:8:344:25 | [FunctionTypeExpr] (value: T) => void | tst.ts:344:8:344:25 | [FunctionExpr] (value: T) => void | semmle.label | 1 |
 | tst.ts:344:8:344:25 | [FunctionTypeExpr] (value: T) => void | tst.ts:344:8:344:25 | [FunctionExpr] (value: T) => void | semmle.order | 1 |
-| tst.ts:344:9:344:13 | [SimpleParameter] value | tst.ts:344:16:344:16 | [LocalTypeAccess] T | semmle.label | 0 |
-| tst.ts:344:9:344:13 | [SimpleParameter] value | tst.ts:344:16:344:16 | [LocalTypeAccess] T | semmle.order | 0 |
+| tst.ts:344:9:344:13 | [SimpleParameter] value | tst.ts:344:16:344:16 | [LocalTypeAccess] T | semmle.label | -2 |
+| tst.ts:344:9:344:13 | [SimpleParameter] value | tst.ts:344:16:344:16 | [LocalTypeAccess] T | semmle.order | -2 |
 | tst.ts:347:1:350:1 | [DeclStmt] const state = ... | tst.ts:347:7:350:1 | [VariableDeclarator] state: ... > { } } | semmle.label | 1 |
 | tst.ts:347:1:350:1 | [DeclStmt] const state = ... | tst.ts:347:7:350:1 | [VariableDeclarator] state: ... > { } } | semmle.order | 1 |
 | tst.ts:347:7:350:1 | [VariableDeclarator] state: ... > { } } | tst.ts:347:7:347:11 | [VarDecl] state | semmle.label | 1 |
@@ -4277,10 +4277,10 @@ edges
 | tst.ts:383:5:383:54 | [FunctionDeclStmt] declare ... T): T; | tst.ts:383:53:383:53 | [LocalTypeAccess] T | semmle.order | 4 |
 | tst.ts:383:37:383:37 | [TypeParameter] T | tst.ts:383:37:383:37 | [Identifier] T | semmle.label | 1 |
 | tst.ts:383:37:383:37 | [TypeParameter] T | tst.ts:383:37:383:37 | [Identifier] T | semmle.order | 1 |
-| tst.ts:383:40:383:40 | [SimpleParameter] x | tst.ts:383:43:383:43 | [LocalTypeAccess] T | semmle.label | 0 |
-| tst.ts:383:40:383:40 | [SimpleParameter] x | tst.ts:383:43:383:43 | [LocalTypeAccess] T | semmle.order | 0 |
-| tst.ts:383:46:383:46 | [SimpleParameter] y | tst.ts:383:49:383:49 | [LocalTypeAccess] T | semmle.label | 0 |
-| tst.ts:383:46:383:46 | [SimpleParameter] y | tst.ts:383:49:383:49 | [LocalTypeAccess] T | semmle.order | 0 |
+| tst.ts:383:40:383:40 | [SimpleParameter] x | tst.ts:383:43:383:43 | [LocalTypeAccess] T | semmle.label | -2 |
+| tst.ts:383:40:383:40 | [SimpleParameter] x | tst.ts:383:43:383:43 | [LocalTypeAccess] T | semmle.order | -2 |
+| tst.ts:383:46:383:46 | [SimpleParameter] y | tst.ts:383:49:383:49 | [LocalTypeAccess] T | semmle.label | -2 |
+| tst.ts:383:46:383:46 | [SimpleParameter] y | tst.ts:383:49:383:49 | [LocalTypeAccess] T | semmle.order | -2 |
 | tst.ts:385:5:385:74 | [DeclStmt] let [a, ... ye!"]); | tst.ts:385:9:385:73 | [VariableDeclarator] [a, b, ... bye!"]) | semmle.label | 1 |
 | tst.ts:385:5:385:74 | [DeclStmt] let [a, ... ye!"]); | tst.ts:385:9:385:73 | [VariableDeclarator] [a, b, ... bye!"]) | semmle.order | 1 |
 | tst.ts:385:9:385:17 | [ArrayPattern] [a, b, c] | tst.ts:385:10:385:10 | [VarDecl] a | semmle.label | 1 |
@@ -4443,8 +4443,8 @@ edges
 | tst.ts:412:3:416:3 | [FunctionDeclStmt] functio ... } } | tst.ts:412:12:412:19 | [VarDecl] setColor | semmle.order | 0 |
 | tst.ts:412:3:416:3 | [FunctionDeclStmt] functio ... } } | tst.ts:412:45:416:3 | [BlockStmt] { i ... } } | semmle.label | 5 |
 | tst.ts:412:3:416:3 | [FunctionDeclStmt] functio ... } } | tst.ts:412:45:416:3 | [BlockStmt] { i ... } } | semmle.order | 5 |
-| tst.ts:412:21:412:25 | [SimpleParameter] color | tst.ts:412:28:412:42 | [UnionTypeExpr] RGBObj \| HSVObj | semmle.label | 0 |
-| tst.ts:412:21:412:25 | [SimpleParameter] color | tst.ts:412:28:412:42 | [UnionTypeExpr] RGBObj \| HSVObj | semmle.order | 0 |
+| tst.ts:412:21:412:25 | [SimpleParameter] color | tst.ts:412:28:412:42 | [UnionTypeExpr] RGBObj \| HSVObj | semmle.label | -2 |
+| tst.ts:412:21:412:25 | [SimpleParameter] color | tst.ts:412:28:412:42 | [UnionTypeExpr] RGBObj \| HSVObj | semmle.order | -2 |
 | tst.ts:412:28:412:42 | [UnionTypeExpr] RGBObj \| HSVObj | tst.ts:412:28:412:33 | [LocalTypeAccess] RGBObj | semmle.label | 1 |
 | tst.ts:412:28:412:42 | [UnionTypeExpr] RGBObj \| HSVObj | tst.ts:412:28:412:33 | [LocalTypeAccess] RGBObj | semmle.order | 1 |
 | tst.ts:412:28:412:42 | [UnionTypeExpr] RGBObj \| HSVObj | tst.ts:412:37:412:42 | [LocalTypeAccess] HSVObj | semmle.label | 2 |
@@ -4485,8 +4485,8 @@ edges
 | tst.ts:422:5:424:5 | [FunctionExpr] constru ... ; } | file://:0:0:0:0 | (Parameters) | semmle.order | 1 |
 | tst.ts:422:5:424:5 | [FunctionExpr] constru ... ; } | tst.ts:422:31:424:5 | [BlockStmt] { ... ; } | semmle.label | 5 |
 | tst.ts:422:5:424:5 | [FunctionExpr] constru ... ; } | tst.ts:422:31:424:5 | [BlockStmt] { ... ; } | semmle.order | 5 |
-| tst.ts:422:17:422:20 | [SimpleParameter] name | tst.ts:422:23:422:28 | [KeywordTypeExpr] string | semmle.label | 0 |
-| tst.ts:422:17:422:20 | [SimpleParameter] name | tst.ts:422:23:422:28 | [KeywordTypeExpr] string | semmle.order | 0 |
+| tst.ts:422:17:422:20 | [SimpleParameter] name | tst.ts:422:23:422:28 | [KeywordTypeExpr] string | semmle.label | -2 |
+| tst.ts:422:17:422:20 | [SimpleParameter] name | tst.ts:422:23:422:28 | [KeywordTypeExpr] string | semmle.order | -2 |
 | tst.ts:422:31:424:5 | [BlockStmt] { ... ; } | tst.ts:423:7:423:23 | [ExprStmt] this.name = name; | semmle.label | 1 |
 | tst.ts:422:31:424:5 | [BlockStmt] { ... ; } | tst.ts:423:7:423:23 | [ExprStmt] this.name = name; | semmle.order | 1 |
 | tst.ts:423:7:423:15 | [DotExpr] this.name | tst.ts:423:7:423:10 | [ThisExpr] this | semmle.label | 1 |
@@ -4663,8 +4663,8 @@ edges
 | type_alias.ts:14:9:14:32 | [FunctionExpr] [proper ... ]: Json | type_alias.ts:14:29:14:32 | [LocalTypeAccess] Json | semmle.order | 4 |
 | type_alias.ts:14:9:14:32 | [IndexSignature] [proper ... ]: Json | type_alias.ts:14:9:14:32 | [FunctionExpr] [proper ... ]: Json | semmle.label | 1 |
 | type_alias.ts:14:9:14:32 | [IndexSignature] [proper ... ]: Json | type_alias.ts:14:9:14:32 | [FunctionExpr] [proper ... ]: Json | semmle.order | 1 |
-| type_alias.ts:14:10:14:17 | [SimpleParameter] property | type_alias.ts:14:20:14:25 | [KeywordTypeExpr] string | semmle.label | 0 |
-| type_alias.ts:14:10:14:17 | [SimpleParameter] property | type_alias.ts:14:20:14:25 | [KeywordTypeExpr] string | semmle.order | 0 |
+| type_alias.ts:14:10:14:17 | [SimpleParameter] property | type_alias.ts:14:20:14:25 | [KeywordTypeExpr] string | semmle.label | -2 |
+| type_alias.ts:14:10:14:17 | [SimpleParameter] property | type_alias.ts:14:20:14:25 | [KeywordTypeExpr] string | semmle.order | -2 |
 | type_alias.ts:15:7:15:12 | [ArrayTypeExpr] Json[] | type_alias.ts:15:7:15:10 | [LocalTypeAccess] Json | semmle.label | 1 |
 | type_alias.ts:15:7:15:12 | [ArrayTypeExpr] Json[] | type_alias.ts:15:7:15:10 | [LocalTypeAccess] Json | semmle.order | 1 |
 | type_alias.ts:17:1:17:15 | [DeclStmt] var json = ... | type_alias.ts:17:5:17:14 | [VariableDeclarator] json: Json | semmle.label | 1 |
@@ -4695,8 +4695,8 @@ edges
 | type_alias.ts:21:18:21:35 | [FunctionExpr] [key: string]: any | type_alias.ts:21:33:21:35 | [KeywordTypeExpr] any | semmle.order | 4 |
 | type_alias.ts:21:18:21:35 | [IndexSignature] [key: string]: any | type_alias.ts:21:18:21:35 | [FunctionExpr] [key: string]: any | semmle.label | 1 |
 | type_alias.ts:21:18:21:35 | [IndexSignature] [key: string]: any | type_alias.ts:21:18:21:35 | [FunctionExpr] [key: string]: any | semmle.order | 1 |
-| type_alias.ts:21:19:21:21 | [SimpleParameter] key | type_alias.ts:21:24:21:29 | [KeywordTypeExpr] string | semmle.label | 0 |
-| type_alias.ts:21:19:21:21 | [SimpleParameter] key | type_alias.ts:21:24:21:29 | [KeywordTypeExpr] string | semmle.order | 0 |
+| type_alias.ts:21:19:21:21 | [SimpleParameter] key | type_alias.ts:21:24:21:29 | [KeywordTypeExpr] string | semmle.label | -2 |
+| type_alias.ts:21:19:21:21 | [SimpleParameter] key | type_alias.ts:21:24:21:29 | [KeywordTypeExpr] string | semmle.order | -2 |
 | type_alias.ts:21:40:21:55 | [RestTypeExpr] ...VirtualNode[] | type_alias.ts:21:43:21:55 | [ArrayTypeExpr] VirtualNode[] | semmle.label | 1 |
 | type_alias.ts:21:40:21:55 | [RestTypeExpr] ...VirtualNode[] | type_alias.ts:21:43:21:55 | [ArrayTypeExpr] VirtualNode[] | semmle.order | 1 |
 | type_alias.ts:21:43:21:55 | [ArrayTypeExpr] VirtualNode[] | type_alias.ts:21:43:21:53 | [LocalTypeAccess] VirtualNode | semmle.label | 1 |


### PR DESCRIPTION
I noticed some issues in the AST viewer while watching this video https://www.youtube.com/watch?v=VrF1RwnJzBk&t=1346s (link is timestamped, you can see the issue).  

This fixes these issues. 

1: There is an internal [private class DecoratorList](https://github.com/github/codeql/blob/4e1f772f23a1b7a91d139284a0acc74dde25c4b4/javascript/ql/lib/semmle/javascript/Variables.qll#L675) that shouldn't appear in the PrintAst output, because there are already direct links to the individual decorators.  
2: The `ParameterNode` class in `PrintAst.qll` didn't handle cases where the parameter had child nodes in the ast (which is the case for destructuring parameters).  