### PR TITLE
Update CODEOWNERS for dynamic teams

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,9 +2,9 @@
 /csharp/ @github/codeql-csharp
 /go/ @github/codeql-go
 /java/ @github/codeql-java
-/javascript/ @github/codeql-javascript
-/python/ @github/codeql-python
-/ruby/ @github/codeql-ruby
+/javascript/ @github/codeql-dynamic
+/python/ @github/codeql-dynamic
+/ruby/ @github/codeql-dynamic
 /swift/ @github/codeql-swift
 /java/kotlin-extractor/ @github/codeql-kotlin
 /java/kotlin-explorer/ @github/codeql-kotlin


### PR DESCRIPTION
As agreed in the retro, we'll make all dynamic team members responsible for PRs