### PR TITLE
C++: Use `Content` approximation

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -1628,9 +1628,7 @@ private newtype TContent =
     // field can be read by any read of the union's fields.
     indirectionIndex =
       [1 .. max(Ssa::getMaxIndirectionsForType(u.getAField().getUnspecifiedType()))]
-  } or
-  TCollectionContent() or // Not used in C/C++
-  TArrayContent() // Not used in C/C++.
+  }
 
 /**
  * A description of the way data may be stored inside an object. Examples
@@ -1682,20 +1680,12 @@ class UnionContent extends Content, TUnionContent {
 
   Field getAField() { result = u.getAField() }
 
+  Union getUnion() { result = u }
+
   pragma[inline]
   int getIndirectionIndex() {
     pragma[only_bind_into](result) = pragma[only_bind_out](indirectionIndex)
   }
-}
-
-/** A reference through an array. */
-class ArrayContent extends Content, TArrayContent {
-  override string toString() { result = "[]" }
-}
-
-/** A reference through the contents of some collection-like container. */
-private class CollectionContent extends Content, TCollectionContent {
-  override string toString() { result = "<element>" }
 }
 
 /**

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -1678,10 +1678,13 @@ class UnionContent extends Content, TUnionContent {
     indirectionIndex > 1 and result = u.toString() + " indirection"
   }
 
+  /** Gets a field of the underlying union of this `UnionContent`, if any. */
   Field getAField() { result = u.getAField() }
 
+  /** Gets the underlying union of this `UnionContent`. */
   Union getUnion() { result = u }
 
+  /** Gets the indirection index of this `UnionContent`. */
   pragma[inline]
   int getIndirectionIndex() {
     pragma[only_bind_into](result) = pragma[only_bind_out](indirectionIndex)


### PR DESCRIPTION
This PR makes use of the `Content` approximation mechanism that was added by Tom [here](https://github.com/github/codeql/pull/11635). It _should_ be a strict performance boost (and it's part of the performance fixes I'm doing for Nelson and vim).

There's a lot of ongoing (and unanswered questions) so far about what makes a good `Content` approximation. This PR just uses the same scheme as used by the other languages. I did experiment with slight variations (using the _last_ character and using the first 2 or 3 letters in the name), but they were either equally good or slightly worse.