### PR TITLE
Java: Test generator fixes

### DIFF
--- a/java/ql/src/utils/flowtestcasegenerator/FlowTestCase.qll
+++ b/java/ql/src/utils/flowtestcasegenerator/FlowTestCase.qll
@@ -228,7 +228,7 @@ class TestCase extends TTestCase {
    */
   Type getOutputType() {
     if baseOutput = SummaryComponentStack::return()
-    then result = getReturnType(callable)
+    then result = callable.getReturnType()
     else
       exists(int i |
         baseOutput = SummaryComponentStack::argument(i) and

--- a/java/ql/src/utils/flowtestcasegenerator/FlowTestCaseUtils.qll
+++ b/java/ql/src/utils/flowtestcasegenerator/FlowTestCaseUtils.qll
@@ -16,11 +16,6 @@ Type getRootSourceDeclaration(Type t) {
   else result = t
 }
 
-/** Gets the return type of the callable c, or the constructed tpe if it's a constructor */
-Type getReturnType(Callable c) {
-  if c instanceof Constructor then result = c.getDeclaringType() else result = c.getReturnType()
-}
-
 /**
  * Holds if type `t` does not clash with another type we want to import that has the same base name.
  */
@@ -69,11 +64,12 @@ string getZero(PrimitiveType t) {
  * Holds if `c` may require disambiguation from an overload with the same argument count.
  */
 predicate mayBeAmbiguous(Callable c) {
-  exists(Callable other, string package, string type, string name |
-    c.hasQualifiedName(package, type, name) and
+  exists(Callable other, Callable override, string package, string type, string name |
+    override = [c, c.(Method).getASourceOverriddenMethod*()] and
+    override.hasQualifiedName(package, type, name) and
     other.hasQualifiedName(package, type, name) and
-    other.getNumberOfParameters() = c.getNumberOfParameters() and
-    other != c
+    other.getNumberOfParameters() = override.getNumberOfParameters() and
+    other != override
   )
   or
   c.isVarargs()


### PR DESCRIPTION
- Revert previous change (in https://github.com/github/codeql/pull/12195) to constructor return types; as constructors are supposed to be modeled using Argument[-1] rather than ReturnValue
- Fix generation of ambiguous calls when one of the conflicting methods is overridden