### PR TITLE
QL: fixup the dependabot config for QL-for-QL

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,11 @@ updates:
     schedule:
       interval: "daily"
 
+  - package-ecosystem: "cargo"
+    directory: "ql"
+    schedule:
+      interval: "daily"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Doing the same thing as was done here for Ruby:  https://github.com/github/codeql/pull/11969