### PR TITLE
Revert "Java/C#: add `isUninteresting` to `ExternalApi` characteristic predicate"

### DIFF
--- a/csharp/ql/src/Telemetry/ExternalApi.qll
+++ b/csharp/ql/src/Telemetry/ExternalApi.qll
@@ -24,12 +24,6 @@ class TestLibrary extends RefType {
   }
 }
 
-/** Holds if the given callable is not worth supporting. */
-private predicate isUninteresting(DotNet::Callable c) {
-  c.getDeclaringType() instanceof TestLibrary or
-  c.(Constructor).isParameterless()
-}
-
 /**
  * An external API from either the C# Standard Library or a 3rd party library.
  */
@@ -37,8 +31,7 @@ class ExternalApi extends DotNet::Callable {
   ExternalApi() {
     this.isUnboundDeclaration() and
     this.fromLibrary() and
-    this.(Modifiable).isEffectivelyPublic() and
-    not isUninteresting(this)
+    this.(Modifiable).isEffectivelyPublic()
   }
 
   /**
@@ -90,6 +83,17 @@ class ExternalApi extends DotNet::Callable {
     or
     defaultAdditionalTaintStep(this.getAnInput(), _)
   }
+
+  /** Holds if this API is a constructor without parameters. */
+  private predicate isParameterlessConstructor() {
+    this instanceof Constructor and this.getNumberOfParameters() = 0
+  }
+
+  /** Holds if this API is part of a common testing library or framework. */
+  private predicate isTestLibrary() { this.getDeclaringType() instanceof TestLibrary }
+
+  /** Holds if this API is not worth supporting. */
+  predicate isUninteresting() { this.isTestLibrary() or this.isParameterlessConstructor() }
 
   /** Holds if this API is a known source. */
   predicate isSource() {

--- a/csharp/ql/src/Telemetry/ExternalLibraryUsage.ql
+++ b/csharp/ql/src/Telemetry/ExternalLibraryUsage.ql
@@ -14,7 +14,8 @@ private predicate getRelevantUsages(string namespace, int usages) {
   usages =
     strictcount(Call c, ExternalApi api |
       c.getTarget().getUnboundDeclaration() = api and
-      api.getNamespace() = namespace
+      api.getNamespace() = namespace and
+      not api.isUninteresting()
     )
 }
 

--- a/csharp/ql/src/Telemetry/SupportedExternalApis.ql
+++ b/csharp/ql/src/Telemetry/SupportedExternalApis.ql
@@ -12,8 +12,11 @@ private import semmle.code.csharp.dataflow.internal.FlowSummaryImpl as FlowSumma
 private import ExternalApi
 
 private predicate relevant(ExternalApi api) {
-  api.isSupported() or
-  api instanceof FlowSummaryImpl::Public::NeutralCallable
+  not api.isUninteresting() and
+  (
+    api.isSupported() or
+    api instanceof FlowSummaryImpl::Public::NeutralCallable
+  )
 }
 
 from string info, int usages

--- a/csharp/ql/src/Telemetry/SupportedExternalSinks.ql
+++ b/csharp/ql/src/Telemetry/SupportedExternalSinks.ql
@@ -10,7 +10,10 @@ private import csharp
 private import semmle.code.csharp.dispatch.Dispatch
 private import ExternalApi
 
-private predicate relevant(ExternalApi api) { api.isSink() }
+private predicate relevant(ExternalApi api) {
+  not api.isUninteresting() and
+  api.isSink()
+}
 
 from string info, int usages
 where Results<relevant/1>::restrict(info, usages)

--- a/csharp/ql/src/Telemetry/SupportedExternalSources.ql
+++ b/csharp/ql/src/Telemetry/SupportedExternalSources.ql
@@ -10,7 +10,10 @@ private import csharp
 private import semmle.code.csharp.dispatch.Dispatch
 private import ExternalApi
 
-private predicate relevant(ExternalApi api) { api.isSource() }
+private predicate relevant(ExternalApi api) {
+  not api.isUninteresting() and
+  api.isSource()
+}
 
 from string info, int usages
 where Results<relevant/1>::restrict(info, usages)

--- a/csharp/ql/src/Telemetry/SupportedExternalTaint.ql
+++ b/csharp/ql/src/Telemetry/SupportedExternalTaint.ql
@@ -10,7 +10,10 @@ private import csharp
 private import semmle.code.csharp.dispatch.Dispatch
 private import ExternalApi
 
-private predicate relevant(ExternalApi api) { api.hasSummary() }
+private predicate relevant(ExternalApi api) {
+  not api.isUninteresting() and
+  api.hasSummary()
+}
 
 from string info, int usages
 where Results<relevant/1>::restrict(info, usages)

--- a/csharp/ql/src/Telemetry/UnsupportedExternalAPIs.ql
+++ b/csharp/ql/src/Telemetry/UnsupportedExternalAPIs.ql
@@ -12,6 +12,7 @@ private import semmle.code.csharp.dataflow.internal.FlowSummaryImpl as FlowSumma
 private import ExternalApi
 
 private predicate relevant(ExternalApi api) {
+  not api.isUninteresting() and
   not api.isSupported() and
   not api instanceof FlowSummaryImpl::Public::NeutralCallable
 }

--- a/csharp/ql/src/meta/frameworks/UnsupportedExternalAPIs.ql
+++ b/csharp/ql/src/meta/frameworks/UnsupportedExternalAPIs.ql
@@ -16,6 +16,7 @@ private import Telemetry.ExternalApi
 from Call c, ExternalApi api
 where
   c.getTarget().getUnboundDeclaration() = api and
+  not api.isUninteresting() and
   not api.isSupported() and
   not api instanceof FlowSummaryImpl::Public::NeutralCallable
 select c, "Call to unsupported external API $@.", api, api.toString()

--- a/java/ql/src/Telemetry/ExternalApi.qll
+++ b/java/ql/src/Telemetry/ExternalApi.qll
@@ -31,17 +31,11 @@ private string containerAsJar(Container container) {
   if container instanceof JarFile then result = container.getBaseName() else result = "rt.jar"
 }
 
-/** Holds if the given callable is not worth supporting. */
-private predicate isUninteresting(Callable c) {
-  c.getDeclaringType() instanceof TestLibrary or
-  c.(Constructor).isParameterless()
-}
-
 /**
  * An external API from either the Standard Library or a 3rd party library.
  */
 class ExternalApi extends Callable {
-  ExternalApi() { not this.fromSource() and not isUninteresting(this) }
+  ExternalApi() { not this.fromSource() }
 
   /**
    * Gets information about the external API in the form expected by the MaD modeling framework.
@@ -79,6 +73,18 @@ class ExternalApi extends Callable {
     TaintTracking::localAdditionalTaintStep(this.getAnInput(), _)
   }
 
+  /** Holds if this API is a constructor without parameters. */
+  private predicate isParameterlessConstructor() {
+    this instanceof Constructor and this.getNumberOfParameters() = 0
+  }
+
+  /** Holds if this API is part of a common testing library or framework. */
+  private predicate isTestLibrary() { this.getDeclaringType() instanceof TestLibrary }
+
+  /** Holds if this API is not worth supporting. */
+  predicate isUninteresting() { this.isTestLibrary() or this.isParameterlessConstructor() }
+
+  /** Holds if this API is a known source. */
   predicate isSource() {
     this.getAnOutput() instanceof RemoteFlowSource or sourceNode(this.getAnOutput(), _)
   }

--- a/java/ql/src/Telemetry/ExternalLibraryUsage.ql
+++ b/java/ql/src/Telemetry/ExternalLibraryUsage.ql
@@ -14,7 +14,8 @@ private predicate getRelevantUsages(string jarname, int usages) {
     strictcount(Call c, ExternalApi a |
       c.getCallee().getSourceDeclaration() = a and
       not c.getFile() instanceof GeneratedFile and
-      a.jarContainer() = jarname
+      a.jarContainer() = jarname and
+      not a.isUninteresting()
     )
 }
 

--- a/java/ql/src/Telemetry/SupportedExternalApis.ql
+++ b/java/ql/src/Telemetry/SupportedExternalApis.ql
@@ -11,8 +11,11 @@ import semmle.code.java.dataflow.internal.FlowSummaryImpl as FlowSummaryImpl
 import ExternalApi
 
 private predicate relevant(ExternalApi api) {
-  api.isSupported() or
-  api = any(FlowSummaryImpl::Public::NeutralCallable nsc).asCallable()
+  not api.isUninteresting() and
+  (
+    api.isSupported() or
+    api = any(FlowSummaryImpl::Public::NeutralCallable nsc).asCallable()
+  )
 }
 
 from string apiName, int usages

--- a/java/ql/src/Telemetry/SupportedExternalSinks.ql
+++ b/java/ql/src/Telemetry/SupportedExternalSinks.ql
@@ -9,7 +9,10 @@
 import java
 import ExternalApi
 
-private predicate relevant(ExternalApi api) { api.isSink() }
+private predicate relevant(ExternalApi api) {
+  not api.isUninteresting() and
+  api.isSink()
+}
 
 from string apiName, int usages
 where Results<relevant/1>::restrict(apiName, usages)

--- a/java/ql/src/Telemetry/SupportedExternalSources.ql
+++ b/java/ql/src/Telemetry/SupportedExternalSources.ql
@@ -9,7 +9,10 @@
 import java
 import ExternalApi
 
-private predicate relevant(ExternalApi api) { api.isSource() }
+private predicate relevant(ExternalApi api) {
+  not api.isUninteresting() and
+  api.isSource()
+}
 
 from string apiName, int usages
 where Results<relevant/1>::restrict(apiName, usages)

--- a/java/ql/src/Telemetry/SupportedExternalTaint.ql
+++ b/java/ql/src/Telemetry/SupportedExternalTaint.ql
@@ -9,7 +9,10 @@
 import java
 import ExternalApi
 
-private predicate relevant(ExternalApi api) { api.hasSummary() }
+private predicate relevant(ExternalApi api) {
+  not api.isUninteresting() and
+  api.hasSummary()
+}
 
 from string apiName, int usages
 where Results<relevant/1>::restrict(apiName, usages)

--- a/java/ql/src/Telemetry/UnsupportedExternalAPIs.ql
+++ b/java/ql/src/Telemetry/UnsupportedExternalAPIs.ql
@@ -11,6 +11,7 @@ import semmle.code.java.dataflow.internal.FlowSummaryImpl as FlowSummaryImpl
 import ExternalApi
 
 private predicate relevant(ExternalApi api) {
+  not api.isUninteresting() and
   not api.isSupported() and
   not api = any(FlowSummaryImpl::Public::NeutralCallable nsc).asCallable()
 }


### PR DESCRIPTION
Reverts github/codeql#11631

It turns out that a bad join order was introduced which affects `java/telemetry/supported-external-api-sinks`. Reverting the PR.
This is reproducible on the project `glopezGitHub/Android23`.
An example database can be downloaded here: https://github.com/codeql-testing/glopezGitHub--Android23/actions/runs/4050012179

Also DCA shows performance discrepancies (but not in the same order of magnitude) on a couple of the DCA projects.
Largest discrepancy is on: `FlansMods__FlansMod`.

We will do a proper fix instead: https://github.com/github/codeql/pull/12118