### PR TITLE
Python: Use _one_ parameter position for normal parameters

### DIFF
--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
@@ -187,7 +187,11 @@ private predicate dictSplatParameterNodeClearStep(ParameterNode n, DictionaryEle
       n = TSummaryParameterNode(callable.asLibraryCallable(), dictSplatPos)
     ) and
     exists(callable.getParameter(keywordPos)) and
-    keywordPos.isKeyword(c.getKey())
+    (
+      keywordPos.isNormal(_, c.getKey())
+      or
+      keywordPos.isKeywordOnly(c.getKey())
+    )
   )
 }
 
@@ -267,7 +271,12 @@ predicate synthDictSplatParameterNodeReadStep(
   exists(DataFlowCallable callable, ParameterPosition ppos |
     nodeFrom = TSynthDictSplatParameterNode(callable) and
     nodeTo = callable.getParameter(ppos) and
-    ppos.isKeyword(c.getKey())
+    (
+      ppos.isNormal(_, c.getKey())
+      or
+      ppos.isKeywordOnly(c.getKey())
+
+    )
   )
 }
 

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowPublic.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowPublic.qll
@@ -121,7 +121,7 @@ newtype TNode =
   TSynthDictSplatArgumentNode(CallNode call) { exists(call.getArgByName(_)) } or
   /** A synthetic node to allow flow to keyword parameters from a `**kwargs` argument. */
   TSynthDictSplatParameterNode(DataFlowCallable callable) {
-    exists(ParameterPosition ppos | ppos.isKeyword(_) | exists(callable.getParameter(ppos)))
+    exists(ParameterPosition ppos | ppos.isNormal(_, _) or ppos.isKeywordOnly(_) | exists(callable.getParameter(ppos)))
   }
 
 /** Helper for `Node::getEnclosingCallable`. */

--- a/python/ql/lib/semmle/python/dataflow/new/internal/FlowSummaryImplSpecific.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/FlowSummaryImplSpecific.qll
@@ -118,12 +118,20 @@ string getParameterPosition(ParameterPosition pos) {
   pos.isSelf() and result = "self"
   or
   exists(int i |
-    pos.isPositional(i) and
+    (
+      pos.isNormal(i, _)
+      or
+      pos.isPositionalOnly(i)
+    ) and
     result = i.toString()
   )
   or
   exists(string name |
-    pos.isKeyword(name) and
+    (
+      pos.isNormal(_, name)
+      or
+      pos.isKeywordOnly(name)
+    ) and
     result = name + ":"
   )
 }
@@ -262,12 +270,12 @@ ArgumentPosition parseParamBody(string s) {
 ParameterPosition parseArgBody(string s) {
   exists(int i |
     ParsePositions::isParsedPositionalArgumentPosition(s, i) and
-    result.isPositional(i)
+    result.isPositionalOnly(i)
   )
   or
   exists(string name |
     ParsePositions::isParsedKeywordArgumentPosition(s, name) and
-    result.isKeyword(name)
+    result.isKeywordOnly(name)
   )
   or
   s = "self" and

--- a/python/ql/test/experimental/dataflow/TestUtil/DataFlowConsistency.qll
+++ b/python/ql/test/experimental/dataflow/TestUtil/DataFlowConsistency.qll
@@ -28,20 +28,4 @@ private class MyConsistencyConfiguration extends ConsistencyConfiguration {
     pos.isDictSplat() and
     not exists(p.getLocation().getFile().getRelativePath())
   }
-
-  override predicate uniqueParameterNodePositionExclude(
-    DataFlowCallable c, ParameterPosition pos, Node p
-  ) {
-    // For normal parameters that can both be passed as positional arguments or keyword
-    // arguments, we currently have parameter positions for both cases..
-    //
-    // TODO: Figure out how bad breaking this consistency check is
-    exists(Function func, Parameter param |
-      c.getScope() = func and
-      p = parameterNode(param) and
-      c.getParameter(pos) = p and
-      param = func.getArg(_) and
-      param = func.getArgByName(_)
-    )
-  }
 }


### PR DESCRIPTION
That can be used with both positional and keyword arguments. Before we provided BOTH a positional and keyword parameter position, which broke some assumptions in the dataflow library.

_(Created as draft to see effect before requesting review)_