### PR TITLE
Swift: Add RNCryptor sinks to swift/constant-salt

### DIFF
--- a/swift/ql/src/queries/Security/CWE-760/ConstantSalt.ql
+++ b/swift/ql/src/queries/Security/CWE-760/ConstantSalt.ql
@@ -38,6 +38,14 @@ class ConstantSaltSink extends Expr {
       call.getStaticTarget() = f and
       call.getArgumentWithLabel("salt").getExpr() = this
     )
+    or
+    // RNCryptor
+    exists(ClassOrStructDecl c, MethodDecl f, CallExpr call |
+      c.getFullName() = ["RNCryptor", "RNEncryptor", "RNDecryptor"] and
+      c.getAMember() = f and
+      call.getStaticTarget() = f and
+      call.getArgumentWithLabel(["salt", "encryptionSalt", "hmacSalt", "HMACSalt"]).getExpr() = this
+    )
   }
 }
 

--- a/swift/ql/src/queries/Security/CWE-760/ConstantSalt.ql
+++ b/swift/ql/src/queries/Security/CWE-760/ConstantSalt.ql
@@ -22,7 +22,8 @@ import DataFlow::PathGraph
 class ConstantSaltSource extends Expr {
   ConstantSaltSource() {
     this = any(ArrayExpr arr | arr.getType().getName() = "Array<UInt8>") or
-    this instanceof StringLiteralExpr
+    this instanceof StringLiteralExpr or
+    this instanceof NumberLiteralExpr
   }
 }
 

--- a/swift/ql/test/query-tests/Security/CWE-760/ConstantSalt.expected
+++ b/swift/ql/test/query-tests/Security/CWE-760/ConstantSalt.expected
@@ -7,6 +7,13 @@ edges
 | rncryptor.swift:59:24:59:43 | call to Data.init(_:) :  | rncryptor.swift:78:135:78:135 | myConstantSalt1 |
 | rncryptor.swift:59:29:59:29 | abcdef123456 :  | rncryptor.swift:5:5:5:29 | [summary param] 0 in Data.init(_:) :  |
 | rncryptor.swift:59:29:59:29 | abcdef123456 :  | rncryptor.swift:59:24:59:43 | call to Data.init(_:) :  |
+| rncryptor.swift:60:24:60:30 | call to Data.init(_:) :  | rncryptor.swift:65:55:65:55 | myConstantSalt2 |
+| rncryptor.swift:60:24:60:30 | call to Data.init(_:) :  | rncryptor.swift:69:131:69:131 | myConstantSalt2 |
+| rncryptor.swift:60:24:60:30 | call to Data.init(_:) :  | rncryptor.swift:72:131:72:131 | myConstantSalt2 |
+| rncryptor.swift:60:24:60:30 | call to Data.init(_:) :  | rncryptor.swift:76:152:76:152 | myConstantSalt2 |
+| rncryptor.swift:60:24:60:30 | call to Data.init(_:) :  | rncryptor.swift:79:160:79:160 | myConstantSalt2 |
+| rncryptor.swift:60:29:60:29 | 0 :  | rncryptor.swift:5:5:5:29 | [summary param] 0 in Data.init(_:) :  |
+| rncryptor.swift:60:29:60:29 | 0 :  | rncryptor.swift:60:24:60:30 | call to Data.init(_:) :  |
 | test.swift:43:35:43:130 | [...] :  | test.swift:51:49:51:49 | constantSalt |
 | test.swift:43:35:43:130 | [...] :  | test.swift:56:59:56:59 | constantSalt |
 | test.swift:43:35:43:130 | [...] :  | test.swift:62:59:62:59 | constantSalt |
@@ -16,11 +23,18 @@ nodes
 | rncryptor.swift:5:5:5:29 | [summary param] 0 in Data.init(_:) :  | semmle.label | [summary param] 0 in Data.init(_:) :  |
 | rncryptor.swift:59:24:59:43 | call to Data.init(_:) :  | semmle.label | call to Data.init(_:) :  |
 | rncryptor.swift:59:29:59:29 | abcdef123456 :  | semmle.label | abcdef123456 :  |
+| rncryptor.swift:60:24:60:30 | call to Data.init(_:) :  | semmle.label | call to Data.init(_:) :  |
+| rncryptor.swift:60:29:60:29 | 0 :  | semmle.label | 0 :  |
 | rncryptor.swift:63:57:63:57 | myConstantSalt1 | semmle.label | myConstantSalt1 |
+| rncryptor.swift:65:55:65:55 | myConstantSalt2 | semmle.label | myConstantSalt2 |
 | rncryptor.swift:68:106:68:106 | myConstantSalt1 | semmle.label | myConstantSalt1 |
+| rncryptor.swift:69:131:69:131 | myConstantSalt2 | semmle.label | myConstantSalt2 |
 | rncryptor.swift:71:106:71:106 | myConstantSalt1 | semmle.label | myConstantSalt1 |
+| rncryptor.swift:72:131:72:131 | myConstantSalt2 | semmle.label | myConstantSalt2 |
 | rncryptor.swift:75:127:75:127 | myConstantSalt1 | semmle.label | myConstantSalt1 |
+| rncryptor.swift:76:152:76:152 | myConstantSalt2 | semmle.label | myConstantSalt2 |
 | rncryptor.swift:78:135:78:135 | myConstantSalt1 | semmle.label | myConstantSalt1 |
+| rncryptor.swift:79:160:79:160 | myConstantSalt2 | semmle.label | myConstantSalt2 |
 | test.swift:43:35:43:130 | [...] :  | semmle.label | [...] :  |
 | test.swift:51:49:51:49 | constantSalt | semmle.label | constantSalt |
 | test.swift:56:59:56:59 | constantSalt | semmle.label | constantSalt |
@@ -28,12 +42,18 @@ nodes
 | test.swift:67:53:67:53 | constantSalt | semmle.label | constantSalt |
 subpaths
 | rncryptor.swift:59:29:59:29 | abcdef123456 :  | rncryptor.swift:5:5:5:29 | [summary param] 0 in Data.init(_:) :  | file://:0:0:0:0 | [summary] to write: return (return) in Data.init(_:) :  | rncryptor.swift:59:24:59:43 | call to Data.init(_:) :  |
+| rncryptor.swift:60:29:60:29 | 0 :  | rncryptor.swift:5:5:5:29 | [summary param] 0 in Data.init(_:) :  | file://:0:0:0:0 | [summary] to write: return (return) in Data.init(_:) :  | rncryptor.swift:60:24:60:30 | call to Data.init(_:) :  |
 #select
 | rncryptor.swift:63:57:63:57 | myConstantSalt1 | rncryptor.swift:59:29:59:29 | abcdef123456 :  | rncryptor.swift:63:57:63:57 | myConstantSalt1 | The value 'abcdef123456' is used as a constant salt, which is insecure for hashing passwords. |
+| rncryptor.swift:65:55:65:55 | myConstantSalt2 | rncryptor.swift:60:29:60:29 | 0 :  | rncryptor.swift:65:55:65:55 | myConstantSalt2 | The value '0' is used as a constant salt, which is insecure for hashing passwords. |
 | rncryptor.swift:68:106:68:106 | myConstantSalt1 | rncryptor.swift:59:29:59:29 | abcdef123456 :  | rncryptor.swift:68:106:68:106 | myConstantSalt1 | The value 'abcdef123456' is used as a constant salt, which is insecure for hashing passwords. |
+| rncryptor.swift:69:131:69:131 | myConstantSalt2 | rncryptor.swift:60:29:60:29 | 0 :  | rncryptor.swift:69:131:69:131 | myConstantSalt2 | The value '0' is used as a constant salt, which is insecure for hashing passwords. |
 | rncryptor.swift:71:106:71:106 | myConstantSalt1 | rncryptor.swift:59:29:59:29 | abcdef123456 :  | rncryptor.swift:71:106:71:106 | myConstantSalt1 | The value 'abcdef123456' is used as a constant salt, which is insecure for hashing passwords. |
+| rncryptor.swift:72:131:72:131 | myConstantSalt2 | rncryptor.swift:60:29:60:29 | 0 :  | rncryptor.swift:72:131:72:131 | myConstantSalt2 | The value '0' is used as a constant salt, which is insecure for hashing passwords. |
 | rncryptor.swift:75:127:75:127 | myConstantSalt1 | rncryptor.swift:59:29:59:29 | abcdef123456 :  | rncryptor.swift:75:127:75:127 | myConstantSalt1 | The value 'abcdef123456' is used as a constant salt, which is insecure for hashing passwords. |
+| rncryptor.swift:76:152:76:152 | myConstantSalt2 | rncryptor.swift:60:29:60:29 | 0 :  | rncryptor.swift:76:152:76:152 | myConstantSalt2 | The value '0' is used as a constant salt, which is insecure for hashing passwords. |
 | rncryptor.swift:78:135:78:135 | myConstantSalt1 | rncryptor.swift:59:29:59:29 | abcdef123456 :  | rncryptor.swift:78:135:78:135 | myConstantSalt1 | The value 'abcdef123456' is used as a constant salt, which is insecure for hashing passwords. |
+| rncryptor.swift:79:160:79:160 | myConstantSalt2 | rncryptor.swift:60:29:60:29 | 0 :  | rncryptor.swift:79:160:79:160 | myConstantSalt2 | The value '0' is used as a constant salt, which is insecure for hashing passwords. |
 | test.swift:51:49:51:49 | constantSalt | test.swift:43:35:43:130 | [...] :  | test.swift:51:49:51:49 | constantSalt | The value '[...]' is used as a constant salt, which is insecure for hashing passwords. |
 | test.swift:56:59:56:59 | constantSalt | test.swift:43:35:43:130 | [...] :  | test.swift:56:59:56:59 | constantSalt | The value '[...]' is used as a constant salt, which is insecure for hashing passwords. |
 | test.swift:62:59:62:59 | constantSalt | test.swift:43:35:43:130 | [...] :  | test.swift:62:59:62:59 | constantSalt | The value '[...]' is used as a constant salt, which is insecure for hashing passwords. |

--- a/swift/ql/test/query-tests/Security/CWE-760/ConstantSalt.expected
+++ b/swift/ql/test/query-tests/Security/CWE-760/ConstantSalt.expected
@@ -1,16 +1,39 @@
 edges
+| rncryptor.swift:5:5:5:29 | [summary param] 0 in Data.init(_:) :  | file://:0:0:0:0 | [summary] to write: return (return) in Data.init(_:) :  |
+| rncryptor.swift:59:24:59:43 | call to Data.init(_:) :  | rncryptor.swift:63:57:63:57 | myConstantSalt1 |
+| rncryptor.swift:59:24:59:43 | call to Data.init(_:) :  | rncryptor.swift:68:106:68:106 | myConstantSalt1 |
+| rncryptor.swift:59:24:59:43 | call to Data.init(_:) :  | rncryptor.swift:71:106:71:106 | myConstantSalt1 |
+| rncryptor.swift:59:24:59:43 | call to Data.init(_:) :  | rncryptor.swift:75:127:75:127 | myConstantSalt1 |
+| rncryptor.swift:59:24:59:43 | call to Data.init(_:) :  | rncryptor.swift:78:135:78:135 | myConstantSalt1 |
+| rncryptor.swift:59:29:59:29 | abcdef123456 :  | rncryptor.swift:5:5:5:29 | [summary param] 0 in Data.init(_:) :  |
+| rncryptor.swift:59:29:59:29 | abcdef123456 :  | rncryptor.swift:59:24:59:43 | call to Data.init(_:) :  |
 | test.swift:43:35:43:130 | [...] :  | test.swift:51:49:51:49 | constantSalt |
 | test.swift:43:35:43:130 | [...] :  | test.swift:56:59:56:59 | constantSalt |
 | test.swift:43:35:43:130 | [...] :  | test.swift:62:59:62:59 | constantSalt |
 | test.swift:43:35:43:130 | [...] :  | test.swift:67:53:67:53 | constantSalt |
 nodes
+| file://:0:0:0:0 | [summary] to write: return (return) in Data.init(_:) :  | semmle.label | [summary] to write: return (return) in Data.init(_:) :  |
+| rncryptor.swift:5:5:5:29 | [summary param] 0 in Data.init(_:) :  | semmle.label | [summary param] 0 in Data.init(_:) :  |
+| rncryptor.swift:59:24:59:43 | call to Data.init(_:) :  | semmle.label | call to Data.init(_:) :  |
+| rncryptor.swift:59:29:59:29 | abcdef123456 :  | semmle.label | abcdef123456 :  |
+| rncryptor.swift:63:57:63:57 | myConstantSalt1 | semmle.label | myConstantSalt1 |
+| rncryptor.swift:68:106:68:106 | myConstantSalt1 | semmle.label | myConstantSalt1 |
+| rncryptor.swift:71:106:71:106 | myConstantSalt1 | semmle.label | myConstantSalt1 |
+| rncryptor.swift:75:127:75:127 | myConstantSalt1 | semmle.label | myConstantSalt1 |
+| rncryptor.swift:78:135:78:135 | myConstantSalt1 | semmle.label | myConstantSalt1 |
 | test.swift:43:35:43:130 | [...] :  | semmle.label | [...] :  |
 | test.swift:51:49:51:49 | constantSalt | semmle.label | constantSalt |
 | test.swift:56:59:56:59 | constantSalt | semmle.label | constantSalt |
 | test.swift:62:59:62:59 | constantSalt | semmle.label | constantSalt |
 | test.swift:67:53:67:53 | constantSalt | semmle.label | constantSalt |
 subpaths
+| rncryptor.swift:59:29:59:29 | abcdef123456 :  | rncryptor.swift:5:5:5:29 | [summary param] 0 in Data.init(_:) :  | file://:0:0:0:0 | [summary] to write: return (return) in Data.init(_:) :  | rncryptor.swift:59:24:59:43 | call to Data.init(_:) :  |
 #select
+| rncryptor.swift:63:57:63:57 | myConstantSalt1 | rncryptor.swift:59:29:59:29 | abcdef123456 :  | rncryptor.swift:63:57:63:57 | myConstantSalt1 | The value 'abcdef123456' is used as a constant salt, which is insecure for hashing passwords. |
+| rncryptor.swift:68:106:68:106 | myConstantSalt1 | rncryptor.swift:59:29:59:29 | abcdef123456 :  | rncryptor.swift:68:106:68:106 | myConstantSalt1 | The value 'abcdef123456' is used as a constant salt, which is insecure for hashing passwords. |
+| rncryptor.swift:71:106:71:106 | myConstantSalt1 | rncryptor.swift:59:29:59:29 | abcdef123456 :  | rncryptor.swift:71:106:71:106 | myConstantSalt1 | The value 'abcdef123456' is used as a constant salt, which is insecure for hashing passwords. |
+| rncryptor.swift:75:127:75:127 | myConstantSalt1 | rncryptor.swift:59:29:59:29 | abcdef123456 :  | rncryptor.swift:75:127:75:127 | myConstantSalt1 | The value 'abcdef123456' is used as a constant salt, which is insecure for hashing passwords. |
+| rncryptor.swift:78:135:78:135 | myConstantSalt1 | rncryptor.swift:59:29:59:29 | abcdef123456 :  | rncryptor.swift:78:135:78:135 | myConstantSalt1 | The value 'abcdef123456' is used as a constant salt, which is insecure for hashing passwords. |
 | test.swift:51:49:51:49 | constantSalt | test.swift:43:35:43:130 | [...] :  | test.swift:51:49:51:49 | constantSalt | The value '[...]' is used as a constant salt, which is insecure for hashing passwords. |
 | test.swift:56:59:56:59 | constantSalt | test.swift:43:35:43:130 | [...] :  | test.swift:56:59:56:59 | constantSalt | The value '[...]' is used as a constant salt, which is insecure for hashing passwords. |
 | test.swift:62:59:62:59 | constantSalt | test.swift:43:35:43:130 | [...] :  | test.swift:62:59:62:59 | constantSalt | The value '[...]' is used as a constant salt, which is insecure for hashing passwords. |

--- a/swift/ql/test/query-tests/Security/CWE-760/rncryptor.swift
+++ b/swift/ql/test/query-tests/Security/CWE-760/rncryptor.swift
@@ -62,19 +62,19 @@ func test(myPassword: String) {
 	let _ = myEncryptor.key(forPassword: myPassword, salt: myRandomSalt1, settings: myKeyDerivationSettings) // GOOD
 	let _ = myEncryptor.key(forPassword: myPassword, salt: myConstantSalt1, settings: myKeyDerivationSettings) // BAD
 	let _ = myEncryptor.keyForPassword(myPassword, salt: myRandomSalt2, settings: myKeyDerivationSettings) // GOOD
-	let _ = myEncryptor.keyForPassword(myPassword, salt: myConstantSalt2, settings: myKeyDerivationSettings) // BAD [NOT DETECTED]
+	let _ = myEncryptor.keyForPassword(myPassword, salt: myConstantSalt2, settings: myKeyDerivationSettings) // BAD
 
 	let _ = RNEncryptor(settings: kRNCryptorAES256Settings, password: myPassword, iv: myIV, encryptionSalt: myRandomSalt1, hmacSalt: myRandomSalt2, handler: myHandler) // GOOD
 	let _ = RNEncryptor(settings: kRNCryptorAES256Settings, password: myPassword, iv: myIV, encryptionSalt: myConstantSalt1, hmacSalt: myRandomSalt2, handler: myHandler) // BAD
-	let _ = RNEncryptor(settings: kRNCryptorAES256Settings, password: myPassword, iv: myIV, encryptionSalt: myRandomSalt1, hmacSalt: myConstantSalt2, handler: myHandler) // BAD [NOT DETECTED]
+	let _ = RNEncryptor(settings: kRNCryptorAES256Settings, password: myPassword, iv: myIV, encryptionSalt: myRandomSalt1, hmacSalt: myConstantSalt2, handler: myHandler) // BAD
 	let _ = RNEncryptor(settings: kRNCryptorAES256Settings, password: myPassword, IV: myIV, encryptionSalt: myRandomSalt1, HMACSalt: myRandomSalt2, handler: myHandler) // GOOD
 	let _ = RNEncryptor(settings: kRNCryptorAES256Settings, password: myPassword, IV: myIV, encryptionSalt: myConstantSalt1, HMACSalt: myRandomSalt2, handler: myHandler) // BAD
-	let _ = RNEncryptor(settings: kRNCryptorAES256Settings, password: myPassword, IV: myIV, encryptionSalt: myRandomSalt1, HMACSalt: myConstantSalt2, handler: myHandler) // BAD [NOT DETECTED]
+	let _ = RNEncryptor(settings: kRNCryptorAES256Settings, password: myPassword, IV: myIV, encryptionSalt: myRandomSalt1, HMACSalt: myConstantSalt2, handler: myHandler) // BAD
 
 	let _ = try? myEncryptor.encryptData(myData, with: kRNCryptorAES256Settings, password: myPassword, iv: myIV, encryptionSalt: myRandomSalt1, hmacSalt: myRandomSalt2) // GOOD
 	let _ = try? myEncryptor.encryptData(myData, with: kRNCryptorAES256Settings, password: myPassword, iv: myIV, encryptionSalt: myConstantSalt1, hmacSalt: myRandomSalt2) // BAD
-	let _ = try? myEncryptor.encryptData(myData, with: kRNCryptorAES256Settings, password: myPassword, iv: myIV, encryptionSalt: myRandomSalt1, hmacSalt: myConstantSalt2) // BAD [NOT DETECTED]
+	let _ = try? myEncryptor.encryptData(myData, with: kRNCryptorAES256Settings, password: myPassword, iv: myIV, encryptionSalt: myRandomSalt1, hmacSalt: myConstantSalt2) // BAD
 	let _ = try? myEncryptor.encryptData(myData, withSettings: kRNCryptorAES256Settings, password: myPassword, IV: myIV, encryptionSalt: myRandomSalt1, HMACSalt: myRandomSalt2) // GOOD
 	let _ = try? myEncryptor.encryptData(myData, withSettings: kRNCryptorAES256Settings, password: myPassword, IV: myIV, encryptionSalt: myConstantSalt1, HMACSalt: myRandomSalt2) // BAD
-	let _ = try? myEncryptor.encryptData(myData, withSettings: kRNCryptorAES256Settings, password: myPassword, IV: myIV, encryptionSalt: myRandomSalt1, HMACSalt: myConstantSalt2) // BAD [NOT DETECTED]
+	let _ = try? myEncryptor.encryptData(myData, withSettings: kRNCryptorAES256Settings, password: myPassword, IV: myIV, encryptionSalt: myRandomSalt1, HMACSalt: myConstantSalt2) // BAD
 }

--- a/swift/ql/test/query-tests/Security/CWE-760/rncryptor.swift
+++ b/swift/ql/test/query-tests/Security/CWE-760/rncryptor.swift
@@ -60,21 +60,21 @@ func test(myPassword: String) {
 	let myConstantSalt2 = Data(0)
 
 	let _ = myEncryptor.key(forPassword: myPassword, salt: myRandomSalt1, settings: myKeyDerivationSettings) // GOOD
-	let _ = myEncryptor.key(forPassword: myPassword, salt: myConstantSalt1, settings: myKeyDerivationSettings) // BAD [NOT DETECTED]
+	let _ = myEncryptor.key(forPassword: myPassword, salt: myConstantSalt1, settings: myKeyDerivationSettings) // BAD
 	let _ = myEncryptor.keyForPassword(myPassword, salt: myRandomSalt2, settings: myKeyDerivationSettings) // GOOD
 	let _ = myEncryptor.keyForPassword(myPassword, salt: myConstantSalt2, settings: myKeyDerivationSettings) // BAD [NOT DETECTED]
 
 	let _ = RNEncryptor(settings: kRNCryptorAES256Settings, password: myPassword, iv: myIV, encryptionSalt: myRandomSalt1, hmacSalt: myRandomSalt2, handler: myHandler) // GOOD
-	let _ = RNEncryptor(settings: kRNCryptorAES256Settings, password: myPassword, iv: myIV, encryptionSalt: myConstantSalt1, hmacSalt: myRandomSalt2, handler: myHandler) // BAD [NOT DETECTED]
+	let _ = RNEncryptor(settings: kRNCryptorAES256Settings, password: myPassword, iv: myIV, encryptionSalt: myConstantSalt1, hmacSalt: myRandomSalt2, handler: myHandler) // BAD
 	let _ = RNEncryptor(settings: kRNCryptorAES256Settings, password: myPassword, iv: myIV, encryptionSalt: myRandomSalt1, hmacSalt: myConstantSalt2, handler: myHandler) // BAD [NOT DETECTED]
 	let _ = RNEncryptor(settings: kRNCryptorAES256Settings, password: myPassword, IV: myIV, encryptionSalt: myRandomSalt1, HMACSalt: myRandomSalt2, handler: myHandler) // GOOD
-	let _ = RNEncryptor(settings: kRNCryptorAES256Settings, password: myPassword, IV: myIV, encryptionSalt: myConstantSalt1, HMACSalt: myRandomSalt2, handler: myHandler) // BAD [NOT DETECTED]
+	let _ = RNEncryptor(settings: kRNCryptorAES256Settings, password: myPassword, IV: myIV, encryptionSalt: myConstantSalt1, HMACSalt: myRandomSalt2, handler: myHandler) // BAD
 	let _ = RNEncryptor(settings: kRNCryptorAES256Settings, password: myPassword, IV: myIV, encryptionSalt: myRandomSalt1, HMACSalt: myConstantSalt2, handler: myHandler) // BAD [NOT DETECTED]
 
 	let _ = try? myEncryptor.encryptData(myData, with: kRNCryptorAES256Settings, password: myPassword, iv: myIV, encryptionSalt: myRandomSalt1, hmacSalt: myRandomSalt2) // GOOD
-	let _ = try? myEncryptor.encryptData(myData, with: kRNCryptorAES256Settings, password: myPassword, iv: myIV, encryptionSalt: myConstantSalt1, hmacSalt: myRandomSalt2) // BAD [NOT DETECTED]
+	let _ = try? myEncryptor.encryptData(myData, with: kRNCryptorAES256Settings, password: myPassword, iv: myIV, encryptionSalt: myConstantSalt1, hmacSalt: myRandomSalt2) // BAD
 	let _ = try? myEncryptor.encryptData(myData, with: kRNCryptorAES256Settings, password: myPassword, iv: myIV, encryptionSalt: myRandomSalt1, hmacSalt: myConstantSalt2) // BAD [NOT DETECTED]
 	let _ = try? myEncryptor.encryptData(myData, withSettings: kRNCryptorAES256Settings, password: myPassword, IV: myIV, encryptionSalt: myRandomSalt1, HMACSalt: myRandomSalt2) // GOOD
-	let _ = try? myEncryptor.encryptData(myData, withSettings: kRNCryptorAES256Settings, password: myPassword, IV: myIV, encryptionSalt: myConstantSalt1, HMACSalt: myRandomSalt2) // BAD [NOT DETECTED]
+	let _ = try? myEncryptor.encryptData(myData, withSettings: kRNCryptorAES256Settings, password: myPassword, IV: myIV, encryptionSalt: myConstantSalt1, HMACSalt: myRandomSalt2) // BAD
 	let _ = try? myEncryptor.encryptData(myData, withSettings: kRNCryptorAES256Settings, password: myPassword, IV: myIV, encryptionSalt: myRandomSalt1, HMACSalt: myConstantSalt2) // BAD [NOT DETECTED]
 }

--- a/swift/ql/test/query-tests/Security/CWE-760/rncryptor.swift
+++ b/swift/ql/test/query-tests/Security/CWE-760/rncryptor.swift
@@ -1,0 +1,80 @@
+
+// --- stubs ---
+
+class Data {
+    init<S>(_ elements: S) {}
+}
+
+class NSObject
+{
+}
+
+struct _RNCryptorSettings {
+	// ...
+}
+typealias RNCryptorSettings = _RNCryptorSettings
+
+let kRNCryptorAES256Settings = RNCryptorSettings()
+
+struct _RNCryptorKeyDerivationSettings {
+	// ...
+}
+typealias RNCryptorKeyDerivationSettings = _RNCryptorKeyDerivationSettings
+
+typealias RNCryptorHandler = () -> Void // simplified
+
+class RNCryptor : NSObject
+{
+	func key(forPassword password: String?, salt: Data?, settings keySettings: RNCryptorKeyDerivationSettings) -> Data? { return nil }
+	func keyForPassword(_ password: String?, salt: Data?, settings keySettings: RNCryptorKeyDerivationSettings) -> Data? { return nil }
+}
+
+class RNEncryptor : RNCryptor
+{
+	override init() {}
+
+	init(settings: RNCryptorSettings, password: String, iv anIV: Data?, encryptionSalt anEncryptionSalt: Data?, hmacSalt anHMACSalt: Data?, handler: RNCryptorHandler?) {}
+	init(settings: RNCryptorSettings, password: String, IV anIV: Data?, encryptionSalt anEncryptionSalt: Data?, HMACSalt anHMACSalt: Data?, handler: RNCryptorHandler?) {}
+
+	func encryptData(_ data: Data?, with settings: RNCryptorSettings, password: String?, iv anIV: Data?, encryptionSalt anEncryptionSalt: Data?, hmacSalt anHMACSalt: Data?) throws -> Data { return Data(0) }
+	func encryptData(_ data: Data?, withSettings settings: RNCryptorSettings, password: String?, IV anIV: Data?, encryptionSalt anEncryptionSalt: Data?, HMACSalt anHMACSalt: Data?) throws -> Data { return Data(0) }
+}
+
+// --- tests ---
+
+func getARandomString() -> String {
+	let charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"
+	return String("................".map{_ in charset.randomElement()!})
+}
+
+func test(myPassword: String) {
+	// RNCryptor
+	let myEncryptor = RNEncryptor()
+	let myData = Data(0)
+	let myKeyDerivationSettings = RNCryptorKeyDerivationSettings()
+	let myHandler = {}
+	let myIV = Data(0)
+	let myRandomSalt1 = Data(getARandomString())
+	let myRandomSalt2 = Data(getARandomString())
+	let myConstantSalt1 = Data("abcdef123456")
+	let myConstantSalt2 = Data(0)
+
+	let _ = myEncryptor.key(forPassword: myPassword, salt: myRandomSalt1, settings: myKeyDerivationSettings) // GOOD
+	let _ = myEncryptor.key(forPassword: myPassword, salt: myConstantSalt1, settings: myKeyDerivationSettings) // BAD [NOT DETECTED]
+	let _ = myEncryptor.keyForPassword(myPassword, salt: myRandomSalt2, settings: myKeyDerivationSettings) // GOOD
+	let _ = myEncryptor.keyForPassword(myPassword, salt: myConstantSalt2, settings: myKeyDerivationSettings) // BAD [NOT DETECTED]
+
+	let _ = RNEncryptor(settings: kRNCryptorAES256Settings, password: myPassword, iv: myIV, encryptionSalt: myRandomSalt1, hmacSalt: myRandomSalt2, handler: myHandler) // GOOD
+	let _ = RNEncryptor(settings: kRNCryptorAES256Settings, password: myPassword, iv: myIV, encryptionSalt: myConstantSalt1, hmacSalt: myRandomSalt2, handler: myHandler) // BAD [NOT DETECTED]
+	let _ = RNEncryptor(settings: kRNCryptorAES256Settings, password: myPassword, iv: myIV, encryptionSalt: myRandomSalt1, hmacSalt: myConstantSalt2, handler: myHandler) // BAD [NOT DETECTED]
+	let _ = RNEncryptor(settings: kRNCryptorAES256Settings, password: myPassword, IV: myIV, encryptionSalt: myRandomSalt1, HMACSalt: myRandomSalt2, handler: myHandler) // GOOD
+	let _ = RNEncryptor(settings: kRNCryptorAES256Settings, password: myPassword, IV: myIV, encryptionSalt: myConstantSalt1, HMACSalt: myRandomSalt2, handler: myHandler) // BAD [NOT DETECTED]
+	let _ = RNEncryptor(settings: kRNCryptorAES256Settings, password: myPassword, IV: myIV, encryptionSalt: myRandomSalt1, HMACSalt: myConstantSalt2, handler: myHandler) // BAD [NOT DETECTED]
+
+	let _ = try? myEncryptor.encryptData(myData, with: kRNCryptorAES256Settings, password: myPassword, iv: myIV, encryptionSalt: myRandomSalt1, hmacSalt: myRandomSalt2) // GOOD
+	let _ = try? myEncryptor.encryptData(myData, with: kRNCryptorAES256Settings, password: myPassword, iv: myIV, encryptionSalt: myConstantSalt1, hmacSalt: myRandomSalt2) // BAD [NOT DETECTED]
+	let _ = try? myEncryptor.encryptData(myData, with: kRNCryptorAES256Settings, password: myPassword, iv: myIV, encryptionSalt: myRandomSalt1, hmacSalt: myConstantSalt2) // BAD [NOT DETECTED]
+	let _ = try? myEncryptor.encryptData(myData, withSettings: kRNCryptorAES256Settings, password: myPassword, IV: myIV, encryptionSalt: myRandomSalt1, HMACSalt: myRandomSalt2) // GOOD
+	let _ = try? myEncryptor.encryptData(myData, withSettings: kRNCryptorAES256Settings, password: myPassword, IV: myIV, encryptionSalt: myConstantSalt1, HMACSalt: myRandomSalt2) // BAD [NOT DETECTED]
+	let _ = try? myEncryptor.encryptData(myData, withSettings: kRNCryptorAES256Settings, password: myPassword, IV: myIV, encryptionSalt: myRandomSalt1, HMACSalt: myConstantSalt2) // BAD [NOT DETECTED]
+}


### PR DESCRIPTION
Add RNCryptor sinks to `swift/constant-salt`. This PR is related to  https://github.com/github/codeql/pull/11905 and https://github.com/github/codeql/pull/11911 .

I have also made `NumberLiteral` a source for this query, to support the very lazy (but all too plausible) initializer `Data(0)` used in some of the tests.
