### PR TITLE
C++: Fix bad join in `definitionOf`

### DIFF
--- a/cpp/ql/lib/definitions.qll
+++ b/cpp/ql/lib/definitions.qll
@@ -123,6 +123,13 @@ private predicate constructorCallTypeMention(ConstructorCall cc, TypeMention tm)
   )
 }
 
+/** Holds if `loc` has the container `container` and is on the line starting at `startLine`. */
+pragma[nomagic]
+private predicate hasContainerAndStartLine(Location loc, Container container, int startLine) {
+  loc.getStartLine() = startLine and
+  loc.getContainer() = container
+}
+
 /**
  * Gets an element, of kind `kind`, that element `e` uses, if any.
  * Attention: This predicate yields multiple definitions for a single location.
@@ -184,11 +191,9 @@ Top definitionOf(Top e, string kind) {
     kind = "I" and
     result = e.(Include).getIncludedFile() and
     // exclude `#include` directives containing macros
-    not exists(MacroInvocation mi, Location l1, Location l2 |
-      l1 = e.(Include).getLocation() and
-      l2 = mi.getLocation() and
-      l1.getContainer() = l2.getContainer() and
-      l1.getStartLine() = l2.getStartLine()
+    not exists(MacroInvocation mi, Container container, int startLine |
+      hasContainerAndStartLine(e.(Include).getLocation(), container, startLine) and
+      hasContainerAndStartLine(mi.getLocation(), container, startLine)
       // (an #include directive must be always on it's own line)
     )
   ) and

--- a/cpp/ql/lib/semmle/code/cpp/Location.qll
+++ b/cpp/ql/lib/semmle/code/cpp/Location.qll
@@ -10,12 +10,14 @@ import semmle.code.cpp.File
  */
 class Location extends @location {
   /** Gets the container corresponding to this location. */
+  pragma[nomagic]
   Container getContainer() { this.fullLocationInfo(result, _, _, _, _) }
 
   /** Gets the file corresponding to this location, if any. */
   File getFile() { result = this.getContainer() }
 
   /** Gets the 1-based line number (inclusive) where this location starts. */
+  pragma[nomagic]
   int getStartLine() { this.fullLocationInfo(_, result, _, _, _) }
 
   /** Gets the 1-based column number (inclusive) where this location starts. */


### PR DESCRIPTION
This fixes an absolutely horrible join in `definitionOf` (which is used for go-to-definition in VSCode).

Before:

```ql
Tuple counts for _Include#feab3531::Include#f_Location#bd5c7591::Location::getContainer#0#dispred#bf_Location#bd5c759__#antijoin_rhs/2@77c30cqt after 20m18s:
  223926      ~0%     {2} r1 = SCAN _Element#496c7fc2::Element::isInMacroExpansion#0#dispred#f__Element#496c7fc2::Element::getLocation#0__#shared OUTPUT In.1 'arg1', In.0 'arg0'
  223926      ~0%     {2} r2 = JOIN r1 WITH Include#feab3531::Include#f ON FIRST 1 OUTPUT Lhs.0 'arg1', Lhs.1 'arg0'
  223926      ~0%     {3} r3 = JOIN r2 WITH preprocdirects ON FIRST 1 OUTPUT Rhs.2, Lhs.1 'arg0', Lhs.0 'arg1'
  223926      ~1%     {4} r4 = JOIN r3 WITH Location#bd5c7591::Location::getStartLine#0#dispred#bf ON FIRST 1 OUTPUT Lhs.0, Lhs.1 'arg0', Lhs.2 'arg1', Rhs.1
  223926      ~0%     {4} r5 = JOIN r4 WITH Location#bd5c7591::Location::getContainer#0#dispred#bf ON FIRST 1 OUTPUT Lhs.3, Lhs.1 'arg0', Lhs.2 'arg1', Rhs.1
  14364578935 ~0%     {4} r6 = JOIN r5 WITH Location#bd5c7591::Location::getStartLine#0#dispred#fb_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.3, Lhs.1 'arg0', Lhs.2 'arg1'
  224014      ~0%     {3} r7 = JOIN r6 WITH Location#bd5c7591::Location::getContainer#0#dispred#bf ON FIRST 2 OUTPUT Lhs.0, Lhs.2 'arg0', Lhs.3 'arg1'
  0           ~0%     {4} r8 = JOIN r7 WITH Macro#a2d95fe3::MacroAccess::getLocation#0#dispred#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, 1, Lhs.1 'arg0', Lhs.2 'arg1'
  0           ~0%     {2} r9 = JOIN r8 WITH macroinvocations_03#join_rhs ON FIRST 2 OUTPUT Lhs.2 'arg0', Lhs.3 'arg1'
                      return r9

Tuple counts for definitions#0969343d::definitionOf#2#fff/3@991921js after 2.7s:
  223926   ~3%     {2} r1 = _Element#496c7fc2::Element::isInMacroExpansion#0#dispred#f__Element#496c7fc2::Element::getLocation#0__#shared AND NOT _Include#feab3531::Include#f_Location#bd5c7591::Location::getContainer#0#dispred#bf_Location#bd5c759__#antijoin_rhs(Lhs.0 'result', Lhs.1 'e')
  223926   ~0%     {3} r2 = SCAN r1 OUTPUT In.0 'result', In.1 'e', "I"
  ...
```

(Yes, you read that right: It took 20 minutes to evaluate this predicate 😱.)

After:

```ql
Tuple counts for definitions#0969343d::hasContainerAndStartLine#3#fff/3@7c4e8emm after 525ms:
  18443045 ~0%     {3} r1 = JOIN Location#bd5c7591::Location::getStartLine#ff WITH Location#bd5c7591::Location::getContainer#ff ON FIRST 1 OUTPUT Lhs.0 'loc', Rhs.1 'container', Lhs.1 'startLine'
                    return r1

Tuple counts for _Include#feab3531::Include#f_Macro#a2d95fe3::MacroAccess::getLocation#0#dispred#ff_10#join_rhs__Elem__#antijoin_rhs/2@80ec55ll after 123ms:
  223926 ~0%     {2} r1 = SCAN _Element#496c7fc2::Element::isInMacroExpansion#0#dispred#f__Element#496c7fc2::Element::getLocation#0__#shared OUTPUT In.1 'arg1', In.0 'arg0'
  223926 ~0%     {2} r2 = JOIN r1 WITH Include#feab3531::Include#f ON FIRST 1 OUTPUT Lhs.0 'arg1', Lhs.1 'arg0'
  223926 ~0%     {3} r3 = JOIN r2 WITH preprocdirects ON FIRST 1 OUTPUT Rhs.2, Lhs.1 'arg0', Lhs.0 'arg1'
  223926 ~3%     {4} r4 = JOIN r3 WITH definitions#0969343d::hasContainerAndStartLine#3#fff ON FIRST 1 OUTPUT Rhs.1, Rhs.2, Lhs.1 'arg0', Lhs.2 'arg1'
  224014 ~0%     {3} r5 = JOIN r4 WITH definitions#0969343d::hasContainerAndStartLine#3#fff_120#join_rhs ON FIRST 2 OUTPUT Rhs.2, Lhs.2 'arg0', Lhs.3 'arg1'
  0      ~0%     {4} r6 = JOIN r5 WITH Macro#a2d95fe3::MacroAccess::getLocation#0#dispred#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, 1, Lhs.1 'arg0', Lhs.2 'arg1'
  0      ~0%     {2} r7 = JOIN r6 WITH macroinvocations_03#join_rhs ON FIRST 2 OUTPUT Lhs.2 'arg0', Lhs.3 'arg1'
                  return r7

Tuple counts for definitions#0969343d::definitionOf#2#fff/3@a2631aqq after 2.7s:
  223926   ~3%     {2} r1 = _Element#496c7fc2::Element::isInMacroExpansion#0#dispred#f__Element#496c7fc2::Element::getLocation#0__#shared AND NOT _Include#feab3531::Include#f_Macro#a2d95fe3::MacroAccess::getLocation#0#dispred#ff_10#join_rhs__Elem__#antijoin_rhs(Lhs.0 'result', Lhs.1 'e')
  223926   ~0%     {3} r2 = SCAN r1 OUTPUT In.0 'result', In.1 'e', "I"
  ...
```