### PR TITLE
Ruby: Add missing flow through `self.new` constructor calls

### DIFF
--- a/ruby/ql/lib/change-notes/2023-03-13-initalize-flow.md
+++ b/ruby/ql/lib/change-notes/2023-03-13-initalize-flow.md
@@ -1,0 +1,4 @@
+---
+ category: minorAnalysis
+---
+* Data flow through `initialize` methods is now taken into account also when the receiver of a `new` call is an (implicit or explicit) `self`.

--- a/ruby/ql/test/library-tests/dataflow/call-sensitivity/call-sensitivity.expected
+++ b/ruby/ql/test/library-tests/dataflow/call-sensitivity/call-sensitivity.expected
@@ -1,6 +1,4 @@
 failures
-| call_sensitivity.rb:51:12:51:202 | # $ hasValueFlow=10 $ hasValueFlow=11 $ hasValueFlow=12 $ hasValueFlow=13 $ hasValueFlow=26 $ hasValueFlow=28 $ hasValueFlow=30 $ hasValueFlow=33 $ hasValueFlow=35 $ SPURIOUS: hasValueFlow=27 | Missing result:hasValueFlow=35 |
-| call_sensitivity.rb:105:12:105:84 | # $ hasValueFlow=28 $ hasValueFlow=30 $ hasValueFlow=32 $ hasValueFlow=35 | Missing result:hasValueFlow=35 |
 edges
 | call_sensitivity.rb:9:7:9:13 | call to taint :  | call_sensitivity.rb:9:6:9:14 | ( ... ) |
 | call_sensitivity.rb:9:7:9:13 | call to taint :  | call_sensitivity.rb:9:6:9:14 | ( ... ) |
@@ -108,6 +106,10 @@ edges
 | call_sensitivity.rb:104:18:104:18 | x :  | call_sensitivity.rb:105:10:105:10 | x |
 | call_sensitivity.rb:104:18:104:18 | x :  | call_sensitivity.rb:105:10:105:10 | x |
 | call_sensitivity.rb:104:18:104:18 | x :  | call_sensitivity.rb:105:10:105:10 | x |
+| call_sensitivity.rb:104:18:104:18 | x :  | call_sensitivity.rb:105:10:105:10 | x |
+| call_sensitivity.rb:104:18:104:18 | x :  | call_sensitivity.rb:105:10:105:10 | x |
+| call_sensitivity.rb:104:18:104:18 | x :  | call_sensitivity.rb:106:13:106:13 | x :  |
+| call_sensitivity.rb:104:18:104:18 | x :  | call_sensitivity.rb:106:13:106:13 | x :  |
 | call_sensitivity.rb:104:18:104:18 | x :  | call_sensitivity.rb:106:13:106:13 | x :  |
 | call_sensitivity.rb:104:18:104:18 | x :  | call_sensitivity.rb:106:13:106:13 | x :  |
 | call_sensitivity.rb:104:18:104:18 | x :  | call_sensitivity.rb:106:13:106:13 | x :  |
@@ -116,6 +118,12 @@ edges
 | call_sensitivity.rb:106:13:106:13 | x :  | call_sensitivity.rb:50:15:50:15 | x :  |
 | call_sensitivity.rb:106:13:106:13 | x :  | call_sensitivity.rb:50:15:50:15 | x :  |
 | call_sensitivity.rb:106:13:106:13 | x :  | call_sensitivity.rb:50:15:50:15 | x :  |
+| call_sensitivity.rb:106:13:106:13 | x :  | call_sensitivity.rb:50:15:50:15 | x :  |
+| call_sensitivity.rb:106:13:106:13 | x :  | call_sensitivity.rb:50:15:50:15 | x :  |
+| call_sensitivity.rb:109:21:109:21 | x :  | call_sensitivity.rb:110:9:110:9 | x :  |
+| call_sensitivity.rb:109:21:109:21 | x :  | call_sensitivity.rb:110:9:110:9 | x :  |
+| call_sensitivity.rb:110:9:110:9 | x :  | call_sensitivity.rb:104:18:104:18 | x :  |
+| call_sensitivity.rb:110:9:110:9 | x :  | call_sensitivity.rb:104:18:104:18 | x :  |
 | call_sensitivity.rb:114:11:114:20 | ( ... ) :  | call_sensitivity.rb:104:18:104:18 | x :  |
 | call_sensitivity.rb:114:11:114:20 | ( ... ) :  | call_sensitivity.rb:104:18:104:18 | x :  |
 | call_sensitivity.rb:114:12:114:19 | call to taint :  | call_sensitivity.rb:114:11:114:20 | ( ... ) :  |
@@ -138,6 +146,8 @@ edges
 | call_sensitivity.rb:123:24:123:32 | call to taint :  | call_sensitivity.rb:96:33:96:33 | y :  |
 | call_sensitivity.rb:124:26:124:33 | call to taint :  | call_sensitivity.rb:100:35:100:35 | x :  |
 | call_sensitivity.rb:124:26:124:33 | call to taint :  | call_sensitivity.rb:100:35:100:35 | x :  |
+| call_sensitivity.rb:125:12:125:19 | call to taint :  | call_sensitivity.rb:109:21:109:21 | x :  |
+| call_sensitivity.rb:125:12:125:19 | call to taint :  | call_sensitivity.rb:109:21:109:21 | x :  |
 | call_sensitivity.rb:166:14:166:22 | call to taint :  | call_sensitivity.rb:74:18:74:18 | y :  |
 | call_sensitivity.rb:166:14:166:22 | call to taint :  | call_sensitivity.rb:74:18:74:18 | y :  |
 | call_sensitivity.rb:174:19:174:19 | x :  | call_sensitivity.rb:175:12:175:12 | x :  |
@@ -271,12 +281,20 @@ nodes
 | call_sensitivity.rb:104:18:104:18 | x :  | semmle.label | x :  |
 | call_sensitivity.rb:104:18:104:18 | x :  | semmle.label | x :  |
 | call_sensitivity.rb:104:18:104:18 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:104:18:104:18 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:104:18:104:18 | x :  | semmle.label | x :  |
 | call_sensitivity.rb:105:10:105:10 | x | semmle.label | x |
 | call_sensitivity.rb:105:10:105:10 | x | semmle.label | x |
 | call_sensitivity.rb:106:13:106:13 | x :  | semmle.label | x :  |
 | call_sensitivity.rb:106:13:106:13 | x :  | semmle.label | x :  |
 | call_sensitivity.rb:106:13:106:13 | x :  | semmle.label | x :  |
 | call_sensitivity.rb:106:13:106:13 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:106:13:106:13 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:106:13:106:13 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:109:21:109:21 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:109:21:109:21 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:110:9:110:9 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:110:9:110:9 | x :  | semmle.label | x :  |
 | call_sensitivity.rb:114:11:114:20 | ( ... ) :  | semmle.label | ( ... ) :  |
 | call_sensitivity.rb:114:11:114:20 | ( ... ) :  | semmle.label | ( ... ) :  |
 | call_sensitivity.rb:114:12:114:19 | call to taint :  | semmle.label | call to taint :  |
@@ -299,6 +317,8 @@ nodes
 | call_sensitivity.rb:123:24:123:32 | call to taint :  | semmle.label | call to taint :  |
 | call_sensitivity.rb:124:26:124:33 | call to taint :  | semmle.label | call to taint :  |
 | call_sensitivity.rb:124:26:124:33 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:125:12:125:19 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:125:12:125:19 | call to taint :  | semmle.label | call to taint :  |
 | call_sensitivity.rb:166:14:166:22 | call to taint :  | semmle.label | call to taint :  |
 | call_sensitivity.rb:166:14:166:22 | call to taint :  | semmle.label | call to taint :  |
 | call_sensitivity.rb:174:19:174:19 | x :  | semmle.label | x :  |
@@ -325,6 +345,7 @@ subpaths
 | call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:117:14:117:22 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:117:14:117:22 | call to taint :  | call to taint :  |
 | call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:118:16:118:24 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:118:16:118:24 | call to taint :  | call to taint :  |
 | call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:119:14:119:22 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:119:14:119:22 | call to taint :  | call to taint :  |
+| call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:125:12:125:19 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:125:12:125:19 | call to taint :  | call to taint :  |
 | call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:166:14:166:22 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:166:14:166:22 | call to taint :  | call to taint :  |
 | call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:178:11:178:19 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:178:11:178:19 | call to taint :  | call to taint :  |
 | call_sensitivity.rb:71:10:71:10 | x | call_sensitivity.rb:121:21:121:28 | call to taint :  | call_sensitivity.rb:71:10:71:10 | x | $@ | call_sensitivity.rb:121:21:121:28 | call to taint :  | call to taint :  |
@@ -332,6 +353,7 @@ subpaths
 | call_sensitivity.rb:71:10:71:10 | x | call_sensitivity.rb:123:24:123:32 | call to taint :  | call_sensitivity.rb:71:10:71:10 | x | $@ | call_sensitivity.rb:123:24:123:32 | call to taint :  | call to taint :  |
 | call_sensitivity.rb:71:10:71:10 | x | call_sensitivity.rb:124:26:124:33 | call to taint :  | call_sensitivity.rb:71:10:71:10 | x | $@ | call_sensitivity.rb:124:26:124:33 | call to taint :  | call to taint :  |
 | call_sensitivity.rb:105:10:105:10 | x | call_sensitivity.rb:114:12:114:19 | call to taint :  | call_sensitivity.rb:105:10:105:10 | x | $@ | call_sensitivity.rb:114:12:114:19 | call to taint :  | call to taint :  |
+| call_sensitivity.rb:105:10:105:10 | x | call_sensitivity.rb:125:12:125:19 | call to taint :  | call_sensitivity.rb:105:10:105:10 | x | $@ | call_sensitivity.rb:125:12:125:19 | call to taint :  | call to taint :  |
 | call_sensitivity.rb:105:10:105:10 | x | call_sensitivity.rb:178:11:178:19 | call to taint :  | call_sensitivity.rb:105:10:105:10 | x | $@ | call_sensitivity.rb:178:11:178:19 | call to taint :  | call to taint :  |
 | call_sensitivity.rb:105:10:105:10 | x | call_sensitivity.rb:187:12:187:19 | call to taint :  | call_sensitivity.rb:105:10:105:10 | x | $@ | call_sensitivity.rb:187:12:187:19 | call to taint :  | call to taint :  |
 mayBenefitFromCallContext
@@ -389,13 +411,19 @@ viableImplInCallContext
 | call_sensitivity.rb:97:5:97:26 | call to singleton_method1 | call_sensitivity.rb:153:5:153:35 | call to singleton_method3 | call_sensitivity.rb:132:3:134:5 | singleton_method1 |
 | call_sensitivity.rb:97:5:97:26 | call to singleton_method1 | call_sensitivity.rb:170:1:170:33 | call to singleton_method3 | call_sensitivity.rb:132:3:134:5 | singleton_method1 |
 | call_sensitivity.rb:101:5:101:35 | call to singleton_method3 | call_sensitivity.rb:124:1:124:34 | call to call_singleton_method3 | call_sensitivity.rb:96:3:98:5 | singleton_method3 |
+| call_sensitivity.rb:105:5:105:10 | call to sink | call_sensitivity.rb:110:5:110:9 | call to new | call_sensitivity.rb:5:1:7:3 | sink |
 | call_sensitivity.rb:105:5:105:10 | call to sink | call_sensitivity.rb:114:5:114:20 | call to new | call_sensitivity.rb:5:1:7:3 | sink |
 | call_sensitivity.rb:105:5:105:10 | call to sink | call_sensitivity.rb:175:3:175:12 | call to new | call_sensitivity.rb:5:1:7:3 | sink |
 | call_sensitivity.rb:105:5:105:10 | call to sink | call_sensitivity.rb:187:5:187:20 | call to new | call_sensitivity.rb:5:1:7:3 | sink |
+| call_sensitivity.rb:106:5:106:13 | call to method1 | call_sensitivity.rb:110:5:110:9 | call to new | call_sensitivity.rb:50:3:52:5 | method1 |
+| call_sensitivity.rb:106:5:106:13 | call to method1 | call_sensitivity.rb:110:5:110:9 | call to new | call_sensitivity.rb:128:3:130:5 | method1 |
+| call_sensitivity.rb:106:5:106:13 | call to method1 | call_sensitivity.rb:110:5:110:9 | call to new | call_sensitivity.rb:182:3:184:5 | method1 |
 | call_sensitivity.rb:106:5:106:13 | call to method1 | call_sensitivity.rb:114:5:114:20 | call to new | call_sensitivity.rb:50:3:52:5 | method1 |
 | call_sensitivity.rb:106:5:106:13 | call to method1 | call_sensitivity.rb:175:3:175:12 | call to new | call_sensitivity.rb:50:3:52:5 | method1 |
 | call_sensitivity.rb:106:5:106:13 | call to method1 | call_sensitivity.rb:175:3:175:12 | call to new | call_sensitivity.rb:128:3:130:5 | method1 |
 | call_sensitivity.rb:106:5:106:13 | call to method1 | call_sensitivity.rb:187:5:187:20 | call to new | call_sensitivity.rb:182:3:184:5 | method1 |
+| call_sensitivity.rb:110:5:110:9 | call to new | call_sensitivity.rb:125:1:125:20 | call to call_new | call_sensitivity.rb:104:3:107:5 | initialize |
+| call_sensitivity.rb:110:5:110:9 | call to new | call_sensitivity.rb:172:1:172:20 | call to call_new | call_sensitivity.rb:156:3:158:5 | initialize |
 | call_sensitivity.rb:137:5:137:18 | call to method2 | call_sensitivity.rb:163:1:163:24 | call to call_method2 | call_sensitivity.rb:54:3:56:5 | method2 |
 | call_sensitivity.rb:141:5:141:25 | call to method3 | call_sensitivity.rb:165:1:165:25 | call to call_method3 | call_sensitivity.rb:62:3:64:5 | method3 |
 | call_sensitivity.rb:149:5:149:28 | call to singleton_method2 | call_sensitivity.rb:169:1:169:34 | call to call_singleton_method2 | call_sensitivity.rb:88:3:90:5 | singleton_method2 |

--- a/ruby/ql/test/library-tests/dataflow/call-sensitivity/call-sensitivity.expected
+++ b/ruby/ql/test/library-tests/dataflow/call-sensitivity/call-sensitivity.expected
@@ -1,4 +1,6 @@
 failures
+| call_sensitivity.rb:51:12:51:202 | # $ hasValueFlow=10 $ hasValueFlow=11 $ hasValueFlow=12 $ hasValueFlow=13 $ hasValueFlow=26 $ hasValueFlow=28 $ hasValueFlow=30 $ hasValueFlow=33 $ hasValueFlow=35 $ SPURIOUS: hasValueFlow=27 | Missing result:hasValueFlow=35 |
+| call_sensitivity.rb:105:12:105:84 | # $ hasValueFlow=28 $ hasValueFlow=30 $ hasValueFlow=32 $ hasValueFlow=35 | Missing result:hasValueFlow=35 |
 edges
 | call_sensitivity.rb:9:7:9:13 | call to taint :  | call_sensitivity.rb:9:6:9:14 | ( ... ) |
 | call_sensitivity.rb:9:7:9:13 | call to taint :  | call_sensitivity.rb:9:6:9:14 | ( ... ) |
@@ -114,40 +116,40 @@ edges
 | call_sensitivity.rb:106:13:106:13 | x :  | call_sensitivity.rb:50:15:50:15 | x :  |
 | call_sensitivity.rb:106:13:106:13 | x :  | call_sensitivity.rb:50:15:50:15 | x :  |
 | call_sensitivity.rb:106:13:106:13 | x :  | call_sensitivity.rb:50:15:50:15 | x :  |
-| call_sensitivity.rb:110:11:110:20 | ( ... ) :  | call_sensitivity.rb:104:18:104:18 | x :  |
-| call_sensitivity.rb:110:11:110:20 | ( ... ) :  | call_sensitivity.rb:104:18:104:18 | x :  |
-| call_sensitivity.rb:110:12:110:19 | call to taint :  | call_sensitivity.rb:110:11:110:20 | ( ... ) :  |
-| call_sensitivity.rb:110:12:110:19 | call to taint :  | call_sensitivity.rb:110:11:110:20 | ( ... ) :  |
-| call_sensitivity.rb:111:11:111:18 | call to taint :  | call_sensitivity.rb:54:15:54:15 | x :  |
-| call_sensitivity.rb:111:11:111:18 | call to taint :  | call_sensitivity.rb:54:15:54:15 | x :  |
-| call_sensitivity.rb:112:16:112:23 | call to taint :  | call_sensitivity.rb:58:20:58:20 | x :  |
-| call_sensitivity.rb:112:16:112:23 | call to taint :  | call_sensitivity.rb:58:20:58:20 | x :  |
-| call_sensitivity.rb:113:14:113:22 | call to taint :  | call_sensitivity.rb:62:18:62:18 | y :  |
-| call_sensitivity.rb:113:14:113:22 | call to taint :  | call_sensitivity.rb:62:18:62:18 | y :  |
-| call_sensitivity.rb:114:16:114:24 | call to taint :  | call_sensitivity.rb:66:20:66:20 | x :  |
-| call_sensitivity.rb:114:16:114:24 | call to taint :  | call_sensitivity.rb:66:20:66:20 | x :  |
-| call_sensitivity.rb:115:14:115:22 | call to taint :  | call_sensitivity.rb:74:18:74:18 | y :  |
-| call_sensitivity.rb:115:14:115:22 | call to taint :  | call_sensitivity.rb:74:18:74:18 | y :  |
-| call_sensitivity.rb:117:21:117:28 | call to taint :  | call_sensitivity.rb:88:30:88:30 | x :  |
-| call_sensitivity.rb:117:21:117:28 | call to taint :  | call_sensitivity.rb:88:30:88:30 | x :  |
-| call_sensitivity.rb:118:26:118:33 | call to taint :  | call_sensitivity.rb:92:35:92:35 | x :  |
-| call_sensitivity.rb:118:26:118:33 | call to taint :  | call_sensitivity.rb:92:35:92:35 | x :  |
-| call_sensitivity.rb:119:24:119:32 | call to taint :  | call_sensitivity.rb:96:33:96:33 | y :  |
-| call_sensitivity.rb:119:24:119:32 | call to taint :  | call_sensitivity.rb:96:33:96:33 | y :  |
-| call_sensitivity.rb:120:26:120:33 | call to taint :  | call_sensitivity.rb:100:35:100:35 | x :  |
-| call_sensitivity.rb:120:26:120:33 | call to taint :  | call_sensitivity.rb:100:35:100:35 | x :  |
-| call_sensitivity.rb:161:14:161:22 | call to taint :  | call_sensitivity.rb:74:18:74:18 | y :  |
-| call_sensitivity.rb:161:14:161:22 | call to taint :  | call_sensitivity.rb:74:18:74:18 | y :  |
-| call_sensitivity.rb:168:19:168:19 | x :  | call_sensitivity.rb:169:12:169:12 | x :  |
-| call_sensitivity.rb:168:19:168:19 | x :  | call_sensitivity.rb:169:12:169:12 | x :  |
-| call_sensitivity.rb:169:12:169:12 | x :  | call_sensitivity.rb:104:18:104:18 | x :  |
-| call_sensitivity.rb:169:12:169:12 | x :  | call_sensitivity.rb:104:18:104:18 | x :  |
-| call_sensitivity.rb:172:11:172:19 | call to taint :  | call_sensitivity.rb:168:19:168:19 | x :  |
-| call_sensitivity.rb:172:11:172:19 | call to taint :  | call_sensitivity.rb:168:19:168:19 | x :  |
-| call_sensitivity.rb:181:11:181:20 | ( ... ) :  | call_sensitivity.rb:104:18:104:18 | x :  |
-| call_sensitivity.rb:181:11:181:20 | ( ... ) :  | call_sensitivity.rb:104:18:104:18 | x :  |
-| call_sensitivity.rb:181:12:181:19 | call to taint :  | call_sensitivity.rb:181:11:181:20 | ( ... ) :  |
-| call_sensitivity.rb:181:12:181:19 | call to taint :  | call_sensitivity.rb:181:11:181:20 | ( ... ) :  |
+| call_sensitivity.rb:114:11:114:20 | ( ... ) :  | call_sensitivity.rb:104:18:104:18 | x :  |
+| call_sensitivity.rb:114:11:114:20 | ( ... ) :  | call_sensitivity.rb:104:18:104:18 | x :  |
+| call_sensitivity.rb:114:12:114:19 | call to taint :  | call_sensitivity.rb:114:11:114:20 | ( ... ) :  |
+| call_sensitivity.rb:114:12:114:19 | call to taint :  | call_sensitivity.rb:114:11:114:20 | ( ... ) :  |
+| call_sensitivity.rb:115:11:115:18 | call to taint :  | call_sensitivity.rb:54:15:54:15 | x :  |
+| call_sensitivity.rb:115:11:115:18 | call to taint :  | call_sensitivity.rb:54:15:54:15 | x :  |
+| call_sensitivity.rb:116:16:116:23 | call to taint :  | call_sensitivity.rb:58:20:58:20 | x :  |
+| call_sensitivity.rb:116:16:116:23 | call to taint :  | call_sensitivity.rb:58:20:58:20 | x :  |
+| call_sensitivity.rb:117:14:117:22 | call to taint :  | call_sensitivity.rb:62:18:62:18 | y :  |
+| call_sensitivity.rb:117:14:117:22 | call to taint :  | call_sensitivity.rb:62:18:62:18 | y :  |
+| call_sensitivity.rb:118:16:118:24 | call to taint :  | call_sensitivity.rb:66:20:66:20 | x :  |
+| call_sensitivity.rb:118:16:118:24 | call to taint :  | call_sensitivity.rb:66:20:66:20 | x :  |
+| call_sensitivity.rb:119:14:119:22 | call to taint :  | call_sensitivity.rb:74:18:74:18 | y :  |
+| call_sensitivity.rb:119:14:119:22 | call to taint :  | call_sensitivity.rb:74:18:74:18 | y :  |
+| call_sensitivity.rb:121:21:121:28 | call to taint :  | call_sensitivity.rb:88:30:88:30 | x :  |
+| call_sensitivity.rb:121:21:121:28 | call to taint :  | call_sensitivity.rb:88:30:88:30 | x :  |
+| call_sensitivity.rb:122:26:122:33 | call to taint :  | call_sensitivity.rb:92:35:92:35 | x :  |
+| call_sensitivity.rb:122:26:122:33 | call to taint :  | call_sensitivity.rb:92:35:92:35 | x :  |
+| call_sensitivity.rb:123:24:123:32 | call to taint :  | call_sensitivity.rb:96:33:96:33 | y :  |
+| call_sensitivity.rb:123:24:123:32 | call to taint :  | call_sensitivity.rb:96:33:96:33 | y :  |
+| call_sensitivity.rb:124:26:124:33 | call to taint :  | call_sensitivity.rb:100:35:100:35 | x :  |
+| call_sensitivity.rb:124:26:124:33 | call to taint :  | call_sensitivity.rb:100:35:100:35 | x :  |
+| call_sensitivity.rb:166:14:166:22 | call to taint :  | call_sensitivity.rb:74:18:74:18 | y :  |
+| call_sensitivity.rb:166:14:166:22 | call to taint :  | call_sensitivity.rb:74:18:74:18 | y :  |
+| call_sensitivity.rb:174:19:174:19 | x :  | call_sensitivity.rb:175:12:175:12 | x :  |
+| call_sensitivity.rb:174:19:174:19 | x :  | call_sensitivity.rb:175:12:175:12 | x :  |
+| call_sensitivity.rb:175:12:175:12 | x :  | call_sensitivity.rb:104:18:104:18 | x :  |
+| call_sensitivity.rb:175:12:175:12 | x :  | call_sensitivity.rb:104:18:104:18 | x :  |
+| call_sensitivity.rb:178:11:178:19 | call to taint :  | call_sensitivity.rb:174:19:174:19 | x :  |
+| call_sensitivity.rb:178:11:178:19 | call to taint :  | call_sensitivity.rb:174:19:174:19 | x :  |
+| call_sensitivity.rb:187:11:187:20 | ( ... ) :  | call_sensitivity.rb:104:18:104:18 | x :  |
+| call_sensitivity.rb:187:11:187:20 | ( ... ) :  | call_sensitivity.rb:104:18:104:18 | x :  |
+| call_sensitivity.rb:187:12:187:19 | call to taint :  | call_sensitivity.rb:187:11:187:20 | ( ... ) :  |
+| call_sensitivity.rb:187:12:187:19 | call to taint :  | call_sensitivity.rb:187:11:187:20 | ( ... ) :  |
 nodes
 | call_sensitivity.rb:9:6:9:14 | ( ... ) | semmle.label | ( ... ) |
 | call_sensitivity.rb:9:6:9:14 | ( ... ) | semmle.label | ( ... ) |
@@ -275,40 +277,40 @@ nodes
 | call_sensitivity.rb:106:13:106:13 | x :  | semmle.label | x :  |
 | call_sensitivity.rb:106:13:106:13 | x :  | semmle.label | x :  |
 | call_sensitivity.rb:106:13:106:13 | x :  | semmle.label | x :  |
-| call_sensitivity.rb:110:11:110:20 | ( ... ) :  | semmle.label | ( ... ) :  |
-| call_sensitivity.rb:110:11:110:20 | ( ... ) :  | semmle.label | ( ... ) :  |
-| call_sensitivity.rb:110:12:110:19 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:110:12:110:19 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:111:11:111:18 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:111:11:111:18 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:112:16:112:23 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:112:16:112:23 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:113:14:113:22 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:113:14:113:22 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:114:16:114:24 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:114:16:114:24 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:115:14:115:22 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:115:14:115:22 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:117:21:117:28 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:117:21:117:28 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:118:26:118:33 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:118:26:118:33 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:119:24:119:32 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:119:24:119:32 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:120:26:120:33 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:120:26:120:33 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:161:14:161:22 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:161:14:161:22 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:168:19:168:19 | x :  | semmle.label | x :  |
-| call_sensitivity.rb:168:19:168:19 | x :  | semmle.label | x :  |
-| call_sensitivity.rb:169:12:169:12 | x :  | semmle.label | x :  |
-| call_sensitivity.rb:169:12:169:12 | x :  | semmle.label | x :  |
-| call_sensitivity.rb:172:11:172:19 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:172:11:172:19 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:181:11:181:20 | ( ... ) :  | semmle.label | ( ... ) :  |
-| call_sensitivity.rb:181:11:181:20 | ( ... ) :  | semmle.label | ( ... ) :  |
-| call_sensitivity.rb:181:12:181:19 | call to taint :  | semmle.label | call to taint :  |
-| call_sensitivity.rb:181:12:181:19 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:114:11:114:20 | ( ... ) :  | semmle.label | ( ... ) :  |
+| call_sensitivity.rb:114:11:114:20 | ( ... ) :  | semmle.label | ( ... ) :  |
+| call_sensitivity.rb:114:12:114:19 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:114:12:114:19 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:115:11:115:18 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:115:11:115:18 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:116:16:116:23 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:116:16:116:23 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:117:14:117:22 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:117:14:117:22 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:118:16:118:24 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:118:16:118:24 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:119:14:119:22 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:119:14:119:22 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:121:21:121:28 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:121:21:121:28 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:122:26:122:33 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:122:26:122:33 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:123:24:123:32 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:123:24:123:32 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:124:26:124:33 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:124:26:124:33 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:166:14:166:22 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:166:14:166:22 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:174:19:174:19 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:174:19:174:19 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:175:12:175:12 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:175:12:175:12 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:178:11:178:19 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:178:11:178:19 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:187:11:187:20 | ( ... ) :  | semmle.label | ( ... ) :  |
+| call_sensitivity.rb:187:11:187:20 | ( ... ) :  | semmle.label | ( ... ) :  |
+| call_sensitivity.rb:187:12:187:19 | call to taint :  | semmle.label | call to taint :  |
+| call_sensitivity.rb:187:12:187:19 | call to taint :  | semmle.label | call to taint :  |
 subpaths
 #select
 | call_sensitivity.rb:9:6:9:14 | ( ... ) | call_sensitivity.rb:9:7:9:13 | call to taint :  | call_sensitivity.rb:9:6:9:14 | ( ... ) | $@ | call_sensitivity.rb:9:7:9:13 | call to taint :  | call to taint :  |
@@ -317,21 +319,21 @@ subpaths
 | call_sensitivity.rb:40:31:40:31 | x | call_sensitivity.rb:41:25:41:32 | call to taint :  | call_sensitivity.rb:40:31:40:31 | x | $@ | call_sensitivity.rb:41:25:41:32 | call to taint :  | call to taint :  |
 | call_sensitivity.rb:43:32:43:32 | x | call_sensitivity.rb:44:26:44:33 | call to taint :  | call_sensitivity.rb:43:32:43:32 | x | $@ | call_sensitivity.rb:44:26:44:33 | call to taint :  | call to taint :  |
 | call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:85:19:85:26 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:85:19:85:26 | call to taint :  | call to taint :  |
-| call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:110:12:110:19 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:110:12:110:19 | call to taint :  | call to taint :  |
-| call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:111:11:111:18 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:111:11:111:18 | call to taint :  | call to taint :  |
-| call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:112:16:112:23 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:112:16:112:23 | call to taint :  | call to taint :  |
-| call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:113:14:113:22 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:113:14:113:22 | call to taint :  | call to taint :  |
-| call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:114:16:114:24 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:114:16:114:24 | call to taint :  | call to taint :  |
-| call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:115:14:115:22 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:115:14:115:22 | call to taint :  | call to taint :  |
-| call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:161:14:161:22 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:161:14:161:22 | call to taint :  | call to taint :  |
-| call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:172:11:172:19 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:172:11:172:19 | call to taint :  | call to taint :  |
-| call_sensitivity.rb:71:10:71:10 | x | call_sensitivity.rb:117:21:117:28 | call to taint :  | call_sensitivity.rb:71:10:71:10 | x | $@ | call_sensitivity.rb:117:21:117:28 | call to taint :  | call to taint :  |
-| call_sensitivity.rb:71:10:71:10 | x | call_sensitivity.rb:118:26:118:33 | call to taint :  | call_sensitivity.rb:71:10:71:10 | x | $@ | call_sensitivity.rb:118:26:118:33 | call to taint :  | call to taint :  |
-| call_sensitivity.rb:71:10:71:10 | x | call_sensitivity.rb:119:24:119:32 | call to taint :  | call_sensitivity.rb:71:10:71:10 | x | $@ | call_sensitivity.rb:119:24:119:32 | call to taint :  | call to taint :  |
-| call_sensitivity.rb:71:10:71:10 | x | call_sensitivity.rb:120:26:120:33 | call to taint :  | call_sensitivity.rb:71:10:71:10 | x | $@ | call_sensitivity.rb:120:26:120:33 | call to taint :  | call to taint :  |
-| call_sensitivity.rb:105:10:105:10 | x | call_sensitivity.rb:110:12:110:19 | call to taint :  | call_sensitivity.rb:105:10:105:10 | x | $@ | call_sensitivity.rb:110:12:110:19 | call to taint :  | call to taint :  |
-| call_sensitivity.rb:105:10:105:10 | x | call_sensitivity.rb:172:11:172:19 | call to taint :  | call_sensitivity.rb:105:10:105:10 | x | $@ | call_sensitivity.rb:172:11:172:19 | call to taint :  | call to taint :  |
-| call_sensitivity.rb:105:10:105:10 | x | call_sensitivity.rb:181:12:181:19 | call to taint :  | call_sensitivity.rb:105:10:105:10 | x | $@ | call_sensitivity.rb:181:12:181:19 | call to taint :  | call to taint :  |
+| call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:114:12:114:19 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:114:12:114:19 | call to taint :  | call to taint :  |
+| call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:115:11:115:18 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:115:11:115:18 | call to taint :  | call to taint :  |
+| call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:116:16:116:23 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:116:16:116:23 | call to taint :  | call to taint :  |
+| call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:117:14:117:22 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:117:14:117:22 | call to taint :  | call to taint :  |
+| call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:118:16:118:24 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:118:16:118:24 | call to taint :  | call to taint :  |
+| call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:119:14:119:22 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:119:14:119:22 | call to taint :  | call to taint :  |
+| call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:166:14:166:22 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:166:14:166:22 | call to taint :  | call to taint :  |
+| call_sensitivity.rb:51:10:51:10 | x | call_sensitivity.rb:178:11:178:19 | call to taint :  | call_sensitivity.rb:51:10:51:10 | x | $@ | call_sensitivity.rb:178:11:178:19 | call to taint :  | call to taint :  |
+| call_sensitivity.rb:71:10:71:10 | x | call_sensitivity.rb:121:21:121:28 | call to taint :  | call_sensitivity.rb:71:10:71:10 | x | $@ | call_sensitivity.rb:121:21:121:28 | call to taint :  | call to taint :  |
+| call_sensitivity.rb:71:10:71:10 | x | call_sensitivity.rb:122:26:122:33 | call to taint :  | call_sensitivity.rb:71:10:71:10 | x | $@ | call_sensitivity.rb:122:26:122:33 | call to taint :  | call to taint :  |
+| call_sensitivity.rb:71:10:71:10 | x | call_sensitivity.rb:123:24:123:32 | call to taint :  | call_sensitivity.rb:71:10:71:10 | x | $@ | call_sensitivity.rb:123:24:123:32 | call to taint :  | call to taint :  |
+| call_sensitivity.rb:71:10:71:10 | x | call_sensitivity.rb:124:26:124:33 | call to taint :  | call_sensitivity.rb:71:10:71:10 | x | $@ | call_sensitivity.rb:124:26:124:33 | call to taint :  | call to taint :  |
+| call_sensitivity.rb:105:10:105:10 | x | call_sensitivity.rb:114:12:114:19 | call to taint :  | call_sensitivity.rb:105:10:105:10 | x | $@ | call_sensitivity.rb:114:12:114:19 | call to taint :  | call to taint :  |
+| call_sensitivity.rb:105:10:105:10 | x | call_sensitivity.rb:178:11:178:19 | call to taint :  | call_sensitivity.rb:105:10:105:10 | x | $@ | call_sensitivity.rb:178:11:178:19 | call to taint :  | call to taint :  |
+| call_sensitivity.rb:105:10:105:10 | x | call_sensitivity.rb:187:12:187:19 | call to taint :  | call_sensitivity.rb:105:10:105:10 | x | $@ | call_sensitivity.rb:187:12:187:19 | call to taint :  | call to taint :  |
 mayBenefitFromCallContext
 | call_sensitivity.rb:51:5:51:10 | call to sink | call_sensitivity.rb:50:3:52:5 | method1 |
 | call_sensitivity.rb:55:5:55:13 | call to method1 | call_sensitivity.rb:54:3:56:5 | method2 |
@@ -345,11 +347,12 @@ mayBenefitFromCallContext
 | call_sensitivity.rb:101:5:101:35 | call to singleton_method3 | call_sensitivity.rb:100:3:102:5 | call_singleton_method3 |
 | call_sensitivity.rb:105:5:105:10 | call to sink | call_sensitivity.rb:104:3:107:5 | initialize |
 | call_sensitivity.rb:106:5:106:13 | call to method1 | call_sensitivity.rb:104:3:107:5 | initialize |
-| call_sensitivity.rb:132:5:132:18 | call to method2 | call_sensitivity.rb:131:3:133:5 | call_method2 |
-| call_sensitivity.rb:136:5:136:25 | call to method3 | call_sensitivity.rb:135:3:137:5 | call_method3 |
-| call_sensitivity.rb:144:5:144:28 | call to singleton_method2 | call_sensitivity.rb:143:3:145:5 | call_singleton_method2 |
-| call_sensitivity.rb:148:5:148:35 | call to singleton_method3 | call_sensitivity.rb:147:3:149:5 | call_singleton_method3 |
-| call_sensitivity.rb:169:3:169:12 | call to new | call_sensitivity.rb:168:1:170:3 | create |
+| call_sensitivity.rb:110:5:110:9 | call to new | call_sensitivity.rb:109:3:111:5 | call_new |
+| call_sensitivity.rb:137:5:137:18 | call to method2 | call_sensitivity.rb:136:3:138:5 | call_method2 |
+| call_sensitivity.rb:141:5:141:25 | call to method3 | call_sensitivity.rb:140:3:142:5 | call_method3 |
+| call_sensitivity.rb:149:5:149:28 | call to singleton_method2 | call_sensitivity.rb:148:3:150:5 | call_singleton_method2 |
+| call_sensitivity.rb:153:5:153:35 | call to singleton_method3 | call_sensitivity.rb:152:3:154:5 | call_singleton_method3 |
+| call_sensitivity.rb:175:3:175:12 | call to new | call_sensitivity.rb:174:1:176:3 | create |
 viableImplInCallContext
 | call_sensitivity.rb:51:5:51:10 | call to sink | call_sensitivity.rb:55:5:55:13 | call to method1 | call_sensitivity.rb:5:1:7:3 | sink |
 | call_sensitivity.rb:51:5:51:10 | call to sink | call_sensitivity.rb:63:5:63:16 | call to method1 | call_sensitivity.rb:5:1:7:3 | sink |
@@ -357,45 +360,45 @@ viableImplInCallContext
 | call_sensitivity.rb:51:5:51:10 | call to sink | call_sensitivity.rb:81:5:81:18 | call to method1 | call_sensitivity.rb:5:1:7:3 | sink |
 | call_sensitivity.rb:51:5:51:10 | call to sink | call_sensitivity.rb:106:5:106:13 | call to method1 | call_sensitivity.rb:5:1:7:3 | sink |
 | call_sensitivity.rb:55:5:55:13 | call to method1 | call_sensitivity.rb:59:5:59:18 | call to method2 | call_sensitivity.rb:50:3:52:5 | method1 |
-| call_sensitivity.rb:55:5:55:13 | call to method1 | call_sensitivity.rb:59:5:59:18 | call to method2 | call_sensitivity.rb:123:3:125:5 | method1 |
-| call_sensitivity.rb:55:5:55:13 | call to method1 | call_sensitivity.rb:59:5:59:18 | call to method2 | call_sensitivity.rb:176:3:178:5 | method1 |
-| call_sensitivity.rb:55:5:55:13 | call to method1 | call_sensitivity.rb:111:1:111:19 | call to method2 | call_sensitivity.rb:50:3:52:5 | method1 |
-| call_sensitivity.rb:55:5:55:13 | call to method1 | call_sensitivity.rb:132:5:132:18 | call to method2 | call_sensitivity.rb:123:3:125:5 | method1 |
-| call_sensitivity.rb:55:5:55:13 | call to method1 | call_sensitivity.rb:157:1:157:19 | call to method2 | call_sensitivity.rb:123:3:125:5 | method1 |
-| call_sensitivity.rb:59:5:59:18 | call to method2 | call_sensitivity.rb:112:1:112:24 | call to call_method2 | call_sensitivity.rb:54:3:56:5 | method2 |
+| call_sensitivity.rb:55:5:55:13 | call to method1 | call_sensitivity.rb:59:5:59:18 | call to method2 | call_sensitivity.rb:128:3:130:5 | method1 |
+| call_sensitivity.rb:55:5:55:13 | call to method1 | call_sensitivity.rb:59:5:59:18 | call to method2 | call_sensitivity.rb:182:3:184:5 | method1 |
+| call_sensitivity.rb:55:5:55:13 | call to method1 | call_sensitivity.rb:115:1:115:19 | call to method2 | call_sensitivity.rb:50:3:52:5 | method1 |
+| call_sensitivity.rb:55:5:55:13 | call to method1 | call_sensitivity.rb:137:5:137:18 | call to method2 | call_sensitivity.rb:128:3:130:5 | method1 |
+| call_sensitivity.rb:55:5:55:13 | call to method1 | call_sensitivity.rb:162:1:162:19 | call to method2 | call_sensitivity.rb:128:3:130:5 | method1 |
+| call_sensitivity.rb:59:5:59:18 | call to method2 | call_sensitivity.rb:116:1:116:24 | call to call_method2 | call_sensitivity.rb:54:3:56:5 | method2 |
 | call_sensitivity.rb:63:5:63:16 | call to method1 | call_sensitivity.rb:67:5:67:25 | call to method3 | call_sensitivity.rb:50:3:52:5 | method1 |
-| call_sensitivity.rb:63:5:63:16 | call to method1 | call_sensitivity.rb:67:5:67:25 | call to method3 | call_sensitivity.rb:123:3:125:5 | method1 |
-| call_sensitivity.rb:63:5:63:16 | call to method1 | call_sensitivity.rb:67:5:67:25 | call to method3 | call_sensitivity.rb:176:3:178:5 | method1 |
-| call_sensitivity.rb:63:5:63:16 | call to method1 | call_sensitivity.rb:113:1:113:23 | call to method3 | call_sensitivity.rb:50:3:52:5 | method1 |
-| call_sensitivity.rb:63:5:63:16 | call to method1 | call_sensitivity.rb:136:5:136:25 | call to method3 | call_sensitivity.rb:123:3:125:5 | method1 |
-| call_sensitivity.rb:63:5:63:16 | call to method1 | call_sensitivity.rb:159:1:159:23 | call to method3 | call_sensitivity.rb:123:3:125:5 | method1 |
-| call_sensitivity.rb:67:5:67:25 | call to method3 | call_sensitivity.rb:114:1:114:25 | call to call_method3 | call_sensitivity.rb:62:3:64:5 | method3 |
+| call_sensitivity.rb:63:5:63:16 | call to method1 | call_sensitivity.rb:67:5:67:25 | call to method3 | call_sensitivity.rb:128:3:130:5 | method1 |
+| call_sensitivity.rb:63:5:63:16 | call to method1 | call_sensitivity.rb:67:5:67:25 | call to method3 | call_sensitivity.rb:182:3:184:5 | method1 |
+| call_sensitivity.rb:63:5:63:16 | call to method1 | call_sensitivity.rb:117:1:117:23 | call to method3 | call_sensitivity.rb:50:3:52:5 | method1 |
+| call_sensitivity.rb:63:5:63:16 | call to method1 | call_sensitivity.rb:141:5:141:25 | call to method3 | call_sensitivity.rb:128:3:130:5 | method1 |
+| call_sensitivity.rb:63:5:63:16 | call to method1 | call_sensitivity.rb:164:1:164:23 | call to method3 | call_sensitivity.rb:128:3:130:5 | method1 |
+| call_sensitivity.rb:67:5:67:25 | call to method3 | call_sensitivity.rb:118:1:118:25 | call to call_method3 | call_sensitivity.rb:62:3:64:5 | method3 |
 | call_sensitivity.rb:81:5:81:18 | call to method1 | call_sensitivity.rb:85:5:85:27 | call to method5 | call_sensitivity.rb:50:3:52:5 | method1 |
-| call_sensitivity.rb:81:5:81:18 | call to method1 | call_sensitivity.rb:85:5:85:27 | call to method5 | call_sensitivity.rb:123:3:125:5 | method1 |
-| call_sensitivity.rb:81:5:81:18 | call to method1 | call_sensitivity.rb:85:5:85:27 | call to method5 | call_sensitivity.rb:176:3:178:5 | method1 |
-| call_sensitivity.rb:81:5:81:18 | call to method1 | call_sensitivity.rb:140:5:140:27 | call to method5 | call_sensitivity.rb:123:3:125:5 | method1 |
+| call_sensitivity.rb:81:5:81:18 | call to method1 | call_sensitivity.rb:85:5:85:27 | call to method5 | call_sensitivity.rb:128:3:130:5 | method1 |
+| call_sensitivity.rb:81:5:81:18 | call to method1 | call_sensitivity.rb:85:5:85:27 | call to method5 | call_sensitivity.rb:182:3:184:5 | method1 |
+| call_sensitivity.rb:81:5:81:18 | call to method1 | call_sensitivity.rb:145:5:145:27 | call to method5 | call_sensitivity.rb:128:3:130:5 | method1 |
 | call_sensitivity.rb:89:5:89:23 | call to singleton_method1 | call_sensitivity.rb:93:5:93:28 | call to singleton_method2 | call_sensitivity.rb:70:3:72:5 | singleton_method1 |
-| call_sensitivity.rb:89:5:89:23 | call to singleton_method1 | call_sensitivity.rb:93:5:93:28 | call to singleton_method2 | call_sensitivity.rb:127:3:129:5 | singleton_method1 |
-| call_sensitivity.rb:89:5:89:23 | call to singleton_method1 | call_sensitivity.rb:117:1:117:29 | call to singleton_method2 | call_sensitivity.rb:70:3:72:5 | singleton_method1 |
-| call_sensitivity.rb:89:5:89:23 | call to singleton_method1 | call_sensitivity.rb:144:5:144:28 | call to singleton_method2 | call_sensitivity.rb:127:3:129:5 | singleton_method1 |
-| call_sensitivity.rb:89:5:89:23 | call to singleton_method1 | call_sensitivity.rb:163:1:163:29 | call to singleton_method2 | call_sensitivity.rb:127:3:129:5 | singleton_method1 |
-| call_sensitivity.rb:93:5:93:28 | call to singleton_method2 | call_sensitivity.rb:118:1:118:34 | call to call_singleton_method2 | call_sensitivity.rb:88:3:90:5 | singleton_method2 |
+| call_sensitivity.rb:89:5:89:23 | call to singleton_method1 | call_sensitivity.rb:93:5:93:28 | call to singleton_method2 | call_sensitivity.rb:132:3:134:5 | singleton_method1 |
+| call_sensitivity.rb:89:5:89:23 | call to singleton_method1 | call_sensitivity.rb:121:1:121:29 | call to singleton_method2 | call_sensitivity.rb:70:3:72:5 | singleton_method1 |
+| call_sensitivity.rb:89:5:89:23 | call to singleton_method1 | call_sensitivity.rb:149:5:149:28 | call to singleton_method2 | call_sensitivity.rb:132:3:134:5 | singleton_method1 |
+| call_sensitivity.rb:89:5:89:23 | call to singleton_method1 | call_sensitivity.rb:168:1:168:29 | call to singleton_method2 | call_sensitivity.rb:132:3:134:5 | singleton_method1 |
+| call_sensitivity.rb:93:5:93:28 | call to singleton_method2 | call_sensitivity.rb:122:1:122:34 | call to call_singleton_method2 | call_sensitivity.rb:88:3:90:5 | singleton_method2 |
 | call_sensitivity.rb:97:5:97:26 | call to singleton_method1 | call_sensitivity.rb:101:5:101:35 | call to singleton_method3 | call_sensitivity.rb:70:3:72:5 | singleton_method1 |
-| call_sensitivity.rb:97:5:97:26 | call to singleton_method1 | call_sensitivity.rb:101:5:101:35 | call to singleton_method3 | call_sensitivity.rb:127:3:129:5 | singleton_method1 |
-| call_sensitivity.rb:97:5:97:26 | call to singleton_method1 | call_sensitivity.rb:119:1:119:33 | call to singleton_method3 | call_sensitivity.rb:70:3:72:5 | singleton_method1 |
-| call_sensitivity.rb:97:5:97:26 | call to singleton_method1 | call_sensitivity.rb:148:5:148:35 | call to singleton_method3 | call_sensitivity.rb:127:3:129:5 | singleton_method1 |
-| call_sensitivity.rb:97:5:97:26 | call to singleton_method1 | call_sensitivity.rb:165:1:165:33 | call to singleton_method3 | call_sensitivity.rb:127:3:129:5 | singleton_method1 |
-| call_sensitivity.rb:101:5:101:35 | call to singleton_method3 | call_sensitivity.rb:120:1:120:34 | call to call_singleton_method3 | call_sensitivity.rb:96:3:98:5 | singleton_method3 |
-| call_sensitivity.rb:105:5:105:10 | call to sink | call_sensitivity.rb:110:5:110:20 | call to new | call_sensitivity.rb:5:1:7:3 | sink |
-| call_sensitivity.rb:105:5:105:10 | call to sink | call_sensitivity.rb:169:3:169:12 | call to new | call_sensitivity.rb:5:1:7:3 | sink |
-| call_sensitivity.rb:105:5:105:10 | call to sink | call_sensitivity.rb:181:5:181:20 | call to new | call_sensitivity.rb:5:1:7:3 | sink |
-| call_sensitivity.rb:106:5:106:13 | call to method1 | call_sensitivity.rb:110:5:110:20 | call to new | call_sensitivity.rb:50:3:52:5 | method1 |
-| call_sensitivity.rb:106:5:106:13 | call to method1 | call_sensitivity.rb:169:3:169:12 | call to new | call_sensitivity.rb:50:3:52:5 | method1 |
-| call_sensitivity.rb:106:5:106:13 | call to method1 | call_sensitivity.rb:169:3:169:12 | call to new | call_sensitivity.rb:123:3:125:5 | method1 |
-| call_sensitivity.rb:106:5:106:13 | call to method1 | call_sensitivity.rb:181:5:181:20 | call to new | call_sensitivity.rb:176:3:178:5 | method1 |
-| call_sensitivity.rb:132:5:132:18 | call to method2 | call_sensitivity.rb:158:1:158:24 | call to call_method2 | call_sensitivity.rb:54:3:56:5 | method2 |
-| call_sensitivity.rb:136:5:136:25 | call to method3 | call_sensitivity.rb:160:1:160:25 | call to call_method3 | call_sensitivity.rb:62:3:64:5 | method3 |
-| call_sensitivity.rb:144:5:144:28 | call to singleton_method2 | call_sensitivity.rb:164:1:164:34 | call to call_singleton_method2 | call_sensitivity.rb:88:3:90:5 | singleton_method2 |
-| call_sensitivity.rb:148:5:148:35 | call to singleton_method3 | call_sensitivity.rb:166:1:166:34 | call to call_singleton_method3 | call_sensitivity.rb:96:3:98:5 | singleton_method3 |
-| call_sensitivity.rb:169:3:169:12 | call to new | call_sensitivity.rb:172:1:172:20 | call to create | call_sensitivity.rb:104:3:107:5 | initialize |
-| call_sensitivity.rb:169:3:169:12 | call to new | call_sensitivity.rb:173:1:173:20 | call to create | call_sensitivity.rb:151:3:153:5 | initialize |
+| call_sensitivity.rb:97:5:97:26 | call to singleton_method1 | call_sensitivity.rb:101:5:101:35 | call to singleton_method3 | call_sensitivity.rb:132:3:134:5 | singleton_method1 |
+| call_sensitivity.rb:97:5:97:26 | call to singleton_method1 | call_sensitivity.rb:123:1:123:33 | call to singleton_method3 | call_sensitivity.rb:70:3:72:5 | singleton_method1 |
+| call_sensitivity.rb:97:5:97:26 | call to singleton_method1 | call_sensitivity.rb:153:5:153:35 | call to singleton_method3 | call_sensitivity.rb:132:3:134:5 | singleton_method1 |
+| call_sensitivity.rb:97:5:97:26 | call to singleton_method1 | call_sensitivity.rb:170:1:170:33 | call to singleton_method3 | call_sensitivity.rb:132:3:134:5 | singleton_method1 |
+| call_sensitivity.rb:101:5:101:35 | call to singleton_method3 | call_sensitivity.rb:124:1:124:34 | call to call_singleton_method3 | call_sensitivity.rb:96:3:98:5 | singleton_method3 |
+| call_sensitivity.rb:105:5:105:10 | call to sink | call_sensitivity.rb:114:5:114:20 | call to new | call_sensitivity.rb:5:1:7:3 | sink |
+| call_sensitivity.rb:105:5:105:10 | call to sink | call_sensitivity.rb:175:3:175:12 | call to new | call_sensitivity.rb:5:1:7:3 | sink |
+| call_sensitivity.rb:105:5:105:10 | call to sink | call_sensitivity.rb:187:5:187:20 | call to new | call_sensitivity.rb:5:1:7:3 | sink |
+| call_sensitivity.rb:106:5:106:13 | call to method1 | call_sensitivity.rb:114:5:114:20 | call to new | call_sensitivity.rb:50:3:52:5 | method1 |
+| call_sensitivity.rb:106:5:106:13 | call to method1 | call_sensitivity.rb:175:3:175:12 | call to new | call_sensitivity.rb:50:3:52:5 | method1 |
+| call_sensitivity.rb:106:5:106:13 | call to method1 | call_sensitivity.rb:175:3:175:12 | call to new | call_sensitivity.rb:128:3:130:5 | method1 |
+| call_sensitivity.rb:106:5:106:13 | call to method1 | call_sensitivity.rb:187:5:187:20 | call to new | call_sensitivity.rb:182:3:184:5 | method1 |
+| call_sensitivity.rb:137:5:137:18 | call to method2 | call_sensitivity.rb:163:1:163:24 | call to call_method2 | call_sensitivity.rb:54:3:56:5 | method2 |
+| call_sensitivity.rb:141:5:141:25 | call to method3 | call_sensitivity.rb:165:1:165:25 | call to call_method3 | call_sensitivity.rb:62:3:64:5 | method3 |
+| call_sensitivity.rb:149:5:149:28 | call to singleton_method2 | call_sensitivity.rb:169:1:169:34 | call to call_singleton_method2 | call_sensitivity.rb:88:3:90:5 | singleton_method2 |
+| call_sensitivity.rb:153:5:153:35 | call to singleton_method3 | call_sensitivity.rb:171:1:171:34 | call to call_singleton_method3 | call_sensitivity.rb:96:3:98:5 | singleton_method3 |
+| call_sensitivity.rb:175:3:175:12 | call to new | call_sensitivity.rb:178:1:178:20 | call to create | call_sensitivity.rb:104:3:107:5 | initialize |
+| call_sensitivity.rb:175:3:175:12 | call to new | call_sensitivity.rb:179:1:179:20 | call to create | call_sensitivity.rb:156:3:158:5 | initialize |

--- a/ruby/ql/test/library-tests/dataflow/call-sensitivity/call_sensitivity.rb
+++ b/ruby/ql/test/library-tests/dataflow/call-sensitivity/call_sensitivity.rb
@@ -48,7 +48,7 @@ apply_lambda(MY_LAMBDA2, taint(9))
 
 class A
   def method1 x
-    sink x # $ hasValueFlow=10 $ hasValueFlow=11 $ hasValueFlow=12 $ hasValueFlow=13 $ hasValueFlow=26 $ hasValueFlow=28 $ hasValueFlow=30 $ hasValueFlow=33 $ SPURIOUS: hasValueFlow=27
+    sink x # $ hasValueFlow=10 $ hasValueFlow=11 $ hasValueFlow=12 $ hasValueFlow=13 $ hasValueFlow=26 $ hasValueFlow=28 $ hasValueFlow=30 $ hasValueFlow=33 $ hasValueFlow=35 $ SPURIOUS: hasValueFlow=27
   end
 
   def method2 x
@@ -102,8 +102,12 @@ class A
   end
 
   def initialize(x)
-    sink x # $ hasValueFlow=28 $ hasValueFlow=30 $ hasValueFlow=32
+    sink x # $ hasValueFlow=28 $ hasValueFlow=30 $ hasValueFlow=32 $ hasValueFlow=35
     method1 x
+  end
+
+  def self.call_new x
+    new x
   end
 end
 
@@ -118,6 +122,7 @@ A.singleton_method2(taint 14)
 A.call_singleton_method2(taint 15)
 A.singleton_method3(A, taint(16))
 A.call_singleton_method3(taint 17)
+A.call_new(taint 35)
 
 class B < A
   def method1 x
@@ -164,6 +169,7 @@ B.singleton_method2(taint 22)
 B.call_singleton_method2(taint 23)
 B.singleton_method3(B, taint(24))
 B.call_singleton_method3(taint 25)
+B.call_new(taint 36)
 
 def create (type, x)
   type.new x

--- a/ruby/ql/test/library-tests/dataflow/global/Flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/global/Flow.expected
@@ -1,7 +1,4 @@
 failures
-| instance_variables.rb:36:36:36:54 | # $ hasValueFlow=34 | Missing result:hasValueFlow=34 |
-| instance_variables.rb:39:36:39:54 | # $ hasValueFlow=35 | Missing result:hasValueFlow=35 |
-| instance_variables.rb:49:16:49:34 | # $ hasValueFlow=36 | Missing result:hasValueFlow=36 |
 edges
 | captured_variables.rb:1:24:1:24 | x :  | captured_variables.rb:2:20:2:20 | x |
 | captured_variables.rb:1:24:1:24 | x :  | captured_variables.rb:2:20:2:20 | x |
@@ -47,8 +44,36 @@ edges
 | instance_variables.rb:28:20:28:24 | field :  | instance_variables.rb:22:20:22:24 | field :  |
 | instance_variables.rb:28:20:28:24 | field :  | instance_variables.rb:28:9:28:25 | [post] self [@field] :  |
 | instance_variables.rb:28:20:28:24 | field :  | instance_variables.rb:28:9:28:25 | [post] self [@field] :  |
+| instance_variables.rb:31:18:31:18 | x :  | instance_variables.rb:33:13:33:13 | x :  |
+| instance_variables.rb:31:18:31:18 | x :  | instance_variables.rb:33:13:33:13 | x :  |
+| instance_variables.rb:32:13:32:21 | call to taint :  | instance_variables.rb:22:20:22:24 | field :  |
+| instance_variables.rb:32:13:32:21 | call to taint :  | instance_variables.rb:22:20:22:24 | field :  |
+| instance_variables.rb:32:13:32:21 | call to taint :  | instance_variables.rb:48:20:48:20 | x :  |
+| instance_variables.rb:32:13:32:21 | call to taint :  | instance_variables.rb:48:20:48:20 | x :  |
+| instance_variables.rb:33:13:33:13 | x :  | instance_variables.rb:22:20:22:24 | field :  |
+| instance_variables.rb:33:13:33:13 | x :  | instance_variables.rb:22:20:22:24 | field :  |
+| instance_variables.rb:33:13:33:13 | x :  | instance_variables.rb:33:9:33:14 | call to new [@field] :  |
+| instance_variables.rb:33:13:33:13 | x :  | instance_variables.rb:33:9:33:14 | call to new [@field] :  |
+| instance_variables.rb:36:10:36:23 | call to new [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:36:10:36:23 | call to new [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:36:10:36:23 | call to new [@field] :  | instance_variables.rb:36:10:36:33 | call to get_field |
+| instance_variables.rb:36:10:36:23 | call to new [@field] :  | instance_variables.rb:36:10:36:33 | call to get_field |
+| instance_variables.rb:36:14:36:22 | call to taint :  | instance_variables.rb:22:20:22:24 | field :  |
+| instance_variables.rb:36:14:36:22 | call to taint :  | instance_variables.rb:22:20:22:24 | field :  |
+| instance_variables.rb:36:14:36:22 | call to taint :  | instance_variables.rb:36:10:36:23 | call to new [@field] :  |
+| instance_variables.rb:36:14:36:22 | call to taint :  | instance_variables.rb:36:10:36:23 | call to new [@field] :  |
+| instance_variables.rb:39:6:39:23 | call to bar [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:39:6:39:23 | call to bar [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:39:6:39:23 | call to bar [@field] :  | instance_variables.rb:39:6:39:33 | call to get_field |
+| instance_variables.rb:39:6:39:23 | call to bar [@field] :  | instance_variables.rb:39:6:39:33 | call to get_field |
+| instance_variables.rb:39:14:39:22 | call to taint :  | instance_variables.rb:31:18:31:18 | x :  |
+| instance_variables.rb:39:14:39:22 | call to taint :  | instance_variables.rb:31:18:31:18 | x :  |
+| instance_variables.rb:39:14:39:22 | call to taint :  | instance_variables.rb:39:6:39:23 | call to bar [@field] :  |
+| instance_variables.rb:39:14:39:22 | call to taint :  | instance_variables.rb:39:6:39:23 | call to bar [@field] :  |
 | instance_variables.rb:43:9:43:17 | call to taint :  | instance_variables.rb:121:7:121:24 | call to new :  |
 | instance_variables.rb:43:9:43:17 | call to taint :  | instance_variables.rb:121:7:121:24 | call to new :  |
+| instance_variables.rb:48:20:48:20 | x :  | instance_variables.rb:49:14:49:14 | x |
+| instance_variables.rb:48:20:48:20 | x :  | instance_variables.rb:49:14:49:14 | x |
 | instance_variables.rb:54:1:54:3 | [post] foo [@field] :  | instance_variables.rb:55:6:55:8 | foo [@field] :  |
 | instance_variables.rb:54:1:54:3 | [post] foo [@field] :  | instance_variables.rb:55:6:55:8 | foo [@field] :  |
 | instance_variables.rb:54:15:54:23 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
@@ -263,8 +288,32 @@ nodes
 | instance_variables.rb:28:9:28:25 | call to initialize :  | semmle.label | call to initialize :  |
 | instance_variables.rb:28:20:28:24 | field :  | semmle.label | field :  |
 | instance_variables.rb:28:20:28:24 | field :  | semmle.label | field :  |
+| instance_variables.rb:31:18:31:18 | x :  | semmle.label | x :  |
+| instance_variables.rb:31:18:31:18 | x :  | semmle.label | x :  |
+| instance_variables.rb:32:13:32:21 | call to taint :  | semmle.label | call to taint :  |
+| instance_variables.rb:32:13:32:21 | call to taint :  | semmle.label | call to taint :  |
+| instance_variables.rb:33:9:33:14 | call to new [@field] :  | semmle.label | call to new [@field] :  |
+| instance_variables.rb:33:9:33:14 | call to new [@field] :  | semmle.label | call to new [@field] :  |
+| instance_variables.rb:33:13:33:13 | x :  | semmle.label | x :  |
+| instance_variables.rb:33:13:33:13 | x :  | semmle.label | x :  |
+| instance_variables.rb:36:10:36:23 | call to new [@field] :  | semmle.label | call to new [@field] :  |
+| instance_variables.rb:36:10:36:23 | call to new [@field] :  | semmle.label | call to new [@field] :  |
+| instance_variables.rb:36:10:36:33 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:36:10:36:33 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:36:14:36:22 | call to taint :  | semmle.label | call to taint :  |
+| instance_variables.rb:36:14:36:22 | call to taint :  | semmle.label | call to taint :  |
+| instance_variables.rb:39:6:39:23 | call to bar [@field] :  | semmle.label | call to bar [@field] :  |
+| instance_variables.rb:39:6:39:23 | call to bar [@field] :  | semmle.label | call to bar [@field] :  |
+| instance_variables.rb:39:6:39:33 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:39:6:39:33 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:39:14:39:22 | call to taint :  | semmle.label | call to taint :  |
+| instance_variables.rb:39:14:39:22 | call to taint :  | semmle.label | call to taint :  |
 | instance_variables.rb:43:9:43:17 | call to taint :  | semmle.label | call to taint :  |
 | instance_variables.rb:43:9:43:17 | call to taint :  | semmle.label | call to taint :  |
+| instance_variables.rb:48:20:48:20 | x :  | semmle.label | x :  |
+| instance_variables.rb:48:20:48:20 | x :  | semmle.label | x :  |
+| instance_variables.rb:49:14:49:14 | x | semmle.label | x |
+| instance_variables.rb:49:14:49:14 | x | semmle.label | x |
 | instance_variables.rb:54:1:54:3 | [post] foo [@field] :  | semmle.label | [post] foo [@field] :  |
 | instance_variables.rb:54:1:54:3 | [post] foo [@field] :  | semmle.label | [post] foo [@field] :  |
 | instance_variables.rb:54:15:54:23 | call to taint :  | semmle.label | call to taint :  |
@@ -400,6 +449,16 @@ nodes
 subpaths
 | instance_variables.rb:28:20:28:24 | field :  | instance_variables.rb:22:20:22:24 | field :  | instance_variables.rb:23:9:23:14 | [post] self [@field] :  | instance_variables.rb:28:9:28:25 | [post] self [@field] :  |
 | instance_variables.rb:28:20:28:24 | field :  | instance_variables.rb:22:20:22:24 | field :  | instance_variables.rb:23:9:23:14 | [post] self [@field] :  | instance_variables.rb:28:9:28:25 | [post] self [@field] :  |
+| instance_variables.rb:33:13:33:13 | x :  | instance_variables.rb:22:20:22:24 | field :  | instance_variables.rb:23:9:23:14 | [post] self [@field] :  | instance_variables.rb:33:9:33:14 | call to new [@field] :  |
+| instance_variables.rb:33:13:33:13 | x :  | instance_variables.rb:22:20:22:24 | field :  | instance_variables.rb:23:9:23:14 | [post] self [@field] :  | instance_variables.rb:33:9:33:14 | call to new [@field] :  |
+| instance_variables.rb:36:10:36:23 | call to new [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:36:10:36:33 | call to get_field |
+| instance_variables.rb:36:10:36:23 | call to new [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:36:10:36:33 | call to get_field |
+| instance_variables.rb:36:14:36:22 | call to taint :  | instance_variables.rb:22:20:22:24 | field :  | instance_variables.rb:23:9:23:14 | [post] self [@field] :  | instance_variables.rb:36:10:36:23 | call to new [@field] :  |
+| instance_variables.rb:36:14:36:22 | call to taint :  | instance_variables.rb:22:20:22:24 | field :  | instance_variables.rb:23:9:23:14 | [post] self [@field] :  | instance_variables.rb:36:10:36:23 | call to new [@field] :  |
+| instance_variables.rb:39:6:39:23 | call to bar [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:39:6:39:33 | call to get_field |
+| instance_variables.rb:39:6:39:23 | call to bar [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:39:6:39:33 | call to get_field |
+| instance_variables.rb:39:14:39:22 | call to taint :  | instance_variables.rb:31:18:31:18 | x :  | instance_variables.rb:33:9:33:14 | call to new [@field] :  | instance_variables.rb:39:6:39:23 | call to bar [@field] :  |
+| instance_variables.rb:39:14:39:22 | call to taint :  | instance_variables.rb:31:18:31:18 | x :  | instance_variables.rb:33:9:33:14 | call to new [@field] :  | instance_variables.rb:39:6:39:23 | call to bar [@field] :  |
 | instance_variables.rb:54:15:54:23 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:54:1:54:3 | [post] foo [@field] :  |
 | instance_variables.rb:54:15:54:23 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:54:1:54:3 | [post] foo [@field] :  |
 | instance_variables.rb:55:6:55:8 | foo [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:55:6:55:18 | call to get_field |
@@ -460,6 +519,9 @@ subpaths
 | captured_variables.rb:23:14:23:14 | x | captured_variables.rb:27:29:27:39 | call to source :  | captured_variables.rb:23:14:23:14 | x | $@ | captured_variables.rb:27:29:27:39 | call to source :  | call to source :  |
 | captured_variables.rb:34:14:34:14 | x | captured_variables.rb:38:27:38:37 | call to source :  | captured_variables.rb:34:14:34:14 | x | $@ | captured_variables.rb:38:27:38:37 | call to source :  | call to source :  |
 | instance_variables.rb:20:10:20:13 | @foo | instance_variables.rb:19:12:19:21 | call to taint :  | instance_variables.rb:20:10:20:13 | @foo | $@ | instance_variables.rb:19:12:19:21 | call to taint :  | call to taint :  |
+| instance_variables.rb:36:10:36:33 | call to get_field | instance_variables.rb:36:14:36:22 | call to taint :  | instance_variables.rb:36:10:36:33 | call to get_field | $@ | instance_variables.rb:36:14:36:22 | call to taint :  | call to taint :  |
+| instance_variables.rb:39:6:39:33 | call to get_field | instance_variables.rb:39:14:39:22 | call to taint :  | instance_variables.rb:39:6:39:33 | call to get_field | $@ | instance_variables.rb:39:14:39:22 | call to taint :  | call to taint :  |
+| instance_variables.rb:49:14:49:14 | x | instance_variables.rb:32:13:32:21 | call to taint :  | instance_variables.rb:49:14:49:14 | x | $@ | instance_variables.rb:32:13:32:21 | call to taint :  | call to taint :  |
 | instance_variables.rb:55:6:55:18 | call to get_field | instance_variables.rb:54:15:54:23 | call to taint :  | instance_variables.rb:55:6:55:18 | call to get_field | $@ | instance_variables.rb:54:15:54:23 | call to taint :  | call to taint :  |
 | instance_variables.rb:59:6:59:18 | call to inc_field | instance_variables.rb:58:15:58:22 | call to taint :  | instance_variables.rb:59:6:59:18 | call to inc_field | $@ | instance_variables.rb:58:15:58:22 | call to taint :  | call to taint :  |
 | instance_variables.rb:63:6:63:15 | call to field | instance_variables.rb:62:14:62:22 | call to taint :  | instance_variables.rb:63:6:63:15 | call to field | $@ | instance_variables.rb:62:14:62:22 | call to taint :  | call to taint :  |

--- a/ruby/ql/test/library-tests/dataflow/global/Flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/global/Flow.expected
@@ -1,4 +1,7 @@
 failures
+| instance_variables.rb:36:36:36:54 | # $ hasValueFlow=34 | Missing result:hasValueFlow=34 |
+| instance_variables.rb:39:36:39:54 | # $ hasValueFlow=35 | Missing result:hasValueFlow=35 |
+| instance_variables.rb:49:16:49:34 | # $ hasValueFlow=36 | Missing result:hasValueFlow=36 |
 edges
 | captured_variables.rb:1:24:1:24 | x :  | captured_variables.rb:2:20:2:20 | x |
 | captured_variables.rb:1:24:1:24 | x :  | captured_variables.rb:2:20:2:20 | x |
@@ -38,169 +41,169 @@ edges
 | instance_variables.rb:24:9:24:17 | call to taint :  | instance_variables.rb:28:9:28:25 | call to initialize :  |
 | instance_variables.rb:27:25:27:29 | field :  | instance_variables.rb:28:20:28:24 | field :  |
 | instance_variables.rb:27:25:27:29 | field :  | instance_variables.rb:28:20:28:24 | field :  |
-| instance_variables.rb:28:9:28:25 | call to initialize :  | instance_variables.rb:104:6:104:37 | call to call_initialize |
-| instance_variables.rb:28:9:28:25 | call to initialize :  | instance_variables.rb:104:6:104:37 | call to call_initialize |
+| instance_variables.rb:28:9:28:25 | call to initialize :  | instance_variables.rb:119:6:119:37 | call to call_initialize |
+| instance_variables.rb:28:9:28:25 | call to initialize :  | instance_variables.rb:119:6:119:37 | call to call_initialize |
 | instance_variables.rb:28:20:28:24 | field :  | instance_variables.rb:22:20:22:24 | field :  |
 | instance_variables.rb:28:20:28:24 | field :  | instance_variables.rb:22:20:22:24 | field :  |
 | instance_variables.rb:28:20:28:24 | field :  | instance_variables.rb:28:9:28:25 | [post] self [@field] :  |
 | instance_variables.rb:28:20:28:24 | field :  | instance_variables.rb:28:9:28:25 | [post] self [@field] :  |
-| instance_variables.rb:34:9:34:17 | call to taint :  | instance_variables.rb:106:7:106:24 | call to new :  |
-| instance_variables.rb:34:9:34:17 | call to taint :  | instance_variables.rb:106:7:106:24 | call to new :  |
-| instance_variables.rb:39:1:39:3 | [post] foo [@field] :  | instance_variables.rb:40:6:40:8 | foo [@field] :  |
-| instance_variables.rb:39:1:39:3 | [post] foo [@field] :  | instance_variables.rb:40:6:40:8 | foo [@field] :  |
-| instance_variables.rb:39:15:39:23 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
-| instance_variables.rb:39:15:39:23 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
-| instance_variables.rb:39:15:39:23 | call to taint :  | instance_variables.rb:39:1:39:3 | [post] foo [@field] :  |
-| instance_variables.rb:39:15:39:23 | call to taint :  | instance_variables.rb:39:1:39:3 | [post] foo [@field] :  |
-| instance_variables.rb:40:6:40:8 | foo [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
-| instance_variables.rb:40:6:40:8 | foo [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
-| instance_variables.rb:40:6:40:8 | foo [@field] :  | instance_variables.rb:40:6:40:18 | call to get_field |
-| instance_variables.rb:40:6:40:8 | foo [@field] :  | instance_variables.rb:40:6:40:18 | call to get_field |
-| instance_variables.rb:43:1:43:3 | [post] bar [@field] :  | instance_variables.rb:44:6:44:8 | bar [@field] :  |
-| instance_variables.rb:43:15:43:22 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
-| instance_variables.rb:43:15:43:22 | call to taint :  | instance_variables.rb:43:1:43:3 | [post] bar [@field] :  |
-| instance_variables.rb:44:6:44:8 | bar [@field] :  | instance_variables.rb:16:5:18:7 | self in inc_field [@field] :  |
-| instance_variables.rb:44:6:44:8 | bar [@field] :  | instance_variables.rb:44:6:44:18 | call to inc_field |
-| instance_variables.rb:47:1:47:4 | [post] foo1 [@field] :  | instance_variables.rb:48:6:48:9 | foo1 [@field] :  |
-| instance_variables.rb:47:1:47:4 | [post] foo1 [@field] :  | instance_variables.rb:48:6:48:9 | foo1 [@field] :  |
-| instance_variables.rb:47:14:47:22 | call to taint :  | instance_variables.rb:47:1:47:4 | [post] foo1 [@field] :  |
-| instance_variables.rb:47:14:47:22 | call to taint :  | instance_variables.rb:47:1:47:4 | [post] foo1 [@field] :  |
-| instance_variables.rb:48:6:48:9 | foo1 [@field] :  | instance_variables.rb:48:6:48:15 | call to field |
-| instance_variables.rb:48:6:48:9 | foo1 [@field] :  | instance_variables.rb:48:6:48:15 | call to field |
-| instance_variables.rb:51:1:51:4 | [post] foo2 [@field] :  | instance_variables.rb:52:6:52:9 | foo2 [@field] :  |
-| instance_variables.rb:51:1:51:4 | [post] foo2 [@field] :  | instance_variables.rb:52:6:52:9 | foo2 [@field] :  |
-| instance_variables.rb:51:14:51:22 | call to taint :  | instance_variables.rb:51:1:51:4 | [post] foo2 [@field] :  |
-| instance_variables.rb:51:14:51:22 | call to taint :  | instance_variables.rb:51:1:51:4 | [post] foo2 [@field] :  |
-| instance_variables.rb:52:6:52:9 | foo2 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
-| instance_variables.rb:52:6:52:9 | foo2 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
-| instance_variables.rb:52:6:52:9 | foo2 [@field] :  | instance_variables.rb:52:6:52:19 | call to get_field |
-| instance_variables.rb:52:6:52:9 | foo2 [@field] :  | instance_variables.rb:52:6:52:19 | call to get_field |
-| instance_variables.rb:55:1:55:4 | [post] foo3 [@field] :  | instance_variables.rb:56:6:56:9 | foo3 [@field] :  |
-| instance_variables.rb:55:1:55:4 | [post] foo3 [@field] :  | instance_variables.rb:56:6:56:9 | foo3 [@field] :  |
-| instance_variables.rb:55:1:55:4 | [post] foo3 [@field] :  | instance_variables.rb:68:6:68:9 | foo3 [@field] :  |
-| instance_variables.rb:55:1:55:4 | [post] foo3 [@field] :  | instance_variables.rb:68:6:68:9 | foo3 [@field] :  |
-| instance_variables.rb:55:16:55:24 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
-| instance_variables.rb:55:16:55:24 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
-| instance_variables.rb:55:16:55:24 | call to taint :  | instance_variables.rb:55:1:55:4 | [post] foo3 [@field] :  |
-| instance_variables.rb:55:16:55:24 | call to taint :  | instance_variables.rb:55:1:55:4 | [post] foo3 [@field] :  |
-| instance_variables.rb:56:6:56:9 | foo3 [@field] :  | instance_variables.rb:56:6:56:15 | call to field |
-| instance_variables.rb:56:6:56:9 | foo3 [@field] :  | instance_variables.rb:56:6:56:15 | call to field |
-| instance_variables.rb:63:2:63:5 | [post] foo5 [@field] :  | instance_variables.rb:64:6:64:9 | foo5 [@field] :  |
-| instance_variables.rb:63:2:63:5 | [post] foo5 [@field] :  | instance_variables.rb:64:6:64:9 | foo5 [@field] :  |
-| instance_variables.rb:63:2:63:5 | [post] foo5 [@field] :  | instance_variables.rb:69:6:69:9 | foo5 [@field] :  |
-| instance_variables.rb:63:2:63:5 | [post] foo5 [@field] :  | instance_variables.rb:69:6:69:9 | foo5 [@field] :  |
-| instance_variables.rb:63:18:63:26 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
-| instance_variables.rb:63:18:63:26 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
-| instance_variables.rb:63:18:63:26 | call to taint :  | instance_variables.rb:63:2:63:5 | [post] foo5 [@field] :  |
-| instance_variables.rb:63:18:63:26 | call to taint :  | instance_variables.rb:63:2:63:5 | [post] foo5 [@field] :  |
-| instance_variables.rb:64:6:64:9 | foo5 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
-| instance_variables.rb:64:6:64:9 | foo5 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
-| instance_variables.rb:64:6:64:9 | foo5 [@field] :  | instance_variables.rb:64:6:64:19 | call to get_field |
-| instance_variables.rb:64:6:64:9 | foo5 [@field] :  | instance_variables.rb:64:6:64:19 | call to get_field |
-| instance_variables.rb:67:15:67:18 | [post] foo6 [@field] :  | instance_variables.rb:70:6:70:9 | foo6 [@field] :  |
-| instance_variables.rb:67:15:67:18 | [post] foo6 [@field] :  | instance_variables.rb:70:6:70:9 | foo6 [@field] :  |
-| instance_variables.rb:67:32:67:40 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
-| instance_variables.rb:67:32:67:40 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
-| instance_variables.rb:67:32:67:40 | call to taint :  | instance_variables.rb:67:15:67:18 | [post] foo6 [@field] :  |
-| instance_variables.rb:67:32:67:40 | call to taint :  | instance_variables.rb:67:15:67:18 | [post] foo6 [@field] :  |
-| instance_variables.rb:68:6:68:9 | foo3 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
-| instance_variables.rb:68:6:68:9 | foo3 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
-| instance_variables.rb:68:6:68:9 | foo3 [@field] :  | instance_variables.rb:68:6:68:19 | call to get_field |
-| instance_variables.rb:68:6:68:9 | foo3 [@field] :  | instance_variables.rb:68:6:68:19 | call to get_field |
-| instance_variables.rb:69:6:69:9 | foo5 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
-| instance_variables.rb:69:6:69:9 | foo5 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
-| instance_variables.rb:69:6:69:9 | foo5 [@field] :  | instance_variables.rb:69:6:69:19 | call to get_field |
-| instance_variables.rb:69:6:69:9 | foo5 [@field] :  | instance_variables.rb:69:6:69:19 | call to get_field |
-| instance_variables.rb:70:6:70:9 | foo6 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
-| instance_variables.rb:70:6:70:9 | foo6 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
-| instance_variables.rb:70:6:70:9 | foo6 [@field] :  | instance_variables.rb:70:6:70:19 | call to get_field |
-| instance_variables.rb:70:6:70:9 | foo6 [@field] :  | instance_variables.rb:70:6:70:19 | call to get_field |
-| instance_variables.rb:74:15:74:18 | [post] foo7 [@field] :  | instance_variables.rb:75:6:75:9 | foo7 [@field] :  |
-| instance_variables.rb:74:15:74:18 | [post] foo7 [@field] :  | instance_variables.rb:75:6:75:9 | foo7 [@field] :  |
-| instance_variables.rb:74:25:74:28 | [post] foo8 [@field] :  | instance_variables.rb:76:6:76:9 | foo8 [@field] :  |
-| instance_variables.rb:74:25:74:28 | [post] foo8 [@field] :  | instance_variables.rb:76:6:76:9 | foo8 [@field] :  |
-| instance_variables.rb:74:45:74:53 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
-| instance_variables.rb:74:45:74:53 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
-| instance_variables.rb:74:45:74:53 | call to taint :  | instance_variables.rb:74:15:74:18 | [post] foo7 [@field] :  |
-| instance_variables.rb:74:45:74:53 | call to taint :  | instance_variables.rb:74:15:74:18 | [post] foo7 [@field] :  |
-| instance_variables.rb:74:45:74:53 | call to taint :  | instance_variables.rb:74:25:74:28 | [post] foo8 [@field] :  |
-| instance_variables.rb:74:45:74:53 | call to taint :  | instance_variables.rb:74:25:74:28 | [post] foo8 [@field] :  |
-| instance_variables.rb:75:6:75:9 | foo7 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
-| instance_variables.rb:75:6:75:9 | foo7 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
-| instance_variables.rb:75:6:75:9 | foo7 [@field] :  | instance_variables.rb:75:6:75:19 | call to get_field |
-| instance_variables.rb:75:6:75:9 | foo7 [@field] :  | instance_variables.rb:75:6:75:19 | call to get_field |
-| instance_variables.rb:76:6:76:9 | foo8 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
-| instance_variables.rb:76:6:76:9 | foo8 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
-| instance_variables.rb:76:6:76:9 | foo8 [@field] :  | instance_variables.rb:76:6:76:19 | call to get_field |
-| instance_variables.rb:76:6:76:9 | foo8 [@field] :  | instance_variables.rb:76:6:76:19 | call to get_field |
-| instance_variables.rb:80:22:80:25 | [post] foo9 [@field] :  | instance_variables.rb:81:6:81:9 | foo9 [@field] :  |
-| instance_variables.rb:80:22:80:25 | [post] foo9 [@field] :  | instance_variables.rb:81:6:81:9 | foo9 [@field] :  |
-| instance_variables.rb:80:32:80:36 | [post] foo10 [@field] :  | instance_variables.rb:82:6:82:10 | foo10 [@field] :  |
-| instance_variables.rb:80:32:80:36 | [post] foo10 [@field] :  | instance_variables.rb:82:6:82:10 | foo10 [@field] :  |
-| instance_variables.rb:80:53:80:61 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
-| instance_variables.rb:80:53:80:61 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
-| instance_variables.rb:80:53:80:61 | call to taint :  | instance_variables.rb:80:22:80:25 | [post] foo9 [@field] :  |
-| instance_variables.rb:80:53:80:61 | call to taint :  | instance_variables.rb:80:22:80:25 | [post] foo9 [@field] :  |
-| instance_variables.rb:80:53:80:61 | call to taint :  | instance_variables.rb:80:32:80:36 | [post] foo10 [@field] :  |
-| instance_variables.rb:80:53:80:61 | call to taint :  | instance_variables.rb:80:32:80:36 | [post] foo10 [@field] :  |
-| instance_variables.rb:81:6:81:9 | foo9 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
-| instance_variables.rb:81:6:81:9 | foo9 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
-| instance_variables.rb:81:6:81:9 | foo9 [@field] :  | instance_variables.rb:81:6:81:19 | call to get_field |
-| instance_variables.rb:81:6:81:9 | foo9 [@field] :  | instance_variables.rb:81:6:81:19 | call to get_field |
-| instance_variables.rb:82:6:82:10 | foo10 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
-| instance_variables.rb:82:6:82:10 | foo10 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
-| instance_variables.rb:82:6:82:10 | foo10 [@field] :  | instance_variables.rb:82:6:82:20 | call to get_field |
-| instance_variables.rb:82:6:82:10 | foo10 [@field] :  | instance_variables.rb:82:6:82:20 | call to get_field |
-| instance_variables.rb:85:5:85:5 | [post] x [@field] :  | instance_variables.rb:89:14:89:18 | [post] foo11 [@field] :  |
-| instance_variables.rb:85:5:85:5 | [post] x [@field] :  | instance_variables.rb:89:14:89:18 | [post] foo11 [@field] :  |
-| instance_variables.rb:85:5:85:5 | [post] x [@field] :  | instance_variables.rb:93:15:93:19 | [post] foo12 [@field] :  |
-| instance_variables.rb:85:5:85:5 | [post] x [@field] :  | instance_variables.rb:93:15:93:19 | [post] foo12 [@field] :  |
-| instance_variables.rb:85:5:85:5 | [post] x [@field] :  | instance_variables.rb:98:22:98:26 | [post] foo13 [@field] :  |
-| instance_variables.rb:85:5:85:5 | [post] x [@field] :  | instance_variables.rb:98:22:98:26 | [post] foo13 [@field] :  |
-| instance_variables.rb:85:17:85:25 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
-| instance_variables.rb:85:17:85:25 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
-| instance_variables.rb:85:17:85:25 | call to taint :  | instance_variables.rb:85:5:85:5 | [post] x [@field] :  |
-| instance_variables.rb:85:17:85:25 | call to taint :  | instance_variables.rb:85:5:85:5 | [post] x [@field] :  |
-| instance_variables.rb:89:14:89:18 | [post] foo11 [@field] :  | instance_variables.rb:90:6:90:10 | foo11 [@field] :  |
-| instance_variables.rb:89:14:89:18 | [post] foo11 [@field] :  | instance_variables.rb:90:6:90:10 | foo11 [@field] :  |
-| instance_variables.rb:90:6:90:10 | foo11 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
-| instance_variables.rb:90:6:90:10 | foo11 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
-| instance_variables.rb:90:6:90:10 | foo11 [@field] :  | instance_variables.rb:90:6:90:20 | call to get_field |
-| instance_variables.rb:90:6:90:10 | foo11 [@field] :  | instance_variables.rb:90:6:90:20 | call to get_field |
-| instance_variables.rb:93:15:93:19 | [post] foo12 [@field] :  | instance_variables.rb:94:6:94:10 | foo12 [@field] :  |
-| instance_variables.rb:93:15:93:19 | [post] foo12 [@field] :  | instance_variables.rb:94:6:94:10 | foo12 [@field] :  |
-| instance_variables.rb:94:6:94:10 | foo12 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
-| instance_variables.rb:94:6:94:10 | foo12 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
-| instance_variables.rb:94:6:94:10 | foo12 [@field] :  | instance_variables.rb:94:6:94:20 | call to get_field |
-| instance_variables.rb:94:6:94:10 | foo12 [@field] :  | instance_variables.rb:94:6:94:20 | call to get_field |
-| instance_variables.rb:98:22:98:26 | [post] foo13 [@field] :  | instance_variables.rb:99:6:99:10 | foo13 [@field] :  |
-| instance_variables.rb:98:22:98:26 | [post] foo13 [@field] :  | instance_variables.rb:99:6:99:10 | foo13 [@field] :  |
-| instance_variables.rb:99:6:99:10 | foo13 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
-| instance_variables.rb:99:6:99:10 | foo13 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
-| instance_variables.rb:99:6:99:10 | foo13 [@field] :  | instance_variables.rb:99:6:99:20 | call to get_field |
-| instance_variables.rb:99:6:99:10 | foo13 [@field] :  | instance_variables.rb:99:6:99:20 | call to get_field |
-| instance_variables.rb:101:9:101:26 | call to new [@field] :  | instance_variables.rb:102:6:102:10 | foo15 [@field] :  |
-| instance_variables.rb:101:9:101:26 | call to new [@field] :  | instance_variables.rb:102:6:102:10 | foo15 [@field] :  |
-| instance_variables.rb:101:17:101:25 | call to taint :  | instance_variables.rb:22:20:22:24 | field :  |
-| instance_variables.rb:101:17:101:25 | call to taint :  | instance_variables.rb:22:20:22:24 | field :  |
-| instance_variables.rb:101:17:101:25 | call to taint :  | instance_variables.rb:101:9:101:26 | call to new [@field] :  |
-| instance_variables.rb:101:17:101:25 | call to taint :  | instance_variables.rb:101:9:101:26 | call to new [@field] :  |
-| instance_variables.rb:102:6:102:10 | foo15 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
-| instance_variables.rb:102:6:102:10 | foo15 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
-| instance_variables.rb:102:6:102:10 | foo15 [@field] :  | instance_variables.rb:102:6:102:20 | call to get_field |
-| instance_variables.rb:102:6:102:10 | foo15 [@field] :  | instance_variables.rb:102:6:102:20 | call to get_field |
-| instance_variables.rb:104:6:104:10 | [post] foo16 [@field] :  | instance_variables.rb:105:6:105:10 | foo16 [@field] :  |
-| instance_variables.rb:104:6:104:10 | [post] foo16 [@field] :  | instance_variables.rb:105:6:105:10 | foo16 [@field] :  |
-| instance_variables.rb:104:28:104:36 | call to taint :  | instance_variables.rb:27:25:27:29 | field :  |
-| instance_variables.rb:104:28:104:36 | call to taint :  | instance_variables.rb:27:25:27:29 | field :  |
-| instance_variables.rb:104:28:104:36 | call to taint :  | instance_variables.rb:104:6:104:10 | [post] foo16 [@field] :  |
-| instance_variables.rb:104:28:104:36 | call to taint :  | instance_variables.rb:104:6:104:10 | [post] foo16 [@field] :  |
-| instance_variables.rb:105:6:105:10 | foo16 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
-| instance_variables.rb:105:6:105:10 | foo16 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
-| instance_variables.rb:105:6:105:10 | foo16 [@field] :  | instance_variables.rb:105:6:105:20 | call to get_field |
-| instance_variables.rb:105:6:105:10 | foo16 [@field] :  | instance_variables.rb:105:6:105:20 | call to get_field |
-| instance_variables.rb:106:7:106:24 | call to new :  | instance_variables.rb:107:6:107:8 | bar |
-| instance_variables.rb:106:7:106:24 | call to new :  | instance_variables.rb:107:6:107:8 | bar |
+| instance_variables.rb:43:9:43:17 | call to taint :  | instance_variables.rb:121:7:121:24 | call to new :  |
+| instance_variables.rb:43:9:43:17 | call to taint :  | instance_variables.rb:121:7:121:24 | call to new :  |
+| instance_variables.rb:54:1:54:3 | [post] foo [@field] :  | instance_variables.rb:55:6:55:8 | foo [@field] :  |
+| instance_variables.rb:54:1:54:3 | [post] foo [@field] :  | instance_variables.rb:55:6:55:8 | foo [@field] :  |
+| instance_variables.rb:54:15:54:23 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
+| instance_variables.rb:54:15:54:23 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
+| instance_variables.rb:54:15:54:23 | call to taint :  | instance_variables.rb:54:1:54:3 | [post] foo [@field] :  |
+| instance_variables.rb:54:15:54:23 | call to taint :  | instance_variables.rb:54:1:54:3 | [post] foo [@field] :  |
+| instance_variables.rb:55:6:55:8 | foo [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:55:6:55:8 | foo [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:55:6:55:8 | foo [@field] :  | instance_variables.rb:55:6:55:18 | call to get_field |
+| instance_variables.rb:55:6:55:8 | foo [@field] :  | instance_variables.rb:55:6:55:18 | call to get_field |
+| instance_variables.rb:58:1:58:3 | [post] bar [@field] :  | instance_variables.rb:59:6:59:8 | bar [@field] :  |
+| instance_variables.rb:58:15:58:22 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
+| instance_variables.rb:58:15:58:22 | call to taint :  | instance_variables.rb:58:1:58:3 | [post] bar [@field] :  |
+| instance_variables.rb:59:6:59:8 | bar [@field] :  | instance_variables.rb:16:5:18:7 | self in inc_field [@field] :  |
+| instance_variables.rb:59:6:59:8 | bar [@field] :  | instance_variables.rb:59:6:59:18 | call to inc_field |
+| instance_variables.rb:62:1:62:4 | [post] foo1 [@field] :  | instance_variables.rb:63:6:63:9 | foo1 [@field] :  |
+| instance_variables.rb:62:1:62:4 | [post] foo1 [@field] :  | instance_variables.rb:63:6:63:9 | foo1 [@field] :  |
+| instance_variables.rb:62:14:62:22 | call to taint :  | instance_variables.rb:62:1:62:4 | [post] foo1 [@field] :  |
+| instance_variables.rb:62:14:62:22 | call to taint :  | instance_variables.rb:62:1:62:4 | [post] foo1 [@field] :  |
+| instance_variables.rb:63:6:63:9 | foo1 [@field] :  | instance_variables.rb:63:6:63:15 | call to field |
+| instance_variables.rb:63:6:63:9 | foo1 [@field] :  | instance_variables.rb:63:6:63:15 | call to field |
+| instance_variables.rb:66:1:66:4 | [post] foo2 [@field] :  | instance_variables.rb:67:6:67:9 | foo2 [@field] :  |
+| instance_variables.rb:66:1:66:4 | [post] foo2 [@field] :  | instance_variables.rb:67:6:67:9 | foo2 [@field] :  |
+| instance_variables.rb:66:14:66:22 | call to taint :  | instance_variables.rb:66:1:66:4 | [post] foo2 [@field] :  |
+| instance_variables.rb:66:14:66:22 | call to taint :  | instance_variables.rb:66:1:66:4 | [post] foo2 [@field] :  |
+| instance_variables.rb:67:6:67:9 | foo2 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:67:6:67:9 | foo2 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:67:6:67:9 | foo2 [@field] :  | instance_variables.rb:67:6:67:19 | call to get_field |
+| instance_variables.rb:67:6:67:9 | foo2 [@field] :  | instance_variables.rb:67:6:67:19 | call to get_field |
+| instance_variables.rb:70:1:70:4 | [post] foo3 [@field] :  | instance_variables.rb:71:6:71:9 | foo3 [@field] :  |
+| instance_variables.rb:70:1:70:4 | [post] foo3 [@field] :  | instance_variables.rb:71:6:71:9 | foo3 [@field] :  |
+| instance_variables.rb:70:1:70:4 | [post] foo3 [@field] :  | instance_variables.rb:83:6:83:9 | foo3 [@field] :  |
+| instance_variables.rb:70:1:70:4 | [post] foo3 [@field] :  | instance_variables.rb:83:6:83:9 | foo3 [@field] :  |
+| instance_variables.rb:70:16:70:24 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
+| instance_variables.rb:70:16:70:24 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
+| instance_variables.rb:70:16:70:24 | call to taint :  | instance_variables.rb:70:1:70:4 | [post] foo3 [@field] :  |
+| instance_variables.rb:70:16:70:24 | call to taint :  | instance_variables.rb:70:1:70:4 | [post] foo3 [@field] :  |
+| instance_variables.rb:71:6:71:9 | foo3 [@field] :  | instance_variables.rb:71:6:71:15 | call to field |
+| instance_variables.rb:71:6:71:9 | foo3 [@field] :  | instance_variables.rb:71:6:71:15 | call to field |
+| instance_variables.rb:78:2:78:5 | [post] foo5 [@field] :  | instance_variables.rb:79:6:79:9 | foo5 [@field] :  |
+| instance_variables.rb:78:2:78:5 | [post] foo5 [@field] :  | instance_variables.rb:79:6:79:9 | foo5 [@field] :  |
+| instance_variables.rb:78:2:78:5 | [post] foo5 [@field] :  | instance_variables.rb:84:6:84:9 | foo5 [@field] :  |
+| instance_variables.rb:78:2:78:5 | [post] foo5 [@field] :  | instance_variables.rb:84:6:84:9 | foo5 [@field] :  |
+| instance_variables.rb:78:18:78:26 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
+| instance_variables.rb:78:18:78:26 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
+| instance_variables.rb:78:18:78:26 | call to taint :  | instance_variables.rb:78:2:78:5 | [post] foo5 [@field] :  |
+| instance_variables.rb:78:18:78:26 | call to taint :  | instance_variables.rb:78:2:78:5 | [post] foo5 [@field] :  |
+| instance_variables.rb:79:6:79:9 | foo5 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:79:6:79:9 | foo5 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:79:6:79:9 | foo5 [@field] :  | instance_variables.rb:79:6:79:19 | call to get_field |
+| instance_variables.rb:79:6:79:9 | foo5 [@field] :  | instance_variables.rb:79:6:79:19 | call to get_field |
+| instance_variables.rb:82:15:82:18 | [post] foo6 [@field] :  | instance_variables.rb:85:6:85:9 | foo6 [@field] :  |
+| instance_variables.rb:82:15:82:18 | [post] foo6 [@field] :  | instance_variables.rb:85:6:85:9 | foo6 [@field] :  |
+| instance_variables.rb:82:32:82:40 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
+| instance_variables.rb:82:32:82:40 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
+| instance_variables.rb:82:32:82:40 | call to taint :  | instance_variables.rb:82:15:82:18 | [post] foo6 [@field] :  |
+| instance_variables.rb:82:32:82:40 | call to taint :  | instance_variables.rb:82:15:82:18 | [post] foo6 [@field] :  |
+| instance_variables.rb:83:6:83:9 | foo3 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:83:6:83:9 | foo3 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:83:6:83:9 | foo3 [@field] :  | instance_variables.rb:83:6:83:19 | call to get_field |
+| instance_variables.rb:83:6:83:9 | foo3 [@field] :  | instance_variables.rb:83:6:83:19 | call to get_field |
+| instance_variables.rb:84:6:84:9 | foo5 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:84:6:84:9 | foo5 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:84:6:84:9 | foo5 [@field] :  | instance_variables.rb:84:6:84:19 | call to get_field |
+| instance_variables.rb:84:6:84:9 | foo5 [@field] :  | instance_variables.rb:84:6:84:19 | call to get_field |
+| instance_variables.rb:85:6:85:9 | foo6 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:85:6:85:9 | foo6 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:85:6:85:9 | foo6 [@field] :  | instance_variables.rb:85:6:85:19 | call to get_field |
+| instance_variables.rb:85:6:85:9 | foo6 [@field] :  | instance_variables.rb:85:6:85:19 | call to get_field |
+| instance_variables.rb:89:15:89:18 | [post] foo7 [@field] :  | instance_variables.rb:90:6:90:9 | foo7 [@field] :  |
+| instance_variables.rb:89:15:89:18 | [post] foo7 [@field] :  | instance_variables.rb:90:6:90:9 | foo7 [@field] :  |
+| instance_variables.rb:89:25:89:28 | [post] foo8 [@field] :  | instance_variables.rb:91:6:91:9 | foo8 [@field] :  |
+| instance_variables.rb:89:25:89:28 | [post] foo8 [@field] :  | instance_variables.rb:91:6:91:9 | foo8 [@field] :  |
+| instance_variables.rb:89:45:89:53 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
+| instance_variables.rb:89:45:89:53 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
+| instance_variables.rb:89:45:89:53 | call to taint :  | instance_variables.rb:89:15:89:18 | [post] foo7 [@field] :  |
+| instance_variables.rb:89:45:89:53 | call to taint :  | instance_variables.rb:89:15:89:18 | [post] foo7 [@field] :  |
+| instance_variables.rb:89:45:89:53 | call to taint :  | instance_variables.rb:89:25:89:28 | [post] foo8 [@field] :  |
+| instance_variables.rb:89:45:89:53 | call to taint :  | instance_variables.rb:89:25:89:28 | [post] foo8 [@field] :  |
+| instance_variables.rb:90:6:90:9 | foo7 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:90:6:90:9 | foo7 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:90:6:90:9 | foo7 [@field] :  | instance_variables.rb:90:6:90:19 | call to get_field |
+| instance_variables.rb:90:6:90:9 | foo7 [@field] :  | instance_variables.rb:90:6:90:19 | call to get_field |
+| instance_variables.rb:91:6:91:9 | foo8 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:91:6:91:9 | foo8 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:91:6:91:9 | foo8 [@field] :  | instance_variables.rb:91:6:91:19 | call to get_field |
+| instance_variables.rb:91:6:91:9 | foo8 [@field] :  | instance_variables.rb:91:6:91:19 | call to get_field |
+| instance_variables.rb:95:22:95:25 | [post] foo9 [@field] :  | instance_variables.rb:96:6:96:9 | foo9 [@field] :  |
+| instance_variables.rb:95:22:95:25 | [post] foo9 [@field] :  | instance_variables.rb:96:6:96:9 | foo9 [@field] :  |
+| instance_variables.rb:95:32:95:36 | [post] foo10 [@field] :  | instance_variables.rb:97:6:97:10 | foo10 [@field] :  |
+| instance_variables.rb:95:32:95:36 | [post] foo10 [@field] :  | instance_variables.rb:97:6:97:10 | foo10 [@field] :  |
+| instance_variables.rb:95:53:95:61 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
+| instance_variables.rb:95:53:95:61 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
+| instance_variables.rb:95:53:95:61 | call to taint :  | instance_variables.rb:95:22:95:25 | [post] foo9 [@field] :  |
+| instance_variables.rb:95:53:95:61 | call to taint :  | instance_variables.rb:95:22:95:25 | [post] foo9 [@field] :  |
+| instance_variables.rb:95:53:95:61 | call to taint :  | instance_variables.rb:95:32:95:36 | [post] foo10 [@field] :  |
+| instance_variables.rb:95:53:95:61 | call to taint :  | instance_variables.rb:95:32:95:36 | [post] foo10 [@field] :  |
+| instance_variables.rb:96:6:96:9 | foo9 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:96:6:96:9 | foo9 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:96:6:96:9 | foo9 [@field] :  | instance_variables.rb:96:6:96:19 | call to get_field |
+| instance_variables.rb:96:6:96:9 | foo9 [@field] :  | instance_variables.rb:96:6:96:19 | call to get_field |
+| instance_variables.rb:97:6:97:10 | foo10 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:97:6:97:10 | foo10 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:97:6:97:10 | foo10 [@field] :  | instance_variables.rb:97:6:97:20 | call to get_field |
+| instance_variables.rb:97:6:97:10 | foo10 [@field] :  | instance_variables.rb:97:6:97:20 | call to get_field |
+| instance_variables.rb:100:5:100:5 | [post] x [@field] :  | instance_variables.rb:104:14:104:18 | [post] foo11 [@field] :  |
+| instance_variables.rb:100:5:100:5 | [post] x [@field] :  | instance_variables.rb:104:14:104:18 | [post] foo11 [@field] :  |
+| instance_variables.rb:100:5:100:5 | [post] x [@field] :  | instance_variables.rb:108:15:108:19 | [post] foo12 [@field] :  |
+| instance_variables.rb:100:5:100:5 | [post] x [@field] :  | instance_variables.rb:108:15:108:19 | [post] foo12 [@field] :  |
+| instance_variables.rb:100:5:100:5 | [post] x [@field] :  | instance_variables.rb:113:22:113:26 | [post] foo13 [@field] :  |
+| instance_variables.rb:100:5:100:5 | [post] x [@field] :  | instance_variables.rb:113:22:113:26 | [post] foo13 [@field] :  |
+| instance_variables.rb:100:17:100:25 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
+| instance_variables.rb:100:17:100:25 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  |
+| instance_variables.rb:100:17:100:25 | call to taint :  | instance_variables.rb:100:5:100:5 | [post] x [@field] :  |
+| instance_variables.rb:100:17:100:25 | call to taint :  | instance_variables.rb:100:5:100:5 | [post] x [@field] :  |
+| instance_variables.rb:104:14:104:18 | [post] foo11 [@field] :  | instance_variables.rb:105:6:105:10 | foo11 [@field] :  |
+| instance_variables.rb:104:14:104:18 | [post] foo11 [@field] :  | instance_variables.rb:105:6:105:10 | foo11 [@field] :  |
+| instance_variables.rb:105:6:105:10 | foo11 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:105:6:105:10 | foo11 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:105:6:105:10 | foo11 [@field] :  | instance_variables.rb:105:6:105:20 | call to get_field |
+| instance_variables.rb:105:6:105:10 | foo11 [@field] :  | instance_variables.rb:105:6:105:20 | call to get_field |
+| instance_variables.rb:108:15:108:19 | [post] foo12 [@field] :  | instance_variables.rb:109:6:109:10 | foo12 [@field] :  |
+| instance_variables.rb:108:15:108:19 | [post] foo12 [@field] :  | instance_variables.rb:109:6:109:10 | foo12 [@field] :  |
+| instance_variables.rb:109:6:109:10 | foo12 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:109:6:109:10 | foo12 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:109:6:109:10 | foo12 [@field] :  | instance_variables.rb:109:6:109:20 | call to get_field |
+| instance_variables.rb:109:6:109:10 | foo12 [@field] :  | instance_variables.rb:109:6:109:20 | call to get_field |
+| instance_variables.rb:113:22:113:26 | [post] foo13 [@field] :  | instance_variables.rb:114:6:114:10 | foo13 [@field] :  |
+| instance_variables.rb:113:22:113:26 | [post] foo13 [@field] :  | instance_variables.rb:114:6:114:10 | foo13 [@field] :  |
+| instance_variables.rb:114:6:114:10 | foo13 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:114:6:114:10 | foo13 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:114:6:114:10 | foo13 [@field] :  | instance_variables.rb:114:6:114:20 | call to get_field |
+| instance_variables.rb:114:6:114:10 | foo13 [@field] :  | instance_variables.rb:114:6:114:20 | call to get_field |
+| instance_variables.rb:116:9:116:26 | call to new [@field] :  | instance_variables.rb:117:6:117:10 | foo15 [@field] :  |
+| instance_variables.rb:116:9:116:26 | call to new [@field] :  | instance_variables.rb:117:6:117:10 | foo15 [@field] :  |
+| instance_variables.rb:116:17:116:25 | call to taint :  | instance_variables.rb:22:20:22:24 | field :  |
+| instance_variables.rb:116:17:116:25 | call to taint :  | instance_variables.rb:22:20:22:24 | field :  |
+| instance_variables.rb:116:17:116:25 | call to taint :  | instance_variables.rb:116:9:116:26 | call to new [@field] :  |
+| instance_variables.rb:116:17:116:25 | call to taint :  | instance_variables.rb:116:9:116:26 | call to new [@field] :  |
+| instance_variables.rb:117:6:117:10 | foo15 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:117:6:117:10 | foo15 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:117:6:117:10 | foo15 [@field] :  | instance_variables.rb:117:6:117:20 | call to get_field |
+| instance_variables.rb:117:6:117:10 | foo15 [@field] :  | instance_variables.rb:117:6:117:20 | call to get_field |
+| instance_variables.rb:119:6:119:10 | [post] foo16 [@field] :  | instance_variables.rb:120:6:120:10 | foo16 [@field] :  |
+| instance_variables.rb:119:6:119:10 | [post] foo16 [@field] :  | instance_variables.rb:120:6:120:10 | foo16 [@field] :  |
+| instance_variables.rb:119:28:119:36 | call to taint :  | instance_variables.rb:27:25:27:29 | field :  |
+| instance_variables.rb:119:28:119:36 | call to taint :  | instance_variables.rb:27:25:27:29 | field :  |
+| instance_variables.rb:119:28:119:36 | call to taint :  | instance_variables.rb:119:6:119:10 | [post] foo16 [@field] :  |
+| instance_variables.rb:119:28:119:36 | call to taint :  | instance_variables.rb:119:6:119:10 | [post] foo16 [@field] :  |
+| instance_variables.rb:120:6:120:10 | foo16 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:120:6:120:10 | foo16 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
+| instance_variables.rb:120:6:120:10 | foo16 [@field] :  | instance_variables.rb:120:6:120:20 | call to get_field |
+| instance_variables.rb:120:6:120:10 | foo16 [@field] :  | instance_variables.rb:120:6:120:20 | call to get_field |
+| instance_variables.rb:121:7:121:24 | call to new :  | instance_variables.rb:122:6:122:8 | bar |
+| instance_variables.rb:121:7:121:24 | call to new :  | instance_variables.rb:122:6:122:8 | bar |
 nodes
 | captured_variables.rb:1:24:1:24 | x :  | semmle.label | x :  |
 | captured_variables.rb:1:24:1:24 | x :  | semmle.label | x :  |
@@ -260,220 +263,220 @@ nodes
 | instance_variables.rb:28:9:28:25 | call to initialize :  | semmle.label | call to initialize :  |
 | instance_variables.rb:28:20:28:24 | field :  | semmle.label | field :  |
 | instance_variables.rb:28:20:28:24 | field :  | semmle.label | field :  |
-| instance_variables.rb:34:9:34:17 | call to taint :  | semmle.label | call to taint :  |
-| instance_variables.rb:34:9:34:17 | call to taint :  | semmle.label | call to taint :  |
-| instance_variables.rb:39:1:39:3 | [post] foo [@field] :  | semmle.label | [post] foo [@field] :  |
-| instance_variables.rb:39:1:39:3 | [post] foo [@field] :  | semmle.label | [post] foo [@field] :  |
-| instance_variables.rb:39:15:39:23 | call to taint :  | semmle.label | call to taint :  |
-| instance_variables.rb:39:15:39:23 | call to taint :  | semmle.label | call to taint :  |
-| instance_variables.rb:40:6:40:8 | foo [@field] :  | semmle.label | foo [@field] :  |
-| instance_variables.rb:40:6:40:8 | foo [@field] :  | semmle.label | foo [@field] :  |
-| instance_variables.rb:40:6:40:18 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:40:6:40:18 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:43:1:43:3 | [post] bar [@field] :  | semmle.label | [post] bar [@field] :  |
-| instance_variables.rb:43:15:43:22 | call to taint :  | semmle.label | call to taint :  |
-| instance_variables.rb:44:6:44:8 | bar [@field] :  | semmle.label | bar [@field] :  |
-| instance_variables.rb:44:6:44:18 | call to inc_field | semmle.label | call to inc_field |
-| instance_variables.rb:47:1:47:4 | [post] foo1 [@field] :  | semmle.label | [post] foo1 [@field] :  |
-| instance_variables.rb:47:1:47:4 | [post] foo1 [@field] :  | semmle.label | [post] foo1 [@field] :  |
-| instance_variables.rb:47:14:47:22 | call to taint :  | semmle.label | call to taint :  |
-| instance_variables.rb:47:14:47:22 | call to taint :  | semmle.label | call to taint :  |
-| instance_variables.rb:48:6:48:9 | foo1 [@field] :  | semmle.label | foo1 [@field] :  |
-| instance_variables.rb:48:6:48:9 | foo1 [@field] :  | semmle.label | foo1 [@field] :  |
-| instance_variables.rb:48:6:48:15 | call to field | semmle.label | call to field |
-| instance_variables.rb:48:6:48:15 | call to field | semmle.label | call to field |
-| instance_variables.rb:51:1:51:4 | [post] foo2 [@field] :  | semmle.label | [post] foo2 [@field] :  |
-| instance_variables.rb:51:1:51:4 | [post] foo2 [@field] :  | semmle.label | [post] foo2 [@field] :  |
-| instance_variables.rb:51:14:51:22 | call to taint :  | semmle.label | call to taint :  |
-| instance_variables.rb:51:14:51:22 | call to taint :  | semmle.label | call to taint :  |
-| instance_variables.rb:52:6:52:9 | foo2 [@field] :  | semmle.label | foo2 [@field] :  |
-| instance_variables.rb:52:6:52:9 | foo2 [@field] :  | semmle.label | foo2 [@field] :  |
-| instance_variables.rb:52:6:52:19 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:52:6:52:19 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:55:1:55:4 | [post] foo3 [@field] :  | semmle.label | [post] foo3 [@field] :  |
-| instance_variables.rb:55:1:55:4 | [post] foo3 [@field] :  | semmle.label | [post] foo3 [@field] :  |
-| instance_variables.rb:55:16:55:24 | call to taint :  | semmle.label | call to taint :  |
-| instance_variables.rb:55:16:55:24 | call to taint :  | semmle.label | call to taint :  |
-| instance_variables.rb:56:6:56:9 | foo3 [@field] :  | semmle.label | foo3 [@field] :  |
-| instance_variables.rb:56:6:56:9 | foo3 [@field] :  | semmle.label | foo3 [@field] :  |
-| instance_variables.rb:56:6:56:15 | call to field | semmle.label | call to field |
-| instance_variables.rb:56:6:56:15 | call to field | semmle.label | call to field |
-| instance_variables.rb:63:2:63:5 | [post] foo5 [@field] :  | semmle.label | [post] foo5 [@field] :  |
-| instance_variables.rb:63:2:63:5 | [post] foo5 [@field] :  | semmle.label | [post] foo5 [@field] :  |
-| instance_variables.rb:63:18:63:26 | call to taint :  | semmle.label | call to taint :  |
-| instance_variables.rb:63:18:63:26 | call to taint :  | semmle.label | call to taint :  |
-| instance_variables.rb:64:6:64:9 | foo5 [@field] :  | semmle.label | foo5 [@field] :  |
-| instance_variables.rb:64:6:64:9 | foo5 [@field] :  | semmle.label | foo5 [@field] :  |
-| instance_variables.rb:64:6:64:19 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:64:6:64:19 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:67:15:67:18 | [post] foo6 [@field] :  | semmle.label | [post] foo6 [@field] :  |
-| instance_variables.rb:67:15:67:18 | [post] foo6 [@field] :  | semmle.label | [post] foo6 [@field] :  |
-| instance_variables.rb:67:32:67:40 | call to taint :  | semmle.label | call to taint :  |
-| instance_variables.rb:67:32:67:40 | call to taint :  | semmle.label | call to taint :  |
-| instance_variables.rb:68:6:68:9 | foo3 [@field] :  | semmle.label | foo3 [@field] :  |
-| instance_variables.rb:68:6:68:9 | foo3 [@field] :  | semmle.label | foo3 [@field] :  |
-| instance_variables.rb:68:6:68:19 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:68:6:68:19 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:69:6:69:9 | foo5 [@field] :  | semmle.label | foo5 [@field] :  |
-| instance_variables.rb:69:6:69:9 | foo5 [@field] :  | semmle.label | foo5 [@field] :  |
-| instance_variables.rb:69:6:69:19 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:69:6:69:19 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:70:6:70:9 | foo6 [@field] :  | semmle.label | foo6 [@field] :  |
-| instance_variables.rb:70:6:70:9 | foo6 [@field] :  | semmle.label | foo6 [@field] :  |
-| instance_variables.rb:70:6:70:19 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:70:6:70:19 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:74:15:74:18 | [post] foo7 [@field] :  | semmle.label | [post] foo7 [@field] :  |
-| instance_variables.rb:74:15:74:18 | [post] foo7 [@field] :  | semmle.label | [post] foo7 [@field] :  |
-| instance_variables.rb:74:25:74:28 | [post] foo8 [@field] :  | semmle.label | [post] foo8 [@field] :  |
-| instance_variables.rb:74:25:74:28 | [post] foo8 [@field] :  | semmle.label | [post] foo8 [@field] :  |
-| instance_variables.rb:74:45:74:53 | call to taint :  | semmle.label | call to taint :  |
-| instance_variables.rb:74:45:74:53 | call to taint :  | semmle.label | call to taint :  |
-| instance_variables.rb:75:6:75:9 | foo7 [@field] :  | semmle.label | foo7 [@field] :  |
-| instance_variables.rb:75:6:75:9 | foo7 [@field] :  | semmle.label | foo7 [@field] :  |
-| instance_variables.rb:75:6:75:19 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:75:6:75:19 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:76:6:76:9 | foo8 [@field] :  | semmle.label | foo8 [@field] :  |
-| instance_variables.rb:76:6:76:9 | foo8 [@field] :  | semmle.label | foo8 [@field] :  |
-| instance_variables.rb:76:6:76:19 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:76:6:76:19 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:80:22:80:25 | [post] foo9 [@field] :  | semmle.label | [post] foo9 [@field] :  |
-| instance_variables.rb:80:22:80:25 | [post] foo9 [@field] :  | semmle.label | [post] foo9 [@field] :  |
-| instance_variables.rb:80:32:80:36 | [post] foo10 [@field] :  | semmle.label | [post] foo10 [@field] :  |
-| instance_variables.rb:80:32:80:36 | [post] foo10 [@field] :  | semmle.label | [post] foo10 [@field] :  |
-| instance_variables.rb:80:53:80:61 | call to taint :  | semmle.label | call to taint :  |
-| instance_variables.rb:80:53:80:61 | call to taint :  | semmle.label | call to taint :  |
-| instance_variables.rb:81:6:81:9 | foo9 [@field] :  | semmle.label | foo9 [@field] :  |
-| instance_variables.rb:81:6:81:9 | foo9 [@field] :  | semmle.label | foo9 [@field] :  |
-| instance_variables.rb:81:6:81:19 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:81:6:81:19 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:82:6:82:10 | foo10 [@field] :  | semmle.label | foo10 [@field] :  |
-| instance_variables.rb:82:6:82:10 | foo10 [@field] :  | semmle.label | foo10 [@field] :  |
-| instance_variables.rb:82:6:82:20 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:82:6:82:20 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:85:5:85:5 | [post] x [@field] :  | semmle.label | [post] x [@field] :  |
-| instance_variables.rb:85:5:85:5 | [post] x [@field] :  | semmle.label | [post] x [@field] :  |
-| instance_variables.rb:85:17:85:25 | call to taint :  | semmle.label | call to taint :  |
-| instance_variables.rb:85:17:85:25 | call to taint :  | semmle.label | call to taint :  |
-| instance_variables.rb:89:14:89:18 | [post] foo11 [@field] :  | semmle.label | [post] foo11 [@field] :  |
-| instance_variables.rb:89:14:89:18 | [post] foo11 [@field] :  | semmle.label | [post] foo11 [@field] :  |
-| instance_variables.rb:90:6:90:10 | foo11 [@field] :  | semmle.label | foo11 [@field] :  |
-| instance_variables.rb:90:6:90:10 | foo11 [@field] :  | semmle.label | foo11 [@field] :  |
-| instance_variables.rb:90:6:90:20 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:90:6:90:20 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:93:15:93:19 | [post] foo12 [@field] :  | semmle.label | [post] foo12 [@field] :  |
-| instance_variables.rb:93:15:93:19 | [post] foo12 [@field] :  | semmle.label | [post] foo12 [@field] :  |
-| instance_variables.rb:94:6:94:10 | foo12 [@field] :  | semmle.label | foo12 [@field] :  |
-| instance_variables.rb:94:6:94:10 | foo12 [@field] :  | semmle.label | foo12 [@field] :  |
-| instance_variables.rb:94:6:94:20 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:94:6:94:20 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:98:22:98:26 | [post] foo13 [@field] :  | semmle.label | [post] foo13 [@field] :  |
-| instance_variables.rb:98:22:98:26 | [post] foo13 [@field] :  | semmle.label | [post] foo13 [@field] :  |
-| instance_variables.rb:99:6:99:10 | foo13 [@field] :  | semmle.label | foo13 [@field] :  |
-| instance_variables.rb:99:6:99:10 | foo13 [@field] :  | semmle.label | foo13 [@field] :  |
-| instance_variables.rb:99:6:99:20 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:99:6:99:20 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:101:9:101:26 | call to new [@field] :  | semmle.label | call to new [@field] :  |
-| instance_variables.rb:101:9:101:26 | call to new [@field] :  | semmle.label | call to new [@field] :  |
-| instance_variables.rb:101:17:101:25 | call to taint :  | semmle.label | call to taint :  |
-| instance_variables.rb:101:17:101:25 | call to taint :  | semmle.label | call to taint :  |
-| instance_variables.rb:102:6:102:10 | foo15 [@field] :  | semmle.label | foo15 [@field] :  |
-| instance_variables.rb:102:6:102:10 | foo15 [@field] :  | semmle.label | foo15 [@field] :  |
-| instance_variables.rb:102:6:102:20 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:102:6:102:20 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:104:6:104:10 | [post] foo16 [@field] :  | semmle.label | [post] foo16 [@field] :  |
-| instance_variables.rb:104:6:104:10 | [post] foo16 [@field] :  | semmle.label | [post] foo16 [@field] :  |
-| instance_variables.rb:104:6:104:37 | call to call_initialize | semmle.label | call to call_initialize |
-| instance_variables.rb:104:6:104:37 | call to call_initialize | semmle.label | call to call_initialize |
-| instance_variables.rb:104:28:104:36 | call to taint :  | semmle.label | call to taint :  |
-| instance_variables.rb:104:28:104:36 | call to taint :  | semmle.label | call to taint :  |
-| instance_variables.rb:105:6:105:10 | foo16 [@field] :  | semmle.label | foo16 [@field] :  |
-| instance_variables.rb:105:6:105:10 | foo16 [@field] :  | semmle.label | foo16 [@field] :  |
+| instance_variables.rb:43:9:43:17 | call to taint :  | semmle.label | call to taint :  |
+| instance_variables.rb:43:9:43:17 | call to taint :  | semmle.label | call to taint :  |
+| instance_variables.rb:54:1:54:3 | [post] foo [@field] :  | semmle.label | [post] foo [@field] :  |
+| instance_variables.rb:54:1:54:3 | [post] foo [@field] :  | semmle.label | [post] foo [@field] :  |
+| instance_variables.rb:54:15:54:23 | call to taint :  | semmle.label | call to taint :  |
+| instance_variables.rb:54:15:54:23 | call to taint :  | semmle.label | call to taint :  |
+| instance_variables.rb:55:6:55:8 | foo [@field] :  | semmle.label | foo [@field] :  |
+| instance_variables.rb:55:6:55:8 | foo [@field] :  | semmle.label | foo [@field] :  |
+| instance_variables.rb:55:6:55:18 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:55:6:55:18 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:58:1:58:3 | [post] bar [@field] :  | semmle.label | [post] bar [@field] :  |
+| instance_variables.rb:58:15:58:22 | call to taint :  | semmle.label | call to taint :  |
+| instance_variables.rb:59:6:59:8 | bar [@field] :  | semmle.label | bar [@field] :  |
+| instance_variables.rb:59:6:59:18 | call to inc_field | semmle.label | call to inc_field |
+| instance_variables.rb:62:1:62:4 | [post] foo1 [@field] :  | semmle.label | [post] foo1 [@field] :  |
+| instance_variables.rb:62:1:62:4 | [post] foo1 [@field] :  | semmle.label | [post] foo1 [@field] :  |
+| instance_variables.rb:62:14:62:22 | call to taint :  | semmle.label | call to taint :  |
+| instance_variables.rb:62:14:62:22 | call to taint :  | semmle.label | call to taint :  |
+| instance_variables.rb:63:6:63:9 | foo1 [@field] :  | semmle.label | foo1 [@field] :  |
+| instance_variables.rb:63:6:63:9 | foo1 [@field] :  | semmle.label | foo1 [@field] :  |
+| instance_variables.rb:63:6:63:15 | call to field | semmle.label | call to field |
+| instance_variables.rb:63:6:63:15 | call to field | semmle.label | call to field |
+| instance_variables.rb:66:1:66:4 | [post] foo2 [@field] :  | semmle.label | [post] foo2 [@field] :  |
+| instance_variables.rb:66:1:66:4 | [post] foo2 [@field] :  | semmle.label | [post] foo2 [@field] :  |
+| instance_variables.rb:66:14:66:22 | call to taint :  | semmle.label | call to taint :  |
+| instance_variables.rb:66:14:66:22 | call to taint :  | semmle.label | call to taint :  |
+| instance_variables.rb:67:6:67:9 | foo2 [@field] :  | semmle.label | foo2 [@field] :  |
+| instance_variables.rb:67:6:67:9 | foo2 [@field] :  | semmle.label | foo2 [@field] :  |
+| instance_variables.rb:67:6:67:19 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:67:6:67:19 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:70:1:70:4 | [post] foo3 [@field] :  | semmle.label | [post] foo3 [@field] :  |
+| instance_variables.rb:70:1:70:4 | [post] foo3 [@field] :  | semmle.label | [post] foo3 [@field] :  |
+| instance_variables.rb:70:16:70:24 | call to taint :  | semmle.label | call to taint :  |
+| instance_variables.rb:70:16:70:24 | call to taint :  | semmle.label | call to taint :  |
+| instance_variables.rb:71:6:71:9 | foo3 [@field] :  | semmle.label | foo3 [@field] :  |
+| instance_variables.rb:71:6:71:9 | foo3 [@field] :  | semmle.label | foo3 [@field] :  |
+| instance_variables.rb:71:6:71:15 | call to field | semmle.label | call to field |
+| instance_variables.rb:71:6:71:15 | call to field | semmle.label | call to field |
+| instance_variables.rb:78:2:78:5 | [post] foo5 [@field] :  | semmle.label | [post] foo5 [@field] :  |
+| instance_variables.rb:78:2:78:5 | [post] foo5 [@field] :  | semmle.label | [post] foo5 [@field] :  |
+| instance_variables.rb:78:18:78:26 | call to taint :  | semmle.label | call to taint :  |
+| instance_variables.rb:78:18:78:26 | call to taint :  | semmle.label | call to taint :  |
+| instance_variables.rb:79:6:79:9 | foo5 [@field] :  | semmle.label | foo5 [@field] :  |
+| instance_variables.rb:79:6:79:9 | foo5 [@field] :  | semmle.label | foo5 [@field] :  |
+| instance_variables.rb:79:6:79:19 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:79:6:79:19 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:82:15:82:18 | [post] foo6 [@field] :  | semmle.label | [post] foo6 [@field] :  |
+| instance_variables.rb:82:15:82:18 | [post] foo6 [@field] :  | semmle.label | [post] foo6 [@field] :  |
+| instance_variables.rb:82:32:82:40 | call to taint :  | semmle.label | call to taint :  |
+| instance_variables.rb:82:32:82:40 | call to taint :  | semmle.label | call to taint :  |
+| instance_variables.rb:83:6:83:9 | foo3 [@field] :  | semmle.label | foo3 [@field] :  |
+| instance_variables.rb:83:6:83:9 | foo3 [@field] :  | semmle.label | foo3 [@field] :  |
+| instance_variables.rb:83:6:83:19 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:83:6:83:19 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:84:6:84:9 | foo5 [@field] :  | semmle.label | foo5 [@field] :  |
+| instance_variables.rb:84:6:84:9 | foo5 [@field] :  | semmle.label | foo5 [@field] :  |
+| instance_variables.rb:84:6:84:19 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:84:6:84:19 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:85:6:85:9 | foo6 [@field] :  | semmle.label | foo6 [@field] :  |
+| instance_variables.rb:85:6:85:9 | foo6 [@field] :  | semmle.label | foo6 [@field] :  |
+| instance_variables.rb:85:6:85:19 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:85:6:85:19 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:89:15:89:18 | [post] foo7 [@field] :  | semmle.label | [post] foo7 [@field] :  |
+| instance_variables.rb:89:15:89:18 | [post] foo7 [@field] :  | semmle.label | [post] foo7 [@field] :  |
+| instance_variables.rb:89:25:89:28 | [post] foo8 [@field] :  | semmle.label | [post] foo8 [@field] :  |
+| instance_variables.rb:89:25:89:28 | [post] foo8 [@field] :  | semmle.label | [post] foo8 [@field] :  |
+| instance_variables.rb:89:45:89:53 | call to taint :  | semmle.label | call to taint :  |
+| instance_variables.rb:89:45:89:53 | call to taint :  | semmle.label | call to taint :  |
+| instance_variables.rb:90:6:90:9 | foo7 [@field] :  | semmle.label | foo7 [@field] :  |
+| instance_variables.rb:90:6:90:9 | foo7 [@field] :  | semmle.label | foo7 [@field] :  |
+| instance_variables.rb:90:6:90:19 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:90:6:90:19 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:91:6:91:9 | foo8 [@field] :  | semmle.label | foo8 [@field] :  |
+| instance_variables.rb:91:6:91:9 | foo8 [@field] :  | semmle.label | foo8 [@field] :  |
+| instance_variables.rb:91:6:91:19 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:91:6:91:19 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:95:22:95:25 | [post] foo9 [@field] :  | semmle.label | [post] foo9 [@field] :  |
+| instance_variables.rb:95:22:95:25 | [post] foo9 [@field] :  | semmle.label | [post] foo9 [@field] :  |
+| instance_variables.rb:95:32:95:36 | [post] foo10 [@field] :  | semmle.label | [post] foo10 [@field] :  |
+| instance_variables.rb:95:32:95:36 | [post] foo10 [@field] :  | semmle.label | [post] foo10 [@field] :  |
+| instance_variables.rb:95:53:95:61 | call to taint :  | semmle.label | call to taint :  |
+| instance_variables.rb:95:53:95:61 | call to taint :  | semmle.label | call to taint :  |
+| instance_variables.rb:96:6:96:9 | foo9 [@field] :  | semmle.label | foo9 [@field] :  |
+| instance_variables.rb:96:6:96:9 | foo9 [@field] :  | semmle.label | foo9 [@field] :  |
+| instance_variables.rb:96:6:96:19 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:96:6:96:19 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:97:6:97:10 | foo10 [@field] :  | semmle.label | foo10 [@field] :  |
+| instance_variables.rb:97:6:97:10 | foo10 [@field] :  | semmle.label | foo10 [@field] :  |
+| instance_variables.rb:97:6:97:20 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:97:6:97:20 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:100:5:100:5 | [post] x [@field] :  | semmle.label | [post] x [@field] :  |
+| instance_variables.rb:100:5:100:5 | [post] x [@field] :  | semmle.label | [post] x [@field] :  |
+| instance_variables.rb:100:17:100:25 | call to taint :  | semmle.label | call to taint :  |
+| instance_variables.rb:100:17:100:25 | call to taint :  | semmle.label | call to taint :  |
+| instance_variables.rb:104:14:104:18 | [post] foo11 [@field] :  | semmle.label | [post] foo11 [@field] :  |
+| instance_variables.rb:104:14:104:18 | [post] foo11 [@field] :  | semmle.label | [post] foo11 [@field] :  |
+| instance_variables.rb:105:6:105:10 | foo11 [@field] :  | semmle.label | foo11 [@field] :  |
+| instance_variables.rb:105:6:105:10 | foo11 [@field] :  | semmle.label | foo11 [@field] :  |
 | instance_variables.rb:105:6:105:20 | call to get_field | semmle.label | call to get_field |
 | instance_variables.rb:105:6:105:20 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:106:7:106:24 | call to new :  | semmle.label | call to new :  |
-| instance_variables.rb:106:7:106:24 | call to new :  | semmle.label | call to new :  |
-| instance_variables.rb:107:6:107:8 | bar | semmle.label | bar |
-| instance_variables.rb:107:6:107:8 | bar | semmle.label | bar |
+| instance_variables.rb:108:15:108:19 | [post] foo12 [@field] :  | semmle.label | [post] foo12 [@field] :  |
+| instance_variables.rb:108:15:108:19 | [post] foo12 [@field] :  | semmle.label | [post] foo12 [@field] :  |
+| instance_variables.rb:109:6:109:10 | foo12 [@field] :  | semmle.label | foo12 [@field] :  |
+| instance_variables.rb:109:6:109:10 | foo12 [@field] :  | semmle.label | foo12 [@field] :  |
+| instance_variables.rb:109:6:109:20 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:109:6:109:20 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:113:22:113:26 | [post] foo13 [@field] :  | semmle.label | [post] foo13 [@field] :  |
+| instance_variables.rb:113:22:113:26 | [post] foo13 [@field] :  | semmle.label | [post] foo13 [@field] :  |
+| instance_variables.rb:114:6:114:10 | foo13 [@field] :  | semmle.label | foo13 [@field] :  |
+| instance_variables.rb:114:6:114:10 | foo13 [@field] :  | semmle.label | foo13 [@field] :  |
+| instance_variables.rb:114:6:114:20 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:114:6:114:20 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:116:9:116:26 | call to new [@field] :  | semmle.label | call to new [@field] :  |
+| instance_variables.rb:116:9:116:26 | call to new [@field] :  | semmle.label | call to new [@field] :  |
+| instance_variables.rb:116:17:116:25 | call to taint :  | semmle.label | call to taint :  |
+| instance_variables.rb:116:17:116:25 | call to taint :  | semmle.label | call to taint :  |
+| instance_variables.rb:117:6:117:10 | foo15 [@field] :  | semmle.label | foo15 [@field] :  |
+| instance_variables.rb:117:6:117:10 | foo15 [@field] :  | semmle.label | foo15 [@field] :  |
+| instance_variables.rb:117:6:117:20 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:117:6:117:20 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:119:6:119:10 | [post] foo16 [@field] :  | semmle.label | [post] foo16 [@field] :  |
+| instance_variables.rb:119:6:119:10 | [post] foo16 [@field] :  | semmle.label | [post] foo16 [@field] :  |
+| instance_variables.rb:119:6:119:37 | call to call_initialize | semmle.label | call to call_initialize |
+| instance_variables.rb:119:6:119:37 | call to call_initialize | semmle.label | call to call_initialize |
+| instance_variables.rb:119:28:119:36 | call to taint :  | semmle.label | call to taint :  |
+| instance_variables.rb:119:28:119:36 | call to taint :  | semmle.label | call to taint :  |
+| instance_variables.rb:120:6:120:10 | foo16 [@field] :  | semmle.label | foo16 [@field] :  |
+| instance_variables.rb:120:6:120:10 | foo16 [@field] :  | semmle.label | foo16 [@field] :  |
+| instance_variables.rb:120:6:120:20 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:120:6:120:20 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:121:7:121:24 | call to new :  | semmle.label | call to new :  |
+| instance_variables.rb:121:7:121:24 | call to new :  | semmle.label | call to new :  |
+| instance_variables.rb:122:6:122:8 | bar | semmle.label | bar |
+| instance_variables.rb:122:6:122:8 | bar | semmle.label | bar |
 subpaths
 | instance_variables.rb:28:20:28:24 | field :  | instance_variables.rb:22:20:22:24 | field :  | instance_variables.rb:23:9:23:14 | [post] self [@field] :  | instance_variables.rb:28:9:28:25 | [post] self [@field] :  |
 | instance_variables.rb:28:20:28:24 | field :  | instance_variables.rb:22:20:22:24 | field :  | instance_variables.rb:23:9:23:14 | [post] self [@field] :  | instance_variables.rb:28:9:28:25 | [post] self [@field] :  |
-| instance_variables.rb:39:15:39:23 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:39:1:39:3 | [post] foo [@field] :  |
-| instance_variables.rb:39:15:39:23 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:39:1:39:3 | [post] foo [@field] :  |
-| instance_variables.rb:40:6:40:8 | foo [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:40:6:40:18 | call to get_field |
-| instance_variables.rb:40:6:40:8 | foo [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:40:6:40:18 | call to get_field |
-| instance_variables.rb:43:15:43:22 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:43:1:43:3 | [post] bar [@field] :  |
-| instance_variables.rb:44:6:44:8 | bar [@field] :  | instance_variables.rb:16:5:18:7 | self in inc_field [@field] :  | instance_variables.rb:16:5:18:7 | self in inc_field [@field] :  | instance_variables.rb:44:6:44:18 | call to inc_field |
-| instance_variables.rb:44:6:44:8 | bar [@field] :  | instance_variables.rb:16:5:18:7 | self in inc_field [@field] :  | instance_variables.rb:17:9:17:14 | [post] self [@field] :  | instance_variables.rb:44:6:44:18 | call to inc_field |
-| instance_variables.rb:52:6:52:9 | foo2 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:52:6:52:19 | call to get_field |
-| instance_variables.rb:52:6:52:9 | foo2 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:52:6:52:19 | call to get_field |
-| instance_variables.rb:55:16:55:24 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:55:1:55:4 | [post] foo3 [@field] :  |
-| instance_variables.rb:55:16:55:24 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:55:1:55:4 | [post] foo3 [@field] :  |
-| instance_variables.rb:63:18:63:26 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:63:2:63:5 | [post] foo5 [@field] :  |
-| instance_variables.rb:63:18:63:26 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:63:2:63:5 | [post] foo5 [@field] :  |
-| instance_variables.rb:64:6:64:9 | foo5 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:64:6:64:19 | call to get_field |
-| instance_variables.rb:64:6:64:9 | foo5 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:64:6:64:19 | call to get_field |
-| instance_variables.rb:67:32:67:40 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:67:15:67:18 | [post] foo6 [@field] :  |
-| instance_variables.rb:67:32:67:40 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:67:15:67:18 | [post] foo6 [@field] :  |
-| instance_variables.rb:68:6:68:9 | foo3 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:68:6:68:19 | call to get_field |
-| instance_variables.rb:68:6:68:9 | foo3 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:68:6:68:19 | call to get_field |
-| instance_variables.rb:69:6:69:9 | foo5 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:69:6:69:19 | call to get_field |
-| instance_variables.rb:69:6:69:9 | foo5 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:69:6:69:19 | call to get_field |
-| instance_variables.rb:70:6:70:9 | foo6 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:70:6:70:19 | call to get_field |
-| instance_variables.rb:70:6:70:9 | foo6 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:70:6:70:19 | call to get_field |
-| instance_variables.rb:74:45:74:53 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:74:15:74:18 | [post] foo7 [@field] :  |
-| instance_variables.rb:74:45:74:53 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:74:15:74:18 | [post] foo7 [@field] :  |
-| instance_variables.rb:74:45:74:53 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:74:25:74:28 | [post] foo8 [@field] :  |
-| instance_variables.rb:74:45:74:53 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:74:25:74:28 | [post] foo8 [@field] :  |
-| instance_variables.rb:75:6:75:9 | foo7 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:75:6:75:19 | call to get_field |
-| instance_variables.rb:75:6:75:9 | foo7 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:75:6:75:19 | call to get_field |
-| instance_variables.rb:76:6:76:9 | foo8 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:76:6:76:19 | call to get_field |
-| instance_variables.rb:76:6:76:9 | foo8 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:76:6:76:19 | call to get_field |
-| instance_variables.rb:80:53:80:61 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:80:22:80:25 | [post] foo9 [@field] :  |
-| instance_variables.rb:80:53:80:61 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:80:22:80:25 | [post] foo9 [@field] :  |
-| instance_variables.rb:80:53:80:61 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:80:32:80:36 | [post] foo10 [@field] :  |
-| instance_variables.rb:80:53:80:61 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:80:32:80:36 | [post] foo10 [@field] :  |
-| instance_variables.rb:81:6:81:9 | foo9 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:81:6:81:19 | call to get_field |
-| instance_variables.rb:81:6:81:9 | foo9 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:81:6:81:19 | call to get_field |
-| instance_variables.rb:82:6:82:10 | foo10 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:82:6:82:20 | call to get_field |
-| instance_variables.rb:82:6:82:10 | foo10 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:82:6:82:20 | call to get_field |
-| instance_variables.rb:85:17:85:25 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:85:5:85:5 | [post] x [@field] :  |
-| instance_variables.rb:85:17:85:25 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:85:5:85:5 | [post] x [@field] :  |
-| instance_variables.rb:90:6:90:10 | foo11 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:90:6:90:20 | call to get_field |
-| instance_variables.rb:90:6:90:10 | foo11 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:90:6:90:20 | call to get_field |
-| instance_variables.rb:94:6:94:10 | foo12 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:94:6:94:20 | call to get_field |
-| instance_variables.rb:94:6:94:10 | foo12 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:94:6:94:20 | call to get_field |
-| instance_variables.rb:99:6:99:10 | foo13 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:99:6:99:20 | call to get_field |
-| instance_variables.rb:99:6:99:10 | foo13 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:99:6:99:20 | call to get_field |
-| instance_variables.rb:101:17:101:25 | call to taint :  | instance_variables.rb:22:20:22:24 | field :  | instance_variables.rb:23:9:23:14 | [post] self [@field] :  | instance_variables.rb:101:9:101:26 | call to new [@field] :  |
-| instance_variables.rb:101:17:101:25 | call to taint :  | instance_variables.rb:22:20:22:24 | field :  | instance_variables.rb:23:9:23:14 | [post] self [@field] :  | instance_variables.rb:101:9:101:26 | call to new [@field] :  |
-| instance_variables.rb:102:6:102:10 | foo15 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:102:6:102:20 | call to get_field |
-| instance_variables.rb:102:6:102:10 | foo15 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:102:6:102:20 | call to get_field |
-| instance_variables.rb:104:28:104:36 | call to taint :  | instance_variables.rb:27:25:27:29 | field :  | instance_variables.rb:28:9:28:25 | [post] self [@field] :  | instance_variables.rb:104:6:104:10 | [post] foo16 [@field] :  |
-| instance_variables.rb:104:28:104:36 | call to taint :  | instance_variables.rb:27:25:27:29 | field :  | instance_variables.rb:28:9:28:25 | [post] self [@field] :  | instance_variables.rb:104:6:104:10 | [post] foo16 [@field] :  |
-| instance_variables.rb:105:6:105:10 | foo16 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:105:6:105:20 | call to get_field |
-| instance_variables.rb:105:6:105:10 | foo16 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:105:6:105:20 | call to get_field |
+| instance_variables.rb:54:15:54:23 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:54:1:54:3 | [post] foo [@field] :  |
+| instance_variables.rb:54:15:54:23 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:54:1:54:3 | [post] foo [@field] :  |
+| instance_variables.rb:55:6:55:8 | foo [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:55:6:55:18 | call to get_field |
+| instance_variables.rb:55:6:55:8 | foo [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:55:6:55:18 | call to get_field |
+| instance_variables.rb:58:15:58:22 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:58:1:58:3 | [post] bar [@field] :  |
+| instance_variables.rb:59:6:59:8 | bar [@field] :  | instance_variables.rb:16:5:18:7 | self in inc_field [@field] :  | instance_variables.rb:16:5:18:7 | self in inc_field [@field] :  | instance_variables.rb:59:6:59:18 | call to inc_field |
+| instance_variables.rb:59:6:59:8 | bar [@field] :  | instance_variables.rb:16:5:18:7 | self in inc_field [@field] :  | instance_variables.rb:17:9:17:14 | [post] self [@field] :  | instance_variables.rb:59:6:59:18 | call to inc_field |
+| instance_variables.rb:67:6:67:9 | foo2 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:67:6:67:19 | call to get_field |
+| instance_variables.rb:67:6:67:9 | foo2 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:67:6:67:19 | call to get_field |
+| instance_variables.rb:70:16:70:24 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:70:1:70:4 | [post] foo3 [@field] :  |
+| instance_variables.rb:70:16:70:24 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:70:1:70:4 | [post] foo3 [@field] :  |
+| instance_variables.rb:78:18:78:26 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:78:2:78:5 | [post] foo5 [@field] :  |
+| instance_variables.rb:78:18:78:26 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:78:2:78:5 | [post] foo5 [@field] :  |
+| instance_variables.rb:79:6:79:9 | foo5 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:79:6:79:19 | call to get_field |
+| instance_variables.rb:79:6:79:9 | foo5 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:79:6:79:19 | call to get_field |
+| instance_variables.rb:82:32:82:40 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:82:15:82:18 | [post] foo6 [@field] :  |
+| instance_variables.rb:82:32:82:40 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:82:15:82:18 | [post] foo6 [@field] :  |
+| instance_variables.rb:83:6:83:9 | foo3 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:83:6:83:19 | call to get_field |
+| instance_variables.rb:83:6:83:9 | foo3 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:83:6:83:19 | call to get_field |
+| instance_variables.rb:84:6:84:9 | foo5 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:84:6:84:19 | call to get_field |
+| instance_variables.rb:84:6:84:9 | foo5 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:84:6:84:19 | call to get_field |
+| instance_variables.rb:85:6:85:9 | foo6 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:85:6:85:19 | call to get_field |
+| instance_variables.rb:85:6:85:9 | foo6 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:85:6:85:19 | call to get_field |
+| instance_variables.rb:89:45:89:53 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:89:15:89:18 | [post] foo7 [@field] :  |
+| instance_variables.rb:89:45:89:53 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:89:15:89:18 | [post] foo7 [@field] :  |
+| instance_variables.rb:89:45:89:53 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:89:25:89:28 | [post] foo8 [@field] :  |
+| instance_variables.rb:89:45:89:53 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:89:25:89:28 | [post] foo8 [@field] :  |
+| instance_variables.rb:90:6:90:9 | foo7 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:90:6:90:19 | call to get_field |
+| instance_variables.rb:90:6:90:9 | foo7 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:90:6:90:19 | call to get_field |
+| instance_variables.rb:91:6:91:9 | foo8 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:91:6:91:19 | call to get_field |
+| instance_variables.rb:91:6:91:9 | foo8 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:91:6:91:19 | call to get_field |
+| instance_variables.rb:95:53:95:61 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:95:22:95:25 | [post] foo9 [@field] :  |
+| instance_variables.rb:95:53:95:61 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:95:22:95:25 | [post] foo9 [@field] :  |
+| instance_variables.rb:95:53:95:61 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:95:32:95:36 | [post] foo10 [@field] :  |
+| instance_variables.rb:95:53:95:61 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:95:32:95:36 | [post] foo10 [@field] :  |
+| instance_variables.rb:96:6:96:9 | foo9 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:96:6:96:19 | call to get_field |
+| instance_variables.rb:96:6:96:9 | foo9 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:96:6:96:19 | call to get_field |
+| instance_variables.rb:97:6:97:10 | foo10 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:97:6:97:20 | call to get_field |
+| instance_variables.rb:97:6:97:10 | foo10 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:97:6:97:20 | call to get_field |
+| instance_variables.rb:100:17:100:25 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:100:5:100:5 | [post] x [@field] :  |
+| instance_variables.rb:100:17:100:25 | call to taint :  | instance_variables.rb:10:19:10:19 | x :  | instance_variables.rb:11:9:11:14 | [post] self [@field] :  | instance_variables.rb:100:5:100:5 | [post] x [@field] :  |
+| instance_variables.rb:105:6:105:10 | foo11 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:105:6:105:20 | call to get_field |
+| instance_variables.rb:105:6:105:10 | foo11 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:105:6:105:20 | call to get_field |
+| instance_variables.rb:109:6:109:10 | foo12 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:109:6:109:20 | call to get_field |
+| instance_variables.rb:109:6:109:10 | foo12 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:109:6:109:20 | call to get_field |
+| instance_variables.rb:114:6:114:10 | foo13 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:114:6:114:20 | call to get_field |
+| instance_variables.rb:114:6:114:10 | foo13 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:114:6:114:20 | call to get_field |
+| instance_variables.rb:116:17:116:25 | call to taint :  | instance_variables.rb:22:20:22:24 | field :  | instance_variables.rb:23:9:23:14 | [post] self [@field] :  | instance_variables.rb:116:9:116:26 | call to new [@field] :  |
+| instance_variables.rb:116:17:116:25 | call to taint :  | instance_variables.rb:22:20:22:24 | field :  | instance_variables.rb:23:9:23:14 | [post] self [@field] :  | instance_variables.rb:116:9:116:26 | call to new [@field] :  |
+| instance_variables.rb:117:6:117:10 | foo15 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:117:6:117:20 | call to get_field |
+| instance_variables.rb:117:6:117:10 | foo15 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:117:6:117:20 | call to get_field |
+| instance_variables.rb:119:28:119:36 | call to taint :  | instance_variables.rb:27:25:27:29 | field :  | instance_variables.rb:28:9:28:25 | [post] self [@field] :  | instance_variables.rb:119:6:119:10 | [post] foo16 [@field] :  |
+| instance_variables.rb:119:28:119:36 | call to taint :  | instance_variables.rb:27:25:27:29 | field :  | instance_variables.rb:28:9:28:25 | [post] self [@field] :  | instance_variables.rb:119:6:119:10 | [post] foo16 [@field] :  |
+| instance_variables.rb:120:6:120:10 | foo16 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:120:6:120:20 | call to get_field |
+| instance_variables.rb:120:6:120:10 | foo16 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  | instance_variables.rb:14:9:14:21 | return :  | instance_variables.rb:120:6:120:20 | call to get_field |
 #select
 | captured_variables.rb:2:20:2:20 | x | captured_variables.rb:5:20:5:30 | call to source :  | captured_variables.rb:2:20:2:20 | x | $@ | captured_variables.rb:5:20:5:30 | call to source :  | call to source :  |
 | captured_variables.rb:23:14:23:14 | x | captured_variables.rb:27:29:27:39 | call to source :  | captured_variables.rb:23:14:23:14 | x | $@ | captured_variables.rb:27:29:27:39 | call to source :  | call to source :  |
 | captured_variables.rb:34:14:34:14 | x | captured_variables.rb:38:27:38:37 | call to source :  | captured_variables.rb:34:14:34:14 | x | $@ | captured_variables.rb:38:27:38:37 | call to source :  | call to source :  |
 | instance_variables.rb:20:10:20:13 | @foo | instance_variables.rb:19:12:19:21 | call to taint :  | instance_variables.rb:20:10:20:13 | @foo | $@ | instance_variables.rb:19:12:19:21 | call to taint :  | call to taint :  |
-| instance_variables.rb:40:6:40:18 | call to get_field | instance_variables.rb:39:15:39:23 | call to taint :  | instance_variables.rb:40:6:40:18 | call to get_field | $@ | instance_variables.rb:39:15:39:23 | call to taint :  | call to taint :  |
-| instance_variables.rb:44:6:44:18 | call to inc_field | instance_variables.rb:43:15:43:22 | call to taint :  | instance_variables.rb:44:6:44:18 | call to inc_field | $@ | instance_variables.rb:43:15:43:22 | call to taint :  | call to taint :  |
-| instance_variables.rb:48:6:48:15 | call to field | instance_variables.rb:47:14:47:22 | call to taint :  | instance_variables.rb:48:6:48:15 | call to field | $@ | instance_variables.rb:47:14:47:22 | call to taint :  | call to taint :  |
-| instance_variables.rb:52:6:52:19 | call to get_field | instance_variables.rb:51:14:51:22 | call to taint :  | instance_variables.rb:52:6:52:19 | call to get_field | $@ | instance_variables.rb:51:14:51:22 | call to taint :  | call to taint :  |
-| instance_variables.rb:56:6:56:15 | call to field | instance_variables.rb:55:16:55:24 | call to taint :  | instance_variables.rb:56:6:56:15 | call to field | $@ | instance_variables.rb:55:16:55:24 | call to taint :  | call to taint :  |
-| instance_variables.rb:64:6:64:19 | call to get_field | instance_variables.rb:63:18:63:26 | call to taint :  | instance_variables.rb:64:6:64:19 | call to get_field | $@ | instance_variables.rb:63:18:63:26 | call to taint :  | call to taint :  |
-| instance_variables.rb:68:6:68:19 | call to get_field | instance_variables.rb:55:16:55:24 | call to taint :  | instance_variables.rb:68:6:68:19 | call to get_field | $@ | instance_variables.rb:55:16:55:24 | call to taint :  | call to taint :  |
-| instance_variables.rb:69:6:69:19 | call to get_field | instance_variables.rb:63:18:63:26 | call to taint :  | instance_variables.rb:69:6:69:19 | call to get_field | $@ | instance_variables.rb:63:18:63:26 | call to taint :  | call to taint :  |
-| instance_variables.rb:70:6:70:19 | call to get_field | instance_variables.rb:67:32:67:40 | call to taint :  | instance_variables.rb:70:6:70:19 | call to get_field | $@ | instance_variables.rb:67:32:67:40 | call to taint :  | call to taint :  |
-| instance_variables.rb:75:6:75:19 | call to get_field | instance_variables.rb:74:45:74:53 | call to taint :  | instance_variables.rb:75:6:75:19 | call to get_field | $@ | instance_variables.rb:74:45:74:53 | call to taint :  | call to taint :  |
-| instance_variables.rb:76:6:76:19 | call to get_field | instance_variables.rb:74:45:74:53 | call to taint :  | instance_variables.rb:76:6:76:19 | call to get_field | $@ | instance_variables.rb:74:45:74:53 | call to taint :  | call to taint :  |
-| instance_variables.rb:81:6:81:19 | call to get_field | instance_variables.rb:80:53:80:61 | call to taint :  | instance_variables.rb:81:6:81:19 | call to get_field | $@ | instance_variables.rb:80:53:80:61 | call to taint :  | call to taint :  |
-| instance_variables.rb:82:6:82:20 | call to get_field | instance_variables.rb:80:53:80:61 | call to taint :  | instance_variables.rb:82:6:82:20 | call to get_field | $@ | instance_variables.rb:80:53:80:61 | call to taint :  | call to taint :  |
-| instance_variables.rb:90:6:90:20 | call to get_field | instance_variables.rb:85:17:85:25 | call to taint :  | instance_variables.rb:90:6:90:20 | call to get_field | $@ | instance_variables.rb:85:17:85:25 | call to taint :  | call to taint :  |
-| instance_variables.rb:94:6:94:20 | call to get_field | instance_variables.rb:85:17:85:25 | call to taint :  | instance_variables.rb:94:6:94:20 | call to get_field | $@ | instance_variables.rb:85:17:85:25 | call to taint :  | call to taint :  |
-| instance_variables.rb:99:6:99:20 | call to get_field | instance_variables.rb:85:17:85:25 | call to taint :  | instance_variables.rb:99:6:99:20 | call to get_field | $@ | instance_variables.rb:85:17:85:25 | call to taint :  | call to taint :  |
-| instance_variables.rb:102:6:102:20 | call to get_field | instance_variables.rb:101:17:101:25 | call to taint :  | instance_variables.rb:102:6:102:20 | call to get_field | $@ | instance_variables.rb:101:17:101:25 | call to taint :  | call to taint :  |
-| instance_variables.rb:104:6:104:37 | call to call_initialize | instance_variables.rb:24:9:24:17 | call to taint :  | instance_variables.rb:104:6:104:37 | call to call_initialize | $@ | instance_variables.rb:24:9:24:17 | call to taint :  | call to taint :  |
-| instance_variables.rb:105:6:105:20 | call to get_field | instance_variables.rb:104:28:104:36 | call to taint :  | instance_variables.rb:105:6:105:20 | call to get_field | $@ | instance_variables.rb:104:28:104:36 | call to taint :  | call to taint :  |
-| instance_variables.rb:107:6:107:8 | bar | instance_variables.rb:34:9:34:17 | call to taint :  | instance_variables.rb:107:6:107:8 | bar | $@ | instance_variables.rb:34:9:34:17 | call to taint :  | call to taint :  |
+| instance_variables.rb:55:6:55:18 | call to get_field | instance_variables.rb:54:15:54:23 | call to taint :  | instance_variables.rb:55:6:55:18 | call to get_field | $@ | instance_variables.rb:54:15:54:23 | call to taint :  | call to taint :  |
+| instance_variables.rb:59:6:59:18 | call to inc_field | instance_variables.rb:58:15:58:22 | call to taint :  | instance_variables.rb:59:6:59:18 | call to inc_field | $@ | instance_variables.rb:58:15:58:22 | call to taint :  | call to taint :  |
+| instance_variables.rb:63:6:63:15 | call to field | instance_variables.rb:62:14:62:22 | call to taint :  | instance_variables.rb:63:6:63:15 | call to field | $@ | instance_variables.rb:62:14:62:22 | call to taint :  | call to taint :  |
+| instance_variables.rb:67:6:67:19 | call to get_field | instance_variables.rb:66:14:66:22 | call to taint :  | instance_variables.rb:67:6:67:19 | call to get_field | $@ | instance_variables.rb:66:14:66:22 | call to taint :  | call to taint :  |
+| instance_variables.rb:71:6:71:15 | call to field | instance_variables.rb:70:16:70:24 | call to taint :  | instance_variables.rb:71:6:71:15 | call to field | $@ | instance_variables.rb:70:16:70:24 | call to taint :  | call to taint :  |
+| instance_variables.rb:79:6:79:19 | call to get_field | instance_variables.rb:78:18:78:26 | call to taint :  | instance_variables.rb:79:6:79:19 | call to get_field | $@ | instance_variables.rb:78:18:78:26 | call to taint :  | call to taint :  |
+| instance_variables.rb:83:6:83:19 | call to get_field | instance_variables.rb:70:16:70:24 | call to taint :  | instance_variables.rb:83:6:83:19 | call to get_field | $@ | instance_variables.rb:70:16:70:24 | call to taint :  | call to taint :  |
+| instance_variables.rb:84:6:84:19 | call to get_field | instance_variables.rb:78:18:78:26 | call to taint :  | instance_variables.rb:84:6:84:19 | call to get_field | $@ | instance_variables.rb:78:18:78:26 | call to taint :  | call to taint :  |
+| instance_variables.rb:85:6:85:19 | call to get_field | instance_variables.rb:82:32:82:40 | call to taint :  | instance_variables.rb:85:6:85:19 | call to get_field | $@ | instance_variables.rb:82:32:82:40 | call to taint :  | call to taint :  |
+| instance_variables.rb:90:6:90:19 | call to get_field | instance_variables.rb:89:45:89:53 | call to taint :  | instance_variables.rb:90:6:90:19 | call to get_field | $@ | instance_variables.rb:89:45:89:53 | call to taint :  | call to taint :  |
+| instance_variables.rb:91:6:91:19 | call to get_field | instance_variables.rb:89:45:89:53 | call to taint :  | instance_variables.rb:91:6:91:19 | call to get_field | $@ | instance_variables.rb:89:45:89:53 | call to taint :  | call to taint :  |
+| instance_variables.rb:96:6:96:19 | call to get_field | instance_variables.rb:95:53:95:61 | call to taint :  | instance_variables.rb:96:6:96:19 | call to get_field | $@ | instance_variables.rb:95:53:95:61 | call to taint :  | call to taint :  |
+| instance_variables.rb:97:6:97:20 | call to get_field | instance_variables.rb:95:53:95:61 | call to taint :  | instance_variables.rb:97:6:97:20 | call to get_field | $@ | instance_variables.rb:95:53:95:61 | call to taint :  | call to taint :  |
+| instance_variables.rb:105:6:105:20 | call to get_field | instance_variables.rb:100:17:100:25 | call to taint :  | instance_variables.rb:105:6:105:20 | call to get_field | $@ | instance_variables.rb:100:17:100:25 | call to taint :  | call to taint :  |
+| instance_variables.rb:109:6:109:20 | call to get_field | instance_variables.rb:100:17:100:25 | call to taint :  | instance_variables.rb:109:6:109:20 | call to get_field | $@ | instance_variables.rb:100:17:100:25 | call to taint :  | call to taint :  |
+| instance_variables.rb:114:6:114:20 | call to get_field | instance_variables.rb:100:17:100:25 | call to taint :  | instance_variables.rb:114:6:114:20 | call to get_field | $@ | instance_variables.rb:100:17:100:25 | call to taint :  | call to taint :  |
+| instance_variables.rb:117:6:117:20 | call to get_field | instance_variables.rb:116:17:116:25 | call to taint :  | instance_variables.rb:117:6:117:20 | call to get_field | $@ | instance_variables.rb:116:17:116:25 | call to taint :  | call to taint :  |
+| instance_variables.rb:119:6:119:37 | call to call_initialize | instance_variables.rb:24:9:24:17 | call to taint :  | instance_variables.rb:119:6:119:37 | call to call_initialize | $@ | instance_variables.rb:24:9:24:17 | call to taint :  | call to taint :  |
+| instance_variables.rb:120:6:120:20 | call to get_field | instance_variables.rb:119:28:119:36 | call to taint :  | instance_variables.rb:120:6:120:20 | call to get_field | $@ | instance_variables.rb:119:28:119:36 | call to taint :  | call to taint :  |
+| instance_variables.rb:122:6:122:8 | bar | instance_variables.rb:43:9:43:17 | call to taint :  | instance_variables.rb:122:6:122:8 | bar | $@ | instance_variables.rb:43:9:43:17 | call to taint :  | call to taint :  |

--- a/ruby/ql/test/library-tests/dataflow/global/TypeTrackingInlineTest.expected
+++ b/ruby/ql/test/library-tests/dataflow/global/TypeTrackingInlineTest.expected
@@ -1,19 +1,23 @@
 | captured_variables.rb:9:14:9:14 | x | Fixed missing result:hasValueFlow=1.2 |
 | captured_variables.rb:16:14:16:14 | x | Fixed missing result:hasValueFlow=1.3 |
 | instance_variables.rb:20:16:20:33 | # $ hasValueFlow=7 | Missing result:hasValueFlow=7 |
-| instance_variables.rb:40:21:40:39 | # $ hasValueFlow=42 | Missing result:hasValueFlow=42 |
-| instance_variables.rb:52:22:52:40 | # $ hasValueFlow=21 | Missing result:hasValueFlow=21 |
-| instance_variables.rb:56:18:56:36 | # $ hasValueFlow=22 | Missing result:hasValueFlow=22 |
-| instance_variables.rb:64:22:64:40 | # $ hasValueFlow=24 | Missing result:hasValueFlow=24 |
-| instance_variables.rb:68:22:68:40 | # $ hasValueFlow=22 | Missing result:hasValueFlow=22 |
-| instance_variables.rb:69:22:69:40 | # $ hasValueFlow=24 | Missing result:hasValueFlow=24 |
-| instance_variables.rb:70:22:70:40 | # $ hasValueFlow=25 | Missing result:hasValueFlow=25 |
-| instance_variables.rb:75:22:75:40 | # $ hasValueFlow=26 | Missing result:hasValueFlow=26 |
-| instance_variables.rb:76:22:76:40 | # $ hasValueFlow=26 | Missing result:hasValueFlow=26 |
-| instance_variables.rb:81:22:81:40 | # $ hasValueFlow=27 | Missing result:hasValueFlow=27 |
-| instance_variables.rb:82:23:82:41 | # $ hasValueFlow=27 | Missing result:hasValueFlow=27 |
-| instance_variables.rb:90:23:90:41 | # $ hasValueFlow=28 | Missing result:hasValueFlow=28 |
-| instance_variables.rb:94:23:94:41 | # $ hasValueFlow=28 | Missing result:hasValueFlow=28 |
-| instance_variables.rb:99:23:99:41 | # $ hasValueFlow=28 | Missing result:hasValueFlow=28 |
-| instance_variables.rb:102:23:102:41 | # $ hasValueFlow=29 | Missing result:hasValueFlow=29 |
-| instance_variables.rb:105:23:105:41 | # $ hasValueFlow=30 | Missing result:hasValueFlow=30 |
+| instance_variables.rb:36:36:36:54 | # $ hasValueFlow=34 | Missing result:hasValueFlow=34 |
+| instance_variables.rb:39:36:39:54 | # $ hasValueFlow=35 | Missing result:hasValueFlow=35 |
+| instance_variables.rb:49:14:49:14 | x | Unexpected result: hasValueFlow=30 |
+| instance_variables.rb:49:16:49:34 | # $ hasValueFlow=36 | Missing result:hasValueFlow=36 |
+| instance_variables.rb:55:21:55:39 | # $ hasValueFlow=42 | Missing result:hasValueFlow=42 |
+| instance_variables.rb:67:22:67:40 | # $ hasValueFlow=21 | Missing result:hasValueFlow=21 |
+| instance_variables.rb:71:18:71:36 | # $ hasValueFlow=22 | Missing result:hasValueFlow=22 |
+| instance_variables.rb:79:22:79:40 | # $ hasValueFlow=24 | Missing result:hasValueFlow=24 |
+| instance_variables.rb:83:22:83:40 | # $ hasValueFlow=22 | Missing result:hasValueFlow=22 |
+| instance_variables.rb:84:22:84:40 | # $ hasValueFlow=24 | Missing result:hasValueFlow=24 |
+| instance_variables.rb:85:22:85:40 | # $ hasValueFlow=25 | Missing result:hasValueFlow=25 |
+| instance_variables.rb:90:22:90:40 | # $ hasValueFlow=26 | Missing result:hasValueFlow=26 |
+| instance_variables.rb:91:22:91:40 | # $ hasValueFlow=26 | Missing result:hasValueFlow=26 |
+| instance_variables.rb:96:22:96:40 | # $ hasValueFlow=27 | Missing result:hasValueFlow=27 |
+| instance_variables.rb:97:23:97:41 | # $ hasValueFlow=27 | Missing result:hasValueFlow=27 |
+| instance_variables.rb:105:23:105:41 | # $ hasValueFlow=28 | Missing result:hasValueFlow=28 |
+| instance_variables.rb:109:23:109:41 | # $ hasValueFlow=28 | Missing result:hasValueFlow=28 |
+| instance_variables.rb:114:23:114:41 | # $ hasValueFlow=28 | Missing result:hasValueFlow=28 |
+| instance_variables.rb:117:23:117:41 | # $ hasValueFlow=29 | Missing result:hasValueFlow=29 |
+| instance_variables.rb:120:23:120:41 | # $ hasValueFlow=30 | Missing result:hasValueFlow=30 |

--- a/ruby/ql/test/library-tests/dataflow/global/TypeTrackingInlineTest.expected
+++ b/ruby/ql/test/library-tests/dataflow/global/TypeTrackingInlineTest.expected
@@ -4,7 +4,7 @@
 | instance_variables.rb:36:36:36:54 | # $ hasValueFlow=34 | Missing result:hasValueFlow=34 |
 | instance_variables.rb:39:36:39:54 | # $ hasValueFlow=35 | Missing result:hasValueFlow=35 |
 | instance_variables.rb:49:14:49:14 | x | Unexpected result: hasValueFlow=30 |
-| instance_variables.rb:49:16:49:34 | # $ hasValueFlow=36 | Missing result:hasValueFlow=36 |
+| instance_variables.rb:49:14:49:14 | x | Unexpected result: hasValueFlow=35 |
 | instance_variables.rb:55:21:55:39 | # $ hasValueFlow=42 | Missing result:hasValueFlow=42 |
 | instance_variables.rb:67:22:67:40 | # $ hasValueFlow=21 | Missing result:hasValueFlow=21 |
 | instance_variables.rb:71:18:71:36 | # $ hasValueFlow=22 | Missing result:hasValueFlow=22 |

--- a/ruby/ql/test/library-tests/dataflow/global/instance_variables.rb
+++ b/ruby/ql/test/library-tests/dataflow/global/instance_variables.rb
@@ -27,11 +27,26 @@ class Foo
     def call_initialize(field)
         initialize(field)
     end
+
+    def self.bar x
+        new(taint(36))
+        new(x)
+    end
+
+    sink(new(taint(34)).get_field) # $ hasValueFlow=34
 end
+
+sink(Foo.bar(taint(35)).get_field) # $ hasValueFlow=35
 
 class Bar < Foo
     def self.new arg
         taint(32)
+    end
+end
+
+class Baz < Foo
+    def initialize x
+        sink x # $ hasValueFlow=36
     end
 end
 


### PR DESCRIPTION
We were missing data flow through `initialize` calls in cases like
```rb
class Foo
  def self.bar
    new(taint) # calls Foo#initialize
  end

  def initialize x
    sink x
  end
end
```