### PR TITLE
C#: Support for virtual dispatch for operators.

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/dispatch/Dispatch.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dispatch/Dispatch.qll
@@ -497,9 +497,10 @@ private module Internal {
         result = c.getAnOverrider(t)
       )
       or
-      exists(NonConstructedOverridableCallable c |
+      exists(NonConstructedOverridableCallable c, NonConstructedOverridableCallable mid |
         c = this.getAViableOverrider0() and
-        result = c.getAnOverrider(_)
+        c = mid.getUnboundDeclaration() and
+        result = mid.getAnOverrider(_)
       |
         this.hasUnconstrainedTypeParameterQualifierType()
         or
@@ -1115,8 +1116,7 @@ private module Internal {
 
   /** A call using reflection. */
   private class DispatchReflectionCall extends DispatchReflectionOrDynamicCall,
-    TDispatchReflectionCall
-  {
+    TDispatchReflectionCall {
     override MethodCall getCall() { this = TDispatchReflectionCall(result, _, _, _, _) }
 
     override string getName() { this = TDispatchReflectionCall(_, result, _, _, _) }
@@ -1164,8 +1164,7 @@ private module Internal {
 
   /** A method call using dynamic types. */
   private class DispatchDynamicMethodCall extends DispatchReflectionOrDynamicCall,
-    TDispatchDynamicMethodCall
-  {
+    TDispatchDynamicMethodCall {
     override DynamicMethodCall getCall() { this = TDispatchDynamicMethodCall(result) }
 
     override string getName() { result = this.getCall().getLateBoundTargetName() }
@@ -1186,8 +1185,7 @@ private module Internal {
 
   /** An operator call using dynamic types. */
   private class DispatchDynamicOperatorCall extends DispatchReflectionOrDynamicCall,
-    TDispatchDynamicOperatorCall
-  {
+    TDispatchDynamicOperatorCall {
     override DynamicOperatorCall getCall() { this = TDispatchDynamicOperatorCall(result) }
 
     override string getName() {
@@ -1204,8 +1202,7 @@ private module Internal {
 
   /** A (potential) call to a property accessor using dynamic types. */
   private class DispatchDynamicMemberAccess extends DispatchReflectionOrDynamicCall,
-    TDispatchDynamicMemberAccess
-  {
+    TDispatchDynamicMemberAccess {
     override DynamicMemberAccess getCall() { this = TDispatchDynamicMemberAccess(result) }
 
     override string getName() {
@@ -1229,8 +1226,7 @@ private module Internal {
 
   /** A (potential) call to an indexer accessor using dynamic types. */
   private class DispatchDynamicElementAccess extends DispatchReflectionOrDynamicCall,
-    TDispatchDynamicElementAccess
-  {
+    TDispatchDynamicElementAccess {
     override DynamicElementAccess getCall() { this = TDispatchDynamicElementAccess(result) }
 
     override string getName() {
@@ -1256,8 +1252,7 @@ private module Internal {
 
   /** A (potential) call to an event accessor using dynamic types. */
   private class DispatchDynamicEventAccess extends DispatchReflectionOrDynamicCall,
-    TDispatchDynamicEventAccess
-  {
+    TDispatchDynamicEventAccess {
     override AssignArithmeticOperation getCall() {
       this = TDispatchDynamicEventAccess(result, _, _)
     }
@@ -1274,8 +1269,7 @@ private module Internal {
 
   /** A call to a constructor using dynamic types. */
   private class DispatchDynamicObjectCreation extends DispatchReflectionOrDynamicCall,
-    TDispatchDynamicObjectCreation
-  {
+    TDispatchDynamicObjectCreation {
     override DynamicObjectCreation getCall() { this = TDispatchDynamicObjectCreation(result) }
 
     override string getName() { none() }

--- a/csharp/ql/test/library-tests/dispatch/CallContext.expected
+++ b/csharp/ql/test/library-tests/dispatch/CallContext.expected
@@ -23,3 +23,4 @@ mayBenefitFromCallContext
 | ViableCallable.cs:411:9:411:18 | call to method M<Int32> |
 | ViableCallable.cs:455:9:455:30 | call to method M2<T> |
 | ViableCallable.cs:461:9:461:30 | call to method M2<T> |
+| ViableCallable.cs:572:9:572:15 | call to method M12 |

--- a/csharp/ql/test/library-tests/dispatch/CallContext.expected
+++ b/csharp/ql/test/library-tests/dispatch/CallContext.expected
@@ -23,4 +23,6 @@ mayBenefitFromCallContext
 | ViableCallable.cs:411:9:411:18 | call to method M<Int32> |
 | ViableCallable.cs:455:9:455:30 | call to method M2<T> |
 | ViableCallable.cs:461:9:461:30 | call to method M2<T> |
+| ViableCallable.cs:563:18:563:22 | call to operator / |
+| ViableCallable.cs:566:26:566:30 | call to operator checked / |
 | ViableCallable.cs:572:9:572:15 | call to method M12 |

--- a/csharp/ql/test/library-tests/dispatch/CallGraph.expected
+++ b/csharp/ql/test/library-tests/dispatch/CallGraph.expected
@@ -242,3 +242,10 @@
 | ViableCallable.cs:492:10:492:12 | Run | ViableCallable.cs:488:40:488:40 | checked + |
 | ViableCallable.cs:492:10:492:12 | Run | ViableCallable.cs:489:28:489:35 | explicit conversion |
 | ViableCallable.cs:492:10:492:12 | Run | ViableCallable.cs:490:28:490:35 | checked explicit conversion |
+| ViableCallable.cs:542:10:542:15 | Run<> | ViableCallable.cs:514:39:514:39 | checked - |
+| ViableCallable.cs:542:10:542:15 | Run<> | ViableCallable.cs:516:31:516:31 | * |
+| ViableCallable.cs:542:10:542:15 | Run<> | ViableCallable.cs:517:39:517:39 | checked * |
+| ViableCallable.cs:542:10:542:15 | Run<> | ViableCallable.cs:519:31:519:31 | / |
+| ViableCallable.cs:542:10:542:15 | Run<> | ViableCallable.cs:520:39:520:39 | checked / |
+| ViableCallable.cs:542:10:542:15 | Run<> | ViableCallable.cs:524:18:524:20 | M12 |
+| ViableCallable.cs:542:10:542:15 | Run<> | ViableCallable.cs:526:18:526:20 | M13 |

--- a/csharp/ql/test/library-tests/dispatch/CallGraph.expected
+++ b/csharp/ql/test/library-tests/dispatch/CallGraph.expected
@@ -249,5 +249,10 @@
 | ViableCallable.cs:542:10:542:15 | Run<> | ViableCallable.cs:520:39:520:39 | checked / |
 | ViableCallable.cs:542:10:542:15 | Run<> | ViableCallable.cs:524:18:524:20 | M12 |
 | ViableCallable.cs:542:10:542:15 | Run<> | ViableCallable.cs:526:18:526:20 | M13 |
+| ViableCallable.cs:542:10:542:15 | Run<> | ViableCallable.cs:531:32:531:32 | + |
+| ViableCallable.cs:542:10:542:15 | Run<> | ViableCallable.cs:532:40:532:40 | checked + |
+| ViableCallable.cs:542:10:542:15 | Run<> | ViableCallable.cs:534:32:534:32 | - |
+| ViableCallable.cs:542:10:542:15 | Run<> | ViableCallable.cs:536:32:536:32 | / |
+| ViableCallable.cs:542:10:542:15 | Run<> | ViableCallable.cs:537:40:537:40 | checked / |
 | ViableCallable.cs:542:10:542:15 | Run<> | ViableCallable.cs:539:17:539:19 | M11 |
 | ViableCallable.cs:542:10:542:15 | Run<> | ViableCallable.cs:540:17:540:19 | M12 |

--- a/csharp/ql/test/library-tests/dispatch/CallGraph.expected
+++ b/csharp/ql/test/library-tests/dispatch/CallGraph.expected
@@ -249,3 +249,5 @@
 | ViableCallable.cs:542:10:542:15 | Run<> | ViableCallable.cs:520:39:520:39 | checked / |
 | ViableCallable.cs:542:10:542:15 | Run<> | ViableCallable.cs:524:18:524:20 | M12 |
 | ViableCallable.cs:542:10:542:15 | Run<> | ViableCallable.cs:526:18:526:20 | M13 |
+| ViableCallable.cs:542:10:542:15 | Run<> | ViableCallable.cs:539:17:539:19 | M11 |
+| ViableCallable.cs:542:10:542:15 | Run<> | ViableCallable.cs:540:17:540:19 | M12 |

--- a/csharp/ql/test/library-tests/dispatch/GetADynamicTarget.expected
+++ b/csharp/ql/test/library-tests/dispatch/GetADynamicTarget.expected
@@ -475,3 +475,10 @@
 | ViableCallable.cs:498:26:498:30 | call to operator checked + | C19.checked +(C19, C19) |
 | ViableCallable.cs:501:18:501:23 | call to operator explicit conversion | C19.explicit conversion(C19) |
 | ViableCallable.cs:504:26:504:31 | call to operator checked explicit conversion | C19.checked explicit conversion(C19) |
+| ViableCallable.cs:554:26:554:30 | call to operator checked - | I3<T>.checked -(T, T) |
+| ViableCallable.cs:557:18:557:22 | call to operator * | I3<T>.*(T, T) |
+| ViableCallable.cs:560:26:560:30 | call to operator checked * | I3<T>.checked *(T, T) |
+| ViableCallable.cs:563:18:563:22 | call to operator / | I3<T>./(T, T) |
+| ViableCallable.cs:566:26:566:30 | call to operator checked / | I3<T>.checked /(T, T) |
+| ViableCallable.cs:572:9:572:15 | call to method M12 | I3<T>.M12() |
+| ViableCallable.cs:575:9:575:15 | call to method M13 | I3<T>.M13() |

--- a/csharp/ql/test/library-tests/dispatch/GetADynamicTarget.expected
+++ b/csharp/ql/test/library-tests/dispatch/GetADynamicTarget.expected
@@ -475,10 +475,15 @@
 | ViableCallable.cs:498:26:498:30 | call to operator checked + | C19.checked +(C19, C19) |
 | ViableCallable.cs:501:18:501:23 | call to operator explicit conversion | C19.explicit conversion(C19) |
 | ViableCallable.cs:504:26:504:31 | call to operator checked explicit conversion | C19.checked explicit conversion(C19) |
+| ViableCallable.cs:545:18:545:22 | call to operator + | C20.+(C20, C20) |
+| ViableCallable.cs:548:26:548:30 | call to operator checked + | C20.checked +(C20, C20) |
+| ViableCallable.cs:551:18:551:22 | call to operator - | C20.-(C20, C20) |
 | ViableCallable.cs:554:26:554:30 | call to operator checked - | I3<T>.checked -(T, T) |
 | ViableCallable.cs:557:18:557:22 | call to operator * | I3<T>.*(T, T) |
 | ViableCallable.cs:560:26:560:30 | call to operator checked * | I3<T>.checked *(T, T) |
+| ViableCallable.cs:563:18:563:22 | call to operator / | C20./(C20, C20) |
 | ViableCallable.cs:563:18:563:22 | call to operator / | I3<T>./(T, T) |
+| ViableCallable.cs:566:26:566:30 | call to operator checked / | C20.checked /(C20, C20) |
 | ViableCallable.cs:566:26:566:30 | call to operator checked / | I3<T>.checked /(T, T) |
 | ViableCallable.cs:569:9:569:15 | call to method M11 | C20.M11() |
 | ViableCallable.cs:572:9:572:15 | call to method M12 | C20.M12() |

--- a/csharp/ql/test/library-tests/dispatch/GetADynamicTarget.expected
+++ b/csharp/ql/test/library-tests/dispatch/GetADynamicTarget.expected
@@ -480,5 +480,7 @@
 | ViableCallable.cs:560:26:560:30 | call to operator checked * | I3<T>.checked *(T, T) |
 | ViableCallable.cs:563:18:563:22 | call to operator / | I3<T>./(T, T) |
 | ViableCallable.cs:566:26:566:30 | call to operator checked / | I3<T>.checked /(T, T) |
+| ViableCallable.cs:569:9:569:15 | call to method M11 | C20.M11() |
+| ViableCallable.cs:572:9:572:15 | call to method M12 | C20.M12() |
 | ViableCallable.cs:572:9:572:15 | call to method M12 | I3<T>.M12() |
 | ViableCallable.cs:575:9:575:15 | call to method M13 | I3<T>.M13() |

--- a/csharp/ql/test/library-tests/dispatch/ViableCallable.cs
+++ b/csharp/ql/test/library-tests/dispatch/ViableCallable.cs
@@ -541,13 +541,13 @@ public class C20 : I3<C20>
 
     void Run<T>(T c) where T : I3<T>
     {
-        // Viable callables: C20.op_Addition(). MISSING: C20.op_Addition()
+        // Viable callables: C20.op_Addition()
         var c1 = c + c;
 
-        // Viable callables: C20.op_CheckedAddition(). MISSING: C20.op_CheckedAddition()
+        // Viable callables: C20.op_CheckedAddition()
         var c2 = checked(c + c);
 
-        // Viable callables: C20.op_Subtraction(). Missing: C20.op_Subtraction()
+        // Viable callables: C20.op_Subtraction()
         var c3 = c - c;
 
         // Viable callables: I3<C20>.op_CheckedSubtraction().
@@ -559,10 +559,10 @@ public class C20 : I3<C20>
         // Viable callables: I3<C20>.op_CheckedMultiply().
         var c6 = checked(c * c);
 
-        // Viable callables: {C20,I3<C20>}.op_Division(). MISSING: C20.op_Division()
+        // Viable callables: {C20,I3<C20>}.op_Division()
         var c7 = c / c;
 
-        // Viable callables: {C20,I3<C20>}.op_CheckedDivision(). MISSING: C20.op_CheckedDivision()
+        // Viable callables: {C20,I3<C20>}.op_CheckedDivision()
         var c8 = checked(c / c);
 
         // Viable callables: C20.M11.

--- a/csharp/ql/test/library-tests/dispatch/ViableCallable.cs
+++ b/csharp/ql/test/library-tests/dispatch/ViableCallable.cs
@@ -565,10 +565,10 @@ public class C20 : I3<C20>
         // Viable callables: {C20,I3<C20>}.op_CheckedDivision(). MISSING: C20.op_CheckedDivision()
         var c8 = checked(c / c);
 
-        // Viable callables: C20.M11. MISSING: C20.M11()
+        // Viable callables: C20.M11.
         c.M11();
 
-        // Viable callables: {C20,I3<C20>}.M12(). MISSING: C20.M12()
+        // Viable callables: {C20,I3<C20>}.M12().
         c.M12();
 
         // Viable callables: I3<C20>.M13()

--- a/csharp/ql/test/library-tests/dispatch/ViableCallable.cs
+++ b/csharp/ql/test/library-tests/dispatch/ViableCallable.cs
@@ -504,3 +504,74 @@ class C19
         var n2 = checked((int)c);
     }
 }
+
+public interface I3<T> where T : I3<T>
+{
+    static abstract T operator +(T x, T y);
+    static abstract T operator checked +(T x, T y);
+
+    static abstract T operator -(T x, T y);
+    static virtual T operator checked -(T x, T y) => throw null;
+
+    static virtual T operator *(T x, T y) => throw null;
+    static virtual T operator checked *(T x, T y) => throw null;
+
+    static virtual T operator /(T x, T y) => throw null;
+    static virtual T operator checked /(T x, T y) => throw null;
+
+    void M11();
+
+    virtual void M12() => throw null;
+
+    virtual void M13() => throw null;
+}
+
+public class C20 : I3<C20>
+{
+    public static C20 operator +(C20 x, C20 y) => throw null;
+    public static C20 operator checked +(C20 x, C20 y) => throw null;
+
+    public static C20 operator -(C20 x, C20 y) => throw null;
+
+    public static C20 operator /(C20 x, C20 y) => throw null;
+    public static C20 operator checked /(C20 x, C20 y) => throw null;
+
+    public void M11() { }
+    public void M12() { }
+
+    void Run<T>(T c) where T : I3<T>
+    {
+        // Viable callables: C20.op_Addition(). MISSING: C20.op_Addition()
+        var c1 = c + c;
+
+        // Viable callables: C20.op_CheckedAddition(). MISSING: C20.op_CheckedAddition()
+        var c2 = checked(c + c);
+
+        // Viable callables: C20.op_Subtraction(). Missing: C20.op_Subtraction()
+        var c3 = c - c;
+
+        // Viable callables: I3<C20>.op_CheckedSubtraction().
+        var c4 = checked(c - c);
+
+        // Viable callables: I3<C20>.op_Multiply().
+        var c5 = c * c;
+
+        // Viable callables: I3<C20>.op_CheckedMultiply().
+        var c6 = checked(c * c);
+
+        // Viable callables: {C20,I3<C20>}.op_Division(). MISSING: C20.op_Division()
+        var c7 = c / c;
+
+        // Viable callables: {C20,I3<C20>}.op_CheckedDivision(). MISSING: C20.op_CheckedDivision()
+        var c8 = checked(c / c);
+
+        // Viable callables: C20.M11. MISSING: C20.M11()
+        c.M11();
+
+        // Viable callables: {C20,I3<C20>}.M12(). MISSING: C20.M12()
+        c.M12();
+
+        // Viable callables: I3<C20>.M13()
+        c.M13();
+    }
+}

--- a/csharp/ql/test/library-tests/dispatch/viableCallable.expected
+++ b/csharp/ql/test/library-tests/dispatch/viableCallable.expected
@@ -277,5 +277,7 @@
 | ViableCallable.cs:560:26:560:30 | call to operator checked * | checked * | I3<> |
 | ViableCallable.cs:563:18:563:22 | call to operator / | / | I3<> |
 | ViableCallable.cs:566:26:566:30 | call to operator checked / | checked / | I3<> |
+| ViableCallable.cs:569:9:569:15 | call to method M11 | M11 | C20 |
+| ViableCallable.cs:572:9:572:15 | call to method M12 | M12 | C20 |
 | ViableCallable.cs:572:9:572:15 | call to method M12 | M12 | I3<> |
 | ViableCallable.cs:575:9:575:15 | call to method M13 | M13 | I3<> |

--- a/csharp/ql/test/library-tests/dispatch/viableCallable.expected
+++ b/csharp/ql/test/library-tests/dispatch/viableCallable.expected
@@ -272,10 +272,15 @@
 | ViableCallable.cs:498:26:498:30 | call to operator checked + | checked + | C19 |
 | ViableCallable.cs:501:18:501:23 | call to operator explicit conversion | explicit conversion | C19 |
 | ViableCallable.cs:504:26:504:31 | call to operator checked explicit conversion | checked explicit conversion | C19 |
+| ViableCallable.cs:545:18:545:22 | call to operator + | + | C20 |
+| ViableCallable.cs:548:26:548:30 | call to operator checked + | checked + | C20 |
+| ViableCallable.cs:551:18:551:22 | call to operator - | - | C20 |
 | ViableCallable.cs:554:26:554:30 | call to operator checked - | checked - | I3<> |
 | ViableCallable.cs:557:18:557:22 | call to operator * | * | I3<> |
 | ViableCallable.cs:560:26:560:30 | call to operator checked * | checked * | I3<> |
+| ViableCallable.cs:563:18:563:22 | call to operator / | / | C20 |
 | ViableCallable.cs:563:18:563:22 | call to operator / | / | I3<> |
+| ViableCallable.cs:566:26:566:30 | call to operator checked / | checked / | C20 |
 | ViableCallable.cs:566:26:566:30 | call to operator checked / | checked / | I3<> |
 | ViableCallable.cs:569:9:569:15 | call to method M11 | M11 | C20 |
 | ViableCallable.cs:572:9:572:15 | call to method M12 | M12 | C20 |

--- a/csharp/ql/test/library-tests/dispatch/viableCallable.expected
+++ b/csharp/ql/test/library-tests/dispatch/viableCallable.expected
@@ -272,3 +272,10 @@
 | ViableCallable.cs:498:26:498:30 | call to operator checked + | checked + | C19 |
 | ViableCallable.cs:501:18:501:23 | call to operator explicit conversion | explicit conversion | C19 |
 | ViableCallable.cs:504:26:504:31 | call to operator checked explicit conversion | checked explicit conversion | C19 |
+| ViableCallable.cs:554:26:554:30 | call to operator checked - | checked - | I3<> |
+| ViableCallable.cs:557:18:557:22 | call to operator * | * | I3<> |
+| ViableCallable.cs:560:26:560:30 | call to operator checked * | checked * | I3<> |
+| ViableCallable.cs:563:18:563:22 | call to operator / | / | I3<> |
+| ViableCallable.cs:566:26:566:30 | call to operator checked / | checked / | I3<> |
+| ViableCallable.cs:572:9:572:15 | call to method M12 | M12 | I3<> |
+| ViableCallable.cs:575:9:575:15 | call to method M13 | M13 | I3<> |


### PR DESCRIPTION
In this PR, we
- Fix issue with dispatch to implementations of virtual interface members for generics.
- Make support for virtual dispatch of operators (Operators are now considered Overridables).

From C# 11 it is possible to declare abstract and virtual operators (see the example below), which means that operator calls no longer only have static call targets. We have implemented support for dynamic call targeting for operators in C#.

```csharp
public interface I<T> where T : I<T>
{
    static abstract T operator +(T x, T y);
    static virtual T operator -(T x, T y) => throw null;
}

public class C : I<C>
{
    public static C operator +(C x, C y) => throw null;
    public static C operator /(C x, C y) => throw null;
}
```
