### PR TITLE
Java/C#: Remove useless disjuncts.

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/rangeanalysis/SignAnalysisCommon.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/rangeanalysis/SignAnalysisCommon.qll
@@ -45,10 +45,6 @@ private Sign certainExprSign(Expr e) {
 private predicate unknownSign(Expr e) {
   not exists(certainExprSign(e)) and
   (
-    exists(IntegerLiteral lit | lit = e and not exists(lit.getValue().toInt()))
-    or
-    exists(LongLiteral lit | lit = e and not exists(lit.getValue().toFloat()))
-    or
     exists(CastingExpr cast, Type fromtyp |
       cast = e and
       fromtyp = cast.getSourceType() and

--- a/java/ql/lib/semmle/code/java/dataflow/internal/rangeanalysis/SignAnalysisCommon.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/rangeanalysis/SignAnalysisCommon.qll
@@ -45,10 +45,6 @@ private Sign certainExprSign(Expr e) {
 private predicate unknownSign(Expr e) {
   not exists(certainExprSign(e)) and
   (
-    exists(IntegerLiteral lit | lit = e and not exists(lit.getValue().toInt()))
-    or
-    exists(LongLiteral lit | lit = e and not exists(lit.getValue().toFloat()))
-    or
     exists(CastingExpr cast, Type fromtyp |
       cast = e and
       fromtyp = cast.getSourceType() and


### PR DESCRIPTION
The value of a long ought to always be convertible to a float, so that case does nothing (it's been around for a long time and git forensics indicate a possible cause, but it's not entirely clear).
The int case is also useless even though it isn't empty in the C# case, but in those cases (large unsigned ints) it is covered by `getNonIntegerValue` and hence still irrelevant.