### PR TITLE
Go: Consolidate repeated calls to `matches` and `regexpMatch`

### DIFF
--- a/go/ql/lib/semmle/go/Comments.qll
+++ b/go/ql/lib/semmle/go/Comments.qll
@@ -208,12 +208,8 @@ class BuildConstraintComment extends LineComment {
       this = getInitialComment(f, i) and
       not getInitialComment(f, [0 .. i - 1]) instanceof BlockComment
     ) and
-    (
-      // comment text starts with `+build` or `go:build`
-      this.getText().regexpMatch("\\s*\\+build.*")
-      or
-      this.getText().regexpMatch("\\s*go:build.*")
-    )
+    // comment text starts with `+build` or `go:build`
+    this.getText().regexpMatch("\\s*(\\+|go:)build.*")
   }
 
   override string getAPrimaryQlClass() { result = "BuildConstraintComment" }

--- a/go/ql/lib/semmle/go/frameworks/Logrus.qll
+++ b/go/ql/lib/semmle/go/frameworks/Logrus.qll
@@ -11,10 +11,7 @@ module Logrus {
 
   bindingset[result]
   private string getALogResultName() {
-    result
-        .matches([
-            "Debug%", "Error%", "Fatal%", "Info%", "Log%", "Panic%", "Print%", "Trace%", "Warn%"
-          ])
+    result.regexpMatch("(Debug|Error|Fatal|Info|Log|Panic|Print|Trace|Warn).*")
   }
 
   bindingset[result]

--- a/go/ql/lib/semmle/go/frameworks/Revel.qll
+++ b/go/ql/lib/semmle/go/frameworks/Revel.qll
@@ -91,7 +91,7 @@ module Revel {
   }
 
   private string contentTypeFromFilename(DataFlow::Node filename) {
-    if filename.getStringValue().toLowerCase().matches(["%.htm", "%.html"])
+    if filename.getStringValue().regexpMatch("(?i).*\\.html?")
     then result = "text/html"
     else result = "application/octet-stream"
     // Actually Revel can figure out a variety of other content-types, but none of our analyses care to

--- a/go/ql/lib/semmle/go/security/SensitiveActions.qll
+++ b/go/ql/lib/semmle/go/security/SensitiveActions.qll
@@ -233,10 +233,9 @@ module PasswordHeuristics {
   predicate isDummyPassword(string password) {
     password.length() < 4
     or
-    exists(string normalized | normalized = password.toLowerCase() |
-      count(normalized.charAt(_)) = 1 or
-      normalized
-          .regexpMatch(".*(pass|test|sample|example|secret|root|admin|user|change|auth|redacted|0123456789).*")
-    )
+    count(password.charAt(_)) <= 2 // aaaaaaaa or bBbBbB or ghghghghghgh or the like
+    or
+    password
+        .regexpMatch("(?i).*(pass|test|sample|example|secret|root|admin|user|change|auth|redacted|0123456789).*")
   }
 }

--- a/go/ql/src/Security/CWE-209/StackTraceExposure.ql
+++ b/go/ql/src/Security/CWE-209/StackTraceExposure.ql
@@ -26,10 +26,7 @@ class DebugModeFlag extends FlagKind {
 
   bindingset[result]
   override string getAFlagName() {
-    result
-        .toLowerCase()
-        .matches("%" + ["trace", "debug", "devel", "enablestack", "disablestack", "printstack"] +
-            "%")
+    result.regexpMatch("(?i).*(trace|debug|devel|((en|dis)able|print)stack).*")
   }
 }
 

--- a/go/ql/src/Security/CWE-295/DisabledCertificateCheck.ql
+++ b/go/ql/src/Security/CWE-295/DisabledCertificateCheck.ql
@@ -45,7 +45,7 @@ class InsecureCertificateFlag extends FlagKind {
 
   bindingset[result]
   override string getAFlagName() {
-    result.toLowerCase().matches("%" + ["selfcert", "selfsign", "validat", "verif", "trust"] + "%")
+    result.regexpMatch("(?i).*(selfcert|selfsign|validat|verif|trust).*")
   }
 }
 

--- a/go/ql/src/Security/CWE-327/InsecureTLS.ql
+++ b/go/ql/src/Security/CWE-327/InsecureTLS.ql
@@ -240,9 +240,7 @@ class LegacyTlsVersionFlag extends FlagKind {
   LegacyTlsVersionFlag() { this = "legacyTlsVersion" }
 
   bindingset[result]
-  override string getAFlagName() {
-    result.toLowerCase().matches("%" + ["old", "intermediate", "legacy"] + "%")
-  }
+  override string getAFlagName() { result.regexpMatch("(?i).*(old|intermediate|legacy).*") }
 }
 
 /**

--- a/go/ql/src/experimental/CWE-942/CorsMisconfiguration.ql
+++ b/go/ql/src/experimental/CWE-942/CorsMisconfiguration.ql
@@ -23,9 +23,7 @@ class AllowedFlag extends FlagKind {
 
   bindingset[result]
   override string getAFlagName() {
-    result
-        .toLowerCase()
-        .matches("%" + ["allow", "match", "check", "debug", "devel", "insecure"] + "%")
+    result.regexpMatch("(?i).*(allow|match|check|debug|devel|insecure).*")
   }
 }
 


### PR DESCRIPTION
This is especially useful if it avoids temporary string construction, such as `toLowerCase().matches(...)`

Thanks to @nickrolfe for pointing us in this direction