### PR TITLE
C++: Add missing condition to `isChiBeforeIteratorUse`

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternalsCommon.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternalsCommon.qll
@@ -538,6 +538,7 @@ private module Cached {
       numberOfLoads >= 0 and
       isUse(_, iteratorDerefAddress, iteratorBase, numberOfLoads + 2, 0) and
       iteratorBase.getResultType() instanceof Interfaces::Iterator and
+      load.getSourceAddressOperand() = iteratorDerefAddress and
       read.getPrimaryInstruction() = load.getSourceAddress() and
       memory = read.getSideEffectOperand().getAnyDef()
     )


### PR DESCRIPTION
We were missing the condition that connected the `LoadInstruction` to the address being dereferenced.

For some reason this doesn't add any FPs on the current feature branch, but I'm seeing a lot of FPs from missing this condition on my local branch that adds more iterator flow 🤔.

DCA reports nothing exciting.