### PR TITLE
Java: Refactor injection queries to new dataflow API

### DIFF
--- a/java/ql/lib/semmle/code/java/security/GroovyInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/GroovyInjectionQuery.qll
@@ -41,4 +41,4 @@ module GroovyInjectionConfig implements DataFlow::ConfigSig {
  * Detect taint flow of unsafe user input
  * that is used to evaluate a Groovy expression.
  */
-module GroovyInjectionFlow = TaintTracking::Make<GroovyInjectionConfig>;
+module GroovyInjectionFlow = TaintTracking::Global<GroovyInjectionConfig>;

--- a/java/ql/lib/semmle/code/java/security/GroovyInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/GroovyInjectionQuery.qll
@@ -6,10 +6,12 @@ import semmle.code.java.dataflow.TaintTracking
 import semmle.code.java.security.GroovyInjection
 
 /**
+ * DEPRECATED: Use `GroovyInjectionFlow` instead.
+ *
  * A taint-tracking configuration for unsafe user input
  * that is used to evaluate a Groovy expression.
  */
-class GroovyInjectionConfig extends TaintTracking::Configuration {
+deprecated class GroovyInjectionConfig extends TaintTracking::Configuration {
   GroovyInjectionConfig() { this = "GroovyInjectionConfig" }
 
   override predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
@@ -20,3 +22,23 @@ class GroovyInjectionConfig extends TaintTracking::Configuration {
     any(GroovyInjectionAdditionalTaintStep c).step(fromNode, toNode)
   }
 }
+
+/**
+ * A taint-tracking configuration for unsafe user input
+ * that is used to evaluate a Groovy expression.
+ */
+module GroovyInjectionConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+
+  predicate isSink(DataFlow::Node sink) { sink instanceof GroovyInjectionSink }
+
+  predicate isAdditionalFlowStep(DataFlow::Node fromNode, DataFlow::Node toNode) {
+    any(GroovyInjectionAdditionalTaintStep c).step(fromNode, toNode)
+  }
+}
+
+/**
+ * Detect taint flow of unsafe user input
+ * that is used to evaluate a Groovy expression.
+ */
+module GroovyInjectionFlow = TaintTracking::Make<GroovyInjectionConfig>;

--- a/java/ql/lib/semmle/code/java/security/JexlInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/JexlInjectionQuery.qll
@@ -62,7 +62,7 @@ deprecated class JexlInjectionConfig extends TaintTracking::Configuration {
  * that is used to construct and evaluate a JEXL expression.
  * It supports both JEXL 2 and 3.
  */
-private module JexlInjectionConfig implements DataFlow::ConfigSig {
+module JexlInjectionConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof JexlEvaluationSink }

--- a/java/ql/lib/semmle/code/java/security/JexlInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/JexlInjectionQuery.qll
@@ -39,11 +39,13 @@ private class DefaultJexlInjectionAdditionalTaintStep extends JexlInjectionAddit
 }
 
 /**
+ * DEPRECATED: Use `JexlInjectionFlow` instead.
+ *
  * A taint-tracking configuration for unsafe user input
  * that is used to construct and evaluate a JEXL expression.
  * It supports both JEXL 2 and 3.
  */
-class JexlInjectionConfig extends TaintTracking::Configuration {
+deprecated class JexlInjectionConfig extends TaintTracking::Configuration {
   JexlInjectionConfig() { this = "JexlInjectionConfig" }
 
   override predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
@@ -54,6 +56,27 @@ class JexlInjectionConfig extends TaintTracking::Configuration {
     any(JexlInjectionAdditionalTaintStep c).step(node1, node2)
   }
 }
+
+/**
+ * A taint-tracking configuration for unsafe user input
+ * that is used to construct and evaluate a JEXL expression.
+ * It supports both JEXL 2 and 3.
+ */
+private module JexlInjectionConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+
+  predicate isSink(DataFlow::Node sink) { sink instanceof JexlEvaluationSink }
+
+  predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
+    any(JexlInjectionAdditionalTaintStep c).step(node1, node2)
+  }
+}
+
+/**
+ * Tracks unsafe user input that is used to construct and evaluate a JEXL expression.
+ * It supports both JEXL 2 and 3.
+ */
+module JexlInjectionFlow = TaintTracking::Make<JexlInjectionConfig>;
 
 /**
  * Holds if `n1` to `n2` is a dataflow step that creates a JEXL script using an unsafe engine
@@ -99,19 +122,15 @@ private predicate createJexlTemplateStep(DataFlow::Node n1, DataFlow::Node n2) {
 /**
  * Holds if `expr` is a JEXL engine that is configured with a sandbox.
  */
-private predicate isSafeEngine(Expr expr) {
-  exists(SandboxedJexlFlowConfig config | config.hasFlowTo(DataFlow::exprNode(expr)))
-}
+private predicate isSafeEngine(Expr expr) { SandboxedJexlFlow::hasFlowToExpr(expr) }
 
 /**
  * A configuration for tracking sandboxed JEXL engines.
  */
-private class SandboxedJexlFlowConfig extends DataFlow2::Configuration {
-  SandboxedJexlFlowConfig() { this = "JexlInjection::SandboxedJexlFlowConfig" }
+private module SandboxedJexlFlowConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node node) { node instanceof SandboxedJexlSource }
 
-  override predicate isSource(DataFlow::Node node) { node instanceof SandboxedJexlSource }
-
-  override predicate isSink(DataFlow::Node node) {
+  predicate isSink(DataFlow::Node node) {
     exists(MethodAccess ma, Method m |
       m instanceof CreateJexlScriptMethod or
       m instanceof CreateJexlExpressionMethod or
@@ -121,10 +140,12 @@ private class SandboxedJexlFlowConfig extends DataFlow2::Configuration {
     )
   }
 
-  override predicate isAdditionalFlowStep(DataFlow::Node fromNode, DataFlow::Node toNode) {
+  predicate isAdditionalFlowStep(DataFlow::Node fromNode, DataFlow::Node toNode) {
     createJexlEngineStep(fromNode, toNode)
   }
 }
+
+private module SandboxedJexlFlow = DataFlow::Make<SandboxedJexlFlowConfig>;
 
 /**
  * Defines a data flow source for JEXL engines configured with a sandbox.

--- a/java/ql/lib/semmle/code/java/security/JexlInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/JexlInjectionQuery.qll
@@ -76,7 +76,7 @@ module JexlInjectionConfig implements DataFlow::ConfigSig {
  * Tracks unsafe user input that is used to construct and evaluate a JEXL expression.
  * It supports both JEXL 2 and 3.
  */
-module JexlInjectionFlow = TaintTracking::Make<JexlInjectionConfig>;
+module JexlInjectionFlow = TaintTracking::Global<JexlInjectionConfig>;
 
 /**
  * Holds if `n1` to `n2` is a dataflow step that creates a JEXL script using an unsafe engine
@@ -122,7 +122,7 @@ private predicate createJexlTemplateStep(DataFlow::Node n1, DataFlow::Node n2) {
 /**
  * Holds if `expr` is a JEXL engine that is configured with a sandbox.
  */
-private predicate isSafeEngine(Expr expr) { SandboxedJexlFlow::hasFlowToExpr(expr) }
+private predicate isSafeEngine(Expr expr) { SandboxedJexlFlow::flowToExpr(expr) }
 
 /**
  * A configuration for tracking sandboxed JEXL engines.
@@ -145,7 +145,7 @@ private module SandboxedJexlFlowConfig implements DataFlow::ConfigSig {
   }
 }
 
-private module SandboxedJexlFlow = DataFlow::Make<SandboxedJexlFlowConfig>;
+private module SandboxedJexlFlow = DataFlow::Global<SandboxedJexlFlowConfig>;
 
 /**
  * Defines a data flow source for JEXL engines configured with a sandbox.

--- a/java/ql/lib/semmle/code/java/security/JndiInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/JndiInjectionQuery.qll
@@ -32,7 +32,7 @@ deprecated class JndiInjectionFlowConfig extends TaintTracking::Configuration {
 /**
  * A taint-tracking configuration for unvalidated user input that is used in JNDI lookup.
  */
-private module JndiInjectionFlowConfig implements DataFlow::ConfigSig {
+module JndiInjectionFlowConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof JndiInjectionSink }

--- a/java/ql/lib/semmle/code/java/security/JndiInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/JndiInjectionQuery.qll
@@ -47,14 +47,14 @@ module JndiInjectionFlowConfig implements DataFlow::ConfigSig {
 }
 
 /** Tracks flow of unvalidated user input that is used in JNDI lookup */
-module JndiInjectionFlow = TaintTracking::Make<JndiInjectionFlowConfig>;
+module JndiInjectionFlow = TaintTracking::Global<JndiInjectionFlowConfig>;
 
 /**
  * A method that does a JNDI lookup when it receives a `SearchControls` argument with `setReturningObjFlag` = `true`
  */
 private class UnsafeSearchControlsSink extends JndiInjectionSink {
   UnsafeSearchControlsSink() {
-    exists(MethodAccess ma | UnsafeSearchControlsFlow::hasFlowToExpr(ma.getAnArgument()) |
+    exists(MethodAccess ma | UnsafeSearchControlsFlow::flowToExpr(ma.getAnArgument()) |
       this.asExpr() = ma.getArgument(0)
     )
   }
@@ -70,7 +70,7 @@ private module UnsafeSearchControlsConfig implements DataFlow::ConfigSig {
   predicate isSink(DataFlow::Node sink) { sink instanceof UnsafeSearchControlsArgument }
 }
 
-private module UnsafeSearchControlsFlow = DataFlow::Make<UnsafeSearchControlsConfig>;
+private module UnsafeSearchControlsFlow = DataFlow::Global<UnsafeSearchControlsConfig>;
 
 /**
  * An argument of type `SearchControls` of an `LdapOperations.search` or `DirContext.search` call.

--- a/java/ql/lib/semmle/code/java/security/JndiInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/JndiInjectionQuery.qll
@@ -7,9 +7,11 @@ import semmle.code.java.frameworks.SpringLdap
 import semmle.code.java.security.JndiInjection
 
 /**
+ * DEPRECATED: Use `JndiInjectionFlow` instead.
+ *
  * A taint-tracking configuration for unvalidated user input that is used in JNDI lookup.
  */
-class JndiInjectionFlowConfig extends TaintTracking::Configuration {
+deprecated class JndiInjectionFlowConfig extends TaintTracking::Configuration {
   JndiInjectionFlowConfig() { this = "JndiInjectionFlowConfig" }
 
   override predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
@@ -28,13 +30,31 @@ class JndiInjectionFlowConfig extends TaintTracking::Configuration {
 }
 
 /**
+ * A taint-tracking configuration for unvalidated user input that is used in JNDI lookup.
+ */
+private module JndiInjectionFlowConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+
+  predicate isSink(DataFlow::Node sink) { sink instanceof JndiInjectionSink }
+
+  predicate isBarrier(DataFlow::Node node) {
+    node.getType() instanceof PrimitiveType or node.getType() instanceof BoxedType
+  }
+
+  predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
+    any(JndiInjectionAdditionalTaintStep c).step(node1, node2)
+  }
+}
+
+/** Tracks flow of unvalidated user input that is used in JNDI lookup */
+module JndiInjectionFlow = TaintTracking::Make<JndiInjectionFlowConfig>;
+
+/**
  * A method that does a JNDI lookup when it receives a `SearchControls` argument with `setReturningObjFlag` = `true`
  */
 private class UnsafeSearchControlsSink extends JndiInjectionSink {
   UnsafeSearchControlsSink() {
-    exists(UnsafeSearchControlsConf conf, MethodAccess ma |
-      conf.hasFlowTo(DataFlow::exprNode(ma.getAnArgument()))
-    |
+    exists(MethodAccess ma | UnsafeSearchControlsFlow::hasFlowToExpr(ma.getAnArgument()) |
       this.asExpr() = ma.getArgument(0)
     )
   }
@@ -44,13 +64,13 @@ private class UnsafeSearchControlsSink extends JndiInjectionSink {
  * Find flows between a `SearchControls` object with `setReturningObjFlag` = `true`
  * and an argument of an `LdapOperations.search` or `DirContext.search` call.
  */
-private class UnsafeSearchControlsConf extends DataFlow2::Configuration {
-  UnsafeSearchControlsConf() { this = "UnsafeSearchControlsConf" }
+private module UnsafeSearchControlsConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { source instanceof UnsafeSearchControls }
 
-  override predicate isSource(DataFlow::Node source) { source instanceof UnsafeSearchControls }
-
-  override predicate isSink(DataFlow::Node sink) { sink instanceof UnsafeSearchControlsArgument }
+  predicate isSink(DataFlow::Node sink) { sink instanceof UnsafeSearchControlsArgument }
 }
+
+private module UnsafeSearchControlsFlow = DataFlow::Make<UnsafeSearchControlsConfig>;
 
 /**
  * An argument of type `SearchControls` of an `LdapOperations.search` or `DirContext.search` call.

--- a/java/ql/lib/semmle/code/java/security/JndiInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/JndiInjectionQuery.qll
@@ -38,7 +38,9 @@ module JndiInjectionFlowConfig implements DataFlow::ConfigSig {
   predicate isSink(DataFlow::Node sink) { sink instanceof JndiInjectionSink }
 
   predicate isBarrier(DataFlow::Node node) {
-    node.getType() instanceof PrimitiveType or node.getType() instanceof BoxedType
+    node.getType() instanceof PrimitiveType or
+    node.getType() instanceof BoxedType or
+    node instanceof JndiInjectionSanitizer
   }
 
   predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {

--- a/java/ql/lib/semmle/code/java/security/MvelInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/MvelInjectionQuery.qll
@@ -31,7 +31,7 @@ deprecated class MvelInjectionFlowConfig extends TaintTracking::Configuration {
  * A taint-tracking configuration for unsafe user input
  * that is used to construct and evaluate a MVEL expression.
  */
-private module MvelInjectionFlowConfig implements DataFlow::ConfigSig {
+module MvelInjectionFlowConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof MvelEvaluationSink }

--- a/java/ql/lib/semmle/code/java/security/MvelInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/MvelInjectionQuery.qll
@@ -44,4 +44,4 @@ module MvelInjectionFlowConfig implements DataFlow::ConfigSig {
 }
 
 /** Tracks flow of unsafe user input that is used to construct and evaluate a MVEL expression. */
-module MvelInjectionFlow = TaintTracking::Make<MvelInjectionFlowConfig>;
+module MvelInjectionFlow = TaintTracking::Global<MvelInjectionFlowConfig>;

--- a/java/ql/lib/semmle/code/java/security/MvelInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/MvelInjectionQuery.qll
@@ -6,10 +6,12 @@ import semmle.code.java.dataflow.TaintTracking
 import semmle.code.java.security.MvelInjection
 
 /**
+ * DEPRECATED: Use `MvelInjectionFlow` instead.
+ *
  * A taint-tracking configuration for unsafe user input
  * that is used to construct and evaluate a MVEL expression.
  */
-class MvelInjectionFlowConfig extends TaintTracking::Configuration {
+deprecated class MvelInjectionFlowConfig extends TaintTracking::Configuration {
   MvelInjectionFlowConfig() { this = "MvelInjectionFlowConfig" }
 
   override predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
@@ -24,3 +26,22 @@ class MvelInjectionFlowConfig extends TaintTracking::Configuration {
     any(MvelInjectionAdditionalTaintStep c).step(node1, node2)
   }
 }
+
+/**
+ * A taint-tracking configuration for unsafe user input
+ * that is used to construct and evaluate a MVEL expression.
+ */
+private module MvelInjectionFlowConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+
+  predicate isSink(DataFlow::Node sink) { sink instanceof MvelEvaluationSink }
+
+  predicate isBarrier(DataFlow::Node sanitizer) { sanitizer instanceof MvelInjectionSanitizer }
+
+  predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
+    any(MvelInjectionAdditionalTaintStep c).step(node1, node2)
+  }
+}
+
+/** Tracks flow of unsafe user input that is used to construct and evaluate a MVEL expression. */
+module MvelInjectionFlow = TaintTracking::Make<MvelInjectionFlowConfig>;

--- a/java/ql/lib/semmle/code/java/security/OgnlInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/OgnlInjectionQuery.qll
@@ -5,9 +5,11 @@ import semmle.code.java.dataflow.FlowSources
 import semmle.code.java.security.OgnlInjection
 
 /**
+ * DEPRECATED: Use `OgnlInjectionFlow` instead.
+ *
  * A taint-tracking configuration for unvalidated user input that is used in OGNL EL evaluation.
  */
-class OgnlInjectionFlowConfig extends TaintTracking::Configuration {
+deprecated class OgnlInjectionFlowConfig extends TaintTracking::Configuration {
   OgnlInjectionFlowConfig() { this = "OgnlInjectionFlowConfig" }
 
   override predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
@@ -22,3 +24,23 @@ class OgnlInjectionFlowConfig extends TaintTracking::Configuration {
     any(OgnlInjectionAdditionalTaintStep c).step(node1, node2)
   }
 }
+
+/**
+ * A taint-tracking configuration for unvalidated user input that is used in OGNL EL evaluation.
+ */
+private module OgnlInjectionFlowConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+
+  predicate isSink(DataFlow::Node sink) { sink instanceof OgnlInjectionSink }
+
+  predicate isBarrier(DataFlow::Node node) {
+    node.getType() instanceof PrimitiveType or node.getType() instanceof BoxedType
+  }
+
+  predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
+    any(OgnlInjectionAdditionalTaintStep c).step(node1, node2)
+  }
+}
+
+/** Tracks flow of unvalidated user input that is used in OGNL EL evaluation. */
+module OgnlInjectionFlow = TaintTracking::Make<OgnlInjectionFlowConfig>;

--- a/java/ql/lib/semmle/code/java/security/OgnlInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/OgnlInjectionQuery.qll
@@ -43,4 +43,4 @@ module OgnlInjectionFlowConfig implements DataFlow::ConfigSig {
 }
 
 /** Tracks flow of unvalidated user input that is used in OGNL EL evaluation. */
-module OgnlInjectionFlow = TaintTracking::Make<OgnlInjectionFlowConfig>;
+module OgnlInjectionFlow = TaintTracking::Global<OgnlInjectionFlowConfig>;

--- a/java/ql/lib/semmle/code/java/security/OgnlInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/OgnlInjectionQuery.qll
@@ -28,7 +28,7 @@ deprecated class OgnlInjectionFlowConfig extends TaintTracking::Configuration {
 /**
  * A taint-tracking configuration for unvalidated user input that is used in OGNL EL evaluation.
  */
-private module OgnlInjectionFlowConfig implements DataFlow::ConfigSig {
+module OgnlInjectionFlowConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof OgnlInjectionSink }

--- a/java/ql/lib/semmle/code/java/security/SpelInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/SpelInjectionQuery.qll
@@ -28,7 +28,7 @@ deprecated class SpelInjectionConfig extends TaintTracking::Configuration {
  * A taint-tracking configuration for unsafe user input
  * that is used to construct and evaluate a SpEL expression.
  */
-private module SpelInjectionConfig implements DataFlow::ConfigSig {
+module SpelInjectionConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof SpelExpressionEvaluationSink }

--- a/java/ql/lib/semmle/code/java/security/SpelInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/SpelInjectionQuery.qll
@@ -39,7 +39,7 @@ module SpelInjectionConfig implements DataFlow::ConfigSig {
 }
 
 /** Tracks flow of unsafe user input that is used to construct and evaluate a SpEL expression. */
-module SpelInjectionFlow = TaintTracking::Make<SpelInjectionConfig>;
+module SpelInjectionFlow = TaintTracking::Global<SpelInjectionConfig>;
 
 /** Default sink for SpEL injection vulnerabilities. */
 private class DefaultSpelExpressionEvaluationSink extends SpelExpressionEvaluationSink {
@@ -47,7 +47,7 @@ private class DefaultSpelExpressionEvaluationSink extends SpelExpressionEvaluati
     exists(MethodAccess ma |
       ma.getMethod() instanceof ExpressionEvaluationMethod and
       ma.getQualifier() = this.asExpr() and
-      not SafeEvaluationContextFlow::hasFlowToExpr(ma.getArgument(0))
+      not SafeEvaluationContextFlow::flowToExpr(ma.getArgument(0))
     )
   }
 }
@@ -68,7 +68,7 @@ private module SafeEvaluationContextFlowConfig implements DataFlow::ConfigSig {
   int fieldFlowBranchLimit() { result = 0 }
 }
 
-private module SafeEvaluationContextFlow = DataFlow::Make<SafeEvaluationContextFlowConfig>;
+private module SafeEvaluationContextFlow = DataFlow::Global<SafeEvaluationContextFlowConfig>;
 
 /**
  * A `ContextSource` that is safe from SpEL injection.

--- a/java/ql/lib/semmle/code/java/security/SpelInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/SpelInjectionQuery.qll
@@ -7,10 +7,12 @@ private import semmle.code.java.frameworks.spring.SpringExpression
 private import semmle.code.java.security.SpelInjection
 
 /**
+ * DEPRECATED: Use `SpelInjectionFlow` instead.
+ *
  * A taint-tracking configuration for unsafe user input
  * that is used to construct and evaluate a SpEL expression.
  */
-class SpelInjectionConfig extends TaintTracking::Configuration {
+deprecated class SpelInjectionConfig extends TaintTracking::Configuration {
   SpelInjectionConfig() { this = "SpelInjectionConfig" }
 
   override predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
@@ -22,15 +24,30 @@ class SpelInjectionConfig extends TaintTracking::Configuration {
   }
 }
 
+/**
+ * A taint-tracking configuration for unsafe user input
+ * that is used to construct and evaluate a SpEL expression.
+ */
+private module SpelInjectionConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+
+  predicate isSink(DataFlow::Node sink) { sink instanceof SpelExpressionEvaluationSink }
+
+  predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
+    any(SpelExpressionInjectionAdditionalTaintStep c).step(node1, node2)
+  }
+}
+
+/** Tracks flow of unsafe user input that is used to construct and evaluate a SpEL expression. */
+module SpelInjectionFlow = TaintTracking::Make<SpelInjectionConfig>;
+
 /** Default sink for SpEL injection vulnerabilities. */
 private class DefaultSpelExpressionEvaluationSink extends SpelExpressionEvaluationSink {
   DefaultSpelExpressionEvaluationSink() {
     exists(MethodAccess ma |
       ma.getMethod() instanceof ExpressionEvaluationMethod and
       ma.getQualifier() = this.asExpr() and
-      not exists(SafeEvaluationContextFlowConfig config |
-        config.hasFlowTo(DataFlow::exprNode(ma.getArgument(0)))
-      )
+      not SafeEvaluationContextFlow::hasFlowToExpr(ma.getArgument(0))
     )
   }
 }
@@ -38,20 +55,20 @@ private class DefaultSpelExpressionEvaluationSink extends SpelExpressionEvaluati
 /**
  * A configuration for safe evaluation context that may be used in expression evaluation.
  */
-private class SafeEvaluationContextFlowConfig extends DataFlow2::Configuration {
-  SafeEvaluationContextFlowConfig() { this = "SpelInjection::SafeEvaluationContextFlowConfig" }
+private module SafeEvaluationContextFlowConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { source instanceof SafeContextSource }
 
-  override predicate isSource(DataFlow::Node source) { source instanceof SafeContextSource }
-
-  override predicate isSink(DataFlow::Node sink) {
+  predicate isSink(DataFlow::Node sink) {
     exists(MethodAccess ma |
       ma.getMethod() instanceof ExpressionEvaluationMethod and
       ma.getArgument(0) = sink.asExpr()
     )
   }
 
-  override int fieldFlowBranchLimit() { result = 0 }
+  int fieldFlowBranchLimit() { result = 0 }
 }
+
+private module SafeEvaluationContextFlow = DataFlow::Make<SafeEvaluationContextFlowConfig>;
 
 /**
  * A `ContextSource` that is safe from SpEL injection.

--- a/java/ql/lib/semmle/code/java/security/SqlInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/SqlInjectionQuery.qll
@@ -11,9 +11,11 @@ import semmle.code.java.dataflow.FlowSources
 import semmle.code.java.security.QueryInjection
 
 /**
+ * DEPRECATED: Use `QueryInjectionFlow` instead.
+ *
  * A taint-tracking configuration for unvalidated user input that is used in SQL queries.
  */
-class QueryInjectionFlowConfig extends TaintTracking::Configuration {
+deprecated class QueryInjectionFlowConfig extends TaintTracking::Configuration {
   QueryInjectionFlowConfig() { this = "SqlInjectionLib::QueryInjectionFlowConfig" }
 
   override predicate isSource(DataFlow::Node src) { src instanceof RemoteFlowSource }
@@ -32,11 +34,33 @@ class QueryInjectionFlowConfig extends TaintTracking::Configuration {
 }
 
 /**
+ * A taint-tracking configuration for unvalidated user input that is used in SQL queries.
+ */
+private module QueryInjectionFlowConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node src) { src instanceof RemoteFlowSource }
+
+  predicate isSink(DataFlow::Node sink) { sink instanceof QueryInjectionSink }
+
+  predicate isBarrier(DataFlow::Node node) {
+    node.getType() instanceof PrimitiveType or
+    node.getType() instanceof BoxedType or
+    node.getType() instanceof NumberType
+  }
+
+  predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
+    any(AdditionalQueryInjectionTaintStep s).step(node1, node2)
+  }
+}
+
+/** Tracks flow of unvalidated user input that is used in SQL queries. */
+module QueryInjectionFlow = TaintTracking::Make<QueryInjectionFlowConfig>;
+
+/**
  * Implementation of `SqlTainted.ql`. This is extracted to a QLL so that it
  * can be excluded from `SqlConcatenated.ql` to avoid overlapping results.
  */
 predicate queryTaintedBy(
-  QueryInjectionSink query, DataFlow::PathNode source, DataFlow::PathNode sink
+  QueryInjectionSink query, QueryInjectionFlow::PathNode source, QueryInjectionFlow::PathNode sink
 ) {
-  exists(QueryInjectionFlowConfig conf | conf.hasFlowPath(source, sink) and sink.getNode() = query)
+  QueryInjectionFlow::hasFlowPath(source, sink) and sink.getNode() = query
 }

--- a/java/ql/lib/semmle/code/java/security/SqlInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/SqlInjectionQuery.qll
@@ -59,7 +59,17 @@ module QueryInjectionFlow = TaintTracking::Global<QueryInjectionFlowConfig>;
  * Implementation of `SqlTainted.ql`. This is extracted to a QLL so that it
  * can be excluded from `SqlConcatenated.ql` to avoid overlapping results.
  */
-predicate queryTaintedBy(
+deprecated predicate queryTaintedBy(
+  QueryInjectionSink query, DataFlow::PathNode source, DataFlow::PathNode sink
+) {
+  any(QueryInjectionFlowConfig c).hasFlowPath(source, sink) and sink.getNode() = query
+}
+
+/**
+ * Implementation of `SqlTainted.ql`. This is extracted to a QLL so that it
+ * can be excluded from `SqlConcatenated.ql` to avoid overlapping results.
+ */
+predicate queryIsTaintedBy(
   QueryInjectionSink query, QueryInjectionFlow::PathNode source, QueryInjectionFlow::PathNode sink
 ) {
   QueryInjectionFlow::flowPath(source, sink) and sink.getNode() = query

--- a/java/ql/lib/semmle/code/java/security/SqlInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/SqlInjectionQuery.qll
@@ -36,7 +36,7 @@ deprecated class QueryInjectionFlowConfig extends TaintTracking::Configuration {
 /**
  * A taint-tracking configuration for unvalidated user input that is used in SQL queries.
  */
-private module QueryInjectionFlowConfig implements DataFlow::ConfigSig {
+module QueryInjectionFlowConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node src) { src instanceof RemoteFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof QueryInjectionSink }

--- a/java/ql/lib/semmle/code/java/security/SqlInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/SqlInjectionQuery.qll
@@ -53,7 +53,7 @@ module QueryInjectionFlowConfig implements DataFlow::ConfigSig {
 }
 
 /** Tracks flow of unvalidated user input that is used in SQL queries. */
-module QueryInjectionFlow = TaintTracking::Make<QueryInjectionFlowConfig>;
+module QueryInjectionFlow = TaintTracking::Global<QueryInjectionFlowConfig>;
 
 /**
  * Implementation of `SqlTainted.ql`. This is extracted to a QLL so that it
@@ -62,5 +62,5 @@ module QueryInjectionFlow = TaintTracking::Make<QueryInjectionFlowConfig>;
 predicate queryTaintedBy(
   QueryInjectionSink query, QueryInjectionFlow::PathNode source, QueryInjectionFlow::PathNode sink
 ) {
-  QueryInjectionFlow::hasFlowPath(source, sink) and sink.getNode() = query
+  QueryInjectionFlow::flowPath(source, sink) and sink.getNode() = query
 }

--- a/java/ql/lib/semmle/code/java/security/TemplateInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/TemplateInjectionQuery.qll
@@ -5,8 +5,12 @@ import semmle.code.java.dataflow.TaintTracking
 import semmle.code.java.dataflow.FlowSources
 import semmle.code.java.security.TemplateInjection
 
-/** A taint tracking configuration to reason about server-side template injection (SST) vulnerabilities */
-class TemplateInjectionFlowConfig extends TaintTracking::Configuration {
+/**
+ * DEPRECATED: Use `TemplateInjectionFlow` instead.
+ *
+ * A taint tracking configuration to reason about server-side template injection (SST) vulnerabilities
+ */
+deprecated class TemplateInjectionFlowConfig extends TaintTracking::Configuration {
   TemplateInjectionFlowConfig() { this = "TemplateInjectionFlowConfig" }
 
   override predicate isSource(DataFlow::Node source, DataFlow::FlowState state) {
@@ -36,3 +40,35 @@ class TemplateInjectionFlowConfig extends TaintTracking::Configuration {
     any(TemplateInjectionAdditionalTaintStep a).isAdditionalTaintStep(node1, state1, node2, state2)
   }
 }
+
+/** A taint tracking configuration to reason about server-side template injection (SST) vulnerabilities */
+private module TemplateInjectionFlowConfig implements DataFlow::StateConfigSig {
+  class FlowState = DataFlow::FlowState;
+
+  predicate isSource(DataFlow::Node source, FlowState state) {
+    source.(TemplateInjectionSource).hasState(state)
+  }
+
+  predicate isSink(DataFlow::Node sink, FlowState state) {
+    sink.(TemplateInjectionSink).hasState(state)
+  }
+
+  predicate isBarrier(DataFlow::Node sanitizer) { sanitizer instanceof TemplateInjectionSanitizer }
+
+  predicate isBarrier(DataFlow::Node sanitizer, FlowState state) {
+    sanitizer.(TemplateInjectionSanitizerWithState).hasState(state)
+  }
+
+  predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
+    any(TemplateInjectionAdditionalTaintStep a).isAdditionalTaintStep(node1, node2)
+  }
+
+  predicate isAdditionalFlowStep(
+    DataFlow::Node node1, FlowState state1, DataFlow::Node node2, FlowState state2
+  ) {
+    any(TemplateInjectionAdditionalTaintStep a).isAdditionalTaintStep(node1, state1, node2, state2)
+  }
+}
+
+/** Tracks server-side template injection (SST) vulnerabilities */
+module TemplateInjectionFlow = TaintTracking::MakeWithState<TemplateInjectionFlowConfig>;

--- a/java/ql/lib/semmle/code/java/security/TemplateInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/TemplateInjectionQuery.qll
@@ -71,4 +71,4 @@ module TemplateInjectionFlowConfig implements DataFlow::StateConfigSig {
 }
 
 /** Tracks server-side template injection (SST) vulnerabilities */
-module TemplateInjectionFlow = TaintTracking::MakeWithState<TemplateInjectionFlowConfig>;
+module TemplateInjectionFlow = TaintTracking::GlobalWithState<TemplateInjectionFlowConfig>;

--- a/java/ql/lib/semmle/code/java/security/TemplateInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/TemplateInjectionQuery.qll
@@ -42,7 +42,7 @@ deprecated class TemplateInjectionFlowConfig extends TaintTracking::Configuratio
 }
 
 /** A taint tracking configuration to reason about server-side template injection (SST) vulnerabilities */
-private module TemplateInjectionFlowConfig implements DataFlow::StateConfigSig {
+module TemplateInjectionFlowConfig implements DataFlow::StateConfigSig {
   class FlowState = DataFlow::FlowState;
 
   predicate isSource(DataFlow::Node source, FlowState state) {

--- a/java/ql/lib/semmle/code/java/security/XsltInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/XsltInjectionQuery.qll
@@ -47,7 +47,7 @@ module XsltInjectionFlowConfig implements DataFlow::ConfigSig {
 /**
  * Tracks flow from unvalidated user input to XSLT transformation.
  */
-module XsltInjectionFlow = TaintTracking::Make<XsltInjectionFlowConfig>;
+module XsltInjectionFlow = TaintTracking::Global<XsltInjectionFlowConfig>;
 
 /**
  * A set of additional taint steps to consider when taint tracking XSLT related data flows.
@@ -70,7 +70,7 @@ private predicate newTransformerOrTemplatesStep(DataFlow::Node n1, DataFlow::Nod
     n2.asExpr() = ma and
     m.getDeclaringType() instanceof TransformerFactory and
     m.hasName(["newTransformer", "newTemplates"]) and
-    not TransformerFactoryWithSecureProcessingFeatureFlow::hasFlowToExpr(ma.getQualifier())
+    not TransformerFactoryWithSecureProcessingFeatureFlow::flowToExpr(ma.getQualifier())
   )
 }
 
@@ -99,7 +99,7 @@ private module TransformerFactoryWithSecureProcessingFeatureFlowConfig implement
 }
 
 private module TransformerFactoryWithSecureProcessingFeatureFlow =
-  DataFlow::Make<TransformerFactoryWithSecureProcessingFeatureFlowConfig>;
+  DataFlow::Global<TransformerFactoryWithSecureProcessingFeatureFlowConfig>;
 
 /** A `ParserConfig` specific to `TransformerFactory`. */
 private class TransformerFactoryFeatureConfig extends ParserConfig {

--- a/java/ql/lib/semmle/code/java/security/XsltInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/XsltInjectionQuery.qll
@@ -30,7 +30,7 @@ deprecated class XsltInjectionFlowConfig extends TaintTracking::Configuration {
 /**
  * A taint-tracking configuration for unvalidated user input that is used in XSLT transformation.
  */
-private module XsltInjectionFlowConfig implements DataFlow::ConfigSig {
+module XsltInjectionFlowConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof XsltInjectionSink }

--- a/java/ql/lib/semmle/code/java/security/regexp/RegexInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/regexp/RegexInjectionQuery.qll
@@ -23,7 +23,7 @@ deprecated class RegexInjectionConfiguration extends TaintTracking::Configuratio
 /**
  * A taint-tracking configuration for untrusted user input used to construct regular expressions.
  */
-private module RegexInjectionConfig implements DataFlow::ConfigSig {
+module RegexInjectionConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof RegexInjectionSink }

--- a/java/ql/lib/semmle/code/java/security/regexp/RegexInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/regexp/RegexInjectionQuery.qll
@@ -31,4 +31,4 @@ module RegexInjectionConfig implements DataFlow::ConfigSig {
   predicate isBarrier(DataFlow::Node node) { node instanceof RegexInjectionSanitizer }
 }
 
-module RegexInjectionFlow = TaintTracking::Make<RegexInjectionConfig>;
+module RegexInjectionFlow = TaintTracking::Global<RegexInjectionConfig>;

--- a/java/ql/lib/semmle/code/java/security/regexp/RegexInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/regexp/RegexInjectionQuery.qll
@@ -5,8 +5,12 @@ import semmle.code.java.dataflow.FlowSources
 import semmle.code.java.dataflow.TaintTracking
 import semmle.code.java.security.regexp.RegexInjection
 
-/** A taint-tracking configuration for untrusted user input used to construct regular expressions. */
-class RegexInjectionConfiguration extends TaintTracking::Configuration {
+/**
+ * DEPRECATED: Use `RegexInjectionFlow` instead.
+ *
+ * A taint-tracking configuration for untrusted user input used to construct regular expressions.
+ */
+deprecated class RegexInjectionConfiguration extends TaintTracking::Configuration {
   RegexInjectionConfiguration() { this = "RegexInjection" }
 
   override predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
@@ -15,3 +19,16 @@ class RegexInjectionConfiguration extends TaintTracking::Configuration {
 
   override predicate isSanitizer(DataFlow::Node node) { node instanceof RegexInjectionSanitizer }
 }
+
+/**
+ * A taint-tracking configuration for untrusted user input used to construct regular expressions.
+ */
+private module RegexInjectionConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+
+  predicate isSink(DataFlow::Node sink) { sink instanceof RegexInjectionSink }
+
+  predicate isBarrier(DataFlow::Node node) { node instanceof RegexInjectionSanitizer }
+}
+
+module RegexInjectionFlow = TaintTracking::Make<RegexInjectionConfig>;

--- a/java/ql/lib/semmle/code/java/security/regexp/RegexInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/regexp/RegexInjectionQuery.qll
@@ -31,4 +31,7 @@ module RegexInjectionConfig implements DataFlow::ConfigSig {
   predicate isBarrier(DataFlow::Node node) { node instanceof RegexInjectionSanitizer }
 }
 
+/**
+ * Taint-tracking flow for untrusted user input used to construct regular expressions.
+ */
 module RegexInjectionFlow = TaintTracking::Global<RegexInjectionConfig>;

--- a/java/ql/src/Security/CWE/CWE-074/JndiInjection.ql
+++ b/java/ql/src/Security/CWE/CWE-074/JndiInjection.ql
@@ -13,9 +13,9 @@
 
 import java
 import semmle.code.java.security.JndiInjectionQuery
-import DataFlow::PathGraph
+import JndiInjectionFlow::PathGraph
 
-from DataFlow::PathNode source, DataFlow::PathNode sink, JndiInjectionFlowConfig conf
-where conf.hasFlowPath(source, sink)
+from JndiInjectionFlow::PathNode source, JndiInjectionFlow::PathNode sink
+where JndiInjectionFlow::hasFlowPath(source, sink)
 select sink.getNode(), source, sink, "JNDI lookup might include name from $@.", source.getNode(),
   "this user input"

--- a/java/ql/src/Security/CWE/CWE-074/JndiInjection.ql
+++ b/java/ql/src/Security/CWE/CWE-074/JndiInjection.ql
@@ -16,6 +16,6 @@ import semmle.code.java.security.JndiInjectionQuery
 import JndiInjectionFlow::PathGraph
 
 from JndiInjectionFlow::PathNode source, JndiInjectionFlow::PathNode sink
-where JndiInjectionFlow::hasFlowPath(source, sink)
+where JndiInjectionFlow::flowPath(source, sink)
 select sink.getNode(), source, sink, "JNDI lookup might include name from $@.", source.getNode(),
   "this user input"

--- a/java/ql/src/Security/CWE/CWE-074/XsltInjection.ql
+++ b/java/ql/src/Security/CWE/CWE-074/XsltInjection.ql
@@ -13,9 +13,9 @@
 
 import java
 import semmle.code.java.security.XsltInjectionQuery
-import DataFlow::PathGraph
+import XsltInjectionFlow::PathGraph
 
-from DataFlow::PathNode source, DataFlow::PathNode sink, XsltInjectionFlowConfig conf
-where conf.hasFlowPath(source, sink)
+from XsltInjectionFlow::PathNode source, XsltInjectionFlow::PathNode sink
+where XsltInjectionFlow::hasFlowPath(source, sink)
 select sink.getNode(), source, sink, "XSLT transformation might include stylesheet from $@.",
   source.getNode(), "this user input"

--- a/java/ql/src/Security/CWE/CWE-074/XsltInjection.ql
+++ b/java/ql/src/Security/CWE/CWE-074/XsltInjection.ql
@@ -16,6 +16,6 @@ import semmle.code.java.security.XsltInjectionQuery
 import XsltInjectionFlow::PathGraph
 
 from XsltInjectionFlow::PathNode source, XsltInjectionFlow::PathNode sink
-where XsltInjectionFlow::hasFlowPath(source, sink)
+where XsltInjectionFlow::flowPath(source, sink)
 select sink.getNode(), source, sink, "XSLT transformation might include stylesheet from $@.",
   source.getNode(), "this user input"

--- a/java/ql/src/Security/CWE/CWE-089/SqlConcatenated.ql
+++ b/java/ql/src/Security/CWE/CWE-089/SqlConcatenated.ql
@@ -48,6 +48,6 @@ where
       UncontrolledStringBuilderSourceFlow::flow(DataFlow::exprNode(sbv.getToStringCall()), query)
     )
   ) and
-  not queryTaintedBy(query, _, _)
+  not queryIsTaintedBy(query, _, _)
 select query, "Query built by concatenation with $@, which may be untrusted.", uncontrolled,
   "this expression"

--- a/java/ql/src/Security/CWE/CWE-089/SqlTainted.ql
+++ b/java/ql/src/Security/CWE/CWE-089/SqlTainted.ql
@@ -15,8 +15,9 @@
 import java
 import semmle.code.java.dataflow.FlowSources
 import semmle.code.java.security.SqlInjectionQuery
-import DataFlow::PathGraph
+import QueryInjectionFlow::PathGraph
 
-from QueryInjectionSink query, DataFlow::PathNode source, DataFlow::PathNode sink
+from
+  QueryInjectionSink query, QueryInjectionFlow::PathNode source, QueryInjectionFlow::PathNode sink
 where queryTaintedBy(query, source, sink)
 select query, source, sink, "This query depends on a $@.", source.getNode(), "user-provided value"

--- a/java/ql/src/Security/CWE/CWE-089/SqlTainted.ql
+++ b/java/ql/src/Security/CWE/CWE-089/SqlTainted.ql
@@ -19,5 +19,5 @@ import QueryInjectionFlow::PathGraph
 
 from
   QueryInjectionSink query, QueryInjectionFlow::PathNode source, QueryInjectionFlow::PathNode sink
-where queryTaintedBy(query, source, sink)
+where queryIsTaintedBy(query, source, sink)
 select query, source, sink, "This query depends on a $@.", source.getNode(), "user-provided value"

--- a/java/ql/src/Security/CWE/CWE-094/GroovyInjection.ql
+++ b/java/ql/src/Security/CWE/CWE-094/GroovyInjection.ql
@@ -13,9 +13,9 @@
 
 import java
 import semmle.code.java.security.GroovyInjectionQuery
-import DataFlow::PathGraph
+import GroovyInjectionFlow::PathGraph
 
-from DataFlow::PathNode source, DataFlow::PathNode sink, GroovyInjectionConfig conf
-where conf.hasFlowPath(source, sink)
+from GroovyInjectionFlow::PathNode source, GroovyInjectionFlow::PathNode sink
+where GroovyInjectionFlow::hasFlowPath(source, sink)
 select sink.getNode(), source, sink, "Groovy script depends on a $@.", source.getNode(),
   "user-provided value"

--- a/java/ql/src/Security/CWE/CWE-094/GroovyInjection.ql
+++ b/java/ql/src/Security/CWE/CWE-094/GroovyInjection.ql
@@ -16,6 +16,6 @@ import semmle.code.java.security.GroovyInjectionQuery
 import GroovyInjectionFlow::PathGraph
 
 from GroovyInjectionFlow::PathNode source, GroovyInjectionFlow::PathNode sink
-where GroovyInjectionFlow::hasFlowPath(source, sink)
+where GroovyInjectionFlow::flowPath(source, sink)
 select sink.getNode(), source, sink, "Groovy script depends on a $@.", source.getNode(),
   "user-provided value"

--- a/java/ql/src/Security/CWE/CWE-094/JexlInjection.ql
+++ b/java/ql/src/Security/CWE/CWE-094/JexlInjection.ql
@@ -16,6 +16,6 @@ import semmle.code.java.security.JexlInjectionQuery
 import JexlInjectionFlow::PathGraph
 
 from JexlInjectionFlow::PathNode source, JexlInjectionFlow::PathNode sink
-where JexlInjectionFlow::hasFlowPath(source, sink)
+where JexlInjectionFlow::flowPath(source, sink)
 select sink.getNode(), source, sink, "JEXL expression depends on a $@.", source.getNode(),
   "user-provided value"

--- a/java/ql/src/Security/CWE/CWE-094/JexlInjection.ql
+++ b/java/ql/src/Security/CWE/CWE-094/JexlInjection.ql
@@ -13,9 +13,9 @@
 
 import java
 import semmle.code.java.security.JexlInjectionQuery
-import DataFlow::PathGraph
+import JexlInjectionFlow::PathGraph
 
-from DataFlow::PathNode source, DataFlow::PathNode sink, JexlInjectionConfig conf
-where conf.hasFlowPath(source, sink)
+from JexlInjectionFlow::PathNode source, JexlInjectionFlow::PathNode sink
+where JexlInjectionFlow::hasFlowPath(source, sink)
 select sink.getNode(), source, sink, "JEXL expression depends on a $@.", source.getNode(),
   "user-provided value"

--- a/java/ql/src/Security/CWE/CWE-094/MvelInjection.ql
+++ b/java/ql/src/Security/CWE/CWE-094/MvelInjection.ql
@@ -13,9 +13,9 @@
 
 import java
 import semmle.code.java.security.MvelInjectionQuery
-import DataFlow::PathGraph
+import MvelInjectionFlow::PathGraph
 
-from DataFlow::PathNode source, DataFlow::PathNode sink, MvelInjectionFlowConfig conf
-where conf.hasFlowPath(source, sink)
+from MvelInjectionFlow::PathNode source, MvelInjectionFlow::PathNode sink
+where MvelInjectionFlow::hasFlowPath(source, sink)
 select sink.getNode(), source, sink, "MVEL expression depends on a $@.", source.getNode(),
   "user-provided value"

--- a/java/ql/src/Security/CWE/CWE-094/MvelInjection.ql
+++ b/java/ql/src/Security/CWE/CWE-094/MvelInjection.ql
@@ -16,6 +16,6 @@ import semmle.code.java.security.MvelInjectionQuery
 import MvelInjectionFlow::PathGraph
 
 from MvelInjectionFlow::PathNode source, MvelInjectionFlow::PathNode sink
-where MvelInjectionFlow::hasFlowPath(source, sink)
+where MvelInjectionFlow::flowPath(source, sink)
 select sink.getNode(), source, sink, "MVEL expression depends on a $@.", source.getNode(),
   "user-provided value"

--- a/java/ql/src/Security/CWE/CWE-094/SpelInjection.ql
+++ b/java/ql/src/Security/CWE/CWE-094/SpelInjection.ql
@@ -14,9 +14,9 @@
 import java
 import semmle.code.java.security.SpelInjectionQuery
 import semmle.code.java.dataflow.DataFlow
-import DataFlow::PathGraph
+import SpelInjectionFlow::PathGraph
 
-from DataFlow::PathNode source, DataFlow::PathNode sink, SpelInjectionConfig conf
-where conf.hasFlowPath(source, sink)
+from SpelInjectionFlow::PathNode source, SpelInjectionFlow::PathNode sink
+where SpelInjectionFlow::hasFlowPath(source, sink)
 select sink.getNode(), source, sink, "SpEL expression depends on a $@.", source.getNode(),
   "user-provided value"

--- a/java/ql/src/Security/CWE/CWE-094/SpelInjection.ql
+++ b/java/ql/src/Security/CWE/CWE-094/SpelInjection.ql
@@ -17,6 +17,6 @@ import semmle.code.java.dataflow.DataFlow
 import SpelInjectionFlow::PathGraph
 
 from SpelInjectionFlow::PathNode source, SpelInjectionFlow::PathNode sink
-where SpelInjectionFlow::hasFlowPath(source, sink)
+where SpelInjectionFlow::flowPath(source, sink)
 select sink.getNode(), source, sink, "SpEL expression depends on a $@.", source.getNode(),
   "user-provided value"

--- a/java/ql/src/Security/CWE/CWE-094/TemplateInjection.ql
+++ b/java/ql/src/Security/CWE/CWE-094/TemplateInjection.ql
@@ -13,9 +13,9 @@
 
 import java
 import semmle.code.java.security.TemplateInjectionQuery
-import DataFlow::PathGraph
+import TemplateInjectionFlow::PathGraph
 
-from TemplateInjectionFlowConfig config, DataFlow::PathNode source, DataFlow::PathNode sink
-where config.hasFlowPath(source, sink)
+from TemplateInjectionFlow::PathNode source, TemplateInjectionFlow::PathNode sink
+where TemplateInjectionFlow::hasFlowPath(source, sink)
 select sink.getNode(), source, sink, "Template, which may contain code, depends on a $@.",
   source.getNode(), "user-provided value"

--- a/java/ql/src/Security/CWE/CWE-094/TemplateInjection.ql
+++ b/java/ql/src/Security/CWE/CWE-094/TemplateInjection.ql
@@ -16,6 +16,6 @@ import semmle.code.java.security.TemplateInjectionQuery
 import TemplateInjectionFlow::PathGraph
 
 from TemplateInjectionFlow::PathNode source, TemplateInjectionFlow::PathNode sink
-where TemplateInjectionFlow::hasFlowPath(source, sink)
+where TemplateInjectionFlow::flowPath(source, sink)
 select sink.getNode(), source, sink, "Template, which may contain code, depends on a $@.",
   source.getNode(), "user-provided value"

--- a/java/ql/src/Security/CWE/CWE-730/RegexInjection.ql
+++ b/java/ql/src/Security/CWE/CWE-730/RegexInjection.ql
@@ -18,6 +18,6 @@ import semmle.code.java.security.regexp.RegexInjectionQuery
 import RegexInjectionFlow::PathGraph
 
 from RegexInjectionFlow::PathNode source, RegexInjectionFlow::PathNode sink
-where RegexInjectionFlow::hasFlowPath(source, sink)
+where RegexInjectionFlow::flowPath(source, sink)
 select sink.getNode(), source, sink, "This regular expression is constructed from a $@.",
   source.getNode(), "user-provided value"

--- a/java/ql/src/Security/CWE/CWE-730/RegexInjection.ql
+++ b/java/ql/src/Security/CWE/CWE-730/RegexInjection.ql
@@ -15,9 +15,9 @@
 
 import java
 import semmle.code.java.security.regexp.RegexInjectionQuery
-import DataFlow::PathGraph
+import RegexInjectionFlow::PathGraph
 
-from DataFlow::PathNode source, DataFlow::PathNode sink, RegexInjectionConfiguration c
-where c.hasFlowPath(source, sink)
+from RegexInjectionFlow::PathNode source, RegexInjectionFlow::PathNode sink
+where RegexInjectionFlow::hasFlowPath(source, sink)
 select sink.getNode(), source, sink, "This regular expression is constructed from a $@.",
   source.getNode(), "user-provided value"

--- a/java/ql/src/Security/CWE/CWE-917/OgnlInjection.ql
+++ b/java/ql/src/Security/CWE/CWE-917/OgnlInjection.ql
@@ -13,9 +13,9 @@
 
 import java
 import semmle.code.java.security.OgnlInjectionQuery
-import DataFlow::PathGraph
+import OgnlInjectionFlow::PathGraph
 
-from DataFlow::PathNode source, DataFlow::PathNode sink, OgnlInjectionFlowConfig conf
-where conf.hasFlowPath(source, sink)
+from OgnlInjectionFlow::PathNode source, OgnlInjectionFlow::PathNode sink
+where OgnlInjectionFlow::hasFlowPath(source, sink)
 select sink.getNode(), source, sink, "OGNL Expression Language statement depends on a $@.",
   source.getNode(), "user-provided value"

--- a/java/ql/src/Security/CWE/CWE-917/OgnlInjection.ql
+++ b/java/ql/src/Security/CWE/CWE-917/OgnlInjection.ql
@@ -16,6 +16,6 @@ import semmle.code.java.security.OgnlInjectionQuery
 import OgnlInjectionFlow::PathGraph
 
 from OgnlInjectionFlow::PathNode source, OgnlInjectionFlow::PathNode sink
-where OgnlInjectionFlow::hasFlowPath(source, sink)
+where OgnlInjectionFlow::flowPath(source, sink)
 select sink.getNode(), source, sink, "OGNL Expression Language statement depends on a $@.",
   source.getNode(), "user-provided value"

--- a/java/ql/test/query-tests/security/CWE-074/JndiInjectionTest.ql
+++ b/java/ql/test/query-tests/security/CWE-074/JndiInjectionTest.ql
@@ -9,7 +9,7 @@ class HasJndiInjectionTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "hasJndiInjection" and
-    exists(DataFlow::Node sink, JndiInjectionFlowConfig conf | conf.hasFlowTo(sink) |
+    exists(DataFlow::Node sink | JndiInjectionFlow::hasFlowTo(sink) |
       sink.getLocation() = location and
       element = sink.toString() and
       value = ""

--- a/java/ql/test/query-tests/security/CWE-074/JndiInjectionTest.ql
+++ b/java/ql/test/query-tests/security/CWE-074/JndiInjectionTest.ql
@@ -9,7 +9,7 @@ class HasJndiInjectionTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "hasJndiInjection" and
-    exists(DataFlow::Node sink | JndiInjectionFlow::hasFlowTo(sink) |
+    exists(DataFlow::Node sink | JndiInjectionFlow::flowTo(sink) |
       sink.getLocation() = location and
       element = sink.toString() and
       value = ""

--- a/java/ql/test/query-tests/security/CWE-074/XsltInjectionTest.ql
+++ b/java/ql/test/query-tests/security/CWE-074/XsltInjectionTest.ql
@@ -11,7 +11,7 @@ class HasXsltInjectionTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "hasXsltInjection" and
-    exists(DataFlow::Node sink | XsltInjectionFlow::hasFlowTo(sink) |
+    exists(DataFlow::Node sink | XsltInjectionFlow::flowTo(sink) |
       sink.getLocation() = location and
       element = sink.toString() and
       value = ""

--- a/java/ql/test/query-tests/security/CWE-074/XsltInjectionTest.ql
+++ b/java/ql/test/query-tests/security/CWE-074/XsltInjectionTest.ql
@@ -11,7 +11,7 @@ class HasXsltInjectionTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "hasXsltInjection" and
-    exists(DataFlow::Node sink, XsltInjectionFlowConfig conf | conf.hasFlowTo(sink) |
+    exists(DataFlow::Node sink | XsltInjectionFlow::hasFlowTo(sink) |
       sink.getLocation() = location and
       element = sink.toString() and
       value = ""

--- a/java/ql/test/query-tests/security/CWE-094/GroovyInjectionTest.ql
+++ b/java/ql/test/query-tests/security/CWE-094/GroovyInjectionTest.ql
@@ -11,7 +11,7 @@ class HasGroovyInjectionTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "hasGroovyInjection" and
-    exists(DataFlow::Node sink | GroovyInjectionFlow::hasFlowTo(sink) |
+    exists(DataFlow::Node sink | GroovyInjectionFlow::flowTo(sink) |
       sink.getLocation() = location and
       element = sink.toString() and
       value = ""

--- a/java/ql/test/query-tests/security/CWE-094/GroovyInjectionTest.ql
+++ b/java/ql/test/query-tests/security/CWE-094/GroovyInjectionTest.ql
@@ -11,7 +11,7 @@ class HasGroovyInjectionTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "hasGroovyInjection" and
-    exists(DataFlow::Node sink, GroovyInjectionConfig conf | conf.hasFlowTo(sink) |
+    exists(DataFlow::Node sink | GroovyInjectionFlow::hasFlowTo(sink) |
       sink.getLocation() = location and
       element = sink.toString() and
       value = ""

--- a/java/ql/test/query-tests/security/CWE-094/JexlInjectionTest.ql
+++ b/java/ql/test/query-tests/security/CWE-094/JexlInjectionTest.ql
@@ -9,7 +9,7 @@ class JexlInjectionTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "hasJexlInjection" and
-    exists(DataFlow::Node sink | JexlInjectionFlow::hasFlowTo(sink) |
+    exists(DataFlow::Node sink | JexlInjectionFlow::flowTo(sink) |
       sink.getLocation() = location and
       element = sink.toString() and
       value = ""

--- a/java/ql/test/query-tests/security/CWE-094/JexlInjectionTest.ql
+++ b/java/ql/test/query-tests/security/CWE-094/JexlInjectionTest.ql
@@ -9,7 +9,7 @@ class JexlInjectionTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "hasJexlInjection" and
-    exists(DataFlow::Node sink, JexlInjectionConfig conf | conf.hasFlowTo(sink) |
+    exists(DataFlow::Node sink | JexlInjectionFlow::hasFlowTo(sink) |
       sink.getLocation() = location and
       element = sink.toString() and
       value = ""

--- a/java/ql/test/query-tests/security/CWE-094/MvelInjectionTest.ql
+++ b/java/ql/test/query-tests/security/CWE-094/MvelInjectionTest.ql
@@ -11,7 +11,7 @@ class HasMvelInjectionTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "hasMvelInjection" and
-    exists(DataFlow::Node sink | MvelInjectionFlow::hasFlowTo(sink) |
+    exists(DataFlow::Node sink | MvelInjectionFlow::flowTo(sink) |
       sink.getLocation() = location and
       element = sink.toString() and
       value = ""

--- a/java/ql/test/query-tests/security/CWE-094/MvelInjectionTest.ql
+++ b/java/ql/test/query-tests/security/CWE-094/MvelInjectionTest.ql
@@ -11,7 +11,7 @@ class HasMvelInjectionTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "hasMvelInjection" and
-    exists(DataFlow::Node sink, MvelInjectionFlowConfig conf | conf.hasFlowTo(sink) |
+    exists(DataFlow::Node sink | MvelInjectionFlow::hasFlowTo(sink) |
       sink.getLocation() = location and
       element = sink.toString() and
       value = ""

--- a/java/ql/test/query-tests/security/CWE-094/SpelInjectionTest.ql
+++ b/java/ql/test/query-tests/security/CWE-094/SpelInjectionTest.ql
@@ -11,7 +11,7 @@ class HasSpelInjectionTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "hasSpelInjection" and
-    exists(DataFlow::Node sink, SpelInjectionConfig conf | conf.hasFlowTo(sink) |
+    exists(DataFlow::Node sink | SpelInjectionFlow::hasFlowTo(sink) |
       sink.getLocation() = location and
       element = sink.toString() and
       value = ""

--- a/java/ql/test/query-tests/security/CWE-094/SpelInjectionTest.ql
+++ b/java/ql/test/query-tests/security/CWE-094/SpelInjectionTest.ql
@@ -11,7 +11,7 @@ class HasSpelInjectionTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "hasSpelInjection" and
-    exists(DataFlow::Node sink | SpelInjectionFlow::hasFlowTo(sink) |
+    exists(DataFlow::Node sink | SpelInjectionFlow::flowTo(sink) |
       sink.getLocation() = location and
       element = sink.toString() and
       value = ""

--- a/java/ql/test/query-tests/security/CWE-094/TemplateInjectionTest.ql
+++ b/java/ql/test/query-tests/security/CWE-094/TemplateInjectionTest.ql
@@ -9,7 +9,7 @@ class TemplateInjectionTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "hasTemplateInjection" and
-    exists(DataFlow::Node sink | TemplateInjectionFlow::hasFlowTo(sink) |
+    exists(DataFlow::Node sink | TemplateInjectionFlow::flowTo(sink) |
       sink.getLocation() = location and
       element = sink.toString() and
       value = ""

--- a/java/ql/test/query-tests/security/CWE-094/TemplateInjectionTest.ql
+++ b/java/ql/test/query-tests/security/CWE-094/TemplateInjectionTest.ql
@@ -9,7 +9,7 @@ class TemplateInjectionTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "hasTemplateInjection" and
-    exists(DataFlow::Node sink, TemplateInjectionFlowConfig conf | conf.hasFlowTo(sink) |
+    exists(DataFlow::Node sink | TemplateInjectionFlow::hasFlowTo(sink) |
       sink.getLocation() = location and
       element = sink.toString() and
       value = ""

--- a/java/ql/test/query-tests/security/CWE-730/RegexInjectionTest.ql
+++ b/java/ql/test/query-tests/security/CWE-730/RegexInjectionTest.ql
@@ -9,7 +9,7 @@ class RegexInjectionTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "hasRegexInjection" and
-    exists(RegexInjectionFlow::PathNode sink | RegexInjectionFlow::hasFlowPath(_, sink) |
+    exists(RegexInjectionFlow::PathNode sink | RegexInjectionFlow::flowPath(_, sink) |
       location = sink.getNode().getLocation() and
       element = sink.getNode().toString() and
       value = ""

--- a/java/ql/test/query-tests/security/CWE-730/RegexInjectionTest.ql
+++ b/java/ql/test/query-tests/security/CWE-730/RegexInjectionTest.ql
@@ -9,7 +9,7 @@ class RegexInjectionTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "hasRegexInjection" and
-    exists(DataFlow::PathNode sink, RegexInjectionConfiguration c | c.hasFlowPath(_, sink) |
+    exists(RegexInjectionFlow::PathNode sink | RegexInjectionFlow::hasFlowPath(_, sink) |
       location = sink.getNode().getLocation() and
       element = sink.getNode().toString() and
       value = ""

--- a/java/ql/test/query-tests/security/CWE-917/OgnlInjectionTest.ql
+++ b/java/ql/test/query-tests/security/CWE-917/OgnlInjectionTest.ql
@@ -9,7 +9,7 @@ class OgnlInjectionTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "hasOgnlInjection" and
-    exists(DataFlow::Node sink | OgnlInjectionFlow::hasFlowTo(sink) |
+    exists(DataFlow::Node sink | OgnlInjectionFlow::flowTo(sink) |
       sink.getLocation() = location and
       element = sink.toString() and
       value = ""

--- a/java/ql/test/query-tests/security/CWE-917/OgnlInjectionTest.ql
+++ b/java/ql/test/query-tests/security/CWE-917/OgnlInjectionTest.ql
@@ -9,7 +9,7 @@ class OgnlInjectionTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "hasOgnlInjection" and
-    exists(DataFlow::Node sink, OgnlInjectionFlowConfig conf | conf.hasFlowTo(sink) |
+    exists(DataFlow::Node sink | OgnlInjectionFlow::hasFlowTo(sink) |
       sink.getLocation() = location and
       element = sink.toString() and
       value = ""


### PR DESCRIPTION
Refactor `Query.qll` files for queries involving injection to use the new dataflow module API.