### PR TITLE
C++: Add another looping dataflow test

### DIFF
--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/dataflow-consistency.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/dataflow-consistency.expected
@@ -94,7 +94,10 @@ postWithInFlow
 | test.cpp:505:35:505:35 | x [inner post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:511:5:511:6 | * ... [post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:511:6:511:6 | p [inner post update] | PostUpdateNode should not be the target of local flow. |
-| test.cpp:516:23:516:23 | x [inner post update] | PostUpdateNode should not be the target of local flow. |
+| test.cpp:516:5:516:6 | * ... [post update] | PostUpdateNode should not be the target of local flow. |
+| test.cpp:516:6:516:6 | p [inner post update] | PostUpdateNode should not be the target of local flow. |
+| test.cpp:522:25:522:25 | x [inner post update] | PostUpdateNode should not be the target of local flow. |
+| test.cpp:526:25:526:25 | y [inner post update] | PostUpdateNode should not be the target of local flow. |
 viableImplInCallContextTooLarge
 uniqueParameterNodeAtPosition
 uniqueParameterNodePosition

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/dataflow-ir-consistency.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/dataflow-ir-consistency.expected
@@ -594,9 +594,15 @@ postWithInFlow
 | test.cpp:511:5:511:6 | * ... [post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:511:6:511:6 | VariableAddress [post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:511:6:511:6 | p [post update] | PostUpdateNode should not be the target of local flow. |
-| test.cpp:516:22:516:23 | & ... [post update] | PostUpdateNode should not be the target of local flow. |
-| test.cpp:516:22:516:23 | & ... [post update] | PostUpdateNode should not be the target of local flow. |
-| test.cpp:516:23:516:23 | x [post update] | PostUpdateNode should not be the target of local flow. |
+| test.cpp:516:5:516:6 | * ... [post update] | PostUpdateNode should not be the target of local flow. |
+| test.cpp:516:6:516:6 | VariableAddress [post update] | PostUpdateNode should not be the target of local flow. |
+| test.cpp:516:6:516:6 | p [post update] | PostUpdateNode should not be the target of local flow. |
+| test.cpp:522:24:522:25 | & ... [post update] | PostUpdateNode should not be the target of local flow. |
+| test.cpp:522:24:522:25 | & ... [post update] | PostUpdateNode should not be the target of local flow. |
+| test.cpp:522:25:522:25 | x [post update] | PostUpdateNode should not be the target of local flow. |
+| test.cpp:526:24:526:25 | & ... [post update] | PostUpdateNode should not be the target of local flow. |
+| test.cpp:526:24:526:25 | & ... [post update] | PostUpdateNode should not be the target of local flow. |
+| test.cpp:526:25:526:25 | y [post update] | PostUpdateNode should not be the target of local flow. |
 | true_upon_entry.cpp:9:7:9:7 | VariableAddress [post update] | PostUpdateNode should not be the target of local flow. |
 | true_upon_entry.cpp:10:12:10:12 | VariableAddress [post update] | PostUpdateNode should not be the target of local flow. |
 | true_upon_entry.cpp:10:27:10:27 | VariableAddress [post update] | PostUpdateNode should not be the target of local flow. |

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
@@ -506,12 +506,23 @@ void viaOutparamMissingReturn() {
   sink(x); // $ ast,ir
 }
 
-void sink_then_source(int* p) {
-    sink(*p);
-    *p = source(); // clean
+void sink_then_source_1(int* p) {
+    sink(*p); // clean
+    *p = source();
+}
+
+void sink_then_source_2(int* p, int y) {
+    sink(y); // $ SPURIOUS: ast
+    *p = source();
 }
 
 void test_sink_then_source() {
+  {
     int x;
-    sink_then_source(&x);
+    sink_then_source_1(&x);
+  }
+  {
+    int y;
+    sink_then_source_2(&y, y);
+  }
 }

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/uninitialized.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/uninitialized.expected
@@ -34,4 +34,6 @@
 | test.cpp:441:7:441:11 | local | test.cpp:442:18:442:22 | local |
 | test.cpp:441:7:441:11 | local | test.cpp:443:8:443:12 | local |
 | test.cpp:441:7:441:11 | local | test.cpp:444:9:444:13 | local |
-| test.cpp:515:9:515:9 | x | test.cpp:516:23:516:23 | x |
+| test.cpp:521:9:521:9 | x | test.cpp:522:25:522:25 | x |
+| test.cpp:525:9:525:9 | y | test.cpp:526:25:526:25 | y |
+| test.cpp:525:9:525:9 | y | test.cpp:526:28:526:28 | y |


### PR DESCRIPTION
Similar to https://github.com/github/codeql/pull/11963, but this one is actually looping with AST def-use dataflow.