### PR TITLE
JS: Updated express-rate-limit example to match implementation examples f…

### DIFF
--- a/javascript/ql/src/Security/CWE-770/examples/MissingRateLimitingGood.js
+++ b/javascript/ql/src/Security/CWE-770/examples/MissingRateLimitingGood.js
@@ -3,7 +3,7 @@ var app = express();
 
 // set up rate limiter: maximum of five requests per minute
 var RateLimit = require('express-rate-limit');
-var limiter = new RateLimit({
+var limiter = RateLimit({
   windowMs: 1*60*1000, // 1 minute
   max: 5
 });

--- a/javascript/ql/src/change-notes/2023-01-18-express-rate-limit.md
+++ b/javascript/ql/src/change-notes/2023-01-18-express-rate-limit.md
@@ -1,0 +1,5 @@
+---
+cetegory: fix
+---
+
+- Updated documentation regarding implementation of [express-rate-limit](https://www.npmjs.com/package/express-rate-limit) package.

--- a/javascript/ql/src/change-notes/2023-01-18-express-rate-limit.md
+++ b/javascript/ql/src/change-notes/2023-01-18-express-rate-limit.md
@@ -1,5 +1,0 @@
----
-cetegory: fix
----
-
-- Updated documentation regarding implementation of [express-rate-limit](https://www.npmjs.com/package/express-rate-limit) package.

--- a/javascript/ql/test/query-tests/Security/CWE-770/MissingRateLimit/MissingRateLimitingGood.js
+++ b/javascript/ql/test/query-tests/Security/CWE-770/MissingRateLimit/MissingRateLimitingGood.js
@@ -1,18 +1,17 @@
-var express = require('express');
+var express = require("express");
 var app = express();
 
 // set up rate limiter: maximum of five requests per minute
-var RateLimit = require('express-rate-limit');
-var limiter = new RateLimit({
-  windowMs: 1*60*1000, // 1 minute
-  max: 5
+var RateLimit = require("express-rate-limit");
+var limiter = RateLimit({
+  windowMs: 1 * 60 * 1000, // 1 minute
+  max: 5,
 });
 
 // apply rate limiter to all requests
 app.use(limiter);
 
-app.get('/:path', function(req, res) {
+app.get("/:path", function (req, res) {
   let path = req.params.path;
-  if (isValidPath(path))
-    res.sendFile(path);
+  if (isValidPath(path)) res.sendFile(path);
 });


### PR DESCRIPTION
…ound on packages' README. Without the update, type errors are thrown saying that RateLimit is not a constructor.