### PR TITLE
DataFlow: Workaround empty predicate usage in IPA branch.

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -418,6 +418,10 @@ module Impl<FullStateConfigSig Config> {
     )
   }
 
+  private predicate sourceCallCtx(CallContext cc) {
+    if hasSourceCallCtx() then cc instanceof CallContextSomeCall else cc instanceof CallContextAny
+  }
+
   private predicate hasSinkCallCtx() {
     exists(FlowFeature feature | feature = Config::getAFeature() |
       feature instanceof FeatureHasSinkCallContext or
@@ -2804,11 +2808,7 @@ module Impl<FullStateConfigSig Config> {
       // A PathNode is introduced by a source ...
       Stage5::revFlow(node, state) and
       sourceNode(node, state) and
-      (
-        if hasSourceCallCtx()
-        then cc instanceof CallContextSomeCall
-        else cc instanceof CallContextAny
-      ) and
+      sourceCallCtx(cc) and
       sc instanceof SummaryCtxNone and
       ap = TAccessPathNil(node.getDataFlowType())
       or
@@ -3214,11 +3214,7 @@ module Impl<FullStateConfigSig Config> {
 
     override predicate isSource() {
       sourceNode(node, state) and
-      (
-        if hasSourceCallCtx()
-        then cc instanceof CallContextSomeCall
-        else cc instanceof CallContextAny
-      ) and
+      sourceCallCtx(cc) and
       sc instanceof SummaryCtxNone and
       ap = TAccessPathNil(node.getDataFlowType())
     }

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -418,6 +418,10 @@ module Impl<FullStateConfigSig Config> {
     )
   }
 
+  private predicate sourceCallCtx(CallContext cc) {
+    if hasSourceCallCtx() then cc instanceof CallContextSomeCall else cc instanceof CallContextAny
+  }
+
   private predicate hasSinkCallCtx() {
     exists(FlowFeature feature | feature = Config::getAFeature() |
       feature instanceof FeatureHasSinkCallContext or
@@ -2804,11 +2808,7 @@ module Impl<FullStateConfigSig Config> {
       // A PathNode is introduced by a source ...
       Stage5::revFlow(node, state) and
       sourceNode(node, state) and
-      (
-        if hasSourceCallCtx()
-        then cc instanceof CallContextSomeCall
-        else cc instanceof CallContextAny
-      ) and
+      sourceCallCtx(cc) and
       sc instanceof SummaryCtxNone and
       ap = TAccessPathNil(node.getDataFlowType())
       or
@@ -3214,11 +3214,7 @@ module Impl<FullStateConfigSig Config> {
 
     override predicate isSource() {
       sourceNode(node, state) and
-      (
-        if hasSourceCallCtx()
-        then cc instanceof CallContextSomeCall
-        else cc instanceof CallContextAny
-      ) and
+      sourceCallCtx(cc) and
       sc instanceof SummaryCtxNone and
       ap = TAccessPathNil(node.getDataFlowType())
     }

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -418,6 +418,10 @@ module Impl<FullStateConfigSig Config> {
     )
   }
 
+  private predicate sourceCallCtx(CallContext cc) {
+    if hasSourceCallCtx() then cc instanceof CallContextSomeCall else cc instanceof CallContextAny
+  }
+
   private predicate hasSinkCallCtx() {
     exists(FlowFeature feature | feature = Config::getAFeature() |
       feature instanceof FeatureHasSinkCallContext or
@@ -2804,11 +2808,7 @@ module Impl<FullStateConfigSig Config> {
       // A PathNode is introduced by a source ...
       Stage5::revFlow(node, state) and
       sourceNode(node, state) and
-      (
-        if hasSourceCallCtx()
-        then cc instanceof CallContextSomeCall
-        else cc instanceof CallContextAny
-      ) and
+      sourceCallCtx(cc) and
       sc instanceof SummaryCtxNone and
       ap = TAccessPathNil(node.getDataFlowType())
       or
@@ -3214,11 +3214,7 @@ module Impl<FullStateConfigSig Config> {
 
     override predicate isSource() {
       sourceNode(node, state) and
-      (
-        if hasSourceCallCtx()
-        then cc instanceof CallContextSomeCall
-        else cc instanceof CallContextAny
-      ) and
+      sourceCallCtx(cc) and
       sc instanceof SummaryCtxNone and
       ap = TAccessPathNil(node.getDataFlowType())
     }

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowImpl.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowImpl.qll
@@ -418,6 +418,10 @@ module Impl<FullStateConfigSig Config> {
     )
   }
 
+  private predicate sourceCallCtx(CallContext cc) {
+    if hasSourceCallCtx() then cc instanceof CallContextSomeCall else cc instanceof CallContextAny
+  }
+
   private predicate hasSinkCallCtx() {
     exists(FlowFeature feature | feature = Config::getAFeature() |
       feature instanceof FeatureHasSinkCallContext or
@@ -2804,11 +2808,7 @@ module Impl<FullStateConfigSig Config> {
       // A PathNode is introduced by a source ...
       Stage5::revFlow(node, state) and
       sourceNode(node, state) and
-      (
-        if hasSourceCallCtx()
-        then cc instanceof CallContextSomeCall
-        else cc instanceof CallContextAny
-      ) and
+      sourceCallCtx(cc) and
       sc instanceof SummaryCtxNone and
       ap = TAccessPathNil(node.getDataFlowType())
       or
@@ -3214,11 +3214,7 @@ module Impl<FullStateConfigSig Config> {
 
     override predicate isSource() {
       sourceNode(node, state) and
-      (
-        if hasSourceCallCtx()
-        then cc instanceof CallContextSomeCall
-        else cc instanceof CallContextAny
-      ) and
+      sourceCallCtx(cc) and
       sc instanceof SummaryCtxNone and
       ap = TAccessPathNil(node.getDataFlowType())
     }

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -418,6 +418,10 @@ module Impl<FullStateConfigSig Config> {
     )
   }
 
+  private predicate sourceCallCtx(CallContext cc) {
+    if hasSourceCallCtx() then cc instanceof CallContextSomeCall else cc instanceof CallContextAny
+  }
+
   private predicate hasSinkCallCtx() {
     exists(FlowFeature feature | feature = Config::getAFeature() |
       feature instanceof FeatureHasSinkCallContext or
@@ -2804,11 +2808,7 @@ module Impl<FullStateConfigSig Config> {
       // A PathNode is introduced by a source ...
       Stage5::revFlow(node, state) and
       sourceNode(node, state) and
-      (
-        if hasSourceCallCtx()
-        then cc instanceof CallContextSomeCall
-        else cc instanceof CallContextAny
-      ) and
+      sourceCallCtx(cc) and
       sc instanceof SummaryCtxNone and
       ap = TAccessPathNil(node.getDataFlowType())
       or
@@ -3214,11 +3214,7 @@ module Impl<FullStateConfigSig Config> {
 
     override predicate isSource() {
       sourceNode(node, state) and
-      (
-        if hasSourceCallCtx()
-        then cc instanceof CallContextSomeCall
-        else cc instanceof CallContextAny
-      ) and
+      sourceCallCtx(cc) and
       sc instanceof SummaryCtxNone and
       ap = TAccessPathNil(node.getDataFlowType())
     }

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl.qll
@@ -418,6 +418,10 @@ module Impl<FullStateConfigSig Config> {
     )
   }
 
+  private predicate sourceCallCtx(CallContext cc) {
+    if hasSourceCallCtx() then cc instanceof CallContextSomeCall else cc instanceof CallContextAny
+  }
+
   private predicate hasSinkCallCtx() {
     exists(FlowFeature feature | feature = Config::getAFeature() |
       feature instanceof FeatureHasSinkCallContext or
@@ -2804,11 +2808,7 @@ module Impl<FullStateConfigSig Config> {
       // A PathNode is introduced by a source ...
       Stage5::revFlow(node, state) and
       sourceNode(node, state) and
-      (
-        if hasSourceCallCtx()
-        then cc instanceof CallContextSomeCall
-        else cc instanceof CallContextAny
-      ) and
+      sourceCallCtx(cc) and
       sc instanceof SummaryCtxNone and
       ap = TAccessPathNil(node.getDataFlowType())
       or
@@ -3214,11 +3214,7 @@ module Impl<FullStateConfigSig Config> {
 
     override predicate isSource() {
       sourceNode(node, state) and
-      (
-        if hasSourceCallCtx()
-        then cc instanceof CallContextSomeCall
-        else cc instanceof CallContextAny
-      ) and
+      sourceCallCtx(cc) and
       sc instanceof SummaryCtxNone and
       ap = TAccessPathNil(node.getDataFlowType())
     }

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl.qll
@@ -418,6 +418,10 @@ module Impl<FullStateConfigSig Config> {
     )
   }
 
+  private predicate sourceCallCtx(CallContext cc) {
+    if hasSourceCallCtx() then cc instanceof CallContextSomeCall else cc instanceof CallContextAny
+  }
+
   private predicate hasSinkCallCtx() {
     exists(FlowFeature feature | feature = Config::getAFeature() |
       feature instanceof FeatureHasSinkCallContext or
@@ -2804,11 +2808,7 @@ module Impl<FullStateConfigSig Config> {
       // A PathNode is introduced by a source ...
       Stage5::revFlow(node, state) and
       sourceNode(node, state) and
-      (
-        if hasSourceCallCtx()
-        then cc instanceof CallContextSomeCall
-        else cc instanceof CallContextAny
-      ) and
+      sourceCallCtx(cc) and
       sc instanceof SummaryCtxNone and
       ap = TAccessPathNil(node.getDataFlowType())
       or
@@ -3214,11 +3214,7 @@ module Impl<FullStateConfigSig Config> {
 
     override predicate isSource() {
       sourceNode(node, state) and
-      (
-        if hasSourceCallCtx()
-        then cc instanceof CallContextSomeCall
-        else cc instanceof CallContextAny
-      ) and
+      sourceCallCtx(cc) and
       sc instanceof SummaryCtxNone and
       ap = TAccessPathNil(node.getDataFlowType())
     }

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImpl.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImpl.qll
@@ -418,6 +418,10 @@ module Impl<FullStateConfigSig Config> {
     )
   }
 
+  private predicate sourceCallCtx(CallContext cc) {
+    if hasSourceCallCtx() then cc instanceof CallContextSomeCall else cc instanceof CallContextAny
+  }
+
   private predicate hasSinkCallCtx() {
     exists(FlowFeature feature | feature = Config::getAFeature() |
       feature instanceof FeatureHasSinkCallContext or
@@ -2804,11 +2808,7 @@ module Impl<FullStateConfigSig Config> {
       // A PathNode is introduced by a source ...
       Stage5::revFlow(node, state) and
       sourceNode(node, state) and
-      (
-        if hasSourceCallCtx()
-        then cc instanceof CallContextSomeCall
-        else cc instanceof CallContextAny
-      ) and
+      sourceCallCtx(cc) and
       sc instanceof SummaryCtxNone and
       ap = TAccessPathNil(node.getDataFlowType())
       or
@@ -3214,11 +3214,7 @@ module Impl<FullStateConfigSig Config> {
 
     override predicate isSource() {
       sourceNode(node, state) and
-      (
-        if hasSourceCallCtx()
-        then cc instanceof CallContextSomeCall
-        else cc instanceof CallContextAny
-      ) and
+      sourceCallCtx(cc) and
       sc instanceof SummaryCtxNone and
       ap = TAccessPathNil(node.getDataFlowType())
     }


### PR DESCRIPTION
It turns out that implementing the `getAFeature()` predicate can lead to a compile error (as seen in https://github.com/github/codeql/pull/12535).
In this PR we make a small re-factor (workaround) to avoid the use of an empty predicate in an IPA type branch, which solves the compilation issue.