### PR TITLE
Script to generate shared code metrics

### DIFF
--- a/misc/scripts/shared-code-metrics.py
+++ b/misc/scripts/shared-code-metrics.py
@@ -1,0 +1,329 @@
+# Generates a report on the amount of code sharing in this repo
+#
+# The purpose of this is 
+# a) To be able to understand the structure and dependencies
+# b) To provide a metric that measures the amount of shared vs non-shared code
+
+import datetime
+from pathlib import Path
+import json
+import yaml
+
+# To add more languages, add them to this list:
+languages = ['cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ql', 'ruby', 'swift']
+
+repo_location = Path(__file__).parent.parent.parent
+
+# Gets the total number of lines in a file
+def linecount(file):
+    with open(file, 'r') as fp: return len(fp.readlines())
+
+# Gets the language name from the path
+def get_language(path):
+    return path.parts[len(repo_location.parts)]
+
+# Is this path a CodeQL query file
+def is_query(path):
+    return path.suffix == '.ql'
+
+# Is this path a CodeQL library file
+def is_library(path):
+    return path.suffix == '.qll'
+
+# Is this path a relevant CodeQL file
+def is_ql(path):
+    return is_query(path) or is_library(path)
+
+# Is this file a CodeQL package file
+def is_package(path):
+    return path.name == 'qlpack.yml'
+
+# A CodeQL source file
+class QlFile:
+    def __init__(self, path):
+        self.path = path
+        self.lines = linecount(path)
+    shared = False
+
+    def language(self):
+        return get_language(self.path)
+
+    def query(self):
+        return is_query(self.path)
+
+    def library(self):
+        return is_library(self.path)
+
+    # Returns if this qlfile is not shared, and is in a pack that is only in one language
+    def isOnlyInLanguage(self, language):
+        return not self.shared and (self.package is None or self.package.languages == {language}) and self.language() == language
+
+# Represents a language folder
+class Language:
+    def __init__(self, name):
+        self.name = name
+        self.packs = []
+        self.nonshared_files = 0
+        self.nonshared_lines = 0
+        self.imported_files = 0
+        self.imported_lines = 0
+
+    def addQlFile(self, qlfile):
+        if not qlfile.shared:
+            self.nonshared_files += 1
+            self.nonshared_lines += qlfile.lines
+
+    def addSharedAsset(self, package):
+        self.imported_files += package.files
+        self.imported_lines += package.lines
+
+# A shared package or file
+class SharedAsset:
+    def __init__(self, name):
+        self.name = name
+
+# A file shared using identical-files.json
+class IdenticalFileSet(SharedAsset):
+    def __init__(self, name, ql_files):
+        self.name = name
+        self.languages = set()
+        self.files = 0
+        self.lines = 0
+        for file in ql_files:
+            file.package = self
+            file.shared = True
+            self.files = 1
+            self.lines = file.lines
+            self.languages.add(file.language())
+
+    # Gets a pretty-printed markdown link
+    def link(self):
+        return self.name
+
+# Represents all files shared in `identical-files.json`
+# Reads the file and builds a list of assets
+class IdenticalFiles:
+    def __init__(self, repo_location, ql_file_index):
+        identical_files = repo_location/'config'/'identical-files.json'
+        with open(identical_files, "r") as fp:
+            identical_files_json = json.load(fp)
+        # Create a list of assets
+        self.assets = []
+        for group in identical_files_json:
+            paths = []
+            for file in identical_files_json[group]:
+                path = repo_location / file
+                if is_ql(path):
+                    ql_file_index[path].shared = True
+                    paths.append(ql_file_index[path])
+            self.assets.append(IdenticalFileSet(group, paths))
+
+# A package created from a `qlpack.yml`` file
+class Package(SharedAsset):
+    def __init__(self, path, ql_file_index):
+        self.path = path
+        self.language = get_language(path)
+        self.lines = 0
+        self.files = 0
+        self.languages = set()
+        self.languages.add(self.language)
+        self.identical_files_dependencies = set()
+        with open(path, 'r') as fp:
+            y = yaml.safe_load(fp)
+            if 'name' in y:
+                self.name = y['name']
+            else:
+                self.name = path.parent.name
+            if 'dependencies' in y:
+                self.deps = y['dependencies']
+                if self.deps is None:
+                    self.deps = {}
+            else:
+                self.deps = {}
+        # Mark all relevant files with their package
+        for file in ql_file_index:
+            if self.containsDirectory(file):
+                file = ql_file_index[file]
+                if not file.shared:
+                    file.package = self
+                    self.lines += file.lines
+                    self.files += 1
+                else:
+                    self.identical_files_dependencies.add(file.package)
+        self.url = "https://github.com/github/codeql/blob/main/" + str(path.relative_to(repo_location))
+
+    # Gets a pretty-printed markdown link
+    def link(self):
+        return '[' + self.name + '](' + self.url + ')'
+
+    def containsDirectory(self, dir):
+        return self.path.parent.parts == dir.parts[:len(self.path.parent.parts)]
+        # dir.startsWith(self.path.parent)
+
+    # Constructs a list of transitive depedencies of this package.
+    def calculateDependencies(self, packageNameMap):
+        self.transitive_dependencies = set(self.deps)
+        queue = list(self.deps)
+        while len(queue):
+            item = queue.pop()
+            for dep2 in packageNameMap[item].deps:
+                if dep2 not in self.transitive_dependencies:
+                    self.transitive_dependencies.add(dep2)
+                    queue.append(dep2)
+        # Calculate the amount of imported code
+        self.total_imported_files = 0
+        self.total_imported_lines = 0
+        self.all_dependencies = set(self.identical_files_dependencies)
+        for dep in self.transitive_dependencies:
+            self.all_dependencies.add(packageNameMap[dep])
+        for dep in self.all_dependencies:
+            self.total_imported_files += dep.files
+            self.total_imported_lines += dep.lines
+            dep.languages.add(self.language)
+
+# Create a big index of all files and their line counts.
+
+# Map from path to line count
+ql_file_index = {}
+package_files = []
+
+# Queue of directories to read
+directories_to_scan = [repo_location]
+
+while len(directories_to_scan)!=0:
+    dir = directories_to_scan.pop()
+    for p in dir.iterdir():
+        if p.is_dir():
+            directories_to_scan.append(p)
+        elif is_ql(p):
+            ql_file_index[p] = QlFile(p)
+        elif is_package(p):
+            package_files.append(p)
+
+# Create identical_files_json
+identical_files = IdenticalFiles(repo_location, ql_file_index)
+
+# Create packages
+# Do this after identical_files so that we can figure out the package sizes
+# Do this after getting the ql_file_index fully built
+packages = []
+for file in package_files:
+    packages.append(Package(file, ql_file_index))
+
+# List all shared assets
+shared_assets = packages + identical_files.assets
+
+# Construct statistics for each language
+language_info = {}
+for l in languages:
+    language_info[l] = Language(l)
+
+for qlfile in ql_file_index.values():
+    lang = qlfile.language()
+    if lang in language_info:
+        info = language_info[lang]
+        if qlfile.isOnlyInLanguage(lang):
+            info.addQlFile(qlfile)            
+
+# Determine all package dependencies
+
+packageNameMap = {}
+
+for package in packages:
+    packageNameMap[package.name] = package
+
+for package in packages:
+    package.calculateDependencies(packageNameMap)
+
+for asset in shared_assets:
+    if len(asset.languages)>1:
+        for lang in asset.languages:
+            if lang in language_info:
+                language_info[lang].addSharedAsset(asset)
+
+
+# Functions to output the results
+
+def list_assets(shared_assets, language_info):
+    print('| Asset | Files | Lines |', end='')
+    for lang in language_info:
+        print('', lang, '|', end='')
+    print()
+    print('| ----- | ----- | ----- |', end='')
+    for lang in language_info:
+        print(' ---- |', end='')
+    print()
+    for asset in shared_assets:
+        print('|', asset.link(), '|', asset.files ,'|', asset.lines, '|', end=' ')
+        for lang in language_info:
+            if lang in asset.languages:
+                print('yes |', end=' ')
+            else:
+                print('    |', end=' ');
+        print()
+    print()
+
+def list_package_dependencies(package):
+    print("Package", package.path, package.name, package.files, package.lines, package.total_imported_files, package.total_imported_lines)
+    for dep in package.all_dependencies:
+        print("  ", dep.name, dep.files, dep.lines)
+
+def print_package_dependencies(packages):
+    print('| Package name | Non-shared files | Non-shared lines of code | Imported files | Imported lines of code | Shared code % |')
+    print('| ------------ | ---------------- | ------------------------ | -------------- | ---------------------- | ------------- |')
+    for package in packages:
+        nlines = package.lines + package.total_imported_lines
+        shared_percentage = 100 * package.total_imported_lines / nlines if nlines>0 else 0
+        print('|', package.link(), '|', package.files, '|', package.lines, '|', package.total_imported_files, '|', package.total_imported_lines, '|',
+            # ','.join([p.name for p in package.all_dependencies]), 
+            "%.2f" % shared_percentage, '|')
+    print()
+
+def print_language_dependencies(packages):
+    print_package_dependencies([p for p in packages if p.name.endswith('-all') and p.name.count('-')==1]) 
+
+def list_shared_code_by_language(language_info):
+    # For each language directory, list the files that are (1) inside the directory and not shared, 
+    # (2) packages from outside the directory, plus identical files
+    print('| Language | Non-shared files | Non-shared lines of code | Imported files | Imported lines of code | Shared code % |')
+    print('| -------- | ---------------- | ------------------------ | -------------- | ---------------------- | ------------- |')
+    for lang in language_info:
+        info = language_info[lang]
+        total = info.imported_lines + info.nonshared_lines
+        shared_percentage = 100 * info.imported_lines / total if total>0 else 0
+        print('|', lang, '|', info.nonshared_files, '|', info.nonshared_lines, '|', info.imported_files, '|', info.imported_lines, '|', "%.2f" % shared_percentage, '|')
+    print()
+
+
+# Output reports
+
+print('# Report on CodeQL code sharing\n')
+print('Generated on', datetime.datetime.now())
+print()
+
+print('## Shared code by language\n')
+
+list_shared_code_by_language(language_info)
+
+print('''
+* *Non-shared files*: The number of CodeQL files  (`.ql`/`.qll`) that are only used within this language folder. Excludes `identical-files.json` that are shared between multiple languages.
+* *Non-shared lines of code*: The number of lines of code in the non-shared files.
+* *Imported files*: All CodeQL files (`.ql`/`.qll`) files that are transitively used in this language folder, either via packages or `identical-files.json`
+* *Imported lines of code*: The number of lines of code in the imported files
+* *Shared code %*: The proportion of imported lines / total lines (nonshared + imported).
+
+## Shared packages use by language
+
+A package is *used* if it is a direct or indirect dependency, or a file shared via `identical-files.json`.
+
+''')
+
+list_assets(shared_assets, language_info)
+
+print('## Shared code by language pack\n')
+
+print_language_dependencies(packages)
+
+print('## Shared code by package\n')
+
+print_package_dependencies(packages)

--- a/misc/scripts/shared-code-metrics.py
+++ b/misc/scripts/shared-code-metrics.py
@@ -1,3 +1,4 @@
+#!/bin/env python3
 # Generates a report on the amount of code sharing in this repo
 #
 # The purpose of this is 


### PR DESCRIPTION
This script measures the amount of code sharing in the CodeQL repo, and displays the package dependencies.

Sample output:

# Report on CodeQL code sharing

Generated on 2023-02-03 16:25:12.551688

## Shared code by language

| Language | Non-shared files | Non-shared lines of code | Imported files | Imported lines of code | Shared code % |
| -------- | ---------------- | ------------------------ | -------------- | ---------------------- | ------------- |
| cpp | 1761 | 121839 | 46 | 19776 | 13.96 |
| csharp | 1465 | 91281 | 55 | 23697 | 20.61 |
| go | 503 | 42928 | 12 | 9904 | 18.75 |
| java | 1615 | 97371 | 32 | 16641 | 14.60 |
| javascript | 1619 | 119286 | 33 | 16801 | 12.35 |
| python | 1398 | 86161 | 32 | 16230 | 15.85 |
| ql | 159 | 14211 | 8 | 9734 | 40.65 |
| ruby | 535 | 55640 | 37 | 18421 | 24.87 |
| swift | 1074 | 33454 | 15 | 12378 | 27.01 |


* *Non-shared files*: The number of CodeQL files  (`.ql`/`.qll`) that are only used within this language folder. Excludes `identical-files.json` that are shared between multiple languages.
* *Non-shared lines of code*: The number of lines of code in the non-shared files.
* *Imported files*: All CodeQL files (`.ql`/`.qll`) files that are transitively used in this language folder, either via packages or `identical-files.json`
* *Imported lines of code*: The number of lines of code in the imported files
* *Shared code %*: The proportion of imported lines / total lines (nonshared + imported).

## Shared packages use by language

A package is *used* if it is a direct or indirect dependency, or a file shared via `identical-files.json`.


| Asset | Files | Lines | cpp | csharp | go | java | javascript | python | ql | ruby | swift |
| ----- | ----- | ----- | ---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- |
| [codeql/ruby-queries](https://github.com/github/codeql/blob/main/ruby/ql/src/qlpack.yml) | 69 | 2287 |     |     |     |     |     |     |     | yes |     | 
| [codeql/ruby-consistency-queries](https://github.com/github/codeql/blob/main/ruby/ql/consistency-queries/qlpack.yml) | 6 | 124 |     |     |     |     |     |     |     | yes |     | 
| [codeql/ruby-all](https://github.com/github/codeql/blob/main/ruby/ql/lib/qlpack.yml) | 232 | 48765 |     |     |     |     |     |     |     | yes |     | 
| [codeql/ruby-examples](https://github.com/github/codeql/blob/main/ruby/ql/examples/qlpack.yml) | 1 | 18 |     |     |     |     |     |     |     | yes |     | 
| [codeql/ruby-tests](https://github.com/github/codeql/blob/main/ruby/ql/test/qlpack.yml) | 106 | 3072 |     |     |     |     |     |     |     | yes |     | 
| [codeql/ruby-downgrades](https://github.com/github/codeql/blob/main/ruby/downgrades/qlpack.yml) | 121 | 1374 |     |     |     |     |     |     |     | yes |     | 
| [codeql/ql](https://github.com/github/codeql/blob/main/ql/ql/src/qlpack.yml) | 108 | 12790 |     |     |     |     |     |     | yes |     |     | 
| [codeql/ql-consistency-queries](https://github.com/github/codeql/blob/main/ql/ql/consistency-queries/qlpack.yml) | 6 | 6 |     |     |     |     |     |     | yes |     |     | 
| [codeql/ql-examples](https://github.com/github/codeql/blob/main/ql/ql/examples/qlpack.yml) | 0 | 0 |     |     |     |     |     |     | yes |     |     | 
| [codeql/ql-tests](https://github.com/github/codeql/blob/main/ql/ql/test/qlpack.yml) | 45 | 1415 |     |     |     |     |     |     | yes |     |     | 
| [ql-testing-src-pack](https://github.com/github/codeql/blob/main/ql/ql/test/callgraph/packs/src/qlpack.yml) | 1 | 8 |     |     |     |     |     |     | yes |     |     | 
| [ql-testing-lib-pack](https://github.com/github/codeql/blob/main/ql/ql/test/callgraph/packs/lib/qlpack.yml) | 1 | 1 |     |     |     |     |     |     | yes |     |     | 
| [ql-other-pack-thing](https://github.com/github/codeql/blob/main/ql/ql/test/callgraph/packs/other/qlpack.yml) | 1 | 7 |     |     |     |     |     |     | yes |     |     | 
| [codeql/javascript-queries](https://github.com/github/codeql/blob/main/javascript/ql/src/qlpack.yml) | 360 | 16712 |     |     |     |     | yes |     |     |     |     | 
| [codeql/javascript-all](https://github.com/github/codeql/blob/main/javascript/ql/lib/qlpack.yml) | 386 | 89332 |     |     |     |     | yes |     |     |     |     | 
| [codeql/javascript-examples](https://github.com/github/codeql/blob/main/javascript/ql/examples/qlpack.yml) | 39 | 804 |     |     |     |     | yes |     |     |     |     | 
| [codeql/javascript-tests](https://github.com/github/codeql/blob/main/javascript/ql/test/qlpack.yml) | 778 | 8293 |     |     |     |     | yes |     |     |     |     | 
| [codeql/javascript-experimental-atm-queries](https://github.com/github/codeql/blob/main/javascript/ql/experimental/adaptivethreatmodeling/src/qlpack.yml) | 6 | 155 |     |     |     |     | yes |     |     |     |     | 
| [codeql/javascript-experimental-atm-lib](https://github.com/github/codeql/blob/main/javascript/ql/experimental/adaptivethreatmodeling/lib/qlpack.yml) | 15 | 2868 |     |     |     |     | yes |     |     |     |     | 
| [codeql/javascript-experimental-atm-model](https://github.com/github/codeql/blob/main/javascript/ql/experimental/adaptivethreatmodeling/model/qlpack.yml) | 0 | 0 |     |     |     |     | yes |     |     |     |     | 
| [codeql/javascript-experimental-atm-model-building](https://github.com/github/codeql/blob/main/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/qlpack.yml) | 22 | 827 |     |     |     |     | yes |     |     |     |     | 
| [codeql/javascript-experimental-atm-tests](https://github.com/github/codeql/blob/main/javascript/ql/experimental/adaptivethreatmodeling/test/qlpack.yml) | 12 | 284 |     |     |     |     | yes |     |     |     |     | 
| [codeql/javascript-downgrades](https://github.com/github/codeql/blob/main/javascript/downgrades/qlpack.yml) | 1 | 11 |     |     |     |     | yes |     |     |     |     | 
| [codeql/csharp-queries](https://github.com/github/codeql/blob/main/csharp/ql/src/qlpack.yml) | 405 | 25086 |     | yes |     |     |     |     |     |     |     | 
| [codeql/csharp-solorigate-queries](https://github.com/github/codeql/blob/main/csharp/ql/campaigns/Solorigate/src/qlpack.yml) | 6 | 197 |     | yes |     |     |     |     |     |     |     | 
| [codeql/csharp-solorigate-all](https://github.com/github/codeql/blob/main/csharp/ql/campaigns/Solorigate/lib/qlpack.yml) | 1 | 210 |     | yes |     |     |     |     |     |     |     | 
| [csharp-solorigate-tests](https://github.com/github/codeql/blob/main/csharp/ql/campaigns/Solorigate/test/qlpack.yml) | 0 | 0 |     | yes |     |     |     |     |     |     |     | 
| [codeql-csharp-consistency-queries](https://github.com/github/codeql/blob/main/csharp/ql/consistency-queries/qlpack.yml) | 6 | 197 |     | yes |     |     |     |     |     |     |     | 
| [codeql/csharp-all](https://github.com/github/codeql/blob/main/csharp/ql/lib/qlpack.yml) | 264 | 55499 |     | yes |     |     |     |     |     |     |     | 
| [codeql/csharp-examples](https://github.com/github/codeql/blob/main/csharp/ql/examples/qlpack.yml) | 28 | 426 |     | yes |     |     |     |     |     |     |     | 
| [integration-tests](https://github.com/github/codeql/blob/main/csharp/ql/integration-tests/qlpack.yml) | 0 | 0 |     | yes |     |     |     |     |     |     |     | 
| [codeql-csharp-tests](https://github.com/github/codeql/blob/main/csharp/ql/test/qlpack.yml) | 752 | 9627 |     | yes |     |     |     |     |     |     |     | 
| [codeql/csharp-downgrades](https://github.com/github/codeql/blob/main/csharp/downgrades/qlpack.yml) | 3 | 39 |     | yes |     |     |     |     |     |     |     | 
| [codeql/swift-queries](https://github.com/github/codeql/blob/main/swift/ql/src/qlpack.yml) | 27 | 1831 |     |     |     |     |     |     |     |     | yes | 
| [codeql/swift-all](https://github.com/github/codeql/blob/main/swift/ql/lib/qlpack.yml) | 857 | 29549 |     |     |     |     |     |     |     |     | yes | 
| [codeql-swift-tests](https://github.com/github/codeql/blob/main/swift/ql/test/qlpack.yml) | 167 | 1953 |     |     |     |     |     |     |     |     | yes | 
| [codeql/swift-downgrades](https://github.com/github/codeql/blob/main/swift/downgrades/qlpack.yml) | 3 | 26 |     |     |     |     |     |     |     |     | yes | 
| [integration-tests-swift](https://github.com/github/codeql/blob/main/swift/integration-tests/qlpack.yml) | 20 | 95 |     |     |     |     |     |     |     |     | yes | 
| [codeql/cpp-queries](https://github.com/github/codeql/blob/main/cpp/ql/src/qlpack.yml) | 624 | 33181 | yes |     |     |     |     |     |     |     |     | 
| [codeql/cpp-all](https://github.com/github/codeql/blob/main/cpp/ql/lib/qlpack.yml) | 364 | 78318 | yes |     |     |     |     |     |     |     |     | 
| [codeql/cpp-examples](https://github.com/github/codeql/blob/main/cpp/ql/examples/qlpack.yml) | 26 | 419 | yes |     |     |     |     |     |     |     |     | 
| [codeql/cpp-tests](https://github.com/github/codeql/blob/main/cpp/ql/test/qlpack.yml) | 740 | 9803 | yes |     |     |     |     |     |     |     |     | 
| [codeql/cpp-tests-cwe-190-tainted](https://github.com/github/codeql/blob/main/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/tainted/qlpack.yml) | 0 | 0 | yes |     |     |     |     |     |     |     |     | 
| [codeql/cpp-downgrades](https://github.com/github/codeql/blob/main/cpp/downgrades/qlpack.yml) | 7 | 118 | yes |     |     |     |     |     |     |     |     | 
| [codeql/typetracking](https://github.com/github/codeql/blob/main/shared/typetracking/qlpack.yml) | 1 | 860 |     |     |     | yes |     |     |     |     |     | 
| [codeql/ssa](https://github.com/github/codeql/blob/main/shared/ssa/qlpack.yml) | 1 | 1169 | yes | yes |     |     |     |     |     | yes | yes | 
| [codeql/regex](https://github.com/github/codeql/blob/main/shared/regex/qlpack.yml) | 9 | 3831 |     |     |     | yes | yes | yes |     | yes |     | 
| [codeql/util](https://github.com/github/codeql/blob/main/shared/util/qlpack.yml) | 6 | 695 | yes | yes | yes | yes | yes | yes | yes | yes | yes | 
| [codeql/typos](https://github.com/github/codeql/blob/main/shared/typos/qlpack.yml) | 1 | 9035 |     |     |     |     | yes |     | yes |     |     | 
| [codeql/tutorial](https://github.com/github/codeql/blob/main/shared/tutorial/qlpack.yml) | 1 | 1094 | yes | yes | yes | yes | yes | yes |     | yes | yes | 
| [codeql/java-queries](https://github.com/github/codeql/blob/main/java/ql/src/qlpack.yml) | 589 | 30268 |     |     |     | yes |     |     |     |     |     | 
| [codeql-java-consistency-queries](https://github.com/github/codeql/blob/main/java/ql/consistency-queries/qlpack.yml) | 20 | 529 |     |     |     | yes |     |     |     |     |     | 
| [codeql/java-all](https://github.com/github/codeql/blob/main/java/ql/lib/qlpack.yml) | 395 | 58943 |     |     |     | yes |     |     |     |     |     | 
| [codeql/java-examples](https://github.com/github/codeql/blob/main/java/ql/examples/qlpack.yml) | 30 | 456 |     |     |     | yes |     |     |     |     |     | 
| [kotlin](https://github.com/github/codeql/blob/main/java/ql/integration-tests/posix-only/kotlin/qlpack.yml) | 4 | 29 |     |     |     | yes |     |     |     |     |     | 
| [kotlin](https://github.com/github/codeql/blob/main/java/ql/integration-tests/all-platforms/kotlin/qlpack.yml) | 29 | 387 |     |     |     | yes |     |     |     |     |     | 
| [integrationtest-default-parameter-mad-flow](https://github.com/github/codeql/blob/main/java/ql/integration-tests/all-platforms/kotlin/default-parameter-mad-flow/qlpack.yml) | 1 | 35 |     |     |     | yes |     |     |     |     |     | 
| [integrationtest-annotation-id-consistency](https://github.com/github/codeql/blob/main/java/ql/integration-tests/all-platforms/kotlin/annotation-id-consistency/qlpack.yml) | 1 | 11 |     |     |     | yes |     |     |     |     |     | 
| [integrationtest-kotlin-interface-inherited-default](https://github.com/github/codeql/blob/main/java/ql/integration-tests/all-platforms/kotlin/kotlin-interface-inherited-default/qlpack.yml) | 1 | 36 |     |     |     | yes |     |     |     |     |     | 
| [integrationtest-kotlin-java-static-fields](https://github.com/github/codeql/blob/main/java/ql/integration-tests/all-platforms/kotlin/kotlin_java_static_fields/qlpack.yml) | 1 | 17 |     |     |     | yes |     |     |     |     |     | 
| [integrationtest-gradle-kotlinx-serialization](https://github.com/github/codeql/blob/main/java/ql/integration-tests/all-platforms/kotlin/gradle_kotlinx_serialization/qlpack.yml) | 1 | 5 |     |     |     | yes |     |     |     |     |     | 
| [java](https://github.com/github/codeql/blob/main/java/ql/integration-tests/all-platforms/java/qlpack.yml) | 21 | 151 |     |     |     | yes |     |     |     |     |     | 
| [kotlin](https://github.com/github/codeql/blob/main/java/ql/integration-tests/linux-only/kotlin/qlpack.yml) | 5 | 71 |     |     |     | yes |     |     |     |     |     | 
| [integrationtest-custom-plugin](https://github.com/github/codeql/blob/main/java/ql/integration-tests/linux-only/kotlin/custom_plugin/qlpack.yml) | 4 | 31 |     |     |     | yes |     |     |     |     |     | 
| [codeql/java-tests](https://github.com/github/codeql/blob/main/java/ql/test/qlpack.yml) | 520 | 6507 |     |     |     | yes |     |     |     |     |     | 
| [codeql/java-downgrades](https://github.com/github/codeql/blob/main/java/downgrades/qlpack.yml) | 2 | 30 |     |     |     | yes |     |     |     |     |     | 
| [codeql/python-queries](https://github.com/github/codeql/blob/main/python/ql/src/qlpack.yml) | 366 | 17276 |     |     |     |     |     | yes |     |     |     | 
| [codeql/python-consistency-queries](https://github.com/github/codeql/blob/main/python/ql/consistency-queries/qlpack.yml) | 0 | 0 |     |     |     |     |     | yes |     |     |     | 
| [codeql/python-all](https://github.com/github/codeql/blob/main/python/ql/lib/qlpack.yml) | 350 | 59305 |     |     |     |     |     | yes |     |     |     | 
| [codeql/python-examples](https://github.com/github/codeql/blob/main/python/ql/examples/qlpack.yml) | 28 | 419 |     |     |     |     |     | yes |     |     |     | 
| [codeql/python-tests](https://github.com/github/codeql/blob/main/python/ql/test/qlpack.yml) | 643 | 8522 |     |     |     |     |     | yes |     |     |     | 
| [codeql/python-downgrades](https://github.com/github/codeql/blob/main/python/downgrades/qlpack.yml) | 3 | 129 |     |     |     |     |     | yes |     |     |     | 
| [codeql-python-recorded-call-graph-metrics](https://github.com/github/codeql/blob/main/python/tools/recorded-call-graph-metrics/ql/qlpack.yml) | 8 | 510 |     |     |     |     |     | yes |     |     |     | 
| [codeql/go-queries](https://github.com/github/codeql/blob/main/go/ql/src/qlpack.yml) | 93 | 7487 |     |     | yes |     |     |     |     |     |     | 
| [codeql/go-all](https://github.com/github/codeql/blob/main/go/ql/lib/qlpack.yml) | 198 | 32464 |     |     | yes |     |     |     |     |     |     | 
| [codeql/go-examples](https://github.com/github/codeql/blob/main/go/ql/examples/qlpack.yml) | 21 | 307 |     |     | yes |     |     |     |     |     |     | 
| [legacy-libraries-go](https://github.com/github/codeql/blob/main/go/ql/config/legacy-support/qlpack.yml) | 0 | 0 |     |     | yes |     |     |     |     |     |     | 
| [codeql/go-tests](https://github.com/github/codeql/blob/main/go/ql/test/qlpack.yml) | 189 | 2598 |     |     | yes |     |     |     |     |     |     | 
| [codeql/go-downgrades](https://github.com/github/codeql/blob/main/go/downgrades/qlpack.yml) | 2 | 72 |     |     | yes |     |     |     |     |     |     | 
| [codeql/suite-helpers](https://github.com/github/codeql/blob/main/go/external-packs/codeql/suite-helpers/0.0.2/qlpack.yml) | 0 | 0 |     |     | yes |     |     |     |     |     |     | 
| [codeql/suite-helpers](https://github.com/github/codeql/blob/main/misc/suite-helpers/qlpack.yml) | 0 | 0 | yes | yes | yes | yes | yes | yes |     | yes | yes | 
| [legacy-libraries-javascript](https://github.com/github/codeql/blob/main/misc/legacy-support/javascript/qlpack.yml) | 0 | 0 |     |     |     |     |     |     |     |     |     | 
| [legacy-libraries-csharp](https://github.com/github/codeql/blob/main/misc/legacy-support/csharp/qlpack.yml) | 0 | 0 |     |     |     |     |     |     |     |     |     | 
| [legacy-libraries-cpp](https://github.com/github/codeql/blob/main/misc/legacy-support/cpp/qlpack.yml) | 0 | 0 |     |     |     |     |     |     |     |     |     | 
| [legacy-libraries-java](https://github.com/github/codeql/blob/main/misc/legacy-support/java/qlpack.yml) | 0 | 0 |     |     |     |     |     |     |     |     |     | 
| [legacy-libraries-python](https://github.com/github/codeql/blob/main/misc/legacy-support/python/qlpack.yml) | 0 | 0 |     |     |     |     |     |     |     |     |     | 
| DataFlow Java/C++/C#/Go/Python/Ruby/Swift | 1 | 4880 | yes | yes | yes | yes |     | yes |     | yes | yes | 
| DataFlow Java/C++/C#/Go/Python/Ruby/Swift Common | 1 | 1521 | yes | yes | yes | yes |     | yes |     | yes | yes | 
| TaintTracking::Configuration Java/C++/C#/Go/Python/Ruby/Swift | 1 | 191 | yes | yes | yes | yes |     | yes |     | yes | yes | 
| DataFlow Java/C++/C#/Python/Ruby/Swift Consistency checks | 1 | 278 | yes | yes |     | yes |     | yes |     | yes | yes | 
| DataFlow Java/C#/Go/Ruby/Python/Swift Flow Summaries | 1 | 1341 |     | yes | yes | yes |     | yes |     | yes | yes | 
| SsaReadPosition Java/C# | 1 | 65 |     | yes |     | yes |     |     |     |     |     | 
| Model as Data Generation Java/C# - CaptureModels | 1 | 291 |     | yes |     | yes |     |     |     |     |     | 
| Sign Java/C# | 1 | 280 |     | yes |     | yes |     |     |     |     |     | 
| SignAnalysis Java/C# | 1 | 376 |     | yes |     | yes |     |     |     |     |     | 
| Bound Java/C# | 1 | 78 |     | yes |     | yes |     |     |     |     |     | 
| ModulusAnalysis Java/C# | 1 | 281 |     | yes |     | yes |     |     |     |     |     | 
| C++ SubBasicBlocks | 1 | 179 | yes |     |     |     |     |     |     |     |     | 
| IR Instruction | 1 | 2228 | yes | yes |     |     |     |     |     |     |     | 
| IR IRBlock | 1 | 343 | yes | yes |     |     |     |     |     |     |     | 
| IR IRVariable | 1 | 336 | yes | yes |     |     |     |     |     |     |     | 
| IR IRFunction | 1 | 59 | yes | yes |     |     |     |     |     |     |     | 
| IR Operand | 1 | 512 | yes | yes |     |     |     |     |     |     |     | 
| IR IRType | 1 | 349 | yes | yes |     |     |     |     |     |     |     | 
| IR IRConfiguration | 1 | 45 | yes | yes |     |     |     |     |     |     |     | 
| IR UseSoundEscapeAnalysis | 1 | 9 | yes | yes |     |     |     |     |     |     |     | 
| IR IRFunctionBase | 1 | 32 | yes | yes |     |     |     |     |     |     |     | 
| IR Operand Tag | 1 | 298 | yes | yes |     |     |     |     |     |     |     | 
| IR TInstruction | 1 | 109 | yes | yes |     |     |     |     |     |     |     | 
| IR TIRVariable | 1 | 23 | yes | yes |     |     |     |     |     |     |     | 
| IR IR | 1 | 80 | yes | yes |     |     |     |     |     |     |     | 
| IR IRConsistency | 1 | 548 | yes | yes |     |     |     |     |     |     |     | 
| IR PrintIR | 1 | 329 | yes | yes |     |     |     |     |     |     |     | 
| IR IntegerConstant | 1 | 236 | yes | yes |     |     |     |     |     |     |     | 
| IR IntegerInteval | 1 | 35 | yes | yes |     |     |     |     |     |     |     | 
| IR IntegerPartial | 1 | 99 | yes | yes |     |     |     |     |     |     |     | 
| IR Overlap | 1 | 70 | yes | yes |     |     |     |     |     |     |     | 
| IR EdgeKind | 1 | 139 | yes | yes |     |     |     |     |     |     |     | 
| IR MemoryAccessKind | 1 | 101 | yes | yes |     |     |     |     |     |     |     | 
| IR TempVariableTag | 1 | 17 | yes | yes |     |     |     |     |     |     |     | 
| IR Opcode | 1 | 1249 | yes | yes |     |     |     |     |     |     |     | 
| IR SSAConsistency | 1 | 2 | yes | yes |     |     |     |     |     |     |     | 
| C++ IR InstructionImports | 1 | 6 | yes |     |     |     |     |     |     |     |     | 
| C++ IR IRImports | 1 | 3 | yes |     |     |     |     |     |     |     |     | 
| C++ IR IRBlockImports | 1 | 1 | yes |     |     |     |     |     |     |     |     | 
| C++ IR IRFunctionImports | 1 | 1 | yes |     |     |     |     |     |     |     |     | 
| C++ IR IRVariableImports | 1 | 5 | yes |     |     |     |     |     |     |     |     | 
| C++ IR OperandImports | 1 | 5 | yes |     |     |     |     |     |     |     |     | 
| C++ IR PrintIRImports | 1 | 1 | yes |     |     |     |     |     |     |     |     | 
| C++ SSA SSAConstructionImports | 1 | 6 | yes |     |     |     |     |     |     |     |     | 
| SSA AliasAnalysis | 1 | 474 | yes | yes |     |     |     |     |     |     |     | 
| SSA PrintAliasAnalysis | 1 | 19 | yes |     |     |     |     |     |     |     |     | 
| C++ SSA AliasAnalysisImports | 1 | 3 | yes |     |     |     |     |     |     |     |     | 
| C++ IR ValueNumberingImports | 1 | 3 | yes |     |     |     |     |     |     |     |     | 
| IR SSA SimpleSSA | 1 | 117 | yes | yes |     |     |     |     |     |     |     | 
| IR AliasConfiguration (unaliased_ssa) | 1 | 18 | yes | yes |     |     |     |     |     |     |     | 
| IR SSA SSAConstruction | 1 | 1139 | yes | yes |     |     |     |     |     |     |     | 
| IR SSA PrintSSA | 1 | 157 | yes | yes |     |     |     |     |     |     |     | 
| IR ValueNumberInternal | 1 | 314 | yes | yes |     |     |     |     |     |     |     | 
| C++ IR ValueNumber | 1 | 88 | yes | yes |     |     |     |     |     |     |     | 
| C++ IR PrintValueNumbering | 1 | 17 | yes | yes |     |     |     |     |     |     |     | 
| C++ IR ConstantAnalysis | 1 | 53 | yes |     |     |     |     |     |     |     |     | 
| C++ IR PrintConstantAnalysis | 1 | 11 | yes |     |     |     |     |     |     |     |     | 
| C++ IR ReachableBlock | 1 | 53 | yes |     |     |     |     |     |     |     |     | 
| C++ IR PrintReachableBlock | 1 | 17 | yes |     |     |     |     |     |     |     |     | 
| C++ IR Dominance | 1 | 22 | yes |     |     |     |     |     |     |     |     | 
| C++ IR PrintDominance | 1 | 22 | yes |     |     |     |     |     |     |     |     | 
| C# IR InstructionImports | 1 | 6 |     | yes |     |     |     |     |     |     |     | 
| C# IR IRImports | 1 | 3 |     | yes |     |     |     |     |     |     |     | 
| C# IR IRBlockImports | 1 | 1 |     | yes |     |     |     |     |     |     |     | 
| C# IR IRFunctionImports | 1 | 1 |     | yes |     |     |     |     |     |     |     | 
| C# IR IRVariableImports | 1 | 5 |     | yes |     |     |     |     |     |     |     | 
| C# IR OperandImports | 1 | 5 |     | yes |     |     |     |     |     |     |     | 
| C# IR PrintIRImports | 1 | 1 |     | yes |     |     |     |     |     |     |     | 
| C# IR ValueNumberingImports | 1 | 3 |     | yes |     |     |     |     |     |     |     | 
| C# ControlFlowReachability | 1 | 215 |     | yes |     |     |     |     |     |     |     | 
| C++ ExternalAPIs | 1 | 58 | yes |     |     |     |     |     |     |     |     | 
| C++ SafeExternalAPIFunction | 1 | 27 | yes |     |     |     |     |     |     |     |     | 
| XML | 1 | 354 | yes | yes |     | yes | yes | yes |     |     |     | 
| DuplicationProblems.inc.qhelp | 0 | 0 |     |     |     |     |     |     |     |     |     | 
| CommentedOutCodeQuery.inc.qhelp | 0 | 0 |     |     |     |     |     |     |     |     |     | 
| FLinesOfCodeReferences.inc.qhelp | 0 | 0 |     |     |     |     |     |     |     |     |     | 
| FCommentRatioCommon.inc.qhelp | 0 | 0 |     |     |     |     |     |     |     |     |     | 
| FLinesOfCodeOverview.inc.qhelp | 0 | 0 |     |     |     |     |     |     |     |     |     | 
| CommentedOutCodeMetricOverview.inc.qhelp | 0 | 0 |     |     |     |     |     |     |     |     |     | 
| FLinesOfDuplicatedCodeCommon.inc.qhelp | 0 | 0 |     |     |     |     |     |     |     |     |     | 
| CommentedOutCodeReferences.inc.qhelp | 0 | 0 |     |     |     |     |     |     |     |     |     | 
| ThreadResourceAbuse qhelp | 0 | 0 |     |     |     |     |     |     |     |     |     | 
| IDE Contextual Queries | 1 | 22 | yes | yes |     | yes | yes | yes |     |     |     | 
| CryptoAlgorithms Python/JS/Ruby | 1 | 101 |     |     |     |     | yes | yes |     | yes |     | 
| CryptoAlgorithmNames Python/JS/Ruby | 1 | 72 |     |     |     |     | yes | yes |     | yes |     | 
| SensitiveDataHeuristics Python/JS | 1 | 124 |     |     |     |     | yes | yes |     | yes |     | 
| CFG | 1 | 1027 |     | yes |     |     |     |     |     | yes | yes | 
| TypeTracker | 1 | 628 |     |     |     |     |     | yes |     | yes |     | 
| AccessPathSyntax | 1 | 182 |     | yes | yes | yes | yes | yes |     | yes | yes | 
| IncompleteUrlSubstringSanitization | 1 | 61 |     |     |     |     | yes |     |     | yes |     | 
| Concepts Python/Ruby/JS | 1 | 156 |     |     |     |     | yes | yes |     | yes |     | 
| ApiGraphModels | 1 | 703 |     |     |     |     | yes | yes |     | yes |     | 
| ApiGraphModelsExtensions | 1 | 36 |     |     |     |     | yes | yes |     | yes |     | 
| TaintedFormatStringQuery Ruby/JS | 1 | 27 |     |     |     |     | yes |     |     | yes |     | 
| TaintedFormatStringCustomizations Ruby/JS | 1 | 43 |     |     |     |     | yes |     |     | yes |     | 
| HttpToFileAccessQuery JS/Ruby | 1 | 25 |     |     |     |     | yes |     |     | yes |     | 
| HttpToFileAccessCustomizations JS/Ruby | 1 | 34 |     |     |     |     | yes |     |     | yes |     | 
| Typo database | 1 | 4 |     |     |     |     | yes |     | yes |     |     | 
| Swift declarations test file | 0 | 0 |     |     |     |     |     |     |     |     |     | 
| Swift statements test file | 0 | 0 |     |     |     |     |     |     |     |     |     | 
| Swift expressions test file | 0 | 0 |     |     |     |     |     |     |     |     |     | 
| Swift patterns test file | 0 | 0 |     |     |     |     |     |     |     |     |     | 
| Swift control flow test file | 0 | 0 |     |     |     |     |     |     |     |     |     | 
| IncompleteMultiCharacterSanitization JS/Ruby | 1 | 202 |     |     |     |     | yes |     |     | yes |     | 
| EncryptionKeySizes Python/Java | 1 | 21 |     |     |     | yes |     | yes |     |     |     | 

## Shared code by language pack

| Package name | Non-shared files | Non-shared lines of code | Imported files | Imported lines of code | Shared code % |
| ------------ | ---------------- | ------------------------ | -------------- | ---------------------- | ------------- |
| [codeql/ruby-all](https://github.com/github/codeql/blob/main/ruby/ql/lib/qlpack.yml) | 232 | 48765 | 30 | 17665 | 26.59 |
| [codeql/javascript-all](https://github.com/github/codeql/blob/main/javascript/ql/lib/qlpack.yml) | 386 | 89332 | 24 | 7006 | 7.27 |
| [codeql/csharp-all](https://github.com/github/codeql/blob/main/csharp/ql/lib/qlpack.yml) | 264 | 55499 | 17 | 13354 | 19.39 |
| [codeql/swift-all](https://github.com/github/codeql/blob/main/swift/ql/lib/qlpack.yml) | 857 | 29549 | 9 | 11683 | 28.33 |
| [codeql/cpp-all](https://github.com/github/codeql/blob/main/cpp/ql/lib/qlpack.yml) | 364 | 78318 | 58 | 19491 | 19.93 |
| [codeql/java-all](https://github.com/github/codeql/blob/main/java/ql/lib/qlpack.yml) | 395 | 58943 | 31 | 16350 | 21.72 |
| [codeql/python-all](https://github.com/github/codeql/blob/main/python/ql/lib/qlpack.yml) | 350 | 59305 | 26 | 15535 | 20.76 |
| [codeql/go-all](https://github.com/github/codeql/blob/main/go/ql/lib/qlpack.yml) | 198 | 32464 | 6 | 9209 | 22.10 |

## Shared code by package

| Package name | Non-shared files | Non-shared lines of code | Imported files | Imported lines of code | Shared code % |
| ------------ | ---------------- | ------------------------ | -------------- | ---------------------- | ------------- |
| [codeql/ruby-queries](https://github.com/github/codeql/blob/main/ruby/ql/src/qlpack.yml) | 69 | 2287 | 250 | 55615 | 96.05 |
| [codeql/ruby-consistency-queries](https://github.com/github/codeql/blob/main/ruby/ql/consistency-queries/qlpack.yml) | 6 | 124 | 243 | 54859 | 99.77 |
| [codeql/ruby-all](https://github.com/github/codeql/blob/main/ruby/ql/lib/qlpack.yml) | 232 | 48765 | 30 | 17665 | 26.59 |
| [codeql/ruby-examples](https://github.com/github/codeql/blob/main/ruby/ql/examples/qlpack.yml) | 1 | 18 | 243 | 54859 | 99.97 |
| [codeql/ruby-tests](https://github.com/github/codeql/blob/main/ruby/ql/test/qlpack.yml) | 106 | 3072 | 319 | 57859 | 94.96 |
| [codeql/ruby-downgrades](https://github.com/github/codeql/blob/main/ruby/downgrades/qlpack.yml) | 121 | 1374 | 0 | 0 | 0.00 |
| [codeql/ql](https://github.com/github/codeql/blob/main/ql/ql/src/qlpack.yml) | 108 | 12790 | 8 | 9734 | 43.22 |
| [codeql/ql-consistency-queries](https://github.com/github/codeql/blob/main/ql/ql/consistency-queries/qlpack.yml) | 6 | 6 | 115 | 22520 | 99.97 |
| [codeql/ql-examples](https://github.com/github/codeql/blob/main/ql/ql/examples/qlpack.yml) | 0 | 0 | 115 | 22520 | 100.00 |
| [codeql/ql-tests](https://github.com/github/codeql/blob/main/ql/ql/test/qlpack.yml) | 45 | 1415 | 115 | 22520 | 94.09 |
| [ql-testing-src-pack](https://github.com/github/codeql/blob/main/ql/ql/test/callgraph/packs/src/qlpack.yml) | 1 | 8 | 1 | 1 | 11.11 |
| [ql-testing-lib-pack](https://github.com/github/codeql/blob/main/ql/ql/test/callgraph/packs/lib/qlpack.yml) | 1 | 1 | 0 | 0 | 0.00 |
| [ql-other-pack-thing](https://github.com/github/codeql/blob/main/ql/ql/test/callgraph/packs/other/qlpack.yml) | 1 | 7 | 2 | 9 | 56.25 |
| [codeql/javascript-queries](https://github.com/github/codeql/blob/main/javascript/ql/src/qlpack.yml) | 360 | 16712 | 405 | 104052 | 86.16 |
| [codeql/javascript-all](https://github.com/github/codeql/blob/main/javascript/ql/lib/qlpack.yml) | 386 | 89332 | 24 | 7006 | 7.27 |
| [codeql/javascript-examples](https://github.com/github/codeql/blob/main/javascript/ql/examples/qlpack.yml) | 39 | 804 | 396 | 94257 | 99.15 |
| [codeql/javascript-tests](https://github.com/github/codeql/blob/main/javascript/ql/test/qlpack.yml) | 778 | 8293 | 763 | 120699 | 93.57 |
| [codeql/javascript-experimental-atm-queries](https://github.com/github/codeql/blob/main/javascript/ql/experimental/adaptivethreatmodeling/src/qlpack.yml) | 6 | 155 | 411 | 97125 | 99.84 |
| [codeql/javascript-experimental-atm-lib](https://github.com/github/codeql/blob/main/javascript/ql/experimental/adaptivethreatmodeling/lib/qlpack.yml) | 15 | 2868 | 396 | 94257 | 97.05 |
| [codeql/javascript-experimental-atm-model](https://github.com/github/codeql/blob/main/javascript/ql/experimental/adaptivethreatmodeling/model/qlpack.yml) | 0 | 0 | 0 | 0 | 0.00 |
| [codeql/javascript-experimental-atm-model-building](https://github.com/github/codeql/blob/main/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/qlpack.yml) | 22 | 827 | 411 | 97125 | 99.16 |
| [codeql/javascript-experimental-atm-tests](https://github.com/github/codeql/blob/main/javascript/ql/experimental/adaptivethreatmodeling/test/qlpack.yml) | 12 | 284 | 433 | 97952 | 99.71 |
| [codeql/javascript-downgrades](https://github.com/github/codeql/blob/main/javascript/downgrades/qlpack.yml) | 1 | 11 | 0 | 0 | 0.00 |
| [codeql/csharp-queries](https://github.com/github/codeql/blob/main/csharp/ql/src/qlpack.yml) | 405 | 25086 | 313 | 68345 | 73.15 |
| [codeql/csharp-solorigate-queries](https://github.com/github/codeql/blob/main/csharp/ql/campaigns/Solorigate/src/qlpack.yml) | 6 | 197 | 267 | 57972 | 99.66 |
| [codeql/csharp-solorigate-all](https://github.com/github/codeql/blob/main/csharp/ql/campaigns/Solorigate/lib/qlpack.yml) | 1 | 210 | 266 | 57762 | 99.64 |
| [csharp-solorigate-tests](https://github.com/github/codeql/blob/main/csharp/ql/campaigns/Solorigate/test/qlpack.yml) | 0 | 0 | 684 | 83950 | 100.00 |
| [codeql-csharp-consistency-queries](https://github.com/github/codeql/blob/main/csharp/ql/consistency-queries/qlpack.yml) | 6 | 197 | 266 | 57762 | 99.66 |
| [codeql/csharp-all](https://github.com/github/codeql/blob/main/csharp/ql/lib/qlpack.yml) | 264 | 55499 | 17 | 13354 | 19.39 |
| [codeql/csharp-examples](https://github.com/github/codeql/blob/main/csharp/ql/examples/qlpack.yml) | 28 | 426 | 266 | 57762 | 99.27 |
| [integration-tests](https://github.com/github/codeql/blob/main/csharp/ql/integration-tests/qlpack.yml) | 0 | 0 | 266 | 57762 | 100.00 |
| [codeql-csharp-tests](https://github.com/github/codeql/blob/main/csharp/ql/test/qlpack.yml) | 752 | 9627 | 677 | 83543 | 89.67 |
| [codeql/csharp-downgrades](https://github.com/github/codeql/blob/main/csharp/downgrades/qlpack.yml) | 3 | 39 | 0 | 0 | 0.00 |
| [codeql/swift-queries](https://github.com/github/codeql/blob/main/swift/ql/src/qlpack.yml) | 27 | 1831 | 865 | 32507 | 94.67 |
| [codeql/swift-all](https://github.com/github/codeql/blob/main/swift/ql/lib/qlpack.yml) | 857 | 29549 | 9 | 11683 | 28.33 |
| [codeql-swift-tests](https://github.com/github/codeql/blob/main/swift/ql/test/qlpack.yml) | 167 | 1953 | 892 | 34338 | 94.62 |
| [codeql/swift-downgrades](https://github.com/github/codeql/blob/main/swift/downgrades/qlpack.yml) | 3 | 26 | 0 | 0 | 0.00 |
| [integration-tests-swift](https://github.com/github/codeql/blob/main/swift/integration-tests/qlpack.yml) | 20 | 95 | 859 | 31812 | 99.70 |
| [codeql/cpp-queries](https://github.com/github/codeql/blob/main/cpp/ql/src/qlpack.yml) | 624 | 33181 | 374 | 81361 | 71.03 |
| [codeql/cpp-all](https://github.com/github/codeql/blob/main/cpp/ql/lib/qlpack.yml) | 364 | 78318 | 58 | 19491 | 19.93 |
| [codeql/cpp-examples](https://github.com/github/codeql/blob/main/cpp/ql/examples/qlpack.yml) | 26 | 419 | 366 | 80581 | 99.48 |
| [codeql/cpp-tests](https://github.com/github/codeql/blob/main/cpp/ql/test/qlpack.yml) | 740 | 9803 | 996 | 114457 | 92.11 |
| [codeql/cpp-tests-cwe-190-tainted](https://github.com/github/codeql/blob/main/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/tainted/qlpack.yml) | 0 | 0 | 996 | 114457 | 100.00 |
| [codeql/cpp-downgrades](https://github.com/github/codeql/blob/main/cpp/downgrades/qlpack.yml) | 7 | 118 | 0 | 0 | 0.00 |
| [codeql/typetracking](https://github.com/github/codeql/blob/main/shared/typetracking/qlpack.yml) | 1 | 860 | 6 | 695 | 44.69 |
| [codeql/ssa](https://github.com/github/codeql/blob/main/shared/ssa/qlpack.yml) | 1 | 1169 | 0 | 0 | 0.00 |
| [codeql/regex](https://github.com/github/codeql/blob/main/shared/regex/qlpack.yml) | 9 | 3831 | 0 | 0 | 0.00 |
| [codeql/util](https://github.com/github/codeql/blob/main/shared/util/qlpack.yml) | 6 | 695 | 0 | 0 | 0.00 |
| [codeql/typos](https://github.com/github/codeql/blob/main/shared/typos/qlpack.yml) | 1 | 9035 | 0 | 0 | 0.00 |
| [codeql/tutorial](https://github.com/github/codeql/blob/main/shared/tutorial/qlpack.yml) | 1 | 1094 | 0 | 0 | 0.00 |
| [codeql/java-queries](https://github.com/github/codeql/blob/main/java/ql/src/qlpack.yml) | 589 | 30268 | 413 | 65714 | 68.46 |
| [codeql-java-consistency-queries](https://github.com/github/codeql/blob/main/java/ql/consistency-queries/qlpack.yml) | 20 | 529 | 412 | 65423 | 99.20 |
| [codeql/java-all](https://github.com/github/codeql/blob/main/java/ql/lib/qlpack.yml) | 395 | 58943 | 31 | 16350 | 21.72 |
| [codeql/java-examples](https://github.com/github/codeql/blob/main/java/ql/examples/qlpack.yml) | 30 | 456 | 412 | 65423 | 99.31 |
| [kotlin](https://github.com/github/codeql/blob/main/java/ql/integration-tests/posix-only/kotlin/qlpack.yml) | 4 | 29 | 1521 | 102198 | 99.97 |
| [kotlin](https://github.com/github/codeql/blob/main/java/ql/integration-tests/all-platforms/kotlin/qlpack.yml) | 29 | 387 | 1521 | 102198 | 99.62 |
| [integrationtest-default-parameter-mad-flow](https://github.com/github/codeql/blob/main/java/ql/integration-tests/all-platforms/kotlin/default-parameter-mad-flow/qlpack.yml) | 1 | 35 | 1521 | 102198 | 99.97 |
| [integrationtest-annotation-id-consistency](https://github.com/github/codeql/blob/main/java/ql/integration-tests/all-platforms/kotlin/annotation-id-consistency/qlpack.yml) | 1 | 11 | 1521 | 102198 | 99.99 |
| [integrationtest-kotlin-interface-inherited-default](https://github.com/github/codeql/blob/main/java/ql/integration-tests/all-platforms/kotlin/kotlin-interface-inherited-default/qlpack.yml) | 1 | 36 | 1521 | 102198 | 99.96 |
| [integrationtest-kotlin-java-static-fields](https://github.com/github/codeql/blob/main/java/ql/integration-tests/all-platforms/kotlin/kotlin_java_static_fields/qlpack.yml) | 1 | 17 | 1521 | 102198 | 99.98 |
| [integrationtest-gradle-kotlinx-serialization](https://github.com/github/codeql/blob/main/java/ql/integration-tests/all-platforms/kotlin/gradle_kotlinx_serialization/qlpack.yml) | 1 | 5 | 1521 | 102198 | 100.00 |
| [java](https://github.com/github/codeql/blob/main/java/ql/integration-tests/all-platforms/java/qlpack.yml) | 21 | 151 | 1521 | 102198 | 99.85 |
| [kotlin](https://github.com/github/codeql/blob/main/java/ql/integration-tests/linux-only/kotlin/qlpack.yml) | 5 | 71 | 412 | 65423 | 99.89 |
| [integrationtest-custom-plugin](https://github.com/github/codeql/blob/main/java/ql/integration-tests/linux-only/kotlin/custom_plugin/qlpack.yml) | 4 | 31 | 412 | 65423 | 99.95 |
| [codeql/java-tests](https://github.com/github/codeql/blob/main/java/ql/test/qlpack.yml) | 520 | 6507 | 1001 | 95691 | 93.63 |
| [codeql/java-downgrades](https://github.com/github/codeql/blob/main/java/downgrades/qlpack.yml) | 2 | 30 | 0 | 0 | 0.00 |
| [codeql/python-queries](https://github.com/github/codeql/blob/main/python/ql/src/qlpack.yml) | 366 | 17276 | 366 | 64925 | 78.98 |
| [codeql/python-consistency-queries](https://github.com/github/codeql/blob/main/python/ql/consistency-queries/qlpack.yml) | 0 | 0 | 360 | 64230 | 100.00 |
| [codeql/python-all](https://github.com/github/codeql/blob/main/python/ql/lib/qlpack.yml) | 350 | 59305 | 26 | 15535 | 20.76 |
| [codeql/python-examples](https://github.com/github/codeql/blob/main/python/ql/examples/qlpack.yml) | 28 | 419 | 360 | 64230 | 99.35 |
| [codeql/python-tests](https://github.com/github/codeql/blob/main/python/ql/test/qlpack.yml) | 643 | 8522 | 732 | 82201 | 90.61 |
| [codeql/python-downgrades](https://github.com/github/codeql/blob/main/python/downgrades/qlpack.yml) | 3 | 129 | 0 | 0 | 0.00 |
| [codeql-python-recorded-call-graph-metrics](https://github.com/github/codeql/blob/main/python/tools/recorded-call-graph-metrics/ql/qlpack.yml) | 8 | 510 | 360 | 64230 | 99.21 |
| [codeql/go-queries](https://github.com/github/codeql/blob/main/go/ql/src/qlpack.yml) | 93 | 7487 | 205 | 34253 | 82.06 |
| [codeql/go-all](https://github.com/github/codeql/blob/main/go/ql/lib/qlpack.yml) | 198 | 32464 | 6 | 9209 | 22.10 |
| [codeql/go-examples](https://github.com/github/codeql/blob/main/go/ql/examples/qlpack.yml) | 21 | 307 | 199 | 33558 | 99.09 |
| [legacy-libraries-go](https://github.com/github/codeql/blob/main/go/ql/config/legacy-support/qlpack.yml) | 0 | 0 | 0 | 0 | 0.00 |
| [codeql/go-tests](https://github.com/github/codeql/blob/main/go/ql/test/qlpack.yml) | 189 | 2598 | 319 | 42047 | 94.18 |
| [codeql/go-downgrades](https://github.com/github/codeql/blob/main/go/downgrades/qlpack.yml) | 2 | 72 | 0 | 0 | 0.00 |
| [codeql/suite-helpers](https://github.com/github/codeql/blob/main/go/external-packs/codeql/suite-helpers/0.0.2/qlpack.yml) | 0 | 0 | 0 | 0 | 0.00 |
| [codeql/suite-helpers](https://github.com/github/codeql/blob/main/misc/suite-helpers/qlpack.yml) | 0 | 0 | 0 | 0 | 0.00 |
| [legacy-libraries-javascript](https://github.com/github/codeql/blob/main/misc/legacy-support/javascript/qlpack.yml) | 0 | 0 | 0 | 0 | 0.00 |
| [legacy-libraries-csharp](https://github.com/github/codeql/blob/main/misc/legacy-support/csharp/qlpack.yml) | 0 | 0 | 0 | 0 | 0.00 |
| [legacy-libraries-cpp](https://github.com/github/codeql/blob/main/misc/legacy-support/cpp/qlpack.yml) | 0 | 0 | 0 | 0 | 0.00 |
| [legacy-libraries-java](https://github.com/github/codeql/blob/main/misc/legacy-support/java/qlpack.yml) | 0 | 0 | 0 | 0 | 0.00 |
| [legacy-libraries-python](https://github.com/github/codeql/blob/main/misc/legacy-support/python/qlpack.yml) | 0 | 0 | 0 | 0 | 0.00 |
