### PR TITLE
C#: Add an integration test which uses MSBuild

### DIFF
--- a/csharp/ql/integration-tests/all-platforms/msbuild/Program.cs
+++ b/csharp/ql/integration-tests/all-platforms/msbuild/Program.cs
@@ -1,0 +1,11 @@
+﻿namespace Test
+{
+    public class Program
+    {
+        public static int Main(string[] args)
+        {
+            Console.WriteLine("Hello world!");
+            return 0;
+        }
+    }
+}

--- a/csharp/ql/integration-tests/all-platforms/msbuild/Program.cs
+++ b/csharp/ql/integration-tests/all-platforms/msbuild/Program.cs
@@ -1,4 +1,6 @@
-﻿namespace Test
+﻿using System;
+
+namespace Test
 {
     public class Program
     {

--- a/csharp/ql/integration-tests/all-platforms/msbuild/test.csproj
+++ b/csharp/ql/integration-tests/all-platforms/msbuild/test.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/csharp/ql/integration-tests/all-platforms/msbuild/test.csproj
+++ b/csharp/ql/integration-tests/all-platforms/msbuild/test.csproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
+    <TargetFramework>net4.0</TargetFramework>
   </PropertyGroup>
 </Project>

--- a/csharp/ql/integration-tests/all-platforms/msbuild/test.py
+++ b/csharp/ql/integration-tests/all-platforms/msbuild/test.py
@@ -1,0 +1,4 @@
+from create_database_utils import *
+
+# force CodeQL to use MSBuild by setting `LGTM_INDEX_MSBUILD_TARGET`
+run_codeql_database_create([], test_db="default-db", db=None, lang="csharp", extra_env={ 'LGTM_INDEX_MSBUILD_TARGET': 'Build' })


### PR DESCRIPTION
This PR adds an integration test for C# which uses MSBuild. 