### PR TITLE
C++: Add tests for all dataflow examples that occur in our docs

### DIFF
--- a/cpp/ql/test/examples/docs-examples/README.md
+++ b/cpp/ql/test/examples/docs-examples/README.md
@@ -1,0 +1,2 @@
+This directory contains the C++ demo queries from the docs directory.
+Maintaining this copy should ensure that they continue to work.

--- a/cpp/ql/test/examples/docs-examples/analyzing-data-flow-in-cpp/exercise1.expected
+++ b/cpp/ql/test/examples/docs-examples/analyzing-data-flow-in-cpp/exercise1.expected
@@ -1,0 +1,2 @@
+| gethostbyname.cpp:6:25:6:44 | https://github.com | gethostbyname.cpp:11:23:11:35 | call to gethostbyname |
+| gethostbyname.cpp:9:37:9:56 | https://github.com | gethostbyname.cpp:9:23:9:35 | call to gethostbyname |

--- a/cpp/ql/test/examples/docs-examples/analyzing-data-flow-in-cpp/exercise1.ql
+++ b/cpp/ql/test/examples/docs-examples/analyzing-data-flow-in-cpp/exercise1.ql
@@ -1,0 +1,10 @@
+import cpp
+import semmle.code.cpp.dataflow.new.DataFlow
+
+from StringLiteral sl, FunctionCall fc, DataFlow::Node source, DataFlow::Node sink
+where
+  fc.getTarget().hasName("gethostbyname") and
+  source.asIndirectExpr(1) = sl and
+  sink.asIndirectExpr(1) = fc.getArgument(0) and
+  DataFlow::localFlow(source, sink)
+select sl, fc

--- a/cpp/ql/test/examples/docs-examples/analyzing-data-flow-in-cpp/exercise2.expected
+++ b/cpp/ql/test/examples/docs-examples/analyzing-data-flow-in-cpp/exercise2.expected
@@ -1,0 +1,2 @@
+| gethostbyname.cpp:6:25:6:44 | https://github.com | gethostbyname.cpp:11:23:11:35 | call to gethostbyname |
+| gethostbyname.cpp:9:37:9:56 | https://github.com | gethostbyname.cpp:9:23:9:35 | call to gethostbyname |

--- a/cpp/ql/test/examples/docs-examples/analyzing-data-flow-in-cpp/exercise2.ql
+++ b/cpp/ql/test/examples/docs-examples/analyzing-data-flow-in-cpp/exercise2.ql
@@ -1,0 +1,26 @@
+import cpp
+import semmle.code.cpp.dataflow.new.DataFlow
+
+class LiteralToGethostbynameConfiguration extends DataFlow::Configuration {
+  LiteralToGethostbynameConfiguration() { this = "LiteralToGethostbynameConfiguration" }
+
+  override predicate isSource(DataFlow::Node source) {
+    source.asIndirectExpr(1) instanceof StringLiteral
+  }
+
+  override predicate isSink(DataFlow::Node sink) {
+    exists(FunctionCall fc |
+      sink.asIndirectExpr(1) = fc.getArgument(0) and
+      fc.getTarget().hasName("gethostbyname")
+    )
+  }
+}
+
+from
+  StringLiteral sl, FunctionCall fc, LiteralToGethostbynameConfiguration cfg, DataFlow::Node source,
+  DataFlow::Node sink
+where
+  source.asIndirectExpr(1) = sl and
+  sink.asIndirectExpr(1) = fc.getArgument(0) and
+  cfg.hasFlow(source, sink)
+select sl, fc

--- a/cpp/ql/test/examples/docs-examples/analyzing-data-flow-in-cpp/exercise4.expected
+++ b/cpp/ql/test/examples/docs-examples/analyzing-data-flow-in-cpp/exercise4.expected
@@ -1,0 +1,2 @@
+| gethostbyname.cpp:7:30:7:35 | call to getenv | gethostbyname.cpp:13:23:13:35 | call to gethostbyname |
+| gethostbyname.cpp:12:37:12:42 | call to getenv | gethostbyname.cpp:12:23:12:35 | call to gethostbyname |

--- a/cpp/ql/test/examples/docs-examples/analyzing-data-flow-in-cpp/exercise4.ql
+++ b/cpp/ql/test/examples/docs-examples/analyzing-data-flow-in-cpp/exercise4.ql
@@ -1,0 +1,28 @@
+import cpp
+import semmle.code.cpp.dataflow.new.DataFlow
+
+class GetenvSource extends DataFlow::Node {
+  GetenvSource() { this.asIndirectExpr(1).(FunctionCall).getTarget().hasQualifiedName("getenv") }
+}
+
+class GetenvToGethostbynameConfiguration extends DataFlow::Configuration {
+  GetenvToGethostbynameConfiguration() { this = "GetenvToGethostbynameConfiguration" }
+
+  override predicate isSource(DataFlow::Node source) { source instanceof GetenvSource }
+
+  override predicate isSink(DataFlow::Node sink) {
+    exists(FunctionCall fc |
+      sink.asIndirectExpr(1) = fc.getArgument(0) and
+      fc.getTarget().hasName("gethostbyname")
+    )
+  }
+}
+
+from
+  Expr getenv, FunctionCall fc, GetenvToGethostbynameConfiguration cfg, DataFlow::Node source,
+  DataFlow::Node sink
+where
+  source.asIndirectExpr(1) = getenv and
+  sink.asIndirectExpr(1) = fc.getArgument(0) and
+  cfg.hasFlow(source, sink)
+select getenv, fc

--- a/cpp/ql/test/examples/docs-examples/analyzing-data-flow-in-cpp/fopen-flow-from-expr.expected
+++ b/cpp/ql/test/examples/docs-examples/analyzing-data-flow-in-cpp/fopen-flow-from-expr.expected
@@ -1,0 +1,10 @@
+| fopen.cpp:6:30:6:37 | a_file |
+| fopen.cpp:8:26:8:33 | a_file |
+| fopen.cpp:9:26:9:34 | filename1 |
+| fopen.cpp:10:26:10:34 | filename2 |
+| fopen.cpp:18:18:18:25 | filename |
+| fopen.cpp:23:30:23:38 | call to do_getenv |
+| fopen.cpp:24:30:24:35 | call to getenv |
+| fopen.cpp:27:26:27:31 | call to getenv |
+| fopen.cpp:28:26:28:34 | filename1 |
+| fopen.cpp:29:26:29:34 | filename2 |

--- a/cpp/ql/test/examples/docs-examples/analyzing-data-flow-in-cpp/fopen-flow-from-expr.ql
+++ b/cpp/ql/test/examples/docs-examples/analyzing-data-flow-in-cpp/fopen-flow-from-expr.ql
@@ -1,0 +1,11 @@
+import cpp
+import semmle.code.cpp.dataflow.new.DataFlow
+
+from Function fopen, FunctionCall fc, Expr src, DataFlow::Node source, DataFlow::Node sink
+where
+  fopen.hasQualifiedName("fopen") and
+  fc.getTarget() = fopen and
+  source.asIndirectExpr(1) = src and
+  sink.asIndirectExpr(1) = fc.getArgument(0) and
+  DataFlow::localFlow(source, sink)
+select src

--- a/cpp/ql/test/examples/docs-examples/analyzing-data-flow-in-cpp/fopen-flow-from-getenv.expected
+++ b/cpp/ql/test/examples/docs-examples/analyzing-data-flow-in-cpp/fopen-flow-from-getenv.expected
@@ -1,0 +1,5 @@
+| fopen.cpp:18:18:18:25 | filename | This 'fopen' uses data from $@. | fopen.cpp:25:30:25:35 | call to getenv | call to 'getenv' |
+| fopen.cpp:18:18:18:25 | filename | This 'fopen' uses data from $@. | fopen.cpp:30:29:30:34 | call to getenv | call to 'getenv' |
+| fopen.cpp:27:26:27:31 | call to getenv | This 'fopen' uses data from $@. | fopen.cpp:27:26:27:31 | call to getenv | call to 'getenv' |
+| fopen.cpp:28:26:28:34 | filename1 | This 'fopen' uses data from $@. | fopen.cpp:14:12:14:17 | call to getenv | call to 'getenv' |
+| fopen.cpp:29:26:29:34 | filename2 | This 'fopen' uses data from $@. | fopen.cpp:24:30:24:35 | call to getenv | call to 'getenv' |

--- a/cpp/ql/test/examples/docs-examples/analyzing-data-flow-in-cpp/fopen-flow-from-getenv.ql
+++ b/cpp/ql/test/examples/docs-examples/analyzing-data-flow-in-cpp/fopen-flow-from-getenv.ql
@@ -1,0 +1,29 @@
+import cpp
+import semmle.code.cpp.dataflow.new.DataFlow
+
+class EnvironmentToFileConfiguration extends DataFlow::Configuration {
+  EnvironmentToFileConfiguration() { this = "EnvironmentToFileConfiguration" }
+
+  override predicate isSource(DataFlow::Node source) {
+    exists(Function getenv |
+      source.asIndirectExpr(1).(FunctionCall).getTarget() = getenv and
+      getenv.hasQualifiedName("getenv")
+    )
+  }
+
+  override predicate isSink(DataFlow::Node sink) {
+    exists(FunctionCall fc |
+      sink.asIndirectExpr(1) = fc.getArgument(0) and
+      fc.getTarget().hasQualifiedName("fopen")
+    )
+  }
+}
+
+from
+  Expr getenv, Expr fopen, EnvironmentToFileConfiguration config, DataFlow::Node source,
+  DataFlow::Node sink
+where
+  source.asIndirectExpr(1) = getenv and
+  sink.asIndirectExpr(1) = fopen and
+  config.hasFlow(source, sink)
+select fopen, "This 'fopen' uses data from $@.", getenv, "call to 'getenv'"

--- a/cpp/ql/test/examples/docs-examples/analyzing-data-flow-in-cpp/fopen-flow-from-param.expected
+++ b/cpp/ql/test/examples/docs-examples/analyzing-data-flow-in-cpp/fopen-flow-from-param.expected
@@ -1,0 +1,2 @@
+| fopen.cpp:5:24:5:32 | filename1 |
+| fopen.cpp:17:30:17:37 | filename |

--- a/cpp/ql/test/examples/docs-examples/analyzing-data-flow-in-cpp/fopen-flow-from-param.ql
+++ b/cpp/ql/test/examples/docs-examples/analyzing-data-flow-in-cpp/fopen-flow-from-param.ql
@@ -1,0 +1,11 @@
+import cpp
+import semmle.code.cpp.dataflow.new.DataFlow
+
+from Function fopen, FunctionCall fc, Parameter p, DataFlow::Node source, DataFlow::Node sink
+where
+  fopen.hasQualifiedName("fopen") and
+  fc.getTarget() = fopen and
+  source.asParameter(1) = p and
+  sink.asIndirectExpr(1) = fc.getArgument(0) and
+  DataFlow::localFlow(source, sink)
+select p

--- a/cpp/ql/test/examples/docs-examples/analyzing-data-flow-in-cpp/fopen-no-flow.expected
+++ b/cpp/ql/test/examples/docs-examples/analyzing-data-flow-in-cpp/fopen-no-flow.expected
@@ -1,0 +1,7 @@
+| fopen.cpp:8:26:8:33 | a_file |
+| fopen.cpp:9:26:9:34 | filename1 |
+| fopen.cpp:10:26:10:34 | filename2 |
+| fopen.cpp:18:18:18:25 | filename |
+| fopen.cpp:27:26:27:31 | call to getenv |
+| fopen.cpp:28:26:28:34 | filename1 |
+| fopen.cpp:29:26:29:34 | filename2 |

--- a/cpp/ql/test/examples/docs-examples/analyzing-data-flow-in-cpp/fopen-no-flow.ql
+++ b/cpp/ql/test/examples/docs-examples/analyzing-data-flow-in-cpp/fopen-no-flow.ql
@@ -1,0 +1,7 @@
+import cpp
+
+from Function fopen, FunctionCall fc
+where
+  fopen.hasQualifiedName("fopen") and
+  fc.getTarget() = fopen
+select fc.getArgument(0)

--- a/cpp/ql/test/examples/docs-examples/analyzing-data-flow-in-cpp/fopen.cpp
+++ b/cpp/ql/test/examples/docs-examples/analyzing-data-flow-in-cpp/fopen.cpp
@@ -1,0 +1,32 @@
+struct FILE;
+FILE *fopen(const char * path, const char * mode);
+char * getenv(const char * name);
+
+void test_fopen(char * filename1) {
+    const char * filename2 = "a_file";
+
+    FILE * file0 = fopen("a_file", "r");
+    FILE * file1 = fopen(filename1, "r");
+    FILE * file2 = fopen(filename2, "r");
+}
+
+const char * do_getenv() {
+    return getenv("FILENAME1");
+}
+
+FILE * do_fopen(const char * filename) {
+    return fopen(filename, "r");
+}
+
+void test_getenv()
+{
+    const char * filename1 = do_getenv();
+    const char * filename2 = getenv("FILENAME2");
+    const char * filename4 = getenv("FILENAME4");
+
+    FILE * file0 = fopen(getenv("FILENAME0"), "r");
+    FILE * file1 = fopen(filename1, "r");
+    FILE * file2 = fopen(filename2, "r");
+    FILE * file3 = do_fopen(getenv("FILENAME3"));
+    FILE * file4 = do_fopen(filename4);
+}

--- a/cpp/ql/test/examples/docs-examples/analyzing-data-flow-in-cpp/gethostbyname.cpp
+++ b/cpp/ql/test/examples/docs-examples/analyzing-data-flow-in-cpp/gethostbyname.cpp
@@ -1,0 +1,14 @@
+struct hostent;
+hostent * gethostbyname(const char * name);
+char * getenv(const char * name);
+
+void test_gethostbyname(const char * url1) {
+    const char * url2 = "https://github.com";
+    const char * hostname1 = getenv("HOSTNAME1");
+
+    hostent * host0 = gethostbyname("https://github.com");
+    hostent * host1 = gethostbyname(url1);
+    hostent * host2 = gethostbyname(url2);
+    hostent * host3 = gethostbyname(getenv("HOSTNAME0"));
+    hostent * host4 = gethostbyname(hostname1);
+}

--- a/cpp/ql/test/examples/docs-examples/analyzing-data-flow-in-cpp/index-flow-from-ntohl.expected
+++ b/cpp/ql/test/examples/docs-examples/analyzing-data-flow-in-cpp/index-flow-from-ntohl.expected
@@ -1,0 +1,2 @@
+| ntohl.cpp:10:20:10:28 | hostlong0 | This array offset may be influenced by $@. | ntohl.cpp:6:30:6:34 | call to ntohl | converted data from the network |
+| ntohl.cpp:17:24:17:24 | i | This array offset may be influenced by $@. | ntohl.cpp:8:30:8:34 | call to ntohl | converted data from the network |

--- a/cpp/ql/test/examples/docs-examples/analyzing-data-flow-in-cpp/index-flow-from-ntohl.ql
+++ b/cpp/ql/test/examples/docs-examples/analyzing-data-flow-in-cpp/index-flow-from-ntohl.ql
@@ -1,0 +1,38 @@
+import cpp
+import semmle.code.cpp.controlflow.Guards
+import semmle.code.cpp.dataflow.new.TaintTracking
+
+class NetworkToBufferSizeConfiguration extends TaintTracking::Configuration {
+  NetworkToBufferSizeConfiguration() { this = "NetworkToBufferSizeConfiguration" }
+
+  override predicate isSource(DataFlow::Node node) {
+    node.asExpr().(FunctionCall).getTarget().hasGlobalName("ntohl")
+  }
+
+  override predicate isSink(DataFlow::Node node) {
+    exists(ArrayExpr ae | node.asExpr() = ae.getArrayOffset())
+  }
+
+  override predicate isAdditionalTaintStep(DataFlow::Node pred, DataFlow::Node succ) {
+    exists(Loop loop, LoopCounter lc |
+      loop = lc.getALoop() and
+      loop.getControllingExpr().(RelationalOperation).getGreaterOperand() = pred.asExpr()
+    |
+      succ.asExpr() = lc.getVariableAccessInLoop(loop)
+    )
+  }
+
+  override predicate isSanitizer(DataFlow::Node node) {
+    exists(GuardCondition gc, Variable v |
+      gc.getAChild*() = v.getAnAccess() and
+      node.asExpr() = v.getAnAccess() and
+      gc.controls(node.asExpr().getBasicBlock(), _) and
+      not exists(Loop loop | loop.getControllingExpr() = gc)
+    )
+  }
+}
+
+from DataFlow::Node ntohl, DataFlow::Node offset, NetworkToBufferSizeConfiguration conf
+where conf.hasFlow(ntohl, offset)
+select offset, "This array offset may be influenced by $@.", ntohl,
+  "converted data from the network"

--- a/cpp/ql/test/examples/docs-examples/analyzing-data-flow-in-cpp/ntohl.cpp
+++ b/cpp/ql/test/examples/docs-examples/analyzing-data-flow-in-cpp/ntohl.cpp
@@ -1,0 +1,19 @@
+unsigned int ntohl(unsigned int netlong);
+
+void test_ntohl(
+        unsigned int netlong0, unsigned int netlong1, unsigned int netlong2,
+        int * arr, unsigned int arr_size) {
+    unsigned int hostlong0 = ntohl(netlong0);
+    unsigned int hostlong1 = ntohl(netlong1);
+    unsigned int hostlong2 = ntohl(netlong2);
+
+    int val0 = arr[hostlong0];
+
+    if (hostlong1 < arr_size) {
+        int val1 = arr[hostlong1];
+    }
+
+    for (unsigned int i = 0; i < hostlong2; ++i) {
+        int val2 = arr[i];
+    }
+}

--- a/cpp/ql/test/examples/docs-examples/analyzing-data-flow-in-cpp/printf-format-not-hard-coded.expected
+++ b/cpp/ql/test/examples/docs-examples/analyzing-data-flow-in-cpp/printf-format-not-hard-coded.expected
@@ -1,0 +1,2 @@
+| printf.cpp:5:5:5:10 | call to printf | Argument to printf isn't hard-coded. |
+| printf.cpp:6:5:6:10 | call to printf | Argument to printf isn't hard-coded. |

--- a/cpp/ql/test/examples/docs-examples/analyzing-data-flow-in-cpp/printf-format-not-hard-coded.ql
+++ b/cpp/ql/test/examples/docs-examples/analyzing-data-flow-in-cpp/printf-format-not-hard-coded.ql
@@ -1,0 +1,13 @@
+import semmle.code.cpp.dataflow.new.DataFlow
+import semmle.code.cpp.commons.Printf
+
+from FormattingFunction format, FunctionCall call, Expr formatString, DataFlow::Node sink
+where
+  call.getTarget() = format and
+  call.getArgument(format.getFormatParameterIndex()) = formatString and
+  sink.asIndirectExpr(1) = formatString and
+  not exists(DataFlow::Node source |
+    DataFlow::localFlow(source, sink) and
+    source.asIndirectExpr(1) instanceof StringLiteral
+  )
+select call, "Argument to " + format.getQualifiedName() + " isn't hard-coded."

--- a/cpp/ql/test/examples/docs-examples/analyzing-data-flow-in-cpp/printf.cpp
+++ b/cpp/ql/test/examples/docs-examples/analyzing-data-flow-in-cpp/printf.cpp
@@ -1,0 +1,11 @@
+int printf(const char * format, ...);
+
+void test_printf(const char * fmt1, bool choice, const char * str) {
+    printf("%s", str);
+    printf(fmt1, str);
+    printf(choice ? "%s" : "%s\n", str);
+
+    return;
+
+    printf("%s", str); // Unreachable
+}


### PR DESCRIPTION
This is on top of the commits from https://github.com/github/codeql/pull/12316. The only relevant commit is 549ebcf703d4211af20c7dec9a663aa1c6d73c8c. Initial attempt of rewriting the example dataflow queries from the docs for the new use-use dataflow library. As I ran into some problems with the queries along the way, these are actually tests. If the queries here look sensible, the next step is to update the documentation.

Note that I've been rather strict with the indirect expressions, and I've always used `asIndirectExpr(1)`, and not `asIndirectExpr()`. I'm not completely sure that makes sense, so feedback on that would be useful.