### PR TITLE
RB: add note in ReDoS qhelp that Ruby 3.2 has fixed ReDoS

### DIFF
--- a/ruby/ql/src/queries/security/cwe-1333/ReDoSIntroduction.inc.qhelp
+++ b/ruby/ql/src/queries/security/cwe-1333/ReDoSIntroduction.inc.qhelp
@@ -20,6 +20,12 @@
       automaton about 1000 times slower.
     </p>
     <p>
+      Note that Ruby 3.2 and later have implemented a caching mechanism that
+      completely eliminates the worst-case time complexity for the regular
+      expressions flagged by this query. The regular expressions flagged by this
+      query are therefore only problematic for Ruby versions prior to 3.2.
+    </p>
+    <p>
       Typically, a regular expression is affected by this problem if it contains
       a repetition of the form <code>r*</code> or <code>r+</code> where the
       sub-expression <code>r</code> is ambiguous in the sense that it can match


### PR DESCRIPTION
See: 
- https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/
- https://bugs.ruby-lang.org/issues/19104
- https://www.computer.org/csdl/proceedings-article/sp/2021/893400a543/1oak988ThvO

There was an earlier PR, but I'm trying again to see if the qhelp preview works now. 
**Edit:** nope. Probably because the change in in a shared `inc.qhelp` file. 