### PR TITLE
Swift: Add RNCryptor sinks to swift/hardcoded-key

### DIFF
--- a/swift/ql/src/queries/Security/CWE-321/HardcodedEncryptionKey.ql
+++ b/swift/ql/src/queries/Security/CWE-321/HardcodedEncryptionKey.ql
@@ -53,7 +53,7 @@ class EncryptionKeySink extends Expr {
       c.getFullName() = ["RNCryptor", "RNEncryptor", "RNDecryptor"] and
       c.getAMember() = f and
       call.getStaticTarget() = f and
-      call.getArgumentWithLabel("encryptionKey").getExpr() = this
+      call.getArgumentWithLabel(["encryptionKey", "withEncryptionKey"]).getExpr() = this
     )
   }
 }

--- a/swift/ql/src/queries/Security/CWE-321/HardcodedEncryptionKey.ql
+++ b/swift/ql/src/queries/Security/CWE-321/HardcodedEncryptionKey.ql
@@ -46,6 +46,14 @@ class EncryptionKeySink extends Expr {
       fName.matches("init(key:%") and
       call.getArgument(0).getExpr() = this
     )
+    or
+    // RNCryptor
+    exists(ClassOrStructDecl c, MethodDecl f, CallExpr call |
+      c.getFullName() = ["RNCryptor", "RNEncryptor", "RNDecryptor"] and
+      c.getAMember() = f and
+      call.getStaticTarget() = f and
+      call.getArgumentWithLabel("encryptionKey").getExpr() = this
+    )
   }
 }
 

--- a/swift/ql/src/queries/Security/CWE-321/HardcodedEncryptionKey.ql
+++ b/swift/ql/src/queries/Security/CWE-321/HardcodedEncryptionKey.ql
@@ -12,6 +12,7 @@
 
 import swift
 import codeql.swift.dataflow.DataFlow
+import codeql.swift.dataflow.TaintTracking
 import DataFlow::PathGraph
 
 /**
@@ -58,10 +59,10 @@ class EncryptionKeySink extends Expr {
 }
 
 /**
- * A dataflow configuration from the key source to expressions that use
+ * A taint configuration from the key source to expressions that use
  * it to initialize a cipher.
  */
-class HardcodedKeyConfig extends DataFlow::Configuration {
+class HardcodedKeyConfig extends TaintTracking::Configuration {
   HardcodedKeyConfig() { this = "HardcodedKeyConfig" }
 
   override predicate isSource(DataFlow::Node node) { node.asExpr() instanceof KeySource }

--- a/swift/ql/test/query-tests/Security/CWE-321/HardcodedEncryptionKey.expected
+++ b/swift/ql/test/query-tests/Security/CWE-321/HardcodedEncryptionKey.expected
@@ -10,6 +10,8 @@ edges
 | rncryptor.swift:60:19:60:38 | call to Data.init(_:) :  | rncryptor.swift:73:102:73:102 | myConstKey |
 | rncryptor.swift:60:19:60:38 | call to Data.init(_:) :  | rncryptor.swift:75:37:75:37 | myConstKey |
 | rncryptor.swift:60:19:60:38 | call to Data.init(_:) :  | rncryptor.swift:76:37:76:37 | myConstKey |
+| rncryptor.swift:60:19:60:38 | call to Data.init(_:) :  | rncryptor.swift:78:66:78:66 | myConstKey |
+| rncryptor.swift:60:19:60:38 | call to Data.init(_:) :  | rncryptor.swift:79:66:79:66 | myConstKey |
 | rncryptor.swift:60:19:60:38 | call to Data.init(_:) :  | rncryptor.swift:80:94:80:94 | myConstKey |
 | rncryptor.swift:60:19:60:38 | call to Data.init(_:) :  | rncryptor.swift:81:102:81:102 | myConstKey |
 | rncryptor.swift:60:24:60:24 | abcdef123456 :  | rncryptor.swift:5:5:5:29 | [summary param] 0 in Data.init(_:) :  |
@@ -49,6 +51,8 @@ nodes
 | rncryptor.swift:73:102:73:102 | myConstKey | semmle.label | myConstKey |
 | rncryptor.swift:75:37:75:37 | myConstKey | semmle.label | myConstKey |
 | rncryptor.swift:76:37:76:37 | myConstKey | semmle.label | myConstKey |
+| rncryptor.swift:78:66:78:66 | myConstKey | semmle.label | myConstKey |
+| rncryptor.swift:79:66:79:66 | myConstKey | semmle.label | myConstKey |
 | rncryptor.swift:80:94:80:94 | myConstKey | semmle.label | myConstKey |
 | rncryptor.swift:81:102:81:102 | myConstKey | semmle.label | myConstKey |
 | test.swift:76:3:76:3 | this string is constant :  | semmle.label | this string is constant :  |
@@ -86,6 +90,8 @@ subpaths
 | rncryptor.swift:73:102:73:102 | myConstKey | rncryptor.swift:60:24:60:24 | abcdef123456 :  | rncryptor.swift:73:102:73:102 | myConstKey | The key 'myConstKey' has been initialized with hard-coded values from $@. | rncryptor.swift:60:24:60:24 | abcdef123456 :  | abcdef123456 |
 | rncryptor.swift:75:37:75:37 | myConstKey | rncryptor.swift:60:24:60:24 | abcdef123456 :  | rncryptor.swift:75:37:75:37 | myConstKey | The key 'myConstKey' has been initialized with hard-coded values from $@. | rncryptor.swift:60:24:60:24 | abcdef123456 :  | abcdef123456 |
 | rncryptor.swift:76:37:76:37 | myConstKey | rncryptor.swift:60:24:60:24 | abcdef123456 :  | rncryptor.swift:76:37:76:37 | myConstKey | The key 'myConstKey' has been initialized with hard-coded values from $@. | rncryptor.swift:60:24:60:24 | abcdef123456 :  | abcdef123456 |
+| rncryptor.swift:78:66:78:66 | myConstKey | rncryptor.swift:60:24:60:24 | abcdef123456 :  | rncryptor.swift:78:66:78:66 | myConstKey | The key 'myConstKey' has been initialized with hard-coded values from $@. | rncryptor.swift:60:24:60:24 | abcdef123456 :  | abcdef123456 |
+| rncryptor.swift:79:66:79:66 | myConstKey | rncryptor.swift:60:24:60:24 | abcdef123456 :  | rncryptor.swift:79:66:79:66 | myConstKey | The key 'myConstKey' has been initialized with hard-coded values from $@. | rncryptor.swift:60:24:60:24 | abcdef123456 :  | abcdef123456 |
 | rncryptor.swift:80:94:80:94 | myConstKey | rncryptor.swift:60:24:60:24 | abcdef123456 :  | rncryptor.swift:80:94:80:94 | myConstKey | The key 'myConstKey' has been initialized with hard-coded values from $@. | rncryptor.swift:60:24:60:24 | abcdef123456 :  | abcdef123456 |
 | rncryptor.swift:81:102:81:102 | myConstKey | rncryptor.swift:60:24:60:24 | abcdef123456 :  | rncryptor.swift:81:102:81:102 | myConstKey | The key 'myConstKey' has been initialized with hard-coded values from $@. | rncryptor.swift:60:24:60:24 | abcdef123456 :  | abcdef123456 |
 | test.swift:108:21:108:21 | keyString | test.swift:76:3:76:3 | this string is constant :  | test.swift:108:21:108:21 | keyString | The key 'keyString' has been initialized with hard-coded values from $@. | test.swift:76:3:76:3 | this string is constant :  | this string is constant |

--- a/swift/ql/test/query-tests/Security/CWE-321/HardcodedEncryptionKey.expected
+++ b/swift/ql/test/query-tests/Security/CWE-321/HardcodedEncryptionKey.expected
@@ -1,4 +1,19 @@
 edges
+| rncryptor.swift:5:5:5:29 | [summary param] 0 in Data.init(_:) :  | file://:0:0:0:0 | [summary] to write: return (return) in Data.init(_:) :  |
+| rncryptor.swift:60:19:60:38 | call to Data.init(_:) :  | rncryptor.swift:65:73:65:73 | myConstKey |
+| rncryptor.swift:60:19:60:38 | call to Data.init(_:) :  | rncryptor.swift:66:73:66:73 | myConstKey |
+| rncryptor.swift:60:19:60:38 | call to Data.init(_:) :  | rncryptor.swift:67:73:67:73 | myConstKey |
+| rncryptor.swift:60:19:60:38 | call to Data.init(_:) :  | rncryptor.swift:68:73:68:73 | myConstKey |
+| rncryptor.swift:60:19:60:38 | call to Data.init(_:) :  | rncryptor.swift:70:94:70:94 | myConstKey |
+| rncryptor.swift:60:19:60:38 | call to Data.init(_:) :  | rncryptor.swift:71:102:71:102 | myConstKey |
+| rncryptor.swift:60:19:60:38 | call to Data.init(_:) :  | rncryptor.swift:72:94:72:94 | myConstKey |
+| rncryptor.swift:60:19:60:38 | call to Data.init(_:) :  | rncryptor.swift:73:102:73:102 | myConstKey |
+| rncryptor.swift:60:19:60:38 | call to Data.init(_:) :  | rncryptor.swift:75:37:75:37 | myConstKey |
+| rncryptor.swift:60:19:60:38 | call to Data.init(_:) :  | rncryptor.swift:76:37:76:37 | myConstKey |
+| rncryptor.swift:60:19:60:38 | call to Data.init(_:) :  | rncryptor.swift:80:94:80:94 | myConstKey |
+| rncryptor.swift:60:19:60:38 | call to Data.init(_:) :  | rncryptor.swift:81:102:81:102 | myConstKey |
+| rncryptor.swift:60:24:60:24 | abcdef123456 :  | rncryptor.swift:5:5:5:29 | [summary param] 0 in Data.init(_:) :  |
+| rncryptor.swift:60:24:60:24 | abcdef123456 :  | rncryptor.swift:60:19:60:38 | call to Data.init(_:) :  |
 | test.swift:76:3:76:3 | this string is constant :  | test.swift:92:18:92:36 | call to getConstantString() :  |
 | test.swift:90:26:90:121 | [...] :  | test.swift:117:22:117:22 | key |
 | test.swift:90:26:90:121 | [...] :  | test.swift:118:22:118:22 | key |
@@ -20,6 +35,22 @@ edges
 | test.swift:92:18:92:36 | call to getConstantString() :  | test.swift:162:24:162:24 | keyString |
 | test.swift:92:18:92:36 | call to getConstantString() :  | test.swift:164:24:164:24 | keyString |
 nodes
+| file://:0:0:0:0 | [summary] to write: return (return) in Data.init(_:) :  | semmle.label | [summary] to write: return (return) in Data.init(_:) :  |
+| rncryptor.swift:5:5:5:29 | [summary param] 0 in Data.init(_:) :  | semmle.label | [summary param] 0 in Data.init(_:) :  |
+| rncryptor.swift:60:19:60:38 | call to Data.init(_:) :  | semmle.label | call to Data.init(_:) :  |
+| rncryptor.swift:60:24:60:24 | abcdef123456 :  | semmle.label | abcdef123456 :  |
+| rncryptor.swift:65:73:65:73 | myConstKey | semmle.label | myConstKey |
+| rncryptor.swift:66:73:66:73 | myConstKey | semmle.label | myConstKey |
+| rncryptor.swift:67:73:67:73 | myConstKey | semmle.label | myConstKey |
+| rncryptor.swift:68:73:68:73 | myConstKey | semmle.label | myConstKey |
+| rncryptor.swift:70:94:70:94 | myConstKey | semmle.label | myConstKey |
+| rncryptor.swift:71:102:71:102 | myConstKey | semmle.label | myConstKey |
+| rncryptor.swift:72:94:72:94 | myConstKey | semmle.label | myConstKey |
+| rncryptor.swift:73:102:73:102 | myConstKey | semmle.label | myConstKey |
+| rncryptor.swift:75:37:75:37 | myConstKey | semmle.label | myConstKey |
+| rncryptor.swift:76:37:76:37 | myConstKey | semmle.label | myConstKey |
+| rncryptor.swift:80:94:80:94 | myConstKey | semmle.label | myConstKey |
+| rncryptor.swift:81:102:81:102 | myConstKey | semmle.label | myConstKey |
 | test.swift:76:3:76:3 | this string is constant :  | semmle.label | this string is constant :  |
 | test.swift:90:26:90:121 | [...] :  | semmle.label | [...] :  |
 | test.swift:92:18:92:36 | call to getConstantString() :  | semmle.label | call to getConstantString() :  |
@@ -43,7 +74,20 @@ nodes
 | test.swift:163:24:163:24 | key | semmle.label | key |
 | test.swift:164:24:164:24 | keyString | semmle.label | keyString |
 subpaths
+| rncryptor.swift:60:24:60:24 | abcdef123456 :  | rncryptor.swift:5:5:5:29 | [summary param] 0 in Data.init(_:) :  | file://:0:0:0:0 | [summary] to write: return (return) in Data.init(_:) :  | rncryptor.swift:60:19:60:38 | call to Data.init(_:) :  |
 #select
+| rncryptor.swift:65:73:65:73 | myConstKey | rncryptor.swift:60:24:60:24 | abcdef123456 :  | rncryptor.swift:65:73:65:73 | myConstKey | The key 'myConstKey' has been initialized with hard-coded values from $@. | rncryptor.swift:60:24:60:24 | abcdef123456 :  | abcdef123456 |
+| rncryptor.swift:66:73:66:73 | myConstKey | rncryptor.swift:60:24:60:24 | abcdef123456 :  | rncryptor.swift:66:73:66:73 | myConstKey | The key 'myConstKey' has been initialized with hard-coded values from $@. | rncryptor.swift:60:24:60:24 | abcdef123456 :  | abcdef123456 |
+| rncryptor.swift:67:73:67:73 | myConstKey | rncryptor.swift:60:24:60:24 | abcdef123456 :  | rncryptor.swift:67:73:67:73 | myConstKey | The key 'myConstKey' has been initialized with hard-coded values from $@. | rncryptor.swift:60:24:60:24 | abcdef123456 :  | abcdef123456 |
+| rncryptor.swift:68:73:68:73 | myConstKey | rncryptor.swift:60:24:60:24 | abcdef123456 :  | rncryptor.swift:68:73:68:73 | myConstKey | The key 'myConstKey' has been initialized with hard-coded values from $@. | rncryptor.swift:60:24:60:24 | abcdef123456 :  | abcdef123456 |
+| rncryptor.swift:70:94:70:94 | myConstKey | rncryptor.swift:60:24:60:24 | abcdef123456 :  | rncryptor.swift:70:94:70:94 | myConstKey | The key 'myConstKey' has been initialized with hard-coded values from $@. | rncryptor.swift:60:24:60:24 | abcdef123456 :  | abcdef123456 |
+| rncryptor.swift:71:102:71:102 | myConstKey | rncryptor.swift:60:24:60:24 | abcdef123456 :  | rncryptor.swift:71:102:71:102 | myConstKey | The key 'myConstKey' has been initialized with hard-coded values from $@. | rncryptor.swift:60:24:60:24 | abcdef123456 :  | abcdef123456 |
+| rncryptor.swift:72:94:72:94 | myConstKey | rncryptor.swift:60:24:60:24 | abcdef123456 :  | rncryptor.swift:72:94:72:94 | myConstKey | The key 'myConstKey' has been initialized with hard-coded values from $@. | rncryptor.swift:60:24:60:24 | abcdef123456 :  | abcdef123456 |
+| rncryptor.swift:73:102:73:102 | myConstKey | rncryptor.swift:60:24:60:24 | abcdef123456 :  | rncryptor.swift:73:102:73:102 | myConstKey | The key 'myConstKey' has been initialized with hard-coded values from $@. | rncryptor.swift:60:24:60:24 | abcdef123456 :  | abcdef123456 |
+| rncryptor.swift:75:37:75:37 | myConstKey | rncryptor.swift:60:24:60:24 | abcdef123456 :  | rncryptor.swift:75:37:75:37 | myConstKey | The key 'myConstKey' has been initialized with hard-coded values from $@. | rncryptor.swift:60:24:60:24 | abcdef123456 :  | abcdef123456 |
+| rncryptor.swift:76:37:76:37 | myConstKey | rncryptor.swift:60:24:60:24 | abcdef123456 :  | rncryptor.swift:76:37:76:37 | myConstKey | The key 'myConstKey' has been initialized with hard-coded values from $@. | rncryptor.swift:60:24:60:24 | abcdef123456 :  | abcdef123456 |
+| rncryptor.swift:80:94:80:94 | myConstKey | rncryptor.swift:60:24:60:24 | abcdef123456 :  | rncryptor.swift:80:94:80:94 | myConstKey | The key 'myConstKey' has been initialized with hard-coded values from $@. | rncryptor.swift:60:24:60:24 | abcdef123456 :  | abcdef123456 |
+| rncryptor.swift:81:102:81:102 | myConstKey | rncryptor.swift:60:24:60:24 | abcdef123456 :  | rncryptor.swift:81:102:81:102 | myConstKey | The key 'myConstKey' has been initialized with hard-coded values from $@. | rncryptor.swift:60:24:60:24 | abcdef123456 :  | abcdef123456 |
 | test.swift:108:21:108:21 | keyString | test.swift:76:3:76:3 | this string is constant :  | test.swift:108:21:108:21 | keyString | The key 'keyString' has been initialized with hard-coded values from $@. | test.swift:76:3:76:3 | this string is constant :  | this string is constant |
 | test.swift:109:21:109:21 | keyString | test.swift:76:3:76:3 | this string is constant :  | test.swift:109:21:109:21 | keyString | The key 'keyString' has been initialized with hard-coded values from $@. | test.swift:76:3:76:3 | this string is constant :  | this string is constant |
 | test.swift:117:22:117:22 | key | test.swift:90:26:90:121 | [...] :  | test.swift:117:22:117:22 | key | The key 'key' has been initialized with hard-coded values from $@. | test.swift:90:26:90:121 | [...] :  | [...] |

--- a/swift/ql/test/query-tests/Security/CWE-321/rncryptor.swift
+++ b/swift/ql/test/query-tests/Security/CWE-321/rncryptor.swift
@@ -62,21 +62,21 @@ func test(cond: Bool) {
 	let myHandler = {}
 	let myIV = Data(0)
 
-	let _ = RNEncryptor(settings: kRNCryptorAES256Settings, encryptionKey: myConstKey, hmacKey: myHMACKey, handler: myHandler) // BAD [NOT DETECTED]
-	let _ = RNEncryptor(settings: kRNCryptorAES256Settings, encryptionKey: myConstKey, HMACKey: myHMACKey, handler: myHandler) // BAD [NOT DETECTED]
-	let _ = RNEncryptor(settings: kRNCryptorAES256Settings, encryptionKey: myConstKey, hmacKey: myHMACKey, iv: myIV, handler: myHandler) // BAD [NOT DETECTED]
-	let _ = RNEncryptor(settings: kRNCryptorAES256Settings, encryptionKey: myConstKey, HMACKey: myHMACKey, IV: myIV, handler: myHandler) // BAD [NOT DETECTED]
+	let _ = RNEncryptor(settings: kRNCryptorAES256Settings, encryptionKey: myConstKey, hmacKey: myHMACKey, handler: myHandler) // BAD
+	let _ = RNEncryptor(settings: kRNCryptorAES256Settings, encryptionKey: myConstKey, HMACKey: myHMACKey, handler: myHandler) // BAD
+	let _ = RNEncryptor(settings: kRNCryptorAES256Settings, encryptionKey: myConstKey, hmacKey: myHMACKey, iv: myIV, handler: myHandler) // BAD
+	let _ = RNEncryptor(settings: kRNCryptorAES256Settings, encryptionKey: myConstKey, HMACKey: myHMACKey, IV: myIV, handler: myHandler) // BAD
 
-	let _ = try? myEncryptor.encryptData(myData, with: kRNCryptorAES256Settings, encryptionKey: myConstKey, hmacKey: myHMACKey) // BAD [NOT DETECTED]
-	let _ = try? myEncryptor.encryptData(myData, withSettings: kRNCryptorAES256Settings, encryptionKey: myConstKey, HMACKey: myHMACKey) // BAD [NOT DETECTED]
-	let _ = try? myEncryptor.encryptData(myData, with: kRNCryptorAES256Settings, encryptionKey: myConstKey, hmacKey: myHMACKey, iv: myIV) // BAD [NOT DETECTED]
-	let _ = try? myEncryptor.encryptData(myData, withSettings: kRNCryptorAES256Settings, encryptionKey: myConstKey, HMACKey: myHMACKey, IV: myIV) // BAD [NOT DETECTED]
+	let _ = try? myEncryptor.encryptData(myData, with: kRNCryptorAES256Settings, encryptionKey: myConstKey, hmacKey: myHMACKey) // BAD
+	let _ = try? myEncryptor.encryptData(myData, withSettings: kRNCryptorAES256Settings, encryptionKey: myConstKey, HMACKey: myHMACKey) // BAD
+	let _ = try? myEncryptor.encryptData(myData, with: kRNCryptorAES256Settings, encryptionKey: myConstKey, hmacKey: myHMACKey, iv: myIV) // BAD
+	let _ = try? myEncryptor.encryptData(myData, withSettings: kRNCryptorAES256Settings, encryptionKey: myConstKey, HMACKey: myHMACKey, IV: myIV) // BAD
 
-	let _ = RNDecryptor(encryptionKey: myConstKey, hmacKey: myHMACKey, handler: myHandler) // BAD [NOT DETECTED]
-	let _ = RNDecryptor(encryptionKey: myConstKey, HMACKey: myHMACKey, handler: myHandler) // BAD [NOT DETECTED]
+	let _ = RNDecryptor(encryptionKey: myConstKey, hmacKey: myHMACKey, handler: myHandler) // BAD
+	let _ = RNDecryptor(encryptionKey: myConstKey, HMACKey: myHMACKey, handler: myHandler) // BAD
 
 	let _ = try? myDecryptor.decryptData(myData, withEncryptionKey: myConstKey, hmacKey: myHMACKey) // BAD [NOT DETECTED]
 	let _ = try? myDecryptor.decryptData(myData, withEncryptionKey: myConstKey, HMACKey: myHMACKey) // BAD [NOT DETECTED]
-	let _ = try? myDecryptor.decryptData(myData, with: kRNCryptorAES256Settings, encryptionKey: myConstKey, hmacKey: myHMACKey) // BAD [NOT DETECTED]
-	let _ = try? myDecryptor.decryptData(myData, withSettings: kRNCryptorAES256Settings, encryptionKey: myConstKey, HMACKey: myHMACKey) // BAD [NOT DETECTED]
+	let _ = try? myDecryptor.decryptData(myData, with: kRNCryptorAES256Settings, encryptionKey: myConstKey, hmacKey: myHMACKey) // BAD
+	let _ = try? myDecryptor.decryptData(myData, withSettings: kRNCryptorAES256Settings, encryptionKey: myConstKey, HMACKey: myHMACKey) // BAD
 }

--- a/swift/ql/test/query-tests/Security/CWE-321/rncryptor.swift
+++ b/swift/ql/test/query-tests/Security/CWE-321/rncryptor.swift
@@ -52,7 +52,7 @@ class RNDecryptor : RNCryptor
 
 // --- tests ---
 
-func test(cond: Bool) {
+func test() {
 	// RNCryptor
 	let myEncryptor = RNEncryptor()
 	let myDecryptor = RNDecryptor()

--- a/swift/ql/test/query-tests/Security/CWE-321/rncryptor.swift
+++ b/swift/ql/test/query-tests/Security/CWE-321/rncryptor.swift
@@ -1,0 +1,82 @@
+
+// --- stubs ---
+
+class Data {
+    init<S>(_ elements: S) {}
+}
+
+class NSObject
+{
+}
+
+struct _RNCryptorSettings {
+	// ...
+}
+typealias RNCryptorSettings = _RNCryptorSettings
+
+let kRNCryptorAES256Settings = RNCryptorSettings()
+
+typealias RNCryptorHandler = () -> Void // simplified
+
+class RNCryptor : NSObject
+{
+}
+
+class RNEncryptor : RNCryptor
+{
+	override init() {}
+
+	init(settings: RNCryptorSettings, encryptionKey: Data?, hmacKey HMACKey: Data?, handler: RNCryptorHandler?) {}
+	init(settings: RNCryptorSettings, encryptionKey: Data?, HMACKey: Data?, handler: RNCryptorHandler?) {}
+	init(settings theSettings: RNCryptorSettings, encryptionKey anEncryptionKey: Data?, hmacKey anHMACKey: Data?, iv anIV: Data?, handler aHandler: RNCryptorHandler?) {}
+	init(settings theSettings: RNCryptorSettings, encryptionKey anEncryptionKey: Data?, HMACKey anHMACKey: Data?, IV anIV: Data?, handler aHandler: RNCryptorHandler?) {}
+
+	func encryptData(_ data: Data?, with settings: RNCryptorSettings, encryptionKey: Data?, hmacKey HMACKey: Data?) throws -> Data { return Data(0) }
+	func encryptData(_ data: Data?, withSettings settings: RNCryptorSettings, encryptionKey: Data?, HMACKey: Data?) throws -> Data { return Data(0) }
+	func encryptData(_ thePlaintext: Data?, with theSettings: RNCryptorSettings, encryptionKey anEncryptionKey: Data?, hmacKey anHMACKey: Data?, iv anIV: Data?) throws -> Data { return Data(0) }
+	func encryptData(_ thePlaintext: Data?, withSettings theSettings: RNCryptorSettings, encryptionKey anEncryptionKey: Data?, HMACKey anHMACKey: Data?, IV anIV: Data?) throws -> Data { return Data(0) }
+}
+
+class RNDecryptor : RNCryptor
+{
+	override init() {}
+
+	init(encryptionKey: Data?, hmacKey HMACKey: Data?, handler: RNCryptorHandler?) {}
+	init(encryptionKey: Data?, HMACKey: Data?, handler: RNCryptorHandler?) {}
+
+	func decryptData(_ data: Data?, withEncryptionKey encryptionKey: Data?, hmacKey HMACKey: Data?) throws -> Data { return Data(0) }
+	func decryptData(_ data: Data?, withEncryptionKey encryptionKey: Data?, HMACKey: Data?) throws -> Data { return Data(0) }
+	func decryptData(_ theCipherText: Data?, with settings: RNCryptorSettings, encryptionKey: Data?, hmacKey HMACKey: Data?) throws -> Data { return Data(0) }
+	func decryptData(_ theCipherText: Data?, withSettings settings: RNCryptorSettings, encryptionKey: Data?, HMACKey: Data?) throws -> Data { return Data(0) }
+}
+
+// --- tests ---
+
+func test(cond: Bool) {
+	// RNCryptor
+	let myEncryptor = RNEncryptor()
+	let myDecryptor = RNDecryptor()
+	let myData = Data(0)
+	let myConstKey = Data("abcdef123456")
+	let myHMACKey = Data(0)
+	let myHandler = {}
+	let myIV = Data(0)
+
+	let _ = RNEncryptor(settings: kRNCryptorAES256Settings, encryptionKey: myConstKey, hmacKey: myHMACKey, handler: myHandler) // BAD [NOT DETECTED]
+	let _ = RNEncryptor(settings: kRNCryptorAES256Settings, encryptionKey: myConstKey, HMACKey: myHMACKey, handler: myHandler) // BAD [NOT DETECTED]
+	let _ = RNEncryptor(settings: kRNCryptorAES256Settings, encryptionKey: myConstKey, hmacKey: myHMACKey, iv: myIV, handler: myHandler) // BAD [NOT DETECTED]
+	let _ = RNEncryptor(settings: kRNCryptorAES256Settings, encryptionKey: myConstKey, HMACKey: myHMACKey, IV: myIV, handler: myHandler) // BAD [NOT DETECTED]
+
+	let _ = try? myEncryptor.encryptData(myData, with: kRNCryptorAES256Settings, encryptionKey: myConstKey, hmacKey: myHMACKey) // BAD [NOT DETECTED]
+	let _ = try? myEncryptor.encryptData(myData, withSettings: kRNCryptorAES256Settings, encryptionKey: myConstKey, HMACKey: myHMACKey) // BAD [NOT DETECTED]
+	let _ = try? myEncryptor.encryptData(myData, with: kRNCryptorAES256Settings, encryptionKey: myConstKey, hmacKey: myHMACKey, iv: myIV) // BAD [NOT DETECTED]
+	let _ = try? myEncryptor.encryptData(myData, withSettings: kRNCryptorAES256Settings, encryptionKey: myConstKey, HMACKey: myHMACKey, IV: myIV) // BAD [NOT DETECTED]
+
+	let _ = RNDecryptor(encryptionKey: myConstKey, hmacKey: myHMACKey, handler: myHandler) // BAD [NOT DETECTED]
+	let _ = RNDecryptor(encryptionKey: myConstKey, HMACKey: myHMACKey, handler: myHandler) // BAD [NOT DETECTED]
+
+	let _ = try? myDecryptor.decryptData(myData, withEncryptionKey: myConstKey, hmacKey: myHMACKey) // BAD [NOT DETECTED]
+	let _ = try? myDecryptor.decryptData(myData, withEncryptionKey: myConstKey, HMACKey: myHMACKey) // BAD [NOT DETECTED]
+	let _ = try? myDecryptor.decryptData(myData, with: kRNCryptorAES256Settings, encryptionKey: myConstKey, hmacKey: myHMACKey) // BAD [NOT DETECTED]
+	let _ = try? myDecryptor.decryptData(myData, withSettings: kRNCryptorAES256Settings, encryptionKey: myConstKey, HMACKey: myHMACKey) // BAD [NOT DETECTED]
+}

--- a/swift/ql/test/query-tests/Security/CWE-321/rncryptor.swift
+++ b/swift/ql/test/query-tests/Security/CWE-321/rncryptor.swift
@@ -75,8 +75,8 @@ func test(cond: Bool) {
 	let _ = RNDecryptor(encryptionKey: myConstKey, hmacKey: myHMACKey, handler: myHandler) // BAD
 	let _ = RNDecryptor(encryptionKey: myConstKey, HMACKey: myHMACKey, handler: myHandler) // BAD
 
-	let _ = try? myDecryptor.decryptData(myData, withEncryptionKey: myConstKey, hmacKey: myHMACKey) // BAD [NOT DETECTED]
-	let _ = try? myDecryptor.decryptData(myData, withEncryptionKey: myConstKey, HMACKey: myHMACKey) // BAD [NOT DETECTED]
+	let _ = try? myDecryptor.decryptData(myData, withEncryptionKey: myConstKey, hmacKey: myHMACKey) // BAD
+	let _ = try? myDecryptor.decryptData(myData, withEncryptionKey: myConstKey, HMACKey: myHMACKey) // BAD
 	let _ = try? myDecryptor.decryptData(myData, with: kRNCryptorAES256Settings, encryptionKey: myConstKey, hmacKey: myHMACKey) // BAD
 	let _ = try? myDecryptor.decryptData(myData, withSettings: kRNCryptorAES256Settings, encryptionKey: myConstKey, HMACKey: myHMACKey) // BAD
 }


### PR DESCRIPTION
Add RNCryptor sinks to `swift/hardcoded-key`.  This PR is very similar to https://github.com/github/codeql/pull/11905 but for the methods where an encryption key is specified, rather than a password.

I have upgraded the query from dataflow to taint tracking so that it can track flow through conversions such as `Data("string")`.  In principle this means we could get false positive results where a constant string is "mixed" with enough random data to make it a sufficiently random key overall.  In practice `swift/constant-password` already uses taint tracking so I don't expect this to be a problem, and if we do see it when our testing scales up (e.g. with MRVA), we can add sanitizers or otherwise restrict flow to find the right balance.