### PR TITLE
Java: add sql summary model discovered with heuristics

### DIFF
--- a/java/ql/lib/change-notes/2023-03-20-nativesql-summary.md
+++ b/java/ql/lib/change-notes/2023-03-20-nativesql-summary.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Added a summary model for the `nativeSQL` method of the `java.sql.Connection` interface.

--- a/java/ql/lib/ext/java.sql.model.yml
+++ b/java/ql/lib/ext/java.sql.model.yml
@@ -3,7 +3,6 @@ extensions:
       pack: codeql/java-all
       extensible: sinkModel
     data:
-      # - ["java.sql", "Connection", True, "nativeSQL", "", "", "Argument[0]", "sql", "manual"]
       - ["java.sql", "Connection", True, "prepareCall", "", "", "Argument[0]", "sql", "manual"]
       - ["java.sql", "Connection", True, "prepareStatement", "", "", "Argument[0]", "sql", "manual"]
       - ["java.sql", "DatabaseMetaData", True, "getColumns", "(String,String,String,String)", "", "Argument[2]", "sql", "ai-generated"]

--- a/java/ql/lib/ext/java.sql.model.yml
+++ b/java/ql/lib/ext/java.sql.model.yml
@@ -3,6 +3,7 @@ extensions:
       pack: codeql/java-all
       extensible: sinkModel
     data:
+      # - ["java.sql", "Connection", True, "nativeSQL", "", "", "Argument[0]", "sql", "manual"]
       - ["java.sql", "Connection", True, "prepareCall", "", "", "Argument[0]", "sql", "manual"]
       - ["java.sql", "Connection", True, "prepareStatement", "", "", "Argument[0]", "sql", "manual"]
       - ["java.sql", "DatabaseMetaData", True, "getColumns", "(String,String,String,String)", "", "Argument[2]", "sql", "ai-generated"]
@@ -20,6 +21,7 @@ extensions:
       pack: codeql/java-all
       extensible: summaryModel
     data:
+      - ["java.sql", "Connection", True, "nativeSQL", "", "", "Argument[0]", "ReturnValue", "taint", "manual"]
       - ["java.sql", "PreparedStatement", True, "setString", "(int,String)", "", "Argument[1]", "Argument[this]", "value", "manual"]
       - ["java.sql", "ResultSet", True, "getString", "(String)", "", "Argument[this]", "ReturnValue", "taint", "manual"]
   - addsTo:

--- a/java/ql/lib/ext/java.sql.model.yml
+++ b/java/ql/lib/ext/java.sql.model.yml
@@ -20,7 +20,7 @@ extensions:
       pack: codeql/java-all
       extensible: summaryModel
     data:
-      - ["java.sql", "Connection", True, "nativeSQL", "", "", "Argument[0]", "ReturnValue", "taint", "manual"]
+      - ["java.sql", "Connection", True, "nativeSQL", "(String)", "", "Argument[0]", "ReturnValue", "taint", "manual"]
       - ["java.sql", "PreparedStatement", True, "setString", "(int,String)", "", "Argument[1]", "Argument[this]", "value", "manual"]
       - ["java.sql", "ResultSet", True, "getString", "(String)", "", "Argument[this]", "ReturnValue", "taint", "manual"]
   - addsTo:


### PR DESCRIPTION
This PR adds `java.sql.Connection#nativeSQL(String)` as a summary model. This model was discovered via heuristics.