### PR TITLE
Swift: Remove a no-longer-needed special case from swift/unsafe-js-eval.

### DIFF
--- a/swift/ql/lib/codeql/swift/security/UnsafeJsEvalExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/UnsafeJsEvalExtensions.qll
@@ -96,16 +96,11 @@ private class JSEvaluateScriptDefaultUnsafeJsEvalSink extends UnsafeJsEvalSink {
 }
 
 /**
- * A default SQL injection sanitrizer.
+ * A default SQL injection sanitizer.
  */
 private class DefaultUnsafeJsEvalAdditionalTaintStep extends UnsafeJsEvalAdditionalTaintStep {
   override predicate step(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
     exists(Argument arg |
-      arg =
-        any(CallExpr ce |
-          ce.getStaticTarget().(MethodDecl).hasQualifiedName("String", "init(decoding:as:)")
-        ).getArgument(0)
-      or
       arg =
         any(CallExpr ce |
           ce.getStaticTarget()

--- a/swift/ql/test/query-tests/Security/CWE-094/UnsafeJsEval.expected
+++ b/swift/ql/test/query-tests/Security/CWE-094/UnsafeJsEval.expected
@@ -27,7 +27,6 @@ edges
 | UnsafeJsEval.swift:208:7:208:39 | ... .+(_:_:) ... :  | UnsafeJsEval.swift:279:13:279:13 | string :  |
 | UnsafeJsEval.swift:208:7:208:39 | ... .+(_:_:) ... :  | UnsafeJsEval.swift:285:13:285:13 | string :  |
 | UnsafeJsEval.swift:208:7:208:39 | ... .+(_:_:) ... :  | UnsafeJsEval.swift:299:13:299:13 | string :  |
-| UnsafeJsEval.swift:211:19:211:41 | call to Data.init(_:) :  | UnsafeJsEval.swift:214:7:214:49 | call to String.init(decoding:as:) :  |
 | UnsafeJsEval.swift:211:19:211:41 | call to Data.init(_:) :  | UnsafeJsEval.swift:214:24:214:24 | remoteData :  |
 | UnsafeJsEval.swift:211:24:211:37 | .utf8 :  | UnsafeJsEval.swift:144:5:144:29 | [summary param] 0 in Data.init(_:) :  |
 | UnsafeJsEval.swift:211:24:211:37 | .utf8 :  | UnsafeJsEval.swift:211:19:211:41 | call to Data.init(_:) :  |


### PR DESCRIPTION
Following on from https://github.com/github/codeql/pull/12094 , this PR removes a no-longer-needed special case from the `swift/unsafe-js-eval` query, that is now covered by general purpose models.