### PR TITLE
JS: Actually extract `.html.erb` files.  

### DIFF
--- a/javascript/extractor/src/com/semmle/js/extractor/FileExtractor.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/FileExtractor.java
@@ -356,7 +356,7 @@ public class FileExtractor {
 
     /** Determine the {@link FileType} for a given file based on its extension only. */
     public static FileType forFileExtension(File f) {
-      String lcExt = StringUtil.lc(FileUtil.extension(f)); // TODO: Here, it doesn't recognize .html.erb files
+      String lcExt = StringUtil.lc(FileUtil.extension(f));
       for (FileType tp : values())
         if (tp.getExtensions().contains(lcExt)) {
           return tp;

--- a/javascript/extractor/src/com/semmle/js/extractor/FileExtractor.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/FileExtractor.java
@@ -122,7 +122,7 @@ public class FileExtractor {
         }
         // for ERB files we are only interrested in `.html.erb` files
         if (FileUtil.extension(f).equalsIgnoreCase(".erb")) {
-          if (!f.getName().endsWith(".html.erb")) {
+          if (!f.getName().toLowerCase().endsWith(".html.erb")) {
             return false;
           }
         }

--- a/javascript/extractor/src/com/semmle/js/extractor/FileExtractor.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/FileExtractor.java
@@ -104,7 +104,7 @@ public class FileExtractor {
 
   /** Information about supported file types. */
   public static enum FileType {
-    HTML(".htm", ".html", ".xhtm", ".xhtml", ".vue", ".hbs", ".ejs", ".njk", ".html.erb") {
+    HTML(".htm", ".html", ".xhtm", ".xhtml", ".vue", ".hbs", ".ejs", ".njk", ".erb") {
       @Override
       public IExtractor mkExtractor(ExtractorConfig config, ExtractorState state) {
         return new HTMLExtractor(config, state);
@@ -119,6 +119,12 @@ public class FileExtractor {
       protected boolean contains(File f, String lcExt, ExtractorConfig config) {
         if (isBinaryFile(f, lcExt, config)) {
           return false;
+        }
+        // for ERB files we are only interrested in `.html.erb` files
+        if (FileUtil.extension(f).equalsIgnoreCase(".erb")) {
+          if (!f.getName().endsWith(".html.erb")) {
+            return false;
+          }
         }
         return super.contains(f, lcExt, config);
       }
@@ -350,7 +356,7 @@ public class FileExtractor {
 
     /** Determine the {@link FileType} for a given file based on its extension only. */
     public static FileType forFileExtension(File f) {
-      String lcExt = StringUtil.lc(FileUtil.extension(f));
+      String lcExt = StringUtil.lc(FileUtil.extension(f)); // TODO: Here, it doesn't recognize .html.erb files
       for (FileType tp : values())
         if (tp.getExtensions().contains(lcExt)) {
           return tp;

--- a/javascript/extractor/src/com/semmle/js/extractor/Main.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/Main.java
@@ -41,7 +41,7 @@ public class Main {
    * A version identifier that should be updated every time the extractor changes in such a way that
    * it may produce different tuples for the same file under the same {@link ExtractorConfig}.
    */
-  public static final String EXTRACTOR_VERSION = "2022-11-29";
+  public static final String EXTRACTOR_VERSION = "2023-02-15";
 
   public static final Pattern NEWLINE = Pattern.compile("\n");
 

--- a/javascript/extractor/tests/vue/output/trap/rails.html.erb.trap
+++ b/javascript/extractor/tests/vue/output/trap/rails.html.erb.trap
@@ -1,5 +1,5 @@
-#10000=@"/rails.erb;sourcefile"
-files(#10000,"/rails.erb")
+#10000=@"/rails.html.erb;sourcefile"
+files(#10000,"/rails.html.erb")
 #10001=@"/;folder"
 folders(#10001,"/")
 containerparent(#10001,#10000)


### PR DESCRIPTION
CVE-2022-3704: TP

The file-extension check only works on the last part of the extension, so I had to change my implementation.  
We already have a filter for which files to extract, so I just put `.erb` as an extension we support, but then use the filter to ensure it's only `.html.erb` files that are considered. 

I didn't test the previous PR for this well enough.  


[Evaluation on nightly was very unevenful](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/pr-12190-25a846__nightly__code-scanning/reports). 
[Evaluation on a bunch of rails projects was very eventful](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/pr-12190-25a846__rails-projects__code-scanning__1/reports).  
Lots of new results (in `.html.erb` files), slightly worse performance (from extracting more files).  
But it looks good to me.  