### PR TITLE
C# 11: Support for `file` scoped types.

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Modifier.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Modifier.cs
@@ -85,6 +85,9 @@ namespace Semmle.Extraction.CSharp.Entities
             if (nt.IsRecord)
                 HasModifier(cx, trapFile, key, Modifiers.Record);
 
+            if (nt.IsFileLocal)
+                HasModifier(cx, trapFile, key, Modifiers.File);
+
             if (nt.TypeKind == TypeKind.Struct)
             {
                 if (nt.IsReadOnly)
@@ -97,7 +100,9 @@ namespace Semmle.Extraction.CSharp.Entities
 
         public static void ExtractModifiers(Context cx, TextWriter trapFile, IEntity key, ISymbol symbol)
         {
-            HasAccessibility(cx, trapFile, key, symbol.DeclaredAccessibility);
+            if (symbol.Kind != SymbolKind.NamedType || !((INamedTypeSymbol)symbol).IsFileLocal)
+                HasAccessibility(cx, trapFile, key, symbol.DeclaredAccessibility);
+
             if (symbol.Kind == SymbolKind.ErrorType)
                 trapFile.has_modifiers(key, Modifier.Create(cx, Accessibility.Public));
 

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Modifier.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Modifier.cs
@@ -100,6 +100,8 @@ namespace Semmle.Extraction.CSharp.Entities
 
         public static void ExtractModifiers(Context cx, TextWriter trapFile, IEntity key, ISymbol symbol)
         {
+            // A file scoped type has declared accessibility `internal` which we shouldn't extract.
+            // The file modifier is extracted as a source level modifier.
             if (symbol.Kind != SymbolKind.NamedType || !((INamedTypeSymbol)symbol).IsFileLocal)
                 HasAccessibility(cx, trapFile, key, symbol.DeclaredAccessibility);
 

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Modifiers.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Modifiers.cs
@@ -4,6 +4,7 @@ internal static class Modifiers
     public const string Async = "async";
     public const string Const = "const";
     public const string Extern = "extern";
+    public const string File = "file";
     public const string Internal = "internal";
     public const string New = "new";
     public const string Override = "override";

--- a/csharp/extractor/Semmle.Extraction.CSharp/SymbolExtensions.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/SymbolExtensions.cs
@@ -286,7 +286,7 @@ namespace Semmle.Extraction.CSharp
         public static IEnumerable<IFieldSymbol?> GetTupleElementsMaybeNull(this INamedTypeSymbol type) =>
             type.TupleElements;
 
-        private static void AddContaining(INamedTypeSymbol named, Context cx, EscapingTextWriter trapFile, ISymbol symbolBeingDefined)
+        private static void BuildQualifierAndName(INamedTypeSymbol named, Context cx, EscapingTextWriter trapFile, ISymbol symbolBeingDefined)
         {
             if (named.ContainingType is not null)
             {
@@ -299,6 +299,9 @@ namespace Semmle.Extraction.CSharp
                     BuildAssembly(named.ContainingAssembly, trapFile);
                 named.ContainingNamespace.BuildNamespace(cx, trapFile);
             }
+
+            var name = named.IsFileLocal ? named.MetadataName : named.Name;
+            trapFile.Write(name);
         }
 
         private static void BuildTupleId(INamedTypeSymbol named, Context cx, EscapingTextWriter trapFile, ISymbol symbolBeingDefined)
@@ -332,13 +335,11 @@ namespace Semmle.Extraction.CSharp
 
             if (named.TypeParameters.IsEmpty)
             {
-                AddContaining(named, cx, trapFile, symbolBeingDefined);
-                trapFile.Write(named.Name);
+                BuildQualifierAndName(named, cx, trapFile, symbolBeingDefined);
             }
             else if (named.IsReallyUnbound())
             {
-                AddContaining(named, cx, trapFile, symbolBeingDefined);
-                trapFile.Write(named.Name);
+                BuildQualifierAndName(named, cx, trapFile, symbolBeingDefined);
                 trapFile.Write("`");
                 trapFile.Write(named.TypeParameters.Length);
             }

--- a/csharp/extractor/Semmle.Extraction.CSharp/SymbolExtensions.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/SymbolExtensions.cs
@@ -286,53 +286,58 @@ namespace Semmle.Extraction.CSharp
         public static IEnumerable<IFieldSymbol?> GetTupleElementsMaybeNull(this INamedTypeSymbol type) =>
             type.TupleElements;
 
+        private static void AddContaining(INamedTypeSymbol named, Context cx, EscapingTextWriter trapFile, ISymbol symbolBeingDefined)
+        {
+            if (named.ContainingType is not null)
+            {
+                named.ContainingType.BuildOrWriteId(cx, trapFile, symbolBeingDefined, constructUnderlyingTupleType: false);
+                trapFile.Write('.');
+            }
+            else if (named.ContainingNamespace is not null)
+            {
+                if (cx.ShouldAddAssemblyTrapPrefix && named.ContainingAssembly is not null)
+                    BuildAssembly(named.ContainingAssembly, trapFile);
+                named.ContainingNamespace.BuildNamespace(cx, trapFile);
+            }
+        }
+
+        private static void BuildTupleId(INamedTypeSymbol named, Context cx, EscapingTextWriter trapFile, ISymbol symbolBeingDefined)
+        {
+            trapFile.Write('(');
+            trapFile.BuildList(",", named.GetTupleElementsMaybeNull(),
+                (i, f) =>
+                {
+                    if (f is null)
+                    {
+                        trapFile.Write($"null({i})");
+                    }
+                    else
+                    {
+                        trapFile.Write((f.CorrespondingTupleField ?? f).Name);
+                        trapFile.Write(":");
+                        f.Type.BuildOrWriteId(cx, trapFile, symbolBeingDefined, constructUnderlyingTupleType: false);
+                    }
+                }
+                );
+            trapFile.Write(")");
+        }
+
         private static void BuildNamedTypeId(this INamedTypeSymbol named, Context cx, EscapingTextWriter trapFile, ISymbol symbolBeingDefined, bool constructUnderlyingTupleType)
         {
             if (!constructUnderlyingTupleType && named.IsTupleType)
             {
-                trapFile.Write('(');
-                trapFile.BuildList(",", named.GetTupleElementsMaybeNull(),
-                    (i, f) =>
-                    {
-                        if (f is null)
-                        {
-                            trapFile.Write($"null({i})");
-                        }
-                        else
-                        {
-                            trapFile.Write((f.CorrespondingTupleField ?? f).Name);
-                            trapFile.Write(":");
-                            f.Type.BuildOrWriteId(cx, trapFile, symbolBeingDefined, constructUnderlyingTupleType: false);
-                        }
-                    }
-                    );
-                trapFile.Write(")");
+                BuildTupleId(named, cx, trapFile, symbolBeingDefined);
                 return;
-            }
-
-            void AddContaining()
-            {
-                if (named.ContainingType is not null)
-                {
-                    named.ContainingType.BuildOrWriteId(cx, trapFile, symbolBeingDefined, constructUnderlyingTupleType: false);
-                    trapFile.Write('.');
-                }
-                else if (named.ContainingNamespace is not null)
-                {
-                    if (cx.ShouldAddAssemblyTrapPrefix && named.ContainingAssembly is not null)
-                        BuildAssembly(named.ContainingAssembly, trapFile);
-                    named.ContainingNamespace.BuildNamespace(cx, trapFile);
-                }
             }
 
             if (named.TypeParameters.IsEmpty)
             {
-                AddContaining();
+                AddContaining(named, cx, trapFile, symbolBeingDefined);
                 trapFile.Write(named.Name);
             }
             else if (named.IsReallyUnbound())
             {
-                AddContaining();
+                AddContaining(named, cx, trapFile, symbolBeingDefined);
                 trapFile.Write(named.Name);
                 trapFile.Write("`");
                 trapFile.Write(named.TypeParameters.Length);

--- a/csharp/ql/lib/change-notes/2023-02-17-filescopedtypes.md
+++ b/csharp/ql/lib/change-notes/2023-02-17-filescopedtypes.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* C# 11: Added extractor and library support for `file` scoped types.

--- a/csharp/ql/lib/semmle/code/csharp/Member.qll
+++ b/csharp/ql/lib/semmle/code/csharp/Member.qll
@@ -93,6 +93,9 @@ class Modifiable extends Declaration, @modifiable {
   /** Holds if this declaration has the modifier `required`. */
   predicate isRequired() { this.hasModifier("required") }
 
+  /** Holds if this declaration is `file` local. */
+  predicate isFile() { this.hasModifier("file") }
+
   /** Holds if this declaration is `unsafe`. */
   predicate isUnsafe() {
     this.hasModifier("unsafe") or
@@ -183,6 +186,8 @@ class Member extends DotNet::Member, Modifiable, @member {
   override predicate isStatic() { Modifiable.super.isStatic() }
 
   override predicate isRequired() { Modifiable.super.isRequired() }
+
+  override predicate isFile() { Modifiable.super.isFile() }
 }
 
 private class TOverridable = @virtualizable or @callable_accessor;

--- a/csharp/ql/lib/semmle/code/dotnet/Declaration.qll
+++ b/csharp/ql/lib/semmle/code/dotnet/Declaration.qll
@@ -83,6 +83,9 @@ class Member extends Declaration, @dotnet_member {
   /** Holds if this member is declared `required`. */
   predicate isRequired() { none() }
 
+  /** Holds if this member is declared `file` local. */
+  predicate isFile() { none() }
+
   /**
    * Holds if this member has name `name` and is defined in type `type`
    * with namespace `namespace`.

--- a/csharp/ql/test/library-tests/csharp11/FileScoped1.cs
+++ b/csharp/ql/test/library-tests/csharp11/FileScoped1.cs
@@ -1,0 +1,25 @@
+file interface I1 { }
+
+file interface I2 { }
+
+file class C1 : I1 { }
+
+public class C2 { }
+
+public class C3 : I2 { }
+
+file interface IC { }
+
+file class C4<T> { }
+
+file class C5<S> : C4<S> { }
+
+file struct S1 { }
+
+file enum E1 { }
+
+file delegate void D1();
+
+file record R1 { }
+
+file record struct RS1 { }

--- a/csharp/ql/test/library-tests/csharp11/FileScoped2.cs
+++ b/csharp/ql/test/library-tests/csharp11/FileScoped2.cs
@@ -1,0 +1,23 @@
+file interface I1 { }
+
+public interface I2 { }
+
+file class C1 { }
+
+file class C2 : I2 { }
+
+file class IC { }
+
+file class C4<T> { }
+
+file class C5<S> : C4<S> { }
+
+file struct S1 { }
+
+file enum E1 { }
+
+file delegate void D1();
+
+file record R1 { }
+
+file record struct RS1 { }

--- a/csharp/ql/test/library-tests/csharp11/FileScoped3.cs
+++ b/csharp/ql/test/library-tests/csharp11/FileScoped3.cs
@@ -1,0 +1,7 @@
+namespace TestFileScoped;
+
+file interface I10 { }
+
+file class C10 { }
+
+public class C11 : I10 { }

--- a/csharp/ql/test/library-tests/csharp11/FileScoped4.cs
+++ b/csharp/ql/test/library-tests/csharp11/FileScoped4.cs
@@ -1,0 +1,7 @@
+namespace TestFileScoped;
+
+public interface I10 { }
+
+file class C10 { }
+
+file class C11 : I10 { }

--- a/csharp/ql/test/library-tests/csharp11/PrintAst.expected
+++ b/csharp/ql/test/library-tests/csharp11/PrintAst.expected
@@ -216,6 +216,103 @@ CheckedOperators.cs:
 #   55|             0: [TypeMention] short
 #   55|           1: [PropertyCall] access to property Value
 #   55|             -1: [ParameterAccess] access to parameter n
+FileScoped1.cs:
+#    1| [Interface] I1
+#    3| [Interface] I2
+#    5| [Class] C1
+#-----|   3: (Base types)
+#    5|     1: [TypeMention] I1
+#    7| [Class] C2
+#    9| [Class] C3
+#-----|   3: (Base types)
+#    9|     1: [TypeMention] I2
+#   11| [Interface] IC
+#   13| [Class] C4<>
+#-----|   1: (Type parameters)
+#   13|     0: [TypeParameter] T
+#   15| [Class] C5<>
+#-----|   1: (Type parameters)
+#   15|     0: [TypeParameter] S
+#-----|   3: (Base types)
+#   15|     0: [TypeMention] C4<S>
+#   15|       1: [TypeMention] S
+#   17| [Struct] S1
+#   19| [Enum] E1
+#   21| [DelegateType] D1
+#   23| [RecordClass] R1
+#   23|   12: [NEOperator] !=
+#-----|     2: (Parameters)
+#   23|       0: [Parameter] left
+#   23|       1: [Parameter] right
+#   23|   13: [EQOperator] ==
+#-----|     2: (Parameters)
+#   23|       0: [Parameter] left
+#   23|       1: [Parameter] right
+#   23|   14: [Property] EqualityContract
+#   23|     3: [Getter] get_EqualityContract
+#   25| [RecordStruct] RS1
+#   25|   10: [NEOperator] !=
+#-----|     2: (Parameters)
+#   25|       0: [Parameter] left
+#   25|       1: [Parameter] right
+#   25|   11: [EQOperator] ==
+#-----|     2: (Parameters)
+#   25|       0: [Parameter] left
+#   25|       1: [Parameter] right
+FileScoped2.cs:
+#    1| [Interface] I1
+#    3| [Interface] I2
+#    5| [Class] C1
+#    7| [Class] C2
+#-----|   3: (Base types)
+#    7|     1: [TypeMention] I2
+#    9| [Class] IC
+#   11| [Class] C4<>
+#-----|   1: (Type parameters)
+#   11|     0: [TypeParameter] T
+#   13| [Class] C5<>
+#-----|   1: (Type parameters)
+#   13|     0: [TypeParameter] S
+#-----|   3: (Base types)
+#   13|     0: [TypeMention] C4<S>
+#   13|       1: [TypeMention] S
+#   15| [Struct] S1
+#   17| [Enum] E1
+#   19| [DelegateType] D1
+#   21| [RecordClass] R1
+#   21|   12: [NEOperator] !=
+#-----|     2: (Parameters)
+#   21|       0: [Parameter] left
+#   21|       1: [Parameter] right
+#   21|   13: [EQOperator] ==
+#-----|     2: (Parameters)
+#   21|       0: [Parameter] left
+#   21|       1: [Parameter] right
+#   21|   14: [Property] EqualityContract
+#   21|     3: [Getter] get_EqualityContract
+#   23| [RecordStruct] RS1
+#   23|   10: [NEOperator] !=
+#-----|     2: (Parameters)
+#   23|       0: [Parameter] left
+#   23|       1: [Parameter] right
+#   23|   11: [EQOperator] ==
+#-----|     2: (Parameters)
+#   23|       0: [Parameter] left
+#   23|       1: [Parameter] right
+FileScoped3.cs:
+#    1| [NamespaceDeclaration] namespace ... { ... }
+#    3|   1: [Interface] I10
+#    5|   2: [Class] C10
+#    7|   3: [Class] C11
+#-----|     3: (Base types)
+#    7|       1: [TypeMention] I10
+FileScoped4.cs:
+#    1| [NamespaceDeclaration] namespace ... { ... }
+#    3|   1: [Interface] I10
+#    5|   2: [Class] C10
+#    7|   3: [Class] C11
+#-----|     3: (Base types)
+#    7|       1: [TypeMention] I10
 GenericAttribute.cs:
 #    3| [GenericAssemblyAttribute] [assembly: MyGeneric<Int32>(...)]
 #    3|   0: [TypeMention] MyGenericAttribute<int>

--- a/csharp/ql/test/library-tests/csharp11/fileScoped.expected
+++ b/csharp/ql/test/library-tests/csharp11/fileScoped.expected
@@ -1,0 +1,116 @@
+typemodifiers
+| FileScoped1.cs:1:16:1:17 | I1 | file |
+| FileScoped1.cs:3:16:3:17 | I2 | file |
+| FileScoped1.cs:5:12:5:13 | C1 | file |
+| FileScoped1.cs:7:14:7:15 | C2 | public |
+| FileScoped1.cs:9:14:9:15 | C3 | public |
+| FileScoped1.cs:11:16:11:17 | IC | file |
+| FileScoped1.cs:13:12:13:16 | C4<> | file |
+| FileScoped1.cs:13:12:13:16 | C4<S> | file |
+| FileScoped1.cs:15:12:15:16 | C5<> | file |
+| FileScoped1.cs:17:13:17:14 | S1 | file |
+| FileScoped1.cs:17:13:17:14 | S1 | sealed |
+| FileScoped1.cs:19:11:19:12 | E1 | file |
+| FileScoped1.cs:19:11:19:12 | E1 | sealed |
+| FileScoped1.cs:21:20:21:21 | D1 | file |
+| FileScoped1.cs:21:20:21:21 | D1 | sealed |
+| FileScoped1.cs:23:1:23:18 | R1 | file |
+| FileScoped1.cs:23:1:23:18 | R1 | record |
+| FileScoped1.cs:25:1:25:26 | RS1 | file |
+| FileScoped1.cs:25:1:25:26 | RS1 | record |
+| FileScoped1.cs:25:1:25:26 | RS1 | sealed |
+| FileScoped2.cs:1:16:1:17 | I1 | file |
+| FileScoped2.cs:3:18:3:19 | I2 | public |
+| FileScoped2.cs:5:12:5:13 | C1 | file |
+| FileScoped2.cs:7:12:7:13 | C2 | file |
+| FileScoped2.cs:9:12:9:13 | IC | file |
+| FileScoped2.cs:11:12:11:16 | C4<> | file |
+| FileScoped2.cs:11:12:11:16 | C4<S> | file |
+| FileScoped2.cs:13:12:13:16 | C5<> | file |
+| FileScoped2.cs:15:13:15:14 | S1 | file |
+| FileScoped2.cs:15:13:15:14 | S1 | sealed |
+| FileScoped2.cs:17:11:17:12 | E1 | file |
+| FileScoped2.cs:17:11:17:12 | E1 | sealed |
+| FileScoped2.cs:19:20:19:21 | D1 | file |
+| FileScoped2.cs:19:20:19:21 | D1 | sealed |
+| FileScoped2.cs:21:1:21:18 | R1 | file |
+| FileScoped2.cs:21:1:21:18 | R1 | record |
+| FileScoped2.cs:23:1:23:26 | RS1 | file |
+| FileScoped2.cs:23:1:23:26 | RS1 | record |
+| FileScoped2.cs:23:1:23:26 | RS1 | sealed |
+| FileScoped3.cs:3:16:3:18 | I10 | file |
+| FileScoped3.cs:5:12:5:14 | C10 | file |
+| FileScoped3.cs:7:14:7:16 | C11 | public |
+| FileScoped4.cs:3:18:3:20 | I10 | public |
+| FileScoped4.cs:5:12:5:14 | C10 | file |
+| FileScoped4.cs:7:12:7:14 | C11 | file |
+qualifiedtypes
+| FileScoped1.cs:1:16:1:17 | I1 | I1 |
+| FileScoped1.cs:3:16:3:17 | I2 | I2 |
+| FileScoped1.cs:5:12:5:13 | C1 | C1 |
+| FileScoped1.cs:7:14:7:15 | C2 | C2 |
+| FileScoped1.cs:9:14:9:15 | C3 | C3 |
+| FileScoped1.cs:11:16:11:17 | IC | IC |
+| FileScoped1.cs:13:12:13:16 | C4<> | C4<> |
+| FileScoped1.cs:13:12:13:16 | C4<S> | C4<S> |
+| FileScoped1.cs:15:12:15:16 | C5<> | C5<> |
+| FileScoped1.cs:17:13:17:14 | S1 | S1 |
+| FileScoped1.cs:19:11:19:12 | E1 | E1 |
+| FileScoped1.cs:21:20:21:21 | D1 | D1 |
+| FileScoped1.cs:23:1:23:18 | R1 | R1 |
+| FileScoped1.cs:25:1:25:26 | RS1 | RS1 |
+| FileScoped2.cs:1:16:1:17 | I1 | I1 |
+| FileScoped2.cs:3:18:3:19 | I2 | I2 |
+| FileScoped2.cs:5:12:5:13 | C1 | C1 |
+| FileScoped2.cs:7:12:7:13 | C2 | C2 |
+| FileScoped2.cs:9:12:9:13 | IC | IC |
+| FileScoped2.cs:11:12:11:16 | C4<> | C4<> |
+| FileScoped2.cs:11:12:11:16 | C4<S> | C4<S> |
+| FileScoped2.cs:13:12:13:16 | C5<> | C5<> |
+| FileScoped2.cs:15:13:15:14 | S1 | S1 |
+| FileScoped2.cs:17:11:17:12 | E1 | E1 |
+| FileScoped2.cs:19:20:19:21 | D1 | D1 |
+| FileScoped2.cs:21:1:21:18 | R1 | R1 |
+| FileScoped2.cs:23:1:23:26 | RS1 | RS1 |
+| FileScoped3.cs:3:16:3:18 | I10 | TestFileScoped.I10 |
+| FileScoped3.cs:5:12:5:14 | C10 | TestFileScoped.C10 |
+| FileScoped3.cs:7:14:7:16 | C11 | TestFileScoped.C11 |
+| FileScoped4.cs:3:18:3:20 | I10 | TestFileScoped.I10 |
+| FileScoped4.cs:5:12:5:14 | C10 | TestFileScoped.C10 |
+| FileScoped4.cs:7:12:7:14 | C11 | TestFileScoped.C11 |
+filetypes
+| FileScoped1.cs:1:16:1:17 | I1 |
+| FileScoped1.cs:3:16:3:17 | I2 |
+| FileScoped1.cs:5:12:5:13 | C1 |
+| FileScoped1.cs:11:16:11:17 | IC |
+| FileScoped1.cs:13:12:13:16 | C4<> |
+| FileScoped1.cs:13:12:13:16 | C4<S> |
+| FileScoped1.cs:15:12:15:16 | C5<> |
+| FileScoped1.cs:17:13:17:14 | S1 |
+| FileScoped1.cs:19:11:19:12 | E1 |
+| FileScoped1.cs:21:20:21:21 | D1 |
+| FileScoped1.cs:23:1:23:18 | R1 |
+| FileScoped1.cs:25:1:25:26 | RS1 |
+| FileScoped2.cs:1:16:1:17 | I1 |
+| FileScoped2.cs:5:12:5:13 | C1 |
+| FileScoped2.cs:7:12:7:13 | C2 |
+| FileScoped2.cs:9:12:9:13 | IC |
+| FileScoped2.cs:11:12:11:16 | C4<> |
+| FileScoped2.cs:11:12:11:16 | C4<S> |
+| FileScoped2.cs:13:12:13:16 | C5<> |
+| FileScoped2.cs:15:13:15:14 | S1 |
+| FileScoped2.cs:17:11:17:12 | E1 |
+| FileScoped2.cs:19:20:19:21 | D1 |
+| FileScoped2.cs:21:1:21:18 | R1 |
+| FileScoped2.cs:23:1:23:26 | RS1 |
+| FileScoped3.cs:3:16:3:18 | I10 |
+| FileScoped3.cs:5:12:5:14 | C10 |
+| FileScoped4.cs:5:12:5:14 | C10 |
+| FileScoped4.cs:7:12:7:14 | C11 |
+internaltypes
+publictypes
+| FileScoped1.cs:7:14:7:15 | C2 |
+| FileScoped1.cs:9:14:9:15 | C3 |
+| FileScoped2.cs:3:18:3:19 | I2 |
+| FileScoped3.cs:7:14:7:16 | C11 |
+| FileScoped4.cs:3:18:3:20 | I10 |

--- a/csharp/ql/test/library-tests/csharp11/fileScoped.ql
+++ b/csharp/ql/test/library-tests/csharp11/fileScoped.ql
@@ -1,0 +1,42 @@
+import csharp
+private import semmle.code.csharp.commons.QualifiedName
+
+private predicate isInteresting(Type t) {
+  (
+    t instanceof Class or
+    t instanceof Interface or
+    t instanceof Struct or
+    t instanceof Enum or
+    t instanceof DelegateType or
+    t instanceof RecordType
+  ) and
+  t.getFile().getStem().matches("FileScoped%")
+}
+
+query predicate typemodifiers(Type t, string modifier) {
+  isInteresting(t) and
+  t.(Modifiable).hasModifier(modifier)
+}
+
+query predicate qualifiedtypes(Type t, string qualifiedName) {
+  isInteresting(t) and
+  exists(string qualifier, string name |
+    t.hasQualifiedName(qualifier, name) and
+    qualifiedName = getQualifiedName(qualifier, name)
+  )
+}
+
+query predicate filetypes(Type t) {
+  isInteresting(t) and
+  t.isFile()
+}
+
+query predicate internaltypes(Type t) {
+  isInteresting(t) and
+  t.isInternal()
+}
+
+query predicate publictypes(Type t) {
+  isInteresting(t) and
+  t.isPublic()
+}


### PR DESCRIPTION
In this PR we make support for `file` scoped types. These types are only *visible* in the file where they are declared.
```csharp
file class C1 { }
```