### PR TITLE
C++: Fix `localStepsToExpr` performance

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -1142,7 +1142,8 @@ private class IndirectOperandIndirectExprNode extends IndirectExprNodeBase, RawI
 }
 
 private class IndirectInstructionIndirectExprNode extends IndirectExprNodeBase,
-  RawIndirectInstruction {
+  RawIndirectInstruction
+{
   IndirectInstructionIndirectExprNode() { indirectExprNodeShouldBeIndirectInstruction(this, _) }
 
   final override Expr getConvertedExpr(int index) {
@@ -1617,7 +1618,13 @@ private module ExprFlowCached {
    */
   private predicate localStepFromNonExpr(Node n1, Node n2) {
     not exists(n1.asExpr()) and
-    localFlowStep(n1, n2)
+    localFlowStep(n1, n2) and
+    // We should never recursive through any of these nodes while
+    // looking for the next expression.
+    not n1 instanceof SsaPhiNode and
+    not n1 instanceof InitialGlobalValue and
+    // These nodes will never take us to a node for which `asExpr` has a result.
+    not n2 instanceof FinalGlobalValue
   }
 
   /**


### PR DESCRIPTION
`localStepFromNonExpr` included a bunch of unnecessary nodes which led to a blowup when taking its transitive closure in `localStepsToExpr`:

```
Evaluated non-recursive predicate DataFlowUtil#47741e1f::ExprFlowCached::localStepsToExpr#3#fff@ac2ee4up in 12957ms (evaluation was halted due to CancellationException).
Evaluated relational algebra for predicate DataFlowUtil#47741e1f::ExprFlowCached::localStepsToExpr#3#fff@ac2ee4up with tuple counts:
 56000   ~4%    {3} r1 = SCAN DataFlowUtil#47741e1f::Node::asExpr#0#dispred#ff OUTPUT In.0, In.0, In.1
            
60965500   ~4%    {3} r2 = JOIN boundedFastTC:DataFlowUtil#47741e1f::ExprFlowCached::localStepFromNonExpr#2#ff_10#higher_order_body:project#DataFlowUtil#47741e1f::Node::asExpr#0#dispred#ff WITH DataFlowUtil#47741e1f::Node::asExpr#0#dispred#ff ON FIRST 1 OUTPUT Lhs.1, Lhs.0, Rhs.1
            
61021500   ~4%    {3} r3 = r1 UNION r2
61021000   ~4%    {3} r4 = r3 AND NOT _DataFlowUtil#47741e1f::Node::toString#0#dispred#ff#antijoin_rhs(Lhs.0)
                return r4
```

(I stopped evaluation midway)

After this PR we get:
```
Evaluated non-recursive predicate DataFlowUtil#47741e1f::ExprFlowCached::localStepsToExpr#3#fff@3b3f70t2 in 353ms (size: 2923152).
Evaluated relational algebra for predicate DataFlowUtil#47741e1f::ExprFlowCached::localStepsToExpr#3#fff@3b3f70t2 with tuple counts:
  1131827   ~0%    {3} r1 = SCAN DataFlowUtil#47741e1f::Node::asExpr#0#dispred#ff OUTPUT In.0, In.0, In.1
               
  1791325   ~0%    {3} r2 = JOIN boundedFastTC:DataFlowUtil#47741e1f::ExprFlowCached::localStepFromNonExpr#2#ff_10#higher_order_body:project#DataFlowUtil#47741e1f::Node::asExpr#0#dispred#ff WITH DataFlowUtil#47741e1f::Node::asExpr#0#dispred#ff ON FIRST 1 OUTPUT Lhs.1, Lhs.0, Rhs.1
               
  2923152   ~0%    {3} r3 = r1 UNION r2
                   return r3
```