### PR TITLE
C#/Java: Re-factor the `isSupported` predicate.

### DIFF
--- a/csharp/ql/src/Telemetry/ExternalApi.qll
+++ b/csharp/ql/src/Telemetry/ExternalApi.qll
@@ -109,7 +109,10 @@ class ExternalApi extends DotNet::Callable {
   pragma[nomagic]
   predicate isNeutral() { this instanceof FlowSummaryImpl::Public::NeutralCallable }
 
-  /** Holds if this API is supported by existing CodeQL libraries, that is, it is either a recognized source or sink or has a flow summary. */
+  /**
+   * Holds if this API is supported by existing CodeQL libraries, that is, it is either a
+   * recognized source, sink or neutral or it has a flow summary.
+   */
   predicate isSupported() {
     this.hasSummary() or this.isSource() or this.isSink() or this.isNeutral()
   }

--- a/csharp/ql/src/Telemetry/ExternalApi.qll
+++ b/csharp/ql/src/Telemetry/ExternalApi.qll
@@ -8,6 +8,7 @@ private import semmle.code.csharp.dataflow.FlowSummary
 private import semmle.code.csharp.dataflow.internal.DataFlowImplCommon as DataFlowImplCommon
 private import semmle.code.csharp.dataflow.internal.DataFlowPrivate
 private import semmle.code.csharp.dataflow.internal.DataFlowDispatch as DataFlowDispatch
+private import semmle.code.csharp.dataflow.internal.FlowSummaryImpl as FlowSummaryImpl
 private import semmle.code.csharp.dataflow.internal.TaintTrackingPrivate
 private import semmle.code.csharp.security.dataflow.flowsources.Remote
 
@@ -104,8 +105,14 @@ class ExternalApi extends DotNet::Callable {
   pragma[nomagic]
   predicate isSink() { sinkNode(this.getAnInput(), _) }
 
+  /** Holds if this API is a known neutral. */
+  pragma[nomagic]
+  predicate isNeutral() { this instanceof FlowSummaryImpl::Public::NeutralCallable }
+
   /** Holds if this API is supported by existing CodeQL libraries, that is, it is either a recognized source or sink or has a flow summary. */
-  predicate isSupported() { this.hasSummary() or this.isSource() or this.isSink() }
+  predicate isSupported() {
+    this.hasSummary() or this.isSource() or this.isSink() or this.isNeutral()
+  }
 }
 
 /**

--- a/csharp/ql/src/Telemetry/SupportedExternalApis.ql
+++ b/csharp/ql/src/Telemetry/SupportedExternalApis.ql
@@ -8,13 +8,9 @@
 
 private import csharp
 private import semmle.code.csharp.dispatch.Dispatch
-private import semmle.code.csharp.dataflow.internal.FlowSummaryImpl as FlowSummaryImpl
 private import ExternalApi
 
-private predicate relevant(ExternalApi api) {
-  api.isSupported() or
-  api instanceof FlowSummaryImpl::Public::NeutralCallable
-}
+private predicate relevant(ExternalApi api) { api.isSupported() }
 
 from string info, int usages
 where Results<relevant/1>::restrict(info, usages)

--- a/csharp/ql/src/Telemetry/UnsupportedExternalAPIs.ql
+++ b/csharp/ql/src/Telemetry/UnsupportedExternalAPIs.ql
@@ -7,14 +7,9 @@
  */
 
 private import csharp
-private import semmle.code.csharp.dispatch.Dispatch
-private import semmle.code.csharp.dataflow.internal.FlowSummaryImpl as FlowSummaryImpl
 private import ExternalApi
 
-private predicate relevant(ExternalApi api) {
-  not api.isSupported() and
-  not api instanceof FlowSummaryImpl::Public::NeutralCallable
-}
+private predicate relevant(ExternalApi api) { not api.isSupported() }
 
 from string info, int usages
 where Results<relevant/1>::restrict(info, usages)

--- a/csharp/ql/src/meta/frameworks/UnsupportedExternalAPIs.ql
+++ b/csharp/ql/src/meta/frameworks/UnsupportedExternalAPIs.ql
@@ -9,13 +9,10 @@
  */
 
 private import csharp
-private import semmle.code.csharp.dispatch.Dispatch
-private import semmle.code.csharp.dataflow.internal.FlowSummaryImpl as FlowSummaryImpl
 private import Telemetry.ExternalApi
 
 from Call c, ExternalApi api
 where
   c.getTarget().getUnboundDeclaration() = api and
-  not api.isSupported() and
-  not api instanceof FlowSummaryImpl::Public::NeutralCallable
+  not api.isSupported()
 select c, "Call to unsupported external API $@.", api, api.toString()

--- a/java/ql/src/Telemetry/ExternalApi.qll
+++ b/java/ql/src/Telemetry/ExternalApi.qll
@@ -6,6 +6,7 @@ private import semmle.code.java.dataflow.ExternalFlow
 private import semmle.code.java.dataflow.FlowSources
 private import semmle.code.java.dataflow.FlowSummary
 private import semmle.code.java.dataflow.internal.DataFlowPrivate
+private import semmle.code.java.dataflow.internal.FlowSummaryImpl as FlowSummaryImpl
 private import semmle.code.java.dataflow.TaintTracking
 
 pragma[nomagic]
@@ -91,8 +92,14 @@ class ExternalApi extends Callable {
   pragma[nomagic]
   predicate isSink() { sinkNode(this.getAnInput(), _) }
 
+  /** Holds if this API is a known neutral. */
+  pragma[nomagic]
+  predicate isNeutral() { this = any(FlowSummaryImpl::Public::NeutralCallable nsc).asCallable() }
+
   /** Holds if this API is supported by existing CodeQL libraries, that is, it is either a recognized source or sink or has a flow summary. */
-  predicate isSupported() { this.hasSummary() or this.isSource() or this.isSink() }
+  predicate isSupported() {
+    this.hasSummary() or this.isSource() or this.isSink() or this.isNeutral()
+  }
 }
 
 /** DEPRECATED: Alias for ExternalApi */

--- a/java/ql/src/Telemetry/ExternalApi.qll
+++ b/java/ql/src/Telemetry/ExternalApi.qll
@@ -96,7 +96,10 @@ class ExternalApi extends Callable {
   pragma[nomagic]
   predicate isNeutral() { this = any(FlowSummaryImpl::Public::NeutralCallable nsc).asCallable() }
 
-  /** Holds if this API is supported by existing CodeQL libraries, that is, it is either a recognized source or sink or has a flow summary. */
+  /**
+   * Holds if this API is supported by existing CodeQL libraries, that is, it is either a
+   * recognized source, sink or neutral or it has a flow summary.
+   */
   predicate isSupported() {
     this.hasSummary() or this.isSource() or this.isSink() or this.isNeutral()
   }

--- a/java/ql/src/Telemetry/SupportedExternalApis.ql
+++ b/java/ql/src/Telemetry/SupportedExternalApis.ql
@@ -7,13 +7,9 @@
  */
 
 import java
-import semmle.code.java.dataflow.internal.FlowSummaryImpl as FlowSummaryImpl
 import ExternalApi
 
-private predicate relevant(ExternalApi api) {
-  api.isSupported() or
-  api = any(FlowSummaryImpl::Public::NeutralCallable nsc).asCallable()
-}
+private predicate relevant(ExternalApi api) { api.isSupported() }
 
 from string apiName, int usages
 where Results<relevant/1>::restrict(apiName, usages)

--- a/java/ql/src/Telemetry/UnsupportedExternalAPIs.ql
+++ b/java/ql/src/Telemetry/UnsupportedExternalAPIs.ql
@@ -7,13 +7,9 @@
  */
 
 import java
-import semmle.code.java.dataflow.internal.FlowSummaryImpl as FlowSummaryImpl
 import ExternalApi
 
-private predicate relevant(ExternalApi api) {
-  not api.isSupported() and
-  not api = any(FlowSummaryImpl::Public::NeutralCallable nsc).asCallable()
-}
+private predicate relevant(ExternalApi api) { not api.isSupported() }
 
 from string apiName, int usages
 where Results<relevant/1>::restrict(apiName, usages)


### PR DESCRIPTION
It turns out that all uses of `isSupported` also includes logic to cater for neutrals. In this PR we put this into the `isSupported` predicate itself.
Thank you @starcke!