### PR TITLE
JS: fix NPE

### DIFF
--- a/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
@@ -1234,7 +1234,8 @@ protected DependencyInstallationResult preparePackagesAndDependencies(Set<Path> 
       ParseResultInfo loc = extractor.extract(f, state);
       if (!extractor.getConfig().isExterns() && (loc == null || loc.getLinesOfCode() != 0)) seenCode = true;
       if (!extractor.getConfig().isExterns()) seenFiles = true;
-      for (ParseError err : loc.getParseErrors()) {
+      List<ParseError> errors = loc == null ? Collections.emptyList() : loc.getParseErrors();
+      for (ParseError err : errors) {
         String msg = "A parse error occurred: " + StringUtil.escapeMarkdown(err.getMessage())
             + ". Check the syntax of the file. If the file is invalid, correct the error or [exclude](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/customizing-code-scanning) the file from analysis.";
         // file, relative to the source root


### PR DESCRIPTION
The `extract` method may return `null`:

```java
  /** @return the number of lines of code extracted, or {@code null} if the file was cached */
  public ParseResultInfo extract(File f, ExtractorState state) throws IOException {
```
