### PR TITLE
JS: Handle forwardRef in React

### DIFF
--- a/javascript/ql/lib/semmle/javascript/frameworks/React.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/React.qll
@@ -773,7 +773,7 @@ private class ReactRouterLocationSource extends DOM::LocationSource::Range {
 private DataFlow::SourceNode higherOrderComponentBuilder() {
   // `memo(f)` returns a function that behaves as `f` but caches results
   // It is sometimes used to wrap an entire functional component.
-  result = react().getAPropertyRead("memo")
+  result = react().getAPropertyRead(["memo", "forwardRef"])
   or
   result = DataFlow::moduleMember("react-redux", "connect").getACall()
   or

--- a/javascript/ql/test/library-tests/frameworks/ReactJS/higherOrderComponent.jsx
+++ b/javascript/ql/test/library-tests/frameworks/ReactJS/higherOrderComponent.jsx
@@ -1,4 +1,4 @@
-import { memo } from 'react';
+import { memo, forwardRef } from 'react';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 import styled from 'styled-components';
@@ -25,4 +25,4 @@ const ConnectedComponent = compose(withConnect, unknownFunction)(StyledComponent
 
 const ConnectedComponent2 = withState('counter', 'setCounter', 0)(ConnectedComponent);
 
-export default hot(module)(memo(ConnectedComponent2));
+export default hot(module)(memo(forwardRef(ConnectedComponent2)));


### PR DESCRIPTION
Recognises React components wrapped in `React.forwardRef`.