### PR TITLE
Ruby: Rewrite Stored XSS query to use new data flow interface

### DIFF
--- a/ruby/ql/lib/codeql/ruby/security/StoredXSSQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/StoredXSSQuery.qll
@@ -16,9 +16,11 @@ module StoredXss {
   import XSS::StoredXss
 
   /**
+   * DEPRECATED.
+   *
    * A taint-tracking configuration for reasoning about Stored XSS.
    */
-  class Configuration extends TaintTracking::Configuration {
+  deprecated class Configuration extends TaintTracking::Configuration {
     Configuration() { this = "StoredXss" }
 
     override predicate isSource(DataFlow::Node source) { source instanceof Source }
@@ -38,6 +40,23 @@ module StoredXss {
       isAdditionalXssTaintStep(node1, node2)
     }
   }
+
+  /**
+   * A taint-tracking configuration for reasoning about Stored XSS.
+   */
+  private module Config implements DataFlow::ConfigSig {
+    predicate isSource(DataFlow::Node source) { source instanceof Source }
+
+    predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
+
+    predicate isBarrier(DataFlow::Node node) { node instanceof Sanitizer }
+
+    predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
+      isAdditionalXssTaintStep(node1, node2)
+    }
+  }
+
+  import TaintTracking::Make<Config>
 }
 
 /** DEPRECATED: Alias for StoredXss */

--- a/ruby/ql/src/queries/security/cwe-079/StoredXSS.ql
+++ b/ruby/ql/src/queries/security/cwe-079/StoredXSS.ql
@@ -14,9 +14,9 @@
 
 import codeql.ruby.AST
 import codeql.ruby.security.StoredXSSQuery
-import DataFlow::PathGraph
+import StoredXss::PathGraph
 
-from StoredXss::Configuration config, DataFlow::PathNode source, DataFlow::PathNode sink
-where config.hasFlowPath(source, sink)
+from StoredXss::PathNode source, StoredXss::PathNode sink
+where StoredXss::hasFlowPath(source, sink)
 select sink.getNode(), source, sink, "Stored cross-site scripting vulnerability due to $@.",
   source.getNode(), "stored value"


### PR DESCRIPTION
This PR converts the Stored XSS query to use the [new data flow interface](https://github.com/github/codeql/pull/12186). It may serve as inspiration for other similar rewrites, until our documentation has been updated.