### PR TITLE
Swift: make `codegen` run also outside `bazel`

### DIFF
--- a/swift/codegen/README.md
+++ b/swift/codegen/README.md
@@ -19,6 +19,13 @@ separated list to select what to generate (choosing among `dbscheme`, `ql`, `tra
 C++ code is generated during build (see [`swift/extractor/trap/BUILD.bazel`](../extractor/trap/BUILD.bazel)). After a
 build you can browse the generated code in `bazel-bin/swift/extractor/trap/generated`.
 
+For debugging you can also run `./codegen.py` directly. You must then ensure dependencies are installed, which you can
+with the command
+
+```bash
+pip3 install -r ./requirements.txt
+```
+
 ## Implementation notes
 
 The suite uses [mustache templating](https://mustache.github.io/) for generation. Templates are

--- a/swift/codegen/codegen.py
+++ b/swift/codegen/codegen.py
@@ -3,11 +3,15 @@
 
 import argparse
 import logging
-import pathlib
+import os
 import sys
-import importlib
-import types
+import pathlib
 import typing
+
+if 'BUILD_WORKSPACE_DIRECTORY' not in os.environ:
+    # we are not running with `bazel run`, set up module search path
+    _repo_root = pathlib.Path(__file__).resolve().parents[2]
+    sys.path.append(str(_repo_root))
 
 from swift.codegen.lib import render, paths
 from swift.codegen.generators import generate


### PR DESCRIPTION
This allows running `codegen.py` in isolation, without needing `bazel run //swift/codegen`. This is mainly intended for debugging.

When running like this, the user is required to make sure python dependencies are installed. You can do so with

```bash
pip3 install -r swift/codegen/requirements.txt
```