### PR TITLE
Python: Fix expected of call-graph after merge

### DIFF
--- a/python/ql/test/experimental/library-tests/CallGraph/InlineCallGraphTest.expected
+++ b/python/ql/test/experimental/library-tests/CallGraph/InlineCallGraphTest.expected
@@ -15,8 +15,6 @@ pointsTo_found_typeTracker_notFound
 | code/func_defined_outside_class.py:42:1:42:7 | ControlFlowNode for Attribute() | B._gen.func |
 | code/func_defined_outside_class.py:43:1:43:7 | ControlFlowNode for Attribute() | B._gen.func |
 | code/funky_regression.py:15:9:15:17 | ControlFlowNode for Attribute() | Wat.f2 |
-| code/runtime_decision.py:44:1:44:7 | ControlFlowNode for func4() | "code/runtime_decision_defns.py:4:func4" |
-| code/runtime_decision.py:44:1:44:7 | ControlFlowNode for func4() | "code/runtime_decision_defns.py:7:func4" |
 | code/tuple_function_return.py:15:1:15:4 | ControlFlowNode for f2() | func |
 | code/type_tracking_limitation.py:8:1:8:3 | ControlFlowNode for x() | my_func |
 typeTracker_found_pointsTo_notFound

--- a/python/ql/test/experimental/library-tests/CallGraph/code/runtime_decision.py
+++ b/python/ql/test/experimental/library-tests/CallGraph/code/runtime_decision.py
@@ -41,4 +41,4 @@ func3() # $ pt,tt=33:func3 pt,tt=36:func3
 
 # func4 uses same setup as func3, it's just defined in an other file
 from code.runtime_decision_defns import func4
-func4() # $ pt="code/runtime_decision_defns.py:4:func4" pt="code/runtime_decision_defns.py:7:func4" MISSING: tt
+func4() # $ pt,tt="code/runtime_decision_defns.py:4:func4" pt,tt="code/runtime_decision_defns.py:7:func4"


### PR DESCRIPTION
Since the import resolution was fixed, but tests not rerun, these
expectations were not updated to reflect that we now handle them
properly :muscle: