### PR TITLE
QL: update codeql-action in QL-for-QL

### DIFF
--- a/.github/workflows/ql-for-ql-build.yml
+++ b/.github/workflows/ql-for-ql-build.yml
@@ -27,7 +27,7 @@ jobs:
         uses: ./.github/actions/find-latest-bundle
       - name: Find codeql
         id: find-codeql
-        uses: github/codeql-action/init@45955cb1830b640e2c1603ad72ad542a49d47b96
+        uses: github/codeql-action/init@beae46e6b1da530ed5e9fc6a756f92433ca47ae1
         with:
           languages: javascript # does not matter
           tools: ${{ steps.find-latest-bundle.outputs.url }}
@@ -139,7 +139,7 @@ jobs:
         env:
           CONF: ./ql-for-ql-config.yml
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@45955cb1830b640e2c1603ad72ad542a49d47b96
+        uses: github/codeql-action/init@beae46e6b1da530ed5e9fc6a756f92433ca47ae1
         with:
           languages: ql
           db-location: ${{ runner.temp }}/db
@@ -152,7 +152,7 @@ jobs:
           PACK: ${{ runner.temp }}/pack
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@45955cb1830b640e2c1603ad72ad542a49d47b96
+        uses: github/codeql-action/analyze@beae46e6b1da530ed5e9fc6a756f92433ca47ae1
         with:
           category: "ql-for-ql"
       - name: Copy sarif file to CWD

--- a/.github/workflows/ql-for-ql-dataset_measure.yml
+++ b/.github/workflows/ql-for-ql-dataset_measure.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Find codeql
         id: find-codeql
-        uses: github/codeql-action/init@45955cb1830b640e2c1603ad72ad542a49d47b96
+        uses: github/codeql-action/init@beae46e6b1da530ed5e9fc6a756f92433ca47ae1
         with:
           languages: javascript # does not matter
       - uses: ./.github/actions/os-version

--- a/.github/workflows/ql-for-ql-tests.yml
+++ b/.github/workflows/ql-for-ql-tests.yml
@@ -6,11 +6,13 @@ on:
     paths:
       - "ql/**"
       - codeql-workspace.yml
+      - .github/workflows/ql-for-ql-tests.yml
   pull_request:
     branches: [main]
     paths:
       - "ql/**"
       - codeql-workspace.yml
+      - .github/workflows/ql-for-ql-tests.yml
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/ql-for-ql-tests.yml
+++ b/.github/workflows/ql-for-ql-tests.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Find codeql
         id: find-codeql
-        uses: github/codeql-action/init@45955cb1830b640e2c1603ad72ad542a49d47b96
+        uses: github/codeql-action/init@beae46e6b1da530ed5e9fc6a756f92433ca47ae1
         with:
           languages: javascript # does not matter
       - uses: ./.github/actions/os-version
@@ -67,7 +67,7 @@ jobs:
           echo "/usr/local/opt/gnu-tar/libexec/gnubin" >> $GITHUB_PATH
       - name: Find codeql
         id: find-codeql
-        uses: github/codeql-action/init@77a8d2d10c0b403a8b4aadbd223dc489ecd22683
+        uses: github/codeql-action/init@beae46e6b1da530ed5e9fc6a756f92433ca47ae1
         with:
           languages: javascript # does not matter
       - uses: ./.github/actions/os-version


### PR DESCRIPTION
This fixes that some runs were using an outdated version of CodeQL, which breaks our tests.  
E.g. this broken run: https://github.com/github/codeql/actions/runs/4050368479/jobs/6971488163