### PR TITLE
Dataflow: Instantiate stage 1 access paths with proper unit type

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -445,11 +445,7 @@ module Impl<FullStateConfigSig Config> {
   }
 
   private module Stage1 implements StageSig {
-    class Ap extends int {
-      // workaround for bad functionality-induced joins (happens when using `Unit`)
-      pragma[nomagic]
-      Ap() { this in [0 .. 1] and this < 1 }
-    }
+    class Ap = Unit;
 
     private class Cc = boolean;
 

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -445,11 +445,7 @@ module Impl<FullStateConfigSig Config> {
   }
 
   private module Stage1 implements StageSig {
-    class Ap extends int {
-      // workaround for bad functionality-induced joins (happens when using `Unit`)
-      pragma[nomagic]
-      Ap() { this in [0 .. 1] and this < 1 }
-    }
+    class Ap = Unit;
 
     private class Cc = boolean;
 

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -445,11 +445,7 @@ module Impl<FullStateConfigSig Config> {
   }
 
   private module Stage1 implements StageSig {
-    class Ap extends int {
-      // workaround for bad functionality-induced joins (happens when using `Unit`)
-      pragma[nomagic]
-      Ap() { this in [0 .. 1] and this < 1 }
-    }
+    class Ap = Unit;
 
     private class Cc = boolean;
 

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowImpl.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowImpl.qll
@@ -445,11 +445,7 @@ module Impl<FullStateConfigSig Config> {
   }
 
   private module Stage1 implements StageSig {
-    class Ap extends int {
-      // workaround for bad functionality-induced joins (happens when using `Unit`)
-      pragma[nomagic]
-      Ap() { this in [0 .. 1] and this < 1 }
-    }
+    class Ap = Unit;
 
     private class Cc = boolean;
 

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -445,11 +445,7 @@ module Impl<FullStateConfigSig Config> {
   }
 
   private module Stage1 implements StageSig {
-    class Ap extends int {
-      // workaround for bad functionality-induced joins (happens when using `Unit`)
-      pragma[nomagic]
-      Ap() { this in [0 .. 1] and this < 1 }
-    }
+    class Ap = Unit;
 
     private class Cc = boolean;
 

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl.qll
@@ -445,11 +445,7 @@ module Impl<FullStateConfigSig Config> {
   }
 
   private module Stage1 implements StageSig {
-    class Ap extends int {
-      // workaround for bad functionality-induced joins (happens when using `Unit`)
-      pragma[nomagic]
-      Ap() { this in [0 .. 1] and this < 1 }
-    }
+    class Ap = Unit;
 
     private class Cc = boolean;
 

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl.qll
@@ -445,11 +445,7 @@ module Impl<FullStateConfigSig Config> {
   }
 
   private module Stage1 implements StageSig {
-    class Ap extends int {
-      // workaround for bad functionality-induced joins (happens when using `Unit`)
-      pragma[nomagic]
-      Ap() { this in [0 .. 1] and this < 1 }
-    }
+    class Ap = Unit;
 
     private class Cc = boolean;
 

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImpl.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImpl.qll
@@ -445,11 +445,7 @@ module Impl<FullStateConfigSig Config> {
   }
 
   private module Stage1 implements StageSig {
-    class Ap extends int {
-      // workaround for bad functionality-induced joins (happens when using `Unit`)
-      pragma[nomagic]
-      Ap() { this in [0 .. 1] and this < 1 }
-    }
+    class Ap = Unit;
 
     private class Cc = boolean;
 


### PR DESCRIPTION
This PR instantiates access paths for stage 1 of the dataflow library with a proper unit type. With recent changes to the join orderer to avoid joins on constant columns and DIL to RA term translation optimisations, the previous trick to prevent the optimiser from inferring that access paths were constant is no longer needed. 

The initial Java DCA experiment showed a significant regression for `palatable__lambda` but it didn't reproduce in subsequent reruns. 