### PR TITLE
C#: Checked operator support.

### DIFF
--- a/csharp/ql/lib/change-notes/2023-02-14-checked-operators.md
+++ b/csharp/ql/lib/change-notes/2023-02-14-checked-operators.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* C# 11: Added library support for `checked` operators.

--- a/csharp/ql/lib/semmle/code/csharp/Callable.qll
+++ b/csharp/ql/lib/semmle/code/csharp/Callable.qll
@@ -485,10 +485,11 @@ class RecordCloneMethod extends Method, DotNet::RecordCloneCallable {
  * A user-defined unary operator - an operator taking one operand.
  *
  * Either a plus operator (`PlusOperator`), minus operator (`MinusOperator`),
- * not operator (`NotOperator`), complement operator (`ComplementOperator`),
- * true operator (`TrueOperator`), false operator (`FalseOperator`),
- * increment operator (`IncrementOperator`), or decrement operator
- * (`DecrementOperator`).
+ * checked minus operator (`CheckedMinusOperator`), not operator (`NotOperator`),
+ * complement operator (`ComplementOperator`), true operator (`TrueOperator`),
+ * false operator (`FalseOperator`), increment operator (`IncrementOperator`),
+ * checked increment operator (`CheckedIncrementOperator`), decrement operator
+ * (`DecrementOperator`) or checked decrement operator (`CheckedDecrementOperator`).
  */
 class UnaryOperator extends Operator {
   UnaryOperator() {
@@ -525,6 +526,21 @@ class MinusOperator extends UnaryOperator {
   MinusOperator() { this.getName() = "-" }
 
   override string getAPrimaryQlClass() { result = "MinusOperator" }
+}
+
+/**
+ * A user-defined checked minus operator (`-`), for example
+ *
+ * ```csharp
+ * public static Widget operator checked -(Widget w) {
+ *   ...
+ * }
+ * ```
+ */
+class CheckedMinusOperator extends UnaryOperator {
+  CheckedMinusOperator() { this.getName() = "checked -" }
+
+  override string getAPrimaryQlClass() { result = "CheckedMinusOperator" }
 }
 
 /**
@@ -573,6 +589,21 @@ class IncrementOperator extends UnaryOperator {
 }
 
 /**
+ * A user-defined checked increment operator (`++`), for example
+ *
+ * ```csharp
+ * public static Widget operator checked ++(Widget w) {
+ *   ...
+ * }
+ * ```
+ */
+class CheckedIncrementOperator extends UnaryOperator {
+  CheckedIncrementOperator() { this.getName() = "checked ++" }
+
+  override string getAPrimaryQlClass() { result = "CheckedIncrementOperator" }
+}
+
+/**
  * A user-defined decrement operator (`--`), for example
  *
  * ```csharp
@@ -585,6 +616,21 @@ class DecrementOperator extends UnaryOperator {
   DecrementOperator() { this.getName() = "--" }
 
   override string getAPrimaryQlClass() { result = "DecrementOperator" }
+}
+
+/**
+ * A user-defined checked decrement operator (`--`), for example
+ *
+ * ```csharp
+ * public static Widget operator checked --(Widget w) {
+ *   ...
+ * }
+ * ```
+ */
+class CheckedDecrementOperator extends UnaryOperator {
+  CheckedDecrementOperator() { this.getName() = "checked --" }
+
+  override string getAPrimaryQlClass() { result = "CheckedDecrementOperator" }
 }
 
 /**
@@ -620,9 +666,12 @@ class TrueOperator extends UnaryOperator {
 /**
  * A user-defined binary operator.
  *
- * Either an addition operator (`AddOperator`), a subtraction operator
- * (`SubOperator`), a multiplication operator (`MulOperator`), a division
- * operator (`DivOperator`), a remainder operator (`RemOperator`), an and
+ * Either an addition operator (`AddOperator`), a checked addition operator
+ * (`CheckedAddOperator`) a subtraction operator (`SubOperator`), a checked
+ * substraction operator (`CheckedSubOperator`), a multiplication operator
+ * (`MulOperator`), a checked multiplication operator (`CheckedMulOperator`),
+ * a division operator (`DivOperator`), a checked division operator
+ * (`CheckedDivOperator`), a remainder operator (`RemOperator`), an and
  * operator (`AndOperator`), an or operator (`OrOperator`), an xor
  * operator (`XorOperator`), a left shift operator (`LeftShiftOperator`),
  * a right shift operator (`RightShiftOperator`), an unsigned right shift
@@ -651,6 +700,21 @@ class AddOperator extends BinaryOperator {
 }
 
 /**
+ * A user-defined checked addition operator (`+`), for example
+ *
+ * ```csharp
+ * public static Widget operator checked +(Widget lhs, Widget rhs) {
+ *   ...
+ * }
+ * ```
+ */
+class CheckedAddOperator extends BinaryOperator {
+  CheckedAddOperator() { this.getName() = "checked +" }
+
+  override string getAPrimaryQlClass() { result = "CheckedAddOperator" }
+}
+
+/**
  * A user-defined subtraction operator (`-`), for example
  *
  * ```csharp
@@ -663,6 +727,21 @@ class SubOperator extends BinaryOperator {
   SubOperator() { this.getName() = "-" }
 
   override string getAPrimaryQlClass() { result = "SubOperator" }
+}
+
+/**
+ * A user-defined checked subtraction operator (`-`), for example
+ *
+ * ```csharp
+ * public static Widget operator checked -(Widget lhs, Widget rhs) {
+ *   ...
+ * }
+ * ```
+ */
+class CheckedSubOperator extends BinaryOperator {
+  CheckedSubOperator() { this.getName() = "checked -" }
+
+  override string getAPrimaryQlClass() { result = "CheckedSubOperator" }
 }
 
 /**
@@ -681,6 +760,21 @@ class MulOperator extends BinaryOperator {
 }
 
 /**
+ * A user-defined checked multiplication operator (`*`), for example
+ *
+ * ```csharp
+ * public static Widget operator checked *(Widget lhs, Widget rhs) {
+ *   ...
+ * }
+ * ```
+ */
+class CheckedMulOperator extends BinaryOperator {
+  CheckedMulOperator() { this.getName() = "checked *" }
+
+  override string getAPrimaryQlClass() { result = "CheckedMulOperator" }
+}
+
+/**
  * A user-defined division operator (`/`), for example
  *
  * ```csharp
@@ -693,6 +787,21 @@ class DivOperator extends BinaryOperator {
   DivOperator() { this.getName() = "/" }
 
   override string getAPrimaryQlClass() { result = "DivOperator" }
+}
+
+/**
+ * A user-defined checked division operator (`/`), for example
+ *
+ * ```csharp
+ * public static Widget operator checked /(Widget lhs, Widget rhs) {
+ *   ...
+ * }
+ * ```
+ */
+class CheckedDivOperator extends BinaryOperator {
+  CheckedDivOperator() { this.getName() = "checked /" }
+
+  override string getAPrimaryQlClass() { result = "CheckedDivOperator" }
 }
 
 /**
@@ -908,7 +1017,8 @@ class GEOperator extends BinaryOperator {
 class ConversionOperator extends Operator {
   ConversionOperator() {
     this.getName() = "implicit conversion" or
-    this.getName() = "explicit conversion"
+    this.getName() = "explicit conversion" or
+    this.getName() = "checked explicit conversion"
   }
 
   /** Gets the source type of the conversion. */
@@ -946,6 +1056,21 @@ class ExplicitConversionOperator extends ConversionOperator {
   ExplicitConversionOperator() { this.getName() = "explicit conversion" }
 
   override string getAPrimaryQlClass() { result = "ExplicitConversionOperator" }
+}
+
+/**
+ * A user-defined checked explicit conversion operator, for example
+ *
+ * ```csharp
+ * public static explicit operator checked int(BigInteger i) {
+ *   ...
+ * }
+ * ```
+ */
+class CheckedExplicitConversionOperator extends ConversionOperator {
+  CheckedExplicitConversionOperator() { this.getName() = "checked explicit conversion" }
+
+  override string getAPrimaryQlClass() { result = "CheckedExplicitConversionOperator" }
 }
 
 /**

--- a/csharp/ql/lib/semmle/code/csharp/Callable.qll
+++ b/csharp/ql/lib/semmle/code/csharp/Callable.qll
@@ -435,8 +435,12 @@ class Destructor extends DotNet::Destructor, Callable, Member, Attributable, @de
  * (`BinaryOperator`), or a conversion operator (`ConversionOperator`).
  */
 class Operator extends Callable, Member, Attributable, @operator {
-  /** Gets the assembly name of this operator. */
-  string getAssemblyName() { operators(this, result, _, _, _, _) }
+  /**
+   * DEPRECATED: use `getFunctionName()` instead.
+   *
+   * Gets the assembly name of this operator.
+   */
+  deprecated string getAssemblyName() { result = this.getFunctionName() }
 
   override string getName() { operators(this, _, result, _, _, _) }
 
@@ -445,7 +449,7 @@ class Operator extends Callable, Member, Attributable, @operator {
   /**
    * Gets the metadata name of the operator, such as `op_implicit` or `op_RightShift`.
    */
-  string getFunctionName() { none() }
+  string getFunctionName() { operators(this, result, _, _, _, _) }
 
   override ValueOrRefType getDeclaringType() { operators(this, _, _, result, _, _) }
 
@@ -505,8 +509,6 @@ class UnaryOperator extends Operator {
 class PlusOperator extends UnaryOperator {
   PlusOperator() { this.getName() = "+" }
 
-  override string getFunctionName() { result = "op_UnaryPlus" }
-
   override string getAPrimaryQlClass() { result = "PlusOperator" }
 }
 
@@ -521,8 +523,6 @@ class PlusOperator extends UnaryOperator {
  */
 class MinusOperator extends UnaryOperator {
   MinusOperator() { this.getName() = "-" }
-
-  override string getFunctionName() { result = "op_UnaryNegation" }
 
   override string getAPrimaryQlClass() { result = "MinusOperator" }
 }
@@ -539,8 +539,6 @@ class MinusOperator extends UnaryOperator {
 class NotOperator extends UnaryOperator {
   NotOperator() { this.getName() = "!" }
 
-  override string getFunctionName() { result = "op_LogicalNot" }
-
   override string getAPrimaryQlClass() { result = "NotOperator" }
 }
 
@@ -555,8 +553,6 @@ class NotOperator extends UnaryOperator {
  */
 class ComplementOperator extends UnaryOperator {
   ComplementOperator() { this.getName() = "~" }
-
-  override string getFunctionName() { result = "op_OnesComplement" }
 
   override string getAPrimaryQlClass() { result = "ComplementOperator" }
 }
@@ -573,8 +569,6 @@ class ComplementOperator extends UnaryOperator {
 class IncrementOperator extends UnaryOperator {
   IncrementOperator() { this.getName() = "++" }
 
-  override string getFunctionName() { result = "op_Increment" }
-
   override string getAPrimaryQlClass() { result = "IncrementOperator" }
 }
 
@@ -589,8 +583,6 @@ class IncrementOperator extends UnaryOperator {
  */
 class DecrementOperator extends UnaryOperator {
   DecrementOperator() { this.getName() = "--" }
-
-  override string getFunctionName() { result = "op_Decrement" }
 
   override string getAPrimaryQlClass() { result = "DecrementOperator" }
 }
@@ -607,8 +599,6 @@ class DecrementOperator extends UnaryOperator {
 class FalseOperator extends UnaryOperator {
   FalseOperator() { this.getName() = "false" }
 
-  override string getFunctionName() { result = "op_False" }
-
   override string getAPrimaryQlClass() { result = "FalseOperator" }
 }
 
@@ -623,8 +613,6 @@ class FalseOperator extends UnaryOperator {
  */
 class TrueOperator extends UnaryOperator {
   TrueOperator() { this.getName() = "true" }
-
-  override string getFunctionName() { result = "op_True" }
 
   override string getAPrimaryQlClass() { result = "TrueOperator" }
 }
@@ -659,8 +647,6 @@ class BinaryOperator extends Operator {
 class AddOperator extends BinaryOperator {
   AddOperator() { this.getName() = "+" }
 
-  override string getFunctionName() { result = "op_Addition" }
-
   override string getAPrimaryQlClass() { result = "AddOperator" }
 }
 
@@ -675,8 +661,6 @@ class AddOperator extends BinaryOperator {
  */
 class SubOperator extends BinaryOperator {
   SubOperator() { this.getName() = "-" }
-
-  override string getFunctionName() { result = "op_Subtraction" }
 
   override string getAPrimaryQlClass() { result = "SubOperator" }
 }
@@ -693,8 +677,6 @@ class SubOperator extends BinaryOperator {
 class MulOperator extends BinaryOperator {
   MulOperator() { this.getName() = "*" }
 
-  override string getFunctionName() { result = "op_Multiply" }
-
   override string getAPrimaryQlClass() { result = "MulOperator" }
 }
 
@@ -709,8 +691,6 @@ class MulOperator extends BinaryOperator {
  */
 class DivOperator extends BinaryOperator {
   DivOperator() { this.getName() = "/" }
-
-  override string getFunctionName() { result = "op_Division" }
 
   override string getAPrimaryQlClass() { result = "DivOperator" }
 }
@@ -727,8 +707,6 @@ class DivOperator extends BinaryOperator {
 class RemOperator extends BinaryOperator {
   RemOperator() { this.getName() = "%" }
 
-  override string getFunctionName() { result = "op_Modulus" }
-
   override string getAPrimaryQlClass() { result = "RemOperator" }
 }
 
@@ -743,8 +721,6 @@ class RemOperator extends BinaryOperator {
  */
 class AndOperator extends BinaryOperator {
   AndOperator() { this.getName() = "&" }
-
-  override string getFunctionName() { result = "op_BitwiseAnd" }
 
   override string getAPrimaryQlClass() { result = "AndOperator" }
 }
@@ -761,8 +737,6 @@ class AndOperator extends BinaryOperator {
 class OrOperator extends BinaryOperator {
   OrOperator() { this.getName() = "|" }
 
-  override string getFunctionName() { result = "op_BitwiseOr" }
-
   override string getAPrimaryQlClass() { result = "OrOperator" }
 }
 
@@ -778,8 +752,6 @@ class OrOperator extends BinaryOperator {
 class XorOperator extends BinaryOperator {
   XorOperator() { this.getName() = "^" }
 
-  override string getFunctionName() { result = "op_ExclusiveOr" }
-
   override string getAPrimaryQlClass() { result = "XorOperator" }
 }
 
@@ -794,8 +766,6 @@ class XorOperator extends BinaryOperator {
  */
 class LeftShiftOperator extends BinaryOperator {
   LeftShiftOperator() { this.getName() = "<<" }
-
-  override string getFunctionName() { result = "op_LeftShift" }
 
   override string getAPrimaryQlClass() { result = "LeftShiftOperator" }
 }
@@ -815,8 +785,6 @@ deprecated class LShiftOperator = LeftShiftOperator;
 class RightShiftOperator extends BinaryOperator {
   RightShiftOperator() { this.getName() = ">>" }
 
-  override string getFunctionName() { result = "op_RightShift" }
-
   override string getAPrimaryQlClass() { result = "RightShiftOperator" }
 }
 
@@ -835,8 +803,6 @@ deprecated class RShiftOperator = RightShiftOperator;
 class UnsignedRightShiftOperator extends BinaryOperator {
   UnsignedRightShiftOperator() { this.getName() = ">>>" }
 
-  override string getFunctionName() { result = "op_UnsignedRightShift" }
-
   override string getAPrimaryQlClass() { result = "UnsignedRightShiftOperator" }
 }
 
@@ -851,8 +817,6 @@ class UnsignedRightShiftOperator extends BinaryOperator {
  */
 class EQOperator extends BinaryOperator {
   EQOperator() { this.getName() = "==" }
-
-  override string getFunctionName() { result = "op_Equality" }
 
   override string getAPrimaryQlClass() { result = "EQOperator" }
 }
@@ -869,8 +833,6 @@ class EQOperator extends BinaryOperator {
 class NEOperator extends BinaryOperator {
   NEOperator() { this.getName() = "!=" }
 
-  override string getFunctionName() { result = "op_Inequality" }
-
   override string getAPrimaryQlClass() { result = "NEOperator" }
 }
 
@@ -885,8 +847,6 @@ class NEOperator extends BinaryOperator {
  */
 class LTOperator extends BinaryOperator {
   LTOperator() { this.getName() = "<" }
-
-  override string getFunctionName() { result = "op_LessThan" }
 
   override string getAPrimaryQlClass() { result = "LTOperator" }
 }
@@ -903,8 +863,6 @@ class LTOperator extends BinaryOperator {
 class GTOperator extends BinaryOperator {
   GTOperator() { this.getName() = ">" }
 
-  override string getFunctionName() { result = "op_GreaterThan" }
-
   override string getAPrimaryQlClass() { result = "GTOperator" }
 }
 
@@ -920,8 +878,6 @@ class GTOperator extends BinaryOperator {
 class LEOperator extends BinaryOperator {
   LEOperator() { this.getName() = "<=" }
 
-  override string getFunctionName() { result = "op_LessThanOrEqual" }
-
   override string getAPrimaryQlClass() { result = "LEOperator" }
 }
 
@@ -936,8 +892,6 @@ class LEOperator extends BinaryOperator {
  */
 class GEOperator extends BinaryOperator {
   GEOperator() { this.getName() = ">=" }
-
-  override string getFunctionName() { result = "op_GreaterThanOrEqual" }
 
   override string getAPrimaryQlClass() { result = "GEOperator" }
 }
@@ -976,8 +930,6 @@ class ConversionOperator extends Operator {
 class ImplicitConversionOperator extends ConversionOperator {
   ImplicitConversionOperator() { this.getName() = "implicit conversion" }
 
-  override string getFunctionName() { result = "op_Implicit" }
-
   override string getAPrimaryQlClass() { result = "ImplicitConversionOperator" }
 }
 
@@ -992,8 +944,6 @@ class ImplicitConversionOperator extends ConversionOperator {
  */
 class ExplicitConversionOperator extends ConversionOperator {
   ExplicitConversionOperator() { this.getName() = "explicit conversion" }
-
-  override string getFunctionName() { result = "op_Explicit" }
 
   override string getAPrimaryQlClass() { result = "ExplicitConversionOperator" }
 }

--- a/csharp/ql/test/library-tests/csharp11/CheckedOperators.cs
+++ b/csharp/ql/test/library-tests/csharp11/CheckedOperators.cs
@@ -1,0 +1,56 @@
+namespace CheckedOperators;
+
+public class Number
+{
+    public int Value { get; }
+
+    public Number(int n) => this.Value = n;
+
+    public static Number operator checked +(Number n1, Number n2) =>
+        new Number(checked(n1.Value + n2.Value));
+
+    public static Number operator +(Number n1, Number n2) =>
+        new Number(n1.Value + n2.Value);
+
+    public static Number operator checked -(Number n1, Number n2) =>
+        new Number(checked(n1.Value - n2.Value));
+
+    public static Number operator -(Number n1, Number n2) =>
+        new Number(n1.Value - n2.Value);
+
+    public static Number operator checked *(Number n1, Number n2) =>
+        new Number(checked(n1.Value * n2.Value));
+
+    public static Number operator *(Number n1, Number n2) =>
+        new Number(n1.Value * n2.Value);
+
+    public static Number operator checked /(Number n1, Number n2) =>
+        new Number(checked(n1.Value / n2.Value));
+
+    public static Number operator /(Number n1, Number n2) =>
+        new Number(n1.Value / n2.Value);
+
+    public static Number operator checked -(Number n) =>
+        new Number(checked(-n.Value));
+
+    public static Number operator -(Number n) =>
+        new Number(-n.Value);
+
+    public static Number operator checked ++(Number n) =>
+        new Number(checked(n.Value + 1));
+
+    public static Number operator ++(Number n) =>
+        new Number(n.Value + 1);
+
+    public static Number operator checked --(Number n) =>
+        new Number(checked(n.Value - 1));
+
+    public static Number operator --(Number n) =>
+        new Number(n.Value - 1);
+
+    public static explicit operator short(Number n) =>
+        (short)n.Value;
+
+    public static explicit operator checked short(Number n) =>
+        checked((short)n.Value);
+}

--- a/csharp/ql/test/library-tests/csharp11/PrintAst.expected
+++ b/csharp/ql/test/library-tests/csharp11/PrintAst.expected
@@ -1,3 +1,221 @@
+CheckedOperators.cs:
+#    1| [NamespaceDeclaration] namespace ... { ... }
+#    3|   1: [Class] Number
+#    5|     4: [Property] Value
+#    5|       -1: [TypeMention] int
+#    5|       3: [Getter] get_Value
+#    7|     5: [InstanceConstructor] Number
+#-----|       2: (Parameters)
+#    7|         0: [Parameter] n
+#    7|           -1: [TypeMention] int
+#    7|       4: [AssignExpr] ... = ...
+#    7|         0: [PropertyCall] access to property Value
+#    7|           -1: [ThisAccess] this access
+#    7|         1: [ParameterAccess] access to parameter n
+#    9|     6: [CheckedAddOperator] checked +
+#    9|       -1: [TypeMention] Number
+#-----|       2: (Parameters)
+#    9|         0: [Parameter] n1
+#    9|           -1: [TypeMention] Number
+#    9|         1: [Parameter] n2
+#    9|           -1: [TypeMention] Number
+#   10|       4: [ObjectCreation] object creation of type Number
+#   10|         -1: [TypeMention] Number
+#   10|         0: [CheckedExpr] checked (...)
+#   10|           0: [AddExpr] ... + ...
+#   10|             0: [PropertyCall] access to property Value
+#   10|               -1: [ParameterAccess] access to parameter n1
+#   10|             1: [PropertyCall] access to property Value
+#   10|               -1: [ParameterAccess] access to parameter n2
+#   12|     7: [AddOperator] +
+#   12|       -1: [TypeMention] Number
+#-----|       2: (Parameters)
+#   12|         0: [Parameter] n1
+#   12|           -1: [TypeMention] Number
+#   12|         1: [Parameter] n2
+#   12|           -1: [TypeMention] Number
+#   13|       4: [ObjectCreation] object creation of type Number
+#   13|         -1: [TypeMention] Number
+#   13|         0: [AddExpr] ... + ...
+#   13|           0: [PropertyCall] access to property Value
+#   13|             -1: [ParameterAccess] access to parameter n1
+#   13|           1: [PropertyCall] access to property Value
+#   13|             -1: [ParameterAccess] access to parameter n2
+#   15|     8: [CheckedSubOperator] checked -
+#   15|       -1: [TypeMention] Number
+#-----|       2: (Parameters)
+#   15|         0: [Parameter] n1
+#   15|           -1: [TypeMention] Number
+#   15|         1: [Parameter] n2
+#   15|           -1: [TypeMention] Number
+#   16|       4: [ObjectCreation] object creation of type Number
+#   16|         -1: [TypeMention] Number
+#   16|         0: [CheckedExpr] checked (...)
+#   16|           0: [SubExpr] ... - ...
+#   16|             0: [PropertyCall] access to property Value
+#   16|               -1: [ParameterAccess] access to parameter n1
+#   16|             1: [PropertyCall] access to property Value
+#   16|               -1: [ParameterAccess] access to parameter n2
+#   18|     9: [SubOperator] -
+#   18|       -1: [TypeMention] Number
+#-----|       2: (Parameters)
+#   18|         0: [Parameter] n1
+#   18|           -1: [TypeMention] Number
+#   18|         1: [Parameter] n2
+#   18|           -1: [TypeMention] Number
+#   19|       4: [ObjectCreation] object creation of type Number
+#   19|         -1: [TypeMention] Number
+#   19|         0: [SubExpr] ... - ...
+#   19|           0: [PropertyCall] access to property Value
+#   19|             -1: [ParameterAccess] access to parameter n1
+#   19|           1: [PropertyCall] access to property Value
+#   19|             -1: [ParameterAccess] access to parameter n2
+#   21|     10: [CheckedMulOperator] checked *
+#   21|       -1: [TypeMention] Number
+#-----|       2: (Parameters)
+#   21|         0: [Parameter] n1
+#   21|           -1: [TypeMention] Number
+#   21|         1: [Parameter] n2
+#   21|           -1: [TypeMention] Number
+#   22|       4: [ObjectCreation] object creation of type Number
+#   22|         -1: [TypeMention] Number
+#   22|         0: [CheckedExpr] checked (...)
+#   22|           0: [MulExpr] ... * ...
+#   22|             0: [PropertyCall] access to property Value
+#   22|               -1: [ParameterAccess] access to parameter n1
+#   22|             1: [PropertyCall] access to property Value
+#   22|               -1: [ParameterAccess] access to parameter n2
+#   24|     11: [MulOperator] *
+#   24|       -1: [TypeMention] Number
+#-----|       2: (Parameters)
+#   24|         0: [Parameter] n1
+#   24|           -1: [TypeMention] Number
+#   24|         1: [Parameter] n2
+#   24|           -1: [TypeMention] Number
+#   25|       4: [ObjectCreation] object creation of type Number
+#   25|         -1: [TypeMention] Number
+#   25|         0: [MulExpr] ... * ...
+#   25|           0: [PropertyCall] access to property Value
+#   25|             -1: [ParameterAccess] access to parameter n1
+#   25|           1: [PropertyCall] access to property Value
+#   25|             -1: [ParameterAccess] access to parameter n2
+#   27|     12: [CheckedDivOperator] checked /
+#   27|       -1: [TypeMention] Number
+#-----|       2: (Parameters)
+#   27|         0: [Parameter] n1
+#   27|           -1: [TypeMention] Number
+#   27|         1: [Parameter] n2
+#   27|           -1: [TypeMention] Number
+#   28|       4: [ObjectCreation] object creation of type Number
+#   28|         -1: [TypeMention] Number
+#   28|         0: [CheckedExpr] checked (...)
+#   28|           0: [DivExpr] ... / ...
+#   28|             0: [PropertyCall] access to property Value
+#   28|               -1: [ParameterAccess] access to parameter n1
+#   28|             1: [PropertyCall] access to property Value
+#   28|               -1: [ParameterAccess] access to parameter n2
+#   30|     13: [DivOperator] /
+#   30|       -1: [TypeMention] Number
+#-----|       2: (Parameters)
+#   30|         0: [Parameter] n1
+#   30|           -1: [TypeMention] Number
+#   30|         1: [Parameter] n2
+#   30|           -1: [TypeMention] Number
+#   31|       4: [ObjectCreation] object creation of type Number
+#   31|         -1: [TypeMention] Number
+#   31|         0: [DivExpr] ... / ...
+#   31|           0: [PropertyCall] access to property Value
+#   31|             -1: [ParameterAccess] access to parameter n1
+#   31|           1: [PropertyCall] access to property Value
+#   31|             -1: [ParameterAccess] access to parameter n2
+#   33|     14: [CheckedMinusOperator] checked -
+#   33|       -1: [TypeMention] Number
+#-----|       2: (Parameters)
+#   33|         0: [Parameter] n
+#   33|           -1: [TypeMention] Number
+#   34|       4: [ObjectCreation] object creation of type Number
+#   34|         -1: [TypeMention] Number
+#   34|         0: [CheckedExpr] checked (...)
+#   34|           0: [UnaryMinusExpr] -...
+#   34|             0: [PropertyCall] access to property Value
+#   34|               -1: [ParameterAccess] access to parameter n
+#   36|     15: [MinusOperator] -
+#   36|       -1: [TypeMention] Number
+#-----|       2: (Parameters)
+#   36|         0: [Parameter] n
+#   36|           -1: [TypeMention] Number
+#   37|       4: [ObjectCreation] object creation of type Number
+#   37|         -1: [TypeMention] Number
+#   37|         0: [UnaryMinusExpr] -...
+#   37|           0: [PropertyCall] access to property Value
+#   37|             -1: [ParameterAccess] access to parameter n
+#   39|     16: [CheckedIncrementOperator] checked ++
+#   39|       -1: [TypeMention] Number
+#-----|       2: (Parameters)
+#   39|         0: [Parameter] n
+#   39|           -1: [TypeMention] Number
+#   40|       4: [ObjectCreation] object creation of type Number
+#   40|         -1: [TypeMention] Number
+#   40|         0: [CheckedExpr] checked (...)
+#   40|           0: [AddExpr] ... + ...
+#   40|             0: [PropertyCall] access to property Value
+#   40|               -1: [ParameterAccess] access to parameter n
+#   40|             1: [IntLiteral] 1
+#   42|     17: [IncrementOperator] ++
+#   42|       -1: [TypeMention] Number
+#-----|       2: (Parameters)
+#   42|         0: [Parameter] n
+#   42|           -1: [TypeMention] Number
+#   43|       4: [ObjectCreation] object creation of type Number
+#   43|         -1: [TypeMention] Number
+#   43|         0: [AddExpr] ... + ...
+#   43|           0: [PropertyCall] access to property Value
+#   43|             -1: [ParameterAccess] access to parameter n
+#   43|           1: [IntLiteral] 1
+#   45|     18: [CheckedDecrementOperator] checked --
+#   45|       -1: [TypeMention] Number
+#-----|       2: (Parameters)
+#   45|         0: [Parameter] n
+#   45|           -1: [TypeMention] Number
+#   46|       4: [ObjectCreation] object creation of type Number
+#   46|         -1: [TypeMention] Number
+#   46|         0: [CheckedExpr] checked (...)
+#   46|           0: [SubExpr] ... - ...
+#   46|             0: [PropertyCall] access to property Value
+#   46|               -1: [ParameterAccess] access to parameter n
+#   46|             1: [IntLiteral] 1
+#   48|     19: [DecrementOperator] --
+#   48|       -1: [TypeMention] Number
+#-----|       2: (Parameters)
+#   48|         0: [Parameter] n
+#   48|           -1: [TypeMention] Number
+#   49|       4: [ObjectCreation] object creation of type Number
+#   49|         -1: [TypeMention] Number
+#   49|         0: [SubExpr] ... - ...
+#   49|           0: [PropertyCall] access to property Value
+#   49|             -1: [ParameterAccess] access to parameter n
+#   49|           1: [IntLiteral] 1
+#   51|     20: [ExplicitConversionOperator] explicit conversion
+#   51|       -1: [TypeMention] short
+#-----|       2: (Parameters)
+#   51|         0: [Parameter] n
+#   51|           -1: [TypeMention] Number
+#   52|       4: [CastExpr] (...) ...
+#   52|         0: [TypeAccess] access to type Int16
+#   52|           0: [TypeMention] short
+#   52|         1: [PropertyCall] access to property Value
+#   52|           -1: [ParameterAccess] access to parameter n
+#   54|     21: [CheckedExplicitConversionOperator] checked explicit conversion
+#   54|       -1: [TypeMention] short
+#-----|       2: (Parameters)
+#   54|         0: [Parameter] n
+#   54|           -1: [TypeMention] Number
+#   55|       4: [CheckedExpr] checked (...)
+#   55|         0: [CastExpr] (...) ...
+#   55|           0: [TypeAccess] access to type Int16
+#   55|             0: [TypeMention] short
+#   55|           1: [PropertyCall] access to property Value
+#   55|             -1: [ParameterAccess] access to parameter n
 GenericAttribute.cs:
 #    3| [GenericAssemblyAttribute] [assembly: MyGeneric<Int32>(...)]
 #    3|   0: [TypeMention] MyGenericAttribute<int>

--- a/csharp/ql/test/library-tests/csharp11/checkedOperators.expected
+++ b/csharp/ql/test/library-tests/csharp11/checkedOperators.expected
@@ -1,0 +1,16 @@
+| CheckedOperators.cs:9:43:9:43 | checked + | op_CheckedAddition | CheckedAddOperator |
+| CheckedOperators.cs:12:35:12:35 | + | op_Addition | AddOperator |
+| CheckedOperators.cs:15:43:15:43 | checked - | op_CheckedSubtraction | CheckedSubOperator |
+| CheckedOperators.cs:18:35:18:35 | - | op_Subtraction | SubOperator |
+| CheckedOperators.cs:21:43:21:43 | checked * | op_CheckedMultiply | CheckedMulOperator |
+| CheckedOperators.cs:24:35:24:35 | * | op_Multiply | MulOperator |
+| CheckedOperators.cs:27:43:27:43 | checked / | op_CheckedDivision | CheckedDivOperator |
+| CheckedOperators.cs:30:35:30:35 | / | op_Division | DivOperator |
+| CheckedOperators.cs:33:43:33:43 | checked - | op_CheckedUnaryNegation | CheckedMinusOperator |
+| CheckedOperators.cs:36:35:36:35 | - | op_UnaryNegation | MinusOperator |
+| CheckedOperators.cs:39:43:39:44 | checked ++ | op_CheckedIncrement | CheckedIncrementOperator |
+| CheckedOperators.cs:42:35:42:36 | ++ | op_Increment | IncrementOperator |
+| CheckedOperators.cs:45:43:45:44 | checked -- | op_CheckedDecrement | CheckedDecrementOperator |
+| CheckedOperators.cs:48:35:48:36 | -- | op_Decrement | DecrementOperator |
+| CheckedOperators.cs:51:28:51:35 | explicit conversion | op_Explicit | ExplicitConversionOperator |
+| CheckedOperators.cs:54:28:54:35 | checked explicit conversion | op_CheckedExplicit | CheckedExplicitConversionOperator |

--- a/csharp/ql/test/library-tests/csharp11/checkedOperators.ql
+++ b/csharp/ql/test/library-tests/csharp11/checkedOperators.ql
@@ -1,0 +1,5 @@
+import csharp
+
+from Operator o
+where o.getFile().getStem() = "CheckedOperators"
+select o, o.getFunctionName(), o.getAPrimaryQlClass()

--- a/csharp/ql/test/library-tests/dispatch/CallGraph.expected
+++ b/csharp/ql/test/library-tests/dispatch/CallGraph.expected
@@ -238,3 +238,7 @@
 | ViableCallable.cs:458:10:458:14 | M5<> | ViableCallable.cs:444:23:444:27 | M2<> |
 | ViableCallable.cs:475:10:475:12 | Run | ViableCallable.cs:468:10:468:11 | M2 |
 | ViableCallable.cs:475:10:475:12 | Run | ViableCallable.cs:473:17:473:18 | M1 |
+| ViableCallable.cs:492:10:492:12 | Run | ViableCallable.cs:487:32:487:32 | + |
+| ViableCallable.cs:492:10:492:12 | Run | ViableCallable.cs:488:40:488:40 | checked + |
+| ViableCallable.cs:492:10:492:12 | Run | ViableCallable.cs:489:28:489:35 | explicit conversion |
+| ViableCallable.cs:492:10:492:12 | Run | ViableCallable.cs:490:28:490:35 | checked explicit conversion |

--- a/csharp/ql/test/library-tests/dispatch/GetADynamicTarget.expected
+++ b/csharp/ql/test/library-tests/dispatch/GetADynamicTarget.expected
@@ -471,3 +471,7 @@
 | ViableCallable.cs:461:9:461:30 | call to method M2<T> | C17.M2<T>(Func<T>) |
 | ViableCallable.cs:478:9:478:14 | call to method M1 | C18.M1() |
 | ViableCallable.cs:481:9:481:14 | call to method M2 | I2.M2() |
+| ViableCallable.cs:495:18:495:22 | call to operator + | C19.+(C19, C19) |
+| ViableCallable.cs:498:26:498:30 | call to operator checked + | C19.checked +(C19, C19) |
+| ViableCallable.cs:501:18:501:23 | call to operator explicit conversion | C19.explicit conversion(C19) |
+| ViableCallable.cs:504:26:504:31 | call to operator checked explicit conversion | C19.checked explicit conversion(C19) |

--- a/csharp/ql/test/library-tests/dispatch/ViableCallable.cs
+++ b/csharp/ql/test/library-tests/dispatch/ViableCallable.cs
@@ -481,3 +481,26 @@ class C18 : I2
         i.M2();
     }
 }
+
+class C19
+{
+    public static C19 operator +(C19 x, C19 y) => throw null;
+    public static C19 operator checked +(C19 x, C19 y) => throw null;
+    public static explicit operator int(C19 x) => throw null;
+    public static explicit operator checked int(C19 x) => throw null;
+
+    void Run(C19 c)
+    {
+        // Viable callables: C19.op_Addition()
+        var c1 = c + c;
+
+        // Viable callables: C19.op_CheckedAddition()
+        var c2 = checked(c + c);
+
+        // Viable callables: C19.op_Explicit()
+        var n1 = (int)c;
+
+        // Viable callables: C19.op_CheckedExplicit()
+        var n2 = checked((int)c);
+    }
+}

--- a/csharp/ql/test/library-tests/dispatch/viableCallable.expected
+++ b/csharp/ql/test/library-tests/dispatch/viableCallable.expected
@@ -268,3 +268,7 @@
 | ViableCallable.cs:423:9:423:21 | call to method M<String> | M<> | A5 |
 | ViableCallable.cs:478:9:478:14 | call to method M1 | M1 | C18 |
 | ViableCallable.cs:481:9:481:14 | call to method M2 | M2 | I2 |
+| ViableCallable.cs:495:18:495:22 | call to operator + | + | C19 |
+| ViableCallable.cs:498:26:498:30 | call to operator checked + | checked + | C19 |
+| ViableCallable.cs:501:18:501:23 | call to operator explicit conversion | explicit conversion | C19 |
+| ViableCallable.cs:504:26:504:31 | call to operator checked explicit conversion | checked explicit conversion | C19 |


### PR DESCRIPTION
In this PR we
- Introduce library support for `checked` operators (extractor support had already been implemented).
- Use the stored *method name* as the function name of an operator instead of hardcoding the name in the QL library code.
- Add appropriate tests.

There is compile time check that ensures that a *regular* operator i always defined, when a *checked* variant is defined.
```csharp
public class Number
{
    public int Value { get; }

    public static Number operator checked +(Number n1, Number n2) =>
        new Number(checked(n1.Value + n2.Value));

    public static Number operator +(Number n1, Number n2) =>
        new Number(n1.Value + n2.Value);
}
```

Should we structure this differently: Eg `AddOperator` could contains all (both *checked* and *regular* operators and then `CheckedAddOperator` could extend `AddOperator`?

Outstanding tasks
- [ ] Run DCA