### PR TITLE
C++: Add `getCall` predicate to `ArgumentOperand`

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/Operand.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/Operand.qll
@@ -412,6 +412,9 @@ class CallTargetOperand extends RegisterOperand {
  */
 class ArgumentOperand extends RegisterOperand {
   override ArgumentOperandTag tag;
+
+  /** Gets the `CallInstruction` for which this is an argument. */
+  CallInstruction getCall() { result.getAnArgumentOperand() = this }
 }
 
 /**

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/Operand.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/Operand.qll
@@ -412,6 +412,9 @@ class CallTargetOperand extends RegisterOperand {
  */
 class ArgumentOperand extends RegisterOperand {
   override ArgumentOperandTag tag;
+
+  /** Gets the `CallInstruction` for which this is an argument. */
+  CallInstruction getCall() { result.getAnArgumentOperand() = this }
 }
 
 /**

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/Operand.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/Operand.qll
@@ -412,6 +412,9 @@ class CallTargetOperand extends RegisterOperand {
  */
 class ArgumentOperand extends RegisterOperand {
   override ArgumentOperandTag tag;
+
+  /** Gets the `CallInstruction` for which this is an argument. */
+  CallInstruction getCall() { result.getAnArgumentOperand() = this }
 }
 
 /**

--- a/csharp/ql/src/experimental/ir/implementation/raw/Operand.qll
+++ b/csharp/ql/src/experimental/ir/implementation/raw/Operand.qll
@@ -412,6 +412,9 @@ class CallTargetOperand extends RegisterOperand {
  */
 class ArgumentOperand extends RegisterOperand {
   override ArgumentOperandTag tag;
+
+  /** Gets the `CallInstruction` for which this is an argument. */
+  CallInstruction getCall() { result.getAnArgumentOperand() = this }
 }
 
 /**

--- a/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/Operand.qll
+++ b/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/Operand.qll
@@ -412,6 +412,9 @@ class CallTargetOperand extends RegisterOperand {
  */
 class ArgumentOperand extends RegisterOperand {
   override ArgumentOperandTag tag;
+
+  /** Gets the `CallInstruction` for which this is an argument. */
+  CallInstruction getCall() { result.getAnArgumentOperand() = this }
 }
 
 /**


### PR DESCRIPTION
I've been wanting this predicate for a while, but never really bothered to add it. But I finally got around to it 😄.

I'm planning to use this predicate for some dataflow stuff in an upcoming PR.