### PR TITLE
JS: also consider relative exports when finding library inputs

### DIFF
--- a/javascript/ql/lib/semmle/javascript/NPM.qll
+++ b/javascript/ql/lib/semmle/javascript/NPM.qll
@@ -198,9 +198,7 @@ class PackageJson extends JsonObject {
   /**
    * Gets the main module of this package.
    */
-  Module getMainModule() {
-    result = min(Module m, int prio | m.getFile() = resolveMainModule(this, prio) | m order by prio)
-  }
+  Module getMainModule() { result = getExportedModule(".") }
 
   /**
    * Gets the module exported under the given relative path.
@@ -208,10 +206,12 @@ class PackageJson extends JsonObject {
    * The main module is considered exported under the path `"."`.
    */
   Module getExportedModule(string relativePath) {
-    relativePath = "." and
-    result = this.getMainModule()
-    or
-    result.getFile() = MainModulePath::of(this, relativePath).resolve()
+    result =
+      min(Module m, int prio |
+        m.getFile() = resolveMainModule(this, prio, relativePath)
+      |
+        m order by prio
+      )
   }
 
   /**

--- a/javascript/ql/lib/semmle/javascript/NPM.qll
+++ b/javascript/ql/lib/semmle/javascript/NPM.qll
@@ -198,7 +198,7 @@ class PackageJson extends JsonObject {
   /**
    * Gets the main module of this package.
    */
-  Module getMainModule() { result = getExportedModule(".") }
+  Module getMainModule() { result = this.getExportedModule(".") }
 
   /**
    * Gets the module exported under the given relative path.

--- a/javascript/ql/lib/semmle/javascript/PackageExports.qll
+++ b/javascript/ql/lib/semmle/javascript/PackageExports.qll
@@ -133,7 +133,9 @@ private DataFlow::Node getAValueExportedByPackage() {
     DataFlow::globalVarRef("define").getACall().getAnArgument() = factory.getALocalUse() and
     func.getFile() =
       min(int j, File f |
-        f = NodeModule::resolveMainModule(any(PackageJson pack | exists(pack.getPackageName())), j)
+        f =
+          NodeModule::resolveMainModule(any(PackageJson pack | exists(pack.getPackageName())), j,
+            ".")
       |
         f order by j
       )

--- a/javascript/ql/test/query-tests/Security/CWE-079/UnsafeHtmlConstruction/UnsafeHtmlConstruction.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/UnsafeHtmlConstruction/UnsafeHtmlConstruction.expected
@@ -12,6 +12,10 @@ nodes
 | lib2/index.ts:1:28:1:28 | s |
 | lib2/index.ts:2:29:2:29 | s |
 | lib2/index.ts:2:29:2:29 | s |
+| lib2/src/MyNode.ts:1:28:1:28 | s |
+| lib2/src/MyNode.ts:1:28:1:28 | s |
+| lib2/src/MyNode.ts:2:29:2:29 | s |
+| lib2/src/MyNode.ts:2:29:2:29 | s |
 | lib/src/MyNode.ts:1:28:1:28 | s |
 | lib/src/MyNode.ts:1:28:1:28 | s |
 | lib/src/MyNode.ts:2:29:2:29 | s |
@@ -108,6 +112,10 @@ edges
 | lib2/index.ts:1:28:1:28 | s | lib2/index.ts:2:29:2:29 | s |
 | lib2/index.ts:1:28:1:28 | s | lib2/index.ts:2:29:2:29 | s |
 | lib2/index.ts:1:28:1:28 | s | lib2/index.ts:2:29:2:29 | s |
+| lib2/src/MyNode.ts:1:28:1:28 | s | lib2/src/MyNode.ts:2:29:2:29 | s |
+| lib2/src/MyNode.ts:1:28:1:28 | s | lib2/src/MyNode.ts:2:29:2:29 | s |
+| lib2/src/MyNode.ts:1:28:1:28 | s | lib2/src/MyNode.ts:2:29:2:29 | s |
+| lib2/src/MyNode.ts:1:28:1:28 | s | lib2/src/MyNode.ts:2:29:2:29 | s |
 | lib/src/MyNode.ts:1:28:1:28 | s | lib/src/MyNode.ts:2:29:2:29 | s |
 | lib/src/MyNode.ts:1:28:1:28 | s | lib/src/MyNode.ts:2:29:2:29 | s |
 | lib/src/MyNode.ts:1:28:1:28 | s | lib/src/MyNode.ts:2:29:2:29 | s |
@@ -200,6 +208,7 @@ edges
 | jquery-plugin.js:12:31:12:41 | options.foo | jquery-plugin.js:11:34:11:40 | options | jquery-plugin.js:12:31:12:41 | options.foo | This HTML construction which depends on $@ might later allow $@. | jquery-plugin.js:11:34:11:40 | options | library input | jquery-plugin.js:12:20:12:53 | "<span> ... /span>" | cross-site scripting |
 | jquery-plugin.js:14:31:14:35 | stuff | jquery-plugin.js:11:27:11:31 | stuff | jquery-plugin.js:14:31:14:35 | stuff | This HTML construction which depends on $@ might later allow $@. | jquery-plugin.js:11:27:11:31 | stuff | library input | jquery-plugin.js:14:20:14:47 | "<span> ... /span>" | cross-site scripting |
 | lib2/index.ts:2:29:2:29 | s | lib2/index.ts:1:28:1:28 | s | lib2/index.ts:2:29:2:29 | s | This HTML construction which depends on $@ might later allow $@. | lib2/index.ts:1:28:1:28 | s | library input | lib2/index.ts:3:49:3:52 | html | cross-site scripting |
+| lib2/src/MyNode.ts:2:29:2:29 | s | lib2/src/MyNode.ts:1:28:1:28 | s | lib2/src/MyNode.ts:2:29:2:29 | s | This HTML construction which depends on $@ might later allow $@. | lib2/src/MyNode.ts:1:28:1:28 | s | library input | lib2/src/MyNode.ts:3:49:3:52 | html | cross-site scripting |
 | lib/src/MyNode.ts:2:29:2:29 | s | lib/src/MyNode.ts:1:28:1:28 | s | lib/src/MyNode.ts:2:29:2:29 | s | This HTML construction which depends on $@ might later allow $@. | lib/src/MyNode.ts:1:28:1:28 | s | library input | lib/src/MyNode.ts:3:49:3:52 | html | cross-site scripting |
 | main.js:2:29:2:29 | s | main.js:1:55:1:55 | s | main.js:2:29:2:29 | s | This HTML construction which depends on $@ might later allow $@. | main.js:1:55:1:55 | s | library input | main.js:3:49:3:52 | html | cross-site scripting |
 | main.js:7:49:7:49 | s | main.js:6:49:6:49 | s | main.js:7:49:7:49 | s | This XML parsing which depends on $@ might later allow $@. | main.js:6:49:6:49 | s | library input | main.js:8:48:8:66 | doc.documentElement | cross-site scripting |

--- a/javascript/ql/test/query-tests/Security/CWE-079/UnsafeHtmlConstruction/lib2/package.json
+++ b/javascript/ql/test/query-tests/Security/CWE-079/UnsafeHtmlConstruction/lib2/package.json
@@ -1,6 +1,6 @@
 {
     "name": "my-unsafe-library",
-    "main": "./foobar.js",
+    "main": "./index.ts",
     "exports": {
         "./MyNode": {
             "require": "./lib/MyNode.cjs",

--- a/javascript/ql/test/query-tests/Security/CWE-079/UnsafeHtmlConstruction/lib2/src/MyNode.ts
+++ b/javascript/ql/test/query-tests/Security/CWE-079/UnsafeHtmlConstruction/lib2/src/MyNode.ts
@@ -1,4 +1,4 @@
 export function trivialXss(s: string) {
-    const html = "<span>" + s + "</span>"; // OK - this file is not recognized as a main file.
+    const html = "<span>" + s + "</span>"; // NOT OK - this file is not recognized as a main file.
     document.querySelector("#html").innerHTML = html;
 }


### PR DESCRIPTION
CVE-2022-36036: TP 

And simplify some of the related code.   
I just had to change an existing test slightly to test the new behavior. 

[Evaluation was unevenful](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/PR-12189-0-javascript/reports). 