### PR TITLE
DataFlow: Disable standard order in `Stage1::fwdFlow`

### DIFF
--- a/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -456,6 +456,7 @@ module Impl<FullStateConfigSig Config> {
      * The Boolean `cc` records whether the node is reached through an
      * argument in a call.
      */
+    pragma[assume_small_delta]
     private predicate fwdFlow(NodeEx node, Cc cc) {
       sourceNode(node, _) and
       if hasSourceCallCtx() then cc = true else cc = false

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -456,6 +456,7 @@ module Impl<FullStateConfigSig Config> {
      * The Boolean `cc` records whether the node is reached through an
      * argument in a call.
      */
+    pragma[assume_small_delta]
     private predicate fwdFlow(NodeEx node, Cc cc) {
       sourceNode(node, _) and
       if hasSourceCallCtx() then cc = true else cc = false

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -456,6 +456,7 @@ module Impl<FullStateConfigSig Config> {
      * The Boolean `cc` records whether the node is reached through an
      * argument in a call.
      */
+    pragma[assume_small_delta]
     private predicate fwdFlow(NodeEx node, Cc cc) {
       sourceNode(node, _) and
       if hasSourceCallCtx() then cc = true else cc = false

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -456,6 +456,7 @@ module Impl<FullStateConfigSig Config> {
      * The Boolean `cc` records whether the node is reached through an
      * argument in a call.
      */
+    pragma[assume_small_delta]
     private predicate fwdFlow(NodeEx node, Cc cc) {
       sourceNode(node, _) and
       if hasSourceCallCtx() then cc = true else cc = false

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowImpl.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowImpl.qll
@@ -456,6 +456,7 @@ module Impl<FullStateConfigSig Config> {
      * The Boolean `cc` records whether the node is reached through an
      * argument in a call.
      */
+    pragma[assume_small_delta]
     private predicate fwdFlow(NodeEx node, Cc cc) {
       sourceNode(node, _) and
       if hasSourceCallCtx() then cc = true else cc = false

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -456,6 +456,7 @@ module Impl<FullStateConfigSig Config> {
      * The Boolean `cc` records whether the node is reached through an
      * argument in a call.
      */
+    pragma[assume_small_delta]
     private predicate fwdFlow(NodeEx node, Cc cc) {
       sourceNode(node, _) and
       if hasSourceCallCtx() then cc = true else cc = false

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl.qll
@@ -456,6 +456,7 @@ module Impl<FullStateConfigSig Config> {
      * The Boolean `cc` records whether the node is reached through an
      * argument in a call.
      */
+    pragma[assume_small_delta]
     private predicate fwdFlow(NodeEx node, Cc cc) {
       sourceNode(node, _) and
       if hasSourceCallCtx() then cc = true else cc = false

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl.qll
@@ -456,6 +456,7 @@ module Impl<FullStateConfigSig Config> {
      * The Boolean `cc` records whether the node is reached through an
      * argument in a call.
      */
+    pragma[assume_small_delta]
     private predicate fwdFlow(NodeEx node, Cc cc) {
       sourceNode(node, _) and
       if hasSourceCallCtx() then cc = true else cc = false

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImpl.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImpl.qll
@@ -456,6 +456,7 @@ module Impl<FullStateConfigSig Config> {
      * The Boolean `cc` records whether the node is reached through an
      * argument in a call.
      */
+    pragma[assume_small_delta]
     private predicate fwdFlow(NodeEx node, Cc cc) {
       sourceNode(node, _) and
       if hasSourceCallCtx() then cc = true else cc = false


### PR DESCRIPTION
Discovered using Schack's magic regexp:

Notice the line `{2} r14 = SELECT DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::Stage1::fwdFlowConsCandSet#2#ff#prev ON In.0 = In.` in:

````
rec DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::Stage1::fwdFlow#2#ff(numbered_tuple node, bool cc) :- 
    SENTINEL DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::sourceNode#2#ff
    [[[ BASE CASE ]]]
    {2} r1 = SCAN DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::sourceNode#2#ff OUTPUT In.0 'node', false
    return r1

    [[[ SEMINAIVE VARIANT - STANDARD ORDER]]]
    {2} r2 = JOIN DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::Stage1::fwdFlowIsEntered#2#ff#prev_delta WITH DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::Stage1::fwdFlowOutFromArg#2#ff#prev ON FIRST 1 OUTPUT Rhs.1 'node', Lhs.1 'cc'

    {2} r3 = JOIN DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::Stage1::fwdFlowIsEntered#2#ff#prev WITH DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::Stage1::fwdFlowOutFromArg#2#ff#prev_delta ON FIRST 1 OUTPUT Rhs.1 'node', Lhs.1 'cc'

    {2} r4 = JOIN DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::Stage1::fwdFlow#2#ff#prev_delta WITH DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::localFlowStepEx#2#ff ON FIRST 1 OUTPUT Rhs.1 'node', Lhs.1 'cc'

    {2} r5 = r3 UNION r4
    {2} r6 = r2 UNION r5

    {2} r7 = JOIN DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::Stage1::fwdFlow#2#ff#prev_delta WITH DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::additionalLocalFlowStep#2#ff ON FIRST 1 OUTPUT Rhs.1 'node', Lhs.1 'cc'

    {2} r8 = JOIN DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::Stage1::fwdFlow#2#ff#prev_delta WITH DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::additionalJumpStep#2#ff ON FIRST 1 OUTPUT Rhs.1 'node', false

    {2} r9 = SELECT DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::Stage1::fwdFlowConsCandSet#2#ff#prev_delta ON In.0 = In.1
    {2} r10 = JOIN r9 WITH DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::Stage1::fwdFlowReadSet#3#fff#prev ON FIRST 1 OUTPUT Rhs.1 'node', Rhs.2 'cc'

    {2} r11 = r8 UNION r10
    {2} r12 = r7 UNION r11
    {2} r13 = r6 UNION r12

    {2} r14 = SELECT DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::Stage1::fwdFlowConsCandSet#2#ff#prev ON In.0 = In.1
    {2} r15 = JOIN r14 WITH DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::Stage1::fwdFlowReadSet#3#fff#prev_delta ON FIRST 1 OUTPUT Rhs.1 'node', Rhs.2 'cc'

    {2} r16 = JOIN DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::Stage1::fwdFlow#2#ff#prev_delta WITH DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::useFieldFlow#0# CARTESIAN PRODUCT OUTPUT Lhs.0, Lhs.1 'cc'
    {2} r17 = JOIN r16 WITH project#DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::storeEx#4#ffff ON FIRST 1 OUTPUT Rhs.1 'node', Lhs.1 'cc'

    {5} r18 = JOIN DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::Stage1::fwdFlow#2#ff#prev_delta WITH DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::additionalLocalStateStep#4#ffff ON FIRST 1 OUTPUT Lhs.0, Lhs.1 'cc', Rhs.1, Rhs.2 'node', Rhs.3
    {5} r19 = SELECT r18 ON In.2 = In.4
    {2} r20 = SCAN r19 OUTPUT In.3 'node', In.1 'cc'

    {2} r21 = r17 UNION r20
    {2} r22 = r15 UNION r21

    {5} r23 = JOIN DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::Stage1::fwdFlow#2#ff#prev_delta WITH DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::additionalJumpStateStep#4#ffff ON FIRST 1 OUTPUT false, Lhs.0, Rhs.1, Rhs.2 'node', Rhs.3
    {5} r24 = SELECT r23 ON In.2 = In.4
    {2} r25 = SCAN r24 OUTPUT In.3 'node', false

    {2} r26 = SCAN DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::Stage1::fwdFlowReturnPosition#2#ff#prev_delta OUTPUT In.1, In.0
    {2} r27 = JOIN r26 WITH const_false_false ON FIRST 1 OUTPUT Lhs.1, false
    {2} r28 = JOIN r27 WITH project#DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::viableReturnPosOutEx#3#fff ON FIRST 1 OUTPUT Rhs.1 'node', false

    {2} r29 = SCAN DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::Stage1::fwdFlow#2#ff#prev_delta OUTPUT In.1 'cc', In.0

    {2} r30 = const_true_true UNION _const_true_true#join_rhs

    {2} r31 = JOIN r29 WITH r30 ON FIRST 1 OUTPUT Lhs.1, true
    {2} r32 = JOIN r31 WITH project#DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::viableParamArgEx#3#fff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1 'node', true

    {2} r33 = r28 UNION r32
    {2} r34 = r25 UNION r33
    {2} r35 = r22 UNION r34
    {2} r36 = r13 UNION r35
    {2} r37 = r36 AND NOT DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::Stage1::fwdFlow#2#ff#prev(Lhs.0 'node', Lhs.1 'cc')
    return r37

    [[[ SEMINAIVE VARIANT - ORDER UP TO SIZE 500000]]]
    {2} r38 = JOIN DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::Stage1::fwdFlowOutFromArg#2#ff#prev_delta WITH DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::Stage1::fwdFlowIsEntered#2#ff#prev ON FIRST 1 OUTPUT Lhs.1 'node', Rhs.1 'cc'

    {2} r39 = r38 UNION r4

    {2} r40 = r2 UNION r39

    {2} r41 = JOIN DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::Stage1::fwdFlow#2#ff#prev_delta WITH DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::additionalJumpStep#2#ff ON FIRST 1 OUTPUT Rhs.1 'node', false

    {2} r42 = JOIN r9 WITH DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::Stage1::fwdFlowReadSet#3#fff#prev ON FIRST 1 OUTPUT Rhs.1 'node', Rhs.2 'cc'

    {2} r43 = r41 UNION r42

    {2} r44 = r7 UNION r43
    {2} r45 = r40 UNION r44

    {4} r46 = SCAN DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::Stage1::fwdFlowReadSet#3#fff#prev_delta OUTPUT In.0, In.0, In.1 'node', In.2 'cc'
    {2} r47 = JOIN r46 WITH DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::Stage1::fwdFlowConsCandSet#2#ff#prev ON FIRST 2 OUTPUT Lhs.2 'node', Lhs.3 'cc'

    {5} r48 = SELECT r18 ON In.2 = In.4
    {2} r49 = SCAN r48 OUTPUT In.3 'node', In.1 'cc'

    {2} r50 = r17 UNION r49
    {2} r51 = r47 UNION r50

    {5} r52 = JOIN DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::Stage1::fwdFlow#2#ff#prev_delta WITH DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::additionalJumpStateStep#4#ffff ON FIRST 1 OUTPUT false, Lhs.0, Rhs.1, Rhs.2 'node', Rhs.3
    {5} r53 = SELECT r52 ON In.2 = In.4
    {2} r54 = SCAN r53 OUTPUT In.3 'node', false

    {2} r55 = r28 UNION r32
    {2} r56 = r54 UNION r55
    {2} r57 = r51 UNION r56
    {2} r58 = r45 UNION r57
    {2} r59 = r58 AND NOT DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::Stage1::fwdFlow#2#ff#prev(Lhs.0 'node', Lhs.1 'cc')
    return r59
````

After:
```
rec DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::Stage1::fwdFlow#2#ff(numbered_tuple node, bool cc) :- 
    SENTINEL DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::sourceNode#2#ff
    [[[ BASE CASE ]]]
    {2} r1 = SCAN DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::sourceNode#2#ff OUTPUT In.0 'node', false
    return r1

    [[[ SEMINAIVE VARIANT - STANDARD ORDER]]]
    {2} r2 = JOIN DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::Stage1::fwdFlowIsEntered#2#ff#prev_delta WITH DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::Stage1::fwdFlowOutFromArg#2#ff#prev ON FIRST 1 OUTPUT Rhs.1 'node', Lhs.1 'cc'

    {2} r3 = JOIN DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::Stage1::fwdFlowOutFromArg#2#ff#prev_delta WITH DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::Stage1::fwdFlowIsEntered#2#ff#prev ON FIRST 1 OUTPUT Lhs.1 'node', Rhs.1 'cc'

    {2} r4 = JOIN DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::Stage1::fwdFlow#2#ff#prev_delta WITH DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::localFlowStepEx#2#ff ON FIRST 1 OUTPUT Rhs.1 'node', Lhs.1 'cc'

    {2} r5 = r3 UNION r4
    {2} r6 = r2 UNION r5

    {2} r7 = JOIN DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::Stage1::fwdFlow#2#ff#prev_delta WITH DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::additionalLocalFlowStep#2#ff ON FIRST 1 OUTPUT Rhs.1 'node', Lhs.1 'cc'

    {2} r8 = JOIN DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::Stage1::fwdFlow#2#ff#prev_delta WITH DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::additionalJumpStep#2#ff ON FIRST 1 OUTPUT Rhs.1 'node', false

    {2} r9 = SELECT DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::Stage1::fwdFlowConsCandSet#2#ff#prev_delta ON In.0 = In.1
    {2} r10 = JOIN r9 WITH DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::Stage1::fwdFlowReadSet#3#fff#prev ON FIRST 1 OUTPUT Rhs.1 'node', Rhs.2 'cc'

    {2} r11 = r8 UNION r10
    {2} r12 = r7 UNION r11
    {2} r13 = r6 UNION r12

    {4} r14 = SCAN DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::Stage1::fwdFlowReadSet#3#fff#prev_delta OUTPUT In.0, In.0, In.1 'node', In.2 'cc'
    {2} r15 = JOIN r14 WITH DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::Stage1::fwdFlowConsCandSet#2#ff#prev ON FIRST 2 OUTPUT Lhs.2 'node', Lhs.3 'cc'

    {2} r16 = JOIN DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::Stage1::fwdFlow#2#ff#prev_delta WITH DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::useFieldFlow#0# CARTESIAN PRODUCT OUTPUT Lhs.0, Lhs.1 'cc'
    {2} r17 = JOIN r16 WITH project#DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::storeEx#4#ffff ON FIRST 1 OUTPUT Rhs.1 'node', Lhs.1 'cc'

    {5} r18 = JOIN DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::Stage1::fwdFlow#2#ff#prev_delta WITH DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::additionalLocalStateStep#4#ffff ON FIRST 1 OUTPUT Lhs.0, Lhs.1 'cc', Rhs.1, Rhs.2 'node', Rhs.3
    {5} r19 = SELECT r18 ON In.2 = In.4
    {2} r20 = SCAN r19 OUTPUT In.3 'node', In.1 'cc'

    {2} r21 = r17 UNION r20
    {2} r22 = r15 UNION r21

    {5} r23 = JOIN DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::Stage1::fwdFlow#2#ff#prev_delta WITH DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::additionalJumpStateStep#4#ffff ON FIRST 1 OUTPUT false, Lhs.0, Rhs.1, Rhs.2 'node', Rhs.3
    {5} r24 = SELECT r23 ON In.2 = In.4
    {2} r25 = SCAN r24 OUTPUT In.3 'node', false

    {2} r26 = SCAN DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::Stage1::fwdFlowReturnPosition#2#ff#prev_delta OUTPUT In.1, In.0
    {2} r27 = JOIN r26 WITH const_false_false ON FIRST 1 OUTPUT Lhs.1, false
    {2} r28 = JOIN r27 WITH project#DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::viableReturnPosOutEx#3#fff ON FIRST 1 OUTPUT Rhs.1 'node', false

    {2} r29 = SCAN DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::Stage1::fwdFlow#2#ff#prev_delta OUTPUT In.1 'cc', In.0

    {2} r30 = const_true_true UNION _const_true_true#join_rhs

    {2} r31 = JOIN r29 WITH r30 ON FIRST 1 OUTPUT Lhs.1, true
    {2} r32 = JOIN r31 WITH project#DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::viableParamArgEx#3#fff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1 'node', true

    {2} r33 = r28 UNION r32
    {2} r34 = r25 UNION r33
    {2} r35 = r22 UNION r34
    {2} r36 = r13 UNION r35
    {2} r37 = r36 AND NOT DataFlowImpl#6ed98661::Impl#DataFlowImpl1#bece54ca::Config#::Stage1::fwdFlow#2#ff#prev(Lhs.0 'node', Lhs.1 'cc')
    return r37
```