### PR TITLE
C++: `bool` -> `int` are safe conversions

### DIFF
--- a/cpp/ql/lib/experimental/semmle/code/cpp/semantic/SemanticType.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/semantic/SemanticType.qll
@@ -250,15 +250,25 @@ SemType getSemanticType(Specific::Type type) {
   Specific::unknownType(type) and result = TSemUnknownType()
 }
 
+private class SemNumericOrBooleanType extends SemSizedType {
+  SemNumericOrBooleanType() {
+    this instanceof SemNumericType
+    or
+    this instanceof SemBooleanType
+  }
+}
+
 /**
  * Holds if the conversion from `fromType` to `toType` can never overflow or underflow.
  */
-predicate conversionCannotOverflow(SemNumericType fromType, SemNumericType toType) {
+predicate conversionCannotOverflow(SemNumericOrBooleanType fromType, SemNumericOrBooleanType toType) {
   // Identity cast
   fromType = toType
   or
   // Treat any cast to an FP type as safe. It can lose precision, but not overflow.
   toType instanceof SemFloatingPointType and fromType = any(SemNumericType n)
+  or
+  fromType instanceof SemBooleanType and toType instanceof SemIntegerType
   or
   exists(SemIntegerType fromInteger, SemIntegerType toInteger, int fromSize, int toSize |
     fromInteger = fromType and


### PR DESCRIPTION
I wasn't able to construct a testcase where this had any effect since all my attempts with tests like:
```cpp
void test() {
  bool b = false;
  range(b); // $ range===0
}
```
failed 😕. However, surely bool to int conversions _should_ be included in this predicate @rdmarsh2?