### PR TITLE
C++: Range analysis on `EquivalenceClass`es

### DIFF
--- a/cpp/ql/lib/experimental/semmle/code/cpp/semantic/SemanticExprSpecific.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/semantic/SemanticExprSpecific.qll
@@ -12,7 +12,95 @@ private import semmle.code.cpp.ir.ValueNumbering
 module SemanticExprConfig {
   class Location = Cpp::Location;
 
-  class Expr = IR::Instruction;
+  /** A `ConvertInstruction` or a `CopyValueInstruction`. */
+  private class Conversion extends IR::UnaryInstruction {
+    Conversion() {
+      this instanceof IR::CopyValueInstruction
+      or
+      this instanceof IR::ConvertInstruction
+    }
+
+    /** Holds if this instruction converts a value of type `tFrom` to a value of type `tTo`. */
+    predicate converts(SemType tFrom, SemType tTo) {
+      exists(IR::ConvertInstruction convert |
+        this = convert and
+        tFrom = getSemanticType(convert.getUnary().getResultIRType()) and
+        tTo = getSemanticType(convert.getResultIRType())
+      )
+      or
+      exists(IR::CopyValueInstruction copy |
+        this = copy and
+        tFrom = getSemanticType(copy.getUnary().getResultIRType()) and
+        tTo = getSemanticType(copy.getResultIRType())
+      )
+    }
+  }
+
+  /**
+   * Gets a conversion-like instruction that consumes `op`, and
+   * which is guaranteed to not overflow.
+   */
+  private IR::Instruction safeConversion(IR::Operand op) {
+    exists(Conversion conv, SemType tFrom, SemType tTo |
+      conv.converts(tFrom, tTo) and
+      conversionCannotOverflow(tFrom, tTo) and
+      conv.getUnaryOperand() = op and
+      result = conv
+    )
+  }
+
+  /** Holds if `i1 = i2` or if `i2` is a safe conversion that consumes `i1`. */
+  private predicate idOrSafeConversion(IR::Instruction i1, IR::Instruction i2) {
+    not i1.getResultIRType() instanceof IR::IRVoidType and
+    (
+      i1 = i2
+      or
+      i2 = safeConversion(i1.getAUse())
+    )
+  }
+
+  module Equiv = QlBuiltins::EquivalenceRelation<IR::Instruction, idOrSafeConversion/2>;
+
+  /**
+   * The expressions on which we perform range analysis.
+   */
+  class Expr extends Equiv::EquivalenceClass {
+    /** Gets the n'th instruction in this equivalence class. */
+    private IR::Instruction getInstruction(int n) {
+      result =
+        rank[n + 1](IR::Instruction instr, int i, IR::IRBlock block |
+          this = Equiv::getEquivalenceClass(instr) and block.getInstruction(i) = instr
+        |
+          instr order by i
+        )
+    }
+
+    /** Gets a textual representation of this element. */
+    string toString() { result = this.getUnconverted().toString() }
+
+    /** Gets the basic block of this expression. */
+    IR::IRBlock getBlock() { result = getInstruction(0).getBlock() }
+
+    /** Gets the unconverted instruction associated with this expression. */
+    IR::Instruction getUnconverted() { result = this.getInstruction(0) }
+
+    /**
+     * Gets the final instruction associated with this expression. This
+     * represents the result after applying all the safe conversions.
+     */
+    IR::Instruction getConverted() {
+      exists(int n |
+        result = this.getInstruction(n) and
+        not exists(this.getInstruction(n + 1))
+      )
+    }
+
+    /** Gets the type of the result produced by this instruction. */
+    IR::IRType getResultIRType() { result = this.getConverted().getResultIRType() }
+
+    /** Gets the location of the source code for this expression. */
+    Location getLocation() { result = this.getUnconverted().getLocation() }
+  }
 
   SemBasicBlock getExprBasicBlock(Expr e) { result = getSemanticBasicBlock(e.getBlock()) }
 

--- a/cpp/ql/test/library-tests/ir/range-analysis/RangeAnalysis.ql
+++ b/cpp/ql/test/library-tests/ir/range-analysis/RangeAnalysis.ql
@@ -12,7 +12,7 @@ class RangeAnalysisTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     exists(SemExpr e, IR::CallInstruction call |
-      call.getArgument(0) = e and
+      getSemanticExpr(call.getArgument(0)) = e and
       call.getStaticCallTarget().hasName("range") and
       tag = "range" and
       element = e.toString() and

--- a/cpp/ql/test/library-tests/ir/range-analysis/SimpleRangeAnalysis_tests.cpp
+++ b/cpp/ql/test/library-tests/ir/range-analysis/SimpleRangeAnalysis_tests.cpp
@@ -18,7 +18,7 @@ int test2(struct List* p) {
   int count = 0;
   for (; p; p = p->next) {
     count = (count+1) % 10;
-    range(count); // $ range=<=9
+    range(count); // $ range=<=9 range=<=count:p+1
   }
   range(count); // $ range=<=9
   return count;
@@ -29,7 +29,7 @@ int test3(struct List* p) {
   for (; p; p = p->next) {
     range(count++); // $ range=<=9
     count = count % 10;
-    range(count); // $ range=<=9
+    range(count); // $ range=<=9 range="<=... +++0" range=<=count:p+1
   }
   range(count); // $ range=<=9
   return count;
@@ -40,13 +40,13 @@ int test4() {
   int total = 0;
   for (i = 0; i < 2; i = i+1) {
     range(i); // $ range=<=1 range=>=0
-    range(total);
+    range(total); // $ range=>=0
     total += i;
-    range(total);
+    range(total); // $ range=>=0 range=>=i+0
   }
-  range(total);
+  range(total); // $ range=>=0
   range(i); // $ range===2
-  range(total + i); // $ range=>=i+1
+  range(total + i); // $ range=>=i+1 range=>=2 range=>=i+0
   return total + i;
 }
 
@@ -55,13 +55,13 @@ int test5() {
   int total = 0;
   for (i = 0; i < 2; i++) {
     range(i); // $ range=<=1 range=>=0
-    range(total);
+    range(total); // $ range=>=0
     total += i;
-    range(total);
+    range(total); // $ range=>=0 range=>=i+0
   }
-  range(total);
+  range(total); // $ range=>=0
   range(i); // $ range===2
-  range(total + i); // $ range=>=i+1
+  range(total + i); // $ range=>=i+1 range=>=2 range=>=i+0
   return total + i;
 }
 
@@ -70,9 +70,9 @@ int test6() {
   int total = 0;
   for (i = 0; i+2 < 4; i = i+1) {
     range(i); // $ range=<=1 range=>=0
-    range(total);
+    range(total); // $ range=>=0
     total += i;
-    range(total);
+    range(total); // $ range=>=0 range=>=i+0
   }
   return total + i;
 }
@@ -149,7 +149,7 @@ int test11(char *p) {
     range(*p);
   }
   if (c == ':') {
-    range(c);
+    range(c); // $ range===58
     c = *p;
     range(*p);
     if (c != '\0') {
@@ -310,7 +310,7 @@ int test_mult01(int a, int b) {
     int r = a*b;  // 0 .. 253
     range(r);
     total += r;
-    range(total); // $ range=>=0 range=>=3+0
+    range(total); // $ range=>=0 range=>=3+0 range=">=... * ...+0"
   }
   if (3 <= a && a <= 11 && -13 <= b && b <= 23) {
     range(a); // $ range=<=11 range=>=3
@@ -318,7 +318,7 @@ int test_mult01(int a, int b) {
     int r = a*b;  // -143 .. 253
     range(r);
     total += r;
-    range(total);
+    range(total); // $ range=">=... * ...+0"
   }
   if (3 <= a && a <= 11 && -13 <= b && b <= 0) {
     range(a); // $ range=<=11 range=>=3
@@ -358,7 +358,7 @@ int test_mult02(int a, int b) {
     int r = a*b;  // 0 .. 253
     range(r);
     total += r;
-    range(total); // $ range=>=0 range=>=0+0
+    range(total); // $ range=>=0 range=>=0+0 range=">=... * ...+0"
   }
   if (0 <= a && a <= 11 && -13 <= b && b <= 23) {
     range(a); // $ range=<=11 range=>=0
@@ -366,7 +366,7 @@ int test_mult02(int a, int b) {
     int r = a*b;  // -143 .. 253
     range(r);
     total += r;
-    range(total);
+    range(total); // $ range=">=... * ...+0"
   }
   if (0 <= a && a <= 11 && -13 <= b && b <= 0) {
     range(a); // $ range=<=11 range=>=0
@@ -453,7 +453,7 @@ int test_mult04(int a, int b) {
     int r = a*b;  // -391 .. 0
     range(r);
     total += r;
-    range(total); // $ range="<=- ...+0" range=<=0
+    range(total); // $ range="<=- ...+0" range=<=0 range="<=... * ...+0"
   }
   if (-17 <= a && a <= 0 && -13 <= b && b <= 23) {
     range(a); // $ range=<=0 range=>=-17
@@ -461,7 +461,7 @@ int test_mult04(int a, int b) {
     int r = a*b;  // -391 .. 221
     range(r);
     total += r;
-    range(total);
+    range(total); // $ range="<=... * ...+0"
   }
   if (-17 <= a && a <= 0 && -13 <= b && b <= 0) {
     range(a); // $ range=<=0 range=>=-17
@@ -501,7 +501,7 @@ int test_mult05(int a, int b) {
     int r = a*b;  // -391 .. 0
     range(r);
     total += r;
-    range(total); // $ range="<=- ...+0" range=<=0
+    range(total); // $ range="<=- ...+0" range=<=0 range="<=... * ...+0"
   }
   if (-17 <= a && a <= -2 && -13 <= b && b <= 23) {
     range(a); // $ range=<=-2 range=>=-17
@@ -509,7 +509,7 @@ int test_mult05(int a, int b) {
     int r = a*b;  // -391 .. 221
     range(r);
     total += r;
-    range(total);
+    range(total); // $ range="<=... * ...+0"
   }
   if (-17 <= a && a <= -2 && -13 <= b && b <= 0) {
     range(a); // $ range=<=-2 range=>=-17
@@ -628,7 +628,7 @@ unsigned int test_ternary02(unsigned int x) {
       (range(x), 5); // $ range=>=300
     range(y5); // y6 >= 0
   }
-  range(y1 + y2 + y3 + y4 + y5); // $ range=">=... = ...:... ? ... : ...+0" range=">=call to range+0"
+  range(y1 + y2 + y3 + y4 + y5); // $ range=">=... = ...:... ? ... : ...+1" range=">=call to range+1"
   return y1 + y2 + y3 + y4 + y5;
 }
 
@@ -693,7 +693,7 @@ int test_unsigned_mult01(unsigned int a, unsigned b) {
     int r = a*b;  // 0 .. 253
     range(r);
     total += r;
-    range(total); // $ range=">=(unsigned int)...+0" range=>=0
+    range(total); // $ range=">=(unsigned int)...+0" range=>=0 range=>=(int)...+0
   }
   if (3 <= a && a <= 11 && 13 <= b && b <= 23) {
     range(a); // $ range=<=11 range=>=3
@@ -701,7 +701,7 @@ int test_unsigned_mult01(unsigned int a, unsigned b) {
     int r = a*b;  // 39 .. 253
     range(r);
     total += r;
-    range(total); // $ range=">=(unsigned int)...+1" range=>=1
+    range(total); // $ range=">=(unsigned int)...+1" range=>=1 range=>=(int)...+0
   }
   range(total); // $ range=">=(unsigned int)...+0" range=>=0
   return total;
@@ -722,14 +722,14 @@ int test_unsigned_mult02(unsigned b) {
     int r = 11*b;  // 0 .. 253
     range(r);
     total += r;
-    range(total); // $ range=">=(unsigned int)...+0" range=>=0
+    range(total); // $ range=">=(unsigned int)...+0" range=>=0 range=>=(int)...+0
   }
   if (13 <= b && b <= 23) {
     range(b); // $ range=<=23 range=>=13
     int r = 11*b;  // 143 .. 253
     range(r);
     total += r;
-    range(total); // $ range=">=(unsigned int)...+1" range=>=1
+    range(total); // $ range=">=(unsigned int)...+1" range=>=1 range=>=(int)...+0
   }
   range(total); // $ range=">=(unsigned int)...+0" range=>=0
   return total;
@@ -856,18 +856,18 @@ int notequal_type_endpoint(unsigned n) {
 
 void notequal_refinement(short n) {
   if (n < 0) {
-    range(n);
+    range(n); // $ range=<=-1
     return;
   }
 
   if (n == 0) {
     range(n); // 0 .. 0
   } else {
-    range(n); // 1 ..
+    range(n); // $ range=>=1
   }
 
   if (n) {
-    range(n); // 1 ..
+    range(n); // $ range=>=1
   } else {
     range(n); // 0 .. 0
   }
@@ -883,16 +883,16 @@ void notequal_refinement(short n) {
 void notequal_variations(short n, float f) {
   if (n != 0) {
     if (n >= 0) {
-      range(n); // 1 .. [BUG: we can't handle `!=` coming first]
+      range(n); // $ range=>=1
     }
   }
 
   if (n >= 5) {
     if (2 * n - 10 == 0) { // Same as `n == 10/2` (modulo overflow)
-      range(n);
+      range(n); // $ range=>=5 MISSING: range===5
       return;
     }
-    range(n); // 6 ..
+    range(n); // $ range=>=5 MISSING: range=>=6
   }
 
   if (n != -32768 && n != -32767) {
@@ -900,8 +900,12 @@ void notequal_variations(short n, float f) {
   }
 
   if (n >= 0) {
-    n  ? (range(n), n) : (range(n), n); // ? 1..  : 0..0
-    !n ? (range(n), n) : (range(n), n); // ? 0..0 : 1..
+    n  ?
+      (range(n), n) // $ range=>=1
+    : (range(n), n); // $ MISSING: range===0
+    !n ?
+      (range(n), n) // $ MISSING: range===0
+    : (range(n), n); // $ range=>=1
   }
 }
 
@@ -917,7 +921,7 @@ void two_bounds_from_one_test(short ss, unsigned short us) {
   }
 
   if (ss < 0x8001) { // Lower bound removed in `getDefLowerBounds`
-    range(ss); // -32768 .. 32767
+    range(ss); // $ range=<=32768 MISSING: range=>=-32768
   }
 
   if ((short)us >= 0) {
@@ -942,7 +946,7 @@ void widen_recursive_expr() {
   for (s = 0; s < 10; s++) {
     range(s); // $ range=<=9 range=>=0
     int result = s + s;
-    range(result); // 0 .. 18
+    range(result); // $ range=>=0 range=>=s+0 // 0 .. 18
   }
 }
 


### PR DESCRIPTION
Consider this snippet:
```ql
void notequal_refinement(short n) {
  if (n < 0) {
    range(n);
    return;
  }
  ...
}
```
the `n` in `n < 0` has an implicit short-to-int conversion which means that the left-hand side of `<` is not actually a `LoadInstruction` of `n`, but instead a `ConvertInstruction` of the result of a `LoadInstruction`.

We could fix up all of these by doing a transitive closure from the `LoadInstruction`, through all "safe conversions" and figure out if we reached the operand of `<`. This is a bit ugly though, and we'd have to do this in multiple places.

Instead, this PR uses the new-ish `QlBuiltins::EquivalenceRelation` feature to define a new type that unifies unconverted instructions with their safe conversions. This means that the `n` in `n < 0` really _is_ the `LoadInstruction` (because the `LoadInstruction` and the `ConvertInstruction` is mapped to the same `Expr`).