### PR TITLE
C++: Include "phi reads" in `DataFlow::Node`

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -43,7 +43,7 @@ class Node0Impl extends TIRDataFlowNode0 {
   /**
    * Gets the type of this node.
    *
-   * If `asInstruction().isGLValue()` holds, then the type of this node
+   * If `isGLValue()` holds, then the type of this node
    * should be thought of as "pointer to `getType()`".
    */
   DataFlowType getType() { none() } // overridden in subclasses

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -498,7 +498,14 @@ class SsaPhiNode extends Node, TSsaPhiNode {
 
   override Declaration getFunction() { result = phi.getBasicBlock().getEnclosingFunction() }
 
-  override DataFlowType getType() { result = this.getAnInput().getType().getUnspecifiedType() }
+  override DataFlowType getType() {
+    exists(Ssa::SourceVariable sv |
+      this.getPhiNode().definesAt(sv, _, _, _) and
+      result = sv.getType()
+    )
+  }
+
+  override predicate isGLValue() { phi.getSourceVariable().isGLValue() }
 
   final override Location getLocationImpl() { result = phi.getBasicBlock().getLocation() }
 

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
@@ -48,6 +48,16 @@ private module SourceVariables {
      * indirections) of this source variable.
      */
     abstract BaseSourceVariable getBaseVariable();
+
+    /** Holds if this variable is a glvalue. */
+    predicate isGLValue() { none() }
+
+    /**
+     * Gets the type of this source variable. If `isGLValue()` holds, then
+     * the type of this source variable should be thought of as "pointer
+     * to `getType()`".
+     */
+    abstract DataFlowType getType();
   }
 
   class SourceIRVariable extends SourceVariable, TSourceIRVariable {
@@ -65,6 +75,12 @@ private module SourceVariables {
       or
       ind > 0 and
       result = this.getIRVariable().toString() + " indirection"
+    }
+
+    override predicate isGLValue() { ind = 0 }
+
+    override DataFlowType getType() {
+      if ind = 0 then result = var.getType() else result = getTypeImpl(var.getType(), ind - 1)
     }
   }
 
@@ -84,6 +100,8 @@ private module SourceVariables {
       ind > 0 and
       result = "Call indirection"
     }
+
+    override DataFlowType getType() { result = getTypeImpl(call.getResultType(), ind) }
   }
 }
 

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/ssa0/SsaInternals.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/ssa0/SsaInternals.qll
@@ -225,8 +225,8 @@ private newtype TSsaDefOrUse =
     or
     // If `defOrUse` is a definition we only include it if the
     // SSA library concludes that it's live after the write.
-    exists(Definition def, SourceVariable sv, IRBlock bb, int i |
-      def.definesAt(sv, bb, i) and
+    exists(DefinitionExt def, SourceVariable sv, IRBlock bb, int i |
+      def.definesAt(sv, bb, i, _) and
       defOrUse.(DefImpl).hasIndexInBlock(bb, i, sv)
     )
   } or
@@ -301,6 +301,11 @@ class Def extends DefOrUse {
 
 private module SsaImpl = SsaImplCommon::Make<SsaInput>;
 
-class PhiNode = SsaImpl::PhiNode;
+class PhiNode extends SsaImpl::DefinitionExt {
+  PhiNode() {
+    this instanceof SsaImpl::PhiNode or
+    this instanceof SsaImpl::PhiReadNode
+  }
+}
 
-class Definition = SsaImpl::Definition;
+class DefinitionExt = SsaImpl::DefinitionExt;

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
@@ -626,5 +626,5 @@ void test_def_via_phi_read(bool b)
     use(buffer);
   }
   intPointerSource(buffer);
-  sink(buffer); // $ ast MISSING: ir
+  sink(buffer); // $ ast,ir
 }

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
@@ -615,3 +615,16 @@ void test_flow_through_void_double_pointer(int *p) // $ ast-def=p
   void* q = (void*)&p;
   sink(**(int**)q); // $ ir MISSING: ast
 }
+
+void use(int *);
+
+void test_def_via_phi_read(bool b)
+{
+  static int buffer[10]; // This is missing an initialisation in IR dataflow
+  if (b)
+  {
+    use(buffer);
+  }
+  intPointerSource(buffer);
+  sink(buffer); // $ ast MISSING: ir
+}

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/type-bugs.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/type-bugs.expected
@@ -1,8 +1,3 @@
 failures
 astTypeBugs
 irTypeBugs
-| test.cpp:15:3:15:6 | test.cpp:15:3:15:6 | test.cpp:15:3:15:6 | Phi |
-| test.cpp:43:10:43:20 | test.cpp:43:10:43:20 | test.cpp:43:10:43:20 | Phi |
-| test.cpp:43:10:43:20 | test.cpp:43:10:43:20 | test.cpp:43:10:43:20 | Phi |
-| test.cpp:628:3:628:18 | test.cpp:628:3:628:18 | test.cpp:628:3:628:18 | Phi |
-| test.cpp:628:3:628:18 | test.cpp:628:3:628:18 | test.cpp:628:3:628:18 | Phi |

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/type-bugs.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/type-bugs.expected
@@ -1,3 +1,8 @@
 failures
 astTypeBugs
 irTypeBugs
+| test.cpp:15:3:15:6 | test.cpp:15:3:15:6 | test.cpp:15:3:15:6 | Phi |
+| test.cpp:43:10:43:20 | test.cpp:43:10:43:20 | test.cpp:43:10:43:20 | Phi |
+| test.cpp:43:10:43:20 | test.cpp:43:10:43:20 | test.cpp:43:10:43:20 | Phi |
+| test.cpp:628:3:628:18 | test.cpp:628:3:628:18 | test.cpp:628:3:628:18 | Phi |
+| test.cpp:628:3:628:18 | test.cpp:628:3:628:18 | test.cpp:628:3:628:18 | Phi |


### PR DESCRIPTION
In https://github.com/github/codeql/pull/11198 Tom added phi nodes for uses in the shared SSA library, but we haven't yet reaped the benefit of those in C++ since we've been using the backwards compatibility wrappers he made. This PR makes use of those new phi nodes for uses. It should give us a small performance boost 🤞.

[The first commit](d845cd7233117c805c9ac105b246eab8ccc04aff) does the real work, and the [second commit](34f8d4d3ebe549cc77d5b1a369c2583c4dc87a36) fixes a bug exposed by the tests.