### PR TITLE
Dataflow: Remove revFlowAlias and revFlowApAlias predicates

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -1144,20 +1144,13 @@ module Impl<FullStateConfigSig Config> {
     module Stage<StageParam Param> implements StageSig {
       import Param
 
-      /* Begin: Stage logic. */
-      // use an alias as a workaround for bad functionality-induced joins
-      pragma[nomagic]
-      private predicate revFlowApAlias(NodeEx node, ApApprox apa) {
-        PrevStage::revFlowAp(node, apa)
-      }
-
       pragma[nomagic]
       private predicate flowIntoCallApa(
         DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, ApApprox apa
       ) {
         flowIntoCall(call, arg, p, allowsFieldFlow) and
         PrevStage::revFlowAp(p, pragma[only_bind_into](apa)) and
-        revFlowApAlias(arg, pragma[only_bind_into](apa))
+        PrevStage::revFlowAp(arg, pragma[only_bind_into](apa))
       }
 
       pragma[nomagic]
@@ -1167,7 +1160,7 @@ module Impl<FullStateConfigSig Config> {
       ) {
         flowOutOfCall(call, ret, kind, out, allowsFieldFlow) and
         PrevStage::revFlowAp(out, pragma[only_bind_into](apa)) and
-        revFlowApAlias(ret, pragma[only_bind_into](apa))
+        PrevStage::revFlowAp(ret, pragma[only_bind_into](apa))
       }
 
       pragma[nomagic]

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -1695,16 +1695,6 @@ module Impl<FullStateConfigSig Config> {
       pragma[nomagic]
       predicate revFlowAp(NodeEx node, Ap ap) { revFlow(node, _, _, _, ap) }
 
-      // use an alias as a workaround for bad functionality-induced joins
-      pragma[nomagic]
-      additional predicate revFlowAlias(NodeEx node) { revFlow(node, _, _, _, _) }
-
-      // use an alias as a workaround for bad functionality-induced joins
-      pragma[nomagic]
-      additional predicate revFlowAlias(NodeEx node, FlowState state, Ap ap) {
-        revFlow(node, state, ap)
-      }
-
       private predicate fwdConsCand(TypedContent tc, Ap ap) { storeStepFwd(_, ap, tc, _, _) }
 
       private predicate revConsCand(TypedContent tc, Ap ap) { storeStepCand(_, ap, tc, _, _) }
@@ -1978,7 +1968,7 @@ module Impl<FullStateConfigSig Config> {
   ) {
     flowOutOfCallNodeCand1(call, node1, kind, node2, allowsFieldFlow) and
     Stage2::revFlow(node2) and
-    Stage2::revFlowAlias(node1)
+    Stage2::revFlow(node1)
   }
 
   pragma[nomagic]
@@ -1987,7 +1977,7 @@ module Impl<FullStateConfigSig Config> {
   ) {
     flowIntoCallNodeCand1(call, node1, node2, allowsFieldFlow) and
     Stage2::revFlow(node2) and
-    Stage2::revFlowAlias(node1)
+    Stage2::revFlow(node1)
   }
 
   private module LocalFlowBigStep {
@@ -2069,11 +2059,11 @@ module Impl<FullStateConfigSig Config> {
       additionalLocalFlowStepNodeCand1(node1, node2) and
       state1 = state2 and
       Stage2::revFlow(node1, pragma[only_bind_into](state1), false) and
-      Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), false)
+      Stage2::revFlow(node2, pragma[only_bind_into](state2), false)
       or
       additionalLocalStateStep(node1, state1, node2, state2) and
       Stage2::revFlow(node1, state1, false) and
-      Stage2::revFlowAlias(node2, state2, false)
+      Stage2::revFlow(node2, state2, false)
     }
 
     /**
@@ -2266,7 +2256,7 @@ module Impl<FullStateConfigSig Config> {
     ) {
       localFlowBigStep(node1, state1, node2, state2, preservesValue, ap.getType(), _) and
       PrevStage::revFlow(node1, pragma[only_bind_into](state1), _) and
-      PrevStage::revFlowAlias(node2, pragma[only_bind_into](state2), _) and
+      PrevStage::revFlow(node2, pragma[only_bind_into](state2), _) and
       exists(lcc)
     }
 
@@ -2277,7 +2267,7 @@ module Impl<FullStateConfigSig Config> {
       exists(FlowState state |
         flowOutOfCallNodeCand2(call, node1, kind, node2, allowsFieldFlow) and
         PrevStage::revFlow(node2, pragma[only_bind_into](state), _) and
-        PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _)
+        PrevStage::revFlow(node1, pragma[only_bind_into](state), _)
       )
     }
 
@@ -2288,7 +2278,7 @@ module Impl<FullStateConfigSig Config> {
       exists(FlowState state |
         flowIntoCallNodeCand2(call, node1, node2, allowsFieldFlow) and
         PrevStage::revFlow(node2, pragma[only_bind_into](state), _) and
-        PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _)
+        PrevStage::revFlow(node1, pragma[only_bind_into](state), _)
       )
     }
 
@@ -2590,7 +2580,7 @@ module Impl<FullStateConfigSig Config> {
     ) {
       localFlowBigStep(node1, state1, node2, state2, preservesValue, ap.getType(), lcc) and
       PrevStage::revFlow(node1, pragma[only_bind_into](state1), _) and
-      PrevStage::revFlowAlias(node2, pragma[only_bind_into](state2), _)
+      PrevStage::revFlow(node2, pragma[only_bind_into](state2), _)
     }
 
     pragma[nomagic]
@@ -2600,7 +2590,7 @@ module Impl<FullStateConfigSig Config> {
       exists(FlowState state |
         flowOutOfCallNodeCand2(call, node1, kind, node2, allowsFieldFlow) and
         PrevStage::revFlow(node2, pragma[only_bind_into](state), _) and
-        PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _)
+        PrevStage::revFlow(node1, pragma[only_bind_into](state), _)
       )
     }
 
@@ -2611,7 +2601,7 @@ module Impl<FullStateConfigSig Config> {
       exists(FlowState state |
         flowIntoCallNodeCand2(call, node1, node2, allowsFieldFlow) and
         PrevStage::revFlow(node2, pragma[only_bind_into](state), _) and
-        PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _)
+        PrevStage::revFlow(node1, pragma[only_bind_into](state), _)
       )
     }
 

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -1144,6 +1144,7 @@ module Impl<FullStateConfigSig Config> {
     module Stage<StageParam Param> implements StageSig {
       import Param
 
+      /* Begin: Stage logic. */
       pragma[nomagic]
       private predicate flowIntoCallApa(
         DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, ApApprox apa

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -1144,20 +1144,13 @@ module Impl<FullStateConfigSig Config> {
     module Stage<StageParam Param> implements StageSig {
       import Param
 
-      /* Begin: Stage logic. */
-      // use an alias as a workaround for bad functionality-induced joins
-      pragma[nomagic]
-      private predicate revFlowApAlias(NodeEx node, ApApprox apa) {
-        PrevStage::revFlowAp(node, apa)
-      }
-
       pragma[nomagic]
       private predicate flowIntoCallApa(
         DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, ApApprox apa
       ) {
         flowIntoCall(call, arg, p, allowsFieldFlow) and
         PrevStage::revFlowAp(p, pragma[only_bind_into](apa)) and
-        revFlowApAlias(arg, pragma[only_bind_into](apa))
+        PrevStage::revFlowAp(arg, pragma[only_bind_into](apa))
       }
 
       pragma[nomagic]
@@ -1167,7 +1160,7 @@ module Impl<FullStateConfigSig Config> {
       ) {
         flowOutOfCall(call, ret, kind, out, allowsFieldFlow) and
         PrevStage::revFlowAp(out, pragma[only_bind_into](apa)) and
-        revFlowApAlias(ret, pragma[only_bind_into](apa))
+        PrevStage::revFlowAp(ret, pragma[only_bind_into](apa))
       }
 
       pragma[nomagic]

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -1695,16 +1695,6 @@ module Impl<FullStateConfigSig Config> {
       pragma[nomagic]
       predicate revFlowAp(NodeEx node, Ap ap) { revFlow(node, _, _, _, ap) }
 
-      // use an alias as a workaround for bad functionality-induced joins
-      pragma[nomagic]
-      additional predicate revFlowAlias(NodeEx node) { revFlow(node, _, _, _, _) }
-
-      // use an alias as a workaround for bad functionality-induced joins
-      pragma[nomagic]
-      additional predicate revFlowAlias(NodeEx node, FlowState state, Ap ap) {
-        revFlow(node, state, ap)
-      }
-
       private predicate fwdConsCand(TypedContent tc, Ap ap) { storeStepFwd(_, ap, tc, _, _) }
 
       private predicate revConsCand(TypedContent tc, Ap ap) { storeStepCand(_, ap, tc, _, _) }
@@ -1978,7 +1968,7 @@ module Impl<FullStateConfigSig Config> {
   ) {
     flowOutOfCallNodeCand1(call, node1, kind, node2, allowsFieldFlow) and
     Stage2::revFlow(node2) and
-    Stage2::revFlowAlias(node1)
+    Stage2::revFlow(node1)
   }
 
   pragma[nomagic]
@@ -1987,7 +1977,7 @@ module Impl<FullStateConfigSig Config> {
   ) {
     flowIntoCallNodeCand1(call, node1, node2, allowsFieldFlow) and
     Stage2::revFlow(node2) and
-    Stage2::revFlowAlias(node1)
+    Stage2::revFlow(node1)
   }
 
   private module LocalFlowBigStep {
@@ -2069,11 +2059,11 @@ module Impl<FullStateConfigSig Config> {
       additionalLocalFlowStepNodeCand1(node1, node2) and
       state1 = state2 and
       Stage2::revFlow(node1, pragma[only_bind_into](state1), false) and
-      Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), false)
+      Stage2::revFlow(node2, pragma[only_bind_into](state2), false)
       or
       additionalLocalStateStep(node1, state1, node2, state2) and
       Stage2::revFlow(node1, state1, false) and
-      Stage2::revFlowAlias(node2, state2, false)
+      Stage2::revFlow(node2, state2, false)
     }
 
     /**
@@ -2266,7 +2256,7 @@ module Impl<FullStateConfigSig Config> {
     ) {
       localFlowBigStep(node1, state1, node2, state2, preservesValue, ap.getType(), _) and
       PrevStage::revFlow(node1, pragma[only_bind_into](state1), _) and
-      PrevStage::revFlowAlias(node2, pragma[only_bind_into](state2), _) and
+      PrevStage::revFlow(node2, pragma[only_bind_into](state2), _) and
       exists(lcc)
     }
 
@@ -2277,7 +2267,7 @@ module Impl<FullStateConfigSig Config> {
       exists(FlowState state |
         flowOutOfCallNodeCand2(call, node1, kind, node2, allowsFieldFlow) and
         PrevStage::revFlow(node2, pragma[only_bind_into](state), _) and
-        PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _)
+        PrevStage::revFlow(node1, pragma[only_bind_into](state), _)
       )
     }
 
@@ -2288,7 +2278,7 @@ module Impl<FullStateConfigSig Config> {
       exists(FlowState state |
         flowIntoCallNodeCand2(call, node1, node2, allowsFieldFlow) and
         PrevStage::revFlow(node2, pragma[only_bind_into](state), _) and
-        PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _)
+        PrevStage::revFlow(node1, pragma[only_bind_into](state), _)
       )
     }
 
@@ -2590,7 +2580,7 @@ module Impl<FullStateConfigSig Config> {
     ) {
       localFlowBigStep(node1, state1, node2, state2, preservesValue, ap.getType(), lcc) and
       PrevStage::revFlow(node1, pragma[only_bind_into](state1), _) and
-      PrevStage::revFlowAlias(node2, pragma[only_bind_into](state2), _)
+      PrevStage::revFlow(node2, pragma[only_bind_into](state2), _)
     }
 
     pragma[nomagic]
@@ -2600,7 +2590,7 @@ module Impl<FullStateConfigSig Config> {
       exists(FlowState state |
         flowOutOfCallNodeCand2(call, node1, kind, node2, allowsFieldFlow) and
         PrevStage::revFlow(node2, pragma[only_bind_into](state), _) and
-        PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _)
+        PrevStage::revFlow(node1, pragma[only_bind_into](state), _)
       )
     }
 
@@ -2611,7 +2601,7 @@ module Impl<FullStateConfigSig Config> {
       exists(FlowState state |
         flowIntoCallNodeCand2(call, node1, node2, allowsFieldFlow) and
         PrevStage::revFlow(node2, pragma[only_bind_into](state), _) and
-        PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _)
+        PrevStage::revFlow(node1, pragma[only_bind_into](state), _)
       )
     }
 

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -1144,6 +1144,7 @@ module Impl<FullStateConfigSig Config> {
     module Stage<StageParam Param> implements StageSig {
       import Param
 
+      /* Begin: Stage logic. */
       pragma[nomagic]
       private predicate flowIntoCallApa(
         DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, ApApprox apa

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -1144,20 +1144,13 @@ module Impl<FullStateConfigSig Config> {
     module Stage<StageParam Param> implements StageSig {
       import Param
 
-      /* Begin: Stage logic. */
-      // use an alias as a workaround for bad functionality-induced joins
-      pragma[nomagic]
-      private predicate revFlowApAlias(NodeEx node, ApApprox apa) {
-        PrevStage::revFlowAp(node, apa)
-      }
-
       pragma[nomagic]
       private predicate flowIntoCallApa(
         DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, ApApprox apa
       ) {
         flowIntoCall(call, arg, p, allowsFieldFlow) and
         PrevStage::revFlowAp(p, pragma[only_bind_into](apa)) and
-        revFlowApAlias(arg, pragma[only_bind_into](apa))
+        PrevStage::revFlowAp(arg, pragma[only_bind_into](apa))
       }
 
       pragma[nomagic]
@@ -1167,7 +1160,7 @@ module Impl<FullStateConfigSig Config> {
       ) {
         flowOutOfCall(call, ret, kind, out, allowsFieldFlow) and
         PrevStage::revFlowAp(out, pragma[only_bind_into](apa)) and
-        revFlowApAlias(ret, pragma[only_bind_into](apa))
+        PrevStage::revFlowAp(ret, pragma[only_bind_into](apa))
       }
 
       pragma[nomagic]

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -1695,16 +1695,6 @@ module Impl<FullStateConfigSig Config> {
       pragma[nomagic]
       predicate revFlowAp(NodeEx node, Ap ap) { revFlow(node, _, _, _, ap) }
 
-      // use an alias as a workaround for bad functionality-induced joins
-      pragma[nomagic]
-      additional predicate revFlowAlias(NodeEx node) { revFlow(node, _, _, _, _) }
-
-      // use an alias as a workaround for bad functionality-induced joins
-      pragma[nomagic]
-      additional predicate revFlowAlias(NodeEx node, FlowState state, Ap ap) {
-        revFlow(node, state, ap)
-      }
-
       private predicate fwdConsCand(TypedContent tc, Ap ap) { storeStepFwd(_, ap, tc, _, _) }
 
       private predicate revConsCand(TypedContent tc, Ap ap) { storeStepCand(_, ap, tc, _, _) }
@@ -1978,7 +1968,7 @@ module Impl<FullStateConfigSig Config> {
   ) {
     flowOutOfCallNodeCand1(call, node1, kind, node2, allowsFieldFlow) and
     Stage2::revFlow(node2) and
-    Stage2::revFlowAlias(node1)
+    Stage2::revFlow(node1)
   }
 
   pragma[nomagic]
@@ -1987,7 +1977,7 @@ module Impl<FullStateConfigSig Config> {
   ) {
     flowIntoCallNodeCand1(call, node1, node2, allowsFieldFlow) and
     Stage2::revFlow(node2) and
-    Stage2::revFlowAlias(node1)
+    Stage2::revFlow(node1)
   }
 
   private module LocalFlowBigStep {
@@ -2069,11 +2059,11 @@ module Impl<FullStateConfigSig Config> {
       additionalLocalFlowStepNodeCand1(node1, node2) and
       state1 = state2 and
       Stage2::revFlow(node1, pragma[only_bind_into](state1), false) and
-      Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), false)
+      Stage2::revFlow(node2, pragma[only_bind_into](state2), false)
       or
       additionalLocalStateStep(node1, state1, node2, state2) and
       Stage2::revFlow(node1, state1, false) and
-      Stage2::revFlowAlias(node2, state2, false)
+      Stage2::revFlow(node2, state2, false)
     }
 
     /**
@@ -2266,7 +2256,7 @@ module Impl<FullStateConfigSig Config> {
     ) {
       localFlowBigStep(node1, state1, node2, state2, preservesValue, ap.getType(), _) and
       PrevStage::revFlow(node1, pragma[only_bind_into](state1), _) and
-      PrevStage::revFlowAlias(node2, pragma[only_bind_into](state2), _) and
+      PrevStage::revFlow(node2, pragma[only_bind_into](state2), _) and
       exists(lcc)
     }
 
@@ -2277,7 +2267,7 @@ module Impl<FullStateConfigSig Config> {
       exists(FlowState state |
         flowOutOfCallNodeCand2(call, node1, kind, node2, allowsFieldFlow) and
         PrevStage::revFlow(node2, pragma[only_bind_into](state), _) and
-        PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _)
+        PrevStage::revFlow(node1, pragma[only_bind_into](state), _)
       )
     }
 
@@ -2288,7 +2278,7 @@ module Impl<FullStateConfigSig Config> {
       exists(FlowState state |
         flowIntoCallNodeCand2(call, node1, node2, allowsFieldFlow) and
         PrevStage::revFlow(node2, pragma[only_bind_into](state), _) and
-        PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _)
+        PrevStage::revFlow(node1, pragma[only_bind_into](state), _)
       )
     }
 
@@ -2590,7 +2580,7 @@ module Impl<FullStateConfigSig Config> {
     ) {
       localFlowBigStep(node1, state1, node2, state2, preservesValue, ap.getType(), lcc) and
       PrevStage::revFlow(node1, pragma[only_bind_into](state1), _) and
-      PrevStage::revFlowAlias(node2, pragma[only_bind_into](state2), _)
+      PrevStage::revFlow(node2, pragma[only_bind_into](state2), _)
     }
 
     pragma[nomagic]
@@ -2600,7 +2590,7 @@ module Impl<FullStateConfigSig Config> {
       exists(FlowState state |
         flowOutOfCallNodeCand2(call, node1, kind, node2, allowsFieldFlow) and
         PrevStage::revFlow(node2, pragma[only_bind_into](state), _) and
-        PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _)
+        PrevStage::revFlow(node1, pragma[only_bind_into](state), _)
       )
     }
 
@@ -2611,7 +2601,7 @@ module Impl<FullStateConfigSig Config> {
       exists(FlowState state |
         flowIntoCallNodeCand2(call, node1, node2, allowsFieldFlow) and
         PrevStage::revFlow(node2, pragma[only_bind_into](state), _) and
-        PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _)
+        PrevStage::revFlow(node1, pragma[only_bind_into](state), _)
       )
     }
 

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -1144,6 +1144,7 @@ module Impl<FullStateConfigSig Config> {
     module Stage<StageParam Param> implements StageSig {
       import Param
 
+      /* Begin: Stage logic. */
       pragma[nomagic]
       private predicate flowIntoCallApa(
         DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, ApApprox apa

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowImpl.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowImpl.qll
@@ -1144,20 +1144,13 @@ module Impl<FullStateConfigSig Config> {
     module Stage<StageParam Param> implements StageSig {
       import Param
 
-      /* Begin: Stage logic. */
-      // use an alias as a workaround for bad functionality-induced joins
-      pragma[nomagic]
-      private predicate revFlowApAlias(NodeEx node, ApApprox apa) {
-        PrevStage::revFlowAp(node, apa)
-      }
-
       pragma[nomagic]
       private predicate flowIntoCallApa(
         DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, ApApprox apa
       ) {
         flowIntoCall(call, arg, p, allowsFieldFlow) and
         PrevStage::revFlowAp(p, pragma[only_bind_into](apa)) and
-        revFlowApAlias(arg, pragma[only_bind_into](apa))
+        PrevStage::revFlowAp(arg, pragma[only_bind_into](apa))
       }
 
       pragma[nomagic]
@@ -1167,7 +1160,7 @@ module Impl<FullStateConfigSig Config> {
       ) {
         flowOutOfCall(call, ret, kind, out, allowsFieldFlow) and
         PrevStage::revFlowAp(out, pragma[only_bind_into](apa)) and
-        revFlowApAlias(ret, pragma[only_bind_into](apa))
+        PrevStage::revFlowAp(ret, pragma[only_bind_into](apa))
       }
 
       pragma[nomagic]

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowImpl.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowImpl.qll
@@ -1695,16 +1695,6 @@ module Impl<FullStateConfigSig Config> {
       pragma[nomagic]
       predicate revFlowAp(NodeEx node, Ap ap) { revFlow(node, _, _, _, ap) }
 
-      // use an alias as a workaround for bad functionality-induced joins
-      pragma[nomagic]
-      additional predicate revFlowAlias(NodeEx node) { revFlow(node, _, _, _, _) }
-
-      // use an alias as a workaround for bad functionality-induced joins
-      pragma[nomagic]
-      additional predicate revFlowAlias(NodeEx node, FlowState state, Ap ap) {
-        revFlow(node, state, ap)
-      }
-
       private predicate fwdConsCand(TypedContent tc, Ap ap) { storeStepFwd(_, ap, tc, _, _) }
 
       private predicate revConsCand(TypedContent tc, Ap ap) { storeStepCand(_, ap, tc, _, _) }
@@ -1978,7 +1968,7 @@ module Impl<FullStateConfigSig Config> {
   ) {
     flowOutOfCallNodeCand1(call, node1, kind, node2, allowsFieldFlow) and
     Stage2::revFlow(node2) and
-    Stage2::revFlowAlias(node1)
+    Stage2::revFlow(node1)
   }
 
   pragma[nomagic]
@@ -1987,7 +1977,7 @@ module Impl<FullStateConfigSig Config> {
   ) {
     flowIntoCallNodeCand1(call, node1, node2, allowsFieldFlow) and
     Stage2::revFlow(node2) and
-    Stage2::revFlowAlias(node1)
+    Stage2::revFlow(node1)
   }
 
   private module LocalFlowBigStep {
@@ -2069,11 +2059,11 @@ module Impl<FullStateConfigSig Config> {
       additionalLocalFlowStepNodeCand1(node1, node2) and
       state1 = state2 and
       Stage2::revFlow(node1, pragma[only_bind_into](state1), false) and
-      Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), false)
+      Stage2::revFlow(node2, pragma[only_bind_into](state2), false)
       or
       additionalLocalStateStep(node1, state1, node2, state2) and
       Stage2::revFlow(node1, state1, false) and
-      Stage2::revFlowAlias(node2, state2, false)
+      Stage2::revFlow(node2, state2, false)
     }
 
     /**
@@ -2266,7 +2256,7 @@ module Impl<FullStateConfigSig Config> {
     ) {
       localFlowBigStep(node1, state1, node2, state2, preservesValue, ap.getType(), _) and
       PrevStage::revFlow(node1, pragma[only_bind_into](state1), _) and
-      PrevStage::revFlowAlias(node2, pragma[only_bind_into](state2), _) and
+      PrevStage::revFlow(node2, pragma[only_bind_into](state2), _) and
       exists(lcc)
     }
 
@@ -2277,7 +2267,7 @@ module Impl<FullStateConfigSig Config> {
       exists(FlowState state |
         flowOutOfCallNodeCand2(call, node1, kind, node2, allowsFieldFlow) and
         PrevStage::revFlow(node2, pragma[only_bind_into](state), _) and
-        PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _)
+        PrevStage::revFlow(node1, pragma[only_bind_into](state), _)
       )
     }
 
@@ -2288,7 +2278,7 @@ module Impl<FullStateConfigSig Config> {
       exists(FlowState state |
         flowIntoCallNodeCand2(call, node1, node2, allowsFieldFlow) and
         PrevStage::revFlow(node2, pragma[only_bind_into](state), _) and
-        PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _)
+        PrevStage::revFlow(node1, pragma[only_bind_into](state), _)
       )
     }
 
@@ -2590,7 +2580,7 @@ module Impl<FullStateConfigSig Config> {
     ) {
       localFlowBigStep(node1, state1, node2, state2, preservesValue, ap.getType(), lcc) and
       PrevStage::revFlow(node1, pragma[only_bind_into](state1), _) and
-      PrevStage::revFlowAlias(node2, pragma[only_bind_into](state2), _)
+      PrevStage::revFlow(node2, pragma[only_bind_into](state2), _)
     }
 
     pragma[nomagic]
@@ -2600,7 +2590,7 @@ module Impl<FullStateConfigSig Config> {
       exists(FlowState state |
         flowOutOfCallNodeCand2(call, node1, kind, node2, allowsFieldFlow) and
         PrevStage::revFlow(node2, pragma[only_bind_into](state), _) and
-        PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _)
+        PrevStage::revFlow(node1, pragma[only_bind_into](state), _)
       )
     }
 
@@ -2611,7 +2601,7 @@ module Impl<FullStateConfigSig Config> {
       exists(FlowState state |
         flowIntoCallNodeCand2(call, node1, node2, allowsFieldFlow) and
         PrevStage::revFlow(node2, pragma[only_bind_into](state), _) and
-        PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _)
+        PrevStage::revFlow(node1, pragma[only_bind_into](state), _)
       )
     }
 

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowImpl.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowImpl.qll
@@ -1144,6 +1144,7 @@ module Impl<FullStateConfigSig Config> {
     module Stage<StageParam Param> implements StageSig {
       import Param
 
+      /* Begin: Stage logic. */
       pragma[nomagic]
       private predicate flowIntoCallApa(
         DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, ApApprox apa

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -1144,20 +1144,13 @@ module Impl<FullStateConfigSig Config> {
     module Stage<StageParam Param> implements StageSig {
       import Param
 
-      /* Begin: Stage logic. */
-      // use an alias as a workaround for bad functionality-induced joins
-      pragma[nomagic]
-      private predicate revFlowApAlias(NodeEx node, ApApprox apa) {
-        PrevStage::revFlowAp(node, apa)
-      }
-
       pragma[nomagic]
       private predicate flowIntoCallApa(
         DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, ApApprox apa
       ) {
         flowIntoCall(call, arg, p, allowsFieldFlow) and
         PrevStage::revFlowAp(p, pragma[only_bind_into](apa)) and
-        revFlowApAlias(arg, pragma[only_bind_into](apa))
+        PrevStage::revFlowAp(arg, pragma[only_bind_into](apa))
       }
 
       pragma[nomagic]
@@ -1167,7 +1160,7 @@ module Impl<FullStateConfigSig Config> {
       ) {
         flowOutOfCall(call, ret, kind, out, allowsFieldFlow) and
         PrevStage::revFlowAp(out, pragma[only_bind_into](apa)) and
-        revFlowApAlias(ret, pragma[only_bind_into](apa))
+        PrevStage::revFlowAp(ret, pragma[only_bind_into](apa))
       }
 
       pragma[nomagic]

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -1695,16 +1695,6 @@ module Impl<FullStateConfigSig Config> {
       pragma[nomagic]
       predicate revFlowAp(NodeEx node, Ap ap) { revFlow(node, _, _, _, ap) }
 
-      // use an alias as a workaround for bad functionality-induced joins
-      pragma[nomagic]
-      additional predicate revFlowAlias(NodeEx node) { revFlow(node, _, _, _, _) }
-
-      // use an alias as a workaround for bad functionality-induced joins
-      pragma[nomagic]
-      additional predicate revFlowAlias(NodeEx node, FlowState state, Ap ap) {
-        revFlow(node, state, ap)
-      }
-
       private predicate fwdConsCand(TypedContent tc, Ap ap) { storeStepFwd(_, ap, tc, _, _) }
 
       private predicate revConsCand(TypedContent tc, Ap ap) { storeStepCand(_, ap, tc, _, _) }
@@ -1978,7 +1968,7 @@ module Impl<FullStateConfigSig Config> {
   ) {
     flowOutOfCallNodeCand1(call, node1, kind, node2, allowsFieldFlow) and
     Stage2::revFlow(node2) and
-    Stage2::revFlowAlias(node1)
+    Stage2::revFlow(node1)
   }
 
   pragma[nomagic]
@@ -1987,7 +1977,7 @@ module Impl<FullStateConfigSig Config> {
   ) {
     flowIntoCallNodeCand1(call, node1, node2, allowsFieldFlow) and
     Stage2::revFlow(node2) and
-    Stage2::revFlowAlias(node1)
+    Stage2::revFlow(node1)
   }
 
   private module LocalFlowBigStep {
@@ -2069,11 +2059,11 @@ module Impl<FullStateConfigSig Config> {
       additionalLocalFlowStepNodeCand1(node1, node2) and
       state1 = state2 and
       Stage2::revFlow(node1, pragma[only_bind_into](state1), false) and
-      Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), false)
+      Stage2::revFlow(node2, pragma[only_bind_into](state2), false)
       or
       additionalLocalStateStep(node1, state1, node2, state2) and
       Stage2::revFlow(node1, state1, false) and
-      Stage2::revFlowAlias(node2, state2, false)
+      Stage2::revFlow(node2, state2, false)
     }
 
     /**
@@ -2266,7 +2256,7 @@ module Impl<FullStateConfigSig Config> {
     ) {
       localFlowBigStep(node1, state1, node2, state2, preservesValue, ap.getType(), _) and
       PrevStage::revFlow(node1, pragma[only_bind_into](state1), _) and
-      PrevStage::revFlowAlias(node2, pragma[only_bind_into](state2), _) and
+      PrevStage::revFlow(node2, pragma[only_bind_into](state2), _) and
       exists(lcc)
     }
 
@@ -2277,7 +2267,7 @@ module Impl<FullStateConfigSig Config> {
       exists(FlowState state |
         flowOutOfCallNodeCand2(call, node1, kind, node2, allowsFieldFlow) and
         PrevStage::revFlow(node2, pragma[only_bind_into](state), _) and
-        PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _)
+        PrevStage::revFlow(node1, pragma[only_bind_into](state), _)
       )
     }
 
@@ -2288,7 +2278,7 @@ module Impl<FullStateConfigSig Config> {
       exists(FlowState state |
         flowIntoCallNodeCand2(call, node1, node2, allowsFieldFlow) and
         PrevStage::revFlow(node2, pragma[only_bind_into](state), _) and
-        PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _)
+        PrevStage::revFlow(node1, pragma[only_bind_into](state), _)
       )
     }
 
@@ -2590,7 +2580,7 @@ module Impl<FullStateConfigSig Config> {
     ) {
       localFlowBigStep(node1, state1, node2, state2, preservesValue, ap.getType(), lcc) and
       PrevStage::revFlow(node1, pragma[only_bind_into](state1), _) and
-      PrevStage::revFlowAlias(node2, pragma[only_bind_into](state2), _)
+      PrevStage::revFlow(node2, pragma[only_bind_into](state2), _)
     }
 
     pragma[nomagic]
@@ -2600,7 +2590,7 @@ module Impl<FullStateConfigSig Config> {
       exists(FlowState state |
         flowOutOfCallNodeCand2(call, node1, kind, node2, allowsFieldFlow) and
         PrevStage::revFlow(node2, pragma[only_bind_into](state), _) and
-        PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _)
+        PrevStage::revFlow(node1, pragma[only_bind_into](state), _)
       )
     }
 
@@ -2611,7 +2601,7 @@ module Impl<FullStateConfigSig Config> {
       exists(FlowState state |
         flowIntoCallNodeCand2(call, node1, node2, allowsFieldFlow) and
         PrevStage::revFlow(node2, pragma[only_bind_into](state), _) and
-        PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _)
+        PrevStage::revFlow(node1, pragma[only_bind_into](state), _)
       )
     }
 

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -1144,6 +1144,7 @@ module Impl<FullStateConfigSig Config> {
     module Stage<StageParam Param> implements StageSig {
       import Param
 
+      /* Begin: Stage logic. */
       pragma[nomagic]
       private predicate flowIntoCallApa(
         DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, ApApprox apa

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl.qll
@@ -1144,20 +1144,13 @@ module Impl<FullStateConfigSig Config> {
     module Stage<StageParam Param> implements StageSig {
       import Param
 
-      /* Begin: Stage logic. */
-      // use an alias as a workaround for bad functionality-induced joins
-      pragma[nomagic]
-      private predicate revFlowApAlias(NodeEx node, ApApprox apa) {
-        PrevStage::revFlowAp(node, apa)
-      }
-
       pragma[nomagic]
       private predicate flowIntoCallApa(
         DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, ApApprox apa
       ) {
         flowIntoCall(call, arg, p, allowsFieldFlow) and
         PrevStage::revFlowAp(p, pragma[only_bind_into](apa)) and
-        revFlowApAlias(arg, pragma[only_bind_into](apa))
+        PrevStage::revFlowAp(arg, pragma[only_bind_into](apa))
       }
 
       pragma[nomagic]
@@ -1167,7 +1160,7 @@ module Impl<FullStateConfigSig Config> {
       ) {
         flowOutOfCall(call, ret, kind, out, allowsFieldFlow) and
         PrevStage::revFlowAp(out, pragma[only_bind_into](apa)) and
-        revFlowApAlias(ret, pragma[only_bind_into](apa))
+        PrevStage::revFlowAp(ret, pragma[only_bind_into](apa))
       }
 
       pragma[nomagic]

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl.qll
@@ -1695,16 +1695,6 @@ module Impl<FullStateConfigSig Config> {
       pragma[nomagic]
       predicate revFlowAp(NodeEx node, Ap ap) { revFlow(node, _, _, _, ap) }
 
-      // use an alias as a workaround for bad functionality-induced joins
-      pragma[nomagic]
-      additional predicate revFlowAlias(NodeEx node) { revFlow(node, _, _, _, _) }
-
-      // use an alias as a workaround for bad functionality-induced joins
-      pragma[nomagic]
-      additional predicate revFlowAlias(NodeEx node, FlowState state, Ap ap) {
-        revFlow(node, state, ap)
-      }
-
       private predicate fwdConsCand(TypedContent tc, Ap ap) { storeStepFwd(_, ap, tc, _, _) }
 
       private predicate revConsCand(TypedContent tc, Ap ap) { storeStepCand(_, ap, tc, _, _) }
@@ -1978,7 +1968,7 @@ module Impl<FullStateConfigSig Config> {
   ) {
     flowOutOfCallNodeCand1(call, node1, kind, node2, allowsFieldFlow) and
     Stage2::revFlow(node2) and
-    Stage2::revFlowAlias(node1)
+    Stage2::revFlow(node1)
   }
 
   pragma[nomagic]
@@ -1987,7 +1977,7 @@ module Impl<FullStateConfigSig Config> {
   ) {
     flowIntoCallNodeCand1(call, node1, node2, allowsFieldFlow) and
     Stage2::revFlow(node2) and
-    Stage2::revFlowAlias(node1)
+    Stage2::revFlow(node1)
   }
 
   private module LocalFlowBigStep {
@@ -2069,11 +2059,11 @@ module Impl<FullStateConfigSig Config> {
       additionalLocalFlowStepNodeCand1(node1, node2) and
       state1 = state2 and
       Stage2::revFlow(node1, pragma[only_bind_into](state1), false) and
-      Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), false)
+      Stage2::revFlow(node2, pragma[only_bind_into](state2), false)
       or
       additionalLocalStateStep(node1, state1, node2, state2) and
       Stage2::revFlow(node1, state1, false) and
-      Stage2::revFlowAlias(node2, state2, false)
+      Stage2::revFlow(node2, state2, false)
     }
 
     /**
@@ -2266,7 +2256,7 @@ module Impl<FullStateConfigSig Config> {
     ) {
       localFlowBigStep(node1, state1, node2, state2, preservesValue, ap.getType(), _) and
       PrevStage::revFlow(node1, pragma[only_bind_into](state1), _) and
-      PrevStage::revFlowAlias(node2, pragma[only_bind_into](state2), _) and
+      PrevStage::revFlow(node2, pragma[only_bind_into](state2), _) and
       exists(lcc)
     }
 
@@ -2277,7 +2267,7 @@ module Impl<FullStateConfigSig Config> {
       exists(FlowState state |
         flowOutOfCallNodeCand2(call, node1, kind, node2, allowsFieldFlow) and
         PrevStage::revFlow(node2, pragma[only_bind_into](state), _) and
-        PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _)
+        PrevStage::revFlow(node1, pragma[only_bind_into](state), _)
       )
     }
 
@@ -2288,7 +2278,7 @@ module Impl<FullStateConfigSig Config> {
       exists(FlowState state |
         flowIntoCallNodeCand2(call, node1, node2, allowsFieldFlow) and
         PrevStage::revFlow(node2, pragma[only_bind_into](state), _) and
-        PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _)
+        PrevStage::revFlow(node1, pragma[only_bind_into](state), _)
       )
     }
 
@@ -2590,7 +2580,7 @@ module Impl<FullStateConfigSig Config> {
     ) {
       localFlowBigStep(node1, state1, node2, state2, preservesValue, ap.getType(), lcc) and
       PrevStage::revFlow(node1, pragma[only_bind_into](state1), _) and
-      PrevStage::revFlowAlias(node2, pragma[only_bind_into](state2), _)
+      PrevStage::revFlow(node2, pragma[only_bind_into](state2), _)
     }
 
     pragma[nomagic]
@@ -2600,7 +2590,7 @@ module Impl<FullStateConfigSig Config> {
       exists(FlowState state |
         flowOutOfCallNodeCand2(call, node1, kind, node2, allowsFieldFlow) and
         PrevStage::revFlow(node2, pragma[only_bind_into](state), _) and
-        PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _)
+        PrevStage::revFlow(node1, pragma[only_bind_into](state), _)
       )
     }
 
@@ -2611,7 +2601,7 @@ module Impl<FullStateConfigSig Config> {
       exists(FlowState state |
         flowIntoCallNodeCand2(call, node1, node2, allowsFieldFlow) and
         PrevStage::revFlow(node2, pragma[only_bind_into](state), _) and
-        PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _)
+        PrevStage::revFlow(node1, pragma[only_bind_into](state), _)
       )
     }
 

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl.qll
@@ -1144,6 +1144,7 @@ module Impl<FullStateConfigSig Config> {
     module Stage<StageParam Param> implements StageSig {
       import Param
 
+      /* Begin: Stage logic. */
       pragma[nomagic]
       private predicate flowIntoCallApa(
         DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, ApApprox apa

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl.qll
@@ -1144,20 +1144,13 @@ module Impl<FullStateConfigSig Config> {
     module Stage<StageParam Param> implements StageSig {
       import Param
 
-      /* Begin: Stage logic. */
-      // use an alias as a workaround for bad functionality-induced joins
-      pragma[nomagic]
-      private predicate revFlowApAlias(NodeEx node, ApApprox apa) {
-        PrevStage::revFlowAp(node, apa)
-      }
-
       pragma[nomagic]
       private predicate flowIntoCallApa(
         DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, ApApprox apa
       ) {
         flowIntoCall(call, arg, p, allowsFieldFlow) and
         PrevStage::revFlowAp(p, pragma[only_bind_into](apa)) and
-        revFlowApAlias(arg, pragma[only_bind_into](apa))
+        PrevStage::revFlowAp(arg, pragma[only_bind_into](apa))
       }
 
       pragma[nomagic]
@@ -1167,7 +1160,7 @@ module Impl<FullStateConfigSig Config> {
       ) {
         flowOutOfCall(call, ret, kind, out, allowsFieldFlow) and
         PrevStage::revFlowAp(out, pragma[only_bind_into](apa)) and
-        revFlowApAlias(ret, pragma[only_bind_into](apa))
+        PrevStage::revFlowAp(ret, pragma[only_bind_into](apa))
       }
 
       pragma[nomagic]

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl.qll
@@ -1695,16 +1695,6 @@ module Impl<FullStateConfigSig Config> {
       pragma[nomagic]
       predicate revFlowAp(NodeEx node, Ap ap) { revFlow(node, _, _, _, ap) }
 
-      // use an alias as a workaround for bad functionality-induced joins
-      pragma[nomagic]
-      additional predicate revFlowAlias(NodeEx node) { revFlow(node, _, _, _, _) }
-
-      // use an alias as a workaround for bad functionality-induced joins
-      pragma[nomagic]
-      additional predicate revFlowAlias(NodeEx node, FlowState state, Ap ap) {
-        revFlow(node, state, ap)
-      }
-
       private predicate fwdConsCand(TypedContent tc, Ap ap) { storeStepFwd(_, ap, tc, _, _) }
 
       private predicate revConsCand(TypedContent tc, Ap ap) { storeStepCand(_, ap, tc, _, _) }
@@ -1978,7 +1968,7 @@ module Impl<FullStateConfigSig Config> {
   ) {
     flowOutOfCallNodeCand1(call, node1, kind, node2, allowsFieldFlow) and
     Stage2::revFlow(node2) and
-    Stage2::revFlowAlias(node1)
+    Stage2::revFlow(node1)
   }
 
   pragma[nomagic]
@@ -1987,7 +1977,7 @@ module Impl<FullStateConfigSig Config> {
   ) {
     flowIntoCallNodeCand1(call, node1, node2, allowsFieldFlow) and
     Stage2::revFlow(node2) and
-    Stage2::revFlowAlias(node1)
+    Stage2::revFlow(node1)
   }
 
   private module LocalFlowBigStep {
@@ -2069,11 +2059,11 @@ module Impl<FullStateConfigSig Config> {
       additionalLocalFlowStepNodeCand1(node1, node2) and
       state1 = state2 and
       Stage2::revFlow(node1, pragma[only_bind_into](state1), false) and
-      Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), false)
+      Stage2::revFlow(node2, pragma[only_bind_into](state2), false)
       or
       additionalLocalStateStep(node1, state1, node2, state2) and
       Stage2::revFlow(node1, state1, false) and
-      Stage2::revFlowAlias(node2, state2, false)
+      Stage2::revFlow(node2, state2, false)
     }
 
     /**
@@ -2266,7 +2256,7 @@ module Impl<FullStateConfigSig Config> {
     ) {
       localFlowBigStep(node1, state1, node2, state2, preservesValue, ap.getType(), _) and
       PrevStage::revFlow(node1, pragma[only_bind_into](state1), _) and
-      PrevStage::revFlowAlias(node2, pragma[only_bind_into](state2), _) and
+      PrevStage::revFlow(node2, pragma[only_bind_into](state2), _) and
       exists(lcc)
     }
 
@@ -2277,7 +2267,7 @@ module Impl<FullStateConfigSig Config> {
       exists(FlowState state |
         flowOutOfCallNodeCand2(call, node1, kind, node2, allowsFieldFlow) and
         PrevStage::revFlow(node2, pragma[only_bind_into](state), _) and
-        PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _)
+        PrevStage::revFlow(node1, pragma[only_bind_into](state), _)
       )
     }
 
@@ -2288,7 +2278,7 @@ module Impl<FullStateConfigSig Config> {
       exists(FlowState state |
         flowIntoCallNodeCand2(call, node1, node2, allowsFieldFlow) and
         PrevStage::revFlow(node2, pragma[only_bind_into](state), _) and
-        PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _)
+        PrevStage::revFlow(node1, pragma[only_bind_into](state), _)
       )
     }
 
@@ -2590,7 +2580,7 @@ module Impl<FullStateConfigSig Config> {
     ) {
       localFlowBigStep(node1, state1, node2, state2, preservesValue, ap.getType(), lcc) and
       PrevStage::revFlow(node1, pragma[only_bind_into](state1), _) and
-      PrevStage::revFlowAlias(node2, pragma[only_bind_into](state2), _)
+      PrevStage::revFlow(node2, pragma[only_bind_into](state2), _)
     }
 
     pragma[nomagic]
@@ -2600,7 +2590,7 @@ module Impl<FullStateConfigSig Config> {
       exists(FlowState state |
         flowOutOfCallNodeCand2(call, node1, kind, node2, allowsFieldFlow) and
         PrevStage::revFlow(node2, pragma[only_bind_into](state), _) and
-        PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _)
+        PrevStage::revFlow(node1, pragma[only_bind_into](state), _)
       )
     }
 
@@ -2611,7 +2601,7 @@ module Impl<FullStateConfigSig Config> {
       exists(FlowState state |
         flowIntoCallNodeCand2(call, node1, node2, allowsFieldFlow) and
         PrevStage::revFlow(node2, pragma[only_bind_into](state), _) and
-        PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _)
+        PrevStage::revFlow(node1, pragma[only_bind_into](state), _)
       )
     }
 

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl.qll
@@ -1144,6 +1144,7 @@ module Impl<FullStateConfigSig Config> {
     module Stage<StageParam Param> implements StageSig {
       import Param
 
+      /* Begin: Stage logic. */
       pragma[nomagic]
       private predicate flowIntoCallApa(
         DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, ApApprox apa

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImpl.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImpl.qll
@@ -1144,20 +1144,13 @@ module Impl<FullStateConfigSig Config> {
     module Stage<StageParam Param> implements StageSig {
       import Param
 
-      /* Begin: Stage logic. */
-      // use an alias as a workaround for bad functionality-induced joins
-      pragma[nomagic]
-      private predicate revFlowApAlias(NodeEx node, ApApprox apa) {
-        PrevStage::revFlowAp(node, apa)
-      }
-
       pragma[nomagic]
       private predicate flowIntoCallApa(
         DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, ApApprox apa
       ) {
         flowIntoCall(call, arg, p, allowsFieldFlow) and
         PrevStage::revFlowAp(p, pragma[only_bind_into](apa)) and
-        revFlowApAlias(arg, pragma[only_bind_into](apa))
+        PrevStage::revFlowAp(arg, pragma[only_bind_into](apa))
       }
 
       pragma[nomagic]
@@ -1167,7 +1160,7 @@ module Impl<FullStateConfigSig Config> {
       ) {
         flowOutOfCall(call, ret, kind, out, allowsFieldFlow) and
         PrevStage::revFlowAp(out, pragma[only_bind_into](apa)) and
-        revFlowApAlias(ret, pragma[only_bind_into](apa))
+        PrevStage::revFlowAp(ret, pragma[only_bind_into](apa))
       }
 
       pragma[nomagic]

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImpl.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImpl.qll
@@ -1695,16 +1695,6 @@ module Impl<FullStateConfigSig Config> {
       pragma[nomagic]
       predicate revFlowAp(NodeEx node, Ap ap) { revFlow(node, _, _, _, ap) }
 
-      // use an alias as a workaround for bad functionality-induced joins
-      pragma[nomagic]
-      additional predicate revFlowAlias(NodeEx node) { revFlow(node, _, _, _, _) }
-
-      // use an alias as a workaround for bad functionality-induced joins
-      pragma[nomagic]
-      additional predicate revFlowAlias(NodeEx node, FlowState state, Ap ap) {
-        revFlow(node, state, ap)
-      }
-
       private predicate fwdConsCand(TypedContent tc, Ap ap) { storeStepFwd(_, ap, tc, _, _) }
 
       private predicate revConsCand(TypedContent tc, Ap ap) { storeStepCand(_, ap, tc, _, _) }
@@ -1978,7 +1968,7 @@ module Impl<FullStateConfigSig Config> {
   ) {
     flowOutOfCallNodeCand1(call, node1, kind, node2, allowsFieldFlow) and
     Stage2::revFlow(node2) and
-    Stage2::revFlowAlias(node1)
+    Stage2::revFlow(node1)
   }
 
   pragma[nomagic]
@@ -1987,7 +1977,7 @@ module Impl<FullStateConfigSig Config> {
   ) {
     flowIntoCallNodeCand1(call, node1, node2, allowsFieldFlow) and
     Stage2::revFlow(node2) and
-    Stage2::revFlowAlias(node1)
+    Stage2::revFlow(node1)
   }
 
   private module LocalFlowBigStep {
@@ -2069,11 +2059,11 @@ module Impl<FullStateConfigSig Config> {
       additionalLocalFlowStepNodeCand1(node1, node2) and
       state1 = state2 and
       Stage2::revFlow(node1, pragma[only_bind_into](state1), false) and
-      Stage2::revFlowAlias(node2, pragma[only_bind_into](state2), false)
+      Stage2::revFlow(node2, pragma[only_bind_into](state2), false)
       or
       additionalLocalStateStep(node1, state1, node2, state2) and
       Stage2::revFlow(node1, state1, false) and
-      Stage2::revFlowAlias(node2, state2, false)
+      Stage2::revFlow(node2, state2, false)
     }
 
     /**
@@ -2266,7 +2256,7 @@ module Impl<FullStateConfigSig Config> {
     ) {
       localFlowBigStep(node1, state1, node2, state2, preservesValue, ap.getType(), _) and
       PrevStage::revFlow(node1, pragma[only_bind_into](state1), _) and
-      PrevStage::revFlowAlias(node2, pragma[only_bind_into](state2), _) and
+      PrevStage::revFlow(node2, pragma[only_bind_into](state2), _) and
       exists(lcc)
     }
 
@@ -2277,7 +2267,7 @@ module Impl<FullStateConfigSig Config> {
       exists(FlowState state |
         flowOutOfCallNodeCand2(call, node1, kind, node2, allowsFieldFlow) and
         PrevStage::revFlow(node2, pragma[only_bind_into](state), _) and
-        PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _)
+        PrevStage::revFlow(node1, pragma[only_bind_into](state), _)
       )
     }
 
@@ -2288,7 +2278,7 @@ module Impl<FullStateConfigSig Config> {
       exists(FlowState state |
         flowIntoCallNodeCand2(call, node1, node2, allowsFieldFlow) and
         PrevStage::revFlow(node2, pragma[only_bind_into](state), _) and
-        PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _)
+        PrevStage::revFlow(node1, pragma[only_bind_into](state), _)
       )
     }
 
@@ -2590,7 +2580,7 @@ module Impl<FullStateConfigSig Config> {
     ) {
       localFlowBigStep(node1, state1, node2, state2, preservesValue, ap.getType(), lcc) and
       PrevStage::revFlow(node1, pragma[only_bind_into](state1), _) and
-      PrevStage::revFlowAlias(node2, pragma[only_bind_into](state2), _)
+      PrevStage::revFlow(node2, pragma[only_bind_into](state2), _)
     }
 
     pragma[nomagic]
@@ -2600,7 +2590,7 @@ module Impl<FullStateConfigSig Config> {
       exists(FlowState state |
         flowOutOfCallNodeCand2(call, node1, kind, node2, allowsFieldFlow) and
         PrevStage::revFlow(node2, pragma[only_bind_into](state), _) and
-        PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _)
+        PrevStage::revFlow(node1, pragma[only_bind_into](state), _)
       )
     }
 
@@ -2611,7 +2601,7 @@ module Impl<FullStateConfigSig Config> {
       exists(FlowState state |
         flowIntoCallNodeCand2(call, node1, node2, allowsFieldFlow) and
         PrevStage::revFlow(node2, pragma[only_bind_into](state), _) and
-        PrevStage::revFlowAlias(node1, pragma[only_bind_into](state), _)
+        PrevStage::revFlow(node1, pragma[only_bind_into](state), _)
       )
     }
 

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImpl.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImpl.qll
@@ -1144,6 +1144,7 @@ module Impl<FullStateConfigSig Config> {
     module Stage<StageParam Param> implements StageSig {
       import Param
 
+      /* Begin: Stage logic. */
       pragma[nomagic]
       private predicate flowIntoCallApa(
         DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, ApApprox apa


### PR DESCRIPTION
This PR remove `revFlowAlias` and `revFlowApAlias` predicates from the dataflow library. The `revFlowAlias` and `revFlowApAlias` predicates were introduced to prevent the compiler from joining on constant node columns. With recent changes to the join ordering heuristic to avoid joins on constant columns, these alias predicates are no longer needed. 