### PR TITLE
QL/Ryby: fix qltest on Windows

### DIFF
--- a/.github/workflows/ql-for-ql-tests.yml
+++ b/.github/workflows/ql-for-ql-tests.yml
@@ -44,11 +44,6 @@ jobs:
           "${CODEQL}" test run --check-databases --check-unused-labels --check-repeated-labels --check-redefined-labels --check-use-before-definition --search-path "${{ github.workspace }}/ql/extractor-pack" --consistency-queries ql/ql/consistency-queries ql/ql/test
         env:
           CODEQL: ${{ steps.find-codeql.outputs.codeql-path }}
-      - name: Check QL formatting
-        run: |
-          find ql/ql/src "(" -name "*.ql" -or -name "*.qll" ")" -print0 | xargs -0 "${CODEQL}" query format --check-only
-        env:
-          CODEQL: ${{ steps.find-codeql.outputs.codeql-path }}
 
   other-os: 
     strategy:

--- a/.github/workflows/ql-for-ql-tests.yml
+++ b/.github/workflows/ql-for-ql-tests.yml
@@ -33,7 +33,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             ql/target
-          key: ${{ runner.os }}-${{ steps.os_version.outputs.version }}-qltest-cargo-${{ hashFiles('ql/**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ steps.os_version.outputs.version }}-qltest-cargo-${{ hashFiles('ql/rust-toolchain.toml', 'ql/**/Cargo.lock') }}
       - name: Build extractor
         run: |
           cd ql;
@@ -47,5 +47,43 @@ jobs:
       - name: Check QL formatting
         run: |
           find ql/ql/src "(" -name "*.ql" -or -name "*.qll" ")" -print0 | xargs -0 "${CODEQL}" query format --check-only
+        env:
+          CODEQL: ${{ steps.find-codeql.outputs.codeql-path }}
+
+  other-os: 
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest]
+    needs: [qltest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install GNU tar 
+        if: runner.os == 'macOS'
+        run: |
+          brew install gnu-tar
+          echo "/usr/local/opt/gnu-tar/libexec/gnubin" >> $GITHUB_PATH
+      - name: Find codeql
+        id: find-codeql
+        uses: github/codeql-action/init@77a8d2d10c0b403a8b4aadbd223dc489ecd22683
+        with:
+          languages: javascript # does not matter
+      - uses: ./.github/actions/os-version
+        id: os_version
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ql/target
+          key: ${{ runner.os }}-${{ steps.os_version.outputs.version }}-qltest-cargo-${{ hashFiles('ql/rust-toolchain.toml', 'ql/**/Cargo.lock') }}
+      - name: Build extractor
+        run: |
+          cd ql;
+          codeqlpath=$(dirname ${{ steps.find-codeql.outputs.codeql-path }});
+          env "PATH=$PATH:$codeqlpath" ./scripts/create-extractor-pack.sh
+      - name: Run a single QL tests
+        run: |
+          "${CODEQL}" test run --check-databases --search-path "${{ github.workspace }}/ql/extractor-pack" ql/ql/test/queries/style/DeadCode/DeadCode.qlref
         env:
           CODEQL: ${{ steps.find-codeql.outputs.codeql-path }}

--- a/.github/workflows/ql-for-ql-tests.yml
+++ b/.github/workflows/ql-for-ql-tests.yml
@@ -39,9 +39,14 @@ jobs:
           cd ql;
           codeqlpath=$(dirname ${{ steps.find-codeql.outputs.codeql-path }});
           env "PATH=$PATH:$codeqlpath" ./scripts/create-extractor-pack.sh
+      - name: Cache compilation cache
+        id: query-cache
+        uses: ./.github/actions/cache-query-compilation
+        with: 
+          key: ql-for-ql-tests
       - name: Run QL tests
         run: |
-          "${CODEQL}" test run --check-databases --check-unused-labels --check-repeated-labels --check-redefined-labels --check-use-before-definition --search-path "${{ github.workspace }}/ql/extractor-pack" --consistency-queries ql/ql/consistency-queries ql/ql/test
+          "${CODEQL}" test run --check-databases --check-unused-labels --check-repeated-labels --check-redefined-labels --check-use-before-definition --search-path "${{ github.workspace }}/ql/extractor-pack" --consistency-queries ql/ql/consistency-queries --compilation-cache "${{ steps.query-cache.outputs.cache-dir }}" ql/ql/test
         env:
           CODEQL: ${{ steps.find-codeql.outputs.codeql-path }}
 

--- a/.github/workflows/ql-for-ql-tests.yml
+++ b/.github/workflows/ql-for-ql-tests.yml
@@ -78,12 +78,28 @@ jobs:
             ql/target
           key: ${{ runner.os }}-${{ steps.os_version.outputs.version }}-qltest-cargo-${{ hashFiles('ql/rust-toolchain.toml', 'ql/**/Cargo.lock') }}
       - name: Build extractor
+        if: runner.os != 'Windows'
         run: |
           cd ql;
           codeqlpath=$(dirname ${{ steps.find-codeql.outputs.codeql-path }});
           env "PATH=$PATH:$codeqlpath" ./scripts/create-extractor-pack.sh
-      - name: Run a single QL tests
+      - name: Build extractor (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          cd ql;
+          $Env:PATH += ";$(dirname ${{ steps.find-codeql.outputs.codeql-path }})"
+          pwsh ./scripts/create-extractor-pack.ps1
+      - name: Run a single QL tests - Unix
+        if: runner.os != 'Windows'
         run: |
           "${CODEQL}" test run --check-databases --search-path "${{ github.workspace }}/ql/extractor-pack" ql/ql/test/queries/style/DeadCode/DeadCode.qlref
         env:
           CODEQL: ${{ steps.find-codeql.outputs.codeql-path }}
+      - name: Run a single QL tests - Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $Env:PATH += ";$(dirname ${{ steps.find-codeql.outputs.codeql-path }})"
+          codeql test run --check-databases --search-path "${{ github.workspace }}/ql/extractor-pack" ql/ql/test/queries/style/DeadCode/DeadCode.qlref
+      

--- a/.github/workflows/ruby-build.yml
+++ b/.github/workflows/ruby-build.yml
@@ -205,11 +205,6 @@ jobs:
       - name: Fetch CodeQL
         uses: ./.github/actions/fetch-codeql
 
-      - uses: actions/checkout@v3
-        with:
-          repository: Shopify/example-ruby-app
-          ref: 67a0decc5eb550f3a9228eda53925c3afd40dfe9
-
       - name: Download Ruby bundle
         uses: actions/download-artifact@v3
         with:
@@ -218,26 +213,15 @@ jobs:
       - name: Unzip Ruby bundle
         shell: bash
         run: unzip -q -d "${{ runner.temp }}/ruby-bundle" "${{ runner.temp }}/codeql-ruby-bundle.zip"
-      - name: Prepare test files
-        shell: bash
-        run: |
-          echo "import codeql.ruby.AST select count(File f)" > "test.ql"
-          echo "| 4 |" > "test.expected"
-          echo 'name: sample-tests
-          version: 0.0.0
-          dependencies:
-            codeql/ruby-all: "*"
-          extractor: ruby
-          tests: .
-          ' > qlpack.yml
+
       - name: Run QL test
         shell: bash
         run: |
-          codeql test run --search-path "${{ runner.temp }}/ruby-bundle" --additional-packs "${{ runner.temp }}/ruby-bundle" .
+          codeql test run --search-path "${{ runner.temp }}/ruby-bundle" --additional-packs "${{ runner.temp }}/ruby-bundle" ruby/ql/test/library-tests/ast/constants/
       - name: Create database
         shell: bash
         run: |
-          codeql database create --search-path "${{ runner.temp }}/ruby-bundle" --language ruby --source-root . ../database
+          codeql database create --search-path "${{ runner.temp }}/ruby-bundle" --language ruby --source-root ruby/ql/test/library-tests/ast/constants/ ../database
       - name: Analyze database
         shell: bash
         run: |

--- a/ql/rust-toolchain.toml
+++ b/ql/rust-toolchain.toml
@@ -1,0 +1,7 @@
+# This file specifies the Rust version used to develop and test the QL
+# extractor. It is set to the lowest version of Rust we want to support.
+
+[toolchain]
+channel = "1.54"
+profile = "minimal"
+components = [ "rustfmt" ]

--- a/ql/tools/qltest.cmd
+++ b/ql/tools/qltest.cmd
@@ -8,6 +8,7 @@ type NUL && "%CODEQL_DIST%\codeql.exe" database index-files ^
     --include-extension=.yml ^
     --size-limit=5m ^
     --language=ql ^
+    --working-dir=. ^
     "%CODEQL_EXTRACTOR_QL_WIP_DATABASE%"
 
 exit /b %ERRORLEVEL%

--- a/ruby/tools/qltest.cmd
+++ b/ruby/tools/qltest.cmd
@@ -8,6 +8,7 @@ type NUL && "%CODEQL_DIST%\codeql.exe" database index-files ^
     --include=**/Gemfile ^
     --size-limit=5m ^
     --language=ruby ^
+    --working-dir=. ^
     "%CODEQL_EXTRACTOR_RUBY_WIP_DATABASE%"
 
 exit /b %ERRORLEVEL%


### PR DESCRIPTION
You can see a Windows failure with Ruby here: https://github.com/github/codeql/actions/runs/3930931476/jobs/6721610060

Originally found when I added Windows/Mac CI tests to QL-for-QL.  

Some drive-by QL-for-QL maintenance. 