### PR TITLE
C#: Add diagnostic checks to all remaining integration tests

### DIFF
--- a/csharp/ql/integration-tests/all-platforms/dotnet_build/test.py
+++ b/csharp/ql/integration-tests/all-platforms/dotnet_build/test.py
@@ -1,3 +1,5 @@
 from create_database_utils import *
+from diagnostics_test_utils import *
 
-run_codeql_database_create(['dotnet build'], test_db="default-db", db=None, lang="csharp")
+run_codeql_database_create(['dotnet build'], db=None, lang="csharp")
+check_diagnostics()

--- a/csharp/ql/integration-tests/all-platforms/dotnet_pack/test.py
+++ b/csharp/ql/integration-tests/all-platforms/dotnet_pack/test.py
@@ -1,8 +1,11 @@
 import os
 from create_database_utils import *
+from diagnostics_test_utils import *
 
-run_codeql_database_create(['dotnet pack'], test_db="default-db", db=None, lang="csharp")
+run_codeql_database_create(['dotnet pack'], db=None, lang="csharp")
 
 ## Check that the NuGet package is created.
 if not os.path.isfile("bin/Debug/dotnet_pack.1.0.0.nupkg"):
-    raise Exception("The NuGet package was not created.") 
+    raise Exception("The NuGet package was not created.")
+
+check_diagnostics()

--- a/csharp/ql/integration-tests/all-platforms/dotnet_publish/test.py
+++ b/csharp/ql/integration-tests/all-platforms/dotnet_publish/test.py
@@ -1,9 +1,12 @@
 import os
 from create_database_utils import *
+from diagnostics_test_utils import *
 
 artifacts = 'bin/Temp'
-run_codeql_database_create([f"dotnet publish -o {artifacts}"], test_db="default-db", db=None, lang="csharp")
+run_codeql_database_create([f"dotnet publish -o {artifacts}"], db=None, lang="csharp")
 
 ## Check that the publish folder is created.
 if not os.path.isdir(artifacts):
-    raise Exception("The publish artifact folder was not created.") 
+    raise Exception("The publish artifact folder was not created.")
+
+check_diagnostics()

--- a/csharp/ql/integration-tests/all-platforms/dotnet_run/test.py
+++ b/csharp/ql/integration-tests/all-platforms/dotnet_run/test.py
@@ -1,5 +1,6 @@
 import os
 from create_database_utils import *
+from diagnostics_test_utils import *
 
 def run_codeql_database_create_stdout(args, dbname):
     stdout = open(dbname + "file.txt", 'w+')
@@ -16,32 +17,40 @@ def check_build_out(msg, s):
 # no arguments
 s = run_codeql_database_create_stdout(['dotnet run'], "test-db")
 check_build_out("Default reply", s)
+check_diagnostics()
 
 # no arguments, but `--`
 s = run_codeql_database_create_stdout(['dotnet clean', 'rm -rf test-db', 'dotnet run --'], "test2-db")
 check_build_out("Default reply", s)
+check_diagnostics(diagnostics_dir="test2-db/diagnostic")
 
 # one argument, no `--`
 s = run_codeql_database_create_stdout(['dotnet clean', 'rm -rf test2-db', 'dotnet run hello'], "test3-db")
 check_build_out("Default reply", s)
+check_diagnostics(diagnostics_dir="test3-db/diagnostic")
 
 # one argument, but `--`
 s = run_codeql_database_create_stdout(['dotnet clean', 'rm -rf test3-db', 'dotnet run -- hello'], "test4-db")
 check_build_out("Default reply", s)
+check_diagnostics(diagnostics_dir="test4-db/diagnostic")
 
 # two arguments, no `--`
 s = run_codeql_database_create_stdout(['dotnet clean', 'rm -rf test4-db', 'dotnet run hello world'], "test5-db")
 check_build_out("hello, world", s)
+check_diagnostics(diagnostics_dir="test5-db/diagnostic")
 
 # two arguments, and `--`
 s = run_codeql_database_create_stdout(['dotnet clean', 'rm -rf test5-db', 'dotnet run -- hello world'], "test6-db")
 check_build_out("hello, world", s)
+check_diagnostics(diagnostics_dir="test6-db/diagnostic")
 
 # shared compilation enabled; tracer should override by changing the command
 # to `dotnet run -p:UseSharedCompilation=true -p:UseSharedCompilation=false -- hello world`
 s = run_codeql_database_create_stdout(['dotnet clean', 'rm -rf test6-db', 'dotnet run -p:UseSharedCompilation=true -- hello world'], "test7-db")
 check_build_out("hello, world", s)
+check_diagnostics(diagnostics_dir="test7-db/diagnostic")
 
 # option passed into `dotnet run`
 s = run_codeql_database_create_stdout(['dotnet clean', 'rm -rf test7-db', 'dotnet build', 'dotnet run --no-build hello world'], "test8-db")
 check_build_out("hello, world", s)
+check_diagnostics(diagnostics_dir="test8-db/diagnostic")

--- a/csharp/ql/integration-tests/all-platforms/msbuild/test.py
+++ b/csharp/ql/integration-tests/all-platforms/msbuild/test.py
@@ -1,4 +1,6 @@
 from create_database_utils import *
+from diagnostics_test_utils import *
 
 # force CodeQL to use MSBuild by setting `LGTM_INDEX_MSBUILD_TARGET`
-run_codeql_database_create([], test_db="default-db", db=None, lang="csharp", extra_env={ 'LGTM_INDEX_MSBUILD_TARGET': 'Build' })
+run_codeql_database_create([], db=None, lang="csharp", extra_env={ 'LGTM_INDEX_MSBUILD_TARGET': 'Build' })
+check_diagnostics()

--- a/csharp/ql/integration-tests/posix-only/dotnet_test/test.py
+++ b/csharp/ql/integration-tests/posix-only/dotnet_test/test.py
@@ -1,3 +1,5 @@
 from create_database_utils import *
+from diagnostics_test_utils import *
 
-run_codeql_database_create(['dotnet test'], test_db="default-db", db=None, lang="csharp")
+run_codeql_database_create(['dotnet test'], db=None, lang="csharp")
+check_diagnostics()

--- a/csharp/ql/integration-tests/posix-only/inherit-env-vars/test.py
+++ b/csharp/ql/integration-tests/posix-only/inherit-env-vars/test.py
@@ -1,6 +1,8 @@
 from create_database_utils import *
+from diagnostics_test_utils import *
 import os
 
 os.environ["PROJECT_TO_BUILD"] = "proj.csproj.no_auto"
 
-run_codeql_database_create([], test_db="default-db", db=None, lang="csharp")
+run_codeql_database_create([], db=None, lang="csharp")
+check_diagnostics()


### PR DESCRIPTION
This PR adds calls to `check_diagnostics()` to all remaining integration tests to ensure that they do not produce any diagnostics, as expected (since they should all succeed). 