### PR TITLE
Swift: QLDoc models files consistently.

### DIFF
--- a/swift/ql/lib/codeql/swift/frameworks/AEXML.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/AEXML.qll
@@ -1,3 +1,7 @@
+/**
+ * Provides models for the AEXML library.
+ */
+
 import swift
 
 /** The creation of an `AEXMLParser`. */

--- a/swift/ql/lib/codeql/swift/frameworks/Alamofire/Alamofire.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/Alamofire/Alamofire.qll
@@ -1,5 +1,5 @@
 /**
- * Models for the Alamofire networking library.
+ * Provides models for the Alamofire networking library.
  */
 
 import swift

--- a/swift/ql/lib/codeql/swift/frameworks/Libxml2.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/Libxml2.qll
@@ -1,3 +1,7 @@
+/**
+ * Provides models for the libxml2 library.
+ */
+
 import swift
 
 /**

--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/CustomUrlSchemes.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/CustomUrlSchemes.qll
@@ -1,3 +1,7 @@
+/**
+ * Provides models related to custom URL schemes.
+ */
+
 import swift
 private import codeql.swift.dataflow.DataFlow
 private import codeql.swift.dataflow.ExternalFlow

--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/Data.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/Data.qll
@@ -1,3 +1,7 @@
+/**
+ * Provides models for the `Data` Swift class.
+ */
+
 import swift
 private import codeql.swift.dataflow.ExternalFlow
 

--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/FilePath.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/FilePath.qll
@@ -1,3 +1,7 @@
+/**
+ * Provides models for the `FilePath` Swift class.
+ */
+
 import swift
 private import codeql.swift.dataflow.ExternalFlow
 

--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/InputStream.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/InputStream.qll
@@ -1,3 +1,7 @@
+/**
+ * Provides models for the `InputStream` Swift class.
+ */
+
 import swift
 private import codeql.swift.dataflow.ExternalFlow
 

--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/NsData.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/NsData.qll
@@ -1,4 +1,6 @@
-/** Provides classes and models to work with `NSData`-related objects. */
+/**
+ * Provides models for `NSData` and related Swift classes.
+ */
 
 import swift
 private import codeql.swift.dataflow.DataFlow

--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/NsUrl.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/NsUrl.qll
@@ -1,3 +1,7 @@
+/**
+ * Provides models for the `NSURL` Swift class.
+ */
+
 import swift
 private import codeql.swift.dataflow.ExternalFlow
 

--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/String.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/String.qll
@@ -1,3 +1,7 @@
+/**
+ * Provides models for `String` and related Swift classes.
+ */
+
 import swift
 private import codeql.swift.dataflow.DataFlow
 private import codeql.swift.dataflow.ExternalFlow

--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/Url.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/Url.qll
@@ -1,3 +1,7 @@
+/**
+ * Provides models for the `URL` Swift class.
+ */
+
 import swift
 private import codeql.swift.dataflow.DataFlow
 private import codeql.swift.dataflow.ExternalFlow

--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/UrlSession.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/UrlSession.qll
@@ -1,3 +1,7 @@
+/**
+ * Provides models for the `URLSession` Swift class.
+ */
+
 private import codeql.swift.dataflow.ExternalFlow
 
 private class UrlSessionSummaries extends SummaryModelCsv {

--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/WebView.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/WebView.qll
@@ -1,3 +1,7 @@
+/**
+ * Provides models for WebView-related Swift classes.
+ */
+
 import swift
 private import codeql.swift.dataflow.DataFlow
 private import codeql.swift.dataflow.ExternalFlow


### PR DESCRIPTION
While working on models I noticed that many of the files were missing a documenting comment at the top.