### PR TITLE
Dataflow: Add MergePathGraph module.

### DIFF
--- a/cpp/ql/lib/change-notes/2023-03-13-mergepathgraph.md
+++ b/cpp/ql/lib/change-notes/2023-03-13-mergepathgraph.md
@@ -1,0 +1,4 @@
+---
+category: feature
+---
+* Added support for merging two `PathGraph`s via disjoint union to allow results from multiple data flow computations in a single `path-problem` query.

--- a/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/DataFlow.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/DataFlow.qll
@@ -243,3 +243,85 @@ module MakeWithState<StateConfigSig Config> implements DataFlowSig {
 
   import Impl<C>
 }
+
+signature class PathNodeSig {
+  /** Gets a textual representation of this element. */
+  string toString();
+
+  /**
+   * Holds if this element is at the specified location.
+   * The location spans column `startcolumn` of line `startline` to
+   * column `endcolumn` of line `endline` in file `filepath`.
+   * For more information, see
+   * [Locations](https://codeql.github.com/docs/writing-codeql-queries/providing-locations-in-codeql-queries/).
+   */
+  predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  );
+
+  /** Gets the underlying `Node`. */
+  Node getNode();
+}
+
+signature module PathGraphSig<PathNodeSig PathNode> {
+  /** Holds if `(a,b)` is an edge in the graph of data flow path explanations. */
+  predicate edges(PathNode a, PathNode b);
+
+  /** Holds if `n` is a node in the graph of data flow path explanations. */
+  predicate nodes(PathNode n, string key, string val);
+
+  /**
+   * Holds if `(arg, par, ret, out)` forms a subpath-tuple, that is, flow through
+   * a subpath between `par` and `ret` with the connecting edges `arg -> par` and
+   * `ret -> out` is summarized as the edge `arg -> out`.
+   */
+  predicate subpaths(PathNode arg, PathNode par, PathNode ret, PathNode out);
+}
+
+module MergePathGraph<
+PathNodeSig PathNode1, PathNodeSig PathNode2, PathGraphSig<PathNode1> Graph1,
+PathGraphSig<PathNode2> Graph2> {
+  private newtype TPathNode =
+    TPathNode1(PathNode1 p) or
+    TPathNode2(PathNode2 p)
+
+  class PathNode extends TPathNode {
+    PathNode1 asPathNode1() { this = TPathNode1(result) }
+
+    PathNode2 asPathNode2() { this = TPathNode2(result) }
+
+    string toString() {
+      result = this.asPathNode1().toString() or
+      result = this.asPathNode2().toString()
+    }
+
+    predicate hasLocationInfo(
+      string filepath, int startline, int startcolumn, int endline, int endcolumn
+    ) {
+      this.asPathNode1().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn) or
+      this.asPathNode2().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    }
+
+    Node getNode() {
+      result = this.asPathNode1().getNode() or
+      result = this.asPathNode2().getNode()
+    }
+  }
+
+  module PathGraph implements PathGraphSig<PathNode> {
+    query predicate edges(PathNode a, PathNode b) {
+      Graph1::edges(a.asPathNode1(), b.asPathNode1()) or
+      Graph2::edges(a.asPathNode2(), b.asPathNode2())
+    }
+
+    query predicate nodes(PathNode n, string key, string val) {
+      Graph1::nodes(n.asPathNode1(), key, val) or
+      Graph2::nodes(n.asPathNode2(), key, val)
+    }
+
+    query predicate subpaths(PathNode arg, PathNode par, PathNode ret, PathNode out) {
+      Graph1::subpaths(arg.asPathNode1(), par.asPathNode1(), ret.asPathNode1(), out.asPathNode1()) or
+      Graph2::subpaths(arg.asPathNode2(), par.asPathNode2(), ret.asPathNode2(), out.asPathNode2())
+    }
+  }
+}

--- a/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/DataFlow.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/DataFlow.qll
@@ -282,8 +282,9 @@ signature module PathGraphSig<PathNodeSig PathNode> {
  * Constructs a `PathGraph` from two `PathGraph`s by disjoint union.
  */
 module MergePathGraph<
-PathNodeSig PathNode1, PathNodeSig PathNode2, PathGraphSig<PathNode1> Graph1,
-PathGraphSig<PathNode2> Graph2> {
+  PathNodeSig PathNode1, PathNodeSig PathNode2, PathGraphSig<PathNode1> Graph1,
+  PathGraphSig<PathNode2> Graph2>
+{
   private newtype TPathNode =
     TPathNode1(PathNode1 p) or
     TPathNode2(PathNode2 p)

--- a/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -3157,7 +3157,7 @@ module Impl<FullStateConfigSig Config> {
   /**
    * Provides the query predicates needed to include a graph in a path-problem query.
    */
-  module PathGraph {
+  module PathGraph implements PathGraphSig<PathNode> {
     /** Holds if `(a,b)` is an edge in the graph of data flow path explanations. */
     query predicate edges(PathNode a, PathNode b) { a.getASuccessor() = b }
 

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlow.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlow.qll
@@ -243,3 +243,85 @@ module MakeWithState<StateConfigSig Config> implements DataFlowSig {
 
   import Impl<C>
 }
+
+signature class PathNodeSig {
+  /** Gets a textual representation of this element. */
+  string toString();
+
+  /**
+   * Holds if this element is at the specified location.
+   * The location spans column `startcolumn` of line `startline` to
+   * column `endcolumn` of line `endline` in file `filepath`.
+   * For more information, see
+   * [Locations](https://codeql.github.com/docs/writing-codeql-queries/providing-locations-in-codeql-queries/).
+   */
+  predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  );
+
+  /** Gets the underlying `Node`. */
+  Node getNode();
+}
+
+signature module PathGraphSig<PathNodeSig PathNode> {
+  /** Holds if `(a,b)` is an edge in the graph of data flow path explanations. */
+  predicate edges(PathNode a, PathNode b);
+
+  /** Holds if `n` is a node in the graph of data flow path explanations. */
+  predicate nodes(PathNode n, string key, string val);
+
+  /**
+   * Holds if `(arg, par, ret, out)` forms a subpath-tuple, that is, flow through
+   * a subpath between `par` and `ret` with the connecting edges `arg -> par` and
+   * `ret -> out` is summarized as the edge `arg -> out`.
+   */
+  predicate subpaths(PathNode arg, PathNode par, PathNode ret, PathNode out);
+}
+
+module MergePathGraph<
+PathNodeSig PathNode1, PathNodeSig PathNode2, PathGraphSig<PathNode1> Graph1,
+PathGraphSig<PathNode2> Graph2> {
+  private newtype TPathNode =
+    TPathNode1(PathNode1 p) or
+    TPathNode2(PathNode2 p)
+
+  class PathNode extends TPathNode {
+    PathNode1 asPathNode1() { this = TPathNode1(result) }
+
+    PathNode2 asPathNode2() { this = TPathNode2(result) }
+
+    string toString() {
+      result = this.asPathNode1().toString() or
+      result = this.asPathNode2().toString()
+    }
+
+    predicate hasLocationInfo(
+      string filepath, int startline, int startcolumn, int endline, int endcolumn
+    ) {
+      this.asPathNode1().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn) or
+      this.asPathNode2().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    }
+
+    Node getNode() {
+      result = this.asPathNode1().getNode() or
+      result = this.asPathNode2().getNode()
+    }
+  }
+
+  module PathGraph implements PathGraphSig<PathNode> {
+    query predicate edges(PathNode a, PathNode b) {
+      Graph1::edges(a.asPathNode1(), b.asPathNode1()) or
+      Graph2::edges(a.asPathNode2(), b.asPathNode2())
+    }
+
+    query predicate nodes(PathNode n, string key, string val) {
+      Graph1::nodes(n.asPathNode1(), key, val) or
+      Graph2::nodes(n.asPathNode2(), key, val)
+    }
+
+    query predicate subpaths(PathNode arg, PathNode par, PathNode ret, PathNode out) {
+      Graph1::subpaths(arg.asPathNode1(), par.asPathNode1(), ret.asPathNode1(), out.asPathNode1()) or
+      Graph2::subpaths(arg.asPathNode2(), par.asPathNode2(), ret.asPathNode2(), out.asPathNode2())
+    }
+  }
+}

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlow.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlow.qll
@@ -282,8 +282,9 @@ signature module PathGraphSig<PathNodeSig PathNode> {
  * Constructs a `PathGraph` from two `PathGraph`s by disjoint union.
  */
 module MergePathGraph<
-PathNodeSig PathNode1, PathNodeSig PathNode2, PathGraphSig<PathNode1> Graph1,
-PathGraphSig<PathNode2> Graph2> {
+  PathNodeSig PathNode1, PathNodeSig PathNode2, PathGraphSig<PathNode1> Graph1,
+  PathGraphSig<PathNode2> Graph2>
+{
   private newtype TPathNode =
     TPathNode1(PathNode1 p) or
     TPathNode2(PathNode2 p)

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -3157,7 +3157,7 @@ module Impl<FullStateConfigSig Config> {
   /**
    * Provides the query predicates needed to include a graph in a path-problem query.
    */
-  module PathGraph {
+  module PathGraph implements PathGraphSig<PathNode> {
     /** Holds if `(a,b)` is an edge in the graph of data flow path explanations. */
     query predicate edges(PathNode a, PathNode b) { a.getASuccessor() = b }
 

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlow.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlow.qll
@@ -243,3 +243,85 @@ module MakeWithState<StateConfigSig Config> implements DataFlowSig {
 
   import Impl<C>
 }
+
+signature class PathNodeSig {
+  /** Gets a textual representation of this element. */
+  string toString();
+
+  /**
+   * Holds if this element is at the specified location.
+   * The location spans column `startcolumn` of line `startline` to
+   * column `endcolumn` of line `endline` in file `filepath`.
+   * For more information, see
+   * [Locations](https://codeql.github.com/docs/writing-codeql-queries/providing-locations-in-codeql-queries/).
+   */
+  predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  );
+
+  /** Gets the underlying `Node`. */
+  Node getNode();
+}
+
+signature module PathGraphSig<PathNodeSig PathNode> {
+  /** Holds if `(a,b)` is an edge in the graph of data flow path explanations. */
+  predicate edges(PathNode a, PathNode b);
+
+  /** Holds if `n` is a node in the graph of data flow path explanations. */
+  predicate nodes(PathNode n, string key, string val);
+
+  /**
+   * Holds if `(arg, par, ret, out)` forms a subpath-tuple, that is, flow through
+   * a subpath between `par` and `ret` with the connecting edges `arg -> par` and
+   * `ret -> out` is summarized as the edge `arg -> out`.
+   */
+  predicate subpaths(PathNode arg, PathNode par, PathNode ret, PathNode out);
+}
+
+module MergePathGraph<
+PathNodeSig PathNode1, PathNodeSig PathNode2, PathGraphSig<PathNode1> Graph1,
+PathGraphSig<PathNode2> Graph2> {
+  private newtype TPathNode =
+    TPathNode1(PathNode1 p) or
+    TPathNode2(PathNode2 p)
+
+  class PathNode extends TPathNode {
+    PathNode1 asPathNode1() { this = TPathNode1(result) }
+
+    PathNode2 asPathNode2() { this = TPathNode2(result) }
+
+    string toString() {
+      result = this.asPathNode1().toString() or
+      result = this.asPathNode2().toString()
+    }
+
+    predicate hasLocationInfo(
+      string filepath, int startline, int startcolumn, int endline, int endcolumn
+    ) {
+      this.asPathNode1().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn) or
+      this.asPathNode2().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    }
+
+    Node getNode() {
+      result = this.asPathNode1().getNode() or
+      result = this.asPathNode2().getNode()
+    }
+  }
+
+  module PathGraph implements PathGraphSig<PathNode> {
+    query predicate edges(PathNode a, PathNode b) {
+      Graph1::edges(a.asPathNode1(), b.asPathNode1()) or
+      Graph2::edges(a.asPathNode2(), b.asPathNode2())
+    }
+
+    query predicate nodes(PathNode n, string key, string val) {
+      Graph1::nodes(n.asPathNode1(), key, val) or
+      Graph2::nodes(n.asPathNode2(), key, val)
+    }
+
+    query predicate subpaths(PathNode arg, PathNode par, PathNode ret, PathNode out) {
+      Graph1::subpaths(arg.asPathNode1(), par.asPathNode1(), ret.asPathNode1(), out.asPathNode1()) or
+      Graph2::subpaths(arg.asPathNode2(), par.asPathNode2(), ret.asPathNode2(), out.asPathNode2())
+    }
+  }
+}

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlow.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlow.qll
@@ -282,8 +282,9 @@ signature module PathGraphSig<PathNodeSig PathNode> {
  * Constructs a `PathGraph` from two `PathGraph`s by disjoint union.
  */
 module MergePathGraph<
-PathNodeSig PathNode1, PathNodeSig PathNode2, PathGraphSig<PathNode1> Graph1,
-PathGraphSig<PathNode2> Graph2> {
+  PathNodeSig PathNode1, PathNodeSig PathNode2, PathGraphSig<PathNode1> Graph1,
+  PathGraphSig<PathNode2> Graph2>
+{
   private newtype TPathNode =
     TPathNode1(PathNode1 p) or
     TPathNode2(PathNode2 p)

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -3157,7 +3157,7 @@ module Impl<FullStateConfigSig Config> {
   /**
    * Provides the query predicates needed to include a graph in a path-problem query.
    */
-  module PathGraph {
+  module PathGraph implements PathGraphSig<PathNode> {
     /** Holds if `(a,b)` is an edge in the graph of data flow path explanations. */
     query predicate edges(PathNode a, PathNode b) { a.getASuccessor() = b }
 

--- a/csharp/ql/lib/change-notes/2023-03-13-mergepathgraph.md
+++ b/csharp/ql/lib/change-notes/2023-03-13-mergepathgraph.md
@@ -1,0 +1,4 @@
+---
+category: feature
+---
+* Added support for merging two `PathGraph`s via disjoint union to allow results from multiple data flow computations in a single `path-problem` query.

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlow.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlow.qll
@@ -243,3 +243,85 @@ module MakeWithState<StateConfigSig Config> implements DataFlowSig {
 
   import Impl<C>
 }
+
+signature class PathNodeSig {
+  /** Gets a textual representation of this element. */
+  string toString();
+
+  /**
+   * Holds if this element is at the specified location.
+   * The location spans column `startcolumn` of line `startline` to
+   * column `endcolumn` of line `endline` in file `filepath`.
+   * For more information, see
+   * [Locations](https://codeql.github.com/docs/writing-codeql-queries/providing-locations-in-codeql-queries/).
+   */
+  predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  );
+
+  /** Gets the underlying `Node`. */
+  Node getNode();
+}
+
+signature module PathGraphSig<PathNodeSig PathNode> {
+  /** Holds if `(a,b)` is an edge in the graph of data flow path explanations. */
+  predicate edges(PathNode a, PathNode b);
+
+  /** Holds if `n` is a node in the graph of data flow path explanations. */
+  predicate nodes(PathNode n, string key, string val);
+
+  /**
+   * Holds if `(arg, par, ret, out)` forms a subpath-tuple, that is, flow through
+   * a subpath between `par` and `ret` with the connecting edges `arg -> par` and
+   * `ret -> out` is summarized as the edge `arg -> out`.
+   */
+  predicate subpaths(PathNode arg, PathNode par, PathNode ret, PathNode out);
+}
+
+module MergePathGraph<
+PathNodeSig PathNode1, PathNodeSig PathNode2, PathGraphSig<PathNode1> Graph1,
+PathGraphSig<PathNode2> Graph2> {
+  private newtype TPathNode =
+    TPathNode1(PathNode1 p) or
+    TPathNode2(PathNode2 p)
+
+  class PathNode extends TPathNode {
+    PathNode1 asPathNode1() { this = TPathNode1(result) }
+
+    PathNode2 asPathNode2() { this = TPathNode2(result) }
+
+    string toString() {
+      result = this.asPathNode1().toString() or
+      result = this.asPathNode2().toString()
+    }
+
+    predicate hasLocationInfo(
+      string filepath, int startline, int startcolumn, int endline, int endcolumn
+    ) {
+      this.asPathNode1().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn) or
+      this.asPathNode2().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    }
+
+    Node getNode() {
+      result = this.asPathNode1().getNode() or
+      result = this.asPathNode2().getNode()
+    }
+  }
+
+  module PathGraph implements PathGraphSig<PathNode> {
+    query predicate edges(PathNode a, PathNode b) {
+      Graph1::edges(a.asPathNode1(), b.asPathNode1()) or
+      Graph2::edges(a.asPathNode2(), b.asPathNode2())
+    }
+
+    query predicate nodes(PathNode n, string key, string val) {
+      Graph1::nodes(n.asPathNode1(), key, val) or
+      Graph2::nodes(n.asPathNode2(), key, val)
+    }
+
+    query predicate subpaths(PathNode arg, PathNode par, PathNode ret, PathNode out) {
+      Graph1::subpaths(arg.asPathNode1(), par.asPathNode1(), ret.asPathNode1(), out.asPathNode1()) or
+      Graph2::subpaths(arg.asPathNode2(), par.asPathNode2(), ret.asPathNode2(), out.asPathNode2())
+    }
+  }
+}

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlow.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlow.qll
@@ -282,8 +282,9 @@ signature module PathGraphSig<PathNodeSig PathNode> {
  * Constructs a `PathGraph` from two `PathGraph`s by disjoint union.
  */
 module MergePathGraph<
-PathNodeSig PathNode1, PathNodeSig PathNode2, PathGraphSig<PathNode1> Graph1,
-PathGraphSig<PathNode2> Graph2> {
+  PathNodeSig PathNode1, PathNodeSig PathNode2, PathGraphSig<PathNode1> Graph1,
+  PathGraphSig<PathNode2> Graph2>
+{
   private newtype TPathNode =
     TPathNode1(PathNode1 p) or
     TPathNode2(PathNode2 p)

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -3157,7 +3157,7 @@ module Impl<FullStateConfigSig Config> {
   /**
    * Provides the query predicates needed to include a graph in a path-problem query.
    */
-  module PathGraph {
+  module PathGraph implements PathGraphSig<PathNode> {
     /** Holds if `(a,b)` is an edge in the graph of data flow path explanations. */
     query predicate edges(PathNode a, PathNode b) { a.getASuccessor() = b }
 

--- a/go/ql/lib/change-notes/2023-03-13-mergepathgraph.md
+++ b/go/ql/lib/change-notes/2023-03-13-mergepathgraph.md
@@ -1,0 +1,4 @@
+---
+category: feature
+---
+* Added support for merging two `PathGraph`s via disjoint union to allow results from multiple data flow computations in a single `path-problem` query.

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlow.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlow.qll
@@ -243,3 +243,85 @@ module MakeWithState<StateConfigSig Config> implements DataFlowSig {
 
   import Impl<C>
 }
+
+signature class PathNodeSig {
+  /** Gets a textual representation of this element. */
+  string toString();
+
+  /**
+   * Holds if this element is at the specified location.
+   * The location spans column `startcolumn` of line `startline` to
+   * column `endcolumn` of line `endline` in file `filepath`.
+   * For more information, see
+   * [Locations](https://codeql.github.com/docs/writing-codeql-queries/providing-locations-in-codeql-queries/).
+   */
+  predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  );
+
+  /** Gets the underlying `Node`. */
+  Node getNode();
+}
+
+signature module PathGraphSig<PathNodeSig PathNode> {
+  /** Holds if `(a,b)` is an edge in the graph of data flow path explanations. */
+  predicate edges(PathNode a, PathNode b);
+
+  /** Holds if `n` is a node in the graph of data flow path explanations. */
+  predicate nodes(PathNode n, string key, string val);
+
+  /**
+   * Holds if `(arg, par, ret, out)` forms a subpath-tuple, that is, flow through
+   * a subpath between `par` and `ret` with the connecting edges `arg -> par` and
+   * `ret -> out` is summarized as the edge `arg -> out`.
+   */
+  predicate subpaths(PathNode arg, PathNode par, PathNode ret, PathNode out);
+}
+
+module MergePathGraph<
+PathNodeSig PathNode1, PathNodeSig PathNode2, PathGraphSig<PathNode1> Graph1,
+PathGraphSig<PathNode2> Graph2> {
+  private newtype TPathNode =
+    TPathNode1(PathNode1 p) or
+    TPathNode2(PathNode2 p)
+
+  class PathNode extends TPathNode {
+    PathNode1 asPathNode1() { this = TPathNode1(result) }
+
+    PathNode2 asPathNode2() { this = TPathNode2(result) }
+
+    string toString() {
+      result = this.asPathNode1().toString() or
+      result = this.asPathNode2().toString()
+    }
+
+    predicate hasLocationInfo(
+      string filepath, int startline, int startcolumn, int endline, int endcolumn
+    ) {
+      this.asPathNode1().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn) or
+      this.asPathNode2().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    }
+
+    Node getNode() {
+      result = this.asPathNode1().getNode() or
+      result = this.asPathNode2().getNode()
+    }
+  }
+
+  module PathGraph implements PathGraphSig<PathNode> {
+    query predicate edges(PathNode a, PathNode b) {
+      Graph1::edges(a.asPathNode1(), b.asPathNode1()) or
+      Graph2::edges(a.asPathNode2(), b.asPathNode2())
+    }
+
+    query predicate nodes(PathNode n, string key, string val) {
+      Graph1::nodes(n.asPathNode1(), key, val) or
+      Graph2::nodes(n.asPathNode2(), key, val)
+    }
+
+    query predicate subpaths(PathNode arg, PathNode par, PathNode ret, PathNode out) {
+      Graph1::subpaths(arg.asPathNode1(), par.asPathNode1(), ret.asPathNode1(), out.asPathNode1()) or
+      Graph2::subpaths(arg.asPathNode2(), par.asPathNode2(), ret.asPathNode2(), out.asPathNode2())
+    }
+  }
+}

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlow.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlow.qll
@@ -282,8 +282,9 @@ signature module PathGraphSig<PathNodeSig PathNode> {
  * Constructs a `PathGraph` from two `PathGraph`s by disjoint union.
  */
 module MergePathGraph<
-PathNodeSig PathNode1, PathNodeSig PathNode2, PathGraphSig<PathNode1> Graph1,
-PathGraphSig<PathNode2> Graph2> {
+  PathNodeSig PathNode1, PathNodeSig PathNode2, PathGraphSig<PathNode1> Graph1,
+  PathGraphSig<PathNode2> Graph2>
+{
   private newtype TPathNode =
     TPathNode1(PathNode1 p) or
     TPathNode2(PathNode2 p)

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowImpl.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowImpl.qll
@@ -3157,7 +3157,7 @@ module Impl<FullStateConfigSig Config> {
   /**
    * Provides the query predicates needed to include a graph in a path-problem query.
    */
-  module PathGraph {
+  module PathGraph implements PathGraphSig<PathNode> {
     /** Holds if `(a,b)` is an edge in the graph of data flow path explanations. */
     query predicate edges(PathNode a, PathNode b) { a.getASuccessor() = b }
 

--- a/java/ql/lib/change-notes/2023-03-13-mergepathgraph.md
+++ b/java/ql/lib/change-notes/2023-03-13-mergepathgraph.md
@@ -1,0 +1,4 @@
+---
+category: feature
+---
+* Added support for merging two `PathGraph`s via disjoint union to allow results from multiple data flow computations in a single `path-problem` query.

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlow.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlow.qll
@@ -243,3 +243,85 @@ module MakeWithState<StateConfigSig Config> implements DataFlowSig {
 
   import Impl<C>
 }
+
+signature class PathNodeSig {
+  /** Gets a textual representation of this element. */
+  string toString();
+
+  /**
+   * Holds if this element is at the specified location.
+   * The location spans column `startcolumn` of line `startline` to
+   * column `endcolumn` of line `endline` in file `filepath`.
+   * For more information, see
+   * [Locations](https://codeql.github.com/docs/writing-codeql-queries/providing-locations-in-codeql-queries/).
+   */
+  predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  );
+
+  /** Gets the underlying `Node`. */
+  Node getNode();
+}
+
+signature module PathGraphSig<PathNodeSig PathNode> {
+  /** Holds if `(a,b)` is an edge in the graph of data flow path explanations. */
+  predicate edges(PathNode a, PathNode b);
+
+  /** Holds if `n` is a node in the graph of data flow path explanations. */
+  predicate nodes(PathNode n, string key, string val);
+
+  /**
+   * Holds if `(arg, par, ret, out)` forms a subpath-tuple, that is, flow through
+   * a subpath between `par` and `ret` with the connecting edges `arg -> par` and
+   * `ret -> out` is summarized as the edge `arg -> out`.
+   */
+  predicate subpaths(PathNode arg, PathNode par, PathNode ret, PathNode out);
+}
+
+module MergePathGraph<
+PathNodeSig PathNode1, PathNodeSig PathNode2, PathGraphSig<PathNode1> Graph1,
+PathGraphSig<PathNode2> Graph2> {
+  private newtype TPathNode =
+    TPathNode1(PathNode1 p) or
+    TPathNode2(PathNode2 p)
+
+  class PathNode extends TPathNode {
+    PathNode1 asPathNode1() { this = TPathNode1(result) }
+
+    PathNode2 asPathNode2() { this = TPathNode2(result) }
+
+    string toString() {
+      result = this.asPathNode1().toString() or
+      result = this.asPathNode2().toString()
+    }
+
+    predicate hasLocationInfo(
+      string filepath, int startline, int startcolumn, int endline, int endcolumn
+    ) {
+      this.asPathNode1().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn) or
+      this.asPathNode2().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    }
+
+    Node getNode() {
+      result = this.asPathNode1().getNode() or
+      result = this.asPathNode2().getNode()
+    }
+  }
+
+  module PathGraph implements PathGraphSig<PathNode> {
+    query predicate edges(PathNode a, PathNode b) {
+      Graph1::edges(a.asPathNode1(), b.asPathNode1()) or
+      Graph2::edges(a.asPathNode2(), b.asPathNode2())
+    }
+
+    query predicate nodes(PathNode n, string key, string val) {
+      Graph1::nodes(n.asPathNode1(), key, val) or
+      Graph2::nodes(n.asPathNode2(), key, val)
+    }
+
+    query predicate subpaths(PathNode arg, PathNode par, PathNode ret, PathNode out) {
+      Graph1::subpaths(arg.asPathNode1(), par.asPathNode1(), ret.asPathNode1(), out.asPathNode1()) or
+      Graph2::subpaths(arg.asPathNode2(), par.asPathNode2(), ret.asPathNode2(), out.asPathNode2())
+    }
+  }
+}

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlow.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlow.qll
@@ -282,8 +282,9 @@ signature module PathGraphSig<PathNodeSig PathNode> {
  * Constructs a `PathGraph` from two `PathGraph`s by disjoint union.
  */
 module MergePathGraph<
-PathNodeSig PathNode1, PathNodeSig PathNode2, PathGraphSig<PathNode1> Graph1,
-PathGraphSig<PathNode2> Graph2> {
+  PathNodeSig PathNode1, PathNodeSig PathNode2, PathGraphSig<PathNode1> Graph1,
+  PathGraphSig<PathNode2> Graph2>
+{
   private newtype TPathNode =
     TPathNode1(PathNode1 p) or
     TPathNode2(PathNode2 p)

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -3157,7 +3157,7 @@ module Impl<FullStateConfigSig Config> {
   /**
    * Provides the query predicates needed to include a graph in a path-problem query.
    */
-  module PathGraph {
+  module PathGraph implements PathGraphSig<PathNode> {
     /** Holds if `(a,b)` is an edge in the graph of data flow path explanations. */
     query predicate edges(PathNode a, PathNode b) { a.getASuccessor() = b }
 

--- a/python/ql/lib/change-notes/2023-03-13-mergepathgraph.md
+++ b/python/ql/lib/change-notes/2023-03-13-mergepathgraph.md
@@ -1,0 +1,4 @@
+---
+category: feature
+---
+* Added support for merging two `PathGraph`s via disjoint union to allow results from multiple data flow computations in a single `path-problem` query.

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlow.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlow.qll
@@ -243,3 +243,85 @@ module MakeWithState<StateConfigSig Config> implements DataFlowSig {
 
   import Impl<C>
 }
+
+signature class PathNodeSig {
+  /** Gets a textual representation of this element. */
+  string toString();
+
+  /**
+   * Holds if this element is at the specified location.
+   * The location spans column `startcolumn` of line `startline` to
+   * column `endcolumn` of line `endline` in file `filepath`.
+   * For more information, see
+   * [Locations](https://codeql.github.com/docs/writing-codeql-queries/providing-locations-in-codeql-queries/).
+   */
+  predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  );
+
+  /** Gets the underlying `Node`. */
+  Node getNode();
+}
+
+signature module PathGraphSig<PathNodeSig PathNode> {
+  /** Holds if `(a,b)` is an edge in the graph of data flow path explanations. */
+  predicate edges(PathNode a, PathNode b);
+
+  /** Holds if `n` is a node in the graph of data flow path explanations. */
+  predicate nodes(PathNode n, string key, string val);
+
+  /**
+   * Holds if `(arg, par, ret, out)` forms a subpath-tuple, that is, flow through
+   * a subpath between `par` and `ret` with the connecting edges `arg -> par` and
+   * `ret -> out` is summarized as the edge `arg -> out`.
+   */
+  predicate subpaths(PathNode arg, PathNode par, PathNode ret, PathNode out);
+}
+
+module MergePathGraph<
+PathNodeSig PathNode1, PathNodeSig PathNode2, PathGraphSig<PathNode1> Graph1,
+PathGraphSig<PathNode2> Graph2> {
+  private newtype TPathNode =
+    TPathNode1(PathNode1 p) or
+    TPathNode2(PathNode2 p)
+
+  class PathNode extends TPathNode {
+    PathNode1 asPathNode1() { this = TPathNode1(result) }
+
+    PathNode2 asPathNode2() { this = TPathNode2(result) }
+
+    string toString() {
+      result = this.asPathNode1().toString() or
+      result = this.asPathNode2().toString()
+    }
+
+    predicate hasLocationInfo(
+      string filepath, int startline, int startcolumn, int endline, int endcolumn
+    ) {
+      this.asPathNode1().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn) or
+      this.asPathNode2().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    }
+
+    Node getNode() {
+      result = this.asPathNode1().getNode() or
+      result = this.asPathNode2().getNode()
+    }
+  }
+
+  module PathGraph implements PathGraphSig<PathNode> {
+    query predicate edges(PathNode a, PathNode b) {
+      Graph1::edges(a.asPathNode1(), b.asPathNode1()) or
+      Graph2::edges(a.asPathNode2(), b.asPathNode2())
+    }
+
+    query predicate nodes(PathNode n, string key, string val) {
+      Graph1::nodes(n.asPathNode1(), key, val) or
+      Graph2::nodes(n.asPathNode2(), key, val)
+    }
+
+    query predicate subpaths(PathNode arg, PathNode par, PathNode ret, PathNode out) {
+      Graph1::subpaths(arg.asPathNode1(), par.asPathNode1(), ret.asPathNode1(), out.asPathNode1()) or
+      Graph2::subpaths(arg.asPathNode2(), par.asPathNode2(), ret.asPathNode2(), out.asPathNode2())
+    }
+  }
+}

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlow.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlow.qll
@@ -282,8 +282,9 @@ signature module PathGraphSig<PathNodeSig PathNode> {
  * Constructs a `PathGraph` from two `PathGraph`s by disjoint union.
  */
 module MergePathGraph<
-PathNodeSig PathNode1, PathNodeSig PathNode2, PathGraphSig<PathNode1> Graph1,
-PathGraphSig<PathNode2> Graph2> {
+  PathNodeSig PathNode1, PathNodeSig PathNode2, PathGraphSig<PathNode1> Graph1,
+  PathGraphSig<PathNode2> Graph2>
+{
   private newtype TPathNode =
     TPathNode1(PathNode1 p) or
     TPathNode2(PathNode2 p)

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl.qll
@@ -3157,7 +3157,7 @@ module Impl<FullStateConfigSig Config> {
   /**
    * Provides the query predicates needed to include a graph in a path-problem query.
    */
-  module PathGraph {
+  module PathGraph implements PathGraphSig<PathNode> {
     /** Holds if `(a,b)` is an edge in the graph of data flow path explanations. */
     query predicate edges(PathNode a, PathNode b) { a.getASuccessor() = b }
 

--- a/ruby/ql/lib/change-notes/2023-03-13-mergepathgraph.md
+++ b/ruby/ql/lib/change-notes/2023-03-13-mergepathgraph.md
@@ -1,0 +1,4 @@
+---
+category: feature
+---
+* Added support for merging two `PathGraph`s via disjoint union to allow results from multiple data flow computations in a single `path-problem` query.

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlow.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlow.qll
@@ -243,3 +243,85 @@ module MakeWithState<StateConfigSig Config> implements DataFlowSig {
 
   import Impl<C>
 }
+
+signature class PathNodeSig {
+  /** Gets a textual representation of this element. */
+  string toString();
+
+  /**
+   * Holds if this element is at the specified location.
+   * The location spans column `startcolumn` of line `startline` to
+   * column `endcolumn` of line `endline` in file `filepath`.
+   * For more information, see
+   * [Locations](https://codeql.github.com/docs/writing-codeql-queries/providing-locations-in-codeql-queries/).
+   */
+  predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  );
+
+  /** Gets the underlying `Node`. */
+  Node getNode();
+}
+
+signature module PathGraphSig<PathNodeSig PathNode> {
+  /** Holds if `(a,b)` is an edge in the graph of data flow path explanations. */
+  predicate edges(PathNode a, PathNode b);
+
+  /** Holds if `n` is a node in the graph of data flow path explanations. */
+  predicate nodes(PathNode n, string key, string val);
+
+  /**
+   * Holds if `(arg, par, ret, out)` forms a subpath-tuple, that is, flow through
+   * a subpath between `par` and `ret` with the connecting edges `arg -> par` and
+   * `ret -> out` is summarized as the edge `arg -> out`.
+   */
+  predicate subpaths(PathNode arg, PathNode par, PathNode ret, PathNode out);
+}
+
+module MergePathGraph<
+PathNodeSig PathNode1, PathNodeSig PathNode2, PathGraphSig<PathNode1> Graph1,
+PathGraphSig<PathNode2> Graph2> {
+  private newtype TPathNode =
+    TPathNode1(PathNode1 p) or
+    TPathNode2(PathNode2 p)
+
+  class PathNode extends TPathNode {
+    PathNode1 asPathNode1() { this = TPathNode1(result) }
+
+    PathNode2 asPathNode2() { this = TPathNode2(result) }
+
+    string toString() {
+      result = this.asPathNode1().toString() or
+      result = this.asPathNode2().toString()
+    }
+
+    predicate hasLocationInfo(
+      string filepath, int startline, int startcolumn, int endline, int endcolumn
+    ) {
+      this.asPathNode1().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn) or
+      this.asPathNode2().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    }
+
+    Node getNode() {
+      result = this.asPathNode1().getNode() or
+      result = this.asPathNode2().getNode()
+    }
+  }
+
+  module PathGraph implements PathGraphSig<PathNode> {
+    query predicate edges(PathNode a, PathNode b) {
+      Graph1::edges(a.asPathNode1(), b.asPathNode1()) or
+      Graph2::edges(a.asPathNode2(), b.asPathNode2())
+    }
+
+    query predicate nodes(PathNode n, string key, string val) {
+      Graph1::nodes(n.asPathNode1(), key, val) or
+      Graph2::nodes(n.asPathNode2(), key, val)
+    }
+
+    query predicate subpaths(PathNode arg, PathNode par, PathNode ret, PathNode out) {
+      Graph1::subpaths(arg.asPathNode1(), par.asPathNode1(), ret.asPathNode1(), out.asPathNode1()) or
+      Graph2::subpaths(arg.asPathNode2(), par.asPathNode2(), ret.asPathNode2(), out.asPathNode2())
+    }
+  }
+}

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlow.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlow.qll
@@ -282,8 +282,9 @@ signature module PathGraphSig<PathNodeSig PathNode> {
  * Constructs a `PathGraph` from two `PathGraph`s by disjoint union.
  */
 module MergePathGraph<
-PathNodeSig PathNode1, PathNodeSig PathNode2, PathGraphSig<PathNode1> Graph1,
-PathGraphSig<PathNode2> Graph2> {
+  PathNodeSig PathNode1, PathNodeSig PathNode2, PathGraphSig<PathNode1> Graph1,
+  PathGraphSig<PathNode2> Graph2>
+{
   private newtype TPathNode =
     TPathNode1(PathNode1 p) or
     TPathNode2(PathNode2 p)

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl.qll
@@ -3157,7 +3157,7 @@ module Impl<FullStateConfigSig Config> {
   /**
    * Provides the query predicates needed to include a graph in a path-problem query.
    */
-  module PathGraph {
+  module PathGraph implements PathGraphSig<PathNode> {
     /** Holds if `(a,b)` is an edge in the graph of data flow path explanations. */
     query predicate edges(PathNode a, PathNode b) { a.getASuccessor() = b }
 

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlow.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlow.qll
@@ -243,3 +243,85 @@ module MakeWithState<StateConfigSig Config> implements DataFlowSig {
 
   import Impl<C>
 }
+
+signature class PathNodeSig {
+  /** Gets a textual representation of this element. */
+  string toString();
+
+  /**
+   * Holds if this element is at the specified location.
+   * The location spans column `startcolumn` of line `startline` to
+   * column `endcolumn` of line `endline` in file `filepath`.
+   * For more information, see
+   * [Locations](https://codeql.github.com/docs/writing-codeql-queries/providing-locations-in-codeql-queries/).
+   */
+  predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  );
+
+  /** Gets the underlying `Node`. */
+  Node getNode();
+}
+
+signature module PathGraphSig<PathNodeSig PathNode> {
+  /** Holds if `(a,b)` is an edge in the graph of data flow path explanations. */
+  predicate edges(PathNode a, PathNode b);
+
+  /** Holds if `n` is a node in the graph of data flow path explanations. */
+  predicate nodes(PathNode n, string key, string val);
+
+  /**
+   * Holds if `(arg, par, ret, out)` forms a subpath-tuple, that is, flow through
+   * a subpath between `par` and `ret` with the connecting edges `arg -> par` and
+   * `ret -> out` is summarized as the edge `arg -> out`.
+   */
+  predicate subpaths(PathNode arg, PathNode par, PathNode ret, PathNode out);
+}
+
+module MergePathGraph<
+PathNodeSig PathNode1, PathNodeSig PathNode2, PathGraphSig<PathNode1> Graph1,
+PathGraphSig<PathNode2> Graph2> {
+  private newtype TPathNode =
+    TPathNode1(PathNode1 p) or
+    TPathNode2(PathNode2 p)
+
+  class PathNode extends TPathNode {
+    PathNode1 asPathNode1() { this = TPathNode1(result) }
+
+    PathNode2 asPathNode2() { this = TPathNode2(result) }
+
+    string toString() {
+      result = this.asPathNode1().toString() or
+      result = this.asPathNode2().toString()
+    }
+
+    predicate hasLocationInfo(
+      string filepath, int startline, int startcolumn, int endline, int endcolumn
+    ) {
+      this.asPathNode1().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn) or
+      this.asPathNode2().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    }
+
+    Node getNode() {
+      result = this.asPathNode1().getNode() or
+      result = this.asPathNode2().getNode()
+    }
+  }
+
+  module PathGraph implements PathGraphSig<PathNode> {
+    query predicate edges(PathNode a, PathNode b) {
+      Graph1::edges(a.asPathNode1(), b.asPathNode1()) or
+      Graph2::edges(a.asPathNode2(), b.asPathNode2())
+    }
+
+    query predicate nodes(PathNode n, string key, string val) {
+      Graph1::nodes(n.asPathNode1(), key, val) or
+      Graph2::nodes(n.asPathNode2(), key, val)
+    }
+
+    query predicate subpaths(PathNode arg, PathNode par, PathNode ret, PathNode out) {
+      Graph1::subpaths(arg.asPathNode1(), par.asPathNode1(), ret.asPathNode1(), out.asPathNode1()) or
+      Graph2::subpaths(arg.asPathNode2(), par.asPathNode2(), ret.asPathNode2(), out.asPathNode2())
+    }
+  }
+}

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlow.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlow.qll
@@ -282,8 +282,9 @@ signature module PathGraphSig<PathNodeSig PathNode> {
  * Constructs a `PathGraph` from two `PathGraph`s by disjoint union.
  */
 module MergePathGraph<
-PathNodeSig PathNode1, PathNodeSig PathNode2, PathGraphSig<PathNode1> Graph1,
-PathGraphSig<PathNode2> Graph2> {
+  PathNodeSig PathNode1, PathNodeSig PathNode2, PathGraphSig<PathNode1> Graph1,
+  PathGraphSig<PathNode2> Graph2>
+{
   private newtype TPathNode =
     TPathNode1(PathNode1 p) or
     TPathNode2(PathNode2 p)

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImpl.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImpl.qll
@@ -3157,7 +3157,7 @@ module Impl<FullStateConfigSig Config> {
   /**
    * Provides the query predicates needed to include a graph in a path-problem query.
    */
-  module PathGraph {
+  module PathGraph implements PathGraphSig<PathNode> {
     /** Holds if `(a,b)` is an edge in the graph of data flow path explanations. */
     query predicate edges(PathNode a, PathNode b) { a.getASuccessor() = b }
 


### PR DESCRIPTION
This adds a convenience module that allows easy combination of 2 PathGraph modules as a disjoint union in order to display the results of two separate flow computations in a path-problem query.