### PR TITLE
QL: add a check to enforce naming convention for new `DataFlow::ConfigSig` modules

### DIFF
--- a/ql/ql/src/queries/style/DataFlowConfigModuleNaming.ql
+++ b/ql/ql/src/queries/style/DataFlowConfigModuleNaming.ql
@@ -1,0 +1,43 @@
+/**
+ * @id ql/dataflow-module-naming-convention
+ * @name Data flow configuration module naming
+ * @description The name of a data flow configuration module should end in `Config`
+ * @kind problem
+ * @problem.severity warning
+ * @precision high
+ */
+
+import ql
+
+/**
+ * The DataFlow configuration module signatures (`ConfigSig`, `StateConfigSig`, `FullStateConfigSig`).
+ */
+class ConfigSig extends TypeExpr {
+  ConfigSig() { this.getClassName() = ["ConfigSig", "StateConfigSig", "FullStateConfigSig"] }
+}
+
+/**
+ * A module that implements a data flow configuration.
+ */
+class DataFlowConfigModule extends Module {
+  DataFlowConfigModule() { this.getImplements(_) instanceof ConfigSig }
+}
+
+/**
+ * A file that is not part of the internal dataflow library.
+ */
+class DataFlowInternalFile extends File {
+  DataFlowInternalFile() {
+    this.getRelativePath()
+        .matches([
+            "%/dataflow/internal/%", "%/dataflow/new/internal/%",
+            "%/ql/test/library-tests/dataflow/%"
+          ])
+  }
+}
+
+from DataFlowConfigModule m
+where
+  not m.getFile() instanceof DataFlowInternalFile and
+  not m.getName().matches("%Config")
+select m, "Modules implementing a data flow configuration should end in `Config`."

--- a/ql/ql/src/queries/style/DataFlowConfigModuleNaming.ql
+++ b/ql/ql/src/queries/style/DataFlowConfigModuleNaming.ql
@@ -24,7 +24,8 @@ class DataFlowConfigModule extends Module {
 }
 
 /**
- * A file that is not part of the internal dataflow library.
+ * A file that is part of the internal dataflow library or dataflow library
+ * tests.
  */
 class DataFlowInternalFile extends File {
   DataFlowInternalFile() {

--- a/ql/ql/test/queries/style/DataFlowConfigModuleNaming/DataFlowConfigModuleNaming.expected
+++ b/ql/ql/test/queries/style/DataFlowConfigModuleNaming/DataFlowConfigModuleNaming.expected
@@ -1,0 +1,2 @@
+| Test.qll:11:8:11:25 | Module EmptyConfiguration | Modules implementing a data flow configuration should end in `Config`. |
+| Test.qll:18:8:18:16 | Module EmptyFlow | Modules implementing a data flow configuration should end in `Config`. |

--- a/ql/ql/test/queries/style/DataFlowConfigModuleNaming/DataFlowConfigModuleNaming.qlref
+++ b/ql/ql/test/queries/style/DataFlowConfigModuleNaming/DataFlowConfigModuleNaming.qlref
@@ -1,0 +1,1 @@
+queries/style/DataFlowConfigModuleNaming.ql

--- a/ql/ql/test/queries/style/DataFlowConfigModuleNaming/Test.qll
+++ b/ql/ql/test/queries/style/DataFlowConfigModuleNaming/Test.qll
@@ -1,0 +1,22 @@
+import semmle.code.java.dataflow.DataFlow
+
+// GOOD - ends with "Config"
+module EmptyConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node src) { none() }
+
+  predicate isSink(DataFlow::Node sink) { none() }
+}
+
+// BAD - does not end with "Config"
+module EmptyConfiguration implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node src) { none() }
+
+  predicate isSink(DataFlow::Node sink) { none() }
+}
+
+// BAD - does not end with "Config"
+module EmptyFlow implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node src) { none() }
+
+  predicate isSink(DataFlow::Node sink) { none() }
+}


### PR DESCRIPTION
Adds a style check to detect modules implementing `DataFlow::ConfigSig`(/`StateConfig`/`FullStateConfig`) and do not end with `Config`.

This can help maintain a consistent naming convention as we refactor dataflow configurations now that #12186 has been merged.

PR to bring files into compliance: #12578