### PR TITLE
JS: add express-ws as a source

### DIFF
--- a/javascript/ql/lib/change-notes/2023-02-12-express-ws.md
+++ b/javascript/ql/lib/change-notes/2023-02-12-express-ws.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Added dataflow sources for the [express-ws](https://www.npmjs.com/package/express-ws) library. 

--- a/javascript/ql/lib/semmle/javascript/frameworks/WebSocket.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/WebSocket.qll
@@ -214,7 +214,13 @@ module ServerWebSocket {
   class ServerSocket extends EventEmitter::Range, DataFlow::SourceNode {
     LibraryName library;
 
-    ServerSocket() { this = getAConnectionCall(library).getCallback(1).getParameter(0) }
+    ServerSocket() {
+      this = getAConnectionCall(library).getCallback(1).getParameter(0)
+      or
+      // support for the express-ws library: https://www.npmjs.com/package/express-ws
+      library = ws() and
+      this = Express::appCreation().getAMemberCall("ws").getABoundCallbackParameter(1, 0)
+    }
 
     /**
      * Gets the name of the library that created this server socket.

--- a/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection/CodeInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection/CodeInjection.expected
@@ -89,6 +89,10 @@ nodes
 | express.js:34:17:34:35 | req.param("wobble") |
 | express.js:43:15:43:19 | taint |
 | express.js:43:15:43:19 | taint |
+| express.js:49:30:49:32 | msg |
+| express.js:49:30:49:32 | msg |
+| express.js:50:10:50:12 | msg |
+| express.js:50:10:50:12 | msg |
 | module.js:9:16:9:29 | req.query.code |
 | module.js:9:16:9:29 | req.query.code |
 | module.js:9:16:9:29 | req.query.code |
@@ -225,6 +229,10 @@ edges
 | express.js:34:9:34:35 | taint | express.js:43:15:43:19 | taint |
 | express.js:34:17:34:35 | req.param("wobble") | express.js:34:9:34:35 | taint |
 | express.js:34:17:34:35 | req.param("wobble") | express.js:34:9:34:35 | taint |
+| express.js:49:30:49:32 | msg | express.js:50:10:50:12 | msg |
+| express.js:49:30:49:32 | msg | express.js:50:10:50:12 | msg |
+| express.js:49:30:49:32 | msg | express.js:50:10:50:12 | msg |
+| express.js:49:30:49:32 | msg | express.js:50:10:50:12 | msg |
 | module.js:9:16:9:29 | req.query.code | module.js:9:16:9:29 | req.query.code |
 | module.js:11:17:11:30 | req.query.code | module.js:11:17:11:30 | req.query.code |
 | react-native.js:7:7:7:33 | tainted | react-native.js:8:32:8:38 | tainted |
@@ -321,6 +329,7 @@ edges
 | express.js:21:19:21:48 | req.par ... ntext") | express.js:21:19:21:48 | req.par ... ntext") | express.js:21:19:21:48 | req.par ... ntext") | This code execution depends on a $@. | express.js:21:19:21:48 | req.par ... ntext") | user-provided value |
 | express.js:27:34:27:38 | taint | express.js:26:17:26:35 | req.param("wobble") | express.js:27:34:27:38 | taint | This code execution depends on a $@. | express.js:26:17:26:35 | req.param("wobble") | user-provided value |
 | express.js:43:15:43:19 | taint | express.js:34:17:34:35 | req.param("wobble") | express.js:43:15:43:19 | taint | This code execution depends on a $@. | express.js:34:17:34:35 | req.param("wobble") | user-provided value |
+| express.js:50:10:50:12 | msg | express.js:49:30:49:32 | msg | express.js:50:10:50:12 | msg | This code execution depends on a $@. | express.js:49:30:49:32 | msg | user-provided value |
 | module.js:9:16:9:29 | req.query.code | module.js:9:16:9:29 | req.query.code | module.js:9:16:9:29 | req.query.code | This code execution depends on a $@. | module.js:9:16:9:29 | req.query.code | user-provided value |
 | module.js:11:17:11:30 | req.query.code | module.js:11:17:11:30 | req.query.code | module.js:11:17:11:30 | req.query.code | This code execution depends on a $@. | module.js:11:17:11:30 | req.query.code | user-provided value |
 | react-native.js:8:32:8:38 | tainted | react-native.js:7:17:7:33 | req.param("code") | react-native.js:8:32:8:38 | tainted | This code execution depends on a $@. | react-native.js:7:17:7:33 | req.param("code") | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection/HeuristicSourceCodeInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection/HeuristicSourceCodeInjection.expected
@@ -93,6 +93,10 @@ nodes
 | express.js:34:17:34:35 | req.param("wobble") |
 | express.js:43:15:43:19 | taint |
 | express.js:43:15:43:19 | taint |
+| express.js:49:30:49:32 | msg |
+| express.js:49:30:49:32 | msg |
+| express.js:50:10:50:12 | msg |
+| express.js:50:10:50:12 | msg |
 | module.js:9:16:9:29 | req.query.code |
 | module.js:9:16:9:29 | req.query.code |
 | module.js:9:16:9:29 | req.query.code |
@@ -233,6 +237,10 @@ edges
 | express.js:34:9:34:35 | taint | express.js:43:15:43:19 | taint |
 | express.js:34:17:34:35 | req.param("wobble") | express.js:34:9:34:35 | taint |
 | express.js:34:17:34:35 | req.param("wobble") | express.js:34:9:34:35 | taint |
+| express.js:49:30:49:32 | msg | express.js:50:10:50:12 | msg |
+| express.js:49:30:49:32 | msg | express.js:50:10:50:12 | msg |
+| express.js:49:30:49:32 | msg | express.js:50:10:50:12 | msg |
+| express.js:49:30:49:32 | msg | express.js:50:10:50:12 | msg |
 | module.js:9:16:9:29 | req.query.code | module.js:9:16:9:29 | req.query.code |
 | module.js:11:17:11:30 | req.query.code | module.js:11:17:11:30 | req.query.code |
 | react-native.js:7:7:7:33 | tainted | react-native.js:8:32:8:38 | tainted |

--- a/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection/express.js
+++ b/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection/express.js
@@ -43,3 +43,10 @@ app.get('/terminal', function(req, res) {
   shell.write(taint); // NOT OK
 });
   
+require("express-ws")(app);
+
+app.ws("/socket-thing/", function (ws, req) {
+  ws.on("message", function (msg) {
+    eval(msg); // NOT OK
+  });
+});


### PR DESCRIPTION
[Evaluation was uneventful](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/PR-12159-0-javascript__1/reports).  

Recognizes the source for CVE-2020-23256