### PR TITLE
ReflectedXss: Prevent bad join order

### DIFF
--- a/javascript/ql/lib/semmle/javascript/security/dataflow/ReflectedXssCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/ReflectedXssCustomizations.qll
@@ -103,6 +103,12 @@ module ReflectedXss {
     )
   }
 
+  bindingset[headerBlock]
+  pragma[inline_late]
+  private predicate doesNotDominateCallback(ReachableBasicBlock headerBlock) {
+    not exists(Expr e | e instanceof Function | headerBlock.dominates(e.getBasicBlock()))
+  }
+
   /**
    * Holds if the HeaderDefinition `header` seems to be local.
    * A HeaderDefinition is local if it dominates exactly one `ResponseSendArgument`.
@@ -122,7 +128,7 @@ module ReflectedXss {
           header.getBasicBlock().(ReachableBasicBlock).dominates(sender.getBasicBlock())
         ) and
       // doesn't dominate something that looks like a callback.
-      not exists(Expr e | e instanceof Function | headerBlock.dominates(e.getBasicBlock()))
+      doesNotDominateCallback(headerBlock)
     )
   }
 


### PR DESCRIPTION
The Core team is planning to make some changes to the join orderer that causes a join order regression for the `isLocalHeaderDefinition` predicate. This PR adds pragmas to prevent the compiler from picking the bad join order. 