### PR TITLE
Make "Detecting a potential buffer overflow" example more uniform

### DIFF
--- a/docs/codeql/codeql-language-guides/detecting-a-potential-buffer-overflow.rst
+++ b/docs/codeql/codeql-language-guides/detecting-a-potential-buffer-overflow.rst
@@ -204,6 +204,7 @@ The completed query will now identify cases where the result of ``strlen`` is st
 .. code-block:: ql
 
    import cpp
+   import semmle.code.cpp.controlflow.SSA
 
    class MallocCall extends FunctionCall
    {


### PR DESCRIPTION
All queries that use SSA import `semmle.code.cpp.controlflow.SSA` explicitly, except for the last one. Also import the library there. Note that this is not strictly necessary, as the library is transitively imported via `import cpp`.