### PR TITLE
Java: Test generator improvements

### DIFF
--- a/java/ql/src/utils/flowtestcasegenerator/FlowTestCase.qll
+++ b/java/ql/src/utils/flowtestcasegenerator/FlowTestCase.qll
@@ -228,7 +228,7 @@ class TestCase extends TTestCase {
    */
   Type getOutputType() {
     if baseOutput = SummaryComponentStack::return()
-    then result = callable.getReturnType()
+    then result = getReturnType(callable)
     else
       exists(int i |
         baseOutput = SummaryComponentStack::argument(i) and

--- a/java/ql/src/utils/flowtestcasegenerator/FlowTestCaseUtils.qll
+++ b/java/ql/src/utils/flowtestcasegenerator/FlowTestCaseUtils.qll
@@ -16,6 +16,11 @@ Type getRootSourceDeclaration(Type t) {
   else result = t
 }
 
+/** Gets the return type of the callable c, or the constructed tpe if it's a constructor */
+Type getReturnType(Callable c) {
+  if c instanceof Constructor then result = c.getDeclaringType() else result = c.getReturnType()
+}
+
 /**
  * Holds if type `t` does not clash with another type we want to import that has the same base name.
  */

--- a/java/ql/src/utils/flowtestcasegenerator/GenerateFlowTestCase.py
+++ b/java/ql/src/utils/flowtestcasegenerator/GenerateFlowTestCase.py
@@ -13,10 +13,13 @@ import tempfile
 
 if any(s == "--help" for s in sys.argv):
     print("""Usage:
-GenerateFlowTestCase.py specsToTest.csv projectPom.xml outdir [--force]
+GenerateFlowTestCase.py specsToTest projectPom.xml outdir [--force]
 
-This generates test cases exercising function model specifications found in specsToTest.csv
+This generates test cases exercising function model specifications found in specsToTest
 producing files Test.java, test.ql, test.ext.yml and test.expected in outdir.
+
+specsToTest should either be a .csv file, a .yml file, or a directory of .yml files, containing the 
+model specifications to test.
 
 projectPom.xml should be a Maven pom sufficient to resolve the classes named in specsToTest.csv.
 Typically this means supplying a skeleton POM <dependencies> section that retrieves whatever jars
@@ -40,9 +43,10 @@ if "--force" in sys.argv:
 
 if len(sys.argv) != 4:
     print(
-        "Usage: GenerateFlowTestCase.py specsToTest.csv projectPom.xml outdir [--force]", file=sys.stderr)
-    print("specsToTest.csv should contain CSV rows describing method taint-propagation specifications to test", file=sys.stderr)
-    print("projectPom.xml should import dependencies sufficient to resolve the types used in specsToTest.csv", file=sys.stderr)
+        "Usage: GenerateFlowTestCase.py specsToTest projectPom.xml outdir [--force]", file=sys.stderr)
+    print("specsToTest should contain CSV rows or YAML models describing method taint-propagation specifications to test", file=sys.stderr)
+    print("projectPom.xml should import dependencies sufficient to resolve the types used in specsToTest", file=sys.stderr)
+    print("\nRun with --help for more details.", file=sys.stderr)
     sys.exit(1)
 
 try:
@@ -85,7 +89,7 @@ def isComment(s):
 def readCsv(file):
     try:
         with open(file, "r") as f:
-            specs = [l for l in f if not isComment(l)]
+            specs = [l.strip() for l in f if not isComment(l)]
     except Exception as e:
         print("Failed to open %s: %s\n" % (file, e))
         sys.exit(1)

--- a/java/ql/src/utils/flowtestcasegenerator/GenerateFlowTestCase.py
+++ b/java/ql/src/utils/flowtestcasegenerator/GenerateFlowTestCase.py
@@ -136,7 +136,7 @@ if os.path.isdir(specsFile):
 elif specsFile.endswith(".yml") or specsFile.endswith(".yaml"):
     specs = readYml(specsFile)
 elif specsFile.endswith(".csv"):
-    spcs = readCsv(specsFile)
+    specs = readCsv(specsFile)
 else:
     print(f"Invalid specs {specsFile}. Must be a csv file, a yml file, or a directory of yml files.")
     sys.exit(1)


### PR DESCRIPTION
This PR allows the test generator to accept a yml file or a diretory of yml files containing MaD specifications as input. 
Also, the generated "return type" of a constuctor is now considered to be the constructed type. 