### PR TITLE
C++: Better discrimination for union `Content`s

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -1616,6 +1616,19 @@ predicate localExprFlow(Expr e1, Expr e2) {
   localExprFlowPlus(e1, e2)
 }
 
+bindingset[f]
+pragma[inline_late]
+private int getFieldSize(Field f) { result = f.getType().getSize() }
+
+/**
+ * Gets a field in the union `u` whose size
+ * is `bytes` number of bytes.
+ */
+private Field getAFieldWithSize(Union u, int bytes) {
+  result = u.getAField() and
+  bytes = getFieldSize(result)
+}
+
 cached
 private newtype TContent =
   TFieldContent(Field f, int indirectionIndex) {
@@ -1623,11 +1636,15 @@ private newtype TContent =
     // Reads and writes of union fields are tracked using `UnionContent`.
     not f.getDeclaringType() instanceof Union
   } or
-  TUnionContent(Union u, int indirectionIndex) {
-    // We key `UnionContent` by the union instead of its fields since a write to one
-    // field can be read by any read of the union's fields.
-    indirectionIndex =
-      [1 .. max(Ssa::getMaxIndirectionsForType(u.getAField().getUnspecifiedType()))]
+  TUnionContent(Union u, int bytes, int indirectionIndex) {
+    exists(Field f |
+      f = u.getAField() and
+      bytes = getFieldSize(f) and
+      // We key `UnionContent` by the union instead of its fields since a write to one
+      // field can be read by any read of the union's fields.
+      indirectionIndex =
+        [1 .. max(Ssa::getMaxIndirectionsForType(getAFieldWithSize(u, bytes).getUnspecifiedType()))]
+    )
   }
 
 /**
@@ -1669,8 +1686,9 @@ class FieldContent extends Content, TFieldContent {
 class UnionContent extends Content, TUnionContent {
   Union u;
   int indirectionIndex;
+  int bytes;
 
-  UnionContent() { this = TUnionContent(u, indirectionIndex) }
+  UnionContent() { this = TUnionContent(u, bytes, indirectionIndex) }
 
   override string toString() {
     indirectionIndex = 1 and result = u.toString()
@@ -1679,7 +1697,7 @@ class UnionContent extends Content, TUnionContent {
   }
 
   /** Gets a field of the underlying union of this `UnionContent`, if any. */
-  Field getAField() { result = u.getAField() }
+  Field getAField() { result = u.getAField() and getFieldSize(result) = bytes }
 
   /** Gets the underlying union of this `UnionContent`. */
   Union getUnion() { result = u }


### PR DESCRIPTION
This PR fixes a performance problem on the use-use flow branch.

One of the things the dataflow library computes is the possible set of tails for an access path that starts with a specific `Content`. We have modelled a read of (or write to) a union using a `Content` branch defined by the union type itself (so that you can write to one union member and read it off another).

The problem is that this makes the set of tails for a union `Content` the a lot larger than the set of tails for a specific Field (since there's just 1 `Content` value per union in the database).

Performance-wise the best fix would be to model unions as we model regular struct fields (as this would increase the discrimination factor by creating a `Content` branch for each field in the union instead of 1 `Content` branch for each union in the database). However, this would prevent a write to one union field to flow to another union read of a different field. This pattern occurs quite frequently (especially in C projects where it's not actually undefined behavior).

Instead, this PR adds another column to the union `Content` branch that specifies "the size of the field that's currently active in the union". This means there are more union `Content` branches in the database (so that the set of tail access paths is spread out more across those `Content`s), while still ensuring that we get dataflow in examples like:
```cpp
union A {
  int x;
  unsigned char buffer[sizeof(int)];
};

void test() {
  A a;
  a.x = source();
  sink(a.buffer);
}
```

Locally, this gives me a large speedup for the Nelson project.