### PR TITLE
TypeTracker: Improve join for `step`

### DIFF
--- a/python/ql/lib/semmle/python/dataflow/new/internal/TypeTracker.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/TypeTracker.qll
@@ -61,6 +61,7 @@ private module Cached {
   }
 
   /** Gets the summary resulting from appending `step` to type-tracking summary `tt`. */
+  pragma[nomagic]
   cached
   TypeTracker append(TypeTracker tt, StepSummary step) {
     exists(Boolean hasCall, OptionalTypeTrackerContent currentContents |
@@ -114,6 +115,7 @@ private module Cached {
   }
 
   /** Gets the summary resulting from prepending `step` to this type-tracking summary. */
+  pragma[nomagic]
   cached
   TypeBackTracker prepend(TypeBackTracker tbt, StepSummary step) {
     exists(Boolean hasReturn, OptionalTypeTrackerContent content |

--- a/python/ql/lib/semmle/python/dataflow/new/internal/TypeTracker.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/TypeTracker.qll
@@ -567,11 +567,11 @@ class TypeBackTracker extends TTypeBackTracker {
    * Gets the summary that corresponds to having taken a backwards
    * heap and/or inter-procedural step from `nodeTo` to `nodeFrom`.
    */
-  bindingset[nodeTo, this]
+  bindingset[nodeTo, result]
   TypeBackTracker step(TypeTrackingNode nodeFrom, TypeTrackingNode nodeTo) {
     exists(StepSummary summary |
       StepSummary::step(_, pragma[only_bind_out](nodeTo), pragma[only_bind_into](summary)) and
-      result = pragma[only_bind_into](pragma[only_bind_out](this)).prepend(summary) and
+      this = pragma[only_bind_into](pragma[only_bind_out](result)).prepend(summary) and
       StepSummary::step(nodeFrom, pragma[only_bind_into](pragma[only_bind_out](nodeTo)), summary)
     )
   }
@@ -600,11 +600,11 @@ class TypeBackTracker extends TTypeBackTracker {
    * }
    * ```
    */
-  bindingset[nodeTo, this]
+  bindingset[nodeTo, result]
   TypeBackTracker smallstep(Node nodeFrom, Node nodeTo) {
     exists(StepSummary summary |
       StepSummary::smallstep(_, pragma[only_bind_out](nodeTo), pragma[only_bind_into](summary)) and
-      result = pragma[only_bind_into](pragma[only_bind_out](this)).prepend(summary) and
+      this = pragma[only_bind_into](pragma[only_bind_out](result)).prepend(summary) and
       StepSummary::smallstep(nodeFrom, pragma[only_bind_into](pragma[only_bind_out](nodeTo)),
         summary)
     )

--- a/python/ql/lib/semmle/python/dataflow/new/internal/TypeTracker.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/TypeTracker.qll
@@ -306,7 +306,7 @@ module StepSummary {
    * to non-linear recursion for the parts of `step` that involve the
    * call graph.
    */
-  pragma[inline]
+  pragma[nomagic]
   predicate step(TypeTrackingNode nodeFrom, TypeTrackingNode nodeTo, StepSummary summary) {
     stepNoCall(nodeFrom, nodeTo, summary)
     or
@@ -320,7 +320,7 @@ module StepSummary {
    * Unlike `StepSummary::step`, this predicate does not compress
    * type-preserving steps.
    */
-  pragma[inline]
+  pragma[nomagic]
   predicate smallstep(Node nodeFrom, TypeTrackingNode nodeTo, StepSummary summary) {
     smallstepNoCall(nodeFrom, nodeTo, summary)
     or
@@ -429,11 +429,12 @@ class TypeTracker extends TTypeTracker {
    * Gets the summary that corresponds to having taken a forwards
    * heap and/or inter-procedural step from `nodeFrom` to `nodeTo`.
    */
-  pragma[inline]
+  bindingset[nodeFrom, this]
   TypeTracker step(TypeTrackingNode nodeFrom, TypeTrackingNode nodeTo) {
     exists(StepSummary summary |
-      StepSummary::step(nodeFrom, pragma[only_bind_out](nodeTo), pragma[only_bind_into](summary)) and
-      result = this.append(pragma[only_bind_into](summary))
+      StepSummary::step(pragma[only_bind_out](nodeFrom), _, pragma[only_bind_into](summary)) and
+      result = pragma[only_bind_into](pragma[only_bind_out](this)).append(summary) and
+      StepSummary::step(pragma[only_bind_into](pragma[only_bind_out](nodeFrom)), nodeTo, summary)
     )
   }
 
@@ -461,11 +462,13 @@ class TypeTracker extends TTypeTracker {
    * }
    * ```
    */
-  pragma[inline]
+  bindingset[nodeFrom, this]
   TypeTracker smallstep(Node nodeFrom, Node nodeTo) {
     exists(StepSummary summary |
-      StepSummary::smallstep(nodeFrom, nodeTo, summary) and
-      result = this.append(summary)
+      StepSummary::smallstep(pragma[only_bind_out](nodeFrom), _, pragma[only_bind_into](summary)) and
+      result = pragma[only_bind_into](pragma[only_bind_out](this)).append(summary) and
+      StepSummary::smallstep(pragma[only_bind_into](pragma[only_bind_out](nodeFrom)), nodeTo,
+        summary)
     )
     or
     simpleLocalFlowStep(nodeFrom, nodeTo) and
@@ -562,11 +565,12 @@ class TypeBackTracker extends TTypeBackTracker {
    * Gets the summary that corresponds to having taken a backwards
    * heap and/or inter-procedural step from `nodeTo` to `nodeFrom`.
    */
-  pragma[inline]
+  bindingset[nodeTo, this]
   TypeBackTracker step(TypeTrackingNode nodeFrom, TypeTrackingNode nodeTo) {
     exists(StepSummary summary |
-      StepSummary::step(pragma[only_bind_out](nodeFrom), nodeTo, pragma[only_bind_into](summary)) and
-      this = result.prepend(pragma[only_bind_into](summary))
+      StepSummary::step(_, pragma[only_bind_out](nodeTo), pragma[only_bind_into](summary)) and
+      result = pragma[only_bind_into](pragma[only_bind_out](this)).prepend(summary) and
+      StepSummary::step(nodeFrom, pragma[only_bind_into](pragma[only_bind_out](nodeTo)), summary)
     )
   }
 
@@ -594,11 +598,13 @@ class TypeBackTracker extends TTypeBackTracker {
    * }
    * ```
    */
-  pragma[inline]
+  bindingset[nodeTo, this]
   TypeBackTracker smallstep(Node nodeFrom, Node nodeTo) {
     exists(StepSummary summary |
-      StepSummary::smallstep(nodeFrom, nodeTo, summary) and
-      this = result.prepend(summary)
+      StepSummary::smallstep(_, pragma[only_bind_out](nodeTo), pragma[only_bind_into](summary)) and
+      result = pragma[only_bind_into](pragma[only_bind_out](this)).prepend(summary) and
+      StepSummary::smallstep(nodeFrom, pragma[only_bind_into](pragma[only_bind_out](nodeTo)),
+        summary)
     )
     or
     simpleLocalFlowStep(nodeFrom, nodeTo) and

--- a/ruby/ql/lib/codeql/ruby/typetracking/TypeTracker.qll
+++ b/ruby/ql/lib/codeql/ruby/typetracking/TypeTracker.qll
@@ -61,6 +61,7 @@ private module Cached {
   }
 
   /** Gets the summary resulting from appending `step` to type-tracking summary `tt`. */
+  pragma[nomagic]
   cached
   TypeTracker append(TypeTracker tt, StepSummary step) {
     exists(Boolean hasCall, OptionalTypeTrackerContent currentContents |
@@ -114,6 +115,7 @@ private module Cached {
   }
 
   /** Gets the summary resulting from prepending `step` to this type-tracking summary. */
+  pragma[nomagic]
   cached
   TypeBackTracker prepend(TypeBackTracker tbt, StepSummary step) {
     exists(Boolean hasReturn, OptionalTypeTrackerContent content |
@@ -565,11 +567,11 @@ class TypeBackTracker extends TTypeBackTracker {
    * Gets the summary that corresponds to having taken a backwards
    * heap and/or inter-procedural step from `nodeTo` to `nodeFrom`.
    */
-  bindingset[nodeTo, this]
+  bindingset[nodeTo, result]
   TypeBackTracker step(TypeTrackingNode nodeFrom, TypeTrackingNode nodeTo) {
     exists(StepSummary summary |
       StepSummary::step(_, pragma[only_bind_out](nodeTo), pragma[only_bind_into](summary)) and
-      result = pragma[only_bind_into](pragma[only_bind_out](this)).prepend(summary) and
+      this = pragma[only_bind_into](pragma[only_bind_out](result)).prepend(summary) and
       StepSummary::step(nodeFrom, pragma[only_bind_into](pragma[only_bind_out](nodeTo)), summary)
     )
   }
@@ -598,11 +600,11 @@ class TypeBackTracker extends TTypeBackTracker {
    * }
    * ```
    */
-  bindingset[nodeTo, this]
+  bindingset[nodeTo, result]
   TypeBackTracker smallstep(Node nodeFrom, Node nodeTo) {
     exists(StepSummary summary |
       StepSummary::smallstep(_, pragma[only_bind_out](nodeTo), pragma[only_bind_into](summary)) and
-      result = pragma[only_bind_into](pragma[only_bind_out](this)).prepend(summary) and
+      this = pragma[only_bind_into](pragma[only_bind_out](result)).prepend(summary) and
       StepSummary::smallstep(nodeFrom, pragma[only_bind_into](pragma[only_bind_out](nodeTo)),
         summary)
     )

--- a/ruby/ql/lib/codeql/ruby/typetracking/TypeTracker.qll
+++ b/ruby/ql/lib/codeql/ruby/typetracking/TypeTracker.qll
@@ -306,7 +306,7 @@ module StepSummary {
    * to non-linear recursion for the parts of `step` that involve the
    * call graph.
    */
-  pragma[inline]
+  pragma[nomagic]
   predicate step(TypeTrackingNode nodeFrom, TypeTrackingNode nodeTo, StepSummary summary) {
     stepNoCall(nodeFrom, nodeTo, summary)
     or
@@ -320,7 +320,7 @@ module StepSummary {
    * Unlike `StepSummary::step`, this predicate does not compress
    * type-preserving steps.
    */
-  pragma[inline]
+  pragma[nomagic]
   predicate smallstep(Node nodeFrom, TypeTrackingNode nodeTo, StepSummary summary) {
     smallstepNoCall(nodeFrom, nodeTo, summary)
     or
@@ -429,11 +429,12 @@ class TypeTracker extends TTypeTracker {
    * Gets the summary that corresponds to having taken a forwards
    * heap and/or inter-procedural step from `nodeFrom` to `nodeTo`.
    */
-  pragma[inline]
+  bindingset[nodeFrom, this]
   TypeTracker step(TypeTrackingNode nodeFrom, TypeTrackingNode nodeTo) {
     exists(StepSummary summary |
-      StepSummary::step(nodeFrom, pragma[only_bind_out](nodeTo), pragma[only_bind_into](summary)) and
-      result = this.append(pragma[only_bind_into](summary))
+      StepSummary::step(pragma[only_bind_out](nodeFrom), _, pragma[only_bind_into](summary)) and
+      result = pragma[only_bind_into](pragma[only_bind_out](this)).append(summary) and
+      StepSummary::step(pragma[only_bind_into](pragma[only_bind_out](nodeFrom)), nodeTo, summary)
     )
   }
 
@@ -461,11 +462,13 @@ class TypeTracker extends TTypeTracker {
    * }
    * ```
    */
-  pragma[inline]
+  bindingset[nodeFrom, this]
   TypeTracker smallstep(Node nodeFrom, Node nodeTo) {
     exists(StepSummary summary |
-      StepSummary::smallstep(nodeFrom, nodeTo, summary) and
-      result = this.append(summary)
+      StepSummary::smallstep(pragma[only_bind_out](nodeFrom), _, pragma[only_bind_into](summary)) and
+      result = pragma[only_bind_into](pragma[only_bind_out](this)).append(summary) and
+      StepSummary::smallstep(pragma[only_bind_into](pragma[only_bind_out](nodeFrom)), nodeTo,
+        summary)
     )
     or
     simpleLocalFlowStep(nodeFrom, nodeTo) and
@@ -562,11 +565,12 @@ class TypeBackTracker extends TTypeBackTracker {
    * Gets the summary that corresponds to having taken a backwards
    * heap and/or inter-procedural step from `nodeTo` to `nodeFrom`.
    */
-  pragma[inline]
+  bindingset[nodeTo, this]
   TypeBackTracker step(TypeTrackingNode nodeFrom, TypeTrackingNode nodeTo) {
     exists(StepSummary summary |
-      StepSummary::step(pragma[only_bind_out](nodeFrom), nodeTo, pragma[only_bind_into](summary)) and
-      this = result.prepend(pragma[only_bind_into](summary))
+      StepSummary::step(_, pragma[only_bind_out](nodeTo), pragma[only_bind_into](summary)) and
+      result = pragma[only_bind_into](pragma[only_bind_out](this)).prepend(summary) and
+      StepSummary::step(nodeFrom, pragma[only_bind_into](pragma[only_bind_out](nodeTo)), summary)
     )
   }
 
@@ -594,11 +598,13 @@ class TypeBackTracker extends TTypeBackTracker {
    * }
    * ```
    */
-  pragma[inline]
+  bindingset[nodeTo, this]
   TypeBackTracker smallstep(Node nodeFrom, Node nodeTo) {
     exists(StepSummary summary |
-      StepSummary::smallstep(nodeFrom, nodeTo, summary) and
-      this = result.prepend(summary)
+      StepSummary::smallstep(_, pragma[only_bind_out](nodeTo), pragma[only_bind_into](summary)) and
+      result = pragma[only_bind_into](pragma[only_bind_out](this)).prepend(summary) and
+      StepSummary::smallstep(nodeFrom, pragma[only_bind_into](pragma[only_bind_out](nodeTo)),
+        summary)
     )
     or
     simpleLocalFlowStep(nodeFrom, nodeTo) and


### PR DESCRIPTION
Based on the work that `@aschackmull` did, specifically this part:
    https://github.com/github/codeql/blob/a29e5296909fd79f0b9877ef42cc2005efbba889/shared/typetracking/codeql/typetracking/TypeTracking.qll#L556-L563