### PR TITLE
The source name of a diagnostic should not change

### DIFF
--- a/go/extractor/diagnostics/diagnostics.go
+++ b/go/extractor/diagnostics/diagnostics.go
@@ -120,8 +120,8 @@ func emitDiagnostic(sourceid, sourcename, markdownMessage string, severity diagn
 func EmitPackageDifferentOSArchitecture(pkgPath string) {
 	emitDiagnostic(
 		"go/autobuilder/package-different-os-architecture",
-		"Package "+pkgPath+" is intended for a different OS or architecture",
-		"Make sure the `GOOS` and `GOARCH` [environment variables are correctly set](https://docs.github.com/en/actions/learn-github-actions/variables#defining-environment-variables-for-a-single-workflow). Alternatively, [change your OS and architecture](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#using-a-github-hosted-runner).",
+		"An imported package is intended for a different OS or architecture",
+		"`"+pkgPath+"` could not be imported. Make sure the `GOOS` and `GOARCH` [environment variables are correctly set](https://docs.github.com/en/actions/learn-github-actions/variables#defining-environment-variables-for-a-single-workflow). Alternatively, [change your OS and architecture](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#using-a-github-hosted-runner).",
 		severityWarning,
 		fullVisibility,
 		noLocation,
@@ -152,8 +152,8 @@ func EmitCannotFindPackages(pkgPaths []string) {
 
 	emitDiagnostic(
 		"go/autobuilder/package-not-found",
-		fmt.Sprintf("%d package%s could not be found", numPkgPaths, ending),
-		"The following packages could not be found.\n\n"+secondLine+"\n\nCheck that the paths are correct and make sure any private packages can be accessed. If any of the packages are present in the repository then you may need a [custom build command](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-the-codeql-workflow-for-compiled-languages).",
+		"Some packages could not be found",
+		fmt.Sprintf("%d package%s could not be found.\n\n%s.\n\nCheck that the paths are correct and make sure any private packages can be accessed. If any of the packages are present in the repository then you may need a [custom build command](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-the-codeql-workflow-for-compiled-languages).", numPkgPaths, ending, secondLine),
 		severityError,
 		fullVisibility,
 		noLocation,

--- a/go/ql/integration-tests/all-platforms/go/diagnostics/build-constraints-exclude-all-go-files/diagnostics.expected
+++ b/go/ql/integration-tests/all-platforms/go/diagnostics/build-constraints-exclude-all-go-files/diagnostics.expected
@@ -1,10 +1,10 @@
 {
-  "markdownMessage": "Make sure the `GOOS` and `GOARCH` [environment variables are correctly set](https://docs.github.com/en/actions/learn-github-actions/variables#defining-environment-variables-for-a-single-workflow). Alternatively, [change your OS and architecture](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#using-a-github-hosted-runner).",
+  "markdownMessage": "`syscall/js` could not be imported. Make sure the `GOOS` and `GOARCH` [environment variables are correctly set](https://docs.github.com/en/actions/learn-github-actions/variables#defining-environment-variables-for-a-single-workflow). Alternatively, [change your OS and architecture](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#using-a-github-hosted-runner).",
   "severity": "warning",
   "source": {
     "extractorName": "go",
     "id": "go/autobuilder/package-different-os-architecture",
-    "name": "Package syscall/js is intended for a different OS or architecture"
+    "name": "An imported package is intended for a different OS or architecture"
   },
   "visibility": {
     "cliSummaryTable": true,

--- a/go/ql/integration-tests/all-platforms/go/diagnostics/package-not-found-with-go-mod/diagnostics.expected
+++ b/go/ql/integration-tests/all-platforms/go/diagnostics/package-not-found-with-go-mod/diagnostics.expected
@@ -1,10 +1,10 @@
 {
-  "markdownMessage": "The following packages could not be found. Check that the paths are correct and make sure any private packages can be accessed. If any of the packages are present in the repository then you may need a [custom build command](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-the-codeql-workflow-for-compiled-languages).\n\n`github.com/nosuchorg/nosuchrepo000`, `github.com/nosuchorg/nosuchrepo001`, `github.com/nosuchorg/nosuchrepo002`, `github.com/nosuchorg/nosuchrepo003`, `github.com/nosuchorg/nosuchrepo004` and 105 more",
+  "markdownMessage": "110 packages could not be found.\n\n`github.com/nosuchorg/nosuchrepo000`, `github.com/nosuchorg/nosuchrepo001`, `github.com/nosuchorg/nosuchrepo002`, `github.com/nosuchorg/nosuchrepo003`, `github.com/nosuchorg/nosuchrepo004` and 105 more.\n\nCheck that the paths are correct and make sure any private packages can be accessed. If any of the packages are present in the repository then you may need a [custom build command](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-the-codeql-workflow-for-compiled-languages).",
   "severity": "error",
   "source": {
     "extractorName": "go",
     "id": "go/autobuilder/package-not-found",
-    "name": "110 packages could not be found"
+    "name": "Some packages could not be found"
   },
   "visibility": {
     "cliSummaryTable": true,

--- a/go/ql/integration-tests/all-platforms/go/diagnostics/package-not-found-without-go-mod/diagnostics.expected
+++ b/go/ql/integration-tests/all-platforms/go/diagnostics/package-not-found-without-go-mod/diagnostics.expected
@@ -1,10 +1,10 @@
 {
-  "markdownMessage": "The following packages could not be found. Check that the paths are correct and make sure any private packages can be accessed. If any of the packages are present in the repository then you may need a [custom build command](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-the-codeql-workflow-for-compiled-languages).\n\n`github.com/linode/linode-docs-theme`",
+  "markdownMessage": "1 package could not be found.\n\n`github.com/linode/linode-docs-theme`.\n\nCheck that the paths are correct and make sure any private packages can be accessed. If any of the packages are present in the repository then you may need a [custom build command](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-the-codeql-workflow-for-compiled-languages).",
   "severity": "error",
   "source": {
     "extractorName": "go",
     "id": "go/autobuilder/package-not-found",
-    "name": "1 package could not be found"
+    "name": "Some packages could not be found"
   },
   "visibility": {
     "cliSummaryTable": true,


### PR DESCRIPTION
Small update to source name and message for two diagnostics. This also updates the expected test output, which was erroneously not updated after a previous change in error message.