### PR TITLE
CI: Fix CI use of the compilation cache

### DIFF
--- a/.github/actions/cache-query-compilation/action.yml
+++ b/.github/actions/cache-query-compilation/action.yml
@@ -27,7 +27,9 @@ runs:
       if: ${{ github.event_name == 'pull_request' }}
       uses: actions/cache/restore@v3
       with:
-        path: '**/.cache'
+        path: |
+          **/.cache
+          ~/.codeql/compile-cache
         key: codeql-compile-${{ inputs.key }}-pr-${{ github.sha }}
         restore-keys: |
           codeql-compile-${{ inputs.key }}-${{ github.base_ref }}-${{ env.merge_base }}
@@ -37,7 +39,9 @@ runs:
       if: ${{ github.event_name != 'pull_request' }}
       uses: actions/cache@v3
       with:
-        path: '**/.cache'
+        path: |
+          **/.cache
+          ~/.codeql/compile-cache
         key: codeql-compile-${{ inputs.key }}-${{ github.ref_name }}-${{ github.sha }} # just fill on main
         restore-keys: | # restore the latest cache if the exact cache is unavailable, to speed up compilation.
           codeql-compile-${{ inputs.key }}-${{ github.ref_name }}-
@@ -66,6 +70,7 @@ runs:
 
           const fs = require("fs");
           const path = require("path");
+          const os = require("os");
 
           // the first argv is the cache folder to create.
           const COMBINED_CACHE_DIR = process.env.COMBINED_CACHE_DIR;
@@ -103,6 +108,17 @@ runs:
 
             for (const dir of cacheDirs) {
               console.log(`Found .cache dir at ${dir}`);
+            }
+
+            const globalCacheDir = path.join(os.homedir(), ".codeql", "compile-cache");
+            if (fs.existsSync(globalCacheDir)) {
+              console.log("Found global home dir: " + globalCacheDir);
+              cacheDirs.push(globalCacheDir);
+            }
+
+            if (cacheDirs.length === 0) {
+              console.log("No cache dirs found");
+              return;
             }
 
             // mkdir -p ${COMBINED_CACHE_DIR}

--- a/.github/actions/cache-query-compilation/action.yml
+++ b/.github/actions/cache-query-compilation/action.yml
@@ -9,7 +9,7 @@ inputs:
 outputs:
   cache-dir:
     description: "The directory where the cache was stored"
-    value: ${{ steps.fill-compilation-dir.outputs.compdir }}
+    value: ${{ steps.output-compilation-dir.outputs.compdir }}
 
 runs:
   using: composite
@@ -42,7 +42,15 @@ runs:
         restore-keys: | # restore the latest cache if the exact cache is unavailable, to speed up compilation.
           codeql-compile-${{ inputs.key }}-${{ github.ref_name }}-
           codeql-compile-${{ inputs.key }}-main-
+    - name: Output-compilationdir
+      id: output-compilation-dir
+      shell: bash
+      run: |
+        echo "compdir=${COMBINED_CACHE_DIR}" >> $GITHUB_OUTPUT
+      env:
+        COMBINED_CACHE_DIR: ${{ runner.temp }}/compilation-dir
     - name: Fill compilation cache directory
+      id: fill-compilation-dir
       uses: actions/github-script@v6
       env: 
         COMBINED_CACHE_DIR: ${{ runner.temp }}/compilation-dir


### PR DESCRIPTION
When I inlined the JavaScript code into `cache-query-compilation` I forgot to port the "output" part of the code.  
So the compilation-cache-dir was never set, and thus the cache was broken.  

Unrelated:  
The cache directory just moved in the latest nightly, which means our use of the compilation cache would have broken anyway.  

This PR should fix both.  