### PR TITLE
RB: always resolve toplevel namespaces to their locally qualified name

### DIFF
--- a/ruby/ql/lib/codeql/ruby/ast/internal/Module.qll
+++ b/ruby/ql/lib/codeql/ruby/ast/internal/Module.qll
@@ -407,7 +407,6 @@ private module ResolveImpl {
    */
   string getAnAssumedGlobalConst() {
     exists(ConstantAccess access |
-      not exists(access.getScopeExpr()) and
       result = access.getName() and
       isToplevel(access)
     )

--- a/ruby/ql/test/library-tests/modules/ancestors.expected
+++ b/ruby/ql/test/library-tests/modules/ancestors.expected
@@ -36,6 +36,12 @@
 #-----| TrueClass
 #-----| super -> Object
 
+#-----| UnresolvedNamespace::X1
+
+#-----| UnresolvedNamespace::X1::X2
+
+#-----| UnresolvedNamespace::X1::X2::X3
+
 calls.rb:
 #   21| M
 
@@ -273,11 +279,11 @@ unresolved_subclass.rb:
 #   11| UnresolvedNamespace::A
 #-----| super -> Object
 
-#   14| ...::Subclass1
+#   14| UnresolvedNamespace::X1::X2::X3::Subclass1
 #-----| super -> ResolvableBaseClass
 
-#   17| ...::Subclass2
-#-----| super -> Object
+#   17| UnresolvedNamespace::X1::X2::X3::Subclass2
+#-----| super -> UnresolvedNamespace::X1::X2::X3::Subclass1
 
-#   21| ...::A
+#   21| UnresolvedNamespace::X1::X2::X3::A
 #-----| super -> Object

--- a/ruby/ql/test/library-tests/modules/ancestors.expected
+++ b/ruby/ql/test/library-tests/modules/ancestors.expected
@@ -272,3 +272,12 @@ unresolved_subclass.rb:
 
 #   11| UnresolvedNamespace::A
 #-----| super -> Object
+
+#   14| ...::Subclass1
+#-----| super -> ResolvableBaseClass
+
+#   17| ...::Subclass2
+#-----| super -> Object
+
+#   21| ...::A
+#-----| super -> Object

--- a/ruby/ql/test/library-tests/modules/methods.expected
+++ b/ruby/ql/test/library-tests/modules/methods.expected
@@ -660,15 +660,15 @@ lookupMethod
 | unresolved_subclass.rb:11:1:12:3 | UnresolvedNamespace::A | new | calls.rb:117:5:117:16 | new |
 | unresolved_subclass.rb:11:1:12:3 | UnresolvedNamespace::A | puts | calls.rb:102:5:102:30 | puts |
 | unresolved_subclass.rb:11:1:12:3 | UnresolvedNamespace::A | to_s | calls.rb:172:5:173:7 | to_s |
-| unresolved_subclass.rb:14:1:15:3 | ...::Subclass1 | new | calls.rb:117:5:117:16 | new |
-| unresolved_subclass.rb:14:1:15:3 | ...::Subclass1 | puts | calls.rb:102:5:102:30 | puts |
-| unresolved_subclass.rb:14:1:15:3 | ...::Subclass1 | to_s | calls.rb:172:5:173:7 | to_s |
-| unresolved_subclass.rb:17:1:18:3 | ...::Subclass2 | new | calls.rb:117:5:117:16 | new |
-| unresolved_subclass.rb:17:1:18:3 | ...::Subclass2 | puts | calls.rb:102:5:102:30 | puts |
-| unresolved_subclass.rb:17:1:18:3 | ...::Subclass2 | to_s | calls.rb:172:5:173:7 | to_s |
-| unresolved_subclass.rb:21:1:22:3 | ...::A | new | calls.rb:117:5:117:16 | new |
-| unresolved_subclass.rb:21:1:22:3 | ...::A | puts | calls.rb:102:5:102:30 | puts |
-| unresolved_subclass.rb:21:1:22:3 | ...::A | to_s | calls.rb:172:5:173:7 | to_s |
+| unresolved_subclass.rb:14:1:15:3 | UnresolvedNamespace::X1::X2::X3::Subclass1 | new | calls.rb:117:5:117:16 | new |
+| unresolved_subclass.rb:14:1:15:3 | UnresolvedNamespace::X1::X2::X3::Subclass1 | puts | calls.rb:102:5:102:30 | puts |
+| unresolved_subclass.rb:14:1:15:3 | UnresolvedNamespace::X1::X2::X3::Subclass1 | to_s | calls.rb:172:5:173:7 | to_s |
+| unresolved_subclass.rb:17:1:18:3 | UnresolvedNamespace::X1::X2::X3::Subclass2 | new | calls.rb:117:5:117:16 | new |
+| unresolved_subclass.rb:17:1:18:3 | UnresolvedNamespace::X1::X2::X3::Subclass2 | puts | calls.rb:102:5:102:30 | puts |
+| unresolved_subclass.rb:17:1:18:3 | UnresolvedNamespace::X1::X2::X3::Subclass2 | to_s | calls.rb:172:5:173:7 | to_s |
+| unresolved_subclass.rb:21:1:22:3 | UnresolvedNamespace::X1::X2::X3::A | new | calls.rb:117:5:117:16 | new |
+| unresolved_subclass.rb:21:1:22:3 | UnresolvedNamespace::X1::X2::X3::A | puts | calls.rb:102:5:102:30 | puts |
+| unresolved_subclass.rb:21:1:22:3 | UnresolvedNamespace::X1::X2::X3::A | to_s | calls.rb:172:5:173:7 | to_s |
 enclosingMethod
 | calls.rb:2:5:2:14 | call to puts | calls.rb:1:1:3:3 | foo |
 | calls.rb:2:5:2:14 | self | calls.rb:1:1:3:3 | foo |

--- a/ruby/ql/test/library-tests/modules/methods.expected
+++ b/ruby/ql/test/library-tests/modules/methods.expected
@@ -660,6 +660,15 @@ lookupMethod
 | unresolved_subclass.rb:11:1:12:3 | UnresolvedNamespace::A | new | calls.rb:117:5:117:16 | new |
 | unresolved_subclass.rb:11:1:12:3 | UnresolvedNamespace::A | puts | calls.rb:102:5:102:30 | puts |
 | unresolved_subclass.rb:11:1:12:3 | UnresolvedNamespace::A | to_s | calls.rb:172:5:173:7 | to_s |
+| unresolved_subclass.rb:14:1:15:3 | ...::Subclass1 | new | calls.rb:117:5:117:16 | new |
+| unresolved_subclass.rb:14:1:15:3 | ...::Subclass1 | puts | calls.rb:102:5:102:30 | puts |
+| unresolved_subclass.rb:14:1:15:3 | ...::Subclass1 | to_s | calls.rb:172:5:173:7 | to_s |
+| unresolved_subclass.rb:17:1:18:3 | ...::Subclass2 | new | calls.rb:117:5:117:16 | new |
+| unresolved_subclass.rb:17:1:18:3 | ...::Subclass2 | puts | calls.rb:102:5:102:30 | puts |
+| unresolved_subclass.rb:17:1:18:3 | ...::Subclass2 | to_s | calls.rb:172:5:173:7 | to_s |
+| unresolved_subclass.rb:21:1:22:3 | ...::A | new | calls.rb:117:5:117:16 | new |
+| unresolved_subclass.rb:21:1:22:3 | ...::A | puts | calls.rb:102:5:102:30 | puts |
+| unresolved_subclass.rb:21:1:22:3 | ...::A | to_s | calls.rb:172:5:173:7 | to_s |
 enclosingMethod
 | calls.rb:2:5:2:14 | call to puts | calls.rb:1:1:3:3 | foo |
 | calls.rb:2:5:2:14 | self | calls.rb:1:1:3:3 | foo |

--- a/ruby/ql/test/library-tests/modules/modules.expected
+++ b/ruby/ql/test/library-tests/modules/modules.expected
@@ -97,6 +97,9 @@ getModule
 | unresolved_subclass.rb:4:1:5:3 | UnresolvedNamespace::Subclass1 |
 | unresolved_subclass.rb:7:1:8:3 | UnresolvedNamespace::Subclass2 |
 | unresolved_subclass.rb:11:1:12:3 | UnresolvedNamespace::A |
+| unresolved_subclass.rb:14:1:15:3 | ...::Subclass1 |
+| unresolved_subclass.rb:17:1:18:3 | ...::Subclass2 |
+| unresolved_subclass.rb:21:1:22:3 | ...::A |
 getADeclaration
 | calls.rb:21:1:34:3 | M | calls.rb:21:1:34:3 | M |
 | calls.rb:43:1:58:3 | C | calls.rb:43:1:58:3 | C |
@@ -113,7 +116,7 @@ getADeclaration
 | calls.rb:115:1:118:3 | Object | modules_rec.rb:1:1:11:26 | modules_rec.rb |
 | calls.rb:115:1:118:3 | Object | private.rb:1:1:105:40 | private.rb |
 | calls.rb:115:1:118:3 | Object | toplevel_self_singleton.rb:1:1:34:4 | toplevel_self_singleton.rb |
-| calls.rb:115:1:118:3 | Object | unresolved_subclass.rb:1:1:12:4 | unresolved_subclass.rb |
+| calls.rb:115:1:118:3 | Object | unresolved_subclass.rb:1:1:22:4 | unresolved_subclass.rb |
 | calls.rb:120:1:123:3 | Hash | calls.rb:120:1:123:3 | Hash |
 | calls.rb:125:1:138:3 | Array | calls.rb:125:1:138:3 | Array |
 | calls.rb:165:1:169:3 | S | calls.rb:165:1:169:3 | S |
@@ -197,6 +200,9 @@ getADeclaration
 | unresolved_subclass.rb:4:1:5:3 | UnresolvedNamespace::Subclass1 | unresolved_subclass.rb:4:1:5:3 | Subclass1 |
 | unresolved_subclass.rb:7:1:8:3 | UnresolvedNamespace::Subclass2 | unresolved_subclass.rb:7:1:8:3 | Subclass2 |
 | unresolved_subclass.rb:11:1:12:3 | UnresolvedNamespace::A | unresolved_subclass.rb:11:1:12:3 | A |
+| unresolved_subclass.rb:14:1:15:3 | ...::Subclass1 | unresolved_subclass.rb:14:1:15:3 | Subclass1 |
+| unresolved_subclass.rb:17:1:18:3 | ...::Subclass2 | unresolved_subclass.rb:17:1:18:3 | Subclass2 |
+| unresolved_subclass.rb:21:1:22:3 | ...::A | unresolved_subclass.rb:21:1:22:3 | A |
 getSuperClass
 | calls.rb:43:1:58:3 | C | calls.rb:115:1:118:3 | Object |
 | calls.rb:65:1:69:3 | D | calls.rb:43:1:58:3 | C |
@@ -259,6 +265,9 @@ getSuperClass
 | unresolved_subclass.rb:4:1:5:3 | UnresolvedNamespace::Subclass1 | unresolved_subclass.rb:1:1:2:3 | ResolvableBaseClass |
 | unresolved_subclass.rb:7:1:8:3 | UnresolvedNamespace::Subclass2 | unresolved_subclass.rb:4:1:5:3 | UnresolvedNamespace::Subclass1 |
 | unresolved_subclass.rb:11:1:12:3 | UnresolvedNamespace::A | calls.rb:115:1:118:3 | Object |
+| unresolved_subclass.rb:14:1:15:3 | ...::Subclass1 | unresolved_subclass.rb:1:1:2:3 | ResolvableBaseClass |
+| unresolved_subclass.rb:17:1:18:3 | ...::Subclass2 | calls.rb:115:1:118:3 | Object |
+| unresolved_subclass.rb:21:1:22:3 | ...::A | calls.rb:115:1:118:3 | Object |
 getAPrependedModule
 | calls.rb:115:1:118:3 | Object | calls.rb:171:1:174:3 | A |
 | calls.rb:171:1:174:3 | A | toplevel_self_singleton.rb:2:5:5:7 | A::B |
@@ -419,6 +428,12 @@ resolveConstantReadAccess
 | unresolved_subclass.rb:7:40:7:69 | Subclass1 | UnresolvedNamespace::Subclass1 |
 | unresolved_subclass.rb:11:7:11:25 | UnresolvedNamespace | UnresolvedNamespace |
 | unresolved_subclass.rb:11:32:11:50 | UnresolvedNamespace | UnresolvedNamespace |
+| unresolved_subclass.rb:14:7:14:25 | UnresolvedNamespace | UnresolvedNamespace |
+| unresolved_subclass.rb:14:52:14:70 | ResolvableBaseClass | ResolvableBaseClass |
+| unresolved_subclass.rb:17:7:17:25 | UnresolvedNamespace | UnresolvedNamespace |
+| unresolved_subclass.rb:17:52:17:70 | UnresolvedNamespace | UnresolvedNamespace |
+| unresolved_subclass.rb:21:7:21:25 | UnresolvedNamespace | UnresolvedNamespace |
+| unresolved_subclass.rb:21:44:21:62 | UnresolvedNamespace | UnresolvedNamespace |
 resolveConstantWriteAccess
 | calls.rb:21:1:34:3 | M | M |
 | calls.rb:43:1:58:3 | C | C |
@@ -1878,15 +1893,41 @@ enclosingModule
 | toplevel_self_singleton.rb:30:13:30:19 | self | toplevel_self_singleton.rb:25:5:33:7 | class << ... |
 | toplevel_self_singleton.rb:31:13:31:20 | call to call_you | toplevel_self_singleton.rb:25:5:33:7 | class << ... |
 | toplevel_self_singleton.rb:31:13:31:20 | self | toplevel_self_singleton.rb:25:5:33:7 | class << ... |
-| unresolved_subclass.rb:1:1:2:3 | ResolvableBaseClass | unresolved_subclass.rb:1:1:12:4 | unresolved_subclass.rb |
-| unresolved_subclass.rb:4:1:5:3 | Subclass1 | unresolved_subclass.rb:1:1:12:4 | unresolved_subclass.rb |
-| unresolved_subclass.rb:4:7:4:25 | UnresolvedNamespace | unresolved_subclass.rb:1:1:12:4 | unresolved_subclass.rb |
-| unresolved_subclass.rb:4:40:4:58 | ResolvableBaseClass | unresolved_subclass.rb:1:1:12:4 | unresolved_subclass.rb |
-| unresolved_subclass.rb:7:1:8:3 | Subclass2 | unresolved_subclass.rb:1:1:12:4 | unresolved_subclass.rb |
-| unresolved_subclass.rb:7:7:7:25 | UnresolvedNamespace | unresolved_subclass.rb:1:1:12:4 | unresolved_subclass.rb |
-| unresolved_subclass.rb:7:40:7:58 | UnresolvedNamespace | unresolved_subclass.rb:1:1:12:4 | unresolved_subclass.rb |
-| unresolved_subclass.rb:7:40:7:69 | Subclass1 | unresolved_subclass.rb:1:1:12:4 | unresolved_subclass.rb |
-| unresolved_subclass.rb:11:1:12:3 | A | unresolved_subclass.rb:1:1:12:4 | unresolved_subclass.rb |
-| unresolved_subclass.rb:11:7:11:25 | UnresolvedNamespace | unresolved_subclass.rb:1:1:12:4 | unresolved_subclass.rb |
-| unresolved_subclass.rb:11:32:11:50 | UnresolvedNamespace | unresolved_subclass.rb:1:1:12:4 | unresolved_subclass.rb |
-| unresolved_subclass.rb:11:32:11:53 | B | unresolved_subclass.rb:1:1:12:4 | unresolved_subclass.rb |
+| unresolved_subclass.rb:1:1:2:3 | ResolvableBaseClass | unresolved_subclass.rb:1:1:22:4 | unresolved_subclass.rb |
+| unresolved_subclass.rb:4:1:5:3 | Subclass1 | unresolved_subclass.rb:1:1:22:4 | unresolved_subclass.rb |
+| unresolved_subclass.rb:4:7:4:25 | UnresolvedNamespace | unresolved_subclass.rb:1:1:22:4 | unresolved_subclass.rb |
+| unresolved_subclass.rb:4:40:4:58 | ResolvableBaseClass | unresolved_subclass.rb:1:1:22:4 | unresolved_subclass.rb |
+| unresolved_subclass.rb:7:1:8:3 | Subclass2 | unresolved_subclass.rb:1:1:22:4 | unresolved_subclass.rb |
+| unresolved_subclass.rb:7:7:7:25 | UnresolvedNamespace | unresolved_subclass.rb:1:1:22:4 | unresolved_subclass.rb |
+| unresolved_subclass.rb:7:40:7:58 | UnresolvedNamespace | unresolved_subclass.rb:1:1:22:4 | unresolved_subclass.rb |
+| unresolved_subclass.rb:7:40:7:69 | Subclass1 | unresolved_subclass.rb:1:1:22:4 | unresolved_subclass.rb |
+| unresolved_subclass.rb:11:1:12:3 | A | unresolved_subclass.rb:1:1:22:4 | unresolved_subclass.rb |
+| unresolved_subclass.rb:11:7:11:25 | UnresolvedNamespace | unresolved_subclass.rb:1:1:22:4 | unresolved_subclass.rb |
+| unresolved_subclass.rb:11:32:11:50 | UnresolvedNamespace | unresolved_subclass.rb:1:1:22:4 | unresolved_subclass.rb |
+| unresolved_subclass.rb:11:32:11:53 | B | unresolved_subclass.rb:1:1:22:4 | unresolved_subclass.rb |
+| unresolved_subclass.rb:14:1:15:3 | Subclass1 | unresolved_subclass.rb:1:1:22:4 | unresolved_subclass.rb |
+| unresolved_subclass.rb:14:7:14:25 | UnresolvedNamespace | unresolved_subclass.rb:1:1:22:4 | unresolved_subclass.rb |
+| unresolved_subclass.rb:14:7:14:29 | X1 | unresolved_subclass.rb:1:1:22:4 | unresolved_subclass.rb |
+| unresolved_subclass.rb:14:7:14:33 | X2 | unresolved_subclass.rb:1:1:22:4 | unresolved_subclass.rb |
+| unresolved_subclass.rb:14:7:14:37 | X3 | unresolved_subclass.rb:1:1:22:4 | unresolved_subclass.rb |
+| unresolved_subclass.rb:14:52:14:70 | ResolvableBaseClass | unresolved_subclass.rb:1:1:22:4 | unresolved_subclass.rb |
+| unresolved_subclass.rb:17:1:18:3 | Subclass2 | unresolved_subclass.rb:1:1:22:4 | unresolved_subclass.rb |
+| unresolved_subclass.rb:17:7:17:25 | UnresolvedNamespace | unresolved_subclass.rb:1:1:22:4 | unresolved_subclass.rb |
+| unresolved_subclass.rb:17:7:17:29 | X1 | unresolved_subclass.rb:1:1:22:4 | unresolved_subclass.rb |
+| unresolved_subclass.rb:17:7:17:33 | X2 | unresolved_subclass.rb:1:1:22:4 | unresolved_subclass.rb |
+| unresolved_subclass.rb:17:7:17:37 | X3 | unresolved_subclass.rb:1:1:22:4 | unresolved_subclass.rb |
+| unresolved_subclass.rb:17:52:17:70 | UnresolvedNamespace | unresolved_subclass.rb:1:1:22:4 | unresolved_subclass.rb |
+| unresolved_subclass.rb:17:52:17:74 | X1 | unresolved_subclass.rb:1:1:22:4 | unresolved_subclass.rb |
+| unresolved_subclass.rb:17:52:17:78 | X2 | unresolved_subclass.rb:1:1:22:4 | unresolved_subclass.rb |
+| unresolved_subclass.rb:17:52:17:82 | X3 | unresolved_subclass.rb:1:1:22:4 | unresolved_subclass.rb |
+| unresolved_subclass.rb:17:52:17:93 | Subclass1 | unresolved_subclass.rb:1:1:22:4 | unresolved_subclass.rb |
+| unresolved_subclass.rb:21:1:22:3 | A | unresolved_subclass.rb:1:1:22:4 | unresolved_subclass.rb |
+| unresolved_subclass.rb:21:7:21:25 | UnresolvedNamespace | unresolved_subclass.rb:1:1:22:4 | unresolved_subclass.rb |
+| unresolved_subclass.rb:21:7:21:29 | X1 | unresolved_subclass.rb:1:1:22:4 | unresolved_subclass.rb |
+| unresolved_subclass.rb:21:7:21:33 | X2 | unresolved_subclass.rb:1:1:22:4 | unresolved_subclass.rb |
+| unresolved_subclass.rb:21:7:21:37 | X3 | unresolved_subclass.rb:1:1:22:4 | unresolved_subclass.rb |
+| unresolved_subclass.rb:21:44:21:62 | UnresolvedNamespace | unresolved_subclass.rb:1:1:22:4 | unresolved_subclass.rb |
+| unresolved_subclass.rb:21:44:21:66 | X1 | unresolved_subclass.rb:1:1:22:4 | unresolved_subclass.rb |
+| unresolved_subclass.rb:21:44:21:70 | X2 | unresolved_subclass.rb:1:1:22:4 | unresolved_subclass.rb |
+| unresolved_subclass.rb:21:44:21:74 | X3 | unresolved_subclass.rb:1:1:22:4 | unresolved_subclass.rb |
+| unresolved_subclass.rb:21:44:21:77 | B | unresolved_subclass.rb:1:1:22:4 | unresolved_subclass.rb |

--- a/ruby/ql/test/library-tests/modules/modules.expected
+++ b/ruby/ql/test/library-tests/modules/modules.expected
@@ -51,6 +51,9 @@ getModule
 | file://:0:0:0:0 | Symbol |
 | file://:0:0:0:0 | TrueClass |
 | file://:0:0:0:0 | UnresolvedNamespace |
+| file://:0:0:0:0 | UnresolvedNamespace::X1 |
+| file://:0:0:0:0 | UnresolvedNamespace::X1::X2 |
+| file://:0:0:0:0 | UnresolvedNamespace::X1::X2::X3 |
 | hello.rb:1:1:8:3 | EnglishWords |
 | hello.rb:11:1:16:3 | Greeting |
 | hello.rb:18:1:22:3 | HelloWorld |
@@ -97,9 +100,9 @@ getModule
 | unresolved_subclass.rb:4:1:5:3 | UnresolvedNamespace::Subclass1 |
 | unresolved_subclass.rb:7:1:8:3 | UnresolvedNamespace::Subclass2 |
 | unresolved_subclass.rb:11:1:12:3 | UnresolvedNamespace::A |
-| unresolved_subclass.rb:14:1:15:3 | ...::Subclass1 |
-| unresolved_subclass.rb:17:1:18:3 | ...::Subclass2 |
-| unresolved_subclass.rb:21:1:22:3 | ...::A |
+| unresolved_subclass.rb:14:1:15:3 | UnresolvedNamespace::X1::X2::X3::Subclass1 |
+| unresolved_subclass.rb:17:1:18:3 | UnresolvedNamespace::X1::X2::X3::Subclass2 |
+| unresolved_subclass.rb:21:1:22:3 | UnresolvedNamespace::X1::X2::X3::A |
 getADeclaration
 | calls.rb:21:1:34:3 | M | calls.rb:21:1:34:3 | M |
 | calls.rb:43:1:58:3 | C | calls.rb:43:1:58:3 | C |
@@ -200,9 +203,9 @@ getADeclaration
 | unresolved_subclass.rb:4:1:5:3 | UnresolvedNamespace::Subclass1 | unresolved_subclass.rb:4:1:5:3 | Subclass1 |
 | unresolved_subclass.rb:7:1:8:3 | UnresolvedNamespace::Subclass2 | unresolved_subclass.rb:7:1:8:3 | Subclass2 |
 | unresolved_subclass.rb:11:1:12:3 | UnresolvedNamespace::A | unresolved_subclass.rb:11:1:12:3 | A |
-| unresolved_subclass.rb:14:1:15:3 | ...::Subclass1 | unresolved_subclass.rb:14:1:15:3 | Subclass1 |
-| unresolved_subclass.rb:17:1:18:3 | ...::Subclass2 | unresolved_subclass.rb:17:1:18:3 | Subclass2 |
-| unresolved_subclass.rb:21:1:22:3 | ...::A | unresolved_subclass.rb:21:1:22:3 | A |
+| unresolved_subclass.rb:14:1:15:3 | UnresolvedNamespace::X1::X2::X3::Subclass1 | unresolved_subclass.rb:14:1:15:3 | Subclass1 |
+| unresolved_subclass.rb:17:1:18:3 | UnresolvedNamespace::X1::X2::X3::Subclass2 | unresolved_subclass.rb:17:1:18:3 | Subclass2 |
+| unresolved_subclass.rb:21:1:22:3 | UnresolvedNamespace::X1::X2::X3::A | unresolved_subclass.rb:21:1:22:3 | A |
 getSuperClass
 | calls.rb:43:1:58:3 | C | calls.rb:115:1:118:3 | Object |
 | calls.rb:65:1:69:3 | D | calls.rb:43:1:58:3 | C |
@@ -265,9 +268,9 @@ getSuperClass
 | unresolved_subclass.rb:4:1:5:3 | UnresolvedNamespace::Subclass1 | unresolved_subclass.rb:1:1:2:3 | ResolvableBaseClass |
 | unresolved_subclass.rb:7:1:8:3 | UnresolvedNamespace::Subclass2 | unresolved_subclass.rb:4:1:5:3 | UnresolvedNamespace::Subclass1 |
 | unresolved_subclass.rb:11:1:12:3 | UnresolvedNamespace::A | calls.rb:115:1:118:3 | Object |
-| unresolved_subclass.rb:14:1:15:3 | ...::Subclass1 | unresolved_subclass.rb:1:1:2:3 | ResolvableBaseClass |
-| unresolved_subclass.rb:17:1:18:3 | ...::Subclass2 | calls.rb:115:1:118:3 | Object |
-| unresolved_subclass.rb:21:1:22:3 | ...::A | calls.rb:115:1:118:3 | Object |
+| unresolved_subclass.rb:14:1:15:3 | UnresolvedNamespace::X1::X2::X3::Subclass1 | unresolved_subclass.rb:1:1:2:3 | ResolvableBaseClass |
+| unresolved_subclass.rb:17:1:18:3 | UnresolvedNamespace::X1::X2::X3::Subclass2 | unresolved_subclass.rb:14:1:15:3 | UnresolvedNamespace::X1::X2::X3::Subclass1 |
+| unresolved_subclass.rb:21:1:22:3 | UnresolvedNamespace::X1::X2::X3::A | calls.rb:115:1:118:3 | Object |
 getAPrependedModule
 | calls.rb:115:1:118:3 | Object | calls.rb:171:1:174:3 | A |
 | calls.rb:171:1:174:3 | A | toplevel_self_singleton.rb:2:5:5:7 | A::B |
@@ -429,11 +432,27 @@ resolveConstantReadAccess
 | unresolved_subclass.rb:11:7:11:25 | UnresolvedNamespace | UnresolvedNamespace |
 | unresolved_subclass.rb:11:32:11:50 | UnresolvedNamespace | UnresolvedNamespace |
 | unresolved_subclass.rb:14:7:14:25 | UnresolvedNamespace | UnresolvedNamespace |
+| unresolved_subclass.rb:14:7:14:29 | X1 | UnresolvedNamespace::X1 |
+| unresolved_subclass.rb:14:7:14:33 | X2 | UnresolvedNamespace::X1::X2 |
+| unresolved_subclass.rb:14:7:14:37 | X3 | UnresolvedNamespace::X1::X2::X3 |
 | unresolved_subclass.rb:14:52:14:70 | ResolvableBaseClass | ResolvableBaseClass |
 | unresolved_subclass.rb:17:7:17:25 | UnresolvedNamespace | UnresolvedNamespace |
+| unresolved_subclass.rb:17:7:17:29 | X1 | UnresolvedNamespace::X1 |
+| unresolved_subclass.rb:17:7:17:33 | X2 | UnresolvedNamespace::X1::X2 |
+| unresolved_subclass.rb:17:7:17:37 | X3 | UnresolvedNamespace::X1::X2::X3 |
 | unresolved_subclass.rb:17:52:17:70 | UnresolvedNamespace | UnresolvedNamespace |
+| unresolved_subclass.rb:17:52:17:74 | X1 | UnresolvedNamespace::X1 |
+| unresolved_subclass.rb:17:52:17:78 | X2 | UnresolvedNamespace::X1::X2 |
+| unresolved_subclass.rb:17:52:17:82 | X3 | UnresolvedNamespace::X1::X2::X3 |
+| unresolved_subclass.rb:17:52:17:93 | Subclass1 | UnresolvedNamespace::X1::X2::X3::Subclass1 |
 | unresolved_subclass.rb:21:7:21:25 | UnresolvedNamespace | UnresolvedNamespace |
+| unresolved_subclass.rb:21:7:21:29 | X1 | UnresolvedNamespace::X1 |
+| unresolved_subclass.rb:21:7:21:33 | X2 | UnresolvedNamespace::X1::X2 |
+| unresolved_subclass.rb:21:7:21:37 | X3 | UnresolvedNamespace::X1::X2::X3 |
 | unresolved_subclass.rb:21:44:21:62 | UnresolvedNamespace | UnresolvedNamespace |
+| unresolved_subclass.rb:21:44:21:66 | X1 | UnresolvedNamespace::X1 |
+| unresolved_subclass.rb:21:44:21:70 | X2 | UnresolvedNamespace::X1::X2 |
+| unresolved_subclass.rb:21:44:21:74 | X3 | UnresolvedNamespace::X1::X2::X3 |
 resolveConstantWriteAccess
 | calls.rb:21:1:34:3 | M | M |
 | calls.rb:43:1:58:3 | C | C |
@@ -538,6 +557,9 @@ resolveConstantWriteAccess
 | unresolved_subclass.rb:4:1:5:3 | Subclass1 | UnresolvedNamespace::Subclass1 |
 | unresolved_subclass.rb:7:1:8:3 | Subclass2 | UnresolvedNamespace::Subclass2 |
 | unresolved_subclass.rb:11:1:12:3 | A | UnresolvedNamespace::A |
+| unresolved_subclass.rb:14:1:15:3 | Subclass1 | UnresolvedNamespace::X1::X2::X3::Subclass1 |
+| unresolved_subclass.rb:17:1:18:3 | Subclass2 | UnresolvedNamespace::X1::X2::X3::Subclass2 |
+| unresolved_subclass.rb:21:1:22:3 | A | UnresolvedNamespace::X1::X2::X3::A |
 enclosingModule
 | calls.rb:1:1:3:3 | foo | calls.rb:1:1:651:24 | calls.rb |
 | calls.rb:2:5:2:14 | call to puts | calls.rb:1:1:651:24 | calls.rb |

--- a/ruby/ql/test/library-tests/modules/superclasses.expected
+++ b/ruby/ql/test/library-tests/modules/superclasses.expected
@@ -36,6 +36,12 @@
 #-----| TrueClass
 #-----|  -> Object
 
+#-----| UnresolvedNamespace::X1
+
+#-----| UnresolvedNamespace::X1::X2
+
+#-----| UnresolvedNamespace::X1::X2::X3
+
 calls.rb:
 #   21| M
 
@@ -263,11 +269,11 @@ unresolved_subclass.rb:
 #   11| UnresolvedNamespace::A
 #-----|  -> Object
 
-#   14| ...::Subclass1
+#   14| UnresolvedNamespace::X1::X2::X3::Subclass1
 #-----|  -> ResolvableBaseClass
 
-#   17| ...::Subclass2
-#-----|  -> Object
+#   17| UnresolvedNamespace::X1::X2::X3::Subclass2
+#-----|  -> UnresolvedNamespace::X1::X2::X3::Subclass1
 
-#   21| ...::A
+#   21| UnresolvedNamespace::X1::X2::X3::A
 #-----|  -> Object

--- a/ruby/ql/test/library-tests/modules/superclasses.expected
+++ b/ruby/ql/test/library-tests/modules/superclasses.expected
@@ -262,3 +262,12 @@ unresolved_subclass.rb:
 
 #   11| UnresolvedNamespace::A
 #-----|  -> Object
+
+#   14| ...::Subclass1
+#-----|  -> ResolvableBaseClass
+
+#   17| ...::Subclass2
+#-----|  -> Object
+
+#   21| ...::A
+#-----|  -> Object

--- a/ruby/ql/test/library-tests/modules/unresolved_subclass.rb
+++ b/ruby/ql/test/library-tests/modules/unresolved_subclass.rb
@@ -10,3 +10,13 @@ end
 # Ensure Object is a transitive superclass of this
 class UnresolvedNamespace::A < UnresolvedNamespace::B
 end
+
+class UnresolvedNamespace::X1::X2::X3::Subclass1 < ResolvableBaseClass
+end
+
+class UnresolvedNamespace::X1::X2::X3::Subclass2 < UnresolvedNamespace::X1::X2::X3::Subclass1
+end
+
+# Ensure Object is a transitive superclass of this
+class UnresolvedNamespace::X1::X2::X3::A < UnresolvedNamespace::X1::X2::X3::B
+end


### PR DESCRIPTION
Previously we were unable to generate a qualified name for `module A::B::C` unless we could find the definition of `A::B` somewhere. This means that references to that module would fail to resolve, for example:
```rb
class A::B::C
end
class X < A::B::C # <- fail to resolve base class
end
```

This PR extends the approach from https://github.com/github/codeql/pull/10928, and like that PR, doesn't try to fix the problem in general, just fix what can be done without overhauling constant resolution.

Whenever a module/class is declared in the top-level, we assume we've seen a definition of each of the modules mentioned in the scope expression. So in the above example, we assume the existence of a module `A` and `A::B`.

[Evaluation](https://github.com/github/codeql-dca-main/tree/data/asgerf/always-resolve-__nightly__code-scanning/reports) looks good and shows no new alerts, but some worthwhile meta results:
- 756 new call edges
- 4 new taint sinks
- 62 new taint sources
- 417 new tainted nodes

