### PR TITLE
C++: Don't count every conversion as a use

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -370,7 +370,7 @@ class ReturnIndirectionNode extends IndirectReturnNode, ReturnNode {
 private Operand fullyConvertedCallStep(Operand op) {
   not exists(getANonConversionUse(op)) and
   exists(Instruction instr |
-    conversionFlow(op, instr, _) and
+    conversionFlow(op, instr, _, _) and
     result = getAUse(instr)
   )
 }
@@ -397,7 +397,7 @@ Operand getAUse(Instruction instr) {
  */
 private Instruction getANonConversionUse(Operand operand) {
   result = getUse(operand) and
-  not conversionFlow(_, result, _)
+  not conversionFlow(_, result, _, _)
 }
 
 /**
@@ -555,7 +555,7 @@ private predicate numberOfLoadsFromOperandRec(Operand operandFrom, Operand opera
   or
   exists(Operand op, Instruction instr |
     instr = op.getDef() and
-    conversionFlow(operandFrom, instr, _) and
+    conversionFlow(operandFrom, instr, _, _) and
     numberOfLoadsFromOperand(op, operandTo, ind)
   )
 }
@@ -568,7 +568,7 @@ private predicate numberOfLoadsFromOperand(Operand operandFrom, Operand operandT
   numberOfLoadsFromOperandRec(operandFrom, operandTo, n)
   or
   not Ssa::isDereference(_, operandFrom) and
-  not conversionFlow(operandFrom, _, _) and
+  not conversionFlow(operandFrom, _, _, _) and
   operandFrom = operandTo and
   n = 0
 }

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -77,22 +77,32 @@ class FieldAddress extends Operand {
  *
  * `isPointerArith` is `true` if `instrTo` is a `PointerArithmeticInstruction` and `opFrom`
  * is the left operand.
+ *
+ * `additional` is `true` if the conversion is supplied by an implementation of the
+ * `Indirection` class. It is sometimes useful to exclude such conversions.
  */
-predicate conversionFlow(Operand opFrom, Instruction instrTo, boolean isPointerArith) {
+predicate conversionFlow(
+  Operand opFrom, Instruction instrTo, boolean isPointerArith, boolean additional
+) {
   isPointerArith = false and
   (
-    instrTo.(CopyValueInstruction).getSourceValueOperand() = opFrom
+    additional = false and
+    (
+      instrTo.(CopyValueInstruction).getSourceValueOperand() = opFrom
+      or
+      instrTo.(ConvertInstruction).getUnaryOperand() = opFrom
+      or
+      instrTo.(CheckedConvertOrNullInstruction).getUnaryOperand() = opFrom
+      or
+      instrTo.(InheritanceConversionInstruction).getUnaryOperand() = opFrom
+    )
     or
-    instrTo.(ConvertInstruction).getUnaryOperand() = opFrom
-    or
-    instrTo.(CheckedConvertOrNullInstruction).getUnaryOperand() = opFrom
-    or
-    instrTo.(InheritanceConversionInstruction).getUnaryOperand() = opFrom
-    or
+    additional = true and
     Ssa::isAdditionalConversionFlow(opFrom, instrTo)
   )
   or
   isPointerArith = true and
+  additional = false and
   instrTo.(PointerArithmeticInstruction).getLeftOperand() = opFrom
 }
 
@@ -1365,7 +1375,7 @@ private module Cached {
 
   private predicate simpleInstructionLocalFlowStep(Operand opFrom, Instruction iTo) {
     // Treat all conversions as flow, even conversions between different numeric types.
-    conversionFlow(opFrom, iTo, false)
+    conversionFlow(opFrom, iTo, false, _)
     or
     iTo.(CopyInstruction).getSourceValueOperand() = opFrom
   }

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
@@ -469,7 +469,7 @@ private predicate indirectConversionFlowStep(Node nFrom, Node nTo) {
     hasOperandAndIndex(nFrom, op1, pragma[only_bind_into](indirectionIndex)) and
     hasOperandAndIndex(nTo, op2, pragma[only_bind_into](indirectionIndex)) and
     instr = op2.getDef() and
-    conversionFlow(op1, instr, _)
+    conversionFlow(op1, instr, _, _)
   )
 }
 

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternalsCommon.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternalsCommon.qll
@@ -652,7 +652,7 @@ private module Cached {
     exists(Operand mid, Instruction instr |
       isUseImpl(mid, base, ind) and
       instr = operand.getDef() and
-      conversionFlow(mid, instr, false)
+      conversionFlow(mid, instr, false, _)
     )
     or
     exists(int ind0 |
@@ -722,7 +722,7 @@ private module Cached {
     exists(Operand mid, Instruction instr, boolean certain0, boolean isPointerArith |
       isDefImpl(mid, base, ind, certain0) and
       instr = operand.getDef() and
-      conversionFlow(mid, instr, isPointerArith) and
+      conversionFlow(mid, instr, isPointerArith, _) and
       if isPointerArith = true then certain = false else certain = certain0
     )
     or

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/clang.cpp
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/clang.cpp
@@ -48,5 +48,5 @@ void following_pointers(
 
   int stackArray[2] = { source(), source() };
   stackArray[0] = source();
-  sink(stackArray); // $ ast ir ir=49:35 ir=50:19
+  sink(stackArray); // $ ast ir
 }

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
@@ -533,12 +533,12 @@ void test_set_through_const_pointer(int *e)
 }
 
 void sink_then_source_1(int* p) {
-    sink(*p); // $ SPURIOUS: ir=537:10 ir=547:9
+    sink(*p); // $ ir // Flow from the unitialized x to the dereference.
     *p = source();
 }
 
 void sink_then_source_2(int* p, int y) {
-    sink(y); // $ SPURIOUS: ast ir=542:10 ir=551:9
+    sink(y); // $ SPURIOUS: ast ir
     *p = source();
 }
 

--- a/cpp/ql/test/library-tests/dataflow/fields/ir-path-flow.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/ir-path-flow.expected
@@ -13,8 +13,6 @@ edges
 | A.cpp:31:20:31:20 | c | A.cpp:31:14:31:21 | call to B [c] |
 | A.cpp:41:15:41:21 | new | A.cpp:43:10:43:12 | & ... indirection |
 | A.cpp:41:15:41:21 | new | A.cpp:43:10:43:12 | & ... indirection |
-| A.cpp:41:15:41:21 | new | A.cpp:43:10:43:12 | & ... indirection |
-| A.cpp:41:15:41:21 | new | A.cpp:43:10:43:12 | & ... indirection |
 | A.cpp:47:12:47:18 | new | A.cpp:48:20:48:20 | c |
 | A.cpp:48:12:48:18 | call to make indirection [c] | A.cpp:49:10:49:10 | b indirection [c] |
 | A.cpp:48:20:48:20 | c | A.cpp:29:23:29:23 | c |
@@ -907,7 +905,6 @@ nodes
 | A.cpp:41:15:41:21 | new | semmle.label | new |
 | A.cpp:41:15:41:21 | new | semmle.label | new |
 | A.cpp:43:10:43:12 | & ... indirection | semmle.label | & ... indirection |
-| A.cpp:43:10:43:12 | & ... indirection | semmle.label | & ... indirection |
 | A.cpp:47:12:47:18 | new | semmle.label | new |
 | A.cpp:48:12:48:18 | call to make indirection [c] | semmle.label | call to make indirection [c] |
 | A.cpp:48:20:48:20 | c | semmle.label | c |
@@ -1763,8 +1760,6 @@ subpaths
 | simple.cpp:42:12:42:21 | call to user_input | simple.cpp:21:19:21:19 | b | simple.cpp:21:24:21:25 | this indirection [post update] [b_] | simple.cpp:42:5:42:5 | setB output argument [b_] |
 | simple.cpp:84:14:84:20 | this indirection [f2, f1] | simple.cpp:78:9:78:15 | this indirection [f2, f1] | simple.cpp:78:9:78:15 | getf2f1 indirection | simple.cpp:84:14:84:20 | call to getf2f1 |
 #select
-| A.cpp:43:10:43:12 | & ... indirection | A.cpp:41:15:41:21 | new | A.cpp:43:10:43:12 | & ... indirection | & ... indirection flows from $@ | A.cpp:41:15:41:21 | new | new |
-| A.cpp:43:10:43:12 | & ... indirection | A.cpp:41:15:41:21 | new | A.cpp:43:10:43:12 | & ... indirection | & ... indirection flows from $@ | A.cpp:41:15:41:21 | new | new |
 | A.cpp:43:10:43:12 | & ... indirection | A.cpp:41:15:41:21 | new | A.cpp:43:10:43:12 | & ... indirection | & ... indirection flows from $@ | A.cpp:41:15:41:21 | new | new |
 | A.cpp:43:10:43:12 | & ... indirection | A.cpp:41:15:41:21 | new | A.cpp:43:10:43:12 | & ... indirection | & ... indirection flows from $@ | A.cpp:41:15:41:21 | new | new |
 | A.cpp:49:10:49:13 | c | A.cpp:47:12:47:18 | new | A.cpp:49:10:49:13 | c | c flows from $@ | A.cpp:47:12:47:18 | new | new |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-078/semmle/ExecTainted/ExecTainted.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-078/semmle/ExecTainted/ExecTainted.expected
@@ -41,57 +41,22 @@ edges
 | test.cpp:178:22:178:26 | (const char *)... indirection | test.cpp:178:13:178:19 | strncat output argument |
 | test.cpp:180:13:180:19 | strncat output argument | test.cpp:183:32:183:38 | array to pointer conversion indirection |
 | test.cpp:180:22:180:29 | (const char *)... indirection | test.cpp:180:13:180:19 | strncat output argument |
-| test.cpp:186:34:186:38 | flags | test.cpp:187:11:187:15 | strncat output argument |
-| test.cpp:186:34:186:38 | flags | test.cpp:187:11:187:15 | strncat output argument |
-| test.cpp:186:34:186:38 | flags | test.cpp:188:11:188:17 | strncat output argument |
-| test.cpp:186:34:186:38 | flags | test.cpp:188:20:188:24 | (const char *)... indirection |
-| test.cpp:186:34:186:38 | flags indirection | test.cpp:187:11:187:15 | strncat output argument |
-| test.cpp:186:34:186:38 | flags indirection | test.cpp:187:11:187:15 | strncat output argument |
-| test.cpp:186:34:186:38 | flags indirection | test.cpp:188:11:188:17 | strncat output argument |
-| test.cpp:186:34:186:38 | flags indirection | test.cpp:188:20:188:24 | (const char *)... indirection |
-| test.cpp:186:47:186:54 | filename | test.cpp:187:11:187:15 | strncat output argument |
 | test.cpp:186:47:186:54 | filename | test.cpp:188:20:188:24 | (const char *)... indirection |
-| test.cpp:186:47:186:54 | filename indirection | test.cpp:187:11:187:15 | strncat output argument |
 | test.cpp:186:47:186:54 | filename indirection | test.cpp:187:18:187:25 | (const char *)... indirection |
 | test.cpp:186:47:186:54 | filename indirection | test.cpp:188:20:188:24 | (const char *)... indirection |
 | test.cpp:187:11:187:15 | strncat output argument | test.cpp:188:11:188:17 | strncat output argument |
-| test.cpp:187:11:187:15 | strncat output argument | test.cpp:188:11:188:17 | strncat output argument |
-| test.cpp:187:11:187:15 | strncat output argument | test.cpp:188:11:188:17 | strncat output argument |
-| test.cpp:187:11:187:15 | strncat output argument | test.cpp:188:20:188:24 | (const char *)... indirection |
-| test.cpp:187:11:187:15 | strncat output argument | test.cpp:188:20:188:24 | (const char *)... indirection |
-| test.cpp:187:11:187:15 | strncat output argument | test.cpp:188:20:188:24 | (const char *)... indirection |
-| test.cpp:187:11:187:15 | strncat output argument | test.cpp:188:20:188:24 | (const char *)... indirection |
 | test.cpp:187:18:187:25 | (const char *)... indirection | test.cpp:187:11:187:15 | strncat output argument |
-| test.cpp:188:20:188:24 | (const char *)... indirection | test.cpp:188:11:188:17 | strncat output argument |
-| test.cpp:188:20:188:24 | (const char *)... indirection | test.cpp:188:11:188:17 | strncat output argument |
 | test.cpp:188:20:188:24 | (const char *)... indirection | test.cpp:188:11:188:17 | strncat output argument |
 | test.cpp:188:20:188:24 | (const char *)... indirection | test.cpp:188:11:188:17 | strncat output argument |
 | test.cpp:194:9:194:16 | fread output argument | test.cpp:196:26:196:33 | array to pointer conversion indirection |
 | test.cpp:194:9:194:16 | fread output argument | test.cpp:196:26:196:33 | filename |
 | test.cpp:196:10:196:16 | concat output argument | test.cpp:198:32:198:38 | array to pointer conversion indirection |
 | test.cpp:196:10:196:16 | concat output argument | test.cpp:198:32:198:38 | array to pointer conversion indirection |
-| test.cpp:196:19:196:23 | array to pointer conversion indirection | test.cpp:186:34:186:38 | flags indirection |
-| test.cpp:196:19:196:23 | array to pointer conversion indirection | test.cpp:186:34:186:38 | flags indirection |
-| test.cpp:196:19:196:23 | array to pointer conversion indirection | test.cpp:196:10:196:16 | concat output argument |
-| test.cpp:196:19:196:23 | array to pointer conversion indirection | test.cpp:196:10:196:16 | concat output argument |
-| test.cpp:196:19:196:23 | concat output argument | test.cpp:196:19:196:23 | array to pointer conversion indirection |
-| test.cpp:196:19:196:23 | concat output argument | test.cpp:196:19:196:23 | array to pointer conversion indirection |
-| test.cpp:196:19:196:23 | concat output argument | test.cpp:196:19:196:23 | flags |
-| test.cpp:196:19:196:23 | concat output argument | test.cpp:196:19:196:23 | flags |
-| test.cpp:196:19:196:23 | flags | test.cpp:186:34:186:38 | flags |
-| test.cpp:196:19:196:23 | flags | test.cpp:186:34:186:38 | flags |
-| test.cpp:196:19:196:23 | flags | test.cpp:196:10:196:16 | concat output argument |
-| test.cpp:196:19:196:23 | flags | test.cpp:196:10:196:16 | concat output argument |
-| test.cpp:196:19:196:23 | flags | test.cpp:196:19:196:23 | concat output argument |
-| test.cpp:196:19:196:23 | flags | test.cpp:196:19:196:23 | concat output argument |
 | test.cpp:196:26:196:33 | array to pointer conversion indirection | test.cpp:186:47:186:54 | filename indirection |
 | test.cpp:196:26:196:33 | array to pointer conversion indirection | test.cpp:196:10:196:16 | concat output argument |
 | test.cpp:196:26:196:33 | array to pointer conversion indirection | test.cpp:196:10:196:16 | concat output argument |
-| test.cpp:196:26:196:33 | array to pointer conversion indirection | test.cpp:196:19:196:23 | concat output argument |
-| test.cpp:196:26:196:33 | array to pointer conversion indirection | test.cpp:196:19:196:23 | concat output argument |
 | test.cpp:196:26:196:33 | filename | test.cpp:186:47:186:54 | filename |
 | test.cpp:196:26:196:33 | filename | test.cpp:196:10:196:16 | concat output argument |
-| test.cpp:196:26:196:33 | filename | test.cpp:196:19:196:23 | concat output argument |
 | test.cpp:218:9:218:16 | fread output argument | test.cpp:220:19:220:26 | (const char *)... indirection |
 | test.cpp:218:9:218:16 | fread output argument | test.cpp:220:19:220:26 | (const char *)... indirection |
 | test.cpp:220:10:220:16 | strncat output argument | test.cpp:222:32:222:38 | array to pointer conversion indirection |
@@ -153,40 +118,18 @@ nodes
 | test.cpp:183:32:183:38 | array to pointer conversion indirection | semmle.label | array to pointer conversion indirection |
 | test.cpp:183:32:183:38 | array to pointer conversion indirection | semmle.label | array to pointer conversion indirection |
 | test.cpp:183:32:183:38 | array to pointer conversion indirection | semmle.label | array to pointer conversion indirection |
-| test.cpp:186:34:186:38 | flags | semmle.label | flags |
-| test.cpp:186:34:186:38 | flags | semmle.label | flags |
-| test.cpp:186:34:186:38 | flags indirection | semmle.label | flags indirection |
-| test.cpp:186:34:186:38 | flags indirection | semmle.label | flags indirection |
 | test.cpp:186:47:186:54 | filename | semmle.label | filename |
 | test.cpp:186:47:186:54 | filename indirection | semmle.label | filename indirection |
-| test.cpp:187:11:187:15 | strncat output argument | semmle.label | strncat output argument |
-| test.cpp:187:11:187:15 | strncat output argument | semmle.label | strncat output argument |
-| test.cpp:187:11:187:15 | strncat output argument | semmle.label | strncat output argument |
-| test.cpp:187:11:187:15 | strncat output argument | semmle.label | strncat output argument |
-| test.cpp:187:11:187:15 | strncat output argument | semmle.label | strncat output argument |
-| test.cpp:187:11:187:15 | strncat output argument | semmle.label | strncat output argument |
 | test.cpp:187:11:187:15 | strncat output argument | semmle.label | strncat output argument |
 | test.cpp:187:18:187:25 | (const char *)... indirection | semmle.label | (const char *)... indirection |
 | test.cpp:188:11:188:17 | strncat output argument | semmle.label | strncat output argument |
 | test.cpp:188:11:188:17 | strncat output argument | semmle.label | strncat output argument |
 | test.cpp:188:11:188:17 | strncat output argument | semmle.label | strncat output argument |
-| test.cpp:188:11:188:17 | strncat output argument | semmle.label | strncat output argument |
-| test.cpp:188:11:188:17 | strncat output argument | semmle.label | strncat output argument |
-| test.cpp:188:11:188:17 | strncat output argument | semmle.label | strncat output argument |
-| test.cpp:188:11:188:17 | strncat output argument | semmle.label | strncat output argument |
-| test.cpp:188:20:188:24 | (const char *)... indirection | semmle.label | (const char *)... indirection |
-| test.cpp:188:20:188:24 | (const char *)... indirection | semmle.label | (const char *)... indirection |
 | test.cpp:188:20:188:24 | (const char *)... indirection | semmle.label | (const char *)... indirection |
 | test.cpp:188:20:188:24 | (const char *)... indirection | semmle.label | (const char *)... indirection |
 | test.cpp:194:9:194:16 | fread output argument | semmle.label | fread output argument |
 | test.cpp:196:10:196:16 | concat output argument | semmle.label | concat output argument |
 | test.cpp:196:10:196:16 | concat output argument | semmle.label | concat output argument |
-| test.cpp:196:19:196:23 | array to pointer conversion indirection | semmle.label | array to pointer conversion indirection |
-| test.cpp:196:19:196:23 | array to pointer conversion indirection | semmle.label | array to pointer conversion indirection |
-| test.cpp:196:19:196:23 | concat output argument | semmle.label | concat output argument |
-| test.cpp:196:19:196:23 | concat output argument | semmle.label | concat output argument |
-| test.cpp:196:19:196:23 | flags | semmle.label | flags |
-| test.cpp:196:19:196:23 | flags | semmle.label | flags |
 | test.cpp:196:26:196:33 | array to pointer conversion indirection | semmle.label | array to pointer conversion indirection |
 | test.cpp:196:26:196:33 | filename | semmle.label | filename |
 | test.cpp:198:32:198:38 | array to pointer conversion indirection | semmle.label | array to pointer conversion indirection |
@@ -198,17 +141,8 @@ nodes
 | test.cpp:220:19:220:26 | (const char *)... indirection | semmle.label | (const char *)... indirection |
 | test.cpp:222:32:222:38 | array to pointer conversion indirection | semmle.label | array to pointer conversion indirection |
 subpaths
-| test.cpp:196:19:196:23 | array to pointer conversion indirection | test.cpp:186:34:186:38 | flags indirection | test.cpp:188:11:188:17 | strncat output argument | test.cpp:196:10:196:16 | concat output argument |
-| test.cpp:196:19:196:23 | array to pointer conversion indirection | test.cpp:186:34:186:38 | flags indirection | test.cpp:188:11:188:17 | strncat output argument | test.cpp:196:10:196:16 | concat output argument |
-| test.cpp:196:19:196:23 | flags | test.cpp:186:34:186:38 | flags | test.cpp:187:11:187:15 | strncat output argument | test.cpp:196:19:196:23 | concat output argument |
-| test.cpp:196:19:196:23 | flags | test.cpp:186:34:186:38 | flags | test.cpp:187:11:187:15 | strncat output argument | test.cpp:196:19:196:23 | concat output argument |
-| test.cpp:196:19:196:23 | flags | test.cpp:186:34:186:38 | flags | test.cpp:188:11:188:17 | strncat output argument | test.cpp:196:10:196:16 | concat output argument |
-| test.cpp:196:19:196:23 | flags | test.cpp:186:34:186:38 | flags | test.cpp:188:11:188:17 | strncat output argument | test.cpp:196:10:196:16 | concat output argument |
-| test.cpp:196:26:196:33 | array to pointer conversion indirection | test.cpp:186:47:186:54 | filename indirection | test.cpp:187:11:187:15 | strncat output argument | test.cpp:196:19:196:23 | concat output argument |
-| test.cpp:196:26:196:33 | array to pointer conversion indirection | test.cpp:186:47:186:54 | filename indirection | test.cpp:187:11:187:15 | strncat output argument | test.cpp:196:19:196:23 | concat output argument |
 | test.cpp:196:26:196:33 | array to pointer conversion indirection | test.cpp:186:47:186:54 | filename indirection | test.cpp:188:11:188:17 | strncat output argument | test.cpp:196:10:196:16 | concat output argument |
 | test.cpp:196:26:196:33 | array to pointer conversion indirection | test.cpp:186:47:186:54 | filename indirection | test.cpp:188:11:188:17 | strncat output argument | test.cpp:196:10:196:16 | concat output argument |
-| test.cpp:196:26:196:33 | filename | test.cpp:186:47:186:54 | filename | test.cpp:187:11:187:15 | strncat output argument | test.cpp:196:19:196:23 | concat output argument |
 | test.cpp:196:26:196:33 | filename | test.cpp:186:47:186:54 | filename | test.cpp:188:11:188:17 | strncat output argument | test.cpp:196:10:196:16 | concat output argument |
 #select
 | test.cpp:23:12:23:19 | command1 | test.cpp:15:27:15:30 | argv indirection | test.cpp:23:12:23:19 | (const char *)... indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to system(string). | test.cpp:15:27:15:30 | argv indirection | user input (a command-line argument) | test.cpp:22:13:22:20 | sprintf output argument | sprintf output argument |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-089/SqlTainted/SqlTainted.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-089/SqlTainted/SqlTainted.expected
@@ -3,10 +3,6 @@ edges
 | test.c:15:20:15:23 | argv | test.c:21:18:21:23 | query1 |
 | test.c:15:20:15:23 | argv | test.c:21:18:21:23 | query1 |
 | test.c:15:20:15:23 | argv | test.c:21:18:21:23 | query1 |
-| test.c:15:20:15:23 | argv | test.c:21:18:21:23 | query1 |
-| test.c:15:20:15:23 | argv | test.c:21:18:21:23 | query1 |
-| test.c:15:20:15:23 | argv | test.c:21:18:21:23 | query1 |
-| test.c:15:20:15:23 | argv | test.c:21:18:21:23 | query1 |
 | test.cpp:43:27:43:30 | argv | test.cpp:43:27:43:33 | access to array |
 | test.cpp:43:27:43:30 | argv | test.cpp:43:27:43:33 | access to array |
 | test.cpp:43:27:43:30 | argv | test.cpp:43:27:43:33 | access to array |
@@ -17,8 +13,6 @@ subpaths
 nodes
 | test.c:15:20:15:23 | argv | semmle.label | argv |
 | test.c:15:20:15:23 | argv | semmle.label | argv |
-| test.c:21:18:21:23 | query1 | semmle.label | query1 |
-| test.c:21:18:21:23 | query1 | semmle.label | query1 |
 | test.c:21:18:21:23 | query1 | semmle.label | query1 |
 | test.c:21:18:21:23 | query1 | semmle.label | query1 |
 | test.cpp:43:27:43:30 | argv | semmle.label | argv |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-114/semmle/UncontrolledProcessOperation/UncontrolledProcessOperation.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-114/semmle/UncontrolledProcessOperation/UncontrolledProcessOperation.expected
@@ -11,10 +11,6 @@ edges
 | test.cpp:56:12:56:17 | buffer | test.cpp:62:10:62:15 | buffer |
 | test.cpp:56:12:56:17 | buffer | test.cpp:62:10:62:15 | buffer |
 | test.cpp:56:12:56:17 | buffer | test.cpp:62:10:62:15 | buffer |
-| test.cpp:56:12:56:17 | buffer | test.cpp:62:10:62:15 | buffer |
-| test.cpp:56:12:56:17 | buffer | test.cpp:62:10:62:15 | buffer |
-| test.cpp:56:12:56:17 | buffer | test.cpp:62:10:62:15 | buffer |
-| test.cpp:56:12:56:17 | buffer | test.cpp:62:10:62:15 | buffer |
 | test.cpp:56:12:56:17 | buffer | test.cpp:63:10:63:13 | data |
 | test.cpp:56:12:56:17 | buffer | test.cpp:63:10:63:13 | data |
 | test.cpp:56:12:56:17 | buffer | test.cpp:63:10:63:13 | data |
@@ -35,8 +31,6 @@ edges
 | test.cpp:56:12:56:17 | buffer | test.cpp:65:10:65:14 | data2 |
 | test.cpp:56:12:56:17 | buffer | test.cpp:65:10:65:14 | data2 |
 | test.cpp:56:12:56:17 | buffer | test.cpp:65:10:65:14 | data2 |
-| test.cpp:56:12:56:17 | fgets output argument | test.cpp:62:10:62:15 | buffer |
-| test.cpp:56:12:56:17 | fgets output argument | test.cpp:62:10:62:15 | buffer |
 | test.cpp:56:12:56:17 | fgets output argument | test.cpp:62:10:62:15 | buffer |
 | test.cpp:56:12:56:17 | fgets output argument | test.cpp:62:10:62:15 | buffer |
 | test.cpp:56:12:56:17 | fgets output argument | test.cpp:63:10:63:13 | data |
@@ -53,36 +47,18 @@ edges
 | test.cpp:76:12:76:17 | buffer | test.cpp:78:10:78:15 | buffer |
 | test.cpp:76:12:76:17 | buffer | test.cpp:78:10:78:15 | buffer |
 | test.cpp:76:12:76:17 | buffer | test.cpp:78:10:78:15 | buffer |
-| test.cpp:76:12:76:17 | buffer | test.cpp:78:10:78:15 | buffer |
-| test.cpp:76:12:76:17 | buffer | test.cpp:78:10:78:15 | buffer |
-| test.cpp:76:12:76:17 | buffer | test.cpp:78:10:78:15 | buffer |
-| test.cpp:76:12:76:17 | buffer | test.cpp:78:10:78:15 | buffer |
-| test.cpp:76:12:76:17 | fgets output argument | test.cpp:78:10:78:15 | buffer |
-| test.cpp:76:12:76:17 | fgets output argument | test.cpp:78:10:78:15 | buffer |
 | test.cpp:76:12:76:17 | fgets output argument | test.cpp:78:10:78:15 | buffer |
 | test.cpp:76:12:76:17 | fgets output argument | test.cpp:78:10:78:15 | buffer |
 | test.cpp:98:17:98:22 | buffer | test.cpp:99:15:99:20 | buffer |
 | test.cpp:98:17:98:22 | buffer | test.cpp:99:15:99:20 | buffer |
 | test.cpp:98:17:98:22 | buffer | test.cpp:99:15:99:20 | buffer |
 | test.cpp:98:17:98:22 | buffer | test.cpp:99:15:99:20 | buffer |
-| test.cpp:98:17:98:22 | buffer | test.cpp:99:15:99:20 | buffer |
-| test.cpp:98:17:98:22 | buffer | test.cpp:99:15:99:20 | buffer |
-| test.cpp:98:17:98:22 | buffer | test.cpp:99:15:99:20 | buffer |
-| test.cpp:98:17:98:22 | buffer | test.cpp:99:15:99:20 | buffer |
-| test.cpp:98:17:98:22 | recv output argument | test.cpp:99:15:99:20 | buffer |
-| test.cpp:98:17:98:22 | recv output argument | test.cpp:99:15:99:20 | buffer |
 | test.cpp:98:17:98:22 | recv output argument | test.cpp:99:15:99:20 | buffer |
 | test.cpp:98:17:98:22 | recv output argument | test.cpp:99:15:99:20 | buffer |
 | test.cpp:106:17:106:22 | buffer | test.cpp:107:15:107:20 | buffer |
 | test.cpp:106:17:106:22 | buffer | test.cpp:107:15:107:20 | buffer |
 | test.cpp:106:17:106:22 | buffer | test.cpp:107:15:107:20 | buffer |
 | test.cpp:106:17:106:22 | buffer | test.cpp:107:15:107:20 | buffer |
-| test.cpp:106:17:106:22 | buffer | test.cpp:107:15:107:20 | buffer |
-| test.cpp:106:17:106:22 | buffer | test.cpp:107:15:107:20 | buffer |
-| test.cpp:106:17:106:22 | buffer | test.cpp:107:15:107:20 | buffer |
-| test.cpp:106:17:106:22 | buffer | test.cpp:107:15:107:20 | buffer |
-| test.cpp:106:17:106:22 | recv output argument | test.cpp:107:15:107:20 | buffer |
-| test.cpp:106:17:106:22 | recv output argument | test.cpp:107:15:107:20 | buffer |
 | test.cpp:106:17:106:22 | recv output argument | test.cpp:107:15:107:20 | buffer |
 | test.cpp:106:17:106:22 | recv output argument | test.cpp:107:15:107:20 | buffer |
 subpaths
@@ -102,8 +78,6 @@ nodes
 | test.cpp:56:12:56:17 | fgets output argument | semmle.label | fgets output argument |
 | test.cpp:62:10:62:15 | buffer | semmle.label | buffer |
 | test.cpp:62:10:62:15 | buffer | semmle.label | buffer |
-| test.cpp:62:10:62:15 | buffer | semmle.label | buffer |
-| test.cpp:62:10:62:15 | buffer | semmle.label | buffer |
 | test.cpp:63:10:63:13 | data | semmle.label | data |
 | test.cpp:63:10:63:13 | data | semmle.label | data |
 | test.cpp:63:10:63:13 | data | semmle.label | data |
@@ -119,20 +93,14 @@ nodes
 | test.cpp:76:12:76:17 | fgets output argument | semmle.label | fgets output argument |
 | test.cpp:78:10:78:15 | buffer | semmle.label | buffer |
 | test.cpp:78:10:78:15 | buffer | semmle.label | buffer |
-| test.cpp:78:10:78:15 | buffer | semmle.label | buffer |
-| test.cpp:78:10:78:15 | buffer | semmle.label | buffer |
 | test.cpp:98:17:98:22 | buffer | semmle.label | buffer |
 | test.cpp:98:17:98:22 | buffer | semmle.label | buffer |
 | test.cpp:98:17:98:22 | recv output argument | semmle.label | recv output argument |
 | test.cpp:99:15:99:20 | buffer | semmle.label | buffer |
 | test.cpp:99:15:99:20 | buffer | semmle.label | buffer |
-| test.cpp:99:15:99:20 | buffer | semmle.label | buffer |
-| test.cpp:99:15:99:20 | buffer | semmle.label | buffer |
 | test.cpp:106:17:106:22 | buffer | semmle.label | buffer |
 | test.cpp:106:17:106:22 | buffer | semmle.label | buffer |
 | test.cpp:106:17:106:22 | recv output argument | semmle.label | recv output argument |
-| test.cpp:107:15:107:20 | buffer | semmle.label | buffer |
-| test.cpp:107:15:107:20 | buffer | semmle.label | buffer |
 | test.cpp:107:15:107:20 | buffer | semmle.label | buffer |
 | test.cpp:107:15:107:20 | buffer | semmle.label | buffer |
 #select

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-119/semmle/tests/OverflowDestination.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-119/semmle/tests/OverflowDestination.expected
@@ -12,65 +12,24 @@ edges
 | overflowdestination.cpp:23:45:23:48 | argv indirection | overflowdestination.cpp:30:17:30:20 | arg1 |
 | overflowdestination.cpp:23:45:23:48 | argv indirection | overflowdestination.cpp:30:17:30:20 | arg1 |
 | overflowdestination.cpp:43:8:43:10 | fgets output argument | overflowdestination.cpp:46:15:46:17 | src |
-| overflowdestination.cpp:50:52:50:54 | src | overflowdestination.cpp:52:9:52:12 | memcpy output argument |
 | overflowdestination.cpp:50:52:50:54 | src | overflowdestination.cpp:53:9:53:12 | memcpy output argument |
 | overflowdestination.cpp:50:52:50:54 | src | overflowdestination.cpp:53:15:53:17 | src |
 | overflowdestination.cpp:50:52:50:54 | src | overflowdestination.cpp:54:9:54:12 | memcpy output argument |
-| overflowdestination.cpp:50:52:50:54 | src indirection | overflowdestination.cpp:52:9:52:12 | memcpy output argument |
-| overflowdestination.cpp:50:52:50:54 | src indirection | overflowdestination.cpp:53:9:53:12 | memcpy output argument |
 | overflowdestination.cpp:50:52:50:54 | src indirection | overflowdestination.cpp:53:15:53:17 | src |
-| overflowdestination.cpp:50:52:50:54 | src indirection | overflowdestination.cpp:54:9:54:12 | memcpy output argument |
-| overflowdestination.cpp:52:9:52:12 | memcpy output argument | overflowdestination.cpp:54:9:54:12 | memcpy output argument |
-| overflowdestination.cpp:52:9:52:12 | memcpy output argument | overflowdestination.cpp:54:9:54:12 | memcpy output argument |
 | overflowdestination.cpp:53:9:53:12 | memcpy output argument | overflowdestination.cpp:54:9:54:12 | memcpy output argument |
-| overflowdestination.cpp:53:9:53:12 | memcpy output argument | overflowdestination.cpp:54:9:54:12 | memcpy output argument |
-| overflowdestination.cpp:54:9:54:12 | memcpy output argument | overflowdestination.cpp:54:9:54:12 | memcpy output argument |
-| overflowdestination.cpp:54:9:54:12 | memcpy output argument | overflowdestination.cpp:54:9:54:12 | memcpy output argument |
-| overflowdestination.cpp:57:40:57:43 | dest | overflowdestination.cpp:65:9:65:13 | memcpy output argument |
-| overflowdestination.cpp:57:40:57:43 | dest indirection | overflowdestination.cpp:65:9:65:13 | memcpy output argument |
-| overflowdestination.cpp:57:52:57:54 | src | overflowdestination.cpp:63:9:63:13 | memcpy output argument |
-| overflowdestination.cpp:57:52:57:54 | src | overflowdestination.cpp:64:9:64:13 | memcpy output argument |
 | overflowdestination.cpp:57:52:57:54 | src | overflowdestination.cpp:64:16:64:19 | src2 |
-| overflowdestination.cpp:57:52:57:54 | src | overflowdestination.cpp:65:9:65:13 | memcpy output argument |
-| overflowdestination.cpp:57:52:57:54 | src indirection | overflowdestination.cpp:63:9:63:13 | memcpy output argument |
-| overflowdestination.cpp:57:52:57:54 | src indirection | overflowdestination.cpp:64:9:64:13 | memcpy output argument |
 | overflowdestination.cpp:57:52:57:54 | src indirection | overflowdestination.cpp:64:16:64:19 | src2 |
-| overflowdestination.cpp:57:52:57:54 | src indirection | overflowdestination.cpp:65:9:65:13 | memcpy output argument |
-| overflowdestination.cpp:63:9:63:13 | memcpy output argument | overflowdestination.cpp:65:9:65:13 | memcpy output argument |
-| overflowdestination.cpp:63:9:63:13 | memcpy output argument | overflowdestination.cpp:65:9:65:13 | memcpy output argument |
-| overflowdestination.cpp:64:9:64:13 | memcpy output argument | overflowdestination.cpp:65:9:65:13 | memcpy output argument |
-| overflowdestination.cpp:64:9:64:13 | memcpy output argument | overflowdestination.cpp:65:9:65:13 | memcpy output argument |
-| overflowdestination.cpp:65:9:65:13 | memcpy output argument | overflowdestination.cpp:65:9:65:13 | memcpy output argument |
-| overflowdestination.cpp:65:9:65:13 | memcpy output argument | overflowdestination.cpp:65:9:65:13 | memcpy output argument |
-| overflowdestination.cpp:65:9:65:13 | memcpy output argument | overflowdestination.cpp:65:9:65:13 | memcpy output argument |
-| overflowdestination.cpp:65:9:65:13 | memcpy output argument | overflowdestination.cpp:65:9:65:13 | memcpy output argument |
 | overflowdestination.cpp:73:8:73:10 | fgets output argument | overflowdestination.cpp:75:30:75:32 | array to pointer conversion indirection |
 | overflowdestination.cpp:73:8:73:10 | fgets output argument | overflowdestination.cpp:75:30:75:32 | src |
 | overflowdestination.cpp:73:8:73:10 | fgets output argument | overflowdestination.cpp:76:30:76:32 | array to pointer conversion indirection |
 | overflowdestination.cpp:73:8:73:10 | fgets output argument | overflowdestination.cpp:76:30:76:32 | src |
-| overflowdestination.cpp:75:24:75:27 | overflowdest_test2 output argument | overflowdestination.cpp:76:24:76:27 | array to pointer conversion indirection |
-| overflowdestination.cpp:75:24:75:27 | overflowdest_test2 output argument | overflowdestination.cpp:76:24:76:27 | dest |
 | overflowdestination.cpp:75:30:75:32 | array to pointer conversion indirection | overflowdestination.cpp:50:52:50:54 | src indirection |
-| overflowdestination.cpp:75:30:75:32 | array to pointer conversion indirection | overflowdestination.cpp:75:24:75:27 | overflowdest_test2 output argument |
 | overflowdestination.cpp:75:30:75:32 | overflowdest_test2 output argument | overflowdestination.cpp:76:30:76:32 | array to pointer conversion indirection |
 | overflowdestination.cpp:75:30:75:32 | overflowdest_test2 output argument | overflowdestination.cpp:76:30:76:32 | src |
 | overflowdestination.cpp:75:30:75:32 | src | overflowdestination.cpp:50:52:50:54 | src |
-| overflowdestination.cpp:75:30:75:32 | src | overflowdestination.cpp:75:24:75:27 | overflowdest_test2 output argument |
 | overflowdestination.cpp:75:30:75:32 | src | overflowdestination.cpp:75:30:75:32 | overflowdest_test2 output argument |
-| overflowdestination.cpp:76:24:76:27 | array to pointer conversion indirection | overflowdestination.cpp:57:40:57:43 | dest indirection |
-| overflowdestination.cpp:76:24:76:27 | array to pointer conversion indirection | overflowdestination.cpp:76:30:76:32 | overflowdest_test3 output argument |
-| overflowdestination.cpp:76:24:76:27 | dest | overflowdestination.cpp:57:40:57:43 | dest |
-| overflowdestination.cpp:76:24:76:27 | dest | overflowdestination.cpp:76:24:76:27 | overflowdest_test3 output argument |
-| overflowdestination.cpp:76:24:76:27 | dest | overflowdestination.cpp:76:30:76:32 | overflowdest_test3 output argument |
-| overflowdestination.cpp:76:24:76:27 | overflowdest_test3 output argument | overflowdestination.cpp:76:24:76:27 | array to pointer conversion indirection |
-| overflowdestination.cpp:76:24:76:27 | overflowdest_test3 output argument | overflowdestination.cpp:76:24:76:27 | dest |
 | overflowdestination.cpp:76:30:76:32 | array to pointer conversion indirection | overflowdestination.cpp:57:52:57:54 | src indirection |
-| overflowdestination.cpp:76:30:76:32 | array to pointer conversion indirection | overflowdestination.cpp:76:24:76:27 | overflowdest_test3 output argument |
-| overflowdestination.cpp:76:30:76:32 | overflowdest_test3 output argument | overflowdestination.cpp:76:30:76:32 | array to pointer conversion indirection |
-| overflowdestination.cpp:76:30:76:32 | overflowdest_test3 output argument | overflowdestination.cpp:76:30:76:32 | src |
 | overflowdestination.cpp:76:30:76:32 | src | overflowdestination.cpp:57:52:57:54 | src |
-| overflowdestination.cpp:76:30:76:32 | src | overflowdestination.cpp:76:24:76:27 | overflowdest_test3 output argument |
-| overflowdestination.cpp:76:30:76:32 | src | overflowdestination.cpp:76:30:76:32 | overflowdest_test3 output argument |
 nodes
 | main.cpp:6:27:6:30 | argv | semmle.label | argv |
 | main.cpp:6:27:6:30 | argv indirection | semmle.label | argv indirection |
@@ -86,57 +45,21 @@ nodes
 | overflowdestination.cpp:46:15:46:17 | src | semmle.label | src |
 | overflowdestination.cpp:50:52:50:54 | src | semmle.label | src |
 | overflowdestination.cpp:50:52:50:54 | src indirection | semmle.label | src indirection |
-| overflowdestination.cpp:52:9:52:12 | memcpy output argument | semmle.label | memcpy output argument |
-| overflowdestination.cpp:52:9:52:12 | memcpy output argument | semmle.label | memcpy output argument |
-| overflowdestination.cpp:53:9:53:12 | memcpy output argument | semmle.label | memcpy output argument |
 | overflowdestination.cpp:53:9:53:12 | memcpy output argument | semmle.label | memcpy output argument |
 | overflowdestination.cpp:53:15:53:17 | src | semmle.label | src |
 | overflowdestination.cpp:54:9:54:12 | memcpy output argument | semmle.label | memcpy output argument |
-| overflowdestination.cpp:54:9:54:12 | memcpy output argument | semmle.label | memcpy output argument |
-| overflowdestination.cpp:57:40:57:43 | dest | semmle.label | dest |
-| overflowdestination.cpp:57:40:57:43 | dest indirection | semmle.label | dest indirection |
 | overflowdestination.cpp:57:52:57:54 | src | semmle.label | src |
 | overflowdestination.cpp:57:52:57:54 | src indirection | semmle.label | src indirection |
-| overflowdestination.cpp:63:9:63:13 | memcpy output argument | semmle.label | memcpy output argument |
-| overflowdestination.cpp:63:9:63:13 | memcpy output argument | semmle.label | memcpy output argument |
-| overflowdestination.cpp:64:9:64:13 | memcpy output argument | semmle.label | memcpy output argument |
-| overflowdestination.cpp:64:9:64:13 | memcpy output argument | semmle.label | memcpy output argument |
 | overflowdestination.cpp:64:16:64:19 | src2 | semmle.label | src2 |
-| overflowdestination.cpp:65:9:65:13 | memcpy output argument | semmle.label | memcpy output argument |
-| overflowdestination.cpp:65:9:65:13 | memcpy output argument | semmle.label | memcpy output argument |
-| overflowdestination.cpp:65:9:65:13 | memcpy output argument | semmle.label | memcpy output argument |
-| overflowdestination.cpp:65:9:65:13 | memcpy output argument | semmle.label | memcpy output argument |
 | overflowdestination.cpp:73:8:73:10 | fgets output argument | semmle.label | fgets output argument |
-| overflowdestination.cpp:75:24:75:27 | overflowdest_test2 output argument | semmle.label | overflowdest_test2 output argument |
 | overflowdestination.cpp:75:30:75:32 | array to pointer conversion indirection | semmle.label | array to pointer conversion indirection |
 | overflowdestination.cpp:75:30:75:32 | overflowdest_test2 output argument | semmle.label | overflowdest_test2 output argument |
 | overflowdestination.cpp:75:30:75:32 | src | semmle.label | src |
-| overflowdestination.cpp:76:24:76:27 | array to pointer conversion indirection | semmle.label | array to pointer conversion indirection |
-| overflowdestination.cpp:76:24:76:27 | dest | semmle.label | dest |
-| overflowdestination.cpp:76:24:76:27 | overflowdest_test3 output argument | semmle.label | overflowdest_test3 output argument |
 | overflowdestination.cpp:76:30:76:32 | array to pointer conversion indirection | semmle.label | array to pointer conversion indirection |
-| overflowdestination.cpp:76:30:76:32 | overflowdest_test3 output argument | semmle.label | overflowdest_test3 output argument |
 | overflowdestination.cpp:76:30:76:32 | src | semmle.label | src |
 subpaths
-| overflowdestination.cpp:75:30:75:32 | array to pointer conversion indirection | overflowdestination.cpp:50:52:50:54 | src indirection | overflowdestination.cpp:52:9:52:12 | memcpy output argument | overflowdestination.cpp:75:24:75:27 | overflowdest_test2 output argument |
-| overflowdestination.cpp:75:30:75:32 | array to pointer conversion indirection | overflowdestination.cpp:50:52:50:54 | src indirection | overflowdestination.cpp:53:9:53:12 | memcpy output argument | overflowdestination.cpp:75:24:75:27 | overflowdest_test2 output argument |
-| overflowdestination.cpp:75:30:75:32 | array to pointer conversion indirection | overflowdestination.cpp:50:52:50:54 | src indirection | overflowdestination.cpp:54:9:54:12 | memcpy output argument | overflowdestination.cpp:75:24:75:27 | overflowdest_test2 output argument |
-| overflowdestination.cpp:75:30:75:32 | src | overflowdestination.cpp:50:52:50:54 | src | overflowdestination.cpp:52:9:52:12 | memcpy output argument | overflowdestination.cpp:75:24:75:27 | overflowdest_test2 output argument |
-| overflowdestination.cpp:75:30:75:32 | src | overflowdestination.cpp:50:52:50:54 | src | overflowdestination.cpp:53:9:53:12 | memcpy output argument | overflowdestination.cpp:75:24:75:27 | overflowdest_test2 output argument |
 | overflowdestination.cpp:75:30:75:32 | src | overflowdestination.cpp:50:52:50:54 | src | overflowdestination.cpp:53:9:53:12 | memcpy output argument | overflowdestination.cpp:75:30:75:32 | overflowdest_test2 output argument |
-| overflowdestination.cpp:75:30:75:32 | src | overflowdestination.cpp:50:52:50:54 | src | overflowdestination.cpp:54:9:54:12 | memcpy output argument | overflowdestination.cpp:75:24:75:27 | overflowdest_test2 output argument |
 | overflowdestination.cpp:75:30:75:32 | src | overflowdestination.cpp:50:52:50:54 | src | overflowdestination.cpp:54:9:54:12 | memcpy output argument | overflowdestination.cpp:75:30:75:32 | overflowdest_test2 output argument |
-| overflowdestination.cpp:76:24:76:27 | array to pointer conversion indirection | overflowdestination.cpp:57:40:57:43 | dest indirection | overflowdestination.cpp:65:9:65:13 | memcpy output argument | overflowdestination.cpp:76:30:76:32 | overflowdest_test3 output argument |
-| overflowdestination.cpp:76:24:76:27 | dest | overflowdestination.cpp:57:40:57:43 | dest | overflowdestination.cpp:65:9:65:13 | memcpy output argument | overflowdestination.cpp:76:24:76:27 | overflowdest_test3 output argument |
-| overflowdestination.cpp:76:24:76:27 | dest | overflowdestination.cpp:57:40:57:43 | dest | overflowdestination.cpp:65:9:65:13 | memcpy output argument | overflowdestination.cpp:76:30:76:32 | overflowdest_test3 output argument |
-| overflowdestination.cpp:76:30:76:32 | array to pointer conversion indirection | overflowdestination.cpp:57:52:57:54 | src indirection | overflowdestination.cpp:63:9:63:13 | memcpy output argument | overflowdestination.cpp:76:24:76:27 | overflowdest_test3 output argument |
-| overflowdestination.cpp:76:30:76:32 | array to pointer conversion indirection | overflowdestination.cpp:57:52:57:54 | src indirection | overflowdestination.cpp:64:9:64:13 | memcpy output argument | overflowdestination.cpp:76:24:76:27 | overflowdest_test3 output argument |
-| overflowdestination.cpp:76:30:76:32 | array to pointer conversion indirection | overflowdestination.cpp:57:52:57:54 | src indirection | overflowdestination.cpp:65:9:65:13 | memcpy output argument | overflowdestination.cpp:76:24:76:27 | overflowdest_test3 output argument |
-| overflowdestination.cpp:76:30:76:32 | src | overflowdestination.cpp:57:52:57:54 | src | overflowdestination.cpp:63:9:63:13 | memcpy output argument | overflowdestination.cpp:76:24:76:27 | overflowdest_test3 output argument |
-| overflowdestination.cpp:76:30:76:32 | src | overflowdestination.cpp:57:52:57:54 | src | overflowdestination.cpp:64:9:64:13 | memcpy output argument | overflowdestination.cpp:76:24:76:27 | overflowdest_test3 output argument |
-| overflowdestination.cpp:76:30:76:32 | src | overflowdestination.cpp:57:52:57:54 | src | overflowdestination.cpp:64:9:64:13 | memcpy output argument | overflowdestination.cpp:76:30:76:32 | overflowdest_test3 output argument |
-| overflowdestination.cpp:76:30:76:32 | src | overflowdestination.cpp:57:52:57:54 | src | overflowdestination.cpp:65:9:65:13 | memcpy output argument | overflowdestination.cpp:76:24:76:27 | overflowdest_test3 output argument |
-| overflowdestination.cpp:76:30:76:32 | src | overflowdestination.cpp:57:52:57:54 | src | overflowdestination.cpp:65:9:65:13 | memcpy output argument | overflowdestination.cpp:76:30:76:32 | overflowdest_test3 output argument |
 #select
 | overflowdestination.cpp:30:2:30:8 | call to strncpy | main.cpp:6:27:6:30 | argv | overflowdestination.cpp:30:17:30:20 | arg1 | To avoid overflow, this operation should be bounded by destination-buffer size, not source-buffer size. |
 | overflowdestination.cpp:30:2:30:8 | call to strncpy | main.cpp:6:27:6:30 | argv indirection | overflowdestination.cpp:30:17:30:20 | arg1 | To avoid overflow, this operation should be bounded by destination-buffer size, not source-buffer size. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/argv/argvLocal.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/argv/argvLocal.expected
@@ -53,12 +53,6 @@ edges
 | argvLocal.c:115:13:115:16 | argv | argvLocal.c:116:9:116:10 | i3 |
 | argvLocal.c:115:13:115:16 | argv | argvLocal.c:116:9:116:10 | i3 |
 | argvLocal.c:115:13:115:16 | argv | argvLocal.c:116:9:116:10 | i3 |
-| argvLocal.c:115:13:115:16 | argv | argvLocal.c:116:9:116:10 | i3 |
-| argvLocal.c:115:13:115:16 | argv | argvLocal.c:116:9:116:10 | i3 |
-| argvLocal.c:115:13:115:16 | argv | argvLocal.c:116:9:116:10 | i3 |
-| argvLocal.c:115:13:115:16 | argv | argvLocal.c:116:9:116:10 | i3 |
-| argvLocal.c:115:13:115:16 | argv | argvLocal.c:117:15:117:16 | i3 |
-| argvLocal.c:115:13:115:16 | argv | argvLocal.c:117:15:117:16 | i3 |
 | argvLocal.c:115:13:115:16 | argv | argvLocal.c:117:15:117:16 | i3 |
 | argvLocal.c:115:13:115:16 | argv | argvLocal.c:117:15:117:16 | i3 |
 | argvLocal.c:115:13:115:16 | argv | argvLocal.c:117:15:117:16 | i3 |
@@ -93,12 +87,6 @@ edges
 | argvLocal.c:126:10:126:13 | argv | argvLocal.c:127:9:127:10 | i5 |
 | argvLocal.c:126:10:126:13 | argv | argvLocal.c:127:9:127:10 | i5 |
 | argvLocal.c:126:10:126:13 | argv | argvLocal.c:127:9:127:10 | i5 |
-| argvLocal.c:126:10:126:13 | argv | argvLocal.c:127:9:127:10 | i5 |
-| argvLocal.c:126:10:126:13 | argv | argvLocal.c:127:9:127:10 | i5 |
-| argvLocal.c:126:10:126:13 | argv | argvLocal.c:127:9:127:10 | i5 |
-| argvLocal.c:126:10:126:13 | argv | argvLocal.c:127:9:127:10 | i5 |
-| argvLocal.c:126:10:126:13 | argv | argvLocal.c:128:15:128:16 | i5 |
-| argvLocal.c:126:10:126:13 | argv | argvLocal.c:128:15:128:16 | i5 |
 | argvLocal.c:126:10:126:13 | argv | argvLocal.c:128:15:128:16 | i5 |
 | argvLocal.c:126:10:126:13 | argv | argvLocal.c:128:15:128:16 | i5 |
 | argvLocal.c:126:10:126:13 | argv | argvLocal.c:128:15:128:16 | i5 |
@@ -181,9 +169,6 @@ nodes
 | argvLocal.c:115:13:115:16 | argv | semmle.label | argv |
 | argvLocal.c:116:9:116:10 | i3 | semmle.label | i3 |
 | argvLocal.c:116:9:116:10 | i3 | semmle.label | i3 |
-| argvLocal.c:116:9:116:10 | i3 | semmle.label | i3 |
-| argvLocal.c:116:9:116:10 | i3 | semmle.label | i3 |
-| argvLocal.c:117:15:117:16 | i3 | semmle.label | i3 |
 | argvLocal.c:117:15:117:16 | i3 | semmle.label | i3 |
 | argvLocal.c:117:15:117:16 | i3 | semmle.label | i3 |
 | argvLocal.c:121:9:121:10 | i4 | semmle.label | i4 |
@@ -195,9 +180,6 @@ nodes
 | argvLocal.c:126:10:126:13 | argv | semmle.label | argv |
 | argvLocal.c:127:9:127:10 | i5 | semmle.label | i5 |
 | argvLocal.c:127:9:127:10 | i5 | semmle.label | i5 |
-| argvLocal.c:127:9:127:10 | i5 | semmle.label | i5 |
-| argvLocal.c:127:9:127:10 | i5 | semmle.label | i5 |
-| argvLocal.c:128:15:128:16 | i5 | semmle.label | i5 |
 | argvLocal.c:128:15:128:16 | i5 | semmle.label | i5 |
 | argvLocal.c:128:15:128:16 | i5 | semmle.label | i5 |
 | argvLocal.c:131:9:131:14 | ... + ... | semmle.label | ... + ... |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/funcs/funcsLocal.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/funcs/funcsLocal.expected
@@ -1,36 +1,18 @@
 edges
 | funcsLocal.c:16:8:16:9 | fread output argument | funcsLocal.c:17:9:17:10 | i1 |
 | funcsLocal.c:16:8:16:9 | fread output argument | funcsLocal.c:17:9:17:10 | i1 |
-| funcsLocal.c:16:8:16:9 | fread output argument | funcsLocal.c:17:9:17:10 | i1 |
-| funcsLocal.c:16:8:16:9 | fread output argument | funcsLocal.c:17:9:17:10 | i1 |
-| funcsLocal.c:16:8:16:9 | fread output argument | funcsLocal.c:58:9:58:10 | e1 |
-| funcsLocal.c:16:8:16:9 | fread output argument | funcsLocal.c:58:9:58:10 | e1 |
 | funcsLocal.c:16:8:16:9 | fread output argument | funcsLocal.c:58:9:58:10 | e1 |
 | funcsLocal.c:16:8:16:9 | fread output argument | funcsLocal.c:58:9:58:10 | e1 |
 | funcsLocal.c:16:8:16:9 | i1 | funcsLocal.c:17:9:17:10 | i1 |
 | funcsLocal.c:16:8:16:9 | i1 | funcsLocal.c:17:9:17:10 | i1 |
 | funcsLocal.c:16:8:16:9 | i1 | funcsLocal.c:17:9:17:10 | i1 |
 | funcsLocal.c:16:8:16:9 | i1 | funcsLocal.c:17:9:17:10 | i1 |
-| funcsLocal.c:16:8:16:9 | i1 | funcsLocal.c:17:9:17:10 | i1 |
-| funcsLocal.c:16:8:16:9 | i1 | funcsLocal.c:17:9:17:10 | i1 |
-| funcsLocal.c:16:8:16:9 | i1 | funcsLocal.c:17:9:17:10 | i1 |
-| funcsLocal.c:16:8:16:9 | i1 | funcsLocal.c:17:9:17:10 | i1 |
-| funcsLocal.c:16:8:16:9 | i1 | funcsLocal.c:58:9:58:10 | e1 |
-| funcsLocal.c:16:8:16:9 | i1 | funcsLocal.c:58:9:58:10 | e1 |
-| funcsLocal.c:16:8:16:9 | i1 | funcsLocal.c:58:9:58:10 | e1 |
-| funcsLocal.c:16:8:16:9 | i1 | funcsLocal.c:58:9:58:10 | e1 |
 | funcsLocal.c:16:8:16:9 | i1 | funcsLocal.c:58:9:58:10 | e1 |
 | funcsLocal.c:16:8:16:9 | i1 | funcsLocal.c:58:9:58:10 | e1 |
 | funcsLocal.c:16:8:16:9 | i1 | funcsLocal.c:58:9:58:10 | e1 |
 | funcsLocal.c:16:8:16:9 | i1 | funcsLocal.c:58:9:58:10 | e1 |
 | funcsLocal.c:26:8:26:9 | fgets output argument | funcsLocal.c:27:9:27:10 | i3 |
 | funcsLocal.c:26:8:26:9 | fgets output argument | funcsLocal.c:27:9:27:10 | i3 |
-| funcsLocal.c:26:8:26:9 | fgets output argument | funcsLocal.c:27:9:27:10 | i3 |
-| funcsLocal.c:26:8:26:9 | fgets output argument | funcsLocal.c:27:9:27:10 | i3 |
-| funcsLocal.c:26:8:26:9 | i3 | funcsLocal.c:27:9:27:10 | i3 |
-| funcsLocal.c:26:8:26:9 | i3 | funcsLocal.c:27:9:27:10 | i3 |
-| funcsLocal.c:26:8:26:9 | i3 | funcsLocal.c:27:9:27:10 | i3 |
-| funcsLocal.c:26:8:26:9 | i3 | funcsLocal.c:27:9:27:10 | i3 |
 | funcsLocal.c:26:8:26:9 | i3 | funcsLocal.c:27:9:27:10 | i3 |
 | funcsLocal.c:26:8:26:9 | i3 | funcsLocal.c:27:9:27:10 | i3 |
 | funcsLocal.c:26:8:26:9 | i3 | funcsLocal.c:27:9:27:10 | i3 |
@@ -41,36 +23,18 @@ edges
 | funcsLocal.c:31:13:31:17 | call to fgets | funcsLocal.c:32:9:32:10 | i4 |
 | funcsLocal.c:31:13:31:17 | call to fgets | funcsLocal.c:32:9:32:10 | i4 |
 | funcsLocal.c:31:13:31:17 | call to fgets | funcsLocal.c:32:9:32:10 | i4 |
-| funcsLocal.c:31:19:31:21 | fgets output argument | funcsLocal.c:32:9:32:10 | i4 |
-| funcsLocal.c:31:19:31:21 | fgets output argument | funcsLocal.c:32:9:32:10 | i4 |
-| funcsLocal.c:31:19:31:21 | fgets output argument | funcsLocal.c:32:9:32:10 | i4 |
-| funcsLocal.c:31:19:31:21 | i41 | funcsLocal.c:32:9:32:10 | i4 |
-| funcsLocal.c:31:19:31:21 | i41 | funcsLocal.c:32:9:32:10 | i4 |
-| funcsLocal.c:31:19:31:21 | i41 | funcsLocal.c:32:9:32:10 | i4 |
-| funcsLocal.c:36:7:36:8 | gets output argument | funcsLocal.c:37:9:37:10 | i5 |
-| funcsLocal.c:36:7:36:8 | gets output argument | funcsLocal.c:37:9:37:10 | i5 |
 | funcsLocal.c:36:7:36:8 | gets output argument | funcsLocal.c:37:9:37:10 | i5 |
 | funcsLocal.c:36:7:36:8 | gets output argument | funcsLocal.c:37:9:37:10 | i5 |
 | funcsLocal.c:36:7:36:8 | i5 | funcsLocal.c:37:9:37:10 | i5 |
 | funcsLocal.c:36:7:36:8 | i5 | funcsLocal.c:37:9:37:10 | i5 |
 | funcsLocal.c:36:7:36:8 | i5 | funcsLocal.c:37:9:37:10 | i5 |
 | funcsLocal.c:36:7:36:8 | i5 | funcsLocal.c:37:9:37:10 | i5 |
-| funcsLocal.c:36:7:36:8 | i5 | funcsLocal.c:37:9:37:10 | i5 |
-| funcsLocal.c:36:7:36:8 | i5 | funcsLocal.c:37:9:37:10 | i5 |
-| funcsLocal.c:36:7:36:8 | i5 | funcsLocal.c:37:9:37:10 | i5 |
-| funcsLocal.c:36:7:36:8 | i5 | funcsLocal.c:37:9:37:10 | i5 |
 | funcsLocal.c:41:13:41:16 | call to gets | funcsLocal.c:42:9:42:10 | i6 |
 | funcsLocal.c:41:13:41:16 | call to gets | funcsLocal.c:42:9:42:10 | i6 |
 | funcsLocal.c:41:13:41:16 | call to gets | funcsLocal.c:42:9:42:10 | i6 |
 | funcsLocal.c:41:13:41:16 | call to gets | funcsLocal.c:42:9:42:10 | i6 |
 | funcsLocal.c:41:13:41:16 | call to gets | funcsLocal.c:42:9:42:10 | i6 |
 | funcsLocal.c:41:13:41:16 | call to gets | funcsLocal.c:42:9:42:10 | i6 |
-| funcsLocal.c:41:18:41:20 | gets output argument | funcsLocal.c:42:9:42:10 | i6 |
-| funcsLocal.c:41:18:41:20 | gets output argument | funcsLocal.c:42:9:42:10 | i6 |
-| funcsLocal.c:41:18:41:20 | gets output argument | funcsLocal.c:42:9:42:10 | i6 |
-| funcsLocal.c:41:18:41:20 | i61 | funcsLocal.c:42:9:42:10 | i6 |
-| funcsLocal.c:41:18:41:20 | i61 | funcsLocal.c:42:9:42:10 | i6 |
-| funcsLocal.c:41:18:41:20 | i61 | funcsLocal.c:42:9:42:10 | i6 |
 | funcsLocal.c:46:7:46:9 | * ... | funcsLocal.c:47:9:47:11 | * ... |
 | funcsLocal.c:46:7:46:9 | * ... | funcsLocal.c:47:9:47:11 | * ... |
 | funcsLocal.c:46:7:46:9 | * ... | funcsLocal.c:47:9:47:11 | * ... |
@@ -86,12 +50,6 @@ edges
 | funcsLocal.c:52:8:52:11 | call to gets | funcsLocal.c:53:9:53:11 | * ... |
 | funcsLocal.c:52:8:52:11 | call to gets | funcsLocal.c:53:9:53:11 | * ... |
 | funcsLocal.c:52:8:52:11 | call to gets | funcsLocal.c:53:9:53:11 | * ... |
-| funcsLocal.c:52:13:52:15 | gets output argument | funcsLocal.c:53:9:53:11 | * ... |
-| funcsLocal.c:52:13:52:15 | gets output argument | funcsLocal.c:53:9:53:11 | * ... |
-| funcsLocal.c:52:13:52:15 | gets output argument | funcsLocal.c:53:9:53:11 | * ... |
-| funcsLocal.c:52:13:52:15 | i81 | funcsLocal.c:53:9:53:11 | * ... |
-| funcsLocal.c:52:13:52:15 | i81 | funcsLocal.c:53:9:53:11 | * ... |
-| funcsLocal.c:52:13:52:15 | i81 | funcsLocal.c:53:9:53:11 | * ... |
 subpaths
 nodes
 | funcsLocal.c:16:8:16:9 | fread output argument | semmle.label | fread output argument |
@@ -99,19 +57,13 @@ nodes
 | funcsLocal.c:16:8:16:9 | i1 | semmle.label | i1 |
 | funcsLocal.c:17:9:17:10 | i1 | semmle.label | i1 |
 | funcsLocal.c:17:9:17:10 | i1 | semmle.label | i1 |
-| funcsLocal.c:17:9:17:10 | i1 | semmle.label | i1 |
-| funcsLocal.c:17:9:17:10 | i1 | semmle.label | i1 |
 | funcsLocal.c:26:8:26:9 | fgets output argument | semmle.label | fgets output argument |
 | funcsLocal.c:26:8:26:9 | i3 | semmle.label | i3 |
 | funcsLocal.c:26:8:26:9 | i3 | semmle.label | i3 |
 | funcsLocal.c:27:9:27:10 | i3 | semmle.label | i3 |
 | funcsLocal.c:27:9:27:10 | i3 | semmle.label | i3 |
-| funcsLocal.c:27:9:27:10 | i3 | semmle.label | i3 |
-| funcsLocal.c:27:9:27:10 | i3 | semmle.label | i3 |
 | funcsLocal.c:31:13:31:17 | call to fgets | semmle.label | call to fgets |
 | funcsLocal.c:31:13:31:17 | call to fgets | semmle.label | call to fgets |
-| funcsLocal.c:31:19:31:21 | fgets output argument | semmle.label | fgets output argument |
-| funcsLocal.c:31:19:31:21 | i41 | semmle.label | i41 |
 | funcsLocal.c:32:9:32:10 | i4 | semmle.label | i4 |
 | funcsLocal.c:32:9:32:10 | i4 | semmle.label | i4 |
 | funcsLocal.c:32:9:32:10 | i4 | semmle.label | i4 |
@@ -120,12 +72,8 @@ nodes
 | funcsLocal.c:36:7:36:8 | i5 | semmle.label | i5 |
 | funcsLocal.c:37:9:37:10 | i5 | semmle.label | i5 |
 | funcsLocal.c:37:9:37:10 | i5 | semmle.label | i5 |
-| funcsLocal.c:37:9:37:10 | i5 | semmle.label | i5 |
-| funcsLocal.c:37:9:37:10 | i5 | semmle.label | i5 |
 | funcsLocal.c:41:13:41:16 | call to gets | semmle.label | call to gets |
 | funcsLocal.c:41:13:41:16 | call to gets | semmle.label | call to gets |
-| funcsLocal.c:41:18:41:20 | gets output argument | semmle.label | gets output argument |
-| funcsLocal.c:41:18:41:20 | i61 | semmle.label | i61 |
 | funcsLocal.c:42:9:42:10 | i6 | semmle.label | i6 |
 | funcsLocal.c:42:9:42:10 | i6 | semmle.label | i6 |
 | funcsLocal.c:42:9:42:10 | i6 | semmle.label | i6 |
@@ -137,24 +85,17 @@ nodes
 | funcsLocal.c:47:9:47:11 | * ... | semmle.label | * ... |
 | funcsLocal.c:52:8:52:11 | call to gets | semmle.label | call to gets |
 | funcsLocal.c:52:8:52:11 | call to gets | semmle.label | call to gets |
-| funcsLocal.c:52:13:52:15 | gets output argument | semmle.label | gets output argument |
-| funcsLocal.c:52:13:52:15 | i81 | semmle.label | i81 |
 | funcsLocal.c:53:9:53:11 | * ... | semmle.label | * ... |
 | funcsLocal.c:53:9:53:11 | * ... | semmle.label | * ... |
 | funcsLocal.c:53:9:53:11 | * ... | semmle.label | * ... |
-| funcsLocal.c:58:9:58:10 | e1 | semmle.label | e1 |
-| funcsLocal.c:58:9:58:10 | e1 | semmle.label | e1 |
 | funcsLocal.c:58:9:58:10 | e1 | semmle.label | e1 |
 | funcsLocal.c:58:9:58:10 | e1 | semmle.label | e1 |
 #select
 | funcsLocal.c:17:9:17:10 | i1 | funcsLocal.c:16:8:16:9 | i1 | funcsLocal.c:17:9:17:10 | i1 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | funcsLocal.c:16:8:16:9 | i1 | fread |
 | funcsLocal.c:27:9:27:10 | i3 | funcsLocal.c:26:8:26:9 | i3 | funcsLocal.c:27:9:27:10 | i3 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | funcsLocal.c:26:8:26:9 | i3 | fgets |
 | funcsLocal.c:32:9:32:10 | i4 | funcsLocal.c:31:13:31:17 | call to fgets | funcsLocal.c:32:9:32:10 | i4 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | funcsLocal.c:31:13:31:17 | call to fgets | fgets |
-| funcsLocal.c:32:9:32:10 | i4 | funcsLocal.c:31:19:31:21 | i41 | funcsLocal.c:32:9:32:10 | i4 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | funcsLocal.c:31:19:31:21 | i41 | fgets |
 | funcsLocal.c:37:9:37:10 | i5 | funcsLocal.c:36:7:36:8 | i5 | funcsLocal.c:37:9:37:10 | i5 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | funcsLocal.c:36:7:36:8 | i5 | gets |
 | funcsLocal.c:42:9:42:10 | i6 | funcsLocal.c:41:13:41:16 | call to gets | funcsLocal.c:42:9:42:10 | i6 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | funcsLocal.c:41:13:41:16 | call to gets | gets |
-| funcsLocal.c:42:9:42:10 | i6 | funcsLocal.c:41:18:41:20 | i61 | funcsLocal.c:42:9:42:10 | i6 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | funcsLocal.c:41:18:41:20 | i61 | gets |
 | funcsLocal.c:47:9:47:11 | * ... | funcsLocal.c:46:7:46:9 | * ... | funcsLocal.c:47:9:47:11 | * ... | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | funcsLocal.c:46:7:46:9 | * ... | gets |
 | funcsLocal.c:53:9:53:11 | * ... | funcsLocal.c:52:8:52:11 | call to gets | funcsLocal.c:53:9:53:11 | * ... | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | funcsLocal.c:52:8:52:11 | call to gets | gets |
-| funcsLocal.c:53:9:53:11 | * ... | funcsLocal.c:52:13:52:15 | i81 | funcsLocal.c:53:9:53:11 | * ... | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | funcsLocal.c:52:13:52:15 | i81 | gets |
 | funcsLocal.c:58:9:58:10 | e1 | funcsLocal.c:16:8:16:9 | i1 | funcsLocal.c:58:9:58:10 | e1 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format). | funcsLocal.c:16:8:16:9 | i1 | fread |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextBufferWrite.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextBufferWrite.expected
@@ -1,11 +1,9 @@
 edges
-| test2.cpp:110:8:110:15 | gets output argument | test2.cpp:110:3:110:6 | call to gets |
 | test.cpp:53:27:53:30 | argv | test.cpp:58:25:58:29 | input |
 | test.cpp:53:27:53:30 | argv indirection | test.cpp:58:25:58:29 | input |
 | test.cpp:53:27:53:30 | argv indirection | test.cpp:58:25:58:29 | input |
 nodes
 | test2.cpp:110:3:110:6 | call to gets | semmle.label | call to gets |
-| test2.cpp:110:8:110:15 | gets output argument | semmle.label | gets output argument |
 | test.cpp:53:27:53:30 | argv | semmle.label | argv |
 | test.cpp:53:27:53:30 | argv indirection | semmle.label | argv indirection |
 | test.cpp:53:27:53:30 | argv indirection | semmle.label | argv indirection |
@@ -13,7 +11,6 @@ nodes
 subpaths
 #select
 | test2.cpp:110:3:110:6 | call to gets | test2.cpp:110:3:110:6 | call to gets | test2.cpp:110:3:110:6 | call to gets | This write into buffer 'password' may contain unencrypted data from $@. | test2.cpp:110:3:110:6 | call to gets | user input (string read by gets) |
-| test2.cpp:110:3:110:6 | call to gets | test2.cpp:110:8:110:15 | gets output argument | test2.cpp:110:3:110:6 | call to gets | This write into buffer 'password' may contain unencrypted data from $@. | test2.cpp:110:8:110:15 | gets output argument | user input (string read by gets) |
 | test.cpp:58:3:58:9 | call to sprintf | test.cpp:53:27:53:30 | argv | test.cpp:58:25:58:29 | input | This write into buffer 'passwd' may contain unencrypted data from $@. | test.cpp:53:27:53:30 | argv | user input (a command-line argument) |
 | test.cpp:58:3:58:9 | call to sprintf | test.cpp:53:27:53:30 | argv indirection | test.cpp:58:25:58:29 | input | This write into buffer 'passwd' may contain unencrypted data from $@. | test.cpp:53:27:53:30 | argv indirection | user input (a command-line argument) |
 | test.cpp:58:3:58:9 | call to sprintf | test.cpp:53:27:53:30 | argv indirection | test.cpp:58:25:58:29 | input | This write into buffer 'passwd' may contain unencrypted data from $@. | test.cpp:53:27:53:30 | argv indirection | user input (a command-line argument) |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextFileWrite.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextFileWrite.expected
@@ -1,14 +1,9 @@
 edges
 | test2.cpp:62:18:62:25 | password | test2.cpp:65:31:65:34 | cpy1 |
 | test2.cpp:72:15:72:24 | password | test2.cpp:73:30:73:32 | buf |
-| test2.cpp:72:15:72:24 | password | test2.cpp:73:30:73:32 | buf |
-| test2.cpp:72:15:72:24 | password | test2.cpp:76:30:76:32 | buf |
 | test2.cpp:72:15:72:24 | password | test2.cpp:76:30:76:32 | buf |
 | test2.cpp:72:17:72:24 | password | test2.cpp:73:30:73:32 | buf |
-| test2.cpp:72:17:72:24 | password | test2.cpp:73:30:73:32 | buf |
 | test2.cpp:72:17:72:24 | password | test2.cpp:76:30:76:32 | buf |
-| test2.cpp:72:17:72:24 | password | test2.cpp:76:30:76:32 | buf |
-| test2.cpp:98:45:98:52 | password | test2.cpp:99:27:99:32 | buffer |
 | test2.cpp:98:45:98:52 | password | test2.cpp:99:27:99:32 | buffer |
 | test.cpp:45:9:45:19 | thePassword | test.cpp:45:9:45:19 | thePassword |
 | test.cpp:45:9:45:19 | thePassword | test.cpp:45:9:45:19 | thePassword |
@@ -41,13 +36,10 @@ nodes
 | test2.cpp:72:15:72:24 | password | semmle.label | password |
 | test2.cpp:72:17:72:24 | password | semmle.label | password |
 | test2.cpp:73:30:73:32 | buf | semmle.label | buf |
-| test2.cpp:73:30:73:32 | buf | semmle.label | buf |
-| test2.cpp:76:30:76:32 | buf | semmle.label | buf |
 | test2.cpp:76:30:76:32 | buf | semmle.label | buf |
 | test2.cpp:86:36:86:43 | password | semmle.label | password |
 | test2.cpp:91:50:91:63 | passwd_config2 | semmle.label | passwd_config2 |
 | test2.cpp:98:45:98:52 | password | semmle.label | password |
-| test2.cpp:99:27:99:32 | buffer | semmle.label | buffer |
 | test2.cpp:99:27:99:32 | buffer | semmle.label | buffer |
 | test.cpp:45:9:45:19 | thePassword | semmle.label | thePassword |
 | test.cpp:45:9:45:19 | thePassword | semmle.label | thePassword |
@@ -72,14 +64,9 @@ subpaths
 | test2.cpp:57:2:57:8 | call to fprintf | test2.cpp:57:39:57:49 | call to getPassword | test2.cpp:57:39:57:49 | call to getPassword | This write into file 'log' may contain unencrypted data from $@. | test2.cpp:57:39:57:49 | call to getPassword | this source. |
 | test2.cpp:65:3:65:9 | call to fprintf | test2.cpp:62:18:62:25 | password | test2.cpp:65:31:65:34 | cpy1 | This write into file 'log' may contain unencrypted data from $@. | test2.cpp:62:18:62:25 | password | this source. |
 | test2.cpp:73:3:73:9 | call to fprintf | test2.cpp:72:15:72:24 | password | test2.cpp:73:30:73:32 | buf | This write into file 'log' may contain unencrypted data from $@. | test2.cpp:72:17:72:24 | password | this source. |
-| test2.cpp:73:3:73:9 | call to fprintf | test2.cpp:72:15:72:24 | password | test2.cpp:73:30:73:32 | buf | This write into file 'log' may contain unencrypted data from $@. | test2.cpp:72:17:72:24 | password | this source. |
-| test2.cpp:73:3:73:9 | call to fprintf | test2.cpp:72:17:72:24 | password | test2.cpp:73:30:73:32 | buf | This write into file 'log' may contain unencrypted data from $@. | test2.cpp:72:17:72:24 | password | this source. |
 | test2.cpp:73:3:73:9 | call to fprintf | test2.cpp:72:17:72:24 | password | test2.cpp:73:30:73:32 | buf | This write into file 'log' may contain unencrypted data from $@. | test2.cpp:72:17:72:24 | password | this source. |
 | test2.cpp:76:3:76:9 | call to fprintf | test2.cpp:72:15:72:24 | password | test2.cpp:76:30:76:32 | buf | This write into file 'log' may contain unencrypted data from $@. | test2.cpp:72:17:72:24 | password | this source. |
-| test2.cpp:76:3:76:9 | call to fprintf | test2.cpp:72:15:72:24 | password | test2.cpp:76:30:76:32 | buf | This write into file 'log' may contain unencrypted data from $@. | test2.cpp:72:17:72:24 | password | this source. |
 | test2.cpp:76:3:76:9 | call to fprintf | test2.cpp:72:17:72:24 | password | test2.cpp:76:30:76:32 | buf | This write into file 'log' may contain unencrypted data from $@. | test2.cpp:72:17:72:24 | password | this source. |
-| test2.cpp:76:3:76:9 | call to fprintf | test2.cpp:72:17:72:24 | password | test2.cpp:76:30:76:32 | buf | This write into file 'log' may contain unencrypted data from $@. | test2.cpp:72:17:72:24 | password | this source. |
-| test2.cpp:99:3:99:9 | call to fprintf | test2.cpp:98:45:98:52 | password | test2.cpp:99:27:99:32 | buffer | This write into file 'log' may contain unencrypted data from $@. | test2.cpp:98:45:98:52 | password | this source. |
 | test2.cpp:99:3:99:9 | call to fprintf | test2.cpp:98:45:98:52 | password | test2.cpp:99:27:99:32 | buffer | This write into file 'log' may contain unencrypted data from $@. | test2.cpp:98:45:98:52 | password | this source. |
 | test.cpp:45:3:45:7 | call to fputs | test.cpp:45:9:45:19 | thePassword | test.cpp:45:9:45:19 | thePassword | This write into file 'file' may contain unencrypted data from $@. | test.cpp:45:9:45:19 | thePassword | this source. |
 | test.cpp:45:3:45:7 | call to fputs | test.cpp:45:9:45:19 | thePassword | test.cpp:45:9:45:19 | thePassword | This write into file 'file' may contain unencrypted data from $@. | test.cpp:45:9:45:19 | thePassword | this source. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-497/SAMATE/PotentiallyExposedSystemData.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-497/SAMATE/PotentiallyExposedSystemData.expected
@@ -1,11 +1,8 @@
 edges
 | tests.c:57:21:57:28 | password | tests.c:70:70:70:77 | password |
-| tests.c:57:21:57:28 | password | tests.c:70:70:70:77 | password |
 nodes
 | tests.c:57:21:57:28 | password | semmle.label | password |
 | tests.c:70:70:70:77 | password | semmle.label | password |
-| tests.c:70:70:70:77 | password | semmle.label | password |
 subpaths
 #select
-| tests.c:70:70:70:77 | password | tests.c:57:21:57:28 | password | tests.c:70:70:70:77 | password | This operation potentially exposes sensitive system data from $@. | tests.c:57:21:57:28 | password | password |
 | tests.c:70:70:70:77 | password | tests.c:57:21:57:28 | password | tests.c:70:70:70:77 | password | This operation potentially exposes sensitive system data from $@. | tests.c:57:21:57:28 | password | password |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-497/semmle/tests/ExposedSystemData.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-497/semmle/tests/ExposedSystemData.expected
@@ -7,8 +7,6 @@ edges
 | tests2.cpp:65:13:65:18 | call to getenv | tests2.cpp:65:13:65:30 | call to getenv |
 | tests2.cpp:66:13:66:18 | call to getenv | tests2.cpp:66:13:66:34 | call to getenv |
 | tests2.cpp:78:18:78:38 | call to mysql_get_client_info | tests2.cpp:81:14:81:19 | buffer |
-| tests2.cpp:78:18:78:38 | call to mysql_get_client_info | tests2.cpp:81:14:81:19 | buffer |
-| tests2.cpp:78:18:78:38 | call to mysql_get_client_info | tests2.cpp:81:14:81:19 | buffer |
 | tests2.cpp:82:14:82:20 | global1 | tests2.cpp:82:14:82:20 | global1 |
 | tests2.cpp:91:42:91:45 | str1 | tests2.cpp:93:14:93:17 | str1 |
 | tests2.cpp:101:8:101:15 | call to getpwuid | tests2.cpp:102:14:102:15 | pw |
@@ -47,8 +45,6 @@ nodes
 | tests2.cpp:66:13:66:34 | call to getenv | semmle.label | call to getenv |
 | tests2.cpp:78:18:78:38 | call to mysql_get_client_info | semmle.label | call to mysql_get_client_info |
 | tests2.cpp:80:14:80:34 | call to mysql_get_client_info | semmle.label | call to mysql_get_client_info |
-| tests2.cpp:81:14:81:19 | buffer | semmle.label | buffer |
-| tests2.cpp:81:14:81:19 | buffer | semmle.label | buffer |
 | tests2.cpp:81:14:81:19 | buffer | semmle.label | buffer |
 | tests2.cpp:82:14:82:20 | global1 | semmle.label | global1 |
 | tests2.cpp:82:14:82:20 | global1 | semmle.label | global1 |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-497/semmle/tests/PotentiallyExposedSystemData.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-497/semmle/tests/PotentiallyExposedSystemData.expected
@@ -17,8 +17,6 @@ edges
 | tests.cpp:97:13:97:34 | call to getenv | tests.cpp:86:29:86:31 | msg |
 | tests.cpp:107:30:107:32 | msg | tests.cpp:111:15:111:17 | tmp |
 | tests.cpp:114:30:114:32 | msg | tests.cpp:119:7:119:12 | buffer |
-| tests.cpp:114:30:114:32 | msg | tests.cpp:119:7:119:12 | buffer |
-| tests.cpp:114:30:114:32 | msg | tests.cpp:119:7:119:12 | buffer |
 | tests.cpp:122:30:122:32 | msg | tests.cpp:124:15:124:17 | msg |
 | tests.cpp:131:14:131:19 | call to getenv | tests.cpp:131:14:131:35 | call to getenv |
 | tests.cpp:131:14:131:35 | call to getenv | tests.cpp:107:30:107:32 | msg |
@@ -65,8 +63,6 @@ nodes
 | tests.cpp:111:15:111:17 | tmp | semmle.label | tmp |
 | tests.cpp:114:30:114:32 | msg | semmle.label | msg |
 | tests.cpp:119:7:119:12 | buffer | semmle.label | buffer |
-| tests.cpp:119:7:119:12 | buffer | semmle.label | buffer |
-| tests.cpp:119:7:119:12 | buffer | semmle.label | buffer |
 | tests.cpp:122:30:122:32 | msg | semmle.label | msg |
 | tests.cpp:124:15:124:17 | msg | semmle.label | msg |
 | tests.cpp:131:14:131:19 | call to getenv | semmle.label | call to getenv |
@@ -100,8 +96,6 @@ subpaths
 | tests.cpp:97:13:97:18 | call to getenv | tests.cpp:97:13:97:18 | call to getenv | tests.cpp:97:13:97:18 | call to getenv | This operation potentially exposes sensitive system data from $@. | tests.cpp:97:13:97:18 | call to getenv | call to getenv |
 | tests.cpp:97:13:97:34 | call to getenv | tests.cpp:97:13:97:18 | call to getenv | tests.cpp:97:13:97:34 | call to getenv | This operation potentially exposes sensitive system data from $@. | tests.cpp:97:13:97:18 | call to getenv | call to getenv |
 | tests.cpp:111:15:111:17 | tmp | tests.cpp:131:14:131:19 | call to getenv | tests.cpp:111:15:111:17 | tmp | This operation potentially exposes sensitive system data from $@. | tests.cpp:131:14:131:19 | call to getenv | call to getenv |
-| tests.cpp:119:7:119:12 | buffer | tests.cpp:132:14:132:19 | call to getenv | tests.cpp:119:7:119:12 | buffer | This operation potentially exposes sensitive system data from $@. | tests.cpp:132:14:132:19 | call to getenv | call to getenv |
-| tests.cpp:119:7:119:12 | buffer | tests.cpp:132:14:132:19 | call to getenv | tests.cpp:119:7:119:12 | buffer | This operation potentially exposes sensitive system data from $@. | tests.cpp:132:14:132:19 | call to getenv | call to getenv |
 | tests.cpp:119:7:119:12 | buffer | tests.cpp:132:14:132:19 | call to getenv | tests.cpp:119:7:119:12 | buffer | This operation potentially exposes sensitive system data from $@. | tests.cpp:132:14:132:19 | call to getenv | call to getenv |
 | tests.cpp:124:15:124:17 | msg | tests.cpp:133:14:133:19 | call to getenv | tests.cpp:124:15:124:17 | msg | This operation potentially exposes sensitive system data from $@. | tests.cpp:133:14:133:19 | call to getenv | call to getenv |
 | tests.cpp:133:14:133:19 | call to getenv | tests.cpp:133:14:133:19 | call to getenv | tests.cpp:133:14:133:19 | call to getenv | This operation potentially exposes sensitive system data from $@. | tests.cpp:133:14:133:19 | call to getenv | call to getenv |


### PR DESCRIPTION
This PR reduces the number of SSA reads by not considering conversions as reads. This partially fixes the looping behavior observed in https://github.com/github/codeql/pull/11963 (but it doesn't fix the one observed in https://github.com/github/codeql/pull/11975).

It should also provide a small speedup boost since we're reducing the amount of reads considered in the SSA phase.

Commit-by-commit review recommended. The meat of the PR is in 9de8d5c501e9f3da470228e403d09588393fee61 (which includes conversions from the set of uses). However, I saw a number of missing results from _just_ that commit, and it took some time to debug why. The reason is as follows:

We mark a number of ad-hoc things as conversions for iterator flow (to handle temporary variables created by rvalue-to-lvalue conversions). When we mark these as conversions we'd also excluding those from the set of uses, and this breaks a bunch of things. So 7ecc3466cfc2c5783cdd6e3629129b856361839e adds an additional column to the `conversionFlow` predicate that we can use to decide whether to consider those ad-hoc conversions. This column should be `_` for most things, but _must_ be `false` when we're excluding the conversions in `isUse`.

Finally, the last two commits just accepts test changes. These all appear to be fine 🎉.