### PR TITLE
JS: dont recognize regexps that match dot as sanitizers

### DIFF
--- a/javascript/ql/lib/semmle/javascript/MembershipCandidates.qll
+++ b/javascript/ql/lib/semmle/javascript/MembershipCandidates.qll
@@ -147,7 +147,9 @@ module MembershipCandidate {
         child instanceof RegExpConstant or
         child instanceof RegExpAlt or
         child instanceof RegExpGroup
-      )
+      ) and
+      // exclude "length matches" that match every string
+      not this.getAChild*() instanceof RegExpDot
     }
 
     /**

--- a/javascript/ql/test/experimental/Security/CWE-918/SSRF.expected
+++ b/javascript/ql/test/experimental/Security/CWE-918/SSRF.expected
@@ -41,6 +41,10 @@ nodes
 | check-path.js:45:13:45:44 | `${base ... inted}` |
 | check-path.js:45:26:45:42 | req.query.tainted |
 | check-path.js:45:26:45:42 | req.query.tainted |
+| check-regex.js:16:15:16:45 | "test.c ... tainted |
+| check-regex.js:16:15:16:45 | "test.c ... tainted |
+| check-regex.js:16:29:16:45 | req.query.tainted |
+| check-regex.js:16:29:16:45 | req.query.tainted |
 | check-regex.js:24:15:24:42 | baseURL ... tainted |
 | check-regex.js:24:15:24:42 | baseURL ... tainted |
 | check-regex.js:24:25:24:42 | req.params.tainted |
@@ -121,6 +125,10 @@ edges
 | check-path.js:45:26:45:42 | req.query.tainted | check-path.js:45:13:45:44 | `${base ... inted}` |
 | check-path.js:45:26:45:42 | req.query.tainted | check-path.js:45:13:45:44 | `${base ... inted}` |
 | check-path.js:45:26:45:42 | req.query.tainted | check-path.js:45:13:45:44 | `${base ... inted}` |
+| check-regex.js:16:29:16:45 | req.query.tainted | check-regex.js:16:15:16:45 | "test.c ... tainted |
+| check-regex.js:16:29:16:45 | req.query.tainted | check-regex.js:16:15:16:45 | "test.c ... tainted |
+| check-regex.js:16:29:16:45 | req.query.tainted | check-regex.js:16:15:16:45 | "test.c ... tainted |
+| check-regex.js:16:29:16:45 | req.query.tainted | check-regex.js:16:15:16:45 | "test.c ... tainted |
 | check-regex.js:24:25:24:42 | req.params.tainted | check-regex.js:24:15:24:42 | baseURL ... tainted |
 | check-regex.js:24:25:24:42 | req.params.tainted | check-regex.js:24:15:24:42 | baseURL ... tainted |
 | check-regex.js:24:25:24:42 | req.params.tainted | check-regex.js:24:15:24:42 | baseURL ... tainted |
@@ -173,6 +181,7 @@ edges
 | check-path.js:33:15:33:45 | 'test.c ... tainted | check-path.js:33:29:33:45 | req.query.tainted | check-path.js:33:15:33:45 | 'test.c ... tainted | The URL of this request depends on a user-provided value. |
 | check-path.js:37:15:37:45 | 'test.c ... tainted | check-path.js:37:29:37:45 | req.query.tainted | check-path.js:37:15:37:45 | 'test.c ... tainted | The URL of this request depends on a user-provided value. |
 | check-path.js:45:13:45:44 | `${base ... inted}` | check-path.js:45:26:45:42 | req.query.tainted | check-path.js:45:13:45:44 | `${base ... inted}` | The URL of this request depends on a user-provided value. |
+| check-regex.js:16:15:16:45 | "test.c ... tainted | check-regex.js:16:29:16:45 | req.query.tainted | check-regex.js:16:15:16:45 | "test.c ... tainted | The URL of this request depends on a user-provided value. |
 | check-regex.js:24:15:24:42 | baseURL ... tainted | check-regex.js:24:25:24:42 | req.params.tainted | check-regex.js:24:15:24:42 | baseURL ... tainted | The URL of this request depends on a user-provided value. |
 | check-regex.js:31:15:31:45 | "test.c ... tainted | check-regex.js:31:29:31:45 | req.query.tainted | check-regex.js:31:15:31:45 | "test.c ... tainted | The URL of this request depends on a user-provided value. |
 | check-regex.js:34:15:34:42 | baseURL ... tainted | check-regex.js:34:25:34:42 | req.params.tainted | check-regex.js:34:15:34:42 | baseURL ... tainted | The URL of this request depends on a user-provided value. |

--- a/javascript/ql/test/query-tests/Security/CWE-078/UnsafeShellCommandConstruction/UnsafeShellCommandConstruction.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-078/UnsafeShellCommandConstruction/UnsafeShellCommandConstruction.expected
@@ -293,6 +293,14 @@ nodes
 | lib/lib.js:555:25:555:37 | ["-rf", name] |
 | lib/lib.js:555:33:555:36 | name |
 | lib/lib.js:555:33:555:36 | name |
+| lib/lib.js:558:41:558:44 | name |
+| lib/lib.js:558:41:558:44 | name |
+| lib/lib.js:560:26:560:29 | name |
+| lib/lib.js:560:26:560:29 | name |
+| lib/lib.js:562:26:562:29 | name |
+| lib/lib.js:562:26:562:29 | name |
+| lib/lib.js:566:26:566:29 | name |
+| lib/lib.js:566:26:566:29 | name |
 | lib/subLib2/compiled-file.ts:3:26:3:29 | name |
 | lib/subLib2/compiled-file.ts:3:26:3:29 | name |
 | lib/subLib2/compiled-file.ts:4:25:4:28 | name |
@@ -683,6 +691,18 @@ edges
 | lib/lib.js:551:33:551:36 | args | lib/lib.js:552:23:552:26 | args |
 | lib/lib.js:555:25:555:37 | ["-rf", name] | lib/lib.js:551:33:551:36 | args |
 | lib/lib.js:555:33:555:36 | name | lib/lib.js:555:25:555:37 | ["-rf", name] |
+| lib/lib.js:558:41:558:44 | name | lib/lib.js:560:26:560:29 | name |
+| lib/lib.js:558:41:558:44 | name | lib/lib.js:560:26:560:29 | name |
+| lib/lib.js:558:41:558:44 | name | lib/lib.js:560:26:560:29 | name |
+| lib/lib.js:558:41:558:44 | name | lib/lib.js:560:26:560:29 | name |
+| lib/lib.js:558:41:558:44 | name | lib/lib.js:562:26:562:29 | name |
+| lib/lib.js:558:41:558:44 | name | lib/lib.js:562:26:562:29 | name |
+| lib/lib.js:558:41:558:44 | name | lib/lib.js:562:26:562:29 | name |
+| lib/lib.js:558:41:558:44 | name | lib/lib.js:562:26:562:29 | name |
+| lib/lib.js:558:41:558:44 | name | lib/lib.js:566:26:566:29 | name |
+| lib/lib.js:558:41:558:44 | name | lib/lib.js:566:26:566:29 | name |
+| lib/lib.js:558:41:558:44 | name | lib/lib.js:566:26:566:29 | name |
+| lib/lib.js:558:41:558:44 | name | lib/lib.js:566:26:566:29 | name |
 | lib/subLib2/compiled-file.ts:3:26:3:29 | name | lib/subLib2/compiled-file.ts:4:25:4:28 | name |
 | lib/subLib2/compiled-file.ts:3:26:3:29 | name | lib/subLib2/compiled-file.ts:4:25:4:28 | name |
 | lib/subLib2/compiled-file.ts:3:26:3:29 | name | lib/subLib2/compiled-file.ts:4:25:4:28 | name |
@@ -803,6 +823,9 @@ edges
 | lib/lib.js:545:11:545:26 | "rm -rf " + name | lib/lib.js:509:39:509:42 | name | lib/lib.js:545:23:545:26 | name | This string concatenation which depends on $@ is later used in a $@. | lib/lib.js:509:39:509:42 | name | library input | lib/lib.js:545:3:545:27 | cp.exec ... + name) | shell command |
 | lib/lib.js:552:23:552:26 | args | lib/lib.js:550:39:550:42 | name | lib/lib.js:552:23:552:26 | args | This shell argument which depends on $@ is later used in a $@. | lib/lib.js:550:39:550:42 | name | library input | lib/lib.js:552:9:552:38 | cp.spaw ... wnOpts) | shell command |
 | lib/lib.js:555:33:555:36 | name | lib/lib.js:550:39:550:42 | name | lib/lib.js:555:33:555:36 | name | This shell argument which depends on $@ is later used in a $@. | lib/lib.js:550:39:550:42 | name | library input | lib/lib.js:552:9:552:38 | cp.spaw ... wnOpts) | shell command |
+| lib/lib.js:560:14:560:29 | "rm -rf " + name | lib/lib.js:558:41:558:44 | name | lib/lib.js:560:26:560:29 | name | This string concatenation which depends on $@ is later used in a $@. | lib/lib.js:558:41:558:44 | name | library input | lib/lib.js:560:9:560:30 | exec("r ... + name) | shell command |
+| lib/lib.js:562:14:562:29 | "rm -rf " + name | lib/lib.js:558:41:558:44 | name | lib/lib.js:562:26:562:29 | name | This string concatenation which depends on $@ is later used in a $@. | lib/lib.js:558:41:558:44 | name | library input | lib/lib.js:562:9:562:30 | exec("r ... + name) | shell command |
+| lib/lib.js:566:14:566:29 | "rm -rf " + name | lib/lib.js:558:41:558:44 | name | lib/lib.js:566:26:566:29 | name | This string concatenation which depends on $@ is later used in a $@. | lib/lib.js:558:41:558:44 | name | library input | lib/lib.js:566:9:566:30 | exec("r ... + name) | shell command |
 | lib/subLib2/compiled-file.ts:4:13:4:28 | "rm -rf " + name | lib/subLib2/compiled-file.ts:3:26:3:29 | name | lib/subLib2/compiled-file.ts:4:25:4:28 | name | This string concatenation which depends on $@ is later used in a $@. | lib/subLib2/compiled-file.ts:3:26:3:29 | name | library input | lib/subLib2/compiled-file.ts:4:5:4:29 | cp.exec ... + name) | shell command |
 | lib/subLib2/special-file.js:4:10:4:25 | "rm -rf " + name | lib/subLib2/special-file.js:3:28:3:31 | name | lib/subLib2/special-file.js:4:22:4:25 | name | This string concatenation which depends on $@ is later used in a $@. | lib/subLib2/special-file.js:3:28:3:31 | name | library input | lib/subLib2/special-file.js:4:2:4:26 | cp.exec ... + name) | shell command |
 | lib/subLib3/my-file.ts:4:10:4:25 | "rm -rf " + name | lib/subLib3/my-file.ts:3:28:3:31 | name | lib/subLib3/my-file.ts:4:22:4:25 | name | This string concatenation which depends on $@ is later used in a $@. | lib/subLib3/my-file.ts:3:28:3:31 | name | library input | lib/subLib3/my-file.ts:4:2:4:26 | cp.exec ... + name) | shell command |

--- a/javascript/ql/test/query-tests/Security/CWE-078/UnsafeShellCommandConstruction/lib/lib.js
+++ b/javascript/ql/test/query-tests/Security/CWE-078/UnsafeShellCommandConstruction/lib/lib.js
@@ -554,3 +554,17 @@ module.exports.shellThing = function (name) {
     
     indirectShell("rm", ["-rf", name], {shell: true});
 }
+
+module.exports.badSanitizer = function (name) {
+    if (!name.match(/^(.|\.){1,64}$/)) { // <- bad sanitizer
+        exec("rm -rf " + name); // NOT OK
+    } else {
+        exec("rm -rf " + name); // NOT OK
+    }
+
+    if (!name.match(/^\w{1,64}$/)) { // <- good sanitizer
+        exec("rm -rf " + name); // NOT OK
+    } else {
+        exec("rm -rf " + name); // OK
+    }
+}


### PR DESCRIPTION
CVE-2019-10778: TP

[Evaluation was unevenful](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/PR-12171-0-javascript/reports).  