### PR TITLE
C#: Generalise modifier extraction from symbols.

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp/SymbolExtensions.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/SymbolExtensions.cs
@@ -77,12 +77,8 @@ namespace Semmle.Extraction.CSharp
         /// <summary>
         /// Gets the source-level modifiers belonging to this symbol, if any.
         /// </summary>
-        public static IEnumerable<string> GetSourceLevelModifiers(this ISymbol symbol)
-        {
-            var methodModifiers = symbol.GetModifiers<Microsoft.CodeAnalysis.CSharp.Syntax.BaseMethodDeclarationSyntax>(md => md.Modifiers);
-            var typeModifiers = symbol.GetModifiers<Microsoft.CodeAnalysis.CSharp.Syntax.TypeDeclarationSyntax>(cd => cd.Modifiers);
-            return methodModifiers.Concat(typeModifiers).Select(m => m.Text);
-        }
+        public static IEnumerable<string> GetSourceLevelModifiers(this ISymbol symbol) =>
+            symbol.GetModifiers<Microsoft.CodeAnalysis.CSharp.Syntax.MemberDeclarationSyntax>(md => md.Modifiers).Select(m => m.Text);
 
         /// <summary>
         /// Holds if the ID generated for `dependant` will contain a reference to

--- a/csharp/ql/lib/change-notes/2023-02-22-modifierextraction.md
+++ b/csharp/ql/lib/change-notes/2023-02-22-modifierextraction.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The extraction of member modifiers has been generalised, which could lead to the extraction of more modifiers.


### PR DESCRIPTION
It looks like we are missing out on the extraction of some modifiers. More specifically, we were missing the extraction of modifiers for enums and delegates.
They could have been added as special cases, but instead we could consider to just extract all member modifiers.