### PR TITLE
Swift: Add unary +

### DIFF
--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPrivate.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPrivate.qll
@@ -153,6 +153,9 @@ private module Cached {
     or
     nodeFrom.asExpr() = nodeTo.asExpr().(OptionalEvaluationExpr).getSubExpr()
     or
+    // flow through unary `+` (which does nothing)
+    nodeFrom.asExpr() = nodeTo.asExpr().(UnaryPlusExpr).getOperand()
+    or
     // flow through nil-coalescing operator `??`
     exists(BinaryExpr nco |
       nco.getOperator().(FreeFunctionDecl).getName() = "??(_:_:)" and

--- a/swift/ql/lib/codeql/swift/elements/expr/ArithmeticOperation.qll
+++ b/swift/ql/lib/codeql/swift/elements/expr/ArithmeticOperation.qll
@@ -97,7 +97,12 @@ class RemExpr extends BinaryExpr {
  * -a
  * ```
  */
-class UnaryArithmeticOperation extends PrefixUnaryExpr instanceof UnaryMinusExpr { }
+class UnaryArithmeticOperation extends PrefixUnaryExpr {
+  UnaryArithmeticOperation() {
+    this instanceof UnaryMinusExpr or
+    this instanceof UnaryPlusExpr
+  }
+}
 
 /**
  * A unary minus expression.
@@ -107,4 +112,14 @@ class UnaryArithmeticOperation extends PrefixUnaryExpr instanceof UnaryMinusExpr
  */
 class UnaryMinusExpr extends PrefixUnaryExpr {
   UnaryMinusExpr() { this.getStaticTarget().getName() = "-(_:)" }
+}
+
+/**
+ * A unary plus expression.
+ * ```
+ * +a
+ * ```
+ */
+class UnaryPlusExpr extends PrefixUnaryExpr {
+  UnaryPlusExpr() { this.getStaticTarget().getName() = "+(_:)" }
 }

--- a/swift/ql/test/library-tests/dataflow/dataflow/DataFlow.expected
+++ b/swift/ql/test/library-tests/dataflow/dataflow/DataFlow.expected
@@ -324,6 +324,7 @@ nodes
 | test.swift:472:20:472:20 | cx [x] :  | semmle.label | cx [x] :  |
 | test.swift:472:20:472:23 | .x :  | semmle.label | .x :  |
 | test.swift:473:15:473:15 | z1 | semmle.label | z1 |
+| test.swift:480:14:480:21 | call to source() | semmle.label | call to source() |
 subpaths
 | test.swift:75:21:75:22 | &... :  | test.swift:65:16:65:28 | arg1 :  | test.swift:65:1:70:1 | arg2[return] :  | test.swift:75:31:75:32 | [post] &... :  |
 | test.swift:114:19:114:19 | arg :  | test.swift:109:9:109:14 | arg :  | test.swift:110:12:110:12 | arg :  | test.swift:114:12:114:22 | call to ... :  |
@@ -408,3 +409,4 @@ subpaths
 | test.swift:361:15:361:18 | .1 | test.swift:351:31:351:38 | call to source() :  | test.swift:361:15:361:18 | .1 | result |
 | test.swift:442:19:442:19 | a | test.swift:259:12:259:19 | call to source() :  | test.swift:442:19:442:19 | a | result |
 | test.swift:473:15:473:15 | z1 | test.swift:259:12:259:19 | call to source() :  | test.swift:473:15:473:15 | z1 | result |
+| test.swift:480:14:480:21 | call to source() | test.swift:480:14:480:21 | call to source() | test.swift:480:14:480:21 | call to source() | result |

--- a/swift/ql/test/library-tests/dataflow/dataflow/DataFlow.expected
+++ b/swift/ql/test/library-tests/dataflow/dataflow/DataFlow.expected
@@ -154,6 +154,7 @@ edges
 | test.swift:472:20:472:20 | cx [x] :  | test.swift:462:9:462:9 | self [x] :  |
 | test.swift:472:20:472:20 | cx [x] :  | test.swift:472:20:472:23 | .x :  |
 | test.swift:472:20:472:23 | .x :  | test.swift:473:15:473:15 | z1 |
+| test.swift:479:14:479:21 | call to source() :  | test.swift:479:13:479:21 | call to +(_:) |
 nodes
 | file://:0:0:0:0 | .a [x] :  | semmle.label | .a [x] :  |
 | file://:0:0:0:0 | .x :  | semmle.label | .x :  |
@@ -324,6 +325,8 @@ nodes
 | test.swift:472:20:472:20 | cx [x] :  | semmle.label | cx [x] :  |
 | test.swift:472:20:472:23 | .x :  | semmle.label | .x :  |
 | test.swift:473:15:473:15 | z1 | semmle.label | z1 |
+| test.swift:479:13:479:21 | call to +(_:) | semmle.label | call to +(_:) |
+| test.swift:479:14:479:21 | call to source() :  | semmle.label | call to source() :  |
 | test.swift:480:14:480:21 | call to source() | semmle.label | call to source() |
 subpaths
 | test.swift:75:21:75:22 | &... :  | test.swift:65:16:65:28 | arg1 :  | test.swift:65:1:70:1 | arg2[return] :  | test.swift:75:31:75:32 | [post] &... :  |
@@ -409,4 +412,5 @@ subpaths
 | test.swift:361:15:361:18 | .1 | test.swift:351:31:351:38 | call to source() :  | test.swift:361:15:361:18 | .1 | result |
 | test.swift:442:19:442:19 | a | test.swift:259:12:259:19 | call to source() :  | test.swift:442:19:442:19 | a | result |
 | test.swift:473:15:473:15 | z1 | test.swift:259:12:259:19 | call to source() :  | test.swift:473:15:473:15 | z1 | result |
+| test.swift:479:13:479:21 | call to +(_:) | test.swift:479:14:479:21 | call to source() :  | test.swift:479:13:479:21 | call to +(_:) | result |
 | test.swift:480:14:480:21 | call to source() | test.swift:480:14:480:21 | call to source() | test.swift:480:14:480:21 | call to source() | result |

--- a/swift/ql/test/library-tests/dataflow/dataflow/LocalFlow.expected
+++ b/swift/ql/test/library-tests/dataflow/dataflow/LocalFlow.expected
@@ -390,3 +390,4 @@
 | test.swift:472:20:472:23 | .x | test.swift:472:11:472:15 | SSA def(z1) |
 | test.swift:474:11:474:15 | SSA def(z2) | test.swift:475:15:475:15 | z2 |
 | test.swift:474:20:474:23 | .x | test.swift:474:11:474:15 | SSA def(z2) |
+| test.swift:479:14:479:21 | call to source() | test.swift:479:13:479:21 | call to +(_:) |

--- a/swift/ql/test/library-tests/dataflow/dataflow/test.swift
+++ b/swift/ql/test/library-tests/dataflow/dataflow/test.swift
@@ -476,6 +476,6 @@ func testOptionalPropertyAccess(y: Int?) {
 }
 
 func testIdentityArithmetic() {
-  sink(arg: +source()) // $ MISSING: flow=479
+  sink(arg: +source()) // $ flow=479
   sink(arg: (source())) // $ flow=480
 }

--- a/swift/ql/test/library-tests/dataflow/dataflow/test.swift
+++ b/swift/ql/test/library-tests/dataflow/dataflow/test.swift
@@ -474,3 +474,8 @@ func testOptionalPropertyAccess(y: Int?) {
     guard let z2 = cy.x else { return }
     sink(arg: z2)
 }
+
+func testIdentityArithmetic() {
+  sink(arg: +source()) // $ MISSING: flow=479
+  sink(arg: (source())) // $ flow=480
+}

--- a/swift/ql/test/library-tests/elements/expr/arithmeticoperation/arithmeticoperation.expected
+++ b/swift/ql/test/library-tests/elements/expr/arithmeticoperation/arithmeticoperation.expected
@@ -4,3 +4,4 @@
 | arithmeticoperation.swift:9:6:9:10 | ... ./(_:_:) ... | BinaryArithmeticOperation, DivExpr |
 | arithmeticoperation.swift:10:6:10:10 | ... .%(_:_:) ... | BinaryArithmeticOperation, RemExpr |
 | arithmeticoperation.swift:11:6:11:7 | call to -(_:) | UnaryArithmeticOperation, UnaryMinusExpr |
+| arithmeticoperation.swift:12:6:12:7 | call to +(_:) | UnaryArithmeticOperation, UnaryPlusExpr |

--- a/swift/ql/test/library-tests/elements/expr/arithmeticoperation/arithmeticoperation.ql
+++ b/swift/ql/test/library-tests/elements/expr/arithmeticoperation/arithmeticoperation.ql
@@ -16,6 +16,8 @@ string describe(ArithmeticOperation e) {
   e instanceof UnaryArithmeticOperation and result = "UnaryArithmeticOperation"
   or
   e instanceof UnaryMinusExpr and result = "UnaryMinusExpr"
+  or
+  e instanceof UnaryPlusExpr and result = "UnaryPlusExpr"
 }
 
 from ArithmeticOperation e

--- a/swift/ql/test/library-tests/elements/expr/arithmeticoperation/arithmeticoperation.swift
+++ b/swift/ql/test/library-tests/elements/expr/arithmeticoperation/arithmeticoperation.swift
@@ -9,4 +9,5 @@ func test(c: Bool, x: Int, y: Int, z: Int) {
 	v = 3 / 4;
 	v = x % y;
 	v = -x;
+	v = +x;
 }


### PR DESCRIPTION
Add tests, a class for, and taint through, unary `+`.  Unary `+` is a Swift operator that takes a number and returns ... that number.