### PR TITLE
QL: disable the consistency check

### DIFF
--- a/ql/ql/src/queries/diagnostics/EmptyConsistencies.ql
+++ b/ql/ql/src/queries/diagnostics/EmptyConsistencies.ql
@@ -58,6 +58,7 @@ where
     or
     ModConsistency::noResolve(node) and msg = "ModConsistency::noResolve"
   ) and
+  none() and // disabled for now
   not node.getLocation()
       .getFile()
       .getAbsolutePath()


### PR DESCRIPTION
It's starting to fail a little too much: https://github.com/github/codeql/pull/12615/files 

Should be re-enabled once QL-for-QL is (hopefully) better at parameterized modules. 