### PR TITLE
Fix files that gofmt can't parse

### DIFF
--- a/go/Makefile
+++ b/go/Makefile
@@ -27,8 +27,6 @@ clean:
 	rm -rf tools/bin tools/linux64 tools/osx64 tools/win64 tools/net tools/opencsv
 	rm -rf $(EXTRACTOR_PACK_OUT) build/stats build/testdb
 
-DATAFLOW_BRANCH=main
-
 autoformat:
 	find ql -iregex '.*\.qll?' -print0 | xargs -0 codeql query format -qq -i
 	find . -path '**/vendor' -prune -or -type f -iname '*.go' ! -empty -print0 | xargs -0 grep -L "//\s*autoformat-ignore" | xargs gofmt -w

--- a/go/ql/src/experimental/CWE-285/PamAuthBad.go
+++ b/go/ql/src/experimental/CWE-285/PamAuthBad.go
@@ -1,4 +1,9 @@
-func bad() error {
+package main
+
+import "fmt"
+
+func bad() (string, error) {
+	// ...
 	t, err := pam.StartFunc("", "username", func(s pam.Style, msg string) (string, error) {
 		switch s {
 		case pam.PromptEchoOff:

--- a/go/ql/src/experimental/CWE-285/PamAuthGood.go
+++ b/go/ql/src/experimental/CWE-285/PamAuthGood.go
@@ -1,4 +1,8 @@
-func good() error {
+package main
+
+import "fmt"
+
+func good() (string, error) {
 	t, err := pam.StartFunc("", "username", func(s pam.Style, msg string) (string, error) {
 		switch s {
 		case pam.PromptEchoOff:

--- a/go/ql/src/experimental/CWE-321/HardcodedKeysBad.go
+++ b/go/ql/src/experimental/CWE-321/HardcodedKeysBad.go
@@ -1,9 +1,15 @@
-mySigningKey := []byte("AllYourBase")
+package main
 
-claims := &jwt.RegisteredClaims{
-	ExpiresAt: jwt.NewNumericDate(time.Unix(1516239022, 0)),
-	Issuer:    "test",
+import "time"
+
+func bad() {
+	mySigningKey := []byte("AllYourBase")
+
+	claims := &jwt.RegisteredClaims{
+		ExpiresAt: jwt.NewNumericDate(time.Unix(1516239022, 0)),
+		Issuer:    "test",
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	ss, err := token.SignedString(mySigningKey)
 }
-
-token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
-ss, err := token.SignedString(mySigningKey)

--- a/go/ql/src/experimental/CWE-321/HardcodedKeysGood.go
+++ b/go/ql/src/experimental/CWE-321/HardcodedKeysGood.go
@@ -1,3 +1,10 @@
+package main
+
+import (
+	"math/big"
+	"time"
+)
+
 func GenerateCryptoString(n int) (string, error) {
 	const chars = "123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-"
 	ret := make([]byte, n)
@@ -11,13 +18,14 @@ func GenerateCryptoString(n int) (string, error) {
 	return string(ret), nil
 }
 
-mySigningKey := GenerateCryptoString(64)
+func good() {
+	mySigningKey := GenerateCryptoString(64)
 
+	claims := &jwt.RegisteredClaims{
+		ExpiresAt: jwt.NewNumericDate(time.Unix(1516239022, 0)),
+		Issuer:    "test",
+	}
 
-claims := &jwt.RegisteredClaims{
-	ExpiresAt: jwt.NewNumericDate(time.Unix(1516239022, 0)),
-	Issuer:    "test",
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	ss, err := token.SignedString(mySigningKey)
 }
-
-token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
-ss, err := token.SignedString(mySigningKey)


### PR DESCRIPTION
We have some .go files that gofmt can't parse because they don't start
with "package". This was intentional, as they are fragments to be
included in .qhelp files. They don't affect the return code as gofmt
doesn't change their formatting, so this wasn't changing the result of
the check. However, it was confusing that when the check failed because
some other files weren't formatted correctly, the user would see the
stderr complaining about those files, so we capture stderr.

It would be an improvement to print which files are not formatted
correctly, but that was beyond my abilities with bash and makefiles.