### PR TITLE
C++: Inline `thisCouldAccessMember`

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/Declaration.qll
+++ b/cpp/ql/lib/semmle/code/cpp/Declaration.qll
@@ -664,7 +664,9 @@ private class DirectAccessHolder extends Element {
     //    bypasses `p`. Then that path must be public, or we are in case 2.
     exists(AccessSpecifier public | public.hasName("public") |
       exists(Class between, Class p |
-        between.accessOfBaseMember(memberClass, memberAccess).hasName("protected") and
+        between
+            .accessOfBaseMember(pragma[only_bind_into](memberClass), memberAccess)
+            .hasName("protected") and
         this.isFriendOfOrEqualTo(p) and
         (
           // This is case 1 from above. If `p` derives privately from `between`

--- a/cpp/ql/lib/semmle/code/cpp/Declaration.qll
+++ b/cpp/ql/lib/semmle/code/cpp/Declaration.qll
@@ -619,11 +619,10 @@ private class DirectAccessHolder extends Element {
   /**
    * Like `couldAccessMember` but only contains derivations in which either
    * (5.2), (5.3) or (5.4) must be invoked. In other words, the `this`
-   * parameter is not ignored. This restriction makes it feasible to fully
-   * enumerate this predicate even on large code bases. We check for 11.4 as
-   * part of (5.3), since this further limits the number of tuples produced by
-   * this predicate.
+   * parameter is not ignored. We check for 11.4 as part of (5.3), since
+   * this further limits the number of tuples produced by this predicate.
    */
+  pragma[inline]
   predicate thisCouldAccessMember(Class memberClass, AccessSpecifier memberAccess, Class derived) {
     // Only (5.4) is recursive, and chains of invocations of (5.4) can always
     // be collapsed to one invocation by the transitivity of 11.2/4.


### PR DESCRIPTION
Turns out this predicate can still be very large even with the restrictions mentioned in its QLDoc:

```
Evaluated relational algebra for predicate Declaration#4bfb53be::DirectAccessHolder::thisCouldAccessMember#3#dispred#ffff@8a38e2tm with tuple counts:
        918297       ~7%    {4} r1 = JOIN _Declaration#4bfb53be::DirectAccessHolder::isFriendOfOrEqualTo#1#dispred#ff_10#join_rhs__Class#bacd9__#shared WITH Declaration#4bfb53be::DirectAccessHolder::isFriendOfOrEqualTo#1#dispred#ff ON FIRST 2 OUTPUT Lhs.0, Lhs.2, Lhs.3, Lhs.1
                        
      7885675       ~0%    {4} r2 = JOIN Declaration#4bfb53be::everyoneCouldAccessMember#3#fff_201#join_rhs WITH Declaration#4bfb53be::DirectAccessHolder::thisCanAccessClassTrans#fff_102#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Rhs.2
                        
      8803972       ~2%    {4} r3 = r1 UNION r2
                        
      22634124       ~5%    {4} r4 = JOIN _Declaration#4bfb53be::DirectAccessHolder::isFriendOfOrEqualTo#1#dispred#ff_10#join_rhs__Class#bacd9__#shared#1 WITH boundedFastTC:Declaration#4bfb53be::isDirectPublicBaseOf#2#ff:_Class#bacd9b46::Class::accessOfBaseMember#2#dispred#ffff_30#join_rhs_Declaration#4bfb53be::DirectAc__#higher_order_body ON FIRST 1 OUTPUT Lhs.3, Lhs.1, Lhs.2, Rhs.1
                        
          137       ~0%    {4} r5 = JOIN _#Declaration#4bfb53be::AccessHolder::getEnclosingAccessHolder#0#dispredPlus#ff_Declaration#4bfb53be__#shared WITH Declaration#4bfb53be::DirectAccessHolder::thisCanAccessClassTrans#fff ON FIRST 2 OUTPUT Lhs.4, Lhs.2, Lhs.3, Rhs.2
                        
        684104       ~0%    {3} r6 = JOIN _Class#bacd9b46::Class::accessOfBaseMember#2#dispred#ffff_2013#join_rhs_specifiers_specifiers_10#joi__#shared WITH Class#bacd9b46::Class::accessOfBaseMember#2#dispred#ffff_1230#join_rhs ON FIRST 3 OUTPUT Lhs.3, Lhs.0, Rhs.3
      34164146       ~0%    {6} r7 = JOIN r6 WITH Class#bacd9b46::Class::accessOfBaseMember#2#dispred#ffff ON FIRST 1 OUTPUT Lhs.0, Rhs.1, Rhs.2, Rhs.3, Lhs.1, Lhs.2
                        
      2319699       ~0%    {3} r8 = JOIN _Class#bacd9b46::Class::accessOfBaseMember#2#dispred#ffff_2301#join_rhs_specifiers_10#join_rhs#shared WITH boundedFastTC:Class#bacd9b46::Class::getADerivedClass#0#dispred#ff_10#higher_order_body:_Class#bacd9b46::Class::accessOfBaseMember#2#dispred#ffff_230#join_rhs_specifiers_10#join_rhs#higher_order_body ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.0
                        
            1       ~0%    {1} r9 = CONSTANT(unique string)["public"]
            1       ~0%    {2} r10 = JOIN r9 WITH specifiers_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Rhs.1
        94454       ~0%    {3} r11 = JOIN r10 WITH Class#bacd9b46::Class::accessOfBaseMember#2#dispred#ffff_2301#join_rhs ON FIRST 2 OUTPUT Rhs.2, Rhs.3, Rhs.2
                        
      2414153       ~0%    {3} r12 = r8 UNION r11
      1461740       ~2%    {4} r13 = JOIN r12 WITH Class#bacd9b46::Class::accessOfBaseMember#2#dispred#ffff ON FIRST 2 OUTPUT Lhs.1, Rhs.2, Lhs.2, Lhs.0
      33573472       ~1%    {6} r14 = JOIN r13 WITH Class#bacd9b46::Class::accessOfBaseMember#2#dispred#ffff_0213#join_rhs ON FIRST 2 OUTPUT Lhs.0, Rhs.2, Lhs.1, Rhs.3, Lhs.3, Lhs.2
                        
      67737618      ~98%    {6} r15 = r7 UNION r14
      67737618    ~2136%    {6} r16 = JOIN r15 WITH Class#bacd9b46::Class::accessOfBaseMember#2#dispred#ffff ON FIRST 4 OUTPUT Lhs.3, "protected", Lhs.4, Lhs.5, Lhs.1, Lhs.2
      30495930    ~4492%    {4} r17 = JOIN r16 WITH specifiers ON FIRST 2 OUTPUT Lhs.2, Lhs.3, Lhs.4, Lhs.5
  11214033184  ~139652%    {4} r18 = JOIN r17 WITH Declaration#4bfb53be::DirectAccessHolder::isFriendOfOrEqualTo#1#dispred#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.2, Lhs.3, Lhs.1
                        
  11214033321  ~139652%    {4} r19 = r5 UNION r18
  11236667445   ~38383%    {4} r20 = r4 UNION r19
  11245471417   ~37531%    {4} r21 = r3 UNION r20
                            return r21
```

Before:
```
Most expensive predicates for completed query RuleOfTwo.ql:
        time  | evals |   max @ iter | predicate
        ------|-------|--------------|----------
        25m9s |       |              | Declaration#4bfb53be::DirectAccessHolder::thisCouldAccessMember#3#dispred#ffff@8a38e2tm
        17m1s |       |              | Declaration#4bfb53be::DirectAccessHolder::thisCouldAccessMember#3#dispred#fffb@0796c497
         3.5s |   130 | 116ms @ 3    | Declaration#4bfb53be::DirectAccessHolder::thisCanAccessClassTrans#fff@926a68j9
         3.3s |       |              | Declaration#4bfb53be::DirectAccessHolder::thisCouldAccessMember#3#dispred#fffb_1230#join_rhs@25e9ffj8
         1.7s |     3 |  1.7s @ 1    | Element#496c7fc2::ElementBase::toString#0#dispred#ff@fcd81c49
         1.3s |       |              | Declaration#4bfb53be::DirectAccessHolder::thisCouldAccessMember#3#dispred#fffb_0132#join_rhs@9c2065t1
         1.3s |       |              | Declaration#4bfb53be::DirectAccessHolder::thisCouldAccessMember#3#dispred#ffff_0132#join_rhs@672330eh
         1.1s |       |              | Declaration#4bfb53be::DirectAccessHolder::thisCanAccessClassTrans#fff_102#join_rhs@f7d5464o
        829ms |   336 |  85ms @ 6    | Enclosing#c50c5fbf::exprEnclosingElement#1#ff@e34d9wq1
        615ms |       |              | Expr#ef463c5d::Expr::getType#ff@e265e79q
```

After:
```
Most expensive predicates for completed query RuleOfTwo.ql:
        time  | evals |  max @ iter | predicate
        ------|-------|-------------|----------
        11.8s |       |             | _#Class#bacd9b46::Class::getADerivedClass#0#dispredPlus#ff_#Declaration#4bfb53be::AccessHolder::getE__#antijoin_rhs#1@fb0627h8
         4.8s |       |             | _#Class#bacd9b46::Class::getADerivedClass#0#dispredPlus#ff_#Declaration#4bfb53be::AccessHolder::getE__#antijoin_rhs#4@c43dbeia
         3.8s |       |             | _#Class#bacd9b46::Class::getADerivedClass#0#dispredPlus#ff_#Declaration#4bfb53be::AccessHolder::getE__#antijoin_rhs#3313e5963
         3.4s |   130 | 93ms @ 3    | Declaration#4bfb53be::DirectAccessHolder::thisCanAccessClassTrans#fff@a0289bfg
         1.5s |     3 | 1.5s @ 1    | Element#496c7fc2::ElementBase::toString#0#dispred#ff@fcd81c49
        806ms |       |             | Declaration#4bfb53be::DirectAccessHolder::thisCanAccessClassTrans#fff_021#join_rhs@cc1b76s7
        721ms |   336 | 61ms @ 5    | Enclosing#c50c5fbf::exprEnclosingElement#1#ff@e34d9wq1
        489ms |       |             | Expr#ef463c5d::Expr::getType#ff@e265e79q
        337ms |   130 | 62ms @ 5    | Class#bacd9b46::Class::accessOfBaseMemberMulti#ffff@0165b0dr
        329ms |       |             | Variable#7a968d4e::ParameterDeclarationEntry::getAnonymousParameterDescription#0#dispred#ff@0f12bdvq
        211ms |       |             | exprs_10#join_rhs@5481143i
```