### PR TITLE
Ruby: Simplify dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,19 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: "cargo"
-    directory: "ruby/node-types"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "cargo"
-    directory: "ruby/generator"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "cargo"
-    directory: "ruby/extractor"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "cargo"
-    directory: "ruby/autobuilder"
+    directory: "ruby"
     schedule:
       interval: "daily"
 


### PR DESCRIPTION
Dependabot is able to understand cargo workspaces, so it's not necessary
to enumerate each workspace member. It should be enough to configure it
with the workspace root directory. This will hopefully ensure that the
Cargo.lock file gets updated correctly.
