### PR TITLE
Java: PrintAst: Improve the ranking of callables

### DIFF
--- a/java/ql/lib/semmle/code/java/PrintAst.qll
+++ b/java/ql/lib/semmle/code/java/PrintAst.qll
@@ -537,17 +537,13 @@ final class ClassInterfaceNode extends ElementNode {
     or
     childIndex >= 0 and
     result.(ElementNode).getElement() =
-      rank[childIndex](Element e, string file, int line, int column, string childStr, int argCount |
+      rank[childIndex](Element e, string file, int line, int column, string childStr, string sig |
         e = this.getADeclaration() and
         locationSortKeys(e, file, line, column) and
         childStr = e.toString() and
-        (
-          if e instanceof Callable
-          then argCount = e.(Callable).getNumberOfParameters()
-          else argCount = 0
-        )
+        (if e instanceof Callable then sig = e.(Callable).getStringSignature() else sig = "")
       |
-        e order by file, line, column, childStr, argCount
+        e order by file, line, column, childStr, sig
       )
   }
 }

--- a/java/ql/test/kotlin/library-tests/jvmoverloads-annotation/PrintAst.expected
+++ b/java/ql/test/kotlin/library-tests/jvmoverloads-annotation/PrintAst.expected
@@ -13,29 +13,6 @@ test.kt:
 #   45|           0: [TypeAccess] Test
 #   45|         1: [Parameter] a
 #   45|           0: [TypeAccess] int
-#   45|         2: [Parameter] c
-#   45|           0: [TypeAccess] double
-#   45|         3: [Parameter] e
-#   45|           0: [TypeAccess] boolean
-#   45|       5: [BlockStmt] { ... }
-#   45|         0: [ReturnStmt] return ...
-#   45|           0: [MethodAccess] testExtensionFunction$default(...)
-#   45|             -1: [TypeAccess] TestKt
-#    0|             0: [ExtensionReceiverAccess] this
-#    0|             1: [VarAccess] a
-#    1|             2: [NullLiteral] null
-#    0|             3: [VarAccess] c
-#    1|             4: [FloatLiteral] 0.0
-#    0|             5: [VarAccess] e
-#    1|             6: [IntegerLiteral] 21
-#    1|             7: [NullLiteral] null
-#   45|     3: [ExtensionMethod] testExtensionFunction
-#   45|       3: [TypeAccess] int
-#-----|       4: (Parameters)
-#   45|         0: [Parameter] <this>
-#   45|           0: [TypeAccess] Test
-#   45|         1: [Parameter] a
-#   45|           0: [TypeAccess] int
 #   45|         2: [Parameter] b
 #   45|           0: [TypeAccess] String
 #   45|         3: [Parameter] c
@@ -54,7 +31,7 @@ test.kt:
 #    0|             5: [VarAccess] e
 #    1|             6: [IntegerLiteral] 23
 #    1|             7: [NullLiteral] null
-#   45|     4: [ExtensionMethod] testExtensionFunction
+#   45|     3: [ExtensionMethod] testExtensionFunction
 #-----|       1: (Annotations)
 #   44|         1: [Annotation] JvmOverloads
 #   45|       3: [TypeAccess] int
@@ -74,6 +51,29 @@ test.kt:
 #   45|       5: [BlockStmt] { ... }
 #   45|         0: [ReturnStmt] return ...
 #   45|           0: [VarAccess] a
+#   45|     4: [ExtensionMethod] testExtensionFunction
+#   45|       3: [TypeAccess] int
+#-----|       4: (Parameters)
+#   45|         0: [Parameter] <this>
+#   45|           0: [TypeAccess] Test
+#   45|         1: [Parameter] a
+#   45|           0: [TypeAccess] int
+#   45|         2: [Parameter] c
+#   45|           0: [TypeAccess] double
+#   45|         3: [Parameter] e
+#   45|           0: [TypeAccess] boolean
+#   45|       5: [BlockStmt] { ... }
+#   45|         0: [ReturnStmt] return ...
+#   45|           0: [MethodAccess] testExtensionFunction$default(...)
+#   45|             -1: [TypeAccess] TestKt
+#    0|             0: [ExtensionReceiverAccess] this
+#    0|             1: [VarAccess] a
+#    1|             2: [NullLiteral] null
+#    0|             3: [VarAccess] c
+#    1|             4: [FloatLiteral] 0.0
+#    0|             5: [VarAccess] e
+#    1|             6: [IntegerLiteral] 21
+#    1|             7: [NullLiteral] null
 #   45|     5: [ExtensionMethod] testExtensionFunction$default
 #   45|       3: [TypeAccess] int
 #-----|       4: (Parameters)
@@ -134,26 +134,6 @@ test.kt:
 #-----|       4: (Parameters)
 #    6|         0: [Parameter] a
 #    6|           0: [TypeAccess] int
-#    6|         1: [Parameter] c
-#    6|           0: [TypeAccess] double
-#    6|         2: [Parameter] e
-#    6|           0: [TypeAccess] boolean
-#    6|       5: [BlockStmt] { ... }
-#    6|         0: [ReturnStmt] return ...
-#    6|           0: [MethodAccess] testStaticFunction$default(...)
-#    6|             -1: [TypeAccess] Test
-#    0|             0: [VarAccess] a
-#    1|             1: [NullLiteral] null
-#    0|             2: [VarAccess] c
-#    1|             3: [FloatLiteral] 0.0
-#    0|             4: [VarAccess] e
-#    1|             5: [IntegerLiteral] 21
-#    1|             6: [NullLiteral] null
-#    6|     3: [Method] testStaticFunction
-#    6|       3: [TypeAccess] int
-#-----|       4: (Parameters)
-#    6|         0: [Parameter] a
-#    6|           0: [TypeAccess] int
 #    6|         1: [Parameter] b
 #    6|           0: [TypeAccess] String
 #    6|         2: [Parameter] c
@@ -171,7 +151,7 @@ test.kt:
 #    0|             4: [VarAccess] e
 #    1|             5: [IntegerLiteral] 23
 #    1|             6: [NullLiteral] null
-#    6|     4: [Method] testStaticFunction
+#    6|     3: [Method] testStaticFunction
 #-----|       1: (Annotations)
 #    5|         1: [Annotation] JvmOverloads
 #    5|         2: [Annotation] JvmStatic
@@ -190,6 +170,26 @@ test.kt:
 #    6|       5: [BlockStmt] { ... }
 #    6|         0: [ReturnStmt] return ...
 #    6|           0: [VarAccess] a
+#    6|     4: [Method] testStaticFunction
+#    6|       3: [TypeAccess] int
+#-----|       4: (Parameters)
+#    6|         0: [Parameter] a
+#    6|           0: [TypeAccess] int
+#    6|         1: [Parameter] c
+#    6|           0: [TypeAccess] double
+#    6|         2: [Parameter] e
+#    6|           0: [TypeAccess] boolean
+#    6|       5: [BlockStmt] { ... }
+#    6|         0: [ReturnStmt] return ...
+#    6|           0: [MethodAccess] testStaticFunction$default(...)
+#    6|             -1: [TypeAccess] Test
+#    0|             0: [VarAccess] a
+#    1|             1: [NullLiteral] null
+#    0|             2: [VarAccess] c
+#    1|             3: [FloatLiteral] 0.0
+#    0|             4: [VarAccess] e
+#    1|             5: [IntegerLiteral] 21
+#    1|             6: [NullLiteral] null
 #    6|     5: [Method] testStaticFunction$default
 #    6|       3: [TypeAccess] int
 #-----|       4: (Parameters)
@@ -242,27 +242,6 @@ test.kt:
 #-----|       4: (Parameters)
 #    9|         0: [Parameter] a
 #    9|           0: [TypeAccess] int
-#    9|         1: [Parameter] c
-#    9|           0: [TypeAccess] double
-#    9|         2: [Parameter] e
-#    9|           0: [TypeAccess] boolean
-#    9|       5: [BlockStmt] { ... }
-#    9|         0: [ReturnStmt] return ...
-#    9|           0: [MethodAccess] testMemberFunction$default(...)
-#    9|             -1: [TypeAccess] Test
-#    0|             0: [ThisAccess] this
-#    0|             1: [VarAccess] a
-#    1|             2: [NullLiteral] null
-#    0|             3: [VarAccess] c
-#    1|             4: [FloatLiteral] 0.0
-#    0|             5: [VarAccess] e
-#    1|             6: [IntegerLiteral] 21
-#    1|             7: [NullLiteral] null
-#    9|     7: [Method] testMemberFunction
-#    9|       3: [TypeAccess] int
-#-----|       4: (Parameters)
-#    9|         0: [Parameter] a
-#    9|           0: [TypeAccess] int
 #    9|         1: [Parameter] b
 #    9|           0: [TypeAccess] String
 #    9|         2: [Parameter] c
@@ -281,7 +260,7 @@ test.kt:
 #    0|             5: [VarAccess] e
 #    1|             6: [IntegerLiteral] 23
 #    1|             7: [NullLiteral] null
-#    9|     8: [Method] testMemberFunction
+#    9|     7: [Method] testMemberFunction
 #-----|       1: (Annotations)
 #    8|         1: [Annotation] JvmOverloads
 #    9|       3: [TypeAccess] int
@@ -299,6 +278,27 @@ test.kt:
 #    9|       5: [BlockStmt] { ... }
 #    9|         0: [ReturnStmt] return ...
 #    9|           0: [VarAccess] a
+#    9|     8: [Method] testMemberFunction
+#    9|       3: [TypeAccess] int
+#-----|       4: (Parameters)
+#    9|         0: [Parameter] a
+#    9|           0: [TypeAccess] int
+#    9|         1: [Parameter] c
+#    9|           0: [TypeAccess] double
+#    9|         2: [Parameter] e
+#    9|           0: [TypeAccess] boolean
+#    9|       5: [BlockStmt] { ... }
+#    9|         0: [ReturnStmt] return ...
+#    9|           0: [MethodAccess] testMemberFunction$default(...)
+#    9|             -1: [TypeAccess] Test
+#    0|             0: [ThisAccess] this
+#    0|             1: [VarAccess] a
+#    1|             2: [NullLiteral] null
+#    0|             3: [VarAccess] c
+#    1|             4: [FloatLiteral] 0.0
+#    0|             5: [VarAccess] e
+#    1|             6: [IntegerLiteral] 21
+#    1|             7: [NullLiteral] null
 #    9|     9: [Method] testMemberFunction$default
 #    9|       3: [TypeAccess] int
 #-----|       4: (Parameters)
@@ -355,31 +355,6 @@ test.kt:
 #   12|           0: [TypeAccess] Test2
 #   12|         1: [Parameter] a
 #   12|           0: [TypeAccess] int
-#   12|         2: [Parameter] c
-#   12|           0: [TypeAccess] double
-#   12|         3: [Parameter] e
-#   12|           0: [TypeAccess] boolean
-#   12|       5: [BlockStmt] { ... }
-#   12|         0: [ReturnStmt] return ...
-#   12|           0: [MethodAccess] testMemberExtensionFunction$default(...)
-#   12|             -1: [TypeAccess] Test
-#    0|             0: [ThisAccess] Test.this
-#    0|               0: [TypeAccess] Test
-#    0|             1: [ExtensionReceiverAccess] this
-#    0|             2: [VarAccess] a
-#    1|             3: [NullLiteral] null
-#    0|             4: [VarAccess] c
-#    1|             5: [FloatLiteral] 0.0
-#    0|             6: [VarAccess] e
-#    1|             7: [IntegerLiteral] 21
-#    1|             8: [NullLiteral] null
-#   12|     11: [ExtensionMethod] testMemberExtensionFunction
-#   12|       3: [TypeAccess] int
-#-----|       4: (Parameters)
-#   12|         0: [Parameter] <this>
-#   12|           0: [TypeAccess] Test2
-#   12|         1: [Parameter] a
-#   12|           0: [TypeAccess] int
 #   12|         2: [Parameter] b
 #   12|           0: [TypeAccess] String
 #   12|         3: [Parameter] c
@@ -400,7 +375,7 @@ test.kt:
 #    0|             6: [VarAccess] e
 #    1|             7: [IntegerLiteral] 23
 #    1|             8: [NullLiteral] null
-#   12|     12: [ExtensionMethod] testMemberExtensionFunction
+#   12|     11: [ExtensionMethod] testMemberExtensionFunction
 #-----|       1: (Annotations)
 #   11|         1: [Annotation] JvmOverloads
 #   12|       3: [TypeAccess] int
@@ -420,6 +395,31 @@ test.kt:
 #   12|       5: [BlockStmt] { ... }
 #   12|         0: [ReturnStmt] return ...
 #   12|           0: [VarAccess] a
+#   12|     12: [ExtensionMethod] testMemberExtensionFunction
+#   12|       3: [TypeAccess] int
+#-----|       4: (Parameters)
+#   12|         0: [Parameter] <this>
+#   12|           0: [TypeAccess] Test2
+#   12|         1: [Parameter] a
+#   12|           0: [TypeAccess] int
+#   12|         2: [Parameter] c
+#   12|           0: [TypeAccess] double
+#   12|         3: [Parameter] e
+#   12|           0: [TypeAccess] boolean
+#   12|       5: [BlockStmt] { ... }
+#   12|         0: [ReturnStmt] return ...
+#   12|           0: [MethodAccess] testMemberExtensionFunction$default(...)
+#   12|             -1: [TypeAccess] Test
+#    0|             0: [ThisAccess] Test.this
+#    0|               0: [TypeAccess] Test
+#    0|             1: [ExtensionReceiverAccess] this
+#    0|             2: [VarAccess] a
+#    1|             3: [NullLiteral] null
+#    0|             4: [VarAccess] c
+#    1|             5: [FloatLiteral] 0.0
+#    0|             6: [VarAccess] e
+#    1|             7: [IntegerLiteral] 21
+#    1|             8: [NullLiteral] null
 #   12|     13: [ExtensionMethod] testMemberExtensionFunction$default
 #   12|       3: [TypeAccess] int
 #-----|       4: (Parameters)
@@ -477,23 +477,6 @@ test.kt:
 #-----|       4: (Parameters)
 #   16|         0: [Parameter] a
 #   16|           0: [TypeAccess] int
-#   16|         1: [Parameter] c
-#   16|           0: [TypeAccess] double
-#   16|         2: [Parameter] e
-#   16|           0: [TypeAccess] boolean
-#   16|       5: [BlockStmt] { ... }
-#   16|         0: [ThisConstructorInvocationStmt] this(...)
-#    0|           0: [VarAccess] a
-#    1|           1: [NullLiteral] null
-#    0|           2: [VarAccess] c
-#    1|           3: [FloatLiteral] 0.0
-#    0|           4: [VarAccess] e
-#    1|           5: [IntegerLiteral] 21
-#    1|           6: [NullLiteral] null
-#   16|     2: [Constructor] Test2
-#-----|       4: (Parameters)
-#   16|         0: [Parameter] a
-#   16|           0: [TypeAccess] int
 #   16|         1: [Parameter] b
 #   16|           0: [TypeAccess] String
 #   16|         2: [Parameter] c
@@ -509,7 +492,7 @@ test.kt:
 #    0|           4: [VarAccess] e
 #    1|           5: [IntegerLiteral] 23
 #    1|           6: [NullLiteral] null
-#   16|     3: [Constructor] Test2
+#   16|     2: [Constructor] Test2
 #-----|       1: (Annotations)
 #   16|         1: [Annotation] JvmOverloads
 #-----|       4: (Parameters)
@@ -526,7 +509,7 @@ test.kt:
 #   16|       5: [BlockStmt] { ... }
 #   16|         0: [SuperConstructorInvocationStmt] super(...)
 #   16|         1: [BlockStmt] { ... }
-#   16|     4: [Constructor] Test2
+#   16|     3: [Constructor] Test2
 #-----|       4: (Parameters)
 #   16|         0: [Parameter] p0
 #   16|           0: [TypeAccess] int
@@ -570,33 +553,29 @@ test.kt:
 #   16|           2: [VarAccess] p2
 #   16|           3: [VarAccess] p3
 #   16|           4: [VarAccess] p4
+#   16|     4: [Constructor] Test2
+#-----|       4: (Parameters)
+#   16|         0: [Parameter] a
+#   16|           0: [TypeAccess] int
+#   16|         1: [Parameter] c
+#   16|           0: [TypeAccess] double
+#   16|         2: [Parameter] e
+#   16|           0: [TypeAccess] boolean
+#   16|       5: [BlockStmt] { ... }
+#   16|         0: [ThisConstructorInvocationStmt] this(...)
+#    0|           0: [VarAccess] a
+#    1|           1: [NullLiteral] null
+#    0|           2: [VarAccess] c
+#    1|           3: [FloatLiteral] 0.0
+#    0|           4: [VarAccess] e
+#    1|           5: [IntegerLiteral] 21
+#    1|           6: [NullLiteral] null
 #   18|     5: [Class] Companion
 #   18|       1: [Constructor] Companion
 #   18|         5: [BlockStmt] { ... }
 #   18|           0: [SuperConstructorInvocationStmt] super(...)
 #   18|           1: [BlockStmt] { ... }
 #   21|       2: [Method] testCompanionFunction
-#   21|         3: [TypeAccess] int
-#-----|         4: (Parameters)
-#   21|           0: [Parameter] a
-#   21|             0: [TypeAccess] int
-#   21|           1: [Parameter] c
-#   21|             0: [TypeAccess] double
-#   21|           2: [Parameter] e
-#   21|             0: [TypeAccess] boolean
-#   21|         5: [BlockStmt] { ... }
-#   21|           0: [ReturnStmt] return ...
-#   21|             0: [MethodAccess] testCompanionFunction$default(...)
-#   21|               -1: [TypeAccess] Companion
-#    0|               0: [ThisAccess] this
-#    0|               1: [VarAccess] a
-#    1|               2: [NullLiteral] null
-#    0|               3: [VarAccess] c
-#    1|               4: [FloatLiteral] 0.0
-#    0|               5: [VarAccess] e
-#    1|               6: [IntegerLiteral] 21
-#    1|               7: [NullLiteral] null
-#   21|       3: [Method] testCompanionFunction
 #   21|         3: [TypeAccess] int
 #-----|         4: (Parameters)
 #   21|           0: [Parameter] a
@@ -619,7 +598,7 @@ test.kt:
 #    0|               5: [VarAccess] e
 #    1|               6: [IntegerLiteral] 23
 #    1|               7: [NullLiteral] null
-#   21|       4: [Method] testCompanionFunction
+#   21|       3: [Method] testCompanionFunction
 #-----|         1: (Annotations)
 #   20|           1: [Annotation] JvmOverloads
 #   21|         3: [TypeAccess] int
@@ -637,6 +616,27 @@ test.kt:
 #   21|         5: [BlockStmt] { ... }
 #   21|           0: [ReturnStmt] return ...
 #   21|             0: [VarAccess] a
+#   21|       4: [Method] testCompanionFunction
+#   21|         3: [TypeAccess] int
+#-----|         4: (Parameters)
+#   21|           0: [Parameter] a
+#   21|             0: [TypeAccess] int
+#   21|           1: [Parameter] c
+#   21|             0: [TypeAccess] double
+#   21|           2: [Parameter] e
+#   21|             0: [TypeAccess] boolean
+#   21|         5: [BlockStmt] { ... }
+#   21|           0: [ReturnStmt] return ...
+#   21|             0: [MethodAccess] testCompanionFunction$default(...)
+#   21|               -1: [TypeAccess] Companion
+#    0|               0: [ThisAccess] this
+#    0|               1: [VarAccess] a
+#    1|               2: [NullLiteral] null
+#    0|               3: [VarAccess] c
+#    1|               4: [FloatLiteral] 0.0
+#    0|               5: [VarAccess] e
+#    1|               6: [IntegerLiteral] 21
+#    1|               7: [NullLiteral] null
 #   21|       5: [Method] testCompanionFunction$default
 #   21|         3: [TypeAccess] int
 #-----|         4: (Parameters)
@@ -691,27 +691,6 @@ test.kt:
 #-----|         4: (Parameters)
 #   24|           0: [Parameter] a
 #   24|             0: [TypeAccess] int
-#   24|           1: [Parameter] c
-#   24|             0: [TypeAccess] double
-#   24|           2: [Parameter] e
-#   24|             0: [TypeAccess] boolean
-#   24|         5: [BlockStmt] { ... }
-#   24|           0: [ReturnStmt] return ...
-#   24|             0: [MethodAccess] testStaticCompanionFunction$default(...)
-#   24|               -1: [TypeAccess] Companion
-#    0|               0: [ThisAccess] this
-#    0|               1: [VarAccess] a
-#    1|               2: [NullLiteral] null
-#    0|               3: [VarAccess] c
-#    1|               4: [FloatLiteral] 0.0
-#    0|               5: [VarAccess] e
-#    1|               6: [IntegerLiteral] 21
-#    1|               7: [NullLiteral] null
-#   24|       7: [Method] testStaticCompanionFunction
-#   24|         3: [TypeAccess] int
-#-----|         4: (Parameters)
-#   24|           0: [Parameter] a
-#   24|             0: [TypeAccess] int
 #   24|           1: [Parameter] b
 #   24|             0: [TypeAccess] String
 #   24|           2: [Parameter] c
@@ -730,7 +709,7 @@ test.kt:
 #    0|               5: [VarAccess] e
 #    1|               6: [IntegerLiteral] 23
 #    1|               7: [NullLiteral] null
-#   24|       8: [Method] testStaticCompanionFunction
+#   24|       7: [Method] testStaticCompanionFunction
 #-----|         1: (Annotations)
 #   23|           1: [Annotation] JvmOverloads
 #   23|           2: [Annotation] JvmStatic
@@ -749,6 +728,27 @@ test.kt:
 #   24|         5: [BlockStmt] { ... }
 #   24|           0: [ReturnStmt] return ...
 #   24|             0: [VarAccess] a
+#   24|       8: [Method] testStaticCompanionFunction
+#   24|         3: [TypeAccess] int
+#-----|         4: (Parameters)
+#   24|           0: [Parameter] a
+#   24|             0: [TypeAccess] int
+#   24|           1: [Parameter] c
+#   24|             0: [TypeAccess] double
+#   24|           2: [Parameter] e
+#   24|             0: [TypeAccess] boolean
+#   24|         5: [BlockStmt] { ... }
+#   24|           0: [ReturnStmt] return ...
+#   24|             0: [MethodAccess] testStaticCompanionFunction$default(...)
+#   24|               -1: [TypeAccess] Companion
+#    0|               0: [ThisAccess] this
+#    0|               1: [VarAccess] a
+#    1|               2: [NullLiteral] null
+#    0|               3: [VarAccess] c
+#    1|               4: [FloatLiteral] 0.0
+#    0|               5: [VarAccess] e
+#    1|               6: [IntegerLiteral] 21
+#    1|               7: [NullLiteral] null
 #   24|       9: [Method] testStaticCompanionFunction$default
 #   24|         3: [TypeAccess] int
 #-----|         4: (Parameters)
@@ -803,27 +803,6 @@ test.kt:
 #-----|       4: (Parameters)
 #   24|         0: [Parameter] a
 #   24|           0: [TypeAccess] int
-#   24|         1: [Parameter] c
-#   24|           0: [TypeAccess] double
-#   24|         2: [Parameter] e
-#   24|           0: [TypeAccess] boolean
-#   24|       5: [BlockStmt] { ... }
-#   24|         0: [ReturnStmt] return ...
-#   24|           0: [MethodAccess] testStaticCompanionFunction$default(...)
-#   24|             -1: [TypeAccess] Companion
-#    0|             0: [ThisAccess] this
-#    0|             1: [VarAccess] a
-#    1|             2: [NullLiteral] null
-#    0|             3: [VarAccess] c
-#    1|             4: [FloatLiteral] 0.0
-#    0|             5: [VarAccess] e
-#    1|             6: [IntegerLiteral] 21
-#    1|             7: [NullLiteral] null
-#   24|     7: [Method] testStaticCompanionFunction
-#   24|       3: [TypeAccess] int
-#-----|       4: (Parameters)
-#   24|         0: [Parameter] a
-#   24|           0: [TypeAccess] int
 #   24|         1: [Parameter] b
 #   24|           0: [TypeAccess] String
 #   24|         2: [Parameter] c
@@ -842,7 +821,7 @@ test.kt:
 #    0|             5: [VarAccess] e
 #    1|             6: [IntegerLiteral] 23
 #    1|             7: [NullLiteral] null
-#   24|     8: [Method] testStaticCompanionFunction
+#   24|     7: [Method] testStaticCompanionFunction
 #   24|       3: [TypeAccess] int
 #-----|       4: (Parameters)
 #   24|         0: [Parameter] a
@@ -865,6 +844,27 @@ test.kt:
 #   24|             2: [VarAccess] c
 #   24|             3: [VarAccess] d
 #   24|             4: [VarAccess] e
+#   24|     8: [Method] testStaticCompanionFunction
+#   24|       3: [TypeAccess] int
+#-----|       4: (Parameters)
+#   24|         0: [Parameter] a
+#   24|           0: [TypeAccess] int
+#   24|         1: [Parameter] c
+#   24|           0: [TypeAccess] double
+#   24|         2: [Parameter] e
+#   24|           0: [TypeAccess] boolean
+#   24|       5: [BlockStmt] { ... }
+#   24|         0: [ReturnStmt] return ...
+#   24|           0: [MethodAccess] testStaticCompanionFunction$default(...)
+#   24|             -1: [TypeAccess] Companion
+#    0|             0: [ThisAccess] this
+#    0|             1: [VarAccess] a
+#    1|             2: [NullLiteral] null
+#    0|             3: [VarAccess] c
+#    1|             4: [FloatLiteral] 0.0
+#    0|             5: [VarAccess] e
+#    1|             6: [IntegerLiteral] 21
+#    1|             7: [NullLiteral] null
 #   30|   4: [Class,GenericType,ParameterizedType] GenericTest
 #-----|     -2: (Generic Parameters)
 #   30|       0: [TypeVariable] T
@@ -883,37 +883,6 @@ test.kt:
 #    1|           4: [IntegerLiteral] 10
 #    1|           5: [NullLiteral] null
 #   30|     2: [Constructor] GenericTest
-#-----|       4: (Parameters)
-#   30|         0: [Parameter] a
-#   30|           0: [TypeAccess] int
-#   30|         1: [Parameter] b
-#   30|           0: [TypeAccess] T
-#   30|         2: [Parameter] d
-#   30|           0: [TypeAccess] T
-#   30|       5: [BlockStmt] { ... }
-#   30|         0: [ThisConstructorInvocationStmt] this(...)
-#    0|           0: [VarAccess] a
-#    0|           1: [VarAccess] b
-#    1|           2: [NullLiteral] null
-#    0|           3: [VarAccess] d
-#    1|           4: [IntegerLiteral] 11
-#    1|           5: [NullLiteral] null
-#   30|     3: [Constructor] GenericTest
-#-----|       1: (Annotations)
-#   30|         1: [Annotation] JvmOverloads
-#-----|       4: (Parameters)
-#   30|         0: [Parameter] a
-#   30|           0: [TypeAccess] int
-#   30|         1: [Parameter] b
-#   30|           0: [TypeAccess] T
-#   30|         2: [Parameter] c
-#   30|           0: [TypeAccess] String
-#   30|         3: [Parameter] d
-#   30|           0: [TypeAccess] T
-#   30|       5: [BlockStmt] { ... }
-#   30|         0: [SuperConstructorInvocationStmt] super(...)
-#   30|         1: [BlockStmt] { ... }
-#   30|     4: [Constructor] GenericTest
 #-----|       4: (Parameters)
 #   30|         0: [Parameter] p0
 #   30|           0: [TypeAccess] int
@@ -953,6 +922,37 @@ test.kt:
 #   30|           1: [VarAccess] p1
 #   30|           2: [VarAccess] p2
 #   30|           3: [VarAccess] p3
+#   30|     3: [Constructor] GenericTest
+#-----|       1: (Annotations)
+#   30|         1: [Annotation] JvmOverloads
+#-----|       4: (Parameters)
+#   30|         0: [Parameter] a
+#   30|           0: [TypeAccess] int
+#   30|         1: [Parameter] b
+#   30|           0: [TypeAccess] T
+#   30|         2: [Parameter] c
+#   30|           0: [TypeAccess] String
+#   30|         3: [Parameter] d
+#   30|           0: [TypeAccess] T
+#   30|       5: [BlockStmt] { ... }
+#   30|         0: [SuperConstructorInvocationStmt] super(...)
+#   30|         1: [BlockStmt] { ... }
+#   30|     4: [Constructor] GenericTest
+#-----|       4: (Parameters)
+#   30|         0: [Parameter] a
+#   30|           0: [TypeAccess] int
+#   30|         1: [Parameter] b
+#   30|           0: [TypeAccess] T
+#   30|         2: [Parameter] d
+#   30|           0: [TypeAccess] T
+#   30|       5: [BlockStmt] { ... }
+#   30|         0: [ThisConstructorInvocationStmt] this(...)
+#    0|           0: [VarAccess] a
+#    0|           1: [VarAccess] b
+#    1|           2: [NullLiteral] null
+#    0|           3: [VarAccess] d
+#    1|           4: [IntegerLiteral] 11
+#    1|           5: [NullLiteral] null
 #   33|     5: [Method] testMemberFunction
 #   33|       3: [TypeAccess] int
 #-----|       4: (Parameters)
@@ -972,6 +972,22 @@ test.kt:
 #    1|             5: [IntegerLiteral] 10
 #    1|             6: [NullLiteral] null
 #   33|     6: [Method] testMemberFunction
+#-----|       1: (Annotations)
+#   32|         1: [Annotation] JvmOverloads
+#   33|       3: [TypeAccess] int
+#-----|       4: (Parameters)
+#   33|         0: [Parameter] a
+#   33|           0: [TypeAccess] int
+#   33|         1: [Parameter] b
+#   33|           0: [TypeAccess] T
+#   33|         2: [Parameter] c
+#   33|           0: [TypeAccess] String
+#   33|         3: [Parameter] d
+#   33|           0: [TypeAccess] T
+#   33|       5: [BlockStmt] { ... }
+#   33|         0: [ReturnStmt] return ...
+#   33|           0: [VarAccess] a
+#   33|     7: [Method] testMemberFunction
 #   33|       3: [TypeAccess] int
 #-----|       4: (Parameters)
 #   33|         0: [Parameter] a
@@ -991,22 +1007,6 @@ test.kt:
 #    0|             4: [VarAccess] d
 #    1|             5: [IntegerLiteral] 11
 #    1|             6: [NullLiteral] null
-#   33|     7: [Method] testMemberFunction
-#-----|       1: (Annotations)
-#   32|         1: [Annotation] JvmOverloads
-#   33|       3: [TypeAccess] int
-#-----|       4: (Parameters)
-#   33|         0: [Parameter] a
-#   33|           0: [TypeAccess] int
-#   33|         1: [Parameter] b
-#   33|           0: [TypeAccess] T
-#   33|         2: [Parameter] c
-#   33|           0: [TypeAccess] String
-#   33|         3: [Parameter] d
-#   33|           0: [TypeAccess] T
-#   33|       5: [BlockStmt] { ... }
-#   33|         0: [ReturnStmt] return ...
-#   33|           0: [VarAccess] a
 #   33|     8: [Method] testMemberFunction$default
 #   33|       3: [TypeAccess] int
 #-----|       4: (Parameters)


### PR DESCRIPTION
We now look not only at how many parameters each callable has, but what its full signature is. This allows us to give a consistent order to
```
    Test(Throwable) { ... }
    Test(String) { ... }
```