### PR TITLE
C++: Fix iterator test

### DIFF
--- a/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
@@ -3482,106 +3482,106 @@
 | smart_pointer.cpp:137:10:137:11 | p2 | smart_pointer.cpp:137:9:137:9 | call to operator* | TAINT |
 | smart_pointer.cpp:137:10:137:11 | ref arg p2 | smart_pointer.cpp:132:95:132:96 | p2 |  |
 | smart_pointer.cpp:137:10:137:11 | ref arg p2 | smart_pointer.cpp:137:10:137:11 | p2 [inner post update] |  |
-| standalone_iterators.cpp:39:45:39:51 | source1 | standalone_iterators.cpp:39:45:39:51 | source1 |  |
-| standalone_iterators.cpp:39:45:39:51 | source1 | standalone_iterators.cpp:40:11:40:17 | source1 |  |
-| standalone_iterators.cpp:39:45:39:51 | source1 | standalone_iterators.cpp:41:12:41:18 | source1 |  |
-| standalone_iterators.cpp:39:45:39:51 | source1 | standalone_iterators.cpp:42:14:42:20 | source1 |  |
-| standalone_iterators.cpp:40:11:40:17 | source1 | standalone_iterators.cpp:40:10:40:10 | call to operator* | TAINT |
-| standalone_iterators.cpp:41:12:41:18 | ref arg source1 | standalone_iterators.cpp:39:45:39:51 | source1 |  |
-| standalone_iterators.cpp:41:12:41:18 | ref arg source1 | standalone_iterators.cpp:42:14:42:20 | source1 |  |
-| standalone_iterators.cpp:41:12:41:18 | source1 | standalone_iterators.cpp:41:19:41:19 | call to operator++ |  |
-| standalone_iterators.cpp:41:19:41:19 | call to operator++ | standalone_iterators.cpp:41:10:41:10 | call to operator* | TAINT |
-| standalone_iterators.cpp:42:12:42:12 | call to operator++ | standalone_iterators.cpp:42:10:42:10 | call to operator* | TAINT |
-| standalone_iterators.cpp:42:14:42:20 | ref arg source1 | standalone_iterators.cpp:39:45:39:51 | source1 |  |
-| standalone_iterators.cpp:42:14:42:20 | source1 | standalone_iterators.cpp:42:12:42:12 | call to operator++ |  |
-| standalone_iterators.cpp:45:39:45:45 | source1 | standalone_iterators.cpp:45:39:45:45 | source1 |  |
-| standalone_iterators.cpp:45:39:45:45 | source1 | standalone_iterators.cpp:46:11:46:17 | source1 |  |
-| standalone_iterators.cpp:45:39:45:45 | source1 | standalone_iterators.cpp:47:12:47:18 | source1 |  |
-| standalone_iterators.cpp:45:39:45:45 | source1 | standalone_iterators.cpp:48:14:48:20 | source1 |  |
-| standalone_iterators.cpp:46:11:46:17 | source1 | standalone_iterators.cpp:46:10:46:10 | call to operator* | TAINT |
-| standalone_iterators.cpp:47:12:47:18 | ref arg source1 | standalone_iterators.cpp:45:39:45:45 | source1 |  |
-| standalone_iterators.cpp:47:12:47:18 | ref arg source1 | standalone_iterators.cpp:48:14:48:20 | source1 |  |
-| standalone_iterators.cpp:47:12:47:18 | source1 | standalone_iterators.cpp:47:19:47:19 | call to operator++ |  |
-| standalone_iterators.cpp:47:19:47:19 | call to operator++ | standalone_iterators.cpp:47:10:47:10 | call to operator* | TAINT |
-| standalone_iterators.cpp:48:12:48:12 | call to operator++ | standalone_iterators.cpp:48:10:48:10 | call to operator* | TAINT |
-| standalone_iterators.cpp:48:14:48:20 | ref arg source1 | standalone_iterators.cpp:45:39:45:45 | source1 |  |
-| standalone_iterators.cpp:48:14:48:20 | source1 | standalone_iterators.cpp:48:12:48:12 | call to operator++ |  |
-| standalone_iterators.cpp:51:37:51:43 | source1 | standalone_iterators.cpp:52:11:52:17 | source1 |  |
-| standalone_iterators.cpp:51:37:51:43 | source1 | standalone_iterators.cpp:53:12:53:18 | source1 |  |
-| standalone_iterators.cpp:51:37:51:43 | source1 | standalone_iterators.cpp:54:14:54:20 | source1 |  |
-| standalone_iterators.cpp:53:12:53:18 | ref arg source1 | standalone_iterators.cpp:54:14:54:20 | source1 |  |
-| standalone_iterators.cpp:83:15:83:16 | call to container | standalone_iterators.cpp:85:35:85:36 | c1 |  |
-| standalone_iterators.cpp:83:15:83:16 | call to container | standalone_iterators.cpp:87:10:87:11 | c1 |  |
-| standalone_iterators.cpp:83:19:83:20 | call to container | standalone_iterators.cpp:89:35:89:36 | c2 |  |
-| standalone_iterators.cpp:83:19:83:20 | call to container | standalone_iterators.cpp:91:10:91:11 | c2 |  |
-| standalone_iterators.cpp:85:35:85:36 | c1 | standalone_iterators.cpp:85:38:85:42 | call to begin | TAINT |
-| standalone_iterators.cpp:85:35:85:36 | ref arg c1 | standalone_iterators.cpp:87:10:87:11 | c1 |  |
-| standalone_iterators.cpp:85:38:85:42 | call to begin | standalone_iterators.cpp:86:6:86:7 | i1 |  |
-| standalone_iterators.cpp:86:5:86:5 | ref arg call to operator* | standalone_iterators.cpp:86:8:86:8 | ref arg call to operator-- | TAINT |
-| standalone_iterators.cpp:86:5:86:5 | ref arg call to operator* | standalone_iterators.cpp:87:10:87:11 | c1 |  |
-| standalone_iterators.cpp:86:6:86:7 | i1 | standalone_iterators.cpp:86:8:86:8 | call to operator-- |  |
-| standalone_iterators.cpp:86:8:86:8 | call to operator-- | standalone_iterators.cpp:86:5:86:5 | call to operator* | TAINT |
-| standalone_iterators.cpp:86:8:86:8 | ref arg call to operator-- | standalone_iterators.cpp:86:6:86:7 | ref arg i1 |  |
-| standalone_iterators.cpp:86:13:86:18 | call to source | standalone_iterators.cpp:86:5:86:5 | ref arg call to operator* | TAINT |
-| standalone_iterators.cpp:89:35:89:36 | c2 | standalone_iterators.cpp:89:38:89:42 | call to begin | TAINT |
-| standalone_iterators.cpp:89:35:89:36 | ref arg c2 | standalone_iterators.cpp:91:10:91:11 | c2 |  |
-| standalone_iterators.cpp:89:38:89:42 | call to begin | standalone_iterators.cpp:90:6:90:7 | i2 |  |
-| standalone_iterators.cpp:90:5:90:5 | ref arg call to operator* | standalone_iterators.cpp:90:8:90:8 | ref arg call to operator-- | TAINT |
-| standalone_iterators.cpp:90:5:90:5 | ref arg call to operator* | standalone_iterators.cpp:91:10:91:11 | c2 |  |
-| standalone_iterators.cpp:90:6:90:7 | i2 | standalone_iterators.cpp:90:8:90:8 | call to operator-- |  |
-| standalone_iterators.cpp:90:8:90:8 | call to operator-- | standalone_iterators.cpp:90:5:90:5 | call to operator* | TAINT |
-| standalone_iterators.cpp:90:8:90:8 | ref arg call to operator-- | standalone_iterators.cpp:90:6:90:7 | ref arg i2 |  |
-| standalone_iterators.cpp:90:13:90:13 | 0 | standalone_iterators.cpp:90:5:90:5 | ref arg call to operator* | TAINT |
-| standalone_iterators.cpp:98:15:98:16 | call to container | standalone_iterators.cpp:101:6:101:7 | c1 |  |
-| standalone_iterators.cpp:98:15:98:16 | call to container | standalone_iterators.cpp:102:6:102:7 | c1 |  |
-| standalone_iterators.cpp:98:15:98:16 | call to container | standalone_iterators.cpp:106:6:106:7 | c1 |  |
-| standalone_iterators.cpp:98:15:98:16 | call to container | standalone_iterators.cpp:109:7:109:8 | c1 |  |
-| standalone_iterators.cpp:101:6:101:7 | c1 | standalone_iterators.cpp:101:9:101:13 | call to begin | TAINT |
-| standalone_iterators.cpp:101:6:101:7 | ref arg c1 | standalone_iterators.cpp:102:6:102:7 | c1 |  |
-| standalone_iterators.cpp:101:6:101:7 | ref arg c1 | standalone_iterators.cpp:106:6:106:7 | c1 |  |
-| standalone_iterators.cpp:101:6:101:7 | ref arg c1 | standalone_iterators.cpp:109:7:109:8 | c1 |  |
-| standalone_iterators.cpp:101:9:101:13 | call to begin | standalone_iterators.cpp:101:2:101:15 | ... = ... |  |
-| standalone_iterators.cpp:101:9:101:13 | call to begin | standalone_iterators.cpp:103:3:103:3 | a |  |
-| standalone_iterators.cpp:101:9:101:13 | call to begin | standalone_iterators.cpp:104:7:104:7 | a |  |
-| standalone_iterators.cpp:102:6:102:7 | c1 | standalone_iterators.cpp:102:9:102:13 | call to begin | TAINT |
-| standalone_iterators.cpp:102:6:102:7 | ref arg c1 | standalone_iterators.cpp:106:6:106:7 | c1 |  |
-| standalone_iterators.cpp:102:6:102:7 | ref arg c1 | standalone_iterators.cpp:109:7:109:8 | c1 |  |
-| standalone_iterators.cpp:102:9:102:13 | call to begin | standalone_iterators.cpp:102:2:102:15 | ... = ... |  |
-| standalone_iterators.cpp:102:9:102:13 | call to begin | standalone_iterators.cpp:107:7:107:7 | b |  |
-| standalone_iterators.cpp:103:2:103:2 | ref arg call to operator* | standalone_iterators.cpp:103:3:103:3 | ref arg a | TAINT |
-| standalone_iterators.cpp:103:2:103:2 | ref arg call to operator* | standalone_iterators.cpp:106:6:106:7 | c1 |  |
-| standalone_iterators.cpp:103:2:103:2 | ref arg call to operator* | standalone_iterators.cpp:109:7:109:8 | c1 |  |
-| standalone_iterators.cpp:103:3:103:3 | a | standalone_iterators.cpp:103:2:103:2 | call to operator* | TAINT |
-| standalone_iterators.cpp:103:3:103:3 | ref arg a | standalone_iterators.cpp:104:7:104:7 | a |  |
-| standalone_iterators.cpp:103:7:103:12 | call to source | standalone_iterators.cpp:103:2:103:2 | ref arg call to operator* | TAINT |
-| standalone_iterators.cpp:104:7:104:7 | a [post update] | standalone_iterators.cpp:106:6:106:7 | c1 |  |
-| standalone_iterators.cpp:104:7:104:7 | a [post update] | standalone_iterators.cpp:109:7:109:8 | c1 |  |
-| standalone_iterators.cpp:106:6:106:7 | c1 | standalone_iterators.cpp:106:9:106:13 | call to begin | TAINT |
-| standalone_iterators.cpp:106:6:106:7 | ref arg c1 | standalone_iterators.cpp:109:7:109:8 | c1 |  |
-| standalone_iterators.cpp:106:9:106:13 | call to begin | standalone_iterators.cpp:106:2:106:15 | ... = ... |  |
-| standalone_iterators.cpp:106:9:106:13 | call to begin | standalone_iterators.cpp:108:7:108:7 | c |  |
-| standalone_iterators.cpp:107:7:107:7 | b [post update] | standalone_iterators.cpp:109:7:109:8 | c1 |  |
-| standalone_iterators.cpp:108:7:108:7 | c [post update] | standalone_iterators.cpp:109:7:109:8 | c1 |  |
-| standalone_iterators.cpp:113:15:113:16 | call to container | standalone_iterators.cpp:116:7:116:8 | c1 |  |
-| standalone_iterators.cpp:113:15:113:16 | call to container | standalone_iterators.cpp:122:7:122:8 | c1 |  |
-| standalone_iterators.cpp:116:7:116:8 | c1 | standalone_iterators.cpp:116:10:116:14 | call to begin | TAINT |
-| standalone_iterators.cpp:116:7:116:8 | ref arg c1 | standalone_iterators.cpp:122:7:122:8 | c1 |  |
-| standalone_iterators.cpp:116:10:116:14 | call to begin | standalone_iterators.cpp:116:2:116:16 | ... = ... |  |
-| standalone_iterators.cpp:116:10:116:14 | call to begin | standalone_iterators.cpp:117:7:117:8 | it |  |
-| standalone_iterators.cpp:116:10:116:14 | call to begin | standalone_iterators.cpp:118:2:118:3 | it |  |
-| standalone_iterators.cpp:116:10:116:14 | call to begin | standalone_iterators.cpp:119:7:119:8 | it |  |
-| standalone_iterators.cpp:116:10:116:14 | call to begin | standalone_iterators.cpp:120:2:120:3 | it |  |
-| standalone_iterators.cpp:116:10:116:14 | call to begin | standalone_iterators.cpp:121:7:121:8 | it |  |
-| standalone_iterators.cpp:117:7:117:8 | it [post update] | standalone_iterators.cpp:122:7:122:8 | c1 |  |
-| standalone_iterators.cpp:118:2:118:3 | it | standalone_iterators.cpp:118:5:118:5 | call to operator+= | TAINT |
-| standalone_iterators.cpp:118:2:118:3 | ref arg it | standalone_iterators.cpp:119:7:119:8 | it |  |
-| standalone_iterators.cpp:118:2:118:3 | ref arg it | standalone_iterators.cpp:120:2:120:3 | it |  |
-| standalone_iterators.cpp:118:2:118:3 | ref arg it | standalone_iterators.cpp:121:7:121:8 | it |  |
-| standalone_iterators.cpp:118:2:118:3 | ref arg it | standalone_iterators.cpp:122:7:122:8 | c1 |  |
-| standalone_iterators.cpp:118:8:118:8 | 1 | standalone_iterators.cpp:118:2:118:3 | ref arg it | TAINT |
-| standalone_iterators.cpp:120:2:120:3 | it | standalone_iterators.cpp:120:5:120:5 | call to operator+= | TAINT |
-| standalone_iterators.cpp:120:2:120:3 | ref arg it | standalone_iterators.cpp:121:7:121:8 | it |  |
-| standalone_iterators.cpp:120:8:120:13 | call to source | standalone_iterators.cpp:120:2:120:3 | ref arg it | TAINT |
+| standalone_iterators.cpp:43:45:43:51 | source1 | standalone_iterators.cpp:43:45:43:51 | source1 |  |
+| standalone_iterators.cpp:43:45:43:51 | source1 | standalone_iterators.cpp:44:11:44:17 | source1 |  |
+| standalone_iterators.cpp:43:45:43:51 | source1 | standalone_iterators.cpp:45:12:45:18 | source1 |  |
+| standalone_iterators.cpp:43:45:43:51 | source1 | standalone_iterators.cpp:46:14:46:20 | source1 |  |
+| standalone_iterators.cpp:44:11:44:17 | source1 | standalone_iterators.cpp:44:10:44:10 | call to operator* | TAINT |
+| standalone_iterators.cpp:45:12:45:18 | ref arg source1 | standalone_iterators.cpp:43:45:43:51 | source1 |  |
+| standalone_iterators.cpp:45:12:45:18 | ref arg source1 | standalone_iterators.cpp:46:14:46:20 | source1 |  |
+| standalone_iterators.cpp:45:12:45:18 | source1 | standalone_iterators.cpp:45:19:45:19 | call to operator++ |  |
+| standalone_iterators.cpp:45:19:45:19 | call to operator++ | standalone_iterators.cpp:45:10:45:10 | call to operator* | TAINT |
+| standalone_iterators.cpp:46:12:46:12 | call to operator++ | standalone_iterators.cpp:46:10:46:10 | call to operator* | TAINT |
+| standalone_iterators.cpp:46:14:46:20 | ref arg source1 | standalone_iterators.cpp:43:45:43:51 | source1 |  |
+| standalone_iterators.cpp:46:14:46:20 | source1 | standalone_iterators.cpp:46:12:46:12 | call to operator++ |  |
+| standalone_iterators.cpp:49:39:49:45 | source1 | standalone_iterators.cpp:49:39:49:45 | source1 |  |
+| standalone_iterators.cpp:49:39:49:45 | source1 | standalone_iterators.cpp:50:11:50:17 | source1 |  |
+| standalone_iterators.cpp:49:39:49:45 | source1 | standalone_iterators.cpp:51:12:51:18 | source1 |  |
+| standalone_iterators.cpp:49:39:49:45 | source1 | standalone_iterators.cpp:52:14:52:20 | source1 |  |
+| standalone_iterators.cpp:50:11:50:17 | source1 | standalone_iterators.cpp:50:10:50:10 | call to operator* | TAINT |
+| standalone_iterators.cpp:51:12:51:18 | ref arg source1 | standalone_iterators.cpp:49:39:49:45 | source1 |  |
+| standalone_iterators.cpp:51:12:51:18 | ref arg source1 | standalone_iterators.cpp:52:14:52:20 | source1 |  |
+| standalone_iterators.cpp:51:12:51:18 | source1 | standalone_iterators.cpp:51:19:51:19 | call to operator++ |  |
+| standalone_iterators.cpp:51:19:51:19 | call to operator++ | standalone_iterators.cpp:51:10:51:10 | call to operator* | TAINT |
+| standalone_iterators.cpp:52:12:52:12 | call to operator++ | standalone_iterators.cpp:52:10:52:10 | call to operator* | TAINT |
+| standalone_iterators.cpp:52:14:52:20 | ref arg source1 | standalone_iterators.cpp:49:39:49:45 | source1 |  |
+| standalone_iterators.cpp:52:14:52:20 | source1 | standalone_iterators.cpp:52:12:52:12 | call to operator++ |  |
+| standalone_iterators.cpp:55:37:55:43 | source1 | standalone_iterators.cpp:56:11:56:17 | source1 |  |
+| standalone_iterators.cpp:55:37:55:43 | source1 | standalone_iterators.cpp:57:12:57:18 | source1 |  |
+| standalone_iterators.cpp:55:37:55:43 | source1 | standalone_iterators.cpp:58:14:58:20 | source1 |  |
+| standalone_iterators.cpp:57:12:57:18 | ref arg source1 | standalone_iterators.cpp:58:14:58:20 | source1 |  |
+| standalone_iterators.cpp:91:15:91:16 | call to container | standalone_iterators.cpp:93:35:93:36 | c1 |  |
+| standalone_iterators.cpp:91:15:91:16 | call to container | standalone_iterators.cpp:95:10:95:11 | c1 |  |
+| standalone_iterators.cpp:91:19:91:20 | call to container | standalone_iterators.cpp:97:35:97:36 | c2 |  |
+| standalone_iterators.cpp:91:19:91:20 | call to container | standalone_iterators.cpp:99:10:99:11 | c2 |  |
+| standalone_iterators.cpp:93:35:93:36 | c1 | standalone_iterators.cpp:93:38:93:42 | call to begin | TAINT |
+| standalone_iterators.cpp:93:35:93:36 | ref arg c1 | standalone_iterators.cpp:95:10:95:11 | c1 |  |
+| standalone_iterators.cpp:93:38:93:42 | call to begin | standalone_iterators.cpp:94:6:94:7 | i1 |  |
+| standalone_iterators.cpp:94:5:94:5 | ref arg call to operator* | standalone_iterators.cpp:94:8:94:8 | ref arg call to operator-- | TAINT |
+| standalone_iterators.cpp:94:5:94:5 | ref arg call to operator* | standalone_iterators.cpp:95:10:95:11 | c1 |  |
+| standalone_iterators.cpp:94:6:94:7 | i1 | standalone_iterators.cpp:94:8:94:8 | call to operator-- |  |
+| standalone_iterators.cpp:94:8:94:8 | call to operator-- | standalone_iterators.cpp:94:5:94:5 | call to operator* | TAINT |
+| standalone_iterators.cpp:94:8:94:8 | ref arg call to operator-- | standalone_iterators.cpp:94:6:94:7 | ref arg i1 |  |
+| standalone_iterators.cpp:94:13:94:18 | call to source | standalone_iterators.cpp:94:5:94:5 | ref arg call to operator* | TAINT |
+| standalone_iterators.cpp:97:35:97:36 | c2 | standalone_iterators.cpp:97:38:97:42 | call to begin | TAINT |
+| standalone_iterators.cpp:97:35:97:36 | ref arg c2 | standalone_iterators.cpp:99:10:99:11 | c2 |  |
+| standalone_iterators.cpp:97:38:97:42 | call to begin | standalone_iterators.cpp:98:6:98:7 | i2 |  |
+| standalone_iterators.cpp:98:5:98:5 | ref arg call to operator* | standalone_iterators.cpp:98:8:98:8 | ref arg call to operator-- | TAINT |
+| standalone_iterators.cpp:98:5:98:5 | ref arg call to operator* | standalone_iterators.cpp:99:10:99:11 | c2 |  |
+| standalone_iterators.cpp:98:6:98:7 | i2 | standalone_iterators.cpp:98:8:98:8 | call to operator-- |  |
+| standalone_iterators.cpp:98:8:98:8 | call to operator-- | standalone_iterators.cpp:98:5:98:5 | call to operator* | TAINT |
+| standalone_iterators.cpp:98:8:98:8 | ref arg call to operator-- | standalone_iterators.cpp:98:6:98:7 | ref arg i2 |  |
+| standalone_iterators.cpp:98:13:98:13 | 0 | standalone_iterators.cpp:98:5:98:5 | ref arg call to operator* | TAINT |
+| standalone_iterators.cpp:106:15:106:16 | call to container | standalone_iterators.cpp:109:6:109:7 | c1 |  |
+| standalone_iterators.cpp:106:15:106:16 | call to container | standalone_iterators.cpp:110:6:110:7 | c1 |  |
+| standalone_iterators.cpp:106:15:106:16 | call to container | standalone_iterators.cpp:114:6:114:7 | c1 |  |
+| standalone_iterators.cpp:106:15:106:16 | call to container | standalone_iterators.cpp:117:7:117:8 | c1 |  |
+| standalone_iterators.cpp:109:6:109:7 | c1 | standalone_iterators.cpp:109:9:109:13 | call to begin | TAINT |
+| standalone_iterators.cpp:109:6:109:7 | ref arg c1 | standalone_iterators.cpp:110:6:110:7 | c1 |  |
+| standalone_iterators.cpp:109:6:109:7 | ref arg c1 | standalone_iterators.cpp:114:6:114:7 | c1 |  |
+| standalone_iterators.cpp:109:6:109:7 | ref arg c1 | standalone_iterators.cpp:117:7:117:8 | c1 |  |
+| standalone_iterators.cpp:109:9:109:13 | call to begin | standalone_iterators.cpp:109:2:109:15 | ... = ... |  |
+| standalone_iterators.cpp:109:9:109:13 | call to begin | standalone_iterators.cpp:111:3:111:3 | a |  |
+| standalone_iterators.cpp:109:9:109:13 | call to begin | standalone_iterators.cpp:112:7:112:7 | a |  |
+| standalone_iterators.cpp:110:6:110:7 | c1 | standalone_iterators.cpp:110:9:110:13 | call to begin | TAINT |
+| standalone_iterators.cpp:110:6:110:7 | ref arg c1 | standalone_iterators.cpp:114:6:114:7 | c1 |  |
+| standalone_iterators.cpp:110:6:110:7 | ref arg c1 | standalone_iterators.cpp:117:7:117:8 | c1 |  |
+| standalone_iterators.cpp:110:9:110:13 | call to begin | standalone_iterators.cpp:110:2:110:15 | ... = ... |  |
+| standalone_iterators.cpp:110:9:110:13 | call to begin | standalone_iterators.cpp:115:7:115:7 | b |  |
+| standalone_iterators.cpp:111:2:111:2 | ref arg call to operator* | standalone_iterators.cpp:111:3:111:3 | ref arg a | TAINT |
+| standalone_iterators.cpp:111:2:111:2 | ref arg call to operator* | standalone_iterators.cpp:114:6:114:7 | c1 |  |
+| standalone_iterators.cpp:111:2:111:2 | ref arg call to operator* | standalone_iterators.cpp:117:7:117:8 | c1 |  |
+| standalone_iterators.cpp:111:3:111:3 | a | standalone_iterators.cpp:111:2:111:2 | call to operator* | TAINT |
+| standalone_iterators.cpp:111:3:111:3 | ref arg a | standalone_iterators.cpp:112:7:112:7 | a |  |
+| standalone_iterators.cpp:111:7:111:12 | call to source | standalone_iterators.cpp:111:2:111:2 | ref arg call to operator* | TAINT |
+| standalone_iterators.cpp:112:7:112:7 | a [post update] | standalone_iterators.cpp:114:6:114:7 | c1 |  |
+| standalone_iterators.cpp:112:7:112:7 | a [post update] | standalone_iterators.cpp:117:7:117:8 | c1 |  |
+| standalone_iterators.cpp:114:6:114:7 | c1 | standalone_iterators.cpp:114:9:114:13 | call to begin | TAINT |
+| standalone_iterators.cpp:114:6:114:7 | ref arg c1 | standalone_iterators.cpp:117:7:117:8 | c1 |  |
+| standalone_iterators.cpp:114:9:114:13 | call to begin | standalone_iterators.cpp:114:2:114:15 | ... = ... |  |
+| standalone_iterators.cpp:114:9:114:13 | call to begin | standalone_iterators.cpp:116:7:116:7 | c |  |
+| standalone_iterators.cpp:115:7:115:7 | b [post update] | standalone_iterators.cpp:117:7:117:8 | c1 |  |
+| standalone_iterators.cpp:116:7:116:7 | c [post update] | standalone_iterators.cpp:117:7:117:8 | c1 |  |
+| standalone_iterators.cpp:121:15:121:16 | call to container | standalone_iterators.cpp:124:7:124:8 | c1 |  |
+| standalone_iterators.cpp:121:15:121:16 | call to container | standalone_iterators.cpp:130:7:130:8 | c1 |  |
+| standalone_iterators.cpp:124:7:124:8 | c1 | standalone_iterators.cpp:124:10:124:14 | call to begin | TAINT |
+| standalone_iterators.cpp:124:7:124:8 | ref arg c1 | standalone_iterators.cpp:130:7:130:8 | c1 |  |
+| standalone_iterators.cpp:124:10:124:14 | call to begin | standalone_iterators.cpp:124:2:124:16 | ... = ... |  |
+| standalone_iterators.cpp:124:10:124:14 | call to begin | standalone_iterators.cpp:125:7:125:8 | it |  |
+| standalone_iterators.cpp:124:10:124:14 | call to begin | standalone_iterators.cpp:126:2:126:3 | it |  |
+| standalone_iterators.cpp:124:10:124:14 | call to begin | standalone_iterators.cpp:127:7:127:8 | it |  |
+| standalone_iterators.cpp:124:10:124:14 | call to begin | standalone_iterators.cpp:128:2:128:3 | it |  |
+| standalone_iterators.cpp:124:10:124:14 | call to begin | standalone_iterators.cpp:129:7:129:8 | it |  |
+| standalone_iterators.cpp:125:7:125:8 | it [post update] | standalone_iterators.cpp:130:7:130:8 | c1 |  |
+| standalone_iterators.cpp:126:2:126:3 | it | standalone_iterators.cpp:126:5:126:5 | call to operator+= | TAINT |
+| standalone_iterators.cpp:126:2:126:3 | ref arg it | standalone_iterators.cpp:127:7:127:8 | it |  |
+| standalone_iterators.cpp:126:2:126:3 | ref arg it | standalone_iterators.cpp:128:2:128:3 | it |  |
+| standalone_iterators.cpp:126:2:126:3 | ref arg it | standalone_iterators.cpp:129:7:129:8 | it |  |
+| standalone_iterators.cpp:126:2:126:3 | ref arg it | standalone_iterators.cpp:130:7:130:8 | c1 |  |
+| standalone_iterators.cpp:126:8:126:8 | 1 | standalone_iterators.cpp:126:2:126:3 | ref arg it | TAINT |
+| standalone_iterators.cpp:128:2:128:3 | it | standalone_iterators.cpp:128:5:128:5 | call to operator+= | TAINT |
+| standalone_iterators.cpp:128:2:128:3 | ref arg it | standalone_iterators.cpp:129:7:129:8 | it |  |
+| standalone_iterators.cpp:128:8:128:13 | call to source | standalone_iterators.cpp:128:2:128:3 | ref arg it | TAINT |
 | stl.h:75:8:75:8 | container | stl.h:75:8:75:8 | constructor init of field container | TAINT |
 | stl.h:75:8:75:8 | container | stl.h:75:8:75:8 | constructor init of field container | TAINT |
 | stl.h:75:8:75:8 | container | stl.h:75:8:75:8 | container |  |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/standalone_iterators.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/standalone_iterators.cpp
@@ -27,6 +27,10 @@ public:
 template<>
 struct std::iterator_traits<int_iterator_by_trait> {
     typedef input_iterator_tag iterator_category;
+    typedef int value_type;
+    typedef size_t difference_type;
+    typedef int* pointer;
+    typedef int& reference;
 };
 
 class non_iterator {
@@ -69,6 +73,10 @@ public:
 template<>
 struct std::iterator_traits<insert_iterator_by_trait> {
     typedef output_iterator_tag iterator_category;
+    typedef int value_type;
+    typedef size_t difference_type;
+    typedef int* pointer;
+    typedef int& reference;
 };
 
 class container {


### PR DESCRIPTION
The specializations we had for `int_iterator_by_trait` and `insert_iterator_by_trait` didn't define all the types. This is making us lose dataflow-through-iterator results on the use-use flow branch.