### PR TITLE
C++: Flow out of writes to iterators

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -381,7 +381,7 @@ private Operand fullyConvertedCallStep(Operand op) {
  */
 private Instruction getUse(Operand op) {
   result = op.getUse() and
-  not Ssa::ignoreOperand(op)
+  not Ssa::ignoreInstruction(result)
 }
 
 /** Gets a use of the instruction `instr` that is not ignored for dataflow purposes. */

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
@@ -121,10 +121,10 @@ private newtype TDefOrUseImpl =
     not isDef(_, _, operand, _, _, _)
   } or
   TIteratorDef(
-    Operand iteratorAddress, BaseSourceVariableInstruction container, int indirectionIndex
+    Operand iteratorDerefAddress, BaseSourceVariableInstruction container, int indirectionIndex
   ) {
-    isIteratorDef(container, iteratorAddress, _, _, indirectionIndex) and
-    any(SsaInternals0::Def def | def.isIteratorDef()).getAddressOperand() = iteratorAddress
+    isIteratorDef(container, iteratorDerefAddress, _, _, indirectionIndex) and
+    any(SsaInternals0::Def def | def.isIteratorDef()).getAddressOperand() = iteratorDerefAddress
   } or
   TIteratorUse(
     Operand iteratorAddress, BaseSourceVariableInstruction container, int indirectionIndex
@@ -465,11 +465,20 @@ private predicate indirectConversionFlowStep(Node nFrom, Node nTo) {
     nodeToDefOrUse(nTo, defOrUse, _) and
     adjacentDefRead(defOrUse, _)
   ) and
-  exists(Operand op1, Operand op2, int indirectionIndex, Instruction instr |
-    hasOperandAndIndex(nFrom, op1, pragma[only_bind_into](indirectionIndex)) and
-    hasOperandAndIndex(nTo, op2, pragma[only_bind_into](indirectionIndex)) and
-    instr = op2.getDef() and
-    conversionFlow(op1, instr, _, _)
+  (
+    exists(Operand op1, Operand op2, int indirectionIndex, Instruction instr |
+      hasOperandAndIndex(nFrom, op1, pragma[only_bind_into](indirectionIndex)) and
+      hasOperandAndIndex(nTo, op2, pragma[only_bind_into](indirectionIndex)) and
+      instr = op2.getDef() and
+      conversionFlow(op1, instr, _, _)
+    )
+    or
+    exists(Operand op1, Operand op2, int indirectionIndex, Instruction instr |
+      hasOperandAndIndex(nFrom, op1, pragma[only_bind_into](indirectionIndex)) and
+      hasOperandAndIndex(nTo, op2, indirectionIndex - 1) and
+      instr = op2.getDef() and
+      isDereference(instr, op1)
+    )
   )
 }
 

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternalsCommon.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternalsCommon.qll
@@ -515,7 +515,11 @@ private module Cached {
 
   private predicate isSink(Instruction instr, CallInstruction call) {
     getAUse(instr).(ArgumentOperand).getCall() = call and
-    // Don't include various operations that don't modify what the iterator points to.
+    // Only include operations that may modify the object that the iterator points to.
+    // The following is a non-exhaustive list of things that may modify the value of the
+    // iterator, but never the value of what the iterator points to.
+    // The more things we can exclude here, the faster the small dataflow-like analysis
+    // done by `convertsIntoArgument` will converge.
     not exists(Function f | f = call.getStaticCallTarget() |
       f instanceof Iterator::IteratorCrementOperator or
       f instanceof Iterator::IteratorBinaryArithmeticOperator or

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternalsCommon.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternalsCommon.qll
@@ -481,10 +481,9 @@ private module Cached {
   }
 
   /**
-   * Holds if `iteratorAddress` is an address of an iterator (i.e., `it`)
-   * that is dereferenced and then used for a write operation that writes the value `value`.
-   * The `memory` instruction represents the memory that the IR's SSA analysis determined was
-   * read by the call to `operator*`.
+   * Holds if `iteratorDerefAddress` is an address of an iterator dereference (i.e., `*it`)
+   * that is used for a write operation that writes the value `value`. The `memory` instruction
+   * represents the memory that the IR's SSA analysis determined was read by the call to `operator*`.
    *
    * The `numberOfLoads` integer represents the number of dereferences this write corresponds to
    * on the underlying container that produced the iterator.

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-359/semmle/tests/PrivateCleartextWrite.expected
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-359/semmle/tests/PrivateCleartextWrite.expected
@@ -2,10 +2,14 @@ edges
 | test.cpp:57:9:57:18 | theZipcode | test.cpp:57:9:57:18 | theZipcode |
 | test.cpp:57:9:57:18 | theZipcode | test.cpp:57:9:57:18 | theZipcode |
 | test.cpp:57:9:57:18 | theZipcode | test.cpp:57:9:57:18 | theZipcode |
+| test.cpp:74:24:74:30 | medical | test.cpp:74:11:74:15 | buff1 |
+| test.cpp:74:24:74:30 | medical | test.cpp:78:11:78:15 | buff2 |
 | test.cpp:74:24:74:30 | medical | test.cpp:78:24:78:27 | temp |
 | test.cpp:74:24:74:30 | medical | test.cpp:81:22:81:28 | medical |
+| test.cpp:77:16:77:22 | medical | test.cpp:78:11:78:15 | buff2 |
 | test.cpp:77:16:77:22 | medical | test.cpp:78:24:78:27 | temp |
 | test.cpp:77:16:77:22 | medical | test.cpp:81:22:81:28 | medical |
+| test.cpp:81:22:81:28 | medical | test.cpp:82:11:82:15 | buff3 |
 | test.cpp:81:22:81:28 | medical | test.cpp:82:24:82:28 | buff5 |
 | test.cpp:96:37:96:46 | theZipcode | test.cpp:96:37:96:46 | theZipcode |
 | test.cpp:96:37:96:46 | theZipcode | test.cpp:96:37:96:46 | theZipcode |
@@ -26,11 +30,14 @@ nodes
 | test.cpp:57:9:57:18 | theZipcode | semmle.label | theZipcode |
 | test.cpp:57:9:57:18 | theZipcode | semmle.label | theZipcode |
 | test.cpp:57:9:57:18 | theZipcode | semmle.label | theZipcode |
+| test.cpp:74:11:74:15 | buff1 | semmle.label | buff1 |
 | test.cpp:74:24:74:30 | medical | semmle.label | medical |
 | test.cpp:74:24:74:30 | medical | semmle.label | medical |
 | test.cpp:77:16:77:22 | medical | semmle.label | medical |
+| test.cpp:78:11:78:15 | buff2 | semmle.label | buff2 |
 | test.cpp:78:24:78:27 | temp | semmle.label | temp |
 | test.cpp:81:22:81:28 | medical | semmle.label | medical |
+| test.cpp:82:11:82:15 | buff3 | semmle.label | buff3 |
 | test.cpp:82:24:82:28 | buff5 | semmle.label | buff5 |
 | test.cpp:96:37:96:46 | theZipcode | semmle.label | theZipcode |
 | test.cpp:96:37:96:46 | theZipcode | semmle.label | theZipcode |
@@ -47,9 +54,15 @@ subpaths
 | test.cpp:57:9:57:18 | theZipcode | test.cpp:57:9:57:18 | theZipcode | test.cpp:57:9:57:18 | theZipcode | This write into the external location 'theZipcode' may contain unencrypted data from $@. | test.cpp:57:9:57:18 | theZipcode | this source of private data. |
 | test.cpp:57:9:57:18 | theZipcode | test.cpp:57:9:57:18 | theZipcode | test.cpp:57:9:57:18 | theZipcode | This write into the external location 'theZipcode' may contain unencrypted data from $@. | test.cpp:57:9:57:18 | theZipcode | this source of private data. |
 | test.cpp:57:9:57:18 | theZipcode | test.cpp:57:9:57:18 | theZipcode | test.cpp:57:9:57:18 | theZipcode | This write into the external location 'theZipcode' may contain unencrypted data from $@. | test.cpp:57:9:57:18 | theZipcode | this source of private data. |
+| test.cpp:74:11:74:15 | buff1 | test.cpp:74:24:74:30 | medical | test.cpp:74:11:74:15 | buff1 | This write into the external location 'buff1' may contain unencrypted data from $@. | test.cpp:74:24:74:30 | medical | this source of private data. |
 | test.cpp:74:24:74:30 | medical | test.cpp:74:24:74:30 | medical | test.cpp:74:24:74:30 | medical | This write into the external location 'medical' may contain unencrypted data from $@. | test.cpp:74:24:74:30 | medical | this source of private data. |
+| test.cpp:78:11:78:15 | buff2 | test.cpp:74:24:74:30 | medical | test.cpp:78:11:78:15 | buff2 | This write into the external location 'buff2' may contain unencrypted data from $@. | test.cpp:74:24:74:30 | medical | this source of private data. |
+| test.cpp:78:11:78:15 | buff2 | test.cpp:77:16:77:22 | medical | test.cpp:78:11:78:15 | buff2 | This write into the external location 'buff2' may contain unencrypted data from $@. | test.cpp:77:16:77:22 | medical | this source of private data. |
 | test.cpp:78:24:78:27 | temp | test.cpp:74:24:74:30 | medical | test.cpp:78:24:78:27 | temp | This write into the external location 'temp' may contain unencrypted data from $@. | test.cpp:74:24:74:30 | medical | this source of private data. |
 | test.cpp:78:24:78:27 | temp | test.cpp:77:16:77:22 | medical | test.cpp:78:24:78:27 | temp | This write into the external location 'temp' may contain unencrypted data from $@. | test.cpp:77:16:77:22 | medical | this source of private data. |
+| test.cpp:82:11:82:15 | buff3 | test.cpp:74:24:74:30 | medical | test.cpp:82:11:82:15 | buff3 | This write into the external location 'buff3' may contain unencrypted data from $@. | test.cpp:74:24:74:30 | medical | this source of private data. |
+| test.cpp:82:11:82:15 | buff3 | test.cpp:77:16:77:22 | medical | test.cpp:82:11:82:15 | buff3 | This write into the external location 'buff3' may contain unencrypted data from $@. | test.cpp:77:16:77:22 | medical | this source of private data. |
+| test.cpp:82:11:82:15 | buff3 | test.cpp:81:22:81:28 | medical | test.cpp:82:11:82:15 | buff3 | This write into the external location 'buff3' may contain unencrypted data from $@. | test.cpp:81:22:81:28 | medical | this source of private data. |
 | test.cpp:82:24:82:28 | buff5 | test.cpp:74:24:74:30 | medical | test.cpp:82:24:82:28 | buff5 | This write into the external location 'buff5' may contain unencrypted data from $@. | test.cpp:74:24:74:30 | medical | this source of private data. |
 | test.cpp:82:24:82:28 | buff5 | test.cpp:77:16:77:22 | medical | test.cpp:82:24:82:28 | buff5 | This write into the external location 'buff5' may contain unencrypted data from $@. | test.cpp:77:16:77:22 | medical | this source of private data. |
 | test.cpp:82:24:82:28 | buff5 | test.cpp:81:22:81:28 | medical | test.cpp:82:24:82:28 | buff5 | This write into the external location 'buff5' may contain unencrypted data from $@. | test.cpp:81:22:81:28 | medical | this source of private data. |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
@@ -8090,20 +8090,20 @@
 | vector.cpp:520:25:520:31 | call to vector | vector.cpp:523:8:523:9 | vs |  |
 | vector.cpp:520:25:520:31 | call to vector | vector.cpp:524:8:524:9 | vs |  |
 | vector.cpp:520:25:520:31 | call to vector | vector.cpp:526:8:526:9 | vs |  |
-| vector.cpp:520:25:520:31 | call to vector | vector.cpp:532:8:532:9 | vs |  |
-| vector.cpp:520:25:520:31 | call to vector | vector.cpp:533:2:533:2 | vs |  |
+| vector.cpp:520:25:520:31 | call to vector | vector.cpp:539:8:539:9 | vs |  |
+| vector.cpp:520:25:520:31 | call to vector | vector.cpp:540:2:540:2 | vs |  |
 | vector.cpp:520:30:520:30 | 0 | vector.cpp:520:25:520:31 | call to vector | TAINT |
 | vector.cpp:523:8:523:9 | ref arg vs | vector.cpp:524:8:524:9 | vs |  |
 | vector.cpp:523:8:523:9 | ref arg vs | vector.cpp:526:8:526:9 | vs |  |
-| vector.cpp:523:8:523:9 | ref arg vs | vector.cpp:532:8:532:9 | vs |  |
-| vector.cpp:523:8:523:9 | ref arg vs | vector.cpp:533:2:533:2 | vs |  |
+| vector.cpp:523:8:523:9 | ref arg vs | vector.cpp:539:8:539:9 | vs |  |
+| vector.cpp:523:8:523:9 | ref arg vs | vector.cpp:540:2:540:2 | vs |  |
 | vector.cpp:523:8:523:9 | vs | vector.cpp:523:10:523:10 | call to operator[] | TAINT |
 | vector.cpp:524:8:524:9 | ref arg vs | vector.cpp:526:8:526:9 | vs |  |
-| vector.cpp:524:8:524:9 | ref arg vs | vector.cpp:532:8:532:9 | vs |  |
-| vector.cpp:524:8:524:9 | ref arg vs | vector.cpp:533:2:533:2 | vs |  |
+| vector.cpp:524:8:524:9 | ref arg vs | vector.cpp:539:8:539:9 | vs |  |
+| vector.cpp:524:8:524:9 | ref arg vs | vector.cpp:540:2:540:2 | vs |  |
 | vector.cpp:524:8:524:9 | vs | vector.cpp:524:10:524:10 | call to operator[] | TAINT |
-| vector.cpp:526:8:526:9 | ref arg vs | vector.cpp:532:8:532:9 | vs |  |
-| vector.cpp:526:8:526:9 | ref arg vs | vector.cpp:533:2:533:2 | vs |  |
+| vector.cpp:526:8:526:9 | ref arg vs | vector.cpp:539:8:539:9 | vs |  |
+| vector.cpp:526:8:526:9 | ref arg vs | vector.cpp:540:2:540:2 | vs |  |
 | vector.cpp:526:8:526:9 | vs | vector.cpp:526:11:526:15 | call to begin | TAINT |
 | vector.cpp:526:11:526:15 | call to begin | vector.cpp:526:3:526:17 | ... = ... |  |
 | vector.cpp:526:11:526:15 | call to begin | vector.cpp:527:9:527:10 | it |  |
@@ -8128,5 +8128,5 @@
 | vector.cpp:530:3:530:4 | ref arg it | vector.cpp:531:9:531:10 | it |  |
 | vector.cpp:530:9:530:14 | call to source | vector.cpp:530:3:530:4 | ref arg it | TAINT |
 | vector.cpp:531:9:531:10 | it | vector.cpp:531:8:531:8 | call to operator* | TAINT |
-| vector.cpp:532:8:532:9 | ref arg vs | vector.cpp:533:2:533:2 | vs |  |
-| vector.cpp:532:8:532:9 | vs | vector.cpp:532:10:532:10 | call to operator[] | TAINT |
+| vector.cpp:539:8:539:9 | ref arg vs | vector.cpp:540:2:540:2 | vs |  |
+| vector.cpp:539:8:539:9 | vs | vector.cpp:539:10:539:10 | call to operator[] | TAINT |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/vector.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/vector.cpp
@@ -354,7 +354,7 @@ void test_vector_output_iterator(int b) {
 	for(std::vector<int>::iterator it = v4.begin(); it != v4.end(); ++it) {
 		taint_vector_output_iterator(it);
 	}
-	sink(v4); // $ ast MISSING: ir
+	sink(v4); // $ ast,ir
 	
 	std::vector<int>::iterator i5 = v5.begin();
 	*i5 = source();
@@ -389,7 +389,7 @@ void test_vector_output_iterator(int b) {
 	*i9 = source();
 	taint_vector_output_iterator(i9);
 
-	sink(v9); // $ ast=330:10 ir SPURIOUS: ast=389:8
+	sink(v9); // $ ast=330:10 ir=330:10 SPURIOUS: ast=389:8 ir=389:8
 
 	std::vector<int>::iterator i10 = v10.begin();
 	vector_iterator_assign_wrapper(i10, 10);
@@ -397,7 +397,7 @@ void test_vector_output_iterator(int b) {
 
 	std::vector<int>::iterator i11 = v11.begin();
 	vector_iterator_assign_wrapper(i11, source());
-	sink(v11); // $ ast MISSING: ir
+	sink(v11); // $ ast,ir
 
 	std::vector<int>::iterator i12 = v12.begin();
 	*i12++ = 0;
@@ -529,6 +529,6 @@ void test_vector_iterator() {
 		sink(*it);
 		it += source();
 		sink(*it); // $ ast,ir
-		sink(vs[1]);
+		sink(vs[1]); // $ SPURIOUS: ir
 	}
 }

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-078/SAMATE/ExecTainted/ExecTainted.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-078/SAMATE/ExecTainted/ExecTainted.expected
@@ -1,16 +1,42 @@
 edges
 | tests.cpp:26:15:26:23 | badSource indirection | tests.cpp:51:12:51:20 | call to badSource indirection |
+| tests.cpp:26:32:26:35 | data | tests.cpp:26:15:26:23 | badSource indirection |
+| tests.cpp:26:32:26:35 | data | tests.cpp:38:25:38:36 | strncat output argument |
+| tests.cpp:26:32:26:35 | data indirection | tests.cpp:26:15:26:23 | badSource indirection |
+| tests.cpp:26:32:26:35 | data indirection | tests.cpp:38:25:38:36 | strncat output argument |
 | tests.cpp:33:34:33:39 | call to getenv indirection | tests.cpp:38:39:38:49 | (const char *)... indirection |
 | tests.cpp:38:25:38:36 | strncat output argument | tests.cpp:26:15:26:23 | badSource indirection |
+| tests.cpp:38:25:38:36 | strncat output argument | tests.cpp:26:15:26:23 | badSource indirection |
+| tests.cpp:38:25:38:36 | strncat output argument | tests.cpp:26:15:26:23 | badSource indirection |
+| tests.cpp:38:25:38:36 | strncat output argument | tests.cpp:51:22:51:25 | badSource output argument |
 | tests.cpp:38:39:38:49 | (const char *)... indirection | tests.cpp:38:25:38:36 | strncat output argument |
 | tests.cpp:51:12:51:20 | call to badSource indirection | tests.cpp:53:16:53:19 | (const char *)... indirection |
+| tests.cpp:51:22:51:25 | badSource output argument | tests.cpp:51:22:51:25 | data |
+| tests.cpp:51:22:51:25 | badSource output argument | tests.cpp:51:22:51:25 | data indirection |
+| tests.cpp:51:22:51:25 | data | tests.cpp:26:32:26:35 | data |
+| tests.cpp:51:22:51:25 | data | tests.cpp:51:12:51:20 | call to badSource indirection |
+| tests.cpp:51:22:51:25 | data | tests.cpp:51:22:51:25 | badSource output argument |
+| tests.cpp:51:22:51:25 | data indirection | tests.cpp:26:32:26:35 | data indirection |
+| tests.cpp:51:22:51:25 | data indirection | tests.cpp:51:12:51:20 | call to badSource indirection |
 nodes
 | tests.cpp:26:15:26:23 | badSource indirection | semmle.label | badSource indirection |
+| tests.cpp:26:15:26:23 | badSource indirection | semmle.label | badSource indirection |
+| tests.cpp:26:15:26:23 | badSource indirection | semmle.label | badSource indirection |
+| tests.cpp:26:32:26:35 | data | semmle.label | data |
+| tests.cpp:26:32:26:35 | data indirection | semmle.label | data indirection |
 | tests.cpp:33:34:33:39 | call to getenv indirection | semmle.label | call to getenv indirection |
+| tests.cpp:38:25:38:36 | strncat output argument | semmle.label | strncat output argument |
+| tests.cpp:38:25:38:36 | strncat output argument | semmle.label | strncat output argument |
 | tests.cpp:38:25:38:36 | strncat output argument | semmle.label | strncat output argument |
 | tests.cpp:38:39:38:49 | (const char *)... indirection | semmle.label | (const char *)... indirection |
 | tests.cpp:51:12:51:20 | call to badSource indirection | semmle.label | call to badSource indirection |
+| tests.cpp:51:22:51:25 | badSource output argument | semmle.label | badSource output argument |
+| tests.cpp:51:22:51:25 | data | semmle.label | data |
+| tests.cpp:51:22:51:25 | data indirection | semmle.label | data indirection |
 | tests.cpp:53:16:53:19 | (const char *)... indirection | semmle.label | (const char *)... indirection |
 subpaths
+| tests.cpp:51:22:51:25 | data | tests.cpp:26:32:26:35 | data | tests.cpp:26:15:26:23 | badSource indirection | tests.cpp:51:12:51:20 | call to badSource indirection |
+| tests.cpp:51:22:51:25 | data | tests.cpp:26:32:26:35 | data | tests.cpp:38:25:38:36 | strncat output argument | tests.cpp:51:22:51:25 | badSource output argument |
+| tests.cpp:51:22:51:25 | data indirection | tests.cpp:26:32:26:35 | data indirection | tests.cpp:26:15:26:23 | badSource indirection | tests.cpp:51:12:51:20 | call to badSource indirection |
 #select
 | tests.cpp:53:16:53:19 | data | tests.cpp:33:34:33:39 | call to getenv indirection | tests.cpp:53:16:53:19 | (const char *)... indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to system(string). | tests.cpp:33:34:33:39 | call to getenv indirection | user input (an environment variable) | tests.cpp:38:25:38:36 | strncat output argument | strncat output argument |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-078/semmle/ExecTainted/ExecTainted.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-078/semmle/ExecTainted/ExecTainted.expected
@@ -46,6 +46,9 @@ edges
 | test.cpp:186:47:186:54 | filename indirection | test.cpp:188:20:188:24 | (const char *)... indirection |
 | test.cpp:187:11:187:15 | strncat output argument | test.cpp:188:11:188:17 | strncat output argument |
 | test.cpp:187:18:187:25 | (const char *)... indirection | test.cpp:187:11:187:15 | strncat output argument |
+| test.cpp:188:11:188:17 | strncat output argument | test.cpp:188:11:188:17 | strncat output argument |
+| test.cpp:188:11:188:17 | strncat output argument | test.cpp:188:11:188:17 | strncat output argument |
+| test.cpp:188:11:188:17 | strncat output argument | test.cpp:188:11:188:17 | strncat output argument |
 | test.cpp:188:20:188:24 | (const char *)... indirection | test.cpp:188:11:188:17 | strncat output argument |
 | test.cpp:188:20:188:24 | (const char *)... indirection | test.cpp:188:11:188:17 | strncat output argument |
 | test.cpp:194:9:194:16 | fread output argument | test.cpp:196:26:196:33 | array to pointer conversion indirection |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-119/semmle/tests/OverflowDestination.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-119/semmle/tests/OverflowDestination.expected
@@ -17,6 +17,7 @@ edges
 | overflowdestination.cpp:50:52:50:54 | src | overflowdestination.cpp:54:9:54:12 | memcpy output argument |
 | overflowdestination.cpp:50:52:50:54 | src indirection | overflowdestination.cpp:53:15:53:17 | src |
 | overflowdestination.cpp:53:9:53:12 | memcpy output argument | overflowdestination.cpp:54:9:54:12 | memcpy output argument |
+| overflowdestination.cpp:54:9:54:12 | memcpy output argument | overflowdestination.cpp:54:9:54:12 | memcpy output argument |
 | overflowdestination.cpp:57:52:57:54 | src | overflowdestination.cpp:64:16:64:19 | src2 |
 | overflowdestination.cpp:57:52:57:54 | src indirection | overflowdestination.cpp:64:16:64:19 | src2 |
 | overflowdestination.cpp:73:8:73:10 | fgets output argument | overflowdestination.cpp:75:30:75:32 | array to pointer conversion indirection |


### PR DESCRIPTION
Ideally, this PR would just be adding the one disjunct to `isIteratorUse` that I've added in 88338bdfcf92b3704908203cdb440f0d9c4399cc, but the `isIteratorUse` code was assuming that we had the `Operand` that represented the actual dereference when using the iterator (i.e., the operand representing `*it` for some iterator `it`). This is obviously not true if the iterator is passed to a function (which then writes to the iterator), so I had to shuffle things around in `isChiBeforeIteratorUse` and extend `indirectConversionFlowStep` to treat dereferences as conversions (when the indirection index is changed accordingly).

The change to `indirectConversionFlowStep` looks like this is giving us a bunch of new good results on Samate 🎉 (and AFAICT, it's also responsible for the small changes to path explanations).