### PR TITLE
C++: Add getSizeExpr and getSizeMult predicates to BufferAccess

### DIFF
--- a/cpp/ql/lib/change-notes/2023-03-30-bufferaccess.md
+++ b/cpp/ql/lib/change-notes/2023-03-30-bufferaccess.md
@@ -1,0 +1,4 @@
+---
+category: feature
+---
+* Added overridable predicates `getSizeExpr` and `getSizeMult` to the `BufferAccess` class (`semmle.code.cpp.security.BufferAccess.qll`). This makes it possible to model a larger class of buffer reads and writes using the library.


### PR DESCRIPTION
Adds the `getSizeExpr` predicate to `BufferAccess`, which returns the `Expr` corresponding to the size of the buffer access. This is useful as `getSize()` will only have a result if the size is a constant.

Fixes https://github.com/github/codeql/issues/12597