### PR TITLE
C++: Do not mark global indirect flow as spurious in dataflow tests

### DIFF
--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
@@ -563,18 +563,18 @@ namespace IndirectFlowThroughGlobals {
   }
 
   void f() {
-    sink(*globalInt); // $ ir=562:17 ir=576:17 // tainted or clean? Not sure.
+    sink(*globalInt); // $ ir=562:17 ir=576:17
     taintGlobal();
-    sink(*globalInt); // $ ir=562:17 MISSING: ast=562:17 SPURIOUS: ir=576:17
+    sink(*globalInt); // $ ir=562:17 ir=576:17 MISSING: ast=562:17 
   }
 
   void calledAfterTaint() {
-    sink(*globalInt); // $ ir=576:17 MISSING: ast=576:17 SPURIOUS: ir=562:17
+    sink(*globalInt); // $ ir=576:17 ir=562:17 MISSING: ast=576:17 
   }
 
   void taintAndCall() {
     globalInt = indirect_source();
     calledAfterTaint();
-    sink(*globalInt); // $ ir=576:17 MISSING: ast=576:17 SPURIOUS: ir=562:17
+    sink(*globalInt); // $ ir=576:17 ir=562:17 MISSING: ast=576:17 
   }
 }

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
@@ -563,18 +563,18 @@ namespace IndirectFlowThroughGlobals {
   }
 
   void f() {
-    sink(*globalInt); // $ ir=562:17 ir=576:17
+    sink(*globalInt); // $ ir=562:17 ir=576:17 MISSING: ast=562:17 ast=576:17
     taintGlobal();
-    sink(*globalInt); // $ ir=562:17 ir=576:17 MISSING: ast=562:17 
+    sink(*globalInt); // $ ir=562:17 ir=576:17 MISSING: ast=562:17 ast=576:17
   }
 
   void calledAfterTaint() {
-    sink(*globalInt); // $ ir=576:17 ir=562:17 MISSING: ast=576:17 
+    sink(*globalInt); // $ ir=562:17 ir=576:17 MISSING: ast=562:17 ast=576:17
   }
 
   void taintAndCall() {
     globalInt = indirect_source();
     calledAfterTaint();
-    sink(*globalInt); // $ ir=576:17 ir=562:17 MISSING: ast=576:17 
+    sink(*globalInt); // $ ir=562:17 ir=576:17 MISSING: ast=562:17 ast=576:17
   }
 }


### PR DESCRIPTION
Follow-up from https://github.com/github/codeql/pull/11171#issuecomment-1416330327