### PR TITLE
C#: Append process id to diagnostics filename

### DIFF
--- a/csharp/autobuilder/Semmle.Autobuild.Shared/Autobuilder.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.Shared/Autobuilder.cs
@@ -241,7 +241,7 @@ namespace Semmle.Autobuild.Shared
             SourceArchiveDir = RequireEnvironmentVariable(EnvVars.SourceArchiveDir(this.Options.Language));
             DiagnosticsDir = RequireEnvironmentVariable(EnvVars.DiagnosticDir(this.Options.Language));
 
-            this.diagnostics = actions.CreateDiagnosticsWriter(Path.Combine(DiagnosticsDir, $"autobuilder-{DateTime.UtcNow:yyyyMMddHHmm}.jsonc"));
+            this.diagnostics = actions.CreateDiagnosticsWriter(Path.Combine(DiagnosticsDir, $"autobuilder-{DateTime.UtcNow:yyyyMMddHHmm}-{Environment.ProcessId}.jsonc"));
         }
 
         /// <summary>


### PR DESCRIPTION
This provides some extra resilience where the autobuilder runs more than once at the same time.