### PR TITLE
Java: update package for `QueryProducer` sinks

### DIFF
--- a/java/ql/lib/change-notes/2023-01-27-update-queryproducer-sinks.md
+++ b/java/ql/lib/change-notes/2023-01-27-update-queryproducer-sinks.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Added sink models for the `createQuery`, `createNativeQuery`, and `createSQLQuery` methods of the `org.hibernate.query.QueryProducer` interface.

--- a/java/ql/lib/ext/org.hibernate.model.yml
+++ b/java/ql/lib/ext/org.hibernate.model.yml
@@ -3,9 +3,6 @@ extensions:
       pack: codeql/java-all
       extensible: sinkModel
     data:
-      - ["org.hibernate", "QueryProducer", True, "createNativeQuery", "", "", "Argument[0]", "sql", "manual"]
-      - ["org.hibernate", "QueryProducer", True, "createQuery", "", "", "Argument[0]", "sql", "manual"]
-      - ["org.hibernate", "QueryProducer", True, "createSQLQuery", "", "", "Argument[0]", "sql", "manual"]
       - ["org.hibernate", "Session", True, "createQuery", "", "", "Argument[0]", "sql", "manual"]
       - ["org.hibernate", "Session", True, "createSQLQuery", "", "", "Argument[0]", "sql", "manual"]
       - ["org.hibernate", "SharedSessionContract", True, "createQuery", "", "", "Argument[0]", "sql", "manual"]

--- a/java/ql/lib/ext/org.hibernate.query.model.yml
+++ b/java/ql/lib/ext/org.hibernate.query.model.yml
@@ -1,0 +1,8 @@
+extensions:
+  - addsTo:
+      pack: codeql/java-all
+      extensible: sinkModel
+    data:
+      - ["org.hibernate.query", "QueryProducer", True, "createNativeQuery", "", "", "Argument[0]", "sql", "manual"]
+      - ["org.hibernate.query", "QueryProducer", True, "createQuery", "", "", "Argument[0]", "sql", "manual"]
+      - ["org.hibernate.query", "QueryProducer", True, "createSQLQuery", "", "", "Argument[0]", "sql", "manual"]


### PR DESCRIPTION
### Description
This PR updates the package for `QueryProducer` sinks to `org.hibernate.query` instead of `org.hibernate`.
According to the [docs](https://javadoc.io/doc/org.hibernate/hibernate-core/5.4.9.Final/org/hibernate/query/QueryProducer.html) and the [`HibernateQueryProducer`](https://github.com/github/codeql/blob/6c0b50c69691cf7a14d3ec3a3400c487022971a0/java/ql/lib/semmle/code/java/frameworks/Hibernate.qll#L9) type in `Hibernate.qll`, the package for `QueryProducer` should be `org.hibernate.query`.
MRVA shows new results from the `java/sql-injection` query after this update is made.

Let me know if there is any reason why these should not be updated.