### PR TITLE
C++: Fix spurious results in default taint tracking

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DefaultTaintTrackingImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DefaultTaintTrackingImpl.qll
@@ -168,16 +168,18 @@ private predicate hasUpperBoundsCheck(Variable var) {
 private predicate nodeIsBarrierEqualityCandidate(
   DataFlow::Node node, Operand access, Variable checkedVar
 ) {
-  readsVariable(node.asInstruction(), checkedVar) and
-  any(IRGuardCondition guard).ensuresEq(access, _, _, node.asInstruction().getBlock(), true)
+  exists(Instruction instr | instr = node.asOperand().getDef() |
+    readsVariable(instr, checkedVar) and
+    any(IRGuardCondition guard).ensuresEq(access, _, _, instr.getBlock(), true)
+  )
 }
 
 cached
 private module Cached {
   cached
   predicate nodeIsBarrier(DataFlow::Node node) {
-    exists(Variable checkedVar |
-      node.asExpr().(VariableAccess).getTarget() = checkedVar and
+    exists(Variable checkedVar, Instruction instr | instr = node.asOperand().getDef() |
+      readsVariable(instr, checkedVar) and
       hasUpperBoundsCheck(checkedVar)
     )
     or

--- a/cpp/ql/src/Security/CWE/CWE-190/TaintedAllocationSize.ql
+++ b/cpp/ql/src/Security/CWE/CWE-190/TaintedAllocationSize.ql
@@ -46,8 +46,10 @@ predicate hasUpperBoundsCheck(Variable var) {
 }
 
 predicate nodeIsBarrierEqualityCandidate(DataFlow::Node node, Operand access, Variable checkedVar) {
-  readsVariable(node.asInstruction(), checkedVar) and
-  any(IRGuardCondition guard).ensuresEq(access, _, _, node.asInstruction().getBlock(), true)
+  exists(Instruction instr | instr = node.asOperand().getDef() |
+    readsVariable(instr, checkedVar) and
+    any(IRGuardCondition guard).ensuresEq(access, _, _, instr.getBlock(), true)
+  )
 }
 
 predicate isFlowSource(FlowSource source, string sourceType) { sourceType = source.getSourceType() }
@@ -79,8 +81,8 @@ class TaintedAllocationSizeConfiguration extends TaintTracking::Configuration {
       e = any(PointerDiffExpr diff).getAnOperand()
     )
     or
-    exists(Variable checkedVar |
-      node.asExpr().(VariableAccess).getTarget() = checkedVar and
+    exists(Variable checkedVar, Instruction instr | instr = node.asOperand().getDef() |
+      readsVariable(instr, checkedVar) and
       hasUpperBoundsCheck(checkedVar)
     )
     or

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/TaintedAllocationSize/TaintedAllocationSize.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/TaintedAllocationSize/TaintedAllocationSize.expected
@@ -42,8 +42,6 @@ edges
 | test.cpp:259:20:259:33 | call to getenv indirection | test.cpp:263:11:263:29 | ... * ... |
 | test.cpp:289:17:289:20 | get_size output argument | test.cpp:291:11:291:28 | ... * ... |
 | test.cpp:305:18:305:21 | get_size output argument | test.cpp:308:10:308:27 | ... * ... |
-| test.cpp:338:19:338:24 | Call | test.cpp:342:25:342:43 | ... * ... |
-| test.cpp:338:19:338:32 | call to getenv indirection | test.cpp:342:25:342:43 | ... * ... |
 | test.cpp:353:18:353:23 | Call | test.cpp:355:35:355:38 | size |
 | test.cpp:353:18:353:23 | Call | test.cpp:356:35:356:38 | size |
 | test.cpp:353:18:353:31 | call to getenv indirection | test.cpp:355:35:355:38 | size |
@@ -88,9 +86,6 @@ nodes
 | test.cpp:291:11:291:28 | ... * ... | semmle.label | ... * ... |
 | test.cpp:305:18:305:21 | get_size output argument | semmle.label | get_size output argument |
 | test.cpp:308:10:308:27 | ... * ... | semmle.label | ... * ... |
-| test.cpp:338:19:338:24 | Call | semmle.label | Call |
-| test.cpp:338:19:338:32 | call to getenv indirection | semmle.label | call to getenv indirection |
-| test.cpp:342:25:342:43 | ... * ... | semmle.label | ... * ... |
 | test.cpp:353:18:353:23 | Call | semmle.label | Call |
 | test.cpp:353:18:353:31 | call to getenv indirection | semmle.label | call to getenv indirection |
 | test.cpp:355:35:355:38 | size | semmle.label | size |
@@ -135,8 +130,6 @@ subpaths
 | test.cpp:291:4:291:9 | call to malloc | test.cpp:251:18:251:31 | call to getenv indirection | test.cpp:291:11:291:28 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:251:18:251:31 | call to getenv indirection | user input (an environment variable) |
 | test.cpp:308:3:308:8 | call to malloc | test.cpp:251:18:251:23 | Call | test.cpp:308:10:308:27 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:251:18:251:23 | Call | user input (an environment variable) |
 | test.cpp:308:3:308:8 | call to malloc | test.cpp:251:18:251:31 | call to getenv indirection | test.cpp:308:10:308:27 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:251:18:251:31 | call to getenv indirection | user input (an environment variable) |
-| test.cpp:342:18:342:23 | call to malloc | test.cpp:338:19:338:24 | Call | test.cpp:342:25:342:43 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:338:19:338:24 | Call | user input (an environment variable) |
-| test.cpp:342:18:342:23 | call to malloc | test.cpp:338:19:338:32 | call to getenv indirection | test.cpp:342:25:342:43 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:338:19:338:32 | call to getenv indirection | user input (an environment variable) |
 | test.cpp:355:25:355:33 | call to MyMalloc1 | test.cpp:353:18:353:23 | Call | test.cpp:355:35:355:38 | size | This allocation size is derived from $@ and might overflow. | test.cpp:353:18:353:23 | Call | user input (an environment variable) |
 | test.cpp:355:25:355:33 | call to MyMalloc1 | test.cpp:353:18:353:31 | call to getenv indirection | test.cpp:355:35:355:38 | size | This allocation size is derived from $@ and might overflow. | test.cpp:353:18:353:31 | call to getenv indirection | user input (an environment variable) |
 | test.cpp:356:25:356:33 | call to MyMalloc2 | test.cpp:353:18:353:23 | Call | test.cpp:356:35:356:38 | size | This allocation size is derived from $@ and might overflow. | test.cpp:353:18:353:23 | Call | user input (an environment variable) |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/tainted/ArithmeticTainted.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/tainted/ArithmeticTainted.expected
@@ -23,10 +23,6 @@ edges
 | test.c:51:17:51:20 | argv | test.c:54:7:54:10 | len3 |
 | test.c:51:17:51:20 | argv | test.c:54:7:54:10 | len3 |
 | test.c:51:17:51:20 | argv | test.c:54:7:54:10 | len3 |
-| test.c:99:30:99:33 | argv | test.c:102:17:102:31 | maxConnections3 |
-| test.c:99:30:99:33 | argv | test.c:102:17:102:31 | maxConnections3 |
-| test.c:99:30:99:33 | argv | test.c:102:17:102:31 | maxConnections3 |
-| test.c:99:30:99:33 | argv | test.c:102:17:102:31 | maxConnections3 |
 subpaths
 nodes
 | test2.cpp:12:21:12:21 | v | semmle.label | v |
@@ -55,10 +51,6 @@ nodes
 | test.c:51:17:51:20 | argv | semmle.label | argv |
 | test.c:54:7:54:10 | len3 | semmle.label | len3 |
 | test.c:54:7:54:10 | len3 | semmle.label | len3 |
-| test.c:99:30:99:33 | argv | semmle.label | argv |
-| test.c:99:30:99:33 | argv | semmle.label | argv |
-| test.c:102:17:102:31 | maxConnections3 | semmle.label | maxConnections3 |
-| test.c:102:17:102:31 | maxConnections3 | semmle.label | maxConnections3 |
 #select
 | test2.cpp:14:11:14:11 | v | test2.cpp:25:22:25:23 | & ... | test2.cpp:14:11:14:11 | v | $@ flows to an operand of an arithmetic expression, potentially causing an overflow. | test2.cpp:25:22:25:23 | & ... | User-provided value |
 | test2.cpp:14:11:14:11 | v | test2.cpp:25:22:25:23 | & ... | test2.cpp:14:11:14:11 | v | $@ flows to an operand of an arithmetic expression, potentially causing an underflow. | test2.cpp:25:22:25:23 | & ... | User-provided value |
@@ -69,5 +61,3 @@ nodes
 | test.c:14:15:14:28 | maxConnections | test.c:11:29:11:32 | argv | test.c:14:15:14:28 | maxConnections | $@ flows to an operand of an arithmetic expression, potentially causing an underflow. | test.c:11:29:11:32 | argv | User-provided value |
 | test.c:44:7:44:10 | len2 | test.c:41:17:41:20 | argv | test.c:44:7:44:10 | len2 | $@ flows to an operand of an arithmetic expression, potentially causing an underflow. | test.c:41:17:41:20 | argv | User-provided value |
 | test.c:54:7:54:10 | len3 | test.c:51:17:51:20 | argv | test.c:54:7:54:10 | len3 | $@ flows to an operand of an arithmetic expression, potentially causing an underflow. | test.c:51:17:51:20 | argv | User-provided value |
-| test.c:102:17:102:31 | maxConnections3 | test.c:99:30:99:33 | argv | test.c:102:17:102:31 | maxConnections3 | $@ flows to an operand of an arithmetic expression, potentially causing an overflow. | test.c:99:30:99:33 | argv | User-provided value |
-| test.c:102:17:102:31 | maxConnections3 | test.c:99:30:99:33 | argv | test.c:102:17:102:31 | maxConnections3 | $@ flows to an operand of an arithmetic expression, potentially causing an underflow. | test.c:99:30:99:33 | argv | User-provided value |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/tainted/IntegerOverflowTainted.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/tainted/IntegerOverflowTainted.expected
@@ -14,4 +14,3 @@
 | test.c:14:15:14:35 | ... * ... | $@ flows an expression which might overflow. | test.c:11:29:11:32 | argv | User-provided value |
 | test.c:44:7:44:12 | ... -- | $@ flows an expression which might overflow negatively. | test.c:41:17:41:20 | argv | User-provided value |
 | test.c:54:7:54:12 | ... -- | $@ flows an expression which might overflow negatively. | test.c:51:17:51:20 | argv | User-provided value |
-| test.c:102:17:102:38 | ... * ... | $@ flows an expression which might overflow. | test.c:99:30:99:33 | argv | User-provided value |


### PR DESCRIPTION
Targets the use-use dataflow feature branch. Also undoes the changes from https://github.com/github/codeql/pull/11413 in favour of something that works for both upper bounds and equality.