### PR TITLE
C++: Silence a number of bogus consistency errors in syntax zoo

### DIFF
--- a/cpp/ql/test/library-tests/syntax-zoo/aggregateinitializer.c
+++ b/cpp/ql/test/library-tests/syntax-zoo/aggregateinitializer.c
@@ -1,4 +1,4 @@
-void f() {
+static void f() {
 	int a, b, c, d;
 	int x[] = { a + b, c - d };
 }

--- a/cpp/ql/test/library-tests/syntax-zoo/aliased_ssa_consistency.expected
+++ b/cpp/ql/test/library-tests/syntax-zoo/aliased_ssa_consistency.expected
@@ -16,67 +16,15 @@ instructionWithoutSuccessor
 | ms_try_mix.cpp:33:13:33:19 | ThrowValue: throw ... | Instruction 'ThrowValue: throw ...' has no successors in function '$@'. | ms_try_mix.cpp:27:6:27:19 | void ms_finally_mix(int) | void ms_finally_mix(int) |
 | ms_try_mix.cpp:51:5:51:11 | ThrowValue: throw ... | Instruction 'ThrowValue: throw ...' has no successors in function '$@'. | ms_try_mix.cpp:47:6:47:28 | void ms_empty_finally_at_end() | void ms_empty_finally_at_end() |
 | stmt_expr.cpp:27:5:27:15 | Store: ... = ... | Instruction 'Store: ... = ...' has no successors in function '$@'. | stmt_expr.cpp:21:6:21:6 | void stmtexpr::g(int) | void stmtexpr::g(int) |
-| vla.c:5:9:5:14 | Uninitialized: definition of matrix | Instruction 'Uninitialized: definition of matrix' has no successors in function '$@'. | vla.c:3:5:3:8 | int main(int, char**) | int main(int, char**) |
+| vla.c:5:9:5:14 | Uninitialized: definition of matrix | Instruction 'Uninitialized: definition of matrix' has no successors in function '$@'. | vla.c:3:12:3:12 | int f(int, char**) | int f(int, char**) |
 | vla.c:11:6:11:16 | Chi: vla_typedef | Instruction 'Chi: vla_typedef' has no successors in function '$@'. | vla.c:11:6:11:16 | void vla_typedef() | void vla_typedef() |
 ambiguousSuccessors
-| allocators.cpp:14:5:14:8 | Chi: main | Instruction 'Chi: main' has 4 successors of kind 'Goto' in function '$@'. | allocators.cpp:14:5:14:8 | int main() | int main() |
-| array_delete.cpp:5:6:5:6 | Chi: f | Instruction 'Chi: f' has 14 successors of kind 'Goto' in function '$@'. | array_delete.cpp:5:6:5:6 | void f() | void f() |
-| assignexpr.cpp:6:6:6:6 | Chi: f | Instruction 'Chi: f' has 14 successors of kind 'Goto' in function '$@'. | array_delete.cpp:5:6:5:6 | void f() | void f() |
-| break_labels.c:2:11:2:11 | InitializeParameter: i | Instruction 'InitializeParameter: i' has 19 successors of kind 'Goto' in function '$@'. | aggregateinitializer.c:1:6:1:6 | int f(int); void f(int) | int f(int); void f(int) |
-| break_labels.c:2:11:2:11 | InitializeParameter: i | Instruction 'InitializeParameter: x' has 19 successors of kind 'Goto' in function '$@'. | aggregateinitializer.c:1:6:1:6 | int f(int); void f(int) | int f(int); void f(int) |
-| break_labels.c:2:11:2:11 | InitializeParameter: x | Instruction 'InitializeParameter: i' has 19 successors of kind 'Goto' in function '$@'. | aggregateinitializer.c:1:6:1:6 | int f(int); void f(int) | int f(int); void f(int) |
-| break_labels.c:2:11:2:11 | InitializeParameter: x | Instruction 'InitializeParameter: x' has 19 successors of kind 'Goto' in function '$@'. | aggregateinitializer.c:1:6:1:6 | int f(int); void f(int) | int f(int); void f(int) |
 | conditional_destructors.cpp:29:6:29:7 | Chi: f1 | Instruction 'Chi: f1' has 2 successors of kind 'Goto' in function '$@'. | conditional_destructors.cpp:29:6:29:7 | void f1() | void f1() |
 | conditional_destructors.cpp:38:6:38:7 | Chi: f2 | Instruction 'Chi: f2' has 2 successors of kind 'Goto' in function '$@'. | conditional_destructors.cpp:38:6:38:7 | void f2() | void f2() |
-| constmemberaccess.cpp:6:6:6:6 | Chi: f | Instruction 'Chi: f' has 14 successors of kind 'Goto' in function '$@'. | array_delete.cpp:5:6:5:6 | void f() | void f() |
-| constructorinitializer.cpp:6:6:6:6 | Chi: f | Instruction 'Chi: f' has 14 successors of kind 'Goto' in function '$@'. | array_delete.cpp:5:6:5:6 | void f() | void f() |
-| defconstructornewexpr.cpp:3:6:3:6 | Chi: f | Instruction 'Chi: f' has 14 successors of kind 'Goto' in function '$@'. | array_delete.cpp:5:6:5:6 | void f() | void f() |
-| defdestructordeleteexpr.cpp:3:6:3:6 | Chi: f | Instruction 'Chi: f' has 14 successors of kind 'Goto' in function '$@'. | array_delete.cpp:5:6:5:6 | void f() | void f() |
-| deleteexpr.cpp:6:6:6:6 | Chi: f | Instruction 'Chi: f' has 14 successors of kind 'Goto' in function '$@'. | array_delete.cpp:5:6:5:6 | void f() | void f() |
-| dostmt.c:8:6:8:18 | Chi: always_true_1 | Instruction 'Chi: always_true_1' has 4 successors of kind 'Goto' in function '$@'. | dostmt.c:8:6:8:18 | void always_true_1() | void always_true_1() |
-| dostmt.c:16:6:16:18 | Chi: always_true_2 | Instruction 'Chi: always_true_2' has 4 successors of kind 'Goto' in function '$@'. | dostmt.c:16:6:16:18 | void always_true_2() | void always_true_2() |
-| dostmt.c:25:6:25:18 | Chi: always_true_3 | Instruction 'Chi: always_true_3' has 2 successors of kind 'Goto' in function '$@'. | dostmt.c:25:6:25:18 | void always_true_3() | void always_true_3() |
-| duff.c:2:12:2:12 | InitializeParameter: i | Instruction 'InitializeParameter: i' has 19 successors of kind 'Goto' in function '$@'. | aggregateinitializer.c:1:6:1:6 | int f(int); void f(int) | int f(int); void f(int) |
-| duff.c:2:12:2:12 | InitializeParameter: i | Instruction 'InitializeParameter: x' has 19 successors of kind 'Goto' in function '$@'. | aggregateinitializer.c:1:6:1:6 | int f(int); void f(int) | int f(int); void f(int) |
-| duff.c:2:12:2:12 | InitializeParameter: x | Instruction 'InitializeParameter: i' has 19 successors of kind 'Goto' in function '$@'. | aggregateinitializer.c:1:6:1:6 | int f(int); void f(int) | int f(int); void f(int) |
-| duff.c:2:12:2:12 | InitializeParameter: x | Instruction 'InitializeParameter: x' has 19 successors of kind 'Goto' in function '$@'. | aggregateinitializer.c:1:6:1:6 | int f(int); void f(int) | int f(int); void f(int) |
-| fieldaccess.cpp:6:6:6:6 | Chi: f | Instruction 'Chi: f' has 14 successors of kind 'Goto' in function '$@'. | array_delete.cpp:5:6:5:6 | void f() | void f() |
 | forstmt.cpp:1:6:1:7 | Chi: f1 | Instruction 'Chi: f1' has 2 successors of kind 'Goto' in function '$@'. | conditional_destructors.cpp:29:6:29:7 | void f1() | void f1() |
 | forstmt.cpp:8:6:8:7 | Chi: f2 | Instruction 'Chi: f2' has 2 successors of kind 'Goto' in function '$@'. | conditional_destructors.cpp:38:6:38:7 | void f2() | void f2() |
-| ifelsestmt.c:1:6:1:19 | Chi: always_false_1 | Instruction 'Chi: always_false_1' has 3 successors of kind 'Goto' in function '$@'. | ifelsestmt.c:1:6:1:19 | void always_false_1() | void always_false_1() |
-| ifelsestmt.c:11:6:11:19 | Chi: always_false_2 | Instruction 'Chi: always_false_2' has 3 successors of kind 'Goto' in function '$@'. | ifelsestmt.c:11:6:11:19 | void always_false_2() | void always_false_2() |
-| ifelsestmt.c:19:6:19:18 | Chi: always_true_1 | Instruction 'Chi: always_true_1' has 4 successors of kind 'Goto' in function '$@'. | dostmt.c:8:6:8:18 | void always_true_1() | void always_true_1() |
-| ifelsestmt.c:29:6:29:18 | Chi: always_true_2 | Instruction 'Chi: always_true_2' has 4 successors of kind 'Goto' in function '$@'. | dostmt.c:16:6:16:18 | void always_true_2() | void always_true_2() |
-| ifelsestmt.c:37:24:37:24 | InitializeParameter: y | Instruction 'InitializeParameter: y' has 4 successors of kind 'Goto' in function '$@'. | dostmt.c:32:6:32:11 | void normal(int, int) | void normal(int, int) |
-| ifstmt.c:1:6:1:19 | Chi: always_false_1 | Instruction 'Chi: always_false_1' has 3 successors of kind 'Goto' in function '$@'. | ifelsestmt.c:1:6:1:19 | void always_false_1() | void always_false_1() |
-| ifstmt.c:8:6:8:19 | Chi: always_false_2 | Instruction 'Chi: always_false_2' has 3 successors of kind 'Goto' in function '$@'. | ifelsestmt.c:11:6:11:19 | void always_false_2() | void always_false_2() |
-| ifstmt.c:14:6:14:18 | Chi: always_true_1 | Instruction 'Chi: always_true_1' has 4 successors of kind 'Goto' in function '$@'. | dostmt.c:8:6:8:18 | void always_true_1() | void always_true_1() |
-| ifstmt.c:21:6:21:18 | Chi: always_true_2 | Instruction 'Chi: always_true_2' has 4 successors of kind 'Goto' in function '$@'. | dostmt.c:16:6:16:18 | void always_true_2() | void always_true_2() |
-| ifstmt.c:27:24:27:24 | InitializeParameter: y | Instruction 'InitializeParameter: y' has 4 successors of kind 'Goto' in function '$@'. | dostmt.c:32:6:32:11 | void normal(int, int) | void normal(int, int) |
-| membercallexpr.cpp:6:6:6:6 | Chi: f | Instruction 'Chi: f' has 14 successors of kind 'Goto' in function '$@'. | array_delete.cpp:5:6:5:6 | void f() | void f() |
-| membercallexpr_args.cpp:7:6:7:6 | Chi: f | Instruction 'Chi: f' has 14 successors of kind 'Goto' in function '$@'. | array_delete.cpp:5:6:5:6 | void f() | void f() |
-| newexpr.cpp:6:6:6:6 | Chi: f | Instruction 'Chi: f' has 14 successors of kind 'Goto' in function '$@'. | array_delete.cpp:5:6:5:6 | void f() | void f() |
-| no_dynamic_init.cpp:9:5:9:8 | Chi: main | Instruction 'Chi: main' has 4 successors of kind 'Goto' in function '$@'. | allocators.cpp:14:5:14:8 | int main() | int main() |
-| nodefaultswitchstmt.c:1:12:1:12 | InitializeParameter: i | Instruction 'InitializeParameter: i' has 19 successors of kind 'Goto' in function '$@'. | aggregateinitializer.c:1:6:1:6 | int f(int); void f(int) | int f(int); void f(int) |
-| nodefaultswitchstmt.c:1:12:1:12 | InitializeParameter: i | Instruction 'InitializeParameter: x' has 19 successors of kind 'Goto' in function '$@'. | aggregateinitializer.c:1:6:1:6 | int f(int); void f(int) | int f(int); void f(int) |
-| nodefaultswitchstmt.c:1:12:1:12 | InitializeParameter: x | Instruction 'InitializeParameter: i' has 19 successors of kind 'Goto' in function '$@'. | aggregateinitializer.c:1:6:1:6 | int f(int); void f(int) | int f(int); void f(int) |
-| nodefaultswitchstmt.c:1:12:1:12 | InitializeParameter: x | Instruction 'InitializeParameter: x' has 19 successors of kind 'Goto' in function '$@'. | aggregateinitializer.c:1:6:1:6 | int f(int); void f(int) | int f(int); void f(int) |
 | nonmembercallexpr.c:1:6:1:6 | Chi: g | Instruction 'Chi: g' has 2 successors of kind 'Goto' in function '$@'. | nonmembercallexpr.c:1:6:1:6 | void g(); void g())(); void(* g(); void(* g())() | void g(); void g())(); void(* g(); void(* g())() |
-| parameterinitializer.cpp:18:5:18:8 | Chi: main | Instruction 'Chi: main' has 4 successors of kind 'Goto' in function '$@'. | allocators.cpp:14:5:14:8 | int main() | int main() |
-| pmcallexpr.cpp:6:6:6:6 | Chi: f | Instruction 'Chi: f' has 14 successors of kind 'Goto' in function '$@'. | array_delete.cpp:5:6:5:6 | void f() | void f() |
 | revsubscriptexpr.c:1:6:1:6 | Chi: g | Instruction 'Chi: g' has 2 successors of kind 'Goto' in function '$@'. | nonmembercallexpr.c:1:6:1:6 | void g(); void g())(); void(* g(); void(* g())() | void g(); void g())(); void(* g(); void(* g())() |
-| staticmembercallexpr.cpp:6:6:6:6 | Chi: f | Instruction 'Chi: f' has 14 successors of kind 'Goto' in function '$@'. | array_delete.cpp:5:6:5:6 | void f() | void f() |
-| staticmembercallexpr_args.cpp:7:6:7:6 | Chi: f | Instruction 'Chi: f' has 14 successors of kind 'Goto' in function '$@'. | array_delete.cpp:5:6:5:6 | void f() | void f() |
-| stream_it.cpp:16:5:16:8 | Chi: main | Instruction 'Chi: main' has 4 successors of kind 'Goto' in function '$@'. | allocators.cpp:14:5:14:8 | int main() | int main() |
-| switchstmt.c:1:12:1:12 | InitializeParameter: i | Instruction 'InitializeParameter: i' has 19 successors of kind 'Goto' in function '$@'. | aggregateinitializer.c:1:6:1:6 | int f(int); void f(int) | int f(int); void f(int) |
-| switchstmt.c:1:12:1:12 | InitializeParameter: i | Instruction 'InitializeParameter: x' has 19 successors of kind 'Goto' in function '$@'. | aggregateinitializer.c:1:6:1:6 | int f(int); void f(int) | int f(int); void f(int) |
-| switchstmt.c:1:12:1:12 | InitializeParameter: x | Instruction 'InitializeParameter: i' has 19 successors of kind 'Goto' in function '$@'. | aggregateinitializer.c:1:6:1:6 | int f(int); void f(int) | int f(int); void f(int) |
-| switchstmt.c:1:12:1:12 | InitializeParameter: x | Instruction 'InitializeParameter: x' has 19 successors of kind 'Goto' in function '$@'. | aggregateinitializer.c:1:6:1:6 | int f(int); void f(int) | int f(int); void f(int) |
-| whilestmt.c:1:6:1:19 | Chi: always_false_1 | Instruction 'Chi: always_false_1' has 3 successors of kind 'Goto' in function '$@'. | ifelsestmt.c:1:6:1:19 | void always_false_1() | void always_false_1() |
-| whilestmt.c:8:6:8:19 | Chi: always_false_2 | Instruction 'Chi: always_false_2' has 3 successors of kind 'Goto' in function '$@'. | ifelsestmt.c:11:6:11:19 | void always_false_2() | void always_false_2() |
-| whilestmt.c:15:6:15:18 | Chi: always_true_1 | Instruction 'Chi: always_true_1' has 4 successors of kind 'Goto' in function '$@'. | dostmt.c:8:6:8:18 | void always_true_1() | void always_true_1() |
-| whilestmt.c:23:6:23:18 | Chi: always_true_2 | Instruction 'Chi: always_true_2' has 4 successors of kind 'Goto' in function '$@'. | dostmt.c:16:6:16:18 | void always_true_2() | void always_true_2() |
-| whilestmt.c:32:6:32:18 | Chi: always_true_3 | Instruction 'Chi: always_true_3' has 2 successors of kind 'Goto' in function '$@'. | dostmt.c:25:6:25:18 | void always_true_3() | void always_true_3() |
 unexplainedLoop
 unnecessaryPhiInstruction
 memoryOperandDefinitionIsUnmodeled
@@ -93,7 +41,7 @@ invalidOverlap
 nonUniqueEnclosingIRFunction
 fieldAddressOnNonPointer
 thisArgumentIsNonPointer
-| pmcallexpr.cpp:8:2:8:15 | Call: call to expression | Call instruction 'Call: call to expression' has a `this` argument operand that is not an address, in function '$@'. | array_delete.cpp:5:6:5:6 | void f() | void f() |
+| pmcallexpr.cpp:8:2:8:15 | Call: call to expression | Call instruction 'Call: call to expression' has a `this` argument operand that is not an address, in function '$@'. | pmcallexpr.cpp:6:13:6:13 | void f() | void f() |
 | pointer_to_member.cpp:23:5:23:54 | Call: call to expression | Call instruction 'Call: call to expression' has a `this` argument operand that is not an address, in function '$@'. | pointer_to_member.cpp:14:5:14:9 | int usePM(int PM::*) | int usePM(int PM::*) |
 | pointer_to_member.cpp:24:5:24:49 | Call: call to expression | Call instruction 'Call: call to expression' has a `this` argument operand that is not an address, in function '$@'. | pointer_to_member.cpp:14:5:14:9 | int usePM(int PM::*) | int usePM(int PM::*) |
 nonUniqueIRVariable

--- a/cpp/ql/test/library-tests/syntax-zoo/allocators.cpp
+++ b/cpp/ql/test/library-tests/syntax-zoo/allocators.cpp
@@ -11,7 +11,7 @@ struct Allocators
   int m_y;
 };
 
-int main()
+static int f()
 {
   auto foo = new(11, 22) Allocators(33, 44);
   delete foo;

--- a/cpp/ql/test/library-tests/syntax-zoo/array_delete.cpp
+++ b/cpp/ql/test/library-tests/syntax-zoo/array_delete.cpp
@@ -2,6 +2,6 @@ struct ArrayDelete {
   ~ArrayDelete();
 };
 
-void f() {
+static void f() {
   delete[] (ArrayDelete*)nullptr;
 }

--- a/cpp/ql/test/library-tests/syntax-zoo/assignexpr.cpp
+++ b/cpp/ql/test/library-tests/syntax-zoo/assignexpr.cpp
@@ -3,7 +3,7 @@ class C {
 		int i;
 };
 
-void f() {
+static void f() {
 	C c;
 	int a, b;
 	c.i = a + b;

--- a/cpp/ql/test/library-tests/syntax-zoo/break_labels.c
+++ b/cpp/ql/test/library-tests/syntax-zoo/break_labels.c
@@ -1,5 +1,5 @@
 
-int f(int i) {
+static int f(int i) {
     int result = 0;
     if (i != 0) {
         result++;

--- a/cpp/ql/test/library-tests/syntax-zoo/constmemberaccess.cpp
+++ b/cpp/ql/test/library-tests/syntax-zoo/constmemberaccess.cpp
@@ -3,7 +3,7 @@ class C {
 		int x;
 };
 
-void f() {
+static void f() {
 	C *c;
 	int i;
 	i = c->x;

--- a/cpp/ql/test/library-tests/syntax-zoo/constructorinitializer.cpp
+++ b/cpp/ql/test/library-tests/syntax-zoo/constructorinitializer.cpp
@@ -3,7 +3,7 @@ class C {
 		C(int x, int y);
 };
 
-void f() {
+static void f() {
 	int i, j, k, l;
 	C c(i + j, k - l);
 }

--- a/cpp/ql/test/library-tests/syntax-zoo/cpp11.cpp
+++ b/cpp/ql/test/library-tests/syntax-zoo/cpp11.cpp
@@ -114,7 +114,7 @@ namespace synthetic_dtor_calls {
     }
   }
 
-  void f(int x) {
+  static void f(int x) {
     while (x > 0) {
       C c;
       if (x == 1) {

--- a/cpp/ql/test/library-tests/syntax-zoo/dataflow-consistency.expected
+++ b/cpp/ql/test/library-tests/syntax-zoo/dataflow-consistency.expected
@@ -10,45 +10,11 @@ uniqueEnclosingCallable
 | misc.c:210:28:210:28 | 1 | Node should have one enclosing callable but has 0. |
 uniqueType
 uniqueNodeLocation
-| break_labels.c:2:11:2:11 | i | Node should have one location but has 4. |
-| break_labels.c:2:11:2:11 | x | Node should have one location but has 4. |
-| duff.c:2:12:2:12 | i | Node should have one location but has 4. |
-| duff.c:2:12:2:12 | x | Node should have one location but has 4. |
 | file://:0:0:0:0 | (unnamed parameter 2) | Node should have one location but has 0. |
 | file://:0:0:0:0 | (unnamed parameter 2) | Node should have one location but has 0. |
-| ifelsestmt.c:37:17:37:17 | x | Node should have one location but has 2. |
-| ifelsestmt.c:37:24:37:24 | y | Node should have one location but has 2. |
-| ifstmt.c:27:17:27:17 | x | Node should have one location but has 2. |
-| ifstmt.c:27:24:27:24 | y | Node should have one location but has 2. |
-| nodefaultswitchstmt.c:1:12:1:12 | i | Node should have one location but has 4. |
-| nodefaultswitchstmt.c:1:12:1:12 | x | Node should have one location but has 4. |
-| switchstmt.c:1:12:1:12 | i | Node should have one location but has 4. |
-| switchstmt.c:1:12:1:12 | x | Node should have one location but has 4. |
 missingLocation
 | Nodes without location: 2 |
 uniqueNodeToString
-| break_labels.c:2:11:2:11 | i | Node should have one toString but has 2. |
-| break_labels.c:2:11:2:11 | x | Node should have one toString but has 2. |
-| break_labels.c:4:9:4:9 | i | Node should have one toString but has 2. |
-| break_labels.c:4:9:4:9 | x | Node should have one toString but has 2. |
-| break_labels.c:6:16:6:16 | i | Node should have one toString but has 2. |
-| break_labels.c:6:16:6:16 | x | Node should have one toString but has 2. |
-| break_labels.c:7:17:7:17 | i | Node should have one toString but has 2. |
-| break_labels.c:7:17:7:17 | x | Node should have one toString but has 2. |
-| duff.c:2:12:2:12 | i | Node should have one toString but has 2. |
-| duff.c:2:12:2:12 | x | Node should have one toString but has 2. |
-| duff.c:3:14:3:14 | i | Node should have one toString but has 2. |
-| duff.c:3:14:3:14 | x | Node should have one toString but has 2. |
-| duff.c:4:13:4:13 | i | Node should have one toString but has 2. |
-| duff.c:4:13:4:13 | x | Node should have one toString but has 2. |
-| nodefaultswitchstmt.c:1:12:1:12 | i | Node should have one toString but has 2. |
-| nodefaultswitchstmt.c:1:12:1:12 | x | Node should have one toString but has 2. |
-| nodefaultswitchstmt.c:2:14:2:14 | i | Node should have one toString but has 2. |
-| nodefaultswitchstmt.c:2:14:2:14 | x | Node should have one toString but has 2. |
-| switchstmt.c:1:12:1:12 | i | Node should have one toString but has 2. |
-| switchstmt.c:1:12:1:12 | x | Node should have one toString but has 2. |
-| switchstmt.c:2:14:2:14 | i | Node should have one toString but has 2. |
-| switchstmt.c:2:14:2:14 | x | Node should have one toString but has 2. |
 missingToString
 parameterCallable
 localFlowIsLocal

--- a/cpp/ql/test/library-tests/syntax-zoo/dataflow-ir-consistency.expected
+++ b/cpp/ql/test/library-tests/syntax-zoo/dataflow-ir-consistency.expected
@@ -1,26 +1,6 @@
 uniqueEnclosingCallable
 uniqueType
 uniqueNodeLocation
-| allocators.cpp:14:5:14:8 | Phi | Node should have one location but has 4. |
-| allocators.cpp:14:5:14:8 | main | Node should have one location but has 4. |
-| allocators.cpp:14:5:14:8 | main indirection | Node should have one location but has 4. |
-| allocators.cpp:14:5:14:8 | main indirection | Node should have one location but has 4. |
-| break_labels.c:2:11:2:11 | i | Node should have one location but has 4. |
-| break_labels.c:2:11:2:11 | i | Node should have one location but has 4. |
-| break_labels.c:2:11:2:11 | i indirection | Node should have one location but has 4. |
-| break_labels.c:2:11:2:11 | i indirection | Node should have one location but has 4. |
-| break_labels.c:2:11:2:11 | x | Node should have one location but has 4. |
-| break_labels.c:2:11:2:11 | x | Node should have one location but has 4. |
-| break_labels.c:2:11:2:11 | x indirection | Node should have one location but has 4. |
-| break_labels.c:2:11:2:11 | x indirection | Node should have one location but has 4. |
-| duff.c:2:12:2:12 | i | Node should have one location but has 4. |
-| duff.c:2:12:2:12 | i | Node should have one location but has 4. |
-| duff.c:2:12:2:12 | i indirection | Node should have one location but has 4. |
-| duff.c:2:12:2:12 | i indirection | Node should have one location but has 4. |
-| duff.c:2:12:2:12 | x | Node should have one location but has 4. |
-| duff.c:2:12:2:12 | x | Node should have one location but has 4. |
-| duff.c:2:12:2:12 | x indirection | Node should have one location but has 4. |
-| duff.c:2:12:2:12 | x indirection | Node should have one location but has 4. |
 | file://:0:0:0:0 | (unnamed parameter 2) | Node should have one location but has 0. |
 | file://:0:0:0:0 | (unnamed parameter 2) | Node should have one location but has 0. |
 | file://:0:0:0:0 | (unnamed parameter 2) | Node should have one location but has 0. |
@@ -33,131 +13,13 @@ uniqueNodeLocation
 | file://:0:0:0:0 | (unnamed parameter 2) indirection | Node should have one location but has 0. |
 | file://:0:0:0:0 | (unnamed parameter 2) indirection | Node should have one location but has 0. |
 | file://:0:0:0:0 | (unnamed parameter 2) indirection | Node should have one location but has 0. |
-| ifelsestmt.c:37:17:37:17 | x | Node should have one location but has 2. |
-| ifelsestmt.c:37:17:37:17 | x | Node should have one location but has 2. |
-| ifelsestmt.c:37:17:37:17 | x indirection | Node should have one location but has 2. |
-| ifelsestmt.c:37:17:37:17 | x indirection | Node should have one location but has 2. |
-| ifelsestmt.c:37:24:37:24 | y | Node should have one location but has 2. |
-| ifelsestmt.c:37:24:37:24 | y | Node should have one location but has 2. |
-| ifelsestmt.c:37:24:37:24 | y indirection | Node should have one location but has 2. |
-| ifelsestmt.c:37:24:37:24 | y indirection | Node should have one location but has 2. |
-| ifstmt.c:27:17:27:17 | x | Node should have one location but has 2. |
-| ifstmt.c:27:17:27:17 | x | Node should have one location but has 2. |
-| ifstmt.c:27:17:27:17 | x indirection | Node should have one location but has 2. |
-| ifstmt.c:27:17:27:17 | x indirection | Node should have one location but has 2. |
-| ifstmt.c:27:24:27:24 | y | Node should have one location but has 2. |
-| ifstmt.c:27:24:27:24 | y | Node should have one location but has 2. |
-| ifstmt.c:27:24:27:24 | y indirection | Node should have one location but has 2. |
-| ifstmt.c:27:24:27:24 | y indirection | Node should have one location but has 2. |
-| no_dynamic_init.cpp:9:5:9:8 | Phi | Node should have one location but has 4. |
-| no_dynamic_init.cpp:9:5:9:8 | main | Node should have one location but has 4. |
-| no_dynamic_init.cpp:9:5:9:8 | main indirection | Node should have one location but has 4. |
-| no_dynamic_init.cpp:9:5:9:8 | main indirection | Node should have one location but has 4. |
-| nodefaultswitchstmt.c:1:12:1:12 | i | Node should have one location but has 4. |
-| nodefaultswitchstmt.c:1:12:1:12 | i | Node should have one location but has 4. |
-| nodefaultswitchstmt.c:1:12:1:12 | i indirection | Node should have one location but has 4. |
-| nodefaultswitchstmt.c:1:12:1:12 | i indirection | Node should have one location but has 4. |
-| nodefaultswitchstmt.c:1:12:1:12 | x | Node should have one location but has 4. |
-| nodefaultswitchstmt.c:1:12:1:12 | x | Node should have one location but has 4. |
-| nodefaultswitchstmt.c:1:12:1:12 | x indirection | Node should have one location but has 4. |
-| nodefaultswitchstmt.c:1:12:1:12 | x indirection | Node should have one location but has 4. |
-| parameterinitializer.cpp:18:5:18:8 | Phi | Node should have one location but has 4. |
-| parameterinitializer.cpp:18:5:18:8 | main | Node should have one location but has 4. |
-| parameterinitializer.cpp:18:5:18:8 | main indirection | Node should have one location but has 4. |
-| parameterinitializer.cpp:18:5:18:8 | main indirection | Node should have one location but has 4. |
-| stream_it.cpp:16:5:16:8 | Phi | Node should have one location but has 4. |
-| stream_it.cpp:16:5:16:8 | main | Node should have one location but has 4. |
-| stream_it.cpp:16:5:16:8 | main indirection | Node should have one location but has 4. |
-| stream_it.cpp:16:5:16:8 | main indirection | Node should have one location but has 4. |
-| switchstmt.c:1:12:1:12 | i | Node should have one location but has 4. |
-| switchstmt.c:1:12:1:12 | i | Node should have one location but has 4. |
-| switchstmt.c:1:12:1:12 | i indirection | Node should have one location but has 4. |
-| switchstmt.c:1:12:1:12 | i indirection | Node should have one location but has 4. |
-| switchstmt.c:1:12:1:12 | x | Node should have one location but has 4. |
-| switchstmt.c:1:12:1:12 | x | Node should have one location but has 4. |
-| switchstmt.c:1:12:1:12 | x indirection | Node should have one location but has 4. |
-| switchstmt.c:1:12:1:12 | x indirection | Node should have one location but has 4. |
 missingLocation
 | Nodes without location: 12 |
 uniqueNodeToString
-| break_labels.c:2:11:2:11 | i | Node should have one toString but has 2. |
-| break_labels.c:2:11:2:11 | i | Node should have one toString but has 2. |
-| break_labels.c:2:11:2:11 | i indirection | Node should have one toString but has 2. |
-| break_labels.c:2:11:2:11 | i indirection | Node should have one toString but has 2. |
-| break_labels.c:2:11:2:11 | x | Node should have one toString but has 2. |
-| break_labels.c:2:11:2:11 | x | Node should have one toString but has 2. |
-| break_labels.c:2:11:2:11 | x indirection | Node should have one toString but has 2. |
-| break_labels.c:2:11:2:11 | x indirection | Node should have one toString but has 2. |
-| break_labels.c:4:9:4:9 | i | Node should have one toString but has 2. |
-| break_labels.c:4:9:4:9 | i | Node should have one toString but has 2. |
-| break_labels.c:4:9:4:9 | x | Node should have one toString but has 2. |
-| break_labels.c:4:9:4:9 | x | Node should have one toString but has 2. |
-| break_labels.c:6:16:6:16 | i | Node should have one toString but has 2. |
-| break_labels.c:6:16:6:16 | i | Node should have one toString but has 2. |
-| break_labels.c:6:16:6:16 | x | Node should have one toString but has 2. |
-| break_labels.c:6:16:6:16 | x | Node should have one toString but has 2. |
-| break_labels.c:7:17:7:17 | i | Node should have one toString but has 2. |
-| break_labels.c:7:17:7:17 | i | Node should have one toString but has 2. |
-| break_labels.c:7:17:7:17 | i | Node should have one toString but has 2. |
-| break_labels.c:7:17:7:17 | i | Node should have one toString but has 2. |
-| break_labels.c:7:17:7:17 | i | Node should have one toString but has 2. |
-| break_labels.c:7:17:7:17 | i | Node should have one toString but has 2. |
-| break_labels.c:7:17:7:17 | i indirection | Node should have one toString but has 2. |
-| break_labels.c:7:17:7:17 | i indirection | Node should have one toString but has 2. |
-| break_labels.c:7:17:7:17 | x | Node should have one toString but has 2. |
-| break_labels.c:7:17:7:17 | x | Node should have one toString but has 2. |
-| break_labels.c:7:17:7:17 | x | Node should have one toString but has 2. |
-| break_labels.c:7:17:7:17 | x | Node should have one toString but has 2. |
-| break_labels.c:7:17:7:17 | x | Node should have one toString but has 2. |
-| break_labels.c:7:17:7:17 | x | Node should have one toString but has 2. |
-| break_labels.c:7:17:7:17 | x indirection | Node should have one toString but has 2. |
-| break_labels.c:7:17:7:17 | x indirection | Node should have one toString but has 2. |
-| duff.c:2:12:2:12 | i | Node should have one toString but has 2. |
-| duff.c:2:12:2:12 | i | Node should have one toString but has 2. |
-| duff.c:2:12:2:12 | i indirection | Node should have one toString but has 2. |
-| duff.c:2:12:2:12 | i indirection | Node should have one toString but has 2. |
-| duff.c:2:12:2:12 | x | Node should have one toString but has 2. |
-| duff.c:2:12:2:12 | x | Node should have one toString but has 2. |
-| duff.c:2:12:2:12 | x indirection | Node should have one toString but has 2. |
-| duff.c:2:12:2:12 | x indirection | Node should have one toString but has 2. |
-| duff.c:3:14:3:14 | i | Node should have one toString but has 2. |
-| duff.c:3:14:3:14 | i | Node should have one toString but has 2. |
-| duff.c:3:14:3:14 | x | Node should have one toString but has 2. |
-| duff.c:3:14:3:14 | x | Node should have one toString but has 2. |
-| duff.c:4:13:4:13 | i | Node should have one toString but has 2. |
-| duff.c:4:13:4:13 | i | Node should have one toString but has 2. |
-| duff.c:4:13:4:13 | x | Node should have one toString but has 2. |
-| duff.c:4:13:4:13 | x | Node should have one toString but has 2. |
-| file://:0:0:0:0 | i | Node should have one toString but has 2. |
 | file://:0:0:0:0 | i | Node should have one toString but has 2. |
 | file://:0:0:0:0 | j | Node should have one toString but has 2. |
 | file://:0:0:0:0 | x | Node should have one toString but has 2. |
-| file://:0:0:0:0 | x | Node should have one toString but has 2. |
 | file://:0:0:0:0 | y | Node should have one toString but has 2. |
-| nodefaultswitchstmt.c:1:12:1:12 | i | Node should have one toString but has 2. |
-| nodefaultswitchstmt.c:1:12:1:12 | i | Node should have one toString but has 2. |
-| nodefaultswitchstmt.c:1:12:1:12 | i indirection | Node should have one toString but has 2. |
-| nodefaultswitchstmt.c:1:12:1:12 | i indirection | Node should have one toString but has 2. |
-| nodefaultswitchstmt.c:1:12:1:12 | x | Node should have one toString but has 2. |
-| nodefaultswitchstmt.c:1:12:1:12 | x | Node should have one toString but has 2. |
-| nodefaultswitchstmt.c:1:12:1:12 | x indirection | Node should have one toString but has 2. |
-| nodefaultswitchstmt.c:1:12:1:12 | x indirection | Node should have one toString but has 2. |
-| nodefaultswitchstmt.c:2:14:2:14 | i | Node should have one toString but has 2. |
-| nodefaultswitchstmt.c:2:14:2:14 | i | Node should have one toString but has 2. |
-| nodefaultswitchstmt.c:2:14:2:14 | x | Node should have one toString but has 2. |
-| nodefaultswitchstmt.c:2:14:2:14 | x | Node should have one toString but has 2. |
-| switchstmt.c:1:12:1:12 | i | Node should have one toString but has 2. |
-| switchstmt.c:1:12:1:12 | i | Node should have one toString but has 2. |
-| switchstmt.c:1:12:1:12 | i indirection | Node should have one toString but has 2. |
-| switchstmt.c:1:12:1:12 | i indirection | Node should have one toString but has 2. |
-| switchstmt.c:1:12:1:12 | x | Node should have one toString but has 2. |
-| switchstmt.c:1:12:1:12 | x | Node should have one toString but has 2. |
-| switchstmt.c:1:12:1:12 | x indirection | Node should have one toString but has 2. |
-| switchstmt.c:1:12:1:12 | x indirection | Node should have one toString but has 2. |
-| switchstmt.c:2:14:2:14 | i | Node should have one toString but has 2. |
-| switchstmt.c:2:14:2:14 | i | Node should have one toString but has 2. |
-| switchstmt.c:2:14:2:14 | x | Node should have one toString but has 2. |
-| switchstmt.c:2:14:2:14 | x | Node should have one toString but has 2. |
 missingToString
 parameterCallable
 localFlowIsLocal

--- a/cpp/ql/test/library-tests/syntax-zoo/defconstructornewexpr.cpp
+++ b/cpp/ql/test/library-tests/syntax-zoo/defconstructornewexpr.cpp
@@ -1,6 +1,6 @@
 class C { };
 
-void f() {
+static void f() {
 	new C;
   return;
 }

--- a/cpp/ql/test/library-tests/syntax-zoo/defdestructordeleteexpr.cpp
+++ b/cpp/ql/test/library-tests/syntax-zoo/defdestructordeleteexpr.cpp
@@ -1,6 +1,6 @@
 class C { };
 
-void f() {
+static void f() {
 	C* c = new C();
 	delete c;
 }

--- a/cpp/ql/test/library-tests/syntax-zoo/deleteexpr.cpp
+++ b/cpp/ql/test/library-tests/syntax-zoo/deleteexpr.cpp
@@ -3,7 +3,7 @@ class C {
 		~C();
 };
 
-void f() {
+static void f() {
 	C* c = new C();
 	delete c;
 }

--- a/cpp/ql/test/library-tests/syntax-zoo/dostmt.c
+++ b/cpp/ql/test/library-tests/syntax-zoo/dostmt.c
@@ -5,7 +5,7 @@ void always_false() {
   l2:;
 }
 
-void always_true_1() {
+static void always_true_1() {
   do {
     l1:;
     break;
@@ -13,7 +13,7 @@ void always_true_1() {
   l2:;
 }
 
-void always_true_2() {
+static void always_true_2() {
   do {
     l1:;
     break;
@@ -22,14 +22,14 @@ void always_true_2() {
   l3:;
 }
 
-void always_true_3() {
+static void always_true_3() {
   do {
     l1:;
   } while(1);
   l2:;
 }
 
-void normal() {
+static void normal() {
   int i = 0;
   do {
     ++i;

--- a/cpp/ql/test/library-tests/syntax-zoo/duff.c
+++ b/cpp/ql/test/library-tests/syntax-zoo/duff.c
@@ -1,5 +1,5 @@
 
-void f(int i) {
+static void f(int i) {
     int n = (i + 7) / 8;
     switch (i % 8) {
     case 0: do { 10;

--- a/cpp/ql/test/library-tests/syntax-zoo/dummyblock.c
+++ b/cpp/ql/test/library-tests/syntax-zoo/dummyblock.c
@@ -1,4 +1,4 @@
-void f() {
+static void f() {
     if (1)
         ;
 }

--- a/cpp/ql/test/library-tests/syntax-zoo/ellipsisexceptionhandler.cpp
+++ b/cpp/ql/test/library-tests/syntax-zoo/ellipsisexceptionhandler.cpp
@@ -1,6 +1,6 @@
 namespace eehandler {
 
-void f() {
+static void f() {
 	try {
 		try {
 			throw 1;

--- a/cpp/ql/test/library-tests/syntax-zoo/emptyblock.c
+++ b/cpp/ql/test/library-tests/syntax-zoo/emptyblock.c
@@ -1,4 +1,4 @@
-void f() {
+static void f() {
     {
     }
     ;

--- a/cpp/ql/test/library-tests/syntax-zoo/enum.c
+++ b/cpp/ql/test/library-tests/syntax-zoo/enum.c
@@ -2,6 +2,6 @@ enum {
 	a = 1 + 1
 };
 
-int f() {
+static int f() {
 	return a;
 }

--- a/cpp/ql/test/library-tests/syntax-zoo/exceptionhandler.cpp
+++ b/cpp/ql/test/library-tests/syntax-zoo/exceptionhandler.cpp
@@ -7,7 +7,7 @@ void g() {
 	throw 1;
 }
 
-void f() {
+static void f() {
 	try {
 		try {
 			g();

--- a/cpp/ql/test/library-tests/syntax-zoo/exprstmt.c
+++ b/cpp/ql/test/library-tests/syntax-zoo/exprstmt.c
@@ -1,4 +1,4 @@
-void f() {
+static void f() {
     1;
     ;
 }

--- a/cpp/ql/test/library-tests/syntax-zoo/fieldaccess.cpp
+++ b/cpp/ql/test/library-tests/syntax-zoo/fieldaccess.cpp
@@ -3,7 +3,7 @@ class C {
 		int x;
 };
 
-void f() {
+static void f() {
 	C *c;
 	int i;
 	i = c->x;

--- a/cpp/ql/test/library-tests/syntax-zoo/ifelsestmt.c
+++ b/cpp/ql/test/library-tests/syntax-zoo/ifelsestmt.c
@@ -1,4 +1,4 @@
-void always_false_1() {
+static void always_false_1() {
   if(0) {
     l1:;
   }
@@ -8,7 +8,7 @@ void always_false_1() {
   l3:;
 }
 
-void always_false_2() {
+static void always_false_2() {
   if(0)
     l1:;
   else
@@ -16,7 +16,7 @@ void always_false_2() {
   l3:;
 }
 
-void always_true_1() {
+static void always_true_1() {
   if(1) {
     l1:;
   }
@@ -26,7 +26,7 @@ void always_true_1() {
   l3:;
 }
 
-void always_true_2() {
+static void always_true_2() {
   if(1)
     l1:;
   else
@@ -34,7 +34,7 @@ void always_true_2() {
   l3:;
 }
 
-void normal(int x, int y) {
+static void normal(int x, int y) {
   if(x == y) {
     l1:;
   }

--- a/cpp/ql/test/library-tests/syntax-zoo/ifstmt.c
+++ b/cpp/ql/test/library-tests/syntax-zoo/ifstmt.c
@@ -1,30 +1,30 @@
-void always_false_1() {
+static void always_false_1() {
   if(0) {
     l1:;
   }
   l2:;
 }
 
-void always_false_2() {
+static void always_false_2() {
   if(0)
     l1:;
   l2:;
 }
 
-void always_true_1() {
+static void always_true_1() {
   if(1) {
     l1:;
   }
   l2:;
 }
 
-void always_true_2() {
+static void always_true_2() {
   if(1)
     l1:;
   l2:;
 }
 
-void normal(int x, int y) {
+static void normal(int x, int y) {
   if(x == y) {
     l1:;
   }

--- a/cpp/ql/test/library-tests/syntax-zoo/initializer.c
+++ b/cpp/ql/test/library-tests/syntax-zoo/initializer.c
@@ -1,4 +1,4 @@
-void f() {
+static void f() {
 	int a, b;
 	int i = a + b;
 }

--- a/cpp/ql/test/library-tests/syntax-zoo/landexpr.c
+++ b/cpp/ql/test/library-tests/syntax-zoo/landexpr.c
@@ -1,4 +1,4 @@
-void f() {
+static void f() {
 	int a, b;
 	if (a && b) {
 	}

--- a/cpp/ql/test/library-tests/syntax-zoo/ltrbinopexpr.c
+++ b/cpp/ql/test/library-tests/syntax-zoo/ltrbinopexpr.c
@@ -1,4 +1,4 @@
-void f() {
+static void f() {
     int i, j;
     int* p, q;
     

--- a/cpp/ql/test/library-tests/syntax-zoo/membercallexpr.cpp
+++ b/cpp/ql/test/library-tests/syntax-zoo/membercallexpr.cpp
@@ -3,7 +3,7 @@ class C {
 		void g();
 };
 
-void f() {
+static void f() {
 	C *c;
 	c->g();
 	;

--- a/cpp/ql/test/library-tests/syntax-zoo/membercallexpr_args.cpp
+++ b/cpp/ql/test/library-tests/syntax-zoo/membercallexpr_args.cpp
@@ -4,7 +4,7 @@ class C {
 		void g(int x, int y);
 };
 
-void f() {
+static void f() {
 	int i, j, k, l;
 	C *c;
 	c->d->g(i + j, k - l);

--- a/cpp/ql/test/library-tests/syntax-zoo/ms_assume.cpp
+++ b/cpp/ql/test/library-tests/syntax-zoo/ms_assume.cpp
@@ -8,7 +8,7 @@ int ignore_return_value();
 #define IGNORE_RETURN_VALUE() ignore_return_value()
 void myIgnoreReturnValue();
 
-int main(int argc, char *argv[])
+static int f(int argc, char *argv[])
 {
 	char *s1 = Xstrdup("Hello, world!");
 	char *s2 = Xstrdup(0);

--- a/cpp/ql/test/library-tests/syntax-zoo/newexpr.cpp
+++ b/cpp/ql/test/library-tests/syntax-zoo/newexpr.cpp
@@ -3,7 +3,7 @@ class C {
 		C(int i, int j);
 };
 
-void f() {
+static void f() {
 	int a, b, c, d;
 	new C(a + b, c - d);
 }

--- a/cpp/ql/test/library-tests/syntax-zoo/no_dynamic_init.cpp
+++ b/cpp/ql/test/library-tests/syntax-zoo/no_dynamic_init.cpp
@@ -6,7 +6,7 @@ struct Magic {
   }
 };
 
-int main() {
+static int f() {
   static Magic m;
   return 0;
 }

--- a/cpp/ql/test/library-tests/syntax-zoo/nodefaultswitchstmt.c
+++ b/cpp/ql/test/library-tests/syntax-zoo/nodefaultswitchstmt.c
@@ -1,4 +1,4 @@
-void f(int x) {
+static void f(int x) {
      switch (x) {
         case 1:
         case 2:

--- a/cpp/ql/test/library-tests/syntax-zoo/nonmembercallexpr.c
+++ b/cpp/ql/test/library-tests/syntax-zoo/nonmembercallexpr.c
@@ -1,6 +1,6 @@
 void g() { }
 
-void f() {
+static void f() {
 	g();
 	;
 }

--- a/cpp/ql/test/library-tests/syntax-zoo/nonmemberfp2callexpr.c
+++ b/cpp/ql/test/library-tests/syntax-zoo/nonmemberfp2callexpr.c
@@ -1,6 +1,6 @@
 void (*g())();
 
-void f() {
+static void f() {
 	g()();
 	;
 }

--- a/cpp/ql/test/library-tests/syntax-zoo/nonmemberfpcallexpr.c
+++ b/cpp/ql/test/library-tests/syntax-zoo/nonmemberfpcallexpr.c
@@ -1,4 +1,4 @@
-void f() {
+static void f() {
 	int (*g)();
 	g();
 	;

--- a/cpp/ql/test/library-tests/syntax-zoo/pmcallexpr.cpp
+++ b/cpp/ql/test/library-tests/syntax-zoo/pmcallexpr.cpp
@@ -3,7 +3,7 @@ class C {
 		void (C::*g)();
 };
 
-void f() {
+static void f() {
 	C *c, *d;
 	(c->*(d->g))();
 	;

--- a/cpp/ql/test/library-tests/syntax-zoo/questionexpr.c
+++ b/cpp/ql/test/library-tests/syntax-zoo/questionexpr.c
@@ -1,4 +1,4 @@
-void f() {
+static void f() {
 	int a, b, c, d, x;
 	x = a == b ? c + b : d - b;
 }

--- a/cpp/ql/test/library-tests/syntax-zoo/raw_consistency.expected
+++ b/cpp/ql/test/library-tests/syntax-zoo/raw_consistency.expected
@@ -20,7 +20,6 @@ instructionWithoutSuccessor
 | condition_decls.cpp:26:23:26:24 | IndirectMayWriteSideEffect: call to BoxedInt | Instruction 'IndirectMayWriteSideEffect: call to BoxedInt' has no successors in function '$@'. | condition_decls.cpp:25:6:25:21 | void switch_decl_bind(int) | void switch_decl_bind(int) |
 | condition_decls.cpp:41:22:41:23 | IndirectMayWriteSideEffect: call to BoxedInt | Instruction 'IndirectMayWriteSideEffect: call to BoxedInt' has no successors in function '$@'. | condition_decls.cpp:40:6:40:20 | void while_decl_bind(int) | void while_decl_bind(int) |
 | condition_decls.cpp:48:52:48:53 | IndirectMayWriteSideEffect: call to BoxedInt | Instruction 'IndirectMayWriteSideEffect: call to BoxedInt' has no successors in function '$@'. | condition_decls.cpp:47:6:47:18 | void for_decl_bind(int) | void for_decl_bind(int) |
-| enum.c:6:9:6:9 | Constant: (int)... | Instruction 'Constant: (int)...' has no successors in function '$@'. | aggregateinitializer.c:1:6:1:6 | int f(int); void f(int) | int f(int); void f(int) |
 | file://:0:0:0:0 | CompareNE: (bool)... | Instruction 'CompareNE: (bool)...' has no successors in function '$@'. | condition_decls.cpp:15:6:15:17 | void if_decl_bind(int) | void if_decl_bind(int) |
 | file://:0:0:0:0 | CompareNE: (bool)... | Instruction 'CompareNE: (bool)...' has no successors in function '$@'. | condition_decls.cpp:40:6:40:20 | void while_decl_bind(int) | void while_decl_bind(int) |
 | file://:0:0:0:0 | CompareNE: (bool)... | Instruction 'CompareNE: (bool)...' has no successors in function '$@'. | condition_decls.cpp:47:6:47:18 | void for_decl_bind(int) | void for_decl_bind(int) |
@@ -36,9 +35,9 @@ instructionWithoutSuccessor
 | stmt_expr.cpp:27:5:27:15 | Store: ... = ... | Instruction 'Store: ... = ...' has no successors in function '$@'. | stmt_expr.cpp:21:6:21:6 | void stmtexpr::g(int) | void stmtexpr::g(int) |
 | stmt_expr.cpp:29:11:32:11 | CopyValue: (statement expression) | Instruction 'CopyValue: (statement expression)' has no successors in function '$@'. | stmt_expr.cpp:21:6:21:6 | void stmtexpr::g(int) | void stmtexpr::g(int) |
 | stmt_in_type.cpp:5:53:5:53 | Constant: 1 | Instruction 'Constant: 1' has no successors in function '$@'. | stmt_in_type.cpp:2:6:2:12 | void cpp_fun() | void cpp_fun() |
-| vla.c:5:9:5:14 | Uninitialized: definition of matrix | Instruction 'Uninitialized: definition of matrix' has no successors in function '$@'. | vla.c:3:5:3:8 | int main(int, char**) | int main(int, char**) |
-| vla.c:5:16:5:19 | Load: argc | Instruction 'Load: argc' has no successors in function '$@'. | vla.c:3:5:3:8 | int main(int, char**) | int main(int, char**) |
-| vla.c:5:27:5:33 | BufferReadSideEffect: (const char *)... | Instruction 'BufferReadSideEffect: (const char *)...' has no successors in function '$@'. | vla.c:3:5:3:8 | int main(int, char**) | int main(int, char**) |
+| vla.c:5:9:5:14 | Uninitialized: definition of matrix | Instruction 'Uninitialized: definition of matrix' has no successors in function '$@'. | vla.c:3:12:3:12 | int f(int, char**) | int f(int, char**) |
+| vla.c:5:16:5:19 | Load: argc | Instruction 'Load: argc' has no successors in function '$@'. | vla.c:3:12:3:12 | int f(int, char**) | int f(int, char**) |
+| vla.c:5:27:5:33 | BufferReadSideEffect: (const char *)... | Instruction 'BufferReadSideEffect: (const char *)...' has no successors in function '$@'. | vla.c:3:12:3:12 | int f(int, char**) | int f(int, char**) |
 | vla.c:11:6:11:16 | InitializeNonLocal: vla_typedef | Instruction 'InitializeNonLocal: vla_typedef' has no successors in function '$@'. | vla.c:11:6:11:16 | void vla_typedef() | void vla_typedef() |
 | vla.c:12:33:12:44 | Add: ... + ... | Instruction 'Add: ... + ...' has no successors in function '$@'. | vla.c:11:6:11:16 | void vla_typedef() | void vla_typedef() |
 | vla.c:12:50:12:62 | Mul: ... * ... | Instruction 'Mul: ... * ...' has no successors in function '$@'. | vla.c:11:6:11:16 | void vla_typedef() | void vla_typedef() |
@@ -48,64 +47,12 @@ instructionWithoutSuccessor
 | vla.c:14:74:14:79 | CallSideEffect: call to getInt | Instruction 'CallSideEffect: call to getInt' has no successors in function '$@'. | vla.c:11:6:11:16 | void vla_typedef() | void vla_typedef() |
 | vla.c:14:92:14:94 | Store: (char *)... | Instruction 'Store: (char *)...' has no successors in function '$@'. | vla.c:11:6:11:16 | void vla_typedef() | void vla_typedef() |
 ambiguousSuccessors
-| allocators.cpp:14:5:14:8 | InitializeNonLocal: main | Instruction 'InitializeNonLocal: main' has 4 successors of kind 'Goto' in function '$@'. | allocators.cpp:14:5:14:8 | int main() | int main() |
-| array_delete.cpp:5:6:5:6 | InitializeNonLocal: f | Instruction 'InitializeNonLocal: f' has 14 successors of kind 'Goto' in function '$@'. | array_delete.cpp:5:6:5:6 | void f() | void f() |
-| assignexpr.cpp:6:6:6:6 | InitializeNonLocal: f | Instruction 'InitializeNonLocal: f' has 14 successors of kind 'Goto' in function '$@'. | array_delete.cpp:5:6:5:6 | void f() | void f() |
-| break_labels.c:2:11:2:11 | InitializeParameter: i | Instruction 'InitializeParameter: i' has 19 successors of kind 'Goto' in function '$@'. | aggregateinitializer.c:1:6:1:6 | int f(int); void f(int) | int f(int); void f(int) |
-| break_labels.c:2:11:2:11 | InitializeParameter: i | Instruction 'InitializeParameter: x' has 19 successors of kind 'Goto' in function '$@'. | aggregateinitializer.c:1:6:1:6 | int f(int); void f(int) | int f(int); void f(int) |
-| break_labels.c:2:11:2:11 | InitializeParameter: x | Instruction 'InitializeParameter: i' has 19 successors of kind 'Goto' in function '$@'. | aggregateinitializer.c:1:6:1:6 | int f(int); void f(int) | int f(int); void f(int) |
-| break_labels.c:2:11:2:11 | InitializeParameter: x | Instruction 'InitializeParameter: x' has 19 successors of kind 'Goto' in function '$@'. | aggregateinitializer.c:1:6:1:6 | int f(int); void f(int) | int f(int); void f(int) |
 | conditional_destructors.cpp:29:6:29:7 | InitializeNonLocal: f1 | Instruction 'InitializeNonLocal: f1' has 2 successors of kind 'Goto' in function '$@'. | conditional_destructors.cpp:29:6:29:7 | void f1() | void f1() |
 | conditional_destructors.cpp:38:6:38:7 | InitializeNonLocal: f2 | Instruction 'InitializeNonLocal: f2' has 2 successors of kind 'Goto' in function '$@'. | conditional_destructors.cpp:38:6:38:7 | void f2() | void f2() |
-| constmemberaccess.cpp:6:6:6:6 | InitializeNonLocal: f | Instruction 'InitializeNonLocal: f' has 14 successors of kind 'Goto' in function '$@'. | array_delete.cpp:5:6:5:6 | void f() | void f() |
-| constructorinitializer.cpp:6:6:6:6 | InitializeNonLocal: f | Instruction 'InitializeNonLocal: f' has 14 successors of kind 'Goto' in function '$@'. | array_delete.cpp:5:6:5:6 | void f() | void f() |
-| defconstructornewexpr.cpp:3:6:3:6 | InitializeNonLocal: f | Instruction 'InitializeNonLocal: f' has 14 successors of kind 'Goto' in function '$@'. | array_delete.cpp:5:6:5:6 | void f() | void f() |
-| defdestructordeleteexpr.cpp:3:6:3:6 | InitializeNonLocal: f | Instruction 'InitializeNonLocal: f' has 14 successors of kind 'Goto' in function '$@'. | array_delete.cpp:5:6:5:6 | void f() | void f() |
-| deleteexpr.cpp:6:6:6:6 | InitializeNonLocal: f | Instruction 'InitializeNonLocal: f' has 14 successors of kind 'Goto' in function '$@'. | array_delete.cpp:5:6:5:6 | void f() | void f() |
-| dostmt.c:8:6:8:18 | InitializeNonLocal: always_true_1 | Instruction 'InitializeNonLocal: always_true_1' has 4 successors of kind 'Goto' in function '$@'. | dostmt.c:8:6:8:18 | void always_true_1() | void always_true_1() |
-| dostmt.c:16:6:16:18 | InitializeNonLocal: always_true_2 | Instruction 'InitializeNonLocal: always_true_2' has 4 successors of kind 'Goto' in function '$@'. | dostmt.c:16:6:16:18 | void always_true_2() | void always_true_2() |
-| dostmt.c:25:6:25:18 | InitializeNonLocal: always_true_3 | Instruction 'InitializeNonLocal: always_true_3' has 2 successors of kind 'Goto' in function '$@'. | dostmt.c:25:6:25:18 | void always_true_3() | void always_true_3() |
-| duff.c:2:12:2:12 | InitializeParameter: i | Instruction 'InitializeParameter: i' has 19 successors of kind 'Goto' in function '$@'. | aggregateinitializer.c:1:6:1:6 | int f(int); void f(int) | int f(int); void f(int) |
-| duff.c:2:12:2:12 | InitializeParameter: i | Instruction 'InitializeParameter: x' has 19 successors of kind 'Goto' in function '$@'. | aggregateinitializer.c:1:6:1:6 | int f(int); void f(int) | int f(int); void f(int) |
-| duff.c:2:12:2:12 | InitializeParameter: x | Instruction 'InitializeParameter: i' has 19 successors of kind 'Goto' in function '$@'. | aggregateinitializer.c:1:6:1:6 | int f(int); void f(int) | int f(int); void f(int) |
-| duff.c:2:12:2:12 | InitializeParameter: x | Instruction 'InitializeParameter: x' has 19 successors of kind 'Goto' in function '$@'. | aggregateinitializer.c:1:6:1:6 | int f(int); void f(int) | int f(int); void f(int) |
-| fieldaccess.cpp:6:6:6:6 | InitializeNonLocal: f | Instruction 'InitializeNonLocal: f' has 14 successors of kind 'Goto' in function '$@'. | array_delete.cpp:5:6:5:6 | void f() | void f() |
 | forstmt.cpp:1:6:1:7 | InitializeNonLocal: f1 | Instruction 'InitializeNonLocal: f1' has 2 successors of kind 'Goto' in function '$@'. | conditional_destructors.cpp:29:6:29:7 | void f1() | void f1() |
 | forstmt.cpp:8:6:8:7 | InitializeNonLocal: f2 | Instruction 'InitializeNonLocal: f2' has 2 successors of kind 'Goto' in function '$@'. | conditional_destructors.cpp:38:6:38:7 | void f2() | void f2() |
-| ifelsestmt.c:1:6:1:19 | InitializeNonLocal: always_false_1 | Instruction 'InitializeNonLocal: always_false_1' has 3 successors of kind 'Goto' in function '$@'. | ifelsestmt.c:1:6:1:19 | void always_false_1() | void always_false_1() |
-| ifelsestmt.c:11:6:11:19 | InitializeNonLocal: always_false_2 | Instruction 'InitializeNonLocal: always_false_2' has 3 successors of kind 'Goto' in function '$@'. | ifelsestmt.c:11:6:11:19 | void always_false_2() | void always_false_2() |
-| ifelsestmt.c:19:6:19:18 | InitializeNonLocal: always_true_1 | Instruction 'InitializeNonLocal: always_true_1' has 4 successors of kind 'Goto' in function '$@'. | dostmt.c:8:6:8:18 | void always_true_1() | void always_true_1() |
-| ifelsestmt.c:29:6:29:18 | InitializeNonLocal: always_true_2 | Instruction 'InitializeNonLocal: always_true_2' has 4 successors of kind 'Goto' in function '$@'. | dostmt.c:16:6:16:18 | void always_true_2() | void always_true_2() |
-| ifelsestmt.c:37:24:37:24 | InitializeParameter: y | Instruction 'InitializeParameter: y' has 4 successors of kind 'Goto' in function '$@'. | dostmt.c:32:6:32:11 | void normal(int, int) | void normal(int, int) |
-| ifstmt.c:1:6:1:19 | InitializeNonLocal: always_false_1 | Instruction 'InitializeNonLocal: always_false_1' has 3 successors of kind 'Goto' in function '$@'. | ifelsestmt.c:1:6:1:19 | void always_false_1() | void always_false_1() |
-| ifstmt.c:8:6:8:19 | InitializeNonLocal: always_false_2 | Instruction 'InitializeNonLocal: always_false_2' has 3 successors of kind 'Goto' in function '$@'. | ifelsestmt.c:11:6:11:19 | void always_false_2() | void always_false_2() |
-| ifstmt.c:14:6:14:18 | InitializeNonLocal: always_true_1 | Instruction 'InitializeNonLocal: always_true_1' has 4 successors of kind 'Goto' in function '$@'. | dostmt.c:8:6:8:18 | void always_true_1() | void always_true_1() |
-| ifstmt.c:21:6:21:18 | InitializeNonLocal: always_true_2 | Instruction 'InitializeNonLocal: always_true_2' has 4 successors of kind 'Goto' in function '$@'. | dostmt.c:16:6:16:18 | void always_true_2() | void always_true_2() |
-| ifstmt.c:27:24:27:24 | InitializeParameter: y | Instruction 'InitializeParameter: y' has 4 successors of kind 'Goto' in function '$@'. | dostmt.c:32:6:32:11 | void normal(int, int) | void normal(int, int) |
-| membercallexpr.cpp:6:6:6:6 | InitializeNonLocal: f | Instruction 'InitializeNonLocal: f' has 14 successors of kind 'Goto' in function '$@'. | array_delete.cpp:5:6:5:6 | void f() | void f() |
-| membercallexpr_args.cpp:7:6:7:6 | InitializeNonLocal: f | Instruction 'InitializeNonLocal: f' has 14 successors of kind 'Goto' in function '$@'. | array_delete.cpp:5:6:5:6 | void f() | void f() |
-| newexpr.cpp:6:6:6:6 | InitializeNonLocal: f | Instruction 'InitializeNonLocal: f' has 14 successors of kind 'Goto' in function '$@'. | array_delete.cpp:5:6:5:6 | void f() | void f() |
-| no_dynamic_init.cpp:9:5:9:8 | InitializeNonLocal: main | Instruction 'InitializeNonLocal: main' has 4 successors of kind 'Goto' in function '$@'. | allocators.cpp:14:5:14:8 | int main() | int main() |
-| nodefaultswitchstmt.c:1:12:1:12 | InitializeParameter: i | Instruction 'InitializeParameter: i' has 19 successors of kind 'Goto' in function '$@'. | aggregateinitializer.c:1:6:1:6 | int f(int); void f(int) | int f(int); void f(int) |
-| nodefaultswitchstmt.c:1:12:1:12 | InitializeParameter: i | Instruction 'InitializeParameter: x' has 19 successors of kind 'Goto' in function '$@'. | aggregateinitializer.c:1:6:1:6 | int f(int); void f(int) | int f(int); void f(int) |
-| nodefaultswitchstmt.c:1:12:1:12 | InitializeParameter: x | Instruction 'InitializeParameter: i' has 19 successors of kind 'Goto' in function '$@'. | aggregateinitializer.c:1:6:1:6 | int f(int); void f(int) | int f(int); void f(int) |
-| nodefaultswitchstmt.c:1:12:1:12 | InitializeParameter: x | Instruction 'InitializeParameter: x' has 19 successors of kind 'Goto' in function '$@'. | aggregateinitializer.c:1:6:1:6 | int f(int); void f(int) | int f(int); void f(int) |
 | nonmembercallexpr.c:1:6:1:6 | InitializeNonLocal: g | Instruction 'InitializeNonLocal: g' has 2 successors of kind 'Goto' in function '$@'. | nonmembercallexpr.c:1:6:1:6 | void g(); void g())(); void(* g(); void(* g())() | void g(); void g())(); void(* g(); void(* g())() |
-| parameterinitializer.cpp:18:5:18:8 | InitializeNonLocal: main | Instruction 'InitializeNonLocal: main' has 4 successors of kind 'Goto' in function '$@'. | allocators.cpp:14:5:14:8 | int main() | int main() |
-| pmcallexpr.cpp:6:6:6:6 | InitializeNonLocal: f | Instruction 'InitializeNonLocal: f' has 14 successors of kind 'Goto' in function '$@'. | array_delete.cpp:5:6:5:6 | void f() | void f() |
 | revsubscriptexpr.c:1:6:1:6 | InitializeNonLocal: g | Instruction 'InitializeNonLocal: g' has 2 successors of kind 'Goto' in function '$@'. | nonmembercallexpr.c:1:6:1:6 | void g(); void g())(); void(* g(); void(* g())() | void g(); void g())(); void(* g(); void(* g())() |
-| staticmembercallexpr.cpp:6:6:6:6 | InitializeNonLocal: f | Instruction 'InitializeNonLocal: f' has 14 successors of kind 'Goto' in function '$@'. | array_delete.cpp:5:6:5:6 | void f() | void f() |
-| staticmembercallexpr_args.cpp:7:6:7:6 | InitializeNonLocal: f | Instruction 'InitializeNonLocal: f' has 14 successors of kind 'Goto' in function '$@'. | array_delete.cpp:5:6:5:6 | void f() | void f() |
-| stream_it.cpp:16:5:16:8 | InitializeNonLocal: main | Instruction 'InitializeNonLocal: main' has 4 successors of kind 'Goto' in function '$@'. | allocators.cpp:14:5:14:8 | int main() | int main() |
-| switchstmt.c:1:12:1:12 | InitializeParameter: i | Instruction 'InitializeParameter: i' has 19 successors of kind 'Goto' in function '$@'. | aggregateinitializer.c:1:6:1:6 | int f(int); void f(int) | int f(int); void f(int) |
-| switchstmt.c:1:12:1:12 | InitializeParameter: i | Instruction 'InitializeParameter: x' has 19 successors of kind 'Goto' in function '$@'. | aggregateinitializer.c:1:6:1:6 | int f(int); void f(int) | int f(int); void f(int) |
-| switchstmt.c:1:12:1:12 | InitializeParameter: x | Instruction 'InitializeParameter: i' has 19 successors of kind 'Goto' in function '$@'. | aggregateinitializer.c:1:6:1:6 | int f(int); void f(int) | int f(int); void f(int) |
-| switchstmt.c:1:12:1:12 | InitializeParameter: x | Instruction 'InitializeParameter: x' has 19 successors of kind 'Goto' in function '$@'. | aggregateinitializer.c:1:6:1:6 | int f(int); void f(int) | int f(int); void f(int) |
-| whilestmt.c:1:6:1:19 | InitializeNonLocal: always_false_1 | Instruction 'InitializeNonLocal: always_false_1' has 3 successors of kind 'Goto' in function '$@'. | ifelsestmt.c:1:6:1:19 | void always_false_1() | void always_false_1() |
-| whilestmt.c:8:6:8:19 | InitializeNonLocal: always_false_2 | Instruction 'InitializeNonLocal: always_false_2' has 3 successors of kind 'Goto' in function '$@'. | ifelsestmt.c:11:6:11:19 | void always_false_2() | void always_false_2() |
-| whilestmt.c:15:6:15:18 | InitializeNonLocal: always_true_1 | Instruction 'InitializeNonLocal: always_true_1' has 4 successors of kind 'Goto' in function '$@'. | dostmt.c:8:6:8:18 | void always_true_1() | void always_true_1() |
-| whilestmt.c:23:6:23:18 | InitializeNonLocal: always_true_2 | Instruction 'InitializeNonLocal: always_true_2' has 4 successors of kind 'Goto' in function '$@'. | dostmt.c:16:6:16:18 | void always_true_2() | void always_true_2() |
-| whilestmt.c:32:6:32:18 | InitializeNonLocal: always_true_3 | Instruction 'InitializeNonLocal: always_true_3' has 2 successors of kind 'Goto' in function '$@'. | dostmt.c:25:6:25:18 | void always_true_3() | void always_true_3() |
 unexplainedLoop
 unnecessaryPhiInstruction
 memoryOperandDefinitionIsUnmodeled
@@ -117,13 +64,14 @@ backEdgeCountMismatch
 useNotDominatedByDefinition
 | VacuousDestructorCall.cpp:2:29:2:29 | Address | Operand 'Address' is not dominated by its definition in function '$@'. | VacuousDestructorCall.cpp:2:6:2:6 | void CallDestructor<int>(int, int*) | void CallDestructor<int>(int, int*) |
 | misc.c:219:47:219:48 | Address | Operand 'Address' is not dominated by its definition in function '$@'. | misc.c:219:5:219:26 | int assign_designated_init(someStruct*) | int assign_designated_init(someStruct*) |
+| ms_assume.cpp:11:30:11:33 | Address | Operand 'Address' is not dominated by its definition in function '$@'. | ms_assume.cpp:11:12:11:12 | int f(int, char*[]) | int f(int, char*[]) |
 | ms_try_except.cpp:9:19:9:19 | Left | Operand 'Left' is not dominated by its definition in function '$@'. | ms_try_except.cpp:2:6:2:18 | void ms_try_except(int) | void ms_try_except(int) |
 | ms_try_except.cpp:9:19:9:19 | Left | Operand 'Left' is not dominated by its definition in function '$@'. | ms_try_except.cpp:2:6:2:18 | void ms_try_except(int) | void ms_try_except(int) |
 | ms_try_except.cpp:19:17:19:21 | Left | Operand 'Left' is not dominated by its definition in function '$@'. | ms_try_except.cpp:2:6:2:18 | void ms_try_except(int) | void ms_try_except(int) |
 | ms_try_except.cpp:19:17:19:21 | Left | Operand 'Left' is not dominated by its definition in function '$@'. | ms_try_except.cpp:2:6:2:18 | void ms_try_except(int) | void ms_try_except(int) |
 | static_init_templates.cpp:15:1:15:18 | Address | Operand 'Address' is not dominated by its definition in function '$@'. | static_init_templates.cpp:15:1:15:18 | void MyClass::MyClass() | void MyClass::MyClass() |
 | try_catch.cpp:21:9:21:9 | Address | Operand 'Address' is not dominated by its definition in function '$@'. | try_catch.cpp:19:6:19:23 | void throw_from_nonstmt(int) | void throw_from_nonstmt(int) |
-| vla.c:3:27:3:30 | Address | Operand 'Address' is not dominated by its definition in function '$@'. | vla.c:3:5:3:8 | int main(int, char**) | int main(int, char**) |
+| vla.c:3:31:3:34 | Address | Operand 'Address' is not dominated by its definition in function '$@'. | vla.c:3:12:3:12 | int f(int, char**) | int f(int, char**) |
 switchInstructionWithoutDefaultEdge
 notMarkedAsConflated
 wronglyMarkedAsConflated
@@ -131,7 +79,7 @@ invalidOverlap
 nonUniqueEnclosingIRFunction
 fieldAddressOnNonPointer
 thisArgumentIsNonPointer
-| pmcallexpr.cpp:8:2:8:15 | Call: call to expression | Call instruction 'Call: call to expression' has a `this` argument operand that is not an address, in function '$@'. | array_delete.cpp:5:6:5:6 | void f() | void f() |
+| pmcallexpr.cpp:8:2:8:15 | Call: call to expression | Call instruction 'Call: call to expression' has a `this` argument operand that is not an address, in function '$@'. | pmcallexpr.cpp:6:13:6:13 | void f() | void f() |
 | pointer_to_member.cpp:23:5:23:54 | Call: call to expression | Call instruction 'Call: call to expression' has a `this` argument operand that is not an address, in function '$@'. | pointer_to_member.cpp:14:5:14:9 | int usePM(int PM::*) | int usePM(int PM::*) |
 | pointer_to_member.cpp:24:5:24:49 | Call: call to expression | Call instruction 'Call: call to expression' has a `this` argument operand that is not an address, in function '$@'. | pointer_to_member.cpp:14:5:14:9 | int usePM(int PM::*) | int usePM(int PM::*) |
 nonUniqueIRVariable

--- a/cpp/ql/test/library-tests/syntax-zoo/staticlocals.cpp
+++ b/cpp/ql/test/library-tests/syntax-zoo/staticlocals.cpp
@@ -8,7 +8,7 @@ int h() {
     return 1;
 }
 
-void f() {
+static void f() {
     static int i = g(), j = h();
     static int k = g();
     ;

--- a/cpp/ql/test/library-tests/syntax-zoo/staticmembercallexpr.cpp
+++ b/cpp/ql/test/library-tests/syntax-zoo/staticmembercallexpr.cpp
@@ -3,7 +3,7 @@ class C {
 		static void g();
 };
 
-void f() {
+static void f() {
 	C c;
 	c.g();
 	;

--- a/cpp/ql/test/library-tests/syntax-zoo/staticmembercallexpr_args.cpp
+++ b/cpp/ql/test/library-tests/syntax-zoo/staticmembercallexpr_args.cpp
@@ -4,7 +4,7 @@ class C {
 		static void g(int x, int y);
 };
 
-void f() {
+static void f() {
 	int i, j, k, l;
 	C c;
 	c.d->g(i + j, k - l);

--- a/cpp/ql/test/library-tests/syntax-zoo/stmt_expr.cpp
+++ b/cpp/ql/test/library-tests/syntax-zoo/stmt_expr.cpp
@@ -6,7 +6,7 @@ class C {
         ~C();
 };
 
-void f(int b) {
+static void f(int b) {
     int i;
 
     if (({

--- a/cpp/ql/test/library-tests/syntax-zoo/stream_it.cpp
+++ b/cpp/ql/test/library-tests/syntax-zoo/stream_it.cpp
@@ -13,7 +13,7 @@ void stream_it(vector<T>& t)
   }
 }
 
-int main()
+static int f()
 {
   vector<int> xs;
   stream_it(xs);

--- a/cpp/ql/test/library-tests/syntax-zoo/subscriptexpr.c
+++ b/cpp/ql/test/library-tests/syntax-zoo/subscriptexpr.c
@@ -1,4 +1,4 @@
-void f() {
+static void f() {
 	double x[5];
 	int i, a, b;
 	i = x[a + b];

--- a/cpp/ql/test/library-tests/syntax-zoo/switchstmt.c
+++ b/cpp/ql/test/library-tests/syntax-zoo/switchstmt.c
@@ -1,4 +1,4 @@
-void f(int x) {
+static void f(int x) {
      switch (x) {
         case 1:
         case 2:

--- a/cpp/ql/test/library-tests/syntax-zoo/tinyforstmt.c
+++ b/cpp/ql/test/library-tests/syntax-zoo/tinyforstmt.c
@@ -1,4 +1,4 @@
-void f() {
+static void f() {
     for (;;) {
         ;
     }

--- a/cpp/ql/test/library-tests/syntax-zoo/unaliased_ssa_consistency.expected
+++ b/cpp/ql/test/library-tests/syntax-zoo/unaliased_ssa_consistency.expected
@@ -16,67 +16,15 @@ instructionWithoutSuccessor
 | ms_try_mix.cpp:33:13:33:19 | ThrowValue: throw ... | Instruction 'ThrowValue: throw ...' has no successors in function '$@'. | ms_try_mix.cpp:27:6:27:19 | void ms_finally_mix(int) | void ms_finally_mix(int) |
 | ms_try_mix.cpp:51:5:51:11 | ThrowValue: throw ... | Instruction 'ThrowValue: throw ...' has no successors in function '$@'. | ms_try_mix.cpp:47:6:47:28 | void ms_empty_finally_at_end() | void ms_empty_finally_at_end() |
 | stmt_expr.cpp:27:5:27:15 | Store: ... = ... | Instruction 'Store: ... = ...' has no successors in function '$@'. | stmt_expr.cpp:21:6:21:6 | void stmtexpr::g(int) | void stmtexpr::g(int) |
-| vla.c:5:9:5:14 | Uninitialized: definition of matrix | Instruction 'Uninitialized: definition of matrix' has no successors in function '$@'. | vla.c:3:5:3:8 | int main(int, char**) | int main(int, char**) |
+| vla.c:5:9:5:14 | Uninitialized: definition of matrix | Instruction 'Uninitialized: definition of matrix' has no successors in function '$@'. | vla.c:3:12:3:12 | int f(int, char**) | int f(int, char**) |
 | vla.c:11:6:11:16 | InitializeNonLocal: vla_typedef | Instruction 'InitializeNonLocal: vla_typedef' has no successors in function '$@'. | vla.c:11:6:11:16 | void vla_typedef() | void vla_typedef() |
 ambiguousSuccessors
-| allocators.cpp:14:5:14:8 | InitializeNonLocal: main | Instruction 'InitializeNonLocal: main' has 4 successors of kind 'Goto' in function '$@'. | allocators.cpp:14:5:14:8 | int main() | int main() |
-| array_delete.cpp:5:6:5:6 | InitializeNonLocal: f | Instruction 'InitializeNonLocal: f' has 14 successors of kind 'Goto' in function '$@'. | array_delete.cpp:5:6:5:6 | void f() | void f() |
-| assignexpr.cpp:6:6:6:6 | InitializeNonLocal: f | Instruction 'InitializeNonLocal: f' has 14 successors of kind 'Goto' in function '$@'. | array_delete.cpp:5:6:5:6 | void f() | void f() |
-| break_labels.c:2:11:2:11 | InitializeParameter: i | Instruction 'InitializeParameter: i' has 19 successors of kind 'Goto' in function '$@'. | aggregateinitializer.c:1:6:1:6 | int f(int); void f(int) | int f(int); void f(int) |
-| break_labels.c:2:11:2:11 | InitializeParameter: i | Instruction 'InitializeParameter: x' has 19 successors of kind 'Goto' in function '$@'. | aggregateinitializer.c:1:6:1:6 | int f(int); void f(int) | int f(int); void f(int) |
-| break_labels.c:2:11:2:11 | InitializeParameter: x | Instruction 'InitializeParameter: i' has 19 successors of kind 'Goto' in function '$@'. | aggregateinitializer.c:1:6:1:6 | int f(int); void f(int) | int f(int); void f(int) |
-| break_labels.c:2:11:2:11 | InitializeParameter: x | Instruction 'InitializeParameter: x' has 19 successors of kind 'Goto' in function '$@'. | aggregateinitializer.c:1:6:1:6 | int f(int); void f(int) | int f(int); void f(int) |
 | conditional_destructors.cpp:29:6:29:7 | InitializeNonLocal: f1 | Instruction 'InitializeNonLocal: f1' has 2 successors of kind 'Goto' in function '$@'. | conditional_destructors.cpp:29:6:29:7 | void f1() | void f1() |
 | conditional_destructors.cpp:38:6:38:7 | InitializeNonLocal: f2 | Instruction 'InitializeNonLocal: f2' has 2 successors of kind 'Goto' in function '$@'. | conditional_destructors.cpp:38:6:38:7 | void f2() | void f2() |
-| constmemberaccess.cpp:6:6:6:6 | InitializeNonLocal: f | Instruction 'InitializeNonLocal: f' has 14 successors of kind 'Goto' in function '$@'. | array_delete.cpp:5:6:5:6 | void f() | void f() |
-| constructorinitializer.cpp:6:6:6:6 | InitializeNonLocal: f | Instruction 'InitializeNonLocal: f' has 14 successors of kind 'Goto' in function '$@'. | array_delete.cpp:5:6:5:6 | void f() | void f() |
-| defconstructornewexpr.cpp:3:6:3:6 | InitializeNonLocal: f | Instruction 'InitializeNonLocal: f' has 14 successors of kind 'Goto' in function '$@'. | array_delete.cpp:5:6:5:6 | void f() | void f() |
-| defdestructordeleteexpr.cpp:3:6:3:6 | InitializeNonLocal: f | Instruction 'InitializeNonLocal: f' has 14 successors of kind 'Goto' in function '$@'. | array_delete.cpp:5:6:5:6 | void f() | void f() |
-| deleteexpr.cpp:6:6:6:6 | InitializeNonLocal: f | Instruction 'InitializeNonLocal: f' has 14 successors of kind 'Goto' in function '$@'. | array_delete.cpp:5:6:5:6 | void f() | void f() |
-| dostmt.c:8:6:8:18 | InitializeNonLocal: always_true_1 | Instruction 'InitializeNonLocal: always_true_1' has 4 successors of kind 'Goto' in function '$@'. | dostmt.c:8:6:8:18 | void always_true_1() | void always_true_1() |
-| dostmt.c:16:6:16:18 | InitializeNonLocal: always_true_2 | Instruction 'InitializeNonLocal: always_true_2' has 4 successors of kind 'Goto' in function '$@'. | dostmt.c:16:6:16:18 | void always_true_2() | void always_true_2() |
-| dostmt.c:25:6:25:18 | InitializeNonLocal: always_true_3 | Instruction 'InitializeNonLocal: always_true_3' has 2 successors of kind 'Goto' in function '$@'. | dostmt.c:25:6:25:18 | void always_true_3() | void always_true_3() |
-| duff.c:2:12:2:12 | InitializeParameter: i | Instruction 'InitializeParameter: i' has 19 successors of kind 'Goto' in function '$@'. | aggregateinitializer.c:1:6:1:6 | int f(int); void f(int) | int f(int); void f(int) |
-| duff.c:2:12:2:12 | InitializeParameter: i | Instruction 'InitializeParameter: x' has 19 successors of kind 'Goto' in function '$@'. | aggregateinitializer.c:1:6:1:6 | int f(int); void f(int) | int f(int); void f(int) |
-| duff.c:2:12:2:12 | InitializeParameter: x | Instruction 'InitializeParameter: i' has 19 successors of kind 'Goto' in function '$@'. | aggregateinitializer.c:1:6:1:6 | int f(int); void f(int) | int f(int); void f(int) |
-| duff.c:2:12:2:12 | InitializeParameter: x | Instruction 'InitializeParameter: x' has 19 successors of kind 'Goto' in function '$@'. | aggregateinitializer.c:1:6:1:6 | int f(int); void f(int) | int f(int); void f(int) |
-| fieldaccess.cpp:6:6:6:6 | InitializeNonLocal: f | Instruction 'InitializeNonLocal: f' has 14 successors of kind 'Goto' in function '$@'. | array_delete.cpp:5:6:5:6 | void f() | void f() |
 | forstmt.cpp:1:6:1:7 | InitializeNonLocal: f1 | Instruction 'InitializeNonLocal: f1' has 2 successors of kind 'Goto' in function '$@'. | conditional_destructors.cpp:29:6:29:7 | void f1() | void f1() |
 | forstmt.cpp:8:6:8:7 | InitializeNonLocal: f2 | Instruction 'InitializeNonLocal: f2' has 2 successors of kind 'Goto' in function '$@'. | conditional_destructors.cpp:38:6:38:7 | void f2() | void f2() |
-| ifelsestmt.c:1:6:1:19 | InitializeNonLocal: always_false_1 | Instruction 'InitializeNonLocal: always_false_1' has 3 successors of kind 'Goto' in function '$@'. | ifelsestmt.c:1:6:1:19 | void always_false_1() | void always_false_1() |
-| ifelsestmt.c:11:6:11:19 | InitializeNonLocal: always_false_2 | Instruction 'InitializeNonLocal: always_false_2' has 3 successors of kind 'Goto' in function '$@'. | ifelsestmt.c:11:6:11:19 | void always_false_2() | void always_false_2() |
-| ifelsestmt.c:19:6:19:18 | InitializeNonLocal: always_true_1 | Instruction 'InitializeNonLocal: always_true_1' has 4 successors of kind 'Goto' in function '$@'. | dostmt.c:8:6:8:18 | void always_true_1() | void always_true_1() |
-| ifelsestmt.c:29:6:29:18 | InitializeNonLocal: always_true_2 | Instruction 'InitializeNonLocal: always_true_2' has 4 successors of kind 'Goto' in function '$@'. | dostmt.c:16:6:16:18 | void always_true_2() | void always_true_2() |
-| ifelsestmt.c:37:24:37:24 | InitializeParameter: y | Instruction 'InitializeParameter: y' has 4 successors of kind 'Goto' in function '$@'. | dostmt.c:32:6:32:11 | void normal(int, int) | void normal(int, int) |
-| ifstmt.c:1:6:1:19 | InitializeNonLocal: always_false_1 | Instruction 'InitializeNonLocal: always_false_1' has 3 successors of kind 'Goto' in function '$@'. | ifelsestmt.c:1:6:1:19 | void always_false_1() | void always_false_1() |
-| ifstmt.c:8:6:8:19 | InitializeNonLocal: always_false_2 | Instruction 'InitializeNonLocal: always_false_2' has 3 successors of kind 'Goto' in function '$@'. | ifelsestmt.c:11:6:11:19 | void always_false_2() | void always_false_2() |
-| ifstmt.c:14:6:14:18 | InitializeNonLocal: always_true_1 | Instruction 'InitializeNonLocal: always_true_1' has 4 successors of kind 'Goto' in function '$@'. | dostmt.c:8:6:8:18 | void always_true_1() | void always_true_1() |
-| ifstmt.c:21:6:21:18 | InitializeNonLocal: always_true_2 | Instruction 'InitializeNonLocal: always_true_2' has 4 successors of kind 'Goto' in function '$@'. | dostmt.c:16:6:16:18 | void always_true_2() | void always_true_2() |
-| ifstmt.c:27:24:27:24 | InitializeParameter: y | Instruction 'InitializeParameter: y' has 4 successors of kind 'Goto' in function '$@'. | dostmt.c:32:6:32:11 | void normal(int, int) | void normal(int, int) |
-| membercallexpr.cpp:6:6:6:6 | InitializeNonLocal: f | Instruction 'InitializeNonLocal: f' has 14 successors of kind 'Goto' in function '$@'. | array_delete.cpp:5:6:5:6 | void f() | void f() |
-| membercallexpr_args.cpp:7:6:7:6 | InitializeNonLocal: f | Instruction 'InitializeNonLocal: f' has 14 successors of kind 'Goto' in function '$@'. | array_delete.cpp:5:6:5:6 | void f() | void f() |
-| newexpr.cpp:6:6:6:6 | InitializeNonLocal: f | Instruction 'InitializeNonLocal: f' has 14 successors of kind 'Goto' in function '$@'. | array_delete.cpp:5:6:5:6 | void f() | void f() |
-| no_dynamic_init.cpp:9:5:9:8 | InitializeNonLocal: main | Instruction 'InitializeNonLocal: main' has 4 successors of kind 'Goto' in function '$@'. | allocators.cpp:14:5:14:8 | int main() | int main() |
-| nodefaultswitchstmt.c:1:12:1:12 | InitializeParameter: i | Instruction 'InitializeParameter: i' has 19 successors of kind 'Goto' in function '$@'. | aggregateinitializer.c:1:6:1:6 | int f(int); void f(int) | int f(int); void f(int) |
-| nodefaultswitchstmt.c:1:12:1:12 | InitializeParameter: i | Instruction 'InitializeParameter: x' has 19 successors of kind 'Goto' in function '$@'. | aggregateinitializer.c:1:6:1:6 | int f(int); void f(int) | int f(int); void f(int) |
-| nodefaultswitchstmt.c:1:12:1:12 | InitializeParameter: x | Instruction 'InitializeParameter: i' has 19 successors of kind 'Goto' in function '$@'. | aggregateinitializer.c:1:6:1:6 | int f(int); void f(int) | int f(int); void f(int) |
-| nodefaultswitchstmt.c:1:12:1:12 | InitializeParameter: x | Instruction 'InitializeParameter: x' has 19 successors of kind 'Goto' in function '$@'. | aggregateinitializer.c:1:6:1:6 | int f(int); void f(int) | int f(int); void f(int) |
 | nonmembercallexpr.c:1:6:1:6 | InitializeNonLocal: g | Instruction 'InitializeNonLocal: g' has 2 successors of kind 'Goto' in function '$@'. | nonmembercallexpr.c:1:6:1:6 | void g(); void g())(); void(* g(); void(* g())() | void g(); void g())(); void(* g(); void(* g())() |
-| parameterinitializer.cpp:18:5:18:8 | InitializeNonLocal: main | Instruction 'InitializeNonLocal: main' has 4 successors of kind 'Goto' in function '$@'. | allocators.cpp:14:5:14:8 | int main() | int main() |
-| pmcallexpr.cpp:6:6:6:6 | InitializeNonLocal: f | Instruction 'InitializeNonLocal: f' has 14 successors of kind 'Goto' in function '$@'. | array_delete.cpp:5:6:5:6 | void f() | void f() |
 | revsubscriptexpr.c:1:6:1:6 | InitializeNonLocal: g | Instruction 'InitializeNonLocal: g' has 2 successors of kind 'Goto' in function '$@'. | nonmembercallexpr.c:1:6:1:6 | void g(); void g())(); void(* g(); void(* g())() | void g(); void g())(); void(* g(); void(* g())() |
-| staticmembercallexpr.cpp:6:6:6:6 | InitializeNonLocal: f | Instruction 'InitializeNonLocal: f' has 14 successors of kind 'Goto' in function '$@'. | array_delete.cpp:5:6:5:6 | void f() | void f() |
-| staticmembercallexpr_args.cpp:7:6:7:6 | InitializeNonLocal: f | Instruction 'InitializeNonLocal: f' has 14 successors of kind 'Goto' in function '$@'. | array_delete.cpp:5:6:5:6 | void f() | void f() |
-| stream_it.cpp:16:5:16:8 | InitializeNonLocal: main | Instruction 'InitializeNonLocal: main' has 4 successors of kind 'Goto' in function '$@'. | allocators.cpp:14:5:14:8 | int main() | int main() |
-| switchstmt.c:1:12:1:12 | InitializeParameter: i | Instruction 'InitializeParameter: i' has 19 successors of kind 'Goto' in function '$@'. | aggregateinitializer.c:1:6:1:6 | int f(int); void f(int) | int f(int); void f(int) |
-| switchstmt.c:1:12:1:12 | InitializeParameter: i | Instruction 'InitializeParameter: x' has 19 successors of kind 'Goto' in function '$@'. | aggregateinitializer.c:1:6:1:6 | int f(int); void f(int) | int f(int); void f(int) |
-| switchstmt.c:1:12:1:12 | InitializeParameter: x | Instruction 'InitializeParameter: i' has 19 successors of kind 'Goto' in function '$@'. | aggregateinitializer.c:1:6:1:6 | int f(int); void f(int) | int f(int); void f(int) |
-| switchstmt.c:1:12:1:12 | InitializeParameter: x | Instruction 'InitializeParameter: x' has 19 successors of kind 'Goto' in function '$@'. | aggregateinitializer.c:1:6:1:6 | int f(int); void f(int) | int f(int); void f(int) |
-| whilestmt.c:1:6:1:19 | InitializeNonLocal: always_false_1 | Instruction 'InitializeNonLocal: always_false_1' has 3 successors of kind 'Goto' in function '$@'. | ifelsestmt.c:1:6:1:19 | void always_false_1() | void always_false_1() |
-| whilestmt.c:8:6:8:19 | InitializeNonLocal: always_false_2 | Instruction 'InitializeNonLocal: always_false_2' has 3 successors of kind 'Goto' in function '$@'. | ifelsestmt.c:11:6:11:19 | void always_false_2() | void always_false_2() |
-| whilestmt.c:15:6:15:18 | InitializeNonLocal: always_true_1 | Instruction 'InitializeNonLocal: always_true_1' has 4 successors of kind 'Goto' in function '$@'. | dostmt.c:8:6:8:18 | void always_true_1() | void always_true_1() |
-| whilestmt.c:23:6:23:18 | InitializeNonLocal: always_true_2 | Instruction 'InitializeNonLocal: always_true_2' has 4 successors of kind 'Goto' in function '$@'. | dostmt.c:16:6:16:18 | void always_true_2() | void always_true_2() |
-| whilestmt.c:32:6:32:18 | InitializeNonLocal: always_true_3 | Instruction 'InitializeNonLocal: always_true_3' has 2 successors of kind 'Goto' in function '$@'. | dostmt.c:25:6:25:18 | void always_true_3() | void always_true_3() |
 unexplainedLoop
 unnecessaryPhiInstruction
 memoryOperandDefinitionIsUnmodeled
@@ -93,7 +41,7 @@ invalidOverlap
 nonUniqueEnclosingIRFunction
 fieldAddressOnNonPointer
 thisArgumentIsNonPointer
-| pmcallexpr.cpp:8:2:8:15 | Call: call to expression | Call instruction 'Call: call to expression' has a `this` argument operand that is not an address, in function '$@'. | array_delete.cpp:5:6:5:6 | void f() | void f() |
+| pmcallexpr.cpp:8:2:8:15 | Call: call to expression | Call instruction 'Call: call to expression' has a `this` argument operand that is not an address, in function '$@'. | pmcallexpr.cpp:6:13:6:13 | void f() | void f() |
 | pointer_to_member.cpp:23:5:23:54 | Call: call to expression | Call instruction 'Call: call to expression' has a `this` argument operand that is not an address, in function '$@'. | pointer_to_member.cpp:14:5:14:9 | int usePM(int PM::*) | int usePM(int PM::*) |
 | pointer_to_member.cpp:24:5:24:49 | Call: call to expression | Call instruction 'Call: call to expression' has a `this` argument operand that is not an address, in function '$@'. | pointer_to_member.cpp:14:5:14:9 | int usePM(int PM::*) | int usePM(int PM::*) |
 nonUniqueIRVariable

--- a/cpp/ql/test/library-tests/syntax-zoo/unaryopexpr.c
+++ b/cpp/ql/test/library-tests/syntax-zoo/unaryopexpr.c
@@ -1,4 +1,4 @@
-void f() {
+static void f() {
     int i;
     &i;
     

--- a/cpp/ql/test/library-tests/syntax-zoo/vla.c
+++ b/cpp/ql/test/library-tests/syntax-zoo/vla.c
@@ -1,6 +1,6 @@
 int atoi(const char*);
 
-int main(int argc, char** argv)
+static int f(int argc, char** argv)
 {
   char* matrix[argc][atoi(argv[1])];
   return 0;

--- a/cpp/ql/test/library-tests/syntax-zoo/whilestmt.c
+++ b/cpp/ql/test/library-tests/syntax-zoo/whilestmt.c
@@ -1,18 +1,18 @@
-void always_false_1() {
+static void always_false_1() {
   while(0) {
     l1:;
   }
   l2:;
 }
 
-void always_false_2() {
+static void always_false_2() {
   int done = 1;
   while(!done) {
     done = 0;
   }
 }
 
-void always_true_1() {
+static void always_true_1() {
   while(1) {
     l1:;
     break;
@@ -20,7 +20,7 @@ void always_true_1() {
   l2:;
 }
 
-void always_true_2() {
+static void always_true_2() {
   while(1) {
     l1:;
     break;
@@ -29,14 +29,14 @@ void always_true_2() {
   l3:;
 }
 
-void always_true_3() {
+static void always_true_3() {
   while(1) {
     l1:;
   }
   l2:;
 }
 
-void normal() {
+static void normal() {
   int i = 0;
   while(i < 10) {
     ++i;


### PR DESCRIPTION
These were due to several functions occurring that would have the same TRAP key. By making the functions static the TRAP keys will differ from each other.

Note that there are more cases left, but the diff was getting unreadable for me, so I want to get these out of the way first.