### PR TITLE
Go: Fix DepErrors test

### DIFF
--- a/go/extractor/util/util.go
+++ b/go/extractor/util/util.go
@@ -170,7 +170,7 @@ func GetPkgDir(pkgpath string, flags ...string) string {
 // DepErrors checks there are any errors resolving dependencies for `pkgpath`. It passes the `go
 // list` command the flags specified by `flags`.
 func DepErrors(pkgpath string, flags ...string) bool {
-	out, err := runGoList("{{if .DepsErrors}}{{else}}error{{end}}", []string{pkgpath}, flags...)
+	out, err := runGoList("{{if .DepsErrors}}error{{else}}{{end}}", []string{pkgpath}, flags...)
 	if err != nil {
 		// if go list failed, assume dependencies are broken
 		return false


### PR DESCRIPTION
This was likely harmlessly causing `go get` reruns, since most (all?) real dependency errors cause `go list` to exit with a nonzero return code in any case.

Requested in https://github.com/github/codeql/issues/11991