### PR TITLE
Go: Downgrade `go/log-injection` precision to medium

### DIFF
--- a/go/ql/src/Security/CWE-117/LogInjection.ql
+++ b/go/ql/src/Security/CWE-117/LogInjection.ql
@@ -5,7 +5,7 @@
  * @kind path-problem
  * @problem.severity error
  * @security-severity 7.8
- * @precision high
+ * @precision medium
  * @id go/log-injection
  * @tags security
  *       external/cwe/cwe-117

--- a/go/ql/src/change-notes/2023-02-09-log-injection-precision.md
+++ b/go/ql/src/change-notes/2023-02-09-log-injection-precision.md
@@ -1,0 +1,4 @@
+---
+category: queryMetadata
+---
+* The precision of the `go/log-injection` query was decreased from `high` to `medium`, since it may not be able to identify every way in which log data may be sanitized. This also aligns it with the precision of comparable queries for other languages.


### PR DESCRIPTION
This is a cherry-picked commit from #11739 which downgrades the precision of the `go/log-injection` query to `medium`. This is in line with the same query for other languages. 