### PR TITLE
JS: add `HtmlSanitizer` as a sanitizer DOMBasedXss

### DIFF
--- a/javascript/ql/lib/semmle/javascript/security/dataflow/DomBasedXssCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/DomBasedXssCustomizations.qll
@@ -287,6 +287,8 @@ module DomBasedXss {
 
   private class IsEscapedInSwitchSanitizer extends Sanitizer, Shared::IsEscapedInSwitchSanitizer { }
 
+  private class HtmlSanitizerAsSanitizer extends Sanitizer instanceof HtmlSanitizerCall { }
+
   /**
    * Holds if there exists two dataflow edges to `succ`, where one edges is sanitized, and the other edge starts with `pred`.
    */

--- a/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/XssThroughDom.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/XssThroughDom.expected
@@ -157,10 +157,6 @@ nodes
 | xss-through-dom.js:140:19:140:21 | src |
 | xss-through-dom.js:141:25:141:27 | src |
 | xss-through-dom.js:141:25:141:27 | src |
-| xss-through-dom.js:148:25:148:65 | DOMPuri ... ) : src |
-| xss-through-dom.js:148:25:148:65 | DOMPuri ... ) : src |
-| xss-through-dom.js:148:37:148:59 | DOMPuri ... ze(src) |
-| xss-through-dom.js:148:56:148:58 | src |
 edges
 | forms.js:8:23:8:28 | values | forms.js:9:31:9:36 | values |
 | forms.js:8:23:8:28 | values | forms.js:9:31:9:36 | values |
@@ -261,12 +257,8 @@ edges
 | xss-through-dom.js:139:11:139:52 | src | xss-through-dom.js:140:19:140:21 | src |
 | xss-through-dom.js:139:11:139:52 | src | xss-through-dom.js:141:25:141:27 | src |
 | xss-through-dom.js:139:11:139:52 | src | xss-through-dom.js:141:25:141:27 | src |
-| xss-through-dom.js:139:11:139:52 | src | xss-through-dom.js:148:56:148:58 | src |
 | xss-through-dom.js:139:17:139:52 | documen ... k").src | xss-through-dom.js:139:11:139:52 | src |
 | xss-through-dom.js:139:17:139:52 | documen ... k").src | xss-through-dom.js:139:11:139:52 | src |
-| xss-through-dom.js:148:37:148:59 | DOMPuri ... ze(src) | xss-through-dom.js:148:25:148:65 | DOMPuri ... ) : src |
-| xss-through-dom.js:148:37:148:59 | DOMPuri ... ze(src) | xss-through-dom.js:148:25:148:65 | DOMPuri ... ) : src |
-| xss-through-dom.js:148:56:148:58 | src | xss-through-dom.js:148:37:148:59 | DOMPuri ... ze(src) |
 #select
 | forms.js:9:31:9:40 | values.foo | forms.js:8:23:8:28 | values | forms.js:9:31:9:40 | values.foo | $@ is reinterpreted as HTML without escaping meta-characters. | forms.js:8:23:8:28 | values | DOM text |
 | forms.js:12:31:12:40 | values.bar | forms.js:11:24:11:29 | values | forms.js:12:31:12:40 | values.bar | $@ is reinterpreted as HTML without escaping meta-characters. | forms.js:11:24:11:29 | values | DOM text |
@@ -310,4 +302,3 @@ edges
 | xss-through-dom.js:132:16:132:23 | linkText | xss-through-dom.js:130:42:130:62 | dSelect ... tring() | xss-through-dom.js:132:16:132:23 | linkText | $@ is reinterpreted as HTML without escaping meta-characters. | xss-through-dom.js:130:42:130:62 | dSelect ... tring() | DOM text |
 | xss-through-dom.js:140:19:140:21 | src | xss-through-dom.js:139:17:139:52 | documen ... k").src | xss-through-dom.js:140:19:140:21 | src | $@ is reinterpreted as HTML without escaping meta-characters. | xss-through-dom.js:139:17:139:52 | documen ... k").src | DOM text |
 | xss-through-dom.js:141:25:141:27 | src | xss-through-dom.js:139:17:139:52 | documen ... k").src | xss-through-dom.js:141:25:141:27 | src | $@ is reinterpreted as HTML without escaping meta-characters. | xss-through-dom.js:139:17:139:52 | documen ... k").src | DOM text |
-| xss-through-dom.js:148:25:148:65 | DOMPuri ... ) : src | xss-through-dom.js:139:17:139:52 | documen ... k").src | xss-through-dom.js:148:25:148:65 | DOMPuri ... ) : src | $@ is reinterpreted as HTML without escaping meta-characters. | xss-through-dom.js:139:17:139:52 | documen ... k").src | DOM text |

--- a/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/XssThroughDom.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/XssThroughDom.expected
@@ -157,6 +157,10 @@ nodes
 | xss-through-dom.js:140:19:140:21 | src |
 | xss-through-dom.js:141:25:141:27 | src |
 | xss-through-dom.js:141:25:141:27 | src |
+| xss-through-dom.js:148:25:148:65 | DOMPuri ... ) : src |
+| xss-through-dom.js:148:25:148:65 | DOMPuri ... ) : src |
+| xss-through-dom.js:148:37:148:59 | DOMPuri ... ze(src) |
+| xss-through-dom.js:148:56:148:58 | src |
 edges
 | forms.js:8:23:8:28 | values | forms.js:9:31:9:36 | values |
 | forms.js:8:23:8:28 | values | forms.js:9:31:9:36 | values |
@@ -257,8 +261,12 @@ edges
 | xss-through-dom.js:139:11:139:52 | src | xss-through-dom.js:140:19:140:21 | src |
 | xss-through-dom.js:139:11:139:52 | src | xss-through-dom.js:141:25:141:27 | src |
 | xss-through-dom.js:139:11:139:52 | src | xss-through-dom.js:141:25:141:27 | src |
+| xss-through-dom.js:139:11:139:52 | src | xss-through-dom.js:148:56:148:58 | src |
 | xss-through-dom.js:139:17:139:52 | documen ... k").src | xss-through-dom.js:139:11:139:52 | src |
 | xss-through-dom.js:139:17:139:52 | documen ... k").src | xss-through-dom.js:139:11:139:52 | src |
+| xss-through-dom.js:148:37:148:59 | DOMPuri ... ze(src) | xss-through-dom.js:148:25:148:65 | DOMPuri ... ) : src |
+| xss-through-dom.js:148:37:148:59 | DOMPuri ... ze(src) | xss-through-dom.js:148:25:148:65 | DOMPuri ... ) : src |
+| xss-through-dom.js:148:56:148:58 | src | xss-through-dom.js:148:37:148:59 | DOMPuri ... ze(src) |
 #select
 | forms.js:9:31:9:40 | values.foo | forms.js:8:23:8:28 | values | forms.js:9:31:9:40 | values.foo | $@ is reinterpreted as HTML without escaping meta-characters. | forms.js:8:23:8:28 | values | DOM text |
 | forms.js:12:31:12:40 | values.bar | forms.js:11:24:11:29 | values | forms.js:12:31:12:40 | values.bar | $@ is reinterpreted as HTML without escaping meta-characters. | forms.js:11:24:11:29 | values | DOM text |
@@ -302,3 +310,4 @@ edges
 | xss-through-dom.js:132:16:132:23 | linkText | xss-through-dom.js:130:42:130:62 | dSelect ... tring() | xss-through-dom.js:132:16:132:23 | linkText | $@ is reinterpreted as HTML without escaping meta-characters. | xss-through-dom.js:130:42:130:62 | dSelect ... tring() | DOM text |
 | xss-through-dom.js:140:19:140:21 | src | xss-through-dom.js:139:17:139:52 | documen ... k").src | xss-through-dom.js:140:19:140:21 | src | $@ is reinterpreted as HTML without escaping meta-characters. | xss-through-dom.js:139:17:139:52 | documen ... k").src | DOM text |
 | xss-through-dom.js:141:25:141:27 | src | xss-through-dom.js:139:17:139:52 | documen ... k").src | xss-through-dom.js:141:25:141:27 | src | $@ is reinterpreted as HTML without escaping meta-characters. | xss-through-dom.js:139:17:139:52 | documen ... k").src | DOM text |
+| xss-through-dom.js:148:25:148:65 | DOMPuri ... ) : src | xss-through-dom.js:139:17:139:52 | documen ... k").src | xss-through-dom.js:148:25:148:65 | DOMPuri ... ) : src | $@ is reinterpreted as HTML without escaping meta-characters. | xss-through-dom.js:139:17:139:52 | documen ... k").src | DOM text |

--- a/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/xss-through-dom.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/xss-through-dom.js
@@ -139,4 +139,11 @@ const cashDom = require("cash-dom");
     const src = document.getElementById("#link").src;
 	cash("#id").html(src); // NOT OK.
     cashDom("#id").html(src); // NOT OK
+
+    var DOMPurify = {
+        sanitize: function (src) {
+            return src; // to model spuriously finding an edge. The below is still OK.
+        }
+    };
+    cashDom("#id").html(DOMPurify ? DOMPurify.sanitize(src) : src); // OK - but currently flagged [INCONSISTENCY]
 })();

--- a/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/xss-through-dom.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/xss-through-dom.js
@@ -145,5 +145,5 @@ const cashDom = require("cash-dom");
             return src; // to model spuriously finding an edge. The below is still OK.
         }
     };
-    cashDom("#id").html(DOMPurify ? DOMPurify.sanitize(src) : src); // OK - but currently flagged [INCONSISTENCY]
+    cashDom("#id").html(DOMPurify ? DOMPurify.sanitize(src) : src); // OK
 })();


### PR DESCRIPTION
CVE-2018-19048: TN

We don't model flow through unknown functions, so adding `HtmlSanitizer` as a sanitizer should't be needed.  
However, if we spuriously find flow through the function (e.g. because the library ships with it's own copy of `DOMPurify`, where we spuriously find flow through), then we need the sanitizer.  

[The evaluation](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/PR-12166-0-javascript/reports) shows some lost results where we had spurious flow through a (good) sanitizer, and around neutral performance. 