### PR TITLE
C++: Restrict sinks in `cpp/cleartext-storage-database`

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-313/CleartextSqliteDatabase.ql
+++ b/cpp/ql/src/Security/CWE/CWE-313/CleartextSqliteDatabase.ql
@@ -102,12 +102,11 @@ predicate isSinkImpl(DataFlow::Node sink, SqliteFunctionCall c, Type t) {
  * A taint flow configuration for flow from a sensitive expression to a `SqliteFunctionCall` sink.
  */
 module FromSensitiveConfiguration implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { isSourceImpl(source, _) }
-
-  predicate isSink(DataFlow::Node sink) {
-    isSinkImpl(sink, _, _) and
-    not sqlite_encryption_used()
+  predicate isSource(DataFlow::Node source) {
+    isSourceImpl(source, _) and not sqlite_encryption_used()
   }
+
+  predicate isSink(DataFlow::Node sink) { isSinkImpl(sink, _, _) }
 
   predicate isBarrier(DataFlow::Node node) {
     node.asExpr().getUnspecifiedType() instanceof IntegralType

--- a/cpp/ql/src/Security/CWE/CWE-313/CleartextSqliteDatabase.ql
+++ b/cpp/ql/src/Security/CWE/CWE-313/CleartextSqliteDatabase.ql
@@ -34,7 +34,7 @@ class SqliteFunctionExecCall extends SqliteFunctionCall {
 
 class SqliteFunctionAppendfCall extends SqliteFunctionCall {
   SqliteFunctionAppendfCall() {
-    this.getTarget().getName().matches(["sqlite3_str_appendf", "sqlite3_str_vappendf"])
+    this.getTarget().hasName(["sqlite3_str_appendf", "sqlite3_str_vappendf"])
   }
 
   override Expr getASource() { result = this.getArgument(any(int n | n > 0)) }
@@ -42,7 +42,7 @@ class SqliteFunctionAppendfCall extends SqliteFunctionCall {
 
 class SqliteFunctionAppendNonCharCall extends SqliteFunctionCall {
   SqliteFunctionAppendNonCharCall() {
-    this.getTarget().getName().matches(["sqlite3_str_append", "sqlite3_str_appendall"])
+    this.getTarget().hasName(["sqlite3_str_append", "sqlite3_str_appendall"])
   }
 
   override Expr getASource() { result = this.getArgument(1) }
@@ -57,8 +57,7 @@ class SqliteFunctionAppendCharCall extends SqliteFunctionCall {
 class SqliteFunctionBindCall extends SqliteFunctionCall {
   SqliteFunctionBindCall() {
     this.getTarget()
-        .getName()
-        .matches([
+        .hasName([
             "sqlite3_bind_blob", "sqlite3_bind_blob64", "sqlite3_bind_text", "sqlite3_bind_text16",
             "sqlite3_bind_text64", "sqlite3_bind_value", "sqlite3_bind_pointer"
           ])

--- a/cpp/ql/src/Security/CWE/CWE-313/CleartextSqliteDatabase.ql
+++ b/cpp/ql/src/Security/CWE/CWE-313/CleartextSqliteDatabase.ql
@@ -112,6 +112,10 @@ module FromSensitiveConfiguration implements DataFlow::ConfigSig {
     node.asExpr().getUnspecifiedType() instanceof IntegralType
   }
 
+  predicate isBarrierIn(DataFlow::Node node) { isSource(node) }
+
+  predicate isBarrierOut(DataFlow::Node node) { isSink(node) }
+
   predicate allowImplicitRead(DataFlow::Node node, DataFlow::ContentSet content) {
     // flow out from fields at the sink (only).
     // constrain `content` to a field inside the node.


### PR DESCRIPTION
This PR reduces the set of sinks considered in the `cpp/cleartext-storage-database` query. Previously we used "all functions prefixed with `sqlite`", and after this PR it's confined to a specific set of functions. This fixes a performance issue I was seeing on a database that had a particularly bad naming convention of prefixing their own functions with `sqlite` 😂.

I've added two additional commits that each should provide a small performance boost.