### PR TITLE
C#: add --working-dir=. to pre-finalize

### DIFF
--- a/csharp/tools/pre-finalize.cmd
+++ b/csharp/tools/pre-finalize.cmd
@@ -7,6 +7,7 @@ type NUL && "%CODEQL_DIST%\codeql" database index-files ^
     --include-extension=.xml ^
     --size-limit 10m ^
     --language xml ^
+    --working-dir=. ^
     -- ^
     "%CODEQL_EXTRACTOR_CSHARP_WIP_DATABASE%" ^
     >nul 2>&1

--- a/csharp/tools/pre-finalize.sh
+++ b/csharp/tools/pre-finalize.sh
@@ -9,6 +9,7 @@ set -eu
     --include-extension=.xml \
     --size-limit 10m \
     --language xml \
+    --working-dir=. \
     -- \
     "$CODEQL_EXTRACTOR_CSHARP_WIP_DATABASE" \
     > /dev/null 2>&1


### PR DESCRIPTION
`codeql database index-files` will by default find all files within the `source-location-prefix` as specified in the WIP database.  

If what you really want is to extract the files under the current working directory, then you need to specify `--working-dir=."`.   
I think that is what you want, and it's also what the pre-finalize script for Go is doing.  

I'm not sure how I would add a test for this.  

I just fixed a related error in Ruby/QL: https://github.com/github/codeql/pull/11884, which is how I found this (by searching for other uses of `codeql database index-files`).  