### PR TITLE
JS: better callgraph support for global variables

### DIFF
--- a/javascript/ql/lib/semmle/javascript/GlobalAccessPaths.qll
+++ b/javascript/ql/lib/semmle/javascript/GlobalAccessPaths.qll
@@ -243,6 +243,11 @@ module AccessPath {
       root.isGlobal()
     )
     or
+    exists(Assignment assign |
+      fromReference(assign.getLhs().flow(), root) = result and
+      node = assign.getRhs().flow()
+    )
+    or
     exists(FunctionDeclStmt fun |
       node = DataFlow::valueNode(fun) and
       result = fun.getIdentifier().(GlobalVarDecl).getName() and

--- a/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/XssThroughDom.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/XssThroughDom.expected
@@ -159,6 +159,11 @@ nodes
 | xss-through-dom.js:141:25:141:27 | src |
 | xss-through-dom.js:150:24:150:26 | src |
 | xss-through-dom.js:150:24:150:26 | src |
+| xss-through-dom.js:154:25:154:27 | msg |
+| xss-through-dom.js:155:27:155:29 | msg |
+| xss-through-dom.js:155:27:155:29 | msg |
+| xss-through-dom.js:159:34:159:52 | $("textarea").val() |
+| xss-through-dom.js:159:34:159:52 | $("textarea").val() |
 edges
 | forms.js:8:23:8:28 | values | forms.js:9:31:9:36 | values |
 | forms.js:8:23:8:28 | values | forms.js:9:31:9:36 | values |
@@ -263,6 +268,10 @@ edges
 | xss-through-dom.js:139:11:139:52 | src | xss-through-dom.js:150:24:150:26 | src |
 | xss-through-dom.js:139:17:139:52 | documen ... k").src | xss-through-dom.js:139:11:139:52 | src |
 | xss-through-dom.js:139:17:139:52 | documen ... k").src | xss-through-dom.js:139:11:139:52 | src |
+| xss-through-dom.js:154:25:154:27 | msg | xss-through-dom.js:155:27:155:29 | msg |
+| xss-through-dom.js:154:25:154:27 | msg | xss-through-dom.js:155:27:155:29 | msg |
+| xss-through-dom.js:159:34:159:52 | $("textarea").val() | xss-through-dom.js:154:25:154:27 | msg |
+| xss-through-dom.js:159:34:159:52 | $("textarea").val() | xss-through-dom.js:154:25:154:27 | msg |
 #select
 | forms.js:9:31:9:40 | values.foo | forms.js:8:23:8:28 | values | forms.js:9:31:9:40 | values.foo | $@ is reinterpreted as HTML without escaping meta-characters. | forms.js:8:23:8:28 | values | DOM text |
 | forms.js:12:31:12:40 | values.bar | forms.js:11:24:11:29 | values | forms.js:12:31:12:40 | values.bar | $@ is reinterpreted as HTML without escaping meta-characters. | forms.js:11:24:11:29 | values | DOM text |
@@ -307,3 +316,4 @@ edges
 | xss-through-dom.js:140:19:140:21 | src | xss-through-dom.js:139:17:139:52 | documen ... k").src | xss-through-dom.js:140:19:140:21 | src | $@ is reinterpreted as HTML without escaping meta-characters. | xss-through-dom.js:139:17:139:52 | documen ... k").src | DOM text |
 | xss-through-dom.js:141:25:141:27 | src | xss-through-dom.js:139:17:139:52 | documen ... k").src | xss-through-dom.js:141:25:141:27 | src | $@ is reinterpreted as HTML without escaping meta-characters. | xss-through-dom.js:139:17:139:52 | documen ... k").src | DOM text |
 | xss-through-dom.js:150:24:150:26 | src | xss-through-dom.js:139:17:139:52 | documen ... k").src | xss-through-dom.js:150:24:150:26 | src | $@ is reinterpreted as HTML without escaping meta-characters. | xss-through-dom.js:139:17:139:52 | documen ... k").src | DOM text |
+| xss-through-dom.js:155:27:155:29 | msg | xss-through-dom.js:159:34:159:52 | $("textarea").val() | xss-through-dom.js:155:27:155:29 | msg | $@ is reinterpreted as HTML without escaping meta-characters. | xss-through-dom.js:159:34:159:52 | $("textarea").val() | DOM text |

--- a/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/xss-through-dom.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/xss-through-dom.js
@@ -148,4 +148,15 @@ const cashDom = require("cash-dom");
     cashDom("#id").html(DOMPurify ? DOMPurify.sanitize(src) : src); // OK
 
     $("<a />", { html: src }).appendTo("#id"); // NOT OK
+
+    function foo() {
+      window.VeryUniqueXssTestName = {
+        send: function (msg) {
+            $("#id").html(msg); // NOT OK
+        },
+      };
+    
+      VeryUniqueXssTestName.send($("textarea").val());
+    }
+    foo()
 })();


### PR DESCRIPTION
Fixes #12627

Consider this example: 

```JavaScript
function foo() {
  window.Port = {
    send: function (msg) {
      sink(msg);
    },
  };

  Port.send(window.source);
}
foo()
```

Our access-path library in `GlobalAccessPaths.qll` would find a read of `Port`, but it found a write of `window.Port`, and thus the two never got matched up (in the `step` predicate in `GlobalAccessPaths.qll`).  

I think this is an OK solution. 