### PR TITLE
Compile error.

### DIFF
--- a/java/ql/test/library-tests/dataflow/inoutbarriers/test.ql
+++ b/java/ql/test/library-tests/dataflow/inoutbarriers/test.ql
@@ -44,6 +44,8 @@ module Conf4 implements ConfigSig {
   predicate isBarrierIn(Node n) { src0(n) }
 
   predicate isBarrierOut(Node n) { sink0(n) }
+
+  DataFlow::FlowFeature getAFeature() { result instanceof DataFlow::FeatureHasSinkCallContext }
 }
 
 predicate flow(Node src, Node sink, string s) {


### PR DESCRIPTION
The added code provides an implementation of a predicate which has a `none()` default.
```codeql
DataFlow::FlowFeature getAFeature() { result instanceof DataFlow::FeatureHasSinkCallContext }
```

This leads to a compile error:
```
ERROR: call to empty relation: DataFlowImpl::Impl::hasSourceCallCtx (/Users/michaelnebel/Work/semmle-code/ql/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll:2808,12-28)
```

Note that
```codeql
  private predicate hasSourceCallCtx() {
    exists(FlowFeature feature | feature = Config::getAFeature() |
      feature instanceof FeatureHasSourceCallContext or
      feature instanceof FeatureEqualSourceSinkCallContext
    )
  }
```

Am I missing anything?