### PR TITLE
C++: Map some indirect nodes to expressions in `localExprFlowStep`

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -1669,14 +1669,18 @@ private module ExprFlowCached {
     result = n.asExpr()
   }
 
+  /**
+   * Holds if `asExpr(n1)` doesn't have a result and `n1` flows to `n2` in a single
+   * dataflow step.
+   */
   private predicate localStepFromNonExpr(Node n1, Node n2) {
     not exists(asExpr(n1)) and
     localFlowStep(n1, n2)
   }
 
   /**
-   * Holds if `n1.asExpr()` doesn't have a result, `n2.asExpr() = e2` and
-   * `n2` is the first node reachable from `n1` such that `n2.asExpr()` exists.
+   * Holds if `asExpr(n1)` doesn't have a result, `asExpr(n2) = e2` and
+   * `n2` is the first node reachable from `n1` such that `asExpr(n2)` exists.
    */
   pragma[nomagic]
   private predicate localStepsToExpr(Node n1, Node n2, Expr e2) {
@@ -1685,8 +1689,8 @@ private module ExprFlowCached {
   }
 
   /**
-   * Holds if `n1.asExpr() = e1` and `n2.asExpr() = e2` and `n2` is the first node
-   * reachable from `n1` such that `n2.asExpr()` exists.
+   * Holds if `asExpr(n1) = e1` and `asExpr(n2) = e2` and `n2` is the first node
+   * reachable from `n1` such that `asExpr(n2)` exists.
    */
   private predicate localExprFlowSingleExprStep(Node n1, Expr e1, Node n2, Expr e2) {
     exists(Node mid |
@@ -1697,8 +1701,8 @@ private module ExprFlowCached {
   }
 
   /**
-   * Holds if `n1.asExpr() = e1` and `e1 != e2` and `n2` is the first reachable node from
-   * `n1` such that `n2.asExpr() = e2`.
+   * Holds if `asExpr(n1) = e1` and `e1 != e2` and `n2` is the first reachable node from
+   * `n1` such that `asExpr(n2) = e2`.
    */
   private predicate localExprFlowStepImpl(Node n1, Expr e1, Node n2, Expr e2) {
     exists(Node n, Expr e | localExprFlowSingleExprStep(n1, e1, n, e) |


### PR DESCRIPTION
This PR supersede https://github.com/github/codeql/pull/12477 and (hopefully) contains the correct performance fix.

On certain projects containing heavily macro-expanded code like:
```cpp
*x = source();
use(x[0]);
use(x[1]);
...
use(x[i]);
use(x[i+1]);
...
use(x[N]);
```
we hit a performance problem caused by each expression of the form `x[i]` being stepped to from `*x = source()` in certain cases in the expression-only local flow relation.

To see why this is the case, consider the transitive closure over `localStepFromNonExpr` in `localStepsToExpr`. We start at `n2` for which `n.asExpr()` exists. For example, `n2` in the above example could be `x[i]` in any of the `use(x[i])` above. We then step to a dataflow predecessor of `n2`. In the above code fragment, thats the indirect node corresponding to `x` in `x[i-1]`. Since this doesn't have a result for `Node::asExpr()` we continue with the recursion until we reach `*x = source()` which does have a result for `Node::asExpr()`.

If `N` is very large this blows up.

This PR fixes this problem by mapping those indirect nodes for `x` in `x[i]` to the `x[i]` expression. Ideally, this would be handled automatically by assigning the dataflow node for the indirection of `x` to the same dataflow node as `x[i]`, but doing this in the past has let to some strange conflations. However, by just doing this in the expression-only local flow relation we're not seeing these strange conflations.