### PR TITLE
Update telemetry privacy document for UI interaction and exceptions

### DIFF
--- a/docs/codeql/codeql-for-visual-studio-code/about-telemetry-in-codeql-for-visual-studio-code.rst
+++ b/docs/codeql/codeql-for-visual-studio-code/about-telemetry-in-codeql-for-visual-studio-code.rst
@@ -21,11 +21,11 @@ If you opt in, GitHub collects the following information related to the usage of
 
 - The identifiers of any CodeQL-related VS Code commands that are run.
     - For each command: the timestamp, time taken, and whether or not the command completed successfully.
-- Usage of UI elements, including buttons, links, and other inputs.
-    - The contents of links or text inputs is not recorded.
-    - Mouse movement and hovering is not recorded.
-- Occurrence of exceptions and error.
-    - All sensitive information such as file paths or non-static exception message content is removed before uploading.
+- Interactions with UI elements, including buttons, links, and other inputs.
+    - Link targets and text inputs are not recorded.
+    - Mouse movement and hovering are not recorded.
+- Occurrence of exceptions and errors.
+    - All sensitive information such as file paths and non-static exception message content are removed before uploading.
 - VS Code and extension version.
 - Randomly generated GUID that uniquely identifies a CodeQL extension installation. (Discarded before aggregation.)
 - IP address of the client sending the telemetry data. (Discarded before aggregation.)
@@ -51,6 +51,7 @@ We only collect the minimal amount of data we need to answer the questions about
 - No contents of CodeQL queries
 - No filesystem paths
 - No user-input text
+- No mouse interactions, such as movement or hovers
 
 Disabling telemetry reporting
 ------------------------------

--- a/docs/codeql/codeql-for-visual-studio-code/about-telemetry-in-codeql-for-visual-studio-code.rst
+++ b/docs/codeql/codeql-for-visual-studio-code/about-telemetry-in-codeql-for-visual-studio-code.rst
@@ -20,7 +20,12 @@ What data is collected
 If you opt in, GitHub collects the following information related to the usage of the extension. The data collected are:
 
 - The identifiers of any CodeQL-related VS Code commands that are run.
-- For each command: the timestamp, time taken, and whether or not the command completed successfully.
+    - For each command: the timestamp, time taken, and whether or not the command completed successfully.
+- Usage of UI elements, including buttons, links, and other inputs.
+    - The contents of links or text inputs is not recorded.
+    - Mouse movement and hovering is not recorded.
+- Occurrence of exceptions and error.
+    - All sensitive information such as file paths or non-static exception message content is removed before uploading.
 - VS Code and extension version.
 - Randomly generated GUID that uniquely identifies a CodeQL extension installation. (Discarded before aggregation.)
 - IP address of the client sending the telemetry data. (Discarded before aggregation.)
@@ -45,6 +50,7 @@ We only collect the minimal amount of data we need to answer the questions about
 - No CodeQL database names or contents
 - No contents of CodeQL queries
 - No filesystem paths
+- No user-input text
 
 Disabling telemetry reporting
 ------------------------------


### PR DESCRIPTION
Updates the document describing what telemetry we collect from the CodeQL VS Code extension.

Don't be afraid to suggest rewriting what I've put here. I wasn't really sure how to fit in with the existing style. I also wasn't sure how to split information between the "what we include" and "what we don't include" sections.

@jf205 and @github/code-scanning-secexp 