### PR TITLE
Java: Refactor Android `Query.qll` libraries to new dataflow api

### DIFF
--- a/java/ql/lib/change-notes/2023-03-22-deprecate-webviewdubuggingenabledquery.md
+++ b/java/ql/lib/change-notes/2023-03-22-deprecate-webviewdubuggingenabledquery.md
@@ -1,0 +1,4 @@
+---
+category: deprecated
+---
+* The `WebViewDubuggingQuery` library has been renamed to `WebViewDebuggingQuery` to fix the typo in the file name. `WebViewDubuggingQuery` is now deprecated. 

--- a/java/ql/lib/semmle/code/java/security/AndroidCertificatePinningQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/AndroidCertificatePinningQuery.qll
@@ -118,7 +118,7 @@ private module UntrustedUrlConfig implements DataFlow::ConfigSig {
   predicate isSink(DataFlow::Node node) { node instanceof MissingPinningSink }
 }
 
-private module UntrustedUrlFlow = TaintTracking::Make<UntrustedUrlConfig>;
+private module UntrustedUrlFlow = TaintTracking::Global<UntrustedUrlConfig>;
 
 /** Holds if `node` is a network communication call for which certificate pinning is not implemented. */
 predicate missingPinning(DataFlow::Node node, string domain) {
@@ -128,7 +128,7 @@ predicate missingPinning(DataFlow::Node node, string domain) {
     not trustedDomain(_) and domain = ""
     or
     exists(DataFlow::Node src |
-      UntrustedUrlFlow::hasFlow(src, node) and
+      UntrustedUrlFlow::flow(src, node) and
       domain = getDomain(src.asExpr())
     )
   )

--- a/java/ql/lib/semmle/code/java/security/AndroidCertificatePinningQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/AndroidCertificatePinningQuery.qll
@@ -106,10 +106,8 @@ private class MissingPinningSink extends DataFlow::Node {
 }
 
 /** Configuration for finding uses of non trusted URLs. */
-private class UntrustedUrlConfig extends TaintTracking::Configuration {
-  UntrustedUrlConfig() { this = "UntrustedUrlConfig" }
-
-  override predicate isSource(DataFlow::Node node) {
+private module UntrustedUrlConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node node) {
     trustedDomain(_) and
     exists(string lit | lit = node.asExpr().(CompileTimeConstantExpr).getStringValue() |
       lit.matches("%://%") and // it's a URL
@@ -117,8 +115,10 @@ private class UntrustedUrlConfig extends TaintTracking::Configuration {
     )
   }
 
-  override predicate isSink(DataFlow::Node node) { node instanceof MissingPinningSink }
+  predicate isSink(DataFlow::Node node) { node instanceof MissingPinningSink }
 }
+
+private module UntrustedUrlFlow = TaintTracking::Make<UntrustedUrlConfig>;
 
 /** Holds if `node` is a network communication call for which certificate pinning is not implemented. */
 predicate missingPinning(DataFlow::Node node, string domain) {
@@ -127,8 +127,8 @@ predicate missingPinning(DataFlow::Node node, string domain) {
   (
     not trustedDomain(_) and domain = ""
     or
-    exists(UntrustedUrlConfig conf, DataFlow::Node src |
-      conf.hasFlow(src, node) and
+    exists(DataFlow::Node src |
+      UntrustedUrlFlow::hasFlow(src, node) and
       domain = getDomain(src.asExpr())
     )
   )

--- a/java/ql/lib/semmle/code/java/security/AndroidIntentRedirectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/AndroidIntentRedirectionQuery.qll
@@ -42,14 +42,14 @@ module IntentRedirectionConfig implements DataFlow::ConfigSig {
 }
 
 /** Tracks the flow of tainted Intents being used to start Android components. */
-module IntentRedirectionFlow = TaintTracking::Make<IntentRedirectionConfig>;
+module IntentRedirectionFlow = TaintTracking::Global<IntentRedirectionConfig>;
 
 /**
  * A sanitizer for sinks that receive the original incoming Intent,
  * since its component cannot be arbitrarily set.
  */
 private class OriginalIntentSanitizer extends IntentRedirectionSanitizer {
-  OriginalIntentSanitizer() { SameIntentBeingRelaunchedFlow::hasFlowTo(this) }
+  OriginalIntentSanitizer() { SameIntentBeingRelaunchedFlow::flowTo(this) }
 }
 
 /**
@@ -77,14 +77,14 @@ private module SameIntentBeingRelaunchedConfig implements DataFlow::ConfigSig {
   }
 }
 
-private module SameIntentBeingRelaunchedFlow = DataFlow::Make<SameIntentBeingRelaunchedConfig>;
+private module SameIntentBeingRelaunchedFlow = DataFlow::Global<SameIntentBeingRelaunchedConfig>;
 
 /** An `Intent` with a tainted component. */
 private class IntentWithTaintedComponent extends DataFlow::Node {
   IntentWithTaintedComponent() {
     exists(IntentSetComponent setExpr |
       setExpr.getQualifier() = this.asExpr() and
-      TaintedIntentComponentFlow::hasFlowTo(DataFlow::exprNode(setExpr.getSink()))
+      TaintedIntentComponentFlow::flowTo(DataFlow::exprNode(setExpr.getSink()))
     )
   }
 }
@@ -100,7 +100,7 @@ private module TaintedIntentComponentConfig implements DataFlow::ConfigSig {
   }
 }
 
-private module TaintedIntentComponentFlow = TaintTracking::Make<TaintedIntentComponentConfig>;
+private module TaintedIntentComponentFlow = TaintTracking::Global<TaintedIntentComponentConfig>;
 
 /** A call to a method that changes the component of an `Intent`. */
 private class IntentSetComponent extends MethodAccess {

--- a/java/ql/lib/semmle/code/java/security/AndroidIntentRedirectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/AndroidIntentRedirectionQuery.qll
@@ -8,9 +8,11 @@ import semmle.code.java.dataflow.TaintTracking3
 import semmle.code.java.security.AndroidIntentRedirection
 
 /**
+ * DEPRECATED: Use `IntentRedirectionFlow` instead.
+ *
  * A taint tracking configuration for tainted Intents being used to start Android components.
  */
-class IntentRedirectionConfiguration extends TaintTracking::Configuration {
+deprecated class IntentRedirectionConfiguration extends TaintTracking::Configuration {
   IntentRedirectionConfiguration() { this = "IntentRedirectionConfiguration" }
 
   override predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
@@ -26,31 +28,44 @@ class IntentRedirectionConfiguration extends TaintTracking::Configuration {
   }
 }
 
+private module IntentRedirectionConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+
+  predicate isSink(DataFlow::Node sink) { sink instanceof IntentRedirectionSink }
+
+  predicate isBarrier(DataFlow::Node sanitizer) { sanitizer instanceof IntentRedirectionSanitizer }
+
+  predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
+    any(IntentRedirectionAdditionalTaintStep c).step(node1, node2)
+  }
+}
+
+/** A taint tracking configuration for tainted Intents being used to start Android components. */
+module IntentRedirectionFlow = TaintTracking::Make<IntentRedirectionConfig>;
+
 /**
  * A sanitizer for sinks that receive the original incoming Intent,
  * since its component cannot be arbitrarily set.
  */
 private class OriginalIntentSanitizer extends IntentRedirectionSanitizer {
-  OriginalIntentSanitizer() { any(SameIntentBeingRelaunchedConfiguration c).hasFlowTo(this) }
+  OriginalIntentSanitizer() { SameIntentBeingRelaunchedFlow::hasFlowTo(this) }
 }
 
 /**
  * Data flow configuration used to discard incoming Intents
  * flowing directly to sinks that start Android components.
  */
-private class SameIntentBeingRelaunchedConfiguration extends DataFlow2::Configuration {
-  SameIntentBeingRelaunchedConfiguration() { this = "SameIntentBeingRelaunchedConfiguration" }
+private module SameIntentBeingRelaunchedConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
 
-  override predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSink(DataFlow::Node sink) { sink instanceof IntentRedirectionSink }
 
-  override predicate isSink(DataFlow::Node sink) { sink instanceof IntentRedirectionSink }
-
-  override predicate isBarrier(DataFlow::Node barrier) {
+  predicate isBarrier(DataFlow::Node barrier) {
     // Don't discard the Intent if its original component is tainted
     barrier instanceof IntentWithTaintedComponent
   }
 
-  override predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
+  predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
     // Intents being built with the copy constructor from the original Intent are discarded too
     exists(ClassInstanceExpr cie |
       cie.getConstructedType() instanceof TypeIntent and
@@ -61,12 +76,14 @@ private class SameIntentBeingRelaunchedConfiguration extends DataFlow2::Configur
   }
 }
 
+private module SameIntentBeingRelaunchedFlow = DataFlow::Make<SameIntentBeingRelaunchedConfig>;
+
 /** An `Intent` with a tainted component. */
 private class IntentWithTaintedComponent extends DataFlow::Node {
   IntentWithTaintedComponent() {
-    exists(IntentSetComponent setExpr, TaintedIntentComponentConf conf |
+    exists(IntentSetComponent setExpr |
       setExpr.getQualifier() = this.asExpr() and
-      conf.hasFlowTo(DataFlow::exprNode(setExpr.getSink()))
+      TaintedIntentComponentFlow::hasFlowTo(DataFlow::exprNode(setExpr.getSink()))
     )
   }
 }
@@ -74,15 +91,15 @@ private class IntentWithTaintedComponent extends DataFlow::Node {
 /**
  * A taint tracking configuration for tainted data flowing to an `Intent`'s component.
  */
-private class TaintedIntentComponentConf extends TaintTracking3::Configuration {
-  TaintedIntentComponentConf() { this = "TaintedIntentComponentConf" }
+private module TaintedIntentComponentConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
 
-  override predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
-
-  override predicate isSink(DataFlow::Node sink) {
+  predicate isSink(DataFlow::Node sink) {
     any(IntentSetComponent setComponent).getSink() = sink.asExpr()
   }
 }
+
+private module TaintedIntentComponentFlow = TaintTracking::Make<TaintedIntentComponentConfig>;
 
 /** A call to a method that changes the component of an `Intent`. */
 private class IntentSetComponent extends MethodAccess {

--- a/java/ql/lib/semmle/code/java/security/AndroidIntentRedirectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/AndroidIntentRedirectionQuery.qll
@@ -28,7 +28,8 @@ deprecated class IntentRedirectionConfiguration extends TaintTracking::Configura
   }
 }
 
-private module IntentRedirectionConfig implements DataFlow::ConfigSig {
+/** A taint tracking configuration for tainted Intents being used to start Android components. */
+module IntentRedirectionConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof IntentRedirectionSink }
@@ -40,7 +41,7 @@ private module IntentRedirectionConfig implements DataFlow::ConfigSig {
   }
 }
 
-/** A taint tracking configuration for tainted Intents being used to start Android components. */
+/** Tracks the flow of tainted Intents being used to start Android components. */
 module IntentRedirectionFlow = TaintTracking::Make<IntentRedirectionConfig>;
 
 /**

--- a/java/ql/lib/semmle/code/java/security/ImproperIntentVerificationQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/ImproperIntentVerificationQuery.qll
@@ -27,12 +27,12 @@ private module VerifiedIntentConfig implements DataFlow::ConfigSig {
   }
 }
 
-private module VerifiedIntentFlow = DataFlow::Make<VerifiedIntentConfig>;
+private module VerifiedIntentFlow = DataFlow::Global<VerifiedIntentConfig>;
 
 /** An `onReceive` method that doesn't verify the action of the intent it receives. */
 private class UnverifiedOnReceiveMethod extends OnReceiveMethod {
   UnverifiedOnReceiveMethod() {
-    not VerifiedIntentFlow::hasFlow(DataFlow::parameterNode(this.getIntentParameter()), _)
+    not VerifiedIntentFlow::flow(DataFlow::parameterNode(this.getIntentParameter()), _)
   }
 }
 

--- a/java/ql/lib/semmle/code/java/security/ImproperIntentVerificationQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/ImproperIntentVerificationQuery.qll
@@ -14,14 +14,12 @@ private class OnReceiveMethod extends Method {
 }
 
 /** A configuration to detect whether the `action` of an `Intent` is checked. */
-private class VerifiedIntentConfig extends DataFlow::Configuration {
-  VerifiedIntentConfig() { this = "VerifiedIntentConfig" }
-
-  override predicate isSource(DataFlow::Node src) {
+private module VerifiedIntentConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node src) {
     src.asParameter() = any(OnReceiveMethod orm).getIntentParameter()
   }
 
-  override predicate isSink(DataFlow::Node sink) {
+  predicate isSink(DataFlow::Node sink) {
     exists(MethodAccess ma |
       ma.getMethod().hasQualifiedName("android.content", "Intent", "getAction") and
       sink.asExpr() = ma.getQualifier()
@@ -29,10 +27,12 @@ private class VerifiedIntentConfig extends DataFlow::Configuration {
   }
 }
 
+private module VerifiedIntentFlow = DataFlow::Make<VerifiedIntentConfig>;
+
 /** An `onReceive` method that doesn't verify the action of the intent it receives. */
 private class UnverifiedOnReceiveMethod extends OnReceiveMethod {
   UnverifiedOnReceiveMethod() {
-    not any(VerifiedIntentConfig c).hasFlow(DataFlow::parameterNode(this.getIntentParameter()), _)
+    not VerifiedIntentFlow::hasFlow(DataFlow::parameterNode(this.getIntentParameter()), _)
   }
 }
 

--- a/java/ql/lib/semmle/code/java/security/SensitiveKeyboardCacheQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/SensitiveKeyboardCacheQuery.qll
@@ -106,7 +106,7 @@ private module GoodInputTypeConfig implements DataFlow::ConfigSig {
   }
 }
 
-private module GoodInputTypeFlow = DataFlow::Make<GoodInputTypeConfig>;
+private module GoodInputTypeFlow = DataFlow::Global<GoodInputTypeConfig>;
 
 /** Gets a regex indicating that an input field may contain sensitive data. */
 private string getInputSensitiveInfoRegex() {
@@ -131,7 +131,7 @@ AndroidEditableXmlElement getASensitiveCachedInput() {
   (
     not inputTypeNotCached(result.getInputType()) and
     not exists(DataFlow::Node sink |
-      GoodInputTypeFlow::hasFlowTo(sink) and
+      GoodInputTypeFlow::flowTo(sink) and
       sink.asExpr() = setInputTypeForId(result.getId())
     )
   )

--- a/java/ql/lib/semmle/code/java/security/SensitiveKeyboardCacheQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/SensitiveKeyboardCacheQuery.qll
@@ -91,22 +91,22 @@ private predicate inputTypeFieldNotCached(Field f) {
 }
 
 /** Configuration that finds uses of `setInputType` for non cached fields. */
-private class GoodInputTypeConf extends DataFlow::Configuration {
-  GoodInputTypeConf() { this = "GoodInputTypeConf" }
-
-  override predicate isSource(DataFlow::Node node) {
+private module GoodInputTypeConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node node) {
     inputTypeFieldNotCached(node.asExpr().(FieldAccess).getField())
   }
 
-  override predicate isSink(DataFlow::Node node) { node.asExpr() = setInputTypeForId(_) }
+  predicate isSink(DataFlow::Node node) { node.asExpr() = setInputTypeForId(_) }
 
-  override predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
+  predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
     exists(OrBitwiseExpr bitOr |
       node1.asExpr() = bitOr.getAChildExpr() and
       node2.asExpr() = bitOr
     )
   }
 }
+
+private module GoodInputTypeFlow = DataFlow::Make<GoodInputTypeConfig>;
 
 /** Gets a regex indicating that an input field may contain sensitive data. */
 private string getInputSensitiveInfoRegex() {
@@ -130,8 +130,8 @@ AndroidEditableXmlElement getASensitiveCachedInput() {
   result.getId().regexpMatch(getInputSensitiveInfoRegex()) and
   (
     not inputTypeNotCached(result.getInputType()) and
-    not exists(GoodInputTypeConf conf, DataFlow::Node sink |
-      conf.hasFlowTo(sink) and
+    not exists(DataFlow::Node sink |
+      GoodInputTypeFlow::hasFlowTo(sink) and
       sink.asExpr() = setInputTypeForId(result.getId())
     )
   )

--- a/java/ql/lib/semmle/code/java/security/UnsafeAndroidAccessQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/UnsafeAndroidAccessQuery.qll
@@ -23,7 +23,10 @@ deprecated class FetchUntrustedResourceConfiguration extends TaintTracking::Conf
   }
 }
 
-private module FetchUntrustedResourceConfig implements DataFlow::ConfigSig {
+/**
+ * A taint configuration tracking flow from untrusted inputs to a resource fetching call.
+ */
+module FetchUntrustedResourceConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof UrlResourceSink }
@@ -31,4 +34,7 @@ private module FetchUntrustedResourceConfig implements DataFlow::ConfigSig {
   predicate isBarrier(DataFlow::Node sanitizer) { sanitizer instanceof RequestForgerySanitizer }
 }
 
+/**
+ * Detects taint flow from untrusted inputs to a resource fetching call.
+ */
 module FetchUntrustedResourceFlow = TaintTracking::Make<FetchUntrustedResourceConfig>;

--- a/java/ql/lib/semmle/code/java/security/UnsafeAndroidAccessQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/UnsafeAndroidAccessQuery.qll
@@ -7,9 +7,11 @@ import semmle.code.java.security.RequestForgery
 import semmle.code.java.security.UnsafeAndroidAccess
 
 /**
+ * DEPRECATED: Use `FetchUntrustedResourceFlow` instead.
+ *
  * A taint configuration tracking flow from untrusted inputs to a resource fetching call.
  */
-class FetchUntrustedResourceConfiguration extends TaintTracking::Configuration {
+deprecated class FetchUntrustedResourceConfiguration extends TaintTracking::Configuration {
   FetchUntrustedResourceConfiguration() { this = "FetchUntrustedResourceConfiguration" }
 
   override predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
@@ -20,3 +22,13 @@ class FetchUntrustedResourceConfiguration extends TaintTracking::Configuration {
     sanitizer instanceof RequestForgerySanitizer
   }
 }
+
+private module FetchUntrustedResourceConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+
+  predicate isSink(DataFlow::Node sink) { sink instanceof UrlResourceSink }
+
+  predicate isBarrier(DataFlow::Node sanitizer) { sanitizer instanceof RequestForgerySanitizer }
+}
+
+module FetchUntrustedResourceFlow = TaintTracking::Make<FetchUntrustedResourceConfig>;

--- a/java/ql/lib/semmle/code/java/security/UnsafeAndroidAccessQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/UnsafeAndroidAccessQuery.qll
@@ -37,4 +37,4 @@ module FetchUntrustedResourceConfig implements DataFlow::ConfigSig {
 /**
  * Detects taint flow from untrusted inputs to a resource fetching call.
  */
-module FetchUntrustedResourceFlow = TaintTracking::Make<FetchUntrustedResourceConfig>;
+module FetchUntrustedResourceFlow = TaintTracking::Global<FetchUntrustedResourceConfig>;

--- a/java/ql/lib/semmle/code/java/security/WebviewDebuggingEnabledQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/WebviewDebuggingEnabledQuery.qll
@@ -45,7 +45,7 @@ deprecated class WebviewDebugEnabledConfig extends DataFlow::Configuration {
 }
 
 /** A configuration to find instances of `setWebContentDebuggingEnabled` called with `true` values. */
-private module WebviewDebugEnabledConfig implements DataFlow::ConfigSig {
+module WebviewDebugEnabledConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node node) {
     node.asExpr().(BooleanLiteral).getBooleanValue() = true
   }
@@ -64,4 +64,7 @@ private module WebviewDebugEnabledConfig implements DataFlow::ConfigSig {
   }
 }
 
+/**
+ * Tracks instances of `setWebContentDebuggingEnabled` with `true` values.
+ */
 module WebviewDebugEnabledFlow = DataFlow::Make<WebviewDebugEnabledConfig>;

--- a/java/ql/lib/semmle/code/java/security/WebviewDebuggingEnabledQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/WebviewDebuggingEnabledQuery.qll
@@ -67,4 +67,4 @@ module WebviewDebugEnabledConfig implements DataFlow::ConfigSig {
 /**
  * Tracks instances of `setWebContentDebuggingEnabled` with `true` values.
  */
-module WebviewDebugEnabledFlow = DataFlow::Make<WebviewDebugEnabledConfig>;
+module WebviewDebugEnabledFlow = DataFlow::Global<WebviewDebugEnabledConfig>;

--- a/java/ql/lib/semmle/code/java/security/WebviewDubuggingEnabledQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/WebviewDubuggingEnabledQuery.qll
@@ -7,4 +7,5 @@
 import java
 private import semmle.code.java.security.WebviewDebuggingEnabledQuery as WebviewDebuggingEnabledQuery
 
-deprecated class WebviewDebugEnabledConfig = WebviewDebuggingEnabledQuery:: WebviewDebugEnabledConfig;
+deprecated class WebviewDebugEnabledConfig =
+  WebviewDebuggingEnabledQuery::WebviewDebugEnabledConfig;

--- a/java/ql/lib/semmle/code/java/security/WebviewDubuggingEnabledQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/WebviewDubuggingEnabledQuery.qll
@@ -1,0 +1,8 @@
+/**
+ * DEPRECATED: Use `semmle.code.java.security.WebviewDebuggingEnabledQuery` instead.
+ *
+ * Definitions for the Android Webview Debugging Enabled query
+ */
+
+import java
+import semmle.code.java.security.WebviewDebuggingEnabledQuery

--- a/java/ql/lib/semmle/code/java/security/WebviewDubuggingEnabledQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/WebviewDubuggingEnabledQuery.qll
@@ -5,4 +5,6 @@
  */
 
 import java
-import semmle.code.java.security.WebviewDebuggingEnabledQuery
+private import semmle.code.java.security.WebviewDebuggingEnabledQuery as WebviewDebuggingEnabledQuery
+
+deprecated class WebviewDebugEnabledConfig = WebviewDebuggingEnabledQuery:: WebviewDebugEnabledConfig;

--- a/java/ql/src/Security/CWE/CWE-489/WebviewDebuggingEnabled.ql
+++ b/java/ql/src/Security/CWE/CWE-489/WebviewDebuggingEnabled.ql
@@ -15,5 +15,5 @@ import semmle.code.java.security.WebviewDebuggingEnabledQuery
 import WebviewDebugEnabledFlow::PathGraph
 
 from WebviewDebugEnabledFlow::PathNode source, WebviewDebugEnabledFlow::PathNode sink
-where WebviewDebugEnabledFlow::hasFlowPath(source, sink)
+where WebviewDebugEnabledFlow::flowPath(source, sink)
 select sink, source, sink, "Webview debugging is enabled."

--- a/java/ql/src/Security/CWE/CWE-489/WebviewDebuggingEnabled.ql
+++ b/java/ql/src/Security/CWE/CWE-489/WebviewDebuggingEnabled.ql
@@ -11,9 +11,9 @@
  */
 
 import java
-import semmle.code.java.security.WebviewDubuggingEnabledQuery
-import DataFlow::PathGraph
+import semmle.code.java.security.WebviewDebuggingEnabledQuery
+import WebviewDebugEnabledFlow::PathGraph
 
-from WebviewDebugEnabledConfig conf, DataFlow::PathNode source, DataFlow::PathNode sink
-where conf.hasFlowPath(source, sink)
+from WebviewDebugEnabledFlow::PathNode source, WebviewDebugEnabledFlow::PathNode sink
+where WebviewDebugEnabledFlow::hasFlowPath(source, sink)
 select sink, source, sink, "Webview debugging is enabled."

--- a/java/ql/src/Security/CWE/CWE-749/UnsafeAndroidAccess.ql
+++ b/java/ql/src/Security/CWE/CWE-749/UnsafeAndroidAccess.ql
@@ -17,6 +17,6 @@ import semmle.code.java.security.UnsafeAndroidAccessQuery
 import FetchUntrustedResourceFlow::PathGraph
 
 from FetchUntrustedResourceFlow::PathNode source, FetchUntrustedResourceFlow::PathNode sink
-where FetchUntrustedResourceFlow::hasFlowPath(source, sink)
+where FetchUntrustedResourceFlow::flowPath(source, sink)
 select sink.getNode(), source, sink, "Unsafe resource fetching in Android WebView due to $@.",
   source.getNode(), sink.getNode().(UrlResourceSink).getSinkType()

--- a/java/ql/src/Security/CWE/CWE-749/UnsafeAndroidAccess.ql
+++ b/java/ql/src/Security/CWE/CWE-749/UnsafeAndroidAccess.ql
@@ -14,9 +14,9 @@
 
 import java
 import semmle.code.java.security.UnsafeAndroidAccessQuery
-import DataFlow::PathGraph
+import FetchUntrustedResourceFlow::PathGraph
 
-from DataFlow::PathNode source, DataFlow::PathNode sink, FetchUntrustedResourceConfiguration conf
-where conf.hasFlowPath(source, sink)
+from FetchUntrustedResourceFlow::PathNode source, FetchUntrustedResourceFlow::PathNode sink
+where FetchUntrustedResourceFlow::hasFlowPath(source, sink)
 select sink.getNode(), source, sink, "Unsafe resource fetching in Android WebView due to $@.",
   source.getNode(), sink.getNode().(UrlResourceSink).getSinkType()

--- a/java/ql/src/Security/CWE/CWE-940/AndroidIntentRedirection.ql
+++ b/java/ql/src/Security/CWE/CWE-940/AndroidIntentRedirection.ql
@@ -15,10 +15,10 @@
 
 import java
 import semmle.code.java.security.AndroidIntentRedirectionQuery
-import DataFlow::PathGraph
+import IntentRedirectionFlow::PathGraph
 
-from DataFlow::PathNode source, DataFlow::PathNode sink, IntentRedirectionConfiguration conf
-where conf.hasFlowPath(source, sink)
+from IntentRedirectionFlow::PathNode source, IntentRedirectionFlow::PathNode sink
+where IntentRedirectionFlow::hasFlowPath(source, sink)
 select sink.getNode(), source, sink,
   "Arbitrary Android activities or services can be started from a $@.", source.getNode(),
   "user-provided value"

--- a/java/ql/src/Security/CWE/CWE-940/AndroidIntentRedirection.ql
+++ b/java/ql/src/Security/CWE/CWE-940/AndroidIntentRedirection.ql
@@ -18,7 +18,7 @@ import semmle.code.java.security.AndroidIntentRedirectionQuery
 import IntentRedirectionFlow::PathGraph
 
 from IntentRedirectionFlow::PathNode source, IntentRedirectionFlow::PathNode sink
-where IntentRedirectionFlow::hasFlowPath(source, sink)
+where IntentRedirectionFlow::flowPath(source, sink)
 select sink.getNode(), source, sink,
   "Arbitrary Android activities or services can be started from a $@.", source.getNode(),
   "user-provided value"

--- a/java/ql/test/query-tests/security/CWE-489/webview-debugging/WebviewDebuggingEnabled.ql
+++ b/java/ql/test/query-tests/security/CWE-489/webview-debugging/WebviewDebuggingEnabled.ql
@@ -1,15 +1,18 @@
 import java
-import TestUtilities.InlineFlowTest
-import semmle.code.java.security.WebviewDubuggingEnabledQuery
+import TestUtilities.InlineExpectationsTest
+import semmle.code.java.security.WebviewDebuggingEnabledQuery
 
-class EnableLegacy extends EnableLegacyConfiguration {
-  EnableLegacy() { exists(this) }
-}
+class HasFlowTest extends InlineExpectationsTest {
+  HasFlowTest() { this = "HasFlowTest" }
 
-class HasFlowTest extends InlineFlowTest {
-  override DataFlow::Configuration getTaintFlowConfig() { none() }
+  override string getARelevantTag() { result = "hasValueFlow" }
 
-  override DataFlow::Configuration getValueFlowConfig() {
-    result = any(WebviewDebugEnabledConfig c)
+  override predicate hasActualResult(Location location, string element, string tag, string value) {
+    tag = "hasValueFlow" and
+    exists(DataFlow::Node sink | WebviewDebugEnabledFlow::hasFlowTo(sink) |
+      location = sink.getLocation() and
+      element = "sink" and
+      value = ""
+    )
   }
 }

--- a/java/ql/test/query-tests/security/CWE-489/webview-debugging/WebviewDebuggingEnabled.ql
+++ b/java/ql/test/query-tests/security/CWE-489/webview-debugging/WebviewDebuggingEnabled.ql
@@ -6,6 +6,6 @@ class HasFlowTest extends InlineFlowTest {
   override predicate hasTaintFlow(DataFlow::Node src, DataFlow::Node sink) { none() }
 
   override predicate hasValueFlow(DataFlow::Node src, DataFlow::Node sink) {
-    WebviewDebugEnabledFlow::hasFlow(src, sink)
+    WebviewDebugEnabledFlow::flow(src, sink)
   }
 }

--- a/java/ql/test/query-tests/security/CWE-489/webview-debugging/WebviewDebuggingEnabled.ql
+++ b/java/ql/test/query-tests/security/CWE-489/webview-debugging/WebviewDebuggingEnabled.ql
@@ -1,18 +1,11 @@
 import java
-import TestUtilities.InlineExpectationsTest
+import TestUtilities.InlineFlowTest
 import semmle.code.java.security.WebviewDebuggingEnabledQuery
 
-class HasFlowTest extends InlineExpectationsTest {
-  HasFlowTest() { this = "HasFlowTest" }
+class HasFlowTest extends InlineFlowTest {
+  override predicate hasTaintFlow(DataFlow::Node src, DataFlow::Node sink) { none() }
 
-  override string getARelevantTag() { result = "hasValueFlow" }
-
-  override predicate hasActualResult(Location location, string element, string tag, string value) {
-    tag = "hasValueFlow" and
-    exists(DataFlow::Node sink | WebviewDebugEnabledFlow::hasFlowTo(sink) |
-      location = sink.getLocation() and
-      element = "sink" and
-      value = ""
-    )
+  override predicate hasValueFlow(DataFlow::Node src, DataFlow::Node sink) {
+    WebviewDebugEnabledFlow::hasFlow(src, sink)
   }
 }

--- a/java/ql/test/query-tests/security/CWE-749/UnsafeAndroidAccessTest.ql
+++ b/java/ql/test/query-tests/security/CWE-749/UnsafeAndroidAccessTest.ql
@@ -9,7 +9,7 @@ class UnsafeAndroidAccessTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "hasUnsafeAndroidAccess" and
-    exists(DataFlow::Node sink, FetchUntrustedResourceConfiguration conf | conf.hasFlowTo(sink) |
+    exists(DataFlow::Node sink | FetchUntrustedResourceFlow::hasFlowTo(sink) |
       sink.getLocation() = location and
       element = sink.toString() and
       value = ""

--- a/java/ql/test/query-tests/security/CWE-749/UnsafeAndroidAccessTest.ql
+++ b/java/ql/test/query-tests/security/CWE-749/UnsafeAndroidAccessTest.ql
@@ -9,7 +9,7 @@ class UnsafeAndroidAccessTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "hasUnsafeAndroidAccess" and
-    exists(DataFlow::Node sink | FetchUntrustedResourceFlow::hasFlowTo(sink) |
+    exists(DataFlow::Node sink | FetchUntrustedResourceFlow::flowTo(sink) |
       sink.getLocation() = location and
       element = sink.toString() and
       value = ""

--- a/java/ql/test/query-tests/security/CWE-940/AndroidIntentRedirectionTest.ql
+++ b/java/ql/test/query-tests/security/CWE-940/AndroidIntentRedirectionTest.ql
@@ -9,7 +9,7 @@ class HasAndroidIntentRedirectionTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "hasAndroidIntentRedirection" and
-    exists(DataFlow::Node sink, IntentRedirectionConfiguration conf | conf.hasFlowTo(sink) |
+    exists(DataFlow::Node sink | IntentRedirectionFlow::hasFlowTo(sink) |
       sink.getLocation() = location and
       element = sink.toString() and
       value = ""

--- a/java/ql/test/query-tests/security/CWE-940/AndroidIntentRedirectionTest.ql
+++ b/java/ql/test/query-tests/security/CWE-940/AndroidIntentRedirectionTest.ql
@@ -9,7 +9,7 @@ class HasAndroidIntentRedirectionTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "hasAndroidIntentRedirection" and
-    exists(DataFlow::Node sink | IntentRedirectionFlow::hasFlowTo(sink) |
+    exists(DataFlow::Node sink | IntentRedirectionFlow::flowTo(sink) |
       sink.getLocation() = location and
       element = sink.toString() and
       value = ""


### PR DESCRIPTION
This refactors `Query.qll` libraries related to Android to use the new dataflow module api.