### PR TITLE
Java/Python: use Number.qll to parse hex numbers in regex parsing

### DIFF
--- a/java/ql/lib/semmle/code/java/regex/RegexTreeView.qll
+++ b/java/ql/lib/semmle/code/java/regex/RegexTreeView.qll
@@ -470,6 +470,8 @@ module Impl implements RegexTreeViewSig {
     override string getPrimaryQLClass() { result = "RegExpAlt" }
   }
 
+  private import codeql.util.Numbers as Numbers
+
   /**
    * An escaped regular expression term, that is, a regular expression
    * term starting with a backslash, which is not a backreference.
@@ -531,11 +533,7 @@ module Impl implements RegexTreeViewSig {
      * Gets the unicode char for this escape.
      * E.g. for `\u0061` this returns "a".
      */
-    private string getUnicode() {
-      exists(int codepoint | codepoint = sum(this.getHexValueFromUnicode(_)) |
-        result = codepoint.toUnicode()
-      )
-    }
+    private string getUnicode() { result = Numbers::parseHexInt(this.getHexString()).toUnicode() }
 
     /** Gets the part of this escape that is a hexidecimal string */
     private string getHexString() {
@@ -546,18 +544,6 @@ module Impl implements RegexTreeViewSig {
         if this.getText().matches("\\x{%") // \x{h..h}
         then result = this.getText().substring(3, this.getText().length() - 1)
         else result = this.getText().suffix(2) // \xhh
-    }
-
-    /**
-     * Gets int value for the `index`th char in the hex number of the unicode escape.
-     * E.g. for `\u0061` and `index = 2` this returns 96 (the number `6` interpreted as hex).
-     */
-    private int getHexValueFromUnicode(int index) {
-      this.isUnicode() and
-      exists(string hex, string char | hex = this.getHexString() |
-        char = hex.charAt(index) and
-        result = 16.pow(hex.length() - index - 1) * toHex(char)
-      )
     }
   }
 
@@ -584,25 +570,6 @@ module Impl implements RegexTreeViewSig {
    */
   class RegExpNonWordBoundary extends RegExpSpecialChar {
     RegExpNonWordBoundary() { this.getChar() = "\\B" }
-  }
-
-  /**
-   * Gets the hex number for the `hex` char.
-   */
-  private int toHex(string hex) {
-    result = [0 .. 9] and hex = result.toString()
-    or
-    result = 10 and hex = ["a", "A"]
-    or
-    result = 11 and hex = ["b", "B"]
-    or
-    result = 12 and hex = ["c", "C"]
-    or
-    result = 13 and hex = ["d", "D"]
-    or
-    result = 14 and hex = ["e", "E"]
-    or
-    result = 15 and hex = ["f", "F"]
   }
 
   /**

--- a/python/ql/lib/qlpack.yml
+++ b/python/ql/lib/qlpack.yml
@@ -7,6 +7,7 @@ library: true
 upgrades: upgrades
 dependencies:
   codeql/regex: ${workspace}
+  codeql/util: ${workspace}
   codeql/tutorial: ${workspace}
 dataExtensions:
   - semmle/python/frameworks/**/model.yml

--- a/python/ql/lib/semmle/python/RegexTreeView.qll
+++ b/python/ql/lib/semmle/python/RegexTreeView.qll
@@ -468,6 +468,8 @@ module Impl implements RegexTreeViewSig {
    */
   class RegExpCharEscape = RegExpEscape;
 
+  private import codeql.util.Numbers as Numbers
+
   /**
    * An escaped regular expression term, that is, a regular expression
    * term starting with a backslash, which is not a backreference.
@@ -528,42 +530,8 @@ module Impl implements RegexTreeViewSig {
      * E.g. for `\u0061` this returns "a".
      */
     private string getUnicode() {
-      exists(int codepoint | codepoint = sum(this.getHexValueFromUnicode(_)) |
-        result = codepoint.toUnicode()
-      )
+      result = Numbers::parseHexInt(this.getText().suffix(2)).toUnicode()
     }
-
-    /**
-     * Gets int value for the `index`th char in the hex number of the unicode escape.
-     * E.g. for `\u0061` and `index = 2` this returns 96 (the number `6` interpreted as hex).
-     */
-    private int getHexValueFromUnicode(int index) {
-      this.isUnicode() and
-      exists(string hex, string char | hex = this.getText().suffix(2) |
-        char = hex.charAt(index) and
-        result = 16.pow(hex.length() - index - 1) * toHex(char)
-      )
-    }
-  }
-
-  /**
-   * Gets the hex number for the `hex` char.
-   */
-  private int toHex(string hex) {
-    hex = [0 .. 9].toString() and
-    result = hex.toInt()
-    or
-    result = 10 and hex = ["a", "A"]
-    or
-    result = 11 and hex = ["b", "B"]
-    or
-    result = 12 and hex = ["c", "C"]
-    or
-    result = 13 and hex = ["d", "D"]
-    or
-    result = 14 and hex = ["e", "E"]
-    or
-    result = 15 and hex = ["f", "F"]
   }
 
   /**

--- a/python/ql/src/qlpack.yml
+++ b/python/ql/src/qlpack.yml
@@ -6,7 +6,6 @@ groups:
 dependencies:
   codeql/python-all: ${workspace}
   codeql/suite-helpers: ${workspace}
-  codeql/util: ${workspace}
 suites: codeql-suites
 extractor: python
 defaultSuiteFile: codeql-suites/python-code-scanning.qls


### PR DESCRIPTION
My own followup to https://github.com/github/codeql/pull/12169 

Evaluations look uneventful: [Python](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/PR-12550-1-python/reports), [Java](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/PR-12550-0-java/reports). 
