### PR TITLE
Swift: Fix formatting of TypeDecl.qll

### DIFF
--- a/swift/ql/lib/codeql/swift/elements/decl/TypeDecl.qll
+++ b/swift/ql/lib/codeql/swift/elements/decl/TypeDecl.qll
@@ -33,6 +33,8 @@ class TypeDecl extends Generated::TypeDecl {
     or
     result = this.getEnclosingDecl().(TypeDecl).getFullName() + "." + this.getName()
     or
-    result = this.getEnclosingDecl().(ExtensionDecl).getExtendedTypeDecl().getFullName() + "." + this.getName()
+    result =
+      this.getEnclosingDecl().(ExtensionDecl).getExtendedTypeDecl().getFullName() + "." +
+        this.getName()
   }
 }


### PR DESCRIPTION
This fixes the formatting of `swift/ql/lib/codeql/swift/elements/decl/TypeDecl.qll`.

CodeQL 2.12.5 had some changes to the formatter.