### PR TITLE
C++: Make `gets` indirect output a LocalFlowSource

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/models/implementations/Gets.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/implementations/Gets.qll
@@ -97,10 +97,11 @@ private class GetsFunction extends DataFlowFunction, ArrayFunction, AliasFunctio
   }
 
   override predicate hasLocalFlowSource(FunctionOutput output, string description) {
-    output.isParameterDeref(0) and
-    description = "string read by " + this.getName()
-    or
-    output.isReturnValue() and
+    (
+      output.isParameterDeref(0) or
+      output.isReturnValue() or
+      output.isReturnValueDeref()
+    ) and
     description = "string read by " + this.getName()
   }
 


### PR DESCRIPTION
This was causing missing flow [here](https://github.com/github/codeql/pull/12316#discussion_r1118883897). The problematic case was:
```cpp
char password[1024];
gets(password); // BAD
```
the source was any `FlowSource`, and the sink was the indirect output of `gets`. And because only the direct return value was specified as being a `LocalFlowSource` we didn't catch this (trivial) flow.