### PR TITLE
Swift: Fix `SummaryCall::getEnclosingCallable`

### DIFF
--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowDispatch.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowDispatch.qll
@@ -219,9 +219,7 @@ class SummaryCall extends DataFlowCall, TSummaryCall {
   /** Gets the data flow node that this call targets. */
   Node getReceiver() { result = receiver }
 
-  override DataFlowCallable getEnclosingCallable() {
-    result = TDataFlowFunc(c.getEnclosingFunction())
-  }
+  override DataFlowCallable getEnclosingCallable() { result = TSummarizedCallable(c) }
 
   override string toString() { result = "[summary] call to " + receiver + " in " + c }
 


### PR DESCRIPTION
Identified via https://github.com/github/codeql/pull/12519.