### PR TITLE
C++: Add RangeNode class

### DIFF
--- a/cpp/ql/lib/experimental/semmle/code/cpp/rangeanalysis/extensions/RangeNode.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/rangeanalysis/extensions/RangeNode.qll
@@ -1,0 +1,111 @@
+private import cpp
+private import semmle.code.cpp.dataflow.DataFlow
+private import semmle.code.cpp.rangeanalysis.SimpleRangeAnalysis
+
+string getExprBoundAsString(Expr e) {
+  if exists(lowerBound(e)) and exists(upperBound(e))
+  then result = "[" + lowerBound(e) + ", " + upperBound(e) + "]"
+  else result = "[unknown range]"
+}
+
+/**
+ * Holds for any integer type after resolving typedefs and stripping `const`
+ * specifiers, such as for `const size_t`
+ */
+predicate isIntegralType(Type t) {
+  // We use `getUnspecifiedType` here because without it things like
+  // `const size_t` aren't considered to be integral
+  t.getUnspecifiedType() instanceof IntegralType
+}
+
+/**
+ * Holds for any reference to an integer type after resolving typedefs and
+ * stripping `const` specifiers, such as for `const size_t&`
+ */
+predicate isIntegralReferenceType(Type t) { isIntegralType(t.(ReferenceType).stripType()) }
+
+/**
+ * Holds for any pointer to an integer type after resolving typedefs and
+ * stripping `const` specifiers, such as for `const size_t*`. This predicate
+ * holds for any pointer depth, such as for `const size_t**`.
+ */
+predicate isIntegralPointerType(Type t) { isIntegralType(t.(PointerType).stripType()) }
+
+predicate hasIntegralOrReferenceIntegralType(Locatable e) {
+  exists(Type t |
+    (
+      t = e.(Expr).getUnspecifiedType()
+      or
+      // This will cover variables, parameters, type declarations, etc.
+      t = e.(DeclarationEntry).getUnspecifiedType()
+    ) and
+    isIntegralType(t)
+    or
+    isIntegralReferenceType(t)
+  )
+}
+
+Expr getLOp(Operation o) {
+  result = o.(BinaryOperation).getLeftOperand() or
+  result = o.(Assignment).getLValue()
+}
+
+Expr getROp(Operation o) {
+  result = o.(BinaryOperation).getRightOperand() or
+  result = o.(Assignment).getRValue()
+}
+
+/**
+ * Display the ranges of expressions in the path view
+ */
+private class ExprRangeNode extends DataFlow::ExprNode {
+  pragma[inline]
+  private string getIntegralBounds(Expr arg) {
+    if hasIntegralOrReferenceIntegralType(arg)
+    then result = getExprBoundAsString(arg)
+    else result = ""
+  }
+
+  private string getOperationBounds(Operation e) {
+    result =
+      getExprBoundAsString(e) + " = " + getExprBoundAsString(getLOp(e)) +
+        e.(Operation).getOperator() + getExprBoundAsString(getROp(e))
+  }
+
+  private string getCallBounds(Call e) {
+    result =
+      getExprBoundAsString(e) + "(" +
+        concat(Expr arg, int i |
+          arg = e.(Call).getArgument(i)
+        |
+          getIntegralBounds(arg) order by i, ","
+        ) + ")"
+  }
+
+  override string toString() {
+    exists(Expr e | e = getExpr() |
+      if hasIntegralOrReferenceIntegralType(e)
+      then
+        exists(getOperationBounds(e)) and result = super.toString() + ": " + getOperationBounds(e)
+        or
+        exists(getCallBounds(e)) and result = super.toString() + ": " + getCallBounds(e)
+        or
+        not exists(getOperationBounds(e)) and
+        not exists(getCallBounds(e)) and
+        result = super.toString() + ": " + getExprBoundAsString(e)
+      else result = super.toString()
+    )
+  }
+}
+
+/**
+ * Display the ranges of expressions in the path view
+ */
+private class ReferenceArgumentRangeNode extends DataFlow::DefinitionByReferenceNode {
+  override string toString() {
+    if hasIntegralOrReferenceIntegralType(asDefiningArgument())
+    then result = super.toString() + ": " + getExprBoundAsString(getArgument())
+    else result = super.toString()
+  }
+}
+// TODO: Show ranges for DataFlow::ExplicitParameterNode


### PR DESCRIPTION
This PR adds a `RangeNode` class, which can be included in any path query to see the calculated ranges of variables.
![image](https://user-images.githubusercontent.com/1012677/213130093-8884535d-9f3f-42b3-a608-12f941d3dec4.png)

I've found this useful, so I wanted to see if you would be interested in something like this upstream, but no worries if you don't think something like this should be merged.

I'm also not sure which folder this should go in, and if all the helper predicates are fine here or should be moved somewhere else (or removed).
