### PR TITLE
Java : Add JndiInjection Sanitizer Class

### DIFF
--- a/java/ql/lib/change-notes/2023-03-23-jndi-sanitizer.md
+++ b/java/ql/lib/change-notes/2023-03-23-jndi-sanitizer.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Added the extensible abstract class `JndiInjectionSanitizer`. Now this class can be extended to add more sanitizers to the `java/jndi-injection` query.

--- a/java/ql/lib/semmle/code/java/security/JndiInjection.qll
+++ b/java/ql/lib/semmle/code/java/security/JndiInjection.qll
@@ -9,6 +9,9 @@ private import semmle.code.java.frameworks.SpringLdap
 /** A data flow sink for unvalidated user input that is used in JNDI lookup. */
 abstract class JndiInjectionSink extends DataFlow::Node { }
 
+/** A sanitizer for JNDI injection vulnerabilities. */
+abstract class JndiInjectionSanitizer extends DataFlow::Node { }
+
 /**
  * A unit class for adding additional taint steps.
  *

--- a/java/ql/lib/semmle/code/java/security/JndiInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/JndiInjectionQuery.qll
@@ -17,13 +17,21 @@ class JndiInjectionFlowConfig extends TaintTracking::Configuration {
   override predicate isSink(DataFlow::Node sink) { sink instanceof JndiInjectionSink }
 
   override predicate isSanitizer(DataFlow::Node node) {
-    node.getType() instanceof PrimitiveType or node.getType() instanceof BoxedType
+    node.getType() instanceof PrimitiveType or node.getType() instanceof BoxedType 
+    or
+    node instanceof JndiInjectionSanitizer
   }
 
   override predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) {
     any(JndiInjectionAdditionalTaintStep c).step(node1, node2)
   }
 }
+
+/**
+ * A Class to be extended for Sanitizer Customizations 
+ */
+
+abstract class JndiInjectionSanitizer extends DataFlow::Node { }
 
 /**
  * A method that does a JNDI lookup when it receives a `SearchControls` argument with `setReturningObjFlag` = `true`

--- a/java/ql/lib/semmle/code/java/security/JndiInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/JndiInjectionQuery.qll
@@ -17,8 +17,8 @@ class JndiInjectionFlowConfig extends TaintTracking::Configuration {
   override predicate isSink(DataFlow::Node sink) { sink instanceof JndiInjectionSink }
 
   override predicate isSanitizer(DataFlow::Node node) {
-    node.getType() instanceof PrimitiveType or node.getType() instanceof BoxedType 
-    or
+    node.getType() instanceof PrimitiveType or
+    node.getType() instanceof BoxedType or
     node instanceof JndiInjectionSanitizer
   }
 
@@ -26,12 +26,6 @@ class JndiInjectionFlowConfig extends TaintTracking::Configuration {
     any(JndiInjectionAdditionalTaintStep c).step(node1, node2)
   }
 }
-
-/**
- * A Class to be extended for Sanitizer Customizations 
- */
-
-abstract class JndiInjectionSanitizer extends DataFlow::Node { }
 
 /**
  * A method that does a JNDI lookup when it receives a `SearchControls` argument with `setReturningObjFlag` = `true`


### PR DESCRIPTION
Currently it's not possible to modify the definition of JndiInjectionFlowConfig sanitizer when performing Customizations. This PR adds a class JndiInjectionSanitizer that will be used whenever Customizations are needed for the sanitizer.