### PR TITLE
C++: Implement `getAdditionalFlowIntoCallNodeTerm`

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -918,11 +918,12 @@ IRBlock getBasicBlock(Node node) {
  */
 pragma[nomagic]
 int getAdditionalFlowIntoCallNodeTerm(ArgumentNode arg, ParameterNode p) {
-  exists(ParameterNode switchee, ConditionOperand op, DataFlowCall call |
+  exists(ParameterNode switchee, SwitchInstruction switch, ConditionOperand op, DataFlowCall call |
     viableParamArg(call, p, arg) and
     viableParamArg(call, switchee, _) and
+    switch.getExpressionOperand() = op and
     valueNumber(switchee.asInstruction()).getAUse() = op and
-    result = countNumberOfBranchesUsingParameter(op, p)
+    result = countNumberOfBranchesUsingParameter(switch, p)
   )
 }
 
@@ -954,9 +955,8 @@ private EdgeKind caseOrDefaultEdge() {
 /**
  * Gets the number of switch branches that that read from (or write to) the parameter `p`.
  */
-int countNumberOfBranchesUsingParameter(ConditionOperand op, ParameterNode p) {
-  exists(SwitchInstruction switch, Ssa::SourceVariable sv |
-    switch.getExpressionOperand() = op and
+int countNumberOfBranchesUsingParameter(SwitchInstruction switch, ParameterNode p) {
+  exists(Ssa::SourceVariable sv |
     parameterNodeHasSourceVariable(p, sv) and
     // Count the number of cases that use the parameter. We do this by finding the phi node
     // that merges the uses/defs of the parameter. There might be multiple such phi nodes, so


### PR DESCRIPTION
This PR implements the predicate added to the shared dataflow library in https://github.com/github/codeql/pull/12236. The goal is to identify which `switch` statements read from/write a given parameter in many branches, which we've seen can cause a large number of access paths to be generated for certain projects.

I've started two DCA runs: One "normal" DCA run that compares the base branch with this PR (to inspect any performance or result changes), and one that just runs on this branch (since the problematic project will probably still OOM on the base branch, thus not even getting to running on this PR's branch).