### PR TITLE
C++: Fix missing subpaths when displaying dataflow paths

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -692,7 +692,11 @@ class Unit extends TUnit {
 }
 
 /** Holds if `n` should be hidden from path explanations. */
-predicate nodeIsHidden(Node n) { n instanceof OperandNode and not n instanceof ArgumentNode }
+predicate nodeIsHidden(Node n) {
+  n instanceof OperandNode and
+  not n instanceof ArgumentNode and
+  not n.asOperand() instanceof StoreValueOperand
+}
 
 class LambdaCallKind = Unit;
 

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-359/semmle/tests/PrivateCleartextWrite.expected
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-359/semmle/tests/PrivateCleartextWrite.expected
@@ -1,4 +1,5 @@
 edges
+| test.cpp:45:18:45:23 | buffer | test.cpp:45:7:45:10 | func indirection |
 | test.cpp:57:9:57:18 | theZipcode | test.cpp:57:9:57:18 | theZipcode |
 | test.cpp:57:9:57:18 | theZipcode | test.cpp:57:9:57:18 | theZipcode |
 | test.cpp:57:9:57:18 | theZipcode | test.cpp:57:9:57:18 | theZipcode |
@@ -6,7 +7,9 @@ edges
 | test.cpp:74:24:74:30 | medical | test.cpp:81:22:81:28 | medical |
 | test.cpp:77:16:77:22 | medical | test.cpp:78:24:78:27 | temp |
 | test.cpp:77:16:77:22 | medical | test.cpp:81:22:81:28 | medical |
-| test.cpp:81:22:81:28 | medical | test.cpp:82:24:82:28 | buff5 |
+| test.cpp:81:17:81:20 | call to func | test.cpp:82:24:82:28 | buff5 |
+| test.cpp:81:22:81:28 | medical | test.cpp:45:18:45:23 | buffer |
+| test.cpp:81:22:81:28 | medical | test.cpp:81:17:81:20 | call to func |
 | test.cpp:96:37:96:46 | theZipcode | test.cpp:96:37:96:46 | theZipcode |
 | test.cpp:96:37:96:46 | theZipcode | test.cpp:96:37:96:46 | theZipcode |
 | test.cpp:96:37:96:46 | theZipcode | test.cpp:96:37:96:46 | theZipcode |
@@ -23,6 +26,8 @@ edges
 | test.cpp:99:61:99:70 | theZipcode | test.cpp:99:42:99:51 | theZipcode |
 | test.cpp:99:61:99:70 | theZipcode | test.cpp:99:42:99:51 | theZipcode |
 nodes
+| test.cpp:45:7:45:10 | func indirection | semmle.label | func indirection |
+| test.cpp:45:18:45:23 | buffer | semmle.label | buffer |
 | test.cpp:57:9:57:18 | theZipcode | semmle.label | theZipcode |
 | test.cpp:57:9:57:18 | theZipcode | semmle.label | theZipcode |
 | test.cpp:57:9:57:18 | theZipcode | semmle.label | theZipcode |
@@ -30,6 +35,7 @@ nodes
 | test.cpp:74:24:74:30 | medical | semmle.label | medical |
 | test.cpp:77:16:77:22 | medical | semmle.label | medical |
 | test.cpp:78:24:78:27 | temp | semmle.label | temp |
+| test.cpp:81:17:81:20 | call to func | semmle.label | call to func |
 | test.cpp:81:22:81:28 | medical | semmle.label | medical |
 | test.cpp:82:24:82:28 | buff5 | semmle.label | buff5 |
 | test.cpp:96:37:96:46 | theZipcode | semmle.label | theZipcode |
@@ -42,6 +48,7 @@ nodes
 | test.cpp:99:61:99:70 | theZipcode | semmle.label | theZipcode |
 | test.cpp:99:61:99:70 | theZipcode | semmle.label | theZipcode |
 subpaths
+| test.cpp:81:22:81:28 | medical | test.cpp:45:18:45:23 | buffer | test.cpp:45:7:45:10 | func indirection | test.cpp:81:17:81:20 | call to func |
 #select
 | test.cpp:57:9:57:18 | theZipcode | test.cpp:57:9:57:18 | theZipcode | test.cpp:57:9:57:18 | theZipcode | This write into the external location 'theZipcode' may contain unencrypted data from $@. | test.cpp:57:9:57:18 | theZipcode | this source of private data. |
 | test.cpp:57:9:57:18 | theZipcode | test.cpp:57:9:57:18 | theZipcode | test.cpp:57:9:57:18 | theZipcode | This write into the external location 'theZipcode' may contain unencrypted data from $@. | test.cpp:57:9:57:18 | theZipcode | this source of private data. |

--- a/cpp/ql/test/library-tests/dataflow/fields/ir-path-flow.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/ir-path-flow.expected
@@ -4,8 +4,9 @@ edges
 | A.cpp:27:17:27:17 | c | A.cpp:27:22:27:32 | ... = ... |
 | A.cpp:27:22:27:32 | ... = ... | A.cpp:27:28:27:28 | this indirection [post update] [c] |
 | A.cpp:28:8:28:10 | this indirection [c] | A.cpp:28:23:28:26 | this indirection [c] |
-| A.cpp:28:23:28:26 | this indirection [c] | A.cpp:28:8:28:10 | get indirection |
+| A.cpp:28:23:28:26 | this indirection [c] | A.cpp:28:29:28:29 | c |
 | A.cpp:28:23:28:26 | this indirection [c] | A.cpp:28:29:28:29 | c indirection |
+| A.cpp:28:29:28:29 | c | A.cpp:28:8:28:10 | get indirection |
 | A.cpp:28:29:28:29 | c indirection | A.cpp:28:8:28:10 | get indirection |
 | A.cpp:29:23:29:23 | c | A.cpp:31:20:31:20 | c |
 | A.cpp:31:14:31:21 | call to B [c] | A.cpp:29:15:29:18 | make indirection [c] |
@@ -207,8 +208,9 @@ edges
 | C.cpp:31:10:31:11 | this indirection [s3] | C.cpp:31:10:31:11 | s3 |
 | C.cpp:31:10:31:11 | this indirection [s3] | C.cpp:31:10:31:11 | s3 indirection |
 | D.cpp:10:11:10:17 | this indirection [elem] | D.cpp:10:30:10:33 | this indirection [elem] |
+| D.cpp:10:30:10:33 | elem | D.cpp:10:11:10:17 | getElem indirection |
 | D.cpp:10:30:10:33 | elem indirection | D.cpp:10:11:10:17 | getElem indirection |
-| D.cpp:10:30:10:33 | this indirection [elem] | D.cpp:10:11:10:17 | getElem indirection |
+| D.cpp:10:30:10:33 | this indirection [elem] | D.cpp:10:30:10:33 | elem |
 | D.cpp:10:30:10:33 | this indirection [elem] | D.cpp:10:30:10:33 | elem indirection |
 | D.cpp:11:24:11:24 | e | D.cpp:11:29:11:36 | ... = ... |
 | D.cpp:11:29:11:36 | ... = ... | D.cpp:11:29:11:32 | this indirection [post update] [elem] |
@@ -439,19 +441,23 @@ edges
 | by_reference.cpp:24:25:24:29 | value | by_reference.cpp:11:48:11:52 | value |
 | by_reference.cpp:24:25:24:29 | value | by_reference.cpp:24:19:24:22 | nonMemberSetA output argument [a] |
 | by_reference.cpp:31:46:31:46 | s indirection [a] | by_reference.cpp:32:12:32:12 | s indirection [a] |
-| by_reference.cpp:32:12:32:12 | s indirection [a] | by_reference.cpp:31:16:31:28 | nonMemberGetA indirection |
+| by_reference.cpp:32:12:32:12 | s indirection [a] | by_reference.cpp:32:15:32:15 | a |
 | by_reference.cpp:32:12:32:12 | s indirection [a] | by_reference.cpp:32:15:32:15 | a indirection |
+| by_reference.cpp:32:15:32:15 | a | by_reference.cpp:31:16:31:28 | nonMemberGetA indirection |
 | by_reference.cpp:32:15:32:15 | a indirection | by_reference.cpp:31:16:31:28 | nonMemberGetA indirection |
 | by_reference.cpp:35:9:35:19 | this indirection [a] | by_reference.cpp:36:12:36:15 | this indirection [a] |
-| by_reference.cpp:36:12:36:15 | this indirection [a] | by_reference.cpp:35:9:35:19 | getDirectly indirection |
+| by_reference.cpp:36:12:36:15 | this indirection [a] | by_reference.cpp:36:18:36:18 | a |
 | by_reference.cpp:36:12:36:15 | this indirection [a] | by_reference.cpp:36:18:36:18 | a indirection |
+| by_reference.cpp:36:18:36:18 | a | by_reference.cpp:35:9:35:19 | getDirectly indirection |
 | by_reference.cpp:36:18:36:18 | a indirection | by_reference.cpp:35:9:35:19 | getDirectly indirection |
 | by_reference.cpp:39:9:39:21 | this indirection [a] | by_reference.cpp:40:12:40:15 | this indirection [a] |
 | by_reference.cpp:40:12:40:15 | this indirection [a] | by_reference.cpp:35:9:35:19 | this indirection [a] |
-| by_reference.cpp:40:12:40:15 | this indirection [a] | by_reference.cpp:39:9:39:21 | getIndirectly indirection |
+| by_reference.cpp:40:12:40:15 | this indirection [a] | by_reference.cpp:40:18:40:28 | call to getDirectly |
+| by_reference.cpp:40:18:40:28 | call to getDirectly | by_reference.cpp:39:9:39:21 | getIndirectly indirection |
 | by_reference.cpp:43:9:43:27 | this indirection [a] | by_reference.cpp:44:26:44:29 | this indirection [a] |
+| by_reference.cpp:44:12:44:24 | call to nonMemberGetA | by_reference.cpp:43:9:43:27 | getThroughNonMember indirection |
 | by_reference.cpp:44:26:44:29 | this indirection [a] | by_reference.cpp:31:46:31:46 | s indirection [a] |
-| by_reference.cpp:44:26:44:29 | this indirection [a] | by_reference.cpp:43:9:43:27 | getThroughNonMember indirection |
+| by_reference.cpp:44:26:44:29 | this indirection [a] | by_reference.cpp:44:12:44:24 | call to nonMemberGetA |
 | by_reference.cpp:50:3:50:3 | setDirectly output argument [a] | by_reference.cpp:51:8:51:8 | (const S)... indirection [a] |
 | by_reference.cpp:50:17:50:26 | call to user_input | by_reference.cpp:15:26:15:30 | value |
 | by_reference.cpp:50:17:50:26 | call to user_input | by_reference.cpp:50:3:50:3 | setDirectly output argument [a] |
@@ -567,12 +573,14 @@ edges
 | by_reference.cpp:136:8:136:13 | pouter indirection [a] | by_reference.cpp:136:16:136:16 | a indirection |
 | by_reference.cpp:136:16:136:16 | a indirection | by_reference.cpp:136:16:136:16 | a |
 | complex.cpp:9:7:9:7 | this indirection [a_] | complex.cpp:9:20:9:21 | this indirection [a_] |
+| complex.cpp:9:20:9:21 | a_ | complex.cpp:9:7:9:7 | a indirection |
 | complex.cpp:9:20:9:21 | a_ indirection | complex.cpp:9:7:9:7 | a indirection |
-| complex.cpp:9:20:9:21 | this indirection [a_] | complex.cpp:9:7:9:7 | a indirection |
+| complex.cpp:9:20:9:21 | this indirection [a_] | complex.cpp:9:20:9:21 | a_ |
 | complex.cpp:9:20:9:21 | this indirection [a_] | complex.cpp:9:20:9:21 | a_ indirection |
 | complex.cpp:10:7:10:7 | this indirection [b_] | complex.cpp:10:20:10:21 | this indirection [b_] |
+| complex.cpp:10:20:10:21 | b_ | complex.cpp:10:7:10:7 | b indirection |
 | complex.cpp:10:20:10:21 | b_ indirection | complex.cpp:10:7:10:7 | b indirection |
-| complex.cpp:10:20:10:21 | this indirection [b_] | complex.cpp:10:7:10:7 | b indirection |
+| complex.cpp:10:20:10:21 | this indirection [b_] | complex.cpp:10:20:10:21 | b_ |
 | complex.cpp:10:20:10:21 | this indirection [b_] | complex.cpp:10:20:10:21 | b_ indirection |
 | complex.cpp:11:17:11:17 | a | complex.cpp:11:22:11:27 | ... = ... |
 | complex.cpp:11:22:11:27 | ... = ... | complex.cpp:11:22:11:23 | this indirection [post update] [a_] |
@@ -671,12 +679,14 @@ edges
 | conflated.cpp:61:12:61:15 | next indirection [y] | conflated.cpp:61:18:61:18 | y indirection |
 | conflated.cpp:61:18:61:18 | y indirection | conflated.cpp:61:18:61:18 | y |
 | constructors.cpp:18:9:18:9 | this indirection [a_] | constructors.cpp:18:22:18:23 | this indirection [a_] |
+| constructors.cpp:18:22:18:23 | a_ | constructors.cpp:18:9:18:9 | a indirection |
 | constructors.cpp:18:22:18:23 | a_ indirection | constructors.cpp:18:9:18:9 | a indirection |
-| constructors.cpp:18:22:18:23 | this indirection [a_] | constructors.cpp:18:9:18:9 | a indirection |
+| constructors.cpp:18:22:18:23 | this indirection [a_] | constructors.cpp:18:22:18:23 | a_ |
 | constructors.cpp:18:22:18:23 | this indirection [a_] | constructors.cpp:18:22:18:23 | a_ indirection |
 | constructors.cpp:19:9:19:9 | this indirection [b_] | constructors.cpp:19:22:19:23 | this indirection [b_] |
+| constructors.cpp:19:22:19:23 | b_ | constructors.cpp:19:9:19:9 | b indirection |
 | constructors.cpp:19:22:19:23 | b_ indirection | constructors.cpp:19:9:19:9 | b indirection |
-| constructors.cpp:19:22:19:23 | this indirection [b_] | constructors.cpp:19:9:19:9 | b indirection |
+| constructors.cpp:19:22:19:23 | this indirection [b_] | constructors.cpp:19:22:19:23 | b_ |
 | constructors.cpp:19:22:19:23 | this indirection [b_] | constructors.cpp:19:22:19:23 | b_ indirection |
 | constructors.cpp:23:13:23:13 | a | constructors.cpp:23:28:23:28 | a |
 | constructors.cpp:23:20:23:20 | b | constructors.cpp:23:35:23:35 | b |
@@ -787,12 +797,14 @@ edges
 | realistic.cpp:61:47:61:55 | bufferLen indirection | realistic.cpp:61:14:61:55 | bufferLen |
 | realistic.cpp:61:47:61:55 | bufferLen indirection | realistic.cpp:61:47:61:55 | bufferLen |
 | simple.cpp:18:9:18:9 | this indirection [a_] | simple.cpp:18:22:18:23 | this indirection [a_] |
+| simple.cpp:18:22:18:23 | a_ | simple.cpp:18:9:18:9 | a indirection |
 | simple.cpp:18:22:18:23 | a_ indirection | simple.cpp:18:9:18:9 | a indirection |
-| simple.cpp:18:22:18:23 | this indirection [a_] | simple.cpp:18:9:18:9 | a indirection |
+| simple.cpp:18:22:18:23 | this indirection [a_] | simple.cpp:18:22:18:23 | a_ |
 | simple.cpp:18:22:18:23 | this indirection [a_] | simple.cpp:18:22:18:23 | a_ indirection |
 | simple.cpp:19:9:19:9 | this indirection [b_] | simple.cpp:19:22:19:23 | this indirection [b_] |
+| simple.cpp:19:22:19:23 | b_ | simple.cpp:19:9:19:9 | b indirection |
 | simple.cpp:19:22:19:23 | b_ indirection | simple.cpp:19:9:19:9 | b indirection |
-| simple.cpp:19:22:19:23 | this indirection [b_] | simple.cpp:19:9:19:9 | b indirection |
+| simple.cpp:19:22:19:23 | this indirection [b_] | simple.cpp:19:22:19:23 | b_ |
 | simple.cpp:19:22:19:23 | this indirection [b_] | simple.cpp:19:22:19:23 | b_ indirection |
 | simple.cpp:20:19:20:19 | a | simple.cpp:20:24:20:29 | ... = ... |
 | simple.cpp:20:24:20:29 | ... = ... | simple.cpp:20:24:20:25 | this indirection [post update] [a_] |
@@ -827,9 +839,10 @@ edges
 | simple.cpp:67:10:67:11 | a2 indirection [i] | simple.cpp:67:13:67:13 | i indirection |
 | simple.cpp:67:13:67:13 | i indirection | simple.cpp:67:13:67:13 | i |
 | simple.cpp:78:9:78:15 | this indirection [f2, f1] | simple.cpp:79:16:79:17 | this indirection [f2, f1] |
-| simple.cpp:79:16:79:17 | f2 indirection [f1] | simple.cpp:78:9:78:15 | getf2f1 indirection |
+| simple.cpp:79:16:79:17 | f2 indirection [f1] | simple.cpp:79:19:79:20 | f1 |
 | simple.cpp:79:16:79:17 | f2 indirection [f1] | simple.cpp:79:19:79:20 | f1 indirection |
 | simple.cpp:79:16:79:17 | this indirection [f2, f1] | simple.cpp:79:16:79:17 | f2 indirection [f1] |
+| simple.cpp:79:19:79:20 | f1 | simple.cpp:78:9:78:15 | getf2f1 indirection |
 | simple.cpp:79:19:79:20 | f1 indirection | simple.cpp:78:9:78:15 | getf2f1 indirection |
 | simple.cpp:83:9:83:10 | this indirection [post update] [f2, f1] | simple.cpp:84:14:84:20 | this indirection [f2, f1] |
 | simple.cpp:83:9:83:28 | ... = ... | simple.cpp:83:12:83:13 | f2 indirection [post update] [f1] |
@@ -897,6 +910,7 @@ nodes
 | A.cpp:28:8:28:10 | get indirection | semmle.label | get indirection |
 | A.cpp:28:8:28:10 | this indirection [c] | semmle.label | this indirection [c] |
 | A.cpp:28:23:28:26 | this indirection [c] | semmle.label | this indirection [c] |
+| A.cpp:28:29:28:29 | c | semmle.label | c |
 | A.cpp:28:29:28:29 | c indirection | semmle.label | c indirection |
 | A.cpp:29:15:29:18 | make indirection [c] | semmle.label | make indirection [c] |
 | A.cpp:29:23:29:23 | c | semmle.label | c |
@@ -1083,6 +1097,7 @@ nodes
 | C.cpp:31:10:31:11 | this indirection [s3] | semmle.label | this indirection [s3] |
 | D.cpp:10:11:10:17 | getElem indirection | semmle.label | getElem indirection |
 | D.cpp:10:11:10:17 | this indirection [elem] | semmle.label | this indirection [elem] |
+| D.cpp:10:30:10:33 | elem | semmle.label | elem |
 | D.cpp:10:30:10:33 | elem indirection | semmle.label | elem indirection |
 | D.cpp:10:30:10:33 | this indirection [elem] | semmle.label | this indirection [elem] |
 | D.cpp:11:24:11:24 | e | semmle.label | e |
@@ -1303,16 +1318,20 @@ nodes
 | by_reference.cpp:31:16:31:28 | nonMemberGetA indirection | semmle.label | nonMemberGetA indirection |
 | by_reference.cpp:31:46:31:46 | s indirection [a] | semmle.label | s indirection [a] |
 | by_reference.cpp:32:12:32:12 | s indirection [a] | semmle.label | s indirection [a] |
+| by_reference.cpp:32:15:32:15 | a | semmle.label | a |
 | by_reference.cpp:32:15:32:15 | a indirection | semmle.label | a indirection |
 | by_reference.cpp:35:9:35:19 | getDirectly indirection | semmle.label | getDirectly indirection |
 | by_reference.cpp:35:9:35:19 | this indirection [a] | semmle.label | this indirection [a] |
 | by_reference.cpp:36:12:36:15 | this indirection [a] | semmle.label | this indirection [a] |
+| by_reference.cpp:36:18:36:18 | a | semmle.label | a |
 | by_reference.cpp:36:18:36:18 | a indirection | semmle.label | a indirection |
 | by_reference.cpp:39:9:39:21 | getIndirectly indirection | semmle.label | getIndirectly indirection |
 | by_reference.cpp:39:9:39:21 | this indirection [a] | semmle.label | this indirection [a] |
 | by_reference.cpp:40:12:40:15 | this indirection [a] | semmle.label | this indirection [a] |
+| by_reference.cpp:40:18:40:28 | call to getDirectly | semmle.label | call to getDirectly |
 | by_reference.cpp:43:9:43:27 | getThroughNonMember indirection | semmle.label | getThroughNonMember indirection |
 | by_reference.cpp:43:9:43:27 | this indirection [a] | semmle.label | this indirection [a] |
+| by_reference.cpp:44:12:44:24 | call to nonMemberGetA | semmle.label | call to nonMemberGetA |
 | by_reference.cpp:44:26:44:29 | this indirection [a] | semmle.label | this indirection [a] |
 | by_reference.cpp:50:3:50:3 | setDirectly output argument [a] | semmle.label | setDirectly output argument [a] |
 | by_reference.cpp:50:17:50:26 | call to user_input | semmle.label | call to user_input |
@@ -1414,10 +1433,12 @@ nodes
 | by_reference.cpp:136:16:136:16 | a indirection | semmle.label | a indirection |
 | complex.cpp:9:7:9:7 | a indirection | semmle.label | a indirection |
 | complex.cpp:9:7:9:7 | this indirection [a_] | semmle.label | this indirection [a_] |
+| complex.cpp:9:20:9:21 | a_ | semmle.label | a_ |
 | complex.cpp:9:20:9:21 | a_ indirection | semmle.label | a_ indirection |
 | complex.cpp:9:20:9:21 | this indirection [a_] | semmle.label | this indirection [a_] |
 | complex.cpp:10:7:10:7 | b indirection | semmle.label | b indirection |
 | complex.cpp:10:7:10:7 | this indirection [b_] | semmle.label | this indirection [b_] |
+| complex.cpp:10:20:10:21 | b_ | semmle.label | b_ |
 | complex.cpp:10:20:10:21 | b_ indirection | semmle.label | b_ indirection |
 | complex.cpp:10:20:10:21 | this indirection [b_] | semmle.label | this indirection [b_] |
 | complex.cpp:11:17:11:17 | a | semmle.label | a |
@@ -1506,10 +1527,12 @@ nodes
 | conflated.cpp:61:18:61:18 | y indirection | semmle.label | y indirection |
 | constructors.cpp:18:9:18:9 | a indirection | semmle.label | a indirection |
 | constructors.cpp:18:9:18:9 | this indirection [a_] | semmle.label | this indirection [a_] |
+| constructors.cpp:18:22:18:23 | a_ | semmle.label | a_ |
 | constructors.cpp:18:22:18:23 | a_ indirection | semmle.label | a_ indirection |
 | constructors.cpp:18:22:18:23 | this indirection [a_] | semmle.label | this indirection [a_] |
 | constructors.cpp:19:9:19:9 | b indirection | semmle.label | b indirection |
 | constructors.cpp:19:9:19:9 | this indirection [b_] | semmle.label | this indirection [b_] |
+| constructors.cpp:19:22:19:23 | b_ | semmle.label | b_ |
 | constructors.cpp:19:22:19:23 | b_ indirection | semmle.label | b_ indirection |
 | constructors.cpp:19:22:19:23 | this indirection [b_] | semmle.label | this indirection [b_] |
 | constructors.cpp:23:13:23:13 | a | semmle.label | a |
@@ -1613,10 +1636,12 @@ nodes
 | realistic.cpp:61:47:61:55 | bufferLen indirection | semmle.label | bufferLen indirection |
 | simple.cpp:18:9:18:9 | a indirection | semmle.label | a indirection |
 | simple.cpp:18:9:18:9 | this indirection [a_] | semmle.label | this indirection [a_] |
+| simple.cpp:18:22:18:23 | a_ | semmle.label | a_ |
 | simple.cpp:18:22:18:23 | a_ indirection | semmle.label | a_ indirection |
 | simple.cpp:18:22:18:23 | this indirection [a_] | semmle.label | this indirection [a_] |
 | simple.cpp:19:9:19:9 | b indirection | semmle.label | b indirection |
 | simple.cpp:19:9:19:9 | this indirection [b_] | semmle.label | this indirection [b_] |
+| simple.cpp:19:22:19:23 | b_ | semmle.label | b_ |
 | simple.cpp:19:22:19:23 | b_ indirection | semmle.label | b_ indirection |
 | simple.cpp:19:22:19:23 | this indirection [b_] | semmle.label | this indirection [b_] |
 | simple.cpp:20:19:20:19 | a | semmle.label | a |
@@ -1653,6 +1678,7 @@ nodes
 | simple.cpp:78:9:78:15 | this indirection [f2, f1] | semmle.label | this indirection [f2, f1] |
 | simple.cpp:79:16:79:17 | f2 indirection [f1] | semmle.label | f2 indirection [f1] |
 | simple.cpp:79:16:79:17 | this indirection [f2, f1] | semmle.label | this indirection [f2, f1] |
+| simple.cpp:79:19:79:20 | f1 | semmle.label | f1 |
 | simple.cpp:79:19:79:20 | f1 indirection | semmle.label | f1 indirection |
 | simple.cpp:83:9:83:10 | this indirection [post update] [f2, f1] | semmle.label | this indirection [post update] [f2, f1] |
 | simple.cpp:83:9:83:28 | ... = ... | semmle.label | ... = ... |
@@ -1729,6 +1755,8 @@ subpaths
 | D.cpp:51:27:51:27 | e | D.cpp:11:24:11:24 | e | D.cpp:11:29:11:32 | this indirection [post update] [elem] | D.cpp:51:8:51:14 | setElem output argument [elem] |
 | by_reference.cpp:20:23:20:27 | value | by_reference.cpp:15:26:15:30 | value | by_reference.cpp:16:11:16:11 | this indirection [post update] [a] | by_reference.cpp:20:5:20:8 | setDirectly output argument [a] |
 | by_reference.cpp:24:25:24:29 | value | by_reference.cpp:11:48:11:52 | value | by_reference.cpp:12:8:12:8 | s indirection [post update] [a] | by_reference.cpp:24:19:24:22 | nonMemberSetA output argument [a] |
+| by_reference.cpp:40:12:40:15 | this indirection [a] | by_reference.cpp:35:9:35:19 | this indirection [a] | by_reference.cpp:35:9:35:19 | getDirectly indirection | by_reference.cpp:40:18:40:28 | call to getDirectly |
+| by_reference.cpp:44:26:44:29 | this indirection [a] | by_reference.cpp:31:46:31:46 | s indirection [a] | by_reference.cpp:31:16:31:28 | nonMemberGetA indirection | by_reference.cpp:44:12:44:24 | call to nonMemberGetA |
 | by_reference.cpp:50:17:50:26 | call to user_input | by_reference.cpp:15:26:15:30 | value | by_reference.cpp:16:11:16:11 | this indirection [post update] [a] | by_reference.cpp:50:3:50:3 | setDirectly output argument [a] |
 | by_reference.cpp:51:8:51:8 | (const S)... indirection [a] | by_reference.cpp:35:9:35:19 | this indirection [a] | by_reference.cpp:35:9:35:19 | getDirectly indirection | by_reference.cpp:51:10:51:20 | call to getDirectly |
 | by_reference.cpp:56:19:56:28 | call to user_input | by_reference.cpp:19:28:19:32 | value | by_reference.cpp:20:5:20:8 | setDirectly output argument [a] | by_reference.cpp:56:3:56:3 | setIndirectly output argument [a] |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/ArithmeticUncontrolled/ArithmeticUncontrolled.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/ArithmeticUncontrolled/ArithmeticUncontrolled.expected
@@ -11,12 +11,13 @@ edges
 | test.c:137:13:137:16 | call to rand | test.c:139:10:139:10 | r |
 | test.c:155:22:155:25 | call to rand | test.c:157:9:157:9 | r |
 | test.c:155:22:155:27 | call to rand | test.c:157:9:157:9 | r |
-| test.cpp:6:5:6:12 | get_rand indirection | test.cpp:25:7:25:7 | r |
+| test.cpp:6:5:6:12 | get_rand indirection | test.cpp:24:11:24:18 | call to get_rand |
 | test.cpp:8:9:8:12 | call to rand | test.cpp:6:5:6:12 | get_rand indirection |
 | test.cpp:11:21:11:24 | dest | test.cpp:30:13:30:14 | get_rand2 output argument |
 | test.cpp:13:10:13:13 | call to rand | test.cpp:11:21:11:24 | dest |
 | test.cpp:16:21:16:24 | dest | test.cpp:36:13:36:13 | get_rand3 output argument |
 | test.cpp:18:9:18:12 | call to rand | test.cpp:16:21:16:24 | dest |
+| test.cpp:24:11:24:18 | call to get_rand | test.cpp:25:7:25:7 | r |
 | test.cpp:30:13:30:14 | get_rand2 output argument | test.cpp:31:7:31:7 | r |
 | test.cpp:36:13:36:13 | get_rand3 output argument | test.cpp:37:7:37:7 | r |
 | test.cpp:86:10:86:13 | call to rand | test.cpp:90:10:90:10 | x |
@@ -60,6 +61,7 @@ nodes
 | test.cpp:13:10:13:13 | call to rand | semmle.label | call to rand |
 | test.cpp:16:21:16:24 | dest | semmle.label | dest |
 | test.cpp:18:9:18:12 | call to rand | semmle.label | call to rand |
+| test.cpp:24:11:24:18 | call to get_rand | semmle.label | call to get_rand |
 | test.cpp:25:7:25:7 | r | semmle.label | r |
 | test.cpp:30:13:30:14 | get_rand2 output argument | semmle.label | get_rand2 output argument |
 | test.cpp:31:7:31:7 | r | semmle.label | r |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/tainted/ArithmeticTainted.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/tainted/ArithmeticTainted.expected
@@ -6,11 +6,12 @@ edges
 | test2.cpp:27:13:27:13 | v | test2.cpp:12:21:12:21 | v |
 | test5.cpp:5:5:5:17 | getTaintedInt indirection | test5.cpp:17:6:17:18 | call to getTaintedInt |
 | test5.cpp:5:5:5:17 | getTaintedInt indirection | test5.cpp:17:6:17:18 | call to getTaintedInt |
-| test5.cpp:5:5:5:17 | getTaintedInt indirection | test5.cpp:19:6:19:6 | y |
-| test5.cpp:5:5:5:17 | getTaintedInt indirection | test5.cpp:19:6:19:6 | y |
+| test5.cpp:5:5:5:17 | getTaintedInt indirection | test5.cpp:18:6:18:18 | call to getTaintedInt |
 | test5.cpp:9:7:9:9 | buf | test5.cpp:5:5:5:17 | getTaintedInt indirection |
 | test5.cpp:9:7:9:9 | buf | test5.cpp:5:5:5:17 | getTaintedInt indirection |
 | test5.cpp:9:7:9:9 | gets output argument | test5.cpp:5:5:5:17 | getTaintedInt indirection |
+| test5.cpp:18:6:18:18 | call to getTaintedInt | test5.cpp:19:6:19:6 | y |
+| test5.cpp:18:6:18:18 | call to getTaintedInt | test5.cpp:19:6:19:6 | y |
 | test.c:11:29:11:32 | argv | test.c:14:15:14:28 | maxConnections |
 | test.c:11:29:11:32 | argv | test.c:14:15:14:28 | maxConnections |
 | test.c:11:29:11:32 | argv | test.c:14:15:14:28 | maxConnections |
@@ -37,6 +38,7 @@ nodes
 | test5.cpp:9:7:9:9 | gets output argument | semmle.label | gets output argument |
 | test5.cpp:17:6:17:18 | call to getTaintedInt | semmle.label | call to getTaintedInt |
 | test5.cpp:17:6:17:18 | call to getTaintedInt | semmle.label | call to getTaintedInt |
+| test5.cpp:18:6:18:18 | call to getTaintedInt | semmle.label | call to getTaintedInt |
 | test5.cpp:19:6:19:6 | y | semmle.label | y |
 | test5.cpp:19:6:19:6 | y | semmle.label | y |
 | test.c:11:29:11:32 | argv | semmle.label | argv |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextTransmission.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextTransmission.expected
@@ -2,10 +2,14 @@ edges
 | test3.cpp:74:21:74:29 | password1 | test3.cpp:76:15:76:17 | ptr |
 | test3.cpp:81:15:81:22 | password | test3.cpp:83:15:83:17 | ptr |
 | test3.cpp:112:20:112:25 | buffer | test3.cpp:114:14:114:19 | buffer |
-| test3.cpp:124:7:124:20 | get_global_str indirection | test3.cpp:146:15:146:18 | data |
+| test3.cpp:117:28:117:33 | buffer | test3.cpp:117:13:117:14 | id indirection |
+| test3.cpp:124:7:124:20 | get_global_str indirection | test3.cpp:144:16:144:29 | call to get_global_str |
 | test3.cpp:126:9:126:23 | global_password | test3.cpp:124:7:124:20 | get_global_str indirection |
 | test3.cpp:134:11:134:18 | password | test3.cpp:112:20:112:25 | buffer |
-| test3.cpp:138:24:138:32 | password1 | test3.cpp:140:15:140:17 | ptr |
+| test3.cpp:138:21:138:22 | call to id | test3.cpp:140:15:140:17 | ptr |
+| test3.cpp:138:24:138:32 | password1 | test3.cpp:117:28:117:33 | buffer |
+| test3.cpp:138:24:138:32 | password1 | test3.cpp:138:21:138:22 | call to id |
+| test3.cpp:144:16:144:29 | call to get_global_str | test3.cpp:146:15:146:18 | data |
 | test3.cpp:157:19:157:26 | password | test3.cpp:159:15:159:20 | buffer |
 | test3.cpp:270:16:270:23 | password | test3.cpp:272:15:272:18 | data |
 | test3.cpp:278:20:278:23 | data | test3.cpp:280:14:280:17 | data |
@@ -40,11 +44,15 @@ nodes
 | test3.cpp:101:12:101:19 | password | semmle.label | password |
 | test3.cpp:112:20:112:25 | buffer | semmle.label | buffer |
 | test3.cpp:114:14:114:19 | buffer | semmle.label | buffer |
+| test3.cpp:117:13:117:14 | id indirection | semmle.label | id indirection |
+| test3.cpp:117:28:117:33 | buffer | semmle.label | buffer |
 | test3.cpp:124:7:124:20 | get_global_str indirection | semmle.label | get_global_str indirection |
 | test3.cpp:126:9:126:23 | global_password | semmle.label | global_password |
 | test3.cpp:134:11:134:18 | password | semmle.label | password |
+| test3.cpp:138:21:138:22 | call to id | semmle.label | call to id |
 | test3.cpp:138:24:138:32 | password1 | semmle.label | password1 |
 | test3.cpp:140:15:140:17 | ptr | semmle.label | ptr |
+| test3.cpp:144:16:144:29 | call to get_global_str | semmle.label | call to get_global_str |
 | test3.cpp:146:15:146:18 | data | semmle.label | data |
 | test3.cpp:157:19:157:26 | password | semmle.label | password |
 | test3.cpp:159:15:159:20 | buffer | semmle.label | buffer |
@@ -111,6 +119,7 @@ nodes
 | test3.cpp:577:8:577:23 | call to get_home_address | semmle.label | call to get_home_address |
 | test3.cpp:578:14:578:16 | str | semmle.label | str |
 subpaths
+| test3.cpp:138:24:138:32 | password1 | test3.cpp:117:28:117:33 | buffer | test3.cpp:117:13:117:14 | id indirection | test3.cpp:138:21:138:22 | call to id |
 #select
 | test3.cpp:22:3:22:6 | call to send | test3.cpp:22:15:22:23 | password1 | test3.cpp:22:15:22:23 | password1 | This operation transmits 'password1', which may contain unencrypted sensitive data from $@. | test3.cpp:22:15:22:23 | password1 | password1 |
 | test3.cpp:26:3:26:6 | call to send | test3.cpp:26:15:26:23 | password2 | test3.cpp:26:15:26:23 | password2 | This operation transmits 'password2', which may contain unencrypted sensitive data from $@. | test3.cpp:26:15:26:23 | password2 | password2 |


### PR DESCRIPTION
This fixes the missing subpaths I observed while looking at the dataflow paths in more detail.