### PR TITLE
C++: Map operand nodes that are only used once onto the related instruction node

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -49,11 +49,7 @@ class Node0Impl extends TIRDataFlowNode0 {
   DataFlowType getType() { none() } // overridden in subclasses
 
   /** Gets the instruction corresponding to this node, if any. */
-  Instruction asInstruction() {
-    result = this.(InstructionNode0).getInstruction()
-    or
-    result = Ssa::getIRRepresentationOfOperand(this.(SingleUseOperandNode0).getOperand())
-  }
+  Instruction asInstruction() { result = this.(InstructionNode0).getInstruction() }
 
   /** Gets the operands corresponding to this node, if any. */
   Operand asOperand() { result = this.(OperandNode0).getOperand() }
@@ -78,10 +74,8 @@ class Node0Impl extends TIRDataFlowNode0 {
 /**
  * An instruction, viewed as a node in a data flow graph.
  */
-class InstructionNode0 extends Node0Impl, TInstructionNode0 {
+abstract class InstructionNode0 extends Node0Impl {
   Instruction instr;
-
-  InstructionNode0() { this = TInstructionNode0(instr) }
 
   /** Gets the instruction corresponding to this node. */
   Instruction getInstruction() { result = instr }
@@ -98,6 +92,25 @@ class InstructionNode0 extends Node0Impl, TInstructionNode0 {
     // This predicate is overridden in subclasses. This default implementation
     // does not use `Instruction.toString` because that's expensive to compute.
     result = instr.getOpcode().toString()
+  }
+}
+
+/**
+ * An instruction without an operand that is used only once, viewed as a node in a data flow graph.
+ */
+private class InstructionInstructionNode0 extends InstructionNode0, TInstructionNode0 {
+  InstructionInstructionNode0() { this = TInstructionNode0(instr) }
+}
+
+/**
+ * An instruction with an operand that is used only once, viewed as a node in a data flow graph.
+ */
+private class SingleUseOperandInstructionNode0 extends InstructionNode0, TSingleUseOperandNode0 {
+  SingleUseOperandInstructionNode0() {
+    exists(Operand op |
+      this = TSingleUseOperandNode0(op) and
+      instr = Ssa::getIRRepresentationOfOperand(op)
+    )
   }
 }
 
@@ -124,14 +137,14 @@ abstract class OperandNode0 extends Node0Impl {
 /**
  * An operand that is used multiple times, viewed as a node in a data flow graph.
  */
-class MultipleUseOperandNode0 extends OperandNode0, TMultipleUseOperandNode0 {
+private class MultipleUseOperandNode0 extends OperandNode0, TMultipleUseOperandNode0 {
   MultipleUseOperandNode0() { this = TMultipleUseOperandNode0(op) }
 }
 
 /**
  * An operand that is used only once, viewed as a node in a data flow graph.
  */
-class SingleUseOperandNode0 extends OperandNode0, TSingleUseOperandNode0 {
+private class SingleUseOperandNode0 extends OperandNode0, TSingleUseOperandNode0 {
   SingleUseOperandNode0() { this = TSingleUseOperandNode0(op) }
 }
 

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -383,13 +383,10 @@ private class Node0 extends Node, TNode0 {
  * An instruction, viewed as a node in a data flow graph.
  */
 class InstructionNode extends Node0 {
+  override InstructionNode0 node;
   Instruction instr;
 
-  InstructionNode() {
-    node.(InstructionNode0).getInstruction() = instr
-    or
-    Ssa::getIRRepresentationOfOperand(node.(SingleUseOperandNode0).getOperand()) = instr
-  }
+  InstructionNode() { instr = node.getInstruction() }
 
   /** Gets the instruction corresponding to this node. */
   Instruction getInstruction() { result = instr }

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternalsCommon.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternalsCommon.qll
@@ -720,6 +720,18 @@ private module Cached {
   }
 
   /**
+   * Holds if the underlying IR has a suitable instruction to represent a value
+   * that would otherwise need to be represented by a dedicated `OperandNode` value.
+   *
+   * Such operands do not create new `OperandNode` values, but are
+   * instead associated with the instruction returned by this predicate.
+   */
+  cached
+  Instruction getIRRepresentationOfOperand(Operand operand) {
+    operand = unique( | | result.getAUse())
+  }
+
+  /**
    * Holds if the underlying IR has a suitable operand to represent a value
    * that would otherwise need to be represented by a dedicated `RawIndirectOperand` value.
    *

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-129/semmle/ImproperArrayIndexValidation/ImproperArrayIndexValidation.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-129/semmle/ImproperArrayIndexValidation/ImproperArrayIndexValidation.expected
@@ -1,23 +1,18 @@
 edges
 | test1.c:7:26:7:29 | argv | test1.c:9:9:9:9 | i |
 | test1.c:7:26:7:29 | argv | test1.c:11:9:11:9 | i |
-| test1.c:7:26:7:29 | argv | test1.c:12:9:12:9 | i |
 | test1.c:7:26:7:29 | argv | test1.c:13:9:13:9 | i |
 | test1.c:7:26:7:29 | argv indirection | test1.c:9:9:9:9 | i |
 | test1.c:7:26:7:29 | argv indirection | test1.c:9:9:9:9 | i |
 | test1.c:7:26:7:29 | argv indirection | test1.c:11:9:11:9 | i |
 | test1.c:7:26:7:29 | argv indirection | test1.c:11:9:11:9 | i |
-| test1.c:7:26:7:29 | argv indirection | test1.c:12:9:12:9 | i |
-| test1.c:7:26:7:29 | argv indirection | test1.c:12:9:12:9 | i |
 | test1.c:7:26:7:29 | argv indirection | test1.c:13:9:13:9 | i |
 | test1.c:7:26:7:29 | argv indirection | test1.c:13:9:13:9 | i |
 | test1.c:9:9:9:9 | i | test1.c:16:16:16:16 | i |
 | test1.c:11:9:11:9 | i | test1.c:32:16:32:16 | i |
-| test1.c:12:9:12:9 | i | test1.c:40:16:40:16 | i |
 | test1.c:13:9:13:9 | i | test1.c:48:16:48:16 | i |
 | test1.c:16:16:16:16 | i | test1.c:18:16:18:16 | i |
 | test1.c:32:16:32:16 | i | test1.c:33:11:33:11 | i |
-| test1.c:40:16:40:16 | i | test1.c:41:11:41:11 | i |
 | test1.c:48:16:48:16 | i | test1.c:53:15:53:15 | j |
 nodes
 | test1.c:7:26:7:29 | argv | semmle.label | argv |
@@ -25,14 +20,11 @@ nodes
 | test1.c:7:26:7:29 | argv indirection | semmle.label | argv indirection |
 | test1.c:9:9:9:9 | i | semmle.label | i |
 | test1.c:11:9:11:9 | i | semmle.label | i |
-| test1.c:12:9:12:9 | i | semmle.label | i |
 | test1.c:13:9:13:9 | i | semmle.label | i |
 | test1.c:16:16:16:16 | i | semmle.label | i |
 | test1.c:18:16:18:16 | i | semmle.label | i |
 | test1.c:32:16:32:16 | i | semmle.label | i |
 | test1.c:33:11:33:11 | i | semmle.label | i |
-| test1.c:40:16:40:16 | i | semmle.label | i |
-| test1.c:41:11:41:11 | i | semmle.label | i |
 | test1.c:48:16:48:16 | i | semmle.label | i |
 | test1.c:53:15:53:15 | j | semmle.label | j |
 subpaths
@@ -43,9 +35,6 @@ subpaths
 | test1.c:33:11:33:11 | i | test1.c:7:26:7:29 | argv | test1.c:33:11:33:11 | i | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | argv | a command-line argument |
 | test1.c:33:11:33:11 | i | test1.c:7:26:7:29 | argv indirection | test1.c:33:11:33:11 | i | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | argv indirection | a command-line argument |
 | test1.c:33:11:33:11 | i | test1.c:7:26:7:29 | argv indirection | test1.c:33:11:33:11 | i | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | argv indirection | a command-line argument |
-| test1.c:41:11:41:11 | i | test1.c:7:26:7:29 | argv | test1.c:41:11:41:11 | i | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | argv | a command-line argument |
-| test1.c:41:11:41:11 | i | test1.c:7:26:7:29 | argv indirection | test1.c:41:11:41:11 | i | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | argv indirection | a command-line argument |
-| test1.c:41:11:41:11 | i | test1.c:7:26:7:29 | argv indirection | test1.c:41:11:41:11 | i | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | argv indirection | a command-line argument |
 | test1.c:53:15:53:15 | j | test1.c:7:26:7:29 | argv | test1.c:53:15:53:15 | j | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | argv | a command-line argument |
 | test1.c:53:15:53:15 | j | test1.c:7:26:7:29 | argv indirection | test1.c:53:15:53:15 | j | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | argv indirection | a command-line argument |
 | test1.c:53:15:53:15 | j | test1.c:7:26:7:29 | argv indirection | test1.c:53:15:53:15 | j | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | argv indirection | a command-line argument |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/globalVars/UncontrolledFormatStringThroughGlobalVar.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/globalVars/UncontrolledFormatStringThroughGlobalVar.expected
@@ -2,7 +2,6 @@ edges
 | globalVars.c:8:7:8:10 | copy | globalVars.c:27:9:27:12 | copy |
 | globalVars.c:8:7:8:10 | copy | globalVars.c:27:9:27:12 | copy |
 | globalVars.c:8:7:8:10 | copy | globalVars.c:27:9:27:12 | copy |
-| globalVars.c:8:7:8:10 | copy | globalVars.c:27:9:27:12 | copy |
 | globalVars.c:8:7:8:10 | copy | globalVars.c:30:15:30:18 | copy |
 | globalVars.c:8:7:8:10 | copy | globalVars.c:30:15:30:18 | copy |
 | globalVars.c:8:7:8:10 | copy | globalVars.c:30:15:30:18 | copy |
@@ -12,12 +11,10 @@ edges
 | globalVars.c:9:7:9:11 | copy2 | globalVars.c:38:9:38:13 | copy2 |
 | globalVars.c:9:7:9:11 | copy2 | globalVars.c:38:9:38:13 | copy2 |
 | globalVars.c:9:7:9:11 | copy2 | globalVars.c:38:9:38:13 | copy2 |
-| globalVars.c:9:7:9:11 | copy2 | globalVars.c:38:9:38:13 | copy2 |
 | globalVars.c:9:7:9:11 | copy2 | globalVars.c:41:15:41:19 | copy2 |
 | globalVars.c:9:7:9:11 | copy2 | globalVars.c:41:15:41:19 | copy2 |
 | globalVars.c:9:7:9:11 | copy2 | globalVars.c:41:15:41:19 | copy2 |
 | globalVars.c:9:7:9:11 | copy2 | globalVars.c:44:15:44:19 | copy2 |
-| globalVars.c:9:7:9:11 | copy2 | globalVars.c:50:9:50:13 | copy2 |
 | globalVars.c:9:7:9:11 | copy2 | globalVars.c:50:9:50:13 | copy2 |
 | globalVars.c:9:7:9:11 | copy2 | globalVars.c:50:9:50:13 | copy2 |
 | globalVars.c:9:7:9:11 | copy2 | globalVars.c:50:9:50:13 | copy2 |
@@ -29,26 +26,12 @@ edges
 | globalVars.c:16:2:16:12 | ... = ... | globalVars.c:9:7:9:11 | copy2 |
 | globalVars.c:24:11:24:14 | argv | globalVars.c:11:22:11:25 | argv |
 | globalVars.c:24:11:24:14 | argv | globalVars.c:11:22:11:25 | argv |
-| globalVars.c:27:9:27:12 | copy | globalVars.c:27:9:27:12 | copy |
-| globalVars.c:27:9:27:12 | copy | globalVars.c:27:9:27:12 | copy |
-| globalVars.c:27:9:27:12 | copy | globalVars.c:27:9:27:12 | copy |
-| globalVars.c:27:9:27:12 | copy | globalVars.c:30:15:30:18 | copy |
-| globalVars.c:27:9:27:12 | copy | globalVars.c:30:15:30:18 | copy |
-| globalVars.c:27:9:27:12 | copy | globalVars.c:35:11:35:14 | copy |
 | globalVars.c:30:15:30:18 | copy | globalVars.c:30:15:30:18 | copy |
 | globalVars.c:30:15:30:18 | copy | globalVars.c:30:15:30:18 | copy |
 | globalVars.c:30:15:30:18 | copy | globalVars.c:35:11:35:14 | copy |
 | globalVars.c:33:15:33:18 | copy | globalVars.c:35:11:35:14 | copy |
 | globalVars.c:35:11:35:14 | copy | globalVars.c:15:21:15:23 | val |
 | globalVars.c:35:11:35:14 | copy | globalVars.c:35:11:35:14 | copy |
-| globalVars.c:38:9:38:13 | copy2 | globalVars.c:38:9:38:13 | copy2 |
-| globalVars.c:38:9:38:13 | copy2 | globalVars.c:38:9:38:13 | copy2 |
-| globalVars.c:38:9:38:13 | copy2 | globalVars.c:38:9:38:13 | copy2 |
-| globalVars.c:38:9:38:13 | copy2 | globalVars.c:41:15:41:19 | copy2 |
-| globalVars.c:38:9:38:13 | copy2 | globalVars.c:41:15:41:19 | copy2 |
-| globalVars.c:38:9:38:13 | copy2 | globalVars.c:50:9:50:13 | copy2 |
-| globalVars.c:38:9:38:13 | copy2 | globalVars.c:50:9:50:13 | copy2 |
-| globalVars.c:38:9:38:13 | copy2 | globalVars.c:50:9:50:13 | copy2 |
 | globalVars.c:41:15:41:19 | copy2 | globalVars.c:41:15:41:19 | copy2 |
 | globalVars.c:41:15:41:19 | copy2 | globalVars.c:41:15:41:19 | copy2 |
 | globalVars.c:41:15:41:19 | copy2 | globalVars.c:50:9:50:13 | copy2 |
@@ -57,9 +40,6 @@ edges
 | globalVars.c:44:15:44:19 | copy2 | globalVars.c:50:9:50:13 | copy2 |
 | globalVars.c:44:15:44:19 | copy2 | globalVars.c:50:9:50:13 | copy2 |
 | globalVars.c:44:15:44:19 | copy2 | globalVars.c:50:9:50:13 | copy2 |
-| globalVars.c:50:9:50:13 | copy2 | globalVars.c:50:9:50:13 | copy2 |
-| globalVars.c:50:9:50:13 | copy2 | globalVars.c:50:9:50:13 | copy2 |
-| globalVars.c:50:9:50:13 | copy2 | globalVars.c:50:9:50:13 | copy2 |
 subpaths
 nodes
 | globalVars.c:8:7:8:10 | copy | semmle.label | copy |
@@ -73,7 +53,6 @@ nodes
 | globalVars.c:27:9:27:12 | copy | semmle.label | copy |
 | globalVars.c:27:9:27:12 | copy | semmle.label | copy |
 | globalVars.c:27:9:27:12 | copy | semmle.label | copy |
-| globalVars.c:27:9:27:12 | copy | semmle.label | copy |
 | globalVars.c:30:15:30:18 | copy | semmle.label | copy |
 | globalVars.c:30:15:30:18 | copy | semmle.label | copy |
 | globalVars.c:30:15:30:18 | copy | semmle.label | copy |
@@ -83,12 +62,10 @@ nodes
 | globalVars.c:38:9:38:13 | copy2 | semmle.label | copy2 |
 | globalVars.c:38:9:38:13 | copy2 | semmle.label | copy2 |
 | globalVars.c:38:9:38:13 | copy2 | semmle.label | copy2 |
-| globalVars.c:38:9:38:13 | copy2 | semmle.label | copy2 |
 | globalVars.c:41:15:41:19 | copy2 | semmle.label | copy2 |
 | globalVars.c:41:15:41:19 | copy2 | semmle.label | copy2 |
 | globalVars.c:41:15:41:19 | copy2 | semmle.label | copy2 |
 | globalVars.c:44:15:44:19 | copy2 | semmle.label | copy2 |
-| globalVars.c:50:9:50:13 | copy2 | semmle.label | copy2 |
 | globalVars.c:50:9:50:13 | copy2 | semmle.label | copy2 |
 | globalVars.c:50:9:50:13 | copy2 | semmle.label | copy2 |
 | globalVars.c:50:9:50:13 | copy2 | semmle.label | copy2 |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-326/InsufficientKeySize.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-326/InsufficientKeySize.expected
@@ -1,13 +1,7 @@
 edges
-| test.cpp:34:45:34:48 | 1024 | test.cpp:34:45:34:48 | 1024 |
-| test.cpp:35:49:35:52 | 1024 | test.cpp:35:49:35:52 | 1024 |
-| test.cpp:37:43:37:46 | 1024 | test.cpp:37:43:37:46 | 1024 |
 nodes
 | test.cpp:34:45:34:48 | 1024 | semmle.label | 1024 |
-| test.cpp:34:45:34:48 | 1024 | semmle.label | 1024 |
 | test.cpp:35:49:35:52 | 1024 | semmle.label | 1024 |
-| test.cpp:35:49:35:52 | 1024 | semmle.label | 1024 |
-| test.cpp:37:43:37:46 | 1024 | semmle.label | 1024 |
 | test.cpp:37:43:37:46 | 1024 | semmle.label | 1024 |
 subpaths
 #select


### PR DESCRIPTION
Also revert the changes to default taint tracking and `TaintedAllocationSize.ql` as these are no longer needed with the above mapping.