### PR TITLE
Swift: replace internal swift mangler with our own

### DIFF
--- a/swift/extractor/SwiftExtractor.cpp
+++ b/swift/extractor/SwiftExtractor.cpp
@@ -14,7 +14,6 @@
 #include "swift/extractor/infra/file/Path.h"
 #include "swift/extractor/infra/SwiftLocationExtractor.h"
 #include "swift/extractor/infra/SwiftBodyEmissionStrategy.h"
-#include "swift/extractor/mangler/SwiftMangler.h"
 #include "swift/logging/SwiftAssert.h"
 
 using namespace codeql;
@@ -49,32 +48,20 @@ static void archiveFile(const SwiftExtractorConfiguration& config, swift::Source
   }
 }
 
-// TODO: This will be factored out/replaced with a simplified version of custom mangling
-static std::string mangledDeclName(const swift::ValueDecl& decl) {
-  std::string_view moduleName = decl.getModuleContext()->getRealName().str();
-  // ASTMangler::mangleAnyDecl crashes when called on `ModuleDecl`
-  if (decl.getKind() == swift::DeclKind::Module) {
-    return std::string{moduleName};
+static std::string mangledDeclName(const swift::Decl& decl) {
+  // SwiftRecursiveMangler mangled name cannot be used directly as it can be too long for file names
+  // so we build some minimal human readable info for debuggability and append a hash
+  auto ret = decl.getModuleContext()->getRealName().str().str();
+  ret += '/';
+  ret += swift::Decl::getKindName(decl.getKind());
+  ret += '_';
+  if (auto valueDecl = llvm::dyn_cast<swift::ValueDecl>(&decl); valueDecl && valueDecl->hasName()) {
+    ret += valueDecl->getBaseName().userFacingName();
+    ret += '_';
   }
-  swift::Mangle::ASTMangler mangler;
-  if (decl.getKind() == swift::DeclKind::TypeAlias) {
-    // In cases like this (when coming from PCM)
-    //  typealias CFXMLTree = CFTree
-    //  typealias CFXMLTreeRef = CFXMLTree
-    // mangleAnyDecl mangles both CFXMLTree and CFXMLTreeRef into 'So12CFXMLTreeRefa'
-    // which is not correct and causes inconsistencies. mangleEntity makes these two distinct
-    // prefix adds a couple of special symbols, we don't necessary need them
-    return mangler.mangleEntity(&decl);
-  }
-  if (decl.getKind() == swift::DeclKind::GenericTypeParam) {
-    // internal mangling does not distinguish generic type parameters with the same name and
-    // position of different functions. We prepend the context (that is, the function) to
-    // circumvent that
-    auto context = llvm::dyn_cast<swift::ValueDecl>(decl.getDeclContext()->getAsDecl());
-    assert(context);
-    return mangledDeclName(*context) + '_' + mangler.mangleAnyDecl(&decl, /* prefix = */ false);
-  }
-  return mangler.mangleAnyDecl(&decl, /* prefix = */ false);
+  SwiftRecursiveMangler mangler;
+  ret += mangler.mangleDecl(decl).hash();
+  return ret;
 }
 
 static fs::path getFilename(swift::ModuleDecl& module,
@@ -84,20 +71,7 @@ static fs::path getFilename(swift::ModuleDecl& module,
     return resolvePath(primaryFile->getFilename());
   }
   if (lazyDeclaration) {
-    // this code will be thrown away in the near future
-    auto decl = llvm::dyn_cast<swift::ValueDecl>(lazyDeclaration);
-    CODEQL_ASSERT(decl, "not a ValueDecl");
-    auto mangled = mangledDeclName(*decl);
-    // mangled name can be too long to use as a file name, so we can't use it directly
-    mangled = picosha2::hash256_hex_string(mangled);
-    std::string ret;
-    ret += module.getRealName().str();
-    ret += '_';
-    ret += decl->getBaseName().userFacingName();
-    ret += '_';
-    // half a SHA2 is enough
-    ret += std::string_view(mangled).substr(0, mangled.size() / 2);
-    return ret;
+    return mangledDeclName(*lazyDeclaration);
   }
   // PCM clang module
   if (module.isNonSwiftModule()) {

--- a/swift/extractor/infra/BUILD.bazel
+++ b/swift/extractor/infra/BUILD.bazel
@@ -11,5 +11,6 @@ swift_cc_library(
         "//swift/extractor/trap",
         "//swift/logging",
         "//swift/third_party/swift-llvm-support",
+        "@picosha2",
     ],
 )

--- a/swift/extractor/infra/SwiftMangledName.cpp
+++ b/swift/extractor/infra/SwiftMangledName.cpp
@@ -1,7 +1,16 @@
 #include "swift/extractor/infra/SwiftMangledName.h"
 #include "absl/strings/str_cat.h"
 
+#include <picosha2.h>
+
 namespace codeql {
+
+std::string SwiftMangledName::hash() const {
+  auto ret = picosha2::hash256_hex_string(value);
+  // half a hash is already enough for disambuiguation
+  ret.resize(ret.size() / 2);
+  return ret;
+}
 
 SwiftMangledName& SwiftMangledName::operator<<(UntypedTrapLabel label) & {
   absl::StrAppend(&value, "{", label.str(), "}");

--- a/swift/extractor/infra/SwiftMangledName.h
+++ b/swift/extractor/infra/SwiftMangledName.h
@@ -16,6 +16,9 @@ class SwiftMangledName {
   explicit operator bool() const { return !value.empty(); }
 
   const std::string& str() const { return value; }
+  operator std::string_view() const { return value; }
+
+  std::string hash() const;
 
   // let's avoid copying as long as we don't need it
   SwiftMangledName() = default;
@@ -29,7 +32,6 @@ class SwiftMangledName {
     (operator<<(std::forward<Args>(args)), ...);
   }
 
-  // streaming labels or ints into a SwiftMangledName just appends them
   SwiftMangledName& operator<<(UntypedTrapLabel label) &;
   SwiftMangledName& operator<<(unsigned i) &;
 
@@ -43,11 +45,6 @@ class SwiftMangledName {
   template <typename T>
   SwiftMangledName& operator<<(T&& arg) & {
     value += arg;
-    return *this;
-  }
-
-  SwiftMangledName& operator<<(const SwiftMangledName& other) {
-    value += other.value;
     return *this;
   }
 

--- a/swift/extractor/translators/SwiftVisitor.h
+++ b/swift/extractor/translators/SwiftVisitor.h
@@ -58,7 +58,7 @@ class SwiftVisitor : private SwiftDispatcher {
   StmtTranslator stmtTranslator{*this};
   TypeTranslator typeTranslator{*this};
   PatternTranslator patternTranslator{*this};
-  SwiftMangler mangler{*this};
+  SwiftTrapMangler mangler{*this};
 };
 
 }  // namespace codeql


### PR DESCRIPTION
Our mangler is split in two version:
* `SwiftTrapMangler`, with the same behaviour as the previous `SwiftMangler`, constructing mangled names with trap label references
* `SwiftRecursiveMangler` that replaces trap label references with recursive calls to its own `mangle` functions, effectively rolling out the entire chain of references

The latter is used to create lazy trap file names. Hashing is used to avoid excessively long filenames.