### PR TITLE
Fix errorneous slash

### DIFF
--- a/docs/codeql/reusables/download-github-database.rst
+++ b/docs/codeql/reusables/download-github-database.rst
@@ -3,7 +3,7 @@ GitHub stores CodeQL databases for over 200,000 repos on GitHub.com, which you c
 You can check if a repository has any CodeQL databases available for download using the ``/repos/<owner>/<repo>/code-scanning/codeql/databases`` endpoint.
 For example, to check for CodeQL databases using the `GitHub CLI <https://cli.github.com/manual/gh_api>`__ you would run::
 
-   gh api /repos/<owner>/<repo>/code-scanning/codeql/databases/
+   gh api /repos/<owner>/<repo>/code-scanning/codeql/databases
 
 This command returns information about any CodeQL databases that are available for a repository, including the language the database represents, and when the database was last updated. If no CodeQL databases are available, the response is empty.
 


### PR DESCRIPTION
The additional slash causes the request to fail.
`gh api /repos/openjdk/jdk/code-scanning/codeql/databases/` fails:
```
gh api /repos/openjdk/jdk/code-scanning/codeql/databases/
{
  "message": "Not Found",
  "documentation_url": "https://docs.github.com/rest"
}
gh: Not Found (HTTP 404)
```
While `gh api /repos/openjdk/jdk/code-scanning/codeql/databases` works.