### PR TITLE
C#: Change handled exception in `TrapWriter.ArchiveContents`

### DIFF
--- a/csharp/extractor/Semmle.Extraction/TrapWriter.cs
+++ b/csharp/extractor/Semmle.Extraction/TrapWriter.cs
@@ -223,7 +223,7 @@ namespace Semmle.Extraction
             {
                 FileUtils.MoveOrReplace(tmpSrcFile, dest);
             }
-            catch (IOException ex)
+            catch (Exception ex)
             {
                 // If this happened, it was probably because the same file was compiled multiple times.
                 // In any case, this is not a fatal error.


### PR DESCRIPTION
This PR makes source archive creation more resilient to exceptions thrown by file operations. 

Fixes https://github.com/github/codeql/issues/12066.