### PR TITLE
C# 11: Support for explicit interface implementations of operators.

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Conversion.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Conversion.cs
@@ -10,6 +10,8 @@ namespace Semmle.Extraction.CSharp.Entities
         private Conversion(Context cx, IMethodSymbol init)
             : base(cx, init) { }
 
+        protected override MethodKind ExplicitlyImplementsKind => MethodKind.Conversion;
+
         public static new Conversion Create(Context cx, IMethodSymbol symbol) =>
             ConversionFactory.Instance.CreateEntityFromSymbol(cx, symbol);
 

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Method.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Method.cs
@@ -83,10 +83,12 @@ namespace Semmle.Extraction.CSharp.Entities
             }
         }
 
+        protected virtual MethodKind ExplicitlyImplementsKind => MethodKind.Ordinary;
+
         public void Overrides(TextWriter trapFile)
         {
             foreach (var explicitInterface in Symbol.ExplicitInterfaceImplementations
-                .Where(sym => sym.MethodKind == MethodKind.Ordinary)
+                .Where(sym => sym.MethodKind == ExplicitlyImplementsKind)
                 .Select(impl => Type.Create(Context, impl.ContainingType)))
             {
                 trapFile.explicitly_implements(this, explicitInterface.TypeRef);

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/UserOperator.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/UserOperator.cs
@@ -11,6 +11,8 @@ namespace Semmle.Extraction.CSharp.Entities
         protected UserOperator(Context cx, IMethodSymbol init)
             : base(cx, init) { }
 
+        protected override MethodKind ExplicitlyImplementsKind => MethodKind.UserDefinedOperator;
+
         public override void Populate(TextWriter trapFile)
         {
             PopulateMethod(trapFile);
@@ -37,6 +39,7 @@ namespace Semmle.Extraction.CSharp.Entities
             }
 
             ContainingType.PopulateGenerics();
+            Overrides(trapFile);
         }
 
         public override bool NeedsPopulation => Context.Defines(Symbol) || IsImplicitOperator(out _);

--- a/csharp/ql/lib/change-notes/2023-02-27-explicitinterfacemember.md
+++ b/csharp/ql/lib/change-notes/2023-02-27-explicitinterfacemember.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* C# 11: Support for explicit interface member implementation of operators.

--- a/csharp/ql/lib/semmle/code/csharp/Callable.qll
+++ b/csharp/ql/lib/semmle/code/csharp/Callable.qll
@@ -434,7 +434,7 @@ class Destructor extends DotNet::Destructor, Callable, Member, Attributable, @de
  * Either a unary operator (`UnaryOperator`), a binary operator
  * (`BinaryOperator`), or a conversion operator (`ConversionOperator`).
  */
-class Operator extends Callable, Member, Attributable, @operator {
+class Operator extends Callable, Member, Attributable, Overridable, @operator {
   /**
    * DEPRECATED: use `getFunctionName()` instead.
    *

--- a/csharp/ql/test/library-tests/csharp11/PrintAst.expected
+++ b/csharp/ql/test/library-tests/csharp11/PrintAst.expected
@@ -1051,14 +1051,14 @@ StaticInterfaceMembers.cs:
 #    5|       0: [Parameter] other
 #    5|         -1: [TypeMention] T
 #    5|     4: [ParameterAccess] access to parameter other
-#    7|   6: [Method] Add
+#    7|   6: [AddOperator] +
 #    7|     -1: [TypeMention] T
 #-----|     2: (Parameters)
 #    7|       0: [Parameter] left
 #    7|         -1: [TypeMention] T
 #    7|       1: [Parameter] right
 #    7|         -1: [TypeMention] T
-#    9|   7: [Method] Subtract
+#    9|   7: [SubOperator] -
 #    9|     -1: [TypeMention] T
 #-----|     2: (Parameters)
 #    9|       0: [Parameter] left
@@ -1066,121 +1066,265 @@ StaticInterfaceMembers.cs:
 #    9|       1: [Parameter] right
 #    9|         -1: [TypeMention] T
 #    9|     4: [ParameterAccess] access to parameter left
-#   11|   8: [Method] Zero
-#   11|     -1: [TypeMention] T
-#   11|     4: [DefaultValueExpr] default(...)
-#   11|       0: [TypeAccess] access to type T
-#   11|         0: [TypeMention] T
-#   14| [Class] Complex
+#   11|   8: [ExplicitConversionOperator] explicit conversion
+#   11|     -1: [TypeMention] int
+#-----|     2: (Parameters)
+#   11|       0: [Parameter] n
+#   11|         -1: [TypeMention] T
+#   13|   9: [ExplicitConversionOperator] explicit conversion
+#   13|     -1: [TypeMention] short
+#-----|     2: (Parameters)
+#   13|       0: [Parameter] n
+#   13|         -1: [TypeMention] T
+#   15|   10: [Method] Inc
+#   15|     -1: [TypeMention] T
+#-----|     2: (Parameters)
+#   15|       0: [Parameter] other
+#   15|         -1: [TypeMention] T
+#   17|   11: [Method] Dec
+#   17|     -1: [TypeMention] T
+#-----|     2: (Parameters)
+#   17|       0: [Parameter] other
+#   17|         -1: [TypeMention] T
+#   17|     4: [ParameterAccess] access to parameter other
+#   19|   12: [Method] Add
+#   19|     -1: [TypeMention] T
+#-----|     2: (Parameters)
+#   19|       0: [Parameter] left
+#   19|         -1: [TypeMention] T
+#   19|       1: [Parameter] right
+#   19|         -1: [TypeMention] T
+#   21|   13: [Method] Subtract
+#   21|     -1: [TypeMention] T
+#-----|     2: (Parameters)
+#   21|       0: [Parameter] left
+#   21|         -1: [TypeMention] T
+#   21|       1: [Parameter] right
+#   21|         -1: [TypeMention] T
+#   21|     4: [ParameterAccess] access to parameter left
+#   23|   14: [Method] Zero
+#   23|     -1: [TypeMention] T
+#   23|     4: [DefaultValueExpr] default(...)
+#   23|       0: [TypeAccess] access to type T
+#   23|         0: [TypeMention] T
+#   26| [Class] Complex
 #-----|   3: (Base types)
-#   16|   4: [Property] Real
-#   16|     -1: [TypeMention] double
-#   16|     2: [AssignExpr] ... = ...
-#   16|       0: [PropertyCall] access to property Real
-#   16|       1: [DoubleLiteral] 0
-#   16|     3: [Getter] get_Real
-#   16|     4: [Setter] set_Real
+#   28|   4: [Property] Real
+#   28|     -1: [TypeMention] double
+#   28|     2: [AssignExpr] ... = ...
+#   28|       0: [PropertyCall] access to property Real
+#   28|       1: [DoubleLiteral] 0
+#   28|     3: [Getter] get_Real
+#   28|     4: [Setter] set_Real
 #-----|       2: (Parameters)
-#   16|         0: [Parameter] value
-#   17|   5: [Property] Imaginary
-#   17|     -1: [TypeMention] double
-#   17|     2: [AssignExpr] ... = ...
-#   17|       0: [PropertyCall] access to property Imaginary
-#   17|       1: [DoubleLiteral] 0
-#   17|     3: [Getter] get_Imaginary
-#   17|     4: [Setter] set_Imaginary
+#   28|         0: [Parameter] value
+#   29|   5: [Property] Imaginary
+#   29|     -1: [TypeMention] double
+#   29|     2: [AssignExpr] ... = ...
+#   29|       0: [PropertyCall] access to property Imaginary
+#   29|       1: [DoubleLiteral] 0
+#   29|     3: [Getter] get_Imaginary
+#   29|     4: [Setter] set_Imaginary
 #-----|       2: (Parameters)
-#   17|         0: [Parameter] value
-#   19|   6: [InstanceConstructor] Complex
-#   19|     4: [BlockStmt] {...}
-#   21|   7: [Method] Zero
-#   21|     -1: [TypeMention] Complex
-#   21|     4: [ObjectCreation] object creation of type Complex
-#   21|       0: [TypeMention] Complex
-#   23|   8: [IncrementOperator] ++
-#   23|     -1: [TypeMention] Complex
-#-----|     2: (Parameters)
-#   23|       0: [Parameter] other
-#   23|         -1: [TypeMention] Complex
-#   24|     4: [ObjectCreation] object creation of type Complex
-#   24|       -2: [TypeMention] Complex
-#   24|       -1: [ObjectInitializer] { ..., ... }
-#   24|         0: [MemberInitializer] ... = ...
-#   24|           0: [PropertyCall] access to property Real
-#   24|           1: [AddExpr] ... + ...
-#   24|             0: [PropertyCall] access to property Real
-#   24|               -1: [ParameterAccess] access to parameter other
-#   24|             1: [DoubleLiteral] 1
-#   24|         1: [MemberInitializer] ... = ...
-#   24|           0: [PropertyCall] access to property Imaginary
-#   24|           1: [PropertyCall] access to property Imaginary
-#   24|             -1: [ParameterAccess] access to parameter other
-#   26|   9: [DecrementOperator] --
-#   26|     -1: [TypeMention] Complex
-#-----|     2: (Parameters)
-#   26|       0: [Parameter] other
-#   26|         -1: [TypeMention] Complex
-#   27|     4: [ObjectCreation] object creation of type Complex
-#   27|       -2: [TypeMention] Complex
-#   27|       -1: [ObjectInitializer] { ..., ... }
-#   27|         0: [MemberInitializer] ... = ...
-#   27|           0: [PropertyCall] access to property Real
-#   27|           1: [SubExpr] ... - ...
-#   27|             0: [PropertyCall] access to property Real
-#   27|               -1: [ParameterAccess] access to parameter other
-#   27|             1: [DoubleLiteral] 1
-#   27|         1: [MemberInitializer] ... = ...
-#   27|           0: [PropertyCall] access to property Imaginary
-#   27|           1: [PropertyCall] access to property Imaginary
-#   27|             -1: [ParameterAccess] access to parameter other
-#   29|   10: [Method] Add
-#   29|     -1: [TypeMention] Complex
-#-----|     2: (Parameters)
-#   29|       0: [Parameter] left
-#   29|         -1: [TypeMention] Complex
-#   29|       1: [Parameter] right
-#   29|         -1: [TypeMention] Complex
-#   30|     4: [ObjectCreation] object creation of type Complex
-#   30|       -2: [TypeMention] Complex
-#   30|       -1: [ObjectInitializer] { ..., ... }
-#   30|         0: [MemberInitializer] ... = ...
-#   30|           0: [PropertyCall] access to property Real
-#   30|           1: [AddExpr] ... + ...
-#   30|             0: [PropertyCall] access to property Real
-#   30|               -1: [ParameterAccess] access to parameter left
-#   30|             1: [PropertyCall] access to property Real
-#   30|               -1: [ParameterAccess] access to parameter right
-#   30|         1: [MemberInitializer] ... = ...
-#   30|           0: [PropertyCall] access to property Imaginary
-#   30|           1: [AddExpr] ... + ...
-#   30|             0: [PropertyCall] access to property Imaginary
-#   30|               -1: [ParameterAccess] access to parameter left
-#   30|             1: [PropertyCall] access to property Imaginary
-#   30|               -1: [ParameterAccess] access to parameter right
-#   32|   11: [Method] Subtract
-#   32|     -1: [TypeMention] Complex
-#-----|     2: (Parameters)
-#   32|       0: [Parameter] left
-#   32|         -1: [TypeMention] Complex
-#   32|       1: [Parameter] right
-#   32|         -1: [TypeMention] Complex
+#   29|         0: [Parameter] value
+#   31|   6: [InstanceConstructor] Complex
+#   31|     4: [BlockStmt] {...}
+#   33|   7: [Method] Zero
+#   33|     -1: [TypeMention] Complex
 #   33|     4: [ObjectCreation] object creation of type Complex
-#   33|       -2: [TypeMention] Complex
-#   33|       -1: [ObjectInitializer] { ..., ... }
-#   33|         0: [MemberInitializer] ... = ...
-#   33|           0: [PropertyCall] access to property Real
-#   33|           1: [SubExpr] ... - ...
-#   33|             0: [PropertyCall] access to property Real
-#   33|               -1: [ParameterAccess] access to parameter left
-#   33|             1: [PropertyCall] access to property Real
-#   33|               -1: [ParameterAccess] access to parameter right
-#   33|         1: [MemberInitializer] ... = ...
-#   33|           0: [PropertyCall] access to property Imaginary
-#   33|           1: [SubExpr] ... - ...
-#   33|             0: [PropertyCall] access to property Imaginary
-#   33|               -1: [ParameterAccess] access to parameter left
-#   33|             1: [PropertyCall] access to property Imaginary
-#   33|               -1: [ParameterAccess] access to parameter right
+#   33|       0: [TypeMention] Complex
+#   35|   8: [IncrementOperator] ++
+#   35|     -1: [TypeMention] Complex
+#-----|     2: (Parameters)
+#   35|       0: [Parameter] other
+#   35|         -1: [TypeMention] Complex
+#   36|     4: [ObjectCreation] object creation of type Complex
+#   36|       -2: [TypeMention] Complex
+#   36|       -1: [ObjectInitializer] { ..., ... }
+#   36|         0: [MemberInitializer] ... = ...
+#   36|           0: [PropertyCall] access to property Real
+#   36|           1: [AddExpr] ... + ...
+#   36|             0: [PropertyCall] access to property Real
+#   36|               -1: [ParameterAccess] access to parameter other
+#   36|             1: [DoubleLiteral] 1
+#   36|         1: [MemberInitializer] ... = ...
+#   36|           0: [PropertyCall] access to property Imaginary
+#   36|           1: [PropertyCall] access to property Imaginary
+#   36|             -1: [ParameterAccess] access to parameter other
+#   38|   9: [DecrementOperator] --
+#   38|     -1: [TypeMention] Complex
+#-----|     2: (Parameters)
+#   38|       0: [Parameter] other
+#   38|         -1: [TypeMention] Complex
+#   39|     4: [ObjectCreation] object creation of type Complex
+#   39|       -2: [TypeMention] Complex
+#   39|       -1: [ObjectInitializer] { ..., ... }
+#   39|         0: [MemberInitializer] ... = ...
+#   39|           0: [PropertyCall] access to property Real
+#   39|           1: [SubExpr] ... - ...
+#   39|             0: [PropertyCall] access to property Real
+#   39|               -1: [ParameterAccess] access to parameter other
+#   39|             1: [DoubleLiteral] 1
+#   39|         1: [MemberInitializer] ... = ...
+#   39|           0: [PropertyCall] access to property Imaginary
+#   39|           1: [PropertyCall] access to property Imaginary
+#   39|             -1: [ParameterAccess] access to parameter other
+#   41|   10: [AddOperator] +
+#   41|     -1: [TypeMention] Complex
+#-----|     2: (Parameters)
+#   41|       0: [Parameter] left
+#   41|         -1: [TypeMention] Complex
+#   41|       1: [Parameter] right
+#   41|         -1: [TypeMention] Complex
+#   42|     4: [ObjectCreation] object creation of type Complex
+#   42|       -2: [TypeMention] Complex
+#   42|       -1: [ObjectInitializer] { ..., ... }
+#   42|         0: [MemberInitializer] ... = ...
+#   42|           0: [PropertyCall] access to property Real
+#   42|           1: [AddExpr] ... + ...
+#   42|             0: [PropertyCall] access to property Real
+#   42|               -1: [ParameterAccess] access to parameter left
+#   42|             1: [PropertyCall] access to property Real
+#   42|               -1: [ParameterAccess] access to parameter right
+#   42|         1: [MemberInitializer] ... = ...
+#   42|           0: [PropertyCall] access to property Imaginary
+#   42|           1: [AddExpr] ... + ...
+#   42|             0: [PropertyCall] access to property Imaginary
+#   42|               -1: [ParameterAccess] access to parameter left
+#   42|             1: [PropertyCall] access to property Imaginary
+#   42|               -1: [ParameterAccess] access to parameter right
+#   44|   11: [SubOperator] -
+#   44|     -1: [TypeMention] Complex
+#-----|     2: (Parameters)
+#   44|       0: [Parameter] left
+#   44|         -1: [TypeMention] Complex
+#   44|       1: [Parameter] right
+#   44|         -1: [TypeMention] Complex
+#   45|     4: [ObjectCreation] object creation of type Complex
+#   45|       -2: [TypeMention] Complex
+#   45|       -1: [ObjectInitializer] { ..., ... }
+#   45|         0: [MemberInitializer] ... = ...
+#   45|           0: [PropertyCall] access to property Real
+#   45|           1: [SubExpr] ... - ...
+#   45|             0: [PropertyCall] access to property Real
+#   45|               -1: [ParameterAccess] access to parameter left
+#   45|             1: [PropertyCall] access to property Real
+#   45|               -1: [ParameterAccess] access to parameter right
+#   45|         1: [MemberInitializer] ... = ...
+#   45|           0: [PropertyCall] access to property Imaginary
+#   45|           1: [SubExpr] ... - ...
+#   45|             0: [PropertyCall] access to property Imaginary
+#   45|               -1: [ParameterAccess] access to parameter left
+#   45|             1: [PropertyCall] access to property Imaginary
+#   45|               -1: [ParameterAccess] access to parameter right
+#   47|   12: [ExplicitConversionOperator] explicit conversion
+#   47|     -1: [TypeMention] int
+#-----|     2: (Parameters)
+#   47|       0: [Parameter] n
+#   47|         -1: [TypeMention] Complex
+#   47|     4: [CastExpr] (...) ...
+#   47|       0: [TypeAccess] access to type Int32
+#   47|         0: [TypeMention] int
+#   47|       1: [PropertyCall] access to property Real
+#   47|         -1: [ParameterAccess] access to parameter n
+#   49|   13: [ExplicitConversionOperator] explicit conversion
+#   49|     -1: [TypeMention] short
+#-----|     2: (Parameters)
+#   49|       0: [Parameter] n
+#   49|         -1: [TypeMention] Complex
+#   49|     4: [CastExpr] (...) ...
+#   49|       0: [TypeAccess] access to type Int16
+#   49|         0: [TypeMention] short
+#   49|       1: [PropertyCall] access to property Real
+#   49|         -1: [ParameterAccess] access to parameter n
+#   51|   14: [Method] Inc
+#   51|     -1: [TypeMention] Complex
+#   51|     -1: [TypeMention] INumber<Complex>
+#   51|       1: [TypeMention] Complex
+#-----|     2: (Parameters)
+#   51|       0: [Parameter] other
+#   51|         -1: [TypeMention] Complex
+#   52|     4: [ObjectCreation] object creation of type Complex
+#   52|       -2: [TypeMention] Complex
+#   52|       -1: [ObjectInitializer] { ..., ... }
+#   52|         0: [MemberInitializer] ... = ...
+#   52|           0: [PropertyCall] access to property Real
+#   52|           1: [AddExpr] ... + ...
+#   52|             0: [PropertyCall] access to property Real
+#   52|               -1: [ParameterAccess] access to parameter other
+#   52|             1: [DoubleLiteral] 1
+#   52|         1: [MemberInitializer] ... = ...
+#   52|           0: [PropertyCall] access to property Imaginary
+#   52|           1: [PropertyCall] access to property Imaginary
+#   52|             -1: [ParameterAccess] access to parameter other
+#   54|   15: [Method] Dec
+#   54|     -1: [TypeMention] Complex
+#   54|     -1: [TypeMention] INumber<Complex>
+#   54|       1: [TypeMention] Complex
+#-----|     2: (Parameters)
+#   54|       0: [Parameter] other
+#   54|         -1: [TypeMention] Complex
+#   55|     4: [ObjectCreation] object creation of type Complex
+#   55|       -2: [TypeMention] Complex
+#   55|       -1: [ObjectInitializer] { ..., ... }
+#   55|         0: [MemberInitializer] ... = ...
+#   55|           0: [PropertyCall] access to property Real
+#   55|           1: [SubExpr] ... - ...
+#   55|             0: [PropertyCall] access to property Real
+#   55|               -1: [ParameterAccess] access to parameter other
+#   55|             1: [DoubleLiteral] 1
+#   55|         1: [MemberInitializer] ... = ...
+#   55|           0: [PropertyCall] access to property Imaginary
+#   55|           1: [PropertyCall] access to property Imaginary
+#   55|             -1: [ParameterAccess] access to parameter other
+#   57|   16: [Method] Add
+#   57|     -1: [TypeMention] Complex
+#-----|     2: (Parameters)
+#   57|       0: [Parameter] left
+#   57|         -1: [TypeMention] Complex
+#   57|       1: [Parameter] right
+#   57|         -1: [TypeMention] Complex
+#   58|     4: [ObjectCreation] object creation of type Complex
+#   58|       -2: [TypeMention] Complex
+#   58|       -1: [ObjectInitializer] { ..., ... }
+#   58|         0: [MemberInitializer] ... = ...
+#   58|           0: [PropertyCall] access to property Real
+#   58|           1: [AddExpr] ... + ...
+#   58|             0: [PropertyCall] access to property Real
+#   58|               -1: [ParameterAccess] access to parameter left
+#   58|             1: [PropertyCall] access to property Real
+#   58|               -1: [ParameterAccess] access to parameter right
+#   58|         1: [MemberInitializer] ... = ...
+#   58|           0: [PropertyCall] access to property Imaginary
+#   58|           1: [AddExpr] ... + ...
+#   58|             0: [PropertyCall] access to property Imaginary
+#   58|               -1: [ParameterAccess] access to parameter left
+#   58|             1: [PropertyCall] access to property Imaginary
+#   58|               -1: [ParameterAccess] access to parameter right
+#   60|   17: [Method] Subtract
+#   60|     -1: [TypeMention] Complex
+#-----|     2: (Parameters)
+#   60|       0: [Parameter] left
+#   60|         -1: [TypeMention] Complex
+#   60|       1: [Parameter] right
+#   60|         -1: [TypeMention] Complex
+#   61|     4: [ObjectCreation] object creation of type Complex
+#   61|       -2: [TypeMention] Complex
+#   61|       -1: [ObjectInitializer] { ..., ... }
+#   61|         0: [MemberInitializer] ... = ...
+#   61|           0: [PropertyCall] access to property Real
+#   61|           1: [SubExpr] ... - ...
+#   61|             0: [PropertyCall] access to property Real
+#   61|               -1: [ParameterAccess] access to parameter left
+#   61|             1: [PropertyCall] access to property Real
+#   61|               -1: [ParameterAccess] access to parameter right
+#   61|         1: [MemberInitializer] ... = ...
+#   61|           0: [PropertyCall] access to property Imaginary
+#   61|           1: [SubExpr] ... - ...
+#   61|             0: [PropertyCall] access to property Imaginary
+#   61|               -1: [ParameterAccess] access to parameter left
+#   61|             1: [PropertyCall] access to property Imaginary
+#   61|               -1: [ParameterAccess] access to parameter right
 Strings.cs:
 #    3| [Class] MyTestClass
 #    5|   5: [Method] M1

--- a/csharp/ql/test/library-tests/csharp11/StaticInterfaceMembers.cs
+++ b/csharp/ql/test/library-tests/csharp11/StaticInterfaceMembers.cs
@@ -4,6 +4,18 @@ public interface INumber<T> where T : INumber<T>
 
     static virtual T operator --(T other) => other;
 
+    static abstract T operator +(T left, T right);
+
+    static virtual T operator -(T left, T right) => left;
+
+    static abstract explicit operator int(T n);
+
+    static abstract explicit operator short(T n);
+
+    static abstract T Inc(T other);
+
+    static virtual T Dec(T other) => other;
+
     static abstract T Add(T left, T right);
 
     static virtual T Subtract(T left, T right) => left;
@@ -24,6 +36,22 @@ public class Complex : INumber<Complex>
         new Complex { Real = other.Real + 1.0, Imaginary = other.Imaginary };
 
     public static Complex operator --(Complex other) =>
+        new Complex { Real = other.Real - 1.0, Imaginary = other.Imaginary };
+
+    static Complex INumber<Complex>.operator +(Complex left, Complex right) =>
+        new Complex { Real = left.Real + right.Real, Imaginary = left.Imaginary + right.Imaginary };
+
+    static Complex INumber<Complex>.operator -(Complex left, Complex right) =>
+        new Complex { Real = left.Real - right.Real, Imaginary = left.Imaginary - right.Imaginary };
+
+    public static explicit operator int(Complex n) => (int)n.Real;
+
+    static explicit INumber<Complex>.operator short(Complex n) => (short)n.Real;
+
+    static Complex INumber<Complex>.Inc(Complex other) =>
+        new Complex { Real = other.Real + 1.0, Imaginary = other.Imaginary };
+
+    static Complex INumber<Complex>.Dec(Complex other) =>
         new Complex { Real = other.Real - 1.0, Imaginary = other.Imaginary };
 
     public static Complex Add(Complex left, Complex right) =>

--- a/csharp/ql/test/library-tests/csharp11/staticInterfaceMembers.expected
+++ b/csharp/ql/test/library-tests/csharp11/staticInterfaceMembers.expected
@@ -5,16 +5,37 @@ interfacemembers
 | INumber<> | StaticInterfaceMembers.cs:5:31:5:32 | -- | public |
 | INumber<> | StaticInterfaceMembers.cs:5:31:5:32 | -- | static |
 | INumber<> | StaticInterfaceMembers.cs:5:31:5:32 | -- | virtual |
-| INumber<> | StaticInterfaceMembers.cs:7:23:7:25 | Add | abstract |
-| INumber<> | StaticInterfaceMembers.cs:7:23:7:25 | Add | public |
-| INumber<> | StaticInterfaceMembers.cs:7:23:7:25 | Add | static |
-| INumber<> | StaticInterfaceMembers.cs:9:22:9:29 | Subtract | public |
-| INumber<> | StaticInterfaceMembers.cs:9:22:9:29 | Subtract | static |
-| INumber<> | StaticInterfaceMembers.cs:9:22:9:29 | Subtract | virtual |
-| INumber<> | StaticInterfaceMembers.cs:11:14:11:17 | Zero | public |
-| INumber<> | StaticInterfaceMembers.cs:11:14:11:17 | Zero | static |
+| INumber<> | StaticInterfaceMembers.cs:7:32:7:32 | + | abstract |
+| INumber<> | StaticInterfaceMembers.cs:7:32:7:32 | + | public |
+| INumber<> | StaticInterfaceMembers.cs:7:32:7:32 | + | static |
+| INumber<> | StaticInterfaceMembers.cs:9:31:9:31 | - | public |
+| INumber<> | StaticInterfaceMembers.cs:9:31:9:31 | - | static |
+| INumber<> | StaticInterfaceMembers.cs:9:31:9:31 | - | virtual |
+| INumber<> | StaticInterfaceMembers.cs:11:30:11:37 | explicit conversion | abstract |
+| INumber<> | StaticInterfaceMembers.cs:11:30:11:37 | explicit conversion | public |
+| INumber<> | StaticInterfaceMembers.cs:11:30:11:37 | explicit conversion | static |
+| INumber<> | StaticInterfaceMembers.cs:13:30:13:37 | explicit conversion | abstract |
+| INumber<> | StaticInterfaceMembers.cs:13:30:13:37 | explicit conversion | public |
+| INumber<> | StaticInterfaceMembers.cs:13:30:13:37 | explicit conversion | static |
+| INumber<> | StaticInterfaceMembers.cs:15:23:15:25 | Inc | abstract |
+| INumber<> | StaticInterfaceMembers.cs:15:23:15:25 | Inc | public |
+| INumber<> | StaticInterfaceMembers.cs:15:23:15:25 | Inc | static |
+| INumber<> | StaticInterfaceMembers.cs:17:22:17:24 | Dec | public |
+| INumber<> | StaticInterfaceMembers.cs:17:22:17:24 | Dec | static |
+| INumber<> | StaticInterfaceMembers.cs:17:22:17:24 | Dec | virtual |
+| INumber<> | StaticInterfaceMembers.cs:19:23:19:25 | Add | abstract |
+| INumber<> | StaticInterfaceMembers.cs:19:23:19:25 | Add | public |
+| INumber<> | StaticInterfaceMembers.cs:19:23:19:25 | Add | static |
+| INumber<> | StaticInterfaceMembers.cs:21:22:21:29 | Subtract | public |
+| INumber<> | StaticInterfaceMembers.cs:21:22:21:29 | Subtract | static |
+| INumber<> | StaticInterfaceMembers.cs:21:22:21:29 | Subtract | virtual |
+| INumber<> | StaticInterfaceMembers.cs:23:14:23:17 | Zero | public |
+| INumber<> | StaticInterfaceMembers.cs:23:14:23:17 | Zero | static |
 implements
-| StaticInterfaceMembers.cs:23:36:23:37 | ++ | StaticInterfaceMembers.cs:3:32:3:33 | ++ |
-| StaticInterfaceMembers.cs:26:36:26:37 | -- | StaticInterfaceMembers.cs:5:31:5:32 | -- |
-| StaticInterfaceMembers.cs:29:27:29:29 | Add | StaticInterfaceMembers.cs:7:23:7:25 | Add |
-| StaticInterfaceMembers.cs:32:27:32:34 | Subtract | StaticInterfaceMembers.cs:9:22:9:29 | Subtract |
+| StaticInterfaceMembers.cs:35:36:35:37 | ++ | StaticInterfaceMembers.cs:3:32:3:33 | ++ |
+| StaticInterfaceMembers.cs:38:36:38:37 | -- | StaticInterfaceMembers.cs:5:31:5:32 | -- |
+| StaticInterfaceMembers.cs:47:28:47:35 | explicit conversion | StaticInterfaceMembers.cs:11:30:11:37 | explicit conversion |
+| StaticInterfaceMembers.cs:51:37:51:39 | Inc | StaticInterfaceMembers.cs:15:23:15:25 | Inc |
+| StaticInterfaceMembers.cs:54:37:54:39 | Dec | StaticInterfaceMembers.cs:17:22:17:24 | Dec |
+| StaticInterfaceMembers.cs:57:27:57:29 | Add | StaticInterfaceMembers.cs:19:23:19:25 | Add |
+| StaticInterfaceMembers.cs:60:27:60:34 | Subtract | StaticInterfaceMembers.cs:21:22:21:29 | Subtract |

--- a/csharp/ql/test/library-tests/csharp11/staticInterfaceMembers.expected
+++ b/csharp/ql/test/library-tests/csharp11/staticInterfaceMembers.expected
@@ -34,7 +34,10 @@ interfacemembers
 implements
 | StaticInterfaceMembers.cs:35:36:35:37 | ++ | StaticInterfaceMembers.cs:3:32:3:33 | ++ |
 | StaticInterfaceMembers.cs:38:36:38:37 | -- | StaticInterfaceMembers.cs:5:31:5:32 | -- |
+| StaticInterfaceMembers.cs:41:46:41:46 | + | StaticInterfaceMembers.cs:7:32:7:32 | + |
+| StaticInterfaceMembers.cs:44:46:44:46 | - | StaticInterfaceMembers.cs:9:31:9:31 | - |
 | StaticInterfaceMembers.cs:47:28:47:35 | explicit conversion | StaticInterfaceMembers.cs:11:30:11:37 | explicit conversion |
+| StaticInterfaceMembers.cs:49:38:49:45 | explicit conversion | StaticInterfaceMembers.cs:13:30:13:37 | explicit conversion |
 | StaticInterfaceMembers.cs:51:37:51:39 | Inc | StaticInterfaceMembers.cs:15:23:15:25 | Inc |
 | StaticInterfaceMembers.cs:54:37:54:39 | Dec | StaticInterfaceMembers.cs:17:22:17:24 | Dec |
 | StaticInterfaceMembers.cs:57:27:57:29 | Add | StaticInterfaceMembers.cs:19:23:19:25 | Add |
@@ -46,7 +49,10 @@ publicmembers
 | StaticInterfaceMembers.cs:33:27:33:30 | Zero |
 | StaticInterfaceMembers.cs:35:36:35:37 | ++ |
 | StaticInterfaceMembers.cs:38:36:38:37 | -- |
+| StaticInterfaceMembers.cs:41:46:41:46 | + |
+| StaticInterfaceMembers.cs:44:46:44:46 | - |
 | StaticInterfaceMembers.cs:47:28:47:35 | explicit conversion |
+| StaticInterfaceMembers.cs:49:38:49:45 | explicit conversion |
 | StaticInterfaceMembers.cs:51:37:51:39 | Inc |
 | StaticInterfaceMembers.cs:54:37:54:39 | Dec |
 | StaticInterfaceMembers.cs:57:27:57:29 | Add |

--- a/csharp/ql/test/library-tests/csharp11/staticInterfaceMembers.expected
+++ b/csharp/ql/test/library-tests/csharp11/staticInterfaceMembers.expected
@@ -39,3 +39,15 @@ implements
 | StaticInterfaceMembers.cs:54:37:54:39 | Dec | StaticInterfaceMembers.cs:17:22:17:24 | Dec |
 | StaticInterfaceMembers.cs:57:27:57:29 | Add | StaticInterfaceMembers.cs:19:23:19:25 | Add |
 | StaticInterfaceMembers.cs:60:27:60:34 | Subtract | StaticInterfaceMembers.cs:21:22:21:29 | Subtract |
+publicmembers
+| StaticInterfaceMembers.cs:28:19:28:22 | Real |
+| StaticInterfaceMembers.cs:29:19:29:27 | Imaginary |
+| StaticInterfaceMembers.cs:31:12:31:18 | Complex |
+| StaticInterfaceMembers.cs:33:27:33:30 | Zero |
+| StaticInterfaceMembers.cs:35:36:35:37 | ++ |
+| StaticInterfaceMembers.cs:38:36:38:37 | -- |
+| StaticInterfaceMembers.cs:47:28:47:35 | explicit conversion |
+| StaticInterfaceMembers.cs:51:37:51:39 | Inc |
+| StaticInterfaceMembers.cs:54:37:54:39 | Dec |
+| StaticInterfaceMembers.cs:57:27:57:29 | Add |
+| StaticInterfaceMembers.cs:60:27:60:34 | Subtract |

--- a/csharp/ql/test/library-tests/csharp11/staticInterfaceMembers.ql
+++ b/csharp/ql/test/library-tests/csharp11/staticInterfaceMembers.ql
@@ -16,3 +16,9 @@ query predicate implements(Overridable o, Virtualizable v) {
   v.isStatic() and
   v.getAnImplementor() = o
 }
+
+query predicate publicmembers(Member m) {
+  m.getFile().getStem() = "StaticInterfaceMembers" and
+  m.getDeclaringType().getName() = "Complex" and
+  m.isPublic()
+}


### PR DESCRIPTION
In this PR we implement proper support (to align with the implementation for methods) for explicit implementation of interface operator members.
Prior to this PR the implementation of `+` in the example below was not identified as being neither `public` nor an implementation of `+` from the `INumber<T>` interface.
```csharp
public interface INumber<T> where T : INumber<T>
{
    static abstract T operator +(T left, T right);
}

public class Complex : INumber<Complex>
{
    static Complex INumber<Complex>.operator +(Complex left, Complex right) =>
        new Complex { Real = left.Real + right.Real, Imaginary = left.Imaginary + right.Imaginary };
}
```