### PR TITLE
C#: Update query to handle static field writes from properties.

### DIFF
--- a/csharp/ql/lib/change-notes/2023-02-28-staticfieldwrites.md
+++ b/csharp/ql/lib/change-notes/2023-02-28-staticfieldwrites.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The query `cs/static-field-written-by-instance` is updated to handle properties.

--- a/csharp/ql/src/Likely Bugs/StaticFieldWrittenByInstance.ql
+++ b/csharp/ql/src/Likely Bugs/StaticFieldWrittenByInstance.ql
@@ -1,6 +1,6 @@
 /**
  * @name Static field written by instance method
- * @description Finds instance methods that write static fields.
+ * @description Finds instance methods and properties that write to static fields.
  *              This is tricky to get right if multiple instances are being manipulated,
  *              and generally bad practice.
  * @kind problem
@@ -14,12 +14,12 @@
 
 import csharp
 
-from FieldWrite fw, Field f, Callable m
+from FieldWrite fw, Field f, Callable c
 where
   fw.getTarget() = f and
   f.isStatic() and
-  m = fw.getEnclosingCallable() and
-  not m.(Member).isStatic() and
-  f.getDeclaringType() = m.getDeclaringType() and
-  m.fromSource()
-select fw.(VariableAccess), "Write to static field from instance method or constructor."
+  c = fw.getEnclosingCallable() and
+  not exists(Member m | m = c or m = c.(Accessor).getDeclaration() | m.isStatic()) and
+  f.getDeclaringType() = c.getDeclaringType() and
+  c.fromSource()
+select fw.(VariableAccess), "Write to static field from instance method, property or constructor."

--- a/csharp/ql/src/Likely Bugs/StaticFieldWrittenByInstance.ql
+++ b/csharp/ql/src/Likely Bugs/StaticFieldWrittenByInstance.ql
@@ -19,7 +19,7 @@ where
   fw.getTarget() = f and
   f.isStatic() and
   c = fw.getEnclosingCallable() and
-  not exists(Member m | m = c or m = c.(Accessor).getDeclaration() | m.isStatic()) and
+  not [c.(Member), c.(Accessor).getDeclaration()].isStatic() and
   f.getDeclaringType() = c.getDeclaringType() and
   c.fromSource()
-select fw.(VariableAccess), "Write to static field from instance method, property or constructor."
+select fw.(VariableAccess), "Write to static field from instance method, property, or constructor."

--- a/csharp/ql/test/query-tests/Likely Bugs/StaticFieldWrittenByInstance/StaticFieldWrittenByInstance.cs
+++ b/csharp/ql/test/query-tests/Likely Bugs/StaticFieldWrittenByInstance/StaticFieldWrittenByInstance.cs
@@ -26,4 +26,21 @@ class StaticFields
         staticField = 0;    // BAD
         instanceField = 0;  // OK
     }
+
+    static object backingField;
+    static object StaticProp
+    {
+        get
+        {
+            return backingField ?? (backingField = new object()); // OK
+        }
+    }
+
+    object Prop
+    {
+        get
+        {
+            return backingField ?? (backingField = new object()); // BAD
+        }
+    }
 }

--- a/csharp/ql/test/query-tests/Likely Bugs/StaticFieldWrittenByInstance/StaticFieldWrittenByInstance.expected
+++ b/csharp/ql/test/query-tests/Likely Bugs/StaticFieldWrittenByInstance/StaticFieldWrittenByInstance.expected
@@ -1,3 +1,3 @@
-| StaticFieldWrittenByInstance.cs:15:9:15:19 | access to field staticField | Write to static field from instance method, property or constructor. |
-| StaticFieldWrittenByInstance.cs:26:9:26:19 | access to field staticField | Write to static field from instance method, property or constructor. |
-| StaticFieldWrittenByInstance.cs:43:37:43:48 | access to field backingField | Write to static field from instance method, property or constructor. |
+| StaticFieldWrittenByInstance.cs:15:9:15:19 | access to field staticField | Write to static field from instance method, property, or constructor. |
+| StaticFieldWrittenByInstance.cs:26:9:26:19 | access to field staticField | Write to static field from instance method, property, or constructor. |
+| StaticFieldWrittenByInstance.cs:43:37:43:48 | access to field backingField | Write to static field from instance method, property, or constructor. |

--- a/csharp/ql/test/query-tests/Likely Bugs/StaticFieldWrittenByInstance/StaticFieldWrittenByInstance.expected
+++ b/csharp/ql/test/query-tests/Likely Bugs/StaticFieldWrittenByInstance/StaticFieldWrittenByInstance.expected
@@ -1,2 +1,3 @@
-| StaticFieldWrittenByInstance.cs:15:9:15:19 | access to field staticField | Write to static field from instance method or constructor. |
-| StaticFieldWrittenByInstance.cs:26:9:26:19 | access to field staticField | Write to static field from instance method or constructor. |
+| StaticFieldWrittenByInstance.cs:15:9:15:19 | access to field staticField | Write to static field from instance method, property or constructor. |
+| StaticFieldWrittenByInstance.cs:26:9:26:19 | access to field staticField | Write to static field from instance method, property or constructor. |
+| StaticFieldWrittenByInstance.cs:43:37:43:48 | access to field backingField | Write to static field from instance method, property or constructor. |


### PR DESCRIPTION
It turns out that the query `cs/static-field-written-by-instance` reports false positives if a static property writes to static field.
That is, the example below leads to a false positive. This is fixed in this PR.
```csharp
static object backingField;
static object StaticProp
{
    get
    {
        return backingField ?? (backingField = new object()); // OK
    }
}
```