### PR TITLE
JS: More library inputs

### DIFF
--- a/javascript/ql/lib/semmle/javascript/NodeModuleResolutionImpl.qll
+++ b/javascript/ql/lib/semmle/javascript/NodeModuleResolutionImpl.qll
@@ -120,6 +120,13 @@ private File resolveMainPath(PackageJson pkg, string mainPath, int priority) {
           priority - 999) // very high priority, to make sure everything else is tried first
     )
   )
+  or
+  not exists(MainModulePath::of(pkg, _)) and
+  exists(Folder parent |
+    parent = pkg.getFile().getParentContainer() and
+    result = tryExtensions(parent, "index", priority) and
+    mainPath = "."
+  )
 }
 
 /**

--- a/javascript/ql/lib/semmle/javascript/PackageExports.qll
+++ b/javascript/ql/lib/semmle/javascript/PackageExports.qll
@@ -45,6 +45,9 @@ private DataFlow::Node getAValueExportedByPackage() {
   // module.exports = new Foo();
   exists(DataFlow::SourceNode callee |
     callee = getAValueExportedByPackage().(DataFlow::NewNode).getCalleeNode().getALocalSource()
+    or
+    callee.(DataFlow::ClassNode).getConstructor() =
+      getAValueExportedByPackage().(DataFlow::NewNode).getCalleeNode().getAFunctionValue()
   |
     result = callee.getAPropertyRead("prototype").getAPropertyWrite(publicPropertyName()).getRhs()
     or

--- a/javascript/ql/test/query-tests/Security/CWE-400/ReDoS/PolynomialBackTracking.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-400/ReDoS/PolynomialBackTracking.expected
@@ -44,6 +44,8 @@
 | lib/subLib4/factory.js:8:3:8:4 | f* | Strings with many repetitions of 'f' can start matching anywhere after the start of the preceeding f*g |
 | lib/subLib5/feature.js:2:3:2:4 | a* | Strings with many repetitions of 'a' can start matching anywhere after the start of the preceeding a*b |
 | lib/subLib5/main.js:2:3:2:4 | a* | Strings with many repetitions of 'a' can start matching anywhere after the start of the preceeding a*b |
+| lib/subLib5/subclass.js:5:6:5:7 | a* | Strings with many repetitions of 'a' can start matching anywhere after the start of the preceeding a*b |
+| lib/subLib6/index.js:2:4:2:5 | f* | Strings with many repetitions of 'f' can start matching anywhere after the start of the preceeding f*g |
 | lib/sublib/factory.js:13:14:13:15 | f* | Strings with many repetitions of 'f' can start matching anywhere after the start of the preceeding f*g |
 | polynomial-redos.js:7:24:7:26 | \\s+ | Strings with many repetitions of '\\t' can start matching anywhere after the start of the preceeding \\s+$ |
 | polynomial-redos.js:8:17:8:18 |  * | Strings with many repetitions of ' ' can start matching anywhere after the start of the preceeding  *, * |

--- a/javascript/ql/test/query-tests/Security/CWE-400/ReDoS/PolynomialReDoS.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-400/ReDoS/PolynomialReDoS.expected
@@ -78,6 +78,14 @@ nodes
 | lib/subLib5/main.js:1:28:1:31 | name |
 | lib/subLib5/main.js:2:13:2:16 | name |
 | lib/subLib5/main.js:2:13:2:16 | name |
+| lib/subLib5/subclass.js:4:10:4:13 | name |
+| lib/subLib5/subclass.js:4:10:4:13 | name |
+| lib/subLib5/subclass.js:5:16:5:19 | name |
+| lib/subLib5/subclass.js:5:16:5:19 | name |
+| lib/subLib6/index.js:1:32:1:35 | name |
+| lib/subLib6/index.js:1:32:1:35 | name |
+| lib/subLib6/index.js:2:14:2:17 | name |
+| lib/subLib6/index.js:2:14:2:17 | name |
 | lib/sublib/factory.js:12:26:12:29 | name |
 | lib/sublib/factory.js:12:26:12:29 | name |
 | lib/sublib/factory.js:13:24:13:27 | name |
@@ -315,6 +323,14 @@ edges
 | lib/subLib5/main.js:1:28:1:31 | name | lib/subLib5/main.js:2:13:2:16 | name |
 | lib/subLib5/main.js:1:28:1:31 | name | lib/subLib5/main.js:2:13:2:16 | name |
 | lib/subLib5/main.js:1:28:1:31 | name | lib/subLib5/main.js:2:13:2:16 | name |
+| lib/subLib5/subclass.js:4:10:4:13 | name | lib/subLib5/subclass.js:5:16:5:19 | name |
+| lib/subLib5/subclass.js:4:10:4:13 | name | lib/subLib5/subclass.js:5:16:5:19 | name |
+| lib/subLib5/subclass.js:4:10:4:13 | name | lib/subLib5/subclass.js:5:16:5:19 | name |
+| lib/subLib5/subclass.js:4:10:4:13 | name | lib/subLib5/subclass.js:5:16:5:19 | name |
+| lib/subLib6/index.js:1:32:1:35 | name | lib/subLib6/index.js:2:14:2:17 | name |
+| lib/subLib6/index.js:1:32:1:35 | name | lib/subLib6/index.js:2:14:2:17 | name |
+| lib/subLib6/index.js:1:32:1:35 | name | lib/subLib6/index.js:2:14:2:17 | name |
+| lib/subLib6/index.js:1:32:1:35 | name | lib/subLib6/index.js:2:14:2:17 | name |
 | lib/sublib/factory.js:12:26:12:29 | name | lib/sublib/factory.js:13:24:13:27 | name |
 | lib/sublib/factory.js:12:26:12:29 | name | lib/sublib/factory.js:13:24:13:27 | name |
 | lib/sublib/factory.js:12:26:12:29 | name | lib/sublib/factory.js:13:24:13:27 | name |
@@ -488,6 +504,8 @@ edges
 | lib/subLib4/factory.js:8:2:8:17 | /f*g/.test(name) | lib/subLib4/factory.js:7:27:7:30 | name | lib/subLib4/factory.js:8:13:8:16 | name | This $@ that depends on $@ may run slow on strings with many repetitions of 'f'. | lib/subLib4/factory.js:8:3:8:4 | f* | regular expression | lib/subLib4/factory.js:7:27:7:30 | name | library input |
 | lib/subLib5/feature.js:2:2:2:17 | /a*b/.test(name) | lib/subLib5/feature.js:1:28:1:31 | name | lib/subLib5/feature.js:2:13:2:16 | name | This $@ that depends on $@ may run slow on strings with many repetitions of 'a'. | lib/subLib5/feature.js:2:3:2:4 | a* | regular expression | lib/subLib5/feature.js:1:28:1:31 | name | library input |
 | lib/subLib5/main.js:2:2:2:17 | /a*b/.test(name) | lib/subLib5/main.js:1:28:1:31 | name | lib/subLib5/main.js:2:13:2:16 | name | This $@ that depends on $@ may run slow on strings with many repetitions of 'a'. | lib/subLib5/main.js:2:3:2:4 | a* | regular expression | lib/subLib5/main.js:1:28:1:31 | name | library input |
+| lib/subLib5/subclass.js:5:5:5:20 | /a*b/.test(name) | lib/subLib5/subclass.js:4:10:4:13 | name | lib/subLib5/subclass.js:5:16:5:19 | name | This $@ that depends on $@ may run slow on strings with many repetitions of 'a'. | lib/subLib5/subclass.js:5:6:5:7 | a* | regular expression | lib/subLib5/subclass.js:4:10:4:13 | name | library input |
+| lib/subLib6/index.js:2:3:2:18 | /f*g/.test(name) | lib/subLib6/index.js:1:32:1:35 | name | lib/subLib6/index.js:2:14:2:17 | name | This $@ that depends on $@ may run slow on strings with many repetitions of 'f'. | lib/subLib6/index.js:2:4:2:5 | f* | regular expression | lib/subLib6/index.js:1:32:1:35 | name | library input |
 | lib/sublib/factory.js:13:13:13:28 | /f*g/.test(name) | lib/sublib/factory.js:12:26:12:29 | name | lib/sublib/factory.js:13:24:13:27 | name | This $@ that depends on $@ may run slow on strings with many repetitions of 'f'. | lib/sublib/factory.js:13:14:13:15 | f* | regular expression | lib/sublib/factory.js:12:26:12:29 | name | library input |
 | polynomial-redos.js:7:2:7:34 | tainted ... /g, '') | polynomial-redos.js:5:16:5:32 | req.query.tainted | polynomial-redos.js:7:2:7:8 | tainted | This $@ that depends on $@ may run slow on strings with many repetitions of '\\t'. | polynomial-redos.js:7:24:7:26 | \\s+ | regular expression | polynomial-redos.js:5:16:5:32 | req.query.tainted | a user-provided value |
 | polynomial-redos.js:8:2:8:23 | tainted ...  *, */) | polynomial-redos.js:5:16:5:32 | req.query.tainted | polynomial-redos.js:8:2:8:8 | tainted | This $@ that depends on $@ may run slow on strings with many repetitions of ' '. | polynomial-redos.js:8:17:8:18 |  * | regular expression | polynomial-redos.js:5:16:5:32 | req.query.tainted | a user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-400/ReDoS/lib/subLib5/main.js
+++ b/javascript/ql/test/query-tests/Security/CWE-400/ReDoS/lib/subLib5/main.js
@@ -1,3 +1,6 @@
 module.exports = function (name) {
 	/a*b/.test(name); // NOT OK
 };
+
+const SubClass = require('./subclass');
+module.exports.SubClass = new SubClass();

--- a/javascript/ql/test/query-tests/Security/CWE-400/ReDoS/lib/subLib5/subclass.js
+++ b/javascript/ql/test/query-tests/Security/CWE-400/ReDoS/lib/subLib5/subclass.js
@@ -1,0 +1,9 @@
+class Subclass {
+  constructor() {}
+
+  define(name) {
+    /a*b/.test(name); // NOT OK
+  }
+}
+
+module.exports = Subclass;

--- a/javascript/ql/test/query-tests/Security/CWE-400/ReDoS/lib/subLib6/index.js
+++ b/javascript/ql/test/query-tests/Security/CWE-400/ReDoS/lib/subLib6/index.js
@@ -1,0 +1,3 @@
+module.exports.foo = function (name) {
+  /f*g/.test(name); // NOT OK
+}

--- a/javascript/ql/test/query-tests/Security/CWE-400/ReDoS/lib/subLib6/package.json
+++ b/javascript/ql/test/query-tests/Security/CWE-400/ReDoS/lib/subLib6/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "my-sub-lib",
+  "version": "0.0.7"
+}


### PR DESCRIPTION
CVE-2017-16138: TP

Recognize an `index.js` file that is sibling to a `package.json` as being exported when no `main:` field is set in the `package.json`.  
And better tracking of class-constructors when finding library inputs. 

[Evaluation looks OK](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/PR-12170-0-javascript__1/reports).  
I'm quite sure the performance improvement is spurious. 