### PR TITLE
Swift: Use numeric types in CleartextLogging.qll.

### DIFF
--- a/swift/ql/lib/codeql/swift/security/CleartextLogging.qll
+++ b/swift/ql/lib/codeql/swift/security/CleartextLogging.qll
@@ -53,7 +53,8 @@ private class OsLogPrivacyCleartextLoggingSanitizer extends CleartextLoggingSani
 /** A type that isn't redacted by default in an `OSLogMessage`. */
 private class OsLogNonRedactedType extends Type {
   OsLogNonRedactedType() {
-    this.getName() = [["", "U"] + "Int" + ["", "8", "16", "32", "64"], "Double", "Float", "Bool"]
+    this instanceof NumericType or
+    this instanceof BoolType
   }
 }
 


### PR DESCRIPTION
Use the new classes from `NumericType.qll` in `CleartextLogging.qll` (follow-up for https://github.com/github/codeql/pull/11841)