### PR TITLE
C++: allow read steps at the sink in IR taint test

### DIFF
--- a/cpp/ql/test/library-tests/dataflow/taint-tests/arrayassignment.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/arrayassignment.cpp
@@ -53,7 +53,7 @@ void test_myint_member_assignment()
 
 	mi.i = source();
 
-	sink(mi); // $ MISSING: ast,ir
+	sink(mi); // $ ir MISSING: ast
 	sink(mi.get()); // $ ast,ir
 }
 
@@ -63,7 +63,7 @@ void test_myint_method_assignment()
 
 	mi.get() = source();
 
-	sink(mi); // $ MISSING: ast,ir
+	sink(mi); // $ ir MISSING: ast
 	sink(mi.get()); // $ ast,ir
 }
 

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/map.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/map.cpp
@@ -28,12 +28,12 @@ void test_pair()
 	b.first = source();
 	sink(b.first); // $ ast,ir
 	sink(b.second);
-	sink(b); // $ MISSING: ast,ir
+	sink(b); // $ ir MISSING: ast
 
 	c.second = source();
 	sink(c.first);
 	sink(c.second); // $ ast,ir
-	sink(c); // $ MISSING: ast,ir
+	sink(c); // $ ir MISSING: ast
 
 	std::pair<char *, char *> d("123", "456");
 	sink(d.first);
@@ -43,7 +43,7 @@ void test_pair()
 	std::pair<char *, char *> e(source(), "456");
 	sink(e.first); // $ ast,ir
 	sink(e.second);
-	sink(e); // $ MISSING: ast,ir
+	sink(e); // $ ir MISSING: ast
 
 	std::pair<char *, char *> f("123", source());
 	sink(f.first);

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.cpp
@@ -448,9 +448,9 @@ void test_qualifiers()
 	sink(b);
 	sink(b.getMember());
 	b.member = source();
-	sink(b); // $ MISSING: ast,ir
+	sink(b); // $ ir MISSING: ast
 	sink(b.member); // $ ast,ir
-	sink(b.getMember()); // $ MISSING: ast,ir
+	sink(b.getMember()); // $ ir MISSING: ast
 
 	c = new MyClass2(0);
 
@@ -690,7 +690,7 @@ void test_argument_source_field_to_obj() {
 	two_members s;
 	argument_source(s.x);
 
-	sink(s); // $ SPURIOUS: ast
+	sink(s); // $ SPURIOUS: ast,ir
 	sink(s.x); // $ ast,ir
 	sink(s.y); // clean
 }

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.ql
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.ql
@@ -106,7 +106,7 @@ module IRTest {
     override predicate allowImplicitRead(DataFlow::Node node, DataFlow::ContentSet c) {
       // allow arbitrary reads at sinks
       isSink(node) and
-      c = any(DataFlow::ContentSet c_)
+      c.(DataFlow::FieldContent).getField().getDeclaringType() = node.getType().getUnspecifiedType()
     }
   }
 }

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.ql
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.ql
@@ -102,5 +102,11 @@ module IRTest {
     override predicate isSanitizer(DataFlow::Node barrier) {
       barrier.asExpr().(VariableAccess).getTarget().hasName("sanitizer")
     }
+
+    override predicate allowImplicitRead(DataFlow::Node node, DataFlow::ContentSet c) {
+      // allow arbitrary reads at sinks
+      isSink(node) and
+      c = any(DataFlow::ContentSet c_)
+    }
   }
 }


### PR DESCRIPTION
This resolves a few missing taint sinks, but I'm not sure if they were testing special handling for single-field structs before. @MathiasVP IIRC you did something special for single-field structs when adding field flow into the def-use IR dataflow, should we reimplement that instead of adding this case?