### PR TITLE
C++: Add `range` call to test

### DIFF
--- a/cpp/ql/test/library-tests/ir/range-analysis/SimpleRangeAnalysis_tests.cpp
+++ b/cpp/ql/test/library-tests/ir/range-analysis/SimpleRangeAnalysis_tests.cpp
@@ -119,6 +119,7 @@ int test9(int x, int y) {
     }
     range(x); // $ range=>=4
   }
+  range(x); // $ MISSING: range=>=4
   return x;
 }
 


### PR DESCRIPTION
This demonstrates a missing bound from nested phi nodes.