### PR TITLE
Swift: Fill some gaps in arithmetic / bitwise operations modelling

### DIFF
--- a/swift/ql/lib/codeql/swift/dataflow/internal/TaintTrackingPrivate.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/TaintTrackingPrivate.qll
@@ -46,6 +46,9 @@ private module Cached {
     // allow flow through arithmetic (this case includes string concatenation)
     nodeTo.asExpr().(ArithmeticOperation).getAnOperand() = nodeFrom.asExpr()
     or
+    // allow flow through bitwise operations
+    nodeTo.asExpr().(BitwiseOperation).getAnOperand() = nodeFrom.asExpr()
+    or
     // allow flow through assignment operations (e.g. `+=`)
     exists(AssignOperation op |
       nodeFrom.asExpr() = op.getSource() and

--- a/swift/ql/lib/codeql/swift/elements/expr/ArithmeticOperation.qll
+++ b/swift/ql/lib/codeql/swift/elements/expr/ArithmeticOperation.qll
@@ -45,30 +45,33 @@ class BinaryArithmeticOperation extends BinaryExpr {
  * An add expression.
  * ```
  * a + b
+ * a &+ b
  * ```
  */
 class AddExpr extends BinaryExpr {
-  AddExpr() { this.getStaticTarget().getName() = "+(_:_:)" }
+  AddExpr() { this.getStaticTarget().getName() = ["+(_:_:)", "&+(_:_:)"] }
 }
 
 /**
  * A subtract expression.
  * ```
  * a - b
+ * a &- b
  * ```
  */
 class SubExpr extends BinaryExpr {
-  SubExpr() { this.getStaticTarget().getName() = "-(_:_:)" }
+  SubExpr() { this.getStaticTarget().getName() = ["-(_:_:)", "&-(_:_:)"] }
 }
 
 /**
  * A multiply expression.
  * ```
  * a * b
+ * a &* b
  * ```
  */
 class MulExpr extends BinaryExpr {
-  MulExpr() { this.getStaticTarget().getName() = "*(_:_:)" }
+  MulExpr() { this.getStaticTarget().getName() = ["*(_:_:)", "&*(_:_:)"] }
 }
 
 /**

--- a/swift/ql/lib/codeql/swift/elements/expr/BitwiseOperation.qll
+++ b/swift/ql/lib/codeql/swift/elements/expr/BitwiseOperation.qll
@@ -73,20 +73,22 @@ class XorBitwiseExpr extends BinaryExpr {
  * A bitwise shift left expression.
  * ```
  * a << b
+ * a &<<
  * ```
  */
 class ShiftLeftBitwiseExpr extends BinaryExpr {
-  ShiftLeftBitwiseExpr() { this.getStaticTarget().getName() = "<<(_:_:)" }
+  ShiftLeftBitwiseExpr() { this.getStaticTarget().getName() = ["<<(_:_:)", "&<<(_:_:)"] }
 }
 
 /**
  * A bitwise shift right expression.
  * ```
  * a >> b
+ * a &>>
  * ```
  */
 class ShiftRightBitwiseExpr extends BinaryExpr {
-  ShiftRightBitwiseExpr() { this.getStaticTarget().getName() = ">>(_:_:)" }
+  ShiftRightBitwiseExpr() { this.getStaticTarget().getName() = [">>(_:_:)", "&>>(_:_:)"] }
 }
 
 /**

--- a/swift/ql/lib/codeql/swift/elements/expr/BitwiseOperation.qll
+++ b/swift/ql/lib/codeql/swift/elements/expr/BitwiseOperation.qll
@@ -6,6 +6,8 @@ private import codeql.swift.elements.expr.PrefixUnaryExpr
  * A bitwise operation, such as:
  * ```
  * a & b
+ * a << b
+ * ~a
  * ```
  */
 class BitwiseOperation extends Expr {
@@ -27,6 +29,8 @@ class BitwiseOperation extends Expr {
  * A binary bitwise operation, such as:
  * ```
  * a & b
+ * a << b
+ * a .^ b
  * ```
  */
 class BinaryBitwiseOperation extends BinaryExpr {
@@ -34,6 +38,9 @@ class BinaryBitwiseOperation extends BinaryExpr {
     this instanceof AndBitwiseExpr or
     this instanceof OrBitwiseExpr or
     this instanceof XorBitwiseExpr or
+    this instanceof PointwiseAndExpr or
+    this instanceof PointwiseOrExpr or
+    this instanceof PointwiseXorExpr or
     this instanceof ShiftLeftBitwiseExpr or
     this instanceof ShiftRightBitwiseExpr
   }
@@ -67,6 +74,36 @@ class OrBitwiseExpr extends BinaryExpr {
  */
 class XorBitwiseExpr extends BinaryExpr {
   XorBitwiseExpr() { this.getStaticTarget().getName() = "^(_:_:)" }
+}
+
+/**
+ * A pointwise bitwise-and expression:
+ * ```
+ * a .& b
+ * ```
+ */
+class PointwiseAndExpr extends BinaryExpr {
+  PointwiseAndExpr() { this.getOperator().getName() = ".&(_:_:)" }
+}
+
+/**
+ * A pointwise bitwise-or expression:
+ * ```
+ * a .| b
+ * ```
+ */
+class PointwiseOrExpr extends BinaryExpr {
+  PointwiseOrExpr() { this.getOperator().getName() = ".|(_:_:)" }
+}
+
+/**
+ * A pointwise bitwise exclusive-or expression:
+ * ```
+ * a .^ b
+ * ```
+ */
+class PointwiseXorExpr extends BinaryExpr {
+  PointwiseXorExpr() { this.getOperator().getName() = ".^(_:_:)" }
 }
 
 /**

--- a/swift/ql/test/library-tests/dataflow/taint/core/LocalTaint.expected
+++ b/swift/ql/test/library-tests/dataflow/taint/core/LocalTaint.expected
@@ -19,6 +19,18 @@
 | simple.swift:21:13:21:20 | call to source() | simple.swift:21:13:21:24 | ... .%(_:_:) ... |
 | simple.swift:21:24:21:24 | 100 | simple.swift:21:13:21:24 | ... .%(_:_:) ... |
 | simple.swift:23:14:23:21 | call to source() | simple.swift:23:13:23:21 | call to -(_:) |
+| simple.swift:27:13:27:13 | 1 | simple.swift:27:13:27:25 | ... .&+(_:_:) ... |
+| simple.swift:27:18:27:25 | call to source() | simple.swift:27:13:27:25 | ... .&+(_:_:) ... |
+| simple.swift:28:13:28:20 | call to source() | simple.swift:28:13:28:25 | ... .&+(_:_:) ... |
+| simple.swift:28:25:28:25 | 1 | simple.swift:28:13:28:25 | ... .&+(_:_:) ... |
+| simple.swift:29:13:29:13 | 1 | simple.swift:29:13:29:25 | ... .&-(_:_:) ... |
+| simple.swift:29:18:29:25 | call to source() | simple.swift:29:13:29:25 | ... .&-(_:_:) ... |
+| simple.swift:30:13:30:20 | call to source() | simple.swift:30:13:30:25 | ... .&-(_:_:) ... |
+| simple.swift:30:25:30:25 | 1 | simple.swift:30:13:30:25 | ... .&-(_:_:) ... |
+| simple.swift:31:13:31:13 | 2 | simple.swift:31:13:31:25 | ... .&*(_:_:) ... |
+| simple.swift:31:18:31:25 | call to source() | simple.swift:31:13:31:25 | ... .&*(_:_:) ... |
+| simple.swift:32:13:32:20 | call to source() | simple.swift:32:13:32:25 | ... .&*(_:_:) ... |
+| simple.swift:32:25:32:25 | 2 | simple.swift:32:13:32:25 | ... .&*(_:_:) ... |
 | simple.swift:36:7:36:7 | SSA def(a) | simple.swift:37:13:37:13 | a |
 | simple.swift:36:11:36:11 | 0 | simple.swift:36:7:36:7 | SSA def(a) |
 | simple.swift:37:13:37:13 | [post] a | simple.swift:38:3:38:3 | a |

--- a/swift/ql/test/library-tests/dataflow/taint/core/LocalTaint.expected
+++ b/swift/ql/test/library-tests/dataflow/taint/core/LocalTaint.expected
@@ -101,6 +101,27 @@
 | simple.swift:68:3:68:3 | [post] &... | simple.swift:69:13:69:13 | e |
 | simple.swift:68:3:68:3 | e | simple.swift:68:3:68:3 | &... |
 | simple.swift:68:8:68:8 | 100 | simple.swift:68:3:68:3 | &... |
+| simple.swift:73:13:73:13 | 0 | simple.swift:73:13:73:24 | ... .\|(_:_:) ... |
+| simple.swift:73:17:73:24 | call to source() | simple.swift:73:13:73:24 | ... .\|(_:_:) ... |
+| simple.swift:74:13:74:20 | call to source() | simple.swift:74:13:74:24 | ... .\|(_:_:) ... |
+| simple.swift:74:24:74:24 | 0 | simple.swift:74:13:74:24 | ... .\|(_:_:) ... |
+| simple.swift:76:13:76:13 | 0xffff | simple.swift:76:13:76:29 | ... .&(_:_:) ... |
+| simple.swift:76:22:76:29 | call to source() | simple.swift:76:13:76:29 | ... .&(_:_:) ... |
+| simple.swift:77:13:77:20 | call to source() | simple.swift:77:13:77:24 | ... .&(_:_:) ... |
+| simple.swift:77:24:77:24 | 0xffff | simple.swift:77:13:77:24 | ... .&(_:_:) ... |
+| simple.swift:79:13:79:13 | 0xffff | simple.swift:79:13:79:29 | ... .^(_:_:) ... |
+| simple.swift:79:22:79:29 | call to source() | simple.swift:79:13:79:29 | ... .^(_:_:) ... |
+| simple.swift:80:13:80:20 | call to source() | simple.swift:80:13:80:24 | ... .^(_:_:) ... |
+| simple.swift:80:24:80:24 | 0xffff | simple.swift:80:13:80:24 | ... .^(_:_:) ... |
+| simple.swift:82:13:82:20 | call to source() | simple.swift:82:13:82:25 | ... .<<(_:_:) ... |
+| simple.swift:82:25:82:25 | 1 | simple.swift:82:13:82:25 | ... .<<(_:_:) ... |
+| simple.swift:83:13:83:20 | call to source() | simple.swift:83:13:83:26 | ... .&<<(_:_:) ... |
+| simple.swift:83:26:83:26 | 1 | simple.swift:83:13:83:26 | ... .&<<(_:_:) ... |
+| simple.swift:84:13:84:20 | call to source() | simple.swift:84:13:84:25 | ... .>>(_:_:) ... |
+| simple.swift:84:25:84:25 | 1 | simple.swift:84:13:84:25 | ... .>>(_:_:) ... |
+| simple.swift:85:13:85:20 | call to source() | simple.swift:85:13:85:26 | ... .&>>(_:_:) ... |
+| simple.swift:85:26:85:26 | 1 | simple.swift:85:13:85:26 | ... .&>>(_:_:) ... |
+| simple.swift:87:14:87:21 | call to source() | simple.swift:87:13:87:21 | call to ~(_:) |
 | subscript.swift:1:7:1:7 | SSA def(self) | subscript.swift:1:7:1:7 | self[return] |
 | subscript.swift:1:7:1:7 | SSA def(self) | subscript.swift:1:7:1:7 | self[return] |
 | subscript.swift:1:7:1:7 | self | subscript.swift:1:7:1:7 | SSA def(self) |

--- a/swift/ql/test/library-tests/dataflow/taint/core/Taint.expected
+++ b/swift/ql/test/library-tests/dataflow/taint/core/Taint.expected
@@ -26,6 +26,17 @@ edges
 | simple.swift:60:8:60:15 | call to source() :  | simple.swift:63:13:63:13 | d |
 | simple.swift:66:8:66:15 | call to source() :  | simple.swift:67:13:67:13 | e |
 | simple.swift:66:8:66:15 | call to source() :  | simple.swift:69:13:69:13 | e |
+| simple.swift:73:17:73:24 | call to source() :  | simple.swift:73:13:73:24 | ... .\|(_:_:) ... |
+| simple.swift:74:13:74:20 | call to source() :  | simple.swift:74:13:74:24 | ... .\|(_:_:) ... |
+| simple.swift:76:22:76:29 | call to source() :  | simple.swift:76:13:76:29 | ... .&(_:_:) ... |
+| simple.swift:77:13:77:20 | call to source() :  | simple.swift:77:13:77:24 | ... .&(_:_:) ... |
+| simple.swift:79:22:79:29 | call to source() :  | simple.swift:79:13:79:29 | ... .^(_:_:) ... |
+| simple.swift:80:13:80:20 | call to source() :  | simple.swift:80:13:80:24 | ... .^(_:_:) ... |
+| simple.swift:82:13:82:20 | call to source() :  | simple.swift:82:13:82:25 | ... .<<(_:_:) ... |
+| simple.swift:83:13:83:20 | call to source() :  | simple.swift:83:13:83:26 | ... .&<<(_:_:) ... |
+| simple.swift:84:13:84:20 | call to source() :  | simple.swift:84:13:84:25 | ... .>>(_:_:) ... |
+| simple.swift:85:13:85:20 | call to source() :  | simple.swift:85:13:85:26 | ... .&>>(_:_:) ... |
+| simple.swift:87:14:87:21 | call to source() :  | simple.swift:87:13:87:21 | call to ~(_:) |
 | subscript.swift:13:15:13:22 | call to source() :  | subscript.swift:13:15:13:25 | ...[...] |
 | subscript.swift:14:15:14:23 | call to source2() :  | subscript.swift:14:15:14:26 | ...[...] |
 | try.swift:9:17:9:24 | call to source() :  | try.swift:9:13:9:24 | try ... |
@@ -81,6 +92,28 @@ nodes
 | simple.swift:66:8:66:15 | call to source() :  | semmle.label | call to source() :  |
 | simple.swift:67:13:67:13 | e | semmle.label | e |
 | simple.swift:69:13:69:13 | e | semmle.label | e |
+| simple.swift:73:13:73:24 | ... .\|(_:_:) ... | semmle.label | ... .\|(_:_:) ... |
+| simple.swift:73:17:73:24 | call to source() :  | semmle.label | call to source() :  |
+| simple.swift:74:13:74:20 | call to source() :  | semmle.label | call to source() :  |
+| simple.swift:74:13:74:24 | ... .\|(_:_:) ... | semmle.label | ... .\|(_:_:) ... |
+| simple.swift:76:13:76:29 | ... .&(_:_:) ... | semmle.label | ... .&(_:_:) ... |
+| simple.swift:76:22:76:29 | call to source() :  | semmle.label | call to source() :  |
+| simple.swift:77:13:77:20 | call to source() :  | semmle.label | call to source() :  |
+| simple.swift:77:13:77:24 | ... .&(_:_:) ... | semmle.label | ... .&(_:_:) ... |
+| simple.swift:79:13:79:29 | ... .^(_:_:) ... | semmle.label | ... .^(_:_:) ... |
+| simple.swift:79:22:79:29 | call to source() :  | semmle.label | call to source() :  |
+| simple.swift:80:13:80:20 | call to source() :  | semmle.label | call to source() :  |
+| simple.swift:80:13:80:24 | ... .^(_:_:) ... | semmle.label | ... .^(_:_:) ... |
+| simple.swift:82:13:82:20 | call to source() :  | semmle.label | call to source() :  |
+| simple.swift:82:13:82:25 | ... .<<(_:_:) ... | semmle.label | ... .<<(_:_:) ... |
+| simple.swift:83:13:83:20 | call to source() :  | semmle.label | call to source() :  |
+| simple.swift:83:13:83:26 | ... .&<<(_:_:) ... | semmle.label | ... .&<<(_:_:) ... |
+| simple.swift:84:13:84:20 | call to source() :  | semmle.label | call to source() :  |
+| simple.swift:84:13:84:25 | ... .>>(_:_:) ... | semmle.label | ... .>>(_:_:) ... |
+| simple.swift:85:13:85:20 | call to source() :  | semmle.label | call to source() :  |
+| simple.swift:85:13:85:26 | ... .&>>(_:_:) ... | semmle.label | ... .&>>(_:_:) ... |
+| simple.swift:87:13:87:21 | call to ~(_:) | semmle.label | call to ~(_:) |
+| simple.swift:87:14:87:21 | call to source() :  | semmle.label | call to source() :  |
 | subscript.swift:13:15:13:22 | call to source() :  | semmle.label | call to source() :  |
 | subscript.swift:13:15:13:25 | ...[...] | semmle.label | ...[...] |
 | subscript.swift:14:15:14:23 | call to source2() :  | semmle.label | call to source2() :  |
@@ -120,6 +153,17 @@ subpaths
 | simple.swift:63:13:63:13 | d | simple.swift:60:8:60:15 | call to source() :  | simple.swift:63:13:63:13 | d | result |
 | simple.swift:67:13:67:13 | e | simple.swift:66:8:66:15 | call to source() :  | simple.swift:67:13:67:13 | e | result |
 | simple.swift:69:13:69:13 | e | simple.swift:66:8:66:15 | call to source() :  | simple.swift:69:13:69:13 | e | result |
+| simple.swift:73:13:73:24 | ... .\|(_:_:) ... | simple.swift:73:17:73:24 | call to source() :  | simple.swift:73:13:73:24 | ... .\|(_:_:) ... | result |
+| simple.swift:74:13:74:24 | ... .\|(_:_:) ... | simple.swift:74:13:74:20 | call to source() :  | simple.swift:74:13:74:24 | ... .\|(_:_:) ... | result |
+| simple.swift:76:13:76:29 | ... .&(_:_:) ... | simple.swift:76:22:76:29 | call to source() :  | simple.swift:76:13:76:29 | ... .&(_:_:) ... | result |
+| simple.swift:77:13:77:24 | ... .&(_:_:) ... | simple.swift:77:13:77:20 | call to source() :  | simple.swift:77:13:77:24 | ... .&(_:_:) ... | result |
+| simple.swift:79:13:79:29 | ... .^(_:_:) ... | simple.swift:79:22:79:29 | call to source() :  | simple.swift:79:13:79:29 | ... .^(_:_:) ... | result |
+| simple.swift:80:13:80:24 | ... .^(_:_:) ... | simple.swift:80:13:80:20 | call to source() :  | simple.swift:80:13:80:24 | ... .^(_:_:) ... | result |
+| simple.swift:82:13:82:25 | ... .<<(_:_:) ... | simple.swift:82:13:82:20 | call to source() :  | simple.swift:82:13:82:25 | ... .<<(_:_:) ... | result |
+| simple.swift:83:13:83:26 | ... .&<<(_:_:) ... | simple.swift:83:13:83:20 | call to source() :  | simple.swift:83:13:83:26 | ... .&<<(_:_:) ... | result |
+| simple.swift:84:13:84:25 | ... .>>(_:_:) ... | simple.swift:84:13:84:20 | call to source() :  | simple.swift:84:13:84:25 | ... .>>(_:_:) ... | result |
+| simple.swift:85:13:85:26 | ... .&>>(_:_:) ... | simple.swift:85:13:85:20 | call to source() :  | simple.swift:85:13:85:26 | ... .&>>(_:_:) ... | result |
+| simple.swift:87:13:87:21 | call to ~(_:) | simple.swift:87:14:87:21 | call to source() :  | simple.swift:87:13:87:21 | call to ~(_:) | result |
 | subscript.swift:13:15:13:25 | ...[...] | subscript.swift:13:15:13:22 | call to source() :  | subscript.swift:13:15:13:25 | ...[...] | result |
 | subscript.swift:14:15:14:26 | ...[...] | subscript.swift:14:15:14:23 | call to source2() :  | subscript.swift:14:15:14:26 | ...[...] | result |
 | try.swift:9:13:9:24 | try ... | try.swift:9:17:9:24 | call to source() :  | try.swift:9:13:9:24 | try ... | result |

--- a/swift/ql/test/library-tests/dataflow/taint/core/Taint.expected
+++ b/swift/ql/test/library-tests/dataflow/taint/core/Taint.expected
@@ -10,6 +10,12 @@ edges
 | simple.swift:20:19:20:26 | call to source() :  | simple.swift:20:13:20:26 | ... .%(_:_:) ... |
 | simple.swift:21:13:21:20 | call to source() :  | simple.swift:21:13:21:24 | ... .%(_:_:) ... |
 | simple.swift:23:14:23:21 | call to source() :  | simple.swift:23:13:23:21 | call to -(_:) |
+| simple.swift:27:18:27:25 | call to source() :  | simple.swift:27:13:27:25 | ... .&+(_:_:) ... |
+| simple.swift:28:13:28:20 | call to source() :  | simple.swift:28:13:28:25 | ... .&+(_:_:) ... |
+| simple.swift:29:18:29:25 | call to source() :  | simple.swift:29:13:29:25 | ... .&-(_:_:) ... |
+| simple.swift:30:13:30:20 | call to source() :  | simple.swift:30:13:30:25 | ... .&-(_:_:) ... |
+| simple.swift:31:18:31:25 | call to source() :  | simple.swift:31:13:31:25 | ... .&*(_:_:) ... |
+| simple.swift:32:13:32:20 | call to source() :  | simple.swift:32:13:32:25 | ... .&*(_:_:) ... |
 | simple.swift:40:8:40:15 | call to source() :  | simple.swift:41:13:41:13 | a |
 | simple.swift:40:8:40:15 | call to source() :  | simple.swift:43:13:43:13 | a |
 | simple.swift:48:8:48:15 | call to source() :  | simple.swift:49:13:49:13 | b |
@@ -48,6 +54,18 @@ nodes
 | simple.swift:21:13:21:24 | ... .%(_:_:) ... | semmle.label | ... .%(_:_:) ... |
 | simple.swift:23:13:23:21 | call to -(_:) | semmle.label | call to -(_:) |
 | simple.swift:23:14:23:21 | call to source() :  | semmle.label | call to source() :  |
+| simple.swift:27:13:27:25 | ... .&+(_:_:) ... | semmle.label | ... .&+(_:_:) ... |
+| simple.swift:27:18:27:25 | call to source() :  | semmle.label | call to source() :  |
+| simple.swift:28:13:28:20 | call to source() :  | semmle.label | call to source() :  |
+| simple.swift:28:13:28:25 | ... .&+(_:_:) ... | semmle.label | ... .&+(_:_:) ... |
+| simple.swift:29:13:29:25 | ... .&-(_:_:) ... | semmle.label | ... .&-(_:_:) ... |
+| simple.swift:29:18:29:25 | call to source() :  | semmle.label | call to source() :  |
+| simple.swift:30:13:30:20 | call to source() :  | semmle.label | call to source() :  |
+| simple.swift:30:13:30:25 | ... .&-(_:_:) ... | semmle.label | ... .&-(_:_:) ... |
+| simple.swift:31:13:31:25 | ... .&*(_:_:) ... | semmle.label | ... .&*(_:_:) ... |
+| simple.swift:31:18:31:25 | call to source() :  | semmle.label | call to source() :  |
+| simple.swift:32:13:32:20 | call to source() :  | semmle.label | call to source() :  |
+| simple.swift:32:13:32:25 | ... .&*(_:_:) ... | semmle.label | ... .&*(_:_:) ... |
 | simple.swift:40:8:40:15 | call to source() :  | semmle.label | call to source() :  |
 | simple.swift:41:13:41:13 | a | semmle.label | a |
 | simple.swift:43:13:43:13 | a | semmle.label | a |
@@ -86,6 +104,12 @@ subpaths
 | simple.swift:20:13:20:26 | ... .%(_:_:) ... | simple.swift:20:19:20:26 | call to source() :  | simple.swift:20:13:20:26 | ... .%(_:_:) ... | result |
 | simple.swift:21:13:21:24 | ... .%(_:_:) ... | simple.swift:21:13:21:20 | call to source() :  | simple.swift:21:13:21:24 | ... .%(_:_:) ... | result |
 | simple.swift:23:13:23:21 | call to -(_:) | simple.swift:23:14:23:21 | call to source() :  | simple.swift:23:13:23:21 | call to -(_:) | result |
+| simple.swift:27:13:27:25 | ... .&+(_:_:) ... | simple.swift:27:18:27:25 | call to source() :  | simple.swift:27:13:27:25 | ... .&+(_:_:) ... | result |
+| simple.swift:28:13:28:25 | ... .&+(_:_:) ... | simple.swift:28:13:28:20 | call to source() :  | simple.swift:28:13:28:25 | ... .&+(_:_:) ... | result |
+| simple.swift:29:13:29:25 | ... .&-(_:_:) ... | simple.swift:29:18:29:25 | call to source() :  | simple.swift:29:13:29:25 | ... .&-(_:_:) ... | result |
+| simple.swift:30:13:30:25 | ... .&-(_:_:) ... | simple.swift:30:13:30:20 | call to source() :  | simple.swift:30:13:30:25 | ... .&-(_:_:) ... | result |
+| simple.swift:31:13:31:25 | ... .&*(_:_:) ... | simple.swift:31:18:31:25 | call to source() :  | simple.swift:31:13:31:25 | ... .&*(_:_:) ... | result |
+| simple.swift:32:13:32:25 | ... .&*(_:_:) ... | simple.swift:32:13:32:20 | call to source() :  | simple.swift:32:13:32:25 | ... .&*(_:_:) ... | result |
 | simple.swift:41:13:41:13 | a | simple.swift:40:8:40:15 | call to source() :  | simple.swift:41:13:41:13 | a | result |
 | simple.swift:43:13:43:13 | a | simple.swift:40:8:40:15 | call to source() :  | simple.swift:43:13:43:13 | a | result |
 | simple.swift:49:13:49:13 | b | simple.swift:48:8:48:15 | call to source() :  | simple.swift:49:13:49:13 | b | result |

--- a/swift/ql/test/library-tests/dataflow/taint/core/simple.swift
+++ b/swift/ql/test/library-tests/dataflow/taint/core/simple.swift
@@ -24,12 +24,12 @@ func taintThroughArithmetic() {
 
   // overflow operators
 
-  sink(arg: 1 &+ source()) // $ MISSING: tainted=
-  sink(arg: source() &+ 1) // $ MISSING: tainted=
-  sink(arg: 1 &- source()) // $ MISSING: tainted=
-  sink(arg: source() &- 1) // $ MISSING: tainted=
-  sink(arg: 2 &* source()) // $ MISSING: tainted=
-  sink(arg: source() &* 2) // $ MISSING: tainted=
+  sink(arg: 1 &+ source()) // $ tainted=27
+  sink(arg: source() &+ 1) // $ tainted=28
+  sink(arg: 1 &- source()) // $ tainted=29
+  sink(arg: source() &- 1) // $ tainted=30
+  sink(arg: 2 &* source()) // $ tainted=31
+  sink(arg: source() &* 2) // $ tainted=32
 }
 
 func taintThroughAssignmentArithmetic() {

--- a/swift/ql/test/library-tests/dataflow/taint/core/simple.swift
+++ b/swift/ql/test/library-tests/dataflow/taint/core/simple.swift
@@ -68,3 +68,21 @@ func taintThroughAssignmentArithmetic() {
   e %= 100
   sink(arg: e) // $ tainted=66
 }
+
+func taintThroughBitwiseOperators() {
+  sink(arg: 0 | source()) // $ MISSING: tainted=73
+  sink(arg: source() | 0) // $ MISSING: tainted=74
+
+  sink(arg: 0xffff & source()) // $ MISSING: tainted=76
+  sink(arg: source() & 0xffff) // $ MISSING: tainted=77
+
+  sink(arg: 0xffff ^ source()) // $ MISSING: tainted=79
+  sink(arg: source() ^ 0xffff) // $ MISSING: tainted=80
+
+  sink(arg: source() << 1) // $ MISSING: tainted=82
+  sink(arg: source() &<< 1) // $ MISSING: tainted=83
+  sink(arg: source() >> 1) // $ MISSING: tainted=84
+  sink(arg: source() &>> 1) // $ MISSING: tainted=85
+
+  sink(arg: ~source()) // $ MISSING: tainted=87
+}

--- a/swift/ql/test/library-tests/dataflow/taint/core/simple.swift
+++ b/swift/ql/test/library-tests/dataflow/taint/core/simple.swift
@@ -70,19 +70,19 @@ func taintThroughAssignmentArithmetic() {
 }
 
 func taintThroughBitwiseOperators() {
-  sink(arg: 0 | source()) // $ MISSING: tainted=73
-  sink(arg: source() | 0) // $ MISSING: tainted=74
+  sink(arg: 0 | source()) // $ tainted=73
+  sink(arg: source() | 0) // $ tainted=74
 
-  sink(arg: 0xffff & source()) // $ MISSING: tainted=76
-  sink(arg: source() & 0xffff) // $ MISSING: tainted=77
+  sink(arg: 0xffff & source()) // $ tainted=76
+  sink(arg: source() & 0xffff) // $ tainted=77
 
-  sink(arg: 0xffff ^ source()) // $ MISSING: tainted=79
-  sink(arg: source() ^ 0xffff) // $ MISSING: tainted=80
+  sink(arg: 0xffff ^ source()) // $ tainted=79
+  sink(arg: source() ^ 0xffff) // $ tainted=80
 
-  sink(arg: source() << 1) // $ MISSING: tainted=82
-  sink(arg: source() &<< 1) // $ MISSING: tainted=83
-  sink(arg: source() >> 1) // $ MISSING: tainted=84
-  sink(arg: source() &>> 1) // $ MISSING: tainted=85
+  sink(arg: source() << 1) // $ tainted=82
+  sink(arg: source() &<< 1) // $ tainted=83
+  sink(arg: source() >> 1) // $ tainted=84
+  sink(arg: source() &>> 1) // $ tainted=85
 
-  sink(arg: ~source()) // $ MISSING: tainted=87
+  sink(arg: ~source()) // $ tainted=87
 }

--- a/swift/ql/test/library-tests/elements/expr/arithmeticoperation/arithmeticoperation.expected
+++ b/swift/ql/test/library-tests/elements/expr/arithmeticoperation/arithmeticoperation.expected
@@ -5,6 +5,6 @@
 | arithmeticoperation.swift:10:6:10:10 | ... .%(_:_:) ... | BinaryArithmeticOperation, RemExpr |
 | arithmeticoperation.swift:11:6:11:7 | call to -(_:) | UnaryArithmeticOperation, UnaryMinusExpr |
 | arithmeticoperation.swift:12:6:12:7 | call to +(_:) | UnaryArithmeticOperation, UnaryPlusExpr |
-| arithmeticoperation.swift:15:8:15:13 | ... .&+(_:_:) ... | AddExpr, BinaryArithmeticOperation |
-| arithmeticoperation.swift:16:8:16:13 | ... .&-(_:_:) ... | BinaryArithmeticOperation, SubExpr |
-| arithmeticoperation.swift:17:8:17:13 | ... .&*(_:_:) ... | BinaryArithmeticOperation, MulExpr |
+| arithmeticoperation.swift:15:6:15:11 | ... .&+(_:_:) ... | AddExpr, BinaryArithmeticOperation |
+| arithmeticoperation.swift:16:6:16:11 | ... .&-(_:_:) ... | BinaryArithmeticOperation, SubExpr |
+| arithmeticoperation.swift:17:6:17:11 | ... .&*(_:_:) ... | BinaryArithmeticOperation, MulExpr |

--- a/swift/ql/test/library-tests/elements/expr/arithmeticoperation/arithmeticoperation.expected
+++ b/swift/ql/test/library-tests/elements/expr/arithmeticoperation/arithmeticoperation.expected
@@ -5,3 +5,6 @@
 | arithmeticoperation.swift:10:6:10:10 | ... .%(_:_:) ... | BinaryArithmeticOperation, RemExpr |
 | arithmeticoperation.swift:11:6:11:7 | call to -(_:) | UnaryArithmeticOperation, UnaryMinusExpr |
 | arithmeticoperation.swift:12:6:12:7 | call to +(_:) | UnaryArithmeticOperation, UnaryPlusExpr |
+| arithmeticoperation.swift:15:8:15:13 | ... .&+(_:_:) ... | AddExpr, BinaryArithmeticOperation |
+| arithmeticoperation.swift:16:8:16:13 | ... .&-(_:_:) ... | BinaryArithmeticOperation, SubExpr |
+| arithmeticoperation.swift:17:8:17:13 | ... .&*(_:_:) ... | BinaryArithmeticOperation, MulExpr |

--- a/swift/ql/test/library-tests/elements/expr/arithmeticoperation/arithmeticoperation.swift
+++ b/swift/ql/test/library-tests/elements/expr/arithmeticoperation/arithmeticoperation.swift
@@ -11,8 +11,8 @@ func test(c: Bool, x: Int, y: Int, z: Int) {
 	v = -x;
 	v = +x;
 
-   // arithmetic operations with overflow
-   v = x &+ y;
-   v = x &- y;
-   v = x &* y;
+	// arithmetic operations with overflow
+	v = x &+ y;
+	v = x &- y;
+	v = x &* y;
 }

--- a/swift/ql/test/library-tests/elements/expr/arithmeticoperation/arithmeticoperation.swift
+++ b/swift/ql/test/library-tests/elements/expr/arithmeticoperation/arithmeticoperation.swift
@@ -12,7 +12,7 @@ func test(c: Bool, x: Int, y: Int, z: Int) {
 	v = +x;
 
    // arithmetic operations with overflow
-   v = x &+ y; // NOT DETECTED
-   v = x &- y; // NOT DETECTED
-   v = x &* y; // NOT DETECTED
+   v = x &+ y;
+   v = x &- y;
+   v = x &* y;
 }

--- a/swift/ql/test/library-tests/elements/expr/arithmeticoperation/arithmeticoperation.swift
+++ b/swift/ql/test/library-tests/elements/expr/arithmeticoperation/arithmeticoperation.swift
@@ -10,4 +10,9 @@ func test(c: Bool, x: Int, y: Int, z: Int) {
 	v = x % y;
 	v = -x;
 	v = +x;
+
+   // arithmetic operations with overflow
+   v = x &+ y; // NOT DETECTED
+   v = x &- y; // NOT DETECTED
+   v = x &* y; // NOT DETECTED
 }

--- a/swift/ql/test/library-tests/elements/expr/bitwiseopration/bitwiseoperation.expected
+++ b/swift/ql/test/library-tests/elements/expr/bitwiseopration/bitwiseoperation.expected
@@ -4,3 +4,5 @@
 | bitwiseoperation.swift:5:7:5:11 | ... .^(_:_:) ... | BinaryBitwiseOperation, XorBitwiseExpr |
 | bitwiseoperation.swift:6:7:6:12 | ... .<<(_:_:) ... | BinaryBitwiseOperation, ShiftLeftBitwiseExpr |
 | bitwiseoperation.swift:7:7:7:12 | ... .>>(_:_:) ... | BinaryBitwiseOperation, ShiftRightBitwiseExpr |
+| bitwiseoperation.swift:10:7:10:13 | ... .&<<(_:_:) ... | BinaryBitwiseOperation, ShiftLeftBitwiseExpr |
+| bitwiseoperation.swift:11:7:11:13 | ... .&>>(_:_:) ... | BinaryBitwiseOperation, ShiftRightBitwiseExpr |

--- a/swift/ql/test/library-tests/elements/expr/bitwiseopration/bitwiseoperation.expected
+++ b/swift/ql/test/library-tests/elements/expr/bitwiseopration/bitwiseoperation.expected
@@ -6,3 +6,6 @@
 | bitwiseoperation.swift:7:7:7:12 | ... .>>(_:_:) ... | BinaryBitwiseOperation, ShiftRightBitwiseExpr |
 | bitwiseoperation.swift:10:7:10:13 | ... .&<<(_:_:) ... | BinaryBitwiseOperation, ShiftLeftBitwiseExpr |
 | bitwiseoperation.swift:11:7:11:13 | ... .&>>(_:_:) ... | BinaryBitwiseOperation, ShiftRightBitwiseExpr |
+| bitwiseoperation.swift:17:7:17:12 | ... ..&(_:_:) ... | BinaryBitwiseOperation, PointwiseAndExpr |
+| bitwiseoperation.swift:18:7:18:12 | ... ..\|(_:_:) ... | BinaryBitwiseOperation, PointwiseOrExpr |
+| bitwiseoperation.swift:19:7:19:12 | ... ..^(_:_:) ... | BinaryBitwiseOperation, PointwiseXorExpr |

--- a/swift/ql/test/library-tests/elements/expr/bitwiseopration/bitwiseoperation.ql
+++ b/swift/ql/test/library-tests/elements/expr/bitwiseopration/bitwiseoperation.ql
@@ -9,6 +9,12 @@ string describe(BitwiseOperation e) {
   or
   e instanceof XorBitwiseExpr and result = "XorBitwiseExpr"
   or
+  e instanceof PointwiseAndExpr and result = "PointwiseAndExpr"
+  or
+  e instanceof PointwiseOrExpr and result = "PointwiseOrExpr"
+  or
+  e instanceof PointwiseXorExpr and result = "PointwiseXorExpr"
+  or
   e instanceof ShiftLeftBitwiseExpr and result = "ShiftLeftBitwiseExpr"
   or
   e instanceof ShiftRightBitwiseExpr and result = "ShiftRightBitwiseExpr"

--- a/swift/ql/test/library-tests/elements/expr/bitwiseopration/bitwiseoperation.swift
+++ b/swift/ql/test/library-tests/elements/expr/bitwiseopration/bitwiseoperation.swift
@@ -7,8 +7,8 @@ func bitwise() {
   _ = 1 >> 0
 
   // bitwise operations with overflow
-  _ = 1 &<< 1 // NOT DETECTED
-  _ = 1 &>> 1 // NOT DETECTED
+  _ = 1 &<< 1
+  _ = 1 &>> 1
 
   // pointwise bitwise operations
   let a = SIMD4<Int>(1, 2, 3, 4)

--- a/swift/ql/test/library-tests/elements/expr/bitwiseopration/bitwiseoperation.swift
+++ b/swift/ql/test/library-tests/elements/expr/bitwiseopration/bitwiseoperation.swift
@@ -14,7 +14,7 @@ func bitwise() {
   let a = SIMD4<Int>(1, 2, 3, 4)
   let b = SIMD4<Int>(4, 3, 2, 1)
   let m = a .< b
-  _ = m .& m // NOT DETECTED
-  _ = m .| m // NOT DETECTED
-  _ = m .^ m // NOT DETECTED
+  _ = m .& m
+  _ = m .| m
+  _ = m .^ m
 }

--- a/swift/ql/test/library-tests/elements/expr/bitwiseopration/bitwiseoperation.swift
+++ b/swift/ql/test/library-tests/elements/expr/bitwiseopration/bitwiseoperation.swift
@@ -5,4 +5,16 @@ func bitwise() {
   _ = 1 ^ 2
   _ = 1 << 0
   _ = 1 >> 0
+
+  // bitwise operations with overflow
+  _ = 1 &<< 1 // NOT DETECTED
+  _ = 1 &>> 1 // NOT DETECTED
+
+  // pointwise bitwise operations
+  let a = SIMD4<Int>(1, 2, 3, 4)
+  let b = SIMD4<Int>(4, 3, 2, 1)
+  let m = a .< b
+  _ = m .& m // NOT DETECTED
+  _ = m .| m // NOT DETECTED
+  _ = m .^ m // NOT DETECTED
 }


### PR DESCRIPTION
Fill some gaps in our arithmetic / bitwise operations modelling:
- overflow arithmetic operations (such as `&+`); they are now treated as variants of the corresponding basic operator (such as `+`).
- overflow bitwise operations (`&<<` and `&>>`); they are now treated as variants of the corresponding basic operator (`<<` or `>>`).
- pointwise bitwise operations (such as `.&`); modelled by new classes, but considered members of the bitwise operations.
- taint flow through bitwise operations.