### PR TITLE
Go: exclude `net/http.Header.Set` and `.Del` from `go/untrusted-data-to-external-api`

### DIFF
--- a/go/ql/lib/semmle/go/security/ExternalAPIs.qll
+++ b/go/ql/lib/semmle/go/security/ExternalAPIs.qll
@@ -19,6 +19,16 @@ abstract class SafeExternalApiFunction extends Function { }
 /** DEPRECATED: Alias for SafeExternalApiFunction */
 deprecated class SafeExternalAPIFunction = SafeExternalApiFunction;
 
+/**
+ * A `Function` with one or more arguments that are considered "safe" from a security perspective.
+ */
+abstract class SafeExternalApiArgument extends Function {
+  /**
+   * Holds if `i` is a safe argument to this function.
+   */
+  abstract predicate isSafeArgument(int i);
+}
+
 private predicate isDefaultSafePackage(Package package) {
   package.getPath() in ["time", "unicode/utf8", package("gopkg.in/go-playground/validator", "")]
 }
@@ -42,6 +52,16 @@ private class DefaultSafeExternalApiFunction extends SafeExternalApiFunction {
     this.hasQualifiedName("crypto/md5", "Sum") or
     this.hasQualifiedName("crypto/sha1", "Sum")
   }
+}
+
+private class DefaultSafeExternalApiFunctionArgument extends SafeExternalApiArgument {
+  int index;
+
+  DefaultSafeExternalApiFunctionArgument() {
+    this.(Method).hasQualifiedName("net/http", "Header", ["Set", "Del"]) and index = -1
+  }
+
+  override predicate isSafeArgument(int i) { i = index }
 }
 
 /** Holds if `callNode` is a local function pointer. */
@@ -77,7 +97,9 @@ class ExternalApiDataNode extends DataFlow::Node {
     // Not already modeled as a taint step
     not TaintTracking::localTaintStep(this, _) and
     // Not a call to a known safe external API
-    not call.getTarget() instanceof SafeExternalApiFunction
+    not call.getTarget() instanceof SafeExternalApiFunction and
+    // Not a known safe argument to an external API
+    not any(SafeExternalApiArgument seaa).isSafeArgument(i)
   }
 
   /** Gets the called API `Function`. */

--- a/go/ql/src/change-notes/2023-03-16-untrusted-data-write-only-args.md
+++ b/go/ql/src/change-notes/2023-03-16-untrusted-data-write-only-args.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The receiver arguments of `net/http.Header.Set` and `.Del` are no longer flagged by query `go/untrusted-data-to-external-api`.


### PR DESCRIPTION
These functions (and doubtless many others) are write-only with respect to their receiver argument, so it doesn't really make sense to flag externally-controlled data flowing there.