### PR TITLE
Swift: Permit data flow out through pointer arguments

### DIFF
--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPrivate.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPrivate.qll
@@ -211,6 +211,8 @@ private predicate modifiable(Argument arg) {
   arg.getExpr() instanceof InOutExpr
   or
   arg.getExpr().getType() instanceof NominalType
+  or
+  arg.getLabel() = "ptr"
 }
 
 predicate modifiableParam(ParamDecl param) {

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPrivate.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPrivate.qll
@@ -7,6 +7,7 @@ private import codeql.swift.dataflow.Ssa
 private import codeql.swift.controlflow.BasicBlocks
 private import codeql.swift.dataflow.FlowSummary as FlowSummary
 private import codeql.swift.dataflow.internal.FlowSummaryImpl as FlowSummaryImpl
+private import codeql.swift.frameworks.StandardLibrary.PointerTypes
 
 /** Gets the callable in which this node occurs. */
 DataFlowCallable nodeGetEnclosingCallable(NodeImpl n) { result = n.getEnclosingCallable() }
@@ -212,7 +213,7 @@ private predicate modifiable(Argument arg) {
   or
   arg.getExpr().getType() instanceof NominalType
   or
-  arg.getLabel() = "ptr"
+  arg.getExpr().getType() instanceof PointerType
 }
 
 predicate modifiableParam(ParamDecl param) {

--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/PointerTypes.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/PointerTypes.qll
@@ -6,6 +6,22 @@
 import swift
 
 /**
+ * A type that is used as a pointer in Swift, such as `UnsafePointer`,
+ * `UnsafeBufferPointer` and similar types.
+ */
+class PointerType extends Type {
+  PointerType() {
+    this instanceof UnsafeTypedPointerType or
+    this instanceof UnsafeRawPointerType or
+    this instanceof OpaquePointerType or
+    this instanceof AutoreleasingUnsafeMutablePointerType or
+    this instanceof UnmanagedType or
+    this instanceof CVaListPointerType or
+    this instanceof ManagedBufferPointerType
+  }
+}
+
+/**
  * A Swift unsafe typed pointer type such as `UnsafePointer`,
  * `UnsafeMutablePointer` or `UnsafeBufferPointer`.
  */

--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/PointerTypes.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/PointerTypes.qll
@@ -26,9 +26,7 @@ class PointerType extends Type {
  * `UnsafeMutablePointer` or `UnsafeBufferPointer`.
  */
 class UnsafeTypedPointerType extends BoundGenericType {
-  UnsafeTypedPointerType() {
-    this.getName().regexpMatch("Unsafe(Mutable|)(Buffer|)Pointer<.*")
-  }
+  UnsafeTypedPointerType() { this.getName().regexpMatch("Unsafe(Mutable|)(Buffer|)Pointer<.*") }
 }
 
 /**
@@ -36,18 +34,14 @@ class UnsafeTypedPointerType extends BoundGenericType {
  * `UnsafeMutableRawPointer` or `UnsafeRawBufferPointer`.
  */
 class UnsafeRawPointerType extends NominalType {
-  UnsafeRawPointerType() {
-    this.getName().regexpMatch("Unsafe(Mutable|)Raw(Buffer|)Pointer")
-  }
+  UnsafeRawPointerType() { this.getName().regexpMatch("Unsafe(Mutable|)Raw(Buffer|)Pointer") }
 }
 
 /**
  * A Swift `OpaquePointer`.
  */
 class OpaquePointerType extends NominalType {
-  OpaquePointerType() {
-    this.getName() = "OpaquePointer"
-  }
+  OpaquePointerType() { this.getName() = "OpaquePointer" }
 }
 
 /**
@@ -63,25 +57,19 @@ class AutoreleasingUnsafeMutablePointerType extends BoundGenericType {
  * A Swift `Unmanaged` object reference.
  */
 class UnmanagedType extends BoundGenericType {
-  UnmanagedType() {
-    this.getName().matches("Unmanaged<%")
-  }
+  UnmanagedType() { this.getName().matches("Unmanaged<%") }
 }
 
 /**
  * A Swift `CVaListPointer`.
  */
 class CVaListPointerType extends NominalType {
-  CVaListPointerType() {
-    this.getName() = "CVaListPointer"
-  }
+  CVaListPointerType() { this.getName() = "CVaListPointer" }
 }
 
 /**
  * A Swift `ManagedBufferPointer`.
  */
 class ManagedBufferPointerType extends BoundGenericType {
-  ManagedBufferPointerType() {
-    this.getName().matches("ManagedBufferPointer<%")
-  }
+  ManagedBufferPointerType() { this.getName().matches("ManagedBufferPointer<%") }
 }

--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/PointerTypes.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/PointerTypes.qll
@@ -1,0 +1,71 @@
+/**
+ * Provides models for Swift pointer types including `UnsafePointer`,
+ * `UnsafeBufferPointer` and similar types.
+ */
+
+import swift
+
+/**
+ * A Swift unsafe typed pointer type such as `UnsafePointer`,
+ * `UnsafeMutablePointer` or `UnsafeBufferPointer`.
+ */
+class UnsafeTypedPointerType extends BoundGenericType {
+  UnsafeTypedPointerType() {
+    this.getName().regexpMatch("Unsafe(Mutable|)(Buffer|)Pointer<.*")
+  }
+}
+
+/**
+ * A Swift unsafe raw pointer type such as `UnsafeRawPointer`,
+ * `UnsafeMutableRawPointer` or `UnsafeRawBufferPointer`.
+ */
+class UnsafeRawPointerType extends NominalType {
+  UnsafeRawPointerType() {
+    this.getName().regexpMatch("Unsafe(Mutable|)Raw(Buffer|)Pointer")
+  }
+}
+
+/**
+ * A Swift `OpaquePointer`.
+ */
+class OpaquePointerType extends NominalType {
+  OpaquePointerType() {
+    this.getName() = "OpaquePointer"
+  }
+}
+
+/**
+ * A Swift `AutoreleasingUnsafeMutablePointer`.
+ */
+class AutoreleasingUnsafeMutablePointerType extends BoundGenericType {
+  AutoreleasingUnsafeMutablePointerType() {
+    this.getName().matches("AutoreleasingUnsafeMutablePointer<%")
+  }
+}
+
+/**
+ * A Swift `Unmanaged` object reference.
+ */
+class UnmanagedType extends BoundGenericType {
+  UnmanagedType() {
+    this.getName().matches("Unmanaged<%")
+  }
+}
+
+/**
+ * A Swift `CVaListPointer`.
+ */
+class CVaListPointerType extends NominalType {
+  CVaListPointerType() {
+    this.getName() = "CVaListPointer"
+  }
+}
+
+/**
+ * A Swift `ManagedBufferPointer`.
+ */
+class ManagedBufferPointerType extends BoundGenericType {
+  ManagedBufferPointerType() {
+    this.getName().matches("ManagedBufferPointer<%")
+  }
+}

--- a/swift/ql/test/library-tests/dataflow/taint/libraries/data.swift
+++ b/swift/ql/test/library-tests/dataflow/taint/libraries/data.swift
@@ -158,13 +158,13 @@ func taintThroughData() {
 	let dataTainted19 = source() as! Data
 	let pointerTainted19 = UnsafeMutablePointer<UInt8>.allocate(capacity: 0)
 	dataTainted19.copyBytes(to: pointerTainted19, count: 0)
-	sink(arg: pointerTainted19) // $ MISSING: tainted=158
+	sink(arg: pointerTainted19) // $ tainted=158
 
 	// ";Data;true;copyBytes(to:from:);;;Argument[-1];Argument[0];taint",
 	let dataTainted20 = source() as! Data
 	let pointerTainted20 = UnsafeMutablePointer<UInt8>.allocate(capacity: 0)
 	dataTainted20.copyBytes(to: pointerTainted20, from: 0..<1)
-	sink(arg: pointerTainted20) // $ MISSING: tainted=164
+	sink(arg: pointerTainted20) // $ tainted=164
 
 	// ";Data;true;flatMap(_:);;;Argument[-1];ReturnValue;taint",
 	let dataTainted21 = source() as! Data

--- a/swift/ql/test/library-tests/dataflow/taint/libraries/nsstring.swift
+++ b/swift/ql/test/library-tests/dataflow/taint/libraries/nsstring.swift
@@ -318,14 +318,14 @@ func taintThroughInterpolatedStrings() {
   harmless.getCharacters(ptr1, range: myRange)
   sink(arg: ptr1)
   sourceNSString().getCharacters(ptr1, range: myRange)
-  sink(arg: ptr1) // $ MISSING: tainted=
+  sink(arg: ptr1) // $ tainted=320
 
   var ptr2 = (nil as UnsafeMutablePointer<unichar>?)!
   sink(arg: ptr2)
   harmless.getCharacters(ptr2)
   sink(arg: ptr2)
   sourceNSString().getCharacters(ptr2)
-  sink(arg: ptr2) // $ MISSING: tainted=
+  sink(arg: ptr2) // $ tainted=327
 
   var ptr3 = (nil as UnsafeMutableRawPointer?)!
   sink(arg: ptr3)
@@ -339,14 +339,14 @@ func taintThroughInterpolatedStrings() {
   harmless.getCString(ptr4, maxLength: 128, encoding: 0)
   sink(arg: ptr4)
   sourceNSString().getCString(ptr4, maxLength: 128, encoding: 0)
-  sink(arg: ptr4) // $ MISSING: tainted=
+  sink(arg: ptr4) // $ tainted=341
 
   var ptr5 = (nil as UnsafeMutablePointer<CChar>?)!
   sink(arg: ptr5)
   harmless.getCString(ptr5)
   sink(arg: ptr5)
   sourceNSString().getCString(ptr5)
-  sink(arg: ptr5) // $ MISSING: tainted=
+  sink(arg: ptr5) // $ tainted=348
 
   sink(arg: harmless.enumerateLines({
     line, stop in
@@ -363,10 +363,10 @@ func taintThroughInterpolatedStrings() {
   var outLongest = (nil as AutoreleasingUnsafeMutablePointer<NSString?>?)!
   var outArray = (nil as AutoreleasingUnsafeMutablePointer<NSArray?>?)!
   if (str10.completePath(into: outLongest, caseSensitive: false, matchesInto: outArray, filterTypes: nil) > 0) {
-    sink(arg: outLongest) // $ MISSING: tainted=
+    sink(arg: outLongest) // $ tainted=362
     sink(arg: outLongest.pointee) // $ MISSING: tainted=
     sink(arg: outLongest.pointee!) // $ MISSING: tainted=
-    sink(arg: outArray) // $ MISSING: tainted=
+    sink(arg: outArray) // $ tainted=362
     sink(arg: outArray.pointee) // $ MISSING: tainted=
     sink(arg: outArray.pointee!) // $ MISSING: tainted=
   }
@@ -374,7 +374,7 @@ func taintThroughInterpolatedStrings() {
   var str11 = sourceNSString()
   var outBuffer = (nil as UnsafeMutablePointer<CChar>?)!
   if (str11.getFileSystemRepresentation(outBuffer, maxLength: 256)) {
-    sink(arg: outBuffer) // $ MISSING: tainted=
+    sink(arg: outBuffer) // $ tainted=374
     sink(arg: outBuffer.pointee) // $ MISSING: tainted=
   }
 

--- a/swift/ql/test/library-tests/dataflow/taint/libraries/unsafepointer.swift
+++ b/swift/ql/test/library-tests/dataflow/taint/libraries/unsafepointer.swift
@@ -96,6 +96,6 @@ func testMutatingMyPointerInCall(ptr: MyPointer) {
 
   taintMyPointer(ptr: ptr) // mutates `ptr` pointee with a tainted value
 
-  sink(arg: ptr.pointee) // $ tainted=87
+  sink(arg: ptr.pointee) // $ MISSING: tainted=87
   sink(arg: ptr)
 }

--- a/swift/ql/test/library-tests/dataflow/taint/libraries/unsafepointer.swift
+++ b/swift/ql/test/library-tests/dataflow/taint/libraries/unsafepointer.swift
@@ -1,0 +1,101 @@
+
+// --- stubs ---
+
+func sourceString() -> String { return "" }
+func sourceUInt8() -> UInt8 { return 0 }
+func sink(arg: Any) {}
+
+// --- tests ---
+
+func clearPointer1(ptr: UnsafeMutablePointer<String>) {
+  ptr.pointee = "abc"
+
+  sink(arg: ptr.pointee)
+  sink(arg: ptr)
+}
+
+func taintPointer(ptr: UnsafeMutablePointer<String>) {
+  sink(arg: ptr.pointee)
+  sink(arg: ptr)
+
+  ptr.pointee = sourceString()
+
+  sink(arg: ptr.pointee) // $ tainted=21
+  sink(arg: ptr)
+}
+
+func clearPointer2(ptr: UnsafeMutablePointer<String>) {
+  sink(arg: ptr.pointee) // $ MISSING: tainted=21
+  sink(arg: ptr)
+
+  ptr.pointee = "abc"
+
+  sink(arg: ptr.pointee)
+  sink(arg: ptr)
+}
+
+func testMutatingPointerInCall(ptr: UnsafeMutablePointer<String>) {
+  clearPointer1(ptr: ptr)
+
+  sink(arg: ptr.pointee)
+  sink(arg: ptr)
+
+  taintPointer(ptr: ptr) // mutates `ptr` pointee with a tainted value
+
+  sink(arg: ptr.pointee) // $ MISSING: tainted=21
+  sink(arg: ptr)
+
+  clearPointer2(ptr: ptr)
+
+  sink(arg: ptr.pointee)
+  sink(arg: ptr)
+}
+
+// ---
+
+func taintBuffer(buffer: UnsafeMutableBufferPointer<UInt8>) {
+  sink(arg: buffer[0])
+  sink(arg: buffer)
+
+  buffer[0] = sourceUInt8()
+
+  sink(arg: buffer[0]) // $ MISSING: tainted=60
+  sink(arg: buffer)
+}
+
+func testMutatingBufferInCall(ptr: UnsafeMutablePointer<UInt8>) {
+  let buffer = UnsafeMutableBufferPointer<UInt8>(start: ptr, count: 1000)
+
+  sink(arg: buffer[0])
+  sink(arg: buffer)
+
+  taintBuffer(buffer: buffer) // mutates `buffer` contents with a tainted value
+
+  sink(arg: buffer[0]) // $ MISSING: tainted=60
+  sink(arg: buffer)
+
+}
+
+// ---
+
+typealias MyPointer = UnsafeMutablePointer<String>
+
+func taintMyPointer(ptr: MyPointer) {
+  sink(arg: ptr.pointee)
+  sink(arg: ptr)
+
+  ptr.pointee = sourceString()
+
+  sink(arg: ptr.pointee) // $ tainted=87
+  sink(arg: ptr)
+}
+
+func testMutatingMyPointerInCall(ptr: MyPointer) {
+  sink(arg: ptr.pointee)
+  sink(arg: ptr)
+
+  taintMyPointer(ptr: ptr) // mutates `ptr` pointee with a tainted value
+
+  sink(arg: ptr.pointee) // $ MISSING: tainted=87
+  sink(arg: ptr)
+}

--- a/swift/ql/test/library-tests/dataflow/taint/libraries/unsafepointer.swift
+++ b/swift/ql/test/library-tests/dataflow/taint/libraries/unsafepointer.swift
@@ -25,7 +25,7 @@ func taintPointer(ptr: UnsafeMutablePointer<String>) {
 }
 
 func clearPointer2(ptr: UnsafeMutablePointer<String>) {
-  sink(arg: ptr.pointee) // $ MISSING: tainted=21
+  sink(arg: ptr.pointee) // $ tainted=21
   sink(arg: ptr)
 
   ptr.pointee = "abc"
@@ -42,12 +42,12 @@ func testMutatingPointerInCall(ptr: UnsafeMutablePointer<String>) {
 
   taintPointer(ptr: ptr) // mutates `ptr` pointee with a tainted value
 
-  sink(arg: ptr.pointee) // $ MISSING: tainted=21
+  sink(arg: ptr.pointee) // $ tainted=21
   sink(arg: ptr)
 
   clearPointer2(ptr: ptr)
 
-  sink(arg: ptr.pointee)
+  sink(arg: ptr.pointee) // $ SPURIOUS: tainted=21
   sink(arg: ptr)
 }
 
@@ -96,6 +96,6 @@ func testMutatingMyPointerInCall(ptr: MyPointer) {
 
   taintMyPointer(ptr: ptr) // mutates `ptr` pointee with a tainted value
 
-  sink(arg: ptr.pointee) // $ MISSING: tainted=87
+  sink(arg: ptr.pointee) // $ tainted=87
   sink(arg: ptr)
 }

--- a/swift/ql/test/library-tests/elements/type/pointertypes/pointers.swift
+++ b/swift/ql/test/library-tests/elements/type/pointertypes/pointers.swift
@@ -1,4 +1,7 @@
 
+struct AutoreleasingUnsafeMutablePointer<Pointee> {
+}
+
 class MyClass {
 	init() {
 		val = 0

--- a/swift/ql/test/library-tests/elements/type/pointertypes/pointers.swift
+++ b/swift/ql/test/library-tests/elements/type/pointertypes/pointers.swift
@@ -1,0 +1,26 @@
+
+class MyClass {
+	init() {
+		val = 0
+	}
+
+	var val: Int
+}
+
+func test() {
+	var p1: UnsafePointer<Int>
+	var p2: UnsafeMutablePointer<UInt8>
+	var p3: UnsafeBufferPointer<String>
+	var p4: UnsafeMutableBufferPointer<MyClass>
+	var p5: UnsafeRawPointer
+	var p6: UnsafeMutableRawPointer
+	var p7: UnsafeRawBufferPointer
+	var p8: UnsafeMutableRawBufferPointer
+
+	var op: OpaquePointer // C-interop
+	var aump: AutoreleasingUnsafeMutablePointer<UInt8> // ObjC-interop
+	var um: Unmanaged<MyClass> // C-interop
+	var cvlp: CVaListPointer // varargs list pointer
+
+	var mbp: ManagedBufferPointer<Int, MyClass>
+}

--- a/swift/ql/test/library-tests/elements/type/pointertypes/pointertypes.expected
+++ b/swift/ql/test/library-tests/elements/type/pointertypes/pointertypes.expected
@@ -1,13 +1,14 @@
-| pointers.swift:11:6:11:6 | p1 | UnsafePointer<Int> | PointerType, UnsafeTypedPointerType |
-| pointers.swift:12:6:12:6 | p2 | UnsafeMutablePointer<UInt8> | PointerType, UnsafeTypedPointerType |
-| pointers.swift:13:6:13:6 | p3 | UnsafeBufferPointer<String> | PointerType, UnsafeTypedPointerType |
-| pointers.swift:14:6:14:6 | p4 | UnsafeMutableBufferPointer<MyClass> | PointerType, UnsafeTypedPointerType |
-| pointers.swift:15:6:15:6 | p5 | UnsafeRawPointer | PointerType, UnsafeRawPointerType |
-| pointers.swift:16:6:16:6 | p6 | UnsafeMutableRawPointer | PointerType, UnsafeRawPointerType |
-| pointers.swift:17:6:17:6 | p7 | UnsafeRawBufferPointer | PointerType, UnsafeRawPointerType |
-| pointers.swift:18:6:18:6 | p8 | UnsafeMutableRawBufferPointer | PointerType, UnsafeRawPointerType |
-| pointers.swift:20:6:20:6 | op | OpaquePointer | OpaquePointerType, PointerType |
-| pointers.swift:21:6:21:6 | aump | AutoreleasingUnsafeMutablePointer<UInt8> | AutoreleasingUnsafeMutablePointerType, PointerType |
-| pointers.swift:22:6:22:6 | um | Unmanaged<MyClass> | PointerType, UnmanagedType |
-| pointers.swift:23:6:23:6 | cvlp | CVaListPointer | CVaListPointerType, PointerType |
-| pointers.swift:25:6:25:6 | mbp | ManagedBufferPointer<Int, MyClass> | ManagedBufferPointerType, PointerType |
+| pointers.swift:2:8:2:8 | self | AutoreleasingUnsafeMutablePointer<Pointee> | AutoreleasingUnsafeMutablePointerType, PointerType |
+| pointers.swift:14:6:14:6 | p1 | UnsafePointer<Int> | PointerType, UnsafeTypedPointerType |
+| pointers.swift:15:6:15:6 | p2 | UnsafeMutablePointer<UInt8> | PointerType, UnsafeTypedPointerType |
+| pointers.swift:16:6:16:6 | p3 | UnsafeBufferPointer<String> | PointerType, UnsafeTypedPointerType |
+| pointers.swift:17:6:17:6 | p4 | UnsafeMutableBufferPointer<MyClass> | PointerType, UnsafeTypedPointerType |
+| pointers.swift:18:6:18:6 | p5 | UnsafeRawPointer | PointerType, UnsafeRawPointerType |
+| pointers.swift:19:6:19:6 | p6 | UnsafeMutableRawPointer | PointerType, UnsafeRawPointerType |
+| pointers.swift:20:6:20:6 | p7 | UnsafeRawBufferPointer | PointerType, UnsafeRawPointerType |
+| pointers.swift:21:6:21:6 | p8 | UnsafeMutableRawBufferPointer | PointerType, UnsafeRawPointerType |
+| pointers.swift:23:6:23:6 | op | OpaquePointer | OpaquePointerType, PointerType |
+| pointers.swift:24:6:24:6 | aump | AutoreleasingUnsafeMutablePointer<UInt8> | AutoreleasingUnsafeMutablePointerType, PointerType |
+| pointers.swift:25:6:25:6 | um | Unmanaged<MyClass> | PointerType, UnmanagedType |
+| pointers.swift:26:6:26:6 | cvlp | CVaListPointer | CVaListPointerType, PointerType |
+| pointers.swift:28:6:28:6 | mbp | ManagedBufferPointer<Int, MyClass> | ManagedBufferPointerType, PointerType |

--- a/swift/ql/test/library-tests/elements/type/pointertypes/pointertypes.expected
+++ b/swift/ql/test/library-tests/elements/type/pointertypes/pointertypes.expected
@@ -1,13 +1,13 @@
-| pointers.swift:11:6:11:6 | p1 | UnsafePointer<Int> | UnsafeTypedPointerType |
-| pointers.swift:12:6:12:6 | p2 | UnsafeMutablePointer<UInt8> | UnsafeTypedPointerType |
-| pointers.swift:13:6:13:6 | p3 | UnsafeBufferPointer<String> | UnsafeTypedPointerType |
-| pointers.swift:14:6:14:6 | p4 | UnsafeMutableBufferPointer<MyClass> | UnsafeTypedPointerType |
-| pointers.swift:15:6:15:6 | p5 | UnsafeRawPointer | UnsafeRawPointerType |
-| pointers.swift:16:6:16:6 | p6 | UnsafeMutableRawPointer | UnsafeRawPointerType |
-| pointers.swift:17:6:17:6 | p7 | UnsafeRawBufferPointer | UnsafeRawPointerType |
-| pointers.swift:18:6:18:6 | p8 | UnsafeMutableRawBufferPointer | UnsafeRawPointerType |
-| pointers.swift:20:6:20:6 | op | OpaquePointer | OpaquePointerType |
-| pointers.swift:21:6:21:6 | aump | AutoreleasingUnsafeMutablePointer<UInt8> | AutoreleasingUnsafeMutablePointerType |
-| pointers.swift:22:6:22:6 | um | Unmanaged<MyClass> | UnmanagedType |
-| pointers.swift:23:6:23:6 | cvlp | CVaListPointer | CVaListPointerType |
-| pointers.swift:25:6:25:6 | mbp | ManagedBufferPointer<Int, MyClass> | ManagedBufferPointerType |
+| pointers.swift:11:6:11:6 | p1 | UnsafePointer<Int> | PointerType, UnsafeTypedPointerType |
+| pointers.swift:12:6:12:6 | p2 | UnsafeMutablePointer<UInt8> | PointerType, UnsafeTypedPointerType |
+| pointers.swift:13:6:13:6 | p3 | UnsafeBufferPointer<String> | PointerType, UnsafeTypedPointerType |
+| pointers.swift:14:6:14:6 | p4 | UnsafeMutableBufferPointer<MyClass> | PointerType, UnsafeTypedPointerType |
+| pointers.swift:15:6:15:6 | p5 | UnsafeRawPointer | PointerType, UnsafeRawPointerType |
+| pointers.swift:16:6:16:6 | p6 | UnsafeMutableRawPointer | PointerType, UnsafeRawPointerType |
+| pointers.swift:17:6:17:6 | p7 | UnsafeRawBufferPointer | PointerType, UnsafeRawPointerType |
+| pointers.swift:18:6:18:6 | p8 | UnsafeMutableRawBufferPointer | PointerType, UnsafeRawPointerType |
+| pointers.swift:20:6:20:6 | op | OpaquePointer | OpaquePointerType, PointerType |
+| pointers.swift:21:6:21:6 | aump | AutoreleasingUnsafeMutablePointer<UInt8> | AutoreleasingUnsafeMutablePointerType, PointerType |
+| pointers.swift:22:6:22:6 | um | Unmanaged<MyClass> | PointerType, UnmanagedType |
+| pointers.swift:23:6:23:6 | cvlp | CVaListPointer | CVaListPointerType, PointerType |
+| pointers.swift:25:6:25:6 | mbp | ManagedBufferPointer<Int, MyClass> | ManagedBufferPointerType, PointerType |

--- a/swift/ql/test/library-tests/elements/type/pointertypes/pointertypes.expected
+++ b/swift/ql/test/library-tests/elements/type/pointertypes/pointertypes.expected
@@ -1,0 +1,13 @@
+| pointers.swift:11:6:11:6 | p1 | UnsafePointer<Int> | UnsafeTypedPointerType |
+| pointers.swift:12:6:12:6 | p2 | UnsafeMutablePointer<UInt8> | UnsafeTypedPointerType |
+| pointers.swift:13:6:13:6 | p3 | UnsafeBufferPointer<String> | UnsafeTypedPointerType |
+| pointers.swift:14:6:14:6 | p4 | UnsafeMutableBufferPointer<MyClass> | UnsafeTypedPointerType |
+| pointers.swift:15:6:15:6 | p5 | UnsafeRawPointer | UnsafeRawPointerType |
+| pointers.swift:16:6:16:6 | p6 | UnsafeMutableRawPointer | UnsafeRawPointerType |
+| pointers.swift:17:6:17:6 | p7 | UnsafeRawBufferPointer | UnsafeRawPointerType |
+| pointers.swift:18:6:18:6 | p8 | UnsafeMutableRawBufferPointer | UnsafeRawPointerType |
+| pointers.swift:20:6:20:6 | op | OpaquePointer | OpaquePointerType |
+| pointers.swift:21:6:21:6 | aump | AutoreleasingUnsafeMutablePointer<UInt8> | AutoreleasingUnsafeMutablePointerType |
+| pointers.swift:22:6:22:6 | um | Unmanaged<MyClass> | UnmanagedType |
+| pointers.swift:23:6:23:6 | cvlp | CVaListPointer | CVaListPointerType |
+| pointers.swift:25:6:25:6 | mbp | ManagedBufferPointer<Int, MyClass> | ManagedBufferPointerType |

--- a/swift/ql/test/library-tests/elements/type/pointertypes/pointertypes.ql
+++ b/swift/ql/test/library-tests/elements/type/pointertypes/pointertypes.ql
@@ -2,6 +2,8 @@ import swift
 import codeql.swift.frameworks.StandardLibrary.PointerTypes
 
 string describe(Type t) {
+  t instanceof PointerType and result = "PointerType"
+  or
   t instanceof BuiltinRawPointerType and result = "BuiltinRawPointerType"
   or
   t instanceof UnsafeTypedPointerType and result = "UnsafeTypedPointerType"

--- a/swift/ql/test/library-tests/elements/type/pointertypes/pointertypes.ql
+++ b/swift/ql/test/library-tests/elements/type/pointertypes/pointertypes.ql
@@ -12,7 +12,8 @@ string describe(Type t) {
   or
   t instanceof OpaquePointerType and result = "OpaquePointerType"
   or
-  t instanceof AutoreleasingUnsafeMutablePointerType and result = "AutoreleasingUnsafeMutablePointerType"
+  t instanceof AutoreleasingUnsafeMutablePointerType and
+  result = "AutoreleasingUnsafeMutablePointerType"
   or
   t instanceof UnmanagedType and result = "UnmanagedType"
   or

--- a/swift/ql/test/library-tests/elements/type/pointertypes/pointertypes.ql
+++ b/swift/ql/test/library-tests/elements/type/pointertypes/pointertypes.ql
@@ -1,0 +1,26 @@
+import swift
+import codeql.swift.frameworks.StandardLibrary.PointerTypes
+
+string describe(Type t) {
+  t instanceof BuiltinRawPointerType and result = "BuiltinRawPointerType"
+  or
+  t instanceof UnsafeTypedPointerType and result = "UnsafeTypedPointerType"
+  or
+  t instanceof UnsafeRawPointerType and result = "UnsafeRawPointerType"
+  or
+  t instanceof OpaquePointerType and result = "OpaquePointerType"
+  or
+  t instanceof AutoreleasingUnsafeMutablePointerType and result = "AutoreleasingUnsafeMutablePointerType"
+  or
+  t instanceof UnmanagedType and result = "UnmanagedType"
+  or
+  t instanceof CVaListPointerType and result = "CVaListPointerType"
+  or
+  t instanceof ManagedBufferPointerType and result = "ManagedBufferPointerType"
+}
+
+from VarDecl v, Type t
+where
+  v.getLocation().getFile().getBaseName() != "" and
+  t = v.getType()
+select v, t.toString(), strictconcat(describe(t), ", ")

--- a/swift/ql/test/query-tests/Security/CWE-089/SqlInjection.expected
+++ b/swift/ql/test/query-tests/Security/CWE-089/SqlInjection.expected
@@ -97,12 +97,23 @@ edges
 | SQLite.swift:62:25:62:79 | call to String.init(contentsOf:) :  | SQLite.swift:117:16:117:16 | unsafeQuery1 |
 | SQLite.swift:62:25:62:79 | call to String.init(contentsOf:) :  | SQLite.swift:119:16:119:16 | unsafeQuery1 |
 | SQLite.swift:62:25:62:79 | call to String.init(contentsOf:) :  | SQLite.swift:132:20:132:20 | remoteString |
+| sqlite3_c_api.swift:15:2:15:71 | [summary param] this in copyBytes(to:count:) :  | file://:0:0:0:0 | [summary] to write: argument 0 in copyBytes(to:count:) :  |
+| sqlite3_c_api.swift:37:2:37:103 | [summary param] this in data(using:allowLossyConversion:) :  | file://:0:0:0:0 | [summary] to write: return (return) in data(using:allowLossyConversion:) :  |
 | sqlite3_c_api.swift:122:26:122:80 | call to String.init(contentsOf:) :  | sqlite3_c_api.swift:133:33:133:33 | unsafeQuery1 |
 | sqlite3_c_api.swift:122:26:122:80 | call to String.init(contentsOf:) :  | sqlite3_c_api.swift:134:33:134:33 | unsafeQuery2 |
 | sqlite3_c_api.swift:122:26:122:80 | call to String.init(contentsOf:) :  | sqlite3_c_api.swift:135:33:135:33 | unsafeQuery3 |
 | sqlite3_c_api.swift:122:26:122:80 | call to String.init(contentsOf:) :  | sqlite3_c_api.swift:145:26:145:26 | unsafeQuery3 |
 | sqlite3_c_api.swift:122:26:122:80 | call to String.init(contentsOf:) :  | sqlite3_c_api.swift:175:29:175:29 | unsafeQuery3 |
 | sqlite3_c_api.swift:122:26:122:80 | call to String.init(contentsOf:) :  | sqlite3_c_api.swift:183:29:183:29 | unsafeQuery3 |
+| sqlite3_c_api.swift:122:26:122:80 | call to String.init(contentsOf:) :  | sqlite3_c_api.swift:189:13:189:13 | unsafeQuery3 :  |
+| sqlite3_c_api.swift:189:13:189:13 | unsafeQuery3 :  | sqlite3_c_api.swift:37:2:37:103 | [summary param] this in data(using:allowLossyConversion:) :  |
+| sqlite3_c_api.swift:189:13:189:13 | unsafeQuery3 :  | sqlite3_c_api.swift:189:13:189:58 | call to data(using:allowLossyConversion:) :  |
+| sqlite3_c_api.swift:189:13:189:58 | call to data(using:allowLossyConversion:) :  | sqlite3_c_api.swift:190:2:190:2 | data :  |
+| sqlite3_c_api.swift:190:2:190:2 | data :  | sqlite3_c_api.swift:15:2:15:71 | [summary param] this in copyBytes(to:count:) :  |
+| sqlite3_c_api.swift:190:2:190:2 | data :  | sqlite3_c_api.swift:190:21:190:21 | [post] buffer :  |
+| sqlite3_c_api.swift:190:21:190:21 | [post] buffer :  | sqlite3_c_api.swift:194:28:194:28 | buffer |
+| sqlite3_c_api.swift:190:21:190:21 | [post] buffer :  | sqlite3_c_api.swift:202:31:202:31 | buffer |
+| sqlite3_c_api.swift:190:21:190:21 | [post] buffer :  | sqlite3_c_api.swift:210:31:210:31 | buffer |
 nodes
 | GRDB.swift:104:25:104:79 | call to String.init(contentsOf:) :  | semmle.label | call to String.init(contentsOf:) :  |
 | GRDB.swift:106:41:106:41 | remoteString | semmle.label | remoteString |
@@ -215,6 +226,10 @@ nodes
 | SQLite.swift:117:16:117:16 | unsafeQuery1 | semmle.label | unsafeQuery1 |
 | SQLite.swift:119:16:119:16 | unsafeQuery1 | semmle.label | unsafeQuery1 |
 | SQLite.swift:132:20:132:20 | remoteString | semmle.label | remoteString |
+| file://:0:0:0:0 | [summary] to write: argument 0 in copyBytes(to:count:) :  | semmle.label | [summary] to write: argument 0 in copyBytes(to:count:) :  |
+| file://:0:0:0:0 | [summary] to write: return (return) in data(using:allowLossyConversion:) :  | semmle.label | [summary] to write: return (return) in data(using:allowLossyConversion:) :  |
+| sqlite3_c_api.swift:15:2:15:71 | [summary param] this in copyBytes(to:count:) :  | semmle.label | [summary param] this in copyBytes(to:count:) :  |
+| sqlite3_c_api.swift:37:2:37:103 | [summary param] this in data(using:allowLossyConversion:) :  | semmle.label | [summary param] this in data(using:allowLossyConversion:) :  |
 | sqlite3_c_api.swift:122:26:122:80 | call to String.init(contentsOf:) :  | semmle.label | call to String.init(contentsOf:) :  |
 | sqlite3_c_api.swift:133:33:133:33 | unsafeQuery1 | semmle.label | unsafeQuery1 |
 | sqlite3_c_api.swift:134:33:134:33 | unsafeQuery2 | semmle.label | unsafeQuery2 |
@@ -222,7 +237,16 @@ nodes
 | sqlite3_c_api.swift:145:26:145:26 | unsafeQuery3 | semmle.label | unsafeQuery3 |
 | sqlite3_c_api.swift:175:29:175:29 | unsafeQuery3 | semmle.label | unsafeQuery3 |
 | sqlite3_c_api.swift:183:29:183:29 | unsafeQuery3 | semmle.label | unsafeQuery3 |
+| sqlite3_c_api.swift:189:13:189:13 | unsafeQuery3 :  | semmle.label | unsafeQuery3 :  |
+| sqlite3_c_api.swift:189:13:189:58 | call to data(using:allowLossyConversion:) :  | semmle.label | call to data(using:allowLossyConversion:) :  |
+| sqlite3_c_api.swift:190:2:190:2 | data :  | semmle.label | data :  |
+| sqlite3_c_api.swift:190:21:190:21 | [post] buffer :  | semmle.label | [post] buffer :  |
+| sqlite3_c_api.swift:194:28:194:28 | buffer | semmle.label | buffer |
+| sqlite3_c_api.swift:202:31:202:31 | buffer | semmle.label | buffer |
+| sqlite3_c_api.swift:210:31:210:31 | buffer | semmle.label | buffer |
 subpaths
+| sqlite3_c_api.swift:189:13:189:13 | unsafeQuery3 :  | sqlite3_c_api.swift:37:2:37:103 | [summary param] this in data(using:allowLossyConversion:) :  | file://:0:0:0:0 | [summary] to write: return (return) in data(using:allowLossyConversion:) :  | sqlite3_c_api.swift:189:13:189:58 | call to data(using:allowLossyConversion:) :  |
+| sqlite3_c_api.swift:190:2:190:2 | data :  | sqlite3_c_api.swift:15:2:15:71 | [summary param] this in copyBytes(to:count:) :  | file://:0:0:0:0 | [summary] to write: argument 0 in copyBytes(to:count:) :  | sqlite3_c_api.swift:190:21:190:21 | [post] buffer :  |
 #select
 | GRDB.swift:106:41:106:41 | remoteString | GRDB.swift:104:25:104:79 | call to String.init(contentsOf:) :  | GRDB.swift:106:41:106:41 | remoteString | This query depends on a $@. | GRDB.swift:104:25:104:79 | call to String.init(contentsOf:) | user-provided value |
 | GRDB.swift:108:41:108:41 | remoteString | GRDB.swift:104:25:104:79 | call to String.init(contentsOf:) :  | GRDB.swift:108:41:108:41 | remoteString | This query depends on a $@. | GRDB.swift:104:25:104:79 | call to String.init(contentsOf:) | user-provided value |
@@ -328,3 +352,6 @@ subpaths
 | sqlite3_c_api.swift:145:26:145:26 | unsafeQuery3 | sqlite3_c_api.swift:122:26:122:80 | call to String.init(contentsOf:) :  | sqlite3_c_api.swift:145:26:145:26 | unsafeQuery3 | This query depends on a $@. | sqlite3_c_api.swift:122:26:122:80 | call to String.init(contentsOf:) | user-provided value |
 | sqlite3_c_api.swift:175:29:175:29 | unsafeQuery3 | sqlite3_c_api.swift:122:26:122:80 | call to String.init(contentsOf:) :  | sqlite3_c_api.swift:175:29:175:29 | unsafeQuery3 | This query depends on a $@. | sqlite3_c_api.swift:122:26:122:80 | call to String.init(contentsOf:) | user-provided value |
 | sqlite3_c_api.swift:183:29:183:29 | unsafeQuery3 | sqlite3_c_api.swift:122:26:122:80 | call to String.init(contentsOf:) :  | sqlite3_c_api.swift:183:29:183:29 | unsafeQuery3 | This query depends on a $@. | sqlite3_c_api.swift:122:26:122:80 | call to String.init(contentsOf:) | user-provided value |
+| sqlite3_c_api.swift:194:28:194:28 | buffer | sqlite3_c_api.swift:122:26:122:80 | call to String.init(contentsOf:) :  | sqlite3_c_api.swift:194:28:194:28 | buffer | This query depends on a $@. | sqlite3_c_api.swift:122:26:122:80 | call to String.init(contentsOf:) | user-provided value |
+| sqlite3_c_api.swift:202:31:202:31 | buffer | sqlite3_c_api.swift:122:26:122:80 | call to String.init(contentsOf:) :  | sqlite3_c_api.swift:202:31:202:31 | buffer | This query depends on a $@. | sqlite3_c_api.swift:122:26:122:80 | call to String.init(contentsOf:) | user-provided value |
+| sqlite3_c_api.swift:210:31:210:31 | buffer | sqlite3_c_api.swift:122:26:122:80 | call to String.init(contentsOf:) :  | sqlite3_c_api.swift:210:31:210:31 | buffer | This query depends on a $@. | sqlite3_c_api.swift:122:26:122:80 | call to String.init(contentsOf:) | user-provided value |

--- a/swift/ql/test/query-tests/Security/CWE-089/sqlite3_c_api.swift
+++ b/swift/ql/test/query-tests/Security/CWE-089/sqlite3_c_api.swift
@@ -191,7 +191,7 @@ func test_sqlite3_c_api(db: OpaquePointer?, buffer: UnsafeMutablePointer<UInt8>)
 
 	var stmt6: OpaquePointer?
 
-	if (sqlite3_prepare16(db, buffer, Int32(data.count), &stmt6, nil) == SQLITE_OK) { // BAD [NOT DETECTED]
+	if (sqlite3_prepare16(db, buffer, Int32(data.count), &stmt6, nil) == SQLITE_OK) { // BAD
 		let result = sqlite3_step(stmt6)
 		// ...
 	}
@@ -199,7 +199,7 @@ func test_sqlite3_c_api(db: OpaquePointer?, buffer: UnsafeMutablePointer<UInt8>)
 
 	var stmt7: OpaquePointer?
 
-	if (sqlite3_prepare16_v2(db, buffer, Int32(data.count), &stmt7, nil) == SQLITE_OK) { // BAD [NOT DETECTED]
+	if (sqlite3_prepare16_v2(db, buffer, Int32(data.count), &stmt7, nil) == SQLITE_OK) { // BAD
 		let result = sqlite3_step(stmt7)
 		// ...
 	}
@@ -207,7 +207,7 @@ func test_sqlite3_c_api(db: OpaquePointer?, buffer: UnsafeMutablePointer<UInt8>)
 
 	var stmt8: OpaquePointer?
 
-	if (sqlite3_prepare16_v3(db, buffer, Int32(data.count), 0, &stmt8, nil) == SQLITE_OK) { // BAD [NOT DETECTED]
+	if (sqlite3_prepare16_v3(db, buffer, Int32(data.count), 0, &stmt8, nil) == SQLITE_OK) { // BAD
 		let result = sqlite3_step(stmt8)
 		// ...
 	}


### PR DESCRIPTION
Permit data flow out through pointer arguments whose contents is modified in the function.  The main change is in `DataFlowPrivate.qll`.  The rest of the changes are adding a `PointerTypes.qll` library to identify pointer types, and lots of testing.

Questions:
- we could restrict `modifiable` to only include _mutable_ pointers, but I think this might introduce edge cases where there really is output through a non-mutable pointer??? (e.g. where the pointee is of immutable type but itself _refers_ to something mutable?)
- alternatively it might be right to widen `modifiable` to include `BoundGenericType`s, as these I think are very similar things to `NominalType`s.  All of the pointers I've modelled are either `NominalType` (which were already part of `modifiable`) or `BoundGenericType`, so the special case for pointers won't be needed if we do that.

Limitations:
 - `modifiable` should account for type aliases, as demonstrated by one of the missing test results.  I've added a note in an issue to address this after the type alias PR is in.
 - we get a spurious result after a pointer contents is cleared in a function; I don't think this is a high priority to fix, but if anyone has a good idea how to do it easily, please say so.
 - some of the `data.swift` and `nsstring.swift` results aren't quite spot on because the MaD models specify taint to the pointer, rather than the pointee.  I've created an issue to sort this out at: https://github.com/github/codeql-c-team/issues/1604
 - the models in `PointerTypes.qll` are *really* basic as they only identify pointers, without modelling any of their methods or consequent taint flow.  I expect we'll expand on this in https://github.com/github/codeql-c-team/issues/1578 .  This is probably why we don't get the results in `taintBuffer`.