### PR TITLE
CI: Add yml files to change note check

### DIFF
--- a/.github/workflows/check-change-note.yml
+++ b/.github/workflows/check-change-note.yml
@@ -8,6 +8,7 @@ on:
       - "*/ql/src/**/*.qll"
       - "*/ql/lib/**/*.ql"
       - "*/ql/lib/**/*.qll"
+      - "*/ql/lib/**/*.yml"
       - "!**/experimental/**"
       - "!ql/**"
       - "!swift/**"


### PR DESCRIPTION
The current “needs change note” CI check does not fail when there is no change note and we only make changes in `.yml` files (MaD/external models). This PR updates the change note check to account for this situation.

Please let me know if there is anything else that needs to be changed/tested for this update (I've never updated a CI workflow before, so I'm not sure if I'm missing anything 🙂).  

(cc @atorralba) 