### PR TITLE
Add classes and predicates to StructuredLogs

### DIFF
--- a/ql/ql/src/codeql_ql/StructuredLogs.qll
+++ b/ql/ql/src/codeql_ql/StructuredLogs.qll
@@ -269,6 +269,31 @@ module KindPredicatesLog {
       then result = this.getPredicateName()
       else result = "<Summary event>"
     }
+
+    RA getRA() { result = this.getObject("ra") }
+  }
+
+  class PipeLine extends Array {
+    RA ra;
+    string raReference;
+
+    RA getRA() { result = ra }
+
+    string getRAReference() { result = raReference }
+
+    PipeLine() { this = ra.getArray(raReference) }
+
+    string getLineOfRA(int n) { result = this.getString(n) }
+  }
+
+  class RA extends Object {
+    SummaryEvent evt;
+
+    SummaryEvent getEvent() { result = evt }
+
+    RA() { evt.getObject("ra") = this }
+
+    PipeLine getPipeLine(string name) { result = this.getArray(name) }
   }
 
   class SentinelEmpty extends SummaryEvent {
@@ -283,6 +308,17 @@ module KindPredicatesLog {
     PipeLineRuns getArray() { result = runs }
 
     string getRAReference() { result = this.getString("raReference") }
+
+    PipeLine getPipeLine() {
+      exists(SummaryEvent evt | runs.getEvent() = evt |
+        result = evt.getRA().getPipeLine(pragma[only_bind_into](this.getRAReference()))
+      )
+    }
+
+    float getCount(int i, string raLine) {
+      result = this.getCount(i) and
+      raLine = this.getPipeLine().getLineOfRA(pragma[only_bind_into](i))
+    }
 
     float getCount(int i) { result = getRanked(this.getArray("counts"), i) }
 

--- a/ql/ql/src/codeql_ql/StructuredLogs.qll
+++ b/ql/ql/src/codeql_ql/StructuredLogs.qll
@@ -68,6 +68,8 @@ class Array extends JSON::Array {
   float getFloat(int i) { result = this.getChild(i).(JSON::Number).getValue().toFloat() }
 
   Array getArray(int i) { result = this.getChild(i) }
+
+  int getLength() { result = count(this.getChild(_)) }
 }
 
 /**

--- a/ql/ql/src/experimental/queries/PredicateSummaries.ql
+++ b/ql/ql/src/experimental/queries/PredicateSummaries.ql
@@ -1,0 +1,18 @@
+/**
+ * Finds evaluations with very large tuple counts somewhere
+ */
+
+import ql
+import codeql_ql.StructuredLogs
+
+float maxTupleCount(KindPredicatesLog::SummaryEvent evt) {
+  result = max(KindPredicatesLog::PipeLineRuns r | r.getEvent() = evt | r.getRun(_).getCount(_))
+}
+
+int maxPipeLineLength(KindPredicatesLog::SummaryEvent evt) {
+  result = max(evt.getRA().getPipeLine(_).getLength())
+}
+
+from KindPredicatesLog::SummaryEvent evt
+select evt, evt.getResultSize(), evt.getMillis() as ms, maxTupleCount(evt) as mc, evt.getMillis(),
+  maxPipeLineLength(evt) as len order by mc desc

--- a/ql/ql/src/experimental/queries/PredicateSummaries.ql
+++ b/ql/ql/src/experimental/queries/PredicateSummaries.ql
@@ -14,5 +14,5 @@ int maxPipeLineLength(KindPredicatesLog::SummaryEvent evt) {
 }
 
 from KindPredicatesLog::SummaryEvent evt
-select evt, evt.getResultSize(), evt.getMillis() as ms, maxTupleCount(evt) as mc, evt.getMillis(),
+select evt, evt.getResultSize(), evt.getMillis() as ms, maxTupleCount(evt) as mc,
   maxPipeLineLength(evt) as len order by mc desc

--- a/ql/ql/src/queries/performance/LargeJoinOrder.ql
+++ b/ql/ql/src/queries/performance/LargeJoinOrder.ql
@@ -35,7 +35,7 @@ predicate extractInformation(
     maxTupleCount = max(run.getCount(_)) and
     tuples = run.getCounts() and
     duplicationPercentages = run.getDuplicationPercentage() and
-    ra = simple.getRA()
+    ra = simple.getPipeLine()
   )
 }
 


### PR DESCRIPTION
Adding a few bits & pieces. The interesting thing is that `PipeLine.getCount(int i, string ra)` also gives you the line of text from the corresponding RA in case you want it.