### PR TITLE
Update supported language versions in documentation

### DIFF
--- a/docs/codeql/reusables/supported-versions-compilers.rst
+++ b/docs/codeql/reusables/supported-versions-compilers.rst
@@ -17,7 +17,7 @@
 
    .NET 5, .NET 6","``.sln``, ``.csproj``, ``.cs``, ``.cshtml``, ``.xaml``"
    Go (aka Golang), "Go up to 1.19", "Go 1.11 or more recent", ``.go``
-   Java,"Java 7 to 18 [4]_","javac (OpenJDK and Oracle JDK),
+   Java,"Java 7 to 19 [4]_","javac (OpenJDK and Oracle JDK),
 
    Eclipse compiler for Java (ECJ) [5]_",``.java``
    Kotlin [6]_,"Kotlin 1.5.0 to 1.8.0","kotlinc",``.kt``

--- a/docs/codeql/reusables/supported-versions-compilers.rst
+++ b/docs/codeql/reusables/supported-versions-compilers.rst
@@ -16,7 +16,7 @@
    .NET Core up to 3.1
 
    .NET 5, .NET 6","``.sln``, ``.csproj``, ``.cs``, ``.cshtml``, ``.xaml``"
-   Go (aka Golang), "Go up to 1.18", "Go 1.11 or more recent", ``.go``
+   Go (aka Golang), "Go up to 1.19", "Go 1.11 or more recent", ``.go``
    Java,"Java 7 to 18 [4]_","javac (OpenJDK and Oracle JDK),
 
    Eclipse compiler for Java (ECJ) [5]_",``.java``


### PR DESCRIPTION
- Updated the supported version of Go in documentation (Go 1.18 -> Go 1.19) 
- Updated the supported version of Java in documentation (Java 18 -> Java 19) 