### PR TITLE
C++: Remove dead code

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
@@ -809,11 +809,6 @@ module SsaCached {
   predicate lastRefRedef(Definition def, IRBlock bb, int i, Definition next) {
     SsaImpl::lastRefRedef(def, bb, i, next)
   }
-
-  cached
-  predicate uncertainWriteDefinitionInput(SsaImpl::UncertainWriteDefinition def, Definition inp) {
-    SsaImpl::uncertainWriteDefinitionInput(def, inp)
-  }
 }
 
 cached


### PR DESCRIPTION
As of https://github.com/github/codeql/pull/12316 this predicate isn't used anymore.