### PR TITLE
C++: Add StrlenLiteralRangeExpr

### DIFF
--- a/cpp/ql/lib/experimental/semmle/code/cpp/rangeanalysis/ExtendedRangeAnalysis.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/rangeanalysis/ExtendedRangeAnalysis.qll
@@ -3,3 +3,4 @@ import semmle.code.cpp.rangeanalysis.SimpleRangeAnalysis
 // Import each extension we want to enable
 import extensions.SubtractSelf
 import extensions.ConstantBitwiseAndExprRange
+import extensions.StrlenLiteralRangeExpr

--- a/cpp/ql/lib/experimental/semmle/code/cpp/rangeanalysis/extensions/StrlenLiteralRangeExpr.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/rangeanalysis/extensions/StrlenLiteralRangeExpr.qll
@@ -1,0 +1,18 @@
+private import cpp
+private import experimental.semmle.code.cpp.models.interfaces.SimpleRangeAnalysisExpr
+
+/**
+ * Provides range analysis information for calls to `strlen` on literal strings.
+ * For example, the range of `strlen("literal")` will be 7.
+ */
+class StrlenLiteralRangeExpr extends SimpleRangeAnalysisExpr, FunctionCall {
+  StrlenLiteralRangeExpr() {
+    getTarget().hasGlobalOrStdName("strlen") and getArgument(0).isConstant()
+  }
+
+  override int getLowerBounds() { result = getArgument(0).getValue().length() }
+
+  override int getUpperBounds() { result = getArgument(0).getValue().length() }
+
+  override predicate dependsOnChild(Expr e) { none() }
+}

--- a/cpp/ql/test/experimental/library-tests/rangeanalysis/strlenliteral/StrlenLiteralRange.expected
+++ b/cpp/ql/test/experimental/library-tests/rangeanalysis/strlenliteral/StrlenLiteralRange.expected
@@ -1,0 +1,2 @@
+| test.cpp:4:3:4:8 | call to strlen | 7.0 | 7.0 |
+| test.cpp:5:3:5:8 | call to strlen | 1.8446744073709552E19 | 0.0 |

--- a/cpp/ql/test/experimental/library-tests/rangeanalysis/strlenliteral/StrlenLiteralRange.ql
+++ b/cpp/ql/test/experimental/library-tests/rangeanalysis/strlenliteral/StrlenLiteralRange.ql
@@ -1,0 +1,6 @@
+import cpp
+import semmle.code.cpp.rangeanalysis.SimpleRangeAnalysis
+import experimental.semmle.code.cpp.rangeanalysis.extensions.StrlenLiteralRangeExpr
+
+from FunctionCall fc
+select fc, upperBound(fc), lowerBound(fc)

--- a/cpp/ql/test/experimental/library-tests/rangeanalysis/strlenliteral/test.cpp
+++ b/cpp/ql/test/experimental/library-tests/rangeanalysis/strlenliteral/test.cpp
@@ -1,0 +1,6 @@
+unsigned long strlen(const char *);
+
+void func(const char *s) {
+  strlen("literal");
+  strlen(s);
+}


### PR DESCRIPTION
While determining the range of the return value of `strlen` is difficult in the general case, we can precisely and efficiently determine the range when the argument is a literal string. This extra precision can help reduce false positives in some queries.