### PR TITLE
C++: Positively phrased sanitizer in `cpp/non-constant-format`

### DIFF
--- a/cpp/ql/src/Likely Bugs/Format/NonConstantFormat.ql
+++ b/cpp/ql/src/Likely Bugs/Format/NonConstantFormat.ql
@@ -120,8 +120,7 @@ pragma[noinline]
 predicate isSanitizerNode(DataFlow::Node node) {
   underscoreMacro(node.asExpr())
   or
-  not exists(node.asIndirectExpr()) and
-  not exists(node.asDefiningArgument()) and
+  exists(node.asExpr()) and
   cannotContainString(node.getType(), false)
 }
 


### PR DESCRIPTION
The sanitizer in the `cpp/non-constant-format` query was very fragile: it's supposed to look at the type of the node, and mark it as a sanitizer if the type reveals that the node could not possible hold a string.

This was easy to do before we introduced indirect dataflow nodes: we could just mark all non-pointer nodes as sanitizers because we were tracking a value of type `char*`. However, when we track indirect nodes as well, those nodes can have type `char` (since we're tracking the indirection of the `char`).

So when we introduced indirect nodes, we modified the sanitizer to not sanitize indirect nodes (for instance, by saying that `node.asIndirectExpr()` shouldn't exist). However, this relies on _all_ indirect nodes having a result for `asIndirectExpr()` which doesn't have to be true (since plenty of dataflow nodes do not map to an expression).

Instead, this PR rephrases the sanitizer to only sanitize nodes for which `node.asExpr()` holds. This predicate never has a result for indirect nodes, so the effect should be the same, but it won't depend on each indirect dataflow node having a result for `asIndirectExpr()`.