### PR TITLE
remove statement about namespaces from documentation that no longer holds

### DIFF
--- a/docs/codeql/ql-language-reference/name-resolution.rst
+++ b/docs/codeql/ql-language-reference/name-resolution.rst
@@ -266,9 +266,6 @@ Within it, the class ``OneTwoThree`` and the module ``P`` are **visible**, as we
 Example
 =======
 
-The namespaces of a general QL module are a union of the local namespaces, the namespaces of any enclosing modules, 
-and the global namespaces. (You can think of global namespaces as the enclosing namespaces of a top-level module.)
-
 Let's see what the module, type, and predicate namespaces look like in a concrete example:
 
 For example, you could define a library module ``Villagers`` containing some of the classes and predicates that 


### PR DESCRIPTION
This statement in the documentation is no longer true. As it is hard to update in a succinct way, and because it is not really required (this is in an example section after all), I have decided to simply remove it. The **namespaces** section above should provide all the necessary information.