### PR TITLE
Python/Ruby: Use new parameter position for synthetic hash-splat instead

### DIFF
--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
@@ -181,11 +181,7 @@ private predicate synthDictSplatArgumentNodeStoreStep(
 private predicate dictSplatParameterNodeClearStep(ParameterNode n, DictionaryElementContent c) {
   exists(DataFlowCallable callable, ParameterPosition dictSplatPos, ParameterPosition keywordPos |
     dictSplatPos.isDictSplat() and
-    (
-      n.getParameter() = callable.(DataFlowFunction).getScope().getKwarg()
-      or
-      n = TSummaryParameterNode(callable.asLibraryCallable(), dictSplatPos)
-    ) and
+    n = callable.getParameter(dictSplatPos) and
     exists(callable.getParameter(keywordPos)) and
     keywordPos.isKeyword(c.getKey())
   )
@@ -234,28 +230,6 @@ class SynthDictSplatParameterNode extends ParameterNodeImpl, TSynthDictSplatPara
   override Location getLocation() { result = callable.getLocation() }
 
   override Parameter getParameter() { none() }
-}
-
-/**
- * Flow step from the synthetic `**kwargs` parameter to the real `**kwargs` parameter.
- * Due to restriction in dataflow library, we can only give one of them as result for
- * `DataFlowCallable.getParameter`, so this is a workaround to ensure there is flow to
- * _both_ of them.
- */
-private predicate dictSplatParameterNodeFlowStep(
-  ParameterNodeImpl nodeFrom, ParameterNodeImpl nodeTo
-) {
-  exists(DataFlowCallable callable |
-    nodeFrom = TSynthDictSplatParameterNode(callable) and
-    (
-      nodeTo.getParameter() = callable.(DataFlowFunction).getScope().getKwarg()
-      or
-      exists(ParameterPosition pos |
-        nodeTo = TSummaryParameterNode(callable.asLibraryCallable(), pos) and
-        pos.isDictSplat()
-      )
-    )
-  )
 }
 
 /**
@@ -403,8 +377,6 @@ predicate simpleLocalFlowStep(Node nodeFrom, Node nodeTo) {
   simpleLocalFlowStepForTypetracking(nodeFrom, nodeTo)
   or
   summaryFlowSteps(nodeFrom, nodeTo)
-  or
-  dictSplatParameterNodeFlowStep(nodeFrom, nodeTo)
 }
 
 /**

--- a/python/ql/test/experimental/dataflow/TestUtil/DataFlowConsistency.qll
+++ b/python/ql/test/experimental/dataflow/TestUtil/DataFlowConsistency.qll
@@ -20,15 +20,6 @@ private class MyConsistencyConfiguration extends ConsistencyConfiguration {
     n instanceof SynthDictSplatParameterNode
   }
 
-  override predicate uniqueParameterNodeAtPositionExclude(
-    DataFlowCallable c, ParameterPosition pos, Node p
-  ) {
-    // TODO: This can be removed once we solve the overlap of dictionary splat parameters
-    c.getParameter(pos) = p and
-    pos.isDictSplat() and
-    not exists(p.getLocation().getFile().getRelativePath())
-  }
-
   override predicate uniqueParameterNodePositionExclude(
     DataFlowCallable c, ParameterPosition pos, Node p
   ) {

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowDispatch.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowDispatch.qll
@@ -441,6 +441,13 @@ private module Cached {
       FlowSummaryImplSpecific::ParsePositions::isParsedKeywordArgumentPosition(_, name)
     } or
     THashSplatParameterPosition() or
+    // To get flow from a hash-splat argument to a keyword parameter, we add a read-step
+    // from a synthetic hash-splat parameter. We need this separate synthetic ParameterNode,
+    // since we clear content of the normal hash-splat parameter for the names that
+    // correspond to normal keyword parameters. Since we cannot re-use the same parameter
+    // position for multiple parameter nodes in the same callable, we introduce this
+    // synthetic parameter position.
+    TSynthHashSplatParameterPosition() or
     TSplatAllParameterPosition() or
     TAnyParameterPosition() or
     TAnyKeywordParameterPosition()
@@ -1238,6 +1245,8 @@ class ParameterPosition extends TParameterPosition {
   /** Holds if this position represents a hash-splat parameter. */
   predicate isHashSplat() { this = THashSplatParameterPosition() }
 
+  predicate isSynthHashSplat() { this = TSynthHashSplatParameterPosition() }
+
   predicate isSplatAll() { this = TSplatAllParameterPosition() }
 
   /**
@@ -1262,6 +1271,8 @@ class ParameterPosition extends TParameterPosition {
     exists(string name | this.isKeyword(name) and result = "keyword " + name)
     or
     this.isHashSplat() and result = "**"
+    or
+    this.isSynthHashSplat() and result = "synthetic **"
     or
     this.isSplatAll() and result = "*"
     or
@@ -1344,6 +1355,8 @@ predicate parameterMatch(ParameterPosition ppos, ArgumentPosition apos) {
   exists(string name | ppos.isKeyword(name) and apos.isKeyword(name))
   or
   ppos.isHashSplat() and apos.isHashSplat()
+  or
+  ppos.isSynthHashSplat() and apos.isHashSplat()
   or
   ppos.isSplatAll() and apos.isSplatAll()
   or


### PR DESCRIPTION
We wanted to ensure that a callable did not have multiple parameters with same parameter position. Originally we fixed this in both Ruby and Python by introducing flow between the synthetic and the normal hash-splat/**kwargs parameters. 

However, since that made things more complex to understand, in this PR I revert those fixes, and instead solve it by introducing a new parameter position (like already discussed).

_(draft PR to check that tests pass before requesting review)_