### PR TITLE
Kotlin: 1.8.10 and 1.8.20 are supported, and use 1.8.10 for CI

### DIFF
--- a/docs/codeql/reusables/supported-versions-compilers.rst
+++ b/docs/codeql/reusables/supported-versions-compilers.rst
@@ -20,7 +20,7 @@
    Java,"Java 7 to 19 [4]_","javac (OpenJDK and Oracle JDK),
 
    Eclipse compiler for Java (ECJ) [5]_",``.java``
-   Kotlin [6]_,"Kotlin 1.5.0 to 1.8.0","kotlinc",``.kt``
+   Kotlin [6]_,"Kotlin 1.5.0 to 1.8.20","kotlinc",``.kt``
    JavaScript,ECMAScript 2022 or lower,Not applicable,"``.js``, ``.jsx``, ``.mjs``, ``.es``, ``.es6``, ``.htm``, ``.html``, ``.xhtm``, ``.xhtml``, ``.vue``, ``.hbs``, ``.ejs``, ``.njk``, ``.json``, ``.yaml``, ``.yml``, ``.raml``, ``.xml`` [7]_"
    Python [8]_,"2.7, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10, 3.11",Not applicable,``.py``
    Ruby [9]_,"up to 3.1",Not applicable,"``.rb``, ``.erb``, ``.gemspec``, ``Gemfile``"

--- a/java/kotlin-extractor/kotlin_plugin_versions.py
+++ b/java/kotlin-extractor/kotlin_plugin_versions.py
@@ -21,8 +21,8 @@ def version_string_to_tuple(version):
     m = re.match(r'([0-9]+)\.([0-9]+)\.([0-9]+)(.*)', version)
     return tuple([int(m.group(i)) for i in range(1, 4)] + [m.group(4)])
 
-# Version number used by CI. It needs to be one of the versions in many_versions.
-ci_version = '1.8.0'
+# Version number used by CI.
+ci_version = '1.8.10'
 
 # Version numbers in the list need to be in semantically increasing order
 many_versions = [ '1.4.32', '1.5.0', '1.5.10', '1.5.20', '1.5.30', '1.6.0', '1.6.20', '1.7.0', '1.7.20', '1.8.0' ]
@@ -57,8 +57,6 @@ def get_single_version(fakeVersionOutput = None):
     raise Exception(f'No suitable kotlinc version found for {current_version} (got {versionOutput}; know about {str(many_versions)})')
 
 def get_latest_url():
-    if ci_version not in many_versions:
-        raise Exception('CI version must be one of many_versions')
     url = 'https://github.com/JetBrains/kotlin/releases/download/v' + ci_version + '/kotlin-compiler-' + ci_version + '.zip'
     return url
 

--- a/java/ql/lib/change-notes/2023-02-08-kotlin-1.8.20.md
+++ b/java/ql/lib/change-notes/2023-02-08-kotlin-1.8.20.md
@@ -1,0 +1,4 @@
+---
+category: feature
+---
+* Kotlin versions up to 1.8.20 are now supported.


### PR DESCRIPTION
I don't think there's any need for the CI version to be one of the versions we build extractors for, so I've removed that check.