### PR TITLE
C++: Fix models and simplify taint flow

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/TaintTrackingUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/TaintTrackingUtil.qll
@@ -169,19 +169,11 @@ predicate defaultTaintSanitizer(DataFlow::Node node) { none() }
  */
 predicate modeledTaintStep(Operand nodeIn, Instruction nodeOut) {
   exists(CallInstruction call, TaintFunction func, FunctionInput modelIn, FunctionOutput modelOut |
-    (
-      nodeIn = callInput(call, modelIn)
-      or
-      exists(int n |
-        modelIn.isParameterDerefOrQualifierObject(n) and
-        if n = -1
-        then nodeIn = callInput(call, any(InQualifierObject inQualifier))
-        else nodeIn = callInput(call, any(InParameter inParam | inParam.getIndex() = n))
-      )
-    ) and
-    nodeOut = callOutput(call, modelOut) and
     call.getStaticCallTarget() = func and
     func.hasTaintFlow(modelIn, modelOut)
+  |
+    nodeIn = callInput(call, modelIn) and
+    nodeOut = callOutput(call, modelOut)
   )
   or
   // Taint flow from one argument to another and data flow from an argument to a

--- a/cpp/ql/lib/semmle/code/cpp/models/implementations/Iterator.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/implementations/Iterator.qll
@@ -206,7 +206,7 @@ private class IteratorAssignArithmeticOperatorModel extends IteratorAssignArithm
     input.isReturnValueDeref() and
     output.isParameterDeref(0)
     or
-    input.isParameterDeref(1) and
+    (input.isParameter(1) or input.isParameterDeref(1)) and
     output.isParameterDeref(0)
   }
 }
@@ -305,7 +305,7 @@ private class IteratorAssignArithmeticMemberOperator extends MemberFunction, Dat
     input.isReturnValueDeref() and
     output.isQualifierObject()
     or
-    input.isParameterDeref(0) and
+    (input.isParameter(0) or input.isParameterDeref(0)) and
     output.isQualifierObject()
   }
 }

--- a/cpp/ql/lib/semmle/code/cpp/models/implementations/StdSet.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/implementations/StdSet.qll
@@ -27,7 +27,12 @@ private class StdSetConstructor extends Constructor, TaintFunction {
 
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
     // taint flow from any parameter of an iterator type to the qualifier
-    input.isParameterDeref(this.getAnIteratorParameterIndex()) and
+    (
+      // AST dataflow doesn't have indirection for iterators.
+      // Once we deprecate AST dataflow we can delete this first disjunct.
+      input.isParameter(this.getAnIteratorParameterIndex()) or
+      input.isParameterDeref(this.getAnIteratorParameterIndex())
+    ) and
     (
       output.isReturnValue() // TODO: this is only needed for AST data flow, which treats constructors as returning the new object
       or
@@ -45,7 +50,12 @@ private class StdSetInsert extends TaintFunction {
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
     // flow from last parameter to qualifier and return value
     // (where the return value is a pair, this should really flow just to the first part of it)
-    input.isParameterDeref(this.getNumberOfParameters() - 1) and
+    (
+      // AST dataflow doesn't have indirection for iterators.
+      // Once we deprecate AST dataflow we can delete this first disjunct.
+      input.isParameter(this.getNumberOfParameters() - 1) or
+      input.isParameterDeref(this.getNumberOfParameters() - 1)
+    ) and
     (
       output.isQualifierObject() or
       output.isReturnValue()

--- a/cpp/ql/lib/semmle/code/cpp/models/interfaces/FormattingFunction.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/interfaces/FormattingFunction.qll
@@ -158,11 +158,10 @@ abstract class FormattingFunction extends ArrayFunction, TaintFunction {
 
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
     exists(int arg |
-      (
-        arg = getFormatParameterIndex() or
-        arg >= getFirstFormatArgumentIndex()
-      ) and
-      input.isParameterDeref(arg) and
+      arg = getFormatParameterIndex() or
+      arg >= getFirstFormatArgumentIndex()
+    |
+      (input.isParameterDeref(arg) or input.isParameter(arg)) and
       output.isParameterDeref(getOutputParameterIndex(_))
     )
   }


### PR DESCRIPTION
The taint-model interpretation code had a weird case that implemented something along the lines of:
> If the model says that there's incoming flow from a dereference, then I'm also going to assume that there's incoming flow from the pointer.

(and similarly for the outgoing flow).

As far as I can see, these rules only existed to fix some models that were missing flow into arguments that didn't have indirections (for example, because the function actually took a non-pointer like argument), but for some reason used `input.asParameterDeref(...)` in their models.

This PR fixes those models and simplifies the taint-model interpretation code.