### PR TITLE
Swift: Permit data flow from all generic arguments

### DIFF
--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPrivate.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPrivate.qll
@@ -211,9 +211,7 @@ private module Cached {
 private predicate modifiable(Argument arg) {
   arg.getExpr() instanceof InOutExpr
   or
-  arg.getExpr().getType() instanceof NominalType
-  or
-  arg.getExpr().getType() instanceof PointerType
+  arg.getExpr().getType() instanceof NominalOrBoundGenericNominalType
 }
 
 predicate modifiableParam(ParamDecl param) {

--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/PointerTypes.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/PointerTypes.qll
@@ -6,22 +6,6 @@
 import swift
 
 /**
- * A type that is used as a pointer in Swift, such as `UnsafePointer`,
- * `UnsafeBufferPointer` and similar types.
- */
-class PointerType extends Type {
-  PointerType() {
-    this instanceof UnsafeTypedPointerType or
-    this instanceof UnsafeRawPointerType or
-    this instanceof OpaquePointerType or
-    this instanceof AutoreleasingUnsafeMutablePointerType or
-    this instanceof UnmanagedType or
-    this instanceof CVaListPointerType or
-    this instanceof ManagedBufferPointerType
-  }
-}
-
-/**
  * A Swift unsafe typed pointer type such as `UnsafePointer`,
  * `UnsafeMutablePointer` or `UnsafeBufferPointer`.
  */

--- a/swift/ql/test/library-tests/dataflow/taint/libraries/unsafepointer.swift
+++ b/swift/ql/test/library-tests/dataflow/taint/libraries/unsafepointer.swift
@@ -99,3 +99,31 @@ func testMutatingMyPointerInCall(ptr: MyPointer) {
   sink(arg: ptr.pointee) // $ MISSING: tainted=87
   sink(arg: ptr)
 }
+
+// ---
+
+struct MyPointerContainer {
+  var ptr: UnsafeMutablePointer<String>
+}
+
+struct MyGenericPointerContainer<T> {
+  var ptr: UnsafeMutablePointer<T>
+}
+
+func writePointerContainer(mpc: MyPointerContainer) {
+  mpc.ptr.pointee = sourceString()
+  sink(arg: mpc.ptr.pointee) // $ tainted=114
+}
+
+func writeGenericPointerContainer<T>(mgpc: MyGenericPointerContainer<T>) {
+  mgpc.ptr.pointee = sourceString() as! T
+  sink(arg: mgpc.ptr.pointee) // $ tainted=119
+}
+
+func testWritingPointerContainersInCalls(mpc: MyPointerContainer, mgpc: MyGenericPointerContainer<Int>) {
+  writePointerContainer(mpc: mpc)
+  sink(arg: mpc.ptr.pointee) // $ tainted=114
+
+  writeGenericPointerContainer(mgpc: mgpc)
+  sink(arg: mgpc.ptr.pointee) // $ MISSING: tainted=119
+}

--- a/swift/ql/test/library-tests/dataflow/taint/libraries/unsafepointer.swift
+++ b/swift/ql/test/library-tests/dataflow/taint/libraries/unsafepointer.swift
@@ -125,5 +125,5 @@ func testWritingPointerContainersInCalls(mpc: MyPointerContainer, mgpc: MyGeneri
   sink(arg: mpc.ptr.pointee) // $ tainted=114
 
   writeGenericPointerContainer(mgpc: mgpc)
-  sink(arg: mgpc.ptr.pointee) // $ MISSING: tainted=119
+  sink(arg: mgpc.ptr.pointee) // $ tainted=119
 }


### PR DESCRIPTION
Permit data flow from all generic arguments with the assumption they could be modified (rather than just pointers).  Follow-up to https://github.com/github/codeql/pull/12391 - see discussion there and test case below.

@MathiasVP 