### PR TITLE
C#: Make diagnostics visible everywhere

### DIFF
--- a/csharp/extractor/Semmle.Util/ToolStatusPage.cs
+++ b/csharp/extractor/Semmle.Util/ToolStatusPage.cs
@@ -58,6 +58,12 @@ namespace Semmle.Util
         public class TspVisibility
         {
             /// <summary>
+            /// A read-only instance of <see cref="TspVisibility" /> which indicates that the
+            /// diagnostic should be used in all supported locations.
+            /// </summary>
+            public static readonly TspVisibility All = new(true, true, true);
+
+            /// <summary>
             /// True if the message should be displayed on the status page (defaults to false).
             /// </summary>
             public bool? StatusPage { get; }
@@ -166,7 +172,7 @@ namespace Semmle.Util
             this.HelpLinks = new List<string>();
             this.Attributes = new Dictionary<string, object>();
             this.Severity = severity;
-            this.Visibility = visibility ?? new TspVisibility(statusPage: true);
+            this.Visibility = visibility ?? TspVisibility.All;
             this.Location = location ?? new TspLocation();
             this.Internal = intrnl ?? false;
             this.MarkdownMessage = markdownMessage;

--- a/csharp/ql/integration-tests/all-platforms/diag_dotnet_incompatible/diagnostics.expected
+++ b/csharp/ql/integration-tests/all-platforms/diag_dotnet_incompatible/diagnostics.expected
@@ -11,7 +11,9 @@
     "name": "Some projects are incompatible with .NET Core"
   },
   "visibility": {
-    "statusPage": true
+    "cliSummaryTable": true,
+    "statusPage": true,
+    "telemetry": true
   }
 }
 {
@@ -27,6 +29,8 @@
     "name": "Some projects or solutions failed to build using MSBuild"
   },
   "visibility": {
-    "statusPage": true
+    "cliSummaryTable": true,
+    "statusPage": true,
+    "telemetry": true
   }
 }

--- a/csharp/ql/integration-tests/all-platforms/diag_missing_project_files/diagnostics.expected
+++ b/csharp/ql/integration-tests/all-platforms/diag_missing_project_files/diagnostics.expected
@@ -11,7 +11,9 @@
     "name": "Some projects or solutions failed to build using MSBuild"
   },
   "visibility": {
-    "statusPage": true
+    "cliSummaryTable": true,
+    "statusPage": true,
+    "telemetry": true
   }
 }
 {
@@ -27,6 +29,8 @@
     "name": "Missing project files"
   },
   "visibility": {
-    "statusPage": true
+    "cliSummaryTable": true,
+    "statusPage": true,
+    "telemetry": true
   }
 }

--- a/csharp/ql/integration-tests/all-platforms/diag_missing_xamarin_sdk/diagnostics.expected
+++ b/csharp/ql/integration-tests/all-platforms/diag_missing_xamarin_sdk/diagnostics.expected
@@ -11,7 +11,9 @@
     "name": "Some projects or solutions failed to build using .NET Core"
   },
   "visibility": {
-    "statusPage": true
+    "cliSummaryTable": true,
+    "statusPage": true,
+    "telemetry": true
   }
 }
 {
@@ -27,7 +29,9 @@
     "name": "Some projects or solutions failed to build using MSBuild"
   },
   "visibility": {
-    "statusPage": true
+    "cliSummaryTable": true,
+    "statusPage": true,
+    "telemetry": true
   }
 }
 {
@@ -43,6 +47,8 @@
     "name": "Missing Xamarin SDK for iOS"
   },
   "visibility": {
-    "statusPage": true
+    "cliSummaryTable": true,
+    "statusPage": true,
+    "telemetry": true
   }
 }

--- a/csharp/ql/integration-tests/posix-only/diag_autobuild_script/diagnostics.expected
+++ b/csharp/ql/integration-tests/posix-only/diag_autobuild_script/diagnostics.expected
@@ -11,7 +11,9 @@
     "name": "Unable to build project using build script"
   },
   "visibility": {
-    "statusPage": true
+    "cliSummaryTable": true,
+    "statusPage": true,
+    "telemetry": true
   }
 }
 {
@@ -27,6 +29,8 @@
     "name": "No project or solutions files found"
   },
   "visibility": {
-    "statusPage": true
+    "cliSummaryTable": true,
+    "statusPage": true,
+    "telemetry": true
   }
 }

--- a/csharp/ql/integration-tests/posix-only/diag_multiple_scripts/diagnostics.expected
+++ b/csharp/ql/integration-tests/posix-only/diag_multiple_scripts/diagnostics.expected
@@ -11,7 +11,9 @@
     "name": "No project or solutions files found"
   },
   "visibility": {
-    "statusPage": true
+    "cliSummaryTable": true,
+    "statusPage": true,
+    "telemetry": true
   }
 }
 {
@@ -27,6 +29,8 @@
     "name": "There are multiple potential build scripts"
   },
   "visibility": {
-    "statusPage": true
+    "cliSummaryTable": true,
+    "statusPage": true,
+    "telemetry": true
   }
 }

--- a/csharp/ql/integration-tests/windows-only/diag_autobuild_script/diagnostics.expected
+++ b/csharp/ql/integration-tests/windows-only/diag_autobuild_script/diagnostics.expected
@@ -11,7 +11,9 @@
     "name": "Unable to build project using build script"
   },
   "visibility": {
-    "statusPage": true
+    "cliSummaryTable": true,
+    "statusPage": true,
+    "telemetry": true
   }
 }
 {
@@ -27,6 +29,8 @@
     "name": "No project or solutions files found"
   },
   "visibility": {
-    "statusPage": true
+    "cliSummaryTable": true,
+    "statusPage": true,
+    "telemetry": true
   }
 }

--- a/csharp/ql/integration-tests/windows-only/diag_multiple_scripts/diagnostics.expected
+++ b/csharp/ql/integration-tests/windows-only/diag_multiple_scripts/diagnostics.expected
@@ -11,7 +11,9 @@
     "name": "No project or solutions files found"
   },
   "visibility": {
-    "statusPage": true
+    "cliSummaryTable": true,
+    "statusPage": true,
+    "telemetry": true
   }
 }
 {
@@ -27,6 +29,8 @@
     "name": "There are multiple potential build scripts"
   },
   "visibility": {
-    "statusPage": true
+    "cliSummaryTable": true,
+    "statusPage": true,
+    "telemetry": true
   }
 }


### PR DESCRIPTION
This PR changes the visibility of diagnostics emitted by the C# autobuilder so that they are used everywhere that we support by default (which applies to all existing diagnostics).