### PR TITLE
JS: add encodeURIComponent as a sanitizer for request-forgery

### DIFF
--- a/javascript/ql/lib/semmle/javascript/security/dataflow/RequestForgeryCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/RequestForgeryCustomizations.qll
@@ -81,4 +81,14 @@ module RequestForgery {
 
     override string getKind() { result = "endpoint" }
   }
+
+  private import Xss as Xss
+
+  /**
+   * A call to `encodeURI` or `encodeURIComponent`, viewed as a sanitizer for request forgery.
+   * These calls will escape "/" to "%2F", which is not a problem for request forgery.
+   * The result from calling `encodeURI` or `encodeURIComponent` is not a valid URL, and only makes sense
+   * as a part of a URL.
+   */
+  class UriEncodingSanitizer extends Sanitizer instanceof Xss::Shared::UriEncodingSanitizer { }
 }

--- a/javascript/ql/test/experimental/Security/CWE-918/SSRF.expected
+++ b/javascript/ql/test/experimental/Security/CWE-918/SSRF.expected
@@ -15,20 +15,10 @@ nodes
 | check-path.js:19:13:19:43 | 'test.c ... tainted |
 | check-path.js:19:27:19:43 | req.query.tainted |
 | check-path.js:19:27:19:43 | req.query.tainted |
-| check-path.js:22:13:22:63 | 'test.c ... ainted) |
-| check-path.js:22:13:22:63 | 'test.c ... ainted) |
-| check-path.js:22:27:22:63 | encodeU ... ainted) |
-| check-path.js:22:46:22:62 | req.query.tainted |
-| check-path.js:22:46:22:62 | req.query.tainted |
 | check-path.js:23:13:23:45 | `/addre ... inted}` |
 | check-path.js:23:13:23:45 | `/addre ... inted}` |
 | check-path.js:23:27:23:43 | req.query.tainted |
 | check-path.js:23:27:23:43 | req.query.tainted |
-| check-path.js:24:13:24:65 | `/addre ... nted)}` |
-| check-path.js:24:13:24:65 | `/addre ... nted)}` |
-| check-path.js:24:27:24:63 | encodeU ... ainted) |
-| check-path.js:24:46:24:62 | req.query.tainted |
-| check-path.js:24:46:24:62 | req.query.tainted |
 | check-path.js:33:15:33:45 | 'test.c ... tainted |
 | check-path.js:33:15:33:45 | 'test.c ... tainted |
 | check-path.js:33:29:33:45 | req.query.tainted |
@@ -97,18 +87,10 @@ edges
 | check-path.js:19:27:19:43 | req.query.tainted | check-path.js:19:13:19:43 | 'test.c ... tainted |
 | check-path.js:19:27:19:43 | req.query.tainted | check-path.js:19:13:19:43 | 'test.c ... tainted |
 | check-path.js:19:27:19:43 | req.query.tainted | check-path.js:19:13:19:43 | 'test.c ... tainted |
-| check-path.js:22:27:22:63 | encodeU ... ainted) | check-path.js:22:13:22:63 | 'test.c ... ainted) |
-| check-path.js:22:27:22:63 | encodeU ... ainted) | check-path.js:22:13:22:63 | 'test.c ... ainted) |
-| check-path.js:22:46:22:62 | req.query.tainted | check-path.js:22:27:22:63 | encodeU ... ainted) |
-| check-path.js:22:46:22:62 | req.query.tainted | check-path.js:22:27:22:63 | encodeU ... ainted) |
 | check-path.js:23:27:23:43 | req.query.tainted | check-path.js:23:13:23:45 | `/addre ... inted}` |
 | check-path.js:23:27:23:43 | req.query.tainted | check-path.js:23:13:23:45 | `/addre ... inted}` |
 | check-path.js:23:27:23:43 | req.query.tainted | check-path.js:23:13:23:45 | `/addre ... inted}` |
 | check-path.js:23:27:23:43 | req.query.tainted | check-path.js:23:13:23:45 | `/addre ... inted}` |
-| check-path.js:24:27:24:63 | encodeU ... ainted) | check-path.js:24:13:24:65 | `/addre ... nted)}` |
-| check-path.js:24:27:24:63 | encodeU ... ainted) | check-path.js:24:13:24:65 | `/addre ... nted)}` |
-| check-path.js:24:46:24:62 | req.query.tainted | check-path.js:24:27:24:63 | encodeU ... ainted) |
-| check-path.js:24:46:24:62 | req.query.tainted | check-path.js:24:27:24:63 | encodeU ... ainted) |
 | check-path.js:33:29:33:45 | req.query.tainted | check-path.js:33:15:33:45 | 'test.c ... tainted |
 | check-path.js:33:29:33:45 | req.query.tainted | check-path.js:33:15:33:45 | 'test.c ... tainted |
 | check-path.js:33:29:33:45 | req.query.tainted | check-path.js:33:15:33:45 | 'test.c ... tainted |
@@ -167,9 +149,7 @@ edges
 | check-domain.js:26:15:26:27 | req.query.url | check-domain.js:26:15:26:27 | req.query.url | check-domain.js:26:15:26:27 | req.query.url | The URL of this request depends on a user-provided value. |
 | check-middleware.js:9:13:9:43 | "test.c ... tainted | check-middleware.js:9:27:9:43 | req.query.tainted | check-middleware.js:9:13:9:43 | "test.c ... tainted | The URL of this request depends on a user-provided value. |
 | check-path.js:19:13:19:43 | 'test.c ... tainted | check-path.js:19:27:19:43 | req.query.tainted | check-path.js:19:13:19:43 | 'test.c ... tainted | The URL of this request depends on a user-provided value. |
-| check-path.js:22:13:22:63 | 'test.c ... ainted) | check-path.js:22:46:22:62 | req.query.tainted | check-path.js:22:13:22:63 | 'test.c ... ainted) | The URL of this request depends on a user-provided value. |
 | check-path.js:23:13:23:45 | `/addre ... inted}` | check-path.js:23:27:23:43 | req.query.tainted | check-path.js:23:13:23:45 | `/addre ... inted}` | The URL of this request depends on a user-provided value. |
-| check-path.js:24:13:24:65 | `/addre ... nted)}` | check-path.js:24:46:24:62 | req.query.tainted | check-path.js:24:13:24:65 | `/addre ... nted)}` | The URL of this request depends on a user-provided value. |
 | check-path.js:33:15:33:45 | 'test.c ... tainted | check-path.js:33:29:33:45 | req.query.tainted | check-path.js:33:15:33:45 | 'test.c ... tainted | The URL of this request depends on a user-provided value. |
 | check-path.js:37:15:37:45 | 'test.c ... tainted | check-path.js:37:29:37:45 | req.query.tainted | check-path.js:37:15:37:45 | 'test.c ... tainted | The URL of this request depends on a user-provided value. |
 | check-path.js:45:13:45:44 | `${base ... inted}` | check-path.js:45:26:45:42 | req.query.tainted | check-path.js:45:13:45:44 | `${base ... inted}` | The URL of this request depends on a user-provided value. |

--- a/javascript/ql/test/experimental/Security/CWE-918/check-path.js
+++ b/javascript/ql/test/experimental/Security/CWE-918/check-path.js
@@ -19,9 +19,9 @@ app.get('/check-with-axios', req => {
   axios.get('test.com/' + req.query.tainted); // SSRF
   axios.get('test.com/' + Number(req.query.tainted)); // OK
   axios.get('test.com/' + req.user.id); // OK
-  axios.get('test.com/' + encodeURIComponent(req.query.tainted)); // SSRF
+  axios.get('test.com/' + encodeURIComponent(req.query.tainted)); // OK
   axios.get(`/addresses/${req.query.tainted}`); // SSRF
-  axios.get(`/addresses/${encodeURIComponent(req.query.tainted)}`); // SSRF
+  axios.get(`/addresses/${encodeURIComponent(req.query.tainted)}`); // OK
   
   if (Number.isInteger(req.query.tainted)) {
     axios.get('test.com/' + req.query.tainted); // OK

--- a/javascript/ql/test/query-tests/Security/CWE-918/RequestForgery.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-918/RequestForgery.expected
@@ -101,12 +101,6 @@ nodes
 | serverSide.js:130:37:130:43 | tainted |
 | serverSide.js:131:15:131:19 | myUrl |
 | serverSide.js:131:15:131:19 | myUrl |
-| serverSide.js:133:9:133:72 | myEncodedUrl |
-| serverSide.js:133:24:133:72 | `${some ... nted)}` |
-| serverSide.js:133:44:133:70 | encodeU ... ainted) |
-| serverSide.js:133:63:133:69 | tainted |
-| serverSide.js:134:15:134:26 | myEncodedUrl |
-| serverSide.js:134:15:134:26 | myEncodedUrl |
 edges
 | serverSide.js:14:9:14:52 | tainted | serverSide.js:18:13:18:19 | tainted |
 | serverSide.js:14:9:14:52 | tainted | serverSide.js:18:13:18:19 | tainted |
@@ -194,7 +188,6 @@ edges
 | serverSide.js:123:9:123:52 | tainted | serverSide.js:127:14:127:20 | tainted |
 | serverSide.js:123:9:123:52 | tainted | serverSide.js:127:14:127:20 | tainted |
 | serverSide.js:123:9:123:52 | tainted | serverSide.js:130:37:130:43 | tainted |
-| serverSide.js:123:9:123:52 | tainted | serverSide.js:133:63:133:69 | tainted |
 | serverSide.js:123:19:123:42 | url.par ... , true) | serverSide.js:123:19:123:48 | url.par ... ).query |
 | serverSide.js:123:19:123:48 | url.par ... ).query | serverSide.js:123:19:123:52 | url.par ... ery.url |
 | serverSide.js:123:19:123:52 | url.par ... ery.url | serverSide.js:123:9:123:52 | tainted |
@@ -204,11 +197,6 @@ edges
 | serverSide.js:130:9:130:45 | myUrl | serverSide.js:131:15:131:19 | myUrl |
 | serverSide.js:130:17:130:45 | `${some ... inted}` | serverSide.js:130:9:130:45 | myUrl |
 | serverSide.js:130:37:130:43 | tainted | serverSide.js:130:17:130:45 | `${some ... inted}` |
-| serverSide.js:133:9:133:72 | myEncodedUrl | serverSide.js:134:15:134:26 | myEncodedUrl |
-| serverSide.js:133:9:133:72 | myEncodedUrl | serverSide.js:134:15:134:26 | myEncodedUrl |
-| serverSide.js:133:24:133:72 | `${some ... nted)}` | serverSide.js:133:9:133:72 | myEncodedUrl |
-| serverSide.js:133:44:133:70 | encodeU ... ainted) | serverSide.js:133:24:133:72 | `${some ... nted)}` |
-| serverSide.js:133:63:133:69 | tainted | serverSide.js:133:44:133:70 | encodeU ... ainted) |
 #select
 | serverSide.js:18:5:18:20 | request(tainted) | serverSide.js:14:29:14:35 | req.url | serverSide.js:18:13:18:19 | tainted | The $@ of this request depends on a $@. | serverSide.js:18:13:18:19 | tainted | URL | serverSide.js:14:29:14:35 | req.url | user-provided value |
 | serverSide.js:20:5:20:24 | request.get(tainted) | serverSide.js:14:29:14:35 | req.url | serverSide.js:20:17:20:23 | tainted | The $@ of this request depends on a $@. | serverSide.js:20:17:20:23 | tainted | URL | serverSide.js:14:29:14:35 | req.url | user-provided value |
@@ -234,4 +222,3 @@ edges
 | serverSide.js:117:20:117:30 | new ws(url) | serverSide.js:115:25:115:35 | request.url | serverSide.js:117:27:117:29 | url | The $@ of this request depends on a $@. | serverSide.js:117:27:117:29 | url | URL | serverSide.js:115:25:115:35 | request.url | user-provided value |
 | serverSide.js:125:5:128:6 | axios({ ... \\n    }) | serverSide.js:123:29:123:35 | req.url | serverSide.js:127:14:127:20 | tainted | The $@ of this request depends on a $@. | serverSide.js:127:14:127:20 | tainted | URL | serverSide.js:123:29:123:35 | req.url | user-provided value |
 | serverSide.js:131:5:131:20 | axios.get(myUrl) | serverSide.js:123:29:123:35 | req.url | serverSide.js:131:15:131:19 | myUrl | The $@ of this request depends on a $@. | serverSide.js:131:15:131:19 | myUrl | URL | serverSide.js:123:29:123:35 | req.url | user-provided value |
-| serverSide.js:134:5:134:27 | axios.g ... dedUrl) | serverSide.js:123:29:123:35 | req.url | serverSide.js:134:15:134:26 | myEncodedUrl | The $@ of this request depends on a $@. | serverSide.js:134:15:134:26 | myEncodedUrl | URL | serverSide.js:123:29:123:35 | req.url | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-918/RequestForgery.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-918/RequestForgery.expected
@@ -88,6 +88,25 @@ nodes
 | serverSide.js:115:25:115:35 | request.url |
 | serverSide.js:117:27:117:29 | url |
 | serverSide.js:117:27:117:29 | url |
+| serverSide.js:123:9:123:52 | tainted |
+| serverSide.js:123:19:123:42 | url.par ... , true) |
+| serverSide.js:123:19:123:48 | url.par ... ).query |
+| serverSide.js:123:19:123:52 | url.par ... ery.url |
+| serverSide.js:123:29:123:35 | req.url |
+| serverSide.js:123:29:123:35 | req.url |
+| serverSide.js:127:14:127:20 | tainted |
+| serverSide.js:127:14:127:20 | tainted |
+| serverSide.js:130:9:130:45 | myUrl |
+| serverSide.js:130:17:130:45 | `${some ... inted}` |
+| serverSide.js:130:37:130:43 | tainted |
+| serverSide.js:131:15:131:19 | myUrl |
+| serverSide.js:131:15:131:19 | myUrl |
+| serverSide.js:133:9:133:72 | myEncodedUrl |
+| serverSide.js:133:24:133:72 | `${some ... nted)}` |
+| serverSide.js:133:44:133:70 | encodeU ... ainted) |
+| serverSide.js:133:63:133:69 | tainted |
+| serverSide.js:134:15:134:26 | myEncodedUrl |
+| serverSide.js:134:15:134:26 | myEncodedUrl |
 edges
 | serverSide.js:14:9:14:52 | tainted | serverSide.js:18:13:18:19 | tainted |
 | serverSide.js:14:9:14:52 | tainted | serverSide.js:18:13:18:19 | tainted |
@@ -172,6 +191,24 @@ edges
 | serverSide.js:115:17:115:42 | new URL ... , base) | serverSide.js:115:11:115:42 | url |
 | serverSide.js:115:25:115:35 | request.url | serverSide.js:115:17:115:42 | new URL ... , base) |
 | serverSide.js:115:25:115:35 | request.url | serverSide.js:115:17:115:42 | new URL ... , base) |
+| serverSide.js:123:9:123:52 | tainted | serverSide.js:127:14:127:20 | tainted |
+| serverSide.js:123:9:123:52 | tainted | serverSide.js:127:14:127:20 | tainted |
+| serverSide.js:123:9:123:52 | tainted | serverSide.js:130:37:130:43 | tainted |
+| serverSide.js:123:9:123:52 | tainted | serverSide.js:133:63:133:69 | tainted |
+| serverSide.js:123:19:123:42 | url.par ... , true) | serverSide.js:123:19:123:48 | url.par ... ).query |
+| serverSide.js:123:19:123:48 | url.par ... ).query | serverSide.js:123:19:123:52 | url.par ... ery.url |
+| serverSide.js:123:19:123:52 | url.par ... ery.url | serverSide.js:123:9:123:52 | tainted |
+| serverSide.js:123:29:123:35 | req.url | serverSide.js:123:19:123:42 | url.par ... , true) |
+| serverSide.js:123:29:123:35 | req.url | serverSide.js:123:19:123:42 | url.par ... , true) |
+| serverSide.js:130:9:130:45 | myUrl | serverSide.js:131:15:131:19 | myUrl |
+| serverSide.js:130:9:130:45 | myUrl | serverSide.js:131:15:131:19 | myUrl |
+| serverSide.js:130:17:130:45 | `${some ... inted}` | serverSide.js:130:9:130:45 | myUrl |
+| serverSide.js:130:37:130:43 | tainted | serverSide.js:130:17:130:45 | `${some ... inted}` |
+| serverSide.js:133:9:133:72 | myEncodedUrl | serverSide.js:134:15:134:26 | myEncodedUrl |
+| serverSide.js:133:9:133:72 | myEncodedUrl | serverSide.js:134:15:134:26 | myEncodedUrl |
+| serverSide.js:133:24:133:72 | `${some ... nted)}` | serverSide.js:133:9:133:72 | myEncodedUrl |
+| serverSide.js:133:44:133:70 | encodeU ... ainted) | serverSide.js:133:24:133:72 | `${some ... nted)}` |
+| serverSide.js:133:63:133:69 | tainted | serverSide.js:133:44:133:70 | encodeU ... ainted) |
 #select
 | serverSide.js:18:5:18:20 | request(tainted) | serverSide.js:14:29:14:35 | req.url | serverSide.js:18:13:18:19 | tainted | The $@ of this request depends on a $@. | serverSide.js:18:13:18:19 | tainted | URL | serverSide.js:14:29:14:35 | req.url | user-provided value |
 | serverSide.js:20:5:20:24 | request.get(tainted) | serverSide.js:14:29:14:35 | req.url | serverSide.js:20:17:20:23 | tainted | The $@ of this request depends on a $@. | serverSide.js:20:17:20:23 | tainted | URL | serverSide.js:14:29:14:35 | req.url | user-provided value |
@@ -195,3 +232,6 @@ edges
 | serverSide.js:100:5:100:26 | new Web ... ainted) | serverSide.js:98:29:98:35 | req.url | serverSide.js:100:19:100:25 | tainted | The $@ of this request depends on a $@. | serverSide.js:100:19:100:25 | tainted | URL | serverSide.js:98:29:98:35 | req.url | user-provided value |
 | serverSide.js:109:20:109:30 | new ws(url) | serverSide.js:108:17:108:27 | request.url | serverSide.js:109:27:109:29 | url | The $@ of this request depends on a $@. | serverSide.js:109:27:109:29 | url | URL | serverSide.js:108:17:108:27 | request.url | user-provided value |
 | serverSide.js:117:20:117:30 | new ws(url) | serverSide.js:115:25:115:35 | request.url | serverSide.js:117:27:117:29 | url | The $@ of this request depends on a $@. | serverSide.js:117:27:117:29 | url | URL | serverSide.js:115:25:115:35 | request.url | user-provided value |
+| serverSide.js:125:5:128:6 | axios({ ... \\n    }) | serverSide.js:123:29:123:35 | req.url | serverSide.js:127:14:127:20 | tainted | The $@ of this request depends on a $@. | serverSide.js:127:14:127:20 | tainted | URL | serverSide.js:123:29:123:35 | req.url | user-provided value |
+| serverSide.js:131:5:131:20 | axios.get(myUrl) | serverSide.js:123:29:123:35 | req.url | serverSide.js:131:15:131:19 | myUrl | The $@ of this request depends on a $@. | serverSide.js:131:15:131:19 | myUrl | URL | serverSide.js:123:29:123:35 | req.url | user-provided value |
+| serverSide.js:134:5:134:27 | axios.g ... dedUrl) | serverSide.js:123:29:123:35 | req.url | serverSide.js:134:15:134:26 | myEncodedUrl | The $@ of this request depends on a $@. | serverSide.js:134:15:134:26 | myEncodedUrl | URL | serverSide.js:123:29:123:35 | req.url | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-918/serverSide.js
+++ b/javascript/ql/test/query-tests/Security/CWE-918/serverSide.js
@@ -117,3 +117,19 @@ new ws.Server({ port: 8080 }).on('connection', function (socket, request) {
     const socket = new ws(url);
   });
 });
+
+
+var server2 = http.createServer(function(req, res) {
+    var tainted = url.parse(req.url, true).query.url;
+
+    axios({
+        method: 'get',
+        url: tainted // NOT OK
+    })
+
+    var myUrl = `${something}/bla/${tainted}`; 
+    axios.get(myUrl); // NOT OK
+
+    var myEncodedUrl = `${something}/bla/${encodeURIComponent(tainted)}`; 
+    axios.get(myEncodedUrl); // OK - but still flagged [INCONSISTENCY]
+})

--- a/javascript/ql/test/query-tests/Security/CWE-918/serverSide.js
+++ b/javascript/ql/test/query-tests/Security/CWE-918/serverSide.js
@@ -131,5 +131,5 @@ var server2 = http.createServer(function(req, res) {
     axios.get(myUrl); // NOT OK
 
     var myEncodedUrl = `${something}/bla/${encodeURIComponent(tainted)}`; 
-    axios.get(myEncodedUrl); // OK - but still flagged [INCONSISTENCY]
+    axios.get(myEncodedUrl); // OK
 })


### PR DESCRIPTION
Fixes an FP found internally.  

[Evaluation shows OK performance, and no change in results](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/pr-11959-3cece5__nightly-old__code-scanning/reports).