### PR TITLE
Dataflow: Add a language specific term to `join` and `branch`

### DIFF
--- a/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -960,6 +960,17 @@ module Impl<FullStateConfigSig Config> {
   }
 
   /**
+   * Gets an additional term that is added to `branch` and `join` when deciding whether
+   * the amount of forward or backward branching is within the limit specified by the
+   * configuration.
+   */
+  pragma[nomagic]
+  private int getLanguageSpecificFlowIntoCallNodeCand1(ArgNodeEx arg, ParamNodeEx p) {
+    flowIntoCallNodeCand1(_, arg, p) and
+    result = getAdditionalFlowIntoCallNodeTerm(arg.projectToNode(), p.projectToNode())
+  }
+
+  /**
    * Gets the amount of forward branching on the origin of a cross-call path
    * edge in the graph of paths between sources and sinks that ignores call
    * contexts.
@@ -968,6 +979,7 @@ module Impl<FullStateConfigSig Config> {
   private int branch(NodeEx n1) {
     result =
       strictcount(NodeEx n | flowOutOfCallNodeCand1(_, n1, _, n) or flowIntoCallNodeCand1(_, n1, n))
+        + sum(ParamNodeEx p1 | | getLanguageSpecificFlowIntoCallNodeCand1(n1, p1))
   }
 
   /**
@@ -979,6 +991,7 @@ module Impl<FullStateConfigSig Config> {
   private int join(NodeEx n2) {
     result =
       strictcount(NodeEx n | flowOutOfCallNodeCand1(_, n, _, n2) or flowIntoCallNodeCand1(_, n, n2))
+        + sum(ArgNodeEx arg2 | | getLanguageSpecificFlowIntoCallNodeCand1(arg2, n2))
   }
 
   /**

--- a/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -565,3 +565,19 @@ private class MyConsistencyConfiguration extends Consistency::ConsistencyConfigu
     any()
   }
 }
+
+/**
+ * Gets an additional term that is added to the `join` and `branch` computations to reflect
+ * an additional forward or backwards branching factor that is not taken into account
+ * when calculating the (virtual) dispatch cost.
+ *
+ * `call` is a call with an argument `arg` that is part of a path from a source to a sink, and
+ * `p` is the target parameter of a callable to which `call` may resolve.
+ *
+ * All these values are bound by the dataflow library, and if this predicate is implemented it
+ * should be specified with a bindingset annotation that binds all the columns.
+ */
+bindingset[call, p, arg]
+int getAdditionalFlowIntoCallNodeTerm(DataFlowCall call, ParameterNode p, ArgumentNode arg) {
+  none()
+}

--- a/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -571,13 +571,6 @@ private class MyConsistencyConfiguration extends Consistency::ConsistencyConfigu
  * an additional forward or backwards branching factor that is not taken into account
  * when calculating the (virtual) dispatch cost.
  *
- * `call` is a call with an argument `arg` that is part of a path from a source to a sink, and
- * `p` is the target parameter of a callable to which `call` may resolve.
- *
- * All these values are bound by the dataflow library, and if this predicate is implemented it
- * should be specified with a bindingset annotation that binds all the columns.
+ * Argument `arg` is part of a path from a source to a sink, and `p` is the target parameter.
  */
-bindingset[call, p, arg]
-int getAdditionalFlowIntoCallNodeTerm(DataFlowCall call, ParameterNode p, ArgumentNode arg) {
-  none()
-}
+int getAdditionalFlowIntoCallNodeTerm(ArgumentNode arg, ParameterNode p) { none() }

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -960,6 +960,17 @@ module Impl<FullStateConfigSig Config> {
   }
 
   /**
+   * Gets an additional term that is added to `branch` and `join` when deciding whether
+   * the amount of forward or backward branching is within the limit specified by the
+   * configuration.
+   */
+  pragma[nomagic]
+  private int getLanguageSpecificFlowIntoCallNodeCand1(ArgNodeEx arg, ParamNodeEx p) {
+    flowIntoCallNodeCand1(_, arg, p) and
+    result = getAdditionalFlowIntoCallNodeTerm(arg.projectToNode(), p.projectToNode())
+  }
+
+  /**
    * Gets the amount of forward branching on the origin of a cross-call path
    * edge in the graph of paths between sources and sinks that ignores call
    * contexts.
@@ -968,6 +979,7 @@ module Impl<FullStateConfigSig Config> {
   private int branch(NodeEx n1) {
     result =
       strictcount(NodeEx n | flowOutOfCallNodeCand1(_, n1, _, n) or flowIntoCallNodeCand1(_, n1, n))
+        + sum(ParamNodeEx p1 | | getLanguageSpecificFlowIntoCallNodeCand1(n1, p1))
   }
 
   /**
@@ -979,6 +991,7 @@ module Impl<FullStateConfigSig Config> {
   private int join(NodeEx n2) {
     result =
       strictcount(NodeEx n | flowOutOfCallNodeCand1(_, n, _, n2) or flowIntoCallNodeCand1(_, n, n2))
+        + sum(ArgNodeEx arg2 | | getLanguageSpecificFlowIntoCallNodeCand1(arg2, n2))
   }
 
   /**

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowPrivate.qll
@@ -318,3 +318,19 @@ private class MyConsistencyConfiguration extends Consistency::ConsistencyConfigu
     // consistency alerts enough that most of them are interesting.
   }
 }
+
+/**
+ * Gets an additional term that is added to the `join` and `branch` computations to reflect
+ * an additional forward or backwards branching factor that is not taken into account
+ * when calculating the (virtual) dispatch cost.
+ *
+ * `call` is a call with an argument `arg` that is part of a path from a source to a sink, and
+ * `p` is the target parameter of a callable to which `call` may resolve.
+ *
+ * All these values are bound by the dataflow library, and if this predicate is implemented it
+ * should be specified with a bindingset annotation that binds all the columns.
+ */
+bindingset[call, p, arg]
+int getAdditionalFlowIntoCallNodeTerm(DataFlowCall call, ParameterNode p, ArgumentNode arg) {
+  none()
+}

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowPrivate.qll
@@ -324,13 +324,6 @@ private class MyConsistencyConfiguration extends Consistency::ConsistencyConfigu
  * an additional forward or backwards branching factor that is not taken into account
  * when calculating the (virtual) dispatch cost.
  *
- * `call` is a call with an argument `arg` that is part of a path from a source to a sink, and
- * `p` is the target parameter of a callable to which `call` may resolve.
- *
- * All these values are bound by the dataflow library, and if this predicate is implemented it
- * should be specified with a bindingset annotation that binds all the columns.
+ * Argument `arg` is part of a path from a source to a sink, and `p` is the target parameter.
  */
-bindingset[call, p, arg]
-int getAdditionalFlowIntoCallNodeTerm(DataFlowCall call, ParameterNode p, ArgumentNode arg) {
-  none()
-}
+int getAdditionalFlowIntoCallNodeTerm(ArgumentNode arg, ParameterNode p) { none() }

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -960,6 +960,17 @@ module Impl<FullStateConfigSig Config> {
   }
 
   /**
+   * Gets an additional term that is added to `branch` and `join` when deciding whether
+   * the amount of forward or backward branching is within the limit specified by the
+   * configuration.
+   */
+  pragma[nomagic]
+  private int getLanguageSpecificFlowIntoCallNodeCand1(ArgNodeEx arg, ParamNodeEx p) {
+    flowIntoCallNodeCand1(_, arg, p) and
+    result = getAdditionalFlowIntoCallNodeTerm(arg.projectToNode(), p.projectToNode())
+  }
+
+  /**
    * Gets the amount of forward branching on the origin of a cross-call path
    * edge in the graph of paths between sources and sinks that ignores call
    * contexts.
@@ -968,6 +979,7 @@ module Impl<FullStateConfigSig Config> {
   private int branch(NodeEx n1) {
     result =
       strictcount(NodeEx n | flowOutOfCallNodeCand1(_, n1, _, n) or flowIntoCallNodeCand1(_, n1, n))
+        + sum(ParamNodeEx p1 | | getLanguageSpecificFlowIntoCallNodeCand1(n1, p1))
   }
 
   /**
@@ -979,6 +991,7 @@ module Impl<FullStateConfigSig Config> {
   private int join(NodeEx n2) {
     result =
       strictcount(NodeEx n | flowOutOfCallNodeCand1(_, n, _, n2) or flowIntoCallNodeCand1(_, n, n2))
+        + sum(ArgNodeEx arg2 | | getLanguageSpecificFlowIntoCallNodeCand1(arg2, n2))
   }
 
   /**

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -414,3 +414,19 @@ private class MyConsistencyConfiguration extends Consistency::ConsistencyConfigu
     any()
   }
 }
+
+/**
+ * Gets an additional term that is added to the `join` and `branch` computations to reflect
+ * an additional forward or backwards branching factor that is not taken into account
+ * when calculating the (virtual) dispatch cost.
+ *
+ * `call` is a call with an argument `arg` that is part of a path from a source to a sink, and
+ * `p` is the target parameter of a callable to which `call` may resolve.
+ *
+ * All these values are bound by the dataflow library, and if this predicate is implemented it
+ * should be specified with a bindingset annotation that binds all the columns.
+ */
+bindingset[call, p, arg]
+int getAdditionalFlowIntoCallNodeTerm(DataFlowCall call, ParameterNode p, ArgumentNode arg) {
+  none()
+}

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -420,13 +420,6 @@ private class MyConsistencyConfiguration extends Consistency::ConsistencyConfigu
  * an additional forward or backwards branching factor that is not taken into account
  * when calculating the (virtual) dispatch cost.
  *
- * `call` is a call with an argument `arg` that is part of a path from a source to a sink, and
- * `p` is the target parameter of a callable to which `call` may resolve.
- *
- * All these values are bound by the dataflow library, and if this predicate is implemented it
- * should be specified with a bindingset annotation that binds all the columns.
+ * Argument `arg` is part of a path from a source to a sink, and `p` is the target parameter.
  */
-bindingset[call, p, arg]
-int getAdditionalFlowIntoCallNodeTerm(DataFlowCall call, ParameterNode p, ArgumentNode arg) {
-  none()
-}
+int getAdditionalFlowIntoCallNodeTerm(ArgumentNode arg, ParameterNode p) { none() }

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -960,6 +960,17 @@ module Impl<FullStateConfigSig Config> {
   }
 
   /**
+   * Gets an additional term that is added to `branch` and `join` when deciding whether
+   * the amount of forward or backward branching is within the limit specified by the
+   * configuration.
+   */
+  pragma[nomagic]
+  private int getLanguageSpecificFlowIntoCallNodeCand1(ArgNodeEx arg, ParamNodeEx p) {
+    flowIntoCallNodeCand1(_, arg, p) and
+    result = getAdditionalFlowIntoCallNodeTerm(arg.projectToNode(), p.projectToNode())
+  }
+
+  /**
    * Gets the amount of forward branching on the origin of a cross-call path
    * edge in the graph of paths between sources and sinks that ignores call
    * contexts.
@@ -968,6 +979,7 @@ module Impl<FullStateConfigSig Config> {
   private int branch(NodeEx n1) {
     result =
       strictcount(NodeEx n | flowOutOfCallNodeCand1(_, n1, _, n) or flowIntoCallNodeCand1(_, n1, n))
+        + sum(ParamNodeEx p1 | | getLanguageSpecificFlowIntoCallNodeCand1(n1, p1))
   }
 
   /**
@@ -979,6 +991,7 @@ module Impl<FullStateConfigSig Config> {
   private int join(NodeEx n2) {
     result =
       strictcount(NodeEx n | flowOutOfCallNodeCand1(_, n, _, n2) or flowIntoCallNodeCand1(_, n, n2))
+        + sum(ArgNodeEx arg2 | | getLanguageSpecificFlowIntoCallNodeCand1(arg2, n2))
   }
 
   /**

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -2374,3 +2374,19 @@ module Csv {
     )
   }
 }
+
+/**
+ * Gets an additional term that is added to the `join` and `branch` computations to reflect
+ * an additional forward or backwards branching factor that is not taken into account
+ * when calculating the (virtual) dispatch cost.
+ *
+ * `call` is a call with an argument `arg` that is part of a path from a source to a sink, and
+ * `p` is the target parameter of a callable to which `call` may resolve.
+ *
+ * All these values are bound by the dataflow library, and if this predicate is implemented it
+ * should be specified with a bindingset annotation that binds all the columns.
+ */
+bindingset[call, p, arg]
+int getAdditionalFlowIntoCallNodeTerm(DataFlowCall call, ParameterNode p, ArgumentNode arg) {
+  none()
+}

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -2380,13 +2380,6 @@ module Csv {
  * an additional forward or backwards branching factor that is not taken into account
  * when calculating the (virtual) dispatch cost.
  *
- * `call` is a call with an argument `arg` that is part of a path from a source to a sink, and
- * `p` is the target parameter of a callable to which `call` may resolve.
- *
- * All these values are bound by the dataflow library, and if this predicate is implemented it
- * should be specified with a bindingset annotation that binds all the columns.
+ * Argument `arg` is part of a path from a source to a sink, and `p` is the target parameter.
  */
-bindingset[call, p, arg]
-int getAdditionalFlowIntoCallNodeTerm(DataFlowCall call, ParameterNode p, ArgumentNode arg) {
-  none()
-}
+int getAdditionalFlowIntoCallNodeTerm(ArgumentNode arg, ParameterNode p) { none() }

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowImpl.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowImpl.qll
@@ -960,6 +960,17 @@ module Impl<FullStateConfigSig Config> {
   }
 
   /**
+   * Gets an additional term that is added to `branch` and `join` when deciding whether
+   * the amount of forward or backward branching is within the limit specified by the
+   * configuration.
+   */
+  pragma[nomagic]
+  private int getLanguageSpecificFlowIntoCallNodeCand1(ArgNodeEx arg, ParamNodeEx p) {
+    flowIntoCallNodeCand1(_, arg, p) and
+    result = getAdditionalFlowIntoCallNodeTerm(arg.projectToNode(), p.projectToNode())
+  }
+
+  /**
    * Gets the amount of forward branching on the origin of a cross-call path
    * edge in the graph of paths between sources and sinks that ignores call
    * contexts.
@@ -968,6 +979,7 @@ module Impl<FullStateConfigSig Config> {
   private int branch(NodeEx n1) {
     result =
       strictcount(NodeEx n | flowOutOfCallNodeCand1(_, n1, _, n) or flowIntoCallNodeCand1(_, n1, n))
+        + sum(ParamNodeEx p1 | | getLanguageSpecificFlowIntoCallNodeCand1(n1, p1))
   }
 
   /**
@@ -979,6 +991,7 @@ module Impl<FullStateConfigSig Config> {
   private int join(NodeEx n2) {
     result =
       strictcount(NodeEx n | flowOutOfCallNodeCand1(_, n, _, n2) or flowIntoCallNodeCand1(_, n, n2))
+        + sum(ArgNodeEx arg2 | | getLanguageSpecificFlowIntoCallNodeCand1(arg2, n2))
   }
 
   /**

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowPrivate.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowPrivate.qll
@@ -390,3 +390,19 @@ class ContentApprox = Unit;
 /** Gets an approximated value for content `c`. */
 pragma[inline]
 ContentApprox getContentApprox(Content c) { any() }
+
+/**
+ * Gets an additional term that is added to the `join` and `branch` computations to reflect
+ * an additional forward or backwards branching factor that is not taken into account
+ * when calculating the (virtual) dispatch cost.
+ *
+ * `call` is a call with an argument `arg` that is part of a path from a source to a sink, and
+ * `p` is the target parameter of a callable to which `call` may resolve.
+ *
+ * All these values are bound by the dataflow library, and if this predicate is implemented it
+ * should be specified with a bindingset annotation that binds all the columns.
+ */
+bindingset[call, p, arg]
+int getAdditionalFlowIntoCallNodeTerm(DataFlowCall call, ParameterNode p, ArgumentNode arg) {
+  none()
+}

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowPrivate.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowPrivate.qll
@@ -396,13 +396,6 @@ ContentApprox getContentApprox(Content c) { any() }
  * an additional forward or backwards branching factor that is not taken into account
  * when calculating the (virtual) dispatch cost.
  *
- * `call` is a call with an argument `arg` that is part of a path from a source to a sink, and
- * `p` is the target parameter of a callable to which `call` may resolve.
- *
- * All these values are bound by the dataflow library, and if this predicate is implemented it
- * should be specified with a bindingset annotation that binds all the columns.
+ * Argument `arg` is part of a path from a source to a sink, and `p` is the target parameter.
  */
-bindingset[call, p, arg]
-int getAdditionalFlowIntoCallNodeTerm(DataFlowCall call, ParameterNode p, ArgumentNode arg) {
-  none()
-}
+int getAdditionalFlowIntoCallNodeTerm(ArgumentNode arg, ParameterNode p) { none() }

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -960,6 +960,17 @@ module Impl<FullStateConfigSig Config> {
   }
 
   /**
+   * Gets an additional term that is added to `branch` and `join` when deciding whether
+   * the amount of forward or backward branching is within the limit specified by the
+   * configuration.
+   */
+  pragma[nomagic]
+  private int getLanguageSpecificFlowIntoCallNodeCand1(ArgNodeEx arg, ParamNodeEx p) {
+    flowIntoCallNodeCand1(_, arg, p) and
+    result = getAdditionalFlowIntoCallNodeTerm(arg.projectToNode(), p.projectToNode())
+  }
+
+  /**
    * Gets the amount of forward branching on the origin of a cross-call path
    * edge in the graph of paths between sources and sinks that ignores call
    * contexts.
@@ -968,6 +979,7 @@ module Impl<FullStateConfigSig Config> {
   private int branch(NodeEx n1) {
     result =
       strictcount(NodeEx n | flowOutOfCallNodeCand1(_, n1, _, n) or flowIntoCallNodeCand1(_, n1, n))
+        + sum(ParamNodeEx p1 | | getLanguageSpecificFlowIntoCallNodeCand1(n1, p1))
   }
 
   /**
@@ -979,6 +991,7 @@ module Impl<FullStateConfigSig Config> {
   private int join(NodeEx n2) {
     result =
       strictcount(NodeEx n | flowOutOfCallNodeCand1(_, n, _, n2) or flowIntoCallNodeCand1(_, n, n2))
+        + sum(ArgNodeEx arg2 | | getLanguageSpecificFlowIntoCallNodeCand1(arg2, n2))
   }
 
   /**

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowPrivate.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowPrivate.qll
@@ -484,13 +484,6 @@ predicate containerContent(Content c) {
  * an additional forward or backwards branching factor that is not taken into account
  * when calculating the (virtual) dispatch cost.
  *
- * `call` is a call with an argument `arg` that is part of a path from a source to a sink, and
- * `p` is the target parameter of a callable to which `call` may resolve.
- *
- * All these values are bound by the dataflow library, and if this predicate is implemented it
- * should be specified with a bindingset annotation that binds all the columns.
+ * Argument `arg` is part of a path from a source to a sink, and `p` is the target parameter.
  */
-bindingset[call, p, arg]
-int getAdditionalFlowIntoCallNodeTerm(DataFlowCall call, ParameterNode p, ArgumentNode arg) {
-  none()
-}
+int getAdditionalFlowIntoCallNodeTerm(ArgumentNode arg, ParameterNode p) { none() }

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowPrivate.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowPrivate.qll
@@ -478,3 +478,19 @@ predicate containerContent(Content c) {
   c instanceof MapKeyContent or
   c instanceof MapValueContent
 }
+
+/**
+ * Gets an additional term that is added to the `join` and `branch` computations to reflect
+ * an additional forward or backwards branching factor that is not taken into account
+ * when calculating the (virtual) dispatch cost.
+ *
+ * `call` is a call with an argument `arg` that is part of a path from a source to a sink, and
+ * `p` is the target parameter of a callable to which `call` may resolve.
+ *
+ * All these values are bound by the dataflow library, and if this predicate is implemented it
+ * should be specified with a bindingset annotation that binds all the columns.
+ */
+bindingset[call, p, arg]
+int getAdditionalFlowIntoCallNodeTerm(DataFlowCall call, ParameterNode p, ArgumentNode arg) {
+  none()
+}

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl.qll
@@ -960,6 +960,17 @@ module Impl<FullStateConfigSig Config> {
   }
 
   /**
+   * Gets an additional term that is added to `branch` and `join` when deciding whether
+   * the amount of forward or backward branching is within the limit specified by the
+   * configuration.
+   */
+  pragma[nomagic]
+  private int getLanguageSpecificFlowIntoCallNodeCand1(ArgNodeEx arg, ParamNodeEx p) {
+    flowIntoCallNodeCand1(_, arg, p) and
+    result = getAdditionalFlowIntoCallNodeTerm(arg.projectToNode(), p.projectToNode())
+  }
+
+  /**
    * Gets the amount of forward branching on the origin of a cross-call path
    * edge in the graph of paths between sources and sinks that ignores call
    * contexts.
@@ -968,6 +979,7 @@ module Impl<FullStateConfigSig Config> {
   private int branch(NodeEx n1) {
     result =
       strictcount(NodeEx n | flowOutOfCallNodeCand1(_, n1, _, n) or flowIntoCallNodeCand1(_, n1, n))
+        + sum(ParamNodeEx p1 | | getLanguageSpecificFlowIntoCallNodeCand1(n1, p1))
   }
 
   /**
@@ -979,6 +991,7 @@ module Impl<FullStateConfigSig Config> {
   private int join(NodeEx n2) {
     result =
       strictcount(NodeEx n | flowOutOfCallNodeCand1(_, n, _, n2) or flowIntoCallNodeCand1(_, n, n2))
+        + sum(ArgNodeEx arg2 | | getLanguageSpecificFlowIntoCallNodeCand1(arg2, n2))
   }
 
   /**

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
@@ -1008,3 +1008,19 @@ class ContentApprox = Unit;
 /** Gets an approximated value for content `c`. */
 pragma[inline]
 ContentApprox getContentApprox(Content c) { any() }
+
+/**
+ * Gets an additional term that is added to the `join` and `branch` computations to reflect
+ * an additional forward or backwards branching factor that is not taken into account
+ * when calculating the (virtual) dispatch cost.
+ *
+ * `call` is a call with an argument `arg` that is part of a path from a source to a sink, and
+ * `p` is the target parameter of a callable to which `call` may resolve.
+ *
+ * All these values are bound by the dataflow library, and if this predicate is implemented it
+ * should be specified with a bindingset annotation that binds all the columns.
+ */
+bindingset[call, p, arg]
+int getAdditionalFlowIntoCallNodeTerm(DataFlowCall call, ParameterNode p, ArgumentNode arg) {
+  none()
+}

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
@@ -1014,13 +1014,6 @@ ContentApprox getContentApprox(Content c) { any() }
  * an additional forward or backwards branching factor that is not taken into account
  * when calculating the (virtual) dispatch cost.
  *
- * `call` is a call with an argument `arg` that is part of a path from a source to a sink, and
- * `p` is the target parameter of a callable to which `call` may resolve.
- *
- * All these values are bound by the dataflow library, and if this predicate is implemented it
- * should be specified with a bindingset annotation that binds all the columns.
+ * Argument `arg` is part of a path from a source to a sink, and `p` is the target parameter.
  */
-bindingset[call, p, arg]
-int getAdditionalFlowIntoCallNodeTerm(DataFlowCall call, ParameterNode p, ArgumentNode arg) {
-  none()
-}
+int getAdditionalFlowIntoCallNodeTerm(ArgumentNode arg, ParameterNode p) { none() }

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl.qll
@@ -960,6 +960,17 @@ module Impl<FullStateConfigSig Config> {
   }
 
   /**
+   * Gets an additional term that is added to `branch` and `join` when deciding whether
+   * the amount of forward or backward branching is within the limit specified by the
+   * configuration.
+   */
+  pragma[nomagic]
+  private int getLanguageSpecificFlowIntoCallNodeCand1(ArgNodeEx arg, ParamNodeEx p) {
+    flowIntoCallNodeCand1(_, arg, p) and
+    result = getAdditionalFlowIntoCallNodeTerm(arg.projectToNode(), p.projectToNode())
+  }
+
+  /**
    * Gets the amount of forward branching on the origin of a cross-call path
    * edge in the graph of paths between sources and sinks that ignores call
    * contexts.
@@ -968,6 +979,7 @@ module Impl<FullStateConfigSig Config> {
   private int branch(NodeEx n1) {
     result =
       strictcount(NodeEx n | flowOutOfCallNodeCand1(_, n1, _, n) or flowIntoCallNodeCand1(_, n1, n))
+        + sum(ParamNodeEx p1 | | getLanguageSpecificFlowIntoCallNodeCand1(n1, p1))
   }
 
   /**
@@ -979,6 +991,7 @@ module Impl<FullStateConfigSig Config> {
   private int join(NodeEx n2) {
     result =
       strictcount(NodeEx n | flowOutOfCallNodeCand1(_, n, _, n2) or flowIntoCallNodeCand1(_, n, n2))
+        + sum(ArgNodeEx arg2 | | getLanguageSpecificFlowIntoCallNodeCand1(arg2, n2))
   }
 
   /**

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
@@ -1504,13 +1504,6 @@ class AdditionalJumpStep extends Unit {
  * an additional forward or backwards branching factor that is not taken into account
  * when calculating the (virtual) dispatch cost.
  *
- * `call` is a call with an argument `arg` that is part of a path from a source to a sink, and
- * `p` is the target parameter of a callable to which `call` may resolve.
- *
- * All these values are bound by the dataflow library, and if this predicate is implemented it
- * should be specified with a bindingset annotation that binds all the columns.
+ * Argument `arg` is part of a path from a source to a sink, and `p` is the target parameter.
  */
-bindingset[call, p, arg]
-int getAdditionalFlowIntoCallNodeTerm(DataFlowCall call, ParameterNode p, ArgumentNode arg) {
-  none()
-}
+int getAdditionalFlowIntoCallNodeTerm(ArgumentNode arg, ParameterNode p) { none() }

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
@@ -1498,3 +1498,19 @@ class AdditionalJumpStep extends Unit {
    */
   abstract predicate step(Node pred, Node succ);
 }
+
+/**
+ * Gets an additional term that is added to the `join` and `branch` computations to reflect
+ * an additional forward or backwards branching factor that is not taken into account
+ * when calculating the (virtual) dispatch cost.
+ *
+ * `call` is a call with an argument `arg` that is part of a path from a source to a sink, and
+ * `p` is the target parameter of a callable to which `call` may resolve.
+ *
+ * All these values are bound by the dataflow library, and if this predicate is implemented it
+ * should be specified with a bindingset annotation that binds all the columns.
+ */
+bindingset[call, p, arg]
+int getAdditionalFlowIntoCallNodeTerm(DataFlowCall call, ParameterNode p, ArgumentNode arg) {
+  none()
+}

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImpl.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImpl.qll
@@ -960,6 +960,17 @@ module Impl<FullStateConfigSig Config> {
   }
 
   /**
+   * Gets an additional term that is added to `branch` and `join` when deciding whether
+   * the amount of forward or backward branching is within the limit specified by the
+   * configuration.
+   */
+  pragma[nomagic]
+  private int getLanguageSpecificFlowIntoCallNodeCand1(ArgNodeEx arg, ParamNodeEx p) {
+    flowIntoCallNodeCand1(_, arg, p) and
+    result = getAdditionalFlowIntoCallNodeTerm(arg.projectToNode(), p.projectToNode())
+  }
+
+  /**
    * Gets the amount of forward branching on the origin of a cross-call path
    * edge in the graph of paths between sources and sinks that ignores call
    * contexts.
@@ -968,6 +979,7 @@ module Impl<FullStateConfigSig Config> {
   private int branch(NodeEx n1) {
     result =
       strictcount(NodeEx n | flowOutOfCallNodeCand1(_, n1, _, n) or flowIntoCallNodeCand1(_, n1, n))
+        + sum(ParamNodeEx p1 | | getLanguageSpecificFlowIntoCallNodeCand1(n1, p1))
   }
 
   /**
@@ -979,6 +991,7 @@ module Impl<FullStateConfigSig Config> {
   private int join(NodeEx n2) {
     result =
       strictcount(NodeEx n | flowOutOfCallNodeCand1(_, n, _, n2) or flowIntoCallNodeCand1(_, n, n2))
+        + sum(ArgNodeEx arg2 | | getLanguageSpecificFlowIntoCallNodeCand1(arg2, n2))
   }
 
   /**

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPrivate.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPrivate.qll
@@ -696,3 +696,19 @@ class ContentApprox = Unit;
 /** Gets an approximated value for content `c`. */
 pragma[inline]
 ContentApprox getContentApprox(Content c) { any() }
+
+/**
+ * Gets an additional term that is added to the `join` and `branch` computations to reflect
+ * an additional forward or backwards branching factor that is not taken into account
+ * when calculating the (virtual) dispatch cost.
+ *
+ * `call` is a call with an argument `arg` that is part of a path from a source to a sink, and
+ * `p` is the target parameter of a callable to which `call` may resolve.
+ *
+ * All these values are bound by the dataflow library, and if this predicate is implemented it
+ * should be specified with a bindingset annotation that binds all the columns.
+ */
+bindingset[call, p, arg]
+int getAdditionalFlowIntoCallNodeTerm(DataFlowCall call, ParameterNode p, ArgumentNode arg) {
+  none()
+}

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPrivate.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPrivate.qll
@@ -702,13 +702,6 @@ ContentApprox getContentApprox(Content c) { any() }
  * an additional forward or backwards branching factor that is not taken into account
  * when calculating the (virtual) dispatch cost.
  *
- * `call` is a call with an argument `arg` that is part of a path from a source to a sink, and
- * `p` is the target parameter of a callable to which `call` may resolve.
- *
- * All these values are bound by the dataflow library, and if this predicate is implemented it
- * should be specified with a bindingset annotation that binds all the columns.
+ * Argument `arg` is part of a path from a source to a sink, and `p` is the target parameter.
  */
-bindingset[call, p, arg]
-int getAdditionalFlowIntoCallNodeTerm(DataFlowCall call, ParameterNode p, ArgumentNode arg) {
-  none()
-}
+int getAdditionalFlowIntoCallNodeTerm(ArgumentNode arg, ParameterNode p) { none() }


### PR DESCRIPTION
In the process of adding more dataflow to C/C++ we've seen a large performance regression on a codebase that contains code like:
```cpp
void foo(int opcode, A* a) {
  switch(opcode) {
    case 0: /*...*/ break;
    case 1: /*...*/ break;
    ...
    case N: /*...*/ break;
  }
}
```
where the code inside `/* ... */` causes the dataflow library to create a giant number of access paths:

<details>

| #  | n  | stage | nodes | field | conscand | states | tuples  | config                   |
|----|----|-------|-------|-------|----------|--------|---------|--------------------------|
| 1  | 10 | 1 Fwd | 95703 | 234   | -1       | 1      | 116835  | TaintedPathConfiguration |
| 2  | 15 | 1 Rev | 29976 | 111   | -1       | 1      | 41712   | TaintedPathConfiguration |
| 3  | 20 | 2 Fwd | 24169 | 85    | 147      | 1      | 61263   | TaintedPathConfiguration |
| 4  | 25 | 2 Rev | 23181 | 82    | 130      | 1      | 68834   | TaintedPathConfiguration |
| 5  | 30 | 3 Fwd | 6574  | 70    | 745      | 1      | 195395  | TaintedPathConfiguration |
| 6  | 35 | 3 Rev | 5929  | 65    | 557      | 1      | 263019  | TaintedPathConfiguration |
| 7  | 40 | 4 Fwd | 5884  | 65    | 1655     | 1      | 723901  | TaintedPathConfiguration |
| 8  | 45 | 4 Rev | 5711  | 65    | 1561     | 1      | 1569580 | TaintedPathConfiguration |
| 9  | 50 | 5 Fwd | 5510  | 64    | 4661     | 1      | 1657203 | TaintedPathConfiguration |
| 10 | 55 | 5 Rev | 5433  | 64    | 3877     | 1      | 3534661 | TaintedPathConfiguration |
| 11 | 60 | 6 Fwd | 5433  | 64    | 2246     | 1      | 1446310 | TaintedPathConfiguration |
| 12 | 65 | 6 Rev | 5303  | 64    | 2246     | 1      | 1416719 | TaintedPathConfiguration |
</details>

As @aschackmull pointed out, this looks a lot like a virtual dispatch hierarchy like (sorry for my bad Java 😅):

```java
public interface Foo {
  public void foo(A*);
}

public class Foo1 implements Foo {
  public void foo(A* a) { /* ... */ }
}

public class Foo2 implements Foo {
  public void foo(A* a) { /* ... */ }
}

...

public class FooN implements Foo {
  public void foo(A* a) { /* ... */ }
}
```

and when written like that, the dataflow library recognizes that such calls to `foo` may have a high fan-in/fan-out.

However, it's not clear how the dataflow library would recognize the `switch` pattern above to selectively disable field flow for such cases. Thus, this PR adds a new predicate that can be overwritten for each language to increase the `join` and `branch` values when calculating the expected fan-in and fan-out.

I've only implemented a "flow-into" version as this was the only thing that was necessary to fix the performance on C/C++.

Implementing this new predicate as `none()` (as I've done so in this PR) will preserve the current fan-in/fan-out estimates. I hope that makes this PR uncontroversial.


Once we implement the predicate for C/C++ (which I'll do in a follow-up PR) the stats will be the much more manageable:

<details>

| #  | n  | stage | nodes | field | conscand | states | tuples | config                   |
|----|----|-------|-------|-------|----------|--------|--------|--------------------------|
| 1  | 10 | 1 Fwd | 95703 | 234   | -1       | 1      | 116835 | TaintedPathConfiguration |
| 2  | 15 | 1 Rev | 29976 | 111   | -1       | 1      | 41712  | TaintedPathConfiguration |
| 3  | 20 | 2 Fwd | 23561 | 85    | 145      | 1      | 54250  | TaintedPathConfiguration |
| 4  | 25 | 2 Rev | 21495 | 79    | 110      | 1      | 49098  | TaintedPathConfiguration |
| 5  | 30 | 3 Fwd | 5964  | 67    | 481      | 1      | 70626  | TaintedPathConfiguration |
| 6  | 35 | 3 Rev | 5421  | 65    | 320      | 1      | 62158  | TaintedPathConfiguration |
| 7  | 40 | 4 Fwd | 5393  | 65    | 885      | 1      | 134163 | TaintedPathConfiguration |
| 8  | 45 | 4 Rev | 5360  | 65    | 846      | 1      | 248973 | TaintedPathConfiguration |
| 9  | 50 | 5 Fwd | 5217  | 64    | 2337     | 1      | 432751 | TaintedPathConfiguration |
| 10 | 55 | 5 Rev | 4657  | 54    | 2097     | 1      | 395159 | TaintedPathConfiguration |
| 11 | 60 | 6 Fwd | 4657  | 54    | 1169     | 1      | 424518 | TaintedPathConfiguration |
| 12 | 65 | 6 Rev | 4527  | 54    | 1169     | 1      | 409183 | TaintedPathConfiguration |
</details>