### PR TITLE
Ruby: Avoid computing `Location::toString` in full

### DIFF
--- a/ruby/ql/lib/codeql/Locations.qll
+++ b/ruby/ql/lib/codeql/Locations.qll
@@ -2,6 +2,15 @@
 
 import files.FileSystem
 
+bindingset[loc]
+pragma[inline_late]
+private string locationToString(Location loc) {
+  exists(string filepath, int startline, int startcolumn, int endline, int endcolumn |
+    loc.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn) and
+    result = filepath + "@" + startline + ":" + startcolumn + ":" + endline + ":" + endcolumn
+  )
+}
+
 /**
  * A location as given by a file, a start line, a start column,
  * an end line, and an end column.
@@ -28,12 +37,8 @@ class Location extends @location {
   int getNumLines() { result = this.getEndLine() - this.getStartLine() + 1 }
 
   /** Gets a textual representation of this element. */
-  string toString() {
-    exists(string filepath, int startline, int startcolumn, int endline, int endcolumn |
-      this.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn) and
-      result = filepath + "@" + startline + ":" + startcolumn + ":" + endline + ":" + endcolumn
-    )
-  }
+  pragma[inline]
+  string toString() { result = locationToString(this) }
 
   /**
    * Holds if this element is at the specified location.

--- a/ruby/ql/lib/codeql/ruby/frameworks/Rails.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/Rails.qll
@@ -303,6 +303,13 @@ private class CookiesSameSiteProtectionSetting extends Settings::NillableStringl
   }
 }
 
+pragma[nomagic]
+private predicate isPotentialRenderCall(MethodCall renderCall, Location loc, ErbFile erbFile) {
+  renderCall.getMethodName() = "render" and
+  loc = renderCall.getLocation() and
+  RenderCallUtils::getTemplateFile(renderCall) = erbFile
+}
+
 // TODO: initialization hooks, e.g. before_configuration, after_initialize...
 // TODO: initializers
 /** A synthetic global to represent the value passed to the `locals` argument of a render call for a specific ERB file. */
@@ -313,10 +320,11 @@ private class LocalAssignsHashSyntheticGlobal extends SummaryComponent::Syntheti
   private MethodCall renderCall;
 
   LocalAssignsHashSyntheticGlobal() {
-    this = "LocalAssignsHashSyntheticGlobal+" + id and
-    id = erbFile.getRelativePath() + "+" + renderCall.getLocation() and
-    renderCall.getMethodName() = "render" and
-    RenderCallUtils::getTemplateFile(renderCall) = erbFile
+    exists(Location loc |
+      this = "LocalAssignsHashSyntheticGlobal+" + id and
+      isPotentialRenderCall(renderCall, loc, erbFile) and
+      id = erbFile.getRelativePath() + "+" + loc
+    )
   }
 
   /** Gets the `ErbFile` which this locals hash is accessible from. */


### PR DESCRIPTION
Computing `Location::toString` in full is not desirable, as it puts a lot of pressure on the string pool.

Before
```
[2023-02-06 19:16:47] Evaluated non-recursive predicate Locations#e31d5b03::Location::toString#0#dispred#ff@3dda59o1 in 80206ms (size: 31304525).
Evaluated relational algebra for predicate Locations#e31d5b03::Location::toString#0#dispred#ff@3dda59o1 with tuple counts:
        31304525  ~1%    {2} r1 = SCAN Locations#e31d5b03::Location::hasLocationInfo#5#dispred#ffffff OUTPUT In.0, (In.1 ++ "@" ++ toString(In.2) ++ ":" ++ toString(In.3) ++ ":" ++ toString(In.4) ++ ":" ++ toString(In.5))
                         return r1
```

After
```
[2023-02-06 18:50:57] Evaluated non-recursive predicate Rails#a086b70b::LocalAssignsHashSyntheticGlobal#ffff@1931101m in 194ms (size: 8515).
Evaluated relational algebra for predicate Rails#a086b70b::LocalAssignsHashSyntheticGlobal#ffff@1931101m with tuple counts:
        37520  ~3%    {2} r1 = SCAN FileSystem#e91ad87f::Container::getRelativePath#0#dispred#ff OUTPUT In.0, (In.1 ++ "+")
         8515  ~4%    {4} r2 = JOIN r1 WITH Rails#a086b70b::isRenderCall#3#fff_201#join_rhs ON FIRST 1 OUTPUT Rhs.2, Lhs.0, Lhs.1, Rhs.1
         8515  ~0%    {4} r3 = JOIN r2 WITH Locations#e31d5b03::Location::hasLocationInfo#5#dispred#ffffff ON FIRST 1 OUTPUT ("LocalAssignsHashSyntheticGlobal+" ++ (Lhs.2 ++ (Rhs.1 ++ "@" ++ toString(Rhs.2) ++ ":" ++ toString(Rhs.3) ++ ":" ++ toString(Rhs.4) ++ ":" ++ toString(Rhs.5)))), Lhs.1, (Lhs.2 ++ (Rhs.1 ++ "@" ++ toString(Rhs.2) ++ ":" ++ toString(Rhs.3) ++ ":" ++ toString(Rhs.4) ++ ":" ++ toString(Rhs.5))), Lhs.3
                      return r3
```