### PR TITLE
C# 11: Required fields and properties.

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Modifier.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Modifier.cs
@@ -65,6 +65,15 @@ namespace Semmle.Extraction.CSharp.Entities
             trapFile.has_modifiers(target, Modifier.Create(cx, modifier));
         }
 
+        private static void ExtractFieldModifiers(Context cx, TextWriter trapFile, IEntity key, IFieldSymbol symbol)
+        {
+            if (symbol.IsReadOnly)
+                HasModifier(cx, trapFile, key, Modifiers.Readonly);
+
+            if (symbol.IsRequired)
+                HasModifier(cx, trapFile, key, Modifiers.Required);
+        }
+
         private static void ExtractNamedTypeModifiers(Context cx, TextWriter trapFile, IEntity key, ISymbol symbol)
         {
             if (symbol.Kind != SymbolKind.NamedType)
@@ -106,8 +115,11 @@ namespace Semmle.Extraction.CSharp.Entities
             if (symbol.IsVirtual)
                 HasModifier(cx, trapFile, key, Modifiers.Virtual);
 
-            if (symbol.Kind == SymbolKind.Field && ((IFieldSymbol)symbol).IsReadOnly)
-                HasModifier(cx, trapFile, key, Modifiers.Readonly);
+            if (symbol is IFieldSymbol field)
+                ExtractFieldModifiers(cx, trapFile, key, field);
+
+            if (symbol.Kind == SymbolKind.Property && ((IPropertySymbol)symbol).IsRequired)
+                HasModifier(cx, trapFile, key, Modifiers.Required);
 
             if (symbol.IsOverride)
                 HasModifier(cx, trapFile, key, Modifiers.Override);

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Modifiers.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Modifiers.cs
@@ -13,6 +13,7 @@ internal static class Modifiers
     public const string Public = "public";
     public const string Readonly = "readonly";
     public const string Record = "record";
+    public const string Required = "required";
     public const string Ref = "ref";
     public const string Sealed = "sealed";
     public const string Static = "static";

--- a/csharp/ql/lib/change-notes/2023-02-16-requiredmembers.md
+++ b/csharp/ql/lib/change-notes/2023-02-16-requiredmembers.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* C# 11: Added extractor support for `required` fields and properties.

--- a/csharp/ql/lib/semmle/code/csharp/Member.qll
+++ b/csharp/ql/lib/semmle/code/csharp/Member.qll
@@ -90,6 +90,9 @@ class Modifiable extends Declaration, @modifiable {
   /** Holds if this declaration is `const`. */
   predicate isConst() { this.hasModifier("const") }
 
+  /** Holds if this declaration has the modifier `required`. */
+  predicate isRequired() { this.hasModifier("required") }
+
   /** Holds if this declaration is `unsafe`. */
   predicate isUnsafe() {
     this.hasModifier("unsafe") or
@@ -178,6 +181,8 @@ class Member extends DotNet::Member, Modifiable, @member {
   override predicate isAbstract() { Modifiable.super.isAbstract() }
 
   override predicate isStatic() { Modifiable.super.isStatic() }
+
+  override predicate isRequired() { Modifiable.super.isRequired() }
 }
 
 private class TOverridable = @virtualizable or @callable_accessor;

--- a/csharp/ql/lib/semmle/code/dotnet/Declaration.qll
+++ b/csharp/ql/lib/semmle/code/dotnet/Declaration.qll
@@ -80,6 +80,9 @@ class Member extends Declaration, @dotnet_member {
   /** Holds if this member is `static`. */
   predicate isStatic() { none() }
 
+  /** Holds if this member is declared `required`. */
+  predicate isRequired() { none() }
+
   /**
    * Holds if this member has name `name` and is defined in type `type`
    * with namespace `namespace`.

--- a/csharp/ql/test/library-tests/csharp11/PrintAst.expected
+++ b/csharp/ql/test/library-tests/csharp11/PrintAst.expected
@@ -657,6 +657,97 @@ RelaxedShift.cs:
 #   30|           1: [OperatorCall] call to operator >>>
 #   30|             0: [LocalVariableAccess] access to local variable n31
 #   30|             1: [StringLiteralUtf16] "3"
+RequiredMembers.cs:
+#    4| [Class] ClassRequiredMembers
+#    6|   4: [Field] RequiredField
+#    6|     -1: [TypeMention] object
+#    7|   5: [Property] RequiredProperty
+#    7|     -1: [TypeMention] string
+#    7|     3: [Getter] get_RequiredProperty
+#    7|     4: [Setter] set_RequiredProperty
+#-----|       2: (Parameters)
+#    7|         0: [Parameter] value
+#    8|   6: [Property] VirtualProperty
+#    8|     -1: [TypeMention] object
+#    8|     3: [Getter] get_VirtualProperty
+#    8|     4: [Setter] set_VirtualProperty
+#-----|       2: (Parameters)
+#    8|         0: [Parameter] value
+#   10|   7: [InstanceConstructor] ClassRequiredMembers
+#   10|     4: [BlockStmt] {...}
+#   13|   8: [InstanceConstructor] ClassRequiredMembers
+#-----|     0: (Attributes)
+#   12|       1: [DefaultAttribute] [SetsRequiredMembers(...)]
+#   12|         0: [TypeMention] SetsRequiredMembersAttribute
+#-----|     2: (Parameters)
+#   13|       0: [Parameter] requiredField
+#   13|         -1: [TypeMention] object
+#   13|       1: [Parameter] requiredProperty
+#   13|         -1: [TypeMention] string
+#   14|     4: [BlockStmt] {...}
+#   15|       0: [ExprStmt] ...;
+#   15|         0: [AssignExpr] ... = ...
+#   15|           0: [FieldAccess] access to field RequiredField
+#   15|           1: [ParameterAccess] access to parameter requiredField
+#   16|       1: [ExprStmt] ...;
+#   16|         0: [AssignExpr] ... = ...
+#   16|           0: [PropertyCall] access to property RequiredProperty
+#   16|           1: [ParameterAccess] access to parameter requiredProperty
+#   20| [Class] ClassRequiredMembersSub
+#-----|   3: (Base types)
+#   20|     0: [TypeMention] ClassRequiredMembers
+#   22|   4: [Property] VirtualProperty
+#   22|     -1: [TypeMention] object
+#   22|     3: [Getter] get_VirtualProperty
+#   22|     4: [Setter] set_VirtualProperty
+#-----|       2: (Parameters)
+#   22|         0: [Parameter] value
+#   24|   5: [InstanceConstructor] ClassRequiredMembersSub
+#   24|     3: [ConstructorInitializer] call to constructor ClassRequiredMembers
+#   24|     4: [BlockStmt] {...}
+#   27|   6: [InstanceConstructor] ClassRequiredMembersSub
+#-----|     0: (Attributes)
+#   26|       1: [DefaultAttribute] [SetsRequiredMembers(...)]
+#   26|         0: [TypeMention] SetsRequiredMembersAttribute
+#-----|     2: (Parameters)
+#   27|       0: [Parameter] requiredField
+#   27|         -1: [TypeMention] object
+#   27|       1: [Parameter] requiredProperty
+#   27|         -1: [TypeMention] string
+#   27|       2: [Parameter] virtualProperty
+#   27|         -1: [TypeMention] object
+#   27|     3: [ConstructorInitializer] call to constructor ClassRequiredMembers
+#   27|       0: [ParameterAccess] access to parameter requiredField
+#   27|       1: [ParameterAccess] access to parameter requiredProperty
+#   28|     4: [BlockStmt] {...}
+#   29|       0: [ExprStmt] ...;
+#   29|         0: [AssignExpr] ... = ...
+#   29|           0: [PropertyCall] access to property VirtualProperty
+#   29|           1: [ParameterAccess] access to parameter virtualProperty
+#   33| [RecordClass] RecordRequiredMembers
+#   33|   12: [NEOperator] !=
+#-----|     2: (Parameters)
+#   33|       0: [Parameter] left
+#   33|       1: [Parameter] right
+#   33|   13: [EQOperator] ==
+#-----|     2: (Parameters)
+#   33|       0: [Parameter] left
+#   33|       1: [Parameter] right
+#   33|   14: [Property] EqualityContract
+#   33|     3: [Getter] get_EqualityContract
+#   35|   15: [Property] X
+#   35|     -1: [TypeMention] object
+#   35|     3: [Getter] get_X
+#   35|     4: [Setter] set_X
+#-----|       2: (Parameters)
+#   35|         0: [Parameter] value
+#   38| [Struct] StructRequiredMembers
+#   40|   5: [Property] Y
+#   40|     -1: [TypeMention] string
+#   40|     3: [Getter] get_Y
+#   40|     4: [Setter] set_Y
+#-----|       2: (Parameters)
+#   40|         0: [Parameter] value
 Scoped.cs:
 #    1| [Struct] S1
 #    2| [Struct] S2

--- a/csharp/ql/test/library-tests/csharp11/RequiredMembers.cs
+++ b/csharp/ql/test/library-tests/csharp11/RequiredMembers.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+public class ClassRequiredMembers
+{
+    public required object? RequiredField;
+    public required string? RequiredProperty { get; init; }
+    public virtual object? VirtualProperty { get; init; }
+
+    public ClassRequiredMembers() { }
+
+    [SetsRequiredMembers]
+    public ClassRequiredMembers(object requiredField, string requiredProperty)
+    {
+        RequiredField = requiredField;
+        RequiredProperty = requiredProperty;
+    }
+}
+
+public class ClassRequiredMembersSub : ClassRequiredMembers
+{
+    public override required object? VirtualProperty { get; init; }
+
+    public ClassRequiredMembersSub() : base() { }
+
+    [SetsRequiredMembers]
+    public ClassRequiredMembersSub(object requiredField, string requiredProperty, object virtualProperty) : base(requiredField, requiredProperty)
+    {
+        VirtualProperty = virtualProperty;
+    }
+}
+
+public record RecordRequiredMembers
+{
+    public required object? X { get; init; }
+}
+
+public struct StructRequiredMembers
+{
+    public required string? Y { get; init; }
+}
+

--- a/csharp/ql/test/library-tests/csharp11/requiredMembers.expected
+++ b/csharp/ql/test/library-tests/csharp11/requiredMembers.expected
@@ -1,0 +1,5 @@
+| RequiredMembers.cs:6:29:6:41 | RequiredField | ClassRequiredMembers | Field |
+| RequiredMembers.cs:7:29:7:44 | RequiredProperty | ClassRequiredMembers | Property |
+| RequiredMembers.cs:22:38:22:52 | VirtualProperty | ClassRequiredMembersSub | Property |
+| RequiredMembers.cs:35:29:35:29 | X | RecordRequiredMembers | Property |
+| RequiredMembers.cs:40:29:40:29 | Y | StructRequiredMembers | Property |

--- a/csharp/ql/test/library-tests/csharp11/requiredMembers.ql
+++ b/csharp/ql/test/library-tests/csharp11/requiredMembers.ql
@@ -1,0 +1,8 @@
+import csharp
+
+query predicate requiredmembers(Member m, string type, string qlclass) {
+  m.getFile().getStem() = "RequiredMembers" and
+  m.isRequired() and
+  type = m.getDeclaringType().getName() and
+  qlclass = m.getAPrimaryQlClass()
+}


### PR DESCRIPTION
In C# 11 it is possible to declare a *field* or *property* as `required`, which means that the entity needs to be initialised by the constructors or using *object initialisation* syntax.
```csharp
public class MyClass {
    public required object X;
}
...
var c = new MyClass() { X = new object() }
...
```