### PR TITLE
C++: Silence some more bogus consistency errors in syntax zoo

### DIFF
--- a/cpp/ql/test/library-tests/syntax-zoo/aliased_ssa_consistency.expected
+++ b/cpp/ql/test/library-tests/syntax-zoo/aliased_ssa_consistency.expected
@@ -13,18 +13,12 @@ instructionWithoutSuccessor
 | condition_decls.cpp:41:22:41:23 | Chi: call to BoxedInt | Instruction 'Chi: call to BoxedInt' has no successors in function '$@'. | condition_decls.cpp:40:6:40:20 | void while_decl_bind(int) | void while_decl_bind(int) |
 | condition_decls.cpp:48:52:48:53 | Chi: call to BoxedInt | Instruction 'Chi: call to BoxedInt' has no successors in function '$@'. | condition_decls.cpp:47:6:47:18 | void for_decl_bind(int) | void for_decl_bind(int) |
 | misc.c:171:10:171:13 | Uninitialized: definition of str2 | Instruction 'Uninitialized: definition of str2' has no successors in function '$@'. | misc.c:168:6:168:8 | void vla() | void vla() |
-| ms_try_mix.cpp:33:13:33:19 | ThrowValue: throw ... | Instruction 'ThrowValue: throw ...' has no successors in function '$@'. | ms_try_mix.cpp:27:6:27:19 | void ms_finally_mix(int) | void ms_finally_mix(int) |
-| ms_try_mix.cpp:51:5:51:11 | ThrowValue: throw ... | Instruction 'ThrowValue: throw ...' has no successors in function '$@'. | ms_try_mix.cpp:47:6:47:28 | void ms_empty_finally_at_end() | void ms_empty_finally_at_end() |
-| stmt_expr.cpp:27:5:27:15 | Store: ... = ... | Instruction 'Store: ... = ...' has no successors in function '$@'. | stmt_expr.cpp:21:6:21:6 | void stmtexpr::g(int) | void stmtexpr::g(int) |
+| ms_try_mix.cpp:35:13:35:19 | ThrowValue: throw ... | Instruction 'ThrowValue: throw ...' has no successors in function '$@'. | ms_try_mix.cpp:29:6:29:19 | void ms_finally_mix(int) | void ms_finally_mix(int) |
+| ms_try_mix.cpp:53:5:53:11 | ThrowValue: throw ... | Instruction 'ThrowValue: throw ...' has no successors in function '$@'. | ms_try_mix.cpp:49:6:49:28 | void ms_empty_finally_at_end() | void ms_empty_finally_at_end() |
+| stmt_expr.cpp:27:5:27:15 | Store: ... = ... | Instruction 'Store: ... = ...' has no successors in function '$@'. | stmt_expr.cpp:21:13:21:13 | void stmtexpr::g(int) | void stmtexpr::g(int) |
 | vla.c:5:9:5:14 | Uninitialized: definition of matrix | Instruction 'Uninitialized: definition of matrix' has no successors in function '$@'. | vla.c:3:12:3:12 | int f(int, char**) | int f(int, char**) |
 | vla.c:11:6:11:16 | Chi: vla_typedef | Instruction 'Chi: vla_typedef' has no successors in function '$@'. | vla.c:11:6:11:16 | void vla_typedef() | void vla_typedef() |
 ambiguousSuccessors
-| conditional_destructors.cpp:29:6:29:7 | Chi: f1 | Instruction 'Chi: f1' has 2 successors of kind 'Goto' in function '$@'. | conditional_destructors.cpp:29:6:29:7 | void f1() | void f1() |
-| conditional_destructors.cpp:38:6:38:7 | Chi: f2 | Instruction 'Chi: f2' has 2 successors of kind 'Goto' in function '$@'. | conditional_destructors.cpp:38:6:38:7 | void f2() | void f2() |
-| forstmt.cpp:1:6:1:7 | Chi: f1 | Instruction 'Chi: f1' has 2 successors of kind 'Goto' in function '$@'. | conditional_destructors.cpp:29:6:29:7 | void f1() | void f1() |
-| forstmt.cpp:8:6:8:7 | Chi: f2 | Instruction 'Chi: f2' has 2 successors of kind 'Goto' in function '$@'. | conditional_destructors.cpp:38:6:38:7 | void f2() | void f2() |
-| nonmembercallexpr.c:1:6:1:6 | Chi: g | Instruction 'Chi: g' has 2 successors of kind 'Goto' in function '$@'. | nonmembercallexpr.c:1:6:1:6 | void g(); void g())(); void(* g(); void(* g())() | void g(); void g())(); void(* g(); void(* g())() |
-| revsubscriptexpr.c:1:6:1:6 | Chi: g | Instruction 'Chi: g' has 2 successors of kind 'Goto' in function '$@'. | nonmembercallexpr.c:1:6:1:6 | void g(); void g())(); void(* g(); void(* g())() | void g(); void g())(); void(* g(); void(* g())() |
 unexplainedLoop
 unnecessaryPhiInstruction
 memoryOperandDefinitionIsUnmodeled
@@ -41,7 +35,7 @@ invalidOverlap
 nonUniqueEnclosingIRFunction
 fieldAddressOnNonPointer
 thisArgumentIsNonPointer
-| pmcallexpr.cpp:8:2:8:15 | Call: call to expression | Call instruction 'Call: call to expression' has a `this` argument operand that is not an address, in function '$@'. | pmcallexpr.cpp:6:13:6:13 | void f() | void f() |
+| pmcallexpr.cpp:10:2:10:15 | Call: call to expression | Call instruction 'Call: call to expression' has a `this` argument operand that is not an address, in function '$@'. | pmcallexpr.cpp:8:13:8:13 | void f() | void f() |
 | pointer_to_member.cpp:23:5:23:54 | Call: call to expression | Call instruction 'Call: call to expression' has a `this` argument operand that is not an address, in function '$@'. | pointer_to_member.cpp:14:5:14:9 | int usePM(int PM::*) | int usePM(int PM::*) |
 | pointer_to_member.cpp:24:5:24:49 | Call: call to expression | Call instruction 'Call: call to expression' has a `this` argument operand that is not an address, in function '$@'. | pointer_to_member.cpp:14:5:14:9 | int usePM(int PM::*) | int usePM(int PM::*) |
 nonUniqueIRVariable

--- a/cpp/ql/test/library-tests/syntax-zoo/assignexpr.cpp
+++ b/cpp/ql/test/library-tests/syntax-zoo/assignexpr.cpp
@@ -1,7 +1,9 @@
+namespace {
 class C {
 	public:
 		int i;
 };
+}
 
 static void f() {
 	C c;

--- a/cpp/ql/test/library-tests/syntax-zoo/conditional_destructors.cpp
+++ b/cpp/ql/test/library-tests/syntax-zoo/conditional_destructors.cpp
@@ -26,7 +26,7 @@ class C2 {
     }
 };
 
-void f1(void) {
+static void f1(void) {
     if (C1(1) == C1(2)) {
         ;
     }
@@ -35,7 +35,7 @@ void f1(void) {
     }
 }
 
-void f2(void) {
+static void f2(void) {
     if (C2(1) == C2(2)) {
         ;
     }

--- a/cpp/ql/test/library-tests/syntax-zoo/constmemberaccess.cpp
+++ b/cpp/ql/test/library-tests/syntax-zoo/constmemberaccess.cpp
@@ -1,7 +1,9 @@
+namespace {
 class C {
 	public:
 		int x;
 };
+}
 
 static void f() {
 	C *c;

--- a/cpp/ql/test/library-tests/syntax-zoo/constructorinitializer.cpp
+++ b/cpp/ql/test/library-tests/syntax-zoo/constructorinitializer.cpp
@@ -1,7 +1,9 @@
+namespace {
 class C {
 	public:
 		C(int x, int y);
 };
+}
 
 static void f() {
 	int i, j, k, l;

--- a/cpp/ql/test/library-tests/syntax-zoo/cpp11.cpp
+++ b/cpp/ql/test/library-tests/syntax-zoo/cpp11.cpp
@@ -138,7 +138,7 @@ namespace synthetic_dtor_calls {
   // This function is interesting because its extractor CFG has unreachable
   // calls to `c2.~C()` and `c3.~C()`. It's the calls that would have come from
   // leaving the block of `c2` by falling off the end, but no path does that.
-  int g(int x) {
+  static int g(int x) {
     do {
       C c1;
       if (x > 0) {

--- a/cpp/ql/test/library-tests/syntax-zoo/dataflow-consistency.expected
+++ b/cpp/ql/test/library-tests/syntax-zoo/dataflow-consistency.expected
@@ -42,7 +42,7 @@ postWithInFlow
 | VacuousDestructorCall.cpp:10:22:10:22 | i [inner post update] | PostUpdateNode should not be the target of local flow. |
 | allocators.cpp:4:18:4:20 | m_x [post update] | PostUpdateNode should not be the target of local flow. |
 | allocators.cpp:4:24:4:26 | m_y [post update] | PostUpdateNode should not be the target of local flow. |
-| assignexpr.cpp:9:4:9:4 | i [post update] | PostUpdateNode should not be the target of local flow. |
+| assignexpr.cpp:11:4:11:4 | i [post update] | PostUpdateNode should not be the target of local flow. |
 | builtin.c:34:23:34:31 | staticint [inner post update] | PostUpdateNode should not be the target of local flow. |
 | builtin.c:39:37:39:45 | carry_out [inner post update] | PostUpdateNode should not be the target of local flow. |
 | builtin.c:43:41:43:49 | staticint [inner post update] | PostUpdateNode should not be the target of local flow. |
@@ -73,18 +73,18 @@ postWithInFlow
 | ir.cpp:342:6:342:6 | p [inner post update] | PostUpdateNode should not be the target of local flow. |
 | ir.cpp:428:8:428:8 | x [post update] | PostUpdateNode should not be the target of local flow. |
 | ir.cpp:429:8:429:8 | y [post update] | PostUpdateNode should not be the target of local flow. |
-| ir.cpp:643:15:643:17 | m_a [post update] | PostUpdateNode should not be the target of local flow. |
-| ir.cpp:644:11:644:14 | this [inner post update] | PostUpdateNode should not be the target of local flow. |
-| ir.cpp:644:17:644:19 | m_a [post update] | PostUpdateNode should not be the target of local flow. |
-| ir.cpp:645:9:645:11 | m_a [post update] | PostUpdateNode should not be the target of local flow. |
-| ir.cpp:654:11:654:14 | this [inner post update] | PostUpdateNode should not be the target of local flow. |
-| ir.cpp:745:8:745:8 | base_s [inner post update] | PostUpdateNode should not be the target of local flow. |
-| ir.cpp:754:8:754:8 | middle_s [inner post update] | PostUpdateNode should not be the target of local flow. |
-| ir.cpp:763:8:763:8 | derived_s [inner post update] | PostUpdateNode should not be the target of local flow. |
-| ir.cpp:809:7:809:13 | call to Base | PostUpdateNode should not be the target of local flow. |
-| ir.cpp:810:7:810:26 | call to Base | PostUpdateNode should not be the target of local flow. |
-| ir.cpp:823:7:823:13 | call to Base | PostUpdateNode should not be the target of local flow. |
-| ir.cpp:824:7:824:26 | call to Base | PostUpdateNode should not be the target of local flow. |
+| ir.cpp:644:15:644:17 | m_a [post update] | PostUpdateNode should not be the target of local flow. |
+| ir.cpp:645:11:645:14 | this [inner post update] | PostUpdateNode should not be the target of local flow. |
+| ir.cpp:645:17:645:19 | m_a [post update] | PostUpdateNode should not be the target of local flow. |
+| ir.cpp:646:9:646:11 | m_a [post update] | PostUpdateNode should not be the target of local flow. |
+| ir.cpp:655:11:655:14 | this [inner post update] | PostUpdateNode should not be the target of local flow. |
+| ir.cpp:747:8:747:8 | base_s [inner post update] | PostUpdateNode should not be the target of local flow. |
+| ir.cpp:756:8:756:8 | middle_s [inner post update] | PostUpdateNode should not be the target of local flow. |
+| ir.cpp:765:8:765:8 | derived_s [inner post update] | PostUpdateNode should not be the target of local flow. |
+| ir.cpp:811:7:811:13 | call to Base | PostUpdateNode should not be the target of local flow. |
+| ir.cpp:812:7:812:26 | call to Base | PostUpdateNode should not be the target of local flow. |
+| ir.cpp:825:7:825:13 | call to Base | PostUpdateNode should not be the target of local flow. |
+| ir.cpp:826:7:826:26 | call to Base | PostUpdateNode should not be the target of local flow. |
 | misc.c:130:7:130:7 | i [post update] | PostUpdateNode should not be the target of local flow. |
 | misc.c:131:9:131:9 | i [post update] | PostUpdateNode should not be the target of local flow. |
 | misc.c:220:3:220:5 | * ... [post update] | PostUpdateNode should not be the target of local flow. |

--- a/cpp/ql/test/library-tests/syntax-zoo/dataflow-ir-consistency.expected
+++ b/cpp/ql/test/library-tests/syntax-zoo/dataflow-ir-consistency.expected
@@ -16,10 +16,6 @@ uniqueNodeLocation
 missingLocation
 | Nodes without location: 12 |
 uniqueNodeToString
-| file://:0:0:0:0 | i | Node should have one toString but has 2. |
-| file://:0:0:0:0 | j | Node should have one toString but has 2. |
-| file://:0:0:0:0 | x | Node should have one toString but has 2. |
-| file://:0:0:0:0 | y | Node should have one toString but has 2. |
 missingToString
 parameterCallable
 localFlowIsLocal
@@ -38,15 +34,15 @@ uniquePostUpdate
 | ir.cpp:515:10:515:11 | definition of r3 indirection | Node has multiple PostUpdateNodes. |
 | ir.cpp:516:10:516:11 | definition of r4 indirection | Node has multiple PostUpdateNodes. |
 | ir.cpp:516:10:516:11 | definition of r4 indirection | Node has multiple PostUpdateNodes. |
-| ir.cpp:658:5:658:5 | this indirection | Node has multiple PostUpdateNodes. |
-| ir.cpp:658:5:658:5 | this indirection | Node has multiple PostUpdateNodes. |
-| ir.cpp:745:8:745:8 | this indirection | Node has multiple PostUpdateNodes. |
-| ir.cpp:748:3:748:6 | this indirection | Node has multiple PostUpdateNodes. |
-| ir.cpp:757:3:757:8 | this indirection | Node has multiple PostUpdateNodes. |
-| ir.cpp:766:3:766:9 | this indirection | Node has multiple PostUpdateNodes. |
-| ir.cpp:775:3:775:11 | this indirection | Node has multiple PostUpdateNodes. |
-| ir.cpp:784:3:784:11 | this indirection | Node has multiple PostUpdateNodes. |
-| ir.cpp:793:3:793:11 | this indirection | Node has multiple PostUpdateNodes. |
+| ir.cpp:659:5:659:5 | this indirection | Node has multiple PostUpdateNodes. |
+| ir.cpp:659:5:659:5 | this indirection | Node has multiple PostUpdateNodes. |
+| ir.cpp:747:8:747:8 | this indirection | Node has multiple PostUpdateNodes. |
+| ir.cpp:750:3:750:6 | this indirection | Node has multiple PostUpdateNodes. |
+| ir.cpp:759:3:759:8 | this indirection | Node has multiple PostUpdateNodes. |
+| ir.cpp:768:3:768:9 | this indirection | Node has multiple PostUpdateNodes. |
+| ir.cpp:777:3:777:11 | this indirection | Node has multiple PostUpdateNodes. |
+| ir.cpp:786:3:786:11 | this indirection | Node has multiple PostUpdateNodes. |
+| ir.cpp:795:3:795:11 | this indirection | Node has multiple PostUpdateNodes. |
 | static_init_templates.cpp:240:7:240:7 | this indirection | Node has multiple PostUpdateNodes. |
 postIsInSameCallable
 reverseRead
@@ -56,14 +52,14 @@ postWithInFlow
 | cpp11.cpp:82:11:82:14 | call to Val | PostUpdateNode should not be the target of local flow. |
 | cpp11.cpp:82:45:82:48 | call to Val | PostUpdateNode should not be the target of local flow. |
 | cpp11.cpp:82:51:82:51 | call to Val | PostUpdateNode should not be the target of local flow. |
-| ir.cpp:809:7:809:13 | call to Base | PostUpdateNode should not be the target of local flow. |
-| ir.cpp:810:7:810:26 | call to Base | PostUpdateNode should not be the target of local flow. |
-| ir.cpp:823:7:823:13 | call to Base | PostUpdateNode should not be the target of local flow. |
-| ir.cpp:824:7:824:26 | call to Base | PostUpdateNode should not be the target of local flow. |
+| ir.cpp:811:7:811:13 | call to Base | PostUpdateNode should not be the target of local flow. |
+| ir.cpp:812:7:812:26 | call to Base | PostUpdateNode should not be the target of local flow. |
+| ir.cpp:825:7:825:13 | call to Base | PostUpdateNode should not be the target of local flow. |
+| ir.cpp:826:7:826:26 | call to Base | PostUpdateNode should not be the target of local flow. |
 | try_catch.cpp:7:8:7:8 | call to exception | PostUpdateNode should not be the target of local flow. |
 viableImplInCallContextTooLarge
 uniqueParameterNodeAtPosition
-| ir.cpp:724:6:724:13 | TryCatch | 0 indirection | ir.cpp:735:22:735:22 | s indirection | Parameters with overlapping positions. |
-| ir.cpp:724:6:724:13 | TryCatch | 0 indirection | ir.cpp:738:24:738:24 | e indirection | Parameters with overlapping positions. |
+| ir.cpp:726:6:726:13 | TryCatch | 0 indirection | ir.cpp:737:22:737:22 | s indirection | Parameters with overlapping positions. |
+| ir.cpp:726:6:726:13 | TryCatch | 0 indirection | ir.cpp:740:24:740:24 | e indirection | Parameters with overlapping positions. |
 uniqueParameterNodePosition
 uniqueContentApprox

--- a/cpp/ql/test/library-tests/syntax-zoo/defconstructornewexpr.cpp
+++ b/cpp/ql/test/library-tests/syntax-zoo/defconstructornewexpr.cpp
@@ -1,4 +1,6 @@
+namespace {
 class C { };
+}
 
 static void f() {
 	new C;

--- a/cpp/ql/test/library-tests/syntax-zoo/defdestructordeleteexpr.cpp
+++ b/cpp/ql/test/library-tests/syntax-zoo/defdestructordeleteexpr.cpp
@@ -1,4 +1,6 @@
+namespace {
 class C { };
+}
 
 static void f() {
 	C* c = new C();

--- a/cpp/ql/test/library-tests/syntax-zoo/deleteexpr.cpp
+++ b/cpp/ql/test/library-tests/syntax-zoo/deleteexpr.cpp
@@ -1,7 +1,9 @@
+namespace {
 class C {
 	public:
 		~C();
 };
+}
 
 static void f() {
 	C* c = new C();

--- a/cpp/ql/test/library-tests/syntax-zoo/ellipsisexceptionhandler.cpp
+++ b/cpp/ql/test/library-tests/syntax-zoo/ellipsisexceptionhandler.cpp
@@ -11,7 +11,7 @@ static void f() {
 	}
 }
 
-void g(bool condition) {
+static void g(bool condition) {
 	try {
 		if (condition) throw 1;
 	} catch (...) {

--- a/cpp/ql/test/library-tests/syntax-zoo/exceptionhandler.cpp
+++ b/cpp/ql/test/library-tests/syntax-zoo/exceptionhandler.cpp
@@ -3,7 +3,7 @@ namespace ehandler {
 class C { };
 class D { };
 
-void g() {
+static void g() {
 	throw 1;
 }
 

--- a/cpp/ql/test/library-tests/syntax-zoo/fieldaccess.cpp
+++ b/cpp/ql/test/library-tests/syntax-zoo/fieldaccess.cpp
@@ -1,7 +1,9 @@
+namespace {
 class C {
 	public:
 		int x;
 };
+}
 
 static void f() {
 	C *c;

--- a/cpp/ql/test/library-tests/syntax-zoo/ir.cpp
+++ b/cpp/ql/test/library-tests/syntax-zoo/ir.cpp
@@ -625,6 +625,7 @@ void CallMethods(String& r, String* p, String s) {
     s.c_str();
 }
 
+namespace {
 class C {
 public:
     static int StaticMemberFunction(int x) {
@@ -671,6 +672,7 @@ private:
     void* m_e;
     String m_f;
 };
+}
 
 int DerefReference(int& r) {
     return r;

--- a/cpp/ql/test/library-tests/syntax-zoo/membercallexpr.cpp
+++ b/cpp/ql/test/library-tests/syntax-zoo/membercallexpr.cpp
@@ -1,7 +1,9 @@
+namespace {
 class C {
 	public:
 		void g();
 };
+}
 
 static void f() {
 	C *c;

--- a/cpp/ql/test/library-tests/syntax-zoo/membercallexpr_args.cpp
+++ b/cpp/ql/test/library-tests/syntax-zoo/membercallexpr_args.cpp
@@ -1,8 +1,10 @@
+namespace {
 class C {
 	public:
 		C* d;
 		void g(int x, int y);
 };
+}
 
 static void f() {
 	int i, j, k, l;

--- a/cpp/ql/test/library-tests/syntax-zoo/ms_try_mix.cpp
+++ b/cpp/ql/test/library-tests/syntax-zoo/ms_try_mix.cpp
@@ -1,11 +1,13 @@
 // semmle-extractor-options: --microsoft
 #define EXCEPTION_EXECUTE_HANDLER 1
 
+namespace {
 class C {
     public:
         C(int x);
         ~C();
 };
+}
 
 void ms_except_mix(int b1) {
     C c101(101);

--- a/cpp/ql/test/library-tests/syntax-zoo/newexpr.cpp
+++ b/cpp/ql/test/library-tests/syntax-zoo/newexpr.cpp
@@ -1,7 +1,9 @@
+namespace {
 class C {
 	public:
 		C(int i, int j);
 };
+}
 
 static void f() {
 	int a, b, c, d;

--- a/cpp/ql/test/library-tests/syntax-zoo/nonmembercallexpr.c
+++ b/cpp/ql/test/library-tests/syntax-zoo/nonmembercallexpr.c
@@ -1,4 +1,4 @@
-void g() { }
+static void g() { }
 
 static void f() {
 	g();

--- a/cpp/ql/test/library-tests/syntax-zoo/parameterinitializer.cpp
+++ b/cpp/ql/test/library-tests/syntax-zoo/parameterinitializer.cpp
@@ -1,10 +1,10 @@
 void printf(char *format, ...);
 
-int g(void) {
+static int g(void) {
     return 5;
 }
 
-void f(int i = g()) {
+static void f(int i = g()) {
     printf("Got %d\n", i);
 }
 
@@ -15,7 +15,7 @@ public:
 	void method(int k = g()) {};
 };
 
-int main(void) {
+static int h(void) {
     f(3);
     f();
     f(4);

--- a/cpp/ql/test/library-tests/syntax-zoo/pmcallexpr.cpp
+++ b/cpp/ql/test/library-tests/syntax-zoo/pmcallexpr.cpp
@@ -1,7 +1,9 @@
+namespace {
 class C {
 	public:
 		void (C::*g)();
 };
+}
 
 static void f() {
 	C *c, *d;

--- a/cpp/ql/test/library-tests/syntax-zoo/raw_consistency.expected
+++ b/cpp/ql/test/library-tests/syntax-zoo/raw_consistency.expected
@@ -30,10 +30,10 @@ instructionWithoutSuccessor
 | misc.c:174:17:174:22 | CallSideEffect: call to getInt | Instruction 'CallSideEffect: call to getInt' has no successors in function '$@'. | misc.c:168:6:168:8 | void vla() | void vla() |
 | misc.c:174:30:174:35 | CallSideEffect: call to getInt | Instruction 'CallSideEffect: call to getInt' has no successors in function '$@'. | misc.c:168:6:168:8 | void vla() | void vla() |
 | misc.c:174:55:174:60 | Store: (char ****)... | Instruction 'Store: (char ****)...' has no successors in function '$@'. | misc.c:168:6:168:8 | void vla() | void vla() |
-| ms_try_mix.cpp:33:13:33:19 | ThrowValue: throw ... | Instruction 'ThrowValue: throw ...' has no successors in function '$@'. | ms_try_mix.cpp:27:6:27:19 | void ms_finally_mix(int) | void ms_finally_mix(int) |
-| ms_try_mix.cpp:51:5:51:11 | ThrowValue: throw ... | Instruction 'ThrowValue: throw ...' has no successors in function '$@'. | ms_try_mix.cpp:47:6:47:28 | void ms_empty_finally_at_end() | void ms_empty_finally_at_end() |
-| stmt_expr.cpp:27:5:27:15 | Store: ... = ... | Instruction 'Store: ... = ...' has no successors in function '$@'. | stmt_expr.cpp:21:6:21:6 | void stmtexpr::g(int) | void stmtexpr::g(int) |
-| stmt_expr.cpp:29:11:32:11 | CopyValue: (statement expression) | Instruction 'CopyValue: (statement expression)' has no successors in function '$@'. | stmt_expr.cpp:21:6:21:6 | void stmtexpr::g(int) | void stmtexpr::g(int) |
+| ms_try_mix.cpp:35:13:35:19 | ThrowValue: throw ... | Instruction 'ThrowValue: throw ...' has no successors in function '$@'. | ms_try_mix.cpp:29:6:29:19 | void ms_finally_mix(int) | void ms_finally_mix(int) |
+| ms_try_mix.cpp:53:5:53:11 | ThrowValue: throw ... | Instruction 'ThrowValue: throw ...' has no successors in function '$@'. | ms_try_mix.cpp:49:6:49:28 | void ms_empty_finally_at_end() | void ms_empty_finally_at_end() |
+| stmt_expr.cpp:27:5:27:15 | Store: ... = ... | Instruction 'Store: ... = ...' has no successors in function '$@'. | stmt_expr.cpp:21:13:21:13 | void stmtexpr::g(int) | void stmtexpr::g(int) |
+| stmt_expr.cpp:29:11:32:11 | CopyValue: (statement expression) | Instruction 'CopyValue: (statement expression)' has no successors in function '$@'. | stmt_expr.cpp:21:13:21:13 | void stmtexpr::g(int) | void stmtexpr::g(int) |
 | stmt_in_type.cpp:5:53:5:53 | Constant: 1 | Instruction 'Constant: 1' has no successors in function '$@'. | stmt_in_type.cpp:2:6:2:12 | void cpp_fun() | void cpp_fun() |
 | vla.c:5:9:5:14 | Uninitialized: definition of matrix | Instruction 'Uninitialized: definition of matrix' has no successors in function '$@'. | vla.c:3:12:3:12 | int f(int, char**) | int f(int, char**) |
 | vla.c:5:16:5:19 | Load: argc | Instruction 'Load: argc' has no successors in function '$@'. | vla.c:3:12:3:12 | int f(int, char**) | int f(int, char**) |
@@ -47,12 +47,6 @@ instructionWithoutSuccessor
 | vla.c:14:74:14:79 | CallSideEffect: call to getInt | Instruction 'CallSideEffect: call to getInt' has no successors in function '$@'. | vla.c:11:6:11:16 | void vla_typedef() | void vla_typedef() |
 | vla.c:14:92:14:94 | Store: (char *)... | Instruction 'Store: (char *)...' has no successors in function '$@'. | vla.c:11:6:11:16 | void vla_typedef() | void vla_typedef() |
 ambiguousSuccessors
-| conditional_destructors.cpp:29:6:29:7 | InitializeNonLocal: f1 | Instruction 'InitializeNonLocal: f1' has 2 successors of kind 'Goto' in function '$@'. | conditional_destructors.cpp:29:6:29:7 | void f1() | void f1() |
-| conditional_destructors.cpp:38:6:38:7 | InitializeNonLocal: f2 | Instruction 'InitializeNonLocal: f2' has 2 successors of kind 'Goto' in function '$@'. | conditional_destructors.cpp:38:6:38:7 | void f2() | void f2() |
-| forstmt.cpp:1:6:1:7 | InitializeNonLocal: f1 | Instruction 'InitializeNonLocal: f1' has 2 successors of kind 'Goto' in function '$@'. | conditional_destructors.cpp:29:6:29:7 | void f1() | void f1() |
-| forstmt.cpp:8:6:8:7 | InitializeNonLocal: f2 | Instruction 'InitializeNonLocal: f2' has 2 successors of kind 'Goto' in function '$@'. | conditional_destructors.cpp:38:6:38:7 | void f2() | void f2() |
-| nonmembercallexpr.c:1:6:1:6 | InitializeNonLocal: g | Instruction 'InitializeNonLocal: g' has 2 successors of kind 'Goto' in function '$@'. | nonmembercallexpr.c:1:6:1:6 | void g(); void g())(); void(* g(); void(* g())() | void g(); void g())(); void(* g(); void(* g())() |
-| revsubscriptexpr.c:1:6:1:6 | InitializeNonLocal: g | Instruction 'InitializeNonLocal: g' has 2 successors of kind 'Goto' in function '$@'. | nonmembercallexpr.c:1:6:1:6 | void g(); void g())(); void(* g(); void(* g())() | void g(); void g())(); void(* g(); void(* g())() |
 unexplainedLoop
 unnecessaryPhiInstruction
 memoryOperandDefinitionIsUnmodeled
@@ -79,7 +73,7 @@ invalidOverlap
 nonUniqueEnclosingIRFunction
 fieldAddressOnNonPointer
 thisArgumentIsNonPointer
-| pmcallexpr.cpp:8:2:8:15 | Call: call to expression | Call instruction 'Call: call to expression' has a `this` argument operand that is not an address, in function '$@'. | pmcallexpr.cpp:6:13:6:13 | void f() | void f() |
+| pmcallexpr.cpp:10:2:10:15 | Call: call to expression | Call instruction 'Call: call to expression' has a `this` argument operand that is not an address, in function '$@'. | pmcallexpr.cpp:8:13:8:13 | void f() | void f() |
 | pointer_to_member.cpp:23:5:23:54 | Call: call to expression | Call instruction 'Call: call to expression' has a `this` argument operand that is not an address, in function '$@'. | pointer_to_member.cpp:14:5:14:9 | int usePM(int PM::*) | int usePM(int PM::*) |
 | pointer_to_member.cpp:24:5:24:49 | Call: call to expression | Call instruction 'Call: call to expression' has a `this` argument operand that is not an address, in function '$@'. | pointer_to_member.cpp:14:5:14:9 | int usePM(int PM::*) | int usePM(int PM::*) |
 nonUniqueIRVariable

--- a/cpp/ql/test/library-tests/syntax-zoo/staticlocals.cpp
+++ b/cpp/ql/test/library-tests/syntax-zoo/staticlocals.cpp
@@ -1,6 +1,6 @@
 namespace staticlocals {
 
-int g() {
+static int g() {
     return 1;
 }
 

--- a/cpp/ql/test/library-tests/syntax-zoo/staticmembercallexpr.cpp
+++ b/cpp/ql/test/library-tests/syntax-zoo/staticmembercallexpr.cpp
@@ -1,7 +1,9 @@
+namespace {
 class C {
 	public:
 		static void g();
 };
+}
 
 static void f() {
 	C c;

--- a/cpp/ql/test/library-tests/syntax-zoo/staticmembercallexpr_args.cpp
+++ b/cpp/ql/test/library-tests/syntax-zoo/staticmembercallexpr_args.cpp
@@ -1,8 +1,10 @@
+namespace {
 class C {
 	public:
 		C* d;
 		static void g(int x, int y);
 };
+}
 
 static void f() {
 	int i, j, k, l;

--- a/cpp/ql/test/library-tests/syntax-zoo/stmt_expr.cpp
+++ b/cpp/ql/test/library-tests/syntax-zoo/stmt_expr.cpp
@@ -18,7 +18,7 @@ static void f(int b) {
         ;
 }
 
-void g(int b) {
+static void g(int b) {
     void *ptr;
     int i;
 

--- a/cpp/ql/test/library-tests/syntax-zoo/unaliased_ssa_consistency.expected
+++ b/cpp/ql/test/library-tests/syntax-zoo/unaliased_ssa_consistency.expected
@@ -13,18 +13,12 @@ instructionWithoutSuccessor
 | condition_decls.cpp:41:22:41:23 | IndirectMayWriteSideEffect: call to BoxedInt | Instruction 'IndirectMayWriteSideEffect: call to BoxedInt' has no successors in function '$@'. | condition_decls.cpp:40:6:40:20 | void while_decl_bind(int) | void while_decl_bind(int) |
 | condition_decls.cpp:48:52:48:53 | IndirectMayWriteSideEffect: call to BoxedInt | Instruction 'IndirectMayWriteSideEffect: call to BoxedInt' has no successors in function '$@'. | condition_decls.cpp:47:6:47:18 | void for_decl_bind(int) | void for_decl_bind(int) |
 | misc.c:171:10:171:13 | Uninitialized: definition of str2 | Instruction 'Uninitialized: definition of str2' has no successors in function '$@'. | misc.c:168:6:168:8 | void vla() | void vla() |
-| ms_try_mix.cpp:33:13:33:19 | ThrowValue: throw ... | Instruction 'ThrowValue: throw ...' has no successors in function '$@'. | ms_try_mix.cpp:27:6:27:19 | void ms_finally_mix(int) | void ms_finally_mix(int) |
-| ms_try_mix.cpp:51:5:51:11 | ThrowValue: throw ... | Instruction 'ThrowValue: throw ...' has no successors in function '$@'. | ms_try_mix.cpp:47:6:47:28 | void ms_empty_finally_at_end() | void ms_empty_finally_at_end() |
-| stmt_expr.cpp:27:5:27:15 | Store: ... = ... | Instruction 'Store: ... = ...' has no successors in function '$@'. | stmt_expr.cpp:21:6:21:6 | void stmtexpr::g(int) | void stmtexpr::g(int) |
+| ms_try_mix.cpp:35:13:35:19 | ThrowValue: throw ... | Instruction 'ThrowValue: throw ...' has no successors in function '$@'. | ms_try_mix.cpp:29:6:29:19 | void ms_finally_mix(int) | void ms_finally_mix(int) |
+| ms_try_mix.cpp:53:5:53:11 | ThrowValue: throw ... | Instruction 'ThrowValue: throw ...' has no successors in function '$@'. | ms_try_mix.cpp:49:6:49:28 | void ms_empty_finally_at_end() | void ms_empty_finally_at_end() |
+| stmt_expr.cpp:27:5:27:15 | Store: ... = ... | Instruction 'Store: ... = ...' has no successors in function '$@'. | stmt_expr.cpp:21:13:21:13 | void stmtexpr::g(int) | void stmtexpr::g(int) |
 | vla.c:5:9:5:14 | Uninitialized: definition of matrix | Instruction 'Uninitialized: definition of matrix' has no successors in function '$@'. | vla.c:3:12:3:12 | int f(int, char**) | int f(int, char**) |
 | vla.c:11:6:11:16 | InitializeNonLocal: vla_typedef | Instruction 'InitializeNonLocal: vla_typedef' has no successors in function '$@'. | vla.c:11:6:11:16 | void vla_typedef() | void vla_typedef() |
 ambiguousSuccessors
-| conditional_destructors.cpp:29:6:29:7 | InitializeNonLocal: f1 | Instruction 'InitializeNonLocal: f1' has 2 successors of kind 'Goto' in function '$@'. | conditional_destructors.cpp:29:6:29:7 | void f1() | void f1() |
-| conditional_destructors.cpp:38:6:38:7 | InitializeNonLocal: f2 | Instruction 'InitializeNonLocal: f2' has 2 successors of kind 'Goto' in function '$@'. | conditional_destructors.cpp:38:6:38:7 | void f2() | void f2() |
-| forstmt.cpp:1:6:1:7 | InitializeNonLocal: f1 | Instruction 'InitializeNonLocal: f1' has 2 successors of kind 'Goto' in function '$@'. | conditional_destructors.cpp:29:6:29:7 | void f1() | void f1() |
-| forstmt.cpp:8:6:8:7 | InitializeNonLocal: f2 | Instruction 'InitializeNonLocal: f2' has 2 successors of kind 'Goto' in function '$@'. | conditional_destructors.cpp:38:6:38:7 | void f2() | void f2() |
-| nonmembercallexpr.c:1:6:1:6 | InitializeNonLocal: g | Instruction 'InitializeNonLocal: g' has 2 successors of kind 'Goto' in function '$@'. | nonmembercallexpr.c:1:6:1:6 | void g(); void g())(); void(* g(); void(* g())() | void g(); void g())(); void(* g(); void(* g())() |
-| revsubscriptexpr.c:1:6:1:6 | InitializeNonLocal: g | Instruction 'InitializeNonLocal: g' has 2 successors of kind 'Goto' in function '$@'. | nonmembercallexpr.c:1:6:1:6 | void g(); void g())(); void(* g(); void(* g())() | void g(); void g())(); void(* g(); void(* g())() |
 unexplainedLoop
 unnecessaryPhiInstruction
 memoryOperandDefinitionIsUnmodeled
@@ -41,7 +35,7 @@ invalidOverlap
 nonUniqueEnclosingIRFunction
 fieldAddressOnNonPointer
 thisArgumentIsNonPointer
-| pmcallexpr.cpp:8:2:8:15 | Call: call to expression | Call instruction 'Call: call to expression' has a `this` argument operand that is not an address, in function '$@'. | pmcallexpr.cpp:6:13:6:13 | void f() | void f() |
+| pmcallexpr.cpp:10:2:10:15 | Call: call to expression | Call instruction 'Call: call to expression' has a `this` argument operand that is not an address, in function '$@'. | pmcallexpr.cpp:8:13:8:13 | void f() | void f() |
 | pointer_to_member.cpp:23:5:23:54 | Call: call to expression | Call instruction 'Call: call to expression' has a `this` argument operand that is not an address, in function '$@'. | pointer_to_member.cpp:14:5:14:9 | int usePM(int PM::*) | int usePM(int PM::*) |
 | pointer_to_member.cpp:24:5:24:49 | Call: call to expression | Call instruction 'Call: call to expression' has a `this` argument operand that is not an address, in function '$@'. | pointer_to_member.cpp:14:5:14:9 | int usePM(int PM::*) | int usePM(int PM::*) |
 nonUniqueIRVariable


### PR DESCRIPTION
These were due to several functions occurring that would have the same TRAP key. By making the functions static or wrapping the defining class in an anonymous namespace the TRAP keys will differ from each other.