### PR TITLE
QL: regen TreeSitter.qll

### DIFF
--- a/ql/ql/src/codeql_ql/StructuredLogs.qll
+++ b/ql/ql/src/codeql_ql/StructuredLogs.qll
@@ -405,7 +405,7 @@ module KindPredicatesLog {
           or
           cand.(InLayer).getComputeRecursiveEvent() = recursive
         ) and
-        cand.hasLocationInfo(filepath, startline, _, _, _)
+        cand.getLocation().hasLocationInfo(filepath, startline, _, _, _)
       |
         cand order by filepath, startline
       )

--- a/ql/ql/src/codeql_ql/ast/internal/TreeSitter.qll
+++ b/ql/ql/src/codeql_ql/ast/internal/TreeSitter.qll
@@ -1866,12 +1866,6 @@ module JSON {
     /** Gets the location of this element. */
     final L::Location getLocation() { json_ast_node_info(this, _, _, result) }
 
-    predicate hasLocationInfo(
-      string filepath, int startline, int startcolumn, int endline, int endcolumn
-    ) {
-      this.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
-    }
-
     /** Gets the parent of this element. */
     final AstNode getParent() { json_ast_node_info(this, result, _, _) }
 


### PR DESCRIPTION
The extractor got updated at some point without the updated `TreeSitter.qll` file getting committed.  

I just ran `ql/scripts/create-extractor-pack.sh`, and re-generated the `TreeSitter.qll` file with that.  