### PR TITLE
Swift: Fix for TypeDecl.getFullName with extensions

### DIFF
--- a/swift/ql/lib/codeql/swift/elements/decl/TypeDecl.qll
+++ b/swift/ql/lib/codeql/swift/elements/decl/TypeDecl.qll
@@ -28,8 +28,11 @@ class TypeDecl extends Generated::TypeDecl {
   cached
   string getFullName() {
     not this.getEnclosingDecl() instanceof TypeDecl and
+    not this.getEnclosingDecl() instanceof ExtensionDecl and
     result = this.getName()
     or
     result = this.getEnclosingDecl().(TypeDecl).getFullName() + "." + this.getName()
+    or
+    result = this.getEnclosingDecl().(ExtensionDecl).getExtendedTypeDecl().getFullName() + "." + this.getName()
   }
 }

--- a/swift/ql/test/library-tests/elements/decl/abstractfunctiondecl/abstractfunctiondecl.expected
+++ b/swift/ql/test/library-tests/elements/decl/abstractfunctiondecl/abstractfunctiondecl.expected
@@ -1,8 +1,9 @@
 | abstractfunctiondecl.swift:2:1:2:15 | func1() | getName:func1(), hasName:func1() |
-| abstractfunctiondecl.swift:5:2:5:16 | func2() | MethodDecl, getName:func2(), hasName:func2(), hasQualifiedName(2):Class1.func2(), hasQualifiedName(3):abstractfunctiondecl.Class1.func2() |
-| abstractfunctiondecl.swift:8:3:8:17 | func3() | MethodDecl, getName:func3(), hasName:func3(), hasQualifiedName(2):Class1.Class2.func3(), hasQualifiedName(3):abstractfunctiondecl.Class1.Class2.func3() |
-| abstractfunctiondecl.swift:13:2:13:13 | func4() | MethodDecl, getName:func4(), hasName:func4(), hasQualifiedName(2):Protocol1.func4(), hasQualifiedName(3):abstractfunctiondecl.Protocol1.func4() |
-| abstractfunctiondecl.swift:17:2:17:16 | func4() | MethodDecl, getName:func4(), hasName:func4(), hasQualifiedName(2):Class3.func4(), hasQualifiedName(3):abstractfunctiondecl.Class3.func4() |
-| abstractfunctiondecl.swift:21:2:21:16 | func5() | MethodDecl, getName:func5(), hasName:func5(), hasQualifiedName(2):Class3.func5(), hasQualifiedName(3):abstractfunctiondecl.Class3.func5() |
-| abstractfunctiondecl.swift:25:2:25:16 | func6() | MethodDecl, getName:func6(), hasName:func6(), hasQualifiedName(2):Struct1.func6(), hasQualifiedName(3):abstractfunctiondecl.Struct1.func6() |
-| abstractfunctiondecl.swift:31:2:31:16 | func7() | MethodDecl, getName:func7(), hasName:func7(), hasQualifiedName(2):Enum1.func7(), hasQualifiedName(3):abstractfunctiondecl.Enum1.func7() |
+| abstractfunctiondecl.swift:5:2:5:16 | func2() | MethodDecl, getName:func2(), hasName:func2(), hasQualifiedName(2):Class1.func2(), hasQualifiedName(3):abstractfunctiondecl.Class1.func2(), memberOf:Class1 |
+| abstractfunctiondecl.swift:8:3:8:17 | func3() | MethodDecl, getName:func3(), hasName:func3(), hasQualifiedName(2):Class1.Class2.func3(), hasQualifiedName(3):abstractfunctiondecl.Class1.Class2.func3(), memberOf:Class1.Class2 |
+| abstractfunctiondecl.swift:13:2:13:13 | func4() | MethodDecl, getName:func4(), hasName:func4(), hasQualifiedName(2):Protocol1.func4(), hasQualifiedName(3):abstractfunctiondecl.Protocol1.func4(), memberOf:Protocol1 |
+| abstractfunctiondecl.swift:17:2:17:16 | func4() | MethodDecl, getName:func4(), hasName:func4(), hasQualifiedName(2):Class3.func4(), hasQualifiedName(3):abstractfunctiondecl.Class3.func4(), memberOf:Class3 |
+| abstractfunctiondecl.swift:21:2:21:16 | func5() | MethodDecl, getName:func5(), hasName:func5(), hasQualifiedName(2):Class3.func5(), hasQualifiedName(3):abstractfunctiondecl.Class3.func5(), memberOf:Class3 |
+| abstractfunctiondecl.swift:25:2:25:16 | func6() | MethodDecl, getName:func6(), hasName:func6(), hasQualifiedName(2):Struct1.func6(), hasQualifiedName(3):abstractfunctiondecl.Struct1.func6(), memberOf:Struct1 |
+| abstractfunctiondecl.swift:31:2:31:16 | func7() | MethodDecl, getName:func7(), hasName:func7(), hasQualifiedName(2):Enum1.func7(), hasQualifiedName(3):abstractfunctiondecl.Enum1.func7(), memberOf:Enum1 |
+| abstractfunctiondecl.swift:37:3:37:17 | func8() | MethodDecl, getName:func8(), hasName:func8(), hasQualifiedName(2):Class4.func8(), hasQualifiedName(3):abstractfunctiondecl.Class4.func8(), memberOf:Class4 |

--- a/swift/ql/test/library-tests/elements/decl/abstractfunctiondecl/abstractfunctiondecl.expected
+++ b/swift/ql/test/library-tests/elements/decl/abstractfunctiondecl/abstractfunctiondecl.expected
@@ -6,4 +6,4 @@
 | abstractfunctiondecl.swift:21:2:21:16 | func5() | MethodDecl, getName:func5(), hasName:func5(), hasQualifiedName(2):Class3.func5(), hasQualifiedName(3):abstractfunctiondecl.Class3.func5(), memberOf:Class3 |
 | abstractfunctiondecl.swift:25:2:25:16 | func6() | MethodDecl, getName:func6(), hasName:func6(), hasQualifiedName(2):Struct1.func6(), hasQualifiedName(3):abstractfunctiondecl.Struct1.func6(), memberOf:Struct1 |
 | abstractfunctiondecl.swift:31:2:31:16 | func7() | MethodDecl, getName:func7(), hasName:func7(), hasQualifiedName(2):Enum1.func7(), hasQualifiedName(3):abstractfunctiondecl.Enum1.func7(), memberOf:Enum1 |
-| abstractfunctiondecl.swift:37:3:37:17 | func8() | MethodDecl, getName:func8(), hasName:func8(), hasQualifiedName(2):Class4.func8(), hasQualifiedName(3):abstractfunctiondecl.Class4.func8(), memberOf:Class4 |
+| abstractfunctiondecl.swift:37:3:37:17 | func8() | MethodDecl, getName:func8(), hasName:func8(), hasQualifiedName(2):Class1.Class4.func8(), hasQualifiedName(3):abstractfunctiondecl.Class1.Class4.func8(), memberOf:Class1.Class4 |

--- a/swift/ql/test/library-tests/elements/decl/abstractfunctiondecl/abstractfunctiondecl.ql
+++ b/swift/ql/test/library-tests/elements/decl/abstractfunctiondecl/abstractfunctiondecl.ql
@@ -19,6 +19,10 @@ string describe(AbstractFunctionDecl f) {
     f.(MethodDecl).hasQualifiedName(a, b, c) and
     result = "hasQualifiedName(3):" + a + "." + b + "." + c
   )
+  or
+  exists(Decl td | td.getAMember() = f |
+    result = "memberOf:" + td.asNominalTypeDecl().getFullName()
+  )
 }
 
 from AbstractFunctionDecl f

--- a/swift/ql/test/library-tests/elements/decl/abstractfunctiondecl/abstractfunctiondecl.swift
+++ b/swift/ql/test/library-tests/elements/decl/abstractfunctiondecl/abstractfunctiondecl.swift
@@ -30,3 +30,10 @@ enum Enum1 {
 	case case2
 	func func7() {}
 }
+
+extension Class1
+{
+	class Class4 {
+		func func8() {}
+	}
+}


### PR DESCRIPTION
`TypeDecl.getFullName` was naive about extensions.  This meant that types contained within other types via an extension (such as `Class4` in the test) had an incomplete `getFullName`.  This in turn meant they could not be referenced properly in MaD / CSV models.