### PR TITLE
Swift: Remove special case for bitwise operations

### DIFF
--- a/swift/ql/lib/codeql/swift/security/XXEExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/XXEExtensions.qll
@@ -2,6 +2,7 @@
 
 import swift
 private import codeql.swift.dataflow.DataFlow
+private import codeql.swift.dataflow.TaintTracking
 private import codeql.swift.frameworks.AEXML
 private import codeql.swift.frameworks.Libxml2
 private import codeql.swift.dataflow.ExternalFlow
@@ -182,9 +183,7 @@ private class Libxml2XxeSink extends XxeSink {
  * including bitwise operations, accesses to `.rawValue`, and casts to `Int32`.
  */
 private predicate lib2xmlOptionLocalTaintStep(DataFlow::Node source, DataFlow::Node sink) {
-  DataFlow::localFlowStep(source, sink)
-  or
-  source.asExpr() = sink.asExpr().(BitwiseOperation).getAnOperand()
+  TaintTracking::localTaintStep(source, sink)
   or
   exists(MemberRefExpr rawValue | rawValue.getMember().(VarDecl).getName() = "rawValue" |
     source.asExpr() = rawValue.getBase() and sink.asExpr() = rawValue

--- a/swift/ql/test/query-tests/Security/CWE-611/testLibxmlXXE.swift
+++ b/swift/ql/test/query-tests/Security/CWE-611/testLibxmlXXE.swift
@@ -20,8 +20,8 @@ struct xmlParserOption : Hashable {
     let rawValue: UInt32 = 0
 }
 
-var XML_PARSE_NOENT: xmlParserOption { get { return xmlParserOption() } } 
-var XML_PARSE_DTDLOAD: xmlParserOption { get { return xmlParserOption() } } 
+var XML_PARSE_NOENT: xmlParserOption { get { return xmlParserOption() } }
+var XML_PARSE_DTDLOAD: xmlParserOption { get { return xmlParserOption() } }
 
 typealias xmlChar = UInt8
 typealias xmlDocPtr = UnsafeMutablePointer<xmlDoc>
@@ -58,6 +58,8 @@ func test() {
     let _ = xmlReadFile(remoteCharPtr, nil, 0) // NO XXE: external entities not enabled
     let _ = xmlReadFile(remoteCharPtr, nil, Int32(XML_PARSE_NOENT.rawValue)) // $ hasXXE=57
     let _ = xmlReadFile(remoteCharPtr, nil, Int32(XML_PARSE_DTDLOAD.rawValue)) // $ hasXXE=57
+    let _ = xmlReadFile(remoteCharPtr, nil, Int32(XML_PARSE_NOENT.rawValue | XML_PARSE_DTDLOAD.rawValue)) // $ hasXXE=57
+    let _ = xmlReadFile(remoteCharPtr, nil, Int32(XML_PARSE_NOENT.rawValue | 0)) // $ hasXXE=57
     let _ = xmlReadDoc(remotePtr, nil, nil, 0) // NO XXE: external entities not enabled
     let _ = xmlReadDoc(remotePtr, nil, nil, Int32(XML_PARSE_NOENT.rawValue)) // $ hasXXE=56
     let _ = xmlReadDoc(remotePtr, nil, nil, Int32(XML_PARSE_DTDLOAD.rawValue)) // $ hasXXE=56


### PR DESCRIPTION
Following https://github.com/github/codeql/pull/12368 we no longer need a special case for bitwise operations in `swift/xxe` ... though the part in question did need to be upgraded from dataflow to taint.