### PR TITLE
C++: Teach iterator flow about `std::back_inserter`

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternalsCommon.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternalsCommon.qll
@@ -463,6 +463,7 @@ cached
 private module Cached {
   private import semmle.code.cpp.models.interfaces.Iterator as Interfaces
   private import semmle.code.cpp.models.implementations.Iterator as Iterator
+  private import semmle.code.cpp.models.interfaces.FunctionInputsAndOutputs as IO
 
   /**
    * Holds if `next` is a instruction with a memory result that potentially
@@ -593,11 +594,16 @@ private module Cached {
   private predicate isChiAfterBegin(
     BaseSourceVariableInstruction containerBase, StoreInstruction iterator
   ) {
-    exists(CallInstruction getIterator |
+    exists(
+      CallInstruction getIterator, Iterator::GetIteratorFunction getIteratorFunction,
+      IO::FunctionInput input, int i
+    |
       getIterator = iterator.getSourceValue() and
-      getIterator.getStaticCallTarget() instanceof Iterator::GetIteratorFunction and
+      getIteratorFunction = getIterator.getStaticCallTarget() and
+      getIteratorFunction.getsIterator(input, _) and
       isDef(_, any(Node0Impl n | n.asInstruction() = iterator), _, _, 1, 0) and
-      isUse(_, getIterator.getThisArgumentOperand(), containerBase, 0, 0)
+      input.isParameterDerefOrQualifierObject(i) and
+      isUse(_, getIterator.getArgumentOperand(i), containerBase, 0, 0)
     )
   }
 

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/vector.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/vector.cpp
@@ -426,14 +426,14 @@ void test_vector_inserter(char *source_string) {
 		std::vector<std::string> out;
 		auto it = std::back_inserter(out);
 		*it++ = std::string(source_string);
-		sink(out); // $ ast MISSING: ir
+		sink(out); // $ ast,ir
 	}
 
 	{
 		std::vector<int> out;
 		auto it = std::back_inserter(out);
 		*it++ = source();
-		sink(out); // $ ast MISSING: ir
+		sink(out); // $ ast,ir
 	}
 
 	{

--- a/cpp/ql/test/library-tests/syntax-zoo/dataflow-ir-consistency.expected
+++ b/cpp/ql/test/library-tests/syntax-zoo/dataflow-ir-consistency.expected
@@ -17,21 +17,13 @@ uniqueNodeLocation
 | break_labels.c:2:11:2:11 | i | Node should have one location but has 4. |
 | break_labels.c:2:11:2:11 | i | Node should have one location but has 4. |
 | break_labels.c:2:11:2:11 | i | Node should have one location but has 4. |
-| break_labels.c:2:11:2:11 | i | Node should have one location but has 4. |
 | break_labels.c:2:11:2:11 | i indirection | Node should have one location but has 4. |
 | break_labels.c:2:11:2:11 | i indirection | Node should have one location but has 4. |
 | break_labels.c:2:11:2:11 | x | Node should have one location but has 4. |
 | break_labels.c:2:11:2:11 | x | Node should have one location but has 4. |
 | break_labels.c:2:11:2:11 | x | Node should have one location but has 4. |
-| break_labels.c:2:11:2:11 | x | Node should have one location but has 4. |
 | break_labels.c:2:11:2:11 | x indirection | Node should have one location but has 4. |
 | break_labels.c:2:11:2:11 | x indirection | Node should have one location but has 4. |
-| constmemberaccess.cpp:3:7:3:7 | x | Node should have one location but has 2. |
-| constructorinitializer.cpp:3:9:3:9 | i | Node should have one location but has 2. |
-| constructorinitializer.cpp:3:9:3:9 | x | Node should have one location but has 2. |
-| constructorinitializer.cpp:3:16:3:16 | j | Node should have one location but has 2. |
-| constructorinitializer.cpp:3:16:3:16 | y | Node should have one location but has 2. |
-| duff.c:2:12:2:12 | i | Node should have one location but has 4. |
 | duff.c:2:12:2:12 | i | Node should have one location but has 4. |
 | duff.c:2:12:2:12 | i | Node should have one location but has 4. |
 | duff.c:2:12:2:12 | i | Node should have one location but has 4. |
@@ -40,32 +32,8 @@ uniqueNodeLocation
 | duff.c:2:12:2:12 | x | Node should have one location but has 4. |
 | duff.c:2:12:2:12 | x | Node should have one location but has 4. |
 | duff.c:2:12:2:12 | x | Node should have one location but has 4. |
-| duff.c:2:12:2:12 | x | Node should have one location but has 4. |
 | duff.c:2:12:2:12 | x indirection | Node should have one location but has 4. |
 | duff.c:2:12:2:12 | x indirection | Node should have one location but has 4. |
-| fieldaccess.cpp:3:7:3:7 | x | Node should have one location but has 2. |
-| file://:0:0:0:0 | (unnamed parameter 0) | Node should have one location but has 0. |
-| file://:0:0:0:0 | (unnamed parameter 0) | Node should have one location but has 0. |
-| file://:0:0:0:0 | (unnamed parameter 0) | Node should have one location but has 0. |
-| file://:0:0:0:0 | (unnamed parameter 0) | Node should have one location but has 0. |
-| file://:0:0:0:0 | (unnamed parameter 0) | Node should have one location but has 0. |
-| file://:0:0:0:0 | (unnamed parameter 0) | Node should have one location but has 0. |
-| file://:0:0:0:0 | (unnamed parameter 0) | Node should have one location but has 0. |
-| file://:0:0:0:0 | (unnamed parameter 0) | Node should have one location but has 0. |
-| file://:0:0:0:0 | (unnamed parameter 0) | Node should have one location but has 0. |
-| file://:0:0:0:0 | (unnamed parameter 0) | Node should have one location but has 0. |
-| file://:0:0:0:0 | (unnamed parameter 0) | Node should have one location but has 0. |
-| file://:0:0:0:0 | (unnamed parameter 1) | Node should have one location but has 0. |
-| file://:0:0:0:0 | (unnamed parameter 1) | Node should have one location but has 0. |
-| file://:0:0:0:0 | (unnamed parameter 1) | Node should have one location but has 0. |
-| file://:0:0:0:0 | (unnamed parameter 1) | Node should have one location but has 0. |
-| file://:0:0:0:0 | (unnamed parameter 1) | Node should have one location but has 0. |
-| file://:0:0:0:0 | (unnamed parameter 1) | Node should have one location but has 0. |
-| file://:0:0:0:0 | (unnamed parameter 1) | Node should have one location but has 0. |
-| file://:0:0:0:0 | (unnamed parameter 1) | Node should have one location but has 0. |
-| file://:0:0:0:0 | (unnamed parameter 2) | Node should have one location but has 0. |
-| file://:0:0:0:0 | (unnamed parameter 2) | Node should have one location but has 0. |
-| file://:0:0:0:0 | (unnamed parameter 2) | Node should have one location but has 0. |
 | file://:0:0:0:0 | (unnamed parameter 2) | Node should have one location but has 0. |
 | file://:0:0:0:0 | (unnamed parameter 2) | Node should have one location but has 0. |
 | file://:0:0:0:0 | (unnamed parameter 2) | Node should have one location but has 0. |
@@ -78,8 +46,6 @@ uniqueNodeLocation
 | file://:0:0:0:0 | (unnamed parameter 2) indirection | Node should have one location but has 0. |
 | file://:0:0:0:0 | (unnamed parameter 2) indirection | Node should have one location but has 0. |
 | file://:0:0:0:0 | (unnamed parameter 2) indirection | Node should have one location but has 0. |
-| file://:0:0:0:0 | (unnamed parameter 3) | Node should have one location but has 0. |
-| ifelsestmt.c:37:17:37:17 | x | Node should have one location but has 2. |
 | ifelsestmt.c:37:17:37:17 | x | Node should have one location but has 2. |
 | ifelsestmt.c:37:17:37:17 | x | Node should have one location but has 2. |
 | ifelsestmt.c:37:17:37:17 | x | Node should have one location but has 2. |
@@ -88,10 +54,8 @@ uniqueNodeLocation
 | ifelsestmt.c:37:24:37:24 | y | Node should have one location but has 2. |
 | ifelsestmt.c:37:24:37:24 | y | Node should have one location but has 2. |
 | ifelsestmt.c:37:24:37:24 | y | Node should have one location but has 2. |
-| ifelsestmt.c:37:24:37:24 | y | Node should have one location but has 2. |
 | ifelsestmt.c:37:24:37:24 | y indirection | Node should have one location but has 2. |
 | ifelsestmt.c:37:24:37:24 | y indirection | Node should have one location but has 2. |
-| ifstmt.c:27:17:27:17 | x | Node should have one location but has 2. |
 | ifstmt.c:27:17:27:17 | x | Node should have one location but has 2. |
 | ifstmt.c:27:17:27:17 | x | Node should have one location but has 2. |
 | ifstmt.c:27:17:27:17 | x | Node should have one location but has 2. |
@@ -100,16 +64,8 @@ uniqueNodeLocation
 | ifstmt.c:27:24:27:24 | y | Node should have one location but has 2. |
 | ifstmt.c:27:24:27:24 | y | Node should have one location but has 2. |
 | ifstmt.c:27:24:27:24 | y | Node should have one location but has 2. |
-| ifstmt.c:27:24:27:24 | y | Node should have one location but has 2. |
 | ifstmt.c:27:24:27:24 | y indirection | Node should have one location but has 2. |
 | ifstmt.c:27:24:27:24 | y indirection | Node should have one location but has 2. |
-| membercallexpr_args.cpp:3:6:3:6 | d | Node should have one location but has 2. |
-| membercallexpr_args.cpp:4:14:4:14 | x | Node should have one location but has 2. |
-| membercallexpr_args.cpp:4:21:4:21 | y | Node should have one location but has 2. |
-| newexpr.cpp:3:9:3:9 | i | Node should have one location but has 2. |
-| newexpr.cpp:3:9:3:9 | x | Node should have one location but has 2. |
-| newexpr.cpp:3:16:3:16 | j | Node should have one location but has 2. |
-| newexpr.cpp:3:16:3:16 | y | Node should have one location but has 2. |
 | no_dynamic_init.cpp:9:5:9:8 | Phi | Node should have one location but has 4. |
 | no_dynamic_init.cpp:9:5:9:8 | main | Node should have one location but has 4. |
 | no_dynamic_init.cpp:9:5:9:8 | main | Node should have one location but has 4. |
@@ -118,10 +74,8 @@ uniqueNodeLocation
 | nodefaultswitchstmt.c:1:12:1:12 | i | Node should have one location but has 4. |
 | nodefaultswitchstmt.c:1:12:1:12 | i | Node should have one location but has 4. |
 | nodefaultswitchstmt.c:1:12:1:12 | i | Node should have one location but has 4. |
-| nodefaultswitchstmt.c:1:12:1:12 | i | Node should have one location but has 4. |
 | nodefaultswitchstmt.c:1:12:1:12 | i indirection | Node should have one location but has 4. |
 | nodefaultswitchstmt.c:1:12:1:12 | i indirection | Node should have one location but has 4. |
-| nodefaultswitchstmt.c:1:12:1:12 | x | Node should have one location but has 4. |
 | nodefaultswitchstmt.c:1:12:1:12 | x | Node should have one location but has 4. |
 | nodefaultswitchstmt.c:1:12:1:12 | x | Node should have one location but has 4. |
 | nodefaultswitchstmt.c:1:12:1:12 | x | Node should have one location but has 4. |
@@ -132,9 +86,6 @@ uniqueNodeLocation
 | parameterinitializer.cpp:18:5:18:8 | main | Node should have one location but has 4. |
 | parameterinitializer.cpp:18:5:18:8 | main indirection | Node should have one location but has 4. |
 | parameterinitializer.cpp:18:5:18:8 | main indirection | Node should have one location but has 4. |
-| staticmembercallexpr_args.cpp:3:6:3:6 | d | Node should have one location but has 2. |
-| staticmembercallexpr_args.cpp:4:21:4:21 | x | Node should have one location but has 2. |
-| staticmembercallexpr_args.cpp:4:28:4:28 | y | Node should have one location but has 2. |
 | stream_it.cpp:16:5:16:8 | Phi | Node should have one location but has 4. |
 | stream_it.cpp:16:5:16:8 | main | Node should have one location but has 4. |
 | stream_it.cpp:16:5:16:8 | main | Node should have one location but has 4. |
@@ -143,25 +94,21 @@ uniqueNodeLocation
 | switchstmt.c:1:12:1:12 | i | Node should have one location but has 4. |
 | switchstmt.c:1:12:1:12 | i | Node should have one location but has 4. |
 | switchstmt.c:1:12:1:12 | i | Node should have one location but has 4. |
-| switchstmt.c:1:12:1:12 | i | Node should have one location but has 4. |
 | switchstmt.c:1:12:1:12 | i indirection | Node should have one location but has 4. |
 | switchstmt.c:1:12:1:12 | i indirection | Node should have one location but has 4. |
-| switchstmt.c:1:12:1:12 | x | Node should have one location but has 4. |
 | switchstmt.c:1:12:1:12 | x | Node should have one location but has 4. |
 | switchstmt.c:1:12:1:12 | x | Node should have one location but has 4. |
 | switchstmt.c:1:12:1:12 | x | Node should have one location but has 4. |
 | switchstmt.c:1:12:1:12 | x indirection | Node should have one location but has 4. |
 | switchstmt.c:1:12:1:12 | x indirection | Node should have one location but has 4. |
 missingLocation
-| Nodes without location: 35 |
+| Nodes without location: 12 |
 uniqueNodeToString
 | break_labels.c:2:11:2:11 | i | Node should have one toString but has 2. |
 | break_labels.c:2:11:2:11 | i | Node should have one toString but has 2. |
 | break_labels.c:2:11:2:11 | i | Node should have one toString but has 2. |
-| break_labels.c:2:11:2:11 | i | Node should have one toString but has 2. |
 | break_labels.c:2:11:2:11 | i indirection | Node should have one toString but has 2. |
 | break_labels.c:2:11:2:11 | i indirection | Node should have one toString but has 2. |
-| break_labels.c:2:11:2:11 | x | Node should have one toString but has 2. |
 | break_labels.c:2:11:2:11 | x | Node should have one toString but has 2. |
 | break_labels.c:2:11:2:11 | x | Node should have one toString but has 2. |
 | break_labels.c:2:11:2:11 | x | Node should have one toString but has 2. |
@@ -199,17 +146,11 @@ uniqueNodeToString
 | break_labels.c:7:17:7:17 | x | Node should have one toString but has 2. |
 | break_labels.c:7:17:7:17 | x indirection | Node should have one toString but has 2. |
 | break_labels.c:7:17:7:17 | x indirection | Node should have one toString but has 2. |
-| constructorinitializer.cpp:3:9:3:9 | i | Node should have one toString but has 2. |
-| constructorinitializer.cpp:3:9:3:9 | x | Node should have one toString but has 2. |
-| constructorinitializer.cpp:3:16:3:16 | j | Node should have one toString but has 2. |
-| constructorinitializer.cpp:3:16:3:16 | y | Node should have one toString but has 2. |
-| duff.c:2:12:2:12 | i | Node should have one toString but has 2. |
 | duff.c:2:12:2:12 | i | Node should have one toString but has 2. |
 | duff.c:2:12:2:12 | i | Node should have one toString but has 2. |
 | duff.c:2:12:2:12 | i | Node should have one toString but has 2. |
 | duff.c:2:12:2:12 | i indirection | Node should have one toString but has 2. |
 | duff.c:2:12:2:12 | i indirection | Node should have one toString but has 2. |
-| duff.c:2:12:2:12 | x | Node should have one toString but has 2. |
 | duff.c:2:12:2:12 | x | Node should have one toString but has 2. |
 | duff.c:2:12:2:12 | x | Node should have one toString but has 2. |
 | duff.c:2:12:2:12 | x | Node should have one toString but has 2. |
@@ -231,17 +172,17 @@ uniqueNodeToString
 | duff.c:4:13:4:13 | x | Node should have one toString but has 2. |
 | duff.c:4:13:4:13 | x | Node should have one toString but has 2. |
 | duff.c:4:13:4:13 | x | Node should have one toString but has 2. |
-| newexpr.cpp:3:9:3:9 | i | Node should have one toString but has 2. |
-| newexpr.cpp:3:9:3:9 | x | Node should have one toString but has 2. |
-| newexpr.cpp:3:16:3:16 | j | Node should have one toString but has 2. |
-| newexpr.cpp:3:16:3:16 | y | Node should have one toString but has 2. |
-| nodefaultswitchstmt.c:1:12:1:12 | i | Node should have one toString but has 2. |
+| file://:0:0:0:0 | i | Node should have one toString but has 2. |
+| file://:0:0:0:0 | i | Node should have one toString but has 2. |
+| file://:0:0:0:0 | j | Node should have one toString but has 2. |
+| file://:0:0:0:0 | x | Node should have one toString but has 2. |
+| file://:0:0:0:0 | x | Node should have one toString but has 2. |
+| file://:0:0:0:0 | y | Node should have one toString but has 2. |
 | nodefaultswitchstmt.c:1:12:1:12 | i | Node should have one toString but has 2. |
 | nodefaultswitchstmt.c:1:12:1:12 | i | Node should have one toString but has 2. |
 | nodefaultswitchstmt.c:1:12:1:12 | i | Node should have one toString but has 2. |
 | nodefaultswitchstmt.c:1:12:1:12 | i indirection | Node should have one toString but has 2. |
 | nodefaultswitchstmt.c:1:12:1:12 | i indirection | Node should have one toString but has 2. |
-| nodefaultswitchstmt.c:1:12:1:12 | x | Node should have one toString but has 2. |
 | nodefaultswitchstmt.c:1:12:1:12 | x | Node should have one toString but has 2. |
 | nodefaultswitchstmt.c:1:12:1:12 | x | Node should have one toString but has 2. |
 | nodefaultswitchstmt.c:1:12:1:12 | x | Node should have one toString but has 2. |
@@ -258,10 +199,8 @@ uniqueNodeToString
 | switchstmt.c:1:12:1:12 | i | Node should have one toString but has 2. |
 | switchstmt.c:1:12:1:12 | i | Node should have one toString but has 2. |
 | switchstmt.c:1:12:1:12 | i | Node should have one toString but has 2. |
-| switchstmt.c:1:12:1:12 | i | Node should have one toString but has 2. |
 | switchstmt.c:1:12:1:12 | i indirection | Node should have one toString but has 2. |
 | switchstmt.c:1:12:1:12 | i indirection | Node should have one toString but has 2. |
-| switchstmt.c:1:12:1:12 | x | Node should have one toString but has 2. |
 | switchstmt.c:1:12:1:12 | x | Node should have one toString but has 2. |
 | switchstmt.c:1:12:1:12 | x | Node should have one toString but has 2. |
 | switchstmt.c:1:12:1:12 | x | Node should have one toString but has 2. |


### PR DESCRIPTION
Turns out that we had hardcoded the `container -> iterator` function to receive the container via the qualifier object, when in reality it may very well come from other parameter positions. For example, the `std::back_inserter` function takes a container as the first argument and returns an iterator for the container.

This PR slightly generalizes the predicate that recognizes this situation. Ideally, we'd be able to delegate this work to `ModelUtil.qll`, but the predicates in that file work with `DataFlow::Node`s, and we've yet to construct the actual dataflow nodes at this stage in the analysis. Instead, we only have `Node0`s, so we have to slightly reinvent `ModelUtil.qll` in this piece of code.

As a follow-up in the future, we could consider creating a parameterized-module version of `ModelUtil.qll` so that it can work on both `Node0`s and `Node`s.