### PR TITLE
C#: Improve C# autobuilder compatibility with Arm-based Macs

### DIFF
--- a/cpp/autobuilder/Semmle.Autobuild.Cpp.Tests/BuildScripts.cs
+++ b/cpp/autobuilder/Semmle.Autobuild.Cpp.Tests/BuildScripts.cs
@@ -131,6 +131,14 @@ namespace Semmle.Autobuild.Cpp.Tests
 
         bool IBuildActions.IsWindows() => IsWindows;
 
+        public bool IsMacOs { get; set; }
+
+        bool IBuildActions.IsMacOs() => IsMacOs;
+
+        public bool IsArm { get; set; }
+
+        bool IBuildActions.IsArm() => IsArm;
+
         string IBuildActions.PathCombine(params string[] parts)
         {
             return string.Join(IsWindows ? '\\' : '/', parts.Where(p => !string.IsNullOrWhiteSpace(p)));

--- a/csharp/autobuilder/Semmle.Autobuild.CSharp.Tests/BuildScripts.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.CSharp.Tests/BuildScripts.cs
@@ -145,6 +145,14 @@ namespace Semmle.Autobuild.CSharp.Tests
 
         bool IBuildActions.IsWindows() => IsWindows;
 
+        public bool IsMacOs { get; set; }
+
+        bool IBuildActions.IsMacOs() => IsMacOs;
+
+        public bool IsArm { get; set; }
+
+        bool IBuildActions.IsArm() => IsArm;
+
         public string PathCombine(params string[] parts)
         {
             return string.Join(IsWindows ? '\\' : '/', parts.Where(p => !string.IsNullOrWhiteSpace(p)));

--- a/csharp/autobuilder/Semmle.Autobuild.Shared/BuildActions.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.Shared/BuildActions.cs
@@ -7,6 +7,7 @@ using System.Xml;
 using System.Net.Http;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
+using System.Runtime.InteropServices;
 
 namespace Semmle.Autobuild.Shared
 {
@@ -97,6 +98,18 @@ namespace Semmle.Autobuild.Shared
         /// True if we are running on Windows.
         /// </summary>
         bool IsWindows();
+
+        /// <summary>
+        /// Gets a value indicating whether we are running on macOS.
+        /// </summary>
+        /// <returns>True if we are running on macOS.</returns>
+        bool IsMacOs();
+
+        /// <summary>
+        /// Gets a value indicating whether we are running on arm.
+        /// </summary>
+        /// <returns>True if we are running on arm.</returns>
+        bool IsArm();
 
         /// <summary>
         /// Combine path segments, Path.Combine().
@@ -202,6 +215,12 @@ namespace Semmle.Autobuild.Shared
         IEnumerable<string> IBuildActions.EnumerateDirectories(string dir) => Directory.EnumerateDirectories(dir);
 
         bool IBuildActions.IsWindows() => Win32.IsWindows();
+
+        bool IBuildActions.IsMacOs() => RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+
+        bool IBuildActions.IsArm() =>
+            RuntimeInformation.ProcessArchitecture == Architecture.Arm64 ||
+            RuntimeInformation.ProcessArchitecture == Architecture.Arm;
 
         string IBuildActions.PathCombine(params string[] parts) => Path.Combine(parts);
 

--- a/csharp/scripts/create-extractor-pack.sh
+++ b/csharp/scripts/create-extractor-pack.sh
@@ -6,7 +6,11 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
   dotnet_platform="linux-x64"
 elif [[ "$OSTYPE" == "darwin"* ]]; then
   platform="osx64"
-  dotnet_platform="osx-x64"
+  if [[ $(uname -m) == 'arm64' ]]; then
+    dotnet_platform="osx-arm64"
+  else
+    dotnet_platform="osx-x64"
+  fi
 else
   echo "Unknown OS"
   exit 1


### PR DESCRIPTION
**Summary**

The C# autobuilder does not currently work super well on Arm-based Macs:

1. The `create-extractor-pack.sh` script always targets x86 on macOS.
1. The autobuilder depends on `mono` and `msbuild`: `mono` to run `nuget.exe` and `msbuild` to build projects that require it. However, on arm64, `mono` does not ship with `msbuild`. This results in the following error:
```
[2023-02-10 13:53:51] [build-stdout] Exit code 1: An error occurred trying to start process 'msbuild' with working directory '[..]'. No such file or directory
```
1. Furthermore, the `msbuild` path is hardcoded in Nuget when run using `mono`. However, since `mono` doesn't ship with `msbuild` on osx-arm64, we always end up with the following error:
```
[2023-02-10 17:02:00] [build-stdout] MSBuild auto-detection: using msbuild version '' from '/opt/homebrew/bin'.
```

This PR addresses the first two issues:

1. We detect when the build platform is arm64 in `create-extractor-pack.sh` and correctly propagate this platform to `dotnet_publish`.
1. We modify the autobuilder to use `dotnet msbuild` instead of `msbuild` on Arm-based Macs.

**Outstanding issues**

- To address the third issue, we might be able to use `dotnet` instead of `mono`, but this requires additional configuration.
- It might be possible for us to use `dotnet msbuild` on all platforms, rather than just osx-arm64. 