### PR TITLE
JS: use SSA in the GetLaterAccess module

### DIFF
--- a/javascript/ql/lib/semmle/javascript/GlobalAccessPaths.qll
+++ b/javascript/ql/lib/semmle/javascript/GlobalAccessPaths.qll
@@ -271,6 +271,16 @@ module AccessPath {
   /** A module for computing an access to a variable that happens after a property has been written onto it */
   private module GetLaterAccess {
     /**
+     * Gets an reference to the SSA variable `variable`.
+     * Either the definition or a use of the SSA variable
+     */
+    private VarRef getAVariableRef(SsaVariable variable) {
+      result = variable.getAUse()
+      or
+      result = variable.getDefinition().getAContributingVarDef().getTarget()
+    }
+
+    /**
      * Gets an access to a variable that is written to in `write`, where the access is after the write.
      *
      * This allows `fromRhs` to compute an access path for e.g. the below example:
@@ -286,7 +296,7 @@ module AccessPath {
     pragma[noopt]
     DataFlow::Node getLaterBaseAccess(DataFlow::PropWrite write) {
       exists(
-        ControlFlowNode writeNode, BindingPattern access, VarRef otherAccess, Variable variable,
+        ControlFlowNode writeNode, BindingPattern access, VarRef otherAccess, SsaVariable variable,
         StmtContainer container
       |
         access = getBaseVar(write) and
@@ -323,24 +333,23 @@ module AccessPath {
     }
 
     /** Gets an access to `var` inside `container` where `usedInWrite` indicates whether the access is the base of a property write. */
-    private VarRef getAnAccessInContainer(Variable var, StmtContainer container, boolean usedInWrite) {
-      result.getVariable() = var and
+    private VarRef getAnAccessInContainer(
+      SsaVariable var, StmtContainer container, boolean usedInWrite
+    ) {
+      result = getAVariableRef(var) and
       result.getContainer() = container and
-      var.isLocal() and
       if result = getBaseVar(_) then usedInWrite = true else usedInWrite = false
     }
 
     /** Gets a variable that is relevant for the computations in the `GetLaterAccess` module. */
-    private Variable getARelevantVariable() {
+    private SsaVariable getARelevantVariable() {
       // The variable might be used where `getLaterBaseAccess()` is called.
       exists(DataFlow::Node node |
         exists(fromRhs(node, _)) and
-        node.asExpr().(VarAccess).getVariable() = result
+        node.asExpr() = getAVariableRef(result)
       ) and
       // There is a write that writes to the variable.
-      getBaseVar(_).getVariable() = result and
-      // It's local.
-      result.isLocal() and // we skip global variables, because that turns messy quick.
+      getBaseVar(_) = getAVariableRef(result) and
       // There is both a "write" and "read" in the same container of the variable.
       exists(StmtContainer container |
         exists(getAnAccessInContainer(result, container, true)) and // a "write", an access to the variable that is the base of a property reference.
@@ -350,9 +359,9 @@ module AccessPath {
 
     /** Gets a basic-block that has a read of the variable that is written to by `write`, where the basicblock occurs after `start`. */
     private ReachableBasicBlock getASuccessorBBThatReadsVar(DataFlow::PropWrite write) {
-      exists(VarAccess baseExpr, Variable var, ControlFlowNode writeNode |
+      exists(VarRef baseExpr, SsaVariable var, ControlFlowNode writeNode |
         baseExpr = getBaseVar(write) and
-        var = baseExpr.getVariable() and
+        getAVariableRef(var) = baseExpr and
         var = getARelevantVariable() and
         writeNode = write.getWriteNode() and
         writeNode.getBasicBlock().(ReachableBasicBlock).strictlyDominates(result) and

--- a/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection/UnsafeCodeConstruction.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection/UnsafeCodeConstruction.expected
@@ -42,8 +42,11 @@ nodes
 | lib/index.js:112:17:112:21 | taint |
 | lib/index.js:112:17:112:21 | taint |
 | lib/index.js:113:20:113:24 | taint |
+| lib/index.js:115:38:115:42 | taint |
 | lib/index.js:121:34:121:38 | taint |
 | lib/index.js:129:32:129:36 | taint |
+| lib/index.js:135:23:135:49 | this.op ... dOption |
+| lib/index.js:135:23:135:49 | this.op ... dOption |
 | lib/index.js:136:23:136:49 | this.op ... dOption |
 | lib/index.js:136:23:136:49 | this.op ... dOption |
 | lib/index.js:137:23:137:49 | this.op ... dOption |
@@ -94,12 +97,16 @@ edges
 | lib/index.js:98:30:98:34 | taint | lib/index.js:105:21:105:47 | this.op ... dOption |
 | lib/index.js:112:17:112:21 | taint | lib/index.js:113:20:113:24 | taint |
 | lib/index.js:112:17:112:21 | taint | lib/index.js:113:20:113:24 | taint |
+| lib/index.js:112:17:112:21 | taint | lib/index.js:115:38:115:42 | taint |
+| lib/index.js:112:17:112:21 | taint | lib/index.js:115:38:115:42 | taint |
 | lib/index.js:112:17:112:21 | taint | lib/index.js:121:34:121:38 | taint |
 | lib/index.js:112:17:112:21 | taint | lib/index.js:121:34:121:38 | taint |
 | lib/index.js:112:17:112:21 | taint | lib/index.js:129:32:129:36 | taint |
 | lib/index.js:112:17:112:21 | taint | lib/index.js:129:32:129:36 | taint |
 | lib/index.js:113:20:113:24 | taint | lib/index.js:138:23:138:32 | this.taint |
 | lib/index.js:113:20:113:24 | taint | lib/index.js:138:23:138:32 | this.taint |
+| lib/index.js:115:38:115:42 | taint | lib/index.js:135:23:135:49 | this.op ... dOption |
+| lib/index.js:115:38:115:42 | taint | lib/index.js:135:23:135:49 | this.op ... dOption |
 | lib/index.js:121:34:121:38 | taint | lib/index.js:136:23:136:49 | this.op ... dOption |
 | lib/index.js:121:34:121:38 | taint | lib/index.js:136:23:136:49 | this.op ... dOption |
 | lib/index.js:129:32:129:36 | taint | lib/index.js:137:23:137:49 | this.op ... dOption |
@@ -114,6 +121,7 @@ edges
 | lib/index.js:104:21:104:47 | this.op ... dOption | lib/index.js:86:15:86:19 | taint | lib/index.js:104:21:104:47 | this.op ... dOption | This string concatenation which depends on $@ is later $@. | lib/index.js:86:15:86:19 | taint | library input | lib/index.js:104:10:104:67 | "  var  ... ing();" | interpreted as code |
 | lib/index.js:105:21:105:47 | this.op ... dOption | lib/index.js:86:15:86:19 | taint | lib/index.js:105:21:105:47 | this.op ... dOption | This string concatenation which depends on $@ is later $@. | lib/index.js:86:15:86:19 | taint | library input | lib/index.js:105:10:105:67 | "  var  ... ing();" | interpreted as code |
 | lib/index.js:106:21:106:30 | this.taint | lib/index.js:86:15:86:19 | taint | lib/index.js:106:21:106:30 | this.taint | This string concatenation which depends on $@ is later $@. | lib/index.js:86:15:86:19 | taint | library input | lib/index.js:106:10:106:50 | "  var  ... ing();" | interpreted as code |
+| lib/index.js:135:23:135:49 | this.op ... dOption | lib/index.js:112:17:112:21 | taint | lib/index.js:135:23:135:49 | this.op ... dOption | This string concatenation which depends on $@ is later $@. | lib/index.js:112:17:112:21 | taint | library input | lib/index.js:135:12:135:69 | "  var  ... ing();" | interpreted as code |
 | lib/index.js:136:23:136:49 | this.op ... dOption | lib/index.js:112:17:112:21 | taint | lib/index.js:136:23:136:49 | this.op ... dOption | This string concatenation which depends on $@ is later $@. | lib/index.js:112:17:112:21 | taint | library input | lib/index.js:136:12:136:69 | "  var  ... ing();" | interpreted as code |
 | lib/index.js:137:23:137:49 | this.op ... dOption | lib/index.js:112:17:112:21 | taint | lib/index.js:137:23:137:49 | this.op ... dOption | This string concatenation which depends on $@ is later $@. | lib/index.js:112:17:112:21 | taint | library input | lib/index.js:137:12:137:69 | "  var  ... ing();" | interpreted as code |
 | lib/index.js:138:23:138:32 | this.taint | lib/index.js:112:17:112:21 | taint | lib/index.js:138:23:138:32 | this.taint | This string concatenation which depends on $@ is later $@. | lib/index.js:112:17:112:21 | taint | library input | lib/index.js:138:12:138:52 | "  var  ... ing();" | interpreted as code |


### PR DESCRIPTION
Fixes a worst-case behavior in the `getLaterBaseAccess` predicate by using SSA variables.  

Gets the worstcase performance down from 20 minutes (on my laptop), down to milliseconds.  
It was causing timeouts on some smaller runners. 

Also somehow fixed a missing result that I apparently missed when I first implemented `GetLaterAccess` 🤷 

TODO: Evaluations: nightly, problematic, default. 

Problematic project:  
```
metafloor/bwip-js (regress with SSA)
varemenos/codemagic (regress with SSA, smaller)
aakashjhawar/commercial-centers-using-POI (regress before SSA)
```