### PR TITLE
Java: update Argument[-1] to Argument[this] for a couple AI models

### DIFF
--- a/java/ql/lib/ext/hudson.model.model.yml
+++ b/java/ql/lib/ext/hudson.model.model.yml
@@ -3,7 +3,7 @@ extensions:
       pack: codeql/java-all
       extensible: summaryModel
     data:
-      - ["hudson.model", "DirectoryBrowserSupport$Path", False, "Path", "(String,String,boolean,long,boolean,long)", "", "Argument[0]", "Argument[-1].SyntheticField[hudson.model.DirectoryBrowserSupport$Path.href]", "taint", "ai-generated"]
+      - ["hudson.model", "DirectoryBrowserSupport$Path", False, "Path", "(String,String,boolean,long,boolean,long)", "", "Argument[0]", "Argument[this].SyntheticField[hudson.model.DirectoryBrowserSupport$Path.href]", "taint", "ai-generated"]
   - addsTo:
       pack: codeql/java-all
       extensible: sinkModel

--- a/java/ql/lib/ext/io.netty.handler.codec.http.model.yml
+++ b/java/ql/lib/ext/io.netty.handler.codec.http.model.yml
@@ -9,4 +9,4 @@ extensions:
       pack: codeql/java-all
       extensible: summaryModel
     data:
-      - ["io.netty.handler.codec.http", "QueryStringEncoder", True, "QueryStringEncoder", "(String)", "", "Argument[0]", "Argument[-1]", "taint", "ai-generated"]
+      - ["io.netty.handler.codec.http", "QueryStringEncoder", True, "QueryStringEncoder", "(String)", "", "Argument[0]", "Argument[this]", "taint", "ai-generated"]


### PR DESCRIPTION
This PR updates a couple AI models to use `Argument[this]` instead of `Argument[-1]`.
I believe this were missed in the transition to using `this` in https://github.com/github/codeql/pull/12556.