### PR TITLE
C++: Use correct DataFlow import in new TaintTracking.qll

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/dataflow/new/TaintTracking.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/new/TaintTracking.qll
@@ -15,8 +15,8 @@
  * `TaintTracking::localTaintStep` with arguments of type `DataFlow::Node`.
  */
 
-import semmle.code.cpp.ir.dataflow.DataFlow
-import semmle.code.cpp.ir.dataflow.DataFlow2
+import semmle.code.cpp.dataflow.new.DataFlow
+import semmle.code.cpp.dataflow.new.DataFlow2
 
 /**
  * Provides classes for performing local (intra-procedural) and


### PR DESCRIPTION
Using the IR version directly gives errors about conflicting imports if both DataFlow and TaintTracking are imported.