### PR TITLE
C#: Source `dotnet-install.sh` script

### DIFF
--- a/csharp/autobuilder/Semmle.Autobuild.CSharp/DotNetRule.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.CSharp/DotNetRule.cs
@@ -192,7 +192,8 @@ namespace Semmle.Autobuild.CSharp
                             Argument("dotnet-install.sh");
 
                         var install = new CommandBuilder(builder.Actions).
-                            RunCommand("./dotnet-install.sh").
+                            RunCommand("source").
+                            Argument("./dotnet-install.sh").
                             Argument("--channel").
                             Argument("release").
                             Argument("--version").


### PR DESCRIPTION
The `dotnet-install.sh` script modifies the `PATH` environment variable to add the newly installed .NET Core SDK, but that addition isn't propagated to the rest of our build script and therefore means that the newly installed .NET Core SDK isn't available later on in the build process. This PR attempts to fix this.