### PR TITLE
Go integer conversion: check against sink, not source signedness

### DIFF
--- a/go/ql/src/change-notes/2023-02-17-integer-conversion-fix.md
+++ b/go/ql/src/change-notes/2023-02-17-integer-conversion-fix.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The query `go/incorrect-integer-conversion` now correctly recognises guards of the form `if val <= x` to protect a conversion `uintX(val)` when `x` is in the range `(math.MaxIntX, math.MaxUintX]`.

--- a/go/ql/test/query-tests/Security/CWE-681/IncorrectIntegerConversion.go
+++ b/go/ql/test/query-tests/Security/CWE-681/IncorrectIntegerConversion.go
@@ -264,8 +264,8 @@ func testBoundsChecking(input string) {
 				_ = int16(parsed)
 			}
 		}
-		if parsed <= math.MaxUint32 {
-			_ = uint32(parsed)
+		if parsed <= math.MaxUint16 {
+			_ = uint16(parsed)
 		}
 	}
 	{

--- a/go/ql/test/query-tests/Security/CWE-681/IncorrectIntegerConversion.go
+++ b/go/ql/test/query-tests/Security/CWE-681/IncorrectIntegerConversion.go
@@ -264,6 +264,9 @@ func testBoundsChecking(input string) {
 				_ = int16(parsed)
 			}
 		}
+		if parsed <= math.MaxUint32 {
+			_ = uint32(parsed)
+		}
 	}
 	{
 		parsed, err := strconv.ParseUint(input, 10, 32)


### PR DESCRIPTION
Previously in order to sanitize based on a guard, we required a check of the form `if valToConvert < limit`, where `limit` had a value not greater than the max value of the conversion target type... with the source signedness. So for example we would accept `valToConvert <= MaxInt32` but not `valToConvert <= MaxUint32` to protect a conversion `uint32(valToConvert)`, even though either works to ensure we're within the target upper bound and either lacks a `>= 0` check.

The query doesn't currently try to spot the need to check `>= 0` prior to converting signed-to-unsigned, and this PR doesn't change that; it just pegs the high threshold to the sink's max value, not the combination of source signedness and sink bit-size.