### PR TITLE
Conform dataflow config modules to follow `*Config` naming convention

### DIFF
--- a/cpp/ql/src/Likely Bugs/Format/NonConstantFormat.ql
+++ b/cpp/ql/src/Likely Bugs/Format/NonConstantFormat.ql
@@ -132,7 +132,7 @@ predicate isSinkImpl(DataFlow::Node sink, Expr formatString) {
   exists(FormattingFunctionCall fc | formatString = fc.getArgument(fc.getFormatParameterIndex()))
 }
 
-module NonConstFlowConfiguration implements DataFlow::ConfigSig {
+module NonConstFlowConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) {
     exists(boolean isIndirect, Type t |
       isNonConst(source, isIndirect) and
@@ -146,7 +146,7 @@ module NonConstFlowConfiguration implements DataFlow::ConfigSig {
   predicate isBarrier(DataFlow::Node node) { isBarrierNode(node) }
 }
 
-module NonConstFlow = TaintTracking::Make<NonConstFlowConfiguration>;
+module NonConstFlow = TaintTracking::Make<NonConstFlowConfig>;
 
 from FormattingFunctionCall call, Expr formatString
 where

--- a/cpp/ql/src/Likely Bugs/Leap Year/LeapYear.qll
+++ b/cpp/ql/src/Likely Bugs/Leap Year/LeapYear.qll
@@ -223,7 +223,7 @@ deprecated class LeapYearCheckConfiguration extends DataFlow::Configuration {
  * Data flow configuration for finding a variable access that would flow into
  * a function call that includes an operation to check for leap year.
  */
-private module LeapYearCheckConfiguration implements DataFlow::ConfigSig {
+private module LeapYearCheckConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) { source.asExpr() instanceof VariableAccess }
 
   predicate isSink(DataFlow::Node sink) {
@@ -231,7 +231,7 @@ private module LeapYearCheckConfiguration implements DataFlow::ConfigSig {
   }
 }
 
-module LeapYearCheckFlow = DataFlow::Make<LeapYearCheckConfiguration>;
+module LeapYearCheckFlow = DataFlow::Make<LeapYearCheckConfig>;
 
 /**
  * Data flow configuration for finding an operation with hardcoded 365 that will flow into
@@ -264,7 +264,7 @@ deprecated class FiletimeYearArithmeticOperationCheckConfiguration extends DataF
  * Data flow configuration for finding an operation with hardcoded 365 that will flow into
  * a `FILEINFO` field.
  */
-private module FiletimeYearArithmeticOperationCheckConfiguration implements DataFlow::ConfigSig {
+private module FiletimeYearArithmeticOperationCheckConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) {
     exists(Expr e, Operation op | e = source.asExpr() |
       op.getAChild*().getValue().toInt() = 365 and
@@ -284,7 +284,7 @@ private module FiletimeYearArithmeticOperationCheckConfiguration implements Data
 }
 
 module FiletimeYearArithmeticOperationCheckFlow =
-  DataFlow::Make<FiletimeYearArithmeticOperationCheckConfiguration>;
+  DataFlow::Make<FiletimeYearArithmeticOperationCheckConfig>;
 
 /**
  * Taint configuration for finding an operation with hardcoded 365 that will flow into any known date/time field.
@@ -334,7 +334,7 @@ deprecated class PossibleYearArithmeticOperationCheckConfiguration extends Taint
 /**
  * Taint configuration for finding an operation with hardcoded 365 that will flow into any known date/time field.
  */
-private module PossibleYearArithmeticOperationCheckConfiguration implements DataFlow::ConfigSig {
+private module PossibleYearArithmeticOperationCheckConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) {
     exists(Operation op | op = source.asConvertedExpr() |
       op.getAChild*().getValue().toInt() = 365 and
@@ -372,4 +372,4 @@ private module PossibleYearArithmeticOperationCheckConfiguration implements Data
 }
 
 module PossibleYearArithmeticOperationCheckFlow =
-  TaintTracking::Make<PossibleYearArithmeticOperationCheckConfiguration>;
+  TaintTracking::Make<PossibleYearArithmeticOperationCheckConfig>;

--- a/cpp/ql/src/Likely Bugs/Memory Management/NtohlArrayNoBound.qll
+++ b/cpp/ql/src/Likely Bugs/Memory Management/NtohlArrayNoBound.qll
@@ -147,7 +147,7 @@ deprecated class NetworkToBufferSizeConfiguration extends DataFlow::Configuratio
   }
 }
 
-private module NetworkToBufferSizeConfiguration implements DataFlow::ConfigSig {
+private module NetworkToBufferSizeConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node node) { node.asExpr() instanceof NetworkFunctionCall }
 
   predicate isSink(DataFlow::Node node) { node.asExpr() = any(BufferAccess ba).getAccessedLength() }
@@ -161,4 +161,4 @@ private module NetworkToBufferSizeConfiguration implements DataFlow::ConfigSig {
   }
 }
 
-module NetworkToBufferSizeFlow = DataFlow::Make<NetworkToBufferSizeConfiguration>;
+module NetworkToBufferSizeFlow = DataFlow::Make<NetworkToBufferSizeConfig>;

--- a/cpp/ql/src/Security/CWE/CWE-022/TaintedPath.ql
+++ b/cpp/ql/src/Security/CWE/CWE-022/TaintedPath.ql
@@ -70,7 +70,7 @@ predicate hasUpperBoundsCheck(Variable var) {
   )
 }
 
-module TaintedPathConfiguration implements DataFlow::ConfigSig {
+module TaintedPathConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node node) { node instanceof FlowSource }
 
   predicate isSink(DataFlow::Node node) {
@@ -90,7 +90,7 @@ module TaintedPathConfiguration implements DataFlow::ConfigSig {
   }
 }
 
-module TaintedPath = TaintTracking::Make<TaintedPathConfiguration>;
+module TaintedPath = TaintTracking::Make<TaintedPathConfig>;
 
 from
   FileFunction fileFunction, Expr taintedArg, FlowSource taintSource,

--- a/cpp/ql/src/Security/CWE/CWE-078/ExecTainted.ql
+++ b/cpp/ql/src/Security/CWE/CWE-078/ExecTainted.ql
@@ -97,7 +97,7 @@ predicate isBarrierImpl(DataFlow::Node node) {
  * given sink. This avoids a cartesian product between all sinks and all `ExecState`s in
  * `ExecTaintConfiguration::isSink`.
  */
-module ExecStateConfiguration implements DataFlow::ConfigSig {
+module ExecStateConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) { any(ExecState state).getOutgoingNode() = source }
 
   predicate isSink(DataFlow::Node sink) { isSinkImpl(sink, _, _) }
@@ -109,9 +109,9 @@ module ExecStateConfiguration implements DataFlow::ConfigSig {
   }
 }
 
-module ExecState = TaintTracking::Make<ExecStateConfiguration>;
+module ExecState = TaintTracking::Make<ExecStateConfig>;
 
-module ExecTaintConfiguration implements DataFlow::StateConfigSig {
+module ExecTaintConfig implements DataFlow::StateConfigSig {
   class FlowState = TState;
 
   predicate isSource(DataFlow::Node source, FlowState state) {
@@ -120,7 +120,7 @@ module ExecTaintConfiguration implements DataFlow::StateConfigSig {
   }
 
   predicate isSink(DataFlow::Node sink, FlowState state) {
-    ExecStateConfiguration::isSink(sink) and
+    ExecStateConfig::isSink(sink) and
     state.(ExecState).isFeasibleForSink(sink)
   }
 
@@ -141,7 +141,7 @@ module ExecTaintConfiguration implements DataFlow::StateConfigSig {
   }
 }
 
-module ExecTaint = TaintTracking::MakeWithState<ExecTaintConfiguration>;
+module ExecTaint = TaintTracking::MakeWithState<ExecTaintConfig>;
 
 from
   ExecTaint::PathNode sourceNode, ExecTaint::PathNode sinkNode, string taintCause, string callChain,

--- a/cpp/ql/src/Security/CWE/CWE-190/ArithmeticUncontrolled.ql
+++ b/cpp/ql/src/Security/CWE/CWE-190/ArithmeticUncontrolled.ql
@@ -90,7 +90,7 @@ predicate missingGuard(VariableAccess va, string effect) {
   )
 }
 
-module UncontrolledArithConfiguration implements DataFlow::ConfigSig {
+module UncontrolledArithConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) {
     exists(RandomFunction rand, Call call | call.getTarget() = rand |
       rand.getFunctionOutput().isReturnValue() and
@@ -122,7 +122,7 @@ module UncontrolledArithConfiguration implements DataFlow::ConfigSig {
   }
 }
 
-module UncontrolledArith = TaintTracking::Make<UncontrolledArithConfiguration>;
+module UncontrolledArith = TaintTracking::Make<UncontrolledArithConfig>;
 
 /** Gets the expression that corresponds to `node`, if any. */
 Expr getExpr(DataFlow::Node node) { result = [node.asExpr(), node.asDefiningArgument()] }

--- a/cpp/ql/src/Security/CWE/CWE-190/TaintedAllocationSize.ql
+++ b/cpp/ql/src/Security/CWE/CWE-190/TaintedAllocationSize.ql
@@ -54,7 +54,7 @@ predicate nodeIsBarrierEqualityCandidate(DataFlow::Node node, Operand access, Va
 
 predicate isFlowSource(FlowSource source, string sourceType) { sourceType = source.getSourceType() }
 
-module TaintedAllocationSizeConfiguration implements DataFlow::ConfigSig {
+module TaintedAllocationSizeConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) { isFlowSource(source, _) }
 
   predicate isSink(DataFlow::Node sink) { allocSink(_, sink) }
@@ -95,7 +95,7 @@ module TaintedAllocationSizeConfiguration implements DataFlow::ConfigSig {
   }
 }
 
-module TaintedAllocationSize = TaintTracking::Make<TaintedAllocationSizeConfiguration>;
+module TaintedAllocationSize = TaintTracking::Make<TaintedAllocationSizeConfig>;
 
 from
   Expr alloc, TaintedAllocationSize::PathNode source, TaintedAllocationSize::PathNode sink,

--- a/cpp/ql/src/Security/CWE/CWE-311/CleartextBufferWrite.ql
+++ b/cpp/ql/src/Security/CWE/CWE-311/CleartextBufferWrite.ql
@@ -39,7 +39,7 @@ class SensitiveBufferWrite extends Expr instanceof BufferWrite::BufferWrite {
  * A taint flow configuration for flow from user input to a buffer write
  * into a sensitive expression.
  */
-module ToBufferConfiguration implements DataFlow::ConfigSig {
+module ToBufferConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) { source instanceof FlowSource }
 
   predicate isBarrier(DataFlow::Node node) {
@@ -49,7 +49,7 @@ module ToBufferConfiguration implements DataFlow::ConfigSig {
   predicate isSink(DataFlow::Node sink) { isSinkImpl(sink, _) }
 }
 
-module ToBufferFlow = TaintTracking::Make<ToBufferConfiguration>;
+module ToBufferFlow = TaintTracking::Make<ToBufferConfig>;
 
 predicate isSinkImpl(DataFlow::Node sink, SensitiveBufferWrite w) {
   w.getASource() = sink.asIndirectExpr()

--- a/cpp/ql/src/Security/CWE/CWE-311/CleartextFileWrite.ql
+++ b/cpp/ql/src/Security/CWE/CWE-311/CleartextFileWrite.ql
@@ -23,7 +23,7 @@ import FromSensitiveFlow::PathGraph
 /**
  * A taint flow configuration for flow from a sensitive expression to a `FileWrite` sink.
  */
-module FromSensitiveConfiguration implements DataFlow::ConfigSig {
+module FromSensitiveConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) { isSourceImpl(source, _) }
 
   predicate isSink(DataFlow::Node sink) { isSinkImpl(sink, _, _) }
@@ -33,7 +33,7 @@ module FromSensitiveConfiguration implements DataFlow::ConfigSig {
   }
 }
 
-module FromSensitiveFlow = TaintTracking::Make<FromSensitiveConfiguration>;
+module FromSensitiveFlow = TaintTracking::Make<FromSensitiveConfig>;
 
 predicate isSinkImpl(DataFlow::Node sink, FileWrite w, Expr dest) {
   exists(Expr e |

--- a/cpp/ql/src/Security/CWE/CWE-311/CleartextTransmission.ql
+++ b/cpp/ql/src/Security/CWE/CWE-311/CleartextTransmission.ql
@@ -234,7 +234,7 @@ predicate isSourceImpl(DataFlow::Node source) {
  * A taint flow configuration for flow from a sensitive expression to a network
  * operation.
  */
-module FromSensitiveConfiguration implements DataFlow::ConfigSig {
+module FromSensitiveConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) { isSourceImpl(source) }
 
   predicate isSink(DataFlow::Node sink) { isSinkSendRecv(sink, _) }
@@ -250,12 +250,12 @@ module FromSensitiveConfiguration implements DataFlow::ConfigSig {
   }
 }
 
-module FromSensitiveFlow = TaintTracking::Make<FromSensitiveConfiguration>;
+module FromSensitiveFlow = TaintTracking::Make<FromSensitiveConfig>;
 
 /**
  * A taint flow configuration for flow from a sensitive expression to an encryption operation.
  */
-module ToEncryptionConfiguration implements DataFlow::ConfigSig {
+module ToEncryptionConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) { FromSensitiveFlow::hasFlow(source, _) }
 
   predicate isSink(DataFlow::Node sink) { isSinkEncrypt(sink, _) }
@@ -271,12 +271,12 @@ module ToEncryptionConfiguration implements DataFlow::ConfigSig {
   }
 }
 
-module ToEncryptionFlow = TaintTracking::Make<ToEncryptionConfiguration>;
+module ToEncryptionFlow = TaintTracking::Make<ToEncryptionConfig>;
 
 /**
  * A taint flow configuration for flow from an encryption operation to a network operation.
  */
-module FromEncryptionConfiguration implements DataFlow::ConfigSig {
+module FromEncryptionConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) { isSinkEncrypt(source, _) }
 
   predicate isSink(DataFlow::Node sink) { FromSensitiveFlow::hasFlowTo(sink) }
@@ -286,7 +286,7 @@ module FromEncryptionConfiguration implements DataFlow::ConfigSig {
   }
 }
 
-module FromEncryptionFlow = TaintTracking::Make<FromEncryptionConfiguration>;
+module FromEncryptionFlow = TaintTracking::Make<FromEncryptionConfig>;
 
 from
   FromSensitiveFlow::PathNode source, FromSensitiveFlow::PathNode sink,

--- a/cpp/ql/src/Security/CWE/CWE-313/CleartextSqliteDatabase.ql
+++ b/cpp/ql/src/Security/CWE/CWE-313/CleartextSqliteDatabase.ql
@@ -100,7 +100,7 @@ predicate isSinkImpl(DataFlow::Node sink, SqliteFunctionCall c, Type t) {
 /**
  * A taint flow configuration for flow from a sensitive expression to a `SqliteFunctionCall` sink.
  */
-module FromSensitiveConfiguration implements DataFlow::ConfigSig {
+module FromSensitiveConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) {
     isSourceImpl(source, _) and not sqlite_encryption_used()
   }
@@ -125,7 +125,7 @@ module FromSensitiveConfiguration implements DataFlow::ConfigSig {
   }
 }
 
-module FromSensitiveFlow = TaintTracking::Make<FromSensitiveConfiguration>;
+module FromSensitiveFlow = TaintTracking::Make<FromSensitiveConfig>;
 
 from
   SensitiveExpr sensitive, FromSensitiveFlow::PathNode source, FromSensitiveFlow::PathNode sink,

--- a/cpp/ql/src/Security/CWE/CWE-326/InsufficientKeySize.ql
+++ b/cpp/ql/src/Security/CWE/CWE-326/InsufficientKeySize.ql
@@ -28,7 +28,7 @@ int getMinimumKeyStrength(string func, int paramIndex) {
   result = 2048
 }
 
-module KeyStrengthFlowConfiguration implements DataFlow::ConfigSig {
+module KeyStrengthFlowConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node node) {
     exists(int bits |
       node.asInstruction().(IntegerConstantInstruction).getValue().toInt() = bits and
@@ -46,7 +46,7 @@ module KeyStrengthFlowConfiguration implements DataFlow::ConfigSig {
   }
 }
 
-module KeyStrengthFlow = DataFlow::Make<KeyStrengthFlowConfiguration>;
+module KeyStrengthFlow = DataFlow::Make<KeyStrengthFlowConfig>;
 
 from
   KeyStrengthFlow::PathNode source, KeyStrengthFlow::PathNode sink, FunctionCall fc, int param,

--- a/cpp/ql/src/Security/CWE/CWE-428/UnsafeCreateProcessCall.ql
+++ b/cpp/ql/src/Security/CWE/CWE-428/UnsafeCreateProcessCall.ql
@@ -54,7 +54,7 @@ class CreateProcessFunctionCall extends FunctionCall {
 /**
  * Dataflow that detects a call to CreateProcess with a NULL value for lpApplicationName argument
  */
-module NullAppNameCreateProcessFunctionConfiguration implements DataFlow::ConfigSig {
+module NullAppNameCreateProcessFunctionConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) { source.asExpr() instanceof NullValue }
 
   predicate isSink(DataFlow::Node sink) {
@@ -64,13 +64,12 @@ module NullAppNameCreateProcessFunctionConfiguration implements DataFlow::Config
   }
 }
 
-module NullAppNameCreateProcessFunction =
-  DataFlow::Make<NullAppNameCreateProcessFunctionConfiguration>;
+module NullAppNameCreateProcessFunction = DataFlow::Make<NullAppNameCreateProcessFunctionConfig>;
 
 /**
  * Dataflow that detects a call to CreateProcess with an unquoted commandLine argument
  */
-module QuotedCommandInCreateProcessFunctionConfiguration implements DataFlow::ConfigSig {
+module QuotedCommandInCreateProcessFunctionConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) {
     exists(string s |
       s = source.asExpr().getValue().toString() and
@@ -86,7 +85,7 @@ module QuotedCommandInCreateProcessFunctionConfiguration implements DataFlow::Co
 }
 
 module QuotedCommandInCreateProcessFunction =
-  DataFlow::Make<QuotedCommandInCreateProcessFunctionConfiguration>;
+  DataFlow::Make<QuotedCommandInCreateProcessFunctionConfig>;
 
 bindingset[s]
 predicate isQuotedOrNoSpaceApplicationNameOnCmd(string s) {

--- a/cpp/ql/src/Security/CWE/CWE-497/ExposedSystemData.ql
+++ b/cpp/ql/src/Security/CWE/CWE-497/ExposedSystemData.ql
@@ -18,7 +18,7 @@ import semmle.code.cpp.models.interfaces.FlowSource
 import ExposedSystemData::PathGraph
 import SystemData
 
-module ExposedSystemDataConfiguration implements DataFlow::ConfigSig {
+module ExposedSystemDataConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) { source = any(SystemData sd).getAnExpr() }
 
   predicate isSink(DataFlow::Node sink) {
@@ -30,7 +30,7 @@ module ExposedSystemDataConfiguration implements DataFlow::ConfigSig {
   }
 }
 
-module ExposedSystemData = TaintTracking::Make<ExposedSystemDataConfiguration>;
+module ExposedSystemData = TaintTracking::Make<ExposedSystemDataConfig>;
 
 from ExposedSystemData::PathNode source, ExposedSystemData::PathNode sink
 where

--- a/cpp/ql/src/Security/CWE/CWE-497/PotentiallyExposedSystemData.ql
+++ b/cpp/ql/src/Security/CWE/CWE-497/PotentiallyExposedSystemData.ql
@@ -31,7 +31,7 @@ import semmle.code.cpp.security.OutputWrite
 import PotentiallyExposedSystemData::PathGraph
 import SystemData
 
-module PotentiallyExposedSystemDataConfiguration implements DataFlow::ConfigSig {
+module PotentiallyExposedSystemDataConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) {
     source = any(SystemData sd | sd.isSensitive()).getAnExpr()
   }
@@ -51,8 +51,7 @@ module PotentiallyExposedSystemDataConfiguration implements DataFlow::ConfigSig 
   }
 }
 
-module PotentiallyExposedSystemData =
-  TaintTracking::Make<PotentiallyExposedSystemDataConfiguration>;
+module PotentiallyExposedSystemData = TaintTracking::Make<PotentiallyExposedSystemDataConfig>;
 
 from PotentiallyExposedSystemData::PathNode source, PotentiallyExposedSystemData::PathNode sink
 where PotentiallyExposedSystemData::hasFlowPath(source, sink)

--- a/cpp/ql/src/Security/CWE/CWE-611/XXE.ql
+++ b/cpp/ql/src/Security/CWE/CWE-611/XXE.ql
@@ -19,7 +19,7 @@ import XxeFlow::PathGraph
 /**
  * A configuration for tracking XML objects and their states.
  */
-module XxeConfiguration implements DataFlow::StateConfigSig {
+module XxeConfig implements DataFlow::StateConfigSig {
   class FlowState = TXxeFlowState;
 
   predicate isSource(DataFlow::Node node, FlowState flowstate) {
@@ -45,7 +45,7 @@ module XxeConfiguration implements DataFlow::StateConfigSig {
   }
 }
 
-module XxeFlow = DataFlow::MakeWithState<XxeConfiguration>;
+module XxeFlow = DataFlow::MakeWithState<XxeConfig>;
 
 from XxeFlow::PathNode source, XxeFlow::PathNode sink
 where XxeFlow::hasFlowPath(source, sink)

--- a/cpp/ql/src/experimental/Security/CWE/CWE-078/WordexpTainted.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-078/WordexpTainted.ql
@@ -35,7 +35,7 @@ private predicate isCommandSubstitutionDisabled(FunctionCall fc) {
 /**
  * A configuration to track user-supplied data to the `wordexp` function.
  */
-module WordexpTaintConfiguration implements DataFlow::ConfigSig {
+module WordexpTaintConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) { source instanceof FlowSource }
 
   predicate isSink(DataFlow::Node sink) {
@@ -50,7 +50,7 @@ module WordexpTaintConfiguration implements DataFlow::ConfigSig {
   }
 }
 
-module WordexpTaint = TaintTracking::Make<WordexpTaintConfiguration>;
+module WordexpTaint = TaintTracking::Make<WordexpTaintConfig>;
 
 from WordexpTaint::PathNode sourceNode, WordexpTaint::PathNode sinkNode
 where WordexpTaint::hasFlowPath(sourceNode, sinkNode)

--- a/java/ql/lib/semmle/code/java/frameworks/android/OnActivityResultSource.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/android/OnActivityResultSource.qll
@@ -63,7 +63,7 @@ class OnActivityResultIncomingIntent extends DataFlow::Node {
 /**
  * A data flow configuration for implicit intents being used in `startActivityForResult`.
  */
-private module ImplicitStartActivityForResultConf implements DataFlow::ConfigSig {
+private module ImplicitStartActivityForResultConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) {
     exists(ClassInstanceExpr cc |
       cc.getConstructedType() instanceof TypeIntent and source.asExpr() = cc
@@ -103,7 +103,8 @@ private module ImplicitStartActivityForResultConf implements DataFlow::ConfigSig
   }
 }
 
-private module ImplicitStartActivityForResult = DataFlow::Make<ImplicitStartActivityForResultConf>;
+private module ImplicitStartActivityForResult =
+  DataFlow::Make<ImplicitStartActivityForResultConfig>;
 
 /** An Android Activity or Fragment. */
 private class ActivityOrFragment extends Class {

--- a/java/ql/lib/semmle/code/java/frameworks/google/GoogleHttpClientApi.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/google/GoogleHttpClientApi.qll
@@ -10,7 +10,7 @@ private class ParseAsMethod extends Method {
   }
 }
 
-private module TypeLiteralToParseAsFlowConfiguration implements DataFlow::ConfigSig {
+private module TypeLiteralToParseAsFlowConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) { source.asExpr() instanceof TypeLiteral }
 
   predicate isSink(DataFlow::Node sink) {
@@ -21,7 +21,7 @@ private module TypeLiteralToParseAsFlowConfiguration implements DataFlow::Config
   }
 }
 
-private module TypeLiteralToParseAsFlow = DataFlow::Make<TypeLiteralToParseAsFlowConfiguration>;
+private module TypeLiteralToParseAsFlow = DataFlow::Make<TypeLiteralToParseAsFlowConfig>;
 
 private TypeLiteral getSourceWithFlowToParseAs() {
   TypeLiteralToParseAsFlow::hasFlow(DataFlow::exprNode(result), _)

--- a/java/ql/lib/semmle/code/java/frameworks/jackson/JacksonSerializability.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/jackson/JacksonSerializability.qll
@@ -90,7 +90,7 @@ private class FieldReferencedJacksonSerializableType extends JacksonSerializable
 /** A type whose values may be deserialized by the Jackson JSON framework. */
 abstract class JacksonDeserializableType extends Type { }
 
-private module TypeLiteralToJacksonDatabindFlowConfiguration implements DataFlow::ConfigSig {
+private module TypeLiteralToJacksonDatabindFlowConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) { source.asExpr() instanceof TypeLiteral }
 
   predicate isSink(DataFlow::Node sink) {
@@ -108,7 +108,7 @@ private module TypeLiteralToJacksonDatabindFlowConfiguration implements DataFlow
 }
 
 private module TypeLiteralToJacksonDatabindFlow =
-  DataFlow::Make<TypeLiteralToJacksonDatabindFlowConfiguration>;
+  DataFlow::Make<TypeLiteralToJacksonDatabindFlowConfig>;
 
 private TypeLiteral getSourceWithFlowToJacksonDatabind() {
   TypeLiteralToJacksonDatabindFlow::hasFlow(DataFlow::exprNode(result), _)

--- a/java/ql/lib/semmle/code/java/security/ArbitraryApkInstallationQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/ArbitraryApkInstallationQuery.qll
@@ -9,7 +9,7 @@ private import semmle.code.java.security.ArbitraryApkInstallation
  * A dataflow configuration for flow from an external source of an APK to the
  * `setData[AndType][AndNormalize]` method of an intent.
  */
-private module ApkInstallationConfiguration implements DataFlow::ConfigSig {
+private module ApkInstallationConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node node) { node instanceof ExternalApkSource }
 
   predicate isSink(DataFlow::Node node) {
@@ -25,7 +25,7 @@ private module ApkInstallationConfiguration implements DataFlow::ConfigSig {
   }
 }
 
-module ApkInstallationFlow = DataFlow::Make<ApkInstallationConfiguration>;
+module ApkInstallationFlow = DataFlow::Make<ApkInstallationConfig>;
 
 private newtype ActionState =
   ActionUnset() or
@@ -37,7 +37,7 @@ private newtype ActionState =
  *
  * This is used to track if an intent is used to install an APK.
  */
-private module InstallPackageActionConfiguration implements DataFlow::StateConfigSig {
+private module InstallPackageActionConfig implements DataFlow::StateConfigSig {
   class FlowState = ActionState;
 
   predicate isSource(DataFlow::Node source, FlowState state) {
@@ -72,8 +72,7 @@ private module InstallPackageActionConfiguration implements DataFlow::StateConfi
   predicate isBarrier(DataFlow::Node node, FlowState state) { none() }
 }
 
-private module InstallPackageActionFlow =
-  TaintTracking::MakeWithState<InstallPackageActionConfiguration>;
+private module InstallPackageActionFlow = TaintTracking::MakeWithState<InstallPackageActionConfig>;
 
 private newtype MimeTypeState =
   MimeTypeUnset() or
@@ -84,7 +83,7 @@ private newtype MimeTypeState =
  * the `setType` or `setTypeAndNormalize` method of an intent, followed by a call
  * to `setData[AndType][AndNormalize]`.
  */
-private module PackageArchiveMimeTypeConfiguration implements DataFlow::StateConfigSig {
+private module PackageArchiveMimeTypeConfig implements DataFlow::StateConfigSig {
   class FlowState = MimeTypeState;
 
   predicate isSource(DataFlow::Node node, FlowState state) {
@@ -118,4 +117,4 @@ private module PackageArchiveMimeTypeConfiguration implements DataFlow::StateCon
 }
 
 private module PackageArchiveMimeTypeFlow =
-  TaintTracking::MakeWithState<PackageArchiveMimeTypeConfiguration>;
+  TaintTracking::MakeWithState<PackageArchiveMimeTypeConfig>;

--- a/java/ql/lib/semmle/code/java/security/FragmentInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/FragmentInjectionQuery.qll
@@ -23,7 +23,7 @@ deprecated class FragmentInjectionTaintConf extends TaintTracking::Configuration
   }
 }
 
-private module FragmentInjectionTaintConf implements DataFlow::ConfigSig {
+private module FragmentInjectionTaintConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof FragmentInjectionSink }
@@ -37,4 +37,4 @@ private module FragmentInjectionTaintConf implements DataFlow::ConfigSig {
  * Taint-tracking flow for unsafe user input
  * that is used to create Android fragments dynamically.
  */
-module FragmentInjectionTaintFlow = TaintTracking::Make<FragmentInjectionTaintConf>;
+module FragmentInjectionTaintFlow = TaintTracking::Make<FragmentInjectionTaintConfig>;

--- a/java/ql/lib/semmle/code/java/security/IntentUriPermissionManipulationQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/IntentUriPermissionManipulationQuery.qll
@@ -35,7 +35,7 @@ deprecated class IntentUriPermissionManipulationConf extends TaintTracking::Conf
   }
 }
 
-private module IntentUriPermissionManipulationConf implements DataFlow::ConfigSig {
+private module IntentUriPermissionManipulationConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof IntentUriPermissionManipulationSink }
@@ -53,4 +53,4 @@ private module IntentUriPermissionManipulationConf implements DataFlow::ConfigSi
  * Taint tracking flow for user-provided Intents being returned to third party apps.
  */
 module IntentUriPermissionManipulationFlow =
-  TaintTracking::Make<IntentUriPermissionManipulationConf>;
+  TaintTracking::Make<IntentUriPermissionManipulationConfig>;

--- a/java/ql/lib/semmle/code/java/security/LogInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/LogInjectionQuery.qll
@@ -23,7 +23,7 @@ deprecated class LogInjectionConfiguration extends TaintTracking::Configuration 
   }
 }
 
-private module LogInjectionConfiguration implements DataFlow::ConfigSig {
+private module LogInjectionConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof LogInjectionSink }
@@ -38,4 +38,4 @@ private module LogInjectionConfiguration implements DataFlow::ConfigSig {
 /**
  * Taint-tracking flow for tracking untrusted user input used in log entries.
  */
-module LogInjectionFlow = TaintTracking::Make<LogInjectionConfiguration>;
+module LogInjectionFlow = TaintTracking::Make<LogInjectionConfig>;

--- a/java/ql/lib/semmle/code/java/security/RequestForgeryConfig.qll
+++ b/java/ql/lib/semmle/code/java/security/RequestForgeryConfig.qll
@@ -35,7 +35,7 @@ deprecated class RequestForgeryConfiguration extends TaintTracking::Configuratio
 /**
  * A taint-tracking configuration characterising request-forgery risks.
  */
-private module RequestForgeryConfiguration implements DataFlow::ConfigSig {
+private module RequestForgeryConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) {
     source instanceof RemoteFlowSource and
     // Exclude results of remote HTTP requests: fetching something else based on that result
@@ -53,4 +53,4 @@ private module RequestForgeryConfiguration implements DataFlow::ConfigSig {
   predicate isBarrier(DataFlow::Node node) { node instanceof RequestForgerySanitizer }
 }
 
-module RequestForgeryFlow = TaintTracking::Make<RequestForgeryConfiguration>;
+module RequestForgeryFlow = TaintTracking::Make<RequestForgeryConfig>;

--- a/java/ql/lib/semmle/code/java/security/SensitiveLoggingQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/SensitiveLoggingQuery.qll
@@ -49,7 +49,7 @@ deprecated class SensitiveLoggerConfiguration extends TaintTracking::Configurati
 }
 
 /** A data-flow configuration for identifying potentially-sensitive data flowing to a log output. */
-private module SensitiveLoggerConfiguration implements DataFlow::ConfigSig {
+private module SensitiveLoggerConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) { source.asExpr() instanceof CredentialExpr }
 
   predicate isSink(DataFlow::Node sink) { sinkNode(sink, "logging") }
@@ -65,4 +65,4 @@ private module SensitiveLoggerConfiguration implements DataFlow::ConfigSig {
   predicate isBarrierIn(Node node) { isSource(node) }
 }
 
-module SensitiveLoggerFlow = TaintTracking::Make<SensitiveLoggerConfiguration>;
+module SensitiveLoggerFlow = TaintTracking::Make<SensitiveLoggerConfig>;

--- a/java/ql/lib/semmle/code/java/security/UnsafeContentUriResolutionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/UnsafeContentUriResolutionQuery.qll
@@ -26,7 +26,7 @@ deprecated class UnsafeContentResolutionConf extends TaintTracking::Configuratio
   }
 }
 
-private module UnsafeContentResolutionConf implements DataFlow::ConfigSig {
+private module UnsafeContentResolutionConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node src) { src instanceof RemoteFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof ContentUriResolutionSink }
@@ -41,4 +41,4 @@ private module UnsafeContentResolutionConf implements DataFlow::ConfigSig {
 }
 
 /** Taint-tracking flow to find paths from remote sources to content URI resolutions. */
-module UnsafeContentResolutionFlow = TaintTracking::Make<UnsafeContentResolutionConf>;
+module UnsafeContentResolutionFlow = TaintTracking::Make<UnsafeContentResolutionConfig>;

--- a/java/ql/src/Security/CWE/CWE-327/BrokenCryptoAlgorithm.ql
+++ b/java/ql/src/Security/CWE/CWE-327/BrokenCryptoAlgorithm.ql
@@ -28,7 +28,7 @@ class BrokenAlgoLiteral extends ShortStringLiteral {
   }
 }
 
-module InsecureCryptoConfiguration implements ConfigSig {
+module InsecureCryptoConfig implements ConfigSig {
   predicate isSource(Node n) { n.asExpr() instanceof BrokenAlgoLiteral }
 
   predicate isSink(Node n) { exists(CryptoAlgoSpec c | n.asExpr() = c.getAlgoSpec()) }
@@ -38,7 +38,7 @@ module InsecureCryptoConfiguration implements ConfigSig {
   }
 }
 
-module InsecureCryptoFlow = TaintTracking::Make<InsecureCryptoConfiguration>;
+module InsecureCryptoFlow = TaintTracking::Make<InsecureCryptoConfig>;
 
 import InsecureCryptoFlow::PathGraph
 

--- a/java/ql/src/Security/CWE/CWE-327/MaybeBrokenCryptoAlgorithm.ql
+++ b/java/ql/src/Security/CWE/CWE-327/MaybeBrokenCryptoAlgorithm.ql
@@ -50,7 +50,7 @@ class StringContainer extends RefType {
   }
 }
 
-module InsecureCryptoConfiguration implements ConfigSig {
+module InsecureCryptoConfig implements ConfigSig {
   predicate isSource(Node n) { n.asExpr() instanceof InsecureAlgoLiteral }
 
   predicate isSink(Node n) { exists(CryptoAlgoSpec c | n.asExpr() = c.getAlgoSpec()) }
@@ -61,7 +61,7 @@ module InsecureCryptoConfiguration implements ConfigSig {
   }
 }
 
-module InsecureCryptoFlow = TaintTracking::Make<InsecureCryptoConfiguration>;
+module InsecureCryptoFlow = TaintTracking::Make<InsecureCryptoConfig>;
 
 import InsecureCryptoFlow::PathGraph
 

--- a/java/ql/test/TestUtilities/InlineFlowTest.qll
+++ b/java/ql/test/TestUtilities/InlineFlowTest.qll
@@ -47,7 +47,7 @@ private predicate defaultSource(DataFlow::Node src) {
   src.asExpr().(MethodAccess).getMethod().getName() = ["source", "taint"]
 }
 
-module DefaultFlowConf implements DataFlow::ConfigSig {
+module DefaultFlowConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node n) { defaultSource(n) }
 
   predicate isSink(DataFlow::Node n) {
@@ -57,9 +57,9 @@ module DefaultFlowConf implements DataFlow::ConfigSig {
   int fieldFlowBranchLimit() { result = 1000 }
 }
 
-private module DefaultValueFlow = DataFlow::Make<DefaultFlowConf>;
+private module DefaultValueFlow = DataFlow::Make<DefaultFlowConfig>;
 
-private module DefaultTaintFlow = TaintTracking::Make<DefaultFlowConf>;
+private module DefaultTaintFlow = TaintTracking::Make<DefaultFlowConfig>;
 
 class DefaultValueFlowConf extends DataFlow::Configuration {
   DefaultValueFlowConf() { this = "qltest:defaultValueFlowConf" }

--- a/java/ql/test/library-tests/dataflow/state/test.ql
+++ b/java/ql/test/library-tests/dataflow/state/test.ql
@@ -39,7 +39,7 @@ predicate step(Node n1, Node n2, string s1, string s2) {
 
 predicate checkNode(Node n) { n.asExpr().(Argument).getCall().getCallee().hasName("check") }
 
-module Conf implements DataFlow::StateConfigSig {
+module Config implements DataFlow::StateConfigSig {
   class FlowState = string;
 
   predicate isSource(Node n, FlowState s) { src(n, s) }
@@ -55,7 +55,7 @@ module Conf implements DataFlow::StateConfigSig {
 
 int explorationLimit() { result = 0 }
 
-module Flow = TaintTracking::MakeWithState<Conf>;
+module Flow = TaintTracking::MakeWithState<Config>;
 
 module PartialFlow = Flow::FlowExploration<explorationLimit/0>;
 


### PR DESCRIPTION
Renames dataflow configurations that use the new dataflow module api from #12186 to follow the naming convention of ending in `Config`.

This is to provide a common naming convention across languages as we refactor our dataflow configurations to the new api.

See also: #12575