### PR TITLE
Remove unused class in Java query PropertiesCleartextStorage

### DIFF
--- a/java/ql/lib/semmle/code/java/security/CleartextStoragePropertiesQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/CleartextStoragePropertiesQuery.qll
@@ -5,14 +5,6 @@ import semmle.code.java.dataflow.DataFlow
 import semmle.code.java.frameworks.Properties
 import semmle.code.java.security.CleartextStorageQuery
 
-private class PropertiesCleartextStorageSink extends CleartextStorageSink {
-  PropertiesCleartextStorageSink() {
-    exists(MethodAccess m |
-      m.getMethod() instanceof PropertiesSetPropertyMethod and this.asExpr() = m.getArgument(1)
-    )
-  }
-}
-
 /** The instantiation of a `Properties` object, which can be stored to disk. */
 class Properties extends Storable, ClassInstanceExpr {
   Properties() { this.getConstructor().getDeclaringType() instanceof TypeProperty }


### PR DESCRIPTION
I think that this class was not needed

it was not used anywhere, seems like it was a residual duplicate of `propertiesInput` predicate in the same lib

I suspect it will be safe to remove since it was a private class, but double check me on that! (if I am wrong, feel free to close)

if I am correct, looks like [this](https://github.com/github/codeql/blob/main/java/ql/lib/semmle/code/java/security/CleartextStorageCookieQuery.qll#L8) can go also?

just trying to make these libs even easier to read