### PR TITLE
C# 11: Nameof on attribute declarations.

### DIFF
--- a/csharp/ql/test/library-tests/csharp11/NameofScope.cs
+++ b/csharp/ql/test/library-tests/csharp11/NameofScope.cs
@@ -1,0 +1,20 @@
+using System;
+
+public class MyAttributeTestClass
+{
+    public class MyAttribute : Attribute
+    {
+        public readonly string S;
+        public MyAttribute(string s) => S = s;
+    }
+
+    [MyAttribute(nameof(T))]
+    public void M1<T>(string x) { }
+
+    [return: MyAttribute(nameof(y))]
+    public string M2(string y) => y;
+
+    public object M3([MyAttribute(nameof(z))] string z) => z;
+
+    public object M4<S>([MyAttribute(nameof(S))] string z) => z;
+}

--- a/csharp/ql/test/library-tests/csharp11/PrintAst.expected
+++ b/csharp/ql/test/library-tests/csharp11/PrintAst.expected
@@ -165,6 +165,70 @@ ListPattern.cs:
 #   33|         13: [BreakStmt] break;
 #   34|         14: [DefaultCase] default:
 #   35|         15: [BreakStmt] break;
+NameofScope.cs:
+#    3| [Class] MyAttributeTestClass
+#    5|   5: [Class] MyAttribute
+#-----|     3: (Base types)
+#    5|       0: [TypeMention] Attribute
+#    7|     4: [Field] S
+#    7|       -1: [TypeMention] string
+#    8|     5: [InstanceConstructor] MyAttribute
+#-----|       2: (Parameters)
+#    8|         0: [Parameter] s
+#    8|           -1: [TypeMention] string
+#    8|       4: [AssignExpr] ... = ...
+#    8|         0: [FieldAccess] access to field S
+#    8|         1: [ParameterAccess] access to parameter s
+#   12|   6: [Method] M1<>
+#   12|     -1: [TypeMention] Void
+#-----|     0: (Attributes)
+#   11|       1: [DefaultAttribute] [My(...)]
+#   11|         -1: [TypeMention] MyAttribute
+#   11|         0: [NameOfExpr] nameof(...)
+#   11|           0: [TypeAccess] access to type T
+#   11|             0: [TypeMention] T
+#-----|     1: (Type parameters)
+#   12|       0: [TypeParameter] T
+#-----|     2: (Parameters)
+#   12|       0: [Parameter] x
+#   12|         -1: [TypeMention] string
+#   12|     4: [BlockStmt] {...}
+#   15|   7: [Method] M2
+#   15|     -1: [TypeMention] string
+#-----|     0: (Attributes)
+#   14|       1: [ReturnAttribute] [return: My(...)]
+#   14|         -1: [TypeMention] MyAttribute
+#   14|         0: [NameOfExpr] nameof(...)
+#   14|           0: [ParameterAccess] access to parameter y
+#-----|     2: (Parameters)
+#   15|       0: [Parameter] y
+#   15|         -1: [TypeMention] string
+#   15|     4: [ParameterAccess] access to parameter y
+#   17|   8: [Method] M3
+#   17|     -1: [TypeMention] object
+#-----|     2: (Parameters)
+#   17|       0: [Parameter] z
+#   17|         -1: [TypeMention] string
+#-----|         0: (Attributes)
+#   17|           1: [DefaultAttribute] [My(...)]
+#   17|             -1: [TypeMention] MyAttribute
+#   17|             0: [NameOfExpr] nameof(...)
+#   17|               0: [ParameterAccess] access to parameter z
+#   17|     4: [ParameterAccess] access to parameter z
+#   19|   9: [Method] M4<>
+#   19|     -1: [TypeMention] object
+#-----|     1: (Type parameters)
+#   19|       0: [TypeParameter] S
+#-----|     2: (Parameters)
+#   19|       0: [Parameter] z
+#   19|         -1: [TypeMention] string
+#-----|         0: (Attributes)
+#   19|           1: [DefaultAttribute] [My(...)]
+#   19|             -1: [TypeMention] MyAttribute
+#   19|             0: [NameOfExpr] nameof(...)
+#   19|               0: [TypeAccess] access to type S
+#   19|                 0: [TypeMention] S
+#   19|     4: [ParameterAccess] access to parameter z
 NativeInt.cs:
 #    1| [Class] NativeInt
 #    3|   5: [Method] M1

--- a/csharp/ql/test/library-tests/csharp11/nameofScope.expected
+++ b/csharp/ql/test/library-tests/csharp11/nameofScope.expected
@@ -1,0 +1,4 @@
+| NameofScope.cs:11:18:11:26 | nameof(...) | [My(...)] | T |
+| NameofScope.cs:14:26:14:34 | nameof(...) | [return: My(...)] | y |
+| NameofScope.cs:17:35:17:43 | nameof(...) | [My(...)] | z |
+| NameofScope.cs:19:38:19:46 | nameof(...) | [My(...)] | S |

--- a/csharp/ql/test/library-tests/csharp11/nameofScope.ql
+++ b/csharp/ql/test/library-tests/csharp11/nameofScope.ql
@@ -1,0 +1,7 @@
+import csharp
+
+query predicate nameof(NameOfExpr e, string parent, string v) {
+  e.getFile().getStem() = "NameofScope" and
+  e.getParent().toString() = parent and
+  v = e.getValue()
+}


### PR DESCRIPTION
In this PR we test the extended scope `nameof`. That is, parameters and type parameters are in scope for `nameof` in attribute declarations.