### PR TITLE
CI: quiter and faster format checks

### DIFF
--- a/.github/workflows/compile-queries.yml
+++ b/.github/workflows/compile-queries.yml
@@ -24,7 +24,7 @@ jobs:
         with: 
           key: all-queries
       - name: check formatting
-        run: find */ql -type f \( -name "*.qll" -o -name "*.ql" \) -print0 | xargs -0 codeql query format --check-only
+        run: find */ql -type f \( -name "*.qll" -o -name "*.ql" \) -print0 | xargs -0 -n 3000 -P 10 codeql query format --check-only -q
       - name: compile queries - check-only
         # run with --check-only if running in a PR (github.sha != main)
         if : ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
`-n 3000`: each CodeQL invocation will at most receive 3000 files to do a format check on.  
`-P 10`: at most 10 concurrent CodeQL invocations.  
`-q`: don't print anything for files that passed the format check.  

There are currently slightly above 10000 files to do the format check on, so 4 CodeQL processes will spawn.  

I tested various numbers for `-n`, and `-n 3000` seemed to run the fastest on my system (which is close enough to the 8 core worker this will run on).  
It in under half the time compared to previously (on my laptop).  