### PR TITLE
C# 11: Test of relaxed shift operator requirements.

### DIFF
--- a/csharp/ql/test/library-tests/csharp11/PrintAst.expected
+++ b/csharp/ql/test/library-tests/csharp11/PrintAst.expected
@@ -343,6 +343,102 @@ PatternMatchSpan.cs:
 #   16|         2: [DefaultCase] default:
 #   16|         3: [BlockStmt] {...}
 #   16|           0: [BreakStmt] break;
+RelaxedShift.cs:
+#    1| [Interface] IShiftOperators<,,>
+#-----|   1: (Type parameters)
+#    1|     0: [TypeParameter] TSelf
+#    1|     1: [TypeParameter] TOther
+#    1|     2: [TypeParameter] TReturn
+#    3|   4: [LeftShiftOperator] <<
+#    3|     -1: [TypeMention] TReturn
+#-----|     2: (Parameters)
+#    3|       0: [Parameter] value
+#    3|         -1: [TypeMention] TSelf
+#    3|       1: [Parameter] shiftAmount
+#    3|         -1: [TypeMention] TOther
+#    5|   5: [RightShiftOperator] >>
+#    5|     -1: [TypeMention] TReturn
+#-----|     2: (Parameters)
+#    5|       0: [Parameter] value
+#    5|         -1: [TypeMention] TSelf
+#    5|       1: [Parameter] shiftAmount
+#    5|         -1: [TypeMention] TOther
+#    7|   6: [UnsignedRightShiftOperator] >>>
+#    7|     -1: [TypeMention] TReturn
+#-----|     2: (Parameters)
+#    7|       0: [Parameter] value
+#    7|         -1: [TypeMention] TSelf
+#    7|       1: [Parameter] shiftAmount
+#    7|         -1: [TypeMention] TOther
+#   10| [Class] Number
+#-----|   3: (Base types)
+#   12|   5: [LeftShiftOperator] <<
+#   12|     -1: [TypeMention] Number
+#-----|     2: (Parameters)
+#   12|       0: [Parameter] value
+#   12|         -1: [TypeMention] Number
+#   12|       1: [Parameter] shiftAmount
+#   12|         -1: [TypeMention] string
+#   12|     4: [ParameterAccess] access to parameter value
+#   14|   6: [RightShiftOperator] >>
+#   14|     -1: [TypeMention] Number
+#-----|     2: (Parameters)
+#   14|       0: [Parameter] value
+#   14|         -1: [TypeMention] Number
+#   14|       1: [Parameter] shiftAmount
+#   14|         -1: [TypeMention] string
+#   14|     4: [ParameterAccess] access to parameter value
+#   16|   7: [UnsignedRightShiftOperator] >>>
+#   16|     -1: [TypeMention] Number
+#-----|     2: (Parameters)
+#   16|       0: [Parameter] value
+#   16|         -1: [TypeMention] Number
+#   16|       1: [Parameter] shiftAmount
+#   16|         -1: [TypeMention] string
+#   16|     4: [ParameterAccess] access to parameter value
+#   19| [Class] TestRelaxedShift
+#   21|   5: [Method] M1
+#   21|     -1: [TypeMention] Void
+#   22|     4: [BlockStmt] {...}
+#   23|       0: [LocalVariableDeclStmt] ... ...;
+#   23|         0: [LocalVariableDeclAndInitExpr] Number n11 = ...
+#   23|           -1: [TypeMention] Number
+#   23|           0: [LocalVariableAccess] access to local variable n11
+#   23|           1: [ObjectCreation] object creation of type Number
+#   23|             0: [TypeMention] Number
+#   24|       1: [LocalVariableDeclStmt] ... ...;
+#   24|         0: [LocalVariableDeclAndInitExpr] Number n12 = ...
+#   24|           -1: [TypeMention] Number
+#   24|           0: [LocalVariableAccess] access to local variable n12
+#   24|           1: [OperatorCall] call to operator <<
+#   24|             0: [LocalVariableAccess] access to local variable n11
+#   24|             1: [StringLiteralUtf16] "1"
+#   26|       2: [LocalVariableDeclStmt] ... ...;
+#   26|         0: [LocalVariableDeclAndInitExpr] Number n21 = ...
+#   26|           -1: [TypeMention] Number
+#   26|           0: [LocalVariableAccess] access to local variable n21
+#   26|           1: [ObjectCreation] object creation of type Number
+#   26|             0: [TypeMention] Number
+#   27|       3: [LocalVariableDeclStmt] ... ...;
+#   27|         0: [LocalVariableDeclAndInitExpr] Number n22 = ...
+#   27|           -1: [TypeMention] Number
+#   27|           0: [LocalVariableAccess] access to local variable n22
+#   27|           1: [OperatorCall] call to operator >>
+#   27|             0: [LocalVariableAccess] access to local variable n21
+#   27|             1: [StringLiteralUtf16] "2"
+#   29|       4: [LocalVariableDeclStmt] ... ...;
+#   29|         0: [LocalVariableDeclAndInitExpr] Number n31 = ...
+#   29|           -1: [TypeMention] Number
+#   29|           0: [LocalVariableAccess] access to local variable n31
+#   29|           1: [ObjectCreation] object creation of type Number
+#   29|             0: [TypeMention] Number
+#   30|       5: [LocalVariableDeclStmt] ... ...;
+#   30|         0: [LocalVariableDeclAndInitExpr] Number n32 = ...
+#   30|           -1: [TypeMention] Number
+#   30|           0: [LocalVariableAccess] access to local variable n32
+#   30|           1: [OperatorCall] call to operator >>>
+#   30|             0: [LocalVariableAccess] access to local variable n31
+#   30|             1: [StringLiteralUtf16] "3"
 Scoped.cs:
 #    1| [Struct] S1
 #    2| [Struct] S2

--- a/csharp/ql/test/library-tests/csharp11/RelaxedShift.cs
+++ b/csharp/ql/test/library-tests/csharp11/RelaxedShift.cs
@@ -1,0 +1,32 @@
+public interface IShiftOperators<TSelf, TOther, TReturn> where TSelf : IShiftOperators<TSelf, TOther, TReturn>
+{
+    public static abstract TReturn operator <<(TSelf value, TOther shiftAmount);
+
+    public static abstract TReturn operator >>(TSelf value, TOther shiftAmount);
+
+    public static abstract TReturn operator >>>(TSelf value, TOther shiftAmount);
+}
+
+public class Number : IShiftOperators<Number, string, Number>
+{
+    public static Number operator <<(Number value, string shiftAmount) => value;
+
+    public static Number operator >>(Number value, string shiftAmount) => value;
+
+    public static Number operator >>>(Number value, string shiftAmount) => value;
+}
+
+public class TestRelaxedShift
+{
+    public void M1()
+    {
+        var n11 = new Number();
+        var n12 = n11 << "1";
+
+        var n21 = new Number();
+        var n22 = n21 >> "2";
+
+        var n31 = new Number();
+        var n32 = n31 >>> "3";
+    }
+}

--- a/csharp/ql/test/library-tests/csharp11/relaxedShift.expected
+++ b/csharp/ql/test/library-tests/csharp11/relaxedShift.expected
@@ -1,0 +1,8 @@
+userdefinedoperators
+| RelaxedShift.cs:3:45:3:46 | << | LeftShiftOperator | RelaxedShift.cs:1:18:1:56 | IShiftOperators<Number,String,Number> |
+| RelaxedShift.cs:5:45:5:46 | >> | RightShiftOperator | RelaxedShift.cs:1:18:1:56 | IShiftOperators<Number,String,Number> |
+| RelaxedShift.cs:7:45:7:47 | >>> | UnsignedRightShiftOperator | RelaxedShift.cs:1:18:1:56 | IShiftOperators<Number,String,Number> |
+binaryoperatorcalls
+| RelaxedShift.cs:24:19:24:28 | call to operator << | RelaxedShift.cs:12:35:12:36 | << | RelaxedShift.cs:24:19:24:21 | access to local variable n11 | RelaxedShift.cs:24:26:24:28 | "1" |
+| RelaxedShift.cs:27:19:27:28 | call to operator >> | RelaxedShift.cs:14:35:14:36 | >> | RelaxedShift.cs:27:19:27:21 | access to local variable n21 | RelaxedShift.cs:27:26:27:28 | "2" |
+| RelaxedShift.cs:30:19:30:29 | call to operator >>> | RelaxedShift.cs:16:35:16:37 | >>> | RelaxedShift.cs:30:19:30:21 | access to local variable n31 | RelaxedShift.cs:30:27:30:29 | "3" |

--- a/csharp/ql/test/library-tests/csharp11/relaxedShift.ql
+++ b/csharp/ql/test/library-tests/csharp11/relaxedShift.ql
@@ -1,0 +1,15 @@
+import csharp
+
+query predicate userdefinedoperators(BinaryOperator op, string qlclass, Type t) {
+  op.getFile().getStem() = "RelaxedShift" and
+  qlclass = op.getAPrimaryQlClass() and
+  t = op.getDeclaringType() and
+  op != op.getUnboundDeclaration()
+}
+
+query predicate binaryoperatorcalls(OperatorCall oc, BinaryOperator o, Expr left, Expr right) {
+  oc.getFile().getStem() = "RelaxedShift" and
+  o = oc.getTarget() and
+  left = oc.getArgument(0) and
+  right = oc.getArgument(1)
+}


### PR DESCRIPTION
In this PR we test the relaxed requirements for shift operators.
It is no longer required that the second operand is an in `int` or implicitly convertible to int.