### PR TITLE
C++: Refactor flow out of parameters

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -46,6 +46,12 @@ private newtype TIRDataFlowNode =
   } or
   TRawIndirectInstruction(Instruction instr, int indirectionIndex) {
     Ssa::hasRawIndirectInstruction(instr, indirectionIndex)
+  } or
+  TFinalParameterNode(Parameter p, int indirectionIndex) {
+    exists(Ssa::FinalParameterUse use |
+      use.getParameter() = p and
+      use.getIndirectionIndex() = indirectionIndex
+    )
   }
 
 /**
@@ -522,16 +528,35 @@ class IndirectParameterNode extends Node, IndirectInstruction {
  * A node representing the indirection of a value that is
  * about to be returned from a function.
  */
-class IndirectReturnNode extends IndirectOperand {
+class IndirectReturnNode extends Node {
   IndirectReturnNode() {
-    this.getOperand() = any(ReturnIndirectionInstruction ret).getSourceAddressOperand()
+    this instanceof FinalParameterNode
     or
-    this.getOperand() = any(ReturnValueInstruction ret).getReturnAddressOperand()
+    this.(IndirectOperand).getOperand() = any(ReturnValueInstruction ret).getReturnAddressOperand()
   }
 
-  Operand getAddressOperand() { result = operand }
-
   override Declaration getEnclosingCallable() { result = this.getFunction() }
+
+  /**
+   * Holds if this node represents the value that is returned to the caller
+   * through a `return` statement.
+   */
+  predicate isNormalReturn() { this instanceof IndirectOperand }
+
+  /**
+   * Holds if this node represents the value that is returned to the caller
+   * by writing to the `argumentIndex`'th argument of the call.
+   */
+  predicate isParameterReturn(int argumentIndex) {
+    this.(FinalParameterNode).getArgumentIndex() = argumentIndex
+  }
+
+  /** Gets the indirection index of this indirect return node. */
+  int getIndirectionIndex() {
+    result = this.(FinalParameterNode).getIndirectionIndex()
+    or
+    result = this.(IndirectOperand).getIndirectionIndex()
+  }
 }
 
 /**
@@ -719,6 +744,47 @@ class RawIndirectOperand extends Node, TRawIndirectOperand {
 
   override string toStringImpl() {
     result = instructionNode(this.getOperand().getDef()).toStringImpl() + " indirection"
+  }
+}
+
+/**
+ * INTERNAL: do not use.
+ *
+ * A node representing the value of an update parameter
+ * just before reaching the end of a function.
+ */
+class FinalParameterNode extends Node, TFinalParameterNode {
+  Parameter p;
+  int indirectionIndex;
+
+  FinalParameterNode() { this = TFinalParameterNode(p, indirectionIndex) }
+
+  /** Gets the parameter associated with this final use. */
+  Parameter getParameter() { result = p }
+
+  /** Gets the underlying indirection index. */
+  int getIndirectionIndex() { result = indirectionIndex }
+
+  /** Gets the argument index associated with this final use. */
+  final int getArgumentIndex() { result = p.getIndex() }
+
+  override Function getFunction() { result = p.getFunction() }
+
+  override Declaration getEnclosingCallable() { result = this.getFunction() }
+
+  override DataFlowType getType() { result = getTypeImpl(p.getUnspecifiedType(), indirectionIndex) }
+
+  final override Location getLocationImpl() {
+    // Parameters can have multiple locations. When there's a unique location we use
+    // that one, but if multiple locations exist we default to an unknown location.
+    result = unique( | | p.getLocation())
+    or
+    not exists(unique( | | p.getLocation())) and
+    result instanceof UnknownDefaultLocation
+  }
+
+  override string toStringImpl() {
+    if indirectionIndex > 1 then result = p.toString() + " indirection" else result = p.toString()
   }
 }
 

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
@@ -130,6 +130,31 @@ private newtype TDefOrUseImpl =
     Operand iteratorAddress, BaseSourceVariableInstruction container, int indirectionIndex
   ) {
     isIteratorUse(container, iteratorAddress, _, indirectionIndex)
+  } or
+  TFinalParameterUse(Parameter p, int indirectionIndex) {
+    // Avoid creating parameter nodes if there is no definitions of the variable other than the initializaion.
+    exists(SsaInternals0::Def def |
+      def.getSourceVariable().getBaseVariable().(BaseIRVariable).getIRVariable().getAst() = p and
+      not def.getValue().asInstruction() instanceof InitializeParameterInstruction
+    ) and
+    // If the type is modifiable
+    exists(CppType cppType |
+      cppType.hasUnspecifiedType(p.getUnspecifiedType(), _) and
+      isModifiableAt(cppType, indirectionIndex + 1)
+    ) and
+    (
+      exists(Indirection indirection |
+        indirection.getType() = p.getUnspecifiedType() and
+        indirectionIndex = [1 .. indirection.getNumberOfIndirections()]
+      )
+      or
+      // Array types don't have indirections. So we need to special case them here.
+      exists(Cpp::ArrayType arrayType, CppType cppType |
+        arrayType = p.getUnspecifiedType() and
+        cppType.hasUnspecifiedType(arrayType, _) and
+        indirectionIndex = [1 .. countIndirectionsForCppType(cppType)]
+      )
+    )
   }
 
 abstract private class DefOrUseImpl extends TDefOrUseImpl {
@@ -137,7 +162,7 @@ abstract private class DefOrUseImpl extends TDefOrUseImpl {
   abstract string toString();
 
   /** Gets the block of this definition or use. */
-  abstract IRBlock getBlock();
+  final IRBlock getBlock() { this.hasIndexInBlock(result, _) }
 
   /** Holds if this definition or use has index `index` in block `block`. */
   abstract predicate hasIndexInBlock(IRBlock block, int index);
@@ -222,8 +247,6 @@ abstract class DefImpl extends DefOrUseImpl {
 
   override string toString() { result = "DefImpl" }
 
-  override IRBlock getBlock() { result = this.getAddressOperand().getUse().getBlock() }
-
   override Cpp::Location getLocation() { result = this.getAddressOperand().getUse().getLocation() }
 
   final override predicate hasIndexInBlock(IRBlock block, int index) {
@@ -258,32 +281,43 @@ private class IteratorDef extends DefImpl, TIteratorDef {
 }
 
 abstract class UseImpl extends DefOrUseImpl {
-  Operand operand;
   int ind;
 
   bindingset[ind]
   UseImpl() { any() }
 
-  Operand getOperand() { result = operand }
+  /** Gets the node associated with this use. */
+  abstract Node getNode();
 
   override string toString() { result = "UseImpl" }
+
+  /** Gets the indirection index of this use. */
+  final override int getIndirectionIndex() { result = ind }
+
+  /** Gets the number of loads that precedence this use. */
+  abstract int getIndirection();
+
+  /**
+   * Holds if this use is guaranteed to read the
+   * associated variable.
+   */
+  abstract predicate isCertain();
+}
+
+abstract private class OperandBasedUse extends UseImpl {
+  Operand operand;
+
+  bindingset[ind]
+  OperandBasedUse() { any() }
 
   final override predicate hasIndexInBlock(IRBlock block, int index) {
     operand.getUse() = block.getInstruction(index)
   }
 
-  final override IRBlock getBlock() { result = operand.getUse().getBlock() }
-
   final override Cpp::Location getLocation() { result = operand.getLocation() }
-
-  override int getIndirectionIndex() { result = ind }
-
-  abstract int getIndirection();
-
-  abstract predicate isCertain();
 }
 
-private class DirectUse extends UseImpl, TUseImpl {
+private class DirectUse extends OperandBasedUse, TUseImpl {
   DirectUse() { this = TUseImpl(operand, ind) }
 
   override int getIndirection() { isUse(_, operand, _, result, ind) }
@@ -291,9 +325,11 @@ private class DirectUse extends UseImpl, TUseImpl {
   override BaseSourceVariableInstruction getBase() { isUse(_, operand, result, _, ind) }
 
   override predicate isCertain() { isUse(true, operand, _, _, ind) }
+
+  override Node getNode() { nodeHasOperand(result, operand, ind) }
 }
 
-private class IteratorUse extends UseImpl, TIteratorUse {
+private class IteratorUse extends OperandBasedUse, TIteratorUse {
   BaseSourceVariableInstruction container;
 
   IteratorUse() { this = TIteratorUse(operand, container, ind) }
@@ -303,6 +339,49 @@ private class IteratorUse extends UseImpl, TIteratorUse {
   override BaseSourceVariableInstruction getBase() { result = container }
 
   override predicate isCertain() { none() }
+
+  override Node getNode() { nodeHasOperand(result, operand, ind) }
+}
+
+class FinalParameterUse extends UseImpl, TFinalParameterUse {
+  Parameter p;
+
+  FinalParameterUse() { this = TFinalParameterUse(p, ind) }
+
+  Parameter getParameter() { result = p }
+
+  override Node getNode() {
+    result.(FinalParameterNode).getParameter() = p and
+    result.(FinalParameterNode).getIndirectionIndex() = ind
+  }
+
+  override int getIndirection() { result = ind + 1 }
+
+  override predicate isCertain() { any() }
+
+  override predicate hasIndexInBlock(IRBlock block, int index) {
+    exists(ReturnInstruction return |
+      block.getInstruction(index) = return and
+      return.getEnclosingFunction() = p.getFunction()
+    )
+  }
+
+  override Cpp::Location getLocation() {
+    // Parameters can have multiple locations. When there's a unique location we use
+    // that one, but if multiple locations exist we default to an unknown location.
+    result = unique( | | p.getLocation())
+    or
+    not exists(unique( | | p.getLocation())) and
+    result instanceof UnknownDefaultLocation
+  }
+
+  override BaseSourceVariableInstruction getBase() {
+    exists(InitializeParameterInstruction init |
+      init.getParameter() = p and
+      // This is always a `VariableAddressInstruction`
+      result = init.getAnOperand().getDef()
+    )
+  }
 }
 
 /**
@@ -331,14 +410,7 @@ predicate adjacentDefRead(DefOrUse defOrUse1, UseOrPhi use) {
   )
 }
 
-private predicate useToNode(UseOrPhi use, Node nodeTo) {
-  exists(UseImpl useImpl |
-    useImpl = use.asDefOrUse() and
-    nodeHasOperand(nodeTo, useImpl.getOperand(), useImpl.getIndirectionIndex())
-  )
-  or
-  nodeTo.(SsaPhiNode).getPhiNode() = use.asPhi()
-}
+private predicate useToNode(UseOrPhi use, Node nodeTo) { nodeTo = use.getNode() }
 
 pragma[noinline]
 predicate outNodeHasAddressAndIndex(
@@ -609,6 +681,8 @@ class Phi extends TPhi, SsaDefOrUse {
   final override Location getLocation() { result = phi.getBasicBlock().getLocation() }
 
   override string toString() { result = "Phi" }
+
+  SsaPhiNode getNode() { result.getPhiNode() = phi }
 }
 
 class UseOrPhi extends SsaDefOrUse {
@@ -620,6 +694,12 @@ class UseOrPhi extends SsaDefOrUse {
 
   final override Location getLocation() {
     result = this.asDefOrUse().getLocation() or result = this.(Phi).getLocation()
+  }
+
+  final Node getNode() {
+    result = this.(Phi).getNode()
+    or
+    result = this.asDefOrUse().(UseImpl).getNode()
   }
 }
 

--- a/cpp/ql/test/library-tests/dataflow/fields/ir-path-flow.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/ir-path-flow.expected
@@ -311,17 +311,17 @@ edges
 | aliasing.cpp:98:10:98:19 | call to user_input | aliasing.cpp:98:3:98:21 | Store |
 | aliasing.cpp:101:13:101:22 | & ... indirection | aliasing.cpp:102:8:102:10 | * ... |
 | aliasing.cpp:101:14:101:19 | s_copy indirection [m1] | aliasing.cpp:101:13:101:22 | & ... indirection |
-| aliasing.cpp:105:23:105:24 | Load indirection | aliasing.cpp:121:15:121:16 | taint_a_ptr output argument |
-| aliasing.cpp:105:23:105:24 | Load indirection | aliasing.cpp:126:15:126:20 | taint_a_ptr output argument |
-| aliasing.cpp:105:23:105:24 | Load indirection | aliasing.cpp:131:15:131:16 | taint_a_ptr output argument |
-| aliasing.cpp:105:23:105:24 | Load indirection | aliasing.cpp:136:15:136:17 | taint_a_ptr output argument |
-| aliasing.cpp:105:23:105:24 | Load indirection | aliasing.cpp:141:17:141:20 | taint_a_ptr output argument |
-| aliasing.cpp:105:23:105:24 | Load indirection | aliasing.cpp:158:15:158:20 | taint_a_ptr output argument |
-| aliasing.cpp:105:23:105:24 | Load indirection | aliasing.cpp:164:15:164:20 | taint_a_ptr output argument |
-| aliasing.cpp:105:23:105:24 | Load indirection | aliasing.cpp:175:15:175:22 | taint_a_ptr output argument |
-| aliasing.cpp:105:23:105:24 | Load indirection | aliasing.cpp:187:15:187:22 | taint_a_ptr output argument |
-| aliasing.cpp:105:23:105:24 | Load indirection | aliasing.cpp:200:15:200:24 | taint_a_ptr output argument |
-| aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:105:23:105:24 | Load indirection |
+| aliasing.cpp:105:23:105:24 | pa | aliasing.cpp:121:15:121:16 | taint_a_ptr output argument |
+| aliasing.cpp:105:23:105:24 | pa | aliasing.cpp:126:15:126:20 | taint_a_ptr output argument |
+| aliasing.cpp:105:23:105:24 | pa | aliasing.cpp:131:15:131:16 | taint_a_ptr output argument |
+| aliasing.cpp:105:23:105:24 | pa | aliasing.cpp:136:15:136:17 | taint_a_ptr output argument |
+| aliasing.cpp:105:23:105:24 | pa | aliasing.cpp:141:17:141:20 | taint_a_ptr output argument |
+| aliasing.cpp:105:23:105:24 | pa | aliasing.cpp:158:15:158:20 | taint_a_ptr output argument |
+| aliasing.cpp:105:23:105:24 | pa | aliasing.cpp:164:15:164:20 | taint_a_ptr output argument |
+| aliasing.cpp:105:23:105:24 | pa | aliasing.cpp:175:15:175:22 | taint_a_ptr output argument |
+| aliasing.cpp:105:23:105:24 | pa | aliasing.cpp:187:15:187:22 | taint_a_ptr output argument |
+| aliasing.cpp:105:23:105:24 | pa | aliasing.cpp:200:15:200:24 | taint_a_ptr output argument |
+| aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:105:23:105:24 | pa |
 | aliasing.cpp:121:15:121:16 | taint_a_ptr output argument | aliasing.cpp:122:8:122:12 | access to array |
 | aliasing.cpp:126:15:126:20 | taint_a_ptr output argument | aliasing.cpp:127:8:127:16 | * ... |
 | aliasing.cpp:131:15:131:16 | taint_a_ptr output argument | aliasing.cpp:132:8:132:14 | * ... |
@@ -486,12 +486,12 @@ edges
 | by_reference.cpp:88:9:88:9 | CopyValue indirection [post update] [a] | by_reference.cpp:126:21:126:40 | taint_inner_a_ref output argument [a] |
 | by_reference.cpp:88:9:88:9 | CopyValue indirection [post update] [a] | by_reference.cpp:127:21:127:38 | taint_inner_a_ref output argument [a] |
 | by_reference.cpp:88:13:88:22 | call to user_input | by_reference.cpp:88:3:88:24 | Store |
-| by_reference.cpp:91:25:91:26 | Load indirection | by_reference.cpp:104:15:104:22 | taint_a_ptr output argument |
-| by_reference.cpp:91:25:91:26 | Load indirection | by_reference.cpp:108:15:108:24 | taint_a_ptr output argument |
-| by_reference.cpp:92:9:92:18 | call to user_input | by_reference.cpp:91:25:91:26 | Load indirection |
-| by_reference.cpp:95:25:95:26 | Load indirection | by_reference.cpp:124:15:124:21 | taint_a_ref output argument |
-| by_reference.cpp:95:25:95:26 | Load indirection | by_reference.cpp:128:15:128:23 | taint_a_ref output argument |
-| by_reference.cpp:96:8:96:17 | call to user_input | by_reference.cpp:95:25:95:26 | Load indirection |
+| by_reference.cpp:91:25:91:26 | pa | by_reference.cpp:104:15:104:22 | taint_a_ptr output argument |
+| by_reference.cpp:91:25:91:26 | pa | by_reference.cpp:108:15:108:24 | taint_a_ptr output argument |
+| by_reference.cpp:92:9:92:18 | call to user_input | by_reference.cpp:91:25:91:26 | pa |
+| by_reference.cpp:95:25:95:26 | pa | by_reference.cpp:124:15:124:21 | taint_a_ref output argument |
+| by_reference.cpp:95:25:95:26 | pa | by_reference.cpp:128:15:128:23 | taint_a_ref output argument |
+| by_reference.cpp:96:8:96:17 | call to user_input | by_reference.cpp:95:25:95:26 | pa |
 | by_reference.cpp:102:21:102:39 | taint_inner_a_ptr output argument [a] | by_reference.cpp:102:28:102:39 | outer indirection [post update] [inner_nested, a] |
 | by_reference.cpp:102:28:102:39 | outer indirection [post update] [inner_nested, a] | by_reference.cpp:110:8:110:12 | outer indirection [inner_nested, a] |
 | by_reference.cpp:103:27:103:35 | outer indirection [post update] [inner_ptr indirection, a] | by_reference.cpp:111:8:111:12 | outer indirection [inner_ptr indirection, a] |
@@ -1185,7 +1185,7 @@ nodes
 | aliasing.cpp:101:13:101:22 | & ... indirection | semmle.label | & ... indirection |
 | aliasing.cpp:101:14:101:19 | s_copy indirection [m1] | semmle.label | s_copy indirection [m1] |
 | aliasing.cpp:102:8:102:10 | * ... | semmle.label | * ... |
-| aliasing.cpp:105:23:105:24 | Load indirection | semmle.label | Load indirection |
+| aliasing.cpp:105:23:105:24 | pa | semmle.label | pa |
 | aliasing.cpp:106:9:106:18 | call to user_input | semmle.label | call to user_input |
 | aliasing.cpp:121:15:121:16 | taint_a_ptr output argument | semmle.label | taint_a_ptr output argument |
 | aliasing.cpp:122:8:122:12 | access to array | semmle.label | access to array |
@@ -1339,9 +1339,9 @@ nodes
 | by_reference.cpp:88:3:88:24 | Store | semmle.label | Store |
 | by_reference.cpp:88:9:88:9 | CopyValue indirection [post update] [a] | semmle.label | CopyValue indirection [post update] [a] |
 | by_reference.cpp:88:13:88:22 | call to user_input | semmle.label | call to user_input |
-| by_reference.cpp:91:25:91:26 | Load indirection | semmle.label | Load indirection |
+| by_reference.cpp:91:25:91:26 | pa | semmle.label | pa |
 | by_reference.cpp:92:9:92:18 | call to user_input | semmle.label | call to user_input |
-| by_reference.cpp:95:25:95:26 | Load indirection | semmle.label | Load indirection |
+| by_reference.cpp:95:25:95:26 | pa | semmle.label | pa |
 | by_reference.cpp:96:8:96:17 | call to user_input | semmle.label | call to user_input |
 | by_reference.cpp:102:21:102:39 | taint_inner_a_ptr output argument [a] | semmle.label | taint_inner_a_ptr output argument [a] |
 | by_reference.cpp:102:28:102:39 | outer indirection [post update] [inner_nested, a] | semmle.label | outer indirection [post update] [inner_nested, a] |


### PR DESCRIPTION
This PR refactors the dataflow code for flow out of functions through parameters.

Flow out of parameters are achieved by:
1. Defining a unique "last use" of a parameter in a function
2. Identify that "last use" as a return-like dataflow node whose output node is the (post-update node of the) argument in a call to the function.

On the feature branch (and on `main`) we use the IRs `ReturnIndirectionInstruction` to define the "last use" of each parameter (i.e., step 1). This is simple for parameters that the IR considers worthy of a `ReturnIndirectionInstruction`, but for the upcoming PR that adds flow out of iterators this won't work (since parameters of iterator types don't get a `ReturnIndirectionInstruction`).

So instead, we use the shared SSA library to define a new "last use" for the parameters we care about.