### PR TITLE
Ruby: Include all assignments in data flow paths

### DIFF
--- a/ruby/ql/lib/codeql/ruby/dataflow/SSA.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/SSA.qll
@@ -216,9 +216,9 @@ module Ssa {
       )
     }
 
-    final override string toString() { result = Definition.super.toString() }
+    final override string toString() { result = write.toString() }
 
-    final override Location getLocation() { result = this.getControlFlowNode().getLocation() }
+    final override Location getLocation() { result = write.getLocation() }
   }
 
   /**

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
@@ -528,10 +528,7 @@ import Cached
 /** Holds if `n` should be hidden from path explanations. */
 predicate nodeIsHidden(Node n) {
   exists(SsaImpl::DefinitionExt def | def = n.(SsaDefinitionExtNode).getDefinitionExt() |
-    def instanceof Ssa::PhiNode or
-    def instanceof SsaImpl::PhiReadNode or
-    def instanceof Ssa::CapturedEntryDefinition or
-    def instanceof Ssa::CapturedCallDefinition
+    not def instanceof Ssa::WriteDefinition
   )
   or
   n = LocalFlow::getParameterDefNode(_)
@@ -1333,7 +1330,15 @@ private module PostUpdateNodes {
 private import PostUpdateNodes
 
 /** A node that performs a type cast. */
-class CastNode extends Node instanceof ReturningNode { }
+class CastNode extends Node {
+  CastNode() {
+    // ensure that actual return nodes are included in the path graph
+    this instanceof ReturningNode
+    or
+    // ensure that all variable assignments are included in the path graph
+    this.(SsaDefinitionExtNode).getDefinitionExt() instanceof Ssa::WriteDefinition
+  }
+}
 
 class DataFlowExpr = CfgNodes::ExprCfgNode;
 

--- a/ruby/ql/test/library-tests/dataflow/array-flow/array-flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/array-flow/array-flow.expected
@@ -1,103 +1,135 @@
 failures
 edges
-| array_flow.rb:2:9:2:20 | * ... [element 0] :  | array_flow.rb:3:10:3:10 | a [element 0] :  |
-| array_flow.rb:2:9:2:20 | * ... [element 0] :  | array_flow.rb:3:10:3:10 | a [element 0] :  |
-| array_flow.rb:2:9:2:20 | * ... [element 0] :  | array_flow.rb:5:10:5:10 | a [element 0] :  |
-| array_flow.rb:2:9:2:20 | * ... [element 0] :  | array_flow.rb:5:10:5:10 | a [element 0] :  |
+| array_flow.rb:2:5:2:5 | a [element 0] :  | array_flow.rb:3:10:3:10 | a [element 0] :  |
+| array_flow.rb:2:5:2:5 | a [element 0] :  | array_flow.rb:3:10:3:10 | a [element 0] :  |
+| array_flow.rb:2:5:2:5 | a [element 0] :  | array_flow.rb:5:10:5:10 | a [element 0] :  |
+| array_flow.rb:2:5:2:5 | a [element 0] :  | array_flow.rb:5:10:5:10 | a [element 0] :  |
+| array_flow.rb:2:9:2:20 | * ... [element 0] :  | array_flow.rb:2:5:2:5 | a [element 0] :  |
+| array_flow.rb:2:9:2:20 | * ... [element 0] :  | array_flow.rb:2:5:2:5 | a [element 0] :  |
 | array_flow.rb:2:10:2:20 | call to source :  | array_flow.rb:2:9:2:20 | * ... [element 0] :  |
 | array_flow.rb:2:10:2:20 | call to source :  | array_flow.rb:2:9:2:20 | * ... [element 0] :  |
 | array_flow.rb:3:10:3:10 | a [element 0] :  | array_flow.rb:3:10:3:13 | ...[...] |
 | array_flow.rb:3:10:3:10 | a [element 0] :  | array_flow.rb:3:10:3:13 | ...[...] |
 | array_flow.rb:5:10:5:10 | a [element 0] :  | array_flow.rb:5:10:5:13 | ...[...] |
 | array_flow.rb:5:10:5:10 | a [element 0] :  | array_flow.rb:5:10:5:13 | ...[...] |
-| array_flow.rb:9:13:9:21 | call to source :  | array_flow.rb:11:10:11:10 | a [element 1] :  |
-| array_flow.rb:9:13:9:21 | call to source :  | array_flow.rb:11:10:11:10 | a [element 1] :  |
-| array_flow.rb:9:13:9:21 | call to source :  | array_flow.rb:13:10:13:10 | a [element 1] :  |
-| array_flow.rb:9:13:9:21 | call to source :  | array_flow.rb:13:10:13:10 | a [element 1] :  |
+| array_flow.rb:9:5:9:5 | a [element 1] :  | array_flow.rb:11:10:11:10 | a [element 1] :  |
+| array_flow.rb:9:5:9:5 | a [element 1] :  | array_flow.rb:11:10:11:10 | a [element 1] :  |
+| array_flow.rb:9:5:9:5 | a [element 1] :  | array_flow.rb:13:10:13:10 | a [element 1] :  |
+| array_flow.rb:9:5:9:5 | a [element 1] :  | array_flow.rb:13:10:13:10 | a [element 1] :  |
+| array_flow.rb:9:13:9:21 | call to source :  | array_flow.rb:9:5:9:5 | a [element 1] :  |
+| array_flow.rb:9:13:9:21 | call to source :  | array_flow.rb:9:5:9:5 | a [element 1] :  |
 | array_flow.rb:11:10:11:10 | a [element 1] :  | array_flow.rb:11:10:11:13 | ...[...] |
 | array_flow.rb:11:10:11:10 | a [element 1] :  | array_flow.rb:11:10:11:13 | ...[...] |
 | array_flow.rb:13:10:13:10 | a [element 1] :  | array_flow.rb:13:10:13:13 | ...[...] |
 | array_flow.rb:13:10:13:10 | a [element 1] :  | array_flow.rb:13:10:13:13 | ...[...] |
-| array_flow.rb:17:9:17:33 | call to new [element] :  | array_flow.rb:18:10:18:10 | a [element] :  |
-| array_flow.rb:17:9:17:33 | call to new [element] :  | array_flow.rb:18:10:18:10 | a [element] :  |
-| array_flow.rb:17:9:17:33 | call to new [element] :  | array_flow.rb:19:10:19:10 | a [element] :  |
-| array_flow.rb:17:9:17:33 | call to new [element] :  | array_flow.rb:19:10:19:10 | a [element] :  |
-| array_flow.rb:17:9:17:33 | call to new [element] :  | array_flow.rb:21:19:21:19 | a [element] :  |
-| array_flow.rb:17:9:17:33 | call to new [element] :  | array_flow.rb:21:19:21:19 | a [element] :  |
+| array_flow.rb:17:5:17:5 | a [element] :  | array_flow.rb:18:10:18:10 | a [element] :  |
+| array_flow.rb:17:5:17:5 | a [element] :  | array_flow.rb:18:10:18:10 | a [element] :  |
+| array_flow.rb:17:5:17:5 | a [element] :  | array_flow.rb:19:10:19:10 | a [element] :  |
+| array_flow.rb:17:5:17:5 | a [element] :  | array_flow.rb:19:10:19:10 | a [element] :  |
+| array_flow.rb:17:5:17:5 | a [element] :  | array_flow.rb:21:19:21:19 | a [element] :  |
+| array_flow.rb:17:5:17:5 | a [element] :  | array_flow.rb:21:19:21:19 | a [element] :  |
+| array_flow.rb:17:9:17:33 | call to new [element] :  | array_flow.rb:17:5:17:5 | a [element] :  |
+| array_flow.rb:17:9:17:33 | call to new [element] :  | array_flow.rb:17:5:17:5 | a [element] :  |
 | array_flow.rb:17:22:17:32 | call to source :  | array_flow.rb:17:9:17:33 | call to new [element] :  |
 | array_flow.rb:17:22:17:32 | call to source :  | array_flow.rb:17:9:17:33 | call to new [element] :  |
 | array_flow.rb:18:10:18:10 | a [element] :  | array_flow.rb:18:10:18:13 | ...[...] |
 | array_flow.rb:18:10:18:10 | a [element] :  | array_flow.rb:18:10:18:13 | ...[...] |
 | array_flow.rb:19:10:19:10 | a [element] :  | array_flow.rb:19:10:19:13 | ...[...] |
 | array_flow.rb:19:10:19:10 | a [element] :  | array_flow.rb:19:10:19:13 | ...[...] |
-| array_flow.rb:21:9:21:20 | call to new [element] :  | array_flow.rb:22:10:22:10 | b [element] :  |
-| array_flow.rb:21:9:21:20 | call to new [element] :  | array_flow.rb:22:10:22:10 | b [element] :  |
-| array_flow.rb:21:9:21:20 | call to new [element] :  | array_flow.rb:23:10:23:10 | b [element] :  |
-| array_flow.rb:21:9:21:20 | call to new [element] :  | array_flow.rb:23:10:23:10 | b [element] :  |
+| array_flow.rb:21:5:21:5 | b [element] :  | array_flow.rb:22:10:22:10 | b [element] :  |
+| array_flow.rb:21:5:21:5 | b [element] :  | array_flow.rb:22:10:22:10 | b [element] :  |
+| array_flow.rb:21:5:21:5 | b [element] :  | array_flow.rb:23:10:23:10 | b [element] :  |
+| array_flow.rb:21:5:21:5 | b [element] :  | array_flow.rb:23:10:23:10 | b [element] :  |
+| array_flow.rb:21:9:21:20 | call to new [element] :  | array_flow.rb:21:5:21:5 | b [element] :  |
+| array_flow.rb:21:9:21:20 | call to new [element] :  | array_flow.rb:21:5:21:5 | b [element] :  |
 | array_flow.rb:21:19:21:19 | a [element] :  | array_flow.rb:21:9:21:20 | call to new [element] :  |
 | array_flow.rb:21:19:21:19 | a [element] :  | array_flow.rb:21:9:21:20 | call to new [element] :  |
 | array_flow.rb:22:10:22:10 | b [element] :  | array_flow.rb:22:10:22:13 | ...[...] |
 | array_flow.rb:22:10:22:10 | b [element] :  | array_flow.rb:22:10:22:13 | ...[...] |
 | array_flow.rb:23:10:23:10 | b [element] :  | array_flow.rb:23:10:23:13 | ...[...] |
 | array_flow.rb:23:10:23:10 | b [element] :  | array_flow.rb:23:10:23:13 | ...[...] |
-| array_flow.rb:25:9:27:7 | call to new [element] :  | array_flow.rb:28:10:28:10 | c [element] :  |
-| array_flow.rb:25:9:27:7 | call to new [element] :  | array_flow.rb:28:10:28:10 | c [element] :  |
-| array_flow.rb:25:9:27:7 | call to new [element] :  | array_flow.rb:29:10:29:10 | c [element] :  |
-| array_flow.rb:25:9:27:7 | call to new [element] :  | array_flow.rb:29:10:29:10 | c [element] :  |
+| array_flow.rb:25:5:25:5 | c [element] :  | array_flow.rb:28:10:28:10 | c [element] :  |
+| array_flow.rb:25:5:25:5 | c [element] :  | array_flow.rb:28:10:28:10 | c [element] :  |
+| array_flow.rb:25:5:25:5 | c [element] :  | array_flow.rb:29:10:29:10 | c [element] :  |
+| array_flow.rb:25:5:25:5 | c [element] :  | array_flow.rb:29:10:29:10 | c [element] :  |
+| array_flow.rb:25:9:27:7 | call to new [element] :  | array_flow.rb:25:5:25:5 | c [element] :  |
+| array_flow.rb:25:9:27:7 | call to new [element] :  | array_flow.rb:25:5:25:5 | c [element] :  |
 | array_flow.rb:26:9:26:19 | call to source :  | array_flow.rb:25:9:27:7 | call to new [element] :  |
 | array_flow.rb:26:9:26:19 | call to source :  | array_flow.rb:25:9:27:7 | call to new [element] :  |
 | array_flow.rb:28:10:28:10 | c [element] :  | array_flow.rb:28:10:28:13 | ...[...] |
 | array_flow.rb:28:10:28:10 | c [element] :  | array_flow.rb:28:10:28:13 | ...[...] |
 | array_flow.rb:29:10:29:10 | c [element] :  | array_flow.rb:29:10:29:13 | ...[...] |
 | array_flow.rb:29:10:29:10 | c [element] :  | array_flow.rb:29:10:29:13 | ...[...] |
-| array_flow.rb:33:10:33:18 | call to source :  | array_flow.rb:34:27:34:27 | a [element 0] :  |
-| array_flow.rb:33:10:33:18 | call to source :  | array_flow.rb:34:27:34:27 | a [element 0] :  |
-| array_flow.rb:34:9:34:28 | call to try_convert [element 0] :  | array_flow.rb:35:10:35:10 | b [element 0] :  |
-| array_flow.rb:34:9:34:28 | call to try_convert [element 0] :  | array_flow.rb:35:10:35:10 | b [element 0] :  |
+| array_flow.rb:33:5:33:5 | a [element 0] :  | array_flow.rb:34:27:34:27 | a [element 0] :  |
+| array_flow.rb:33:5:33:5 | a [element 0] :  | array_flow.rb:34:27:34:27 | a [element 0] :  |
+| array_flow.rb:33:10:33:18 | call to source :  | array_flow.rb:33:5:33:5 | a [element 0] :  |
+| array_flow.rb:33:10:33:18 | call to source :  | array_flow.rb:33:5:33:5 | a [element 0] :  |
+| array_flow.rb:34:5:34:5 | b [element 0] :  | array_flow.rb:35:10:35:10 | b [element 0] :  |
+| array_flow.rb:34:5:34:5 | b [element 0] :  | array_flow.rb:35:10:35:10 | b [element 0] :  |
+| array_flow.rb:34:9:34:28 | call to try_convert [element 0] :  | array_flow.rb:34:5:34:5 | b [element 0] :  |
+| array_flow.rb:34:9:34:28 | call to try_convert [element 0] :  | array_flow.rb:34:5:34:5 | b [element 0] :  |
 | array_flow.rb:34:27:34:27 | a [element 0] :  | array_flow.rb:34:9:34:28 | call to try_convert [element 0] :  |
 | array_flow.rb:34:27:34:27 | a [element 0] :  | array_flow.rb:34:9:34:28 | call to try_convert [element 0] :  |
 | array_flow.rb:35:10:35:10 | b [element 0] :  | array_flow.rb:35:10:35:13 | ...[...] |
 | array_flow.rb:35:10:35:10 | b [element 0] :  | array_flow.rb:35:10:35:13 | ...[...] |
-| array_flow.rb:40:10:40:20 | call to source :  | array_flow.rb:42:9:42:9 | a [element 0] :  |
-| array_flow.rb:40:10:40:20 | call to source :  | array_flow.rb:42:9:42:9 | a [element 0] :  |
-| array_flow.rb:41:16:41:26 | call to source :  | array_flow.rb:42:13:42:13 | b [element 2] :  |
-| array_flow.rb:41:16:41:26 | call to source :  | array_flow.rb:42:13:42:13 | b [element 2] :  |
+| array_flow.rb:40:5:40:5 | a [element 0] :  | array_flow.rb:42:9:42:9 | a [element 0] :  |
+| array_flow.rb:40:5:40:5 | a [element 0] :  | array_flow.rb:42:9:42:9 | a [element 0] :  |
+| array_flow.rb:40:10:40:20 | call to source :  | array_flow.rb:40:5:40:5 | a [element 0] :  |
+| array_flow.rb:40:10:40:20 | call to source :  | array_flow.rb:40:5:40:5 | a [element 0] :  |
+| array_flow.rb:41:5:41:5 | b [element 2] :  | array_flow.rb:42:13:42:13 | b [element 2] :  |
+| array_flow.rb:41:5:41:5 | b [element 2] :  | array_flow.rb:42:13:42:13 | b [element 2] :  |
+| array_flow.rb:41:16:41:26 | call to source :  | array_flow.rb:41:5:41:5 | b [element 2] :  |
+| array_flow.rb:41:16:41:26 | call to source :  | array_flow.rb:41:5:41:5 | b [element 2] :  |
+| array_flow.rb:42:5:42:5 | c [element] :  | array_flow.rb:43:10:43:10 | c [element] :  |
+| array_flow.rb:42:5:42:5 | c [element] :  | array_flow.rb:43:10:43:10 | c [element] :  |
+| array_flow.rb:42:5:42:5 | c [element] :  | array_flow.rb:44:10:44:10 | c [element] :  |
+| array_flow.rb:42:5:42:5 | c [element] :  | array_flow.rb:44:10:44:10 | c [element] :  |
 | array_flow.rb:42:9:42:9 | a [element 0] :  | array_flow.rb:42:9:42:13 | ... & ... [element] :  |
 | array_flow.rb:42:9:42:9 | a [element 0] :  | array_flow.rb:42:9:42:13 | ... & ... [element] :  |
-| array_flow.rb:42:9:42:13 | ... & ... [element] :  | array_flow.rb:43:10:43:10 | c [element] :  |
-| array_flow.rb:42:9:42:13 | ... & ... [element] :  | array_flow.rb:43:10:43:10 | c [element] :  |
-| array_flow.rb:42:9:42:13 | ... & ... [element] :  | array_flow.rb:44:10:44:10 | c [element] :  |
-| array_flow.rb:42:9:42:13 | ... & ... [element] :  | array_flow.rb:44:10:44:10 | c [element] :  |
+| array_flow.rb:42:9:42:13 | ... & ... [element] :  | array_flow.rb:42:5:42:5 | c [element] :  |
+| array_flow.rb:42:9:42:13 | ... & ... [element] :  | array_flow.rb:42:5:42:5 | c [element] :  |
 | array_flow.rb:42:13:42:13 | b [element 2] :  | array_flow.rb:42:9:42:13 | ... & ... [element] :  |
 | array_flow.rb:42:13:42:13 | b [element 2] :  | array_flow.rb:42:9:42:13 | ... & ... [element] :  |
 | array_flow.rb:43:10:43:10 | c [element] :  | array_flow.rb:43:10:43:13 | ...[...] |
 | array_flow.rb:43:10:43:10 | c [element] :  | array_flow.rb:43:10:43:13 | ...[...] |
 | array_flow.rb:44:10:44:10 | c [element] :  | array_flow.rb:44:10:44:13 | ...[...] |
 | array_flow.rb:44:10:44:10 | c [element] :  | array_flow.rb:44:10:44:13 | ...[...] |
-| array_flow.rb:48:10:48:18 | call to source :  | array_flow.rb:49:9:49:9 | a [element 0] :  |
-| array_flow.rb:48:10:48:18 | call to source :  | array_flow.rb:49:9:49:9 | a [element 0] :  |
+| array_flow.rb:48:5:48:5 | a [element 0] :  | array_flow.rb:49:9:49:9 | a [element 0] :  |
+| array_flow.rb:48:5:48:5 | a [element 0] :  | array_flow.rb:49:9:49:9 | a [element 0] :  |
+| array_flow.rb:48:10:48:18 | call to source :  | array_flow.rb:48:5:48:5 | a [element 0] :  |
+| array_flow.rb:48:10:48:18 | call to source :  | array_flow.rb:48:5:48:5 | a [element 0] :  |
+| array_flow.rb:49:5:49:5 | b [element] :  | array_flow.rb:50:10:50:10 | b [element] :  |
+| array_flow.rb:49:5:49:5 | b [element] :  | array_flow.rb:50:10:50:10 | b [element] :  |
+| array_flow.rb:49:5:49:5 | b [element] :  | array_flow.rb:51:10:51:10 | b [element] :  |
+| array_flow.rb:49:5:49:5 | b [element] :  | array_flow.rb:51:10:51:10 | b [element] :  |
 | array_flow.rb:49:9:49:9 | a [element 0] :  | array_flow.rb:49:9:49:13 | ... * ... [element] :  |
 | array_flow.rb:49:9:49:9 | a [element 0] :  | array_flow.rb:49:9:49:13 | ... * ... [element] :  |
-| array_flow.rb:49:9:49:13 | ... * ... [element] :  | array_flow.rb:50:10:50:10 | b [element] :  |
-| array_flow.rb:49:9:49:13 | ... * ... [element] :  | array_flow.rb:50:10:50:10 | b [element] :  |
-| array_flow.rb:49:9:49:13 | ... * ... [element] :  | array_flow.rb:51:10:51:10 | b [element] :  |
-| array_flow.rb:49:9:49:13 | ... * ... [element] :  | array_flow.rb:51:10:51:10 | b [element] :  |
+| array_flow.rb:49:9:49:13 | ... * ... [element] :  | array_flow.rb:49:5:49:5 | b [element] :  |
+| array_flow.rb:49:9:49:13 | ... * ... [element] :  | array_flow.rb:49:5:49:5 | b [element] :  |
 | array_flow.rb:50:10:50:10 | b [element] :  | array_flow.rb:50:10:50:13 | ...[...] |
 | array_flow.rb:50:10:50:10 | b [element] :  | array_flow.rb:50:10:50:13 | ...[...] |
 | array_flow.rb:51:10:51:10 | b [element] :  | array_flow.rb:51:10:51:13 | ...[...] |
 | array_flow.rb:51:10:51:10 | b [element] :  | array_flow.rb:51:10:51:13 | ...[...] |
-| array_flow.rb:55:10:55:20 | call to source :  | array_flow.rb:57:9:57:9 | a [element 0] :  |
-| array_flow.rb:55:10:55:20 | call to source :  | array_flow.rb:57:9:57:9 | a [element 0] :  |
-| array_flow.rb:56:13:56:23 | call to source :  | array_flow.rb:57:13:57:13 | b [element 1] :  |
-| array_flow.rb:56:13:56:23 | call to source :  | array_flow.rb:57:13:57:13 | b [element 1] :  |
+| array_flow.rb:55:5:55:5 | a [element 0] :  | array_flow.rb:57:9:57:9 | a [element 0] :  |
+| array_flow.rb:55:5:55:5 | a [element 0] :  | array_flow.rb:57:9:57:9 | a [element 0] :  |
+| array_flow.rb:55:10:55:20 | call to source :  | array_flow.rb:55:5:55:5 | a [element 0] :  |
+| array_flow.rb:55:10:55:20 | call to source :  | array_flow.rb:55:5:55:5 | a [element 0] :  |
+| array_flow.rb:56:5:56:5 | b [element 1] :  | array_flow.rb:57:13:57:13 | b [element 1] :  |
+| array_flow.rb:56:5:56:5 | b [element 1] :  | array_flow.rb:57:13:57:13 | b [element 1] :  |
+| array_flow.rb:56:13:56:23 | call to source :  | array_flow.rb:56:5:56:5 | b [element 1] :  |
+| array_flow.rb:56:13:56:23 | call to source :  | array_flow.rb:56:5:56:5 | b [element 1] :  |
+| array_flow.rb:57:5:57:5 | c [element 0] :  | array_flow.rb:58:10:58:10 | c [element 0] :  |
+| array_flow.rb:57:5:57:5 | c [element 0] :  | array_flow.rb:58:10:58:10 | c [element 0] :  |
+| array_flow.rb:57:5:57:5 | c [element] :  | array_flow.rb:58:10:58:10 | c [element] :  |
+| array_flow.rb:57:5:57:5 | c [element] :  | array_flow.rb:58:10:58:10 | c [element] :  |
+| array_flow.rb:57:5:57:5 | c [element] :  | array_flow.rb:59:10:59:10 | c [element] :  |
+| array_flow.rb:57:5:57:5 | c [element] :  | array_flow.rb:59:10:59:10 | c [element] :  |
 | array_flow.rb:57:9:57:9 | a [element 0] :  | array_flow.rb:57:9:57:13 | ... + ... [element 0] :  |
 | array_flow.rb:57:9:57:9 | a [element 0] :  | array_flow.rb:57:9:57:13 | ... + ... [element 0] :  |
-| array_flow.rb:57:9:57:13 | ... + ... [element 0] :  | array_flow.rb:58:10:58:10 | c [element 0] :  |
-| array_flow.rb:57:9:57:13 | ... + ... [element 0] :  | array_flow.rb:58:10:58:10 | c [element 0] :  |
-| array_flow.rb:57:9:57:13 | ... + ... [element] :  | array_flow.rb:58:10:58:10 | c [element] :  |
-| array_flow.rb:57:9:57:13 | ... + ... [element] :  | array_flow.rb:58:10:58:10 | c [element] :  |
-| array_flow.rb:57:9:57:13 | ... + ... [element] :  | array_flow.rb:59:10:59:10 | c [element] :  |
-| array_flow.rb:57:9:57:13 | ... + ... [element] :  | array_flow.rb:59:10:59:10 | c [element] :  |
+| array_flow.rb:57:9:57:13 | ... + ... [element 0] :  | array_flow.rb:57:5:57:5 | c [element 0] :  |
+| array_flow.rb:57:9:57:13 | ... + ... [element 0] :  | array_flow.rb:57:5:57:5 | c [element 0] :  |
+| array_flow.rb:57:9:57:13 | ... + ... [element] :  | array_flow.rb:57:5:57:5 | c [element] :  |
+| array_flow.rb:57:9:57:13 | ... + ... [element] :  | array_flow.rb:57:5:57:5 | c [element] :  |
 | array_flow.rb:57:13:57:13 | b [element 1] :  | array_flow.rb:57:9:57:13 | ... + ... [element] :  |
 | array_flow.rb:57:13:57:13 | b [element 1] :  | array_flow.rb:57:9:57:13 | ... + ... [element] :  |
 | array_flow.rb:58:10:58:10 | c [element 0] :  | array_flow.rb:58:10:58:13 | ...[...] |
@@ -106,40 +138,51 @@ edges
 | array_flow.rb:58:10:58:10 | c [element] :  | array_flow.rb:58:10:58:13 | ...[...] |
 | array_flow.rb:59:10:59:10 | c [element] :  | array_flow.rb:59:10:59:13 | ...[...] |
 | array_flow.rb:59:10:59:10 | c [element] :  | array_flow.rb:59:10:59:13 | ...[...] |
-| array_flow.rb:63:10:63:20 | call to source :  | array_flow.rb:65:9:65:9 | a [element 0] :  |
-| array_flow.rb:63:10:63:20 | call to source :  | array_flow.rb:65:9:65:9 | a [element 0] :  |
+| array_flow.rb:63:5:63:5 | a [element 0] :  | array_flow.rb:65:9:65:9 | a [element 0] :  |
+| array_flow.rb:63:5:63:5 | a [element 0] :  | array_flow.rb:65:9:65:9 | a [element 0] :  |
+| array_flow.rb:63:10:63:20 | call to source :  | array_flow.rb:63:5:63:5 | a [element 0] :  |
+| array_flow.rb:63:10:63:20 | call to source :  | array_flow.rb:63:5:63:5 | a [element 0] :  |
+| array_flow.rb:65:5:65:5 | c [element] :  | array_flow.rb:66:10:66:10 | c [element] :  |
+| array_flow.rb:65:5:65:5 | c [element] :  | array_flow.rb:66:10:66:10 | c [element] :  |
+| array_flow.rb:65:5:65:5 | c [element] :  | array_flow.rb:67:10:67:10 | c [element] :  |
+| array_flow.rb:65:5:65:5 | c [element] :  | array_flow.rb:67:10:67:10 | c [element] :  |
 | array_flow.rb:65:9:65:9 | a [element 0] :  | array_flow.rb:65:9:65:13 | ... - ... [element] :  |
 | array_flow.rb:65:9:65:9 | a [element 0] :  | array_flow.rb:65:9:65:13 | ... - ... [element] :  |
-| array_flow.rb:65:9:65:13 | ... - ... [element] :  | array_flow.rb:66:10:66:10 | c [element] :  |
-| array_flow.rb:65:9:65:13 | ... - ... [element] :  | array_flow.rb:66:10:66:10 | c [element] :  |
-| array_flow.rb:65:9:65:13 | ... - ... [element] :  | array_flow.rb:67:10:67:10 | c [element] :  |
-| array_flow.rb:65:9:65:13 | ... - ... [element] :  | array_flow.rb:67:10:67:10 | c [element] :  |
+| array_flow.rb:65:9:65:13 | ... - ... [element] :  | array_flow.rb:65:5:65:5 | c [element] :  |
+| array_flow.rb:65:9:65:13 | ... - ... [element] :  | array_flow.rb:65:5:65:5 | c [element] :  |
 | array_flow.rb:66:10:66:10 | c [element] :  | array_flow.rb:66:10:66:13 | ...[...] |
 | array_flow.rb:66:10:66:10 | c [element] :  | array_flow.rb:66:10:66:13 | ...[...] |
 | array_flow.rb:67:10:67:10 | c [element] :  | array_flow.rb:67:10:67:13 | ...[...] |
 | array_flow.rb:67:10:67:10 | c [element] :  | array_flow.rb:67:10:67:13 | ...[...] |
-| array_flow.rb:71:10:71:20 | call to source :  | array_flow.rb:72:9:72:9 | a [element 0] :  |
-| array_flow.rb:71:10:71:20 | call to source :  | array_flow.rb:72:9:72:9 | a [element 0] :  |
-| array_flow.rb:71:10:71:20 | call to source :  | array_flow.rb:73:10:73:10 | a [element 0] :  |
-| array_flow.rb:71:10:71:20 | call to source :  | array_flow.rb:73:10:73:10 | a [element 0] :  |
+| array_flow.rb:71:5:71:5 | a [element 0] :  | array_flow.rb:72:9:72:9 | a [element 0] :  |
+| array_flow.rb:71:5:71:5 | a [element 0] :  | array_flow.rb:72:9:72:9 | a [element 0] :  |
+| array_flow.rb:71:5:71:5 | a [element 0] :  | array_flow.rb:73:10:73:10 | a [element 0] :  |
+| array_flow.rb:71:5:71:5 | a [element 0] :  | array_flow.rb:73:10:73:10 | a [element 0] :  |
+| array_flow.rb:71:10:71:20 | call to source :  | array_flow.rb:71:5:71:5 | a [element 0] :  |
+| array_flow.rb:71:10:71:20 | call to source :  | array_flow.rb:71:5:71:5 | a [element 0] :  |
+| array_flow.rb:72:5:72:5 | b :  | array_flow.rb:75:10:75:10 | b :  |
+| array_flow.rb:72:5:72:5 | b :  | array_flow.rb:76:10:76:10 | b :  |
+| array_flow.rb:72:5:72:5 | b [element 0] :  | array_flow.rb:75:10:75:10 | b [element 0] :  |
+| array_flow.rb:72:5:72:5 | b [element 0] :  | array_flow.rb:75:10:75:10 | b [element 0] :  |
+| array_flow.rb:72:5:72:5 | b [element] :  | array_flow.rb:75:10:75:10 | b [element] :  |
+| array_flow.rb:72:5:72:5 | b [element] :  | array_flow.rb:75:10:75:10 | b [element] :  |
+| array_flow.rb:72:5:72:5 | b [element] :  | array_flow.rb:76:10:76:10 | b [element] :  |
+| array_flow.rb:72:5:72:5 | b [element] :  | array_flow.rb:76:10:76:10 | b [element] :  |
 | array_flow.rb:72:9:72:9 | [post] a [element] :  | array_flow.rb:73:10:73:10 | a [element] :  |
 | array_flow.rb:72:9:72:9 | [post] a [element] :  | array_flow.rb:73:10:73:10 | a [element] :  |
 | array_flow.rb:72:9:72:9 | [post] a [element] :  | array_flow.rb:74:10:74:10 | a [element] :  |
 | array_flow.rb:72:9:72:9 | [post] a [element] :  | array_flow.rb:74:10:74:10 | a [element] :  |
 | array_flow.rb:72:9:72:9 | a [element 0] :  | array_flow.rb:72:9:72:24 | ... << ... [element 0] :  |
 | array_flow.rb:72:9:72:9 | a [element 0] :  | array_flow.rb:72:9:72:24 | ... << ... [element 0] :  |
-| array_flow.rb:72:9:72:24 | ... << ... [element 0] :  | array_flow.rb:75:10:75:10 | b [element 0] :  |
-| array_flow.rb:72:9:72:24 | ... << ... [element 0] :  | array_flow.rb:75:10:75:10 | b [element 0] :  |
-| array_flow.rb:72:9:72:24 | ... << ... [element] :  | array_flow.rb:75:10:75:10 | b [element] :  |
-| array_flow.rb:72:9:72:24 | ... << ... [element] :  | array_flow.rb:75:10:75:10 | b [element] :  |
-| array_flow.rb:72:9:72:24 | ... << ... [element] :  | array_flow.rb:76:10:76:10 | b [element] :  |
-| array_flow.rb:72:9:72:24 | ... << ... [element] :  | array_flow.rb:76:10:76:10 | b [element] :  |
+| array_flow.rb:72:9:72:24 | ... << ... [element 0] :  | array_flow.rb:72:5:72:5 | b [element 0] :  |
+| array_flow.rb:72:9:72:24 | ... << ... [element 0] :  | array_flow.rb:72:5:72:5 | b [element 0] :  |
+| array_flow.rb:72:9:72:24 | ... << ... [element] :  | array_flow.rb:72:5:72:5 | b [element] :  |
+| array_flow.rb:72:9:72:24 | ... << ... [element] :  | array_flow.rb:72:5:72:5 | b [element] :  |
+| array_flow.rb:72:14:72:24 | call to source :  | array_flow.rb:72:5:72:5 | b :  |
 | array_flow.rb:72:14:72:24 | call to source :  | array_flow.rb:72:9:72:9 | [post] a [element] :  |
 | array_flow.rb:72:14:72:24 | call to source :  | array_flow.rb:72:9:72:9 | [post] a [element] :  |
 | array_flow.rb:72:14:72:24 | call to source :  | array_flow.rb:72:9:72:24 | ... << ... [element] :  |
 | array_flow.rb:72:14:72:24 | call to source :  | array_flow.rb:72:9:72:24 | ... << ... [element] :  |
-| array_flow.rb:72:14:72:24 | call to source :  | array_flow.rb:75:10:75:10 | b :  |
-| array_flow.rb:72:14:72:24 | call to source :  | array_flow.rb:76:10:76:10 | b :  |
 | array_flow.rb:73:10:73:10 | a [element 0] :  | array_flow.rb:73:10:73:13 | ...[...] |
 | array_flow.rb:73:10:73:10 | a [element 0] :  | array_flow.rb:73:10:73:13 | ...[...] |
 | array_flow.rb:73:10:73:10 | a [element] :  | array_flow.rb:73:10:73:13 | ...[...] |
@@ -154,70 +197,96 @@ edges
 | array_flow.rb:76:10:76:10 | b :  | array_flow.rb:76:10:76:13 | ...[...] |
 | array_flow.rb:76:10:76:10 | b [element] :  | array_flow.rb:76:10:76:13 | ...[...] |
 | array_flow.rb:76:10:76:10 | b [element] :  | array_flow.rb:76:10:76:13 | ...[...] |
-| array_flow.rb:80:13:80:21 | call to source :  | array_flow.rb:81:15:81:15 | a [element 1] :  |
-| array_flow.rb:80:13:80:21 | call to source :  | array_flow.rb:81:15:81:15 | a [element 1] :  |
-| array_flow.rb:81:15:81:15 | a [element 1] :  | array_flow.rb:83:10:83:10 | c |
-| array_flow.rb:81:15:81:15 | a [element 1] :  | array_flow.rb:83:10:83:10 | c |
-| array_flow.rb:88:13:88:22 | call to source :  | array_flow.rb:89:9:89:9 | a [element 1] :  |
-| array_flow.rb:88:13:88:22 | call to source :  | array_flow.rb:89:9:89:9 | a [element 1] :  |
+| array_flow.rb:80:5:80:5 | a [element 1] :  | array_flow.rb:81:15:81:15 | a [element 1] :  |
+| array_flow.rb:80:5:80:5 | a [element 1] :  | array_flow.rb:81:15:81:15 | a [element 1] :  |
+| array_flow.rb:80:13:80:21 | call to source :  | array_flow.rb:80:5:80:5 | a [element 1] :  |
+| array_flow.rb:80:13:80:21 | call to source :  | array_flow.rb:80:5:80:5 | a [element 1] :  |
+| array_flow.rb:81:8:81:8 | c :  | array_flow.rb:83:10:83:10 | c |
+| array_flow.rb:81:8:81:8 | c :  | array_flow.rb:83:10:83:10 | c |
+| array_flow.rb:81:15:81:15 | __synth__0 [element 1] :  | array_flow.rb:81:8:81:8 | c :  |
+| array_flow.rb:81:15:81:15 | __synth__0 [element 1] :  | array_flow.rb:81:8:81:8 | c :  |
+| array_flow.rb:81:15:81:15 | a [element 1] :  | array_flow.rb:81:15:81:15 | __synth__0 [element 1] :  |
+| array_flow.rb:81:15:81:15 | a [element 1] :  | array_flow.rb:81:15:81:15 | __synth__0 [element 1] :  |
+| array_flow.rb:88:5:88:5 | a [element 1] :  | array_flow.rb:89:9:89:9 | a [element 1] :  |
+| array_flow.rb:88:5:88:5 | a [element 1] :  | array_flow.rb:89:9:89:9 | a [element 1] :  |
+| array_flow.rb:88:13:88:22 | call to source :  | array_flow.rb:88:5:88:5 | a [element 1] :  |
+| array_flow.rb:88:13:88:22 | call to source :  | array_flow.rb:88:5:88:5 | a [element 1] :  |
+| array_flow.rb:89:5:89:5 | b [element 1] :  | array_flow.rb:91:10:91:10 | b [element 1] :  |
+| array_flow.rb:89:5:89:5 | b [element 1] :  | array_flow.rb:91:10:91:10 | b [element 1] :  |
+| array_flow.rb:89:5:89:5 | b [element 1] :  | array_flow.rb:92:10:92:10 | b [element 1] :  |
+| array_flow.rb:89:5:89:5 | b [element 1] :  | array_flow.rb:92:10:92:10 | b [element 1] :  |
 | array_flow.rb:89:9:89:9 | a [element 1] :  | array_flow.rb:89:9:89:15 | ...[...] [element 1] :  |
 | array_flow.rb:89:9:89:9 | a [element 1] :  | array_flow.rb:89:9:89:15 | ...[...] [element 1] :  |
-| array_flow.rb:89:9:89:15 | ...[...] [element 1] :  | array_flow.rb:91:10:91:10 | b [element 1] :  |
-| array_flow.rb:89:9:89:15 | ...[...] [element 1] :  | array_flow.rb:91:10:91:10 | b [element 1] :  |
-| array_flow.rb:89:9:89:15 | ...[...] [element 1] :  | array_flow.rb:92:10:92:10 | b [element 1] :  |
-| array_flow.rb:89:9:89:15 | ...[...] [element 1] :  | array_flow.rb:92:10:92:10 | b [element 1] :  |
+| array_flow.rb:89:9:89:15 | ...[...] [element 1] :  | array_flow.rb:89:5:89:5 | b [element 1] :  |
+| array_flow.rb:89:9:89:15 | ...[...] [element 1] :  | array_flow.rb:89:5:89:5 | b [element 1] :  |
 | array_flow.rb:91:10:91:10 | b [element 1] :  | array_flow.rb:91:10:91:13 | ...[...] |
 | array_flow.rb:91:10:91:10 | b [element 1] :  | array_flow.rb:91:10:91:13 | ...[...] |
 | array_flow.rb:92:10:92:10 | b [element 1] :  | array_flow.rb:92:10:92:13 | ...[...] |
 | array_flow.rb:92:10:92:10 | b [element 1] :  | array_flow.rb:92:10:92:13 | ...[...] |
-| array_flow.rb:96:13:96:22 | call to source :  | array_flow.rb:97:9:97:9 | a [element 1] :  |
-| array_flow.rb:96:13:96:22 | call to source :  | array_flow.rb:97:9:97:9 | a [element 1] :  |
+| array_flow.rb:96:5:96:5 | a [element 1] :  | array_flow.rb:97:9:97:9 | a [element 1] :  |
+| array_flow.rb:96:5:96:5 | a [element 1] :  | array_flow.rb:97:9:97:9 | a [element 1] :  |
+| array_flow.rb:96:13:96:22 | call to source :  | array_flow.rb:96:5:96:5 | a [element 1] :  |
+| array_flow.rb:96:13:96:22 | call to source :  | array_flow.rb:96:5:96:5 | a [element 1] :  |
+| array_flow.rb:97:5:97:5 | b [element 1] :  | array_flow.rb:99:10:99:10 | b [element 1] :  |
+| array_flow.rb:97:5:97:5 | b [element 1] :  | array_flow.rb:99:10:99:10 | b [element 1] :  |
+| array_flow.rb:97:5:97:5 | b [element 1] :  | array_flow.rb:101:10:101:10 | b [element 1] :  |
+| array_flow.rb:97:5:97:5 | b [element 1] :  | array_flow.rb:101:10:101:10 | b [element 1] :  |
 | array_flow.rb:97:9:97:9 | a [element 1] :  | array_flow.rb:97:9:97:15 | ...[...] [element 1] :  |
 | array_flow.rb:97:9:97:9 | a [element 1] :  | array_flow.rb:97:9:97:15 | ...[...] [element 1] :  |
-| array_flow.rb:97:9:97:15 | ...[...] [element 1] :  | array_flow.rb:99:10:99:10 | b [element 1] :  |
-| array_flow.rb:97:9:97:15 | ...[...] [element 1] :  | array_flow.rb:99:10:99:10 | b [element 1] :  |
-| array_flow.rb:97:9:97:15 | ...[...] [element 1] :  | array_flow.rb:101:10:101:10 | b [element 1] :  |
-| array_flow.rb:97:9:97:15 | ...[...] [element 1] :  | array_flow.rb:101:10:101:10 | b [element 1] :  |
+| array_flow.rb:97:9:97:15 | ...[...] [element 1] :  | array_flow.rb:97:5:97:5 | b [element 1] :  |
+| array_flow.rb:97:9:97:15 | ...[...] [element 1] :  | array_flow.rb:97:5:97:5 | b [element 1] :  |
 | array_flow.rb:99:10:99:10 | b [element 1] :  | array_flow.rb:99:10:99:13 | ...[...] |
 | array_flow.rb:99:10:99:10 | b [element 1] :  | array_flow.rb:99:10:99:13 | ...[...] |
 | array_flow.rb:101:10:101:10 | b [element 1] :  | array_flow.rb:101:10:101:13 | ...[...] |
 | array_flow.rb:101:10:101:10 | b [element 1] :  | array_flow.rb:101:10:101:13 | ...[...] |
-| array_flow.rb:103:13:103:24 | call to source :  | array_flow.rb:104:9:104:9 | a [element 1] :  |
-| array_flow.rb:103:13:103:24 | call to source :  | array_flow.rb:104:9:104:9 | a [element 1] :  |
+| array_flow.rb:103:5:103:5 | a [element 1] :  | array_flow.rb:104:9:104:9 | a [element 1] :  |
+| array_flow.rb:103:5:103:5 | a [element 1] :  | array_flow.rb:104:9:104:9 | a [element 1] :  |
+| array_flow.rb:103:13:103:24 | call to source :  | array_flow.rb:103:5:103:5 | a [element 1] :  |
+| array_flow.rb:103:13:103:24 | call to source :  | array_flow.rb:103:5:103:5 | a [element 1] :  |
+| array_flow.rb:104:5:104:5 | b [element 1] :  | array_flow.rb:106:10:106:10 | b [element 1] :  |
+| array_flow.rb:104:5:104:5 | b [element 1] :  | array_flow.rb:106:10:106:10 | b [element 1] :  |
 | array_flow.rb:104:9:104:9 | a [element 1] :  | array_flow.rb:104:9:104:16 | ...[...] [element 1] :  |
 | array_flow.rb:104:9:104:9 | a [element 1] :  | array_flow.rb:104:9:104:16 | ...[...] [element 1] :  |
-| array_flow.rb:104:9:104:16 | ...[...] [element 1] :  | array_flow.rb:106:10:106:10 | b [element 1] :  |
-| array_flow.rb:104:9:104:16 | ...[...] [element 1] :  | array_flow.rb:106:10:106:10 | b [element 1] :  |
+| array_flow.rb:104:9:104:16 | ...[...] [element 1] :  | array_flow.rb:104:5:104:5 | b [element 1] :  |
+| array_flow.rb:104:9:104:16 | ...[...] [element 1] :  | array_flow.rb:104:5:104:5 | b [element 1] :  |
 | array_flow.rb:106:10:106:10 | b [element 1] :  | array_flow.rb:106:10:106:13 | ...[...] |
 | array_flow.rb:106:10:106:10 | b [element 1] :  | array_flow.rb:106:10:106:13 | ...[...] |
-| array_flow.rb:109:13:109:24 | call to source :  | array_flow.rb:110:9:110:9 | a [element 1] :  |
-| array_flow.rb:109:13:109:24 | call to source :  | array_flow.rb:110:9:110:9 | a [element 1] :  |
-| array_flow.rb:109:13:109:24 | call to source :  | array_flow.rb:114:9:114:9 | a [element 1] :  |
-| array_flow.rb:109:13:109:24 | call to source :  | array_flow.rb:114:9:114:9 | a [element 1] :  |
-| array_flow.rb:109:30:109:41 | call to source :  | array_flow.rb:110:9:110:9 | a [element 3] :  |
-| array_flow.rb:109:30:109:41 | call to source :  | array_flow.rb:110:9:110:9 | a [element 3] :  |
-| array_flow.rb:109:30:109:41 | call to source :  | array_flow.rb:114:9:114:9 | a [element 3] :  |
-| array_flow.rb:109:30:109:41 | call to source :  | array_flow.rb:114:9:114:9 | a [element 3] :  |
+| array_flow.rb:109:5:109:5 | a [element 1] :  | array_flow.rb:110:9:110:9 | a [element 1] :  |
+| array_flow.rb:109:5:109:5 | a [element 1] :  | array_flow.rb:110:9:110:9 | a [element 1] :  |
+| array_flow.rb:109:5:109:5 | a [element 1] :  | array_flow.rb:114:9:114:9 | a [element 1] :  |
+| array_flow.rb:109:5:109:5 | a [element 1] :  | array_flow.rb:114:9:114:9 | a [element 1] :  |
+| array_flow.rb:109:5:109:5 | a [element 3] :  | array_flow.rb:110:9:110:9 | a [element 3] :  |
+| array_flow.rb:109:5:109:5 | a [element 3] :  | array_flow.rb:110:9:110:9 | a [element 3] :  |
+| array_flow.rb:109:5:109:5 | a [element 3] :  | array_flow.rb:114:9:114:9 | a [element 3] :  |
+| array_flow.rb:109:5:109:5 | a [element 3] :  | array_flow.rb:114:9:114:9 | a [element 3] :  |
+| array_flow.rb:109:13:109:24 | call to source :  | array_flow.rb:109:5:109:5 | a [element 1] :  |
+| array_flow.rb:109:13:109:24 | call to source :  | array_flow.rb:109:5:109:5 | a [element 1] :  |
+| array_flow.rb:109:30:109:41 | call to source :  | array_flow.rb:109:5:109:5 | a [element 3] :  |
+| array_flow.rb:109:30:109:41 | call to source :  | array_flow.rb:109:5:109:5 | a [element 3] :  |
+| array_flow.rb:110:5:110:5 | b [element] :  | array_flow.rb:111:10:111:10 | b [element] :  |
+| array_flow.rb:110:5:110:5 | b [element] :  | array_flow.rb:111:10:111:10 | b [element] :  |
+| array_flow.rb:110:5:110:5 | b [element] :  | array_flow.rb:112:10:112:10 | b [element] :  |
+| array_flow.rb:110:5:110:5 | b [element] :  | array_flow.rb:112:10:112:10 | b [element] :  |
 | array_flow.rb:110:9:110:9 | a [element 1] :  | array_flow.rb:110:9:110:18 | ...[...] [element] :  |
 | array_flow.rb:110:9:110:9 | a [element 1] :  | array_flow.rb:110:9:110:18 | ...[...] [element] :  |
 | array_flow.rb:110:9:110:9 | a [element 3] :  | array_flow.rb:110:9:110:18 | ...[...] [element] :  |
 | array_flow.rb:110:9:110:9 | a [element 3] :  | array_flow.rb:110:9:110:18 | ...[...] [element] :  |
-| array_flow.rb:110:9:110:18 | ...[...] [element] :  | array_flow.rb:111:10:111:10 | b [element] :  |
-| array_flow.rb:110:9:110:18 | ...[...] [element] :  | array_flow.rb:111:10:111:10 | b [element] :  |
-| array_flow.rb:110:9:110:18 | ...[...] [element] :  | array_flow.rb:112:10:112:10 | b [element] :  |
-| array_flow.rb:110:9:110:18 | ...[...] [element] :  | array_flow.rb:112:10:112:10 | b [element] :  |
+| array_flow.rb:110:9:110:18 | ...[...] [element] :  | array_flow.rb:110:5:110:5 | b [element] :  |
+| array_flow.rb:110:9:110:18 | ...[...] [element] :  | array_flow.rb:110:5:110:5 | b [element] :  |
 | array_flow.rb:111:10:111:10 | b [element] :  | array_flow.rb:111:10:111:13 | ...[...] |
 | array_flow.rb:111:10:111:10 | b [element] :  | array_flow.rb:111:10:111:13 | ...[...] |
 | array_flow.rb:112:10:112:10 | b [element] :  | array_flow.rb:112:10:112:13 | ...[...] |
 | array_flow.rb:112:10:112:10 | b [element] :  | array_flow.rb:112:10:112:13 | ...[...] |
+| array_flow.rb:114:5:114:5 | b [element] :  | array_flow.rb:115:10:115:10 | b [element] :  |
+| array_flow.rb:114:5:114:5 | b [element] :  | array_flow.rb:115:10:115:10 | b [element] :  |
+| array_flow.rb:114:5:114:5 | b [element] :  | array_flow.rb:116:10:116:10 | b [element] :  |
+| array_flow.rb:114:5:114:5 | b [element] :  | array_flow.rb:116:10:116:10 | b [element] :  |
 | array_flow.rb:114:9:114:9 | a [element 1] :  | array_flow.rb:114:9:114:19 | ...[...] [element] :  |
 | array_flow.rb:114:9:114:9 | a [element 1] :  | array_flow.rb:114:9:114:19 | ...[...] [element] :  |
 | array_flow.rb:114:9:114:9 | a [element 3] :  | array_flow.rb:114:9:114:19 | ...[...] [element] :  |
 | array_flow.rb:114:9:114:9 | a [element 3] :  | array_flow.rb:114:9:114:19 | ...[...] [element] :  |
-| array_flow.rb:114:9:114:19 | ...[...] [element] :  | array_flow.rb:115:10:115:10 | b [element] :  |
-| array_flow.rb:114:9:114:19 | ...[...] [element] :  | array_flow.rb:115:10:115:10 | b [element] :  |
-| array_flow.rb:114:9:114:19 | ...[...] [element] :  | array_flow.rb:116:10:116:10 | b [element] :  |
-| array_flow.rb:114:9:114:19 | ...[...] [element] :  | array_flow.rb:116:10:116:10 | b [element] :  |
+| array_flow.rb:114:9:114:19 | ...[...] [element] :  | array_flow.rb:114:5:114:5 | b [element] :  |
+| array_flow.rb:114:9:114:19 | ...[...] [element] :  | array_flow.rb:114:5:114:5 | b [element] :  |
 | array_flow.rb:115:10:115:10 | b [element] :  | array_flow.rb:115:10:115:13 | ...[...] |
 | array_flow.rb:115:10:115:10 | b [element] :  | array_flow.rb:115:10:115:13 | ...[...] |
 | array_flow.rb:116:10:116:10 | b [element] :  | array_flow.rb:116:10:116:13 | ...[...] |
@@ -278,34 +347,44 @@ edges
 | array_flow.rb:147:10:147:10 | a [element] :  | array_flow.rb:147:10:147:13 | ...[...] |
 | array_flow.rb:148:10:148:10 | a [element] :  | array_flow.rb:148:10:148:13 | ...[...] |
 | array_flow.rb:148:10:148:10 | a [element] :  | array_flow.rb:148:10:148:13 | ...[...] |
-| array_flow.rb:152:16:152:25 | call to source :  | array_flow.rb:153:5:153:5 | a [element 2] :  |
-| array_flow.rb:152:16:152:25 | call to source :  | array_flow.rb:153:5:153:5 | a [element 2] :  |
+| array_flow.rb:152:5:152:5 | a [element 2] :  | array_flow.rb:153:5:153:5 | a [element 2] :  |
+| array_flow.rb:152:5:152:5 | a [element 2] :  | array_flow.rb:153:5:153:5 | a [element 2] :  |
+| array_flow.rb:152:16:152:25 | call to source :  | array_flow.rb:152:5:152:5 | a [element 2] :  |
+| array_flow.rb:152:16:152:25 | call to source :  | array_flow.rb:152:5:152:5 | a [element 2] :  |
 | array_flow.rb:153:5:153:5 | a [element 2] :  | array_flow.rb:153:16:153:16 | x :  |
 | array_flow.rb:153:5:153:5 | a [element 2] :  | array_flow.rb:153:16:153:16 | x :  |
 | array_flow.rb:153:16:153:16 | x :  | array_flow.rb:154:14:154:14 | x |
 | array_flow.rb:153:16:153:16 | x :  | array_flow.rb:154:14:154:14 | x |
-| array_flow.rb:159:16:159:25 | call to source :  | array_flow.rb:160:5:160:5 | a [element 2] :  |
-| array_flow.rb:159:16:159:25 | call to source :  | array_flow.rb:160:5:160:5 | a [element 2] :  |
+| array_flow.rb:159:5:159:5 | a [element 2] :  | array_flow.rb:160:5:160:5 | a [element 2] :  |
+| array_flow.rb:159:5:159:5 | a [element 2] :  | array_flow.rb:160:5:160:5 | a [element 2] :  |
+| array_flow.rb:159:16:159:25 | call to source :  | array_flow.rb:159:5:159:5 | a [element 2] :  |
+| array_flow.rb:159:16:159:25 | call to source :  | array_flow.rb:159:5:159:5 | a [element 2] :  |
 | array_flow.rb:160:5:160:5 | a [element 2] :  | array_flow.rb:160:16:160:16 | x :  |
 | array_flow.rb:160:5:160:5 | a [element 2] :  | array_flow.rb:160:16:160:16 | x :  |
 | array_flow.rb:160:16:160:16 | x :  | array_flow.rb:161:14:161:14 | x |
 | array_flow.rb:160:16:160:16 | x :  | array_flow.rb:161:14:161:14 | x |
-| array_flow.rb:166:10:166:21 | call to source :  | array_flow.rb:167:9:167:9 | a [element 0] :  |
-| array_flow.rb:166:10:166:21 | call to source :  | array_flow.rb:167:9:167:9 | a [element 0] :  |
-| array_flow.rb:166:10:166:21 | call to source :  | array_flow.rb:168:10:168:10 | a [element 0] :  |
-| array_flow.rb:166:10:166:21 | call to source :  | array_flow.rb:168:10:168:10 | a [element 0] :  |
+| array_flow.rb:166:5:166:5 | a [element 0] :  | array_flow.rb:167:9:167:9 | a [element 0] :  |
+| array_flow.rb:166:5:166:5 | a [element 0] :  | array_flow.rb:167:9:167:9 | a [element 0] :  |
+| array_flow.rb:166:5:166:5 | a [element 0] :  | array_flow.rb:168:10:168:10 | a [element 0] :  |
+| array_flow.rb:166:5:166:5 | a [element 0] :  | array_flow.rb:168:10:168:10 | a [element 0] :  |
+| array_flow.rb:166:10:166:21 | call to source :  | array_flow.rb:166:5:166:5 | a [element 0] :  |
+| array_flow.rb:166:10:166:21 | call to source :  | array_flow.rb:166:5:166:5 | a [element 0] :  |
+| array_flow.rb:167:5:167:5 | b [element 0] :  | array_flow.rb:170:10:170:10 | b [element 0] :  |
+| array_flow.rb:167:5:167:5 | b [element 0] :  | array_flow.rb:170:10:170:10 | b [element 0] :  |
+| array_flow.rb:167:5:167:5 | b [element] :  | array_flow.rb:170:10:170:10 | b [element] :  |
+| array_flow.rb:167:5:167:5 | b [element] :  | array_flow.rb:170:10:170:10 | b [element] :  |
+| array_flow.rb:167:5:167:5 | b [element] :  | array_flow.rb:171:10:171:10 | b [element] :  |
+| array_flow.rb:167:5:167:5 | b [element] :  | array_flow.rb:171:10:171:10 | b [element] :  |
 | array_flow.rb:167:9:167:9 | [post] a [element] :  | array_flow.rb:168:10:168:10 | a [element] :  |
 | array_flow.rb:167:9:167:9 | [post] a [element] :  | array_flow.rb:168:10:168:10 | a [element] :  |
 | array_flow.rb:167:9:167:9 | [post] a [element] :  | array_flow.rb:169:10:169:10 | a [element] :  |
 | array_flow.rb:167:9:167:9 | [post] a [element] :  | array_flow.rb:169:10:169:10 | a [element] :  |
 | array_flow.rb:167:9:167:9 | a [element 0] :  | array_flow.rb:167:9:167:44 | call to append [element 0] :  |
 | array_flow.rb:167:9:167:9 | a [element 0] :  | array_flow.rb:167:9:167:44 | call to append [element 0] :  |
-| array_flow.rb:167:9:167:44 | call to append [element 0] :  | array_flow.rb:170:10:170:10 | b [element 0] :  |
-| array_flow.rb:167:9:167:44 | call to append [element 0] :  | array_flow.rb:170:10:170:10 | b [element 0] :  |
-| array_flow.rb:167:9:167:44 | call to append [element] :  | array_flow.rb:170:10:170:10 | b [element] :  |
-| array_flow.rb:167:9:167:44 | call to append [element] :  | array_flow.rb:170:10:170:10 | b [element] :  |
-| array_flow.rb:167:9:167:44 | call to append [element] :  | array_flow.rb:171:10:171:10 | b [element] :  |
-| array_flow.rb:167:9:167:44 | call to append [element] :  | array_flow.rb:171:10:171:10 | b [element] :  |
+| array_flow.rb:167:9:167:44 | call to append [element 0] :  | array_flow.rb:167:5:167:5 | b [element 0] :  |
+| array_flow.rb:167:9:167:44 | call to append [element 0] :  | array_flow.rb:167:5:167:5 | b [element 0] :  |
+| array_flow.rb:167:9:167:44 | call to append [element] :  | array_flow.rb:167:5:167:5 | b [element] :  |
+| array_flow.rb:167:9:167:44 | call to append [element] :  | array_flow.rb:167:5:167:5 | b [element] :  |
 | array_flow.rb:167:18:167:29 | call to source :  | array_flow.rb:167:9:167:9 | [post] a [element] :  |
 | array_flow.rb:167:18:167:29 | call to source :  | array_flow.rb:167:9:167:9 | [post] a [element] :  |
 | array_flow.rb:167:18:167:29 | call to source :  | array_flow.rb:167:9:167:44 | call to append [element] :  |
@@ -326,12 +405,16 @@ edges
 | array_flow.rb:170:10:170:10 | b [element] :  | array_flow.rb:170:10:170:13 | ...[...] |
 | array_flow.rb:171:10:171:10 | b [element] :  | array_flow.rb:171:10:171:13 | ...[...] |
 | array_flow.rb:171:10:171:10 | b [element] :  | array_flow.rb:171:10:171:13 | ...[...] |
-| array_flow.rb:177:15:177:24 | call to source :  | array_flow.rb:178:16:178:16 | c [element 1] :  |
-| array_flow.rb:177:15:177:24 | call to source :  | array_flow.rb:178:16:178:16 | c [element 1] :  |
-| array_flow.rb:178:16:178:16 | c [element 1] :  | array_flow.rb:179:11:179:11 | d [element 2, element 1] :  |
-| array_flow.rb:178:16:178:16 | c [element 1] :  | array_flow.rb:179:11:179:11 | d [element 2, element 1] :  |
-| array_flow.rb:178:16:178:16 | c [element 1] :  | array_flow.rb:180:11:180:11 | d [element 2, element 1] :  |
-| array_flow.rb:178:16:178:16 | c [element 1] :  | array_flow.rb:180:11:180:11 | d [element 2, element 1] :  |
+| array_flow.rb:177:5:177:5 | c [element 1] :  | array_flow.rb:178:16:178:16 | c [element 1] :  |
+| array_flow.rb:177:5:177:5 | c [element 1] :  | array_flow.rb:178:16:178:16 | c [element 1] :  |
+| array_flow.rb:177:15:177:24 | call to source :  | array_flow.rb:177:5:177:5 | c [element 1] :  |
+| array_flow.rb:177:15:177:24 | call to source :  | array_flow.rb:177:5:177:5 | c [element 1] :  |
+| array_flow.rb:178:5:178:5 | d [element 2, element 1] :  | array_flow.rb:179:11:179:11 | d [element 2, element 1] :  |
+| array_flow.rb:178:5:178:5 | d [element 2, element 1] :  | array_flow.rb:179:11:179:11 | d [element 2, element 1] :  |
+| array_flow.rb:178:5:178:5 | d [element 2, element 1] :  | array_flow.rb:180:11:180:11 | d [element 2, element 1] :  |
+| array_flow.rb:178:5:178:5 | d [element 2, element 1] :  | array_flow.rb:180:11:180:11 | d [element 2, element 1] :  |
+| array_flow.rb:178:16:178:16 | c [element 1] :  | array_flow.rb:178:5:178:5 | d [element 2, element 1] :  |
+| array_flow.rb:178:16:178:16 | c [element 1] :  | array_flow.rb:178:5:178:5 | d [element 2, element 1] :  |
 | array_flow.rb:179:11:179:11 | d [element 2, element 1] :  | array_flow.rb:179:11:179:22 | call to assoc [element 1] :  |
 | array_flow.rb:179:11:179:11 | d [element 2, element 1] :  | array_flow.rb:179:11:179:22 | call to assoc [element 1] :  |
 | array_flow.rb:179:11:179:22 | call to assoc [element 1] :  | array_flow.rb:179:11:179:25 | ...[...] :  |
@@ -344,40 +427,54 @@ edges
 | array_flow.rb:180:11:180:22 | call to assoc [element 1] :  | array_flow.rb:180:11:180:25 | ...[...] :  |
 | array_flow.rb:180:11:180:25 | ...[...] :  | array_flow.rb:180:10:180:26 | ( ... ) |
 | array_flow.rb:180:11:180:25 | ...[...] :  | array_flow.rb:180:10:180:26 | ( ... ) |
-| array_flow.rb:184:13:184:22 | call to source :  | array_flow.rb:186:10:186:10 | a [element 1] :  |
-| array_flow.rb:184:13:184:22 | call to source :  | array_flow.rb:186:10:186:10 | a [element 1] :  |
-| array_flow.rb:184:13:184:22 | call to source :  | array_flow.rb:188:10:188:10 | a [element 1] :  |
-| array_flow.rb:184:13:184:22 | call to source :  | array_flow.rb:188:10:188:10 | a [element 1] :  |
+| array_flow.rb:184:5:184:5 | a [element 1] :  | array_flow.rb:186:10:186:10 | a [element 1] :  |
+| array_flow.rb:184:5:184:5 | a [element 1] :  | array_flow.rb:186:10:186:10 | a [element 1] :  |
+| array_flow.rb:184:5:184:5 | a [element 1] :  | array_flow.rb:188:10:188:10 | a [element 1] :  |
+| array_flow.rb:184:5:184:5 | a [element 1] :  | array_flow.rb:188:10:188:10 | a [element 1] :  |
+| array_flow.rb:184:13:184:22 | call to source :  | array_flow.rb:184:5:184:5 | a [element 1] :  |
+| array_flow.rb:184:13:184:22 | call to source :  | array_flow.rb:184:5:184:5 | a [element 1] :  |
 | array_flow.rb:186:10:186:10 | a [element 1] :  | array_flow.rb:186:10:186:16 | call to at |
 | array_flow.rb:186:10:186:10 | a [element 1] :  | array_flow.rb:186:10:186:16 | call to at |
 | array_flow.rb:188:10:188:10 | a [element 1] :  | array_flow.rb:188:10:188:16 | call to at |
 | array_flow.rb:188:10:188:10 | a [element 1] :  | array_flow.rb:188:10:188:16 | call to at |
-| array_flow.rb:192:16:192:25 | call to source :  | array_flow.rb:193:9:193:9 | a [element 2] :  |
-| array_flow.rb:192:16:192:25 | call to source :  | array_flow.rb:193:9:193:9 | a [element 2] :  |
+| array_flow.rb:192:5:192:5 | a [element 2] :  | array_flow.rb:193:9:193:9 | a [element 2] :  |
+| array_flow.rb:192:5:192:5 | a [element 2] :  | array_flow.rb:193:9:193:9 | a [element 2] :  |
+| array_flow.rb:192:16:192:25 | call to source :  | array_flow.rb:192:5:192:5 | a [element 2] :  |
+| array_flow.rb:192:16:192:25 | call to source :  | array_flow.rb:192:5:192:5 | a [element 2] :  |
+| array_flow.rb:193:5:193:5 | b :  | array_flow.rb:196:10:196:10 | b |
+| array_flow.rb:193:5:193:5 | b :  | array_flow.rb:196:10:196:10 | b |
 | array_flow.rb:193:9:193:9 | a [element 2] :  | array_flow.rb:193:9:195:7 | call to bsearch :  |
 | array_flow.rb:193:9:193:9 | a [element 2] :  | array_flow.rb:193:9:195:7 | call to bsearch :  |
 | array_flow.rb:193:9:193:9 | a [element 2] :  | array_flow.rb:193:23:193:23 | x :  |
 | array_flow.rb:193:9:193:9 | a [element 2] :  | array_flow.rb:193:23:193:23 | x :  |
-| array_flow.rb:193:9:195:7 | call to bsearch :  | array_flow.rb:196:10:196:10 | b |
-| array_flow.rb:193:9:195:7 | call to bsearch :  | array_flow.rb:196:10:196:10 | b |
+| array_flow.rb:193:9:195:7 | call to bsearch :  | array_flow.rb:193:5:193:5 | b :  |
+| array_flow.rb:193:9:195:7 | call to bsearch :  | array_flow.rb:193:5:193:5 | b :  |
 | array_flow.rb:193:23:193:23 | x :  | array_flow.rb:194:14:194:14 | x |
 | array_flow.rb:193:23:193:23 | x :  | array_flow.rb:194:14:194:14 | x |
-| array_flow.rb:200:16:200:25 | call to source :  | array_flow.rb:201:9:201:9 | a [element 2] :  |
-| array_flow.rb:200:16:200:25 | call to source :  | array_flow.rb:201:9:201:9 | a [element 2] :  |
+| array_flow.rb:200:5:200:5 | a [element 2] :  | array_flow.rb:201:9:201:9 | a [element 2] :  |
+| array_flow.rb:200:5:200:5 | a [element 2] :  | array_flow.rb:201:9:201:9 | a [element 2] :  |
+| array_flow.rb:200:16:200:25 | call to source :  | array_flow.rb:200:5:200:5 | a [element 2] :  |
+| array_flow.rb:200:16:200:25 | call to source :  | array_flow.rb:200:5:200:5 | a [element 2] :  |
 | array_flow.rb:201:9:201:9 | a [element 2] :  | array_flow.rb:201:29:201:29 | x :  |
 | array_flow.rb:201:9:201:9 | a [element 2] :  | array_flow.rb:201:29:201:29 | x :  |
 | array_flow.rb:201:29:201:29 | x :  | array_flow.rb:202:14:202:14 | x |
 | array_flow.rb:201:29:201:29 | x :  | array_flow.rb:202:14:202:14 | x |
-| array_flow.rb:208:16:208:25 | call to source :  | array_flow.rb:209:5:209:5 | a [element 2] :  |
-| array_flow.rb:208:16:208:25 | call to source :  | array_flow.rb:209:5:209:5 | a [element 2] :  |
+| array_flow.rb:208:5:208:5 | a [element 2] :  | array_flow.rb:209:5:209:5 | a [element 2] :  |
+| array_flow.rb:208:5:208:5 | a [element 2] :  | array_flow.rb:209:5:209:5 | a [element 2] :  |
+| array_flow.rb:208:16:208:25 | call to source :  | array_flow.rb:208:5:208:5 | a [element 2] :  |
+| array_flow.rb:208:16:208:25 | call to source :  | array_flow.rb:208:5:208:5 | a [element 2] :  |
 | array_flow.rb:209:5:209:5 | a [element 2] :  | array_flow.rb:209:17:209:17 | x :  |
 | array_flow.rb:209:5:209:5 | a [element 2] :  | array_flow.rb:209:17:209:17 | x :  |
 | array_flow.rb:209:17:209:17 | x :  | array_flow.rb:210:14:210:14 | x |
 | array_flow.rb:209:17:209:17 | x :  | array_flow.rb:210:14:210:14 | x |
-| array_flow.rb:215:16:215:27 | call to source :  | array_flow.rb:216:9:216:9 | a [element 2] :  |
-| array_flow.rb:215:16:215:27 | call to source :  | array_flow.rb:216:9:216:9 | a [element 2] :  |
-| array_flow.rb:215:30:215:41 | call to source :  | array_flow.rb:216:9:216:9 | a [element 3] :  |
-| array_flow.rb:215:30:215:41 | call to source :  | array_flow.rb:216:9:216:9 | a [element 3] :  |
+| array_flow.rb:215:5:215:5 | a [element 2] :  | array_flow.rb:216:9:216:9 | a [element 2] :  |
+| array_flow.rb:215:5:215:5 | a [element 2] :  | array_flow.rb:216:9:216:9 | a [element 2] :  |
+| array_flow.rb:215:5:215:5 | a [element 3] :  | array_flow.rb:216:9:216:9 | a [element 3] :  |
+| array_flow.rb:215:5:215:5 | a [element 3] :  | array_flow.rb:216:9:216:9 | a [element 3] :  |
+| array_flow.rb:215:16:215:27 | call to source :  | array_flow.rb:215:5:215:5 | a [element 2] :  |
+| array_flow.rb:215:16:215:27 | call to source :  | array_flow.rb:215:5:215:5 | a [element 2] :  |
+| array_flow.rb:215:30:215:41 | call to source :  | array_flow.rb:215:5:215:5 | a [element 3] :  |
+| array_flow.rb:215:30:215:41 | call to source :  | array_flow.rb:215:5:215:5 | a [element 3] :  |
 | array_flow.rb:216:9:216:9 | a [element 2] :  | array_flow.rb:216:27:216:27 | x :  |
 | array_flow.rb:216:9:216:9 | a [element 2] :  | array_flow.rb:216:27:216:27 | x :  |
 | array_flow.rb:216:9:216:9 | a [element 2] :  | array_flow.rb:216:30:216:30 | y :  |
@@ -390,26 +487,34 @@ edges
 | array_flow.rb:216:27:216:27 | x :  | array_flow.rb:217:14:217:14 | x |
 | array_flow.rb:216:30:216:30 | y :  | array_flow.rb:218:14:218:14 | y |
 | array_flow.rb:216:30:216:30 | y :  | array_flow.rb:218:14:218:14 | y |
-| array_flow.rb:231:16:231:27 | call to source :  | array_flow.rb:232:9:232:9 | a [element 2] :  |
-| array_flow.rb:231:16:231:27 | call to source :  | array_flow.rb:232:9:232:9 | a [element 2] :  |
+| array_flow.rb:231:5:231:5 | a [element 2] :  | array_flow.rb:232:9:232:9 | a [element 2] :  |
+| array_flow.rb:231:5:231:5 | a [element 2] :  | array_flow.rb:232:9:232:9 | a [element 2] :  |
+| array_flow.rb:231:16:231:27 | call to source :  | array_flow.rb:231:5:231:5 | a [element 2] :  |
+| array_flow.rb:231:16:231:27 | call to source :  | array_flow.rb:231:5:231:5 | a [element 2] :  |
+| array_flow.rb:232:5:232:5 | b [element] :  | array_flow.rb:236:10:236:10 | b [element] :  |
+| array_flow.rb:232:5:232:5 | b [element] :  | array_flow.rb:236:10:236:10 | b [element] :  |
 | array_flow.rb:232:9:232:9 | a [element 2] :  | array_flow.rb:232:23:232:23 | x :  |
 | array_flow.rb:232:9:232:9 | a [element 2] :  | array_flow.rb:232:23:232:23 | x :  |
-| array_flow.rb:232:9:235:7 | call to collect [element] :  | array_flow.rb:236:10:236:10 | b [element] :  |
-| array_flow.rb:232:9:235:7 | call to collect [element] :  | array_flow.rb:236:10:236:10 | b [element] :  |
+| array_flow.rb:232:9:235:7 | call to collect [element] :  | array_flow.rb:232:5:232:5 | b [element] :  |
+| array_flow.rb:232:9:235:7 | call to collect [element] :  | array_flow.rb:232:5:232:5 | b [element] :  |
 | array_flow.rb:232:23:232:23 | x :  | array_flow.rb:233:14:233:14 | x |
 | array_flow.rb:232:23:232:23 | x :  | array_flow.rb:233:14:233:14 | x |
 | array_flow.rb:234:9:234:19 | call to source :  | array_flow.rb:232:9:235:7 | call to collect [element] :  |
 | array_flow.rb:234:9:234:19 | call to source :  | array_flow.rb:232:9:235:7 | call to collect [element] :  |
 | array_flow.rb:236:10:236:10 | b [element] :  | array_flow.rb:236:10:236:13 | ...[...] |
 | array_flow.rb:236:10:236:10 | b [element] :  | array_flow.rb:236:10:236:13 | ...[...] |
-| array_flow.rb:240:16:240:27 | call to source :  | array_flow.rb:241:9:241:9 | a [element 2] :  |
-| array_flow.rb:240:16:240:27 | call to source :  | array_flow.rb:241:9:241:9 | a [element 2] :  |
+| array_flow.rb:240:5:240:5 | a [element 2] :  | array_flow.rb:241:9:241:9 | a [element 2] :  |
+| array_flow.rb:240:5:240:5 | a [element 2] :  | array_flow.rb:241:9:241:9 | a [element 2] :  |
+| array_flow.rb:240:16:240:27 | call to source :  | array_flow.rb:240:5:240:5 | a [element 2] :  |
+| array_flow.rb:240:16:240:27 | call to source :  | array_flow.rb:240:5:240:5 | a [element 2] :  |
+| array_flow.rb:241:5:241:5 | b [element] :  | array_flow.rb:246:10:246:10 | b [element] :  |
+| array_flow.rb:241:5:241:5 | b [element] :  | array_flow.rb:246:10:246:10 | b [element] :  |
 | array_flow.rb:241:9:241:9 | [post] a [element] :  | array_flow.rb:245:10:245:10 | a [element] :  |
 | array_flow.rb:241:9:241:9 | [post] a [element] :  | array_flow.rb:245:10:245:10 | a [element] :  |
 | array_flow.rb:241:9:241:9 | a [element 2] :  | array_flow.rb:241:24:241:24 | x :  |
 | array_flow.rb:241:9:241:9 | a [element 2] :  | array_flow.rb:241:24:241:24 | x :  |
-| array_flow.rb:241:9:244:7 | call to collect! [element] :  | array_flow.rb:246:10:246:10 | b [element] :  |
-| array_flow.rb:241:9:244:7 | call to collect! [element] :  | array_flow.rb:246:10:246:10 | b [element] :  |
+| array_flow.rb:241:9:244:7 | call to collect! [element] :  | array_flow.rb:241:5:241:5 | b [element] :  |
+| array_flow.rb:241:9:244:7 | call to collect! [element] :  | array_flow.rb:241:5:241:5 | b [element] :  |
 | array_flow.rb:241:24:241:24 | x :  | array_flow.rb:242:14:242:14 | x |
 | array_flow.rb:241:24:241:24 | x :  | array_flow.rb:242:14:242:14 | x |
 | array_flow.rb:243:9:243:19 | call to source :  | array_flow.rb:241:9:241:9 | [post] a [element] :  |
@@ -420,72 +525,94 @@ edges
 | array_flow.rb:245:10:245:10 | a [element] :  | array_flow.rb:245:10:245:13 | ...[...] |
 | array_flow.rb:246:10:246:10 | b [element] :  | array_flow.rb:246:10:246:13 | ...[...] |
 | array_flow.rb:246:10:246:10 | b [element] :  | array_flow.rb:246:10:246:13 | ...[...] |
-| array_flow.rb:250:16:250:27 | call to source :  | array_flow.rb:251:9:251:9 | a [element 2] :  |
-| array_flow.rb:250:16:250:27 | call to source :  | array_flow.rb:251:9:251:9 | a [element 2] :  |
-| array_flow.rb:250:16:250:27 | call to source :  | array_flow.rb:256:9:256:9 | a [element 2] :  |
-| array_flow.rb:250:16:250:27 | call to source :  | array_flow.rb:256:9:256:9 | a [element 2] :  |
+| array_flow.rb:250:5:250:5 | a [element 2] :  | array_flow.rb:251:9:251:9 | a [element 2] :  |
+| array_flow.rb:250:5:250:5 | a [element 2] :  | array_flow.rb:251:9:251:9 | a [element 2] :  |
+| array_flow.rb:250:5:250:5 | a [element 2] :  | array_flow.rb:256:9:256:9 | a [element 2] :  |
+| array_flow.rb:250:5:250:5 | a [element 2] :  | array_flow.rb:256:9:256:9 | a [element 2] :  |
+| array_flow.rb:250:16:250:27 | call to source :  | array_flow.rb:250:5:250:5 | a [element 2] :  |
+| array_flow.rb:250:16:250:27 | call to source :  | array_flow.rb:250:5:250:5 | a [element 2] :  |
+| array_flow.rb:251:5:251:5 | b [element] :  | array_flow.rb:255:10:255:10 | b [element] :  |
+| array_flow.rb:251:5:251:5 | b [element] :  | array_flow.rb:255:10:255:10 | b [element] :  |
 | array_flow.rb:251:9:251:9 | a [element 2] :  | array_flow.rb:251:9:254:7 | call to collect_concat [element] :  |
 | array_flow.rb:251:9:251:9 | a [element 2] :  | array_flow.rb:251:9:254:7 | call to collect_concat [element] :  |
 | array_flow.rb:251:9:251:9 | a [element 2] :  | array_flow.rb:251:30:251:30 | x :  |
 | array_flow.rb:251:9:251:9 | a [element 2] :  | array_flow.rb:251:30:251:30 | x :  |
-| array_flow.rb:251:9:254:7 | call to collect_concat [element] :  | array_flow.rb:255:10:255:10 | b [element] :  |
-| array_flow.rb:251:9:254:7 | call to collect_concat [element] :  | array_flow.rb:255:10:255:10 | b [element] :  |
+| array_flow.rb:251:9:254:7 | call to collect_concat [element] :  | array_flow.rb:251:5:251:5 | b [element] :  |
+| array_flow.rb:251:9:254:7 | call to collect_concat [element] :  | array_flow.rb:251:5:251:5 | b [element] :  |
 | array_flow.rb:251:30:251:30 | x :  | array_flow.rb:252:14:252:14 | x |
 | array_flow.rb:251:30:251:30 | x :  | array_flow.rb:252:14:252:14 | x |
 | array_flow.rb:253:13:253:24 | call to source :  | array_flow.rb:251:9:254:7 | call to collect_concat [element] :  |
 | array_flow.rb:253:13:253:24 | call to source :  | array_flow.rb:251:9:254:7 | call to collect_concat [element] :  |
 | array_flow.rb:255:10:255:10 | b [element] :  | array_flow.rb:255:10:255:13 | ...[...] |
 | array_flow.rb:255:10:255:10 | b [element] :  | array_flow.rb:255:10:255:13 | ...[...] |
+| array_flow.rb:256:5:256:5 | b [element] :  | array_flow.rb:260:10:260:10 | b [element] :  |
+| array_flow.rb:256:5:256:5 | b [element] :  | array_flow.rb:260:10:260:10 | b [element] :  |
 | array_flow.rb:256:9:256:9 | a [element 2] :  | array_flow.rb:256:30:256:30 | x :  |
 | array_flow.rb:256:9:256:9 | a [element 2] :  | array_flow.rb:256:30:256:30 | x :  |
-| array_flow.rb:256:9:259:7 | call to collect_concat [element] :  | array_flow.rb:260:10:260:10 | b [element] :  |
-| array_flow.rb:256:9:259:7 | call to collect_concat [element] :  | array_flow.rb:260:10:260:10 | b [element] :  |
+| array_flow.rb:256:9:259:7 | call to collect_concat [element] :  | array_flow.rb:256:5:256:5 | b [element] :  |
+| array_flow.rb:256:9:259:7 | call to collect_concat [element] :  | array_flow.rb:256:5:256:5 | b [element] :  |
 | array_flow.rb:256:30:256:30 | x :  | array_flow.rb:257:14:257:14 | x |
 | array_flow.rb:256:30:256:30 | x :  | array_flow.rb:257:14:257:14 | x |
 | array_flow.rb:258:9:258:20 | call to source :  | array_flow.rb:256:9:259:7 | call to collect_concat [element] :  |
 | array_flow.rb:258:9:258:20 | call to source :  | array_flow.rb:256:9:259:7 | call to collect_concat [element] :  |
 | array_flow.rb:260:10:260:10 | b [element] :  | array_flow.rb:260:10:260:13 | ...[...] |
 | array_flow.rb:260:10:260:10 | b [element] :  | array_flow.rb:260:10:260:13 | ...[...] |
-| array_flow.rb:264:16:264:25 | call to source :  | array_flow.rb:265:9:265:9 | a [element 2] :  |
-| array_flow.rb:264:16:264:25 | call to source :  | array_flow.rb:265:9:265:9 | a [element 2] :  |
+| array_flow.rb:264:5:264:5 | a [element 2] :  | array_flow.rb:265:9:265:9 | a [element 2] :  |
+| array_flow.rb:264:5:264:5 | a [element 2] :  | array_flow.rb:265:9:265:9 | a [element 2] :  |
+| array_flow.rb:264:16:264:25 | call to source :  | array_flow.rb:264:5:264:5 | a [element 2] :  |
+| array_flow.rb:264:16:264:25 | call to source :  | array_flow.rb:264:5:264:5 | a [element 2] :  |
+| array_flow.rb:265:5:265:5 | b [element 2] :  | array_flow.rb:269:10:269:10 | b [element 2] :  |
+| array_flow.rb:265:5:265:5 | b [element 2] :  | array_flow.rb:269:10:269:10 | b [element 2] :  |
 | array_flow.rb:265:9:265:9 | a [element 2] :  | array_flow.rb:265:9:267:7 | call to combination [element 2] :  |
 | array_flow.rb:265:9:265:9 | a [element 2] :  | array_flow.rb:265:9:267:7 | call to combination [element 2] :  |
 | array_flow.rb:265:9:265:9 | a [element 2] :  | array_flow.rb:265:30:265:30 | x [element] :  |
 | array_flow.rb:265:9:265:9 | a [element 2] :  | array_flow.rb:265:30:265:30 | x [element] :  |
-| array_flow.rb:265:9:267:7 | call to combination [element 2] :  | array_flow.rb:269:10:269:10 | b [element 2] :  |
-| array_flow.rb:265:9:267:7 | call to combination [element 2] :  | array_flow.rb:269:10:269:10 | b [element 2] :  |
+| array_flow.rb:265:9:267:7 | call to combination [element 2] :  | array_flow.rb:265:5:265:5 | b [element 2] :  |
+| array_flow.rb:265:9:267:7 | call to combination [element 2] :  | array_flow.rb:265:5:265:5 | b [element 2] :  |
 | array_flow.rb:265:30:265:30 | x [element] :  | array_flow.rb:266:14:266:14 | x [element] :  |
 | array_flow.rb:265:30:265:30 | x [element] :  | array_flow.rb:266:14:266:14 | x [element] :  |
 | array_flow.rb:266:14:266:14 | x [element] :  | array_flow.rb:266:14:266:17 | ...[...] |
 | array_flow.rb:266:14:266:14 | x [element] :  | array_flow.rb:266:14:266:17 | ...[...] |
 | array_flow.rb:269:10:269:10 | b [element 2] :  | array_flow.rb:269:10:269:13 | ...[...] |
 | array_flow.rb:269:10:269:10 | b [element 2] :  | array_flow.rb:269:10:269:13 | ...[...] |
-| array_flow.rb:273:16:273:25 | call to source :  | array_flow.rb:274:9:274:9 | a [element 2] :  |
-| array_flow.rb:273:16:273:25 | call to source :  | array_flow.rb:274:9:274:9 | a [element 2] :  |
+| array_flow.rb:273:5:273:5 | a [element 2] :  | array_flow.rb:274:9:274:9 | a [element 2] :  |
+| array_flow.rb:273:5:273:5 | a [element 2] :  | array_flow.rb:274:9:274:9 | a [element 2] :  |
+| array_flow.rb:273:16:273:25 | call to source :  | array_flow.rb:273:5:273:5 | a [element 2] :  |
+| array_flow.rb:273:16:273:25 | call to source :  | array_flow.rb:273:5:273:5 | a [element 2] :  |
+| array_flow.rb:274:5:274:5 | b [element] :  | array_flow.rb:275:10:275:10 | b [element] :  |
+| array_flow.rb:274:5:274:5 | b [element] :  | array_flow.rb:275:10:275:10 | b [element] :  |
 | array_flow.rb:274:9:274:9 | a [element 2] :  | array_flow.rb:274:9:274:17 | call to compact [element] :  |
 | array_flow.rb:274:9:274:9 | a [element 2] :  | array_flow.rb:274:9:274:17 | call to compact [element] :  |
-| array_flow.rb:274:9:274:17 | call to compact [element] :  | array_flow.rb:275:10:275:10 | b [element] :  |
-| array_flow.rb:274:9:274:17 | call to compact [element] :  | array_flow.rb:275:10:275:10 | b [element] :  |
+| array_flow.rb:274:9:274:17 | call to compact [element] :  | array_flow.rb:274:5:274:5 | b [element] :  |
+| array_flow.rb:274:9:274:17 | call to compact [element] :  | array_flow.rb:274:5:274:5 | b [element] :  |
 | array_flow.rb:275:10:275:10 | b [element] :  | array_flow.rb:275:10:275:13 | ...[...] |
 | array_flow.rb:275:10:275:10 | b [element] :  | array_flow.rb:275:10:275:13 | ...[...] |
-| array_flow.rb:279:16:279:25 | call to source :  | array_flow.rb:280:9:280:9 | a [element 2] :  |
-| array_flow.rb:279:16:279:25 | call to source :  | array_flow.rb:280:9:280:9 | a [element 2] :  |
+| array_flow.rb:279:5:279:5 | a [element 2] :  | array_flow.rb:280:9:280:9 | a [element 2] :  |
+| array_flow.rb:279:5:279:5 | a [element 2] :  | array_flow.rb:280:9:280:9 | a [element 2] :  |
+| array_flow.rb:279:16:279:25 | call to source :  | array_flow.rb:279:5:279:5 | a [element 2] :  |
+| array_flow.rb:279:16:279:25 | call to source :  | array_flow.rb:279:5:279:5 | a [element 2] :  |
+| array_flow.rb:280:5:280:5 | b [element] :  | array_flow.rb:282:10:282:10 | b [element] :  |
+| array_flow.rb:280:5:280:5 | b [element] :  | array_flow.rb:282:10:282:10 | b [element] :  |
 | array_flow.rb:280:9:280:9 | [post] a [element] :  | array_flow.rb:281:10:281:10 | a [element] :  |
 | array_flow.rb:280:9:280:9 | [post] a [element] :  | array_flow.rb:281:10:281:10 | a [element] :  |
 | array_flow.rb:280:9:280:9 | a [element 2] :  | array_flow.rb:280:9:280:9 | [post] a [element] :  |
 | array_flow.rb:280:9:280:9 | a [element 2] :  | array_flow.rb:280:9:280:9 | [post] a [element] :  |
 | array_flow.rb:280:9:280:9 | a [element 2] :  | array_flow.rb:280:9:280:18 | call to compact! [element] :  |
 | array_flow.rb:280:9:280:9 | a [element 2] :  | array_flow.rb:280:9:280:18 | call to compact! [element] :  |
-| array_flow.rb:280:9:280:18 | call to compact! [element] :  | array_flow.rb:282:10:282:10 | b [element] :  |
-| array_flow.rb:280:9:280:18 | call to compact! [element] :  | array_flow.rb:282:10:282:10 | b [element] :  |
+| array_flow.rb:280:9:280:18 | call to compact! [element] :  | array_flow.rb:280:5:280:5 | b [element] :  |
+| array_flow.rb:280:9:280:18 | call to compact! [element] :  | array_flow.rb:280:5:280:5 | b [element] :  |
 | array_flow.rb:281:10:281:10 | a [element] :  | array_flow.rb:281:10:281:13 | ...[...] |
 | array_flow.rb:281:10:281:10 | a [element] :  | array_flow.rb:281:10:281:13 | ...[...] |
 | array_flow.rb:282:10:282:10 | b [element] :  | array_flow.rb:282:10:282:13 | ...[...] |
 | array_flow.rb:282:10:282:10 | b [element] :  | array_flow.rb:282:10:282:13 | ...[...] |
-| array_flow.rb:286:16:286:27 | call to source :  | array_flow.rb:290:10:290:10 | a [element 2] :  |
-| array_flow.rb:286:16:286:27 | call to source :  | array_flow.rb:290:10:290:10 | a [element 2] :  |
-| array_flow.rb:287:16:287:27 | call to source :  | array_flow.rb:288:14:288:14 | b [element 2] :  |
-| array_flow.rb:287:16:287:27 | call to source :  | array_flow.rb:288:14:288:14 | b [element 2] :  |
+| array_flow.rb:286:5:286:5 | a [element 2] :  | array_flow.rb:290:10:290:10 | a [element 2] :  |
+| array_flow.rb:286:5:286:5 | a [element 2] :  | array_flow.rb:290:10:290:10 | a [element 2] :  |
+| array_flow.rb:286:16:286:27 | call to source :  | array_flow.rb:286:5:286:5 | a [element 2] :  |
+| array_flow.rb:286:16:286:27 | call to source :  | array_flow.rb:286:5:286:5 | a [element 2] :  |
+| array_flow.rb:287:5:287:5 | b [element 2] :  | array_flow.rb:288:14:288:14 | b [element 2] :  |
+| array_flow.rb:287:5:287:5 | b [element 2] :  | array_flow.rb:288:14:288:14 | b [element 2] :  |
+| array_flow.rb:287:16:287:27 | call to source :  | array_flow.rb:287:5:287:5 | b [element 2] :  |
+| array_flow.rb:287:16:287:27 | call to source :  | array_flow.rb:287:5:287:5 | b [element 2] :  |
 | array_flow.rb:288:5:288:5 | [post] a [element] :  | array_flow.rb:289:10:289:10 | a [element] :  |
 | array_flow.rb:288:5:288:5 | [post] a [element] :  | array_flow.rb:289:10:289:10 | a [element] :  |
 | array_flow.rb:288:5:288:5 | [post] a [element] :  | array_flow.rb:290:10:290:10 | a [element] :  |
@@ -498,52 +625,76 @@ edges
 | array_flow.rb:290:10:290:10 | a [element 2] :  | array_flow.rb:290:10:290:13 | ...[...] |
 | array_flow.rb:290:10:290:10 | a [element] :  | array_flow.rb:290:10:290:13 | ...[...] |
 | array_flow.rb:290:10:290:10 | a [element] :  | array_flow.rb:290:10:290:13 | ...[...] |
-| array_flow.rb:294:16:294:25 | call to source :  | array_flow.rb:295:5:295:5 | a [element 2] :  |
-| array_flow.rb:294:16:294:25 | call to source :  | array_flow.rb:295:5:295:5 | a [element 2] :  |
+| array_flow.rb:294:5:294:5 | a [element 2] :  | array_flow.rb:295:5:295:5 | a [element 2] :  |
+| array_flow.rb:294:5:294:5 | a [element 2] :  | array_flow.rb:295:5:295:5 | a [element 2] :  |
+| array_flow.rb:294:16:294:25 | call to source :  | array_flow.rb:294:5:294:5 | a [element 2] :  |
+| array_flow.rb:294:16:294:25 | call to source :  | array_flow.rb:294:5:294:5 | a [element 2] :  |
 | array_flow.rb:295:5:295:5 | a [element 2] :  | array_flow.rb:295:17:295:17 | x :  |
 | array_flow.rb:295:5:295:5 | a [element 2] :  | array_flow.rb:295:17:295:17 | x :  |
 | array_flow.rb:295:17:295:17 | x :  | array_flow.rb:296:14:296:14 | x |
 | array_flow.rb:295:17:295:17 | x :  | array_flow.rb:296:14:296:14 | x |
-| array_flow.rb:301:16:301:25 | call to source :  | array_flow.rb:302:5:302:5 | a [element 2] :  |
-| array_flow.rb:301:16:301:25 | call to source :  | array_flow.rb:302:5:302:5 | a [element 2] :  |
+| array_flow.rb:301:5:301:5 | a [element 2] :  | array_flow.rb:302:5:302:5 | a [element 2] :  |
+| array_flow.rb:301:5:301:5 | a [element 2] :  | array_flow.rb:302:5:302:5 | a [element 2] :  |
+| array_flow.rb:301:16:301:25 | call to source :  | array_flow.rb:301:5:301:5 | a [element 2] :  |
+| array_flow.rb:301:16:301:25 | call to source :  | array_flow.rb:301:5:301:5 | a [element 2] :  |
 | array_flow.rb:302:5:302:5 | a [element 2] :  | array_flow.rb:302:20:302:20 | x :  |
 | array_flow.rb:302:5:302:5 | a [element 2] :  | array_flow.rb:302:20:302:20 | x :  |
 | array_flow.rb:302:20:302:20 | x :  | array_flow.rb:303:14:303:14 | x |
 | array_flow.rb:302:20:302:20 | x :  | array_flow.rb:303:14:303:14 | x |
-| array_flow.rb:308:16:308:25 | call to source :  | array_flow.rb:309:9:309:9 | a [element 2] :  |
-| array_flow.rb:308:16:308:25 | call to source :  | array_flow.rb:309:9:309:9 | a [element 2] :  |
+| array_flow.rb:308:5:308:5 | a [element 2] :  | array_flow.rb:309:9:309:9 | a [element 2] :  |
+| array_flow.rb:308:5:308:5 | a [element 2] :  | array_flow.rb:309:9:309:9 | a [element 2] :  |
+| array_flow.rb:308:16:308:25 | call to source :  | array_flow.rb:308:5:308:5 | a [element 2] :  |
+| array_flow.rb:308:16:308:25 | call to source :  | array_flow.rb:308:5:308:5 | a [element 2] :  |
+| array_flow.rb:309:5:309:5 | b [element 2] :  | array_flow.rb:312:10:312:10 | b [element 2] :  |
+| array_flow.rb:309:5:309:5 | b [element 2] :  | array_flow.rb:312:10:312:10 | b [element 2] :  |
 | array_flow.rb:309:9:309:9 | a [element 2] :  | array_flow.rb:309:9:309:21 | call to deconstruct [element 2] :  |
 | array_flow.rb:309:9:309:9 | a [element 2] :  | array_flow.rb:309:9:309:21 | call to deconstruct [element 2] :  |
-| array_flow.rb:309:9:309:21 | call to deconstruct [element 2] :  | array_flow.rb:312:10:312:10 | b [element 2] :  |
-| array_flow.rb:309:9:309:21 | call to deconstruct [element 2] :  | array_flow.rb:312:10:312:10 | b [element 2] :  |
+| array_flow.rb:309:9:309:21 | call to deconstruct [element 2] :  | array_flow.rb:309:5:309:5 | b [element 2] :  |
+| array_flow.rb:309:9:309:21 | call to deconstruct [element 2] :  | array_flow.rb:309:5:309:5 | b [element 2] :  |
 | array_flow.rb:312:10:312:10 | b [element 2] :  | array_flow.rb:312:10:312:13 | ...[...] |
 | array_flow.rb:312:10:312:10 | b [element 2] :  | array_flow.rb:312:10:312:13 | ...[...] |
-| array_flow.rb:316:16:316:27 | call to source :  | array_flow.rb:317:9:317:9 | a [element 2] :  |
-| array_flow.rb:316:16:316:27 | call to source :  | array_flow.rb:317:9:317:9 | a [element 2] :  |
+| array_flow.rb:316:5:316:5 | a [element 2] :  | array_flow.rb:317:9:317:9 | a [element 2] :  |
+| array_flow.rb:316:5:316:5 | a [element 2] :  | array_flow.rb:317:9:317:9 | a [element 2] :  |
+| array_flow.rb:316:16:316:27 | call to source :  | array_flow.rb:316:5:316:5 | a [element 2] :  |
+| array_flow.rb:316:16:316:27 | call to source :  | array_flow.rb:316:5:316:5 | a [element 2] :  |
+| array_flow.rb:317:5:317:5 | b :  | array_flow.rb:318:10:318:10 | b |
+| array_flow.rb:317:5:317:5 | b :  | array_flow.rb:318:10:318:10 | b |
 | array_flow.rb:317:9:317:9 | a [element 2] :  | array_flow.rb:317:9:317:36 | call to delete :  |
 | array_flow.rb:317:9:317:9 | a [element 2] :  | array_flow.rb:317:9:317:36 | call to delete :  |
-| array_flow.rb:317:9:317:36 | call to delete :  | array_flow.rb:318:10:318:10 | b |
-| array_flow.rb:317:9:317:36 | call to delete :  | array_flow.rb:318:10:318:10 | b |
+| array_flow.rb:317:9:317:36 | call to delete :  | array_flow.rb:317:5:317:5 | b :  |
+| array_flow.rb:317:9:317:36 | call to delete :  | array_flow.rb:317:5:317:5 | b :  |
 | array_flow.rb:317:23:317:34 | call to source :  | array_flow.rb:317:9:317:36 | call to delete :  |
 | array_flow.rb:317:23:317:34 | call to source :  | array_flow.rb:317:9:317:36 | call to delete :  |
-| array_flow.rb:325:16:325:27 | call to source :  | array_flow.rb:326:9:326:9 | a [element 2] :  |
-| array_flow.rb:325:16:325:27 | call to source :  | array_flow.rb:326:9:326:9 | a [element 2] :  |
-| array_flow.rb:325:30:325:41 | call to source :  | array_flow.rb:326:9:326:9 | a [element 3] :  |
-| array_flow.rb:325:30:325:41 | call to source :  | array_flow.rb:326:9:326:9 | a [element 3] :  |
+| array_flow.rb:325:5:325:5 | a [element 2] :  | array_flow.rb:326:9:326:9 | a [element 2] :  |
+| array_flow.rb:325:5:325:5 | a [element 2] :  | array_flow.rb:326:9:326:9 | a [element 2] :  |
+| array_flow.rb:325:5:325:5 | a [element 3] :  | array_flow.rb:326:9:326:9 | a [element 3] :  |
+| array_flow.rb:325:5:325:5 | a [element 3] :  | array_flow.rb:326:9:326:9 | a [element 3] :  |
+| array_flow.rb:325:16:325:27 | call to source :  | array_flow.rb:325:5:325:5 | a [element 2] :  |
+| array_flow.rb:325:16:325:27 | call to source :  | array_flow.rb:325:5:325:5 | a [element 2] :  |
+| array_flow.rb:325:30:325:41 | call to source :  | array_flow.rb:325:5:325:5 | a [element 3] :  |
+| array_flow.rb:325:30:325:41 | call to source :  | array_flow.rb:325:5:325:5 | a [element 3] :  |
+| array_flow.rb:326:5:326:5 | b :  | array_flow.rb:327:10:327:10 | b |
+| array_flow.rb:326:5:326:5 | b :  | array_flow.rb:327:10:327:10 | b |
 | array_flow.rb:326:9:326:9 | [post] a [element 2] :  | array_flow.rb:328:10:328:10 | a [element 2] :  |
 | array_flow.rb:326:9:326:9 | [post] a [element 2] :  | array_flow.rb:328:10:328:10 | a [element 2] :  |
 | array_flow.rb:326:9:326:9 | a [element 2] :  | array_flow.rb:326:9:326:22 | call to delete_at :  |
 | array_flow.rb:326:9:326:9 | a [element 2] :  | array_flow.rb:326:9:326:22 | call to delete_at :  |
 | array_flow.rb:326:9:326:9 | a [element 3] :  | array_flow.rb:326:9:326:9 | [post] a [element 2] :  |
 | array_flow.rb:326:9:326:9 | a [element 3] :  | array_flow.rb:326:9:326:9 | [post] a [element 2] :  |
-| array_flow.rb:326:9:326:22 | call to delete_at :  | array_flow.rb:327:10:327:10 | b |
-| array_flow.rb:326:9:326:22 | call to delete_at :  | array_flow.rb:327:10:327:10 | b |
+| array_flow.rb:326:9:326:22 | call to delete_at :  | array_flow.rb:326:5:326:5 | b :  |
+| array_flow.rb:326:9:326:22 | call to delete_at :  | array_flow.rb:326:5:326:5 | b :  |
 | array_flow.rb:328:10:328:10 | a [element 2] :  | array_flow.rb:328:10:328:13 | ...[...] |
 | array_flow.rb:328:10:328:10 | a [element 2] :  | array_flow.rb:328:10:328:13 | ...[...] |
-| array_flow.rb:330:16:330:27 | call to source :  | array_flow.rb:331:9:331:9 | a [element 2] :  |
-| array_flow.rb:330:16:330:27 | call to source :  | array_flow.rb:331:9:331:9 | a [element 2] :  |
-| array_flow.rb:330:30:330:41 | call to source :  | array_flow.rb:331:9:331:9 | a [element 3] :  |
-| array_flow.rb:330:30:330:41 | call to source :  | array_flow.rb:331:9:331:9 | a [element 3] :  |
+| array_flow.rb:330:5:330:5 | a [element 2] :  | array_flow.rb:331:9:331:9 | a [element 2] :  |
+| array_flow.rb:330:5:330:5 | a [element 2] :  | array_flow.rb:331:9:331:9 | a [element 2] :  |
+| array_flow.rb:330:5:330:5 | a [element 3] :  | array_flow.rb:331:9:331:9 | a [element 3] :  |
+| array_flow.rb:330:5:330:5 | a [element 3] :  | array_flow.rb:331:9:331:9 | a [element 3] :  |
+| array_flow.rb:330:16:330:27 | call to source :  | array_flow.rb:330:5:330:5 | a [element 2] :  |
+| array_flow.rb:330:16:330:27 | call to source :  | array_flow.rb:330:5:330:5 | a [element 2] :  |
+| array_flow.rb:330:30:330:41 | call to source :  | array_flow.rb:330:5:330:5 | a [element 3] :  |
+| array_flow.rb:330:30:330:41 | call to source :  | array_flow.rb:330:5:330:5 | a [element 3] :  |
+| array_flow.rb:331:5:331:5 | b :  | array_flow.rb:332:10:332:10 | b |
+| array_flow.rb:331:5:331:5 | b :  | array_flow.rb:332:10:332:10 | b |
 | array_flow.rb:331:9:331:9 | [post] a [element] :  | array_flow.rb:333:10:333:10 | a [element] :  |
 | array_flow.rb:331:9:331:9 | [post] a [element] :  | array_flow.rb:333:10:333:10 | a [element] :  |
 | array_flow.rb:331:9:331:9 | [post] a [element] :  | array_flow.rb:334:10:334:10 | a [element] :  |
@@ -556,14 +707,18 @@ edges
 | array_flow.rb:331:9:331:9 | a [element 3] :  | array_flow.rb:331:9:331:9 | [post] a [element] :  |
 | array_flow.rb:331:9:331:9 | a [element 3] :  | array_flow.rb:331:9:331:22 | call to delete_at :  |
 | array_flow.rb:331:9:331:9 | a [element 3] :  | array_flow.rb:331:9:331:22 | call to delete_at :  |
-| array_flow.rb:331:9:331:22 | call to delete_at :  | array_flow.rb:332:10:332:10 | b |
-| array_flow.rb:331:9:331:22 | call to delete_at :  | array_flow.rb:332:10:332:10 | b |
+| array_flow.rb:331:9:331:22 | call to delete_at :  | array_flow.rb:331:5:331:5 | b :  |
+| array_flow.rb:331:9:331:22 | call to delete_at :  | array_flow.rb:331:5:331:5 | b :  |
 | array_flow.rb:333:10:333:10 | a [element] :  | array_flow.rb:333:10:333:13 | ...[...] |
 | array_flow.rb:333:10:333:10 | a [element] :  | array_flow.rb:333:10:333:13 | ...[...] |
 | array_flow.rb:334:10:334:10 | a [element] :  | array_flow.rb:334:10:334:13 | ...[...] |
 | array_flow.rb:334:10:334:10 | a [element] :  | array_flow.rb:334:10:334:13 | ...[...] |
-| array_flow.rb:338:16:338:25 | call to source :  | array_flow.rb:339:9:339:9 | a [element 2] :  |
-| array_flow.rb:338:16:338:25 | call to source :  | array_flow.rb:339:9:339:9 | a [element 2] :  |
+| array_flow.rb:338:5:338:5 | a [element 2] :  | array_flow.rb:339:9:339:9 | a [element 2] :  |
+| array_flow.rb:338:5:338:5 | a [element 2] :  | array_flow.rb:339:9:339:9 | a [element 2] :  |
+| array_flow.rb:338:16:338:25 | call to source :  | array_flow.rb:338:5:338:5 | a [element 2] :  |
+| array_flow.rb:338:16:338:25 | call to source :  | array_flow.rb:338:5:338:5 | a [element 2] :  |
+| array_flow.rb:339:5:339:5 | b [element] :  | array_flow.rb:342:10:342:10 | b [element] :  |
+| array_flow.rb:339:5:339:5 | b [element] :  | array_flow.rb:342:10:342:10 | b [element] :  |
 | array_flow.rb:339:9:339:9 | [post] a [element] :  | array_flow.rb:343:10:343:10 | a [element] :  |
 | array_flow.rb:339:9:339:9 | [post] a [element] :  | array_flow.rb:343:10:343:10 | a [element] :  |
 | array_flow.rb:339:9:339:9 | [post] a [element] :  | array_flow.rb:344:10:344:10 | a [element] :  |
@@ -576,8 +731,8 @@ edges
 | array_flow.rb:339:9:339:9 | a [element 2] :  | array_flow.rb:339:9:341:7 | call to delete_if [element] :  |
 | array_flow.rb:339:9:339:9 | a [element 2] :  | array_flow.rb:339:25:339:25 | x :  |
 | array_flow.rb:339:9:339:9 | a [element 2] :  | array_flow.rb:339:25:339:25 | x :  |
-| array_flow.rb:339:9:341:7 | call to delete_if [element] :  | array_flow.rb:342:10:342:10 | b [element] :  |
-| array_flow.rb:339:9:341:7 | call to delete_if [element] :  | array_flow.rb:342:10:342:10 | b [element] :  |
+| array_flow.rb:339:9:341:7 | call to delete_if [element] :  | array_flow.rb:339:5:339:5 | b [element] :  |
+| array_flow.rb:339:9:341:7 | call to delete_if [element] :  | array_flow.rb:339:5:339:5 | b [element] :  |
 | array_flow.rb:339:25:339:25 | x :  | array_flow.rb:340:14:340:14 | x |
 | array_flow.rb:339:25:339:25 | x :  | array_flow.rb:340:14:340:14 | x |
 | array_flow.rb:342:10:342:10 | b [element] :  | array_flow.rb:342:10:342:13 | ...[...] |
@@ -588,66 +743,88 @@ edges
 | array_flow.rb:344:10:344:10 | a [element] :  | array_flow.rb:344:10:344:13 | ...[...] |
 | array_flow.rb:345:10:345:10 | a [element] :  | array_flow.rb:345:10:345:13 | ...[...] |
 | array_flow.rb:345:10:345:10 | a [element] :  | array_flow.rb:345:10:345:13 | ...[...] |
-| array_flow.rb:349:16:349:25 | call to source :  | array_flow.rb:350:9:350:9 | a [element 2] :  |
-| array_flow.rb:349:16:349:25 | call to source :  | array_flow.rb:350:9:350:9 | a [element 2] :  |
+| array_flow.rb:349:5:349:5 | a [element 2] :  | array_flow.rb:350:9:350:9 | a [element 2] :  |
+| array_flow.rb:349:5:349:5 | a [element 2] :  | array_flow.rb:350:9:350:9 | a [element 2] :  |
+| array_flow.rb:349:16:349:25 | call to source :  | array_flow.rb:349:5:349:5 | a [element 2] :  |
+| array_flow.rb:349:16:349:25 | call to source :  | array_flow.rb:349:5:349:5 | a [element 2] :  |
+| array_flow.rb:350:5:350:5 | b [element] :  | array_flow.rb:351:10:351:10 | b [element] :  |
+| array_flow.rb:350:5:350:5 | b [element] :  | array_flow.rb:351:10:351:10 | b [element] :  |
 | array_flow.rb:350:9:350:9 | a [element 2] :  | array_flow.rb:350:9:350:25 | call to difference [element] :  |
 | array_flow.rb:350:9:350:9 | a [element 2] :  | array_flow.rb:350:9:350:25 | call to difference [element] :  |
-| array_flow.rb:350:9:350:25 | call to difference [element] :  | array_flow.rb:351:10:351:10 | b [element] :  |
-| array_flow.rb:350:9:350:25 | call to difference [element] :  | array_flow.rb:351:10:351:10 | b [element] :  |
+| array_flow.rb:350:9:350:25 | call to difference [element] :  | array_flow.rb:350:5:350:5 | b [element] :  |
+| array_flow.rb:350:9:350:25 | call to difference [element] :  | array_flow.rb:350:5:350:5 | b [element] :  |
 | array_flow.rb:351:10:351:10 | b [element] :  | array_flow.rb:351:10:351:13 | ...[...] |
 | array_flow.rb:351:10:351:10 | b [element] :  | array_flow.rb:351:10:351:13 | ...[...] |
-| array_flow.rb:355:16:355:27 | call to source :  | array_flow.rb:357:10:357:10 | a [element 2] :  |
-| array_flow.rb:355:16:355:27 | call to source :  | array_flow.rb:357:10:357:10 | a [element 2] :  |
-| array_flow.rb:355:16:355:27 | call to source :  | array_flow.rb:358:10:358:10 | a [element 2] :  |
-| array_flow.rb:355:16:355:27 | call to source :  | array_flow.rb:358:10:358:10 | a [element 2] :  |
-| array_flow.rb:355:34:355:45 | call to source :  | array_flow.rb:360:10:360:10 | a [element 3, element 1] :  |
-| array_flow.rb:355:34:355:45 | call to source :  | array_flow.rb:360:10:360:10 | a [element 3, element 1] :  |
+| array_flow.rb:355:5:355:5 | a [element 2] :  | array_flow.rb:357:10:357:10 | a [element 2] :  |
+| array_flow.rb:355:5:355:5 | a [element 2] :  | array_flow.rb:357:10:357:10 | a [element 2] :  |
+| array_flow.rb:355:5:355:5 | a [element 2] :  | array_flow.rb:358:10:358:10 | a [element 2] :  |
+| array_flow.rb:355:5:355:5 | a [element 2] :  | array_flow.rb:358:10:358:10 | a [element 2] :  |
+| array_flow.rb:355:5:355:5 | a [element 3, element 1] :  | array_flow.rb:360:10:360:10 | a [element 3, element 1] :  |
+| array_flow.rb:355:5:355:5 | a [element 3, element 1] :  | array_flow.rb:360:10:360:10 | a [element 3, element 1] :  |
+| array_flow.rb:355:16:355:27 | call to source :  | array_flow.rb:355:5:355:5 | a [element 2] :  |
+| array_flow.rb:355:16:355:27 | call to source :  | array_flow.rb:355:5:355:5 | a [element 2] :  |
+| array_flow.rb:355:34:355:45 | call to source :  | array_flow.rb:355:5:355:5 | a [element 3, element 1] :  |
+| array_flow.rb:355:34:355:45 | call to source :  | array_flow.rb:355:5:355:5 | a [element 3, element 1] :  |
 | array_flow.rb:357:10:357:10 | a [element 2] :  | array_flow.rb:357:10:357:17 | call to dig |
 | array_flow.rb:357:10:357:10 | a [element 2] :  | array_flow.rb:357:10:357:17 | call to dig |
 | array_flow.rb:358:10:358:10 | a [element 2] :  | array_flow.rb:358:10:358:17 | call to dig |
 | array_flow.rb:358:10:358:10 | a [element 2] :  | array_flow.rb:358:10:358:17 | call to dig |
 | array_flow.rb:360:10:360:10 | a [element 3, element 1] :  | array_flow.rb:360:10:360:19 | call to dig |
 | array_flow.rb:360:10:360:10 | a [element 3, element 1] :  | array_flow.rb:360:10:360:19 | call to dig |
-| array_flow.rb:364:16:364:27 | call to source :  | array_flow.rb:365:9:365:9 | a [element 2] :  |
-| array_flow.rb:364:16:364:27 | call to source :  | array_flow.rb:365:9:365:9 | a [element 2] :  |
+| array_flow.rb:364:5:364:5 | a [element 2] :  | array_flow.rb:365:9:365:9 | a [element 2] :  |
+| array_flow.rb:364:5:364:5 | a [element 2] :  | array_flow.rb:365:9:365:9 | a [element 2] :  |
+| array_flow.rb:364:16:364:27 | call to source :  | array_flow.rb:364:5:364:5 | a [element 2] :  |
+| array_flow.rb:364:16:364:27 | call to source :  | array_flow.rb:364:5:364:5 | a [element 2] :  |
+| array_flow.rb:365:5:365:5 | b :  | array_flow.rb:368:10:368:10 | b |
+| array_flow.rb:365:5:365:5 | b :  | array_flow.rb:368:10:368:10 | b |
 | array_flow.rb:365:9:365:9 | a [element 2] :  | array_flow.rb:365:9:367:7 | call to detect :  |
 | array_flow.rb:365:9:365:9 | a [element 2] :  | array_flow.rb:365:9:367:7 | call to detect :  |
 | array_flow.rb:365:9:365:9 | a [element 2] :  | array_flow.rb:365:43:365:43 | x :  |
 | array_flow.rb:365:9:365:9 | a [element 2] :  | array_flow.rb:365:43:365:43 | x :  |
-| array_flow.rb:365:9:367:7 | call to detect :  | array_flow.rb:368:10:368:10 | b |
-| array_flow.rb:365:9:367:7 | call to detect :  | array_flow.rb:368:10:368:10 | b |
+| array_flow.rb:365:9:367:7 | call to detect :  | array_flow.rb:365:5:365:5 | b :  |
+| array_flow.rb:365:9:367:7 | call to detect :  | array_flow.rb:365:5:365:5 | b :  |
 | array_flow.rb:365:23:365:34 | call to source :  | array_flow.rb:365:9:367:7 | call to detect :  |
 | array_flow.rb:365:23:365:34 | call to source :  | array_flow.rb:365:9:367:7 | call to detect :  |
 | array_flow.rb:365:43:365:43 | x :  | array_flow.rb:366:14:366:14 | x |
 | array_flow.rb:365:43:365:43 | x :  | array_flow.rb:366:14:366:14 | x |
-| array_flow.rb:372:16:372:27 | call to source :  | array_flow.rb:373:9:373:9 | a [element 2] :  |
-| array_flow.rb:372:16:372:27 | call to source :  | array_flow.rb:373:9:373:9 | a [element 2] :  |
-| array_flow.rb:372:16:372:27 | call to source :  | array_flow.rb:375:9:375:9 | a [element 2] :  |
-| array_flow.rb:372:16:372:27 | call to source :  | array_flow.rb:375:9:375:9 | a [element 2] :  |
-| array_flow.rb:372:16:372:27 | call to source :  | array_flow.rb:380:9:380:9 | a [element 2] :  |
-| array_flow.rb:372:16:372:27 | call to source :  | array_flow.rb:380:9:380:9 | a [element 2] :  |
-| array_flow.rb:372:30:372:41 | call to source :  | array_flow.rb:373:9:373:9 | a [element 3] :  |
-| array_flow.rb:372:30:372:41 | call to source :  | array_flow.rb:373:9:373:9 | a [element 3] :  |
-| array_flow.rb:372:30:372:41 | call to source :  | array_flow.rb:375:9:375:9 | a [element 3] :  |
-| array_flow.rb:372:30:372:41 | call to source :  | array_flow.rb:375:9:375:9 | a [element 3] :  |
+| array_flow.rb:372:5:372:5 | a [element 2] :  | array_flow.rb:373:9:373:9 | a [element 2] :  |
+| array_flow.rb:372:5:372:5 | a [element 2] :  | array_flow.rb:373:9:373:9 | a [element 2] :  |
+| array_flow.rb:372:5:372:5 | a [element 2] :  | array_flow.rb:375:9:375:9 | a [element 2] :  |
+| array_flow.rb:372:5:372:5 | a [element 2] :  | array_flow.rb:375:9:375:9 | a [element 2] :  |
+| array_flow.rb:372:5:372:5 | a [element 2] :  | array_flow.rb:380:9:380:9 | a [element 2] :  |
+| array_flow.rb:372:5:372:5 | a [element 2] :  | array_flow.rb:380:9:380:9 | a [element 2] :  |
+| array_flow.rb:372:5:372:5 | a [element 3] :  | array_flow.rb:373:9:373:9 | a [element 3] :  |
+| array_flow.rb:372:5:372:5 | a [element 3] :  | array_flow.rb:373:9:373:9 | a [element 3] :  |
+| array_flow.rb:372:5:372:5 | a [element 3] :  | array_flow.rb:375:9:375:9 | a [element 3] :  |
+| array_flow.rb:372:5:372:5 | a [element 3] :  | array_flow.rb:375:9:375:9 | a [element 3] :  |
+| array_flow.rb:372:16:372:27 | call to source :  | array_flow.rb:372:5:372:5 | a [element 2] :  |
+| array_flow.rb:372:16:372:27 | call to source :  | array_flow.rb:372:5:372:5 | a [element 2] :  |
+| array_flow.rb:372:30:372:41 | call to source :  | array_flow.rb:372:5:372:5 | a [element 3] :  |
+| array_flow.rb:372:30:372:41 | call to source :  | array_flow.rb:372:5:372:5 | a [element 3] :  |
+| array_flow.rb:373:5:373:5 | b [element] :  | array_flow.rb:374:10:374:10 | b [element] :  |
+| array_flow.rb:373:5:373:5 | b [element] :  | array_flow.rb:374:10:374:10 | b [element] :  |
 | array_flow.rb:373:9:373:9 | a [element 2] :  | array_flow.rb:373:9:373:17 | call to drop [element] :  |
 | array_flow.rb:373:9:373:9 | a [element 2] :  | array_flow.rb:373:9:373:17 | call to drop [element] :  |
 | array_flow.rb:373:9:373:9 | a [element 3] :  | array_flow.rb:373:9:373:17 | call to drop [element] :  |
 | array_flow.rb:373:9:373:9 | a [element 3] :  | array_flow.rb:373:9:373:17 | call to drop [element] :  |
-| array_flow.rb:373:9:373:17 | call to drop [element] :  | array_flow.rb:374:10:374:10 | b [element] :  |
-| array_flow.rb:373:9:373:17 | call to drop [element] :  | array_flow.rb:374:10:374:10 | b [element] :  |
+| array_flow.rb:373:9:373:17 | call to drop [element] :  | array_flow.rb:373:5:373:5 | b [element] :  |
+| array_flow.rb:373:9:373:17 | call to drop [element] :  | array_flow.rb:373:5:373:5 | b [element] :  |
 | array_flow.rb:374:10:374:10 | b [element] :  | array_flow.rb:374:10:374:13 | ...[...] |
 | array_flow.rb:374:10:374:10 | b [element] :  | array_flow.rb:374:10:374:13 | ...[...] |
+| array_flow.rb:375:5:375:5 | b [element 1] :  | array_flow.rb:377:10:377:10 | b [element 1] :  |
+| array_flow.rb:375:5:375:5 | b [element 1] :  | array_flow.rb:377:10:377:10 | b [element 1] :  |
+| array_flow.rb:375:5:375:5 | b [element 1] :  | array_flow.rb:378:10:378:10 | b [element 1] :  |
+| array_flow.rb:375:5:375:5 | b [element 1] :  | array_flow.rb:378:10:378:10 | b [element 1] :  |
+| array_flow.rb:375:5:375:5 | b [element 2] :  | array_flow.rb:378:10:378:10 | b [element 2] :  |
+| array_flow.rb:375:5:375:5 | b [element 2] :  | array_flow.rb:378:10:378:10 | b [element 2] :  |
 | array_flow.rb:375:9:375:9 | a [element 2] :  | array_flow.rb:375:9:375:17 | call to drop [element 1] :  |
 | array_flow.rb:375:9:375:9 | a [element 2] :  | array_flow.rb:375:9:375:17 | call to drop [element 1] :  |
 | array_flow.rb:375:9:375:9 | a [element 3] :  | array_flow.rb:375:9:375:17 | call to drop [element 2] :  |
 | array_flow.rb:375:9:375:9 | a [element 3] :  | array_flow.rb:375:9:375:17 | call to drop [element 2] :  |
-| array_flow.rb:375:9:375:17 | call to drop [element 1] :  | array_flow.rb:377:10:377:10 | b [element 1] :  |
-| array_flow.rb:375:9:375:17 | call to drop [element 1] :  | array_flow.rb:377:10:377:10 | b [element 1] :  |
-| array_flow.rb:375:9:375:17 | call to drop [element 1] :  | array_flow.rb:378:10:378:10 | b [element 1] :  |
-| array_flow.rb:375:9:375:17 | call to drop [element 1] :  | array_flow.rb:378:10:378:10 | b [element 1] :  |
-| array_flow.rb:375:9:375:17 | call to drop [element 2] :  | array_flow.rb:378:10:378:10 | b [element 2] :  |
-| array_flow.rb:375:9:375:17 | call to drop [element 2] :  | array_flow.rb:378:10:378:10 | b [element 2] :  |
+| array_flow.rb:375:9:375:17 | call to drop [element 1] :  | array_flow.rb:375:5:375:5 | b [element 1] :  |
+| array_flow.rb:375:9:375:17 | call to drop [element 1] :  | array_flow.rb:375:5:375:5 | b [element 1] :  |
+| array_flow.rb:375:9:375:17 | call to drop [element 2] :  | array_flow.rb:375:5:375:5 | b [element 2] :  |
+| array_flow.rb:375:9:375:17 | call to drop [element 2] :  | array_flow.rb:375:5:375:5 | b [element 2] :  |
 | array_flow.rb:377:10:377:10 | b [element 1] :  | array_flow.rb:377:10:377:13 | ...[...] |
 | array_flow.rb:377:10:377:10 | b [element 1] :  | array_flow.rb:377:10:377:13 | ...[...] |
 | array_flow.rb:378:10:378:10 | b [element 1] :  | array_flow.rb:378:10:378:13 | ...[...] |
@@ -658,30 +835,42 @@ edges
 | array_flow.rb:379:5:379:5 | [post] a [element] :  | array_flow.rb:380:9:380:9 | a [element] :  |
 | array_flow.rb:379:12:379:23 | call to source :  | array_flow.rb:379:5:379:5 | [post] a [element] :  |
 | array_flow.rb:379:12:379:23 | call to source :  | array_flow.rb:379:5:379:5 | [post] a [element] :  |
+| array_flow.rb:380:5:380:5 | b [element 1] :  | array_flow.rb:381:10:381:10 | b [element 1] :  |
+| array_flow.rb:380:5:380:5 | b [element 1] :  | array_flow.rb:381:10:381:10 | b [element 1] :  |
+| array_flow.rb:380:5:380:5 | b [element] :  | array_flow.rb:381:10:381:10 | b [element] :  |
+| array_flow.rb:380:5:380:5 | b [element] :  | array_flow.rb:381:10:381:10 | b [element] :  |
+| array_flow.rb:380:5:380:5 | b [element] :  | array_flow.rb:382:9:382:9 | b [element] :  |
+| array_flow.rb:380:5:380:5 | b [element] :  | array_flow.rb:382:9:382:9 | b [element] :  |
 | array_flow.rb:380:9:380:9 | a [element 2] :  | array_flow.rb:380:9:380:17 | call to drop [element 1] :  |
 | array_flow.rb:380:9:380:9 | a [element 2] :  | array_flow.rb:380:9:380:17 | call to drop [element 1] :  |
 | array_flow.rb:380:9:380:9 | a [element] :  | array_flow.rb:380:9:380:17 | call to drop [element] :  |
 | array_flow.rb:380:9:380:9 | a [element] :  | array_flow.rb:380:9:380:17 | call to drop [element] :  |
-| array_flow.rb:380:9:380:17 | call to drop [element 1] :  | array_flow.rb:381:10:381:10 | b [element 1] :  |
-| array_flow.rb:380:9:380:17 | call to drop [element 1] :  | array_flow.rb:381:10:381:10 | b [element 1] :  |
-| array_flow.rb:380:9:380:17 | call to drop [element] :  | array_flow.rb:381:10:381:10 | b [element] :  |
-| array_flow.rb:380:9:380:17 | call to drop [element] :  | array_flow.rb:381:10:381:10 | b [element] :  |
-| array_flow.rb:380:9:380:17 | call to drop [element] :  | array_flow.rb:382:9:382:9 | b [element] :  |
-| array_flow.rb:380:9:380:17 | call to drop [element] :  | array_flow.rb:382:9:382:9 | b [element] :  |
+| array_flow.rb:380:9:380:17 | call to drop [element 1] :  | array_flow.rb:380:5:380:5 | b [element 1] :  |
+| array_flow.rb:380:9:380:17 | call to drop [element 1] :  | array_flow.rb:380:5:380:5 | b [element 1] :  |
+| array_flow.rb:380:9:380:17 | call to drop [element] :  | array_flow.rb:380:5:380:5 | b [element] :  |
+| array_flow.rb:380:9:380:17 | call to drop [element] :  | array_flow.rb:380:5:380:5 | b [element] :  |
 | array_flow.rb:381:10:381:10 | b [element 1] :  | array_flow.rb:381:10:381:13 | ...[...] |
 | array_flow.rb:381:10:381:10 | b [element 1] :  | array_flow.rb:381:10:381:13 | ...[...] |
 | array_flow.rb:381:10:381:10 | b [element] :  | array_flow.rb:381:10:381:13 | ...[...] |
 | array_flow.rb:381:10:381:10 | b [element] :  | array_flow.rb:381:10:381:13 | ...[...] |
+| array_flow.rb:382:5:382:5 | c [element] :  | array_flow.rb:383:10:383:10 | c [element] :  |
+| array_flow.rb:382:5:382:5 | c [element] :  | array_flow.rb:383:10:383:10 | c [element] :  |
 | array_flow.rb:382:9:382:9 | b [element] :  | array_flow.rb:382:9:382:19 | call to drop [element] :  |
 | array_flow.rb:382:9:382:9 | b [element] :  | array_flow.rb:382:9:382:19 | call to drop [element] :  |
-| array_flow.rb:382:9:382:19 | call to drop [element] :  | array_flow.rb:383:10:383:10 | c [element] :  |
-| array_flow.rb:382:9:382:19 | call to drop [element] :  | array_flow.rb:383:10:383:10 | c [element] :  |
+| array_flow.rb:382:9:382:19 | call to drop [element] :  | array_flow.rb:382:5:382:5 | c [element] :  |
+| array_flow.rb:382:9:382:19 | call to drop [element] :  | array_flow.rb:382:5:382:5 | c [element] :  |
 | array_flow.rb:383:10:383:10 | c [element] :  | array_flow.rb:383:10:383:13 | ...[...] |
 | array_flow.rb:383:10:383:10 | c [element] :  | array_flow.rb:383:10:383:13 | ...[...] |
-| array_flow.rb:387:16:387:27 | call to source :  | array_flow.rb:388:9:388:9 | a [element 2] :  |
-| array_flow.rb:387:16:387:27 | call to source :  | array_flow.rb:388:9:388:9 | a [element 2] :  |
-| array_flow.rb:387:30:387:41 | call to source :  | array_flow.rb:388:9:388:9 | a [element 3] :  |
-| array_flow.rb:387:30:387:41 | call to source :  | array_flow.rb:388:9:388:9 | a [element 3] :  |
+| array_flow.rb:387:5:387:5 | a [element 2] :  | array_flow.rb:388:9:388:9 | a [element 2] :  |
+| array_flow.rb:387:5:387:5 | a [element 2] :  | array_flow.rb:388:9:388:9 | a [element 2] :  |
+| array_flow.rb:387:5:387:5 | a [element 3] :  | array_flow.rb:388:9:388:9 | a [element 3] :  |
+| array_flow.rb:387:5:387:5 | a [element 3] :  | array_flow.rb:388:9:388:9 | a [element 3] :  |
+| array_flow.rb:387:16:387:27 | call to source :  | array_flow.rb:387:5:387:5 | a [element 2] :  |
+| array_flow.rb:387:16:387:27 | call to source :  | array_flow.rb:387:5:387:5 | a [element 2] :  |
+| array_flow.rb:387:30:387:41 | call to source :  | array_flow.rb:387:5:387:5 | a [element 3] :  |
+| array_flow.rb:387:30:387:41 | call to source :  | array_flow.rb:387:5:387:5 | a [element 3] :  |
+| array_flow.rb:388:5:388:5 | b [element] :  | array_flow.rb:391:10:391:10 | b [element] :  |
+| array_flow.rb:388:5:388:5 | b [element] :  | array_flow.rb:391:10:391:10 | b [element] :  |
 | array_flow.rb:388:9:388:9 | a [element 2] :  | array_flow.rb:388:9:390:7 | call to drop_while [element] :  |
 | array_flow.rb:388:9:388:9 | a [element 2] :  | array_flow.rb:388:9:390:7 | call to drop_while [element] :  |
 | array_flow.rb:388:9:388:9 | a [element 2] :  | array_flow.rb:388:26:388:26 | x :  |
@@ -690,40 +879,50 @@ edges
 | array_flow.rb:388:9:388:9 | a [element 3] :  | array_flow.rb:388:9:390:7 | call to drop_while [element] :  |
 | array_flow.rb:388:9:388:9 | a [element 3] :  | array_flow.rb:388:26:388:26 | x :  |
 | array_flow.rb:388:9:388:9 | a [element 3] :  | array_flow.rb:388:26:388:26 | x :  |
-| array_flow.rb:388:9:390:7 | call to drop_while [element] :  | array_flow.rb:391:10:391:10 | b [element] :  |
-| array_flow.rb:388:9:390:7 | call to drop_while [element] :  | array_flow.rb:391:10:391:10 | b [element] :  |
+| array_flow.rb:388:9:390:7 | call to drop_while [element] :  | array_flow.rb:388:5:388:5 | b [element] :  |
+| array_flow.rb:388:9:390:7 | call to drop_while [element] :  | array_flow.rb:388:5:388:5 | b [element] :  |
 | array_flow.rb:388:26:388:26 | x :  | array_flow.rb:389:14:389:14 | x |
 | array_flow.rb:388:26:388:26 | x :  | array_flow.rb:389:14:389:14 | x |
 | array_flow.rb:391:10:391:10 | b [element] :  | array_flow.rb:391:10:391:13 | ...[...] |
 | array_flow.rb:391:10:391:10 | b [element] :  | array_flow.rb:391:10:391:13 | ...[...] |
-| array_flow.rb:395:16:395:25 | call to source :  | array_flow.rb:396:9:396:9 | a [element 2] :  |
-| array_flow.rb:395:16:395:25 | call to source :  | array_flow.rb:396:9:396:9 | a [element 2] :  |
+| array_flow.rb:395:5:395:5 | a [element 2] :  | array_flow.rb:396:9:396:9 | a [element 2] :  |
+| array_flow.rb:395:5:395:5 | a [element 2] :  | array_flow.rb:396:9:396:9 | a [element 2] :  |
+| array_flow.rb:395:16:395:25 | call to source :  | array_flow.rb:395:5:395:5 | a [element 2] :  |
+| array_flow.rb:395:16:395:25 | call to source :  | array_flow.rb:395:5:395:5 | a [element 2] :  |
+| array_flow.rb:396:5:396:5 | b [element 2] :  | array_flow.rb:399:10:399:10 | b [element 2] :  |
+| array_flow.rb:396:5:396:5 | b [element 2] :  | array_flow.rb:399:10:399:10 | b [element 2] :  |
 | array_flow.rb:396:9:396:9 | a [element 2] :  | array_flow.rb:396:9:398:7 | call to each [element 2] :  |
 | array_flow.rb:396:9:396:9 | a [element 2] :  | array_flow.rb:396:9:398:7 | call to each [element 2] :  |
 | array_flow.rb:396:9:396:9 | a [element 2] :  | array_flow.rb:396:20:396:20 | x :  |
 | array_flow.rb:396:9:396:9 | a [element 2] :  | array_flow.rb:396:20:396:20 | x :  |
-| array_flow.rb:396:9:398:7 | call to each [element 2] :  | array_flow.rb:399:10:399:10 | b [element 2] :  |
-| array_flow.rb:396:9:398:7 | call to each [element 2] :  | array_flow.rb:399:10:399:10 | b [element 2] :  |
+| array_flow.rb:396:9:398:7 | call to each [element 2] :  | array_flow.rb:396:5:396:5 | b [element 2] :  |
+| array_flow.rb:396:9:398:7 | call to each [element 2] :  | array_flow.rb:396:5:396:5 | b [element 2] :  |
 | array_flow.rb:396:20:396:20 | x :  | array_flow.rb:397:14:397:14 | x |
 | array_flow.rb:396:20:396:20 | x :  | array_flow.rb:397:14:397:14 | x |
 | array_flow.rb:399:10:399:10 | b [element 2] :  | array_flow.rb:399:10:399:13 | ...[...] |
 | array_flow.rb:399:10:399:10 | b [element 2] :  | array_flow.rb:399:10:399:13 | ...[...] |
-| array_flow.rb:403:16:403:25 | call to source :  | array_flow.rb:404:18:404:18 | a [element 2] :  |
-| array_flow.rb:403:16:403:25 | call to source :  | array_flow.rb:404:18:404:18 | a [element 2] :  |
-| array_flow.rb:404:9:406:7 | ... = ... :  | array_flow.rb:407:10:407:10 | x |
-| array_flow.rb:404:9:406:7 | ... = ... :  | array_flow.rb:407:10:407:10 | x |
-| array_flow.rb:404:9:406:7 | __synth__0__1 :  | array_flow.rb:404:9:406:7 | ... = ... :  |
-| array_flow.rb:404:9:406:7 | __synth__0__1 :  | array_flow.rb:404:9:406:7 | ... = ... :  |
-| array_flow.rb:404:9:406:7 | __synth__0__1 :  | array_flow.rb:405:14:405:14 | x |
-| array_flow.rb:404:9:406:7 | __synth__0__1 :  | array_flow.rb:405:14:405:14 | x |
+| array_flow.rb:403:5:403:5 | a [element 2] :  | array_flow.rb:404:18:404:18 | a [element 2] :  |
+| array_flow.rb:403:5:403:5 | a [element 2] :  | array_flow.rb:404:18:404:18 | a [element 2] :  |
+| array_flow.rb:403:16:403:25 | call to source :  | array_flow.rb:403:5:403:5 | a [element 2] :  |
+| array_flow.rb:403:16:403:25 | call to source :  | array_flow.rb:403:5:403:5 | a [element 2] :  |
+| array_flow.rb:404:5:404:5 | b [element 2] :  | array_flow.rb:408:10:408:10 | b [element 2] :  |
+| array_flow.rb:404:5:404:5 | b [element 2] :  | array_flow.rb:408:10:408:10 | b [element 2] :  |
+| array_flow.rb:404:9:406:7 | __synth__0__1 :  | array_flow.rb:404:13:404:13 | x :  |
+| array_flow.rb:404:9:406:7 | __synth__0__1 :  | array_flow.rb:404:13:404:13 | x :  |
+| array_flow.rb:404:13:404:13 | x :  | array_flow.rb:405:14:405:14 | x |
+| array_flow.rb:404:13:404:13 | x :  | array_flow.rb:405:14:405:14 | x |
+| array_flow.rb:404:13:404:13 | x :  | array_flow.rb:407:10:407:10 | x |
+| array_flow.rb:404:13:404:13 | x :  | array_flow.rb:407:10:407:10 | x |
+| array_flow.rb:404:18:404:18 | a [element 2] :  | array_flow.rb:404:5:404:5 | b [element 2] :  |
+| array_flow.rb:404:18:404:18 | a [element 2] :  | array_flow.rb:404:5:404:5 | b [element 2] :  |
 | array_flow.rb:404:18:404:18 | a [element 2] :  | array_flow.rb:404:9:406:7 | __synth__0__1 :  |
 | array_flow.rb:404:18:404:18 | a [element 2] :  | array_flow.rb:404:9:406:7 | __synth__0__1 :  |
-| array_flow.rb:404:18:404:18 | a [element 2] :  | array_flow.rb:408:10:408:10 | b [element 2] :  |
-| array_flow.rb:404:18:404:18 | a [element 2] :  | array_flow.rb:408:10:408:10 | b [element 2] :  |
 | array_flow.rb:408:10:408:10 | b [element 2] :  | array_flow.rb:408:10:408:13 | ...[...] |
 | array_flow.rb:408:10:408:10 | b [element 2] :  | array_flow.rb:408:10:408:13 | ...[...] |
-| array_flow.rb:412:16:412:25 | call to source :  | array_flow.rb:413:5:413:5 | a [element 2] :  |
-| array_flow.rb:412:16:412:25 | call to source :  | array_flow.rb:413:5:413:5 | a [element 2] :  |
+| array_flow.rb:412:5:412:5 | a [element 2] :  | array_flow.rb:413:5:413:5 | a [element 2] :  |
+| array_flow.rb:412:5:412:5 | a [element 2] :  | array_flow.rb:413:5:413:5 | a [element 2] :  |
+| array_flow.rb:412:16:412:25 | call to source :  | array_flow.rb:412:5:412:5 | a [element 2] :  |
+| array_flow.rb:412:16:412:25 | call to source :  | array_flow.rb:412:5:412:5 | a [element 2] :  |
 | array_flow.rb:413:5:413:5 | a [element 2] :  | array_flow.rb:413:24:413:24 | x [element] :  |
 | array_flow.rb:413:5:413:5 | a [element 2] :  | array_flow.rb:413:24:413:24 | x [element] :  |
 | array_flow.rb:413:24:413:24 | x [element] :  | array_flow.rb:414:15:414:15 | x [element] :  |
@@ -732,52 +931,70 @@ edges
 | array_flow.rb:414:15:414:15 | x [element] :  | array_flow.rb:414:15:414:18 | ...[...] :  |
 | array_flow.rb:414:15:414:18 | ...[...] :  | array_flow.rb:414:14:414:19 | ( ... ) |
 | array_flow.rb:414:15:414:18 | ...[...] :  | array_flow.rb:414:14:414:19 | ( ... ) |
-| array_flow.rb:419:16:419:25 | call to source :  | array_flow.rb:420:9:420:9 | a [element 2] :  |
-| array_flow.rb:419:16:419:25 | call to source :  | array_flow.rb:420:9:420:9 | a [element 2] :  |
+| array_flow.rb:419:5:419:5 | a [element 2] :  | array_flow.rb:420:9:420:9 | a [element 2] :  |
+| array_flow.rb:419:5:419:5 | a [element 2] :  | array_flow.rb:420:9:420:9 | a [element 2] :  |
+| array_flow.rb:419:16:419:25 | call to source :  | array_flow.rb:419:5:419:5 | a [element 2] :  |
+| array_flow.rb:419:16:419:25 | call to source :  | array_flow.rb:419:5:419:5 | a [element 2] :  |
+| array_flow.rb:420:5:420:5 | b [element 2] :  | array_flow.rb:423:10:423:10 | b [element 2] :  |
+| array_flow.rb:420:5:420:5 | b [element 2] :  | array_flow.rb:423:10:423:10 | b [element 2] :  |
 | array_flow.rb:420:9:420:9 | a [element 2] :  | array_flow.rb:420:9:422:7 | call to each_entry [element 2] :  |
 | array_flow.rb:420:9:420:9 | a [element 2] :  | array_flow.rb:420:9:422:7 | call to each_entry [element 2] :  |
 | array_flow.rb:420:9:420:9 | a [element 2] :  | array_flow.rb:420:26:420:26 | x :  |
 | array_flow.rb:420:9:420:9 | a [element 2] :  | array_flow.rb:420:26:420:26 | x :  |
-| array_flow.rb:420:9:422:7 | call to each_entry [element 2] :  | array_flow.rb:423:10:423:10 | b [element 2] :  |
-| array_flow.rb:420:9:422:7 | call to each_entry [element 2] :  | array_flow.rb:423:10:423:10 | b [element 2] :  |
+| array_flow.rb:420:9:422:7 | call to each_entry [element 2] :  | array_flow.rb:420:5:420:5 | b [element 2] :  |
+| array_flow.rb:420:9:422:7 | call to each_entry [element 2] :  | array_flow.rb:420:5:420:5 | b [element 2] :  |
 | array_flow.rb:420:26:420:26 | x :  | array_flow.rb:421:14:421:14 | x |
 | array_flow.rb:420:26:420:26 | x :  | array_flow.rb:421:14:421:14 | x |
 | array_flow.rb:423:10:423:10 | b [element 2] :  | array_flow.rb:423:10:423:13 | ...[...] |
 | array_flow.rb:423:10:423:10 | b [element 2] :  | array_flow.rb:423:10:423:13 | ...[...] |
-| array_flow.rb:427:16:427:25 | call to source :  | array_flow.rb:428:9:428:9 | a [element 2] :  |
-| array_flow.rb:427:16:427:25 | call to source :  | array_flow.rb:428:9:428:9 | a [element 2] :  |
+| array_flow.rb:427:5:427:5 | a [element 2] :  | array_flow.rb:428:9:428:9 | a [element 2] :  |
+| array_flow.rb:427:5:427:5 | a [element 2] :  | array_flow.rb:428:9:428:9 | a [element 2] :  |
+| array_flow.rb:427:16:427:25 | call to source :  | array_flow.rb:427:5:427:5 | a [element 2] :  |
+| array_flow.rb:427:16:427:25 | call to source :  | array_flow.rb:427:5:427:5 | a [element 2] :  |
+| array_flow.rb:428:5:428:5 | b [element 2] :  | array_flow.rb:431:10:431:10 | b [element 2] :  |
+| array_flow.rb:428:5:428:5 | b [element 2] :  | array_flow.rb:431:10:431:10 | b [element 2] :  |
 | array_flow.rb:428:9:428:9 | a [element 2] :  | array_flow.rb:428:9:430:7 | call to each_index [element 2] :  |
 | array_flow.rb:428:9:428:9 | a [element 2] :  | array_flow.rb:428:9:430:7 | call to each_index [element 2] :  |
-| array_flow.rb:428:9:430:7 | call to each_index [element 2] :  | array_flow.rb:431:10:431:10 | b [element 2] :  |
-| array_flow.rb:428:9:430:7 | call to each_index [element 2] :  | array_flow.rb:431:10:431:10 | b [element 2] :  |
+| array_flow.rb:428:9:430:7 | call to each_index [element 2] :  | array_flow.rb:428:5:428:5 | b [element 2] :  |
+| array_flow.rb:428:9:430:7 | call to each_index [element 2] :  | array_flow.rb:428:5:428:5 | b [element 2] :  |
 | array_flow.rb:431:10:431:10 | b [element 2] :  | array_flow.rb:431:10:431:13 | ...[...] |
 | array_flow.rb:431:10:431:10 | b [element 2] :  | array_flow.rb:431:10:431:13 | ...[...] |
-| array_flow.rb:435:19:435:28 | call to source :  | array_flow.rb:436:5:436:5 | a [element 3] :  |
-| array_flow.rb:435:19:435:28 | call to source :  | array_flow.rb:436:5:436:5 | a [element 3] :  |
+| array_flow.rb:435:5:435:5 | a [element 3] :  | array_flow.rb:436:5:436:5 | a [element 3] :  |
+| array_flow.rb:435:5:435:5 | a [element 3] :  | array_flow.rb:436:5:436:5 | a [element 3] :  |
+| array_flow.rb:435:19:435:28 | call to source :  | array_flow.rb:435:5:435:5 | a [element 3] :  |
+| array_flow.rb:435:19:435:28 | call to source :  | array_flow.rb:435:5:435:5 | a [element 3] :  |
 | array_flow.rb:436:5:436:5 | a [element 3] :  | array_flow.rb:436:25:436:25 | x [element] :  |
 | array_flow.rb:436:5:436:5 | a [element 3] :  | array_flow.rb:436:25:436:25 | x [element] :  |
 | array_flow.rb:436:25:436:25 | x [element] :  | array_flow.rb:437:14:437:14 | x [element] :  |
 | array_flow.rb:436:25:436:25 | x [element] :  | array_flow.rb:437:14:437:14 | x [element] :  |
 | array_flow.rb:437:14:437:14 | x [element] :  | array_flow.rb:437:14:437:17 | ...[...] |
 | array_flow.rb:437:14:437:14 | x [element] :  | array_flow.rb:437:14:437:17 | ...[...] |
-| array_flow.rb:442:19:442:28 | call to source :  | array_flow.rb:443:9:443:9 | a [element 3] :  |
-| array_flow.rb:442:19:442:28 | call to source :  | array_flow.rb:443:9:443:9 | a [element 3] :  |
+| array_flow.rb:442:5:442:5 | a [element 3] :  | array_flow.rb:443:9:443:9 | a [element 3] :  |
+| array_flow.rb:442:5:442:5 | a [element 3] :  | array_flow.rb:443:9:443:9 | a [element 3] :  |
+| array_flow.rb:442:19:442:28 | call to source :  | array_flow.rb:442:5:442:5 | a [element 3] :  |
+| array_flow.rb:442:19:442:28 | call to source :  | array_flow.rb:442:5:442:5 | a [element 3] :  |
+| array_flow.rb:443:5:443:5 | b [element 3] :  | array_flow.rb:447:10:447:10 | b [element 3] :  |
+| array_flow.rb:443:5:443:5 | b [element 3] :  | array_flow.rb:447:10:447:10 | b [element 3] :  |
 | array_flow.rb:443:9:443:9 | a [element 3] :  | array_flow.rb:443:9:446:7 | call to each_with_index [element 3] :  |
 | array_flow.rb:443:9:443:9 | a [element 3] :  | array_flow.rb:443:9:446:7 | call to each_with_index [element 3] :  |
 | array_flow.rb:443:9:443:9 | a [element 3] :  | array_flow.rb:443:31:443:31 | x :  |
 | array_flow.rb:443:9:443:9 | a [element 3] :  | array_flow.rb:443:31:443:31 | x :  |
-| array_flow.rb:443:9:446:7 | call to each_with_index [element 3] :  | array_flow.rb:447:10:447:10 | b [element 3] :  |
-| array_flow.rb:443:9:446:7 | call to each_with_index [element 3] :  | array_flow.rb:447:10:447:10 | b [element 3] :  |
+| array_flow.rb:443:9:446:7 | call to each_with_index [element 3] :  | array_flow.rb:443:5:443:5 | b [element 3] :  |
+| array_flow.rb:443:9:446:7 | call to each_with_index [element 3] :  | array_flow.rb:443:5:443:5 | b [element 3] :  |
 | array_flow.rb:443:31:443:31 | x :  | array_flow.rb:444:14:444:14 | x |
 | array_flow.rb:443:31:443:31 | x :  | array_flow.rb:444:14:444:14 | x |
 | array_flow.rb:447:10:447:10 | b [element 3] :  | array_flow.rb:447:10:447:13 | ...[...] |
 | array_flow.rb:447:10:447:10 | b [element 3] :  | array_flow.rb:447:10:447:13 | ...[...] |
-| array_flow.rb:451:19:451:30 | call to source :  | array_flow.rb:452:9:452:9 | a [element 3] :  |
-| array_flow.rb:451:19:451:30 | call to source :  | array_flow.rb:452:9:452:9 | a [element 3] :  |
+| array_flow.rb:451:5:451:5 | a [element 3] :  | array_flow.rb:452:9:452:9 | a [element 3] :  |
+| array_flow.rb:451:5:451:5 | a [element 3] :  | array_flow.rb:452:9:452:9 | a [element 3] :  |
+| array_flow.rb:451:19:451:30 | call to source :  | array_flow.rb:451:5:451:5 | a [element 3] :  |
+| array_flow.rb:451:19:451:30 | call to source :  | array_flow.rb:451:5:451:5 | a [element 3] :  |
+| array_flow.rb:452:5:452:5 | b :  | array_flow.rb:456:10:456:10 | b |
+| array_flow.rb:452:5:452:5 | b :  | array_flow.rb:456:10:456:10 | b |
 | array_flow.rb:452:9:452:9 | a [element 3] :  | array_flow.rb:452:46:452:46 | x :  |
 | array_flow.rb:452:9:452:9 | a [element 3] :  | array_flow.rb:452:46:452:46 | x :  |
-| array_flow.rb:452:9:455:7 | call to each_with_object :  | array_flow.rb:456:10:456:10 | b |
-| array_flow.rb:452:9:455:7 | call to each_with_object :  | array_flow.rb:456:10:456:10 | b |
+| array_flow.rb:452:9:455:7 | call to each_with_object :  | array_flow.rb:452:5:452:5 | b :  |
+| array_flow.rb:452:9:455:7 | call to each_with_object :  | array_flow.rb:452:5:452:5 | b :  |
 | array_flow.rb:452:28:452:39 | call to source :  | array_flow.rb:452:9:455:7 | call to each_with_object :  |
 | array_flow.rb:452:28:452:39 | call to source :  | array_flow.rb:452:9:455:7 | call to each_with_object :  |
 | array_flow.rb:452:28:452:39 | call to source :  | array_flow.rb:452:48:452:48 | a :  |
@@ -786,60 +1003,80 @@ edges
 | array_flow.rb:452:46:452:46 | x :  | array_flow.rb:453:14:453:14 | x |
 | array_flow.rb:452:48:452:48 | a :  | array_flow.rb:454:14:454:14 | a |
 | array_flow.rb:452:48:452:48 | a :  | array_flow.rb:454:14:454:14 | a |
-| array_flow.rb:460:19:460:28 | call to source :  | array_flow.rb:461:9:461:9 | a [element 3] :  |
-| array_flow.rb:460:19:460:28 | call to source :  | array_flow.rb:461:9:461:9 | a [element 3] :  |
+| array_flow.rb:460:5:460:5 | a [element 3] :  | array_flow.rb:461:9:461:9 | a [element 3] :  |
+| array_flow.rb:460:5:460:5 | a [element 3] :  | array_flow.rb:461:9:461:9 | a [element 3] :  |
+| array_flow.rb:460:19:460:28 | call to source :  | array_flow.rb:460:5:460:5 | a [element 3] :  |
+| array_flow.rb:460:19:460:28 | call to source :  | array_flow.rb:460:5:460:5 | a [element 3] :  |
+| array_flow.rb:461:5:461:5 | b [element 3] :  | array_flow.rb:462:10:462:10 | b [element 3] :  |
+| array_flow.rb:461:5:461:5 | b [element 3] :  | array_flow.rb:462:10:462:10 | b [element 3] :  |
 | array_flow.rb:461:9:461:9 | a [element 3] :  | array_flow.rb:461:9:461:17 | call to entries [element 3] :  |
 | array_flow.rb:461:9:461:9 | a [element 3] :  | array_flow.rb:461:9:461:17 | call to entries [element 3] :  |
-| array_flow.rb:461:9:461:17 | call to entries [element 3] :  | array_flow.rb:462:10:462:10 | b [element 3] :  |
-| array_flow.rb:461:9:461:17 | call to entries [element 3] :  | array_flow.rb:462:10:462:10 | b [element 3] :  |
+| array_flow.rb:461:9:461:17 | call to entries [element 3] :  | array_flow.rb:461:5:461:5 | b [element 3] :  |
+| array_flow.rb:461:9:461:17 | call to entries [element 3] :  | array_flow.rb:461:5:461:5 | b [element 3] :  |
 | array_flow.rb:462:10:462:10 | b [element 3] :  | array_flow.rb:462:10:462:13 | ...[...] |
 | array_flow.rb:462:10:462:10 | b [element 3] :  | array_flow.rb:462:10:462:13 | ...[...] |
-| array_flow.rb:466:19:466:30 | call to source :  | array_flow.rb:467:9:467:9 | a [element 3] :  |
-| array_flow.rb:466:19:466:30 | call to source :  | array_flow.rb:467:9:467:9 | a [element 3] :  |
-| array_flow.rb:466:19:466:30 | call to source :  | array_flow.rb:471:9:471:9 | a [element 3] :  |
-| array_flow.rb:466:19:466:30 | call to source :  | array_flow.rb:471:9:471:9 | a [element 3] :  |
-| array_flow.rb:466:19:466:30 | call to source :  | array_flow.rb:473:9:473:9 | a [element 3] :  |
-| array_flow.rb:466:19:466:30 | call to source :  | array_flow.rb:473:9:473:9 | a [element 3] :  |
-| array_flow.rb:466:19:466:30 | call to source :  | array_flow.rb:477:9:477:9 | a [element 3] :  |
-| array_flow.rb:466:19:466:30 | call to source :  | array_flow.rb:477:9:477:9 | a [element 3] :  |
-| array_flow.rb:466:33:466:44 | call to source :  | array_flow.rb:467:9:467:9 | a [element 4] :  |
-| array_flow.rb:466:33:466:44 | call to source :  | array_flow.rb:467:9:467:9 | a [element 4] :  |
-| array_flow.rb:466:33:466:44 | call to source :  | array_flow.rb:477:9:477:9 | a [element 4] :  |
-| array_flow.rb:466:33:466:44 | call to source :  | array_flow.rb:477:9:477:9 | a [element 4] :  |
+| array_flow.rb:466:5:466:5 | a [element 3] :  | array_flow.rb:467:9:467:9 | a [element 3] :  |
+| array_flow.rb:466:5:466:5 | a [element 3] :  | array_flow.rb:467:9:467:9 | a [element 3] :  |
+| array_flow.rb:466:5:466:5 | a [element 3] :  | array_flow.rb:471:9:471:9 | a [element 3] :  |
+| array_flow.rb:466:5:466:5 | a [element 3] :  | array_flow.rb:471:9:471:9 | a [element 3] :  |
+| array_flow.rb:466:5:466:5 | a [element 3] :  | array_flow.rb:473:9:473:9 | a [element 3] :  |
+| array_flow.rb:466:5:466:5 | a [element 3] :  | array_flow.rb:473:9:473:9 | a [element 3] :  |
+| array_flow.rb:466:5:466:5 | a [element 3] :  | array_flow.rb:477:9:477:9 | a [element 3] :  |
+| array_flow.rb:466:5:466:5 | a [element 3] :  | array_flow.rb:477:9:477:9 | a [element 3] :  |
+| array_flow.rb:466:5:466:5 | a [element 4] :  | array_flow.rb:467:9:467:9 | a [element 4] :  |
+| array_flow.rb:466:5:466:5 | a [element 4] :  | array_flow.rb:467:9:467:9 | a [element 4] :  |
+| array_flow.rb:466:5:466:5 | a [element 4] :  | array_flow.rb:477:9:477:9 | a [element 4] :  |
+| array_flow.rb:466:5:466:5 | a [element 4] :  | array_flow.rb:477:9:477:9 | a [element 4] :  |
+| array_flow.rb:466:19:466:30 | call to source :  | array_flow.rb:466:5:466:5 | a [element 3] :  |
+| array_flow.rb:466:19:466:30 | call to source :  | array_flow.rb:466:5:466:5 | a [element 3] :  |
+| array_flow.rb:466:33:466:44 | call to source :  | array_flow.rb:466:5:466:5 | a [element 4] :  |
+| array_flow.rb:466:33:466:44 | call to source :  | array_flow.rb:466:5:466:5 | a [element 4] :  |
+| array_flow.rb:467:5:467:5 | b :  | array_flow.rb:470:10:470:10 | b |
+| array_flow.rb:467:5:467:5 | b :  | array_flow.rb:470:10:470:10 | b |
 | array_flow.rb:467:9:467:9 | a [element 3] :  | array_flow.rb:467:9:469:7 | call to fetch :  |
 | array_flow.rb:467:9:467:9 | a [element 3] :  | array_flow.rb:467:9:469:7 | call to fetch :  |
 | array_flow.rb:467:9:467:9 | a [element 4] :  | array_flow.rb:467:9:469:7 | call to fetch :  |
 | array_flow.rb:467:9:467:9 | a [element 4] :  | array_flow.rb:467:9:469:7 | call to fetch :  |
-| array_flow.rb:467:9:469:7 | call to fetch :  | array_flow.rb:470:10:470:10 | b |
-| array_flow.rb:467:9:469:7 | call to fetch :  | array_flow.rb:470:10:470:10 | b |
+| array_flow.rb:467:9:469:7 | call to fetch :  | array_flow.rb:467:5:467:5 | b :  |
+| array_flow.rb:467:9:469:7 | call to fetch :  | array_flow.rb:467:5:467:5 | b :  |
 | array_flow.rb:467:17:467:28 | call to source :  | array_flow.rb:467:35:467:35 | x :  |
 | array_flow.rb:467:17:467:28 | call to source :  | array_flow.rb:467:35:467:35 | x :  |
 | array_flow.rb:467:35:467:35 | x :  | array_flow.rb:468:14:468:14 | x |
 | array_flow.rb:467:35:467:35 | x :  | array_flow.rb:468:14:468:14 | x |
+| array_flow.rb:471:5:471:5 | b :  | array_flow.rb:472:10:472:10 | b |
+| array_flow.rb:471:5:471:5 | b :  | array_flow.rb:472:10:472:10 | b |
 | array_flow.rb:471:9:471:9 | a [element 3] :  | array_flow.rb:471:9:471:18 | call to fetch :  |
 | array_flow.rb:471:9:471:9 | a [element 3] :  | array_flow.rb:471:9:471:18 | call to fetch :  |
-| array_flow.rb:471:9:471:18 | call to fetch :  | array_flow.rb:472:10:472:10 | b |
-| array_flow.rb:471:9:471:18 | call to fetch :  | array_flow.rb:472:10:472:10 | b |
+| array_flow.rb:471:9:471:18 | call to fetch :  | array_flow.rb:471:5:471:5 | b :  |
+| array_flow.rb:471:9:471:18 | call to fetch :  | array_flow.rb:471:5:471:5 | b :  |
+| array_flow.rb:473:5:473:5 | b :  | array_flow.rb:474:10:474:10 | b |
+| array_flow.rb:473:5:473:5 | b :  | array_flow.rb:474:10:474:10 | b |
 | array_flow.rb:473:9:473:9 | a [element 3] :  | array_flow.rb:473:9:473:32 | call to fetch :  |
 | array_flow.rb:473:9:473:9 | a [element 3] :  | array_flow.rb:473:9:473:32 | call to fetch :  |
-| array_flow.rb:473:9:473:32 | call to fetch :  | array_flow.rb:474:10:474:10 | b |
-| array_flow.rb:473:9:473:32 | call to fetch :  | array_flow.rb:474:10:474:10 | b |
+| array_flow.rb:473:9:473:32 | call to fetch :  | array_flow.rb:473:5:473:5 | b :  |
+| array_flow.rb:473:9:473:32 | call to fetch :  | array_flow.rb:473:5:473:5 | b :  |
 | array_flow.rb:473:20:473:31 | call to source :  | array_flow.rb:473:9:473:32 | call to fetch :  |
 | array_flow.rb:473:20:473:31 | call to source :  | array_flow.rb:473:9:473:32 | call to fetch :  |
-| array_flow.rb:475:9:475:34 | call to fetch :  | array_flow.rb:476:10:476:10 | b |
-| array_flow.rb:475:9:475:34 | call to fetch :  | array_flow.rb:476:10:476:10 | b |
+| array_flow.rb:475:5:475:5 | b :  | array_flow.rb:476:10:476:10 | b |
+| array_flow.rb:475:5:475:5 | b :  | array_flow.rb:476:10:476:10 | b |
+| array_flow.rb:475:9:475:34 | call to fetch :  | array_flow.rb:475:5:475:5 | b :  |
+| array_flow.rb:475:9:475:34 | call to fetch :  | array_flow.rb:475:5:475:5 | b :  |
 | array_flow.rb:475:22:475:33 | call to source :  | array_flow.rb:475:9:475:34 | call to fetch :  |
 | array_flow.rb:475:22:475:33 | call to source :  | array_flow.rb:475:9:475:34 | call to fetch :  |
+| array_flow.rb:477:5:477:5 | b :  | array_flow.rb:478:10:478:10 | b |
+| array_flow.rb:477:5:477:5 | b :  | array_flow.rb:478:10:478:10 | b |
 | array_flow.rb:477:9:477:9 | a [element 3] :  | array_flow.rb:477:9:477:32 | call to fetch :  |
 | array_flow.rb:477:9:477:9 | a [element 3] :  | array_flow.rb:477:9:477:32 | call to fetch :  |
 | array_flow.rb:477:9:477:9 | a [element 4] :  | array_flow.rb:477:9:477:32 | call to fetch :  |
 | array_flow.rb:477:9:477:9 | a [element 4] :  | array_flow.rb:477:9:477:32 | call to fetch :  |
-| array_flow.rb:477:9:477:32 | call to fetch :  | array_flow.rb:478:10:478:10 | b |
-| array_flow.rb:477:9:477:32 | call to fetch :  | array_flow.rb:478:10:478:10 | b |
+| array_flow.rb:477:9:477:32 | call to fetch :  | array_flow.rb:477:5:477:5 | b :  |
+| array_flow.rb:477:9:477:32 | call to fetch :  | array_flow.rb:477:5:477:5 | b :  |
 | array_flow.rb:477:20:477:31 | call to source :  | array_flow.rb:477:9:477:32 | call to fetch :  |
 | array_flow.rb:477:20:477:31 | call to source :  | array_flow.rb:477:9:477:32 | call to fetch :  |
-| array_flow.rb:482:19:482:30 | call to source :  | array_flow.rb:484:10:484:10 | a [element 3] :  |
-| array_flow.rb:482:19:482:30 | call to source :  | array_flow.rb:484:10:484:10 | a [element 3] :  |
+| array_flow.rb:482:5:482:5 | a [element 3] :  | array_flow.rb:484:10:484:10 | a [element 3] :  |
+| array_flow.rb:482:5:482:5 | a [element 3] :  | array_flow.rb:484:10:484:10 | a [element 3] :  |
+| array_flow.rb:482:19:482:30 | call to source :  | array_flow.rb:482:5:482:5 | a [element 3] :  |
+| array_flow.rb:482:19:482:30 | call to source :  | array_flow.rb:482:5:482:5 | a [element 3] :  |
 | array_flow.rb:483:5:483:5 | [post] a [element] :  | array_flow.rb:484:10:484:10 | a [element] :  |
 | array_flow.rb:483:5:483:5 | [post] a [element] :  | array_flow.rb:484:10:484:10 | a [element] :  |
 | array_flow.rb:483:12:483:23 | call to source :  | array_flow.rb:483:5:483:5 | [post] a [element] :  |
@@ -868,32 +1105,44 @@ edges
 | array_flow.rb:492:9:492:20 | call to source :  | array_flow.rb:491:5:491:5 | [post] a [element] :  |
 | array_flow.rb:494:10:494:10 | a [element] :  | array_flow.rb:494:10:494:13 | ...[...] |
 | array_flow.rb:494:10:494:10 | a [element] :  | array_flow.rb:494:10:494:13 | ...[...] |
-| array_flow.rb:498:19:498:28 | call to source :  | array_flow.rb:499:9:499:9 | a [element 3] :  |
-| array_flow.rb:498:19:498:28 | call to source :  | array_flow.rb:499:9:499:9 | a [element 3] :  |
+| array_flow.rb:498:5:498:5 | a [element 3] :  | array_flow.rb:499:9:499:9 | a [element 3] :  |
+| array_flow.rb:498:5:498:5 | a [element 3] :  | array_flow.rb:499:9:499:9 | a [element 3] :  |
+| array_flow.rb:498:19:498:28 | call to source :  | array_flow.rb:498:5:498:5 | a [element 3] :  |
+| array_flow.rb:498:19:498:28 | call to source :  | array_flow.rb:498:5:498:5 | a [element 3] :  |
+| array_flow.rb:499:5:499:5 | b [element] :  | array_flow.rb:502:10:502:10 | b [element] :  |
+| array_flow.rb:499:5:499:5 | b [element] :  | array_flow.rb:502:10:502:10 | b [element] :  |
 | array_flow.rb:499:9:499:9 | a [element 3] :  | array_flow.rb:499:9:501:7 | call to filter [element] :  |
 | array_flow.rb:499:9:499:9 | a [element 3] :  | array_flow.rb:499:9:501:7 | call to filter [element] :  |
 | array_flow.rb:499:9:499:9 | a [element 3] :  | array_flow.rb:499:22:499:22 | x :  |
 | array_flow.rb:499:9:499:9 | a [element 3] :  | array_flow.rb:499:22:499:22 | x :  |
-| array_flow.rb:499:9:501:7 | call to filter [element] :  | array_flow.rb:502:10:502:10 | b [element] :  |
-| array_flow.rb:499:9:501:7 | call to filter [element] :  | array_flow.rb:502:10:502:10 | b [element] :  |
+| array_flow.rb:499:9:501:7 | call to filter [element] :  | array_flow.rb:499:5:499:5 | b [element] :  |
+| array_flow.rb:499:9:501:7 | call to filter [element] :  | array_flow.rb:499:5:499:5 | b [element] :  |
 | array_flow.rb:499:22:499:22 | x :  | array_flow.rb:500:14:500:14 | x |
 | array_flow.rb:499:22:499:22 | x :  | array_flow.rb:500:14:500:14 | x |
 | array_flow.rb:502:10:502:10 | b [element] :  | array_flow.rb:502:10:502:13 | ...[...] |
 | array_flow.rb:502:10:502:10 | b [element] :  | array_flow.rb:502:10:502:13 | ...[...] |
-| array_flow.rb:506:19:506:28 | call to source :  | array_flow.rb:507:9:507:9 | a [element 3] :  |
-| array_flow.rb:506:19:506:28 | call to source :  | array_flow.rb:507:9:507:9 | a [element 3] :  |
+| array_flow.rb:506:5:506:5 | a [element 3] :  | array_flow.rb:507:9:507:9 | a [element 3] :  |
+| array_flow.rb:506:5:506:5 | a [element 3] :  | array_flow.rb:507:9:507:9 | a [element 3] :  |
+| array_flow.rb:506:19:506:28 | call to source :  | array_flow.rb:506:5:506:5 | a [element 3] :  |
+| array_flow.rb:506:19:506:28 | call to source :  | array_flow.rb:506:5:506:5 | a [element 3] :  |
+| array_flow.rb:507:5:507:5 | b [element] :  | array_flow.rb:510:10:510:10 | b [element] :  |
+| array_flow.rb:507:5:507:5 | b [element] :  | array_flow.rb:510:10:510:10 | b [element] :  |
 | array_flow.rb:507:9:507:9 | a [element 3] :  | array_flow.rb:507:9:509:7 | call to filter_map [element] :  |
 | array_flow.rb:507:9:507:9 | a [element 3] :  | array_flow.rb:507:9:509:7 | call to filter_map [element] :  |
 | array_flow.rb:507:9:507:9 | a [element 3] :  | array_flow.rb:507:26:507:26 | x :  |
 | array_flow.rb:507:9:507:9 | a [element 3] :  | array_flow.rb:507:26:507:26 | x :  |
-| array_flow.rb:507:9:509:7 | call to filter_map [element] :  | array_flow.rb:510:10:510:10 | b [element] :  |
-| array_flow.rb:507:9:509:7 | call to filter_map [element] :  | array_flow.rb:510:10:510:10 | b [element] :  |
+| array_flow.rb:507:9:509:7 | call to filter_map [element] :  | array_flow.rb:507:5:507:5 | b [element] :  |
+| array_flow.rb:507:9:509:7 | call to filter_map [element] :  | array_flow.rb:507:5:507:5 | b [element] :  |
 | array_flow.rb:507:26:507:26 | x :  | array_flow.rb:508:14:508:14 | x |
 | array_flow.rb:507:26:507:26 | x :  | array_flow.rb:508:14:508:14 | x |
 | array_flow.rb:510:10:510:10 | b [element] :  | array_flow.rb:510:10:510:13 | ...[...] |
 | array_flow.rb:510:10:510:10 | b [element] :  | array_flow.rb:510:10:510:13 | ...[...] |
-| array_flow.rb:514:19:514:28 | call to source :  | array_flow.rb:515:9:515:9 | a [element 3] :  |
-| array_flow.rb:514:19:514:28 | call to source :  | array_flow.rb:515:9:515:9 | a [element 3] :  |
+| array_flow.rb:514:5:514:5 | a [element 3] :  | array_flow.rb:515:9:515:9 | a [element 3] :  |
+| array_flow.rb:514:5:514:5 | a [element 3] :  | array_flow.rb:515:9:515:9 | a [element 3] :  |
+| array_flow.rb:514:19:514:28 | call to source :  | array_flow.rb:514:5:514:5 | a [element 3] :  |
+| array_flow.rb:514:19:514:28 | call to source :  | array_flow.rb:514:5:514:5 | a [element 3] :  |
+| array_flow.rb:515:5:515:5 | b [element] :  | array_flow.rb:520:10:520:10 | b [element] :  |
+| array_flow.rb:515:5:515:5 | b [element] :  | array_flow.rb:520:10:520:10 | b [element] :  |
 | array_flow.rb:515:9:515:9 | [post] a [element] :  | array_flow.rb:519:10:519:10 | a [element] :  |
 | array_flow.rb:515:9:515:9 | [post] a [element] :  | array_flow.rb:519:10:519:10 | a [element] :  |
 | array_flow.rb:515:9:515:9 | a [element 3] :  | array_flow.rb:515:9:515:9 | [post] a [element] :  |
@@ -902,52 +1151,66 @@ edges
 | array_flow.rb:515:9:515:9 | a [element 3] :  | array_flow.rb:515:9:518:7 | call to filter! [element] :  |
 | array_flow.rb:515:9:515:9 | a [element 3] :  | array_flow.rb:515:23:515:23 | x :  |
 | array_flow.rb:515:9:515:9 | a [element 3] :  | array_flow.rb:515:23:515:23 | x :  |
-| array_flow.rb:515:9:518:7 | call to filter! [element] :  | array_flow.rb:520:10:520:10 | b [element] :  |
-| array_flow.rb:515:9:518:7 | call to filter! [element] :  | array_flow.rb:520:10:520:10 | b [element] :  |
+| array_flow.rb:515:9:518:7 | call to filter! [element] :  | array_flow.rb:515:5:515:5 | b [element] :  |
+| array_flow.rb:515:9:518:7 | call to filter! [element] :  | array_flow.rb:515:5:515:5 | b [element] :  |
 | array_flow.rb:515:23:515:23 | x :  | array_flow.rb:516:14:516:14 | x |
 | array_flow.rb:515:23:515:23 | x :  | array_flow.rb:516:14:516:14 | x |
 | array_flow.rb:519:10:519:10 | a [element] :  | array_flow.rb:519:10:519:13 | ...[...] |
 | array_flow.rb:519:10:519:10 | a [element] :  | array_flow.rb:519:10:519:13 | ...[...] |
 | array_flow.rb:520:10:520:10 | b [element] :  | array_flow.rb:520:10:520:13 | ...[...] |
 | array_flow.rb:520:10:520:10 | b [element] :  | array_flow.rb:520:10:520:13 | ...[...] |
-| array_flow.rb:524:19:524:30 | call to source :  | array_flow.rb:525:9:525:9 | a [element 3] :  |
-| array_flow.rb:524:19:524:30 | call to source :  | array_flow.rb:525:9:525:9 | a [element 3] :  |
+| array_flow.rb:524:5:524:5 | a [element 3] :  | array_flow.rb:525:9:525:9 | a [element 3] :  |
+| array_flow.rb:524:5:524:5 | a [element 3] :  | array_flow.rb:525:9:525:9 | a [element 3] :  |
+| array_flow.rb:524:19:524:30 | call to source :  | array_flow.rb:524:5:524:5 | a [element 3] :  |
+| array_flow.rb:524:19:524:30 | call to source :  | array_flow.rb:524:5:524:5 | a [element 3] :  |
+| array_flow.rb:525:5:525:5 | b :  | array_flow.rb:528:10:528:10 | b |
+| array_flow.rb:525:5:525:5 | b :  | array_flow.rb:528:10:528:10 | b |
 | array_flow.rb:525:9:525:9 | a [element 3] :  | array_flow.rb:525:9:527:7 | call to find :  |
 | array_flow.rb:525:9:525:9 | a [element 3] :  | array_flow.rb:525:9:527:7 | call to find :  |
 | array_flow.rb:525:9:525:9 | a [element 3] :  | array_flow.rb:525:41:525:41 | x :  |
 | array_flow.rb:525:9:525:9 | a [element 3] :  | array_flow.rb:525:41:525:41 | x :  |
-| array_flow.rb:525:9:527:7 | call to find :  | array_flow.rb:528:10:528:10 | b |
-| array_flow.rb:525:9:527:7 | call to find :  | array_flow.rb:528:10:528:10 | b |
+| array_flow.rb:525:9:527:7 | call to find :  | array_flow.rb:525:5:525:5 | b :  |
+| array_flow.rb:525:9:527:7 | call to find :  | array_flow.rb:525:5:525:5 | b :  |
 | array_flow.rb:525:21:525:32 | call to source :  | array_flow.rb:525:9:527:7 | call to find :  |
 | array_flow.rb:525:21:525:32 | call to source :  | array_flow.rb:525:9:527:7 | call to find :  |
 | array_flow.rb:525:41:525:41 | x :  | array_flow.rb:526:14:526:14 | x |
 | array_flow.rb:525:41:525:41 | x :  | array_flow.rb:526:14:526:14 | x |
-| array_flow.rb:532:19:532:28 | call to source :  | array_flow.rb:533:9:533:9 | a [element 3] :  |
-| array_flow.rb:532:19:532:28 | call to source :  | array_flow.rb:533:9:533:9 | a [element 3] :  |
+| array_flow.rb:532:5:532:5 | a [element 3] :  | array_flow.rb:533:9:533:9 | a [element 3] :  |
+| array_flow.rb:532:5:532:5 | a [element 3] :  | array_flow.rb:533:9:533:9 | a [element 3] :  |
+| array_flow.rb:532:19:532:28 | call to source :  | array_flow.rb:532:5:532:5 | a [element 3] :  |
+| array_flow.rb:532:19:532:28 | call to source :  | array_flow.rb:532:5:532:5 | a [element 3] :  |
+| array_flow.rb:533:5:533:5 | b [element] :  | array_flow.rb:536:10:536:10 | b [element] :  |
+| array_flow.rb:533:5:533:5 | b [element] :  | array_flow.rb:536:10:536:10 | b [element] :  |
 | array_flow.rb:533:9:533:9 | a [element 3] :  | array_flow.rb:533:9:535:7 | call to find_all [element] :  |
 | array_flow.rb:533:9:533:9 | a [element 3] :  | array_flow.rb:533:9:535:7 | call to find_all [element] :  |
 | array_flow.rb:533:9:533:9 | a [element 3] :  | array_flow.rb:533:24:533:24 | x :  |
 | array_flow.rb:533:9:533:9 | a [element 3] :  | array_flow.rb:533:24:533:24 | x :  |
-| array_flow.rb:533:9:535:7 | call to find_all [element] :  | array_flow.rb:536:10:536:10 | b [element] :  |
-| array_flow.rb:533:9:535:7 | call to find_all [element] :  | array_flow.rb:536:10:536:10 | b [element] :  |
+| array_flow.rb:533:9:535:7 | call to find_all [element] :  | array_flow.rb:533:5:533:5 | b [element] :  |
+| array_flow.rb:533:9:535:7 | call to find_all [element] :  | array_flow.rb:533:5:533:5 | b [element] :  |
 | array_flow.rb:533:24:533:24 | x :  | array_flow.rb:534:14:534:14 | x |
 | array_flow.rb:533:24:533:24 | x :  | array_flow.rb:534:14:534:14 | x |
 | array_flow.rb:536:10:536:10 | b [element] :  | array_flow.rb:536:10:536:13 | ...[...] |
 | array_flow.rb:536:10:536:10 | b [element] :  | array_flow.rb:536:10:536:13 | ...[...] |
-| array_flow.rb:540:19:540:28 | call to source :  | array_flow.rb:541:5:541:5 | a [element 3] :  |
-| array_flow.rb:540:19:540:28 | call to source :  | array_flow.rb:541:5:541:5 | a [element 3] :  |
+| array_flow.rb:540:5:540:5 | a [element 3] :  | array_flow.rb:541:5:541:5 | a [element 3] :  |
+| array_flow.rb:540:5:540:5 | a [element 3] :  | array_flow.rb:541:5:541:5 | a [element 3] :  |
+| array_flow.rb:540:19:540:28 | call to source :  | array_flow.rb:540:5:540:5 | a [element 3] :  |
+| array_flow.rb:540:19:540:28 | call to source :  | array_flow.rb:540:5:540:5 | a [element 3] :  |
 | array_flow.rb:541:5:541:5 | a [element 3] :  | array_flow.rb:541:22:541:22 | x :  |
 | array_flow.rb:541:5:541:5 | a [element 3] :  | array_flow.rb:541:22:541:22 | x :  |
 | array_flow.rb:541:22:541:22 | x :  | array_flow.rb:542:14:542:14 | x |
 | array_flow.rb:541:22:541:22 | x :  | array_flow.rb:542:14:542:14 | x |
-| array_flow.rb:547:10:547:21 | call to source :  | array_flow.rb:549:10:549:10 | a [element 0] :  |
-| array_flow.rb:547:10:547:21 | call to source :  | array_flow.rb:549:10:549:10 | a [element 0] :  |
-| array_flow.rb:547:10:547:21 | call to source :  | array_flow.rb:550:9:550:9 | a [element 0] :  |
-| array_flow.rb:547:10:547:21 | call to source :  | array_flow.rb:550:9:550:9 | a [element 0] :  |
-| array_flow.rb:547:10:547:21 | call to source :  | array_flow.rb:553:9:553:9 | a [element 0] :  |
-| array_flow.rb:547:10:547:21 | call to source :  | array_flow.rb:553:9:553:9 | a [element 0] :  |
-| array_flow.rb:547:30:547:41 | call to source :  | array_flow.rb:553:9:553:9 | a [element 3] :  |
-| array_flow.rb:547:30:547:41 | call to source :  | array_flow.rb:553:9:553:9 | a [element 3] :  |
+| array_flow.rb:547:5:547:5 | a [element 0] :  | array_flow.rb:549:10:549:10 | a [element 0] :  |
+| array_flow.rb:547:5:547:5 | a [element 0] :  | array_flow.rb:549:10:549:10 | a [element 0] :  |
+| array_flow.rb:547:5:547:5 | a [element 0] :  | array_flow.rb:550:9:550:9 | a [element 0] :  |
+| array_flow.rb:547:5:547:5 | a [element 0] :  | array_flow.rb:550:9:550:9 | a [element 0] :  |
+| array_flow.rb:547:5:547:5 | a [element 0] :  | array_flow.rb:553:9:553:9 | a [element 0] :  |
+| array_flow.rb:547:5:547:5 | a [element 0] :  | array_flow.rb:553:9:553:9 | a [element 0] :  |
+| array_flow.rb:547:5:547:5 | a [element 3] :  | array_flow.rb:553:9:553:9 | a [element 3] :  |
+| array_flow.rb:547:5:547:5 | a [element 3] :  | array_flow.rb:553:9:553:9 | a [element 3] :  |
+| array_flow.rb:547:10:547:21 | call to source :  | array_flow.rb:547:5:547:5 | a [element 0] :  |
+| array_flow.rb:547:10:547:21 | call to source :  | array_flow.rb:547:5:547:5 | a [element 0] :  |
+| array_flow.rb:547:30:547:41 | call to source :  | array_flow.rb:547:5:547:5 | a [element 3] :  |
+| array_flow.rb:547:30:547:41 | call to source :  | array_flow.rb:547:5:547:5 | a [element 3] :  |
 | array_flow.rb:548:5:548:5 | [post] a [element] :  | array_flow.rb:549:10:549:10 | a [element] :  |
 | array_flow.rb:548:5:548:5 | [post] a [element] :  | array_flow.rb:549:10:549:10 | a [element] :  |
 | array_flow.rb:548:5:548:5 | [post] a [element] :  | array_flow.rb:550:9:550:9 | a [element] :  |
@@ -960,36 +1223,46 @@ edges
 | array_flow.rb:549:10:549:10 | a [element 0] :  | array_flow.rb:549:10:549:16 | call to first |
 | array_flow.rb:549:10:549:10 | a [element] :  | array_flow.rb:549:10:549:16 | call to first |
 | array_flow.rb:549:10:549:10 | a [element] :  | array_flow.rb:549:10:549:16 | call to first |
+| array_flow.rb:550:5:550:5 | b [element 0] :  | array_flow.rb:551:10:551:10 | b [element 0] :  |
+| array_flow.rb:550:5:550:5 | b [element 0] :  | array_flow.rb:551:10:551:10 | b [element 0] :  |
+| array_flow.rb:550:5:550:5 | b [element] :  | array_flow.rb:551:10:551:10 | b [element] :  |
+| array_flow.rb:550:5:550:5 | b [element] :  | array_flow.rb:551:10:551:10 | b [element] :  |
+| array_flow.rb:550:5:550:5 | b [element] :  | array_flow.rb:552:10:552:10 | b [element] :  |
+| array_flow.rb:550:5:550:5 | b [element] :  | array_flow.rb:552:10:552:10 | b [element] :  |
 | array_flow.rb:550:9:550:9 | a [element 0] :  | array_flow.rb:550:9:550:18 | call to first [element 0] :  |
 | array_flow.rb:550:9:550:9 | a [element 0] :  | array_flow.rb:550:9:550:18 | call to first [element 0] :  |
 | array_flow.rb:550:9:550:9 | a [element] :  | array_flow.rb:550:9:550:18 | call to first [element] :  |
 | array_flow.rb:550:9:550:9 | a [element] :  | array_flow.rb:550:9:550:18 | call to first [element] :  |
-| array_flow.rb:550:9:550:18 | call to first [element 0] :  | array_flow.rb:551:10:551:10 | b [element 0] :  |
-| array_flow.rb:550:9:550:18 | call to first [element 0] :  | array_flow.rb:551:10:551:10 | b [element 0] :  |
-| array_flow.rb:550:9:550:18 | call to first [element] :  | array_flow.rb:551:10:551:10 | b [element] :  |
-| array_flow.rb:550:9:550:18 | call to first [element] :  | array_flow.rb:551:10:551:10 | b [element] :  |
-| array_flow.rb:550:9:550:18 | call to first [element] :  | array_flow.rb:552:10:552:10 | b [element] :  |
-| array_flow.rb:550:9:550:18 | call to first [element] :  | array_flow.rb:552:10:552:10 | b [element] :  |
+| array_flow.rb:550:9:550:18 | call to first [element 0] :  | array_flow.rb:550:5:550:5 | b [element 0] :  |
+| array_flow.rb:550:9:550:18 | call to first [element 0] :  | array_flow.rb:550:5:550:5 | b [element 0] :  |
+| array_flow.rb:550:9:550:18 | call to first [element] :  | array_flow.rb:550:5:550:5 | b [element] :  |
+| array_flow.rb:550:9:550:18 | call to first [element] :  | array_flow.rb:550:5:550:5 | b [element] :  |
 | array_flow.rb:551:10:551:10 | b [element 0] :  | array_flow.rb:551:10:551:13 | ...[...] |
 | array_flow.rb:551:10:551:10 | b [element 0] :  | array_flow.rb:551:10:551:13 | ...[...] |
 | array_flow.rb:551:10:551:10 | b [element] :  | array_flow.rb:551:10:551:13 | ...[...] |
 | array_flow.rb:551:10:551:10 | b [element] :  | array_flow.rb:551:10:551:13 | ...[...] |
 | array_flow.rb:552:10:552:10 | b [element] :  | array_flow.rb:552:10:552:13 | ...[...] |
 | array_flow.rb:552:10:552:10 | b [element] :  | array_flow.rb:552:10:552:13 | ...[...] |
+| array_flow.rb:553:5:553:5 | c [element 0] :  | array_flow.rb:554:10:554:10 | c [element 0] :  |
+| array_flow.rb:553:5:553:5 | c [element 0] :  | array_flow.rb:554:10:554:10 | c [element 0] :  |
+| array_flow.rb:553:5:553:5 | c [element 3] :  | array_flow.rb:555:10:555:10 | c [element 3] :  |
+| array_flow.rb:553:5:553:5 | c [element 3] :  | array_flow.rb:555:10:555:10 | c [element 3] :  |
+| array_flow.rb:553:5:553:5 | c [element] :  | array_flow.rb:554:10:554:10 | c [element] :  |
+| array_flow.rb:553:5:553:5 | c [element] :  | array_flow.rb:554:10:554:10 | c [element] :  |
+| array_flow.rb:553:5:553:5 | c [element] :  | array_flow.rb:555:10:555:10 | c [element] :  |
+| array_flow.rb:553:5:553:5 | c [element] :  | array_flow.rb:555:10:555:10 | c [element] :  |
 | array_flow.rb:553:9:553:9 | a [element 0] :  | array_flow.rb:553:9:553:18 | call to first [element 0] :  |
 | array_flow.rb:553:9:553:9 | a [element 0] :  | array_flow.rb:553:9:553:18 | call to first [element 0] :  |
 | array_flow.rb:553:9:553:9 | a [element 3] :  | array_flow.rb:553:9:553:18 | call to first [element 3] :  |
 | array_flow.rb:553:9:553:9 | a [element 3] :  | array_flow.rb:553:9:553:18 | call to first [element 3] :  |
 | array_flow.rb:553:9:553:9 | a [element] :  | array_flow.rb:553:9:553:18 | call to first [element] :  |
 | array_flow.rb:553:9:553:9 | a [element] :  | array_flow.rb:553:9:553:18 | call to first [element] :  |
-| array_flow.rb:553:9:553:18 | call to first [element 0] :  | array_flow.rb:554:10:554:10 | c [element 0] :  |
-| array_flow.rb:553:9:553:18 | call to first [element 0] :  | array_flow.rb:554:10:554:10 | c [element 0] :  |
-| array_flow.rb:553:9:553:18 | call to first [element 3] :  | array_flow.rb:555:10:555:10 | c [element 3] :  |
-| array_flow.rb:553:9:553:18 | call to first [element 3] :  | array_flow.rb:555:10:555:10 | c [element 3] :  |
-| array_flow.rb:553:9:553:18 | call to first [element] :  | array_flow.rb:554:10:554:10 | c [element] :  |
-| array_flow.rb:553:9:553:18 | call to first [element] :  | array_flow.rb:554:10:554:10 | c [element] :  |
-| array_flow.rb:553:9:553:18 | call to first [element] :  | array_flow.rb:555:10:555:10 | c [element] :  |
-| array_flow.rb:553:9:553:18 | call to first [element] :  | array_flow.rb:555:10:555:10 | c [element] :  |
+| array_flow.rb:553:9:553:18 | call to first [element 0] :  | array_flow.rb:553:5:553:5 | c [element 0] :  |
+| array_flow.rb:553:9:553:18 | call to first [element 0] :  | array_flow.rb:553:5:553:5 | c [element 0] :  |
+| array_flow.rb:553:9:553:18 | call to first [element 3] :  | array_flow.rb:553:5:553:5 | c [element 3] :  |
+| array_flow.rb:553:9:553:18 | call to first [element 3] :  | array_flow.rb:553:5:553:5 | c [element 3] :  |
+| array_flow.rb:553:9:553:18 | call to first [element] :  | array_flow.rb:553:5:553:5 | c [element] :  |
+| array_flow.rb:553:9:553:18 | call to first [element] :  | array_flow.rb:553:5:553:5 | c [element] :  |
 | array_flow.rb:554:10:554:10 | c [element 0] :  | array_flow.rb:554:10:554:13 | ...[...] |
 | array_flow.rb:554:10:554:10 | c [element 0] :  | array_flow.rb:554:10:554:13 | ...[...] |
 | array_flow.rb:554:10:554:10 | c [element] :  | array_flow.rb:554:10:554:13 | ...[...] |
@@ -998,48 +1271,65 @@ edges
 | array_flow.rb:555:10:555:10 | c [element 3] :  | array_flow.rb:555:10:555:13 | ...[...] |
 | array_flow.rb:555:10:555:10 | c [element] :  | array_flow.rb:555:10:555:13 | ...[...] |
 | array_flow.rb:555:10:555:10 | c [element] :  | array_flow.rb:555:10:555:13 | ...[...] |
-| array_flow.rb:559:16:559:27 | call to source :  | array_flow.rb:560:9:560:9 | a [element 2] :  |
-| array_flow.rb:559:16:559:27 | call to source :  | array_flow.rb:560:9:560:9 | a [element 2] :  |
-| array_flow.rb:559:16:559:27 | call to source :  | array_flow.rb:565:9:565:9 | a [element 2] :  |
-| array_flow.rb:559:16:559:27 | call to source :  | array_flow.rb:565:9:565:9 | a [element 2] :  |
+| array_flow.rb:559:5:559:5 | a [element 2] :  | array_flow.rb:560:9:560:9 | a [element 2] :  |
+| array_flow.rb:559:5:559:5 | a [element 2] :  | array_flow.rb:560:9:560:9 | a [element 2] :  |
+| array_flow.rb:559:5:559:5 | a [element 2] :  | array_flow.rb:565:9:565:9 | a [element 2] :  |
+| array_flow.rb:559:5:559:5 | a [element 2] :  | array_flow.rb:565:9:565:9 | a [element 2] :  |
+| array_flow.rb:559:16:559:27 | call to source :  | array_flow.rb:559:5:559:5 | a [element 2] :  |
+| array_flow.rb:559:16:559:27 | call to source :  | array_flow.rb:559:5:559:5 | a [element 2] :  |
+| array_flow.rb:560:5:560:5 | b [element] :  | array_flow.rb:564:10:564:10 | b [element] :  |
+| array_flow.rb:560:5:560:5 | b [element] :  | array_flow.rb:564:10:564:10 | b [element] :  |
 | array_flow.rb:560:9:560:9 | a [element 2] :  | array_flow.rb:560:9:563:7 | call to flat_map [element] :  |
 | array_flow.rb:560:9:560:9 | a [element 2] :  | array_flow.rb:560:9:563:7 | call to flat_map [element] :  |
 | array_flow.rb:560:9:560:9 | a [element 2] :  | array_flow.rb:560:24:560:24 | x :  |
 | array_flow.rb:560:9:560:9 | a [element 2] :  | array_flow.rb:560:24:560:24 | x :  |
-| array_flow.rb:560:9:563:7 | call to flat_map [element] :  | array_flow.rb:564:10:564:10 | b [element] :  |
-| array_flow.rb:560:9:563:7 | call to flat_map [element] :  | array_flow.rb:564:10:564:10 | b [element] :  |
+| array_flow.rb:560:9:563:7 | call to flat_map [element] :  | array_flow.rb:560:5:560:5 | b [element] :  |
+| array_flow.rb:560:9:563:7 | call to flat_map [element] :  | array_flow.rb:560:5:560:5 | b [element] :  |
 | array_flow.rb:560:24:560:24 | x :  | array_flow.rb:561:14:561:14 | x |
 | array_flow.rb:560:24:560:24 | x :  | array_flow.rb:561:14:561:14 | x |
 | array_flow.rb:562:13:562:24 | call to source :  | array_flow.rb:560:9:563:7 | call to flat_map [element] :  |
 | array_flow.rb:562:13:562:24 | call to source :  | array_flow.rb:560:9:563:7 | call to flat_map [element] :  |
 | array_flow.rb:564:10:564:10 | b [element] :  | array_flow.rb:564:10:564:13 | ...[...] |
 | array_flow.rb:564:10:564:10 | b [element] :  | array_flow.rb:564:10:564:13 | ...[...] |
+| array_flow.rb:565:5:565:5 | b [element] :  | array_flow.rb:569:10:569:10 | b [element] :  |
+| array_flow.rb:565:5:565:5 | b [element] :  | array_flow.rb:569:10:569:10 | b [element] :  |
 | array_flow.rb:565:9:565:9 | a [element 2] :  | array_flow.rb:565:24:565:24 | x :  |
 | array_flow.rb:565:9:565:9 | a [element 2] :  | array_flow.rb:565:24:565:24 | x :  |
-| array_flow.rb:565:9:568:7 | call to flat_map [element] :  | array_flow.rb:569:10:569:10 | b [element] :  |
-| array_flow.rb:565:9:568:7 | call to flat_map [element] :  | array_flow.rb:569:10:569:10 | b [element] :  |
+| array_flow.rb:565:9:568:7 | call to flat_map [element] :  | array_flow.rb:565:5:565:5 | b [element] :  |
+| array_flow.rb:565:9:568:7 | call to flat_map [element] :  | array_flow.rb:565:5:565:5 | b [element] :  |
 | array_flow.rb:565:24:565:24 | x :  | array_flow.rb:566:14:566:14 | x |
 | array_flow.rb:565:24:565:24 | x :  | array_flow.rb:566:14:566:14 | x |
 | array_flow.rb:567:9:567:20 | call to source :  | array_flow.rb:565:9:568:7 | call to flat_map [element] :  |
 | array_flow.rb:567:9:567:20 | call to source :  | array_flow.rb:565:9:568:7 | call to flat_map [element] :  |
 | array_flow.rb:569:10:569:10 | b [element] :  | array_flow.rb:569:10:569:13 | ...[...] |
 | array_flow.rb:569:10:569:10 | b [element] :  | array_flow.rb:569:10:569:13 | ...[...] |
-| array_flow.rb:573:20:573:29 | call to source :  | array_flow.rb:574:9:574:9 | a [element 2, element 1] :  |
-| array_flow.rb:573:20:573:29 | call to source :  | array_flow.rb:574:9:574:9 | a [element 2, element 1] :  |
+| array_flow.rb:573:5:573:5 | a [element 2, element 1] :  | array_flow.rb:574:9:574:9 | a [element 2, element 1] :  |
+| array_flow.rb:573:5:573:5 | a [element 2, element 1] :  | array_flow.rb:574:9:574:9 | a [element 2, element 1] :  |
+| array_flow.rb:573:20:573:29 | call to source :  | array_flow.rb:573:5:573:5 | a [element 2, element 1] :  |
+| array_flow.rb:573:20:573:29 | call to source :  | array_flow.rb:573:5:573:5 | a [element 2, element 1] :  |
+| array_flow.rb:574:5:574:5 | b [element] :  | array_flow.rb:575:10:575:10 | b [element] :  |
+| array_flow.rb:574:5:574:5 | b [element] :  | array_flow.rb:575:10:575:10 | b [element] :  |
 | array_flow.rb:574:9:574:9 | a [element 2, element 1] :  | array_flow.rb:574:9:574:17 | call to flatten [element] :  |
 | array_flow.rb:574:9:574:9 | a [element 2, element 1] :  | array_flow.rb:574:9:574:17 | call to flatten [element] :  |
-| array_flow.rb:574:9:574:17 | call to flatten [element] :  | array_flow.rb:575:10:575:10 | b [element] :  |
-| array_flow.rb:574:9:574:17 | call to flatten [element] :  | array_flow.rb:575:10:575:10 | b [element] :  |
+| array_flow.rb:574:9:574:17 | call to flatten [element] :  | array_flow.rb:574:5:574:5 | b [element] :  |
+| array_flow.rb:574:9:574:17 | call to flatten [element] :  | array_flow.rb:574:5:574:5 | b [element] :  |
 | array_flow.rb:575:10:575:10 | b [element] :  | array_flow.rb:575:10:575:13 | ...[...] |
 | array_flow.rb:575:10:575:10 | b [element] :  | array_flow.rb:575:10:575:13 | ...[...] |
-| array_flow.rb:579:20:579:29 | call to source :  | array_flow.rb:580:10:580:10 | a [element 2, element 1] :  |
-| array_flow.rb:579:20:579:29 | call to source :  | array_flow.rb:580:10:580:10 | a [element 2, element 1] :  |
-| array_flow.rb:579:20:579:29 | call to source :  | array_flow.rb:581:9:581:9 | a [element 2, element 1] :  |
-| array_flow.rb:579:20:579:29 | call to source :  | array_flow.rb:581:9:581:9 | a [element 2, element 1] :  |
+| array_flow.rb:579:5:579:5 | a [element 2, element 1] :  | array_flow.rb:580:10:580:10 | a [element 2, element 1] :  |
+| array_flow.rb:579:5:579:5 | a [element 2, element 1] :  | array_flow.rb:580:10:580:10 | a [element 2, element 1] :  |
+| array_flow.rb:579:5:579:5 | a [element 2, element 1] :  | array_flow.rb:581:9:581:9 | a [element 2, element 1] :  |
+| array_flow.rb:579:5:579:5 | a [element 2, element 1] :  | array_flow.rb:581:9:581:9 | a [element 2, element 1] :  |
+| array_flow.rb:579:20:579:29 | call to source :  | array_flow.rb:579:5:579:5 | a [element 2, element 1] :  |
+| array_flow.rb:579:20:579:29 | call to source :  | array_flow.rb:579:5:579:5 | a [element 2, element 1] :  |
 | array_flow.rb:580:10:580:10 | a [element 2, element 1] :  | array_flow.rb:580:10:580:13 | ...[...] [element 1] :  |
 | array_flow.rb:580:10:580:10 | a [element 2, element 1] :  | array_flow.rb:580:10:580:13 | ...[...] [element 1] :  |
 | array_flow.rb:580:10:580:13 | ...[...] [element 1] :  | array_flow.rb:580:10:580:16 | ...[...] |
 | array_flow.rb:580:10:580:13 | ...[...] [element 1] :  | array_flow.rb:580:10:580:16 | ...[...] |
+| array_flow.rb:581:5:581:5 | b [element, element 1] :  | array_flow.rb:585:10:585:10 | b [element, element 1] :  |
+| array_flow.rb:581:5:581:5 | b [element, element 1] :  | array_flow.rb:585:10:585:10 | b [element, element 1] :  |
+| array_flow.rb:581:5:581:5 | b [element] :  | array_flow.rb:584:10:584:10 | b [element] :  |
+| array_flow.rb:581:5:581:5 | b [element] :  | array_flow.rb:584:10:584:10 | b [element] :  |
+| array_flow.rb:581:5:581:5 | b [element] :  | array_flow.rb:585:10:585:10 | b [element] :  |
 | array_flow.rb:581:9:581:9 | [post] a [element, element 1] :  | array_flow.rb:583:10:583:10 | a [element, element 1] :  |
 | array_flow.rb:581:9:581:9 | [post] a [element, element 1] :  | array_flow.rb:583:10:583:10 | a [element, element 1] :  |
 | array_flow.rb:581:9:581:9 | [post] a [element] :  | array_flow.rb:582:10:582:10 | a [element] :  |
@@ -1053,11 +1343,10 @@ edges
 | array_flow.rb:581:9:581:9 | a [element 2, element 1] :  | array_flow.rb:581:9:581:18 | call to flatten! [element, element 1] :  |
 | array_flow.rb:581:9:581:9 | a [element 2, element 1] :  | array_flow.rb:581:9:581:18 | call to flatten! [element] :  |
 | array_flow.rb:581:9:581:9 | a [element 2, element 1] :  | array_flow.rb:581:9:581:18 | call to flatten! [element] :  |
-| array_flow.rb:581:9:581:18 | call to flatten! [element, element 1] :  | array_flow.rb:585:10:585:10 | b [element, element 1] :  |
-| array_flow.rb:581:9:581:18 | call to flatten! [element, element 1] :  | array_flow.rb:585:10:585:10 | b [element, element 1] :  |
-| array_flow.rb:581:9:581:18 | call to flatten! [element] :  | array_flow.rb:584:10:584:10 | b [element] :  |
-| array_flow.rb:581:9:581:18 | call to flatten! [element] :  | array_flow.rb:584:10:584:10 | b [element] :  |
-| array_flow.rb:581:9:581:18 | call to flatten! [element] :  | array_flow.rb:585:10:585:10 | b [element] :  |
+| array_flow.rb:581:9:581:18 | call to flatten! [element, element 1] :  | array_flow.rb:581:5:581:5 | b [element, element 1] :  |
+| array_flow.rb:581:9:581:18 | call to flatten! [element, element 1] :  | array_flow.rb:581:5:581:5 | b [element, element 1] :  |
+| array_flow.rb:581:9:581:18 | call to flatten! [element] :  | array_flow.rb:581:5:581:5 | b [element] :  |
+| array_flow.rb:581:9:581:18 | call to flatten! [element] :  | array_flow.rb:581:5:581:5 | b [element] :  |
 | array_flow.rb:582:10:582:10 | a [element] :  | array_flow.rb:582:10:582:13 | ...[...] |
 | array_flow.rb:582:10:582:10 | a [element] :  | array_flow.rb:582:10:582:13 | ...[...] |
 | array_flow.rb:583:10:583:10 | a [element, element 1] :  | array_flow.rb:583:10:583:13 | ...[...] [element 1] :  |
@@ -1074,90 +1363,122 @@ edges
 | array_flow.rb:585:10:585:13 | ...[...] :  | array_flow.rb:585:10:585:16 | ...[...] |
 | array_flow.rb:585:10:585:13 | ...[...] [element 1] :  | array_flow.rb:585:10:585:16 | ...[...] |
 | array_flow.rb:585:10:585:13 | ...[...] [element 1] :  | array_flow.rb:585:10:585:16 | ...[...] |
-| array_flow.rb:589:19:589:30 | call to source :  | array_flow.rb:590:9:590:9 | a [element 3] :  |
-| array_flow.rb:589:19:589:30 | call to source :  | array_flow.rb:590:9:590:9 | a [element 3] :  |
-| array_flow.rb:589:19:589:30 | call to source :  | array_flow.rb:592:9:592:9 | a [element 3] :  |
-| array_flow.rb:589:19:589:30 | call to source :  | array_flow.rb:592:9:592:9 | a [element 3] :  |
+| array_flow.rb:589:5:589:5 | a [element 3] :  | array_flow.rb:590:9:590:9 | a [element 3] :  |
+| array_flow.rb:589:5:589:5 | a [element 3] :  | array_flow.rb:590:9:590:9 | a [element 3] :  |
+| array_flow.rb:589:5:589:5 | a [element 3] :  | array_flow.rb:592:9:592:9 | a [element 3] :  |
+| array_flow.rb:589:5:589:5 | a [element 3] :  | array_flow.rb:592:9:592:9 | a [element 3] :  |
+| array_flow.rb:589:19:589:30 | call to source :  | array_flow.rb:589:5:589:5 | a [element 3] :  |
+| array_flow.rb:589:19:589:30 | call to source :  | array_flow.rb:589:5:589:5 | a [element 3] :  |
+| array_flow.rb:590:5:590:5 | b [element] :  | array_flow.rb:591:10:591:10 | b [element] :  |
+| array_flow.rb:590:5:590:5 | b [element] :  | array_flow.rb:591:10:591:10 | b [element] :  |
 | array_flow.rb:590:9:590:9 | a [element 3] :  | array_flow.rb:590:9:590:20 | call to grep [element] :  |
 | array_flow.rb:590:9:590:9 | a [element 3] :  | array_flow.rb:590:9:590:20 | call to grep [element] :  |
-| array_flow.rb:590:9:590:20 | call to grep [element] :  | array_flow.rb:591:10:591:10 | b [element] :  |
-| array_flow.rb:590:9:590:20 | call to grep [element] :  | array_flow.rb:591:10:591:10 | b [element] :  |
+| array_flow.rb:590:9:590:20 | call to grep [element] :  | array_flow.rb:590:5:590:5 | b [element] :  |
+| array_flow.rb:590:9:590:20 | call to grep [element] :  | array_flow.rb:590:5:590:5 | b [element] :  |
 | array_flow.rb:591:10:591:10 | b [element] :  | array_flow.rb:591:10:591:13 | ...[...] |
 | array_flow.rb:591:10:591:10 | b [element] :  | array_flow.rb:591:10:591:13 | ...[...] |
+| array_flow.rb:592:5:592:5 | b [element] :  | array_flow.rb:596:10:596:10 | b [element] :  |
+| array_flow.rb:592:5:592:5 | b [element] :  | array_flow.rb:596:10:596:10 | b [element] :  |
 | array_flow.rb:592:9:592:9 | a [element 3] :  | array_flow.rb:592:26:592:26 | x :  |
 | array_flow.rb:592:9:592:9 | a [element 3] :  | array_flow.rb:592:26:592:26 | x :  |
-| array_flow.rb:592:9:595:7 | call to grep [element] :  | array_flow.rb:596:10:596:10 | b [element] :  |
-| array_flow.rb:592:9:595:7 | call to grep [element] :  | array_flow.rb:596:10:596:10 | b [element] :  |
+| array_flow.rb:592:9:595:7 | call to grep [element] :  | array_flow.rb:592:5:592:5 | b [element] :  |
+| array_flow.rb:592:9:595:7 | call to grep [element] :  | array_flow.rb:592:5:592:5 | b [element] :  |
 | array_flow.rb:592:26:592:26 | x :  | array_flow.rb:593:14:593:14 | x |
 | array_flow.rb:592:26:592:26 | x :  | array_flow.rb:593:14:593:14 | x |
 | array_flow.rb:594:9:594:20 | call to source :  | array_flow.rb:592:9:595:7 | call to grep [element] :  |
 | array_flow.rb:594:9:594:20 | call to source :  | array_flow.rb:592:9:595:7 | call to grep [element] :  |
 | array_flow.rb:596:10:596:10 | b [element] :  | array_flow.rb:596:10:596:13 | ...[...] |
 | array_flow.rb:596:10:596:10 | b [element] :  | array_flow.rb:596:10:596:13 | ...[...] |
-| array_flow.rb:600:19:600:30 | call to source :  | array_flow.rb:601:9:601:9 | a [element 3] :  |
-| array_flow.rb:600:19:600:30 | call to source :  | array_flow.rb:601:9:601:9 | a [element 3] :  |
-| array_flow.rb:600:19:600:30 | call to source :  | array_flow.rb:603:9:603:9 | a [element 3] :  |
-| array_flow.rb:600:19:600:30 | call to source :  | array_flow.rb:603:9:603:9 | a [element 3] :  |
+| array_flow.rb:600:5:600:5 | a [element 3] :  | array_flow.rb:601:9:601:9 | a [element 3] :  |
+| array_flow.rb:600:5:600:5 | a [element 3] :  | array_flow.rb:601:9:601:9 | a [element 3] :  |
+| array_flow.rb:600:5:600:5 | a [element 3] :  | array_flow.rb:603:9:603:9 | a [element 3] :  |
+| array_flow.rb:600:5:600:5 | a [element 3] :  | array_flow.rb:603:9:603:9 | a [element 3] :  |
+| array_flow.rb:600:19:600:30 | call to source :  | array_flow.rb:600:5:600:5 | a [element 3] :  |
+| array_flow.rb:600:19:600:30 | call to source :  | array_flow.rb:600:5:600:5 | a [element 3] :  |
+| array_flow.rb:601:5:601:5 | b [element] :  | array_flow.rb:602:10:602:10 | b [element] :  |
+| array_flow.rb:601:5:601:5 | b [element] :  | array_flow.rb:602:10:602:10 | b [element] :  |
 | array_flow.rb:601:9:601:9 | a [element 3] :  | array_flow.rb:601:9:601:21 | call to grep_v [element] :  |
 | array_flow.rb:601:9:601:9 | a [element 3] :  | array_flow.rb:601:9:601:21 | call to grep_v [element] :  |
-| array_flow.rb:601:9:601:21 | call to grep_v [element] :  | array_flow.rb:602:10:602:10 | b [element] :  |
-| array_flow.rb:601:9:601:21 | call to grep_v [element] :  | array_flow.rb:602:10:602:10 | b [element] :  |
+| array_flow.rb:601:9:601:21 | call to grep_v [element] :  | array_flow.rb:601:5:601:5 | b [element] :  |
+| array_flow.rb:601:9:601:21 | call to grep_v [element] :  | array_flow.rb:601:5:601:5 | b [element] :  |
 | array_flow.rb:602:10:602:10 | b [element] :  | array_flow.rb:602:10:602:13 | ...[...] |
 | array_flow.rb:602:10:602:10 | b [element] :  | array_flow.rb:602:10:602:13 | ...[...] |
+| array_flow.rb:603:5:603:5 | b [element] :  | array_flow.rb:607:10:607:10 | b [element] :  |
+| array_flow.rb:603:5:603:5 | b [element] :  | array_flow.rb:607:10:607:10 | b [element] :  |
 | array_flow.rb:603:9:603:9 | a [element 3] :  | array_flow.rb:603:27:603:27 | x :  |
 | array_flow.rb:603:9:603:9 | a [element 3] :  | array_flow.rb:603:27:603:27 | x :  |
-| array_flow.rb:603:9:606:7 | call to grep_v [element] :  | array_flow.rb:607:10:607:10 | b [element] :  |
-| array_flow.rb:603:9:606:7 | call to grep_v [element] :  | array_flow.rb:607:10:607:10 | b [element] :  |
+| array_flow.rb:603:9:606:7 | call to grep_v [element] :  | array_flow.rb:603:5:603:5 | b [element] :  |
+| array_flow.rb:603:9:606:7 | call to grep_v [element] :  | array_flow.rb:603:5:603:5 | b [element] :  |
 | array_flow.rb:603:27:603:27 | x :  | array_flow.rb:604:14:604:14 | x |
 | array_flow.rb:603:27:603:27 | x :  | array_flow.rb:604:14:604:14 | x |
 | array_flow.rb:605:9:605:20 | call to source :  | array_flow.rb:603:9:606:7 | call to grep_v [element] :  |
 | array_flow.rb:605:9:605:20 | call to source :  | array_flow.rb:603:9:606:7 | call to grep_v [element] :  |
 | array_flow.rb:607:10:607:10 | b [element] :  | array_flow.rb:607:10:607:13 | ...[...] |
 | array_flow.rb:607:10:607:10 | b [element] :  | array_flow.rb:607:10:607:13 | ...[...] |
-| array_flow.rb:611:19:611:30 | call to source :  | array_flow.rb:612:9:612:9 | a [element 3] :  |
-| array_flow.rb:611:19:611:30 | call to source :  | array_flow.rb:612:9:612:9 | a [element 3] :  |
+| array_flow.rb:611:5:611:5 | a [element 3] :  | array_flow.rb:612:9:612:9 | a [element 3] :  |
+| array_flow.rb:611:5:611:5 | a [element 3] :  | array_flow.rb:612:9:612:9 | a [element 3] :  |
+| array_flow.rb:611:19:611:30 | call to source :  | array_flow.rb:611:5:611:5 | a [element 3] :  |
+| array_flow.rb:611:19:611:30 | call to source :  | array_flow.rb:611:5:611:5 | a [element 3] :  |
 | array_flow.rb:612:9:612:9 | a [element 3] :  | array_flow.rb:612:24:612:24 | x :  |
 | array_flow.rb:612:9:612:9 | a [element 3] :  | array_flow.rb:612:24:612:24 | x :  |
 | array_flow.rb:612:24:612:24 | x :  | array_flow.rb:613:14:613:14 | x |
 | array_flow.rb:612:24:612:24 | x :  | array_flow.rb:613:14:613:14 | x |
-| array_flow.rb:620:19:620:28 | call to source :  | array_flow.rb:621:5:621:5 | a [element 3] :  |
-| array_flow.rb:620:19:620:28 | call to source :  | array_flow.rb:621:5:621:5 | a [element 3] :  |
+| array_flow.rb:620:5:620:5 | a [element 3] :  | array_flow.rb:621:5:621:5 | a [element 3] :  |
+| array_flow.rb:620:5:620:5 | a [element 3] :  | array_flow.rb:621:5:621:5 | a [element 3] :  |
+| array_flow.rb:620:19:620:28 | call to source :  | array_flow.rb:620:5:620:5 | a [element 3] :  |
+| array_flow.rb:620:19:620:28 | call to source :  | array_flow.rb:620:5:620:5 | a [element 3] :  |
 | array_flow.rb:621:5:621:5 | a [element 3] :  | array_flow.rb:621:17:621:17 | x :  |
 | array_flow.rb:621:5:621:5 | a [element 3] :  | array_flow.rb:621:17:621:17 | x :  |
 | array_flow.rb:621:17:621:17 | x :  | array_flow.rb:622:14:622:14 | x |
 | array_flow.rb:621:17:621:17 | x :  | array_flow.rb:622:14:622:14 | x |
-| array_flow.rb:627:10:627:21 | call to source :  | array_flow.rb:628:9:628:9 | a [element 0] :  |
-| array_flow.rb:627:10:627:21 | call to source :  | array_flow.rb:628:9:628:9 | a [element 0] :  |
-| array_flow.rb:627:10:627:21 | call to source :  | array_flow.rb:634:9:634:9 | a [element 0] :  |
-| array_flow.rb:627:10:627:21 | call to source :  | array_flow.rb:634:9:634:9 | a [element 0] :  |
-| array_flow.rb:627:27:627:38 | call to source :  | array_flow.rb:628:9:628:9 | a [element 2] :  |
-| array_flow.rb:627:27:627:38 | call to source :  | array_flow.rb:628:9:628:9 | a [element 2] :  |
-| array_flow.rb:627:27:627:38 | call to source :  | array_flow.rb:634:9:634:9 | a [element 2] :  |
-| array_flow.rb:627:27:627:38 | call to source :  | array_flow.rb:634:9:634:9 | a [element 2] :  |
+| array_flow.rb:627:5:627:5 | a [element 0] :  | array_flow.rb:628:9:628:9 | a [element 0] :  |
+| array_flow.rb:627:5:627:5 | a [element 0] :  | array_flow.rb:628:9:628:9 | a [element 0] :  |
+| array_flow.rb:627:5:627:5 | a [element 0] :  | array_flow.rb:634:9:634:9 | a [element 0] :  |
+| array_flow.rb:627:5:627:5 | a [element 0] :  | array_flow.rb:634:9:634:9 | a [element 0] :  |
+| array_flow.rb:627:5:627:5 | a [element 2] :  | array_flow.rb:628:9:628:9 | a [element 2] :  |
+| array_flow.rb:627:5:627:5 | a [element 2] :  | array_flow.rb:628:9:628:9 | a [element 2] :  |
+| array_flow.rb:627:5:627:5 | a [element 2] :  | array_flow.rb:634:9:634:9 | a [element 2] :  |
+| array_flow.rb:627:5:627:5 | a [element 2] :  | array_flow.rb:634:9:634:9 | a [element 2] :  |
+| array_flow.rb:627:10:627:21 | call to source :  | array_flow.rb:627:5:627:5 | a [element 0] :  |
+| array_flow.rb:627:10:627:21 | call to source :  | array_flow.rb:627:5:627:5 | a [element 0] :  |
+| array_flow.rb:627:27:627:38 | call to source :  | array_flow.rb:627:5:627:5 | a [element 2] :  |
+| array_flow.rb:627:27:627:38 | call to source :  | array_flow.rb:627:5:627:5 | a [element 2] :  |
+| array_flow.rb:628:5:628:5 | b :  | array_flow.rb:633:10:633:10 | b |
+| array_flow.rb:628:5:628:5 | b :  | array_flow.rb:633:10:633:10 | b |
 | array_flow.rb:628:9:628:9 | a [element 0] :  | array_flow.rb:628:22:628:22 | x :  |
 | array_flow.rb:628:9:628:9 | a [element 0] :  | array_flow.rb:628:22:628:22 | x :  |
 | array_flow.rb:628:9:628:9 | a [element 2] :  | array_flow.rb:628:25:628:25 | y :  |
 | array_flow.rb:628:9:628:9 | a [element 2] :  | array_flow.rb:628:25:628:25 | y :  |
-| array_flow.rb:628:9:632:7 | call to inject :  | array_flow.rb:633:10:633:10 | b |
-| array_flow.rb:628:9:632:7 | call to inject :  | array_flow.rb:633:10:633:10 | b |
+| array_flow.rb:628:9:632:7 | call to inject :  | array_flow.rb:628:5:628:5 | b :  |
+| array_flow.rb:628:9:632:7 | call to inject :  | array_flow.rb:628:5:628:5 | b :  |
 | array_flow.rb:628:22:628:22 | x :  | array_flow.rb:629:14:629:14 | x |
 | array_flow.rb:628:22:628:22 | x :  | array_flow.rb:629:14:629:14 | x |
 | array_flow.rb:628:25:628:25 | y :  | array_flow.rb:630:14:630:14 | y |
 | array_flow.rb:628:25:628:25 | y :  | array_flow.rb:630:14:630:14 | y |
 | array_flow.rb:631:9:631:19 | call to source :  | array_flow.rb:628:9:632:7 | call to inject :  |
 | array_flow.rb:631:9:631:19 | call to source :  | array_flow.rb:628:9:632:7 | call to inject :  |
+| array_flow.rb:634:5:634:5 | c :  | array_flow.rb:639:10:639:10 | c |
+| array_flow.rb:634:5:634:5 | c :  | array_flow.rb:639:10:639:10 | c |
 | array_flow.rb:634:9:634:9 | a [element 0] :  | array_flow.rb:634:28:634:28 | y :  |
 | array_flow.rb:634:9:634:9 | a [element 0] :  | array_flow.rb:634:28:634:28 | y :  |
 | array_flow.rb:634:9:634:9 | a [element 2] :  | array_flow.rb:634:28:634:28 | y :  |
 | array_flow.rb:634:9:634:9 | a [element 2] :  | array_flow.rb:634:28:634:28 | y :  |
-| array_flow.rb:634:9:638:7 | call to inject :  | array_flow.rb:639:10:639:10 | c |
-| array_flow.rb:634:9:638:7 | call to inject :  | array_flow.rb:639:10:639:10 | c |
+| array_flow.rb:634:9:638:7 | call to inject :  | array_flow.rb:634:5:634:5 | c :  |
+| array_flow.rb:634:9:638:7 | call to inject :  | array_flow.rb:634:5:634:5 | c :  |
 | array_flow.rb:634:28:634:28 | y :  | array_flow.rb:636:14:636:14 | y |
 | array_flow.rb:634:28:634:28 | y :  | array_flow.rb:636:14:636:14 | y |
 | array_flow.rb:637:9:637:19 | call to source :  | array_flow.rb:634:9:638:7 | call to inject :  |
 | array_flow.rb:637:9:637:19 | call to source :  | array_flow.rb:634:9:638:7 | call to inject :  |
-| array_flow.rb:644:16:644:27 | call to source :  | array_flow.rb:645:9:645:9 | a [element 2] :  |
-| array_flow.rb:644:16:644:27 | call to source :  | array_flow.rb:645:9:645:9 | a [element 2] :  |
+| array_flow.rb:644:5:644:5 | a [element 2] :  | array_flow.rb:645:9:645:9 | a [element 2] :  |
+| array_flow.rb:644:5:644:5 | a [element 2] :  | array_flow.rb:645:9:645:9 | a [element 2] :  |
+| array_flow.rb:644:16:644:27 | call to source :  | array_flow.rb:644:5:644:5 | a [element 2] :  |
+| array_flow.rb:644:16:644:27 | call to source :  | array_flow.rb:644:5:644:5 | a [element 2] :  |
+| array_flow.rb:645:5:645:5 | b [element 1] :  | array_flow.rb:652:10:652:10 | b [element 1] :  |
+| array_flow.rb:645:5:645:5 | b [element 1] :  | array_flow.rb:652:10:652:10 | b [element 1] :  |
+| array_flow.rb:645:5:645:5 | b [element 2] :  | array_flow.rb:653:10:653:10 | b [element 2] :  |
+| array_flow.rb:645:5:645:5 | b [element 2] :  | array_flow.rb:653:10:653:10 | b [element 2] :  |
+| array_flow.rb:645:5:645:5 | b [element 4] :  | array_flow.rb:655:10:655:10 | b [element 4] :  |
+| array_flow.rb:645:5:645:5 | b [element 4] :  | array_flow.rb:655:10:655:10 | b [element 4] :  |
 | array_flow.rb:645:9:645:9 | [post] a [element 1] :  | array_flow.rb:647:10:647:10 | a [element 1] :  |
 | array_flow.rb:645:9:645:9 | [post] a [element 1] :  | array_flow.rb:647:10:647:10 | a [element 1] :  |
 | array_flow.rb:645:9:645:9 | [post] a [element 2] :  | array_flow.rb:648:10:648:10 | a [element 2] :  |
@@ -1168,12 +1489,12 @@ edges
 | array_flow.rb:645:9:645:9 | a [element 2] :  | array_flow.rb:645:9:645:9 | [post] a [element 4] :  |
 | array_flow.rb:645:9:645:9 | a [element 2] :  | array_flow.rb:645:9:645:47 | call to insert [element 4] :  |
 | array_flow.rb:645:9:645:9 | a [element 2] :  | array_flow.rb:645:9:645:47 | call to insert [element 4] :  |
-| array_flow.rb:645:9:645:47 | call to insert [element 1] :  | array_flow.rb:652:10:652:10 | b [element 1] :  |
-| array_flow.rb:645:9:645:47 | call to insert [element 1] :  | array_flow.rb:652:10:652:10 | b [element 1] :  |
-| array_flow.rb:645:9:645:47 | call to insert [element 2] :  | array_flow.rb:653:10:653:10 | b [element 2] :  |
-| array_flow.rb:645:9:645:47 | call to insert [element 2] :  | array_flow.rb:653:10:653:10 | b [element 2] :  |
-| array_flow.rb:645:9:645:47 | call to insert [element 4] :  | array_flow.rb:655:10:655:10 | b [element 4] :  |
-| array_flow.rb:645:9:645:47 | call to insert [element 4] :  | array_flow.rb:655:10:655:10 | b [element 4] :  |
+| array_flow.rb:645:9:645:47 | call to insert [element 1] :  | array_flow.rb:645:5:645:5 | b [element 1] :  |
+| array_flow.rb:645:9:645:47 | call to insert [element 1] :  | array_flow.rb:645:5:645:5 | b [element 1] :  |
+| array_flow.rb:645:9:645:47 | call to insert [element 2] :  | array_flow.rb:645:5:645:5 | b [element 2] :  |
+| array_flow.rb:645:9:645:47 | call to insert [element 2] :  | array_flow.rb:645:5:645:5 | b [element 2] :  |
+| array_flow.rb:645:9:645:47 | call to insert [element 4] :  | array_flow.rb:645:5:645:5 | b [element 4] :  |
+| array_flow.rb:645:9:645:47 | call to insert [element 4] :  | array_flow.rb:645:5:645:5 | b [element 4] :  |
 | array_flow.rb:645:21:645:32 | call to source :  | array_flow.rb:645:9:645:9 | [post] a [element 1] :  |
 | array_flow.rb:645:21:645:32 | call to source :  | array_flow.rb:645:9:645:9 | [post] a [element 1] :  |
 | array_flow.rb:645:21:645:32 | call to source :  | array_flow.rb:645:9:645:47 | call to insert [element 1] :  |
@@ -1194,16 +1515,20 @@ edges
 | array_flow.rb:653:10:653:10 | b [element 2] :  | array_flow.rb:653:10:653:13 | ...[...] |
 | array_flow.rb:655:10:655:10 | b [element 4] :  | array_flow.rb:655:10:655:13 | ...[...] |
 | array_flow.rb:655:10:655:10 | b [element 4] :  | array_flow.rb:655:10:655:13 | ...[...] |
-| array_flow.rb:658:16:658:27 | call to source :  | array_flow.rb:659:9:659:9 | c [element 2] :  |
-| array_flow.rb:658:16:658:27 | call to source :  | array_flow.rb:659:9:659:9 | c [element 2] :  |
+| array_flow.rb:658:5:658:5 | c [element 2] :  | array_flow.rb:659:9:659:9 | c [element 2] :  |
+| array_flow.rb:658:5:658:5 | c [element 2] :  | array_flow.rb:659:9:659:9 | c [element 2] :  |
+| array_flow.rb:658:16:658:27 | call to source :  | array_flow.rb:658:5:658:5 | c [element 2] :  |
+| array_flow.rb:658:16:658:27 | call to source :  | array_flow.rb:658:5:658:5 | c [element 2] :  |
+| array_flow.rb:659:5:659:5 | d [element] :  | array_flow.rb:661:10:661:10 | d [element] :  |
+| array_flow.rb:659:5:659:5 | d [element] :  | array_flow.rb:661:10:661:10 | d [element] :  |
 | array_flow.rb:659:9:659:9 | [post] c [element] :  | array_flow.rb:660:10:660:10 | c [element] :  |
 | array_flow.rb:659:9:659:9 | [post] c [element] :  | array_flow.rb:660:10:660:10 | c [element] :  |
 | array_flow.rb:659:9:659:9 | c [element 2] :  | array_flow.rb:659:9:659:9 | [post] c [element] :  |
 | array_flow.rb:659:9:659:9 | c [element 2] :  | array_flow.rb:659:9:659:9 | [post] c [element] :  |
 | array_flow.rb:659:9:659:9 | c [element 2] :  | array_flow.rb:659:9:659:47 | call to insert [element] :  |
 | array_flow.rb:659:9:659:9 | c [element 2] :  | array_flow.rb:659:9:659:47 | call to insert [element] :  |
-| array_flow.rb:659:9:659:47 | call to insert [element] :  | array_flow.rb:661:10:661:10 | d [element] :  |
-| array_flow.rb:659:9:659:47 | call to insert [element] :  | array_flow.rb:661:10:661:10 | d [element] :  |
+| array_flow.rb:659:9:659:47 | call to insert [element] :  | array_flow.rb:659:5:659:5 | d [element] :  |
+| array_flow.rb:659:9:659:47 | call to insert [element] :  | array_flow.rb:659:5:659:5 | d [element] :  |
 | array_flow.rb:659:21:659:32 | call to source :  | array_flow.rb:659:9:659:9 | [post] c [element] :  |
 | array_flow.rb:659:21:659:32 | call to source :  | array_flow.rb:659:9:659:9 | [post] c [element] :  |
 | array_flow.rb:659:21:659:32 | call to source :  | array_flow.rb:659:9:659:47 | call to insert [element] :  |
@@ -1216,20 +1541,28 @@ edges
 | array_flow.rb:660:10:660:10 | c [element] :  | array_flow.rb:660:10:660:13 | ...[...] |
 | array_flow.rb:661:10:661:10 | d [element] :  | array_flow.rb:661:10:661:13 | ...[...] |
 | array_flow.rb:661:10:661:10 | d [element] :  | array_flow.rb:661:10:661:13 | ...[...] |
-| array_flow.rb:672:16:672:27 | call to source :  | array_flow.rb:673:9:673:9 | a [element 2] :  |
-| array_flow.rb:672:16:672:27 | call to source :  | array_flow.rb:673:9:673:9 | a [element 2] :  |
+| array_flow.rb:672:5:672:5 | a [element 2] :  | array_flow.rb:673:9:673:9 | a [element 2] :  |
+| array_flow.rb:672:5:672:5 | a [element 2] :  | array_flow.rb:673:9:673:9 | a [element 2] :  |
+| array_flow.rb:672:16:672:27 | call to source :  | array_flow.rb:672:5:672:5 | a [element 2] :  |
+| array_flow.rb:672:16:672:27 | call to source :  | array_flow.rb:672:5:672:5 | a [element 2] :  |
+| array_flow.rb:673:5:673:5 | b [element] :  | array_flow.rb:674:10:674:10 | b [element] :  |
+| array_flow.rb:673:5:673:5 | b [element] :  | array_flow.rb:674:10:674:10 | b [element] :  |
 | array_flow.rb:673:9:673:9 | a [element 2] :  | array_flow.rb:673:9:673:60 | call to intersection [element] :  |
 | array_flow.rb:673:9:673:9 | a [element 2] :  | array_flow.rb:673:9:673:60 | call to intersection [element] :  |
-| array_flow.rb:673:9:673:60 | call to intersection [element] :  | array_flow.rb:674:10:674:10 | b [element] :  |
-| array_flow.rb:673:9:673:60 | call to intersection [element] :  | array_flow.rb:674:10:674:10 | b [element] :  |
+| array_flow.rb:673:9:673:60 | call to intersection [element] :  | array_flow.rb:673:5:673:5 | b [element] :  |
+| array_flow.rb:673:9:673:60 | call to intersection [element] :  | array_flow.rb:673:5:673:5 | b [element] :  |
 | array_flow.rb:673:31:673:42 | call to source :  | array_flow.rb:673:9:673:60 | call to intersection [element] :  |
 | array_flow.rb:673:31:673:42 | call to source :  | array_flow.rb:673:9:673:60 | call to intersection [element] :  |
 | array_flow.rb:673:47:673:58 | call to source :  | array_flow.rb:673:9:673:60 | call to intersection [element] :  |
 | array_flow.rb:673:47:673:58 | call to source :  | array_flow.rb:673:9:673:60 | call to intersection [element] :  |
 | array_flow.rb:674:10:674:10 | b [element] :  | array_flow.rb:674:10:674:13 | ...[...] |
 | array_flow.rb:674:10:674:10 | b [element] :  | array_flow.rb:674:10:674:13 | ...[...] |
-| array_flow.rb:678:16:678:25 | call to source :  | array_flow.rb:679:9:679:9 | a [element 2] :  |
-| array_flow.rb:678:16:678:25 | call to source :  | array_flow.rb:679:9:679:9 | a [element 2] :  |
+| array_flow.rb:678:5:678:5 | a [element 2] :  | array_flow.rb:679:9:679:9 | a [element 2] :  |
+| array_flow.rb:678:5:678:5 | a [element 2] :  | array_flow.rb:679:9:679:9 | a [element 2] :  |
+| array_flow.rb:678:16:678:25 | call to source :  | array_flow.rb:678:5:678:5 | a [element 2] :  |
+| array_flow.rb:678:16:678:25 | call to source :  | array_flow.rb:678:5:678:5 | a [element 2] :  |
+| array_flow.rb:679:5:679:5 | b [element] :  | array_flow.rb:684:10:684:10 | b [element] :  |
+| array_flow.rb:679:5:679:5 | b [element] :  | array_flow.rb:684:10:684:10 | b [element] :  |
 | array_flow.rb:679:9:679:9 | [post] a [element] :  | array_flow.rb:683:10:683:10 | a [element] :  |
 | array_flow.rb:679:9:679:9 | [post] a [element] :  | array_flow.rb:683:10:683:10 | a [element] :  |
 | array_flow.rb:679:9:679:9 | a [element 2] :  | array_flow.rb:679:9:679:9 | [post] a [element] :  |
@@ -1238,18 +1571,20 @@ edges
 | array_flow.rb:679:9:679:9 | a [element 2] :  | array_flow.rb:679:9:682:7 | call to keep_if [element] :  |
 | array_flow.rb:679:9:679:9 | a [element 2] :  | array_flow.rb:679:23:679:23 | x :  |
 | array_flow.rb:679:9:679:9 | a [element 2] :  | array_flow.rb:679:23:679:23 | x :  |
-| array_flow.rb:679:9:682:7 | call to keep_if [element] :  | array_flow.rb:684:10:684:10 | b [element] :  |
-| array_flow.rb:679:9:682:7 | call to keep_if [element] :  | array_flow.rb:684:10:684:10 | b [element] :  |
+| array_flow.rb:679:9:682:7 | call to keep_if [element] :  | array_flow.rb:679:5:679:5 | b [element] :  |
+| array_flow.rb:679:9:682:7 | call to keep_if [element] :  | array_flow.rb:679:5:679:5 | b [element] :  |
 | array_flow.rb:679:23:679:23 | x :  | array_flow.rb:680:14:680:14 | x |
 | array_flow.rb:679:23:679:23 | x :  | array_flow.rb:680:14:680:14 | x |
 | array_flow.rb:683:10:683:10 | a [element] :  | array_flow.rb:683:10:683:13 | ...[...] |
 | array_flow.rb:683:10:683:10 | a [element] :  | array_flow.rb:683:10:683:13 | ...[...] |
 | array_flow.rb:684:10:684:10 | b [element] :  | array_flow.rb:684:10:684:13 | ...[...] |
 | array_flow.rb:684:10:684:10 | b [element] :  | array_flow.rb:684:10:684:13 | ...[...] |
-| array_flow.rb:688:16:688:27 | call to source :  | array_flow.rb:690:10:690:10 | a [element 2] :  |
-| array_flow.rb:688:16:688:27 | call to source :  | array_flow.rb:690:10:690:10 | a [element 2] :  |
-| array_flow.rb:688:16:688:27 | call to source :  | array_flow.rb:691:9:691:9 | a [element 2] :  |
-| array_flow.rb:688:16:688:27 | call to source :  | array_flow.rb:691:9:691:9 | a [element 2] :  |
+| array_flow.rb:688:5:688:5 | a [element 2] :  | array_flow.rb:690:10:690:10 | a [element 2] :  |
+| array_flow.rb:688:5:688:5 | a [element 2] :  | array_flow.rb:690:10:690:10 | a [element 2] :  |
+| array_flow.rb:688:5:688:5 | a [element 2] :  | array_flow.rb:691:9:691:9 | a [element 2] :  |
+| array_flow.rb:688:5:688:5 | a [element 2] :  | array_flow.rb:691:9:691:9 | a [element 2] :  |
+| array_flow.rb:688:16:688:27 | call to source :  | array_flow.rb:688:5:688:5 | a [element 2] :  |
+| array_flow.rb:688:16:688:27 | call to source :  | array_flow.rb:688:5:688:5 | a [element 2] :  |
 | array_flow.rb:689:5:689:5 | [post] a [element] :  | array_flow.rb:690:10:690:10 | a [element] :  |
 | array_flow.rb:689:5:689:5 | [post] a [element] :  | array_flow.rb:690:10:690:10 | a [element] :  |
 | array_flow.rb:689:5:689:5 | [post] a [element] :  | array_flow.rb:691:9:691:9 | a [element] :  |
@@ -1260,198 +1595,246 @@ edges
 | array_flow.rb:690:10:690:10 | a [element 2] :  | array_flow.rb:690:10:690:15 | call to last |
 | array_flow.rb:690:10:690:10 | a [element] :  | array_flow.rb:690:10:690:15 | call to last |
 | array_flow.rb:690:10:690:10 | a [element] :  | array_flow.rb:690:10:690:15 | call to last |
+| array_flow.rb:691:5:691:5 | b [element] :  | array_flow.rb:692:10:692:10 | b [element] :  |
+| array_flow.rb:691:5:691:5 | b [element] :  | array_flow.rb:692:10:692:10 | b [element] :  |
+| array_flow.rb:691:5:691:5 | b [element] :  | array_flow.rb:693:10:693:10 | b [element] :  |
+| array_flow.rb:691:5:691:5 | b [element] :  | array_flow.rb:693:10:693:10 | b [element] :  |
 | array_flow.rb:691:9:691:9 | a [element 2] :  | array_flow.rb:691:9:691:17 | call to last [element] :  |
 | array_flow.rb:691:9:691:9 | a [element 2] :  | array_flow.rb:691:9:691:17 | call to last [element] :  |
 | array_flow.rb:691:9:691:9 | a [element] :  | array_flow.rb:691:9:691:17 | call to last [element] :  |
 | array_flow.rb:691:9:691:9 | a [element] :  | array_flow.rb:691:9:691:17 | call to last [element] :  |
-| array_flow.rb:691:9:691:17 | call to last [element] :  | array_flow.rb:692:10:692:10 | b [element] :  |
-| array_flow.rb:691:9:691:17 | call to last [element] :  | array_flow.rb:692:10:692:10 | b [element] :  |
-| array_flow.rb:691:9:691:17 | call to last [element] :  | array_flow.rb:693:10:693:10 | b [element] :  |
-| array_flow.rb:691:9:691:17 | call to last [element] :  | array_flow.rb:693:10:693:10 | b [element] :  |
+| array_flow.rb:691:9:691:17 | call to last [element] :  | array_flow.rb:691:5:691:5 | b [element] :  |
+| array_flow.rb:691:9:691:17 | call to last [element] :  | array_flow.rb:691:5:691:5 | b [element] :  |
 | array_flow.rb:692:10:692:10 | b [element] :  | array_flow.rb:692:10:692:13 | ...[...] |
 | array_flow.rb:692:10:692:10 | b [element] :  | array_flow.rb:692:10:692:13 | ...[...] |
 | array_flow.rb:693:10:693:10 | b [element] :  | array_flow.rb:693:10:693:13 | ...[...] |
 | array_flow.rb:693:10:693:10 | b [element] :  | array_flow.rb:693:10:693:13 | ...[...] |
-| array_flow.rb:697:16:697:27 | call to source :  | array_flow.rb:698:9:698:9 | a [element 2] :  |
-| array_flow.rb:697:16:697:27 | call to source :  | array_flow.rb:698:9:698:9 | a [element 2] :  |
+| array_flow.rb:697:5:697:5 | a [element 2] :  | array_flow.rb:698:9:698:9 | a [element 2] :  |
+| array_flow.rb:697:5:697:5 | a [element 2] :  | array_flow.rb:698:9:698:9 | a [element 2] :  |
+| array_flow.rb:697:16:697:27 | call to source :  | array_flow.rb:697:5:697:5 | a [element 2] :  |
+| array_flow.rb:697:16:697:27 | call to source :  | array_flow.rb:697:5:697:5 | a [element 2] :  |
+| array_flow.rb:698:5:698:5 | b [element] :  | array_flow.rb:702:10:702:10 | b [element] :  |
+| array_flow.rb:698:5:698:5 | b [element] :  | array_flow.rb:702:10:702:10 | b [element] :  |
 | array_flow.rb:698:9:698:9 | a [element 2] :  | array_flow.rb:698:19:698:19 | x :  |
 | array_flow.rb:698:9:698:9 | a [element 2] :  | array_flow.rb:698:19:698:19 | x :  |
-| array_flow.rb:698:9:701:7 | call to map [element] :  | array_flow.rb:702:10:702:10 | b [element] :  |
-| array_flow.rb:698:9:701:7 | call to map [element] :  | array_flow.rb:702:10:702:10 | b [element] :  |
+| array_flow.rb:698:9:701:7 | call to map [element] :  | array_flow.rb:698:5:698:5 | b [element] :  |
+| array_flow.rb:698:9:701:7 | call to map [element] :  | array_flow.rb:698:5:698:5 | b [element] :  |
 | array_flow.rb:698:19:698:19 | x :  | array_flow.rb:699:14:699:14 | x |
 | array_flow.rb:698:19:698:19 | x :  | array_flow.rb:699:14:699:14 | x |
 | array_flow.rb:700:9:700:19 | call to source :  | array_flow.rb:698:9:701:7 | call to map [element] :  |
 | array_flow.rb:700:9:700:19 | call to source :  | array_flow.rb:698:9:701:7 | call to map [element] :  |
 | array_flow.rb:702:10:702:10 | b [element] :  | array_flow.rb:702:10:702:13 | ...[...] |
 | array_flow.rb:702:10:702:10 | b [element] :  | array_flow.rb:702:10:702:13 | ...[...] |
-| array_flow.rb:706:16:706:27 | call to source :  | array_flow.rb:707:9:707:9 | a [element 2] :  |
-| array_flow.rb:706:16:706:27 | call to source :  | array_flow.rb:707:9:707:9 | a [element 2] :  |
+| array_flow.rb:706:5:706:5 | a [element 2] :  | array_flow.rb:707:9:707:9 | a [element 2] :  |
+| array_flow.rb:706:5:706:5 | a [element 2] :  | array_flow.rb:707:9:707:9 | a [element 2] :  |
+| array_flow.rb:706:16:706:27 | call to source :  | array_flow.rb:706:5:706:5 | a [element 2] :  |
+| array_flow.rb:706:16:706:27 | call to source :  | array_flow.rb:706:5:706:5 | a [element 2] :  |
+| array_flow.rb:707:5:707:5 | b [element] :  | array_flow.rb:711:10:711:10 | b [element] :  |
+| array_flow.rb:707:5:707:5 | b [element] :  | array_flow.rb:711:10:711:10 | b [element] :  |
 | array_flow.rb:707:9:707:9 | a [element 2] :  | array_flow.rb:707:20:707:20 | x :  |
 | array_flow.rb:707:9:707:9 | a [element 2] :  | array_flow.rb:707:20:707:20 | x :  |
-| array_flow.rb:707:9:710:7 | call to map! [element] :  | array_flow.rb:711:10:711:10 | b [element] :  |
-| array_flow.rb:707:9:710:7 | call to map! [element] :  | array_flow.rb:711:10:711:10 | b [element] :  |
+| array_flow.rb:707:9:710:7 | call to map! [element] :  | array_flow.rb:707:5:707:5 | b [element] :  |
+| array_flow.rb:707:9:710:7 | call to map! [element] :  | array_flow.rb:707:5:707:5 | b [element] :  |
 | array_flow.rb:707:20:707:20 | x :  | array_flow.rb:708:14:708:14 | x |
 | array_flow.rb:707:20:707:20 | x :  | array_flow.rb:708:14:708:14 | x |
 | array_flow.rb:709:9:709:19 | call to source :  | array_flow.rb:707:9:710:7 | call to map! [element] :  |
 | array_flow.rb:709:9:709:19 | call to source :  | array_flow.rb:707:9:710:7 | call to map! [element] :  |
 | array_flow.rb:711:10:711:10 | b [element] :  | array_flow.rb:711:10:711:13 | ...[...] |
 | array_flow.rb:711:10:711:10 | b [element] :  | array_flow.rb:711:10:711:13 | ...[...] |
-| array_flow.rb:715:16:715:25 | call to source :  | array_flow.rb:718:9:718:9 | a [element 2] :  |
-| array_flow.rb:715:16:715:25 | call to source :  | array_flow.rb:718:9:718:9 | a [element 2] :  |
-| array_flow.rb:715:16:715:25 | call to source :  | array_flow.rb:722:9:722:9 | a [element 2] :  |
-| array_flow.rb:715:16:715:25 | call to source :  | array_flow.rb:722:9:722:9 | a [element 2] :  |
-| array_flow.rb:715:16:715:25 | call to source :  | array_flow.rb:726:9:726:9 | a [element 2] :  |
-| array_flow.rb:715:16:715:25 | call to source :  | array_flow.rb:726:9:726:9 | a [element 2] :  |
-| array_flow.rb:715:16:715:25 | call to source :  | array_flow.rb:734:9:734:9 | a [element 2] :  |
-| array_flow.rb:715:16:715:25 | call to source :  | array_flow.rb:734:9:734:9 | a [element 2] :  |
+| array_flow.rb:715:5:715:5 | a [element 2] :  | array_flow.rb:718:9:718:9 | a [element 2] :  |
+| array_flow.rb:715:5:715:5 | a [element 2] :  | array_flow.rb:718:9:718:9 | a [element 2] :  |
+| array_flow.rb:715:5:715:5 | a [element 2] :  | array_flow.rb:722:9:722:9 | a [element 2] :  |
+| array_flow.rb:715:5:715:5 | a [element 2] :  | array_flow.rb:722:9:722:9 | a [element 2] :  |
+| array_flow.rb:715:5:715:5 | a [element 2] :  | array_flow.rb:726:9:726:9 | a [element 2] :  |
+| array_flow.rb:715:5:715:5 | a [element 2] :  | array_flow.rb:726:9:726:9 | a [element 2] :  |
+| array_flow.rb:715:5:715:5 | a [element 2] :  | array_flow.rb:734:9:734:9 | a [element 2] :  |
+| array_flow.rb:715:5:715:5 | a [element 2] :  | array_flow.rb:734:9:734:9 | a [element 2] :  |
+| array_flow.rb:715:16:715:25 | call to source :  | array_flow.rb:715:5:715:5 | a [element 2] :  |
+| array_flow.rb:715:16:715:25 | call to source :  | array_flow.rb:715:5:715:5 | a [element 2] :  |
+| array_flow.rb:718:5:718:5 | b :  | array_flow.rb:719:10:719:10 | b |
+| array_flow.rb:718:5:718:5 | b :  | array_flow.rb:719:10:719:10 | b |
 | array_flow.rb:718:9:718:9 | a [element 2] :  | array_flow.rb:718:9:718:13 | call to max :  |
 | array_flow.rb:718:9:718:9 | a [element 2] :  | array_flow.rb:718:9:718:13 | call to max :  |
-| array_flow.rb:718:9:718:13 | call to max :  | array_flow.rb:719:10:719:10 | b |
-| array_flow.rb:718:9:718:13 | call to max :  | array_flow.rb:719:10:719:10 | b |
+| array_flow.rb:718:9:718:13 | call to max :  | array_flow.rb:718:5:718:5 | b :  |
+| array_flow.rb:718:9:718:13 | call to max :  | array_flow.rb:718:5:718:5 | b :  |
+| array_flow.rb:722:5:722:5 | c [element] :  | array_flow.rb:723:10:723:10 | c [element] :  |
+| array_flow.rb:722:5:722:5 | c [element] :  | array_flow.rb:723:10:723:10 | c [element] :  |
 | array_flow.rb:722:9:722:9 | a [element 2] :  | array_flow.rb:722:9:722:16 | call to max [element] :  |
 | array_flow.rb:722:9:722:9 | a [element 2] :  | array_flow.rb:722:9:722:16 | call to max [element] :  |
-| array_flow.rb:722:9:722:16 | call to max [element] :  | array_flow.rb:723:10:723:10 | c [element] :  |
-| array_flow.rb:722:9:722:16 | call to max [element] :  | array_flow.rb:723:10:723:10 | c [element] :  |
+| array_flow.rb:722:9:722:16 | call to max [element] :  | array_flow.rb:722:5:722:5 | c [element] :  |
+| array_flow.rb:722:9:722:16 | call to max [element] :  | array_flow.rb:722:5:722:5 | c [element] :  |
 | array_flow.rb:723:10:723:10 | c [element] :  | array_flow.rb:723:10:723:13 | ...[...] |
 | array_flow.rb:723:10:723:10 | c [element] :  | array_flow.rb:723:10:723:13 | ...[...] |
+| array_flow.rb:726:5:726:5 | d :  | array_flow.rb:731:10:731:10 | d |
+| array_flow.rb:726:5:726:5 | d :  | array_flow.rb:731:10:731:10 | d |
 | array_flow.rb:726:9:726:9 | a [element 2] :  | array_flow.rb:726:9:730:7 | call to max :  |
 | array_flow.rb:726:9:726:9 | a [element 2] :  | array_flow.rb:726:9:730:7 | call to max :  |
 | array_flow.rb:726:9:726:9 | a [element 2] :  | array_flow.rb:726:19:726:19 | x :  |
 | array_flow.rb:726:9:726:9 | a [element 2] :  | array_flow.rb:726:19:726:19 | x :  |
 | array_flow.rb:726:9:726:9 | a [element 2] :  | array_flow.rb:726:22:726:22 | y :  |
 | array_flow.rb:726:9:726:9 | a [element 2] :  | array_flow.rb:726:22:726:22 | y :  |
-| array_flow.rb:726:9:730:7 | call to max :  | array_flow.rb:731:10:731:10 | d |
-| array_flow.rb:726:9:730:7 | call to max :  | array_flow.rb:731:10:731:10 | d |
+| array_flow.rb:726:9:730:7 | call to max :  | array_flow.rb:726:5:726:5 | d :  |
+| array_flow.rb:726:9:730:7 | call to max :  | array_flow.rb:726:5:726:5 | d :  |
 | array_flow.rb:726:19:726:19 | x :  | array_flow.rb:727:14:727:14 | x |
 | array_flow.rb:726:19:726:19 | x :  | array_flow.rb:727:14:727:14 | x |
 | array_flow.rb:726:22:726:22 | y :  | array_flow.rb:728:14:728:14 | y |
 | array_flow.rb:726:22:726:22 | y :  | array_flow.rb:728:14:728:14 | y |
+| array_flow.rb:734:5:734:5 | e [element] :  | array_flow.rb:739:10:739:10 | e [element] :  |
+| array_flow.rb:734:5:734:5 | e [element] :  | array_flow.rb:739:10:739:10 | e [element] :  |
 | array_flow.rb:734:9:734:9 | a [element 2] :  | array_flow.rb:734:9:738:7 | call to max [element] :  |
 | array_flow.rb:734:9:734:9 | a [element 2] :  | array_flow.rb:734:9:738:7 | call to max [element] :  |
 | array_flow.rb:734:9:734:9 | a [element 2] :  | array_flow.rb:734:22:734:22 | x :  |
 | array_flow.rb:734:9:734:9 | a [element 2] :  | array_flow.rb:734:22:734:22 | x :  |
 | array_flow.rb:734:9:734:9 | a [element 2] :  | array_flow.rb:734:25:734:25 | y :  |
 | array_flow.rb:734:9:734:9 | a [element 2] :  | array_flow.rb:734:25:734:25 | y :  |
-| array_flow.rb:734:9:738:7 | call to max [element] :  | array_flow.rb:739:10:739:10 | e [element] :  |
-| array_flow.rb:734:9:738:7 | call to max [element] :  | array_flow.rb:739:10:739:10 | e [element] :  |
+| array_flow.rb:734:9:738:7 | call to max [element] :  | array_flow.rb:734:5:734:5 | e [element] :  |
+| array_flow.rb:734:9:738:7 | call to max [element] :  | array_flow.rb:734:5:734:5 | e [element] :  |
 | array_flow.rb:734:22:734:22 | x :  | array_flow.rb:735:14:735:14 | x |
 | array_flow.rb:734:22:734:22 | x :  | array_flow.rb:735:14:735:14 | x |
 | array_flow.rb:734:25:734:25 | y :  | array_flow.rb:736:14:736:14 | y |
 | array_flow.rb:734:25:734:25 | y :  | array_flow.rb:736:14:736:14 | y |
 | array_flow.rb:739:10:739:10 | e [element] :  | array_flow.rb:739:10:739:13 | ...[...] |
 | array_flow.rb:739:10:739:10 | e [element] :  | array_flow.rb:739:10:739:13 | ...[...] |
-| array_flow.rb:743:16:743:25 | call to source :  | array_flow.rb:746:9:746:9 | a [element 2] :  |
-| array_flow.rb:743:16:743:25 | call to source :  | array_flow.rb:746:9:746:9 | a [element 2] :  |
-| array_flow.rb:743:16:743:25 | call to source :  | array_flow.rb:753:9:753:9 | a [element 2] :  |
-| array_flow.rb:743:16:743:25 | call to source :  | array_flow.rb:753:9:753:9 | a [element 2] :  |
+| array_flow.rb:743:5:743:5 | a [element 2] :  | array_flow.rb:746:9:746:9 | a [element 2] :  |
+| array_flow.rb:743:5:743:5 | a [element 2] :  | array_flow.rb:746:9:746:9 | a [element 2] :  |
+| array_flow.rb:743:5:743:5 | a [element 2] :  | array_flow.rb:753:9:753:9 | a [element 2] :  |
+| array_flow.rb:743:5:743:5 | a [element 2] :  | array_flow.rb:753:9:753:9 | a [element 2] :  |
+| array_flow.rb:743:16:743:25 | call to source :  | array_flow.rb:743:5:743:5 | a [element 2] :  |
+| array_flow.rb:743:16:743:25 | call to source :  | array_flow.rb:743:5:743:5 | a [element 2] :  |
+| array_flow.rb:746:5:746:5 | b :  | array_flow.rb:750:10:750:10 | b |
+| array_flow.rb:746:5:746:5 | b :  | array_flow.rb:750:10:750:10 | b |
 | array_flow.rb:746:9:746:9 | a [element 2] :  | array_flow.rb:746:9:749:7 | call to max_by :  |
 | array_flow.rb:746:9:746:9 | a [element 2] :  | array_flow.rb:746:9:749:7 | call to max_by :  |
 | array_flow.rb:746:9:746:9 | a [element 2] :  | array_flow.rb:746:22:746:22 | x :  |
 | array_flow.rb:746:9:746:9 | a [element 2] :  | array_flow.rb:746:22:746:22 | x :  |
-| array_flow.rb:746:9:749:7 | call to max_by :  | array_flow.rb:750:10:750:10 | b |
-| array_flow.rb:746:9:749:7 | call to max_by :  | array_flow.rb:750:10:750:10 | b |
+| array_flow.rb:746:9:749:7 | call to max_by :  | array_flow.rb:746:5:746:5 | b :  |
+| array_flow.rb:746:9:749:7 | call to max_by :  | array_flow.rb:746:5:746:5 | b :  |
 | array_flow.rb:746:22:746:22 | x :  | array_flow.rb:747:14:747:14 | x |
 | array_flow.rb:746:22:746:22 | x :  | array_flow.rb:747:14:747:14 | x |
+| array_flow.rb:753:5:753:5 | c [element] :  | array_flow.rb:757:10:757:10 | c [element] :  |
+| array_flow.rb:753:5:753:5 | c [element] :  | array_flow.rb:757:10:757:10 | c [element] :  |
 | array_flow.rb:753:9:753:9 | a [element 2] :  | array_flow.rb:753:9:756:7 | call to max_by [element] :  |
 | array_flow.rb:753:9:753:9 | a [element 2] :  | array_flow.rb:753:9:756:7 | call to max_by [element] :  |
 | array_flow.rb:753:9:753:9 | a [element 2] :  | array_flow.rb:753:25:753:25 | x :  |
 | array_flow.rb:753:9:753:9 | a [element 2] :  | array_flow.rb:753:25:753:25 | x :  |
-| array_flow.rb:753:9:756:7 | call to max_by [element] :  | array_flow.rb:757:10:757:10 | c [element] :  |
-| array_flow.rb:753:9:756:7 | call to max_by [element] :  | array_flow.rb:757:10:757:10 | c [element] :  |
+| array_flow.rb:753:9:756:7 | call to max_by [element] :  | array_flow.rb:753:5:753:5 | c [element] :  |
+| array_flow.rb:753:9:756:7 | call to max_by [element] :  | array_flow.rb:753:5:753:5 | c [element] :  |
 | array_flow.rb:753:25:753:25 | x :  | array_flow.rb:754:14:754:14 | x |
 | array_flow.rb:753:25:753:25 | x :  | array_flow.rb:754:14:754:14 | x |
 | array_flow.rb:757:10:757:10 | c [element] :  | array_flow.rb:757:10:757:13 | ...[...] |
 | array_flow.rb:757:10:757:10 | c [element] :  | array_flow.rb:757:10:757:13 | ...[...] |
-| array_flow.rb:761:16:761:25 | call to source :  | array_flow.rb:764:9:764:9 | a [element 2] :  |
-| array_flow.rb:761:16:761:25 | call to source :  | array_flow.rb:764:9:764:9 | a [element 2] :  |
-| array_flow.rb:761:16:761:25 | call to source :  | array_flow.rb:768:9:768:9 | a [element 2] :  |
-| array_flow.rb:761:16:761:25 | call to source :  | array_flow.rb:768:9:768:9 | a [element 2] :  |
-| array_flow.rb:761:16:761:25 | call to source :  | array_flow.rb:772:9:772:9 | a [element 2] :  |
-| array_flow.rb:761:16:761:25 | call to source :  | array_flow.rb:772:9:772:9 | a [element 2] :  |
-| array_flow.rb:761:16:761:25 | call to source :  | array_flow.rb:780:9:780:9 | a [element 2] :  |
-| array_flow.rb:761:16:761:25 | call to source :  | array_flow.rb:780:9:780:9 | a [element 2] :  |
+| array_flow.rb:761:5:761:5 | a [element 2] :  | array_flow.rb:764:9:764:9 | a [element 2] :  |
+| array_flow.rb:761:5:761:5 | a [element 2] :  | array_flow.rb:764:9:764:9 | a [element 2] :  |
+| array_flow.rb:761:5:761:5 | a [element 2] :  | array_flow.rb:768:9:768:9 | a [element 2] :  |
+| array_flow.rb:761:5:761:5 | a [element 2] :  | array_flow.rb:768:9:768:9 | a [element 2] :  |
+| array_flow.rb:761:5:761:5 | a [element 2] :  | array_flow.rb:772:9:772:9 | a [element 2] :  |
+| array_flow.rb:761:5:761:5 | a [element 2] :  | array_flow.rb:772:9:772:9 | a [element 2] :  |
+| array_flow.rb:761:5:761:5 | a [element 2] :  | array_flow.rb:780:9:780:9 | a [element 2] :  |
+| array_flow.rb:761:5:761:5 | a [element 2] :  | array_flow.rb:780:9:780:9 | a [element 2] :  |
+| array_flow.rb:761:16:761:25 | call to source :  | array_flow.rb:761:5:761:5 | a [element 2] :  |
+| array_flow.rb:761:16:761:25 | call to source :  | array_flow.rb:761:5:761:5 | a [element 2] :  |
+| array_flow.rb:764:5:764:5 | b :  | array_flow.rb:765:10:765:10 | b |
+| array_flow.rb:764:5:764:5 | b :  | array_flow.rb:765:10:765:10 | b |
 | array_flow.rb:764:9:764:9 | a [element 2] :  | array_flow.rb:764:9:764:13 | call to min :  |
 | array_flow.rb:764:9:764:9 | a [element 2] :  | array_flow.rb:764:9:764:13 | call to min :  |
-| array_flow.rb:764:9:764:13 | call to min :  | array_flow.rb:765:10:765:10 | b |
-| array_flow.rb:764:9:764:13 | call to min :  | array_flow.rb:765:10:765:10 | b |
+| array_flow.rb:764:9:764:13 | call to min :  | array_flow.rb:764:5:764:5 | b :  |
+| array_flow.rb:764:9:764:13 | call to min :  | array_flow.rb:764:5:764:5 | b :  |
+| array_flow.rb:768:5:768:5 | c [element] :  | array_flow.rb:769:10:769:10 | c [element] :  |
+| array_flow.rb:768:5:768:5 | c [element] :  | array_flow.rb:769:10:769:10 | c [element] :  |
 | array_flow.rb:768:9:768:9 | a [element 2] :  | array_flow.rb:768:9:768:16 | call to min [element] :  |
 | array_flow.rb:768:9:768:9 | a [element 2] :  | array_flow.rb:768:9:768:16 | call to min [element] :  |
-| array_flow.rb:768:9:768:16 | call to min [element] :  | array_flow.rb:769:10:769:10 | c [element] :  |
-| array_flow.rb:768:9:768:16 | call to min [element] :  | array_flow.rb:769:10:769:10 | c [element] :  |
+| array_flow.rb:768:9:768:16 | call to min [element] :  | array_flow.rb:768:5:768:5 | c [element] :  |
+| array_flow.rb:768:9:768:16 | call to min [element] :  | array_flow.rb:768:5:768:5 | c [element] :  |
 | array_flow.rb:769:10:769:10 | c [element] :  | array_flow.rb:769:10:769:13 | ...[...] |
 | array_flow.rb:769:10:769:10 | c [element] :  | array_flow.rb:769:10:769:13 | ...[...] |
+| array_flow.rb:772:5:772:5 | d :  | array_flow.rb:777:10:777:10 | d |
+| array_flow.rb:772:5:772:5 | d :  | array_flow.rb:777:10:777:10 | d |
 | array_flow.rb:772:9:772:9 | a [element 2] :  | array_flow.rb:772:9:776:7 | call to min :  |
 | array_flow.rb:772:9:772:9 | a [element 2] :  | array_flow.rb:772:9:776:7 | call to min :  |
 | array_flow.rb:772:9:772:9 | a [element 2] :  | array_flow.rb:772:19:772:19 | x :  |
 | array_flow.rb:772:9:772:9 | a [element 2] :  | array_flow.rb:772:19:772:19 | x :  |
 | array_flow.rb:772:9:772:9 | a [element 2] :  | array_flow.rb:772:22:772:22 | y :  |
 | array_flow.rb:772:9:772:9 | a [element 2] :  | array_flow.rb:772:22:772:22 | y :  |
-| array_flow.rb:772:9:776:7 | call to min :  | array_flow.rb:777:10:777:10 | d |
-| array_flow.rb:772:9:776:7 | call to min :  | array_flow.rb:777:10:777:10 | d |
+| array_flow.rb:772:9:776:7 | call to min :  | array_flow.rb:772:5:772:5 | d :  |
+| array_flow.rb:772:9:776:7 | call to min :  | array_flow.rb:772:5:772:5 | d :  |
 | array_flow.rb:772:19:772:19 | x :  | array_flow.rb:773:14:773:14 | x |
 | array_flow.rb:772:19:772:19 | x :  | array_flow.rb:773:14:773:14 | x |
 | array_flow.rb:772:22:772:22 | y :  | array_flow.rb:774:14:774:14 | y |
 | array_flow.rb:772:22:772:22 | y :  | array_flow.rb:774:14:774:14 | y |
+| array_flow.rb:780:5:780:5 | e [element] :  | array_flow.rb:785:10:785:10 | e [element] :  |
+| array_flow.rb:780:5:780:5 | e [element] :  | array_flow.rb:785:10:785:10 | e [element] :  |
 | array_flow.rb:780:9:780:9 | a [element 2] :  | array_flow.rb:780:9:784:7 | call to min [element] :  |
 | array_flow.rb:780:9:780:9 | a [element 2] :  | array_flow.rb:780:9:784:7 | call to min [element] :  |
 | array_flow.rb:780:9:780:9 | a [element 2] :  | array_flow.rb:780:22:780:22 | x :  |
 | array_flow.rb:780:9:780:9 | a [element 2] :  | array_flow.rb:780:22:780:22 | x :  |
 | array_flow.rb:780:9:780:9 | a [element 2] :  | array_flow.rb:780:25:780:25 | y :  |
 | array_flow.rb:780:9:780:9 | a [element 2] :  | array_flow.rb:780:25:780:25 | y :  |
-| array_flow.rb:780:9:784:7 | call to min [element] :  | array_flow.rb:785:10:785:10 | e [element] :  |
-| array_flow.rb:780:9:784:7 | call to min [element] :  | array_flow.rb:785:10:785:10 | e [element] :  |
+| array_flow.rb:780:9:784:7 | call to min [element] :  | array_flow.rb:780:5:780:5 | e [element] :  |
+| array_flow.rb:780:9:784:7 | call to min [element] :  | array_flow.rb:780:5:780:5 | e [element] :  |
 | array_flow.rb:780:22:780:22 | x :  | array_flow.rb:781:14:781:14 | x |
 | array_flow.rb:780:22:780:22 | x :  | array_flow.rb:781:14:781:14 | x |
 | array_flow.rb:780:25:780:25 | y :  | array_flow.rb:782:14:782:14 | y |
 | array_flow.rb:780:25:780:25 | y :  | array_flow.rb:782:14:782:14 | y |
 | array_flow.rb:785:10:785:10 | e [element] :  | array_flow.rb:785:10:785:13 | ...[...] |
 | array_flow.rb:785:10:785:10 | e [element] :  | array_flow.rb:785:10:785:13 | ...[...] |
-| array_flow.rb:789:16:789:25 | call to source :  | array_flow.rb:792:9:792:9 | a [element 2] :  |
-| array_flow.rb:789:16:789:25 | call to source :  | array_flow.rb:792:9:792:9 | a [element 2] :  |
-| array_flow.rb:789:16:789:25 | call to source :  | array_flow.rb:799:9:799:9 | a [element 2] :  |
-| array_flow.rb:789:16:789:25 | call to source :  | array_flow.rb:799:9:799:9 | a [element 2] :  |
+| array_flow.rb:789:5:789:5 | a [element 2] :  | array_flow.rb:792:9:792:9 | a [element 2] :  |
+| array_flow.rb:789:5:789:5 | a [element 2] :  | array_flow.rb:792:9:792:9 | a [element 2] :  |
+| array_flow.rb:789:5:789:5 | a [element 2] :  | array_flow.rb:799:9:799:9 | a [element 2] :  |
+| array_flow.rb:789:5:789:5 | a [element 2] :  | array_flow.rb:799:9:799:9 | a [element 2] :  |
+| array_flow.rb:789:16:789:25 | call to source :  | array_flow.rb:789:5:789:5 | a [element 2] :  |
+| array_flow.rb:789:16:789:25 | call to source :  | array_flow.rb:789:5:789:5 | a [element 2] :  |
+| array_flow.rb:792:5:792:5 | b :  | array_flow.rb:796:10:796:10 | b |
+| array_flow.rb:792:5:792:5 | b :  | array_flow.rb:796:10:796:10 | b |
 | array_flow.rb:792:9:792:9 | a [element 2] :  | array_flow.rb:792:9:795:7 | call to min_by :  |
 | array_flow.rb:792:9:792:9 | a [element 2] :  | array_flow.rb:792:9:795:7 | call to min_by :  |
 | array_flow.rb:792:9:792:9 | a [element 2] :  | array_flow.rb:792:22:792:22 | x :  |
 | array_flow.rb:792:9:792:9 | a [element 2] :  | array_flow.rb:792:22:792:22 | x :  |
-| array_flow.rb:792:9:795:7 | call to min_by :  | array_flow.rb:796:10:796:10 | b |
-| array_flow.rb:792:9:795:7 | call to min_by :  | array_flow.rb:796:10:796:10 | b |
+| array_flow.rb:792:9:795:7 | call to min_by :  | array_flow.rb:792:5:792:5 | b :  |
+| array_flow.rb:792:9:795:7 | call to min_by :  | array_flow.rb:792:5:792:5 | b :  |
 | array_flow.rb:792:22:792:22 | x :  | array_flow.rb:793:14:793:14 | x |
 | array_flow.rb:792:22:792:22 | x :  | array_flow.rb:793:14:793:14 | x |
+| array_flow.rb:799:5:799:5 | c [element] :  | array_flow.rb:803:10:803:10 | c [element] :  |
+| array_flow.rb:799:5:799:5 | c [element] :  | array_flow.rb:803:10:803:10 | c [element] :  |
 | array_flow.rb:799:9:799:9 | a [element 2] :  | array_flow.rb:799:9:802:7 | call to min_by [element] :  |
 | array_flow.rb:799:9:799:9 | a [element 2] :  | array_flow.rb:799:9:802:7 | call to min_by [element] :  |
 | array_flow.rb:799:9:799:9 | a [element 2] :  | array_flow.rb:799:25:799:25 | x :  |
 | array_flow.rb:799:9:799:9 | a [element 2] :  | array_flow.rb:799:25:799:25 | x :  |
-| array_flow.rb:799:9:802:7 | call to min_by [element] :  | array_flow.rb:803:10:803:10 | c [element] :  |
-| array_flow.rb:799:9:802:7 | call to min_by [element] :  | array_flow.rb:803:10:803:10 | c [element] :  |
+| array_flow.rb:799:9:802:7 | call to min_by [element] :  | array_flow.rb:799:5:799:5 | c [element] :  |
+| array_flow.rb:799:9:802:7 | call to min_by [element] :  | array_flow.rb:799:5:799:5 | c [element] :  |
 | array_flow.rb:799:25:799:25 | x :  | array_flow.rb:800:14:800:14 | x |
 | array_flow.rb:799:25:799:25 | x :  | array_flow.rb:800:14:800:14 | x |
 | array_flow.rb:803:10:803:10 | c [element] :  | array_flow.rb:803:10:803:13 | ...[...] |
 | array_flow.rb:803:10:803:10 | c [element] :  | array_flow.rb:803:10:803:13 | ...[...] |
-| array_flow.rb:807:16:807:25 | call to source :  | array_flow.rb:809:9:809:9 | a [element 2] :  |
-| array_flow.rb:807:16:807:25 | call to source :  | array_flow.rb:809:9:809:9 | a [element 2] :  |
-| array_flow.rb:807:16:807:25 | call to source :  | array_flow.rb:813:9:813:9 | a [element 2] :  |
-| array_flow.rb:807:16:807:25 | call to source :  | array_flow.rb:813:9:813:9 | a [element 2] :  |
+| array_flow.rb:807:5:807:5 | a [element 2] :  | array_flow.rb:809:9:809:9 | a [element 2] :  |
+| array_flow.rb:807:5:807:5 | a [element 2] :  | array_flow.rb:809:9:809:9 | a [element 2] :  |
+| array_flow.rb:807:5:807:5 | a [element 2] :  | array_flow.rb:813:9:813:9 | a [element 2] :  |
+| array_flow.rb:807:5:807:5 | a [element 2] :  | array_flow.rb:813:9:813:9 | a [element 2] :  |
+| array_flow.rb:807:16:807:25 | call to source :  | array_flow.rb:807:5:807:5 | a [element 2] :  |
+| array_flow.rb:807:16:807:25 | call to source :  | array_flow.rb:807:5:807:5 | a [element 2] :  |
+| array_flow.rb:809:5:809:5 | b [element] :  | array_flow.rb:810:10:810:10 | b [element] :  |
+| array_flow.rb:809:5:809:5 | b [element] :  | array_flow.rb:810:10:810:10 | b [element] :  |
+| array_flow.rb:809:5:809:5 | b [element] :  | array_flow.rb:811:10:811:10 | b [element] :  |
+| array_flow.rb:809:5:809:5 | b [element] :  | array_flow.rb:811:10:811:10 | b [element] :  |
 | array_flow.rb:809:9:809:9 | a [element 2] :  | array_flow.rb:809:9:809:16 | call to minmax [element] :  |
 | array_flow.rb:809:9:809:9 | a [element 2] :  | array_flow.rb:809:9:809:16 | call to minmax [element] :  |
-| array_flow.rb:809:9:809:16 | call to minmax [element] :  | array_flow.rb:810:10:810:10 | b [element] :  |
-| array_flow.rb:809:9:809:16 | call to minmax [element] :  | array_flow.rb:810:10:810:10 | b [element] :  |
-| array_flow.rb:809:9:809:16 | call to minmax [element] :  | array_flow.rb:811:10:811:10 | b [element] :  |
-| array_flow.rb:809:9:809:16 | call to minmax [element] :  | array_flow.rb:811:10:811:10 | b [element] :  |
+| array_flow.rb:809:9:809:16 | call to minmax [element] :  | array_flow.rb:809:5:809:5 | b [element] :  |
+| array_flow.rb:809:9:809:16 | call to minmax [element] :  | array_flow.rb:809:5:809:5 | b [element] :  |
 | array_flow.rb:810:10:810:10 | b [element] :  | array_flow.rb:810:10:810:13 | ...[...] |
 | array_flow.rb:810:10:810:10 | b [element] :  | array_flow.rb:810:10:810:13 | ...[...] |
 | array_flow.rb:811:10:811:10 | b [element] :  | array_flow.rb:811:10:811:13 | ...[...] |
 | array_flow.rb:811:10:811:10 | b [element] :  | array_flow.rb:811:10:811:13 | ...[...] |
+| array_flow.rb:813:5:813:5 | c [element] :  | array_flow.rb:818:10:818:10 | c [element] :  |
+| array_flow.rb:813:5:813:5 | c [element] :  | array_flow.rb:818:10:818:10 | c [element] :  |
+| array_flow.rb:813:5:813:5 | c [element] :  | array_flow.rb:819:10:819:10 | c [element] :  |
+| array_flow.rb:813:5:813:5 | c [element] :  | array_flow.rb:819:10:819:10 | c [element] :  |
 | array_flow.rb:813:9:813:9 | a [element 2] :  | array_flow.rb:813:9:817:7 | call to minmax [element] :  |
 | array_flow.rb:813:9:813:9 | a [element 2] :  | array_flow.rb:813:9:817:7 | call to minmax [element] :  |
 | array_flow.rb:813:9:813:9 | a [element 2] :  | array_flow.rb:813:22:813:22 | x :  |
 | array_flow.rb:813:9:813:9 | a [element 2] :  | array_flow.rb:813:22:813:22 | x :  |
 | array_flow.rb:813:9:813:9 | a [element 2] :  | array_flow.rb:813:25:813:25 | y :  |
 | array_flow.rb:813:9:813:9 | a [element 2] :  | array_flow.rb:813:25:813:25 | y :  |
-| array_flow.rb:813:9:817:7 | call to minmax [element] :  | array_flow.rb:818:10:818:10 | c [element] :  |
-| array_flow.rb:813:9:817:7 | call to minmax [element] :  | array_flow.rb:818:10:818:10 | c [element] :  |
-| array_flow.rb:813:9:817:7 | call to minmax [element] :  | array_flow.rb:819:10:819:10 | c [element] :  |
-| array_flow.rb:813:9:817:7 | call to minmax [element] :  | array_flow.rb:819:10:819:10 | c [element] :  |
+| array_flow.rb:813:9:817:7 | call to minmax [element] :  | array_flow.rb:813:5:813:5 | c [element] :  |
+| array_flow.rb:813:9:817:7 | call to minmax [element] :  | array_flow.rb:813:5:813:5 | c [element] :  |
 | array_flow.rb:813:22:813:22 | x :  | array_flow.rb:814:14:814:14 | x |
 | array_flow.rb:813:22:813:22 | x :  | array_flow.rb:814:14:814:14 | x |
 | array_flow.rb:813:25:813:25 | y :  | array_flow.rb:815:14:815:14 | y |
@@ -1460,47 +1843,61 @@ edges
 | array_flow.rb:818:10:818:10 | c [element] :  | array_flow.rb:818:10:818:13 | ...[...] |
 | array_flow.rb:819:10:819:10 | c [element] :  | array_flow.rb:819:10:819:13 | ...[...] |
 | array_flow.rb:819:10:819:10 | c [element] :  | array_flow.rb:819:10:819:13 | ...[...] |
-| array_flow.rb:823:16:823:25 | call to source :  | array_flow.rb:824:9:824:9 | a [element 2] :  |
-| array_flow.rb:823:16:823:25 | call to source :  | array_flow.rb:824:9:824:9 | a [element 2] :  |
+| array_flow.rb:823:5:823:5 | a [element 2] :  | array_flow.rb:824:9:824:9 | a [element 2] :  |
+| array_flow.rb:823:5:823:5 | a [element 2] :  | array_flow.rb:824:9:824:9 | a [element 2] :  |
+| array_flow.rb:823:16:823:25 | call to source :  | array_flow.rb:823:5:823:5 | a [element 2] :  |
+| array_flow.rb:823:16:823:25 | call to source :  | array_flow.rb:823:5:823:5 | a [element 2] :  |
+| array_flow.rb:824:5:824:5 | b [element] :  | array_flow.rb:828:10:828:10 | b [element] :  |
+| array_flow.rb:824:5:824:5 | b [element] :  | array_flow.rb:828:10:828:10 | b [element] :  |
+| array_flow.rb:824:5:824:5 | b [element] :  | array_flow.rb:829:10:829:10 | b [element] :  |
+| array_flow.rb:824:5:824:5 | b [element] :  | array_flow.rb:829:10:829:10 | b [element] :  |
 | array_flow.rb:824:9:824:9 | a [element 2] :  | array_flow.rb:824:9:827:7 | call to minmax_by [element] :  |
 | array_flow.rb:824:9:824:9 | a [element 2] :  | array_flow.rb:824:9:827:7 | call to minmax_by [element] :  |
 | array_flow.rb:824:9:824:9 | a [element 2] :  | array_flow.rb:824:25:824:25 | x :  |
 | array_flow.rb:824:9:824:9 | a [element 2] :  | array_flow.rb:824:25:824:25 | x :  |
-| array_flow.rb:824:9:827:7 | call to minmax_by [element] :  | array_flow.rb:828:10:828:10 | b [element] :  |
-| array_flow.rb:824:9:827:7 | call to minmax_by [element] :  | array_flow.rb:828:10:828:10 | b [element] :  |
-| array_flow.rb:824:9:827:7 | call to minmax_by [element] :  | array_flow.rb:829:10:829:10 | b [element] :  |
-| array_flow.rb:824:9:827:7 | call to minmax_by [element] :  | array_flow.rb:829:10:829:10 | b [element] :  |
+| array_flow.rb:824:9:827:7 | call to minmax_by [element] :  | array_flow.rb:824:5:824:5 | b [element] :  |
+| array_flow.rb:824:9:827:7 | call to minmax_by [element] :  | array_flow.rb:824:5:824:5 | b [element] :  |
 | array_flow.rb:824:25:824:25 | x :  | array_flow.rb:825:14:825:14 | x |
 | array_flow.rb:824:25:824:25 | x :  | array_flow.rb:825:14:825:14 | x |
 | array_flow.rb:828:10:828:10 | b [element] :  | array_flow.rb:828:10:828:13 | ...[...] |
 | array_flow.rb:828:10:828:10 | b [element] :  | array_flow.rb:828:10:828:13 | ...[...] |
 | array_flow.rb:829:10:829:10 | b [element] :  | array_flow.rb:829:10:829:13 | ...[...] |
 | array_flow.rb:829:10:829:10 | b [element] :  | array_flow.rb:829:10:829:13 | ...[...] |
-| array_flow.rb:833:16:833:25 | call to source :  | array_flow.rb:834:5:834:5 | a [element 2] :  |
-| array_flow.rb:833:16:833:25 | call to source :  | array_flow.rb:834:5:834:5 | a [element 2] :  |
+| array_flow.rb:833:5:833:5 | a [element 2] :  | array_flow.rb:834:5:834:5 | a [element 2] :  |
+| array_flow.rb:833:5:833:5 | a [element 2] :  | array_flow.rb:834:5:834:5 | a [element 2] :  |
+| array_flow.rb:833:16:833:25 | call to source :  | array_flow.rb:833:5:833:5 | a [element 2] :  |
+| array_flow.rb:833:16:833:25 | call to source :  | array_flow.rb:833:5:833:5 | a [element 2] :  |
 | array_flow.rb:834:5:834:5 | a [element 2] :  | array_flow.rb:834:17:834:17 | x :  |
 | array_flow.rb:834:5:834:5 | a [element 2] :  | array_flow.rb:834:17:834:17 | x :  |
 | array_flow.rb:834:17:834:17 | x :  | array_flow.rb:835:14:835:14 | x |
 | array_flow.rb:834:17:834:17 | x :  | array_flow.rb:835:14:835:14 | x |
-| array_flow.rb:842:16:842:25 | call to source :  | array_flow.rb:843:5:843:5 | a [element 2] :  |
-| array_flow.rb:842:16:842:25 | call to source :  | array_flow.rb:843:5:843:5 | a [element 2] :  |
+| array_flow.rb:842:5:842:5 | a [element 2] :  | array_flow.rb:843:5:843:5 | a [element 2] :  |
+| array_flow.rb:842:5:842:5 | a [element 2] :  | array_flow.rb:843:5:843:5 | a [element 2] :  |
+| array_flow.rb:842:16:842:25 | call to source :  | array_flow.rb:842:5:842:5 | a [element 2] :  |
+| array_flow.rb:842:16:842:25 | call to source :  | array_flow.rb:842:5:842:5 | a [element 2] :  |
 | array_flow.rb:843:5:843:5 | a [element 2] :  | array_flow.rb:843:16:843:16 | x :  |
 | array_flow.rb:843:5:843:5 | a [element 2] :  | array_flow.rb:843:16:843:16 | x :  |
 | array_flow.rb:843:16:843:16 | x :  | array_flow.rb:844:14:844:14 | x |
 | array_flow.rb:843:16:843:16 | x :  | array_flow.rb:844:14:844:14 | x |
-| array_flow.rb:849:16:849:25 | call to source :  | array_flow.rb:850:9:850:9 | a [element 2] :  |
+| array_flow.rb:849:5:849:5 | a [element 2] :  | array_flow.rb:850:9:850:9 | a [element 2] :  |
+| array_flow.rb:849:16:849:25 | call to source :  | array_flow.rb:849:5:849:5 | a [element 2] :  |
+| array_flow.rb:850:5:850:5 | b :  | array_flow.rb:851:10:851:10 | b |
 | array_flow.rb:850:9:850:9 | a [element 2] :  | array_flow.rb:850:9:850:20 | call to pack :  |
-| array_flow.rb:850:9:850:20 | call to pack :  | array_flow.rb:851:10:851:10 | b |
-| array_flow.rb:855:16:855:25 | call to source :  | array_flow.rb:856:9:856:9 | a [element 2] :  |
-| array_flow.rb:855:16:855:25 | call to source :  | array_flow.rb:856:9:856:9 | a [element 2] :  |
+| array_flow.rb:850:9:850:20 | call to pack :  | array_flow.rb:850:5:850:5 | b :  |
+| array_flow.rb:855:5:855:5 | a [element 2] :  | array_flow.rb:856:9:856:9 | a [element 2] :  |
+| array_flow.rb:855:5:855:5 | a [element 2] :  | array_flow.rb:856:9:856:9 | a [element 2] :  |
+| array_flow.rb:855:16:855:25 | call to source :  | array_flow.rb:855:5:855:5 | a [element 2] :  |
+| array_flow.rb:855:16:855:25 | call to source :  | array_flow.rb:855:5:855:5 | a [element 2] :  |
+| array_flow.rb:856:5:856:5 | b [element, element] :  | array_flow.rb:860:10:860:10 | b [element, element] :  |
+| array_flow.rb:856:5:856:5 | b [element, element] :  | array_flow.rb:860:10:860:10 | b [element, element] :  |
+| array_flow.rb:856:5:856:5 | b [element, element] :  | array_flow.rb:861:10:861:10 | b [element, element] :  |
+| array_flow.rb:856:5:856:5 | b [element, element] :  | array_flow.rb:861:10:861:10 | b [element, element] :  |
 | array_flow.rb:856:9:856:9 | a [element 2] :  | array_flow.rb:856:9:859:7 | call to partition [element, element] :  |
 | array_flow.rb:856:9:856:9 | a [element 2] :  | array_flow.rb:856:9:859:7 | call to partition [element, element] :  |
 | array_flow.rb:856:9:856:9 | a [element 2] :  | array_flow.rb:856:25:856:25 | x :  |
 | array_flow.rb:856:9:856:9 | a [element 2] :  | array_flow.rb:856:25:856:25 | x :  |
-| array_flow.rb:856:9:859:7 | call to partition [element, element] :  | array_flow.rb:860:10:860:10 | b [element, element] :  |
-| array_flow.rb:856:9:859:7 | call to partition [element, element] :  | array_flow.rb:860:10:860:10 | b [element, element] :  |
-| array_flow.rb:856:9:859:7 | call to partition [element, element] :  | array_flow.rb:861:10:861:10 | b [element, element] :  |
-| array_flow.rb:856:9:859:7 | call to partition [element, element] :  | array_flow.rb:861:10:861:10 | b [element, element] :  |
+| array_flow.rb:856:9:859:7 | call to partition [element, element] :  | array_flow.rb:856:5:856:5 | b [element, element] :  |
+| array_flow.rb:856:9:859:7 | call to partition [element, element] :  | array_flow.rb:856:5:856:5 | b [element, element] :  |
 | array_flow.rb:856:25:856:25 | x :  | array_flow.rb:857:14:857:14 | x |
 | array_flow.rb:856:25:856:25 | x :  | array_flow.rb:857:14:857:14 | x |
 | array_flow.rb:860:10:860:10 | b [element, element] :  | array_flow.rb:860:10:860:13 | ...[...] [element] :  |
@@ -1511,18 +1908,22 @@ edges
 | array_flow.rb:861:10:861:10 | b [element, element] :  | array_flow.rb:861:10:861:13 | ...[...] [element] :  |
 | array_flow.rb:861:10:861:13 | ...[...] [element] :  | array_flow.rb:861:10:861:16 | ...[...] |
 | array_flow.rb:861:10:861:13 | ...[...] [element] :  | array_flow.rb:861:10:861:16 | ...[...] |
-| array_flow.rb:865:16:865:25 | call to source :  | array_flow.rb:867:9:867:9 | a [element 2] :  |
-| array_flow.rb:865:16:865:25 | call to source :  | array_flow.rb:867:9:867:9 | a [element 2] :  |
-| array_flow.rb:865:16:865:25 | call to source :  | array_flow.rb:875:9:875:9 | a [element 2] :  |
-| array_flow.rb:865:16:865:25 | call to source :  | array_flow.rb:875:9:875:9 | a [element 2] :  |
-| array_flow.rb:865:16:865:25 | call to source :  | array_flow.rb:882:9:882:9 | a [element 2] :  |
-| array_flow.rb:865:16:865:25 | call to source :  | array_flow.rb:882:9:882:9 | a [element 2] :  |
+| array_flow.rb:865:5:865:5 | a [element 2] :  | array_flow.rb:867:9:867:9 | a [element 2] :  |
+| array_flow.rb:865:5:865:5 | a [element 2] :  | array_flow.rb:867:9:867:9 | a [element 2] :  |
+| array_flow.rb:865:5:865:5 | a [element 2] :  | array_flow.rb:875:9:875:9 | a [element 2] :  |
+| array_flow.rb:865:5:865:5 | a [element 2] :  | array_flow.rb:875:9:875:9 | a [element 2] :  |
+| array_flow.rb:865:5:865:5 | a [element 2] :  | array_flow.rb:882:9:882:9 | a [element 2] :  |
+| array_flow.rb:865:5:865:5 | a [element 2] :  | array_flow.rb:882:9:882:9 | a [element 2] :  |
+| array_flow.rb:865:16:865:25 | call to source :  | array_flow.rb:865:5:865:5 | a [element 2] :  |
+| array_flow.rb:865:16:865:25 | call to source :  | array_flow.rb:865:5:865:5 | a [element 2] :  |
+| array_flow.rb:867:5:867:5 | b [element 2] :  | array_flow.rb:873:10:873:10 | b [element 2] :  |
+| array_flow.rb:867:5:867:5 | b [element 2] :  | array_flow.rb:873:10:873:10 | b [element 2] :  |
 | array_flow.rb:867:9:867:9 | a [element 2] :  | array_flow.rb:867:9:871:7 | call to permutation [element 2] :  |
 | array_flow.rb:867:9:867:9 | a [element 2] :  | array_flow.rb:867:9:871:7 | call to permutation [element 2] :  |
 | array_flow.rb:867:9:867:9 | a [element 2] :  | array_flow.rb:867:27:867:27 | x [element] :  |
 | array_flow.rb:867:9:867:9 | a [element 2] :  | array_flow.rb:867:27:867:27 | x [element] :  |
-| array_flow.rb:867:9:871:7 | call to permutation [element 2] :  | array_flow.rb:873:10:873:10 | b [element 2] :  |
-| array_flow.rb:867:9:871:7 | call to permutation [element 2] :  | array_flow.rb:873:10:873:10 | b [element 2] :  |
+| array_flow.rb:867:9:871:7 | call to permutation [element 2] :  | array_flow.rb:867:5:867:5 | b [element 2] :  |
+| array_flow.rb:867:9:871:7 | call to permutation [element 2] :  | array_flow.rb:867:5:867:5 | b [element 2] :  |
 | array_flow.rb:867:27:867:27 | x [element] :  | array_flow.rb:868:14:868:14 | x [element] :  |
 | array_flow.rb:867:27:867:27 | x [element] :  | array_flow.rb:868:14:868:14 | x [element] :  |
 | array_flow.rb:867:27:867:27 | x [element] :  | array_flow.rb:869:14:869:14 | x [element] :  |
@@ -1537,14 +1938,16 @@ edges
 | array_flow.rb:870:14:870:14 | x [element] :  | array_flow.rb:870:14:870:17 | ...[...] |
 | array_flow.rb:873:10:873:10 | b [element 2] :  | array_flow.rb:873:10:873:13 | ...[...] |
 | array_flow.rb:873:10:873:10 | b [element 2] :  | array_flow.rb:873:10:873:13 | ...[...] |
+| array_flow.rb:875:5:875:5 | c [element 2] :  | array_flow.rb:880:10:880:10 | c [element 2] :  |
+| array_flow.rb:875:5:875:5 | c [element 2] :  | array_flow.rb:880:10:880:10 | c [element 2] :  |
+| array_flow.rb:875:5:875:5 | c [element 2] :  | array_flow.rb:887:10:887:10 | c [element 2] :  |
+| array_flow.rb:875:5:875:5 | c [element 2] :  | array_flow.rb:887:10:887:10 | c [element 2] :  |
 | array_flow.rb:875:9:875:9 | a [element 2] :  | array_flow.rb:875:9:878:7 | call to permutation [element 2] :  |
 | array_flow.rb:875:9:875:9 | a [element 2] :  | array_flow.rb:875:9:878:7 | call to permutation [element 2] :  |
 | array_flow.rb:875:9:875:9 | a [element 2] :  | array_flow.rb:875:30:875:30 | x [element] :  |
 | array_flow.rb:875:9:875:9 | a [element 2] :  | array_flow.rb:875:30:875:30 | x [element] :  |
-| array_flow.rb:875:9:878:7 | call to permutation [element 2] :  | array_flow.rb:880:10:880:10 | c [element 2] :  |
-| array_flow.rb:875:9:878:7 | call to permutation [element 2] :  | array_flow.rb:880:10:880:10 | c [element 2] :  |
-| array_flow.rb:875:9:878:7 | call to permutation [element 2] :  | array_flow.rb:887:10:887:10 | c [element 2] :  |
-| array_flow.rb:875:9:878:7 | call to permutation [element 2] :  | array_flow.rb:887:10:887:10 | c [element 2] :  |
+| array_flow.rb:875:9:878:7 | call to permutation [element 2] :  | array_flow.rb:875:5:875:5 | c [element 2] :  |
+| array_flow.rb:875:9:878:7 | call to permutation [element 2] :  | array_flow.rb:875:5:875:5 | c [element 2] :  |
 | array_flow.rb:875:30:875:30 | x [element] :  | array_flow.rb:876:14:876:14 | x [element] :  |
 | array_flow.rb:875:30:875:30 | x [element] :  | array_flow.rb:876:14:876:14 | x [element] :  |
 | array_flow.rb:875:30:875:30 | x [element] :  | array_flow.rb:877:14:877:14 | x [element] :  |
@@ -1567,40 +1970,52 @@ edges
 | array_flow.rb:884:14:884:14 | x [element] :  | array_flow.rb:884:14:884:17 | ...[...] |
 | array_flow.rb:887:10:887:10 | c [element 2] :  | array_flow.rb:887:10:887:13 | ...[...] |
 | array_flow.rb:887:10:887:10 | c [element 2] :  | array_flow.rb:887:10:887:13 | ...[...] |
-| array_flow.rb:894:13:894:24 | call to source :  | array_flow.rb:895:9:895:9 | a [element 1] :  |
-| array_flow.rb:894:13:894:24 | call to source :  | array_flow.rb:895:9:895:9 | a [element 1] :  |
-| array_flow.rb:894:13:894:24 | call to source :  | array_flow.rb:898:10:898:10 | a [element 1] :  |
-| array_flow.rb:894:13:894:24 | call to source :  | array_flow.rb:898:10:898:10 | a [element 1] :  |
-| array_flow.rb:894:30:894:41 | call to source :  | array_flow.rb:895:9:895:9 | a [element 3] :  |
-| array_flow.rb:894:30:894:41 | call to source :  | array_flow.rb:895:9:895:9 | a [element 3] :  |
-| array_flow.rb:894:30:894:41 | call to source :  | array_flow.rb:900:10:900:10 | a [element 3] :  |
-| array_flow.rb:894:30:894:41 | call to source :  | array_flow.rb:900:10:900:10 | a [element 3] :  |
+| array_flow.rb:894:5:894:5 | a [element 1] :  | array_flow.rb:895:9:895:9 | a [element 1] :  |
+| array_flow.rb:894:5:894:5 | a [element 1] :  | array_flow.rb:895:9:895:9 | a [element 1] :  |
+| array_flow.rb:894:5:894:5 | a [element 1] :  | array_flow.rb:898:10:898:10 | a [element 1] :  |
+| array_flow.rb:894:5:894:5 | a [element 1] :  | array_flow.rb:898:10:898:10 | a [element 1] :  |
+| array_flow.rb:894:5:894:5 | a [element 3] :  | array_flow.rb:895:9:895:9 | a [element 3] :  |
+| array_flow.rb:894:5:894:5 | a [element 3] :  | array_flow.rb:895:9:895:9 | a [element 3] :  |
+| array_flow.rb:894:5:894:5 | a [element 3] :  | array_flow.rb:900:10:900:10 | a [element 3] :  |
+| array_flow.rb:894:5:894:5 | a [element 3] :  | array_flow.rb:900:10:900:10 | a [element 3] :  |
+| array_flow.rb:894:13:894:24 | call to source :  | array_flow.rb:894:5:894:5 | a [element 1] :  |
+| array_flow.rb:894:13:894:24 | call to source :  | array_flow.rb:894:5:894:5 | a [element 1] :  |
+| array_flow.rb:894:30:894:41 | call to source :  | array_flow.rb:894:5:894:5 | a [element 3] :  |
+| array_flow.rb:894:30:894:41 | call to source :  | array_flow.rb:894:5:894:5 | a [element 3] :  |
+| array_flow.rb:895:5:895:5 | b :  | array_flow.rb:896:10:896:10 | b |
+| array_flow.rb:895:5:895:5 | b :  | array_flow.rb:896:10:896:10 | b |
 | array_flow.rb:895:9:895:9 | a [element 1] :  | array_flow.rb:895:9:895:13 | call to pop :  |
 | array_flow.rb:895:9:895:9 | a [element 1] :  | array_flow.rb:895:9:895:13 | call to pop :  |
 | array_flow.rb:895:9:895:9 | a [element 3] :  | array_flow.rb:895:9:895:13 | call to pop :  |
 | array_flow.rb:895:9:895:9 | a [element 3] :  | array_flow.rb:895:9:895:13 | call to pop :  |
-| array_flow.rb:895:9:895:13 | call to pop :  | array_flow.rb:896:10:896:10 | b |
-| array_flow.rb:895:9:895:13 | call to pop :  | array_flow.rb:896:10:896:10 | b |
+| array_flow.rb:895:9:895:13 | call to pop :  | array_flow.rb:895:5:895:5 | b :  |
+| array_flow.rb:895:9:895:13 | call to pop :  | array_flow.rb:895:5:895:5 | b :  |
 | array_flow.rb:898:10:898:10 | a [element 1] :  | array_flow.rb:898:10:898:13 | ...[...] |
 | array_flow.rb:898:10:898:10 | a [element 1] :  | array_flow.rb:898:10:898:13 | ...[...] |
 | array_flow.rb:900:10:900:10 | a [element 3] :  | array_flow.rb:900:10:900:13 | ...[...] |
 | array_flow.rb:900:10:900:10 | a [element 3] :  | array_flow.rb:900:10:900:13 | ...[...] |
-| array_flow.rb:902:13:902:24 | call to source :  | array_flow.rb:903:9:903:9 | a [element 1] :  |
-| array_flow.rb:902:13:902:24 | call to source :  | array_flow.rb:903:9:903:9 | a [element 1] :  |
-| array_flow.rb:902:13:902:24 | call to source :  | array_flow.rb:907:10:907:10 | a [element 1] :  |
-| array_flow.rb:902:13:902:24 | call to source :  | array_flow.rb:907:10:907:10 | a [element 1] :  |
-| array_flow.rb:902:30:902:41 | call to source :  | array_flow.rb:903:9:903:9 | a [element 3] :  |
-| array_flow.rb:902:30:902:41 | call to source :  | array_flow.rb:903:9:903:9 | a [element 3] :  |
-| array_flow.rb:902:30:902:41 | call to source :  | array_flow.rb:909:10:909:10 | a [element 3] :  |
-| array_flow.rb:902:30:902:41 | call to source :  | array_flow.rb:909:10:909:10 | a [element 3] :  |
+| array_flow.rb:902:5:902:5 | a [element 1] :  | array_flow.rb:903:9:903:9 | a [element 1] :  |
+| array_flow.rb:902:5:902:5 | a [element 1] :  | array_flow.rb:903:9:903:9 | a [element 1] :  |
+| array_flow.rb:902:5:902:5 | a [element 1] :  | array_flow.rb:907:10:907:10 | a [element 1] :  |
+| array_flow.rb:902:5:902:5 | a [element 1] :  | array_flow.rb:907:10:907:10 | a [element 1] :  |
+| array_flow.rb:902:5:902:5 | a [element 3] :  | array_flow.rb:903:9:903:9 | a [element 3] :  |
+| array_flow.rb:902:5:902:5 | a [element 3] :  | array_flow.rb:903:9:903:9 | a [element 3] :  |
+| array_flow.rb:902:5:902:5 | a [element 3] :  | array_flow.rb:909:10:909:10 | a [element 3] :  |
+| array_flow.rb:902:5:902:5 | a [element 3] :  | array_flow.rb:909:10:909:10 | a [element 3] :  |
+| array_flow.rb:902:13:902:24 | call to source :  | array_flow.rb:902:5:902:5 | a [element 1] :  |
+| array_flow.rb:902:13:902:24 | call to source :  | array_flow.rb:902:5:902:5 | a [element 1] :  |
+| array_flow.rb:902:30:902:41 | call to source :  | array_flow.rb:902:5:902:5 | a [element 3] :  |
+| array_flow.rb:902:30:902:41 | call to source :  | array_flow.rb:902:5:902:5 | a [element 3] :  |
+| array_flow.rb:903:5:903:5 | b [element] :  | array_flow.rb:904:10:904:10 | b [element] :  |
+| array_flow.rb:903:5:903:5 | b [element] :  | array_flow.rb:904:10:904:10 | b [element] :  |
+| array_flow.rb:903:5:903:5 | b [element] :  | array_flow.rb:905:10:905:10 | b [element] :  |
+| array_flow.rb:903:5:903:5 | b [element] :  | array_flow.rb:905:10:905:10 | b [element] :  |
 | array_flow.rb:903:9:903:9 | a [element 1] :  | array_flow.rb:903:9:903:16 | call to pop [element] :  |
 | array_flow.rb:903:9:903:9 | a [element 1] :  | array_flow.rb:903:9:903:16 | call to pop [element] :  |
 | array_flow.rb:903:9:903:9 | a [element 3] :  | array_flow.rb:903:9:903:16 | call to pop [element] :  |
 | array_flow.rb:903:9:903:9 | a [element 3] :  | array_flow.rb:903:9:903:16 | call to pop [element] :  |
-| array_flow.rb:903:9:903:16 | call to pop [element] :  | array_flow.rb:904:10:904:10 | b [element] :  |
-| array_flow.rb:903:9:903:16 | call to pop [element] :  | array_flow.rb:904:10:904:10 | b [element] :  |
-| array_flow.rb:903:9:903:16 | call to pop [element] :  | array_flow.rb:905:10:905:10 | b [element] :  |
-| array_flow.rb:903:9:903:16 | call to pop [element] :  | array_flow.rb:905:10:905:10 | b [element] :  |
+| array_flow.rb:903:9:903:16 | call to pop [element] :  | array_flow.rb:903:5:903:5 | b [element] :  |
+| array_flow.rb:903:9:903:16 | call to pop [element] :  | array_flow.rb:903:5:903:5 | b [element] :  |
 | array_flow.rb:904:10:904:10 | b [element] :  | array_flow.rb:904:10:904:13 | ...[...] |
 | array_flow.rb:904:10:904:10 | b [element] :  | array_flow.rb:904:10:904:13 | ...[...] |
 | array_flow.rb:905:10:905:10 | b [element] :  | array_flow.rb:905:10:905:13 | ...[...] |
@@ -1609,8 +2024,10 @@ edges
 | array_flow.rb:907:10:907:10 | a [element 1] :  | array_flow.rb:907:10:907:13 | ...[...] |
 | array_flow.rb:909:10:909:10 | a [element 3] :  | array_flow.rb:909:10:909:13 | ...[...] |
 | array_flow.rb:909:10:909:10 | a [element 3] :  | array_flow.rb:909:10:909:13 | ...[...] |
-| array_flow.rb:913:16:913:27 | call to source :  | array_flow.rb:914:5:914:5 | a [element 2] :  |
-| array_flow.rb:913:16:913:27 | call to source :  | array_flow.rb:914:5:914:5 | a [element 2] :  |
+| array_flow.rb:913:5:913:5 | a [element 2] :  | array_flow.rb:914:5:914:5 | a [element 2] :  |
+| array_flow.rb:913:5:913:5 | a [element 2] :  | array_flow.rb:914:5:914:5 | a [element 2] :  |
+| array_flow.rb:913:16:913:27 | call to source :  | array_flow.rb:913:5:913:5 | a [element 2] :  |
+| array_flow.rb:913:16:913:27 | call to source :  | array_flow.rb:913:5:913:5 | a [element 2] :  |
 | array_flow.rb:914:5:914:5 | [post] a [element 2] :  | array_flow.rb:917:10:917:10 | a [element 2] :  |
 | array_flow.rb:914:5:914:5 | [post] a [element 2] :  | array_flow.rb:917:10:917:10 | a [element 2] :  |
 | array_flow.rb:914:5:914:5 | [post] a [element 5] :  | array_flow.rb:920:10:920:10 | a [element 5] :  |
@@ -1623,18 +2040,26 @@ edges
 | array_flow.rb:917:10:917:10 | a [element 2] :  | array_flow.rb:917:10:917:13 | ...[...] |
 | array_flow.rb:920:10:920:10 | a [element 5] :  | array_flow.rb:920:10:920:13 | ...[...] |
 | array_flow.rb:920:10:920:10 | a [element 5] :  | array_flow.rb:920:10:920:13 | ...[...] |
-| array_flow.rb:924:16:924:27 | call to source :  | array_flow.rb:927:9:927:9 | a [element 2] :  |
-| array_flow.rb:924:16:924:27 | call to source :  | array_flow.rb:927:9:927:9 | a [element 2] :  |
-| array_flow.rb:925:13:925:24 | call to source :  | array_flow.rb:927:19:927:19 | b [element 1] :  |
-| array_flow.rb:925:13:925:24 | call to source :  | array_flow.rb:927:19:927:19 | b [element 1] :  |
-| array_flow.rb:926:10:926:21 | call to source :  | array_flow.rb:927:22:927:22 | c [element 0] :  |
-| array_flow.rb:926:10:926:21 | call to source :  | array_flow.rb:927:22:927:22 | c [element 0] :  |
+| array_flow.rb:924:5:924:5 | a [element 2] :  | array_flow.rb:927:9:927:9 | a [element 2] :  |
+| array_flow.rb:924:5:924:5 | a [element 2] :  | array_flow.rb:927:9:927:9 | a [element 2] :  |
+| array_flow.rb:924:16:924:27 | call to source :  | array_flow.rb:924:5:924:5 | a [element 2] :  |
+| array_flow.rb:924:16:924:27 | call to source :  | array_flow.rb:924:5:924:5 | a [element 2] :  |
+| array_flow.rb:925:5:925:5 | b [element 1] :  | array_flow.rb:927:19:927:19 | b [element 1] :  |
+| array_flow.rb:925:5:925:5 | b [element 1] :  | array_flow.rb:927:19:927:19 | b [element 1] :  |
+| array_flow.rb:925:13:925:24 | call to source :  | array_flow.rb:925:5:925:5 | b [element 1] :  |
+| array_flow.rb:925:13:925:24 | call to source :  | array_flow.rb:925:5:925:5 | b [element 1] :  |
+| array_flow.rb:926:5:926:5 | c [element 0] :  | array_flow.rb:927:22:927:22 | c [element 0] :  |
+| array_flow.rb:926:5:926:5 | c [element 0] :  | array_flow.rb:927:22:927:22 | c [element 0] :  |
+| array_flow.rb:926:10:926:21 | call to source :  | array_flow.rb:926:5:926:5 | c [element 0] :  |
+| array_flow.rb:926:10:926:21 | call to source :  | array_flow.rb:926:5:926:5 | c [element 0] :  |
+| array_flow.rb:927:5:927:5 | d [element, element] :  | array_flow.rb:928:10:928:10 | d [element, element] :  |
+| array_flow.rb:927:5:927:5 | d [element, element] :  | array_flow.rb:928:10:928:10 | d [element, element] :  |
+| array_flow.rb:927:5:927:5 | d [element, element] :  | array_flow.rb:929:10:929:10 | d [element, element] :  |
+| array_flow.rb:927:5:927:5 | d [element, element] :  | array_flow.rb:929:10:929:10 | d [element, element] :  |
 | array_flow.rb:927:9:927:9 | a [element 2] :  | array_flow.rb:927:9:927:22 | call to product [element, element] :  |
 | array_flow.rb:927:9:927:9 | a [element 2] :  | array_flow.rb:927:9:927:22 | call to product [element, element] :  |
-| array_flow.rb:927:9:927:22 | call to product [element, element] :  | array_flow.rb:928:10:928:10 | d [element, element] :  |
-| array_flow.rb:927:9:927:22 | call to product [element, element] :  | array_flow.rb:928:10:928:10 | d [element, element] :  |
-| array_flow.rb:927:9:927:22 | call to product [element, element] :  | array_flow.rb:929:10:929:10 | d [element, element] :  |
-| array_flow.rb:927:9:927:22 | call to product [element, element] :  | array_flow.rb:929:10:929:10 | d [element, element] :  |
+| array_flow.rb:927:9:927:22 | call to product [element, element] :  | array_flow.rb:927:5:927:5 | d [element, element] :  |
+| array_flow.rb:927:9:927:22 | call to product [element, element] :  | array_flow.rb:927:5:927:5 | d [element, element] :  |
 | array_flow.rb:927:19:927:19 | b [element 1] :  | array_flow.rb:927:9:927:22 | call to product [element, element] :  |
 | array_flow.rb:927:19:927:19 | b [element 1] :  | array_flow.rb:927:9:927:22 | call to product [element, element] :  |
 | array_flow.rb:927:22:927:22 | c [element 0] :  | array_flow.rb:927:9:927:22 | call to product [element, element] :  |
@@ -1647,22 +2072,28 @@ edges
 | array_flow.rb:929:10:929:10 | d [element, element] :  | array_flow.rb:929:10:929:13 | ...[...] [element] :  |
 | array_flow.rb:929:10:929:13 | ...[...] [element] :  | array_flow.rb:929:10:929:16 | ...[...] |
 | array_flow.rb:929:10:929:13 | ...[...] [element] :  | array_flow.rb:929:10:929:16 | ...[...] |
-| array_flow.rb:933:10:933:21 | call to source :  | array_flow.rb:934:9:934:9 | a [element 0] :  |
-| array_flow.rb:933:10:933:21 | call to source :  | array_flow.rb:934:9:934:9 | a [element 0] :  |
-| array_flow.rb:933:10:933:21 | call to source :  | array_flow.rb:935:10:935:10 | a [element 0] :  |
-| array_flow.rb:933:10:933:21 | call to source :  | array_flow.rb:935:10:935:10 | a [element 0] :  |
+| array_flow.rb:933:5:933:5 | a [element 0] :  | array_flow.rb:934:9:934:9 | a [element 0] :  |
+| array_flow.rb:933:5:933:5 | a [element 0] :  | array_flow.rb:934:9:934:9 | a [element 0] :  |
+| array_flow.rb:933:5:933:5 | a [element 0] :  | array_flow.rb:935:10:935:10 | a [element 0] :  |
+| array_flow.rb:933:5:933:5 | a [element 0] :  | array_flow.rb:935:10:935:10 | a [element 0] :  |
+| array_flow.rb:933:10:933:21 | call to source :  | array_flow.rb:933:5:933:5 | a [element 0] :  |
+| array_flow.rb:933:10:933:21 | call to source :  | array_flow.rb:933:5:933:5 | a [element 0] :  |
+| array_flow.rb:934:5:934:5 | b [element 0] :  | array_flow.rb:937:10:937:10 | b [element 0] :  |
+| array_flow.rb:934:5:934:5 | b [element 0] :  | array_flow.rb:937:10:937:10 | b [element 0] :  |
+| array_flow.rb:934:5:934:5 | b [element] :  | array_flow.rb:937:10:937:10 | b [element] :  |
+| array_flow.rb:934:5:934:5 | b [element] :  | array_flow.rb:937:10:937:10 | b [element] :  |
+| array_flow.rb:934:5:934:5 | b [element] :  | array_flow.rb:938:10:938:10 | b [element] :  |
+| array_flow.rb:934:5:934:5 | b [element] :  | array_flow.rb:938:10:938:10 | b [element] :  |
 | array_flow.rb:934:9:934:9 | [post] a [element] :  | array_flow.rb:935:10:935:10 | a [element] :  |
 | array_flow.rb:934:9:934:9 | [post] a [element] :  | array_flow.rb:935:10:935:10 | a [element] :  |
 | array_flow.rb:934:9:934:9 | [post] a [element] :  | array_flow.rb:936:10:936:10 | a [element] :  |
 | array_flow.rb:934:9:934:9 | [post] a [element] :  | array_flow.rb:936:10:936:10 | a [element] :  |
 | array_flow.rb:934:9:934:9 | a [element 0] :  | array_flow.rb:934:9:934:44 | call to append [element 0] :  |
 | array_flow.rb:934:9:934:9 | a [element 0] :  | array_flow.rb:934:9:934:44 | call to append [element 0] :  |
-| array_flow.rb:934:9:934:44 | call to append [element 0] :  | array_flow.rb:937:10:937:10 | b [element 0] :  |
-| array_flow.rb:934:9:934:44 | call to append [element 0] :  | array_flow.rb:937:10:937:10 | b [element 0] :  |
-| array_flow.rb:934:9:934:44 | call to append [element] :  | array_flow.rb:937:10:937:10 | b [element] :  |
-| array_flow.rb:934:9:934:44 | call to append [element] :  | array_flow.rb:937:10:937:10 | b [element] :  |
-| array_flow.rb:934:9:934:44 | call to append [element] :  | array_flow.rb:938:10:938:10 | b [element] :  |
-| array_flow.rb:934:9:934:44 | call to append [element] :  | array_flow.rb:938:10:938:10 | b [element] :  |
+| array_flow.rb:934:9:934:44 | call to append [element 0] :  | array_flow.rb:934:5:934:5 | b [element 0] :  |
+| array_flow.rb:934:9:934:44 | call to append [element 0] :  | array_flow.rb:934:5:934:5 | b [element 0] :  |
+| array_flow.rb:934:9:934:44 | call to append [element] :  | array_flow.rb:934:5:934:5 | b [element] :  |
+| array_flow.rb:934:9:934:44 | call to append [element] :  | array_flow.rb:934:5:934:5 | b [element] :  |
 | array_flow.rb:934:18:934:29 | call to source :  | array_flow.rb:934:9:934:9 | [post] a [element] :  |
 | array_flow.rb:934:18:934:29 | call to source :  | array_flow.rb:934:9:934:9 | [post] a [element] :  |
 | array_flow.rb:934:18:934:29 | call to source :  | array_flow.rb:934:9:934:44 | call to append [element] :  |
@@ -1683,12 +2114,16 @@ edges
 | array_flow.rb:937:10:937:10 | b [element] :  | array_flow.rb:937:10:937:13 | ...[...] |
 | array_flow.rb:938:10:938:10 | b [element] :  | array_flow.rb:938:10:938:13 | ...[...] |
 | array_flow.rb:938:10:938:10 | b [element] :  | array_flow.rb:938:10:938:13 | ...[...] |
-| array_flow.rb:944:10:944:19 | call to source :  | array_flow.rb:945:16:945:16 | c [element 0] :  |
-| array_flow.rb:944:10:944:19 | call to source :  | array_flow.rb:945:16:945:16 | c [element 0] :  |
-| array_flow.rb:945:16:945:16 | c [element 0] :  | array_flow.rb:946:10:946:10 | d [element 2, element 0] :  |
-| array_flow.rb:945:16:945:16 | c [element 0] :  | array_flow.rb:946:10:946:10 | d [element 2, element 0] :  |
-| array_flow.rb:945:16:945:16 | c [element 0] :  | array_flow.rb:947:10:947:10 | d [element 2, element 0] :  |
-| array_flow.rb:945:16:945:16 | c [element 0] :  | array_flow.rb:947:10:947:10 | d [element 2, element 0] :  |
+| array_flow.rb:944:5:944:5 | c [element 0] :  | array_flow.rb:945:16:945:16 | c [element 0] :  |
+| array_flow.rb:944:5:944:5 | c [element 0] :  | array_flow.rb:945:16:945:16 | c [element 0] :  |
+| array_flow.rb:944:10:944:19 | call to source :  | array_flow.rb:944:5:944:5 | c [element 0] :  |
+| array_flow.rb:944:10:944:19 | call to source :  | array_flow.rb:944:5:944:5 | c [element 0] :  |
+| array_flow.rb:945:5:945:5 | d [element 2, element 0] :  | array_flow.rb:946:10:946:10 | d [element 2, element 0] :  |
+| array_flow.rb:945:5:945:5 | d [element 2, element 0] :  | array_flow.rb:946:10:946:10 | d [element 2, element 0] :  |
+| array_flow.rb:945:5:945:5 | d [element 2, element 0] :  | array_flow.rb:947:10:947:10 | d [element 2, element 0] :  |
+| array_flow.rb:945:5:945:5 | d [element 2, element 0] :  | array_flow.rb:947:10:947:10 | d [element 2, element 0] :  |
+| array_flow.rb:945:16:945:16 | c [element 0] :  | array_flow.rb:945:5:945:5 | d [element 2, element 0] :  |
+| array_flow.rb:945:16:945:16 | c [element 0] :  | array_flow.rb:945:5:945:5 | d [element 2, element 0] :  |
 | array_flow.rb:946:10:946:10 | d [element 2, element 0] :  | array_flow.rb:946:10:946:22 | call to rassoc [element 0] :  |
 | array_flow.rb:946:10:946:10 | d [element 2, element 0] :  | array_flow.rb:946:10:946:22 | call to rassoc [element 0] :  |
 | array_flow.rb:946:10:946:22 | call to rassoc [element 0] :  | array_flow.rb:946:10:946:25 | ...[...] |
@@ -1697,14 +2132,18 @@ edges
 | array_flow.rb:947:10:947:10 | d [element 2, element 0] :  | array_flow.rb:947:10:947:22 | call to rassoc [element 0] :  |
 | array_flow.rb:947:10:947:22 | call to rassoc [element 0] :  | array_flow.rb:947:10:947:25 | ...[...] |
 | array_flow.rb:947:10:947:22 | call to rassoc [element 0] :  | array_flow.rb:947:10:947:25 | ...[...] |
-| array_flow.rb:951:10:951:21 | call to source :  | array_flow.rb:952:9:952:9 | a [element 0] :  |
-| array_flow.rb:951:10:951:21 | call to source :  | array_flow.rb:952:9:952:9 | a [element 0] :  |
-| array_flow.rb:951:10:951:21 | call to source :  | array_flow.rb:957:9:957:9 | a [element 0] :  |
-| array_flow.rb:951:10:951:21 | call to source :  | array_flow.rb:957:9:957:9 | a [element 0] :  |
-| array_flow.rb:951:27:951:38 | call to source :  | array_flow.rb:952:9:952:9 | a [element 2] :  |
-| array_flow.rb:951:27:951:38 | call to source :  | array_flow.rb:952:9:952:9 | a [element 2] :  |
-| array_flow.rb:951:27:951:38 | call to source :  | array_flow.rb:957:9:957:9 | a [element 2] :  |
-| array_flow.rb:951:27:951:38 | call to source :  | array_flow.rb:957:9:957:9 | a [element 2] :  |
+| array_flow.rb:951:5:951:5 | a [element 0] :  | array_flow.rb:952:9:952:9 | a [element 0] :  |
+| array_flow.rb:951:5:951:5 | a [element 0] :  | array_flow.rb:952:9:952:9 | a [element 0] :  |
+| array_flow.rb:951:5:951:5 | a [element 0] :  | array_flow.rb:957:9:957:9 | a [element 0] :  |
+| array_flow.rb:951:5:951:5 | a [element 0] :  | array_flow.rb:957:9:957:9 | a [element 0] :  |
+| array_flow.rb:951:5:951:5 | a [element 2] :  | array_flow.rb:952:9:952:9 | a [element 2] :  |
+| array_flow.rb:951:5:951:5 | a [element 2] :  | array_flow.rb:952:9:952:9 | a [element 2] :  |
+| array_flow.rb:951:5:951:5 | a [element 2] :  | array_flow.rb:957:9:957:9 | a [element 2] :  |
+| array_flow.rb:951:5:951:5 | a [element 2] :  | array_flow.rb:957:9:957:9 | a [element 2] :  |
+| array_flow.rb:951:10:951:21 | call to source :  | array_flow.rb:951:5:951:5 | a [element 0] :  |
+| array_flow.rb:951:10:951:21 | call to source :  | array_flow.rb:951:5:951:5 | a [element 0] :  |
+| array_flow.rb:951:27:951:38 | call to source :  | array_flow.rb:951:5:951:5 | a [element 2] :  |
+| array_flow.rb:951:27:951:38 | call to source :  | array_flow.rb:951:5:951:5 | a [element 2] :  |
 | array_flow.rb:952:9:952:9 | a [element 0] :  | array_flow.rb:952:22:952:22 | x :  |
 | array_flow.rb:952:9:952:9 | a [element 0] :  | array_flow.rb:952:22:952:22 | x :  |
 | array_flow.rb:952:9:952:9 | a [element 2] :  | array_flow.rb:952:25:952:25 | y :  |
@@ -1719,20 +2158,28 @@ edges
 | array_flow.rb:957:9:957:9 | a [element 2] :  | array_flow.rb:957:28:957:28 | y :  |
 | array_flow.rb:957:28:957:28 | y :  | array_flow.rb:959:14:959:14 | y |
 | array_flow.rb:957:28:957:28 | y :  | array_flow.rb:959:14:959:14 | y |
-| array_flow.rb:965:16:965:25 | call to source :  | array_flow.rb:966:9:966:9 | a [element 2] :  |
-| array_flow.rb:965:16:965:25 | call to source :  | array_flow.rb:966:9:966:9 | a [element 2] :  |
+| array_flow.rb:965:5:965:5 | a [element 2] :  | array_flow.rb:966:9:966:9 | a [element 2] :  |
+| array_flow.rb:965:5:965:5 | a [element 2] :  | array_flow.rb:966:9:966:9 | a [element 2] :  |
+| array_flow.rb:965:16:965:25 | call to source :  | array_flow.rb:965:5:965:5 | a [element 2] :  |
+| array_flow.rb:965:16:965:25 | call to source :  | array_flow.rb:965:5:965:5 | a [element 2] :  |
+| array_flow.rb:966:5:966:5 | b [element] :  | array_flow.rb:970:10:970:10 | b [element] :  |
+| array_flow.rb:966:5:966:5 | b [element] :  | array_flow.rb:970:10:970:10 | b [element] :  |
 | array_flow.rb:966:9:966:9 | a [element 2] :  | array_flow.rb:966:9:969:7 | call to reject [element] :  |
 | array_flow.rb:966:9:966:9 | a [element 2] :  | array_flow.rb:966:9:969:7 | call to reject [element] :  |
 | array_flow.rb:966:9:966:9 | a [element 2] :  | array_flow.rb:966:22:966:22 | x :  |
 | array_flow.rb:966:9:966:9 | a [element 2] :  | array_flow.rb:966:22:966:22 | x :  |
-| array_flow.rb:966:9:969:7 | call to reject [element] :  | array_flow.rb:970:10:970:10 | b [element] :  |
-| array_flow.rb:966:9:969:7 | call to reject [element] :  | array_flow.rb:970:10:970:10 | b [element] :  |
+| array_flow.rb:966:9:969:7 | call to reject [element] :  | array_flow.rb:966:5:966:5 | b [element] :  |
+| array_flow.rb:966:9:969:7 | call to reject [element] :  | array_flow.rb:966:5:966:5 | b [element] :  |
 | array_flow.rb:966:22:966:22 | x :  | array_flow.rb:967:14:967:14 | x |
 | array_flow.rb:966:22:966:22 | x :  | array_flow.rb:967:14:967:14 | x |
 | array_flow.rb:970:10:970:10 | b [element] :  | array_flow.rb:970:10:970:13 | ...[...] |
 | array_flow.rb:970:10:970:10 | b [element] :  | array_flow.rb:970:10:970:13 | ...[...] |
-| array_flow.rb:974:16:974:25 | call to source :  | array_flow.rb:975:9:975:9 | a [element 2] :  |
-| array_flow.rb:974:16:974:25 | call to source :  | array_flow.rb:975:9:975:9 | a [element 2] :  |
+| array_flow.rb:974:5:974:5 | a [element 2] :  | array_flow.rb:975:9:975:9 | a [element 2] :  |
+| array_flow.rb:974:5:974:5 | a [element 2] :  | array_flow.rb:975:9:975:9 | a [element 2] :  |
+| array_flow.rb:974:16:974:25 | call to source :  | array_flow.rb:974:5:974:5 | a [element 2] :  |
+| array_flow.rb:974:16:974:25 | call to source :  | array_flow.rb:974:5:974:5 | a [element 2] :  |
+| array_flow.rb:975:5:975:5 | b [element] :  | array_flow.rb:980:10:980:10 | b [element] :  |
+| array_flow.rb:975:5:975:5 | b [element] :  | array_flow.rb:980:10:980:10 | b [element] :  |
 | array_flow.rb:975:9:975:9 | [post] a [element] :  | array_flow.rb:979:10:979:10 | a [element] :  |
 | array_flow.rb:975:9:975:9 | [post] a [element] :  | array_flow.rb:979:10:979:10 | a [element] :  |
 | array_flow.rb:975:9:975:9 | a [element 2] :  | array_flow.rb:975:9:975:9 | [post] a [element] :  |
@@ -1741,22 +2188,26 @@ edges
 | array_flow.rb:975:9:975:9 | a [element 2] :  | array_flow.rb:975:9:978:7 | call to reject! [element] :  |
 | array_flow.rb:975:9:975:9 | a [element 2] :  | array_flow.rb:975:23:975:23 | x :  |
 | array_flow.rb:975:9:975:9 | a [element 2] :  | array_flow.rb:975:23:975:23 | x :  |
-| array_flow.rb:975:9:978:7 | call to reject! [element] :  | array_flow.rb:980:10:980:10 | b [element] :  |
-| array_flow.rb:975:9:978:7 | call to reject! [element] :  | array_flow.rb:980:10:980:10 | b [element] :  |
+| array_flow.rb:975:9:978:7 | call to reject! [element] :  | array_flow.rb:975:5:975:5 | b [element] :  |
+| array_flow.rb:975:9:978:7 | call to reject! [element] :  | array_flow.rb:975:5:975:5 | b [element] :  |
 | array_flow.rb:975:23:975:23 | x :  | array_flow.rb:976:14:976:14 | x |
 | array_flow.rb:975:23:975:23 | x :  | array_flow.rb:976:14:976:14 | x |
 | array_flow.rb:979:10:979:10 | a [element] :  | array_flow.rb:979:10:979:13 | ...[...] |
 | array_flow.rb:979:10:979:10 | a [element] :  | array_flow.rb:979:10:979:13 | ...[...] |
 | array_flow.rb:980:10:980:10 | b [element] :  | array_flow.rb:980:10:980:13 | ...[...] |
 | array_flow.rb:980:10:980:10 | b [element] :  | array_flow.rb:980:10:980:13 | ...[...] |
-| array_flow.rb:984:16:984:25 | call to source :  | array_flow.rb:985:9:985:9 | a [element 2] :  |
-| array_flow.rb:984:16:984:25 | call to source :  | array_flow.rb:985:9:985:9 | a [element 2] :  |
+| array_flow.rb:984:5:984:5 | a [element 2] :  | array_flow.rb:985:9:985:9 | a [element 2] :  |
+| array_flow.rb:984:5:984:5 | a [element 2] :  | array_flow.rb:985:9:985:9 | a [element 2] :  |
+| array_flow.rb:984:16:984:25 | call to source :  | array_flow.rb:984:5:984:5 | a [element 2] :  |
+| array_flow.rb:984:16:984:25 | call to source :  | array_flow.rb:984:5:984:5 | a [element 2] :  |
+| array_flow.rb:985:5:985:5 | b [element 2] :  | array_flow.rb:990:10:990:10 | b [element 2] :  |
+| array_flow.rb:985:5:985:5 | b [element 2] :  | array_flow.rb:990:10:990:10 | b [element 2] :  |
 | array_flow.rb:985:9:985:9 | a [element 2] :  | array_flow.rb:985:9:988:7 | call to repeated_combination [element 2] :  |
 | array_flow.rb:985:9:985:9 | a [element 2] :  | array_flow.rb:985:9:988:7 | call to repeated_combination [element 2] :  |
 | array_flow.rb:985:9:985:9 | a [element 2] :  | array_flow.rb:985:39:985:39 | x [element] :  |
 | array_flow.rb:985:9:985:9 | a [element 2] :  | array_flow.rb:985:39:985:39 | x [element] :  |
-| array_flow.rb:985:9:988:7 | call to repeated_combination [element 2] :  | array_flow.rb:990:10:990:10 | b [element 2] :  |
-| array_flow.rb:985:9:988:7 | call to repeated_combination [element 2] :  | array_flow.rb:990:10:990:10 | b [element 2] :  |
+| array_flow.rb:985:9:988:7 | call to repeated_combination [element 2] :  | array_flow.rb:985:5:985:5 | b [element 2] :  |
+| array_flow.rb:985:9:988:7 | call to repeated_combination [element 2] :  | array_flow.rb:985:5:985:5 | b [element 2] :  |
 | array_flow.rb:985:39:985:39 | x [element] :  | array_flow.rb:986:14:986:14 | x [element] :  |
 | array_flow.rb:985:39:985:39 | x [element] :  | array_flow.rb:986:14:986:14 | x [element] :  |
 | array_flow.rb:985:39:985:39 | x [element] :  | array_flow.rb:987:14:987:14 | x [element] :  |
@@ -1767,14 +2218,18 @@ edges
 | array_flow.rb:987:14:987:14 | x [element] :  | array_flow.rb:987:14:987:17 | ...[...] |
 | array_flow.rb:990:10:990:10 | b [element 2] :  | array_flow.rb:990:10:990:13 | ...[...] |
 | array_flow.rb:990:10:990:10 | b [element 2] :  | array_flow.rb:990:10:990:13 | ...[...] |
-| array_flow.rb:994:16:994:25 | call to source :  | array_flow.rb:995:9:995:9 | a [element 2] :  |
-| array_flow.rb:994:16:994:25 | call to source :  | array_flow.rb:995:9:995:9 | a [element 2] :  |
+| array_flow.rb:994:5:994:5 | a [element 2] :  | array_flow.rb:995:9:995:9 | a [element 2] :  |
+| array_flow.rb:994:5:994:5 | a [element 2] :  | array_flow.rb:995:9:995:9 | a [element 2] :  |
+| array_flow.rb:994:16:994:25 | call to source :  | array_flow.rb:994:5:994:5 | a [element 2] :  |
+| array_flow.rb:994:16:994:25 | call to source :  | array_flow.rb:994:5:994:5 | a [element 2] :  |
+| array_flow.rb:995:5:995:5 | b [element 2] :  | array_flow.rb:1000:10:1000:10 | b [element 2] :  |
+| array_flow.rb:995:5:995:5 | b [element 2] :  | array_flow.rb:1000:10:1000:10 | b [element 2] :  |
 | array_flow.rb:995:9:995:9 | a [element 2] :  | array_flow.rb:995:9:998:7 | call to repeated_permutation [element 2] :  |
 | array_flow.rb:995:9:995:9 | a [element 2] :  | array_flow.rb:995:9:998:7 | call to repeated_permutation [element 2] :  |
 | array_flow.rb:995:9:995:9 | a [element 2] :  | array_flow.rb:995:39:995:39 | x [element] :  |
 | array_flow.rb:995:9:995:9 | a [element 2] :  | array_flow.rb:995:39:995:39 | x [element] :  |
-| array_flow.rb:995:9:998:7 | call to repeated_permutation [element 2] :  | array_flow.rb:1000:10:1000:10 | b [element 2] :  |
-| array_flow.rb:995:9:998:7 | call to repeated_permutation [element 2] :  | array_flow.rb:1000:10:1000:10 | b [element 2] :  |
+| array_flow.rb:995:9:998:7 | call to repeated_permutation [element 2] :  | array_flow.rb:995:5:995:5 | b [element 2] :  |
+| array_flow.rb:995:9:998:7 | call to repeated_permutation [element 2] :  | array_flow.rb:995:5:995:5 | b [element 2] :  |
 | array_flow.rb:995:39:995:39 | x [element] :  | array_flow.rb:996:14:996:14 | x [element] :  |
 | array_flow.rb:995:39:995:39 | x [element] :  | array_flow.rb:996:14:996:14 | x [element] :  |
 | array_flow.rb:995:39:995:39 | x [element] :  | array_flow.rb:997:14:997:14 | x [element] :  |
@@ -1785,10 +2240,12 @@ edges
 | array_flow.rb:997:14:997:14 | x [element] :  | array_flow.rb:997:14:997:17 | ...[...] |
 | array_flow.rb:1000:10:1000:10 | b [element 2] :  | array_flow.rb:1000:10:1000:13 | ...[...] |
 | array_flow.rb:1000:10:1000:10 | b [element 2] :  | array_flow.rb:1000:10:1000:13 | ...[...] |
+| array_flow.rb:1006:5:1006:5 | b [element 0] :  | array_flow.rb:1008:10:1008:10 | b [element 0] :  |
+| array_flow.rb:1006:5:1006:5 | b [element 0] :  | array_flow.rb:1008:10:1008:10 | b [element 0] :  |
 | array_flow.rb:1006:9:1006:9 | [post] a [element 0] :  | array_flow.rb:1007:10:1007:10 | a [element 0] :  |
 | array_flow.rb:1006:9:1006:9 | [post] a [element 0] :  | array_flow.rb:1007:10:1007:10 | a [element 0] :  |
-| array_flow.rb:1006:9:1006:33 | call to replace [element 0] :  | array_flow.rb:1008:10:1008:10 | b [element 0] :  |
-| array_flow.rb:1006:9:1006:33 | call to replace [element 0] :  | array_flow.rb:1008:10:1008:10 | b [element 0] :  |
+| array_flow.rb:1006:9:1006:33 | call to replace [element 0] :  | array_flow.rb:1006:5:1006:5 | b [element 0] :  |
+| array_flow.rb:1006:9:1006:33 | call to replace [element 0] :  | array_flow.rb:1006:5:1006:5 | b [element 0] :  |
 | array_flow.rb:1006:20:1006:31 | call to source :  | array_flow.rb:1006:9:1006:9 | [post] a [element 0] :  |
 | array_flow.rb:1006:20:1006:31 | call to source :  | array_flow.rb:1006:9:1006:9 | [post] a [element 0] :  |
 | array_flow.rb:1006:20:1006:31 | call to source :  | array_flow.rb:1006:9:1006:33 | call to replace [element 0] :  |
@@ -1797,24 +2254,30 @@ edges
 | array_flow.rb:1007:10:1007:10 | a [element 0] :  | array_flow.rb:1007:10:1007:13 | ...[...] |
 | array_flow.rb:1008:10:1008:10 | b [element 0] :  | array_flow.rb:1008:10:1008:13 | ...[...] |
 | array_flow.rb:1008:10:1008:10 | b [element 0] :  | array_flow.rb:1008:10:1008:13 | ...[...] |
-| array_flow.rb:1012:16:1012:28 | call to source :  | array_flow.rb:1013:9:1013:9 | a [element 2] :  |
-| array_flow.rb:1012:16:1012:28 | call to source :  | array_flow.rb:1013:9:1013:9 | a [element 2] :  |
-| array_flow.rb:1012:16:1012:28 | call to source :  | array_flow.rb:1018:10:1018:10 | a [element 2] :  |
-| array_flow.rb:1012:16:1012:28 | call to source :  | array_flow.rb:1018:10:1018:10 | a [element 2] :  |
-| array_flow.rb:1012:31:1012:43 | call to source :  | array_flow.rb:1013:9:1013:9 | a [element 3] :  |
-| array_flow.rb:1012:31:1012:43 | call to source :  | array_flow.rb:1013:9:1013:9 | a [element 3] :  |
-| array_flow.rb:1012:31:1012:43 | call to source :  | array_flow.rb:1019:10:1019:10 | a [element 3] :  |
-| array_flow.rb:1012:31:1012:43 | call to source :  | array_flow.rb:1019:10:1019:10 | a [element 3] :  |
+| array_flow.rb:1012:5:1012:5 | a [element 2] :  | array_flow.rb:1013:9:1013:9 | a [element 2] :  |
+| array_flow.rb:1012:5:1012:5 | a [element 2] :  | array_flow.rb:1013:9:1013:9 | a [element 2] :  |
+| array_flow.rb:1012:5:1012:5 | a [element 2] :  | array_flow.rb:1018:10:1018:10 | a [element 2] :  |
+| array_flow.rb:1012:5:1012:5 | a [element 2] :  | array_flow.rb:1018:10:1018:10 | a [element 2] :  |
+| array_flow.rb:1012:5:1012:5 | a [element 3] :  | array_flow.rb:1013:9:1013:9 | a [element 3] :  |
+| array_flow.rb:1012:5:1012:5 | a [element 3] :  | array_flow.rb:1013:9:1013:9 | a [element 3] :  |
+| array_flow.rb:1012:5:1012:5 | a [element 3] :  | array_flow.rb:1019:10:1019:10 | a [element 3] :  |
+| array_flow.rb:1012:5:1012:5 | a [element 3] :  | array_flow.rb:1019:10:1019:10 | a [element 3] :  |
+| array_flow.rb:1012:16:1012:28 | call to source :  | array_flow.rb:1012:5:1012:5 | a [element 2] :  |
+| array_flow.rb:1012:16:1012:28 | call to source :  | array_flow.rb:1012:5:1012:5 | a [element 2] :  |
+| array_flow.rb:1012:31:1012:43 | call to source :  | array_flow.rb:1012:5:1012:5 | a [element 3] :  |
+| array_flow.rb:1012:31:1012:43 | call to source :  | array_flow.rb:1012:5:1012:5 | a [element 3] :  |
+| array_flow.rb:1013:5:1013:5 | b [element] :  | array_flow.rb:1014:10:1014:10 | b [element] :  |
+| array_flow.rb:1013:5:1013:5 | b [element] :  | array_flow.rb:1014:10:1014:10 | b [element] :  |
+| array_flow.rb:1013:5:1013:5 | b [element] :  | array_flow.rb:1015:10:1015:10 | b [element] :  |
+| array_flow.rb:1013:5:1013:5 | b [element] :  | array_flow.rb:1015:10:1015:10 | b [element] :  |
+| array_flow.rb:1013:5:1013:5 | b [element] :  | array_flow.rb:1016:10:1016:10 | b [element] :  |
+| array_flow.rb:1013:5:1013:5 | b [element] :  | array_flow.rb:1016:10:1016:10 | b [element] :  |
 | array_flow.rb:1013:9:1013:9 | a [element 2] :  | array_flow.rb:1013:9:1013:17 | call to reverse [element] :  |
 | array_flow.rb:1013:9:1013:9 | a [element 2] :  | array_flow.rb:1013:9:1013:17 | call to reverse [element] :  |
 | array_flow.rb:1013:9:1013:9 | a [element 3] :  | array_flow.rb:1013:9:1013:17 | call to reverse [element] :  |
 | array_flow.rb:1013:9:1013:9 | a [element 3] :  | array_flow.rb:1013:9:1013:17 | call to reverse [element] :  |
-| array_flow.rb:1013:9:1013:17 | call to reverse [element] :  | array_flow.rb:1014:10:1014:10 | b [element] :  |
-| array_flow.rb:1013:9:1013:17 | call to reverse [element] :  | array_flow.rb:1014:10:1014:10 | b [element] :  |
-| array_flow.rb:1013:9:1013:17 | call to reverse [element] :  | array_flow.rb:1015:10:1015:10 | b [element] :  |
-| array_flow.rb:1013:9:1013:17 | call to reverse [element] :  | array_flow.rb:1015:10:1015:10 | b [element] :  |
-| array_flow.rb:1013:9:1013:17 | call to reverse [element] :  | array_flow.rb:1016:10:1016:10 | b [element] :  |
-| array_flow.rb:1013:9:1013:17 | call to reverse [element] :  | array_flow.rb:1016:10:1016:10 | b [element] :  |
+| array_flow.rb:1013:9:1013:17 | call to reverse [element] :  | array_flow.rb:1013:5:1013:5 | b [element] :  |
+| array_flow.rb:1013:9:1013:17 | call to reverse [element] :  | array_flow.rb:1013:5:1013:5 | b [element] :  |
 | array_flow.rb:1014:10:1014:10 | b [element] :  | array_flow.rb:1014:10:1014:13 | ...[...] |
 | array_flow.rb:1014:10:1014:10 | b [element] :  | array_flow.rb:1014:10:1014:13 | ...[...] |
 | array_flow.rb:1015:10:1015:10 | b [element] :  | array_flow.rb:1015:10:1015:13 | ...[...] |
@@ -1825,14 +2288,24 @@ edges
 | array_flow.rb:1018:10:1018:10 | a [element 2] :  | array_flow.rb:1018:10:1018:13 | ...[...] |
 | array_flow.rb:1019:10:1019:10 | a [element 3] :  | array_flow.rb:1019:10:1019:13 | ...[...] |
 | array_flow.rb:1019:10:1019:10 | a [element 3] :  | array_flow.rb:1019:10:1019:13 | ...[...] |
-| array_flow.rb:1023:16:1023:28 | call to source :  | array_flow.rb:1024:9:1024:9 | a [element 2] :  |
-| array_flow.rb:1023:16:1023:28 | call to source :  | array_flow.rb:1024:9:1024:9 | a [element 2] :  |
-| array_flow.rb:1023:16:1023:28 | call to source :  | array_flow.rb:1029:10:1029:10 | a [element 2] :  |
-| array_flow.rb:1023:16:1023:28 | call to source :  | array_flow.rb:1029:10:1029:10 | a [element 2] :  |
-| array_flow.rb:1023:31:1023:43 | call to source :  | array_flow.rb:1024:9:1024:9 | a [element 3] :  |
-| array_flow.rb:1023:31:1023:43 | call to source :  | array_flow.rb:1024:9:1024:9 | a [element 3] :  |
-| array_flow.rb:1023:31:1023:43 | call to source :  | array_flow.rb:1030:10:1030:10 | a [element 3] :  |
-| array_flow.rb:1023:31:1023:43 | call to source :  | array_flow.rb:1030:10:1030:10 | a [element 3] :  |
+| array_flow.rb:1023:5:1023:5 | a [element 2] :  | array_flow.rb:1024:9:1024:9 | a [element 2] :  |
+| array_flow.rb:1023:5:1023:5 | a [element 2] :  | array_flow.rb:1024:9:1024:9 | a [element 2] :  |
+| array_flow.rb:1023:5:1023:5 | a [element 2] :  | array_flow.rb:1029:10:1029:10 | a [element 2] :  |
+| array_flow.rb:1023:5:1023:5 | a [element 2] :  | array_flow.rb:1029:10:1029:10 | a [element 2] :  |
+| array_flow.rb:1023:5:1023:5 | a [element 3] :  | array_flow.rb:1024:9:1024:9 | a [element 3] :  |
+| array_flow.rb:1023:5:1023:5 | a [element 3] :  | array_flow.rb:1024:9:1024:9 | a [element 3] :  |
+| array_flow.rb:1023:5:1023:5 | a [element 3] :  | array_flow.rb:1030:10:1030:10 | a [element 3] :  |
+| array_flow.rb:1023:5:1023:5 | a [element 3] :  | array_flow.rb:1030:10:1030:10 | a [element 3] :  |
+| array_flow.rb:1023:16:1023:28 | call to source :  | array_flow.rb:1023:5:1023:5 | a [element 2] :  |
+| array_flow.rb:1023:16:1023:28 | call to source :  | array_flow.rb:1023:5:1023:5 | a [element 2] :  |
+| array_flow.rb:1023:31:1023:43 | call to source :  | array_flow.rb:1023:5:1023:5 | a [element 3] :  |
+| array_flow.rb:1023:31:1023:43 | call to source :  | array_flow.rb:1023:5:1023:5 | a [element 3] :  |
+| array_flow.rb:1024:5:1024:5 | b [element] :  | array_flow.rb:1025:10:1025:10 | b [element] :  |
+| array_flow.rb:1024:5:1024:5 | b [element] :  | array_flow.rb:1025:10:1025:10 | b [element] :  |
+| array_flow.rb:1024:5:1024:5 | b [element] :  | array_flow.rb:1026:10:1026:10 | b [element] :  |
+| array_flow.rb:1024:5:1024:5 | b [element] :  | array_flow.rb:1026:10:1026:10 | b [element] :  |
+| array_flow.rb:1024:5:1024:5 | b [element] :  | array_flow.rb:1027:10:1027:10 | b [element] :  |
+| array_flow.rb:1024:5:1024:5 | b [element] :  | array_flow.rb:1027:10:1027:10 | b [element] :  |
 | array_flow.rb:1024:9:1024:9 | [post] a [element] :  | array_flow.rb:1028:10:1028:10 | a [element] :  |
 | array_flow.rb:1024:9:1024:9 | [post] a [element] :  | array_flow.rb:1028:10:1028:10 | a [element] :  |
 | array_flow.rb:1024:9:1024:9 | [post] a [element] :  | array_flow.rb:1029:10:1029:10 | a [element] :  |
@@ -1847,12 +2320,8 @@ edges
 | array_flow.rb:1024:9:1024:9 | a [element 3] :  | array_flow.rb:1024:9:1024:9 | [post] a [element] :  |
 | array_flow.rb:1024:9:1024:9 | a [element 3] :  | array_flow.rb:1024:9:1024:18 | call to reverse! [element] :  |
 | array_flow.rb:1024:9:1024:9 | a [element 3] :  | array_flow.rb:1024:9:1024:18 | call to reverse! [element] :  |
-| array_flow.rb:1024:9:1024:18 | call to reverse! [element] :  | array_flow.rb:1025:10:1025:10 | b [element] :  |
-| array_flow.rb:1024:9:1024:18 | call to reverse! [element] :  | array_flow.rb:1025:10:1025:10 | b [element] :  |
-| array_flow.rb:1024:9:1024:18 | call to reverse! [element] :  | array_flow.rb:1026:10:1026:10 | b [element] :  |
-| array_flow.rb:1024:9:1024:18 | call to reverse! [element] :  | array_flow.rb:1026:10:1026:10 | b [element] :  |
-| array_flow.rb:1024:9:1024:18 | call to reverse! [element] :  | array_flow.rb:1027:10:1027:10 | b [element] :  |
-| array_flow.rb:1024:9:1024:18 | call to reverse! [element] :  | array_flow.rb:1027:10:1027:10 | b [element] :  |
+| array_flow.rb:1024:9:1024:18 | call to reverse! [element] :  | array_flow.rb:1024:5:1024:5 | b [element] :  |
+| array_flow.rb:1024:9:1024:18 | call to reverse! [element] :  | array_flow.rb:1024:5:1024:5 | b [element] :  |
 | array_flow.rb:1025:10:1025:10 | b [element] :  | array_flow.rb:1025:10:1025:13 | ...[...] |
 | array_flow.rb:1025:10:1025:10 | b [element] :  | array_flow.rb:1025:10:1025:13 | ...[...] |
 | array_flow.rb:1026:10:1026:10 | b [element] :  | array_flow.rb:1026:10:1026:13 | ...[...] |
@@ -1869,66 +2338,84 @@ edges
 | array_flow.rb:1030:10:1030:10 | a [element 3] :  | array_flow.rb:1030:10:1030:13 | ...[...] |
 | array_flow.rb:1030:10:1030:10 | a [element] :  | array_flow.rb:1030:10:1030:13 | ...[...] |
 | array_flow.rb:1030:10:1030:10 | a [element] :  | array_flow.rb:1030:10:1030:13 | ...[...] |
-| array_flow.rb:1034:16:1034:26 | call to source :  | array_flow.rb:1035:9:1035:9 | a [element 2] :  |
-| array_flow.rb:1034:16:1034:26 | call to source :  | array_flow.rb:1035:9:1035:9 | a [element 2] :  |
+| array_flow.rb:1034:5:1034:5 | a [element 2] :  | array_flow.rb:1035:9:1035:9 | a [element 2] :  |
+| array_flow.rb:1034:5:1034:5 | a [element 2] :  | array_flow.rb:1035:9:1035:9 | a [element 2] :  |
+| array_flow.rb:1034:16:1034:26 | call to source :  | array_flow.rb:1034:5:1034:5 | a [element 2] :  |
+| array_flow.rb:1034:16:1034:26 | call to source :  | array_flow.rb:1034:5:1034:5 | a [element 2] :  |
+| array_flow.rb:1035:5:1035:5 | b [element 2] :  | array_flow.rb:1038:10:1038:10 | b [element 2] :  |
+| array_flow.rb:1035:5:1035:5 | b [element 2] :  | array_flow.rb:1038:10:1038:10 | b [element 2] :  |
 | array_flow.rb:1035:9:1035:9 | a [element 2] :  | array_flow.rb:1035:9:1037:7 | call to reverse_each [element 2] :  |
 | array_flow.rb:1035:9:1035:9 | a [element 2] :  | array_flow.rb:1035:9:1037:7 | call to reverse_each [element 2] :  |
 | array_flow.rb:1035:9:1035:9 | a [element 2] :  | array_flow.rb:1035:28:1035:28 | x :  |
 | array_flow.rb:1035:9:1035:9 | a [element 2] :  | array_flow.rb:1035:28:1035:28 | x :  |
-| array_flow.rb:1035:9:1037:7 | call to reverse_each [element 2] :  | array_flow.rb:1038:10:1038:10 | b [element 2] :  |
-| array_flow.rb:1035:9:1037:7 | call to reverse_each [element 2] :  | array_flow.rb:1038:10:1038:10 | b [element 2] :  |
+| array_flow.rb:1035:9:1037:7 | call to reverse_each [element 2] :  | array_flow.rb:1035:5:1035:5 | b [element 2] :  |
+| array_flow.rb:1035:9:1037:7 | call to reverse_each [element 2] :  | array_flow.rb:1035:5:1035:5 | b [element 2] :  |
 | array_flow.rb:1035:28:1035:28 | x :  | array_flow.rb:1036:14:1036:14 | x |
 | array_flow.rb:1035:28:1035:28 | x :  | array_flow.rb:1036:14:1036:14 | x |
 | array_flow.rb:1038:10:1038:10 | b [element 2] :  | array_flow.rb:1038:10:1038:13 | ...[...] |
 | array_flow.rb:1038:10:1038:10 | b [element 2] :  | array_flow.rb:1038:10:1038:13 | ...[...] |
-| array_flow.rb:1042:16:1042:26 | call to source :  | array_flow.rb:1043:5:1043:5 | a [element 2] :  |
-| array_flow.rb:1042:16:1042:26 | call to source :  | array_flow.rb:1043:5:1043:5 | a [element 2] :  |
+| array_flow.rb:1042:5:1042:5 | a [element 2] :  | array_flow.rb:1043:5:1043:5 | a [element 2] :  |
+| array_flow.rb:1042:5:1042:5 | a [element 2] :  | array_flow.rb:1043:5:1043:5 | a [element 2] :  |
+| array_flow.rb:1042:16:1042:26 | call to source :  | array_flow.rb:1042:5:1042:5 | a [element 2] :  |
+| array_flow.rb:1042:16:1042:26 | call to source :  | array_flow.rb:1042:5:1042:5 | a [element 2] :  |
 | array_flow.rb:1043:5:1043:5 | a [element 2] :  | array_flow.rb:1043:18:1043:18 | x :  |
 | array_flow.rb:1043:5:1043:5 | a [element 2] :  | array_flow.rb:1043:18:1043:18 | x :  |
 | array_flow.rb:1043:18:1043:18 | x :  | array_flow.rb:1044:14:1044:14 | x |
 | array_flow.rb:1043:18:1043:18 | x :  | array_flow.rb:1044:14:1044:14 | x |
-| array_flow.rb:1052:10:1052:22 | call to source :  | array_flow.rb:1054:9:1054:9 | a [element 0] :  |
-| array_flow.rb:1052:10:1052:22 | call to source :  | array_flow.rb:1054:9:1054:9 | a [element 0] :  |
-| array_flow.rb:1052:10:1052:22 | call to source :  | array_flow.rb:1060:9:1060:9 | a [element 0] :  |
-| array_flow.rb:1052:10:1052:22 | call to source :  | array_flow.rb:1060:9:1060:9 | a [element 0] :  |
-| array_flow.rb:1052:10:1052:22 | call to source :  | array_flow.rb:1066:9:1066:9 | a [element 0] :  |
-| array_flow.rb:1052:10:1052:22 | call to source :  | array_flow.rb:1066:9:1066:9 | a [element 0] :  |
-| array_flow.rb:1052:10:1052:22 | call to source :  | array_flow.rb:1072:9:1072:9 | a [element 0] :  |
-| array_flow.rb:1052:10:1052:22 | call to source :  | array_flow.rb:1072:9:1072:9 | a [element 0] :  |
-| array_flow.rb:1052:28:1052:40 | call to source :  | array_flow.rb:1054:9:1054:9 | a [element 2] :  |
-| array_flow.rb:1052:28:1052:40 | call to source :  | array_flow.rb:1054:9:1054:9 | a [element 2] :  |
-| array_flow.rb:1052:28:1052:40 | call to source :  | array_flow.rb:1060:9:1060:9 | a [element 2] :  |
-| array_flow.rb:1052:28:1052:40 | call to source :  | array_flow.rb:1060:9:1060:9 | a [element 2] :  |
-| array_flow.rb:1052:28:1052:40 | call to source :  | array_flow.rb:1066:9:1066:9 | a [element 2] :  |
-| array_flow.rb:1052:28:1052:40 | call to source :  | array_flow.rb:1066:9:1066:9 | a [element 2] :  |
-| array_flow.rb:1052:28:1052:40 | call to source :  | array_flow.rb:1072:9:1072:9 | a [element 2] :  |
-| array_flow.rb:1052:28:1052:40 | call to source :  | array_flow.rb:1072:9:1072:9 | a [element 2] :  |
-| array_flow.rb:1052:43:1052:55 | call to source :  | array_flow.rb:1054:9:1054:9 | a [element 3] :  |
-| array_flow.rb:1052:43:1052:55 | call to source :  | array_flow.rb:1054:9:1054:9 | a [element 3] :  |
-| array_flow.rb:1052:43:1052:55 | call to source :  | array_flow.rb:1060:9:1060:9 | a [element 3] :  |
-| array_flow.rb:1052:43:1052:55 | call to source :  | array_flow.rb:1060:9:1060:9 | a [element 3] :  |
-| array_flow.rb:1052:43:1052:55 | call to source :  | array_flow.rb:1066:9:1066:9 | a [element 3] :  |
-| array_flow.rb:1052:43:1052:55 | call to source :  | array_flow.rb:1066:9:1066:9 | a [element 3] :  |
-| array_flow.rb:1052:43:1052:55 | call to source :  | array_flow.rb:1072:9:1072:9 | a [element 3] :  |
-| array_flow.rb:1052:43:1052:55 | call to source :  | array_flow.rb:1072:9:1072:9 | a [element 3] :  |
+| array_flow.rb:1052:5:1052:5 | a [element 0] :  | array_flow.rb:1054:9:1054:9 | a [element 0] :  |
+| array_flow.rb:1052:5:1052:5 | a [element 0] :  | array_flow.rb:1054:9:1054:9 | a [element 0] :  |
+| array_flow.rb:1052:5:1052:5 | a [element 0] :  | array_flow.rb:1060:9:1060:9 | a [element 0] :  |
+| array_flow.rb:1052:5:1052:5 | a [element 0] :  | array_flow.rb:1060:9:1060:9 | a [element 0] :  |
+| array_flow.rb:1052:5:1052:5 | a [element 0] :  | array_flow.rb:1066:9:1066:9 | a [element 0] :  |
+| array_flow.rb:1052:5:1052:5 | a [element 0] :  | array_flow.rb:1066:9:1066:9 | a [element 0] :  |
+| array_flow.rb:1052:5:1052:5 | a [element 0] :  | array_flow.rb:1072:9:1072:9 | a [element 0] :  |
+| array_flow.rb:1052:5:1052:5 | a [element 0] :  | array_flow.rb:1072:9:1072:9 | a [element 0] :  |
+| array_flow.rb:1052:5:1052:5 | a [element 2] :  | array_flow.rb:1054:9:1054:9 | a [element 2] :  |
+| array_flow.rb:1052:5:1052:5 | a [element 2] :  | array_flow.rb:1054:9:1054:9 | a [element 2] :  |
+| array_flow.rb:1052:5:1052:5 | a [element 2] :  | array_flow.rb:1060:9:1060:9 | a [element 2] :  |
+| array_flow.rb:1052:5:1052:5 | a [element 2] :  | array_flow.rb:1060:9:1060:9 | a [element 2] :  |
+| array_flow.rb:1052:5:1052:5 | a [element 2] :  | array_flow.rb:1066:9:1066:9 | a [element 2] :  |
+| array_flow.rb:1052:5:1052:5 | a [element 2] :  | array_flow.rb:1066:9:1066:9 | a [element 2] :  |
+| array_flow.rb:1052:5:1052:5 | a [element 2] :  | array_flow.rb:1072:9:1072:9 | a [element 2] :  |
+| array_flow.rb:1052:5:1052:5 | a [element 2] :  | array_flow.rb:1072:9:1072:9 | a [element 2] :  |
+| array_flow.rb:1052:5:1052:5 | a [element 3] :  | array_flow.rb:1054:9:1054:9 | a [element 3] :  |
+| array_flow.rb:1052:5:1052:5 | a [element 3] :  | array_flow.rb:1054:9:1054:9 | a [element 3] :  |
+| array_flow.rb:1052:5:1052:5 | a [element 3] :  | array_flow.rb:1060:9:1060:9 | a [element 3] :  |
+| array_flow.rb:1052:5:1052:5 | a [element 3] :  | array_flow.rb:1060:9:1060:9 | a [element 3] :  |
+| array_flow.rb:1052:5:1052:5 | a [element 3] :  | array_flow.rb:1066:9:1066:9 | a [element 3] :  |
+| array_flow.rb:1052:5:1052:5 | a [element 3] :  | array_flow.rb:1066:9:1066:9 | a [element 3] :  |
+| array_flow.rb:1052:5:1052:5 | a [element 3] :  | array_flow.rb:1072:9:1072:9 | a [element 3] :  |
+| array_flow.rb:1052:5:1052:5 | a [element 3] :  | array_flow.rb:1072:9:1072:9 | a [element 3] :  |
+| array_flow.rb:1052:10:1052:22 | call to source :  | array_flow.rb:1052:5:1052:5 | a [element 0] :  |
+| array_flow.rb:1052:10:1052:22 | call to source :  | array_flow.rb:1052:5:1052:5 | a [element 0] :  |
+| array_flow.rb:1052:28:1052:40 | call to source :  | array_flow.rb:1052:5:1052:5 | a [element 2] :  |
+| array_flow.rb:1052:28:1052:40 | call to source :  | array_flow.rb:1052:5:1052:5 | a [element 2] :  |
+| array_flow.rb:1052:43:1052:55 | call to source :  | array_flow.rb:1052:5:1052:5 | a [element 3] :  |
+| array_flow.rb:1052:43:1052:55 | call to source :  | array_flow.rb:1052:5:1052:5 | a [element 3] :  |
+| array_flow.rb:1054:5:1054:5 | b [element 1] :  | array_flow.rb:1056:10:1056:10 | b [element 1] :  |
+| array_flow.rb:1054:5:1054:5 | b [element 1] :  | array_flow.rb:1056:10:1056:10 | b [element 1] :  |
+| array_flow.rb:1054:5:1054:5 | b [element 2] :  | array_flow.rb:1057:10:1057:10 | b [element 2] :  |
+| array_flow.rb:1054:5:1054:5 | b [element 2] :  | array_flow.rb:1057:10:1057:10 | b [element 2] :  |
+| array_flow.rb:1054:5:1054:5 | b [element] :  | array_flow.rb:1055:10:1055:10 | b [element] :  |
+| array_flow.rb:1054:5:1054:5 | b [element] :  | array_flow.rb:1055:10:1055:10 | b [element] :  |
+| array_flow.rb:1054:5:1054:5 | b [element] :  | array_flow.rb:1056:10:1056:10 | b [element] :  |
+| array_flow.rb:1054:5:1054:5 | b [element] :  | array_flow.rb:1056:10:1056:10 | b [element] :  |
+| array_flow.rb:1054:5:1054:5 | b [element] :  | array_flow.rb:1057:10:1057:10 | b [element] :  |
+| array_flow.rb:1054:5:1054:5 | b [element] :  | array_flow.rb:1057:10:1057:10 | b [element] :  |
+| array_flow.rb:1054:5:1054:5 | b [element] :  | array_flow.rb:1058:10:1058:10 | b [element] :  |
+| array_flow.rb:1054:5:1054:5 | b [element] :  | array_flow.rb:1058:10:1058:10 | b [element] :  |
 | array_flow.rb:1054:9:1054:9 | a [element 0] :  | array_flow.rb:1054:9:1054:16 | call to rotate [element] :  |
 | array_flow.rb:1054:9:1054:9 | a [element 0] :  | array_flow.rb:1054:9:1054:16 | call to rotate [element] :  |
 | array_flow.rb:1054:9:1054:9 | a [element 2] :  | array_flow.rb:1054:9:1054:16 | call to rotate [element 1] :  |
 | array_flow.rb:1054:9:1054:9 | a [element 2] :  | array_flow.rb:1054:9:1054:16 | call to rotate [element 1] :  |
 | array_flow.rb:1054:9:1054:9 | a [element 3] :  | array_flow.rb:1054:9:1054:16 | call to rotate [element 2] :  |
 | array_flow.rb:1054:9:1054:9 | a [element 3] :  | array_flow.rb:1054:9:1054:16 | call to rotate [element 2] :  |
-| array_flow.rb:1054:9:1054:16 | call to rotate [element 1] :  | array_flow.rb:1056:10:1056:10 | b [element 1] :  |
-| array_flow.rb:1054:9:1054:16 | call to rotate [element 1] :  | array_flow.rb:1056:10:1056:10 | b [element 1] :  |
-| array_flow.rb:1054:9:1054:16 | call to rotate [element 2] :  | array_flow.rb:1057:10:1057:10 | b [element 2] :  |
-| array_flow.rb:1054:9:1054:16 | call to rotate [element 2] :  | array_flow.rb:1057:10:1057:10 | b [element 2] :  |
-| array_flow.rb:1054:9:1054:16 | call to rotate [element] :  | array_flow.rb:1055:10:1055:10 | b [element] :  |
-| array_flow.rb:1054:9:1054:16 | call to rotate [element] :  | array_flow.rb:1055:10:1055:10 | b [element] :  |
-| array_flow.rb:1054:9:1054:16 | call to rotate [element] :  | array_flow.rb:1056:10:1056:10 | b [element] :  |
-| array_flow.rb:1054:9:1054:16 | call to rotate [element] :  | array_flow.rb:1056:10:1056:10 | b [element] :  |
-| array_flow.rb:1054:9:1054:16 | call to rotate [element] :  | array_flow.rb:1057:10:1057:10 | b [element] :  |
-| array_flow.rb:1054:9:1054:16 | call to rotate [element] :  | array_flow.rb:1057:10:1057:10 | b [element] :  |
-| array_flow.rb:1054:9:1054:16 | call to rotate [element] :  | array_flow.rb:1058:10:1058:10 | b [element] :  |
-| array_flow.rb:1054:9:1054:16 | call to rotate [element] :  | array_flow.rb:1058:10:1058:10 | b [element] :  |
+| array_flow.rb:1054:9:1054:16 | call to rotate [element 1] :  | array_flow.rb:1054:5:1054:5 | b [element 1] :  |
+| array_flow.rb:1054:9:1054:16 | call to rotate [element 1] :  | array_flow.rb:1054:5:1054:5 | b [element 1] :  |
+| array_flow.rb:1054:9:1054:16 | call to rotate [element 2] :  | array_flow.rb:1054:5:1054:5 | b [element 2] :  |
+| array_flow.rb:1054:9:1054:16 | call to rotate [element 2] :  | array_flow.rb:1054:5:1054:5 | b [element 2] :  |
+| array_flow.rb:1054:9:1054:16 | call to rotate [element] :  | array_flow.rb:1054:5:1054:5 | b [element] :  |
+| array_flow.rb:1054:9:1054:16 | call to rotate [element] :  | array_flow.rb:1054:5:1054:5 | b [element] :  |
 | array_flow.rb:1055:10:1055:10 | b [element] :  | array_flow.rb:1055:10:1055:13 | ...[...] |
 | array_flow.rb:1055:10:1055:10 | b [element] :  | array_flow.rb:1055:10:1055:13 | ...[...] |
 | array_flow.rb:1056:10:1056:10 | b [element 1] :  | array_flow.rb:1056:10:1056:13 | ...[...] |
@@ -1941,24 +2428,30 @@ edges
 | array_flow.rb:1057:10:1057:10 | b [element] :  | array_flow.rb:1057:10:1057:13 | ...[...] |
 | array_flow.rb:1058:10:1058:10 | b [element] :  | array_flow.rb:1058:10:1058:13 | ...[...] |
 | array_flow.rb:1058:10:1058:10 | b [element] :  | array_flow.rb:1058:10:1058:13 | ...[...] |
+| array_flow.rb:1060:5:1060:5 | b [element 0] :  | array_flow.rb:1061:10:1061:10 | b [element 0] :  |
+| array_flow.rb:1060:5:1060:5 | b [element 0] :  | array_flow.rb:1061:10:1061:10 | b [element 0] :  |
+| array_flow.rb:1060:5:1060:5 | b [element 1] :  | array_flow.rb:1062:10:1062:10 | b [element 1] :  |
+| array_flow.rb:1060:5:1060:5 | b [element 1] :  | array_flow.rb:1062:10:1062:10 | b [element 1] :  |
+| array_flow.rb:1060:5:1060:5 | b [element] :  | array_flow.rb:1061:10:1061:10 | b [element] :  |
+| array_flow.rb:1060:5:1060:5 | b [element] :  | array_flow.rb:1061:10:1061:10 | b [element] :  |
+| array_flow.rb:1060:5:1060:5 | b [element] :  | array_flow.rb:1062:10:1062:10 | b [element] :  |
+| array_flow.rb:1060:5:1060:5 | b [element] :  | array_flow.rb:1062:10:1062:10 | b [element] :  |
+| array_flow.rb:1060:5:1060:5 | b [element] :  | array_flow.rb:1063:10:1063:10 | b [element] :  |
+| array_flow.rb:1060:5:1060:5 | b [element] :  | array_flow.rb:1063:10:1063:10 | b [element] :  |
+| array_flow.rb:1060:5:1060:5 | b [element] :  | array_flow.rb:1064:10:1064:10 | b [element] :  |
+| array_flow.rb:1060:5:1060:5 | b [element] :  | array_flow.rb:1064:10:1064:10 | b [element] :  |
 | array_flow.rb:1060:9:1060:9 | a [element 0] :  | array_flow.rb:1060:9:1060:19 | call to rotate [element] :  |
 | array_flow.rb:1060:9:1060:9 | a [element 0] :  | array_flow.rb:1060:9:1060:19 | call to rotate [element] :  |
 | array_flow.rb:1060:9:1060:9 | a [element 2] :  | array_flow.rb:1060:9:1060:19 | call to rotate [element 0] :  |
 | array_flow.rb:1060:9:1060:9 | a [element 2] :  | array_flow.rb:1060:9:1060:19 | call to rotate [element 0] :  |
 | array_flow.rb:1060:9:1060:9 | a [element 3] :  | array_flow.rb:1060:9:1060:19 | call to rotate [element 1] :  |
 | array_flow.rb:1060:9:1060:9 | a [element 3] :  | array_flow.rb:1060:9:1060:19 | call to rotate [element 1] :  |
-| array_flow.rb:1060:9:1060:19 | call to rotate [element 0] :  | array_flow.rb:1061:10:1061:10 | b [element 0] :  |
-| array_flow.rb:1060:9:1060:19 | call to rotate [element 0] :  | array_flow.rb:1061:10:1061:10 | b [element 0] :  |
-| array_flow.rb:1060:9:1060:19 | call to rotate [element 1] :  | array_flow.rb:1062:10:1062:10 | b [element 1] :  |
-| array_flow.rb:1060:9:1060:19 | call to rotate [element 1] :  | array_flow.rb:1062:10:1062:10 | b [element 1] :  |
-| array_flow.rb:1060:9:1060:19 | call to rotate [element] :  | array_flow.rb:1061:10:1061:10 | b [element] :  |
-| array_flow.rb:1060:9:1060:19 | call to rotate [element] :  | array_flow.rb:1061:10:1061:10 | b [element] :  |
-| array_flow.rb:1060:9:1060:19 | call to rotate [element] :  | array_flow.rb:1062:10:1062:10 | b [element] :  |
-| array_flow.rb:1060:9:1060:19 | call to rotate [element] :  | array_flow.rb:1062:10:1062:10 | b [element] :  |
-| array_flow.rb:1060:9:1060:19 | call to rotate [element] :  | array_flow.rb:1063:10:1063:10 | b [element] :  |
-| array_flow.rb:1060:9:1060:19 | call to rotate [element] :  | array_flow.rb:1063:10:1063:10 | b [element] :  |
-| array_flow.rb:1060:9:1060:19 | call to rotate [element] :  | array_flow.rb:1064:10:1064:10 | b [element] :  |
-| array_flow.rb:1060:9:1060:19 | call to rotate [element] :  | array_flow.rb:1064:10:1064:10 | b [element] :  |
+| array_flow.rb:1060:9:1060:19 | call to rotate [element 0] :  | array_flow.rb:1060:5:1060:5 | b [element 0] :  |
+| array_flow.rb:1060:9:1060:19 | call to rotate [element 0] :  | array_flow.rb:1060:5:1060:5 | b [element 0] :  |
+| array_flow.rb:1060:9:1060:19 | call to rotate [element 1] :  | array_flow.rb:1060:5:1060:5 | b [element 1] :  |
+| array_flow.rb:1060:9:1060:19 | call to rotate [element 1] :  | array_flow.rb:1060:5:1060:5 | b [element 1] :  |
+| array_flow.rb:1060:9:1060:19 | call to rotate [element] :  | array_flow.rb:1060:5:1060:5 | b [element] :  |
+| array_flow.rb:1060:9:1060:19 | call to rotate [element] :  | array_flow.rb:1060:5:1060:5 | b [element] :  |
 | array_flow.rb:1061:10:1061:10 | b [element 0] :  | array_flow.rb:1061:10:1061:13 | ...[...] |
 | array_flow.rb:1061:10:1061:10 | b [element 0] :  | array_flow.rb:1061:10:1061:13 | ...[...] |
 | array_flow.rb:1061:10:1061:10 | b [element] :  | array_flow.rb:1061:10:1061:13 | ...[...] |
@@ -1971,38 +2464,46 @@ edges
 | array_flow.rb:1063:10:1063:10 | b [element] :  | array_flow.rb:1063:10:1063:13 | ...[...] |
 | array_flow.rb:1064:10:1064:10 | b [element] :  | array_flow.rb:1064:10:1064:13 | ...[...] |
 | array_flow.rb:1064:10:1064:10 | b [element] :  | array_flow.rb:1064:10:1064:13 | ...[...] |
+| array_flow.rb:1066:5:1066:5 | b [element 0] :  | array_flow.rb:1067:10:1067:10 | b [element 0] :  |
+| array_flow.rb:1066:5:1066:5 | b [element 0] :  | array_flow.rb:1067:10:1067:10 | b [element 0] :  |
+| array_flow.rb:1066:5:1066:5 | b [element 2] :  | array_flow.rb:1069:10:1069:10 | b [element 2] :  |
+| array_flow.rb:1066:5:1066:5 | b [element 2] :  | array_flow.rb:1069:10:1069:10 | b [element 2] :  |
+| array_flow.rb:1066:5:1066:5 | b [element 3] :  | array_flow.rb:1070:10:1070:10 | b [element 3] :  |
+| array_flow.rb:1066:5:1066:5 | b [element 3] :  | array_flow.rb:1070:10:1070:10 | b [element 3] :  |
 | array_flow.rb:1066:9:1066:9 | a [element 0] :  | array_flow.rb:1066:9:1066:19 | call to rotate [element 0] :  |
 | array_flow.rb:1066:9:1066:9 | a [element 0] :  | array_flow.rb:1066:9:1066:19 | call to rotate [element 0] :  |
 | array_flow.rb:1066:9:1066:9 | a [element 2] :  | array_flow.rb:1066:9:1066:19 | call to rotate [element 2] :  |
 | array_flow.rb:1066:9:1066:9 | a [element 2] :  | array_flow.rb:1066:9:1066:19 | call to rotate [element 2] :  |
 | array_flow.rb:1066:9:1066:9 | a [element 3] :  | array_flow.rb:1066:9:1066:19 | call to rotate [element 3] :  |
 | array_flow.rb:1066:9:1066:9 | a [element 3] :  | array_flow.rb:1066:9:1066:19 | call to rotate [element 3] :  |
-| array_flow.rb:1066:9:1066:19 | call to rotate [element 0] :  | array_flow.rb:1067:10:1067:10 | b [element 0] :  |
-| array_flow.rb:1066:9:1066:19 | call to rotate [element 0] :  | array_flow.rb:1067:10:1067:10 | b [element 0] :  |
-| array_flow.rb:1066:9:1066:19 | call to rotate [element 2] :  | array_flow.rb:1069:10:1069:10 | b [element 2] :  |
-| array_flow.rb:1066:9:1066:19 | call to rotate [element 2] :  | array_flow.rb:1069:10:1069:10 | b [element 2] :  |
-| array_flow.rb:1066:9:1066:19 | call to rotate [element 3] :  | array_flow.rb:1070:10:1070:10 | b [element 3] :  |
-| array_flow.rb:1066:9:1066:19 | call to rotate [element 3] :  | array_flow.rb:1070:10:1070:10 | b [element 3] :  |
+| array_flow.rb:1066:9:1066:19 | call to rotate [element 0] :  | array_flow.rb:1066:5:1066:5 | b [element 0] :  |
+| array_flow.rb:1066:9:1066:19 | call to rotate [element 0] :  | array_flow.rb:1066:5:1066:5 | b [element 0] :  |
+| array_flow.rb:1066:9:1066:19 | call to rotate [element 2] :  | array_flow.rb:1066:5:1066:5 | b [element 2] :  |
+| array_flow.rb:1066:9:1066:19 | call to rotate [element 2] :  | array_flow.rb:1066:5:1066:5 | b [element 2] :  |
+| array_flow.rb:1066:9:1066:19 | call to rotate [element 3] :  | array_flow.rb:1066:5:1066:5 | b [element 3] :  |
+| array_flow.rb:1066:9:1066:19 | call to rotate [element 3] :  | array_flow.rb:1066:5:1066:5 | b [element 3] :  |
 | array_flow.rb:1067:10:1067:10 | b [element 0] :  | array_flow.rb:1067:10:1067:13 | ...[...] |
 | array_flow.rb:1067:10:1067:10 | b [element 0] :  | array_flow.rb:1067:10:1067:13 | ...[...] |
 | array_flow.rb:1069:10:1069:10 | b [element 2] :  | array_flow.rb:1069:10:1069:13 | ...[...] |
 | array_flow.rb:1069:10:1069:10 | b [element 2] :  | array_flow.rb:1069:10:1069:13 | ...[...] |
 | array_flow.rb:1070:10:1070:10 | b [element 3] :  | array_flow.rb:1070:10:1070:13 | ...[...] |
 | array_flow.rb:1070:10:1070:10 | b [element 3] :  | array_flow.rb:1070:10:1070:13 | ...[...] |
+| array_flow.rb:1072:5:1072:5 | b [element] :  | array_flow.rb:1073:10:1073:10 | b [element] :  |
+| array_flow.rb:1072:5:1072:5 | b [element] :  | array_flow.rb:1073:10:1073:10 | b [element] :  |
+| array_flow.rb:1072:5:1072:5 | b [element] :  | array_flow.rb:1074:10:1074:10 | b [element] :  |
+| array_flow.rb:1072:5:1072:5 | b [element] :  | array_flow.rb:1074:10:1074:10 | b [element] :  |
+| array_flow.rb:1072:5:1072:5 | b [element] :  | array_flow.rb:1075:10:1075:10 | b [element] :  |
+| array_flow.rb:1072:5:1072:5 | b [element] :  | array_flow.rb:1075:10:1075:10 | b [element] :  |
+| array_flow.rb:1072:5:1072:5 | b [element] :  | array_flow.rb:1076:10:1076:10 | b [element] :  |
+| array_flow.rb:1072:5:1072:5 | b [element] :  | array_flow.rb:1076:10:1076:10 | b [element] :  |
 | array_flow.rb:1072:9:1072:9 | a [element 0] :  | array_flow.rb:1072:9:1072:19 | call to rotate [element] :  |
 | array_flow.rb:1072:9:1072:9 | a [element 0] :  | array_flow.rb:1072:9:1072:19 | call to rotate [element] :  |
 | array_flow.rb:1072:9:1072:9 | a [element 2] :  | array_flow.rb:1072:9:1072:19 | call to rotate [element] :  |
 | array_flow.rb:1072:9:1072:9 | a [element 2] :  | array_flow.rb:1072:9:1072:19 | call to rotate [element] :  |
 | array_flow.rb:1072:9:1072:9 | a [element 3] :  | array_flow.rb:1072:9:1072:19 | call to rotate [element] :  |
 | array_flow.rb:1072:9:1072:9 | a [element 3] :  | array_flow.rb:1072:9:1072:19 | call to rotate [element] :  |
-| array_flow.rb:1072:9:1072:19 | call to rotate [element] :  | array_flow.rb:1073:10:1073:10 | b [element] :  |
-| array_flow.rb:1072:9:1072:19 | call to rotate [element] :  | array_flow.rb:1073:10:1073:10 | b [element] :  |
-| array_flow.rb:1072:9:1072:19 | call to rotate [element] :  | array_flow.rb:1074:10:1074:10 | b [element] :  |
-| array_flow.rb:1072:9:1072:19 | call to rotate [element] :  | array_flow.rb:1074:10:1074:10 | b [element] :  |
-| array_flow.rb:1072:9:1072:19 | call to rotate [element] :  | array_flow.rb:1075:10:1075:10 | b [element] :  |
-| array_flow.rb:1072:9:1072:19 | call to rotate [element] :  | array_flow.rb:1075:10:1075:10 | b [element] :  |
-| array_flow.rb:1072:9:1072:19 | call to rotate [element] :  | array_flow.rb:1076:10:1076:10 | b [element] :  |
-| array_flow.rb:1072:9:1072:19 | call to rotate [element] :  | array_flow.rb:1076:10:1076:10 | b [element] :  |
+| array_flow.rb:1072:9:1072:19 | call to rotate [element] :  | array_flow.rb:1072:5:1072:5 | b [element] :  |
+| array_flow.rb:1072:9:1072:19 | call to rotate [element] :  | array_flow.rb:1072:5:1072:5 | b [element] :  |
 | array_flow.rb:1073:10:1073:10 | b [element] :  | array_flow.rb:1073:10:1073:13 | ...[...] |
 | array_flow.rb:1073:10:1073:10 | b [element] :  | array_flow.rb:1073:10:1073:13 | ...[...] |
 | array_flow.rb:1074:10:1074:10 | b [element] :  | array_flow.rb:1074:10:1074:13 | ...[...] |
@@ -2011,12 +2512,30 @@ edges
 | array_flow.rb:1075:10:1075:10 | b [element] :  | array_flow.rb:1075:10:1075:13 | ...[...] |
 | array_flow.rb:1076:10:1076:10 | b [element] :  | array_flow.rb:1076:10:1076:13 | ...[...] |
 | array_flow.rb:1076:10:1076:10 | b [element] :  | array_flow.rb:1076:10:1076:13 | ...[...] |
-| array_flow.rb:1084:10:1084:22 | call to source :  | array_flow.rb:1085:9:1085:9 | a [element 0] :  |
-| array_flow.rb:1084:10:1084:22 | call to source :  | array_flow.rb:1085:9:1085:9 | a [element 0] :  |
-| array_flow.rb:1084:28:1084:40 | call to source :  | array_flow.rb:1085:9:1085:9 | a [element 2] :  |
-| array_flow.rb:1084:28:1084:40 | call to source :  | array_flow.rb:1085:9:1085:9 | a [element 2] :  |
-| array_flow.rb:1084:43:1084:55 | call to source :  | array_flow.rb:1085:9:1085:9 | a [element 3] :  |
-| array_flow.rb:1084:43:1084:55 | call to source :  | array_flow.rb:1085:9:1085:9 | a [element 3] :  |
+| array_flow.rb:1084:5:1084:5 | a [element 0] :  | array_flow.rb:1085:9:1085:9 | a [element 0] :  |
+| array_flow.rb:1084:5:1084:5 | a [element 0] :  | array_flow.rb:1085:9:1085:9 | a [element 0] :  |
+| array_flow.rb:1084:5:1084:5 | a [element 2] :  | array_flow.rb:1085:9:1085:9 | a [element 2] :  |
+| array_flow.rb:1084:5:1084:5 | a [element 2] :  | array_flow.rb:1085:9:1085:9 | a [element 2] :  |
+| array_flow.rb:1084:5:1084:5 | a [element 3] :  | array_flow.rb:1085:9:1085:9 | a [element 3] :  |
+| array_flow.rb:1084:5:1084:5 | a [element 3] :  | array_flow.rb:1085:9:1085:9 | a [element 3] :  |
+| array_flow.rb:1084:10:1084:22 | call to source :  | array_flow.rb:1084:5:1084:5 | a [element 0] :  |
+| array_flow.rb:1084:10:1084:22 | call to source :  | array_flow.rb:1084:5:1084:5 | a [element 0] :  |
+| array_flow.rb:1084:28:1084:40 | call to source :  | array_flow.rb:1084:5:1084:5 | a [element 2] :  |
+| array_flow.rb:1084:28:1084:40 | call to source :  | array_flow.rb:1084:5:1084:5 | a [element 2] :  |
+| array_flow.rb:1084:43:1084:55 | call to source :  | array_flow.rb:1084:5:1084:5 | a [element 3] :  |
+| array_flow.rb:1084:43:1084:55 | call to source :  | array_flow.rb:1084:5:1084:5 | a [element 3] :  |
+| array_flow.rb:1085:5:1085:5 | b [element 1] :  | array_flow.rb:1091:10:1091:10 | b [element 1] :  |
+| array_flow.rb:1085:5:1085:5 | b [element 1] :  | array_flow.rb:1091:10:1091:10 | b [element 1] :  |
+| array_flow.rb:1085:5:1085:5 | b [element 2] :  | array_flow.rb:1092:10:1092:10 | b [element 2] :  |
+| array_flow.rb:1085:5:1085:5 | b [element 2] :  | array_flow.rb:1092:10:1092:10 | b [element 2] :  |
+| array_flow.rb:1085:5:1085:5 | b [element] :  | array_flow.rb:1090:10:1090:10 | b [element] :  |
+| array_flow.rb:1085:5:1085:5 | b [element] :  | array_flow.rb:1090:10:1090:10 | b [element] :  |
+| array_flow.rb:1085:5:1085:5 | b [element] :  | array_flow.rb:1091:10:1091:10 | b [element] :  |
+| array_flow.rb:1085:5:1085:5 | b [element] :  | array_flow.rb:1091:10:1091:10 | b [element] :  |
+| array_flow.rb:1085:5:1085:5 | b [element] :  | array_flow.rb:1092:10:1092:10 | b [element] :  |
+| array_flow.rb:1085:5:1085:5 | b [element] :  | array_flow.rb:1092:10:1092:10 | b [element] :  |
+| array_flow.rb:1085:5:1085:5 | b [element] :  | array_flow.rb:1093:10:1093:10 | b [element] :  |
+| array_flow.rb:1085:5:1085:5 | b [element] :  | array_flow.rb:1093:10:1093:10 | b [element] :  |
 | array_flow.rb:1085:9:1085:9 | [post] a [element 1] :  | array_flow.rb:1087:10:1087:10 | a [element 1] :  |
 | array_flow.rb:1085:9:1085:9 | [post] a [element 1] :  | array_flow.rb:1087:10:1087:10 | a [element 1] :  |
 | array_flow.rb:1085:9:1085:9 | [post] a [element 2] :  | array_flow.rb:1088:10:1088:10 | a [element 2] :  |
@@ -2041,18 +2560,12 @@ edges
 | array_flow.rb:1085:9:1085:9 | a [element 3] :  | array_flow.rb:1085:9:1085:9 | [post] a [element 2] :  |
 | array_flow.rb:1085:9:1085:9 | a [element 3] :  | array_flow.rb:1085:9:1085:17 | call to rotate! [element 2] :  |
 | array_flow.rb:1085:9:1085:9 | a [element 3] :  | array_flow.rb:1085:9:1085:17 | call to rotate! [element 2] :  |
-| array_flow.rb:1085:9:1085:17 | call to rotate! [element 1] :  | array_flow.rb:1091:10:1091:10 | b [element 1] :  |
-| array_flow.rb:1085:9:1085:17 | call to rotate! [element 1] :  | array_flow.rb:1091:10:1091:10 | b [element 1] :  |
-| array_flow.rb:1085:9:1085:17 | call to rotate! [element 2] :  | array_flow.rb:1092:10:1092:10 | b [element 2] :  |
-| array_flow.rb:1085:9:1085:17 | call to rotate! [element 2] :  | array_flow.rb:1092:10:1092:10 | b [element 2] :  |
-| array_flow.rb:1085:9:1085:17 | call to rotate! [element] :  | array_flow.rb:1090:10:1090:10 | b [element] :  |
-| array_flow.rb:1085:9:1085:17 | call to rotate! [element] :  | array_flow.rb:1090:10:1090:10 | b [element] :  |
-| array_flow.rb:1085:9:1085:17 | call to rotate! [element] :  | array_flow.rb:1091:10:1091:10 | b [element] :  |
-| array_flow.rb:1085:9:1085:17 | call to rotate! [element] :  | array_flow.rb:1091:10:1091:10 | b [element] :  |
-| array_flow.rb:1085:9:1085:17 | call to rotate! [element] :  | array_flow.rb:1092:10:1092:10 | b [element] :  |
-| array_flow.rb:1085:9:1085:17 | call to rotate! [element] :  | array_flow.rb:1092:10:1092:10 | b [element] :  |
-| array_flow.rb:1085:9:1085:17 | call to rotate! [element] :  | array_flow.rb:1093:10:1093:10 | b [element] :  |
-| array_flow.rb:1085:9:1085:17 | call to rotate! [element] :  | array_flow.rb:1093:10:1093:10 | b [element] :  |
+| array_flow.rb:1085:9:1085:17 | call to rotate! [element 1] :  | array_flow.rb:1085:5:1085:5 | b [element 1] :  |
+| array_flow.rb:1085:9:1085:17 | call to rotate! [element 1] :  | array_flow.rb:1085:5:1085:5 | b [element 1] :  |
+| array_flow.rb:1085:9:1085:17 | call to rotate! [element 2] :  | array_flow.rb:1085:5:1085:5 | b [element 2] :  |
+| array_flow.rb:1085:9:1085:17 | call to rotate! [element 2] :  | array_flow.rb:1085:5:1085:5 | b [element 2] :  |
+| array_flow.rb:1085:9:1085:17 | call to rotate! [element] :  | array_flow.rb:1085:5:1085:5 | b [element] :  |
+| array_flow.rb:1085:9:1085:17 | call to rotate! [element] :  | array_flow.rb:1085:5:1085:5 | b [element] :  |
 | array_flow.rb:1086:10:1086:10 | a [element] :  | array_flow.rb:1086:10:1086:13 | ...[...] |
 | array_flow.rb:1086:10:1086:10 | a [element] :  | array_flow.rb:1086:10:1086:13 | ...[...] |
 | array_flow.rb:1087:10:1087:10 | a [element 1] :  | array_flow.rb:1087:10:1087:13 | ...[...] |
@@ -2077,12 +2590,30 @@ edges
 | array_flow.rb:1092:10:1092:10 | b [element] :  | array_flow.rb:1092:10:1092:13 | ...[...] |
 | array_flow.rb:1093:10:1093:10 | b [element] :  | array_flow.rb:1093:10:1093:13 | ...[...] |
 | array_flow.rb:1093:10:1093:10 | b [element] :  | array_flow.rb:1093:10:1093:13 | ...[...] |
-| array_flow.rb:1095:10:1095:22 | call to source :  | array_flow.rb:1096:9:1096:9 | a [element 0] :  |
-| array_flow.rb:1095:10:1095:22 | call to source :  | array_flow.rb:1096:9:1096:9 | a [element 0] :  |
-| array_flow.rb:1095:28:1095:40 | call to source :  | array_flow.rb:1096:9:1096:9 | a [element 2] :  |
-| array_flow.rb:1095:28:1095:40 | call to source :  | array_flow.rb:1096:9:1096:9 | a [element 2] :  |
-| array_flow.rb:1095:43:1095:55 | call to source :  | array_flow.rb:1096:9:1096:9 | a [element 3] :  |
-| array_flow.rb:1095:43:1095:55 | call to source :  | array_flow.rb:1096:9:1096:9 | a [element 3] :  |
+| array_flow.rb:1095:5:1095:5 | a [element 0] :  | array_flow.rb:1096:9:1096:9 | a [element 0] :  |
+| array_flow.rb:1095:5:1095:5 | a [element 0] :  | array_flow.rb:1096:9:1096:9 | a [element 0] :  |
+| array_flow.rb:1095:5:1095:5 | a [element 2] :  | array_flow.rb:1096:9:1096:9 | a [element 2] :  |
+| array_flow.rb:1095:5:1095:5 | a [element 2] :  | array_flow.rb:1096:9:1096:9 | a [element 2] :  |
+| array_flow.rb:1095:5:1095:5 | a [element 3] :  | array_flow.rb:1096:9:1096:9 | a [element 3] :  |
+| array_flow.rb:1095:5:1095:5 | a [element 3] :  | array_flow.rb:1096:9:1096:9 | a [element 3] :  |
+| array_flow.rb:1095:10:1095:22 | call to source :  | array_flow.rb:1095:5:1095:5 | a [element 0] :  |
+| array_flow.rb:1095:10:1095:22 | call to source :  | array_flow.rb:1095:5:1095:5 | a [element 0] :  |
+| array_flow.rb:1095:28:1095:40 | call to source :  | array_flow.rb:1095:5:1095:5 | a [element 2] :  |
+| array_flow.rb:1095:28:1095:40 | call to source :  | array_flow.rb:1095:5:1095:5 | a [element 2] :  |
+| array_flow.rb:1095:43:1095:55 | call to source :  | array_flow.rb:1095:5:1095:5 | a [element 3] :  |
+| array_flow.rb:1095:43:1095:55 | call to source :  | array_flow.rb:1095:5:1095:5 | a [element 3] :  |
+| array_flow.rb:1096:5:1096:5 | b [element 0] :  | array_flow.rb:1101:10:1101:10 | b [element 0] :  |
+| array_flow.rb:1096:5:1096:5 | b [element 0] :  | array_flow.rb:1101:10:1101:10 | b [element 0] :  |
+| array_flow.rb:1096:5:1096:5 | b [element 1] :  | array_flow.rb:1102:10:1102:10 | b [element 1] :  |
+| array_flow.rb:1096:5:1096:5 | b [element 1] :  | array_flow.rb:1102:10:1102:10 | b [element 1] :  |
+| array_flow.rb:1096:5:1096:5 | b [element] :  | array_flow.rb:1101:10:1101:10 | b [element] :  |
+| array_flow.rb:1096:5:1096:5 | b [element] :  | array_flow.rb:1101:10:1101:10 | b [element] :  |
+| array_flow.rb:1096:5:1096:5 | b [element] :  | array_flow.rb:1102:10:1102:10 | b [element] :  |
+| array_flow.rb:1096:5:1096:5 | b [element] :  | array_flow.rb:1102:10:1102:10 | b [element] :  |
+| array_flow.rb:1096:5:1096:5 | b [element] :  | array_flow.rb:1103:10:1103:10 | b [element] :  |
+| array_flow.rb:1096:5:1096:5 | b [element] :  | array_flow.rb:1103:10:1103:10 | b [element] :  |
+| array_flow.rb:1096:5:1096:5 | b [element] :  | array_flow.rb:1104:10:1104:10 | b [element] :  |
+| array_flow.rb:1096:5:1096:5 | b [element] :  | array_flow.rb:1104:10:1104:10 | b [element] :  |
 | array_flow.rb:1096:9:1096:9 | [post] a [element 0] :  | array_flow.rb:1097:10:1097:10 | a [element 0] :  |
 | array_flow.rb:1096:9:1096:9 | [post] a [element 0] :  | array_flow.rb:1097:10:1097:10 | a [element 0] :  |
 | array_flow.rb:1096:9:1096:9 | [post] a [element 1] :  | array_flow.rb:1098:10:1098:10 | a [element 1] :  |
@@ -2107,18 +2638,12 @@ edges
 | array_flow.rb:1096:9:1096:9 | a [element 3] :  | array_flow.rb:1096:9:1096:9 | [post] a [element 1] :  |
 | array_flow.rb:1096:9:1096:9 | a [element 3] :  | array_flow.rb:1096:9:1096:20 | call to rotate! [element 1] :  |
 | array_flow.rb:1096:9:1096:9 | a [element 3] :  | array_flow.rb:1096:9:1096:20 | call to rotate! [element 1] :  |
-| array_flow.rb:1096:9:1096:20 | call to rotate! [element 0] :  | array_flow.rb:1101:10:1101:10 | b [element 0] :  |
-| array_flow.rb:1096:9:1096:20 | call to rotate! [element 0] :  | array_flow.rb:1101:10:1101:10 | b [element 0] :  |
-| array_flow.rb:1096:9:1096:20 | call to rotate! [element 1] :  | array_flow.rb:1102:10:1102:10 | b [element 1] :  |
-| array_flow.rb:1096:9:1096:20 | call to rotate! [element 1] :  | array_flow.rb:1102:10:1102:10 | b [element 1] :  |
-| array_flow.rb:1096:9:1096:20 | call to rotate! [element] :  | array_flow.rb:1101:10:1101:10 | b [element] :  |
-| array_flow.rb:1096:9:1096:20 | call to rotate! [element] :  | array_flow.rb:1101:10:1101:10 | b [element] :  |
-| array_flow.rb:1096:9:1096:20 | call to rotate! [element] :  | array_flow.rb:1102:10:1102:10 | b [element] :  |
-| array_flow.rb:1096:9:1096:20 | call to rotate! [element] :  | array_flow.rb:1102:10:1102:10 | b [element] :  |
-| array_flow.rb:1096:9:1096:20 | call to rotate! [element] :  | array_flow.rb:1103:10:1103:10 | b [element] :  |
-| array_flow.rb:1096:9:1096:20 | call to rotate! [element] :  | array_flow.rb:1103:10:1103:10 | b [element] :  |
-| array_flow.rb:1096:9:1096:20 | call to rotate! [element] :  | array_flow.rb:1104:10:1104:10 | b [element] :  |
-| array_flow.rb:1096:9:1096:20 | call to rotate! [element] :  | array_flow.rb:1104:10:1104:10 | b [element] :  |
+| array_flow.rb:1096:9:1096:20 | call to rotate! [element 0] :  | array_flow.rb:1096:5:1096:5 | b [element 0] :  |
+| array_flow.rb:1096:9:1096:20 | call to rotate! [element 0] :  | array_flow.rb:1096:5:1096:5 | b [element 0] :  |
+| array_flow.rb:1096:9:1096:20 | call to rotate! [element 1] :  | array_flow.rb:1096:5:1096:5 | b [element 1] :  |
+| array_flow.rb:1096:9:1096:20 | call to rotate! [element 1] :  | array_flow.rb:1096:5:1096:5 | b [element 1] :  |
+| array_flow.rb:1096:9:1096:20 | call to rotate! [element] :  | array_flow.rb:1096:5:1096:5 | b [element] :  |
+| array_flow.rb:1096:9:1096:20 | call to rotate! [element] :  | array_flow.rb:1096:5:1096:5 | b [element] :  |
 | array_flow.rb:1097:10:1097:10 | a [element 0] :  | array_flow.rb:1097:10:1097:13 | ...[...] |
 | array_flow.rb:1097:10:1097:10 | a [element 0] :  | array_flow.rb:1097:10:1097:13 | ...[...] |
 | array_flow.rb:1097:10:1097:10 | a [element] :  | array_flow.rb:1097:10:1097:13 | ...[...] |
@@ -2143,12 +2668,24 @@ edges
 | array_flow.rb:1103:10:1103:10 | b [element] :  | array_flow.rb:1103:10:1103:13 | ...[...] |
 | array_flow.rb:1104:10:1104:10 | b [element] :  | array_flow.rb:1104:10:1104:13 | ...[...] |
 | array_flow.rb:1104:10:1104:10 | b [element] :  | array_flow.rb:1104:10:1104:13 | ...[...] |
-| array_flow.rb:1106:10:1106:22 | call to source :  | array_flow.rb:1107:9:1107:9 | a [element 0] :  |
-| array_flow.rb:1106:10:1106:22 | call to source :  | array_flow.rb:1107:9:1107:9 | a [element 0] :  |
-| array_flow.rb:1106:28:1106:40 | call to source :  | array_flow.rb:1107:9:1107:9 | a [element 2] :  |
-| array_flow.rb:1106:28:1106:40 | call to source :  | array_flow.rb:1107:9:1107:9 | a [element 2] :  |
-| array_flow.rb:1106:43:1106:55 | call to source :  | array_flow.rb:1107:9:1107:9 | a [element 3] :  |
-| array_flow.rb:1106:43:1106:55 | call to source :  | array_flow.rb:1107:9:1107:9 | a [element 3] :  |
+| array_flow.rb:1106:5:1106:5 | a [element 0] :  | array_flow.rb:1107:9:1107:9 | a [element 0] :  |
+| array_flow.rb:1106:5:1106:5 | a [element 0] :  | array_flow.rb:1107:9:1107:9 | a [element 0] :  |
+| array_flow.rb:1106:5:1106:5 | a [element 2] :  | array_flow.rb:1107:9:1107:9 | a [element 2] :  |
+| array_flow.rb:1106:5:1106:5 | a [element 2] :  | array_flow.rb:1107:9:1107:9 | a [element 2] :  |
+| array_flow.rb:1106:5:1106:5 | a [element 3] :  | array_flow.rb:1107:9:1107:9 | a [element 3] :  |
+| array_flow.rb:1106:5:1106:5 | a [element 3] :  | array_flow.rb:1107:9:1107:9 | a [element 3] :  |
+| array_flow.rb:1106:10:1106:22 | call to source :  | array_flow.rb:1106:5:1106:5 | a [element 0] :  |
+| array_flow.rb:1106:10:1106:22 | call to source :  | array_flow.rb:1106:5:1106:5 | a [element 0] :  |
+| array_flow.rb:1106:28:1106:40 | call to source :  | array_flow.rb:1106:5:1106:5 | a [element 2] :  |
+| array_flow.rb:1106:28:1106:40 | call to source :  | array_flow.rb:1106:5:1106:5 | a [element 2] :  |
+| array_flow.rb:1106:43:1106:55 | call to source :  | array_flow.rb:1106:5:1106:5 | a [element 3] :  |
+| array_flow.rb:1106:43:1106:55 | call to source :  | array_flow.rb:1106:5:1106:5 | a [element 3] :  |
+| array_flow.rb:1107:5:1107:5 | b [element 0] :  | array_flow.rb:1112:10:1112:10 | b [element 0] :  |
+| array_flow.rb:1107:5:1107:5 | b [element 0] :  | array_flow.rb:1112:10:1112:10 | b [element 0] :  |
+| array_flow.rb:1107:5:1107:5 | b [element 2] :  | array_flow.rb:1114:10:1114:10 | b [element 2] :  |
+| array_flow.rb:1107:5:1107:5 | b [element 2] :  | array_flow.rb:1114:10:1114:10 | b [element 2] :  |
+| array_flow.rb:1107:5:1107:5 | b [element 3] :  | array_flow.rb:1115:10:1115:10 | b [element 3] :  |
+| array_flow.rb:1107:5:1107:5 | b [element 3] :  | array_flow.rb:1115:10:1115:10 | b [element 3] :  |
 | array_flow.rb:1107:9:1107:9 | [post] a [element 0] :  | array_flow.rb:1108:10:1108:10 | a [element 0] :  |
 | array_flow.rb:1107:9:1107:9 | [post] a [element 0] :  | array_flow.rb:1108:10:1108:10 | a [element 0] :  |
 | array_flow.rb:1107:9:1107:9 | [post] a [element 2] :  | array_flow.rb:1110:10:1110:10 | a [element 2] :  |
@@ -2167,12 +2704,12 @@ edges
 | array_flow.rb:1107:9:1107:9 | a [element 3] :  | array_flow.rb:1107:9:1107:9 | [post] a [element 3] :  |
 | array_flow.rb:1107:9:1107:9 | a [element 3] :  | array_flow.rb:1107:9:1107:20 | call to rotate! [element 3] :  |
 | array_flow.rb:1107:9:1107:9 | a [element 3] :  | array_flow.rb:1107:9:1107:20 | call to rotate! [element 3] :  |
-| array_flow.rb:1107:9:1107:20 | call to rotate! [element 0] :  | array_flow.rb:1112:10:1112:10 | b [element 0] :  |
-| array_flow.rb:1107:9:1107:20 | call to rotate! [element 0] :  | array_flow.rb:1112:10:1112:10 | b [element 0] :  |
-| array_flow.rb:1107:9:1107:20 | call to rotate! [element 2] :  | array_flow.rb:1114:10:1114:10 | b [element 2] :  |
-| array_flow.rb:1107:9:1107:20 | call to rotate! [element 2] :  | array_flow.rb:1114:10:1114:10 | b [element 2] :  |
-| array_flow.rb:1107:9:1107:20 | call to rotate! [element 3] :  | array_flow.rb:1115:10:1115:10 | b [element 3] :  |
-| array_flow.rb:1107:9:1107:20 | call to rotate! [element 3] :  | array_flow.rb:1115:10:1115:10 | b [element 3] :  |
+| array_flow.rb:1107:9:1107:20 | call to rotate! [element 0] :  | array_flow.rb:1107:5:1107:5 | b [element 0] :  |
+| array_flow.rb:1107:9:1107:20 | call to rotate! [element 0] :  | array_flow.rb:1107:5:1107:5 | b [element 0] :  |
+| array_flow.rb:1107:9:1107:20 | call to rotate! [element 2] :  | array_flow.rb:1107:5:1107:5 | b [element 2] :  |
+| array_flow.rb:1107:9:1107:20 | call to rotate! [element 2] :  | array_flow.rb:1107:5:1107:5 | b [element 2] :  |
+| array_flow.rb:1107:9:1107:20 | call to rotate! [element 3] :  | array_flow.rb:1107:5:1107:5 | b [element 3] :  |
+| array_flow.rb:1107:9:1107:20 | call to rotate! [element 3] :  | array_flow.rb:1107:5:1107:5 | b [element 3] :  |
 | array_flow.rb:1108:10:1108:10 | a [element 0] :  | array_flow.rb:1108:10:1108:13 | ...[...] |
 | array_flow.rb:1108:10:1108:10 | a [element 0] :  | array_flow.rb:1108:10:1108:13 | ...[...] |
 | array_flow.rb:1110:10:1110:10 | a [element 2] :  | array_flow.rb:1110:10:1110:13 | ...[...] |
@@ -2185,12 +2722,26 @@ edges
 | array_flow.rb:1114:10:1114:10 | b [element 2] :  | array_flow.rb:1114:10:1114:13 | ...[...] |
 | array_flow.rb:1115:10:1115:10 | b [element 3] :  | array_flow.rb:1115:10:1115:13 | ...[...] |
 | array_flow.rb:1115:10:1115:10 | b [element 3] :  | array_flow.rb:1115:10:1115:13 | ...[...] |
-| array_flow.rb:1117:10:1117:22 | call to source :  | array_flow.rb:1118:9:1118:9 | a [element 0] :  |
-| array_flow.rb:1117:10:1117:22 | call to source :  | array_flow.rb:1118:9:1118:9 | a [element 0] :  |
-| array_flow.rb:1117:28:1117:40 | call to source :  | array_flow.rb:1118:9:1118:9 | a [element 2] :  |
-| array_flow.rb:1117:28:1117:40 | call to source :  | array_flow.rb:1118:9:1118:9 | a [element 2] :  |
-| array_flow.rb:1117:43:1117:55 | call to source :  | array_flow.rb:1118:9:1118:9 | a [element 3] :  |
-| array_flow.rb:1117:43:1117:55 | call to source :  | array_flow.rb:1118:9:1118:9 | a [element 3] :  |
+| array_flow.rb:1117:5:1117:5 | a [element 0] :  | array_flow.rb:1118:9:1118:9 | a [element 0] :  |
+| array_flow.rb:1117:5:1117:5 | a [element 0] :  | array_flow.rb:1118:9:1118:9 | a [element 0] :  |
+| array_flow.rb:1117:5:1117:5 | a [element 2] :  | array_flow.rb:1118:9:1118:9 | a [element 2] :  |
+| array_flow.rb:1117:5:1117:5 | a [element 2] :  | array_flow.rb:1118:9:1118:9 | a [element 2] :  |
+| array_flow.rb:1117:5:1117:5 | a [element 3] :  | array_flow.rb:1118:9:1118:9 | a [element 3] :  |
+| array_flow.rb:1117:5:1117:5 | a [element 3] :  | array_flow.rb:1118:9:1118:9 | a [element 3] :  |
+| array_flow.rb:1117:10:1117:22 | call to source :  | array_flow.rb:1117:5:1117:5 | a [element 0] :  |
+| array_flow.rb:1117:10:1117:22 | call to source :  | array_flow.rb:1117:5:1117:5 | a [element 0] :  |
+| array_flow.rb:1117:28:1117:40 | call to source :  | array_flow.rb:1117:5:1117:5 | a [element 2] :  |
+| array_flow.rb:1117:28:1117:40 | call to source :  | array_flow.rb:1117:5:1117:5 | a [element 2] :  |
+| array_flow.rb:1117:43:1117:55 | call to source :  | array_flow.rb:1117:5:1117:5 | a [element 3] :  |
+| array_flow.rb:1117:43:1117:55 | call to source :  | array_flow.rb:1117:5:1117:5 | a [element 3] :  |
+| array_flow.rb:1118:5:1118:5 | b [element] :  | array_flow.rb:1123:10:1123:10 | b [element] :  |
+| array_flow.rb:1118:5:1118:5 | b [element] :  | array_flow.rb:1123:10:1123:10 | b [element] :  |
+| array_flow.rb:1118:5:1118:5 | b [element] :  | array_flow.rb:1124:10:1124:10 | b [element] :  |
+| array_flow.rb:1118:5:1118:5 | b [element] :  | array_flow.rb:1124:10:1124:10 | b [element] :  |
+| array_flow.rb:1118:5:1118:5 | b [element] :  | array_flow.rb:1125:10:1125:10 | b [element] :  |
+| array_flow.rb:1118:5:1118:5 | b [element] :  | array_flow.rb:1125:10:1125:10 | b [element] :  |
+| array_flow.rb:1118:5:1118:5 | b [element] :  | array_flow.rb:1126:10:1126:10 | b [element] :  |
+| array_flow.rb:1118:5:1118:5 | b [element] :  | array_flow.rb:1126:10:1126:10 | b [element] :  |
 | array_flow.rb:1118:9:1118:9 | [post] a [element] :  | array_flow.rb:1119:10:1119:10 | a [element] :  |
 | array_flow.rb:1118:9:1118:9 | [post] a [element] :  | array_flow.rb:1119:10:1119:10 | a [element] :  |
 | array_flow.rb:1118:9:1118:9 | [post] a [element] :  | array_flow.rb:1120:10:1120:10 | a [element] :  |
@@ -2211,14 +2762,8 @@ edges
 | array_flow.rb:1118:9:1118:9 | a [element 3] :  | array_flow.rb:1118:9:1118:9 | [post] a [element] :  |
 | array_flow.rb:1118:9:1118:9 | a [element 3] :  | array_flow.rb:1118:9:1118:20 | call to rotate! [element] :  |
 | array_flow.rb:1118:9:1118:9 | a [element 3] :  | array_flow.rb:1118:9:1118:20 | call to rotate! [element] :  |
-| array_flow.rb:1118:9:1118:20 | call to rotate! [element] :  | array_flow.rb:1123:10:1123:10 | b [element] :  |
-| array_flow.rb:1118:9:1118:20 | call to rotate! [element] :  | array_flow.rb:1123:10:1123:10 | b [element] :  |
-| array_flow.rb:1118:9:1118:20 | call to rotate! [element] :  | array_flow.rb:1124:10:1124:10 | b [element] :  |
-| array_flow.rb:1118:9:1118:20 | call to rotate! [element] :  | array_flow.rb:1124:10:1124:10 | b [element] :  |
-| array_flow.rb:1118:9:1118:20 | call to rotate! [element] :  | array_flow.rb:1125:10:1125:10 | b [element] :  |
-| array_flow.rb:1118:9:1118:20 | call to rotate! [element] :  | array_flow.rb:1125:10:1125:10 | b [element] :  |
-| array_flow.rb:1118:9:1118:20 | call to rotate! [element] :  | array_flow.rb:1126:10:1126:10 | b [element] :  |
-| array_flow.rb:1118:9:1118:20 | call to rotate! [element] :  | array_flow.rb:1126:10:1126:10 | b [element] :  |
+| array_flow.rb:1118:9:1118:20 | call to rotate! [element] :  | array_flow.rb:1118:5:1118:5 | b [element] :  |
+| array_flow.rb:1118:9:1118:20 | call to rotate! [element] :  | array_flow.rb:1118:5:1118:5 | b [element] :  |
 | array_flow.rb:1119:10:1119:10 | a [element] :  | array_flow.rb:1119:10:1119:13 | ...[...] |
 | array_flow.rb:1119:10:1119:10 | a [element] :  | array_flow.rb:1119:10:1119:13 | ...[...] |
 | array_flow.rb:1120:10:1120:10 | a [element] :  | array_flow.rb:1120:10:1120:13 | ...[...] |
@@ -2235,20 +2780,28 @@ edges
 | array_flow.rb:1125:10:1125:10 | b [element] :  | array_flow.rb:1125:10:1125:13 | ...[...] |
 | array_flow.rb:1126:10:1126:10 | b [element] :  | array_flow.rb:1126:10:1126:13 | ...[...] |
 | array_flow.rb:1126:10:1126:10 | b [element] :  | array_flow.rb:1126:10:1126:13 | ...[...] |
-| array_flow.rb:1130:19:1130:29 | call to source :  | array_flow.rb:1131:9:1131:9 | a [element 3] :  |
-| array_flow.rb:1130:19:1130:29 | call to source :  | array_flow.rb:1131:9:1131:9 | a [element 3] :  |
+| array_flow.rb:1130:5:1130:5 | a [element 3] :  | array_flow.rb:1131:9:1131:9 | a [element 3] :  |
+| array_flow.rb:1130:5:1130:5 | a [element 3] :  | array_flow.rb:1131:9:1131:9 | a [element 3] :  |
+| array_flow.rb:1130:19:1130:29 | call to source :  | array_flow.rb:1130:5:1130:5 | a [element 3] :  |
+| array_flow.rb:1130:19:1130:29 | call to source :  | array_flow.rb:1130:5:1130:5 | a [element 3] :  |
+| array_flow.rb:1131:5:1131:5 | b [element] :  | array_flow.rb:1134:10:1134:10 | b [element] :  |
+| array_flow.rb:1131:5:1131:5 | b [element] :  | array_flow.rb:1134:10:1134:10 | b [element] :  |
 | array_flow.rb:1131:9:1131:9 | a [element 3] :  | array_flow.rb:1131:9:1133:7 | call to select [element] :  |
 | array_flow.rb:1131:9:1131:9 | a [element 3] :  | array_flow.rb:1131:9:1133:7 | call to select [element] :  |
 | array_flow.rb:1131:9:1131:9 | a [element 3] :  | array_flow.rb:1131:22:1131:22 | x :  |
 | array_flow.rb:1131:9:1131:9 | a [element 3] :  | array_flow.rb:1131:22:1131:22 | x :  |
-| array_flow.rb:1131:9:1133:7 | call to select [element] :  | array_flow.rb:1134:10:1134:10 | b [element] :  |
-| array_flow.rb:1131:9:1133:7 | call to select [element] :  | array_flow.rb:1134:10:1134:10 | b [element] :  |
+| array_flow.rb:1131:9:1133:7 | call to select [element] :  | array_flow.rb:1131:5:1131:5 | b [element] :  |
+| array_flow.rb:1131:9:1133:7 | call to select [element] :  | array_flow.rb:1131:5:1131:5 | b [element] :  |
 | array_flow.rb:1131:22:1131:22 | x :  | array_flow.rb:1132:14:1132:14 | x |
 | array_flow.rb:1131:22:1131:22 | x :  | array_flow.rb:1132:14:1132:14 | x |
 | array_flow.rb:1134:10:1134:10 | b [element] :  | array_flow.rb:1134:10:1134:13 | ...[...] |
 | array_flow.rb:1134:10:1134:10 | b [element] :  | array_flow.rb:1134:10:1134:13 | ...[...] |
-| array_flow.rb:1138:16:1138:26 | call to source :  | array_flow.rb:1139:9:1139:9 | a [element 2] :  |
-| array_flow.rb:1138:16:1138:26 | call to source :  | array_flow.rb:1139:9:1139:9 | a [element 2] :  |
+| array_flow.rb:1138:5:1138:5 | a [element 2] :  | array_flow.rb:1139:9:1139:9 | a [element 2] :  |
+| array_flow.rb:1138:5:1138:5 | a [element 2] :  | array_flow.rb:1139:9:1139:9 | a [element 2] :  |
+| array_flow.rb:1138:16:1138:26 | call to source :  | array_flow.rb:1138:5:1138:5 | a [element 2] :  |
+| array_flow.rb:1138:16:1138:26 | call to source :  | array_flow.rb:1138:5:1138:5 | a [element 2] :  |
+| array_flow.rb:1139:5:1139:5 | b [element] :  | array_flow.rb:1144:10:1144:10 | b [element] :  |
+| array_flow.rb:1139:5:1139:5 | b [element] :  | array_flow.rb:1144:10:1144:10 | b [element] :  |
 | array_flow.rb:1139:9:1139:9 | [post] a [element] :  | array_flow.rb:1143:10:1143:10 | a [element] :  |
 | array_flow.rb:1139:9:1139:9 | [post] a [element] :  | array_flow.rb:1143:10:1143:10 | a [element] :  |
 | array_flow.rb:1139:9:1139:9 | a [element 2] :  | array_flow.rb:1139:9:1139:9 | [post] a [element] :  |
@@ -2257,52 +2810,72 @@ edges
 | array_flow.rb:1139:9:1139:9 | a [element 2] :  | array_flow.rb:1139:9:1142:7 | call to select! [element] :  |
 | array_flow.rb:1139:9:1139:9 | a [element 2] :  | array_flow.rb:1139:23:1139:23 | x :  |
 | array_flow.rb:1139:9:1139:9 | a [element 2] :  | array_flow.rb:1139:23:1139:23 | x :  |
-| array_flow.rb:1139:9:1142:7 | call to select! [element] :  | array_flow.rb:1144:10:1144:10 | b [element] :  |
-| array_flow.rb:1139:9:1142:7 | call to select! [element] :  | array_flow.rb:1144:10:1144:10 | b [element] :  |
+| array_flow.rb:1139:9:1142:7 | call to select! [element] :  | array_flow.rb:1139:5:1139:5 | b [element] :  |
+| array_flow.rb:1139:9:1142:7 | call to select! [element] :  | array_flow.rb:1139:5:1139:5 | b [element] :  |
 | array_flow.rb:1139:23:1139:23 | x :  | array_flow.rb:1140:14:1140:14 | x |
 | array_flow.rb:1139:23:1139:23 | x :  | array_flow.rb:1140:14:1140:14 | x |
 | array_flow.rb:1143:10:1143:10 | a [element] :  | array_flow.rb:1143:10:1143:13 | ...[...] |
 | array_flow.rb:1143:10:1143:10 | a [element] :  | array_flow.rb:1143:10:1143:13 | ...[...] |
 | array_flow.rb:1144:10:1144:10 | b [element] :  | array_flow.rb:1144:10:1144:13 | ...[...] |
 | array_flow.rb:1144:10:1144:10 | b [element] :  | array_flow.rb:1144:10:1144:13 | ...[...] |
-| array_flow.rb:1148:10:1148:22 | call to source :  | array_flow.rb:1149:9:1149:9 | a [element 0] :  |
-| array_flow.rb:1148:10:1148:22 | call to source :  | array_flow.rb:1149:9:1149:9 | a [element 0] :  |
-| array_flow.rb:1148:28:1148:40 | call to source :  | array_flow.rb:1149:9:1149:9 | a [element 2] :  |
-| array_flow.rb:1148:28:1148:40 | call to source :  | array_flow.rb:1149:9:1149:9 | a [element 2] :  |
+| array_flow.rb:1148:5:1148:5 | a [element 0] :  | array_flow.rb:1149:9:1149:9 | a [element 0] :  |
+| array_flow.rb:1148:5:1148:5 | a [element 0] :  | array_flow.rb:1149:9:1149:9 | a [element 0] :  |
+| array_flow.rb:1148:5:1148:5 | a [element 2] :  | array_flow.rb:1149:9:1149:9 | a [element 2] :  |
+| array_flow.rb:1148:5:1148:5 | a [element 2] :  | array_flow.rb:1149:9:1149:9 | a [element 2] :  |
+| array_flow.rb:1148:10:1148:22 | call to source :  | array_flow.rb:1148:5:1148:5 | a [element 0] :  |
+| array_flow.rb:1148:10:1148:22 | call to source :  | array_flow.rb:1148:5:1148:5 | a [element 0] :  |
+| array_flow.rb:1148:28:1148:40 | call to source :  | array_flow.rb:1148:5:1148:5 | a [element 2] :  |
+| array_flow.rb:1148:28:1148:40 | call to source :  | array_flow.rb:1148:5:1148:5 | a [element 2] :  |
+| array_flow.rb:1149:5:1149:5 | b :  | array_flow.rb:1150:10:1150:10 | b |
+| array_flow.rb:1149:5:1149:5 | b :  | array_flow.rb:1150:10:1150:10 | b |
 | array_flow.rb:1149:9:1149:9 | [post] a [element 1] :  | array_flow.rb:1152:10:1152:10 | a [element 1] :  |
 | array_flow.rb:1149:9:1149:9 | [post] a [element 1] :  | array_flow.rb:1152:10:1152:10 | a [element 1] :  |
 | array_flow.rb:1149:9:1149:9 | a [element 0] :  | array_flow.rb:1149:9:1149:15 | call to shift :  |
 | array_flow.rb:1149:9:1149:9 | a [element 0] :  | array_flow.rb:1149:9:1149:15 | call to shift :  |
 | array_flow.rb:1149:9:1149:9 | a [element 2] :  | array_flow.rb:1149:9:1149:9 | [post] a [element 1] :  |
 | array_flow.rb:1149:9:1149:9 | a [element 2] :  | array_flow.rb:1149:9:1149:9 | [post] a [element 1] :  |
-| array_flow.rb:1149:9:1149:15 | call to shift :  | array_flow.rb:1150:10:1150:10 | b |
-| array_flow.rb:1149:9:1149:15 | call to shift :  | array_flow.rb:1150:10:1150:10 | b |
+| array_flow.rb:1149:9:1149:15 | call to shift :  | array_flow.rb:1149:5:1149:5 | b :  |
+| array_flow.rb:1149:9:1149:15 | call to shift :  | array_flow.rb:1149:5:1149:5 | b :  |
 | array_flow.rb:1152:10:1152:10 | a [element 1] :  | array_flow.rb:1152:10:1152:13 | ...[...] |
 | array_flow.rb:1152:10:1152:10 | a [element 1] :  | array_flow.rb:1152:10:1152:13 | ...[...] |
-| array_flow.rb:1155:10:1155:22 | call to source :  | array_flow.rb:1156:9:1156:9 | a [element 0] :  |
-| array_flow.rb:1155:10:1155:22 | call to source :  | array_flow.rb:1156:9:1156:9 | a [element 0] :  |
-| array_flow.rb:1155:28:1155:40 | call to source :  | array_flow.rb:1156:9:1156:9 | a [element 2] :  |
-| array_flow.rb:1155:28:1155:40 | call to source :  | array_flow.rb:1156:9:1156:9 | a [element 2] :  |
+| array_flow.rb:1155:5:1155:5 | a [element 0] :  | array_flow.rb:1156:9:1156:9 | a [element 0] :  |
+| array_flow.rb:1155:5:1155:5 | a [element 0] :  | array_flow.rb:1156:9:1156:9 | a [element 0] :  |
+| array_flow.rb:1155:5:1155:5 | a [element 2] :  | array_flow.rb:1156:9:1156:9 | a [element 2] :  |
+| array_flow.rb:1155:5:1155:5 | a [element 2] :  | array_flow.rb:1156:9:1156:9 | a [element 2] :  |
+| array_flow.rb:1155:10:1155:22 | call to source :  | array_flow.rb:1155:5:1155:5 | a [element 0] :  |
+| array_flow.rb:1155:10:1155:22 | call to source :  | array_flow.rb:1155:5:1155:5 | a [element 0] :  |
+| array_flow.rb:1155:28:1155:40 | call to source :  | array_flow.rb:1155:5:1155:5 | a [element 2] :  |
+| array_flow.rb:1155:28:1155:40 | call to source :  | array_flow.rb:1155:5:1155:5 | a [element 2] :  |
+| array_flow.rb:1156:5:1156:5 | b [element 0] :  | array_flow.rb:1157:10:1157:10 | b [element 0] :  |
+| array_flow.rb:1156:5:1156:5 | b [element 0] :  | array_flow.rb:1157:10:1157:10 | b [element 0] :  |
 | array_flow.rb:1156:9:1156:9 | [post] a [element 0] :  | array_flow.rb:1159:10:1159:10 | a [element 0] :  |
 | array_flow.rb:1156:9:1156:9 | [post] a [element 0] :  | array_flow.rb:1159:10:1159:10 | a [element 0] :  |
 | array_flow.rb:1156:9:1156:9 | a [element 0] :  | array_flow.rb:1156:9:1156:18 | call to shift [element 0] :  |
 | array_flow.rb:1156:9:1156:9 | a [element 0] :  | array_flow.rb:1156:9:1156:18 | call to shift [element 0] :  |
 | array_flow.rb:1156:9:1156:9 | a [element 2] :  | array_flow.rb:1156:9:1156:9 | [post] a [element 0] :  |
 | array_flow.rb:1156:9:1156:9 | a [element 2] :  | array_flow.rb:1156:9:1156:9 | [post] a [element 0] :  |
-| array_flow.rb:1156:9:1156:18 | call to shift [element 0] :  | array_flow.rb:1157:10:1157:10 | b [element 0] :  |
-| array_flow.rb:1156:9:1156:18 | call to shift [element 0] :  | array_flow.rb:1157:10:1157:10 | b [element 0] :  |
+| array_flow.rb:1156:9:1156:18 | call to shift [element 0] :  | array_flow.rb:1156:5:1156:5 | b [element 0] :  |
+| array_flow.rb:1156:9:1156:18 | call to shift [element 0] :  | array_flow.rb:1156:5:1156:5 | b [element 0] :  |
 | array_flow.rb:1157:10:1157:10 | b [element 0] :  | array_flow.rb:1157:10:1157:13 | ...[...] |
 | array_flow.rb:1157:10:1157:10 | b [element 0] :  | array_flow.rb:1157:10:1157:13 | ...[...] |
 | array_flow.rb:1159:10:1159:10 | a [element 0] :  | array_flow.rb:1159:10:1159:13 | ...[...] |
 | array_flow.rb:1159:10:1159:10 | a [element 0] :  | array_flow.rb:1159:10:1159:13 | ...[...] |
-| array_flow.rb:1163:10:1163:22 | call to source :  | array_flow.rb:1164:9:1164:9 | a [element 0] :  |
-| array_flow.rb:1163:10:1163:22 | call to source :  | array_flow.rb:1164:9:1164:9 | a [element 0] :  |
-| array_flow.rb:1163:10:1163:22 | call to source :  | array_flow.rb:1167:10:1167:10 | a [element 0] :  |
-| array_flow.rb:1163:10:1163:22 | call to source :  | array_flow.rb:1167:10:1167:10 | a [element 0] :  |
-| array_flow.rb:1163:28:1163:40 | call to source :  | array_flow.rb:1164:9:1164:9 | a [element 2] :  |
-| array_flow.rb:1163:28:1163:40 | call to source :  | array_flow.rb:1164:9:1164:9 | a [element 2] :  |
-| array_flow.rb:1163:28:1163:40 | call to source :  | array_flow.rb:1169:10:1169:10 | a [element 2] :  |
-| array_flow.rb:1163:28:1163:40 | call to source :  | array_flow.rb:1169:10:1169:10 | a [element 2] :  |
+| array_flow.rb:1163:5:1163:5 | a [element 0] :  | array_flow.rb:1164:9:1164:9 | a [element 0] :  |
+| array_flow.rb:1163:5:1163:5 | a [element 0] :  | array_flow.rb:1164:9:1164:9 | a [element 0] :  |
+| array_flow.rb:1163:5:1163:5 | a [element 0] :  | array_flow.rb:1167:10:1167:10 | a [element 0] :  |
+| array_flow.rb:1163:5:1163:5 | a [element 0] :  | array_flow.rb:1167:10:1167:10 | a [element 0] :  |
+| array_flow.rb:1163:5:1163:5 | a [element 2] :  | array_flow.rb:1164:9:1164:9 | a [element 2] :  |
+| array_flow.rb:1163:5:1163:5 | a [element 2] :  | array_flow.rb:1164:9:1164:9 | a [element 2] :  |
+| array_flow.rb:1163:5:1163:5 | a [element 2] :  | array_flow.rb:1169:10:1169:10 | a [element 2] :  |
+| array_flow.rb:1163:5:1163:5 | a [element 2] :  | array_flow.rb:1169:10:1169:10 | a [element 2] :  |
+| array_flow.rb:1163:10:1163:22 | call to source :  | array_flow.rb:1163:5:1163:5 | a [element 0] :  |
+| array_flow.rb:1163:10:1163:22 | call to source :  | array_flow.rb:1163:5:1163:5 | a [element 0] :  |
+| array_flow.rb:1163:28:1163:40 | call to source :  | array_flow.rb:1163:5:1163:5 | a [element 2] :  |
+| array_flow.rb:1163:28:1163:40 | call to source :  | array_flow.rb:1163:5:1163:5 | a [element 2] :  |
+| array_flow.rb:1164:5:1164:5 | b [element] :  | array_flow.rb:1165:10:1165:10 | b [element] :  |
+| array_flow.rb:1164:5:1164:5 | b [element] :  | array_flow.rb:1165:10:1165:10 | b [element] :  |
+| array_flow.rb:1164:5:1164:5 | b [element] :  | array_flow.rb:1166:10:1166:10 | b [element] :  |
+| array_flow.rb:1164:5:1164:5 | b [element] :  | array_flow.rb:1166:10:1166:10 | b [element] :  |
 | array_flow.rb:1164:9:1164:9 | [post] a [element] :  | array_flow.rb:1167:10:1167:10 | a [element] :  |
 | array_flow.rb:1164:9:1164:9 | [post] a [element] :  | array_flow.rb:1167:10:1167:10 | a [element] :  |
 | array_flow.rb:1164:9:1164:9 | [post] a [element] :  | array_flow.rb:1168:10:1168:10 | a [element] :  |
@@ -2317,10 +2890,8 @@ edges
 | array_flow.rb:1164:9:1164:9 | a [element 2] :  | array_flow.rb:1164:9:1164:9 | [post] a [element] :  |
 | array_flow.rb:1164:9:1164:9 | a [element 2] :  | array_flow.rb:1164:9:1164:18 | call to shift [element] :  |
 | array_flow.rb:1164:9:1164:9 | a [element 2] :  | array_flow.rb:1164:9:1164:18 | call to shift [element] :  |
-| array_flow.rb:1164:9:1164:18 | call to shift [element] :  | array_flow.rb:1165:10:1165:10 | b [element] :  |
-| array_flow.rb:1164:9:1164:18 | call to shift [element] :  | array_flow.rb:1165:10:1165:10 | b [element] :  |
-| array_flow.rb:1164:9:1164:18 | call to shift [element] :  | array_flow.rb:1166:10:1166:10 | b [element] :  |
-| array_flow.rb:1164:9:1164:18 | call to shift [element] :  | array_flow.rb:1166:10:1166:10 | b [element] :  |
+| array_flow.rb:1164:9:1164:18 | call to shift [element] :  | array_flow.rb:1164:5:1164:5 | b [element] :  |
+| array_flow.rb:1164:9:1164:18 | call to shift [element] :  | array_flow.rb:1164:5:1164:5 | b [element] :  |
 | array_flow.rb:1165:10:1165:10 | b [element] :  | array_flow.rb:1165:10:1165:13 | ...[...] |
 | array_flow.rb:1165:10:1165:10 | b [element] :  | array_flow.rb:1165:10:1165:13 | ...[...] |
 | array_flow.rb:1166:10:1166:10 | b [element] :  | array_flow.rb:1166:10:1166:13 | ...[...] |
@@ -2335,18 +2906,22 @@ edges
 | array_flow.rb:1169:10:1169:10 | a [element 2] :  | array_flow.rb:1169:10:1169:13 | ...[...] |
 | array_flow.rb:1169:10:1169:10 | a [element] :  | array_flow.rb:1169:10:1169:13 | ...[...] |
 | array_flow.rb:1169:10:1169:10 | a [element] :  | array_flow.rb:1169:10:1169:13 | ...[...] |
-| array_flow.rb:1173:16:1173:26 | call to source :  | array_flow.rb:1174:9:1174:9 | a [element 2] :  |
-| array_flow.rb:1173:16:1173:26 | call to source :  | array_flow.rb:1174:9:1174:9 | a [element 2] :  |
-| array_flow.rb:1173:16:1173:26 | call to source :  | array_flow.rb:1177:10:1177:10 | a [element 2] :  |
-| array_flow.rb:1173:16:1173:26 | call to source :  | array_flow.rb:1177:10:1177:10 | a [element 2] :  |
+| array_flow.rb:1173:5:1173:5 | a [element 2] :  | array_flow.rb:1174:9:1174:9 | a [element 2] :  |
+| array_flow.rb:1173:5:1173:5 | a [element 2] :  | array_flow.rb:1174:9:1174:9 | a [element 2] :  |
+| array_flow.rb:1173:5:1173:5 | a [element 2] :  | array_flow.rb:1177:10:1177:10 | a [element 2] :  |
+| array_flow.rb:1173:5:1173:5 | a [element 2] :  | array_flow.rb:1177:10:1177:10 | a [element 2] :  |
+| array_flow.rb:1173:16:1173:26 | call to source :  | array_flow.rb:1173:5:1173:5 | a [element 2] :  |
+| array_flow.rb:1173:16:1173:26 | call to source :  | array_flow.rb:1173:5:1173:5 | a [element 2] :  |
+| array_flow.rb:1174:5:1174:5 | b [element] :  | array_flow.rb:1178:10:1178:10 | b [element] :  |
+| array_flow.rb:1174:5:1174:5 | b [element] :  | array_flow.rb:1178:10:1178:10 | b [element] :  |
+| array_flow.rb:1174:5:1174:5 | b [element] :  | array_flow.rb:1179:10:1179:10 | b [element] :  |
+| array_flow.rb:1174:5:1174:5 | b [element] :  | array_flow.rb:1179:10:1179:10 | b [element] :  |
+| array_flow.rb:1174:5:1174:5 | b [element] :  | array_flow.rb:1180:10:1180:10 | b [element] :  |
+| array_flow.rb:1174:5:1174:5 | b [element] :  | array_flow.rb:1180:10:1180:10 | b [element] :  |
 | array_flow.rb:1174:9:1174:9 | a [element 2] :  | array_flow.rb:1174:9:1174:17 | call to shuffle [element] :  |
 | array_flow.rb:1174:9:1174:9 | a [element 2] :  | array_flow.rb:1174:9:1174:17 | call to shuffle [element] :  |
-| array_flow.rb:1174:9:1174:17 | call to shuffle [element] :  | array_flow.rb:1178:10:1178:10 | b [element] :  |
-| array_flow.rb:1174:9:1174:17 | call to shuffle [element] :  | array_flow.rb:1178:10:1178:10 | b [element] :  |
-| array_flow.rb:1174:9:1174:17 | call to shuffle [element] :  | array_flow.rb:1179:10:1179:10 | b [element] :  |
-| array_flow.rb:1174:9:1174:17 | call to shuffle [element] :  | array_flow.rb:1179:10:1179:10 | b [element] :  |
-| array_flow.rb:1174:9:1174:17 | call to shuffle [element] :  | array_flow.rb:1180:10:1180:10 | b [element] :  |
-| array_flow.rb:1174:9:1174:17 | call to shuffle [element] :  | array_flow.rb:1180:10:1180:10 | b [element] :  |
+| array_flow.rb:1174:9:1174:17 | call to shuffle [element] :  | array_flow.rb:1174:5:1174:5 | b [element] :  |
+| array_flow.rb:1174:9:1174:17 | call to shuffle [element] :  | array_flow.rb:1174:5:1174:5 | b [element] :  |
 | array_flow.rb:1177:10:1177:10 | a [element 2] :  | array_flow.rb:1177:10:1177:13 | ...[...] |
 | array_flow.rb:1177:10:1177:10 | a [element 2] :  | array_flow.rb:1177:10:1177:13 | ...[...] |
 | array_flow.rb:1178:10:1178:10 | b [element] :  | array_flow.rb:1178:10:1178:13 | ...[...] |
@@ -2355,10 +2930,18 @@ edges
 | array_flow.rb:1179:10:1179:10 | b [element] :  | array_flow.rb:1179:10:1179:13 | ...[...] |
 | array_flow.rb:1180:10:1180:10 | b [element] :  | array_flow.rb:1180:10:1180:13 | ...[...] |
 | array_flow.rb:1180:10:1180:10 | b [element] :  | array_flow.rb:1180:10:1180:13 | ...[...] |
-| array_flow.rb:1184:16:1184:26 | call to source :  | array_flow.rb:1185:9:1185:9 | a [element 2] :  |
-| array_flow.rb:1184:16:1184:26 | call to source :  | array_flow.rb:1185:9:1185:9 | a [element 2] :  |
-| array_flow.rb:1184:16:1184:26 | call to source :  | array_flow.rb:1188:10:1188:10 | a [element 2] :  |
-| array_flow.rb:1184:16:1184:26 | call to source :  | array_flow.rb:1188:10:1188:10 | a [element 2] :  |
+| array_flow.rb:1184:5:1184:5 | a [element 2] :  | array_flow.rb:1185:9:1185:9 | a [element 2] :  |
+| array_flow.rb:1184:5:1184:5 | a [element 2] :  | array_flow.rb:1185:9:1185:9 | a [element 2] :  |
+| array_flow.rb:1184:5:1184:5 | a [element 2] :  | array_flow.rb:1188:10:1188:10 | a [element 2] :  |
+| array_flow.rb:1184:5:1184:5 | a [element 2] :  | array_flow.rb:1188:10:1188:10 | a [element 2] :  |
+| array_flow.rb:1184:16:1184:26 | call to source :  | array_flow.rb:1184:5:1184:5 | a [element 2] :  |
+| array_flow.rb:1184:16:1184:26 | call to source :  | array_flow.rb:1184:5:1184:5 | a [element 2] :  |
+| array_flow.rb:1185:5:1185:5 | b [element] :  | array_flow.rb:1189:10:1189:10 | b [element] :  |
+| array_flow.rb:1185:5:1185:5 | b [element] :  | array_flow.rb:1189:10:1189:10 | b [element] :  |
+| array_flow.rb:1185:5:1185:5 | b [element] :  | array_flow.rb:1190:10:1190:10 | b [element] :  |
+| array_flow.rb:1185:5:1185:5 | b [element] :  | array_flow.rb:1190:10:1190:10 | b [element] :  |
+| array_flow.rb:1185:5:1185:5 | b [element] :  | array_flow.rb:1191:10:1191:10 | b [element] :  |
+| array_flow.rb:1185:5:1185:5 | b [element] :  | array_flow.rb:1191:10:1191:10 | b [element] :  |
 | array_flow.rb:1185:9:1185:9 | [post] a [element] :  | array_flow.rb:1186:10:1186:10 | a [element] :  |
 | array_flow.rb:1185:9:1185:9 | [post] a [element] :  | array_flow.rb:1186:10:1186:10 | a [element] :  |
 | array_flow.rb:1185:9:1185:9 | [post] a [element] :  | array_flow.rb:1187:10:1187:10 | a [element] :  |
@@ -2369,12 +2952,8 @@ edges
 | array_flow.rb:1185:9:1185:9 | a [element 2] :  | array_flow.rb:1185:9:1185:9 | [post] a [element] :  |
 | array_flow.rb:1185:9:1185:9 | a [element 2] :  | array_flow.rb:1185:9:1185:18 | call to shuffle! [element] :  |
 | array_flow.rb:1185:9:1185:9 | a [element 2] :  | array_flow.rb:1185:9:1185:18 | call to shuffle! [element] :  |
-| array_flow.rb:1185:9:1185:18 | call to shuffle! [element] :  | array_flow.rb:1189:10:1189:10 | b [element] :  |
-| array_flow.rb:1185:9:1185:18 | call to shuffle! [element] :  | array_flow.rb:1189:10:1189:10 | b [element] :  |
-| array_flow.rb:1185:9:1185:18 | call to shuffle! [element] :  | array_flow.rb:1190:10:1190:10 | b [element] :  |
-| array_flow.rb:1185:9:1185:18 | call to shuffle! [element] :  | array_flow.rb:1190:10:1190:10 | b [element] :  |
-| array_flow.rb:1185:9:1185:18 | call to shuffle! [element] :  | array_flow.rb:1191:10:1191:10 | b [element] :  |
-| array_flow.rb:1185:9:1185:18 | call to shuffle! [element] :  | array_flow.rb:1191:10:1191:10 | b [element] :  |
+| array_flow.rb:1185:9:1185:18 | call to shuffle! [element] :  | array_flow.rb:1185:5:1185:5 | b [element] :  |
+| array_flow.rb:1185:9:1185:18 | call to shuffle! [element] :  | array_flow.rb:1185:5:1185:5 | b [element] :  |
 | array_flow.rb:1186:10:1186:10 | a [element] :  | array_flow.rb:1186:10:1186:13 | ...[...] |
 | array_flow.rb:1186:10:1186:10 | a [element] :  | array_flow.rb:1186:10:1186:13 | ...[...] |
 | array_flow.rb:1187:10:1187:10 | a [element] :  | array_flow.rb:1187:10:1187:13 | ...[...] |
@@ -2389,52 +2968,65 @@ edges
 | array_flow.rb:1190:10:1190:10 | b [element] :  | array_flow.rb:1190:10:1190:13 | ...[...] |
 | array_flow.rb:1191:10:1191:10 | b [element] :  | array_flow.rb:1191:10:1191:13 | ...[...] |
 | array_flow.rb:1191:10:1191:10 | b [element] :  | array_flow.rb:1191:10:1191:13 | ...[...] |
-| array_flow.rb:1195:16:1195:28 | call to source :  | array_flow.rb:1200:9:1200:9 | a [element 2] :  |
-| array_flow.rb:1195:16:1195:28 | call to source :  | array_flow.rb:1200:9:1200:9 | a [element 2] :  |
-| array_flow.rb:1195:16:1195:28 | call to source :  | array_flow.rb:1203:9:1203:9 | a [element 2] :  |
-| array_flow.rb:1195:16:1195:28 | call to source :  | array_flow.rb:1203:9:1203:9 | a [element 2] :  |
-| array_flow.rb:1195:16:1195:28 | call to source :  | array_flow.rb:1209:9:1209:9 | a [element 2] :  |
-| array_flow.rb:1195:16:1195:28 | call to source :  | array_flow.rb:1209:9:1209:9 | a [element 2] :  |
-| array_flow.rb:1195:16:1195:28 | call to source :  | array_flow.rb:1214:9:1214:9 | a [element 2] :  |
-| array_flow.rb:1195:16:1195:28 | call to source :  | array_flow.rb:1214:9:1214:9 | a [element 2] :  |
-| array_flow.rb:1195:16:1195:28 | call to source :  | array_flow.rb:1218:9:1218:9 | a [element 2] :  |
-| array_flow.rb:1195:16:1195:28 | call to source :  | array_flow.rb:1218:9:1218:9 | a [element 2] :  |
-| array_flow.rb:1195:16:1195:28 | call to source :  | array_flow.rb:1223:9:1223:9 | a [element 2] :  |
-| array_flow.rb:1195:16:1195:28 | call to source :  | array_flow.rb:1223:9:1223:9 | a [element 2] :  |
-| array_flow.rb:1195:16:1195:28 | call to source :  | array_flow.rb:1228:9:1228:9 | a [element 2] :  |
-| array_flow.rb:1195:16:1195:28 | call to source :  | array_flow.rb:1228:9:1228:9 | a [element 2] :  |
-| array_flow.rb:1195:16:1195:28 | call to source :  | array_flow.rb:1232:9:1232:9 | a [element 2] :  |
-| array_flow.rb:1195:16:1195:28 | call to source :  | array_flow.rb:1232:9:1232:9 | a [element 2] :  |
-| array_flow.rb:1195:16:1195:28 | call to source :  | array_flow.rb:1236:9:1236:9 | a [element 2] :  |
-| array_flow.rb:1195:16:1195:28 | call to source :  | array_flow.rb:1236:9:1236:9 | a [element 2] :  |
-| array_flow.rb:1195:16:1195:28 | call to source :  | array_flow.rb:1241:9:1241:9 | a [element 2] :  |
-| array_flow.rb:1195:16:1195:28 | call to source :  | array_flow.rb:1241:9:1241:9 | a [element 2] :  |
-| array_flow.rb:1195:34:1195:46 | call to source :  | array_flow.rb:1197:9:1197:9 | a [element 4] :  |
-| array_flow.rb:1195:34:1195:46 | call to source :  | array_flow.rb:1197:9:1197:9 | a [element 4] :  |
-| array_flow.rb:1195:34:1195:46 | call to source :  | array_flow.rb:1200:9:1200:9 | a [element 4] :  |
-| array_flow.rb:1195:34:1195:46 | call to source :  | array_flow.rb:1200:9:1200:9 | a [element 4] :  |
-| array_flow.rb:1195:34:1195:46 | call to source :  | array_flow.rb:1203:9:1203:9 | a [element 4] :  |
-| array_flow.rb:1195:34:1195:46 | call to source :  | array_flow.rb:1203:9:1203:9 | a [element 4] :  |
-| array_flow.rb:1195:34:1195:46 | call to source :  | array_flow.rb:1209:9:1209:9 | a [element 4] :  |
-| array_flow.rb:1195:34:1195:46 | call to source :  | array_flow.rb:1209:9:1209:9 | a [element 4] :  |
-| array_flow.rb:1195:34:1195:46 | call to source :  | array_flow.rb:1214:9:1214:9 | a [element 4] :  |
-| array_flow.rb:1195:34:1195:46 | call to source :  | array_flow.rb:1214:9:1214:9 | a [element 4] :  |
-| array_flow.rb:1195:34:1195:46 | call to source :  | array_flow.rb:1228:9:1228:9 | a [element 4] :  |
-| array_flow.rb:1195:34:1195:46 | call to source :  | array_flow.rb:1228:9:1228:9 | a [element 4] :  |
-| array_flow.rb:1195:34:1195:46 | call to source :  | array_flow.rb:1232:9:1232:9 | a [element 4] :  |
-| array_flow.rb:1195:34:1195:46 | call to source :  | array_flow.rb:1232:9:1232:9 | a [element 4] :  |
-| array_flow.rb:1195:34:1195:46 | call to source :  | array_flow.rb:1241:9:1241:9 | a [element 4] :  |
-| array_flow.rb:1195:34:1195:46 | call to source :  | array_flow.rb:1241:9:1241:9 | a [element 4] :  |
+| array_flow.rb:1195:5:1195:5 | a [element 2] :  | array_flow.rb:1200:9:1200:9 | a [element 2] :  |
+| array_flow.rb:1195:5:1195:5 | a [element 2] :  | array_flow.rb:1200:9:1200:9 | a [element 2] :  |
+| array_flow.rb:1195:5:1195:5 | a [element 2] :  | array_flow.rb:1203:9:1203:9 | a [element 2] :  |
+| array_flow.rb:1195:5:1195:5 | a [element 2] :  | array_flow.rb:1203:9:1203:9 | a [element 2] :  |
+| array_flow.rb:1195:5:1195:5 | a [element 2] :  | array_flow.rb:1209:9:1209:9 | a [element 2] :  |
+| array_flow.rb:1195:5:1195:5 | a [element 2] :  | array_flow.rb:1209:9:1209:9 | a [element 2] :  |
+| array_flow.rb:1195:5:1195:5 | a [element 2] :  | array_flow.rb:1214:9:1214:9 | a [element 2] :  |
+| array_flow.rb:1195:5:1195:5 | a [element 2] :  | array_flow.rb:1214:9:1214:9 | a [element 2] :  |
+| array_flow.rb:1195:5:1195:5 | a [element 2] :  | array_flow.rb:1218:9:1218:9 | a [element 2] :  |
+| array_flow.rb:1195:5:1195:5 | a [element 2] :  | array_flow.rb:1218:9:1218:9 | a [element 2] :  |
+| array_flow.rb:1195:5:1195:5 | a [element 2] :  | array_flow.rb:1223:9:1223:9 | a [element 2] :  |
+| array_flow.rb:1195:5:1195:5 | a [element 2] :  | array_flow.rb:1223:9:1223:9 | a [element 2] :  |
+| array_flow.rb:1195:5:1195:5 | a [element 2] :  | array_flow.rb:1228:9:1228:9 | a [element 2] :  |
+| array_flow.rb:1195:5:1195:5 | a [element 2] :  | array_flow.rb:1228:9:1228:9 | a [element 2] :  |
+| array_flow.rb:1195:5:1195:5 | a [element 2] :  | array_flow.rb:1232:9:1232:9 | a [element 2] :  |
+| array_flow.rb:1195:5:1195:5 | a [element 2] :  | array_flow.rb:1232:9:1232:9 | a [element 2] :  |
+| array_flow.rb:1195:5:1195:5 | a [element 2] :  | array_flow.rb:1236:9:1236:9 | a [element 2] :  |
+| array_flow.rb:1195:5:1195:5 | a [element 2] :  | array_flow.rb:1236:9:1236:9 | a [element 2] :  |
+| array_flow.rb:1195:5:1195:5 | a [element 2] :  | array_flow.rb:1241:9:1241:9 | a [element 2] :  |
+| array_flow.rb:1195:5:1195:5 | a [element 2] :  | array_flow.rb:1241:9:1241:9 | a [element 2] :  |
+| array_flow.rb:1195:5:1195:5 | a [element 4] :  | array_flow.rb:1197:9:1197:9 | a [element 4] :  |
+| array_flow.rb:1195:5:1195:5 | a [element 4] :  | array_flow.rb:1197:9:1197:9 | a [element 4] :  |
+| array_flow.rb:1195:5:1195:5 | a [element 4] :  | array_flow.rb:1200:9:1200:9 | a [element 4] :  |
+| array_flow.rb:1195:5:1195:5 | a [element 4] :  | array_flow.rb:1200:9:1200:9 | a [element 4] :  |
+| array_flow.rb:1195:5:1195:5 | a [element 4] :  | array_flow.rb:1203:9:1203:9 | a [element 4] :  |
+| array_flow.rb:1195:5:1195:5 | a [element 4] :  | array_flow.rb:1203:9:1203:9 | a [element 4] :  |
+| array_flow.rb:1195:5:1195:5 | a [element 4] :  | array_flow.rb:1209:9:1209:9 | a [element 4] :  |
+| array_flow.rb:1195:5:1195:5 | a [element 4] :  | array_flow.rb:1209:9:1209:9 | a [element 4] :  |
+| array_flow.rb:1195:5:1195:5 | a [element 4] :  | array_flow.rb:1214:9:1214:9 | a [element 4] :  |
+| array_flow.rb:1195:5:1195:5 | a [element 4] :  | array_flow.rb:1214:9:1214:9 | a [element 4] :  |
+| array_flow.rb:1195:5:1195:5 | a [element 4] :  | array_flow.rb:1228:9:1228:9 | a [element 4] :  |
+| array_flow.rb:1195:5:1195:5 | a [element 4] :  | array_flow.rb:1228:9:1228:9 | a [element 4] :  |
+| array_flow.rb:1195:5:1195:5 | a [element 4] :  | array_flow.rb:1232:9:1232:9 | a [element 4] :  |
+| array_flow.rb:1195:5:1195:5 | a [element 4] :  | array_flow.rb:1232:9:1232:9 | a [element 4] :  |
+| array_flow.rb:1195:5:1195:5 | a [element 4] :  | array_flow.rb:1241:9:1241:9 | a [element 4] :  |
+| array_flow.rb:1195:5:1195:5 | a [element 4] :  | array_flow.rb:1241:9:1241:9 | a [element 4] :  |
+| array_flow.rb:1195:16:1195:28 | call to source :  | array_flow.rb:1195:5:1195:5 | a [element 2] :  |
+| array_flow.rb:1195:16:1195:28 | call to source :  | array_flow.rb:1195:5:1195:5 | a [element 2] :  |
+| array_flow.rb:1195:34:1195:46 | call to source :  | array_flow.rb:1195:5:1195:5 | a [element 4] :  |
+| array_flow.rb:1195:34:1195:46 | call to source :  | array_flow.rb:1195:5:1195:5 | a [element 4] :  |
+| array_flow.rb:1197:5:1197:5 | b :  | array_flow.rb:1198:10:1198:10 | b |
+| array_flow.rb:1197:5:1197:5 | b :  | array_flow.rb:1198:10:1198:10 | b |
 | array_flow.rb:1197:9:1197:9 | a [element 4] :  | array_flow.rb:1197:9:1197:17 | call to slice :  |
 | array_flow.rb:1197:9:1197:9 | a [element 4] :  | array_flow.rb:1197:9:1197:17 | call to slice :  |
-| array_flow.rb:1197:9:1197:17 | call to slice :  | array_flow.rb:1198:10:1198:10 | b |
-| array_flow.rb:1197:9:1197:17 | call to slice :  | array_flow.rb:1198:10:1198:10 | b |
+| array_flow.rb:1197:9:1197:17 | call to slice :  | array_flow.rb:1197:5:1197:5 | b :  |
+| array_flow.rb:1197:9:1197:17 | call to slice :  | array_flow.rb:1197:5:1197:5 | b :  |
+| array_flow.rb:1200:5:1200:5 | b :  | array_flow.rb:1201:10:1201:10 | b |
+| array_flow.rb:1200:5:1200:5 | b :  | array_flow.rb:1201:10:1201:10 | b |
 | array_flow.rb:1200:9:1200:9 | a [element 2] :  | array_flow.rb:1200:9:1200:19 | call to slice :  |
 | array_flow.rb:1200:9:1200:9 | a [element 2] :  | array_flow.rb:1200:9:1200:19 | call to slice :  |
 | array_flow.rb:1200:9:1200:9 | a [element 4] :  | array_flow.rb:1200:9:1200:19 | call to slice :  |
 | array_flow.rb:1200:9:1200:9 | a [element 4] :  | array_flow.rb:1200:9:1200:19 | call to slice :  |
-| array_flow.rb:1200:9:1200:19 | call to slice :  | array_flow.rb:1201:10:1201:10 | b |
-| array_flow.rb:1200:9:1200:19 | call to slice :  | array_flow.rb:1201:10:1201:10 | b |
+| array_flow.rb:1200:9:1200:19 | call to slice :  | array_flow.rb:1200:5:1200:5 | b :  |
+| array_flow.rb:1200:9:1200:19 | call to slice :  | array_flow.rb:1200:5:1200:5 | b :  |
+| array_flow.rb:1203:5:1203:5 | b :  | array_flow.rb:1205:10:1205:10 | b |
+| array_flow.rb:1203:5:1203:5 | b :  | array_flow.rb:1205:10:1205:10 | b |
+| array_flow.rb:1203:5:1203:5 | b :  | array_flow.rb:1207:10:1207:10 | b :  |
+| array_flow.rb:1203:5:1203:5 | b [element] :  | array_flow.rb:1207:10:1207:10 | b [element] :  |
+| array_flow.rb:1203:5:1203:5 | b [element] :  | array_flow.rb:1207:10:1207:10 | b [element] :  |
 | array_flow.rb:1203:9:1203:9 | a [element 2] :  | array_flow.rb:1203:9:1203:17 | call to slice :  |
 | array_flow.rb:1203:9:1203:9 | a [element 2] :  | array_flow.rb:1203:9:1203:17 | call to slice :  |
 | array_flow.rb:1203:9:1203:9 | a [element 2] :  | array_flow.rb:1203:9:1203:17 | call to slice [element] :  |
@@ -2443,114 +3035,146 @@ edges
 | array_flow.rb:1203:9:1203:9 | a [element 4] :  | array_flow.rb:1203:9:1203:17 | call to slice :  |
 | array_flow.rb:1203:9:1203:9 | a [element 4] :  | array_flow.rb:1203:9:1203:17 | call to slice [element] :  |
 | array_flow.rb:1203:9:1203:9 | a [element 4] :  | array_flow.rb:1203:9:1203:17 | call to slice [element] :  |
-| array_flow.rb:1203:9:1203:17 | call to slice :  | array_flow.rb:1205:10:1205:10 | b |
-| array_flow.rb:1203:9:1203:17 | call to slice :  | array_flow.rb:1205:10:1205:10 | b |
-| array_flow.rb:1203:9:1203:17 | call to slice :  | array_flow.rb:1207:10:1207:10 | b :  |
-| array_flow.rb:1203:9:1203:17 | call to slice [element] :  | array_flow.rb:1207:10:1207:10 | b [element] :  |
-| array_flow.rb:1203:9:1203:17 | call to slice [element] :  | array_flow.rb:1207:10:1207:10 | b [element] :  |
+| array_flow.rb:1203:9:1203:17 | call to slice :  | array_flow.rb:1203:5:1203:5 | b :  |
+| array_flow.rb:1203:9:1203:17 | call to slice :  | array_flow.rb:1203:5:1203:5 | b :  |
+| array_flow.rb:1203:9:1203:17 | call to slice [element] :  | array_flow.rb:1203:5:1203:5 | b [element] :  |
+| array_flow.rb:1203:9:1203:17 | call to slice [element] :  | array_flow.rb:1203:5:1203:5 | b [element] :  |
 | array_flow.rb:1207:10:1207:10 | b :  | array_flow.rb:1207:10:1207:13 | ...[...] |
 | array_flow.rb:1207:10:1207:10 | b [element] :  | array_flow.rb:1207:10:1207:13 | ...[...] |
 | array_flow.rb:1207:10:1207:10 | b [element] :  | array_flow.rb:1207:10:1207:13 | ...[...] |
+| array_flow.rb:1209:5:1209:5 | b [element 0] :  | array_flow.rb:1210:10:1210:10 | b [element 0] :  |
+| array_flow.rb:1209:5:1209:5 | b [element 0] :  | array_flow.rb:1210:10:1210:10 | b [element 0] :  |
+| array_flow.rb:1209:5:1209:5 | b [element 2] :  | array_flow.rb:1212:10:1212:10 | b [element 2] :  |
+| array_flow.rb:1209:5:1209:5 | b [element 2] :  | array_flow.rb:1212:10:1212:10 | b [element 2] :  |
 | array_flow.rb:1209:9:1209:9 | a [element 2] :  | array_flow.rb:1209:9:1209:21 | call to slice [element 0] :  |
 | array_flow.rb:1209:9:1209:9 | a [element 2] :  | array_flow.rb:1209:9:1209:21 | call to slice [element 0] :  |
 | array_flow.rb:1209:9:1209:9 | a [element 4] :  | array_flow.rb:1209:9:1209:21 | call to slice [element 2] :  |
 | array_flow.rb:1209:9:1209:9 | a [element 4] :  | array_flow.rb:1209:9:1209:21 | call to slice [element 2] :  |
-| array_flow.rb:1209:9:1209:21 | call to slice [element 0] :  | array_flow.rb:1210:10:1210:10 | b [element 0] :  |
-| array_flow.rb:1209:9:1209:21 | call to slice [element 0] :  | array_flow.rb:1210:10:1210:10 | b [element 0] :  |
-| array_flow.rb:1209:9:1209:21 | call to slice [element 2] :  | array_flow.rb:1212:10:1212:10 | b [element 2] :  |
-| array_flow.rb:1209:9:1209:21 | call to slice [element 2] :  | array_flow.rb:1212:10:1212:10 | b [element 2] :  |
+| array_flow.rb:1209:9:1209:21 | call to slice [element 0] :  | array_flow.rb:1209:5:1209:5 | b [element 0] :  |
+| array_flow.rb:1209:9:1209:21 | call to slice [element 0] :  | array_flow.rb:1209:5:1209:5 | b [element 0] :  |
+| array_flow.rb:1209:9:1209:21 | call to slice [element 2] :  | array_flow.rb:1209:5:1209:5 | b [element 2] :  |
+| array_flow.rb:1209:9:1209:21 | call to slice [element 2] :  | array_flow.rb:1209:5:1209:5 | b [element 2] :  |
 | array_flow.rb:1210:10:1210:10 | b [element 0] :  | array_flow.rb:1210:10:1210:13 | ...[...] |
 | array_flow.rb:1210:10:1210:10 | b [element 0] :  | array_flow.rb:1210:10:1210:13 | ...[...] |
 | array_flow.rb:1212:10:1212:10 | b [element 2] :  | array_flow.rb:1212:10:1212:13 | ...[...] |
 | array_flow.rb:1212:10:1212:10 | b [element 2] :  | array_flow.rb:1212:10:1212:13 | ...[...] |
+| array_flow.rb:1214:5:1214:5 | b [element] :  | array_flow.rb:1215:10:1215:10 | b [element] :  |
+| array_flow.rb:1214:5:1214:5 | b [element] :  | array_flow.rb:1215:10:1215:10 | b [element] :  |
+| array_flow.rb:1214:5:1214:5 | b [element] :  | array_flow.rb:1216:10:1216:10 | b [element] :  |
+| array_flow.rb:1214:5:1214:5 | b [element] :  | array_flow.rb:1216:10:1216:10 | b [element] :  |
 | array_flow.rb:1214:9:1214:9 | a [element 2] :  | array_flow.rb:1214:9:1214:21 | call to slice [element] :  |
 | array_flow.rb:1214:9:1214:9 | a [element 2] :  | array_flow.rb:1214:9:1214:21 | call to slice [element] :  |
 | array_flow.rb:1214:9:1214:9 | a [element 4] :  | array_flow.rb:1214:9:1214:21 | call to slice [element] :  |
 | array_flow.rb:1214:9:1214:9 | a [element 4] :  | array_flow.rb:1214:9:1214:21 | call to slice [element] :  |
-| array_flow.rb:1214:9:1214:21 | call to slice [element] :  | array_flow.rb:1215:10:1215:10 | b [element] :  |
-| array_flow.rb:1214:9:1214:21 | call to slice [element] :  | array_flow.rb:1215:10:1215:10 | b [element] :  |
-| array_flow.rb:1214:9:1214:21 | call to slice [element] :  | array_flow.rb:1216:10:1216:10 | b [element] :  |
-| array_flow.rb:1214:9:1214:21 | call to slice [element] :  | array_flow.rb:1216:10:1216:10 | b [element] :  |
+| array_flow.rb:1214:9:1214:21 | call to slice [element] :  | array_flow.rb:1214:5:1214:5 | b [element] :  |
+| array_flow.rb:1214:9:1214:21 | call to slice [element] :  | array_flow.rb:1214:5:1214:5 | b [element] :  |
 | array_flow.rb:1215:10:1215:10 | b [element] :  | array_flow.rb:1215:10:1215:13 | ...[...] |
 | array_flow.rb:1215:10:1215:10 | b [element] :  | array_flow.rb:1215:10:1215:13 | ...[...] |
 | array_flow.rb:1216:10:1216:10 | b [element] :  | array_flow.rb:1216:10:1216:13 | ...[...] |
 | array_flow.rb:1216:10:1216:10 | b [element] :  | array_flow.rb:1216:10:1216:13 | ...[...] |
+| array_flow.rb:1218:5:1218:5 | b [element 0] :  | array_flow.rb:1219:10:1219:10 | b [element 0] :  |
+| array_flow.rb:1218:5:1218:5 | b [element 0] :  | array_flow.rb:1219:10:1219:10 | b [element 0] :  |
 | array_flow.rb:1218:9:1218:9 | a [element 2] :  | array_flow.rb:1218:9:1218:21 | call to slice [element 0] :  |
 | array_flow.rb:1218:9:1218:9 | a [element 2] :  | array_flow.rb:1218:9:1218:21 | call to slice [element 0] :  |
-| array_flow.rb:1218:9:1218:21 | call to slice [element 0] :  | array_flow.rb:1219:10:1219:10 | b [element 0] :  |
-| array_flow.rb:1218:9:1218:21 | call to slice [element 0] :  | array_flow.rb:1219:10:1219:10 | b [element 0] :  |
+| array_flow.rb:1218:9:1218:21 | call to slice [element 0] :  | array_flow.rb:1218:5:1218:5 | b [element 0] :  |
+| array_flow.rb:1218:9:1218:21 | call to slice [element 0] :  | array_flow.rb:1218:5:1218:5 | b [element 0] :  |
 | array_flow.rb:1219:10:1219:10 | b [element 0] :  | array_flow.rb:1219:10:1219:13 | ...[...] |
 | array_flow.rb:1219:10:1219:10 | b [element 0] :  | array_flow.rb:1219:10:1219:13 | ...[...] |
+| array_flow.rb:1223:5:1223:5 | b [element 0] :  | array_flow.rb:1224:10:1224:10 | b [element 0] :  |
+| array_flow.rb:1223:5:1223:5 | b [element 0] :  | array_flow.rb:1224:10:1224:10 | b [element 0] :  |
 | array_flow.rb:1223:9:1223:9 | a [element 2] :  | array_flow.rb:1223:9:1223:22 | call to slice [element 0] :  |
 | array_flow.rb:1223:9:1223:9 | a [element 2] :  | array_flow.rb:1223:9:1223:22 | call to slice [element 0] :  |
-| array_flow.rb:1223:9:1223:22 | call to slice [element 0] :  | array_flow.rb:1224:10:1224:10 | b [element 0] :  |
-| array_flow.rb:1223:9:1223:22 | call to slice [element 0] :  | array_flow.rb:1224:10:1224:10 | b [element 0] :  |
+| array_flow.rb:1223:9:1223:22 | call to slice [element 0] :  | array_flow.rb:1223:5:1223:5 | b [element 0] :  |
+| array_flow.rb:1223:9:1223:22 | call to slice [element 0] :  | array_flow.rb:1223:5:1223:5 | b [element 0] :  |
 | array_flow.rb:1224:10:1224:10 | b [element 0] :  | array_flow.rb:1224:10:1224:13 | ...[...] |
 | array_flow.rb:1224:10:1224:10 | b [element 0] :  | array_flow.rb:1224:10:1224:13 | ...[...] |
+| array_flow.rb:1228:5:1228:5 | b [element] :  | array_flow.rb:1229:10:1229:10 | b [element] :  |
+| array_flow.rb:1228:5:1228:5 | b [element] :  | array_flow.rb:1229:10:1229:10 | b [element] :  |
+| array_flow.rb:1228:5:1228:5 | b [element] :  | array_flow.rb:1230:10:1230:10 | b [element] :  |
+| array_flow.rb:1228:5:1228:5 | b [element] :  | array_flow.rb:1230:10:1230:10 | b [element] :  |
 | array_flow.rb:1228:9:1228:9 | a [element 2] :  | array_flow.rb:1228:9:1228:21 | call to slice [element] :  |
 | array_flow.rb:1228:9:1228:9 | a [element 2] :  | array_flow.rb:1228:9:1228:21 | call to slice [element] :  |
 | array_flow.rb:1228:9:1228:9 | a [element 4] :  | array_flow.rb:1228:9:1228:21 | call to slice [element] :  |
 | array_flow.rb:1228:9:1228:9 | a [element 4] :  | array_flow.rb:1228:9:1228:21 | call to slice [element] :  |
-| array_flow.rb:1228:9:1228:21 | call to slice [element] :  | array_flow.rb:1229:10:1229:10 | b [element] :  |
-| array_flow.rb:1228:9:1228:21 | call to slice [element] :  | array_flow.rb:1229:10:1229:10 | b [element] :  |
-| array_flow.rb:1228:9:1228:21 | call to slice [element] :  | array_flow.rb:1230:10:1230:10 | b [element] :  |
-| array_flow.rb:1228:9:1228:21 | call to slice [element] :  | array_flow.rb:1230:10:1230:10 | b [element] :  |
+| array_flow.rb:1228:9:1228:21 | call to slice [element] :  | array_flow.rb:1228:5:1228:5 | b [element] :  |
+| array_flow.rb:1228:9:1228:21 | call to slice [element] :  | array_flow.rb:1228:5:1228:5 | b [element] :  |
 | array_flow.rb:1229:10:1229:10 | b [element] :  | array_flow.rb:1229:10:1229:13 | ...[...] |
 | array_flow.rb:1229:10:1229:10 | b [element] :  | array_flow.rb:1229:10:1229:13 | ...[...] |
 | array_flow.rb:1230:10:1230:10 | b [element] :  | array_flow.rb:1230:10:1230:13 | ...[...] |
 | array_flow.rb:1230:10:1230:10 | b [element] :  | array_flow.rb:1230:10:1230:13 | ...[...] |
+| array_flow.rb:1232:5:1232:5 | b [element] :  | array_flow.rb:1233:10:1233:10 | b [element] :  |
+| array_flow.rb:1232:5:1232:5 | b [element] :  | array_flow.rb:1233:10:1233:10 | b [element] :  |
+| array_flow.rb:1232:5:1232:5 | b [element] :  | array_flow.rb:1234:10:1234:10 | b [element] :  |
+| array_flow.rb:1232:5:1232:5 | b [element] :  | array_flow.rb:1234:10:1234:10 | b [element] :  |
 | array_flow.rb:1232:9:1232:9 | a [element 2] :  | array_flow.rb:1232:9:1232:24 | call to slice [element] :  |
 | array_flow.rb:1232:9:1232:9 | a [element 2] :  | array_flow.rb:1232:9:1232:24 | call to slice [element] :  |
 | array_flow.rb:1232:9:1232:9 | a [element 4] :  | array_flow.rb:1232:9:1232:24 | call to slice [element] :  |
 | array_flow.rb:1232:9:1232:9 | a [element 4] :  | array_flow.rb:1232:9:1232:24 | call to slice [element] :  |
-| array_flow.rb:1232:9:1232:24 | call to slice [element] :  | array_flow.rb:1233:10:1233:10 | b [element] :  |
-| array_flow.rb:1232:9:1232:24 | call to slice [element] :  | array_flow.rb:1233:10:1233:10 | b [element] :  |
-| array_flow.rb:1232:9:1232:24 | call to slice [element] :  | array_flow.rb:1234:10:1234:10 | b [element] :  |
-| array_flow.rb:1232:9:1232:24 | call to slice [element] :  | array_flow.rb:1234:10:1234:10 | b [element] :  |
+| array_flow.rb:1232:9:1232:24 | call to slice [element] :  | array_flow.rb:1232:5:1232:5 | b [element] :  |
+| array_flow.rb:1232:9:1232:24 | call to slice [element] :  | array_flow.rb:1232:5:1232:5 | b [element] :  |
 | array_flow.rb:1233:10:1233:10 | b [element] :  | array_flow.rb:1233:10:1233:13 | ...[...] |
 | array_flow.rb:1233:10:1233:10 | b [element] :  | array_flow.rb:1233:10:1233:13 | ...[...] |
 | array_flow.rb:1234:10:1234:10 | b [element] :  | array_flow.rb:1234:10:1234:13 | ...[...] |
 | array_flow.rb:1234:10:1234:10 | b [element] :  | array_flow.rb:1234:10:1234:13 | ...[...] |
+| array_flow.rb:1236:5:1236:5 | b [element 2] :  | array_flow.rb:1239:10:1239:10 | b [element 2] :  |
+| array_flow.rb:1236:5:1236:5 | b [element 2] :  | array_flow.rb:1239:10:1239:10 | b [element 2] :  |
 | array_flow.rb:1236:9:1236:9 | a [element 2] :  | array_flow.rb:1236:9:1236:20 | call to slice [element 2] :  |
 | array_flow.rb:1236:9:1236:9 | a [element 2] :  | array_flow.rb:1236:9:1236:20 | call to slice [element 2] :  |
-| array_flow.rb:1236:9:1236:20 | call to slice [element 2] :  | array_flow.rb:1239:10:1239:10 | b [element 2] :  |
-| array_flow.rb:1236:9:1236:20 | call to slice [element 2] :  | array_flow.rb:1239:10:1239:10 | b [element 2] :  |
+| array_flow.rb:1236:9:1236:20 | call to slice [element 2] :  | array_flow.rb:1236:5:1236:5 | b [element 2] :  |
+| array_flow.rb:1236:9:1236:20 | call to slice [element 2] :  | array_flow.rb:1236:5:1236:5 | b [element 2] :  |
 | array_flow.rb:1239:10:1239:10 | b [element 2] :  | array_flow.rb:1239:10:1239:13 | ...[...] |
 | array_flow.rb:1239:10:1239:10 | b [element 2] :  | array_flow.rb:1239:10:1239:13 | ...[...] |
+| array_flow.rb:1241:5:1241:5 | b [element] :  | array_flow.rb:1242:10:1242:10 | b [element] :  |
+| array_flow.rb:1241:5:1241:5 | b [element] :  | array_flow.rb:1242:10:1242:10 | b [element] :  |
+| array_flow.rb:1241:5:1241:5 | b [element] :  | array_flow.rb:1243:10:1243:10 | b [element] :  |
+| array_flow.rb:1241:5:1241:5 | b [element] :  | array_flow.rb:1243:10:1243:10 | b [element] :  |
+| array_flow.rb:1241:5:1241:5 | b [element] :  | array_flow.rb:1244:10:1244:10 | b [element] :  |
+| array_flow.rb:1241:5:1241:5 | b [element] :  | array_flow.rb:1244:10:1244:10 | b [element] :  |
 | array_flow.rb:1241:9:1241:9 | a [element 2] :  | array_flow.rb:1241:9:1241:20 | call to slice [element] :  |
 | array_flow.rb:1241:9:1241:9 | a [element 2] :  | array_flow.rb:1241:9:1241:20 | call to slice [element] :  |
 | array_flow.rb:1241:9:1241:9 | a [element 4] :  | array_flow.rb:1241:9:1241:20 | call to slice [element] :  |
 | array_flow.rb:1241:9:1241:9 | a [element 4] :  | array_flow.rb:1241:9:1241:20 | call to slice [element] :  |
-| array_flow.rb:1241:9:1241:20 | call to slice [element] :  | array_flow.rb:1242:10:1242:10 | b [element] :  |
-| array_flow.rb:1241:9:1241:20 | call to slice [element] :  | array_flow.rb:1242:10:1242:10 | b [element] :  |
-| array_flow.rb:1241:9:1241:20 | call to slice [element] :  | array_flow.rb:1243:10:1243:10 | b [element] :  |
-| array_flow.rb:1241:9:1241:20 | call to slice [element] :  | array_flow.rb:1243:10:1243:10 | b [element] :  |
-| array_flow.rb:1241:9:1241:20 | call to slice [element] :  | array_flow.rb:1244:10:1244:10 | b [element] :  |
-| array_flow.rb:1241:9:1241:20 | call to slice [element] :  | array_flow.rb:1244:10:1244:10 | b [element] :  |
+| array_flow.rb:1241:9:1241:20 | call to slice [element] :  | array_flow.rb:1241:5:1241:5 | b [element] :  |
+| array_flow.rb:1241:9:1241:20 | call to slice [element] :  | array_flow.rb:1241:5:1241:5 | b [element] :  |
 | array_flow.rb:1242:10:1242:10 | b [element] :  | array_flow.rb:1242:10:1242:13 | ...[...] |
 | array_flow.rb:1242:10:1242:10 | b [element] :  | array_flow.rb:1242:10:1242:13 | ...[...] |
 | array_flow.rb:1243:10:1243:10 | b [element] :  | array_flow.rb:1243:10:1243:13 | ...[...] |
 | array_flow.rb:1243:10:1243:10 | b [element] :  | array_flow.rb:1243:10:1243:13 | ...[...] |
 | array_flow.rb:1244:10:1244:10 | b [element] :  | array_flow.rb:1244:10:1244:13 | ...[...] |
 | array_flow.rb:1244:10:1244:10 | b [element] :  | array_flow.rb:1244:10:1244:13 | ...[...] |
-| array_flow.rb:1248:16:1248:28 | call to source :  | array_flow.rb:1249:9:1249:9 | a [element 2] :  |
-| array_flow.rb:1248:16:1248:28 | call to source :  | array_flow.rb:1249:9:1249:9 | a [element 2] :  |
-| array_flow.rb:1248:34:1248:46 | call to source :  | array_flow.rb:1249:9:1249:9 | a [element 4] :  |
-| array_flow.rb:1248:34:1248:46 | call to source :  | array_flow.rb:1249:9:1249:9 | a [element 4] :  |
+| array_flow.rb:1248:5:1248:5 | a [element 2] :  | array_flow.rb:1249:9:1249:9 | a [element 2] :  |
+| array_flow.rb:1248:5:1248:5 | a [element 2] :  | array_flow.rb:1249:9:1249:9 | a [element 2] :  |
+| array_flow.rb:1248:5:1248:5 | a [element 4] :  | array_flow.rb:1249:9:1249:9 | a [element 4] :  |
+| array_flow.rb:1248:5:1248:5 | a [element 4] :  | array_flow.rb:1249:9:1249:9 | a [element 4] :  |
+| array_flow.rb:1248:16:1248:28 | call to source :  | array_flow.rb:1248:5:1248:5 | a [element 2] :  |
+| array_flow.rb:1248:16:1248:28 | call to source :  | array_flow.rb:1248:5:1248:5 | a [element 2] :  |
+| array_flow.rb:1248:34:1248:46 | call to source :  | array_flow.rb:1248:5:1248:5 | a [element 4] :  |
+| array_flow.rb:1248:34:1248:46 | call to source :  | array_flow.rb:1248:5:1248:5 | a [element 4] :  |
+| array_flow.rb:1249:5:1249:5 | b :  | array_flow.rb:1250:10:1250:10 | b |
+| array_flow.rb:1249:5:1249:5 | b :  | array_flow.rb:1250:10:1250:10 | b |
 | array_flow.rb:1249:9:1249:9 | [post] a [element 3] :  | array_flow.rb:1254:10:1254:10 | a [element 3] :  |
 | array_flow.rb:1249:9:1249:9 | [post] a [element 3] :  | array_flow.rb:1254:10:1254:10 | a [element 3] :  |
 | array_flow.rb:1249:9:1249:9 | a [element 2] :  | array_flow.rb:1249:9:1249:19 | call to slice! :  |
 | array_flow.rb:1249:9:1249:9 | a [element 2] :  | array_flow.rb:1249:9:1249:19 | call to slice! :  |
 | array_flow.rb:1249:9:1249:9 | a [element 4] :  | array_flow.rb:1249:9:1249:9 | [post] a [element 3] :  |
 | array_flow.rb:1249:9:1249:9 | a [element 4] :  | array_flow.rb:1249:9:1249:9 | [post] a [element 3] :  |
-| array_flow.rb:1249:9:1249:19 | call to slice! :  | array_flow.rb:1250:10:1250:10 | b |
-| array_flow.rb:1249:9:1249:19 | call to slice! :  | array_flow.rb:1250:10:1250:10 | b |
+| array_flow.rb:1249:9:1249:19 | call to slice! :  | array_flow.rb:1249:5:1249:5 | b :  |
+| array_flow.rb:1249:9:1249:19 | call to slice! :  | array_flow.rb:1249:5:1249:5 | b :  |
 | array_flow.rb:1254:10:1254:10 | a [element 3] :  | array_flow.rb:1254:10:1254:13 | ...[...] |
 | array_flow.rb:1254:10:1254:10 | a [element 3] :  | array_flow.rb:1254:10:1254:13 | ...[...] |
-| array_flow.rb:1256:16:1256:28 | call to source :  | array_flow.rb:1257:9:1257:9 | a [element 2] :  |
-| array_flow.rb:1256:16:1256:28 | call to source :  | array_flow.rb:1257:9:1257:9 | a [element 2] :  |
-| array_flow.rb:1256:34:1256:46 | call to source :  | array_flow.rb:1257:9:1257:9 | a [element 4] :  |
-| array_flow.rb:1256:34:1256:46 | call to source :  | array_flow.rb:1257:9:1257:9 | a [element 4] :  |
+| array_flow.rb:1256:5:1256:5 | a [element 2] :  | array_flow.rb:1257:9:1257:9 | a [element 2] :  |
+| array_flow.rb:1256:5:1256:5 | a [element 2] :  | array_flow.rb:1257:9:1257:9 | a [element 2] :  |
+| array_flow.rb:1256:5:1256:5 | a [element 4] :  | array_flow.rb:1257:9:1257:9 | a [element 4] :  |
+| array_flow.rb:1256:5:1256:5 | a [element 4] :  | array_flow.rb:1257:9:1257:9 | a [element 4] :  |
+| array_flow.rb:1256:16:1256:28 | call to source :  | array_flow.rb:1256:5:1256:5 | a [element 2] :  |
+| array_flow.rb:1256:16:1256:28 | call to source :  | array_flow.rb:1256:5:1256:5 | a [element 2] :  |
+| array_flow.rb:1256:34:1256:46 | call to source :  | array_flow.rb:1256:5:1256:5 | a [element 4] :  |
+| array_flow.rb:1256:34:1256:46 | call to source :  | array_flow.rb:1256:5:1256:5 | a [element 4] :  |
+| array_flow.rb:1257:5:1257:5 | b :  | array_flow.rb:1263:10:1263:10 | b |
+| array_flow.rb:1257:5:1257:5 | b :  | array_flow.rb:1263:10:1263:10 | b |
+| array_flow.rb:1257:5:1257:5 | b :  | array_flow.rb:1265:10:1265:10 | b :  |
+| array_flow.rb:1257:5:1257:5 | b [element] :  | array_flow.rb:1265:10:1265:10 | b [element] :  |
+| array_flow.rb:1257:5:1257:5 | b [element] :  | array_flow.rb:1265:10:1265:10 | b [element] :  |
 | array_flow.rb:1257:9:1257:9 | [post] a [element] :  | array_flow.rb:1258:10:1258:10 | a [element] :  |
 | array_flow.rb:1257:9:1257:9 | [post] a [element] :  | array_flow.rb:1258:10:1258:10 | a [element] :  |
 | array_flow.rb:1257:9:1257:9 | [post] a [element] :  | array_flow.rb:1259:10:1259:10 | a [element] :  |
@@ -2571,11 +3195,10 @@ edges
 | array_flow.rb:1257:9:1257:9 | a [element 4] :  | array_flow.rb:1257:9:1257:19 | call to slice! :  |
 | array_flow.rb:1257:9:1257:9 | a [element 4] :  | array_flow.rb:1257:9:1257:19 | call to slice! [element] :  |
 | array_flow.rb:1257:9:1257:9 | a [element 4] :  | array_flow.rb:1257:9:1257:19 | call to slice! [element] :  |
-| array_flow.rb:1257:9:1257:19 | call to slice! :  | array_flow.rb:1263:10:1263:10 | b |
-| array_flow.rb:1257:9:1257:19 | call to slice! :  | array_flow.rb:1263:10:1263:10 | b |
-| array_flow.rb:1257:9:1257:19 | call to slice! :  | array_flow.rb:1265:10:1265:10 | b :  |
-| array_flow.rb:1257:9:1257:19 | call to slice! [element] :  | array_flow.rb:1265:10:1265:10 | b [element] :  |
-| array_flow.rb:1257:9:1257:19 | call to slice! [element] :  | array_flow.rb:1265:10:1265:10 | b [element] :  |
+| array_flow.rb:1257:9:1257:19 | call to slice! :  | array_flow.rb:1257:5:1257:5 | b :  |
+| array_flow.rb:1257:9:1257:19 | call to slice! :  | array_flow.rb:1257:5:1257:5 | b :  |
+| array_flow.rb:1257:9:1257:19 | call to slice! [element] :  | array_flow.rb:1257:5:1257:5 | b [element] :  |
+| array_flow.rb:1257:9:1257:19 | call to slice! [element] :  | array_flow.rb:1257:5:1257:5 | b [element] :  |
 | array_flow.rb:1258:10:1258:10 | a [element] :  | array_flow.rb:1258:10:1258:13 | ...[...] |
 | array_flow.rb:1258:10:1258:10 | a [element] :  | array_flow.rb:1258:10:1258:13 | ...[...] |
 | array_flow.rb:1259:10:1259:10 | a [element] :  | array_flow.rb:1259:10:1259:13 | ...[...] |
@@ -2587,58 +3210,88 @@ edges
 | array_flow.rb:1265:10:1265:10 | b :  | array_flow.rb:1265:10:1265:13 | ...[...] |
 | array_flow.rb:1265:10:1265:10 | b [element] :  | array_flow.rb:1265:10:1265:13 | ...[...] |
 | array_flow.rb:1265:10:1265:10 | b [element] :  | array_flow.rb:1265:10:1265:13 | ...[...] |
-| array_flow.rb:1267:16:1267:28 | call to source :  | array_flow.rb:1268:9:1268:9 | a [element 2] :  |
-| array_flow.rb:1267:16:1267:28 | call to source :  | array_flow.rb:1268:9:1268:9 | a [element 2] :  |
-| array_flow.rb:1267:34:1267:46 | call to source :  | array_flow.rb:1268:9:1268:9 | a [element 4] :  |
-| array_flow.rb:1267:34:1267:46 | call to source :  | array_flow.rb:1268:9:1268:9 | a [element 4] :  |
+| array_flow.rb:1267:5:1267:5 | a [element 2] :  | array_flow.rb:1268:9:1268:9 | a [element 2] :  |
+| array_flow.rb:1267:5:1267:5 | a [element 2] :  | array_flow.rb:1268:9:1268:9 | a [element 2] :  |
+| array_flow.rb:1267:5:1267:5 | a [element 4] :  | array_flow.rb:1268:9:1268:9 | a [element 4] :  |
+| array_flow.rb:1267:5:1267:5 | a [element 4] :  | array_flow.rb:1268:9:1268:9 | a [element 4] :  |
+| array_flow.rb:1267:16:1267:28 | call to source :  | array_flow.rb:1267:5:1267:5 | a [element 2] :  |
+| array_flow.rb:1267:16:1267:28 | call to source :  | array_flow.rb:1267:5:1267:5 | a [element 2] :  |
+| array_flow.rb:1267:34:1267:46 | call to source :  | array_flow.rb:1267:5:1267:5 | a [element 4] :  |
+| array_flow.rb:1267:34:1267:46 | call to source :  | array_flow.rb:1267:5:1267:5 | a [element 4] :  |
+| array_flow.rb:1268:5:1268:5 | b [element 0] :  | array_flow.rb:1269:10:1269:10 | b [element 0] :  |
+| array_flow.rb:1268:5:1268:5 | b [element 0] :  | array_flow.rb:1269:10:1269:10 | b [element 0] :  |
+| array_flow.rb:1268:5:1268:5 | b [element 2] :  | array_flow.rb:1271:10:1271:10 | b [element 2] :  |
+| array_flow.rb:1268:5:1268:5 | b [element 2] :  | array_flow.rb:1271:10:1271:10 | b [element 2] :  |
 | array_flow.rb:1268:9:1268:9 | a [element 2] :  | array_flow.rb:1268:9:1268:22 | call to slice! [element 0] :  |
 | array_flow.rb:1268:9:1268:9 | a [element 2] :  | array_flow.rb:1268:9:1268:22 | call to slice! [element 0] :  |
 | array_flow.rb:1268:9:1268:9 | a [element 4] :  | array_flow.rb:1268:9:1268:22 | call to slice! [element 2] :  |
 | array_flow.rb:1268:9:1268:9 | a [element 4] :  | array_flow.rb:1268:9:1268:22 | call to slice! [element 2] :  |
-| array_flow.rb:1268:9:1268:22 | call to slice! [element 0] :  | array_flow.rb:1269:10:1269:10 | b [element 0] :  |
-| array_flow.rb:1268:9:1268:22 | call to slice! [element 0] :  | array_flow.rb:1269:10:1269:10 | b [element 0] :  |
-| array_flow.rb:1268:9:1268:22 | call to slice! [element 2] :  | array_flow.rb:1271:10:1271:10 | b [element 2] :  |
-| array_flow.rb:1268:9:1268:22 | call to slice! [element 2] :  | array_flow.rb:1271:10:1271:10 | b [element 2] :  |
+| array_flow.rb:1268:9:1268:22 | call to slice! [element 0] :  | array_flow.rb:1268:5:1268:5 | b [element 0] :  |
+| array_flow.rb:1268:9:1268:22 | call to slice! [element 0] :  | array_flow.rb:1268:5:1268:5 | b [element 0] :  |
+| array_flow.rb:1268:9:1268:22 | call to slice! [element 2] :  | array_flow.rb:1268:5:1268:5 | b [element 2] :  |
+| array_flow.rb:1268:9:1268:22 | call to slice! [element 2] :  | array_flow.rb:1268:5:1268:5 | b [element 2] :  |
 | array_flow.rb:1269:10:1269:10 | b [element 0] :  | array_flow.rb:1269:10:1269:13 | ...[...] |
 | array_flow.rb:1269:10:1269:10 | b [element 0] :  | array_flow.rb:1269:10:1269:13 | ...[...] |
 | array_flow.rb:1271:10:1271:10 | b [element 2] :  | array_flow.rb:1271:10:1271:13 | ...[...] |
 | array_flow.rb:1271:10:1271:10 | b [element 2] :  | array_flow.rb:1271:10:1271:13 | ...[...] |
-| array_flow.rb:1278:16:1278:28 | call to source :  | array_flow.rb:1279:9:1279:9 | a [element 2] :  |
-| array_flow.rb:1278:16:1278:28 | call to source :  | array_flow.rb:1279:9:1279:9 | a [element 2] :  |
-| array_flow.rb:1278:34:1278:46 | call to source :  | array_flow.rb:1279:9:1279:9 | a [element 4] :  |
-| array_flow.rb:1278:34:1278:46 | call to source :  | array_flow.rb:1279:9:1279:9 | a [element 4] :  |
+| array_flow.rb:1278:5:1278:5 | a [element 2] :  | array_flow.rb:1279:9:1279:9 | a [element 2] :  |
+| array_flow.rb:1278:5:1278:5 | a [element 2] :  | array_flow.rb:1279:9:1279:9 | a [element 2] :  |
+| array_flow.rb:1278:5:1278:5 | a [element 4] :  | array_flow.rb:1279:9:1279:9 | a [element 4] :  |
+| array_flow.rb:1278:5:1278:5 | a [element 4] :  | array_flow.rb:1279:9:1279:9 | a [element 4] :  |
+| array_flow.rb:1278:16:1278:28 | call to source :  | array_flow.rb:1278:5:1278:5 | a [element 2] :  |
+| array_flow.rb:1278:16:1278:28 | call to source :  | array_flow.rb:1278:5:1278:5 | a [element 2] :  |
+| array_flow.rb:1278:34:1278:46 | call to source :  | array_flow.rb:1278:5:1278:5 | a [element 4] :  |
+| array_flow.rb:1278:34:1278:46 | call to source :  | array_flow.rb:1278:5:1278:5 | a [element 4] :  |
+| array_flow.rb:1279:5:1279:5 | b [element 0] :  | array_flow.rb:1280:10:1280:10 | b [element 0] :  |
+| array_flow.rb:1279:5:1279:5 | b [element 0] :  | array_flow.rb:1280:10:1280:10 | b [element 0] :  |
 | array_flow.rb:1279:9:1279:9 | [post] a [element 2] :  | array_flow.rb:1285:10:1285:10 | a [element 2] :  |
 | array_flow.rb:1279:9:1279:9 | [post] a [element 2] :  | array_flow.rb:1285:10:1285:10 | a [element 2] :  |
 | array_flow.rb:1279:9:1279:9 | a [element 2] :  | array_flow.rb:1279:9:1279:22 | call to slice! [element 0] :  |
 | array_flow.rb:1279:9:1279:9 | a [element 2] :  | array_flow.rb:1279:9:1279:22 | call to slice! [element 0] :  |
 | array_flow.rb:1279:9:1279:9 | a [element 4] :  | array_flow.rb:1279:9:1279:9 | [post] a [element 2] :  |
 | array_flow.rb:1279:9:1279:9 | a [element 4] :  | array_flow.rb:1279:9:1279:9 | [post] a [element 2] :  |
-| array_flow.rb:1279:9:1279:22 | call to slice! [element 0] :  | array_flow.rb:1280:10:1280:10 | b [element 0] :  |
-| array_flow.rb:1279:9:1279:22 | call to slice! [element 0] :  | array_flow.rb:1280:10:1280:10 | b [element 0] :  |
+| array_flow.rb:1279:9:1279:22 | call to slice! [element 0] :  | array_flow.rb:1279:5:1279:5 | b [element 0] :  |
+| array_flow.rb:1279:9:1279:22 | call to slice! [element 0] :  | array_flow.rb:1279:5:1279:5 | b [element 0] :  |
 | array_flow.rb:1280:10:1280:10 | b [element 0] :  | array_flow.rb:1280:10:1280:13 | ...[...] |
 | array_flow.rb:1280:10:1280:10 | b [element 0] :  | array_flow.rb:1280:10:1280:13 | ...[...] |
 | array_flow.rb:1285:10:1285:10 | a [element 2] :  | array_flow.rb:1285:10:1285:13 | ...[...] |
 | array_flow.rb:1285:10:1285:10 | a [element 2] :  | array_flow.rb:1285:10:1285:13 | ...[...] |
-| array_flow.rb:1289:16:1289:28 | call to source :  | array_flow.rb:1290:9:1290:9 | a [element 2] :  |
-| array_flow.rb:1289:16:1289:28 | call to source :  | array_flow.rb:1290:9:1290:9 | a [element 2] :  |
-| array_flow.rb:1289:34:1289:46 | call to source :  | array_flow.rb:1290:9:1290:9 | a [element 4] :  |
-| array_flow.rb:1289:34:1289:46 | call to source :  | array_flow.rb:1290:9:1290:9 | a [element 4] :  |
+| array_flow.rb:1289:5:1289:5 | a [element 2] :  | array_flow.rb:1290:9:1290:9 | a [element 2] :  |
+| array_flow.rb:1289:5:1289:5 | a [element 2] :  | array_flow.rb:1290:9:1290:9 | a [element 2] :  |
+| array_flow.rb:1289:5:1289:5 | a [element 4] :  | array_flow.rb:1290:9:1290:9 | a [element 4] :  |
+| array_flow.rb:1289:5:1289:5 | a [element 4] :  | array_flow.rb:1290:9:1290:9 | a [element 4] :  |
+| array_flow.rb:1289:16:1289:28 | call to source :  | array_flow.rb:1289:5:1289:5 | a [element 2] :  |
+| array_flow.rb:1289:16:1289:28 | call to source :  | array_flow.rb:1289:5:1289:5 | a [element 2] :  |
+| array_flow.rb:1289:34:1289:46 | call to source :  | array_flow.rb:1289:5:1289:5 | a [element 4] :  |
+| array_flow.rb:1289:34:1289:46 | call to source :  | array_flow.rb:1289:5:1289:5 | a [element 4] :  |
+| array_flow.rb:1290:5:1290:5 | b [element 0] :  | array_flow.rb:1291:10:1291:10 | b [element 0] :  |
+| array_flow.rb:1290:5:1290:5 | b [element 0] :  | array_flow.rb:1291:10:1291:10 | b [element 0] :  |
 | array_flow.rb:1290:9:1290:9 | [post] a [element 2] :  | array_flow.rb:1296:10:1296:10 | a [element 2] :  |
 | array_flow.rb:1290:9:1290:9 | [post] a [element 2] :  | array_flow.rb:1296:10:1296:10 | a [element 2] :  |
 | array_flow.rb:1290:9:1290:9 | a [element 2] :  | array_flow.rb:1290:9:1290:23 | call to slice! [element 0] :  |
 | array_flow.rb:1290:9:1290:9 | a [element 2] :  | array_flow.rb:1290:9:1290:23 | call to slice! [element 0] :  |
 | array_flow.rb:1290:9:1290:9 | a [element 4] :  | array_flow.rb:1290:9:1290:9 | [post] a [element 2] :  |
 | array_flow.rb:1290:9:1290:9 | a [element 4] :  | array_flow.rb:1290:9:1290:9 | [post] a [element 2] :  |
-| array_flow.rb:1290:9:1290:23 | call to slice! [element 0] :  | array_flow.rb:1291:10:1291:10 | b [element 0] :  |
-| array_flow.rb:1290:9:1290:23 | call to slice! [element 0] :  | array_flow.rb:1291:10:1291:10 | b [element 0] :  |
+| array_flow.rb:1290:9:1290:23 | call to slice! [element 0] :  | array_flow.rb:1290:5:1290:5 | b [element 0] :  |
+| array_flow.rb:1290:9:1290:23 | call to slice! [element 0] :  | array_flow.rb:1290:5:1290:5 | b [element 0] :  |
 | array_flow.rb:1291:10:1291:10 | b [element 0] :  | array_flow.rb:1291:10:1291:13 | ...[...] |
 | array_flow.rb:1291:10:1291:10 | b [element 0] :  | array_flow.rb:1291:10:1291:13 | ...[...] |
 | array_flow.rb:1296:10:1296:10 | a [element 2] :  | array_flow.rb:1296:10:1296:13 | ...[...] |
 | array_flow.rb:1296:10:1296:10 | a [element 2] :  | array_flow.rb:1296:10:1296:13 | ...[...] |
-| array_flow.rb:1300:16:1300:28 | call to source :  | array_flow.rb:1301:9:1301:9 | a [element 2] :  |
-| array_flow.rb:1300:16:1300:28 | call to source :  | array_flow.rb:1301:9:1301:9 | a [element 2] :  |
-| array_flow.rb:1300:34:1300:46 | call to source :  | array_flow.rb:1301:9:1301:9 | a [element 4] :  |
-| array_flow.rb:1300:34:1300:46 | call to source :  | array_flow.rb:1301:9:1301:9 | a [element 4] :  |
+| array_flow.rb:1300:5:1300:5 | a [element 2] :  | array_flow.rb:1301:9:1301:9 | a [element 2] :  |
+| array_flow.rb:1300:5:1300:5 | a [element 2] :  | array_flow.rb:1301:9:1301:9 | a [element 2] :  |
+| array_flow.rb:1300:5:1300:5 | a [element 4] :  | array_flow.rb:1301:9:1301:9 | a [element 4] :  |
+| array_flow.rb:1300:5:1300:5 | a [element 4] :  | array_flow.rb:1301:9:1301:9 | a [element 4] :  |
+| array_flow.rb:1300:16:1300:28 | call to source :  | array_flow.rb:1300:5:1300:5 | a [element 2] :  |
+| array_flow.rb:1300:16:1300:28 | call to source :  | array_flow.rb:1300:5:1300:5 | a [element 2] :  |
+| array_flow.rb:1300:34:1300:46 | call to source :  | array_flow.rb:1300:5:1300:5 | a [element 4] :  |
+| array_flow.rb:1300:34:1300:46 | call to source :  | array_flow.rb:1300:5:1300:5 | a [element 4] :  |
+| array_flow.rb:1301:5:1301:5 | b [element] :  | array_flow.rb:1302:10:1302:10 | b [element] :  |
+| array_flow.rb:1301:5:1301:5 | b [element] :  | array_flow.rb:1302:10:1302:10 | b [element] :  |
+| array_flow.rb:1301:5:1301:5 | b [element] :  | array_flow.rb:1303:10:1303:10 | b [element] :  |
+| array_flow.rb:1301:5:1301:5 | b [element] :  | array_flow.rb:1303:10:1303:10 | b [element] :  |
+| array_flow.rb:1301:5:1301:5 | b [element] :  | array_flow.rb:1304:10:1304:10 | b [element] :  |
+| array_flow.rb:1301:5:1301:5 | b [element] :  | array_flow.rb:1304:10:1304:10 | b [element] :  |
 | array_flow.rb:1301:9:1301:9 | [post] a [element] :  | array_flow.rb:1305:10:1305:10 | a [element] :  |
 | array_flow.rb:1301:9:1301:9 | [post] a [element] :  | array_flow.rb:1305:10:1305:10 | a [element] :  |
 | array_flow.rb:1301:9:1301:9 | [post] a [element] :  | array_flow.rb:1306:10:1306:10 | a [element] :  |
@@ -2653,12 +3306,8 @@ edges
 | array_flow.rb:1301:9:1301:9 | a [element 4] :  | array_flow.rb:1301:9:1301:9 | [post] a [element] :  |
 | array_flow.rb:1301:9:1301:9 | a [element 4] :  | array_flow.rb:1301:9:1301:22 | call to slice! [element] :  |
 | array_flow.rb:1301:9:1301:9 | a [element 4] :  | array_flow.rb:1301:9:1301:22 | call to slice! [element] :  |
-| array_flow.rb:1301:9:1301:22 | call to slice! [element] :  | array_flow.rb:1302:10:1302:10 | b [element] :  |
-| array_flow.rb:1301:9:1301:22 | call to slice! [element] :  | array_flow.rb:1302:10:1302:10 | b [element] :  |
-| array_flow.rb:1301:9:1301:22 | call to slice! [element] :  | array_flow.rb:1303:10:1303:10 | b [element] :  |
-| array_flow.rb:1301:9:1301:22 | call to slice! [element] :  | array_flow.rb:1303:10:1303:10 | b [element] :  |
-| array_flow.rb:1301:9:1301:22 | call to slice! [element] :  | array_flow.rb:1304:10:1304:10 | b [element] :  |
-| array_flow.rb:1301:9:1301:22 | call to slice! [element] :  | array_flow.rb:1304:10:1304:10 | b [element] :  |
+| array_flow.rb:1301:9:1301:22 | call to slice! [element] :  | array_flow.rb:1301:5:1301:5 | b [element] :  |
+| array_flow.rb:1301:9:1301:22 | call to slice! [element] :  | array_flow.rb:1301:5:1301:5 | b [element] :  |
 | array_flow.rb:1302:10:1302:10 | b [element] :  | array_flow.rb:1302:10:1302:13 | ...[...] |
 | array_flow.rb:1302:10:1302:10 | b [element] :  | array_flow.rb:1302:10:1302:13 | ...[...] |
 | array_flow.rb:1303:10:1303:10 | b [element] :  | array_flow.rb:1303:10:1303:13 | ...[...] |
@@ -2671,10 +3320,20 @@ edges
 | array_flow.rb:1306:10:1306:10 | a [element] :  | array_flow.rb:1306:10:1306:13 | ...[...] |
 | array_flow.rb:1307:10:1307:10 | a [element] :  | array_flow.rb:1307:10:1307:13 | ...[...] |
 | array_flow.rb:1307:10:1307:10 | a [element] :  | array_flow.rb:1307:10:1307:13 | ...[...] |
-| array_flow.rb:1309:16:1309:28 | call to source :  | array_flow.rb:1310:9:1310:9 | a [element 2] :  |
-| array_flow.rb:1309:16:1309:28 | call to source :  | array_flow.rb:1310:9:1310:9 | a [element 2] :  |
-| array_flow.rb:1309:34:1309:46 | call to source :  | array_flow.rb:1310:9:1310:9 | a [element 4] :  |
-| array_flow.rb:1309:34:1309:46 | call to source :  | array_flow.rb:1310:9:1310:9 | a [element 4] :  |
+| array_flow.rb:1309:5:1309:5 | a [element 2] :  | array_flow.rb:1310:9:1310:9 | a [element 2] :  |
+| array_flow.rb:1309:5:1309:5 | a [element 2] :  | array_flow.rb:1310:9:1310:9 | a [element 2] :  |
+| array_flow.rb:1309:5:1309:5 | a [element 4] :  | array_flow.rb:1310:9:1310:9 | a [element 4] :  |
+| array_flow.rb:1309:5:1309:5 | a [element 4] :  | array_flow.rb:1310:9:1310:9 | a [element 4] :  |
+| array_flow.rb:1309:16:1309:28 | call to source :  | array_flow.rb:1309:5:1309:5 | a [element 2] :  |
+| array_flow.rb:1309:16:1309:28 | call to source :  | array_flow.rb:1309:5:1309:5 | a [element 2] :  |
+| array_flow.rb:1309:34:1309:46 | call to source :  | array_flow.rb:1309:5:1309:5 | a [element 4] :  |
+| array_flow.rb:1309:34:1309:46 | call to source :  | array_flow.rb:1309:5:1309:5 | a [element 4] :  |
+| array_flow.rb:1310:5:1310:5 | b [element] :  | array_flow.rb:1311:10:1311:10 | b [element] :  |
+| array_flow.rb:1310:5:1310:5 | b [element] :  | array_flow.rb:1311:10:1311:10 | b [element] :  |
+| array_flow.rb:1310:5:1310:5 | b [element] :  | array_flow.rb:1312:10:1312:10 | b [element] :  |
+| array_flow.rb:1310:5:1310:5 | b [element] :  | array_flow.rb:1312:10:1312:10 | b [element] :  |
+| array_flow.rb:1310:5:1310:5 | b [element] :  | array_flow.rb:1313:10:1313:10 | b [element] :  |
+| array_flow.rb:1310:5:1310:5 | b [element] :  | array_flow.rb:1313:10:1313:10 | b [element] :  |
 | array_flow.rb:1310:9:1310:9 | [post] a [element] :  | array_flow.rb:1314:10:1314:10 | a [element] :  |
 | array_flow.rb:1310:9:1310:9 | [post] a [element] :  | array_flow.rb:1314:10:1314:10 | a [element] :  |
 | array_flow.rb:1310:9:1310:9 | [post] a [element] :  | array_flow.rb:1315:10:1315:10 | a [element] :  |
@@ -2689,12 +3348,8 @@ edges
 | array_flow.rb:1310:9:1310:9 | a [element 4] :  | array_flow.rb:1310:9:1310:9 | [post] a [element] :  |
 | array_flow.rb:1310:9:1310:9 | a [element 4] :  | array_flow.rb:1310:9:1310:22 | call to slice! [element] :  |
 | array_flow.rb:1310:9:1310:9 | a [element 4] :  | array_flow.rb:1310:9:1310:22 | call to slice! [element] :  |
-| array_flow.rb:1310:9:1310:22 | call to slice! [element] :  | array_flow.rb:1311:10:1311:10 | b [element] :  |
-| array_flow.rb:1310:9:1310:22 | call to slice! [element] :  | array_flow.rb:1311:10:1311:10 | b [element] :  |
-| array_flow.rb:1310:9:1310:22 | call to slice! [element] :  | array_flow.rb:1312:10:1312:10 | b [element] :  |
-| array_flow.rb:1310:9:1310:22 | call to slice! [element] :  | array_flow.rb:1312:10:1312:10 | b [element] :  |
-| array_flow.rb:1310:9:1310:22 | call to slice! [element] :  | array_flow.rb:1313:10:1313:10 | b [element] :  |
-| array_flow.rb:1310:9:1310:22 | call to slice! [element] :  | array_flow.rb:1313:10:1313:10 | b [element] :  |
+| array_flow.rb:1310:9:1310:22 | call to slice! [element] :  | array_flow.rb:1310:5:1310:5 | b [element] :  |
+| array_flow.rb:1310:9:1310:22 | call to slice! [element] :  | array_flow.rb:1310:5:1310:5 | b [element] :  |
 | array_flow.rb:1311:10:1311:10 | b [element] :  | array_flow.rb:1311:10:1311:13 | ...[...] |
 | array_flow.rb:1311:10:1311:10 | b [element] :  | array_flow.rb:1311:10:1311:13 | ...[...] |
 | array_flow.rb:1312:10:1312:10 | b [element] :  | array_flow.rb:1312:10:1312:13 | ...[...] |
@@ -2707,10 +3362,20 @@ edges
 | array_flow.rb:1315:10:1315:10 | a [element] :  | array_flow.rb:1315:10:1315:13 | ...[...] |
 | array_flow.rb:1316:10:1316:10 | a [element] :  | array_flow.rb:1316:10:1316:13 | ...[...] |
 | array_flow.rb:1316:10:1316:10 | a [element] :  | array_flow.rb:1316:10:1316:13 | ...[...] |
-| array_flow.rb:1318:16:1318:28 | call to source :  | array_flow.rb:1319:9:1319:9 | a [element 2] :  |
-| array_flow.rb:1318:16:1318:28 | call to source :  | array_flow.rb:1319:9:1319:9 | a [element 2] :  |
-| array_flow.rb:1318:34:1318:46 | call to source :  | array_flow.rb:1319:9:1319:9 | a [element 4] :  |
-| array_flow.rb:1318:34:1318:46 | call to source :  | array_flow.rb:1319:9:1319:9 | a [element 4] :  |
+| array_flow.rb:1318:5:1318:5 | a [element 2] :  | array_flow.rb:1319:9:1319:9 | a [element 2] :  |
+| array_flow.rb:1318:5:1318:5 | a [element 2] :  | array_flow.rb:1319:9:1319:9 | a [element 2] :  |
+| array_flow.rb:1318:5:1318:5 | a [element 4] :  | array_flow.rb:1319:9:1319:9 | a [element 4] :  |
+| array_flow.rb:1318:5:1318:5 | a [element 4] :  | array_flow.rb:1319:9:1319:9 | a [element 4] :  |
+| array_flow.rb:1318:16:1318:28 | call to source :  | array_flow.rb:1318:5:1318:5 | a [element 2] :  |
+| array_flow.rb:1318:16:1318:28 | call to source :  | array_flow.rb:1318:5:1318:5 | a [element 2] :  |
+| array_flow.rb:1318:34:1318:46 | call to source :  | array_flow.rb:1318:5:1318:5 | a [element 4] :  |
+| array_flow.rb:1318:34:1318:46 | call to source :  | array_flow.rb:1318:5:1318:5 | a [element 4] :  |
+| array_flow.rb:1319:5:1319:5 | b [element] :  | array_flow.rb:1320:10:1320:10 | b [element] :  |
+| array_flow.rb:1319:5:1319:5 | b [element] :  | array_flow.rb:1320:10:1320:10 | b [element] :  |
+| array_flow.rb:1319:5:1319:5 | b [element] :  | array_flow.rb:1321:10:1321:10 | b [element] :  |
+| array_flow.rb:1319:5:1319:5 | b [element] :  | array_flow.rb:1321:10:1321:10 | b [element] :  |
+| array_flow.rb:1319:5:1319:5 | b [element] :  | array_flow.rb:1322:10:1322:10 | b [element] :  |
+| array_flow.rb:1319:5:1319:5 | b [element] :  | array_flow.rb:1322:10:1322:10 | b [element] :  |
 | array_flow.rb:1319:9:1319:9 | [post] a [element] :  | array_flow.rb:1323:10:1323:10 | a [element] :  |
 | array_flow.rb:1319:9:1319:9 | [post] a [element] :  | array_flow.rb:1323:10:1323:10 | a [element] :  |
 | array_flow.rb:1319:9:1319:9 | [post] a [element] :  | array_flow.rb:1324:10:1324:10 | a [element] :  |
@@ -2725,12 +3390,8 @@ edges
 | array_flow.rb:1319:9:1319:9 | a [element 4] :  | array_flow.rb:1319:9:1319:9 | [post] a [element] :  |
 | array_flow.rb:1319:9:1319:9 | a [element 4] :  | array_flow.rb:1319:9:1319:25 | call to slice! [element] :  |
 | array_flow.rb:1319:9:1319:9 | a [element 4] :  | array_flow.rb:1319:9:1319:25 | call to slice! [element] :  |
-| array_flow.rb:1319:9:1319:25 | call to slice! [element] :  | array_flow.rb:1320:10:1320:10 | b [element] :  |
-| array_flow.rb:1319:9:1319:25 | call to slice! [element] :  | array_flow.rb:1320:10:1320:10 | b [element] :  |
-| array_flow.rb:1319:9:1319:25 | call to slice! [element] :  | array_flow.rb:1321:10:1321:10 | b [element] :  |
-| array_flow.rb:1319:9:1319:25 | call to slice! [element] :  | array_flow.rb:1321:10:1321:10 | b [element] :  |
-| array_flow.rb:1319:9:1319:25 | call to slice! [element] :  | array_flow.rb:1322:10:1322:10 | b [element] :  |
-| array_flow.rb:1319:9:1319:25 | call to slice! [element] :  | array_flow.rb:1322:10:1322:10 | b [element] :  |
+| array_flow.rb:1319:9:1319:25 | call to slice! [element] :  | array_flow.rb:1319:5:1319:5 | b [element] :  |
+| array_flow.rb:1319:9:1319:25 | call to slice! [element] :  | array_flow.rb:1319:5:1319:5 | b [element] :  |
 | array_flow.rb:1320:10:1320:10 | b [element] :  | array_flow.rb:1320:10:1320:13 | ...[...] |
 | array_flow.rb:1320:10:1320:10 | b [element] :  | array_flow.rb:1320:10:1320:13 | ...[...] |
 | array_flow.rb:1321:10:1321:10 | b [element] :  | array_flow.rb:1321:10:1321:13 | ...[...] |
@@ -2743,26 +3404,42 @@ edges
 | array_flow.rb:1324:10:1324:10 | a [element] :  | array_flow.rb:1324:10:1324:13 | ...[...] |
 | array_flow.rb:1325:10:1325:10 | a [element] :  | array_flow.rb:1325:10:1325:13 | ...[...] |
 | array_flow.rb:1325:10:1325:10 | a [element] :  | array_flow.rb:1325:10:1325:13 | ...[...] |
-| array_flow.rb:1327:16:1327:28 | call to source :  | array_flow.rb:1328:9:1328:9 | a [element 2] :  |
-| array_flow.rb:1327:16:1327:28 | call to source :  | array_flow.rb:1328:9:1328:9 | a [element 2] :  |
-| array_flow.rb:1327:34:1327:46 | call to source :  | array_flow.rb:1328:9:1328:9 | a [element 4] :  |
-| array_flow.rb:1327:34:1327:46 | call to source :  | array_flow.rb:1328:9:1328:9 | a [element 4] :  |
+| array_flow.rb:1327:5:1327:5 | a [element 2] :  | array_flow.rb:1328:9:1328:9 | a [element 2] :  |
+| array_flow.rb:1327:5:1327:5 | a [element 2] :  | array_flow.rb:1328:9:1328:9 | a [element 2] :  |
+| array_flow.rb:1327:5:1327:5 | a [element 4] :  | array_flow.rb:1328:9:1328:9 | a [element 4] :  |
+| array_flow.rb:1327:5:1327:5 | a [element 4] :  | array_flow.rb:1328:9:1328:9 | a [element 4] :  |
+| array_flow.rb:1327:16:1327:28 | call to source :  | array_flow.rb:1327:5:1327:5 | a [element 2] :  |
+| array_flow.rb:1327:16:1327:28 | call to source :  | array_flow.rb:1327:5:1327:5 | a [element 2] :  |
+| array_flow.rb:1327:34:1327:46 | call to source :  | array_flow.rb:1327:5:1327:5 | a [element 4] :  |
+| array_flow.rb:1327:34:1327:46 | call to source :  | array_flow.rb:1327:5:1327:5 | a [element 4] :  |
+| array_flow.rb:1328:5:1328:5 | b [element 2] :  | array_flow.rb:1331:10:1331:10 | b [element 2] :  |
+| array_flow.rb:1328:5:1328:5 | b [element 2] :  | array_flow.rb:1331:10:1331:10 | b [element 2] :  |
 | array_flow.rb:1328:9:1328:9 | [post] a [element 1] :  | array_flow.rb:1333:10:1333:10 | a [element 1] :  |
 | array_flow.rb:1328:9:1328:9 | [post] a [element 1] :  | array_flow.rb:1333:10:1333:10 | a [element 1] :  |
 | array_flow.rb:1328:9:1328:9 | a [element 2] :  | array_flow.rb:1328:9:1328:21 | call to slice! [element 2] :  |
 | array_flow.rb:1328:9:1328:9 | a [element 2] :  | array_flow.rb:1328:9:1328:21 | call to slice! [element 2] :  |
 | array_flow.rb:1328:9:1328:9 | a [element 4] :  | array_flow.rb:1328:9:1328:9 | [post] a [element 1] :  |
 | array_flow.rb:1328:9:1328:9 | a [element 4] :  | array_flow.rb:1328:9:1328:9 | [post] a [element 1] :  |
-| array_flow.rb:1328:9:1328:21 | call to slice! [element 2] :  | array_flow.rb:1331:10:1331:10 | b [element 2] :  |
-| array_flow.rb:1328:9:1328:21 | call to slice! [element 2] :  | array_flow.rb:1331:10:1331:10 | b [element 2] :  |
+| array_flow.rb:1328:9:1328:21 | call to slice! [element 2] :  | array_flow.rb:1328:5:1328:5 | b [element 2] :  |
+| array_flow.rb:1328:9:1328:21 | call to slice! [element 2] :  | array_flow.rb:1328:5:1328:5 | b [element 2] :  |
 | array_flow.rb:1331:10:1331:10 | b [element 2] :  | array_flow.rb:1331:10:1331:13 | ...[...] |
 | array_flow.rb:1331:10:1331:10 | b [element 2] :  | array_flow.rb:1331:10:1331:13 | ...[...] |
 | array_flow.rb:1333:10:1333:10 | a [element 1] :  | array_flow.rb:1333:10:1333:13 | ...[...] |
 | array_flow.rb:1333:10:1333:10 | a [element 1] :  | array_flow.rb:1333:10:1333:13 | ...[...] |
-| array_flow.rb:1336:16:1336:28 | call to source :  | array_flow.rb:1337:9:1337:9 | a [element 2] :  |
-| array_flow.rb:1336:16:1336:28 | call to source :  | array_flow.rb:1337:9:1337:9 | a [element 2] :  |
-| array_flow.rb:1336:34:1336:46 | call to source :  | array_flow.rb:1337:9:1337:9 | a [element 4] :  |
-| array_flow.rb:1336:34:1336:46 | call to source :  | array_flow.rb:1337:9:1337:9 | a [element 4] :  |
+| array_flow.rb:1336:5:1336:5 | a [element 2] :  | array_flow.rb:1337:9:1337:9 | a [element 2] :  |
+| array_flow.rb:1336:5:1336:5 | a [element 2] :  | array_flow.rb:1337:9:1337:9 | a [element 2] :  |
+| array_flow.rb:1336:5:1336:5 | a [element 4] :  | array_flow.rb:1337:9:1337:9 | a [element 4] :  |
+| array_flow.rb:1336:5:1336:5 | a [element 4] :  | array_flow.rb:1337:9:1337:9 | a [element 4] :  |
+| array_flow.rb:1336:16:1336:28 | call to source :  | array_flow.rb:1336:5:1336:5 | a [element 2] :  |
+| array_flow.rb:1336:16:1336:28 | call to source :  | array_flow.rb:1336:5:1336:5 | a [element 2] :  |
+| array_flow.rb:1336:34:1336:46 | call to source :  | array_flow.rb:1336:5:1336:5 | a [element 4] :  |
+| array_flow.rb:1336:34:1336:46 | call to source :  | array_flow.rb:1336:5:1336:5 | a [element 4] :  |
+| array_flow.rb:1337:5:1337:5 | b [element] :  | array_flow.rb:1338:10:1338:10 | b [element] :  |
+| array_flow.rb:1337:5:1337:5 | b [element] :  | array_flow.rb:1338:10:1338:10 | b [element] :  |
+| array_flow.rb:1337:5:1337:5 | b [element] :  | array_flow.rb:1339:10:1339:10 | b [element] :  |
+| array_flow.rb:1337:5:1337:5 | b [element] :  | array_flow.rb:1339:10:1339:10 | b [element] :  |
+| array_flow.rb:1337:5:1337:5 | b [element] :  | array_flow.rb:1340:10:1340:10 | b [element] :  |
+| array_flow.rb:1337:5:1337:5 | b [element] :  | array_flow.rb:1340:10:1340:10 | b [element] :  |
 | array_flow.rb:1337:9:1337:9 | [post] a [element] :  | array_flow.rb:1341:10:1341:10 | a [element] :  |
 | array_flow.rb:1337:9:1337:9 | [post] a [element] :  | array_flow.rb:1341:10:1341:10 | a [element] :  |
 | array_flow.rb:1337:9:1337:9 | [post] a [element] :  | array_flow.rb:1342:10:1342:10 | a [element] :  |
@@ -2777,12 +3454,8 @@ edges
 | array_flow.rb:1337:9:1337:9 | a [element 4] :  | array_flow.rb:1337:9:1337:9 | [post] a [element] :  |
 | array_flow.rb:1337:9:1337:9 | a [element 4] :  | array_flow.rb:1337:9:1337:21 | call to slice! [element] :  |
 | array_flow.rb:1337:9:1337:9 | a [element 4] :  | array_flow.rb:1337:9:1337:21 | call to slice! [element] :  |
-| array_flow.rb:1337:9:1337:21 | call to slice! [element] :  | array_flow.rb:1338:10:1338:10 | b [element] :  |
-| array_flow.rb:1337:9:1337:21 | call to slice! [element] :  | array_flow.rb:1338:10:1338:10 | b [element] :  |
-| array_flow.rb:1337:9:1337:21 | call to slice! [element] :  | array_flow.rb:1339:10:1339:10 | b [element] :  |
-| array_flow.rb:1337:9:1337:21 | call to slice! [element] :  | array_flow.rb:1339:10:1339:10 | b [element] :  |
-| array_flow.rb:1337:9:1337:21 | call to slice! [element] :  | array_flow.rb:1340:10:1340:10 | b [element] :  |
-| array_flow.rb:1337:9:1337:21 | call to slice! [element] :  | array_flow.rb:1340:10:1340:10 | b [element] :  |
+| array_flow.rb:1337:9:1337:21 | call to slice! [element] :  | array_flow.rb:1337:5:1337:5 | b [element] :  |
+| array_flow.rb:1337:9:1337:21 | call to slice! [element] :  | array_flow.rb:1337:5:1337:5 | b [element] :  |
 | array_flow.rb:1338:10:1338:10 | b [element] :  | array_flow.rb:1338:10:1338:13 | ...[...] |
 | array_flow.rb:1338:10:1338:10 | b [element] :  | array_flow.rb:1338:10:1338:13 | ...[...] |
 | array_flow.rb:1339:10:1339:10 | b [element] :  | array_flow.rb:1339:10:1339:13 | ...[...] |
@@ -2795,20 +3468,26 @@ edges
 | array_flow.rb:1342:10:1342:10 | a [element] :  | array_flow.rb:1342:10:1342:13 | ...[...] |
 | array_flow.rb:1343:10:1343:10 | a [element] :  | array_flow.rb:1343:10:1343:13 | ...[...] |
 | array_flow.rb:1343:10:1343:10 | a [element] :  | array_flow.rb:1343:10:1343:13 | ...[...] |
-| array_flow.rb:1347:16:1347:26 | call to source :  | array_flow.rb:1348:9:1348:9 | a [element 2] :  |
-| array_flow.rb:1347:16:1347:26 | call to source :  | array_flow.rb:1348:9:1348:9 | a [element 2] :  |
+| array_flow.rb:1347:5:1347:5 | a [element 2] :  | array_flow.rb:1348:9:1348:9 | a [element 2] :  |
+| array_flow.rb:1347:5:1347:5 | a [element 2] :  | array_flow.rb:1348:9:1348:9 | a [element 2] :  |
+| array_flow.rb:1347:16:1347:26 | call to source :  | array_flow.rb:1347:5:1347:5 | a [element 2] :  |
+| array_flow.rb:1347:16:1347:26 | call to source :  | array_flow.rb:1347:5:1347:5 | a [element 2] :  |
 | array_flow.rb:1348:9:1348:9 | a [element 2] :  | array_flow.rb:1348:27:1348:27 | x :  |
 | array_flow.rb:1348:9:1348:9 | a [element 2] :  | array_flow.rb:1348:27:1348:27 | x :  |
 | array_flow.rb:1348:27:1348:27 | x :  | array_flow.rb:1349:14:1349:14 | x |
 | array_flow.rb:1348:27:1348:27 | x :  | array_flow.rb:1349:14:1349:14 | x |
-| array_flow.rb:1355:16:1355:26 | call to source :  | array_flow.rb:1356:9:1356:9 | a [element 2] :  |
-| array_flow.rb:1355:16:1355:26 | call to source :  | array_flow.rb:1356:9:1356:9 | a [element 2] :  |
+| array_flow.rb:1355:5:1355:5 | a [element 2] :  | array_flow.rb:1356:9:1356:9 | a [element 2] :  |
+| array_flow.rb:1355:5:1355:5 | a [element 2] :  | array_flow.rb:1356:9:1356:9 | a [element 2] :  |
+| array_flow.rb:1355:16:1355:26 | call to source :  | array_flow.rb:1355:5:1355:5 | a [element 2] :  |
+| array_flow.rb:1355:16:1355:26 | call to source :  | array_flow.rb:1355:5:1355:5 | a [element 2] :  |
 | array_flow.rb:1356:9:1356:9 | a [element 2] :  | array_flow.rb:1356:28:1356:28 | x :  |
 | array_flow.rb:1356:9:1356:9 | a [element 2] :  | array_flow.rb:1356:28:1356:28 | x :  |
 | array_flow.rb:1356:28:1356:28 | x :  | array_flow.rb:1357:14:1357:14 | x |
 | array_flow.rb:1356:28:1356:28 | x :  | array_flow.rb:1357:14:1357:14 | x |
-| array_flow.rb:1363:16:1363:26 | call to source :  | array_flow.rb:1364:9:1364:9 | a [element 2] :  |
-| array_flow.rb:1363:16:1363:26 | call to source :  | array_flow.rb:1364:9:1364:9 | a [element 2] :  |
+| array_flow.rb:1363:5:1363:5 | a [element 2] :  | array_flow.rb:1364:9:1364:9 | a [element 2] :  |
+| array_flow.rb:1363:5:1363:5 | a [element 2] :  | array_flow.rb:1364:9:1364:9 | a [element 2] :  |
+| array_flow.rb:1363:16:1363:26 | call to source :  | array_flow.rb:1363:5:1363:5 | a [element 2] :  |
+| array_flow.rb:1363:16:1363:26 | call to source :  | array_flow.rb:1363:5:1363:5 | a [element 2] :  |
 | array_flow.rb:1364:9:1364:9 | a [element 2] :  | array_flow.rb:1364:26:1364:26 | x :  |
 | array_flow.rb:1364:9:1364:9 | a [element 2] :  | array_flow.rb:1364:26:1364:26 | x :  |
 | array_flow.rb:1364:9:1364:9 | a [element 2] :  | array_flow.rb:1364:29:1364:29 | y :  |
@@ -2817,30 +3496,36 @@ edges
 | array_flow.rb:1364:26:1364:26 | x :  | array_flow.rb:1365:14:1365:14 | x |
 | array_flow.rb:1364:29:1364:29 | y :  | array_flow.rb:1366:14:1366:14 | y |
 | array_flow.rb:1364:29:1364:29 | y :  | array_flow.rb:1366:14:1366:14 | y |
-| array_flow.rb:1371:16:1371:26 | call to source :  | array_flow.rb:1372:9:1372:9 | a [element 2] :  |
-| array_flow.rb:1371:16:1371:26 | call to source :  | array_flow.rb:1372:9:1372:9 | a [element 2] :  |
-| array_flow.rb:1371:16:1371:26 | call to source :  | array_flow.rb:1375:9:1375:9 | a [element 2] :  |
-| array_flow.rb:1371:16:1371:26 | call to source :  | array_flow.rb:1375:9:1375:9 | a [element 2] :  |
+| array_flow.rb:1371:5:1371:5 | a [element 2] :  | array_flow.rb:1372:9:1372:9 | a [element 2] :  |
+| array_flow.rb:1371:5:1371:5 | a [element 2] :  | array_flow.rb:1372:9:1372:9 | a [element 2] :  |
+| array_flow.rb:1371:5:1371:5 | a [element 2] :  | array_flow.rb:1375:9:1375:9 | a [element 2] :  |
+| array_flow.rb:1371:5:1371:5 | a [element 2] :  | array_flow.rb:1375:9:1375:9 | a [element 2] :  |
+| array_flow.rb:1371:16:1371:26 | call to source :  | array_flow.rb:1371:5:1371:5 | a [element 2] :  |
+| array_flow.rb:1371:16:1371:26 | call to source :  | array_flow.rb:1371:5:1371:5 | a [element 2] :  |
+| array_flow.rb:1372:5:1372:5 | b [element] :  | array_flow.rb:1373:10:1373:10 | b [element] :  |
+| array_flow.rb:1372:5:1372:5 | b [element] :  | array_flow.rb:1373:10:1373:10 | b [element] :  |
+| array_flow.rb:1372:5:1372:5 | b [element] :  | array_flow.rb:1374:10:1374:10 | b [element] :  |
+| array_flow.rb:1372:5:1372:5 | b [element] :  | array_flow.rb:1374:10:1374:10 | b [element] :  |
 | array_flow.rb:1372:9:1372:9 | a [element 2] :  | array_flow.rb:1372:9:1372:14 | call to sort [element] :  |
 | array_flow.rb:1372:9:1372:9 | a [element 2] :  | array_flow.rb:1372:9:1372:14 | call to sort [element] :  |
-| array_flow.rb:1372:9:1372:14 | call to sort [element] :  | array_flow.rb:1373:10:1373:10 | b [element] :  |
-| array_flow.rb:1372:9:1372:14 | call to sort [element] :  | array_flow.rb:1373:10:1373:10 | b [element] :  |
-| array_flow.rb:1372:9:1372:14 | call to sort [element] :  | array_flow.rb:1374:10:1374:10 | b [element] :  |
-| array_flow.rb:1372:9:1372:14 | call to sort [element] :  | array_flow.rb:1374:10:1374:10 | b [element] :  |
+| array_flow.rb:1372:9:1372:14 | call to sort [element] :  | array_flow.rb:1372:5:1372:5 | b [element] :  |
+| array_flow.rb:1372:9:1372:14 | call to sort [element] :  | array_flow.rb:1372:5:1372:5 | b [element] :  |
 | array_flow.rb:1373:10:1373:10 | b [element] :  | array_flow.rb:1373:10:1373:13 | ...[...] |
 | array_flow.rb:1373:10:1373:10 | b [element] :  | array_flow.rb:1373:10:1373:13 | ...[...] |
 | array_flow.rb:1374:10:1374:10 | b [element] :  | array_flow.rb:1374:10:1374:13 | ...[...] |
 | array_flow.rb:1374:10:1374:10 | b [element] :  | array_flow.rb:1374:10:1374:13 | ...[...] |
+| array_flow.rb:1375:5:1375:5 | c [element] :  | array_flow.rb:1380:10:1380:10 | c [element] :  |
+| array_flow.rb:1375:5:1375:5 | c [element] :  | array_flow.rb:1380:10:1380:10 | c [element] :  |
+| array_flow.rb:1375:5:1375:5 | c [element] :  | array_flow.rb:1381:10:1381:10 | c [element] :  |
+| array_flow.rb:1375:5:1375:5 | c [element] :  | array_flow.rb:1381:10:1381:10 | c [element] :  |
 | array_flow.rb:1375:9:1375:9 | a [element 2] :  | array_flow.rb:1375:9:1379:7 | call to sort [element] :  |
 | array_flow.rb:1375:9:1375:9 | a [element 2] :  | array_flow.rb:1375:9:1379:7 | call to sort [element] :  |
 | array_flow.rb:1375:9:1375:9 | a [element 2] :  | array_flow.rb:1375:20:1375:20 | x :  |
 | array_flow.rb:1375:9:1375:9 | a [element 2] :  | array_flow.rb:1375:20:1375:20 | x :  |
 | array_flow.rb:1375:9:1375:9 | a [element 2] :  | array_flow.rb:1375:23:1375:23 | y :  |
 | array_flow.rb:1375:9:1375:9 | a [element 2] :  | array_flow.rb:1375:23:1375:23 | y :  |
-| array_flow.rb:1375:9:1379:7 | call to sort [element] :  | array_flow.rb:1380:10:1380:10 | c [element] :  |
-| array_flow.rb:1375:9:1379:7 | call to sort [element] :  | array_flow.rb:1380:10:1380:10 | c [element] :  |
-| array_flow.rb:1375:9:1379:7 | call to sort [element] :  | array_flow.rb:1381:10:1381:10 | c [element] :  |
-| array_flow.rb:1375:9:1379:7 | call to sort [element] :  | array_flow.rb:1381:10:1381:10 | c [element] :  |
+| array_flow.rb:1375:9:1379:7 | call to sort [element] :  | array_flow.rb:1375:5:1375:5 | c [element] :  |
+| array_flow.rb:1375:9:1379:7 | call to sort [element] :  | array_flow.rb:1375:5:1375:5 | c [element] :  |
 | array_flow.rb:1375:20:1375:20 | x :  | array_flow.rb:1376:14:1376:14 | x |
 | array_flow.rb:1375:20:1375:20 | x :  | array_flow.rb:1376:14:1376:14 | x |
 | array_flow.rb:1375:23:1375:23 | y :  | array_flow.rb:1377:14:1377:14 | y |
@@ -2849,8 +3534,14 @@ edges
 | array_flow.rb:1380:10:1380:10 | c [element] :  | array_flow.rb:1380:10:1380:13 | ...[...] |
 | array_flow.rb:1381:10:1381:10 | c [element] :  | array_flow.rb:1381:10:1381:13 | ...[...] |
 | array_flow.rb:1381:10:1381:10 | c [element] :  | array_flow.rb:1381:10:1381:13 | ...[...] |
-| array_flow.rb:1385:16:1385:26 | call to source :  | array_flow.rb:1386:9:1386:9 | a [element 2] :  |
-| array_flow.rb:1385:16:1385:26 | call to source :  | array_flow.rb:1386:9:1386:9 | a [element 2] :  |
+| array_flow.rb:1385:5:1385:5 | a [element 2] :  | array_flow.rb:1386:9:1386:9 | a [element 2] :  |
+| array_flow.rb:1385:5:1385:5 | a [element 2] :  | array_flow.rb:1386:9:1386:9 | a [element 2] :  |
+| array_flow.rb:1385:16:1385:26 | call to source :  | array_flow.rb:1385:5:1385:5 | a [element 2] :  |
+| array_flow.rb:1385:16:1385:26 | call to source :  | array_flow.rb:1385:5:1385:5 | a [element 2] :  |
+| array_flow.rb:1386:5:1386:5 | b [element] :  | array_flow.rb:1387:10:1387:10 | b [element] :  |
+| array_flow.rb:1386:5:1386:5 | b [element] :  | array_flow.rb:1387:10:1387:10 | b [element] :  |
+| array_flow.rb:1386:5:1386:5 | b [element] :  | array_flow.rb:1388:10:1388:10 | b [element] :  |
+| array_flow.rb:1386:5:1386:5 | b [element] :  | array_flow.rb:1388:10:1388:10 | b [element] :  |
 | array_flow.rb:1386:9:1386:9 | [post] a [element] :  | array_flow.rb:1389:10:1389:10 | a [element] :  |
 | array_flow.rb:1386:9:1386:9 | [post] a [element] :  | array_flow.rb:1389:10:1389:10 | a [element] :  |
 | array_flow.rb:1386:9:1386:9 | [post] a [element] :  | array_flow.rb:1390:10:1390:10 | a [element] :  |
@@ -2859,10 +3550,8 @@ edges
 | array_flow.rb:1386:9:1386:9 | a [element 2] :  | array_flow.rb:1386:9:1386:9 | [post] a [element] :  |
 | array_flow.rb:1386:9:1386:9 | a [element 2] :  | array_flow.rb:1386:9:1386:15 | call to sort! [element] :  |
 | array_flow.rb:1386:9:1386:9 | a [element 2] :  | array_flow.rb:1386:9:1386:15 | call to sort! [element] :  |
-| array_flow.rb:1386:9:1386:15 | call to sort! [element] :  | array_flow.rb:1387:10:1387:10 | b [element] :  |
-| array_flow.rb:1386:9:1386:15 | call to sort! [element] :  | array_flow.rb:1387:10:1387:10 | b [element] :  |
-| array_flow.rb:1386:9:1386:15 | call to sort! [element] :  | array_flow.rb:1388:10:1388:10 | b [element] :  |
-| array_flow.rb:1386:9:1386:15 | call to sort! [element] :  | array_flow.rb:1388:10:1388:10 | b [element] :  |
+| array_flow.rb:1386:9:1386:15 | call to sort! [element] :  | array_flow.rb:1386:5:1386:5 | b [element] :  |
+| array_flow.rb:1386:9:1386:15 | call to sort! [element] :  | array_flow.rb:1386:5:1386:5 | b [element] :  |
 | array_flow.rb:1387:10:1387:10 | b [element] :  | array_flow.rb:1387:10:1387:13 | ...[...] |
 | array_flow.rb:1387:10:1387:10 | b [element] :  | array_flow.rb:1387:10:1387:13 | ...[...] |
 | array_flow.rb:1388:10:1388:10 | b [element] :  | array_flow.rb:1388:10:1388:13 | ...[...] |
@@ -2871,8 +3560,14 @@ edges
 | array_flow.rb:1389:10:1389:10 | a [element] :  | array_flow.rb:1389:10:1389:13 | ...[...] |
 | array_flow.rb:1390:10:1390:10 | a [element] :  | array_flow.rb:1390:10:1390:13 | ...[...] |
 | array_flow.rb:1390:10:1390:10 | a [element] :  | array_flow.rb:1390:10:1390:13 | ...[...] |
-| array_flow.rb:1392:16:1392:26 | call to source :  | array_flow.rb:1393:9:1393:9 | a [element 2] :  |
-| array_flow.rb:1392:16:1392:26 | call to source :  | array_flow.rb:1393:9:1393:9 | a [element 2] :  |
+| array_flow.rb:1392:5:1392:5 | a [element 2] :  | array_flow.rb:1393:9:1393:9 | a [element 2] :  |
+| array_flow.rb:1392:5:1392:5 | a [element 2] :  | array_flow.rb:1393:9:1393:9 | a [element 2] :  |
+| array_flow.rb:1392:16:1392:26 | call to source :  | array_flow.rb:1392:5:1392:5 | a [element 2] :  |
+| array_flow.rb:1392:16:1392:26 | call to source :  | array_flow.rb:1392:5:1392:5 | a [element 2] :  |
+| array_flow.rb:1393:5:1393:5 | b [element] :  | array_flow.rb:1398:10:1398:10 | b [element] :  |
+| array_flow.rb:1393:5:1393:5 | b [element] :  | array_flow.rb:1398:10:1398:10 | b [element] :  |
+| array_flow.rb:1393:5:1393:5 | b [element] :  | array_flow.rb:1399:10:1399:10 | b [element] :  |
+| array_flow.rb:1393:5:1393:5 | b [element] :  | array_flow.rb:1399:10:1399:10 | b [element] :  |
 | array_flow.rb:1393:9:1393:9 | [post] a [element] :  | array_flow.rb:1400:10:1400:10 | a [element] :  |
 | array_flow.rb:1393:9:1393:9 | [post] a [element] :  | array_flow.rb:1400:10:1400:10 | a [element] :  |
 | array_flow.rb:1393:9:1393:9 | [post] a [element] :  | array_flow.rb:1401:10:1401:10 | a [element] :  |
@@ -2885,10 +3580,8 @@ edges
 | array_flow.rb:1393:9:1393:9 | a [element 2] :  | array_flow.rb:1393:21:1393:21 | x :  |
 | array_flow.rb:1393:9:1393:9 | a [element 2] :  | array_flow.rb:1393:24:1393:24 | y :  |
 | array_flow.rb:1393:9:1393:9 | a [element 2] :  | array_flow.rb:1393:24:1393:24 | y :  |
-| array_flow.rb:1393:9:1397:7 | call to sort! [element] :  | array_flow.rb:1398:10:1398:10 | b [element] :  |
-| array_flow.rb:1393:9:1397:7 | call to sort! [element] :  | array_flow.rb:1398:10:1398:10 | b [element] :  |
-| array_flow.rb:1393:9:1397:7 | call to sort! [element] :  | array_flow.rb:1399:10:1399:10 | b [element] :  |
-| array_flow.rb:1393:9:1397:7 | call to sort! [element] :  | array_flow.rb:1399:10:1399:10 | b [element] :  |
+| array_flow.rb:1393:9:1397:7 | call to sort! [element] :  | array_flow.rb:1393:5:1393:5 | b [element] :  |
+| array_flow.rb:1393:9:1397:7 | call to sort! [element] :  | array_flow.rb:1393:5:1393:5 | b [element] :  |
 | array_flow.rb:1393:21:1393:21 | x :  | array_flow.rb:1394:14:1394:14 | x |
 | array_flow.rb:1393:21:1393:21 | x :  | array_flow.rb:1394:14:1394:14 | x |
 | array_flow.rb:1393:24:1393:24 | y :  | array_flow.rb:1395:14:1395:14 | y |
@@ -2901,24 +3594,34 @@ edges
 | array_flow.rb:1400:10:1400:10 | a [element] :  | array_flow.rb:1400:10:1400:13 | ...[...] |
 | array_flow.rb:1401:10:1401:10 | a [element] :  | array_flow.rb:1401:10:1401:13 | ...[...] |
 | array_flow.rb:1401:10:1401:10 | a [element] :  | array_flow.rb:1401:10:1401:13 | ...[...] |
-| array_flow.rb:1405:16:1405:26 | call to source :  | array_flow.rb:1406:9:1406:9 | a [element 2] :  |
-| array_flow.rb:1405:16:1405:26 | call to source :  | array_flow.rb:1406:9:1406:9 | a [element 2] :  |
+| array_flow.rb:1405:5:1405:5 | a [element 2] :  | array_flow.rb:1406:9:1406:9 | a [element 2] :  |
+| array_flow.rb:1405:5:1405:5 | a [element 2] :  | array_flow.rb:1406:9:1406:9 | a [element 2] :  |
+| array_flow.rb:1405:16:1405:26 | call to source :  | array_flow.rb:1405:5:1405:5 | a [element 2] :  |
+| array_flow.rb:1405:16:1405:26 | call to source :  | array_flow.rb:1405:5:1405:5 | a [element 2] :  |
+| array_flow.rb:1406:5:1406:5 | b [element] :  | array_flow.rb:1410:10:1410:10 | b [element] :  |
+| array_flow.rb:1406:5:1406:5 | b [element] :  | array_flow.rb:1410:10:1410:10 | b [element] :  |
+| array_flow.rb:1406:5:1406:5 | b [element] :  | array_flow.rb:1411:10:1411:10 | b [element] :  |
+| array_flow.rb:1406:5:1406:5 | b [element] :  | array_flow.rb:1411:10:1411:10 | b [element] :  |
 | array_flow.rb:1406:9:1406:9 | a [element 2] :  | array_flow.rb:1406:9:1409:7 | call to sort_by [element] :  |
 | array_flow.rb:1406:9:1406:9 | a [element 2] :  | array_flow.rb:1406:9:1409:7 | call to sort_by [element] :  |
 | array_flow.rb:1406:9:1406:9 | a [element 2] :  | array_flow.rb:1406:23:1406:23 | x :  |
 | array_flow.rb:1406:9:1406:9 | a [element 2] :  | array_flow.rb:1406:23:1406:23 | x :  |
-| array_flow.rb:1406:9:1409:7 | call to sort_by [element] :  | array_flow.rb:1410:10:1410:10 | b [element] :  |
-| array_flow.rb:1406:9:1409:7 | call to sort_by [element] :  | array_flow.rb:1410:10:1410:10 | b [element] :  |
-| array_flow.rb:1406:9:1409:7 | call to sort_by [element] :  | array_flow.rb:1411:10:1411:10 | b [element] :  |
-| array_flow.rb:1406:9:1409:7 | call to sort_by [element] :  | array_flow.rb:1411:10:1411:10 | b [element] :  |
+| array_flow.rb:1406:9:1409:7 | call to sort_by [element] :  | array_flow.rb:1406:5:1406:5 | b [element] :  |
+| array_flow.rb:1406:9:1409:7 | call to sort_by [element] :  | array_flow.rb:1406:5:1406:5 | b [element] :  |
 | array_flow.rb:1406:23:1406:23 | x :  | array_flow.rb:1407:14:1407:14 | x |
 | array_flow.rb:1406:23:1406:23 | x :  | array_flow.rb:1407:14:1407:14 | x |
 | array_flow.rb:1410:10:1410:10 | b [element] :  | array_flow.rb:1410:10:1410:13 | ...[...] |
 | array_flow.rb:1410:10:1410:10 | b [element] :  | array_flow.rb:1410:10:1410:13 | ...[...] |
 | array_flow.rb:1411:10:1411:10 | b [element] :  | array_flow.rb:1411:10:1411:13 | ...[...] |
 | array_flow.rb:1411:10:1411:10 | b [element] :  | array_flow.rb:1411:10:1411:13 | ...[...] |
-| array_flow.rb:1415:16:1415:26 | call to source :  | array_flow.rb:1416:9:1416:9 | a [element 2] :  |
-| array_flow.rb:1415:16:1415:26 | call to source :  | array_flow.rb:1416:9:1416:9 | a [element 2] :  |
+| array_flow.rb:1415:5:1415:5 | a [element 2] :  | array_flow.rb:1416:9:1416:9 | a [element 2] :  |
+| array_flow.rb:1415:5:1415:5 | a [element 2] :  | array_flow.rb:1416:9:1416:9 | a [element 2] :  |
+| array_flow.rb:1415:16:1415:26 | call to source :  | array_flow.rb:1415:5:1415:5 | a [element 2] :  |
+| array_flow.rb:1415:16:1415:26 | call to source :  | array_flow.rb:1415:5:1415:5 | a [element 2] :  |
+| array_flow.rb:1416:5:1416:5 | b [element] :  | array_flow.rb:1422:10:1422:10 | b [element] :  |
+| array_flow.rb:1416:5:1416:5 | b [element] :  | array_flow.rb:1422:10:1422:10 | b [element] :  |
+| array_flow.rb:1416:5:1416:5 | b [element] :  | array_flow.rb:1423:10:1423:10 | b [element] :  |
+| array_flow.rb:1416:5:1416:5 | b [element] :  | array_flow.rb:1423:10:1423:10 | b [element] :  |
 | array_flow.rb:1416:9:1416:9 | [post] a [element] :  | array_flow.rb:1420:10:1420:10 | a [element] :  |
 | array_flow.rb:1416:9:1416:9 | [post] a [element] :  | array_flow.rb:1420:10:1420:10 | a [element] :  |
 | array_flow.rb:1416:9:1416:9 | [post] a [element] :  | array_flow.rb:1421:10:1421:10 | a [element] :  |
@@ -2929,10 +3632,8 @@ edges
 | array_flow.rb:1416:9:1416:9 | a [element 2] :  | array_flow.rb:1416:9:1419:7 | call to sort_by! [element] :  |
 | array_flow.rb:1416:9:1416:9 | a [element 2] :  | array_flow.rb:1416:24:1416:24 | x :  |
 | array_flow.rb:1416:9:1416:9 | a [element 2] :  | array_flow.rb:1416:24:1416:24 | x :  |
-| array_flow.rb:1416:9:1419:7 | call to sort_by! [element] :  | array_flow.rb:1422:10:1422:10 | b [element] :  |
-| array_flow.rb:1416:9:1419:7 | call to sort_by! [element] :  | array_flow.rb:1422:10:1422:10 | b [element] :  |
-| array_flow.rb:1416:9:1419:7 | call to sort_by! [element] :  | array_flow.rb:1423:10:1423:10 | b [element] :  |
-| array_flow.rb:1416:9:1419:7 | call to sort_by! [element] :  | array_flow.rb:1423:10:1423:10 | b [element] :  |
+| array_flow.rb:1416:9:1419:7 | call to sort_by! [element] :  | array_flow.rb:1416:5:1416:5 | b [element] :  |
+| array_flow.rb:1416:9:1419:7 | call to sort_by! [element] :  | array_flow.rb:1416:5:1416:5 | b [element] :  |
 | array_flow.rb:1416:24:1416:24 | x :  | array_flow.rb:1417:14:1417:14 | x |
 | array_flow.rb:1416:24:1416:24 | x :  | array_flow.rb:1417:14:1417:14 | x |
 | array_flow.rb:1420:10:1420:10 | a [element] :  | array_flow.rb:1420:10:1420:13 | ...[...] |
@@ -2943,58 +3644,74 @@ edges
 | array_flow.rb:1422:10:1422:10 | b [element] :  | array_flow.rb:1422:10:1422:13 | ...[...] |
 | array_flow.rb:1423:10:1423:10 | b [element] :  | array_flow.rb:1423:10:1423:13 | ...[...] |
 | array_flow.rb:1423:10:1423:10 | b [element] :  | array_flow.rb:1423:10:1423:13 | ...[...] |
-| array_flow.rb:1427:16:1427:26 | call to source :  | array_flow.rb:1428:9:1428:9 | a [element 2] :  |
-| array_flow.rb:1427:16:1427:26 | call to source :  | array_flow.rb:1428:9:1428:9 | a [element 2] :  |
+| array_flow.rb:1427:5:1427:5 | a [element 2] :  | array_flow.rb:1428:9:1428:9 | a [element 2] :  |
+| array_flow.rb:1427:5:1427:5 | a [element 2] :  | array_flow.rb:1428:9:1428:9 | a [element 2] :  |
+| array_flow.rb:1427:16:1427:26 | call to source :  | array_flow.rb:1427:5:1427:5 | a [element 2] :  |
+| array_flow.rb:1427:16:1427:26 | call to source :  | array_flow.rb:1427:5:1427:5 | a [element 2] :  |
 | array_flow.rb:1428:9:1428:9 | a [element 2] :  | array_flow.rb:1428:19:1428:19 | x :  |
 | array_flow.rb:1428:9:1428:9 | a [element 2] :  | array_flow.rb:1428:19:1428:19 | x :  |
 | array_flow.rb:1428:19:1428:19 | x :  | array_flow.rb:1429:14:1429:14 | x |
 | array_flow.rb:1428:19:1428:19 | x :  | array_flow.rb:1429:14:1429:14 | x |
-| array_flow.rb:1435:16:1435:28 | call to source :  | array_flow.rb:1436:9:1436:9 | a [element 2] :  |
-| array_flow.rb:1435:16:1435:28 | call to source :  | array_flow.rb:1436:9:1436:9 | a [element 2] :  |
-| array_flow.rb:1435:16:1435:28 | call to source :  | array_flow.rb:1441:9:1441:9 | a [element 2] :  |
-| array_flow.rb:1435:16:1435:28 | call to source :  | array_flow.rb:1441:9:1441:9 | a [element 2] :  |
-| array_flow.rb:1435:16:1435:28 | call to source :  | array_flow.rb:1447:9:1447:9 | a [element 2] :  |
-| array_flow.rb:1435:16:1435:28 | call to source :  | array_flow.rb:1447:9:1447:9 | a [element 2] :  |
-| array_flow.rb:1435:16:1435:28 | call to source :  | array_flow.rb:1454:9:1454:9 | a [element 2] :  |
-| array_flow.rb:1435:16:1435:28 | call to source :  | array_flow.rb:1454:9:1454:9 | a [element 2] :  |
-| array_flow.rb:1435:31:1435:43 | call to source :  | array_flow.rb:1436:9:1436:9 | a [element 3] :  |
-| array_flow.rb:1435:31:1435:43 | call to source :  | array_flow.rb:1436:9:1436:9 | a [element 3] :  |
-| array_flow.rb:1435:31:1435:43 | call to source :  | array_flow.rb:1447:9:1447:9 | a [element 3] :  |
-| array_flow.rb:1435:31:1435:43 | call to source :  | array_flow.rb:1447:9:1447:9 | a [element 3] :  |
+| array_flow.rb:1435:5:1435:5 | a [element 2] :  | array_flow.rb:1436:9:1436:9 | a [element 2] :  |
+| array_flow.rb:1435:5:1435:5 | a [element 2] :  | array_flow.rb:1436:9:1436:9 | a [element 2] :  |
+| array_flow.rb:1435:5:1435:5 | a [element 2] :  | array_flow.rb:1441:9:1441:9 | a [element 2] :  |
+| array_flow.rb:1435:5:1435:5 | a [element 2] :  | array_flow.rb:1441:9:1441:9 | a [element 2] :  |
+| array_flow.rb:1435:5:1435:5 | a [element 2] :  | array_flow.rb:1447:9:1447:9 | a [element 2] :  |
+| array_flow.rb:1435:5:1435:5 | a [element 2] :  | array_flow.rb:1447:9:1447:9 | a [element 2] :  |
+| array_flow.rb:1435:5:1435:5 | a [element 2] :  | array_flow.rb:1454:9:1454:9 | a [element 2] :  |
+| array_flow.rb:1435:5:1435:5 | a [element 2] :  | array_flow.rb:1454:9:1454:9 | a [element 2] :  |
+| array_flow.rb:1435:5:1435:5 | a [element 3] :  | array_flow.rb:1436:9:1436:9 | a [element 3] :  |
+| array_flow.rb:1435:5:1435:5 | a [element 3] :  | array_flow.rb:1436:9:1436:9 | a [element 3] :  |
+| array_flow.rb:1435:5:1435:5 | a [element 3] :  | array_flow.rb:1447:9:1447:9 | a [element 3] :  |
+| array_flow.rb:1435:5:1435:5 | a [element 3] :  | array_flow.rb:1447:9:1447:9 | a [element 3] :  |
+| array_flow.rb:1435:16:1435:28 | call to source :  | array_flow.rb:1435:5:1435:5 | a [element 2] :  |
+| array_flow.rb:1435:16:1435:28 | call to source :  | array_flow.rb:1435:5:1435:5 | a [element 2] :  |
+| array_flow.rb:1435:31:1435:43 | call to source :  | array_flow.rb:1435:5:1435:5 | a [element 3] :  |
+| array_flow.rb:1435:31:1435:43 | call to source :  | array_flow.rb:1435:5:1435:5 | a [element 3] :  |
+| array_flow.rb:1436:5:1436:5 | b [element 2] :  | array_flow.rb:1439:10:1439:10 | b [element 2] :  |
+| array_flow.rb:1436:5:1436:5 | b [element 2] :  | array_flow.rb:1439:10:1439:10 | b [element 2] :  |
+| array_flow.rb:1436:5:1436:5 | b [element 3] :  | array_flow.rb:1440:10:1440:10 | b [element 3] :  |
+| array_flow.rb:1436:5:1436:5 | b [element 3] :  | array_flow.rb:1440:10:1440:10 | b [element 3] :  |
 | array_flow.rb:1436:9:1436:9 | a [element 2] :  | array_flow.rb:1436:9:1436:17 | call to take [element 2] :  |
 | array_flow.rb:1436:9:1436:9 | a [element 2] :  | array_flow.rb:1436:9:1436:17 | call to take [element 2] :  |
 | array_flow.rb:1436:9:1436:9 | a [element 3] :  | array_flow.rb:1436:9:1436:17 | call to take [element 3] :  |
 | array_flow.rb:1436:9:1436:9 | a [element 3] :  | array_flow.rb:1436:9:1436:17 | call to take [element 3] :  |
-| array_flow.rb:1436:9:1436:17 | call to take [element 2] :  | array_flow.rb:1439:10:1439:10 | b [element 2] :  |
-| array_flow.rb:1436:9:1436:17 | call to take [element 2] :  | array_flow.rb:1439:10:1439:10 | b [element 2] :  |
-| array_flow.rb:1436:9:1436:17 | call to take [element 3] :  | array_flow.rb:1440:10:1440:10 | b [element 3] :  |
-| array_flow.rb:1436:9:1436:17 | call to take [element 3] :  | array_flow.rb:1440:10:1440:10 | b [element 3] :  |
+| array_flow.rb:1436:9:1436:17 | call to take [element 2] :  | array_flow.rb:1436:5:1436:5 | b [element 2] :  |
+| array_flow.rb:1436:9:1436:17 | call to take [element 2] :  | array_flow.rb:1436:5:1436:5 | b [element 2] :  |
+| array_flow.rb:1436:9:1436:17 | call to take [element 3] :  | array_flow.rb:1436:5:1436:5 | b [element 3] :  |
+| array_flow.rb:1436:9:1436:17 | call to take [element 3] :  | array_flow.rb:1436:5:1436:5 | b [element 3] :  |
 | array_flow.rb:1439:10:1439:10 | b [element 2] :  | array_flow.rb:1439:10:1439:13 | ...[...] |
 | array_flow.rb:1439:10:1439:10 | b [element 2] :  | array_flow.rb:1439:10:1439:13 | ...[...] |
 | array_flow.rb:1440:10:1440:10 | b [element 3] :  | array_flow.rb:1440:10:1440:13 | ...[...] |
 | array_flow.rb:1440:10:1440:10 | b [element 3] :  | array_flow.rb:1440:10:1440:13 | ...[...] |
+| array_flow.rb:1441:5:1441:5 | b [element 2] :  | array_flow.rb:1444:10:1444:10 | b [element 2] :  |
+| array_flow.rb:1441:5:1441:5 | b [element 2] :  | array_flow.rb:1444:10:1444:10 | b [element 2] :  |
+| array_flow.rb:1441:5:1441:5 | b [element 2] :  | array_flow.rb:1446:10:1446:10 | b [element 2] :  |
+| array_flow.rb:1441:5:1441:5 | b [element 2] :  | array_flow.rb:1446:10:1446:10 | b [element 2] :  |
 | array_flow.rb:1441:9:1441:9 | a [element 2] :  | array_flow.rb:1441:9:1441:17 | call to take [element 2] :  |
 | array_flow.rb:1441:9:1441:9 | a [element 2] :  | array_flow.rb:1441:9:1441:17 | call to take [element 2] :  |
-| array_flow.rb:1441:9:1441:17 | call to take [element 2] :  | array_flow.rb:1444:10:1444:10 | b [element 2] :  |
-| array_flow.rb:1441:9:1441:17 | call to take [element 2] :  | array_flow.rb:1444:10:1444:10 | b [element 2] :  |
-| array_flow.rb:1441:9:1441:17 | call to take [element 2] :  | array_flow.rb:1446:10:1446:10 | b [element 2] :  |
-| array_flow.rb:1441:9:1441:17 | call to take [element 2] :  | array_flow.rb:1446:10:1446:10 | b [element 2] :  |
+| array_flow.rb:1441:9:1441:17 | call to take [element 2] :  | array_flow.rb:1441:5:1441:5 | b [element 2] :  |
+| array_flow.rb:1441:9:1441:17 | call to take [element 2] :  | array_flow.rb:1441:5:1441:5 | b [element 2] :  |
 | array_flow.rb:1444:10:1444:10 | b [element 2] :  | array_flow.rb:1444:10:1444:13 | ...[...] |
 | array_flow.rb:1444:10:1444:10 | b [element 2] :  | array_flow.rb:1444:10:1444:13 | ...[...] |
 | array_flow.rb:1446:10:1446:10 | b [element 2] :  | array_flow.rb:1446:10:1446:13 | ...[...] |
 | array_flow.rb:1446:10:1446:10 | b [element 2] :  | array_flow.rb:1446:10:1446:13 | ...[...] |
+| array_flow.rb:1447:5:1447:5 | b [element 2] :  | array_flow.rb:1450:10:1450:10 | b [element 2] :  |
+| array_flow.rb:1447:5:1447:5 | b [element 2] :  | array_flow.rb:1450:10:1450:10 | b [element 2] :  |
+| array_flow.rb:1447:5:1447:5 | b [element 2] :  | array_flow.rb:1452:10:1452:10 | b [element 2] :  |
+| array_flow.rb:1447:5:1447:5 | b [element 2] :  | array_flow.rb:1452:10:1452:10 | b [element 2] :  |
+| array_flow.rb:1447:5:1447:5 | b [element 3] :  | array_flow.rb:1451:10:1451:10 | b [element 3] :  |
+| array_flow.rb:1447:5:1447:5 | b [element 3] :  | array_flow.rb:1451:10:1451:10 | b [element 3] :  |
+| array_flow.rb:1447:5:1447:5 | b [element 3] :  | array_flow.rb:1452:10:1452:10 | b [element 3] :  |
+| array_flow.rb:1447:5:1447:5 | b [element 3] :  | array_flow.rb:1452:10:1452:10 | b [element 3] :  |
 | array_flow.rb:1447:9:1447:9 | a [element 2] :  | array_flow.rb:1447:9:1447:19 | call to take [element 2] :  |
 | array_flow.rb:1447:9:1447:9 | a [element 2] :  | array_flow.rb:1447:9:1447:19 | call to take [element 2] :  |
 | array_flow.rb:1447:9:1447:9 | a [element 3] :  | array_flow.rb:1447:9:1447:19 | call to take [element 3] :  |
 | array_flow.rb:1447:9:1447:9 | a [element 3] :  | array_flow.rb:1447:9:1447:19 | call to take [element 3] :  |
-| array_flow.rb:1447:9:1447:19 | call to take [element 2] :  | array_flow.rb:1450:10:1450:10 | b [element 2] :  |
-| array_flow.rb:1447:9:1447:19 | call to take [element 2] :  | array_flow.rb:1450:10:1450:10 | b [element 2] :  |
-| array_flow.rb:1447:9:1447:19 | call to take [element 2] :  | array_flow.rb:1452:10:1452:10 | b [element 2] :  |
-| array_flow.rb:1447:9:1447:19 | call to take [element 2] :  | array_flow.rb:1452:10:1452:10 | b [element 2] :  |
-| array_flow.rb:1447:9:1447:19 | call to take [element 3] :  | array_flow.rb:1451:10:1451:10 | b [element 3] :  |
-| array_flow.rb:1447:9:1447:19 | call to take [element 3] :  | array_flow.rb:1451:10:1451:10 | b [element 3] :  |
-| array_flow.rb:1447:9:1447:19 | call to take [element 3] :  | array_flow.rb:1452:10:1452:10 | b [element 3] :  |
-| array_flow.rb:1447:9:1447:19 | call to take [element 3] :  | array_flow.rb:1452:10:1452:10 | b [element 3] :  |
+| array_flow.rb:1447:9:1447:19 | call to take [element 2] :  | array_flow.rb:1447:5:1447:5 | b [element 2] :  |
+| array_flow.rb:1447:9:1447:19 | call to take [element 2] :  | array_flow.rb:1447:5:1447:5 | b [element 2] :  |
+| array_flow.rb:1447:9:1447:19 | call to take [element 3] :  | array_flow.rb:1447:5:1447:5 | b [element 3] :  |
+| array_flow.rb:1447:9:1447:19 | call to take [element 3] :  | array_flow.rb:1447:5:1447:5 | b [element 3] :  |
 | array_flow.rb:1450:10:1450:10 | b [element 2] :  | array_flow.rb:1450:10:1450:13 | ...[...] |
 | array_flow.rb:1450:10:1450:10 | b [element 2] :  | array_flow.rb:1450:10:1450:13 | ...[...] |
 | array_flow.rb:1451:10:1451:10 | b [element 3] :  | array_flow.rb:1451:10:1451:13 | ...[...] |
@@ -3007,64 +3724,92 @@ edges
 | array_flow.rb:1453:5:1453:5 | [post] a [element] :  | array_flow.rb:1454:9:1454:9 | a [element] :  |
 | array_flow.rb:1453:12:1453:24 | call to source :  | array_flow.rb:1453:5:1453:5 | [post] a [element] :  |
 | array_flow.rb:1453:12:1453:24 | call to source :  | array_flow.rb:1453:5:1453:5 | [post] a [element] :  |
+| array_flow.rb:1454:5:1454:5 | b [element 2] :  | array_flow.rb:1455:10:1455:10 | b [element 2] :  |
+| array_flow.rb:1454:5:1454:5 | b [element 2] :  | array_flow.rb:1455:10:1455:10 | b [element 2] :  |
+| array_flow.rb:1454:5:1454:5 | b [element] :  | array_flow.rb:1455:10:1455:10 | b [element] :  |
+| array_flow.rb:1454:5:1454:5 | b [element] :  | array_flow.rb:1455:10:1455:10 | b [element] :  |
 | array_flow.rb:1454:9:1454:9 | a [element 2] :  | array_flow.rb:1454:9:1454:17 | call to take [element 2] :  |
 | array_flow.rb:1454:9:1454:9 | a [element 2] :  | array_flow.rb:1454:9:1454:17 | call to take [element 2] :  |
 | array_flow.rb:1454:9:1454:9 | a [element] :  | array_flow.rb:1454:9:1454:17 | call to take [element] :  |
 | array_flow.rb:1454:9:1454:9 | a [element] :  | array_flow.rb:1454:9:1454:17 | call to take [element] :  |
-| array_flow.rb:1454:9:1454:17 | call to take [element 2] :  | array_flow.rb:1455:10:1455:10 | b [element 2] :  |
-| array_flow.rb:1454:9:1454:17 | call to take [element 2] :  | array_flow.rb:1455:10:1455:10 | b [element 2] :  |
-| array_flow.rb:1454:9:1454:17 | call to take [element] :  | array_flow.rb:1455:10:1455:10 | b [element] :  |
-| array_flow.rb:1454:9:1454:17 | call to take [element] :  | array_flow.rb:1455:10:1455:10 | b [element] :  |
+| array_flow.rb:1454:9:1454:17 | call to take [element 2] :  | array_flow.rb:1454:5:1454:5 | b [element 2] :  |
+| array_flow.rb:1454:9:1454:17 | call to take [element 2] :  | array_flow.rb:1454:5:1454:5 | b [element 2] :  |
+| array_flow.rb:1454:9:1454:17 | call to take [element] :  | array_flow.rb:1454:5:1454:5 | b [element] :  |
+| array_flow.rb:1454:9:1454:17 | call to take [element] :  | array_flow.rb:1454:5:1454:5 | b [element] :  |
 | array_flow.rb:1455:10:1455:10 | b [element 2] :  | array_flow.rb:1455:10:1455:13 | ...[...] |
 | array_flow.rb:1455:10:1455:10 | b [element 2] :  | array_flow.rb:1455:10:1455:13 | ...[...] |
 | array_flow.rb:1455:10:1455:10 | b [element] :  | array_flow.rb:1455:10:1455:13 | ...[...] |
 | array_flow.rb:1455:10:1455:10 | b [element] :  | array_flow.rb:1455:10:1455:13 | ...[...] |
-| array_flow.rb:1459:16:1459:26 | call to source :  | array_flow.rb:1460:9:1460:9 | a [element 2] :  |
-| array_flow.rb:1459:16:1459:26 | call to source :  | array_flow.rb:1460:9:1460:9 | a [element 2] :  |
+| array_flow.rb:1459:5:1459:5 | a [element 2] :  | array_flow.rb:1460:9:1460:9 | a [element 2] :  |
+| array_flow.rb:1459:5:1459:5 | a [element 2] :  | array_flow.rb:1460:9:1460:9 | a [element 2] :  |
+| array_flow.rb:1459:16:1459:26 | call to source :  | array_flow.rb:1459:5:1459:5 | a [element 2] :  |
+| array_flow.rb:1459:16:1459:26 | call to source :  | array_flow.rb:1459:5:1459:5 | a [element 2] :  |
+| array_flow.rb:1460:5:1460:5 | b [element 2] :  | array_flow.rb:1466:10:1466:10 | b [element 2] :  |
+| array_flow.rb:1460:5:1460:5 | b [element 2] :  | array_flow.rb:1466:10:1466:10 | b [element 2] :  |
 | array_flow.rb:1460:9:1460:9 | a [element 2] :  | array_flow.rb:1460:9:1463:7 | call to take_while [element 2] :  |
 | array_flow.rb:1460:9:1460:9 | a [element 2] :  | array_flow.rb:1460:9:1463:7 | call to take_while [element 2] :  |
 | array_flow.rb:1460:9:1460:9 | a [element 2] :  | array_flow.rb:1460:26:1460:26 | x :  |
 | array_flow.rb:1460:9:1460:9 | a [element 2] :  | array_flow.rb:1460:26:1460:26 | x :  |
-| array_flow.rb:1460:9:1463:7 | call to take_while [element 2] :  | array_flow.rb:1466:10:1466:10 | b [element 2] :  |
-| array_flow.rb:1460:9:1463:7 | call to take_while [element 2] :  | array_flow.rb:1466:10:1466:10 | b [element 2] :  |
+| array_flow.rb:1460:9:1463:7 | call to take_while [element 2] :  | array_flow.rb:1460:5:1460:5 | b [element 2] :  |
+| array_flow.rb:1460:9:1463:7 | call to take_while [element 2] :  | array_flow.rb:1460:5:1460:5 | b [element 2] :  |
 | array_flow.rb:1460:26:1460:26 | x :  | array_flow.rb:1461:14:1461:14 | x |
 | array_flow.rb:1460:26:1460:26 | x :  | array_flow.rb:1461:14:1461:14 | x |
 | array_flow.rb:1466:10:1466:10 | b [element 2] :  | array_flow.rb:1466:10:1466:13 | ...[...] |
 | array_flow.rb:1466:10:1466:10 | b [element 2] :  | array_flow.rb:1466:10:1466:13 | ...[...] |
-| array_flow.rb:1472:19:1472:29 | call to source :  | array_flow.rb:1473:9:1473:9 | a [element 3] :  |
-| array_flow.rb:1472:19:1472:29 | call to source :  | array_flow.rb:1473:9:1473:9 | a [element 3] :  |
+| array_flow.rb:1472:5:1472:5 | a [element 3] :  | array_flow.rb:1473:9:1473:9 | a [element 3] :  |
+| array_flow.rb:1472:5:1472:5 | a [element 3] :  | array_flow.rb:1473:9:1473:9 | a [element 3] :  |
+| array_flow.rb:1472:19:1472:29 | call to source :  | array_flow.rb:1472:5:1472:5 | a [element 3] :  |
+| array_flow.rb:1472:19:1472:29 | call to source :  | array_flow.rb:1472:5:1472:5 | a [element 3] :  |
+| array_flow.rb:1473:5:1473:5 | b [element 3] :  | array_flow.rb:1474:10:1474:10 | b [element 3] :  |
+| array_flow.rb:1473:5:1473:5 | b [element 3] :  | array_flow.rb:1474:10:1474:10 | b [element 3] :  |
 | array_flow.rb:1473:9:1473:9 | a [element 3] :  | array_flow.rb:1473:9:1473:14 | call to to_a [element 3] :  |
 | array_flow.rb:1473:9:1473:9 | a [element 3] :  | array_flow.rb:1473:9:1473:14 | call to to_a [element 3] :  |
-| array_flow.rb:1473:9:1473:14 | call to to_a [element 3] :  | array_flow.rb:1474:10:1474:10 | b [element 3] :  |
-| array_flow.rb:1473:9:1473:14 | call to to_a [element 3] :  | array_flow.rb:1474:10:1474:10 | b [element 3] :  |
+| array_flow.rb:1473:9:1473:14 | call to to_a [element 3] :  | array_flow.rb:1473:5:1473:5 | b [element 3] :  |
+| array_flow.rb:1473:9:1473:14 | call to to_a [element 3] :  | array_flow.rb:1473:5:1473:5 | b [element 3] :  |
 | array_flow.rb:1474:10:1474:10 | b [element 3] :  | array_flow.rb:1474:10:1474:13 | ...[...] |
 | array_flow.rb:1474:10:1474:10 | b [element 3] :  | array_flow.rb:1474:10:1474:13 | ...[...] |
-| array_flow.rb:1478:16:1478:26 | call to source :  | array_flow.rb:1479:9:1479:9 | a [element 2] :  |
-| array_flow.rb:1478:16:1478:26 | call to source :  | array_flow.rb:1479:9:1479:9 | a [element 2] :  |
+| array_flow.rb:1478:5:1478:5 | a [element 2] :  | array_flow.rb:1479:9:1479:9 | a [element 2] :  |
+| array_flow.rb:1478:5:1478:5 | a [element 2] :  | array_flow.rb:1479:9:1479:9 | a [element 2] :  |
+| array_flow.rb:1478:16:1478:26 | call to source :  | array_flow.rb:1478:5:1478:5 | a [element 2] :  |
+| array_flow.rb:1478:16:1478:26 | call to source :  | array_flow.rb:1478:5:1478:5 | a [element 2] :  |
+| array_flow.rb:1479:5:1479:5 | b [element 2] :  | array_flow.rb:1482:10:1482:10 | b [element 2] :  |
+| array_flow.rb:1479:5:1479:5 | b [element 2] :  | array_flow.rb:1482:10:1482:10 | b [element 2] :  |
 | array_flow.rb:1479:9:1479:9 | a [element 2] :  | array_flow.rb:1479:9:1479:16 | call to to_ary [element 2] :  |
 | array_flow.rb:1479:9:1479:9 | a [element 2] :  | array_flow.rb:1479:9:1479:16 | call to to_ary [element 2] :  |
-| array_flow.rb:1479:9:1479:16 | call to to_ary [element 2] :  | array_flow.rb:1482:10:1482:10 | b [element 2] :  |
-| array_flow.rb:1479:9:1479:16 | call to to_ary [element 2] :  | array_flow.rb:1482:10:1482:10 | b [element 2] :  |
+| array_flow.rb:1479:9:1479:16 | call to to_ary [element 2] :  | array_flow.rb:1479:5:1479:5 | b [element 2] :  |
+| array_flow.rb:1479:9:1479:16 | call to to_ary [element 2] :  | array_flow.rb:1479:5:1479:5 | b [element 2] :  |
 | array_flow.rb:1482:10:1482:10 | b [element 2] :  | array_flow.rb:1482:10:1482:13 | ...[...] |
 | array_flow.rb:1482:10:1482:10 | b [element 2] :  | array_flow.rb:1482:10:1482:13 | ...[...] |
-| array_flow.rb:1495:14:1495:26 | call to source :  | array_flow.rb:1496:9:1496:9 | a [element 0, element 1] :  |
-| array_flow.rb:1495:14:1495:26 | call to source :  | array_flow.rb:1496:9:1496:9 | a [element 0, element 1] :  |
-| array_flow.rb:1495:34:1495:46 | call to source :  | array_flow.rb:1496:9:1496:9 | a [element 1, element 1] :  |
-| array_flow.rb:1495:34:1495:46 | call to source :  | array_flow.rb:1496:9:1496:9 | a [element 1, element 1] :  |
-| array_flow.rb:1495:54:1495:66 | call to source :  | array_flow.rb:1496:9:1496:9 | a [element 2, element 1] :  |
-| array_flow.rb:1495:54:1495:66 | call to source :  | array_flow.rb:1496:9:1496:9 | a [element 2, element 1] :  |
+| array_flow.rb:1495:5:1495:5 | a [element 0, element 1] :  | array_flow.rb:1496:9:1496:9 | a [element 0, element 1] :  |
+| array_flow.rb:1495:5:1495:5 | a [element 0, element 1] :  | array_flow.rb:1496:9:1496:9 | a [element 0, element 1] :  |
+| array_flow.rb:1495:5:1495:5 | a [element 1, element 1] :  | array_flow.rb:1496:9:1496:9 | a [element 1, element 1] :  |
+| array_flow.rb:1495:5:1495:5 | a [element 1, element 1] :  | array_flow.rb:1496:9:1496:9 | a [element 1, element 1] :  |
+| array_flow.rb:1495:5:1495:5 | a [element 2, element 1] :  | array_flow.rb:1496:9:1496:9 | a [element 2, element 1] :  |
+| array_flow.rb:1495:5:1495:5 | a [element 2, element 1] :  | array_flow.rb:1496:9:1496:9 | a [element 2, element 1] :  |
+| array_flow.rb:1495:14:1495:26 | call to source :  | array_flow.rb:1495:5:1495:5 | a [element 0, element 1] :  |
+| array_flow.rb:1495:14:1495:26 | call to source :  | array_flow.rb:1495:5:1495:5 | a [element 0, element 1] :  |
+| array_flow.rb:1495:34:1495:46 | call to source :  | array_flow.rb:1495:5:1495:5 | a [element 1, element 1] :  |
+| array_flow.rb:1495:34:1495:46 | call to source :  | array_flow.rb:1495:5:1495:5 | a [element 1, element 1] :  |
+| array_flow.rb:1495:54:1495:66 | call to source :  | array_flow.rb:1495:5:1495:5 | a [element 2, element 1] :  |
+| array_flow.rb:1495:54:1495:66 | call to source :  | array_flow.rb:1495:5:1495:5 | a [element 2, element 1] :  |
+| array_flow.rb:1496:5:1496:5 | b [element 1, element 0] :  | array_flow.rb:1500:10:1500:10 | b [element 1, element 0] :  |
+| array_flow.rb:1496:5:1496:5 | b [element 1, element 0] :  | array_flow.rb:1500:10:1500:10 | b [element 1, element 0] :  |
+| array_flow.rb:1496:5:1496:5 | b [element 1, element 1] :  | array_flow.rb:1501:10:1501:10 | b [element 1, element 1] :  |
+| array_flow.rb:1496:5:1496:5 | b [element 1, element 1] :  | array_flow.rb:1501:10:1501:10 | b [element 1, element 1] :  |
+| array_flow.rb:1496:5:1496:5 | b [element 1, element 2] :  | array_flow.rb:1502:10:1502:10 | b [element 1, element 2] :  |
+| array_flow.rb:1496:5:1496:5 | b [element 1, element 2] :  | array_flow.rb:1502:10:1502:10 | b [element 1, element 2] :  |
 | array_flow.rb:1496:9:1496:9 | a [element 0, element 1] :  | array_flow.rb:1496:9:1496:19 | call to transpose [element 1, element 0] :  |
 | array_flow.rb:1496:9:1496:9 | a [element 0, element 1] :  | array_flow.rb:1496:9:1496:19 | call to transpose [element 1, element 0] :  |
 | array_flow.rb:1496:9:1496:9 | a [element 1, element 1] :  | array_flow.rb:1496:9:1496:19 | call to transpose [element 1, element 1] :  |
 | array_flow.rb:1496:9:1496:9 | a [element 1, element 1] :  | array_flow.rb:1496:9:1496:19 | call to transpose [element 1, element 1] :  |
 | array_flow.rb:1496:9:1496:9 | a [element 2, element 1] :  | array_flow.rb:1496:9:1496:19 | call to transpose [element 1, element 2] :  |
 | array_flow.rb:1496:9:1496:9 | a [element 2, element 1] :  | array_flow.rb:1496:9:1496:19 | call to transpose [element 1, element 2] :  |
-| array_flow.rb:1496:9:1496:19 | call to transpose [element 1, element 0] :  | array_flow.rb:1500:10:1500:10 | b [element 1, element 0] :  |
-| array_flow.rb:1496:9:1496:19 | call to transpose [element 1, element 0] :  | array_flow.rb:1500:10:1500:10 | b [element 1, element 0] :  |
-| array_flow.rb:1496:9:1496:19 | call to transpose [element 1, element 1] :  | array_flow.rb:1501:10:1501:10 | b [element 1, element 1] :  |
-| array_flow.rb:1496:9:1496:19 | call to transpose [element 1, element 1] :  | array_flow.rb:1501:10:1501:10 | b [element 1, element 1] :  |
-| array_flow.rb:1496:9:1496:19 | call to transpose [element 1, element 2] :  | array_flow.rb:1502:10:1502:10 | b [element 1, element 2] :  |
-| array_flow.rb:1496:9:1496:19 | call to transpose [element 1, element 2] :  | array_flow.rb:1502:10:1502:10 | b [element 1, element 2] :  |
+| array_flow.rb:1496:9:1496:19 | call to transpose [element 1, element 0] :  | array_flow.rb:1496:5:1496:5 | b [element 1, element 0] :  |
+| array_flow.rb:1496:9:1496:19 | call to transpose [element 1, element 0] :  | array_flow.rb:1496:5:1496:5 | b [element 1, element 0] :  |
+| array_flow.rb:1496:9:1496:19 | call to transpose [element 1, element 1] :  | array_flow.rb:1496:5:1496:5 | b [element 1, element 1] :  |
+| array_flow.rb:1496:9:1496:19 | call to transpose [element 1, element 1] :  | array_flow.rb:1496:5:1496:5 | b [element 1, element 1] :  |
+| array_flow.rb:1496:9:1496:19 | call to transpose [element 1, element 2] :  | array_flow.rb:1496:5:1496:5 | b [element 1, element 2] :  |
+| array_flow.rb:1496:9:1496:19 | call to transpose [element 1, element 2] :  | array_flow.rb:1496:5:1496:5 | b [element 1, element 2] :  |
 | array_flow.rb:1500:10:1500:10 | b [element 1, element 0] :  | array_flow.rb:1500:10:1500:13 | ...[...] [element 0] :  |
 | array_flow.rb:1500:10:1500:10 | b [element 1, element 0] :  | array_flow.rb:1500:10:1500:13 | ...[...] [element 0] :  |
 | array_flow.rb:1500:10:1500:13 | ...[...] [element 0] :  | array_flow.rb:1500:10:1500:16 | ...[...] |
@@ -3077,20 +3822,28 @@ edges
 | array_flow.rb:1502:10:1502:10 | b [element 1, element 2] :  | array_flow.rb:1502:10:1502:13 | ...[...] [element 2] :  |
 | array_flow.rb:1502:10:1502:13 | ...[...] [element 2] :  | array_flow.rb:1502:10:1502:16 | ...[...] |
 | array_flow.rb:1502:10:1502:13 | ...[...] [element 2] :  | array_flow.rb:1502:10:1502:16 | ...[...] |
-| array_flow.rb:1506:16:1506:28 | call to source :  | array_flow.rb:1509:9:1509:9 | a [element 2] :  |
-| array_flow.rb:1506:16:1506:28 | call to source :  | array_flow.rb:1509:9:1509:9 | a [element 2] :  |
-| array_flow.rb:1507:13:1507:25 | call to source :  | array_flow.rb:1509:17:1509:17 | b [element 1] :  |
-| array_flow.rb:1507:13:1507:25 | call to source :  | array_flow.rb:1509:17:1509:17 | b [element 1] :  |
-| array_flow.rb:1508:13:1508:25 | call to source :  | array_flow.rb:1509:20:1509:20 | c [element 1] :  |
-| array_flow.rb:1508:13:1508:25 | call to source :  | array_flow.rb:1509:20:1509:20 | c [element 1] :  |
+| array_flow.rb:1506:5:1506:5 | a [element 2] :  | array_flow.rb:1509:9:1509:9 | a [element 2] :  |
+| array_flow.rb:1506:5:1506:5 | a [element 2] :  | array_flow.rb:1509:9:1509:9 | a [element 2] :  |
+| array_flow.rb:1506:16:1506:28 | call to source :  | array_flow.rb:1506:5:1506:5 | a [element 2] :  |
+| array_flow.rb:1506:16:1506:28 | call to source :  | array_flow.rb:1506:5:1506:5 | a [element 2] :  |
+| array_flow.rb:1507:5:1507:5 | b [element 1] :  | array_flow.rb:1509:17:1509:17 | b [element 1] :  |
+| array_flow.rb:1507:5:1507:5 | b [element 1] :  | array_flow.rb:1509:17:1509:17 | b [element 1] :  |
+| array_flow.rb:1507:13:1507:25 | call to source :  | array_flow.rb:1507:5:1507:5 | b [element 1] :  |
+| array_flow.rb:1507:13:1507:25 | call to source :  | array_flow.rb:1507:5:1507:5 | b [element 1] :  |
+| array_flow.rb:1508:5:1508:5 | c [element 1] :  | array_flow.rb:1509:20:1509:20 | c [element 1] :  |
+| array_flow.rb:1508:5:1508:5 | c [element 1] :  | array_flow.rb:1509:20:1509:20 | c [element 1] :  |
+| array_flow.rb:1508:13:1508:25 | call to source :  | array_flow.rb:1508:5:1508:5 | c [element 1] :  |
+| array_flow.rb:1508:13:1508:25 | call to source :  | array_flow.rb:1508:5:1508:5 | c [element 1] :  |
+| array_flow.rb:1509:5:1509:5 | d [element] :  | array_flow.rb:1510:10:1510:10 | d [element] :  |
+| array_flow.rb:1509:5:1509:5 | d [element] :  | array_flow.rb:1510:10:1510:10 | d [element] :  |
+| array_flow.rb:1509:5:1509:5 | d [element] :  | array_flow.rb:1511:10:1511:10 | d [element] :  |
+| array_flow.rb:1509:5:1509:5 | d [element] :  | array_flow.rb:1511:10:1511:10 | d [element] :  |
+| array_flow.rb:1509:5:1509:5 | d [element] :  | array_flow.rb:1512:10:1512:10 | d [element] :  |
+| array_flow.rb:1509:5:1509:5 | d [element] :  | array_flow.rb:1512:10:1512:10 | d [element] :  |
 | array_flow.rb:1509:9:1509:9 | a [element 2] :  | array_flow.rb:1509:9:1509:21 | call to union [element] :  |
 | array_flow.rb:1509:9:1509:9 | a [element 2] :  | array_flow.rb:1509:9:1509:21 | call to union [element] :  |
-| array_flow.rb:1509:9:1509:21 | call to union [element] :  | array_flow.rb:1510:10:1510:10 | d [element] :  |
-| array_flow.rb:1509:9:1509:21 | call to union [element] :  | array_flow.rb:1510:10:1510:10 | d [element] :  |
-| array_flow.rb:1509:9:1509:21 | call to union [element] :  | array_flow.rb:1511:10:1511:10 | d [element] :  |
-| array_flow.rb:1509:9:1509:21 | call to union [element] :  | array_flow.rb:1511:10:1511:10 | d [element] :  |
-| array_flow.rb:1509:9:1509:21 | call to union [element] :  | array_flow.rb:1512:10:1512:10 | d [element] :  |
-| array_flow.rb:1509:9:1509:21 | call to union [element] :  | array_flow.rb:1512:10:1512:10 | d [element] :  |
+| array_flow.rb:1509:9:1509:21 | call to union [element] :  | array_flow.rb:1509:5:1509:5 | d [element] :  |
+| array_flow.rb:1509:9:1509:21 | call to union [element] :  | array_flow.rb:1509:5:1509:5 | d [element] :  |
 | array_flow.rb:1509:17:1509:17 | b [element 1] :  | array_flow.rb:1509:9:1509:21 | call to union [element] :  |
 | array_flow.rb:1509:17:1509:17 | b [element 1] :  | array_flow.rb:1509:9:1509:21 | call to union [element] :  |
 | array_flow.rb:1509:20:1509:20 | c [element 1] :  | array_flow.rb:1509:9:1509:21 | call to union [element] :  |
@@ -3101,26 +3854,34 @@ edges
 | array_flow.rb:1511:10:1511:10 | d [element] :  | array_flow.rb:1511:10:1511:13 | ...[...] |
 | array_flow.rb:1512:10:1512:10 | d [element] :  | array_flow.rb:1512:10:1512:13 | ...[...] |
 | array_flow.rb:1512:10:1512:10 | d [element] :  | array_flow.rb:1512:10:1512:13 | ...[...] |
-| array_flow.rb:1516:19:1516:31 | call to source :  | array_flow.rb:1518:9:1518:9 | a [element 3] :  |
-| array_flow.rb:1516:19:1516:31 | call to source :  | array_flow.rb:1518:9:1518:9 | a [element 3] :  |
-| array_flow.rb:1516:19:1516:31 | call to source :  | array_flow.rb:1522:9:1522:9 | a [element 3] :  |
-| array_flow.rb:1516:19:1516:31 | call to source :  | array_flow.rb:1522:9:1522:9 | a [element 3] :  |
-| array_flow.rb:1516:34:1516:46 | call to source :  | array_flow.rb:1518:9:1518:9 | a [element 4] :  |
-| array_flow.rb:1516:34:1516:46 | call to source :  | array_flow.rb:1518:9:1518:9 | a [element 4] :  |
-| array_flow.rb:1516:34:1516:46 | call to source :  | array_flow.rb:1522:9:1522:9 | a [element 4] :  |
-| array_flow.rb:1516:34:1516:46 | call to source :  | array_flow.rb:1522:9:1522:9 | a [element 4] :  |
+| array_flow.rb:1516:5:1516:5 | a [element 3] :  | array_flow.rb:1518:9:1518:9 | a [element 3] :  |
+| array_flow.rb:1516:5:1516:5 | a [element 3] :  | array_flow.rb:1518:9:1518:9 | a [element 3] :  |
+| array_flow.rb:1516:5:1516:5 | a [element 3] :  | array_flow.rb:1522:9:1522:9 | a [element 3] :  |
+| array_flow.rb:1516:5:1516:5 | a [element 3] :  | array_flow.rb:1522:9:1522:9 | a [element 3] :  |
+| array_flow.rb:1516:5:1516:5 | a [element 4] :  | array_flow.rb:1518:9:1518:9 | a [element 4] :  |
+| array_flow.rb:1516:5:1516:5 | a [element 4] :  | array_flow.rb:1518:9:1518:9 | a [element 4] :  |
+| array_flow.rb:1516:5:1516:5 | a [element 4] :  | array_flow.rb:1522:9:1522:9 | a [element 4] :  |
+| array_flow.rb:1516:5:1516:5 | a [element 4] :  | array_flow.rb:1522:9:1522:9 | a [element 4] :  |
+| array_flow.rb:1516:19:1516:31 | call to source :  | array_flow.rb:1516:5:1516:5 | a [element 3] :  |
+| array_flow.rb:1516:19:1516:31 | call to source :  | array_flow.rb:1516:5:1516:5 | a [element 3] :  |
+| array_flow.rb:1516:34:1516:46 | call to source :  | array_flow.rb:1516:5:1516:5 | a [element 4] :  |
+| array_flow.rb:1516:34:1516:46 | call to source :  | array_flow.rb:1516:5:1516:5 | a [element 4] :  |
+| array_flow.rb:1518:5:1518:5 | b [element] :  | array_flow.rb:1519:10:1519:10 | b [element] :  |
+| array_flow.rb:1518:5:1518:5 | b [element] :  | array_flow.rb:1519:10:1519:10 | b [element] :  |
+| array_flow.rb:1518:5:1518:5 | b [element] :  | array_flow.rb:1520:10:1520:10 | b [element] :  |
+| array_flow.rb:1518:5:1518:5 | b [element] :  | array_flow.rb:1520:10:1520:10 | b [element] :  |
 | array_flow.rb:1518:9:1518:9 | a [element 3] :  | array_flow.rb:1518:9:1518:14 | call to uniq [element] :  |
 | array_flow.rb:1518:9:1518:9 | a [element 3] :  | array_flow.rb:1518:9:1518:14 | call to uniq [element] :  |
 | array_flow.rb:1518:9:1518:9 | a [element 4] :  | array_flow.rb:1518:9:1518:14 | call to uniq [element] :  |
 | array_flow.rb:1518:9:1518:9 | a [element 4] :  | array_flow.rb:1518:9:1518:14 | call to uniq [element] :  |
-| array_flow.rb:1518:9:1518:14 | call to uniq [element] :  | array_flow.rb:1519:10:1519:10 | b [element] :  |
-| array_flow.rb:1518:9:1518:14 | call to uniq [element] :  | array_flow.rb:1519:10:1519:10 | b [element] :  |
-| array_flow.rb:1518:9:1518:14 | call to uniq [element] :  | array_flow.rb:1520:10:1520:10 | b [element] :  |
-| array_flow.rb:1518:9:1518:14 | call to uniq [element] :  | array_flow.rb:1520:10:1520:10 | b [element] :  |
+| array_flow.rb:1518:9:1518:14 | call to uniq [element] :  | array_flow.rb:1518:5:1518:5 | b [element] :  |
+| array_flow.rb:1518:9:1518:14 | call to uniq [element] :  | array_flow.rb:1518:5:1518:5 | b [element] :  |
 | array_flow.rb:1519:10:1519:10 | b [element] :  | array_flow.rb:1519:10:1519:13 | ...[...] |
 | array_flow.rb:1519:10:1519:10 | b [element] :  | array_flow.rb:1519:10:1519:13 | ...[...] |
 | array_flow.rb:1520:10:1520:10 | b [element] :  | array_flow.rb:1520:10:1520:13 | ...[...] |
 | array_flow.rb:1520:10:1520:10 | b [element] :  | array_flow.rb:1520:10:1520:13 | ...[...] |
+| array_flow.rb:1522:5:1522:5 | c [element] :  | array_flow.rb:1526:10:1526:10 | c [element] :  |
+| array_flow.rb:1522:5:1522:5 | c [element] :  | array_flow.rb:1526:10:1526:10 | c [element] :  |
 | array_flow.rb:1522:9:1522:9 | a [element 3] :  | array_flow.rb:1522:9:1525:7 | call to uniq [element] :  |
 | array_flow.rb:1522:9:1522:9 | a [element 3] :  | array_flow.rb:1522:9:1525:7 | call to uniq [element] :  |
 | array_flow.rb:1522:9:1522:9 | a [element 3] :  | array_flow.rb:1522:20:1522:20 | x :  |
@@ -3129,16 +3890,24 @@ edges
 | array_flow.rb:1522:9:1522:9 | a [element 4] :  | array_flow.rb:1522:9:1525:7 | call to uniq [element] :  |
 | array_flow.rb:1522:9:1522:9 | a [element 4] :  | array_flow.rb:1522:20:1522:20 | x :  |
 | array_flow.rb:1522:9:1522:9 | a [element 4] :  | array_flow.rb:1522:20:1522:20 | x :  |
-| array_flow.rb:1522:9:1525:7 | call to uniq [element] :  | array_flow.rb:1526:10:1526:10 | c [element] :  |
-| array_flow.rb:1522:9:1525:7 | call to uniq [element] :  | array_flow.rb:1526:10:1526:10 | c [element] :  |
+| array_flow.rb:1522:9:1525:7 | call to uniq [element] :  | array_flow.rb:1522:5:1522:5 | c [element] :  |
+| array_flow.rb:1522:9:1525:7 | call to uniq [element] :  | array_flow.rb:1522:5:1522:5 | c [element] :  |
 | array_flow.rb:1522:20:1522:20 | x :  | array_flow.rb:1523:14:1523:14 | x |
 | array_flow.rb:1522:20:1522:20 | x :  | array_flow.rb:1523:14:1523:14 | x |
 | array_flow.rb:1526:10:1526:10 | c [element] :  | array_flow.rb:1526:10:1526:13 | ...[...] |
 | array_flow.rb:1526:10:1526:10 | c [element] :  | array_flow.rb:1526:10:1526:13 | ...[...] |
-| array_flow.rb:1530:16:1530:28 | call to source :  | array_flow.rb:1531:9:1531:9 | a [element 2] :  |
-| array_flow.rb:1530:16:1530:28 | call to source :  | array_flow.rb:1531:9:1531:9 | a [element 2] :  |
-| array_flow.rb:1530:31:1530:43 | call to source :  | array_flow.rb:1531:9:1531:9 | a [element 3] :  |
-| array_flow.rb:1530:31:1530:43 | call to source :  | array_flow.rb:1531:9:1531:9 | a [element 3] :  |
+| array_flow.rb:1530:5:1530:5 | a [element 2] :  | array_flow.rb:1531:9:1531:9 | a [element 2] :  |
+| array_flow.rb:1530:5:1530:5 | a [element 2] :  | array_flow.rb:1531:9:1531:9 | a [element 2] :  |
+| array_flow.rb:1530:5:1530:5 | a [element 3] :  | array_flow.rb:1531:9:1531:9 | a [element 3] :  |
+| array_flow.rb:1530:5:1530:5 | a [element 3] :  | array_flow.rb:1531:9:1531:9 | a [element 3] :  |
+| array_flow.rb:1530:16:1530:28 | call to source :  | array_flow.rb:1530:5:1530:5 | a [element 2] :  |
+| array_flow.rb:1530:16:1530:28 | call to source :  | array_flow.rb:1530:5:1530:5 | a [element 2] :  |
+| array_flow.rb:1530:31:1530:43 | call to source :  | array_flow.rb:1530:5:1530:5 | a [element 3] :  |
+| array_flow.rb:1530:31:1530:43 | call to source :  | array_flow.rb:1530:5:1530:5 | a [element 3] :  |
+| array_flow.rb:1531:5:1531:5 | b [element] :  | array_flow.rb:1532:10:1532:10 | b [element] :  |
+| array_flow.rb:1531:5:1531:5 | b [element] :  | array_flow.rb:1532:10:1532:10 | b [element] :  |
+| array_flow.rb:1531:5:1531:5 | b [element] :  | array_flow.rb:1533:10:1533:10 | b [element] :  |
+| array_flow.rb:1531:5:1531:5 | b [element] :  | array_flow.rb:1533:10:1533:10 | b [element] :  |
 | array_flow.rb:1531:9:1531:9 | [post] a [element] :  | array_flow.rb:1534:10:1534:10 | a [element] :  |
 | array_flow.rb:1531:9:1531:9 | [post] a [element] :  | array_flow.rb:1534:10:1534:10 | a [element] :  |
 | array_flow.rb:1531:9:1531:9 | [post] a [element] :  | array_flow.rb:1535:10:1535:10 | a [element] :  |
@@ -3151,10 +3920,8 @@ edges
 | array_flow.rb:1531:9:1531:9 | a [element 3] :  | array_flow.rb:1531:9:1531:9 | [post] a [element] :  |
 | array_flow.rb:1531:9:1531:9 | a [element 3] :  | array_flow.rb:1531:9:1531:15 | call to uniq! [element] :  |
 | array_flow.rb:1531:9:1531:9 | a [element 3] :  | array_flow.rb:1531:9:1531:15 | call to uniq! [element] :  |
-| array_flow.rb:1531:9:1531:15 | call to uniq! [element] :  | array_flow.rb:1532:10:1532:10 | b [element] :  |
-| array_flow.rb:1531:9:1531:15 | call to uniq! [element] :  | array_flow.rb:1532:10:1532:10 | b [element] :  |
-| array_flow.rb:1531:9:1531:15 | call to uniq! [element] :  | array_flow.rb:1533:10:1533:10 | b [element] :  |
-| array_flow.rb:1531:9:1531:15 | call to uniq! [element] :  | array_flow.rb:1533:10:1533:10 | b [element] :  |
+| array_flow.rb:1531:9:1531:15 | call to uniq! [element] :  | array_flow.rb:1531:5:1531:5 | b [element] :  |
+| array_flow.rb:1531:9:1531:15 | call to uniq! [element] :  | array_flow.rb:1531:5:1531:5 | b [element] :  |
 | array_flow.rb:1532:10:1532:10 | b [element] :  | array_flow.rb:1532:10:1532:13 | ...[...] |
 | array_flow.rb:1532:10:1532:10 | b [element] :  | array_flow.rb:1532:10:1532:13 | ...[...] |
 | array_flow.rb:1533:10:1533:10 | b [element] :  | array_flow.rb:1533:10:1533:13 | ...[...] |
@@ -3163,10 +3930,18 @@ edges
 | array_flow.rb:1534:10:1534:10 | a [element] :  | array_flow.rb:1534:10:1534:13 | ...[...] |
 | array_flow.rb:1535:10:1535:10 | a [element] :  | array_flow.rb:1535:10:1535:13 | ...[...] |
 | array_flow.rb:1535:10:1535:10 | a [element] :  | array_flow.rb:1535:10:1535:13 | ...[...] |
-| array_flow.rb:1537:16:1537:28 | call to source :  | array_flow.rb:1538:9:1538:9 | a [element 2] :  |
-| array_flow.rb:1537:16:1537:28 | call to source :  | array_flow.rb:1538:9:1538:9 | a [element 2] :  |
-| array_flow.rb:1537:31:1537:43 | call to source :  | array_flow.rb:1538:9:1538:9 | a [element 3] :  |
-| array_flow.rb:1537:31:1537:43 | call to source :  | array_flow.rb:1538:9:1538:9 | a [element 3] :  |
+| array_flow.rb:1537:5:1537:5 | a [element 2] :  | array_flow.rb:1538:9:1538:9 | a [element 2] :  |
+| array_flow.rb:1537:5:1537:5 | a [element 2] :  | array_flow.rb:1538:9:1538:9 | a [element 2] :  |
+| array_flow.rb:1537:5:1537:5 | a [element 3] :  | array_flow.rb:1538:9:1538:9 | a [element 3] :  |
+| array_flow.rb:1537:5:1537:5 | a [element 3] :  | array_flow.rb:1538:9:1538:9 | a [element 3] :  |
+| array_flow.rb:1537:16:1537:28 | call to source :  | array_flow.rb:1537:5:1537:5 | a [element 2] :  |
+| array_flow.rb:1537:16:1537:28 | call to source :  | array_flow.rb:1537:5:1537:5 | a [element 2] :  |
+| array_flow.rb:1537:31:1537:43 | call to source :  | array_flow.rb:1537:5:1537:5 | a [element 3] :  |
+| array_flow.rb:1537:31:1537:43 | call to source :  | array_flow.rb:1537:5:1537:5 | a [element 3] :  |
+| array_flow.rb:1538:5:1538:5 | b [element] :  | array_flow.rb:1542:10:1542:10 | b [element] :  |
+| array_flow.rb:1538:5:1538:5 | b [element] :  | array_flow.rb:1542:10:1542:10 | b [element] :  |
+| array_flow.rb:1538:5:1538:5 | b [element] :  | array_flow.rb:1543:10:1543:10 | b [element] :  |
+| array_flow.rb:1538:5:1538:5 | b [element] :  | array_flow.rb:1543:10:1543:10 | b [element] :  |
 | array_flow.rb:1538:9:1538:9 | [post] a [element] :  | array_flow.rb:1544:10:1544:10 | a [element] :  |
 | array_flow.rb:1538:9:1538:9 | [post] a [element] :  | array_flow.rb:1544:10:1544:10 | a [element] :  |
 | array_flow.rb:1538:9:1538:9 | [post] a [element] :  | array_flow.rb:1545:10:1545:10 | a [element] :  |
@@ -3183,10 +3958,8 @@ edges
 | array_flow.rb:1538:9:1538:9 | a [element 3] :  | array_flow.rb:1538:9:1541:7 | call to uniq! [element] :  |
 | array_flow.rb:1538:9:1538:9 | a [element 3] :  | array_flow.rb:1538:21:1538:21 | x :  |
 | array_flow.rb:1538:9:1538:9 | a [element 3] :  | array_flow.rb:1538:21:1538:21 | x :  |
-| array_flow.rb:1538:9:1541:7 | call to uniq! [element] :  | array_flow.rb:1542:10:1542:10 | b [element] :  |
-| array_flow.rb:1538:9:1541:7 | call to uniq! [element] :  | array_flow.rb:1542:10:1542:10 | b [element] :  |
-| array_flow.rb:1538:9:1541:7 | call to uniq! [element] :  | array_flow.rb:1543:10:1543:10 | b [element] :  |
-| array_flow.rb:1538:9:1541:7 | call to uniq! [element] :  | array_flow.rb:1543:10:1543:10 | b [element] :  |
+| array_flow.rb:1538:9:1541:7 | call to uniq! [element] :  | array_flow.rb:1538:5:1538:5 | b [element] :  |
+| array_flow.rb:1538:9:1541:7 | call to uniq! [element] :  | array_flow.rb:1538:5:1538:5 | b [element] :  |
 | array_flow.rb:1538:21:1538:21 | x :  | array_flow.rb:1539:14:1539:14 | x |
 | array_flow.rb:1538:21:1538:21 | x :  | array_flow.rb:1539:14:1539:14 | x |
 | array_flow.rb:1542:10:1542:10 | b [element] :  | array_flow.rb:1542:10:1542:13 | ...[...] |
@@ -3197,8 +3970,10 @@ edges
 | array_flow.rb:1544:10:1544:10 | a [element] :  | array_flow.rb:1544:10:1544:13 | ...[...] |
 | array_flow.rb:1545:10:1545:10 | a [element] :  | array_flow.rb:1545:10:1545:13 | ...[...] |
 | array_flow.rb:1545:10:1545:10 | a [element] :  | array_flow.rb:1545:10:1545:13 | ...[...] |
-| array_flow.rb:1549:16:1549:28 | call to source :  | array_flow.rb:1550:5:1550:5 | a [element 2] :  |
-| array_flow.rb:1549:16:1549:28 | call to source :  | array_flow.rb:1550:5:1550:5 | a [element 2] :  |
+| array_flow.rb:1549:5:1549:5 | a [element 2] :  | array_flow.rb:1550:5:1550:5 | a [element 2] :  |
+| array_flow.rb:1549:5:1549:5 | a [element 2] :  | array_flow.rb:1550:5:1550:5 | a [element 2] :  |
+| array_flow.rb:1549:16:1549:28 | call to source :  | array_flow.rb:1549:5:1549:5 | a [element 2] :  |
+| array_flow.rb:1549:16:1549:28 | call to source :  | array_flow.rb:1549:5:1549:5 | a [element 2] :  |
 | array_flow.rb:1550:5:1550:5 | [post] a [element 2] :  | array_flow.rb:1553:10:1553:10 | a [element 2] :  |
 | array_flow.rb:1550:5:1550:5 | [post] a [element 2] :  | array_flow.rb:1553:10:1553:10 | a [element 2] :  |
 | array_flow.rb:1550:5:1550:5 | [post] a [element 5] :  | array_flow.rb:1556:10:1556:10 | a [element 5] :  |
@@ -3211,72 +3986,88 @@ edges
 | array_flow.rb:1553:10:1553:10 | a [element 2] :  | array_flow.rb:1553:10:1553:13 | ...[...] |
 | array_flow.rb:1556:10:1556:10 | a [element 5] :  | array_flow.rb:1556:10:1556:13 | ...[...] |
 | array_flow.rb:1556:10:1556:10 | a [element 5] :  | array_flow.rb:1556:10:1556:13 | ...[...] |
-| array_flow.rb:1560:13:1560:25 | call to source :  | array_flow.rb:1562:9:1562:9 | a [element 1] :  |
-| array_flow.rb:1560:13:1560:25 | call to source :  | array_flow.rb:1562:9:1562:9 | a [element 1] :  |
-| array_flow.rb:1560:13:1560:25 | call to source :  | array_flow.rb:1568:9:1568:9 | a [element 1] :  |
-| array_flow.rb:1560:13:1560:25 | call to source :  | array_flow.rb:1568:9:1568:9 | a [element 1] :  |
-| array_flow.rb:1560:13:1560:25 | call to source :  | array_flow.rb:1572:9:1572:9 | a [element 1] :  |
-| array_flow.rb:1560:13:1560:25 | call to source :  | array_flow.rb:1572:9:1572:9 | a [element 1] :  |
-| array_flow.rb:1560:13:1560:25 | call to source :  | array_flow.rb:1576:9:1576:9 | a [element 1] :  |
-| array_flow.rb:1560:13:1560:25 | call to source :  | array_flow.rb:1576:9:1576:9 | a [element 1] :  |
-| array_flow.rb:1560:31:1560:43 | call to source :  | array_flow.rb:1568:9:1568:9 | a [element 3] :  |
-| array_flow.rb:1560:31:1560:43 | call to source :  | array_flow.rb:1568:9:1568:9 | a [element 3] :  |
-| array_flow.rb:1560:31:1560:43 | call to source :  | array_flow.rb:1572:9:1572:9 | a [element 3] :  |
-| array_flow.rb:1560:31:1560:43 | call to source :  | array_flow.rb:1572:9:1572:9 | a [element 3] :  |
-| array_flow.rb:1560:31:1560:43 | call to source :  | array_flow.rb:1576:9:1576:9 | a [element 3] :  |
-| array_flow.rb:1560:31:1560:43 | call to source :  | array_flow.rb:1576:9:1576:9 | a [element 3] :  |
+| array_flow.rb:1560:5:1560:5 | a [element 1] :  | array_flow.rb:1562:9:1562:9 | a [element 1] :  |
+| array_flow.rb:1560:5:1560:5 | a [element 1] :  | array_flow.rb:1562:9:1562:9 | a [element 1] :  |
+| array_flow.rb:1560:5:1560:5 | a [element 1] :  | array_flow.rb:1568:9:1568:9 | a [element 1] :  |
+| array_flow.rb:1560:5:1560:5 | a [element 1] :  | array_flow.rb:1568:9:1568:9 | a [element 1] :  |
+| array_flow.rb:1560:5:1560:5 | a [element 1] :  | array_flow.rb:1572:9:1572:9 | a [element 1] :  |
+| array_flow.rb:1560:5:1560:5 | a [element 1] :  | array_flow.rb:1572:9:1572:9 | a [element 1] :  |
+| array_flow.rb:1560:5:1560:5 | a [element 1] :  | array_flow.rb:1576:9:1576:9 | a [element 1] :  |
+| array_flow.rb:1560:5:1560:5 | a [element 1] :  | array_flow.rb:1576:9:1576:9 | a [element 1] :  |
+| array_flow.rb:1560:5:1560:5 | a [element 3] :  | array_flow.rb:1568:9:1568:9 | a [element 3] :  |
+| array_flow.rb:1560:5:1560:5 | a [element 3] :  | array_flow.rb:1568:9:1568:9 | a [element 3] :  |
+| array_flow.rb:1560:5:1560:5 | a [element 3] :  | array_flow.rb:1572:9:1572:9 | a [element 3] :  |
+| array_flow.rb:1560:5:1560:5 | a [element 3] :  | array_flow.rb:1572:9:1572:9 | a [element 3] :  |
+| array_flow.rb:1560:5:1560:5 | a [element 3] :  | array_flow.rb:1576:9:1576:9 | a [element 3] :  |
+| array_flow.rb:1560:5:1560:5 | a [element 3] :  | array_flow.rb:1576:9:1576:9 | a [element 3] :  |
+| array_flow.rb:1560:13:1560:25 | call to source :  | array_flow.rb:1560:5:1560:5 | a [element 1] :  |
+| array_flow.rb:1560:13:1560:25 | call to source :  | array_flow.rb:1560:5:1560:5 | a [element 1] :  |
+| array_flow.rb:1560:31:1560:43 | call to source :  | array_flow.rb:1560:5:1560:5 | a [element 3] :  |
+| array_flow.rb:1560:31:1560:43 | call to source :  | array_flow.rb:1560:5:1560:5 | a [element 3] :  |
+| array_flow.rb:1562:5:1562:5 | b [element 1] :  | array_flow.rb:1564:10:1564:10 | b [element 1] :  |
+| array_flow.rb:1562:5:1562:5 | b [element 1] :  | array_flow.rb:1564:10:1564:10 | b [element 1] :  |
+| array_flow.rb:1562:5:1562:5 | b [element 3] :  | array_flow.rb:1566:10:1566:10 | b [element 3] :  |
+| array_flow.rb:1562:5:1562:5 | b [element 3] :  | array_flow.rb:1566:10:1566:10 | b [element 3] :  |
 | array_flow.rb:1562:9:1562:9 | a [element 1] :  | array_flow.rb:1562:9:1562:31 | call to values_at [element 1] :  |
 | array_flow.rb:1562:9:1562:9 | a [element 1] :  | array_flow.rb:1562:9:1562:31 | call to values_at [element 1] :  |
 | array_flow.rb:1562:9:1562:9 | a [element 1] :  | array_flow.rb:1562:9:1562:31 | call to values_at [element 3] :  |
 | array_flow.rb:1562:9:1562:9 | a [element 1] :  | array_flow.rb:1562:9:1562:31 | call to values_at [element 3] :  |
-| array_flow.rb:1562:9:1562:31 | call to values_at [element 1] :  | array_flow.rb:1564:10:1564:10 | b [element 1] :  |
-| array_flow.rb:1562:9:1562:31 | call to values_at [element 1] :  | array_flow.rb:1564:10:1564:10 | b [element 1] :  |
-| array_flow.rb:1562:9:1562:31 | call to values_at [element 3] :  | array_flow.rb:1566:10:1566:10 | b [element 3] :  |
-| array_flow.rb:1562:9:1562:31 | call to values_at [element 3] :  | array_flow.rb:1566:10:1566:10 | b [element 3] :  |
+| array_flow.rb:1562:9:1562:31 | call to values_at [element 1] :  | array_flow.rb:1562:5:1562:5 | b [element 1] :  |
+| array_flow.rb:1562:9:1562:31 | call to values_at [element 1] :  | array_flow.rb:1562:5:1562:5 | b [element 1] :  |
+| array_flow.rb:1562:9:1562:31 | call to values_at [element 3] :  | array_flow.rb:1562:5:1562:5 | b [element 3] :  |
+| array_flow.rb:1562:9:1562:31 | call to values_at [element 3] :  | array_flow.rb:1562:5:1562:5 | b [element 3] :  |
 | array_flow.rb:1564:10:1564:10 | b [element 1] :  | array_flow.rb:1564:10:1564:13 | ...[...] |
 | array_flow.rb:1564:10:1564:10 | b [element 1] :  | array_flow.rb:1564:10:1564:13 | ...[...] |
 | array_flow.rb:1566:10:1566:10 | b [element 3] :  | array_flow.rb:1566:10:1566:13 | ...[...] |
 | array_flow.rb:1566:10:1566:10 | b [element 3] :  | array_flow.rb:1566:10:1566:13 | ...[...] |
+| array_flow.rb:1568:5:1568:5 | b [element] :  | array_flow.rb:1569:10:1569:10 | b [element] :  |
+| array_flow.rb:1568:5:1568:5 | b [element] :  | array_flow.rb:1569:10:1569:10 | b [element] :  |
+| array_flow.rb:1568:5:1568:5 | b [element] :  | array_flow.rb:1570:10:1570:10 | b [element] :  |
+| array_flow.rb:1568:5:1568:5 | b [element] :  | array_flow.rb:1570:10:1570:10 | b [element] :  |
 | array_flow.rb:1568:9:1568:9 | a [element 1] :  | array_flow.rb:1568:9:1568:25 | call to values_at [element] :  |
 | array_flow.rb:1568:9:1568:9 | a [element 1] :  | array_flow.rb:1568:9:1568:25 | call to values_at [element] :  |
 | array_flow.rb:1568:9:1568:9 | a [element 3] :  | array_flow.rb:1568:9:1568:25 | call to values_at [element] :  |
 | array_flow.rb:1568:9:1568:9 | a [element 3] :  | array_flow.rb:1568:9:1568:25 | call to values_at [element] :  |
-| array_flow.rb:1568:9:1568:25 | call to values_at [element] :  | array_flow.rb:1569:10:1569:10 | b [element] :  |
-| array_flow.rb:1568:9:1568:25 | call to values_at [element] :  | array_flow.rb:1569:10:1569:10 | b [element] :  |
-| array_flow.rb:1568:9:1568:25 | call to values_at [element] :  | array_flow.rb:1570:10:1570:10 | b [element] :  |
-| array_flow.rb:1568:9:1568:25 | call to values_at [element] :  | array_flow.rb:1570:10:1570:10 | b [element] :  |
+| array_flow.rb:1568:9:1568:25 | call to values_at [element] :  | array_flow.rb:1568:5:1568:5 | b [element] :  |
+| array_flow.rb:1568:9:1568:25 | call to values_at [element] :  | array_flow.rb:1568:5:1568:5 | b [element] :  |
 | array_flow.rb:1569:10:1569:10 | b [element] :  | array_flow.rb:1569:10:1569:13 | ...[...] |
 | array_flow.rb:1569:10:1569:10 | b [element] :  | array_flow.rb:1569:10:1569:13 | ...[...] |
 | array_flow.rb:1570:10:1570:10 | b [element] :  | array_flow.rb:1570:10:1570:13 | ...[...] |
 | array_flow.rb:1570:10:1570:10 | b [element] :  | array_flow.rb:1570:10:1570:13 | ...[...] |
+| array_flow.rb:1572:5:1572:5 | b [element] :  | array_flow.rb:1573:10:1573:10 | b [element] :  |
+| array_flow.rb:1572:5:1572:5 | b [element] :  | array_flow.rb:1573:10:1573:10 | b [element] :  |
+| array_flow.rb:1572:5:1572:5 | b [element] :  | array_flow.rb:1574:10:1574:10 | b [element] :  |
+| array_flow.rb:1572:5:1572:5 | b [element] :  | array_flow.rb:1574:10:1574:10 | b [element] :  |
 | array_flow.rb:1572:9:1572:9 | a [element 1] :  | array_flow.rb:1572:9:1572:26 | call to values_at [element] :  |
 | array_flow.rb:1572:9:1572:9 | a [element 1] :  | array_flow.rb:1572:9:1572:26 | call to values_at [element] :  |
 | array_flow.rb:1572:9:1572:9 | a [element 3] :  | array_flow.rb:1572:9:1572:26 | call to values_at [element] :  |
 | array_flow.rb:1572:9:1572:9 | a [element 3] :  | array_flow.rb:1572:9:1572:26 | call to values_at [element] :  |
-| array_flow.rb:1572:9:1572:26 | call to values_at [element] :  | array_flow.rb:1573:10:1573:10 | b [element] :  |
-| array_flow.rb:1572:9:1572:26 | call to values_at [element] :  | array_flow.rb:1573:10:1573:10 | b [element] :  |
-| array_flow.rb:1572:9:1572:26 | call to values_at [element] :  | array_flow.rb:1574:10:1574:10 | b [element] :  |
-| array_flow.rb:1572:9:1572:26 | call to values_at [element] :  | array_flow.rb:1574:10:1574:10 | b [element] :  |
+| array_flow.rb:1572:9:1572:26 | call to values_at [element] :  | array_flow.rb:1572:5:1572:5 | b [element] :  |
+| array_flow.rb:1572:9:1572:26 | call to values_at [element] :  | array_flow.rb:1572:5:1572:5 | b [element] :  |
 | array_flow.rb:1573:10:1573:10 | b [element] :  | array_flow.rb:1573:10:1573:13 | ...[...] |
 | array_flow.rb:1573:10:1573:10 | b [element] :  | array_flow.rb:1573:10:1573:13 | ...[...] |
 | array_flow.rb:1574:10:1574:10 | b [element] :  | array_flow.rb:1574:10:1574:13 | ...[...] |
 | array_flow.rb:1574:10:1574:10 | b [element] :  | array_flow.rb:1574:10:1574:13 | ...[...] |
+| array_flow.rb:1576:5:1576:5 | b [element 1] :  | array_flow.rb:1578:10:1578:10 | b [element 1] :  |
+| array_flow.rb:1576:5:1576:5 | b [element 1] :  | array_flow.rb:1578:10:1578:10 | b [element 1] :  |
+| array_flow.rb:1576:5:1576:5 | b [element] :  | array_flow.rb:1577:10:1577:10 | b [element] :  |
+| array_flow.rb:1576:5:1576:5 | b [element] :  | array_flow.rb:1577:10:1577:10 | b [element] :  |
+| array_flow.rb:1576:5:1576:5 | b [element] :  | array_flow.rb:1578:10:1578:10 | b [element] :  |
+| array_flow.rb:1576:5:1576:5 | b [element] :  | array_flow.rb:1578:10:1578:10 | b [element] :  |
+| array_flow.rb:1576:5:1576:5 | b [element] :  | array_flow.rb:1579:10:1579:10 | b [element] :  |
+| array_flow.rb:1576:5:1576:5 | b [element] :  | array_flow.rb:1579:10:1579:10 | b [element] :  |
+| array_flow.rb:1576:5:1576:5 | b [element] :  | array_flow.rb:1580:10:1580:10 | b [element] :  |
+| array_flow.rb:1576:5:1576:5 | b [element] :  | array_flow.rb:1580:10:1580:10 | b [element] :  |
 | array_flow.rb:1576:9:1576:9 | a [element 1] :  | array_flow.rb:1576:9:1576:28 | call to values_at [element] :  |
 | array_flow.rb:1576:9:1576:9 | a [element 1] :  | array_flow.rb:1576:9:1576:28 | call to values_at [element] :  |
 | array_flow.rb:1576:9:1576:9 | a [element 3] :  | array_flow.rb:1576:9:1576:28 | call to values_at [element 1] :  |
 | array_flow.rb:1576:9:1576:9 | a [element 3] :  | array_flow.rb:1576:9:1576:28 | call to values_at [element 1] :  |
 | array_flow.rb:1576:9:1576:9 | a [element 3] :  | array_flow.rb:1576:9:1576:28 | call to values_at [element] :  |
 | array_flow.rb:1576:9:1576:9 | a [element 3] :  | array_flow.rb:1576:9:1576:28 | call to values_at [element] :  |
-| array_flow.rb:1576:9:1576:28 | call to values_at [element 1] :  | array_flow.rb:1578:10:1578:10 | b [element 1] :  |
-| array_flow.rb:1576:9:1576:28 | call to values_at [element 1] :  | array_flow.rb:1578:10:1578:10 | b [element 1] :  |
-| array_flow.rb:1576:9:1576:28 | call to values_at [element] :  | array_flow.rb:1577:10:1577:10 | b [element] :  |
-| array_flow.rb:1576:9:1576:28 | call to values_at [element] :  | array_flow.rb:1577:10:1577:10 | b [element] :  |
-| array_flow.rb:1576:9:1576:28 | call to values_at [element] :  | array_flow.rb:1578:10:1578:10 | b [element] :  |
-| array_flow.rb:1576:9:1576:28 | call to values_at [element] :  | array_flow.rb:1578:10:1578:10 | b [element] :  |
-| array_flow.rb:1576:9:1576:28 | call to values_at [element] :  | array_flow.rb:1579:10:1579:10 | b [element] :  |
-| array_flow.rb:1576:9:1576:28 | call to values_at [element] :  | array_flow.rb:1579:10:1579:10 | b [element] :  |
-| array_flow.rb:1576:9:1576:28 | call to values_at [element] :  | array_flow.rb:1580:10:1580:10 | b [element] :  |
-| array_flow.rb:1576:9:1576:28 | call to values_at [element] :  | array_flow.rb:1580:10:1580:10 | b [element] :  |
+| array_flow.rb:1576:9:1576:28 | call to values_at [element 1] :  | array_flow.rb:1576:5:1576:5 | b [element 1] :  |
+| array_flow.rb:1576:9:1576:28 | call to values_at [element 1] :  | array_flow.rb:1576:5:1576:5 | b [element 1] :  |
+| array_flow.rb:1576:9:1576:28 | call to values_at [element] :  | array_flow.rb:1576:5:1576:5 | b [element] :  |
+| array_flow.rb:1576:9:1576:28 | call to values_at [element] :  | array_flow.rb:1576:5:1576:5 | b [element] :  |
 | array_flow.rb:1577:10:1577:10 | b [element] :  | array_flow.rb:1577:10:1577:13 | ...[...] |
 | array_flow.rb:1577:10:1577:10 | b [element] :  | array_flow.rb:1577:10:1577:13 | ...[...] |
 | array_flow.rb:1578:10:1578:10 | b [element 1] :  | array_flow.rb:1578:10:1578:13 | ...[...] |
@@ -3287,26 +4078,38 @@ edges
 | array_flow.rb:1579:10:1579:10 | b [element] :  | array_flow.rb:1579:10:1579:13 | ...[...] |
 | array_flow.rb:1580:10:1580:10 | b [element] :  | array_flow.rb:1580:10:1580:13 | ...[...] |
 | array_flow.rb:1580:10:1580:10 | b [element] :  | array_flow.rb:1580:10:1580:13 | ...[...] |
-| array_flow.rb:1584:16:1584:28 | call to source :  | array_flow.rb:1587:9:1587:9 | a [element 2] :  |
-| array_flow.rb:1584:16:1584:28 | call to source :  | array_flow.rb:1587:9:1587:9 | a [element 2] :  |
-| array_flow.rb:1584:16:1584:28 | call to source :  | array_flow.rb:1592:5:1592:5 | a [element 2] :  |
-| array_flow.rb:1584:16:1584:28 | call to source :  | array_flow.rb:1592:5:1592:5 | a [element 2] :  |
-| array_flow.rb:1585:13:1585:25 | call to source :  | array_flow.rb:1587:15:1587:15 | b [element 1] :  |
-| array_flow.rb:1585:13:1585:25 | call to source :  | array_flow.rb:1587:15:1587:15 | b [element 1] :  |
-| array_flow.rb:1585:13:1585:25 | call to source :  | array_flow.rb:1592:11:1592:11 | b [element 1] :  |
-| array_flow.rb:1585:13:1585:25 | call to source :  | array_flow.rb:1592:11:1592:11 | b [element 1] :  |
-| array_flow.rb:1586:10:1586:22 | call to source :  | array_flow.rb:1587:18:1587:18 | c [element 0] :  |
-| array_flow.rb:1586:10:1586:22 | call to source :  | array_flow.rb:1587:18:1587:18 | c [element 0] :  |
-| array_flow.rb:1586:10:1586:22 | call to source :  | array_flow.rb:1592:14:1592:14 | c [element 0] :  |
-| array_flow.rb:1586:10:1586:22 | call to source :  | array_flow.rb:1592:14:1592:14 | c [element 0] :  |
+| array_flow.rb:1584:5:1584:5 | a [element 2] :  | array_flow.rb:1587:9:1587:9 | a [element 2] :  |
+| array_flow.rb:1584:5:1584:5 | a [element 2] :  | array_flow.rb:1587:9:1587:9 | a [element 2] :  |
+| array_flow.rb:1584:5:1584:5 | a [element 2] :  | array_flow.rb:1592:5:1592:5 | a [element 2] :  |
+| array_flow.rb:1584:5:1584:5 | a [element 2] :  | array_flow.rb:1592:5:1592:5 | a [element 2] :  |
+| array_flow.rb:1584:16:1584:28 | call to source :  | array_flow.rb:1584:5:1584:5 | a [element 2] :  |
+| array_flow.rb:1584:16:1584:28 | call to source :  | array_flow.rb:1584:5:1584:5 | a [element 2] :  |
+| array_flow.rb:1585:5:1585:5 | b [element 1] :  | array_flow.rb:1587:15:1587:15 | b [element 1] :  |
+| array_flow.rb:1585:5:1585:5 | b [element 1] :  | array_flow.rb:1587:15:1587:15 | b [element 1] :  |
+| array_flow.rb:1585:5:1585:5 | b [element 1] :  | array_flow.rb:1592:11:1592:11 | b [element 1] :  |
+| array_flow.rb:1585:5:1585:5 | b [element 1] :  | array_flow.rb:1592:11:1592:11 | b [element 1] :  |
+| array_flow.rb:1585:13:1585:25 | call to source :  | array_flow.rb:1585:5:1585:5 | b [element 1] :  |
+| array_flow.rb:1585:13:1585:25 | call to source :  | array_flow.rb:1585:5:1585:5 | b [element 1] :  |
+| array_flow.rb:1586:5:1586:5 | c [element 0] :  | array_flow.rb:1587:18:1587:18 | c [element 0] :  |
+| array_flow.rb:1586:5:1586:5 | c [element 0] :  | array_flow.rb:1587:18:1587:18 | c [element 0] :  |
+| array_flow.rb:1586:5:1586:5 | c [element 0] :  | array_flow.rb:1592:14:1592:14 | c [element 0] :  |
+| array_flow.rb:1586:5:1586:5 | c [element 0] :  | array_flow.rb:1592:14:1592:14 | c [element 0] :  |
+| array_flow.rb:1586:10:1586:22 | call to source :  | array_flow.rb:1586:5:1586:5 | c [element 0] :  |
+| array_flow.rb:1586:10:1586:22 | call to source :  | array_flow.rb:1586:5:1586:5 | c [element 0] :  |
+| array_flow.rb:1587:5:1587:5 | d [element 0, element 2] :  | array_flow.rb:1589:10:1589:10 | d [element 0, element 2] :  |
+| array_flow.rb:1587:5:1587:5 | d [element 0, element 2] :  | array_flow.rb:1589:10:1589:10 | d [element 0, element 2] :  |
+| array_flow.rb:1587:5:1587:5 | d [element 1, element 1] :  | array_flow.rb:1590:10:1590:10 | d [element 1, element 1] :  |
+| array_flow.rb:1587:5:1587:5 | d [element 1, element 1] :  | array_flow.rb:1590:10:1590:10 | d [element 1, element 1] :  |
+| array_flow.rb:1587:5:1587:5 | d [element 2, element 0] :  | array_flow.rb:1591:10:1591:10 | d [element 2, element 0] :  |
+| array_flow.rb:1587:5:1587:5 | d [element 2, element 0] :  | array_flow.rb:1591:10:1591:10 | d [element 2, element 0] :  |
 | array_flow.rb:1587:9:1587:9 | a [element 2] :  | array_flow.rb:1587:9:1587:19 | call to zip [element 2, element 0] :  |
 | array_flow.rb:1587:9:1587:9 | a [element 2] :  | array_flow.rb:1587:9:1587:19 | call to zip [element 2, element 0] :  |
-| array_flow.rb:1587:9:1587:19 | call to zip [element 0, element 2] :  | array_flow.rb:1589:10:1589:10 | d [element 0, element 2] :  |
-| array_flow.rb:1587:9:1587:19 | call to zip [element 0, element 2] :  | array_flow.rb:1589:10:1589:10 | d [element 0, element 2] :  |
-| array_flow.rb:1587:9:1587:19 | call to zip [element 1, element 1] :  | array_flow.rb:1590:10:1590:10 | d [element 1, element 1] :  |
-| array_flow.rb:1587:9:1587:19 | call to zip [element 1, element 1] :  | array_flow.rb:1590:10:1590:10 | d [element 1, element 1] :  |
-| array_flow.rb:1587:9:1587:19 | call to zip [element 2, element 0] :  | array_flow.rb:1591:10:1591:10 | d [element 2, element 0] :  |
-| array_flow.rb:1587:9:1587:19 | call to zip [element 2, element 0] :  | array_flow.rb:1591:10:1591:10 | d [element 2, element 0] :  |
+| array_flow.rb:1587:9:1587:19 | call to zip [element 0, element 2] :  | array_flow.rb:1587:5:1587:5 | d [element 0, element 2] :  |
+| array_flow.rb:1587:9:1587:19 | call to zip [element 0, element 2] :  | array_flow.rb:1587:5:1587:5 | d [element 0, element 2] :  |
+| array_flow.rb:1587:9:1587:19 | call to zip [element 1, element 1] :  | array_flow.rb:1587:5:1587:5 | d [element 1, element 1] :  |
+| array_flow.rb:1587:9:1587:19 | call to zip [element 1, element 1] :  | array_flow.rb:1587:5:1587:5 | d [element 1, element 1] :  |
+| array_flow.rb:1587:9:1587:19 | call to zip [element 2, element 0] :  | array_flow.rb:1587:5:1587:5 | d [element 2, element 0] :  |
+| array_flow.rb:1587:9:1587:19 | call to zip [element 2, element 0] :  | array_flow.rb:1587:5:1587:5 | d [element 2, element 0] :  |
 | array_flow.rb:1587:15:1587:15 | b [element 1] :  | array_flow.rb:1587:9:1587:19 | call to zip [element 1, element 1] :  |
 | array_flow.rb:1587:15:1587:15 | b [element 1] :  | array_flow.rb:1587:9:1587:19 | call to zip [element 1, element 1] :  |
 | array_flow.rb:1587:18:1587:18 | c [element 0] :  | array_flow.rb:1587:9:1587:19 | call to zip [element 0, element 2] :  |
@@ -3341,18 +4144,24 @@ edges
 | array_flow.rb:1594:14:1594:14 | x [element 1] :  | array_flow.rb:1594:14:1594:17 | ...[...] |
 | array_flow.rb:1595:14:1595:14 | x [element 2] :  | array_flow.rb:1595:14:1595:17 | ...[...] |
 | array_flow.rb:1595:14:1595:14 | x [element 2] :  | array_flow.rb:1595:14:1595:17 | ...[...] |
-| array_flow.rb:1600:16:1600:28 | call to source :  | array_flow.rb:1602:9:1602:9 | a [element 2] :  |
-| array_flow.rb:1600:16:1600:28 | call to source :  | array_flow.rb:1602:9:1602:9 | a [element 2] :  |
-| array_flow.rb:1601:13:1601:25 | call to source :  | array_flow.rb:1602:13:1602:13 | b [element 1] :  |
-| array_flow.rb:1601:13:1601:25 | call to source :  | array_flow.rb:1602:13:1602:13 | b [element 1] :  |
+| array_flow.rb:1600:5:1600:5 | a [element 2] :  | array_flow.rb:1602:9:1602:9 | a [element 2] :  |
+| array_flow.rb:1600:5:1600:5 | a [element 2] :  | array_flow.rb:1602:9:1602:9 | a [element 2] :  |
+| array_flow.rb:1600:16:1600:28 | call to source :  | array_flow.rb:1600:5:1600:5 | a [element 2] :  |
+| array_flow.rb:1600:16:1600:28 | call to source :  | array_flow.rb:1600:5:1600:5 | a [element 2] :  |
+| array_flow.rb:1601:5:1601:5 | b [element 1] :  | array_flow.rb:1602:13:1602:13 | b [element 1] :  |
+| array_flow.rb:1601:5:1601:5 | b [element 1] :  | array_flow.rb:1602:13:1602:13 | b [element 1] :  |
+| array_flow.rb:1601:13:1601:25 | call to source :  | array_flow.rb:1601:5:1601:5 | b [element 1] :  |
+| array_flow.rb:1601:13:1601:25 | call to source :  | array_flow.rb:1601:5:1601:5 | b [element 1] :  |
+| array_flow.rb:1602:5:1602:5 | c [element] :  | array_flow.rb:1603:10:1603:10 | c [element] :  |
+| array_flow.rb:1602:5:1602:5 | c [element] :  | array_flow.rb:1603:10:1603:10 | c [element] :  |
+| array_flow.rb:1602:5:1602:5 | c [element] :  | array_flow.rb:1604:10:1604:10 | c [element] :  |
+| array_flow.rb:1602:5:1602:5 | c [element] :  | array_flow.rb:1604:10:1604:10 | c [element] :  |
+| array_flow.rb:1602:5:1602:5 | c [element] :  | array_flow.rb:1605:10:1605:10 | c [element] :  |
+| array_flow.rb:1602:5:1602:5 | c [element] :  | array_flow.rb:1605:10:1605:10 | c [element] :  |
 | array_flow.rb:1602:9:1602:9 | a [element 2] :  | array_flow.rb:1602:9:1602:13 | ... \| ... [element] :  |
 | array_flow.rb:1602:9:1602:9 | a [element 2] :  | array_flow.rb:1602:9:1602:13 | ... \| ... [element] :  |
-| array_flow.rb:1602:9:1602:13 | ... \| ... [element] :  | array_flow.rb:1603:10:1603:10 | c [element] :  |
-| array_flow.rb:1602:9:1602:13 | ... \| ... [element] :  | array_flow.rb:1603:10:1603:10 | c [element] :  |
-| array_flow.rb:1602:9:1602:13 | ... \| ... [element] :  | array_flow.rb:1604:10:1604:10 | c [element] :  |
-| array_flow.rb:1602:9:1602:13 | ... \| ... [element] :  | array_flow.rb:1604:10:1604:10 | c [element] :  |
-| array_flow.rb:1602:9:1602:13 | ... \| ... [element] :  | array_flow.rb:1605:10:1605:10 | c [element] :  |
-| array_flow.rb:1602:9:1602:13 | ... \| ... [element] :  | array_flow.rb:1605:10:1605:10 | c [element] :  |
+| array_flow.rb:1602:9:1602:13 | ... \| ... [element] :  | array_flow.rb:1602:5:1602:5 | c [element] :  |
+| array_flow.rb:1602:9:1602:13 | ... \| ... [element] :  | array_flow.rb:1602:5:1602:5 | c [element] :  |
 | array_flow.rb:1602:13:1602:13 | b [element 1] :  | array_flow.rb:1602:9:1602:13 | ... \| ... [element] :  |
 | array_flow.rb:1602:13:1602:13 | b [element 1] :  | array_flow.rb:1602:9:1602:13 | ... \| ... [element] :  |
 | array_flow.rb:1603:10:1603:10 | c [element] :  | array_flow.rb:1603:10:1603:13 | ...[...] |
@@ -3432,6 +4241,8 @@ edges
 | array_flow.rb:1631:10:1631:10 | a [element] :  | array_flow.rb:1631:10:1631:15 | ...[...] |
 | array_flow.rb:1631:10:1631:10 | a [element] :  | array_flow.rb:1631:10:1631:15 | ...[...] |
 nodes
+| array_flow.rb:2:5:2:5 | a [element 0] :  | semmle.label | a [element 0] :  |
+| array_flow.rb:2:5:2:5 | a [element 0] :  | semmle.label | a [element 0] :  |
 | array_flow.rb:2:9:2:20 | * ... [element 0] :  | semmle.label | * ... [element 0] :  |
 | array_flow.rb:2:9:2:20 | * ... [element 0] :  | semmle.label | * ... [element 0] :  |
 | array_flow.rb:2:10:2:20 | call to source :  | semmle.label | call to source :  |
@@ -3444,6 +4255,8 @@ nodes
 | array_flow.rb:5:10:5:10 | a [element 0] :  | semmle.label | a [element 0] :  |
 | array_flow.rb:5:10:5:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:5:10:5:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:9:5:9:5 | a [element 1] :  | semmle.label | a [element 1] :  |
+| array_flow.rb:9:5:9:5 | a [element 1] :  | semmle.label | a [element 1] :  |
 | array_flow.rb:9:13:9:21 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:9:13:9:21 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:11:10:11:10 | a [element 1] :  | semmle.label | a [element 1] :  |
@@ -3454,6 +4267,8 @@ nodes
 | array_flow.rb:13:10:13:10 | a [element 1] :  | semmle.label | a [element 1] :  |
 | array_flow.rb:13:10:13:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:13:10:13:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:17:5:17:5 | a [element] :  | semmle.label | a [element] :  |
+| array_flow.rb:17:5:17:5 | a [element] :  | semmle.label | a [element] :  |
 | array_flow.rb:17:9:17:33 | call to new [element] :  | semmle.label | call to new [element] :  |
 | array_flow.rb:17:9:17:33 | call to new [element] :  | semmle.label | call to new [element] :  |
 | array_flow.rb:17:22:17:32 | call to source :  | semmle.label | call to source :  |
@@ -3466,6 +4281,8 @@ nodes
 | array_flow.rb:19:10:19:10 | a [element] :  | semmle.label | a [element] :  |
 | array_flow.rb:19:10:19:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:19:10:19:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:21:5:21:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:21:5:21:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:21:9:21:20 | call to new [element] :  | semmle.label | call to new [element] :  |
 | array_flow.rb:21:9:21:20 | call to new [element] :  | semmle.label | call to new [element] :  |
 | array_flow.rb:21:19:21:19 | a [element] :  | semmle.label | a [element] :  |
@@ -3478,6 +4295,8 @@ nodes
 | array_flow.rb:23:10:23:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:23:10:23:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:23:10:23:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:25:5:25:5 | c [element] :  | semmle.label | c [element] :  |
+| array_flow.rb:25:5:25:5 | c [element] :  | semmle.label | c [element] :  |
 | array_flow.rb:25:9:27:7 | call to new [element] :  | semmle.label | call to new [element] :  |
 | array_flow.rb:25:9:27:7 | call to new [element] :  | semmle.label | call to new [element] :  |
 | array_flow.rb:26:9:26:19 | call to source :  | semmle.label | call to source :  |
@@ -3490,8 +4309,12 @@ nodes
 | array_flow.rb:29:10:29:10 | c [element] :  | semmle.label | c [element] :  |
 | array_flow.rb:29:10:29:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:29:10:29:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:33:5:33:5 | a [element 0] :  | semmle.label | a [element 0] :  |
+| array_flow.rb:33:5:33:5 | a [element 0] :  | semmle.label | a [element 0] :  |
 | array_flow.rb:33:10:33:18 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:33:10:33:18 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:34:5:34:5 | b [element 0] :  | semmle.label | b [element 0] :  |
+| array_flow.rb:34:5:34:5 | b [element 0] :  | semmle.label | b [element 0] :  |
 | array_flow.rb:34:9:34:28 | call to try_convert [element 0] :  | semmle.label | call to try_convert [element 0] :  |
 | array_flow.rb:34:9:34:28 | call to try_convert [element 0] :  | semmle.label | call to try_convert [element 0] :  |
 | array_flow.rb:34:27:34:27 | a [element 0] :  | semmle.label | a [element 0] :  |
@@ -3500,10 +4323,16 @@ nodes
 | array_flow.rb:35:10:35:10 | b [element 0] :  | semmle.label | b [element 0] :  |
 | array_flow.rb:35:10:35:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:35:10:35:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:40:5:40:5 | a [element 0] :  | semmle.label | a [element 0] :  |
+| array_flow.rb:40:5:40:5 | a [element 0] :  | semmle.label | a [element 0] :  |
 | array_flow.rb:40:10:40:20 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:40:10:40:20 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:41:5:41:5 | b [element 2] :  | semmle.label | b [element 2] :  |
+| array_flow.rb:41:5:41:5 | b [element 2] :  | semmle.label | b [element 2] :  |
 | array_flow.rb:41:16:41:26 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:41:16:41:26 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:42:5:42:5 | c [element] :  | semmle.label | c [element] :  |
+| array_flow.rb:42:5:42:5 | c [element] :  | semmle.label | c [element] :  |
 | array_flow.rb:42:9:42:9 | a [element 0] :  | semmle.label | a [element 0] :  |
 | array_flow.rb:42:9:42:9 | a [element 0] :  | semmle.label | a [element 0] :  |
 | array_flow.rb:42:9:42:13 | ... & ... [element] :  | semmle.label | ... & ... [element] :  |
@@ -3518,8 +4347,12 @@ nodes
 | array_flow.rb:44:10:44:10 | c [element] :  | semmle.label | c [element] :  |
 | array_flow.rb:44:10:44:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:44:10:44:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:48:5:48:5 | a [element 0] :  | semmle.label | a [element 0] :  |
+| array_flow.rb:48:5:48:5 | a [element 0] :  | semmle.label | a [element 0] :  |
 | array_flow.rb:48:10:48:18 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:48:10:48:18 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:49:5:49:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:49:5:49:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:49:9:49:9 | a [element 0] :  | semmle.label | a [element 0] :  |
 | array_flow.rb:49:9:49:9 | a [element 0] :  | semmle.label | a [element 0] :  |
 | array_flow.rb:49:9:49:13 | ... * ... [element] :  | semmle.label | ... * ... [element] :  |
@@ -3532,10 +4365,18 @@ nodes
 | array_flow.rb:51:10:51:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:51:10:51:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:51:10:51:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:55:5:55:5 | a [element 0] :  | semmle.label | a [element 0] :  |
+| array_flow.rb:55:5:55:5 | a [element 0] :  | semmle.label | a [element 0] :  |
 | array_flow.rb:55:10:55:20 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:55:10:55:20 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:56:5:56:5 | b [element 1] :  | semmle.label | b [element 1] :  |
+| array_flow.rb:56:5:56:5 | b [element 1] :  | semmle.label | b [element 1] :  |
 | array_flow.rb:56:13:56:23 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:56:13:56:23 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:57:5:57:5 | c [element 0] :  | semmle.label | c [element 0] :  |
+| array_flow.rb:57:5:57:5 | c [element 0] :  | semmle.label | c [element 0] :  |
+| array_flow.rb:57:5:57:5 | c [element] :  | semmle.label | c [element] :  |
+| array_flow.rb:57:5:57:5 | c [element] :  | semmle.label | c [element] :  |
 | array_flow.rb:57:9:57:9 | a [element 0] :  | semmle.label | a [element 0] :  |
 | array_flow.rb:57:9:57:9 | a [element 0] :  | semmle.label | a [element 0] :  |
 | array_flow.rb:57:9:57:13 | ... + ... [element 0] :  | semmle.label | ... + ... [element 0] :  |
@@ -3554,8 +4395,12 @@ nodes
 | array_flow.rb:59:10:59:10 | c [element] :  | semmle.label | c [element] :  |
 | array_flow.rb:59:10:59:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:59:10:59:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:63:5:63:5 | a [element 0] :  | semmle.label | a [element 0] :  |
+| array_flow.rb:63:5:63:5 | a [element 0] :  | semmle.label | a [element 0] :  |
 | array_flow.rb:63:10:63:20 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:63:10:63:20 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:65:5:65:5 | c [element] :  | semmle.label | c [element] :  |
+| array_flow.rb:65:5:65:5 | c [element] :  | semmle.label | c [element] :  |
 | array_flow.rb:65:9:65:9 | a [element 0] :  | semmle.label | a [element 0] :  |
 | array_flow.rb:65:9:65:9 | a [element 0] :  | semmle.label | a [element 0] :  |
 | array_flow.rb:65:9:65:13 | ... - ... [element] :  | semmle.label | ... - ... [element] :  |
@@ -3568,8 +4413,15 @@ nodes
 | array_flow.rb:67:10:67:10 | c [element] :  | semmle.label | c [element] :  |
 | array_flow.rb:67:10:67:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:67:10:67:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:71:5:71:5 | a [element 0] :  | semmle.label | a [element 0] :  |
+| array_flow.rb:71:5:71:5 | a [element 0] :  | semmle.label | a [element 0] :  |
 | array_flow.rb:71:10:71:20 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:71:10:71:20 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:72:5:72:5 | b :  | semmle.label | b :  |
+| array_flow.rb:72:5:72:5 | b [element 0] :  | semmle.label | b [element 0] :  |
+| array_flow.rb:72:5:72:5 | b [element 0] :  | semmle.label | b [element 0] :  |
+| array_flow.rb:72:5:72:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:72:5:72:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:72:9:72:9 | [post] a [element] :  | semmle.label | [post] a [element] :  |
 | array_flow.rb:72:9:72:9 | [post] a [element] :  | semmle.label | [post] a [element] :  |
 | array_flow.rb:72:9:72:9 | a [element 0] :  | semmle.label | a [element 0] :  |
@@ -3602,14 +4454,24 @@ nodes
 | array_flow.rb:76:10:76:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:76:10:76:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:76:10:76:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:80:5:80:5 | a [element 1] :  | semmle.label | a [element 1] :  |
+| array_flow.rb:80:5:80:5 | a [element 1] :  | semmle.label | a [element 1] :  |
 | array_flow.rb:80:13:80:21 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:80:13:80:21 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:81:8:81:8 | c :  | semmle.label | c :  |
+| array_flow.rb:81:8:81:8 | c :  | semmle.label | c :  |
+| array_flow.rb:81:15:81:15 | __synth__0 [element 1] :  | semmle.label | __synth__0 [element 1] :  |
+| array_flow.rb:81:15:81:15 | __synth__0 [element 1] :  | semmle.label | __synth__0 [element 1] :  |
 | array_flow.rb:81:15:81:15 | a [element 1] :  | semmle.label | a [element 1] :  |
 | array_flow.rb:81:15:81:15 | a [element 1] :  | semmle.label | a [element 1] :  |
 | array_flow.rb:83:10:83:10 | c | semmle.label | c |
 | array_flow.rb:83:10:83:10 | c | semmle.label | c |
+| array_flow.rb:88:5:88:5 | a [element 1] :  | semmle.label | a [element 1] :  |
+| array_flow.rb:88:5:88:5 | a [element 1] :  | semmle.label | a [element 1] :  |
 | array_flow.rb:88:13:88:22 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:88:13:88:22 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:89:5:89:5 | b [element 1] :  | semmle.label | b [element 1] :  |
+| array_flow.rb:89:5:89:5 | b [element 1] :  | semmle.label | b [element 1] :  |
 | array_flow.rb:89:9:89:9 | a [element 1] :  | semmle.label | a [element 1] :  |
 | array_flow.rb:89:9:89:9 | a [element 1] :  | semmle.label | a [element 1] :  |
 | array_flow.rb:89:9:89:15 | ...[...] [element 1] :  | semmle.label | ...[...] [element 1] :  |
@@ -3622,8 +4484,12 @@ nodes
 | array_flow.rb:92:10:92:10 | b [element 1] :  | semmle.label | b [element 1] :  |
 | array_flow.rb:92:10:92:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:92:10:92:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:96:5:96:5 | a [element 1] :  | semmle.label | a [element 1] :  |
+| array_flow.rb:96:5:96:5 | a [element 1] :  | semmle.label | a [element 1] :  |
 | array_flow.rb:96:13:96:22 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:96:13:96:22 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:97:5:97:5 | b [element 1] :  | semmle.label | b [element 1] :  |
+| array_flow.rb:97:5:97:5 | b [element 1] :  | semmle.label | b [element 1] :  |
 | array_flow.rb:97:9:97:9 | a [element 1] :  | semmle.label | a [element 1] :  |
 | array_flow.rb:97:9:97:9 | a [element 1] :  | semmle.label | a [element 1] :  |
 | array_flow.rb:97:9:97:15 | ...[...] [element 1] :  | semmle.label | ...[...] [element 1] :  |
@@ -3636,8 +4502,12 @@ nodes
 | array_flow.rb:101:10:101:10 | b [element 1] :  | semmle.label | b [element 1] :  |
 | array_flow.rb:101:10:101:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:101:10:101:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:103:5:103:5 | a [element 1] :  | semmle.label | a [element 1] :  |
+| array_flow.rb:103:5:103:5 | a [element 1] :  | semmle.label | a [element 1] :  |
 | array_flow.rb:103:13:103:24 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:103:13:103:24 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:104:5:104:5 | b [element 1] :  | semmle.label | b [element 1] :  |
+| array_flow.rb:104:5:104:5 | b [element 1] :  | semmle.label | b [element 1] :  |
 | array_flow.rb:104:9:104:9 | a [element 1] :  | semmle.label | a [element 1] :  |
 | array_flow.rb:104:9:104:9 | a [element 1] :  | semmle.label | a [element 1] :  |
 | array_flow.rb:104:9:104:16 | ...[...] [element 1] :  | semmle.label | ...[...] [element 1] :  |
@@ -3646,10 +4516,16 @@ nodes
 | array_flow.rb:106:10:106:10 | b [element 1] :  | semmle.label | b [element 1] :  |
 | array_flow.rb:106:10:106:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:106:10:106:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:109:5:109:5 | a [element 1] :  | semmle.label | a [element 1] :  |
+| array_flow.rb:109:5:109:5 | a [element 1] :  | semmle.label | a [element 1] :  |
+| array_flow.rb:109:5:109:5 | a [element 3] :  | semmle.label | a [element 3] :  |
+| array_flow.rb:109:5:109:5 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:109:13:109:24 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:109:13:109:24 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:109:30:109:41 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:109:30:109:41 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:110:5:110:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:110:5:110:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:110:9:110:9 | a [element 1] :  | semmle.label | a [element 1] :  |
 | array_flow.rb:110:9:110:9 | a [element 1] :  | semmle.label | a [element 1] :  |
 | array_flow.rb:110:9:110:9 | a [element 3] :  | semmle.label | a [element 3] :  |
@@ -3664,6 +4540,8 @@ nodes
 | array_flow.rb:112:10:112:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:112:10:112:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:112:10:112:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:114:5:114:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:114:5:114:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:114:9:114:9 | a [element 1] :  | semmle.label | a [element 1] :  |
 | array_flow.rb:114:9:114:9 | a [element 1] :  | semmle.label | a [element 1] :  |
 | array_flow.rb:114:9:114:9 | a [element 3] :  | semmle.label | a [element 3] :  |
@@ -3742,6 +4620,8 @@ nodes
 | array_flow.rb:148:10:148:10 | a [element] :  | semmle.label | a [element] :  |
 | array_flow.rb:148:10:148:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:148:10:148:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:152:5:152:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:152:5:152:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:152:16:152:25 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:152:16:152:25 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:153:5:153:5 | a [element 2] :  | semmle.label | a [element 2] :  |
@@ -3750,6 +4630,8 @@ nodes
 | array_flow.rb:153:16:153:16 | x :  | semmle.label | x :  |
 | array_flow.rb:154:14:154:14 | x | semmle.label | x |
 | array_flow.rb:154:14:154:14 | x | semmle.label | x |
+| array_flow.rb:159:5:159:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:159:5:159:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:159:16:159:25 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:159:16:159:25 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:160:5:160:5 | a [element 2] :  | semmle.label | a [element 2] :  |
@@ -3758,8 +4640,14 @@ nodes
 | array_flow.rb:160:16:160:16 | x :  | semmle.label | x :  |
 | array_flow.rb:161:14:161:14 | x | semmle.label | x |
 | array_flow.rb:161:14:161:14 | x | semmle.label | x |
+| array_flow.rb:166:5:166:5 | a [element 0] :  | semmle.label | a [element 0] :  |
+| array_flow.rb:166:5:166:5 | a [element 0] :  | semmle.label | a [element 0] :  |
 | array_flow.rb:166:10:166:21 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:166:10:166:21 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:167:5:167:5 | b [element 0] :  | semmle.label | b [element 0] :  |
+| array_flow.rb:167:5:167:5 | b [element 0] :  | semmle.label | b [element 0] :  |
+| array_flow.rb:167:5:167:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:167:5:167:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:167:9:167:9 | [post] a [element] :  | semmle.label | [post] a [element] :  |
 | array_flow.rb:167:9:167:9 | [post] a [element] :  | semmle.label | [post] a [element] :  |
 | array_flow.rb:167:9:167:9 | a [element 0] :  | semmle.label | a [element 0] :  |
@@ -3792,8 +4680,12 @@ nodes
 | array_flow.rb:171:10:171:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:171:10:171:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:171:10:171:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:177:5:177:5 | c [element 1] :  | semmle.label | c [element 1] :  |
+| array_flow.rb:177:5:177:5 | c [element 1] :  | semmle.label | c [element 1] :  |
 | array_flow.rb:177:15:177:24 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:177:15:177:24 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:178:5:178:5 | d [element 2, element 1] :  | semmle.label | d [element 2, element 1] :  |
+| array_flow.rb:178:5:178:5 | d [element 2, element 1] :  | semmle.label | d [element 2, element 1] :  |
 | array_flow.rb:178:16:178:16 | c [element 1] :  | semmle.label | c [element 1] :  |
 | array_flow.rb:178:16:178:16 | c [element 1] :  | semmle.label | c [element 1] :  |
 | array_flow.rb:179:10:179:26 | ( ... ) | semmle.label | ( ... ) |
@@ -3812,6 +4704,8 @@ nodes
 | array_flow.rb:180:11:180:22 | call to assoc [element 1] :  | semmle.label | call to assoc [element 1] :  |
 | array_flow.rb:180:11:180:25 | ...[...] :  | semmle.label | ...[...] :  |
 | array_flow.rb:180:11:180:25 | ...[...] :  | semmle.label | ...[...] :  |
+| array_flow.rb:184:5:184:5 | a [element 1] :  | semmle.label | a [element 1] :  |
+| array_flow.rb:184:5:184:5 | a [element 1] :  | semmle.label | a [element 1] :  |
 | array_flow.rb:184:13:184:22 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:184:13:184:22 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:186:10:186:10 | a [element 1] :  | semmle.label | a [element 1] :  |
@@ -3822,8 +4716,12 @@ nodes
 | array_flow.rb:188:10:188:10 | a [element 1] :  | semmle.label | a [element 1] :  |
 | array_flow.rb:188:10:188:16 | call to at | semmle.label | call to at |
 | array_flow.rb:188:10:188:16 | call to at | semmle.label | call to at |
+| array_flow.rb:192:5:192:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:192:5:192:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:192:16:192:25 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:192:16:192:25 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:193:5:193:5 | b :  | semmle.label | b :  |
+| array_flow.rb:193:5:193:5 | b :  | semmle.label | b :  |
 | array_flow.rb:193:9:193:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:193:9:193:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:193:9:195:7 | call to bsearch :  | semmle.label | call to bsearch :  |
@@ -3834,6 +4732,8 @@ nodes
 | array_flow.rb:194:14:194:14 | x | semmle.label | x |
 | array_flow.rb:196:10:196:10 | b | semmle.label | b |
 | array_flow.rb:196:10:196:10 | b | semmle.label | b |
+| array_flow.rb:200:5:200:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:200:5:200:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:200:16:200:25 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:200:16:200:25 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:201:9:201:9 | a [element 2] :  | semmle.label | a [element 2] :  |
@@ -3842,6 +4742,8 @@ nodes
 | array_flow.rb:201:29:201:29 | x :  | semmle.label | x :  |
 | array_flow.rb:202:14:202:14 | x | semmle.label | x |
 | array_flow.rb:202:14:202:14 | x | semmle.label | x |
+| array_flow.rb:208:5:208:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:208:5:208:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:208:16:208:25 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:208:16:208:25 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:209:5:209:5 | a [element 2] :  | semmle.label | a [element 2] :  |
@@ -3850,6 +4752,10 @@ nodes
 | array_flow.rb:209:17:209:17 | x :  | semmle.label | x :  |
 | array_flow.rb:210:14:210:14 | x | semmle.label | x |
 | array_flow.rb:210:14:210:14 | x | semmle.label | x |
+| array_flow.rb:215:5:215:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:215:5:215:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:215:5:215:5 | a [element 3] :  | semmle.label | a [element 3] :  |
+| array_flow.rb:215:5:215:5 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:215:16:215:27 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:215:16:215:27 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:215:30:215:41 | call to source :  | semmle.label | call to source :  |
@@ -3866,8 +4772,12 @@ nodes
 | array_flow.rb:217:14:217:14 | x | semmle.label | x |
 | array_flow.rb:218:14:218:14 | y | semmle.label | y |
 | array_flow.rb:218:14:218:14 | y | semmle.label | y |
+| array_flow.rb:231:5:231:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:231:5:231:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:231:16:231:27 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:231:16:231:27 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:232:5:232:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:232:5:232:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:232:9:232:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:232:9:232:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:232:9:235:7 | call to collect [element] :  | semmle.label | call to collect [element] :  |
@@ -3882,8 +4792,12 @@ nodes
 | array_flow.rb:236:10:236:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:236:10:236:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:236:10:236:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:240:5:240:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:240:5:240:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:240:16:240:27 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:240:16:240:27 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:241:5:241:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:241:5:241:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:241:9:241:9 | [post] a [element] :  | semmle.label | [post] a [element] :  |
 | array_flow.rb:241:9:241:9 | [post] a [element] :  | semmle.label | [post] a [element] :  |
 | array_flow.rb:241:9:241:9 | a [element 2] :  | semmle.label | a [element 2] :  |
@@ -3904,8 +4818,12 @@ nodes
 | array_flow.rb:246:10:246:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:246:10:246:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:246:10:246:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:250:5:250:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:250:5:250:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:250:16:250:27 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:250:16:250:27 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:251:5:251:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:251:5:251:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:251:9:251:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:251:9:251:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:251:9:254:7 | call to collect_concat [element] :  | semmle.label | call to collect_concat [element] :  |
@@ -3920,6 +4838,8 @@ nodes
 | array_flow.rb:255:10:255:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:255:10:255:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:255:10:255:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:256:5:256:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:256:5:256:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:256:9:256:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:256:9:256:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:256:9:259:7 | call to collect_concat [element] :  | semmle.label | call to collect_concat [element] :  |
@@ -3934,8 +4854,12 @@ nodes
 | array_flow.rb:260:10:260:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:260:10:260:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:260:10:260:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:264:5:264:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:264:5:264:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:264:16:264:25 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:264:16:264:25 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:265:5:265:5 | b [element 2] :  | semmle.label | b [element 2] :  |
+| array_flow.rb:265:5:265:5 | b [element 2] :  | semmle.label | b [element 2] :  |
 | array_flow.rb:265:9:265:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:265:9:265:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:265:9:267:7 | call to combination [element 2] :  | semmle.label | call to combination [element 2] :  |
@@ -3950,8 +4874,12 @@ nodes
 | array_flow.rb:269:10:269:10 | b [element 2] :  | semmle.label | b [element 2] :  |
 | array_flow.rb:269:10:269:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:269:10:269:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:273:5:273:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:273:5:273:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:273:16:273:25 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:273:16:273:25 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:274:5:274:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:274:5:274:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:274:9:274:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:274:9:274:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:274:9:274:17 | call to compact [element] :  | semmle.label | call to compact [element] :  |
@@ -3960,8 +4888,12 @@ nodes
 | array_flow.rb:275:10:275:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:275:10:275:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:275:10:275:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:279:5:279:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:279:5:279:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:279:16:279:25 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:279:16:279:25 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:280:5:280:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:280:5:280:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:280:9:280:9 | [post] a [element] :  | semmle.label | [post] a [element] :  |
 | array_flow.rb:280:9:280:9 | [post] a [element] :  | semmle.label | [post] a [element] :  |
 | array_flow.rb:280:9:280:9 | a [element 2] :  | semmle.label | a [element 2] :  |
@@ -3976,8 +4908,12 @@ nodes
 | array_flow.rb:282:10:282:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:282:10:282:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:282:10:282:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:286:5:286:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:286:5:286:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:286:16:286:27 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:286:16:286:27 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:287:5:287:5 | b [element 2] :  | semmle.label | b [element 2] :  |
+| array_flow.rb:287:5:287:5 | b [element 2] :  | semmle.label | b [element 2] :  |
 | array_flow.rb:287:16:287:27 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:287:16:287:27 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:288:5:288:5 | [post] a [element] :  | semmle.label | [post] a [element] :  |
@@ -3994,6 +4930,8 @@ nodes
 | array_flow.rb:290:10:290:10 | a [element] :  | semmle.label | a [element] :  |
 | array_flow.rb:290:10:290:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:290:10:290:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:294:5:294:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:294:5:294:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:294:16:294:25 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:294:16:294:25 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:295:5:295:5 | a [element 2] :  | semmle.label | a [element 2] :  |
@@ -4002,6 +4940,8 @@ nodes
 | array_flow.rb:295:17:295:17 | x :  | semmle.label | x :  |
 | array_flow.rb:296:14:296:14 | x | semmle.label | x |
 | array_flow.rb:296:14:296:14 | x | semmle.label | x |
+| array_flow.rb:301:5:301:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:301:5:301:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:301:16:301:25 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:301:16:301:25 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:302:5:302:5 | a [element 2] :  | semmle.label | a [element 2] :  |
@@ -4010,8 +4950,12 @@ nodes
 | array_flow.rb:302:20:302:20 | x :  | semmle.label | x :  |
 | array_flow.rb:303:14:303:14 | x | semmle.label | x |
 | array_flow.rb:303:14:303:14 | x | semmle.label | x |
+| array_flow.rb:308:5:308:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:308:5:308:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:308:16:308:25 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:308:16:308:25 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:309:5:309:5 | b [element 2] :  | semmle.label | b [element 2] :  |
+| array_flow.rb:309:5:309:5 | b [element 2] :  | semmle.label | b [element 2] :  |
 | array_flow.rb:309:9:309:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:309:9:309:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:309:9:309:21 | call to deconstruct [element 2] :  | semmle.label | call to deconstruct [element 2] :  |
@@ -4020,8 +4964,12 @@ nodes
 | array_flow.rb:312:10:312:10 | b [element 2] :  | semmle.label | b [element 2] :  |
 | array_flow.rb:312:10:312:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:312:10:312:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:316:5:316:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:316:5:316:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:316:16:316:27 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:316:16:316:27 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:317:5:317:5 | b :  | semmle.label | b :  |
+| array_flow.rb:317:5:317:5 | b :  | semmle.label | b :  |
 | array_flow.rb:317:9:317:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:317:9:317:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:317:9:317:36 | call to delete :  | semmle.label | call to delete :  |
@@ -4030,10 +4978,16 @@ nodes
 | array_flow.rb:317:23:317:34 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:318:10:318:10 | b | semmle.label | b |
 | array_flow.rb:318:10:318:10 | b | semmle.label | b |
+| array_flow.rb:325:5:325:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:325:5:325:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:325:5:325:5 | a [element 3] :  | semmle.label | a [element 3] :  |
+| array_flow.rb:325:5:325:5 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:325:16:325:27 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:325:16:325:27 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:325:30:325:41 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:325:30:325:41 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:326:5:326:5 | b :  | semmle.label | b :  |
+| array_flow.rb:326:5:326:5 | b :  | semmle.label | b :  |
 | array_flow.rb:326:9:326:9 | [post] a [element 2] :  | semmle.label | [post] a [element 2] :  |
 | array_flow.rb:326:9:326:9 | [post] a [element 2] :  | semmle.label | [post] a [element 2] :  |
 | array_flow.rb:326:9:326:9 | a [element 2] :  | semmle.label | a [element 2] :  |
@@ -4048,10 +5002,16 @@ nodes
 | array_flow.rb:328:10:328:10 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:328:10:328:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:328:10:328:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:330:5:330:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:330:5:330:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:330:5:330:5 | a [element 3] :  | semmle.label | a [element 3] :  |
+| array_flow.rb:330:5:330:5 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:330:16:330:27 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:330:16:330:27 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:330:30:330:41 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:330:30:330:41 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:331:5:331:5 | b :  | semmle.label | b :  |
+| array_flow.rb:331:5:331:5 | b :  | semmle.label | b :  |
 | array_flow.rb:331:9:331:9 | [post] a [element] :  | semmle.label | [post] a [element] :  |
 | array_flow.rb:331:9:331:9 | [post] a [element] :  | semmle.label | [post] a [element] :  |
 | array_flow.rb:331:9:331:9 | a [element 2] :  | semmle.label | a [element 2] :  |
@@ -4070,8 +5030,12 @@ nodes
 | array_flow.rb:334:10:334:10 | a [element] :  | semmle.label | a [element] :  |
 | array_flow.rb:334:10:334:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:334:10:334:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:338:5:338:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:338:5:338:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:338:16:338:25 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:338:16:338:25 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:339:5:339:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:339:5:339:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:339:9:339:9 | [post] a [element] :  | semmle.label | [post] a [element] :  |
 | array_flow.rb:339:9:339:9 | [post] a [element] :  | semmle.label | [post] a [element] :  |
 | array_flow.rb:339:9:339:9 | a [element 2] :  | semmle.label | a [element 2] :  |
@@ -4098,8 +5062,12 @@ nodes
 | array_flow.rb:345:10:345:10 | a [element] :  | semmle.label | a [element] :  |
 | array_flow.rb:345:10:345:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:345:10:345:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:349:5:349:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:349:5:349:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:349:16:349:25 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:349:16:349:25 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:350:5:350:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:350:5:350:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:350:9:350:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:350:9:350:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:350:9:350:25 | call to difference [element] :  | semmle.label | call to difference [element] :  |
@@ -4108,6 +5076,10 @@ nodes
 | array_flow.rb:351:10:351:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:351:10:351:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:351:10:351:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:355:5:355:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:355:5:355:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:355:5:355:5 | a [element 3, element 1] :  | semmle.label | a [element 3, element 1] :  |
+| array_flow.rb:355:5:355:5 | a [element 3, element 1] :  | semmle.label | a [element 3, element 1] :  |
 | array_flow.rb:355:16:355:27 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:355:16:355:27 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:355:34:355:45 | call to source :  | semmle.label | call to source :  |
@@ -4124,8 +5096,12 @@ nodes
 | array_flow.rb:360:10:360:10 | a [element 3, element 1] :  | semmle.label | a [element 3, element 1] :  |
 | array_flow.rb:360:10:360:19 | call to dig | semmle.label | call to dig |
 | array_flow.rb:360:10:360:19 | call to dig | semmle.label | call to dig |
+| array_flow.rb:364:5:364:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:364:5:364:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:364:16:364:27 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:364:16:364:27 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:365:5:365:5 | b :  | semmle.label | b :  |
+| array_flow.rb:365:5:365:5 | b :  | semmle.label | b :  |
 | array_flow.rb:365:9:365:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:365:9:365:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:365:9:367:7 | call to detect :  | semmle.label | call to detect :  |
@@ -4138,10 +5114,16 @@ nodes
 | array_flow.rb:366:14:366:14 | x | semmle.label | x |
 | array_flow.rb:368:10:368:10 | b | semmle.label | b |
 | array_flow.rb:368:10:368:10 | b | semmle.label | b |
+| array_flow.rb:372:5:372:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:372:5:372:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:372:5:372:5 | a [element 3] :  | semmle.label | a [element 3] :  |
+| array_flow.rb:372:5:372:5 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:372:16:372:27 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:372:16:372:27 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:372:30:372:41 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:372:30:372:41 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:373:5:373:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:373:5:373:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:373:9:373:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:373:9:373:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:373:9:373:9 | a [element 3] :  | semmle.label | a [element 3] :  |
@@ -4152,6 +5134,10 @@ nodes
 | array_flow.rb:374:10:374:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:374:10:374:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:374:10:374:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:375:5:375:5 | b [element 1] :  | semmle.label | b [element 1] :  |
+| array_flow.rb:375:5:375:5 | b [element 1] :  | semmle.label | b [element 1] :  |
+| array_flow.rb:375:5:375:5 | b [element 2] :  | semmle.label | b [element 2] :  |
+| array_flow.rb:375:5:375:5 | b [element 2] :  | semmle.label | b [element 2] :  |
 | array_flow.rb:375:9:375:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:375:9:375:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:375:9:375:9 | a [element 3] :  | semmle.label | a [element 3] :  |
@@ -4174,6 +5160,10 @@ nodes
 | array_flow.rb:379:5:379:5 | [post] a [element] :  | semmle.label | [post] a [element] :  |
 | array_flow.rb:379:12:379:23 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:379:12:379:23 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:380:5:380:5 | b [element 1] :  | semmle.label | b [element 1] :  |
+| array_flow.rb:380:5:380:5 | b [element 1] :  | semmle.label | b [element 1] :  |
+| array_flow.rb:380:5:380:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:380:5:380:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:380:9:380:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:380:9:380:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:380:9:380:9 | a [element] :  | semmle.label | a [element] :  |
@@ -4188,6 +5178,8 @@ nodes
 | array_flow.rb:381:10:381:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:381:10:381:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:381:10:381:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:382:5:382:5 | c [element] :  | semmle.label | c [element] :  |
+| array_flow.rb:382:5:382:5 | c [element] :  | semmle.label | c [element] :  |
 | array_flow.rb:382:9:382:9 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:382:9:382:9 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:382:9:382:19 | call to drop [element] :  | semmle.label | call to drop [element] :  |
@@ -4196,10 +5188,16 @@ nodes
 | array_flow.rb:383:10:383:10 | c [element] :  | semmle.label | c [element] :  |
 | array_flow.rb:383:10:383:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:383:10:383:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:387:5:387:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:387:5:387:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:387:5:387:5 | a [element 3] :  | semmle.label | a [element 3] :  |
+| array_flow.rb:387:5:387:5 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:387:16:387:27 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:387:16:387:27 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:387:30:387:41 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:387:30:387:41 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:388:5:388:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:388:5:388:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:388:9:388:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:388:9:388:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:388:9:388:9 | a [element 3] :  | semmle.label | a [element 3] :  |
@@ -4214,8 +5212,12 @@ nodes
 | array_flow.rb:391:10:391:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:391:10:391:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:391:10:391:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:395:5:395:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:395:5:395:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:395:16:395:25 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:395:16:395:25 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:396:5:396:5 | b [element 2] :  | semmle.label | b [element 2] :  |
+| array_flow.rb:396:5:396:5 | b [element 2] :  | semmle.label | b [element 2] :  |
 | array_flow.rb:396:9:396:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:396:9:396:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:396:9:398:7 | call to each [element 2] :  | semmle.label | call to each [element 2] :  |
@@ -4228,12 +5230,16 @@ nodes
 | array_flow.rb:399:10:399:10 | b [element 2] :  | semmle.label | b [element 2] :  |
 | array_flow.rb:399:10:399:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:399:10:399:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:403:5:403:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:403:5:403:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:403:16:403:25 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:403:16:403:25 | call to source :  | semmle.label | call to source :  |
-| array_flow.rb:404:9:406:7 | ... = ... :  | semmle.label | ... = ... :  |
-| array_flow.rb:404:9:406:7 | ... = ... :  | semmle.label | ... = ... :  |
+| array_flow.rb:404:5:404:5 | b [element 2] :  | semmle.label | b [element 2] :  |
+| array_flow.rb:404:5:404:5 | b [element 2] :  | semmle.label | b [element 2] :  |
 | array_flow.rb:404:9:406:7 | __synth__0__1 :  | semmle.label | __synth__0__1 :  |
 | array_flow.rb:404:9:406:7 | __synth__0__1 :  | semmle.label | __synth__0__1 :  |
+| array_flow.rb:404:13:404:13 | x :  | semmle.label | x :  |
+| array_flow.rb:404:13:404:13 | x :  | semmle.label | x :  |
 | array_flow.rb:404:18:404:18 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:404:18:404:18 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:405:14:405:14 | x | semmle.label | x |
@@ -4244,6 +5250,8 @@ nodes
 | array_flow.rb:408:10:408:10 | b [element 2] :  | semmle.label | b [element 2] :  |
 | array_flow.rb:408:10:408:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:408:10:408:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:412:5:412:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:412:5:412:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:412:16:412:25 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:412:16:412:25 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:413:5:413:5 | a [element 2] :  | semmle.label | a [element 2] :  |
@@ -4256,8 +5264,12 @@ nodes
 | array_flow.rb:414:15:414:15 | x [element] :  | semmle.label | x [element] :  |
 | array_flow.rb:414:15:414:18 | ...[...] :  | semmle.label | ...[...] :  |
 | array_flow.rb:414:15:414:18 | ...[...] :  | semmle.label | ...[...] :  |
+| array_flow.rb:419:5:419:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:419:5:419:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:419:16:419:25 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:419:16:419:25 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:420:5:420:5 | b [element 2] :  | semmle.label | b [element 2] :  |
+| array_flow.rb:420:5:420:5 | b [element 2] :  | semmle.label | b [element 2] :  |
 | array_flow.rb:420:9:420:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:420:9:420:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:420:9:422:7 | call to each_entry [element 2] :  | semmle.label | call to each_entry [element 2] :  |
@@ -4270,8 +5282,12 @@ nodes
 | array_flow.rb:423:10:423:10 | b [element 2] :  | semmle.label | b [element 2] :  |
 | array_flow.rb:423:10:423:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:423:10:423:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:427:5:427:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:427:5:427:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:427:16:427:25 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:427:16:427:25 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:428:5:428:5 | b [element 2] :  | semmle.label | b [element 2] :  |
+| array_flow.rb:428:5:428:5 | b [element 2] :  | semmle.label | b [element 2] :  |
 | array_flow.rb:428:9:428:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:428:9:428:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:428:9:430:7 | call to each_index [element 2] :  | semmle.label | call to each_index [element 2] :  |
@@ -4280,6 +5296,8 @@ nodes
 | array_flow.rb:431:10:431:10 | b [element 2] :  | semmle.label | b [element 2] :  |
 | array_flow.rb:431:10:431:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:431:10:431:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:435:5:435:5 | a [element 3] :  | semmle.label | a [element 3] :  |
+| array_flow.rb:435:5:435:5 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:435:19:435:28 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:435:19:435:28 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:436:5:436:5 | a [element 3] :  | semmle.label | a [element 3] :  |
@@ -4290,8 +5308,12 @@ nodes
 | array_flow.rb:437:14:437:14 | x [element] :  | semmle.label | x [element] :  |
 | array_flow.rb:437:14:437:17 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:437:14:437:17 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:442:5:442:5 | a [element 3] :  | semmle.label | a [element 3] :  |
+| array_flow.rb:442:5:442:5 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:442:19:442:28 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:442:19:442:28 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:443:5:443:5 | b [element 3] :  | semmle.label | b [element 3] :  |
+| array_flow.rb:443:5:443:5 | b [element 3] :  | semmle.label | b [element 3] :  |
 | array_flow.rb:443:9:443:9 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:443:9:443:9 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:443:9:446:7 | call to each_with_index [element 3] :  | semmle.label | call to each_with_index [element 3] :  |
@@ -4304,8 +5326,12 @@ nodes
 | array_flow.rb:447:10:447:10 | b [element 3] :  | semmle.label | b [element 3] :  |
 | array_flow.rb:447:10:447:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:447:10:447:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:451:5:451:5 | a [element 3] :  | semmle.label | a [element 3] :  |
+| array_flow.rb:451:5:451:5 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:451:19:451:30 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:451:19:451:30 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:452:5:452:5 | b :  | semmle.label | b :  |
+| array_flow.rb:452:5:452:5 | b :  | semmle.label | b :  |
 | array_flow.rb:452:9:452:9 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:452:9:452:9 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:452:9:455:7 | call to each_with_object :  | semmle.label | call to each_with_object :  |
@@ -4322,8 +5348,12 @@ nodes
 | array_flow.rb:454:14:454:14 | a | semmle.label | a |
 | array_flow.rb:456:10:456:10 | b | semmle.label | b |
 | array_flow.rb:456:10:456:10 | b | semmle.label | b |
+| array_flow.rb:460:5:460:5 | a [element 3] :  | semmle.label | a [element 3] :  |
+| array_flow.rb:460:5:460:5 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:460:19:460:28 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:460:19:460:28 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:461:5:461:5 | b [element 3] :  | semmle.label | b [element 3] :  |
+| array_flow.rb:461:5:461:5 | b [element 3] :  | semmle.label | b [element 3] :  |
 | array_flow.rb:461:9:461:9 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:461:9:461:9 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:461:9:461:17 | call to entries [element 3] :  | semmle.label | call to entries [element 3] :  |
@@ -4332,10 +5362,16 @@ nodes
 | array_flow.rb:462:10:462:10 | b [element 3] :  | semmle.label | b [element 3] :  |
 | array_flow.rb:462:10:462:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:462:10:462:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:466:5:466:5 | a [element 3] :  | semmle.label | a [element 3] :  |
+| array_flow.rb:466:5:466:5 | a [element 3] :  | semmle.label | a [element 3] :  |
+| array_flow.rb:466:5:466:5 | a [element 4] :  | semmle.label | a [element 4] :  |
+| array_flow.rb:466:5:466:5 | a [element 4] :  | semmle.label | a [element 4] :  |
 | array_flow.rb:466:19:466:30 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:466:19:466:30 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:466:33:466:44 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:466:33:466:44 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:467:5:467:5 | b :  | semmle.label | b :  |
+| array_flow.rb:467:5:467:5 | b :  | semmle.label | b :  |
 | array_flow.rb:467:9:467:9 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:467:9:467:9 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:467:9:467:9 | a [element 4] :  | semmle.label | a [element 4] :  |
@@ -4350,12 +5386,16 @@ nodes
 | array_flow.rb:468:14:468:14 | x | semmle.label | x |
 | array_flow.rb:470:10:470:10 | b | semmle.label | b |
 | array_flow.rb:470:10:470:10 | b | semmle.label | b |
+| array_flow.rb:471:5:471:5 | b :  | semmle.label | b :  |
+| array_flow.rb:471:5:471:5 | b :  | semmle.label | b :  |
 | array_flow.rb:471:9:471:9 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:471:9:471:9 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:471:9:471:18 | call to fetch :  | semmle.label | call to fetch :  |
 | array_flow.rb:471:9:471:18 | call to fetch :  | semmle.label | call to fetch :  |
 | array_flow.rb:472:10:472:10 | b | semmle.label | b |
 | array_flow.rb:472:10:472:10 | b | semmle.label | b |
+| array_flow.rb:473:5:473:5 | b :  | semmle.label | b :  |
+| array_flow.rb:473:5:473:5 | b :  | semmle.label | b :  |
 | array_flow.rb:473:9:473:9 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:473:9:473:9 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:473:9:473:32 | call to fetch :  | semmle.label | call to fetch :  |
@@ -4364,12 +5404,16 @@ nodes
 | array_flow.rb:473:20:473:31 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:474:10:474:10 | b | semmle.label | b |
 | array_flow.rb:474:10:474:10 | b | semmle.label | b |
+| array_flow.rb:475:5:475:5 | b :  | semmle.label | b :  |
+| array_flow.rb:475:5:475:5 | b :  | semmle.label | b :  |
 | array_flow.rb:475:9:475:34 | call to fetch :  | semmle.label | call to fetch :  |
 | array_flow.rb:475:9:475:34 | call to fetch :  | semmle.label | call to fetch :  |
 | array_flow.rb:475:22:475:33 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:475:22:475:33 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:476:10:476:10 | b | semmle.label | b |
 | array_flow.rb:476:10:476:10 | b | semmle.label | b |
+| array_flow.rb:477:5:477:5 | b :  | semmle.label | b :  |
+| array_flow.rb:477:5:477:5 | b :  | semmle.label | b :  |
 | array_flow.rb:477:9:477:9 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:477:9:477:9 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:477:9:477:9 | a [element 4] :  | semmle.label | a [element 4] :  |
@@ -4380,6 +5424,8 @@ nodes
 | array_flow.rb:477:20:477:31 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:478:10:478:10 | b | semmle.label | b |
 | array_flow.rb:478:10:478:10 | b | semmle.label | b |
+| array_flow.rb:482:5:482:5 | a [element 3] :  | semmle.label | a [element 3] :  |
+| array_flow.rb:482:5:482:5 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:482:19:482:30 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:482:19:482:30 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:483:5:483:5 | [post] a [element] :  | semmle.label | [post] a [element] :  |
@@ -4416,8 +5462,12 @@ nodes
 | array_flow.rb:494:10:494:10 | a [element] :  | semmle.label | a [element] :  |
 | array_flow.rb:494:10:494:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:494:10:494:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:498:5:498:5 | a [element 3] :  | semmle.label | a [element 3] :  |
+| array_flow.rb:498:5:498:5 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:498:19:498:28 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:498:19:498:28 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:499:5:499:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:499:5:499:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:499:9:499:9 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:499:9:499:9 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:499:9:501:7 | call to filter [element] :  | semmle.label | call to filter [element] :  |
@@ -4430,8 +5480,12 @@ nodes
 | array_flow.rb:502:10:502:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:502:10:502:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:502:10:502:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:506:5:506:5 | a [element 3] :  | semmle.label | a [element 3] :  |
+| array_flow.rb:506:5:506:5 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:506:19:506:28 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:506:19:506:28 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:507:5:507:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:507:5:507:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:507:9:507:9 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:507:9:507:9 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:507:9:509:7 | call to filter_map [element] :  | semmle.label | call to filter_map [element] :  |
@@ -4444,8 +5498,12 @@ nodes
 | array_flow.rb:510:10:510:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:510:10:510:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:510:10:510:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:514:5:514:5 | a [element 3] :  | semmle.label | a [element 3] :  |
+| array_flow.rb:514:5:514:5 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:514:19:514:28 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:514:19:514:28 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:515:5:515:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:515:5:515:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:515:9:515:9 | [post] a [element] :  | semmle.label | [post] a [element] :  |
 | array_flow.rb:515:9:515:9 | [post] a [element] :  | semmle.label | [post] a [element] :  |
 | array_flow.rb:515:9:515:9 | a [element 3] :  | semmle.label | a [element 3] :  |
@@ -4464,8 +5522,12 @@ nodes
 | array_flow.rb:520:10:520:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:520:10:520:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:520:10:520:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:524:5:524:5 | a [element 3] :  | semmle.label | a [element 3] :  |
+| array_flow.rb:524:5:524:5 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:524:19:524:30 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:524:19:524:30 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:525:5:525:5 | b :  | semmle.label | b :  |
+| array_flow.rb:525:5:525:5 | b :  | semmle.label | b :  |
 | array_flow.rb:525:9:525:9 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:525:9:525:9 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:525:9:527:7 | call to find :  | semmle.label | call to find :  |
@@ -4478,8 +5540,12 @@ nodes
 | array_flow.rb:526:14:526:14 | x | semmle.label | x |
 | array_flow.rb:528:10:528:10 | b | semmle.label | b |
 | array_flow.rb:528:10:528:10 | b | semmle.label | b |
+| array_flow.rb:532:5:532:5 | a [element 3] :  | semmle.label | a [element 3] :  |
+| array_flow.rb:532:5:532:5 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:532:19:532:28 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:532:19:532:28 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:533:5:533:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:533:5:533:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:533:9:533:9 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:533:9:533:9 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:533:9:535:7 | call to find_all [element] :  | semmle.label | call to find_all [element] :  |
@@ -4492,6 +5558,8 @@ nodes
 | array_flow.rb:536:10:536:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:536:10:536:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:536:10:536:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:540:5:540:5 | a [element 3] :  | semmle.label | a [element 3] :  |
+| array_flow.rb:540:5:540:5 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:540:19:540:28 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:540:19:540:28 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:541:5:541:5 | a [element 3] :  | semmle.label | a [element 3] :  |
@@ -4500,6 +5568,10 @@ nodes
 | array_flow.rb:541:22:541:22 | x :  | semmle.label | x :  |
 | array_flow.rb:542:14:542:14 | x | semmle.label | x |
 | array_flow.rb:542:14:542:14 | x | semmle.label | x |
+| array_flow.rb:547:5:547:5 | a [element 0] :  | semmle.label | a [element 0] :  |
+| array_flow.rb:547:5:547:5 | a [element 0] :  | semmle.label | a [element 0] :  |
+| array_flow.rb:547:5:547:5 | a [element 3] :  | semmle.label | a [element 3] :  |
+| array_flow.rb:547:5:547:5 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:547:10:547:21 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:547:10:547:21 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:547:30:547:41 | call to source :  | semmle.label | call to source :  |
@@ -4514,6 +5586,10 @@ nodes
 | array_flow.rb:549:10:549:10 | a [element] :  | semmle.label | a [element] :  |
 | array_flow.rb:549:10:549:16 | call to first | semmle.label | call to first |
 | array_flow.rb:549:10:549:16 | call to first | semmle.label | call to first |
+| array_flow.rb:550:5:550:5 | b [element 0] :  | semmle.label | b [element 0] :  |
+| array_flow.rb:550:5:550:5 | b [element 0] :  | semmle.label | b [element 0] :  |
+| array_flow.rb:550:5:550:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:550:5:550:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:550:9:550:9 | a [element 0] :  | semmle.label | a [element 0] :  |
 | array_flow.rb:550:9:550:9 | a [element 0] :  | semmle.label | a [element 0] :  |
 | array_flow.rb:550:9:550:9 | a [element] :  | semmle.label | a [element] :  |
@@ -4532,6 +5608,12 @@ nodes
 | array_flow.rb:552:10:552:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:552:10:552:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:552:10:552:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:553:5:553:5 | c [element 0] :  | semmle.label | c [element 0] :  |
+| array_flow.rb:553:5:553:5 | c [element 0] :  | semmle.label | c [element 0] :  |
+| array_flow.rb:553:5:553:5 | c [element 3] :  | semmle.label | c [element 3] :  |
+| array_flow.rb:553:5:553:5 | c [element 3] :  | semmle.label | c [element 3] :  |
+| array_flow.rb:553:5:553:5 | c [element] :  | semmle.label | c [element] :  |
+| array_flow.rb:553:5:553:5 | c [element] :  | semmle.label | c [element] :  |
 | array_flow.rb:553:9:553:9 | a [element 0] :  | semmle.label | a [element 0] :  |
 | array_flow.rb:553:9:553:9 | a [element 0] :  | semmle.label | a [element 0] :  |
 | array_flow.rb:553:9:553:9 | a [element 3] :  | semmle.label | a [element 3] :  |
@@ -4556,8 +5638,12 @@ nodes
 | array_flow.rb:555:10:555:10 | c [element] :  | semmle.label | c [element] :  |
 | array_flow.rb:555:10:555:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:555:10:555:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:559:5:559:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:559:5:559:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:559:16:559:27 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:559:16:559:27 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:560:5:560:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:560:5:560:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:560:9:560:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:560:9:560:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:560:9:563:7 | call to flat_map [element] :  | semmle.label | call to flat_map [element] :  |
@@ -4572,6 +5658,8 @@ nodes
 | array_flow.rb:564:10:564:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:564:10:564:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:564:10:564:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:565:5:565:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:565:5:565:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:565:9:565:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:565:9:565:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:565:9:568:7 | call to flat_map [element] :  | semmle.label | call to flat_map [element] :  |
@@ -4586,8 +5674,12 @@ nodes
 | array_flow.rb:569:10:569:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:569:10:569:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:569:10:569:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:573:5:573:5 | a [element 2, element 1] :  | semmle.label | a [element 2, element 1] :  |
+| array_flow.rb:573:5:573:5 | a [element 2, element 1] :  | semmle.label | a [element 2, element 1] :  |
 | array_flow.rb:573:20:573:29 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:573:20:573:29 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:574:5:574:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:574:5:574:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:574:9:574:9 | a [element 2, element 1] :  | semmle.label | a [element 2, element 1] :  |
 | array_flow.rb:574:9:574:9 | a [element 2, element 1] :  | semmle.label | a [element 2, element 1] :  |
 | array_flow.rb:574:9:574:17 | call to flatten [element] :  | semmle.label | call to flatten [element] :  |
@@ -4596,6 +5688,8 @@ nodes
 | array_flow.rb:575:10:575:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:575:10:575:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:575:10:575:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:579:5:579:5 | a [element 2, element 1] :  | semmle.label | a [element 2, element 1] :  |
+| array_flow.rb:579:5:579:5 | a [element 2, element 1] :  | semmle.label | a [element 2, element 1] :  |
 | array_flow.rb:579:20:579:29 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:579:20:579:29 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:580:10:580:10 | a [element 2, element 1] :  | semmle.label | a [element 2, element 1] :  |
@@ -4604,6 +5698,10 @@ nodes
 | array_flow.rb:580:10:580:13 | ...[...] [element 1] :  | semmle.label | ...[...] [element 1] :  |
 | array_flow.rb:580:10:580:16 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:580:10:580:16 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:581:5:581:5 | b [element, element 1] :  | semmle.label | b [element, element 1] :  |
+| array_flow.rb:581:5:581:5 | b [element, element 1] :  | semmle.label | b [element, element 1] :  |
+| array_flow.rb:581:5:581:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:581:5:581:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:581:9:581:9 | [post] a [element, element 1] :  | semmle.label | [post] a [element, element 1] :  |
 | array_flow.rb:581:9:581:9 | [post] a [element, element 1] :  | semmle.label | [post] a [element, element 1] :  |
 | array_flow.rb:581:9:581:9 | [post] a [element] :  | semmle.label | [post] a [element] :  |
@@ -4638,8 +5736,12 @@ nodes
 | array_flow.rb:585:10:585:13 | ...[...] [element 1] :  | semmle.label | ...[...] [element 1] :  |
 | array_flow.rb:585:10:585:16 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:585:10:585:16 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:589:5:589:5 | a [element 3] :  | semmle.label | a [element 3] :  |
+| array_flow.rb:589:5:589:5 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:589:19:589:30 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:589:19:589:30 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:590:5:590:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:590:5:590:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:590:9:590:9 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:590:9:590:9 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:590:9:590:20 | call to grep [element] :  | semmle.label | call to grep [element] :  |
@@ -4648,6 +5750,8 @@ nodes
 | array_flow.rb:591:10:591:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:591:10:591:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:591:10:591:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:592:5:592:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:592:5:592:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:592:9:592:9 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:592:9:592:9 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:592:9:595:7 | call to grep [element] :  | semmle.label | call to grep [element] :  |
@@ -4662,8 +5766,12 @@ nodes
 | array_flow.rb:596:10:596:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:596:10:596:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:596:10:596:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:600:5:600:5 | a [element 3] :  | semmle.label | a [element 3] :  |
+| array_flow.rb:600:5:600:5 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:600:19:600:30 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:600:19:600:30 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:601:5:601:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:601:5:601:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:601:9:601:9 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:601:9:601:9 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:601:9:601:21 | call to grep_v [element] :  | semmle.label | call to grep_v [element] :  |
@@ -4672,6 +5780,8 @@ nodes
 | array_flow.rb:602:10:602:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:602:10:602:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:602:10:602:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:603:5:603:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:603:5:603:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:603:9:603:9 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:603:9:603:9 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:603:9:606:7 | call to grep_v [element] :  | semmle.label | call to grep_v [element] :  |
@@ -4686,6 +5796,8 @@ nodes
 | array_flow.rb:607:10:607:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:607:10:607:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:607:10:607:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:611:5:611:5 | a [element 3] :  | semmle.label | a [element 3] :  |
+| array_flow.rb:611:5:611:5 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:611:19:611:30 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:611:19:611:30 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:612:9:612:9 | a [element 3] :  | semmle.label | a [element 3] :  |
@@ -4694,6 +5806,8 @@ nodes
 | array_flow.rb:612:24:612:24 | x :  | semmle.label | x :  |
 | array_flow.rb:613:14:613:14 | x | semmle.label | x |
 | array_flow.rb:613:14:613:14 | x | semmle.label | x |
+| array_flow.rb:620:5:620:5 | a [element 3] :  | semmle.label | a [element 3] :  |
+| array_flow.rb:620:5:620:5 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:620:19:620:28 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:620:19:620:28 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:621:5:621:5 | a [element 3] :  | semmle.label | a [element 3] :  |
@@ -4702,10 +5816,16 @@ nodes
 | array_flow.rb:621:17:621:17 | x :  | semmle.label | x :  |
 | array_flow.rb:622:14:622:14 | x | semmle.label | x |
 | array_flow.rb:622:14:622:14 | x | semmle.label | x |
+| array_flow.rb:627:5:627:5 | a [element 0] :  | semmle.label | a [element 0] :  |
+| array_flow.rb:627:5:627:5 | a [element 0] :  | semmle.label | a [element 0] :  |
+| array_flow.rb:627:5:627:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:627:5:627:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:627:10:627:21 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:627:10:627:21 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:627:27:627:38 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:627:27:627:38 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:628:5:628:5 | b :  | semmle.label | b :  |
+| array_flow.rb:628:5:628:5 | b :  | semmle.label | b :  |
 | array_flow.rb:628:9:628:9 | a [element 0] :  | semmle.label | a [element 0] :  |
 | array_flow.rb:628:9:628:9 | a [element 0] :  | semmle.label | a [element 0] :  |
 | array_flow.rb:628:9:628:9 | a [element 2] :  | semmle.label | a [element 2] :  |
@@ -4724,6 +5844,8 @@ nodes
 | array_flow.rb:631:9:631:19 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:633:10:633:10 | b | semmle.label | b |
 | array_flow.rb:633:10:633:10 | b | semmle.label | b |
+| array_flow.rb:634:5:634:5 | c :  | semmle.label | c :  |
+| array_flow.rb:634:5:634:5 | c :  | semmle.label | c :  |
 | array_flow.rb:634:9:634:9 | a [element 0] :  | semmle.label | a [element 0] :  |
 | array_flow.rb:634:9:634:9 | a [element 0] :  | semmle.label | a [element 0] :  |
 | array_flow.rb:634:9:634:9 | a [element 2] :  | semmle.label | a [element 2] :  |
@@ -4738,8 +5860,16 @@ nodes
 | array_flow.rb:637:9:637:19 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:639:10:639:10 | c | semmle.label | c |
 | array_flow.rb:639:10:639:10 | c | semmle.label | c |
+| array_flow.rb:644:5:644:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:644:5:644:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:644:16:644:27 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:644:16:644:27 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:645:5:645:5 | b [element 1] :  | semmle.label | b [element 1] :  |
+| array_flow.rb:645:5:645:5 | b [element 1] :  | semmle.label | b [element 1] :  |
+| array_flow.rb:645:5:645:5 | b [element 2] :  | semmle.label | b [element 2] :  |
+| array_flow.rb:645:5:645:5 | b [element 2] :  | semmle.label | b [element 2] :  |
+| array_flow.rb:645:5:645:5 | b [element 4] :  | semmle.label | b [element 4] :  |
+| array_flow.rb:645:5:645:5 | b [element 4] :  | semmle.label | b [element 4] :  |
 | array_flow.rb:645:9:645:9 | [post] a [element 1] :  | semmle.label | [post] a [element 1] :  |
 | array_flow.rb:645:9:645:9 | [post] a [element 1] :  | semmle.label | [post] a [element 1] :  |
 | array_flow.rb:645:9:645:9 | [post] a [element 2] :  | semmle.label | [post] a [element 2] :  |
@@ -4782,8 +5912,12 @@ nodes
 | array_flow.rb:655:10:655:10 | b [element 4] :  | semmle.label | b [element 4] :  |
 | array_flow.rb:655:10:655:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:655:10:655:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:658:5:658:5 | c [element 2] :  | semmle.label | c [element 2] :  |
+| array_flow.rb:658:5:658:5 | c [element 2] :  | semmle.label | c [element 2] :  |
 | array_flow.rb:658:16:658:27 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:658:16:658:27 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:659:5:659:5 | d [element] :  | semmle.label | d [element] :  |
+| array_flow.rb:659:5:659:5 | d [element] :  | semmle.label | d [element] :  |
 | array_flow.rb:659:9:659:9 | [post] c [element] :  | semmle.label | [post] c [element] :  |
 | array_flow.rb:659:9:659:9 | [post] c [element] :  | semmle.label | [post] c [element] :  |
 | array_flow.rb:659:9:659:9 | c [element 2] :  | semmle.label | c [element 2] :  |
@@ -4802,8 +5936,12 @@ nodes
 | array_flow.rb:661:10:661:10 | d [element] :  | semmle.label | d [element] :  |
 | array_flow.rb:661:10:661:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:661:10:661:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:672:5:672:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:672:5:672:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:672:16:672:27 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:672:16:672:27 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:673:5:673:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:673:5:673:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:673:9:673:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:673:9:673:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:673:9:673:60 | call to intersection [element] :  | semmle.label | call to intersection [element] :  |
@@ -4816,8 +5954,12 @@ nodes
 | array_flow.rb:674:10:674:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:674:10:674:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:674:10:674:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:678:5:678:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:678:5:678:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:678:16:678:25 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:678:16:678:25 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:679:5:679:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:679:5:679:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:679:9:679:9 | [post] a [element] :  | semmle.label | [post] a [element] :  |
 | array_flow.rb:679:9:679:9 | [post] a [element] :  | semmle.label | [post] a [element] :  |
 | array_flow.rb:679:9:679:9 | a [element 2] :  | semmle.label | a [element 2] :  |
@@ -4836,6 +5978,8 @@ nodes
 | array_flow.rb:684:10:684:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:684:10:684:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:684:10:684:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:688:5:688:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:688:5:688:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:688:16:688:27 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:688:16:688:27 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:689:5:689:5 | [post] a [element] :  | semmle.label | [post] a [element] :  |
@@ -4848,6 +5992,8 @@ nodes
 | array_flow.rb:690:10:690:10 | a [element] :  | semmle.label | a [element] :  |
 | array_flow.rb:690:10:690:15 | call to last | semmle.label | call to last |
 | array_flow.rb:690:10:690:15 | call to last | semmle.label | call to last |
+| array_flow.rb:691:5:691:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:691:5:691:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:691:9:691:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:691:9:691:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:691:9:691:9 | a [element] :  | semmle.label | a [element] :  |
@@ -4862,8 +6008,12 @@ nodes
 | array_flow.rb:693:10:693:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:693:10:693:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:693:10:693:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:697:5:697:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:697:5:697:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:697:16:697:27 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:697:16:697:27 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:698:5:698:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:698:5:698:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:698:9:698:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:698:9:698:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:698:9:701:7 | call to map [element] :  | semmle.label | call to map [element] :  |
@@ -4878,8 +6028,12 @@ nodes
 | array_flow.rb:702:10:702:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:702:10:702:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:702:10:702:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:706:5:706:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:706:5:706:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:706:16:706:27 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:706:16:706:27 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:707:5:707:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:707:5:707:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:707:9:707:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:707:9:707:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:707:9:710:7 | call to map! [element] :  | semmle.label | call to map! [element] :  |
@@ -4894,14 +6048,20 @@ nodes
 | array_flow.rb:711:10:711:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:711:10:711:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:711:10:711:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:715:5:715:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:715:5:715:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:715:16:715:25 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:715:16:715:25 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:718:5:718:5 | b :  | semmle.label | b :  |
+| array_flow.rb:718:5:718:5 | b :  | semmle.label | b :  |
 | array_flow.rb:718:9:718:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:718:9:718:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:718:9:718:13 | call to max :  | semmle.label | call to max :  |
 | array_flow.rb:718:9:718:13 | call to max :  | semmle.label | call to max :  |
 | array_flow.rb:719:10:719:10 | b | semmle.label | b |
 | array_flow.rb:719:10:719:10 | b | semmle.label | b |
+| array_flow.rb:722:5:722:5 | c [element] :  | semmle.label | c [element] :  |
+| array_flow.rb:722:5:722:5 | c [element] :  | semmle.label | c [element] :  |
 | array_flow.rb:722:9:722:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:722:9:722:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:722:9:722:16 | call to max [element] :  | semmle.label | call to max [element] :  |
@@ -4910,6 +6070,8 @@ nodes
 | array_flow.rb:723:10:723:10 | c [element] :  | semmle.label | c [element] :  |
 | array_flow.rb:723:10:723:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:723:10:723:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:726:5:726:5 | d :  | semmle.label | d :  |
+| array_flow.rb:726:5:726:5 | d :  | semmle.label | d :  |
 | array_flow.rb:726:9:726:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:726:9:726:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:726:9:730:7 | call to max :  | semmle.label | call to max :  |
@@ -4924,6 +6086,8 @@ nodes
 | array_flow.rb:728:14:728:14 | y | semmle.label | y |
 | array_flow.rb:731:10:731:10 | d | semmle.label | d |
 | array_flow.rb:731:10:731:10 | d | semmle.label | d |
+| array_flow.rb:734:5:734:5 | e [element] :  | semmle.label | e [element] :  |
+| array_flow.rb:734:5:734:5 | e [element] :  | semmle.label | e [element] :  |
 | array_flow.rb:734:9:734:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:734:9:734:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:734:9:738:7 | call to max [element] :  | semmle.label | call to max [element] :  |
@@ -4940,8 +6104,12 @@ nodes
 | array_flow.rb:739:10:739:10 | e [element] :  | semmle.label | e [element] :  |
 | array_flow.rb:739:10:739:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:739:10:739:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:743:5:743:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:743:5:743:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:743:16:743:25 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:743:16:743:25 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:746:5:746:5 | b :  | semmle.label | b :  |
+| array_flow.rb:746:5:746:5 | b :  | semmle.label | b :  |
 | array_flow.rb:746:9:746:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:746:9:746:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:746:9:749:7 | call to max_by :  | semmle.label | call to max_by :  |
@@ -4952,6 +6120,8 @@ nodes
 | array_flow.rb:747:14:747:14 | x | semmle.label | x |
 | array_flow.rb:750:10:750:10 | b | semmle.label | b |
 | array_flow.rb:750:10:750:10 | b | semmle.label | b |
+| array_flow.rb:753:5:753:5 | c [element] :  | semmle.label | c [element] :  |
+| array_flow.rb:753:5:753:5 | c [element] :  | semmle.label | c [element] :  |
 | array_flow.rb:753:9:753:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:753:9:753:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:753:9:756:7 | call to max_by [element] :  | semmle.label | call to max_by [element] :  |
@@ -4964,14 +6134,20 @@ nodes
 | array_flow.rb:757:10:757:10 | c [element] :  | semmle.label | c [element] :  |
 | array_flow.rb:757:10:757:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:757:10:757:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:761:5:761:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:761:5:761:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:761:16:761:25 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:761:16:761:25 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:764:5:764:5 | b :  | semmle.label | b :  |
+| array_flow.rb:764:5:764:5 | b :  | semmle.label | b :  |
 | array_flow.rb:764:9:764:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:764:9:764:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:764:9:764:13 | call to min :  | semmle.label | call to min :  |
 | array_flow.rb:764:9:764:13 | call to min :  | semmle.label | call to min :  |
 | array_flow.rb:765:10:765:10 | b | semmle.label | b |
 | array_flow.rb:765:10:765:10 | b | semmle.label | b |
+| array_flow.rb:768:5:768:5 | c [element] :  | semmle.label | c [element] :  |
+| array_flow.rb:768:5:768:5 | c [element] :  | semmle.label | c [element] :  |
 | array_flow.rb:768:9:768:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:768:9:768:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:768:9:768:16 | call to min [element] :  | semmle.label | call to min [element] :  |
@@ -4980,6 +6156,8 @@ nodes
 | array_flow.rb:769:10:769:10 | c [element] :  | semmle.label | c [element] :  |
 | array_flow.rb:769:10:769:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:769:10:769:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:772:5:772:5 | d :  | semmle.label | d :  |
+| array_flow.rb:772:5:772:5 | d :  | semmle.label | d :  |
 | array_flow.rb:772:9:772:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:772:9:772:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:772:9:776:7 | call to min :  | semmle.label | call to min :  |
@@ -4994,6 +6172,8 @@ nodes
 | array_flow.rb:774:14:774:14 | y | semmle.label | y |
 | array_flow.rb:777:10:777:10 | d | semmle.label | d |
 | array_flow.rb:777:10:777:10 | d | semmle.label | d |
+| array_flow.rb:780:5:780:5 | e [element] :  | semmle.label | e [element] :  |
+| array_flow.rb:780:5:780:5 | e [element] :  | semmle.label | e [element] :  |
 | array_flow.rb:780:9:780:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:780:9:780:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:780:9:784:7 | call to min [element] :  | semmle.label | call to min [element] :  |
@@ -5010,8 +6190,12 @@ nodes
 | array_flow.rb:785:10:785:10 | e [element] :  | semmle.label | e [element] :  |
 | array_flow.rb:785:10:785:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:785:10:785:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:789:5:789:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:789:5:789:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:789:16:789:25 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:789:16:789:25 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:792:5:792:5 | b :  | semmle.label | b :  |
+| array_flow.rb:792:5:792:5 | b :  | semmle.label | b :  |
 | array_flow.rb:792:9:792:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:792:9:792:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:792:9:795:7 | call to min_by :  | semmle.label | call to min_by :  |
@@ -5022,6 +6206,8 @@ nodes
 | array_flow.rb:793:14:793:14 | x | semmle.label | x |
 | array_flow.rb:796:10:796:10 | b | semmle.label | b |
 | array_flow.rb:796:10:796:10 | b | semmle.label | b |
+| array_flow.rb:799:5:799:5 | c [element] :  | semmle.label | c [element] :  |
+| array_flow.rb:799:5:799:5 | c [element] :  | semmle.label | c [element] :  |
 | array_flow.rb:799:9:799:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:799:9:799:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:799:9:802:7 | call to min_by [element] :  | semmle.label | call to min_by [element] :  |
@@ -5034,8 +6220,12 @@ nodes
 | array_flow.rb:803:10:803:10 | c [element] :  | semmle.label | c [element] :  |
 | array_flow.rb:803:10:803:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:803:10:803:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:807:5:807:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:807:5:807:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:807:16:807:25 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:807:16:807:25 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:809:5:809:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:809:5:809:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:809:9:809:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:809:9:809:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:809:9:809:16 | call to minmax [element] :  | semmle.label | call to minmax [element] :  |
@@ -5048,6 +6238,8 @@ nodes
 | array_flow.rb:811:10:811:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:811:10:811:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:811:10:811:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:813:5:813:5 | c [element] :  | semmle.label | c [element] :  |
+| array_flow.rb:813:5:813:5 | c [element] :  | semmle.label | c [element] :  |
 | array_flow.rb:813:9:813:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:813:9:813:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:813:9:817:7 | call to minmax [element] :  | semmle.label | call to minmax [element] :  |
@@ -5068,8 +6260,12 @@ nodes
 | array_flow.rb:819:10:819:10 | c [element] :  | semmle.label | c [element] :  |
 | array_flow.rb:819:10:819:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:819:10:819:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:823:5:823:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:823:5:823:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:823:16:823:25 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:823:16:823:25 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:824:5:824:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:824:5:824:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:824:9:824:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:824:9:824:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:824:9:827:7 | call to minmax_by [element] :  | semmle.label | call to minmax_by [element] :  |
@@ -5086,6 +6282,8 @@ nodes
 | array_flow.rb:829:10:829:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:829:10:829:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:829:10:829:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:833:5:833:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:833:5:833:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:833:16:833:25 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:833:16:833:25 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:834:5:834:5 | a [element 2] :  | semmle.label | a [element 2] :  |
@@ -5094,6 +6292,8 @@ nodes
 | array_flow.rb:834:17:834:17 | x :  | semmle.label | x :  |
 | array_flow.rb:835:14:835:14 | x | semmle.label | x |
 | array_flow.rb:835:14:835:14 | x | semmle.label | x |
+| array_flow.rb:842:5:842:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:842:5:842:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:842:16:842:25 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:842:16:842:25 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:843:5:843:5 | a [element 2] :  | semmle.label | a [element 2] :  |
@@ -5102,12 +6302,18 @@ nodes
 | array_flow.rb:843:16:843:16 | x :  | semmle.label | x :  |
 | array_flow.rb:844:14:844:14 | x | semmle.label | x |
 | array_flow.rb:844:14:844:14 | x | semmle.label | x |
+| array_flow.rb:849:5:849:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:849:16:849:25 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:850:5:850:5 | b :  | semmle.label | b :  |
 | array_flow.rb:850:9:850:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:850:9:850:20 | call to pack :  | semmle.label | call to pack :  |
 | array_flow.rb:851:10:851:10 | b | semmle.label | b |
+| array_flow.rb:855:5:855:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:855:5:855:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:855:16:855:25 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:855:16:855:25 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:856:5:856:5 | b [element, element] :  | semmle.label | b [element, element] :  |
+| array_flow.rb:856:5:856:5 | b [element, element] :  | semmle.label | b [element, element] :  |
 | array_flow.rb:856:9:856:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:856:9:856:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:856:9:859:7 | call to partition [element, element] :  | semmle.label | call to partition [element, element] :  |
@@ -5128,8 +6334,12 @@ nodes
 | array_flow.rb:861:10:861:13 | ...[...] [element] :  | semmle.label | ...[...] [element] :  |
 | array_flow.rb:861:10:861:16 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:861:10:861:16 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:865:5:865:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:865:5:865:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:865:16:865:25 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:865:16:865:25 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:867:5:867:5 | b [element 2] :  | semmle.label | b [element 2] :  |
+| array_flow.rb:867:5:867:5 | b [element 2] :  | semmle.label | b [element 2] :  |
 | array_flow.rb:867:9:867:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:867:9:867:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:867:9:871:7 | call to permutation [element 2] :  | semmle.label | call to permutation [element 2] :  |
@@ -5152,6 +6362,8 @@ nodes
 | array_flow.rb:873:10:873:10 | b [element 2] :  | semmle.label | b [element 2] :  |
 | array_flow.rb:873:10:873:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:873:10:873:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:875:5:875:5 | c [element 2] :  | semmle.label | c [element 2] :  |
+| array_flow.rb:875:5:875:5 | c [element 2] :  | semmle.label | c [element 2] :  |
 | array_flow.rb:875:9:875:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:875:9:875:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:875:9:878:7 | call to permutation [element 2] :  | semmle.label | call to permutation [element 2] :  |
@@ -5186,10 +6398,16 @@ nodes
 | array_flow.rb:887:10:887:10 | c [element 2] :  | semmle.label | c [element 2] :  |
 | array_flow.rb:887:10:887:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:887:10:887:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:894:5:894:5 | a [element 1] :  | semmle.label | a [element 1] :  |
+| array_flow.rb:894:5:894:5 | a [element 1] :  | semmle.label | a [element 1] :  |
+| array_flow.rb:894:5:894:5 | a [element 3] :  | semmle.label | a [element 3] :  |
+| array_flow.rb:894:5:894:5 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:894:13:894:24 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:894:13:894:24 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:894:30:894:41 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:894:30:894:41 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:895:5:895:5 | b :  | semmle.label | b :  |
+| array_flow.rb:895:5:895:5 | b :  | semmle.label | b :  |
 | array_flow.rb:895:9:895:9 | a [element 1] :  | semmle.label | a [element 1] :  |
 | array_flow.rb:895:9:895:9 | a [element 1] :  | semmle.label | a [element 1] :  |
 | array_flow.rb:895:9:895:9 | a [element 3] :  | semmle.label | a [element 3] :  |
@@ -5206,10 +6424,16 @@ nodes
 | array_flow.rb:900:10:900:10 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:900:10:900:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:900:10:900:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:902:5:902:5 | a [element 1] :  | semmle.label | a [element 1] :  |
+| array_flow.rb:902:5:902:5 | a [element 1] :  | semmle.label | a [element 1] :  |
+| array_flow.rb:902:5:902:5 | a [element 3] :  | semmle.label | a [element 3] :  |
+| array_flow.rb:902:5:902:5 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:902:13:902:24 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:902:13:902:24 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:902:30:902:41 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:902:30:902:41 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:903:5:903:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:903:5:903:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:903:9:903:9 | a [element 1] :  | semmle.label | a [element 1] :  |
 | array_flow.rb:903:9:903:9 | a [element 1] :  | semmle.label | a [element 1] :  |
 | array_flow.rb:903:9:903:9 | a [element 3] :  | semmle.label | a [element 3] :  |
@@ -5232,6 +6456,8 @@ nodes
 | array_flow.rb:909:10:909:10 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:909:10:909:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:909:10:909:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:913:5:913:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:913:5:913:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:913:16:913:27 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:913:16:913:27 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:914:5:914:5 | [post] a [element 2] :  | semmle.label | [post] a [element 2] :  |
@@ -5250,12 +6476,20 @@ nodes
 | array_flow.rb:920:10:920:10 | a [element 5] :  | semmle.label | a [element 5] :  |
 | array_flow.rb:920:10:920:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:920:10:920:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:924:5:924:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:924:5:924:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:924:16:924:27 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:924:16:924:27 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:925:5:925:5 | b [element 1] :  | semmle.label | b [element 1] :  |
+| array_flow.rb:925:5:925:5 | b [element 1] :  | semmle.label | b [element 1] :  |
 | array_flow.rb:925:13:925:24 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:925:13:925:24 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:926:5:926:5 | c [element 0] :  | semmle.label | c [element 0] :  |
+| array_flow.rb:926:5:926:5 | c [element 0] :  | semmle.label | c [element 0] :  |
 | array_flow.rb:926:10:926:21 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:926:10:926:21 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:927:5:927:5 | d [element, element] :  | semmle.label | d [element, element] :  |
+| array_flow.rb:927:5:927:5 | d [element, element] :  | semmle.label | d [element, element] :  |
 | array_flow.rb:927:9:927:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:927:9:927:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:927:9:927:22 | call to product [element, element] :  | semmle.label | call to product [element, element] :  |
@@ -5276,8 +6510,14 @@ nodes
 | array_flow.rb:929:10:929:13 | ...[...] [element] :  | semmle.label | ...[...] [element] :  |
 | array_flow.rb:929:10:929:16 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:929:10:929:16 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:933:5:933:5 | a [element 0] :  | semmle.label | a [element 0] :  |
+| array_flow.rb:933:5:933:5 | a [element 0] :  | semmle.label | a [element 0] :  |
 | array_flow.rb:933:10:933:21 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:933:10:933:21 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:934:5:934:5 | b [element 0] :  | semmle.label | b [element 0] :  |
+| array_flow.rb:934:5:934:5 | b [element 0] :  | semmle.label | b [element 0] :  |
+| array_flow.rb:934:5:934:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:934:5:934:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:934:9:934:9 | [post] a [element] :  | semmle.label | [post] a [element] :  |
 | array_flow.rb:934:9:934:9 | [post] a [element] :  | semmle.label | [post] a [element] :  |
 | array_flow.rb:934:9:934:9 | a [element 0] :  | semmle.label | a [element 0] :  |
@@ -5310,8 +6550,12 @@ nodes
 | array_flow.rb:938:10:938:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:938:10:938:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:938:10:938:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:944:5:944:5 | c [element 0] :  | semmle.label | c [element 0] :  |
+| array_flow.rb:944:5:944:5 | c [element 0] :  | semmle.label | c [element 0] :  |
 | array_flow.rb:944:10:944:19 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:944:10:944:19 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:945:5:945:5 | d [element 2, element 0] :  | semmle.label | d [element 2, element 0] :  |
+| array_flow.rb:945:5:945:5 | d [element 2, element 0] :  | semmle.label | d [element 2, element 0] :  |
 | array_flow.rb:945:16:945:16 | c [element 0] :  | semmle.label | c [element 0] :  |
 | array_flow.rb:945:16:945:16 | c [element 0] :  | semmle.label | c [element 0] :  |
 | array_flow.rb:946:10:946:10 | d [element 2, element 0] :  | semmle.label | d [element 2, element 0] :  |
@@ -5326,6 +6570,10 @@ nodes
 | array_flow.rb:947:10:947:22 | call to rassoc [element 0] :  | semmle.label | call to rassoc [element 0] :  |
 | array_flow.rb:947:10:947:25 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:947:10:947:25 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:951:5:951:5 | a [element 0] :  | semmle.label | a [element 0] :  |
+| array_flow.rb:951:5:951:5 | a [element 0] :  | semmle.label | a [element 0] :  |
+| array_flow.rb:951:5:951:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:951:5:951:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:951:10:951:21 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:951:10:951:21 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:951:27:951:38 | call to source :  | semmle.label | call to source :  |
@@ -5350,8 +6598,12 @@ nodes
 | array_flow.rb:957:28:957:28 | y :  | semmle.label | y :  |
 | array_flow.rb:959:14:959:14 | y | semmle.label | y |
 | array_flow.rb:959:14:959:14 | y | semmle.label | y |
+| array_flow.rb:965:5:965:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:965:5:965:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:965:16:965:25 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:965:16:965:25 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:966:5:966:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:966:5:966:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:966:9:966:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:966:9:966:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:966:9:969:7 | call to reject [element] :  | semmle.label | call to reject [element] :  |
@@ -5364,8 +6616,12 @@ nodes
 | array_flow.rb:970:10:970:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:970:10:970:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:970:10:970:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:974:5:974:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:974:5:974:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:974:16:974:25 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:974:16:974:25 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:975:5:975:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:975:5:975:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:975:9:975:9 | [post] a [element] :  | semmle.label | [post] a [element] :  |
 | array_flow.rb:975:9:975:9 | [post] a [element] :  | semmle.label | [post] a [element] :  |
 | array_flow.rb:975:9:975:9 | a [element 2] :  | semmle.label | a [element 2] :  |
@@ -5384,8 +6640,12 @@ nodes
 | array_flow.rb:980:10:980:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:980:10:980:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:980:10:980:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:984:5:984:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:984:5:984:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:984:16:984:25 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:984:16:984:25 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:985:5:985:5 | b [element 2] :  | semmle.label | b [element 2] :  |
+| array_flow.rb:985:5:985:5 | b [element 2] :  | semmle.label | b [element 2] :  |
 | array_flow.rb:985:9:985:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:985:9:985:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:985:9:988:7 | call to repeated_combination [element 2] :  | semmle.label | call to repeated_combination [element 2] :  |
@@ -5404,8 +6664,12 @@ nodes
 | array_flow.rb:990:10:990:10 | b [element 2] :  | semmle.label | b [element 2] :  |
 | array_flow.rb:990:10:990:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:990:10:990:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:994:5:994:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:994:5:994:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:994:16:994:25 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:994:16:994:25 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:995:5:995:5 | b [element 2] :  | semmle.label | b [element 2] :  |
+| array_flow.rb:995:5:995:5 | b [element 2] :  | semmle.label | b [element 2] :  |
 | array_flow.rb:995:9:995:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:995:9:995:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:995:9:998:7 | call to repeated_permutation [element 2] :  | semmle.label | call to repeated_permutation [element 2] :  |
@@ -5424,6 +6688,8 @@ nodes
 | array_flow.rb:1000:10:1000:10 | b [element 2] :  | semmle.label | b [element 2] :  |
 | array_flow.rb:1000:10:1000:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1000:10:1000:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1006:5:1006:5 | b [element 0] :  | semmle.label | b [element 0] :  |
+| array_flow.rb:1006:5:1006:5 | b [element 0] :  | semmle.label | b [element 0] :  |
 | array_flow.rb:1006:9:1006:9 | [post] a [element 0] :  | semmle.label | [post] a [element 0] :  |
 | array_flow.rb:1006:9:1006:9 | [post] a [element 0] :  | semmle.label | [post] a [element 0] :  |
 | array_flow.rb:1006:9:1006:33 | call to replace [element 0] :  | semmle.label | call to replace [element 0] :  |
@@ -5438,10 +6704,16 @@ nodes
 | array_flow.rb:1008:10:1008:10 | b [element 0] :  | semmle.label | b [element 0] :  |
 | array_flow.rb:1008:10:1008:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1008:10:1008:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1012:5:1012:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1012:5:1012:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1012:5:1012:5 | a [element 3] :  | semmle.label | a [element 3] :  |
+| array_flow.rb:1012:5:1012:5 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:1012:16:1012:28 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1012:16:1012:28 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1012:31:1012:43 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1012:31:1012:43 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1013:5:1013:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:1013:5:1013:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:1013:9:1013:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1013:9:1013:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1013:9:1013:9 | a [element 3] :  | semmle.label | a [element 3] :  |
@@ -5468,10 +6740,16 @@ nodes
 | array_flow.rb:1019:10:1019:10 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:1019:10:1019:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1019:10:1019:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1023:5:1023:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1023:5:1023:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1023:5:1023:5 | a [element 3] :  | semmle.label | a [element 3] :  |
+| array_flow.rb:1023:5:1023:5 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:1023:16:1023:28 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1023:16:1023:28 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1023:31:1023:43 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1023:31:1023:43 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1024:5:1024:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:1024:5:1024:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:1024:9:1024:9 | [post] a [element] :  | semmle.label | [post] a [element] :  |
 | array_flow.rb:1024:9:1024:9 | [post] a [element] :  | semmle.label | [post] a [element] :  |
 | array_flow.rb:1024:9:1024:9 | a [element 2] :  | semmle.label | a [element 2] :  |
@@ -5508,8 +6786,12 @@ nodes
 | array_flow.rb:1030:10:1030:10 | a [element] :  | semmle.label | a [element] :  |
 | array_flow.rb:1030:10:1030:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1030:10:1030:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1034:5:1034:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1034:5:1034:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1034:16:1034:26 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1034:16:1034:26 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1035:5:1035:5 | b [element 2] :  | semmle.label | b [element 2] :  |
+| array_flow.rb:1035:5:1035:5 | b [element 2] :  | semmle.label | b [element 2] :  |
 | array_flow.rb:1035:9:1035:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1035:9:1035:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1035:9:1037:7 | call to reverse_each [element 2] :  | semmle.label | call to reverse_each [element 2] :  |
@@ -5522,6 +6804,8 @@ nodes
 | array_flow.rb:1038:10:1038:10 | b [element 2] :  | semmle.label | b [element 2] :  |
 | array_flow.rb:1038:10:1038:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1038:10:1038:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1042:5:1042:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1042:5:1042:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1042:16:1042:26 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1042:16:1042:26 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1043:5:1043:5 | a [element 2] :  | semmle.label | a [element 2] :  |
@@ -5530,12 +6814,24 @@ nodes
 | array_flow.rb:1043:18:1043:18 | x :  | semmle.label | x :  |
 | array_flow.rb:1044:14:1044:14 | x | semmle.label | x |
 | array_flow.rb:1044:14:1044:14 | x | semmle.label | x |
+| array_flow.rb:1052:5:1052:5 | a [element 0] :  | semmle.label | a [element 0] :  |
+| array_flow.rb:1052:5:1052:5 | a [element 0] :  | semmle.label | a [element 0] :  |
+| array_flow.rb:1052:5:1052:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1052:5:1052:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1052:5:1052:5 | a [element 3] :  | semmle.label | a [element 3] :  |
+| array_flow.rb:1052:5:1052:5 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:1052:10:1052:22 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1052:10:1052:22 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1052:28:1052:40 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1052:28:1052:40 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1052:43:1052:55 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1052:43:1052:55 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1054:5:1054:5 | b [element 1] :  | semmle.label | b [element 1] :  |
+| array_flow.rb:1054:5:1054:5 | b [element 1] :  | semmle.label | b [element 1] :  |
+| array_flow.rb:1054:5:1054:5 | b [element 2] :  | semmle.label | b [element 2] :  |
+| array_flow.rb:1054:5:1054:5 | b [element 2] :  | semmle.label | b [element 2] :  |
+| array_flow.rb:1054:5:1054:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:1054:5:1054:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:1054:9:1054:9 | a [element 0] :  | semmle.label | a [element 0] :  |
 | array_flow.rb:1054:9:1054:9 | a [element 0] :  | semmle.label | a [element 0] :  |
 | array_flow.rb:1054:9:1054:9 | a [element 2] :  | semmle.label | a [element 2] :  |
@@ -5568,6 +6864,12 @@ nodes
 | array_flow.rb:1058:10:1058:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:1058:10:1058:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1058:10:1058:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1060:5:1060:5 | b [element 0] :  | semmle.label | b [element 0] :  |
+| array_flow.rb:1060:5:1060:5 | b [element 0] :  | semmle.label | b [element 0] :  |
+| array_flow.rb:1060:5:1060:5 | b [element 1] :  | semmle.label | b [element 1] :  |
+| array_flow.rb:1060:5:1060:5 | b [element 1] :  | semmle.label | b [element 1] :  |
+| array_flow.rb:1060:5:1060:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:1060:5:1060:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:1060:9:1060:9 | a [element 0] :  | semmle.label | a [element 0] :  |
 | array_flow.rb:1060:9:1060:9 | a [element 0] :  | semmle.label | a [element 0] :  |
 | array_flow.rb:1060:9:1060:9 | a [element 2] :  | semmle.label | a [element 2] :  |
@@ -5600,6 +6902,12 @@ nodes
 | array_flow.rb:1064:10:1064:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:1064:10:1064:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1064:10:1064:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1066:5:1066:5 | b [element 0] :  | semmle.label | b [element 0] :  |
+| array_flow.rb:1066:5:1066:5 | b [element 0] :  | semmle.label | b [element 0] :  |
+| array_flow.rb:1066:5:1066:5 | b [element 2] :  | semmle.label | b [element 2] :  |
+| array_flow.rb:1066:5:1066:5 | b [element 2] :  | semmle.label | b [element 2] :  |
+| array_flow.rb:1066:5:1066:5 | b [element 3] :  | semmle.label | b [element 3] :  |
+| array_flow.rb:1066:5:1066:5 | b [element 3] :  | semmle.label | b [element 3] :  |
 | array_flow.rb:1066:9:1066:9 | a [element 0] :  | semmle.label | a [element 0] :  |
 | array_flow.rb:1066:9:1066:9 | a [element 0] :  | semmle.label | a [element 0] :  |
 | array_flow.rb:1066:9:1066:9 | a [element 2] :  | semmle.label | a [element 2] :  |
@@ -5624,6 +6932,8 @@ nodes
 | array_flow.rb:1070:10:1070:10 | b [element 3] :  | semmle.label | b [element 3] :  |
 | array_flow.rb:1070:10:1070:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1070:10:1070:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1072:5:1072:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:1072:5:1072:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:1072:9:1072:9 | a [element 0] :  | semmle.label | a [element 0] :  |
 | array_flow.rb:1072:9:1072:9 | a [element 0] :  | semmle.label | a [element 0] :  |
 | array_flow.rb:1072:9:1072:9 | a [element 2] :  | semmle.label | a [element 2] :  |
@@ -5648,12 +6958,24 @@ nodes
 | array_flow.rb:1076:10:1076:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:1076:10:1076:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1076:10:1076:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1084:5:1084:5 | a [element 0] :  | semmle.label | a [element 0] :  |
+| array_flow.rb:1084:5:1084:5 | a [element 0] :  | semmle.label | a [element 0] :  |
+| array_flow.rb:1084:5:1084:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1084:5:1084:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1084:5:1084:5 | a [element 3] :  | semmle.label | a [element 3] :  |
+| array_flow.rb:1084:5:1084:5 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:1084:10:1084:22 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1084:10:1084:22 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1084:28:1084:40 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1084:28:1084:40 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1084:43:1084:55 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1084:43:1084:55 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1085:5:1085:5 | b [element 1] :  | semmle.label | b [element 1] :  |
+| array_flow.rb:1085:5:1085:5 | b [element 1] :  | semmle.label | b [element 1] :  |
+| array_flow.rb:1085:5:1085:5 | b [element 2] :  | semmle.label | b [element 2] :  |
+| array_flow.rb:1085:5:1085:5 | b [element 2] :  | semmle.label | b [element 2] :  |
+| array_flow.rb:1085:5:1085:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:1085:5:1085:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:1085:9:1085:9 | [post] a [element 1] :  | semmle.label | [post] a [element 1] :  |
 | array_flow.rb:1085:9:1085:9 | [post] a [element 1] :  | semmle.label | [post] a [element 1] :  |
 | array_flow.rb:1085:9:1085:9 | [post] a [element 2] :  | semmle.label | [post] a [element 2] :  |
@@ -5712,12 +7034,24 @@ nodes
 | array_flow.rb:1093:10:1093:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:1093:10:1093:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1093:10:1093:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1095:5:1095:5 | a [element 0] :  | semmle.label | a [element 0] :  |
+| array_flow.rb:1095:5:1095:5 | a [element 0] :  | semmle.label | a [element 0] :  |
+| array_flow.rb:1095:5:1095:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1095:5:1095:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1095:5:1095:5 | a [element 3] :  | semmle.label | a [element 3] :  |
+| array_flow.rb:1095:5:1095:5 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:1095:10:1095:22 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1095:10:1095:22 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1095:28:1095:40 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1095:28:1095:40 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1095:43:1095:55 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1095:43:1095:55 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1096:5:1096:5 | b [element 0] :  | semmle.label | b [element 0] :  |
+| array_flow.rb:1096:5:1096:5 | b [element 0] :  | semmle.label | b [element 0] :  |
+| array_flow.rb:1096:5:1096:5 | b [element 1] :  | semmle.label | b [element 1] :  |
+| array_flow.rb:1096:5:1096:5 | b [element 1] :  | semmle.label | b [element 1] :  |
+| array_flow.rb:1096:5:1096:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:1096:5:1096:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:1096:9:1096:9 | [post] a [element 0] :  | semmle.label | [post] a [element 0] :  |
 | array_flow.rb:1096:9:1096:9 | [post] a [element 0] :  | semmle.label | [post] a [element 0] :  |
 | array_flow.rb:1096:9:1096:9 | [post] a [element 1] :  | semmle.label | [post] a [element 1] :  |
@@ -5776,12 +7110,24 @@ nodes
 | array_flow.rb:1104:10:1104:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:1104:10:1104:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1104:10:1104:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1106:5:1106:5 | a [element 0] :  | semmle.label | a [element 0] :  |
+| array_flow.rb:1106:5:1106:5 | a [element 0] :  | semmle.label | a [element 0] :  |
+| array_flow.rb:1106:5:1106:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1106:5:1106:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1106:5:1106:5 | a [element 3] :  | semmle.label | a [element 3] :  |
+| array_flow.rb:1106:5:1106:5 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:1106:10:1106:22 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1106:10:1106:22 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1106:28:1106:40 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1106:28:1106:40 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1106:43:1106:55 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1106:43:1106:55 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1107:5:1107:5 | b [element 0] :  | semmle.label | b [element 0] :  |
+| array_flow.rb:1107:5:1107:5 | b [element 0] :  | semmle.label | b [element 0] :  |
+| array_flow.rb:1107:5:1107:5 | b [element 2] :  | semmle.label | b [element 2] :  |
+| array_flow.rb:1107:5:1107:5 | b [element 2] :  | semmle.label | b [element 2] :  |
+| array_flow.rb:1107:5:1107:5 | b [element 3] :  | semmle.label | b [element 3] :  |
+| array_flow.rb:1107:5:1107:5 | b [element 3] :  | semmle.label | b [element 3] :  |
 | array_flow.rb:1107:9:1107:9 | [post] a [element 0] :  | semmle.label | [post] a [element 0] :  |
 | array_flow.rb:1107:9:1107:9 | [post] a [element 0] :  | semmle.label | [post] a [element 0] :  |
 | array_flow.rb:1107:9:1107:9 | [post] a [element 2] :  | semmle.label | [post] a [element 2] :  |
@@ -5824,12 +7170,20 @@ nodes
 | array_flow.rb:1115:10:1115:10 | b [element 3] :  | semmle.label | b [element 3] :  |
 | array_flow.rb:1115:10:1115:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1115:10:1115:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1117:5:1117:5 | a [element 0] :  | semmle.label | a [element 0] :  |
+| array_flow.rb:1117:5:1117:5 | a [element 0] :  | semmle.label | a [element 0] :  |
+| array_flow.rb:1117:5:1117:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1117:5:1117:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1117:5:1117:5 | a [element 3] :  | semmle.label | a [element 3] :  |
+| array_flow.rb:1117:5:1117:5 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:1117:10:1117:22 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1117:10:1117:22 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1117:28:1117:40 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1117:28:1117:40 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1117:43:1117:55 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1117:43:1117:55 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1118:5:1118:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:1118:5:1118:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:1118:9:1118:9 | [post] a [element] :  | semmle.label | [post] a [element] :  |
 | array_flow.rb:1118:9:1118:9 | [post] a [element] :  | semmle.label | [post] a [element] :  |
 | array_flow.rb:1118:9:1118:9 | a [element 0] :  | semmle.label | a [element 0] :  |
@@ -5872,8 +7226,12 @@ nodes
 | array_flow.rb:1126:10:1126:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:1126:10:1126:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1126:10:1126:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1130:5:1130:5 | a [element 3] :  | semmle.label | a [element 3] :  |
+| array_flow.rb:1130:5:1130:5 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:1130:19:1130:29 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1130:19:1130:29 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1131:5:1131:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:1131:5:1131:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:1131:9:1131:9 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:1131:9:1131:9 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:1131:9:1133:7 | call to select [element] :  | semmle.label | call to select [element] :  |
@@ -5886,8 +7244,12 @@ nodes
 | array_flow.rb:1134:10:1134:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:1134:10:1134:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1134:10:1134:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1138:5:1138:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1138:5:1138:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1138:16:1138:26 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1138:16:1138:26 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1139:5:1139:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:1139:5:1139:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:1139:9:1139:9 | [post] a [element] :  | semmle.label | [post] a [element] :  |
 | array_flow.rb:1139:9:1139:9 | [post] a [element] :  | semmle.label | [post] a [element] :  |
 | array_flow.rb:1139:9:1139:9 | a [element 2] :  | semmle.label | a [element 2] :  |
@@ -5906,10 +7268,16 @@ nodes
 | array_flow.rb:1144:10:1144:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:1144:10:1144:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1144:10:1144:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1148:5:1148:5 | a [element 0] :  | semmle.label | a [element 0] :  |
+| array_flow.rb:1148:5:1148:5 | a [element 0] :  | semmle.label | a [element 0] :  |
+| array_flow.rb:1148:5:1148:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1148:5:1148:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1148:10:1148:22 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1148:10:1148:22 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1148:28:1148:40 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1148:28:1148:40 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1149:5:1149:5 | b :  | semmle.label | b :  |
+| array_flow.rb:1149:5:1149:5 | b :  | semmle.label | b :  |
 | array_flow.rb:1149:9:1149:9 | [post] a [element 1] :  | semmle.label | [post] a [element 1] :  |
 | array_flow.rb:1149:9:1149:9 | [post] a [element 1] :  | semmle.label | [post] a [element 1] :  |
 | array_flow.rb:1149:9:1149:9 | a [element 0] :  | semmle.label | a [element 0] :  |
@@ -5924,10 +7292,16 @@ nodes
 | array_flow.rb:1152:10:1152:10 | a [element 1] :  | semmle.label | a [element 1] :  |
 | array_flow.rb:1152:10:1152:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1152:10:1152:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1155:5:1155:5 | a [element 0] :  | semmle.label | a [element 0] :  |
+| array_flow.rb:1155:5:1155:5 | a [element 0] :  | semmle.label | a [element 0] :  |
+| array_flow.rb:1155:5:1155:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1155:5:1155:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1155:10:1155:22 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1155:10:1155:22 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1155:28:1155:40 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1155:28:1155:40 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1156:5:1156:5 | b [element 0] :  | semmle.label | b [element 0] :  |
+| array_flow.rb:1156:5:1156:5 | b [element 0] :  | semmle.label | b [element 0] :  |
 | array_flow.rb:1156:9:1156:9 | [post] a [element 0] :  | semmle.label | [post] a [element 0] :  |
 | array_flow.rb:1156:9:1156:9 | [post] a [element 0] :  | semmle.label | [post] a [element 0] :  |
 | array_flow.rb:1156:9:1156:9 | a [element 0] :  | semmle.label | a [element 0] :  |
@@ -5944,10 +7318,16 @@ nodes
 | array_flow.rb:1159:10:1159:10 | a [element 0] :  | semmle.label | a [element 0] :  |
 | array_flow.rb:1159:10:1159:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1159:10:1159:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1163:5:1163:5 | a [element 0] :  | semmle.label | a [element 0] :  |
+| array_flow.rb:1163:5:1163:5 | a [element 0] :  | semmle.label | a [element 0] :  |
+| array_flow.rb:1163:5:1163:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1163:5:1163:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1163:10:1163:22 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1163:10:1163:22 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1163:28:1163:40 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1163:28:1163:40 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1164:5:1164:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:1164:5:1164:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:1164:9:1164:9 | [post] a [element] :  | semmle.label | [post] a [element] :  |
 | array_flow.rb:1164:9:1164:9 | [post] a [element] :  | semmle.label | [post] a [element] :  |
 | array_flow.rb:1164:9:1164:9 | a [element 0] :  | semmle.label | a [element 0] :  |
@@ -5980,8 +7360,12 @@ nodes
 | array_flow.rb:1169:10:1169:10 | a [element] :  | semmle.label | a [element] :  |
 | array_flow.rb:1169:10:1169:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1169:10:1169:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1173:5:1173:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1173:5:1173:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1173:16:1173:26 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1173:16:1173:26 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1174:5:1174:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:1174:5:1174:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:1174:9:1174:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1174:9:1174:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1174:9:1174:17 | call to shuffle [element] :  | semmle.label | call to shuffle [element] :  |
@@ -6002,8 +7386,12 @@ nodes
 | array_flow.rb:1180:10:1180:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:1180:10:1180:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1180:10:1180:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1184:5:1184:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1184:5:1184:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1184:16:1184:26 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1184:16:1184:26 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1185:5:1185:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:1185:5:1185:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:1185:9:1185:9 | [post] a [element] :  | semmle.label | [post] a [element] :  |
 | array_flow.rb:1185:9:1185:9 | [post] a [element] :  | semmle.label | [post] a [element] :  |
 | array_flow.rb:1185:9:1185:9 | a [element 2] :  | semmle.label | a [element 2] :  |
@@ -6036,16 +7424,24 @@ nodes
 | array_flow.rb:1191:10:1191:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:1191:10:1191:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1191:10:1191:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1195:5:1195:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1195:5:1195:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1195:5:1195:5 | a [element 4] :  | semmle.label | a [element 4] :  |
+| array_flow.rb:1195:5:1195:5 | a [element 4] :  | semmle.label | a [element 4] :  |
 | array_flow.rb:1195:16:1195:28 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1195:16:1195:28 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1195:34:1195:46 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1195:34:1195:46 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1197:5:1197:5 | b :  | semmle.label | b :  |
+| array_flow.rb:1197:5:1197:5 | b :  | semmle.label | b :  |
 | array_flow.rb:1197:9:1197:9 | a [element 4] :  | semmle.label | a [element 4] :  |
 | array_flow.rb:1197:9:1197:9 | a [element 4] :  | semmle.label | a [element 4] :  |
 | array_flow.rb:1197:9:1197:17 | call to slice :  | semmle.label | call to slice :  |
 | array_flow.rb:1197:9:1197:17 | call to slice :  | semmle.label | call to slice :  |
 | array_flow.rb:1198:10:1198:10 | b | semmle.label | b |
 | array_flow.rb:1198:10:1198:10 | b | semmle.label | b |
+| array_flow.rb:1200:5:1200:5 | b :  | semmle.label | b :  |
+| array_flow.rb:1200:5:1200:5 | b :  | semmle.label | b :  |
 | array_flow.rb:1200:9:1200:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1200:9:1200:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1200:9:1200:9 | a [element 4] :  | semmle.label | a [element 4] :  |
@@ -6054,6 +7450,10 @@ nodes
 | array_flow.rb:1200:9:1200:19 | call to slice :  | semmle.label | call to slice :  |
 | array_flow.rb:1201:10:1201:10 | b | semmle.label | b |
 | array_flow.rb:1201:10:1201:10 | b | semmle.label | b |
+| array_flow.rb:1203:5:1203:5 | b :  | semmle.label | b :  |
+| array_flow.rb:1203:5:1203:5 | b :  | semmle.label | b :  |
+| array_flow.rb:1203:5:1203:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:1203:5:1203:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:1203:9:1203:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1203:9:1203:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1203:9:1203:9 | a [element 4] :  | semmle.label | a [element 4] :  |
@@ -6069,6 +7469,10 @@ nodes
 | array_flow.rb:1207:10:1207:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:1207:10:1207:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1207:10:1207:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1209:5:1209:5 | b [element 0] :  | semmle.label | b [element 0] :  |
+| array_flow.rb:1209:5:1209:5 | b [element 0] :  | semmle.label | b [element 0] :  |
+| array_flow.rb:1209:5:1209:5 | b [element 2] :  | semmle.label | b [element 2] :  |
+| array_flow.rb:1209:5:1209:5 | b [element 2] :  | semmle.label | b [element 2] :  |
 | array_flow.rb:1209:9:1209:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1209:9:1209:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1209:9:1209:9 | a [element 4] :  | semmle.label | a [element 4] :  |
@@ -6085,6 +7489,8 @@ nodes
 | array_flow.rb:1212:10:1212:10 | b [element 2] :  | semmle.label | b [element 2] :  |
 | array_flow.rb:1212:10:1212:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1212:10:1212:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1214:5:1214:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:1214:5:1214:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:1214:9:1214:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1214:9:1214:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1214:9:1214:9 | a [element 4] :  | semmle.label | a [element 4] :  |
@@ -6099,6 +7505,8 @@ nodes
 | array_flow.rb:1216:10:1216:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:1216:10:1216:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1216:10:1216:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1218:5:1218:5 | b [element 0] :  | semmle.label | b [element 0] :  |
+| array_flow.rb:1218:5:1218:5 | b [element 0] :  | semmle.label | b [element 0] :  |
 | array_flow.rb:1218:9:1218:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1218:9:1218:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1218:9:1218:21 | call to slice [element 0] :  | semmle.label | call to slice [element 0] :  |
@@ -6107,6 +7515,8 @@ nodes
 | array_flow.rb:1219:10:1219:10 | b [element 0] :  | semmle.label | b [element 0] :  |
 | array_flow.rb:1219:10:1219:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1219:10:1219:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1223:5:1223:5 | b [element 0] :  | semmle.label | b [element 0] :  |
+| array_flow.rb:1223:5:1223:5 | b [element 0] :  | semmle.label | b [element 0] :  |
 | array_flow.rb:1223:9:1223:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1223:9:1223:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1223:9:1223:22 | call to slice [element 0] :  | semmle.label | call to slice [element 0] :  |
@@ -6115,6 +7525,8 @@ nodes
 | array_flow.rb:1224:10:1224:10 | b [element 0] :  | semmle.label | b [element 0] :  |
 | array_flow.rb:1224:10:1224:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1224:10:1224:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1228:5:1228:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:1228:5:1228:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:1228:9:1228:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1228:9:1228:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1228:9:1228:9 | a [element 4] :  | semmle.label | a [element 4] :  |
@@ -6129,6 +7541,8 @@ nodes
 | array_flow.rb:1230:10:1230:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:1230:10:1230:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1230:10:1230:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1232:5:1232:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:1232:5:1232:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:1232:9:1232:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1232:9:1232:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1232:9:1232:9 | a [element 4] :  | semmle.label | a [element 4] :  |
@@ -6143,6 +7557,8 @@ nodes
 | array_flow.rb:1234:10:1234:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:1234:10:1234:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1234:10:1234:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1236:5:1236:5 | b [element 2] :  | semmle.label | b [element 2] :  |
+| array_flow.rb:1236:5:1236:5 | b [element 2] :  | semmle.label | b [element 2] :  |
 | array_flow.rb:1236:9:1236:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1236:9:1236:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1236:9:1236:20 | call to slice [element 2] :  | semmle.label | call to slice [element 2] :  |
@@ -6151,6 +7567,8 @@ nodes
 | array_flow.rb:1239:10:1239:10 | b [element 2] :  | semmle.label | b [element 2] :  |
 | array_flow.rb:1239:10:1239:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1239:10:1239:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1241:5:1241:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:1241:5:1241:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:1241:9:1241:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1241:9:1241:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1241:9:1241:9 | a [element 4] :  | semmle.label | a [element 4] :  |
@@ -6169,10 +7587,16 @@ nodes
 | array_flow.rb:1244:10:1244:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:1244:10:1244:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1244:10:1244:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1248:5:1248:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1248:5:1248:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1248:5:1248:5 | a [element 4] :  | semmle.label | a [element 4] :  |
+| array_flow.rb:1248:5:1248:5 | a [element 4] :  | semmle.label | a [element 4] :  |
 | array_flow.rb:1248:16:1248:28 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1248:16:1248:28 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1248:34:1248:46 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1248:34:1248:46 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1249:5:1249:5 | b :  | semmle.label | b :  |
+| array_flow.rb:1249:5:1249:5 | b :  | semmle.label | b :  |
 | array_flow.rb:1249:9:1249:9 | [post] a [element 3] :  | semmle.label | [post] a [element 3] :  |
 | array_flow.rb:1249:9:1249:9 | [post] a [element 3] :  | semmle.label | [post] a [element 3] :  |
 | array_flow.rb:1249:9:1249:9 | a [element 2] :  | semmle.label | a [element 2] :  |
@@ -6187,10 +7611,18 @@ nodes
 | array_flow.rb:1254:10:1254:10 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:1254:10:1254:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1254:10:1254:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1256:5:1256:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1256:5:1256:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1256:5:1256:5 | a [element 4] :  | semmle.label | a [element 4] :  |
+| array_flow.rb:1256:5:1256:5 | a [element 4] :  | semmle.label | a [element 4] :  |
 | array_flow.rb:1256:16:1256:28 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1256:16:1256:28 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1256:34:1256:46 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1256:34:1256:46 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1257:5:1257:5 | b :  | semmle.label | b :  |
+| array_flow.rb:1257:5:1257:5 | b :  | semmle.label | b :  |
+| array_flow.rb:1257:5:1257:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:1257:5:1257:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:1257:9:1257:9 | [post] a [element] :  | semmle.label | [post] a [element] :  |
 | array_flow.rb:1257:9:1257:9 | [post] a [element] :  | semmle.label | [post] a [element] :  |
 | array_flow.rb:1257:9:1257:9 | a [element 2] :  | semmle.label | a [element 2] :  |
@@ -6224,10 +7656,18 @@ nodes
 | array_flow.rb:1265:10:1265:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:1265:10:1265:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1265:10:1265:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1267:5:1267:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1267:5:1267:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1267:5:1267:5 | a [element 4] :  | semmle.label | a [element 4] :  |
+| array_flow.rb:1267:5:1267:5 | a [element 4] :  | semmle.label | a [element 4] :  |
 | array_flow.rb:1267:16:1267:28 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1267:16:1267:28 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1267:34:1267:46 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1267:34:1267:46 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1268:5:1268:5 | b [element 0] :  | semmle.label | b [element 0] :  |
+| array_flow.rb:1268:5:1268:5 | b [element 0] :  | semmle.label | b [element 0] :  |
+| array_flow.rb:1268:5:1268:5 | b [element 2] :  | semmle.label | b [element 2] :  |
+| array_flow.rb:1268:5:1268:5 | b [element 2] :  | semmle.label | b [element 2] :  |
 | array_flow.rb:1268:9:1268:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1268:9:1268:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1268:9:1268:9 | a [element 4] :  | semmle.label | a [element 4] :  |
@@ -6244,10 +7684,16 @@ nodes
 | array_flow.rb:1271:10:1271:10 | b [element 2] :  | semmle.label | b [element 2] :  |
 | array_flow.rb:1271:10:1271:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1271:10:1271:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1278:5:1278:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1278:5:1278:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1278:5:1278:5 | a [element 4] :  | semmle.label | a [element 4] :  |
+| array_flow.rb:1278:5:1278:5 | a [element 4] :  | semmle.label | a [element 4] :  |
 | array_flow.rb:1278:16:1278:28 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1278:16:1278:28 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1278:34:1278:46 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1278:34:1278:46 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1279:5:1279:5 | b [element 0] :  | semmle.label | b [element 0] :  |
+| array_flow.rb:1279:5:1279:5 | b [element 0] :  | semmle.label | b [element 0] :  |
 | array_flow.rb:1279:9:1279:9 | [post] a [element 2] :  | semmle.label | [post] a [element 2] :  |
 | array_flow.rb:1279:9:1279:9 | [post] a [element 2] :  | semmle.label | [post] a [element 2] :  |
 | array_flow.rb:1279:9:1279:9 | a [element 2] :  | semmle.label | a [element 2] :  |
@@ -6264,10 +7710,16 @@ nodes
 | array_flow.rb:1285:10:1285:10 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1285:10:1285:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1285:10:1285:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1289:5:1289:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1289:5:1289:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1289:5:1289:5 | a [element 4] :  | semmle.label | a [element 4] :  |
+| array_flow.rb:1289:5:1289:5 | a [element 4] :  | semmle.label | a [element 4] :  |
 | array_flow.rb:1289:16:1289:28 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1289:16:1289:28 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1289:34:1289:46 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1289:34:1289:46 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1290:5:1290:5 | b [element 0] :  | semmle.label | b [element 0] :  |
+| array_flow.rb:1290:5:1290:5 | b [element 0] :  | semmle.label | b [element 0] :  |
 | array_flow.rb:1290:9:1290:9 | [post] a [element 2] :  | semmle.label | [post] a [element 2] :  |
 | array_flow.rb:1290:9:1290:9 | [post] a [element 2] :  | semmle.label | [post] a [element 2] :  |
 | array_flow.rb:1290:9:1290:9 | a [element 2] :  | semmle.label | a [element 2] :  |
@@ -6284,10 +7736,16 @@ nodes
 | array_flow.rb:1296:10:1296:10 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1296:10:1296:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1296:10:1296:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1300:5:1300:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1300:5:1300:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1300:5:1300:5 | a [element 4] :  | semmle.label | a [element 4] :  |
+| array_flow.rb:1300:5:1300:5 | a [element 4] :  | semmle.label | a [element 4] :  |
 | array_flow.rb:1300:16:1300:28 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1300:16:1300:28 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1300:34:1300:46 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1300:34:1300:46 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1301:5:1301:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:1301:5:1301:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:1301:9:1301:9 | [post] a [element] :  | semmle.label | [post] a [element] :  |
 | array_flow.rb:1301:9:1301:9 | [post] a [element] :  | semmle.label | [post] a [element] :  |
 | array_flow.rb:1301:9:1301:9 | a [element 2] :  | semmle.label | a [element 2] :  |
@@ -6320,10 +7778,16 @@ nodes
 | array_flow.rb:1307:10:1307:10 | a [element] :  | semmle.label | a [element] :  |
 | array_flow.rb:1307:10:1307:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1307:10:1307:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1309:5:1309:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1309:5:1309:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1309:5:1309:5 | a [element 4] :  | semmle.label | a [element 4] :  |
+| array_flow.rb:1309:5:1309:5 | a [element 4] :  | semmle.label | a [element 4] :  |
 | array_flow.rb:1309:16:1309:28 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1309:16:1309:28 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1309:34:1309:46 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1309:34:1309:46 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1310:5:1310:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:1310:5:1310:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:1310:9:1310:9 | [post] a [element] :  | semmle.label | [post] a [element] :  |
 | array_flow.rb:1310:9:1310:9 | [post] a [element] :  | semmle.label | [post] a [element] :  |
 | array_flow.rb:1310:9:1310:9 | a [element 2] :  | semmle.label | a [element 2] :  |
@@ -6356,10 +7820,16 @@ nodes
 | array_flow.rb:1316:10:1316:10 | a [element] :  | semmle.label | a [element] :  |
 | array_flow.rb:1316:10:1316:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1316:10:1316:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1318:5:1318:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1318:5:1318:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1318:5:1318:5 | a [element 4] :  | semmle.label | a [element 4] :  |
+| array_flow.rb:1318:5:1318:5 | a [element 4] :  | semmle.label | a [element 4] :  |
 | array_flow.rb:1318:16:1318:28 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1318:16:1318:28 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1318:34:1318:46 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1318:34:1318:46 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1319:5:1319:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:1319:5:1319:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:1319:9:1319:9 | [post] a [element] :  | semmle.label | [post] a [element] :  |
 | array_flow.rb:1319:9:1319:9 | [post] a [element] :  | semmle.label | [post] a [element] :  |
 | array_flow.rb:1319:9:1319:9 | a [element 2] :  | semmle.label | a [element 2] :  |
@@ -6392,10 +7862,16 @@ nodes
 | array_flow.rb:1325:10:1325:10 | a [element] :  | semmle.label | a [element] :  |
 | array_flow.rb:1325:10:1325:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1325:10:1325:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1327:5:1327:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1327:5:1327:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1327:5:1327:5 | a [element 4] :  | semmle.label | a [element 4] :  |
+| array_flow.rb:1327:5:1327:5 | a [element 4] :  | semmle.label | a [element 4] :  |
 | array_flow.rb:1327:16:1327:28 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1327:16:1327:28 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1327:34:1327:46 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1327:34:1327:46 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1328:5:1328:5 | b [element 2] :  | semmle.label | b [element 2] :  |
+| array_flow.rb:1328:5:1328:5 | b [element 2] :  | semmle.label | b [element 2] :  |
 | array_flow.rb:1328:9:1328:9 | [post] a [element 1] :  | semmle.label | [post] a [element 1] :  |
 | array_flow.rb:1328:9:1328:9 | [post] a [element 1] :  | semmle.label | [post] a [element 1] :  |
 | array_flow.rb:1328:9:1328:9 | a [element 2] :  | semmle.label | a [element 2] :  |
@@ -6412,10 +7888,16 @@ nodes
 | array_flow.rb:1333:10:1333:10 | a [element 1] :  | semmle.label | a [element 1] :  |
 | array_flow.rb:1333:10:1333:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1333:10:1333:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1336:5:1336:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1336:5:1336:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1336:5:1336:5 | a [element 4] :  | semmle.label | a [element 4] :  |
+| array_flow.rb:1336:5:1336:5 | a [element 4] :  | semmle.label | a [element 4] :  |
 | array_flow.rb:1336:16:1336:28 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1336:16:1336:28 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1336:34:1336:46 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1336:34:1336:46 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1337:5:1337:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:1337:5:1337:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:1337:9:1337:9 | [post] a [element] :  | semmle.label | [post] a [element] :  |
 | array_flow.rb:1337:9:1337:9 | [post] a [element] :  | semmle.label | [post] a [element] :  |
 | array_flow.rb:1337:9:1337:9 | a [element 2] :  | semmle.label | a [element 2] :  |
@@ -6448,6 +7930,8 @@ nodes
 | array_flow.rb:1343:10:1343:10 | a [element] :  | semmle.label | a [element] :  |
 | array_flow.rb:1343:10:1343:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1343:10:1343:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1347:5:1347:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1347:5:1347:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1347:16:1347:26 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1347:16:1347:26 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1348:9:1348:9 | a [element 2] :  | semmle.label | a [element 2] :  |
@@ -6456,6 +7940,8 @@ nodes
 | array_flow.rb:1348:27:1348:27 | x :  | semmle.label | x :  |
 | array_flow.rb:1349:14:1349:14 | x | semmle.label | x |
 | array_flow.rb:1349:14:1349:14 | x | semmle.label | x |
+| array_flow.rb:1355:5:1355:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1355:5:1355:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1355:16:1355:26 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1355:16:1355:26 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1356:9:1356:9 | a [element 2] :  | semmle.label | a [element 2] :  |
@@ -6464,6 +7950,8 @@ nodes
 | array_flow.rb:1356:28:1356:28 | x :  | semmle.label | x :  |
 | array_flow.rb:1357:14:1357:14 | x | semmle.label | x |
 | array_flow.rb:1357:14:1357:14 | x | semmle.label | x |
+| array_flow.rb:1363:5:1363:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1363:5:1363:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1363:16:1363:26 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1363:16:1363:26 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1364:9:1364:9 | a [element 2] :  | semmle.label | a [element 2] :  |
@@ -6476,8 +7964,12 @@ nodes
 | array_flow.rb:1365:14:1365:14 | x | semmle.label | x |
 | array_flow.rb:1366:14:1366:14 | y | semmle.label | y |
 | array_flow.rb:1366:14:1366:14 | y | semmle.label | y |
+| array_flow.rb:1371:5:1371:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1371:5:1371:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1371:16:1371:26 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1371:16:1371:26 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1372:5:1372:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:1372:5:1372:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:1372:9:1372:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1372:9:1372:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1372:9:1372:14 | call to sort [element] :  | semmle.label | call to sort [element] :  |
@@ -6490,6 +7982,8 @@ nodes
 | array_flow.rb:1374:10:1374:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:1374:10:1374:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1374:10:1374:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1375:5:1375:5 | c [element] :  | semmle.label | c [element] :  |
+| array_flow.rb:1375:5:1375:5 | c [element] :  | semmle.label | c [element] :  |
 | array_flow.rb:1375:9:1375:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1375:9:1375:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1375:9:1379:7 | call to sort [element] :  | semmle.label | call to sort [element] :  |
@@ -6510,8 +8004,12 @@ nodes
 | array_flow.rb:1381:10:1381:10 | c [element] :  | semmle.label | c [element] :  |
 | array_flow.rb:1381:10:1381:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1381:10:1381:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1385:5:1385:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1385:5:1385:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1385:16:1385:26 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1385:16:1385:26 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1386:5:1386:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:1386:5:1386:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:1386:9:1386:9 | [post] a [element] :  | semmle.label | [post] a [element] :  |
 | array_flow.rb:1386:9:1386:9 | [post] a [element] :  | semmle.label | [post] a [element] :  |
 | array_flow.rb:1386:9:1386:9 | a [element 2] :  | semmle.label | a [element 2] :  |
@@ -6534,8 +8032,12 @@ nodes
 | array_flow.rb:1390:10:1390:10 | a [element] :  | semmle.label | a [element] :  |
 | array_flow.rb:1390:10:1390:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1390:10:1390:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1392:5:1392:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1392:5:1392:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1392:16:1392:26 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1392:16:1392:26 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1393:5:1393:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:1393:5:1393:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:1393:9:1393:9 | [post] a [element] :  | semmle.label | [post] a [element] :  |
 | array_flow.rb:1393:9:1393:9 | [post] a [element] :  | semmle.label | [post] a [element] :  |
 | array_flow.rb:1393:9:1393:9 | a [element 2] :  | semmle.label | a [element 2] :  |
@@ -6566,8 +8068,12 @@ nodes
 | array_flow.rb:1401:10:1401:10 | a [element] :  | semmle.label | a [element] :  |
 | array_flow.rb:1401:10:1401:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1401:10:1401:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1405:5:1405:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1405:5:1405:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1405:16:1405:26 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1405:16:1405:26 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1406:5:1406:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:1406:5:1406:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:1406:9:1406:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1406:9:1406:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1406:9:1409:7 | call to sort_by [element] :  | semmle.label | call to sort_by [element] :  |
@@ -6584,8 +8090,12 @@ nodes
 | array_flow.rb:1411:10:1411:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:1411:10:1411:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1411:10:1411:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1415:5:1415:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1415:5:1415:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1415:16:1415:26 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1415:16:1415:26 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1416:5:1416:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:1416:5:1416:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:1416:9:1416:9 | [post] a [element] :  | semmle.label | [post] a [element] :  |
 | array_flow.rb:1416:9:1416:9 | [post] a [element] :  | semmle.label | [post] a [element] :  |
 | array_flow.rb:1416:9:1416:9 | a [element 2] :  | semmle.label | a [element 2] :  |
@@ -6612,6 +8122,8 @@ nodes
 | array_flow.rb:1423:10:1423:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:1423:10:1423:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1423:10:1423:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1427:5:1427:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1427:5:1427:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1427:16:1427:26 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1427:16:1427:26 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1428:9:1428:9 | a [element 2] :  | semmle.label | a [element 2] :  |
@@ -6620,10 +8132,18 @@ nodes
 | array_flow.rb:1428:19:1428:19 | x :  | semmle.label | x :  |
 | array_flow.rb:1429:14:1429:14 | x | semmle.label | x |
 | array_flow.rb:1429:14:1429:14 | x | semmle.label | x |
+| array_flow.rb:1435:5:1435:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1435:5:1435:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1435:5:1435:5 | a [element 3] :  | semmle.label | a [element 3] :  |
+| array_flow.rb:1435:5:1435:5 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:1435:16:1435:28 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1435:16:1435:28 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1435:31:1435:43 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1435:31:1435:43 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1436:5:1436:5 | b [element 2] :  | semmle.label | b [element 2] :  |
+| array_flow.rb:1436:5:1436:5 | b [element 2] :  | semmle.label | b [element 2] :  |
+| array_flow.rb:1436:5:1436:5 | b [element 3] :  | semmle.label | b [element 3] :  |
+| array_flow.rb:1436:5:1436:5 | b [element 3] :  | semmle.label | b [element 3] :  |
 | array_flow.rb:1436:9:1436:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1436:9:1436:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1436:9:1436:9 | a [element 3] :  | semmle.label | a [element 3] :  |
@@ -6640,6 +8160,8 @@ nodes
 | array_flow.rb:1440:10:1440:10 | b [element 3] :  | semmle.label | b [element 3] :  |
 | array_flow.rb:1440:10:1440:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1440:10:1440:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1441:5:1441:5 | b [element 2] :  | semmle.label | b [element 2] :  |
+| array_flow.rb:1441:5:1441:5 | b [element 2] :  | semmle.label | b [element 2] :  |
 | array_flow.rb:1441:9:1441:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1441:9:1441:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1441:9:1441:17 | call to take [element 2] :  | semmle.label | call to take [element 2] :  |
@@ -6652,6 +8174,10 @@ nodes
 | array_flow.rb:1446:10:1446:10 | b [element 2] :  | semmle.label | b [element 2] :  |
 | array_flow.rb:1446:10:1446:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1446:10:1446:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1447:5:1447:5 | b [element 2] :  | semmle.label | b [element 2] :  |
+| array_flow.rb:1447:5:1447:5 | b [element 2] :  | semmle.label | b [element 2] :  |
+| array_flow.rb:1447:5:1447:5 | b [element 3] :  | semmle.label | b [element 3] :  |
+| array_flow.rb:1447:5:1447:5 | b [element 3] :  | semmle.label | b [element 3] :  |
 | array_flow.rb:1447:9:1447:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1447:9:1447:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1447:9:1447:9 | a [element 3] :  | semmle.label | a [element 3] :  |
@@ -6678,6 +8204,10 @@ nodes
 | array_flow.rb:1453:5:1453:5 | [post] a [element] :  | semmle.label | [post] a [element] :  |
 | array_flow.rb:1453:12:1453:24 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1453:12:1453:24 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1454:5:1454:5 | b [element 2] :  | semmle.label | b [element 2] :  |
+| array_flow.rb:1454:5:1454:5 | b [element 2] :  | semmle.label | b [element 2] :  |
+| array_flow.rb:1454:5:1454:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:1454:5:1454:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:1454:9:1454:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1454:9:1454:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1454:9:1454:9 | a [element] :  | semmle.label | a [element] :  |
@@ -6692,8 +8222,12 @@ nodes
 | array_flow.rb:1455:10:1455:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:1455:10:1455:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1455:10:1455:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1459:5:1459:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1459:5:1459:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1459:16:1459:26 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1459:16:1459:26 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1460:5:1460:5 | b [element 2] :  | semmle.label | b [element 2] :  |
+| array_flow.rb:1460:5:1460:5 | b [element 2] :  | semmle.label | b [element 2] :  |
 | array_flow.rb:1460:9:1460:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1460:9:1460:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1460:9:1463:7 | call to take_while [element 2] :  | semmle.label | call to take_while [element 2] :  |
@@ -6706,8 +8240,12 @@ nodes
 | array_flow.rb:1466:10:1466:10 | b [element 2] :  | semmle.label | b [element 2] :  |
 | array_flow.rb:1466:10:1466:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1466:10:1466:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1472:5:1472:5 | a [element 3] :  | semmle.label | a [element 3] :  |
+| array_flow.rb:1472:5:1472:5 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:1472:19:1472:29 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1472:19:1472:29 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1473:5:1473:5 | b [element 3] :  | semmle.label | b [element 3] :  |
+| array_flow.rb:1473:5:1473:5 | b [element 3] :  | semmle.label | b [element 3] :  |
 | array_flow.rb:1473:9:1473:9 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:1473:9:1473:9 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:1473:9:1473:14 | call to to_a [element 3] :  | semmle.label | call to to_a [element 3] :  |
@@ -6716,8 +8254,12 @@ nodes
 | array_flow.rb:1474:10:1474:10 | b [element 3] :  | semmle.label | b [element 3] :  |
 | array_flow.rb:1474:10:1474:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1474:10:1474:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1478:5:1478:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1478:5:1478:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1478:16:1478:26 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1478:16:1478:26 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1479:5:1479:5 | b [element 2] :  | semmle.label | b [element 2] :  |
+| array_flow.rb:1479:5:1479:5 | b [element 2] :  | semmle.label | b [element 2] :  |
 | array_flow.rb:1479:9:1479:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1479:9:1479:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1479:9:1479:16 | call to to_ary [element 2] :  | semmle.label | call to to_ary [element 2] :  |
@@ -6726,12 +8268,24 @@ nodes
 | array_flow.rb:1482:10:1482:10 | b [element 2] :  | semmle.label | b [element 2] :  |
 | array_flow.rb:1482:10:1482:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1482:10:1482:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1495:5:1495:5 | a [element 0, element 1] :  | semmle.label | a [element 0, element 1] :  |
+| array_flow.rb:1495:5:1495:5 | a [element 0, element 1] :  | semmle.label | a [element 0, element 1] :  |
+| array_flow.rb:1495:5:1495:5 | a [element 1, element 1] :  | semmle.label | a [element 1, element 1] :  |
+| array_flow.rb:1495:5:1495:5 | a [element 1, element 1] :  | semmle.label | a [element 1, element 1] :  |
+| array_flow.rb:1495:5:1495:5 | a [element 2, element 1] :  | semmle.label | a [element 2, element 1] :  |
+| array_flow.rb:1495:5:1495:5 | a [element 2, element 1] :  | semmle.label | a [element 2, element 1] :  |
 | array_flow.rb:1495:14:1495:26 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1495:14:1495:26 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1495:34:1495:46 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1495:34:1495:46 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1495:54:1495:66 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1495:54:1495:66 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1496:5:1496:5 | b [element 1, element 0] :  | semmle.label | b [element 1, element 0] :  |
+| array_flow.rb:1496:5:1496:5 | b [element 1, element 0] :  | semmle.label | b [element 1, element 0] :  |
+| array_flow.rb:1496:5:1496:5 | b [element 1, element 1] :  | semmle.label | b [element 1, element 1] :  |
+| array_flow.rb:1496:5:1496:5 | b [element 1, element 1] :  | semmle.label | b [element 1, element 1] :  |
+| array_flow.rb:1496:5:1496:5 | b [element 1, element 2] :  | semmle.label | b [element 1, element 2] :  |
+| array_flow.rb:1496:5:1496:5 | b [element 1, element 2] :  | semmle.label | b [element 1, element 2] :  |
 | array_flow.rb:1496:9:1496:9 | a [element 0, element 1] :  | semmle.label | a [element 0, element 1] :  |
 | array_flow.rb:1496:9:1496:9 | a [element 0, element 1] :  | semmle.label | a [element 0, element 1] :  |
 | array_flow.rb:1496:9:1496:9 | a [element 1, element 1] :  | semmle.label | a [element 1, element 1] :  |
@@ -6762,12 +8316,20 @@ nodes
 | array_flow.rb:1502:10:1502:13 | ...[...] [element 2] :  | semmle.label | ...[...] [element 2] :  |
 | array_flow.rb:1502:10:1502:16 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1502:10:1502:16 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1506:5:1506:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1506:5:1506:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1506:16:1506:28 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1506:16:1506:28 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1507:5:1507:5 | b [element 1] :  | semmle.label | b [element 1] :  |
+| array_flow.rb:1507:5:1507:5 | b [element 1] :  | semmle.label | b [element 1] :  |
 | array_flow.rb:1507:13:1507:25 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1507:13:1507:25 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1508:5:1508:5 | c [element 1] :  | semmle.label | c [element 1] :  |
+| array_flow.rb:1508:5:1508:5 | c [element 1] :  | semmle.label | c [element 1] :  |
 | array_flow.rb:1508:13:1508:25 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1508:13:1508:25 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1509:5:1509:5 | d [element] :  | semmle.label | d [element] :  |
+| array_flow.rb:1509:5:1509:5 | d [element] :  | semmle.label | d [element] :  |
 | array_flow.rb:1509:9:1509:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1509:9:1509:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1509:9:1509:21 | call to union [element] :  | semmle.label | call to union [element] :  |
@@ -6788,10 +8350,16 @@ nodes
 | array_flow.rb:1512:10:1512:10 | d [element] :  | semmle.label | d [element] :  |
 | array_flow.rb:1512:10:1512:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1512:10:1512:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1516:5:1516:5 | a [element 3] :  | semmle.label | a [element 3] :  |
+| array_flow.rb:1516:5:1516:5 | a [element 3] :  | semmle.label | a [element 3] :  |
+| array_flow.rb:1516:5:1516:5 | a [element 4] :  | semmle.label | a [element 4] :  |
+| array_flow.rb:1516:5:1516:5 | a [element 4] :  | semmle.label | a [element 4] :  |
 | array_flow.rb:1516:19:1516:31 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1516:19:1516:31 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1516:34:1516:46 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1516:34:1516:46 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1518:5:1518:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:1518:5:1518:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:1518:9:1518:9 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:1518:9:1518:9 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:1518:9:1518:9 | a [element 4] :  | semmle.label | a [element 4] :  |
@@ -6806,6 +8374,8 @@ nodes
 | array_flow.rb:1520:10:1520:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:1520:10:1520:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1520:10:1520:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1522:5:1522:5 | c [element] :  | semmle.label | c [element] :  |
+| array_flow.rb:1522:5:1522:5 | c [element] :  | semmle.label | c [element] :  |
 | array_flow.rb:1522:9:1522:9 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:1522:9:1522:9 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:1522:9:1522:9 | a [element 4] :  | semmle.label | a [element 4] :  |
@@ -6820,10 +8390,16 @@ nodes
 | array_flow.rb:1526:10:1526:10 | c [element] :  | semmle.label | c [element] :  |
 | array_flow.rb:1526:10:1526:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1526:10:1526:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1530:5:1530:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1530:5:1530:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1530:5:1530:5 | a [element 3] :  | semmle.label | a [element 3] :  |
+| array_flow.rb:1530:5:1530:5 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:1530:16:1530:28 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1530:16:1530:28 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1530:31:1530:43 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1530:31:1530:43 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1531:5:1531:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:1531:5:1531:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:1531:9:1531:9 | [post] a [element] :  | semmle.label | [post] a [element] :  |
 | array_flow.rb:1531:9:1531:9 | [post] a [element] :  | semmle.label | [post] a [element] :  |
 | array_flow.rb:1531:9:1531:9 | a [element 2] :  | semmle.label | a [element 2] :  |
@@ -6848,10 +8424,16 @@ nodes
 | array_flow.rb:1535:10:1535:10 | a [element] :  | semmle.label | a [element] :  |
 | array_flow.rb:1535:10:1535:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1535:10:1535:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1537:5:1537:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1537:5:1537:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1537:5:1537:5 | a [element 3] :  | semmle.label | a [element 3] :  |
+| array_flow.rb:1537:5:1537:5 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:1537:16:1537:28 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1537:16:1537:28 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1537:31:1537:43 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1537:31:1537:43 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1538:5:1538:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:1538:5:1538:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:1538:9:1538:9 | [post] a [element] :  | semmle.label | [post] a [element] :  |
 | array_flow.rb:1538:9:1538:9 | [post] a [element] :  | semmle.label | [post] a [element] :  |
 | array_flow.rb:1538:9:1538:9 | a [element 2] :  | semmle.label | a [element 2] :  |
@@ -6880,6 +8462,8 @@ nodes
 | array_flow.rb:1545:10:1545:10 | a [element] :  | semmle.label | a [element] :  |
 | array_flow.rb:1545:10:1545:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1545:10:1545:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1549:5:1549:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1549:5:1549:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1549:16:1549:28 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1549:16:1549:28 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1550:5:1550:5 | [post] a [element 2] :  | semmle.label | [post] a [element 2] :  |
@@ -6898,10 +8482,18 @@ nodes
 | array_flow.rb:1556:10:1556:10 | a [element 5] :  | semmle.label | a [element 5] :  |
 | array_flow.rb:1556:10:1556:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1556:10:1556:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1560:5:1560:5 | a [element 1] :  | semmle.label | a [element 1] :  |
+| array_flow.rb:1560:5:1560:5 | a [element 1] :  | semmle.label | a [element 1] :  |
+| array_flow.rb:1560:5:1560:5 | a [element 3] :  | semmle.label | a [element 3] :  |
+| array_flow.rb:1560:5:1560:5 | a [element 3] :  | semmle.label | a [element 3] :  |
 | array_flow.rb:1560:13:1560:25 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1560:13:1560:25 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1560:31:1560:43 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1560:31:1560:43 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1562:5:1562:5 | b [element 1] :  | semmle.label | b [element 1] :  |
+| array_flow.rb:1562:5:1562:5 | b [element 1] :  | semmle.label | b [element 1] :  |
+| array_flow.rb:1562:5:1562:5 | b [element 3] :  | semmle.label | b [element 3] :  |
+| array_flow.rb:1562:5:1562:5 | b [element 3] :  | semmle.label | b [element 3] :  |
 | array_flow.rb:1562:9:1562:9 | a [element 1] :  | semmle.label | a [element 1] :  |
 | array_flow.rb:1562:9:1562:9 | a [element 1] :  | semmle.label | a [element 1] :  |
 | array_flow.rb:1562:9:1562:31 | call to values_at [element 1] :  | semmle.label | call to values_at [element 1] :  |
@@ -6916,6 +8508,8 @@ nodes
 | array_flow.rb:1566:10:1566:10 | b [element 3] :  | semmle.label | b [element 3] :  |
 | array_flow.rb:1566:10:1566:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1566:10:1566:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1568:5:1568:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:1568:5:1568:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:1568:9:1568:9 | a [element 1] :  | semmle.label | a [element 1] :  |
 | array_flow.rb:1568:9:1568:9 | a [element 1] :  | semmle.label | a [element 1] :  |
 | array_flow.rb:1568:9:1568:9 | a [element 3] :  | semmle.label | a [element 3] :  |
@@ -6930,6 +8524,8 @@ nodes
 | array_flow.rb:1570:10:1570:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:1570:10:1570:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1570:10:1570:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1572:5:1572:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:1572:5:1572:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:1572:9:1572:9 | a [element 1] :  | semmle.label | a [element 1] :  |
 | array_flow.rb:1572:9:1572:9 | a [element 1] :  | semmle.label | a [element 1] :  |
 | array_flow.rb:1572:9:1572:9 | a [element 3] :  | semmle.label | a [element 3] :  |
@@ -6944,6 +8540,10 @@ nodes
 | array_flow.rb:1574:10:1574:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:1574:10:1574:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1574:10:1574:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1576:5:1576:5 | b [element 1] :  | semmle.label | b [element 1] :  |
+| array_flow.rb:1576:5:1576:5 | b [element 1] :  | semmle.label | b [element 1] :  |
+| array_flow.rb:1576:5:1576:5 | b [element] :  | semmle.label | b [element] :  |
+| array_flow.rb:1576:5:1576:5 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:1576:9:1576:9 | a [element 1] :  | semmle.label | a [element 1] :  |
 | array_flow.rb:1576:9:1576:9 | a [element 1] :  | semmle.label | a [element 1] :  |
 | array_flow.rb:1576:9:1576:9 | a [element 3] :  | semmle.label | a [element 3] :  |
@@ -6970,12 +8570,24 @@ nodes
 | array_flow.rb:1580:10:1580:10 | b [element] :  | semmle.label | b [element] :  |
 | array_flow.rb:1580:10:1580:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1580:10:1580:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1584:5:1584:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1584:5:1584:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1584:16:1584:28 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1584:16:1584:28 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1585:5:1585:5 | b [element 1] :  | semmle.label | b [element 1] :  |
+| array_flow.rb:1585:5:1585:5 | b [element 1] :  | semmle.label | b [element 1] :  |
 | array_flow.rb:1585:13:1585:25 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1585:13:1585:25 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1586:5:1586:5 | c [element 0] :  | semmle.label | c [element 0] :  |
+| array_flow.rb:1586:5:1586:5 | c [element 0] :  | semmle.label | c [element 0] :  |
 | array_flow.rb:1586:10:1586:22 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1586:10:1586:22 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1587:5:1587:5 | d [element 0, element 2] :  | semmle.label | d [element 0, element 2] :  |
+| array_flow.rb:1587:5:1587:5 | d [element 0, element 2] :  | semmle.label | d [element 0, element 2] :  |
+| array_flow.rb:1587:5:1587:5 | d [element 1, element 1] :  | semmle.label | d [element 1, element 1] :  |
+| array_flow.rb:1587:5:1587:5 | d [element 1, element 1] :  | semmle.label | d [element 1, element 1] :  |
+| array_flow.rb:1587:5:1587:5 | d [element 2, element 0] :  | semmle.label | d [element 2, element 0] :  |
+| array_flow.rb:1587:5:1587:5 | d [element 2, element 0] :  | semmle.label | d [element 2, element 0] :  |
 | array_flow.rb:1587:9:1587:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1587:9:1587:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1587:9:1587:19 | call to zip [element 0, element 2] :  | semmle.label | call to zip [element 0, element 2] :  |
@@ -7030,10 +8642,16 @@ nodes
 | array_flow.rb:1595:14:1595:14 | x [element 2] :  | semmle.label | x [element 2] :  |
 | array_flow.rb:1595:14:1595:17 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1595:14:1595:17 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1600:5:1600:5 | a [element 2] :  | semmle.label | a [element 2] :  |
+| array_flow.rb:1600:5:1600:5 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1600:16:1600:28 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1600:16:1600:28 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1601:5:1601:5 | b [element 1] :  | semmle.label | b [element 1] :  |
+| array_flow.rb:1601:5:1601:5 | b [element 1] :  | semmle.label | b [element 1] :  |
 | array_flow.rb:1601:13:1601:25 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:1601:13:1601:25 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:1602:5:1602:5 | c [element] :  | semmle.label | c [element] :  |
+| array_flow.rb:1602:5:1602:5 | c [element] :  | semmle.label | c [element] :  |
 | array_flow.rb:1602:9:1602:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1602:9:1602:9 | a [element 2] :  | semmle.label | a [element 2] :  |
 | array_flow.rb:1602:9:1602:13 | ... \| ... [element] :  | semmle.label | ... \| ... [element] :  |

--- a/ruby/ql/test/library-tests/dataflow/flow-summaries/semantics.expected
+++ b/ruby/ql/test/library-tests/dataflow/flow-summaries/semantics.expected
@@ -1,19 +1,27 @@
 failures
 edges
-| semantics.rb:2:9:2:18 | call to source :  | semantics.rb:3:9:3:9 | a :  |
-| semantics.rb:2:9:2:18 | call to source :  | semantics.rb:3:9:3:9 | a :  |
+| semantics.rb:2:5:2:5 | a :  | semantics.rb:3:9:3:9 | a :  |
+| semantics.rb:2:5:2:5 | a :  | semantics.rb:3:9:3:9 | a :  |
+| semantics.rb:2:9:2:18 | call to source :  | semantics.rb:2:5:2:5 | a :  |
+| semantics.rb:2:9:2:18 | call to source :  | semantics.rb:2:5:2:5 | a :  |
+| semantics.rb:3:5:3:5 | x :  | semantics.rb:4:10:4:10 | x |
+| semantics.rb:3:5:3:5 | x :  | semantics.rb:4:10:4:10 | x |
 | semantics.rb:3:9:3:9 | a :  | semantics.rb:3:9:3:14 | call to s1 :  |
 | semantics.rb:3:9:3:9 | a :  | semantics.rb:3:9:3:14 | call to s1 :  |
-| semantics.rb:3:9:3:14 | call to s1 :  | semantics.rb:4:10:4:10 | x |
-| semantics.rb:3:9:3:14 | call to s1 :  | semantics.rb:4:10:4:10 | x |
-| semantics.rb:8:9:8:18 | call to source :  | semantics.rb:9:10:9:10 | a :  |
-| semantics.rb:8:9:8:18 | call to source :  | semantics.rb:9:10:9:10 | a :  |
+| semantics.rb:3:9:3:14 | call to s1 :  | semantics.rb:3:5:3:5 | x :  |
+| semantics.rb:3:9:3:14 | call to s1 :  | semantics.rb:3:5:3:5 | x :  |
+| semantics.rb:8:5:8:5 | a :  | semantics.rb:9:10:9:10 | a :  |
+| semantics.rb:8:5:8:5 | a :  | semantics.rb:9:10:9:10 | a :  |
+| semantics.rb:8:9:8:18 | call to source :  | semantics.rb:8:5:8:5 | a :  |
+| semantics.rb:8:9:8:18 | call to source :  | semantics.rb:8:5:8:5 | a :  |
 | semantics.rb:9:5:9:5 | [post] x :  | semantics.rb:10:10:10:10 | x |
 | semantics.rb:9:5:9:5 | [post] x :  | semantics.rb:10:10:10:10 | x |
 | semantics.rb:9:10:9:10 | a :  | semantics.rb:9:5:9:5 | [post] x :  |
 | semantics.rb:9:10:9:10 | a :  | semantics.rb:9:5:9:5 | [post] x :  |
-| semantics.rb:14:9:14:18 | call to source :  | semantics.rb:15:8:15:8 | a :  |
-| semantics.rb:14:9:14:18 | call to source :  | semantics.rb:15:8:15:8 | a :  |
+| semantics.rb:14:5:14:5 | a :  | semantics.rb:15:8:15:8 | a :  |
+| semantics.rb:14:5:14:5 | a :  | semantics.rb:15:8:15:8 | a :  |
+| semantics.rb:14:9:14:18 | call to source :  | semantics.rb:14:5:14:5 | a :  |
+| semantics.rb:14:9:14:18 | call to source :  | semantics.rb:14:5:14:5 | a :  |
 | semantics.rb:15:8:15:8 | a :  | semantics.rb:15:11:15:11 | [post] x :  |
 | semantics.rb:15:8:15:8 | a :  | semantics.rb:15:11:15:11 | [post] x :  |
 | semantics.rb:15:11:15:11 | [post] x :  | semantics.rb:16:10:16:10 | x |
@@ -22,8 +30,10 @@ edges
 | semantics.rb:22:18:22:32 | call to source :  | semantics.rb:22:10:22:33 | call to s4 |
 | semantics.rb:23:23:23:32 | call to source :  | semantics.rb:23:10:23:33 | call to s4 |
 | semantics.rb:23:23:23:32 | call to source :  | semantics.rb:23:10:23:33 | call to s4 |
-| semantics.rb:28:9:28:18 | call to source :  | semantics.rb:29:8:29:8 | a :  |
-| semantics.rb:28:9:28:18 | call to source :  | semantics.rb:29:8:29:8 | a :  |
+| semantics.rb:28:5:28:5 | a :  | semantics.rb:29:8:29:8 | a :  |
+| semantics.rb:28:5:28:5 | a :  | semantics.rb:29:8:29:8 | a :  |
+| semantics.rb:28:9:28:18 | call to source :  | semantics.rb:28:5:28:5 | a :  |
+| semantics.rb:28:9:28:18 | call to source :  | semantics.rb:28:5:28:5 | a :  |
 | semantics.rb:29:8:29:8 | a :  | semantics.rb:29:14:29:14 | [post] y :  |
 | semantics.rb:29:8:29:8 | a :  | semantics.rb:29:14:29:14 | [post] y :  |
 | semantics.rb:29:8:29:8 | a :  | semantics.rb:29:17:29:17 | [post] z :  |
@@ -32,8 +42,10 @@ edges
 | semantics.rb:29:14:29:14 | [post] y :  | semantics.rb:31:10:31:10 | y |
 | semantics.rb:29:17:29:17 | [post] z :  | semantics.rb:32:10:32:10 | z |
 | semantics.rb:29:17:29:17 | [post] z :  | semantics.rb:32:10:32:10 | z |
-| semantics.rb:40:9:40:18 | call to source :  | semantics.rb:41:8:41:8 | a :  |
-| semantics.rb:40:9:40:18 | call to source :  | semantics.rb:41:8:41:8 | a :  |
+| semantics.rb:40:5:40:5 | a :  | semantics.rb:41:8:41:8 | a :  |
+| semantics.rb:40:5:40:5 | a :  | semantics.rb:41:8:41:8 | a :  |
+| semantics.rb:40:9:40:18 | call to source :  | semantics.rb:40:5:40:5 | a :  |
+| semantics.rb:40:9:40:18 | call to source :  | semantics.rb:40:5:40:5 | a :  |
 | semantics.rb:41:8:41:8 | a :  | semantics.rb:41:16:41:16 | [post] x :  |
 | semantics.rb:41:8:41:8 | a :  | semantics.rb:41:16:41:16 | [post] x :  |
 | semantics.rb:41:16:41:16 | [post] x :  | semantics.rb:42:10:42:10 | x |
@@ -50,16 +62,18 @@ edges
 | semantics.rb:54:8:54:17 | call to source :  | semantics.rb:54:24:54:24 | x :  |
 | semantics.rb:54:24:54:24 | x :  | semantics.rb:55:14:55:14 | x |
 | semantics.rb:54:24:54:24 | x :  | semantics.rb:55:14:55:14 | x |
-| semantics.rb:60:9:60:18 | call to source :  | semantics.rb:61:14:61:14 | a :  |
-| semantics.rb:60:9:60:18 | call to source :  | semantics.rb:61:14:61:14 | a :  |
-| semantics.rb:60:9:60:18 | call to source :  | semantics.rb:62:17:62:17 | a :  |
-| semantics.rb:60:9:60:18 | call to source :  | semantics.rb:62:17:62:17 | a :  |
-| semantics.rb:60:9:60:18 | call to source :  | semantics.rb:63:19:63:19 | a :  |
-| semantics.rb:60:9:60:18 | call to source :  | semantics.rb:63:19:63:19 | a :  |
-| semantics.rb:60:9:60:18 | call to source :  | semantics.rb:64:27:64:27 | a :  |
-| semantics.rb:60:9:60:18 | call to source :  | semantics.rb:64:27:64:27 | a :  |
-| semantics.rb:60:9:60:18 | call to source :  | semantics.rb:66:14:66:15 | &... :  |
-| semantics.rb:60:9:60:18 | call to source :  | semantics.rb:66:14:66:15 | &... :  |
+| semantics.rb:60:5:60:5 | a :  | semantics.rb:61:14:61:14 | a :  |
+| semantics.rb:60:5:60:5 | a :  | semantics.rb:61:14:61:14 | a :  |
+| semantics.rb:60:5:60:5 | a :  | semantics.rb:62:17:62:17 | a :  |
+| semantics.rb:60:5:60:5 | a :  | semantics.rb:62:17:62:17 | a :  |
+| semantics.rb:60:5:60:5 | a :  | semantics.rb:63:19:63:19 | a :  |
+| semantics.rb:60:5:60:5 | a :  | semantics.rb:63:19:63:19 | a :  |
+| semantics.rb:60:5:60:5 | a :  | semantics.rb:64:27:64:27 | a :  |
+| semantics.rb:60:5:60:5 | a :  | semantics.rb:64:27:64:27 | a :  |
+| semantics.rb:60:5:60:5 | a :  | semantics.rb:66:14:66:15 | &... :  |
+| semantics.rb:60:5:60:5 | a :  | semantics.rb:66:14:66:15 | &... :  |
+| semantics.rb:60:9:60:18 | call to source :  | semantics.rb:60:5:60:5 | a :  |
+| semantics.rb:60:9:60:18 | call to source :  | semantics.rb:60:5:60:5 | a :  |
 | semantics.rb:61:14:61:14 | a :  | semantics.rb:61:10:61:15 | call to s10 |
 | semantics.rb:61:14:61:14 | a :  | semantics.rb:61:10:61:15 | call to s10 |
 | semantics.rb:62:17:62:17 | a :  | semantics.rb:62:10:62:18 | call to s10 |
@@ -70,8 +84,10 @@ edges
 | semantics.rb:64:27:64:27 | a :  | semantics.rb:64:10:64:28 | call to s10 |
 | semantics.rb:66:14:66:15 | &... :  | semantics.rb:66:10:66:16 | call to s10 |
 | semantics.rb:66:14:66:15 | &... :  | semantics.rb:66:10:66:16 | call to s10 |
-| semantics.rb:80:9:80:18 | call to source :  | semantics.rb:81:5:81:5 | a :  |
-| semantics.rb:80:9:80:18 | call to source :  | semantics.rb:81:5:81:5 | a :  |
+| semantics.rb:80:5:80:5 | a :  | semantics.rb:81:5:81:5 | a :  |
+| semantics.rb:80:5:80:5 | a :  | semantics.rb:81:5:81:5 | a :  |
+| semantics.rb:80:9:80:18 | call to source :  | semantics.rb:80:5:80:5 | a :  |
+| semantics.rb:80:9:80:18 | call to source :  | semantics.rb:80:5:80:5 | a :  |
 | semantics.rb:81:5:81:5 | a :  | semantics.rb:81:11:81:11 | [post] x :  |
 | semantics.rb:81:5:81:5 | a :  | semantics.rb:81:11:81:11 | [post] x :  |
 | semantics.rb:81:5:81:5 | a :  | semantics.rb:81:14:81:14 | [post] y :  |
@@ -84,18 +100,22 @@ edges
 | semantics.rb:81:14:81:14 | [post] y :  | semantics.rb:83:10:83:10 | y |
 | semantics.rb:81:22:81:22 | [post] z :  | semantics.rb:84:10:84:10 | z |
 | semantics.rb:81:22:81:22 | [post] z :  | semantics.rb:84:10:84:10 | z |
-| semantics.rb:89:9:89:18 | call to source :  | semantics.rb:91:19:91:19 | a :  |
-| semantics.rb:89:9:89:18 | call to source :  | semantics.rb:91:19:91:19 | a :  |
-| semantics.rb:89:9:89:18 | call to source :  | semantics.rb:92:27:92:27 | a :  |
-| semantics.rb:89:9:89:18 | call to source :  | semantics.rb:92:27:92:27 | a :  |
+| semantics.rb:89:5:89:5 | a :  | semantics.rb:91:19:91:19 | a :  |
+| semantics.rb:89:5:89:5 | a :  | semantics.rb:91:19:91:19 | a :  |
+| semantics.rb:89:5:89:5 | a :  | semantics.rb:92:27:92:27 | a :  |
+| semantics.rb:89:5:89:5 | a :  | semantics.rb:92:27:92:27 | a :  |
+| semantics.rb:89:9:89:18 | call to source :  | semantics.rb:89:5:89:5 | a :  |
+| semantics.rb:89:9:89:18 | call to source :  | semantics.rb:89:5:89:5 | a :  |
 | semantics.rb:91:19:91:19 | a :  | semantics.rb:91:10:91:20 | call to s13 |
 | semantics.rb:91:19:91:19 | a :  | semantics.rb:91:10:91:20 | call to s13 |
 | semantics.rb:92:27:92:27 | a :  | semantics.rb:92:10:92:28 | call to s13 |
 | semantics.rb:92:27:92:27 | a :  | semantics.rb:92:10:92:28 | call to s13 |
-| semantics.rb:97:9:97:18 | call to source :  | semantics.rb:98:5:98:5 | a :  |
-| semantics.rb:97:9:97:18 | call to source :  | semantics.rb:98:5:98:5 | a :  |
-| semantics.rb:97:9:97:18 | call to source :  | semantics.rb:99:5:99:5 | a :  |
-| semantics.rb:97:9:97:18 | call to source :  | semantics.rb:99:5:99:5 | a :  |
+| semantics.rb:97:5:97:5 | a :  | semantics.rb:98:5:98:5 | a :  |
+| semantics.rb:97:5:97:5 | a :  | semantics.rb:98:5:98:5 | a :  |
+| semantics.rb:97:5:97:5 | a :  | semantics.rb:99:5:99:5 | a :  |
+| semantics.rb:97:5:97:5 | a :  | semantics.rb:99:5:99:5 | a :  |
+| semantics.rb:97:9:97:18 | call to source :  | semantics.rb:97:5:97:5 | a :  |
+| semantics.rb:97:9:97:18 | call to source :  | semantics.rb:97:5:97:5 | a :  |
 | semantics.rb:98:5:98:5 | a :  | semantics.rb:98:19:98:19 | [post] x :  |
 | semantics.rb:98:5:98:5 | a :  | semantics.rb:98:19:98:19 | [post] x :  |
 | semantics.rb:98:19:98:19 | [post] x :  | semantics.rb:101:10:101:10 | x |
@@ -108,20 +128,27 @@ edges
 | semantics.rb:99:16:99:16 | [post] y :  | semantics.rb:102:10:102:10 | y |
 | semantics.rb:99:24:99:24 | [post] z :  | semantics.rb:103:10:103:10 | z |
 | semantics.rb:99:24:99:24 | [post] z :  | semantics.rb:103:10:103:10 | z |
-| semantics.rb:107:9:107:18 | call to source :  | semantics.rb:109:14:109:16 | ** ... :  |
-| semantics.rb:107:9:107:18 | call to source :  | semantics.rb:110:28:110:30 | ** ... :  |
+| semantics.rb:107:5:107:5 | a :  | semantics.rb:109:14:109:16 | ** ... :  |
+| semantics.rb:107:5:107:5 | a :  | semantics.rb:110:28:110:30 | ** ... :  |
+| semantics.rb:107:9:107:18 | call to source :  | semantics.rb:107:5:107:5 | a :  |
 | semantics.rb:109:14:109:16 | ** ... :  | semantics.rb:109:10:109:17 | call to s15 |
 | semantics.rb:110:28:110:30 | ** ... :  | semantics.rb:110:10:110:31 | call to s15 |
-| semantics.rb:114:9:114:18 | call to source :  | semantics.rb:116:14:116:14 | a :  |
-| semantics.rb:114:9:114:18 | call to source :  | semantics.rb:116:14:116:14 | a :  |
-| semantics.rb:114:9:114:18 | call to source :  | semantics.rb:119:17:119:17 | a :  |
-| semantics.rb:114:9:114:18 | call to source :  | semantics.rb:119:17:119:17 | a :  |
-| semantics.rb:115:9:115:18 | call to source :  | semantics.rb:121:17:121:17 | b :  |
-| semantics.rb:115:9:115:18 | call to source :  | semantics.rb:121:17:121:17 | b :  |
-| semantics.rb:116:14:116:14 | a :  | semantics.rb:117:16:117:16 | h [element :a] :  |
-| semantics.rb:116:14:116:14 | a :  | semantics.rb:117:16:117:16 | h [element :a] :  |
-| semantics.rb:116:14:116:14 | a :  | semantics.rb:121:22:121:22 | h [element :a] :  |
-| semantics.rb:116:14:116:14 | a :  | semantics.rb:121:22:121:22 | h [element :a] :  |
+| semantics.rb:114:5:114:5 | a :  | semantics.rb:116:14:116:14 | a :  |
+| semantics.rb:114:5:114:5 | a :  | semantics.rb:116:14:116:14 | a :  |
+| semantics.rb:114:5:114:5 | a :  | semantics.rb:119:17:119:17 | a :  |
+| semantics.rb:114:5:114:5 | a :  | semantics.rb:119:17:119:17 | a :  |
+| semantics.rb:114:9:114:18 | call to source :  | semantics.rb:114:5:114:5 | a :  |
+| semantics.rb:114:9:114:18 | call to source :  | semantics.rb:114:5:114:5 | a :  |
+| semantics.rb:115:5:115:5 | b :  | semantics.rb:121:17:121:17 | b :  |
+| semantics.rb:115:5:115:5 | b :  | semantics.rb:121:17:121:17 | b :  |
+| semantics.rb:115:9:115:18 | call to source :  | semantics.rb:115:5:115:5 | b :  |
+| semantics.rb:115:9:115:18 | call to source :  | semantics.rb:115:5:115:5 | b :  |
+| semantics.rb:116:5:116:5 | h [element :a] :  | semantics.rb:117:16:117:16 | h [element :a] :  |
+| semantics.rb:116:5:116:5 | h [element :a] :  | semantics.rb:117:16:117:16 | h [element :a] :  |
+| semantics.rb:116:5:116:5 | h [element :a] :  | semantics.rb:121:22:121:22 | h [element :a] :  |
+| semantics.rb:116:5:116:5 | h [element :a] :  | semantics.rb:121:22:121:22 | h [element :a] :  |
+| semantics.rb:116:14:116:14 | a :  | semantics.rb:116:5:116:5 | h [element :a] :  |
+| semantics.rb:116:14:116:14 | a :  | semantics.rb:116:5:116:5 | h [element :a] :  |
 | semantics.rb:117:14:117:16 | ** ... [element :a] :  | semantics.rb:117:10:117:17 | call to s16 |
 | semantics.rb:117:14:117:16 | ** ... [element :a] :  | semantics.rb:117:10:117:17 | call to s16 |
 | semantics.rb:117:16:117:16 | h [element :a] :  | semantics.rb:117:14:117:16 | ** ... [element :a] :  |
@@ -134,34 +161,46 @@ edges
 | semantics.rb:121:20:121:22 | ** ... [element :a] :  | semantics.rb:121:10:121:23 | call to s16 |
 | semantics.rb:121:22:121:22 | h [element :a] :  | semantics.rb:121:20:121:22 | ** ... [element :a] :  |
 | semantics.rb:121:22:121:22 | h [element :a] :  | semantics.rb:121:20:121:22 | ** ... [element :a] :  |
-| semantics.rb:125:9:125:18 | call to source :  | semantics.rb:126:9:126:9 | a :  |
-| semantics.rb:125:9:125:18 | call to source :  | semantics.rb:126:9:126:9 | a :  |
+| semantics.rb:125:5:125:5 | a :  | semantics.rb:126:9:126:9 | a :  |
+| semantics.rb:125:5:125:5 | a :  | semantics.rb:126:9:126:9 | a :  |
+| semantics.rb:125:9:125:18 | call to source :  | semantics.rb:125:5:125:5 | a :  |
+| semantics.rb:125:9:125:18 | call to source :  | semantics.rb:125:5:125:5 | a :  |
 | semantics.rb:126:9:126:9 | a :  | semantics.rb:126:12:126:14 | [post] ** ... :  |
 | semantics.rb:126:9:126:9 | a :  | semantics.rb:126:12:126:14 | [post] ** ... :  |
 | semantics.rb:126:12:126:14 | [post] ** ... :  | semantics.rb:127:10:127:10 | h |
 | semantics.rb:126:12:126:14 | [post] ** ... :  | semantics.rb:127:10:127:10 | h |
-| semantics.rb:141:9:141:18 | call to source :  | semantics.rb:145:5:145:5 | [post] h [element] :  |
-| semantics.rb:141:9:141:18 | call to source :  | semantics.rb:145:5:145:5 | [post] h [element] :  |
+| semantics.rb:141:5:141:5 | b :  | semantics.rb:145:5:145:5 | [post] h [element] :  |
+| semantics.rb:141:5:141:5 | b :  | semantics.rb:145:5:145:5 | [post] h [element] :  |
+| semantics.rb:141:9:141:18 | call to source :  | semantics.rb:141:5:141:5 | b :  |
+| semantics.rb:141:9:141:18 | call to source :  | semantics.rb:141:5:141:5 | b :  |
 | semantics.rb:145:5:145:5 | [post] h [element] :  | semantics.rb:147:14:147:14 | h [element] :  |
 | semantics.rb:145:5:145:5 | [post] h [element] :  | semantics.rb:147:14:147:14 | h [element] :  |
 | semantics.rb:147:14:147:14 | h [element] :  | semantics.rb:147:10:147:15 | call to s19 |
 | semantics.rb:147:14:147:14 | h [element] :  | semantics.rb:147:10:147:15 | call to s19 |
-| semantics.rb:151:9:151:18 | call to source :  | semantics.rb:152:13:152:13 | a :  |
-| semantics.rb:151:9:151:18 | call to source :  | semantics.rb:152:13:152:13 | a :  |
-| semantics.rb:152:9:152:14 | call to s20 [element] :  | semantics.rb:153:10:153:10 | x [element] :  |
-| semantics.rb:152:9:152:14 | call to s20 [element] :  | semantics.rb:153:10:153:10 | x [element] :  |
-| semantics.rb:152:9:152:14 | call to s20 [element] :  | semantics.rb:154:10:154:10 | x [element] :  |
-| semantics.rb:152:9:152:14 | call to s20 [element] :  | semantics.rb:154:10:154:10 | x [element] :  |
+| semantics.rb:151:5:151:5 | a :  | semantics.rb:152:13:152:13 | a :  |
+| semantics.rb:151:5:151:5 | a :  | semantics.rb:152:13:152:13 | a :  |
+| semantics.rb:151:9:151:18 | call to source :  | semantics.rb:151:5:151:5 | a :  |
+| semantics.rb:151:9:151:18 | call to source :  | semantics.rb:151:5:151:5 | a :  |
+| semantics.rb:152:5:152:5 | x [element] :  | semantics.rb:153:10:153:10 | x [element] :  |
+| semantics.rb:152:5:152:5 | x [element] :  | semantics.rb:153:10:153:10 | x [element] :  |
+| semantics.rb:152:5:152:5 | x [element] :  | semantics.rb:154:10:154:10 | x [element] :  |
+| semantics.rb:152:5:152:5 | x [element] :  | semantics.rb:154:10:154:10 | x [element] :  |
+| semantics.rb:152:9:152:14 | call to s20 [element] :  | semantics.rb:152:5:152:5 | x [element] :  |
+| semantics.rb:152:9:152:14 | call to s20 [element] :  | semantics.rb:152:5:152:5 | x [element] :  |
 | semantics.rb:152:13:152:13 | a :  | semantics.rb:152:9:152:14 | call to s20 [element] :  |
 | semantics.rb:152:13:152:13 | a :  | semantics.rb:152:9:152:14 | call to s20 [element] :  |
 | semantics.rb:153:10:153:10 | x [element] :  | semantics.rb:153:10:153:13 | ...[...] |
 | semantics.rb:153:10:153:10 | x [element] :  | semantics.rb:153:10:153:13 | ...[...] |
 | semantics.rb:154:10:154:10 | x [element] :  | semantics.rb:154:10:154:13 | ...[...] |
 | semantics.rb:154:10:154:10 | x [element] :  | semantics.rb:154:10:154:13 | ...[...] |
-| semantics.rb:158:9:158:18 | call to source :  | semantics.rb:162:5:162:5 | [post] h [element 0] :  |
-| semantics.rb:158:9:158:18 | call to source :  | semantics.rb:162:5:162:5 | [post] h [element 0] :  |
-| semantics.rb:159:9:159:18 | call to source :  | semantics.rb:163:5:163:5 | [post] h [element] :  |
-| semantics.rb:159:9:159:18 | call to source :  | semantics.rb:163:5:163:5 | [post] h [element] :  |
+| semantics.rb:158:5:158:5 | a :  | semantics.rb:162:5:162:5 | [post] h [element 0] :  |
+| semantics.rb:158:5:158:5 | a :  | semantics.rb:162:5:162:5 | [post] h [element 0] :  |
+| semantics.rb:158:9:158:18 | call to source :  | semantics.rb:158:5:158:5 | a :  |
+| semantics.rb:158:9:158:18 | call to source :  | semantics.rb:158:5:158:5 | a :  |
+| semantics.rb:159:5:159:5 | b :  | semantics.rb:163:5:163:5 | [post] h [element] :  |
+| semantics.rb:159:5:159:5 | b :  | semantics.rb:163:5:163:5 | [post] h [element] :  |
+| semantics.rb:159:9:159:18 | call to source :  | semantics.rb:159:5:159:5 | b :  |
+| semantics.rb:159:9:159:18 | call to source :  | semantics.rb:159:5:159:5 | b :  |
 | semantics.rb:162:5:162:5 | [post] h [element 0] :  | semantics.rb:165:14:165:14 | h [element 0] :  |
 | semantics.rb:162:5:162:5 | [post] h [element 0] :  | semantics.rb:165:14:165:14 | h [element 0] :  |
 | semantics.rb:163:5:163:5 | [post] h [element] :  | semantics.rb:165:14:165:14 | h [element] :  |
@@ -170,20 +209,26 @@ edges
 | semantics.rb:165:14:165:14 | h [element 0] :  | semantics.rb:165:10:165:15 | call to s21 |
 | semantics.rb:165:14:165:14 | h [element] :  | semantics.rb:165:10:165:15 | call to s21 |
 | semantics.rb:165:14:165:14 | h [element] :  | semantics.rb:165:10:165:15 | call to s21 |
-| semantics.rb:169:9:169:18 | call to source :  | semantics.rb:170:13:170:13 | a :  |
-| semantics.rb:169:9:169:18 | call to source :  | semantics.rb:170:13:170:13 | a :  |
-| semantics.rb:170:9:170:14 | call to s22 [element] :  | semantics.rb:171:10:171:10 | x [element] :  |
-| semantics.rb:170:9:170:14 | call to s22 [element] :  | semantics.rb:171:10:171:10 | x [element] :  |
-| semantics.rb:170:9:170:14 | call to s22 [element] :  | semantics.rb:172:10:172:10 | x [element] :  |
-| semantics.rb:170:9:170:14 | call to s22 [element] :  | semantics.rb:172:10:172:10 | x [element] :  |
+| semantics.rb:169:5:169:5 | a :  | semantics.rb:170:13:170:13 | a :  |
+| semantics.rb:169:5:169:5 | a :  | semantics.rb:170:13:170:13 | a :  |
+| semantics.rb:169:9:169:18 | call to source :  | semantics.rb:169:5:169:5 | a :  |
+| semantics.rb:169:9:169:18 | call to source :  | semantics.rb:169:5:169:5 | a :  |
+| semantics.rb:170:5:170:5 | x [element] :  | semantics.rb:171:10:171:10 | x [element] :  |
+| semantics.rb:170:5:170:5 | x [element] :  | semantics.rb:171:10:171:10 | x [element] :  |
+| semantics.rb:170:5:170:5 | x [element] :  | semantics.rb:172:10:172:10 | x [element] :  |
+| semantics.rb:170:5:170:5 | x [element] :  | semantics.rb:172:10:172:10 | x [element] :  |
+| semantics.rb:170:9:170:14 | call to s22 [element] :  | semantics.rb:170:5:170:5 | x [element] :  |
+| semantics.rb:170:9:170:14 | call to s22 [element] :  | semantics.rb:170:5:170:5 | x [element] :  |
 | semantics.rb:170:13:170:13 | a :  | semantics.rb:170:9:170:14 | call to s22 [element] :  |
 | semantics.rb:170:13:170:13 | a :  | semantics.rb:170:9:170:14 | call to s22 [element] :  |
 | semantics.rb:171:10:171:10 | x [element] :  | semantics.rb:171:10:171:13 | ...[...] |
 | semantics.rb:171:10:171:10 | x [element] :  | semantics.rb:171:10:171:13 | ...[...] |
 | semantics.rb:172:10:172:10 | x [element] :  | semantics.rb:172:10:172:13 | ...[...] |
 | semantics.rb:172:10:172:10 | x [element] :  | semantics.rb:172:10:172:13 | ...[...] |
-| semantics.rb:176:9:176:18 | call to source :  | semantics.rb:179:5:179:5 | [post] h [element 0] :  |
-| semantics.rb:176:9:176:18 | call to source :  | semantics.rb:179:5:179:5 | [post] h [element 0] :  |
+| semantics.rb:176:5:176:5 | a :  | semantics.rb:179:5:179:5 | [post] h [element 0] :  |
+| semantics.rb:176:5:176:5 | a :  | semantics.rb:179:5:179:5 | [post] h [element 0] :  |
+| semantics.rb:176:9:176:18 | call to source :  | semantics.rb:176:5:176:5 | a :  |
+| semantics.rb:176:9:176:18 | call to source :  | semantics.rb:176:5:176:5 | a :  |
 | semantics.rb:179:5:179:5 | [post] h [element 0] :  | semantics.rb:180:5:180:5 | h [element 0] :  |
 | semantics.rb:179:5:179:5 | [post] h [element 0] :  | semantics.rb:180:5:180:5 | h [element 0] :  |
 | semantics.rb:180:5:180:5 | [post] h [element 0] :  | semantics.rb:181:14:181:14 | h [element 0] :  |
@@ -192,20 +237,26 @@ edges
 | semantics.rb:180:5:180:5 | h [element 0] :  | semantics.rb:180:5:180:5 | [post] h [element 0] :  |
 | semantics.rb:181:14:181:14 | h [element 0] :  | semantics.rb:181:10:181:15 | call to s23 |
 | semantics.rb:181:14:181:14 | h [element 0] :  | semantics.rb:181:10:181:15 | call to s23 |
-| semantics.rb:185:9:185:18 | call to source :  | semantics.rb:186:13:186:13 | a :  |
-| semantics.rb:185:9:185:18 | call to source :  | semantics.rb:186:13:186:13 | a :  |
-| semantics.rb:186:9:186:14 | call to s24 [element 0] :  | semantics.rb:187:10:187:10 | x [element 0] :  |
-| semantics.rb:186:9:186:14 | call to s24 [element 0] :  | semantics.rb:187:10:187:10 | x [element 0] :  |
-| semantics.rb:186:9:186:14 | call to s24 [element 0] :  | semantics.rb:189:10:189:10 | x [element 0] :  |
-| semantics.rb:186:9:186:14 | call to s24 [element 0] :  | semantics.rb:189:10:189:10 | x [element 0] :  |
+| semantics.rb:185:5:185:5 | a :  | semantics.rb:186:13:186:13 | a :  |
+| semantics.rb:185:5:185:5 | a :  | semantics.rb:186:13:186:13 | a :  |
+| semantics.rb:185:9:185:18 | call to source :  | semantics.rb:185:5:185:5 | a :  |
+| semantics.rb:185:9:185:18 | call to source :  | semantics.rb:185:5:185:5 | a :  |
+| semantics.rb:186:5:186:5 | x [element 0] :  | semantics.rb:187:10:187:10 | x [element 0] :  |
+| semantics.rb:186:5:186:5 | x [element 0] :  | semantics.rb:187:10:187:10 | x [element 0] :  |
+| semantics.rb:186:5:186:5 | x [element 0] :  | semantics.rb:189:10:189:10 | x [element 0] :  |
+| semantics.rb:186:5:186:5 | x [element 0] :  | semantics.rb:189:10:189:10 | x [element 0] :  |
+| semantics.rb:186:9:186:14 | call to s24 [element 0] :  | semantics.rb:186:5:186:5 | x [element 0] :  |
+| semantics.rb:186:9:186:14 | call to s24 [element 0] :  | semantics.rb:186:5:186:5 | x [element 0] :  |
 | semantics.rb:186:13:186:13 | a :  | semantics.rb:186:9:186:14 | call to s24 [element 0] :  |
 | semantics.rb:186:13:186:13 | a :  | semantics.rb:186:9:186:14 | call to s24 [element 0] :  |
 | semantics.rb:187:10:187:10 | x [element 0] :  | semantics.rb:187:10:187:13 | ...[...] |
 | semantics.rb:187:10:187:10 | x [element 0] :  | semantics.rb:187:10:187:13 | ...[...] |
 | semantics.rb:189:10:189:10 | x [element 0] :  | semantics.rb:189:10:189:13 | ...[...] |
 | semantics.rb:189:10:189:10 | x [element 0] :  | semantics.rb:189:10:189:13 | ...[...] |
-| semantics.rb:193:9:193:18 | call to source :  | semantics.rb:196:5:196:5 | [post] h [element 0] :  |
-| semantics.rb:193:9:193:18 | call to source :  | semantics.rb:196:5:196:5 | [post] h [element 0] :  |
+| semantics.rb:193:5:193:5 | a :  | semantics.rb:196:5:196:5 | [post] h [element 0] :  |
+| semantics.rb:193:5:193:5 | a :  | semantics.rb:196:5:196:5 | [post] h [element 0] :  |
+| semantics.rb:193:9:193:18 | call to source :  | semantics.rb:193:5:193:5 | a :  |
+| semantics.rb:193:9:193:18 | call to source :  | semantics.rb:193:5:193:5 | a :  |
 | semantics.rb:196:5:196:5 | [post] h [element 0] :  | semantics.rb:197:5:197:5 | h [element 0] :  |
 | semantics.rb:196:5:196:5 | [post] h [element 0] :  | semantics.rb:197:5:197:5 | h [element 0] :  |
 | semantics.rb:197:5:197:5 | [post] h [element 0] :  | semantics.rb:198:14:198:14 | h [element 0] :  |
@@ -214,24 +265,34 @@ edges
 | semantics.rb:197:5:197:5 | h [element 0] :  | semantics.rb:197:5:197:5 | [post] h [element 0] :  |
 | semantics.rb:198:14:198:14 | h [element 0] :  | semantics.rb:198:10:198:15 | call to s25 |
 | semantics.rb:198:14:198:14 | h [element 0] :  | semantics.rb:198:10:198:15 | call to s25 |
-| semantics.rb:202:9:202:18 | call to source :  | semantics.rb:203:13:203:13 | a :  |
-| semantics.rb:202:9:202:18 | call to source :  | semantics.rb:203:13:203:13 | a :  |
-| semantics.rb:203:9:203:14 | call to s26 [element 0] :  | semantics.rb:204:10:204:10 | x [element 0] :  |
-| semantics.rb:203:9:203:14 | call to s26 [element 0] :  | semantics.rb:204:10:204:10 | x [element 0] :  |
-| semantics.rb:203:9:203:14 | call to s26 [element 0] :  | semantics.rb:206:10:206:10 | x [element 0] :  |
-| semantics.rb:203:9:203:14 | call to s26 [element 0] :  | semantics.rb:206:10:206:10 | x [element 0] :  |
+| semantics.rb:202:5:202:5 | a :  | semantics.rb:203:13:203:13 | a :  |
+| semantics.rb:202:5:202:5 | a :  | semantics.rb:203:13:203:13 | a :  |
+| semantics.rb:202:9:202:18 | call to source :  | semantics.rb:202:5:202:5 | a :  |
+| semantics.rb:202:9:202:18 | call to source :  | semantics.rb:202:5:202:5 | a :  |
+| semantics.rb:203:5:203:5 | x [element 0] :  | semantics.rb:204:10:204:10 | x [element 0] :  |
+| semantics.rb:203:5:203:5 | x [element 0] :  | semantics.rb:204:10:204:10 | x [element 0] :  |
+| semantics.rb:203:5:203:5 | x [element 0] :  | semantics.rb:206:10:206:10 | x [element 0] :  |
+| semantics.rb:203:5:203:5 | x [element 0] :  | semantics.rb:206:10:206:10 | x [element 0] :  |
+| semantics.rb:203:9:203:14 | call to s26 [element 0] :  | semantics.rb:203:5:203:5 | x [element 0] :  |
+| semantics.rb:203:9:203:14 | call to s26 [element 0] :  | semantics.rb:203:5:203:5 | x [element 0] :  |
 | semantics.rb:203:13:203:13 | a :  | semantics.rb:203:9:203:14 | call to s26 [element 0] :  |
 | semantics.rb:203:13:203:13 | a :  | semantics.rb:203:9:203:14 | call to s26 [element 0] :  |
 | semantics.rb:204:10:204:10 | x [element 0] :  | semantics.rb:204:10:204:13 | ...[...] |
 | semantics.rb:204:10:204:10 | x [element 0] :  | semantics.rb:204:10:204:13 | ...[...] |
 | semantics.rb:206:10:206:10 | x [element 0] :  | semantics.rb:206:10:206:13 | ...[...] |
 | semantics.rb:206:10:206:10 | x [element 0] :  | semantics.rb:206:10:206:13 | ...[...] |
-| semantics.rb:211:9:211:18 | call to source :  | semantics.rb:217:5:217:5 | [post] h [element 1] :  |
-| semantics.rb:211:9:211:18 | call to source :  | semantics.rb:217:5:217:5 | [post] h [element 1] :  |
-| semantics.rb:212:9:212:18 | call to source :  | semantics.rb:218:5:218:5 | [post] h [element 2] :  |
-| semantics.rb:212:9:212:18 | call to source :  | semantics.rb:218:5:218:5 | [post] h [element 2] :  |
-| semantics.rb:213:9:213:18 | call to source :  | semantics.rb:219:5:219:5 | [post] h [element] :  |
-| semantics.rb:213:9:213:18 | call to source :  | semantics.rb:219:5:219:5 | [post] h [element] :  |
+| semantics.rb:211:5:211:5 | b :  | semantics.rb:217:5:217:5 | [post] h [element 1] :  |
+| semantics.rb:211:5:211:5 | b :  | semantics.rb:217:5:217:5 | [post] h [element 1] :  |
+| semantics.rb:211:9:211:18 | call to source :  | semantics.rb:211:5:211:5 | b :  |
+| semantics.rb:211:9:211:18 | call to source :  | semantics.rb:211:5:211:5 | b :  |
+| semantics.rb:212:5:212:5 | c :  | semantics.rb:218:5:218:5 | [post] h [element 2] :  |
+| semantics.rb:212:5:212:5 | c :  | semantics.rb:218:5:218:5 | [post] h [element 2] :  |
+| semantics.rb:212:9:212:18 | call to source :  | semantics.rb:212:5:212:5 | c :  |
+| semantics.rb:212:9:212:18 | call to source :  | semantics.rb:212:5:212:5 | c :  |
+| semantics.rb:213:5:213:5 | d :  | semantics.rb:219:5:219:5 | [post] h [element] :  |
+| semantics.rb:213:5:213:5 | d :  | semantics.rb:219:5:219:5 | [post] h [element] :  |
+| semantics.rb:213:9:213:18 | call to source :  | semantics.rb:213:5:213:5 | d :  |
+| semantics.rb:213:9:213:18 | call to source :  | semantics.rb:213:5:213:5 | d :  |
 | semantics.rb:217:5:217:5 | [post] h [element 1] :  | semantics.rb:218:5:218:5 | h [element 1] :  |
 | semantics.rb:217:5:217:5 | [post] h [element 1] :  | semantics.rb:218:5:218:5 | h [element 1] :  |
 | semantics.rb:218:5:218:5 | [post] h [element 1] :  | semantics.rb:221:14:221:14 | h [element 1] :  |
@@ -248,16 +309,20 @@ edges
 | semantics.rb:221:14:221:14 | h [element 2] :  | semantics.rb:221:10:221:15 | call to s27 |
 | semantics.rb:221:14:221:14 | h [element] :  | semantics.rb:221:10:221:15 | call to s27 |
 | semantics.rb:221:14:221:14 | h [element] :  | semantics.rb:221:10:221:15 | call to s27 |
-| semantics.rb:225:9:225:18 | call to source :  | semantics.rb:226:13:226:13 | a :  |
-| semantics.rb:225:9:225:18 | call to source :  | semantics.rb:226:13:226:13 | a :  |
-| semantics.rb:226:9:226:14 | call to s28 [element] :  | semantics.rb:227:10:227:10 | x [element] :  |
-| semantics.rb:226:9:226:14 | call to s28 [element] :  | semantics.rb:227:10:227:10 | x [element] :  |
-| semantics.rb:226:9:226:14 | call to s28 [element] :  | semantics.rb:228:10:228:10 | x [element] :  |
-| semantics.rb:226:9:226:14 | call to s28 [element] :  | semantics.rb:228:10:228:10 | x [element] :  |
-| semantics.rb:226:9:226:14 | call to s28 [element] :  | semantics.rb:229:10:229:10 | x [element] :  |
-| semantics.rb:226:9:226:14 | call to s28 [element] :  | semantics.rb:229:10:229:10 | x [element] :  |
-| semantics.rb:226:9:226:14 | call to s28 [element] :  | semantics.rb:230:10:230:10 | x [element] :  |
-| semantics.rb:226:9:226:14 | call to s28 [element] :  | semantics.rb:230:10:230:10 | x [element] :  |
+| semantics.rb:225:5:225:5 | a :  | semantics.rb:226:13:226:13 | a :  |
+| semantics.rb:225:5:225:5 | a :  | semantics.rb:226:13:226:13 | a :  |
+| semantics.rb:225:9:225:18 | call to source :  | semantics.rb:225:5:225:5 | a :  |
+| semantics.rb:225:9:225:18 | call to source :  | semantics.rb:225:5:225:5 | a :  |
+| semantics.rb:226:5:226:5 | x [element] :  | semantics.rb:227:10:227:10 | x [element] :  |
+| semantics.rb:226:5:226:5 | x [element] :  | semantics.rb:227:10:227:10 | x [element] :  |
+| semantics.rb:226:5:226:5 | x [element] :  | semantics.rb:228:10:228:10 | x [element] :  |
+| semantics.rb:226:5:226:5 | x [element] :  | semantics.rb:228:10:228:10 | x [element] :  |
+| semantics.rb:226:5:226:5 | x [element] :  | semantics.rb:229:10:229:10 | x [element] :  |
+| semantics.rb:226:5:226:5 | x [element] :  | semantics.rb:229:10:229:10 | x [element] :  |
+| semantics.rb:226:5:226:5 | x [element] :  | semantics.rb:230:10:230:10 | x [element] :  |
+| semantics.rb:226:5:226:5 | x [element] :  | semantics.rb:230:10:230:10 | x [element] :  |
+| semantics.rb:226:9:226:14 | call to s28 [element] :  | semantics.rb:226:5:226:5 | x [element] :  |
+| semantics.rb:226:9:226:14 | call to s28 [element] :  | semantics.rb:226:5:226:5 | x [element] :  |
 | semantics.rb:226:13:226:13 | a :  | semantics.rb:226:9:226:14 | call to s28 [element] :  |
 | semantics.rb:226:13:226:13 | a :  | semantics.rb:226:9:226:14 | call to s28 [element] :  |
 | semantics.rb:227:10:227:10 | x [element] :  | semantics.rb:227:10:227:13 | ...[...] |
@@ -268,10 +333,14 @@ edges
 | semantics.rb:229:10:229:10 | x [element] :  | semantics.rb:229:10:229:13 | ...[...] |
 | semantics.rb:230:10:230:10 | x [element] :  | semantics.rb:230:10:230:13 | ...[...] |
 | semantics.rb:230:10:230:10 | x [element] :  | semantics.rb:230:10:230:13 | ...[...] |
-| semantics.rb:235:9:235:18 | call to source :  | semantics.rb:240:5:240:5 | [post] h [element 1] :  |
-| semantics.rb:235:9:235:18 | call to source :  | semantics.rb:240:5:240:5 | [post] h [element 1] :  |
-| semantics.rb:236:9:236:18 | call to source :  | semantics.rb:241:5:241:5 | [post] h [element 2] :  |
-| semantics.rb:236:9:236:18 | call to source :  | semantics.rb:241:5:241:5 | [post] h [element 2] :  |
+| semantics.rb:235:5:235:5 | b :  | semantics.rb:240:5:240:5 | [post] h [element 1] :  |
+| semantics.rb:235:5:235:5 | b :  | semantics.rb:240:5:240:5 | [post] h [element 1] :  |
+| semantics.rb:235:9:235:18 | call to source :  | semantics.rb:235:5:235:5 | b :  |
+| semantics.rb:235:9:235:18 | call to source :  | semantics.rb:235:5:235:5 | b :  |
+| semantics.rb:236:5:236:5 | c :  | semantics.rb:241:5:241:5 | [post] h [element 2] :  |
+| semantics.rb:236:5:236:5 | c :  | semantics.rb:241:5:241:5 | [post] h [element 2] :  |
+| semantics.rb:236:9:236:18 | call to source :  | semantics.rb:236:5:236:5 | c :  |
+| semantics.rb:236:9:236:18 | call to source :  | semantics.rb:236:5:236:5 | c :  |
 | semantics.rb:240:5:240:5 | [post] h [element 1] :  | semantics.rb:241:5:241:5 | h [element 1] :  |
 | semantics.rb:240:5:240:5 | [post] h [element 1] :  | semantics.rb:241:5:241:5 | h [element 1] :  |
 | semantics.rb:241:5:241:5 | [post] h [element 1] :  | semantics.rb:244:14:244:14 | h [element 1] :  |
@@ -284,16 +353,20 @@ edges
 | semantics.rb:244:14:244:14 | h [element 1] :  | semantics.rb:244:10:244:15 | call to s29 |
 | semantics.rb:244:14:244:14 | h [element 2] :  | semantics.rb:244:10:244:15 | call to s29 |
 | semantics.rb:244:14:244:14 | h [element 2] :  | semantics.rb:244:10:244:15 | call to s29 |
-| semantics.rb:248:9:248:18 | call to source :  | semantics.rb:249:13:249:13 | a :  |
-| semantics.rb:248:9:248:18 | call to source :  | semantics.rb:249:13:249:13 | a :  |
-| semantics.rb:249:9:249:14 | call to s30 [element] :  | semantics.rb:250:10:250:10 | x [element] :  |
-| semantics.rb:249:9:249:14 | call to s30 [element] :  | semantics.rb:250:10:250:10 | x [element] :  |
-| semantics.rb:249:9:249:14 | call to s30 [element] :  | semantics.rb:251:10:251:10 | x [element] :  |
-| semantics.rb:249:9:249:14 | call to s30 [element] :  | semantics.rb:251:10:251:10 | x [element] :  |
-| semantics.rb:249:9:249:14 | call to s30 [element] :  | semantics.rb:252:10:252:10 | x [element] :  |
-| semantics.rb:249:9:249:14 | call to s30 [element] :  | semantics.rb:252:10:252:10 | x [element] :  |
-| semantics.rb:249:9:249:14 | call to s30 [element] :  | semantics.rb:253:10:253:10 | x [element] :  |
-| semantics.rb:249:9:249:14 | call to s30 [element] :  | semantics.rb:253:10:253:10 | x [element] :  |
+| semantics.rb:248:5:248:5 | a :  | semantics.rb:249:13:249:13 | a :  |
+| semantics.rb:248:5:248:5 | a :  | semantics.rb:249:13:249:13 | a :  |
+| semantics.rb:248:9:248:18 | call to source :  | semantics.rb:248:5:248:5 | a :  |
+| semantics.rb:248:9:248:18 | call to source :  | semantics.rb:248:5:248:5 | a :  |
+| semantics.rb:249:5:249:5 | x [element] :  | semantics.rb:250:10:250:10 | x [element] :  |
+| semantics.rb:249:5:249:5 | x [element] :  | semantics.rb:250:10:250:10 | x [element] :  |
+| semantics.rb:249:5:249:5 | x [element] :  | semantics.rb:251:10:251:10 | x [element] :  |
+| semantics.rb:249:5:249:5 | x [element] :  | semantics.rb:251:10:251:10 | x [element] :  |
+| semantics.rb:249:5:249:5 | x [element] :  | semantics.rb:252:10:252:10 | x [element] :  |
+| semantics.rb:249:5:249:5 | x [element] :  | semantics.rb:252:10:252:10 | x [element] :  |
+| semantics.rb:249:5:249:5 | x [element] :  | semantics.rb:253:10:253:10 | x [element] :  |
+| semantics.rb:249:5:249:5 | x [element] :  | semantics.rb:253:10:253:10 | x [element] :  |
+| semantics.rb:249:9:249:14 | call to s30 [element] :  | semantics.rb:249:5:249:5 | x [element] :  |
+| semantics.rb:249:9:249:14 | call to s30 [element] :  | semantics.rb:249:5:249:5 | x [element] :  |
 | semantics.rb:249:13:249:13 | a :  | semantics.rb:249:9:249:14 | call to s30 [element] :  |
 | semantics.rb:249:13:249:13 | a :  | semantics.rb:249:9:249:14 | call to s30 [element] :  |
 | semantics.rb:250:10:250:10 | x [element] :  | semantics.rb:250:10:250:13 | ...[...] |
@@ -392,30 +465,36 @@ edges
 | semantics.rb:285:14:285:14 | h [element true] :  | semantics.rb:285:10:285:15 | call to s33 |
 | semantics.rb:285:14:285:14 | h [element] :  | semantics.rb:285:10:285:15 | call to s33 |
 | semantics.rb:285:14:285:14 | h [element] :  | semantics.rb:285:10:285:15 | call to s33 |
-| semantics.rb:289:9:289:24 | call to s35 [element :foo] :  | semantics.rb:290:10:290:10 | x [element :foo] :  |
-| semantics.rb:289:9:289:24 | call to s35 [element :foo] :  | semantics.rb:290:10:290:10 | x [element :foo] :  |
-| semantics.rb:289:9:289:24 | call to s35 [element :foo] :  | semantics.rb:292:10:292:10 | x [element :foo] :  |
-| semantics.rb:289:9:289:24 | call to s35 [element :foo] :  | semantics.rb:292:10:292:10 | x [element :foo] :  |
+| semantics.rb:289:5:289:5 | x [element :foo] :  | semantics.rb:290:10:290:10 | x [element :foo] :  |
+| semantics.rb:289:5:289:5 | x [element :foo] :  | semantics.rb:290:10:290:10 | x [element :foo] :  |
+| semantics.rb:289:5:289:5 | x [element :foo] :  | semantics.rb:292:10:292:10 | x [element :foo] :  |
+| semantics.rb:289:5:289:5 | x [element :foo] :  | semantics.rb:292:10:292:10 | x [element :foo] :  |
+| semantics.rb:289:9:289:24 | call to s35 [element :foo] :  | semantics.rb:289:5:289:5 | x [element :foo] :  |
+| semantics.rb:289:9:289:24 | call to s35 [element :foo] :  | semantics.rb:289:5:289:5 | x [element :foo] :  |
 | semantics.rb:289:13:289:23 | call to source :  | semantics.rb:289:9:289:24 | call to s35 [element :foo] :  |
 | semantics.rb:289:13:289:23 | call to source :  | semantics.rb:289:9:289:24 | call to s35 [element :foo] :  |
 | semantics.rb:290:10:290:10 | x [element :foo] :  | semantics.rb:290:10:290:16 | ...[...] |
 | semantics.rb:290:10:290:10 | x [element :foo] :  | semantics.rb:290:10:290:16 | ...[...] |
 | semantics.rb:292:10:292:10 | x [element :foo] :  | semantics.rb:292:10:292:13 | ...[...] |
 | semantics.rb:292:10:292:10 | x [element :foo] :  | semantics.rb:292:10:292:13 | ...[...] |
-| semantics.rb:296:9:296:24 | call to s36 [element foo] :  | semantics.rb:298:10:298:10 | x [element foo] :  |
-| semantics.rb:296:9:296:24 | call to s36 [element foo] :  | semantics.rb:298:10:298:10 | x [element foo] :  |
-| semantics.rb:296:9:296:24 | call to s36 [element foo] :  | semantics.rb:300:10:300:10 | x [element foo] :  |
-| semantics.rb:296:9:296:24 | call to s36 [element foo] :  | semantics.rb:300:10:300:10 | x [element foo] :  |
+| semantics.rb:296:5:296:5 | x [element foo] :  | semantics.rb:298:10:298:10 | x [element foo] :  |
+| semantics.rb:296:5:296:5 | x [element foo] :  | semantics.rb:298:10:298:10 | x [element foo] :  |
+| semantics.rb:296:5:296:5 | x [element foo] :  | semantics.rb:300:10:300:10 | x [element foo] :  |
+| semantics.rb:296:5:296:5 | x [element foo] :  | semantics.rb:300:10:300:10 | x [element foo] :  |
+| semantics.rb:296:9:296:24 | call to s36 [element foo] :  | semantics.rb:296:5:296:5 | x [element foo] :  |
+| semantics.rb:296:9:296:24 | call to s36 [element foo] :  | semantics.rb:296:5:296:5 | x [element foo] :  |
 | semantics.rb:296:13:296:23 | call to source :  | semantics.rb:296:9:296:24 | call to s36 [element foo] :  |
 | semantics.rb:296:13:296:23 | call to source :  | semantics.rb:296:9:296:24 | call to s36 [element foo] :  |
 | semantics.rb:298:10:298:10 | x [element foo] :  | semantics.rb:298:10:298:17 | ...[...] |
 | semantics.rb:298:10:298:10 | x [element foo] :  | semantics.rb:298:10:298:17 | ...[...] |
 | semantics.rb:300:10:300:10 | x [element foo] :  | semantics.rb:300:10:300:13 | ...[...] |
 | semantics.rb:300:10:300:10 | x [element foo] :  | semantics.rb:300:10:300:13 | ...[...] |
-| semantics.rb:304:9:304:24 | call to s37 [element true] :  | semantics.rb:306:10:306:10 | x [element true] :  |
-| semantics.rb:304:9:304:24 | call to s37 [element true] :  | semantics.rb:306:10:306:10 | x [element true] :  |
-| semantics.rb:304:9:304:24 | call to s37 [element true] :  | semantics.rb:308:10:308:10 | x [element true] :  |
-| semantics.rb:304:9:304:24 | call to s37 [element true] :  | semantics.rb:308:10:308:10 | x [element true] :  |
+| semantics.rb:304:5:304:5 | x [element true] :  | semantics.rb:306:10:306:10 | x [element true] :  |
+| semantics.rb:304:5:304:5 | x [element true] :  | semantics.rb:306:10:306:10 | x [element true] :  |
+| semantics.rb:304:5:304:5 | x [element true] :  | semantics.rb:308:10:308:10 | x [element true] :  |
+| semantics.rb:304:5:304:5 | x [element true] :  | semantics.rb:308:10:308:10 | x [element true] :  |
+| semantics.rb:304:9:304:24 | call to s37 [element true] :  | semantics.rb:304:5:304:5 | x [element true] :  |
+| semantics.rb:304:9:304:24 | call to s37 [element true] :  | semantics.rb:304:5:304:5 | x [element true] :  |
 | semantics.rb:304:13:304:23 | call to source :  | semantics.rb:304:9:304:24 | call to s37 [element true] :  |
 | semantics.rb:304:13:304:23 | call to source :  | semantics.rb:304:9:304:24 | call to s37 [element true] :  |
 | semantics.rb:306:10:306:10 | x [element true] :  | semantics.rb:306:10:306:16 | ...[...] |
@@ -428,10 +507,12 @@ edges
 | semantics.rb:312:16:312:26 | call to source :  | semantics.rb:312:5:312:5 | [post] h [element foo] :  |
 | semantics.rb:315:14:315:14 | h [element foo] :  | semantics.rb:315:10:315:15 | call to s38 |
 | semantics.rb:315:14:315:14 | h [element foo] :  | semantics.rb:315:10:315:15 | call to s38 |
-| semantics.rb:319:9:319:24 | call to s39 [element :foo] :  | semantics.rb:321:10:321:10 | x [element :foo] :  |
-| semantics.rb:319:9:319:24 | call to s39 [element :foo] :  | semantics.rb:321:10:321:10 | x [element :foo] :  |
-| semantics.rb:319:9:319:24 | call to s39 [element :foo] :  | semantics.rb:322:10:322:10 | x [element :foo] :  |
-| semantics.rb:319:9:319:24 | call to s39 [element :foo] :  | semantics.rb:322:10:322:10 | x [element :foo] :  |
+| semantics.rb:319:5:319:5 | x [element :foo] :  | semantics.rb:321:10:321:10 | x [element :foo] :  |
+| semantics.rb:319:5:319:5 | x [element :foo] :  | semantics.rb:321:10:321:10 | x [element :foo] :  |
+| semantics.rb:319:5:319:5 | x [element :foo] :  | semantics.rb:322:10:322:10 | x [element :foo] :  |
+| semantics.rb:319:5:319:5 | x [element :foo] :  | semantics.rb:322:10:322:10 | x [element :foo] :  |
+| semantics.rb:319:9:319:24 | call to s39 [element :foo] :  | semantics.rb:319:5:319:5 | x [element :foo] :  |
+| semantics.rb:319:9:319:24 | call to s39 [element :foo] :  | semantics.rb:319:5:319:5 | x [element :foo] :  |
 | semantics.rb:319:13:319:23 | call to source :  | semantics.rb:319:9:319:24 | call to s39 [element :foo] :  |
 | semantics.rb:319:13:319:23 | call to source :  | semantics.rb:319:9:319:24 | call to s39 [element :foo] :  |
 | semantics.rb:321:10:321:10 | x [element :foo] :  | semantics.rb:321:10:321:16 | ...[...] |
@@ -444,8 +525,10 @@ edges
 | semantics.rb:327:13:327:23 | call to source :  | semantics.rb:327:5:327:5 | [post] x [@foo] :  |
 | semantics.rb:329:14:329:14 | x [@foo] :  | semantics.rb:329:10:329:15 | call to s40 |
 | semantics.rb:329:14:329:14 | x [@foo] :  | semantics.rb:329:10:329:15 | call to s40 |
-| semantics.rb:333:9:333:24 | call to s41 [@foo] :  | semantics.rb:334:10:334:10 | x [@foo] :  |
-| semantics.rb:333:9:333:24 | call to s41 [@foo] :  | semantics.rb:334:10:334:10 | x [@foo] :  |
+| semantics.rb:333:5:333:5 | x [@foo] :  | semantics.rb:334:10:334:10 | x [@foo] :  |
+| semantics.rb:333:5:333:5 | x [@foo] :  | semantics.rb:334:10:334:10 | x [@foo] :  |
+| semantics.rb:333:9:333:24 | call to s41 [@foo] :  | semantics.rb:333:5:333:5 | x [@foo] :  |
+| semantics.rb:333:9:333:24 | call to s41 [@foo] :  | semantics.rb:333:5:333:5 | x [@foo] :  |
 | semantics.rb:333:13:333:23 | call to source :  | semantics.rb:333:9:333:24 | call to s41 [@foo] :  |
 | semantics.rb:333:13:333:23 | call to source :  | semantics.rb:333:9:333:24 | call to s41 [@foo] :  |
 | semantics.rb:334:10:334:10 | x [@foo] :  | semantics.rb:334:10:334:14 | call to foo |
@@ -458,16 +541,20 @@ edges
 | semantics.rb:340:5:340:5 | [post] h [element] :  | semantics.rb:342:13:342:13 | h [element] :  |
 | semantics.rb:340:12:340:22 | call to source :  | semantics.rb:340:5:340:5 | [post] h [element] :  |
 | semantics.rb:340:12:340:22 | call to source :  | semantics.rb:340:5:340:5 | [post] h [element] :  |
-| semantics.rb:342:9:342:14 | call to s42 [element 0] :  | semantics.rb:344:10:344:10 | x [element 0] :  |
-| semantics.rb:342:9:342:14 | call to s42 [element 0] :  | semantics.rb:344:10:344:10 | x [element 0] :  |
-| semantics.rb:342:9:342:14 | call to s42 [element 0] :  | semantics.rb:346:10:346:10 | x [element 0] :  |
-| semantics.rb:342:9:342:14 | call to s42 [element 0] :  | semantics.rb:346:10:346:10 | x [element 0] :  |
-| semantics.rb:342:9:342:14 | call to s42 [element] :  | semantics.rb:344:10:344:10 | x [element] :  |
-| semantics.rb:342:9:342:14 | call to s42 [element] :  | semantics.rb:344:10:344:10 | x [element] :  |
-| semantics.rb:342:9:342:14 | call to s42 [element] :  | semantics.rb:345:10:345:10 | x [element] :  |
-| semantics.rb:342:9:342:14 | call to s42 [element] :  | semantics.rb:345:10:345:10 | x [element] :  |
-| semantics.rb:342:9:342:14 | call to s42 [element] :  | semantics.rb:346:10:346:10 | x [element] :  |
-| semantics.rb:342:9:342:14 | call to s42 [element] :  | semantics.rb:346:10:346:10 | x [element] :  |
+| semantics.rb:342:5:342:5 | x [element 0] :  | semantics.rb:344:10:344:10 | x [element 0] :  |
+| semantics.rb:342:5:342:5 | x [element 0] :  | semantics.rb:344:10:344:10 | x [element 0] :  |
+| semantics.rb:342:5:342:5 | x [element 0] :  | semantics.rb:346:10:346:10 | x [element 0] :  |
+| semantics.rb:342:5:342:5 | x [element 0] :  | semantics.rb:346:10:346:10 | x [element 0] :  |
+| semantics.rb:342:5:342:5 | x [element] :  | semantics.rb:344:10:344:10 | x [element] :  |
+| semantics.rb:342:5:342:5 | x [element] :  | semantics.rb:344:10:344:10 | x [element] :  |
+| semantics.rb:342:5:342:5 | x [element] :  | semantics.rb:345:10:345:10 | x [element] :  |
+| semantics.rb:342:5:342:5 | x [element] :  | semantics.rb:345:10:345:10 | x [element] :  |
+| semantics.rb:342:5:342:5 | x [element] :  | semantics.rb:346:10:346:10 | x [element] :  |
+| semantics.rb:342:5:342:5 | x [element] :  | semantics.rb:346:10:346:10 | x [element] :  |
+| semantics.rb:342:9:342:14 | call to s42 [element 0] :  | semantics.rb:342:5:342:5 | x [element 0] :  |
+| semantics.rb:342:9:342:14 | call to s42 [element 0] :  | semantics.rb:342:5:342:5 | x [element 0] :  |
+| semantics.rb:342:9:342:14 | call to s42 [element] :  | semantics.rb:342:5:342:5 | x [element] :  |
+| semantics.rb:342:9:342:14 | call to s42 [element] :  | semantics.rb:342:5:342:5 | x [element] :  |
 | semantics.rb:342:13:342:13 | h [element 0] :  | semantics.rb:342:9:342:14 | call to s42 [element 0] :  |
 | semantics.rb:342:13:342:13 | h [element 0] :  | semantics.rb:342:9:342:14 | call to s42 [element 0] :  |
 | semantics.rb:342:13:342:13 | h [element] :  | semantics.rb:342:9:342:14 | call to s42 [element] :  |
@@ -486,10 +573,12 @@ edges
 | semantics.rb:350:5:350:5 | [post] h [element 0] :  | semantics.rb:353:13:353:13 | h [element 0] :  |
 | semantics.rb:350:12:350:22 | call to source :  | semantics.rb:350:5:350:5 | [post] h [element 0] :  |
 | semantics.rb:350:12:350:22 | call to source :  | semantics.rb:350:5:350:5 | [post] h [element 0] :  |
-| semantics.rb:353:9:353:14 | call to s43 [element 0] :  | semantics.rb:355:10:355:10 | x [element 0] :  |
-| semantics.rb:353:9:353:14 | call to s43 [element 0] :  | semantics.rb:355:10:355:10 | x [element 0] :  |
-| semantics.rb:353:9:353:14 | call to s43 [element 0] :  | semantics.rb:357:10:357:10 | x [element 0] :  |
-| semantics.rb:353:9:353:14 | call to s43 [element 0] :  | semantics.rb:357:10:357:10 | x [element 0] :  |
+| semantics.rb:353:5:353:5 | x [element 0] :  | semantics.rb:355:10:355:10 | x [element 0] :  |
+| semantics.rb:353:5:353:5 | x [element 0] :  | semantics.rb:355:10:355:10 | x [element 0] :  |
+| semantics.rb:353:5:353:5 | x [element 0] :  | semantics.rb:357:10:357:10 | x [element 0] :  |
+| semantics.rb:353:5:353:5 | x [element 0] :  | semantics.rb:357:10:357:10 | x [element 0] :  |
+| semantics.rb:353:9:353:14 | call to s43 [element 0] :  | semantics.rb:353:5:353:5 | x [element 0] :  |
+| semantics.rb:353:9:353:14 | call to s43 [element 0] :  | semantics.rb:353:5:353:5 | x [element 0] :  |
 | semantics.rb:353:13:353:13 | h [element 0] :  | semantics.rb:353:9:353:14 | call to s43 [element 0] :  |
 | semantics.rb:353:13:353:13 | h [element 0] :  | semantics.rb:353:9:353:14 | call to s43 [element 0] :  |
 | semantics.rb:355:10:355:10 | x [element 0] :  | semantics.rb:355:10:355:13 | ...[...] |
@@ -616,10 +705,12 @@ edges
 | semantics.rb:395:10:395:10 | h [element 1] :  | semantics.rb:395:10:395:13 | ...[...] |
 | semantics.rb:395:10:395:10 | h [element] :  | semantics.rb:395:10:395:13 | ...[...] |
 | semantics.rb:395:10:395:10 | h [element] :  | semantics.rb:395:10:395:13 | ...[...] |
-| semantics.rb:397:9:397:14 | call to s46 [element 1] :  | semantics.rb:400:10:400:10 | x [element 1] :  |
-| semantics.rb:397:9:397:14 | call to s46 [element 1] :  | semantics.rb:400:10:400:10 | x [element 1] :  |
-| semantics.rb:397:9:397:14 | call to s46 [element 1] :  | semantics.rb:401:10:401:10 | x [element 1] :  |
-| semantics.rb:397:9:397:14 | call to s46 [element 1] :  | semantics.rb:401:10:401:10 | x [element 1] :  |
+| semantics.rb:397:5:397:5 | x [element 1] :  | semantics.rb:400:10:400:10 | x [element 1] :  |
+| semantics.rb:397:5:397:5 | x [element 1] :  | semantics.rb:400:10:400:10 | x [element 1] :  |
+| semantics.rb:397:5:397:5 | x [element 1] :  | semantics.rb:401:10:401:10 | x [element 1] :  |
+| semantics.rb:397:5:397:5 | x [element 1] :  | semantics.rb:401:10:401:10 | x [element 1] :  |
+| semantics.rb:397:9:397:14 | call to s46 [element 1] :  | semantics.rb:397:5:397:5 | x [element 1] :  |
+| semantics.rb:397:9:397:14 | call to s46 [element 1] :  | semantics.rb:397:5:397:5 | x [element 1] :  |
 | semantics.rb:397:13:397:13 | h [element 1] :  | semantics.rb:397:9:397:14 | call to s46 [element 1] :  |
 | semantics.rb:397:13:397:13 | h [element 1] :  | semantics.rb:397:9:397:14 | call to s46 [element 1] :  |
 | semantics.rb:400:10:400:10 | x [element 1] :  | semantics.rb:400:10:400:13 | ...[...] |
@@ -654,8 +745,10 @@ edges
 | semantics.rb:410:10:410:10 | h [element :bar] :  | semantics.rb:410:10:410:16 | ...[...] |
 | semantics.rb:410:10:410:10 | h [element] :  | semantics.rb:410:10:410:16 | ...[...] |
 | semantics.rb:410:10:410:10 | h [element] :  | semantics.rb:410:10:410:16 | ...[...] |
-| semantics.rb:412:9:412:14 | call to s47 [element :bar] :  | semantics.rb:415:10:415:10 | x [element :bar] :  |
-| semantics.rb:412:9:412:14 | call to s47 [element :bar] :  | semantics.rb:415:10:415:10 | x [element :bar] :  |
+| semantics.rb:412:5:412:5 | x [element :bar] :  | semantics.rb:415:10:415:10 | x [element :bar] :  |
+| semantics.rb:412:5:412:5 | x [element :bar] :  | semantics.rb:415:10:415:10 | x [element :bar] :  |
+| semantics.rb:412:9:412:14 | call to s47 [element :bar] :  | semantics.rb:412:5:412:5 | x [element :bar] :  |
+| semantics.rb:412:9:412:14 | call to s47 [element :bar] :  | semantics.rb:412:5:412:5 | x [element :bar] :  |
 | semantics.rb:412:13:412:13 | h [element :bar] :  | semantics.rb:412:9:412:14 | call to s47 [element :bar] :  |
 | semantics.rb:412:13:412:13 | h [element :bar] :  | semantics.rb:412:9:412:14 | call to s47 [element :bar] :  |
 | semantics.rb:415:10:415:10 | x [element :bar] :  | semantics.rb:415:10:415:16 | ...[...] |
@@ -688,8 +781,10 @@ edges
 | semantics.rb:424:10:424:10 | h [element :bar] :  | semantics.rb:424:10:424:16 | ...[...] |
 | semantics.rb:424:10:424:10 | h [element] :  | semantics.rb:424:10:424:16 | ...[...] |
 | semantics.rb:424:10:424:10 | h [element] :  | semantics.rb:424:10:424:16 | ...[...] |
-| semantics.rb:426:9:426:14 | call to s48 [element :bar] :  | semantics.rb:429:10:429:10 | x [element :bar] :  |
-| semantics.rb:426:9:426:14 | call to s48 [element :bar] :  | semantics.rb:429:10:429:10 | x [element :bar] :  |
+| semantics.rb:426:5:426:5 | x [element :bar] :  | semantics.rb:429:10:429:10 | x [element :bar] :  |
+| semantics.rb:426:5:426:5 | x [element :bar] :  | semantics.rb:429:10:429:10 | x [element :bar] :  |
+| semantics.rb:426:9:426:14 | call to s48 [element :bar] :  | semantics.rb:426:5:426:5 | x [element :bar] :  |
+| semantics.rb:426:9:426:14 | call to s48 [element :bar] :  | semantics.rb:426:5:426:5 | x [element :bar] :  |
 | semantics.rb:426:13:426:13 | h [element :bar] :  | semantics.rb:426:9:426:14 | call to s48 [element :bar] :  |
 | semantics.rb:426:13:426:13 | h [element :bar] :  | semantics.rb:426:9:426:14 | call to s48 [element :bar] :  |
 | semantics.rb:429:10:429:10 | x [element :bar] :  | semantics.rb:429:10:429:16 | ...[...] |
@@ -724,12 +819,16 @@ edges
 | semantics.rb:438:10:438:10 | h [element :bar] :  | semantics.rb:438:10:438:16 | ...[...] |
 | semantics.rb:438:10:438:10 | h [element] :  | semantics.rb:438:10:438:16 | ...[...] |
 | semantics.rb:438:10:438:10 | h [element] :  | semantics.rb:438:10:438:16 | ...[...] |
-| semantics.rb:440:9:440:14 | call to s49 [element :bar] :  | semantics.rb:443:10:443:10 | x [element :bar] :  |
-| semantics.rb:440:9:440:14 | call to s49 [element :bar] :  | semantics.rb:443:10:443:10 | x [element :bar] :  |
-| semantics.rb:440:9:440:14 | call to s49 [element] :  | semantics.rb:442:10:442:10 | x [element] :  |
-| semantics.rb:440:9:440:14 | call to s49 [element] :  | semantics.rb:442:10:442:10 | x [element] :  |
-| semantics.rb:440:9:440:14 | call to s49 [element] :  | semantics.rb:443:10:443:10 | x [element] :  |
-| semantics.rb:440:9:440:14 | call to s49 [element] :  | semantics.rb:443:10:443:10 | x [element] :  |
+| semantics.rb:440:5:440:5 | x [element :bar] :  | semantics.rb:443:10:443:10 | x [element :bar] :  |
+| semantics.rb:440:5:440:5 | x [element :bar] :  | semantics.rb:443:10:443:10 | x [element :bar] :  |
+| semantics.rb:440:5:440:5 | x [element] :  | semantics.rb:442:10:442:10 | x [element] :  |
+| semantics.rb:440:5:440:5 | x [element] :  | semantics.rb:442:10:442:10 | x [element] :  |
+| semantics.rb:440:5:440:5 | x [element] :  | semantics.rb:443:10:443:10 | x [element] :  |
+| semantics.rb:440:5:440:5 | x [element] :  | semantics.rb:443:10:443:10 | x [element] :  |
+| semantics.rb:440:9:440:14 | call to s49 [element :bar] :  | semantics.rb:440:5:440:5 | x [element :bar] :  |
+| semantics.rb:440:9:440:14 | call to s49 [element :bar] :  | semantics.rb:440:5:440:5 | x [element :bar] :  |
+| semantics.rb:440:9:440:14 | call to s49 [element] :  | semantics.rb:440:5:440:5 | x [element] :  |
+| semantics.rb:440:9:440:14 | call to s49 [element] :  | semantics.rb:440:5:440:5 | x [element] :  |
 | semantics.rb:440:13:440:13 | h [element :bar] :  | semantics.rb:440:9:440:14 | call to s49 [element :bar] :  |
 | semantics.rb:440:13:440:13 | h [element :bar] :  | semantics.rb:440:9:440:14 | call to s49 [element :bar] :  |
 | semantics.rb:440:13:440:13 | h [element] :  | semantics.rb:440:9:440:14 | call to s49 [element] :  |
@@ -882,10 +981,12 @@ edges
 | semantics.rb:494:10:494:10 | h [element :bar] :  | semantics.rb:494:10:494:16 | ...[...] |
 | semantics.rb:494:10:494:10 | h [element] :  | semantics.rb:494:10:494:16 | ...[...] |
 | semantics.rb:494:10:494:10 | h [element] :  | semantics.rb:494:10:494:16 | ...[...] |
+| semantics.rb:496:5:496:5 | x [element :bar] :  | semantics.rb:499:10:499:10 | x [element :bar] :  |
+| semantics.rb:496:5:496:5 | x [element :bar] :  | semantics.rb:499:10:499:10 | x [element :bar] :  |
 | semantics.rb:496:9:496:9 | h [element :bar] :  | semantics.rb:496:9:496:15 | call to s53 [element :bar] :  |
 | semantics.rb:496:9:496:9 | h [element :bar] :  | semantics.rb:496:9:496:15 | call to s53 [element :bar] :  |
-| semantics.rb:496:9:496:15 | call to s53 [element :bar] :  | semantics.rb:499:10:499:10 | x [element :bar] :  |
-| semantics.rb:496:9:496:15 | call to s53 [element :bar] :  | semantics.rb:499:10:499:10 | x [element :bar] :  |
+| semantics.rb:496:9:496:15 | call to s53 [element :bar] :  | semantics.rb:496:5:496:5 | x [element :bar] :  |
+| semantics.rb:496:9:496:15 | call to s53 [element :bar] :  | semantics.rb:496:5:496:5 | x [element :bar] :  |
 | semantics.rb:499:10:499:10 | x [element :bar] :  | semantics.rb:499:10:499:16 | ...[...] |
 | semantics.rb:499:10:499:10 | x [element :bar] :  | semantics.rb:499:10:499:16 | ...[...] |
 | semantics.rb:501:10:501:20 | call to source :  | semantics.rb:501:10:501:26 | call to s53 |
@@ -918,21 +1019,29 @@ edges
 | semantics.rb:510:10:510:10 | h [element :bar] :  | semantics.rb:510:10:510:16 | ...[...] |
 | semantics.rb:510:10:510:10 | h [element] :  | semantics.rb:510:10:510:16 | ...[...] |
 | semantics.rb:510:10:510:10 | h [element] :  | semantics.rb:510:10:510:16 | ...[...] |
+| semantics.rb:512:5:512:5 | x [element :bar] :  | semantics.rb:515:10:515:10 | x [element :bar] :  |
+| semantics.rb:512:5:512:5 | x [element :bar] :  | semantics.rb:515:10:515:10 | x [element :bar] :  |
 | semantics.rb:512:9:512:9 | h [element :bar] :  | semantics.rb:512:9:512:15 | call to s54 [element :bar] :  |
 | semantics.rb:512:9:512:9 | h [element :bar] :  | semantics.rb:512:9:512:15 | call to s54 [element :bar] :  |
-| semantics.rb:512:9:512:15 | call to s54 [element :bar] :  | semantics.rb:515:10:515:10 | x [element :bar] :  |
-| semantics.rb:512:9:512:15 | call to s54 [element :bar] :  | semantics.rb:515:10:515:10 | x [element :bar] :  |
+| semantics.rb:512:9:512:15 | call to s54 [element :bar] :  | semantics.rb:512:5:512:5 | x [element :bar] :  |
+| semantics.rb:512:9:512:15 | call to s54 [element :bar] :  | semantics.rb:512:5:512:5 | x [element :bar] :  |
 | semantics.rb:515:10:515:10 | x [element :bar] :  | semantics.rb:515:10:515:16 | ...[...] |
 | semantics.rb:515:10:515:10 | x [element :bar] :  | semantics.rb:515:10:515:16 | ...[...] |
 nodes
+| semantics.rb:2:5:2:5 | a :  | semmle.label | a :  |
+| semantics.rb:2:5:2:5 | a :  | semmle.label | a :  |
 | semantics.rb:2:9:2:18 | call to source :  | semmle.label | call to source :  |
 | semantics.rb:2:9:2:18 | call to source :  | semmle.label | call to source :  |
+| semantics.rb:3:5:3:5 | x :  | semmle.label | x :  |
+| semantics.rb:3:5:3:5 | x :  | semmle.label | x :  |
 | semantics.rb:3:9:3:9 | a :  | semmle.label | a :  |
 | semantics.rb:3:9:3:9 | a :  | semmle.label | a :  |
 | semantics.rb:3:9:3:14 | call to s1 :  | semmle.label | call to s1 :  |
 | semantics.rb:3:9:3:14 | call to s1 :  | semmle.label | call to s1 :  |
 | semantics.rb:4:10:4:10 | x | semmle.label | x |
 | semantics.rb:4:10:4:10 | x | semmle.label | x |
+| semantics.rb:8:5:8:5 | a :  | semmle.label | a :  |
+| semantics.rb:8:5:8:5 | a :  | semmle.label | a :  |
 | semantics.rb:8:9:8:18 | call to source :  | semmle.label | call to source :  |
 | semantics.rb:8:9:8:18 | call to source :  | semmle.label | call to source :  |
 | semantics.rb:9:5:9:5 | [post] x :  | semmle.label | [post] x :  |
@@ -941,6 +1050,8 @@ nodes
 | semantics.rb:9:10:9:10 | a :  | semmle.label | a :  |
 | semantics.rb:10:10:10:10 | x | semmle.label | x |
 | semantics.rb:10:10:10:10 | x | semmle.label | x |
+| semantics.rb:14:5:14:5 | a :  | semmle.label | a :  |
+| semantics.rb:14:5:14:5 | a :  | semmle.label | a :  |
 | semantics.rb:14:9:14:18 | call to source :  | semmle.label | call to source :  |
 | semantics.rb:14:9:14:18 | call to source :  | semmle.label | call to source :  |
 | semantics.rb:15:8:15:8 | a :  | semmle.label | a :  |
@@ -957,6 +1068,8 @@ nodes
 | semantics.rb:23:10:23:33 | call to s4 | semmle.label | call to s4 |
 | semantics.rb:23:23:23:32 | call to source :  | semmle.label | call to source :  |
 | semantics.rb:23:23:23:32 | call to source :  | semmle.label | call to source :  |
+| semantics.rb:28:5:28:5 | a :  | semmle.label | a :  |
+| semantics.rb:28:5:28:5 | a :  | semmle.label | a :  |
 | semantics.rb:28:9:28:18 | call to source :  | semmle.label | call to source :  |
 | semantics.rb:28:9:28:18 | call to source :  | semmle.label | call to source :  |
 | semantics.rb:29:8:29:8 | a :  | semmle.label | a :  |
@@ -969,6 +1082,8 @@ nodes
 | semantics.rb:31:10:31:10 | y | semmle.label | y |
 | semantics.rb:32:10:32:10 | z | semmle.label | z |
 | semantics.rb:32:10:32:10 | z | semmle.label | z |
+| semantics.rb:40:5:40:5 | a :  | semmle.label | a :  |
+| semantics.rb:40:5:40:5 | a :  | semmle.label | a :  |
 | semantics.rb:40:9:40:18 | call to source :  | semmle.label | call to source :  |
 | semantics.rb:40:9:40:18 | call to source :  | semmle.label | call to source :  |
 | semantics.rb:41:8:41:8 | a :  | semmle.label | a :  |
@@ -997,6 +1112,8 @@ nodes
 | semantics.rb:54:24:54:24 | x :  | semmle.label | x :  |
 | semantics.rb:55:14:55:14 | x | semmle.label | x |
 | semantics.rb:55:14:55:14 | x | semmle.label | x |
+| semantics.rb:60:5:60:5 | a :  | semmle.label | a :  |
+| semantics.rb:60:5:60:5 | a :  | semmle.label | a :  |
 | semantics.rb:60:9:60:18 | call to source :  | semmle.label | call to source :  |
 | semantics.rb:60:9:60:18 | call to source :  | semmle.label | call to source :  |
 | semantics.rb:61:10:61:15 | call to s10 | semmle.label | call to s10 |
@@ -1019,6 +1136,8 @@ nodes
 | semantics.rb:66:10:66:16 | call to s10 | semmle.label | call to s10 |
 | semantics.rb:66:14:66:15 | &... :  | semmle.label | &... :  |
 | semantics.rb:66:14:66:15 | &... :  | semmle.label | &... :  |
+| semantics.rb:80:5:80:5 | a :  | semmle.label | a :  |
+| semantics.rb:80:5:80:5 | a :  | semmle.label | a :  |
 | semantics.rb:80:9:80:18 | call to source :  | semmle.label | call to source :  |
 | semantics.rb:80:9:80:18 | call to source :  | semmle.label | call to source :  |
 | semantics.rb:81:5:81:5 | a :  | semmle.label | a :  |
@@ -1035,6 +1154,8 @@ nodes
 | semantics.rb:83:10:83:10 | y | semmle.label | y |
 | semantics.rb:84:10:84:10 | z | semmle.label | z |
 | semantics.rb:84:10:84:10 | z | semmle.label | z |
+| semantics.rb:89:5:89:5 | a :  | semmle.label | a :  |
+| semantics.rb:89:5:89:5 | a :  | semmle.label | a :  |
 | semantics.rb:89:9:89:18 | call to source :  | semmle.label | call to source :  |
 | semantics.rb:89:9:89:18 | call to source :  | semmle.label | call to source :  |
 | semantics.rb:91:10:91:20 | call to s13 | semmle.label | call to s13 |
@@ -1045,6 +1166,8 @@ nodes
 | semantics.rb:92:10:92:28 | call to s13 | semmle.label | call to s13 |
 | semantics.rb:92:27:92:27 | a :  | semmle.label | a :  |
 | semantics.rb:92:27:92:27 | a :  | semmle.label | a :  |
+| semantics.rb:97:5:97:5 | a :  | semmle.label | a :  |
+| semantics.rb:97:5:97:5 | a :  | semmle.label | a :  |
 | semantics.rb:97:9:97:18 | call to source :  | semmle.label | call to source :  |
 | semantics.rb:97:9:97:18 | call to source :  | semmle.label | call to source :  |
 | semantics.rb:98:5:98:5 | a :  | semmle.label | a :  |
@@ -1063,15 +1186,22 @@ nodes
 | semantics.rb:102:10:102:10 | y | semmle.label | y |
 | semantics.rb:103:10:103:10 | z | semmle.label | z |
 | semantics.rb:103:10:103:10 | z | semmle.label | z |
+| semantics.rb:107:5:107:5 | a :  | semmle.label | a :  |
 | semantics.rb:107:9:107:18 | call to source :  | semmle.label | call to source :  |
 | semantics.rb:109:10:109:17 | call to s15 | semmle.label | call to s15 |
 | semantics.rb:109:14:109:16 | ** ... :  | semmle.label | ** ... :  |
 | semantics.rb:110:10:110:31 | call to s15 | semmle.label | call to s15 |
 | semantics.rb:110:28:110:30 | ** ... :  | semmle.label | ** ... :  |
+| semantics.rb:114:5:114:5 | a :  | semmle.label | a :  |
+| semantics.rb:114:5:114:5 | a :  | semmle.label | a :  |
 | semantics.rb:114:9:114:18 | call to source :  | semmle.label | call to source :  |
 | semantics.rb:114:9:114:18 | call to source :  | semmle.label | call to source :  |
+| semantics.rb:115:5:115:5 | b :  | semmle.label | b :  |
+| semantics.rb:115:5:115:5 | b :  | semmle.label | b :  |
 | semantics.rb:115:9:115:18 | call to source :  | semmle.label | call to source :  |
 | semantics.rb:115:9:115:18 | call to source :  | semmle.label | call to source :  |
+| semantics.rb:116:5:116:5 | h [element :a] :  | semmle.label | h [element :a] :  |
+| semantics.rb:116:5:116:5 | h [element :a] :  | semmle.label | h [element :a] :  |
 | semantics.rb:116:14:116:14 | a :  | semmle.label | a :  |
 | semantics.rb:116:14:116:14 | a :  | semmle.label | a :  |
 | semantics.rb:117:10:117:17 | call to s16 | semmle.label | call to s16 |
@@ -1092,6 +1222,8 @@ nodes
 | semantics.rb:121:20:121:22 | ** ... [element :a] :  | semmle.label | ** ... [element :a] :  |
 | semantics.rb:121:22:121:22 | h [element :a] :  | semmle.label | h [element :a] :  |
 | semantics.rb:121:22:121:22 | h [element :a] :  | semmle.label | h [element :a] :  |
+| semantics.rb:125:5:125:5 | a :  | semmle.label | a :  |
+| semantics.rb:125:5:125:5 | a :  | semmle.label | a :  |
 | semantics.rb:125:9:125:18 | call to source :  | semmle.label | call to source :  |
 | semantics.rb:125:9:125:18 | call to source :  | semmle.label | call to source :  |
 | semantics.rb:126:9:126:9 | a :  | semmle.label | a :  |
@@ -1100,6 +1232,8 @@ nodes
 | semantics.rb:126:12:126:14 | [post] ** ... :  | semmle.label | [post] ** ... :  |
 | semantics.rb:127:10:127:10 | h | semmle.label | h |
 | semantics.rb:127:10:127:10 | h | semmle.label | h |
+| semantics.rb:141:5:141:5 | b :  | semmle.label | b :  |
+| semantics.rb:141:5:141:5 | b :  | semmle.label | b :  |
 | semantics.rb:141:9:141:18 | call to source :  | semmle.label | call to source :  |
 | semantics.rb:141:9:141:18 | call to source :  | semmle.label | call to source :  |
 | semantics.rb:145:5:145:5 | [post] h [element] :  | semmle.label | [post] h [element] :  |
@@ -1108,8 +1242,12 @@ nodes
 | semantics.rb:147:10:147:15 | call to s19 | semmle.label | call to s19 |
 | semantics.rb:147:14:147:14 | h [element] :  | semmle.label | h [element] :  |
 | semantics.rb:147:14:147:14 | h [element] :  | semmle.label | h [element] :  |
+| semantics.rb:151:5:151:5 | a :  | semmle.label | a :  |
+| semantics.rb:151:5:151:5 | a :  | semmle.label | a :  |
 | semantics.rb:151:9:151:18 | call to source :  | semmle.label | call to source :  |
 | semantics.rb:151:9:151:18 | call to source :  | semmle.label | call to source :  |
+| semantics.rb:152:5:152:5 | x [element] :  | semmle.label | x [element] :  |
+| semantics.rb:152:5:152:5 | x [element] :  | semmle.label | x [element] :  |
 | semantics.rb:152:9:152:14 | call to s20 [element] :  | semmle.label | call to s20 [element] :  |
 | semantics.rb:152:9:152:14 | call to s20 [element] :  | semmle.label | call to s20 [element] :  |
 | semantics.rb:152:13:152:13 | a :  | semmle.label | a :  |
@@ -1122,8 +1260,12 @@ nodes
 | semantics.rb:154:10:154:10 | x [element] :  | semmle.label | x [element] :  |
 | semantics.rb:154:10:154:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:154:10:154:13 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:158:5:158:5 | a :  | semmle.label | a :  |
+| semantics.rb:158:5:158:5 | a :  | semmle.label | a :  |
 | semantics.rb:158:9:158:18 | call to source :  | semmle.label | call to source :  |
 | semantics.rb:158:9:158:18 | call to source :  | semmle.label | call to source :  |
+| semantics.rb:159:5:159:5 | b :  | semmle.label | b :  |
+| semantics.rb:159:5:159:5 | b :  | semmle.label | b :  |
 | semantics.rb:159:9:159:18 | call to source :  | semmle.label | call to source :  |
 | semantics.rb:159:9:159:18 | call to source :  | semmle.label | call to source :  |
 | semantics.rb:162:5:162:5 | [post] h [element 0] :  | semmle.label | [post] h [element 0] :  |
@@ -1136,8 +1278,12 @@ nodes
 | semantics.rb:165:14:165:14 | h [element 0] :  | semmle.label | h [element 0] :  |
 | semantics.rb:165:14:165:14 | h [element] :  | semmle.label | h [element] :  |
 | semantics.rb:165:14:165:14 | h [element] :  | semmle.label | h [element] :  |
+| semantics.rb:169:5:169:5 | a :  | semmle.label | a :  |
+| semantics.rb:169:5:169:5 | a :  | semmle.label | a :  |
 | semantics.rb:169:9:169:18 | call to source :  | semmle.label | call to source :  |
 | semantics.rb:169:9:169:18 | call to source :  | semmle.label | call to source :  |
+| semantics.rb:170:5:170:5 | x [element] :  | semmle.label | x [element] :  |
+| semantics.rb:170:5:170:5 | x [element] :  | semmle.label | x [element] :  |
 | semantics.rb:170:9:170:14 | call to s22 [element] :  | semmle.label | call to s22 [element] :  |
 | semantics.rb:170:9:170:14 | call to s22 [element] :  | semmle.label | call to s22 [element] :  |
 | semantics.rb:170:13:170:13 | a :  | semmle.label | a :  |
@@ -1150,6 +1296,8 @@ nodes
 | semantics.rb:172:10:172:10 | x [element] :  | semmle.label | x [element] :  |
 | semantics.rb:172:10:172:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:172:10:172:13 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:176:5:176:5 | a :  | semmle.label | a :  |
+| semantics.rb:176:5:176:5 | a :  | semmle.label | a :  |
 | semantics.rb:176:9:176:18 | call to source :  | semmle.label | call to source :  |
 | semantics.rb:176:9:176:18 | call to source :  | semmle.label | call to source :  |
 | semantics.rb:179:5:179:5 | [post] h [element 0] :  | semmle.label | [post] h [element 0] :  |
@@ -1162,8 +1310,12 @@ nodes
 | semantics.rb:181:10:181:15 | call to s23 | semmle.label | call to s23 |
 | semantics.rb:181:14:181:14 | h [element 0] :  | semmle.label | h [element 0] :  |
 | semantics.rb:181:14:181:14 | h [element 0] :  | semmle.label | h [element 0] :  |
+| semantics.rb:185:5:185:5 | a :  | semmle.label | a :  |
+| semantics.rb:185:5:185:5 | a :  | semmle.label | a :  |
 | semantics.rb:185:9:185:18 | call to source :  | semmle.label | call to source :  |
 | semantics.rb:185:9:185:18 | call to source :  | semmle.label | call to source :  |
+| semantics.rb:186:5:186:5 | x [element 0] :  | semmle.label | x [element 0] :  |
+| semantics.rb:186:5:186:5 | x [element 0] :  | semmle.label | x [element 0] :  |
 | semantics.rb:186:9:186:14 | call to s24 [element 0] :  | semmle.label | call to s24 [element 0] :  |
 | semantics.rb:186:9:186:14 | call to s24 [element 0] :  | semmle.label | call to s24 [element 0] :  |
 | semantics.rb:186:13:186:13 | a :  | semmle.label | a :  |
@@ -1176,6 +1328,8 @@ nodes
 | semantics.rb:189:10:189:10 | x [element 0] :  | semmle.label | x [element 0] :  |
 | semantics.rb:189:10:189:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:189:10:189:13 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:193:5:193:5 | a :  | semmle.label | a :  |
+| semantics.rb:193:5:193:5 | a :  | semmle.label | a :  |
 | semantics.rb:193:9:193:18 | call to source :  | semmle.label | call to source :  |
 | semantics.rb:193:9:193:18 | call to source :  | semmle.label | call to source :  |
 | semantics.rb:196:5:196:5 | [post] h [element 0] :  | semmle.label | [post] h [element 0] :  |
@@ -1188,8 +1342,12 @@ nodes
 | semantics.rb:198:10:198:15 | call to s25 | semmle.label | call to s25 |
 | semantics.rb:198:14:198:14 | h [element 0] :  | semmle.label | h [element 0] :  |
 | semantics.rb:198:14:198:14 | h [element 0] :  | semmle.label | h [element 0] :  |
+| semantics.rb:202:5:202:5 | a :  | semmle.label | a :  |
+| semantics.rb:202:5:202:5 | a :  | semmle.label | a :  |
 | semantics.rb:202:9:202:18 | call to source :  | semmle.label | call to source :  |
 | semantics.rb:202:9:202:18 | call to source :  | semmle.label | call to source :  |
+| semantics.rb:203:5:203:5 | x [element 0] :  | semmle.label | x [element 0] :  |
+| semantics.rb:203:5:203:5 | x [element 0] :  | semmle.label | x [element 0] :  |
 | semantics.rb:203:9:203:14 | call to s26 [element 0] :  | semmle.label | call to s26 [element 0] :  |
 | semantics.rb:203:9:203:14 | call to s26 [element 0] :  | semmle.label | call to s26 [element 0] :  |
 | semantics.rb:203:13:203:13 | a :  | semmle.label | a :  |
@@ -1202,10 +1360,16 @@ nodes
 | semantics.rb:206:10:206:10 | x [element 0] :  | semmle.label | x [element 0] :  |
 | semantics.rb:206:10:206:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:206:10:206:13 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:211:5:211:5 | b :  | semmle.label | b :  |
+| semantics.rb:211:5:211:5 | b :  | semmle.label | b :  |
 | semantics.rb:211:9:211:18 | call to source :  | semmle.label | call to source :  |
 | semantics.rb:211:9:211:18 | call to source :  | semmle.label | call to source :  |
+| semantics.rb:212:5:212:5 | c :  | semmle.label | c :  |
+| semantics.rb:212:5:212:5 | c :  | semmle.label | c :  |
 | semantics.rb:212:9:212:18 | call to source :  | semmle.label | call to source :  |
 | semantics.rb:212:9:212:18 | call to source :  | semmle.label | call to source :  |
+| semantics.rb:213:5:213:5 | d :  | semmle.label | d :  |
+| semantics.rb:213:5:213:5 | d :  | semmle.label | d :  |
 | semantics.rb:213:9:213:18 | call to source :  | semmle.label | call to source :  |
 | semantics.rb:213:9:213:18 | call to source :  | semmle.label | call to source :  |
 | semantics.rb:217:5:217:5 | [post] h [element 1] :  | semmle.label | [post] h [element 1] :  |
@@ -1226,8 +1390,12 @@ nodes
 | semantics.rb:221:14:221:14 | h [element 2] :  | semmle.label | h [element 2] :  |
 | semantics.rb:221:14:221:14 | h [element] :  | semmle.label | h [element] :  |
 | semantics.rb:221:14:221:14 | h [element] :  | semmle.label | h [element] :  |
+| semantics.rb:225:5:225:5 | a :  | semmle.label | a :  |
+| semantics.rb:225:5:225:5 | a :  | semmle.label | a :  |
 | semantics.rb:225:9:225:18 | call to source :  | semmle.label | call to source :  |
 | semantics.rb:225:9:225:18 | call to source :  | semmle.label | call to source :  |
+| semantics.rb:226:5:226:5 | x [element] :  | semmle.label | x [element] :  |
+| semantics.rb:226:5:226:5 | x [element] :  | semmle.label | x [element] :  |
 | semantics.rb:226:9:226:14 | call to s28 [element] :  | semmle.label | call to s28 [element] :  |
 | semantics.rb:226:9:226:14 | call to s28 [element] :  | semmle.label | call to s28 [element] :  |
 | semantics.rb:226:13:226:13 | a :  | semmle.label | a :  |
@@ -1248,8 +1416,12 @@ nodes
 | semantics.rb:230:10:230:10 | x [element] :  | semmle.label | x [element] :  |
 | semantics.rb:230:10:230:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:230:10:230:13 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:235:5:235:5 | b :  | semmle.label | b :  |
+| semantics.rb:235:5:235:5 | b :  | semmle.label | b :  |
 | semantics.rb:235:9:235:18 | call to source :  | semmle.label | call to source :  |
 | semantics.rb:235:9:235:18 | call to source :  | semmle.label | call to source :  |
+| semantics.rb:236:5:236:5 | c :  | semmle.label | c :  |
+| semantics.rb:236:5:236:5 | c :  | semmle.label | c :  |
 | semantics.rb:236:9:236:18 | call to source :  | semmle.label | call to source :  |
 | semantics.rb:236:9:236:18 | call to source :  | semmle.label | call to source :  |
 | semantics.rb:240:5:240:5 | [post] h [element 1] :  | semmle.label | [post] h [element 1] :  |
@@ -1266,8 +1438,12 @@ nodes
 | semantics.rb:244:14:244:14 | h [element 1] :  | semmle.label | h [element 1] :  |
 | semantics.rb:244:14:244:14 | h [element 2] :  | semmle.label | h [element 2] :  |
 | semantics.rb:244:14:244:14 | h [element 2] :  | semmle.label | h [element 2] :  |
+| semantics.rb:248:5:248:5 | a :  | semmle.label | a :  |
+| semantics.rb:248:5:248:5 | a :  | semmle.label | a :  |
 | semantics.rb:248:9:248:18 | call to source :  | semmle.label | call to source :  |
 | semantics.rb:248:9:248:18 | call to source :  | semmle.label | call to source :  |
+| semantics.rb:249:5:249:5 | x [element] :  | semmle.label | x [element] :  |
+| semantics.rb:249:5:249:5 | x [element] :  | semmle.label | x [element] :  |
 | semantics.rb:249:9:249:14 | call to s30 [element] :  | semmle.label | call to s30 [element] :  |
 | semantics.rb:249:9:249:14 | call to s30 [element] :  | semmle.label | call to s30 [element] :  |
 | semantics.rb:249:13:249:13 | a :  | semmle.label | a :  |
@@ -1382,6 +1558,8 @@ nodes
 | semantics.rb:285:14:285:14 | h [element true] :  | semmle.label | h [element true] :  |
 | semantics.rb:285:14:285:14 | h [element] :  | semmle.label | h [element] :  |
 | semantics.rb:285:14:285:14 | h [element] :  | semmle.label | h [element] :  |
+| semantics.rb:289:5:289:5 | x [element :foo] :  | semmle.label | x [element :foo] :  |
+| semantics.rb:289:5:289:5 | x [element :foo] :  | semmle.label | x [element :foo] :  |
 | semantics.rb:289:9:289:24 | call to s35 [element :foo] :  | semmle.label | call to s35 [element :foo] :  |
 | semantics.rb:289:9:289:24 | call to s35 [element :foo] :  | semmle.label | call to s35 [element :foo] :  |
 | semantics.rb:289:13:289:23 | call to source :  | semmle.label | call to source :  |
@@ -1394,6 +1572,8 @@ nodes
 | semantics.rb:292:10:292:10 | x [element :foo] :  | semmle.label | x [element :foo] :  |
 | semantics.rb:292:10:292:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:292:10:292:13 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:296:5:296:5 | x [element foo] :  | semmle.label | x [element foo] :  |
+| semantics.rb:296:5:296:5 | x [element foo] :  | semmle.label | x [element foo] :  |
 | semantics.rb:296:9:296:24 | call to s36 [element foo] :  | semmle.label | call to s36 [element foo] :  |
 | semantics.rb:296:9:296:24 | call to s36 [element foo] :  | semmle.label | call to s36 [element foo] :  |
 | semantics.rb:296:13:296:23 | call to source :  | semmle.label | call to source :  |
@@ -1406,6 +1586,8 @@ nodes
 | semantics.rb:300:10:300:10 | x [element foo] :  | semmle.label | x [element foo] :  |
 | semantics.rb:300:10:300:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:300:10:300:13 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:304:5:304:5 | x [element true] :  | semmle.label | x [element true] :  |
+| semantics.rb:304:5:304:5 | x [element true] :  | semmle.label | x [element true] :  |
 | semantics.rb:304:9:304:24 | call to s37 [element true] :  | semmle.label | call to s37 [element true] :  |
 | semantics.rb:304:9:304:24 | call to s37 [element true] :  | semmle.label | call to s37 [element true] :  |
 | semantics.rb:304:13:304:23 | call to source :  | semmle.label | call to source :  |
@@ -1426,6 +1608,8 @@ nodes
 | semantics.rb:315:10:315:15 | call to s38 | semmle.label | call to s38 |
 | semantics.rb:315:14:315:14 | h [element foo] :  | semmle.label | h [element foo] :  |
 | semantics.rb:315:14:315:14 | h [element foo] :  | semmle.label | h [element foo] :  |
+| semantics.rb:319:5:319:5 | x [element :foo] :  | semmle.label | x [element :foo] :  |
+| semantics.rb:319:5:319:5 | x [element :foo] :  | semmle.label | x [element :foo] :  |
 | semantics.rb:319:9:319:24 | call to s39 [element :foo] :  | semmle.label | call to s39 [element :foo] :  |
 | semantics.rb:319:9:319:24 | call to s39 [element :foo] :  | semmle.label | call to s39 [element :foo] :  |
 | semantics.rb:319:13:319:23 | call to source :  | semmle.label | call to source :  |
@@ -1446,6 +1630,8 @@ nodes
 | semantics.rb:329:10:329:15 | call to s40 | semmle.label | call to s40 |
 | semantics.rb:329:14:329:14 | x [@foo] :  | semmle.label | x [@foo] :  |
 | semantics.rb:329:14:329:14 | x [@foo] :  | semmle.label | x [@foo] :  |
+| semantics.rb:333:5:333:5 | x [@foo] :  | semmle.label | x [@foo] :  |
+| semantics.rb:333:5:333:5 | x [@foo] :  | semmle.label | x [@foo] :  |
 | semantics.rb:333:9:333:24 | call to s41 [@foo] :  | semmle.label | call to s41 [@foo] :  |
 | semantics.rb:333:9:333:24 | call to s41 [@foo] :  | semmle.label | call to s41 [@foo] :  |
 | semantics.rb:333:13:333:23 | call to source :  | semmle.label | call to source :  |
@@ -1462,6 +1648,10 @@ nodes
 | semantics.rb:340:5:340:5 | [post] h [element] :  | semmle.label | [post] h [element] :  |
 | semantics.rb:340:12:340:22 | call to source :  | semmle.label | call to source :  |
 | semantics.rb:340:12:340:22 | call to source :  | semmle.label | call to source :  |
+| semantics.rb:342:5:342:5 | x [element 0] :  | semmle.label | x [element 0] :  |
+| semantics.rb:342:5:342:5 | x [element 0] :  | semmle.label | x [element 0] :  |
+| semantics.rb:342:5:342:5 | x [element] :  | semmle.label | x [element] :  |
+| semantics.rb:342:5:342:5 | x [element] :  | semmle.label | x [element] :  |
 | semantics.rb:342:9:342:14 | call to s42 [element 0] :  | semmle.label | call to s42 [element 0] :  |
 | semantics.rb:342:9:342:14 | call to s42 [element 0] :  | semmle.label | call to s42 [element 0] :  |
 | semantics.rb:342:9:342:14 | call to s42 [element] :  | semmle.label | call to s42 [element] :  |
@@ -1490,6 +1680,8 @@ nodes
 | semantics.rb:350:5:350:5 | [post] h [element 0] :  | semmle.label | [post] h [element 0] :  |
 | semantics.rb:350:12:350:22 | call to source :  | semmle.label | call to source :  |
 | semantics.rb:350:12:350:22 | call to source :  | semmle.label | call to source :  |
+| semantics.rb:353:5:353:5 | x [element 0] :  | semmle.label | x [element 0] :  |
+| semantics.rb:353:5:353:5 | x [element 0] :  | semmle.label | x [element 0] :  |
 | semantics.rb:353:9:353:14 | call to s43 [element 0] :  | semmle.label | call to s43 [element 0] :  |
 | semantics.rb:353:9:353:14 | call to s43 [element 0] :  | semmle.label | call to s43 [element 0] :  |
 | semantics.rb:353:13:353:13 | h [element 0] :  | semmle.label | h [element 0] :  |
@@ -1614,6 +1806,8 @@ nodes
 | semantics.rb:395:10:395:10 | h [element] :  | semmle.label | h [element] :  |
 | semantics.rb:395:10:395:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:395:10:395:13 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:397:5:397:5 | x [element 1] :  | semmle.label | x [element 1] :  |
+| semantics.rb:397:5:397:5 | x [element 1] :  | semmle.label | x [element 1] :  |
 | semantics.rb:397:9:397:14 | call to s46 [element 1] :  | semmle.label | call to s46 [element 1] :  |
 | semantics.rb:397:9:397:14 | call to s46 [element 1] :  | semmle.label | call to s46 [element 1] :  |
 | semantics.rb:397:13:397:13 | h [element 1] :  | semmle.label | h [element 1] :  |
@@ -1654,6 +1848,8 @@ nodes
 | semantics.rb:410:10:410:10 | h [element] :  | semmle.label | h [element] :  |
 | semantics.rb:410:10:410:16 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:410:10:410:16 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:412:5:412:5 | x [element :bar] :  | semmle.label | x [element :bar] :  |
+| semantics.rb:412:5:412:5 | x [element :bar] :  | semmle.label | x [element :bar] :  |
 | semantics.rb:412:9:412:14 | call to s47 [element :bar] :  | semmle.label | call to s47 [element :bar] :  |
 | semantics.rb:412:9:412:14 | call to s47 [element :bar] :  | semmle.label | call to s47 [element :bar] :  |
 | semantics.rb:412:13:412:13 | h [element :bar] :  | semmle.label | h [element :bar] :  |
@@ -1690,6 +1886,8 @@ nodes
 | semantics.rb:424:10:424:10 | h [element] :  | semmle.label | h [element] :  |
 | semantics.rb:424:10:424:16 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:424:10:424:16 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:426:5:426:5 | x [element :bar] :  | semmle.label | x [element :bar] :  |
+| semantics.rb:426:5:426:5 | x [element :bar] :  | semmle.label | x [element :bar] :  |
 | semantics.rb:426:9:426:14 | call to s48 [element :bar] :  | semmle.label | call to s48 [element :bar] :  |
 | semantics.rb:426:9:426:14 | call to s48 [element :bar] :  | semmle.label | call to s48 [element :bar] :  |
 | semantics.rb:426:13:426:13 | h [element :bar] :  | semmle.label | h [element :bar] :  |
@@ -1726,6 +1924,10 @@ nodes
 | semantics.rb:438:10:438:10 | h [element] :  | semmle.label | h [element] :  |
 | semantics.rb:438:10:438:16 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:438:10:438:16 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:440:5:440:5 | x [element :bar] :  | semmle.label | x [element :bar] :  |
+| semantics.rb:440:5:440:5 | x [element :bar] :  | semmle.label | x [element :bar] :  |
+| semantics.rb:440:5:440:5 | x [element] :  | semmle.label | x [element] :  |
+| semantics.rb:440:5:440:5 | x [element] :  | semmle.label | x [element] :  |
 | semantics.rb:440:9:440:14 | call to s49 [element :bar] :  | semmle.label | call to s49 [element :bar] :  |
 | semantics.rb:440:9:440:14 | call to s49 [element :bar] :  | semmle.label | call to s49 [element :bar] :  |
 | semantics.rb:440:9:440:14 | call to s49 [element] :  | semmle.label | call to s49 [element] :  |
@@ -1890,6 +2092,8 @@ nodes
 | semantics.rb:494:10:494:10 | h [element] :  | semmle.label | h [element] :  |
 | semantics.rb:494:10:494:16 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:494:10:494:16 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:496:5:496:5 | x [element :bar] :  | semmle.label | x [element :bar] :  |
+| semantics.rb:496:5:496:5 | x [element :bar] :  | semmle.label | x [element :bar] :  |
 | semantics.rb:496:9:496:9 | h [element :bar] :  | semmle.label | h [element :bar] :  |
 | semantics.rb:496:9:496:9 | h [element :bar] :  | semmle.label | h [element :bar] :  |
 | semantics.rb:496:9:496:15 | call to s53 [element :bar] :  | semmle.label | call to s53 [element :bar] :  |
@@ -1930,6 +2134,8 @@ nodes
 | semantics.rb:510:10:510:10 | h [element] :  | semmle.label | h [element] :  |
 | semantics.rb:510:10:510:16 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:510:10:510:16 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:512:5:512:5 | x [element :bar] :  | semmle.label | x [element :bar] :  |
+| semantics.rb:512:5:512:5 | x [element :bar] :  | semmle.label | x [element :bar] :  |
 | semantics.rb:512:9:512:9 | h [element :bar] :  | semmle.label | h [element :bar] :  |
 | semantics.rb:512:9:512:9 | h [element :bar] :  | semmle.label | h [element :bar] :  |
 | semantics.rb:512:9:512:15 | call to s54 [element :bar] :  | semmle.label | call to s54 [element :bar] :  |

--- a/ruby/ql/test/library-tests/dataflow/global/Flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/global/Flow.expected
@@ -207,8 +207,10 @@ edges
 | instance_variables.rb:114:6:114:10 | foo13 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
 | instance_variables.rb:114:6:114:10 | foo13 [@field] :  | instance_variables.rb:114:6:114:20 | call to get_field |
 | instance_variables.rb:114:6:114:10 | foo13 [@field] :  | instance_variables.rb:114:6:114:20 | call to get_field |
-| instance_variables.rb:116:9:116:26 | call to new [@field] :  | instance_variables.rb:117:6:117:10 | foo15 [@field] :  |
-| instance_variables.rb:116:9:116:26 | call to new [@field] :  | instance_variables.rb:117:6:117:10 | foo15 [@field] :  |
+| instance_variables.rb:116:1:116:5 | foo15 [@field] :  | instance_variables.rb:117:6:117:10 | foo15 [@field] :  |
+| instance_variables.rb:116:1:116:5 | foo15 [@field] :  | instance_variables.rb:117:6:117:10 | foo15 [@field] :  |
+| instance_variables.rb:116:9:116:26 | call to new [@field] :  | instance_variables.rb:116:1:116:5 | foo15 [@field] :  |
+| instance_variables.rb:116:9:116:26 | call to new [@field] :  | instance_variables.rb:116:1:116:5 | foo15 [@field] :  |
 | instance_variables.rb:116:17:116:25 | call to taint :  | instance_variables.rb:22:20:22:24 | field :  |
 | instance_variables.rb:116:17:116:25 | call to taint :  | instance_variables.rb:22:20:22:24 | field :  |
 | instance_variables.rb:116:17:116:25 | call to taint :  | instance_variables.rb:116:9:116:26 | call to new [@field] :  |
@@ -227,8 +229,10 @@ edges
 | instance_variables.rb:120:6:120:10 | foo16 [@field] :  | instance_variables.rb:13:5:15:7 | self in get_field [@field] :  |
 | instance_variables.rb:120:6:120:10 | foo16 [@field] :  | instance_variables.rb:120:6:120:20 | call to get_field |
 | instance_variables.rb:120:6:120:10 | foo16 [@field] :  | instance_variables.rb:120:6:120:20 | call to get_field |
-| instance_variables.rb:121:7:121:24 | call to new :  | instance_variables.rb:122:6:122:8 | bar |
-| instance_variables.rb:121:7:121:24 | call to new :  | instance_variables.rb:122:6:122:8 | bar |
+| instance_variables.rb:121:1:121:3 | bar :  | instance_variables.rb:122:6:122:8 | bar |
+| instance_variables.rb:121:1:121:3 | bar :  | instance_variables.rb:122:6:122:8 | bar |
+| instance_variables.rb:121:7:121:24 | call to new :  | instance_variables.rb:121:1:121:3 | bar :  |
+| instance_variables.rb:121:7:121:24 | call to new :  | instance_variables.rb:121:1:121:3 | bar :  |
 nodes
 | captured_variables.rb:1:24:1:24 | x :  | semmle.label | x :  |
 | captured_variables.rb:1:24:1:24 | x :  | semmle.label | x :  |
@@ -424,6 +428,8 @@ nodes
 | instance_variables.rb:114:6:114:10 | foo13 [@field] :  | semmle.label | foo13 [@field] :  |
 | instance_variables.rb:114:6:114:20 | call to get_field | semmle.label | call to get_field |
 | instance_variables.rb:114:6:114:20 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:116:1:116:5 | foo15 [@field] :  | semmle.label | foo15 [@field] :  |
+| instance_variables.rb:116:1:116:5 | foo15 [@field] :  | semmle.label | foo15 [@field] :  |
 | instance_variables.rb:116:9:116:26 | call to new [@field] :  | semmle.label | call to new [@field] :  |
 | instance_variables.rb:116:9:116:26 | call to new [@field] :  | semmle.label | call to new [@field] :  |
 | instance_variables.rb:116:17:116:25 | call to taint :  | semmle.label | call to taint :  |
@@ -442,6 +448,8 @@ nodes
 | instance_variables.rb:120:6:120:10 | foo16 [@field] :  | semmle.label | foo16 [@field] :  |
 | instance_variables.rb:120:6:120:20 | call to get_field | semmle.label | call to get_field |
 | instance_variables.rb:120:6:120:20 | call to get_field | semmle.label | call to get_field |
+| instance_variables.rb:121:1:121:3 | bar :  | semmle.label | bar :  |
+| instance_variables.rb:121:1:121:3 | bar :  | semmle.label | bar :  |
 | instance_variables.rb:121:7:121:24 | call to new :  | semmle.label | call to new :  |
 | instance_variables.rb:121:7:121:24 | call to new :  | semmle.label | call to new :  |
 | instance_variables.rb:122:6:122:8 | bar | semmle.label | bar |

--- a/ruby/ql/test/library-tests/dataflow/hash-flow/hash-flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/hash-flow/hash-flow.expected
@@ -1,10 +1,15 @@
 failures
 edges
-| hash_flow.rb:11:15:11:24 | call to taint :  | hash_flow.rb:22:10:22:13 | hash [element :a] :  |
-| hash_flow.rb:13:12:13:21 | call to taint :  | hash_flow.rb:24:10:24:13 | hash [element :c] :  |
-| hash_flow.rb:15:14:15:23 | call to taint :  | hash_flow.rb:26:10:26:13 | hash [element e] :  |
-| hash_flow.rb:17:16:17:25 | call to taint :  | hash_flow.rb:28:10:28:13 | hash [element g] :  |
-| hash_flow.rb:19:14:19:23 | call to taint :  | hash_flow.rb:30:10:30:13 | hash [element 0] :  |
+| hash_flow.rb:10:5:10:8 | hash [element 0] :  | hash_flow.rb:30:10:30:13 | hash [element 0] :  |
+| hash_flow.rb:10:5:10:8 | hash [element :a] :  | hash_flow.rb:22:10:22:13 | hash [element :a] :  |
+| hash_flow.rb:10:5:10:8 | hash [element :c] :  | hash_flow.rb:24:10:24:13 | hash [element :c] :  |
+| hash_flow.rb:10:5:10:8 | hash [element e] :  | hash_flow.rb:26:10:26:13 | hash [element e] :  |
+| hash_flow.rb:10:5:10:8 | hash [element g] :  | hash_flow.rb:28:10:28:13 | hash [element g] :  |
+| hash_flow.rb:11:15:11:24 | call to taint :  | hash_flow.rb:10:5:10:8 | hash [element :a] :  |
+| hash_flow.rb:13:12:13:21 | call to taint :  | hash_flow.rb:10:5:10:8 | hash [element :c] :  |
+| hash_flow.rb:15:14:15:23 | call to taint :  | hash_flow.rb:10:5:10:8 | hash [element e] :  |
+| hash_flow.rb:17:16:17:25 | call to taint :  | hash_flow.rb:10:5:10:8 | hash [element g] :  |
+| hash_flow.rb:19:14:19:23 | call to taint :  | hash_flow.rb:10:5:10:8 | hash [element 0] :  |
 | hash_flow.rb:22:10:22:13 | hash [element :a] :  | hash_flow.rb:22:10:22:17 | ...[...] |
 | hash_flow.rb:24:10:24:13 | hash [element :c] :  | hash_flow.rb:24:10:24:17 | ...[...] |
 | hash_flow.rb:26:10:26:13 | hash [element e] :  | hash_flow.rb:26:10:26:18 | ...[...] |
@@ -37,161 +42,214 @@ edges
 | hash_flow.rb:44:10:44:13 | hash [element 0] :  | hash_flow.rb:44:10:44:16 | ...[...] |
 | hash_flow.rb:46:10:46:13 | hash [element :a] :  | hash_flow.rb:46:10:46:17 | ...[...] |
 | hash_flow.rb:48:10:48:13 | hash [element a] :  | hash_flow.rb:48:10:48:18 | ...[...] |
-| hash_flow.rb:55:13:55:37 | ...[...] [element :a] :  | hash_flow.rb:56:10:56:14 | hash1 [element :a] :  |
+| hash_flow.rb:55:5:55:9 | hash1 [element :a] :  | hash_flow.rb:56:10:56:14 | hash1 [element :a] :  |
+| hash_flow.rb:55:13:55:37 | ...[...] [element :a] :  | hash_flow.rb:55:5:55:9 | hash1 [element :a] :  |
 | hash_flow.rb:55:21:55:30 | call to taint :  | hash_flow.rb:55:13:55:37 | ...[...] [element :a] :  |
 | hash_flow.rb:56:10:56:14 | hash1 [element :a] :  | hash_flow.rb:56:10:56:18 | ...[...] |
-| hash_flow.rb:59:13:59:22 | call to taint :  | hash_flow.rb:60:18:60:18 | x [element :a] :  |
-| hash_flow.rb:60:13:60:19 | ...[...] [element :a] :  | hash_flow.rb:61:10:61:14 | hash2 [element :a] :  |
+| hash_flow.rb:59:5:59:5 | x [element :a] :  | hash_flow.rb:60:18:60:18 | x [element :a] :  |
+| hash_flow.rb:59:13:59:22 | call to taint :  | hash_flow.rb:59:5:59:5 | x [element :a] :  |
+| hash_flow.rb:60:5:60:9 | hash2 [element :a] :  | hash_flow.rb:61:10:61:14 | hash2 [element :a] :  |
+| hash_flow.rb:60:13:60:19 | ...[...] [element :a] :  | hash_flow.rb:60:5:60:9 | hash2 [element :a] :  |
 | hash_flow.rb:60:18:60:18 | x [element :a] :  | hash_flow.rb:60:13:60:19 | ...[...] [element :a] :  |
 | hash_flow.rb:61:10:61:14 | hash2 [element :a] :  | hash_flow.rb:61:10:61:18 | ...[...] |
-| hash_flow.rb:64:13:64:45 | ...[...] [element] :  | hash_flow.rb:65:10:65:14 | hash3 [element] :  |
-| hash_flow.rb:64:13:64:45 | ...[...] [element] :  | hash_flow.rb:66:10:66:14 | hash3 [element] :  |
+| hash_flow.rb:64:5:64:9 | hash3 [element] :  | hash_flow.rb:65:10:65:14 | hash3 [element] :  |
+| hash_flow.rb:64:5:64:9 | hash3 [element] :  | hash_flow.rb:66:10:66:14 | hash3 [element] :  |
+| hash_flow.rb:64:13:64:45 | ...[...] [element] :  | hash_flow.rb:64:5:64:9 | hash3 [element] :  |
 | hash_flow.rb:64:24:64:33 | call to taint :  | hash_flow.rb:64:13:64:45 | ...[...] [element] :  |
 | hash_flow.rb:65:10:65:14 | hash3 [element] :  | hash_flow.rb:65:10:65:18 | ...[...] |
 | hash_flow.rb:66:10:66:14 | hash3 [element] :  | hash_flow.rb:66:10:66:18 | ...[...] |
-| hash_flow.rb:68:13:68:39 | ...[...] [element :a] :  | hash_flow.rb:69:10:69:14 | hash4 [element :a] :  |
+| hash_flow.rb:68:5:68:9 | hash4 [element :a] :  | hash_flow.rb:69:10:69:14 | hash4 [element :a] :  |
+| hash_flow.rb:68:13:68:39 | ...[...] [element :a] :  | hash_flow.rb:68:5:68:9 | hash4 [element :a] :  |
 | hash_flow.rb:68:22:68:31 | call to taint :  | hash_flow.rb:68:13:68:39 | ...[...] [element :a] :  |
 | hash_flow.rb:69:10:69:14 | hash4 [element :a] :  | hash_flow.rb:69:10:69:18 | ...[...] |
-| hash_flow.rb:72:13:72:45 | ...[...] [element a] :  | hash_flow.rb:73:10:73:14 | hash5 [element a] :  |
+| hash_flow.rb:72:5:72:9 | hash5 [element a] :  | hash_flow.rb:73:10:73:14 | hash5 [element a] :  |
+| hash_flow.rb:72:13:72:45 | ...[...] [element a] :  | hash_flow.rb:72:5:72:9 | hash5 [element a] :  |
 | hash_flow.rb:72:25:72:34 | call to taint :  | hash_flow.rb:72:13:72:45 | ...[...] [element a] :  |
 | hash_flow.rb:73:10:73:14 | hash5 [element a] :  | hash_flow.rb:73:10:73:19 | ...[...] |
-| hash_flow.rb:76:13:76:47 | ...[...] [element a] :  | hash_flow.rb:77:10:77:14 | hash6 [element a] :  |
+| hash_flow.rb:76:5:76:9 | hash6 [element a] :  | hash_flow.rb:77:10:77:14 | hash6 [element a] :  |
+| hash_flow.rb:76:13:76:47 | ...[...] [element a] :  | hash_flow.rb:76:5:76:9 | hash6 [element a] :  |
 | hash_flow.rb:76:26:76:35 | call to taint :  | hash_flow.rb:76:13:76:47 | ...[...] [element a] :  |
 | hash_flow.rb:77:10:77:14 | hash6 [element a] :  | hash_flow.rb:77:10:77:19 | ...[...] |
-| hash_flow.rb:84:13:84:42 | call to [] [element :a] :  | hash_flow.rb:85:10:85:14 | hash1 [element :a] :  |
+| hash_flow.rb:84:5:84:9 | hash1 [element :a] :  | hash_flow.rb:85:10:85:14 | hash1 [element :a] :  |
+| hash_flow.rb:84:13:84:42 | call to [] [element :a] :  | hash_flow.rb:84:5:84:9 | hash1 [element :a] :  |
 | hash_flow.rb:84:26:84:35 | call to taint :  | hash_flow.rb:84:13:84:42 | call to [] [element :a] :  |
 | hash_flow.rb:85:10:85:14 | hash1 [element :a] :  | hash_flow.rb:85:10:85:18 | ...[...] |
-| hash_flow.rb:93:15:93:24 | call to taint :  | hash_flow.rb:96:30:96:33 | hash [element :a] :  |
-| hash_flow.rb:96:13:96:34 | call to try_convert [element :a] :  | hash_flow.rb:97:10:97:14 | hash2 [element :a] :  |
+| hash_flow.rb:92:5:92:8 | hash [element :a] :  | hash_flow.rb:96:30:96:33 | hash [element :a] :  |
+| hash_flow.rb:93:15:93:24 | call to taint :  | hash_flow.rb:92:5:92:8 | hash [element :a] :  |
+| hash_flow.rb:96:5:96:9 | hash2 [element :a] :  | hash_flow.rb:97:10:97:14 | hash2 [element :a] :  |
+| hash_flow.rb:96:13:96:34 | call to try_convert [element :a] :  | hash_flow.rb:96:5:96:9 | hash2 [element :a] :  |
 | hash_flow.rb:96:30:96:33 | hash [element :a] :  | hash_flow.rb:96:13:96:34 | call to try_convert [element :a] :  |
 | hash_flow.rb:97:10:97:14 | hash2 [element :a] :  | hash_flow.rb:97:10:97:18 | ...[...] |
-| hash_flow.rb:105:21:105:30 | call to taint :  | hash_flow.rb:106:10:106:10 | b |
+| hash_flow.rb:105:5:105:5 | b :  | hash_flow.rb:106:10:106:10 | b |
+| hash_flow.rb:105:21:105:30 | __synth__0 :  | hash_flow.rb:105:5:105:5 | b :  |
+| hash_flow.rb:105:21:105:30 | call to taint :  | hash_flow.rb:105:21:105:30 | __synth__0 :  |
+| hash_flow.rb:113:5:113:5 | b :  | hash_flow.rb:115:10:115:10 | b |
 | hash_flow.rb:113:9:113:12 | [post] hash [element :a] :  | hash_flow.rb:114:10:114:13 | hash [element :a] :  |
-| hash_flow.rb:113:9:113:34 | call to store :  | hash_flow.rb:115:10:115:10 | b |
+| hash_flow.rb:113:9:113:34 | call to store :  | hash_flow.rb:113:5:113:5 | b :  |
 | hash_flow.rb:113:24:113:33 | call to taint :  | hash_flow.rb:113:9:113:12 | [post] hash [element :a] :  |
 | hash_flow.rb:113:24:113:33 | call to taint :  | hash_flow.rb:113:9:113:34 | call to store :  |
 | hash_flow.rb:114:10:114:13 | hash [element :a] :  | hash_flow.rb:114:10:114:17 | ...[...] |
+| hash_flow.rb:118:5:118:5 | c :  | hash_flow.rb:121:10:121:10 | c |
 | hash_flow.rb:118:9:118:12 | [post] hash [element] :  | hash_flow.rb:119:10:119:13 | hash [element] :  |
 | hash_flow.rb:118:9:118:12 | [post] hash [element] :  | hash_flow.rb:120:10:120:13 | hash [element] :  |
-| hash_flow.rb:118:9:118:33 | call to store :  | hash_flow.rb:121:10:121:10 | c |
+| hash_flow.rb:118:9:118:33 | call to store :  | hash_flow.rb:118:5:118:5 | c :  |
 | hash_flow.rb:118:23:118:32 | call to taint :  | hash_flow.rb:118:9:118:12 | [post] hash [element] :  |
 | hash_flow.rb:118:23:118:32 | call to taint :  | hash_flow.rb:118:9:118:33 | call to store :  |
 | hash_flow.rb:119:10:119:13 | hash [element] :  | hash_flow.rb:119:10:119:17 | ...[...] |
 | hash_flow.rb:120:10:120:13 | hash [element] :  | hash_flow.rb:120:10:120:17 | ...[...] |
-| hash_flow.rb:128:15:128:24 | call to taint :  | hash_flow.rb:131:5:131:8 | hash [element :a] :  |
-| hash_flow.rb:128:15:128:24 | call to taint :  | hash_flow.rb:134:5:134:8 | hash [element :a] :  |
+| hash_flow.rb:127:5:127:8 | hash [element :a] :  | hash_flow.rb:131:5:131:8 | hash [element :a] :  |
+| hash_flow.rb:127:5:127:8 | hash [element :a] :  | hash_flow.rb:134:5:134:8 | hash [element :a] :  |
+| hash_flow.rb:128:15:128:24 | call to taint :  | hash_flow.rb:127:5:127:8 | hash [element :a] :  |
 | hash_flow.rb:131:5:131:8 | hash [element :a] :  | hash_flow.rb:131:18:131:29 | key_or_value :  |
 | hash_flow.rb:131:18:131:29 | key_or_value :  | hash_flow.rb:132:14:132:25 | key_or_value |
 | hash_flow.rb:134:5:134:8 | hash [element :a] :  | hash_flow.rb:134:22:134:26 | value :  |
 | hash_flow.rb:134:22:134:26 | value :  | hash_flow.rb:136:14:136:18 | value |
-| hash_flow.rb:144:15:144:25 | call to taint :  | hash_flow.rb:147:9:147:12 | hash [element :a] :  |
-| hash_flow.rb:144:15:144:25 | call to taint :  | hash_flow.rb:151:9:151:12 | hash [element :a] :  |
+| hash_flow.rb:143:5:143:8 | hash [element :a] :  | hash_flow.rb:147:9:147:12 | hash [element :a] :  |
+| hash_flow.rb:143:5:143:8 | hash [element :a] :  | hash_flow.rb:151:9:151:12 | hash [element :a] :  |
+| hash_flow.rb:144:15:144:25 | call to taint :  | hash_flow.rb:143:5:143:8 | hash [element :a] :  |
+| hash_flow.rb:147:5:147:5 | b [element 1] :  | hash_flow.rb:149:10:149:10 | b [element 1] :  |
+| hash_flow.rb:147:5:147:5 | b [element 1] :  | hash_flow.rb:150:10:150:10 | b [element 1] :  |
 | hash_flow.rb:147:9:147:12 | hash [element :a] :  | hash_flow.rb:147:9:147:22 | call to assoc [element 1] :  |
-| hash_flow.rb:147:9:147:22 | call to assoc [element 1] :  | hash_flow.rb:149:10:149:10 | b [element 1] :  |
-| hash_flow.rb:147:9:147:22 | call to assoc [element 1] :  | hash_flow.rb:150:10:150:10 | b [element 1] :  |
+| hash_flow.rb:147:9:147:22 | call to assoc [element 1] :  | hash_flow.rb:147:5:147:5 | b [element 1] :  |
 | hash_flow.rb:149:10:149:10 | b [element 1] :  | hash_flow.rb:149:10:149:13 | ...[...] |
 | hash_flow.rb:150:10:150:10 | b [element 1] :  | hash_flow.rb:150:10:150:13 | ...[...] |
+| hash_flow.rb:151:5:151:5 | c [element 1] :  | hash_flow.rb:152:10:152:10 | c [element 1] :  |
 | hash_flow.rb:151:9:151:12 | hash [element :a] :  | hash_flow.rb:151:9:151:21 | call to assoc [element 1] :  |
-| hash_flow.rb:151:9:151:21 | call to assoc [element 1] :  | hash_flow.rb:152:10:152:10 | c [element 1] :  |
+| hash_flow.rb:151:9:151:21 | call to assoc [element 1] :  | hash_flow.rb:151:5:151:5 | c [element 1] :  |
 | hash_flow.rb:152:10:152:10 | c [element 1] :  | hash_flow.rb:152:10:152:13 | ...[...] |
-| hash_flow.rb:170:15:170:25 | call to taint :  | hash_flow.rb:173:9:173:12 | hash [element :a] :  |
+| hash_flow.rb:169:5:169:8 | hash [element :a] :  | hash_flow.rb:173:9:173:12 | hash [element :a] :  |
+| hash_flow.rb:170:15:170:25 | call to taint :  | hash_flow.rb:169:5:169:8 | hash [element :a] :  |
+| hash_flow.rb:173:5:173:5 | a [element :a] :  | hash_flow.rb:174:10:174:10 | a [element :a] :  |
 | hash_flow.rb:173:9:173:12 | hash [element :a] :  | hash_flow.rb:173:9:173:20 | call to compact [element :a] :  |
-| hash_flow.rb:173:9:173:20 | call to compact [element :a] :  | hash_flow.rb:174:10:174:10 | a [element :a] :  |
+| hash_flow.rb:173:9:173:20 | call to compact [element :a] :  | hash_flow.rb:173:5:173:5 | a [element :a] :  |
 | hash_flow.rb:174:10:174:10 | a [element :a] :  | hash_flow.rb:174:10:174:14 | ...[...] |
-| hash_flow.rb:182:15:182:25 | call to taint :  | hash_flow.rb:185:9:185:12 | hash [element :a] :  |
+| hash_flow.rb:181:5:181:8 | hash [element :a] :  | hash_flow.rb:185:9:185:12 | hash [element :a] :  |
+| hash_flow.rb:182:15:182:25 | call to taint :  | hash_flow.rb:181:5:181:8 | hash [element :a] :  |
+| hash_flow.rb:185:5:185:5 | a :  | hash_flow.rb:186:10:186:10 | a |
 | hash_flow.rb:185:9:185:12 | hash [element :a] :  | hash_flow.rb:185:9:185:23 | call to delete :  |
-| hash_flow.rb:185:9:185:23 | call to delete :  | hash_flow.rb:186:10:186:10 | a |
-| hash_flow.rb:194:15:194:25 | call to taint :  | hash_flow.rb:197:9:197:12 | hash [element :a] :  |
+| hash_flow.rb:185:9:185:23 | call to delete :  | hash_flow.rb:185:5:185:5 | a :  |
+| hash_flow.rb:193:5:193:8 | hash [element :a] :  | hash_flow.rb:197:9:197:12 | hash [element :a] :  |
+| hash_flow.rb:194:15:194:25 | call to taint :  | hash_flow.rb:193:5:193:8 | hash [element :a] :  |
+| hash_flow.rb:197:5:197:5 | a [element :a] :  | hash_flow.rb:201:10:201:10 | a [element :a] :  |
 | hash_flow.rb:197:9:197:12 | [post] hash [element :a] :  | hash_flow.rb:202:10:202:13 | hash [element :a] :  |
 | hash_flow.rb:197:9:197:12 | hash [element :a] :  | hash_flow.rb:197:9:197:12 | [post] hash [element :a] :  |
 | hash_flow.rb:197:9:197:12 | hash [element :a] :  | hash_flow.rb:197:9:200:7 | call to delete_if [element :a] :  |
 | hash_flow.rb:197:9:197:12 | hash [element :a] :  | hash_flow.rb:197:33:197:37 | value :  |
-| hash_flow.rb:197:9:200:7 | call to delete_if [element :a] :  | hash_flow.rb:201:10:201:10 | a [element :a] :  |
+| hash_flow.rb:197:9:200:7 | call to delete_if [element :a] :  | hash_flow.rb:197:5:197:5 | a [element :a] :  |
 | hash_flow.rb:197:33:197:37 | value :  | hash_flow.rb:199:14:199:18 | value |
 | hash_flow.rb:201:10:201:10 | a [element :a] :  | hash_flow.rb:201:10:201:14 | ...[...] |
 | hash_flow.rb:202:10:202:13 | hash [element :a] :  | hash_flow.rb:202:10:202:17 | ...[...] |
-| hash_flow.rb:210:15:210:25 | call to taint :  | hash_flow.rb:217:10:217:13 | hash [element :a] :  |
-| hash_flow.rb:213:19:213:29 | call to taint :  | hash_flow.rb:219:10:219:13 | hash [element :c, element :d] :  |
+| hash_flow.rb:209:5:209:8 | hash [element :a] :  | hash_flow.rb:217:10:217:13 | hash [element :a] :  |
+| hash_flow.rb:209:5:209:8 | hash [element :c, element :d] :  | hash_flow.rb:219:10:219:13 | hash [element :c, element :d] :  |
+| hash_flow.rb:210:15:210:25 | call to taint :  | hash_flow.rb:209:5:209:8 | hash [element :a] :  |
+| hash_flow.rb:213:19:213:29 | call to taint :  | hash_flow.rb:209:5:209:8 | hash [element :c, element :d] :  |
 | hash_flow.rb:217:10:217:13 | hash [element :a] :  | hash_flow.rb:217:10:217:21 | call to dig |
 | hash_flow.rb:219:10:219:13 | hash [element :c, element :d] :  | hash_flow.rb:219:10:219:24 | call to dig |
-| hash_flow.rb:227:15:227:25 | call to taint :  | hash_flow.rb:230:9:230:12 | hash [element :a] :  |
+| hash_flow.rb:226:5:226:8 | hash [element :a] :  | hash_flow.rb:230:9:230:12 | hash [element :a] :  |
+| hash_flow.rb:227:15:227:25 | call to taint :  | hash_flow.rb:226:5:226:8 | hash [element :a] :  |
+| hash_flow.rb:230:5:230:5 | x [element :a] :  | hash_flow.rb:234:10:234:10 | x [element :a] :  |
 | hash_flow.rb:230:9:230:12 | hash [element :a] :  | hash_flow.rb:230:9:233:7 | call to each [element :a] :  |
 | hash_flow.rb:230:9:230:12 | hash [element :a] :  | hash_flow.rb:230:28:230:32 | value :  |
-| hash_flow.rb:230:9:233:7 | call to each [element :a] :  | hash_flow.rb:234:10:234:10 | x [element :a] :  |
+| hash_flow.rb:230:9:233:7 | call to each [element :a] :  | hash_flow.rb:230:5:230:5 | x [element :a] :  |
 | hash_flow.rb:230:28:230:32 | value :  | hash_flow.rb:232:14:232:18 | value |
 | hash_flow.rb:234:10:234:10 | x [element :a] :  | hash_flow.rb:234:10:234:14 | ...[...] |
-| hash_flow.rb:242:15:242:25 | call to taint :  | hash_flow.rb:245:9:245:12 | hash [element :a] :  |
+| hash_flow.rb:241:5:241:8 | hash [element :a] :  | hash_flow.rb:245:9:245:12 | hash [element :a] :  |
+| hash_flow.rb:242:15:242:25 | call to taint :  | hash_flow.rb:241:5:241:8 | hash [element :a] :  |
+| hash_flow.rb:245:5:245:5 | x [element :a] :  | hash_flow.rb:248:10:248:10 | x [element :a] :  |
 | hash_flow.rb:245:9:245:12 | hash [element :a] :  | hash_flow.rb:245:9:247:7 | call to each_key [element :a] :  |
-| hash_flow.rb:245:9:247:7 | call to each_key [element :a] :  | hash_flow.rb:248:10:248:10 | x [element :a] :  |
+| hash_flow.rb:245:9:247:7 | call to each_key [element :a] :  | hash_flow.rb:245:5:245:5 | x [element :a] :  |
 | hash_flow.rb:248:10:248:10 | x [element :a] :  | hash_flow.rb:248:10:248:14 | ...[...] |
-| hash_flow.rb:256:15:256:25 | call to taint :  | hash_flow.rb:259:9:259:12 | hash [element :a] :  |
+| hash_flow.rb:255:5:255:8 | hash [element :a] :  | hash_flow.rb:259:9:259:12 | hash [element :a] :  |
+| hash_flow.rb:256:15:256:25 | call to taint :  | hash_flow.rb:255:5:255:8 | hash [element :a] :  |
+| hash_flow.rb:259:5:259:5 | x [element :a] :  | hash_flow.rb:263:10:263:10 | x [element :a] :  |
 | hash_flow.rb:259:9:259:12 | hash [element :a] :  | hash_flow.rb:259:9:262:7 | call to each_pair [element :a] :  |
 | hash_flow.rb:259:9:259:12 | hash [element :a] :  | hash_flow.rb:259:33:259:37 | value :  |
-| hash_flow.rb:259:9:262:7 | call to each_pair [element :a] :  | hash_flow.rb:263:10:263:10 | x [element :a] :  |
+| hash_flow.rb:259:9:262:7 | call to each_pair [element :a] :  | hash_flow.rb:259:5:259:5 | x [element :a] :  |
 | hash_flow.rb:259:33:259:37 | value :  | hash_flow.rb:261:14:261:18 | value |
 | hash_flow.rb:263:10:263:10 | x [element :a] :  | hash_flow.rb:263:10:263:14 | ...[...] |
-| hash_flow.rb:271:15:271:25 | call to taint :  | hash_flow.rb:274:9:274:12 | hash [element :a] :  |
+| hash_flow.rb:270:5:270:8 | hash [element :a] :  | hash_flow.rb:274:9:274:12 | hash [element :a] :  |
+| hash_flow.rb:271:15:271:25 | call to taint :  | hash_flow.rb:270:5:270:8 | hash [element :a] :  |
+| hash_flow.rb:274:5:274:5 | x [element :a] :  | hash_flow.rb:277:10:277:10 | x [element :a] :  |
 | hash_flow.rb:274:9:274:12 | hash [element :a] :  | hash_flow.rb:274:9:276:7 | call to each_value [element :a] :  |
 | hash_flow.rb:274:9:274:12 | hash [element :a] :  | hash_flow.rb:274:29:274:33 | value :  |
-| hash_flow.rb:274:9:276:7 | call to each_value [element :a] :  | hash_flow.rb:277:10:277:10 | x [element :a] :  |
+| hash_flow.rb:274:9:276:7 | call to each_value [element :a] :  | hash_flow.rb:274:5:274:5 | x [element :a] :  |
 | hash_flow.rb:274:29:274:33 | value :  | hash_flow.rb:275:14:275:18 | value |
 | hash_flow.rb:277:10:277:10 | x [element :a] :  | hash_flow.rb:277:10:277:14 | ...[...] |
-| hash_flow.rb:287:15:287:25 | call to taint :  | hash_flow.rb:290:9:290:12 | hash [element :c] :  |
+| hash_flow.rb:284:5:284:8 | hash [element :c] :  | hash_flow.rb:290:9:290:12 | hash [element :c] :  |
+| hash_flow.rb:287:15:287:25 | call to taint :  | hash_flow.rb:284:5:284:8 | hash [element :c] :  |
+| hash_flow.rb:290:5:290:5 | x [element :c] :  | hash_flow.rb:293:10:293:10 | x [element :c] :  |
 | hash_flow.rb:290:9:290:12 | hash [element :c] :  | hash_flow.rb:290:9:290:28 | call to except [element :c] :  |
-| hash_flow.rb:290:9:290:28 | call to except [element :c] :  | hash_flow.rb:293:10:293:10 | x [element :c] :  |
+| hash_flow.rb:290:9:290:28 | call to except [element :c] :  | hash_flow.rb:290:5:290:5 | x [element :c] :  |
 | hash_flow.rb:293:10:293:10 | x [element :c] :  | hash_flow.rb:293:10:293:14 | ...[...] |
-| hash_flow.rb:301:15:301:25 | call to taint :  | hash_flow.rb:305:9:305:12 | hash [element :a] :  |
-| hash_flow.rb:301:15:301:25 | call to taint :  | hash_flow.rb:309:9:309:12 | hash [element :a] :  |
-| hash_flow.rb:301:15:301:25 | call to taint :  | hash_flow.rb:311:9:311:12 | hash [element :a] :  |
-| hash_flow.rb:301:15:301:25 | call to taint :  | hash_flow.rb:315:9:315:12 | hash [element :a] :  |
-| hash_flow.rb:303:15:303:25 | call to taint :  | hash_flow.rb:305:9:305:12 | hash [element :c] :  |
-| hash_flow.rb:303:15:303:25 | call to taint :  | hash_flow.rb:315:9:315:12 | hash [element :c] :  |
+| hash_flow.rb:300:5:300:8 | hash [element :a] :  | hash_flow.rb:305:9:305:12 | hash [element :a] :  |
+| hash_flow.rb:300:5:300:8 | hash [element :a] :  | hash_flow.rb:309:9:309:12 | hash [element :a] :  |
+| hash_flow.rb:300:5:300:8 | hash [element :a] :  | hash_flow.rb:311:9:311:12 | hash [element :a] :  |
+| hash_flow.rb:300:5:300:8 | hash [element :a] :  | hash_flow.rb:315:9:315:12 | hash [element :a] :  |
+| hash_flow.rb:300:5:300:8 | hash [element :c] :  | hash_flow.rb:305:9:305:12 | hash [element :c] :  |
+| hash_flow.rb:300:5:300:8 | hash [element :c] :  | hash_flow.rb:315:9:315:12 | hash [element :c] :  |
+| hash_flow.rb:301:15:301:25 | call to taint :  | hash_flow.rb:300:5:300:8 | hash [element :a] :  |
+| hash_flow.rb:303:15:303:25 | call to taint :  | hash_flow.rb:300:5:300:8 | hash [element :c] :  |
+| hash_flow.rb:305:5:305:5 | b :  | hash_flow.rb:308:10:308:10 | b |
 | hash_flow.rb:305:9:305:12 | hash [element :a] :  | hash_flow.rb:305:9:307:7 | call to fetch :  |
 | hash_flow.rb:305:9:305:12 | hash [element :c] :  | hash_flow.rb:305:9:307:7 | call to fetch :  |
-| hash_flow.rb:305:9:307:7 | call to fetch :  | hash_flow.rb:308:10:308:10 | b |
+| hash_flow.rb:305:9:307:7 | call to fetch :  | hash_flow.rb:305:5:305:5 | b :  |
 | hash_flow.rb:305:20:305:30 | call to taint :  | hash_flow.rb:305:37:305:37 | x :  |
 | hash_flow.rb:305:37:305:37 | x :  | hash_flow.rb:306:14:306:14 | x |
+| hash_flow.rb:309:5:309:5 | b :  | hash_flow.rb:310:10:310:10 | b |
 | hash_flow.rb:309:9:309:12 | hash [element :a] :  | hash_flow.rb:309:9:309:22 | call to fetch :  |
-| hash_flow.rb:309:9:309:22 | call to fetch :  | hash_flow.rb:310:10:310:10 | b |
+| hash_flow.rb:309:9:309:22 | call to fetch :  | hash_flow.rb:309:5:309:5 | b :  |
+| hash_flow.rb:311:5:311:5 | b :  | hash_flow.rb:312:10:312:10 | b |
 | hash_flow.rb:311:9:311:12 | hash [element :a] :  | hash_flow.rb:311:9:311:35 | call to fetch :  |
-| hash_flow.rb:311:9:311:35 | call to fetch :  | hash_flow.rb:312:10:312:10 | b |
+| hash_flow.rb:311:9:311:35 | call to fetch :  | hash_flow.rb:311:5:311:5 | b :  |
 | hash_flow.rb:311:24:311:34 | call to taint :  | hash_flow.rb:311:9:311:35 | call to fetch :  |
-| hash_flow.rb:313:9:313:35 | call to fetch :  | hash_flow.rb:314:10:314:10 | b |
+| hash_flow.rb:313:5:313:5 | b :  | hash_flow.rb:314:10:314:10 | b |
+| hash_flow.rb:313:9:313:35 | call to fetch :  | hash_flow.rb:313:5:313:5 | b :  |
 | hash_flow.rb:313:24:313:34 | call to taint :  | hash_flow.rb:313:9:313:35 | call to fetch :  |
+| hash_flow.rb:315:5:315:5 | b :  | hash_flow.rb:316:10:316:10 | b |
 | hash_flow.rb:315:9:315:12 | hash [element :a] :  | hash_flow.rb:315:9:315:34 | call to fetch :  |
 | hash_flow.rb:315:9:315:12 | hash [element :c] :  | hash_flow.rb:315:9:315:34 | call to fetch :  |
-| hash_flow.rb:315:9:315:34 | call to fetch :  | hash_flow.rb:316:10:316:10 | b |
+| hash_flow.rb:315:9:315:34 | call to fetch :  | hash_flow.rb:315:5:315:5 | b :  |
 | hash_flow.rb:315:23:315:33 | call to taint :  | hash_flow.rb:315:9:315:34 | call to fetch :  |
-| hash_flow.rb:323:15:323:25 | call to taint :  | hash_flow.rb:327:9:327:12 | hash [element :a] :  |
-| hash_flow.rb:323:15:323:25 | call to taint :  | hash_flow.rb:332:9:332:12 | hash [element :a] :  |
-| hash_flow.rb:323:15:323:25 | call to taint :  | hash_flow.rb:334:9:334:12 | hash [element :a] :  |
-| hash_flow.rb:325:15:325:25 | call to taint :  | hash_flow.rb:327:9:327:12 | hash [element :c] :  |
-| hash_flow.rb:325:15:325:25 | call to taint :  | hash_flow.rb:334:9:334:12 | hash [element :c] :  |
+| hash_flow.rb:322:5:322:8 | hash [element :a] :  | hash_flow.rb:327:9:327:12 | hash [element :a] :  |
+| hash_flow.rb:322:5:322:8 | hash [element :a] :  | hash_flow.rb:332:9:332:12 | hash [element :a] :  |
+| hash_flow.rb:322:5:322:8 | hash [element :a] :  | hash_flow.rb:334:9:334:12 | hash [element :a] :  |
+| hash_flow.rb:322:5:322:8 | hash [element :c] :  | hash_flow.rb:327:9:327:12 | hash [element :c] :  |
+| hash_flow.rb:322:5:322:8 | hash [element :c] :  | hash_flow.rb:334:9:334:12 | hash [element :c] :  |
+| hash_flow.rb:323:15:323:25 | call to taint :  | hash_flow.rb:322:5:322:8 | hash [element :a] :  |
+| hash_flow.rb:325:15:325:25 | call to taint :  | hash_flow.rb:322:5:322:8 | hash [element :c] :  |
+| hash_flow.rb:327:5:327:5 | b [element] :  | hash_flow.rb:331:10:331:10 | b [element] :  |
 | hash_flow.rb:327:9:327:12 | hash [element :a] :  | hash_flow.rb:327:9:330:7 | call to fetch_values [element] :  |
 | hash_flow.rb:327:9:327:12 | hash [element :c] :  | hash_flow.rb:327:9:330:7 | call to fetch_values [element] :  |
-| hash_flow.rb:327:9:330:7 | call to fetch_values [element] :  | hash_flow.rb:331:10:331:10 | b [element] :  |
+| hash_flow.rb:327:9:330:7 | call to fetch_values [element] :  | hash_flow.rb:327:5:327:5 | b [element] :  |
 | hash_flow.rb:327:27:327:37 | call to taint :  | hash_flow.rb:327:44:327:44 | x :  |
 | hash_flow.rb:327:44:327:44 | x :  | hash_flow.rb:328:14:328:14 | x |
 | hash_flow.rb:329:9:329:19 | call to taint :  | hash_flow.rb:327:9:330:7 | call to fetch_values [element] :  |
 | hash_flow.rb:331:10:331:10 | b [element] :  | hash_flow.rb:331:10:331:13 | ...[...] |
+| hash_flow.rb:332:5:332:5 | b [element] :  | hash_flow.rb:333:10:333:10 | b [element] :  |
 | hash_flow.rb:332:9:332:12 | hash [element :a] :  | hash_flow.rb:332:9:332:29 | call to fetch_values [element] :  |
-| hash_flow.rb:332:9:332:29 | call to fetch_values [element] :  | hash_flow.rb:333:10:333:10 | b [element] :  |
+| hash_flow.rb:332:9:332:29 | call to fetch_values [element] :  | hash_flow.rb:332:5:332:5 | b [element] :  |
 | hash_flow.rb:333:10:333:10 | b [element] :  | hash_flow.rb:333:10:333:13 | ...[...] |
+| hash_flow.rb:334:5:334:5 | b [element] :  | hash_flow.rb:335:10:335:10 | b [element] :  |
 | hash_flow.rb:334:9:334:12 | hash [element :a] :  | hash_flow.rb:334:9:334:31 | call to fetch_values [element] :  |
 | hash_flow.rb:334:9:334:12 | hash [element :c] :  | hash_flow.rb:334:9:334:31 | call to fetch_values [element] :  |
-| hash_flow.rb:334:9:334:31 | call to fetch_values [element] :  | hash_flow.rb:335:10:335:10 | b [element] :  |
+| hash_flow.rb:334:9:334:31 | call to fetch_values [element] :  | hash_flow.rb:334:5:334:5 | b [element] :  |
 | hash_flow.rb:335:10:335:10 | b [element] :  | hash_flow.rb:335:10:335:13 | ...[...] |
-| hash_flow.rb:342:15:342:25 | call to taint :  | hash_flow.rb:346:9:346:12 | hash [element :a] :  |
-| hash_flow.rb:344:15:344:25 | call to taint :  | hash_flow.rb:346:9:346:12 | hash [element :c] :  |
+| hash_flow.rb:341:5:341:8 | hash [element :a] :  | hash_flow.rb:346:9:346:12 | hash [element :a] :  |
+| hash_flow.rb:341:5:341:8 | hash [element :c] :  | hash_flow.rb:346:9:346:12 | hash [element :c] :  |
+| hash_flow.rb:342:15:342:25 | call to taint :  | hash_flow.rb:341:5:341:8 | hash [element :a] :  |
+| hash_flow.rb:344:15:344:25 | call to taint :  | hash_flow.rb:341:5:341:8 | hash [element :c] :  |
+| hash_flow.rb:346:5:346:5 | b [element :a] :  | hash_flow.rb:351:11:351:11 | b [element :a] :  |
 | hash_flow.rb:346:9:346:12 | hash [element :a] :  | hash_flow.rb:346:9:350:7 | call to filter [element :a] :  |
 | hash_flow.rb:346:9:346:12 | hash [element :a] :  | hash_flow.rb:346:30:346:34 | value :  |
 | hash_flow.rb:346:9:346:12 | hash [element :c] :  | hash_flow.rb:346:30:346:34 | value :  |
-| hash_flow.rb:346:9:350:7 | call to filter [element :a] :  | hash_flow.rb:351:11:351:11 | b [element :a] :  |
+| hash_flow.rb:346:9:350:7 | call to filter [element :a] :  | hash_flow.rb:346:5:346:5 | b [element :a] :  |
 | hash_flow.rb:346:30:346:34 | value :  | hash_flow.rb:348:14:348:18 | value |
 | hash_flow.rb:351:11:351:11 | b [element :a] :  | hash_flow.rb:351:11:351:15 | ...[...] :  |
 | hash_flow.rb:351:11:351:15 | ...[...] :  | hash_flow.rb:351:10:351:16 | ( ... ) |
-| hash_flow.rb:358:15:358:25 | call to taint :  | hash_flow.rb:362:5:362:8 | hash [element :a] :  |
-| hash_flow.rb:360:15:360:25 | call to taint :  | hash_flow.rb:362:5:362:8 | hash [element :c] :  |
+| hash_flow.rb:357:5:357:8 | hash [element :a] :  | hash_flow.rb:362:5:362:8 | hash [element :a] :  |
+| hash_flow.rb:357:5:357:8 | hash [element :c] :  | hash_flow.rb:362:5:362:8 | hash [element :c] :  |
+| hash_flow.rb:358:15:358:25 | call to taint :  | hash_flow.rb:357:5:357:8 | hash [element :a] :  |
+| hash_flow.rb:360:15:360:25 | call to taint :  | hash_flow.rb:357:5:357:8 | hash [element :c] :  |
 | hash_flow.rb:362:5:362:8 | [post] hash [element :a] :  | hash_flow.rb:367:11:367:14 | hash [element :a] :  |
 | hash_flow.rb:362:5:362:8 | hash [element :a] :  | hash_flow.rb:362:5:362:8 | [post] hash [element :a] :  |
 | hash_flow.rb:362:5:362:8 | hash [element :a] :  | hash_flow.rb:362:27:362:31 | value :  |
@@ -199,40 +257,54 @@ edges
 | hash_flow.rb:362:27:362:31 | value :  | hash_flow.rb:364:14:364:18 | value |
 | hash_flow.rb:367:11:367:14 | hash [element :a] :  | hash_flow.rb:367:11:367:18 | ...[...] :  |
 | hash_flow.rb:367:11:367:18 | ...[...] :  | hash_flow.rb:367:10:367:19 | ( ... ) |
-| hash_flow.rb:374:15:374:25 | call to taint :  | hash_flow.rb:378:9:378:12 | hash [element :a] :  |
-| hash_flow.rb:376:15:376:25 | call to taint :  | hash_flow.rb:378:9:378:12 | hash [element :c] :  |
+| hash_flow.rb:373:5:373:8 | hash [element :a] :  | hash_flow.rb:378:9:378:12 | hash [element :a] :  |
+| hash_flow.rb:373:5:373:8 | hash [element :c] :  | hash_flow.rb:378:9:378:12 | hash [element :c] :  |
+| hash_flow.rb:374:15:374:25 | call to taint :  | hash_flow.rb:373:5:373:8 | hash [element :a] :  |
+| hash_flow.rb:376:15:376:25 | call to taint :  | hash_flow.rb:373:5:373:8 | hash [element :c] :  |
+| hash_flow.rb:378:5:378:5 | b [element] :  | hash_flow.rb:379:11:379:11 | b [element] :  |
 | hash_flow.rb:378:9:378:12 | hash [element :a] :  | hash_flow.rb:378:9:378:20 | call to flatten [element] :  |
 | hash_flow.rb:378:9:378:12 | hash [element :c] :  | hash_flow.rb:378:9:378:20 | call to flatten [element] :  |
-| hash_flow.rb:378:9:378:20 | call to flatten [element] :  | hash_flow.rb:379:11:379:11 | b [element] :  |
+| hash_flow.rb:378:9:378:20 | call to flatten [element] :  | hash_flow.rb:378:5:378:5 | b [element] :  |
 | hash_flow.rb:379:11:379:11 | b [element] :  | hash_flow.rb:379:11:379:14 | ...[...] :  |
 | hash_flow.rb:379:11:379:14 | ...[...] :  | hash_flow.rb:379:10:379:15 | ( ... ) |
-| hash_flow.rb:386:15:386:25 | call to taint :  | hash_flow.rb:390:9:390:12 | hash [element :a] :  |
-| hash_flow.rb:388:15:388:25 | call to taint :  | hash_flow.rb:390:9:390:12 | hash [element :c] :  |
+| hash_flow.rb:385:5:385:8 | hash [element :a] :  | hash_flow.rb:390:9:390:12 | hash [element :a] :  |
+| hash_flow.rb:385:5:385:8 | hash [element :c] :  | hash_flow.rb:390:9:390:12 | hash [element :c] :  |
+| hash_flow.rb:386:15:386:25 | call to taint :  | hash_flow.rb:385:5:385:8 | hash [element :a] :  |
+| hash_flow.rb:388:15:388:25 | call to taint :  | hash_flow.rb:385:5:385:8 | hash [element :c] :  |
+| hash_flow.rb:390:5:390:5 | b [element :a] :  | hash_flow.rb:396:11:396:11 | b [element :a] :  |
 | hash_flow.rb:390:9:390:12 | [post] hash [element :a] :  | hash_flow.rb:395:11:395:14 | hash [element :a] :  |
 | hash_flow.rb:390:9:390:12 | hash [element :a] :  | hash_flow.rb:390:9:390:12 | [post] hash [element :a] :  |
 | hash_flow.rb:390:9:390:12 | hash [element :a] :  | hash_flow.rb:390:9:394:7 | call to keep_if [element :a] :  |
 | hash_flow.rb:390:9:390:12 | hash [element :a] :  | hash_flow.rb:390:31:390:35 | value :  |
 | hash_flow.rb:390:9:390:12 | hash [element :c] :  | hash_flow.rb:390:31:390:35 | value :  |
-| hash_flow.rb:390:9:394:7 | call to keep_if [element :a] :  | hash_flow.rb:396:11:396:11 | b [element :a] :  |
+| hash_flow.rb:390:9:394:7 | call to keep_if [element :a] :  | hash_flow.rb:390:5:390:5 | b [element :a] :  |
 | hash_flow.rb:390:31:390:35 | value :  | hash_flow.rb:392:14:392:18 | value |
 | hash_flow.rb:395:11:395:14 | hash [element :a] :  | hash_flow.rb:395:11:395:18 | ...[...] :  |
 | hash_flow.rb:395:11:395:18 | ...[...] :  | hash_flow.rb:395:10:395:19 | ( ... ) |
 | hash_flow.rb:396:11:396:11 | b [element :a] :  | hash_flow.rb:396:11:396:15 | ...[...] :  |
 | hash_flow.rb:396:11:396:15 | ...[...] :  | hash_flow.rb:396:10:396:16 | ( ... ) |
-| hash_flow.rb:403:15:403:25 | call to taint :  | hash_flow.rb:412:12:412:16 | hash1 [element :a] :  |
-| hash_flow.rb:405:15:405:25 | call to taint :  | hash_flow.rb:412:12:412:16 | hash1 [element :c] :  |
-| hash_flow.rb:408:15:408:25 | call to taint :  | hash_flow.rb:412:24:412:28 | hash2 [element :d] :  |
-| hash_flow.rb:410:15:410:25 | call to taint :  | hash_flow.rb:412:24:412:28 | hash2 [element :f] :  |
+| hash_flow.rb:402:5:402:9 | hash1 [element :a] :  | hash_flow.rb:412:12:412:16 | hash1 [element :a] :  |
+| hash_flow.rb:402:5:402:9 | hash1 [element :c] :  | hash_flow.rb:412:12:412:16 | hash1 [element :c] :  |
+| hash_flow.rb:403:15:403:25 | call to taint :  | hash_flow.rb:402:5:402:9 | hash1 [element :a] :  |
+| hash_flow.rb:405:15:405:25 | call to taint :  | hash_flow.rb:402:5:402:9 | hash1 [element :c] :  |
+| hash_flow.rb:407:5:407:9 | hash2 [element :d] :  | hash_flow.rb:412:24:412:28 | hash2 [element :d] :  |
+| hash_flow.rb:407:5:407:9 | hash2 [element :f] :  | hash_flow.rb:412:24:412:28 | hash2 [element :f] :  |
+| hash_flow.rb:408:15:408:25 | call to taint :  | hash_flow.rb:407:5:407:9 | hash2 [element :d] :  |
+| hash_flow.rb:410:15:410:25 | call to taint :  | hash_flow.rb:407:5:407:9 | hash2 [element :f] :  |
+| hash_flow.rb:412:5:412:8 | hash [element :a] :  | hash_flow.rb:417:11:417:14 | hash [element :a] :  |
+| hash_flow.rb:412:5:412:8 | hash [element :c] :  | hash_flow.rb:419:11:419:14 | hash [element :c] :  |
+| hash_flow.rb:412:5:412:8 | hash [element :d] :  | hash_flow.rb:420:11:420:14 | hash [element :d] :  |
+| hash_flow.rb:412:5:412:8 | hash [element :f] :  | hash_flow.rb:422:11:422:14 | hash [element :f] :  |
 | hash_flow.rb:412:12:412:16 | hash1 [element :a] :  | hash_flow.rb:412:12:416:7 | call to merge [element :a] :  |
 | hash_flow.rb:412:12:412:16 | hash1 [element :a] :  | hash_flow.rb:412:40:412:48 | old_value :  |
 | hash_flow.rb:412:12:412:16 | hash1 [element :a] :  | hash_flow.rb:412:51:412:59 | new_value :  |
 | hash_flow.rb:412:12:412:16 | hash1 [element :c] :  | hash_flow.rb:412:12:416:7 | call to merge [element :c] :  |
 | hash_flow.rb:412:12:412:16 | hash1 [element :c] :  | hash_flow.rb:412:40:412:48 | old_value :  |
 | hash_flow.rb:412:12:412:16 | hash1 [element :c] :  | hash_flow.rb:412:51:412:59 | new_value :  |
-| hash_flow.rb:412:12:416:7 | call to merge [element :a] :  | hash_flow.rb:417:11:417:14 | hash [element :a] :  |
-| hash_flow.rb:412:12:416:7 | call to merge [element :c] :  | hash_flow.rb:419:11:419:14 | hash [element :c] :  |
-| hash_flow.rb:412:12:416:7 | call to merge [element :d] :  | hash_flow.rb:420:11:420:14 | hash [element :d] :  |
-| hash_flow.rb:412:12:416:7 | call to merge [element :f] :  | hash_flow.rb:422:11:422:14 | hash [element :f] :  |
+| hash_flow.rb:412:12:416:7 | call to merge [element :a] :  | hash_flow.rb:412:5:412:8 | hash [element :a] :  |
+| hash_flow.rb:412:12:416:7 | call to merge [element :c] :  | hash_flow.rb:412:5:412:8 | hash [element :c] :  |
+| hash_flow.rb:412:12:416:7 | call to merge [element :d] :  | hash_flow.rb:412:5:412:8 | hash [element :d] :  |
+| hash_flow.rb:412:12:416:7 | call to merge [element :f] :  | hash_flow.rb:412:5:412:8 | hash [element :f] :  |
 | hash_flow.rb:412:24:412:28 | hash2 [element :d] :  | hash_flow.rb:412:12:416:7 | call to merge [element :d] :  |
 | hash_flow.rb:412:24:412:28 | hash2 [element :d] :  | hash_flow.rb:412:40:412:48 | old_value :  |
 | hash_flow.rb:412:24:412:28 | hash2 [element :d] :  | hash_flow.rb:412:51:412:59 | new_value :  |
@@ -249,10 +321,18 @@ edges
 | hash_flow.rb:420:11:420:18 | ...[...] :  | hash_flow.rb:420:10:420:19 | ( ... ) |
 | hash_flow.rb:422:11:422:14 | hash [element :f] :  | hash_flow.rb:422:11:422:18 | ...[...] :  |
 | hash_flow.rb:422:11:422:18 | ...[...] :  | hash_flow.rb:422:10:422:19 | ( ... ) |
-| hash_flow.rb:429:15:429:25 | call to taint :  | hash_flow.rb:438:12:438:16 | hash1 [element :a] :  |
-| hash_flow.rb:431:15:431:25 | call to taint :  | hash_flow.rb:438:12:438:16 | hash1 [element :c] :  |
-| hash_flow.rb:434:15:434:25 | call to taint :  | hash_flow.rb:438:25:438:29 | hash2 [element :d] :  |
-| hash_flow.rb:436:15:436:25 | call to taint :  | hash_flow.rb:438:25:438:29 | hash2 [element :f] :  |
+| hash_flow.rb:428:5:428:9 | hash1 [element :a] :  | hash_flow.rb:438:12:438:16 | hash1 [element :a] :  |
+| hash_flow.rb:428:5:428:9 | hash1 [element :c] :  | hash_flow.rb:438:12:438:16 | hash1 [element :c] :  |
+| hash_flow.rb:429:15:429:25 | call to taint :  | hash_flow.rb:428:5:428:9 | hash1 [element :a] :  |
+| hash_flow.rb:431:15:431:25 | call to taint :  | hash_flow.rb:428:5:428:9 | hash1 [element :c] :  |
+| hash_flow.rb:433:5:433:9 | hash2 [element :d] :  | hash_flow.rb:438:25:438:29 | hash2 [element :d] :  |
+| hash_flow.rb:433:5:433:9 | hash2 [element :f] :  | hash_flow.rb:438:25:438:29 | hash2 [element :f] :  |
+| hash_flow.rb:434:15:434:25 | call to taint :  | hash_flow.rb:433:5:433:9 | hash2 [element :d] :  |
+| hash_flow.rb:436:15:436:25 | call to taint :  | hash_flow.rb:433:5:433:9 | hash2 [element :f] :  |
+| hash_flow.rb:438:5:438:8 | hash [element :a] :  | hash_flow.rb:443:11:443:14 | hash [element :a] :  |
+| hash_flow.rb:438:5:438:8 | hash [element :c] :  | hash_flow.rb:445:11:445:14 | hash [element :c] :  |
+| hash_flow.rb:438:5:438:8 | hash [element :d] :  | hash_flow.rb:446:11:446:14 | hash [element :d] :  |
+| hash_flow.rb:438:5:438:8 | hash [element :f] :  | hash_flow.rb:448:11:448:14 | hash [element :f] :  |
 | hash_flow.rb:438:12:438:16 | [post] hash1 [element :a] :  | hash_flow.rb:450:11:450:15 | hash1 [element :a] :  |
 | hash_flow.rb:438:12:438:16 | [post] hash1 [element :c] :  | hash_flow.rb:452:11:452:15 | hash1 [element :c] :  |
 | hash_flow.rb:438:12:438:16 | [post] hash1 [element :d] :  | hash_flow.rb:453:11:453:15 | hash1 [element :d] :  |
@@ -265,10 +345,10 @@ edges
 | hash_flow.rb:438:12:438:16 | hash1 [element :c] :  | hash_flow.rb:438:12:442:7 | call to merge! [element :c] :  |
 | hash_flow.rb:438:12:438:16 | hash1 [element :c] :  | hash_flow.rb:438:41:438:49 | old_value :  |
 | hash_flow.rb:438:12:438:16 | hash1 [element :c] :  | hash_flow.rb:438:52:438:60 | new_value :  |
-| hash_flow.rb:438:12:442:7 | call to merge! [element :a] :  | hash_flow.rb:443:11:443:14 | hash [element :a] :  |
-| hash_flow.rb:438:12:442:7 | call to merge! [element :c] :  | hash_flow.rb:445:11:445:14 | hash [element :c] :  |
-| hash_flow.rb:438:12:442:7 | call to merge! [element :d] :  | hash_flow.rb:446:11:446:14 | hash [element :d] :  |
-| hash_flow.rb:438:12:442:7 | call to merge! [element :f] :  | hash_flow.rb:448:11:448:14 | hash [element :f] :  |
+| hash_flow.rb:438:12:442:7 | call to merge! [element :a] :  | hash_flow.rb:438:5:438:8 | hash [element :a] :  |
+| hash_flow.rb:438:12:442:7 | call to merge! [element :c] :  | hash_flow.rb:438:5:438:8 | hash [element :c] :  |
+| hash_flow.rb:438:12:442:7 | call to merge! [element :d] :  | hash_flow.rb:438:5:438:8 | hash [element :d] :  |
+| hash_flow.rb:438:12:442:7 | call to merge! [element :f] :  | hash_flow.rb:438:5:438:8 | hash [element :f] :  |
 | hash_flow.rb:438:25:438:29 | hash2 [element :d] :  | hash_flow.rb:438:12:438:16 | [post] hash1 [element :d] :  |
 | hash_flow.rb:438:25:438:29 | hash2 [element :d] :  | hash_flow.rb:438:12:442:7 | call to merge! [element :d] :  |
 | hash_flow.rb:438:25:438:29 | hash2 [element :d] :  | hash_flow.rb:438:41:438:49 | old_value :  |
@@ -295,27 +375,35 @@ edges
 | hash_flow.rb:453:11:453:19 | ...[...] :  | hash_flow.rb:453:10:453:20 | ( ... ) |
 | hash_flow.rb:455:11:455:15 | hash1 [element :f] :  | hash_flow.rb:455:11:455:19 | ...[...] :  |
 | hash_flow.rb:455:11:455:19 | ...[...] :  | hash_flow.rb:455:10:455:20 | ( ... ) |
-| hash_flow.rb:462:15:462:25 | call to taint :  | hash_flow.rb:465:9:465:12 | hash [element :a] :  |
+| hash_flow.rb:461:5:461:8 | hash [element :a] :  | hash_flow.rb:465:9:465:12 | hash [element :a] :  |
+| hash_flow.rb:462:15:462:25 | call to taint :  | hash_flow.rb:461:5:461:8 | hash [element :a] :  |
+| hash_flow.rb:465:5:465:5 | b [element 1] :  | hash_flow.rb:467:10:467:10 | b [element 1] :  |
 | hash_flow.rb:465:9:465:12 | hash [element :a] :  | hash_flow.rb:465:9:465:22 | call to rassoc [element 1] :  |
-| hash_flow.rb:465:9:465:22 | call to rassoc [element 1] :  | hash_flow.rb:467:10:467:10 | b [element 1] :  |
+| hash_flow.rb:465:9:465:22 | call to rassoc [element 1] :  | hash_flow.rb:465:5:465:5 | b [element 1] :  |
 | hash_flow.rb:467:10:467:10 | b [element 1] :  | hash_flow.rb:467:10:467:13 | ...[...] |
-| hash_flow.rb:474:15:474:25 | call to taint :  | hash_flow.rb:477:9:477:12 | hash [element :a] :  |
+| hash_flow.rb:473:5:473:8 | hash [element :a] :  | hash_flow.rb:477:9:477:12 | hash [element :a] :  |
+| hash_flow.rb:474:15:474:25 | call to taint :  | hash_flow.rb:473:5:473:8 | hash [element :a] :  |
+| hash_flow.rb:477:5:477:5 | b [element :a] :  | hash_flow.rb:482:10:482:10 | b [element :a] :  |
 | hash_flow.rb:477:9:477:12 | hash [element :a] :  | hash_flow.rb:477:9:481:7 | call to reject [element :a] :  |
 | hash_flow.rb:477:9:477:12 | hash [element :a] :  | hash_flow.rb:477:29:477:33 | value :  |
-| hash_flow.rb:477:9:481:7 | call to reject [element :a] :  | hash_flow.rb:482:10:482:10 | b [element :a] :  |
+| hash_flow.rb:477:9:481:7 | call to reject [element :a] :  | hash_flow.rb:477:5:477:5 | b [element :a] :  |
 | hash_flow.rb:477:29:477:33 | value :  | hash_flow.rb:479:14:479:18 | value |
 | hash_flow.rb:482:10:482:10 | b [element :a] :  | hash_flow.rb:482:10:482:14 | ...[...] |
-| hash_flow.rb:489:15:489:25 | call to taint :  | hash_flow.rb:492:9:492:12 | hash [element :a] :  |
+| hash_flow.rb:488:5:488:8 | hash [element :a] :  | hash_flow.rb:492:9:492:12 | hash [element :a] :  |
+| hash_flow.rb:489:15:489:25 | call to taint :  | hash_flow.rb:488:5:488:8 | hash [element :a] :  |
+| hash_flow.rb:492:5:492:5 | b [element :a] :  | hash_flow.rb:497:10:497:10 | b [element :a] :  |
 | hash_flow.rb:492:9:492:12 | [post] hash [element :a] :  | hash_flow.rb:498:10:498:13 | hash [element :a] :  |
 | hash_flow.rb:492:9:492:12 | hash [element :a] :  | hash_flow.rb:492:9:492:12 | [post] hash [element :a] :  |
 | hash_flow.rb:492:9:492:12 | hash [element :a] :  | hash_flow.rb:492:9:496:7 | call to reject! [element :a] :  |
 | hash_flow.rb:492:9:492:12 | hash [element :a] :  | hash_flow.rb:492:30:492:34 | value :  |
-| hash_flow.rb:492:9:496:7 | call to reject! [element :a] :  | hash_flow.rb:497:10:497:10 | b [element :a] :  |
+| hash_flow.rb:492:9:496:7 | call to reject! [element :a] :  | hash_flow.rb:492:5:492:5 | b [element :a] :  |
 | hash_flow.rb:492:30:492:34 | value :  | hash_flow.rb:494:14:494:18 | value |
 | hash_flow.rb:497:10:497:10 | b [element :a] :  | hash_flow.rb:497:10:497:14 | ...[...] |
 | hash_flow.rb:498:10:498:13 | hash [element :a] :  | hash_flow.rb:498:10:498:17 | ...[...] |
-| hash_flow.rb:505:15:505:25 | call to taint :  | hash_flow.rb:512:19:512:22 | hash [element :a] :  |
-| hash_flow.rb:507:15:507:25 | call to taint :  | hash_flow.rb:512:19:512:22 | hash [element :c] :  |
+| hash_flow.rb:504:5:504:8 | hash [element :a] :  | hash_flow.rb:512:19:512:22 | hash [element :a] :  |
+| hash_flow.rb:504:5:504:8 | hash [element :c] :  | hash_flow.rb:512:19:512:22 | hash [element :c] :  |
+| hash_flow.rb:505:15:505:25 | call to taint :  | hash_flow.rb:504:5:504:8 | hash [element :a] :  |
+| hash_flow.rb:507:15:507:25 | call to taint :  | hash_flow.rb:504:5:504:8 | hash [element :c] :  |
 | hash_flow.rb:512:5:512:9 | [post] hash2 [element :a] :  | hash_flow.rb:513:11:513:15 | hash2 [element :a] :  |
 | hash_flow.rb:512:5:512:9 | [post] hash2 [element :c] :  | hash_flow.rb:515:11:515:15 | hash2 [element :c] :  |
 | hash_flow.rb:512:19:512:22 | hash [element :a] :  | hash_flow.rb:512:5:512:9 | [post] hash2 [element :a] :  |
@@ -324,17 +412,22 @@ edges
 | hash_flow.rb:513:11:513:19 | ...[...] :  | hash_flow.rb:513:10:513:20 | ( ... ) |
 | hash_flow.rb:515:11:515:15 | hash2 [element :c] :  | hash_flow.rb:515:11:515:19 | ...[...] :  |
 | hash_flow.rb:515:11:515:19 | ...[...] :  | hash_flow.rb:515:10:515:20 | ( ... ) |
-| hash_flow.rb:520:15:520:25 | call to taint :  | hash_flow.rb:524:9:524:12 | hash [element :a] :  |
-| hash_flow.rb:522:15:522:25 | call to taint :  | hash_flow.rb:524:9:524:12 | hash [element :c] :  |
+| hash_flow.rb:519:5:519:8 | hash [element :a] :  | hash_flow.rb:524:9:524:12 | hash [element :a] :  |
+| hash_flow.rb:519:5:519:8 | hash [element :c] :  | hash_flow.rb:524:9:524:12 | hash [element :c] :  |
+| hash_flow.rb:520:15:520:25 | call to taint :  | hash_flow.rb:519:5:519:8 | hash [element :a] :  |
+| hash_flow.rb:522:15:522:25 | call to taint :  | hash_flow.rb:519:5:519:8 | hash [element :c] :  |
+| hash_flow.rb:524:5:524:5 | b [element :a] :  | hash_flow.rb:529:11:529:11 | b [element :a] :  |
 | hash_flow.rb:524:9:524:12 | hash [element :a] :  | hash_flow.rb:524:9:528:7 | call to select [element :a] :  |
 | hash_flow.rb:524:9:524:12 | hash [element :a] :  | hash_flow.rb:524:30:524:34 | value :  |
 | hash_flow.rb:524:9:524:12 | hash [element :c] :  | hash_flow.rb:524:30:524:34 | value :  |
-| hash_flow.rb:524:9:528:7 | call to select [element :a] :  | hash_flow.rb:529:11:529:11 | b [element :a] :  |
+| hash_flow.rb:524:9:528:7 | call to select [element :a] :  | hash_flow.rb:524:5:524:5 | b [element :a] :  |
 | hash_flow.rb:524:30:524:34 | value :  | hash_flow.rb:526:14:526:18 | value |
 | hash_flow.rb:529:11:529:11 | b [element :a] :  | hash_flow.rb:529:11:529:15 | ...[...] :  |
 | hash_flow.rb:529:11:529:15 | ...[...] :  | hash_flow.rb:529:10:529:16 | ( ... ) |
-| hash_flow.rb:536:15:536:25 | call to taint :  | hash_flow.rb:540:5:540:8 | hash [element :a] :  |
-| hash_flow.rb:538:15:538:25 | call to taint :  | hash_flow.rb:540:5:540:8 | hash [element :c] :  |
+| hash_flow.rb:535:5:535:8 | hash [element :a] :  | hash_flow.rb:540:5:540:8 | hash [element :a] :  |
+| hash_flow.rb:535:5:535:8 | hash [element :c] :  | hash_flow.rb:540:5:540:8 | hash [element :c] :  |
+| hash_flow.rb:536:15:536:25 | call to taint :  | hash_flow.rb:535:5:535:8 | hash [element :a] :  |
+| hash_flow.rb:538:15:538:25 | call to taint :  | hash_flow.rb:535:5:535:8 | hash [element :c] :  |
 | hash_flow.rb:540:5:540:8 | [post] hash [element :a] :  | hash_flow.rb:545:11:545:14 | hash [element :a] :  |
 | hash_flow.rb:540:5:540:8 | hash [element :a] :  | hash_flow.rb:540:5:540:8 | [post] hash [element :a] :  |
 | hash_flow.rb:540:5:540:8 | hash [element :a] :  | hash_flow.rb:540:27:540:31 | value :  |
@@ -342,74 +435,95 @@ edges
 | hash_flow.rb:540:27:540:31 | value :  | hash_flow.rb:542:14:542:18 | value |
 | hash_flow.rb:545:11:545:14 | hash [element :a] :  | hash_flow.rb:545:11:545:18 | ...[...] :  |
 | hash_flow.rb:545:11:545:18 | ...[...] :  | hash_flow.rb:545:10:545:19 | ( ... ) |
-| hash_flow.rb:552:15:552:25 | call to taint :  | hash_flow.rb:556:9:556:12 | hash [element :a] :  |
-| hash_flow.rb:554:15:554:25 | call to taint :  | hash_flow.rb:556:9:556:12 | hash [element :c] :  |
+| hash_flow.rb:551:5:551:8 | hash [element :a] :  | hash_flow.rb:556:9:556:12 | hash [element :a] :  |
+| hash_flow.rb:551:5:551:8 | hash [element :c] :  | hash_flow.rb:556:9:556:12 | hash [element :c] :  |
+| hash_flow.rb:552:15:552:25 | call to taint :  | hash_flow.rb:551:5:551:8 | hash [element :a] :  |
+| hash_flow.rb:554:15:554:25 | call to taint :  | hash_flow.rb:551:5:551:8 | hash [element :c] :  |
+| hash_flow.rb:556:5:556:5 | b [element 1] :  | hash_flow.rb:559:11:559:11 | b [element 1] :  |
 | hash_flow.rb:556:9:556:12 | [post] hash [element :a] :  | hash_flow.rb:557:11:557:14 | hash [element :a] :  |
 | hash_flow.rb:556:9:556:12 | hash [element :a] :  | hash_flow.rb:556:9:556:12 | [post] hash [element :a] :  |
 | hash_flow.rb:556:9:556:12 | hash [element :a] :  | hash_flow.rb:556:9:556:18 | call to shift [element 1] :  |
 | hash_flow.rb:556:9:556:12 | hash [element :c] :  | hash_flow.rb:556:9:556:18 | call to shift [element 1] :  |
-| hash_flow.rb:556:9:556:18 | call to shift [element 1] :  | hash_flow.rb:559:11:559:11 | b [element 1] :  |
+| hash_flow.rb:556:9:556:18 | call to shift [element 1] :  | hash_flow.rb:556:5:556:5 | b [element 1] :  |
 | hash_flow.rb:557:11:557:14 | hash [element :a] :  | hash_flow.rb:557:11:557:18 | ...[...] :  |
 | hash_flow.rb:557:11:557:18 | ...[...] :  | hash_flow.rb:557:10:557:19 | ( ... ) |
 | hash_flow.rb:559:11:559:11 | b [element 1] :  | hash_flow.rb:559:11:559:14 | ...[...] :  |
 | hash_flow.rb:559:11:559:14 | ...[...] :  | hash_flow.rb:559:10:559:15 | ( ... ) |
-| hash_flow.rb:566:15:566:25 | call to taint :  | hash_flow.rb:570:9:570:12 | hash [element :a] :  |
-| hash_flow.rb:566:15:566:25 | call to taint :  | hash_flow.rb:575:9:575:12 | hash [element :a] :  |
-| hash_flow.rb:568:15:568:25 | call to taint :  | hash_flow.rb:575:9:575:12 | hash [element :c] :  |
+| hash_flow.rb:565:5:565:8 | hash [element :a] :  | hash_flow.rb:570:9:570:12 | hash [element :a] :  |
+| hash_flow.rb:565:5:565:8 | hash [element :a] :  | hash_flow.rb:575:9:575:12 | hash [element :a] :  |
+| hash_flow.rb:565:5:565:8 | hash [element :c] :  | hash_flow.rb:575:9:575:12 | hash [element :c] :  |
+| hash_flow.rb:566:15:566:25 | call to taint :  | hash_flow.rb:565:5:565:8 | hash [element :a] :  |
+| hash_flow.rb:568:15:568:25 | call to taint :  | hash_flow.rb:565:5:565:8 | hash [element :c] :  |
+| hash_flow.rb:570:5:570:5 | b [element :a] :  | hash_flow.rb:571:11:571:11 | b [element :a] :  |
 | hash_flow.rb:570:9:570:12 | hash [element :a] :  | hash_flow.rb:570:9:570:26 | call to slice [element :a] :  |
-| hash_flow.rb:570:9:570:26 | call to slice [element :a] :  | hash_flow.rb:571:11:571:11 | b [element :a] :  |
+| hash_flow.rb:570:9:570:26 | call to slice [element :a] :  | hash_flow.rb:570:5:570:5 | b [element :a] :  |
 | hash_flow.rb:571:11:571:11 | b [element :a] :  | hash_flow.rb:571:11:571:15 | ...[...] :  |
 | hash_flow.rb:571:11:571:15 | ...[...] :  | hash_flow.rb:571:10:571:16 | ( ... ) |
+| hash_flow.rb:575:5:575:5 | c [element :a] :  | hash_flow.rb:576:11:576:11 | c [element :a] :  |
+| hash_flow.rb:575:5:575:5 | c [element :c] :  | hash_flow.rb:578:11:578:11 | c [element :c] :  |
 | hash_flow.rb:575:9:575:12 | hash [element :a] :  | hash_flow.rb:575:9:575:25 | call to slice [element :a] :  |
 | hash_flow.rb:575:9:575:12 | hash [element :c] :  | hash_flow.rb:575:9:575:25 | call to slice [element :c] :  |
-| hash_flow.rb:575:9:575:25 | call to slice [element :a] :  | hash_flow.rb:576:11:576:11 | c [element :a] :  |
-| hash_flow.rb:575:9:575:25 | call to slice [element :c] :  | hash_flow.rb:578:11:578:11 | c [element :c] :  |
+| hash_flow.rb:575:9:575:25 | call to slice [element :a] :  | hash_flow.rb:575:5:575:5 | c [element :a] :  |
+| hash_flow.rb:575:9:575:25 | call to slice [element :c] :  | hash_flow.rb:575:5:575:5 | c [element :c] :  |
 | hash_flow.rb:576:11:576:11 | c [element :a] :  | hash_flow.rb:576:11:576:15 | ...[...] :  |
 | hash_flow.rb:576:11:576:15 | ...[...] :  | hash_flow.rb:576:10:576:16 | ( ... ) |
 | hash_flow.rb:578:11:578:11 | c [element :c] :  | hash_flow.rb:578:11:578:15 | ...[...] :  |
 | hash_flow.rb:578:11:578:15 | ...[...] :  | hash_flow.rb:578:10:578:16 | ( ... ) |
-| hash_flow.rb:585:15:585:25 | call to taint :  | hash_flow.rb:589:9:589:12 | hash [element :a] :  |
-| hash_flow.rb:587:15:587:25 | call to taint :  | hash_flow.rb:589:9:589:12 | hash [element :c] :  |
+| hash_flow.rb:584:5:584:8 | hash [element :a] :  | hash_flow.rb:589:9:589:12 | hash [element :a] :  |
+| hash_flow.rb:584:5:584:8 | hash [element :c] :  | hash_flow.rb:589:9:589:12 | hash [element :c] :  |
+| hash_flow.rb:585:15:585:25 | call to taint :  | hash_flow.rb:584:5:584:8 | hash [element :a] :  |
+| hash_flow.rb:587:15:587:25 | call to taint :  | hash_flow.rb:584:5:584:8 | hash [element :c] :  |
+| hash_flow.rb:589:5:589:5 | a [element, element 1] :  | hash_flow.rb:591:11:591:11 | a [element, element 1] :  |
 | hash_flow.rb:589:9:589:12 | hash [element :a] :  | hash_flow.rb:589:9:589:17 | call to to_a [element, element 1] :  |
 | hash_flow.rb:589:9:589:12 | hash [element :c] :  | hash_flow.rb:589:9:589:17 | call to to_a [element, element 1] :  |
-| hash_flow.rb:589:9:589:17 | call to to_a [element, element 1] :  | hash_flow.rb:591:11:591:11 | a [element, element 1] :  |
+| hash_flow.rb:589:9:589:17 | call to to_a [element, element 1] :  | hash_flow.rb:589:5:589:5 | a [element, element 1] :  |
 | hash_flow.rb:591:11:591:11 | a [element, element 1] :  | hash_flow.rb:591:11:591:14 | ...[...] [element 1] :  |
 | hash_flow.rb:591:11:591:14 | ...[...] [element 1] :  | hash_flow.rb:591:11:591:17 | ...[...] :  |
 | hash_flow.rb:591:11:591:17 | ...[...] :  | hash_flow.rb:591:10:591:18 | ( ... ) |
-| hash_flow.rb:598:15:598:25 | call to taint :  | hash_flow.rb:602:9:602:12 | hash [element :a] :  |
-| hash_flow.rb:598:15:598:25 | call to taint :  | hash_flow.rb:607:9:607:12 | hash [element :a] :  |
-| hash_flow.rb:600:15:600:25 | call to taint :  | hash_flow.rb:602:9:602:12 | hash [element :c] :  |
-| hash_flow.rb:600:15:600:25 | call to taint :  | hash_flow.rb:607:9:607:12 | hash [element :c] :  |
+| hash_flow.rb:597:5:597:8 | hash [element :a] :  | hash_flow.rb:602:9:602:12 | hash [element :a] :  |
+| hash_flow.rb:597:5:597:8 | hash [element :a] :  | hash_flow.rb:607:9:607:12 | hash [element :a] :  |
+| hash_flow.rb:597:5:597:8 | hash [element :c] :  | hash_flow.rb:602:9:602:12 | hash [element :c] :  |
+| hash_flow.rb:597:5:597:8 | hash [element :c] :  | hash_flow.rb:607:9:607:12 | hash [element :c] :  |
+| hash_flow.rb:598:15:598:25 | call to taint :  | hash_flow.rb:597:5:597:8 | hash [element :a] :  |
+| hash_flow.rb:600:15:600:25 | call to taint :  | hash_flow.rb:597:5:597:8 | hash [element :c] :  |
+| hash_flow.rb:602:5:602:5 | a [element :a] :  | hash_flow.rb:603:11:603:11 | a [element :a] :  |
+| hash_flow.rb:602:5:602:5 | a [element :c] :  | hash_flow.rb:605:11:605:11 | a [element :c] :  |
 | hash_flow.rb:602:9:602:12 | hash [element :a] :  | hash_flow.rb:602:9:602:17 | call to to_h [element :a] :  |
 | hash_flow.rb:602:9:602:12 | hash [element :c] :  | hash_flow.rb:602:9:602:17 | call to to_h [element :c] :  |
-| hash_flow.rb:602:9:602:17 | call to to_h [element :a] :  | hash_flow.rb:603:11:603:11 | a [element :a] :  |
-| hash_flow.rb:602:9:602:17 | call to to_h [element :c] :  | hash_flow.rb:605:11:605:11 | a [element :c] :  |
+| hash_flow.rb:602:9:602:17 | call to to_h [element :a] :  | hash_flow.rb:602:5:602:5 | a [element :a] :  |
+| hash_flow.rb:602:9:602:17 | call to to_h [element :c] :  | hash_flow.rb:602:5:602:5 | a [element :c] :  |
 | hash_flow.rb:603:11:603:11 | a [element :a] :  | hash_flow.rb:603:11:603:15 | ...[...] :  |
 | hash_flow.rb:603:11:603:15 | ...[...] :  | hash_flow.rb:603:10:603:16 | ( ... ) |
 | hash_flow.rb:605:11:605:11 | a [element :c] :  | hash_flow.rb:605:11:605:15 | ...[...] :  |
 | hash_flow.rb:605:11:605:15 | ...[...] :  | hash_flow.rb:605:10:605:16 | ( ... ) |
+| hash_flow.rb:607:5:607:5 | b [element] :  | hash_flow.rb:612:11:612:11 | b [element] :  |
 | hash_flow.rb:607:9:607:12 | hash [element :a] :  | hash_flow.rb:607:28:607:32 | value :  |
 | hash_flow.rb:607:9:607:12 | hash [element :c] :  | hash_flow.rb:607:28:607:32 | value :  |
-| hash_flow.rb:607:9:611:7 | call to to_h [element] :  | hash_flow.rb:612:11:612:11 | b [element] :  |
+| hash_flow.rb:607:9:611:7 | call to to_h [element] :  | hash_flow.rb:607:5:607:5 | b [element] :  |
 | hash_flow.rb:607:28:607:32 | value :  | hash_flow.rb:609:14:609:18 | value |
 | hash_flow.rb:610:14:610:24 | call to taint :  | hash_flow.rb:607:9:611:7 | call to to_h [element] :  |
 | hash_flow.rb:612:11:612:11 | b [element] :  | hash_flow.rb:612:11:612:15 | ...[...] :  |
 | hash_flow.rb:612:11:612:15 | ...[...] :  | hash_flow.rb:612:10:612:16 | ( ... ) |
-| hash_flow.rb:619:15:619:25 | call to taint :  | hash_flow.rb:623:9:623:12 | hash [element :a] :  |
-| hash_flow.rb:621:15:621:25 | call to taint :  | hash_flow.rb:623:9:623:12 | hash [element :c] :  |
+| hash_flow.rb:618:5:618:8 | hash [element :a] :  | hash_flow.rb:623:9:623:12 | hash [element :a] :  |
+| hash_flow.rb:618:5:618:8 | hash [element :c] :  | hash_flow.rb:623:9:623:12 | hash [element :c] :  |
+| hash_flow.rb:619:15:619:25 | call to taint :  | hash_flow.rb:618:5:618:8 | hash [element :a] :  |
+| hash_flow.rb:621:15:621:25 | call to taint :  | hash_flow.rb:618:5:618:8 | hash [element :c] :  |
+| hash_flow.rb:623:5:623:5 | a [element] :  | hash_flow.rb:624:11:624:11 | a [element] :  |
+| hash_flow.rb:623:5:623:5 | a [element] :  | hash_flow.rb:625:11:625:11 | a [element] :  |
+| hash_flow.rb:623:5:623:5 | a [element] :  | hash_flow.rb:626:11:626:11 | a [element] :  |
 | hash_flow.rb:623:9:623:12 | hash [element :a] :  | hash_flow.rb:623:9:623:45 | call to transform_keys [element] :  |
 | hash_flow.rb:623:9:623:12 | hash [element :c] :  | hash_flow.rb:623:9:623:45 | call to transform_keys [element] :  |
-| hash_flow.rb:623:9:623:45 | call to transform_keys [element] :  | hash_flow.rb:624:11:624:11 | a [element] :  |
-| hash_flow.rb:623:9:623:45 | call to transform_keys [element] :  | hash_flow.rb:625:11:625:11 | a [element] :  |
-| hash_flow.rb:623:9:623:45 | call to transform_keys [element] :  | hash_flow.rb:626:11:626:11 | a [element] :  |
+| hash_flow.rb:623:9:623:45 | call to transform_keys [element] :  | hash_flow.rb:623:5:623:5 | a [element] :  |
 | hash_flow.rb:624:11:624:11 | a [element] :  | hash_flow.rb:624:11:624:16 | ...[...] :  |
 | hash_flow.rb:624:11:624:16 | ...[...] :  | hash_flow.rb:624:10:624:17 | ( ... ) |
 | hash_flow.rb:625:11:625:11 | a [element] :  | hash_flow.rb:625:11:625:16 | ...[...] :  |
 | hash_flow.rb:625:11:625:16 | ...[...] :  | hash_flow.rb:625:10:625:17 | ( ... ) |
 | hash_flow.rb:626:11:626:11 | a [element] :  | hash_flow.rb:626:11:626:16 | ...[...] :  |
 | hash_flow.rb:626:11:626:16 | ...[...] :  | hash_flow.rb:626:10:626:17 | ( ... ) |
-| hash_flow.rb:633:15:633:25 | call to taint :  | hash_flow.rb:639:5:639:8 | hash [element :a] :  |
-| hash_flow.rb:635:15:635:25 | call to taint :  | hash_flow.rb:639:5:639:8 | hash [element :c] :  |
+| hash_flow.rb:632:5:632:8 | hash [element :a] :  | hash_flow.rb:639:5:639:8 | hash [element :a] :  |
+| hash_flow.rb:632:5:632:8 | hash [element :c] :  | hash_flow.rb:639:5:639:8 | hash [element :c] :  |
+| hash_flow.rb:633:15:633:25 | call to taint :  | hash_flow.rb:632:5:632:8 | hash [element :a] :  |
+| hash_flow.rb:635:15:635:25 | call to taint :  | hash_flow.rb:632:5:632:8 | hash [element :c] :  |
 | hash_flow.rb:637:5:637:8 | [post] hash [element] :  | hash_flow.rb:639:5:639:8 | hash [element] :  |
 | hash_flow.rb:637:5:637:8 | [post] hash [element] :  | hash_flow.rb:640:11:640:14 | hash [element] :  |
 | hash_flow.rb:637:5:637:8 | [post] hash [element] :  | hash_flow.rb:641:11:641:14 | hash [element] :  |
@@ -427,20 +541,25 @@ edges
 | hash_flow.rb:641:11:641:19 | ...[...] :  | hash_flow.rb:641:10:641:20 | ( ... ) |
 | hash_flow.rb:642:11:642:14 | hash [element] :  | hash_flow.rb:642:11:642:19 | ...[...] :  |
 | hash_flow.rb:642:11:642:19 | ...[...] :  | hash_flow.rb:642:10:642:20 | ( ... ) |
-| hash_flow.rb:649:15:649:25 | call to taint :  | hash_flow.rb:653:9:653:12 | hash [element :a] :  |
-| hash_flow.rb:649:15:649:25 | call to taint :  | hash_flow.rb:657:11:657:14 | hash [element :a] :  |
-| hash_flow.rb:651:15:651:25 | call to taint :  | hash_flow.rb:653:9:653:12 | hash [element :c] :  |
+| hash_flow.rb:648:5:648:8 | hash [element :a] :  | hash_flow.rb:653:9:653:12 | hash [element :a] :  |
+| hash_flow.rb:648:5:648:8 | hash [element :a] :  | hash_flow.rb:657:11:657:14 | hash [element :a] :  |
+| hash_flow.rb:648:5:648:8 | hash [element :c] :  | hash_flow.rb:653:9:653:12 | hash [element :c] :  |
+| hash_flow.rb:649:15:649:25 | call to taint :  | hash_flow.rb:648:5:648:8 | hash [element :a] :  |
+| hash_flow.rb:651:15:651:25 | call to taint :  | hash_flow.rb:648:5:648:8 | hash [element :c] :  |
+| hash_flow.rb:653:5:653:5 | b [element] :  | hash_flow.rb:658:11:658:11 | b [element] :  |
 | hash_flow.rb:653:9:653:12 | hash [element :a] :  | hash_flow.rb:653:35:653:39 | value :  |
 | hash_flow.rb:653:9:653:12 | hash [element :c] :  | hash_flow.rb:653:35:653:39 | value :  |
-| hash_flow.rb:653:9:656:7 | call to transform_values [element] :  | hash_flow.rb:658:11:658:11 | b [element] :  |
+| hash_flow.rb:653:9:656:7 | call to transform_values [element] :  | hash_flow.rb:653:5:653:5 | b [element] :  |
 | hash_flow.rb:653:35:653:39 | value :  | hash_flow.rb:654:14:654:18 | value |
 | hash_flow.rb:655:9:655:19 | call to taint :  | hash_flow.rb:653:9:656:7 | call to transform_values [element] :  |
 | hash_flow.rb:657:11:657:14 | hash [element :a] :  | hash_flow.rb:657:11:657:18 | ...[...] :  |
 | hash_flow.rb:657:11:657:18 | ...[...] :  | hash_flow.rb:657:10:657:19 | ( ... ) |
 | hash_flow.rb:658:11:658:11 | b [element] :  | hash_flow.rb:658:11:658:15 | ...[...] :  |
 | hash_flow.rb:658:11:658:15 | ...[...] :  | hash_flow.rb:658:10:658:16 | ( ... ) |
-| hash_flow.rb:665:15:665:25 | call to taint :  | hash_flow.rb:669:5:669:8 | hash [element :a] :  |
-| hash_flow.rb:667:15:667:25 | call to taint :  | hash_flow.rb:669:5:669:8 | hash [element :c] :  |
+| hash_flow.rb:664:5:664:8 | hash [element :a] :  | hash_flow.rb:669:5:669:8 | hash [element :a] :  |
+| hash_flow.rb:664:5:664:8 | hash [element :c] :  | hash_flow.rb:669:5:669:8 | hash [element :c] :  |
+| hash_flow.rb:665:15:665:25 | call to taint :  | hash_flow.rb:664:5:664:8 | hash [element :a] :  |
+| hash_flow.rb:667:15:667:25 | call to taint :  | hash_flow.rb:664:5:664:8 | hash [element :c] :  |
 | hash_flow.rb:669:5:669:8 | [post] hash [element] :  | hash_flow.rb:673:11:673:14 | hash [element] :  |
 | hash_flow.rb:669:5:669:8 | hash [element :a] :  | hash_flow.rb:669:32:669:36 | value :  |
 | hash_flow.rb:669:5:669:8 | hash [element :c] :  | hash_flow.rb:669:32:669:36 | value :  |
@@ -448,10 +567,18 @@ edges
 | hash_flow.rb:671:9:671:19 | call to taint :  | hash_flow.rb:669:5:669:8 | [post] hash [element] :  |
 | hash_flow.rb:673:11:673:14 | hash [element] :  | hash_flow.rb:673:11:673:18 | ...[...] :  |
 | hash_flow.rb:673:11:673:18 | ...[...] :  | hash_flow.rb:673:10:673:19 | ( ... ) |
-| hash_flow.rb:680:15:680:25 | call to taint :  | hash_flow.rb:689:12:689:16 | hash1 [element :a] :  |
-| hash_flow.rb:682:15:682:25 | call to taint :  | hash_flow.rb:689:12:689:16 | hash1 [element :c] :  |
-| hash_flow.rb:685:15:685:25 | call to taint :  | hash_flow.rb:689:25:689:29 | hash2 [element :d] :  |
-| hash_flow.rb:687:15:687:25 | call to taint :  | hash_flow.rb:689:25:689:29 | hash2 [element :f] :  |
+| hash_flow.rb:679:5:679:9 | hash1 [element :a] :  | hash_flow.rb:689:12:689:16 | hash1 [element :a] :  |
+| hash_flow.rb:679:5:679:9 | hash1 [element :c] :  | hash_flow.rb:689:12:689:16 | hash1 [element :c] :  |
+| hash_flow.rb:680:15:680:25 | call to taint :  | hash_flow.rb:679:5:679:9 | hash1 [element :a] :  |
+| hash_flow.rb:682:15:682:25 | call to taint :  | hash_flow.rb:679:5:679:9 | hash1 [element :c] :  |
+| hash_flow.rb:684:5:684:9 | hash2 [element :d] :  | hash_flow.rb:689:25:689:29 | hash2 [element :d] :  |
+| hash_flow.rb:684:5:684:9 | hash2 [element :f] :  | hash_flow.rb:689:25:689:29 | hash2 [element :f] :  |
+| hash_flow.rb:685:15:685:25 | call to taint :  | hash_flow.rb:684:5:684:9 | hash2 [element :d] :  |
+| hash_flow.rb:687:15:687:25 | call to taint :  | hash_flow.rb:684:5:684:9 | hash2 [element :f] :  |
+| hash_flow.rb:689:5:689:8 | hash [element :a] :  | hash_flow.rb:694:11:694:14 | hash [element :a] :  |
+| hash_flow.rb:689:5:689:8 | hash [element :c] :  | hash_flow.rb:696:11:696:14 | hash [element :c] :  |
+| hash_flow.rb:689:5:689:8 | hash [element :d] :  | hash_flow.rb:697:11:697:14 | hash [element :d] :  |
+| hash_flow.rb:689:5:689:8 | hash [element :f] :  | hash_flow.rb:699:11:699:14 | hash [element :f] :  |
 | hash_flow.rb:689:12:689:16 | [post] hash1 [element :a] :  | hash_flow.rb:701:11:701:15 | hash1 [element :a] :  |
 | hash_flow.rb:689:12:689:16 | [post] hash1 [element :c] :  | hash_flow.rb:703:11:703:15 | hash1 [element :c] :  |
 | hash_flow.rb:689:12:689:16 | [post] hash1 [element :d] :  | hash_flow.rb:704:11:704:15 | hash1 [element :d] :  |
@@ -464,10 +591,10 @@ edges
 | hash_flow.rb:689:12:689:16 | hash1 [element :c] :  | hash_flow.rb:689:12:693:7 | call to update [element :c] :  |
 | hash_flow.rb:689:12:689:16 | hash1 [element :c] :  | hash_flow.rb:689:41:689:49 | old_value :  |
 | hash_flow.rb:689:12:689:16 | hash1 [element :c] :  | hash_flow.rb:689:52:689:60 | new_value :  |
-| hash_flow.rb:689:12:693:7 | call to update [element :a] :  | hash_flow.rb:694:11:694:14 | hash [element :a] :  |
-| hash_flow.rb:689:12:693:7 | call to update [element :c] :  | hash_flow.rb:696:11:696:14 | hash [element :c] :  |
-| hash_flow.rb:689:12:693:7 | call to update [element :d] :  | hash_flow.rb:697:11:697:14 | hash [element :d] :  |
-| hash_flow.rb:689:12:693:7 | call to update [element :f] :  | hash_flow.rb:699:11:699:14 | hash [element :f] :  |
+| hash_flow.rb:689:12:693:7 | call to update [element :a] :  | hash_flow.rb:689:5:689:8 | hash [element :a] :  |
+| hash_flow.rb:689:12:693:7 | call to update [element :c] :  | hash_flow.rb:689:5:689:8 | hash [element :c] :  |
+| hash_flow.rb:689:12:693:7 | call to update [element :d] :  | hash_flow.rb:689:5:689:8 | hash [element :d] :  |
+| hash_flow.rb:689:12:693:7 | call to update [element :f] :  | hash_flow.rb:689:5:689:8 | hash [element :f] :  |
 | hash_flow.rb:689:25:689:29 | hash2 [element :d] :  | hash_flow.rb:689:12:689:16 | [post] hash1 [element :d] :  |
 | hash_flow.rb:689:25:689:29 | hash2 [element :d] :  | hash_flow.rb:689:12:693:7 | call to update [element :d] :  |
 | hash_flow.rb:689:25:689:29 | hash2 [element :d] :  | hash_flow.rb:689:41:689:49 | old_value :  |
@@ -494,34 +621,50 @@ edges
 | hash_flow.rb:704:11:704:19 | ...[...] :  | hash_flow.rb:704:10:704:20 | ( ... ) |
 | hash_flow.rb:706:11:706:15 | hash1 [element :f] :  | hash_flow.rb:706:11:706:19 | ...[...] :  |
 | hash_flow.rb:706:11:706:19 | ...[...] :  | hash_flow.rb:706:10:706:20 | ( ... ) |
-| hash_flow.rb:713:15:713:25 | call to taint :  | hash_flow.rb:717:9:717:12 | hash [element :a] :  |
-| hash_flow.rb:715:15:715:25 | call to taint :  | hash_flow.rb:717:9:717:12 | hash [element :c] :  |
+| hash_flow.rb:712:5:712:8 | hash [element :a] :  | hash_flow.rb:717:9:717:12 | hash [element :a] :  |
+| hash_flow.rb:712:5:712:8 | hash [element :c] :  | hash_flow.rb:717:9:717:12 | hash [element :c] :  |
+| hash_flow.rb:713:15:713:25 | call to taint :  | hash_flow.rb:712:5:712:8 | hash [element :a] :  |
+| hash_flow.rb:715:15:715:25 | call to taint :  | hash_flow.rb:712:5:712:8 | hash [element :c] :  |
+| hash_flow.rb:717:5:717:5 | a [element] :  | hash_flow.rb:718:11:718:11 | a [element] :  |
 | hash_flow.rb:717:9:717:12 | hash [element :a] :  | hash_flow.rb:717:9:717:19 | call to values [element] :  |
 | hash_flow.rb:717:9:717:12 | hash [element :c] :  | hash_flow.rb:717:9:717:19 | call to values [element] :  |
-| hash_flow.rb:717:9:717:19 | call to values [element] :  | hash_flow.rb:718:11:718:11 | a [element] :  |
+| hash_flow.rb:717:9:717:19 | call to values [element] :  | hash_flow.rb:717:5:717:5 | a [element] :  |
 | hash_flow.rb:718:11:718:11 | a [element] :  | hash_flow.rb:718:11:718:14 | ...[...] :  |
 | hash_flow.rb:718:11:718:14 | ...[...] :  | hash_flow.rb:718:10:718:15 | ( ... ) |
-| hash_flow.rb:725:15:725:25 | call to taint :  | hash_flow.rb:729:9:729:12 | hash [element :a] :  |
-| hash_flow.rb:725:15:725:25 | call to taint :  | hash_flow.rb:731:9:731:12 | hash [element :a] :  |
-| hash_flow.rb:727:15:727:25 | call to taint :  | hash_flow.rb:731:9:731:12 | hash [element :c] :  |
+| hash_flow.rb:724:5:724:8 | hash [element :a] :  | hash_flow.rb:729:9:729:12 | hash [element :a] :  |
+| hash_flow.rb:724:5:724:8 | hash [element :a] :  | hash_flow.rb:731:9:731:12 | hash [element :a] :  |
+| hash_flow.rb:724:5:724:8 | hash [element :c] :  | hash_flow.rb:731:9:731:12 | hash [element :c] :  |
+| hash_flow.rb:725:15:725:25 | call to taint :  | hash_flow.rb:724:5:724:8 | hash [element :a] :  |
+| hash_flow.rb:727:15:727:25 | call to taint :  | hash_flow.rb:724:5:724:8 | hash [element :c] :  |
+| hash_flow.rb:729:5:729:5 | b [element 0] :  | hash_flow.rb:730:10:730:10 | b [element 0] :  |
 | hash_flow.rb:729:9:729:12 | hash [element :a] :  | hash_flow.rb:729:9:729:26 | call to values_at [element 0] :  |
-| hash_flow.rb:729:9:729:26 | call to values_at [element 0] :  | hash_flow.rb:730:10:730:10 | b [element 0] :  |
+| hash_flow.rb:729:9:729:26 | call to values_at [element 0] :  | hash_flow.rb:729:5:729:5 | b [element 0] :  |
 | hash_flow.rb:730:10:730:10 | b [element 0] :  | hash_flow.rb:730:10:730:13 | ...[...] |
+| hash_flow.rb:731:5:731:5 | b [element] :  | hash_flow.rb:732:10:732:10 | b [element] :  |
 | hash_flow.rb:731:9:731:12 | hash [element :a] :  | hash_flow.rb:731:9:731:31 | call to fetch_values [element] :  |
 | hash_flow.rb:731:9:731:12 | hash [element :c] :  | hash_flow.rb:731:9:731:31 | call to fetch_values [element] :  |
-| hash_flow.rb:731:9:731:31 | call to fetch_values [element] :  | hash_flow.rb:732:10:732:10 | b [element] :  |
+| hash_flow.rb:731:9:731:31 | call to fetch_values [element] :  | hash_flow.rb:731:5:731:5 | b [element] :  |
 | hash_flow.rb:732:10:732:10 | b [element] :  | hash_flow.rb:732:10:732:13 | ...[...] |
-| hash_flow.rb:739:15:739:25 | call to taint :  | hash_flow.rb:748:16:748:20 | hash1 [element :a] :  |
-| hash_flow.rb:741:15:741:25 | call to taint :  | hash_flow.rb:748:16:748:20 | hash1 [element :c] :  |
-| hash_flow.rb:744:15:744:25 | call to taint :  | hash_flow.rb:748:44:748:48 | hash2 [element :d] :  |
-| hash_flow.rb:746:15:746:25 | call to taint :  | hash_flow.rb:748:44:748:48 | hash2 [element :f] :  |
-| hash_flow.rb:748:14:748:20 | ** ... [element :a] :  | hash_flow.rb:749:10:749:13 | hash [element :a] :  |
-| hash_flow.rb:748:14:748:20 | ** ... [element :c] :  | hash_flow.rb:751:10:751:13 | hash [element :c] :  |
+| hash_flow.rb:738:5:738:9 | hash1 [element :a] :  | hash_flow.rb:748:16:748:20 | hash1 [element :a] :  |
+| hash_flow.rb:738:5:738:9 | hash1 [element :c] :  | hash_flow.rb:748:16:748:20 | hash1 [element :c] :  |
+| hash_flow.rb:739:15:739:25 | call to taint :  | hash_flow.rb:738:5:738:9 | hash1 [element :a] :  |
+| hash_flow.rb:741:15:741:25 | call to taint :  | hash_flow.rb:738:5:738:9 | hash1 [element :c] :  |
+| hash_flow.rb:743:5:743:9 | hash2 [element :d] :  | hash_flow.rb:748:44:748:48 | hash2 [element :d] :  |
+| hash_flow.rb:743:5:743:9 | hash2 [element :f] :  | hash_flow.rb:748:44:748:48 | hash2 [element :f] :  |
+| hash_flow.rb:744:15:744:25 | call to taint :  | hash_flow.rb:743:5:743:9 | hash2 [element :d] :  |
+| hash_flow.rb:746:15:746:25 | call to taint :  | hash_flow.rb:743:5:743:9 | hash2 [element :f] :  |
+| hash_flow.rb:748:5:748:8 | hash [element :a] :  | hash_flow.rb:749:10:749:13 | hash [element :a] :  |
+| hash_flow.rb:748:5:748:8 | hash [element :c] :  | hash_flow.rb:751:10:751:13 | hash [element :c] :  |
+| hash_flow.rb:748:5:748:8 | hash [element :d] :  | hash_flow.rb:752:10:752:13 | hash [element :d] :  |
+| hash_flow.rb:748:5:748:8 | hash [element :f] :  | hash_flow.rb:754:10:754:13 | hash [element :f] :  |
+| hash_flow.rb:748:5:748:8 | hash [element :g] :  | hash_flow.rb:755:10:755:13 | hash [element :g] :  |
+| hash_flow.rb:748:14:748:20 | ** ... [element :a] :  | hash_flow.rb:748:5:748:8 | hash [element :a] :  |
+| hash_flow.rb:748:14:748:20 | ** ... [element :c] :  | hash_flow.rb:748:5:748:8 | hash [element :c] :  |
 | hash_flow.rb:748:16:748:20 | hash1 [element :a] :  | hash_flow.rb:748:14:748:20 | ** ... [element :a] :  |
 | hash_flow.rb:748:16:748:20 | hash1 [element :c] :  | hash_flow.rb:748:14:748:20 | ** ... [element :c] :  |
-| hash_flow.rb:748:29:748:39 | call to taint :  | hash_flow.rb:755:10:755:13 | hash [element :g] :  |
-| hash_flow.rb:748:42:748:48 | ** ... [element :d] :  | hash_flow.rb:752:10:752:13 | hash [element :d] :  |
-| hash_flow.rb:748:42:748:48 | ** ... [element :f] :  | hash_flow.rb:754:10:754:13 | hash [element :f] :  |
+| hash_flow.rb:748:29:748:39 | call to taint :  | hash_flow.rb:748:5:748:8 | hash [element :g] :  |
+| hash_flow.rb:748:42:748:48 | ** ... [element :d] :  | hash_flow.rb:748:5:748:8 | hash [element :d] :  |
+| hash_flow.rb:748:42:748:48 | ** ... [element :f] :  | hash_flow.rb:748:5:748:8 | hash [element :f] :  |
 | hash_flow.rb:748:44:748:48 | hash2 [element :d] :  | hash_flow.rb:748:42:748:48 | ** ... [element :d] :  |
 | hash_flow.rb:748:44:748:48 | hash2 [element :f] :  | hash_flow.rb:748:42:748:48 | ** ... [element :f] :  |
 | hash_flow.rb:749:10:749:13 | hash [element :a] :  | hash_flow.rb:749:10:749:17 | ...[...] |
@@ -529,33 +672,45 @@ edges
 | hash_flow.rb:752:10:752:13 | hash [element :d] :  | hash_flow.rb:752:10:752:17 | ...[...] |
 | hash_flow.rb:754:10:754:13 | hash [element :f] :  | hash_flow.rb:754:10:754:17 | ...[...] |
 | hash_flow.rb:755:10:755:13 | hash [element :g] :  | hash_flow.rb:755:10:755:17 | ...[...] |
-| hash_flow.rb:763:15:763:25 | call to taint :  | hash_flow.rb:769:10:769:13 | hash [element :a] :  |
-| hash_flow.rb:765:15:765:25 | call to taint :  | hash_flow.rb:771:10:771:13 | hash [element :c] :  |
-| hash_flow.rb:765:15:765:25 | call to taint :  | hash_flow.rb:774:9:774:12 | hash [element :c] :  |
-| hash_flow.rb:766:15:766:25 | call to taint :  | hash_flow.rb:772:10:772:13 | hash [element :d] :  |
+| hash_flow.rb:762:5:762:8 | hash [element :a] :  | hash_flow.rb:769:10:769:13 | hash [element :a] :  |
+| hash_flow.rb:762:5:762:8 | hash [element :c] :  | hash_flow.rb:771:10:771:13 | hash [element :c] :  |
+| hash_flow.rb:762:5:762:8 | hash [element :c] :  | hash_flow.rb:774:9:774:12 | hash [element :c] :  |
+| hash_flow.rb:762:5:762:8 | hash [element :d] :  | hash_flow.rb:772:10:772:13 | hash [element :d] :  |
+| hash_flow.rb:763:15:763:25 | call to taint :  | hash_flow.rb:762:5:762:8 | hash [element :a] :  |
+| hash_flow.rb:765:15:765:25 | call to taint :  | hash_flow.rb:762:5:762:8 | hash [element :c] :  |
+| hash_flow.rb:766:15:766:25 | call to taint :  | hash_flow.rb:762:5:762:8 | hash [element :d] :  |
 | hash_flow.rb:769:10:769:13 | hash [element :a] :  | hash_flow.rb:769:10:769:17 | ...[...] |
 | hash_flow.rb:771:10:771:13 | hash [element :c] :  | hash_flow.rb:771:10:771:17 | ...[...] |
 | hash_flow.rb:772:10:772:13 | hash [element :d] :  | hash_flow.rb:772:10:772:17 | ...[...] |
+| hash_flow.rb:774:5:774:5 | x [element :c] :  | hash_flow.rb:778:10:778:10 | x [element :c] :  |
 | hash_flow.rb:774:9:774:12 | [post] hash [element :c] :  | hash_flow.rb:783:10:783:13 | hash [element :c] :  |
 | hash_flow.rb:774:9:774:12 | hash [element :c] :  | hash_flow.rb:774:9:774:12 | [post] hash [element :c] :  |
 | hash_flow.rb:774:9:774:12 | hash [element :c] :  | hash_flow.rb:774:9:774:31 | call to except! [element :c] :  |
-| hash_flow.rb:774:9:774:31 | call to except! [element :c] :  | hash_flow.rb:778:10:778:10 | x [element :c] :  |
+| hash_flow.rb:774:9:774:31 | call to except! [element :c] :  | hash_flow.rb:774:5:774:5 | x [element :c] :  |
 | hash_flow.rb:778:10:778:10 | x [element :c] :  | hash_flow.rb:778:10:778:14 | ...[...] |
 | hash_flow.rb:783:10:783:13 | hash [element :c] :  | hash_flow.rb:783:10:783:17 | ...[...] |
-| hash_flow.rb:791:15:791:25 | call to taint :  | hash_flow.rb:800:12:800:16 | hash1 [element :a] :  |
-| hash_flow.rb:793:15:793:25 | call to taint :  | hash_flow.rb:800:12:800:16 | hash1 [element :c] :  |
-| hash_flow.rb:796:15:796:25 | call to taint :  | hash_flow.rb:800:29:800:33 | hash2 [element :d] :  |
-| hash_flow.rb:798:15:798:25 | call to taint :  | hash_flow.rb:800:29:800:33 | hash2 [element :f] :  |
+| hash_flow.rb:790:5:790:9 | hash1 [element :a] :  | hash_flow.rb:800:12:800:16 | hash1 [element :a] :  |
+| hash_flow.rb:790:5:790:9 | hash1 [element :c] :  | hash_flow.rb:800:12:800:16 | hash1 [element :c] :  |
+| hash_flow.rb:791:15:791:25 | call to taint :  | hash_flow.rb:790:5:790:9 | hash1 [element :a] :  |
+| hash_flow.rb:793:15:793:25 | call to taint :  | hash_flow.rb:790:5:790:9 | hash1 [element :c] :  |
+| hash_flow.rb:795:5:795:9 | hash2 [element :d] :  | hash_flow.rb:800:29:800:33 | hash2 [element :d] :  |
+| hash_flow.rb:795:5:795:9 | hash2 [element :f] :  | hash_flow.rb:800:29:800:33 | hash2 [element :f] :  |
+| hash_flow.rb:796:15:796:25 | call to taint :  | hash_flow.rb:795:5:795:9 | hash2 [element :d] :  |
+| hash_flow.rb:798:15:798:25 | call to taint :  | hash_flow.rb:795:5:795:9 | hash2 [element :f] :  |
+| hash_flow.rb:800:5:800:8 | hash [element :a] :  | hash_flow.rb:805:11:805:14 | hash [element :a] :  |
+| hash_flow.rb:800:5:800:8 | hash [element :c] :  | hash_flow.rb:807:11:807:14 | hash [element :c] :  |
+| hash_flow.rb:800:5:800:8 | hash [element :d] :  | hash_flow.rb:808:11:808:14 | hash [element :d] :  |
+| hash_flow.rb:800:5:800:8 | hash [element :f] :  | hash_flow.rb:810:11:810:14 | hash [element :f] :  |
 | hash_flow.rb:800:12:800:16 | hash1 [element :a] :  | hash_flow.rb:800:12:804:7 | call to deep_merge [element :a] :  |
 | hash_flow.rb:800:12:800:16 | hash1 [element :a] :  | hash_flow.rb:800:45:800:53 | old_value :  |
 | hash_flow.rb:800:12:800:16 | hash1 [element :a] :  | hash_flow.rb:800:56:800:64 | new_value :  |
 | hash_flow.rb:800:12:800:16 | hash1 [element :c] :  | hash_flow.rb:800:12:804:7 | call to deep_merge [element :c] :  |
 | hash_flow.rb:800:12:800:16 | hash1 [element :c] :  | hash_flow.rb:800:45:800:53 | old_value :  |
 | hash_flow.rb:800:12:800:16 | hash1 [element :c] :  | hash_flow.rb:800:56:800:64 | new_value :  |
-| hash_flow.rb:800:12:804:7 | call to deep_merge [element :a] :  | hash_flow.rb:805:11:805:14 | hash [element :a] :  |
-| hash_flow.rb:800:12:804:7 | call to deep_merge [element :c] :  | hash_flow.rb:807:11:807:14 | hash [element :c] :  |
-| hash_flow.rb:800:12:804:7 | call to deep_merge [element :d] :  | hash_flow.rb:808:11:808:14 | hash [element :d] :  |
-| hash_flow.rb:800:12:804:7 | call to deep_merge [element :f] :  | hash_flow.rb:810:11:810:14 | hash [element :f] :  |
+| hash_flow.rb:800:12:804:7 | call to deep_merge [element :a] :  | hash_flow.rb:800:5:800:8 | hash [element :a] :  |
+| hash_flow.rb:800:12:804:7 | call to deep_merge [element :c] :  | hash_flow.rb:800:5:800:8 | hash [element :c] :  |
+| hash_flow.rb:800:12:804:7 | call to deep_merge [element :d] :  | hash_flow.rb:800:5:800:8 | hash [element :d] :  |
+| hash_flow.rb:800:12:804:7 | call to deep_merge [element :f] :  | hash_flow.rb:800:5:800:8 | hash [element :f] :  |
 | hash_flow.rb:800:29:800:33 | hash2 [element :d] :  | hash_flow.rb:800:12:804:7 | call to deep_merge [element :d] :  |
 | hash_flow.rb:800:29:800:33 | hash2 [element :d] :  | hash_flow.rb:800:45:800:53 | old_value :  |
 | hash_flow.rb:800:29:800:33 | hash2 [element :d] :  | hash_flow.rb:800:56:800:64 | new_value :  |
@@ -572,10 +727,18 @@ edges
 | hash_flow.rb:808:11:808:18 | ...[...] :  | hash_flow.rb:808:10:808:19 | ( ... ) |
 | hash_flow.rb:810:11:810:14 | hash [element :f] :  | hash_flow.rb:810:11:810:18 | ...[...] :  |
 | hash_flow.rb:810:11:810:18 | ...[...] :  | hash_flow.rb:810:10:810:19 | ( ... ) |
-| hash_flow.rb:817:15:817:25 | call to taint :  | hash_flow.rb:826:12:826:16 | hash1 [element :a] :  |
-| hash_flow.rb:819:15:819:25 | call to taint :  | hash_flow.rb:826:12:826:16 | hash1 [element :c] :  |
-| hash_flow.rb:822:15:822:25 | call to taint :  | hash_flow.rb:826:30:826:34 | hash2 [element :d] :  |
-| hash_flow.rb:824:15:824:25 | call to taint :  | hash_flow.rb:826:30:826:34 | hash2 [element :f] :  |
+| hash_flow.rb:816:5:816:9 | hash1 [element :a] :  | hash_flow.rb:826:12:826:16 | hash1 [element :a] :  |
+| hash_flow.rb:816:5:816:9 | hash1 [element :c] :  | hash_flow.rb:826:12:826:16 | hash1 [element :c] :  |
+| hash_flow.rb:817:15:817:25 | call to taint :  | hash_flow.rb:816:5:816:9 | hash1 [element :a] :  |
+| hash_flow.rb:819:15:819:25 | call to taint :  | hash_flow.rb:816:5:816:9 | hash1 [element :c] :  |
+| hash_flow.rb:821:5:821:9 | hash2 [element :d] :  | hash_flow.rb:826:30:826:34 | hash2 [element :d] :  |
+| hash_flow.rb:821:5:821:9 | hash2 [element :f] :  | hash_flow.rb:826:30:826:34 | hash2 [element :f] :  |
+| hash_flow.rb:822:15:822:25 | call to taint :  | hash_flow.rb:821:5:821:9 | hash2 [element :d] :  |
+| hash_flow.rb:824:15:824:25 | call to taint :  | hash_flow.rb:821:5:821:9 | hash2 [element :f] :  |
+| hash_flow.rb:826:5:826:8 | hash [element :a] :  | hash_flow.rb:831:11:831:14 | hash [element :a] :  |
+| hash_flow.rb:826:5:826:8 | hash [element :c] :  | hash_flow.rb:833:11:833:14 | hash [element :c] :  |
+| hash_flow.rb:826:5:826:8 | hash [element :d] :  | hash_flow.rb:834:11:834:14 | hash [element :d] :  |
+| hash_flow.rb:826:5:826:8 | hash [element :f] :  | hash_flow.rb:836:11:836:14 | hash [element :f] :  |
 | hash_flow.rb:826:12:826:16 | [post] hash1 [element :a] :  | hash_flow.rb:838:11:838:15 | hash1 [element :a] :  |
 | hash_flow.rb:826:12:826:16 | [post] hash1 [element :c] :  | hash_flow.rb:840:11:840:15 | hash1 [element :c] :  |
 | hash_flow.rb:826:12:826:16 | [post] hash1 [element :d] :  | hash_flow.rb:841:11:841:15 | hash1 [element :d] :  |
@@ -588,10 +751,10 @@ edges
 | hash_flow.rb:826:12:826:16 | hash1 [element :c] :  | hash_flow.rb:826:12:830:7 | call to deep_merge! [element :c] :  |
 | hash_flow.rb:826:12:826:16 | hash1 [element :c] :  | hash_flow.rb:826:46:826:54 | old_value :  |
 | hash_flow.rb:826:12:826:16 | hash1 [element :c] :  | hash_flow.rb:826:57:826:65 | new_value :  |
-| hash_flow.rb:826:12:830:7 | call to deep_merge! [element :a] :  | hash_flow.rb:831:11:831:14 | hash [element :a] :  |
-| hash_flow.rb:826:12:830:7 | call to deep_merge! [element :c] :  | hash_flow.rb:833:11:833:14 | hash [element :c] :  |
-| hash_flow.rb:826:12:830:7 | call to deep_merge! [element :d] :  | hash_flow.rb:834:11:834:14 | hash [element :d] :  |
-| hash_flow.rb:826:12:830:7 | call to deep_merge! [element :f] :  | hash_flow.rb:836:11:836:14 | hash [element :f] :  |
+| hash_flow.rb:826:12:830:7 | call to deep_merge! [element :a] :  | hash_flow.rb:826:5:826:8 | hash [element :a] :  |
+| hash_flow.rb:826:12:830:7 | call to deep_merge! [element :c] :  | hash_flow.rb:826:5:826:8 | hash [element :c] :  |
+| hash_flow.rb:826:12:830:7 | call to deep_merge! [element :d] :  | hash_flow.rb:826:5:826:8 | hash [element :d] :  |
+| hash_flow.rb:826:12:830:7 | call to deep_merge! [element :f] :  | hash_flow.rb:826:5:826:8 | hash [element :f] :  |
 | hash_flow.rb:826:30:826:34 | hash2 [element :d] :  | hash_flow.rb:826:12:826:16 | [post] hash1 [element :d] :  |
 | hash_flow.rb:826:30:826:34 | hash2 [element :d] :  | hash_flow.rb:826:12:830:7 | call to deep_merge! [element :d] :  |
 | hash_flow.rb:826:30:826:34 | hash2 [element :d] :  | hash_flow.rb:826:46:826:54 | old_value :  |
@@ -618,20 +781,28 @@ edges
 | hash_flow.rb:841:11:841:19 | ...[...] :  | hash_flow.rb:841:10:841:20 | ( ... ) |
 | hash_flow.rb:843:11:843:15 | hash1 [element :f] :  | hash_flow.rb:843:11:843:19 | ...[...] :  |
 | hash_flow.rb:843:11:843:19 | ...[...] :  | hash_flow.rb:843:10:843:20 | ( ... ) |
-| hash_flow.rb:850:12:850:22 | call to taint :  | hash_flow.rb:860:13:860:17 | hash1 [element :a] :  |
-| hash_flow.rb:850:12:850:22 | call to taint :  | hash_flow.rb:869:13:869:17 | hash1 [element :a] :  |
-| hash_flow.rb:852:12:852:22 | call to taint :  | hash_flow.rb:860:13:860:17 | hash1 [element :c] :  |
-| hash_flow.rb:852:12:852:22 | call to taint :  | hash_flow.rb:869:13:869:17 | hash1 [element :c] :  |
-| hash_flow.rb:855:12:855:22 | call to taint :  | hash_flow.rb:860:33:860:37 | hash2 [element :d] :  |
-| hash_flow.rb:855:12:855:22 | call to taint :  | hash_flow.rb:869:33:869:37 | hash2 [element :d] :  |
-| hash_flow.rb:857:12:857:22 | call to taint :  | hash_flow.rb:860:33:860:37 | hash2 [element :f] :  |
-| hash_flow.rb:857:12:857:22 | call to taint :  | hash_flow.rb:869:33:869:37 | hash2 [element :f] :  |
+| hash_flow.rb:849:5:849:9 | hash1 [element :a] :  | hash_flow.rb:860:13:860:17 | hash1 [element :a] :  |
+| hash_flow.rb:849:5:849:9 | hash1 [element :a] :  | hash_flow.rb:869:13:869:17 | hash1 [element :a] :  |
+| hash_flow.rb:849:5:849:9 | hash1 [element :c] :  | hash_flow.rb:860:13:860:17 | hash1 [element :c] :  |
+| hash_flow.rb:849:5:849:9 | hash1 [element :c] :  | hash_flow.rb:869:13:869:17 | hash1 [element :c] :  |
+| hash_flow.rb:850:12:850:22 | call to taint :  | hash_flow.rb:849:5:849:9 | hash1 [element :a] :  |
+| hash_flow.rb:852:12:852:22 | call to taint :  | hash_flow.rb:849:5:849:9 | hash1 [element :c] :  |
+| hash_flow.rb:854:5:854:9 | hash2 [element :d] :  | hash_flow.rb:860:33:860:37 | hash2 [element :d] :  |
+| hash_flow.rb:854:5:854:9 | hash2 [element :d] :  | hash_flow.rb:869:33:869:37 | hash2 [element :d] :  |
+| hash_flow.rb:854:5:854:9 | hash2 [element :f] :  | hash_flow.rb:860:33:860:37 | hash2 [element :f] :  |
+| hash_flow.rb:854:5:854:9 | hash2 [element :f] :  | hash_flow.rb:869:33:869:37 | hash2 [element :f] :  |
+| hash_flow.rb:855:12:855:22 | call to taint :  | hash_flow.rb:854:5:854:9 | hash2 [element :d] :  |
+| hash_flow.rb:857:12:857:22 | call to taint :  | hash_flow.rb:854:5:854:9 | hash2 [element :f] :  |
+| hash_flow.rb:860:5:860:9 | hash3 [element :a] :  | hash_flow.rb:861:11:861:15 | hash3 [element :a] :  |
+| hash_flow.rb:860:5:860:9 | hash3 [element :c] :  | hash_flow.rb:863:11:863:15 | hash3 [element :c] :  |
+| hash_flow.rb:860:5:860:9 | hash3 [element :d] :  | hash_flow.rb:864:11:864:15 | hash3 [element :d] :  |
+| hash_flow.rb:860:5:860:9 | hash3 [element :f] :  | hash_flow.rb:866:11:866:15 | hash3 [element :f] :  |
 | hash_flow.rb:860:13:860:17 | hash1 [element :a] :  | hash_flow.rb:860:13:860:38 | call to reverse_merge [element :a] :  |
 | hash_flow.rb:860:13:860:17 | hash1 [element :c] :  | hash_flow.rb:860:13:860:38 | call to reverse_merge [element :c] :  |
-| hash_flow.rb:860:13:860:38 | call to reverse_merge [element :a] :  | hash_flow.rb:861:11:861:15 | hash3 [element :a] :  |
-| hash_flow.rb:860:13:860:38 | call to reverse_merge [element :c] :  | hash_flow.rb:863:11:863:15 | hash3 [element :c] :  |
-| hash_flow.rb:860:13:860:38 | call to reverse_merge [element :d] :  | hash_flow.rb:864:11:864:15 | hash3 [element :d] :  |
-| hash_flow.rb:860:13:860:38 | call to reverse_merge [element :f] :  | hash_flow.rb:866:11:866:15 | hash3 [element :f] :  |
+| hash_flow.rb:860:13:860:38 | call to reverse_merge [element :a] :  | hash_flow.rb:860:5:860:9 | hash3 [element :a] :  |
+| hash_flow.rb:860:13:860:38 | call to reverse_merge [element :c] :  | hash_flow.rb:860:5:860:9 | hash3 [element :c] :  |
+| hash_flow.rb:860:13:860:38 | call to reverse_merge [element :d] :  | hash_flow.rb:860:5:860:9 | hash3 [element :d] :  |
+| hash_flow.rb:860:13:860:38 | call to reverse_merge [element :f] :  | hash_flow.rb:860:5:860:9 | hash3 [element :f] :  |
 | hash_flow.rb:860:33:860:37 | hash2 [element :d] :  | hash_flow.rb:860:13:860:38 | call to reverse_merge [element :d] :  |
 | hash_flow.rb:860:33:860:37 | hash2 [element :f] :  | hash_flow.rb:860:13:860:38 | call to reverse_merge [element :f] :  |
 | hash_flow.rb:861:11:861:15 | hash3 [element :a] :  | hash_flow.rb:861:11:861:19 | ...[...] :  |
@@ -642,12 +813,16 @@ edges
 | hash_flow.rb:864:11:864:19 | ...[...] :  | hash_flow.rb:864:10:864:20 | ( ... ) |
 | hash_flow.rb:866:11:866:15 | hash3 [element :f] :  | hash_flow.rb:866:11:866:19 | ...[...] :  |
 | hash_flow.rb:866:11:866:19 | ...[...] :  | hash_flow.rb:866:10:866:20 | ( ... ) |
+| hash_flow.rb:869:5:869:9 | hash4 [element :a] :  | hash_flow.rb:870:11:870:15 | hash4 [element :a] :  |
+| hash_flow.rb:869:5:869:9 | hash4 [element :c] :  | hash_flow.rb:872:11:872:15 | hash4 [element :c] :  |
+| hash_flow.rb:869:5:869:9 | hash4 [element :d] :  | hash_flow.rb:873:11:873:15 | hash4 [element :d] :  |
+| hash_flow.rb:869:5:869:9 | hash4 [element :f] :  | hash_flow.rb:875:11:875:15 | hash4 [element :f] :  |
 | hash_flow.rb:869:13:869:17 | hash1 [element :a] :  | hash_flow.rb:869:13:869:38 | call to with_defaults [element :a] :  |
 | hash_flow.rb:869:13:869:17 | hash1 [element :c] :  | hash_flow.rb:869:13:869:38 | call to with_defaults [element :c] :  |
-| hash_flow.rb:869:13:869:38 | call to with_defaults [element :a] :  | hash_flow.rb:870:11:870:15 | hash4 [element :a] :  |
-| hash_flow.rb:869:13:869:38 | call to with_defaults [element :c] :  | hash_flow.rb:872:11:872:15 | hash4 [element :c] :  |
-| hash_flow.rb:869:13:869:38 | call to with_defaults [element :d] :  | hash_flow.rb:873:11:873:15 | hash4 [element :d] :  |
-| hash_flow.rb:869:13:869:38 | call to with_defaults [element :f] :  | hash_flow.rb:875:11:875:15 | hash4 [element :f] :  |
+| hash_flow.rb:869:13:869:38 | call to with_defaults [element :a] :  | hash_flow.rb:869:5:869:9 | hash4 [element :a] :  |
+| hash_flow.rb:869:13:869:38 | call to with_defaults [element :c] :  | hash_flow.rb:869:5:869:9 | hash4 [element :c] :  |
+| hash_flow.rb:869:13:869:38 | call to with_defaults [element :d] :  | hash_flow.rb:869:5:869:9 | hash4 [element :d] :  |
+| hash_flow.rb:869:13:869:38 | call to with_defaults [element :f] :  | hash_flow.rb:869:5:869:9 | hash4 [element :f] :  |
 | hash_flow.rb:869:33:869:37 | hash2 [element :d] :  | hash_flow.rb:869:13:869:38 | call to with_defaults [element :d] :  |
 | hash_flow.rb:869:33:869:37 | hash2 [element :f] :  | hash_flow.rb:869:13:869:38 | call to with_defaults [element :f] :  |
 | hash_flow.rb:870:11:870:15 | hash4 [element :a] :  | hash_flow.rb:870:11:870:19 | ...[...] :  |
@@ -658,10 +833,18 @@ edges
 | hash_flow.rb:873:11:873:19 | ...[...] :  | hash_flow.rb:873:10:873:20 | ( ... ) |
 | hash_flow.rb:875:11:875:15 | hash4 [element :f] :  | hash_flow.rb:875:11:875:19 | ...[...] :  |
 | hash_flow.rb:875:11:875:19 | ...[...] :  | hash_flow.rb:875:10:875:20 | ( ... ) |
-| hash_flow.rb:882:12:882:22 | call to taint :  | hash_flow.rb:892:12:892:16 | hash1 [element :a] :  |
-| hash_flow.rb:884:12:884:22 | call to taint :  | hash_flow.rb:892:12:892:16 | hash1 [element :c] :  |
-| hash_flow.rb:887:12:887:22 | call to taint :  | hash_flow.rb:892:33:892:37 | hash2 [element :d] :  |
-| hash_flow.rb:889:12:889:22 | call to taint :  | hash_flow.rb:892:33:892:37 | hash2 [element :f] :  |
+| hash_flow.rb:881:5:881:9 | hash1 [element :a] :  | hash_flow.rb:892:12:892:16 | hash1 [element :a] :  |
+| hash_flow.rb:881:5:881:9 | hash1 [element :c] :  | hash_flow.rb:892:12:892:16 | hash1 [element :c] :  |
+| hash_flow.rb:882:12:882:22 | call to taint :  | hash_flow.rb:881:5:881:9 | hash1 [element :a] :  |
+| hash_flow.rb:884:12:884:22 | call to taint :  | hash_flow.rb:881:5:881:9 | hash1 [element :c] :  |
+| hash_flow.rb:886:5:886:9 | hash2 [element :d] :  | hash_flow.rb:892:33:892:37 | hash2 [element :d] :  |
+| hash_flow.rb:886:5:886:9 | hash2 [element :f] :  | hash_flow.rb:892:33:892:37 | hash2 [element :f] :  |
+| hash_flow.rb:887:12:887:22 | call to taint :  | hash_flow.rb:886:5:886:9 | hash2 [element :d] :  |
+| hash_flow.rb:889:12:889:22 | call to taint :  | hash_flow.rb:886:5:886:9 | hash2 [element :f] :  |
+| hash_flow.rb:892:5:892:8 | hash [element :a] :  | hash_flow.rb:893:11:893:14 | hash [element :a] :  |
+| hash_flow.rb:892:5:892:8 | hash [element :c] :  | hash_flow.rb:895:11:895:14 | hash [element :c] :  |
+| hash_flow.rb:892:5:892:8 | hash [element :d] :  | hash_flow.rb:896:11:896:14 | hash [element :d] :  |
+| hash_flow.rb:892:5:892:8 | hash [element :f] :  | hash_flow.rb:898:11:898:14 | hash [element :f] :  |
 | hash_flow.rb:892:12:892:16 | [post] hash1 [element :a] :  | hash_flow.rb:900:11:900:15 | hash1 [element :a] :  |
 | hash_flow.rb:892:12:892:16 | [post] hash1 [element :c] :  | hash_flow.rb:902:11:902:15 | hash1 [element :c] :  |
 | hash_flow.rb:892:12:892:16 | [post] hash1 [element :d] :  | hash_flow.rb:903:11:903:15 | hash1 [element :d] :  |
@@ -670,10 +853,10 @@ edges
 | hash_flow.rb:892:12:892:16 | hash1 [element :a] :  | hash_flow.rb:892:12:892:38 | call to reverse_merge! [element :a] :  |
 | hash_flow.rb:892:12:892:16 | hash1 [element :c] :  | hash_flow.rb:892:12:892:16 | [post] hash1 [element :c] :  |
 | hash_flow.rb:892:12:892:16 | hash1 [element :c] :  | hash_flow.rb:892:12:892:38 | call to reverse_merge! [element :c] :  |
-| hash_flow.rb:892:12:892:38 | call to reverse_merge! [element :a] :  | hash_flow.rb:893:11:893:14 | hash [element :a] :  |
-| hash_flow.rb:892:12:892:38 | call to reverse_merge! [element :c] :  | hash_flow.rb:895:11:895:14 | hash [element :c] :  |
-| hash_flow.rb:892:12:892:38 | call to reverse_merge! [element :d] :  | hash_flow.rb:896:11:896:14 | hash [element :d] :  |
-| hash_flow.rb:892:12:892:38 | call to reverse_merge! [element :f] :  | hash_flow.rb:898:11:898:14 | hash [element :f] :  |
+| hash_flow.rb:892:12:892:38 | call to reverse_merge! [element :a] :  | hash_flow.rb:892:5:892:8 | hash [element :a] :  |
+| hash_flow.rb:892:12:892:38 | call to reverse_merge! [element :c] :  | hash_flow.rb:892:5:892:8 | hash [element :c] :  |
+| hash_flow.rb:892:12:892:38 | call to reverse_merge! [element :d] :  | hash_flow.rb:892:5:892:8 | hash [element :d] :  |
+| hash_flow.rb:892:12:892:38 | call to reverse_merge! [element :f] :  | hash_flow.rb:892:5:892:8 | hash [element :f] :  |
 | hash_flow.rb:892:33:892:37 | hash2 [element :d] :  | hash_flow.rb:892:12:892:16 | [post] hash1 [element :d] :  |
 | hash_flow.rb:892:33:892:37 | hash2 [element :d] :  | hash_flow.rb:892:12:892:38 | call to reverse_merge! [element :d] :  |
 | hash_flow.rb:892:33:892:37 | hash2 [element :f] :  | hash_flow.rb:892:12:892:16 | [post] hash1 [element :f] :  |
@@ -694,10 +877,18 @@ edges
 | hash_flow.rb:903:11:903:19 | ...[...] :  | hash_flow.rb:903:10:903:20 | ( ... ) |
 | hash_flow.rb:905:11:905:15 | hash1 [element :f] :  | hash_flow.rb:905:11:905:19 | ...[...] :  |
 | hash_flow.rb:905:11:905:19 | ...[...] :  | hash_flow.rb:905:10:905:20 | ( ... ) |
-| hash_flow.rb:912:12:912:22 | call to taint :  | hash_flow.rb:922:12:922:16 | hash1 [element :a] :  |
-| hash_flow.rb:914:12:914:22 | call to taint :  | hash_flow.rb:922:12:922:16 | hash1 [element :c] :  |
-| hash_flow.rb:917:12:917:22 | call to taint :  | hash_flow.rb:922:33:922:37 | hash2 [element :d] :  |
-| hash_flow.rb:919:12:919:22 | call to taint :  | hash_flow.rb:922:33:922:37 | hash2 [element :f] :  |
+| hash_flow.rb:911:5:911:9 | hash1 [element :a] :  | hash_flow.rb:922:12:922:16 | hash1 [element :a] :  |
+| hash_flow.rb:911:5:911:9 | hash1 [element :c] :  | hash_flow.rb:922:12:922:16 | hash1 [element :c] :  |
+| hash_flow.rb:912:12:912:22 | call to taint :  | hash_flow.rb:911:5:911:9 | hash1 [element :a] :  |
+| hash_flow.rb:914:12:914:22 | call to taint :  | hash_flow.rb:911:5:911:9 | hash1 [element :c] :  |
+| hash_flow.rb:916:5:916:9 | hash2 [element :d] :  | hash_flow.rb:922:33:922:37 | hash2 [element :d] :  |
+| hash_flow.rb:916:5:916:9 | hash2 [element :f] :  | hash_flow.rb:922:33:922:37 | hash2 [element :f] :  |
+| hash_flow.rb:917:12:917:22 | call to taint :  | hash_flow.rb:916:5:916:9 | hash2 [element :d] :  |
+| hash_flow.rb:919:12:919:22 | call to taint :  | hash_flow.rb:916:5:916:9 | hash2 [element :f] :  |
+| hash_flow.rb:922:5:922:8 | hash [element :a] :  | hash_flow.rb:923:11:923:14 | hash [element :a] :  |
+| hash_flow.rb:922:5:922:8 | hash [element :c] :  | hash_flow.rb:925:11:925:14 | hash [element :c] :  |
+| hash_flow.rb:922:5:922:8 | hash [element :d] :  | hash_flow.rb:926:11:926:14 | hash [element :d] :  |
+| hash_flow.rb:922:5:922:8 | hash [element :f] :  | hash_flow.rb:928:11:928:14 | hash [element :f] :  |
 | hash_flow.rb:922:12:922:16 | [post] hash1 [element :a] :  | hash_flow.rb:930:11:930:15 | hash1 [element :a] :  |
 | hash_flow.rb:922:12:922:16 | [post] hash1 [element :c] :  | hash_flow.rb:932:11:932:15 | hash1 [element :c] :  |
 | hash_flow.rb:922:12:922:16 | [post] hash1 [element :d] :  | hash_flow.rb:933:11:933:15 | hash1 [element :d] :  |
@@ -706,10 +897,10 @@ edges
 | hash_flow.rb:922:12:922:16 | hash1 [element :a] :  | hash_flow.rb:922:12:922:38 | call to with_defaults! [element :a] :  |
 | hash_flow.rb:922:12:922:16 | hash1 [element :c] :  | hash_flow.rb:922:12:922:16 | [post] hash1 [element :c] :  |
 | hash_flow.rb:922:12:922:16 | hash1 [element :c] :  | hash_flow.rb:922:12:922:38 | call to with_defaults! [element :c] :  |
-| hash_flow.rb:922:12:922:38 | call to with_defaults! [element :a] :  | hash_flow.rb:923:11:923:14 | hash [element :a] :  |
-| hash_flow.rb:922:12:922:38 | call to with_defaults! [element :c] :  | hash_flow.rb:925:11:925:14 | hash [element :c] :  |
-| hash_flow.rb:922:12:922:38 | call to with_defaults! [element :d] :  | hash_flow.rb:926:11:926:14 | hash [element :d] :  |
-| hash_flow.rb:922:12:922:38 | call to with_defaults! [element :f] :  | hash_flow.rb:928:11:928:14 | hash [element :f] :  |
+| hash_flow.rb:922:12:922:38 | call to with_defaults! [element :a] :  | hash_flow.rb:922:5:922:8 | hash [element :a] :  |
+| hash_flow.rb:922:12:922:38 | call to with_defaults! [element :c] :  | hash_flow.rb:922:5:922:8 | hash [element :c] :  |
+| hash_flow.rb:922:12:922:38 | call to with_defaults! [element :d] :  | hash_flow.rb:922:5:922:8 | hash [element :d] :  |
+| hash_flow.rb:922:12:922:38 | call to with_defaults! [element :f] :  | hash_flow.rb:922:5:922:8 | hash [element :f] :  |
 | hash_flow.rb:922:33:922:37 | hash2 [element :d] :  | hash_flow.rb:922:12:922:16 | [post] hash1 [element :d] :  |
 | hash_flow.rb:922:33:922:37 | hash2 [element :d] :  | hash_flow.rb:922:12:922:38 | call to with_defaults! [element :d] :  |
 | hash_flow.rb:922:33:922:37 | hash2 [element :f] :  | hash_flow.rb:922:12:922:16 | [post] hash1 [element :f] :  |
@@ -730,10 +921,18 @@ edges
 | hash_flow.rb:933:11:933:19 | ...[...] :  | hash_flow.rb:933:10:933:20 | ( ... ) |
 | hash_flow.rb:935:11:935:15 | hash1 [element :f] :  | hash_flow.rb:935:11:935:19 | ...[...] :  |
 | hash_flow.rb:935:11:935:19 | ...[...] :  | hash_flow.rb:935:10:935:20 | ( ... ) |
-| hash_flow.rb:942:12:942:22 | call to taint :  | hash_flow.rb:952:12:952:16 | hash1 [element :a] :  |
-| hash_flow.rb:944:12:944:22 | call to taint :  | hash_flow.rb:952:12:952:16 | hash1 [element :c] :  |
-| hash_flow.rb:947:12:947:22 | call to taint :  | hash_flow.rb:952:33:952:37 | hash2 [element :d] :  |
-| hash_flow.rb:949:12:949:22 | call to taint :  | hash_flow.rb:952:33:952:37 | hash2 [element :f] :  |
+| hash_flow.rb:941:5:941:9 | hash1 [element :a] :  | hash_flow.rb:952:12:952:16 | hash1 [element :a] :  |
+| hash_flow.rb:941:5:941:9 | hash1 [element :c] :  | hash_flow.rb:952:12:952:16 | hash1 [element :c] :  |
+| hash_flow.rb:942:12:942:22 | call to taint :  | hash_flow.rb:941:5:941:9 | hash1 [element :a] :  |
+| hash_flow.rb:944:12:944:22 | call to taint :  | hash_flow.rb:941:5:941:9 | hash1 [element :c] :  |
+| hash_flow.rb:946:5:946:9 | hash2 [element :d] :  | hash_flow.rb:952:33:952:37 | hash2 [element :d] :  |
+| hash_flow.rb:946:5:946:9 | hash2 [element :f] :  | hash_flow.rb:952:33:952:37 | hash2 [element :f] :  |
+| hash_flow.rb:947:12:947:22 | call to taint :  | hash_flow.rb:946:5:946:9 | hash2 [element :d] :  |
+| hash_flow.rb:949:12:949:22 | call to taint :  | hash_flow.rb:946:5:946:9 | hash2 [element :f] :  |
+| hash_flow.rb:952:5:952:8 | hash [element :a] :  | hash_flow.rb:953:11:953:14 | hash [element :a] :  |
+| hash_flow.rb:952:5:952:8 | hash [element :c] :  | hash_flow.rb:955:11:955:14 | hash [element :c] :  |
+| hash_flow.rb:952:5:952:8 | hash [element :d] :  | hash_flow.rb:956:11:956:14 | hash [element :d] :  |
+| hash_flow.rb:952:5:952:8 | hash [element :f] :  | hash_flow.rb:958:11:958:14 | hash [element :f] :  |
 | hash_flow.rb:952:12:952:16 | [post] hash1 [element :a] :  | hash_flow.rb:960:11:960:15 | hash1 [element :a] :  |
 | hash_flow.rb:952:12:952:16 | [post] hash1 [element :c] :  | hash_flow.rb:962:11:962:15 | hash1 [element :c] :  |
 | hash_flow.rb:952:12:952:16 | [post] hash1 [element :d] :  | hash_flow.rb:963:11:963:15 | hash1 [element :d] :  |
@@ -742,10 +941,10 @@ edges
 | hash_flow.rb:952:12:952:16 | hash1 [element :a] :  | hash_flow.rb:952:12:952:38 | call to with_defaults! [element :a] :  |
 | hash_flow.rb:952:12:952:16 | hash1 [element :c] :  | hash_flow.rb:952:12:952:16 | [post] hash1 [element :c] :  |
 | hash_flow.rb:952:12:952:16 | hash1 [element :c] :  | hash_flow.rb:952:12:952:38 | call to with_defaults! [element :c] :  |
-| hash_flow.rb:952:12:952:38 | call to with_defaults! [element :a] :  | hash_flow.rb:953:11:953:14 | hash [element :a] :  |
-| hash_flow.rb:952:12:952:38 | call to with_defaults! [element :c] :  | hash_flow.rb:955:11:955:14 | hash [element :c] :  |
-| hash_flow.rb:952:12:952:38 | call to with_defaults! [element :d] :  | hash_flow.rb:956:11:956:14 | hash [element :d] :  |
-| hash_flow.rb:952:12:952:38 | call to with_defaults! [element :f] :  | hash_flow.rb:958:11:958:14 | hash [element :f] :  |
+| hash_flow.rb:952:12:952:38 | call to with_defaults! [element :a] :  | hash_flow.rb:952:5:952:8 | hash [element :a] :  |
+| hash_flow.rb:952:12:952:38 | call to with_defaults! [element :c] :  | hash_flow.rb:952:5:952:8 | hash [element :c] :  |
+| hash_flow.rb:952:12:952:38 | call to with_defaults! [element :d] :  | hash_flow.rb:952:5:952:8 | hash [element :d] :  |
+| hash_flow.rb:952:12:952:38 | call to with_defaults! [element :f] :  | hash_flow.rb:952:5:952:8 | hash [element :f] :  |
 | hash_flow.rb:952:33:952:37 | hash2 [element :d] :  | hash_flow.rb:952:12:952:16 | [post] hash1 [element :d] :  |
 | hash_flow.rb:952:33:952:37 | hash2 [element :d] :  | hash_flow.rb:952:12:952:38 | call to with_defaults! [element :d] :  |
 | hash_flow.rb:952:33:952:37 | hash2 [element :f] :  | hash_flow.rb:952:12:952:16 | [post] hash1 [element :f] :  |
@@ -767,6 +966,11 @@ edges
 | hash_flow.rb:965:11:965:15 | hash1 [element :f] :  | hash_flow.rb:965:11:965:19 | ...[...] :  |
 | hash_flow.rb:965:11:965:19 | ...[...] :  | hash_flow.rb:965:10:965:20 | ( ... ) |
 nodes
+| hash_flow.rb:10:5:10:8 | hash [element 0] :  | semmle.label | hash [element 0] :  |
+| hash_flow.rb:10:5:10:8 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:10:5:10:8 | hash [element :c] :  | semmle.label | hash [element :c] :  |
+| hash_flow.rb:10:5:10:8 | hash [element e] :  | semmle.label | hash [element e] :  |
+| hash_flow.rb:10:5:10:8 | hash [element g] :  | semmle.label | hash [element g] :  |
 | hash_flow.rb:11:15:11:24 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:13:12:13:21 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:15:14:15:23 | call to taint :  | semmle.label | call to taint :  |
@@ -812,50 +1016,64 @@ nodes
 | hash_flow.rb:46:10:46:17 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:48:10:48:13 | hash [element a] :  | semmle.label | hash [element a] :  |
 | hash_flow.rb:48:10:48:18 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:55:5:55:9 | hash1 [element :a] :  | semmle.label | hash1 [element :a] :  |
 | hash_flow.rb:55:13:55:37 | ...[...] [element :a] :  | semmle.label | ...[...] [element :a] :  |
 | hash_flow.rb:55:21:55:30 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:56:10:56:14 | hash1 [element :a] :  | semmle.label | hash1 [element :a] :  |
 | hash_flow.rb:56:10:56:18 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:59:5:59:5 | x [element :a] :  | semmle.label | x [element :a] :  |
 | hash_flow.rb:59:13:59:22 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:60:5:60:9 | hash2 [element :a] :  | semmle.label | hash2 [element :a] :  |
 | hash_flow.rb:60:13:60:19 | ...[...] [element :a] :  | semmle.label | ...[...] [element :a] :  |
 | hash_flow.rb:60:18:60:18 | x [element :a] :  | semmle.label | x [element :a] :  |
 | hash_flow.rb:61:10:61:14 | hash2 [element :a] :  | semmle.label | hash2 [element :a] :  |
 | hash_flow.rb:61:10:61:18 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:64:5:64:9 | hash3 [element] :  | semmle.label | hash3 [element] :  |
 | hash_flow.rb:64:13:64:45 | ...[...] [element] :  | semmle.label | ...[...] [element] :  |
 | hash_flow.rb:64:24:64:33 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:65:10:65:14 | hash3 [element] :  | semmle.label | hash3 [element] :  |
 | hash_flow.rb:65:10:65:18 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:66:10:66:14 | hash3 [element] :  | semmle.label | hash3 [element] :  |
 | hash_flow.rb:66:10:66:18 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:68:5:68:9 | hash4 [element :a] :  | semmle.label | hash4 [element :a] :  |
 | hash_flow.rb:68:13:68:39 | ...[...] [element :a] :  | semmle.label | ...[...] [element :a] :  |
 | hash_flow.rb:68:22:68:31 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:69:10:69:14 | hash4 [element :a] :  | semmle.label | hash4 [element :a] :  |
 | hash_flow.rb:69:10:69:18 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:72:5:72:9 | hash5 [element a] :  | semmle.label | hash5 [element a] :  |
 | hash_flow.rb:72:13:72:45 | ...[...] [element a] :  | semmle.label | ...[...] [element a] :  |
 | hash_flow.rb:72:25:72:34 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:73:10:73:14 | hash5 [element a] :  | semmle.label | hash5 [element a] :  |
 | hash_flow.rb:73:10:73:19 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:76:5:76:9 | hash6 [element a] :  | semmle.label | hash6 [element a] :  |
 | hash_flow.rb:76:13:76:47 | ...[...] [element a] :  | semmle.label | ...[...] [element a] :  |
 | hash_flow.rb:76:26:76:35 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:77:10:77:14 | hash6 [element a] :  | semmle.label | hash6 [element a] :  |
 | hash_flow.rb:77:10:77:19 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:84:5:84:9 | hash1 [element :a] :  | semmle.label | hash1 [element :a] :  |
 | hash_flow.rb:84:13:84:42 | call to [] [element :a] :  | semmle.label | call to [] [element :a] :  |
 | hash_flow.rb:84:26:84:35 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:85:10:85:14 | hash1 [element :a] :  | semmle.label | hash1 [element :a] :  |
 | hash_flow.rb:85:10:85:18 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:92:5:92:8 | hash [element :a] :  | semmle.label | hash [element :a] :  |
 | hash_flow.rb:93:15:93:24 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:96:5:96:9 | hash2 [element :a] :  | semmle.label | hash2 [element :a] :  |
 | hash_flow.rb:96:13:96:34 | call to try_convert [element :a] :  | semmle.label | call to try_convert [element :a] :  |
 | hash_flow.rb:96:30:96:33 | hash [element :a] :  | semmle.label | hash [element :a] :  |
 | hash_flow.rb:97:10:97:14 | hash2 [element :a] :  | semmle.label | hash2 [element :a] :  |
 | hash_flow.rb:97:10:97:18 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:105:5:105:5 | b :  | semmle.label | b :  |
+| hash_flow.rb:105:21:105:30 | __synth__0 :  | semmle.label | __synth__0 :  |
 | hash_flow.rb:105:21:105:30 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:106:10:106:10 | b | semmle.label | b |
+| hash_flow.rb:113:5:113:5 | b :  | semmle.label | b :  |
 | hash_flow.rb:113:9:113:12 | [post] hash [element :a] :  | semmle.label | [post] hash [element :a] :  |
 | hash_flow.rb:113:9:113:34 | call to store :  | semmle.label | call to store :  |
 | hash_flow.rb:113:24:113:33 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:114:10:114:13 | hash [element :a] :  | semmle.label | hash [element :a] :  |
 | hash_flow.rb:114:10:114:17 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:115:10:115:10 | b | semmle.label | b |
+| hash_flow.rb:118:5:118:5 | c :  | semmle.label | c :  |
 | hash_flow.rb:118:9:118:12 | [post] hash [element] :  | semmle.label | [post] hash [element] :  |
 | hash_flow.rb:118:9:118:33 | call to store :  | semmle.label | call to store :  |
 | hash_flow.rb:118:23:118:32 | call to taint :  | semmle.label | call to taint :  |
@@ -864,6 +1082,7 @@ nodes
 | hash_flow.rb:120:10:120:13 | hash [element] :  | semmle.label | hash [element] :  |
 | hash_flow.rb:120:10:120:17 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:121:10:121:10 | c | semmle.label | c |
+| hash_flow.rb:127:5:127:8 | hash [element :a] :  | semmle.label | hash [element :a] :  |
 | hash_flow.rb:128:15:128:24 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:131:5:131:8 | hash [element :a] :  | semmle.label | hash [element :a] :  |
 | hash_flow.rb:131:18:131:29 | key_or_value :  | semmle.label | key_or_value :  |
@@ -871,27 +1090,36 @@ nodes
 | hash_flow.rb:134:5:134:8 | hash [element :a] :  | semmle.label | hash [element :a] :  |
 | hash_flow.rb:134:22:134:26 | value :  | semmle.label | value :  |
 | hash_flow.rb:136:14:136:18 | value | semmle.label | value |
+| hash_flow.rb:143:5:143:8 | hash [element :a] :  | semmle.label | hash [element :a] :  |
 | hash_flow.rb:144:15:144:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:147:5:147:5 | b [element 1] :  | semmle.label | b [element 1] :  |
 | hash_flow.rb:147:9:147:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
 | hash_flow.rb:147:9:147:22 | call to assoc [element 1] :  | semmle.label | call to assoc [element 1] :  |
 | hash_flow.rb:149:10:149:10 | b [element 1] :  | semmle.label | b [element 1] :  |
 | hash_flow.rb:149:10:149:13 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:150:10:150:10 | b [element 1] :  | semmle.label | b [element 1] :  |
 | hash_flow.rb:150:10:150:13 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:151:5:151:5 | c [element 1] :  | semmle.label | c [element 1] :  |
 | hash_flow.rb:151:9:151:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
 | hash_flow.rb:151:9:151:21 | call to assoc [element 1] :  | semmle.label | call to assoc [element 1] :  |
 | hash_flow.rb:152:10:152:10 | c [element 1] :  | semmle.label | c [element 1] :  |
 | hash_flow.rb:152:10:152:13 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:169:5:169:8 | hash [element :a] :  | semmle.label | hash [element :a] :  |
 | hash_flow.rb:170:15:170:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:173:5:173:5 | a [element :a] :  | semmle.label | a [element :a] :  |
 | hash_flow.rb:173:9:173:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
 | hash_flow.rb:173:9:173:20 | call to compact [element :a] :  | semmle.label | call to compact [element :a] :  |
 | hash_flow.rb:174:10:174:10 | a [element :a] :  | semmle.label | a [element :a] :  |
 | hash_flow.rb:174:10:174:14 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:181:5:181:8 | hash [element :a] :  | semmle.label | hash [element :a] :  |
 | hash_flow.rb:182:15:182:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:185:5:185:5 | a :  | semmle.label | a :  |
 | hash_flow.rb:185:9:185:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
 | hash_flow.rb:185:9:185:23 | call to delete :  | semmle.label | call to delete :  |
 | hash_flow.rb:186:10:186:10 | a | semmle.label | a |
+| hash_flow.rb:193:5:193:8 | hash [element :a] :  | semmle.label | hash [element :a] :  |
 | hash_flow.rb:194:15:194:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:197:5:197:5 | a [element :a] :  | semmle.label | a [element :a] :  |
 | hash_flow.rb:197:9:197:12 | [post] hash [element :a] :  | semmle.label | [post] hash [element :a] :  |
 | hash_flow.rb:197:9:197:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
 | hash_flow.rb:197:9:200:7 | call to delete_if [element :a] :  | semmle.label | call to delete_if [element :a] :  |
@@ -901,45 +1129,60 @@ nodes
 | hash_flow.rb:201:10:201:14 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:202:10:202:13 | hash [element :a] :  | semmle.label | hash [element :a] :  |
 | hash_flow.rb:202:10:202:17 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:209:5:209:8 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:209:5:209:8 | hash [element :c, element :d] :  | semmle.label | hash [element :c, element :d] :  |
 | hash_flow.rb:210:15:210:25 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:213:19:213:29 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:217:10:217:13 | hash [element :a] :  | semmle.label | hash [element :a] :  |
 | hash_flow.rb:217:10:217:21 | call to dig | semmle.label | call to dig |
 | hash_flow.rb:219:10:219:13 | hash [element :c, element :d] :  | semmle.label | hash [element :c, element :d] :  |
 | hash_flow.rb:219:10:219:24 | call to dig | semmle.label | call to dig |
+| hash_flow.rb:226:5:226:8 | hash [element :a] :  | semmle.label | hash [element :a] :  |
 | hash_flow.rb:227:15:227:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:230:5:230:5 | x [element :a] :  | semmle.label | x [element :a] :  |
 | hash_flow.rb:230:9:230:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
 | hash_flow.rb:230:9:233:7 | call to each [element :a] :  | semmle.label | call to each [element :a] :  |
 | hash_flow.rb:230:28:230:32 | value :  | semmle.label | value :  |
 | hash_flow.rb:232:14:232:18 | value | semmle.label | value |
 | hash_flow.rb:234:10:234:10 | x [element :a] :  | semmle.label | x [element :a] :  |
 | hash_flow.rb:234:10:234:14 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:241:5:241:8 | hash [element :a] :  | semmle.label | hash [element :a] :  |
 | hash_flow.rb:242:15:242:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:245:5:245:5 | x [element :a] :  | semmle.label | x [element :a] :  |
 | hash_flow.rb:245:9:245:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
 | hash_flow.rb:245:9:247:7 | call to each_key [element :a] :  | semmle.label | call to each_key [element :a] :  |
 | hash_flow.rb:248:10:248:10 | x [element :a] :  | semmle.label | x [element :a] :  |
 | hash_flow.rb:248:10:248:14 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:255:5:255:8 | hash [element :a] :  | semmle.label | hash [element :a] :  |
 | hash_flow.rb:256:15:256:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:259:5:259:5 | x [element :a] :  | semmle.label | x [element :a] :  |
 | hash_flow.rb:259:9:259:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
 | hash_flow.rb:259:9:262:7 | call to each_pair [element :a] :  | semmle.label | call to each_pair [element :a] :  |
 | hash_flow.rb:259:33:259:37 | value :  | semmle.label | value :  |
 | hash_flow.rb:261:14:261:18 | value | semmle.label | value |
 | hash_flow.rb:263:10:263:10 | x [element :a] :  | semmle.label | x [element :a] :  |
 | hash_flow.rb:263:10:263:14 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:270:5:270:8 | hash [element :a] :  | semmle.label | hash [element :a] :  |
 | hash_flow.rb:271:15:271:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:274:5:274:5 | x [element :a] :  | semmle.label | x [element :a] :  |
 | hash_flow.rb:274:9:274:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
 | hash_flow.rb:274:9:276:7 | call to each_value [element :a] :  | semmle.label | call to each_value [element :a] :  |
 | hash_flow.rb:274:29:274:33 | value :  | semmle.label | value :  |
 | hash_flow.rb:275:14:275:18 | value | semmle.label | value |
 | hash_flow.rb:277:10:277:10 | x [element :a] :  | semmle.label | x [element :a] :  |
 | hash_flow.rb:277:10:277:14 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:284:5:284:8 | hash [element :c] :  | semmle.label | hash [element :c] :  |
 | hash_flow.rb:287:15:287:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:290:5:290:5 | x [element :c] :  | semmle.label | x [element :c] :  |
 | hash_flow.rb:290:9:290:12 | hash [element :c] :  | semmle.label | hash [element :c] :  |
 | hash_flow.rb:290:9:290:28 | call to except [element :c] :  | semmle.label | call to except [element :c] :  |
 | hash_flow.rb:293:10:293:10 | x [element :c] :  | semmle.label | x [element :c] :  |
 | hash_flow.rb:293:10:293:14 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:300:5:300:8 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:300:5:300:8 | hash [element :c] :  | semmle.label | hash [element :c] :  |
 | hash_flow.rb:301:15:301:25 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:303:15:303:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:305:5:305:5 | b :  | semmle.label | b :  |
 | hash_flow.rb:305:9:305:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
 | hash_flow.rb:305:9:305:12 | hash [element :c] :  | semmle.label | hash [element :c] :  |
 | hash_flow.rb:305:9:307:7 | call to fetch :  | semmle.label | call to fetch :  |
@@ -947,23 +1190,30 @@ nodes
 | hash_flow.rb:305:37:305:37 | x :  | semmle.label | x :  |
 | hash_flow.rb:306:14:306:14 | x | semmle.label | x |
 | hash_flow.rb:308:10:308:10 | b | semmle.label | b |
+| hash_flow.rb:309:5:309:5 | b :  | semmle.label | b :  |
 | hash_flow.rb:309:9:309:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
 | hash_flow.rb:309:9:309:22 | call to fetch :  | semmle.label | call to fetch :  |
 | hash_flow.rb:310:10:310:10 | b | semmle.label | b |
+| hash_flow.rb:311:5:311:5 | b :  | semmle.label | b :  |
 | hash_flow.rb:311:9:311:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
 | hash_flow.rb:311:9:311:35 | call to fetch :  | semmle.label | call to fetch :  |
 | hash_flow.rb:311:24:311:34 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:312:10:312:10 | b | semmle.label | b |
+| hash_flow.rb:313:5:313:5 | b :  | semmle.label | b :  |
 | hash_flow.rb:313:9:313:35 | call to fetch :  | semmle.label | call to fetch :  |
 | hash_flow.rb:313:24:313:34 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:314:10:314:10 | b | semmle.label | b |
+| hash_flow.rb:315:5:315:5 | b :  | semmle.label | b :  |
 | hash_flow.rb:315:9:315:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
 | hash_flow.rb:315:9:315:12 | hash [element :c] :  | semmle.label | hash [element :c] :  |
 | hash_flow.rb:315:9:315:34 | call to fetch :  | semmle.label | call to fetch :  |
 | hash_flow.rb:315:23:315:33 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:316:10:316:10 | b | semmle.label | b |
+| hash_flow.rb:322:5:322:8 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:322:5:322:8 | hash [element :c] :  | semmle.label | hash [element :c] :  |
 | hash_flow.rb:323:15:323:25 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:325:15:325:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:327:5:327:5 | b [element] :  | semmle.label | b [element] :  |
 | hash_flow.rb:327:9:327:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
 | hash_flow.rb:327:9:327:12 | hash [element :c] :  | semmle.label | hash [element :c] :  |
 | hash_flow.rb:327:9:330:7 | call to fetch_values [element] :  | semmle.label | call to fetch_values [element] :  |
@@ -973,17 +1223,22 @@ nodes
 | hash_flow.rb:329:9:329:19 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:331:10:331:10 | b [element] :  | semmle.label | b [element] :  |
 | hash_flow.rb:331:10:331:13 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:332:5:332:5 | b [element] :  | semmle.label | b [element] :  |
 | hash_flow.rb:332:9:332:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
 | hash_flow.rb:332:9:332:29 | call to fetch_values [element] :  | semmle.label | call to fetch_values [element] :  |
 | hash_flow.rb:333:10:333:10 | b [element] :  | semmle.label | b [element] :  |
 | hash_flow.rb:333:10:333:13 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:334:5:334:5 | b [element] :  | semmle.label | b [element] :  |
 | hash_flow.rb:334:9:334:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
 | hash_flow.rb:334:9:334:12 | hash [element :c] :  | semmle.label | hash [element :c] :  |
 | hash_flow.rb:334:9:334:31 | call to fetch_values [element] :  | semmle.label | call to fetch_values [element] :  |
 | hash_flow.rb:335:10:335:10 | b [element] :  | semmle.label | b [element] :  |
 | hash_flow.rb:335:10:335:13 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:341:5:341:8 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:341:5:341:8 | hash [element :c] :  | semmle.label | hash [element :c] :  |
 | hash_flow.rb:342:15:342:25 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:344:15:344:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:346:5:346:5 | b [element :a] :  | semmle.label | b [element :a] :  |
 | hash_flow.rb:346:9:346:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
 | hash_flow.rb:346:9:346:12 | hash [element :c] :  | semmle.label | hash [element :c] :  |
 | hash_flow.rb:346:9:350:7 | call to filter [element :a] :  | semmle.label | call to filter [element :a] :  |
@@ -992,6 +1247,8 @@ nodes
 | hash_flow.rb:351:10:351:16 | ( ... ) | semmle.label | ( ... ) |
 | hash_flow.rb:351:11:351:11 | b [element :a] :  | semmle.label | b [element :a] :  |
 | hash_flow.rb:351:11:351:15 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:357:5:357:8 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:357:5:357:8 | hash [element :c] :  | semmle.label | hash [element :c] :  |
 | hash_flow.rb:358:15:358:25 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:360:15:360:25 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:362:5:362:8 | [post] hash [element :a] :  | semmle.label | [post] hash [element :a] :  |
@@ -1002,16 +1259,22 @@ nodes
 | hash_flow.rb:367:10:367:19 | ( ... ) | semmle.label | ( ... ) |
 | hash_flow.rb:367:11:367:14 | hash [element :a] :  | semmle.label | hash [element :a] :  |
 | hash_flow.rb:367:11:367:18 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:373:5:373:8 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:373:5:373:8 | hash [element :c] :  | semmle.label | hash [element :c] :  |
 | hash_flow.rb:374:15:374:25 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:376:15:376:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:378:5:378:5 | b [element] :  | semmle.label | b [element] :  |
 | hash_flow.rb:378:9:378:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
 | hash_flow.rb:378:9:378:12 | hash [element :c] :  | semmle.label | hash [element :c] :  |
 | hash_flow.rb:378:9:378:20 | call to flatten [element] :  | semmle.label | call to flatten [element] :  |
 | hash_flow.rb:379:10:379:15 | ( ... ) | semmle.label | ( ... ) |
 | hash_flow.rb:379:11:379:11 | b [element] :  | semmle.label | b [element] :  |
 | hash_flow.rb:379:11:379:14 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:385:5:385:8 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:385:5:385:8 | hash [element :c] :  | semmle.label | hash [element :c] :  |
 | hash_flow.rb:386:15:386:25 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:388:15:388:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:390:5:390:5 | b [element :a] :  | semmle.label | b [element :a] :  |
 | hash_flow.rb:390:9:390:12 | [post] hash [element :a] :  | semmle.label | [post] hash [element :a] :  |
 | hash_flow.rb:390:9:390:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
 | hash_flow.rb:390:9:390:12 | hash [element :c] :  | semmle.label | hash [element :c] :  |
@@ -1024,10 +1287,18 @@ nodes
 | hash_flow.rb:396:10:396:16 | ( ... ) | semmle.label | ( ... ) |
 | hash_flow.rb:396:11:396:11 | b [element :a] :  | semmle.label | b [element :a] :  |
 | hash_flow.rb:396:11:396:15 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:402:5:402:9 | hash1 [element :a] :  | semmle.label | hash1 [element :a] :  |
+| hash_flow.rb:402:5:402:9 | hash1 [element :c] :  | semmle.label | hash1 [element :c] :  |
 | hash_flow.rb:403:15:403:25 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:405:15:405:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:407:5:407:9 | hash2 [element :d] :  | semmle.label | hash2 [element :d] :  |
+| hash_flow.rb:407:5:407:9 | hash2 [element :f] :  | semmle.label | hash2 [element :f] :  |
 | hash_flow.rb:408:15:408:25 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:410:15:410:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:412:5:412:8 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:412:5:412:8 | hash [element :c] :  | semmle.label | hash [element :c] :  |
+| hash_flow.rb:412:5:412:8 | hash [element :d] :  | semmle.label | hash [element :d] :  |
+| hash_flow.rb:412:5:412:8 | hash [element :f] :  | semmle.label | hash [element :f] :  |
 | hash_flow.rb:412:12:412:16 | hash1 [element :a] :  | semmle.label | hash1 [element :a] :  |
 | hash_flow.rb:412:12:412:16 | hash1 [element :c] :  | semmle.label | hash1 [element :c] :  |
 | hash_flow.rb:412:12:416:7 | call to merge [element :a] :  | semmle.label | call to merge [element :a] :  |
@@ -1052,10 +1323,18 @@ nodes
 | hash_flow.rb:422:10:422:19 | ( ... ) | semmle.label | ( ... ) |
 | hash_flow.rb:422:11:422:14 | hash [element :f] :  | semmle.label | hash [element :f] :  |
 | hash_flow.rb:422:11:422:18 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:428:5:428:9 | hash1 [element :a] :  | semmle.label | hash1 [element :a] :  |
+| hash_flow.rb:428:5:428:9 | hash1 [element :c] :  | semmle.label | hash1 [element :c] :  |
 | hash_flow.rb:429:15:429:25 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:431:15:431:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:433:5:433:9 | hash2 [element :d] :  | semmle.label | hash2 [element :d] :  |
+| hash_flow.rb:433:5:433:9 | hash2 [element :f] :  | semmle.label | hash2 [element :f] :  |
 | hash_flow.rb:434:15:434:25 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:436:15:436:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:438:5:438:8 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:438:5:438:8 | hash [element :c] :  | semmle.label | hash [element :c] :  |
+| hash_flow.rb:438:5:438:8 | hash [element :d] :  | semmle.label | hash [element :d] :  |
+| hash_flow.rb:438:5:438:8 | hash [element :f] :  | semmle.label | hash [element :f] :  |
 | hash_flow.rb:438:12:438:16 | [post] hash1 [element :a] :  | semmle.label | [post] hash1 [element :a] :  |
 | hash_flow.rb:438:12:438:16 | [post] hash1 [element :c] :  | semmle.label | [post] hash1 [element :c] :  |
 | hash_flow.rb:438:12:438:16 | [post] hash1 [element :d] :  | semmle.label | [post] hash1 [element :d] :  |
@@ -1096,19 +1375,25 @@ nodes
 | hash_flow.rb:455:10:455:20 | ( ... ) | semmle.label | ( ... ) |
 | hash_flow.rb:455:11:455:15 | hash1 [element :f] :  | semmle.label | hash1 [element :f] :  |
 | hash_flow.rb:455:11:455:19 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:461:5:461:8 | hash [element :a] :  | semmle.label | hash [element :a] :  |
 | hash_flow.rb:462:15:462:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:465:5:465:5 | b [element 1] :  | semmle.label | b [element 1] :  |
 | hash_flow.rb:465:9:465:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
 | hash_flow.rb:465:9:465:22 | call to rassoc [element 1] :  | semmle.label | call to rassoc [element 1] :  |
 | hash_flow.rb:467:10:467:10 | b [element 1] :  | semmle.label | b [element 1] :  |
 | hash_flow.rb:467:10:467:13 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:473:5:473:8 | hash [element :a] :  | semmle.label | hash [element :a] :  |
 | hash_flow.rb:474:15:474:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:477:5:477:5 | b [element :a] :  | semmle.label | b [element :a] :  |
 | hash_flow.rb:477:9:477:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
 | hash_flow.rb:477:9:481:7 | call to reject [element :a] :  | semmle.label | call to reject [element :a] :  |
 | hash_flow.rb:477:29:477:33 | value :  | semmle.label | value :  |
 | hash_flow.rb:479:14:479:18 | value | semmle.label | value |
 | hash_flow.rb:482:10:482:10 | b [element :a] :  | semmle.label | b [element :a] :  |
 | hash_flow.rb:482:10:482:14 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:488:5:488:8 | hash [element :a] :  | semmle.label | hash [element :a] :  |
 | hash_flow.rb:489:15:489:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:492:5:492:5 | b [element :a] :  | semmle.label | b [element :a] :  |
 | hash_flow.rb:492:9:492:12 | [post] hash [element :a] :  | semmle.label | [post] hash [element :a] :  |
 | hash_flow.rb:492:9:492:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
 | hash_flow.rb:492:9:496:7 | call to reject! [element :a] :  | semmle.label | call to reject! [element :a] :  |
@@ -1118,6 +1403,8 @@ nodes
 | hash_flow.rb:497:10:497:14 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:498:10:498:13 | hash [element :a] :  | semmle.label | hash [element :a] :  |
 | hash_flow.rb:498:10:498:17 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:504:5:504:8 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:504:5:504:8 | hash [element :c] :  | semmle.label | hash [element :c] :  |
 | hash_flow.rb:505:15:505:25 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:507:15:507:25 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:512:5:512:9 | [post] hash2 [element :a] :  | semmle.label | [post] hash2 [element :a] :  |
@@ -1130,8 +1417,11 @@ nodes
 | hash_flow.rb:515:10:515:20 | ( ... ) | semmle.label | ( ... ) |
 | hash_flow.rb:515:11:515:15 | hash2 [element :c] :  | semmle.label | hash2 [element :c] :  |
 | hash_flow.rb:515:11:515:19 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:519:5:519:8 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:519:5:519:8 | hash [element :c] :  | semmle.label | hash [element :c] :  |
 | hash_flow.rb:520:15:520:25 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:522:15:522:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:524:5:524:5 | b [element :a] :  | semmle.label | b [element :a] :  |
 | hash_flow.rb:524:9:524:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
 | hash_flow.rb:524:9:524:12 | hash [element :c] :  | semmle.label | hash [element :c] :  |
 | hash_flow.rb:524:9:528:7 | call to select [element :a] :  | semmle.label | call to select [element :a] :  |
@@ -1140,6 +1430,8 @@ nodes
 | hash_flow.rb:529:10:529:16 | ( ... ) | semmle.label | ( ... ) |
 | hash_flow.rb:529:11:529:11 | b [element :a] :  | semmle.label | b [element :a] :  |
 | hash_flow.rb:529:11:529:15 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:535:5:535:8 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:535:5:535:8 | hash [element :c] :  | semmle.label | hash [element :c] :  |
 | hash_flow.rb:536:15:536:25 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:538:15:538:25 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:540:5:540:8 | [post] hash [element :a] :  | semmle.label | [post] hash [element :a] :  |
@@ -1150,8 +1442,11 @@ nodes
 | hash_flow.rb:545:10:545:19 | ( ... ) | semmle.label | ( ... ) |
 | hash_flow.rb:545:11:545:14 | hash [element :a] :  | semmle.label | hash [element :a] :  |
 | hash_flow.rb:545:11:545:18 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:551:5:551:8 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:551:5:551:8 | hash [element :c] :  | semmle.label | hash [element :c] :  |
 | hash_flow.rb:552:15:552:25 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:554:15:554:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:556:5:556:5 | b [element 1] :  | semmle.label | b [element 1] :  |
 | hash_flow.rb:556:9:556:12 | [post] hash [element :a] :  | semmle.label | [post] hash [element :a] :  |
 | hash_flow.rb:556:9:556:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
 | hash_flow.rb:556:9:556:12 | hash [element :c] :  | semmle.label | hash [element :c] :  |
@@ -1162,13 +1457,18 @@ nodes
 | hash_flow.rb:559:10:559:15 | ( ... ) | semmle.label | ( ... ) |
 | hash_flow.rb:559:11:559:11 | b [element 1] :  | semmle.label | b [element 1] :  |
 | hash_flow.rb:559:11:559:14 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:565:5:565:8 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:565:5:565:8 | hash [element :c] :  | semmle.label | hash [element :c] :  |
 | hash_flow.rb:566:15:566:25 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:568:15:568:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:570:5:570:5 | b [element :a] :  | semmle.label | b [element :a] :  |
 | hash_flow.rb:570:9:570:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
 | hash_flow.rb:570:9:570:26 | call to slice [element :a] :  | semmle.label | call to slice [element :a] :  |
 | hash_flow.rb:571:10:571:16 | ( ... ) | semmle.label | ( ... ) |
 | hash_flow.rb:571:11:571:11 | b [element :a] :  | semmle.label | b [element :a] :  |
 | hash_flow.rb:571:11:571:15 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:575:5:575:5 | c [element :a] :  | semmle.label | c [element :a] :  |
+| hash_flow.rb:575:5:575:5 | c [element :c] :  | semmle.label | c [element :c] :  |
 | hash_flow.rb:575:9:575:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
 | hash_flow.rb:575:9:575:12 | hash [element :c] :  | semmle.label | hash [element :c] :  |
 | hash_flow.rb:575:9:575:25 | call to slice [element :a] :  | semmle.label | call to slice [element :a] :  |
@@ -1179,8 +1479,11 @@ nodes
 | hash_flow.rb:578:10:578:16 | ( ... ) | semmle.label | ( ... ) |
 | hash_flow.rb:578:11:578:11 | c [element :c] :  | semmle.label | c [element :c] :  |
 | hash_flow.rb:578:11:578:15 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:584:5:584:8 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:584:5:584:8 | hash [element :c] :  | semmle.label | hash [element :c] :  |
 | hash_flow.rb:585:15:585:25 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:587:15:587:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:589:5:589:5 | a [element, element 1] :  | semmle.label | a [element, element 1] :  |
 | hash_flow.rb:589:9:589:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
 | hash_flow.rb:589:9:589:12 | hash [element :c] :  | semmle.label | hash [element :c] :  |
 | hash_flow.rb:589:9:589:17 | call to to_a [element, element 1] :  | semmle.label | call to to_a [element, element 1] :  |
@@ -1188,8 +1491,12 @@ nodes
 | hash_flow.rb:591:11:591:11 | a [element, element 1] :  | semmle.label | a [element, element 1] :  |
 | hash_flow.rb:591:11:591:14 | ...[...] [element 1] :  | semmle.label | ...[...] [element 1] :  |
 | hash_flow.rb:591:11:591:17 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:597:5:597:8 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:597:5:597:8 | hash [element :c] :  | semmle.label | hash [element :c] :  |
 | hash_flow.rb:598:15:598:25 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:600:15:600:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:602:5:602:5 | a [element :a] :  | semmle.label | a [element :a] :  |
+| hash_flow.rb:602:5:602:5 | a [element :c] :  | semmle.label | a [element :c] :  |
 | hash_flow.rb:602:9:602:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
 | hash_flow.rb:602:9:602:12 | hash [element :c] :  | semmle.label | hash [element :c] :  |
 | hash_flow.rb:602:9:602:17 | call to to_h [element :a] :  | semmle.label | call to to_h [element :a] :  |
@@ -1200,6 +1507,7 @@ nodes
 | hash_flow.rb:605:10:605:16 | ( ... ) | semmle.label | ( ... ) |
 | hash_flow.rb:605:11:605:11 | a [element :c] :  | semmle.label | a [element :c] :  |
 | hash_flow.rb:605:11:605:15 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:607:5:607:5 | b [element] :  | semmle.label | b [element] :  |
 | hash_flow.rb:607:9:607:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
 | hash_flow.rb:607:9:607:12 | hash [element :c] :  | semmle.label | hash [element :c] :  |
 | hash_flow.rb:607:9:611:7 | call to to_h [element] :  | semmle.label | call to to_h [element] :  |
@@ -1209,8 +1517,11 @@ nodes
 | hash_flow.rb:612:10:612:16 | ( ... ) | semmle.label | ( ... ) |
 | hash_flow.rb:612:11:612:11 | b [element] :  | semmle.label | b [element] :  |
 | hash_flow.rb:612:11:612:15 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:618:5:618:8 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:618:5:618:8 | hash [element :c] :  | semmle.label | hash [element :c] :  |
 | hash_flow.rb:619:15:619:25 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:621:15:621:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:623:5:623:5 | a [element] :  | semmle.label | a [element] :  |
 | hash_flow.rb:623:9:623:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
 | hash_flow.rb:623:9:623:12 | hash [element :c] :  | semmle.label | hash [element :c] :  |
 | hash_flow.rb:623:9:623:45 | call to transform_keys [element] :  | semmle.label | call to transform_keys [element] :  |
@@ -1223,6 +1534,8 @@ nodes
 | hash_flow.rb:626:10:626:17 | ( ... ) | semmle.label | ( ... ) |
 | hash_flow.rb:626:11:626:11 | a [element] :  | semmle.label | a [element] :  |
 | hash_flow.rb:626:11:626:16 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:632:5:632:8 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:632:5:632:8 | hash [element :c] :  | semmle.label | hash [element :c] :  |
 | hash_flow.rb:633:15:633:25 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:635:15:635:25 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:637:5:637:8 | [post] hash [element] :  | semmle.label | [post] hash [element] :  |
@@ -1240,8 +1553,11 @@ nodes
 | hash_flow.rb:642:10:642:20 | ( ... ) | semmle.label | ( ... ) |
 | hash_flow.rb:642:11:642:14 | hash [element] :  | semmle.label | hash [element] :  |
 | hash_flow.rb:642:11:642:19 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:648:5:648:8 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:648:5:648:8 | hash [element :c] :  | semmle.label | hash [element :c] :  |
 | hash_flow.rb:649:15:649:25 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:651:15:651:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:653:5:653:5 | b [element] :  | semmle.label | b [element] :  |
 | hash_flow.rb:653:9:653:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
 | hash_flow.rb:653:9:653:12 | hash [element :c] :  | semmle.label | hash [element :c] :  |
 | hash_flow.rb:653:9:656:7 | call to transform_values [element] :  | semmle.label | call to transform_values [element] :  |
@@ -1254,6 +1570,8 @@ nodes
 | hash_flow.rb:658:10:658:16 | ( ... ) | semmle.label | ( ... ) |
 | hash_flow.rb:658:11:658:11 | b [element] :  | semmle.label | b [element] :  |
 | hash_flow.rb:658:11:658:15 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:664:5:664:8 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:664:5:664:8 | hash [element :c] :  | semmle.label | hash [element :c] :  |
 | hash_flow.rb:665:15:665:25 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:667:15:667:25 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:669:5:669:8 | [post] hash [element] :  | semmle.label | [post] hash [element] :  |
@@ -1265,10 +1583,18 @@ nodes
 | hash_flow.rb:673:10:673:19 | ( ... ) | semmle.label | ( ... ) |
 | hash_flow.rb:673:11:673:14 | hash [element] :  | semmle.label | hash [element] :  |
 | hash_flow.rb:673:11:673:18 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:679:5:679:9 | hash1 [element :a] :  | semmle.label | hash1 [element :a] :  |
+| hash_flow.rb:679:5:679:9 | hash1 [element :c] :  | semmle.label | hash1 [element :c] :  |
 | hash_flow.rb:680:15:680:25 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:682:15:682:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:684:5:684:9 | hash2 [element :d] :  | semmle.label | hash2 [element :d] :  |
+| hash_flow.rb:684:5:684:9 | hash2 [element :f] :  | semmle.label | hash2 [element :f] :  |
 | hash_flow.rb:685:15:685:25 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:687:15:687:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:689:5:689:8 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:689:5:689:8 | hash [element :c] :  | semmle.label | hash [element :c] :  |
+| hash_flow.rb:689:5:689:8 | hash [element :d] :  | semmle.label | hash [element :d] :  |
+| hash_flow.rb:689:5:689:8 | hash [element :f] :  | semmle.label | hash [element :f] :  |
 | hash_flow.rb:689:12:689:16 | [post] hash1 [element :a] :  | semmle.label | [post] hash1 [element :a] :  |
 | hash_flow.rb:689:12:689:16 | [post] hash1 [element :c] :  | semmle.label | [post] hash1 [element :c] :  |
 | hash_flow.rb:689:12:689:16 | [post] hash1 [element :d] :  | semmle.label | [post] hash1 [element :d] :  |
@@ -1309,29 +1635,45 @@ nodes
 | hash_flow.rb:706:10:706:20 | ( ... ) | semmle.label | ( ... ) |
 | hash_flow.rb:706:11:706:15 | hash1 [element :f] :  | semmle.label | hash1 [element :f] :  |
 | hash_flow.rb:706:11:706:19 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:712:5:712:8 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:712:5:712:8 | hash [element :c] :  | semmle.label | hash [element :c] :  |
 | hash_flow.rb:713:15:713:25 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:715:15:715:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:717:5:717:5 | a [element] :  | semmle.label | a [element] :  |
 | hash_flow.rb:717:9:717:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
 | hash_flow.rb:717:9:717:12 | hash [element :c] :  | semmle.label | hash [element :c] :  |
 | hash_flow.rb:717:9:717:19 | call to values [element] :  | semmle.label | call to values [element] :  |
 | hash_flow.rb:718:10:718:15 | ( ... ) | semmle.label | ( ... ) |
 | hash_flow.rb:718:11:718:11 | a [element] :  | semmle.label | a [element] :  |
 | hash_flow.rb:718:11:718:14 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:724:5:724:8 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:724:5:724:8 | hash [element :c] :  | semmle.label | hash [element :c] :  |
 | hash_flow.rb:725:15:725:25 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:727:15:727:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:729:5:729:5 | b [element 0] :  | semmle.label | b [element 0] :  |
 | hash_flow.rb:729:9:729:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
 | hash_flow.rb:729:9:729:26 | call to values_at [element 0] :  | semmle.label | call to values_at [element 0] :  |
 | hash_flow.rb:730:10:730:10 | b [element 0] :  | semmle.label | b [element 0] :  |
 | hash_flow.rb:730:10:730:13 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:731:5:731:5 | b [element] :  | semmle.label | b [element] :  |
 | hash_flow.rb:731:9:731:12 | hash [element :a] :  | semmle.label | hash [element :a] :  |
 | hash_flow.rb:731:9:731:12 | hash [element :c] :  | semmle.label | hash [element :c] :  |
 | hash_flow.rb:731:9:731:31 | call to fetch_values [element] :  | semmle.label | call to fetch_values [element] :  |
 | hash_flow.rb:732:10:732:10 | b [element] :  | semmle.label | b [element] :  |
 | hash_flow.rb:732:10:732:13 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:738:5:738:9 | hash1 [element :a] :  | semmle.label | hash1 [element :a] :  |
+| hash_flow.rb:738:5:738:9 | hash1 [element :c] :  | semmle.label | hash1 [element :c] :  |
 | hash_flow.rb:739:15:739:25 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:741:15:741:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:743:5:743:9 | hash2 [element :d] :  | semmle.label | hash2 [element :d] :  |
+| hash_flow.rb:743:5:743:9 | hash2 [element :f] :  | semmle.label | hash2 [element :f] :  |
 | hash_flow.rb:744:15:744:25 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:746:15:746:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:748:5:748:8 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:748:5:748:8 | hash [element :c] :  | semmle.label | hash [element :c] :  |
+| hash_flow.rb:748:5:748:8 | hash [element :d] :  | semmle.label | hash [element :d] :  |
+| hash_flow.rb:748:5:748:8 | hash [element :f] :  | semmle.label | hash [element :f] :  |
+| hash_flow.rb:748:5:748:8 | hash [element :g] :  | semmle.label | hash [element :g] :  |
 | hash_flow.rb:748:14:748:20 | ** ... [element :a] :  | semmle.label | ** ... [element :a] :  |
 | hash_flow.rb:748:14:748:20 | ** ... [element :c] :  | semmle.label | ** ... [element :c] :  |
 | hash_flow.rb:748:16:748:20 | hash1 [element :a] :  | semmle.label | hash1 [element :a] :  |
@@ -1351,6 +1693,9 @@ nodes
 | hash_flow.rb:754:10:754:17 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:755:10:755:13 | hash [element :g] :  | semmle.label | hash [element :g] :  |
 | hash_flow.rb:755:10:755:17 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:762:5:762:8 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:762:5:762:8 | hash [element :c] :  | semmle.label | hash [element :c] :  |
+| hash_flow.rb:762:5:762:8 | hash [element :d] :  | semmle.label | hash [element :d] :  |
 | hash_flow.rb:763:15:763:25 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:765:15:765:25 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:766:15:766:25 | call to taint :  | semmle.label | call to taint :  |
@@ -1360,6 +1705,7 @@ nodes
 | hash_flow.rb:771:10:771:17 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:772:10:772:13 | hash [element :d] :  | semmle.label | hash [element :d] :  |
 | hash_flow.rb:772:10:772:17 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:774:5:774:5 | x [element :c] :  | semmle.label | x [element :c] :  |
 | hash_flow.rb:774:9:774:12 | [post] hash [element :c] :  | semmle.label | [post] hash [element :c] :  |
 | hash_flow.rb:774:9:774:12 | hash [element :c] :  | semmle.label | hash [element :c] :  |
 | hash_flow.rb:774:9:774:31 | call to except! [element :c] :  | semmle.label | call to except! [element :c] :  |
@@ -1367,10 +1713,18 @@ nodes
 | hash_flow.rb:778:10:778:14 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:783:10:783:13 | hash [element :c] :  | semmle.label | hash [element :c] :  |
 | hash_flow.rb:783:10:783:17 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:790:5:790:9 | hash1 [element :a] :  | semmle.label | hash1 [element :a] :  |
+| hash_flow.rb:790:5:790:9 | hash1 [element :c] :  | semmle.label | hash1 [element :c] :  |
 | hash_flow.rb:791:15:791:25 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:793:15:793:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:795:5:795:9 | hash2 [element :d] :  | semmle.label | hash2 [element :d] :  |
+| hash_flow.rb:795:5:795:9 | hash2 [element :f] :  | semmle.label | hash2 [element :f] :  |
 | hash_flow.rb:796:15:796:25 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:798:15:798:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:800:5:800:8 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:800:5:800:8 | hash [element :c] :  | semmle.label | hash [element :c] :  |
+| hash_flow.rb:800:5:800:8 | hash [element :d] :  | semmle.label | hash [element :d] :  |
+| hash_flow.rb:800:5:800:8 | hash [element :f] :  | semmle.label | hash [element :f] :  |
 | hash_flow.rb:800:12:800:16 | hash1 [element :a] :  | semmle.label | hash1 [element :a] :  |
 | hash_flow.rb:800:12:800:16 | hash1 [element :c] :  | semmle.label | hash1 [element :c] :  |
 | hash_flow.rb:800:12:804:7 | call to deep_merge [element :a] :  | semmle.label | call to deep_merge [element :a] :  |
@@ -1395,10 +1749,18 @@ nodes
 | hash_flow.rb:810:10:810:19 | ( ... ) | semmle.label | ( ... ) |
 | hash_flow.rb:810:11:810:14 | hash [element :f] :  | semmle.label | hash [element :f] :  |
 | hash_flow.rb:810:11:810:18 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:816:5:816:9 | hash1 [element :a] :  | semmle.label | hash1 [element :a] :  |
+| hash_flow.rb:816:5:816:9 | hash1 [element :c] :  | semmle.label | hash1 [element :c] :  |
 | hash_flow.rb:817:15:817:25 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:819:15:819:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:821:5:821:9 | hash2 [element :d] :  | semmle.label | hash2 [element :d] :  |
+| hash_flow.rb:821:5:821:9 | hash2 [element :f] :  | semmle.label | hash2 [element :f] :  |
 | hash_flow.rb:822:15:822:25 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:824:15:824:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:826:5:826:8 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:826:5:826:8 | hash [element :c] :  | semmle.label | hash [element :c] :  |
+| hash_flow.rb:826:5:826:8 | hash [element :d] :  | semmle.label | hash [element :d] :  |
+| hash_flow.rb:826:5:826:8 | hash [element :f] :  | semmle.label | hash [element :f] :  |
 | hash_flow.rb:826:12:826:16 | [post] hash1 [element :a] :  | semmle.label | [post] hash1 [element :a] :  |
 | hash_flow.rb:826:12:826:16 | [post] hash1 [element :c] :  | semmle.label | [post] hash1 [element :c] :  |
 | hash_flow.rb:826:12:826:16 | [post] hash1 [element :d] :  | semmle.label | [post] hash1 [element :d] :  |
@@ -1439,10 +1801,18 @@ nodes
 | hash_flow.rb:843:10:843:20 | ( ... ) | semmle.label | ( ... ) |
 | hash_flow.rb:843:11:843:15 | hash1 [element :f] :  | semmle.label | hash1 [element :f] :  |
 | hash_flow.rb:843:11:843:19 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:849:5:849:9 | hash1 [element :a] :  | semmle.label | hash1 [element :a] :  |
+| hash_flow.rb:849:5:849:9 | hash1 [element :c] :  | semmle.label | hash1 [element :c] :  |
 | hash_flow.rb:850:12:850:22 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:852:12:852:22 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:854:5:854:9 | hash2 [element :d] :  | semmle.label | hash2 [element :d] :  |
+| hash_flow.rb:854:5:854:9 | hash2 [element :f] :  | semmle.label | hash2 [element :f] :  |
 | hash_flow.rb:855:12:855:22 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:857:12:857:22 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:860:5:860:9 | hash3 [element :a] :  | semmle.label | hash3 [element :a] :  |
+| hash_flow.rb:860:5:860:9 | hash3 [element :c] :  | semmle.label | hash3 [element :c] :  |
+| hash_flow.rb:860:5:860:9 | hash3 [element :d] :  | semmle.label | hash3 [element :d] :  |
+| hash_flow.rb:860:5:860:9 | hash3 [element :f] :  | semmle.label | hash3 [element :f] :  |
 | hash_flow.rb:860:13:860:17 | hash1 [element :a] :  | semmle.label | hash1 [element :a] :  |
 | hash_flow.rb:860:13:860:17 | hash1 [element :c] :  | semmle.label | hash1 [element :c] :  |
 | hash_flow.rb:860:13:860:38 | call to reverse_merge [element :a] :  | semmle.label | call to reverse_merge [element :a] :  |
@@ -1463,6 +1833,10 @@ nodes
 | hash_flow.rb:866:10:866:20 | ( ... ) | semmle.label | ( ... ) |
 | hash_flow.rb:866:11:866:15 | hash3 [element :f] :  | semmle.label | hash3 [element :f] :  |
 | hash_flow.rb:866:11:866:19 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:869:5:869:9 | hash4 [element :a] :  | semmle.label | hash4 [element :a] :  |
+| hash_flow.rb:869:5:869:9 | hash4 [element :c] :  | semmle.label | hash4 [element :c] :  |
+| hash_flow.rb:869:5:869:9 | hash4 [element :d] :  | semmle.label | hash4 [element :d] :  |
+| hash_flow.rb:869:5:869:9 | hash4 [element :f] :  | semmle.label | hash4 [element :f] :  |
 | hash_flow.rb:869:13:869:17 | hash1 [element :a] :  | semmle.label | hash1 [element :a] :  |
 | hash_flow.rb:869:13:869:17 | hash1 [element :c] :  | semmle.label | hash1 [element :c] :  |
 | hash_flow.rb:869:13:869:38 | call to with_defaults [element :a] :  | semmle.label | call to with_defaults [element :a] :  |
@@ -1483,10 +1857,18 @@ nodes
 | hash_flow.rb:875:10:875:20 | ( ... ) | semmle.label | ( ... ) |
 | hash_flow.rb:875:11:875:15 | hash4 [element :f] :  | semmle.label | hash4 [element :f] :  |
 | hash_flow.rb:875:11:875:19 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:881:5:881:9 | hash1 [element :a] :  | semmle.label | hash1 [element :a] :  |
+| hash_flow.rb:881:5:881:9 | hash1 [element :c] :  | semmle.label | hash1 [element :c] :  |
 | hash_flow.rb:882:12:882:22 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:884:12:884:22 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:886:5:886:9 | hash2 [element :d] :  | semmle.label | hash2 [element :d] :  |
+| hash_flow.rb:886:5:886:9 | hash2 [element :f] :  | semmle.label | hash2 [element :f] :  |
 | hash_flow.rb:887:12:887:22 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:889:12:889:22 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:892:5:892:8 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:892:5:892:8 | hash [element :c] :  | semmle.label | hash [element :c] :  |
+| hash_flow.rb:892:5:892:8 | hash [element :d] :  | semmle.label | hash [element :d] :  |
+| hash_flow.rb:892:5:892:8 | hash [element :f] :  | semmle.label | hash [element :f] :  |
 | hash_flow.rb:892:12:892:16 | [post] hash1 [element :a] :  | semmle.label | [post] hash1 [element :a] :  |
 | hash_flow.rb:892:12:892:16 | [post] hash1 [element :c] :  | semmle.label | [post] hash1 [element :c] :  |
 | hash_flow.rb:892:12:892:16 | [post] hash1 [element :d] :  | semmle.label | [post] hash1 [element :d] :  |
@@ -1523,10 +1905,18 @@ nodes
 | hash_flow.rb:905:10:905:20 | ( ... ) | semmle.label | ( ... ) |
 | hash_flow.rb:905:11:905:15 | hash1 [element :f] :  | semmle.label | hash1 [element :f] :  |
 | hash_flow.rb:905:11:905:19 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:911:5:911:9 | hash1 [element :a] :  | semmle.label | hash1 [element :a] :  |
+| hash_flow.rb:911:5:911:9 | hash1 [element :c] :  | semmle.label | hash1 [element :c] :  |
 | hash_flow.rb:912:12:912:22 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:914:12:914:22 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:916:5:916:9 | hash2 [element :d] :  | semmle.label | hash2 [element :d] :  |
+| hash_flow.rb:916:5:916:9 | hash2 [element :f] :  | semmle.label | hash2 [element :f] :  |
 | hash_flow.rb:917:12:917:22 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:919:12:919:22 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:922:5:922:8 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:922:5:922:8 | hash [element :c] :  | semmle.label | hash [element :c] :  |
+| hash_flow.rb:922:5:922:8 | hash [element :d] :  | semmle.label | hash [element :d] :  |
+| hash_flow.rb:922:5:922:8 | hash [element :f] :  | semmle.label | hash [element :f] :  |
 | hash_flow.rb:922:12:922:16 | [post] hash1 [element :a] :  | semmle.label | [post] hash1 [element :a] :  |
 | hash_flow.rb:922:12:922:16 | [post] hash1 [element :c] :  | semmle.label | [post] hash1 [element :c] :  |
 | hash_flow.rb:922:12:922:16 | [post] hash1 [element :d] :  | semmle.label | [post] hash1 [element :d] :  |
@@ -1563,10 +1953,18 @@ nodes
 | hash_flow.rb:935:10:935:20 | ( ... ) | semmle.label | ( ... ) |
 | hash_flow.rb:935:11:935:15 | hash1 [element :f] :  | semmle.label | hash1 [element :f] :  |
 | hash_flow.rb:935:11:935:19 | ...[...] :  | semmle.label | ...[...] :  |
+| hash_flow.rb:941:5:941:9 | hash1 [element :a] :  | semmle.label | hash1 [element :a] :  |
+| hash_flow.rb:941:5:941:9 | hash1 [element :c] :  | semmle.label | hash1 [element :c] :  |
 | hash_flow.rb:942:12:942:22 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:944:12:944:22 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:946:5:946:9 | hash2 [element :d] :  | semmle.label | hash2 [element :d] :  |
+| hash_flow.rb:946:5:946:9 | hash2 [element :f] :  | semmle.label | hash2 [element :f] :  |
 | hash_flow.rb:947:12:947:22 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:949:12:949:22 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:952:5:952:8 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:952:5:952:8 | hash [element :c] :  | semmle.label | hash [element :c] :  |
+| hash_flow.rb:952:5:952:8 | hash [element :d] :  | semmle.label | hash [element :d] :  |
+| hash_flow.rb:952:5:952:8 | hash [element :f] :  | semmle.label | hash [element :f] :  |
 | hash_flow.rb:952:12:952:16 | [post] hash1 [element :a] :  | semmle.label | [post] hash1 [element :a] :  |
 | hash_flow.rb:952:12:952:16 | [post] hash1 [element :c] :  | semmle.label | [post] hash1 [element :c] :  |
 | hash_flow.rb:952:12:952:16 | [post] hash1 [element :d] :  | semmle.label | [post] hash1 [element :d] :  |

--- a/ruby/ql/test/library-tests/dataflow/local/DataflowStep.expected
+++ b/ruby/ql/test/library-tests/dataflow/local/DataflowStep.expected
@@ -1,107 +1,107 @@
 | UseUseExplosion.rb:18:5:22:7 | self (m) | UseUseExplosion.rb:20:13:20:17 | self |
 | UseUseExplosion.rb:18:5:22:7 | self in m | UseUseExplosion.rb:18:5:22:7 | self (m) |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2081:20:2116 | SSA phi read(x) |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2111:20:2111 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2127:20:2127 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2143:20:2143 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2159:20:2159 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2175:20:2175 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2191:20:2191 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2207:20:2207 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2223:20:2223 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2239:20:2239 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2255:20:2255 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2271:20:2271 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2287:20:2287 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2303:20:2303 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2319:20:2319 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2335:20:2335 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2351:20:2351 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2367:20:2367 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2383:20:2383 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2399:20:2399 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2415:20:2415 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2431:20:2431 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2447:20:2447 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2463:20:2463 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2479:20:2479 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2495:20:2495 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2511:20:2511 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2527:20:2527 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2543:20:2543 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2559:20:2559 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2575:20:2575 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2591:20:2591 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2607:20:2607 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2623:20:2623 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2639:20:2639 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2655:20:2655 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2671:20:2671 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2687:20:2687 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2703:20:2703 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2719:20:2719 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2735:20:2735 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2751:20:2751 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2767:20:2767 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2783:20:2783 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2799:20:2799 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2815:20:2815 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2831:20:2831 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2847:20:2847 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2863:20:2863 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2879:20:2879 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2895:20:2895 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2911:20:2911 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2927:20:2927 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2943:20:2943 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2959:20:2959 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2975:20:2975 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2991:20:2991 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3007:20:3007 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3023:20:3023 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3039:20:3039 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3055:20:3055 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3071:20:3071 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3087:20:3087 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3103:20:3103 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3119:20:3119 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3135:20:3135 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3151:20:3151 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3167:20:3167 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3183:20:3183 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3199:20:3199 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3215:20:3215 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3231:20:3231 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3247:20:3247 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3263:20:3263 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3279:20:3279 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3295:20:3295 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3311:20:3311 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3327:20:3327 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3343:20:3343 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3359:20:3359 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3375:20:3375 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3391:20:3391 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3407:20:3407 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3423:20:3423 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3439:20:3439 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3455:20:3455 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3471:20:3471 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3487:20:3487 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3503:20:3503 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3519:20:3519 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3535:20:3535 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3551:20:3551 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3567:20:3567 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3583:20:3583 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3599:20:3599 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3615:20:3615 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3631:20:3631 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3647:20:3647 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3663:20:3663 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3679:20:3679 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3695:20:3695 | x |
-| UseUseExplosion.rb:19:13:19:13 | 0 | UseUseExplosion.rb:19:9:19:13 | ... = ... |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2081:20:2116 | SSA phi read(x) |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2111:20:2111 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2127:20:2127 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2143:20:2143 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2159:20:2159 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2175:20:2175 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2191:20:2191 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2207:20:2207 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2223:20:2223 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2239:20:2239 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2255:20:2255 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2271:20:2271 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2287:20:2287 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2303:20:2303 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2319:20:2319 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2335:20:2335 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2351:20:2351 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2367:20:2367 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2383:20:2383 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2399:20:2399 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2415:20:2415 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2431:20:2431 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2447:20:2447 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2463:20:2463 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2479:20:2479 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2495:20:2495 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2511:20:2511 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2527:20:2527 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2543:20:2543 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2559:20:2559 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2575:20:2575 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2591:20:2591 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2607:20:2607 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2623:20:2623 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2639:20:2639 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2655:20:2655 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2671:20:2671 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2687:20:2687 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2703:20:2703 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2719:20:2719 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2735:20:2735 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2751:20:2751 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2767:20:2767 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2783:20:2783 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2799:20:2799 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2815:20:2815 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2831:20:2831 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2847:20:2847 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2863:20:2863 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2879:20:2879 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2895:20:2895 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2911:20:2911 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2927:20:2927 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2943:20:2943 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2959:20:2959 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2975:20:2975 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2991:20:2991 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3007:20:3007 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3023:20:3023 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3039:20:3039 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3055:20:3055 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3071:20:3071 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3087:20:3087 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3103:20:3103 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3119:20:3119 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3135:20:3135 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3151:20:3151 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3167:20:3167 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3183:20:3183 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3199:20:3199 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3215:20:3215 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3231:20:3231 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3247:20:3247 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3263:20:3263 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3279:20:3279 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3295:20:3295 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3311:20:3311 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3327:20:3327 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3343:20:3343 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3359:20:3359 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3375:20:3375 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3391:20:3391 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3407:20:3407 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3423:20:3423 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3439:20:3439 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3455:20:3455 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3471:20:3471 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3487:20:3487 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3503:20:3503 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3519:20:3519 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3535:20:3535 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3551:20:3551 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3567:20:3567 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3583:20:3583 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3599:20:3599 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3615:20:3615 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3631:20:3631 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3647:20:3647 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3663:20:3663 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3679:20:3679 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3695:20:3695 | x |
+| UseUseExplosion.rb:19:13:19:13 | 0 | UseUseExplosion.rb:19:9:19:9 | x |
 | UseUseExplosion.rb:19:13:19:13 | 0 | UseUseExplosion.rb:19:9:19:13 | ... = ... |
 | UseUseExplosion.rb:20:9:20:3700 | SSA phi read(self) | UseUseExplosion.rb:21:13:21:17 | self |
 | UseUseExplosion.rb:20:9:20:3700 | SSA phi read(x) | UseUseExplosion.rb:21:2111:21:2111 | x |
@@ -2402,8 +2402,8 @@
 | local_dataflow.rb:1:1:150:3 | self (local_dataflow.rb) | local_dataflow.rb:49:1:53:3 | self |
 | local_dataflow.rb:1:9:1:9 | a | local_dataflow.rb:1:9:1:9 | a |
 | local_dataflow.rb:1:9:1:9 | a | local_dataflow.rb:2:7:2:7 | a |
-| local_dataflow.rb:2:3:2:7 | ... = ... | local_dataflow.rb:3:13:3:13 | b |
-| local_dataflow.rb:2:7:2:7 | a | local_dataflow.rb:2:3:2:7 | ... = ... |
+| local_dataflow.rb:2:3:2:3 | b | local_dataflow.rb:3:13:3:13 | b |
+| local_dataflow.rb:2:7:2:7 | a | local_dataflow.rb:2:3:2:3 | b |
 | local_dataflow.rb:2:7:2:7 | a | local_dataflow.rb:2:3:2:7 | ... = ... |
 | local_dataflow.rb:2:7:2:7 | a | local_dataflow.rb:3:10:3:10 | a |
 | local_dataflow.rb:3:7:3:14 | ( ... ) | local_dataflow.rb:3:3:3:14 | ... = ... |
@@ -2421,39 +2421,39 @@
 | local_dataflow.rb:6:7:6:14 | ( ... ) | local_dataflow.rb:6:3:6:14 | ... = ... |
 | local_dataflow.rb:6:8:6:13 | ... = ... | local_dataflow.rb:6:7:6:14 | ( ... ) |
 | local_dataflow.rb:6:10:6:11 | ... + ... | local_dataflow.rb:6:8:6:13 | ... = ... |
-| local_dataflow.rb:9:1:9:15 | ... = ... | local_dataflow.rb:10:14:10:18 | array |
+| local_dataflow.rb:9:1:9:5 | array | local_dataflow.rb:10:14:10:18 | array |
+| local_dataflow.rb:9:9:9:15 | call to [] | local_dataflow.rb:9:1:9:5 | array |
 | local_dataflow.rb:9:9:9:15 | call to [] | local_dataflow.rb:9:1:9:15 | ... = ... |
-| local_dataflow.rb:9:9:9:15 | call to [] | local_dataflow.rb:9:1:9:15 | ... = ... |
-| local_dataflow.rb:10:5:13:3 | ... = ... | local_dataflow.rb:12:5:12:5 | x |
 | local_dataflow.rb:10:5:13:3 | <captured entry> self | local_dataflow.rb:11:1:11:2 | self |
 | local_dataflow.rb:10:5:13:3 | __synth__0__1 | local_dataflow.rb:10:5:13:3 | ... = ... |
-| local_dataflow.rb:10:5:13:3 | __synth__0__1 | local_dataflow.rb:10:5:13:3 | ... = ... |
 | local_dataflow.rb:10:5:13:3 | __synth__0__1 | local_dataflow.rb:10:5:13:3 | __synth__0__1 |
 | local_dataflow.rb:10:5:13:3 | __synth__0__1 | local_dataflow.rb:10:5:13:3 | __synth__0__1 |
+| local_dataflow.rb:10:5:13:3 | __synth__0__1 | local_dataflow.rb:10:9:10:9 | x |
 | local_dataflow.rb:10:5:13:3 | call to each | local_dataflow.rb:10:1:13:3 | ... = ... |
+| local_dataflow.rb:10:9:10:9 | x | local_dataflow.rb:12:5:12:5 | x |
 | local_dataflow.rb:10:14:10:18 | [post] array | local_dataflow.rb:15:10:15:14 | array |
 | local_dataflow.rb:10:14:10:18 | array | local_dataflow.rb:15:10:15:14 | array |
 | local_dataflow.rb:11:1:11:2 | [post] self | local_dataflow.rb:12:3:12:5 | self |
 | local_dataflow.rb:11:1:11:2 | self | local_dataflow.rb:12:3:12:5 | self |
 | local_dataflow.rb:15:1:17:3 | __synth__0__1 | local_dataflow.rb:15:1:17:3 | ... = ... |
-| local_dataflow.rb:15:1:17:3 | __synth__0__1 | local_dataflow.rb:15:1:17:3 | ... = ... |
 | local_dataflow.rb:15:1:17:3 | __synth__0__1 | local_dataflow.rb:15:1:17:3 | __synth__0__1 |
 | local_dataflow.rb:15:1:17:3 | __synth__0__1 | local_dataflow.rb:15:1:17:3 | __synth__0__1 |
+| local_dataflow.rb:15:1:17:3 | __synth__0__1 | local_dataflow.rb:15:5:15:5 | x |
 | local_dataflow.rb:15:10:15:14 | [post] array | local_dataflow.rb:19:10:19:14 | array |
 | local_dataflow.rb:15:10:15:14 | array | local_dataflow.rb:19:10:19:14 | array |
 | local_dataflow.rb:16:9:16:10 | 10 | local_dataflow.rb:16:3:16:10 | break |
-| local_dataflow.rb:19:1:21:3 | ... = ... | local_dataflow.rb:20:6:20:6 | x |
-| local_dataflow.rb:19:1:21:3 | __synth__0__1 | local_dataflow.rb:19:1:21:3 | ... = ... |
 | local_dataflow.rb:19:1:21:3 | __synth__0__1 | local_dataflow.rb:19:1:21:3 | ... = ... |
 | local_dataflow.rb:19:1:21:3 | __synth__0__1 | local_dataflow.rb:19:1:21:3 | __synth__0__1 |
 | local_dataflow.rb:19:1:21:3 | __synth__0__1 | local_dataflow.rb:19:1:21:3 | __synth__0__1 |
+| local_dataflow.rb:19:1:21:3 | __synth__0__1 | local_dataflow.rb:19:5:19:5 | x |
+| local_dataflow.rb:19:5:19:5 | x | local_dataflow.rb:20:6:20:6 | x |
 | local_dataflow.rb:24:2:24:8 | break | local_dataflow.rb:23:1:25:3 | while ... |
 | local_dataflow.rb:24:8:24:8 | 5 | local_dataflow.rb:24:2:24:8 | break |
 | local_dataflow.rb:28:5:28:26 | M | local_dataflow.rb:28:1:28:26 | ... = ... |
 | local_dataflow.rb:28:15:28:22 | "module" | local_dataflow.rb:28:5:28:26 | M |
 | local_dataflow.rb:30:5:30:24 | C | local_dataflow.rb:30:1:30:24 | ... = ... |
 | local_dataflow.rb:30:14:30:20 | "class" | local_dataflow.rb:30:5:30:24 | C |
-| local_dataflow.rb:32:5:32:25 | bar | local_dataflow.rb:32:1:32:25 | ... = ... |
+| local_dataflow.rb:32:5:32:25 | bar | local_dataflow.rb:32:1:32:1 | x |
 | local_dataflow.rb:32:5:32:25 | bar | local_dataflow.rb:32:1:32:25 | ... = ... |
 | local_dataflow.rb:34:7:34:7 | x | local_dataflow.rb:34:7:34:7 | x |
 | local_dataflow.rb:34:7:34:7 | x | local_dataflow.rb:35:6:35:6 | x |
@@ -2498,9 +2498,9 @@
 | local_dataflow.rb:73:7:73:7 | x | local_dataflow.rb:72:7:73:7 | then ... |
 | local_dataflow.rb:74:3:75:6 | else ... | local_dataflow.rb:69:7:76:5 | case ... |
 | local_dataflow.rb:75:6:75:6 | x | local_dataflow.rb:74:3:75:6 | else ... |
-| local_dataflow.rb:78:3:88:5 | ... = ... | local_dataflow.rb:89:8:89:8 | z |
+| local_dataflow.rb:78:3:78:3 | z | local_dataflow.rb:89:8:89:8 | z |
 | local_dataflow.rb:78:7:88:5 | SSA phi read(self) | local_dataflow.rb:89:3:89:9 | self |
-| local_dataflow.rb:78:7:88:5 | case ... | local_dataflow.rb:78:3:88:5 | ... = ... |
+| local_dataflow.rb:78:7:88:5 | case ... | local_dataflow.rb:78:3:78:3 | z |
 | local_dataflow.rb:78:7:88:5 | case ... | local_dataflow.rb:78:3:88:5 | ... = ... |
 | local_dataflow.rb:78:12:78:20 | [post] self | local_dataflow.rb:79:20:79:26 | self |
 | local_dataflow.rb:78:12:78:20 | [post] self | local_dataflow.rb:80:24:80:30 | self |
@@ -2544,18 +2544,18 @@
 | local_dataflow.rb:87:29:87:29 | x | local_dataflow.rb:87:15:87:48 | then ... |
 | local_dataflow.rb:92:1:109:3 | self (and_or) | local_dataflow.rb:93:7:93:15 | self |
 | local_dataflow.rb:92:1:109:3 | self in and_or | local_dataflow.rb:92:1:109:3 | self (and_or) |
-| local_dataflow.rb:93:3:93:28 | ... = ... | local_dataflow.rb:94:8:94:8 | a |
+| local_dataflow.rb:93:3:93:3 | a | local_dataflow.rb:94:8:94:8 | a |
 | local_dataflow.rb:93:7:93:15 | [post] self | local_dataflow.rb:93:20:93:28 | self |
 | local_dataflow.rb:93:7:93:15 | call to source | local_dataflow.rb:93:7:93:28 | ... \|\| ... |
 | local_dataflow.rb:93:7:93:15 | self | local_dataflow.rb:93:20:93:28 | self |
-| local_dataflow.rb:93:7:93:28 | ... \|\| ... | local_dataflow.rb:93:3:93:28 | ... = ... |
+| local_dataflow.rb:93:7:93:28 | ... \|\| ... | local_dataflow.rb:93:3:93:3 | a |
 | local_dataflow.rb:93:7:93:28 | ... \|\| ... | local_dataflow.rb:93:3:93:28 | ... = ... |
 | local_dataflow.rb:93:7:93:28 | SSA phi read(self) | local_dataflow.rb:94:3:94:9 | self |
 | local_dataflow.rb:93:20:93:28 | call to source | local_dataflow.rb:93:7:93:28 | ... \|\| ... |
 | local_dataflow.rb:94:3:94:9 | [post] self | local_dataflow.rb:95:8:95:16 | self |
 | local_dataflow.rb:94:3:94:9 | self | local_dataflow.rb:95:8:95:16 | self |
-| local_dataflow.rb:95:3:95:30 | ... = ... | local_dataflow.rb:96:8:96:8 | b |
-| local_dataflow.rb:95:7:95:30 | ( ... ) | local_dataflow.rb:95:3:95:30 | ... = ... |
+| local_dataflow.rb:95:3:95:3 | b | local_dataflow.rb:96:8:96:8 | b |
+| local_dataflow.rb:95:7:95:30 | ( ... ) | local_dataflow.rb:95:3:95:3 | b |
 | local_dataflow.rb:95:7:95:30 | ( ... ) | local_dataflow.rb:95:3:95:30 | ... = ... |
 | local_dataflow.rb:95:8:95:16 | [post] self | local_dataflow.rb:95:21:95:29 | self |
 | local_dataflow.rb:95:8:95:16 | call to source | local_dataflow.rb:95:8:95:29 | ... or ... |
@@ -2565,18 +2565,18 @@
 | local_dataflow.rb:95:21:95:29 | call to source | local_dataflow.rb:95:8:95:29 | ... or ... |
 | local_dataflow.rb:96:3:96:9 | [post] self | local_dataflow.rb:98:7:98:15 | self |
 | local_dataflow.rb:96:3:96:9 | self | local_dataflow.rb:98:7:98:15 | self |
-| local_dataflow.rb:98:3:98:28 | ... = ... | local_dataflow.rb:99:8:99:8 | a |
+| local_dataflow.rb:98:3:98:3 | a | local_dataflow.rb:99:8:99:8 | a |
 | local_dataflow.rb:98:7:98:15 | [post] self | local_dataflow.rb:98:20:98:28 | self |
 | local_dataflow.rb:98:7:98:15 | call to source | local_dataflow.rb:98:7:98:28 | ... && ... |
 | local_dataflow.rb:98:7:98:15 | self | local_dataflow.rb:98:20:98:28 | self |
-| local_dataflow.rb:98:7:98:28 | ... && ... | local_dataflow.rb:98:3:98:28 | ... = ... |
+| local_dataflow.rb:98:7:98:28 | ... && ... | local_dataflow.rb:98:3:98:3 | a |
 | local_dataflow.rb:98:7:98:28 | ... && ... | local_dataflow.rb:98:3:98:28 | ... = ... |
 | local_dataflow.rb:98:7:98:28 | SSA phi read(self) | local_dataflow.rb:99:3:99:9 | self |
 | local_dataflow.rb:98:20:98:28 | call to source | local_dataflow.rb:98:7:98:28 | ... && ... |
 | local_dataflow.rb:99:3:99:9 | [post] self | local_dataflow.rb:100:8:100:16 | self |
 | local_dataflow.rb:99:3:99:9 | self | local_dataflow.rb:100:8:100:16 | self |
-| local_dataflow.rb:100:3:100:31 | ... = ... | local_dataflow.rb:101:8:101:8 | b |
-| local_dataflow.rb:100:7:100:31 | ( ... ) | local_dataflow.rb:100:3:100:31 | ... = ... |
+| local_dataflow.rb:100:3:100:3 | b | local_dataflow.rb:101:8:101:8 | b |
+| local_dataflow.rb:100:7:100:31 | ( ... ) | local_dataflow.rb:100:3:100:3 | b |
 | local_dataflow.rb:100:7:100:31 | ( ... ) | local_dataflow.rb:100:3:100:31 | ... = ... |
 | local_dataflow.rb:100:8:100:16 | [post] self | local_dataflow.rb:100:22:100:30 | self |
 | local_dataflow.rb:100:8:100:16 | call to source | local_dataflow.rb:100:8:100:30 | ... and ... |
@@ -2586,27 +2586,27 @@
 | local_dataflow.rb:100:22:100:30 | call to source | local_dataflow.rb:100:8:100:30 | ... and ... |
 | local_dataflow.rb:101:3:101:9 | [post] self | local_dataflow.rb:103:7:103:15 | self |
 | local_dataflow.rb:101:3:101:9 | self | local_dataflow.rb:103:7:103:15 | self |
-| local_dataflow.rb:103:3:103:15 | ... = ... | local_dataflow.rb:104:3:104:3 | a |
+| local_dataflow.rb:103:3:103:3 | a | local_dataflow.rb:104:3:104:3 | a |
 | local_dataflow.rb:103:7:103:15 | [post] self | local_dataflow.rb:104:9:104:17 | self |
-| local_dataflow.rb:103:7:103:15 | call to source | local_dataflow.rb:103:3:103:15 | ... = ... |
+| local_dataflow.rb:103:7:103:15 | call to source | local_dataflow.rb:103:3:103:3 | a |
 | local_dataflow.rb:103:7:103:15 | call to source | local_dataflow.rb:103:3:103:15 | ... = ... |
 | local_dataflow.rb:103:7:103:15 | self | local_dataflow.rb:104:9:104:17 | self |
 | local_dataflow.rb:104:3:104:3 | a | local_dataflow.rb:104:5:104:7 | ... \|\| ... |
-| local_dataflow.rb:104:3:104:17 | ... = ... | local_dataflow.rb:105:8:105:8 | a |
-| local_dataflow.rb:104:5:104:7 | ... \|\| ... | local_dataflow.rb:104:3:104:17 | ... = ... |
+| local_dataflow.rb:104:3:104:3 | a | local_dataflow.rb:105:8:105:8 | a |
+| local_dataflow.rb:104:5:104:7 | ... \|\| ... | local_dataflow.rb:104:3:104:3 | a |
 | local_dataflow.rb:104:5:104:7 | ... \|\| ... | local_dataflow.rb:104:3:104:17 | ... = ... |
 | local_dataflow.rb:104:5:104:7 | SSA phi read(self) | local_dataflow.rb:105:3:105:9 | self |
 | local_dataflow.rb:104:9:104:17 | call to source | local_dataflow.rb:104:5:104:7 | ... \|\| ... |
 | local_dataflow.rb:105:3:105:9 | [post] self | local_dataflow.rb:106:7:106:15 | self |
 | local_dataflow.rb:105:3:105:9 | self | local_dataflow.rb:106:7:106:15 | self |
-| local_dataflow.rb:106:3:106:15 | ... = ... | local_dataflow.rb:107:3:107:3 | b |
+| local_dataflow.rb:106:3:106:3 | b | local_dataflow.rb:107:3:107:3 | b |
 | local_dataflow.rb:106:7:106:15 | [post] self | local_dataflow.rb:107:9:107:17 | self |
-| local_dataflow.rb:106:7:106:15 | call to source | local_dataflow.rb:106:3:106:15 | ... = ... |
+| local_dataflow.rb:106:7:106:15 | call to source | local_dataflow.rb:106:3:106:3 | b |
 | local_dataflow.rb:106:7:106:15 | call to source | local_dataflow.rb:106:3:106:15 | ... = ... |
 | local_dataflow.rb:106:7:106:15 | self | local_dataflow.rb:107:9:107:17 | self |
 | local_dataflow.rb:107:3:107:3 | b | local_dataflow.rb:107:5:107:7 | ... && ... |
-| local_dataflow.rb:107:3:107:17 | ... = ... | local_dataflow.rb:108:8:108:8 | b |
-| local_dataflow.rb:107:5:107:7 | ... && ... | local_dataflow.rb:107:3:107:17 | ... = ... |
+| local_dataflow.rb:107:3:107:3 | b | local_dataflow.rb:108:8:108:8 | b |
+| local_dataflow.rb:107:5:107:7 | ... && ... | local_dataflow.rb:107:3:107:3 | b |
 | local_dataflow.rb:107:5:107:7 | ... && ... | local_dataflow.rb:107:3:107:17 | ... = ... |
 | local_dataflow.rb:107:5:107:7 | SSA phi read(self) | local_dataflow.rb:108:3:108:9 | self |
 | local_dataflow.rb:107:9:107:17 | call to source | local_dataflow.rb:107:5:107:7 | ... && ... |
@@ -2650,8 +2650,8 @@
 | local_dataflow.rb:126:1:128:3 | self in use | local_dataflow.rb:126:1:128:3 | self (use) |
 | local_dataflow.rb:130:1:150:3 | self (use_use_madness) | local_dataflow.rb:132:6:132:11 | self |
 | local_dataflow.rb:130:1:150:3 | self in use_use_madness | local_dataflow.rb:130:1:150:3 | self (use_use_madness) |
-| local_dataflow.rb:131:3:131:8 | ... = ... | local_dataflow.rb:132:10:132:10 | x |
-| local_dataflow.rb:131:7:131:8 | "" | local_dataflow.rb:131:3:131:8 | ... = ... |
+| local_dataflow.rb:131:3:131:3 | x | local_dataflow.rb:132:10:132:10 | x |
+| local_dataflow.rb:131:7:131:8 | "" | local_dataflow.rb:131:3:131:3 | x |
 | local_dataflow.rb:131:7:131:8 | "" | local_dataflow.rb:131:3:131:8 | ... = ... |
 | local_dataflow.rb:132:6:132:11 | [post] self | local_dataflow.rb:133:8:133:13 | self |
 | local_dataflow.rb:132:6:132:11 | self | local_dataflow.rb:133:8:133:13 | self |

--- a/ruby/ql/test/library-tests/dataflow/local/InlineFlowTest.expected
+++ b/ruby/ql/test/library-tests/dataflow/local/InlineFlowTest.expected
@@ -1,38 +1,63 @@
 failures
 edges
-| local_dataflow.rb:78:12:78:20 | call to source :  | local_dataflow.rb:79:25:79:25 | b |
-| local_dataflow.rb:78:12:78:20 | call to source :  | local_dataflow.rb:80:29:80:29 | a |
-| local_dataflow.rb:78:12:78:20 | call to source :  | local_dataflow.rb:82:12:82:12 | c |
-| local_dataflow.rb:78:12:78:20 | call to source :  | local_dataflow.rb:83:12:83:12 | d |
-| local_dataflow.rb:78:12:78:20 | call to source :  | local_dataflow.rb:84:12:84:12 | e |
-| local_dataflow.rb:78:12:78:20 | call to source :  | local_dataflow.rb:85:27:85:27 | f |
-| local_dataflow.rb:78:12:78:20 | call to source :  | local_dataflow.rb:86:33:86:33 | g |
-| local_dataflow.rb:78:12:78:20 | call to source :  | local_dataflow.rb:87:25:87:25 | x |
-| local_dataflow.rb:78:12:78:20 | call to source :  | local_dataflow.rb:89:8:89:8 | z |
-| local_dataflow.rb:93:7:93:15 | call to source :  | local_dataflow.rb:94:8:94:8 | a |
-| local_dataflow.rb:93:7:93:15 | call to source :  | local_dataflow.rb:94:8:94:8 | a |
-| local_dataflow.rb:93:20:93:28 | call to source :  | local_dataflow.rb:94:8:94:8 | a |
-| local_dataflow.rb:93:20:93:28 | call to source :  | local_dataflow.rb:94:8:94:8 | a |
-| local_dataflow.rb:95:8:95:16 | call to source :  | local_dataflow.rb:96:8:96:8 | b |
-| local_dataflow.rb:95:8:95:16 | call to source :  | local_dataflow.rb:96:8:96:8 | b |
-| local_dataflow.rb:95:21:95:29 | call to source :  | local_dataflow.rb:96:8:96:8 | b |
-| local_dataflow.rb:95:21:95:29 | call to source :  | local_dataflow.rb:96:8:96:8 | b |
-| local_dataflow.rb:98:7:98:15 | call to source :  | local_dataflow.rb:99:8:99:8 | a |
-| local_dataflow.rb:98:7:98:15 | call to source :  | local_dataflow.rb:99:8:99:8 | a |
-| local_dataflow.rb:98:20:98:28 | call to source :  | local_dataflow.rb:99:8:99:8 | a |
-| local_dataflow.rb:98:20:98:28 | call to source :  | local_dataflow.rb:99:8:99:8 | a |
-| local_dataflow.rb:100:8:100:16 | call to source :  | local_dataflow.rb:101:8:101:8 | b |
-| local_dataflow.rb:100:8:100:16 | call to source :  | local_dataflow.rb:101:8:101:8 | b |
-| local_dataflow.rb:100:22:100:30 | call to source :  | local_dataflow.rb:101:8:101:8 | b |
-| local_dataflow.rb:100:22:100:30 | call to source :  | local_dataflow.rb:101:8:101:8 | b |
-| local_dataflow.rb:103:7:103:15 | call to source :  | local_dataflow.rb:105:8:105:8 | a |
-| local_dataflow.rb:103:7:103:15 | call to source :  | local_dataflow.rb:105:8:105:8 | a |
-| local_dataflow.rb:104:9:104:17 | call to source :  | local_dataflow.rb:105:8:105:8 | a |
-| local_dataflow.rb:104:9:104:17 | call to source :  | local_dataflow.rb:105:8:105:8 | a |
-| local_dataflow.rb:106:7:106:15 | call to source :  | local_dataflow.rb:108:8:108:8 | b |
-| local_dataflow.rb:106:7:106:15 | call to source :  | local_dataflow.rb:108:8:108:8 | b |
-| local_dataflow.rb:107:9:107:17 | call to source :  | local_dataflow.rb:108:8:108:8 | b |
-| local_dataflow.rb:107:9:107:17 | call to source :  | local_dataflow.rb:108:8:108:8 | b |
+| local_dataflow.rb:78:3:78:3 | z :  | local_dataflow.rb:89:8:89:8 | z |
+| local_dataflow.rb:78:12:78:20 | call to source :  | local_dataflow.rb:79:13:79:13 | b :  |
+| local_dataflow.rb:78:12:78:20 | call to source :  | local_dataflow.rb:80:8:80:8 | a :  |
+| local_dataflow.rb:78:12:78:20 | call to source :  | local_dataflow.rb:81:9:81:9 | c :  |
+| local_dataflow.rb:78:12:78:20 | call to source :  | local_dataflow.rb:81:13:81:13 | d :  |
+| local_dataflow.rb:78:12:78:20 | call to source :  | local_dataflow.rb:81:16:81:16 | e :  |
+| local_dataflow.rb:78:12:78:20 | call to source :  | local_dataflow.rb:85:13:85:13 | f :  |
+| local_dataflow.rb:78:12:78:20 | call to source :  | local_dataflow.rb:86:18:86:18 | g :  |
+| local_dataflow.rb:78:12:78:20 | call to source :  | local_dataflow.rb:87:10:87:10 | x :  |
+| local_dataflow.rb:79:13:79:13 | b :  | local_dataflow.rb:79:25:79:25 | b |
+| local_dataflow.rb:80:8:80:8 | a :  | local_dataflow.rb:80:29:80:29 | a |
+| local_dataflow.rb:81:9:81:9 | c :  | local_dataflow.rb:82:12:82:12 | c |
+| local_dataflow.rb:81:13:81:13 | d :  | local_dataflow.rb:83:12:83:12 | d |
+| local_dataflow.rb:81:16:81:16 | e :  | local_dataflow.rb:84:12:84:12 | e |
+| local_dataflow.rb:85:13:85:13 | f :  | local_dataflow.rb:85:27:85:27 | f |
+| local_dataflow.rb:86:18:86:18 | g :  | local_dataflow.rb:86:33:86:33 | g |
+| local_dataflow.rb:87:10:87:10 | x :  | local_dataflow.rb:78:3:78:3 | z :  |
+| local_dataflow.rb:87:10:87:10 | x :  | local_dataflow.rb:87:25:87:25 | x |
+| local_dataflow.rb:93:3:93:3 | a :  | local_dataflow.rb:94:8:94:8 | a |
+| local_dataflow.rb:93:3:93:3 | a :  | local_dataflow.rb:94:8:94:8 | a |
+| local_dataflow.rb:93:7:93:15 | call to source :  | local_dataflow.rb:93:3:93:3 | a :  |
+| local_dataflow.rb:93:7:93:15 | call to source :  | local_dataflow.rb:93:3:93:3 | a :  |
+| local_dataflow.rb:93:20:93:28 | call to source :  | local_dataflow.rb:93:3:93:3 | a :  |
+| local_dataflow.rb:93:20:93:28 | call to source :  | local_dataflow.rb:93:3:93:3 | a :  |
+| local_dataflow.rb:95:3:95:3 | b :  | local_dataflow.rb:96:8:96:8 | b |
+| local_dataflow.rb:95:3:95:3 | b :  | local_dataflow.rb:96:8:96:8 | b |
+| local_dataflow.rb:95:8:95:16 | call to source :  | local_dataflow.rb:95:3:95:3 | b :  |
+| local_dataflow.rb:95:8:95:16 | call to source :  | local_dataflow.rb:95:3:95:3 | b :  |
+| local_dataflow.rb:95:21:95:29 | call to source :  | local_dataflow.rb:95:3:95:3 | b :  |
+| local_dataflow.rb:95:21:95:29 | call to source :  | local_dataflow.rb:95:3:95:3 | b :  |
+| local_dataflow.rb:98:3:98:3 | a :  | local_dataflow.rb:99:8:99:8 | a |
+| local_dataflow.rb:98:3:98:3 | a :  | local_dataflow.rb:99:8:99:8 | a |
+| local_dataflow.rb:98:7:98:15 | call to source :  | local_dataflow.rb:98:3:98:3 | a :  |
+| local_dataflow.rb:98:7:98:15 | call to source :  | local_dataflow.rb:98:3:98:3 | a :  |
+| local_dataflow.rb:98:20:98:28 | call to source :  | local_dataflow.rb:98:3:98:3 | a :  |
+| local_dataflow.rb:98:20:98:28 | call to source :  | local_dataflow.rb:98:3:98:3 | a :  |
+| local_dataflow.rb:100:3:100:3 | b :  | local_dataflow.rb:101:8:101:8 | b |
+| local_dataflow.rb:100:3:100:3 | b :  | local_dataflow.rb:101:8:101:8 | b |
+| local_dataflow.rb:100:8:100:16 | call to source :  | local_dataflow.rb:100:3:100:3 | b :  |
+| local_dataflow.rb:100:8:100:16 | call to source :  | local_dataflow.rb:100:3:100:3 | b :  |
+| local_dataflow.rb:100:22:100:30 | call to source :  | local_dataflow.rb:100:3:100:3 | b :  |
+| local_dataflow.rb:100:22:100:30 | call to source :  | local_dataflow.rb:100:3:100:3 | b :  |
+| local_dataflow.rb:103:3:103:3 | a :  | local_dataflow.rb:104:3:104:3 | a :  |
+| local_dataflow.rb:103:3:103:3 | a :  | local_dataflow.rb:104:3:104:3 | a :  |
+| local_dataflow.rb:103:7:103:15 | call to source :  | local_dataflow.rb:103:3:103:3 | a :  |
+| local_dataflow.rb:103:7:103:15 | call to source :  | local_dataflow.rb:103:3:103:3 | a :  |
+| local_dataflow.rb:104:3:104:3 | a :  | local_dataflow.rb:105:8:105:8 | a |
+| local_dataflow.rb:104:3:104:3 | a :  | local_dataflow.rb:105:8:105:8 | a |
+| local_dataflow.rb:104:9:104:17 | call to source :  | local_dataflow.rb:104:3:104:3 | a :  |
+| local_dataflow.rb:104:9:104:17 | call to source :  | local_dataflow.rb:104:3:104:3 | a :  |
+| local_dataflow.rb:106:3:106:3 | b :  | local_dataflow.rb:107:3:107:3 | b :  |
+| local_dataflow.rb:106:3:106:3 | b :  | local_dataflow.rb:107:3:107:3 | b :  |
+| local_dataflow.rb:106:7:106:15 | call to source :  | local_dataflow.rb:106:3:106:3 | b :  |
+| local_dataflow.rb:106:7:106:15 | call to source :  | local_dataflow.rb:106:3:106:3 | b :  |
+| local_dataflow.rb:107:3:107:3 | b :  | local_dataflow.rb:108:8:108:8 | b |
+| local_dataflow.rb:107:3:107:3 | b :  | local_dataflow.rb:108:8:108:8 | b |
+| local_dataflow.rb:107:9:107:17 | call to source :  | local_dataflow.rb:107:3:107:3 | b :  |
+| local_dataflow.rb:107:9:107:17 | call to source :  | local_dataflow.rb:107:3:107:3 | b :  |
 | local_dataflow.rb:112:8:112:16 | call to source :  | local_dataflow.rb:112:8:112:20 | call to dup |
 | local_dataflow.rb:112:8:112:16 | call to source :  | local_dataflow.rb:112:8:112:20 | call to dup |
 | local_dataflow.rb:113:8:113:16 | call to source :  | local_dataflow.rb:113:8:113:20 | call to dup :  |
@@ -56,48 +81,73 @@ edges
 | local_dataflow.rb:123:8:123:45 | call to tap :  | local_dataflow.rb:123:8:123:49 | call to dup |
 | local_dataflow.rb:123:8:123:45 | call to tap :  | local_dataflow.rb:123:8:123:49 | call to dup |
 nodes
+| local_dataflow.rb:78:3:78:3 | z :  | semmle.label | z :  |
 | local_dataflow.rb:78:12:78:20 | call to source :  | semmle.label | call to source :  |
+| local_dataflow.rb:79:13:79:13 | b :  | semmle.label | b :  |
 | local_dataflow.rb:79:25:79:25 | b | semmle.label | b |
+| local_dataflow.rb:80:8:80:8 | a :  | semmle.label | a :  |
 | local_dataflow.rb:80:29:80:29 | a | semmle.label | a |
+| local_dataflow.rb:81:9:81:9 | c :  | semmle.label | c :  |
+| local_dataflow.rb:81:13:81:13 | d :  | semmle.label | d :  |
+| local_dataflow.rb:81:16:81:16 | e :  | semmle.label | e :  |
 | local_dataflow.rb:82:12:82:12 | c | semmle.label | c |
 | local_dataflow.rb:83:12:83:12 | d | semmle.label | d |
 | local_dataflow.rb:84:12:84:12 | e | semmle.label | e |
+| local_dataflow.rb:85:13:85:13 | f :  | semmle.label | f :  |
 | local_dataflow.rb:85:27:85:27 | f | semmle.label | f |
+| local_dataflow.rb:86:18:86:18 | g :  | semmle.label | g :  |
 | local_dataflow.rb:86:33:86:33 | g | semmle.label | g |
+| local_dataflow.rb:87:10:87:10 | x :  | semmle.label | x :  |
 | local_dataflow.rb:87:25:87:25 | x | semmle.label | x |
 | local_dataflow.rb:89:8:89:8 | z | semmle.label | z |
+| local_dataflow.rb:93:3:93:3 | a :  | semmle.label | a :  |
+| local_dataflow.rb:93:3:93:3 | a :  | semmle.label | a :  |
 | local_dataflow.rb:93:7:93:15 | call to source :  | semmle.label | call to source :  |
 | local_dataflow.rb:93:7:93:15 | call to source :  | semmle.label | call to source :  |
 | local_dataflow.rb:93:20:93:28 | call to source :  | semmle.label | call to source :  |
 | local_dataflow.rb:93:20:93:28 | call to source :  | semmle.label | call to source :  |
 | local_dataflow.rb:94:8:94:8 | a | semmle.label | a |
 | local_dataflow.rb:94:8:94:8 | a | semmle.label | a |
+| local_dataflow.rb:95:3:95:3 | b :  | semmle.label | b :  |
+| local_dataflow.rb:95:3:95:3 | b :  | semmle.label | b :  |
 | local_dataflow.rb:95:8:95:16 | call to source :  | semmle.label | call to source :  |
 | local_dataflow.rb:95:8:95:16 | call to source :  | semmle.label | call to source :  |
 | local_dataflow.rb:95:21:95:29 | call to source :  | semmle.label | call to source :  |
 | local_dataflow.rb:95:21:95:29 | call to source :  | semmle.label | call to source :  |
 | local_dataflow.rb:96:8:96:8 | b | semmle.label | b |
 | local_dataflow.rb:96:8:96:8 | b | semmle.label | b |
+| local_dataflow.rb:98:3:98:3 | a :  | semmle.label | a :  |
+| local_dataflow.rb:98:3:98:3 | a :  | semmle.label | a :  |
 | local_dataflow.rb:98:7:98:15 | call to source :  | semmle.label | call to source :  |
 | local_dataflow.rb:98:7:98:15 | call to source :  | semmle.label | call to source :  |
 | local_dataflow.rb:98:20:98:28 | call to source :  | semmle.label | call to source :  |
 | local_dataflow.rb:98:20:98:28 | call to source :  | semmle.label | call to source :  |
 | local_dataflow.rb:99:8:99:8 | a | semmle.label | a |
 | local_dataflow.rb:99:8:99:8 | a | semmle.label | a |
+| local_dataflow.rb:100:3:100:3 | b :  | semmle.label | b :  |
+| local_dataflow.rb:100:3:100:3 | b :  | semmle.label | b :  |
 | local_dataflow.rb:100:8:100:16 | call to source :  | semmle.label | call to source :  |
 | local_dataflow.rb:100:8:100:16 | call to source :  | semmle.label | call to source :  |
 | local_dataflow.rb:100:22:100:30 | call to source :  | semmle.label | call to source :  |
 | local_dataflow.rb:100:22:100:30 | call to source :  | semmle.label | call to source :  |
 | local_dataflow.rb:101:8:101:8 | b | semmle.label | b |
 | local_dataflow.rb:101:8:101:8 | b | semmle.label | b |
+| local_dataflow.rb:103:3:103:3 | a :  | semmle.label | a :  |
+| local_dataflow.rb:103:3:103:3 | a :  | semmle.label | a :  |
 | local_dataflow.rb:103:7:103:15 | call to source :  | semmle.label | call to source :  |
 | local_dataflow.rb:103:7:103:15 | call to source :  | semmle.label | call to source :  |
+| local_dataflow.rb:104:3:104:3 | a :  | semmle.label | a :  |
+| local_dataflow.rb:104:3:104:3 | a :  | semmle.label | a :  |
 | local_dataflow.rb:104:9:104:17 | call to source :  | semmle.label | call to source :  |
 | local_dataflow.rb:104:9:104:17 | call to source :  | semmle.label | call to source :  |
 | local_dataflow.rb:105:8:105:8 | a | semmle.label | a |
 | local_dataflow.rb:105:8:105:8 | a | semmle.label | a |
+| local_dataflow.rb:106:3:106:3 | b :  | semmle.label | b :  |
+| local_dataflow.rb:106:3:106:3 | b :  | semmle.label | b :  |
 | local_dataflow.rb:106:7:106:15 | call to source :  | semmle.label | call to source :  |
 | local_dataflow.rb:106:7:106:15 | call to source :  | semmle.label | call to source :  |
+| local_dataflow.rb:107:3:107:3 | b :  | semmle.label | b :  |
+| local_dataflow.rb:107:3:107:3 | b :  | semmle.label | b :  |
 | local_dataflow.rb:107:9:107:17 | call to source :  | semmle.label | call to source :  |
 | local_dataflow.rb:107:9:107:17 | call to source :  | semmle.label | call to source :  |
 | local_dataflow.rb:108:8:108:8 | b | semmle.label | b |

--- a/ruby/ql/test/library-tests/dataflow/local/TaintStep.expected
+++ b/ruby/ql/test/library-tests/dataflow/local/TaintStep.expected
@@ -1,107 +1,107 @@
 | UseUseExplosion.rb:18:5:22:7 | self (m) | UseUseExplosion.rb:20:13:20:17 | self |
 | UseUseExplosion.rb:18:5:22:7 | self in m | UseUseExplosion.rb:18:5:22:7 | self (m) |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2081:20:2116 | SSA phi read(x) |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2111:20:2111 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2127:20:2127 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2143:20:2143 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2159:20:2159 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2175:20:2175 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2191:20:2191 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2207:20:2207 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2223:20:2223 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2239:20:2239 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2255:20:2255 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2271:20:2271 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2287:20:2287 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2303:20:2303 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2319:20:2319 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2335:20:2335 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2351:20:2351 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2367:20:2367 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2383:20:2383 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2399:20:2399 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2415:20:2415 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2431:20:2431 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2447:20:2447 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2463:20:2463 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2479:20:2479 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2495:20:2495 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2511:20:2511 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2527:20:2527 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2543:20:2543 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2559:20:2559 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2575:20:2575 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2591:20:2591 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2607:20:2607 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2623:20:2623 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2639:20:2639 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2655:20:2655 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2671:20:2671 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2687:20:2687 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2703:20:2703 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2719:20:2719 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2735:20:2735 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2751:20:2751 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2767:20:2767 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2783:20:2783 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2799:20:2799 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2815:20:2815 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2831:20:2831 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2847:20:2847 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2863:20:2863 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2879:20:2879 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2895:20:2895 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2911:20:2911 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2927:20:2927 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2943:20:2943 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2959:20:2959 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2975:20:2975 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:2991:20:2991 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3007:20:3007 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3023:20:3023 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3039:20:3039 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3055:20:3055 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3071:20:3071 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3087:20:3087 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3103:20:3103 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3119:20:3119 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3135:20:3135 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3151:20:3151 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3167:20:3167 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3183:20:3183 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3199:20:3199 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3215:20:3215 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3231:20:3231 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3247:20:3247 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3263:20:3263 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3279:20:3279 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3295:20:3295 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3311:20:3311 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3327:20:3327 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3343:20:3343 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3359:20:3359 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3375:20:3375 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3391:20:3391 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3407:20:3407 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3423:20:3423 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3439:20:3439 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3455:20:3455 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3471:20:3471 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3487:20:3487 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3503:20:3503 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3519:20:3519 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3535:20:3535 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3551:20:3551 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3567:20:3567 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3583:20:3583 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3599:20:3599 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3615:20:3615 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3631:20:3631 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3647:20:3647 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3663:20:3663 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3679:20:3679 | x |
-| UseUseExplosion.rb:19:9:19:13 | ... = ... | UseUseExplosion.rb:20:3695:20:3695 | x |
-| UseUseExplosion.rb:19:13:19:13 | 0 | UseUseExplosion.rb:19:9:19:13 | ... = ... |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2081:20:2116 | SSA phi read(x) |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2111:20:2111 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2127:20:2127 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2143:20:2143 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2159:20:2159 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2175:20:2175 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2191:20:2191 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2207:20:2207 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2223:20:2223 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2239:20:2239 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2255:20:2255 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2271:20:2271 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2287:20:2287 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2303:20:2303 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2319:20:2319 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2335:20:2335 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2351:20:2351 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2367:20:2367 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2383:20:2383 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2399:20:2399 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2415:20:2415 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2431:20:2431 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2447:20:2447 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2463:20:2463 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2479:20:2479 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2495:20:2495 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2511:20:2511 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2527:20:2527 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2543:20:2543 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2559:20:2559 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2575:20:2575 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2591:20:2591 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2607:20:2607 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2623:20:2623 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2639:20:2639 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2655:20:2655 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2671:20:2671 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2687:20:2687 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2703:20:2703 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2719:20:2719 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2735:20:2735 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2751:20:2751 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2767:20:2767 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2783:20:2783 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2799:20:2799 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2815:20:2815 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2831:20:2831 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2847:20:2847 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2863:20:2863 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2879:20:2879 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2895:20:2895 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2911:20:2911 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2927:20:2927 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2943:20:2943 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2959:20:2959 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2975:20:2975 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:2991:20:2991 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3007:20:3007 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3023:20:3023 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3039:20:3039 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3055:20:3055 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3071:20:3071 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3087:20:3087 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3103:20:3103 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3119:20:3119 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3135:20:3135 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3151:20:3151 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3167:20:3167 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3183:20:3183 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3199:20:3199 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3215:20:3215 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3231:20:3231 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3247:20:3247 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3263:20:3263 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3279:20:3279 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3295:20:3295 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3311:20:3311 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3327:20:3327 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3343:20:3343 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3359:20:3359 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3375:20:3375 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3391:20:3391 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3407:20:3407 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3423:20:3423 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3439:20:3439 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3455:20:3455 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3471:20:3471 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3487:20:3487 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3503:20:3503 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3519:20:3519 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3535:20:3535 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3551:20:3551 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3567:20:3567 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3583:20:3583 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3599:20:3599 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3615:20:3615 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3631:20:3631 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3647:20:3647 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3663:20:3663 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3679:20:3679 | x |
+| UseUseExplosion.rb:19:9:19:9 | x | UseUseExplosion.rb:20:3695:20:3695 | x |
+| UseUseExplosion.rb:19:13:19:13 | 0 | UseUseExplosion.rb:19:9:19:9 | x |
 | UseUseExplosion.rb:19:13:19:13 | 0 | UseUseExplosion.rb:19:9:19:13 | ... = ... |
 | UseUseExplosion.rb:20:9:20:3700 | SSA phi read(self) | UseUseExplosion.rb:21:13:21:17 | self |
 | UseUseExplosion.rb:20:9:20:3700 | SSA phi read(x) | UseUseExplosion.rb:21:2111:21:2111 | x |
@@ -2833,8 +2833,8 @@
 | local_dataflow.rb:1:1:150:3 | self (local_dataflow.rb) | local_dataflow.rb:49:1:53:3 | self |
 | local_dataflow.rb:1:9:1:9 | a | local_dataflow.rb:1:9:1:9 | a |
 | local_dataflow.rb:1:9:1:9 | a | local_dataflow.rb:2:7:2:7 | a |
-| local_dataflow.rb:2:3:2:7 | ... = ... | local_dataflow.rb:3:13:3:13 | b |
-| local_dataflow.rb:2:7:2:7 | a | local_dataflow.rb:2:3:2:7 | ... = ... |
+| local_dataflow.rb:2:3:2:3 | b | local_dataflow.rb:3:13:3:13 | b |
+| local_dataflow.rb:2:7:2:7 | a | local_dataflow.rb:2:3:2:3 | b |
 | local_dataflow.rb:2:7:2:7 | a | local_dataflow.rb:2:3:2:7 | ... = ... |
 | local_dataflow.rb:2:7:2:7 | a | local_dataflow.rb:3:10:3:10 | a |
 | local_dataflow.rb:3:7:3:14 | ( ... ) | local_dataflow.rb:3:3:3:14 | ... = ... |
@@ -2854,33 +2854,33 @@
 | local_dataflow.rb:6:8:6:13 | ... = ... | local_dataflow.rb:6:7:6:14 | ( ... ) |
 | local_dataflow.rb:6:10:6:11 | ... + ... | local_dataflow.rb:6:8:6:13 | ... = ... |
 | local_dataflow.rb:6:13:6:13 | b | local_dataflow.rb:6:10:6:11 | ... + ... |
-| local_dataflow.rb:9:1:9:15 | ... = ... | local_dataflow.rb:10:14:10:18 | array |
+| local_dataflow.rb:9:1:9:5 | array | local_dataflow.rb:10:14:10:18 | array |
 | local_dataflow.rb:9:9:9:15 | Array | local_dataflow.rb:9:9:9:15 | call to [] |
+| local_dataflow.rb:9:9:9:15 | call to [] | local_dataflow.rb:9:1:9:5 | array |
 | local_dataflow.rb:9:9:9:15 | call to [] | local_dataflow.rb:9:1:9:15 | ... = ... |
-| local_dataflow.rb:9:9:9:15 | call to [] | local_dataflow.rb:9:1:9:15 | ... = ... |
-| local_dataflow.rb:10:5:13:3 | ... = ... | local_dataflow.rb:12:5:12:5 | x |
 | local_dataflow.rb:10:5:13:3 | <captured entry> self | local_dataflow.rb:11:1:11:2 | self |
 | local_dataflow.rb:10:5:13:3 | __synth__0__1 | local_dataflow.rb:10:5:13:3 | ... = ... |
-| local_dataflow.rb:10:5:13:3 | __synth__0__1 | local_dataflow.rb:10:5:13:3 | ... = ... |
 | local_dataflow.rb:10:5:13:3 | __synth__0__1 | local_dataflow.rb:10:5:13:3 | __synth__0__1 |
 | local_dataflow.rb:10:5:13:3 | __synth__0__1 | local_dataflow.rb:10:5:13:3 | __synth__0__1 |
+| local_dataflow.rb:10:5:13:3 | __synth__0__1 | local_dataflow.rb:10:9:10:9 | x |
 | local_dataflow.rb:10:5:13:3 | call to each | local_dataflow.rb:10:1:13:3 | ... = ... |
+| local_dataflow.rb:10:9:10:9 | x | local_dataflow.rb:12:5:12:5 | x |
 | local_dataflow.rb:10:14:10:18 | [post] array | local_dataflow.rb:15:10:15:14 | array |
 | local_dataflow.rb:10:14:10:18 | array | local_dataflow.rb:15:10:15:14 | array |
 | local_dataflow.rb:11:1:11:2 | [post] self | local_dataflow.rb:12:3:12:5 | self |
 | local_dataflow.rb:11:1:11:2 | self | local_dataflow.rb:12:3:12:5 | self |
 | local_dataflow.rb:15:1:17:3 | __synth__0__1 | local_dataflow.rb:15:1:17:3 | ... = ... |
-| local_dataflow.rb:15:1:17:3 | __synth__0__1 | local_dataflow.rb:15:1:17:3 | ... = ... |
 | local_dataflow.rb:15:1:17:3 | __synth__0__1 | local_dataflow.rb:15:1:17:3 | __synth__0__1 |
 | local_dataflow.rb:15:1:17:3 | __synth__0__1 | local_dataflow.rb:15:1:17:3 | __synth__0__1 |
+| local_dataflow.rb:15:1:17:3 | __synth__0__1 | local_dataflow.rb:15:5:15:5 | x |
 | local_dataflow.rb:15:10:15:14 | [post] array | local_dataflow.rb:19:10:19:14 | array |
 | local_dataflow.rb:15:10:15:14 | array | local_dataflow.rb:19:10:19:14 | array |
 | local_dataflow.rb:16:9:16:10 | 10 | local_dataflow.rb:16:3:16:10 | break |
-| local_dataflow.rb:19:1:21:3 | ... = ... | local_dataflow.rb:20:6:20:6 | x |
-| local_dataflow.rb:19:1:21:3 | __synth__0__1 | local_dataflow.rb:19:1:21:3 | ... = ... |
 | local_dataflow.rb:19:1:21:3 | __synth__0__1 | local_dataflow.rb:19:1:21:3 | ... = ... |
 | local_dataflow.rb:19:1:21:3 | __synth__0__1 | local_dataflow.rb:19:1:21:3 | __synth__0__1 |
 | local_dataflow.rb:19:1:21:3 | __synth__0__1 | local_dataflow.rb:19:1:21:3 | __synth__0__1 |
+| local_dataflow.rb:19:1:21:3 | __synth__0__1 | local_dataflow.rb:19:5:19:5 | x |
+| local_dataflow.rb:19:5:19:5 | x | local_dataflow.rb:20:6:20:6 | x |
 | local_dataflow.rb:20:6:20:6 | x | local_dataflow.rb:20:6:20:10 | ... > ... |
 | local_dataflow.rb:20:10:20:10 | 1 | local_dataflow.rb:20:6:20:10 | ... > ... |
 | local_dataflow.rb:24:2:24:8 | break | local_dataflow.rb:23:1:25:3 | while ... |
@@ -2889,7 +2889,7 @@
 | local_dataflow.rb:28:15:28:22 | "module" | local_dataflow.rb:28:5:28:26 | M |
 | local_dataflow.rb:30:5:30:24 | C | local_dataflow.rb:30:1:30:24 | ... = ... |
 | local_dataflow.rb:30:14:30:20 | "class" | local_dataflow.rb:30:5:30:24 | C |
-| local_dataflow.rb:32:5:32:25 | bar | local_dataflow.rb:32:1:32:25 | ... = ... |
+| local_dataflow.rb:32:5:32:25 | bar | local_dataflow.rb:32:1:32:1 | x |
 | local_dataflow.rb:32:5:32:25 | bar | local_dataflow.rb:32:1:32:25 | ... = ... |
 | local_dataflow.rb:34:7:34:7 | x | local_dataflow.rb:34:7:34:7 | x |
 | local_dataflow.rb:34:7:34:7 | x | local_dataflow.rb:35:6:35:6 | x |
@@ -2943,9 +2943,9 @@
 | local_dataflow.rb:73:7:73:7 | x | local_dataflow.rb:72:7:73:7 | then ... |
 | local_dataflow.rb:74:3:75:6 | else ... | local_dataflow.rb:69:7:76:5 | case ... |
 | local_dataflow.rb:75:6:75:6 | x | local_dataflow.rb:74:3:75:6 | else ... |
-| local_dataflow.rb:78:3:88:5 | ... = ... | local_dataflow.rb:89:8:89:8 | z |
+| local_dataflow.rb:78:3:78:3 | z | local_dataflow.rb:89:8:89:8 | z |
 | local_dataflow.rb:78:7:88:5 | SSA phi read(self) | local_dataflow.rb:89:3:89:9 | self |
-| local_dataflow.rb:78:7:88:5 | case ... | local_dataflow.rb:78:3:88:5 | ... = ... |
+| local_dataflow.rb:78:7:88:5 | case ... | local_dataflow.rb:78:3:78:3 | z |
 | local_dataflow.rb:78:7:88:5 | case ... | local_dataflow.rb:78:3:88:5 | ... = ... |
 | local_dataflow.rb:78:12:78:20 | [post] self | local_dataflow.rb:79:20:79:26 | self |
 | local_dataflow.rb:78:12:78:20 | [post] self | local_dataflow.rb:80:24:80:30 | self |
@@ -3000,18 +3000,18 @@
 | local_dataflow.rb:87:29:87:29 | x | local_dataflow.rb:87:15:87:48 | then ... |
 | local_dataflow.rb:92:1:109:3 | self (and_or) | local_dataflow.rb:93:7:93:15 | self |
 | local_dataflow.rb:92:1:109:3 | self in and_or | local_dataflow.rb:92:1:109:3 | self (and_or) |
-| local_dataflow.rb:93:3:93:28 | ... = ... | local_dataflow.rb:94:8:94:8 | a |
+| local_dataflow.rb:93:3:93:3 | a | local_dataflow.rb:94:8:94:8 | a |
 | local_dataflow.rb:93:7:93:15 | [post] self | local_dataflow.rb:93:20:93:28 | self |
 | local_dataflow.rb:93:7:93:15 | call to source | local_dataflow.rb:93:7:93:28 | ... \|\| ... |
 | local_dataflow.rb:93:7:93:15 | self | local_dataflow.rb:93:20:93:28 | self |
-| local_dataflow.rb:93:7:93:28 | ... \|\| ... | local_dataflow.rb:93:3:93:28 | ... = ... |
+| local_dataflow.rb:93:7:93:28 | ... \|\| ... | local_dataflow.rb:93:3:93:3 | a |
 | local_dataflow.rb:93:7:93:28 | ... \|\| ... | local_dataflow.rb:93:3:93:28 | ... = ... |
 | local_dataflow.rb:93:7:93:28 | SSA phi read(self) | local_dataflow.rb:94:3:94:9 | self |
 | local_dataflow.rb:93:20:93:28 | call to source | local_dataflow.rb:93:7:93:28 | ... \|\| ... |
 | local_dataflow.rb:94:3:94:9 | [post] self | local_dataflow.rb:95:8:95:16 | self |
 | local_dataflow.rb:94:3:94:9 | self | local_dataflow.rb:95:8:95:16 | self |
-| local_dataflow.rb:95:3:95:30 | ... = ... | local_dataflow.rb:96:8:96:8 | b |
-| local_dataflow.rb:95:7:95:30 | ( ... ) | local_dataflow.rb:95:3:95:30 | ... = ... |
+| local_dataflow.rb:95:3:95:3 | b | local_dataflow.rb:96:8:96:8 | b |
+| local_dataflow.rb:95:7:95:30 | ( ... ) | local_dataflow.rb:95:3:95:3 | b |
 | local_dataflow.rb:95:7:95:30 | ( ... ) | local_dataflow.rb:95:3:95:30 | ... = ... |
 | local_dataflow.rb:95:8:95:16 | [post] self | local_dataflow.rb:95:21:95:29 | self |
 | local_dataflow.rb:95:8:95:16 | call to source | local_dataflow.rb:95:8:95:29 | ... or ... |
@@ -3021,18 +3021,18 @@
 | local_dataflow.rb:95:21:95:29 | call to source | local_dataflow.rb:95:8:95:29 | ... or ... |
 | local_dataflow.rb:96:3:96:9 | [post] self | local_dataflow.rb:98:7:98:15 | self |
 | local_dataflow.rb:96:3:96:9 | self | local_dataflow.rb:98:7:98:15 | self |
-| local_dataflow.rb:98:3:98:28 | ... = ... | local_dataflow.rb:99:8:99:8 | a |
+| local_dataflow.rb:98:3:98:3 | a | local_dataflow.rb:99:8:99:8 | a |
 | local_dataflow.rb:98:7:98:15 | [post] self | local_dataflow.rb:98:20:98:28 | self |
 | local_dataflow.rb:98:7:98:15 | call to source | local_dataflow.rb:98:7:98:28 | ... && ... |
 | local_dataflow.rb:98:7:98:15 | self | local_dataflow.rb:98:20:98:28 | self |
-| local_dataflow.rb:98:7:98:28 | ... && ... | local_dataflow.rb:98:3:98:28 | ... = ... |
+| local_dataflow.rb:98:7:98:28 | ... && ... | local_dataflow.rb:98:3:98:3 | a |
 | local_dataflow.rb:98:7:98:28 | ... && ... | local_dataflow.rb:98:3:98:28 | ... = ... |
 | local_dataflow.rb:98:7:98:28 | SSA phi read(self) | local_dataflow.rb:99:3:99:9 | self |
 | local_dataflow.rb:98:20:98:28 | call to source | local_dataflow.rb:98:7:98:28 | ... && ... |
 | local_dataflow.rb:99:3:99:9 | [post] self | local_dataflow.rb:100:8:100:16 | self |
 | local_dataflow.rb:99:3:99:9 | self | local_dataflow.rb:100:8:100:16 | self |
-| local_dataflow.rb:100:3:100:31 | ... = ... | local_dataflow.rb:101:8:101:8 | b |
-| local_dataflow.rb:100:7:100:31 | ( ... ) | local_dataflow.rb:100:3:100:31 | ... = ... |
+| local_dataflow.rb:100:3:100:3 | b | local_dataflow.rb:101:8:101:8 | b |
+| local_dataflow.rb:100:7:100:31 | ( ... ) | local_dataflow.rb:100:3:100:3 | b |
 | local_dataflow.rb:100:7:100:31 | ( ... ) | local_dataflow.rb:100:3:100:31 | ... = ... |
 | local_dataflow.rb:100:8:100:16 | [post] self | local_dataflow.rb:100:22:100:30 | self |
 | local_dataflow.rb:100:8:100:16 | call to source | local_dataflow.rb:100:8:100:30 | ... and ... |
@@ -3042,27 +3042,27 @@
 | local_dataflow.rb:100:22:100:30 | call to source | local_dataflow.rb:100:8:100:30 | ... and ... |
 | local_dataflow.rb:101:3:101:9 | [post] self | local_dataflow.rb:103:7:103:15 | self |
 | local_dataflow.rb:101:3:101:9 | self | local_dataflow.rb:103:7:103:15 | self |
-| local_dataflow.rb:103:3:103:15 | ... = ... | local_dataflow.rb:104:3:104:3 | a |
+| local_dataflow.rb:103:3:103:3 | a | local_dataflow.rb:104:3:104:3 | a |
 | local_dataflow.rb:103:7:103:15 | [post] self | local_dataflow.rb:104:9:104:17 | self |
-| local_dataflow.rb:103:7:103:15 | call to source | local_dataflow.rb:103:3:103:15 | ... = ... |
+| local_dataflow.rb:103:7:103:15 | call to source | local_dataflow.rb:103:3:103:3 | a |
 | local_dataflow.rb:103:7:103:15 | call to source | local_dataflow.rb:103:3:103:15 | ... = ... |
 | local_dataflow.rb:103:7:103:15 | self | local_dataflow.rb:104:9:104:17 | self |
 | local_dataflow.rb:104:3:104:3 | a | local_dataflow.rb:104:5:104:7 | ... \|\| ... |
-| local_dataflow.rb:104:3:104:17 | ... = ... | local_dataflow.rb:105:8:105:8 | a |
-| local_dataflow.rb:104:5:104:7 | ... \|\| ... | local_dataflow.rb:104:3:104:17 | ... = ... |
+| local_dataflow.rb:104:3:104:3 | a | local_dataflow.rb:105:8:105:8 | a |
+| local_dataflow.rb:104:5:104:7 | ... \|\| ... | local_dataflow.rb:104:3:104:3 | a |
 | local_dataflow.rb:104:5:104:7 | ... \|\| ... | local_dataflow.rb:104:3:104:17 | ... = ... |
 | local_dataflow.rb:104:5:104:7 | SSA phi read(self) | local_dataflow.rb:105:3:105:9 | self |
 | local_dataflow.rb:104:9:104:17 | call to source | local_dataflow.rb:104:5:104:7 | ... \|\| ... |
 | local_dataflow.rb:105:3:105:9 | [post] self | local_dataflow.rb:106:7:106:15 | self |
 | local_dataflow.rb:105:3:105:9 | self | local_dataflow.rb:106:7:106:15 | self |
-| local_dataflow.rb:106:3:106:15 | ... = ... | local_dataflow.rb:107:3:107:3 | b |
+| local_dataflow.rb:106:3:106:3 | b | local_dataflow.rb:107:3:107:3 | b |
 | local_dataflow.rb:106:7:106:15 | [post] self | local_dataflow.rb:107:9:107:17 | self |
-| local_dataflow.rb:106:7:106:15 | call to source | local_dataflow.rb:106:3:106:15 | ... = ... |
+| local_dataflow.rb:106:7:106:15 | call to source | local_dataflow.rb:106:3:106:3 | b |
 | local_dataflow.rb:106:7:106:15 | call to source | local_dataflow.rb:106:3:106:15 | ... = ... |
 | local_dataflow.rb:106:7:106:15 | self | local_dataflow.rb:107:9:107:17 | self |
 | local_dataflow.rb:107:3:107:3 | b | local_dataflow.rb:107:5:107:7 | ... && ... |
-| local_dataflow.rb:107:3:107:17 | ... = ... | local_dataflow.rb:108:8:108:8 | b |
-| local_dataflow.rb:107:5:107:7 | ... && ... | local_dataflow.rb:107:3:107:17 | ... = ... |
+| local_dataflow.rb:107:3:107:3 | b | local_dataflow.rb:108:8:108:8 | b |
+| local_dataflow.rb:107:5:107:7 | ... && ... | local_dataflow.rb:107:3:107:3 | b |
 | local_dataflow.rb:107:5:107:7 | ... && ... | local_dataflow.rb:107:3:107:17 | ... = ... |
 | local_dataflow.rb:107:5:107:7 | SSA phi read(self) | local_dataflow.rb:108:3:108:9 | self |
 | local_dataflow.rb:107:9:107:17 | call to source | local_dataflow.rb:107:5:107:7 | ... && ... |
@@ -3106,8 +3106,8 @@
 | local_dataflow.rb:126:1:128:3 | self in use | local_dataflow.rb:126:1:128:3 | self (use) |
 | local_dataflow.rb:130:1:150:3 | self (use_use_madness) | local_dataflow.rb:132:6:132:11 | self |
 | local_dataflow.rb:130:1:150:3 | self in use_use_madness | local_dataflow.rb:130:1:150:3 | self (use_use_madness) |
-| local_dataflow.rb:131:3:131:8 | ... = ... | local_dataflow.rb:132:10:132:10 | x |
-| local_dataflow.rb:131:7:131:8 | "" | local_dataflow.rb:131:3:131:8 | ... = ... |
+| local_dataflow.rb:131:3:131:3 | x | local_dataflow.rb:132:10:132:10 | x |
+| local_dataflow.rb:131:7:131:8 | "" | local_dataflow.rb:131:3:131:3 | x |
 | local_dataflow.rb:131:7:131:8 | "" | local_dataflow.rb:131:3:131:8 | ... = ... |
 | local_dataflow.rb:132:6:132:11 | [post] self | local_dataflow.rb:133:8:133:13 | self |
 | local_dataflow.rb:132:6:132:11 | self | local_dataflow.rb:133:8:133:13 | self |

--- a/ruby/ql/test/library-tests/dataflow/params/params-flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/params/params-flow.expected
@@ -22,17 +22,21 @@ edges
 | params_flow.rb:33:12:33:19 | call to taint :  | params_flow.rb:25:12:25:13 | p1 :  |
 | params_flow.rb:33:26:33:34 | call to taint :  | params_flow.rb:25:17:25:24 | **kwargs [element :p2] :  |
 | params_flow.rb:33:41:33:49 | call to taint :  | params_flow.rb:25:17:25:24 | **kwargs [element :p3] :  |
-| params_flow.rb:34:14:34:22 | call to taint :  | params_flow.rb:35:25:35:28 | args [element :p3] :  |
+| params_flow.rb:34:1:34:4 | args [element :p3] :  | params_flow.rb:35:25:35:28 | args [element :p3] :  |
+| params_flow.rb:34:14:34:22 | call to taint :  | params_flow.rb:34:1:34:4 | args [element :p3] :  |
 | params_flow.rb:35:12:35:20 | call to taint :  | params_flow.rb:25:12:25:13 | p1 :  |
 | params_flow.rb:35:23:35:28 | ** ... [element :p3] :  | params_flow.rb:25:17:25:24 | **kwargs [element :p3] :  |
 | params_flow.rb:35:25:35:28 | args [element :p3] :  | params_flow.rb:35:23:35:28 | ** ... [element :p3] :  |
-| params_flow.rb:37:16:37:24 | call to taint :  | params_flow.rb:38:10:38:13 | args [element :p1] :  |
-| params_flow.rb:37:34:37:42 | call to taint :  | params_flow.rb:38:10:38:13 | args [element :p2] :  |
+| params_flow.rb:37:1:37:4 | args [element :p1] :  | params_flow.rb:38:10:38:13 | args [element :p1] :  |
+| params_flow.rb:37:1:37:4 | args [element :p2] :  | params_flow.rb:38:10:38:13 | args [element :p2] :  |
+| params_flow.rb:37:16:37:24 | call to taint :  | params_flow.rb:37:1:37:4 | args [element :p1] :  |
+| params_flow.rb:37:34:37:42 | call to taint :  | params_flow.rb:37:1:37:4 | args [element :p2] :  |
 | params_flow.rb:38:8:38:13 | ** ... [element :p1] :  | params_flow.rb:25:12:25:13 | p1 :  |
 | params_flow.rb:38:8:38:13 | ** ... [element :p2] :  | params_flow.rb:25:17:25:24 | **kwargs [element :p2] :  |
 | params_flow.rb:38:10:38:13 | args [element :p1] :  | params_flow.rb:38:8:38:13 | ** ... [element :p1] :  |
 | params_flow.rb:38:10:38:13 | args [element :p2] :  | params_flow.rb:38:8:38:13 | ** ... [element :p2] :  |
-| params_flow.rb:40:16:40:24 | call to taint :  | params_flow.rb:41:26:41:29 | args [element :p1] :  |
+| params_flow.rb:40:1:40:4 | args [element :p1] :  | params_flow.rb:41:26:41:29 | args [element :p1] :  |
+| params_flow.rb:40:16:40:24 | call to taint :  | params_flow.rb:40:1:40:4 | args [element :p1] :  |
 | params_flow.rb:41:13:41:21 | call to taint :  | params_flow.rb:16:18:16:19 | p2 :  |
 | params_flow.rb:41:24:41:29 | ** ... [element :p1] :  | params_flow.rb:16:13:16:14 | p1 :  |
 | params_flow.rb:41:26:41:29 | args [element :p1] :  | params_flow.rb:41:24:41:29 | ** ... [element :p1] :  |
@@ -40,7 +44,8 @@ edges
 | params_flow.rb:49:13:49:14 | p1 :  | params_flow.rb:50:10:50:11 | p1 |
 | params_flow.rb:54:9:54:17 | call to taint :  | params_flow.rb:49:13:49:14 | p1 :  |
 | params_flow.rb:57:9:57:17 | call to taint :  | params_flow.rb:49:13:49:14 | p1 :  |
-| params_flow.rb:62:8:62:16 | call to taint :  | params_flow.rb:66:13:66:16 | args :  |
+| params_flow.rb:62:1:62:4 | args :  | params_flow.rb:66:13:66:16 | args :  |
+| params_flow.rb:62:8:62:16 | call to taint :  | params_flow.rb:62:1:62:4 | args :  |
 | params_flow.rb:63:16:63:17 | *x [element 0] :  | params_flow.rb:64:10:64:10 | x [element 0] :  |
 | params_flow.rb:64:10:64:10 | x [element 0] :  | params_flow.rb:64:10:64:13 | ...[...] |
 | params_flow.rb:66:12:66:16 | * ... [element 0] :  | params_flow.rb:63:16:63:17 | *x [element 0] :  |
@@ -75,16 +80,20 @@ nodes
 | params_flow.rb:33:12:33:19 | call to taint :  | semmle.label | call to taint :  |
 | params_flow.rb:33:26:33:34 | call to taint :  | semmle.label | call to taint :  |
 | params_flow.rb:33:41:33:49 | call to taint :  | semmle.label | call to taint :  |
+| params_flow.rb:34:1:34:4 | args [element :p3] :  | semmle.label | args [element :p3] :  |
 | params_flow.rb:34:14:34:22 | call to taint :  | semmle.label | call to taint :  |
 | params_flow.rb:35:12:35:20 | call to taint :  | semmle.label | call to taint :  |
 | params_flow.rb:35:23:35:28 | ** ... [element :p3] :  | semmle.label | ** ... [element :p3] :  |
 | params_flow.rb:35:25:35:28 | args [element :p3] :  | semmle.label | args [element :p3] :  |
+| params_flow.rb:37:1:37:4 | args [element :p1] :  | semmle.label | args [element :p1] :  |
+| params_flow.rb:37:1:37:4 | args [element :p2] :  | semmle.label | args [element :p2] :  |
 | params_flow.rb:37:16:37:24 | call to taint :  | semmle.label | call to taint :  |
 | params_flow.rb:37:34:37:42 | call to taint :  | semmle.label | call to taint :  |
 | params_flow.rb:38:8:38:13 | ** ... [element :p1] :  | semmle.label | ** ... [element :p1] :  |
 | params_flow.rb:38:8:38:13 | ** ... [element :p2] :  | semmle.label | ** ... [element :p2] :  |
 | params_flow.rb:38:10:38:13 | args [element :p1] :  | semmle.label | args [element :p1] :  |
 | params_flow.rb:38:10:38:13 | args [element :p2] :  | semmle.label | args [element :p2] :  |
+| params_flow.rb:40:1:40:4 | args [element :p1] :  | semmle.label | args [element :p1] :  |
 | params_flow.rb:40:16:40:24 | call to taint :  | semmle.label | call to taint :  |
 | params_flow.rb:41:13:41:21 | call to taint :  | semmle.label | call to taint :  |
 | params_flow.rb:41:24:41:29 | ** ... [element :p1] :  | semmle.label | ** ... [element :p1] :  |
@@ -94,6 +103,7 @@ nodes
 | params_flow.rb:50:10:50:11 | p1 | semmle.label | p1 |
 | params_flow.rb:54:9:54:17 | call to taint :  | semmle.label | call to taint :  |
 | params_flow.rb:57:9:57:17 | call to taint :  | semmle.label | call to taint :  |
+| params_flow.rb:62:1:62:4 | args :  | semmle.label | args :  |
 | params_flow.rb:62:8:62:16 | call to taint :  | semmle.label | call to taint :  |
 | params_flow.rb:63:16:63:17 | *x [element 0] :  | semmle.label | *x [element 0] :  |
 | params_flow.rb:64:10:64:10 | x [element 0] :  | semmle.label | x [element 0] :  |

--- a/ruby/ql/test/library-tests/dataflow/pathname-flow/pathame-flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/pathname-flow/pathame-flow.expected
@@ -1,216 +1,290 @@
 failures
 edges
-| pathname_flow.rb:4:10:4:33 | call to new :  | pathname_flow.rb:5:10:5:11 | pn |
+| pathname_flow.rb:4:5:4:6 | pn :  | pathname_flow.rb:5:10:5:11 | pn |
+| pathname_flow.rb:4:10:4:33 | call to new :  | pathname_flow.rb:4:5:4:6 | pn :  |
 | pathname_flow.rb:4:23:4:32 | call to source :  | pathname_flow.rb:4:10:4:33 | call to new :  |
-| pathname_flow.rb:9:7:9:30 | call to new :  | pathname_flow.rb:11:8:11:12 | ... + ... |
+| pathname_flow.rb:9:3:9:3 | a :  | pathname_flow.rb:11:8:11:12 | ... + ... |
+| pathname_flow.rb:9:7:9:30 | call to new :  | pathname_flow.rb:9:3:9:3 | a :  |
 | pathname_flow.rb:9:20:9:29 | call to source :  | pathname_flow.rb:9:7:9:30 | call to new :  |
-| pathname_flow.rb:10:7:10:30 | call to new :  | pathname_flow.rb:11:8:11:12 | ... + ... |
+| pathname_flow.rb:10:3:10:3 | b :  | pathname_flow.rb:11:8:11:12 | ... + ... |
+| pathname_flow.rb:10:7:10:30 | call to new :  | pathname_flow.rb:10:3:10:3 | b :  |
 | pathname_flow.rb:10:20:10:29 | call to source :  | pathname_flow.rb:10:7:10:30 | call to new :  |
-| pathname_flow.rb:15:8:15:31 | call to new :  | pathname_flow.rb:16:8:16:9 | pn :  |
+| pathname_flow.rb:15:3:15:4 | pn :  | pathname_flow.rb:16:8:16:9 | pn :  |
+| pathname_flow.rb:15:8:15:31 | call to new :  | pathname_flow.rb:15:3:15:4 | pn :  |
 | pathname_flow.rb:15:21:15:30 | call to source :  | pathname_flow.rb:15:8:15:31 | call to new :  |
 | pathname_flow.rb:16:8:16:9 | pn :  | pathname_flow.rb:16:8:16:17 | call to dirname |
-| pathname_flow.rb:20:7:20:30 | call to new :  | pathname_flow.rb:21:3:21:3 | a :  |
+| pathname_flow.rb:20:3:20:3 | a :  | pathname_flow.rb:21:3:21:3 | a :  |
+| pathname_flow.rb:20:7:20:30 | call to new :  | pathname_flow.rb:20:3:20:3 | a :  |
 | pathname_flow.rb:20:20:20:29 | call to source :  | pathname_flow.rb:20:7:20:30 | call to new :  |
 | pathname_flow.rb:21:3:21:3 | a :  | pathname_flow.rb:21:23:21:23 | x :  |
 | pathname_flow.rb:21:23:21:23 | x :  | pathname_flow.rb:22:10:22:10 | x |
-| pathname_flow.rb:27:7:27:30 | call to new :  | pathname_flow.rb:28:8:28:8 | a :  |
+| pathname_flow.rb:27:3:27:3 | a :  | pathname_flow.rb:28:8:28:8 | a :  |
+| pathname_flow.rb:27:7:27:30 | call to new :  | pathname_flow.rb:27:3:27:3 | a :  |
 | pathname_flow.rb:27:20:27:29 | call to source :  | pathname_flow.rb:27:7:27:30 | call to new :  |
 | pathname_flow.rb:28:8:28:8 | a :  | pathname_flow.rb:28:8:28:22 | call to expand_path |
-| pathname_flow.rb:32:7:32:30 | call to new :  | pathname_flow.rb:35:8:35:8 | a :  |
+| pathname_flow.rb:32:3:32:3 | a :  | pathname_flow.rb:35:8:35:8 | a :  |
+| pathname_flow.rb:32:7:32:30 | call to new :  | pathname_flow.rb:32:3:32:3 | a :  |
 | pathname_flow.rb:32:20:32:29 | call to source :  | pathname_flow.rb:32:7:32:30 | call to new :  |
-| pathname_flow.rb:34:7:34:30 | call to new :  | pathname_flow.rb:35:18:35:18 | c :  |
+| pathname_flow.rb:34:3:34:3 | c :  | pathname_flow.rb:35:18:35:18 | c :  |
+| pathname_flow.rb:34:7:34:30 | call to new :  | pathname_flow.rb:34:3:34:3 | c :  |
 | pathname_flow.rb:34:20:34:29 | call to source :  | pathname_flow.rb:34:7:34:30 | call to new :  |
 | pathname_flow.rb:35:8:35:8 | a :  | pathname_flow.rb:35:8:35:19 | call to join |
 | pathname_flow.rb:35:18:35:18 | c :  | pathname_flow.rb:35:8:35:19 | call to join |
-| pathname_flow.rb:39:7:39:30 | call to new :  | pathname_flow.rb:40:8:40:8 | a :  |
+| pathname_flow.rb:39:3:39:3 | a :  | pathname_flow.rb:40:8:40:8 | a :  |
+| pathname_flow.rb:39:7:39:30 | call to new :  | pathname_flow.rb:39:3:39:3 | a :  |
 | pathname_flow.rb:39:20:39:29 | call to source :  | pathname_flow.rb:39:7:39:30 | call to new :  |
 | pathname_flow.rb:40:8:40:8 | a :  | pathname_flow.rb:40:8:40:17 | call to parent |
-| pathname_flow.rb:44:7:44:30 | call to new :  | pathname_flow.rb:45:8:45:8 | a :  |
+| pathname_flow.rb:44:3:44:3 | a :  | pathname_flow.rb:45:8:45:8 | a :  |
+| pathname_flow.rb:44:7:44:30 | call to new :  | pathname_flow.rb:44:3:44:3 | a :  |
 | pathname_flow.rb:44:20:44:29 | call to source :  | pathname_flow.rb:44:7:44:30 | call to new :  |
 | pathname_flow.rb:45:8:45:8 | a :  | pathname_flow.rb:45:8:45:19 | call to realpath |
-| pathname_flow.rb:49:7:49:30 | call to new :  | pathname_flow.rb:50:8:50:8 | a :  |
+| pathname_flow.rb:49:3:49:3 | a :  | pathname_flow.rb:50:8:50:8 | a :  |
+| pathname_flow.rb:49:7:49:30 | call to new :  | pathname_flow.rb:49:3:49:3 | a :  |
 | pathname_flow.rb:49:20:49:29 | call to source :  | pathname_flow.rb:49:7:49:30 | call to new :  |
 | pathname_flow.rb:50:8:50:8 | a :  | pathname_flow.rb:50:8:50:39 | call to relative_path_from |
-| pathname_flow.rb:54:7:54:30 | call to new :  | pathname_flow.rb:55:8:55:8 | a :  |
+| pathname_flow.rb:54:3:54:3 | a :  | pathname_flow.rb:55:8:55:8 | a :  |
+| pathname_flow.rb:54:7:54:30 | call to new :  | pathname_flow.rb:54:3:54:3 | a :  |
 | pathname_flow.rb:54:20:54:29 | call to source :  | pathname_flow.rb:54:7:54:30 | call to new :  |
 | pathname_flow.rb:55:8:55:8 | a :  | pathname_flow.rb:55:8:55:16 | call to to_path |
-| pathname_flow.rb:59:7:59:30 | call to new :  | pathname_flow.rb:60:8:60:8 | a :  |
+| pathname_flow.rb:59:3:59:3 | a :  | pathname_flow.rb:60:8:60:8 | a :  |
+| pathname_flow.rb:59:7:59:30 | call to new :  | pathname_flow.rb:59:3:59:3 | a :  |
 | pathname_flow.rb:59:20:59:29 | call to source :  | pathname_flow.rb:59:7:59:30 | call to new :  |
 | pathname_flow.rb:60:8:60:8 | a :  | pathname_flow.rb:60:8:60:13 | call to to_s |
-| pathname_flow.rb:64:7:64:30 | call to new :  | pathname_flow.rb:66:8:66:8 | b |
+| pathname_flow.rb:64:3:64:3 | a :  | pathname_flow.rb:65:3:65:3 | b :  |
+| pathname_flow.rb:64:7:64:30 | call to new :  | pathname_flow.rb:64:3:64:3 | a :  |
 | pathname_flow.rb:64:20:64:29 | call to source :  | pathname_flow.rb:64:7:64:30 | call to new :  |
-| pathname_flow.rb:70:7:70:30 | call to new :  | pathname_flow.rb:72:8:72:8 | b |
+| pathname_flow.rb:65:3:65:3 | b :  | pathname_flow.rb:66:8:66:8 | b |
+| pathname_flow.rb:70:3:70:3 | a :  | pathname_flow.rb:71:3:71:3 | b :  |
+| pathname_flow.rb:70:7:70:30 | call to new :  | pathname_flow.rb:70:3:70:3 | a :  |
 | pathname_flow.rb:70:20:70:29 | call to source :  | pathname_flow.rb:70:7:70:30 | call to new :  |
-| pathname_flow.rb:76:7:76:30 | call to new :  | pathname_flow.rb:77:7:77:7 | a :  |
+| pathname_flow.rb:71:3:71:3 | b :  | pathname_flow.rb:72:8:72:8 | b |
+| pathname_flow.rb:76:3:76:3 | a :  | pathname_flow.rb:77:7:77:7 | a :  |
+| pathname_flow.rb:76:7:76:30 | call to new :  | pathname_flow.rb:76:3:76:3 | a :  |
 | pathname_flow.rb:76:20:76:29 | call to source :  | pathname_flow.rb:76:7:76:30 | call to new :  |
+| pathname_flow.rb:77:3:77:3 | b :  | pathname_flow.rb:78:8:78:8 | b |
 | pathname_flow.rb:77:7:77:7 | a :  | pathname_flow.rb:77:7:77:16 | call to basename :  |
-| pathname_flow.rb:77:7:77:16 | call to basename :  | pathname_flow.rb:78:8:78:8 | b |
-| pathname_flow.rb:82:7:82:30 | call to new :  | pathname_flow.rb:83:7:83:7 | a :  |
+| pathname_flow.rb:77:7:77:16 | call to basename :  | pathname_flow.rb:77:3:77:3 | b :  |
+| pathname_flow.rb:82:3:82:3 | a :  | pathname_flow.rb:83:7:83:7 | a :  |
+| pathname_flow.rb:82:7:82:30 | call to new :  | pathname_flow.rb:82:3:82:3 | a :  |
 | pathname_flow.rb:82:20:82:29 | call to source :  | pathname_flow.rb:82:7:82:30 | call to new :  |
+| pathname_flow.rb:83:3:83:3 | b :  | pathname_flow.rb:84:8:84:8 | b |
 | pathname_flow.rb:83:7:83:7 | a :  | pathname_flow.rb:83:7:83:17 | call to cleanpath :  |
-| pathname_flow.rb:83:7:83:17 | call to cleanpath :  | pathname_flow.rb:84:8:84:8 | b |
-| pathname_flow.rb:88:7:88:30 | call to new :  | pathname_flow.rb:89:7:89:7 | a :  |
+| pathname_flow.rb:83:7:83:17 | call to cleanpath :  | pathname_flow.rb:83:3:83:3 | b :  |
+| pathname_flow.rb:88:3:88:3 | a :  | pathname_flow.rb:89:7:89:7 | a :  |
+| pathname_flow.rb:88:7:88:30 | call to new :  | pathname_flow.rb:88:3:88:3 | a :  |
 | pathname_flow.rb:88:20:88:29 | call to source :  | pathname_flow.rb:88:7:88:30 | call to new :  |
+| pathname_flow.rb:89:3:89:3 | b :  | pathname_flow.rb:90:8:90:8 | b |
 | pathname_flow.rb:89:7:89:7 | a :  | pathname_flow.rb:89:7:89:25 | call to sub :  |
-| pathname_flow.rb:89:7:89:25 | call to sub :  | pathname_flow.rb:90:8:90:8 | b |
-| pathname_flow.rb:94:7:94:30 | call to new :  | pathname_flow.rb:95:7:95:7 | a :  |
+| pathname_flow.rb:89:7:89:25 | call to sub :  | pathname_flow.rb:89:3:89:3 | b :  |
+| pathname_flow.rb:94:3:94:3 | a :  | pathname_flow.rb:95:7:95:7 | a :  |
+| pathname_flow.rb:94:7:94:30 | call to new :  | pathname_flow.rb:94:3:94:3 | a :  |
 | pathname_flow.rb:94:20:94:29 | call to source :  | pathname_flow.rb:94:7:94:30 | call to new :  |
+| pathname_flow.rb:95:3:95:3 | b :  | pathname_flow.rb:96:8:96:8 | b |
 | pathname_flow.rb:95:7:95:7 | a :  | pathname_flow.rb:95:7:95:23 | call to sub_ext :  |
-| pathname_flow.rb:95:7:95:23 | call to sub_ext :  | pathname_flow.rb:96:8:96:8 | b |
-| pathname_flow.rb:101:7:101:30 | call to new :  | pathname_flow.rb:104:8:104:8 | b :  |
-| pathname_flow.rb:101:7:101:30 | call to new :  | pathname_flow.rb:107:8:107:8 | c :  |
-| pathname_flow.rb:101:7:101:30 | call to new :  | pathname_flow.rb:109:7:109:7 | a :  |
-| pathname_flow.rb:101:7:101:30 | call to new :  | pathname_flow.rb:112:7:112:7 | a :  |
-| pathname_flow.rb:101:7:101:30 | call to new :  | pathname_flow.rb:115:7:115:7 | a :  |
-| pathname_flow.rb:101:7:101:30 | call to new :  | pathname_flow.rb:118:7:118:7 | a :  |
-| pathname_flow.rb:101:7:101:30 | call to new :  | pathname_flow.rb:121:7:121:7 | a :  |
-| pathname_flow.rb:101:7:101:30 | call to new :  | pathname_flow.rb:124:7:124:7 | a :  |
-| pathname_flow.rb:101:7:101:30 | call to new :  | pathname_flow.rb:127:7:127:7 | a :  |
-| pathname_flow.rb:101:7:101:30 | call to new :  | pathname_flow.rb:130:7:130:7 | a :  |
-| pathname_flow.rb:101:7:101:30 | call to new :  | pathname_flow.rb:133:7:133:7 | a :  |
+| pathname_flow.rb:95:7:95:23 | call to sub_ext :  | pathname_flow.rb:95:3:95:3 | b :  |
+| pathname_flow.rb:101:3:101:3 | a :  | pathname_flow.rb:103:3:103:3 | b :  |
+| pathname_flow.rb:101:3:101:3 | a :  | pathname_flow.rb:106:3:106:3 | c :  |
+| pathname_flow.rb:101:3:101:3 | a :  | pathname_flow.rb:109:7:109:7 | a :  |
+| pathname_flow.rb:101:3:101:3 | a :  | pathname_flow.rb:112:7:112:7 | a :  |
+| pathname_flow.rb:101:3:101:3 | a :  | pathname_flow.rb:115:7:115:7 | a :  |
+| pathname_flow.rb:101:3:101:3 | a :  | pathname_flow.rb:118:7:118:7 | a :  |
+| pathname_flow.rb:101:3:101:3 | a :  | pathname_flow.rb:121:7:121:7 | a :  |
+| pathname_flow.rb:101:3:101:3 | a :  | pathname_flow.rb:124:7:124:7 | a :  |
+| pathname_flow.rb:101:3:101:3 | a :  | pathname_flow.rb:127:7:127:7 | a :  |
+| pathname_flow.rb:101:3:101:3 | a :  | pathname_flow.rb:130:7:130:7 | a :  |
+| pathname_flow.rb:101:3:101:3 | a :  | pathname_flow.rb:133:7:133:7 | a :  |
+| pathname_flow.rb:101:7:101:30 | call to new :  | pathname_flow.rb:101:3:101:3 | a :  |
 | pathname_flow.rb:101:20:101:29 | call to source :  | pathname_flow.rb:101:7:101:30 | call to new :  |
+| pathname_flow.rb:103:3:103:3 | b :  | pathname_flow.rb:104:8:104:8 | b :  |
 | pathname_flow.rb:104:8:104:8 | b :  | pathname_flow.rb:104:8:104:17 | call to realpath |
+| pathname_flow.rb:106:3:106:3 | c :  | pathname_flow.rb:107:8:107:8 | c :  |
 | pathname_flow.rb:107:8:107:8 | c :  | pathname_flow.rb:107:8:107:17 | call to realpath |
+| pathname_flow.rb:109:3:109:3 | d :  | pathname_flow.rb:110:8:110:8 | d :  |
 | pathname_flow.rb:109:7:109:7 | a :  | pathname_flow.rb:109:7:109:16 | call to basename :  |
-| pathname_flow.rb:109:7:109:16 | call to basename :  | pathname_flow.rb:110:8:110:8 | d :  |
+| pathname_flow.rb:109:7:109:16 | call to basename :  | pathname_flow.rb:109:3:109:3 | d :  |
 | pathname_flow.rb:110:8:110:8 | d :  | pathname_flow.rb:110:8:110:17 | call to realpath |
+| pathname_flow.rb:112:3:112:3 | e :  | pathname_flow.rb:113:8:113:8 | e :  |
 | pathname_flow.rb:112:7:112:7 | a :  | pathname_flow.rb:112:7:112:17 | call to cleanpath :  |
-| pathname_flow.rb:112:7:112:17 | call to cleanpath :  | pathname_flow.rb:113:8:113:8 | e :  |
+| pathname_flow.rb:112:7:112:17 | call to cleanpath :  | pathname_flow.rb:112:3:112:3 | e :  |
 | pathname_flow.rb:113:8:113:8 | e :  | pathname_flow.rb:113:8:113:17 | call to realpath |
+| pathname_flow.rb:115:3:115:3 | f :  | pathname_flow.rb:116:8:116:8 | f :  |
 | pathname_flow.rb:115:7:115:7 | a :  | pathname_flow.rb:115:7:115:19 | call to expand_path :  |
-| pathname_flow.rb:115:7:115:19 | call to expand_path :  | pathname_flow.rb:116:8:116:8 | f :  |
+| pathname_flow.rb:115:7:115:19 | call to expand_path :  | pathname_flow.rb:115:3:115:3 | f :  |
 | pathname_flow.rb:116:8:116:8 | f :  | pathname_flow.rb:116:8:116:17 | call to realpath |
+| pathname_flow.rb:118:3:118:3 | g :  | pathname_flow.rb:119:8:119:8 | g :  |
 | pathname_flow.rb:118:7:118:7 | a :  | pathname_flow.rb:118:7:118:19 | call to join :  |
-| pathname_flow.rb:118:7:118:19 | call to join :  | pathname_flow.rb:119:8:119:8 | g :  |
+| pathname_flow.rb:118:7:118:19 | call to join :  | pathname_flow.rb:118:3:118:3 | g :  |
 | pathname_flow.rb:119:8:119:8 | g :  | pathname_flow.rb:119:8:119:17 | call to realpath |
+| pathname_flow.rb:121:3:121:3 | h :  | pathname_flow.rb:122:8:122:8 | h :  |
 | pathname_flow.rb:121:7:121:7 | a :  | pathname_flow.rb:121:7:121:16 | call to realpath :  |
-| pathname_flow.rb:121:7:121:16 | call to realpath :  | pathname_flow.rb:122:8:122:8 | h :  |
+| pathname_flow.rb:121:7:121:16 | call to realpath :  | pathname_flow.rb:121:3:121:3 | h :  |
 | pathname_flow.rb:122:8:122:8 | h :  | pathname_flow.rb:122:8:122:17 | call to realpath |
+| pathname_flow.rb:124:3:124:3 | i :  | pathname_flow.rb:125:8:125:8 | i :  |
 | pathname_flow.rb:124:7:124:7 | a :  | pathname_flow.rb:124:7:124:38 | call to relative_path_from :  |
-| pathname_flow.rb:124:7:124:38 | call to relative_path_from :  | pathname_flow.rb:125:8:125:8 | i :  |
+| pathname_flow.rb:124:7:124:38 | call to relative_path_from :  | pathname_flow.rb:124:3:124:3 | i :  |
 | pathname_flow.rb:125:8:125:8 | i :  | pathname_flow.rb:125:8:125:17 | call to realpath |
+| pathname_flow.rb:127:3:127:3 | j :  | pathname_flow.rb:128:8:128:8 | j :  |
 | pathname_flow.rb:127:7:127:7 | a :  | pathname_flow.rb:127:7:127:25 | call to sub :  |
-| pathname_flow.rb:127:7:127:25 | call to sub :  | pathname_flow.rb:128:8:128:8 | j :  |
+| pathname_flow.rb:127:7:127:25 | call to sub :  | pathname_flow.rb:127:3:127:3 | j :  |
 | pathname_flow.rb:128:8:128:8 | j :  | pathname_flow.rb:128:8:128:17 | call to realpath |
+| pathname_flow.rb:130:3:130:3 | k :  | pathname_flow.rb:131:8:131:8 | k :  |
 | pathname_flow.rb:130:7:130:7 | a :  | pathname_flow.rb:130:7:130:23 | call to sub_ext :  |
-| pathname_flow.rb:130:7:130:23 | call to sub_ext :  | pathname_flow.rb:131:8:131:8 | k :  |
+| pathname_flow.rb:130:7:130:23 | call to sub_ext :  | pathname_flow.rb:130:3:130:3 | k :  |
 | pathname_flow.rb:131:8:131:8 | k :  | pathname_flow.rb:131:8:131:17 | call to realpath |
+| pathname_flow.rb:133:3:133:3 | l :  | pathname_flow.rb:134:8:134:8 | l :  |
 | pathname_flow.rb:133:7:133:7 | a :  | pathname_flow.rb:133:7:133:15 | call to to_path :  |
-| pathname_flow.rb:133:7:133:15 | call to to_path :  | pathname_flow.rb:134:8:134:8 | l :  |
+| pathname_flow.rb:133:7:133:15 | call to to_path :  | pathname_flow.rb:133:3:133:3 | l :  |
 | pathname_flow.rb:134:8:134:8 | l :  | pathname_flow.rb:134:8:134:17 | call to realpath |
 nodes
+| pathname_flow.rb:4:5:4:6 | pn :  | semmle.label | pn :  |
 | pathname_flow.rb:4:10:4:33 | call to new :  | semmle.label | call to new :  |
 | pathname_flow.rb:4:23:4:32 | call to source :  | semmle.label | call to source :  |
 | pathname_flow.rb:5:10:5:11 | pn | semmle.label | pn |
+| pathname_flow.rb:9:3:9:3 | a :  | semmle.label | a :  |
 | pathname_flow.rb:9:7:9:30 | call to new :  | semmle.label | call to new :  |
 | pathname_flow.rb:9:20:9:29 | call to source :  | semmle.label | call to source :  |
+| pathname_flow.rb:10:3:10:3 | b :  | semmle.label | b :  |
 | pathname_flow.rb:10:7:10:30 | call to new :  | semmle.label | call to new :  |
 | pathname_flow.rb:10:20:10:29 | call to source :  | semmle.label | call to source :  |
 | pathname_flow.rb:11:8:11:12 | ... + ... | semmle.label | ... + ... |
+| pathname_flow.rb:15:3:15:4 | pn :  | semmle.label | pn :  |
 | pathname_flow.rb:15:8:15:31 | call to new :  | semmle.label | call to new :  |
 | pathname_flow.rb:15:21:15:30 | call to source :  | semmle.label | call to source :  |
 | pathname_flow.rb:16:8:16:9 | pn :  | semmle.label | pn :  |
 | pathname_flow.rb:16:8:16:17 | call to dirname | semmle.label | call to dirname |
+| pathname_flow.rb:20:3:20:3 | a :  | semmle.label | a :  |
 | pathname_flow.rb:20:7:20:30 | call to new :  | semmle.label | call to new :  |
 | pathname_flow.rb:20:20:20:29 | call to source :  | semmle.label | call to source :  |
 | pathname_flow.rb:21:3:21:3 | a :  | semmle.label | a :  |
 | pathname_flow.rb:21:23:21:23 | x :  | semmle.label | x :  |
 | pathname_flow.rb:22:10:22:10 | x | semmle.label | x |
+| pathname_flow.rb:27:3:27:3 | a :  | semmle.label | a :  |
 | pathname_flow.rb:27:7:27:30 | call to new :  | semmle.label | call to new :  |
 | pathname_flow.rb:27:20:27:29 | call to source :  | semmle.label | call to source :  |
 | pathname_flow.rb:28:8:28:8 | a :  | semmle.label | a :  |
 | pathname_flow.rb:28:8:28:22 | call to expand_path | semmle.label | call to expand_path |
+| pathname_flow.rb:32:3:32:3 | a :  | semmle.label | a :  |
 | pathname_flow.rb:32:7:32:30 | call to new :  | semmle.label | call to new :  |
 | pathname_flow.rb:32:20:32:29 | call to source :  | semmle.label | call to source :  |
+| pathname_flow.rb:34:3:34:3 | c :  | semmle.label | c :  |
 | pathname_flow.rb:34:7:34:30 | call to new :  | semmle.label | call to new :  |
 | pathname_flow.rb:34:20:34:29 | call to source :  | semmle.label | call to source :  |
 | pathname_flow.rb:35:8:35:8 | a :  | semmle.label | a :  |
 | pathname_flow.rb:35:8:35:19 | call to join | semmle.label | call to join |
 | pathname_flow.rb:35:18:35:18 | c :  | semmle.label | c :  |
+| pathname_flow.rb:39:3:39:3 | a :  | semmle.label | a :  |
 | pathname_flow.rb:39:7:39:30 | call to new :  | semmle.label | call to new :  |
 | pathname_flow.rb:39:20:39:29 | call to source :  | semmle.label | call to source :  |
 | pathname_flow.rb:40:8:40:8 | a :  | semmle.label | a :  |
 | pathname_flow.rb:40:8:40:17 | call to parent | semmle.label | call to parent |
+| pathname_flow.rb:44:3:44:3 | a :  | semmle.label | a :  |
 | pathname_flow.rb:44:7:44:30 | call to new :  | semmle.label | call to new :  |
 | pathname_flow.rb:44:20:44:29 | call to source :  | semmle.label | call to source :  |
 | pathname_flow.rb:45:8:45:8 | a :  | semmle.label | a :  |
 | pathname_flow.rb:45:8:45:19 | call to realpath | semmle.label | call to realpath |
+| pathname_flow.rb:49:3:49:3 | a :  | semmle.label | a :  |
 | pathname_flow.rb:49:7:49:30 | call to new :  | semmle.label | call to new :  |
 | pathname_flow.rb:49:20:49:29 | call to source :  | semmle.label | call to source :  |
 | pathname_flow.rb:50:8:50:8 | a :  | semmle.label | a :  |
 | pathname_flow.rb:50:8:50:39 | call to relative_path_from | semmle.label | call to relative_path_from |
+| pathname_flow.rb:54:3:54:3 | a :  | semmle.label | a :  |
 | pathname_flow.rb:54:7:54:30 | call to new :  | semmle.label | call to new :  |
 | pathname_flow.rb:54:20:54:29 | call to source :  | semmle.label | call to source :  |
 | pathname_flow.rb:55:8:55:8 | a :  | semmle.label | a :  |
 | pathname_flow.rb:55:8:55:16 | call to to_path | semmle.label | call to to_path |
+| pathname_flow.rb:59:3:59:3 | a :  | semmle.label | a :  |
 | pathname_flow.rb:59:7:59:30 | call to new :  | semmle.label | call to new :  |
 | pathname_flow.rb:59:20:59:29 | call to source :  | semmle.label | call to source :  |
 | pathname_flow.rb:60:8:60:8 | a :  | semmle.label | a :  |
 | pathname_flow.rb:60:8:60:13 | call to to_s | semmle.label | call to to_s |
+| pathname_flow.rb:64:3:64:3 | a :  | semmle.label | a :  |
 | pathname_flow.rb:64:7:64:30 | call to new :  | semmle.label | call to new :  |
 | pathname_flow.rb:64:20:64:29 | call to source :  | semmle.label | call to source :  |
+| pathname_flow.rb:65:3:65:3 | b :  | semmle.label | b :  |
 | pathname_flow.rb:66:8:66:8 | b | semmle.label | b |
+| pathname_flow.rb:70:3:70:3 | a :  | semmle.label | a :  |
 | pathname_flow.rb:70:7:70:30 | call to new :  | semmle.label | call to new :  |
 | pathname_flow.rb:70:20:70:29 | call to source :  | semmle.label | call to source :  |
+| pathname_flow.rb:71:3:71:3 | b :  | semmle.label | b :  |
 | pathname_flow.rb:72:8:72:8 | b | semmle.label | b |
+| pathname_flow.rb:76:3:76:3 | a :  | semmle.label | a :  |
 | pathname_flow.rb:76:7:76:30 | call to new :  | semmle.label | call to new :  |
 | pathname_flow.rb:76:20:76:29 | call to source :  | semmle.label | call to source :  |
+| pathname_flow.rb:77:3:77:3 | b :  | semmle.label | b :  |
 | pathname_flow.rb:77:7:77:7 | a :  | semmle.label | a :  |
 | pathname_flow.rb:77:7:77:16 | call to basename :  | semmle.label | call to basename :  |
 | pathname_flow.rb:78:8:78:8 | b | semmle.label | b |
+| pathname_flow.rb:82:3:82:3 | a :  | semmle.label | a :  |
 | pathname_flow.rb:82:7:82:30 | call to new :  | semmle.label | call to new :  |
 | pathname_flow.rb:82:20:82:29 | call to source :  | semmle.label | call to source :  |
+| pathname_flow.rb:83:3:83:3 | b :  | semmle.label | b :  |
 | pathname_flow.rb:83:7:83:7 | a :  | semmle.label | a :  |
 | pathname_flow.rb:83:7:83:17 | call to cleanpath :  | semmle.label | call to cleanpath :  |
 | pathname_flow.rb:84:8:84:8 | b | semmle.label | b |
+| pathname_flow.rb:88:3:88:3 | a :  | semmle.label | a :  |
 | pathname_flow.rb:88:7:88:30 | call to new :  | semmle.label | call to new :  |
 | pathname_flow.rb:88:20:88:29 | call to source :  | semmle.label | call to source :  |
+| pathname_flow.rb:89:3:89:3 | b :  | semmle.label | b :  |
 | pathname_flow.rb:89:7:89:7 | a :  | semmle.label | a :  |
 | pathname_flow.rb:89:7:89:25 | call to sub :  | semmle.label | call to sub :  |
 | pathname_flow.rb:90:8:90:8 | b | semmle.label | b |
+| pathname_flow.rb:94:3:94:3 | a :  | semmle.label | a :  |
 | pathname_flow.rb:94:7:94:30 | call to new :  | semmle.label | call to new :  |
 | pathname_flow.rb:94:20:94:29 | call to source :  | semmle.label | call to source :  |
+| pathname_flow.rb:95:3:95:3 | b :  | semmle.label | b :  |
 | pathname_flow.rb:95:7:95:7 | a :  | semmle.label | a :  |
 | pathname_flow.rb:95:7:95:23 | call to sub_ext :  | semmle.label | call to sub_ext :  |
 | pathname_flow.rb:96:8:96:8 | b | semmle.label | b |
+| pathname_flow.rb:101:3:101:3 | a :  | semmle.label | a :  |
 | pathname_flow.rb:101:7:101:30 | call to new :  | semmle.label | call to new :  |
 | pathname_flow.rb:101:20:101:29 | call to source :  | semmle.label | call to source :  |
+| pathname_flow.rb:103:3:103:3 | b :  | semmle.label | b :  |
 | pathname_flow.rb:104:8:104:8 | b :  | semmle.label | b :  |
 | pathname_flow.rb:104:8:104:17 | call to realpath | semmle.label | call to realpath |
+| pathname_flow.rb:106:3:106:3 | c :  | semmle.label | c :  |
 | pathname_flow.rb:107:8:107:8 | c :  | semmle.label | c :  |
 | pathname_flow.rb:107:8:107:17 | call to realpath | semmle.label | call to realpath |
+| pathname_flow.rb:109:3:109:3 | d :  | semmle.label | d :  |
 | pathname_flow.rb:109:7:109:7 | a :  | semmle.label | a :  |
 | pathname_flow.rb:109:7:109:16 | call to basename :  | semmle.label | call to basename :  |
 | pathname_flow.rb:110:8:110:8 | d :  | semmle.label | d :  |
 | pathname_flow.rb:110:8:110:17 | call to realpath | semmle.label | call to realpath |
+| pathname_flow.rb:112:3:112:3 | e :  | semmle.label | e :  |
 | pathname_flow.rb:112:7:112:7 | a :  | semmle.label | a :  |
 | pathname_flow.rb:112:7:112:17 | call to cleanpath :  | semmle.label | call to cleanpath :  |
 | pathname_flow.rb:113:8:113:8 | e :  | semmle.label | e :  |
 | pathname_flow.rb:113:8:113:17 | call to realpath | semmle.label | call to realpath |
+| pathname_flow.rb:115:3:115:3 | f :  | semmle.label | f :  |
 | pathname_flow.rb:115:7:115:7 | a :  | semmle.label | a :  |
 | pathname_flow.rb:115:7:115:19 | call to expand_path :  | semmle.label | call to expand_path :  |
 | pathname_flow.rb:116:8:116:8 | f :  | semmle.label | f :  |
 | pathname_flow.rb:116:8:116:17 | call to realpath | semmle.label | call to realpath |
+| pathname_flow.rb:118:3:118:3 | g :  | semmle.label | g :  |
 | pathname_flow.rb:118:7:118:7 | a :  | semmle.label | a :  |
 | pathname_flow.rb:118:7:118:19 | call to join :  | semmle.label | call to join :  |
 | pathname_flow.rb:119:8:119:8 | g :  | semmle.label | g :  |
 | pathname_flow.rb:119:8:119:17 | call to realpath | semmle.label | call to realpath |
+| pathname_flow.rb:121:3:121:3 | h :  | semmle.label | h :  |
 | pathname_flow.rb:121:7:121:7 | a :  | semmle.label | a :  |
 | pathname_flow.rb:121:7:121:16 | call to realpath :  | semmle.label | call to realpath :  |
 | pathname_flow.rb:122:8:122:8 | h :  | semmle.label | h :  |
 | pathname_flow.rb:122:8:122:17 | call to realpath | semmle.label | call to realpath |
+| pathname_flow.rb:124:3:124:3 | i :  | semmle.label | i :  |
 | pathname_flow.rb:124:7:124:7 | a :  | semmle.label | a :  |
 | pathname_flow.rb:124:7:124:38 | call to relative_path_from :  | semmle.label | call to relative_path_from :  |
 | pathname_flow.rb:125:8:125:8 | i :  | semmle.label | i :  |
 | pathname_flow.rb:125:8:125:17 | call to realpath | semmle.label | call to realpath |
+| pathname_flow.rb:127:3:127:3 | j :  | semmle.label | j :  |
 | pathname_flow.rb:127:7:127:7 | a :  | semmle.label | a :  |
 | pathname_flow.rb:127:7:127:25 | call to sub :  | semmle.label | call to sub :  |
 | pathname_flow.rb:128:8:128:8 | j :  | semmle.label | j :  |
 | pathname_flow.rb:128:8:128:17 | call to realpath | semmle.label | call to realpath |
+| pathname_flow.rb:130:3:130:3 | k :  | semmle.label | k :  |
 | pathname_flow.rb:130:7:130:7 | a :  | semmle.label | a :  |
 | pathname_flow.rb:130:7:130:23 | call to sub_ext :  | semmle.label | call to sub_ext :  |
 | pathname_flow.rb:131:8:131:8 | k :  | semmle.label | k :  |
 | pathname_flow.rb:131:8:131:17 | call to realpath | semmle.label | call to realpath |
+| pathname_flow.rb:133:3:133:3 | l :  | semmle.label | l :  |
 | pathname_flow.rb:133:7:133:7 | a :  | semmle.label | a :  |
 | pathname_flow.rb:133:7:133:15 | call to to_path :  | semmle.label | call to to_path :  |
 | pathname_flow.rb:134:8:134:8 | l :  | semmle.label | l :  |

--- a/ruby/ql/test/library-tests/dataflow/string-flow/string-flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/string-flow/string-flow.expected
@@ -2,126 +2,161 @@ failures
 | string_flow.rb:85:10:85:10 | a | Unexpected result: hasValueFlow=a |
 | string_flow.rb:227:10:227:10 | a | Unexpected result: hasValueFlow=a |
 edges
-| string_flow.rb:2:9:2:18 | call to source :  | string_flow.rb:3:21:3:21 | a :  |
-| string_flow.rb:2:9:2:18 | call to source :  | string_flow.rb:3:21:3:21 | a :  |
+| string_flow.rb:2:5:2:5 | a :  | string_flow.rb:3:21:3:21 | a :  |
+| string_flow.rb:2:5:2:5 | a :  | string_flow.rb:3:21:3:21 | a :  |
+| string_flow.rb:2:9:2:18 | call to source :  | string_flow.rb:2:5:2:5 | a :  |
+| string_flow.rb:2:9:2:18 | call to source :  | string_flow.rb:2:5:2:5 | a :  |
 | string_flow.rb:3:21:3:21 | a :  | string_flow.rb:3:10:3:22 | call to new |
 | string_flow.rb:3:21:3:21 | a :  | string_flow.rb:3:10:3:22 | call to new |
-| string_flow.rb:7:9:7:18 | call to source :  | string_flow.rb:9:29:9:29 | a :  |
-| string_flow.rb:8:9:8:16 | call to source :  | string_flow.rb:10:29:10:29 | b :  |
+| string_flow.rb:7:5:7:5 | a :  | string_flow.rb:9:29:9:29 | a :  |
+| string_flow.rb:7:9:7:18 | call to source :  | string_flow.rb:7:5:7:5 | a :  |
+| string_flow.rb:8:5:8:5 | b :  | string_flow.rb:10:29:10:29 | b :  |
+| string_flow.rb:8:9:8:16 | call to source :  | string_flow.rb:8:5:8:5 | b :  |
 | string_flow.rb:9:29:9:29 | a :  | string_flow.rb:9:10:9:30 | call to try_convert |
 | string_flow.rb:10:29:10:29 | b :  | string_flow.rb:10:10:10:30 | call to try_convert |
-| string_flow.rb:14:9:14:18 | call to source :  | string_flow.rb:15:10:15:17 | ... % ... |
-| string_flow.rb:14:9:14:18 | call to source :  | string_flow.rb:15:17:15:17 | a :  |
-| string_flow.rb:14:9:14:18 | call to source :  | string_flow.rb:16:10:16:29 | ... % ... |
-| string_flow.rb:14:9:14:18 | call to source :  | string_flow.rb:16:28:16:28 | a :  |
-| string_flow.rb:14:9:14:18 | call to source :  | string_flow.rb:17:10:17:10 | a :  |
-| string_flow.rb:14:9:14:18 | call to source :  | string_flow.rb:17:10:17:18 | ... % ... |
+| string_flow.rb:14:5:14:5 | a :  | string_flow.rb:15:10:15:17 | ... % ... |
+| string_flow.rb:14:5:14:5 | a :  | string_flow.rb:15:17:15:17 | a :  |
+| string_flow.rb:14:5:14:5 | a :  | string_flow.rb:16:10:16:29 | ... % ... |
+| string_flow.rb:14:5:14:5 | a :  | string_flow.rb:16:28:16:28 | a :  |
+| string_flow.rb:14:5:14:5 | a :  | string_flow.rb:17:10:17:10 | a :  |
+| string_flow.rb:14:5:14:5 | a :  | string_flow.rb:17:10:17:18 | ... % ... |
+| string_flow.rb:14:9:14:18 | call to source :  | string_flow.rb:14:5:14:5 | a :  |
 | string_flow.rb:15:17:15:17 | a :  | string_flow.rb:15:10:15:17 | ... % ... |
 | string_flow.rb:16:28:16:28 | a :  | string_flow.rb:16:10:16:29 | ... % ... |
 | string_flow.rb:17:10:17:10 | a :  | string_flow.rb:17:10:17:18 | ... % ... |
-| string_flow.rb:21:9:21:18 | call to source :  | string_flow.rb:23:10:23:10 | b |
-| string_flow.rb:27:9:27:18 | call to source :  | string_flow.rb:29:10:29:10 | b |
-| string_flow.rb:33:9:33:18 | call to source :  | string_flow.rb:35:10:35:10 | b |
-| string_flow.rb:33:9:33:18 | call to source :  | string_flow.rb:37:10:37:10 | c |
-| string_flow.rb:41:9:41:18 | call to source :  | string_flow.rb:42:10:42:10 | a :  |
+| string_flow.rb:21:5:21:5 | a :  | string_flow.rb:22:5:22:5 | b :  |
+| string_flow.rb:21:9:21:18 | call to source :  | string_flow.rb:21:5:21:5 | a :  |
+| string_flow.rb:22:5:22:5 | b :  | string_flow.rb:23:10:23:10 | b |
+| string_flow.rb:27:5:27:5 | a :  | string_flow.rb:28:5:28:5 | b :  |
+| string_flow.rb:27:9:27:18 | call to source :  | string_flow.rb:27:5:27:5 | a :  |
+| string_flow.rb:28:5:28:5 | b :  | string_flow.rb:29:10:29:10 | b |
+| string_flow.rb:33:5:33:5 | a :  | string_flow.rb:34:5:34:5 | b :  |
+| string_flow.rb:33:5:33:5 | a :  | string_flow.rb:36:5:36:5 | c :  |
+| string_flow.rb:33:9:33:18 | call to source :  | string_flow.rb:33:5:33:5 | a :  |
+| string_flow.rb:34:5:34:5 | b :  | string_flow.rb:35:10:35:10 | b |
+| string_flow.rb:36:5:36:5 | c :  | string_flow.rb:37:10:37:10 | c |
+| string_flow.rb:41:5:41:5 | a :  | string_flow.rb:42:10:42:10 | a :  |
+| string_flow.rb:41:9:41:18 | call to source :  | string_flow.rb:41:5:41:5 | a :  |
 | string_flow.rb:42:10:42:10 | a :  | string_flow.rb:42:10:42:12 | call to b |
-| string_flow.rb:46:9:46:18 | call to source :  | string_flow.rb:47:10:47:10 | a :  |
-| string_flow.rb:46:9:46:18 | call to source :  | string_flow.rb:48:10:48:10 | a :  |
-| string_flow.rb:46:9:46:18 | call to source :  | string_flow.rb:49:10:49:10 | a :  |
+| string_flow.rb:46:5:46:5 | a :  | string_flow.rb:47:10:47:10 | a :  |
+| string_flow.rb:46:5:46:5 | a :  | string_flow.rb:48:10:48:10 | a :  |
+| string_flow.rb:46:5:46:5 | a :  | string_flow.rb:49:10:49:10 | a :  |
+| string_flow.rb:46:9:46:18 | call to source :  | string_flow.rb:46:5:46:5 | a :  |
 | string_flow.rb:47:10:47:10 | a :  | string_flow.rb:47:10:47:23 | call to byteslice |
 | string_flow.rb:48:10:48:10 | a :  | string_flow.rb:48:10:48:26 | call to byteslice |
 | string_flow.rb:49:10:49:10 | a :  | string_flow.rb:49:10:49:26 | call to byteslice |
-| string_flow.rb:53:9:53:18 | call to source :  | string_flow.rb:54:10:54:10 | a :  |
-| string_flow.rb:53:9:53:18 | call to source :  | string_flow.rb:55:10:55:10 | a :  |
+| string_flow.rb:53:5:53:5 | a :  | string_flow.rb:54:10:54:10 | a :  |
+| string_flow.rb:53:5:53:5 | a :  | string_flow.rb:55:10:55:10 | a :  |
+| string_flow.rb:53:9:53:18 | call to source :  | string_flow.rb:53:5:53:5 | a :  |
 | string_flow.rb:54:10:54:10 | a :  | string_flow.rb:54:10:54:21 | call to capitalize |
 | string_flow.rb:55:10:55:10 | a :  | string_flow.rb:55:10:55:22 | call to capitalize! |
-| string_flow.rb:59:9:59:18 | call to source :  | string_flow.rb:60:10:60:10 | a :  |
-| string_flow.rb:59:9:59:18 | call to source :  | string_flow.rb:61:27:61:27 | a :  |
-| string_flow.rb:59:9:59:18 | call to source :  | string_flow.rb:62:10:62:10 | a :  |
-| string_flow.rb:59:9:59:18 | call to source :  | string_flow.rb:63:26:63:26 | a :  |
-| string_flow.rb:59:9:59:18 | call to source :  | string_flow.rb:64:10:64:10 | a :  |
-| string_flow.rb:59:9:59:18 | call to source :  | string_flow.rb:65:26:65:26 | a :  |
+| string_flow.rb:59:5:59:5 | a :  | string_flow.rb:60:10:60:10 | a :  |
+| string_flow.rb:59:5:59:5 | a :  | string_flow.rb:61:27:61:27 | a :  |
+| string_flow.rb:59:5:59:5 | a :  | string_flow.rb:62:10:62:10 | a :  |
+| string_flow.rb:59:5:59:5 | a :  | string_flow.rb:63:26:63:26 | a :  |
+| string_flow.rb:59:5:59:5 | a :  | string_flow.rb:64:10:64:10 | a :  |
+| string_flow.rb:59:5:59:5 | a :  | string_flow.rb:65:26:65:26 | a :  |
+| string_flow.rb:59:9:59:18 | call to source :  | string_flow.rb:59:5:59:5 | a :  |
 | string_flow.rb:60:10:60:10 | a :  | string_flow.rb:60:10:60:21 | call to center |
 | string_flow.rb:61:27:61:27 | a :  | string_flow.rb:61:10:61:28 | call to center |
 | string_flow.rb:62:10:62:10 | a :  | string_flow.rb:62:10:62:20 | call to ljust |
 | string_flow.rb:63:26:63:26 | a :  | string_flow.rb:63:10:63:27 | call to ljust |
 | string_flow.rb:64:10:64:10 | a :  | string_flow.rb:64:10:64:20 | call to rjust |
 | string_flow.rb:65:26:65:26 | a :  | string_flow.rb:65:10:65:27 | call to rjust |
-| string_flow.rb:69:9:69:18 | call to source :  | string_flow.rb:70:10:70:10 | a :  |
-| string_flow.rb:69:9:69:18 | call to source :  | string_flow.rb:71:10:71:10 | a :  |
+| string_flow.rb:69:5:69:5 | a :  | string_flow.rb:70:10:70:10 | a :  |
+| string_flow.rb:69:5:69:5 | a :  | string_flow.rb:71:10:71:10 | a :  |
+| string_flow.rb:69:9:69:18 | call to source :  | string_flow.rb:69:5:69:5 | a :  |
 | string_flow.rb:70:10:70:10 | a :  | string_flow.rb:70:10:70:16 | call to chomp |
 | string_flow.rb:71:10:71:10 | a :  | string_flow.rb:71:10:71:17 | call to chomp! |
-| string_flow.rb:75:9:75:18 | call to source :  | string_flow.rb:76:10:76:10 | a :  |
-| string_flow.rb:75:9:75:18 | call to source :  | string_flow.rb:77:10:77:10 | a :  |
+| string_flow.rb:75:5:75:5 | a :  | string_flow.rb:76:10:76:10 | a :  |
+| string_flow.rb:75:5:75:5 | a :  | string_flow.rb:77:10:77:10 | a :  |
+| string_flow.rb:75:9:75:18 | call to source :  | string_flow.rb:75:5:75:5 | a :  |
 | string_flow.rb:76:10:76:10 | a :  | string_flow.rb:76:10:76:15 | call to chop |
 | string_flow.rb:77:10:77:10 | a :  | string_flow.rb:77:10:77:16 | call to chop! |
-| string_flow.rb:83:9:83:18 | call to source :  | string_flow.rb:84:5:84:5 | a :  |
-| string_flow.rb:83:9:83:18 | call to source :  | string_flow.rb:84:5:84:5 | a :  |
+| string_flow.rb:83:5:83:5 | a :  | string_flow.rb:84:5:84:5 | a :  |
+| string_flow.rb:83:5:83:5 | a :  | string_flow.rb:84:5:84:5 | a :  |
+| string_flow.rb:83:9:83:18 | call to source :  | string_flow.rb:83:5:83:5 | a :  |
+| string_flow.rb:83:9:83:18 | call to source :  | string_flow.rb:83:5:83:5 | a :  |
 | string_flow.rb:84:5:84:5 | [post] a :  | string_flow.rb:85:10:85:10 | a |
 | string_flow.rb:84:5:84:5 | [post] a :  | string_flow.rb:85:10:85:10 | a |
 | string_flow.rb:84:5:84:5 | a :  | string_flow.rb:84:5:84:5 | [post] a :  |
 | string_flow.rb:84:5:84:5 | a :  | string_flow.rb:84:5:84:5 | [post] a :  |
-| string_flow.rb:108:9:108:18 | call to source :  | string_flow.rb:109:10:109:10 | a :  |
+| string_flow.rb:108:5:108:5 | a :  | string_flow.rb:109:10:109:10 | a :  |
+| string_flow.rb:108:9:108:18 | call to source :  | string_flow.rb:108:5:108:5 | a :  |
 | string_flow.rb:109:10:109:10 | [post] a :  | string_flow.rb:110:10:110:10 | a :  |
 | string_flow.rb:109:10:109:10 | [post] a :  | string_flow.rb:111:10:111:10 | a :  |
 | string_flow.rb:109:10:109:10 | a :  | string_flow.rb:109:10:109:10 | [post] a :  |
 | string_flow.rb:109:10:109:10 | a :  | string_flow.rb:109:10:109:22 | call to delete |
 | string_flow.rb:110:10:110:10 | a :  | string_flow.rb:110:10:110:29 | call to delete_prefix |
 | string_flow.rb:111:10:111:10 | a :  | string_flow.rb:111:10:111:29 | call to delete_suffix |
-| string_flow.rb:115:9:115:18 | call to source :  | string_flow.rb:116:10:116:10 | a :  |
-| string_flow.rb:115:9:115:18 | call to source :  | string_flow.rb:117:10:117:10 | a :  |
-| string_flow.rb:115:9:115:18 | call to source :  | string_flow.rb:118:10:118:10 | a :  |
-| string_flow.rb:115:9:115:18 | call to source :  | string_flow.rb:119:10:119:10 | a :  |
-| string_flow.rb:115:9:115:18 | call to source :  | string_flow.rb:120:10:120:10 | a :  |
-| string_flow.rb:115:9:115:18 | call to source :  | string_flow.rb:121:10:121:10 | a :  |
+| string_flow.rb:115:5:115:5 | a :  | string_flow.rb:116:10:116:10 | a :  |
+| string_flow.rb:115:5:115:5 | a :  | string_flow.rb:117:10:117:10 | a :  |
+| string_flow.rb:115:5:115:5 | a :  | string_flow.rb:118:10:118:10 | a :  |
+| string_flow.rb:115:5:115:5 | a :  | string_flow.rb:119:10:119:10 | a :  |
+| string_flow.rb:115:5:115:5 | a :  | string_flow.rb:120:10:120:10 | a :  |
+| string_flow.rb:115:5:115:5 | a :  | string_flow.rb:121:10:121:10 | a :  |
+| string_flow.rb:115:9:115:18 | call to source :  | string_flow.rb:115:5:115:5 | a :  |
 | string_flow.rb:116:10:116:10 | a :  | string_flow.rb:116:10:116:19 | call to downcase |
 | string_flow.rb:117:10:117:10 | a :  | string_flow.rb:117:10:117:20 | call to downcase! |
 | string_flow.rb:118:10:118:10 | a :  | string_flow.rb:118:10:118:19 | call to swapcase |
 | string_flow.rb:119:10:119:10 | a :  | string_flow.rb:119:10:119:20 | call to swapcase! |
 | string_flow.rb:120:10:120:10 | a :  | string_flow.rb:120:10:120:17 | call to upcase |
 | string_flow.rb:121:10:121:10 | a :  | string_flow.rb:121:10:121:18 | call to upcase! |
-| string_flow.rb:125:9:125:18 | call to source :  | string_flow.rb:126:9:126:9 | a :  |
+| string_flow.rb:125:5:125:5 | a :  | string_flow.rb:126:9:126:9 | a :  |
+| string_flow.rb:125:9:125:18 | call to source :  | string_flow.rb:125:5:125:5 | a :  |
+| string_flow.rb:126:5:126:5 | b :  | string_flow.rb:127:10:127:10 | b |
+| string_flow.rb:126:5:126:5 | b :  | string_flow.rb:128:10:128:10 | b :  |
 | string_flow.rb:126:9:126:9 | a :  | string_flow.rb:126:9:126:14 | call to dump :  |
-| string_flow.rb:126:9:126:14 | call to dump :  | string_flow.rb:127:10:127:10 | b |
-| string_flow.rb:126:9:126:14 | call to dump :  | string_flow.rb:128:10:128:10 | b :  |
+| string_flow.rb:126:9:126:14 | call to dump :  | string_flow.rb:126:5:126:5 | b :  |
 | string_flow.rb:128:10:128:10 | b :  | string_flow.rb:128:10:128:17 | call to undump |
-| string_flow.rb:132:9:132:18 | call to source :  | string_flow.rb:133:9:133:9 | a :  |
-| string_flow.rb:132:9:132:18 | call to source :  | string_flow.rb:135:9:135:9 | a :  |
+| string_flow.rb:132:5:132:5 | a :  | string_flow.rb:133:9:133:9 | a :  |
+| string_flow.rb:132:5:132:5 | a :  | string_flow.rb:135:9:135:9 | a :  |
+| string_flow.rb:132:9:132:18 | call to source :  | string_flow.rb:132:5:132:5 | a :  |
+| string_flow.rb:133:5:133:5 | b :  | string_flow.rb:134:10:134:10 | b |
 | string_flow.rb:133:9:133:9 | a :  | string_flow.rb:133:9:133:40 | call to each_line :  |
 | string_flow.rb:133:9:133:9 | a :  | string_flow.rb:133:24:133:27 | line :  |
-| string_flow.rb:133:9:133:40 | call to each_line :  | string_flow.rb:134:10:134:10 | b |
+| string_flow.rb:133:9:133:40 | call to each_line :  | string_flow.rb:133:5:133:5 | b :  |
 | string_flow.rb:133:24:133:27 | line :  | string_flow.rb:133:35:133:38 | line |
+| string_flow.rb:135:5:135:5 | c [element] :  | string_flow.rb:136:10:136:10 | c [element] :  |
 | string_flow.rb:135:9:135:9 | a :  | string_flow.rb:135:9:135:19 | call to each_line [element] :  |
-| string_flow.rb:135:9:135:19 | call to each_line [element] :  | string_flow.rb:136:10:136:10 | c [element] :  |
+| string_flow.rb:135:9:135:19 | call to each_line [element] :  | string_flow.rb:135:5:135:5 | c [element] :  |
 | string_flow.rb:136:10:136:10 | c [element] :  | string_flow.rb:136:10:136:15 | call to to_a [element] :  |
 | string_flow.rb:136:10:136:15 | call to to_a [element] :  | string_flow.rb:136:10:136:18 | ...[...] |
-| string_flow.rb:140:9:140:18 | call to source :  | string_flow.rb:141:9:141:9 | a :  |
-| string_flow.rb:140:9:140:18 | call to source :  | string_flow.rb:143:9:143:9 | a :  |
+| string_flow.rb:140:5:140:5 | a :  | string_flow.rb:141:9:141:9 | a :  |
+| string_flow.rb:140:5:140:5 | a :  | string_flow.rb:143:9:143:9 | a :  |
+| string_flow.rb:140:9:140:18 | call to source :  | string_flow.rb:140:5:140:5 | a :  |
+| string_flow.rb:141:5:141:5 | b :  | string_flow.rb:142:10:142:10 | b |
 | string_flow.rb:141:9:141:9 | a :  | string_flow.rb:141:9:141:36 | call to lines :  |
 | string_flow.rb:141:9:141:9 | a :  | string_flow.rb:141:20:141:23 | line :  |
-| string_flow.rb:141:9:141:36 | call to lines :  | string_flow.rb:142:10:142:10 | b |
+| string_flow.rb:141:9:141:36 | call to lines :  | string_flow.rb:141:5:141:5 | b :  |
 | string_flow.rb:141:20:141:23 | line :  | string_flow.rb:141:31:141:34 | line |
+| string_flow.rb:143:5:143:5 | c [element] :  | string_flow.rb:144:10:144:10 | c [element] :  |
 | string_flow.rb:143:9:143:9 | a :  | string_flow.rb:143:9:143:15 | call to lines [element] :  |
-| string_flow.rb:143:9:143:15 | call to lines [element] :  | string_flow.rb:144:10:144:10 | c [element] :  |
+| string_flow.rb:143:9:143:15 | call to lines [element] :  | string_flow.rb:143:5:143:5 | c [element] :  |
 | string_flow.rb:144:10:144:10 | c [element] :  | string_flow.rb:144:10:144:13 | ...[...] |
-| string_flow.rb:148:9:148:18 | call to source :  | string_flow.rb:149:10:149:10 | a :  |
-| string_flow.rb:148:9:148:18 | call to source :  | string_flow.rb:150:10:150:10 | a :  |
-| string_flow.rb:148:9:148:18 | call to source :  | string_flow.rb:151:10:151:10 | a :  |
-| string_flow.rb:148:9:148:18 | call to source :  | string_flow.rb:152:10:152:10 | a :  |
+| string_flow.rb:148:5:148:5 | a :  | string_flow.rb:149:10:149:10 | a :  |
+| string_flow.rb:148:5:148:5 | a :  | string_flow.rb:150:10:150:10 | a :  |
+| string_flow.rb:148:5:148:5 | a :  | string_flow.rb:151:10:151:10 | a :  |
+| string_flow.rb:148:5:148:5 | a :  | string_flow.rb:152:10:152:10 | a :  |
+| string_flow.rb:148:9:148:18 | call to source :  | string_flow.rb:148:5:148:5 | a :  |
 | string_flow.rb:149:10:149:10 | a :  | string_flow.rb:149:10:149:26 | call to encode |
 | string_flow.rb:150:10:150:10 | a :  | string_flow.rb:150:10:150:27 | call to encode! |
 | string_flow.rb:151:10:151:10 | a :  | string_flow.rb:151:10:151:28 | call to unicode_normalize |
 | string_flow.rb:152:10:152:10 | a :  | string_flow.rb:152:10:152:29 | call to unicode_normalize! |
-| string_flow.rb:156:9:156:18 | call to source :  | string_flow.rb:157:10:157:10 | a :  |
+| string_flow.rb:156:5:156:5 | a :  | string_flow.rb:157:10:157:10 | a :  |
+| string_flow.rb:156:9:156:18 | call to source :  | string_flow.rb:156:5:156:5 | a :  |
 | string_flow.rb:157:10:157:10 | a :  | string_flow.rb:157:10:157:34 | call to force_encoding |
-| string_flow.rb:161:9:161:18 | call to source :  | string_flow.rb:162:10:162:10 | a :  |
+| string_flow.rb:161:5:161:5 | a :  | string_flow.rb:162:10:162:10 | a :  |
+| string_flow.rb:161:9:161:18 | call to source :  | string_flow.rb:161:5:161:5 | a :  |
 | string_flow.rb:162:10:162:10 | a :  | string_flow.rb:162:10:162:17 | call to freeze |
-| string_flow.rb:166:9:166:18 | call to source :  | string_flow.rb:168:10:168:10 | a :  |
-| string_flow.rb:166:9:166:18 | call to source :  | string_flow.rb:169:10:169:10 | a :  |
-| string_flow.rb:166:9:166:18 | call to source :  | string_flow.rb:170:10:170:10 | a :  |
-| string_flow.rb:166:9:166:18 | call to source :  | string_flow.rb:171:10:171:10 | a :  |
-| string_flow.rb:167:9:167:18 | call to source :  | string_flow.rb:168:22:168:22 | c :  |
-| string_flow.rb:167:9:167:18 | call to source :  | string_flow.rb:169:23:169:23 | c :  |
+| string_flow.rb:166:5:166:5 | a :  | string_flow.rb:168:10:168:10 | a :  |
+| string_flow.rb:166:5:166:5 | a :  | string_flow.rb:169:10:169:10 | a :  |
+| string_flow.rb:166:5:166:5 | a :  | string_flow.rb:170:10:170:10 | a :  |
+| string_flow.rb:166:5:166:5 | a :  | string_flow.rb:171:10:171:10 | a :  |
+| string_flow.rb:166:9:166:18 | call to source :  | string_flow.rb:166:5:166:5 | a :  |
+| string_flow.rb:167:5:167:5 | c :  | string_flow.rb:168:22:168:22 | c :  |
+| string_flow.rb:167:5:167:5 | c :  | string_flow.rb:169:23:169:23 | c :  |
+| string_flow.rb:167:9:167:18 | call to source :  | string_flow.rb:167:5:167:5 | c :  |
 | string_flow.rb:168:10:168:10 | a :  | string_flow.rb:168:10:168:23 | call to gsub |
 | string_flow.rb:168:22:168:22 | c :  | string_flow.rb:168:10:168:23 | call to gsub |
 | string_flow.rb:169:10:169:10 | a :  | string_flow.rb:169:10:169:24 | call to gsub! |
@@ -130,12 +165,14 @@ edges
 | string_flow.rb:170:32:170:41 | call to source :  | string_flow.rb:170:10:170:43 | call to gsub |
 | string_flow.rb:171:10:171:10 | a :  | string_flow.rb:171:10:171:44 | call to gsub! |
 | string_flow.rb:171:33:171:42 | call to source :  | string_flow.rb:171:10:171:44 | call to gsub! |
-| string_flow.rb:175:9:175:18 | call to source :  | string_flow.rb:177:10:177:10 | a :  |
-| string_flow.rb:175:9:175:18 | call to source :  | string_flow.rb:178:10:178:10 | a :  |
-| string_flow.rb:175:9:175:18 | call to source :  | string_flow.rb:179:10:179:10 | a :  |
-| string_flow.rb:175:9:175:18 | call to source :  | string_flow.rb:180:10:180:10 | a :  |
-| string_flow.rb:176:9:176:18 | call to source :  | string_flow.rb:177:21:177:21 | c :  |
-| string_flow.rb:176:9:176:18 | call to source :  | string_flow.rb:178:22:178:22 | c :  |
+| string_flow.rb:175:5:175:5 | a :  | string_flow.rb:177:10:177:10 | a :  |
+| string_flow.rb:175:5:175:5 | a :  | string_flow.rb:178:10:178:10 | a :  |
+| string_flow.rb:175:5:175:5 | a :  | string_flow.rb:179:10:179:10 | a :  |
+| string_flow.rb:175:5:175:5 | a :  | string_flow.rb:180:10:180:10 | a :  |
+| string_flow.rb:175:9:175:18 | call to source :  | string_flow.rb:175:5:175:5 | a :  |
+| string_flow.rb:176:5:176:5 | c :  | string_flow.rb:177:21:177:21 | c :  |
+| string_flow.rb:176:5:176:5 | c :  | string_flow.rb:178:22:178:22 | c :  |
+| string_flow.rb:176:9:176:18 | call to source :  | string_flow.rb:176:5:176:5 | c :  |
 | string_flow.rb:177:10:177:10 | a :  | string_flow.rb:177:10:177:22 | call to sub |
 | string_flow.rb:177:21:177:21 | c :  | string_flow.rb:177:10:177:22 | call to sub |
 | string_flow.rb:178:10:178:10 | a :  | string_flow.rb:178:10:178:23 | call to sub! |
@@ -144,70 +181,84 @@ edges
 | string_flow.rb:179:31:179:40 | call to source :  | string_flow.rb:179:10:179:42 | call to sub |
 | string_flow.rb:180:10:180:10 | a :  | string_flow.rb:180:10:180:43 | call to sub! |
 | string_flow.rb:180:32:180:41 | call to source :  | string_flow.rb:180:10:180:43 | call to sub! |
-| string_flow.rb:191:9:191:18 | call to source :  | string_flow.rb:192:10:192:10 | a :  |
+| string_flow.rb:191:5:191:5 | a :  | string_flow.rb:192:10:192:10 | a :  |
+| string_flow.rb:191:9:191:18 | call to source :  | string_flow.rb:191:5:191:5 | a :  |
 | string_flow.rb:192:10:192:10 | a :  | string_flow.rb:192:10:192:18 | call to inspect |
-| string_flow.rb:196:9:196:18 | call to source :  | string_flow.rb:197:10:197:10 | a :  |
-| string_flow.rb:196:9:196:18 | call to source :  | string_flow.rb:198:10:198:10 | a :  |
-| string_flow.rb:196:9:196:18 | call to source :  | string_flow.rb:199:10:199:10 | a :  |
-| string_flow.rb:196:9:196:18 | call to source :  | string_flow.rb:200:10:200:10 | a :  |
-| string_flow.rb:196:9:196:18 | call to source :  | string_flow.rb:201:10:201:10 | a :  |
-| string_flow.rb:196:9:196:18 | call to source :  | string_flow.rb:202:10:202:10 | a :  |
+| string_flow.rb:196:5:196:5 | a :  | string_flow.rb:197:10:197:10 | a :  |
+| string_flow.rb:196:5:196:5 | a :  | string_flow.rb:198:10:198:10 | a :  |
+| string_flow.rb:196:5:196:5 | a :  | string_flow.rb:199:10:199:10 | a :  |
+| string_flow.rb:196:5:196:5 | a :  | string_flow.rb:200:10:200:10 | a :  |
+| string_flow.rb:196:5:196:5 | a :  | string_flow.rb:201:10:201:10 | a :  |
+| string_flow.rb:196:5:196:5 | a :  | string_flow.rb:202:10:202:10 | a :  |
+| string_flow.rb:196:9:196:18 | call to source :  | string_flow.rb:196:5:196:5 | a :  |
 | string_flow.rb:197:10:197:10 | a :  | string_flow.rb:197:10:197:16 | call to strip |
 | string_flow.rb:198:10:198:10 | a :  | string_flow.rb:198:10:198:17 | call to strip! |
 | string_flow.rb:199:10:199:10 | a :  | string_flow.rb:199:10:199:17 | call to lstrip |
 | string_flow.rb:200:10:200:10 | a :  | string_flow.rb:200:10:200:18 | call to lstrip! |
 | string_flow.rb:201:10:201:10 | a :  | string_flow.rb:201:10:201:17 | call to rstrip |
 | string_flow.rb:202:10:202:10 | a :  | string_flow.rb:202:10:202:18 | call to rstrip! |
-| string_flow.rb:206:9:206:18 | call to source :  | string_flow.rb:207:10:207:10 | a :  |
-| string_flow.rb:206:9:206:18 | call to source :  | string_flow.rb:208:10:208:10 | a :  |
-| string_flow.rb:206:9:206:18 | call to source :  | string_flow.rb:209:10:209:10 | a :  |
-| string_flow.rb:206:9:206:18 | call to source :  | string_flow.rb:210:10:210:10 | a :  |
+| string_flow.rb:206:5:206:5 | a :  | string_flow.rb:207:10:207:10 | a :  |
+| string_flow.rb:206:5:206:5 | a :  | string_flow.rb:208:10:208:10 | a :  |
+| string_flow.rb:206:5:206:5 | a :  | string_flow.rb:209:10:209:10 | a :  |
+| string_flow.rb:206:5:206:5 | a :  | string_flow.rb:210:10:210:10 | a :  |
+| string_flow.rb:206:9:206:18 | call to source :  | string_flow.rb:206:5:206:5 | a :  |
 | string_flow.rb:207:10:207:10 | a :  | string_flow.rb:207:10:207:15 | call to next |
 | string_flow.rb:208:10:208:10 | a :  | string_flow.rb:208:10:208:16 | call to next! |
 | string_flow.rb:209:10:209:10 | a :  | string_flow.rb:209:10:209:15 | call to succ |
 | string_flow.rb:210:10:210:10 | a :  | string_flow.rb:210:10:210:16 | call to succ! |
-| string_flow.rb:214:9:214:18 | call to source :  | string_flow.rb:215:9:215:9 | a :  |
+| string_flow.rb:214:5:214:5 | a :  | string_flow.rb:215:9:215:9 | a :  |
+| string_flow.rb:214:9:214:18 | call to source :  | string_flow.rb:214:5:214:5 | a :  |
+| string_flow.rb:215:5:215:5 | b [element 0] :  | string_flow.rb:216:10:216:10 | b [element 0] :  |
+| string_flow.rb:215:5:215:5 | b [element 1] :  | string_flow.rb:217:10:217:10 | b [element 1] :  |
+| string_flow.rb:215:5:215:5 | b [element 2] :  | string_flow.rb:218:10:218:10 | b [element 2] :  |
 | string_flow.rb:215:9:215:9 | a :  | string_flow.rb:215:9:215:24 | call to partition [element 0] :  |
 | string_flow.rb:215:9:215:9 | a :  | string_flow.rb:215:9:215:24 | call to partition [element 1] :  |
 | string_flow.rb:215:9:215:9 | a :  | string_flow.rb:215:9:215:24 | call to partition [element 2] :  |
-| string_flow.rb:215:9:215:24 | call to partition [element 0] :  | string_flow.rb:216:10:216:10 | b [element 0] :  |
-| string_flow.rb:215:9:215:24 | call to partition [element 1] :  | string_flow.rb:217:10:217:10 | b [element 1] :  |
-| string_flow.rb:215:9:215:24 | call to partition [element 2] :  | string_flow.rb:218:10:218:10 | b [element 2] :  |
+| string_flow.rb:215:9:215:24 | call to partition [element 0] :  | string_flow.rb:215:5:215:5 | b [element 0] :  |
+| string_flow.rb:215:9:215:24 | call to partition [element 1] :  | string_flow.rb:215:5:215:5 | b [element 1] :  |
+| string_flow.rb:215:9:215:24 | call to partition [element 2] :  | string_flow.rb:215:5:215:5 | b [element 2] :  |
 | string_flow.rb:216:10:216:10 | b [element 0] :  | string_flow.rb:216:10:216:13 | ...[...] |
 | string_flow.rb:217:10:217:10 | b [element 1] :  | string_flow.rb:217:10:217:13 | ...[...] |
 | string_flow.rb:218:10:218:10 | b [element 2] :  | string_flow.rb:218:10:218:13 | ...[...] |
-| string_flow.rb:223:9:223:18 | call to source :  | string_flow.rb:225:10:225:10 | a :  |
-| string_flow.rb:223:9:223:18 | call to source :  | string_flow.rb:225:10:225:10 | a :  |
-| string_flow.rb:224:9:224:18 | call to source :  | string_flow.rb:225:20:225:20 | b :  |
+| string_flow.rb:223:5:223:5 | a :  | string_flow.rb:225:10:225:10 | a :  |
+| string_flow.rb:223:5:223:5 | a :  | string_flow.rb:225:10:225:10 | a :  |
+| string_flow.rb:223:9:223:18 | call to source :  | string_flow.rb:223:5:223:5 | a :  |
+| string_flow.rb:223:9:223:18 | call to source :  | string_flow.rb:223:5:223:5 | a :  |
+| string_flow.rb:224:5:224:5 | b :  | string_flow.rb:225:20:225:20 | b :  |
+| string_flow.rb:224:9:224:18 | call to source :  | string_flow.rb:224:5:224:5 | b :  |
 | string_flow.rb:225:10:225:10 | [post] a :  | string_flow.rb:227:10:227:10 | a |
 | string_flow.rb:225:10:225:10 | [post] a :  | string_flow.rb:227:10:227:10 | a |
 | string_flow.rb:225:10:225:10 | a :  | string_flow.rb:225:10:225:10 | [post] a :  |
 | string_flow.rb:225:10:225:10 | a :  | string_flow.rb:225:10:225:10 | [post] a :  |
 | string_flow.rb:225:20:225:20 | b :  | string_flow.rb:225:10:225:10 | [post] a :  |
 | string_flow.rb:225:20:225:20 | b :  | string_flow.rb:225:10:225:21 | call to replace |
-| string_flow.rb:231:9:231:18 | call to source :  | string_flow.rb:232:10:232:10 | a :  |
+| string_flow.rb:231:5:231:5 | a :  | string_flow.rb:232:10:232:10 | a :  |
+| string_flow.rb:231:9:231:18 | call to source :  | string_flow.rb:231:5:231:5 | a :  |
 | string_flow.rb:232:10:232:10 | a :  | string_flow.rb:232:10:232:18 | call to reverse |
-| string_flow.rb:236:9:236:18 | call to source :  | string_flow.rb:237:9:237:9 | a :  |
-| string_flow.rb:236:9:236:18 | call to source :  | string_flow.rb:238:9:238:9 | a :  |
-| string_flow.rb:236:9:236:18 | call to source :  | string_flow.rb:240:9:240:9 | a :  |
+| string_flow.rb:236:5:236:5 | a :  | string_flow.rb:237:9:237:9 | a :  |
+| string_flow.rb:236:5:236:5 | a :  | string_flow.rb:238:9:238:9 | a :  |
+| string_flow.rb:236:5:236:5 | a :  | string_flow.rb:240:9:240:9 | a :  |
+| string_flow.rb:236:9:236:18 | call to source :  | string_flow.rb:236:5:236:5 | a :  |
 | string_flow.rb:237:9:237:9 | a :  | string_flow.rb:237:24:237:24 | x :  |
 | string_flow.rb:237:24:237:24 | x :  | string_flow.rb:237:35:237:35 | x |
+| string_flow.rb:238:5:238:5 | b :  | string_flow.rb:239:10:239:10 | b |
 | string_flow.rb:238:9:238:9 | a :  | string_flow.rb:238:9:238:37 | call to scan :  |
 | string_flow.rb:238:9:238:9 | a :  | string_flow.rb:238:27:238:27 | y :  |
-| string_flow.rb:238:9:238:37 | call to scan :  | string_flow.rb:239:10:239:10 | b |
+| string_flow.rb:238:9:238:37 | call to scan :  | string_flow.rb:238:5:238:5 | b :  |
 | string_flow.rb:238:27:238:27 | y :  | string_flow.rb:238:35:238:35 | y |
+| string_flow.rb:240:5:240:5 | b [element] :  | string_flow.rb:241:10:241:10 | b [element] :  |
+| string_flow.rb:240:5:240:5 | b [element] :  | string_flow.rb:242:10:242:10 | b [element] :  |
 | string_flow.rb:240:9:240:9 | a :  | string_flow.rb:240:9:240:19 | call to scan [element] :  |
-| string_flow.rb:240:9:240:19 | call to scan [element] :  | string_flow.rb:241:10:241:10 | b [element] :  |
-| string_flow.rb:240:9:240:19 | call to scan [element] :  | string_flow.rb:242:10:242:10 | b [element] :  |
+| string_flow.rb:240:9:240:19 | call to scan [element] :  | string_flow.rb:240:5:240:5 | b [element] :  |
 | string_flow.rb:241:10:241:10 | b [element] :  | string_flow.rb:241:10:241:13 | ...[...] |
 | string_flow.rb:242:10:242:10 | b [element] :  | string_flow.rb:242:10:242:13 | ...[...] |
-| string_flow.rb:246:5:246:18 | ... = ... :  | string_flow.rb:250:26:250:26 | a :  |
-| string_flow.rb:246:9:246:18 | call to source :  | string_flow.rb:246:5:246:18 | ... = ... :  |
-| string_flow.rb:246:9:246:18 | call to source :  | string_flow.rb:247:10:247:10 | a :  |
-| string_flow.rb:246:9:246:18 | call to source :  | string_flow.rb:248:20:248:20 | a :  |
-| string_flow.rb:246:9:246:18 | call to source :  | string_flow.rb:249:5:249:5 | a :  |
-| string_flow.rb:246:9:246:18 | call to source :  | string_flow.rb:252:10:252:10 | a :  |
-| string_flow.rb:246:9:246:18 | call to source :  | string_flow.rb:253:21:253:21 | a :  |
+| string_flow.rb:246:5:246:5 | a :  | string_flow.rb:247:10:247:10 | a :  |
+| string_flow.rb:246:5:246:5 | a :  | string_flow.rb:248:20:248:20 | a :  |
+| string_flow.rb:246:5:246:5 | a :  | string_flow.rb:249:5:249:5 | a :  |
+| string_flow.rb:246:5:246:5 | a :  | string_flow.rb:250:26:250:26 | a :  |
+| string_flow.rb:246:5:246:5 | a :  | string_flow.rb:252:10:252:10 | a :  |
+| string_flow.rb:246:5:246:5 | a :  | string_flow.rb:253:21:253:21 | a :  |
+| string_flow.rb:246:9:246:18 | call to source :  | string_flow.rb:246:5:246:5 | a :  |
 | string_flow.rb:247:10:247:10 | a :  | string_flow.rb:247:10:247:21 | call to scrub |
 | string_flow.rb:248:20:248:20 | a :  | string_flow.rb:248:10:248:21 | call to scrub |
 | string_flow.rb:249:5:249:5 | a :  | string_flow.rb:249:16:249:16 | x :  |
@@ -215,23 +266,29 @@ edges
 | string_flow.rb:250:26:250:26 | a :  | string_flow.rb:250:10:250:28 | call to scrub |
 | string_flow.rb:252:10:252:10 | a :  | string_flow.rb:252:10:252:22 | call to scrub! |
 | string_flow.rb:253:21:253:21 | a :  | string_flow.rb:253:10:253:22 | call to scrub! |
-| string_flow.rb:255:5:255:18 | ... = ... :  | string_flow.rb:258:27:258:27 | a :  |
-| string_flow.rb:255:9:255:18 | call to source :  | string_flow.rb:255:5:255:18 | ... = ... :  |
-| string_flow.rb:255:9:255:18 | call to source :  | string_flow.rb:256:5:256:5 | a :  |
+| string_flow.rb:255:5:255:5 | a :  | string_flow.rb:256:5:256:5 | a :  |
+| string_flow.rb:255:5:255:5 | a :  | string_flow.rb:258:27:258:27 | a :  |
+| string_flow.rb:255:9:255:18 | call to source :  | string_flow.rb:255:5:255:5 | a :  |
 | string_flow.rb:256:5:256:5 | a :  | string_flow.rb:256:17:256:17 | x :  |
 | string_flow.rb:256:17:256:17 | x :  | string_flow.rb:256:25:256:25 | x |
 | string_flow.rb:258:27:258:27 | a :  | string_flow.rb:258:10:258:29 | call to scrub! |
-| string_flow.rb:262:9:262:18 | call to source :  | string_flow.rb:263:10:263:10 | a :  |
+| string_flow.rb:262:5:262:5 | a :  | string_flow.rb:263:10:263:10 | a :  |
+| string_flow.rb:262:9:262:18 | call to source :  | string_flow.rb:262:5:262:5 | a :  |
 | string_flow.rb:263:10:263:10 | a :  | string_flow.rb:263:10:263:22 | call to shellescape |
-| string_flow.rb:267:9:267:18 | call to source :  | string_flow.rb:268:9:268:9 | a :  |
+| string_flow.rb:267:5:267:5 | a :  | string_flow.rb:268:9:268:9 | a :  |
+| string_flow.rb:267:9:267:18 | call to source :  | string_flow.rb:267:5:267:5 | a :  |
+| string_flow.rb:268:5:268:5 | b [element] :  | string_flow.rb:269:10:269:10 | b [element] :  |
 | string_flow.rb:268:9:268:9 | a :  | string_flow.rb:268:9:268:20 | call to shellsplit [element] :  |
-| string_flow.rb:268:9:268:20 | call to shellsplit [element] :  | string_flow.rb:269:10:269:10 | b [element] :  |
+| string_flow.rb:268:9:268:20 | call to shellsplit [element] :  | string_flow.rb:268:5:268:5 | b [element] :  |
 | string_flow.rb:269:10:269:10 | b [element] :  | string_flow.rb:269:10:269:13 | ...[...] |
-| string_flow.rb:273:9:273:18 | call to source :  | string_flow.rb:274:9:274:9 | a :  |
-| string_flow.rb:273:9:273:18 | call to source :  | string_flow.rb:277:9:277:9 | a :  |
+| string_flow.rb:273:5:273:5 | a :  | string_flow.rb:274:9:274:9 | a :  |
+| string_flow.rb:273:5:273:5 | a :  | string_flow.rb:277:9:277:9 | a :  |
+| string_flow.rb:273:9:273:18 | call to source :  | string_flow.rb:273:5:273:5 | a :  |
+| string_flow.rb:274:5:274:5 | b :  | string_flow.rb:275:10:275:10 | b :  |
 | string_flow.rb:274:9:274:9 | a :  | string_flow.rb:274:9:274:18 | call to slice :  |
-| string_flow.rb:274:9:274:18 | call to slice :  | string_flow.rb:275:10:275:10 | b :  |
+| string_flow.rb:274:9:274:18 | call to slice :  | string_flow.rb:274:5:274:5 | b :  |
 | string_flow.rb:275:10:275:10 | b :  | string_flow.rb:275:10:275:13 | ...[...] |
+| string_flow.rb:277:5:277:5 | b :  | string_flow.rb:278:10:278:10 | b :  |
 | string_flow.rb:277:9:277:9 | [post] a :  | string_flow.rb:280:9:280:9 | a :  |
 | string_flow.rb:277:9:277:9 | [post] a :  | string_flow.rb:283:9:283:9 | a :  |
 | string_flow.rb:277:9:277:9 | [post] a [element 1] :  | string_flow.rb:283:9:283:9 | a [element 1] :  |
@@ -242,45 +299,53 @@ edges
 | string_flow.rb:277:9:277:9 | a :  | string_flow.rb:277:9:277:9 | [post] a [element 2] :  |
 | string_flow.rb:277:9:277:9 | a :  | string_flow.rb:277:9:277:9 | [post] a [element] :  |
 | string_flow.rb:277:9:277:9 | a :  | string_flow.rb:277:9:277:19 | call to slice! :  |
-| string_flow.rb:277:9:277:19 | call to slice! :  | string_flow.rb:278:10:278:10 | b :  |
+| string_flow.rb:277:9:277:19 | call to slice! :  | string_flow.rb:277:5:277:5 | b :  |
 | string_flow.rb:278:10:278:10 | b :  | string_flow.rb:278:10:278:13 | ...[...] |
+| string_flow.rb:280:5:280:5 | b :  | string_flow.rb:281:10:281:10 | b :  |
 | string_flow.rb:280:9:280:9 | a :  | string_flow.rb:280:9:280:20 | call to split :  |
-| string_flow.rb:280:9:280:20 | call to split :  | string_flow.rb:281:10:281:10 | b :  |
+| string_flow.rb:280:9:280:20 | call to split :  | string_flow.rb:280:5:280:5 | b :  |
 | string_flow.rb:281:10:281:10 | b :  | string_flow.rb:281:10:281:13 | ...[...] |
+| string_flow.rb:283:5:283:5 | b :  | string_flow.rb:284:10:284:10 | b :  |
+| string_flow.rb:283:5:283:5 | b [element 0] :  | string_flow.rb:284:10:284:10 | b [element 0] :  |
+| string_flow.rb:283:5:283:5 | b [element 1] :  | string_flow.rb:284:10:284:10 | b [element 1] :  |
+| string_flow.rb:283:5:283:5 | b [element] :  | string_flow.rb:284:10:284:10 | b [element] :  |
 | string_flow.rb:283:9:283:9 | a :  | string_flow.rb:283:9:283:14 | ...[...] :  |
 | string_flow.rb:283:9:283:9 | a :  | string_flow.rb:283:9:283:14 | ...[...] [element 0] :  |
 | string_flow.rb:283:9:283:9 | a :  | string_flow.rb:283:9:283:14 | ...[...] [element 1] :  |
 | string_flow.rb:283:9:283:9 | a [element 1] :  | string_flow.rb:283:9:283:14 | ...[...] [element 0] :  |
 | string_flow.rb:283:9:283:9 | a [element 2] :  | string_flow.rb:283:9:283:14 | ...[...] [element 1] :  |
 | string_flow.rb:283:9:283:9 | a [element] :  | string_flow.rb:283:9:283:14 | ...[...] [element] :  |
-| string_flow.rb:283:9:283:14 | ...[...] :  | string_flow.rb:284:10:284:10 | b :  |
-| string_flow.rb:283:9:283:14 | ...[...] [element 0] :  | string_flow.rb:284:10:284:10 | b [element 0] :  |
-| string_flow.rb:283:9:283:14 | ...[...] [element 1] :  | string_flow.rb:284:10:284:10 | b [element 1] :  |
-| string_flow.rb:283:9:283:14 | ...[...] [element] :  | string_flow.rb:284:10:284:10 | b [element] :  |
+| string_flow.rb:283:9:283:14 | ...[...] :  | string_flow.rb:283:5:283:5 | b :  |
+| string_flow.rb:283:9:283:14 | ...[...] [element 0] :  | string_flow.rb:283:5:283:5 | b [element 0] :  |
+| string_flow.rb:283:9:283:14 | ...[...] [element 1] :  | string_flow.rb:283:5:283:5 | b [element 1] :  |
+| string_flow.rb:283:9:283:14 | ...[...] [element] :  | string_flow.rb:283:5:283:5 | b [element] :  |
 | string_flow.rb:284:10:284:10 | b :  | string_flow.rb:284:10:284:13 | ...[...] |
 | string_flow.rb:284:10:284:10 | b [element 0] :  | string_flow.rb:284:10:284:13 | ...[...] |
 | string_flow.rb:284:10:284:10 | b [element 1] :  | string_flow.rb:284:10:284:13 | ...[...] |
 | string_flow.rb:284:10:284:10 | b [element] :  | string_flow.rb:284:10:284:13 | ...[...] |
-| string_flow.rb:288:9:288:18 | call to source :  | string_flow.rb:289:10:289:10 | a :  |
-| string_flow.rb:288:9:288:18 | call to source :  | string_flow.rb:290:10:290:10 | a :  |
-| string_flow.rb:288:9:288:18 | call to source :  | string_flow.rb:291:10:291:10 | a :  |
-| string_flow.rb:288:9:288:18 | call to source :  | string_flow.rb:292:10:292:10 | a :  |
+| string_flow.rb:288:5:288:5 | a :  | string_flow.rb:289:10:289:10 | a :  |
+| string_flow.rb:288:5:288:5 | a :  | string_flow.rb:290:10:290:10 | a :  |
+| string_flow.rb:288:5:288:5 | a :  | string_flow.rb:291:10:291:10 | a :  |
+| string_flow.rb:288:5:288:5 | a :  | string_flow.rb:292:10:292:10 | a :  |
+| string_flow.rb:288:9:288:18 | call to source :  | string_flow.rb:288:5:288:5 | a :  |
 | string_flow.rb:289:10:289:10 | a :  | string_flow.rb:289:10:289:18 | call to squeeze |
 | string_flow.rb:290:10:290:10 | a :  | string_flow.rb:290:10:290:23 | call to squeeze |
 | string_flow.rb:291:10:291:10 | a :  | string_flow.rb:291:10:291:19 | call to squeeze! |
 | string_flow.rb:292:10:292:10 | a :  | string_flow.rb:292:10:292:24 | call to squeeze! |
-| string_flow.rb:296:9:296:18 | call to source :  | string_flow.rb:297:10:297:10 | a :  |
-| string_flow.rb:296:9:296:18 | call to source :  | string_flow.rb:298:10:298:10 | a :  |
+| string_flow.rb:296:5:296:5 | a :  | string_flow.rb:297:10:297:10 | a :  |
+| string_flow.rb:296:5:296:5 | a :  | string_flow.rb:298:10:298:10 | a :  |
+| string_flow.rb:296:9:296:18 | call to source :  | string_flow.rb:296:5:296:5 | a :  |
 | string_flow.rb:297:10:297:10 | a :  | string_flow.rb:297:10:297:17 | call to to_str |
 | string_flow.rb:298:10:298:10 | a :  | string_flow.rb:298:10:298:15 | call to to_s |
-| string_flow.rb:302:9:302:18 | call to source :  | string_flow.rb:303:10:303:10 | a :  |
-| string_flow.rb:302:9:302:18 | call to source :  | string_flow.rb:304:22:304:22 | a :  |
-| string_flow.rb:302:9:302:18 | call to source :  | string_flow.rb:305:10:305:10 | a :  |
-| string_flow.rb:302:9:302:18 | call to source :  | string_flow.rb:306:23:306:23 | a :  |
-| string_flow.rb:302:9:302:18 | call to source :  | string_flow.rb:307:10:307:10 | a :  |
-| string_flow.rb:302:9:302:18 | call to source :  | string_flow.rb:308:24:308:24 | a :  |
-| string_flow.rb:302:9:302:18 | call to source :  | string_flow.rb:309:10:309:10 | a :  |
-| string_flow.rb:302:9:302:18 | call to source :  | string_flow.rb:310:25:310:25 | a :  |
+| string_flow.rb:302:5:302:5 | a :  | string_flow.rb:303:10:303:10 | a :  |
+| string_flow.rb:302:5:302:5 | a :  | string_flow.rb:304:22:304:22 | a :  |
+| string_flow.rb:302:5:302:5 | a :  | string_flow.rb:305:10:305:10 | a :  |
+| string_flow.rb:302:5:302:5 | a :  | string_flow.rb:306:23:306:23 | a :  |
+| string_flow.rb:302:5:302:5 | a :  | string_flow.rb:307:10:307:10 | a :  |
+| string_flow.rb:302:5:302:5 | a :  | string_flow.rb:308:24:308:24 | a :  |
+| string_flow.rb:302:5:302:5 | a :  | string_flow.rb:309:10:309:10 | a :  |
+| string_flow.rb:302:5:302:5 | a :  | string_flow.rb:310:25:310:25 | a :  |
+| string_flow.rb:302:9:302:18 | call to source :  | string_flow.rb:302:5:302:5 | a :  |
 | string_flow.rb:303:10:303:10 | a :  | string_flow.rb:303:10:303:23 | call to tr |
 | string_flow.rb:304:22:304:22 | a :  | string_flow.rb:304:10:304:23 | call to tr |
 | string_flow.rb:305:10:305:10 | a :  | string_flow.rb:305:10:305:24 | call to tr! |
@@ -289,9 +354,10 @@ edges
 | string_flow.rb:308:24:308:24 | a :  | string_flow.rb:308:10:308:25 | call to tr_s |
 | string_flow.rb:309:10:309:10 | a :  | string_flow.rb:309:10:309:26 | call to tr_s! |
 | string_flow.rb:310:25:310:25 | a :  | string_flow.rb:310:10:310:26 | call to tr_s! |
-| string_flow.rb:314:9:314:18 | call to source :  | string_flow.rb:315:5:315:5 | a :  |
-| string_flow.rb:314:9:314:18 | call to source :  | string_flow.rb:316:5:316:5 | a :  |
-| string_flow.rb:314:9:314:18 | call to source :  | string_flow.rb:317:14:317:14 | a :  |
+| string_flow.rb:314:5:314:5 | a :  | string_flow.rb:315:5:315:5 | a :  |
+| string_flow.rb:314:5:314:5 | a :  | string_flow.rb:316:5:316:5 | a :  |
+| string_flow.rb:314:5:314:5 | a :  | string_flow.rb:317:14:317:14 | a :  |
+| string_flow.rb:314:9:314:18 | call to source :  | string_flow.rb:314:5:314:5 | a :  |
 | string_flow.rb:315:5:315:5 | a :  | string_flow.rb:315:20:315:20 | x :  |
 | string_flow.rb:315:20:315:20 | x :  | string_flow.rb:315:28:315:28 | x |
 | string_flow.rb:316:5:316:5 | a :  | string_flow.rb:316:26:316:26 | x :  |
@@ -299,18 +365,23 @@ edges
 | string_flow.rb:317:14:317:14 | a :  | string_flow.rb:317:20:317:20 | x :  |
 | string_flow.rb:317:20:317:20 | x :  | string_flow.rb:317:28:317:28 | x |
 nodes
+| string_flow.rb:2:5:2:5 | a :  | semmle.label | a :  |
+| string_flow.rb:2:5:2:5 | a :  | semmle.label | a :  |
 | string_flow.rb:2:9:2:18 | call to source :  | semmle.label | call to source :  |
 | string_flow.rb:2:9:2:18 | call to source :  | semmle.label | call to source :  |
 | string_flow.rb:3:10:3:22 | call to new | semmle.label | call to new |
 | string_flow.rb:3:10:3:22 | call to new | semmle.label | call to new |
 | string_flow.rb:3:21:3:21 | a :  | semmle.label | a :  |
 | string_flow.rb:3:21:3:21 | a :  | semmle.label | a :  |
+| string_flow.rb:7:5:7:5 | a :  | semmle.label | a :  |
 | string_flow.rb:7:9:7:18 | call to source :  | semmle.label | call to source :  |
+| string_flow.rb:8:5:8:5 | b :  | semmle.label | b :  |
 | string_flow.rb:8:9:8:16 | call to source :  | semmle.label | call to source :  |
 | string_flow.rb:9:10:9:30 | call to try_convert | semmle.label | call to try_convert |
 | string_flow.rb:9:29:9:29 | a :  | semmle.label | a :  |
 | string_flow.rb:10:10:10:30 | call to try_convert | semmle.label | call to try_convert |
 | string_flow.rb:10:29:10:29 | b :  | semmle.label | b :  |
+| string_flow.rb:14:5:14:5 | a :  | semmle.label | a :  |
 | string_flow.rb:14:9:14:18 | call to source :  | semmle.label | call to source :  |
 | string_flow.rb:15:10:15:17 | ... % ... | semmle.label | ... % ... |
 | string_flow.rb:15:17:15:17 | a :  | semmle.label | a :  |
@@ -318,16 +389,25 @@ nodes
 | string_flow.rb:16:28:16:28 | a :  | semmle.label | a :  |
 | string_flow.rb:17:10:17:10 | a :  | semmle.label | a :  |
 | string_flow.rb:17:10:17:18 | ... % ... | semmle.label | ... % ... |
+| string_flow.rb:21:5:21:5 | a :  | semmle.label | a :  |
 | string_flow.rb:21:9:21:18 | call to source :  | semmle.label | call to source :  |
+| string_flow.rb:22:5:22:5 | b :  | semmle.label | b :  |
 | string_flow.rb:23:10:23:10 | b | semmle.label | b |
+| string_flow.rb:27:5:27:5 | a :  | semmle.label | a :  |
 | string_flow.rb:27:9:27:18 | call to source :  | semmle.label | call to source :  |
+| string_flow.rb:28:5:28:5 | b :  | semmle.label | b :  |
 | string_flow.rb:29:10:29:10 | b | semmle.label | b |
+| string_flow.rb:33:5:33:5 | a :  | semmle.label | a :  |
 | string_flow.rb:33:9:33:18 | call to source :  | semmle.label | call to source :  |
+| string_flow.rb:34:5:34:5 | b :  | semmle.label | b :  |
 | string_flow.rb:35:10:35:10 | b | semmle.label | b |
+| string_flow.rb:36:5:36:5 | c :  | semmle.label | c :  |
 | string_flow.rb:37:10:37:10 | c | semmle.label | c |
+| string_flow.rb:41:5:41:5 | a :  | semmle.label | a :  |
 | string_flow.rb:41:9:41:18 | call to source :  | semmle.label | call to source :  |
 | string_flow.rb:42:10:42:10 | a :  | semmle.label | a :  |
 | string_flow.rb:42:10:42:12 | call to b | semmle.label | call to b |
+| string_flow.rb:46:5:46:5 | a :  | semmle.label | a :  |
 | string_flow.rb:46:9:46:18 | call to source :  | semmle.label | call to source :  |
 | string_flow.rb:47:10:47:10 | a :  | semmle.label | a :  |
 | string_flow.rb:47:10:47:23 | call to byteslice | semmle.label | call to byteslice |
@@ -335,11 +415,13 @@ nodes
 | string_flow.rb:48:10:48:26 | call to byteslice | semmle.label | call to byteslice |
 | string_flow.rb:49:10:49:10 | a :  | semmle.label | a :  |
 | string_flow.rb:49:10:49:26 | call to byteslice | semmle.label | call to byteslice |
+| string_flow.rb:53:5:53:5 | a :  | semmle.label | a :  |
 | string_flow.rb:53:9:53:18 | call to source :  | semmle.label | call to source :  |
 | string_flow.rb:54:10:54:10 | a :  | semmle.label | a :  |
 | string_flow.rb:54:10:54:21 | call to capitalize | semmle.label | call to capitalize |
 | string_flow.rb:55:10:55:10 | a :  | semmle.label | a :  |
 | string_flow.rb:55:10:55:22 | call to capitalize! | semmle.label | call to capitalize! |
+| string_flow.rb:59:5:59:5 | a :  | semmle.label | a :  |
 | string_flow.rb:59:9:59:18 | call to source :  | semmle.label | call to source :  |
 | string_flow.rb:60:10:60:10 | a :  | semmle.label | a :  |
 | string_flow.rb:60:10:60:21 | call to center | semmle.label | call to center |
@@ -353,16 +435,20 @@ nodes
 | string_flow.rb:64:10:64:20 | call to rjust | semmle.label | call to rjust |
 | string_flow.rb:65:10:65:27 | call to rjust | semmle.label | call to rjust |
 | string_flow.rb:65:26:65:26 | a :  | semmle.label | a :  |
+| string_flow.rb:69:5:69:5 | a :  | semmle.label | a :  |
 | string_flow.rb:69:9:69:18 | call to source :  | semmle.label | call to source :  |
 | string_flow.rb:70:10:70:10 | a :  | semmle.label | a :  |
 | string_flow.rb:70:10:70:16 | call to chomp | semmle.label | call to chomp |
 | string_flow.rb:71:10:71:10 | a :  | semmle.label | a :  |
 | string_flow.rb:71:10:71:17 | call to chomp! | semmle.label | call to chomp! |
+| string_flow.rb:75:5:75:5 | a :  | semmle.label | a :  |
 | string_flow.rb:75:9:75:18 | call to source :  | semmle.label | call to source :  |
 | string_flow.rb:76:10:76:10 | a :  | semmle.label | a :  |
 | string_flow.rb:76:10:76:15 | call to chop | semmle.label | call to chop |
 | string_flow.rb:77:10:77:10 | a :  | semmle.label | a :  |
 | string_flow.rb:77:10:77:16 | call to chop! | semmle.label | call to chop! |
+| string_flow.rb:83:5:83:5 | a :  | semmle.label | a :  |
+| string_flow.rb:83:5:83:5 | a :  | semmle.label | a :  |
 | string_flow.rb:83:9:83:18 | call to source :  | semmle.label | call to source :  |
 | string_flow.rb:83:9:83:18 | call to source :  | semmle.label | call to source :  |
 | string_flow.rb:84:5:84:5 | [post] a :  | semmle.label | [post] a :  |
@@ -371,6 +457,7 @@ nodes
 | string_flow.rb:84:5:84:5 | a :  | semmle.label | a :  |
 | string_flow.rb:85:10:85:10 | a | semmle.label | a |
 | string_flow.rb:85:10:85:10 | a | semmle.label | a |
+| string_flow.rb:108:5:108:5 | a :  | semmle.label | a :  |
 | string_flow.rb:108:9:108:18 | call to source :  | semmle.label | call to source :  |
 | string_flow.rb:109:10:109:10 | [post] a :  | semmle.label | [post] a :  |
 | string_flow.rb:109:10:109:10 | a :  | semmle.label | a :  |
@@ -379,6 +466,7 @@ nodes
 | string_flow.rb:110:10:110:29 | call to delete_prefix | semmle.label | call to delete_prefix |
 | string_flow.rb:111:10:111:10 | a :  | semmle.label | a :  |
 | string_flow.rb:111:10:111:29 | call to delete_suffix | semmle.label | call to delete_suffix |
+| string_flow.rb:115:5:115:5 | a :  | semmle.label | a :  |
 | string_flow.rb:115:9:115:18 | call to source :  | semmle.label | call to source :  |
 | string_flow.rb:116:10:116:10 | a :  | semmle.label | a :  |
 | string_flow.rb:116:10:116:19 | call to downcase | semmle.label | call to downcase |
@@ -392,33 +480,42 @@ nodes
 | string_flow.rb:120:10:120:17 | call to upcase | semmle.label | call to upcase |
 | string_flow.rb:121:10:121:10 | a :  | semmle.label | a :  |
 | string_flow.rb:121:10:121:18 | call to upcase! | semmle.label | call to upcase! |
+| string_flow.rb:125:5:125:5 | a :  | semmle.label | a :  |
 | string_flow.rb:125:9:125:18 | call to source :  | semmle.label | call to source :  |
+| string_flow.rb:126:5:126:5 | b :  | semmle.label | b :  |
 | string_flow.rb:126:9:126:9 | a :  | semmle.label | a :  |
 | string_flow.rb:126:9:126:14 | call to dump :  | semmle.label | call to dump :  |
 | string_flow.rb:127:10:127:10 | b | semmle.label | b |
 | string_flow.rb:128:10:128:10 | b :  | semmle.label | b :  |
 | string_flow.rb:128:10:128:17 | call to undump | semmle.label | call to undump |
+| string_flow.rb:132:5:132:5 | a :  | semmle.label | a :  |
 | string_flow.rb:132:9:132:18 | call to source :  | semmle.label | call to source :  |
+| string_flow.rb:133:5:133:5 | b :  | semmle.label | b :  |
 | string_flow.rb:133:9:133:9 | a :  | semmle.label | a :  |
 | string_flow.rb:133:9:133:40 | call to each_line :  | semmle.label | call to each_line :  |
 | string_flow.rb:133:24:133:27 | line :  | semmle.label | line :  |
 | string_flow.rb:133:35:133:38 | line | semmle.label | line |
 | string_flow.rb:134:10:134:10 | b | semmle.label | b |
+| string_flow.rb:135:5:135:5 | c [element] :  | semmle.label | c [element] :  |
 | string_flow.rb:135:9:135:9 | a :  | semmle.label | a :  |
 | string_flow.rb:135:9:135:19 | call to each_line [element] :  | semmle.label | call to each_line [element] :  |
 | string_flow.rb:136:10:136:10 | c [element] :  | semmle.label | c [element] :  |
 | string_flow.rb:136:10:136:15 | call to to_a [element] :  | semmle.label | call to to_a [element] :  |
 | string_flow.rb:136:10:136:18 | ...[...] | semmle.label | ...[...] |
+| string_flow.rb:140:5:140:5 | a :  | semmle.label | a :  |
 | string_flow.rb:140:9:140:18 | call to source :  | semmle.label | call to source :  |
+| string_flow.rb:141:5:141:5 | b :  | semmle.label | b :  |
 | string_flow.rb:141:9:141:9 | a :  | semmle.label | a :  |
 | string_flow.rb:141:9:141:36 | call to lines :  | semmle.label | call to lines :  |
 | string_flow.rb:141:20:141:23 | line :  | semmle.label | line :  |
 | string_flow.rb:141:31:141:34 | line | semmle.label | line |
 | string_flow.rb:142:10:142:10 | b | semmle.label | b |
+| string_flow.rb:143:5:143:5 | c [element] :  | semmle.label | c [element] :  |
 | string_flow.rb:143:9:143:9 | a :  | semmle.label | a :  |
 | string_flow.rb:143:9:143:15 | call to lines [element] :  | semmle.label | call to lines [element] :  |
 | string_flow.rb:144:10:144:10 | c [element] :  | semmle.label | c [element] :  |
 | string_flow.rb:144:10:144:13 | ...[...] | semmle.label | ...[...] |
+| string_flow.rb:148:5:148:5 | a :  | semmle.label | a :  |
 | string_flow.rb:148:9:148:18 | call to source :  | semmle.label | call to source :  |
 | string_flow.rb:149:10:149:10 | a :  | semmle.label | a :  |
 | string_flow.rb:149:10:149:26 | call to encode | semmle.label | call to encode |
@@ -428,13 +525,17 @@ nodes
 | string_flow.rb:151:10:151:28 | call to unicode_normalize | semmle.label | call to unicode_normalize |
 | string_flow.rb:152:10:152:10 | a :  | semmle.label | a :  |
 | string_flow.rb:152:10:152:29 | call to unicode_normalize! | semmle.label | call to unicode_normalize! |
+| string_flow.rb:156:5:156:5 | a :  | semmle.label | a :  |
 | string_flow.rb:156:9:156:18 | call to source :  | semmle.label | call to source :  |
 | string_flow.rb:157:10:157:10 | a :  | semmle.label | a :  |
 | string_flow.rb:157:10:157:34 | call to force_encoding | semmle.label | call to force_encoding |
+| string_flow.rb:161:5:161:5 | a :  | semmle.label | a :  |
 | string_flow.rb:161:9:161:18 | call to source :  | semmle.label | call to source :  |
 | string_flow.rb:162:10:162:10 | a :  | semmle.label | a :  |
 | string_flow.rb:162:10:162:17 | call to freeze | semmle.label | call to freeze |
+| string_flow.rb:166:5:166:5 | a :  | semmle.label | a :  |
 | string_flow.rb:166:9:166:18 | call to source :  | semmle.label | call to source :  |
+| string_flow.rb:167:5:167:5 | c :  | semmle.label | c :  |
 | string_flow.rb:167:9:167:18 | call to source :  | semmle.label | call to source :  |
 | string_flow.rb:168:10:168:10 | a :  | semmle.label | a :  |
 | string_flow.rb:168:10:168:23 | call to gsub | semmle.label | call to gsub |
@@ -448,7 +549,9 @@ nodes
 | string_flow.rb:171:10:171:10 | a :  | semmle.label | a :  |
 | string_flow.rb:171:10:171:44 | call to gsub! | semmle.label | call to gsub! |
 | string_flow.rb:171:33:171:42 | call to source :  | semmle.label | call to source :  |
+| string_flow.rb:175:5:175:5 | a :  | semmle.label | a :  |
 | string_flow.rb:175:9:175:18 | call to source :  | semmle.label | call to source :  |
+| string_flow.rb:176:5:176:5 | c :  | semmle.label | c :  |
 | string_flow.rb:176:9:176:18 | call to source :  | semmle.label | call to source :  |
 | string_flow.rb:177:10:177:10 | a :  | semmle.label | a :  |
 | string_flow.rb:177:10:177:22 | call to sub | semmle.label | call to sub |
@@ -462,9 +565,11 @@ nodes
 | string_flow.rb:180:10:180:10 | a :  | semmle.label | a :  |
 | string_flow.rb:180:10:180:43 | call to sub! | semmle.label | call to sub! |
 | string_flow.rb:180:32:180:41 | call to source :  | semmle.label | call to source :  |
+| string_flow.rb:191:5:191:5 | a :  | semmle.label | a :  |
 | string_flow.rb:191:9:191:18 | call to source :  | semmle.label | call to source :  |
 | string_flow.rb:192:10:192:10 | a :  | semmle.label | a :  |
 | string_flow.rb:192:10:192:18 | call to inspect | semmle.label | call to inspect |
+| string_flow.rb:196:5:196:5 | a :  | semmle.label | a :  |
 | string_flow.rb:196:9:196:18 | call to source :  | semmle.label | call to source :  |
 | string_flow.rb:197:10:197:10 | a :  | semmle.label | a :  |
 | string_flow.rb:197:10:197:16 | call to strip | semmle.label | call to strip |
@@ -478,6 +583,7 @@ nodes
 | string_flow.rb:201:10:201:17 | call to rstrip | semmle.label | call to rstrip |
 | string_flow.rb:202:10:202:10 | a :  | semmle.label | a :  |
 | string_flow.rb:202:10:202:18 | call to rstrip! | semmle.label | call to rstrip! |
+| string_flow.rb:206:5:206:5 | a :  | semmle.label | a :  |
 | string_flow.rb:206:9:206:18 | call to source :  | semmle.label | call to source :  |
 | string_flow.rb:207:10:207:10 | a :  | semmle.label | a :  |
 | string_flow.rb:207:10:207:15 | call to next | semmle.label | call to next |
@@ -487,7 +593,11 @@ nodes
 | string_flow.rb:209:10:209:15 | call to succ | semmle.label | call to succ |
 | string_flow.rb:210:10:210:10 | a :  | semmle.label | a :  |
 | string_flow.rb:210:10:210:16 | call to succ! | semmle.label | call to succ! |
+| string_flow.rb:214:5:214:5 | a :  | semmle.label | a :  |
 | string_flow.rb:214:9:214:18 | call to source :  | semmle.label | call to source :  |
+| string_flow.rb:215:5:215:5 | b [element 0] :  | semmle.label | b [element 0] :  |
+| string_flow.rb:215:5:215:5 | b [element 1] :  | semmle.label | b [element 1] :  |
+| string_flow.rb:215:5:215:5 | b [element 2] :  | semmle.label | b [element 2] :  |
 | string_flow.rb:215:9:215:9 | a :  | semmle.label | a :  |
 | string_flow.rb:215:9:215:24 | call to partition [element 0] :  | semmle.label | call to partition [element 0] :  |
 | string_flow.rb:215:9:215:24 | call to partition [element 1] :  | semmle.label | call to partition [element 1] :  |
@@ -498,8 +608,11 @@ nodes
 | string_flow.rb:217:10:217:13 | ...[...] | semmle.label | ...[...] |
 | string_flow.rb:218:10:218:10 | b [element 2] :  | semmle.label | b [element 2] :  |
 | string_flow.rb:218:10:218:13 | ...[...] | semmle.label | ...[...] |
+| string_flow.rb:223:5:223:5 | a :  | semmle.label | a :  |
+| string_flow.rb:223:5:223:5 | a :  | semmle.label | a :  |
 | string_flow.rb:223:9:223:18 | call to source :  | semmle.label | call to source :  |
 | string_flow.rb:223:9:223:18 | call to source :  | semmle.label | call to source :  |
+| string_flow.rb:224:5:224:5 | b :  | semmle.label | b :  |
 | string_flow.rb:224:9:224:18 | call to source :  | semmle.label | call to source :  |
 | string_flow.rb:225:10:225:10 | [post] a :  | semmle.label | [post] a :  |
 | string_flow.rb:225:10:225:10 | [post] a :  | semmle.label | [post] a :  |
@@ -509,25 +622,29 @@ nodes
 | string_flow.rb:225:20:225:20 | b :  | semmle.label | b :  |
 | string_flow.rb:227:10:227:10 | a | semmle.label | a |
 | string_flow.rb:227:10:227:10 | a | semmle.label | a |
+| string_flow.rb:231:5:231:5 | a :  | semmle.label | a :  |
 | string_flow.rb:231:9:231:18 | call to source :  | semmle.label | call to source :  |
 | string_flow.rb:232:10:232:10 | a :  | semmle.label | a :  |
 | string_flow.rb:232:10:232:18 | call to reverse | semmle.label | call to reverse |
+| string_flow.rb:236:5:236:5 | a :  | semmle.label | a :  |
 | string_flow.rb:236:9:236:18 | call to source :  | semmle.label | call to source :  |
 | string_flow.rb:237:9:237:9 | a :  | semmle.label | a :  |
 | string_flow.rb:237:24:237:24 | x :  | semmle.label | x :  |
 | string_flow.rb:237:35:237:35 | x | semmle.label | x |
+| string_flow.rb:238:5:238:5 | b :  | semmle.label | b :  |
 | string_flow.rb:238:9:238:9 | a :  | semmle.label | a :  |
 | string_flow.rb:238:9:238:37 | call to scan :  | semmle.label | call to scan :  |
 | string_flow.rb:238:27:238:27 | y :  | semmle.label | y :  |
 | string_flow.rb:238:35:238:35 | y | semmle.label | y |
 | string_flow.rb:239:10:239:10 | b | semmle.label | b |
+| string_flow.rb:240:5:240:5 | b [element] :  | semmle.label | b [element] :  |
 | string_flow.rb:240:9:240:9 | a :  | semmle.label | a :  |
 | string_flow.rb:240:9:240:19 | call to scan [element] :  | semmle.label | call to scan [element] :  |
 | string_flow.rb:241:10:241:10 | b [element] :  | semmle.label | b [element] :  |
 | string_flow.rb:241:10:241:13 | ...[...] | semmle.label | ...[...] |
 | string_flow.rb:242:10:242:10 | b [element] :  | semmle.label | b [element] :  |
 | string_flow.rb:242:10:242:13 | ...[...] | semmle.label | ...[...] |
-| string_flow.rb:246:5:246:18 | ... = ... :  | semmle.label | ... = ... :  |
+| string_flow.rb:246:5:246:5 | a :  | semmle.label | a :  |
 | string_flow.rb:246:9:246:18 | call to source :  | semmle.label | call to source :  |
 | string_flow.rb:247:10:247:10 | a :  | semmle.label | a :  |
 | string_flow.rb:247:10:247:21 | call to scrub | semmle.label | call to scrub |
@@ -542,26 +659,32 @@ nodes
 | string_flow.rb:252:10:252:22 | call to scrub! | semmle.label | call to scrub! |
 | string_flow.rb:253:10:253:22 | call to scrub! | semmle.label | call to scrub! |
 | string_flow.rb:253:21:253:21 | a :  | semmle.label | a :  |
-| string_flow.rb:255:5:255:18 | ... = ... :  | semmle.label | ... = ... :  |
+| string_flow.rb:255:5:255:5 | a :  | semmle.label | a :  |
 | string_flow.rb:255:9:255:18 | call to source :  | semmle.label | call to source :  |
 | string_flow.rb:256:5:256:5 | a :  | semmle.label | a :  |
 | string_flow.rb:256:17:256:17 | x :  | semmle.label | x :  |
 | string_flow.rb:256:25:256:25 | x | semmle.label | x |
 | string_flow.rb:258:10:258:29 | call to scrub! | semmle.label | call to scrub! |
 | string_flow.rb:258:27:258:27 | a :  | semmle.label | a :  |
+| string_flow.rb:262:5:262:5 | a :  | semmle.label | a :  |
 | string_flow.rb:262:9:262:18 | call to source :  | semmle.label | call to source :  |
 | string_flow.rb:263:10:263:10 | a :  | semmle.label | a :  |
 | string_flow.rb:263:10:263:22 | call to shellescape | semmle.label | call to shellescape |
+| string_flow.rb:267:5:267:5 | a :  | semmle.label | a :  |
 | string_flow.rb:267:9:267:18 | call to source :  | semmle.label | call to source :  |
+| string_flow.rb:268:5:268:5 | b [element] :  | semmle.label | b [element] :  |
 | string_flow.rb:268:9:268:9 | a :  | semmle.label | a :  |
 | string_flow.rb:268:9:268:20 | call to shellsplit [element] :  | semmle.label | call to shellsplit [element] :  |
 | string_flow.rb:269:10:269:10 | b [element] :  | semmle.label | b [element] :  |
 | string_flow.rb:269:10:269:13 | ...[...] | semmle.label | ...[...] |
+| string_flow.rb:273:5:273:5 | a :  | semmle.label | a :  |
 | string_flow.rb:273:9:273:18 | call to source :  | semmle.label | call to source :  |
+| string_flow.rb:274:5:274:5 | b :  | semmle.label | b :  |
 | string_flow.rb:274:9:274:9 | a :  | semmle.label | a :  |
 | string_flow.rb:274:9:274:18 | call to slice :  | semmle.label | call to slice :  |
 | string_flow.rb:275:10:275:10 | b :  | semmle.label | b :  |
 | string_flow.rb:275:10:275:13 | ...[...] | semmle.label | ...[...] |
+| string_flow.rb:277:5:277:5 | b :  | semmle.label | b :  |
 | string_flow.rb:277:9:277:9 | [post] a :  | semmle.label | [post] a :  |
 | string_flow.rb:277:9:277:9 | [post] a [element 1] :  | semmle.label | [post] a [element 1] :  |
 | string_flow.rb:277:9:277:9 | [post] a [element 2] :  | semmle.label | [post] a [element 2] :  |
@@ -570,10 +693,15 @@ nodes
 | string_flow.rb:277:9:277:19 | call to slice! :  | semmle.label | call to slice! :  |
 | string_flow.rb:278:10:278:10 | b :  | semmle.label | b :  |
 | string_flow.rb:278:10:278:13 | ...[...] | semmle.label | ...[...] |
+| string_flow.rb:280:5:280:5 | b :  | semmle.label | b :  |
 | string_flow.rb:280:9:280:9 | a :  | semmle.label | a :  |
 | string_flow.rb:280:9:280:20 | call to split :  | semmle.label | call to split :  |
 | string_flow.rb:281:10:281:10 | b :  | semmle.label | b :  |
 | string_flow.rb:281:10:281:13 | ...[...] | semmle.label | ...[...] |
+| string_flow.rb:283:5:283:5 | b :  | semmle.label | b :  |
+| string_flow.rb:283:5:283:5 | b [element 0] :  | semmle.label | b [element 0] :  |
+| string_flow.rb:283:5:283:5 | b [element 1] :  | semmle.label | b [element 1] :  |
+| string_flow.rb:283:5:283:5 | b [element] :  | semmle.label | b [element] :  |
 | string_flow.rb:283:9:283:9 | a :  | semmle.label | a :  |
 | string_flow.rb:283:9:283:9 | a [element 1] :  | semmle.label | a [element 1] :  |
 | string_flow.rb:283:9:283:9 | a [element 2] :  | semmle.label | a [element 2] :  |
@@ -587,6 +715,7 @@ nodes
 | string_flow.rb:284:10:284:10 | b [element 1] :  | semmle.label | b [element 1] :  |
 | string_flow.rb:284:10:284:10 | b [element] :  | semmle.label | b [element] :  |
 | string_flow.rb:284:10:284:13 | ...[...] | semmle.label | ...[...] |
+| string_flow.rb:288:5:288:5 | a :  | semmle.label | a :  |
 | string_flow.rb:288:9:288:18 | call to source :  | semmle.label | call to source :  |
 | string_flow.rb:289:10:289:10 | a :  | semmle.label | a :  |
 | string_flow.rb:289:10:289:18 | call to squeeze | semmle.label | call to squeeze |
@@ -596,11 +725,13 @@ nodes
 | string_flow.rb:291:10:291:19 | call to squeeze! | semmle.label | call to squeeze! |
 | string_flow.rb:292:10:292:10 | a :  | semmle.label | a :  |
 | string_flow.rb:292:10:292:24 | call to squeeze! | semmle.label | call to squeeze! |
+| string_flow.rb:296:5:296:5 | a :  | semmle.label | a :  |
 | string_flow.rb:296:9:296:18 | call to source :  | semmle.label | call to source :  |
 | string_flow.rb:297:10:297:10 | a :  | semmle.label | a :  |
 | string_flow.rb:297:10:297:17 | call to to_str | semmle.label | call to to_str |
 | string_flow.rb:298:10:298:10 | a :  | semmle.label | a :  |
 | string_flow.rb:298:10:298:15 | call to to_s | semmle.label | call to to_s |
+| string_flow.rb:302:5:302:5 | a :  | semmle.label | a :  |
 | string_flow.rb:302:9:302:18 | call to source :  | semmle.label | call to source :  |
 | string_flow.rb:303:10:303:10 | a :  | semmle.label | a :  |
 | string_flow.rb:303:10:303:23 | call to tr | semmle.label | call to tr |
@@ -618,6 +749,7 @@ nodes
 | string_flow.rb:309:10:309:26 | call to tr_s! | semmle.label | call to tr_s! |
 | string_flow.rb:310:10:310:26 | call to tr_s! | semmle.label | call to tr_s! |
 | string_flow.rb:310:25:310:25 | a :  | semmle.label | a :  |
+| string_flow.rb:314:5:314:5 | a :  | semmle.label | a :  |
 | string_flow.rb:314:9:314:18 | call to source :  | semmle.label | call to source :  |
 | string_flow.rb:315:5:315:5 | a :  | semmle.label | a :  |
 | string_flow.rb:315:20:315:20 | x :  | semmle.label | x :  |

--- a/ruby/ql/test/library-tests/dataflow/summaries/Summaries.expected
+++ b/ruby/ql/test/library-tests/dataflow/summaries/Summaries.expected
@@ -1,53 +1,57 @@
 failures
 edges
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:2:6:2:12 | tainted |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:2:6:2:12 | tainted |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:4:24:4:30 | tainted :  |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:4:24:4:30 | tainted :  |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:16:36:16:42 | tainted :  |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:16:36:16:42 | tainted :  |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:20:25:20:31 | tainted :  |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:26:31:26:37 | tainted :  |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:30:24:30:30 | tainted :  |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:31:27:31:33 | tainted :  |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:34:16:34:22 | tainted |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:34:16:34:22 | tainted |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:35:16:35:22 | tainted |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:35:16:35:22 | tainted |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:36:21:36:27 | tainted |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:36:21:36:27 | tainted |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:37:36:37:42 | tainted |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:37:36:37:42 | tainted |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:51:24:51:30 | tainted :  |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:56:22:56:28 | tainted :  |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:57:17:57:23 | tainted :  |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:59:27:59:33 | tainted :  |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:63:32:63:38 | tainted :  |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:65:23:65:29 | tainted :  |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:122:16:122:22 | tainted :  |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:128:14:128:20 | tainted :  |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:131:16:131:22 | tainted |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:131:16:131:22 | tainted |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:132:21:132:27 | tainted |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:132:21:132:27 | tainted |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:135:26:135:32 | tainted |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:135:26:135:32 | tainted |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:137:23:137:29 | tainted |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:137:23:137:29 | tainted |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:140:19:140:25 | tainted |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:140:19:140:25 | tainted |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:141:19:141:25 | tainted |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:141:19:141:25 | tainted |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:145:26:145:32 | tainted |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:145:26:145:32 | tainted |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:147:16:147:22 | tainted |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:147:16:147:22 | tainted |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:150:39:150:45 | tainted |
-| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:150:39:150:45 | tainted |
+| summaries.rb:1:1:1:7 | tainted :  | summaries.rb:2:6:2:12 | tainted |
+| summaries.rb:1:1:1:7 | tainted :  | summaries.rb:2:6:2:12 | tainted |
+| summaries.rb:1:1:1:7 | tainted :  | summaries.rb:4:24:4:30 | tainted :  |
+| summaries.rb:1:1:1:7 | tainted :  | summaries.rb:4:24:4:30 | tainted :  |
+| summaries.rb:1:1:1:7 | tainted :  | summaries.rb:16:36:16:42 | tainted :  |
+| summaries.rb:1:1:1:7 | tainted :  | summaries.rb:16:36:16:42 | tainted :  |
+| summaries.rb:1:1:1:7 | tainted :  | summaries.rb:20:25:20:31 | tainted :  |
+| summaries.rb:1:1:1:7 | tainted :  | summaries.rb:26:31:26:37 | tainted :  |
+| summaries.rb:1:1:1:7 | tainted :  | summaries.rb:30:24:30:30 | tainted :  |
+| summaries.rb:1:1:1:7 | tainted :  | summaries.rb:31:27:31:33 | tainted :  |
+| summaries.rb:1:1:1:7 | tainted :  | summaries.rb:34:16:34:22 | tainted |
+| summaries.rb:1:1:1:7 | tainted :  | summaries.rb:34:16:34:22 | tainted |
+| summaries.rb:1:1:1:7 | tainted :  | summaries.rb:35:16:35:22 | tainted |
+| summaries.rb:1:1:1:7 | tainted :  | summaries.rb:35:16:35:22 | tainted |
+| summaries.rb:1:1:1:7 | tainted :  | summaries.rb:36:21:36:27 | tainted |
+| summaries.rb:1:1:1:7 | tainted :  | summaries.rb:36:21:36:27 | tainted |
+| summaries.rb:1:1:1:7 | tainted :  | summaries.rb:37:36:37:42 | tainted |
+| summaries.rb:1:1:1:7 | tainted :  | summaries.rb:37:36:37:42 | tainted |
+| summaries.rb:1:1:1:7 | tainted :  | summaries.rb:51:24:51:30 | tainted :  |
+| summaries.rb:1:1:1:7 | tainted :  | summaries.rb:56:22:56:28 | tainted :  |
+| summaries.rb:1:1:1:7 | tainted :  | summaries.rb:57:17:57:23 | tainted :  |
+| summaries.rb:1:1:1:7 | tainted :  | summaries.rb:59:27:59:33 | tainted :  |
+| summaries.rb:1:1:1:7 | tainted :  | summaries.rb:63:32:63:38 | tainted :  |
+| summaries.rb:1:1:1:7 | tainted :  | summaries.rb:65:23:65:29 | tainted :  |
+| summaries.rb:1:1:1:7 | tainted :  | summaries.rb:122:16:122:22 | tainted :  |
+| summaries.rb:1:1:1:7 | tainted :  | summaries.rb:128:14:128:20 | tainted :  |
+| summaries.rb:1:1:1:7 | tainted :  | summaries.rb:131:16:131:22 | tainted |
+| summaries.rb:1:1:1:7 | tainted :  | summaries.rb:131:16:131:22 | tainted |
+| summaries.rb:1:1:1:7 | tainted :  | summaries.rb:132:21:132:27 | tainted |
+| summaries.rb:1:1:1:7 | tainted :  | summaries.rb:132:21:132:27 | tainted |
+| summaries.rb:1:1:1:7 | tainted :  | summaries.rb:135:26:135:32 | tainted |
+| summaries.rb:1:1:1:7 | tainted :  | summaries.rb:135:26:135:32 | tainted |
+| summaries.rb:1:1:1:7 | tainted :  | summaries.rb:137:23:137:29 | tainted |
+| summaries.rb:1:1:1:7 | tainted :  | summaries.rb:137:23:137:29 | tainted |
+| summaries.rb:1:1:1:7 | tainted :  | summaries.rb:140:19:140:25 | tainted |
+| summaries.rb:1:1:1:7 | tainted :  | summaries.rb:140:19:140:25 | tainted |
+| summaries.rb:1:1:1:7 | tainted :  | summaries.rb:141:19:141:25 | tainted |
+| summaries.rb:1:1:1:7 | tainted :  | summaries.rb:141:19:141:25 | tainted |
+| summaries.rb:1:1:1:7 | tainted :  | summaries.rb:145:26:145:32 | tainted |
+| summaries.rb:1:1:1:7 | tainted :  | summaries.rb:145:26:145:32 | tainted |
+| summaries.rb:1:1:1:7 | tainted :  | summaries.rb:147:16:147:22 | tainted |
+| summaries.rb:1:1:1:7 | tainted :  | summaries.rb:147:16:147:22 | tainted |
+| summaries.rb:1:1:1:7 | tainted :  | summaries.rb:150:39:150:45 | tainted |
+| summaries.rb:1:1:1:7 | tainted :  | summaries.rb:150:39:150:45 | tainted |
+| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:1:1:1:7 | tainted :  |
+| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:1:1:1:7 | tainted :  |
 | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:1:11:1:36 | call to identity :  |
 | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:1:11:1:36 | call to identity :  |
-| summaries.rb:4:12:7:3 | call to apply_block :  | summaries.rb:9:6:9:13 | tainted2 |
-| summaries.rb:4:12:7:3 | call to apply_block :  | summaries.rb:9:6:9:13 | tainted2 |
+| summaries.rb:4:1:4:8 | tainted2 :  | summaries.rb:9:6:9:13 | tainted2 |
+| summaries.rb:4:1:4:8 | tainted2 :  | summaries.rb:9:6:9:13 | tainted2 |
+| summaries.rb:4:12:7:3 | call to apply_block :  | summaries.rb:4:1:4:8 | tainted2 :  |
+| summaries.rb:4:12:7:3 | call to apply_block :  | summaries.rb:4:1:4:8 | tainted2 :  |
 | summaries.rb:4:24:4:30 | tainted :  | summaries.rb:4:12:7:3 | call to apply_block :  |
 | summaries.rb:4:24:4:30 | tainted :  | summaries.rb:4:12:7:3 | call to apply_block :  |
 | summaries.rb:4:24:4:30 | tainted :  | summaries.rb:4:36:4:36 | x :  |
@@ -56,27 +60,33 @@ edges
 | summaries.rb:4:36:4:36 | x :  | summaries.rb:5:8:5:8 | x |
 | summaries.rb:11:17:11:17 | x :  | summaries.rb:12:8:12:8 | x |
 | summaries.rb:11:17:11:17 | x :  | summaries.rb:12:8:12:8 | x |
-| summaries.rb:16:12:16:43 | call to apply_lambda :  | summaries.rb:18:6:18:13 | tainted3 |
-| summaries.rb:16:12:16:43 | call to apply_lambda :  | summaries.rb:18:6:18:13 | tainted3 |
+| summaries.rb:16:1:16:8 | tainted3 :  | summaries.rb:18:6:18:13 | tainted3 |
+| summaries.rb:16:1:16:8 | tainted3 :  | summaries.rb:18:6:18:13 | tainted3 |
+| summaries.rb:16:12:16:43 | call to apply_lambda :  | summaries.rb:16:1:16:8 | tainted3 :  |
+| summaries.rb:16:12:16:43 | call to apply_lambda :  | summaries.rb:16:1:16:8 | tainted3 :  |
 | summaries.rb:16:36:16:42 | tainted :  | summaries.rb:11:17:11:17 | x :  |
 | summaries.rb:16:36:16:42 | tainted :  | summaries.rb:11:17:11:17 | x :  |
 | summaries.rb:16:36:16:42 | tainted :  | summaries.rb:16:12:16:43 | call to apply_lambda :  |
 | summaries.rb:16:36:16:42 | tainted :  | summaries.rb:16:12:16:43 | call to apply_lambda :  |
-| summaries.rb:20:12:20:32 | call to firstArg :  | summaries.rb:21:6:21:13 | tainted4 |
+| summaries.rb:20:1:20:8 | tainted4 :  | summaries.rb:21:6:21:13 | tainted4 |
+| summaries.rb:20:12:20:32 | call to firstArg :  | summaries.rb:20:1:20:8 | tainted4 :  |
 | summaries.rb:20:25:20:31 | tainted :  | summaries.rb:20:12:20:32 | call to firstArg :  |
-| summaries.rb:26:12:26:38 | call to secondArg :  | summaries.rb:27:6:27:13 | tainted5 |
+| summaries.rb:26:1:26:8 | tainted5 :  | summaries.rb:27:6:27:13 | tainted5 |
+| summaries.rb:26:12:26:38 | call to secondArg :  | summaries.rb:26:1:26:8 | tainted5 :  |
 | summaries.rb:26:31:26:37 | tainted :  | summaries.rb:26:12:26:38 | call to secondArg :  |
 | summaries.rb:30:24:30:30 | tainted :  | summaries.rb:30:6:30:42 | call to onlyWithBlock |
 | summaries.rb:31:27:31:33 | tainted :  | summaries.rb:31:6:31:34 | call to onlyWithoutBlock |
-| summaries.rb:40:7:40:17 | call to source :  | summaries.rb:41:24:41:24 | t :  |
-| summaries.rb:40:7:40:17 | call to source :  | summaries.rb:42:24:42:24 | t :  |
-| summaries.rb:40:7:40:17 | call to source :  | summaries.rb:44:8:44:8 | t :  |
+| summaries.rb:40:3:40:3 | t :  | summaries.rb:41:24:41:24 | t :  |
+| summaries.rb:40:3:40:3 | t :  | summaries.rb:42:24:42:24 | t :  |
+| summaries.rb:40:3:40:3 | t :  | summaries.rb:44:8:44:8 | t :  |
+| summaries.rb:40:7:40:17 | call to source :  | summaries.rb:40:3:40:3 | t :  |
 | summaries.rb:41:24:41:24 | t :  | summaries.rb:41:8:41:25 | call to matchedByName |
 | summaries.rb:42:24:42:24 | t :  | summaries.rb:42:8:42:25 | call to matchedByName |
 | summaries.rb:44:8:44:8 | t :  | summaries.rb:44:8:44:27 | call to matchedByNameRcv |
 | summaries.rb:48:24:48:41 | call to source :  | summaries.rb:48:8:48:42 | call to preserveTaint |
 | summaries.rb:51:24:51:30 | tainted :  | summaries.rb:51:6:51:31 | call to namedArg |
-| summaries.rb:53:15:53:31 | call to source :  | summaries.rb:54:21:54:24 | args [element :foo] :  |
+| summaries.rb:53:1:53:4 | args [element :foo] :  | summaries.rb:54:21:54:24 | args [element :foo] :  |
+| summaries.rb:53:15:53:31 | call to source :  | summaries.rb:53:1:53:4 | args [element :foo] :  |
 | summaries.rb:54:19:54:24 | ** ... [element :foo] :  | summaries.rb:54:6:54:25 | call to namedArg |
 | summaries.rb:54:21:54:24 | args [element :foo] :  | summaries.rb:54:19:54:24 | ** ... [element :foo] :  |
 | summaries.rb:56:22:56:28 | tainted :  | summaries.rb:56:6:56:29 | call to anyArg |
@@ -87,20 +97,24 @@ edges
 | summaries.rb:65:40:65:40 | x :  | summaries.rb:66:8:66:8 | x |
 | summaries.rb:73:24:73:53 | call to source :  | summaries.rb:73:8:73:54 | call to preserveTaint |
 | summaries.rb:76:26:76:56 | call to source :  | summaries.rb:76:8:76:57 | call to preserveTaint |
-| summaries.rb:79:15:79:29 | call to source :  | summaries.rb:82:6:82:6 | a [element 1] :  |
-| summaries.rb:79:15:79:29 | call to source :  | summaries.rb:82:6:82:6 | a [element 1] :  |
-| summaries.rb:79:15:79:29 | call to source :  | summaries.rb:83:6:83:6 | a [element 1] :  |
-| summaries.rb:79:15:79:29 | call to source :  | summaries.rb:83:6:83:6 | a [element 1] :  |
-| summaries.rb:79:15:79:29 | call to source :  | summaries.rb:85:6:85:6 | a [element 1] :  |
-| summaries.rb:79:15:79:29 | call to source :  | summaries.rb:85:6:85:6 | a [element 1] :  |
-| summaries.rb:79:15:79:29 | call to source :  | summaries.rb:87:5:87:5 | a [element 1] :  |
-| summaries.rb:79:15:79:29 | call to source :  | summaries.rb:87:5:87:5 | a [element 1] :  |
-| summaries.rb:79:15:79:29 | call to source :  | summaries.rb:91:5:91:5 | a [element 1] :  |
-| summaries.rb:79:15:79:29 | call to source :  | summaries.rb:91:5:91:5 | a [element 1] :  |
-| summaries.rb:79:32:79:46 | call to source :  | summaries.rb:86:6:86:6 | a [element 2] :  |
-| summaries.rb:79:32:79:46 | call to source :  | summaries.rb:86:6:86:6 | a [element 2] :  |
-| summaries.rb:79:32:79:46 | call to source :  | summaries.rb:95:1:95:1 | a [element 2] :  |
-| summaries.rb:79:32:79:46 | call to source :  | summaries.rb:95:1:95:1 | a [element 2] :  |
+| summaries.rb:79:1:79:1 | a [element 1] :  | summaries.rb:82:6:82:6 | a [element 1] :  |
+| summaries.rb:79:1:79:1 | a [element 1] :  | summaries.rb:82:6:82:6 | a [element 1] :  |
+| summaries.rb:79:1:79:1 | a [element 1] :  | summaries.rb:83:6:83:6 | a [element 1] :  |
+| summaries.rb:79:1:79:1 | a [element 1] :  | summaries.rb:83:6:83:6 | a [element 1] :  |
+| summaries.rb:79:1:79:1 | a [element 1] :  | summaries.rb:85:6:85:6 | a [element 1] :  |
+| summaries.rb:79:1:79:1 | a [element 1] :  | summaries.rb:85:6:85:6 | a [element 1] :  |
+| summaries.rb:79:1:79:1 | a [element 1] :  | summaries.rb:87:5:87:5 | a [element 1] :  |
+| summaries.rb:79:1:79:1 | a [element 1] :  | summaries.rb:87:5:87:5 | a [element 1] :  |
+| summaries.rb:79:1:79:1 | a [element 1] :  | summaries.rb:91:5:91:5 | a [element 1] :  |
+| summaries.rb:79:1:79:1 | a [element 1] :  | summaries.rb:91:5:91:5 | a [element 1] :  |
+| summaries.rb:79:1:79:1 | a [element 2] :  | summaries.rb:86:6:86:6 | a [element 2] :  |
+| summaries.rb:79:1:79:1 | a [element 2] :  | summaries.rb:86:6:86:6 | a [element 2] :  |
+| summaries.rb:79:1:79:1 | a [element 2] :  | summaries.rb:95:1:95:1 | a [element 2] :  |
+| summaries.rb:79:1:79:1 | a [element 2] :  | summaries.rb:95:1:95:1 | a [element 2] :  |
+| summaries.rb:79:15:79:29 | call to source :  | summaries.rb:79:1:79:1 | a [element 1] :  |
+| summaries.rb:79:15:79:29 | call to source :  | summaries.rb:79:1:79:1 | a [element 1] :  |
+| summaries.rb:79:32:79:46 | call to source :  | summaries.rb:79:1:79:1 | a [element 2] :  |
+| summaries.rb:79:32:79:46 | call to source :  | summaries.rb:79:1:79:1 | a [element 2] :  |
 | summaries.rb:81:1:81:1 | [post] a [element] :  | summaries.rb:82:6:82:6 | a [element] :  |
 | summaries.rb:81:1:81:1 | [post] a [element] :  | summaries.rb:82:6:82:6 | a [element] :  |
 | summaries.rb:81:1:81:1 | [post] a [element] :  | summaries.rb:84:6:84:6 | a [element] :  |
@@ -131,18 +145,22 @@ edges
 | summaries.rb:86:6:86:6 | a [element 2] :  | summaries.rb:86:6:86:9 | ...[...] |
 | summaries.rb:86:6:86:6 | a [element] :  | summaries.rb:86:6:86:9 | ...[...] |
 | summaries.rb:86:6:86:6 | a [element] :  | summaries.rb:86:6:86:9 | ...[...] |
+| summaries.rb:87:1:87:1 | b [element 1] :  | summaries.rb:89:6:89:6 | b [element 1] :  |
+| summaries.rb:87:1:87:1 | b [element 1] :  | summaries.rb:89:6:89:6 | b [element 1] :  |
+| summaries.rb:87:1:87:1 | b [element] :  | summaries.rb:88:6:88:6 | b [element] :  |
+| summaries.rb:87:1:87:1 | b [element] :  | summaries.rb:88:6:88:6 | b [element] :  |
+| summaries.rb:87:1:87:1 | b [element] :  | summaries.rb:89:6:89:6 | b [element] :  |
+| summaries.rb:87:1:87:1 | b [element] :  | summaries.rb:89:6:89:6 | b [element] :  |
+| summaries.rb:87:1:87:1 | b [element] :  | summaries.rb:90:6:90:6 | b [element] :  |
+| summaries.rb:87:1:87:1 | b [element] :  | summaries.rb:90:6:90:6 | b [element] :  |
 | summaries.rb:87:5:87:5 | a [element 1] :  | summaries.rb:87:5:87:22 | call to withElementOne [element 1] :  |
 | summaries.rb:87:5:87:5 | a [element 1] :  | summaries.rb:87:5:87:22 | call to withElementOne [element 1] :  |
 | summaries.rb:87:5:87:5 | a [element] :  | summaries.rb:87:5:87:22 | call to withElementOne [element] :  |
 | summaries.rb:87:5:87:5 | a [element] :  | summaries.rb:87:5:87:22 | call to withElementOne [element] :  |
-| summaries.rb:87:5:87:22 | call to withElementOne [element 1] :  | summaries.rb:89:6:89:6 | b [element 1] :  |
-| summaries.rb:87:5:87:22 | call to withElementOne [element 1] :  | summaries.rb:89:6:89:6 | b [element 1] :  |
-| summaries.rb:87:5:87:22 | call to withElementOne [element] :  | summaries.rb:88:6:88:6 | b [element] :  |
-| summaries.rb:87:5:87:22 | call to withElementOne [element] :  | summaries.rb:88:6:88:6 | b [element] :  |
-| summaries.rb:87:5:87:22 | call to withElementOne [element] :  | summaries.rb:89:6:89:6 | b [element] :  |
-| summaries.rb:87:5:87:22 | call to withElementOne [element] :  | summaries.rb:89:6:89:6 | b [element] :  |
-| summaries.rb:87:5:87:22 | call to withElementOne [element] :  | summaries.rb:90:6:90:6 | b [element] :  |
-| summaries.rb:87:5:87:22 | call to withElementOne [element] :  | summaries.rb:90:6:90:6 | b [element] :  |
+| summaries.rb:87:5:87:22 | call to withElementOne [element 1] :  | summaries.rb:87:1:87:1 | b [element 1] :  |
+| summaries.rb:87:5:87:22 | call to withElementOne [element 1] :  | summaries.rb:87:1:87:1 | b [element 1] :  |
+| summaries.rb:87:5:87:22 | call to withElementOne [element] :  | summaries.rb:87:1:87:1 | b [element] :  |
+| summaries.rb:87:5:87:22 | call to withElementOne [element] :  | summaries.rb:87:1:87:1 | b [element] :  |
 | summaries.rb:88:6:88:6 | b [element] :  | summaries.rb:88:6:88:9 | ...[...] |
 | summaries.rb:88:6:88:6 | b [element] :  | summaries.rb:88:6:88:9 | ...[...] |
 | summaries.rb:89:6:89:6 | b [element 1] :  | summaries.rb:89:6:89:9 | ...[...] |
@@ -151,10 +169,12 @@ edges
 | summaries.rb:89:6:89:6 | b [element] :  | summaries.rb:89:6:89:9 | ...[...] |
 | summaries.rb:90:6:90:6 | b [element] :  | summaries.rb:90:6:90:9 | ...[...] |
 | summaries.rb:90:6:90:6 | b [element] :  | summaries.rb:90:6:90:9 | ...[...] |
+| summaries.rb:91:1:91:1 | c [element 1] :  | summaries.rb:93:6:93:6 | c [element 1] :  |
+| summaries.rb:91:1:91:1 | c [element 1] :  | summaries.rb:93:6:93:6 | c [element 1] :  |
 | summaries.rb:91:5:91:5 | a [element 1] :  | summaries.rb:91:5:91:29 | call to withExactlyElementOne [element 1] :  |
 | summaries.rb:91:5:91:5 | a [element 1] :  | summaries.rb:91:5:91:29 | call to withExactlyElementOne [element 1] :  |
-| summaries.rb:91:5:91:29 | call to withExactlyElementOne [element 1] :  | summaries.rb:93:6:93:6 | c [element 1] :  |
-| summaries.rb:91:5:91:29 | call to withExactlyElementOne [element 1] :  | summaries.rb:93:6:93:6 | c [element 1] :  |
+| summaries.rb:91:5:91:29 | call to withExactlyElementOne [element 1] :  | summaries.rb:91:1:91:1 | c [element 1] :  |
+| summaries.rb:91:5:91:29 | call to withExactlyElementOne [element 1] :  | summaries.rb:91:1:91:1 | c [element 1] :  |
 | summaries.rb:93:6:93:6 | c [element 1] :  | summaries.rb:93:6:93:9 | ...[...] |
 | summaries.rb:93:6:93:6 | c [element 1] :  | summaries.rb:93:6:93:9 | ...[...] |
 | summaries.rb:95:1:95:1 | [post] a [element 2] :  | summaries.rb:98:6:98:6 | a [element 2] :  |
@@ -219,12 +239,16 @@ edges
 | summaries.rb:128:1:128:1 | [post] x :  | summaries.rb:129:6:129:6 | x |
 | summaries.rb:128:14:128:20 | tainted :  | summaries.rb:128:1:128:1 | [post] x :  |
 nodes
+| summaries.rb:1:1:1:7 | tainted :  | semmle.label | tainted :  |
+| summaries.rb:1:1:1:7 | tainted :  | semmle.label | tainted :  |
 | summaries.rb:1:11:1:36 | call to identity :  | semmle.label | call to identity :  |
 | summaries.rb:1:11:1:36 | call to identity :  | semmle.label | call to identity :  |
 | summaries.rb:1:20:1:36 | call to source :  | semmle.label | call to source :  |
 | summaries.rb:1:20:1:36 | call to source :  | semmle.label | call to source :  |
 | summaries.rb:2:6:2:12 | tainted | semmle.label | tainted |
 | summaries.rb:2:6:2:12 | tainted | semmle.label | tainted |
+| summaries.rb:4:1:4:8 | tainted2 :  | semmle.label | tainted2 :  |
+| summaries.rb:4:1:4:8 | tainted2 :  | semmle.label | tainted2 :  |
 | summaries.rb:4:12:7:3 | call to apply_block :  | semmle.label | call to apply_block :  |
 | summaries.rb:4:12:7:3 | call to apply_block :  | semmle.label | call to apply_block :  |
 | summaries.rb:4:24:4:30 | tainted :  | semmle.label | tainted :  |
@@ -239,15 +263,19 @@ nodes
 | summaries.rb:11:17:11:17 | x :  | semmle.label | x :  |
 | summaries.rb:12:8:12:8 | x | semmle.label | x |
 | summaries.rb:12:8:12:8 | x | semmle.label | x |
+| summaries.rb:16:1:16:8 | tainted3 :  | semmle.label | tainted3 :  |
+| summaries.rb:16:1:16:8 | tainted3 :  | semmle.label | tainted3 :  |
 | summaries.rb:16:12:16:43 | call to apply_lambda :  | semmle.label | call to apply_lambda :  |
 | summaries.rb:16:12:16:43 | call to apply_lambda :  | semmle.label | call to apply_lambda :  |
 | summaries.rb:16:36:16:42 | tainted :  | semmle.label | tainted :  |
 | summaries.rb:16:36:16:42 | tainted :  | semmle.label | tainted :  |
 | summaries.rb:18:6:18:13 | tainted3 | semmle.label | tainted3 |
 | summaries.rb:18:6:18:13 | tainted3 | semmle.label | tainted3 |
+| summaries.rb:20:1:20:8 | tainted4 :  | semmle.label | tainted4 :  |
 | summaries.rb:20:12:20:32 | call to firstArg :  | semmle.label | call to firstArg :  |
 | summaries.rb:20:25:20:31 | tainted :  | semmle.label | tainted :  |
 | summaries.rb:21:6:21:13 | tainted4 | semmle.label | tainted4 |
+| summaries.rb:26:1:26:8 | tainted5 :  | semmle.label | tainted5 :  |
 | summaries.rb:26:12:26:38 | call to secondArg :  | semmle.label | call to secondArg :  |
 | summaries.rb:26:31:26:37 | tainted :  | semmle.label | tainted :  |
 | summaries.rb:27:6:27:13 | tainted5 | semmle.label | tainted5 |
@@ -263,6 +291,7 @@ nodes
 | summaries.rb:36:21:36:27 | tainted | semmle.label | tainted |
 | summaries.rb:37:36:37:42 | tainted | semmle.label | tainted |
 | summaries.rb:37:36:37:42 | tainted | semmle.label | tainted |
+| summaries.rb:40:3:40:3 | t :  | semmle.label | t :  |
 | summaries.rb:40:7:40:17 | call to source :  | semmle.label | call to source :  |
 | summaries.rb:41:8:41:25 | call to matchedByName | semmle.label | call to matchedByName |
 | summaries.rb:41:24:41:24 | t :  | semmle.label | t :  |
@@ -274,6 +303,7 @@ nodes
 | summaries.rb:48:24:48:41 | call to source :  | semmle.label | call to source :  |
 | summaries.rb:51:6:51:31 | call to namedArg | semmle.label | call to namedArg |
 | summaries.rb:51:24:51:30 | tainted :  | semmle.label | tainted :  |
+| summaries.rb:53:1:53:4 | args [element :foo] :  | semmle.label | args [element :foo] :  |
 | summaries.rb:53:15:53:31 | call to source :  | semmle.label | call to source :  |
 | summaries.rb:54:6:54:25 | call to namedArg | semmle.label | call to namedArg |
 | summaries.rb:54:19:54:24 | ** ... [element :foo] :  | semmle.label | ** ... [element :foo] :  |
@@ -293,6 +323,10 @@ nodes
 | summaries.rb:73:24:73:53 | call to source :  | semmle.label | call to source :  |
 | summaries.rb:76:8:76:57 | call to preserveTaint | semmle.label | call to preserveTaint |
 | summaries.rb:76:26:76:56 | call to source :  | semmle.label | call to source :  |
+| summaries.rb:79:1:79:1 | a [element 1] :  | semmle.label | a [element 1] :  |
+| summaries.rb:79:1:79:1 | a [element 1] :  | semmle.label | a [element 1] :  |
+| summaries.rb:79:1:79:1 | a [element 2] :  | semmle.label | a [element 2] :  |
+| summaries.rb:79:1:79:1 | a [element 2] :  | semmle.label | a [element 2] :  |
 | summaries.rb:79:15:79:29 | call to source :  | semmle.label | call to source :  |
 | summaries.rb:79:15:79:29 | call to source :  | semmle.label | call to source :  |
 | summaries.rb:79:32:79:46 | call to source :  | semmle.label | call to source :  |
@@ -327,6 +361,10 @@ nodes
 | summaries.rb:86:6:86:6 | a [element] :  | semmle.label | a [element] :  |
 | summaries.rb:86:6:86:9 | ...[...] | semmle.label | ...[...] |
 | summaries.rb:86:6:86:9 | ...[...] | semmle.label | ...[...] |
+| summaries.rb:87:1:87:1 | b [element 1] :  | semmle.label | b [element 1] :  |
+| summaries.rb:87:1:87:1 | b [element 1] :  | semmle.label | b [element 1] :  |
+| summaries.rb:87:1:87:1 | b [element] :  | semmle.label | b [element] :  |
+| summaries.rb:87:1:87:1 | b [element] :  | semmle.label | b [element] :  |
 | summaries.rb:87:5:87:5 | a [element 1] :  | semmle.label | a [element 1] :  |
 | summaries.rb:87:5:87:5 | a [element 1] :  | semmle.label | a [element 1] :  |
 | summaries.rb:87:5:87:5 | a [element] :  | semmle.label | a [element] :  |
@@ -349,6 +387,8 @@ nodes
 | summaries.rb:90:6:90:6 | b [element] :  | semmle.label | b [element] :  |
 | summaries.rb:90:6:90:9 | ...[...] | semmle.label | ...[...] |
 | summaries.rb:90:6:90:9 | ...[...] | semmle.label | ...[...] |
+| summaries.rb:91:1:91:1 | c [element 1] :  | semmle.label | c [element 1] :  |
+| summaries.rb:91:1:91:1 | c [element 1] :  | semmle.label | c [element 1] :  |
 | summaries.rb:91:5:91:5 | a [element 1] :  | semmle.label | a [element 1] :  |
 | summaries.rb:91:5:91:5 | a [element 1] :  | semmle.label | a [element 1] :  |
 | summaries.rb:91:5:91:29 | call to withExactlyElementOne [element 1] :  | semmle.label | call to withExactlyElementOne [element 1] :  |

--- a/ruby/ql/test/library-tests/dataflow/type-tracker/TypeTracker.expected
+++ b/ruby/ql/test/library-tests/dataflow/type-tracker/TypeTracker.expected
@@ -446,7 +446,7 @@ trackEnd
 | type_tracker.rb:13:11:13:23 | call to new | type_tracker.rb:7:5:9:7 | self (field) |
 | type_tracker.rb:13:11:13:23 | call to new | type_tracker.rb:7:5:9:7 | self in field |
 | type_tracker.rb:13:11:13:23 | call to new | type_tracker.rb:8:9:8:14 | self |
-| type_tracker.rb:13:11:13:23 | call to new | type_tracker.rb:13:5:13:23 | ... = ... |
+| type_tracker.rb:13:11:13:23 | call to new | type_tracker.rb:13:5:13:7 | var |
 | type_tracker.rb:13:11:13:23 | call to new | type_tracker.rb:13:5:13:23 | ... = ... |
 | type_tracker.rb:13:11:13:23 | call to new | type_tracker.rb:13:11:13:23 | call to new |
 | type_tracker.rb:13:11:13:23 | call to new | type_tracker.rb:14:5:14:7 | var |
@@ -467,7 +467,7 @@ trackEnd
 | type_tracker.rb:14:17:14:23 | "hello" | type_tracker.rb:14:5:14:23 | ... |
 | type_tracker.rb:14:17:14:23 | "hello" | type_tracker.rb:14:17:14:23 | "hello" |
 | type_tracker.rb:14:17:14:23 | "hello" | type_tracker.rb:14:17:14:23 | ... = ... |
-| type_tracker.rb:14:17:14:23 | "hello" | type_tracker.rb:14:17:14:23 | ... = ... |
+| type_tracker.rb:14:17:14:23 | "hello" | type_tracker.rb:14:17:14:23 | __synth__0 |
 | type_tracker.rb:14:17:14:23 | "hello" | type_tracker.rb:15:10:15:18 | call to field |
 | type_tracker.rb:14:17:14:23 | __synth__0 | type_tracker.rb:14:17:14:23 | __synth__0 |
 | type_tracker.rb:15:5:15:18 | call to puts | type_tracker.rb:12:1:16:3 | return return in m |
@@ -606,8 +606,8 @@ trackEnd
 | type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:39:5:39:18 | ... |
 | type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:39:16:39:18 | ... = ... |
 | type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:39:16:39:18 | ... = ... |
-| type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:39:16:39:18 | ... = ... |
-| type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:39:16:39:18 | ... = ... |
+| type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:39:16:39:18 | __synth__0 |
+| type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:39:16:39:18 | __synth__0 |
 | type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:39:16:39:18 | obj |
 | type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:39:16:39:18 | obj |
 | type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:40:5:40:12 | ...[...] |
@@ -618,8 +618,8 @@ trackEnd
 | type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:43:5:43:19 | ... |
 | type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:43:17:43:19 | ... = ... |
 | type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:43:17:43:19 | ... = ... |
-| type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:43:17:43:19 | ... = ... |
-| type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:43:17:43:19 | ... = ... |
+| type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:43:17:43:19 | __synth__0 |
+| type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:43:17:43:19 | __synth__0 |
 | type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:43:17:43:19 | obj |
 | type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:43:17:43:19 | obj |
 | type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:44:5:44:13 | ...[...] |
@@ -630,8 +630,8 @@ trackEnd
 | type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:47:5:47:19 | ... |
 | type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:47:17:47:19 | ... = ... |
 | type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:47:17:47:19 | ... = ... |
-| type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:47:17:47:19 | ... = ... |
-| type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:47:17:47:19 | ... = ... |
+| type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:47:17:47:19 | __synth__0 |
+| type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:47:17:47:19 | __synth__0 |
 | type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:47:17:47:19 | obj |
 | type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:47:17:47:19 | obj |
 | type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:51:5:51:13 | __synth__0 |
@@ -640,8 +640,8 @@ trackEnd
 | type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:51:5:51:19 | ... |
 | type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:51:17:51:19 | ... = ... |
 | type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:51:17:51:19 | ... = ... |
-| type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:51:17:51:19 | ... = ... |
-| type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:51:17:51:19 | ... = ... |
+| type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:51:17:51:19 | __synth__0 |
+| type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:51:17:51:19 | __synth__0 |
 | type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:51:17:51:19 | obj |
 | type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:51:17:51:19 | obj |
 | type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:52:5:52:13 | ...[...] |
@@ -664,7 +664,7 @@ trackEnd
 | type_tracker.rb:34:26:34:26 | z | type_tracker.rb:52:12:52:12 | z |
 | type_tracker.rb:35:5:35:7 | tmp | type_tracker.rb:35:5:35:7 | tmp |
 | type_tracker.rb:35:11:35:15 | Array | type_tracker.rb:35:11:35:15 | Array |
-| type_tracker.rb:35:11:35:15 | call to [] | type_tracker.rb:35:5:35:15 | ... = ... |
+| type_tracker.rb:35:11:35:15 | call to [] | type_tracker.rb:35:5:35:7 | tmp |
 | type_tracker.rb:35:11:35:15 | call to [] | type_tracker.rb:35:5:35:15 | ... = ... |
 | type_tracker.rb:35:11:35:15 | call to [] | type_tracker.rb:35:11:35:15 | call to [] |
 | type_tracker.rb:35:11:35:15 | call to [] | type_tracker.rb:36:5:36:7 | tmp |
@@ -672,7 +672,7 @@ trackEnd
 | type_tracker.rb:36:9:36:9 | 0 | type_tracker.rb:36:9:36:9 | 0 |
 | type_tracker.rb:38:5:38:9 | array | type_tracker.rb:38:5:38:9 | array |
 | type_tracker.rb:38:13:38:25 | Array | type_tracker.rb:38:13:38:25 | Array |
-| type_tracker.rb:38:13:38:25 | call to [] | type_tracker.rb:38:5:38:25 | ... = ... |
+| type_tracker.rb:38:13:38:25 | call to [] | type_tracker.rb:38:5:38:9 | array |
 | type_tracker.rb:38:13:38:25 | call to [] | type_tracker.rb:38:5:38:25 | ... = ... |
 | type_tracker.rb:38:13:38:25 | call to [] | type_tracker.rb:38:13:38:25 | call to [] |
 | type_tracker.rb:38:13:38:25 | call to [] | type_tracker.rb:39:5:39:9 | array |
@@ -692,7 +692,7 @@ trackEnd
 | type_tracker.rb:40:11:40:11 | 0 | type_tracker.rb:40:11:40:11 | 0 |
 | type_tracker.rb:42:5:42:10 | array2 | type_tracker.rb:42:5:42:10 | array2 |
 | type_tracker.rb:42:14:42:26 | Array | type_tracker.rb:42:14:42:26 | Array |
-| type_tracker.rb:42:14:42:26 | call to [] | type_tracker.rb:42:5:42:26 | ... = ... |
+| type_tracker.rb:42:14:42:26 | call to [] | type_tracker.rb:42:5:42:10 | array2 |
 | type_tracker.rb:42:14:42:26 | call to [] | type_tracker.rb:42:5:42:26 | ... = ... |
 | type_tracker.rb:42:14:42:26 | call to [] | type_tracker.rb:42:14:42:26 | call to [] |
 | type_tracker.rb:42:14:42:26 | call to [] | type_tracker.rb:43:5:43:10 | array2 |
@@ -717,7 +717,7 @@ trackEnd
 | type_tracker.rb:44:5:44:13 | ...[...] | type_tracker.rb:44:5:44:13 | ...[...] |
 | type_tracker.rb:46:5:46:10 | array3 | type_tracker.rb:46:5:46:10 | array3 |
 | type_tracker.rb:46:14:46:26 | Array | type_tracker.rb:46:14:46:26 | Array |
-| type_tracker.rb:46:14:46:26 | call to [] | type_tracker.rb:46:5:46:26 | ... = ... |
+| type_tracker.rb:46:14:46:26 | call to [] | type_tracker.rb:46:5:46:10 | array3 |
 | type_tracker.rb:46:14:46:26 | call to [] | type_tracker.rb:46:5:46:26 | ... = ... |
 | type_tracker.rb:46:14:46:26 | call to [] | type_tracker.rb:46:14:46:26 | call to [] |
 | type_tracker.rb:46:14:46:26 | call to [] | type_tracker.rb:47:5:47:10 | array3 |
@@ -738,7 +738,7 @@ trackEnd
 | type_tracker.rb:48:12:48:12 | 1 | type_tracker.rb:48:12:48:12 | 1 |
 | type_tracker.rb:50:5:50:10 | array4 | type_tracker.rb:50:5:50:10 | array4 |
 | type_tracker.rb:50:14:50:26 | Array | type_tracker.rb:50:14:50:26 | Array |
-| type_tracker.rb:50:14:50:26 | call to [] | type_tracker.rb:50:5:50:26 | ... = ... |
+| type_tracker.rb:50:14:50:26 | call to [] | type_tracker.rb:50:5:50:10 | array4 |
 | type_tracker.rb:50:14:50:26 | call to [] | type_tracker.rb:50:5:50:26 | ... = ... |
 | type_tracker.rb:50:14:50:26 | call to [] | type_tracker.rb:50:14:50:26 | call to [] |
 | type_tracker.rb:50:14:50:26 | call to [] | type_tracker.rb:51:5:51:10 | array4 |

--- a/ruby/ql/test/library-tests/frameworks/active_record/ActiveRecord.expected
+++ b/ruby/ql/test/library-tests/frameworks/active_record/ActiveRecord.expected
@@ -20,10 +20,10 @@ activeRecordInstances
 | ActiveRecord.rb:76:5:76:66 | call to create |
 | ActiveRecord.rb:80:5:80:68 | call to create |
 | ActiveRecord.rb:84:5:84:16 | call to create |
-| associations.rb:19:1:19:20 | ... = ... |
+| associations.rb:19:1:19:7 | author1 |
 | associations.rb:19:1:19:20 | ... = ... |
 | associations.rb:19:11:19:20 | call to new |
-| associations.rb:21:1:21:28 | ... = ... |
+| associations.rb:21:1:21:5 | post1 |
 | associations.rb:21:1:21:28 | ... = ... |
 | associations.rb:21:9:21:15 | author1 |
 | associations.rb:21:9:21:21 | call to posts |
@@ -32,11 +32,11 @@ activeRecordInstances
 | associations.rb:23:12:23:16 | post1 |
 | associations.rb:23:12:23:25 | call to comments |
 | associations.rb:23:12:23:32 | call to create |
-| associations.rb:25:1:25:22 | ... = ... |
+| associations.rb:25:1:25:7 | author2 |
 | associations.rb:25:1:25:22 | ... = ... |
 | associations.rb:25:11:25:15 | post1 |
 | associations.rb:25:11:25:22 | call to author |
-| associations.rb:27:1:27:28 | ... = ... |
+| associations.rb:27:1:27:5 | post2 |
 | associations.rb:27:1:27:28 | ... = ... |
 | associations.rb:27:9:27:15 | author2 |
 | associations.rb:27:9:27:21 | call to posts |
@@ -50,7 +50,7 @@ activeRecordInstances
 | associations.rb:31:1:31:12 | call to author= |
 | associations.rb:31:1:31:22 | ... |
 | associations.rb:31:16:31:22 | ... = ... |
-| associations.rb:31:16:31:22 | ... = ... |
+| associations.rb:31:16:31:22 | __synth__0 |
 | associations.rb:31:16:31:22 | author2 |
 | associations.rb:35:1:35:5 | post2 |
 | associations.rb:35:1:35:14 | call to comments |

--- a/ruby/ql/test/library-tests/frameworks/active_resource/ActiveResource.expected
+++ b/ruby/ql/test/library-tests/frameworks/active_resource/ActiveResource.expected
@@ -11,11 +11,11 @@ modelClassMethodCalls
 | active_resource.rb:24:10:24:26 | call to find |
 | active_resource.rb:30:3:30:11 | call to site= |
 modelInstances
-| active_resource.rb:5:1:5:33 | ... = ... |
+| active_resource.rb:5:1:5:5 | alice |
 | active_resource.rb:5:1:5:33 | ... = ... |
 | active_resource.rb:5:9:5:33 | call to new |
 | active_resource.rb:6:1:6:5 | alice |
-| active_resource.rb:8:1:8:22 | ... = ... |
+| active_resource.rb:8:1:8:5 | alice |
 | active_resource.rb:8:1:8:22 | ... = ... |
 | active_resource.rb:8:9:8:22 | call to find |
 | active_resource.rb:9:1:9:5 | alice |
@@ -25,10 +25,10 @@ modelInstances
 | active_resource.rb:17:1:17:5 | alice |
 | active_resource.rb:18:1:18:22 | call to get |
 | active_resource.rb:19:1:19:5 | alice |
-| active_resource.rb:24:1:24:26 | ... = ... |
+| active_resource.rb:24:1:24:6 | people |
 | active_resource.rb:24:1:24:26 | ... = ... |
 | active_resource.rb:24:10:24:26 | call to find |
-| active_resource.rb:26:1:26:20 | ... = ... |
+| active_resource.rb:26:1:26:5 | alice |
 | active_resource.rb:26:1:26:20 | ... = ... |
 | active_resource.rb:26:9:26:14 | people |
 | active_resource.rb:26:9:26:20 | call to first |
@@ -46,7 +46,7 @@ modelInstanceMethodCalls
 collections
 | active_resource.rb:23:1:23:19 | ... = ... |
 | active_resource.rb:23:10:23:19 | call to all |
-| active_resource.rb:24:1:24:26 | ... = ... |
+| active_resource.rb:24:1:24:6 | people |
 | active_resource.rb:24:1:24:26 | ... = ... |
 | active_resource.rb:24:10:24:26 | call to find |
 | active_resource.rb:26:9:26:14 | people |

--- a/ruby/ql/test/library-tests/frameworks/active_storage/ActiveStorage.expected
+++ b/ruby/ql/test/library-tests/frameworks/active_storage/ActiveStorage.expected
@@ -1,12 +1,12 @@
 attachmentInstances
-| active_storage.rb:11:1:11:25 | ... = ... |
+| active_storage.rb:11:1:11:11 | user_avatar |
 | active_storage.rb:11:1:11:25 | ... = ... |
 | active_storage.rb:11:15:11:25 | call to avatar |
 | active_storage.rb:13:1:13:11 | user_avatar |
 | active_storage.rb:14:1:14:11 | user_avatar |
 | active_storage.rb:15:1:15:11 | user_avatar |
 | active_storage.rb:17:1:17:11 | call to avatar |
-| active_storage.rb:19:1:19:42 | ... = ... |
+| active_storage.rb:19:1:19:10 | attachment |
 | active_storage.rb:19:1:19:42 | ... = ... |
 | active_storage.rb:19:14:19:42 | call to new |
 | active_storage.rb:23:11:23:20 | attachment |

--- a/ruby/ql/test/library-tests/frameworks/active_support/ActiveSupportDataFlow.expected
+++ b/ruby/ql/test/library-tests/frameworks/active_support/ActiveSupportDataFlow.expected
@@ -1,122 +1,178 @@
 failures
 | hash_extensions.rb:126:10:126:19 | call to sole | Unexpected result: hasValueFlow=b |
 edges
-| active_support.rb:10:9:10:18 | call to source :  | active_support.rb:11:10:11:10 | x :  |
+| active_support.rb:10:5:10:5 | x :  | active_support.rb:11:10:11:10 | x :  |
+| active_support.rb:10:9:10:18 | call to source :  | active_support.rb:10:5:10:5 | x :  |
 | active_support.rb:11:10:11:10 | x :  | active_support.rb:11:10:11:19 | call to at |
-| active_support.rb:15:9:15:18 | call to source :  | active_support.rb:16:10:16:10 | x :  |
+| active_support.rb:15:5:15:5 | x :  | active_support.rb:16:10:16:10 | x :  |
+| active_support.rb:15:9:15:18 | call to source :  | active_support.rb:15:5:15:5 | x :  |
 | active_support.rb:16:10:16:10 | x :  | active_support.rb:16:10:16:19 | call to camelize |
-| active_support.rb:20:9:20:18 | call to source :  | active_support.rb:21:10:21:10 | x :  |
+| active_support.rb:20:5:20:5 | x :  | active_support.rb:21:10:21:10 | x :  |
+| active_support.rb:20:9:20:18 | call to source :  | active_support.rb:20:5:20:5 | x :  |
 | active_support.rb:21:10:21:10 | x :  | active_support.rb:21:10:21:20 | call to camelcase |
-| active_support.rb:25:9:25:18 | call to source :  | active_support.rb:26:10:26:10 | x :  |
+| active_support.rb:25:5:25:5 | x :  | active_support.rb:26:10:26:10 | x :  |
+| active_support.rb:25:9:25:18 | call to source :  | active_support.rb:25:5:25:5 | x :  |
 | active_support.rb:26:10:26:10 | x :  | active_support.rb:26:10:26:19 | call to classify |
-| active_support.rb:30:9:30:18 | call to source :  | active_support.rb:31:10:31:10 | x :  |
+| active_support.rb:30:5:30:5 | x :  | active_support.rb:31:10:31:10 | x :  |
+| active_support.rb:30:9:30:18 | call to source :  | active_support.rb:30:5:30:5 | x :  |
 | active_support.rb:31:10:31:10 | x :  | active_support.rb:31:10:31:20 | call to dasherize |
-| active_support.rb:35:9:35:18 | call to source :  | active_support.rb:36:10:36:10 | x :  |
+| active_support.rb:35:5:35:5 | x :  | active_support.rb:36:10:36:10 | x :  |
+| active_support.rb:35:9:35:18 | call to source :  | active_support.rb:35:5:35:5 | x :  |
 | active_support.rb:36:10:36:10 | x :  | active_support.rb:36:10:36:24 | call to deconstantize |
-| active_support.rb:40:9:40:18 | call to source :  | active_support.rb:41:10:41:10 | x :  |
+| active_support.rb:40:5:40:5 | x :  | active_support.rb:41:10:41:10 | x :  |
+| active_support.rb:40:9:40:18 | call to source :  | active_support.rb:40:5:40:5 | x :  |
 | active_support.rb:41:10:41:10 | x :  | active_support.rb:41:10:41:21 | call to demodulize |
-| active_support.rb:45:9:45:18 | call to source :  | active_support.rb:46:10:46:10 | x :  |
+| active_support.rb:45:5:45:5 | x :  | active_support.rb:46:10:46:10 | x :  |
+| active_support.rb:45:9:45:18 | call to source :  | active_support.rb:45:5:45:5 | x :  |
 | active_support.rb:46:10:46:10 | x :  | active_support.rb:46:10:46:19 | call to first |
-| active_support.rb:50:9:50:18 | call to source :  | active_support.rb:51:10:51:10 | x :  |
+| active_support.rb:50:5:50:5 | x :  | active_support.rb:51:10:51:10 | x :  |
+| active_support.rb:50:9:50:18 | call to source :  | active_support.rb:50:5:50:5 | x :  |
 | active_support.rb:51:10:51:10 | x :  | active_support.rb:51:10:51:22 | call to foreign_key |
-| active_support.rb:55:9:55:18 | call to source :  | active_support.rb:56:10:56:10 | x :  |
+| active_support.rb:55:5:55:5 | x :  | active_support.rb:56:10:56:10 | x :  |
+| active_support.rb:55:9:55:18 | call to source :  | active_support.rb:55:5:55:5 | x :  |
 | active_support.rb:56:10:56:10 | x :  | active_support.rb:56:10:56:18 | call to from |
-| active_support.rb:60:9:60:18 | call to source :  | active_support.rb:61:10:61:10 | x :  |
+| active_support.rb:60:5:60:5 | x :  | active_support.rb:61:10:61:10 | x :  |
+| active_support.rb:60:9:60:18 | call to source :  | active_support.rb:60:5:60:5 | x :  |
 | active_support.rb:61:10:61:10 | x :  | active_support.rb:61:10:61:20 | call to html_safe |
-| active_support.rb:65:9:65:18 | call to source :  | active_support.rb:66:10:66:10 | x :  |
+| active_support.rb:65:5:65:5 | x :  | active_support.rb:66:10:66:10 | x :  |
+| active_support.rb:65:9:65:18 | call to source :  | active_support.rb:65:5:65:5 | x :  |
 | active_support.rb:66:10:66:10 | x :  | active_support.rb:66:10:66:19 | call to humanize |
-| active_support.rb:70:9:70:18 | call to source :  | active_support.rb:71:10:71:10 | x :  |
+| active_support.rb:70:5:70:5 | x :  | active_support.rb:71:10:71:10 | x :  |
+| active_support.rb:70:9:70:18 | call to source :  | active_support.rb:70:5:70:5 | x :  |
 | active_support.rb:71:10:71:10 | x :  | active_support.rb:71:10:71:20 | call to indent |
-| active_support.rb:75:9:75:18 | call to source :  | active_support.rb:76:10:76:10 | x :  |
+| active_support.rb:75:5:75:5 | x :  | active_support.rb:76:10:76:10 | x :  |
+| active_support.rb:75:9:75:18 | call to source :  | active_support.rb:75:5:75:5 | x :  |
 | active_support.rb:76:10:76:10 | x :  | active_support.rb:76:10:76:21 | call to indent! |
-| active_support.rb:80:9:80:18 | call to source :  | active_support.rb:81:10:81:10 | x :  |
+| active_support.rb:80:5:80:5 | x :  | active_support.rb:81:10:81:10 | x :  |
+| active_support.rb:80:9:80:18 | call to source :  | active_support.rb:80:5:80:5 | x :  |
 | active_support.rb:81:10:81:10 | x :  | active_support.rb:81:10:81:18 | call to inquiry |
-| active_support.rb:85:9:85:18 | call to source :  | active_support.rb:86:10:86:10 | x :  |
+| active_support.rb:85:5:85:5 | x :  | active_support.rb:86:10:86:10 | x :  |
+| active_support.rb:85:9:85:18 | call to source :  | active_support.rb:85:5:85:5 | x :  |
 | active_support.rb:86:10:86:10 | x :  | active_support.rb:86:10:86:18 | call to last |
-| active_support.rb:90:9:90:18 | call to source :  | active_support.rb:91:10:91:10 | x :  |
+| active_support.rb:90:5:90:5 | x :  | active_support.rb:91:10:91:10 | x :  |
+| active_support.rb:90:9:90:18 | call to source :  | active_support.rb:90:5:90:5 | x :  |
 | active_support.rb:91:10:91:10 | x :  | active_support.rb:91:10:91:19 | call to mb_chars |
-| active_support.rb:95:9:95:18 | call to source :  | active_support.rb:96:10:96:10 | x :  |
+| active_support.rb:95:5:95:5 | x :  | active_support.rb:96:10:96:10 | x :  |
+| active_support.rb:95:9:95:18 | call to source :  | active_support.rb:95:5:95:5 | x :  |
 | active_support.rb:96:10:96:10 | x :  | active_support.rb:96:10:96:23 | call to parameterize |
-| active_support.rb:100:9:100:18 | call to source :  | active_support.rb:101:10:101:10 | x :  |
+| active_support.rb:100:5:100:5 | x :  | active_support.rb:101:10:101:10 | x :  |
+| active_support.rb:100:9:100:18 | call to source :  | active_support.rb:100:5:100:5 | x :  |
 | active_support.rb:101:10:101:10 | x :  | active_support.rb:101:10:101:20 | call to pluralize |
-| active_support.rb:105:9:105:18 | call to source :  | active_support.rb:106:10:106:10 | x :  |
+| active_support.rb:105:5:105:5 | x :  | active_support.rb:106:10:106:10 | x :  |
+| active_support.rb:105:9:105:18 | call to source :  | active_support.rb:105:5:105:5 | x :  |
 | active_support.rb:106:10:106:10 | x :  | active_support.rb:106:10:106:24 | call to remove |
-| active_support.rb:110:9:110:18 | call to source :  | active_support.rb:111:10:111:10 | x :  |
+| active_support.rb:110:5:110:5 | x :  | active_support.rb:111:10:111:10 | x :  |
+| active_support.rb:110:9:110:18 | call to source :  | active_support.rb:110:5:110:5 | x :  |
 | active_support.rb:111:10:111:10 | x :  | active_support.rb:111:10:111:25 | call to remove! |
-| active_support.rb:115:9:115:18 | call to source :  | active_support.rb:116:10:116:10 | x :  |
+| active_support.rb:115:5:115:5 | x :  | active_support.rb:116:10:116:10 | x :  |
+| active_support.rb:115:9:115:18 | call to source :  | active_support.rb:115:5:115:5 | x :  |
 | active_support.rb:116:10:116:10 | x :  | active_support.rb:116:10:116:22 | call to singularize |
-| active_support.rb:120:9:120:18 | call to source :  | active_support.rb:121:10:121:10 | x :  |
+| active_support.rb:120:5:120:5 | x :  | active_support.rb:121:10:121:10 | x :  |
+| active_support.rb:120:9:120:18 | call to source :  | active_support.rb:120:5:120:5 | x :  |
 | active_support.rb:121:10:121:10 | x :  | active_support.rb:121:10:121:17 | call to squish |
-| active_support.rb:125:9:125:18 | call to source :  | active_support.rb:126:10:126:10 | x :  |
+| active_support.rb:125:5:125:5 | x :  | active_support.rb:126:10:126:10 | x :  |
+| active_support.rb:125:9:125:18 | call to source :  | active_support.rb:125:5:125:5 | x :  |
 | active_support.rb:126:10:126:10 | x :  | active_support.rb:126:10:126:18 | call to squish! |
-| active_support.rb:130:9:130:18 | call to source :  | active_support.rb:131:10:131:10 | x :  |
+| active_support.rb:130:5:130:5 | x :  | active_support.rb:131:10:131:10 | x :  |
+| active_support.rb:130:9:130:18 | call to source :  | active_support.rb:130:5:130:5 | x :  |
 | active_support.rb:131:10:131:10 | x :  | active_support.rb:131:10:131:24 | call to strip_heredoc |
-| active_support.rb:135:9:135:18 | call to source :  | active_support.rb:136:10:136:10 | x :  |
+| active_support.rb:135:5:135:5 | x :  | active_support.rb:136:10:136:10 | x :  |
+| active_support.rb:135:9:135:18 | call to source :  | active_support.rb:135:5:135:5 | x :  |
 | active_support.rb:136:10:136:10 | x :  | active_support.rb:136:10:136:19 | call to tableize |
-| active_support.rb:140:9:140:18 | call to source :  | active_support.rb:141:10:141:10 | x :  |
+| active_support.rb:140:5:140:5 | x :  | active_support.rb:141:10:141:10 | x :  |
+| active_support.rb:140:9:140:18 | call to source :  | active_support.rb:140:5:140:5 | x :  |
 | active_support.rb:141:10:141:10 | x :  | active_support.rb:141:10:141:20 | call to titlecase |
-| active_support.rb:145:9:145:18 | call to source :  | active_support.rb:146:10:146:10 | x :  |
+| active_support.rb:145:5:145:5 | x :  | active_support.rb:146:10:146:10 | x :  |
+| active_support.rb:145:9:145:18 | call to source :  | active_support.rb:145:5:145:5 | x :  |
 | active_support.rb:146:10:146:10 | x :  | active_support.rb:146:10:146:19 | call to titleize |
-| active_support.rb:150:9:150:18 | call to source :  | active_support.rb:151:10:151:10 | x :  |
+| active_support.rb:150:5:150:5 | x :  | active_support.rb:151:10:151:10 | x :  |
+| active_support.rb:150:9:150:18 | call to source :  | active_support.rb:150:5:150:5 | x :  |
 | active_support.rb:151:10:151:10 | x :  | active_support.rb:151:10:151:16 | call to to |
-| active_support.rb:155:9:155:18 | call to source :  | active_support.rb:156:10:156:10 | x :  |
+| active_support.rb:155:5:155:5 | x :  | active_support.rb:156:10:156:10 | x :  |
+| active_support.rb:155:9:155:18 | call to source :  | active_support.rb:155:5:155:5 | x :  |
 | active_support.rb:156:10:156:10 | x :  | active_support.rb:156:10:156:22 | call to truncate |
-| active_support.rb:160:9:160:18 | call to source :  | active_support.rb:161:10:161:10 | x :  |
+| active_support.rb:160:5:160:5 | x :  | active_support.rb:161:10:161:10 | x :  |
+| active_support.rb:160:9:160:18 | call to source :  | active_support.rb:160:5:160:5 | x :  |
 | active_support.rb:161:10:161:10 | x :  | active_support.rb:161:10:161:28 | call to truncate_bytes |
-| active_support.rb:165:9:165:18 | call to source :  | active_support.rb:166:10:166:10 | x :  |
+| active_support.rb:165:5:165:5 | x :  | active_support.rb:166:10:166:10 | x :  |
+| active_support.rb:165:9:165:18 | call to source :  | active_support.rb:165:5:165:5 | x :  |
 | active_support.rb:166:10:166:10 | x :  | active_support.rb:166:10:166:28 | call to truncate_words |
-| active_support.rb:170:9:170:18 | call to source :  | active_support.rb:171:10:171:10 | x :  |
+| active_support.rb:170:5:170:5 | x :  | active_support.rb:171:10:171:10 | x :  |
+| active_support.rb:170:9:170:18 | call to source :  | active_support.rb:170:5:170:5 | x :  |
 | active_support.rb:171:10:171:10 | x :  | active_support.rb:171:10:171:21 | call to underscore |
-| active_support.rb:175:9:175:18 | call to source :  | active_support.rb:176:10:176:10 | x :  |
+| active_support.rb:175:5:175:5 | x :  | active_support.rb:176:10:176:10 | x :  |
+| active_support.rb:175:9:175:18 | call to source :  | active_support.rb:175:5:175:5 | x :  |
 | active_support.rb:176:10:176:10 | x :  | active_support.rb:176:10:176:23 | call to upcase_first |
-| active_support.rb:180:10:180:17 | call to source :  | active_support.rb:181:9:181:9 | x [element 0] :  |
-| active_support.rb:180:10:180:17 | call to source :  | active_support.rb:181:9:181:9 | x [element 0] :  |
+| active_support.rb:180:5:180:5 | x [element 0] :  | active_support.rb:181:9:181:9 | x [element 0] :  |
+| active_support.rb:180:5:180:5 | x [element 0] :  | active_support.rb:181:9:181:9 | x [element 0] :  |
+| active_support.rb:180:10:180:17 | call to source :  | active_support.rb:180:5:180:5 | x [element 0] :  |
+| active_support.rb:180:10:180:17 | call to source :  | active_support.rb:180:5:180:5 | x [element 0] :  |
+| active_support.rb:181:5:181:5 | y [element] :  | active_support.rb:182:10:182:10 | y [element] :  |
+| active_support.rb:181:5:181:5 | y [element] :  | active_support.rb:182:10:182:10 | y [element] :  |
 | active_support.rb:181:9:181:9 | x [element 0] :  | active_support.rb:181:9:181:23 | call to compact_blank [element] :  |
 | active_support.rb:181:9:181:9 | x [element 0] :  | active_support.rb:181:9:181:23 | call to compact_blank [element] :  |
-| active_support.rb:181:9:181:23 | call to compact_blank [element] :  | active_support.rb:182:10:182:10 | y [element] :  |
-| active_support.rb:181:9:181:23 | call to compact_blank [element] :  | active_support.rb:182:10:182:10 | y [element] :  |
+| active_support.rb:181:9:181:23 | call to compact_blank [element] :  | active_support.rb:181:5:181:5 | y [element] :  |
+| active_support.rb:181:9:181:23 | call to compact_blank [element] :  | active_support.rb:181:5:181:5 | y [element] :  |
 | active_support.rb:182:10:182:10 | y [element] :  | active_support.rb:182:10:182:13 | ...[...] |
 | active_support.rb:182:10:182:10 | y [element] :  | active_support.rb:182:10:182:13 | ...[...] |
-| active_support.rb:186:10:186:18 | call to source :  | active_support.rb:187:9:187:9 | x [element 0] :  |
-| active_support.rb:186:10:186:18 | call to source :  | active_support.rb:187:9:187:9 | x [element 0] :  |
+| active_support.rb:186:5:186:5 | x [element 0] :  | active_support.rb:187:9:187:9 | x [element 0] :  |
+| active_support.rb:186:5:186:5 | x [element 0] :  | active_support.rb:187:9:187:9 | x [element 0] :  |
+| active_support.rb:186:10:186:18 | call to source :  | active_support.rb:186:5:186:5 | x [element 0] :  |
+| active_support.rb:186:10:186:18 | call to source :  | active_support.rb:186:5:186:5 | x [element 0] :  |
+| active_support.rb:187:5:187:5 | y [element] :  | active_support.rb:188:10:188:10 | y [element] :  |
+| active_support.rb:187:5:187:5 | y [element] :  | active_support.rb:188:10:188:10 | y [element] :  |
 | active_support.rb:187:9:187:9 | x [element 0] :  | active_support.rb:187:9:187:21 | call to excluding [element] :  |
 | active_support.rb:187:9:187:9 | x [element 0] :  | active_support.rb:187:9:187:21 | call to excluding [element] :  |
-| active_support.rb:187:9:187:21 | call to excluding [element] :  | active_support.rb:188:10:188:10 | y [element] :  |
-| active_support.rb:187:9:187:21 | call to excluding [element] :  | active_support.rb:188:10:188:10 | y [element] :  |
+| active_support.rb:187:9:187:21 | call to excluding [element] :  | active_support.rb:187:5:187:5 | y [element] :  |
+| active_support.rb:187:9:187:21 | call to excluding [element] :  | active_support.rb:187:5:187:5 | y [element] :  |
 | active_support.rb:188:10:188:10 | y [element] :  | active_support.rb:188:10:188:13 | ...[...] |
 | active_support.rb:188:10:188:10 | y [element] :  | active_support.rb:188:10:188:13 | ...[...] |
-| active_support.rb:192:10:192:18 | call to source :  | active_support.rb:193:9:193:9 | x [element 0] :  |
-| active_support.rb:192:10:192:18 | call to source :  | active_support.rb:193:9:193:9 | x [element 0] :  |
+| active_support.rb:192:5:192:5 | x [element 0] :  | active_support.rb:193:9:193:9 | x [element 0] :  |
+| active_support.rb:192:5:192:5 | x [element 0] :  | active_support.rb:193:9:193:9 | x [element 0] :  |
+| active_support.rb:192:10:192:18 | call to source :  | active_support.rb:192:5:192:5 | x [element 0] :  |
+| active_support.rb:192:10:192:18 | call to source :  | active_support.rb:192:5:192:5 | x [element 0] :  |
+| active_support.rb:193:5:193:5 | y [element] :  | active_support.rb:194:10:194:10 | y [element] :  |
+| active_support.rb:193:5:193:5 | y [element] :  | active_support.rb:194:10:194:10 | y [element] :  |
 | active_support.rb:193:9:193:9 | x [element 0] :  | active_support.rb:193:9:193:19 | call to without [element] :  |
 | active_support.rb:193:9:193:9 | x [element 0] :  | active_support.rb:193:9:193:19 | call to without [element] :  |
-| active_support.rb:193:9:193:19 | call to without [element] :  | active_support.rb:194:10:194:10 | y [element] :  |
-| active_support.rb:193:9:193:19 | call to without [element] :  | active_support.rb:194:10:194:10 | y [element] :  |
+| active_support.rb:193:9:193:19 | call to without [element] :  | active_support.rb:193:5:193:5 | y [element] :  |
+| active_support.rb:193:9:193:19 | call to without [element] :  | active_support.rb:193:5:193:5 | y [element] :  |
 | active_support.rb:194:10:194:10 | y [element] :  | active_support.rb:194:10:194:13 | ...[...] |
 | active_support.rb:194:10:194:10 | y [element] :  | active_support.rb:194:10:194:13 | ...[...] |
-| active_support.rb:198:10:198:18 | call to source :  | active_support.rb:199:9:199:9 | x [element 0] :  |
-| active_support.rb:198:10:198:18 | call to source :  | active_support.rb:199:9:199:9 | x [element 0] :  |
+| active_support.rb:198:5:198:5 | x [element 0] :  | active_support.rb:199:9:199:9 | x [element 0] :  |
+| active_support.rb:198:5:198:5 | x [element 0] :  | active_support.rb:199:9:199:9 | x [element 0] :  |
+| active_support.rb:198:10:198:18 | call to source :  | active_support.rb:198:5:198:5 | x [element 0] :  |
+| active_support.rb:198:10:198:18 | call to source :  | active_support.rb:198:5:198:5 | x [element 0] :  |
+| active_support.rb:199:5:199:5 | y [element] :  | active_support.rb:200:10:200:10 | y [element] :  |
+| active_support.rb:199:5:199:5 | y [element] :  | active_support.rb:200:10:200:10 | y [element] :  |
 | active_support.rb:199:9:199:9 | x [element 0] :  | active_support.rb:199:9:199:37 | call to in_order_of [element] :  |
 | active_support.rb:199:9:199:9 | x [element 0] :  | active_support.rb:199:9:199:37 | call to in_order_of [element] :  |
-| active_support.rb:199:9:199:37 | call to in_order_of [element] :  | active_support.rb:200:10:200:10 | y [element] :  |
-| active_support.rb:199:9:199:37 | call to in_order_of [element] :  | active_support.rb:200:10:200:10 | y [element] :  |
+| active_support.rb:199:9:199:37 | call to in_order_of [element] :  | active_support.rb:199:5:199:5 | y [element] :  |
+| active_support.rb:199:9:199:37 | call to in_order_of [element] :  | active_support.rb:199:5:199:5 | y [element] :  |
 | active_support.rb:200:10:200:10 | y [element] :  | active_support.rb:200:10:200:13 | ...[...] |
 | active_support.rb:200:10:200:10 | y [element] :  | active_support.rb:200:10:200:13 | ...[...] |
-| active_support.rb:204:10:204:18 | call to source :  | active_support.rb:205:9:205:9 | a [element 0] :  |
-| active_support.rb:204:10:204:18 | call to source :  | active_support.rb:205:9:205:9 | a [element 0] :  |
-| active_support.rb:204:10:204:18 | call to source :  | active_support.rb:206:10:206:10 | a [element 0] :  |
-| active_support.rb:204:10:204:18 | call to source :  | active_support.rb:206:10:206:10 | a [element 0] :  |
+| active_support.rb:204:5:204:5 | a [element 0] :  | active_support.rb:205:9:205:9 | a [element 0] :  |
+| active_support.rb:204:5:204:5 | a [element 0] :  | active_support.rb:205:9:205:9 | a [element 0] :  |
+| active_support.rb:204:5:204:5 | a [element 0] :  | active_support.rb:206:10:206:10 | a [element 0] :  |
+| active_support.rb:204:5:204:5 | a [element 0] :  | active_support.rb:206:10:206:10 | a [element 0] :  |
+| active_support.rb:204:10:204:18 | call to source :  | active_support.rb:204:5:204:5 | a [element 0] :  |
+| active_support.rb:204:10:204:18 | call to source :  | active_support.rb:204:5:204:5 | a [element 0] :  |
+| active_support.rb:205:5:205:5 | b [element 0] :  | active_support.rb:208:10:208:10 | b [element 0] :  |
+| active_support.rb:205:5:205:5 | b [element 0] :  | active_support.rb:208:10:208:10 | b [element 0] :  |
+| active_support.rb:205:5:205:5 | b [element] :  | active_support.rb:208:10:208:10 | b [element] :  |
+| active_support.rb:205:5:205:5 | b [element] :  | active_support.rb:208:10:208:10 | b [element] :  |
+| active_support.rb:205:5:205:5 | b [element] :  | active_support.rb:209:10:209:10 | b [element] :  |
+| active_support.rb:205:5:205:5 | b [element] :  | active_support.rb:209:10:209:10 | b [element] :  |
+| active_support.rb:205:5:205:5 | b [element] :  | active_support.rb:210:10:210:10 | b [element] :  |
+| active_support.rb:205:5:205:5 | b [element] :  | active_support.rb:210:10:210:10 | b [element] :  |
+| active_support.rb:205:5:205:5 | b [element] :  | active_support.rb:211:10:211:10 | b [element] :  |
+| active_support.rb:205:5:205:5 | b [element] :  | active_support.rb:211:10:211:10 | b [element] :  |
 | active_support.rb:205:9:205:9 | a [element 0] :  | active_support.rb:205:9:205:41 | call to including [element 0] :  |
 | active_support.rb:205:9:205:9 | a [element 0] :  | active_support.rb:205:9:205:41 | call to including [element 0] :  |
-| active_support.rb:205:9:205:41 | call to including [element 0] :  | active_support.rb:208:10:208:10 | b [element 0] :  |
-| active_support.rb:205:9:205:41 | call to including [element 0] :  | active_support.rb:208:10:208:10 | b [element 0] :  |
-| active_support.rb:205:9:205:41 | call to including [element] :  | active_support.rb:208:10:208:10 | b [element] :  |
-| active_support.rb:205:9:205:41 | call to including [element] :  | active_support.rb:208:10:208:10 | b [element] :  |
-| active_support.rb:205:9:205:41 | call to including [element] :  | active_support.rb:209:10:209:10 | b [element] :  |
-| active_support.rb:205:9:205:41 | call to including [element] :  | active_support.rb:209:10:209:10 | b [element] :  |
-| active_support.rb:205:9:205:41 | call to including [element] :  | active_support.rb:210:10:210:10 | b [element] :  |
-| active_support.rb:205:9:205:41 | call to including [element] :  | active_support.rb:210:10:210:10 | b [element] :  |
-| active_support.rb:205:9:205:41 | call to including [element] :  | active_support.rb:211:10:211:10 | b [element] :  |
-| active_support.rb:205:9:205:41 | call to including [element] :  | active_support.rb:211:10:211:10 | b [element] :  |
+| active_support.rb:205:9:205:41 | call to including [element 0] :  | active_support.rb:205:5:205:5 | b [element 0] :  |
+| active_support.rb:205:9:205:41 | call to including [element 0] :  | active_support.rb:205:5:205:5 | b [element 0] :  |
+| active_support.rb:205:9:205:41 | call to including [element] :  | active_support.rb:205:5:205:5 | b [element] :  |
+| active_support.rb:205:9:205:41 | call to including [element] :  | active_support.rb:205:5:205:5 | b [element] :  |
 | active_support.rb:205:21:205:29 | call to source :  | active_support.rb:205:9:205:41 | call to including [element] :  |
 | active_support.rb:205:21:205:29 | call to source :  | active_support.rb:205:9:205:41 | call to including [element] :  |
 | active_support.rb:205:32:205:40 | call to source :  | active_support.rb:205:9:205:41 | call to including [element] :  |
@@ -133,130 +189,202 @@ edges
 | active_support.rb:210:10:210:10 | b [element] :  | active_support.rb:210:10:210:13 | ...[...] |
 | active_support.rb:211:10:211:10 | b [element] :  | active_support.rb:211:10:211:13 | ...[...] |
 | active_support.rb:211:10:211:10 | b [element] :  | active_support.rb:211:10:211:13 | ...[...] |
-| active_support.rb:215:7:215:16 | call to source :  | active_support.rb:216:34:216:34 | x :  |
-| active_support.rb:216:7:216:35 | call to new :  | active_support.rb:217:8:217:8 | y |
+| active_support.rb:215:3:215:3 | x :  | active_support.rb:216:34:216:34 | x :  |
+| active_support.rb:215:7:215:16 | call to source :  | active_support.rb:215:3:215:3 | x :  |
+| active_support.rb:216:3:216:3 | y :  | active_support.rb:217:8:217:8 | y |
+| active_support.rb:216:7:216:35 | call to new :  | active_support.rb:216:3:216:3 | y :  |
 | active_support.rb:216:34:216:34 | x :  | active_support.rb:216:7:216:35 | call to new :  |
-| active_support.rb:222:7:222:16 | call to source :  | active_support.rb:223:21:223:21 | b :  |
-| active_support.rb:223:7:223:22 | call to safe_concat :  | active_support.rb:224:8:224:8 | y |
+| active_support.rb:222:3:222:3 | b :  | active_support.rb:223:21:223:21 | b :  |
+| active_support.rb:222:7:222:16 | call to source :  | active_support.rb:222:3:222:3 | b :  |
+| active_support.rb:223:3:223:3 | y :  | active_support.rb:224:8:224:8 | y |
+| active_support.rb:223:7:223:22 | call to safe_concat :  | active_support.rb:223:3:223:3 | y :  |
 | active_support.rb:223:21:223:21 | b :  | active_support.rb:223:7:223:22 | call to safe_concat :  |
-| active_support.rb:229:7:229:16 | call to source :  | active_support.rb:230:17:230:17 | b :  |
+| active_support.rb:229:3:229:3 | b :  | active_support.rb:230:17:230:17 | b :  |
+| active_support.rb:229:7:229:16 | call to source :  | active_support.rb:229:3:229:3 | b :  |
 | active_support.rb:230:3:230:3 | [post] x :  | active_support.rb:231:8:231:8 | x |
 | active_support.rb:230:17:230:17 | b :  | active_support.rb:230:3:230:3 | [post] x :  |
-| active_support.rb:235:7:235:16 | call to source :  | active_support.rb:237:34:237:34 | a :  |
-| active_support.rb:237:7:237:35 | call to new :  | active_support.rb:238:7:238:7 | x :  |
+| active_support.rb:235:3:235:3 | a :  | active_support.rb:237:34:237:34 | a :  |
+| active_support.rb:235:7:235:16 | call to source :  | active_support.rb:235:3:235:3 | a :  |
+| active_support.rb:237:3:237:3 | x :  | active_support.rb:238:7:238:7 | x :  |
+| active_support.rb:237:7:237:35 | call to new :  | active_support.rb:237:3:237:3 | x :  |
 | active_support.rb:237:34:237:34 | a :  | active_support.rb:237:7:237:35 | call to new :  |
+| active_support.rb:238:3:238:3 | y :  | active_support.rb:239:8:239:8 | y |
 | active_support.rb:238:7:238:7 | x :  | active_support.rb:238:7:238:17 | call to concat :  |
-| active_support.rb:238:7:238:17 | call to concat :  | active_support.rb:239:8:239:8 | y |
-| active_support.rb:243:7:243:16 | call to source :  | active_support.rb:245:34:245:34 | a :  |
-| active_support.rb:245:7:245:35 | call to new :  | active_support.rb:246:7:246:7 | x :  |
+| active_support.rb:238:7:238:17 | call to concat :  | active_support.rb:238:3:238:3 | y :  |
+| active_support.rb:243:3:243:3 | a :  | active_support.rb:245:34:245:34 | a :  |
+| active_support.rb:243:7:243:16 | call to source :  | active_support.rb:243:3:243:3 | a :  |
+| active_support.rb:245:3:245:3 | x :  | active_support.rb:246:7:246:7 | x :  |
+| active_support.rb:245:7:245:35 | call to new :  | active_support.rb:245:3:245:3 | x :  |
 | active_support.rb:245:34:245:34 | a :  | active_support.rb:245:7:245:35 | call to new :  |
+| active_support.rb:246:3:246:3 | y :  | active_support.rb:247:8:247:8 | y |
 | active_support.rb:246:7:246:7 | x :  | active_support.rb:246:7:246:20 | call to insert :  |
-| active_support.rb:246:7:246:20 | call to insert :  | active_support.rb:247:8:247:8 | y |
-| active_support.rb:251:7:251:16 | call to source :  | active_support.rb:253:34:253:34 | a :  |
-| active_support.rb:253:7:253:35 | call to new :  | active_support.rb:254:7:254:7 | x :  |
+| active_support.rb:246:7:246:20 | call to insert :  | active_support.rb:246:3:246:3 | y :  |
+| active_support.rb:251:3:251:3 | a :  | active_support.rb:253:34:253:34 | a :  |
+| active_support.rb:251:7:251:16 | call to source :  | active_support.rb:251:3:251:3 | a :  |
+| active_support.rb:253:3:253:3 | x :  | active_support.rb:254:7:254:7 | x :  |
+| active_support.rb:253:7:253:35 | call to new :  | active_support.rb:253:3:253:3 | x :  |
 | active_support.rb:253:34:253:34 | a :  | active_support.rb:253:7:253:35 | call to new :  |
+| active_support.rb:254:3:254:3 | y :  | active_support.rb:255:8:255:8 | y |
 | active_support.rb:254:7:254:7 | x :  | active_support.rb:254:7:254:18 | call to prepend :  |
-| active_support.rb:254:7:254:18 | call to prepend :  | active_support.rb:255:8:255:8 | y |
-| active_support.rb:259:7:259:16 | call to source :  | active_support.rb:260:34:260:34 | a :  |
-| active_support.rb:260:7:260:35 | call to new :  | active_support.rb:261:7:261:7 | x :  |
+| active_support.rb:254:7:254:18 | call to prepend :  | active_support.rb:254:3:254:3 | y :  |
+| active_support.rb:259:3:259:3 | a :  | active_support.rb:260:34:260:34 | a :  |
+| active_support.rb:259:7:259:16 | call to source :  | active_support.rb:259:3:259:3 | a :  |
+| active_support.rb:260:3:260:3 | x :  | active_support.rb:261:7:261:7 | x :  |
+| active_support.rb:260:7:260:35 | call to new :  | active_support.rb:260:3:260:3 | x :  |
 | active_support.rb:260:34:260:34 | a :  | active_support.rb:260:7:260:35 | call to new :  |
+| active_support.rb:261:3:261:3 | y :  | active_support.rb:262:8:262:8 | y |
 | active_support.rb:261:7:261:7 | x :  | active_support.rb:261:7:261:12 | call to to_s :  |
-| active_support.rb:261:7:261:12 | call to to_s :  | active_support.rb:262:8:262:8 | y |
-| active_support.rb:266:7:266:16 | call to source :  | active_support.rb:267:34:267:34 | a :  |
-| active_support.rb:267:7:267:35 | call to new :  | active_support.rb:268:7:268:7 | x :  |
+| active_support.rb:261:7:261:12 | call to to_s :  | active_support.rb:261:3:261:3 | y :  |
+| active_support.rb:266:3:266:3 | a :  | active_support.rb:267:34:267:34 | a :  |
+| active_support.rb:266:7:266:16 | call to source :  | active_support.rb:266:3:266:3 | a :  |
+| active_support.rb:267:3:267:3 | x :  | active_support.rb:268:7:268:7 | x :  |
+| active_support.rb:267:7:267:35 | call to new :  | active_support.rb:267:3:267:3 | x :  |
 | active_support.rb:267:34:267:34 | a :  | active_support.rb:267:7:267:35 | call to new :  |
+| active_support.rb:268:3:268:3 | y :  | active_support.rb:269:8:269:8 | y |
 | active_support.rb:268:7:268:7 | x :  | active_support.rb:268:7:268:16 | call to to_param :  |
-| active_support.rb:268:7:268:16 | call to to_param :  | active_support.rb:269:8:269:8 | y |
-| active_support.rb:273:7:273:16 | call to source :  | active_support.rb:274:20:274:20 | a :  |
-| active_support.rb:274:7:274:21 | call to new :  | active_support.rb:275:7:275:7 | x :  |
+| active_support.rb:268:7:268:16 | call to to_param :  | active_support.rb:268:3:268:3 | y :  |
+| active_support.rb:273:3:273:3 | a :  | active_support.rb:274:20:274:20 | a :  |
+| active_support.rb:273:7:273:16 | call to source :  | active_support.rb:273:3:273:3 | a :  |
+| active_support.rb:274:3:274:3 | x :  | active_support.rb:275:7:275:7 | x :  |
+| active_support.rb:274:7:274:21 | call to new :  | active_support.rb:274:3:274:3 | x :  |
 | active_support.rb:274:20:274:20 | a :  | active_support.rb:274:7:274:21 | call to new :  |
+| active_support.rb:275:3:275:3 | y :  | active_support.rb:276:8:276:8 | y |
+| active_support.rb:275:3:275:3 | y :  | active_support.rb:277:7:277:7 | y :  |
 | active_support.rb:275:7:275:7 | x :  | active_support.rb:275:7:275:17 | call to existence :  |
-| active_support.rb:275:7:275:17 | call to existence :  | active_support.rb:276:8:276:8 | y |
-| active_support.rb:275:7:275:17 | call to existence :  | active_support.rb:277:7:277:7 | y :  |
+| active_support.rb:275:7:275:17 | call to existence :  | active_support.rb:275:3:275:3 | y :  |
+| active_support.rb:277:3:277:3 | z :  | active_support.rb:278:8:278:8 | z |
 | active_support.rb:277:7:277:7 | y :  | active_support.rb:277:7:277:17 | call to existence :  |
-| active_support.rb:277:7:277:17 | call to existence :  | active_support.rb:278:8:278:8 | z |
-| active_support.rb:282:7:282:16 | call to source :  | active_support.rb:283:8:283:8 | x :  |
-| active_support.rb:282:7:282:16 | call to source :  | active_support.rb:283:8:283:8 | x :  |
+| active_support.rb:277:7:277:17 | call to existence :  | active_support.rb:277:3:277:3 | z :  |
+| active_support.rb:282:3:282:3 | x :  | active_support.rb:283:8:283:8 | x :  |
+| active_support.rb:282:3:282:3 | x :  | active_support.rb:283:8:283:8 | x :  |
+| active_support.rb:282:7:282:16 | call to source :  | active_support.rb:282:3:282:3 | x :  |
+| active_support.rb:282:7:282:16 | call to source :  | active_support.rb:282:3:282:3 | x :  |
 | active_support.rb:283:8:283:8 | x :  | active_support.rb:283:8:283:17 | call to presence |
 | active_support.rb:283:8:283:8 | x :  | active_support.rb:283:8:283:17 | call to presence |
-| active_support.rb:285:7:285:16 | call to source :  | active_support.rb:286:8:286:8 | y :  |
-| active_support.rb:285:7:285:16 | call to source :  | active_support.rb:286:8:286:8 | y :  |
+| active_support.rb:285:3:285:3 | y :  | active_support.rb:286:8:286:8 | y :  |
+| active_support.rb:285:3:285:3 | y :  | active_support.rb:286:8:286:8 | y :  |
+| active_support.rb:285:7:285:16 | call to source :  | active_support.rb:285:3:285:3 | y :  |
+| active_support.rb:285:7:285:16 | call to source :  | active_support.rb:285:3:285:3 | y :  |
 | active_support.rb:286:8:286:8 | y :  | active_support.rb:286:8:286:17 | call to presence |
 | active_support.rb:286:8:286:8 | y :  | active_support.rb:286:8:286:17 | call to presence |
-| active_support.rb:290:7:290:16 | call to source :  | active_support.rb:291:8:291:8 | x :  |
-| active_support.rb:290:7:290:16 | call to source :  | active_support.rb:291:8:291:8 | x :  |
+| active_support.rb:290:3:290:3 | x :  | active_support.rb:291:8:291:8 | x :  |
+| active_support.rb:290:3:290:3 | x :  | active_support.rb:291:8:291:8 | x :  |
+| active_support.rb:290:7:290:16 | call to source :  | active_support.rb:290:3:290:3 | x :  |
+| active_support.rb:290:7:290:16 | call to source :  | active_support.rb:290:3:290:3 | x :  |
 | active_support.rb:291:8:291:8 | x :  | active_support.rb:291:8:291:17 | call to deep_dup |
 | active_support.rb:291:8:291:8 | x :  | active_support.rb:291:8:291:17 | call to deep_dup |
-| active_support.rb:303:7:303:16 | call to source :  | active_support.rb:304:19:304:19 | a :  |
-| active_support.rb:304:7:304:19 | call to json_escape :  | active_support.rb:305:8:305:8 | b |
+| active_support.rb:303:3:303:3 | a :  | active_support.rb:304:19:304:19 | a :  |
+| active_support.rb:303:7:303:16 | call to source :  | active_support.rb:303:3:303:3 | a :  |
+| active_support.rb:304:3:304:3 | b :  | active_support.rb:305:8:305:8 | b |
+| active_support.rb:304:7:304:19 | call to json_escape :  | active_support.rb:304:3:304:3 | b :  |
 | active_support.rb:304:19:304:19 | a :  | active_support.rb:304:7:304:19 | call to json_escape :  |
-| active_support.rb:309:9:309:18 | call to source :  | active_support.rb:310:37:310:37 | x :  |
+| active_support.rb:309:5:309:5 | x :  | active_support.rb:310:37:310:37 | x :  |
+| active_support.rb:309:9:309:18 | call to source :  | active_support.rb:309:5:309:5 | x :  |
 | active_support.rb:310:37:310:37 | x :  | active_support.rb:310:10:310:38 | call to encode |
-| active_support.rb:314:9:314:18 | call to source :  | active_support.rb:315:37:315:37 | x :  |
+| active_support.rb:314:5:314:5 | x :  | active_support.rb:315:37:315:37 | x :  |
+| active_support.rb:314:9:314:18 | call to source :  | active_support.rb:314:5:314:5 | x :  |
 | active_support.rb:315:37:315:37 | x :  | active_support.rb:315:10:315:38 | call to decode |
-| active_support.rb:319:9:319:18 | call to source :  | active_support.rb:320:35:320:35 | x :  |
+| active_support.rb:319:5:319:5 | x :  | active_support.rb:320:35:320:35 | x :  |
+| active_support.rb:319:9:319:18 | call to source :  | active_support.rb:319:5:319:5 | x :  |
 | active_support.rb:320:35:320:35 | x :  | active_support.rb:320:10:320:36 | call to dump |
-| active_support.rb:324:9:324:18 | call to source :  | active_support.rb:325:35:325:35 | x :  |
+| active_support.rb:324:5:324:5 | x :  | active_support.rb:325:35:325:35 | x :  |
+| active_support.rb:324:9:324:18 | call to source :  | active_support.rb:324:5:324:5 | x :  |
 | active_support.rb:325:35:325:35 | x :  | active_support.rb:325:10:325:36 | call to load |
-| active_support.rb:329:9:329:18 | call to source :  | active_support.rb:330:10:330:10 | x :  |
-| active_support.rb:329:9:329:18 | call to source :  | active_support.rb:331:10:331:10 | x :  |
-| active_support.rb:330:10:330:10 | x :  | active_support.rb:332:10:332:10 | y [element 0] :  |
+| active_support.rb:329:5:329:5 | x :  | active_support.rb:330:10:330:10 | x :  |
+| active_support.rb:329:5:329:5 | x :  | active_support.rb:331:10:331:10 | x :  |
+| active_support.rb:329:9:329:18 | call to source :  | active_support.rb:329:5:329:5 | x :  |
+| active_support.rb:330:5:330:5 | y [element 0] :  | active_support.rb:332:10:332:10 | y [element 0] :  |
+| active_support.rb:330:10:330:10 | x :  | active_support.rb:330:5:330:5 | y [element 0] :  |
 | active_support.rb:331:10:331:10 | x :  | active_support.rb:331:10:331:18 | call to to_json |
 | active_support.rb:332:10:332:10 | y [element 0] :  | active_support.rb:332:10:332:18 | call to to_json |
-| hash_extensions.rb:2:14:2:24 | call to source :  | hash_extensions.rb:3:9:3:9 | h [element :a] :  |
-| hash_extensions.rb:2:14:2:24 | call to source :  | hash_extensions.rb:3:9:3:9 | h [element :a] :  |
+| hash_extensions.rb:2:5:2:5 | h [element :a] :  | hash_extensions.rb:3:9:3:9 | h [element :a] :  |
+| hash_extensions.rb:2:5:2:5 | h [element :a] :  | hash_extensions.rb:3:9:3:9 | h [element :a] :  |
+| hash_extensions.rb:2:14:2:24 | call to source :  | hash_extensions.rb:2:5:2:5 | h [element :a] :  |
+| hash_extensions.rb:2:14:2:24 | call to source :  | hash_extensions.rb:2:5:2:5 | h [element :a] :  |
+| hash_extensions.rb:3:5:3:5 | x [element] :  | hash_extensions.rb:4:10:4:10 | x [element] :  |
+| hash_extensions.rb:3:5:3:5 | x [element] :  | hash_extensions.rb:4:10:4:10 | x [element] :  |
 | hash_extensions.rb:3:9:3:9 | h [element :a] :  | hash_extensions.rb:3:9:3:24 | call to stringify_keys [element] :  |
 | hash_extensions.rb:3:9:3:9 | h [element :a] :  | hash_extensions.rb:3:9:3:24 | call to stringify_keys [element] :  |
-| hash_extensions.rb:3:9:3:24 | call to stringify_keys [element] :  | hash_extensions.rb:4:10:4:10 | x [element] :  |
-| hash_extensions.rb:3:9:3:24 | call to stringify_keys [element] :  | hash_extensions.rb:4:10:4:10 | x [element] :  |
+| hash_extensions.rb:3:9:3:24 | call to stringify_keys [element] :  | hash_extensions.rb:3:5:3:5 | x [element] :  |
+| hash_extensions.rb:3:9:3:24 | call to stringify_keys [element] :  | hash_extensions.rb:3:5:3:5 | x [element] :  |
 | hash_extensions.rb:4:10:4:10 | x [element] :  | hash_extensions.rb:4:10:4:14 | ...[...] |
 | hash_extensions.rb:4:10:4:10 | x [element] :  | hash_extensions.rb:4:10:4:14 | ...[...] |
-| hash_extensions.rb:10:14:10:24 | call to source :  | hash_extensions.rb:11:9:11:9 | h [element :a] :  |
-| hash_extensions.rb:10:14:10:24 | call to source :  | hash_extensions.rb:11:9:11:9 | h [element :a] :  |
+| hash_extensions.rb:10:5:10:5 | h [element :a] :  | hash_extensions.rb:11:9:11:9 | h [element :a] :  |
+| hash_extensions.rb:10:5:10:5 | h [element :a] :  | hash_extensions.rb:11:9:11:9 | h [element :a] :  |
+| hash_extensions.rb:10:14:10:24 | call to source :  | hash_extensions.rb:10:5:10:5 | h [element :a] :  |
+| hash_extensions.rb:10:14:10:24 | call to source :  | hash_extensions.rb:10:5:10:5 | h [element :a] :  |
+| hash_extensions.rb:11:5:11:5 | x [element] :  | hash_extensions.rb:12:10:12:10 | x [element] :  |
+| hash_extensions.rb:11:5:11:5 | x [element] :  | hash_extensions.rb:12:10:12:10 | x [element] :  |
 | hash_extensions.rb:11:9:11:9 | h [element :a] :  | hash_extensions.rb:11:9:11:20 | call to to_options [element] :  |
 | hash_extensions.rb:11:9:11:9 | h [element :a] :  | hash_extensions.rb:11:9:11:20 | call to to_options [element] :  |
-| hash_extensions.rb:11:9:11:20 | call to to_options [element] :  | hash_extensions.rb:12:10:12:10 | x [element] :  |
-| hash_extensions.rb:11:9:11:20 | call to to_options [element] :  | hash_extensions.rb:12:10:12:10 | x [element] :  |
+| hash_extensions.rb:11:9:11:20 | call to to_options [element] :  | hash_extensions.rb:11:5:11:5 | x [element] :  |
+| hash_extensions.rb:11:9:11:20 | call to to_options [element] :  | hash_extensions.rb:11:5:11:5 | x [element] :  |
 | hash_extensions.rb:12:10:12:10 | x [element] :  | hash_extensions.rb:12:10:12:14 | ...[...] |
 | hash_extensions.rb:12:10:12:10 | x [element] :  | hash_extensions.rb:12:10:12:14 | ...[...] |
-| hash_extensions.rb:18:14:18:24 | call to source :  | hash_extensions.rb:19:9:19:9 | h [element :a] :  |
-| hash_extensions.rb:18:14:18:24 | call to source :  | hash_extensions.rb:19:9:19:9 | h [element :a] :  |
+| hash_extensions.rb:18:5:18:5 | h [element :a] :  | hash_extensions.rb:19:9:19:9 | h [element :a] :  |
+| hash_extensions.rb:18:5:18:5 | h [element :a] :  | hash_extensions.rb:19:9:19:9 | h [element :a] :  |
+| hash_extensions.rb:18:14:18:24 | call to source :  | hash_extensions.rb:18:5:18:5 | h [element :a] :  |
+| hash_extensions.rb:18:14:18:24 | call to source :  | hash_extensions.rb:18:5:18:5 | h [element :a] :  |
+| hash_extensions.rb:19:5:19:5 | x [element] :  | hash_extensions.rb:20:10:20:10 | x [element] :  |
+| hash_extensions.rb:19:5:19:5 | x [element] :  | hash_extensions.rb:20:10:20:10 | x [element] :  |
 | hash_extensions.rb:19:9:19:9 | h [element :a] :  | hash_extensions.rb:19:9:19:24 | call to symbolize_keys [element] :  |
 | hash_extensions.rb:19:9:19:9 | h [element :a] :  | hash_extensions.rb:19:9:19:24 | call to symbolize_keys [element] :  |
-| hash_extensions.rb:19:9:19:24 | call to symbolize_keys [element] :  | hash_extensions.rb:20:10:20:10 | x [element] :  |
-| hash_extensions.rb:19:9:19:24 | call to symbolize_keys [element] :  | hash_extensions.rb:20:10:20:10 | x [element] :  |
+| hash_extensions.rb:19:9:19:24 | call to symbolize_keys [element] :  | hash_extensions.rb:19:5:19:5 | x [element] :  |
+| hash_extensions.rb:19:9:19:24 | call to symbolize_keys [element] :  | hash_extensions.rb:19:5:19:5 | x [element] :  |
 | hash_extensions.rb:20:10:20:10 | x [element] :  | hash_extensions.rb:20:10:20:14 | ...[...] |
 | hash_extensions.rb:20:10:20:10 | x [element] :  | hash_extensions.rb:20:10:20:14 | ...[...] |
-| hash_extensions.rb:26:14:26:24 | call to source :  | hash_extensions.rb:27:9:27:9 | h [element :a] :  |
-| hash_extensions.rb:26:14:26:24 | call to source :  | hash_extensions.rb:27:9:27:9 | h [element :a] :  |
+| hash_extensions.rb:26:5:26:5 | h [element :a] :  | hash_extensions.rb:27:9:27:9 | h [element :a] :  |
+| hash_extensions.rb:26:5:26:5 | h [element :a] :  | hash_extensions.rb:27:9:27:9 | h [element :a] :  |
+| hash_extensions.rb:26:14:26:24 | call to source :  | hash_extensions.rb:26:5:26:5 | h [element :a] :  |
+| hash_extensions.rb:26:14:26:24 | call to source :  | hash_extensions.rb:26:5:26:5 | h [element :a] :  |
+| hash_extensions.rb:27:5:27:5 | x [element] :  | hash_extensions.rb:28:10:28:10 | x [element] :  |
+| hash_extensions.rb:27:5:27:5 | x [element] :  | hash_extensions.rb:28:10:28:10 | x [element] :  |
 | hash_extensions.rb:27:9:27:9 | h [element :a] :  | hash_extensions.rb:27:9:27:29 | call to deep_stringify_keys [element] :  |
 | hash_extensions.rb:27:9:27:9 | h [element :a] :  | hash_extensions.rb:27:9:27:29 | call to deep_stringify_keys [element] :  |
-| hash_extensions.rb:27:9:27:29 | call to deep_stringify_keys [element] :  | hash_extensions.rb:28:10:28:10 | x [element] :  |
-| hash_extensions.rb:27:9:27:29 | call to deep_stringify_keys [element] :  | hash_extensions.rb:28:10:28:10 | x [element] :  |
+| hash_extensions.rb:27:9:27:29 | call to deep_stringify_keys [element] :  | hash_extensions.rb:27:5:27:5 | x [element] :  |
+| hash_extensions.rb:27:9:27:29 | call to deep_stringify_keys [element] :  | hash_extensions.rb:27:5:27:5 | x [element] :  |
 | hash_extensions.rb:28:10:28:10 | x [element] :  | hash_extensions.rb:28:10:28:14 | ...[...] |
 | hash_extensions.rb:28:10:28:10 | x [element] :  | hash_extensions.rb:28:10:28:14 | ...[...] |
-| hash_extensions.rb:34:14:34:24 | call to source :  | hash_extensions.rb:35:9:35:9 | h [element :a] :  |
-| hash_extensions.rb:34:14:34:24 | call to source :  | hash_extensions.rb:35:9:35:9 | h [element :a] :  |
+| hash_extensions.rb:34:5:34:5 | h [element :a] :  | hash_extensions.rb:35:9:35:9 | h [element :a] :  |
+| hash_extensions.rb:34:5:34:5 | h [element :a] :  | hash_extensions.rb:35:9:35:9 | h [element :a] :  |
+| hash_extensions.rb:34:14:34:24 | call to source :  | hash_extensions.rb:34:5:34:5 | h [element :a] :  |
+| hash_extensions.rb:34:14:34:24 | call to source :  | hash_extensions.rb:34:5:34:5 | h [element :a] :  |
+| hash_extensions.rb:35:5:35:5 | x [element] :  | hash_extensions.rb:36:10:36:10 | x [element] :  |
+| hash_extensions.rb:35:5:35:5 | x [element] :  | hash_extensions.rb:36:10:36:10 | x [element] :  |
 | hash_extensions.rb:35:9:35:9 | h [element :a] :  | hash_extensions.rb:35:9:35:29 | call to deep_symbolize_keys [element] :  |
 | hash_extensions.rb:35:9:35:9 | h [element :a] :  | hash_extensions.rb:35:9:35:29 | call to deep_symbolize_keys [element] :  |
-| hash_extensions.rb:35:9:35:29 | call to deep_symbolize_keys [element] :  | hash_extensions.rb:36:10:36:10 | x [element] :  |
-| hash_extensions.rb:35:9:35:29 | call to deep_symbolize_keys [element] :  | hash_extensions.rb:36:10:36:10 | x [element] :  |
+| hash_extensions.rb:35:9:35:29 | call to deep_symbolize_keys [element] :  | hash_extensions.rb:35:5:35:5 | x [element] :  |
+| hash_extensions.rb:35:9:35:29 | call to deep_symbolize_keys [element] :  | hash_extensions.rb:35:5:35:5 | x [element] :  |
 | hash_extensions.rb:36:10:36:10 | x [element] :  | hash_extensions.rb:36:10:36:14 | ...[...] |
 | hash_extensions.rb:36:10:36:10 | x [element] :  | hash_extensions.rb:36:10:36:14 | ...[...] |
-| hash_extensions.rb:42:14:42:24 | call to source :  | hash_extensions.rb:43:9:43:9 | h [element :a] :  |
-| hash_extensions.rb:42:14:42:24 | call to source :  | hash_extensions.rb:43:9:43:9 | h [element :a] :  |
+| hash_extensions.rb:42:5:42:5 | h [element :a] :  | hash_extensions.rb:43:9:43:9 | h [element :a] :  |
+| hash_extensions.rb:42:5:42:5 | h [element :a] :  | hash_extensions.rb:43:9:43:9 | h [element :a] :  |
+| hash_extensions.rb:42:14:42:24 | call to source :  | hash_extensions.rb:42:5:42:5 | h [element :a] :  |
+| hash_extensions.rb:42:14:42:24 | call to source :  | hash_extensions.rb:42:5:42:5 | h [element :a] :  |
+| hash_extensions.rb:43:5:43:5 | x [element] :  | hash_extensions.rb:44:10:44:10 | x [element] :  |
+| hash_extensions.rb:43:5:43:5 | x [element] :  | hash_extensions.rb:44:10:44:10 | x [element] :  |
 | hash_extensions.rb:43:9:43:9 | h [element :a] :  | hash_extensions.rb:43:9:43:33 | call to with_indifferent_access [element] :  |
 | hash_extensions.rb:43:9:43:9 | h [element :a] :  | hash_extensions.rb:43:9:43:33 | call to with_indifferent_access [element] :  |
-| hash_extensions.rb:43:9:43:33 | call to with_indifferent_access [element] :  | hash_extensions.rb:44:10:44:10 | x [element] :  |
-| hash_extensions.rb:43:9:43:33 | call to with_indifferent_access [element] :  | hash_extensions.rb:44:10:44:10 | x [element] :  |
+| hash_extensions.rb:43:9:43:33 | call to with_indifferent_access [element] :  | hash_extensions.rb:43:5:43:5 | x [element] :  |
+| hash_extensions.rb:43:9:43:33 | call to with_indifferent_access [element] :  | hash_extensions.rb:43:5:43:5 | x [element] :  |
 | hash_extensions.rb:44:10:44:10 | x [element] :  | hash_extensions.rb:44:10:44:14 | ...[...] |
 | hash_extensions.rb:44:10:44:10 | x [element] :  | hash_extensions.rb:44:10:44:14 | ...[...] |
-| hash_extensions.rb:50:14:50:23 | call to taint :  | hash_extensions.rb:51:9:51:9 | h [element :a] :  |
-| hash_extensions.rb:50:14:50:23 | call to taint :  | hash_extensions.rb:51:9:51:9 | h [element :a] :  |
-| hash_extensions.rb:50:29:50:38 | call to taint :  | hash_extensions.rb:51:9:51:9 | h [element :b] :  |
-| hash_extensions.rb:50:29:50:38 | call to taint :  | hash_extensions.rb:51:9:51:9 | h [element :b] :  |
-| hash_extensions.rb:50:52:50:61 | call to taint :  | hash_extensions.rb:51:9:51:9 | h [element :d] :  |
-| hash_extensions.rb:50:52:50:61 | call to taint :  | hash_extensions.rb:51:9:51:9 | h [element :d] :  |
+| hash_extensions.rb:50:5:50:5 | h [element :a] :  | hash_extensions.rb:51:9:51:9 | h [element :a] :  |
+| hash_extensions.rb:50:5:50:5 | h [element :a] :  | hash_extensions.rb:51:9:51:9 | h [element :a] :  |
+| hash_extensions.rb:50:5:50:5 | h [element :b] :  | hash_extensions.rb:51:9:51:9 | h [element :b] :  |
+| hash_extensions.rb:50:5:50:5 | h [element :b] :  | hash_extensions.rb:51:9:51:9 | h [element :b] :  |
+| hash_extensions.rb:50:5:50:5 | h [element :d] :  | hash_extensions.rb:51:9:51:9 | h [element :d] :  |
+| hash_extensions.rb:50:5:50:5 | h [element :d] :  | hash_extensions.rb:51:9:51:9 | h [element :d] :  |
+| hash_extensions.rb:50:14:50:23 | call to taint :  | hash_extensions.rb:50:5:50:5 | h [element :a] :  |
+| hash_extensions.rb:50:14:50:23 | call to taint :  | hash_extensions.rb:50:5:50:5 | h [element :a] :  |
+| hash_extensions.rb:50:29:50:38 | call to taint :  | hash_extensions.rb:50:5:50:5 | h [element :b] :  |
+| hash_extensions.rb:50:29:50:38 | call to taint :  | hash_extensions.rb:50:5:50:5 | h [element :b] :  |
+| hash_extensions.rb:50:52:50:61 | call to taint :  | hash_extensions.rb:50:5:50:5 | h [element :d] :  |
+| hash_extensions.rb:50:52:50:61 | call to taint :  | hash_extensions.rb:50:5:50:5 | h [element :d] :  |
+| hash_extensions.rb:51:5:51:5 | x [element :a] :  | hash_extensions.rb:58:10:58:10 | x [element :a] :  |
+| hash_extensions.rb:51:5:51:5 | x [element :a] :  | hash_extensions.rb:58:10:58:10 | x [element :a] :  |
+| hash_extensions.rb:51:5:51:5 | x [element :b] :  | hash_extensions.rb:59:10:59:10 | x [element :b] :  |
+| hash_extensions.rb:51:5:51:5 | x [element :b] :  | hash_extensions.rb:59:10:59:10 | x [element :b] :  |
 | hash_extensions.rb:51:9:51:9 | [post] h [element :d] :  | hash_extensions.rb:56:10:56:10 | h [element :d] :  |
 | hash_extensions.rb:51:9:51:9 | [post] h [element :d] :  | hash_extensions.rb:56:10:56:10 | h [element :d] :  |
 | hash_extensions.rb:51:9:51:9 | h [element :a] :  | hash_extensions.rb:51:9:51:29 | call to extract! [element :a] :  |
@@ -265,22 +393,32 @@ edges
 | hash_extensions.rb:51:9:51:9 | h [element :b] :  | hash_extensions.rb:51:9:51:29 | call to extract! [element :b] :  |
 | hash_extensions.rb:51:9:51:9 | h [element :d] :  | hash_extensions.rb:51:9:51:9 | [post] h [element :d] :  |
 | hash_extensions.rb:51:9:51:9 | h [element :d] :  | hash_extensions.rb:51:9:51:9 | [post] h [element :d] :  |
-| hash_extensions.rb:51:9:51:29 | call to extract! [element :a] :  | hash_extensions.rb:58:10:58:10 | x [element :a] :  |
-| hash_extensions.rb:51:9:51:29 | call to extract! [element :a] :  | hash_extensions.rb:58:10:58:10 | x [element :a] :  |
-| hash_extensions.rb:51:9:51:29 | call to extract! [element :b] :  | hash_extensions.rb:59:10:59:10 | x [element :b] :  |
-| hash_extensions.rb:51:9:51:29 | call to extract! [element :b] :  | hash_extensions.rb:59:10:59:10 | x [element :b] :  |
+| hash_extensions.rb:51:9:51:29 | call to extract! [element :a] :  | hash_extensions.rb:51:5:51:5 | x [element :a] :  |
+| hash_extensions.rb:51:9:51:29 | call to extract! [element :a] :  | hash_extensions.rb:51:5:51:5 | x [element :a] :  |
+| hash_extensions.rb:51:9:51:29 | call to extract! [element :b] :  | hash_extensions.rb:51:5:51:5 | x [element :b] :  |
+| hash_extensions.rb:51:9:51:29 | call to extract! [element :b] :  | hash_extensions.rb:51:5:51:5 | x [element :b] :  |
 | hash_extensions.rb:56:10:56:10 | h [element :d] :  | hash_extensions.rb:56:10:56:14 | ...[...] |
 | hash_extensions.rb:56:10:56:10 | h [element :d] :  | hash_extensions.rb:56:10:56:14 | ...[...] |
 | hash_extensions.rb:58:10:58:10 | x [element :a] :  | hash_extensions.rb:58:10:58:14 | ...[...] |
 | hash_extensions.rb:58:10:58:10 | x [element :a] :  | hash_extensions.rb:58:10:58:14 | ...[...] |
 | hash_extensions.rb:59:10:59:10 | x [element :b] :  | hash_extensions.rb:59:10:59:14 | ...[...] |
 | hash_extensions.rb:59:10:59:10 | x [element :b] :  | hash_extensions.rb:59:10:59:14 | ...[...] |
-| hash_extensions.rb:67:15:67:25 | call to source :  | hash_extensions.rb:68:9:68:14 | values [element 0] :  |
-| hash_extensions.rb:67:15:67:25 | call to source :  | hash_extensions.rb:68:9:68:14 | values [element 0] :  |
-| hash_extensions.rb:67:28:67:38 | call to source :  | hash_extensions.rb:68:9:68:14 | values [element 1] :  |
-| hash_extensions.rb:67:28:67:38 | call to source :  | hash_extensions.rb:68:9:68:14 | values [element 1] :  |
-| hash_extensions.rb:67:41:67:51 | call to source :  | hash_extensions.rb:68:9:68:14 | values [element 2] :  |
-| hash_extensions.rb:67:41:67:51 | call to source :  | hash_extensions.rb:68:9:68:14 | values [element 2] :  |
+| hash_extensions.rb:67:5:67:10 | values [element 0] :  | hash_extensions.rb:68:9:68:14 | values [element 0] :  |
+| hash_extensions.rb:67:5:67:10 | values [element 0] :  | hash_extensions.rb:68:9:68:14 | values [element 0] :  |
+| hash_extensions.rb:67:5:67:10 | values [element 1] :  | hash_extensions.rb:68:9:68:14 | values [element 1] :  |
+| hash_extensions.rb:67:5:67:10 | values [element 1] :  | hash_extensions.rb:68:9:68:14 | values [element 1] :  |
+| hash_extensions.rb:67:5:67:10 | values [element 2] :  | hash_extensions.rb:68:9:68:14 | values [element 2] :  |
+| hash_extensions.rb:67:5:67:10 | values [element 2] :  | hash_extensions.rb:68:9:68:14 | values [element 2] :  |
+| hash_extensions.rb:67:15:67:25 | call to source :  | hash_extensions.rb:67:5:67:10 | values [element 0] :  |
+| hash_extensions.rb:67:15:67:25 | call to source :  | hash_extensions.rb:67:5:67:10 | values [element 0] :  |
+| hash_extensions.rb:67:28:67:38 | call to source :  | hash_extensions.rb:67:5:67:10 | values [element 1] :  |
+| hash_extensions.rb:67:28:67:38 | call to source :  | hash_extensions.rb:67:5:67:10 | values [element 1] :  |
+| hash_extensions.rb:67:41:67:51 | call to source :  | hash_extensions.rb:67:5:67:10 | values [element 2] :  |
+| hash_extensions.rb:67:41:67:51 | call to source :  | hash_extensions.rb:67:5:67:10 | values [element 2] :  |
+| hash_extensions.rb:68:5:68:5 | h [element] :  | hash_extensions.rb:73:10:73:10 | h [element] :  |
+| hash_extensions.rb:68:5:68:5 | h [element] :  | hash_extensions.rb:73:10:73:10 | h [element] :  |
+| hash_extensions.rb:68:5:68:5 | h [element] :  | hash_extensions.rb:74:10:74:10 | h [element] :  |
+| hash_extensions.rb:68:5:68:5 | h [element] :  | hash_extensions.rb:74:10:74:10 | h [element] :  |
 | hash_extensions.rb:68:9:68:14 | values [element 0] :  | hash_extensions.rb:68:9:71:7 | call to index_by [element] :  |
 | hash_extensions.rb:68:9:68:14 | values [element 0] :  | hash_extensions.rb:68:9:71:7 | call to index_by [element] :  |
 | hash_extensions.rb:68:9:68:14 | values [element 0] :  | hash_extensions.rb:68:29:68:33 | value :  |
@@ -293,32 +431,38 @@ edges
 | hash_extensions.rb:68:9:68:14 | values [element 2] :  | hash_extensions.rb:68:9:71:7 | call to index_by [element] :  |
 | hash_extensions.rb:68:9:68:14 | values [element 2] :  | hash_extensions.rb:68:29:68:33 | value :  |
 | hash_extensions.rb:68:9:68:14 | values [element 2] :  | hash_extensions.rb:68:29:68:33 | value :  |
-| hash_extensions.rb:68:9:71:7 | call to index_by [element] :  | hash_extensions.rb:73:10:73:10 | h [element] :  |
-| hash_extensions.rb:68:9:71:7 | call to index_by [element] :  | hash_extensions.rb:73:10:73:10 | h [element] :  |
-| hash_extensions.rb:68:9:71:7 | call to index_by [element] :  | hash_extensions.rb:74:10:74:10 | h [element] :  |
-| hash_extensions.rb:68:9:71:7 | call to index_by [element] :  | hash_extensions.rb:74:10:74:10 | h [element] :  |
+| hash_extensions.rb:68:9:71:7 | call to index_by [element] :  | hash_extensions.rb:68:5:68:5 | h [element] :  |
+| hash_extensions.rb:68:9:71:7 | call to index_by [element] :  | hash_extensions.rb:68:5:68:5 | h [element] :  |
 | hash_extensions.rb:68:29:68:33 | value :  | hash_extensions.rb:69:14:69:18 | value |
 | hash_extensions.rb:68:29:68:33 | value :  | hash_extensions.rb:69:14:69:18 | value |
 | hash_extensions.rb:73:10:73:10 | h [element] :  | hash_extensions.rb:73:10:73:16 | ...[...] |
 | hash_extensions.rb:73:10:73:10 | h [element] :  | hash_extensions.rb:73:10:73:16 | ...[...] |
 | hash_extensions.rb:74:10:74:10 | h [element] :  | hash_extensions.rb:74:10:74:16 | ...[...] |
 | hash_extensions.rb:74:10:74:10 | h [element] :  | hash_extensions.rb:74:10:74:16 | ...[...] |
-| hash_extensions.rb:80:15:80:25 | call to source :  | hash_extensions.rb:81:9:81:14 | values [element 0] :  |
-| hash_extensions.rb:80:15:80:25 | call to source :  | hash_extensions.rb:81:9:81:14 | values [element 0] :  |
-| hash_extensions.rb:80:28:80:38 | call to source :  | hash_extensions.rb:81:9:81:14 | values [element 1] :  |
-| hash_extensions.rb:80:28:80:38 | call to source :  | hash_extensions.rb:81:9:81:14 | values [element 1] :  |
-| hash_extensions.rb:80:41:80:51 | call to source :  | hash_extensions.rb:81:9:81:14 | values [element 2] :  |
-| hash_extensions.rb:80:41:80:51 | call to source :  | hash_extensions.rb:81:9:81:14 | values [element 2] :  |
+| hash_extensions.rb:80:5:80:10 | values [element 0] :  | hash_extensions.rb:81:9:81:14 | values [element 0] :  |
+| hash_extensions.rb:80:5:80:10 | values [element 0] :  | hash_extensions.rb:81:9:81:14 | values [element 0] :  |
+| hash_extensions.rb:80:5:80:10 | values [element 1] :  | hash_extensions.rb:81:9:81:14 | values [element 1] :  |
+| hash_extensions.rb:80:5:80:10 | values [element 1] :  | hash_extensions.rb:81:9:81:14 | values [element 1] :  |
+| hash_extensions.rb:80:5:80:10 | values [element 2] :  | hash_extensions.rb:81:9:81:14 | values [element 2] :  |
+| hash_extensions.rb:80:5:80:10 | values [element 2] :  | hash_extensions.rb:81:9:81:14 | values [element 2] :  |
+| hash_extensions.rb:80:15:80:25 | call to source :  | hash_extensions.rb:80:5:80:10 | values [element 0] :  |
+| hash_extensions.rb:80:15:80:25 | call to source :  | hash_extensions.rb:80:5:80:10 | values [element 0] :  |
+| hash_extensions.rb:80:28:80:38 | call to source :  | hash_extensions.rb:80:5:80:10 | values [element 1] :  |
+| hash_extensions.rb:80:28:80:38 | call to source :  | hash_extensions.rb:80:5:80:10 | values [element 1] :  |
+| hash_extensions.rb:80:41:80:51 | call to source :  | hash_extensions.rb:80:5:80:10 | values [element 2] :  |
+| hash_extensions.rb:80:41:80:51 | call to source :  | hash_extensions.rb:80:5:80:10 | values [element 2] :  |
+| hash_extensions.rb:81:5:81:5 | h [element] :  | hash_extensions.rb:86:10:86:10 | h [element] :  |
+| hash_extensions.rb:81:5:81:5 | h [element] :  | hash_extensions.rb:86:10:86:10 | h [element] :  |
+| hash_extensions.rb:81:5:81:5 | h [element] :  | hash_extensions.rb:87:10:87:10 | h [element] :  |
+| hash_extensions.rb:81:5:81:5 | h [element] :  | hash_extensions.rb:87:10:87:10 | h [element] :  |
 | hash_extensions.rb:81:9:81:14 | values [element 0] :  | hash_extensions.rb:81:31:81:33 | key :  |
 | hash_extensions.rb:81:9:81:14 | values [element 0] :  | hash_extensions.rb:81:31:81:33 | key :  |
 | hash_extensions.rb:81:9:81:14 | values [element 1] :  | hash_extensions.rb:81:31:81:33 | key :  |
 | hash_extensions.rb:81:9:81:14 | values [element 1] :  | hash_extensions.rb:81:31:81:33 | key :  |
 | hash_extensions.rb:81:9:81:14 | values [element 2] :  | hash_extensions.rb:81:31:81:33 | key :  |
 | hash_extensions.rb:81:9:81:14 | values [element 2] :  | hash_extensions.rb:81:31:81:33 | key :  |
-| hash_extensions.rb:81:9:84:7 | call to index_with [element] :  | hash_extensions.rb:86:10:86:10 | h [element] :  |
-| hash_extensions.rb:81:9:84:7 | call to index_with [element] :  | hash_extensions.rb:86:10:86:10 | h [element] :  |
-| hash_extensions.rb:81:9:84:7 | call to index_with [element] :  | hash_extensions.rb:87:10:87:10 | h [element] :  |
-| hash_extensions.rb:81:9:84:7 | call to index_with [element] :  | hash_extensions.rb:87:10:87:10 | h [element] :  |
+| hash_extensions.rb:81:9:84:7 | call to index_with [element] :  | hash_extensions.rb:81:5:81:5 | h [element] :  |
+| hash_extensions.rb:81:9:84:7 | call to index_with [element] :  | hash_extensions.rb:81:5:81:5 | h [element] :  |
 | hash_extensions.rb:81:31:81:33 | key :  | hash_extensions.rb:82:14:82:16 | key |
 | hash_extensions.rb:81:31:81:33 | key :  | hash_extensions.rb:82:14:82:16 | key |
 | hash_extensions.rb:83:9:83:19 | call to source :  | hash_extensions.rb:81:9:84:7 | call to index_with [element] :  |
@@ -327,28 +471,34 @@ edges
 | hash_extensions.rb:86:10:86:10 | h [element] :  | hash_extensions.rb:86:10:86:16 | ...[...] |
 | hash_extensions.rb:87:10:87:10 | h [element] :  | hash_extensions.rb:87:10:87:16 | ...[...] |
 | hash_extensions.rb:87:10:87:10 | h [element] :  | hash_extensions.rb:87:10:87:16 | ...[...] |
-| hash_extensions.rb:89:9:89:38 | call to index_with [element] :  | hash_extensions.rb:91:10:91:10 | j [element] :  |
-| hash_extensions.rb:89:9:89:38 | call to index_with [element] :  | hash_extensions.rb:91:10:91:10 | j [element] :  |
-| hash_extensions.rb:89:9:89:38 | call to index_with [element] :  | hash_extensions.rb:92:10:92:10 | j [element] :  |
-| hash_extensions.rb:89:9:89:38 | call to index_with [element] :  | hash_extensions.rb:92:10:92:10 | j [element] :  |
+| hash_extensions.rb:89:5:89:5 | j [element] :  | hash_extensions.rb:91:10:91:10 | j [element] :  |
+| hash_extensions.rb:89:5:89:5 | j [element] :  | hash_extensions.rb:91:10:91:10 | j [element] :  |
+| hash_extensions.rb:89:5:89:5 | j [element] :  | hash_extensions.rb:92:10:92:10 | j [element] :  |
+| hash_extensions.rb:89:5:89:5 | j [element] :  | hash_extensions.rb:92:10:92:10 | j [element] :  |
+| hash_extensions.rb:89:9:89:38 | call to index_with [element] :  | hash_extensions.rb:89:5:89:5 | j [element] :  |
+| hash_extensions.rb:89:9:89:38 | call to index_with [element] :  | hash_extensions.rb:89:5:89:5 | j [element] :  |
 | hash_extensions.rb:89:27:89:37 | call to source :  | hash_extensions.rb:89:9:89:38 | call to index_with [element] :  |
 | hash_extensions.rb:89:27:89:37 | call to source :  | hash_extensions.rb:89:9:89:38 | call to index_with [element] :  |
 | hash_extensions.rb:91:10:91:10 | j [element] :  | hash_extensions.rb:91:10:91:16 | ...[...] |
 | hash_extensions.rb:91:10:91:10 | j [element] :  | hash_extensions.rb:91:10:91:16 | ...[...] |
 | hash_extensions.rb:92:10:92:10 | j [element] :  | hash_extensions.rb:92:10:92:16 | ...[...] |
 | hash_extensions.rb:92:10:92:10 | j [element] :  | hash_extensions.rb:92:10:92:16 | ...[...] |
-| hash_extensions.rb:98:21:98:31 | call to source :  | hash_extensions.rb:99:10:99:15 | values [element 0, element :id] :  |
-| hash_extensions.rb:98:21:98:31 | call to source :  | hash_extensions.rb:99:10:99:15 | values [element 0, element :id] :  |
-| hash_extensions.rb:98:21:98:31 | call to source :  | hash_extensions.rb:101:10:101:15 | values [element 0, element :id] :  |
-| hash_extensions.rb:98:21:98:31 | call to source :  | hash_extensions.rb:101:10:101:15 | values [element 0, element :id] :  |
-| hash_extensions.rb:98:21:98:31 | call to source :  | hash_extensions.rb:104:10:104:15 | values [element 0, element :id] :  |
-| hash_extensions.rb:98:21:98:31 | call to source :  | hash_extensions.rb:104:10:104:15 | values [element 0, element :id] :  |
-| hash_extensions.rb:98:40:98:54 | call to source :  | hash_extensions.rb:100:10:100:15 | values [element 0, element :name] :  |
-| hash_extensions.rb:98:40:98:54 | call to source :  | hash_extensions.rb:100:10:100:15 | values [element 0, element :name] :  |
-| hash_extensions.rb:98:40:98:54 | call to source :  | hash_extensions.rb:102:10:102:15 | values [element 0, element :name] :  |
-| hash_extensions.rb:98:40:98:54 | call to source :  | hash_extensions.rb:102:10:102:15 | values [element 0, element :name] :  |
-| hash_extensions.rb:98:40:98:54 | call to source :  | hash_extensions.rb:103:10:103:15 | values [element 0, element :name] :  |
-| hash_extensions.rb:98:40:98:54 | call to source :  | hash_extensions.rb:103:10:103:15 | values [element 0, element :name] :  |
+| hash_extensions.rb:98:5:98:10 | values [element 0, element :id] :  | hash_extensions.rb:99:10:99:15 | values [element 0, element :id] :  |
+| hash_extensions.rb:98:5:98:10 | values [element 0, element :id] :  | hash_extensions.rb:99:10:99:15 | values [element 0, element :id] :  |
+| hash_extensions.rb:98:5:98:10 | values [element 0, element :id] :  | hash_extensions.rb:101:10:101:15 | values [element 0, element :id] :  |
+| hash_extensions.rb:98:5:98:10 | values [element 0, element :id] :  | hash_extensions.rb:101:10:101:15 | values [element 0, element :id] :  |
+| hash_extensions.rb:98:5:98:10 | values [element 0, element :id] :  | hash_extensions.rb:104:10:104:15 | values [element 0, element :id] :  |
+| hash_extensions.rb:98:5:98:10 | values [element 0, element :id] :  | hash_extensions.rb:104:10:104:15 | values [element 0, element :id] :  |
+| hash_extensions.rb:98:5:98:10 | values [element 0, element :name] :  | hash_extensions.rb:100:10:100:15 | values [element 0, element :name] :  |
+| hash_extensions.rb:98:5:98:10 | values [element 0, element :name] :  | hash_extensions.rb:100:10:100:15 | values [element 0, element :name] :  |
+| hash_extensions.rb:98:5:98:10 | values [element 0, element :name] :  | hash_extensions.rb:102:10:102:15 | values [element 0, element :name] :  |
+| hash_extensions.rb:98:5:98:10 | values [element 0, element :name] :  | hash_extensions.rb:102:10:102:15 | values [element 0, element :name] :  |
+| hash_extensions.rb:98:5:98:10 | values [element 0, element :name] :  | hash_extensions.rb:103:10:103:15 | values [element 0, element :name] :  |
+| hash_extensions.rb:98:5:98:10 | values [element 0, element :name] :  | hash_extensions.rb:103:10:103:15 | values [element 0, element :name] :  |
+| hash_extensions.rb:98:21:98:31 | call to source :  | hash_extensions.rb:98:5:98:10 | values [element 0, element :id] :  |
+| hash_extensions.rb:98:21:98:31 | call to source :  | hash_extensions.rb:98:5:98:10 | values [element 0, element :id] :  |
+| hash_extensions.rb:98:40:98:54 | call to source :  | hash_extensions.rb:98:5:98:10 | values [element 0, element :name] :  |
+| hash_extensions.rb:98:40:98:54 | call to source :  | hash_extensions.rb:98:5:98:10 | values [element 0, element :name] :  |
 | hash_extensions.rb:99:10:99:15 | values [element 0, element :id] :  | hash_extensions.rb:99:10:99:25 | call to pick |
 | hash_extensions.rb:99:10:99:15 | values [element 0, element :id] :  | hash_extensions.rb:99:10:99:25 | call to pick |
 | hash_extensions.rb:100:10:100:15 | values [element 0, element :name] :  | hash_extensions.rb:100:10:100:27 | call to pick |
@@ -369,26 +519,34 @@ edges
 | hash_extensions.rb:104:10:104:15 | values [element 0, element :id] :  | hash_extensions.rb:104:10:104:32 | call to pick [element 1] :  |
 | hash_extensions.rb:104:10:104:32 | call to pick [element 1] :  | hash_extensions.rb:104:10:104:35 | ...[...] |
 | hash_extensions.rb:104:10:104:32 | call to pick [element 1] :  | hash_extensions.rb:104:10:104:35 | ...[...] |
-| hash_extensions.rb:110:21:110:31 | call to source :  | hash_extensions.rb:112:10:112:15 | values [element 0, element :id] :  |
-| hash_extensions.rb:110:21:110:31 | call to source :  | hash_extensions.rb:112:10:112:15 | values [element 0, element :id] :  |
-| hash_extensions.rb:110:21:110:31 | call to source :  | hash_extensions.rb:115:10:115:15 | values [element 0, element :id] :  |
-| hash_extensions.rb:110:21:110:31 | call to source :  | hash_extensions.rb:115:10:115:15 | values [element 0, element :id] :  |
-| hash_extensions.rb:110:40:110:54 | call to source :  | hash_extensions.rb:111:10:111:15 | values [element 0, element :name] :  |
-| hash_extensions.rb:110:40:110:54 | call to source :  | hash_extensions.rb:111:10:111:15 | values [element 0, element :name] :  |
-| hash_extensions.rb:110:40:110:54 | call to source :  | hash_extensions.rb:113:10:113:15 | values [element 0, element :name] :  |
-| hash_extensions.rb:110:40:110:54 | call to source :  | hash_extensions.rb:113:10:113:15 | values [element 0, element :name] :  |
-| hash_extensions.rb:110:40:110:54 | call to source :  | hash_extensions.rb:114:10:114:15 | values [element 0, element :name] :  |
-| hash_extensions.rb:110:40:110:54 | call to source :  | hash_extensions.rb:114:10:114:15 | values [element 0, element :name] :  |
-| hash_extensions.rb:110:65:110:75 | call to source :  | hash_extensions.rb:112:10:112:15 | values [element 1, element :id] :  |
-| hash_extensions.rb:110:65:110:75 | call to source :  | hash_extensions.rb:112:10:112:15 | values [element 1, element :id] :  |
-| hash_extensions.rb:110:65:110:75 | call to source :  | hash_extensions.rb:115:10:115:15 | values [element 1, element :id] :  |
-| hash_extensions.rb:110:65:110:75 | call to source :  | hash_extensions.rb:115:10:115:15 | values [element 1, element :id] :  |
-| hash_extensions.rb:110:84:110:99 | call to source :  | hash_extensions.rb:111:10:111:15 | values [element 1, element :name] :  |
-| hash_extensions.rb:110:84:110:99 | call to source :  | hash_extensions.rb:111:10:111:15 | values [element 1, element :name] :  |
-| hash_extensions.rb:110:84:110:99 | call to source :  | hash_extensions.rb:113:10:113:15 | values [element 1, element :name] :  |
-| hash_extensions.rb:110:84:110:99 | call to source :  | hash_extensions.rb:113:10:113:15 | values [element 1, element :name] :  |
-| hash_extensions.rb:110:84:110:99 | call to source :  | hash_extensions.rb:114:10:114:15 | values [element 1, element :name] :  |
-| hash_extensions.rb:110:84:110:99 | call to source :  | hash_extensions.rb:114:10:114:15 | values [element 1, element :name] :  |
+| hash_extensions.rb:110:5:110:10 | values [element 0, element :id] :  | hash_extensions.rb:112:10:112:15 | values [element 0, element :id] :  |
+| hash_extensions.rb:110:5:110:10 | values [element 0, element :id] :  | hash_extensions.rb:112:10:112:15 | values [element 0, element :id] :  |
+| hash_extensions.rb:110:5:110:10 | values [element 0, element :id] :  | hash_extensions.rb:115:10:115:15 | values [element 0, element :id] :  |
+| hash_extensions.rb:110:5:110:10 | values [element 0, element :id] :  | hash_extensions.rb:115:10:115:15 | values [element 0, element :id] :  |
+| hash_extensions.rb:110:5:110:10 | values [element 0, element :name] :  | hash_extensions.rb:111:10:111:15 | values [element 0, element :name] :  |
+| hash_extensions.rb:110:5:110:10 | values [element 0, element :name] :  | hash_extensions.rb:111:10:111:15 | values [element 0, element :name] :  |
+| hash_extensions.rb:110:5:110:10 | values [element 0, element :name] :  | hash_extensions.rb:113:10:113:15 | values [element 0, element :name] :  |
+| hash_extensions.rb:110:5:110:10 | values [element 0, element :name] :  | hash_extensions.rb:113:10:113:15 | values [element 0, element :name] :  |
+| hash_extensions.rb:110:5:110:10 | values [element 0, element :name] :  | hash_extensions.rb:114:10:114:15 | values [element 0, element :name] :  |
+| hash_extensions.rb:110:5:110:10 | values [element 0, element :name] :  | hash_extensions.rb:114:10:114:15 | values [element 0, element :name] :  |
+| hash_extensions.rb:110:5:110:10 | values [element 1, element :id] :  | hash_extensions.rb:112:10:112:15 | values [element 1, element :id] :  |
+| hash_extensions.rb:110:5:110:10 | values [element 1, element :id] :  | hash_extensions.rb:112:10:112:15 | values [element 1, element :id] :  |
+| hash_extensions.rb:110:5:110:10 | values [element 1, element :id] :  | hash_extensions.rb:115:10:115:15 | values [element 1, element :id] :  |
+| hash_extensions.rb:110:5:110:10 | values [element 1, element :id] :  | hash_extensions.rb:115:10:115:15 | values [element 1, element :id] :  |
+| hash_extensions.rb:110:5:110:10 | values [element 1, element :name] :  | hash_extensions.rb:111:10:111:15 | values [element 1, element :name] :  |
+| hash_extensions.rb:110:5:110:10 | values [element 1, element :name] :  | hash_extensions.rb:111:10:111:15 | values [element 1, element :name] :  |
+| hash_extensions.rb:110:5:110:10 | values [element 1, element :name] :  | hash_extensions.rb:113:10:113:15 | values [element 1, element :name] :  |
+| hash_extensions.rb:110:5:110:10 | values [element 1, element :name] :  | hash_extensions.rb:113:10:113:15 | values [element 1, element :name] :  |
+| hash_extensions.rb:110:5:110:10 | values [element 1, element :name] :  | hash_extensions.rb:114:10:114:15 | values [element 1, element :name] :  |
+| hash_extensions.rb:110:5:110:10 | values [element 1, element :name] :  | hash_extensions.rb:114:10:114:15 | values [element 1, element :name] :  |
+| hash_extensions.rb:110:21:110:31 | call to source :  | hash_extensions.rb:110:5:110:10 | values [element 0, element :id] :  |
+| hash_extensions.rb:110:21:110:31 | call to source :  | hash_extensions.rb:110:5:110:10 | values [element 0, element :id] :  |
+| hash_extensions.rb:110:40:110:54 | call to source :  | hash_extensions.rb:110:5:110:10 | values [element 0, element :name] :  |
+| hash_extensions.rb:110:40:110:54 | call to source :  | hash_extensions.rb:110:5:110:10 | values [element 0, element :name] :  |
+| hash_extensions.rb:110:65:110:75 | call to source :  | hash_extensions.rb:110:5:110:10 | values [element 1, element :id] :  |
+| hash_extensions.rb:110:65:110:75 | call to source :  | hash_extensions.rb:110:5:110:10 | values [element 1, element :id] :  |
+| hash_extensions.rb:110:84:110:99 | call to source :  | hash_extensions.rb:110:5:110:10 | values [element 1, element :name] :  |
+| hash_extensions.rb:110:84:110:99 | call to source :  | hash_extensions.rb:110:5:110:10 | values [element 1, element :name] :  |
 | hash_extensions.rb:111:10:111:15 | values [element 0, element :name] :  | hash_extensions.rb:111:10:111:28 | call to pluck [element] :  |
 | hash_extensions.rb:111:10:111:15 | values [element 0, element :name] :  | hash_extensions.rb:111:10:111:28 | call to pluck [element] :  |
 | hash_extensions.rb:111:10:111:15 | values [element 1, element :name] :  | hash_extensions.rb:111:10:111:28 | call to pluck [element] :  |
@@ -427,119 +585,161 @@ edges
 | hash_extensions.rb:115:10:115:33 | call to pluck [element, element 1] :  | hash_extensions.rb:115:10:115:36 | ...[...] [element 1] :  |
 | hash_extensions.rb:115:10:115:36 | ...[...] [element 1] :  | hash_extensions.rb:115:10:115:39 | ...[...] |
 | hash_extensions.rb:115:10:115:36 | ...[...] [element 1] :  | hash_extensions.rb:115:10:115:39 | ...[...] |
-| hash_extensions.rb:122:15:122:25 | call to source :  | hash_extensions.rb:125:10:125:15 | single [element 0] :  |
-| hash_extensions.rb:122:15:122:25 | call to source :  | hash_extensions.rb:125:10:125:15 | single [element 0] :  |
-| hash_extensions.rb:123:14:123:24 | call to source :  | hash_extensions.rb:126:10:126:14 | multi [element 0] :  |
-| hash_extensions.rb:123:14:123:24 | call to source :  | hash_extensions.rb:126:10:126:14 | multi [element 0] :  |
+| hash_extensions.rb:122:5:122:10 | single [element 0] :  | hash_extensions.rb:125:10:125:15 | single [element 0] :  |
+| hash_extensions.rb:122:5:122:10 | single [element 0] :  | hash_extensions.rb:125:10:125:15 | single [element 0] :  |
+| hash_extensions.rb:122:15:122:25 | call to source :  | hash_extensions.rb:122:5:122:10 | single [element 0] :  |
+| hash_extensions.rb:122:15:122:25 | call to source :  | hash_extensions.rb:122:5:122:10 | single [element 0] :  |
+| hash_extensions.rb:123:5:123:9 | multi [element 0] :  | hash_extensions.rb:126:10:126:14 | multi [element 0] :  |
+| hash_extensions.rb:123:5:123:9 | multi [element 0] :  | hash_extensions.rb:126:10:126:14 | multi [element 0] :  |
+| hash_extensions.rb:123:14:123:24 | call to source :  | hash_extensions.rb:123:5:123:9 | multi [element 0] :  |
+| hash_extensions.rb:123:14:123:24 | call to source :  | hash_extensions.rb:123:5:123:9 | multi [element 0] :  |
 | hash_extensions.rb:125:10:125:15 | single [element 0] :  | hash_extensions.rb:125:10:125:20 | call to sole |
 | hash_extensions.rb:125:10:125:15 | single [element 0] :  | hash_extensions.rb:125:10:125:20 | call to sole |
 | hash_extensions.rb:126:10:126:14 | multi [element 0] :  | hash_extensions.rb:126:10:126:19 | call to sole |
 | hash_extensions.rb:126:10:126:14 | multi [element 0] :  | hash_extensions.rb:126:10:126:19 | call to sole |
 nodes
+| active_support.rb:10:5:10:5 | x :  | semmle.label | x :  |
 | active_support.rb:10:9:10:18 | call to source :  | semmle.label | call to source :  |
 | active_support.rb:11:10:11:10 | x :  | semmle.label | x :  |
 | active_support.rb:11:10:11:19 | call to at | semmle.label | call to at |
+| active_support.rb:15:5:15:5 | x :  | semmle.label | x :  |
 | active_support.rb:15:9:15:18 | call to source :  | semmle.label | call to source :  |
 | active_support.rb:16:10:16:10 | x :  | semmle.label | x :  |
 | active_support.rb:16:10:16:19 | call to camelize | semmle.label | call to camelize |
+| active_support.rb:20:5:20:5 | x :  | semmle.label | x :  |
 | active_support.rb:20:9:20:18 | call to source :  | semmle.label | call to source :  |
 | active_support.rb:21:10:21:10 | x :  | semmle.label | x :  |
 | active_support.rb:21:10:21:20 | call to camelcase | semmle.label | call to camelcase |
+| active_support.rb:25:5:25:5 | x :  | semmle.label | x :  |
 | active_support.rb:25:9:25:18 | call to source :  | semmle.label | call to source :  |
 | active_support.rb:26:10:26:10 | x :  | semmle.label | x :  |
 | active_support.rb:26:10:26:19 | call to classify | semmle.label | call to classify |
+| active_support.rb:30:5:30:5 | x :  | semmle.label | x :  |
 | active_support.rb:30:9:30:18 | call to source :  | semmle.label | call to source :  |
 | active_support.rb:31:10:31:10 | x :  | semmle.label | x :  |
 | active_support.rb:31:10:31:20 | call to dasherize | semmle.label | call to dasherize |
+| active_support.rb:35:5:35:5 | x :  | semmle.label | x :  |
 | active_support.rb:35:9:35:18 | call to source :  | semmle.label | call to source :  |
 | active_support.rb:36:10:36:10 | x :  | semmle.label | x :  |
 | active_support.rb:36:10:36:24 | call to deconstantize | semmle.label | call to deconstantize |
+| active_support.rb:40:5:40:5 | x :  | semmle.label | x :  |
 | active_support.rb:40:9:40:18 | call to source :  | semmle.label | call to source :  |
 | active_support.rb:41:10:41:10 | x :  | semmle.label | x :  |
 | active_support.rb:41:10:41:21 | call to demodulize | semmle.label | call to demodulize |
+| active_support.rb:45:5:45:5 | x :  | semmle.label | x :  |
 | active_support.rb:45:9:45:18 | call to source :  | semmle.label | call to source :  |
 | active_support.rb:46:10:46:10 | x :  | semmle.label | x :  |
 | active_support.rb:46:10:46:19 | call to first | semmle.label | call to first |
+| active_support.rb:50:5:50:5 | x :  | semmle.label | x :  |
 | active_support.rb:50:9:50:18 | call to source :  | semmle.label | call to source :  |
 | active_support.rb:51:10:51:10 | x :  | semmle.label | x :  |
 | active_support.rb:51:10:51:22 | call to foreign_key | semmle.label | call to foreign_key |
+| active_support.rb:55:5:55:5 | x :  | semmle.label | x :  |
 | active_support.rb:55:9:55:18 | call to source :  | semmle.label | call to source :  |
 | active_support.rb:56:10:56:10 | x :  | semmle.label | x :  |
 | active_support.rb:56:10:56:18 | call to from | semmle.label | call to from |
+| active_support.rb:60:5:60:5 | x :  | semmle.label | x :  |
 | active_support.rb:60:9:60:18 | call to source :  | semmle.label | call to source :  |
 | active_support.rb:61:10:61:10 | x :  | semmle.label | x :  |
 | active_support.rb:61:10:61:20 | call to html_safe | semmle.label | call to html_safe |
+| active_support.rb:65:5:65:5 | x :  | semmle.label | x :  |
 | active_support.rb:65:9:65:18 | call to source :  | semmle.label | call to source :  |
 | active_support.rb:66:10:66:10 | x :  | semmle.label | x :  |
 | active_support.rb:66:10:66:19 | call to humanize | semmle.label | call to humanize |
+| active_support.rb:70:5:70:5 | x :  | semmle.label | x :  |
 | active_support.rb:70:9:70:18 | call to source :  | semmle.label | call to source :  |
 | active_support.rb:71:10:71:10 | x :  | semmle.label | x :  |
 | active_support.rb:71:10:71:20 | call to indent | semmle.label | call to indent |
+| active_support.rb:75:5:75:5 | x :  | semmle.label | x :  |
 | active_support.rb:75:9:75:18 | call to source :  | semmle.label | call to source :  |
 | active_support.rb:76:10:76:10 | x :  | semmle.label | x :  |
 | active_support.rb:76:10:76:21 | call to indent! | semmle.label | call to indent! |
+| active_support.rb:80:5:80:5 | x :  | semmle.label | x :  |
 | active_support.rb:80:9:80:18 | call to source :  | semmle.label | call to source :  |
 | active_support.rb:81:10:81:10 | x :  | semmle.label | x :  |
 | active_support.rb:81:10:81:18 | call to inquiry | semmle.label | call to inquiry |
+| active_support.rb:85:5:85:5 | x :  | semmle.label | x :  |
 | active_support.rb:85:9:85:18 | call to source :  | semmle.label | call to source :  |
 | active_support.rb:86:10:86:10 | x :  | semmle.label | x :  |
 | active_support.rb:86:10:86:18 | call to last | semmle.label | call to last |
+| active_support.rb:90:5:90:5 | x :  | semmle.label | x :  |
 | active_support.rb:90:9:90:18 | call to source :  | semmle.label | call to source :  |
 | active_support.rb:91:10:91:10 | x :  | semmle.label | x :  |
 | active_support.rb:91:10:91:19 | call to mb_chars | semmle.label | call to mb_chars |
+| active_support.rb:95:5:95:5 | x :  | semmle.label | x :  |
 | active_support.rb:95:9:95:18 | call to source :  | semmle.label | call to source :  |
 | active_support.rb:96:10:96:10 | x :  | semmle.label | x :  |
 | active_support.rb:96:10:96:23 | call to parameterize | semmle.label | call to parameterize |
+| active_support.rb:100:5:100:5 | x :  | semmle.label | x :  |
 | active_support.rb:100:9:100:18 | call to source :  | semmle.label | call to source :  |
 | active_support.rb:101:10:101:10 | x :  | semmle.label | x :  |
 | active_support.rb:101:10:101:20 | call to pluralize | semmle.label | call to pluralize |
+| active_support.rb:105:5:105:5 | x :  | semmle.label | x :  |
 | active_support.rb:105:9:105:18 | call to source :  | semmle.label | call to source :  |
 | active_support.rb:106:10:106:10 | x :  | semmle.label | x :  |
 | active_support.rb:106:10:106:24 | call to remove | semmle.label | call to remove |
+| active_support.rb:110:5:110:5 | x :  | semmle.label | x :  |
 | active_support.rb:110:9:110:18 | call to source :  | semmle.label | call to source :  |
 | active_support.rb:111:10:111:10 | x :  | semmle.label | x :  |
 | active_support.rb:111:10:111:25 | call to remove! | semmle.label | call to remove! |
+| active_support.rb:115:5:115:5 | x :  | semmle.label | x :  |
 | active_support.rb:115:9:115:18 | call to source :  | semmle.label | call to source :  |
 | active_support.rb:116:10:116:10 | x :  | semmle.label | x :  |
 | active_support.rb:116:10:116:22 | call to singularize | semmle.label | call to singularize |
+| active_support.rb:120:5:120:5 | x :  | semmle.label | x :  |
 | active_support.rb:120:9:120:18 | call to source :  | semmle.label | call to source :  |
 | active_support.rb:121:10:121:10 | x :  | semmle.label | x :  |
 | active_support.rb:121:10:121:17 | call to squish | semmle.label | call to squish |
+| active_support.rb:125:5:125:5 | x :  | semmle.label | x :  |
 | active_support.rb:125:9:125:18 | call to source :  | semmle.label | call to source :  |
 | active_support.rb:126:10:126:10 | x :  | semmle.label | x :  |
 | active_support.rb:126:10:126:18 | call to squish! | semmle.label | call to squish! |
+| active_support.rb:130:5:130:5 | x :  | semmle.label | x :  |
 | active_support.rb:130:9:130:18 | call to source :  | semmle.label | call to source :  |
 | active_support.rb:131:10:131:10 | x :  | semmle.label | x :  |
 | active_support.rb:131:10:131:24 | call to strip_heredoc | semmle.label | call to strip_heredoc |
+| active_support.rb:135:5:135:5 | x :  | semmle.label | x :  |
 | active_support.rb:135:9:135:18 | call to source :  | semmle.label | call to source :  |
 | active_support.rb:136:10:136:10 | x :  | semmle.label | x :  |
 | active_support.rb:136:10:136:19 | call to tableize | semmle.label | call to tableize |
+| active_support.rb:140:5:140:5 | x :  | semmle.label | x :  |
 | active_support.rb:140:9:140:18 | call to source :  | semmle.label | call to source :  |
 | active_support.rb:141:10:141:10 | x :  | semmle.label | x :  |
 | active_support.rb:141:10:141:20 | call to titlecase | semmle.label | call to titlecase |
+| active_support.rb:145:5:145:5 | x :  | semmle.label | x :  |
 | active_support.rb:145:9:145:18 | call to source :  | semmle.label | call to source :  |
 | active_support.rb:146:10:146:10 | x :  | semmle.label | x :  |
 | active_support.rb:146:10:146:19 | call to titleize | semmle.label | call to titleize |
+| active_support.rb:150:5:150:5 | x :  | semmle.label | x :  |
 | active_support.rb:150:9:150:18 | call to source :  | semmle.label | call to source :  |
 | active_support.rb:151:10:151:10 | x :  | semmle.label | x :  |
 | active_support.rb:151:10:151:16 | call to to | semmle.label | call to to |
+| active_support.rb:155:5:155:5 | x :  | semmle.label | x :  |
 | active_support.rb:155:9:155:18 | call to source :  | semmle.label | call to source :  |
 | active_support.rb:156:10:156:10 | x :  | semmle.label | x :  |
 | active_support.rb:156:10:156:22 | call to truncate | semmle.label | call to truncate |
+| active_support.rb:160:5:160:5 | x :  | semmle.label | x :  |
 | active_support.rb:160:9:160:18 | call to source :  | semmle.label | call to source :  |
 | active_support.rb:161:10:161:10 | x :  | semmle.label | x :  |
 | active_support.rb:161:10:161:28 | call to truncate_bytes | semmle.label | call to truncate_bytes |
+| active_support.rb:165:5:165:5 | x :  | semmle.label | x :  |
 | active_support.rb:165:9:165:18 | call to source :  | semmle.label | call to source :  |
 | active_support.rb:166:10:166:10 | x :  | semmle.label | x :  |
 | active_support.rb:166:10:166:28 | call to truncate_words | semmle.label | call to truncate_words |
+| active_support.rb:170:5:170:5 | x :  | semmle.label | x :  |
 | active_support.rb:170:9:170:18 | call to source :  | semmle.label | call to source :  |
 | active_support.rb:171:10:171:10 | x :  | semmle.label | x :  |
 | active_support.rb:171:10:171:21 | call to underscore | semmle.label | call to underscore |
+| active_support.rb:175:5:175:5 | x :  | semmle.label | x :  |
 | active_support.rb:175:9:175:18 | call to source :  | semmle.label | call to source :  |
 | active_support.rb:176:10:176:10 | x :  | semmle.label | x :  |
 | active_support.rb:176:10:176:23 | call to upcase_first | semmle.label | call to upcase_first |
+| active_support.rb:180:5:180:5 | x [element 0] :  | semmle.label | x [element 0] :  |
+| active_support.rb:180:5:180:5 | x [element 0] :  | semmle.label | x [element 0] :  |
 | active_support.rb:180:10:180:17 | call to source :  | semmle.label | call to source :  |
 | active_support.rb:180:10:180:17 | call to source :  | semmle.label | call to source :  |
+| active_support.rb:181:5:181:5 | y [element] :  | semmle.label | y [element] :  |
+| active_support.rb:181:5:181:5 | y [element] :  | semmle.label | y [element] :  |
 | active_support.rb:181:9:181:9 | x [element 0] :  | semmle.label | x [element 0] :  |
 | active_support.rb:181:9:181:9 | x [element 0] :  | semmle.label | x [element 0] :  |
 | active_support.rb:181:9:181:23 | call to compact_blank [element] :  | semmle.label | call to compact_blank [element] :  |
@@ -548,8 +748,12 @@ nodes
 | active_support.rb:182:10:182:10 | y [element] :  | semmle.label | y [element] :  |
 | active_support.rb:182:10:182:13 | ...[...] | semmle.label | ...[...] |
 | active_support.rb:182:10:182:13 | ...[...] | semmle.label | ...[...] |
+| active_support.rb:186:5:186:5 | x [element 0] :  | semmle.label | x [element 0] :  |
+| active_support.rb:186:5:186:5 | x [element 0] :  | semmle.label | x [element 0] :  |
 | active_support.rb:186:10:186:18 | call to source :  | semmle.label | call to source :  |
 | active_support.rb:186:10:186:18 | call to source :  | semmle.label | call to source :  |
+| active_support.rb:187:5:187:5 | y [element] :  | semmle.label | y [element] :  |
+| active_support.rb:187:5:187:5 | y [element] :  | semmle.label | y [element] :  |
 | active_support.rb:187:9:187:9 | x [element 0] :  | semmle.label | x [element 0] :  |
 | active_support.rb:187:9:187:9 | x [element 0] :  | semmle.label | x [element 0] :  |
 | active_support.rb:187:9:187:21 | call to excluding [element] :  | semmle.label | call to excluding [element] :  |
@@ -558,8 +762,12 @@ nodes
 | active_support.rb:188:10:188:10 | y [element] :  | semmle.label | y [element] :  |
 | active_support.rb:188:10:188:13 | ...[...] | semmle.label | ...[...] |
 | active_support.rb:188:10:188:13 | ...[...] | semmle.label | ...[...] |
+| active_support.rb:192:5:192:5 | x [element 0] :  | semmle.label | x [element 0] :  |
+| active_support.rb:192:5:192:5 | x [element 0] :  | semmle.label | x [element 0] :  |
 | active_support.rb:192:10:192:18 | call to source :  | semmle.label | call to source :  |
 | active_support.rb:192:10:192:18 | call to source :  | semmle.label | call to source :  |
+| active_support.rb:193:5:193:5 | y [element] :  | semmle.label | y [element] :  |
+| active_support.rb:193:5:193:5 | y [element] :  | semmle.label | y [element] :  |
 | active_support.rb:193:9:193:9 | x [element 0] :  | semmle.label | x [element 0] :  |
 | active_support.rb:193:9:193:9 | x [element 0] :  | semmle.label | x [element 0] :  |
 | active_support.rb:193:9:193:19 | call to without [element] :  | semmle.label | call to without [element] :  |
@@ -568,8 +776,12 @@ nodes
 | active_support.rb:194:10:194:10 | y [element] :  | semmle.label | y [element] :  |
 | active_support.rb:194:10:194:13 | ...[...] | semmle.label | ...[...] |
 | active_support.rb:194:10:194:13 | ...[...] | semmle.label | ...[...] |
+| active_support.rb:198:5:198:5 | x [element 0] :  | semmle.label | x [element 0] :  |
+| active_support.rb:198:5:198:5 | x [element 0] :  | semmle.label | x [element 0] :  |
 | active_support.rb:198:10:198:18 | call to source :  | semmle.label | call to source :  |
 | active_support.rb:198:10:198:18 | call to source :  | semmle.label | call to source :  |
+| active_support.rb:199:5:199:5 | y [element] :  | semmle.label | y [element] :  |
+| active_support.rb:199:5:199:5 | y [element] :  | semmle.label | y [element] :  |
 | active_support.rb:199:9:199:9 | x [element 0] :  | semmle.label | x [element 0] :  |
 | active_support.rb:199:9:199:9 | x [element 0] :  | semmle.label | x [element 0] :  |
 | active_support.rb:199:9:199:37 | call to in_order_of [element] :  | semmle.label | call to in_order_of [element] :  |
@@ -578,8 +790,14 @@ nodes
 | active_support.rb:200:10:200:10 | y [element] :  | semmle.label | y [element] :  |
 | active_support.rb:200:10:200:13 | ...[...] | semmle.label | ...[...] |
 | active_support.rb:200:10:200:13 | ...[...] | semmle.label | ...[...] |
+| active_support.rb:204:5:204:5 | a [element 0] :  | semmle.label | a [element 0] :  |
+| active_support.rb:204:5:204:5 | a [element 0] :  | semmle.label | a [element 0] :  |
 | active_support.rb:204:10:204:18 | call to source :  | semmle.label | call to source :  |
 | active_support.rb:204:10:204:18 | call to source :  | semmle.label | call to source :  |
+| active_support.rb:205:5:205:5 | b [element 0] :  | semmle.label | b [element 0] :  |
+| active_support.rb:205:5:205:5 | b [element 0] :  | semmle.label | b [element 0] :  |
+| active_support.rb:205:5:205:5 | b [element] :  | semmle.label | b [element] :  |
+| active_support.rb:205:5:205:5 | b [element] :  | semmle.label | b [element] :  |
 | active_support.rb:205:9:205:9 | a [element 0] :  | semmle.label | a [element 0] :  |
 | active_support.rb:205:9:205:9 | a [element 0] :  | semmle.label | a [element 0] :  |
 | active_support.rb:205:9:205:41 | call to including [element 0] :  | semmle.label | call to including [element 0] :  |
@@ -612,99 +830,141 @@ nodes
 | active_support.rb:211:10:211:10 | b [element] :  | semmle.label | b [element] :  |
 | active_support.rb:211:10:211:13 | ...[...] | semmle.label | ...[...] |
 | active_support.rb:211:10:211:13 | ...[...] | semmle.label | ...[...] |
+| active_support.rb:215:3:215:3 | x :  | semmle.label | x :  |
 | active_support.rb:215:7:215:16 | call to source :  | semmle.label | call to source :  |
+| active_support.rb:216:3:216:3 | y :  | semmle.label | y :  |
 | active_support.rb:216:7:216:35 | call to new :  | semmle.label | call to new :  |
 | active_support.rb:216:34:216:34 | x :  | semmle.label | x :  |
 | active_support.rb:217:8:217:8 | y | semmle.label | y |
+| active_support.rb:222:3:222:3 | b :  | semmle.label | b :  |
 | active_support.rb:222:7:222:16 | call to source :  | semmle.label | call to source :  |
+| active_support.rb:223:3:223:3 | y :  | semmle.label | y :  |
 | active_support.rb:223:7:223:22 | call to safe_concat :  | semmle.label | call to safe_concat :  |
 | active_support.rb:223:21:223:21 | b :  | semmle.label | b :  |
 | active_support.rb:224:8:224:8 | y | semmle.label | y |
+| active_support.rb:229:3:229:3 | b :  | semmle.label | b :  |
 | active_support.rb:229:7:229:16 | call to source :  | semmle.label | call to source :  |
 | active_support.rb:230:3:230:3 | [post] x :  | semmle.label | [post] x :  |
 | active_support.rb:230:17:230:17 | b :  | semmle.label | b :  |
 | active_support.rb:231:8:231:8 | x | semmle.label | x |
+| active_support.rb:235:3:235:3 | a :  | semmle.label | a :  |
 | active_support.rb:235:7:235:16 | call to source :  | semmle.label | call to source :  |
+| active_support.rb:237:3:237:3 | x :  | semmle.label | x :  |
 | active_support.rb:237:7:237:35 | call to new :  | semmle.label | call to new :  |
 | active_support.rb:237:34:237:34 | a :  | semmle.label | a :  |
+| active_support.rb:238:3:238:3 | y :  | semmle.label | y :  |
 | active_support.rb:238:7:238:7 | x :  | semmle.label | x :  |
 | active_support.rb:238:7:238:17 | call to concat :  | semmle.label | call to concat :  |
 | active_support.rb:239:8:239:8 | y | semmle.label | y |
+| active_support.rb:243:3:243:3 | a :  | semmle.label | a :  |
 | active_support.rb:243:7:243:16 | call to source :  | semmle.label | call to source :  |
+| active_support.rb:245:3:245:3 | x :  | semmle.label | x :  |
 | active_support.rb:245:7:245:35 | call to new :  | semmle.label | call to new :  |
 | active_support.rb:245:34:245:34 | a :  | semmle.label | a :  |
+| active_support.rb:246:3:246:3 | y :  | semmle.label | y :  |
 | active_support.rb:246:7:246:7 | x :  | semmle.label | x :  |
 | active_support.rb:246:7:246:20 | call to insert :  | semmle.label | call to insert :  |
 | active_support.rb:247:8:247:8 | y | semmle.label | y |
+| active_support.rb:251:3:251:3 | a :  | semmle.label | a :  |
 | active_support.rb:251:7:251:16 | call to source :  | semmle.label | call to source :  |
+| active_support.rb:253:3:253:3 | x :  | semmle.label | x :  |
 | active_support.rb:253:7:253:35 | call to new :  | semmle.label | call to new :  |
 | active_support.rb:253:34:253:34 | a :  | semmle.label | a :  |
+| active_support.rb:254:3:254:3 | y :  | semmle.label | y :  |
 | active_support.rb:254:7:254:7 | x :  | semmle.label | x :  |
 | active_support.rb:254:7:254:18 | call to prepend :  | semmle.label | call to prepend :  |
 | active_support.rb:255:8:255:8 | y | semmle.label | y |
+| active_support.rb:259:3:259:3 | a :  | semmle.label | a :  |
 | active_support.rb:259:7:259:16 | call to source :  | semmle.label | call to source :  |
+| active_support.rb:260:3:260:3 | x :  | semmle.label | x :  |
 | active_support.rb:260:7:260:35 | call to new :  | semmle.label | call to new :  |
 | active_support.rb:260:34:260:34 | a :  | semmle.label | a :  |
+| active_support.rb:261:3:261:3 | y :  | semmle.label | y :  |
 | active_support.rb:261:7:261:7 | x :  | semmle.label | x :  |
 | active_support.rb:261:7:261:12 | call to to_s :  | semmle.label | call to to_s :  |
 | active_support.rb:262:8:262:8 | y | semmle.label | y |
+| active_support.rb:266:3:266:3 | a :  | semmle.label | a :  |
 | active_support.rb:266:7:266:16 | call to source :  | semmle.label | call to source :  |
+| active_support.rb:267:3:267:3 | x :  | semmle.label | x :  |
 | active_support.rb:267:7:267:35 | call to new :  | semmle.label | call to new :  |
 | active_support.rb:267:34:267:34 | a :  | semmle.label | a :  |
+| active_support.rb:268:3:268:3 | y :  | semmle.label | y :  |
 | active_support.rb:268:7:268:7 | x :  | semmle.label | x :  |
 | active_support.rb:268:7:268:16 | call to to_param :  | semmle.label | call to to_param :  |
 | active_support.rb:269:8:269:8 | y | semmle.label | y |
+| active_support.rb:273:3:273:3 | a :  | semmle.label | a :  |
 | active_support.rb:273:7:273:16 | call to source :  | semmle.label | call to source :  |
+| active_support.rb:274:3:274:3 | x :  | semmle.label | x :  |
 | active_support.rb:274:7:274:21 | call to new :  | semmle.label | call to new :  |
 | active_support.rb:274:20:274:20 | a :  | semmle.label | a :  |
+| active_support.rb:275:3:275:3 | y :  | semmle.label | y :  |
 | active_support.rb:275:7:275:7 | x :  | semmle.label | x :  |
 | active_support.rb:275:7:275:17 | call to existence :  | semmle.label | call to existence :  |
 | active_support.rb:276:8:276:8 | y | semmle.label | y |
+| active_support.rb:277:3:277:3 | z :  | semmle.label | z :  |
 | active_support.rb:277:7:277:7 | y :  | semmle.label | y :  |
 | active_support.rb:277:7:277:17 | call to existence :  | semmle.label | call to existence :  |
 | active_support.rb:278:8:278:8 | z | semmle.label | z |
+| active_support.rb:282:3:282:3 | x :  | semmle.label | x :  |
+| active_support.rb:282:3:282:3 | x :  | semmle.label | x :  |
 | active_support.rb:282:7:282:16 | call to source :  | semmle.label | call to source :  |
 | active_support.rb:282:7:282:16 | call to source :  | semmle.label | call to source :  |
 | active_support.rb:283:8:283:8 | x :  | semmle.label | x :  |
 | active_support.rb:283:8:283:8 | x :  | semmle.label | x :  |
 | active_support.rb:283:8:283:17 | call to presence | semmle.label | call to presence |
 | active_support.rb:283:8:283:17 | call to presence | semmle.label | call to presence |
+| active_support.rb:285:3:285:3 | y :  | semmle.label | y :  |
+| active_support.rb:285:3:285:3 | y :  | semmle.label | y :  |
 | active_support.rb:285:7:285:16 | call to source :  | semmle.label | call to source :  |
 | active_support.rb:285:7:285:16 | call to source :  | semmle.label | call to source :  |
 | active_support.rb:286:8:286:8 | y :  | semmle.label | y :  |
 | active_support.rb:286:8:286:8 | y :  | semmle.label | y :  |
 | active_support.rb:286:8:286:17 | call to presence | semmle.label | call to presence |
 | active_support.rb:286:8:286:17 | call to presence | semmle.label | call to presence |
+| active_support.rb:290:3:290:3 | x :  | semmle.label | x :  |
+| active_support.rb:290:3:290:3 | x :  | semmle.label | x :  |
 | active_support.rb:290:7:290:16 | call to source :  | semmle.label | call to source :  |
 | active_support.rb:290:7:290:16 | call to source :  | semmle.label | call to source :  |
 | active_support.rb:291:8:291:8 | x :  | semmle.label | x :  |
 | active_support.rb:291:8:291:8 | x :  | semmle.label | x :  |
 | active_support.rb:291:8:291:17 | call to deep_dup | semmle.label | call to deep_dup |
 | active_support.rb:291:8:291:17 | call to deep_dup | semmle.label | call to deep_dup |
+| active_support.rb:303:3:303:3 | a :  | semmle.label | a :  |
 | active_support.rb:303:7:303:16 | call to source :  | semmle.label | call to source :  |
+| active_support.rb:304:3:304:3 | b :  | semmle.label | b :  |
 | active_support.rb:304:7:304:19 | call to json_escape :  | semmle.label | call to json_escape :  |
 | active_support.rb:304:19:304:19 | a :  | semmle.label | a :  |
 | active_support.rb:305:8:305:8 | b | semmle.label | b |
+| active_support.rb:309:5:309:5 | x :  | semmle.label | x :  |
 | active_support.rb:309:9:309:18 | call to source :  | semmle.label | call to source :  |
 | active_support.rb:310:10:310:38 | call to encode | semmle.label | call to encode |
 | active_support.rb:310:37:310:37 | x :  | semmle.label | x :  |
+| active_support.rb:314:5:314:5 | x :  | semmle.label | x :  |
 | active_support.rb:314:9:314:18 | call to source :  | semmle.label | call to source :  |
 | active_support.rb:315:10:315:38 | call to decode | semmle.label | call to decode |
 | active_support.rb:315:37:315:37 | x :  | semmle.label | x :  |
+| active_support.rb:319:5:319:5 | x :  | semmle.label | x :  |
 | active_support.rb:319:9:319:18 | call to source :  | semmle.label | call to source :  |
 | active_support.rb:320:10:320:36 | call to dump | semmle.label | call to dump |
 | active_support.rb:320:35:320:35 | x :  | semmle.label | x :  |
+| active_support.rb:324:5:324:5 | x :  | semmle.label | x :  |
 | active_support.rb:324:9:324:18 | call to source :  | semmle.label | call to source :  |
 | active_support.rb:325:10:325:36 | call to load | semmle.label | call to load |
 | active_support.rb:325:35:325:35 | x :  | semmle.label | x :  |
+| active_support.rb:329:5:329:5 | x :  | semmle.label | x :  |
 | active_support.rb:329:9:329:18 | call to source :  | semmle.label | call to source :  |
+| active_support.rb:330:5:330:5 | y [element 0] :  | semmle.label | y [element 0] :  |
 | active_support.rb:330:10:330:10 | x :  | semmle.label | x :  |
 | active_support.rb:331:10:331:10 | x :  | semmle.label | x :  |
 | active_support.rb:331:10:331:18 | call to to_json | semmle.label | call to to_json |
 | active_support.rb:332:10:332:10 | y [element 0] :  | semmle.label | y [element 0] :  |
 | active_support.rb:332:10:332:18 | call to to_json | semmle.label | call to to_json |
+| hash_extensions.rb:2:5:2:5 | h [element :a] :  | semmle.label | h [element :a] :  |
+| hash_extensions.rb:2:5:2:5 | h [element :a] :  | semmle.label | h [element :a] :  |
 | hash_extensions.rb:2:14:2:24 | call to source :  | semmle.label | call to source :  |
 | hash_extensions.rb:2:14:2:24 | call to source :  | semmle.label | call to source :  |
+| hash_extensions.rb:3:5:3:5 | x [element] :  | semmle.label | x [element] :  |
+| hash_extensions.rb:3:5:3:5 | x [element] :  | semmle.label | x [element] :  |
 | hash_extensions.rb:3:9:3:9 | h [element :a] :  | semmle.label | h [element :a] :  |
 | hash_extensions.rb:3:9:3:9 | h [element :a] :  | semmle.label | h [element :a] :  |
 | hash_extensions.rb:3:9:3:24 | call to stringify_keys [element] :  | semmle.label | call to stringify_keys [element] :  |
@@ -713,8 +973,12 @@ nodes
 | hash_extensions.rb:4:10:4:10 | x [element] :  | semmle.label | x [element] :  |
 | hash_extensions.rb:4:10:4:14 | ...[...] | semmle.label | ...[...] |
 | hash_extensions.rb:4:10:4:14 | ...[...] | semmle.label | ...[...] |
+| hash_extensions.rb:10:5:10:5 | h [element :a] :  | semmle.label | h [element :a] :  |
+| hash_extensions.rb:10:5:10:5 | h [element :a] :  | semmle.label | h [element :a] :  |
 | hash_extensions.rb:10:14:10:24 | call to source :  | semmle.label | call to source :  |
 | hash_extensions.rb:10:14:10:24 | call to source :  | semmle.label | call to source :  |
+| hash_extensions.rb:11:5:11:5 | x [element] :  | semmle.label | x [element] :  |
+| hash_extensions.rb:11:5:11:5 | x [element] :  | semmle.label | x [element] :  |
 | hash_extensions.rb:11:9:11:9 | h [element :a] :  | semmle.label | h [element :a] :  |
 | hash_extensions.rb:11:9:11:9 | h [element :a] :  | semmle.label | h [element :a] :  |
 | hash_extensions.rb:11:9:11:20 | call to to_options [element] :  | semmle.label | call to to_options [element] :  |
@@ -723,8 +987,12 @@ nodes
 | hash_extensions.rb:12:10:12:10 | x [element] :  | semmle.label | x [element] :  |
 | hash_extensions.rb:12:10:12:14 | ...[...] | semmle.label | ...[...] |
 | hash_extensions.rb:12:10:12:14 | ...[...] | semmle.label | ...[...] |
+| hash_extensions.rb:18:5:18:5 | h [element :a] :  | semmle.label | h [element :a] :  |
+| hash_extensions.rb:18:5:18:5 | h [element :a] :  | semmle.label | h [element :a] :  |
 | hash_extensions.rb:18:14:18:24 | call to source :  | semmle.label | call to source :  |
 | hash_extensions.rb:18:14:18:24 | call to source :  | semmle.label | call to source :  |
+| hash_extensions.rb:19:5:19:5 | x [element] :  | semmle.label | x [element] :  |
+| hash_extensions.rb:19:5:19:5 | x [element] :  | semmle.label | x [element] :  |
 | hash_extensions.rb:19:9:19:9 | h [element :a] :  | semmle.label | h [element :a] :  |
 | hash_extensions.rb:19:9:19:9 | h [element :a] :  | semmle.label | h [element :a] :  |
 | hash_extensions.rb:19:9:19:24 | call to symbolize_keys [element] :  | semmle.label | call to symbolize_keys [element] :  |
@@ -733,8 +1001,12 @@ nodes
 | hash_extensions.rb:20:10:20:10 | x [element] :  | semmle.label | x [element] :  |
 | hash_extensions.rb:20:10:20:14 | ...[...] | semmle.label | ...[...] |
 | hash_extensions.rb:20:10:20:14 | ...[...] | semmle.label | ...[...] |
+| hash_extensions.rb:26:5:26:5 | h [element :a] :  | semmle.label | h [element :a] :  |
+| hash_extensions.rb:26:5:26:5 | h [element :a] :  | semmle.label | h [element :a] :  |
 | hash_extensions.rb:26:14:26:24 | call to source :  | semmle.label | call to source :  |
 | hash_extensions.rb:26:14:26:24 | call to source :  | semmle.label | call to source :  |
+| hash_extensions.rb:27:5:27:5 | x [element] :  | semmle.label | x [element] :  |
+| hash_extensions.rb:27:5:27:5 | x [element] :  | semmle.label | x [element] :  |
 | hash_extensions.rb:27:9:27:9 | h [element :a] :  | semmle.label | h [element :a] :  |
 | hash_extensions.rb:27:9:27:9 | h [element :a] :  | semmle.label | h [element :a] :  |
 | hash_extensions.rb:27:9:27:29 | call to deep_stringify_keys [element] :  | semmle.label | call to deep_stringify_keys [element] :  |
@@ -743,8 +1015,12 @@ nodes
 | hash_extensions.rb:28:10:28:10 | x [element] :  | semmle.label | x [element] :  |
 | hash_extensions.rb:28:10:28:14 | ...[...] | semmle.label | ...[...] |
 | hash_extensions.rb:28:10:28:14 | ...[...] | semmle.label | ...[...] |
+| hash_extensions.rb:34:5:34:5 | h [element :a] :  | semmle.label | h [element :a] :  |
+| hash_extensions.rb:34:5:34:5 | h [element :a] :  | semmle.label | h [element :a] :  |
 | hash_extensions.rb:34:14:34:24 | call to source :  | semmle.label | call to source :  |
 | hash_extensions.rb:34:14:34:24 | call to source :  | semmle.label | call to source :  |
+| hash_extensions.rb:35:5:35:5 | x [element] :  | semmle.label | x [element] :  |
+| hash_extensions.rb:35:5:35:5 | x [element] :  | semmle.label | x [element] :  |
 | hash_extensions.rb:35:9:35:9 | h [element :a] :  | semmle.label | h [element :a] :  |
 | hash_extensions.rb:35:9:35:9 | h [element :a] :  | semmle.label | h [element :a] :  |
 | hash_extensions.rb:35:9:35:29 | call to deep_symbolize_keys [element] :  | semmle.label | call to deep_symbolize_keys [element] :  |
@@ -753,8 +1029,12 @@ nodes
 | hash_extensions.rb:36:10:36:10 | x [element] :  | semmle.label | x [element] :  |
 | hash_extensions.rb:36:10:36:14 | ...[...] | semmle.label | ...[...] |
 | hash_extensions.rb:36:10:36:14 | ...[...] | semmle.label | ...[...] |
+| hash_extensions.rb:42:5:42:5 | h [element :a] :  | semmle.label | h [element :a] :  |
+| hash_extensions.rb:42:5:42:5 | h [element :a] :  | semmle.label | h [element :a] :  |
 | hash_extensions.rb:42:14:42:24 | call to source :  | semmle.label | call to source :  |
 | hash_extensions.rb:42:14:42:24 | call to source :  | semmle.label | call to source :  |
+| hash_extensions.rb:43:5:43:5 | x [element] :  | semmle.label | x [element] :  |
+| hash_extensions.rb:43:5:43:5 | x [element] :  | semmle.label | x [element] :  |
 | hash_extensions.rb:43:9:43:9 | h [element :a] :  | semmle.label | h [element :a] :  |
 | hash_extensions.rb:43:9:43:9 | h [element :a] :  | semmle.label | h [element :a] :  |
 | hash_extensions.rb:43:9:43:33 | call to with_indifferent_access [element] :  | semmle.label | call to with_indifferent_access [element] :  |
@@ -763,12 +1043,22 @@ nodes
 | hash_extensions.rb:44:10:44:10 | x [element] :  | semmle.label | x [element] :  |
 | hash_extensions.rb:44:10:44:14 | ...[...] | semmle.label | ...[...] |
 | hash_extensions.rb:44:10:44:14 | ...[...] | semmle.label | ...[...] |
+| hash_extensions.rb:50:5:50:5 | h [element :a] :  | semmle.label | h [element :a] :  |
+| hash_extensions.rb:50:5:50:5 | h [element :a] :  | semmle.label | h [element :a] :  |
+| hash_extensions.rb:50:5:50:5 | h [element :b] :  | semmle.label | h [element :b] :  |
+| hash_extensions.rb:50:5:50:5 | h [element :b] :  | semmle.label | h [element :b] :  |
+| hash_extensions.rb:50:5:50:5 | h [element :d] :  | semmle.label | h [element :d] :  |
+| hash_extensions.rb:50:5:50:5 | h [element :d] :  | semmle.label | h [element :d] :  |
 | hash_extensions.rb:50:14:50:23 | call to taint :  | semmle.label | call to taint :  |
 | hash_extensions.rb:50:14:50:23 | call to taint :  | semmle.label | call to taint :  |
 | hash_extensions.rb:50:29:50:38 | call to taint :  | semmle.label | call to taint :  |
 | hash_extensions.rb:50:29:50:38 | call to taint :  | semmle.label | call to taint :  |
 | hash_extensions.rb:50:52:50:61 | call to taint :  | semmle.label | call to taint :  |
 | hash_extensions.rb:50:52:50:61 | call to taint :  | semmle.label | call to taint :  |
+| hash_extensions.rb:51:5:51:5 | x [element :a] :  | semmle.label | x [element :a] :  |
+| hash_extensions.rb:51:5:51:5 | x [element :a] :  | semmle.label | x [element :a] :  |
+| hash_extensions.rb:51:5:51:5 | x [element :b] :  | semmle.label | x [element :b] :  |
+| hash_extensions.rb:51:5:51:5 | x [element :b] :  | semmle.label | x [element :b] :  |
 | hash_extensions.rb:51:9:51:9 | [post] h [element :d] :  | semmle.label | [post] h [element :d] :  |
 | hash_extensions.rb:51:9:51:9 | [post] h [element :d] :  | semmle.label | [post] h [element :d] :  |
 | hash_extensions.rb:51:9:51:9 | h [element :a] :  | semmle.label | h [element :a] :  |
@@ -793,12 +1083,20 @@ nodes
 | hash_extensions.rb:59:10:59:10 | x [element :b] :  | semmle.label | x [element :b] :  |
 | hash_extensions.rb:59:10:59:14 | ...[...] | semmle.label | ...[...] |
 | hash_extensions.rb:59:10:59:14 | ...[...] | semmle.label | ...[...] |
+| hash_extensions.rb:67:5:67:10 | values [element 0] :  | semmle.label | values [element 0] :  |
+| hash_extensions.rb:67:5:67:10 | values [element 0] :  | semmle.label | values [element 0] :  |
+| hash_extensions.rb:67:5:67:10 | values [element 1] :  | semmle.label | values [element 1] :  |
+| hash_extensions.rb:67:5:67:10 | values [element 1] :  | semmle.label | values [element 1] :  |
+| hash_extensions.rb:67:5:67:10 | values [element 2] :  | semmle.label | values [element 2] :  |
+| hash_extensions.rb:67:5:67:10 | values [element 2] :  | semmle.label | values [element 2] :  |
 | hash_extensions.rb:67:15:67:25 | call to source :  | semmle.label | call to source :  |
 | hash_extensions.rb:67:15:67:25 | call to source :  | semmle.label | call to source :  |
 | hash_extensions.rb:67:28:67:38 | call to source :  | semmle.label | call to source :  |
 | hash_extensions.rb:67:28:67:38 | call to source :  | semmle.label | call to source :  |
 | hash_extensions.rb:67:41:67:51 | call to source :  | semmle.label | call to source :  |
 | hash_extensions.rb:67:41:67:51 | call to source :  | semmle.label | call to source :  |
+| hash_extensions.rb:68:5:68:5 | h [element] :  | semmle.label | h [element] :  |
+| hash_extensions.rb:68:5:68:5 | h [element] :  | semmle.label | h [element] :  |
 | hash_extensions.rb:68:9:68:14 | values [element 0] :  | semmle.label | values [element 0] :  |
 | hash_extensions.rb:68:9:68:14 | values [element 0] :  | semmle.label | values [element 0] :  |
 | hash_extensions.rb:68:9:68:14 | values [element 1] :  | semmle.label | values [element 1] :  |
@@ -819,12 +1117,20 @@ nodes
 | hash_extensions.rb:74:10:74:10 | h [element] :  | semmle.label | h [element] :  |
 | hash_extensions.rb:74:10:74:16 | ...[...] | semmle.label | ...[...] |
 | hash_extensions.rb:74:10:74:16 | ...[...] | semmle.label | ...[...] |
+| hash_extensions.rb:80:5:80:10 | values [element 0] :  | semmle.label | values [element 0] :  |
+| hash_extensions.rb:80:5:80:10 | values [element 0] :  | semmle.label | values [element 0] :  |
+| hash_extensions.rb:80:5:80:10 | values [element 1] :  | semmle.label | values [element 1] :  |
+| hash_extensions.rb:80:5:80:10 | values [element 1] :  | semmle.label | values [element 1] :  |
+| hash_extensions.rb:80:5:80:10 | values [element 2] :  | semmle.label | values [element 2] :  |
+| hash_extensions.rb:80:5:80:10 | values [element 2] :  | semmle.label | values [element 2] :  |
 | hash_extensions.rb:80:15:80:25 | call to source :  | semmle.label | call to source :  |
 | hash_extensions.rb:80:15:80:25 | call to source :  | semmle.label | call to source :  |
 | hash_extensions.rb:80:28:80:38 | call to source :  | semmle.label | call to source :  |
 | hash_extensions.rb:80:28:80:38 | call to source :  | semmle.label | call to source :  |
 | hash_extensions.rb:80:41:80:51 | call to source :  | semmle.label | call to source :  |
 | hash_extensions.rb:80:41:80:51 | call to source :  | semmle.label | call to source :  |
+| hash_extensions.rb:81:5:81:5 | h [element] :  | semmle.label | h [element] :  |
+| hash_extensions.rb:81:5:81:5 | h [element] :  | semmle.label | h [element] :  |
 | hash_extensions.rb:81:9:81:14 | values [element 0] :  | semmle.label | values [element 0] :  |
 | hash_extensions.rb:81:9:81:14 | values [element 0] :  | semmle.label | values [element 0] :  |
 | hash_extensions.rb:81:9:81:14 | values [element 1] :  | semmle.label | values [element 1] :  |
@@ -847,6 +1153,8 @@ nodes
 | hash_extensions.rb:87:10:87:10 | h [element] :  | semmle.label | h [element] :  |
 | hash_extensions.rb:87:10:87:16 | ...[...] | semmle.label | ...[...] |
 | hash_extensions.rb:87:10:87:16 | ...[...] | semmle.label | ...[...] |
+| hash_extensions.rb:89:5:89:5 | j [element] :  | semmle.label | j [element] :  |
+| hash_extensions.rb:89:5:89:5 | j [element] :  | semmle.label | j [element] :  |
 | hash_extensions.rb:89:9:89:38 | call to index_with [element] :  | semmle.label | call to index_with [element] :  |
 | hash_extensions.rb:89:9:89:38 | call to index_with [element] :  | semmle.label | call to index_with [element] :  |
 | hash_extensions.rb:89:27:89:37 | call to source :  | semmle.label | call to source :  |
@@ -859,6 +1167,10 @@ nodes
 | hash_extensions.rb:92:10:92:10 | j [element] :  | semmle.label | j [element] :  |
 | hash_extensions.rb:92:10:92:16 | ...[...] | semmle.label | ...[...] |
 | hash_extensions.rb:92:10:92:16 | ...[...] | semmle.label | ...[...] |
+| hash_extensions.rb:98:5:98:10 | values [element 0, element :id] :  | semmle.label | values [element 0, element :id] :  |
+| hash_extensions.rb:98:5:98:10 | values [element 0, element :id] :  | semmle.label | values [element 0, element :id] :  |
+| hash_extensions.rb:98:5:98:10 | values [element 0, element :name] :  | semmle.label | values [element 0, element :name] :  |
+| hash_extensions.rb:98:5:98:10 | values [element 0, element :name] :  | semmle.label | values [element 0, element :name] :  |
 | hash_extensions.rb:98:21:98:31 | call to source :  | semmle.label | call to source :  |
 | hash_extensions.rb:98:21:98:31 | call to source :  | semmle.label | call to source :  |
 | hash_extensions.rb:98:40:98:54 | call to source :  | semmle.label | call to source :  |
@@ -895,6 +1207,14 @@ nodes
 | hash_extensions.rb:104:10:104:32 | call to pick [element 1] :  | semmle.label | call to pick [element 1] :  |
 | hash_extensions.rb:104:10:104:35 | ...[...] | semmle.label | ...[...] |
 | hash_extensions.rb:104:10:104:35 | ...[...] | semmle.label | ...[...] |
+| hash_extensions.rb:110:5:110:10 | values [element 0, element :id] :  | semmle.label | values [element 0, element :id] :  |
+| hash_extensions.rb:110:5:110:10 | values [element 0, element :id] :  | semmle.label | values [element 0, element :id] :  |
+| hash_extensions.rb:110:5:110:10 | values [element 0, element :name] :  | semmle.label | values [element 0, element :name] :  |
+| hash_extensions.rb:110:5:110:10 | values [element 0, element :name] :  | semmle.label | values [element 0, element :name] :  |
+| hash_extensions.rb:110:5:110:10 | values [element 1, element :id] :  | semmle.label | values [element 1, element :id] :  |
+| hash_extensions.rb:110:5:110:10 | values [element 1, element :id] :  | semmle.label | values [element 1, element :id] :  |
+| hash_extensions.rb:110:5:110:10 | values [element 1, element :name] :  | semmle.label | values [element 1, element :name] :  |
+| hash_extensions.rb:110:5:110:10 | values [element 1, element :name] :  | semmle.label | values [element 1, element :name] :  |
 | hash_extensions.rb:110:21:110:31 | call to source :  | semmle.label | call to source :  |
 | hash_extensions.rb:110:21:110:31 | call to source :  | semmle.label | call to source :  |
 | hash_extensions.rb:110:40:110:54 | call to source :  | semmle.label | call to source :  |
@@ -951,8 +1271,12 @@ nodes
 | hash_extensions.rb:115:10:115:36 | ...[...] [element 1] :  | semmle.label | ...[...] [element 1] :  |
 | hash_extensions.rb:115:10:115:39 | ...[...] | semmle.label | ...[...] |
 | hash_extensions.rb:115:10:115:39 | ...[...] | semmle.label | ...[...] |
+| hash_extensions.rb:122:5:122:10 | single [element 0] :  | semmle.label | single [element 0] :  |
+| hash_extensions.rb:122:5:122:10 | single [element 0] :  | semmle.label | single [element 0] :  |
 | hash_extensions.rb:122:15:122:25 | call to source :  | semmle.label | call to source :  |
 | hash_extensions.rb:122:15:122:25 | call to source :  | semmle.label | call to source :  |
+| hash_extensions.rb:123:5:123:9 | multi [element 0] :  | semmle.label | multi [element 0] :  |
+| hash_extensions.rb:123:5:123:9 | multi [element 0] :  | semmle.label | multi [element 0] :  |
 | hash_extensions.rb:123:14:123:24 | call to source :  | semmle.label | call to source :  |
 | hash_extensions.rb:123:14:123:24 | call to source :  | semmle.label | call to source :  |
 | hash_extensions.rb:125:10:125:15 | single [element 0] :  | semmle.label | single [element 0] :  |

--- a/ruby/ql/test/library-tests/frameworks/files/Files.expected
+++ b/ruby/ql/test/library-tests/frameworks/files/Files.expected
@@ -1,8 +1,8 @@
 fileInstances
-| Files.rb:2:1:2:36 | ... = ... |
+| Files.rb:2:1:2:8 | foo_file |
 | Files.rb:2:1:2:36 | ... = ... |
 | Files.rb:2:12:2:36 | call to new |
-| Files.rb:3:1:3:21 | ... = ... |
+| Files.rb:3:1:3:10 | foo_file_2 |
 | Files.rb:3:1:3:21 | ... = ... |
 | Files.rb:3:14:3:21 | foo_file |
 | Files.rb:4:1:4:8 | foo_file |
@@ -18,17 +18,17 @@ fileInstances
 | Files.rb:40:1:40:8 | foo_file |
 | Files.rb:41:1:41:26 | call to open |
 ioInstances
-| Files.rb:2:1:2:36 | ... = ... |
+| Files.rb:2:1:2:8 | foo_file |
 | Files.rb:2:1:2:36 | ... = ... |
 | Files.rb:2:12:2:36 | call to new |
-| Files.rb:3:1:3:21 | ... = ... |
+| Files.rb:3:1:3:10 | foo_file_2 |
 | Files.rb:3:1:3:21 | ... = ... |
 | Files.rb:3:14:3:21 | foo_file |
 | Files.rb:4:1:4:8 | foo_file |
 | Files.rb:7:13:7:22 | foo_file_2 |
 | Files.rb:10:6:10:13 | foo_file |
 | Files.rb:11:6:11:13 | foo_file |
-| Files.rb:17:1:17:50 | ... = ... |
+| Files.rb:17:1:17:4 | rand |
 | Files.rb:17:1:17:50 | ... = ... |
 | Files.rb:17:8:17:50 | call to new |
 | Files.rb:18:1:18:13 | ... = ... |
@@ -44,7 +44,7 @@ ioInstances
 | Files.rb:37:14:37:33 | call to open |
 | Files.rb:40:1:40:8 | foo_file |
 | Files.rb:41:1:41:26 | call to open |
-| Files.rb:44:1:44:45 | ... = ... |
+| Files.rb:44:1:44:7 | io_file |
 | Files.rb:44:1:44:45 | ... = ... |
 | Files.rb:44:11:44:45 | call to open |
 | Files.rb:48:1:48:7 | io_file |

--- a/ruby/ql/test/library-tests/frameworks/pathname/Pathname.expected
+++ b/ruby/ql/test/library-tests/frameworks/pathname/Pathname.expected
@@ -1,21 +1,21 @@
 pathnameInstances
-| Pathname.rb:2:1:2:33 | ... = ... |
+| Pathname.rb:2:1:2:8 | foo_path |
 | Pathname.rb:2:1:2:33 | ... = ... |
 | Pathname.rb:2:12:2:33 | call to new |
 | Pathname.rb:3:1:3:20 | ... = ... |
 | Pathname.rb:3:13:3:20 | foo_path |
 | Pathname.rb:4:1:4:8 | foo_path |
-| Pathname.rb:6:1:6:29 | ... = ... |
+| Pathname.rb:6:1:6:8 | bar_path |
 | Pathname.rb:6:1:6:29 | ... = ... |
 | Pathname.rb:6:12:6:29 | call to new |
-| Pathname.rb:9:1:9:21 | ... = ... |
+| Pathname.rb:9:1:9:4 | pwd1 |
 | Pathname.rb:9:1:9:21 | ... = ... |
 | Pathname.rb:9:8:9:21 | call to getwd |
 | Pathname.rb:10:1:10:21 | ... = ... |
 | Pathname.rb:10:7:10:10 | pwd1 |
 | Pathname.rb:10:7:10:21 | ... + ... |
 | Pathname.rb:10:14:10:21 | foo_path |
-| Pathname.rb:11:1:11:21 | ... = ... |
+| Pathname.rb:11:1:11:3 | p01 |
 | Pathname.rb:11:1:11:21 | ... = ... |
 | Pathname.rb:11:7:11:10 | pwd1 |
 | Pathname.rb:11:7:11:21 | ... / ... |
@@ -38,7 +38,7 @@ pathnameInstances
 | Pathname.rb:17:1:17:59 | ... = ... |
 | Pathname.rb:17:7:17:33 | call to new |
 | Pathname.rb:17:7:17:59 | call to relative_path_from |
-| Pathname.rb:18:1:18:33 | ... = ... |
+| Pathname.rb:18:1:18:3 | p08 |
 | Pathname.rb:18:1:18:33 | ... = ... |
 | Pathname.rb:18:7:18:10 | pwd1 |
 | Pathname.rb:18:7:18:33 | call to sub |
@@ -75,23 +75,23 @@ fileSystemAccesses
 | Pathname.rb:35:1:35:23 | call to write | Pathname.rb:35:1:35:8 | foo_path |
 | Pathname.rb:39:12:39:34 | call to open | Pathname.rb:39:12:39:19 | foo_path |
 fileNameSources
-| Pathname.rb:2:1:2:33 | ... = ... |
+| Pathname.rb:2:1:2:8 | foo_path |
 | Pathname.rb:2:1:2:33 | ... = ... |
 | Pathname.rb:2:12:2:33 | call to new |
 | Pathname.rb:3:1:3:20 | ... = ... |
 | Pathname.rb:3:13:3:20 | foo_path |
 | Pathname.rb:4:1:4:8 | foo_path |
-| Pathname.rb:6:1:6:29 | ... = ... |
+| Pathname.rb:6:1:6:8 | bar_path |
 | Pathname.rb:6:1:6:29 | ... = ... |
 | Pathname.rb:6:12:6:29 | call to new |
-| Pathname.rb:9:1:9:21 | ... = ... |
+| Pathname.rb:9:1:9:4 | pwd1 |
 | Pathname.rb:9:1:9:21 | ... = ... |
 | Pathname.rb:9:8:9:21 | call to getwd |
 | Pathname.rb:10:1:10:21 | ... = ... |
 | Pathname.rb:10:7:10:10 | pwd1 |
 | Pathname.rb:10:7:10:21 | ... + ... |
 | Pathname.rb:10:14:10:21 | foo_path |
-| Pathname.rb:11:1:11:21 | ... = ... |
+| Pathname.rb:11:1:11:3 | p01 |
 | Pathname.rb:11:1:11:21 | ... = ... |
 | Pathname.rb:11:7:11:10 | pwd1 |
 | Pathname.rb:11:7:11:21 | ... / ... |
@@ -114,7 +114,7 @@ fileNameSources
 | Pathname.rb:17:1:17:59 | ... = ... |
 | Pathname.rb:17:7:17:33 | call to new |
 | Pathname.rb:17:7:17:59 | call to relative_path_from |
-| Pathname.rb:18:1:18:33 | ... = ... |
+| Pathname.rb:18:1:18:3 | p08 |
 | Pathname.rb:18:1:18:33 | ... = ... |
 | Pathname.rb:18:7:18:10 | pwd1 |
 | Pathname.rb:18:7:18:33 | call to sub |

--- a/ruby/ql/test/library-tests/variables/ssa.expected
+++ b/ruby/ql/test/library-tests/variables/ssa.expected
@@ -22,29 +22,29 @@ definition
 | instance_variables.rb:38:4:40:6 | self (y) | instance_variables.rb:38:4:40:6 | self |
 | nested_scopes.rb:1:1:3:3 | self (a) | nested_scopes.rb:1:1:3:3 | self |
 | nested_scopes.rb:4:1:39:3 | self (C) | nested_scopes.rb:4:1:39:3 | self |
-| nested_scopes.rb:5:3:5:7 | ... = ... | nested_scopes.rb:5:3:5:3 | a |
+| nested_scopes.rb:5:3:5:3 | a | nested_scopes.rb:5:3:5:3 | a |
 | nested_scopes.rb:6:3:37:5 | self (M) | nested_scopes.rb:6:3:37:5 | self |
-| nested_scopes.rb:7:5:7:9 | ... = ... | nested_scopes.rb:7:5:7:5 | a |
+| nested_scopes.rb:7:5:7:5 | a | nested_scopes.rb:7:5:7:5 | a |
 | nested_scopes.rb:8:5:35:7 | self (N) | nested_scopes.rb:8:5:35:7 | self |
-| nested_scopes.rb:9:7:9:11 | ... = ... | nested_scopes.rb:9:7:9:7 | a |
+| nested_scopes.rb:9:7:9:7 | a | nested_scopes.rb:9:7:9:7 | a |
 | nested_scopes.rb:10:7:26:9 | self (D) | nested_scopes.rb:10:7:26:9 | self |
-| nested_scopes.rb:11:9:11:13 | ... = ... | nested_scopes.rb:11:9:11:9 | a |
+| nested_scopes.rb:11:9:11:9 | a | nested_scopes.rb:11:9:11:9 | a |
 | nested_scopes.rb:12:9:21:11 | self (show_a) | nested_scopes.rb:12:9:21:11 | self |
-| nested_scopes.rb:13:11:13:15 | ... = ... | nested_scopes.rb:13:11:13:11 | a |
+| nested_scopes.rb:13:11:13:11 | a | nested_scopes.rb:13:11:13:11 | a |
 | nested_scopes.rb:15:23:15:23 | a | nested_scopes.rb:15:23:15:23 | a |
-| nested_scopes.rb:17:15:17:19 | ... = ... | nested_scopes.rb:16:29:16:29 | a |
+| nested_scopes.rb:17:15:17:15 | a | nested_scopes.rb:16:29:16:29 | a |
 | nested_scopes.rb:18:23:18:36 | <captured entry> a | nested_scopes.rb:16:29:16:29 | a |
 | nested_scopes.rb:18:23:18:36 | <captured entry> self | nested_scopes.rb:12:9:21:11 | self |
 | nested_scopes.rb:22:9:24:11 | self (show_a2) | nested_scopes.rb:22:9:24:11 | self |
 | nested_scopes.rb:22:21:22:21 | a | nested_scopes.rb:22:21:22:21 | a |
 | nested_scopes.rb:27:7:29:9 | self (show) | nested_scopes.rb:27:7:29:9 | self |
 | nested_scopes.rb:30:16:30:19 | self (class << ...) | nested_scopes.rb:30:7:33:9 | self |
-| nested_scopes.rb:31:11:31:16 | ... = ... | nested_scopes.rb:31:11:31:11 | a |
-| nested_scopes.rb:40:1:40:18 | ... = ... | nested_scopes.rb:40:1:40:1 | d |
+| nested_scopes.rb:31:11:31:11 | a | nested_scopes.rb:31:11:31:11 | a |
+| nested_scopes.rb:40:1:40:1 | d | nested_scopes.rb:40:1:40:1 | d |
 | parameters.rb:1:1:62:1 | self (parameters.rb) | parameters.rb:1:1:62:1 | self |
 | parameters.rb:1:9:5:3 | <captured entry> self | parameters.rb:1:1:62:1 | self |
 | parameters.rb:1:14:1:14 | x | parameters.rb:1:14:1:14 | x |
-| parameters.rb:2:4:2:8 | ... = ... | parameters.rb:1:18:1:18 | y |
+| parameters.rb:2:4:2:4 | y | parameters.rb:1:18:1:18 | y |
 | parameters.rb:7:1:13:3 | self (order_pizza) | parameters.rb:7:1:13:3 | self |
 | parameters.rb:7:17:7:22 | client | parameters.rb:7:17:7:22 | client |
 | parameters.rb:7:26:7:31 | pizzas | parameters.rb:7:26:7:31 | pizzas |
@@ -64,23 +64,23 @@ definition
 | parameters.rb:35:1:38:3 | <uninitialized> | parameters.rb:35:16:35:16 | b |
 | parameters.rb:35:1:38:3 | self (multi) | parameters.rb:35:1:38:3 | self |
 | parameters.rb:35:11:35:11 | a | parameters.rb:35:11:35:11 | a |
-| parameters.rb:35:16:35:20 | ... = ... | parameters.rb:35:16:35:16 | b |
+| parameters.rb:35:16:35:16 | b | parameters.rb:35:16:35:16 | b |
 | parameters.rb:37:3:37:18 | phi | parameters.rb:35:16:35:16 | b |
 | parameters.rb:40:1:43:3 | <uninitialized> | parameters.rb:40:15:40:15 | e |
 | parameters.rb:40:1:43:3 | self (multi2) | parameters.rb:40:1:43:3 | self |
 | parameters.rb:40:12:40:12 | d | parameters.rb:40:12:40:12 | d |
-| parameters.rb:40:15:40:19 | ... = ... | parameters.rb:40:15:40:15 | e |
+| parameters.rb:40:15:40:15 | e | parameters.rb:40:15:40:15 | e |
 | parameters.rb:42:3:42:18 | phi | parameters.rb:40:15:40:15 | e |
 | parameters.rb:45:1:47:3 | self (dup_underscore) | parameters.rb:45:1:47:3 | self |
 | parameters.rb:45:20:45:20 | _ | parameters.rb:45:20:45:20 | _ |
 | parameters.rb:49:1:51:3 | self (tuples) | parameters.rb:49:1:51:3 | self |
 | parameters.rb:49:13:49:13 | a | parameters.rb:49:13:49:13 | a |
 | parameters.rb:49:15:49:15 | b | parameters.rb:49:15:49:15 | b |
-| parameters.rb:53:1:53:6 | ... = ... | parameters.rb:53:1:53:1 | x |
+| parameters.rb:53:1:53:1 | x | parameters.rb:53:1:53:1 | x |
 | parameters.rb:54:9:57:3 | <captured entry> self | parameters.rb:1:1:62:1 | self |
 | parameters.rb:54:9:57:3 | <captured entry> x | parameters.rb:53:1:53:1 | x |
 | parameters.rb:54:14:54:14 | y | parameters.rb:54:14:54:14 | y |
-| parameters.rb:54:19:54:23 | ... = ... | parameters.rb:53:1:53:1 | x |
+| parameters.rb:54:19:54:19 | x | parameters.rb:53:1:53:1 | x |
 | parameters.rb:55:4:55:9 | phi | parameters.rb:53:1:53:1 | x |
 | parameters.rb:59:1:61:3 | self (tuples_nested) | parameters.rb:59:1:61:3 | self |
 | parameters.rb:59:20:59:20 | a | parameters.rb:59:20:59:20 | a |
@@ -88,80 +88,80 @@ definition
 | parameters.rb:59:25:59:25 | c | parameters.rb:59:25:59:25 | c |
 | scopes.rb:1:1:49:4 | self (scopes.rb) | scopes.rb:1:1:49:4 | self |
 | scopes.rb:2:9:6:3 | <captured entry> self | scopes.rb:1:1:49:4 | self |
-| scopes.rb:4:4:4:8 | ... = ... | scopes.rb:4:4:4:4 | a |
-| scopes.rb:7:1:7:5 | ... = ... | scopes.rb:7:1:7:1 | a |
+| scopes.rb:4:4:4:4 | a | scopes.rb:4:4:4:4 | a |
+| scopes.rb:7:1:7:1 | a | scopes.rb:7:1:7:1 | a |
 | scopes.rb:9:1:18:3 | <captured exit> a | scopes.rb:7:1:7:1 | a |
 | scopes.rb:9:9:18:3 | <captured entry> a | scopes.rb:7:1:7:1 | a |
 | scopes.rb:9:9:18:3 | <captured entry> self | scopes.rb:1:1:49:4 | self |
-| scopes.rb:11:4:11:9 | ... = ... | scopes.rb:7:1:7:1 | a |
-| scopes.rb:13:4:13:4 | ... = ... | scopes.rb:7:1:7:1 | a |
-| scopes.rb:13:7:13:7 | ... = ... | scopes.rb:13:7:13:7 | b |
-| scopes.rb:13:10:13:15 | ... = ... | scopes.rb:13:10:13:15 | __synth__0__1 |
-| scopes.rb:13:11:13:11 | ... = ... | scopes.rb:13:11:13:11 | c |
-| scopes.rb:13:14:13:14 | ... = ... | scopes.rb:13:14:13:14 | d |
-| scopes.rb:13:19:13:32 | ... = ... | scopes.rb:13:4:13:32 | __synth__0 |
+| scopes.rb:11:4:11:4 | a | scopes.rb:7:1:7:1 | a |
+| scopes.rb:13:4:13:4 | a | scopes.rb:7:1:7:1 | a |
+| scopes.rb:13:7:13:7 | b | scopes.rb:13:7:13:7 | b |
+| scopes.rb:13:10:13:15 | __synth__0__1 | scopes.rb:13:10:13:15 | __synth__0__1 |
+| scopes.rb:13:11:13:11 | c | scopes.rb:13:11:13:11 | c |
+| scopes.rb:13:14:13:14 | d | scopes.rb:13:14:13:14 | d |
+| scopes.rb:13:19:13:32 | __synth__0 | scopes.rb:13:4:13:32 | __synth__0 |
 | scopes.rb:26:1:26:12 | self (A) | scopes.rb:26:1:26:12 | self |
-| scopes.rb:27:1:27:5 | ... = ... | scopes.rb:27:1:27:1 | x |
+| scopes.rb:27:1:27:1 | x | scopes.rb:27:1:27:1 | x |
 | scopes.rb:28:1:30:3 | self (B) | scopes.rb:28:1:30:3 | self |
-| scopes.rb:29:3:29:7 | ... = ... | scopes.rb:29:3:29:3 | x |
-| scopes.rb:32:3:32:7 | ... = ... | scopes.rb:32:3:32:3 | x |
+| scopes.rb:29:3:29:3 | x | scopes.rb:29:3:29:3 | x |
+| scopes.rb:32:3:32:3 | x | scopes.rb:32:3:32:3 | x |
 | scopes.rb:34:1:36:3 | self (C) | scopes.rb:34:1:36:3 | self |
-| scopes.rb:35:3:35:7 | ... = ... | scopes.rb:35:3:35:3 | x |
+| scopes.rb:35:3:35:3 | x | scopes.rb:35:3:35:3 | x |
 | scopes.rb:41:1:49:3 | self (M) | scopes.rb:41:1:49:3 | self |
-| scopes.rb:42:2:42:9 | ... = ... | scopes.rb:42:2:42:4 | var |
-| scopes.rb:43:2:43:13 | ... = ... | scopes.rb:43:2:43:4 | foo |
-| scopes.rb:46:5:46:13 | ... = ... | scopes.rb:46:5:46:8 | var2 |
+| scopes.rb:42:2:42:4 | var | scopes.rb:42:2:42:4 | var |
+| scopes.rb:43:2:43:4 | foo | scopes.rb:43:2:43:4 | foo |
+| scopes.rb:46:5:46:8 | var2 | scopes.rb:46:5:46:8 | var2 |
 | ssa.rb:1:1:16:3 | self (m) | ssa.rb:1:1:16:3 | self |
 | ssa.rb:1:7:1:7 | b | ssa.rb:1:7:1:7 | b |
-| ssa.rb:2:3:2:7 | ... = ... | ssa.rb:2:3:2:3 | i |
+| ssa.rb:2:3:2:3 | i | ssa.rb:2:3:2:3 | i |
 | ssa.rb:5:3:13:5 | phi | ssa.rb:2:3:2:3 | i |
-| ssa.rb:6:5:6:9 | ... = ... | ssa.rb:2:3:2:3 | i |
-| ssa.rb:10:5:10:9 | ... = ... | ssa.rb:2:3:2:3 | i |
+| ssa.rb:6:5:6:5 | i | ssa.rb:2:3:2:3 | i |
+| ssa.rb:10:5:10:5 | i | ssa.rb:2:3:2:3 | i |
 | ssa.rb:18:1:23:3 | self (m1) | ssa.rb:18:1:23:3 | self |
 | ssa.rb:18:8:18:8 | x | ssa.rb:18:8:18:8 | x |
 | ssa.rb:19:9:19:9 | phi | ssa.rb:18:8:18:8 | x |
-| ssa.rb:21:5:21:10 | ... = ... | ssa.rb:18:8:18:8 | x |
+| ssa.rb:21:5:21:5 | x | ssa.rb:18:8:18:8 | x |
 | ssa.rb:25:1:30:3 | <uninitialized> | ssa.rb:26:7:26:10 | elem |
 | ssa.rb:25:1:30:3 | self (m2) | ssa.rb:25:1:30:3 | self |
 | ssa.rb:25:8:25:15 | elements | ssa.rb:25:8:25:15 | elements |
-| ssa.rb:26:3:28:5 | ... = ... | ssa.rb:26:7:26:10 | elem |
 | ssa.rb:26:3:28:5 | <captured entry> self | ssa.rb:25:1:30:3 | self |
 | ssa.rb:26:3:28:5 | <captured exit> elem | ssa.rb:26:7:26:10 | elem |
 | ssa.rb:26:3:28:5 | __synth__0__1 | ssa.rb:26:3:28:5 | __synth__0__1 |
+| ssa.rb:26:7:26:10 | elem | ssa.rb:26:7:26:10 | elem |
 | ssa.rb:32:1:36:3 | self (m3) | ssa.rb:32:1:36:3 | self |
 | ssa.rb:33:16:35:5 | <captured entry> self | ssa.rb:32:1:36:3 | self |
 | ssa.rb:33:20:33:20 | x | ssa.rb:33:20:33:20 | x |
 | ssa.rb:38:1:42:3 | self (m4) | ssa.rb:38:1:42:3 | self |
-| ssa.rb:40:3:40:9 | ... = ... | ssa.rb:40:3:40:4 | m3 |
+| ssa.rb:40:3:40:4 | m3 | ssa.rb:40:3:40:4 | m3 |
 | ssa.rb:44:1:47:3 | <uninitialized> | ssa.rb:45:3:45:3 | x |
 | ssa.rb:44:1:47:3 | self (m5) | ssa.rb:44:1:47:3 | self |
 | ssa.rb:44:8:44:8 | b | ssa.rb:44:8:44:8 | b |
-| ssa.rb:45:3:45:7 | ... = ... | ssa.rb:45:3:45:3 | x |
+| ssa.rb:45:3:45:3 | x | ssa.rb:45:3:45:3 | x |
 | ssa.rb:45:3:45:12 | phi | ssa.rb:45:3:45:3 | x |
 | ssa.rb:49:1:51:3 | <uninitialized> | ssa.rb:49:14:49:14 | y |
 | ssa.rb:49:1:51:3 | self (m6) | ssa.rb:49:1:51:3 | self |
-| ssa.rb:49:14:49:19 | ... = ... | ssa.rb:49:14:49:14 | y |
+| ssa.rb:49:14:49:14 | y | ssa.rb:49:14:49:14 | y |
 | ssa.rb:50:3:50:8 | phi | ssa.rb:49:14:49:14 | y |
 | ssa.rb:53:1:56:3 | self (m7) | ssa.rb:53:1:56:3 | self |
 | ssa.rb:53:8:53:10 | foo | ssa.rb:53:8:53:10 | foo |
-| ssa.rb:54:3:54:11 | ... = ... | ssa.rb:54:3:54:3 | x |
+| ssa.rb:54:3:54:3 | x | ssa.rb:54:3:54:3 | x |
 | ssa.rb:58:1:62:3 | self (m8) | ssa.rb:58:1:62:3 | self |
-| ssa.rb:59:3:59:8 | ... = ... | ssa.rb:59:3:59:3 | x |
-| ssa.rb:60:3:60:9 | ... = ... | ssa.rb:59:3:59:3 | x |
+| ssa.rb:59:3:59:3 | x | ssa.rb:59:3:59:3 | x |
+| ssa.rb:60:3:60:3 | x | ssa.rb:59:3:59:3 | x |
 | ssa.rb:64:1:72:3 | self (m9) | ssa.rb:64:1:72:3 | self |
 | ssa.rb:64:8:64:8 | a | ssa.rb:64:8:64:8 | a |
-| ssa.rb:65:3:65:15 | ... = ... | ssa.rb:65:3:65:10 | captured |
+| ssa.rb:65:3:65:10 | captured | ssa.rb:65:3:65:10 | captured |
 | ssa.rb:66:3:70:5 | <captured exit> captured | ssa.rb:65:3:65:10 | captured |
 | ssa.rb:66:11:70:5 | <captured entry> captured | ssa.rb:65:3:65:10 | captured |
 | ssa.rb:66:11:70:5 | <captured entry> self | ssa.rb:64:1:72:3 | self |
 | ssa.rb:66:15:66:15 | a | ssa.rb:66:15:66:15 | a |
-| ssa.rb:69:5:69:17 | ... = ... | ssa.rb:65:3:65:10 | captured |
+| ssa.rb:69:5:69:12 | captured | ssa.rb:65:3:65:10 | captured |
 | ssa.rb:74:1:79:3 | self (m10) | ssa.rb:74:1:79:3 | self |
-| ssa.rb:75:3:75:14 | ... = ... | ssa.rb:75:3:75:10 | captured |
+| ssa.rb:75:3:75:10 | captured | ssa.rb:75:3:75:10 | captured |
 | ssa.rb:76:7:78:5 | <captured entry> captured | ssa.rb:75:3:75:10 | captured |
 | ssa.rb:76:7:78:5 | <captured entry> self | ssa.rb:74:1:79:3 | self |
 | ssa.rb:81:1:88:3 | self (m11) | ssa.rb:81:1:88:3 | self |
-| ssa.rb:82:3:82:14 | ... = ... | ssa.rb:82:3:82:10 | captured |
+| ssa.rb:82:3:82:10 | captured | ssa.rb:82:3:82:10 | captured |
 | ssa.rb:83:7:87:5 | <captured entry> self | ssa.rb:81:1:88:3 | self |
 | ssa.rb:84:10:86:8 | <captured entry> captured | ssa.rb:82:3:82:10 | captured |
 | ssa.rb:84:10:86:8 | <captured entry> self | ssa.rb:81:1:88:3 | self |
@@ -170,7 +170,7 @@ definition
 | ssa.rb:90:13:90:14 | b2 | ssa.rb:90:13:90:14 | b2 |
 | ssa.rb:90:17:90:18 | b3 | ssa.rb:90:17:90:18 | b3 |
 | ssa.rb:90:21:90:22 | b4 | ssa.rb:90:21:90:22 | b4 |
-| ssa.rb:91:3:91:7 | ... = ... | ssa.rb:91:3:91:3 | x |
+| ssa.rb:91:3:91:3 | x | ssa.rb:91:3:91:3 | x |
 read
 | class_variables.rb:1:1:29:4 | self (class_variables.rb) | class_variables.rb:1:1:29:4 | self | class_variables.rb:3:1:3:5 | self |
 | class_variables.rb:5:1:7:3 | self (print) | class_variables.rb:5:1:7:3 | self | class_variables.rb:6:2:6:6 | self |
@@ -199,20 +199,20 @@ read
 | instance_variables.rb:38:4:40:6 | self (y) | instance_variables.rb:38:4:40:6 | self | instance_variables.rb:39:6:39:7 | self |
 | nested_scopes.rb:1:1:3:3 | self (a) | nested_scopes.rb:1:1:3:3 | self | nested_scopes.rb:2:3:2:17 | self |
 | nested_scopes.rb:4:1:39:3 | self (C) | nested_scopes.rb:4:1:39:3 | self | nested_scopes.rb:38:3:38:8 | self |
-| nested_scopes.rb:5:3:5:7 | ... = ... | nested_scopes.rb:5:3:5:3 | a | nested_scopes.rb:38:8:38:8 | a |
+| nested_scopes.rb:5:3:5:3 | a | nested_scopes.rb:5:3:5:3 | a | nested_scopes.rb:38:8:38:8 | a |
 | nested_scopes.rb:6:3:37:5 | self (M) | nested_scopes.rb:6:3:37:5 | self | nested_scopes.rb:36:5:36:10 | self |
-| nested_scopes.rb:7:5:7:9 | ... = ... | nested_scopes.rb:7:5:7:5 | a | nested_scopes.rb:36:10:36:10 | a |
+| nested_scopes.rb:7:5:7:5 | a | nested_scopes.rb:7:5:7:5 | a | nested_scopes.rb:36:10:36:10 | a |
 | nested_scopes.rb:8:5:35:7 | self (N) | nested_scopes.rb:8:5:35:7 | self | nested_scopes.rb:27:11:27:14 | self |
 | nested_scopes.rb:8:5:35:7 | self (N) | nested_scopes.rb:8:5:35:7 | self | nested_scopes.rb:30:16:30:19 | self |
 | nested_scopes.rb:8:5:35:7 | self (N) | nested_scopes.rb:8:5:35:7 | self | nested_scopes.rb:34:7:34:12 | self |
-| nested_scopes.rb:9:7:9:11 | ... = ... | nested_scopes.rb:9:7:9:7 | a | nested_scopes.rb:34:12:34:12 | a |
+| nested_scopes.rb:9:7:9:7 | a | nested_scopes.rb:9:7:9:7 | a | nested_scopes.rb:34:12:34:12 | a |
 | nested_scopes.rb:10:7:26:9 | self (D) | nested_scopes.rb:10:7:26:9 | self | nested_scopes.rb:25:9:25:14 | self |
-| nested_scopes.rb:11:9:11:13 | ... = ... | nested_scopes.rb:11:9:11:9 | a | nested_scopes.rb:25:14:25:14 | a |
+| nested_scopes.rb:11:9:11:9 | a | nested_scopes.rb:11:9:11:9 | a | nested_scopes.rb:25:14:25:14 | a |
 | nested_scopes.rb:12:9:21:11 | self (show_a) | nested_scopes.rb:12:9:21:11 | self | nested_scopes.rb:14:11:14:16 | self |
-| nested_scopes.rb:13:11:13:15 | ... = ... | nested_scopes.rb:13:11:13:11 | a | nested_scopes.rb:14:16:14:16 | a |
-| nested_scopes.rb:13:11:13:15 | ... = ... | nested_scopes.rb:13:11:13:11 | a | nested_scopes.rb:15:11:15:11 | a |
+| nested_scopes.rb:13:11:13:11 | a | nested_scopes.rb:13:11:13:11 | a | nested_scopes.rb:14:16:14:16 | a |
+| nested_scopes.rb:13:11:13:11 | a | nested_scopes.rb:13:11:13:11 | a | nested_scopes.rb:15:11:15:11 | a |
 | nested_scopes.rb:15:23:15:23 | a | nested_scopes.rb:15:23:15:23 | a | nested_scopes.rb:16:13:16:13 | a |
-| nested_scopes.rb:17:15:17:19 | ... = ... | nested_scopes.rb:16:29:16:29 | a | nested_scopes.rb:18:15:18:15 | a |
+| nested_scopes.rb:17:15:17:15 | a | nested_scopes.rb:16:29:16:29 | a | nested_scopes.rb:18:15:18:15 | a |
 | nested_scopes.rb:18:23:18:36 | <captured entry> a | nested_scopes.rb:16:29:16:29 | a | nested_scopes.rb:18:34:18:34 | a |
 | nested_scopes.rb:18:23:18:36 | <captured entry> self | nested_scopes.rb:12:9:21:11 | self | nested_scopes.rb:18:29:18:34 | self |
 | nested_scopes.rb:22:9:24:11 | self (show_a2) | nested_scopes.rb:22:9:24:11 | self | nested_scopes.rb:23:11:23:16 | self |
@@ -220,12 +220,12 @@ read
 | nested_scopes.rb:27:7:29:9 | self (show) | nested_scopes.rb:27:7:29:9 | self | nested_scopes.rb:28:11:28:16 | self |
 | nested_scopes.rb:27:7:29:9 | self (show) | nested_scopes.rb:27:7:29:9 | self | nested_scopes.rb:28:16:28:16 | self |
 | nested_scopes.rb:30:16:30:19 | self (class << ...) | nested_scopes.rb:30:7:33:9 | self | nested_scopes.rb:32:11:32:16 | self |
-| nested_scopes.rb:31:11:31:16 | ... = ... | nested_scopes.rb:31:11:31:11 | a | nested_scopes.rb:32:16:32:16 | a |
-| nested_scopes.rb:40:1:40:18 | ... = ... | nested_scopes.rb:40:1:40:1 | d | nested_scopes.rb:41:1:41:1 | d |
+| nested_scopes.rb:31:11:31:11 | a | nested_scopes.rb:31:11:31:11 | a | nested_scopes.rb:32:16:32:16 | a |
+| nested_scopes.rb:40:1:40:1 | d | nested_scopes.rb:40:1:40:1 | d | nested_scopes.rb:41:1:41:1 | d |
 | parameters.rb:1:9:5:3 | <captured entry> self | parameters.rb:1:1:62:1 | self | parameters.rb:3:4:3:9 | self |
 | parameters.rb:1:9:5:3 | <captured entry> self | parameters.rb:1:1:62:1 | self | parameters.rb:4:4:4:9 | self |
 | parameters.rb:1:14:1:14 | x | parameters.rb:1:14:1:14 | x | parameters.rb:3:9:3:9 | x |
-| parameters.rb:2:4:2:8 | ... = ... | parameters.rb:1:18:1:18 | y | parameters.rb:4:9:4:9 | y |
+| parameters.rb:2:4:2:4 | y | parameters.rb:1:18:1:18 | y | parameters.rb:4:9:4:9 | y |
 | parameters.rb:7:1:13:3 | self (order_pizza) | parameters.rb:7:1:13:3 | self | parameters.rb:9:5:9:33 | self |
 | parameters.rb:7:1:13:3 | self (order_pizza) | parameters.rb:7:1:13:3 | self | parameters.rb:11:5:11:49 | self |
 | parameters.rb:7:17:7:22 | client | parameters.rb:7:17:7:22 | client | parameters.rb:9:25:9:30 | client |
@@ -269,8 +269,8 @@ read
 | scopes.rb:2:9:6:3 | <captured entry> self | scopes.rb:1:1:49:4 | self | scopes.rb:3:4:3:9 | self |
 | scopes.rb:2:9:6:3 | <captured entry> self | scopes.rb:1:1:49:4 | self | scopes.rb:3:9:3:9 | self |
 | scopes.rb:2:9:6:3 | <captured entry> self | scopes.rb:1:1:49:4 | self | scopes.rb:5:4:5:9 | self |
-| scopes.rb:4:4:4:8 | ... = ... | scopes.rb:4:4:4:4 | a | scopes.rb:5:9:5:9 | a |
-| scopes.rb:7:1:7:5 | ... = ... | scopes.rb:7:1:7:1 | a | scopes.rb:8:6:8:6 | a |
+| scopes.rb:4:4:4:4 | a | scopes.rb:4:4:4:4 | a | scopes.rb:5:9:5:9 | a |
+| scopes.rb:7:1:7:1 | a | scopes.rb:7:1:7:1 | a | scopes.rb:8:6:8:6 | a |
 | scopes.rb:9:9:18:3 | <captured entry> a | scopes.rb:7:1:7:1 | a | scopes.rb:10:9:10:9 | a |
 | scopes.rb:9:9:18:3 | <captured entry> a | scopes.rb:7:1:7:1 | a | scopes.rb:11:4:11:4 | a |
 | scopes.rb:9:9:18:3 | <captured entry> self | scopes.rb:1:1:49:4 | self | scopes.rb:10:4:10:9 | self |
@@ -279,24 +279,24 @@ read
 | scopes.rb:9:9:18:3 | <captured entry> self | scopes.rb:1:1:49:4 | self | scopes.rb:15:4:15:9 | self |
 | scopes.rb:9:9:18:3 | <captured entry> self | scopes.rb:1:1:49:4 | self | scopes.rb:16:4:16:9 | self |
 | scopes.rb:9:9:18:3 | <captured entry> self | scopes.rb:1:1:49:4 | self | scopes.rb:17:4:17:9 | self |
-| scopes.rb:11:4:11:9 | ... = ... | scopes.rb:7:1:7:1 | a | scopes.rb:12:9:12:9 | a |
-| scopes.rb:13:4:13:4 | ... = ... | scopes.rb:7:1:7:1 | a | scopes.rb:14:9:14:9 | a |
-| scopes.rb:13:7:13:7 | ... = ... | scopes.rb:13:7:13:7 | b | scopes.rb:15:9:15:9 | b |
-| scopes.rb:13:10:13:15 | ... = ... | scopes.rb:13:10:13:15 | __synth__0__1 | scopes.rb:13:11:13:11 | __synth__0__1 |
-| scopes.rb:13:10:13:15 | ... = ... | scopes.rb:13:10:13:15 | __synth__0__1 | scopes.rb:13:14:13:14 | __synth__0__1 |
-| scopes.rb:13:11:13:11 | ... = ... | scopes.rb:13:11:13:11 | c | scopes.rb:16:9:16:9 | c |
-| scopes.rb:13:14:13:14 | ... = ... | scopes.rb:13:14:13:14 | d | scopes.rb:17:9:17:9 | d |
-| scopes.rb:13:19:13:32 | ... = ... | scopes.rb:13:4:13:32 | __synth__0 | scopes.rb:13:4:13:4 | __synth__0 |
-| scopes.rb:13:19:13:32 | ... = ... | scopes.rb:13:4:13:32 | __synth__0 | scopes.rb:13:7:13:7 | __synth__0 |
-| scopes.rb:13:19:13:32 | ... = ... | scopes.rb:13:4:13:32 | __synth__0 | scopes.rb:13:10:13:15 | __synth__0 |
-| scopes.rb:27:1:27:5 | ... = ... | scopes.rb:27:1:27:1 | x | scopes.rb:28:8:28:8 | x |
-| scopes.rb:27:1:27:5 | ... = ... | scopes.rb:27:1:27:1 | x | scopes.rb:31:10:31:10 | x |
-| scopes.rb:27:1:27:5 | ... = ... | scopes.rb:27:1:27:1 | x | scopes.rb:34:7:34:7 | x |
-| scopes.rb:27:1:27:5 | ... = ... | scopes.rb:27:1:27:1 | x | scopes.rb:34:14:34:14 | x |
-| scopes.rb:27:1:27:5 | ... = ... | scopes.rb:27:1:27:1 | x | scopes.rb:37:5:37:5 | x |
+| scopes.rb:11:4:11:4 | a | scopes.rb:7:1:7:1 | a | scopes.rb:12:9:12:9 | a |
+| scopes.rb:13:4:13:4 | a | scopes.rb:7:1:7:1 | a | scopes.rb:14:9:14:9 | a |
+| scopes.rb:13:7:13:7 | b | scopes.rb:13:7:13:7 | b | scopes.rb:15:9:15:9 | b |
+| scopes.rb:13:10:13:15 | __synth__0__1 | scopes.rb:13:10:13:15 | __synth__0__1 | scopes.rb:13:11:13:11 | __synth__0__1 |
+| scopes.rb:13:10:13:15 | __synth__0__1 | scopes.rb:13:10:13:15 | __synth__0__1 | scopes.rb:13:14:13:14 | __synth__0__1 |
+| scopes.rb:13:11:13:11 | c | scopes.rb:13:11:13:11 | c | scopes.rb:16:9:16:9 | c |
+| scopes.rb:13:14:13:14 | d | scopes.rb:13:14:13:14 | d | scopes.rb:17:9:17:9 | d |
+| scopes.rb:13:19:13:32 | __synth__0 | scopes.rb:13:4:13:32 | __synth__0 | scopes.rb:13:4:13:4 | __synth__0 |
+| scopes.rb:13:19:13:32 | __synth__0 | scopes.rb:13:4:13:32 | __synth__0 | scopes.rb:13:7:13:7 | __synth__0 |
+| scopes.rb:13:19:13:32 | __synth__0 | scopes.rb:13:4:13:32 | __synth__0 | scopes.rb:13:10:13:15 | __synth__0 |
+| scopes.rb:27:1:27:1 | x | scopes.rb:27:1:27:1 | x | scopes.rb:28:8:28:8 | x |
+| scopes.rb:27:1:27:1 | x | scopes.rb:27:1:27:1 | x | scopes.rb:31:10:31:10 | x |
+| scopes.rb:27:1:27:1 | x | scopes.rb:27:1:27:1 | x | scopes.rb:34:7:34:7 | x |
+| scopes.rb:27:1:27:1 | x | scopes.rb:27:1:27:1 | x | scopes.rb:34:14:34:14 | x |
+| scopes.rb:27:1:27:1 | x | scopes.rb:27:1:27:1 | x | scopes.rb:37:5:37:5 | x |
 | scopes.rb:41:1:49:3 | self (M) | scopes.rb:41:1:49:3 | self | scopes.rb:45:5:45:7 | self |
-| scopes.rb:42:2:42:9 | ... = ... | scopes.rb:42:2:42:4 | var | scopes.rb:44:5:44:7 | var |
-| scopes.rb:46:5:46:13 | ... = ... | scopes.rb:46:5:46:8 | var2 | scopes.rb:47:5:47:8 | var2 |
+| scopes.rb:42:2:42:4 | var | scopes.rb:42:2:42:4 | var | scopes.rb:44:5:44:7 | var |
+| scopes.rb:46:5:46:8 | var2 | scopes.rb:46:5:46:8 | var2 | scopes.rb:47:5:47:8 | var2 |
 | ssa.rb:1:1:16:3 | self (m) | ssa.rb:1:1:16:3 | self | ssa.rb:3:3:3:8 | self |
 | ssa.rb:1:1:16:3 | self (m) | ssa.rb:1:1:16:3 | self | ssa.rb:4:3:4:12 | self |
 | ssa.rb:1:1:16:3 | self (m) | ssa.rb:1:1:16:3 | self | ssa.rb:7:5:7:10 | self |
@@ -305,29 +305,29 @@ read
 | ssa.rb:1:1:16:3 | self (m) | ssa.rb:1:1:16:3 | self | ssa.rb:12:5:12:14 | self |
 | ssa.rb:1:1:16:3 | self (m) | ssa.rb:1:1:16:3 | self | ssa.rb:15:3:15:8 | self |
 | ssa.rb:1:7:1:7 | b | ssa.rb:1:7:1:7 | b | ssa.rb:5:6:5:6 | b |
-| ssa.rb:2:3:2:7 | ... = ... | ssa.rb:2:3:2:3 | i | ssa.rb:3:8:3:8 | i |
-| ssa.rb:2:3:2:7 | ... = ... | ssa.rb:2:3:2:3 | i | ssa.rb:4:8:4:8 | i |
+| ssa.rb:2:3:2:3 | i | ssa.rb:2:3:2:3 | i | ssa.rb:3:8:3:8 | i |
+| ssa.rb:2:3:2:3 | i | ssa.rb:2:3:2:3 | i | ssa.rb:4:8:4:8 | i |
 | ssa.rb:5:3:13:5 | phi | ssa.rb:2:3:2:3 | i | ssa.rb:15:8:15:8 | i |
-| ssa.rb:6:5:6:9 | ... = ... | ssa.rb:2:3:2:3 | i | ssa.rb:7:10:7:10 | i |
-| ssa.rb:6:5:6:9 | ... = ... | ssa.rb:2:3:2:3 | i | ssa.rb:8:10:8:10 | i |
-| ssa.rb:10:5:10:9 | ... = ... | ssa.rb:2:3:2:3 | i | ssa.rb:11:10:11:10 | i |
-| ssa.rb:10:5:10:9 | ... = ... | ssa.rb:2:3:2:3 | i | ssa.rb:12:10:12:10 | i |
+| ssa.rb:6:5:6:5 | i | ssa.rb:2:3:2:3 | i | ssa.rb:7:10:7:10 | i |
+| ssa.rb:6:5:6:5 | i | ssa.rb:2:3:2:3 | i | ssa.rb:8:10:8:10 | i |
+| ssa.rb:10:5:10:5 | i | ssa.rb:2:3:2:3 | i | ssa.rb:11:10:11:10 | i |
+| ssa.rb:10:5:10:5 | i | ssa.rb:2:3:2:3 | i | ssa.rb:12:10:12:10 | i |
 | ssa.rb:18:1:23:3 | self (m1) | ssa.rb:18:1:23:3 | self | ssa.rb:20:5:20:10 | self |
 | ssa.rb:19:9:19:9 | phi | ssa.rb:18:8:18:8 | x | ssa.rb:19:9:19:9 | x |
 | ssa.rb:19:9:19:9 | phi | ssa.rb:18:8:18:8 | x | ssa.rb:20:10:20:10 | x |
 | ssa.rb:19:9:19:9 | phi | ssa.rb:18:8:18:8 | x | ssa.rb:21:5:21:5 | x |
 | ssa.rb:25:1:30:3 | self (m2) | ssa.rb:25:1:30:3 | self | ssa.rb:29:3:29:11 | self |
 | ssa.rb:25:8:25:15 | elements | ssa.rb:25:8:25:15 | elements | ssa.rb:26:15:26:22 | elements |
-| ssa.rb:26:3:28:5 | ... = ... | ssa.rb:26:7:26:10 | elem | ssa.rb:27:10:27:13 | elem |
 | ssa.rb:26:3:28:5 | <captured entry> self | ssa.rb:25:1:30:3 | self | ssa.rb:27:5:27:13 | self |
 | ssa.rb:26:3:28:5 | <captured exit> elem | ssa.rb:26:7:26:10 | elem | ssa.rb:29:8:29:11 | elem |
 | ssa.rb:26:3:28:5 | __synth__0__1 | ssa.rb:26:3:28:5 | __synth__0__1 | ssa.rb:26:3:28:5 | __synth__0__1 |
+| ssa.rb:26:7:26:10 | elem | ssa.rb:26:7:26:10 | elem | ssa.rb:27:10:27:13 | elem |
 | ssa.rb:33:16:35:5 | <captured entry> self | ssa.rb:32:1:36:3 | self | ssa.rb:34:5:34:10 | self |
 | ssa.rb:33:20:33:20 | x | ssa.rb:33:20:33:20 | x | ssa.rb:34:10:34:10 | x |
 | ssa.rb:38:1:42:3 | self (m4) | ssa.rb:38:1:42:3 | self | ssa.rb:39:3:39:9 | self |
 | ssa.rb:38:1:42:3 | self (m4) | ssa.rb:38:1:42:3 | self | ssa.rb:39:8:39:9 | self |
 | ssa.rb:38:1:42:3 | self (m4) | ssa.rb:38:1:42:3 | self | ssa.rb:41:3:41:13 | self |
-| ssa.rb:40:3:40:9 | ... = ... | ssa.rb:40:3:40:4 | m3 | ssa.rb:41:8:41:9 | m3 |
+| ssa.rb:40:3:40:4 | m3 | ssa.rb:40:3:40:4 | m3 | ssa.rb:41:8:41:9 | m3 |
 | ssa.rb:44:1:47:3 | self (m5) | ssa.rb:44:1:47:3 | self | ssa.rb:46:3:46:8 | self |
 | ssa.rb:44:8:44:8 | b | ssa.rb:44:8:44:8 | b | ssa.rb:45:12:45:12 | b |
 | ssa.rb:45:3:45:12 | phi | ssa.rb:45:3:45:3 | x | ssa.rb:46:8:46:8 | x |
@@ -335,10 +335,10 @@ read
 | ssa.rb:50:3:50:8 | phi | ssa.rb:49:14:49:14 | y | ssa.rb:50:8:50:8 | y |
 | ssa.rb:53:1:56:3 | self (m7) | ssa.rb:53:1:56:3 | self | ssa.rb:55:3:55:8 | self |
 | ssa.rb:53:8:53:10 | foo | ssa.rb:53:8:53:10 | foo | ssa.rb:54:7:54:9 | foo |
-| ssa.rb:54:3:54:11 | ... = ... | ssa.rb:54:3:54:3 | x | ssa.rb:55:8:55:8 | x |
+| ssa.rb:54:3:54:3 | x | ssa.rb:54:3:54:3 | x | ssa.rb:55:8:55:8 | x |
 | ssa.rb:58:1:62:3 | self (m8) | ssa.rb:58:1:62:3 | self | ssa.rb:61:3:61:8 | self |
-| ssa.rb:59:3:59:8 | ... = ... | ssa.rb:59:3:59:3 | x | ssa.rb:60:3:60:3 | x |
-| ssa.rb:60:3:60:9 | ... = ... | ssa.rb:59:3:59:3 | x | ssa.rb:61:8:61:8 | x |
+| ssa.rb:59:3:59:3 | x | ssa.rb:59:3:59:3 | x | ssa.rb:60:3:60:3 | x |
+| ssa.rb:60:3:60:3 | x | ssa.rb:59:3:59:3 | x | ssa.rb:61:8:61:8 | x |
 | ssa.rb:64:1:72:3 | self (m9) | ssa.rb:64:1:72:3 | self | ssa.rb:71:3:71:15 | self |
 | ssa.rb:64:8:64:8 | a | ssa.rb:64:8:64:8 | a | ssa.rb:66:3:66:3 | a |
 | ssa.rb:66:3:70:5 | <captured exit> captured | ssa.rb:65:3:65:10 | captured | ssa.rb:71:8:71:15 | captured |
@@ -362,10 +362,10 @@ read
 | ssa.rb:90:13:90:14 | b2 | ssa.rb:90:13:90:14 | b2 | ssa.rb:94:10:94:11 | b2 |
 | ssa.rb:90:17:90:18 | b3 | ssa.rb:90:17:90:18 | b3 | ssa.rb:98:7:98:8 | b3 |
 | ssa.rb:90:21:90:22 | b4 | ssa.rb:90:21:90:22 | b4 | ssa.rb:100:10:100:11 | b4 |
-| ssa.rb:91:3:91:7 | ... = ... | ssa.rb:91:3:91:3 | x | ssa.rb:93:10:93:10 | x |
-| ssa.rb:91:3:91:7 | ... = ... | ssa.rb:91:3:91:3 | x | ssa.rb:95:10:95:10 | x |
-| ssa.rb:91:3:91:7 | ... = ... | ssa.rb:91:3:91:3 | x | ssa.rb:99:10:99:10 | x |
-| ssa.rb:91:3:91:7 | ... = ... | ssa.rb:91:3:91:3 | x | ssa.rb:101:10:101:10 | x |
+| ssa.rb:91:3:91:3 | x | ssa.rb:91:3:91:3 | x | ssa.rb:93:10:93:10 | x |
+| ssa.rb:91:3:91:3 | x | ssa.rb:91:3:91:3 | x | ssa.rb:95:10:95:10 | x |
+| ssa.rb:91:3:91:3 | x | ssa.rb:91:3:91:3 | x | ssa.rb:99:10:99:10 | x |
+| ssa.rb:91:3:91:3 | x | ssa.rb:91:3:91:3 | x | ssa.rb:101:10:101:10 | x |
 firstRead
 | class_variables.rb:1:1:29:4 | self (class_variables.rb) | class_variables.rb:1:1:29:4 | self | class_variables.rb:3:1:3:5 | self |
 | class_variables.rb:5:1:7:3 | self (print) | class_variables.rb:5:1:7:3 | self | class_variables.rb:6:2:6:6 | self |
@@ -387,28 +387,28 @@ firstRead
 | instance_variables.rb:38:4:40:6 | self (y) | instance_variables.rb:38:4:40:6 | self | instance_variables.rb:39:6:39:7 | self |
 | nested_scopes.rb:1:1:3:3 | self (a) | nested_scopes.rb:1:1:3:3 | self | nested_scopes.rb:2:3:2:17 | self |
 | nested_scopes.rb:4:1:39:3 | self (C) | nested_scopes.rb:4:1:39:3 | self | nested_scopes.rb:38:3:38:8 | self |
-| nested_scopes.rb:5:3:5:7 | ... = ... | nested_scopes.rb:5:3:5:3 | a | nested_scopes.rb:38:8:38:8 | a |
+| nested_scopes.rb:5:3:5:3 | a | nested_scopes.rb:5:3:5:3 | a | nested_scopes.rb:38:8:38:8 | a |
 | nested_scopes.rb:6:3:37:5 | self (M) | nested_scopes.rb:6:3:37:5 | self | nested_scopes.rb:36:5:36:10 | self |
-| nested_scopes.rb:7:5:7:9 | ... = ... | nested_scopes.rb:7:5:7:5 | a | nested_scopes.rb:36:10:36:10 | a |
+| nested_scopes.rb:7:5:7:5 | a | nested_scopes.rb:7:5:7:5 | a | nested_scopes.rb:36:10:36:10 | a |
 | nested_scopes.rb:8:5:35:7 | self (N) | nested_scopes.rb:8:5:35:7 | self | nested_scopes.rb:27:11:27:14 | self |
-| nested_scopes.rb:9:7:9:11 | ... = ... | nested_scopes.rb:9:7:9:7 | a | nested_scopes.rb:34:12:34:12 | a |
+| nested_scopes.rb:9:7:9:7 | a | nested_scopes.rb:9:7:9:7 | a | nested_scopes.rb:34:12:34:12 | a |
 | nested_scopes.rb:10:7:26:9 | self (D) | nested_scopes.rb:10:7:26:9 | self | nested_scopes.rb:25:9:25:14 | self |
-| nested_scopes.rb:11:9:11:13 | ... = ... | nested_scopes.rb:11:9:11:9 | a | nested_scopes.rb:25:14:25:14 | a |
+| nested_scopes.rb:11:9:11:9 | a | nested_scopes.rb:11:9:11:9 | a | nested_scopes.rb:25:14:25:14 | a |
 | nested_scopes.rb:12:9:21:11 | self (show_a) | nested_scopes.rb:12:9:21:11 | self | nested_scopes.rb:14:11:14:16 | self |
-| nested_scopes.rb:13:11:13:15 | ... = ... | nested_scopes.rb:13:11:13:11 | a | nested_scopes.rb:14:16:14:16 | a |
+| nested_scopes.rb:13:11:13:11 | a | nested_scopes.rb:13:11:13:11 | a | nested_scopes.rb:14:16:14:16 | a |
 | nested_scopes.rb:15:23:15:23 | a | nested_scopes.rb:15:23:15:23 | a | nested_scopes.rb:16:13:16:13 | a |
-| nested_scopes.rb:17:15:17:19 | ... = ... | nested_scopes.rb:16:29:16:29 | a | nested_scopes.rb:18:15:18:15 | a |
+| nested_scopes.rb:17:15:17:15 | a | nested_scopes.rb:16:29:16:29 | a | nested_scopes.rb:18:15:18:15 | a |
 | nested_scopes.rb:18:23:18:36 | <captured entry> a | nested_scopes.rb:16:29:16:29 | a | nested_scopes.rb:18:34:18:34 | a |
 | nested_scopes.rb:18:23:18:36 | <captured entry> self | nested_scopes.rb:12:9:21:11 | self | nested_scopes.rb:18:29:18:34 | self |
 | nested_scopes.rb:22:9:24:11 | self (show_a2) | nested_scopes.rb:22:9:24:11 | self | nested_scopes.rb:23:11:23:16 | self |
 | nested_scopes.rb:22:21:22:21 | a | nested_scopes.rb:22:21:22:21 | a | nested_scopes.rb:23:16:23:16 | a |
 | nested_scopes.rb:27:7:29:9 | self (show) | nested_scopes.rb:27:7:29:9 | self | nested_scopes.rb:28:11:28:16 | self |
 | nested_scopes.rb:30:16:30:19 | self (class << ...) | nested_scopes.rb:30:7:33:9 | self | nested_scopes.rb:32:11:32:16 | self |
-| nested_scopes.rb:31:11:31:16 | ... = ... | nested_scopes.rb:31:11:31:11 | a | nested_scopes.rb:32:16:32:16 | a |
-| nested_scopes.rb:40:1:40:18 | ... = ... | nested_scopes.rb:40:1:40:1 | d | nested_scopes.rb:41:1:41:1 | d |
+| nested_scopes.rb:31:11:31:11 | a | nested_scopes.rb:31:11:31:11 | a | nested_scopes.rb:32:16:32:16 | a |
+| nested_scopes.rb:40:1:40:1 | d | nested_scopes.rb:40:1:40:1 | d | nested_scopes.rb:41:1:41:1 | d |
 | parameters.rb:1:9:5:3 | <captured entry> self | parameters.rb:1:1:62:1 | self | parameters.rb:3:4:3:9 | self |
 | parameters.rb:1:14:1:14 | x | parameters.rb:1:14:1:14 | x | parameters.rb:3:9:3:9 | x |
-| parameters.rb:2:4:2:8 | ... = ... | parameters.rb:1:18:1:18 | y | parameters.rb:4:9:4:9 | y |
+| parameters.rb:2:4:2:4 | y | parameters.rb:1:18:1:18 | y | parameters.rb:4:9:4:9 | y |
 | parameters.rb:7:1:13:3 | self (order_pizza) | parameters.rb:7:1:13:3 | self | parameters.rb:9:5:9:33 | self |
 | parameters.rb:7:1:13:3 | self (order_pizza) | parameters.rb:7:1:13:3 | self | parameters.rb:11:5:11:49 | self |
 | parameters.rb:7:17:7:22 | client | parameters.rb:7:17:7:22 | client | parameters.rb:9:25:9:30 | client |
@@ -447,39 +447,39 @@ firstRead
 | parameters.rb:59:25:59:25 | c | parameters.rb:59:25:59:25 | c | parameters.rb:60:21:60:21 | c |
 | scopes.rb:1:1:49:4 | self (scopes.rb) | scopes.rb:1:1:49:4 | self | scopes.rb:8:1:8:6 | self |
 | scopes.rb:2:9:6:3 | <captured entry> self | scopes.rb:1:1:49:4 | self | scopes.rb:3:4:3:9 | self |
-| scopes.rb:4:4:4:8 | ... = ... | scopes.rb:4:4:4:4 | a | scopes.rb:5:9:5:9 | a |
-| scopes.rb:7:1:7:5 | ... = ... | scopes.rb:7:1:7:1 | a | scopes.rb:8:6:8:6 | a |
+| scopes.rb:4:4:4:4 | a | scopes.rb:4:4:4:4 | a | scopes.rb:5:9:5:9 | a |
+| scopes.rb:7:1:7:1 | a | scopes.rb:7:1:7:1 | a | scopes.rb:8:6:8:6 | a |
 | scopes.rb:9:9:18:3 | <captured entry> a | scopes.rb:7:1:7:1 | a | scopes.rb:10:9:10:9 | a |
 | scopes.rb:9:9:18:3 | <captured entry> self | scopes.rb:1:1:49:4 | self | scopes.rb:10:4:10:9 | self |
-| scopes.rb:11:4:11:9 | ... = ... | scopes.rb:7:1:7:1 | a | scopes.rb:12:9:12:9 | a |
-| scopes.rb:13:4:13:4 | ... = ... | scopes.rb:7:1:7:1 | a | scopes.rb:14:9:14:9 | a |
-| scopes.rb:13:7:13:7 | ... = ... | scopes.rb:13:7:13:7 | b | scopes.rb:15:9:15:9 | b |
-| scopes.rb:13:10:13:15 | ... = ... | scopes.rb:13:10:13:15 | __synth__0__1 | scopes.rb:13:11:13:11 | __synth__0__1 |
-| scopes.rb:13:11:13:11 | ... = ... | scopes.rb:13:11:13:11 | c | scopes.rb:16:9:16:9 | c |
-| scopes.rb:13:14:13:14 | ... = ... | scopes.rb:13:14:13:14 | d | scopes.rb:17:9:17:9 | d |
-| scopes.rb:13:19:13:32 | ... = ... | scopes.rb:13:4:13:32 | __synth__0 | scopes.rb:13:4:13:4 | __synth__0 |
-| scopes.rb:27:1:27:5 | ... = ... | scopes.rb:27:1:27:1 | x | scopes.rb:28:8:28:8 | x |
+| scopes.rb:11:4:11:4 | a | scopes.rb:7:1:7:1 | a | scopes.rb:12:9:12:9 | a |
+| scopes.rb:13:4:13:4 | a | scopes.rb:7:1:7:1 | a | scopes.rb:14:9:14:9 | a |
+| scopes.rb:13:7:13:7 | b | scopes.rb:13:7:13:7 | b | scopes.rb:15:9:15:9 | b |
+| scopes.rb:13:10:13:15 | __synth__0__1 | scopes.rb:13:10:13:15 | __synth__0__1 | scopes.rb:13:11:13:11 | __synth__0__1 |
+| scopes.rb:13:11:13:11 | c | scopes.rb:13:11:13:11 | c | scopes.rb:16:9:16:9 | c |
+| scopes.rb:13:14:13:14 | d | scopes.rb:13:14:13:14 | d | scopes.rb:17:9:17:9 | d |
+| scopes.rb:13:19:13:32 | __synth__0 | scopes.rb:13:4:13:32 | __synth__0 | scopes.rb:13:4:13:4 | __synth__0 |
+| scopes.rb:27:1:27:1 | x | scopes.rb:27:1:27:1 | x | scopes.rb:28:8:28:8 | x |
 | scopes.rb:41:1:49:3 | self (M) | scopes.rb:41:1:49:3 | self | scopes.rb:45:5:45:7 | self |
-| scopes.rb:42:2:42:9 | ... = ... | scopes.rb:42:2:42:4 | var | scopes.rb:44:5:44:7 | var |
-| scopes.rb:46:5:46:13 | ... = ... | scopes.rb:46:5:46:8 | var2 | scopes.rb:47:5:47:8 | var2 |
+| scopes.rb:42:2:42:4 | var | scopes.rb:42:2:42:4 | var | scopes.rb:44:5:44:7 | var |
+| scopes.rb:46:5:46:8 | var2 | scopes.rb:46:5:46:8 | var2 | scopes.rb:47:5:47:8 | var2 |
 | ssa.rb:1:1:16:3 | self (m) | ssa.rb:1:1:16:3 | self | ssa.rb:3:3:3:8 | self |
 | ssa.rb:1:7:1:7 | b | ssa.rb:1:7:1:7 | b | ssa.rb:5:6:5:6 | b |
-| ssa.rb:2:3:2:7 | ... = ... | ssa.rb:2:3:2:3 | i | ssa.rb:3:8:3:8 | i |
+| ssa.rb:2:3:2:3 | i | ssa.rb:2:3:2:3 | i | ssa.rb:3:8:3:8 | i |
 | ssa.rb:5:3:13:5 | phi | ssa.rb:2:3:2:3 | i | ssa.rb:15:8:15:8 | i |
-| ssa.rb:6:5:6:9 | ... = ... | ssa.rb:2:3:2:3 | i | ssa.rb:7:10:7:10 | i |
-| ssa.rb:10:5:10:9 | ... = ... | ssa.rb:2:3:2:3 | i | ssa.rb:11:10:11:10 | i |
+| ssa.rb:6:5:6:5 | i | ssa.rb:2:3:2:3 | i | ssa.rb:7:10:7:10 | i |
+| ssa.rb:10:5:10:5 | i | ssa.rb:2:3:2:3 | i | ssa.rb:11:10:11:10 | i |
 | ssa.rb:18:1:23:3 | self (m1) | ssa.rb:18:1:23:3 | self | ssa.rb:20:5:20:10 | self |
 | ssa.rb:19:9:19:9 | phi | ssa.rb:18:8:18:8 | x | ssa.rb:19:9:19:9 | x |
 | ssa.rb:25:1:30:3 | self (m2) | ssa.rb:25:1:30:3 | self | ssa.rb:29:3:29:11 | self |
 | ssa.rb:25:8:25:15 | elements | ssa.rb:25:8:25:15 | elements | ssa.rb:26:15:26:22 | elements |
-| ssa.rb:26:3:28:5 | ... = ... | ssa.rb:26:7:26:10 | elem | ssa.rb:27:10:27:13 | elem |
 | ssa.rb:26:3:28:5 | <captured entry> self | ssa.rb:25:1:30:3 | self | ssa.rb:27:5:27:13 | self |
 | ssa.rb:26:3:28:5 | <captured exit> elem | ssa.rb:26:7:26:10 | elem | ssa.rb:29:8:29:11 | elem |
 | ssa.rb:26:3:28:5 | __synth__0__1 | ssa.rb:26:3:28:5 | __synth__0__1 | ssa.rb:26:3:28:5 | __synth__0__1 |
+| ssa.rb:26:7:26:10 | elem | ssa.rb:26:7:26:10 | elem | ssa.rb:27:10:27:13 | elem |
 | ssa.rb:33:16:35:5 | <captured entry> self | ssa.rb:32:1:36:3 | self | ssa.rb:34:5:34:10 | self |
 | ssa.rb:33:20:33:20 | x | ssa.rb:33:20:33:20 | x | ssa.rb:34:10:34:10 | x |
 | ssa.rb:38:1:42:3 | self (m4) | ssa.rb:38:1:42:3 | self | ssa.rb:39:3:39:9 | self |
-| ssa.rb:40:3:40:9 | ... = ... | ssa.rb:40:3:40:4 | m3 | ssa.rb:41:8:41:9 | m3 |
+| ssa.rb:40:3:40:4 | m3 | ssa.rb:40:3:40:4 | m3 | ssa.rb:41:8:41:9 | m3 |
 | ssa.rb:44:1:47:3 | self (m5) | ssa.rb:44:1:47:3 | self | ssa.rb:46:3:46:8 | self |
 | ssa.rb:44:8:44:8 | b | ssa.rb:44:8:44:8 | b | ssa.rb:45:12:45:12 | b |
 | ssa.rb:45:3:45:12 | phi | ssa.rb:45:3:45:3 | x | ssa.rb:46:8:46:8 | x |
@@ -487,10 +487,10 @@ firstRead
 | ssa.rb:50:3:50:8 | phi | ssa.rb:49:14:49:14 | y | ssa.rb:50:8:50:8 | y |
 | ssa.rb:53:1:56:3 | self (m7) | ssa.rb:53:1:56:3 | self | ssa.rb:55:3:55:8 | self |
 | ssa.rb:53:8:53:10 | foo | ssa.rb:53:8:53:10 | foo | ssa.rb:54:7:54:9 | foo |
-| ssa.rb:54:3:54:11 | ... = ... | ssa.rb:54:3:54:3 | x | ssa.rb:55:8:55:8 | x |
+| ssa.rb:54:3:54:3 | x | ssa.rb:54:3:54:3 | x | ssa.rb:55:8:55:8 | x |
 | ssa.rb:58:1:62:3 | self (m8) | ssa.rb:58:1:62:3 | self | ssa.rb:61:3:61:8 | self |
-| ssa.rb:59:3:59:8 | ... = ... | ssa.rb:59:3:59:3 | x | ssa.rb:60:3:60:3 | x |
-| ssa.rb:60:3:60:9 | ... = ... | ssa.rb:59:3:59:3 | x | ssa.rb:61:8:61:8 | x |
+| ssa.rb:59:3:59:3 | x | ssa.rb:59:3:59:3 | x | ssa.rb:60:3:60:3 | x |
+| ssa.rb:60:3:60:3 | x | ssa.rb:59:3:59:3 | x | ssa.rb:61:8:61:8 | x |
 | ssa.rb:64:1:72:3 | self (m9) | ssa.rb:64:1:72:3 | self | ssa.rb:71:3:71:15 | self |
 | ssa.rb:64:8:64:8 | a | ssa.rb:64:8:64:8 | a | ssa.rb:66:3:66:3 | a |
 | ssa.rb:66:3:70:5 | <captured exit> captured | ssa.rb:65:3:65:10 | captured | ssa.rb:71:8:71:15 | captured |
@@ -512,10 +512,10 @@ firstRead
 | ssa.rb:90:13:90:14 | b2 | ssa.rb:90:13:90:14 | b2 | ssa.rb:94:10:94:11 | b2 |
 | ssa.rb:90:17:90:18 | b3 | ssa.rb:90:17:90:18 | b3 | ssa.rb:98:7:98:8 | b3 |
 | ssa.rb:90:21:90:22 | b4 | ssa.rb:90:21:90:22 | b4 | ssa.rb:100:10:100:11 | b4 |
-| ssa.rb:91:3:91:7 | ... = ... | ssa.rb:91:3:91:3 | x | ssa.rb:93:10:93:10 | x |
-| ssa.rb:91:3:91:7 | ... = ... | ssa.rb:91:3:91:3 | x | ssa.rb:95:10:95:10 | x |
-| ssa.rb:91:3:91:7 | ... = ... | ssa.rb:91:3:91:3 | x | ssa.rb:99:10:99:10 | x |
-| ssa.rb:91:3:91:7 | ... = ... | ssa.rb:91:3:91:3 | x | ssa.rb:101:10:101:10 | x |
+| ssa.rb:91:3:91:3 | x | ssa.rb:91:3:91:3 | x | ssa.rb:93:10:93:10 | x |
+| ssa.rb:91:3:91:3 | x | ssa.rb:91:3:91:3 | x | ssa.rb:95:10:95:10 | x |
+| ssa.rb:91:3:91:3 | x | ssa.rb:91:3:91:3 | x | ssa.rb:99:10:99:10 | x |
+| ssa.rb:91:3:91:3 | x | ssa.rb:91:3:91:3 | x | ssa.rb:101:10:101:10 | x |
 lastRead
 | class_variables.rb:1:1:29:4 | self (class_variables.rb) | class_variables.rb:1:1:29:4 | self | class_variables.rb:3:1:3:5 | self |
 | class_variables.rb:5:1:7:3 | self (print) | class_variables.rb:5:1:7:3 | self | class_variables.rb:6:2:6:6 | self |
@@ -537,28 +537,28 @@ lastRead
 | instance_variables.rb:38:4:40:6 | self (y) | instance_variables.rb:38:4:40:6 | self | instance_variables.rb:39:6:39:7 | self |
 | nested_scopes.rb:1:1:3:3 | self (a) | nested_scopes.rb:1:1:3:3 | self | nested_scopes.rb:2:3:2:17 | self |
 | nested_scopes.rb:4:1:39:3 | self (C) | nested_scopes.rb:4:1:39:3 | self | nested_scopes.rb:38:3:38:8 | self |
-| nested_scopes.rb:5:3:5:7 | ... = ... | nested_scopes.rb:5:3:5:3 | a | nested_scopes.rb:38:8:38:8 | a |
+| nested_scopes.rb:5:3:5:3 | a | nested_scopes.rb:5:3:5:3 | a | nested_scopes.rb:38:8:38:8 | a |
 | nested_scopes.rb:6:3:37:5 | self (M) | nested_scopes.rb:6:3:37:5 | self | nested_scopes.rb:36:5:36:10 | self |
-| nested_scopes.rb:7:5:7:9 | ... = ... | nested_scopes.rb:7:5:7:5 | a | nested_scopes.rb:36:10:36:10 | a |
+| nested_scopes.rb:7:5:7:5 | a | nested_scopes.rb:7:5:7:5 | a | nested_scopes.rb:36:10:36:10 | a |
 | nested_scopes.rb:8:5:35:7 | self (N) | nested_scopes.rb:8:5:35:7 | self | nested_scopes.rb:34:7:34:12 | self |
-| nested_scopes.rb:9:7:9:11 | ... = ... | nested_scopes.rb:9:7:9:7 | a | nested_scopes.rb:34:12:34:12 | a |
+| nested_scopes.rb:9:7:9:7 | a | nested_scopes.rb:9:7:9:7 | a | nested_scopes.rb:34:12:34:12 | a |
 | nested_scopes.rb:10:7:26:9 | self (D) | nested_scopes.rb:10:7:26:9 | self | nested_scopes.rb:25:9:25:14 | self |
-| nested_scopes.rb:11:9:11:13 | ... = ... | nested_scopes.rb:11:9:11:9 | a | nested_scopes.rb:25:14:25:14 | a |
+| nested_scopes.rb:11:9:11:9 | a | nested_scopes.rb:11:9:11:9 | a | nested_scopes.rb:25:14:25:14 | a |
 | nested_scopes.rb:12:9:21:11 | self (show_a) | nested_scopes.rb:12:9:21:11 | self | nested_scopes.rb:14:11:14:16 | self |
-| nested_scopes.rb:13:11:13:15 | ... = ... | nested_scopes.rb:13:11:13:11 | a | nested_scopes.rb:15:11:15:11 | a |
+| nested_scopes.rb:13:11:13:11 | a | nested_scopes.rb:13:11:13:11 | a | nested_scopes.rb:15:11:15:11 | a |
 | nested_scopes.rb:15:23:15:23 | a | nested_scopes.rb:15:23:15:23 | a | nested_scopes.rb:16:13:16:13 | a |
-| nested_scopes.rb:17:15:17:19 | ... = ... | nested_scopes.rb:16:29:16:29 | a | nested_scopes.rb:18:15:18:15 | a |
+| nested_scopes.rb:17:15:17:15 | a | nested_scopes.rb:16:29:16:29 | a | nested_scopes.rb:18:15:18:15 | a |
 | nested_scopes.rb:18:23:18:36 | <captured entry> a | nested_scopes.rb:16:29:16:29 | a | nested_scopes.rb:18:34:18:34 | a |
 | nested_scopes.rb:18:23:18:36 | <captured entry> self | nested_scopes.rb:12:9:21:11 | self | nested_scopes.rb:18:29:18:34 | self |
 | nested_scopes.rb:22:9:24:11 | self (show_a2) | nested_scopes.rb:22:9:24:11 | self | nested_scopes.rb:23:11:23:16 | self |
 | nested_scopes.rb:22:21:22:21 | a | nested_scopes.rb:22:21:22:21 | a | nested_scopes.rb:23:16:23:16 | a |
 | nested_scopes.rb:27:7:29:9 | self (show) | nested_scopes.rb:27:7:29:9 | self | nested_scopes.rb:28:16:28:16 | self |
 | nested_scopes.rb:30:16:30:19 | self (class << ...) | nested_scopes.rb:30:7:33:9 | self | nested_scopes.rb:32:11:32:16 | self |
-| nested_scopes.rb:31:11:31:16 | ... = ... | nested_scopes.rb:31:11:31:11 | a | nested_scopes.rb:32:16:32:16 | a |
-| nested_scopes.rb:40:1:40:18 | ... = ... | nested_scopes.rb:40:1:40:1 | d | nested_scopes.rb:41:1:41:1 | d |
+| nested_scopes.rb:31:11:31:11 | a | nested_scopes.rb:31:11:31:11 | a | nested_scopes.rb:32:16:32:16 | a |
+| nested_scopes.rb:40:1:40:1 | d | nested_scopes.rb:40:1:40:1 | d | nested_scopes.rb:41:1:41:1 | d |
 | parameters.rb:1:9:5:3 | <captured entry> self | parameters.rb:1:1:62:1 | self | parameters.rb:4:4:4:9 | self |
 | parameters.rb:1:14:1:14 | x | parameters.rb:1:14:1:14 | x | parameters.rb:3:9:3:9 | x |
-| parameters.rb:2:4:2:8 | ... = ... | parameters.rb:1:18:1:18 | y | parameters.rb:4:9:4:9 | y |
+| parameters.rb:2:4:2:4 | y | parameters.rb:1:18:1:18 | y | parameters.rb:4:9:4:9 | y |
 | parameters.rb:7:1:13:3 | self (order_pizza) | parameters.rb:7:1:13:3 | self | parameters.rb:9:5:9:33 | self |
 | parameters.rb:7:1:13:3 | self (order_pizza) | parameters.rb:7:1:13:3 | self | parameters.rb:11:5:11:49 | self |
 | parameters.rb:7:17:7:22 | client | parameters.rb:7:17:7:22 | client | parameters.rb:9:25:9:30 | client |
@@ -597,40 +597,40 @@ lastRead
 | parameters.rb:59:25:59:25 | c | parameters.rb:59:25:59:25 | c | parameters.rb:60:21:60:21 | c |
 | scopes.rb:1:1:49:4 | self (scopes.rb) | scopes.rb:1:1:49:4 | self | scopes.rb:8:1:8:6 | self |
 | scopes.rb:2:9:6:3 | <captured entry> self | scopes.rb:1:1:49:4 | self | scopes.rb:5:4:5:9 | self |
-| scopes.rb:4:4:4:8 | ... = ... | scopes.rb:4:4:4:4 | a | scopes.rb:5:9:5:9 | a |
-| scopes.rb:7:1:7:5 | ... = ... | scopes.rb:7:1:7:1 | a | scopes.rb:8:6:8:6 | a |
+| scopes.rb:4:4:4:4 | a | scopes.rb:4:4:4:4 | a | scopes.rb:5:9:5:9 | a |
+| scopes.rb:7:1:7:1 | a | scopes.rb:7:1:7:1 | a | scopes.rb:8:6:8:6 | a |
 | scopes.rb:9:9:18:3 | <captured entry> a | scopes.rb:7:1:7:1 | a | scopes.rb:11:4:11:4 | a |
 | scopes.rb:9:9:18:3 | <captured entry> self | scopes.rb:1:1:49:4 | self | scopes.rb:17:4:17:9 | self |
-| scopes.rb:11:4:11:9 | ... = ... | scopes.rb:7:1:7:1 | a | scopes.rb:12:9:12:9 | a |
-| scopes.rb:13:4:13:4 | ... = ... | scopes.rb:7:1:7:1 | a | scopes.rb:14:9:14:9 | a |
-| scopes.rb:13:7:13:7 | ... = ... | scopes.rb:13:7:13:7 | b | scopes.rb:15:9:15:9 | b |
-| scopes.rb:13:10:13:15 | ... = ... | scopes.rb:13:10:13:15 | __synth__0__1 | scopes.rb:13:14:13:14 | __synth__0__1 |
-| scopes.rb:13:11:13:11 | ... = ... | scopes.rb:13:11:13:11 | c | scopes.rb:16:9:16:9 | c |
-| scopes.rb:13:14:13:14 | ... = ... | scopes.rb:13:14:13:14 | d | scopes.rb:17:9:17:9 | d |
-| scopes.rb:13:19:13:32 | ... = ... | scopes.rb:13:4:13:32 | __synth__0 | scopes.rb:13:10:13:15 | __synth__0 |
-| scopes.rb:27:1:27:5 | ... = ... | scopes.rb:27:1:27:1 | x | scopes.rb:37:5:37:5 | x |
+| scopes.rb:11:4:11:4 | a | scopes.rb:7:1:7:1 | a | scopes.rb:12:9:12:9 | a |
+| scopes.rb:13:4:13:4 | a | scopes.rb:7:1:7:1 | a | scopes.rb:14:9:14:9 | a |
+| scopes.rb:13:7:13:7 | b | scopes.rb:13:7:13:7 | b | scopes.rb:15:9:15:9 | b |
+| scopes.rb:13:10:13:15 | __synth__0__1 | scopes.rb:13:10:13:15 | __synth__0__1 | scopes.rb:13:14:13:14 | __synth__0__1 |
+| scopes.rb:13:11:13:11 | c | scopes.rb:13:11:13:11 | c | scopes.rb:16:9:16:9 | c |
+| scopes.rb:13:14:13:14 | d | scopes.rb:13:14:13:14 | d | scopes.rb:17:9:17:9 | d |
+| scopes.rb:13:19:13:32 | __synth__0 | scopes.rb:13:4:13:32 | __synth__0 | scopes.rb:13:10:13:15 | __synth__0 |
+| scopes.rb:27:1:27:1 | x | scopes.rb:27:1:27:1 | x | scopes.rb:37:5:37:5 | x |
 | scopes.rb:41:1:49:3 | self (M) | scopes.rb:41:1:49:3 | self | scopes.rb:45:5:45:7 | self |
-| scopes.rb:42:2:42:9 | ... = ... | scopes.rb:42:2:42:4 | var | scopes.rb:44:5:44:7 | var |
-| scopes.rb:46:5:46:13 | ... = ... | scopes.rb:46:5:46:8 | var2 | scopes.rb:47:5:47:8 | var2 |
+| scopes.rb:42:2:42:4 | var | scopes.rb:42:2:42:4 | var | scopes.rb:44:5:44:7 | var |
+| scopes.rb:46:5:46:8 | var2 | scopes.rb:46:5:46:8 | var2 | scopes.rb:47:5:47:8 | var2 |
 | ssa.rb:1:1:16:3 | self (m) | ssa.rb:1:1:16:3 | self | ssa.rb:15:3:15:8 | self |
 | ssa.rb:1:7:1:7 | b | ssa.rb:1:7:1:7 | b | ssa.rb:5:6:5:6 | b |
-| ssa.rb:2:3:2:7 | ... = ... | ssa.rb:2:3:2:3 | i | ssa.rb:4:8:4:8 | i |
+| ssa.rb:2:3:2:3 | i | ssa.rb:2:3:2:3 | i | ssa.rb:4:8:4:8 | i |
 | ssa.rb:5:3:13:5 | phi | ssa.rb:2:3:2:3 | i | ssa.rb:15:8:15:8 | i |
-| ssa.rb:6:5:6:9 | ... = ... | ssa.rb:2:3:2:3 | i | ssa.rb:8:10:8:10 | i |
-| ssa.rb:10:5:10:9 | ... = ... | ssa.rb:2:3:2:3 | i | ssa.rb:12:10:12:10 | i |
+| ssa.rb:6:5:6:5 | i | ssa.rb:2:3:2:3 | i | ssa.rb:8:10:8:10 | i |
+| ssa.rb:10:5:10:5 | i | ssa.rb:2:3:2:3 | i | ssa.rb:12:10:12:10 | i |
 | ssa.rb:18:1:23:3 | self (m1) | ssa.rb:18:1:23:3 | self | ssa.rb:20:5:20:10 | self |
 | ssa.rb:19:9:19:9 | phi | ssa.rb:18:8:18:8 | x | ssa.rb:19:9:19:9 | x |
 | ssa.rb:19:9:19:9 | phi | ssa.rb:18:8:18:8 | x | ssa.rb:21:5:21:5 | x |
 | ssa.rb:25:1:30:3 | self (m2) | ssa.rb:25:1:30:3 | self | ssa.rb:29:3:29:11 | self |
 | ssa.rb:25:8:25:15 | elements | ssa.rb:25:8:25:15 | elements | ssa.rb:26:15:26:22 | elements |
-| ssa.rb:26:3:28:5 | ... = ... | ssa.rb:26:7:26:10 | elem | ssa.rb:27:10:27:13 | elem |
 | ssa.rb:26:3:28:5 | <captured entry> self | ssa.rb:25:1:30:3 | self | ssa.rb:27:5:27:13 | self |
 | ssa.rb:26:3:28:5 | <captured exit> elem | ssa.rb:26:7:26:10 | elem | ssa.rb:29:8:29:11 | elem |
 | ssa.rb:26:3:28:5 | __synth__0__1 | ssa.rb:26:3:28:5 | __synth__0__1 | ssa.rb:26:3:28:5 | __synth__0__1 |
+| ssa.rb:26:7:26:10 | elem | ssa.rb:26:7:26:10 | elem | ssa.rb:27:10:27:13 | elem |
 | ssa.rb:33:16:35:5 | <captured entry> self | ssa.rb:32:1:36:3 | self | ssa.rb:34:5:34:10 | self |
 | ssa.rb:33:20:33:20 | x | ssa.rb:33:20:33:20 | x | ssa.rb:34:10:34:10 | x |
 | ssa.rb:38:1:42:3 | self (m4) | ssa.rb:38:1:42:3 | self | ssa.rb:41:3:41:13 | self |
-| ssa.rb:40:3:40:9 | ... = ... | ssa.rb:40:3:40:4 | m3 | ssa.rb:41:8:41:9 | m3 |
+| ssa.rb:40:3:40:4 | m3 | ssa.rb:40:3:40:4 | m3 | ssa.rb:41:8:41:9 | m3 |
 | ssa.rb:44:1:47:3 | self (m5) | ssa.rb:44:1:47:3 | self | ssa.rb:46:3:46:8 | self |
 | ssa.rb:44:8:44:8 | b | ssa.rb:44:8:44:8 | b | ssa.rb:45:12:45:12 | b |
 | ssa.rb:45:3:45:12 | phi | ssa.rb:45:3:45:3 | x | ssa.rb:46:8:46:8 | x |
@@ -638,10 +638,10 @@ lastRead
 | ssa.rb:50:3:50:8 | phi | ssa.rb:49:14:49:14 | y | ssa.rb:50:8:50:8 | y |
 | ssa.rb:53:1:56:3 | self (m7) | ssa.rb:53:1:56:3 | self | ssa.rb:55:3:55:8 | self |
 | ssa.rb:53:8:53:10 | foo | ssa.rb:53:8:53:10 | foo | ssa.rb:54:7:54:9 | foo |
-| ssa.rb:54:3:54:11 | ... = ... | ssa.rb:54:3:54:3 | x | ssa.rb:55:8:55:8 | x |
+| ssa.rb:54:3:54:3 | x | ssa.rb:54:3:54:3 | x | ssa.rb:55:8:55:8 | x |
 | ssa.rb:58:1:62:3 | self (m8) | ssa.rb:58:1:62:3 | self | ssa.rb:61:3:61:8 | self |
-| ssa.rb:59:3:59:8 | ... = ... | ssa.rb:59:3:59:3 | x | ssa.rb:60:3:60:3 | x |
-| ssa.rb:60:3:60:9 | ... = ... | ssa.rb:59:3:59:3 | x | ssa.rb:61:8:61:8 | x |
+| ssa.rb:59:3:59:3 | x | ssa.rb:59:3:59:3 | x | ssa.rb:60:3:60:3 | x |
+| ssa.rb:60:3:60:3 | x | ssa.rb:59:3:59:3 | x | ssa.rb:61:8:61:8 | x |
 | ssa.rb:64:1:72:3 | self (m9) | ssa.rb:64:1:72:3 | self | ssa.rb:71:3:71:15 | self |
 | ssa.rb:64:8:64:8 | a | ssa.rb:64:8:64:8 | a | ssa.rb:66:3:66:3 | a |
 | ssa.rb:66:3:70:5 | <captured exit> captured | ssa.rb:65:3:65:10 | captured | ssa.rb:71:8:71:15 | captured |
@@ -663,10 +663,10 @@ lastRead
 | ssa.rb:90:13:90:14 | b2 | ssa.rb:90:13:90:14 | b2 | ssa.rb:94:10:94:11 | b2 |
 | ssa.rb:90:17:90:18 | b3 | ssa.rb:90:17:90:18 | b3 | ssa.rb:98:7:98:8 | b3 |
 | ssa.rb:90:21:90:22 | b4 | ssa.rb:90:21:90:22 | b4 | ssa.rb:100:10:100:11 | b4 |
-| ssa.rb:91:3:91:7 | ... = ... | ssa.rb:91:3:91:3 | x | ssa.rb:93:10:93:10 | x |
-| ssa.rb:91:3:91:7 | ... = ... | ssa.rb:91:3:91:3 | x | ssa.rb:95:10:95:10 | x |
-| ssa.rb:91:3:91:7 | ... = ... | ssa.rb:91:3:91:3 | x | ssa.rb:99:10:99:10 | x |
-| ssa.rb:91:3:91:7 | ... = ... | ssa.rb:91:3:91:3 | x | ssa.rb:101:10:101:10 | x |
+| ssa.rb:91:3:91:3 | x | ssa.rb:91:3:91:3 | x | ssa.rb:93:10:93:10 | x |
+| ssa.rb:91:3:91:3 | x | ssa.rb:91:3:91:3 | x | ssa.rb:95:10:95:10 | x |
+| ssa.rb:91:3:91:3 | x | ssa.rb:91:3:91:3 | x | ssa.rb:99:10:99:10 | x |
+| ssa.rb:91:3:91:3 | x | ssa.rb:91:3:91:3 | x | ssa.rb:101:10:101:10 | x |
 adjacentReads
 | class_variables.rb:26:1:29:3 | self (N) | class_variables.rb:26:1:29:3 | self | class_variables.rb:27:3:27:11 | self | class_variables.rb:28:3:28:7 | self |
 | instance_variables.rb:1:1:44:4 | self (instance_variables.rb) | instance_variables.rb:1:1:44:4 | self | instance_variables.rb:1:1:1:4 | self | instance_variables.rb:11:1:11:9 | self |
@@ -677,7 +677,7 @@ adjacentReads
 | instance_variables.rb:37:3:43:5 | self (x) | instance_variables.rb:37:3:43:5 | self | instance_variables.rb:42:4:42:7 | self | instance_variables.rb:42:6:42:7 | self |
 | nested_scopes.rb:8:5:35:7 | self (N) | nested_scopes.rb:8:5:35:7 | self | nested_scopes.rb:27:11:27:14 | self | nested_scopes.rb:30:16:30:19 | self |
 | nested_scopes.rb:8:5:35:7 | self (N) | nested_scopes.rb:8:5:35:7 | self | nested_scopes.rb:30:16:30:19 | self | nested_scopes.rb:34:7:34:12 | self |
-| nested_scopes.rb:13:11:13:15 | ... = ... | nested_scopes.rb:13:11:13:11 | a | nested_scopes.rb:14:16:14:16 | a | nested_scopes.rb:15:11:15:11 | a |
+| nested_scopes.rb:13:11:13:11 | a | nested_scopes.rb:13:11:13:11 | a | nested_scopes.rb:14:16:14:16 | a | nested_scopes.rb:15:11:15:11 | a |
 | nested_scopes.rb:27:7:29:9 | self (show) | nested_scopes.rb:27:7:29:9 | self | nested_scopes.rb:28:11:28:16 | self | nested_scopes.rb:28:16:28:16 | self |
 | nested_scopes.rb:30:16:30:19 | self (class << ...) | nested_scopes.rb:30:7:33:9 | self | nested_scopes.rb:30:16:30:19 | self | nested_scopes.rb:32:11:32:16 | self |
 | parameters.rb:1:9:5:3 | <captured entry> self | parameters.rb:1:1:62:1 | self | parameters.rb:3:4:3:9 | self | parameters.rb:4:4:4:9 | self |
@@ -693,13 +693,13 @@ adjacentReads
 | scopes.rb:9:9:18:3 | <captured entry> self | scopes.rb:1:1:49:4 | self | scopes.rb:14:4:14:9 | self | scopes.rb:15:4:15:9 | self |
 | scopes.rb:9:9:18:3 | <captured entry> self | scopes.rb:1:1:49:4 | self | scopes.rb:15:4:15:9 | self | scopes.rb:16:4:16:9 | self |
 | scopes.rb:9:9:18:3 | <captured entry> self | scopes.rb:1:1:49:4 | self | scopes.rb:16:4:16:9 | self | scopes.rb:17:4:17:9 | self |
-| scopes.rb:13:10:13:15 | ... = ... | scopes.rb:13:10:13:15 | __synth__0__1 | scopes.rb:13:11:13:11 | __synth__0__1 | scopes.rb:13:14:13:14 | __synth__0__1 |
-| scopes.rb:13:19:13:32 | ... = ... | scopes.rb:13:4:13:32 | __synth__0 | scopes.rb:13:4:13:4 | __synth__0 | scopes.rb:13:7:13:7 | __synth__0 |
-| scopes.rb:13:19:13:32 | ... = ... | scopes.rb:13:4:13:32 | __synth__0 | scopes.rb:13:7:13:7 | __synth__0 | scopes.rb:13:10:13:15 | __synth__0 |
-| scopes.rb:27:1:27:5 | ... = ... | scopes.rb:27:1:27:1 | x | scopes.rb:28:8:28:8 | x | scopes.rb:31:10:31:10 | x |
-| scopes.rb:27:1:27:5 | ... = ... | scopes.rb:27:1:27:1 | x | scopes.rb:31:10:31:10 | x | scopes.rb:34:7:34:7 | x |
-| scopes.rb:27:1:27:5 | ... = ... | scopes.rb:27:1:27:1 | x | scopes.rb:34:7:34:7 | x | scopes.rb:34:14:34:14 | x |
-| scopes.rb:27:1:27:5 | ... = ... | scopes.rb:27:1:27:1 | x | scopes.rb:34:14:34:14 | x | scopes.rb:37:5:37:5 | x |
+| scopes.rb:13:10:13:15 | __synth__0__1 | scopes.rb:13:10:13:15 | __synth__0__1 | scopes.rb:13:11:13:11 | __synth__0__1 | scopes.rb:13:14:13:14 | __synth__0__1 |
+| scopes.rb:13:19:13:32 | __synth__0 | scopes.rb:13:4:13:32 | __synth__0 | scopes.rb:13:4:13:4 | __synth__0 | scopes.rb:13:7:13:7 | __synth__0 |
+| scopes.rb:13:19:13:32 | __synth__0 | scopes.rb:13:4:13:32 | __synth__0 | scopes.rb:13:7:13:7 | __synth__0 | scopes.rb:13:10:13:15 | __synth__0 |
+| scopes.rb:27:1:27:1 | x | scopes.rb:27:1:27:1 | x | scopes.rb:28:8:28:8 | x | scopes.rb:31:10:31:10 | x |
+| scopes.rb:27:1:27:1 | x | scopes.rb:27:1:27:1 | x | scopes.rb:31:10:31:10 | x | scopes.rb:34:7:34:7 | x |
+| scopes.rb:27:1:27:1 | x | scopes.rb:27:1:27:1 | x | scopes.rb:34:7:34:7 | x | scopes.rb:34:14:34:14 | x |
+| scopes.rb:27:1:27:1 | x | scopes.rb:27:1:27:1 | x | scopes.rb:34:14:34:14 | x | scopes.rb:37:5:37:5 | x |
 | ssa.rb:1:1:16:3 | self (m) | ssa.rb:1:1:16:3 | self | ssa.rb:3:3:3:8 | self | ssa.rb:4:3:4:12 | self |
 | ssa.rb:1:1:16:3 | self (m) | ssa.rb:1:1:16:3 | self | ssa.rb:4:3:4:12 | self | ssa.rb:7:5:7:10 | self |
 | ssa.rb:1:1:16:3 | self (m) | ssa.rb:1:1:16:3 | self | ssa.rb:4:3:4:12 | self | ssa.rb:11:5:11:10 | self |
@@ -707,9 +707,9 @@ adjacentReads
 | ssa.rb:1:1:16:3 | self (m) | ssa.rb:1:1:16:3 | self | ssa.rb:8:5:8:14 | self | ssa.rb:15:3:15:8 | self |
 | ssa.rb:1:1:16:3 | self (m) | ssa.rb:1:1:16:3 | self | ssa.rb:11:5:11:10 | self | ssa.rb:12:5:12:14 | self |
 | ssa.rb:1:1:16:3 | self (m) | ssa.rb:1:1:16:3 | self | ssa.rb:12:5:12:14 | self | ssa.rb:15:3:15:8 | self |
-| ssa.rb:2:3:2:7 | ... = ... | ssa.rb:2:3:2:3 | i | ssa.rb:3:8:3:8 | i | ssa.rb:4:8:4:8 | i |
-| ssa.rb:6:5:6:9 | ... = ... | ssa.rb:2:3:2:3 | i | ssa.rb:7:10:7:10 | i | ssa.rb:8:10:8:10 | i |
-| ssa.rb:10:5:10:9 | ... = ... | ssa.rb:2:3:2:3 | i | ssa.rb:11:10:11:10 | i | ssa.rb:12:10:12:10 | i |
+| ssa.rb:2:3:2:3 | i | ssa.rb:2:3:2:3 | i | ssa.rb:3:8:3:8 | i | ssa.rb:4:8:4:8 | i |
+| ssa.rb:6:5:6:5 | i | ssa.rb:2:3:2:3 | i | ssa.rb:7:10:7:10 | i | ssa.rb:8:10:8:10 | i |
+| ssa.rb:10:5:10:5 | i | ssa.rb:2:3:2:3 | i | ssa.rb:11:10:11:10 | i | ssa.rb:12:10:12:10 | i |
 | ssa.rb:18:1:23:3 | self (m1) | ssa.rb:18:1:23:3 | self | ssa.rb:20:5:20:10 | self | ssa.rb:20:5:20:10 | self |
 | ssa.rb:19:9:19:9 | phi | ssa.rb:18:8:18:8 | x | ssa.rb:19:9:19:9 | x | ssa.rb:20:10:20:10 | x |
 | ssa.rb:19:9:19:9 | phi | ssa.rb:18:8:18:8 | x | ssa.rb:20:10:20:10 | x | ssa.rb:21:5:21:5 | x |
@@ -721,25 +721,25 @@ adjacentReads
 | ssa.rb:90:1:103:3 | self (m12) | ssa.rb:90:1:103:3 | self | ssa.rb:93:5:93:10 | self | ssa.rb:101:5:101:10 | self |
 | ssa.rb:90:1:103:3 | self (m12) | ssa.rb:90:1:103:3 | self | ssa.rb:95:5:95:10 | self | ssa.rb:99:5:99:10 | self |
 | ssa.rb:90:1:103:3 | self (m12) | ssa.rb:90:1:103:3 | self | ssa.rb:95:5:95:10 | self | ssa.rb:101:5:101:10 | self |
-| ssa.rb:91:3:91:7 | ... = ... | ssa.rb:91:3:91:3 | x | ssa.rb:93:10:93:10 | x | ssa.rb:99:10:99:10 | x |
-| ssa.rb:91:3:91:7 | ... = ... | ssa.rb:91:3:91:3 | x | ssa.rb:93:10:93:10 | x | ssa.rb:101:10:101:10 | x |
-| ssa.rb:91:3:91:7 | ... = ... | ssa.rb:91:3:91:3 | x | ssa.rb:95:10:95:10 | x | ssa.rb:99:10:99:10 | x |
-| ssa.rb:91:3:91:7 | ... = ... | ssa.rb:91:3:91:3 | x | ssa.rb:95:10:95:10 | x | ssa.rb:101:10:101:10 | x |
+| ssa.rb:91:3:91:3 | x | ssa.rb:91:3:91:3 | x | ssa.rb:93:10:93:10 | x | ssa.rb:99:10:99:10 | x |
+| ssa.rb:91:3:91:3 | x | ssa.rb:91:3:91:3 | x | ssa.rb:93:10:93:10 | x | ssa.rb:101:10:101:10 | x |
+| ssa.rb:91:3:91:3 | x | ssa.rb:91:3:91:3 | x | ssa.rb:95:10:95:10 | x | ssa.rb:99:10:99:10 | x |
+| ssa.rb:91:3:91:3 | x | ssa.rb:91:3:91:3 | x | ssa.rb:95:10:95:10 | x | ssa.rb:101:10:101:10 | x |
 phi
 | parameters.rb:37:3:37:18 | phi | parameters.rb:35:16:35:16 | b | parameters.rb:35:1:38:3 | <uninitialized> |
-| parameters.rb:37:3:37:18 | phi | parameters.rb:35:16:35:16 | b | parameters.rb:35:16:35:20 | ... = ... |
+| parameters.rb:37:3:37:18 | phi | parameters.rb:35:16:35:16 | b | parameters.rb:35:16:35:16 | b |
 | parameters.rb:42:3:42:18 | phi | parameters.rb:40:15:40:15 | e | parameters.rb:40:1:43:3 | <uninitialized> |
-| parameters.rb:42:3:42:18 | phi | parameters.rb:40:15:40:15 | e | parameters.rb:40:15:40:19 | ... = ... |
+| parameters.rb:42:3:42:18 | phi | parameters.rb:40:15:40:15 | e | parameters.rb:40:15:40:15 | e |
 | parameters.rb:55:4:55:9 | phi | parameters.rb:53:1:53:1 | x | parameters.rb:54:9:57:3 | <captured entry> x |
-| parameters.rb:55:4:55:9 | phi | parameters.rb:53:1:53:1 | x | parameters.rb:54:19:54:23 | ... = ... |
-| ssa.rb:5:3:13:5 | phi | ssa.rb:2:3:2:3 | i | ssa.rb:6:5:6:9 | ... = ... |
-| ssa.rb:5:3:13:5 | phi | ssa.rb:2:3:2:3 | i | ssa.rb:10:5:10:9 | ... = ... |
+| parameters.rb:55:4:55:9 | phi | parameters.rb:53:1:53:1 | x | parameters.rb:54:19:54:19 | x |
+| ssa.rb:5:3:13:5 | phi | ssa.rb:2:3:2:3 | i | ssa.rb:6:5:6:5 | i |
+| ssa.rb:5:3:13:5 | phi | ssa.rb:2:3:2:3 | i | ssa.rb:10:5:10:5 | i |
 | ssa.rb:19:9:19:9 | phi | ssa.rb:18:8:18:8 | x | ssa.rb:18:8:18:8 | x |
-| ssa.rb:19:9:19:9 | phi | ssa.rb:18:8:18:8 | x | ssa.rb:21:5:21:10 | ... = ... |
+| ssa.rb:19:9:19:9 | phi | ssa.rb:18:8:18:8 | x | ssa.rb:21:5:21:5 | x |
 | ssa.rb:45:3:45:12 | phi | ssa.rb:45:3:45:3 | x | ssa.rb:44:1:47:3 | <uninitialized> |
-| ssa.rb:45:3:45:12 | phi | ssa.rb:45:3:45:3 | x | ssa.rb:45:3:45:7 | ... = ... |
+| ssa.rb:45:3:45:12 | phi | ssa.rb:45:3:45:3 | x | ssa.rb:45:3:45:3 | x |
 | ssa.rb:50:3:50:8 | phi | ssa.rb:49:14:49:14 | y | ssa.rb:49:1:51:3 | <uninitialized> |
-| ssa.rb:50:3:50:8 | phi | ssa.rb:49:14:49:14 | y | ssa.rb:49:14:49:19 | ... = ... |
+| ssa.rb:50:3:50:8 | phi | ssa.rb:49:14:49:14 | y | ssa.rb:49:14:49:14 | y |
 phiReadNode
 | parameters.rb:26:3:26:11 | SSA phi read(name) | parameters.rb:25:15:25:18 | name |
 | ssa.rb:5:3:13:5 | SSA phi read(self) | ssa.rb:1:1:16:3 | self |
@@ -763,7 +763,7 @@ phiReadInput
 | ssa.rb:19:9:19:9 | SSA phi read(self) | ssa.rb:19:9:19:9 | SSA phi read(self) |
 | ssa.rb:92:3:96:5 | SSA phi read(self) | ssa.rb:90:1:103:3 | self (m12) |
 | ssa.rb:92:3:96:5 | SSA phi read(self) | ssa.rb:94:3:95:10 | SSA phi read(self) |
-| ssa.rb:92:3:96:5 | SSA phi read(x) | ssa.rb:91:3:91:7 | ... = ... |
+| ssa.rb:92:3:96:5 | SSA phi read(x) | ssa.rb:91:3:91:3 | x |
 | ssa.rb:92:3:96:5 | SSA phi read(x) | ssa.rb:94:3:95:10 | SSA phi read(x) |
 | ssa.rb:94:3:95:10 | SSA phi read(self) | ssa.rb:90:1:103:3 | self (m12) |
-| ssa.rb:94:3:95:10 | SSA phi read(x) | ssa.rb:91:3:91:7 | ... = ... |
+| ssa.rb:94:3:95:10 | SSA phi read(x) | ssa.rb:91:3:91:3 | x |

--- a/ruby/ql/test/query-tests/experimental/TemplateInjection/TemplateInjection.expected
+++ b/ruby/ql/test/query-tests/experimental/TemplateInjection/TemplateInjection.expected
@@ -1,30 +1,36 @@
 edges
+| ErbInjection.rb:5:5:5:8 | name :  | ErbInjection.rb:8:5:8:12 | bad_text :  |
+| ErbInjection.rb:5:5:5:8 | name :  | ErbInjection.rb:11:11:11:14 | name :  |
 | ErbInjection.rb:5:12:5:17 | call to params :  | ErbInjection.rb:5:12:5:24 | ...[...] :  |
-| ErbInjection.rb:5:12:5:24 | ...[...] :  | ErbInjection.rb:11:11:11:14 | name :  |
-| ErbInjection.rb:5:12:5:24 | ...[...] :  | ErbInjection.rb:15:24:15:31 | bad_text |
-| ErbInjection.rb:8:16:11:14 | ... % ... :  | ErbInjection.rb:15:24:15:31 | bad_text |
+| ErbInjection.rb:5:12:5:24 | ...[...] :  | ErbInjection.rb:5:5:5:8 | name :  |
+| ErbInjection.rb:8:5:8:12 | bad_text :  | ErbInjection.rb:15:24:15:31 | bad_text |
+| ErbInjection.rb:8:16:11:14 | ... % ... :  | ErbInjection.rb:8:5:8:12 | bad_text :  |
 | ErbInjection.rb:11:11:11:14 | name :  | ErbInjection.rb:8:16:11:14 | ... % ... :  |
+| SlimInjection.rb:5:5:5:8 | name :  | SlimInjection.rb:8:5:8:12 | bad_text :  |
+| SlimInjection.rb:5:5:5:8 | name :  | SlimInjection.rb:11:11:11:14 | name :  |
+| SlimInjection.rb:5:5:5:8 | name :  | SlimInjection.rb:17:5:17:13 | bad2_text :  |
 | SlimInjection.rb:5:12:5:17 | call to params :  | SlimInjection.rb:5:12:5:24 | ...[...] :  |
-| SlimInjection.rb:5:12:5:24 | ...[...] :  | SlimInjection.rb:8:5:11:14 | ... = ... :  |
-| SlimInjection.rb:5:12:5:24 | ...[...] :  | SlimInjection.rb:11:11:11:14 | name :  |
-| SlimInjection.rb:5:12:5:24 | ...[...] :  | SlimInjection.rb:17:5:20:7 | ... = ... :  |
-| SlimInjection.rb:8:5:11:14 | ... = ... :  | SlimInjection.rb:14:25:14:32 | bad_text |
-| SlimInjection.rb:8:16:11:14 | ... % ... :  | SlimInjection.rb:8:5:11:14 | ... = ... :  |
+| SlimInjection.rb:5:12:5:24 | ...[...] :  | SlimInjection.rb:5:5:5:8 | name :  |
+| SlimInjection.rb:8:5:8:12 | bad_text :  | SlimInjection.rb:14:25:14:32 | bad_text |
+| SlimInjection.rb:8:16:11:14 | ... % ... :  | SlimInjection.rb:8:5:8:12 | bad_text :  |
 | SlimInjection.rb:11:11:11:14 | name :  | SlimInjection.rb:8:16:11:14 | ... % ... :  |
-| SlimInjection.rb:17:5:20:7 | ... = ... :  | SlimInjection.rb:23:25:23:33 | bad2_text |
+| SlimInjection.rb:17:5:17:13 | bad2_text :  | SlimInjection.rb:23:25:23:33 | bad2_text |
 nodes
+| ErbInjection.rb:5:5:5:8 | name :  | semmle.label | name :  |
 | ErbInjection.rb:5:12:5:17 | call to params :  | semmle.label | call to params :  |
 | ErbInjection.rb:5:12:5:24 | ...[...] :  | semmle.label | ...[...] :  |
+| ErbInjection.rb:8:5:8:12 | bad_text :  | semmle.label | bad_text :  |
 | ErbInjection.rb:8:16:11:14 | ... % ... :  | semmle.label | ... % ... :  |
 | ErbInjection.rb:11:11:11:14 | name :  | semmle.label | name :  |
 | ErbInjection.rb:15:24:15:31 | bad_text | semmle.label | bad_text |
+| SlimInjection.rb:5:5:5:8 | name :  | semmle.label | name :  |
 | SlimInjection.rb:5:12:5:17 | call to params :  | semmle.label | call to params :  |
 | SlimInjection.rb:5:12:5:24 | ...[...] :  | semmle.label | ...[...] :  |
-| SlimInjection.rb:8:5:11:14 | ... = ... :  | semmle.label | ... = ... :  |
+| SlimInjection.rb:8:5:8:12 | bad_text :  | semmle.label | bad_text :  |
 | SlimInjection.rb:8:16:11:14 | ... % ... :  | semmle.label | ... % ... :  |
 | SlimInjection.rb:11:11:11:14 | name :  | semmle.label | name :  |
 | SlimInjection.rb:14:25:14:32 | bad_text | semmle.label | bad_text |
-| SlimInjection.rb:17:5:20:7 | ... = ... :  | semmle.label | ... = ... :  |
+| SlimInjection.rb:17:5:17:13 | bad2_text :  | semmle.label | bad2_text :  |
 | SlimInjection.rb:23:25:23:33 | bad2_text | semmle.label | bad2_text |
 subpaths
 #select

--- a/ruby/ql/test/query-tests/experimental/cwe-022-ZipSlip/ZipSlip.expected
+++ b/ruby/ql/test/query-tests/experimental/cwe-022-ZipSlip/ZipSlip.expected
@@ -1,5 +1,6 @@
 edges
-| zip_slip.rb:8:15:8:54 | call to new :  | zip_slip.rb:9:5:9:11 | tarfile :  |
+| zip_slip.rb:8:5:8:11 | tarfile :  | zip_slip.rb:9:5:9:11 | tarfile :  |
+| zip_slip.rb:8:15:8:54 | call to new :  | zip_slip.rb:8:5:8:11 | tarfile :  |
 | zip_slip.rb:9:5:9:11 | tarfile :  | zip_slip.rb:9:22:9:26 | entry :  |
 | zip_slip.rb:9:22:9:26 | entry :  | zip_slip.rb:10:19:10:33 | call to full_name |
 | zip_slip.rb:20:50:20:56 | tarfile :  | zip_slip.rb:21:7:21:13 | tarfile :  |
@@ -10,15 +11,20 @@ edges
 | zip_slip.rb:56:30:56:37 | zip_file :  | zip_slip.rb:57:7:57:14 | zip_file :  |
 | zip_slip.rb:57:7:57:14 | zip_file :  | zip_slip.rb:57:25:57:29 | entry :  |
 | zip_slip.rb:57:25:57:29 | entry :  | zip_slip.rb:58:19:58:28 | call to name |
-| zip_slip.rb:90:12:90:54 | call to open :  | zip_slip.rb:91:11:91:14 | gzip :  |
+| zip_slip.rb:90:5:90:8 | gzip :  | zip_slip.rb:91:11:91:14 | gzip :  |
+| zip_slip.rb:90:12:90:54 | call to open :  | zip_slip.rb:90:5:90:8 | gzip :  |
 | zip_slip.rb:91:11:91:14 | gzip :  | zip_slip.rb:97:42:97:56 | compressed_file :  |
 | zip_slip.rb:97:42:97:56 | compressed_file :  | zip_slip.rb:98:7:98:21 | compressed_file :  |
 | zip_slip.rb:98:7:98:21 | compressed_file :  | zip_slip.rb:98:32:98:36 | entry :  |
-| zip_slip.rb:98:32:98:36 | entry :  | zip_slip.rb:100:21:100:30 | entry_path |
-| zip_slip.rb:123:12:123:34 | call to new :  | zip_slip.rb:124:7:124:8 | gz :  |
+| zip_slip.rb:98:32:98:36 | entry :  | zip_slip.rb:99:9:99:18 | entry_path :  |
+| zip_slip.rb:99:9:99:18 | entry_path :  | zip_slip.rb:100:21:100:30 | entry_path |
+| zip_slip.rb:123:7:123:8 | gz :  | zip_slip.rb:124:7:124:8 | gz :  |
+| zip_slip.rb:123:12:123:34 | call to new :  | zip_slip.rb:123:7:123:8 | gz :  |
 | zip_slip.rb:124:7:124:8 | gz :  | zip_slip.rb:124:19:124:23 | entry :  |
-| zip_slip.rb:124:19:124:23 | entry :  | zip_slip.rb:126:21:126:30 | entry_path |
+| zip_slip.rb:124:19:124:23 | entry :  | zip_slip.rb:125:9:125:18 | entry_path :  |
+| zip_slip.rb:125:9:125:18 | entry_path :  | zip_slip.rb:126:21:126:30 | entry_path |
 nodes
+| zip_slip.rb:8:5:8:11 | tarfile :  | semmle.label | tarfile :  |
 | zip_slip.rb:8:15:8:54 | call to new :  | semmle.label | call to new :  |
 | zip_slip.rb:9:5:9:11 | tarfile :  | semmle.label | tarfile :  |
 | zip_slip.rb:9:22:9:26 | entry :  | semmle.label | entry :  |
@@ -34,15 +40,19 @@ nodes
 | zip_slip.rb:57:7:57:14 | zip_file :  | semmle.label | zip_file :  |
 | zip_slip.rb:57:25:57:29 | entry :  | semmle.label | entry :  |
 | zip_slip.rb:58:19:58:28 | call to name | semmle.label | call to name |
+| zip_slip.rb:90:5:90:8 | gzip :  | semmle.label | gzip :  |
 | zip_slip.rb:90:12:90:54 | call to open :  | semmle.label | call to open :  |
 | zip_slip.rb:91:11:91:14 | gzip :  | semmle.label | gzip :  |
 | zip_slip.rb:97:42:97:56 | compressed_file :  | semmle.label | compressed_file :  |
 | zip_slip.rb:98:7:98:21 | compressed_file :  | semmle.label | compressed_file :  |
 | zip_slip.rb:98:32:98:36 | entry :  | semmle.label | entry :  |
+| zip_slip.rb:99:9:99:18 | entry_path :  | semmle.label | entry_path :  |
 | zip_slip.rb:100:21:100:30 | entry_path | semmle.label | entry_path |
+| zip_slip.rb:123:7:123:8 | gz :  | semmle.label | gz :  |
 | zip_slip.rb:123:12:123:34 | call to new :  | semmle.label | call to new :  |
 | zip_slip.rb:124:7:124:8 | gz :  | semmle.label | gz :  |
 | zip_slip.rb:124:19:124:23 | entry :  | semmle.label | entry :  |
+| zip_slip.rb:125:9:125:18 | entry_path :  | semmle.label | entry_path :  |
 | zip_slip.rb:126:21:126:30 | entry_path | semmle.label | entry_path |
 subpaths
 #select

--- a/ruby/ql/test/query-tests/experimental/manually-check-http-verb/ManuallyCheckHttpVerb.expected
+++ b/ruby/ql/test/query-tests/experimental/manually-check-http-verb/ManuallyCheckHttpVerb.expected
@@ -1,22 +1,32 @@
 edges
+| ManuallyCheckHttpVerb.rb:11:5:11:10 | method :  | ManuallyCheckHttpVerb.rb:12:8:12:22 | ... == ... |
 | ManuallyCheckHttpVerb.rb:11:14:11:24 | call to env :  | ManuallyCheckHttpVerb.rb:11:14:11:42 | ...[...] :  |
-| ManuallyCheckHttpVerb.rb:11:14:11:42 | ...[...] :  | ManuallyCheckHttpVerb.rb:12:8:12:22 | ... == ... |
-| ManuallyCheckHttpVerb.rb:19:14:19:35 | call to request_method :  | ManuallyCheckHttpVerb.rb:20:8:20:22 | ... == ... |
-| ManuallyCheckHttpVerb.rb:27:14:27:27 | call to method :  | ManuallyCheckHttpVerb.rb:28:8:28:22 | ... == ... |
-| ManuallyCheckHttpVerb.rb:35:14:35:39 | call to raw_request_method :  | ManuallyCheckHttpVerb.rb:36:8:36:22 | ... == ... |
-| ManuallyCheckHttpVerb.rb:51:16:51:44 | call to request_method_symbol :  | ManuallyCheckHttpVerb.rb:52:10:52:23 | ... == ... |
+| ManuallyCheckHttpVerb.rb:11:14:11:42 | ...[...] :  | ManuallyCheckHttpVerb.rb:11:5:11:10 | method :  |
+| ManuallyCheckHttpVerb.rb:19:5:19:10 | method :  | ManuallyCheckHttpVerb.rb:20:8:20:22 | ... == ... |
+| ManuallyCheckHttpVerb.rb:19:14:19:35 | call to request_method :  | ManuallyCheckHttpVerb.rb:19:5:19:10 | method :  |
+| ManuallyCheckHttpVerb.rb:27:5:27:10 | method :  | ManuallyCheckHttpVerb.rb:28:8:28:22 | ... == ... |
+| ManuallyCheckHttpVerb.rb:27:14:27:27 | call to method :  | ManuallyCheckHttpVerb.rb:27:5:27:10 | method :  |
+| ManuallyCheckHttpVerb.rb:35:5:35:10 | method :  | ManuallyCheckHttpVerb.rb:36:8:36:22 | ... == ... |
+| ManuallyCheckHttpVerb.rb:35:14:35:39 | call to raw_request_method :  | ManuallyCheckHttpVerb.rb:35:5:35:10 | method :  |
+| ManuallyCheckHttpVerb.rb:51:7:51:12 | method :  | ManuallyCheckHttpVerb.rb:52:10:52:23 | ... == ... |
+| ManuallyCheckHttpVerb.rb:51:16:51:44 | call to request_method_symbol :  | ManuallyCheckHttpVerb.rb:51:7:51:12 | method :  |
 | ManuallyCheckHttpVerb.rb:59:10:59:20 | call to env :  | ManuallyCheckHttpVerb.rb:59:10:59:38 | ...[...] |
 nodes
 | ManuallyCheckHttpVerb.rb:4:8:4:19 | call to get? | semmle.label | call to get? |
+| ManuallyCheckHttpVerb.rb:11:5:11:10 | method :  | semmle.label | method :  |
 | ManuallyCheckHttpVerb.rb:11:14:11:24 | call to env :  | semmle.label | call to env :  |
 | ManuallyCheckHttpVerb.rb:11:14:11:42 | ...[...] :  | semmle.label | ...[...] :  |
 | ManuallyCheckHttpVerb.rb:12:8:12:22 | ... == ... | semmle.label | ... == ... |
+| ManuallyCheckHttpVerb.rb:19:5:19:10 | method :  | semmle.label | method :  |
 | ManuallyCheckHttpVerb.rb:19:14:19:35 | call to request_method :  | semmle.label | call to request_method :  |
 | ManuallyCheckHttpVerb.rb:20:8:20:22 | ... == ... | semmle.label | ... == ... |
+| ManuallyCheckHttpVerb.rb:27:5:27:10 | method :  | semmle.label | method :  |
 | ManuallyCheckHttpVerb.rb:27:14:27:27 | call to method :  | semmle.label | call to method :  |
 | ManuallyCheckHttpVerb.rb:28:8:28:22 | ... == ... | semmle.label | ... == ... |
+| ManuallyCheckHttpVerb.rb:35:5:35:10 | method :  | semmle.label | method :  |
 | ManuallyCheckHttpVerb.rb:35:14:35:39 | call to raw_request_method :  | semmle.label | call to raw_request_method :  |
 | ManuallyCheckHttpVerb.rb:36:8:36:22 | ... == ... | semmle.label | ... == ... |
+| ManuallyCheckHttpVerb.rb:51:7:51:12 | method :  | semmle.label | method :  |
 | ManuallyCheckHttpVerb.rb:51:16:51:44 | call to request_method_symbol :  | semmle.label | call to request_method_symbol :  |
 | ManuallyCheckHttpVerb.rb:52:10:52:23 | ... == ... | semmle.label | ... == ... |
 | ManuallyCheckHttpVerb.rb:59:10:59:20 | call to env :  | semmle.label | call to env :  |

--- a/ruby/ql/test/query-tests/security/cwe-022/PathInjection.expected
+++ b/ruby/ql/test/query-tests/security/cwe-022/PathInjection.expected
@@ -6,48 +6,62 @@ edges
 | ArchiveApiPathTraversal.rb:15:9:15:14 | call to params :  | ArchiveApiPathTraversal.rb:15:9:15:25 | ...[...] :  |
 | ArchiveApiPathTraversal.rb:15:9:15:25 | ...[...] :  | ArchiveApiPathTraversal.rb:75:11:75:18 | filename :  |
 | ArchiveApiPathTraversal.rb:49:17:49:27 | destination :  | ArchiveApiPathTraversal.rb:52:38:52:48 | destination :  |
-| ArchiveApiPathTraversal.rb:52:28:52:67 | call to join :  | ArchiveApiPathTraversal.rb:59:21:59:36 | destination_file |
+| ArchiveApiPathTraversal.rb:52:9:52:24 | destination_file :  | ArchiveApiPathTraversal.rb:59:21:59:36 | destination_file |
+| ArchiveApiPathTraversal.rb:52:28:52:67 | call to join :  | ArchiveApiPathTraversal.rb:52:9:52:24 | destination_file :  |
 | ArchiveApiPathTraversal.rb:52:38:52:48 | destination :  | ArchiveApiPathTraversal.rb:52:28:52:67 | call to join :  |
 | ArchiveApiPathTraversal.rb:67:13:67:16 | file :  | ArchiveApiPathTraversal.rb:68:20:68:23 | file |
 | ArchiveApiPathTraversal.rb:75:11:75:18 | filename :  | ArchiveApiPathTraversal.rb:76:19:76:26 | filename |
+| tainted_path.rb:4:5:4:8 | path :  | tainted_path.rb:5:26:5:29 | path |
 | tainted_path.rb:4:12:4:17 | call to params :  | tainted_path.rb:4:12:4:24 | ...[...] :  |
-| tainted_path.rb:4:12:4:24 | ...[...] :  | tainted_path.rb:5:26:5:29 | path |
-| tainted_path.rb:10:12:10:43 | call to absolute_path :  | tainted_path.rb:11:26:11:29 | path |
+| tainted_path.rb:4:12:4:24 | ...[...] :  | tainted_path.rb:4:5:4:8 | path :  |
+| tainted_path.rb:10:5:10:8 | path :  | tainted_path.rb:11:26:11:29 | path |
+| tainted_path.rb:10:12:10:43 | call to absolute_path :  | tainted_path.rb:10:5:10:8 | path :  |
 | tainted_path.rb:10:31:10:36 | call to params :  | tainted_path.rb:10:31:10:43 | ...[...] :  |
 | tainted_path.rb:10:31:10:43 | ...[...] :  | tainted_path.rb:10:12:10:43 | call to absolute_path :  |
-| tainted_path.rb:16:15:16:41 | call to dirname :  | tainted_path.rb:17:26:17:29 | path |
+| tainted_path.rb:16:5:16:8 | path :  | tainted_path.rb:17:26:17:29 | path |
+| tainted_path.rb:16:15:16:41 | call to dirname :  | tainted_path.rb:16:5:16:8 | path :  |
 | tainted_path.rb:16:28:16:33 | call to params :  | tainted_path.rb:16:28:16:40 | ...[...] :  |
 | tainted_path.rb:16:28:16:40 | ...[...] :  | tainted_path.rb:16:15:16:41 | call to dirname :  |
-| tainted_path.rb:22:12:22:41 | call to expand_path :  | tainted_path.rb:23:26:23:29 | path |
+| tainted_path.rb:22:5:22:8 | path :  | tainted_path.rb:23:26:23:29 | path |
+| tainted_path.rb:22:12:22:41 | call to expand_path :  | tainted_path.rb:22:5:22:8 | path :  |
 | tainted_path.rb:22:29:22:34 | call to params :  | tainted_path.rb:22:29:22:41 | ...[...] :  |
 | tainted_path.rb:22:29:22:41 | ...[...] :  | tainted_path.rb:22:12:22:41 | call to expand_path :  |
-| tainted_path.rb:28:12:28:34 | call to path :  | tainted_path.rb:29:26:29:29 | path |
+| tainted_path.rb:28:5:28:8 | path :  | tainted_path.rb:29:26:29:29 | path |
+| tainted_path.rb:28:12:28:34 | call to path :  | tainted_path.rb:28:5:28:8 | path :  |
 | tainted_path.rb:28:22:28:27 | call to params :  | tainted_path.rb:28:22:28:34 | ...[...] :  |
 | tainted_path.rb:28:22:28:34 | ...[...] :  | tainted_path.rb:28:12:28:34 | call to path :  |
-| tainted_path.rb:34:12:34:41 | call to realdirpath :  | tainted_path.rb:35:26:35:29 | path |
+| tainted_path.rb:34:5:34:8 | path :  | tainted_path.rb:35:26:35:29 | path |
+| tainted_path.rb:34:12:34:41 | call to realdirpath :  | tainted_path.rb:34:5:34:8 | path :  |
 | tainted_path.rb:34:29:34:34 | call to params :  | tainted_path.rb:34:29:34:41 | ...[...] :  |
 | tainted_path.rb:34:29:34:41 | ...[...] :  | tainted_path.rb:34:12:34:41 | call to realdirpath :  |
-| tainted_path.rb:40:12:40:38 | call to realpath :  | tainted_path.rb:41:26:41:29 | path |
+| tainted_path.rb:40:5:40:8 | path :  | tainted_path.rb:41:26:41:29 | path |
+| tainted_path.rb:40:12:40:38 | call to realpath :  | tainted_path.rb:40:5:40:8 | path :  |
 | tainted_path.rb:40:26:40:31 | call to params :  | tainted_path.rb:40:26:40:38 | ...[...] :  |
 | tainted_path.rb:40:26:40:38 | ...[...] :  | tainted_path.rb:40:12:40:38 | call to realpath :  |
-| tainted_path.rb:47:12:47:63 | call to join :  | tainted_path.rb:48:26:48:29 | path |
+| tainted_path.rb:47:5:47:8 | path :  | tainted_path.rb:48:26:48:29 | path |
+| tainted_path.rb:47:12:47:63 | call to join :  | tainted_path.rb:47:5:47:8 | path :  |
 | tainted_path.rb:47:43:47:48 | call to params :  | tainted_path.rb:47:43:47:55 | ...[...] :  |
 | tainted_path.rb:47:43:47:55 | ...[...] :  | tainted_path.rb:47:12:47:63 | call to join :  |
-| tainted_path.rb:59:12:59:53 | call to new :  | tainted_path.rb:60:26:60:29 | path |
+| tainted_path.rb:59:5:59:8 | path :  | tainted_path.rb:60:26:60:29 | path |
+| tainted_path.rb:59:12:59:53 | call to new :  | tainted_path.rb:59:5:59:8 | path :  |
 | tainted_path.rb:59:40:59:45 | call to params :  | tainted_path.rb:59:40:59:52 | ...[...] :  |
 | tainted_path.rb:59:40:59:52 | ...[...] :  | tainted_path.rb:59:12:59:53 | call to new :  |
-| tainted_path.rb:71:12:71:53 | call to new :  | tainted_path.rb:72:15:72:18 | path |
+| tainted_path.rb:71:5:71:8 | path :  | tainted_path.rb:72:15:72:18 | path |
+| tainted_path.rb:71:12:71:53 | call to new :  | tainted_path.rb:71:5:71:8 | path :  |
 | tainted_path.rb:71:40:71:45 | call to params :  | tainted_path.rb:71:40:71:52 | ...[...] :  |
 | tainted_path.rb:71:40:71:52 | ...[...] :  | tainted_path.rb:71:12:71:53 | call to new :  |
-| tainted_path.rb:77:12:77:53 | call to new :  | tainted_path.rb:78:19:78:22 | path |
-| tainted_path.rb:77:12:77:53 | call to new :  | tainted_path.rb:79:14:79:17 | path |
+| tainted_path.rb:77:5:77:8 | path :  | tainted_path.rb:78:19:78:22 | path |
+| tainted_path.rb:77:5:77:8 | path :  | tainted_path.rb:79:14:79:17 | path |
+| tainted_path.rb:77:12:77:53 | call to new :  | tainted_path.rb:77:5:77:8 | path :  |
 | tainted_path.rb:77:40:77:45 | call to params :  | tainted_path.rb:77:40:77:52 | ...[...] :  |
 | tainted_path.rb:77:40:77:52 | ...[...] :  | tainted_path.rb:77:12:77:53 | call to new :  |
-| tainted_path.rb:84:12:84:53 | call to new :  | tainted_path.rb:85:10:85:13 | path |
-| tainted_path.rb:84:12:84:53 | call to new :  | tainted_path.rb:86:25:86:28 | path |
+| tainted_path.rb:84:5:84:8 | path :  | tainted_path.rb:85:10:85:13 | path |
+| tainted_path.rb:84:5:84:8 | path :  | tainted_path.rb:86:25:86:28 | path |
+| tainted_path.rb:84:12:84:53 | call to new :  | tainted_path.rb:84:5:84:8 | path :  |
 | tainted_path.rb:84:40:84:45 | call to params :  | tainted_path.rb:84:40:84:52 | ...[...] :  |
 | tainted_path.rb:84:40:84:52 | ...[...] :  | tainted_path.rb:84:12:84:53 | call to new :  |
-| tainted_path.rb:90:12:90:53 | call to new :  | tainted_path.rb:92:11:92:14 | path |
+| tainted_path.rb:90:5:90:8 | path :  | tainted_path.rb:92:11:92:14 | path |
+| tainted_path.rb:90:12:90:53 | call to new :  | tainted_path.rb:90:5:90:8 | path :  |
 | tainted_path.rb:90:40:90:45 | call to params :  | tainted_path.rb:90:40:90:52 | ...[...] :  |
 | tainted_path.rb:90:40:90:52 | ...[...] :  | tainted_path.rb:90:12:90:53 | call to new :  |
 nodes
@@ -58,6 +72,7 @@ nodes
 | ArchiveApiPathTraversal.rb:15:9:15:14 | call to params :  | semmle.label | call to params :  |
 | ArchiveApiPathTraversal.rb:15:9:15:25 | ...[...] :  | semmle.label | ...[...] :  |
 | ArchiveApiPathTraversal.rb:49:17:49:27 | destination :  | semmle.label | destination :  |
+| ArchiveApiPathTraversal.rb:52:9:52:24 | destination_file :  | semmle.label | destination_file :  |
 | ArchiveApiPathTraversal.rb:52:28:52:67 | call to join :  | semmle.label | call to join :  |
 | ArchiveApiPathTraversal.rb:52:38:52:48 | destination :  | semmle.label | destination :  |
 | ArchiveApiPathTraversal.rb:59:21:59:36 | destination_file | semmle.label | destination_file |
@@ -65,55 +80,68 @@ nodes
 | ArchiveApiPathTraversal.rb:68:20:68:23 | file | semmle.label | file |
 | ArchiveApiPathTraversal.rb:75:11:75:18 | filename :  | semmle.label | filename :  |
 | ArchiveApiPathTraversal.rb:76:19:76:26 | filename | semmle.label | filename |
+| tainted_path.rb:4:5:4:8 | path :  | semmle.label | path :  |
 | tainted_path.rb:4:12:4:17 | call to params :  | semmle.label | call to params :  |
 | tainted_path.rb:4:12:4:24 | ...[...] :  | semmle.label | ...[...] :  |
 | tainted_path.rb:5:26:5:29 | path | semmle.label | path |
+| tainted_path.rb:10:5:10:8 | path :  | semmle.label | path :  |
 | tainted_path.rb:10:12:10:43 | call to absolute_path :  | semmle.label | call to absolute_path :  |
 | tainted_path.rb:10:31:10:36 | call to params :  | semmle.label | call to params :  |
 | tainted_path.rb:10:31:10:43 | ...[...] :  | semmle.label | ...[...] :  |
 | tainted_path.rb:11:26:11:29 | path | semmle.label | path |
+| tainted_path.rb:16:5:16:8 | path :  | semmle.label | path :  |
 | tainted_path.rb:16:15:16:41 | call to dirname :  | semmle.label | call to dirname :  |
 | tainted_path.rb:16:28:16:33 | call to params :  | semmle.label | call to params :  |
 | tainted_path.rb:16:28:16:40 | ...[...] :  | semmle.label | ...[...] :  |
 | tainted_path.rb:17:26:17:29 | path | semmle.label | path |
+| tainted_path.rb:22:5:22:8 | path :  | semmle.label | path :  |
 | tainted_path.rb:22:12:22:41 | call to expand_path :  | semmle.label | call to expand_path :  |
 | tainted_path.rb:22:29:22:34 | call to params :  | semmle.label | call to params :  |
 | tainted_path.rb:22:29:22:41 | ...[...] :  | semmle.label | ...[...] :  |
 | tainted_path.rb:23:26:23:29 | path | semmle.label | path |
+| tainted_path.rb:28:5:28:8 | path :  | semmle.label | path :  |
 | tainted_path.rb:28:12:28:34 | call to path :  | semmle.label | call to path :  |
 | tainted_path.rb:28:22:28:27 | call to params :  | semmle.label | call to params :  |
 | tainted_path.rb:28:22:28:34 | ...[...] :  | semmle.label | ...[...] :  |
 | tainted_path.rb:29:26:29:29 | path | semmle.label | path |
+| tainted_path.rb:34:5:34:8 | path :  | semmle.label | path :  |
 | tainted_path.rb:34:12:34:41 | call to realdirpath :  | semmle.label | call to realdirpath :  |
 | tainted_path.rb:34:29:34:34 | call to params :  | semmle.label | call to params :  |
 | tainted_path.rb:34:29:34:41 | ...[...] :  | semmle.label | ...[...] :  |
 | tainted_path.rb:35:26:35:29 | path | semmle.label | path |
+| tainted_path.rb:40:5:40:8 | path :  | semmle.label | path :  |
 | tainted_path.rb:40:12:40:38 | call to realpath :  | semmle.label | call to realpath :  |
 | tainted_path.rb:40:26:40:31 | call to params :  | semmle.label | call to params :  |
 | tainted_path.rb:40:26:40:38 | ...[...] :  | semmle.label | ...[...] :  |
 | tainted_path.rb:41:26:41:29 | path | semmle.label | path |
+| tainted_path.rb:47:5:47:8 | path :  | semmle.label | path :  |
 | tainted_path.rb:47:12:47:63 | call to join :  | semmle.label | call to join :  |
 | tainted_path.rb:47:43:47:48 | call to params :  | semmle.label | call to params :  |
 | tainted_path.rb:47:43:47:55 | ...[...] :  | semmle.label | ...[...] :  |
 | tainted_path.rb:48:26:48:29 | path | semmle.label | path |
+| tainted_path.rb:59:5:59:8 | path :  | semmle.label | path :  |
 | tainted_path.rb:59:12:59:53 | call to new :  | semmle.label | call to new :  |
 | tainted_path.rb:59:40:59:45 | call to params :  | semmle.label | call to params :  |
 | tainted_path.rb:59:40:59:52 | ...[...] :  | semmle.label | ...[...] :  |
 | tainted_path.rb:60:26:60:29 | path | semmle.label | path |
+| tainted_path.rb:71:5:71:8 | path :  | semmle.label | path :  |
 | tainted_path.rb:71:12:71:53 | call to new :  | semmle.label | call to new :  |
 | tainted_path.rb:71:40:71:45 | call to params :  | semmle.label | call to params :  |
 | tainted_path.rb:71:40:71:52 | ...[...] :  | semmle.label | ...[...] :  |
 | tainted_path.rb:72:15:72:18 | path | semmle.label | path |
+| tainted_path.rb:77:5:77:8 | path :  | semmle.label | path :  |
 | tainted_path.rb:77:12:77:53 | call to new :  | semmle.label | call to new :  |
 | tainted_path.rb:77:40:77:45 | call to params :  | semmle.label | call to params :  |
 | tainted_path.rb:77:40:77:52 | ...[...] :  | semmle.label | ...[...] :  |
 | tainted_path.rb:78:19:78:22 | path | semmle.label | path |
 | tainted_path.rb:79:14:79:17 | path | semmle.label | path |
+| tainted_path.rb:84:5:84:8 | path :  | semmle.label | path :  |
 | tainted_path.rb:84:12:84:53 | call to new :  | semmle.label | call to new :  |
 | tainted_path.rb:84:40:84:45 | call to params :  | semmle.label | call to params :  |
 | tainted_path.rb:84:40:84:52 | ...[...] :  | semmle.label | ...[...] :  |
 | tainted_path.rb:85:10:85:13 | path | semmle.label | path |
 | tainted_path.rb:86:25:86:28 | path | semmle.label | path |
+| tainted_path.rb:90:5:90:8 | path :  | semmle.label | path :  |
 | tainted_path.rb:90:12:90:53 | call to new :  | semmle.label | call to new :  |
 | tainted_path.rb:90:40:90:45 | call to params :  | semmle.label | call to params :  |
 | tainted_path.rb:90:40:90:52 | ...[...] :  | semmle.label | ...[...] :  |

--- a/ruby/ql/test/query-tests/security/cwe-078/CommandInjection/CommandInjection.expected
+++ b/ruby/ql/test/query-tests/security/cwe-078/CommandInjection/CommandInjection.expected
@@ -1,25 +1,30 @@
 edges
+| CommandInjection.rb:6:9:6:11 | cmd :  | CommandInjection.rb:7:10:7:15 | #{...} |
+| CommandInjection.rb:6:9:6:11 | cmd :  | CommandInjection.rb:8:16:8:18 | cmd |
+| CommandInjection.rb:6:9:6:11 | cmd :  | CommandInjection.rb:10:14:10:16 | cmd |
+| CommandInjection.rb:6:9:6:11 | cmd :  | CommandInjection.rb:11:17:11:22 | #{...} |
+| CommandInjection.rb:6:9:6:11 | cmd :  | CommandInjection.rb:13:9:13:14 | #{...} |
+| CommandInjection.rb:6:9:6:11 | cmd :  | CommandInjection.rb:29:19:29:24 | #{...} |
+| CommandInjection.rb:6:9:6:11 | cmd :  | CommandInjection.rb:33:24:33:36 | "echo #{...}" |
+| CommandInjection.rb:6:9:6:11 | cmd :  | CommandInjection.rb:34:39:34:51 | "grep #{...}" |
 | CommandInjection.rb:6:15:6:20 | call to params :  | CommandInjection.rb:6:15:6:26 | ...[...] :  |
-| CommandInjection.rb:6:15:6:26 | ...[...] :  | CommandInjection.rb:7:10:7:15 | #{...} |
-| CommandInjection.rb:6:15:6:26 | ...[...] :  | CommandInjection.rb:8:16:8:18 | cmd |
-| CommandInjection.rb:6:15:6:26 | ...[...] :  | CommandInjection.rb:10:14:10:16 | cmd |
-| CommandInjection.rb:6:15:6:26 | ...[...] :  | CommandInjection.rb:11:17:11:22 | #{...} |
-| CommandInjection.rb:6:15:6:26 | ...[...] :  | CommandInjection.rb:13:9:13:14 | #{...} |
-| CommandInjection.rb:6:15:6:26 | ...[...] :  | CommandInjection.rb:29:19:29:24 | #{...} |
-| CommandInjection.rb:6:15:6:26 | ...[...] :  | CommandInjection.rb:33:24:33:36 | "echo #{...}" |
-| CommandInjection.rb:6:15:6:26 | ...[...] :  | CommandInjection.rb:34:39:34:51 | "grep #{...}" |
+| CommandInjection.rb:6:15:6:26 | ...[...] :  | CommandInjection.rb:6:9:6:11 | cmd :  |
+| CommandInjection.rb:46:9:46:11 | cmd :  | CommandInjection.rb:50:24:50:36 | "echo #{...}" |
 | CommandInjection.rb:46:15:46:20 | call to params :  | CommandInjection.rb:46:15:46:26 | ...[...] :  |
-| CommandInjection.rb:46:15:46:26 | ...[...] :  | CommandInjection.rb:50:24:50:36 | "echo #{...}" |
+| CommandInjection.rb:46:15:46:26 | ...[...] :  | CommandInjection.rb:46:9:46:11 | cmd :  |
+| CommandInjection.rb:54:7:54:9 | cmd :  | CommandInjection.rb:59:14:59:16 | cmd |
 | CommandInjection.rb:54:13:54:18 | call to params :  | CommandInjection.rb:54:13:54:24 | ...[...] :  |
-| CommandInjection.rb:54:13:54:24 | ...[...] :  | CommandInjection.rb:59:14:59:16 | cmd |
+| CommandInjection.rb:54:13:54:24 | ...[...] :  | CommandInjection.rb:54:7:54:9 | cmd :  |
 | CommandInjection.rb:73:18:73:23 | number :  | CommandInjection.rb:74:14:74:29 | "echo #{...}" |
 | CommandInjection.rb:81:23:81:33 | blah_number :  | CommandInjection.rb:82:14:82:34 | "echo #{...}" |
 | CommandInjection.rb:90:20:90:25 | **args :  | CommandInjection.rb:91:22:91:25 | args :  |
 | CommandInjection.rb:91:22:91:25 | args :  | CommandInjection.rb:91:22:91:37 | ...[...] :  |
 | CommandInjection.rb:91:22:91:37 | ...[...] :  | CommandInjection.rb:91:14:91:39 | "echo #{...}" |
+| CommandInjection.rb:103:9:103:12 | file :  | CommandInjection.rb:104:16:104:28 | "cat #{...}" |
 | CommandInjection.rb:103:16:103:21 | call to params :  | CommandInjection.rb:103:16:103:28 | ...[...] :  |
-| CommandInjection.rb:103:16:103:28 | ...[...] :  | CommandInjection.rb:104:16:104:28 | "cat #{...}" |
+| CommandInjection.rb:103:16:103:28 | ...[...] :  | CommandInjection.rb:103:9:103:12 | file :  |
 nodes
+| CommandInjection.rb:6:9:6:11 | cmd :  | semmle.label | cmd :  |
 | CommandInjection.rb:6:15:6:20 | call to params :  | semmle.label | call to params :  |
 | CommandInjection.rb:6:15:6:26 | ...[...] :  | semmle.label | ...[...] :  |
 | CommandInjection.rb:7:10:7:15 | #{...} | semmle.label | #{...} |
@@ -30,9 +35,11 @@ nodes
 | CommandInjection.rb:29:19:29:24 | #{...} | semmle.label | #{...} |
 | CommandInjection.rb:33:24:33:36 | "echo #{...}" | semmle.label | "echo #{...}" |
 | CommandInjection.rb:34:39:34:51 | "grep #{...}" | semmle.label | "grep #{...}" |
+| CommandInjection.rb:46:9:46:11 | cmd :  | semmle.label | cmd :  |
 | CommandInjection.rb:46:15:46:20 | call to params :  | semmle.label | call to params :  |
 | CommandInjection.rb:46:15:46:26 | ...[...] :  | semmle.label | ...[...] :  |
 | CommandInjection.rb:50:24:50:36 | "echo #{...}" | semmle.label | "echo #{...}" |
+| CommandInjection.rb:54:7:54:9 | cmd :  | semmle.label | cmd :  |
 | CommandInjection.rb:54:13:54:18 | call to params :  | semmle.label | call to params :  |
 | CommandInjection.rb:54:13:54:24 | ...[...] :  | semmle.label | ...[...] :  |
 | CommandInjection.rb:59:14:59:16 | cmd | semmle.label | cmd |
@@ -44,6 +51,7 @@ nodes
 | CommandInjection.rb:91:14:91:39 | "echo #{...}" | semmle.label | "echo #{...}" |
 | CommandInjection.rb:91:22:91:25 | args :  | semmle.label | args :  |
 | CommandInjection.rb:91:22:91:37 | ...[...] :  | semmle.label | ...[...] :  |
+| CommandInjection.rb:103:9:103:12 | file :  | semmle.label | file :  |
 | CommandInjection.rb:103:16:103:21 | call to params :  | semmle.label | call to params :  |
 | CommandInjection.rb:103:16:103:28 | ...[...] :  | semmle.label | ...[...] :  |
 | CommandInjection.rb:104:16:104:28 | "cat #{...}" | semmle.label | "cat #{...}" |

--- a/ruby/ql/test/query-tests/security/cwe-078/KernelOpen/KernelOpen.expected
+++ b/ruby/ql/test/query-tests/security/cwe-078/KernelOpen/KernelOpen.expected
@@ -1,17 +1,19 @@
 edges
+| KernelOpen.rb:3:5:3:8 | file :  | KernelOpen.rb:4:10:4:13 | file |
+| KernelOpen.rb:3:5:3:8 | file :  | KernelOpen.rb:5:13:5:16 | file |
+| KernelOpen.rb:3:5:3:8 | file :  | KernelOpen.rb:6:14:6:17 | file |
+| KernelOpen.rb:3:5:3:8 | file :  | KernelOpen.rb:7:16:7:19 | file |
+| KernelOpen.rb:3:5:3:8 | file :  | KernelOpen.rb:8:17:8:20 | file |
+| KernelOpen.rb:3:5:3:8 | file :  | KernelOpen.rb:9:16:9:19 | file |
+| KernelOpen.rb:3:5:3:8 | file :  | KernelOpen.rb:10:18:10:21 | file |
+| KernelOpen.rb:3:5:3:8 | file :  | KernelOpen.rb:11:14:11:17 | file |
+| KernelOpen.rb:3:5:3:8 | file :  | KernelOpen.rb:13:23:13:26 | file :  |
+| KernelOpen.rb:3:5:3:8 | file :  | KernelOpen.rb:26:10:26:13 | file |
 | KernelOpen.rb:3:12:3:17 | call to params :  | KernelOpen.rb:3:12:3:24 | ...[...] :  |
-| KernelOpen.rb:3:12:3:24 | ...[...] :  | KernelOpen.rb:4:10:4:13 | file |
-| KernelOpen.rb:3:12:3:24 | ...[...] :  | KernelOpen.rb:5:13:5:16 | file |
-| KernelOpen.rb:3:12:3:24 | ...[...] :  | KernelOpen.rb:6:14:6:17 | file |
-| KernelOpen.rb:3:12:3:24 | ...[...] :  | KernelOpen.rb:7:16:7:19 | file |
-| KernelOpen.rb:3:12:3:24 | ...[...] :  | KernelOpen.rb:8:17:8:20 | file |
-| KernelOpen.rb:3:12:3:24 | ...[...] :  | KernelOpen.rb:9:16:9:19 | file |
-| KernelOpen.rb:3:12:3:24 | ...[...] :  | KernelOpen.rb:10:18:10:21 | file |
-| KernelOpen.rb:3:12:3:24 | ...[...] :  | KernelOpen.rb:11:14:11:17 | file |
-| KernelOpen.rb:3:12:3:24 | ...[...] :  | KernelOpen.rb:13:23:13:26 | file :  |
-| KernelOpen.rb:3:12:3:24 | ...[...] :  | KernelOpen.rb:26:10:26:13 | file |
+| KernelOpen.rb:3:12:3:24 | ...[...] :  | KernelOpen.rb:3:5:3:8 | file :  |
 | KernelOpen.rb:13:23:13:26 | file :  | KernelOpen.rb:13:13:13:31 | call to join |
 nodes
+| KernelOpen.rb:3:5:3:8 | file :  | semmle.label | file :  |
 | KernelOpen.rb:3:12:3:17 | call to params :  | semmle.label | call to params :  |
 | KernelOpen.rb:3:12:3:24 | ...[...] :  | semmle.label | ...[...] :  |
 | KernelOpen.rb:4:10:4:13 | file | semmle.label | file |

--- a/ruby/ql/test/query-tests/security/cwe-079/ReflectedXSS.expected
+++ b/ruby/ql/test/query-tests/security/cwe-079/ReflectedXSS.expected
@@ -8,9 +8,10 @@ edges
 | app/controllers/foo/bars_controller.rb:13:20:13:37 | ...[...] :  | app/views/foo/bars/show.html.erb:50:5:50:18 | call to user_name_memo |
 | app/controllers/foo/bars_controller.rb:17:21:17:26 | call to params :  | app/controllers/foo/bars_controller.rb:17:21:17:36 | ...[...] :  |
 | app/controllers/foo/bars_controller.rb:17:21:17:36 | ...[...] :  | app/views/foo/bars/show.html.erb:2:18:2:30 | @user_website |
+| app/controllers/foo/bars_controller.rb:18:5:18:6 | dt :  | app/controllers/foo/bars_controller.rb:19:22:19:23 | dt :  |
+| app/controllers/foo/bars_controller.rb:18:5:18:6 | dt :  | app/controllers/foo/bars_controller.rb:26:53:26:54 | dt :  |
 | app/controllers/foo/bars_controller.rb:18:10:18:15 | call to params :  | app/controllers/foo/bars_controller.rb:18:10:18:22 | ...[...] :  |
-| app/controllers/foo/bars_controller.rb:18:10:18:22 | ...[...] :  | app/controllers/foo/bars_controller.rb:19:22:19:23 | dt :  |
-| app/controllers/foo/bars_controller.rb:18:10:18:22 | ...[...] :  | app/controllers/foo/bars_controller.rb:26:53:26:54 | dt :  |
+| app/controllers/foo/bars_controller.rb:18:10:18:22 | ...[...] :  | app/controllers/foo/bars_controller.rb:18:5:18:6 | dt :  |
 | app/controllers/foo/bars_controller.rb:19:22:19:23 | dt :  | app/views/foo/bars/show.html.erb:40:3:40:16 | @instance_text |
 | app/controllers/foo/bars_controller.rb:24:39:24:44 | call to params :  | app/controllers/foo/bars_controller.rb:24:39:24:59 | ...[...] :  |
 | app/controllers/foo/bars_controller.rb:24:39:24:59 | ...[...] :  | app/controllers/foo/bars_controller.rb:24:39:24:59 | ... = ... |
@@ -20,8 +21,9 @@ edges
 | app/controllers/foo/bars_controller.rb:26:53:26:54 | dt :  | app/views/foo/bars/show.html.erb:17:15:17:27 | call to local_assigns [element :display_text] :  |
 | app/controllers/foo/bars_controller.rb:26:53:26:54 | dt :  | app/views/foo/bars/show.html.erb:35:3:35:14 | call to display_text |
 | app/controllers/foo/bars_controller.rb:26:53:26:54 | dt :  | app/views/foo/bars/show.html.erb:43:76:43:87 | call to display_text :  |
+| app/controllers/foo/bars_controller.rb:30:5:30:7 | str :  | app/controllers/foo/bars_controller.rb:31:5:31:7 | str |
 | app/controllers/foo/bars_controller.rb:30:11:30:16 | call to params :  | app/controllers/foo/bars_controller.rb:30:11:30:28 | ...[...] :  |
-| app/controllers/foo/bars_controller.rb:30:11:30:28 | ...[...] :  | app/controllers/foo/bars_controller.rb:31:5:31:7 | str |
+| app/controllers/foo/bars_controller.rb:30:11:30:28 | ...[...] :  | app/controllers/foo/bars_controller.rb:30:5:30:7 | str :  |
 | app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns [element :display_text] :  | app/views/foo/bars/_widget.html.erb:8:9:8:36 | ...[...] |
 | app/views/foo/bars/show.html.erb:8:9:8:21 | call to local_assigns [element :display_text] :  | app/views/foo/bars/show.html.erb:8:9:8:36 | ...[...] |
 | app/views/foo/bars/show.html.erb:12:9:12:21 | call to local_assigns [element :display_text] :  | app/views/foo/bars/show.html.erb:12:9:12:26 | ...[...] |
@@ -41,6 +43,7 @@ nodes
 | app/controllers/foo/bars_controller.rb:13:20:13:37 | ...[...] :  | semmle.label | ...[...] :  |
 | app/controllers/foo/bars_controller.rb:17:21:17:26 | call to params :  | semmle.label | call to params :  |
 | app/controllers/foo/bars_controller.rb:17:21:17:36 | ...[...] :  | semmle.label | ...[...] :  |
+| app/controllers/foo/bars_controller.rb:18:5:18:6 | dt :  | semmle.label | dt :  |
 | app/controllers/foo/bars_controller.rb:18:10:18:15 | call to params :  | semmle.label | call to params :  |
 | app/controllers/foo/bars_controller.rb:18:10:18:22 | ...[...] :  | semmle.label | ...[...] :  |
 | app/controllers/foo/bars_controller.rb:19:22:19:23 | dt :  | semmle.label | dt :  |
@@ -48,6 +51,7 @@ nodes
 | app/controllers/foo/bars_controller.rb:24:39:24:59 | ... = ... | semmle.label | ... = ... |
 | app/controllers/foo/bars_controller.rb:24:39:24:59 | ...[...] :  | semmle.label | ...[...] :  |
 | app/controllers/foo/bars_controller.rb:26:53:26:54 | dt :  | semmle.label | dt :  |
+| app/controllers/foo/bars_controller.rb:30:5:30:7 | str :  | semmle.label | str :  |
 | app/controllers/foo/bars_controller.rb:30:11:30:16 | call to params :  | semmle.label | call to params :  |
 | app/controllers/foo/bars_controller.rb:30:11:30:28 | ...[...] :  | semmle.label | ...[...] :  |
 | app/controllers/foo/bars_controller.rb:31:5:31:7 | str | semmle.label | str |

--- a/ruby/ql/test/query-tests/security/cwe-079/StoredXSS.expected
+++ b/ruby/ql/test/query-tests/security/cwe-079/StoredXSS.expected
@@ -1,6 +1,7 @@
 edges
-| app/controllers/foo/stores_controller.rb:8:10:8:29 | call to read :  | app/controllers/foo/stores_controller.rb:9:22:9:23 | dt :  |
-| app/controllers/foo/stores_controller.rb:8:10:8:29 | call to read :  | app/controllers/foo/stores_controller.rb:13:55:13:56 | dt :  |
+| app/controllers/foo/stores_controller.rb:8:5:8:6 | dt :  | app/controllers/foo/stores_controller.rb:9:22:9:23 | dt :  |
+| app/controllers/foo/stores_controller.rb:8:5:8:6 | dt :  | app/controllers/foo/stores_controller.rb:13:55:13:56 | dt :  |
+| app/controllers/foo/stores_controller.rb:8:10:8:29 | call to read :  | app/controllers/foo/stores_controller.rb:8:5:8:6 | dt :  |
 | app/controllers/foo/stores_controller.rb:9:22:9:23 | dt :  | app/views/foo/stores/show.html.erb:37:3:37:16 | @instance_text |
 | app/controllers/foo/stores_controller.rb:12:28:12:48 | call to raw_name :  | app/views/foo/stores/show.html.erb:82:5:82:24 | @other_user_raw_name |
 | app/controllers/foo/stores_controller.rb:13:55:13:56 | dt :  | app/views/foo/stores/show.html.erb:2:9:2:20 | call to display_text |
@@ -18,6 +19,7 @@ edges
 | app/views/foo/stores/show.html.erb:40:76:40:87 | call to display_text :  | app/views/foo/stores/show.html.erb:40:64:40:87 | ... + ... :  |
 | app/views/foo/stores/show.html.erb:86:17:86:28 | call to handle :  | app/views/foo/stores/show.html.erb:86:3:86:29 | call to sprintf |
 nodes
+| app/controllers/foo/stores_controller.rb:8:5:8:6 | dt :  | semmle.label | dt :  |
 | app/controllers/foo/stores_controller.rb:8:10:8:29 | call to read :  | semmle.label | call to read :  |
 | app/controllers/foo/stores_controller.rb:9:22:9:23 | dt :  | semmle.label | dt :  |
 | app/controllers/foo/stores_controller.rb:12:28:12:48 | call to raw_name :  | semmle.label | call to raw_name :  |

--- a/ruby/ql/test/query-tests/security/cwe-089/SqlInjection.expected
+++ b/ruby/ql/test/query-tests/security/cwe-089/SqlInjection.expected
@@ -28,16 +28,21 @@ edges
 | ActiveRecordInjection.rb:92:21:92:26 | call to params :  | ActiveRecordInjection.rb:92:21:92:35 | ...[...] |
 | ActiveRecordInjection.rb:94:18:94:23 | call to params :  | ActiveRecordInjection.rb:94:18:94:35 | ...[...] |
 | ActiveRecordInjection.rb:96:23:96:28 | call to params :  | ActiveRecordInjection.rb:96:23:96:47 | ...[...] |
-| ActiveRecordInjection.rb:102:10:102:15 | call to params :  | ActiveRecordInjection.rb:103:11:103:12 | ps :  |
+| ActiveRecordInjection.rb:102:5:102:6 | ps :  | ActiveRecordInjection.rb:103:11:103:12 | ps :  |
+| ActiveRecordInjection.rb:102:10:102:15 | call to params :  | ActiveRecordInjection.rb:102:5:102:6 | ps :  |
+| ActiveRecordInjection.rb:103:5:103:7 | uid :  | ActiveRecordInjection.rb:104:5:104:9 | uidEq :  |
 | ActiveRecordInjection.rb:103:11:103:12 | ps :  | ActiveRecordInjection.rb:103:11:103:17 | ...[...] :  |
-| ActiveRecordInjection.rb:103:11:103:17 | ...[...] :  | ActiveRecordInjection.rb:108:20:108:32 | ... + ... |
+| ActiveRecordInjection.rb:103:11:103:17 | ...[...] :  | ActiveRecordInjection.rb:103:5:103:7 | uid :  |
+| ActiveRecordInjection.rb:104:5:104:9 | uidEq :  | ActiveRecordInjection.rb:108:20:108:32 | ... + ... |
 | ActiveRecordInjection.rb:141:21:141:26 | call to params :  | ActiveRecordInjection.rb:141:21:141:44 | ...[...] :  |
 | ActiveRecordInjection.rb:141:21:141:44 | ...[...] :  | ActiveRecordInjection.rb:20:22:20:30 | condition :  |
 | ActiveRecordInjection.rb:155:59:155:64 | call to params :  | ActiveRecordInjection.rb:155:59:155:74 | ...[...] :  |
 | ActiveRecordInjection.rb:155:59:155:74 | ...[...] :  | ActiveRecordInjection.rb:155:27:155:76 | "this is an unsafe annotation:..." |
-| ActiveRecordInjection.rb:166:17:166:32 | call to permitted_params :  | ActiveRecordInjection.rb:167:47:167:55 | my_params :  |
+| ActiveRecordInjection.rb:166:5:166:13 | my_params :  | ActiveRecordInjection.rb:167:47:167:55 | my_params :  |
+| ActiveRecordInjection.rb:166:17:166:32 | call to permitted_params :  | ActiveRecordInjection.rb:166:5:166:13 | my_params :  |
+| ActiveRecordInjection.rb:167:5:167:9 | query :  | ActiveRecordInjection.rb:168:37:168:41 | query |
 | ActiveRecordInjection.rb:167:47:167:55 | my_params :  | ActiveRecordInjection.rb:167:47:167:65 | ...[...] :  |
-| ActiveRecordInjection.rb:167:47:167:65 | ...[...] :  | ActiveRecordInjection.rb:168:37:168:41 | query |
+| ActiveRecordInjection.rb:167:47:167:65 | ...[...] :  | ActiveRecordInjection.rb:167:5:167:9 | query :  |
 | ActiveRecordInjection.rb:173:5:173:10 | call to params :  | ActiveRecordInjection.rb:173:5:173:27 | call to require :  |
 | ActiveRecordInjection.rb:173:5:173:27 | call to require :  | ActiveRecordInjection.rb:173:5:173:59 | call to permit :  |
 | ActiveRecordInjection.rb:173:5:173:59 | call to permit :  | ActiveRecordInjection.rb:166:17:166:32 | call to permitted_params :  |
@@ -47,8 +52,9 @@ edges
 | ActiveRecordInjection.rb:177:77:177:102 | ...[...] :  | ActiveRecordInjection.rb:177:43:177:104 | "SELECT * FROM users WHERE id ..." |
 | ActiveRecordInjection.rb:178:69:178:84 | call to permitted_params :  | ActiveRecordInjection.rb:178:69:178:94 | ...[...] :  |
 | ActiveRecordInjection.rb:178:69:178:94 | ...[...] :  | ActiveRecordInjection.rb:178:35:178:96 | "SELECT * FROM users WHERE id ..." |
+| ArelInjection.rb:4:5:4:8 | name :  | ArelInjection.rb:6:20:6:61 | "SELECT * FROM users WHERE nam..." |
 | ArelInjection.rb:4:12:4:17 | call to params :  | ArelInjection.rb:4:12:4:29 | ...[...] :  |
-| ArelInjection.rb:4:12:4:29 | ...[...] :  | ArelInjection.rb:6:20:6:61 | "SELECT * FROM users WHERE nam..." |
+| ArelInjection.rb:4:12:4:29 | ...[...] :  | ArelInjection.rb:4:5:4:8 | name :  |
 nodes
 | ActiveRecordInjection.rb:8:25:8:28 | name :  | semmle.label | name :  |
 | ActiveRecordInjection.rb:8:31:8:34 | pass :  | semmle.label | pass :  |
@@ -96,16 +102,21 @@ nodes
 | ActiveRecordInjection.rb:94:18:94:35 | ...[...] | semmle.label | ...[...] |
 | ActiveRecordInjection.rb:96:23:96:28 | call to params :  | semmle.label | call to params :  |
 | ActiveRecordInjection.rb:96:23:96:47 | ...[...] | semmle.label | ...[...] |
+| ActiveRecordInjection.rb:102:5:102:6 | ps :  | semmle.label | ps :  |
 | ActiveRecordInjection.rb:102:10:102:15 | call to params :  | semmle.label | call to params :  |
+| ActiveRecordInjection.rb:103:5:103:7 | uid :  | semmle.label | uid :  |
 | ActiveRecordInjection.rb:103:11:103:12 | ps :  | semmle.label | ps :  |
 | ActiveRecordInjection.rb:103:11:103:17 | ...[...] :  | semmle.label | ...[...] :  |
+| ActiveRecordInjection.rb:104:5:104:9 | uidEq :  | semmle.label | uidEq :  |
 | ActiveRecordInjection.rb:108:20:108:32 | ... + ... | semmle.label | ... + ... |
 | ActiveRecordInjection.rb:141:21:141:26 | call to params :  | semmle.label | call to params :  |
 | ActiveRecordInjection.rb:141:21:141:44 | ...[...] :  | semmle.label | ...[...] :  |
 | ActiveRecordInjection.rb:155:27:155:76 | "this is an unsafe annotation:..." | semmle.label | "this is an unsafe annotation:..." |
 | ActiveRecordInjection.rb:155:59:155:64 | call to params :  | semmle.label | call to params :  |
 | ActiveRecordInjection.rb:155:59:155:74 | ...[...] :  | semmle.label | ...[...] :  |
+| ActiveRecordInjection.rb:166:5:166:13 | my_params :  | semmle.label | my_params :  |
 | ActiveRecordInjection.rb:166:17:166:32 | call to permitted_params :  | semmle.label | call to permitted_params :  |
+| ActiveRecordInjection.rb:167:5:167:9 | query :  | semmle.label | query :  |
 | ActiveRecordInjection.rb:167:47:167:55 | my_params :  | semmle.label | my_params :  |
 | ActiveRecordInjection.rb:167:47:167:65 | ...[...] :  | semmle.label | ...[...] :  |
 | ActiveRecordInjection.rb:168:37:168:41 | query | semmle.label | query |
@@ -118,6 +129,7 @@ nodes
 | ActiveRecordInjection.rb:178:35:178:96 | "SELECT * FROM users WHERE id ..." | semmle.label | "SELECT * FROM users WHERE id ..." |
 | ActiveRecordInjection.rb:178:69:178:84 | call to permitted_params :  | semmle.label | call to permitted_params :  |
 | ActiveRecordInjection.rb:178:69:178:94 | ...[...] :  | semmle.label | ...[...] :  |
+| ArelInjection.rb:4:5:4:8 | name :  | semmle.label | name :  |
 | ArelInjection.rb:4:12:4:17 | call to params :  | semmle.label | call to params :  |
 | ArelInjection.rb:4:12:4:29 | ...[...] :  | semmle.label | ...[...] :  |
 | ArelInjection.rb:6:20:6:61 | "SELECT * FROM users WHERE nam..." | semmle.label | "SELECT * FROM users WHERE nam..." |

--- a/ruby/ql/test/query-tests/security/cwe-094/CodeInjection/CodeInjection.expected
+++ b/ruby/ql/test/query-tests/security/cwe-094/CodeInjection/CodeInjection.expected
@@ -1,26 +1,30 @@
 edges
+| CodeInjection.rb:5:5:5:8 | code :  | CodeInjection.rb:8:10:8:13 | code |
+| CodeInjection.rb:5:5:5:8 | code :  | CodeInjection.rb:8:10:8:13 | code |
+| CodeInjection.rb:5:5:5:8 | code :  | CodeInjection.rb:20:20:20:23 | code |
+| CodeInjection.rb:5:5:5:8 | code :  | CodeInjection.rb:20:20:20:23 | code |
+| CodeInjection.rb:5:5:5:8 | code :  | CodeInjection.rb:23:21:23:24 | code |
+| CodeInjection.rb:5:5:5:8 | code :  | CodeInjection.rb:23:21:23:24 | code |
+| CodeInjection.rb:5:5:5:8 | code :  | CodeInjection.rb:29:15:29:18 | code |
+| CodeInjection.rb:5:5:5:8 | code :  | CodeInjection.rb:32:19:32:22 | code |
+| CodeInjection.rb:5:5:5:8 | code :  | CodeInjection.rb:38:24:38:27 | code :  |
+| CodeInjection.rb:5:5:5:8 | code :  | CodeInjection.rb:38:24:38:27 | code :  |
+| CodeInjection.rb:5:5:5:8 | code :  | CodeInjection.rb:41:40:41:43 | code |
 | CodeInjection.rb:5:12:5:17 | call to params :  | CodeInjection.rb:5:12:5:24 | ...[...] :  |
 | CodeInjection.rb:5:12:5:17 | call to params :  | CodeInjection.rb:5:12:5:24 | ...[...] :  |
-| CodeInjection.rb:5:12:5:24 | ...[...] :  | CodeInjection.rb:8:10:8:13 | code |
-| CodeInjection.rb:5:12:5:24 | ...[...] :  | CodeInjection.rb:8:10:8:13 | code |
-| CodeInjection.rb:5:12:5:24 | ...[...] :  | CodeInjection.rb:20:20:20:23 | code |
-| CodeInjection.rb:5:12:5:24 | ...[...] :  | CodeInjection.rb:20:20:20:23 | code |
-| CodeInjection.rb:5:12:5:24 | ...[...] :  | CodeInjection.rb:23:21:23:24 | code |
-| CodeInjection.rb:5:12:5:24 | ...[...] :  | CodeInjection.rb:23:21:23:24 | code |
-| CodeInjection.rb:5:12:5:24 | ...[...] :  | CodeInjection.rb:29:15:29:18 | code |
-| CodeInjection.rb:5:12:5:24 | ...[...] :  | CodeInjection.rb:32:19:32:22 | code |
-| CodeInjection.rb:5:12:5:24 | ...[...] :  | CodeInjection.rb:38:24:38:27 | code :  |
-| CodeInjection.rb:5:12:5:24 | ...[...] :  | CodeInjection.rb:38:24:38:27 | code :  |
-| CodeInjection.rb:5:12:5:24 | ...[...] :  | CodeInjection.rb:41:40:41:43 | code |
+| CodeInjection.rb:5:12:5:24 | ...[...] :  | CodeInjection.rb:5:5:5:8 | code :  |
+| CodeInjection.rb:5:12:5:24 | ...[...] :  | CodeInjection.rb:5:5:5:8 | code :  |
 | CodeInjection.rb:38:24:38:27 | code :  | CodeInjection.rb:38:10:38:28 | call to escape |
 | CodeInjection.rb:38:24:38:27 | code :  | CodeInjection.rb:38:10:38:28 | call to escape |
+| CodeInjection.rb:78:5:78:8 | code :  | CodeInjection.rb:80:16:80:19 | code |
+| CodeInjection.rb:78:5:78:8 | code :  | CodeInjection.rb:86:10:86:37 | ... + ... |
+| CodeInjection.rb:78:5:78:8 | code :  | CodeInjection.rb:88:10:88:32 | "prefix_#{...}_suffix" |
+| CodeInjection.rb:78:5:78:8 | code :  | CodeInjection.rb:90:10:90:13 | code |
+| CodeInjection.rb:78:5:78:8 | code :  | CodeInjection.rb:90:10:90:13 | code |
 | CodeInjection.rb:78:12:78:17 | call to params :  | CodeInjection.rb:78:12:78:24 | ...[...] :  |
 | CodeInjection.rb:78:12:78:17 | call to params :  | CodeInjection.rb:78:12:78:24 | ...[...] :  |
-| CodeInjection.rb:78:12:78:24 | ...[...] :  | CodeInjection.rb:80:16:80:19 | code |
-| CodeInjection.rb:78:12:78:24 | ...[...] :  | CodeInjection.rb:86:10:86:37 | ... + ... |
-| CodeInjection.rb:78:12:78:24 | ...[...] :  | CodeInjection.rb:88:10:88:32 | "prefix_#{...}_suffix" |
-| CodeInjection.rb:78:12:78:24 | ...[...] :  | CodeInjection.rb:90:10:90:13 | code |
-| CodeInjection.rb:78:12:78:24 | ...[...] :  | CodeInjection.rb:90:10:90:13 | code |
+| CodeInjection.rb:78:12:78:24 | ...[...] :  | CodeInjection.rb:78:5:78:8 | code :  |
+| CodeInjection.rb:78:12:78:24 | ...[...] :  | CodeInjection.rb:78:5:78:8 | code :  |
 | CodeInjection.rb:101:3:102:5 | self in index [@foo] :  | CodeInjection.rb:111:3:113:5 | self in baz [@foo] :  |
 | CodeInjection.rb:101:3:102:5 | self in index [@foo] :  | CodeInjection.rb:111:3:113:5 | self in baz [@foo] :  |
 | CodeInjection.rb:105:5:105:8 | [post] self [@foo] :  | CodeInjection.rb:108:3:109:5 | self in bar [@foo] :  |
@@ -36,6 +40,8 @@ edges
 | CodeInjection.rb:112:10:112:13 | self [@foo] :  | CodeInjection.rb:112:10:112:13 | @foo |
 | CodeInjection.rb:112:10:112:13 | self [@foo] :  | CodeInjection.rb:112:10:112:13 | @foo |
 nodes
+| CodeInjection.rb:5:5:5:8 | code :  | semmle.label | code :  |
+| CodeInjection.rb:5:5:5:8 | code :  | semmle.label | code :  |
 | CodeInjection.rb:5:12:5:17 | call to params :  | semmle.label | call to params :  |
 | CodeInjection.rb:5:12:5:17 | call to params :  | semmle.label | call to params :  |
 | CodeInjection.rb:5:12:5:24 | ...[...] :  | semmle.label | ...[...] :  |
@@ -55,6 +61,8 @@ nodes
 | CodeInjection.rb:38:24:38:27 | code :  | semmle.label | code :  |
 | CodeInjection.rb:38:24:38:27 | code :  | semmle.label | code :  |
 | CodeInjection.rb:41:40:41:43 | code | semmle.label | code |
+| CodeInjection.rb:78:5:78:8 | code :  | semmle.label | code :  |
+| CodeInjection.rb:78:5:78:8 | code :  | semmle.label | code :  |
 | CodeInjection.rb:78:12:78:17 | call to params :  | semmle.label | call to params :  |
 | CodeInjection.rb:78:12:78:17 | call to params :  | semmle.label | call to params :  |
 | CodeInjection.rb:78:12:78:24 | ...[...] :  | semmle.label | ...[...] :  |

--- a/ruby/ql/test/query-tests/security/cwe-094/UnsafeCodeConstruction/UnsafeCodeConstruction.expected
+++ b/ruby/ql/test/query-tests/security/cwe-094/UnsafeCodeConstruction/UnsafeCodeConstruction.expected
@@ -4,7 +4,8 @@ edges
 | impl/unsafeCode.rb:12:12:12:12 | x :  | impl/unsafeCode.rb:13:33:13:33 | x |
 | impl/unsafeCode.rb:28:17:28:22 | my_arr :  | impl/unsafeCode.rb:29:10:29:15 | my_arr |
 | impl/unsafeCode.rb:32:21:32:21 | x :  | impl/unsafeCode.rb:33:12:33:12 | x :  |
-| impl/unsafeCode.rb:33:12:33:12 | x :  | impl/unsafeCode.rb:34:10:34:12 | arr |
+| impl/unsafeCode.rb:33:5:33:7 | arr [element 0] :  | impl/unsafeCode.rb:34:10:34:12 | arr |
+| impl/unsafeCode.rb:33:12:33:12 | x :  | impl/unsafeCode.rb:33:5:33:7 | arr [element 0] :  |
 | impl/unsafeCode.rb:37:15:37:15 | x :  | impl/unsafeCode.rb:39:14:39:14 | x :  |
 | impl/unsafeCode.rb:39:5:39:7 | [post] arr [element] :  | impl/unsafeCode.rb:40:10:40:12 | arr |
 | impl/unsafeCode.rb:39:5:39:7 | [post] arr [element] :  | impl/unsafeCode.rb:44:10:44:12 | arr |
@@ -13,10 +14,12 @@ edges
 | impl/unsafeCode.rb:54:21:54:21 | x :  | impl/unsafeCode.rb:55:22:55:22 | x |
 | impl/unsafeCode.rb:59:21:59:21 | x :  | impl/unsafeCode.rb:60:17:60:17 | x :  |
 | impl/unsafeCode.rb:59:24:59:24 | y :  | impl/unsafeCode.rb:63:30:63:30 | y :  |
-| impl/unsafeCode.rb:60:11:60:18 | call to Array [element 0] :  | impl/unsafeCode.rb:61:10:61:12 | arr |
+| impl/unsafeCode.rb:60:5:60:7 | arr [element 0] :  | impl/unsafeCode.rb:61:10:61:12 | arr |
+| impl/unsafeCode.rb:60:11:60:18 | call to Array [element 0] :  | impl/unsafeCode.rb:60:5:60:7 | arr [element 0] :  |
 | impl/unsafeCode.rb:60:17:60:17 | x :  | impl/unsafeCode.rb:60:11:60:18 | call to Array [element 0] :  |
+| impl/unsafeCode.rb:63:5:63:8 | arr2 [element 0] :  | impl/unsafeCode.rb:64:10:64:13 | arr2 |
 | impl/unsafeCode.rb:63:13:63:32 | call to Array [element 1] :  | impl/unsafeCode.rb:63:13:63:42 | call to join :  |
-| impl/unsafeCode.rb:63:13:63:42 | call to join :  | impl/unsafeCode.rb:64:10:64:13 | arr2 |
+| impl/unsafeCode.rb:63:13:63:42 | call to join :  | impl/unsafeCode.rb:63:5:63:8 | arr2 [element 0] :  |
 | impl/unsafeCode.rb:63:30:63:30 | y :  | impl/unsafeCode.rb:63:13:63:32 | call to Array [element 1] :  |
 nodes
 | impl/unsafeCode.rb:2:12:2:17 | target :  | semmle.label | target :  |
@@ -28,6 +31,7 @@ nodes
 | impl/unsafeCode.rb:28:17:28:22 | my_arr :  | semmle.label | my_arr :  |
 | impl/unsafeCode.rb:29:10:29:15 | my_arr | semmle.label | my_arr |
 | impl/unsafeCode.rb:32:21:32:21 | x :  | semmle.label | x :  |
+| impl/unsafeCode.rb:33:5:33:7 | arr [element 0] :  | semmle.label | arr [element 0] :  |
 | impl/unsafeCode.rb:33:12:33:12 | x :  | semmle.label | x :  |
 | impl/unsafeCode.rb:34:10:34:12 | arr | semmle.label | arr |
 | impl/unsafeCode.rb:37:15:37:15 | x :  | semmle.label | x :  |
@@ -41,9 +45,11 @@ nodes
 | impl/unsafeCode.rb:55:22:55:22 | x | semmle.label | x |
 | impl/unsafeCode.rb:59:21:59:21 | x :  | semmle.label | x :  |
 | impl/unsafeCode.rb:59:24:59:24 | y :  | semmle.label | y :  |
+| impl/unsafeCode.rb:60:5:60:7 | arr [element 0] :  | semmle.label | arr [element 0] :  |
 | impl/unsafeCode.rb:60:11:60:18 | call to Array [element 0] :  | semmle.label | call to Array [element 0] :  |
 | impl/unsafeCode.rb:60:17:60:17 | x :  | semmle.label | x :  |
 | impl/unsafeCode.rb:61:10:61:12 | arr | semmle.label | arr |
+| impl/unsafeCode.rb:63:5:63:8 | arr2 [element 0] :  | semmle.label | arr2 [element 0] :  |
 | impl/unsafeCode.rb:63:13:63:32 | call to Array [element 1] :  | semmle.label | call to Array [element 1] :  |
 | impl/unsafeCode.rb:63:13:63:42 | call to join :  | semmle.label | call to join :  |
 | impl/unsafeCode.rb:63:30:63:30 | y :  | semmle.label | y :  |

--- a/ruby/ql/test/query-tests/security/cwe-117/LogInjection.expected
+++ b/ruby/ql/test/query-tests/security/cwe-117/LogInjection.expected
@@ -1,28 +1,30 @@
 edges
+| app/controllers/users_controller.rb:15:5:15:15 | unsanitized :  | app/controllers/users_controller.rb:16:19:16:29 | unsanitized |
+| app/controllers/users_controller.rb:15:5:15:15 | unsanitized :  | app/controllers/users_controller.rb:17:19:17:41 | ... + ... |
+| app/controllers/users_controller.rb:15:5:15:15 | unsanitized :  | app/controllers/users_controller.rb:23:20:23:30 | unsanitized :  |
 | app/controllers/users_controller.rb:15:19:15:24 | call to params :  | app/controllers/users_controller.rb:15:19:15:30 | ...[...] :  |
-| app/controllers/users_controller.rb:15:19:15:30 | ...[...] :  | app/controllers/users_controller.rb:16:19:16:29 | unsanitized |
-| app/controllers/users_controller.rb:15:19:15:30 | ...[...] :  | app/controllers/users_controller.rb:17:19:17:41 | ... + ... |
-| app/controllers/users_controller.rb:15:19:15:30 | ...[...] :  | app/controllers/users_controller.rb:23:20:23:30 | unsanitized :  |
-| app/controllers/users_controller.rb:23:5:23:44 | ... = ... :  | app/controllers/users_controller.rb:25:7:25:18 | unsanitized2 |
+| app/controllers/users_controller.rb:15:19:15:30 | ...[...] :  | app/controllers/users_controller.rb:15:5:15:15 | unsanitized :  |
+| app/controllers/users_controller.rb:23:5:23:16 | unsanitized2 :  | app/controllers/users_controller.rb:25:7:25:18 | unsanitized2 |
+| app/controllers/users_controller.rb:23:5:23:16 | unsanitized2 :  | app/controllers/users_controller.rb:27:16:27:39 | ... + ... |
 | app/controllers/users_controller.rb:23:20:23:30 | unsanitized :  | app/controllers/users_controller.rb:23:20:23:44 | call to sub :  |
-| app/controllers/users_controller.rb:23:20:23:44 | call to sub :  | app/controllers/users_controller.rb:23:5:23:44 | ... = ... :  |
-| app/controllers/users_controller.rb:23:20:23:44 | call to sub :  | app/controllers/users_controller.rb:27:16:27:39 | ... + ... |
-| app/controllers/users_controller.rb:33:5:33:31 | ... = ... :  | app/controllers/users_controller.rb:34:33:34:43 | unsanitized |
-| app/controllers/users_controller.rb:33:5:33:31 | ... = ... :  | app/controllers/users_controller.rb:35:33:35:55 | ... + ... |
+| app/controllers/users_controller.rb:23:20:23:44 | call to sub :  | app/controllers/users_controller.rb:23:5:23:16 | unsanitized2 :  |
+| app/controllers/users_controller.rb:33:5:33:15 | unsanitized :  | app/controllers/users_controller.rb:34:33:34:43 | unsanitized |
+| app/controllers/users_controller.rb:33:5:33:15 | unsanitized :  | app/controllers/users_controller.rb:35:33:35:55 | ... + ... |
 | app/controllers/users_controller.rb:33:19:33:25 | call to cookies :  | app/controllers/users_controller.rb:33:19:33:31 | ...[...] :  |
-| app/controllers/users_controller.rb:33:19:33:31 | ...[...] :  | app/controllers/users_controller.rb:33:5:33:31 | ... = ... :  |
+| app/controllers/users_controller.rb:33:19:33:31 | ...[...] :  | app/controllers/users_controller.rb:33:5:33:15 | unsanitized :  |
 | app/controllers/users_controller.rb:49:19:49:24 | call to params :  | app/controllers/users_controller.rb:49:19:49:30 | ...[...] |
 nodes
+| app/controllers/users_controller.rb:15:5:15:15 | unsanitized :  | semmle.label | unsanitized :  |
 | app/controllers/users_controller.rb:15:19:15:24 | call to params :  | semmle.label | call to params :  |
 | app/controllers/users_controller.rb:15:19:15:30 | ...[...] :  | semmle.label | ...[...] :  |
 | app/controllers/users_controller.rb:16:19:16:29 | unsanitized | semmle.label | unsanitized |
 | app/controllers/users_controller.rb:17:19:17:41 | ... + ... | semmle.label | ... + ... |
-| app/controllers/users_controller.rb:23:5:23:44 | ... = ... :  | semmle.label | ... = ... :  |
+| app/controllers/users_controller.rb:23:5:23:16 | unsanitized2 :  | semmle.label | unsanitized2 :  |
 | app/controllers/users_controller.rb:23:20:23:30 | unsanitized :  | semmle.label | unsanitized :  |
 | app/controllers/users_controller.rb:23:20:23:44 | call to sub :  | semmle.label | call to sub :  |
 | app/controllers/users_controller.rb:25:7:25:18 | unsanitized2 | semmle.label | unsanitized2 |
 | app/controllers/users_controller.rb:27:16:27:39 | ... + ... | semmle.label | ... + ... |
-| app/controllers/users_controller.rb:33:5:33:31 | ... = ... :  | semmle.label | ... = ... :  |
+| app/controllers/users_controller.rb:33:5:33:15 | unsanitized :  | semmle.label | unsanitized :  |
 | app/controllers/users_controller.rb:33:19:33:25 | call to cookies :  | semmle.label | call to cookies :  |
 | app/controllers/users_controller.rb:33:19:33:31 | ...[...] :  | semmle.label | ...[...] :  |
 | app/controllers/users_controller.rb:34:33:34:43 | unsanitized | semmle.label | unsanitized |

--- a/ruby/ql/test/query-tests/security/cwe-1333-polynomial-redos/PolynomialReDoS.expected
+++ b/ruby/ql/test/query-tests/security/cwe-1333-polynomial-redos/PolynomialReDoS.expected
@@ -1,42 +1,49 @@
 edges
+| PolynomialReDoS.rb:4:5:4:8 | name :  | PolynomialReDoS.rb:10:5:10:8 | name |
+| PolynomialReDoS.rb:4:5:4:8 | name :  | PolynomialReDoS.rb:11:5:11:8 | name |
+| PolynomialReDoS.rb:4:5:4:8 | name :  | PolynomialReDoS.rb:12:5:12:8 | name |
+| PolynomialReDoS.rb:4:5:4:8 | name :  | PolynomialReDoS.rb:13:5:13:8 | name |
+| PolynomialReDoS.rb:4:5:4:8 | name :  | PolynomialReDoS.rb:14:5:14:8 | name |
+| PolynomialReDoS.rb:4:5:4:8 | name :  | PolynomialReDoS.rb:15:5:15:8 | name |
+| PolynomialReDoS.rb:4:5:4:8 | name :  | PolynomialReDoS.rb:16:5:16:8 | name |
+| PolynomialReDoS.rb:4:5:4:8 | name :  | PolynomialReDoS.rb:17:5:17:8 | name |
+| PolynomialReDoS.rb:4:5:4:8 | name :  | PolynomialReDoS.rb:18:5:18:8 | name |
+| PolynomialReDoS.rb:4:5:4:8 | name :  | PolynomialReDoS.rb:19:5:19:8 | name |
+| PolynomialReDoS.rb:4:5:4:8 | name :  | PolynomialReDoS.rb:20:5:20:8 | name |
+| PolynomialReDoS.rb:4:5:4:8 | name :  | PolynomialReDoS.rb:21:5:21:8 | name |
+| PolynomialReDoS.rb:4:5:4:8 | name :  | PolynomialReDoS.rb:22:5:22:8 | name |
+| PolynomialReDoS.rb:4:5:4:8 | name :  | PolynomialReDoS.rb:23:17:23:20 | name |
+| PolynomialReDoS.rb:4:5:4:8 | name :  | PolynomialReDoS.rb:24:18:24:21 | name |
+| PolynomialReDoS.rb:4:5:4:8 | name :  | PolynomialReDoS.rb:42:10:42:13 | name |
+| PolynomialReDoS.rb:4:5:4:8 | name :  | PolynomialReDoS.rb:47:10:47:13 | name |
 | PolynomialReDoS.rb:4:12:4:17 | call to params :  | PolynomialReDoS.rb:4:12:4:24 | ...[...] :  |
-| PolynomialReDoS.rb:4:12:4:24 | ...[...] :  | PolynomialReDoS.rb:10:5:10:8 | name |
-| PolynomialReDoS.rb:4:12:4:24 | ...[...] :  | PolynomialReDoS.rb:11:5:11:8 | name |
-| PolynomialReDoS.rb:4:12:4:24 | ...[...] :  | PolynomialReDoS.rb:12:5:12:8 | name |
-| PolynomialReDoS.rb:4:12:4:24 | ...[...] :  | PolynomialReDoS.rb:13:5:13:8 | name |
-| PolynomialReDoS.rb:4:12:4:24 | ...[...] :  | PolynomialReDoS.rb:14:5:14:8 | name |
-| PolynomialReDoS.rb:4:12:4:24 | ...[...] :  | PolynomialReDoS.rb:15:5:15:8 | name |
-| PolynomialReDoS.rb:4:12:4:24 | ...[...] :  | PolynomialReDoS.rb:16:5:16:8 | name |
-| PolynomialReDoS.rb:4:12:4:24 | ...[...] :  | PolynomialReDoS.rb:17:5:17:8 | name |
-| PolynomialReDoS.rb:4:12:4:24 | ...[...] :  | PolynomialReDoS.rb:18:5:18:8 | name |
-| PolynomialReDoS.rb:4:12:4:24 | ...[...] :  | PolynomialReDoS.rb:19:5:19:8 | name |
-| PolynomialReDoS.rb:4:12:4:24 | ...[...] :  | PolynomialReDoS.rb:20:5:20:8 | name |
-| PolynomialReDoS.rb:4:12:4:24 | ...[...] :  | PolynomialReDoS.rb:21:5:21:8 | name |
-| PolynomialReDoS.rb:4:12:4:24 | ...[...] :  | PolynomialReDoS.rb:22:5:22:8 | name |
-| PolynomialReDoS.rb:4:12:4:24 | ...[...] :  | PolynomialReDoS.rb:23:17:23:20 | name |
-| PolynomialReDoS.rb:4:12:4:24 | ...[...] :  | PolynomialReDoS.rb:24:18:24:21 | name |
-| PolynomialReDoS.rb:4:12:4:24 | ...[...] :  | PolynomialReDoS.rb:42:10:42:13 | name |
-| PolynomialReDoS.rb:4:12:4:24 | ...[...] :  | PolynomialReDoS.rb:47:10:47:13 | name |
+| PolynomialReDoS.rb:4:12:4:24 | ...[...] :  | PolynomialReDoS.rb:4:5:4:8 | name :  |
+| PolynomialReDoS.rb:27:5:27:5 | a :  | PolynomialReDoS.rb:28:5:28:5 | a |
 | PolynomialReDoS.rb:27:9:27:14 | call to params :  | PolynomialReDoS.rb:27:9:27:18 | ...[...] :  |
-| PolynomialReDoS.rb:27:9:27:18 | ...[...] :  | PolynomialReDoS.rb:28:5:28:5 | a |
+| PolynomialReDoS.rb:27:9:27:18 | ...[...] :  | PolynomialReDoS.rb:27:5:27:5 | a :  |
+| PolynomialReDoS.rb:29:5:29:5 | b :  | PolynomialReDoS.rb:30:5:30:5 | b |
 | PolynomialReDoS.rb:29:9:29:14 | call to params :  | PolynomialReDoS.rb:29:9:29:18 | ...[...] :  |
-| PolynomialReDoS.rb:29:9:29:18 | ...[...] :  | PolynomialReDoS.rb:30:5:30:5 | b |
+| PolynomialReDoS.rb:29:9:29:18 | ...[...] :  | PolynomialReDoS.rb:29:5:29:5 | b :  |
+| PolynomialReDoS.rb:31:5:31:5 | c :  | PolynomialReDoS.rb:32:5:32:5 | c |
 | PolynomialReDoS.rb:31:9:31:14 | call to params :  | PolynomialReDoS.rb:31:9:31:18 | ...[...] :  |
-| PolynomialReDoS.rb:31:9:31:18 | ...[...] :  | PolynomialReDoS.rb:32:5:32:5 | c |
+| PolynomialReDoS.rb:31:9:31:18 | ...[...] :  | PolynomialReDoS.rb:31:5:31:5 | c :  |
+| PolynomialReDoS.rb:54:5:54:8 | name :  | PolynomialReDoS.rb:56:38:56:41 | name :  |
+| PolynomialReDoS.rb:54:5:54:8 | name :  | PolynomialReDoS.rb:58:37:58:40 | name :  |
 | PolynomialReDoS.rb:54:12:54:17 | call to params :  | PolynomialReDoS.rb:54:12:54:24 | ...[...] :  |
-| PolynomialReDoS.rb:54:12:54:24 | ...[...] :  | PolynomialReDoS.rb:56:38:56:41 | name :  |
-| PolynomialReDoS.rb:54:12:54:24 | ...[...] :  | PolynomialReDoS.rb:58:37:58:40 | name :  |
+| PolynomialReDoS.rb:54:12:54:24 | ...[...] :  | PolynomialReDoS.rb:54:5:54:8 | name :  |
 | PolynomialReDoS.rb:56:38:56:41 | name :  | PolynomialReDoS.rb:61:33:61:37 | input :  |
 | PolynomialReDoS.rb:58:37:58:40 | name :  | PolynomialReDoS.rb:65:42:65:46 | input :  |
 | PolynomialReDoS.rb:61:33:61:37 | input :  | PolynomialReDoS.rb:62:5:62:9 | input |
 | PolynomialReDoS.rb:65:42:65:46 | input :  | PolynomialReDoS.rb:66:5:66:9 | input |
+| PolynomialReDoS.rb:70:5:70:8 | name :  | PolynomialReDoS.rb:73:32:73:35 | name :  |
 | PolynomialReDoS.rb:70:12:70:17 | call to params :  | PolynomialReDoS.rb:70:12:70:24 | ...[...] :  |
-| PolynomialReDoS.rb:70:12:70:24 | ...[...] :  | PolynomialReDoS.rb:73:32:73:35 | name :  |
+| PolynomialReDoS.rb:70:12:70:24 | ...[...] :  | PolynomialReDoS.rb:70:5:70:8 | name :  |
 | PolynomialReDoS.rb:73:32:73:35 | name :  | PolynomialReDoS.rb:76:35:76:39 | input :  |
 | PolynomialReDoS.rb:76:35:76:39 | input :  | PolynomialReDoS.rb:77:5:77:9 | input |
 | lib/index.rb:2:11:2:11 | x :  | lib/index.rb:4:13:4:13 | x |
 | lib/index.rb:8:13:8:13 | x :  | lib/index.rb:9:15:9:15 | x |
 nodes
+| PolynomialReDoS.rb:4:5:4:8 | name :  | semmle.label | name :  |
 | PolynomialReDoS.rb:4:12:4:17 | call to params :  | semmle.label | call to params :  |
 | PolynomialReDoS.rb:4:12:4:24 | ...[...] :  | semmle.label | ...[...] :  |
 | PolynomialReDoS.rb:10:5:10:8 | name | semmle.label | name |
@@ -54,17 +61,21 @@ nodes
 | PolynomialReDoS.rb:22:5:22:8 | name | semmle.label | name |
 | PolynomialReDoS.rb:23:17:23:20 | name | semmle.label | name |
 | PolynomialReDoS.rb:24:18:24:21 | name | semmle.label | name |
+| PolynomialReDoS.rb:27:5:27:5 | a :  | semmle.label | a :  |
 | PolynomialReDoS.rb:27:9:27:14 | call to params :  | semmle.label | call to params :  |
 | PolynomialReDoS.rb:27:9:27:18 | ...[...] :  | semmle.label | ...[...] :  |
 | PolynomialReDoS.rb:28:5:28:5 | a | semmle.label | a |
+| PolynomialReDoS.rb:29:5:29:5 | b :  | semmle.label | b :  |
 | PolynomialReDoS.rb:29:9:29:14 | call to params :  | semmle.label | call to params :  |
 | PolynomialReDoS.rb:29:9:29:18 | ...[...] :  | semmle.label | ...[...] :  |
 | PolynomialReDoS.rb:30:5:30:5 | b | semmle.label | b |
+| PolynomialReDoS.rb:31:5:31:5 | c :  | semmle.label | c :  |
 | PolynomialReDoS.rb:31:9:31:14 | call to params :  | semmle.label | call to params :  |
 | PolynomialReDoS.rb:31:9:31:18 | ...[...] :  | semmle.label | ...[...] :  |
 | PolynomialReDoS.rb:32:5:32:5 | c | semmle.label | c |
 | PolynomialReDoS.rb:42:10:42:13 | name | semmle.label | name |
 | PolynomialReDoS.rb:47:10:47:13 | name | semmle.label | name |
+| PolynomialReDoS.rb:54:5:54:8 | name :  | semmle.label | name :  |
 | PolynomialReDoS.rb:54:12:54:17 | call to params :  | semmle.label | call to params :  |
 | PolynomialReDoS.rb:54:12:54:24 | ...[...] :  | semmle.label | ...[...] :  |
 | PolynomialReDoS.rb:56:38:56:41 | name :  | semmle.label | name :  |
@@ -73,6 +84,7 @@ nodes
 | PolynomialReDoS.rb:62:5:62:9 | input | semmle.label | input |
 | PolynomialReDoS.rb:65:42:65:46 | input :  | semmle.label | input :  |
 | PolynomialReDoS.rb:66:5:66:9 | input | semmle.label | input |
+| PolynomialReDoS.rb:70:5:70:8 | name :  | semmle.label | name :  |
 | PolynomialReDoS.rb:70:12:70:17 | call to params :  | semmle.label | call to params :  |
 | PolynomialReDoS.rb:70:12:70:24 | ...[...] :  | semmle.label | ...[...] :  |
 | PolynomialReDoS.rb:73:32:73:35 | name :  | semmle.label | name :  |

--- a/ruby/ql/test/query-tests/security/cwe-1333-regexp-injection/RegExpInjection.expected
+++ b/ruby/ql/test/query-tests/security/cwe-1333-regexp-injection/RegExpInjection.expected
@@ -1,27 +1,37 @@
 edges
+| RegExpInjection.rb:4:5:4:8 | name :  | RegExpInjection.rb:5:13:5:21 | /#{...}/ |
 | RegExpInjection.rb:4:12:4:17 | call to params :  | RegExpInjection.rb:4:12:4:24 | ...[...] :  |
-| RegExpInjection.rb:4:12:4:24 | ...[...] :  | RegExpInjection.rb:5:13:5:21 | /#{...}/ |
+| RegExpInjection.rb:4:12:4:24 | ...[...] :  | RegExpInjection.rb:4:5:4:8 | name :  |
+| RegExpInjection.rb:10:5:10:8 | name :  | RegExpInjection.rb:11:13:11:27 | /foo#{...}bar/ |
 | RegExpInjection.rb:10:12:10:17 | call to params :  | RegExpInjection.rb:10:12:10:24 | ...[...] :  |
-| RegExpInjection.rb:10:12:10:24 | ...[...] :  | RegExpInjection.rb:11:13:11:27 | /foo#{...}bar/ |
+| RegExpInjection.rb:10:12:10:24 | ...[...] :  | RegExpInjection.rb:10:5:10:8 | name :  |
+| RegExpInjection.rb:16:5:16:8 | name :  | RegExpInjection.rb:17:24:17:27 | name |
 | RegExpInjection.rb:16:12:16:17 | call to params :  | RegExpInjection.rb:16:12:16:24 | ...[...] :  |
-| RegExpInjection.rb:16:12:16:24 | ...[...] :  | RegExpInjection.rb:17:24:17:27 | name |
+| RegExpInjection.rb:16:12:16:24 | ...[...] :  | RegExpInjection.rb:16:5:16:8 | name :  |
+| RegExpInjection.rb:22:5:22:8 | name :  | RegExpInjection.rb:23:24:23:33 | ... + ... |
 | RegExpInjection.rb:22:12:22:17 | call to params :  | RegExpInjection.rb:22:12:22:24 | ...[...] :  |
-| RegExpInjection.rb:22:12:22:24 | ...[...] :  | RegExpInjection.rb:23:24:23:33 | ... + ... |
+| RegExpInjection.rb:22:12:22:24 | ...[...] :  | RegExpInjection.rb:22:5:22:8 | name :  |
+| RegExpInjection.rb:54:5:54:8 | name :  | RegExpInjection.rb:55:28:55:37 | ... + ... |
 | RegExpInjection.rb:54:12:54:17 | call to params :  | RegExpInjection.rb:54:12:54:24 | ...[...] :  |
-| RegExpInjection.rb:54:12:54:24 | ...[...] :  | RegExpInjection.rb:55:28:55:37 | ... + ... |
+| RegExpInjection.rb:54:12:54:24 | ...[...] :  | RegExpInjection.rb:54:5:54:8 | name :  |
 nodes
+| RegExpInjection.rb:4:5:4:8 | name :  | semmle.label | name :  |
 | RegExpInjection.rb:4:12:4:17 | call to params :  | semmle.label | call to params :  |
 | RegExpInjection.rb:4:12:4:24 | ...[...] :  | semmle.label | ...[...] :  |
 | RegExpInjection.rb:5:13:5:21 | /#{...}/ | semmle.label | /#{...}/ |
+| RegExpInjection.rb:10:5:10:8 | name :  | semmle.label | name :  |
 | RegExpInjection.rb:10:12:10:17 | call to params :  | semmle.label | call to params :  |
 | RegExpInjection.rb:10:12:10:24 | ...[...] :  | semmle.label | ...[...] :  |
 | RegExpInjection.rb:11:13:11:27 | /foo#{...}bar/ | semmle.label | /foo#{...}bar/ |
+| RegExpInjection.rb:16:5:16:8 | name :  | semmle.label | name :  |
 | RegExpInjection.rb:16:12:16:17 | call to params :  | semmle.label | call to params :  |
 | RegExpInjection.rb:16:12:16:24 | ...[...] :  | semmle.label | ...[...] :  |
 | RegExpInjection.rb:17:24:17:27 | name | semmle.label | name |
+| RegExpInjection.rb:22:5:22:8 | name :  | semmle.label | name :  |
 | RegExpInjection.rb:22:12:22:17 | call to params :  | semmle.label | call to params :  |
 | RegExpInjection.rb:22:12:22:24 | ...[...] :  | semmle.label | ...[...] :  |
 | RegExpInjection.rb:23:24:23:33 | ... + ... | semmle.label | ... + ... |
+| RegExpInjection.rb:54:5:54:8 | name :  | semmle.label | name :  |
 | RegExpInjection.rb:54:12:54:17 | call to params :  | semmle.label | call to params :  |
 | RegExpInjection.rb:54:12:54:24 | ...[...] :  | semmle.label | ...[...] :  |
 | RegExpInjection.rb:55:28:55:37 | ... + ... | semmle.label | ... + ... |

--- a/ruby/ql/test/query-tests/security/cwe-209/StackTraceExposure.expected
+++ b/ruby/ql/test/query-tests/security/cwe-209/StackTraceExposure.expected
@@ -1,7 +1,9 @@
 edges
-| StackTraceExposure.rb:11:10:11:17 | call to caller :  | StackTraceExposure.rb:12:18:12:19 | bt |
+| StackTraceExposure.rb:11:5:11:6 | bt :  | StackTraceExposure.rb:12:18:12:19 | bt |
+| StackTraceExposure.rb:11:10:11:17 | call to caller :  | StackTraceExposure.rb:11:5:11:6 | bt :  |
 nodes
 | StackTraceExposure.rb:6:18:6:28 | call to backtrace | semmle.label | call to backtrace |
+| StackTraceExposure.rb:11:5:11:6 | bt :  | semmle.label | bt :  |
 | StackTraceExposure.rb:11:10:11:17 | call to caller :  | semmle.label | call to caller :  |
 | StackTraceExposure.rb:12:18:12:19 | bt | semmle.label | bt |
 | StackTraceExposure.rb:18:18:18:28 | call to backtrace | semmle.label | call to backtrace |

--- a/ruby/ql/test/query-tests/security/cwe-312/CleartextLogging.expected
+++ b/ruby/ql/test/query-tests/security/cwe-312/CleartextLogging.expected
@@ -1,34 +1,45 @@
 edges
-| logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" :  | logging.rb:6:20:6:27 | password |
-| logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" :  | logging.rb:8:21:8:28 | password |
-| logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" :  | logging.rb:10:21:10:28 | password |
-| logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" :  | logging.rb:12:21:12:28 | password |
-| logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" :  | logging.rb:14:23:14:30 | password |
-| logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" :  | logging.rb:16:20:16:27 | password |
-| logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" :  | logging.rb:19:33:19:40 | password |
-| logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" :  | logging.rb:21:44:21:51 | password |
-| logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" :  | logging.rb:23:33:23:40 | password |
-| logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" :  | logging.rb:26:18:26:34 | "pw: #{...}" |
-| logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" :  | logging.rb:28:26:28:33 | password |
-| logging.rb:30:20:30:53 | "aec5058e61f7f122998b1a30ee2c66b6" :  | logging.rb:38:20:38:23 | hsh1 [element :password] :  |
+| logging.rb:3:1:3:8 | password :  | logging.rb:6:20:6:27 | password |
+| logging.rb:3:1:3:8 | password :  | logging.rb:8:21:8:28 | password |
+| logging.rb:3:1:3:8 | password :  | logging.rb:10:21:10:28 | password |
+| logging.rb:3:1:3:8 | password :  | logging.rb:12:21:12:28 | password |
+| logging.rb:3:1:3:8 | password :  | logging.rb:14:23:14:30 | password |
+| logging.rb:3:1:3:8 | password :  | logging.rb:16:20:16:27 | password |
+| logging.rb:3:1:3:8 | password :  | logging.rb:19:33:19:40 | password |
+| logging.rb:3:1:3:8 | password :  | logging.rb:21:44:21:51 | password |
+| logging.rb:3:1:3:8 | password :  | logging.rb:23:33:23:40 | password |
+| logging.rb:3:1:3:8 | password :  | logging.rb:26:18:26:34 | "pw: #{...}" |
+| logging.rb:3:1:3:8 | password :  | logging.rb:28:26:28:33 | password |
+| logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" :  | logging.rb:3:1:3:8 | password :  |
+| logging.rb:30:1:30:4 | hsh1 [element :password] :  | logging.rb:38:20:38:23 | hsh1 [element :password] :  |
+| logging.rb:30:20:30:53 | "aec5058e61f7f122998b1a30ee2c66b6" :  | logging.rb:30:1:30:4 | hsh1 [element :password] :  |
+| logging.rb:34:1:34:4 | [post] hsh2 [element :password] :  | logging.rb:35:1:35:4 | hsh3 [element :password] :  |
 | logging.rb:34:1:34:4 | [post] hsh2 [element :password] :  | logging.rb:40:20:40:23 | hsh2 [element :password] :  |
-| logging.rb:34:1:34:4 | [post] hsh2 [element :password] :  | logging.rb:42:20:42:23 | hsh3 [element :password] :  |
 | logging.rb:34:19:34:52 | "beeda625d7306b45784d91ea0336e201" :  | logging.rb:34:1:34:4 | [post] hsh2 [element :password] :  |
+| logging.rb:35:1:35:4 | hsh3 [element :password] :  | logging.rb:42:20:42:23 | hsh3 [element :password] :  |
 | logging.rb:38:20:38:23 | hsh1 [element :password] :  | logging.rb:38:20:38:34 | ...[...] |
 | logging.rb:40:20:40:23 | hsh2 [element :password] :  | logging.rb:40:20:40:34 | ...[...] |
 | logging.rb:42:20:42:23 | hsh3 [element :password] :  | logging.rb:42:20:42:34 | ...[...] |
-| logging.rb:64:35:64:68 | "ca497451f5e883662fb1a37bc9ec7838" :  | logging.rb:68:35:68:65 | password_masked_ineffective_sub :  |
-| logging.rb:65:38:65:71 | "ca497451f5e883662fb1a37bc9ec7838" :  | logging.rb:78:20:78:53 | password_masked_ineffective_sub_ex |
-| logging.rb:66:36:66:69 | "a7e3747b19930d4f4b8181047194832f" :  | logging.rb:70:36:70:67 | password_masked_ineffective_gsub :  |
-| logging.rb:67:39:67:72 | "a7e3747b19930d4f4b8181047194832f" :  | logging.rb:80:20:80:54 | password_masked_ineffective_gsub_ex |
+| logging.rb:64:1:64:31 | password_masked_ineffective_sub :  | logging.rb:68:35:68:65 | password_masked_ineffective_sub :  |
+| logging.rb:64:35:64:68 | "ca497451f5e883662fb1a37bc9ec7838" :  | logging.rb:64:1:64:31 | password_masked_ineffective_sub :  |
+| logging.rb:65:1:65:34 | password_masked_ineffective_sub_ex :  | logging.rb:78:20:78:53 | password_masked_ineffective_sub_ex |
+| logging.rb:65:38:65:71 | "ca497451f5e883662fb1a37bc9ec7838" :  | logging.rb:65:1:65:34 | password_masked_ineffective_sub_ex :  |
+| logging.rb:66:1:66:32 | password_masked_ineffective_gsub :  | logging.rb:70:36:70:67 | password_masked_ineffective_gsub :  |
+| logging.rb:66:36:66:69 | "a7e3747b19930d4f4b8181047194832f" :  | logging.rb:66:1:66:32 | password_masked_ineffective_gsub :  |
+| logging.rb:67:1:67:35 | password_masked_ineffective_gsub_ex :  | logging.rb:80:20:80:54 | password_masked_ineffective_gsub_ex |
+| logging.rb:67:39:67:72 | "a7e3747b19930d4f4b8181047194832f" :  | logging.rb:67:1:67:35 | password_masked_ineffective_gsub_ex :  |
+| logging.rb:68:1:68:31 | password_masked_ineffective_sub :  | logging.rb:74:20:74:50 | password_masked_ineffective_sub |
 | logging.rb:68:35:68:65 | password_masked_ineffective_sub :  | logging.rb:68:35:68:88 | call to sub :  |
-| logging.rb:68:35:68:88 | call to sub :  | logging.rb:74:20:74:50 | password_masked_ineffective_sub |
+| logging.rb:68:35:68:88 | call to sub :  | logging.rb:68:1:68:31 | password_masked_ineffective_sub :  |
+| logging.rb:70:1:70:32 | password_masked_ineffective_gsub :  | logging.rb:76:20:76:51 | password_masked_ineffective_gsub |
 | logging.rb:70:36:70:67 | password_masked_ineffective_gsub :  | logging.rb:70:36:70:86 | call to gsub :  |
-| logging.rb:70:36:70:86 | call to gsub :  | logging.rb:76:20:76:51 | password_masked_ineffective_gsub |
+| logging.rb:70:36:70:86 | call to gsub :  | logging.rb:70:1:70:32 | password_masked_ineffective_gsub :  |
 | logging.rb:82:9:82:16 | password :  | logging.rb:84:15:84:22 | password |
-| logging.rb:87:16:87:49 | "65f2950df2f0e2c38d7ba2ccca767291" :  | logging.rb:88:5:88:16 | password_arg :  |
+| logging.rb:87:1:87:12 | password_arg :  | logging.rb:88:5:88:16 | password_arg :  |
+| logging.rb:87:16:87:49 | "65f2950df2f0e2c38d7ba2ccca767291" :  | logging.rb:87:1:87:12 | password_arg :  |
 | logging.rb:88:5:88:16 | password_arg :  | logging.rb:82:9:82:16 | password :  |
 nodes
+| logging.rb:3:1:3:8 | password :  | semmle.label | password :  |
 | logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" :  | semmle.label | "043697b96909e03ca907599d6420555f" :  |
 | logging.rb:6:20:6:27 | password | semmle.label | password |
 | logging.rb:8:21:8:28 | password | semmle.label | password |
@@ -41,21 +52,29 @@ nodes
 | logging.rb:23:33:23:40 | password | semmle.label | password |
 | logging.rb:26:18:26:34 | "pw: #{...}" | semmle.label | "pw: #{...}" |
 | logging.rb:28:26:28:33 | password | semmle.label | password |
+| logging.rb:30:1:30:4 | hsh1 [element :password] :  | semmle.label | hsh1 [element :password] :  |
 | logging.rb:30:20:30:53 | "aec5058e61f7f122998b1a30ee2c66b6" :  | semmle.label | "aec5058e61f7f122998b1a30ee2c66b6" :  |
 | logging.rb:34:1:34:4 | [post] hsh2 [element :password] :  | semmle.label | [post] hsh2 [element :password] :  |
 | logging.rb:34:19:34:52 | "beeda625d7306b45784d91ea0336e201" :  | semmle.label | "beeda625d7306b45784d91ea0336e201" :  |
+| logging.rb:35:1:35:4 | hsh3 [element :password] :  | semmle.label | hsh3 [element :password] :  |
 | logging.rb:38:20:38:23 | hsh1 [element :password] :  | semmle.label | hsh1 [element :password] :  |
 | logging.rb:38:20:38:34 | ...[...] | semmle.label | ...[...] |
 | logging.rb:40:20:40:23 | hsh2 [element :password] :  | semmle.label | hsh2 [element :password] :  |
 | logging.rb:40:20:40:34 | ...[...] | semmle.label | ...[...] |
 | logging.rb:42:20:42:23 | hsh3 [element :password] :  | semmle.label | hsh3 [element :password] :  |
 | logging.rb:42:20:42:34 | ...[...] | semmle.label | ...[...] |
+| logging.rb:64:1:64:31 | password_masked_ineffective_sub :  | semmle.label | password_masked_ineffective_sub :  |
 | logging.rb:64:35:64:68 | "ca497451f5e883662fb1a37bc9ec7838" :  | semmle.label | "ca497451f5e883662fb1a37bc9ec7838" :  |
+| logging.rb:65:1:65:34 | password_masked_ineffective_sub_ex :  | semmle.label | password_masked_ineffective_sub_ex :  |
 | logging.rb:65:38:65:71 | "ca497451f5e883662fb1a37bc9ec7838" :  | semmle.label | "ca497451f5e883662fb1a37bc9ec7838" :  |
+| logging.rb:66:1:66:32 | password_masked_ineffective_gsub :  | semmle.label | password_masked_ineffective_gsub :  |
 | logging.rb:66:36:66:69 | "a7e3747b19930d4f4b8181047194832f" :  | semmle.label | "a7e3747b19930d4f4b8181047194832f" :  |
+| logging.rb:67:1:67:35 | password_masked_ineffective_gsub_ex :  | semmle.label | password_masked_ineffective_gsub_ex :  |
 | logging.rb:67:39:67:72 | "a7e3747b19930d4f4b8181047194832f" :  | semmle.label | "a7e3747b19930d4f4b8181047194832f" :  |
+| logging.rb:68:1:68:31 | password_masked_ineffective_sub :  | semmle.label | password_masked_ineffective_sub :  |
 | logging.rb:68:35:68:65 | password_masked_ineffective_sub :  | semmle.label | password_masked_ineffective_sub :  |
 | logging.rb:68:35:68:88 | call to sub :  | semmle.label | call to sub :  |
+| logging.rb:70:1:70:32 | password_masked_ineffective_gsub :  | semmle.label | password_masked_ineffective_gsub :  |
 | logging.rb:70:36:70:67 | password_masked_ineffective_gsub :  | semmle.label | password_masked_ineffective_gsub :  |
 | logging.rb:70:36:70:86 | call to gsub :  | semmle.label | call to gsub :  |
 | logging.rb:74:20:74:50 | password_masked_ineffective_sub | semmle.label | password_masked_ineffective_sub |
@@ -64,6 +83,7 @@ nodes
 | logging.rb:80:20:80:54 | password_masked_ineffective_gsub_ex | semmle.label | password_masked_ineffective_gsub_ex |
 | logging.rb:82:9:82:16 | password :  | semmle.label | password :  |
 | logging.rb:84:15:84:22 | password | semmle.label | password |
+| logging.rb:87:1:87:12 | password_arg :  | semmle.label | password_arg :  |
 | logging.rb:87:16:87:49 | "65f2950df2f0e2c38d7ba2ccca767291" :  | semmle.label | "65f2950df2f0e2c38d7ba2ccca767291" :  |
 | logging.rb:88:5:88:16 | password_arg :  | semmle.label | password_arg :  |
 subpaths

--- a/ruby/ql/test/query-tests/security/cwe-312/CleartextStorage.expected
+++ b/ruby/ql/test/query-tests/security/cwe-312/CleartextStorage.expected
@@ -1,51 +1,71 @@
 edges
-| app/controllers/users_controller.rb:3:20:3:53 | "043697b96909e03ca907599d6420555f" :  | app/controllers/users_controller.rb:5:39:5:50 | new_password |
-| app/controllers/users_controller.rb:3:20:3:53 | "043697b96909e03ca907599d6420555f" :  | app/controllers/users_controller.rb:7:41:7:52 | new_password |
-| app/controllers/users_controller.rb:11:20:11:53 | "083c9e1da4cc0c2f5480bb4dbe6ff141" :  | app/controllers/users_controller.rb:13:42:13:53 | new_password |
-| app/controllers/users_controller.rb:11:20:11:53 | "083c9e1da4cc0c2f5480bb4dbe6ff141" :  | app/controllers/users_controller.rb:15:49:15:60 | new_password |
-| app/controllers/users_controller.rb:11:20:11:53 | "083c9e1da4cc0c2f5480bb4dbe6ff141" :  | app/controllers/users_controller.rb:15:49:15:60 | new_password :  |
-| app/controllers/users_controller.rb:11:20:11:53 | "083c9e1da4cc0c2f5480bb4dbe6ff141" :  | app/controllers/users_controller.rb:15:87:15:98 | new_password |
+| app/controllers/users_controller.rb:3:5:3:16 | new_password :  | app/controllers/users_controller.rb:5:39:5:50 | new_password |
+| app/controllers/users_controller.rb:3:5:3:16 | new_password :  | app/controllers/users_controller.rb:7:41:7:52 | new_password |
+| app/controllers/users_controller.rb:3:20:3:53 | "043697b96909e03ca907599d6420555f" :  | app/controllers/users_controller.rb:3:5:3:16 | new_password :  |
+| app/controllers/users_controller.rb:11:5:11:16 | new_password :  | app/controllers/users_controller.rb:13:42:13:53 | new_password |
+| app/controllers/users_controller.rb:11:5:11:16 | new_password :  | app/controllers/users_controller.rb:15:49:15:60 | new_password |
+| app/controllers/users_controller.rb:11:5:11:16 | new_password :  | app/controllers/users_controller.rb:15:49:15:60 | new_password :  |
+| app/controllers/users_controller.rb:11:5:11:16 | new_password :  | app/controllers/users_controller.rb:15:87:15:98 | new_password |
+| app/controllers/users_controller.rb:11:20:11:53 | "083c9e1da4cc0c2f5480bb4dbe6ff141" :  | app/controllers/users_controller.rb:11:5:11:16 | new_password :  |
 | app/controllers/users_controller.rb:15:49:15:60 | new_password :  | app/controllers/users_controller.rb:15:87:15:98 | new_password |
-| app/controllers/users_controller.rb:19:20:19:53 | "504d224a806cf8073cd14ef08242d422" :  | app/controllers/users_controller.rb:21:45:21:56 | new_password |
-| app/controllers/users_controller.rb:19:20:19:53 | "504d224a806cf8073cd14ef08242d422" :  | app/controllers/users_controller.rb:21:45:21:56 | new_password :  |
-| app/controllers/users_controller.rb:19:20:19:53 | "504d224a806cf8073cd14ef08242d422" :  | app/controllers/users_controller.rb:21:83:21:94 | new_password |
+| app/controllers/users_controller.rb:19:5:19:16 | new_password :  | app/controllers/users_controller.rb:21:45:21:56 | new_password |
+| app/controllers/users_controller.rb:19:5:19:16 | new_password :  | app/controllers/users_controller.rb:21:45:21:56 | new_password :  |
+| app/controllers/users_controller.rb:19:5:19:16 | new_password :  | app/controllers/users_controller.rb:21:83:21:94 | new_password |
+| app/controllers/users_controller.rb:19:20:19:53 | "504d224a806cf8073cd14ef08242d422" :  | app/controllers/users_controller.rb:19:5:19:16 | new_password :  |
 | app/controllers/users_controller.rb:21:45:21:56 | new_password :  | app/controllers/users_controller.rb:21:83:21:94 | new_password |
-| app/controllers/users_controller.rb:26:20:26:53 | "7d6ae08394c3f284506dca70f05995f6" :  | app/controllers/users_controller.rb:28:27:28:38 | new_password |
-| app/controllers/users_controller.rb:26:20:26:53 | "7d6ae08394c3f284506dca70f05995f6" :  | app/controllers/users_controller.rb:30:28:30:39 | new_password |
-| app/controllers/users_controller.rb:35:20:35:53 | "ff295f8648a406c37fbe378377320e4c" :  | app/controllers/users_controller.rb:37:39:37:50 | new_password |
-| app/controllers/users_controller.rb:42:20:42:53 | "78ffbec583b546bd073efd898f833184" :  | app/controllers/users_controller.rb:44:21:44:32 | new_password |
-| app/controllers/users_controller.rb:58:20:58:53 | "0157af7c38cbdd24f1616de4e5321861" :  | app/controllers/users_controller.rb:61:25:61:53 | "password: #{...}\\n" |
-| app/controllers/users_controller.rb:58:20:58:53 | "0157af7c38cbdd24f1616de4e5321861" :  | app/controllers/users_controller.rb:64:35:64:61 | "password: #{...}" |
-| app/models/user.rb:3:20:3:53 | "06c38c6a8a9c11a9d3b209a3193047b4" :  | app/models/user.rb:5:27:5:38 | new_password |
-| app/models/user.rb:9:20:9:53 | "52652fb5c709fb6b9b5a0194af7c6067" :  | app/models/user.rb:11:22:11:33 | new_password |
-| app/models/user.rb:15:20:15:53 | "f982bf2531c149a8a1444a951b12e830" :  | app/models/user.rb:17:21:17:32 | new_password |
+| app/controllers/users_controller.rb:26:5:26:16 | new_password :  | app/controllers/users_controller.rb:28:27:28:38 | new_password |
+| app/controllers/users_controller.rb:26:5:26:16 | new_password :  | app/controllers/users_controller.rb:30:28:30:39 | new_password |
+| app/controllers/users_controller.rb:26:20:26:53 | "7d6ae08394c3f284506dca70f05995f6" :  | app/controllers/users_controller.rb:26:5:26:16 | new_password :  |
+| app/controllers/users_controller.rb:35:5:35:16 | new_password :  | app/controllers/users_controller.rb:37:39:37:50 | new_password |
+| app/controllers/users_controller.rb:35:20:35:53 | "ff295f8648a406c37fbe378377320e4c" :  | app/controllers/users_controller.rb:35:5:35:16 | new_password :  |
+| app/controllers/users_controller.rb:42:5:42:16 | new_password :  | app/controllers/users_controller.rb:44:21:44:32 | new_password |
+| app/controllers/users_controller.rb:42:20:42:53 | "78ffbec583b546bd073efd898f833184" :  | app/controllers/users_controller.rb:42:5:42:16 | new_password :  |
+| app/controllers/users_controller.rb:58:5:58:16 | new_password :  | app/controllers/users_controller.rb:61:25:61:53 | "password: #{...}\\n" |
+| app/controllers/users_controller.rb:58:5:58:16 | new_password :  | app/controllers/users_controller.rb:64:35:64:61 | "password: #{...}" |
+| app/controllers/users_controller.rb:58:20:58:53 | "0157af7c38cbdd24f1616de4e5321861" :  | app/controllers/users_controller.rb:58:5:58:16 | new_password :  |
+| app/models/user.rb:3:5:3:16 | new_password :  | app/models/user.rb:5:27:5:38 | new_password |
+| app/models/user.rb:3:20:3:53 | "06c38c6a8a9c11a9d3b209a3193047b4" :  | app/models/user.rb:3:5:3:16 | new_password :  |
+| app/models/user.rb:9:5:9:16 | new_password :  | app/models/user.rb:11:22:11:33 | new_password |
+| app/models/user.rb:9:20:9:53 | "52652fb5c709fb6b9b5a0194af7c6067" :  | app/models/user.rb:9:5:9:16 | new_password :  |
+| app/models/user.rb:15:5:15:16 | new_password :  | app/models/user.rb:17:21:17:32 | new_password |
+| app/models/user.rb:15:20:15:53 | "f982bf2531c149a8a1444a951b12e830" :  | app/models/user.rb:15:5:15:16 | new_password :  |
 nodes
+| app/controllers/users_controller.rb:3:5:3:16 | new_password :  | semmle.label | new_password :  |
 | app/controllers/users_controller.rb:3:20:3:53 | "043697b96909e03ca907599d6420555f" :  | semmle.label | "043697b96909e03ca907599d6420555f" :  |
 | app/controllers/users_controller.rb:5:39:5:50 | new_password | semmle.label | new_password |
 | app/controllers/users_controller.rb:7:41:7:52 | new_password | semmle.label | new_password |
+| app/controllers/users_controller.rb:11:5:11:16 | new_password :  | semmle.label | new_password :  |
 | app/controllers/users_controller.rb:11:20:11:53 | "083c9e1da4cc0c2f5480bb4dbe6ff141" :  | semmle.label | "083c9e1da4cc0c2f5480bb4dbe6ff141" :  |
 | app/controllers/users_controller.rb:13:42:13:53 | new_password | semmle.label | new_password |
 | app/controllers/users_controller.rb:15:49:15:60 | new_password | semmle.label | new_password |
 | app/controllers/users_controller.rb:15:49:15:60 | new_password :  | semmle.label | new_password :  |
 | app/controllers/users_controller.rb:15:87:15:98 | new_password | semmle.label | new_password |
+| app/controllers/users_controller.rb:19:5:19:16 | new_password :  | semmle.label | new_password :  |
 | app/controllers/users_controller.rb:19:20:19:53 | "504d224a806cf8073cd14ef08242d422" :  | semmle.label | "504d224a806cf8073cd14ef08242d422" :  |
 | app/controllers/users_controller.rb:21:45:21:56 | new_password | semmle.label | new_password |
 | app/controllers/users_controller.rb:21:45:21:56 | new_password :  | semmle.label | new_password :  |
 | app/controllers/users_controller.rb:21:83:21:94 | new_password | semmle.label | new_password |
+| app/controllers/users_controller.rb:26:5:26:16 | new_password :  | semmle.label | new_password :  |
 | app/controllers/users_controller.rb:26:20:26:53 | "7d6ae08394c3f284506dca70f05995f6" :  | semmle.label | "7d6ae08394c3f284506dca70f05995f6" :  |
 | app/controllers/users_controller.rb:28:27:28:38 | new_password | semmle.label | new_password |
 | app/controllers/users_controller.rb:30:28:30:39 | new_password | semmle.label | new_password |
+| app/controllers/users_controller.rb:35:5:35:16 | new_password :  | semmle.label | new_password :  |
 | app/controllers/users_controller.rb:35:20:35:53 | "ff295f8648a406c37fbe378377320e4c" :  | semmle.label | "ff295f8648a406c37fbe378377320e4c" :  |
 | app/controllers/users_controller.rb:37:39:37:50 | new_password | semmle.label | new_password |
+| app/controllers/users_controller.rb:42:5:42:16 | new_password :  | semmle.label | new_password :  |
 | app/controllers/users_controller.rb:42:20:42:53 | "78ffbec583b546bd073efd898f833184" :  | semmle.label | "78ffbec583b546bd073efd898f833184" :  |
 | app/controllers/users_controller.rb:44:21:44:32 | new_password | semmle.label | new_password |
+| app/controllers/users_controller.rb:58:5:58:16 | new_password :  | semmle.label | new_password :  |
 | app/controllers/users_controller.rb:58:20:58:53 | "0157af7c38cbdd24f1616de4e5321861" :  | semmle.label | "0157af7c38cbdd24f1616de4e5321861" :  |
 | app/controllers/users_controller.rb:61:25:61:53 | "password: #{...}\\n" | semmle.label | "password: #{...}\\n" |
 | app/controllers/users_controller.rb:64:35:64:61 | "password: #{...}" | semmle.label | "password: #{...}" |
+| app/models/user.rb:3:5:3:16 | new_password :  | semmle.label | new_password :  |
 | app/models/user.rb:3:20:3:53 | "06c38c6a8a9c11a9d3b209a3193047b4" :  | semmle.label | "06c38c6a8a9c11a9d3b209a3193047b4" :  |
 | app/models/user.rb:5:27:5:38 | new_password | semmle.label | new_password |
+| app/models/user.rb:9:5:9:16 | new_password :  | semmle.label | new_password :  |
 | app/models/user.rb:9:20:9:53 | "52652fb5c709fb6b9b5a0194af7c6067" :  | semmle.label | "52652fb5c709fb6b9b5a0194af7c6067" :  |
 | app/models/user.rb:11:22:11:33 | new_password | semmle.label | new_password |
+| app/models/user.rb:15:5:15:16 | new_password :  | semmle.label | new_password :  |
 | app/models/user.rb:15:20:15:53 | "f982bf2531c149a8a1444a951b12e830" :  | semmle.label | "f982bf2531c149a8a1444a951b12e830" :  |
 | app/models/user.rb:17:21:17:32 | new_password | semmle.label | new_password |
 subpaths

--- a/ruby/ql/test/query-tests/security/cwe-502/oj-global-options/UnsafeDeserialization.expected
+++ b/ruby/ql/test/query-tests/security/cwe-502/oj-global-options/UnsafeDeserialization.expected
@@ -1,7 +1,9 @@
 edges
+| OjGlobalOptions.rb:13:5:13:13 | json_data :  | OjGlobalOptions.rb:14:22:14:30 | json_data |
 | OjGlobalOptions.rb:13:17:13:22 | call to params :  | OjGlobalOptions.rb:13:17:13:28 | ...[...] :  |
-| OjGlobalOptions.rb:13:17:13:28 | ...[...] :  | OjGlobalOptions.rb:14:22:14:30 | json_data |
+| OjGlobalOptions.rb:13:17:13:28 | ...[...] :  | OjGlobalOptions.rb:13:5:13:13 | json_data :  |
 nodes
+| OjGlobalOptions.rb:13:5:13:13 | json_data :  | semmle.label | json_data :  |
 | OjGlobalOptions.rb:13:17:13:22 | call to params :  | semmle.label | call to params :  |
 | OjGlobalOptions.rb:13:17:13:28 | ...[...] :  | semmle.label | ...[...] :  |
 | OjGlobalOptions.rb:14:22:14:30 | json_data | semmle.label | json_data |

--- a/ruby/ql/test/query-tests/security/cwe-502/unsafe-deserialization/UnsafeDeserialization.expected
+++ b/ruby/ql/test/query-tests/security/cwe-502/unsafe-deserialization/UnsafeDeserialization.expected
@@ -1,53 +1,71 @@
 edges
-| UnsafeDeserialization.rb:10:23:10:50 | call to decode64 :  | UnsafeDeserialization.rb:11:27:11:41 | serialized_data |
+| UnsafeDeserialization.rb:10:5:10:19 | serialized_data :  | UnsafeDeserialization.rb:11:27:11:41 | serialized_data |
+| UnsafeDeserialization.rb:10:23:10:50 | call to decode64 :  | UnsafeDeserialization.rb:10:5:10:19 | serialized_data :  |
 | UnsafeDeserialization.rb:10:39:10:44 | call to params :  | UnsafeDeserialization.rb:10:39:10:50 | ...[...] :  |
 | UnsafeDeserialization.rb:10:39:10:50 | ...[...] :  | UnsafeDeserialization.rb:10:23:10:50 | call to decode64 :  |
-| UnsafeDeserialization.rb:16:23:16:50 | call to decode64 :  | UnsafeDeserialization.rb:17:30:17:44 | serialized_data |
+| UnsafeDeserialization.rb:16:5:16:19 | serialized_data :  | UnsafeDeserialization.rb:17:30:17:44 | serialized_data |
+| UnsafeDeserialization.rb:16:23:16:50 | call to decode64 :  | UnsafeDeserialization.rb:16:5:16:19 | serialized_data :  |
 | UnsafeDeserialization.rb:16:39:16:44 | call to params :  | UnsafeDeserialization.rb:16:39:16:50 | ...[...] :  |
 | UnsafeDeserialization.rb:16:39:16:50 | ...[...] :  | UnsafeDeserialization.rb:16:23:16:50 | call to decode64 :  |
+| UnsafeDeserialization.rb:22:5:22:13 | json_data :  | UnsafeDeserialization.rb:23:24:23:32 | json_data |
 | UnsafeDeserialization.rb:22:17:22:22 | call to params :  | UnsafeDeserialization.rb:22:17:22:28 | ...[...] :  |
-| UnsafeDeserialization.rb:22:17:22:28 | ...[...] :  | UnsafeDeserialization.rb:23:24:23:32 | json_data |
+| UnsafeDeserialization.rb:22:17:22:28 | ...[...] :  | UnsafeDeserialization.rb:22:5:22:13 | json_data :  |
+| UnsafeDeserialization.rb:28:5:28:13 | json_data :  | UnsafeDeserialization.rb:29:27:29:35 | json_data |
 | UnsafeDeserialization.rb:28:17:28:22 | call to params :  | UnsafeDeserialization.rb:28:17:28:28 | ...[...] :  |
-| UnsafeDeserialization.rb:28:17:28:28 | ...[...] :  | UnsafeDeserialization.rb:29:27:29:35 | json_data |
+| UnsafeDeserialization.rb:28:17:28:28 | ...[...] :  | UnsafeDeserialization.rb:28:5:28:13 | json_data :  |
+| UnsafeDeserialization.rb:40:5:40:13 | yaml_data :  | UnsafeDeserialization.rb:41:24:41:32 | yaml_data |
 | UnsafeDeserialization.rb:40:17:40:22 | call to params :  | UnsafeDeserialization.rb:40:17:40:28 | ...[...] :  |
-| UnsafeDeserialization.rb:40:17:40:28 | ...[...] :  | UnsafeDeserialization.rb:41:24:41:32 | yaml_data |
+| UnsafeDeserialization.rb:40:17:40:28 | ...[...] :  | UnsafeDeserialization.rb:40:5:40:13 | yaml_data :  |
+| UnsafeDeserialization.rb:52:5:52:13 | json_data :  | UnsafeDeserialization.rb:53:22:53:30 | json_data |
+| UnsafeDeserialization.rb:52:5:52:13 | json_data :  | UnsafeDeserialization.rb:54:22:54:30 | json_data |
 | UnsafeDeserialization.rb:52:17:52:22 | call to params :  | UnsafeDeserialization.rb:52:17:52:28 | ...[...] :  |
-| UnsafeDeserialization.rb:52:17:52:28 | ...[...] :  | UnsafeDeserialization.rb:53:22:53:30 | json_data |
-| UnsafeDeserialization.rb:52:17:52:28 | ...[...] :  | UnsafeDeserialization.rb:54:22:54:30 | json_data |
+| UnsafeDeserialization.rb:52:17:52:28 | ...[...] :  | UnsafeDeserialization.rb:52:5:52:13 | json_data :  |
+| UnsafeDeserialization.rb:59:5:59:13 | json_data :  | UnsafeDeserialization.rb:69:23:69:31 | json_data |
 | UnsafeDeserialization.rb:59:17:59:22 | call to params :  | UnsafeDeserialization.rb:59:17:59:28 | ...[...] :  |
-| UnsafeDeserialization.rb:59:17:59:28 | ...[...] :  | UnsafeDeserialization.rb:69:23:69:31 | json_data |
+| UnsafeDeserialization.rb:59:17:59:28 | ...[...] :  | UnsafeDeserialization.rb:59:5:59:13 | json_data :  |
+| UnsafeDeserialization.rb:81:5:81:7 | xml :  | UnsafeDeserialization.rb:82:34:82:36 | xml |
 | UnsafeDeserialization.rb:81:11:81:16 | call to params :  | UnsafeDeserialization.rb:81:11:81:22 | ...[...] :  |
-| UnsafeDeserialization.rb:81:11:81:22 | ...[...] :  | UnsafeDeserialization.rb:82:34:82:36 | xml |
+| UnsafeDeserialization.rb:81:11:81:22 | ...[...] :  | UnsafeDeserialization.rb:81:5:81:7 | xml :  |
+| UnsafeDeserialization.rb:87:5:87:13 | yaml_data :  | UnsafeDeserialization.rb:88:25:88:33 | yaml_data |
 | UnsafeDeserialization.rb:87:17:87:22 | call to params :  | UnsafeDeserialization.rb:87:17:87:28 | ...[...] :  |
-| UnsafeDeserialization.rb:87:17:87:28 | ...[...] :  | UnsafeDeserialization.rb:88:25:88:33 | yaml_data |
+| UnsafeDeserialization.rb:87:17:87:28 | ...[...] :  | UnsafeDeserialization.rb:87:5:87:13 | yaml_data :  |
 nodes
+| UnsafeDeserialization.rb:10:5:10:19 | serialized_data :  | semmle.label | serialized_data :  |
 | UnsafeDeserialization.rb:10:23:10:50 | call to decode64 :  | semmle.label | call to decode64 :  |
 | UnsafeDeserialization.rb:10:39:10:44 | call to params :  | semmle.label | call to params :  |
 | UnsafeDeserialization.rb:10:39:10:50 | ...[...] :  | semmle.label | ...[...] :  |
 | UnsafeDeserialization.rb:11:27:11:41 | serialized_data | semmle.label | serialized_data |
+| UnsafeDeserialization.rb:16:5:16:19 | serialized_data :  | semmle.label | serialized_data :  |
 | UnsafeDeserialization.rb:16:23:16:50 | call to decode64 :  | semmle.label | call to decode64 :  |
 | UnsafeDeserialization.rb:16:39:16:44 | call to params :  | semmle.label | call to params :  |
 | UnsafeDeserialization.rb:16:39:16:50 | ...[...] :  | semmle.label | ...[...] :  |
 | UnsafeDeserialization.rb:17:30:17:44 | serialized_data | semmle.label | serialized_data |
+| UnsafeDeserialization.rb:22:5:22:13 | json_data :  | semmle.label | json_data :  |
 | UnsafeDeserialization.rb:22:17:22:22 | call to params :  | semmle.label | call to params :  |
 | UnsafeDeserialization.rb:22:17:22:28 | ...[...] :  | semmle.label | ...[...] :  |
 | UnsafeDeserialization.rb:23:24:23:32 | json_data | semmle.label | json_data |
+| UnsafeDeserialization.rb:28:5:28:13 | json_data :  | semmle.label | json_data :  |
 | UnsafeDeserialization.rb:28:17:28:22 | call to params :  | semmle.label | call to params :  |
 | UnsafeDeserialization.rb:28:17:28:28 | ...[...] :  | semmle.label | ...[...] :  |
 | UnsafeDeserialization.rb:29:27:29:35 | json_data | semmle.label | json_data |
+| UnsafeDeserialization.rb:40:5:40:13 | yaml_data :  | semmle.label | yaml_data :  |
 | UnsafeDeserialization.rb:40:17:40:22 | call to params :  | semmle.label | call to params :  |
 | UnsafeDeserialization.rb:40:17:40:28 | ...[...] :  | semmle.label | ...[...] :  |
 | UnsafeDeserialization.rb:41:24:41:32 | yaml_data | semmle.label | yaml_data |
+| UnsafeDeserialization.rb:52:5:52:13 | json_data :  | semmle.label | json_data :  |
 | UnsafeDeserialization.rb:52:17:52:22 | call to params :  | semmle.label | call to params :  |
 | UnsafeDeserialization.rb:52:17:52:28 | ...[...] :  | semmle.label | ...[...] :  |
 | UnsafeDeserialization.rb:53:22:53:30 | json_data | semmle.label | json_data |
 | UnsafeDeserialization.rb:54:22:54:30 | json_data | semmle.label | json_data |
+| UnsafeDeserialization.rb:59:5:59:13 | json_data :  | semmle.label | json_data :  |
 | UnsafeDeserialization.rb:59:17:59:22 | call to params :  | semmle.label | call to params :  |
 | UnsafeDeserialization.rb:59:17:59:28 | ...[...] :  | semmle.label | ...[...] :  |
 | UnsafeDeserialization.rb:69:23:69:31 | json_data | semmle.label | json_data |
+| UnsafeDeserialization.rb:81:5:81:7 | xml :  | semmle.label | xml :  |
 | UnsafeDeserialization.rb:81:11:81:16 | call to params :  | semmle.label | call to params :  |
 | UnsafeDeserialization.rb:81:11:81:22 | ...[...] :  | semmle.label | ...[...] :  |
 | UnsafeDeserialization.rb:82:34:82:36 | xml | semmle.label | xml |
+| UnsafeDeserialization.rb:87:5:87:13 | yaml_data :  | semmle.label | yaml_data :  |
 | UnsafeDeserialization.rb:87:17:87:22 | call to params :  | semmle.label | call to params :  |
 | UnsafeDeserialization.rb:87:17:87:28 | ...[...] :  | semmle.label | ...[...] :  |
 | UnsafeDeserialization.rb:88:25:88:33 | yaml_data | semmle.label | yaml_data |

--- a/ruby/ql/test/query-tests/security/cwe-506/HardcodedDataInterpretedAsCode.expected
+++ b/ruby/ql/test/query-tests/security/cwe-506/HardcodedDataInterpretedAsCode.expected
@@ -1,22 +1,26 @@
 edges
 | tst.rb:1:7:1:7 | r :  | tst.rb:2:4:2:4 | r :  |
 | tst.rb:2:4:2:4 | r :  | tst.rb:2:3:2:15 | call to pack :  |
-| tst.rb:5:27:5:72 | "707574732822636f646520696e6a6..." :  | tst.rb:7:8:7:30 | totally_harmless_string :  |
+| tst.rb:5:1:5:23 | totally_harmless_string :  | tst.rb:7:8:7:30 | totally_harmless_string :  |
+| tst.rb:5:27:5:72 | "707574732822636f646520696e6a6..." :  | tst.rb:5:1:5:23 | totally_harmless_string :  |
 | tst.rb:7:8:7:30 | totally_harmless_string :  | tst.rb:1:7:1:7 | r :  |
 | tst.rb:7:8:7:30 | totally_harmless_string :  | tst.rb:7:6:7:31 | call to e |
 | tst.rb:10:11:10:24 | "666f6f626172" :  | tst.rb:1:7:1:7 | r :  |
 | tst.rb:10:11:10:24 | "666f6f626172" :  | tst.rb:10:9:10:25 | call to e |
-| tst.rb:16:31:16:84 | "\\x70\\x75\\x74\\x73\\x28\\x27\\x68\\..." :  | tst.rb:17:6:17:32 | another_questionable_string :  |
+| tst.rb:16:1:16:27 | another_questionable_string :  | tst.rb:17:6:17:32 | another_questionable_string :  |
+| tst.rb:16:31:16:84 | "\\x70\\x75\\x74\\x73\\x28\\x27\\x68\\..." :  | tst.rb:16:1:16:27 | another_questionable_string :  |
 | tst.rb:17:6:17:32 | another_questionable_string :  | tst.rb:17:6:17:38 | call to strip |
 nodes
 | tst.rb:1:7:1:7 | r :  | semmle.label | r :  |
 | tst.rb:2:3:2:15 | call to pack :  | semmle.label | call to pack :  |
 | tst.rb:2:4:2:4 | r :  | semmle.label | r :  |
+| tst.rb:5:1:5:23 | totally_harmless_string :  | semmle.label | totally_harmless_string :  |
 | tst.rb:5:27:5:72 | "707574732822636f646520696e6a6..." :  | semmle.label | "707574732822636f646520696e6a6..." :  |
 | tst.rb:7:6:7:31 | call to e | semmle.label | call to e |
 | tst.rb:7:8:7:30 | totally_harmless_string :  | semmle.label | totally_harmless_string :  |
 | tst.rb:10:9:10:25 | call to e | semmle.label | call to e |
 | tst.rb:10:11:10:24 | "666f6f626172" :  | semmle.label | "666f6f626172" :  |
+| tst.rb:16:1:16:27 | another_questionable_string :  | semmle.label | another_questionable_string :  |
 | tst.rb:16:31:16:84 | "\\x70\\x75\\x74\\x73\\x28\\x27\\x68\\..." :  | semmle.label | "\\x70\\x75\\x74\\x73\\x28\\x27\\x68\\..." :  |
 | tst.rb:17:6:17:32 | another_questionable_string :  | semmle.label | another_questionable_string :  |
 | tst.rb:17:6:17:38 | call to strip | semmle.label | call to strip |

--- a/ruby/ql/test/query-tests/security/cwe-598/SensitiveGetQuery.expected
+++ b/ruby/ql/test/query-tests/security/cwe-598/SensitiveGetQuery.expected
@@ -1,7 +1,8 @@
 edges
 | app/controllers/users_controller.rb:4:11:4:16 | call to params :  | app/controllers/users_controller.rb:4:11:4:27 | ...[...] |
+| app/controllers/users_controller.rb:9:5:9:12 | password :  | app/controllers/users_controller.rb:10:42:10:49 | password |
 | app/controllers/users_controller.rb:9:16:9:21 | call to params :  | app/controllers/users_controller.rb:9:16:9:27 | ...[...] :  |
-| app/controllers/users_controller.rb:9:16:9:27 | ...[...] :  | app/controllers/users_controller.rb:10:42:10:49 | password |
+| app/controllers/users_controller.rb:9:16:9:27 | ...[...] :  | app/controllers/users_controller.rb:9:5:9:12 | password :  |
 | app/controllers/users_controller.rb:14:5:14:13 | [post] self [@password] :  | app/controllers/users_controller.rb:15:42:15:50 | self [@password] :  |
 | app/controllers/users_controller.rb:14:17:14:22 | call to params :  | app/controllers/users_controller.rb:14:17:14:28 | ...[...] :  |
 | app/controllers/users_controller.rb:14:17:14:28 | ...[...] :  | app/controllers/users_controller.rb:14:5:14:13 | [post] self [@password] :  |
@@ -9,6 +10,7 @@ edges
 nodes
 | app/controllers/users_controller.rb:4:11:4:16 | call to params :  | semmle.label | call to params :  |
 | app/controllers/users_controller.rb:4:11:4:27 | ...[...] | semmle.label | ...[...] |
+| app/controllers/users_controller.rb:9:5:9:12 | password :  | semmle.label | password :  |
 | app/controllers/users_controller.rb:9:16:9:21 | call to params :  | semmle.label | call to params :  |
 | app/controllers/users_controller.rb:9:16:9:27 | ...[...] :  | semmle.label | ...[...] :  |
 | app/controllers/users_controller.rb:10:42:10:49 | password | semmle.label | password |

--- a/ruby/ql/test/query-tests/security/cwe-611/libxml-backend/Xxe.expected
+++ b/ruby/ql/test/query-tests/security/cwe-611/libxml-backend/Xxe.expected
@@ -1,10 +1,12 @@
 edges
+| LibXmlBackend.rb:16:5:16:11 | content :  | LibXmlBackend.rb:18:30:18:36 | content |
+| LibXmlBackend.rb:16:5:16:11 | content :  | LibXmlBackend.rb:19:19:19:25 | content |
+| LibXmlBackend.rb:16:5:16:11 | content :  | LibXmlBackend.rb:20:27:20:33 | content |
+| LibXmlBackend.rb:16:5:16:11 | content :  | LibXmlBackend.rb:21:34:21:40 | content |
 | LibXmlBackend.rb:16:15:16:20 | call to params :  | LibXmlBackend.rb:16:15:16:26 | ...[...] :  |
-| LibXmlBackend.rb:16:15:16:26 | ...[...] :  | LibXmlBackend.rb:18:30:18:36 | content |
-| LibXmlBackend.rb:16:15:16:26 | ...[...] :  | LibXmlBackend.rb:19:19:19:25 | content |
-| LibXmlBackend.rb:16:15:16:26 | ...[...] :  | LibXmlBackend.rb:20:27:20:33 | content |
-| LibXmlBackend.rb:16:15:16:26 | ...[...] :  | LibXmlBackend.rb:21:34:21:40 | content |
+| LibXmlBackend.rb:16:15:16:26 | ...[...] :  | LibXmlBackend.rb:16:5:16:11 | content :  |
 nodes
+| LibXmlBackend.rb:16:5:16:11 | content :  | semmle.label | content :  |
 | LibXmlBackend.rb:16:15:16:20 | call to params :  | semmle.label | call to params :  |
 | LibXmlBackend.rb:16:15:16:26 | ...[...] :  | semmle.label | ...[...] :  |
 | LibXmlBackend.rb:18:30:18:36 | content | semmle.label | content |

--- a/ruby/ql/test/query-tests/security/cwe-611/xxe/Xxe.expected
+++ b/ruby/ql/test/query-tests/security/cwe-611/xxe/Xxe.expected
@@ -1,30 +1,33 @@
 edges
+| LibXmlRuby.rb:3:5:3:11 | content :  | LibXmlRuby.rb:4:34:4:40 | content |
+| LibXmlRuby.rb:3:5:3:11 | content :  | LibXmlRuby.rb:5:32:5:38 | content |
+| LibXmlRuby.rb:3:5:3:11 | content :  | LibXmlRuby.rb:6:30:6:36 | content |
+| LibXmlRuby.rb:3:5:3:11 | content :  | LibXmlRuby.rb:7:32:7:38 | content |
+| LibXmlRuby.rb:3:5:3:11 | content :  | LibXmlRuby.rb:8:30:8:36 | content |
+| LibXmlRuby.rb:3:5:3:11 | content :  | LibXmlRuby.rb:9:28:9:34 | content |
+| LibXmlRuby.rb:3:5:3:11 | content :  | LibXmlRuby.rb:11:26:11:32 | content |
+| LibXmlRuby.rb:3:5:3:11 | content :  | LibXmlRuby.rb:12:24:12:30 | content |
 | LibXmlRuby.rb:3:15:3:20 | call to params :  | LibXmlRuby.rb:3:15:3:26 | ...[...] :  |
-| LibXmlRuby.rb:3:15:3:26 | ...[...] :  | LibXmlRuby.rb:4:34:4:40 | content |
-| LibXmlRuby.rb:3:15:3:26 | ...[...] :  | LibXmlRuby.rb:5:32:5:38 | content |
-| LibXmlRuby.rb:3:15:3:26 | ...[...] :  | LibXmlRuby.rb:6:30:6:36 | content |
-| LibXmlRuby.rb:3:15:3:26 | ...[...] :  | LibXmlRuby.rb:7:32:7:38 | content |
-| LibXmlRuby.rb:3:15:3:26 | ...[...] :  | LibXmlRuby.rb:8:30:8:36 | content |
-| LibXmlRuby.rb:3:15:3:26 | ...[...] :  | LibXmlRuby.rb:9:28:9:34 | content |
-| LibXmlRuby.rb:3:15:3:26 | ...[...] :  | LibXmlRuby.rb:11:26:11:32 | content |
-| LibXmlRuby.rb:3:15:3:26 | ...[...] :  | LibXmlRuby.rb:12:24:12:30 | content |
+| LibXmlRuby.rb:3:15:3:26 | ...[...] :  | LibXmlRuby.rb:3:5:3:11 | content :  |
+| Nokogiri.rb:3:5:3:11 | content :  | Nokogiri.rb:5:26:5:32 | content |
+| Nokogiri.rb:3:5:3:11 | content :  | Nokogiri.rb:6:26:6:32 | content |
+| Nokogiri.rb:3:5:3:11 | content :  | Nokogiri.rb:7:26:7:32 | content |
+| Nokogiri.rb:3:5:3:11 | content :  | Nokogiri.rb:8:26:8:32 | content |
+| Nokogiri.rb:3:5:3:11 | content :  | Nokogiri.rb:9:26:9:32 | content |
+| Nokogiri.rb:3:5:3:11 | content :  | Nokogiri.rb:11:26:11:32 | content |
+| Nokogiri.rb:3:5:3:11 | content :  | Nokogiri.rb:12:26:12:32 | content |
+| Nokogiri.rb:3:5:3:11 | content :  | Nokogiri.rb:15:26:15:32 | content |
+| Nokogiri.rb:3:5:3:11 | content :  | Nokogiri.rb:16:26:16:32 | content |
+| Nokogiri.rb:3:5:3:11 | content :  | Nokogiri.rb:18:26:18:32 | content |
+| Nokogiri.rb:3:5:3:11 | content :  | Nokogiri.rb:19:26:19:32 | content |
+| Nokogiri.rb:3:5:3:11 | content :  | Nokogiri.rb:22:26:22:32 | content |
+| Nokogiri.rb:3:5:3:11 | content :  | Nokogiri.rb:25:26:25:32 | content |
+| Nokogiri.rb:3:5:3:11 | content :  | Nokogiri.rb:27:26:27:32 | content |
+| Nokogiri.rb:3:5:3:11 | content :  | Nokogiri.rb:28:26:28:32 | content |
 | Nokogiri.rb:3:15:3:20 | call to params :  | Nokogiri.rb:3:15:3:26 | ...[...] :  |
-| Nokogiri.rb:3:15:3:26 | ...[...] :  | Nokogiri.rb:5:26:5:32 | content |
-| Nokogiri.rb:3:15:3:26 | ...[...] :  | Nokogiri.rb:6:26:6:32 | content |
-| Nokogiri.rb:3:15:3:26 | ...[...] :  | Nokogiri.rb:7:26:7:32 | content |
-| Nokogiri.rb:3:15:3:26 | ...[...] :  | Nokogiri.rb:8:26:8:32 | content |
-| Nokogiri.rb:3:15:3:26 | ...[...] :  | Nokogiri.rb:9:26:9:32 | content |
-| Nokogiri.rb:3:15:3:26 | ...[...] :  | Nokogiri.rb:11:26:11:32 | content |
-| Nokogiri.rb:3:15:3:26 | ...[...] :  | Nokogiri.rb:12:26:12:32 | content |
-| Nokogiri.rb:3:15:3:26 | ...[...] :  | Nokogiri.rb:15:26:15:32 | content |
-| Nokogiri.rb:3:15:3:26 | ...[...] :  | Nokogiri.rb:16:26:16:32 | content |
-| Nokogiri.rb:3:15:3:26 | ...[...] :  | Nokogiri.rb:18:26:18:32 | content |
-| Nokogiri.rb:3:15:3:26 | ...[...] :  | Nokogiri.rb:19:26:19:32 | content |
-| Nokogiri.rb:3:15:3:26 | ...[...] :  | Nokogiri.rb:22:26:22:32 | content |
-| Nokogiri.rb:3:15:3:26 | ...[...] :  | Nokogiri.rb:25:26:25:32 | content |
-| Nokogiri.rb:3:15:3:26 | ...[...] :  | Nokogiri.rb:27:26:27:32 | content |
-| Nokogiri.rb:3:15:3:26 | ...[...] :  | Nokogiri.rb:28:26:28:32 | content |
+| Nokogiri.rb:3:15:3:26 | ...[...] :  | Nokogiri.rb:3:5:3:11 | content :  |
 nodes
+| LibXmlRuby.rb:3:5:3:11 | content :  | semmle.label | content :  |
 | LibXmlRuby.rb:3:15:3:20 | call to params :  | semmle.label | call to params :  |
 | LibXmlRuby.rb:3:15:3:26 | ...[...] :  | semmle.label | ...[...] :  |
 | LibXmlRuby.rb:4:34:4:40 | content | semmle.label | content |
@@ -35,6 +38,7 @@ nodes
 | LibXmlRuby.rb:9:28:9:34 | content | semmle.label | content |
 | LibXmlRuby.rb:11:26:11:32 | content | semmle.label | content |
 | LibXmlRuby.rb:12:24:12:30 | content | semmle.label | content |
+| Nokogiri.rb:3:5:3:11 | content :  | semmle.label | content :  |
 | Nokogiri.rb:3:15:3:20 | call to params :  | semmle.label | call to params :  |
 | Nokogiri.rb:3:15:3:26 | ...[...] :  | semmle.label | ...[...] :  |
 | Nokogiri.rb:5:26:5:32 | content | semmle.label | content |

--- a/ruby/ql/test/query-tests/security/cwe-732/WeakFilePermissions.expected
+++ b/ruby/ql/test/query-tests/security/cwe-732/WeakFilePermissions.expected
@@ -1,17 +1,25 @@
 edges
-| FilePermissions.rb:51:10:51:13 | 0777 :  | FilePermissions.rb:53:19:53:22 | perm |
-| FilePermissions.rb:51:10:51:13 | 0777 :  | FilePermissions.rb:56:19:56:23 | perm2 |
-| FilePermissions.rb:58:10:58:26 | "u=wrx,g=rwx,o=x" :  | FilePermissions.rb:61:19:61:23 | perm2 |
+| FilePermissions.rb:51:3:51:6 | perm :  | FilePermissions.rb:53:19:53:22 | perm |
+| FilePermissions.rb:51:3:51:6 | perm :  | FilePermissions.rb:54:3:54:7 | perm2 :  |
+| FilePermissions.rb:51:10:51:13 | 0777 :  | FilePermissions.rb:51:3:51:6 | perm :  |
+| FilePermissions.rb:54:3:54:7 | perm2 :  | FilePermissions.rb:56:19:56:23 | perm2 |
+| FilePermissions.rb:58:3:58:6 | perm :  | FilePermissions.rb:59:3:59:7 | perm2 :  |
+| FilePermissions.rb:58:10:58:26 | "u=wrx,g=rwx,o=x" :  | FilePermissions.rb:58:3:58:6 | perm :  |
+| FilePermissions.rb:59:3:59:7 | perm2 :  | FilePermissions.rb:61:19:61:23 | perm2 |
 nodes
 | FilePermissions.rb:5:19:5:22 | 0222 | semmle.label | 0222 |
 | FilePermissions.rb:7:19:7:22 | 0622 | semmle.label | 0622 |
 | FilePermissions.rb:9:19:9:22 | 0755 | semmle.label | 0755 |
 | FilePermissions.rb:11:19:11:22 | 0777 | semmle.label | 0777 |
 | FilePermissions.rb:28:13:28:16 | 0755 | semmle.label | 0755 |
+| FilePermissions.rb:51:3:51:6 | perm :  | semmle.label | perm :  |
 | FilePermissions.rb:51:10:51:13 | 0777 :  | semmle.label | 0777 :  |
 | FilePermissions.rb:53:19:53:22 | perm | semmle.label | perm |
+| FilePermissions.rb:54:3:54:7 | perm2 :  | semmle.label | perm2 :  |
 | FilePermissions.rb:56:19:56:23 | perm2 | semmle.label | perm2 |
+| FilePermissions.rb:58:3:58:6 | perm :  | semmle.label | perm :  |
 | FilePermissions.rb:58:10:58:26 | "u=wrx,g=rwx,o=x" :  | semmle.label | "u=wrx,g=rwx,o=x" :  |
+| FilePermissions.rb:59:3:59:7 | perm2 :  | semmle.label | perm2 :  |
 | FilePermissions.rb:61:19:61:23 | perm2 | semmle.label | perm2 |
 | FilePermissions.rb:63:19:63:29 | "u=rwx,o+r" | semmle.label | "u=rwx,o+r" |
 | FilePermissions.rb:67:19:67:24 | "a+rw" | semmle.label | "a+rw" |

--- a/ruby/ql/test/query-tests/security/cwe-798/HardcodedCredentials.expected
+++ b/ruby/ql/test/query-tests/security/cwe-798/HardcodedCredentials.expected
@@ -3,8 +3,11 @@ edges
 | HardcodedCredentials.rb:15:30:15:75 | "WLC17dLQ9P8YlQvqm77qplOMm5pd1..." :  | HardcodedCredentials.rb:1:33:1:36 | cert |
 | HardcodedCredentials.rb:18:19:18:72 | ... + ... :  | HardcodedCredentials.rb:1:23:1:30 | password |
 | HardcodedCredentials.rb:18:27:18:72 | "ogH6qSYWGdbR/2WOGYa7eZ/tObL+G..." :  | HardcodedCredentials.rb:18:19:18:72 | ... + ... :  |
-| HardcodedCredentials.rb:20:11:20:76 | "3jOe7sXKX6Tx52qHWUVqh2t9LNsE+..." :  | HardcodedCredentials.rb:23:19:23:20 | pw :  |
-| HardcodedCredentials.rb:21:12:21:37 | "4fQuzXef4f2yow8KWvIJTA==" :  | HardcodedCredentials.rb:23:19:23:20 | pw :  |
+| HardcodedCredentials.rb:20:1:20:7 | pw_left :  | HardcodedCredentials.rb:22:1:22:2 | pw :  |
+| HardcodedCredentials.rb:20:11:20:76 | "3jOe7sXKX6Tx52qHWUVqh2t9LNsE+..." :  | HardcodedCredentials.rb:20:1:20:7 | pw_left :  |
+| HardcodedCredentials.rb:21:1:21:8 | pw_right :  | HardcodedCredentials.rb:22:1:22:2 | pw :  |
+| HardcodedCredentials.rb:21:12:21:37 | "4fQuzXef4f2yow8KWvIJTA==" :  | HardcodedCredentials.rb:21:1:21:8 | pw_right :  |
+| HardcodedCredentials.rb:22:1:22:2 | pw :  | HardcodedCredentials.rb:23:19:23:20 | pw :  |
 | HardcodedCredentials.rb:23:19:23:20 | pw :  | HardcodedCredentials.rb:1:23:1:30 | password |
 | HardcodedCredentials.rb:38:40:38:85 | "kdW/xVhiv6y1fQQNevDpUaq+2rfPK..." :  | HardcodedCredentials.rb:31:18:31:23 | passwd |
 | HardcodedCredentials.rb:43:29:43:43 | "user@test.com" :  | HardcodedCredentials.rb:43:18:43:25 | username |
@@ -19,8 +22,11 @@ nodes
 | HardcodedCredentials.rb:15:30:15:75 | "WLC17dLQ9P8YlQvqm77qplOMm5pd1..." :  | semmle.label | "WLC17dLQ9P8YlQvqm77qplOMm5pd1..." :  |
 | HardcodedCredentials.rb:18:19:18:72 | ... + ... :  | semmle.label | ... + ... :  |
 | HardcodedCredentials.rb:18:27:18:72 | "ogH6qSYWGdbR/2WOGYa7eZ/tObL+G..." :  | semmle.label | "ogH6qSYWGdbR/2WOGYa7eZ/tObL+G..." :  |
+| HardcodedCredentials.rb:20:1:20:7 | pw_left :  | semmle.label | pw_left :  |
 | HardcodedCredentials.rb:20:11:20:76 | "3jOe7sXKX6Tx52qHWUVqh2t9LNsE+..." :  | semmle.label | "3jOe7sXKX6Tx52qHWUVqh2t9LNsE+..." :  |
+| HardcodedCredentials.rb:21:1:21:8 | pw_right :  | semmle.label | pw_right :  |
 | HardcodedCredentials.rb:21:12:21:37 | "4fQuzXef4f2yow8KWvIJTA==" :  | semmle.label | "4fQuzXef4f2yow8KWvIJTA==" :  |
+| HardcodedCredentials.rb:22:1:22:2 | pw :  | semmle.label | pw :  |
 | HardcodedCredentials.rb:23:19:23:20 | pw :  | semmle.label | pw :  |
 | HardcodedCredentials.rb:31:18:31:23 | passwd | semmle.label | passwd |
 | HardcodedCredentials.rb:38:40:38:85 | "kdW/xVhiv6y1fQQNevDpUaq+2rfPK..." :  | semmle.label | "kdW/xVhiv6y1fQQNevDpUaq+2rfPK..." :  |

--- a/ruby/ql/test/query-tests/security/cwe-807-user-controlled-bypass/ConditionalBypass.expected
+++ b/ruby/ql/test/query-tests/security/cwe-807-user-controlled-bypass/ConditionalBypass.expected
@@ -1,16 +1,20 @@
 edges
+| ConditionalBypass.rb:3:5:3:9 | check :  | ConditionalBypass.rb:6:8:6:12 | check |
 | ConditionalBypass.rb:3:13:3:18 | call to params :  | ConditionalBypass.rb:3:13:3:26 | ...[...] :  |
-| ConditionalBypass.rb:3:13:3:26 | ...[...] :  | ConditionalBypass.rb:6:8:6:12 | check |
+| ConditionalBypass.rb:3:13:3:26 | ...[...] :  | ConditionalBypass.rb:3:5:3:9 | check :  |
 | ConditionalBypass.rb:14:14:14:19 | call to params :  | ConditionalBypass.rb:14:14:14:27 | ...[...] |
+| ConditionalBypass.rb:25:5:25:5 | p :  | ConditionalBypass.rb:27:8:27:8 | p |
 | ConditionalBypass.rb:25:10:25:15 | call to params :  | ConditionalBypass.rb:25:10:25:22 | ...[...] |
 | ConditionalBypass.rb:25:10:25:15 | call to params :  | ConditionalBypass.rb:25:10:25:22 | ...[...] :  |
-| ConditionalBypass.rb:25:10:25:22 | ...[...] :  | ConditionalBypass.rb:27:8:27:8 | p |
+| ConditionalBypass.rb:25:10:25:22 | ...[...] :  | ConditionalBypass.rb:25:5:25:5 | p :  |
 nodes
+| ConditionalBypass.rb:3:5:3:9 | check :  | semmle.label | check :  |
 | ConditionalBypass.rb:3:13:3:18 | call to params :  | semmle.label | call to params :  |
 | ConditionalBypass.rb:3:13:3:26 | ...[...] :  | semmle.label | ...[...] :  |
 | ConditionalBypass.rb:6:8:6:12 | check | semmle.label | check |
 | ConditionalBypass.rb:14:14:14:19 | call to params :  | semmle.label | call to params :  |
 | ConditionalBypass.rb:14:14:14:27 | ...[...] | semmle.label | ...[...] |
+| ConditionalBypass.rb:25:5:25:5 | p :  | semmle.label | p :  |
 | ConditionalBypass.rb:25:10:25:15 | call to params :  | semmle.label | call to params :  |
 | ConditionalBypass.rb:25:10:25:22 | ...[...] | semmle.label | ...[...] |
 | ConditionalBypass.rb:25:10:25:22 | ...[...] :  | semmle.label | ...[...] :  |

--- a/ruby/ql/test/query-tests/security/cwe-829/InsecureDownload.expected
+++ b/ruby/ql/test/query-tests/security/cwe-829/InsecureDownload.expected
@@ -1,10 +1,14 @@
 failures
 edges
-| insecure_download.rb:31:11:31:41 | "http://example.org/unsafe.APK" :  | insecure_download.rb:33:15:33:17 | url |
-| insecure_download.rb:31:11:31:41 | "http://example.org/unsafe.APK" :  | insecure_download.rb:33:15:33:17 | url |
+| insecure_download.rb:31:5:31:7 | url :  | insecure_download.rb:33:15:33:17 | url |
+| insecure_download.rb:31:5:31:7 | url :  | insecure_download.rb:33:15:33:17 | url |
+| insecure_download.rb:31:11:31:41 | "http://example.org/unsafe.APK" :  | insecure_download.rb:31:5:31:7 | url :  |
+| insecure_download.rb:31:11:31:41 | "http://example.org/unsafe.APK" :  | insecure_download.rb:31:5:31:7 | url :  |
 nodes
 | insecure_download.rb:27:15:27:45 | "http://example.org/unsafe.APK" | semmle.label | "http://example.org/unsafe.APK" |
 | insecure_download.rb:27:15:27:45 | "http://example.org/unsafe.APK" | semmle.label | "http://example.org/unsafe.APK" |
+| insecure_download.rb:31:5:31:7 | url :  | semmle.label | url :  |
+| insecure_download.rb:31:5:31:7 | url :  | semmle.label | url :  |
 | insecure_download.rb:31:11:31:41 | "http://example.org/unsafe.APK" :  | semmle.label | "http://example.org/unsafe.APK" :  |
 | insecure_download.rb:31:11:31:41 | "http://example.org/unsafe.APK" :  | semmle.label | "http://example.org/unsafe.APK" :  |
 | insecure_download.rb:33:15:33:17 | url | semmle.label | url |

--- a/ruby/ql/test/query-tests/security/cwe-912/HttpToFileAccess.expected
+++ b/ruby/ql/test/query-tests/security/cwe-912/HttpToFileAccess.expected
@@ -1,10 +1,14 @@
 edges
-| http_to_file_access.rb:3:8:3:52 | call to body :  | http_to_file_access.rb:5:12:5:15 | resp |
+| http_to_file_access.rb:3:1:3:4 | resp :  | http_to_file_access.rb:5:12:5:15 | resp |
+| http_to_file_access.rb:3:8:3:52 | call to body :  | http_to_file_access.rb:3:1:3:4 | resp :  |
+| http_to_file_access.rb:9:7:9:12 | script :  | http_to_file_access.rb:11:18:11:23 | script |
 | http_to_file_access.rb:9:16:9:21 | call to params :  | http_to_file_access.rb:9:16:9:30 | ...[...] :  |
-| http_to_file_access.rb:9:16:9:30 | ...[...] :  | http_to_file_access.rb:11:18:11:23 | script |
+| http_to_file_access.rb:9:16:9:30 | ...[...] :  | http_to_file_access.rb:9:7:9:12 | script :  |
 nodes
+| http_to_file_access.rb:3:1:3:4 | resp :  | semmle.label | resp :  |
 | http_to_file_access.rb:3:8:3:52 | call to body :  | semmle.label | call to body :  |
 | http_to_file_access.rb:5:12:5:15 | resp | semmle.label | resp |
+| http_to_file_access.rb:9:7:9:12 | script :  | semmle.label | script :  |
 | http_to_file_access.rb:9:16:9:21 | call to params :  | semmle.label | call to params :  |
 | http_to_file_access.rb:9:16:9:30 | ...[...] :  | semmle.label | ...[...] :  |
 | http_to_file_access.rb:11:18:11:23 | script | semmle.label | script |

--- a/ruby/ql/test/query-tests/security/cwe-918/ServerSideRequestForgery.expected
+++ b/ruby/ql/test/query-tests/security/cwe-918/ServerSideRequestForgery.expected
@@ -1,9 +1,11 @@
 edges
+| ServerSideRequestForgery.rb:10:9:10:28 | users_service_domain :  | ServerSideRequestForgery.rb:11:31:11:62 | "#{...}/logins" |
 | ServerSideRequestForgery.rb:10:32:10:37 | call to params :  | ServerSideRequestForgery.rb:10:32:10:60 | ...[...] :  |
-| ServerSideRequestForgery.rb:10:32:10:60 | ...[...] :  | ServerSideRequestForgery.rb:11:31:11:62 | "#{...}/logins" |
+| ServerSideRequestForgery.rb:10:32:10:60 | ...[...] :  | ServerSideRequestForgery.rb:10:9:10:28 | users_service_domain :  |
 | ServerSideRequestForgery.rb:15:33:15:38 | call to params :  | ServerSideRequestForgery.rb:15:33:15:44 | ...[...] |
 | ServerSideRequestForgery.rb:20:45:20:50 | call to params :  | ServerSideRequestForgery.rb:20:45:20:56 | ...[...] |
 nodes
+| ServerSideRequestForgery.rb:10:9:10:28 | users_service_domain :  | semmle.label | users_service_domain :  |
 | ServerSideRequestForgery.rb:10:32:10:37 | call to params :  | semmle.label | call to params :  |
 | ServerSideRequestForgery.rb:10:32:10:60 | ...[...] :  | semmle.label | ...[...] :  |
 | ServerSideRequestForgery.rb:11:31:11:62 | "#{...}/logins" | semmle.label | "#{...}/logins" |

--- a/ruby/ql/test/query-tests/security/decompression-api/DecompressionApi.expected
+++ b/ruby/ql/test/query-tests/security/decompression-api/DecompressionApi.expected
@@ -1,8 +1,10 @@
 edges
+| decompression_api.rb:4:9:4:12 | path :  | decompression_api.rb:5:31:5:34 | path |
 | decompression_api.rb:4:16:4:21 | call to params :  | decompression_api.rb:4:16:4:28 | ...[...] :  |
-| decompression_api.rb:4:16:4:28 | ...[...] :  | decompression_api.rb:5:31:5:34 | path |
+| decompression_api.rb:4:16:4:28 | ...[...] :  | decompression_api.rb:4:9:4:12 | path :  |
 | decompression_api.rb:15:31:15:36 | call to params :  | decompression_api.rb:15:31:15:43 | ...[...] |
 nodes
+| decompression_api.rb:4:9:4:12 | path :  | semmle.label | path :  |
 | decompression_api.rb:4:16:4:21 | call to params :  | semmle.label | call to params :  |
 | decompression_api.rb:4:16:4:28 | ...[...] :  | semmle.label | ...[...] :  |
 | decompression_api.rb:5:31:5:34 | path | semmle.label | path |


### PR DESCRIPTION
This PR ensures that flow that goes through assignments always include those assignments in the reported data flow path.

For example, in

```rb
x = taint
if (b)
  y = x
sink(y)
```

we will no longer report a flow path directly from `taint` to the `y` in `sink(y)`, but instead have an intermediate step that goes through the assignment `y = x`. This should make it easier to follow flow paths.

Instead of requiring that all right-hand sides of assignments always be included in flow paths, we make use of the underlying SSA definition, which means that we will only break at assignments when flow actually goes via the assignee. For example, in

```rb
x = taint
if (b)
  y = x
sink(x)
```

we don't want to have an intermediate step at the assignment `y = x`.