### PR TITLE
C++: Add some additional uncontrolled format string tests

### DIFF
--- a/cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/argv/argvLocal.c
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/argv/argvLocal.c
@@ -168,4 +168,34 @@ int main(int argc, char **argv) {
 	int i10 = (int) argv[1];
 	printf((char *) i10);
 	printWrapper((char *) i10);
+
+	// BAD: b value comes from argv
+	{
+		char b[64];
+		char *bp = &b[0];
+		char *t;
+		if (0) {
+			t = 0;
+		} else {
+			t = bp;
+		}
+		memcpy(t, argv[1] + 1, 1);
+		printf(bp);
+		printWrapper(bp);
+	}
+
+	// BAD: b value comes from argv
+	{
+		char b[64];
+		char *bp = &b[0];
+		char *t;
+		if (1) {
+			t = ++bp;
+		} else {
+			t = 0;
+		}
+		memcpy(t, argv[1] + 1, 1);
+		printf(bp);
+		printWrapper(bp);
+	}
 }

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/argv/argvLocal.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/argv/argvLocal.expected
@@ -260,6 +260,30 @@ edges
 | argvLocal.c:168:18:168:21 | argv | argvLocal.c:170:24:170:26 | i10 |
 | argvLocal.c:168:18:168:21 | argv | argvLocal.c:170:24:170:26 | i10 |
 | argvLocal.c:168:18:168:21 | argv | argvLocal.c:170:24:170:26 | i10 |
+| argvLocal.c:182:13:182:16 | argv | argvLocal.c:183:10:183:11 | (const char *)... |
+| argvLocal.c:182:13:182:16 | argv | argvLocal.c:183:10:183:11 | (const char *)... |
+| argvLocal.c:182:13:182:16 | argv | argvLocal.c:183:10:183:11 | bp |
+| argvLocal.c:182:13:182:16 | argv | argvLocal.c:183:10:183:11 | bp |
+| argvLocal.c:182:13:182:16 | argv | argvLocal.c:183:10:183:11 | bp indirection |
+| argvLocal.c:182:13:182:16 | argv | argvLocal.c:183:10:183:11 | bp indirection |
+| argvLocal.c:182:13:182:16 | argv | argvLocal.c:184:16:184:17 | bp |
+| argvLocal.c:182:13:182:16 | argv | argvLocal.c:184:16:184:17 | bp |
+| argvLocal.c:182:13:182:16 | argv | argvLocal.c:184:16:184:17 | bp |
+| argvLocal.c:182:13:182:16 | argv | argvLocal.c:184:16:184:17 | bp |
+| argvLocal.c:182:13:182:16 | argv | argvLocal.c:184:16:184:17 | bp indirection |
+| argvLocal.c:182:13:182:16 | argv | argvLocal.c:184:16:184:17 | bp indirection |
+| argvLocal.c:197:13:197:16 | argv | argvLocal.c:198:10:198:11 | (const char *)... |
+| argvLocal.c:197:13:197:16 | argv | argvLocal.c:198:10:198:11 | (const char *)... |
+| argvLocal.c:197:13:197:16 | argv | argvLocal.c:198:10:198:11 | bp |
+| argvLocal.c:197:13:197:16 | argv | argvLocal.c:198:10:198:11 | bp |
+| argvLocal.c:197:13:197:16 | argv | argvLocal.c:198:10:198:11 | bp indirection |
+| argvLocal.c:197:13:197:16 | argv | argvLocal.c:198:10:198:11 | bp indirection |
+| argvLocal.c:197:13:197:16 | argv | argvLocal.c:199:16:199:17 | bp |
+| argvLocal.c:197:13:197:16 | argv | argvLocal.c:199:16:199:17 | bp |
+| argvLocal.c:197:13:197:16 | argv | argvLocal.c:199:16:199:17 | bp |
+| argvLocal.c:197:13:197:16 | argv | argvLocal.c:199:16:199:17 | bp |
+| argvLocal.c:197:13:197:16 | argv | argvLocal.c:199:16:199:17 | bp indirection |
+| argvLocal.c:197:13:197:16 | argv | argvLocal.c:199:16:199:17 | bp indirection |
 subpaths
 | argvLocal.c:102:15:102:16 | i1 indirection | argvLocal.c:9:25:9:31 | *correct | argvLocal.c:9:25:9:31 | ReturnIndirection | argvLocal.c:102:15:102:16 | printWrapper output argument |
 | argvLocal.c:107:15:107:19 | access to array indirection | argvLocal.c:9:25:9:31 | *correct | argvLocal.c:9:25:9:31 | ReturnIndirection | argvLocal.c:107:15:107:19 | printWrapper output argument |
@@ -396,6 +420,22 @@ nodes
 | argvLocal.c:170:15:170:26 | i10 indirection | semmle.label | i10 indirection |
 | argvLocal.c:170:24:170:26 | i10 | semmle.label | i10 |
 | argvLocal.c:170:24:170:26 | i10 | semmle.label | i10 |
+| argvLocal.c:182:13:182:16 | argv | semmle.label | argv |
+| argvLocal.c:182:13:182:16 | argv | semmle.label | argv |
+| argvLocal.c:183:10:183:11 | (const char *)... | semmle.label | (const char *)... |
+| argvLocal.c:183:10:183:11 | bp | semmle.label | bp |
+| argvLocal.c:183:10:183:11 | bp indirection | semmle.label | bp indirection |
+| argvLocal.c:184:16:184:17 | bp | semmle.label | bp |
+| argvLocal.c:184:16:184:17 | bp | semmle.label | bp |
+| argvLocal.c:184:16:184:17 | bp indirection | semmle.label | bp indirection |
+| argvLocal.c:197:13:197:16 | argv | semmle.label | argv |
+| argvLocal.c:197:13:197:16 | argv | semmle.label | argv |
+| argvLocal.c:198:10:198:11 | (const char *)... | semmle.label | (const char *)... |
+| argvLocal.c:198:10:198:11 | bp | semmle.label | bp |
+| argvLocal.c:198:10:198:11 | bp indirection | semmle.label | bp indirection |
+| argvLocal.c:199:16:199:17 | bp | semmle.label | bp |
+| argvLocal.c:199:16:199:17 | bp | semmle.label | bp |
+| argvLocal.c:199:16:199:17 | bp indirection | semmle.label | bp indirection |
 #select
 | argvLocal.c:95:9:95:15 | access to array | argvLocal.c:95:9:95:12 | argv | argvLocal.c:95:9:95:15 | access to array | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | argvLocal.c:95:9:95:12 | argv | argv |
 | argvLocal.c:96:15:96:21 | access to array | argvLocal.c:96:15:96:18 | argv | argvLocal.c:96:15:96:21 | access to array | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format). | argvLocal.c:96:15:96:18 | argv | argv |
@@ -425,3 +465,7 @@ nodes
 | argvLocal.c:165:15:165:17 | i91 | argvLocal.c:163:22:163:25 | argv | argvLocal.c:165:15:165:17 | i91 | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format). | argvLocal.c:163:22:163:25 | argv | argv |
 | argvLocal.c:169:18:169:20 | i10 | argvLocal.c:168:18:168:21 | argv | argvLocal.c:169:18:169:20 | i10 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | argvLocal.c:168:18:168:21 | argv | argv |
 | argvLocal.c:170:24:170:26 | i10 | argvLocal.c:168:18:168:21 | argv | argvLocal.c:170:24:170:26 | i10 | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format). | argvLocal.c:168:18:168:21 | argv | argv |
+| argvLocal.c:183:10:183:11 | bp | argvLocal.c:182:13:182:16 | argv | argvLocal.c:183:10:183:11 | bp | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | argvLocal.c:182:13:182:16 | argv | argv |
+| argvLocal.c:184:16:184:17 | bp | argvLocal.c:182:13:182:16 | argv | argvLocal.c:184:16:184:17 | bp | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format). | argvLocal.c:182:13:182:16 | argv | argv |
+| argvLocal.c:198:10:198:11 | bp | argvLocal.c:197:13:197:16 | argv | argvLocal.c:198:10:198:11 | bp | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | argvLocal.c:197:13:197:16 | argv | argv |
+| argvLocal.c:199:16:199:17 | bp | argvLocal.c:197:13:197:16 | argv | argvLocal.c:199:16:199:17 | bp | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format). | argvLocal.c:197:13:197:16 | argv | argv |


### PR DESCRIPTION
These duplicate the `i9` and `i91` tests slightly earlier in the same file, but use an explicit `if` instead of the ternary operator.

These demonstrate that the missing results for the `i9` and `i91` tests on the use-use dataflow feature branch are not due to the use of the ternary operator. As these tests might be useful in general, this PR targets `main`.