### PR TITLE
Swift: Add new source and flow step related to WkWebView

### DIFF
--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/WebView.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/WebView.qll
@@ -34,6 +34,58 @@ private class WKScriptMessageBodyInheritsTaint extends TaintInheritingContent,
 }
 
 /**
+ * A type or extension delcaration that adopts the protocol `WKNavigationDelegate`.
+ */
+private class AdoptsWkNavigationDelegate extends Decl {
+  AdoptsWkNavigationDelegate() {
+    exists(ProtocolDecl delegate |
+      this.(ExtensionDecl).getAProtocol().getABaseTypeDecl*() = delegate or
+      this.(NominalTypeDecl).getABaseTypeDecl*() = delegate
+    |
+      delegate.getName() = "WKNavigationDelegate"
+    )
+  }
+}
+
+/**
+ * A source for the `decidePolicyFor` parameter of the `webView` method of a type adopting `WKNavigationDelegate`.
+ */
+private class WKNavigationDelegateSource extends RemoteFlowSource {
+  WKNavigationDelegateSource() {
+    exists(ParamDecl p, FuncDecl f, AdoptsWkNavigationDelegate t |
+      f.getEnclosingDecl() = t and
+      f.getName() =
+        [
+          "webView(_:decidePolicyFor:preferences:decisionHandler:)",
+          "webView(_:decidePolicyFor:decisionHandler:)"
+        ] and
+      p.getDeclaringFunction() = f and
+      p.getIndex() = 1 and
+      this.(DataFlow::ParameterNode).getParameter() = p
+    )
+  }
+
+  override string getSourceType() { result = "Navigation action of a WebView" }
+}
+
+/**
+ * A taint step implying that, if a `WKNavigationAction` is tainted, its `request` field is also tainted.
+ */
+private class WKNavigationActionTaintStep extends AdditionalTaintStep {
+  override predicate step(DataFlow::Node n1, DataFlow::Node n2) {
+    exists(MemberRefExpr e, Expr self, VarDecl member |
+      self.getType().getName() = "WKNavigationAction" and
+      member.getName() = "request"
+    |
+      e.getBase() = self and
+      e.getMember() = member and
+      n1.asExpr() = self and
+      n2.asExpr() = e
+    )
+  }
+}
+
+/**
  * A model for `JSContext` sources. `JSContext` acts as a bridge between JavaScript and
  * native code, so any object obtained from it has the potential of being tainted by a malicious
  * website visited in the WebView.

--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/WebView.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/WebView.qll
@@ -53,7 +53,7 @@ private class AdoptsWkNavigationDelegate extends Decl {
 private class WKNavigationDelegateSource extends RemoteFlowSource {
   WKNavigationDelegateSource() {
     exists(ParamDecl p, FuncDecl f, AdoptsWkNavigationDelegate t |
-      f.getEnclosingDecl() = t and
+      t.getAMember() = f and
       f.getName() =
         [
           "webView(_:decidePolicyFor:preferences:decisionHandler:)",

--- a/swift/ql/test/library-tests/dataflow/flowsources/FlowSources.expected
+++ b/swift/ql/test/library-tests/dataflow/flowsources/FlowSources.expected
@@ -94,10 +94,16 @@
 | url.swift:53:15:53:19 | .resourceBytes | external |
 | url.swift:60:15:60:19 | .lines | external |
 | url.swift:67:16:67:22 | .lines | external |
-| webview.swift:20:82:20:102 | message | external |
-| webview.swift:25:5:25:13 | .globalObject | external |
-| webview.swift:26:5:26:39 | call to objectForKeyedSubscript(_:) | external |
-| webview.swift:39:9:39:9 | .tainted | Member of a type exposed through JSExport |
-| webview.swift:43:10:43:10 | self | Member of a type exposed through JSExport |
-| webview.swift:43:18:43:24 | arg1 | Member of a type exposed through JSExport |
-| webview.swift:43:29:43:35 | arg2 | Member of a type exposed through JSExport |
+| webview.swift:13:32:13:49 | decidePolicyFor | Navigation action of a WebView |
+| webview.swift:14:32:14:49 | decidePolicyFor | Navigation action of a WebView |
+| webview.swift:41:82:41:102 | message | external |
+| webview.swift:46:5:46:13 | .globalObject | external |
+| webview.swift:47:5:47:39 | call to objectForKeyedSubscript(_:) | external |
+| webview.swift:60:9:60:9 | .tainted | Member of a type exposed through JSExport |
+| webview.swift:64:10:64:10 | self | Member of a type exposed through JSExport |
+| webview.swift:64:18:64:24 | arg1 | Member of a type exposed through JSExport |
+| webview.swift:64:29:64:35 | arg2 | Member of a type exposed through JSExport |
+| webview.swift:72:32:72:49 | decidePolicyFor | Navigation action of a WebView |
+| webview.swift:73:32:73:49 | decidePolicyFor | Navigation action of a WebView |
+| webview.swift:79:32:79:49 | decidePolicyFor | Navigation action of a WebView |
+| webview.swift:80:32:80:49 | decidePolicyFor | Navigation action of a WebView |

--- a/swift/ql/test/library-tests/dataflow/flowsources/webview.swift
+++ b/swift/ql/test/library-tests/dataflow/flowsources/webview.swift
@@ -1,18 +1,39 @@
 
 // --- stubs ---
+
 class WKUserContentController {}
+
 class WKScriptMessage {}
+
 protocol WKScriptMessageHandler {
     func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage)
 }
+
+protocol WKNavigationDelegate {
+    func webView(_: WKWebView, decidePolicyFor: WKNavigationAction, preferences: WKWebpagePreferences, decisionHandler: (WKNavigationActionPolicy, WKWebpagePreferences) -> Void)
+    func webView(_: WKWebView, decidePolicyFor: WKNavigationAction, decisionHandler: (WKNavigationActionPolicy) -> Void)
+}
+
+class WKWebView {}
+
+class WKNavigationAction {}
+
+class WKWebpagePreferences {}
+
+enum WKNavigationActionPolicy {}
+
 protocol NSCopying {}
+
 protocol NSObjectProtocol {}
+
 class JSValue {}
+
 class JSContext {
     var globalObject: JSValue { get { return JSValue() } }
     func objectForKeyedSubscript(_: Any!) -> JSValue! { return JSValue() } 
     func setObject(_: Any, forKeyedSubscript: (NSCopying & NSObjectProtocol) ) {}
 }
+
 protocol JSExport {}
 
 // --- tests ---
@@ -46,3 +67,15 @@ class ExportedImpl : Exported {
     func notTainted(arg1: Any, arg2: Any) {
     }
 } 
+
+class WebViewDelegate : WKNavigationDelegate {
+    func webView(_: WKWebView, decidePolicyFor: WKNavigationAction, preferences: WKWebpagePreferences, decisionHandler: (WKNavigationActionPolicy, WKWebpagePreferences) -> Void) {} // SOURCE
+    func webView(_: WKWebView, decidePolicyFor: WKNavigationAction, decisionHandler: (WKNavigationActionPolicy) -> Void) {} // SOURCE
+}
+
+class Extended {}
+
+extension Extended : WKNavigationDelegate {
+    func webView(_: WKWebView, decidePolicyFor: WKNavigationAction, preferences: WKWebpagePreferences, decisionHandler: (WKNavigationActionPolicy, WKWebpagePreferences) -> Void) {} // SOURCE
+    func webView(_: WKWebView, decidePolicyFor: WKNavigationAction, decisionHandler: (WKNavigationActionPolicy) -> Void) {} // SOURCE
+}

--- a/swift/ql/test/library-tests/dataflow/taint/LocalTaint.expected
+++ b/swift/ql/test/library-tests/dataflow/taint/LocalTaint.expected
@@ -1723,146 +1723,159 @@
 | webview.swift:66:5:66:5 | self | webview.swift:66:5:66:5 | SSA def(self) |
 | webview.swift:68:26:68:26 | SSA def(self) | webview.swift:68:26:68:42 | self[return] |
 | webview.swift:68:26:68:26 | self | webview.swift:68:26:68:26 | SSA def(self) |
-| webview.swift:77:11:77:18 | call to source() | webview.swift:77:10:77:41 | .body |
-| webview.swift:81:9:81:9 | SSA def(s) | webview.swift:83:18:83:18 | s |
-| webview.swift:81:13:81:20 | call to source() | webview.swift:81:9:81:9 | SSA def(s) |
-| webview.swift:83:9:83:9 | SSA def(source) | webview.swift:84:10:84:10 | source |
-| webview.swift:83:18:83:18 | s | webview.swift:83:9:83:9 | SSA def(source) |
-| webview.swift:83:18:83:18 | s | webview.swift:103:26:103:26 | s |
-| webview.swift:84:10:84:10 | [post] source | webview.swift:85:10:85:10 | source |
-| webview.swift:84:10:84:10 | source | webview.swift:84:10:84:26 | call to toObject() |
-| webview.swift:84:10:84:10 | source | webview.swift:85:10:85:10 | source |
-| webview.swift:85:10:85:10 | [post] source | webview.swift:86:10:86:10 | source |
-| webview.swift:85:10:85:10 | source | webview.swift:85:10:85:41 | call to toObjectOf(_:) |
-| webview.swift:85:10:85:10 | source | webview.swift:86:10:86:10 | source |
-| webview.swift:86:10:86:10 | [post] source | webview.swift:87:10:87:10 | source |
-| webview.swift:86:10:86:10 | source | webview.swift:86:10:86:24 | call to toBool() |
-| webview.swift:86:10:86:10 | source | webview.swift:87:10:87:10 | source |
-| webview.swift:87:10:87:10 | [post] source | webview.swift:88:10:88:10 | source |
-| webview.swift:87:10:87:10 | source | webview.swift:87:10:87:26 | call to toDouble() |
-| webview.swift:87:10:87:10 | source | webview.swift:88:10:88:10 | source |
-| webview.swift:88:10:88:10 | [post] source | webview.swift:89:10:89:10 | source |
-| webview.swift:88:10:88:10 | source | webview.swift:88:10:88:25 | call to toInt32() |
-| webview.swift:88:10:88:10 | source | webview.swift:89:10:89:10 | source |
-| webview.swift:89:10:89:10 | [post] source | webview.swift:90:10:90:10 | source |
-| webview.swift:89:10:89:10 | source | webview.swift:89:10:89:26 | call to toUInt32() |
-| webview.swift:89:10:89:10 | source | webview.swift:90:10:90:10 | source |
+| webview.swift:71:7:71:7 | SSA def(self) | webview.swift:71:7:71:7 | self[return] |
+| webview.swift:71:7:71:7 | self | webview.swift:71:7:71:7 | SSA def(self) |
+| webview.swift:71:37:71:37 | SSA def(self) | webview.swift:71:37:71:37 | self[return] |
+| webview.swift:71:37:71:37 | self | webview.swift:71:37:71:37 | SSA def(self) |
+| webview.swift:72:9:72:9 | self | webview.swift:72:9:72:9 | SSA def(self) |
+| webview.swift:72:9:72:9 | self | webview.swift:72:9:72:9 | SSA def(self) |
+| webview.swift:72:9:72:9 | self | webview.swift:72:9:72:9 | SSA def(self) |
+| webview.swift:72:9:72:9 | value | webview.swift:72:9:72:9 | SSA def(value) |
+| webview.swift:75:8:75:8 | SSA def(self) | webview.swift:75:8:75:8 | self[return] |
+| webview.swift:75:8:75:8 | self | webview.swift:75:8:75:8 | SSA def(self) |
+| webview.swift:83:11:83:18 | call to source() | webview.swift:83:10:83:41 | .body |
+| webview.swift:87:9:87:9 | SSA def(s) | webview.swift:89:18:89:18 | s |
+| webview.swift:87:13:87:20 | call to source() | webview.swift:87:9:87:9 | SSA def(s) |
+| webview.swift:89:9:89:9 | SSA def(source) | webview.swift:90:10:90:10 | source |
+| webview.swift:89:18:89:18 | s | webview.swift:89:9:89:9 | SSA def(source) |
+| webview.swift:89:18:89:18 | s | webview.swift:109:26:109:26 | s |
 | webview.swift:90:10:90:10 | [post] source | webview.swift:91:10:91:10 | source |
-| webview.swift:90:10:90:10 | source | webview.swift:90:10:90:26 | call to toNumber() |
+| webview.swift:90:10:90:10 | source | webview.swift:90:10:90:26 | call to toObject() |
 | webview.swift:90:10:90:10 | source | webview.swift:91:10:91:10 | source |
 | webview.swift:91:10:91:10 | [post] source | webview.swift:92:10:92:10 | source |
-| webview.swift:91:10:91:10 | source | webview.swift:91:10:91:26 | call to toString() |
+| webview.swift:91:10:91:10 | source | webview.swift:91:10:91:41 | call to toObjectOf(_:) |
 | webview.swift:91:10:91:10 | source | webview.swift:92:10:92:10 | source |
 | webview.swift:92:10:92:10 | [post] source | webview.swift:93:10:93:10 | source |
-| webview.swift:92:10:92:10 | source | webview.swift:92:10:92:24 | call to toDate() |
+| webview.swift:92:10:92:10 | source | webview.swift:92:10:92:24 | call to toBool() |
 | webview.swift:92:10:92:10 | source | webview.swift:93:10:93:10 | source |
 | webview.swift:93:10:93:10 | [post] source | webview.swift:94:10:94:10 | source |
-| webview.swift:93:10:93:10 | source | webview.swift:93:10:93:25 | call to toArray() |
+| webview.swift:93:10:93:10 | source | webview.swift:93:10:93:26 | call to toDouble() |
 | webview.swift:93:10:93:10 | source | webview.swift:94:10:94:10 | source |
 | webview.swift:94:10:94:10 | [post] source | webview.swift:95:10:95:10 | source |
-| webview.swift:94:10:94:10 | source | webview.swift:94:10:94:30 | call to toDictionary() |
+| webview.swift:94:10:94:10 | source | webview.swift:94:10:94:25 | call to toInt32() |
 | webview.swift:94:10:94:10 | source | webview.swift:95:10:95:10 | source |
 | webview.swift:95:10:95:10 | [post] source | webview.swift:96:10:96:10 | source |
-| webview.swift:95:10:95:10 | source | webview.swift:95:10:95:25 | call to toPoint() |
+| webview.swift:95:10:95:10 | source | webview.swift:95:10:95:26 | call to toUInt32() |
 | webview.swift:95:10:95:10 | source | webview.swift:96:10:96:10 | source |
 | webview.swift:96:10:96:10 | [post] source | webview.swift:97:10:97:10 | source |
-| webview.swift:96:10:96:10 | source | webview.swift:96:10:96:25 | call to toRange() |
+| webview.swift:96:10:96:10 | source | webview.swift:96:10:96:26 | call to toNumber() |
 | webview.swift:96:10:96:10 | source | webview.swift:97:10:97:10 | source |
 | webview.swift:97:10:97:10 | [post] source | webview.swift:98:10:98:10 | source |
-| webview.swift:97:10:97:10 | source | webview.swift:97:10:97:24 | call to toRect() |
+| webview.swift:97:10:97:10 | source | webview.swift:97:10:97:26 | call to toString() |
 | webview.swift:97:10:97:10 | source | webview.swift:98:10:98:10 | source |
 | webview.swift:98:10:98:10 | [post] source | webview.swift:99:10:99:10 | source |
-| webview.swift:98:10:98:10 | source | webview.swift:98:10:98:24 | call to toSize() |
+| webview.swift:98:10:98:10 | source | webview.swift:98:10:98:24 | call to toDate() |
 | webview.swift:98:10:98:10 | source | webview.swift:99:10:99:10 | source |
 | webview.swift:99:10:99:10 | [post] source | webview.swift:100:10:100:10 | source |
-| webview.swift:99:10:99:10 | source | webview.swift:99:10:99:26 | call to atIndex(_:) |
+| webview.swift:99:10:99:10 | source | webview.swift:99:10:99:25 | call to toArray() |
 | webview.swift:99:10:99:10 | source | webview.swift:100:10:100:10 | source |
-| webview.swift:100:10:100:10 | source | webview.swift:100:10:100:31 | call to forProperty(_:) |
-| webview.swift:102:9:102:9 | SSA def(context) | webview.swift:103:40:103:40 | context |
-| webview.swift:102:19:102:29 | call to JSContext.init() | webview.swift:102:9:102:9 | SSA def(context) |
-| webview.swift:103:26:103:26 | s | webview.swift:103:10:103:47 | call to JSValue.init(object:in:) |
-| webview.swift:103:26:103:26 | s | webview.swift:104:24:104:24 | s |
-| webview.swift:103:40:103:40 | [post] context | webview.swift:104:40:104:40 | context |
-| webview.swift:103:40:103:40 | context | webview.swift:104:40:104:40 | context |
-| webview.swift:104:24:104:24 | s | webview.swift:104:10:104:47 | call to JSValue.init(bool:in:) |
-| webview.swift:104:24:104:24 | s | webview.swift:105:26:105:26 | s |
-| webview.swift:104:40:104:40 | [post] context | webview.swift:105:44:105:44 | context |
-| webview.swift:104:40:104:40 | context | webview.swift:105:44:105:44 | context |
-| webview.swift:105:26:105:26 | s | webview.swift:105:10:105:51 | call to JSValue.init(double:in:) |
-| webview.swift:105:26:105:26 | s | webview.swift:106:25:106:25 | s |
-| webview.swift:105:44:105:44 | [post] context | webview.swift:106:42:106:42 | context |
-| webview.swift:105:44:105:44 | context | webview.swift:106:42:106:42 | context |
-| webview.swift:106:25:106:25 | s | webview.swift:106:10:106:49 | call to JSValue.init(int32:in:) |
-| webview.swift:106:25:106:25 | s | webview.swift:107:26:107:26 | s |
-| webview.swift:106:42:106:42 | [post] context | webview.swift:107:44:107:44 | context |
-| webview.swift:106:42:106:42 | context | webview.swift:107:44:107:44 | context |
-| webview.swift:107:26:107:26 | s | webview.swift:107:10:107:51 | call to JSValue.init(uInt32:in:) |
-| webview.swift:107:26:107:26 | s | webview.swift:108:25:108:25 | s |
-| webview.swift:107:44:107:44 | [post] context | webview.swift:108:44:108:44 | context |
-| webview.swift:107:44:107:44 | context | webview.swift:108:44:108:44 | context |
-| webview.swift:108:25:108:25 | s | webview.swift:108:10:108:51 | call to JSValue.init(point:in:) |
-| webview.swift:108:25:108:25 | s | webview.swift:109:25:109:25 | s |
-| webview.swift:108:44:108:44 | [post] context | webview.swift:109:44:109:44 | context |
-| webview.swift:108:44:108:44 | context | webview.swift:109:44:109:44 | context |
-| webview.swift:109:25:109:25 | s | webview.swift:109:10:109:51 | call to JSValue.init(range:in:) |
-| webview.swift:109:25:109:25 | s | webview.swift:110:24:110:24 | s |
-| webview.swift:109:44:109:44 | [post] context | webview.swift:110:42:110:42 | context |
-| webview.swift:109:44:109:44 | context | webview.swift:110:42:110:42 | context |
-| webview.swift:110:24:110:24 | s | webview.swift:110:10:110:49 | call to JSValue.init(rect:in:) |
-| webview.swift:110:24:110:24 | s | webview.swift:111:24:111:24 | s |
-| webview.swift:110:42:110:42 | [post] context | webview.swift:111:42:111:42 | context |
-| webview.swift:110:42:110:42 | context | webview.swift:111:42:111:42 | context |
-| webview.swift:111:24:111:24 | s | webview.swift:111:10:111:49 | call to JSValue.init(size:in:) |
-| webview.swift:111:24:111:24 | s | webview.swift:114:39:114:39 | s |
-| webview.swift:111:42:111:42 | [post] context | webview.swift:113:38:113:38 | context |
-| webview.swift:111:42:111:42 | context | webview.swift:113:38:113:38 | context |
-| webview.swift:113:9:113:9 | SSA def(v1) | webview.swift:114:5:114:5 | v1 |
-| webview.swift:113:14:113:45 | call to JSValue.init(object:in:) | webview.swift:113:9:113:9 | SSA def(v1) |
-| webview.swift:113:30:113:30 |  | webview.swift:113:14:113:45 | call to JSValue.init(object:in:) |
-| webview.swift:113:38:113:38 | [post] context | webview.swift:117:38:117:38 | context |
-| webview.swift:113:38:113:38 | context | webview.swift:117:38:117:38 | context |
-| webview.swift:114:5:114:5 | [post] v1 | webview.swift:115:10:115:10 | v1 |
-| webview.swift:114:5:114:5 | v1 | webview.swift:115:10:115:10 | v1 |
-| webview.swift:114:39:114:39 | s | webview.swift:114:5:114:5 | [post] v1 |
-| webview.swift:114:39:114:39 | s | webview.swift:118:17:118:17 | s |
-| webview.swift:117:9:117:9 | SSA def(v2) | webview.swift:118:5:118:5 | v2 |
-| webview.swift:117:14:117:45 | call to JSValue.init(object:in:) | webview.swift:117:9:117:9 | SSA def(v2) |
-| webview.swift:117:30:117:30 |  | webview.swift:117:14:117:45 | call to JSValue.init(object:in:) |
-| webview.swift:117:38:117:38 | [post] context | webview.swift:121:38:121:38 | context |
-| webview.swift:117:38:117:38 | context | webview.swift:121:38:121:38 | context |
-| webview.swift:118:5:118:5 | [post] v2 | webview.swift:119:10:119:10 | v2 |
-| webview.swift:118:5:118:5 | v2 | webview.swift:119:10:119:10 | v2 |
-| webview.swift:118:17:118:17 | s | webview.swift:118:5:118:5 | [post] v2 |
-| webview.swift:118:17:118:17 | s | webview.swift:122:17:122:17 | s |
-| webview.swift:121:9:121:9 | SSA def(v3) | webview.swift:122:5:122:5 | v3 |
-| webview.swift:121:14:121:45 | call to JSValue.init(object:in:) | webview.swift:121:9:121:9 | SSA def(v3) |
-| webview.swift:121:30:121:30 |  | webview.swift:121:14:121:45 | call to JSValue.init(object:in:) |
-| webview.swift:122:5:122:5 | [post] v3 | webview.swift:123:10:123:10 | v3 |
-| webview.swift:122:5:122:5 | v3 | webview.swift:123:10:123:10 | v3 |
-| webview.swift:122:17:122:17 | s | webview.swift:122:5:122:5 | [post] v3 |
-| webview.swift:127:9:127:9 | SSA def(atStart) | webview.swift:128:56:128:56 | atStart |
-| webview.swift:127:19:127:45 | .atDocumentStart | webview.swift:127:9:127:9 | SSA def(atStart) |
-| webview.swift:128:9:128:9 | SSA def(a) | webview.swift:129:10:129:10 | a |
-| webview.swift:128:13:128:88 | call to WKUserScript.init(source:injectionTime:forMainFrameOnly:) | webview.swift:128:9:128:9 | SSA def(a) |
-| webview.swift:128:34:128:34 | abc | webview.swift:128:13:128:88 | call to WKUserScript.init(source:injectionTime:forMainFrameOnly:) |
-| webview.swift:128:56:128:56 | [post] atStart | webview.swift:132:70:132:70 | atStart |
-| webview.swift:128:56:128:56 | atStart | webview.swift:132:70:132:70 | atStart |
-| webview.swift:129:10:129:10 | [post] a | webview.swift:130:10:130:10 | a |
-| webview.swift:129:10:129:10 | a | webview.swift:130:10:130:10 | a |
-| webview.swift:130:10:130:10 | a | webview.swift:130:10:130:12 | .source |
-| webview.swift:132:9:132:9 | SSA def(b) | webview.swift:133:10:133:10 | b |
-| webview.swift:132:13:132:102 | call to WKUserScript.init(source:injectionTime:forMainFrameOnly:) | webview.swift:132:9:132:9 | SSA def(b) |
-| webview.swift:132:34:132:41 | call to source() | webview.swift:132:13:132:102 | call to WKUserScript.init(source:injectionTime:forMainFrameOnly:) |
-| webview.swift:132:70:132:70 | [post] atStart | webview.swift:137:70:137:70 | atStart |
-| webview.swift:132:70:132:70 | atStart | webview.swift:137:70:137:70 | atStart |
-| webview.swift:133:10:133:10 | [post] b | webview.swift:134:10:134:10 | b |
-| webview.swift:133:10:133:10 | b | webview.swift:134:10:134:10 | b |
-| webview.swift:134:10:134:10 | b | webview.swift:134:10:134:12 | .source |
-| webview.swift:136:9:136:9 | SSA def(world) | webview.swift:137:108:137:108 | world |
-| webview.swift:136:17:136:32 | call to WKContentWorld.init() | webview.swift:136:9:136:9 | SSA def(world) |
-| webview.swift:137:9:137:9 | SSA def(c) | webview.swift:138:10:138:10 | c |
-| webview.swift:137:13:137:113 | call to WKUserScript.init(source:injectionTime:forMainFrameOnly:in:) | webview.swift:137:9:137:9 | SSA def(c) |
-| webview.swift:137:34:137:41 | call to source() | webview.swift:137:13:137:113 | call to WKUserScript.init(source:injectionTime:forMainFrameOnly:in:) |
-| webview.swift:138:10:138:10 | [post] c | webview.swift:139:10:139:10 | c |
-| webview.swift:138:10:138:10 | c | webview.swift:139:10:139:10 | c |
-| webview.swift:139:10:139:10 | c | webview.swift:139:10:139:12 | .source |
+| webview.swift:100:10:100:10 | [post] source | webview.swift:101:10:101:10 | source |
+| webview.swift:100:10:100:10 | source | webview.swift:100:10:100:30 | call to toDictionary() |
+| webview.swift:100:10:100:10 | source | webview.swift:101:10:101:10 | source |
+| webview.swift:101:10:101:10 | [post] source | webview.swift:102:10:102:10 | source |
+| webview.swift:101:10:101:10 | source | webview.swift:101:10:101:25 | call to toPoint() |
+| webview.swift:101:10:101:10 | source | webview.swift:102:10:102:10 | source |
+| webview.swift:102:10:102:10 | [post] source | webview.swift:103:10:103:10 | source |
+| webview.swift:102:10:102:10 | source | webview.swift:102:10:102:25 | call to toRange() |
+| webview.swift:102:10:102:10 | source | webview.swift:103:10:103:10 | source |
+| webview.swift:103:10:103:10 | [post] source | webview.swift:104:10:104:10 | source |
+| webview.swift:103:10:103:10 | source | webview.swift:103:10:103:24 | call to toRect() |
+| webview.swift:103:10:103:10 | source | webview.swift:104:10:104:10 | source |
+| webview.swift:104:10:104:10 | [post] source | webview.swift:105:10:105:10 | source |
+| webview.swift:104:10:104:10 | source | webview.swift:104:10:104:24 | call to toSize() |
+| webview.swift:104:10:104:10 | source | webview.swift:105:10:105:10 | source |
+| webview.swift:105:10:105:10 | [post] source | webview.swift:106:10:106:10 | source |
+| webview.swift:105:10:105:10 | source | webview.swift:105:10:105:26 | call to atIndex(_:) |
+| webview.swift:105:10:105:10 | source | webview.swift:106:10:106:10 | source |
+| webview.swift:106:10:106:10 | source | webview.swift:106:10:106:31 | call to forProperty(_:) |
+| webview.swift:108:9:108:9 | SSA def(context) | webview.swift:109:40:109:40 | context |
+| webview.swift:108:19:108:29 | call to JSContext.init() | webview.swift:108:9:108:9 | SSA def(context) |
+| webview.swift:109:26:109:26 | s | webview.swift:109:10:109:47 | call to JSValue.init(object:in:) |
+| webview.swift:109:26:109:26 | s | webview.swift:110:24:110:24 | s |
+| webview.swift:109:40:109:40 | [post] context | webview.swift:110:40:110:40 | context |
+| webview.swift:109:40:109:40 | context | webview.swift:110:40:110:40 | context |
+| webview.swift:110:24:110:24 | s | webview.swift:110:10:110:47 | call to JSValue.init(bool:in:) |
+| webview.swift:110:24:110:24 | s | webview.swift:111:26:111:26 | s |
+| webview.swift:110:40:110:40 | [post] context | webview.swift:111:44:111:44 | context |
+| webview.swift:110:40:110:40 | context | webview.swift:111:44:111:44 | context |
+| webview.swift:111:26:111:26 | s | webview.swift:111:10:111:51 | call to JSValue.init(double:in:) |
+| webview.swift:111:26:111:26 | s | webview.swift:112:25:112:25 | s |
+| webview.swift:111:44:111:44 | [post] context | webview.swift:112:42:112:42 | context |
+| webview.swift:111:44:111:44 | context | webview.swift:112:42:112:42 | context |
+| webview.swift:112:25:112:25 | s | webview.swift:112:10:112:49 | call to JSValue.init(int32:in:) |
+| webview.swift:112:25:112:25 | s | webview.swift:113:26:113:26 | s |
+| webview.swift:112:42:112:42 | [post] context | webview.swift:113:44:113:44 | context |
+| webview.swift:112:42:112:42 | context | webview.swift:113:44:113:44 | context |
+| webview.swift:113:26:113:26 | s | webview.swift:113:10:113:51 | call to JSValue.init(uInt32:in:) |
+| webview.swift:113:26:113:26 | s | webview.swift:114:25:114:25 | s |
+| webview.swift:113:44:113:44 | [post] context | webview.swift:114:44:114:44 | context |
+| webview.swift:113:44:113:44 | context | webview.swift:114:44:114:44 | context |
+| webview.swift:114:25:114:25 | s | webview.swift:114:10:114:51 | call to JSValue.init(point:in:) |
+| webview.swift:114:25:114:25 | s | webview.swift:115:25:115:25 | s |
+| webview.swift:114:44:114:44 | [post] context | webview.swift:115:44:115:44 | context |
+| webview.swift:114:44:114:44 | context | webview.swift:115:44:115:44 | context |
+| webview.swift:115:25:115:25 | s | webview.swift:115:10:115:51 | call to JSValue.init(range:in:) |
+| webview.swift:115:25:115:25 | s | webview.swift:116:24:116:24 | s |
+| webview.swift:115:44:115:44 | [post] context | webview.swift:116:42:116:42 | context |
+| webview.swift:115:44:115:44 | context | webview.swift:116:42:116:42 | context |
+| webview.swift:116:24:116:24 | s | webview.swift:116:10:116:49 | call to JSValue.init(rect:in:) |
+| webview.swift:116:24:116:24 | s | webview.swift:117:24:117:24 | s |
+| webview.swift:116:42:116:42 | [post] context | webview.swift:117:42:117:42 | context |
+| webview.swift:116:42:116:42 | context | webview.swift:117:42:117:42 | context |
+| webview.swift:117:24:117:24 | s | webview.swift:117:10:117:49 | call to JSValue.init(size:in:) |
+| webview.swift:117:24:117:24 | s | webview.swift:120:39:120:39 | s |
+| webview.swift:117:42:117:42 | [post] context | webview.swift:119:38:119:38 | context |
+| webview.swift:117:42:117:42 | context | webview.swift:119:38:119:38 | context |
+| webview.swift:119:9:119:9 | SSA def(v1) | webview.swift:120:5:120:5 | v1 |
+| webview.swift:119:14:119:45 | call to JSValue.init(object:in:) | webview.swift:119:9:119:9 | SSA def(v1) |
+| webview.swift:119:30:119:30 |  | webview.swift:119:14:119:45 | call to JSValue.init(object:in:) |
+| webview.swift:119:38:119:38 | [post] context | webview.swift:123:38:123:38 | context |
+| webview.swift:119:38:119:38 | context | webview.swift:123:38:123:38 | context |
+| webview.swift:120:5:120:5 | [post] v1 | webview.swift:121:10:121:10 | v1 |
+| webview.swift:120:5:120:5 | v1 | webview.swift:121:10:121:10 | v1 |
+| webview.swift:120:39:120:39 | s | webview.swift:120:5:120:5 | [post] v1 |
+| webview.swift:120:39:120:39 | s | webview.swift:124:17:124:17 | s |
+| webview.swift:123:9:123:9 | SSA def(v2) | webview.swift:124:5:124:5 | v2 |
+| webview.swift:123:14:123:45 | call to JSValue.init(object:in:) | webview.swift:123:9:123:9 | SSA def(v2) |
+| webview.swift:123:30:123:30 |  | webview.swift:123:14:123:45 | call to JSValue.init(object:in:) |
+| webview.swift:123:38:123:38 | [post] context | webview.swift:127:38:127:38 | context |
+| webview.swift:123:38:123:38 | context | webview.swift:127:38:127:38 | context |
+| webview.swift:124:5:124:5 | [post] v2 | webview.swift:125:10:125:10 | v2 |
+| webview.swift:124:5:124:5 | v2 | webview.swift:125:10:125:10 | v2 |
+| webview.swift:124:17:124:17 | s | webview.swift:124:5:124:5 | [post] v2 |
+| webview.swift:124:17:124:17 | s | webview.swift:128:17:128:17 | s |
+| webview.swift:127:9:127:9 | SSA def(v3) | webview.swift:128:5:128:5 | v3 |
+| webview.swift:127:14:127:45 | call to JSValue.init(object:in:) | webview.swift:127:9:127:9 | SSA def(v3) |
+| webview.swift:127:30:127:30 |  | webview.swift:127:14:127:45 | call to JSValue.init(object:in:) |
+| webview.swift:128:5:128:5 | [post] v3 | webview.swift:129:10:129:10 | v3 |
+| webview.swift:128:5:128:5 | v3 | webview.swift:129:10:129:10 | v3 |
+| webview.swift:128:17:128:17 | s | webview.swift:128:5:128:5 | [post] v3 |
+| webview.swift:133:9:133:9 | SSA def(atStart) | webview.swift:134:56:134:56 | atStart |
+| webview.swift:133:19:133:45 | .atDocumentStart | webview.swift:133:9:133:9 | SSA def(atStart) |
+| webview.swift:134:9:134:9 | SSA def(a) | webview.swift:135:10:135:10 | a |
+| webview.swift:134:13:134:88 | call to WKUserScript.init(source:injectionTime:forMainFrameOnly:) | webview.swift:134:9:134:9 | SSA def(a) |
+| webview.swift:134:34:134:34 | abc | webview.swift:134:13:134:88 | call to WKUserScript.init(source:injectionTime:forMainFrameOnly:) |
+| webview.swift:134:56:134:56 | [post] atStart | webview.swift:138:70:138:70 | atStart |
+| webview.swift:134:56:134:56 | atStart | webview.swift:138:70:138:70 | atStart |
+| webview.swift:135:10:135:10 | [post] a | webview.swift:136:10:136:10 | a |
+| webview.swift:135:10:135:10 | a | webview.swift:136:10:136:10 | a |
+| webview.swift:136:10:136:10 | a | webview.swift:136:10:136:12 | .source |
+| webview.swift:138:9:138:9 | SSA def(b) | webview.swift:139:10:139:10 | b |
+| webview.swift:138:13:138:102 | call to WKUserScript.init(source:injectionTime:forMainFrameOnly:) | webview.swift:138:9:138:9 | SSA def(b) |
+| webview.swift:138:34:138:41 | call to source() | webview.swift:138:13:138:102 | call to WKUserScript.init(source:injectionTime:forMainFrameOnly:) |
+| webview.swift:138:70:138:70 | [post] atStart | webview.swift:143:70:143:70 | atStart |
+| webview.swift:138:70:138:70 | atStart | webview.swift:143:70:143:70 | atStart |
+| webview.swift:139:10:139:10 | [post] b | webview.swift:140:10:140:10 | b |
+| webview.swift:139:10:139:10 | b | webview.swift:140:10:140:10 | b |
+| webview.swift:140:10:140:10 | b | webview.swift:140:10:140:12 | .source |
+| webview.swift:142:9:142:9 | SSA def(world) | webview.swift:143:108:143:108 | world |
+| webview.swift:142:17:142:32 | call to WKContentWorld.init() | webview.swift:142:9:142:9 | SSA def(world) |
+| webview.swift:143:9:143:9 | SSA def(c) | webview.swift:144:10:144:10 | c |
+| webview.swift:143:13:143:113 | call to WKUserScript.init(source:injectionTime:forMainFrameOnly:in:) | webview.swift:143:9:143:9 | SSA def(c) |
+| webview.swift:143:34:143:41 | call to source() | webview.swift:143:13:143:113 | call to WKUserScript.init(source:injectionTime:forMainFrameOnly:in:) |
+| webview.swift:144:10:144:10 | [post] c | webview.swift:145:10:145:10 | c |
+| webview.swift:144:10:144:10 | c | webview.swift:145:10:145:10 | c |
+| webview.swift:145:10:145:10 | c | webview.swift:145:10:145:12 | .source |
+| webview.swift:149:9:149:9 | SSA def(src) | webview.swift:150:10:150:10 | src |
+| webview.swift:149:15:149:22 | call to source() | webview.swift:149:9:149:9 | SSA def(src) |
+| webview.swift:150:10:150:10 | src | webview.swift:150:10:150:14 | .request |

--- a/swift/ql/test/library-tests/dataflow/taint/Taint.expected
+++ b/swift/ql/test/library-tests/dataflow/taint/Taint.expected
@@ -500,105 +500,110 @@ edges
 | webview.swift:55:5:55:48 | [summary param] 0 in setValue(_:forProperty:) :  | file://:0:0:0:0 | [summary] to write: argument this in setValue(_:forProperty:) :  |
 | webview.swift:65:5:65:93 | [summary param] 0 in WKUserScript.init(source:injectionTime:forMainFrameOnly:) :  | file://:0:0:0:0 | [summary] to write: return (return) in WKUserScript.init(source:injectionTime:forMainFrameOnly:) :  |
 | webview.swift:66:5:66:126 | [summary param] 0 in WKUserScript.init(source:injectionTime:forMainFrameOnly:in:) :  | file://:0:0:0:0 | [summary] to write: return (return) in WKUserScript.init(source:injectionTime:forMainFrameOnly:in:) :  |
-| webview.swift:77:11:77:18 | call to source() :  | webview.swift:77:10:77:41 | .body |
-| webview.swift:81:13:81:20 | call to source() :  | webview.swift:84:10:84:10 | source :  |
-| webview.swift:81:13:81:20 | call to source() :  | webview.swift:85:10:85:10 | source :  |
-| webview.swift:81:13:81:20 | call to source() :  | webview.swift:86:10:86:10 | source :  |
-| webview.swift:81:13:81:20 | call to source() :  | webview.swift:87:10:87:10 | source :  |
-| webview.swift:81:13:81:20 | call to source() :  | webview.swift:88:10:88:10 | source :  |
-| webview.swift:81:13:81:20 | call to source() :  | webview.swift:89:10:89:10 | source :  |
-| webview.swift:81:13:81:20 | call to source() :  | webview.swift:90:10:90:10 | source :  |
-| webview.swift:81:13:81:20 | call to source() :  | webview.swift:91:10:91:10 | source :  |
-| webview.swift:81:13:81:20 | call to source() :  | webview.swift:92:10:92:10 | source :  |
-| webview.swift:81:13:81:20 | call to source() :  | webview.swift:93:10:93:10 | source :  |
-| webview.swift:81:13:81:20 | call to source() :  | webview.swift:94:10:94:10 | source :  |
-| webview.swift:81:13:81:20 | call to source() :  | webview.swift:95:10:95:10 | source :  |
-| webview.swift:81:13:81:20 | call to source() :  | webview.swift:96:10:96:10 | source :  |
-| webview.swift:81:13:81:20 | call to source() :  | webview.swift:97:10:97:10 | source :  |
-| webview.swift:81:13:81:20 | call to source() :  | webview.swift:98:10:98:10 | source :  |
-| webview.swift:81:13:81:20 | call to source() :  | webview.swift:99:10:99:10 | source :  |
-| webview.swift:81:13:81:20 | call to source() :  | webview.swift:100:10:100:10 | source :  |
-| webview.swift:81:13:81:20 | call to source() :  | webview.swift:103:26:103:26 | s :  |
-| webview.swift:81:13:81:20 | call to source() :  | webview.swift:104:24:104:24 | s :  |
-| webview.swift:81:13:81:20 | call to source() :  | webview.swift:105:26:105:26 | s :  |
-| webview.swift:81:13:81:20 | call to source() :  | webview.swift:106:25:106:25 | s :  |
-| webview.swift:81:13:81:20 | call to source() :  | webview.swift:107:26:107:26 | s :  |
-| webview.swift:81:13:81:20 | call to source() :  | webview.swift:108:25:108:25 | s :  |
-| webview.swift:81:13:81:20 | call to source() :  | webview.swift:109:25:109:25 | s :  |
-| webview.swift:81:13:81:20 | call to source() :  | webview.swift:110:24:110:24 | s :  |
-| webview.swift:81:13:81:20 | call to source() :  | webview.swift:111:24:111:24 | s :  |
-| webview.swift:81:13:81:20 | call to source() :  | webview.swift:114:39:114:39 | s :  |
-| webview.swift:81:13:81:20 | call to source() :  | webview.swift:118:17:118:17 | s :  |
-| webview.swift:81:13:81:20 | call to source() :  | webview.swift:122:17:122:17 | s :  |
-| webview.swift:84:10:84:10 | source :  | webview.swift:36:5:36:41 | [summary param] this in toObject() :  |
-| webview.swift:84:10:84:10 | source :  | webview.swift:84:10:84:26 | call to toObject() |
-| webview.swift:85:10:85:10 | source :  | webview.swift:37:5:37:55 | [summary param] this in toObjectOf(_:) :  |
-| webview.swift:85:10:85:10 | source :  | webview.swift:85:10:85:41 | call to toObjectOf(_:) |
-| webview.swift:86:10:86:10 | source :  | webview.swift:38:5:38:42 | [summary param] this in toBool() :  |
-| webview.swift:86:10:86:10 | source :  | webview.swift:86:10:86:24 | call to toBool() |
-| webview.swift:87:10:87:10 | source :  | webview.swift:39:5:39:44 | [summary param] this in toDouble() :  |
-| webview.swift:87:10:87:10 | source :  | webview.swift:87:10:87:26 | call to toDouble() |
-| webview.swift:88:10:88:10 | source :  | webview.swift:40:5:40:40 | [summary param] this in toInt32() :  |
-| webview.swift:88:10:88:10 | source :  | webview.swift:88:10:88:25 | call to toInt32() |
-| webview.swift:89:10:89:10 | source :  | webview.swift:41:5:41:42 | [summary param] this in toUInt32() :  |
-| webview.swift:89:10:89:10 | source :  | webview.swift:89:10:89:26 | call to toUInt32() |
-| webview.swift:90:10:90:10 | source :  | webview.swift:42:5:42:62 | [summary param] this in toNumber() :  |
-| webview.swift:90:10:90:10 | source :  | webview.swift:90:10:90:26 | call to toNumber() |
-| webview.swift:91:10:91:10 | source :  | webview.swift:43:5:43:44 | [summary param] this in toString() :  |
-| webview.swift:91:10:91:10 | source :  | webview.swift:91:10:91:26 | call to toString() |
-| webview.swift:92:10:92:10 | source :  | webview.swift:44:5:44:44 | [summary param] this in toDate() :  |
-| webview.swift:92:10:92:10 | source :  | webview.swift:92:10:92:24 | call to toDate() |
-| webview.swift:93:10:93:10 | source :  | webview.swift:45:5:45:44 | [summary param] this in toArray() :  |
-| webview.swift:93:10:93:10 | source :  | webview.swift:93:10:93:25 | call to toArray() |
-| webview.swift:94:10:94:10 | source :  | webview.swift:46:5:46:65 | [summary param] this in toDictionary() :  |
-| webview.swift:94:10:94:10 | source :  | webview.swift:94:10:94:30 | call to toDictionary() |
-| webview.swift:95:10:95:10 | source :  | webview.swift:47:5:47:50 | [summary param] this in toPoint() :  |
-| webview.swift:95:10:95:10 | source :  | webview.swift:95:10:95:25 | call to toPoint() |
-| webview.swift:96:10:96:10 | source :  | webview.swift:48:5:48:50 | [summary param] this in toRange() :  |
-| webview.swift:96:10:96:10 | source :  | webview.swift:96:10:96:25 | call to toRange() |
-| webview.swift:97:10:97:10 | source :  | webview.swift:49:5:49:47 | [summary param] this in toRect() :  |
-| webview.swift:97:10:97:10 | source :  | webview.swift:97:10:97:24 | call to toRect() |
-| webview.swift:98:10:98:10 | source :  | webview.swift:50:5:50:47 | [summary param] this in toSize() :  |
-| webview.swift:98:10:98:10 | source :  | webview.swift:98:10:98:24 | call to toSize() |
-| webview.swift:99:10:99:10 | source :  | webview.swift:51:5:51:84 | [summary param] this in atIndex(_:) :  |
-| webview.swift:99:10:99:10 | source :  | webview.swift:99:10:99:26 | call to atIndex(_:) |
-| webview.swift:100:10:100:10 | source :  | webview.swift:53:5:53:89 | [summary param] this in forProperty(_:) :  |
-| webview.swift:100:10:100:10 | source :  | webview.swift:100:10:100:31 | call to forProperty(_:) |
-| webview.swift:103:26:103:26 | s :  | webview.swift:27:5:27:39 | [summary param] 0 in JSValue.init(object:in:) :  |
-| webview.swift:103:26:103:26 | s :  | webview.swift:103:10:103:47 | call to JSValue.init(object:in:) |
-| webview.swift:104:24:104:24 | s :  | webview.swift:28:5:28:38 | [summary param] 0 in JSValue.init(bool:in:) :  |
-| webview.swift:104:24:104:24 | s :  | webview.swift:104:10:104:47 | call to JSValue.init(bool:in:) |
-| webview.swift:105:26:105:26 | s :  | webview.swift:29:5:29:42 | [summary param] 0 in JSValue.init(double:in:) :  |
-| webview.swift:105:26:105:26 | s :  | webview.swift:105:10:105:51 | call to JSValue.init(double:in:) |
-| webview.swift:106:25:106:25 | s :  | webview.swift:30:5:30:40 | [summary param] 0 in JSValue.init(int32:in:) :  |
-| webview.swift:106:25:106:25 | s :  | webview.swift:106:10:106:49 | call to JSValue.init(int32:in:) |
-| webview.swift:107:26:107:26 | s :  | webview.swift:31:5:31:42 | [summary param] 0 in JSValue.init(uInt32:in:) :  |
-| webview.swift:107:26:107:26 | s :  | webview.swift:107:10:107:51 | call to JSValue.init(uInt32:in:) |
-| webview.swift:108:25:108:25 | s :  | webview.swift:32:5:32:42 | [summary param] 0 in JSValue.init(point:in:) :  |
-| webview.swift:108:25:108:25 | s :  | webview.swift:108:10:108:51 | call to JSValue.init(point:in:) |
-| webview.swift:109:25:109:25 | s :  | webview.swift:33:5:33:42 | [summary param] 0 in JSValue.init(range:in:) :  |
-| webview.swift:109:25:109:25 | s :  | webview.swift:109:10:109:51 | call to JSValue.init(range:in:) |
-| webview.swift:110:24:110:24 | s :  | webview.swift:34:5:34:40 | [summary param] 0 in JSValue.init(rect:in:) :  |
-| webview.swift:110:24:110:24 | s :  | webview.swift:110:10:110:49 | call to JSValue.init(rect:in:) |
-| webview.swift:111:24:111:24 | s :  | webview.swift:35:5:35:40 | [summary param] 0 in JSValue.init(size:in:) :  |
-| webview.swift:111:24:111:24 | s :  | webview.swift:111:10:111:49 | call to JSValue.init(size:in:) |
-| webview.swift:114:5:114:5 | [post] v1 :  | webview.swift:115:10:115:10 | v1 |
-| webview.swift:114:39:114:39 | s :  | webview.swift:52:5:52:53 | [summary param] 1 in defineProperty(_:descriptor:) :  |
-| webview.swift:114:39:114:39 | s :  | webview.swift:114:5:114:5 | [post] v1 :  |
-| webview.swift:118:5:118:5 | [post] v2 :  | webview.swift:119:10:119:10 | v2 |
-| webview.swift:118:17:118:17 | s :  | webview.swift:54:5:54:38 | [summary param] 0 in setValue(_:at:) :  |
-| webview.swift:118:17:118:17 | s :  | webview.swift:118:5:118:5 | [post] v2 :  |
-| webview.swift:122:5:122:5 | [post] v3 :  | webview.swift:123:10:123:10 | v3 |
-| webview.swift:122:17:122:17 | s :  | webview.swift:55:5:55:48 | [summary param] 0 in setValue(_:forProperty:) :  |
-| webview.swift:122:17:122:17 | s :  | webview.swift:122:5:122:5 | [post] v3 :  |
-| webview.swift:132:13:132:102 | call to WKUserScript.init(source:injectionTime:forMainFrameOnly:) :  | webview.swift:133:10:133:10 | b |
-| webview.swift:132:13:132:102 | call to WKUserScript.init(source:injectionTime:forMainFrameOnly:) :  | webview.swift:134:10:134:12 | .source |
-| webview.swift:132:34:132:41 | call to source() :  | webview.swift:65:5:65:93 | [summary param] 0 in WKUserScript.init(source:injectionTime:forMainFrameOnly:) :  |
-| webview.swift:132:34:132:41 | call to source() :  | webview.swift:132:13:132:102 | call to WKUserScript.init(source:injectionTime:forMainFrameOnly:) :  |
-| webview.swift:137:13:137:113 | call to WKUserScript.init(source:injectionTime:forMainFrameOnly:in:) :  | webview.swift:138:10:138:10 | c |
-| webview.swift:137:13:137:113 | call to WKUserScript.init(source:injectionTime:forMainFrameOnly:in:) :  | webview.swift:139:10:139:12 | .source |
-| webview.swift:137:34:137:41 | call to source() :  | webview.swift:66:5:66:126 | [summary param] 0 in WKUserScript.init(source:injectionTime:forMainFrameOnly:in:) :  |
-| webview.swift:137:34:137:41 | call to source() :  | webview.swift:137:13:137:113 | call to WKUserScript.init(source:injectionTime:forMainFrameOnly:in:) :  |
+| webview.swift:72:9:72:9 | self :  | file://:0:0:0:0 | .request :  |
+| webview.swift:83:11:83:18 | call to source() :  | webview.swift:83:10:83:41 | .body |
+| webview.swift:87:13:87:20 | call to source() :  | webview.swift:90:10:90:10 | source :  |
+| webview.swift:87:13:87:20 | call to source() :  | webview.swift:91:10:91:10 | source :  |
+| webview.swift:87:13:87:20 | call to source() :  | webview.swift:92:10:92:10 | source :  |
+| webview.swift:87:13:87:20 | call to source() :  | webview.swift:93:10:93:10 | source :  |
+| webview.swift:87:13:87:20 | call to source() :  | webview.swift:94:10:94:10 | source :  |
+| webview.swift:87:13:87:20 | call to source() :  | webview.swift:95:10:95:10 | source :  |
+| webview.swift:87:13:87:20 | call to source() :  | webview.swift:96:10:96:10 | source :  |
+| webview.swift:87:13:87:20 | call to source() :  | webview.swift:97:10:97:10 | source :  |
+| webview.swift:87:13:87:20 | call to source() :  | webview.swift:98:10:98:10 | source :  |
+| webview.swift:87:13:87:20 | call to source() :  | webview.swift:99:10:99:10 | source :  |
+| webview.swift:87:13:87:20 | call to source() :  | webview.swift:100:10:100:10 | source :  |
+| webview.swift:87:13:87:20 | call to source() :  | webview.swift:101:10:101:10 | source :  |
+| webview.swift:87:13:87:20 | call to source() :  | webview.swift:102:10:102:10 | source :  |
+| webview.swift:87:13:87:20 | call to source() :  | webview.swift:103:10:103:10 | source :  |
+| webview.swift:87:13:87:20 | call to source() :  | webview.swift:104:10:104:10 | source :  |
+| webview.swift:87:13:87:20 | call to source() :  | webview.swift:105:10:105:10 | source :  |
+| webview.swift:87:13:87:20 | call to source() :  | webview.swift:106:10:106:10 | source :  |
+| webview.swift:87:13:87:20 | call to source() :  | webview.swift:109:26:109:26 | s :  |
+| webview.swift:87:13:87:20 | call to source() :  | webview.swift:110:24:110:24 | s :  |
+| webview.swift:87:13:87:20 | call to source() :  | webview.swift:111:26:111:26 | s :  |
+| webview.swift:87:13:87:20 | call to source() :  | webview.swift:112:25:112:25 | s :  |
+| webview.swift:87:13:87:20 | call to source() :  | webview.swift:113:26:113:26 | s :  |
+| webview.swift:87:13:87:20 | call to source() :  | webview.swift:114:25:114:25 | s :  |
+| webview.swift:87:13:87:20 | call to source() :  | webview.swift:115:25:115:25 | s :  |
+| webview.swift:87:13:87:20 | call to source() :  | webview.swift:116:24:116:24 | s :  |
+| webview.swift:87:13:87:20 | call to source() :  | webview.swift:117:24:117:24 | s :  |
+| webview.swift:87:13:87:20 | call to source() :  | webview.swift:120:39:120:39 | s :  |
+| webview.swift:87:13:87:20 | call to source() :  | webview.swift:124:17:124:17 | s :  |
+| webview.swift:87:13:87:20 | call to source() :  | webview.swift:128:17:128:17 | s :  |
+| webview.swift:90:10:90:10 | source :  | webview.swift:36:5:36:41 | [summary param] this in toObject() :  |
+| webview.swift:90:10:90:10 | source :  | webview.swift:90:10:90:26 | call to toObject() |
+| webview.swift:91:10:91:10 | source :  | webview.swift:37:5:37:55 | [summary param] this in toObjectOf(_:) :  |
+| webview.swift:91:10:91:10 | source :  | webview.swift:91:10:91:41 | call to toObjectOf(_:) |
+| webview.swift:92:10:92:10 | source :  | webview.swift:38:5:38:42 | [summary param] this in toBool() :  |
+| webview.swift:92:10:92:10 | source :  | webview.swift:92:10:92:24 | call to toBool() |
+| webview.swift:93:10:93:10 | source :  | webview.swift:39:5:39:44 | [summary param] this in toDouble() :  |
+| webview.swift:93:10:93:10 | source :  | webview.swift:93:10:93:26 | call to toDouble() |
+| webview.swift:94:10:94:10 | source :  | webview.swift:40:5:40:40 | [summary param] this in toInt32() :  |
+| webview.swift:94:10:94:10 | source :  | webview.swift:94:10:94:25 | call to toInt32() |
+| webview.swift:95:10:95:10 | source :  | webview.swift:41:5:41:42 | [summary param] this in toUInt32() :  |
+| webview.swift:95:10:95:10 | source :  | webview.swift:95:10:95:26 | call to toUInt32() |
+| webview.swift:96:10:96:10 | source :  | webview.swift:42:5:42:62 | [summary param] this in toNumber() :  |
+| webview.swift:96:10:96:10 | source :  | webview.swift:96:10:96:26 | call to toNumber() |
+| webview.swift:97:10:97:10 | source :  | webview.swift:43:5:43:44 | [summary param] this in toString() :  |
+| webview.swift:97:10:97:10 | source :  | webview.swift:97:10:97:26 | call to toString() |
+| webview.swift:98:10:98:10 | source :  | webview.swift:44:5:44:44 | [summary param] this in toDate() :  |
+| webview.swift:98:10:98:10 | source :  | webview.swift:98:10:98:24 | call to toDate() |
+| webview.swift:99:10:99:10 | source :  | webview.swift:45:5:45:44 | [summary param] this in toArray() :  |
+| webview.swift:99:10:99:10 | source :  | webview.swift:99:10:99:25 | call to toArray() |
+| webview.swift:100:10:100:10 | source :  | webview.swift:46:5:46:65 | [summary param] this in toDictionary() :  |
+| webview.swift:100:10:100:10 | source :  | webview.swift:100:10:100:30 | call to toDictionary() |
+| webview.swift:101:10:101:10 | source :  | webview.swift:47:5:47:50 | [summary param] this in toPoint() :  |
+| webview.swift:101:10:101:10 | source :  | webview.swift:101:10:101:25 | call to toPoint() |
+| webview.swift:102:10:102:10 | source :  | webview.swift:48:5:48:50 | [summary param] this in toRange() :  |
+| webview.swift:102:10:102:10 | source :  | webview.swift:102:10:102:25 | call to toRange() |
+| webview.swift:103:10:103:10 | source :  | webview.swift:49:5:49:47 | [summary param] this in toRect() :  |
+| webview.swift:103:10:103:10 | source :  | webview.swift:103:10:103:24 | call to toRect() |
+| webview.swift:104:10:104:10 | source :  | webview.swift:50:5:50:47 | [summary param] this in toSize() :  |
+| webview.swift:104:10:104:10 | source :  | webview.swift:104:10:104:24 | call to toSize() |
+| webview.swift:105:10:105:10 | source :  | webview.swift:51:5:51:84 | [summary param] this in atIndex(_:) :  |
+| webview.swift:105:10:105:10 | source :  | webview.swift:105:10:105:26 | call to atIndex(_:) |
+| webview.swift:106:10:106:10 | source :  | webview.swift:53:5:53:89 | [summary param] this in forProperty(_:) :  |
+| webview.swift:106:10:106:10 | source :  | webview.swift:106:10:106:31 | call to forProperty(_:) |
+| webview.swift:109:26:109:26 | s :  | webview.swift:27:5:27:39 | [summary param] 0 in JSValue.init(object:in:) :  |
+| webview.swift:109:26:109:26 | s :  | webview.swift:109:10:109:47 | call to JSValue.init(object:in:) |
+| webview.swift:110:24:110:24 | s :  | webview.swift:28:5:28:38 | [summary param] 0 in JSValue.init(bool:in:) :  |
+| webview.swift:110:24:110:24 | s :  | webview.swift:110:10:110:47 | call to JSValue.init(bool:in:) |
+| webview.swift:111:26:111:26 | s :  | webview.swift:29:5:29:42 | [summary param] 0 in JSValue.init(double:in:) :  |
+| webview.swift:111:26:111:26 | s :  | webview.swift:111:10:111:51 | call to JSValue.init(double:in:) |
+| webview.swift:112:25:112:25 | s :  | webview.swift:30:5:30:40 | [summary param] 0 in JSValue.init(int32:in:) :  |
+| webview.swift:112:25:112:25 | s :  | webview.swift:112:10:112:49 | call to JSValue.init(int32:in:) |
+| webview.swift:113:26:113:26 | s :  | webview.swift:31:5:31:42 | [summary param] 0 in JSValue.init(uInt32:in:) :  |
+| webview.swift:113:26:113:26 | s :  | webview.swift:113:10:113:51 | call to JSValue.init(uInt32:in:) |
+| webview.swift:114:25:114:25 | s :  | webview.swift:32:5:32:42 | [summary param] 0 in JSValue.init(point:in:) :  |
+| webview.swift:114:25:114:25 | s :  | webview.swift:114:10:114:51 | call to JSValue.init(point:in:) |
+| webview.swift:115:25:115:25 | s :  | webview.swift:33:5:33:42 | [summary param] 0 in JSValue.init(range:in:) :  |
+| webview.swift:115:25:115:25 | s :  | webview.swift:115:10:115:51 | call to JSValue.init(range:in:) |
+| webview.swift:116:24:116:24 | s :  | webview.swift:34:5:34:40 | [summary param] 0 in JSValue.init(rect:in:) :  |
+| webview.swift:116:24:116:24 | s :  | webview.swift:116:10:116:49 | call to JSValue.init(rect:in:) |
+| webview.swift:117:24:117:24 | s :  | webview.swift:35:5:35:40 | [summary param] 0 in JSValue.init(size:in:) :  |
+| webview.swift:117:24:117:24 | s :  | webview.swift:117:10:117:49 | call to JSValue.init(size:in:) |
+| webview.swift:120:5:120:5 | [post] v1 :  | webview.swift:121:10:121:10 | v1 |
+| webview.swift:120:39:120:39 | s :  | webview.swift:52:5:52:53 | [summary param] 1 in defineProperty(_:descriptor:) :  |
+| webview.swift:120:39:120:39 | s :  | webview.swift:120:5:120:5 | [post] v1 :  |
+| webview.swift:124:5:124:5 | [post] v2 :  | webview.swift:125:10:125:10 | v2 |
+| webview.swift:124:17:124:17 | s :  | webview.swift:54:5:54:38 | [summary param] 0 in setValue(_:at:) :  |
+| webview.swift:124:17:124:17 | s :  | webview.swift:124:5:124:5 | [post] v2 :  |
+| webview.swift:128:5:128:5 | [post] v3 :  | webview.swift:129:10:129:10 | v3 |
+| webview.swift:128:17:128:17 | s :  | webview.swift:55:5:55:48 | [summary param] 0 in setValue(_:forProperty:) :  |
+| webview.swift:128:17:128:17 | s :  | webview.swift:128:5:128:5 | [post] v3 :  |
+| webview.swift:138:13:138:102 | call to WKUserScript.init(source:injectionTime:forMainFrameOnly:) :  | webview.swift:139:10:139:10 | b |
+| webview.swift:138:13:138:102 | call to WKUserScript.init(source:injectionTime:forMainFrameOnly:) :  | webview.swift:140:10:140:12 | .source |
+| webview.swift:138:34:138:41 | call to source() :  | webview.swift:65:5:65:93 | [summary param] 0 in WKUserScript.init(source:injectionTime:forMainFrameOnly:) :  |
+| webview.swift:138:34:138:41 | call to source() :  | webview.swift:138:13:138:102 | call to WKUserScript.init(source:injectionTime:forMainFrameOnly:) :  |
+| webview.swift:143:13:143:113 | call to WKUserScript.init(source:injectionTime:forMainFrameOnly:in:) :  | webview.swift:144:10:144:10 | c |
+| webview.swift:143:13:143:113 | call to WKUserScript.init(source:injectionTime:forMainFrameOnly:in:) :  | webview.swift:145:10:145:12 | .source |
+| webview.swift:143:34:143:41 | call to source() :  | webview.swift:66:5:66:126 | [summary param] 0 in WKUserScript.init(source:injectionTime:forMainFrameOnly:in:) :  |
+| webview.swift:143:34:143:41 | call to source() :  | webview.swift:143:13:143:113 | call to WKUserScript.init(source:injectionTime:forMainFrameOnly:in:) :  |
+| webview.swift:149:15:149:22 | call to source() :  | webview.swift:150:10:150:10 | src :  |
+| webview.swift:149:15:149:22 | call to source() :  | webview.swift:150:10:150:14 | .request |
+| webview.swift:150:10:150:10 | src :  | webview.swift:72:9:72:9 | self :  |
+| webview.swift:150:10:150:10 | src :  | webview.swift:150:10:150:14 | .request |
 nodes
 | data.swift:24:5:24:29 | [summary param] 0 in Data.init(_:) :  | semmle.label | [summary param] 0 in Data.init(_:) :  |
 | data.swift:25:2:25:66 | [summary param] 0 in Data.init(base64Encoded:options:) :  | semmle.label | [summary param] 0 in Data.init(base64Encoded:options:) :  |
@@ -765,6 +770,7 @@ nodes
 | file://:0:0:0:0 | .httpBodyStream :  | semmle.label | .httpBodyStream :  |
 | file://:0:0:0:0 | .mainDocument :  | semmle.label | .mainDocument :  |
 | file://:0:0:0:0 | .mutableBytes :  | semmle.label | .mutableBytes :  |
+| file://:0:0:0:0 | .request :  | semmle.label | .request :  |
 | file://:0:0:0:0 | .url :  | semmle.label | .url :  |
 | file://:0:0:0:0 | .url :  | semmle.label | .url :  |
 | file://:0:0:0:0 | .urlContexts :  | semmle.label | .urlContexts :  |
@@ -1182,78 +1188,82 @@ nodes
 | webview.swift:55:5:55:48 | [summary param] 0 in setValue(_:forProperty:) :  | semmle.label | [summary param] 0 in setValue(_:forProperty:) :  |
 | webview.swift:65:5:65:93 | [summary param] 0 in WKUserScript.init(source:injectionTime:forMainFrameOnly:) :  | semmle.label | [summary param] 0 in WKUserScript.init(source:injectionTime:forMainFrameOnly:) :  |
 | webview.swift:66:5:66:126 | [summary param] 0 in WKUserScript.init(source:injectionTime:forMainFrameOnly:in:) :  | semmle.label | [summary param] 0 in WKUserScript.init(source:injectionTime:forMainFrameOnly:in:) :  |
-| webview.swift:77:10:77:41 | .body | semmle.label | .body |
-| webview.swift:77:11:77:18 | call to source() :  | semmle.label | call to source() :  |
-| webview.swift:81:13:81:20 | call to source() :  | semmle.label | call to source() :  |
-| webview.swift:84:10:84:10 | source :  | semmle.label | source :  |
-| webview.swift:84:10:84:26 | call to toObject() | semmle.label | call to toObject() |
-| webview.swift:85:10:85:10 | source :  | semmle.label | source :  |
-| webview.swift:85:10:85:41 | call to toObjectOf(_:) | semmle.label | call to toObjectOf(_:) |
-| webview.swift:86:10:86:10 | source :  | semmle.label | source :  |
-| webview.swift:86:10:86:24 | call to toBool() | semmle.label | call to toBool() |
-| webview.swift:87:10:87:10 | source :  | semmle.label | source :  |
-| webview.swift:87:10:87:26 | call to toDouble() | semmle.label | call to toDouble() |
-| webview.swift:88:10:88:10 | source :  | semmle.label | source :  |
-| webview.swift:88:10:88:25 | call to toInt32() | semmle.label | call to toInt32() |
-| webview.swift:89:10:89:10 | source :  | semmle.label | source :  |
-| webview.swift:89:10:89:26 | call to toUInt32() | semmle.label | call to toUInt32() |
+| webview.swift:72:9:72:9 | self :  | semmle.label | self :  |
+| webview.swift:83:10:83:41 | .body | semmle.label | .body |
+| webview.swift:83:11:83:18 | call to source() :  | semmle.label | call to source() :  |
+| webview.swift:87:13:87:20 | call to source() :  | semmle.label | call to source() :  |
 | webview.swift:90:10:90:10 | source :  | semmle.label | source :  |
-| webview.swift:90:10:90:26 | call to toNumber() | semmle.label | call to toNumber() |
+| webview.swift:90:10:90:26 | call to toObject() | semmle.label | call to toObject() |
 | webview.swift:91:10:91:10 | source :  | semmle.label | source :  |
-| webview.swift:91:10:91:26 | call to toString() | semmle.label | call to toString() |
+| webview.swift:91:10:91:41 | call to toObjectOf(_:) | semmle.label | call to toObjectOf(_:) |
 | webview.swift:92:10:92:10 | source :  | semmle.label | source :  |
-| webview.swift:92:10:92:24 | call to toDate() | semmle.label | call to toDate() |
+| webview.swift:92:10:92:24 | call to toBool() | semmle.label | call to toBool() |
 | webview.swift:93:10:93:10 | source :  | semmle.label | source :  |
-| webview.swift:93:10:93:25 | call to toArray() | semmle.label | call to toArray() |
+| webview.swift:93:10:93:26 | call to toDouble() | semmle.label | call to toDouble() |
 | webview.swift:94:10:94:10 | source :  | semmle.label | source :  |
-| webview.swift:94:10:94:30 | call to toDictionary() | semmle.label | call to toDictionary() |
+| webview.swift:94:10:94:25 | call to toInt32() | semmle.label | call to toInt32() |
 | webview.swift:95:10:95:10 | source :  | semmle.label | source :  |
-| webview.swift:95:10:95:25 | call to toPoint() | semmle.label | call to toPoint() |
+| webview.swift:95:10:95:26 | call to toUInt32() | semmle.label | call to toUInt32() |
 | webview.swift:96:10:96:10 | source :  | semmle.label | source :  |
-| webview.swift:96:10:96:25 | call to toRange() | semmle.label | call to toRange() |
+| webview.swift:96:10:96:26 | call to toNumber() | semmle.label | call to toNumber() |
 | webview.swift:97:10:97:10 | source :  | semmle.label | source :  |
-| webview.swift:97:10:97:24 | call to toRect() | semmle.label | call to toRect() |
+| webview.swift:97:10:97:26 | call to toString() | semmle.label | call to toString() |
 | webview.swift:98:10:98:10 | source :  | semmle.label | source :  |
-| webview.swift:98:10:98:24 | call to toSize() | semmle.label | call to toSize() |
+| webview.swift:98:10:98:24 | call to toDate() | semmle.label | call to toDate() |
 | webview.swift:99:10:99:10 | source :  | semmle.label | source :  |
-| webview.swift:99:10:99:26 | call to atIndex(_:) | semmle.label | call to atIndex(_:) |
+| webview.swift:99:10:99:25 | call to toArray() | semmle.label | call to toArray() |
 | webview.swift:100:10:100:10 | source :  | semmle.label | source :  |
-| webview.swift:100:10:100:31 | call to forProperty(_:) | semmle.label | call to forProperty(_:) |
-| webview.swift:103:10:103:47 | call to JSValue.init(object:in:) | semmle.label | call to JSValue.init(object:in:) |
-| webview.swift:103:26:103:26 | s :  | semmle.label | s :  |
-| webview.swift:104:10:104:47 | call to JSValue.init(bool:in:) | semmle.label | call to JSValue.init(bool:in:) |
-| webview.swift:104:24:104:24 | s :  | semmle.label | s :  |
-| webview.swift:105:10:105:51 | call to JSValue.init(double:in:) | semmle.label | call to JSValue.init(double:in:) |
-| webview.swift:105:26:105:26 | s :  | semmle.label | s :  |
-| webview.swift:106:10:106:49 | call to JSValue.init(int32:in:) | semmle.label | call to JSValue.init(int32:in:) |
-| webview.swift:106:25:106:25 | s :  | semmle.label | s :  |
-| webview.swift:107:10:107:51 | call to JSValue.init(uInt32:in:) | semmle.label | call to JSValue.init(uInt32:in:) |
-| webview.swift:107:26:107:26 | s :  | semmle.label | s :  |
-| webview.swift:108:10:108:51 | call to JSValue.init(point:in:) | semmle.label | call to JSValue.init(point:in:) |
-| webview.swift:108:25:108:25 | s :  | semmle.label | s :  |
-| webview.swift:109:10:109:51 | call to JSValue.init(range:in:) | semmle.label | call to JSValue.init(range:in:) |
-| webview.swift:109:25:109:25 | s :  | semmle.label | s :  |
-| webview.swift:110:10:110:49 | call to JSValue.init(rect:in:) | semmle.label | call to JSValue.init(rect:in:) |
+| webview.swift:100:10:100:30 | call to toDictionary() | semmle.label | call to toDictionary() |
+| webview.swift:101:10:101:10 | source :  | semmle.label | source :  |
+| webview.swift:101:10:101:25 | call to toPoint() | semmle.label | call to toPoint() |
+| webview.swift:102:10:102:10 | source :  | semmle.label | source :  |
+| webview.swift:102:10:102:25 | call to toRange() | semmle.label | call to toRange() |
+| webview.swift:103:10:103:10 | source :  | semmle.label | source :  |
+| webview.swift:103:10:103:24 | call to toRect() | semmle.label | call to toRect() |
+| webview.swift:104:10:104:10 | source :  | semmle.label | source :  |
+| webview.swift:104:10:104:24 | call to toSize() | semmle.label | call to toSize() |
+| webview.swift:105:10:105:10 | source :  | semmle.label | source :  |
+| webview.swift:105:10:105:26 | call to atIndex(_:) | semmle.label | call to atIndex(_:) |
+| webview.swift:106:10:106:10 | source :  | semmle.label | source :  |
+| webview.swift:106:10:106:31 | call to forProperty(_:) | semmle.label | call to forProperty(_:) |
+| webview.swift:109:10:109:47 | call to JSValue.init(object:in:) | semmle.label | call to JSValue.init(object:in:) |
+| webview.swift:109:26:109:26 | s :  | semmle.label | s :  |
+| webview.swift:110:10:110:47 | call to JSValue.init(bool:in:) | semmle.label | call to JSValue.init(bool:in:) |
 | webview.swift:110:24:110:24 | s :  | semmle.label | s :  |
-| webview.swift:111:10:111:49 | call to JSValue.init(size:in:) | semmle.label | call to JSValue.init(size:in:) |
-| webview.swift:111:24:111:24 | s :  | semmle.label | s :  |
-| webview.swift:114:5:114:5 | [post] v1 :  | semmle.label | [post] v1 :  |
-| webview.swift:114:39:114:39 | s :  | semmle.label | s :  |
-| webview.swift:115:10:115:10 | v1 | semmle.label | v1 |
-| webview.swift:118:5:118:5 | [post] v2 :  | semmle.label | [post] v2 :  |
-| webview.swift:118:17:118:17 | s :  | semmle.label | s :  |
-| webview.swift:119:10:119:10 | v2 | semmle.label | v2 |
-| webview.swift:122:5:122:5 | [post] v3 :  | semmle.label | [post] v3 :  |
-| webview.swift:122:17:122:17 | s :  | semmle.label | s :  |
-| webview.swift:123:10:123:10 | v3 | semmle.label | v3 |
-| webview.swift:132:13:132:102 | call to WKUserScript.init(source:injectionTime:forMainFrameOnly:) :  | semmle.label | call to WKUserScript.init(source:injectionTime:forMainFrameOnly:) :  |
-| webview.swift:132:34:132:41 | call to source() :  | semmle.label | call to source() :  |
-| webview.swift:133:10:133:10 | b | semmle.label | b |
-| webview.swift:134:10:134:12 | .source | semmle.label | .source |
-| webview.swift:137:13:137:113 | call to WKUserScript.init(source:injectionTime:forMainFrameOnly:in:) :  | semmle.label | call to WKUserScript.init(source:injectionTime:forMainFrameOnly:in:) :  |
-| webview.swift:137:34:137:41 | call to source() :  | semmle.label | call to source() :  |
-| webview.swift:138:10:138:10 | c | semmle.label | c |
-| webview.swift:139:10:139:12 | .source | semmle.label | .source |
+| webview.swift:111:10:111:51 | call to JSValue.init(double:in:) | semmle.label | call to JSValue.init(double:in:) |
+| webview.swift:111:26:111:26 | s :  | semmle.label | s :  |
+| webview.swift:112:10:112:49 | call to JSValue.init(int32:in:) | semmle.label | call to JSValue.init(int32:in:) |
+| webview.swift:112:25:112:25 | s :  | semmle.label | s :  |
+| webview.swift:113:10:113:51 | call to JSValue.init(uInt32:in:) | semmle.label | call to JSValue.init(uInt32:in:) |
+| webview.swift:113:26:113:26 | s :  | semmle.label | s :  |
+| webview.swift:114:10:114:51 | call to JSValue.init(point:in:) | semmle.label | call to JSValue.init(point:in:) |
+| webview.swift:114:25:114:25 | s :  | semmle.label | s :  |
+| webview.swift:115:10:115:51 | call to JSValue.init(range:in:) | semmle.label | call to JSValue.init(range:in:) |
+| webview.swift:115:25:115:25 | s :  | semmle.label | s :  |
+| webview.swift:116:10:116:49 | call to JSValue.init(rect:in:) | semmle.label | call to JSValue.init(rect:in:) |
+| webview.swift:116:24:116:24 | s :  | semmle.label | s :  |
+| webview.swift:117:10:117:49 | call to JSValue.init(size:in:) | semmle.label | call to JSValue.init(size:in:) |
+| webview.swift:117:24:117:24 | s :  | semmle.label | s :  |
+| webview.swift:120:5:120:5 | [post] v1 :  | semmle.label | [post] v1 :  |
+| webview.swift:120:39:120:39 | s :  | semmle.label | s :  |
+| webview.swift:121:10:121:10 | v1 | semmle.label | v1 |
+| webview.swift:124:5:124:5 | [post] v2 :  | semmle.label | [post] v2 :  |
+| webview.swift:124:17:124:17 | s :  | semmle.label | s :  |
+| webview.swift:125:10:125:10 | v2 | semmle.label | v2 |
+| webview.swift:128:5:128:5 | [post] v3 :  | semmle.label | [post] v3 :  |
+| webview.swift:128:17:128:17 | s :  | semmle.label | s :  |
+| webview.swift:129:10:129:10 | v3 | semmle.label | v3 |
+| webview.swift:138:13:138:102 | call to WKUserScript.init(source:injectionTime:forMainFrameOnly:) :  | semmle.label | call to WKUserScript.init(source:injectionTime:forMainFrameOnly:) :  |
+| webview.swift:138:34:138:41 | call to source() :  | semmle.label | call to source() :  |
+| webview.swift:139:10:139:10 | b | semmle.label | b |
+| webview.swift:140:10:140:12 | .source | semmle.label | .source |
+| webview.swift:143:13:143:113 | call to WKUserScript.init(source:injectionTime:forMainFrameOnly:in:) :  | semmle.label | call to WKUserScript.init(source:injectionTime:forMainFrameOnly:in:) :  |
+| webview.swift:143:34:143:41 | call to source() :  | semmle.label | call to source() :  |
+| webview.swift:144:10:144:10 | c | semmle.label | c |
+| webview.swift:145:10:145:12 | .source | semmle.label | .source |
+| webview.swift:149:15:149:22 | call to source() :  | semmle.label | call to source() :  |
+| webview.swift:150:10:150:10 | src :  | semmle.label | src :  |
+| webview.swift:150:10:150:14 | .request | semmle.label | .request |
 subpaths
 | data.swift:81:25:81:47 | .utf8 :  | data.swift:24:5:24:29 | [summary param] 0 in Data.init(_:) :  | file://:0:0:0:0 | [summary] to write: return (return) in Data.init(_:) :  | data.swift:81:20:81:51 | call to Data.init(_:) :  |
 | data.swift:82:26:82:26 | dataTainted :  | data.swift:24:5:24:29 | [summary param] 0 in Data.init(_:) :  | file://:0:0:0:0 | [summary] to write: return (return) in Data.init(_:) :  | data.swift:82:21:82:37 | call to Data.init(_:) :  |
@@ -1355,37 +1365,38 @@ subpaths
 | url.swift:174:12:174:12 | tainted :  | url.swift:48:6:48:6 | self :  | file://:0:0:0:0 | .httpBodyStream :  | url.swift:174:12:174:20 | .httpBodyStream |
 | url.swift:176:12:176:12 | tainted :  | url.swift:49:6:49:6 | self :  | file://:0:0:0:0 | .mainDocument :  | url.swift:176:12:176:20 | .mainDocument |
 | url.swift:178:12:178:12 | tainted :  | url.swift:50:6:50:6 | self :  | file://:0:0:0:0 | .allHTTPHeaderFields :  | url.swift:178:12:178:20 | .allHTTPHeaderFields |
-| webview.swift:84:10:84:10 | source :  | webview.swift:36:5:36:41 | [summary param] this in toObject() :  | file://:0:0:0:0 | [summary] to write: return (return) in toObject() :  | webview.swift:84:10:84:26 | call to toObject() |
-| webview.swift:85:10:85:10 | source :  | webview.swift:37:5:37:55 | [summary param] this in toObjectOf(_:) :  | file://:0:0:0:0 | [summary] to write: return (return) in toObjectOf(_:) :  | webview.swift:85:10:85:41 | call to toObjectOf(_:) |
-| webview.swift:86:10:86:10 | source :  | webview.swift:38:5:38:42 | [summary param] this in toBool() :  | file://:0:0:0:0 | [summary] to write: return (return) in toBool() :  | webview.swift:86:10:86:24 | call to toBool() |
-| webview.swift:87:10:87:10 | source :  | webview.swift:39:5:39:44 | [summary param] this in toDouble() :  | file://:0:0:0:0 | [summary] to write: return (return) in toDouble() :  | webview.swift:87:10:87:26 | call to toDouble() |
-| webview.swift:88:10:88:10 | source :  | webview.swift:40:5:40:40 | [summary param] this in toInt32() :  | file://:0:0:0:0 | [summary] to write: return (return) in toInt32() :  | webview.swift:88:10:88:25 | call to toInt32() |
-| webview.swift:89:10:89:10 | source :  | webview.swift:41:5:41:42 | [summary param] this in toUInt32() :  | file://:0:0:0:0 | [summary] to write: return (return) in toUInt32() :  | webview.swift:89:10:89:26 | call to toUInt32() |
-| webview.swift:90:10:90:10 | source :  | webview.swift:42:5:42:62 | [summary param] this in toNumber() :  | file://:0:0:0:0 | [summary] to write: return (return) in toNumber() :  | webview.swift:90:10:90:26 | call to toNumber() |
-| webview.swift:91:10:91:10 | source :  | webview.swift:43:5:43:44 | [summary param] this in toString() :  | file://:0:0:0:0 | [summary] to write: return (return) in toString() :  | webview.swift:91:10:91:26 | call to toString() |
-| webview.swift:92:10:92:10 | source :  | webview.swift:44:5:44:44 | [summary param] this in toDate() :  | file://:0:0:0:0 | [summary] to write: return (return) in toDate() :  | webview.swift:92:10:92:24 | call to toDate() |
-| webview.swift:93:10:93:10 | source :  | webview.swift:45:5:45:44 | [summary param] this in toArray() :  | file://:0:0:0:0 | [summary] to write: return (return) in toArray() :  | webview.swift:93:10:93:25 | call to toArray() |
-| webview.swift:94:10:94:10 | source :  | webview.swift:46:5:46:65 | [summary param] this in toDictionary() :  | file://:0:0:0:0 | [summary] to write: return (return) in toDictionary() :  | webview.swift:94:10:94:30 | call to toDictionary() |
-| webview.swift:95:10:95:10 | source :  | webview.swift:47:5:47:50 | [summary param] this in toPoint() :  | file://:0:0:0:0 | [summary] to write: return (return) in toPoint() :  | webview.swift:95:10:95:25 | call to toPoint() |
-| webview.swift:96:10:96:10 | source :  | webview.swift:48:5:48:50 | [summary param] this in toRange() :  | file://:0:0:0:0 | [summary] to write: return (return) in toRange() :  | webview.swift:96:10:96:25 | call to toRange() |
-| webview.swift:97:10:97:10 | source :  | webview.swift:49:5:49:47 | [summary param] this in toRect() :  | file://:0:0:0:0 | [summary] to write: return (return) in toRect() :  | webview.swift:97:10:97:24 | call to toRect() |
-| webview.swift:98:10:98:10 | source :  | webview.swift:50:5:50:47 | [summary param] this in toSize() :  | file://:0:0:0:0 | [summary] to write: return (return) in toSize() :  | webview.swift:98:10:98:24 | call to toSize() |
-| webview.swift:99:10:99:10 | source :  | webview.swift:51:5:51:84 | [summary param] this in atIndex(_:) :  | file://:0:0:0:0 | [summary] to write: return (return) in atIndex(_:) :  | webview.swift:99:10:99:26 | call to atIndex(_:) |
-| webview.swift:100:10:100:10 | source :  | webview.swift:53:5:53:89 | [summary param] this in forProperty(_:) :  | file://:0:0:0:0 | [summary] to write: return (return) in forProperty(_:) :  | webview.swift:100:10:100:31 | call to forProperty(_:) |
-| webview.swift:103:26:103:26 | s :  | webview.swift:27:5:27:39 | [summary param] 0 in JSValue.init(object:in:) :  | file://:0:0:0:0 | [summary] to write: return (return) in JSValue.init(object:in:) :  | webview.swift:103:10:103:47 | call to JSValue.init(object:in:) |
-| webview.swift:104:24:104:24 | s :  | webview.swift:28:5:28:38 | [summary param] 0 in JSValue.init(bool:in:) :  | file://:0:0:0:0 | [summary] to write: return (return) in JSValue.init(bool:in:) :  | webview.swift:104:10:104:47 | call to JSValue.init(bool:in:) |
-| webview.swift:105:26:105:26 | s :  | webview.swift:29:5:29:42 | [summary param] 0 in JSValue.init(double:in:) :  | file://:0:0:0:0 | [summary] to write: return (return) in JSValue.init(double:in:) :  | webview.swift:105:10:105:51 | call to JSValue.init(double:in:) |
-| webview.swift:106:25:106:25 | s :  | webview.swift:30:5:30:40 | [summary param] 0 in JSValue.init(int32:in:) :  | file://:0:0:0:0 | [summary] to write: return (return) in JSValue.init(int32:in:) :  | webview.swift:106:10:106:49 | call to JSValue.init(int32:in:) |
-| webview.swift:107:26:107:26 | s :  | webview.swift:31:5:31:42 | [summary param] 0 in JSValue.init(uInt32:in:) :  | file://:0:0:0:0 | [summary] to write: return (return) in JSValue.init(uInt32:in:) :  | webview.swift:107:10:107:51 | call to JSValue.init(uInt32:in:) |
-| webview.swift:108:25:108:25 | s :  | webview.swift:32:5:32:42 | [summary param] 0 in JSValue.init(point:in:) :  | file://:0:0:0:0 | [summary] to write: return (return) in JSValue.init(point:in:) :  | webview.swift:108:10:108:51 | call to JSValue.init(point:in:) |
-| webview.swift:109:25:109:25 | s :  | webview.swift:33:5:33:42 | [summary param] 0 in JSValue.init(range:in:) :  | file://:0:0:0:0 | [summary] to write: return (return) in JSValue.init(range:in:) :  | webview.swift:109:10:109:51 | call to JSValue.init(range:in:) |
-| webview.swift:110:24:110:24 | s :  | webview.swift:34:5:34:40 | [summary param] 0 in JSValue.init(rect:in:) :  | file://:0:0:0:0 | [summary] to write: return (return) in JSValue.init(rect:in:) :  | webview.swift:110:10:110:49 | call to JSValue.init(rect:in:) |
-| webview.swift:111:24:111:24 | s :  | webview.swift:35:5:35:40 | [summary param] 0 in JSValue.init(size:in:) :  | file://:0:0:0:0 | [summary] to write: return (return) in JSValue.init(size:in:) :  | webview.swift:111:10:111:49 | call to JSValue.init(size:in:) |
-| webview.swift:114:39:114:39 | s :  | webview.swift:52:5:52:53 | [summary param] 1 in defineProperty(_:descriptor:) :  | file://:0:0:0:0 | [summary] to write: argument this in defineProperty(_:descriptor:) :  | webview.swift:114:5:114:5 | [post] v1 :  |
-| webview.swift:118:17:118:17 | s :  | webview.swift:54:5:54:38 | [summary param] 0 in setValue(_:at:) :  | file://:0:0:0:0 | [summary] to write: argument this in setValue(_:at:) :  | webview.swift:118:5:118:5 | [post] v2 :  |
-| webview.swift:122:17:122:17 | s :  | webview.swift:55:5:55:48 | [summary param] 0 in setValue(_:forProperty:) :  | file://:0:0:0:0 | [summary] to write: argument this in setValue(_:forProperty:) :  | webview.swift:122:5:122:5 | [post] v3 :  |
-| webview.swift:132:34:132:41 | call to source() :  | webview.swift:65:5:65:93 | [summary param] 0 in WKUserScript.init(source:injectionTime:forMainFrameOnly:) :  | file://:0:0:0:0 | [summary] to write: return (return) in WKUserScript.init(source:injectionTime:forMainFrameOnly:) :  | webview.swift:132:13:132:102 | call to WKUserScript.init(source:injectionTime:forMainFrameOnly:) :  |
-| webview.swift:137:34:137:41 | call to source() :  | webview.swift:66:5:66:126 | [summary param] 0 in WKUserScript.init(source:injectionTime:forMainFrameOnly:in:) :  | file://:0:0:0:0 | [summary] to write: return (return) in WKUserScript.init(source:injectionTime:forMainFrameOnly:in:) :  | webview.swift:137:13:137:113 | call to WKUserScript.init(source:injectionTime:forMainFrameOnly:in:) :  |
+| webview.swift:90:10:90:10 | source :  | webview.swift:36:5:36:41 | [summary param] this in toObject() :  | file://:0:0:0:0 | [summary] to write: return (return) in toObject() :  | webview.swift:90:10:90:26 | call to toObject() |
+| webview.swift:91:10:91:10 | source :  | webview.swift:37:5:37:55 | [summary param] this in toObjectOf(_:) :  | file://:0:0:0:0 | [summary] to write: return (return) in toObjectOf(_:) :  | webview.swift:91:10:91:41 | call to toObjectOf(_:) |
+| webview.swift:92:10:92:10 | source :  | webview.swift:38:5:38:42 | [summary param] this in toBool() :  | file://:0:0:0:0 | [summary] to write: return (return) in toBool() :  | webview.swift:92:10:92:24 | call to toBool() |
+| webview.swift:93:10:93:10 | source :  | webview.swift:39:5:39:44 | [summary param] this in toDouble() :  | file://:0:0:0:0 | [summary] to write: return (return) in toDouble() :  | webview.swift:93:10:93:26 | call to toDouble() |
+| webview.swift:94:10:94:10 | source :  | webview.swift:40:5:40:40 | [summary param] this in toInt32() :  | file://:0:0:0:0 | [summary] to write: return (return) in toInt32() :  | webview.swift:94:10:94:25 | call to toInt32() |
+| webview.swift:95:10:95:10 | source :  | webview.swift:41:5:41:42 | [summary param] this in toUInt32() :  | file://:0:0:0:0 | [summary] to write: return (return) in toUInt32() :  | webview.swift:95:10:95:26 | call to toUInt32() |
+| webview.swift:96:10:96:10 | source :  | webview.swift:42:5:42:62 | [summary param] this in toNumber() :  | file://:0:0:0:0 | [summary] to write: return (return) in toNumber() :  | webview.swift:96:10:96:26 | call to toNumber() |
+| webview.swift:97:10:97:10 | source :  | webview.swift:43:5:43:44 | [summary param] this in toString() :  | file://:0:0:0:0 | [summary] to write: return (return) in toString() :  | webview.swift:97:10:97:26 | call to toString() |
+| webview.swift:98:10:98:10 | source :  | webview.swift:44:5:44:44 | [summary param] this in toDate() :  | file://:0:0:0:0 | [summary] to write: return (return) in toDate() :  | webview.swift:98:10:98:24 | call to toDate() |
+| webview.swift:99:10:99:10 | source :  | webview.swift:45:5:45:44 | [summary param] this in toArray() :  | file://:0:0:0:0 | [summary] to write: return (return) in toArray() :  | webview.swift:99:10:99:25 | call to toArray() |
+| webview.swift:100:10:100:10 | source :  | webview.swift:46:5:46:65 | [summary param] this in toDictionary() :  | file://:0:0:0:0 | [summary] to write: return (return) in toDictionary() :  | webview.swift:100:10:100:30 | call to toDictionary() |
+| webview.swift:101:10:101:10 | source :  | webview.swift:47:5:47:50 | [summary param] this in toPoint() :  | file://:0:0:0:0 | [summary] to write: return (return) in toPoint() :  | webview.swift:101:10:101:25 | call to toPoint() |
+| webview.swift:102:10:102:10 | source :  | webview.swift:48:5:48:50 | [summary param] this in toRange() :  | file://:0:0:0:0 | [summary] to write: return (return) in toRange() :  | webview.swift:102:10:102:25 | call to toRange() |
+| webview.swift:103:10:103:10 | source :  | webview.swift:49:5:49:47 | [summary param] this in toRect() :  | file://:0:0:0:0 | [summary] to write: return (return) in toRect() :  | webview.swift:103:10:103:24 | call to toRect() |
+| webview.swift:104:10:104:10 | source :  | webview.swift:50:5:50:47 | [summary param] this in toSize() :  | file://:0:0:0:0 | [summary] to write: return (return) in toSize() :  | webview.swift:104:10:104:24 | call to toSize() |
+| webview.swift:105:10:105:10 | source :  | webview.swift:51:5:51:84 | [summary param] this in atIndex(_:) :  | file://:0:0:0:0 | [summary] to write: return (return) in atIndex(_:) :  | webview.swift:105:10:105:26 | call to atIndex(_:) |
+| webview.swift:106:10:106:10 | source :  | webview.swift:53:5:53:89 | [summary param] this in forProperty(_:) :  | file://:0:0:0:0 | [summary] to write: return (return) in forProperty(_:) :  | webview.swift:106:10:106:31 | call to forProperty(_:) |
+| webview.swift:109:26:109:26 | s :  | webview.swift:27:5:27:39 | [summary param] 0 in JSValue.init(object:in:) :  | file://:0:0:0:0 | [summary] to write: return (return) in JSValue.init(object:in:) :  | webview.swift:109:10:109:47 | call to JSValue.init(object:in:) |
+| webview.swift:110:24:110:24 | s :  | webview.swift:28:5:28:38 | [summary param] 0 in JSValue.init(bool:in:) :  | file://:0:0:0:0 | [summary] to write: return (return) in JSValue.init(bool:in:) :  | webview.swift:110:10:110:47 | call to JSValue.init(bool:in:) |
+| webview.swift:111:26:111:26 | s :  | webview.swift:29:5:29:42 | [summary param] 0 in JSValue.init(double:in:) :  | file://:0:0:0:0 | [summary] to write: return (return) in JSValue.init(double:in:) :  | webview.swift:111:10:111:51 | call to JSValue.init(double:in:) |
+| webview.swift:112:25:112:25 | s :  | webview.swift:30:5:30:40 | [summary param] 0 in JSValue.init(int32:in:) :  | file://:0:0:0:0 | [summary] to write: return (return) in JSValue.init(int32:in:) :  | webview.swift:112:10:112:49 | call to JSValue.init(int32:in:) |
+| webview.swift:113:26:113:26 | s :  | webview.swift:31:5:31:42 | [summary param] 0 in JSValue.init(uInt32:in:) :  | file://:0:0:0:0 | [summary] to write: return (return) in JSValue.init(uInt32:in:) :  | webview.swift:113:10:113:51 | call to JSValue.init(uInt32:in:) |
+| webview.swift:114:25:114:25 | s :  | webview.swift:32:5:32:42 | [summary param] 0 in JSValue.init(point:in:) :  | file://:0:0:0:0 | [summary] to write: return (return) in JSValue.init(point:in:) :  | webview.swift:114:10:114:51 | call to JSValue.init(point:in:) |
+| webview.swift:115:25:115:25 | s :  | webview.swift:33:5:33:42 | [summary param] 0 in JSValue.init(range:in:) :  | file://:0:0:0:0 | [summary] to write: return (return) in JSValue.init(range:in:) :  | webview.swift:115:10:115:51 | call to JSValue.init(range:in:) |
+| webview.swift:116:24:116:24 | s :  | webview.swift:34:5:34:40 | [summary param] 0 in JSValue.init(rect:in:) :  | file://:0:0:0:0 | [summary] to write: return (return) in JSValue.init(rect:in:) :  | webview.swift:116:10:116:49 | call to JSValue.init(rect:in:) |
+| webview.swift:117:24:117:24 | s :  | webview.swift:35:5:35:40 | [summary param] 0 in JSValue.init(size:in:) :  | file://:0:0:0:0 | [summary] to write: return (return) in JSValue.init(size:in:) :  | webview.swift:117:10:117:49 | call to JSValue.init(size:in:) |
+| webview.swift:120:39:120:39 | s :  | webview.swift:52:5:52:53 | [summary param] 1 in defineProperty(_:descriptor:) :  | file://:0:0:0:0 | [summary] to write: argument this in defineProperty(_:descriptor:) :  | webview.swift:120:5:120:5 | [post] v1 :  |
+| webview.swift:124:17:124:17 | s :  | webview.swift:54:5:54:38 | [summary param] 0 in setValue(_:at:) :  | file://:0:0:0:0 | [summary] to write: argument this in setValue(_:at:) :  | webview.swift:124:5:124:5 | [post] v2 :  |
+| webview.swift:128:17:128:17 | s :  | webview.swift:55:5:55:48 | [summary param] 0 in setValue(_:forProperty:) :  | file://:0:0:0:0 | [summary] to write: argument this in setValue(_:forProperty:) :  | webview.swift:128:5:128:5 | [post] v3 :  |
+| webview.swift:138:34:138:41 | call to source() :  | webview.swift:65:5:65:93 | [summary param] 0 in WKUserScript.init(source:injectionTime:forMainFrameOnly:) :  | file://:0:0:0:0 | [summary] to write: return (return) in WKUserScript.init(source:injectionTime:forMainFrameOnly:) :  | webview.swift:138:13:138:102 | call to WKUserScript.init(source:injectionTime:forMainFrameOnly:) :  |
+| webview.swift:143:34:143:41 | call to source() :  | webview.swift:66:5:66:126 | [summary param] 0 in WKUserScript.init(source:injectionTime:forMainFrameOnly:in:) :  | file://:0:0:0:0 | [summary] to write: return (return) in WKUserScript.init(source:injectionTime:forMainFrameOnly:in:) :  | webview.swift:143:13:143:113 | call to WKUserScript.init(source:injectionTime:forMainFrameOnly:in:) :  |
+| webview.swift:150:10:150:10 | src :  | webview.swift:72:9:72:9 | self :  | file://:0:0:0:0 | .request :  | webview.swift:150:10:150:14 | .request |
 #select
 | data.swift:85:12:85:12 | dataTainted | data.swift:81:26:81:33 | call to source() :  | data.swift:85:12:85:12 | dataTainted | result |
 | data.swift:86:12:86:12 | dataTainted2 | data.swift:81:26:81:33 | call to source() :  | data.swift:86:12:86:12 | dataTainted2 | result |
@@ -1527,37 +1538,38 @@ subpaths
 | url.swift:174:12:174:20 | .httpBodyStream | url.swift:161:16:161:23 | call to source() :  | url.swift:174:12:174:20 | .httpBodyStream | result |
 | url.swift:176:12:176:20 | .mainDocument | url.swift:161:16:161:23 | call to source() :  | url.swift:176:12:176:20 | .mainDocument | result |
 | url.swift:178:12:178:20 | .allHTTPHeaderFields | url.swift:161:16:161:23 | call to source() :  | url.swift:178:12:178:20 | .allHTTPHeaderFields | result |
-| webview.swift:77:10:77:41 | .body | webview.swift:77:11:77:18 | call to source() :  | webview.swift:77:10:77:41 | .body | result |
-| webview.swift:84:10:84:26 | call to toObject() | webview.swift:81:13:81:20 | call to source() :  | webview.swift:84:10:84:26 | call to toObject() | result |
-| webview.swift:85:10:85:41 | call to toObjectOf(_:) | webview.swift:81:13:81:20 | call to source() :  | webview.swift:85:10:85:41 | call to toObjectOf(_:) | result |
-| webview.swift:86:10:86:24 | call to toBool() | webview.swift:81:13:81:20 | call to source() :  | webview.swift:86:10:86:24 | call to toBool() | result |
-| webview.swift:87:10:87:26 | call to toDouble() | webview.swift:81:13:81:20 | call to source() :  | webview.swift:87:10:87:26 | call to toDouble() | result |
-| webview.swift:88:10:88:25 | call to toInt32() | webview.swift:81:13:81:20 | call to source() :  | webview.swift:88:10:88:25 | call to toInt32() | result |
-| webview.swift:89:10:89:26 | call to toUInt32() | webview.swift:81:13:81:20 | call to source() :  | webview.swift:89:10:89:26 | call to toUInt32() | result |
-| webview.swift:90:10:90:26 | call to toNumber() | webview.swift:81:13:81:20 | call to source() :  | webview.swift:90:10:90:26 | call to toNumber() | result |
-| webview.swift:91:10:91:26 | call to toString() | webview.swift:81:13:81:20 | call to source() :  | webview.swift:91:10:91:26 | call to toString() | result |
-| webview.swift:92:10:92:24 | call to toDate() | webview.swift:81:13:81:20 | call to source() :  | webview.swift:92:10:92:24 | call to toDate() | result |
-| webview.swift:93:10:93:25 | call to toArray() | webview.swift:81:13:81:20 | call to source() :  | webview.swift:93:10:93:25 | call to toArray() | result |
-| webview.swift:94:10:94:30 | call to toDictionary() | webview.swift:81:13:81:20 | call to source() :  | webview.swift:94:10:94:30 | call to toDictionary() | result |
-| webview.swift:95:10:95:25 | call to toPoint() | webview.swift:81:13:81:20 | call to source() :  | webview.swift:95:10:95:25 | call to toPoint() | result |
-| webview.swift:96:10:96:25 | call to toRange() | webview.swift:81:13:81:20 | call to source() :  | webview.swift:96:10:96:25 | call to toRange() | result |
-| webview.swift:97:10:97:24 | call to toRect() | webview.swift:81:13:81:20 | call to source() :  | webview.swift:97:10:97:24 | call to toRect() | result |
-| webview.swift:98:10:98:24 | call to toSize() | webview.swift:81:13:81:20 | call to source() :  | webview.swift:98:10:98:24 | call to toSize() | result |
-| webview.swift:99:10:99:26 | call to atIndex(_:) | webview.swift:81:13:81:20 | call to source() :  | webview.swift:99:10:99:26 | call to atIndex(_:) | result |
-| webview.swift:100:10:100:31 | call to forProperty(_:) | webview.swift:81:13:81:20 | call to source() :  | webview.swift:100:10:100:31 | call to forProperty(_:) | result |
-| webview.swift:103:10:103:47 | call to JSValue.init(object:in:) | webview.swift:81:13:81:20 | call to source() :  | webview.swift:103:10:103:47 | call to JSValue.init(object:in:) | result |
-| webview.swift:104:10:104:47 | call to JSValue.init(bool:in:) | webview.swift:81:13:81:20 | call to source() :  | webview.swift:104:10:104:47 | call to JSValue.init(bool:in:) | result |
-| webview.swift:105:10:105:51 | call to JSValue.init(double:in:) | webview.swift:81:13:81:20 | call to source() :  | webview.swift:105:10:105:51 | call to JSValue.init(double:in:) | result |
-| webview.swift:106:10:106:49 | call to JSValue.init(int32:in:) | webview.swift:81:13:81:20 | call to source() :  | webview.swift:106:10:106:49 | call to JSValue.init(int32:in:) | result |
-| webview.swift:107:10:107:51 | call to JSValue.init(uInt32:in:) | webview.swift:81:13:81:20 | call to source() :  | webview.swift:107:10:107:51 | call to JSValue.init(uInt32:in:) | result |
-| webview.swift:108:10:108:51 | call to JSValue.init(point:in:) | webview.swift:81:13:81:20 | call to source() :  | webview.swift:108:10:108:51 | call to JSValue.init(point:in:) | result |
-| webview.swift:109:10:109:51 | call to JSValue.init(range:in:) | webview.swift:81:13:81:20 | call to source() :  | webview.swift:109:10:109:51 | call to JSValue.init(range:in:) | result |
-| webview.swift:110:10:110:49 | call to JSValue.init(rect:in:) | webview.swift:81:13:81:20 | call to source() :  | webview.swift:110:10:110:49 | call to JSValue.init(rect:in:) | result |
-| webview.swift:111:10:111:49 | call to JSValue.init(size:in:) | webview.swift:81:13:81:20 | call to source() :  | webview.swift:111:10:111:49 | call to JSValue.init(size:in:) | result |
-| webview.swift:115:10:115:10 | v1 | webview.swift:81:13:81:20 | call to source() :  | webview.swift:115:10:115:10 | v1 | result |
-| webview.swift:119:10:119:10 | v2 | webview.swift:81:13:81:20 | call to source() :  | webview.swift:119:10:119:10 | v2 | result |
-| webview.swift:123:10:123:10 | v3 | webview.swift:81:13:81:20 | call to source() :  | webview.swift:123:10:123:10 | v3 | result |
-| webview.swift:133:10:133:10 | b | webview.swift:132:34:132:41 | call to source() :  | webview.swift:133:10:133:10 | b | result |
-| webview.swift:134:10:134:12 | .source | webview.swift:132:34:132:41 | call to source() :  | webview.swift:134:10:134:12 | .source | result |
-| webview.swift:138:10:138:10 | c | webview.swift:137:34:137:41 | call to source() :  | webview.swift:138:10:138:10 | c | result |
-| webview.swift:139:10:139:12 | .source | webview.swift:137:34:137:41 | call to source() :  | webview.swift:139:10:139:12 | .source | result |
+| webview.swift:83:10:83:41 | .body | webview.swift:83:11:83:18 | call to source() :  | webview.swift:83:10:83:41 | .body | result |
+| webview.swift:90:10:90:26 | call to toObject() | webview.swift:87:13:87:20 | call to source() :  | webview.swift:90:10:90:26 | call to toObject() | result |
+| webview.swift:91:10:91:41 | call to toObjectOf(_:) | webview.swift:87:13:87:20 | call to source() :  | webview.swift:91:10:91:41 | call to toObjectOf(_:) | result |
+| webview.swift:92:10:92:24 | call to toBool() | webview.swift:87:13:87:20 | call to source() :  | webview.swift:92:10:92:24 | call to toBool() | result |
+| webview.swift:93:10:93:26 | call to toDouble() | webview.swift:87:13:87:20 | call to source() :  | webview.swift:93:10:93:26 | call to toDouble() | result |
+| webview.swift:94:10:94:25 | call to toInt32() | webview.swift:87:13:87:20 | call to source() :  | webview.swift:94:10:94:25 | call to toInt32() | result |
+| webview.swift:95:10:95:26 | call to toUInt32() | webview.swift:87:13:87:20 | call to source() :  | webview.swift:95:10:95:26 | call to toUInt32() | result |
+| webview.swift:96:10:96:26 | call to toNumber() | webview.swift:87:13:87:20 | call to source() :  | webview.swift:96:10:96:26 | call to toNumber() | result |
+| webview.swift:97:10:97:26 | call to toString() | webview.swift:87:13:87:20 | call to source() :  | webview.swift:97:10:97:26 | call to toString() | result |
+| webview.swift:98:10:98:24 | call to toDate() | webview.swift:87:13:87:20 | call to source() :  | webview.swift:98:10:98:24 | call to toDate() | result |
+| webview.swift:99:10:99:25 | call to toArray() | webview.swift:87:13:87:20 | call to source() :  | webview.swift:99:10:99:25 | call to toArray() | result |
+| webview.swift:100:10:100:30 | call to toDictionary() | webview.swift:87:13:87:20 | call to source() :  | webview.swift:100:10:100:30 | call to toDictionary() | result |
+| webview.swift:101:10:101:25 | call to toPoint() | webview.swift:87:13:87:20 | call to source() :  | webview.swift:101:10:101:25 | call to toPoint() | result |
+| webview.swift:102:10:102:25 | call to toRange() | webview.swift:87:13:87:20 | call to source() :  | webview.swift:102:10:102:25 | call to toRange() | result |
+| webview.swift:103:10:103:24 | call to toRect() | webview.swift:87:13:87:20 | call to source() :  | webview.swift:103:10:103:24 | call to toRect() | result |
+| webview.swift:104:10:104:24 | call to toSize() | webview.swift:87:13:87:20 | call to source() :  | webview.swift:104:10:104:24 | call to toSize() | result |
+| webview.swift:105:10:105:26 | call to atIndex(_:) | webview.swift:87:13:87:20 | call to source() :  | webview.swift:105:10:105:26 | call to atIndex(_:) | result |
+| webview.swift:106:10:106:31 | call to forProperty(_:) | webview.swift:87:13:87:20 | call to source() :  | webview.swift:106:10:106:31 | call to forProperty(_:) | result |
+| webview.swift:109:10:109:47 | call to JSValue.init(object:in:) | webview.swift:87:13:87:20 | call to source() :  | webview.swift:109:10:109:47 | call to JSValue.init(object:in:) | result |
+| webview.swift:110:10:110:47 | call to JSValue.init(bool:in:) | webview.swift:87:13:87:20 | call to source() :  | webview.swift:110:10:110:47 | call to JSValue.init(bool:in:) | result |
+| webview.swift:111:10:111:51 | call to JSValue.init(double:in:) | webview.swift:87:13:87:20 | call to source() :  | webview.swift:111:10:111:51 | call to JSValue.init(double:in:) | result |
+| webview.swift:112:10:112:49 | call to JSValue.init(int32:in:) | webview.swift:87:13:87:20 | call to source() :  | webview.swift:112:10:112:49 | call to JSValue.init(int32:in:) | result |
+| webview.swift:113:10:113:51 | call to JSValue.init(uInt32:in:) | webview.swift:87:13:87:20 | call to source() :  | webview.swift:113:10:113:51 | call to JSValue.init(uInt32:in:) | result |
+| webview.swift:114:10:114:51 | call to JSValue.init(point:in:) | webview.swift:87:13:87:20 | call to source() :  | webview.swift:114:10:114:51 | call to JSValue.init(point:in:) | result |
+| webview.swift:115:10:115:51 | call to JSValue.init(range:in:) | webview.swift:87:13:87:20 | call to source() :  | webview.swift:115:10:115:51 | call to JSValue.init(range:in:) | result |
+| webview.swift:116:10:116:49 | call to JSValue.init(rect:in:) | webview.swift:87:13:87:20 | call to source() :  | webview.swift:116:10:116:49 | call to JSValue.init(rect:in:) | result |
+| webview.swift:117:10:117:49 | call to JSValue.init(size:in:) | webview.swift:87:13:87:20 | call to source() :  | webview.swift:117:10:117:49 | call to JSValue.init(size:in:) | result |
+| webview.swift:121:10:121:10 | v1 | webview.swift:87:13:87:20 | call to source() :  | webview.swift:121:10:121:10 | v1 | result |
+| webview.swift:125:10:125:10 | v2 | webview.swift:87:13:87:20 | call to source() :  | webview.swift:125:10:125:10 | v2 | result |
+| webview.swift:129:10:129:10 | v3 | webview.swift:87:13:87:20 | call to source() :  | webview.swift:129:10:129:10 | v3 | result |
+| webview.swift:139:10:139:10 | b | webview.swift:138:34:138:41 | call to source() :  | webview.swift:139:10:139:10 | b | result |
+| webview.swift:140:10:140:12 | .source | webview.swift:138:34:138:41 | call to source() :  | webview.swift:140:10:140:12 | .source | result |
+| webview.swift:144:10:144:10 | c | webview.swift:143:34:143:41 | call to source() :  | webview.swift:144:10:144:10 | c | result |
+| webview.swift:145:10:145:12 | .source | webview.swift:143:34:143:41 | call to source() :  | webview.swift:145:10:145:12 | .source | result |
+| webview.swift:150:10:150:14 | .request | webview.swift:149:15:149:22 | call to source() :  | webview.swift:150:10:150:14 | .request | result |

--- a/swift/ql/test/library-tests/dataflow/taint/webview.swift
+++ b/swift/ql/test/library-tests/dataflow/taint/webview.swift
@@ -68,59 +68,65 @@ class WKUserScript : NSObject {
     var source: String { get { return "" } }
 }
 
+class WKNavigationAction : NSObject {
+    var request: URLRequest = URLRequest()
+}
+
+struct URLRequest {}
+
 // --- tests ---
 
 func source() -> Any { return "" }
 func sink(_: Any) {}
 
 func testInheritBodyTaint() {
-    sink((source() as! WKScriptMessage).body) // $ tainted=77
+    sink((source() as! WKScriptMessage).body) // $ tainted=83
 }
 
 func testJsValue() {
     let s = source()
 
     let source = s as! JSValue
-    sink(source.toObject() as Any) // $ tainted=81
-    sink(source.toObjectOf(NSNumber.self) as Any) // $ tainted=81
-    sink(source.toBool()) // $ tainted=81
-    sink(source.toDouble()) // $ tainted=81
-    sink(source.toInt32()) // $ tainted=81
-    sink(source.toUInt32()) // $ tainted=81
-    sink(source.toNumber() as Any) // $ tainted=81
-    sink(source.toString() as Any) // $ tainted=81
-    sink(source.toDate() as Any) // $ tainted=81
-    sink(source.toArray() as Any) // $ tainted=81
-    sink(source.toDictionary() as Any) // $ tainted=81
-    sink(source.toPoint()) // $ tainted=81
-    sink(source.toRange()) // $ tainted=81
-    sink(source.toRect()) // $ tainted=81
-    sink(source.toSize()) // $ tainted=81
-    sink(source.atIndex(0) as Any) // $ tainted=81
-    sink(source.forProperty("") as Any) // $ tainted=81
+    sink(source.toObject() as Any) // $ tainted=87
+    sink(source.toObjectOf(NSNumber.self) as Any) // $ tainted=87
+    sink(source.toBool()) // $ tainted=87
+    sink(source.toDouble()) // $ tainted=87
+    sink(source.toInt32()) // $ tainted=87
+    sink(source.toUInt32()) // $ tainted=87
+    sink(source.toNumber() as Any) // $ tainted=87
+    sink(source.toString() as Any) // $ tainted=87
+    sink(source.toDate() as Any) // $ tainted=87
+    sink(source.toArray() as Any) // $ tainted=87
+    sink(source.toDictionary() as Any) // $ tainted=87
+    sink(source.toPoint()) // $ tainted=87
+    sink(source.toRange()) // $ tainted=87
+    sink(source.toRect()) // $ tainted=87
+    sink(source.toSize()) // $ tainted=87
+    sink(source.atIndex(0) as Any) // $ tainted=87
+    sink(source.forProperty("") as Any) // $ tainted=87
 
     let context = JSContext()
-    sink(JSValue(object: s as Any, in: context)) // $ tainted=81
-    sink(JSValue(bool: s as! Bool, in: context)) // $ tainted=81
-    sink(JSValue(double: s as! Double, in: context)) // $ tainted=81
-    sink(JSValue(int32: s as! Int32, in: context)) // $ tainted=81
-    sink(JSValue(uInt32: s as! UInt32, in: context)) // $ tainted=81
-    sink(JSValue(point: s as! CGPoint, in: context)) // $ tainted=81
-    sink(JSValue(range: s as! NSRange, in: context)) // $ tainted=81
-    sink(JSValue(rect: s as! CGRect, in: context)) // $ tainted=81
-    sink(JSValue(size: s as! CGSize, in: context)) // $ tainted=81
+    sink(JSValue(object: s as Any, in: context)) // $ tainted=87
+    sink(JSValue(bool: s as! Bool, in: context)) // $ tainted=87
+    sink(JSValue(double: s as! Double, in: context)) // $ tainted=87
+    sink(JSValue(int32: s as! Int32, in: context)) // $ tainted=87
+    sink(JSValue(uInt32: s as! UInt32, in: context)) // $ tainted=87
+    sink(JSValue(point: s as! CGPoint, in: context)) // $ tainted=87
+    sink(JSValue(range: s as! NSRange, in: context)) // $ tainted=87
+    sink(JSValue(rect: s as! CGRect, in: context)) // $ tainted=87
+    sink(JSValue(size: s as! CGSize, in: context)) // $ tainted=87
 
     let v1 = JSValue(object: "", in: context)
     v1.defineProperty("", descriptor: s as Any)
-    sink(v1) // $ tainted=81
+    sink(v1) // $ tainted=87
 
     let v2 = JSValue(object: "", in: context)
     v2.setValue(s as Any, at: 0)
-    sink(v2) // $ tainted=81
+    sink(v2) // $ tainted=87
 
     let v3 = JSValue(object: "", in: context)
     v3.setValue(s as Any, forProperty: "")
-    sink(v3) // $ tainted=81
+    sink(v3) // $ tainted=87
 }
 
 func testWKUserScript() {
@@ -130,11 +136,16 @@ func testWKUserScript() {
     sink(a.source)
 
     let b = WKUserScript(source: source() as! String, injectionTime: atStart, forMainFrameOnly: false)
-    sink(b) // $ tainted=132
-    sink(b.source) // $ tainted=132
+    sink(b) // $ tainted=138
+    sink(b.source) // $ tainted=138
 
     let world = WKContentWorld()
     let c = WKUserScript(source: source() as! String, injectionTime: atStart, forMainFrameOnly: false, in: world)
-    sink(c) // $ tainted=137
-    sink(c.source) // $ tainted=137
+    sink(c) // $ tainted=143
+    sink(c.source) // $ tainted=143
+}
+
+func testWKNavigationAction() {
+    let src = source() as! WKNavigationAction
+    sink(src.request) // $ tainted=149
 }


### PR DESCRIPTION
Adds a new source modeling the navigation action of a user in a WebView. This works under the assumption that the links present in the WebView are untrusted (that is, users can create their own links and those are displayed to the other users). Although that assumption may not always be correct, I think it makes sense to have this not-so-fine-grained source, more so considering the few sources we have modeled until now.

This also adds a few taint steps so that the added source is actually useful.