### PR TITLE
DataFlow: Fix join in `fwdFlowRead`

### DIFF
--- a/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -1487,6 +1487,10 @@ private module MkStage<StageSig PrevStage> {
       PrevStage::readStepCand(node1, _, _, config)
     }
 
+    bindingset[ap, c]
+    pragma[inline_late]
+    private predicate hasHeadContent(Ap ap, Content c) { getHeadContent(ap) = c }
+
     pragma[nomagic]
     private predicate fwdFlowRead(
       Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc,
@@ -1494,7 +1498,7 @@ private module MkStage<StageSig PrevStage> {
     ) {
       fwdFlowRead0(node1, state, cc, summaryCtx, argAp, ap, config) and
       PrevStage::readStepCand(node1, c, node2, config) and
-      getHeadContent(ap) = c
+      hasHeadContent(ap, c)
     }
 
     pragma[nomagic]

--- a/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -1487,6 +1487,10 @@ private module MkStage<StageSig PrevStage> {
       PrevStage::readStepCand(node1, _, _, config)
     }
 
+    bindingset[ap, c]
+    pragma[inline_late]
+    private predicate hasHeadContent(Ap ap, Content c) { getHeadContent(ap) = c }
+
     pragma[nomagic]
     private predicate fwdFlowRead(
       Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc,
@@ -1494,7 +1498,7 @@ private module MkStage<StageSig PrevStage> {
     ) {
       fwdFlowRead0(node1, state, cc, summaryCtx, argAp, ap, config) and
       PrevStage::readStepCand(node1, c, node2, config) and
-      getHeadContent(ap) = c
+      hasHeadContent(ap, c)
     }
 
     pragma[nomagic]

--- a/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -1487,6 +1487,10 @@ private module MkStage<StageSig PrevStage> {
       PrevStage::readStepCand(node1, _, _, config)
     }
 
+    bindingset[ap, c]
+    pragma[inline_late]
+    private predicate hasHeadContent(Ap ap, Content c) { getHeadContent(ap) = c }
+
     pragma[nomagic]
     private predicate fwdFlowRead(
       Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc,
@@ -1494,7 +1498,7 @@ private module MkStage<StageSig PrevStage> {
     ) {
       fwdFlowRead0(node1, state, cc, summaryCtx, argAp, ap, config) and
       PrevStage::readStepCand(node1, c, node2, config) and
-      getHeadContent(ap) = c
+      hasHeadContent(ap, c)
     }
 
     pragma[nomagic]

--- a/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -1487,6 +1487,10 @@ private module MkStage<StageSig PrevStage> {
       PrevStage::readStepCand(node1, _, _, config)
     }
 
+    bindingset[ap, c]
+    pragma[inline_late]
+    private predicate hasHeadContent(Ap ap, Content c) { getHeadContent(ap) = c }
+
     pragma[nomagic]
     private predicate fwdFlowRead(
       Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc,
@@ -1494,7 +1498,7 @@ private module MkStage<StageSig PrevStage> {
     ) {
       fwdFlowRead0(node1, state, cc, summaryCtx, argAp, ap, config) and
       PrevStage::readStepCand(node1, c, node2, config) and
-      getHeadContent(ap) = c
+      hasHeadContent(ap, c)
     }
 
     pragma[nomagic]

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -1487,6 +1487,10 @@ private module MkStage<StageSig PrevStage> {
       PrevStage::readStepCand(node1, _, _, config)
     }
 
+    bindingset[ap, c]
+    pragma[inline_late]
+    private predicate hasHeadContent(Ap ap, Content c) { getHeadContent(ap) = c }
+
     pragma[nomagic]
     private predicate fwdFlowRead(
       Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc,
@@ -1494,7 +1498,7 @@ private module MkStage<StageSig PrevStage> {
     ) {
       fwdFlowRead0(node1, state, cc, summaryCtx, argAp, ap, config) and
       PrevStage::readStepCand(node1, c, node2, config) and
-      getHeadContent(ap) = c
+      hasHeadContent(ap, c)
     }
 
     pragma[nomagic]

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
@@ -1487,6 +1487,10 @@ private module MkStage<StageSig PrevStage> {
       PrevStage::readStepCand(node1, _, _, config)
     }
 
+    bindingset[ap, c]
+    pragma[inline_late]
+    private predicate hasHeadContent(Ap ap, Content c) { getHeadContent(ap) = c }
+
     pragma[nomagic]
     private predicate fwdFlowRead(
       Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc,
@@ -1494,7 +1498,7 @@ private module MkStage<StageSig PrevStage> {
     ) {
       fwdFlowRead0(node1, state, cc, summaryCtx, argAp, ap, config) and
       PrevStage::readStepCand(node1, c, node2, config) and
-      getHeadContent(ap) = c
+      hasHeadContent(ap, c)
     }
 
     pragma[nomagic]

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
@@ -1487,6 +1487,10 @@ private module MkStage<StageSig PrevStage> {
       PrevStage::readStepCand(node1, _, _, config)
     }
 
+    bindingset[ap, c]
+    pragma[inline_late]
+    private predicate hasHeadContent(Ap ap, Content c) { getHeadContent(ap) = c }
+
     pragma[nomagic]
     private predicate fwdFlowRead(
       Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc,
@@ -1494,7 +1498,7 @@ private module MkStage<StageSig PrevStage> {
     ) {
       fwdFlowRead0(node1, state, cc, summaryCtx, argAp, ap, config) and
       PrevStage::readStepCand(node1, c, node2, config) and
-      getHeadContent(ap) = c
+      hasHeadContent(ap, c)
     }
 
     pragma[nomagic]

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
@@ -1487,6 +1487,10 @@ private module MkStage<StageSig PrevStage> {
       PrevStage::readStepCand(node1, _, _, config)
     }
 
+    bindingset[ap, c]
+    pragma[inline_late]
+    private predicate hasHeadContent(Ap ap, Content c) { getHeadContent(ap) = c }
+
     pragma[nomagic]
     private predicate fwdFlowRead(
       Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc,
@@ -1494,7 +1498,7 @@ private module MkStage<StageSig PrevStage> {
     ) {
       fwdFlowRead0(node1, state, cc, summaryCtx, argAp, ap, config) and
       PrevStage::readStepCand(node1, c, node2, config) and
-      getHeadContent(ap) = c
+      hasHeadContent(ap, c)
     }
 
     pragma[nomagic]

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
@@ -1487,6 +1487,10 @@ private module MkStage<StageSig PrevStage> {
       PrevStage::readStepCand(node1, _, _, config)
     }
 
+    bindingset[ap, c]
+    pragma[inline_late]
+    private predicate hasHeadContent(Ap ap, Content c) { getHeadContent(ap) = c }
+
     pragma[nomagic]
     private predicate fwdFlowRead(
       Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc,
@@ -1494,7 +1498,7 @@ private module MkStage<StageSig PrevStage> {
     ) {
       fwdFlowRead0(node1, state, cc, summaryCtx, argAp, ap, config) and
       PrevStage::readStepCand(node1, c, node2, config) and
-      getHeadContent(ap) = c
+      hasHeadContent(ap, c)
     }
 
     pragma[nomagic]

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -1487,6 +1487,10 @@ private module MkStage<StageSig PrevStage> {
       PrevStage::readStepCand(node1, _, _, config)
     }
 
+    bindingset[ap, c]
+    pragma[inline_late]
+    private predicate hasHeadContent(Ap ap, Content c) { getHeadContent(ap) = c }
+
     pragma[nomagic]
     private predicate fwdFlowRead(
       Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc,
@@ -1494,7 +1498,7 @@ private module MkStage<StageSig PrevStage> {
     ) {
       fwdFlowRead0(node1, state, cc, summaryCtx, argAp, ap, config) and
       PrevStage::readStepCand(node1, c, node2, config) and
-      getHeadContent(ap) = c
+      hasHeadContent(ap, c)
     }
 
     pragma[nomagic]

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -1487,6 +1487,10 @@ private module MkStage<StageSig PrevStage> {
       PrevStage::readStepCand(node1, _, _, config)
     }
 
+    bindingset[ap, c]
+    pragma[inline_late]
+    private predicate hasHeadContent(Ap ap, Content c) { getHeadContent(ap) = c }
+
     pragma[nomagic]
     private predicate fwdFlowRead(
       Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc,
@@ -1494,7 +1498,7 @@ private module MkStage<StageSig PrevStage> {
     ) {
       fwdFlowRead0(node1, state, cc, summaryCtx, argAp, ap, config) and
       PrevStage::readStepCand(node1, c, node2, config) and
-      getHeadContent(ap) = c
+      hasHeadContent(ap, c)
     }
 
     pragma[nomagic]

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -1487,6 +1487,10 @@ private module MkStage<StageSig PrevStage> {
       PrevStage::readStepCand(node1, _, _, config)
     }
 
+    bindingset[ap, c]
+    pragma[inline_late]
+    private predicate hasHeadContent(Ap ap, Content c) { getHeadContent(ap) = c }
+
     pragma[nomagic]
     private predicate fwdFlowRead(
       Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc,
@@ -1494,7 +1498,7 @@ private module MkStage<StageSig PrevStage> {
     ) {
       fwdFlowRead0(node1, state, cc, summaryCtx, argAp, ap, config) and
       PrevStage::readStepCand(node1, c, node2, config) and
-      getHeadContent(ap) = c
+      hasHeadContent(ap, c)
     }
 
     pragma[nomagic]

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -1487,6 +1487,10 @@ private module MkStage<StageSig PrevStage> {
       PrevStage::readStepCand(node1, _, _, config)
     }
 
+    bindingset[ap, c]
+    pragma[inline_late]
+    private predicate hasHeadContent(Ap ap, Content c) { getHeadContent(ap) = c }
+
     pragma[nomagic]
     private predicate fwdFlowRead(
       Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc,
@@ -1494,7 +1498,7 @@ private module MkStage<StageSig PrevStage> {
     ) {
       fwdFlowRead0(node1, state, cc, summaryCtx, argAp, ap, config) and
       PrevStage::readStepCand(node1, c, node2, config) and
-      getHeadContent(ap) = c
+      hasHeadContent(ap, c)
     }
 
     pragma[nomagic]

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -1487,6 +1487,10 @@ private module MkStage<StageSig PrevStage> {
       PrevStage::readStepCand(node1, _, _, config)
     }
 
+    bindingset[ap, c]
+    pragma[inline_late]
+    private predicate hasHeadContent(Ap ap, Content c) { getHeadContent(ap) = c }
+
     pragma[nomagic]
     private predicate fwdFlowRead(
       Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc,
@@ -1494,7 +1498,7 @@ private module MkStage<StageSig PrevStage> {
     ) {
       fwdFlowRead0(node1, state, cc, summaryCtx, argAp, ap, config) and
       PrevStage::readStepCand(node1, c, node2, config) and
-      getHeadContent(ap) = c
+      hasHeadContent(ap, c)
     }
 
     pragma[nomagic]

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
@@ -1487,6 +1487,10 @@ private module MkStage<StageSig PrevStage> {
       PrevStage::readStepCand(node1, _, _, config)
     }
 
+    bindingset[ap, c]
+    pragma[inline_late]
+    private predicate hasHeadContent(Ap ap, Content c) { getHeadContent(ap) = c }
+
     pragma[nomagic]
     private predicate fwdFlowRead(
       Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc,
@@ -1494,7 +1498,7 @@ private module MkStage<StageSig PrevStage> {
     ) {
       fwdFlowRead0(node1, state, cc, summaryCtx, argAp, ap, config) and
       PrevStage::readStepCand(node1, c, node2, config) and
-      getHeadContent(ap) = c
+      hasHeadContent(ap, c)
     }
 
     pragma[nomagic]

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
@@ -1487,6 +1487,10 @@ private module MkStage<StageSig PrevStage> {
       PrevStage::readStepCand(node1, _, _, config)
     }
 
+    bindingset[ap, c]
+    pragma[inline_late]
+    private predicate hasHeadContent(Ap ap, Content c) { getHeadContent(ap) = c }
+
     pragma[nomagic]
     private predicate fwdFlowRead(
       Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc,
@@ -1494,7 +1498,7 @@ private module MkStage<StageSig PrevStage> {
     ) {
       fwdFlowRead0(node1, state, cc, summaryCtx, argAp, ap, config) and
       PrevStage::readStepCand(node1, c, node2, config) and
-      getHeadContent(ap) = c
+      hasHeadContent(ap, c)
     }
 
     pragma[nomagic]

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
@@ -1487,6 +1487,10 @@ private module MkStage<StageSig PrevStage> {
       PrevStage::readStepCand(node1, _, _, config)
     }
 
+    bindingset[ap, c]
+    pragma[inline_late]
+    private predicate hasHeadContent(Ap ap, Content c) { getHeadContent(ap) = c }
+
     pragma[nomagic]
     private predicate fwdFlowRead(
       Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc,
@@ -1494,7 +1498,7 @@ private module MkStage<StageSig PrevStage> {
     ) {
       fwdFlowRead0(node1, state, cc, summaryCtx, argAp, ap, config) and
       PrevStage::readStepCand(node1, c, node2, config) and
-      getHeadContent(ap) = c
+      hasHeadContent(ap, c)
     }
 
     pragma[nomagic]

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
@@ -1487,6 +1487,10 @@ private module MkStage<StageSig PrevStage> {
       PrevStage::readStepCand(node1, _, _, config)
     }
 
+    bindingset[ap, c]
+    pragma[inline_late]
+    private predicate hasHeadContent(Ap ap, Content c) { getHeadContent(ap) = c }
+
     pragma[nomagic]
     private predicate fwdFlowRead(
       Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc,
@@ -1494,7 +1498,7 @@ private module MkStage<StageSig PrevStage> {
     ) {
       fwdFlowRead0(node1, state, cc, summaryCtx, argAp, ap, config) and
       PrevStage::readStepCand(node1, c, node2, config) and
-      getHeadContent(ap) = c
+      hasHeadContent(ap, c)
     }
 
     pragma[nomagic]

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImplForContentDataFlow.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImplForContentDataFlow.qll
@@ -1487,6 +1487,10 @@ private module MkStage<StageSig PrevStage> {
       PrevStage::readStepCand(node1, _, _, config)
     }
 
+    bindingset[ap, c]
+    pragma[inline_late]
+    private predicate hasHeadContent(Ap ap, Content c) { getHeadContent(ap) = c }
+
     pragma[nomagic]
     private predicate fwdFlowRead(
       Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc,
@@ -1494,7 +1498,7 @@ private module MkStage<StageSig PrevStage> {
     ) {
       fwdFlowRead0(node1, state, cc, summaryCtx, argAp, ap, config) and
       PrevStage::readStepCand(node1, c, node2, config) and
-      getHeadContent(ap) = c
+      hasHeadContent(ap, c)
     }
 
     pragma[nomagic]

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowImpl.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowImpl.qll
@@ -1487,6 +1487,10 @@ private module MkStage<StageSig PrevStage> {
       PrevStage::readStepCand(node1, _, _, config)
     }
 
+    bindingset[ap, c]
+    pragma[inline_late]
+    private predicate hasHeadContent(Ap ap, Content c) { getHeadContent(ap) = c }
+
     pragma[nomagic]
     private predicate fwdFlowRead(
       Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc,
@@ -1494,7 +1498,7 @@ private module MkStage<StageSig PrevStage> {
     ) {
       fwdFlowRead0(node1, state, cc, summaryCtx, argAp, ap, config) and
       PrevStage::readStepCand(node1, c, node2, config) and
-      getHeadContent(ap) = c
+      hasHeadContent(ap, c)
     }
 
     pragma[nomagic]

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowImpl2.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowImpl2.qll
@@ -1487,6 +1487,10 @@ private module MkStage<StageSig PrevStage> {
       PrevStage::readStepCand(node1, _, _, config)
     }
 
+    bindingset[ap, c]
+    pragma[inline_late]
+    private predicate hasHeadContent(Ap ap, Content c) { getHeadContent(ap) = c }
+
     pragma[nomagic]
     private predicate fwdFlowRead(
       Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc,
@@ -1494,7 +1498,7 @@ private module MkStage<StageSig PrevStage> {
     ) {
       fwdFlowRead0(node1, state, cc, summaryCtx, argAp, ap, config) and
       PrevStage::readStepCand(node1, c, node2, config) and
-      getHeadContent(ap) = c
+      hasHeadContent(ap, c)
     }
 
     pragma[nomagic]

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowImplForStringsNewReplacer.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowImplForStringsNewReplacer.qll
@@ -1487,6 +1487,10 @@ private module MkStage<StageSig PrevStage> {
       PrevStage::readStepCand(node1, _, _, config)
     }
 
+    bindingset[ap, c]
+    pragma[inline_late]
+    private predicate hasHeadContent(Ap ap, Content c) { getHeadContent(ap) = c }
+
     pragma[nomagic]
     private predicate fwdFlowRead(
       Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc,
@@ -1494,7 +1498,7 @@ private module MkStage<StageSig PrevStage> {
     ) {
       fwdFlowRead0(node1, state, cc, summaryCtx, argAp, ap, config) and
       PrevStage::readStepCand(node1, c, node2, config) and
-      getHeadContent(ap) = c
+      hasHeadContent(ap, c)
     }
 
     pragma[nomagic]

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -1487,6 +1487,10 @@ private module MkStage<StageSig PrevStage> {
       PrevStage::readStepCand(node1, _, _, config)
     }
 
+    bindingset[ap, c]
+    pragma[inline_late]
+    private predicate hasHeadContent(Ap ap, Content c) { getHeadContent(ap) = c }
+
     pragma[nomagic]
     private predicate fwdFlowRead(
       Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc,
@@ -1494,7 +1498,7 @@ private module MkStage<StageSig PrevStage> {
     ) {
       fwdFlowRead0(node1, state, cc, summaryCtx, argAp, ap, config) and
       PrevStage::readStepCand(node1, c, node2, config) and
-      getHeadContent(ap) = c
+      hasHeadContent(ap, c)
     }
 
     pragma[nomagic]

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
@@ -1487,6 +1487,10 @@ private module MkStage<StageSig PrevStage> {
       PrevStage::readStepCand(node1, _, _, config)
     }
 
+    bindingset[ap, c]
+    pragma[inline_late]
+    private predicate hasHeadContent(Ap ap, Content c) { getHeadContent(ap) = c }
+
     pragma[nomagic]
     private predicate fwdFlowRead(
       Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc,
@@ -1494,7 +1498,7 @@ private module MkStage<StageSig PrevStage> {
     ) {
       fwdFlowRead0(node1, state, cc, summaryCtx, argAp, ap, config) and
       PrevStage::readStepCand(node1, c, node2, config) and
-      getHeadContent(ap) = c
+      hasHeadContent(ap, c)
     }
 
     pragma[nomagic]

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
@@ -1487,6 +1487,10 @@ private module MkStage<StageSig PrevStage> {
       PrevStage::readStepCand(node1, _, _, config)
     }
 
+    bindingset[ap, c]
+    pragma[inline_late]
+    private predicate hasHeadContent(Ap ap, Content c) { getHeadContent(ap) = c }
+
     pragma[nomagic]
     private predicate fwdFlowRead(
       Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc,
@@ -1494,7 +1498,7 @@ private module MkStage<StageSig PrevStage> {
     ) {
       fwdFlowRead0(node1, state, cc, summaryCtx, argAp, ap, config) and
       PrevStage::readStepCand(node1, c, node2, config) and
-      getHeadContent(ap) = c
+      hasHeadContent(ap, c)
     }
 
     pragma[nomagic]

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
@@ -1487,6 +1487,10 @@ private module MkStage<StageSig PrevStage> {
       PrevStage::readStepCand(node1, _, _, config)
     }
 
+    bindingset[ap, c]
+    pragma[inline_late]
+    private predicate hasHeadContent(Ap ap, Content c) { getHeadContent(ap) = c }
+
     pragma[nomagic]
     private predicate fwdFlowRead(
       Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc,
@@ -1494,7 +1498,7 @@ private module MkStage<StageSig PrevStage> {
     ) {
       fwdFlowRead0(node1, state, cc, summaryCtx, argAp, ap, config) and
       PrevStage::readStepCand(node1, c, node2, config) and
-      getHeadContent(ap) = c
+      hasHeadContent(ap, c)
     }
 
     pragma[nomagic]

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
@@ -1487,6 +1487,10 @@ private module MkStage<StageSig PrevStage> {
       PrevStage::readStepCand(node1, _, _, config)
     }
 
+    bindingset[ap, c]
+    pragma[inline_late]
+    private predicate hasHeadContent(Ap ap, Content c) { getHeadContent(ap) = c }
+
     pragma[nomagic]
     private predicate fwdFlowRead(
       Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc,
@@ -1494,7 +1498,7 @@ private module MkStage<StageSig PrevStage> {
     ) {
       fwdFlowRead0(node1, state, cc, summaryCtx, argAp, ap, config) and
       PrevStage::readStepCand(node1, c, node2, config) and
-      getHeadContent(ap) = c
+      hasHeadContent(ap, c)
     }
 
     pragma[nomagic]

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl6.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl6.qll
@@ -1487,6 +1487,10 @@ private module MkStage<StageSig PrevStage> {
       PrevStage::readStepCand(node1, _, _, config)
     }
 
+    bindingset[ap, c]
+    pragma[inline_late]
+    private predicate hasHeadContent(Ap ap, Content c) { getHeadContent(ap) = c }
+
     pragma[nomagic]
     private predicate fwdFlowRead(
       Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc,
@@ -1494,7 +1498,7 @@ private module MkStage<StageSig PrevStage> {
     ) {
       fwdFlowRead0(node1, state, cc, summaryCtx, argAp, ap, config) and
       PrevStage::readStepCand(node1, c, node2, config) and
-      getHeadContent(ap) = c
+      hasHeadContent(ap, c)
     }
 
     pragma[nomagic]

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplForOnActivityResult.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplForOnActivityResult.qll
@@ -1487,6 +1487,10 @@ private module MkStage<StageSig PrevStage> {
       PrevStage::readStepCand(node1, _, _, config)
     }
 
+    bindingset[ap, c]
+    pragma[inline_late]
+    private predicate hasHeadContent(Ap ap, Content c) { getHeadContent(ap) = c }
+
     pragma[nomagic]
     private predicate fwdFlowRead(
       Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc,
@@ -1494,7 +1498,7 @@ private module MkStage<StageSig PrevStage> {
     ) {
       fwdFlowRead0(node1, state, cc, summaryCtx, argAp, ap, config) and
       PrevStage::readStepCand(node1, c, node2, config) and
-      getHeadContent(ap) = c
+      hasHeadContent(ap, c)
     }
 
     pragma[nomagic]

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplForSerializability.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplForSerializability.qll
@@ -1487,6 +1487,10 @@ private module MkStage<StageSig PrevStage> {
       PrevStage::readStepCand(node1, _, _, config)
     }
 
+    bindingset[ap, c]
+    pragma[inline_late]
+    private predicate hasHeadContent(Ap ap, Content c) { getHeadContent(ap) = c }
+
     pragma[nomagic]
     private predicate fwdFlowRead(
       Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc,
@@ -1494,7 +1498,7 @@ private module MkStage<StageSig PrevStage> {
     ) {
       fwdFlowRead0(node1, state, cc, summaryCtx, argAp, ap, config) and
       PrevStage::readStepCand(node1, c, node2, config) and
-      getHeadContent(ap) = c
+      hasHeadContent(ap, c)
     }
 
     pragma[nomagic]

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl.qll
@@ -1487,6 +1487,10 @@ private module MkStage<StageSig PrevStage> {
       PrevStage::readStepCand(node1, _, _, config)
     }
 
+    bindingset[ap, c]
+    pragma[inline_late]
+    private predicate hasHeadContent(Ap ap, Content c) { getHeadContent(ap) = c }
+
     pragma[nomagic]
     private predicate fwdFlowRead(
       Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc,
@@ -1494,7 +1498,7 @@ private module MkStage<StageSig PrevStage> {
     ) {
       fwdFlowRead0(node1, state, cc, summaryCtx, argAp, ap, config) and
       PrevStage::readStepCand(node1, c, node2, config) and
-      getHeadContent(ap) = c
+      hasHeadContent(ap, c)
     }
 
     pragma[nomagic]

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl2.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl2.qll
@@ -1487,6 +1487,10 @@ private module MkStage<StageSig PrevStage> {
       PrevStage::readStepCand(node1, _, _, config)
     }
 
+    bindingset[ap, c]
+    pragma[inline_late]
+    private predicate hasHeadContent(Ap ap, Content c) { getHeadContent(ap) = c }
+
     pragma[nomagic]
     private predicate fwdFlowRead(
       Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc,
@@ -1494,7 +1498,7 @@ private module MkStage<StageSig PrevStage> {
     ) {
       fwdFlowRead0(node1, state, cc, summaryCtx, argAp, ap, config) and
       PrevStage::readStepCand(node1, c, node2, config) and
-      getHeadContent(ap) = c
+      hasHeadContent(ap, c)
     }
 
     pragma[nomagic]

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl3.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl3.qll
@@ -1487,6 +1487,10 @@ private module MkStage<StageSig PrevStage> {
       PrevStage::readStepCand(node1, _, _, config)
     }
 
+    bindingset[ap, c]
+    pragma[inline_late]
+    private predicate hasHeadContent(Ap ap, Content c) { getHeadContent(ap) = c }
+
     pragma[nomagic]
     private predicate fwdFlowRead(
       Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc,
@@ -1494,7 +1498,7 @@ private module MkStage<StageSig PrevStage> {
     ) {
       fwdFlowRead0(node1, state, cc, summaryCtx, argAp, ap, config) and
       PrevStage::readStepCand(node1, c, node2, config) and
-      getHeadContent(ap) = c
+      hasHeadContent(ap, c)
     }
 
     pragma[nomagic]

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl4.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl4.qll
@@ -1487,6 +1487,10 @@ private module MkStage<StageSig PrevStage> {
       PrevStage::readStepCand(node1, _, _, config)
     }
 
+    bindingset[ap, c]
+    pragma[inline_late]
+    private predicate hasHeadContent(Ap ap, Content c) { getHeadContent(ap) = c }
+
     pragma[nomagic]
     private predicate fwdFlowRead(
       Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc,
@@ -1494,7 +1498,7 @@ private module MkStage<StageSig PrevStage> {
     ) {
       fwdFlowRead0(node1, state, cc, summaryCtx, argAp, ap, config) and
       PrevStage::readStepCand(node1, c, node2, config) and
-      getHeadContent(ap) = c
+      hasHeadContent(ap, c)
     }
 
     pragma[nomagic]

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl.qll
@@ -1487,6 +1487,10 @@ private module MkStage<StageSig PrevStage> {
       PrevStage::readStepCand(node1, _, _, config)
     }
 
+    bindingset[ap, c]
+    pragma[inline_late]
+    private predicate hasHeadContent(Ap ap, Content c) { getHeadContent(ap) = c }
+
     pragma[nomagic]
     private predicate fwdFlowRead(
       Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc,
@@ -1494,7 +1498,7 @@ private module MkStage<StageSig PrevStage> {
     ) {
       fwdFlowRead0(node1, state, cc, summaryCtx, argAp, ap, config) and
       PrevStage::readStepCand(node1, c, node2, config) and
-      getHeadContent(ap) = c
+      hasHeadContent(ap, c)
     }
 
     pragma[nomagic]

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl2.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl2.qll
@@ -1487,6 +1487,10 @@ private module MkStage<StageSig PrevStage> {
       PrevStage::readStepCand(node1, _, _, config)
     }
 
+    bindingset[ap, c]
+    pragma[inline_late]
+    private predicate hasHeadContent(Ap ap, Content c) { getHeadContent(ap) = c }
+
     pragma[nomagic]
     private predicate fwdFlowRead(
       Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc,
@@ -1494,7 +1498,7 @@ private module MkStage<StageSig PrevStage> {
     ) {
       fwdFlowRead0(node1, state, cc, summaryCtx, argAp, ap, config) and
       PrevStage::readStepCand(node1, c, node2, config) and
-      getHeadContent(ap) = c
+      hasHeadContent(ap, c)
     }
 
     pragma[nomagic]

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplForHttpClientLibraries.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplForHttpClientLibraries.qll
@@ -1487,6 +1487,10 @@ private module MkStage<StageSig PrevStage> {
       PrevStage::readStepCand(node1, _, _, config)
     }
 
+    bindingset[ap, c]
+    pragma[inline_late]
+    private predicate hasHeadContent(Ap ap, Content c) { getHeadContent(ap) = c }
+
     pragma[nomagic]
     private predicate fwdFlowRead(
       Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc,
@@ -1494,7 +1498,7 @@ private module MkStage<StageSig PrevStage> {
     ) {
       fwdFlowRead0(node1, state, cc, summaryCtx, argAp, ap, config) and
       PrevStage::readStepCand(node1, c, node2, config) and
-      getHeadContent(ap) = c
+      hasHeadContent(ap, c)
     }
 
     pragma[nomagic]

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplForPathname.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplForPathname.qll
@@ -1487,6 +1487,10 @@ private module MkStage<StageSig PrevStage> {
       PrevStage::readStepCand(node1, _, _, config)
     }
 
+    bindingset[ap, c]
+    pragma[inline_late]
+    private predicate hasHeadContent(Ap ap, Content c) { getHeadContent(ap) = c }
+
     pragma[nomagic]
     private predicate fwdFlowRead(
       Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc,
@@ -1494,7 +1498,7 @@ private module MkStage<StageSig PrevStage> {
     ) {
       fwdFlowRead0(node1, state, cc, summaryCtx, argAp, ap, config) and
       PrevStage::readStepCand(node1, c, node2, config) and
-      getHeadContent(ap) = c
+      hasHeadContent(ap, c)
     }
 
     pragma[nomagic]

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplForRegExp.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplForRegExp.qll
@@ -1487,6 +1487,10 @@ private module MkStage<StageSig PrevStage> {
       PrevStage::readStepCand(node1, _, _, config)
     }
 
+    bindingset[ap, c]
+    pragma[inline_late]
+    private predicate hasHeadContent(Ap ap, Content c) { getHeadContent(ap) = c }
+
     pragma[nomagic]
     private predicate fwdFlowRead(
       Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc,
@@ -1494,7 +1498,7 @@ private module MkStage<StageSig PrevStage> {
     ) {
       fwdFlowRead0(node1, state, cc, summaryCtx, argAp, ap, config) and
       PrevStage::readStepCand(node1, c, node2, config) and
-      getHeadContent(ap) = c
+      hasHeadContent(ap, c)
     }
 
     pragma[nomagic]

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImpl.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImpl.qll
@@ -1487,6 +1487,10 @@ private module MkStage<StageSig PrevStage> {
       PrevStage::readStepCand(node1, _, _, config)
     }
 
+    bindingset[ap, c]
+    pragma[inline_late]
+    private predicate hasHeadContent(Ap ap, Content c) { getHeadContent(ap) = c }
+
     pragma[nomagic]
     private predicate fwdFlowRead(
       Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc,
@@ -1494,7 +1498,7 @@ private module MkStage<StageSig PrevStage> {
     ) {
       fwdFlowRead0(node1, state, cc, summaryCtx, argAp, ap, config) and
       PrevStage::readStepCand(node1, c, node2, config) and
-      getHeadContent(ap) = c
+      hasHeadContent(ap, c)
     }
 
     pragma[nomagic]


### PR DESCRIPTION
Before (on `vim/vim`):
```
Pipeline order_500000 for DataFlowImpl#9021cc4c::MkStage#Stage2#::Stage#Stage3Param#::fwdFlowRead#9#fffffffff#reorder_0_1_8_2_3_4_5_6_7@6322e1w6 was evaluated in 149 iterations totaling 5563ms (delta sizes total: 140038).
            50161  ~1%    {7} r1 = SCAN DataFlowImpl#9021cc4c::MkStage#Stage2#::Stage#Stage3Param#::fwdFlowRead0#7#fffffff#prev_delta OUTPUT In.5, In.0, In.1, In.2, In.3, In.4, In.6
        198587399  ~1%    {8} r2 = JOIN r1 WITH DataFlowImpl#9021cc4c::Stage3Param::getHeadContent#1#ff ON FIRST 1 OUTPUT Lhs.1, Rhs.1, Lhs.6, Lhs.2, Lhs.3, Lhs.4, Lhs.5, Lhs.0
           140038  ~1%    {9} r3 = JOIN r2 WITH DataFlowImpl#9021cc4c::MkStage#Stage1#::Stage#Stage2Param#::readStepCand#4#ffff_0132#join_rhs ON FIRST 3 OUTPUT Lhs.7, Lhs.1, Lhs.2, Lhs.0, Rhs.3, Lhs.3, Lhs.4, Lhs.5, Lhs.6
                          return r3
```

After:
```
Pipeline order_500000 for DataFlowImpl#9021cc4c::MkStage#Stage2#::Stage#Stage3Param#::fwdFlowRead#9#fffffffff#reorder_0_1_8_2_3_4_5_6_7@a04731w3 was evaluated in 149 iterations totaling 110ms (delta sizes total: 140038).
         50161  ~1%    {7} r1 = SCAN DataFlowImpl#9021cc4c::MkStage#Stage2#::Stage#Stage3Param#::fwdFlowRead0#7#fffffff#prev_delta OUTPUT In.0, In.6, In.1, In.2, In.3, In.4, In.5
        140038  ~1%    {9} r2 = JOIN r1 WITH DataFlowImpl#9021cc4c::MkStage#Stage1#::Stage#Stage2Param#::readStepCand#4#ffff_0312#join_rhs ON FIRST 2 OUTPUT Lhs.6, Rhs.2, Lhs.0, Lhs.2, Lhs.3, Lhs.4, Lhs.5, Lhs.1, Rhs.3
        140038  ~1%    {9} r3 = JOIN r2 WITH DataFlowImpl#9021cc4c::Stage3Param::getHeadContent#1#ff ON FIRST 2 OUTPUT Lhs.0, Lhs.1, Lhs.7, Lhs.2, Lhs.8, Lhs.3, Lhs.4, Lhs.5, Lhs.6
                       return r3
```