### PR TITLE
Use Java 11 for some integration tests

### DIFF
--- a/java/ql/integration-tests/all-platforms/java/gradle-sample/test.py
+++ b/java/ql/integration-tests/all-platforms/java/gradle-sample/test.py
@@ -2,4 +2,7 @@ import sys
 
 from create_database_utils import *
 
+#The version of gradle used doesn't work on java 17
+try_use_java11()
+
 run_codeql_database_create([], lang="java")

--- a/java/ql/integration-tests/all-platforms/java/partial-gradle-sample/test.py
+++ b/java/ql/integration-tests/all-platforms/java/partial-gradle-sample/test.py
@@ -2,4 +2,7 @@ import sys
 
 from create_database_utils import *
 
+#The version of gradle used doesn't work on java 17
+try_use_java11()
+
 run_codeql_database_create([], lang="java")


### PR DESCRIPTION
These test don't currently work under java 17 which will be the default for our CI in future.

These are currently due to crashes within the version of gradle used for these tests. 