### PR TITLE
DataFlow: Add `uniqueParameterNodePositionExclude`

### DIFF
--- a/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/DataFlowImplConsistency.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/DataFlowImplConsistency.qll
@@ -45,6 +45,11 @@ module Consistency {
     ) {
       none()
     }
+
+    /** Holds if `(c, pos, p)` should be excluded from the consistency test `uniqueParameterNodeAtPosition`. */
+    predicate uniqueParameterNodeAtPositionExclude(DataFlowCallable c, ParameterPosition pos, Node p) {
+      none()
+    }
   }
 
   private class RelevantNode extends Node {
@@ -246,6 +251,7 @@ module Consistency {
   query predicate uniqueParameterNodeAtPosition(
     DataFlowCallable c, ParameterPosition pos, Node p, string msg
   ) {
+    not any(ConsistencyConfiguration conf).uniqueParameterNodeAtPositionExclude(c, pos, p) and
     isParameterNode(p, c, pos) and
     not exists(unique(Node p0 | isParameterNode(p0, c, pos))) and
     msg = "Parameters with overlapping positions."

--- a/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/DataFlowImplConsistency.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/DataFlowImplConsistency.qll
@@ -50,6 +50,11 @@ module Consistency {
     predicate uniqueParameterNodeAtPositionExclude(DataFlowCallable c, ParameterPosition pos, Node p) {
       none()
     }
+
+    /** Holds if `(c, pos, p)` should be excluded from the consistency test `uniqueParameterNodePosition`. */
+    predicate uniqueParameterNodePositionExclude(DataFlowCallable c, ParameterPosition pos, Node p) {
+      none()
+    }
   }
 
   private class RelevantNode extends Node {
@@ -260,6 +265,7 @@ module Consistency {
   query predicate uniqueParameterNodePosition(
     DataFlowCallable c, ParameterPosition pos, Node p, string msg
   ) {
+    not any(ConsistencyConfiguration conf).uniqueParameterNodePositionExclude(c, pos, p) and
     isParameterNode(p, c, pos) and
     not exists(unique(ParameterPosition pos0 | isParameterNode(p, c, pos0))) and
     msg = "Parameter node with multiple positions."

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplConsistency.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplConsistency.qll
@@ -45,6 +45,11 @@ module Consistency {
     ) {
       none()
     }
+
+    /** Holds if `(c, pos, p)` should be excluded from the consistency test `uniqueParameterNodeAtPosition`. */
+    predicate uniqueParameterNodeAtPositionExclude(DataFlowCallable c, ParameterPosition pos, Node p) {
+      none()
+    }
   }
 
   private class RelevantNode extends Node {
@@ -246,6 +251,7 @@ module Consistency {
   query predicate uniqueParameterNodeAtPosition(
     DataFlowCallable c, ParameterPosition pos, Node p, string msg
   ) {
+    not any(ConsistencyConfiguration conf).uniqueParameterNodeAtPositionExclude(c, pos, p) and
     isParameterNode(p, c, pos) and
     not exists(unique(Node p0 | isParameterNode(p0, c, pos))) and
     msg = "Parameters with overlapping positions."

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplConsistency.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplConsistency.qll
@@ -50,6 +50,11 @@ module Consistency {
     predicate uniqueParameterNodeAtPositionExclude(DataFlowCallable c, ParameterPosition pos, Node p) {
       none()
     }
+
+    /** Holds if `(c, pos, p)` should be excluded from the consistency test `uniqueParameterNodePosition`. */
+    predicate uniqueParameterNodePositionExclude(DataFlowCallable c, ParameterPosition pos, Node p) {
+      none()
+    }
   }
 
   private class RelevantNode extends Node {
@@ -260,6 +265,7 @@ module Consistency {
   query predicate uniqueParameterNodePosition(
     DataFlowCallable c, ParameterPosition pos, Node p, string msg
   ) {
+    not any(ConsistencyConfiguration conf).uniqueParameterNodePositionExclude(c, pos, p) and
     isParameterNode(p, c, pos) and
     not exists(unique(ParameterPosition pos0 | isParameterNode(p, c, pos0))) and
     msg = "Parameter node with multiple positions."

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImplConsistency.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImplConsistency.qll
@@ -45,6 +45,11 @@ module Consistency {
     ) {
       none()
     }
+
+    /** Holds if `(c, pos, p)` should be excluded from the consistency test `uniqueParameterNodeAtPosition`. */
+    predicate uniqueParameterNodeAtPositionExclude(DataFlowCallable c, ParameterPosition pos, Node p) {
+      none()
+    }
   }
 
   private class RelevantNode extends Node {
@@ -246,6 +251,7 @@ module Consistency {
   query predicate uniqueParameterNodeAtPosition(
     DataFlowCallable c, ParameterPosition pos, Node p, string msg
   ) {
+    not any(ConsistencyConfiguration conf).uniqueParameterNodeAtPositionExclude(c, pos, p) and
     isParameterNode(p, c, pos) and
     not exists(unique(Node p0 | isParameterNode(p0, c, pos))) and
     msg = "Parameters with overlapping positions."

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImplConsistency.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImplConsistency.qll
@@ -50,6 +50,11 @@ module Consistency {
     predicate uniqueParameterNodeAtPositionExclude(DataFlowCallable c, ParameterPosition pos, Node p) {
       none()
     }
+
+    /** Holds if `(c, pos, p)` should be excluded from the consistency test `uniqueParameterNodePosition`. */
+    predicate uniqueParameterNodePositionExclude(DataFlowCallable c, ParameterPosition pos, Node p) {
+      none()
+    }
   }
 
   private class RelevantNode extends Node {
@@ -260,6 +265,7 @@ module Consistency {
   query predicate uniqueParameterNodePosition(
     DataFlowCallable c, ParameterPosition pos, Node p, string msg
   ) {
+    not any(ConsistencyConfiguration conf).uniqueParameterNodePositionExclude(c, pos, p) and
     isParameterNode(p, c, pos) and
     not exists(unique(ParameterPosition pos0 | isParameterNode(p, c, pos0))) and
     msg = "Parameter node with multiple positions."

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImplConsistency.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImplConsistency.qll
@@ -45,6 +45,11 @@ module Consistency {
     ) {
       none()
     }
+
+    /** Holds if `(c, pos, p)` should be excluded from the consistency test `uniqueParameterNodeAtPosition`. */
+    predicate uniqueParameterNodeAtPositionExclude(DataFlowCallable c, ParameterPosition pos, Node p) {
+      none()
+    }
   }
 
   private class RelevantNode extends Node {
@@ -246,6 +251,7 @@ module Consistency {
   query predicate uniqueParameterNodeAtPosition(
     DataFlowCallable c, ParameterPosition pos, Node p, string msg
   ) {
+    not any(ConsistencyConfiguration conf).uniqueParameterNodeAtPositionExclude(c, pos, p) and
     isParameterNode(p, c, pos) and
     not exists(unique(Node p0 | isParameterNode(p0, c, pos))) and
     msg = "Parameters with overlapping positions."

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImplConsistency.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImplConsistency.qll
@@ -50,6 +50,11 @@ module Consistency {
     predicate uniqueParameterNodeAtPositionExclude(DataFlowCallable c, ParameterPosition pos, Node p) {
       none()
     }
+
+    /** Holds if `(c, pos, p)` should be excluded from the consistency test `uniqueParameterNodePosition`. */
+    predicate uniqueParameterNodePositionExclude(DataFlowCallable c, ParameterPosition pos, Node p) {
+      none()
+    }
   }
 
   private class RelevantNode extends Node {
@@ -260,6 +265,7 @@ module Consistency {
   query predicate uniqueParameterNodePosition(
     DataFlowCallable c, ParameterPosition pos, Node p, string msg
   ) {
+    not any(ConsistencyConfiguration conf).uniqueParameterNodePositionExclude(c, pos, p) and
     isParameterNode(p, c, pos) and
     not exists(unique(ParameterPosition pos0 | isParameterNode(p, c, pos0))) and
     msg = "Parameter node with multiple positions."

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplConsistency.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplConsistency.qll
@@ -45,6 +45,11 @@ module Consistency {
     ) {
       none()
     }
+
+    /** Holds if `(c, pos, p)` should be excluded from the consistency test `uniqueParameterNodeAtPosition`. */
+    predicate uniqueParameterNodeAtPositionExclude(DataFlowCallable c, ParameterPosition pos, Node p) {
+      none()
+    }
   }
 
   private class RelevantNode extends Node {
@@ -246,6 +251,7 @@ module Consistency {
   query predicate uniqueParameterNodeAtPosition(
     DataFlowCallable c, ParameterPosition pos, Node p, string msg
   ) {
+    not any(ConsistencyConfiguration conf).uniqueParameterNodeAtPositionExclude(c, pos, p) and
     isParameterNode(p, c, pos) and
     not exists(unique(Node p0 | isParameterNode(p0, c, pos))) and
     msg = "Parameters with overlapping positions."

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplConsistency.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplConsistency.qll
@@ -50,6 +50,11 @@ module Consistency {
     predicate uniqueParameterNodeAtPositionExclude(DataFlowCallable c, ParameterPosition pos, Node p) {
       none()
     }
+
+    /** Holds if `(c, pos, p)` should be excluded from the consistency test `uniqueParameterNodePosition`. */
+    predicate uniqueParameterNodePositionExclude(DataFlowCallable c, ParameterPosition pos, Node p) {
+      none()
+    }
   }
 
   private class RelevantNode extends Node {
@@ -260,6 +265,7 @@ module Consistency {
   query predicate uniqueParameterNodePosition(
     DataFlowCallable c, ParameterPosition pos, Node p, string msg
   ) {
+    not any(ConsistencyConfiguration conf).uniqueParameterNodePositionExclude(c, pos, p) and
     isParameterNode(p, c, pos) and
     not exists(unique(ParameterPosition pos0 | isParameterNode(p, c, pos0))) and
     msg = "Parameter node with multiple positions."

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImplConsistency.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImplConsistency.qll
@@ -45,6 +45,11 @@ module Consistency {
     ) {
       none()
     }
+
+    /** Holds if `(c, pos, p)` should be excluded from the consistency test `uniqueParameterNodeAtPosition`. */
+    predicate uniqueParameterNodeAtPositionExclude(DataFlowCallable c, ParameterPosition pos, Node p) {
+      none()
+    }
   }
 
   private class RelevantNode extends Node {
@@ -246,6 +251,7 @@ module Consistency {
   query predicate uniqueParameterNodeAtPosition(
     DataFlowCallable c, ParameterPosition pos, Node p, string msg
   ) {
+    not any(ConsistencyConfiguration conf).uniqueParameterNodeAtPositionExclude(c, pos, p) and
     isParameterNode(p, c, pos) and
     not exists(unique(Node p0 | isParameterNode(p0, c, pos))) and
     msg = "Parameters with overlapping positions."

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImplConsistency.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImplConsistency.qll
@@ -50,6 +50,11 @@ module Consistency {
     predicate uniqueParameterNodeAtPositionExclude(DataFlowCallable c, ParameterPosition pos, Node p) {
       none()
     }
+
+    /** Holds if `(c, pos, p)` should be excluded from the consistency test `uniqueParameterNodePosition`. */
+    predicate uniqueParameterNodePositionExclude(DataFlowCallable c, ParameterPosition pos, Node p) {
+      none()
+    }
   }
 
   private class RelevantNode extends Node {
@@ -260,6 +265,7 @@ module Consistency {
   query predicate uniqueParameterNodePosition(
     DataFlowCallable c, ParameterPosition pos, Node p, string msg
   ) {
+    not any(ConsistencyConfiguration conf).uniqueParameterNodePositionExclude(c, pos, p) and
     isParameterNode(p, c, pos) and
     not exists(unique(ParameterPosition pos0 | isParameterNode(p, c, pos0))) and
     msg = "Parameter node with multiple positions."

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplConsistency.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplConsistency.qll
@@ -45,6 +45,11 @@ module Consistency {
     ) {
       none()
     }
+
+    /** Holds if `(c, pos, p)` should be excluded from the consistency test `uniqueParameterNodeAtPosition`. */
+    predicate uniqueParameterNodeAtPositionExclude(DataFlowCallable c, ParameterPosition pos, Node p) {
+      none()
+    }
   }
 
   private class RelevantNode extends Node {
@@ -246,6 +251,7 @@ module Consistency {
   query predicate uniqueParameterNodeAtPosition(
     DataFlowCallable c, ParameterPosition pos, Node p, string msg
   ) {
+    not any(ConsistencyConfiguration conf).uniqueParameterNodeAtPositionExclude(c, pos, p) and
     isParameterNode(p, c, pos) and
     not exists(unique(Node p0 | isParameterNode(p0, c, pos))) and
     msg = "Parameters with overlapping positions."

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplConsistency.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplConsistency.qll
@@ -50,6 +50,11 @@ module Consistency {
     predicate uniqueParameterNodeAtPositionExclude(DataFlowCallable c, ParameterPosition pos, Node p) {
       none()
     }
+
+    /** Holds if `(c, pos, p)` should be excluded from the consistency test `uniqueParameterNodePosition`. */
+    predicate uniqueParameterNodePositionExclude(DataFlowCallable c, ParameterPosition pos, Node p) {
+      none()
+    }
   }
 
   private class RelevantNode extends Node {
@@ -260,6 +265,7 @@ module Consistency {
   query predicate uniqueParameterNodePosition(
     DataFlowCallable c, ParameterPosition pos, Node p, string msg
   ) {
+    not any(ConsistencyConfiguration conf).uniqueParameterNodePositionExclude(c, pos, p) and
     isParameterNode(p, c, pos) and
     not exists(unique(ParameterPosition pos0 | isParameterNode(p, c, pos0))) and
     msg = "Parameter node with multiple positions."

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImplConsistency.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImplConsistency.qll
@@ -45,6 +45,11 @@ module Consistency {
     ) {
       none()
     }
+
+    /** Holds if `(c, pos, p)` should be excluded from the consistency test `uniqueParameterNodeAtPosition`. */
+    predicate uniqueParameterNodeAtPositionExclude(DataFlowCallable c, ParameterPosition pos, Node p) {
+      none()
+    }
   }
 
   private class RelevantNode extends Node {
@@ -246,6 +251,7 @@ module Consistency {
   query predicate uniqueParameterNodeAtPosition(
     DataFlowCallable c, ParameterPosition pos, Node p, string msg
   ) {
+    not any(ConsistencyConfiguration conf).uniqueParameterNodeAtPositionExclude(c, pos, p) and
     isParameterNode(p, c, pos) and
     not exists(unique(Node p0 | isParameterNode(p0, c, pos))) and
     msg = "Parameters with overlapping positions."

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImplConsistency.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImplConsistency.qll
@@ -50,6 +50,11 @@ module Consistency {
     predicate uniqueParameterNodeAtPositionExclude(DataFlowCallable c, ParameterPosition pos, Node p) {
       none()
     }
+
+    /** Holds if `(c, pos, p)` should be excluded from the consistency test `uniqueParameterNodePosition`. */
+    predicate uniqueParameterNodePositionExclude(DataFlowCallable c, ParameterPosition pos, Node p) {
+      none()
+    }
   }
 
   private class RelevantNode extends Node {
@@ -260,6 +265,7 @@ module Consistency {
   query predicate uniqueParameterNodePosition(
     DataFlowCallable c, ParameterPosition pos, Node p, string msg
   ) {
+    not any(ConsistencyConfiguration conf).uniqueParameterNodePositionExclude(c, pos, p) and
     isParameterNode(p, c, pos) and
     not exists(unique(ParameterPosition pos0 | isParameterNode(p, c, pos0))) and
     msg = "Parameter node with multiple positions."


### PR DESCRIPTION
When the two new consistency checks where added in https://github.com/github/codeql/pull/11564 it was not possible to exclude any nodes from these checks.

Due to the way the new Python call graph violates these checks currently, we need a way to exclude some results while figuring out how to avoid violating these. Since some of the violations are outside the test folder, it's not just possible to accept the (massive) changes to the .expected files, since the results would depend on the locations of your local Python installation.

TL;DR; I would like to have these available as a short term workaround for Python.