### PR TITLE
C++: Add copy of dataflow docs for new use-use dataflow library

### DIFF
--- a/cpp/ql/test/examples/docs-examples/analyzing-data-flow-in-cpp/exercise4.ql
+++ b/cpp/ql/test/examples/docs-examples/analyzing-data-flow-in-cpp/exercise4.ql
@@ -2,7 +2,7 @@ import cpp
 import semmle.code.cpp.dataflow.new.DataFlow
 
 class GetenvSource extends DataFlow::Node {
-  GetenvSource() { this.asIndirectExpr(1).(FunctionCall).getTarget().hasQualifiedName("getenv") }
+  GetenvSource() { this.asIndirectExpr(1).(FunctionCall).getTarget().hasGlobalName("getenv") }
 }
 
 class GetenvToGethostbynameConfiguration extends DataFlow::Configuration {

--- a/cpp/ql/test/examples/docs-examples/analyzing-data-flow-in-cpp/fopen-flow-from-expr.ql
+++ b/cpp/ql/test/examples/docs-examples/analyzing-data-flow-in-cpp/fopen-flow-from-expr.ql
@@ -3,7 +3,7 @@ import semmle.code.cpp.dataflow.new.DataFlow
 
 from Function fopen, FunctionCall fc, Expr src, DataFlow::Node source, DataFlow::Node sink
 where
-  fopen.hasQualifiedName("fopen") and
+  fopen.hasGlobalName("fopen") and
   fc.getTarget() = fopen and
   source.asIndirectExpr(1) = src and
   sink.asIndirectExpr(1) = fc.getArgument(0) and

--- a/cpp/ql/test/examples/docs-examples/analyzing-data-flow-in-cpp/fopen-flow-from-getenv.ql
+++ b/cpp/ql/test/examples/docs-examples/analyzing-data-flow-in-cpp/fopen-flow-from-getenv.ql
@@ -7,14 +7,14 @@ class EnvironmentToFileConfiguration extends DataFlow::Configuration {
   override predicate isSource(DataFlow::Node source) {
     exists(Function getenv |
       source.asIndirectExpr(1).(FunctionCall).getTarget() = getenv and
-      getenv.hasQualifiedName("getenv")
+      getenv.hasGlobalName("getenv")
     )
   }
 
   override predicate isSink(DataFlow::Node sink) {
     exists(FunctionCall fc |
       sink.asIndirectExpr(1) = fc.getArgument(0) and
-      fc.getTarget().hasQualifiedName("fopen")
+      fc.getTarget().hasGlobalName("fopen")
     )
   }
 }

--- a/cpp/ql/test/examples/docs-examples/analyzing-data-flow-in-cpp/fopen-flow-from-param.ql
+++ b/cpp/ql/test/examples/docs-examples/analyzing-data-flow-in-cpp/fopen-flow-from-param.ql
@@ -3,7 +3,7 @@ import semmle.code.cpp.dataflow.new.DataFlow
 
 from Function fopen, FunctionCall fc, Parameter p, DataFlow::Node source, DataFlow::Node sink
 where
-  fopen.hasQualifiedName("fopen") and
+  fopen.hasGlobalName("fopen") and
   fc.getTarget() = fopen and
   source.asParameter(1) = p and
   sink.asIndirectExpr(1) = fc.getArgument(0) and

--- a/cpp/ql/test/examples/docs-examples/analyzing-data-flow-in-cpp/fopen-no-flow.ql
+++ b/cpp/ql/test/examples/docs-examples/analyzing-data-flow-in-cpp/fopen-no-flow.ql
@@ -2,6 +2,6 @@ import cpp
 
 from Function fopen, FunctionCall fc
 where
-  fopen.hasQualifiedName("fopen") and
+  fopen.hasGlobalName("fopen") and
   fc.getTarget() = fopen
 select fc.getArgument(0)

--- a/docs/codeql/codeql-language-guides/analyzing-data-flow-in-cpp-new.rst
+++ b/docs/codeql/codeql-language-guides/analyzing-data-flow-in-cpp-new.rst
@@ -2,10 +2,10 @@
 
 .. pull-quote:: Note
 
-   The data flow library described here is available from CodeQL 2.13.0 onwards. See :ref:`here <analyzing-data-flow-in-cpp>` for the library available in earlier versions.
+   The data flow library described here is available from CodeQL 2.12.5 onwards. See :ref:`here <analyzing-data-flow-in-cpp>` for the library available in earlier versions.
 
 Analyzing data flow in C and C++ (New)
-================================
+======================================
 
 You can use data flow analysis to track the flow of potentially malicious or insecure data that can cause vulnerabilities in your codebase.
 
@@ -101,7 +101,7 @@ The following query finds the filename passed to ``fopen``:
      fc.getTarget() = fopen
    select fc.getArgument(0)
 
-Unfortunately, this will only give the expression in the argument, not the values which could be passed to it. So we use local data flow to find all expressions that flow into the argument, where we use ``asIndirectExpr(1)`` as we are interested in the value of the string passed to `fopen`, not the pointer pointing to it:
+However, this will only give the expression in the argument, not the values which could be passed to it. Instead we can use local data flow to find all expressions that flow into the argument, where we use ``asIndirectExpr(1)``. This is because we are interested in the value of the string passed to `fopen`, not the pointer pointing to it:
 
 .. code-block:: ql
 

--- a/docs/codeql/codeql-language-guides/analyzing-data-flow-in-cpp-new.rst
+++ b/docs/codeql/codeql-language-guides/analyzing-data-flow-in-cpp-new.rst
@@ -4,7 +4,7 @@
 
    The data flow library described here is available from CodeQL 2.13.0 onwards. See :ref:`here <analyzing-data-flow-in-cpp>` for the library available in earlier versions.
 
-Analyzing data flow in C and C++
+Analyzing data flow in C and C++ (New)
 ================================
 
 You can use data flow analysis to track the flow of potentially malicious or insecure data that can cause vulnerabilities in your codebase.

--- a/docs/codeql/codeql-language-guides/analyzing-data-flow-in-cpp-new.rst
+++ b/docs/codeql/codeql-language-guides/analyzing-data-flow-in-cpp-new.rst
@@ -89,7 +89,7 @@ For example, finding taint propagation from a parameter ``source`` to an express
 Examples
 ~~~~~~~~
 
-The following query finds the filename passed to ``fopen``.
+The following query finds the filename passed to ``fopen``:
 
 .. code-block:: ql
 

--- a/docs/codeql/codeql-language-guides/analyzing-data-flow-in-cpp-new.rst
+++ b/docs/codeql/codeql-language-guides/analyzing-data-flow-in-cpp-new.rst
@@ -33,8 +33,8 @@ The local data flow library is in the module ``DataFlow``, which defines the cla
      Expr asExpr() { ... }
 
      /**
-      * Gets the expression corresponding to this node, if any, after dereferencing
-      * the expression `index` times.
+      * Gets the expression corresponding to a node that is obtained after dereferencing
+      * the expression `index` times, if any.
       */
      Expr asIndirectExpr(int index) { ... }
 
@@ -44,8 +44,8 @@ The local data flow library is in the module ``DataFlow``, which defines the cla
      Parameter asParameter() { ... }
 
      /**
-      * Gets the parameter corresponding to this node, if any, after dereferencing
-      * the expression `index` times.
+      * Gets the parameter corresponding to a node that is obtained after dereferencing
+      * the parameter `index` times.
       */
      Parameter asParameter(int index) { ... }
 

--- a/docs/codeql/codeql-language-guides/analyzing-data-flow-in-cpp-new.rst
+++ b/docs/codeql/codeql-language-guides/analyzing-data-flow-in-cpp-new.rst
@@ -22,7 +22,9 @@ Local data flow is data flow within a single function. Local data flow is usuall
 Using local data flow
 ~~~~~~~~~~~~~~~~~~~~~
 
-The local data flow library is in the module ``DataFlow``, which defines the class ``Node`` denoting any element that data can flow through. ``Node``\ s are divided into expression nodes (``ExprNode``) and parameter nodes (``ParameterNode``). It is possible to map between data flow nodes and expressions/parameters using the member predicates ``asExpr``, ``asIndirectExpr``, and ``asParameter``:
+The local data flow library is in the module ``DataFlow``, which defines the class ``Node`` denoting any element that data can flow through. ``Node``\ s are divided into expression nodes (``ExprNode``, ``IndirectExprNode``) and parameter nodes (``ParameterNode``, ``IndirectParameterNode``). The indirect nodes represent expressions or parameters after a fixed number of pointer dereferences.
+
+It is possible to map between data flow nodes and expressions/parameters using the member predicates ``asExpr``, ``asIndirectExpr``, and ``asParameter``:
 
 .. code-block:: ql
 
@@ -115,7 +117,7 @@ Unfortunately, this will only give the expression in the argument, not the value
      DataFlow::localFlow(source, sink)
    select src
 
-Then we can vary the source, for example an access to a public parameter. The following query finds where a public parameter is used to open a file:
+Then we can vary the source and, for example, use the parameter of a function. The following query finds where a parameter is used when opening a file:
 
 .. code-block:: ql
 

--- a/docs/codeql/codeql-language-guides/analyzing-data-flow-in-cpp-new.rst
+++ b/docs/codeql/codeql-language-guides/analyzing-data-flow-in-cpp-new.rst
@@ -82,7 +82,7 @@ For example, finding taint propagation from a parameter ``source`` to an express
 
    nodeFrom.asParameter() = source and
    nodeTo.asExpr() = sink and
-   TaintTracking::localTaint(nodeFrom, nodeTo):
+   TaintTracking::localTaint(nodeFrom, nodeTo)
 
 Examples
 ~~~~~~~~

--- a/docs/codeql/codeql-language-guides/analyzing-data-flow-in-cpp-new.rst
+++ b/docs/codeql/codeql-language-guides/analyzing-data-flow-in-cpp-new.rst
@@ -97,7 +97,7 @@ The following query finds the filename passed to ``fopen``.
 
    from Function fopen, FunctionCall fc
    where
-     fopen.hasQualifiedName("fopen") and
+     fopen.hasGlobalName("fopen") and
      fc.getTarget() = fopen
    select fc.getArgument(0)
 
@@ -110,7 +110,7 @@ Unfortunately, this will only give the expression in the argument, not the value
 
    from Function fopen, FunctionCall fc, Expr src, DataFlow::Node source, DataFlow::Node sink
    where
-     fopen.hasQualifiedName("fopen") and
+     fopen.hasGlobalName("fopen") and
      fc.getTarget() = fopen and
      source.asIndirectExpr(1) = src and
      sink.asIndirectExpr(1) = fc.getArgument(0) and
@@ -126,7 +126,7 @@ Then we can vary the source and, for example, use the parameter of a function. T
 
    from Function fopen, FunctionCall fc, Parameter p, DataFlow::Node source, DataFlow::Node sink
    where
-     fopen.hasQualifiedName("fopen") and
+     fopen.hasGlobalName("fopen") and
      fc.getTarget() = fopen and
      source.asParameter(1) = p and
      sink.asIndirectExpr(1) = fc.getArgument(0) and
@@ -253,14 +253,14 @@ The following data flow configuration tracks data flow from environment variable
      override predicate isSource(DataFlow::Node source) {
        exists(Function getenv |
          source.asIndirectExpr(1).(FunctionCall).getTarget() = getenv and
-         getenv.hasQualifiedName("getenv")
+         getenv.hasGlobalName("getenv")
        )
      }
 
      override predicate isSink(DataFlow::Node sink) {
        exists(FunctionCall fc |
          sink.asIndirectExpr(1) = fc.getArgument(0) and
-         fc.getTarget().hasQualifiedName("fopen")
+         fc.getTarget().hasGlobalName("fopen")
        )
      }
    }
@@ -386,7 +386,7 @@ Exercise 3
    import semmle.code.cpp.dataflow.new.DataFlow
 
    class GetenvSource extends DataFlow::Node {
-     GetenvSource() { this.asIndirectExpr(1).(FunctionCall).getTarget().hasQualifiedName("getenv") }
+     GetenvSource() { this.asIndirectExpr(1).(FunctionCall).getTarget().hasGlobalName("getenv") }
    }
 
 Exercise 4
@@ -398,7 +398,7 @@ Exercise 4
    import semmle.code.cpp.dataflow.new.DataFlow
 
    class GetenvSource extends DataFlow::Node {
-     GetenvSource() { this.asIndirectExpr(1).(FunctionCall).getTarget().hasQualifiedName("getenv") }
+     GetenvSource() { this.asIndirectExpr(1).(FunctionCall).getTarget().hasGlobalName("getenv") }
    }
 
    class GetenvToGethostbynameConfiguration extends DataFlow::Configuration {

--- a/docs/codeql/codeql-language-guides/analyzing-data-flow-in-cpp-new.rst
+++ b/docs/codeql/codeql-language-guides/analyzing-data-flow-in-cpp-new.rst
@@ -24,7 +24,7 @@ Using local data flow
 
 The local data flow library is in the module ``DataFlow``, which defines the class ``Node`` denoting any element that data can flow through. ``Node``\ s are divided into expression nodes (``ExprNode``, ``IndirectExprNode``) and parameter nodes (``ParameterNode``, ``IndirectParameterNode``). The indirect nodes represent expressions or parameters after a fixed number of pointer dereferences.
 
-It is possible to map between data flow nodes and expressions/parameters using the member predicates ``asExpr``, ``asIndirectExpr``, and ``asParameter``:
+It is possible to map between data flow nodes and expressions or parameters using the member predicates ``asExpr``, ``asIndirectExpr``, and ``asParameter``:
 
 .. code-block:: ql
 

--- a/docs/codeql/codeql-language-guides/analyzing-data-flow-in-cpp.rst
+++ b/docs/codeql/codeql-language-guides/analyzing-data-flow-in-cpp.rst
@@ -1,9 +1,11 @@
 .. _analyzing-data-flow-in-cpp:
 
+.. pull-quote:: Note
+
+   The data flow library described here will be deprecated in the near future. For the replacement library see :ref:`here <analyzing-data-flow-in-cpp-new>`.
+
 Analyzing data flow in C and C++
 ================================
-
-:ref:`Data flow <analyzing-data-flow-in-cpp-new>`
 
 You can use data flow analysis to track the flow of potentially malicious or insecure data that can cause vulnerabilities in your codebase.
 

--- a/docs/codeql/codeql-language-guides/analyzing-data-flow-in-cpp.rst
+++ b/docs/codeql/codeql-language-guides/analyzing-data-flow-in-cpp.rst
@@ -105,7 +105,7 @@ Unfortunately, this will only give the expression in the argument, not the value
      and DataFlow::localFlow(DataFlow::exprNode(src), DataFlow::exprNode(fc.getArgument(0)))
    select src
 
-Then we can vary the source, for example an access to a public parameter. The following query finds where a public parameter is used to open a file:
+Then we can vary the source and, for example, use the parameter of a function. The following query finds where a parameter is used when opening a file:
 
 .. code-block:: ql
 

--- a/docs/codeql/codeql-language-guides/analyzing-data-flow-in-cpp.rst
+++ b/docs/codeql/codeql-language-guides/analyzing-data-flow-in-cpp.rst
@@ -88,7 +88,7 @@ The following query finds the filename passed to ``fopen``.
    import cpp
 
    from Function fopen, FunctionCall fc
-   where fopen.hasQualifiedName("fopen")
+   where fopen.hasGlobalName("fopen")
      and fc.getTarget() = fopen
    select fc.getArgument(0)
 
@@ -100,7 +100,7 @@ Unfortunately, this will only give the expression in the argument, not the value
    import semmle.code.cpp.dataflow.DataFlow
 
    from Function fopen, FunctionCall fc, Expr src
-   where fopen.hasQualifiedName("fopen")
+   where fopen.hasGlobalName("fopen")
      and fc.getTarget() = fopen
      and DataFlow::localFlow(DataFlow::exprNode(src), DataFlow::exprNode(fc.getArgument(0)))
    select src
@@ -113,7 +113,7 @@ Then we can vary the source and, for example, use the parameter of a function. T
    import semmle.code.cpp.dataflow.DataFlow
 
    from Function fopen, FunctionCall fc, Parameter p
-   where fopen.hasQualifiedName("fopen")
+   where fopen.hasGlobalName("fopen")
      and fc.getTarget() = fopen
      and DataFlow::localFlow(DataFlow::parameterNode(p), DataFlow::exprNode(fc.getArgument(0)))
    select p
@@ -236,14 +236,14 @@ The following data flow configuration tracks data flow from environment variable
      override predicate isSource(DataFlow::Node source) {
        exists (Function getenv |
          source.asExpr().(FunctionCall).getTarget() = getenv and
-         getenv.hasQualifiedName("getenv")
+         getenv.hasGlobalName("getenv")
        )
      }
 
      override predicate isSink(DataFlow::Node sink) {
        exists (FunctionCall fc |
          sink.asExpr() = fc.getArgument(0) and
-         fc.getTarget().hasQualifiedName("fopen")
+         fc.getTarget().hasGlobalName("fopen")
        )
      }
    }
@@ -356,7 +356,7 @@ Exercise 3
 
    class GetenvSource extends FunctionCall {
      GetenvSource() {
-       this.getTarget().hasQualifiedName("getenv")
+       this.getTarget().hasGlobalName("getenv")
      }
    }
 
@@ -369,7 +369,7 @@ Exercise 4
 
    class GetenvSource extends DataFlow::Node {
      GetenvSource() {
-       this.asExpr().(FunctionCall).getTarget().hasQualifiedName("getenv")
+       this.asExpr().(FunctionCall).getTarget().hasGlobalName("getenv")
      }
    }
 

--- a/docs/codeql/codeql-language-guides/analyzing-data-flow-in-cpp.rst
+++ b/docs/codeql/codeql-language-guides/analyzing-data-flow-in-cpp.rst
@@ -2,7 +2,7 @@
 
 .. pull-quote:: Note
 
-   The data flow library described here will be deprecated in the near future. For the replacement library see :ref:`here <analyzing-data-flow-in-cpp-new>`.
+   The data flow library described here will be deprecated in the near future. For the replacement library, which is available from CodeQL 2.12.5 onwards, see :ref:`here <analyzing-data-flow-in-cpp-new>`.
 
 Analyzing data flow in C and C++
 ================================

--- a/docs/codeql/codeql-language-guides/codeql-for-cpp.rst
+++ b/docs/codeql/codeql-language-guides/codeql-for-cpp.rst
@@ -14,6 +14,7 @@ Experiment and learn how to write effective and efficient queries for CodeQL dat
    expressions-types-and-statements-in-cpp
    conversions-and-classes-in-cpp
    analyzing-data-flow-in-cpp
+   analyzing-data-flow-in-cpp-new
    refining-a-query-to-account-for-edge-cases
    detecting-a-potential-buffer-overflow
    using-the-guards-library-in-cpp


### PR DESCRIPTION
First attempt at writing a docs page for the new use-use dataflow library. Before looping in the docs people and James, it's seems sensible to get feedback from @github/codeql-c-analysis. This is cloned from the original C/C++ doc on dataflow, which describes a library we are going to deprecate in the near future.

Note that I dropped the `exprNode(expr)` and `parameterNode(param)` from the documentation compared to the original version. I did this as there are no equivalents for indirect expressions and parameters.