### PR TITLE
Ruby: Allow for implicit array reads at all sinks during taint tracking

### DIFF
--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/TaintTrackingPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/TaintTrackingPrivate.qll
@@ -17,7 +17,10 @@ predicate defaultTaintSanitizer(DataFlow::Node node) { none() }
  * of `c` at sinks and inputs to additional taint steps.
  */
 bindingset[node]
-predicate defaultImplicitTaintRead(DataFlow::Node node, DataFlow::ContentSet c) { none() }
+predicate defaultImplicitTaintRead(DataFlow::Node node, DataFlow::ContentSet c) {
+  exists(node) and
+  c.isElementOfTypeOrUnknown("int")
+}
 
 private CfgNodes::ExprNodes::VariableWriteAccessCfgNode variablesInPattern(
   CfgNodes::ExprNodes::CasePatternCfgNode p

--- a/ruby/ql/lib/codeql/ruby/frameworks/ActiveRecord.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/ActiveRecord.qll
@@ -201,11 +201,8 @@ private predicate sqlFragmentArgumentInner(DataFlow::CallNode call, DataFlow::No
 }
 
 private predicate sqlFragmentArgument(DataFlow::CallNode call, DataFlow::Node sink) {
-  exists(DataFlow::Node arg |
-    sqlFragmentArgumentInner(call, arg) and
-    sink = [arg, arg.(DataFlow::ArrayLiteralNode).getElement(0)] and
-    unsafeSqlExpr(sink.asExpr().getExpr())
-  )
+  sqlFragmentArgumentInner(call, sink) and
+  unsafeSqlExpr(sink.asExpr().getExpr())
 }
 
 // An expression that, if tainted by unsanitized input, should not be used as

--- a/ruby/ql/lib/codeql/ruby/frameworks/core/Array.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/core/Array.qll
@@ -210,9 +210,28 @@ module Array {
     }
   }
 
+  private predicate isKnownRange(RangeLiteral rl, int start, int end) {
+    (
+      // Either an explicit, positive beginning index...
+      start = rl.getBegin().getConstantValue().getInt() and start >= 0
+      or
+      // Or a begin-less one, since `..n` is equivalent to `0..n`
+      not exists(rl.getBegin()) and start = 0
+    ) and
+    // There must be an explicit end. An end-less range like `2..` is not
+    // treated as a known range, since we don't track the length of the array.
+    exists(int e | e = rl.getEnd().getConstantValue().getInt() and e >= 0 |
+      rl.isInclusive() and end = e
+      or
+      rl.isExclusive() and end = e - 1
+    )
+  }
+
   /**
    * A call to `[]` with an unknown argument, which could be either an index or
-   * a range.
+   * a range. To avoid spurious flow, we are going to ignore the possibility
+   * that the argument might be a range (unless it is an explicit range literal,
+   * see `ElementReferenceRangeReadUnknownSummary`).
    */
   private class ElementReferenceReadUnknownSummary extends ElementReferenceReadSummary {
     ElementReferenceReadUnknownSummary() {
@@ -223,7 +242,7 @@ module Array {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       input = "Argument[self].Element[any]" and
-      output = ["ReturnValue", "ReturnValue.Element[?]"] and
+      output = "ReturnValue" and
       preservesValue = true
     }
   }
@@ -242,24 +261,8 @@ module Array {
       )
       or
       mc.getNumberOfArguments() = 1 and
-      exists(RangeLiteral rl |
-        rl = mc.getArgument(0) and
-        (
-          // Either an explicit, positive beginning index...
-          start = rl.getBegin().getConstantValue().getInt() and start >= 0
-          or
-          // Or a begin-less one, since `..n` is equivalent to `0..n`
-          not exists(rl.getBegin()) and start = 0
-        ) and
-        // There must be an explicit end. An end-less range like `2..` is not
-        // treated as a known range, since we don't track the length of the array.
-        exists(int e | e = rl.getEnd().getConstantValue().getInt() and e >= 0 |
-          rl.isInclusive() and end = e
-          or
-          rl.isExclusive() and end = e - 1
-        ) and
-        this = methodName + "(" + start + ".." + end + ")"
-      )
+      isKnownRange(mc.getArgument(0), start, end) and
+      this = methodName + "(" + start + ".." + end + ")"
     }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
@@ -291,12 +294,7 @@ module Array {
         )
         or
         mc.getNumberOfArguments() = 1 and
-        exists(RangeLiteral rl | rl = mc.getArgument(0) |
-          exists(rl.getBegin()) and
-          not exists(int b | b = rl.getBegin().getConstantValue().getInt() and b >= 0)
-          or
-          not exists(int e | e = rl.getEnd().getConstantValue().getInt() and e >= 0)
-        )
+        mc.getArgument(0) = any(RangeLiteral range | not isKnownRange(range, _, _))
       )
     }
 

--- a/ruby/ql/lib/codeql/ruby/security/UnsafeCodeConstructionQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/UnsafeCodeConstructionQuery.qll
@@ -32,12 +32,6 @@ deprecated class Configuration extends TaintTracking::Configuration {
   override DataFlow::FlowFeature getAFeature() {
     result instanceof DataFlow::FeatureHasSourceCallContext
   }
-
-  override predicate allowImplicitRead(DataFlow::Node node, DataFlow::ContentSet set) {
-    // allow implicit reads of array elements
-    this.isSink(node) and
-    set.isElementOfTypeOrUnknown("int")
-  }
 }
 
 private module UnsafeCodeConstructionConfig implements DataFlow::ConfigSig {

--- a/ruby/ql/lib/codeql/ruby/security/UnsafeShellCommandConstructionQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/UnsafeShellCommandConstructionQuery.qll
@@ -34,12 +34,6 @@ deprecated class Configuration extends TaintTracking::Configuration {
   override DataFlow::FlowFeature getAFeature() {
     result instanceof DataFlow::FeatureHasSourceCallContext
   }
-
-  override predicate allowImplicitRead(DataFlow::Node node, DataFlow::ContentSet set) {
-    // allow implicit reads of array elements
-    this.isSink(node) and
-    set.isElementOfTypeOrUnknown("int")
-  }
 }
 
 private module UnsafeShellCommandConstructionConfig implements DataFlow::ConfigSig {

--- a/ruby/ql/test/library-tests/dataflow/array-flow/array-flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/array-flow/array-flow.expected
@@ -1481,22 +1481,22 @@ edges
 | array_flow.rb:1202:10:1202:10 | b [element] | array_flow.rb:1202:10:1202:13 | ...[...] |
 | array_flow.rb:1206:5:1206:5 | a [element 2] | array_flow.rb:1211:9:1211:9 | a [element 2] |
 | array_flow.rb:1206:5:1206:5 | a [element 2] | array_flow.rb:1214:9:1214:9 | a [element 2] |
-| array_flow.rb:1206:5:1206:5 | a [element 2] | array_flow.rb:1220:9:1220:9 | a [element 2] |
-| array_flow.rb:1206:5:1206:5 | a [element 2] | array_flow.rb:1225:9:1225:9 | a [element 2] |
-| array_flow.rb:1206:5:1206:5 | a [element 2] | array_flow.rb:1229:9:1229:9 | a [element 2] |
-| array_flow.rb:1206:5:1206:5 | a [element 2] | array_flow.rb:1234:9:1234:9 | a [element 2] |
-| array_flow.rb:1206:5:1206:5 | a [element 2] | array_flow.rb:1239:9:1239:9 | a [element 2] |
-| array_flow.rb:1206:5:1206:5 | a [element 2] | array_flow.rb:1243:9:1243:9 | a [element 2] |
-| array_flow.rb:1206:5:1206:5 | a [element 2] | array_flow.rb:1247:9:1247:9 | a [element 2] |
-| array_flow.rb:1206:5:1206:5 | a [element 2] | array_flow.rb:1252:9:1252:9 | a [element 2] |
+| array_flow.rb:1206:5:1206:5 | a [element 2] | array_flow.rb:1221:9:1221:9 | a [element 2] |
+| array_flow.rb:1206:5:1206:5 | a [element 2] | array_flow.rb:1226:9:1226:9 | a [element 2] |
+| array_flow.rb:1206:5:1206:5 | a [element 2] | array_flow.rb:1230:9:1230:9 | a [element 2] |
+| array_flow.rb:1206:5:1206:5 | a [element 2] | array_flow.rb:1235:9:1235:9 | a [element 2] |
+| array_flow.rb:1206:5:1206:5 | a [element 2] | array_flow.rb:1240:9:1240:9 | a [element 2] |
+| array_flow.rb:1206:5:1206:5 | a [element 2] | array_flow.rb:1244:9:1244:9 | a [element 2] |
+| array_flow.rb:1206:5:1206:5 | a [element 2] | array_flow.rb:1248:9:1248:9 | a [element 2] |
+| array_flow.rb:1206:5:1206:5 | a [element 2] | array_flow.rb:1253:9:1253:9 | a [element 2] |
 | array_flow.rb:1206:5:1206:5 | a [element 4] | array_flow.rb:1208:9:1208:9 | a [element 4] |
 | array_flow.rb:1206:5:1206:5 | a [element 4] | array_flow.rb:1211:9:1211:9 | a [element 4] |
 | array_flow.rb:1206:5:1206:5 | a [element 4] | array_flow.rb:1214:9:1214:9 | a [element 4] |
-| array_flow.rb:1206:5:1206:5 | a [element 4] | array_flow.rb:1220:9:1220:9 | a [element 4] |
-| array_flow.rb:1206:5:1206:5 | a [element 4] | array_flow.rb:1225:9:1225:9 | a [element 4] |
-| array_flow.rb:1206:5:1206:5 | a [element 4] | array_flow.rb:1239:9:1239:9 | a [element 4] |
-| array_flow.rb:1206:5:1206:5 | a [element 4] | array_flow.rb:1243:9:1243:9 | a [element 4] |
-| array_flow.rb:1206:5:1206:5 | a [element 4] | array_flow.rb:1252:9:1252:9 | a [element 4] |
+| array_flow.rb:1206:5:1206:5 | a [element 4] | array_flow.rb:1221:9:1221:9 | a [element 4] |
+| array_flow.rb:1206:5:1206:5 | a [element 4] | array_flow.rb:1226:9:1226:9 | a [element 4] |
+| array_flow.rb:1206:5:1206:5 | a [element 4] | array_flow.rb:1240:9:1240:9 | a [element 4] |
+| array_flow.rb:1206:5:1206:5 | a [element 4] | array_flow.rb:1244:9:1244:9 | a [element 4] |
+| array_flow.rb:1206:5:1206:5 | a [element 4] | array_flow.rb:1253:9:1253:9 | a [element 4] |
 | array_flow.rb:1206:16:1206:28 | call to source | array_flow.rb:1206:5:1206:5 | a [element 2] |
 | array_flow.rb:1206:34:1206:46 | call to source | array_flow.rb:1206:5:1206:5 | a [element 4] |
 | array_flow.rb:1208:5:1208:5 | b | array_flow.rb:1209:10:1209:10 | b |
@@ -1507,612 +1507,607 @@ edges
 | array_flow.rb:1211:9:1211:9 | a [element 4] | array_flow.rb:1211:9:1211:19 | call to slice |
 | array_flow.rb:1211:9:1211:19 | call to slice | array_flow.rb:1211:5:1211:5 | b |
 | array_flow.rb:1214:5:1214:5 | b | array_flow.rb:1216:10:1216:10 | b |
-| array_flow.rb:1214:5:1214:5 | b [element] | array_flow.rb:1218:10:1218:10 | b [element] |
 | array_flow.rb:1214:9:1214:9 | a [element 2] | array_flow.rb:1214:9:1214:17 | call to slice |
-| array_flow.rb:1214:9:1214:9 | a [element 2] | array_flow.rb:1214:9:1214:17 | call to slice [element] |
 | array_flow.rb:1214:9:1214:9 | a [element 4] | array_flow.rb:1214:9:1214:17 | call to slice |
-| array_flow.rb:1214:9:1214:9 | a [element 4] | array_flow.rb:1214:9:1214:17 | call to slice [element] |
 | array_flow.rb:1214:9:1214:17 | call to slice | array_flow.rb:1214:5:1214:5 | b |
-| array_flow.rb:1214:9:1214:17 | call to slice [element] | array_flow.rb:1214:5:1214:5 | b [element] |
-| array_flow.rb:1218:10:1218:10 | b [element] | array_flow.rb:1218:10:1218:13 | ...[...] |
-| array_flow.rb:1220:5:1220:5 | b [element 0] | array_flow.rb:1221:10:1221:10 | b [element 0] |
-| array_flow.rb:1220:5:1220:5 | b [element 2] | array_flow.rb:1223:10:1223:10 | b [element 2] |
-| array_flow.rb:1220:9:1220:9 | a [element 2] | array_flow.rb:1220:9:1220:21 | call to slice [element 0] |
-| array_flow.rb:1220:9:1220:9 | a [element 4] | array_flow.rb:1220:9:1220:21 | call to slice [element 2] |
-| array_flow.rb:1220:9:1220:21 | call to slice [element 0] | array_flow.rb:1220:5:1220:5 | b [element 0] |
-| array_flow.rb:1220:9:1220:21 | call to slice [element 2] | array_flow.rb:1220:5:1220:5 | b [element 2] |
-| array_flow.rb:1221:10:1221:10 | b [element 0] | array_flow.rb:1221:10:1221:13 | ...[...] |
-| array_flow.rb:1223:10:1223:10 | b [element 2] | array_flow.rb:1223:10:1223:13 | ...[...] |
-| array_flow.rb:1225:5:1225:5 | b [element] | array_flow.rb:1226:10:1226:10 | b [element] |
-| array_flow.rb:1225:5:1225:5 | b [element] | array_flow.rb:1227:10:1227:10 | b [element] |
-| array_flow.rb:1225:9:1225:9 | a [element 2] | array_flow.rb:1225:9:1225:21 | call to slice [element] |
-| array_flow.rb:1225:9:1225:9 | a [element 4] | array_flow.rb:1225:9:1225:21 | call to slice [element] |
-| array_flow.rb:1225:9:1225:21 | call to slice [element] | array_flow.rb:1225:5:1225:5 | b [element] |
-| array_flow.rb:1226:10:1226:10 | b [element] | array_flow.rb:1226:10:1226:13 | ...[...] |
+| array_flow.rb:1221:5:1221:5 | b [element 0] | array_flow.rb:1222:10:1222:10 | b [element 0] |
+| array_flow.rb:1221:5:1221:5 | b [element 2] | array_flow.rb:1224:10:1224:10 | b [element 2] |
+| array_flow.rb:1221:9:1221:9 | a [element 2] | array_flow.rb:1221:9:1221:21 | call to slice [element 0] |
+| array_flow.rb:1221:9:1221:9 | a [element 4] | array_flow.rb:1221:9:1221:21 | call to slice [element 2] |
+| array_flow.rb:1221:9:1221:21 | call to slice [element 0] | array_flow.rb:1221:5:1221:5 | b [element 0] |
+| array_flow.rb:1221:9:1221:21 | call to slice [element 2] | array_flow.rb:1221:5:1221:5 | b [element 2] |
+| array_flow.rb:1222:10:1222:10 | b [element 0] | array_flow.rb:1222:10:1222:13 | ...[...] |
+| array_flow.rb:1224:10:1224:10 | b [element 2] | array_flow.rb:1224:10:1224:13 | ...[...] |
+| array_flow.rb:1226:5:1226:5 | b [element] | array_flow.rb:1227:10:1227:10 | b [element] |
+| array_flow.rb:1226:5:1226:5 | b [element] | array_flow.rb:1228:10:1228:10 | b [element] |
+| array_flow.rb:1226:9:1226:9 | a [element 2] | array_flow.rb:1226:9:1226:21 | call to slice [element] |
+| array_flow.rb:1226:9:1226:9 | a [element 4] | array_flow.rb:1226:9:1226:21 | call to slice [element] |
+| array_flow.rb:1226:9:1226:21 | call to slice [element] | array_flow.rb:1226:5:1226:5 | b [element] |
 | array_flow.rb:1227:10:1227:10 | b [element] | array_flow.rb:1227:10:1227:13 | ...[...] |
-| array_flow.rb:1229:5:1229:5 | b [element 0] | array_flow.rb:1230:10:1230:10 | b [element 0] |
-| array_flow.rb:1229:9:1229:9 | a [element 2] | array_flow.rb:1229:9:1229:21 | call to slice [element 0] |
-| array_flow.rb:1229:9:1229:21 | call to slice [element 0] | array_flow.rb:1229:5:1229:5 | b [element 0] |
-| array_flow.rb:1230:10:1230:10 | b [element 0] | array_flow.rb:1230:10:1230:13 | ...[...] |
-| array_flow.rb:1234:5:1234:5 | b [element 0] | array_flow.rb:1235:10:1235:10 | b [element 0] |
-| array_flow.rb:1234:9:1234:9 | a [element 2] | array_flow.rb:1234:9:1234:22 | call to slice [element 0] |
-| array_flow.rb:1234:9:1234:22 | call to slice [element 0] | array_flow.rb:1234:5:1234:5 | b [element 0] |
-| array_flow.rb:1235:10:1235:10 | b [element 0] | array_flow.rb:1235:10:1235:13 | ...[...] |
-| array_flow.rb:1239:5:1239:5 | b [element] | array_flow.rb:1240:10:1240:10 | b [element] |
-| array_flow.rb:1239:5:1239:5 | b [element] | array_flow.rb:1241:10:1241:10 | b [element] |
-| array_flow.rb:1239:9:1239:9 | a [element 2] | array_flow.rb:1239:9:1239:21 | call to slice [element] |
-| array_flow.rb:1239:9:1239:9 | a [element 4] | array_flow.rb:1239:9:1239:21 | call to slice [element] |
-| array_flow.rb:1239:9:1239:21 | call to slice [element] | array_flow.rb:1239:5:1239:5 | b [element] |
-| array_flow.rb:1240:10:1240:10 | b [element] | array_flow.rb:1240:10:1240:13 | ...[...] |
+| array_flow.rb:1228:10:1228:10 | b [element] | array_flow.rb:1228:10:1228:13 | ...[...] |
+| array_flow.rb:1230:5:1230:5 | b [element 0] | array_flow.rb:1231:10:1231:10 | b [element 0] |
+| array_flow.rb:1230:9:1230:9 | a [element 2] | array_flow.rb:1230:9:1230:21 | call to slice [element 0] |
+| array_flow.rb:1230:9:1230:21 | call to slice [element 0] | array_flow.rb:1230:5:1230:5 | b [element 0] |
+| array_flow.rb:1231:10:1231:10 | b [element 0] | array_flow.rb:1231:10:1231:13 | ...[...] |
+| array_flow.rb:1235:5:1235:5 | b [element 0] | array_flow.rb:1236:10:1236:10 | b [element 0] |
+| array_flow.rb:1235:9:1235:9 | a [element 2] | array_flow.rb:1235:9:1235:22 | call to slice [element 0] |
+| array_flow.rb:1235:9:1235:22 | call to slice [element 0] | array_flow.rb:1235:5:1235:5 | b [element 0] |
+| array_flow.rb:1236:10:1236:10 | b [element 0] | array_flow.rb:1236:10:1236:13 | ...[...] |
+| array_flow.rb:1240:5:1240:5 | b [element] | array_flow.rb:1241:10:1241:10 | b [element] |
+| array_flow.rb:1240:5:1240:5 | b [element] | array_flow.rb:1242:10:1242:10 | b [element] |
+| array_flow.rb:1240:9:1240:9 | a [element 2] | array_flow.rb:1240:9:1240:21 | call to slice [element] |
+| array_flow.rb:1240:9:1240:9 | a [element 4] | array_flow.rb:1240:9:1240:21 | call to slice [element] |
+| array_flow.rb:1240:9:1240:21 | call to slice [element] | array_flow.rb:1240:5:1240:5 | b [element] |
 | array_flow.rb:1241:10:1241:10 | b [element] | array_flow.rb:1241:10:1241:13 | ...[...] |
-| array_flow.rb:1243:5:1243:5 | b [element] | array_flow.rb:1244:10:1244:10 | b [element] |
-| array_flow.rb:1243:5:1243:5 | b [element] | array_flow.rb:1245:10:1245:10 | b [element] |
-| array_flow.rb:1243:9:1243:9 | a [element 2] | array_flow.rb:1243:9:1243:24 | call to slice [element] |
-| array_flow.rb:1243:9:1243:9 | a [element 4] | array_flow.rb:1243:9:1243:24 | call to slice [element] |
-| array_flow.rb:1243:9:1243:24 | call to slice [element] | array_flow.rb:1243:5:1243:5 | b [element] |
-| array_flow.rb:1244:10:1244:10 | b [element] | array_flow.rb:1244:10:1244:13 | ...[...] |
+| array_flow.rb:1242:10:1242:10 | b [element] | array_flow.rb:1242:10:1242:13 | ...[...] |
+| array_flow.rb:1244:5:1244:5 | b [element] | array_flow.rb:1245:10:1245:10 | b [element] |
+| array_flow.rb:1244:5:1244:5 | b [element] | array_flow.rb:1246:10:1246:10 | b [element] |
+| array_flow.rb:1244:9:1244:9 | a [element 2] | array_flow.rb:1244:9:1244:24 | call to slice [element] |
+| array_flow.rb:1244:9:1244:9 | a [element 4] | array_flow.rb:1244:9:1244:24 | call to slice [element] |
+| array_flow.rb:1244:9:1244:24 | call to slice [element] | array_flow.rb:1244:5:1244:5 | b [element] |
 | array_flow.rb:1245:10:1245:10 | b [element] | array_flow.rb:1245:10:1245:13 | ...[...] |
-| array_flow.rb:1247:5:1247:5 | b [element 2] | array_flow.rb:1250:10:1250:10 | b [element 2] |
-| array_flow.rb:1247:9:1247:9 | a [element 2] | array_flow.rb:1247:9:1247:20 | call to slice [element 2] |
-| array_flow.rb:1247:9:1247:20 | call to slice [element 2] | array_flow.rb:1247:5:1247:5 | b [element 2] |
-| array_flow.rb:1250:10:1250:10 | b [element 2] | array_flow.rb:1250:10:1250:13 | ...[...] |
-| array_flow.rb:1252:5:1252:5 | b [element] | array_flow.rb:1253:10:1253:10 | b [element] |
-| array_flow.rb:1252:5:1252:5 | b [element] | array_flow.rb:1254:10:1254:10 | b [element] |
-| array_flow.rb:1252:5:1252:5 | b [element] | array_flow.rb:1255:10:1255:10 | b [element] |
-| array_flow.rb:1252:9:1252:9 | a [element 2] | array_flow.rb:1252:9:1252:20 | call to slice [element] |
-| array_flow.rb:1252:9:1252:9 | a [element 4] | array_flow.rb:1252:9:1252:20 | call to slice [element] |
-| array_flow.rb:1252:9:1252:20 | call to slice [element] | array_flow.rb:1252:5:1252:5 | b [element] |
-| array_flow.rb:1253:10:1253:10 | b [element] | array_flow.rb:1253:10:1253:13 | ...[...] |
+| array_flow.rb:1246:10:1246:10 | b [element] | array_flow.rb:1246:10:1246:13 | ...[...] |
+| array_flow.rb:1248:5:1248:5 | b [element 2] | array_flow.rb:1251:10:1251:10 | b [element 2] |
+| array_flow.rb:1248:9:1248:9 | a [element 2] | array_flow.rb:1248:9:1248:20 | call to slice [element 2] |
+| array_flow.rb:1248:9:1248:20 | call to slice [element 2] | array_flow.rb:1248:5:1248:5 | b [element 2] |
+| array_flow.rb:1251:10:1251:10 | b [element 2] | array_flow.rb:1251:10:1251:13 | ...[...] |
+| array_flow.rb:1253:5:1253:5 | b [element] | array_flow.rb:1254:10:1254:10 | b [element] |
+| array_flow.rb:1253:5:1253:5 | b [element] | array_flow.rb:1255:10:1255:10 | b [element] |
+| array_flow.rb:1253:5:1253:5 | b [element] | array_flow.rb:1256:10:1256:10 | b [element] |
+| array_flow.rb:1253:9:1253:9 | a [element 2] | array_flow.rb:1253:9:1253:20 | call to slice [element] |
+| array_flow.rb:1253:9:1253:9 | a [element 4] | array_flow.rb:1253:9:1253:20 | call to slice [element] |
+| array_flow.rb:1253:9:1253:20 | call to slice [element] | array_flow.rb:1253:5:1253:5 | b [element] |
 | array_flow.rb:1254:10:1254:10 | b [element] | array_flow.rb:1254:10:1254:13 | ...[...] |
 | array_flow.rb:1255:10:1255:10 | b [element] | array_flow.rb:1255:10:1255:13 | ...[...] |
-| array_flow.rb:1259:5:1259:5 | a [element 2] | array_flow.rb:1260:9:1260:9 | a [element 2] |
-| array_flow.rb:1259:5:1259:5 | a [element 4] | array_flow.rb:1260:9:1260:9 | a [element 4] |
-| array_flow.rb:1259:16:1259:28 | call to source | array_flow.rb:1259:5:1259:5 | a [element 2] |
-| array_flow.rb:1259:34:1259:46 | call to source | array_flow.rb:1259:5:1259:5 | a [element 4] |
-| array_flow.rb:1260:5:1260:5 | b | array_flow.rb:1261:10:1261:10 | b |
-| array_flow.rb:1260:9:1260:9 | [post] a [element 3] | array_flow.rb:1265:10:1265:10 | a [element 3] |
-| array_flow.rb:1260:9:1260:9 | a [element 2] | array_flow.rb:1260:9:1260:19 | call to slice! |
-| array_flow.rb:1260:9:1260:9 | a [element 4] | array_flow.rb:1260:9:1260:9 | [post] a [element 3] |
-| array_flow.rb:1260:9:1260:19 | call to slice! | array_flow.rb:1260:5:1260:5 | b |
-| array_flow.rb:1265:10:1265:10 | a [element 3] | array_flow.rb:1265:10:1265:13 | ...[...] |
-| array_flow.rb:1267:5:1267:5 | a [element 2] | array_flow.rb:1268:9:1268:9 | a [element 2] |
-| array_flow.rb:1267:5:1267:5 | a [element 4] | array_flow.rb:1268:9:1268:9 | a [element 4] |
-| array_flow.rb:1267:16:1267:28 | call to source | array_flow.rb:1267:5:1267:5 | a [element 2] |
-| array_flow.rb:1267:34:1267:46 | call to source | array_flow.rb:1267:5:1267:5 | a [element 4] |
-| array_flow.rb:1268:5:1268:5 | b | array_flow.rb:1274:10:1274:10 | b |
-| array_flow.rb:1268:5:1268:5 | b [element] | array_flow.rb:1276:10:1276:10 | b [element] |
-| array_flow.rb:1268:9:1268:9 | [post] a [element] | array_flow.rb:1269:10:1269:10 | a [element] |
-| array_flow.rb:1268:9:1268:9 | [post] a [element] | array_flow.rb:1270:10:1270:10 | a [element] |
-| array_flow.rb:1268:9:1268:9 | [post] a [element] | array_flow.rb:1271:10:1271:10 | a [element] |
-| array_flow.rb:1268:9:1268:9 | [post] a [element] | array_flow.rb:1272:10:1272:10 | a [element] |
-| array_flow.rb:1268:9:1268:9 | a [element 2] | array_flow.rb:1268:9:1268:9 | [post] a [element] |
-| array_flow.rb:1268:9:1268:9 | a [element 2] | array_flow.rb:1268:9:1268:19 | call to slice! |
-| array_flow.rb:1268:9:1268:9 | a [element 2] | array_flow.rb:1268:9:1268:19 | call to slice! [element] |
-| array_flow.rb:1268:9:1268:9 | a [element 4] | array_flow.rb:1268:9:1268:9 | [post] a [element] |
-| array_flow.rb:1268:9:1268:9 | a [element 4] | array_flow.rb:1268:9:1268:19 | call to slice! |
-| array_flow.rb:1268:9:1268:9 | a [element 4] | array_flow.rb:1268:9:1268:19 | call to slice! [element] |
-| array_flow.rb:1268:9:1268:19 | call to slice! | array_flow.rb:1268:5:1268:5 | b |
-| array_flow.rb:1268:9:1268:19 | call to slice! [element] | array_flow.rb:1268:5:1268:5 | b [element] |
-| array_flow.rb:1269:10:1269:10 | a [element] | array_flow.rb:1269:10:1269:13 | ...[...] |
+| array_flow.rb:1256:10:1256:10 | b [element] | array_flow.rb:1256:10:1256:13 | ...[...] |
+| array_flow.rb:1260:5:1260:5 | a [element 2] | array_flow.rb:1261:9:1261:9 | a [element 2] |
+| array_flow.rb:1260:5:1260:5 | a [element 4] | array_flow.rb:1261:9:1261:9 | a [element 4] |
+| array_flow.rb:1260:16:1260:28 | call to source | array_flow.rb:1260:5:1260:5 | a [element 2] |
+| array_flow.rb:1260:34:1260:46 | call to source | array_flow.rb:1260:5:1260:5 | a [element 4] |
+| array_flow.rb:1261:5:1261:5 | b | array_flow.rb:1262:10:1262:10 | b |
+| array_flow.rb:1261:9:1261:9 | [post] a [element 3] | array_flow.rb:1266:10:1266:10 | a [element 3] |
+| array_flow.rb:1261:9:1261:9 | a [element 2] | array_flow.rb:1261:9:1261:19 | call to slice! |
+| array_flow.rb:1261:9:1261:9 | a [element 4] | array_flow.rb:1261:9:1261:9 | [post] a [element 3] |
+| array_flow.rb:1261:9:1261:19 | call to slice! | array_flow.rb:1261:5:1261:5 | b |
+| array_flow.rb:1266:10:1266:10 | a [element 3] | array_flow.rb:1266:10:1266:13 | ...[...] |
+| array_flow.rb:1268:5:1268:5 | a [element 2] | array_flow.rb:1269:9:1269:9 | a [element 2] |
+| array_flow.rb:1268:5:1268:5 | a [element 4] | array_flow.rb:1269:9:1269:9 | a [element 4] |
+| array_flow.rb:1268:16:1268:28 | call to source | array_flow.rb:1268:5:1268:5 | a [element 2] |
+| array_flow.rb:1268:34:1268:46 | call to source | array_flow.rb:1268:5:1268:5 | a [element 4] |
+| array_flow.rb:1269:5:1269:5 | b | array_flow.rb:1275:10:1275:10 | b |
+| array_flow.rb:1269:5:1269:5 | b [element] | array_flow.rb:1277:10:1277:10 | b [element] |
+| array_flow.rb:1269:9:1269:9 | [post] a [element] | array_flow.rb:1270:10:1270:10 | a [element] |
+| array_flow.rb:1269:9:1269:9 | [post] a [element] | array_flow.rb:1271:10:1271:10 | a [element] |
+| array_flow.rb:1269:9:1269:9 | [post] a [element] | array_flow.rb:1272:10:1272:10 | a [element] |
+| array_flow.rb:1269:9:1269:9 | [post] a [element] | array_flow.rb:1273:10:1273:10 | a [element] |
+| array_flow.rb:1269:9:1269:9 | a [element 2] | array_flow.rb:1269:9:1269:9 | [post] a [element] |
+| array_flow.rb:1269:9:1269:9 | a [element 2] | array_flow.rb:1269:9:1269:19 | call to slice! |
+| array_flow.rb:1269:9:1269:9 | a [element 2] | array_flow.rb:1269:9:1269:19 | call to slice! [element] |
+| array_flow.rb:1269:9:1269:9 | a [element 4] | array_flow.rb:1269:9:1269:9 | [post] a [element] |
+| array_flow.rb:1269:9:1269:9 | a [element 4] | array_flow.rb:1269:9:1269:19 | call to slice! |
+| array_flow.rb:1269:9:1269:9 | a [element 4] | array_flow.rb:1269:9:1269:19 | call to slice! [element] |
+| array_flow.rb:1269:9:1269:19 | call to slice! | array_flow.rb:1269:5:1269:5 | b |
+| array_flow.rb:1269:9:1269:19 | call to slice! [element] | array_flow.rb:1269:5:1269:5 | b [element] |
 | array_flow.rb:1270:10:1270:10 | a [element] | array_flow.rb:1270:10:1270:13 | ...[...] |
 | array_flow.rb:1271:10:1271:10 | a [element] | array_flow.rb:1271:10:1271:13 | ...[...] |
 | array_flow.rb:1272:10:1272:10 | a [element] | array_flow.rb:1272:10:1272:13 | ...[...] |
-| array_flow.rb:1276:10:1276:10 | b [element] | array_flow.rb:1276:10:1276:13 | ...[...] |
-| array_flow.rb:1278:5:1278:5 | a [element 2] | array_flow.rb:1279:9:1279:9 | a [element 2] |
-| array_flow.rb:1278:5:1278:5 | a [element 4] | array_flow.rb:1279:9:1279:9 | a [element 4] |
-| array_flow.rb:1278:16:1278:28 | call to source | array_flow.rb:1278:5:1278:5 | a [element 2] |
-| array_flow.rb:1278:34:1278:46 | call to source | array_flow.rb:1278:5:1278:5 | a [element 4] |
-| array_flow.rb:1279:5:1279:5 | b [element 0] | array_flow.rb:1280:10:1280:10 | b [element 0] |
-| array_flow.rb:1279:5:1279:5 | b [element 2] | array_flow.rb:1282:10:1282:10 | b [element 2] |
-| array_flow.rb:1279:9:1279:9 | a [element 2] | array_flow.rb:1279:9:1279:22 | call to slice! [element 0] |
-| array_flow.rb:1279:9:1279:9 | a [element 4] | array_flow.rb:1279:9:1279:22 | call to slice! [element 2] |
-| array_flow.rb:1279:9:1279:22 | call to slice! [element 0] | array_flow.rb:1279:5:1279:5 | b [element 0] |
-| array_flow.rb:1279:9:1279:22 | call to slice! [element 2] | array_flow.rb:1279:5:1279:5 | b [element 2] |
-| array_flow.rb:1280:10:1280:10 | b [element 0] | array_flow.rb:1280:10:1280:13 | ...[...] |
-| array_flow.rb:1282:10:1282:10 | b [element 2] | array_flow.rb:1282:10:1282:13 | ...[...] |
-| array_flow.rb:1289:5:1289:5 | a [element 2] | array_flow.rb:1290:9:1290:9 | a [element 2] |
-| array_flow.rb:1289:5:1289:5 | a [element 4] | array_flow.rb:1290:9:1290:9 | a [element 4] |
-| array_flow.rb:1289:16:1289:28 | call to source | array_flow.rb:1289:5:1289:5 | a [element 2] |
-| array_flow.rb:1289:34:1289:46 | call to source | array_flow.rb:1289:5:1289:5 | a [element 4] |
-| array_flow.rb:1290:5:1290:5 | b [element 0] | array_flow.rb:1291:10:1291:10 | b [element 0] |
-| array_flow.rb:1290:9:1290:9 | [post] a [element 2] | array_flow.rb:1296:10:1296:10 | a [element 2] |
-| array_flow.rb:1290:9:1290:9 | a [element 2] | array_flow.rb:1290:9:1290:22 | call to slice! [element 0] |
-| array_flow.rb:1290:9:1290:9 | a [element 4] | array_flow.rb:1290:9:1290:9 | [post] a [element 2] |
-| array_flow.rb:1290:9:1290:22 | call to slice! [element 0] | array_flow.rb:1290:5:1290:5 | b [element 0] |
-| array_flow.rb:1291:10:1291:10 | b [element 0] | array_flow.rb:1291:10:1291:13 | ...[...] |
-| array_flow.rb:1296:10:1296:10 | a [element 2] | array_flow.rb:1296:10:1296:13 | ...[...] |
-| array_flow.rb:1300:5:1300:5 | a [element 2] | array_flow.rb:1301:9:1301:9 | a [element 2] |
-| array_flow.rb:1300:5:1300:5 | a [element 4] | array_flow.rb:1301:9:1301:9 | a [element 4] |
-| array_flow.rb:1300:16:1300:28 | call to source | array_flow.rb:1300:5:1300:5 | a [element 2] |
-| array_flow.rb:1300:34:1300:46 | call to source | array_flow.rb:1300:5:1300:5 | a [element 4] |
-| array_flow.rb:1301:5:1301:5 | b [element 0] | array_flow.rb:1302:10:1302:10 | b [element 0] |
-| array_flow.rb:1301:9:1301:9 | [post] a [element 2] | array_flow.rb:1307:10:1307:10 | a [element 2] |
-| array_flow.rb:1301:9:1301:9 | a [element 2] | array_flow.rb:1301:9:1301:23 | call to slice! [element 0] |
-| array_flow.rb:1301:9:1301:9 | a [element 4] | array_flow.rb:1301:9:1301:9 | [post] a [element 2] |
-| array_flow.rb:1301:9:1301:23 | call to slice! [element 0] | array_flow.rb:1301:5:1301:5 | b [element 0] |
-| array_flow.rb:1302:10:1302:10 | b [element 0] | array_flow.rb:1302:10:1302:13 | ...[...] |
-| array_flow.rb:1307:10:1307:10 | a [element 2] | array_flow.rb:1307:10:1307:13 | ...[...] |
-| array_flow.rb:1311:5:1311:5 | a [element 2] | array_flow.rb:1312:9:1312:9 | a [element 2] |
-| array_flow.rb:1311:5:1311:5 | a [element 4] | array_flow.rb:1312:9:1312:9 | a [element 4] |
-| array_flow.rb:1311:16:1311:28 | call to source | array_flow.rb:1311:5:1311:5 | a [element 2] |
-| array_flow.rb:1311:34:1311:46 | call to source | array_flow.rb:1311:5:1311:5 | a [element 4] |
-| array_flow.rb:1312:5:1312:5 | b [element] | array_flow.rb:1313:10:1313:10 | b [element] |
-| array_flow.rb:1312:5:1312:5 | b [element] | array_flow.rb:1314:10:1314:10 | b [element] |
-| array_flow.rb:1312:5:1312:5 | b [element] | array_flow.rb:1315:10:1315:10 | b [element] |
-| array_flow.rb:1312:9:1312:9 | [post] a [element] | array_flow.rb:1316:10:1316:10 | a [element] |
-| array_flow.rb:1312:9:1312:9 | [post] a [element] | array_flow.rb:1317:10:1317:10 | a [element] |
-| array_flow.rb:1312:9:1312:9 | [post] a [element] | array_flow.rb:1318:10:1318:10 | a [element] |
-| array_flow.rb:1312:9:1312:9 | a [element 2] | array_flow.rb:1312:9:1312:9 | [post] a [element] |
-| array_flow.rb:1312:9:1312:9 | a [element 2] | array_flow.rb:1312:9:1312:22 | call to slice! [element] |
-| array_flow.rb:1312:9:1312:9 | a [element 4] | array_flow.rb:1312:9:1312:9 | [post] a [element] |
-| array_flow.rb:1312:9:1312:9 | a [element 4] | array_flow.rb:1312:9:1312:22 | call to slice! [element] |
-| array_flow.rb:1312:9:1312:22 | call to slice! [element] | array_flow.rb:1312:5:1312:5 | b [element] |
-| array_flow.rb:1313:10:1313:10 | b [element] | array_flow.rb:1313:10:1313:13 | ...[...] |
+| array_flow.rb:1273:10:1273:10 | a [element] | array_flow.rb:1273:10:1273:13 | ...[...] |
+| array_flow.rb:1277:10:1277:10 | b [element] | array_flow.rb:1277:10:1277:13 | ...[...] |
+| array_flow.rb:1279:5:1279:5 | a [element 2] | array_flow.rb:1280:9:1280:9 | a [element 2] |
+| array_flow.rb:1279:5:1279:5 | a [element 4] | array_flow.rb:1280:9:1280:9 | a [element 4] |
+| array_flow.rb:1279:16:1279:28 | call to source | array_flow.rb:1279:5:1279:5 | a [element 2] |
+| array_flow.rb:1279:34:1279:46 | call to source | array_flow.rb:1279:5:1279:5 | a [element 4] |
+| array_flow.rb:1280:5:1280:5 | b [element 0] | array_flow.rb:1281:10:1281:10 | b [element 0] |
+| array_flow.rb:1280:5:1280:5 | b [element 2] | array_flow.rb:1283:10:1283:10 | b [element 2] |
+| array_flow.rb:1280:9:1280:9 | a [element 2] | array_flow.rb:1280:9:1280:22 | call to slice! [element 0] |
+| array_flow.rb:1280:9:1280:9 | a [element 4] | array_flow.rb:1280:9:1280:22 | call to slice! [element 2] |
+| array_flow.rb:1280:9:1280:22 | call to slice! [element 0] | array_flow.rb:1280:5:1280:5 | b [element 0] |
+| array_flow.rb:1280:9:1280:22 | call to slice! [element 2] | array_flow.rb:1280:5:1280:5 | b [element 2] |
+| array_flow.rb:1281:10:1281:10 | b [element 0] | array_flow.rb:1281:10:1281:13 | ...[...] |
+| array_flow.rb:1283:10:1283:10 | b [element 2] | array_flow.rb:1283:10:1283:13 | ...[...] |
+| array_flow.rb:1290:5:1290:5 | a [element 2] | array_flow.rb:1291:9:1291:9 | a [element 2] |
+| array_flow.rb:1290:5:1290:5 | a [element 4] | array_flow.rb:1291:9:1291:9 | a [element 4] |
+| array_flow.rb:1290:16:1290:28 | call to source | array_flow.rb:1290:5:1290:5 | a [element 2] |
+| array_flow.rb:1290:34:1290:46 | call to source | array_flow.rb:1290:5:1290:5 | a [element 4] |
+| array_flow.rb:1291:5:1291:5 | b [element 0] | array_flow.rb:1292:10:1292:10 | b [element 0] |
+| array_flow.rb:1291:9:1291:9 | [post] a [element 2] | array_flow.rb:1297:10:1297:10 | a [element 2] |
+| array_flow.rb:1291:9:1291:9 | a [element 2] | array_flow.rb:1291:9:1291:22 | call to slice! [element 0] |
+| array_flow.rb:1291:9:1291:9 | a [element 4] | array_flow.rb:1291:9:1291:9 | [post] a [element 2] |
+| array_flow.rb:1291:9:1291:22 | call to slice! [element 0] | array_flow.rb:1291:5:1291:5 | b [element 0] |
+| array_flow.rb:1292:10:1292:10 | b [element 0] | array_flow.rb:1292:10:1292:13 | ...[...] |
+| array_flow.rb:1297:10:1297:10 | a [element 2] | array_flow.rb:1297:10:1297:13 | ...[...] |
+| array_flow.rb:1301:5:1301:5 | a [element 2] | array_flow.rb:1302:9:1302:9 | a [element 2] |
+| array_flow.rb:1301:5:1301:5 | a [element 4] | array_flow.rb:1302:9:1302:9 | a [element 4] |
+| array_flow.rb:1301:16:1301:28 | call to source | array_flow.rb:1301:5:1301:5 | a [element 2] |
+| array_flow.rb:1301:34:1301:46 | call to source | array_flow.rb:1301:5:1301:5 | a [element 4] |
+| array_flow.rb:1302:5:1302:5 | b [element 0] | array_flow.rb:1303:10:1303:10 | b [element 0] |
+| array_flow.rb:1302:9:1302:9 | [post] a [element 2] | array_flow.rb:1308:10:1308:10 | a [element 2] |
+| array_flow.rb:1302:9:1302:9 | a [element 2] | array_flow.rb:1302:9:1302:23 | call to slice! [element 0] |
+| array_flow.rb:1302:9:1302:9 | a [element 4] | array_flow.rb:1302:9:1302:9 | [post] a [element 2] |
+| array_flow.rb:1302:9:1302:23 | call to slice! [element 0] | array_flow.rb:1302:5:1302:5 | b [element 0] |
+| array_flow.rb:1303:10:1303:10 | b [element 0] | array_flow.rb:1303:10:1303:13 | ...[...] |
+| array_flow.rb:1308:10:1308:10 | a [element 2] | array_flow.rb:1308:10:1308:13 | ...[...] |
+| array_flow.rb:1312:5:1312:5 | a [element 2] | array_flow.rb:1313:9:1313:9 | a [element 2] |
+| array_flow.rb:1312:5:1312:5 | a [element 4] | array_flow.rb:1313:9:1313:9 | a [element 4] |
+| array_flow.rb:1312:16:1312:28 | call to source | array_flow.rb:1312:5:1312:5 | a [element 2] |
+| array_flow.rb:1312:34:1312:46 | call to source | array_flow.rb:1312:5:1312:5 | a [element 4] |
+| array_flow.rb:1313:5:1313:5 | b [element] | array_flow.rb:1314:10:1314:10 | b [element] |
+| array_flow.rb:1313:5:1313:5 | b [element] | array_flow.rb:1315:10:1315:10 | b [element] |
+| array_flow.rb:1313:5:1313:5 | b [element] | array_flow.rb:1316:10:1316:10 | b [element] |
+| array_flow.rb:1313:9:1313:9 | [post] a [element] | array_flow.rb:1317:10:1317:10 | a [element] |
+| array_flow.rb:1313:9:1313:9 | [post] a [element] | array_flow.rb:1318:10:1318:10 | a [element] |
+| array_flow.rb:1313:9:1313:9 | [post] a [element] | array_flow.rb:1319:10:1319:10 | a [element] |
+| array_flow.rb:1313:9:1313:9 | a [element 2] | array_flow.rb:1313:9:1313:9 | [post] a [element] |
+| array_flow.rb:1313:9:1313:9 | a [element 2] | array_flow.rb:1313:9:1313:22 | call to slice! [element] |
+| array_flow.rb:1313:9:1313:9 | a [element 4] | array_flow.rb:1313:9:1313:9 | [post] a [element] |
+| array_flow.rb:1313:9:1313:9 | a [element 4] | array_flow.rb:1313:9:1313:22 | call to slice! [element] |
+| array_flow.rb:1313:9:1313:22 | call to slice! [element] | array_flow.rb:1313:5:1313:5 | b [element] |
 | array_flow.rb:1314:10:1314:10 | b [element] | array_flow.rb:1314:10:1314:13 | ...[...] |
 | array_flow.rb:1315:10:1315:10 | b [element] | array_flow.rb:1315:10:1315:13 | ...[...] |
-| array_flow.rb:1316:10:1316:10 | a [element] | array_flow.rb:1316:10:1316:13 | ...[...] |
+| array_flow.rb:1316:10:1316:10 | b [element] | array_flow.rb:1316:10:1316:13 | ...[...] |
 | array_flow.rb:1317:10:1317:10 | a [element] | array_flow.rb:1317:10:1317:13 | ...[...] |
 | array_flow.rb:1318:10:1318:10 | a [element] | array_flow.rb:1318:10:1318:13 | ...[...] |
-| array_flow.rb:1320:5:1320:5 | a [element 2] | array_flow.rb:1321:9:1321:9 | a [element 2] |
-| array_flow.rb:1320:5:1320:5 | a [element 4] | array_flow.rb:1321:9:1321:9 | a [element 4] |
-| array_flow.rb:1320:16:1320:28 | call to source | array_flow.rb:1320:5:1320:5 | a [element 2] |
-| array_flow.rb:1320:34:1320:46 | call to source | array_flow.rb:1320:5:1320:5 | a [element 4] |
-| array_flow.rb:1321:5:1321:5 | b [element] | array_flow.rb:1322:10:1322:10 | b [element] |
-| array_flow.rb:1321:5:1321:5 | b [element] | array_flow.rb:1323:10:1323:10 | b [element] |
-| array_flow.rb:1321:5:1321:5 | b [element] | array_flow.rb:1324:10:1324:10 | b [element] |
-| array_flow.rb:1321:9:1321:9 | [post] a [element] | array_flow.rb:1325:10:1325:10 | a [element] |
-| array_flow.rb:1321:9:1321:9 | [post] a [element] | array_flow.rb:1326:10:1326:10 | a [element] |
-| array_flow.rb:1321:9:1321:9 | [post] a [element] | array_flow.rb:1327:10:1327:10 | a [element] |
-| array_flow.rb:1321:9:1321:9 | a [element 2] | array_flow.rb:1321:9:1321:9 | [post] a [element] |
-| array_flow.rb:1321:9:1321:9 | a [element 2] | array_flow.rb:1321:9:1321:22 | call to slice! [element] |
-| array_flow.rb:1321:9:1321:9 | a [element 4] | array_flow.rb:1321:9:1321:9 | [post] a [element] |
-| array_flow.rb:1321:9:1321:9 | a [element 4] | array_flow.rb:1321:9:1321:22 | call to slice! [element] |
-| array_flow.rb:1321:9:1321:22 | call to slice! [element] | array_flow.rb:1321:5:1321:5 | b [element] |
-| array_flow.rb:1322:10:1322:10 | b [element] | array_flow.rb:1322:10:1322:13 | ...[...] |
+| array_flow.rb:1319:10:1319:10 | a [element] | array_flow.rb:1319:10:1319:13 | ...[...] |
+| array_flow.rb:1321:5:1321:5 | a [element 2] | array_flow.rb:1322:9:1322:9 | a [element 2] |
+| array_flow.rb:1321:5:1321:5 | a [element 4] | array_flow.rb:1322:9:1322:9 | a [element 4] |
+| array_flow.rb:1321:16:1321:28 | call to source | array_flow.rb:1321:5:1321:5 | a [element 2] |
+| array_flow.rb:1321:34:1321:46 | call to source | array_flow.rb:1321:5:1321:5 | a [element 4] |
+| array_flow.rb:1322:5:1322:5 | b [element] | array_flow.rb:1323:10:1323:10 | b [element] |
+| array_flow.rb:1322:5:1322:5 | b [element] | array_flow.rb:1324:10:1324:10 | b [element] |
+| array_flow.rb:1322:5:1322:5 | b [element] | array_flow.rb:1325:10:1325:10 | b [element] |
+| array_flow.rb:1322:9:1322:9 | [post] a [element] | array_flow.rb:1326:10:1326:10 | a [element] |
+| array_flow.rb:1322:9:1322:9 | [post] a [element] | array_flow.rb:1327:10:1327:10 | a [element] |
+| array_flow.rb:1322:9:1322:9 | [post] a [element] | array_flow.rb:1328:10:1328:10 | a [element] |
+| array_flow.rb:1322:9:1322:9 | a [element 2] | array_flow.rb:1322:9:1322:9 | [post] a [element] |
+| array_flow.rb:1322:9:1322:9 | a [element 2] | array_flow.rb:1322:9:1322:22 | call to slice! [element] |
+| array_flow.rb:1322:9:1322:9 | a [element 4] | array_flow.rb:1322:9:1322:9 | [post] a [element] |
+| array_flow.rb:1322:9:1322:9 | a [element 4] | array_flow.rb:1322:9:1322:22 | call to slice! [element] |
+| array_flow.rb:1322:9:1322:22 | call to slice! [element] | array_flow.rb:1322:5:1322:5 | b [element] |
 | array_flow.rb:1323:10:1323:10 | b [element] | array_flow.rb:1323:10:1323:13 | ...[...] |
 | array_flow.rb:1324:10:1324:10 | b [element] | array_flow.rb:1324:10:1324:13 | ...[...] |
-| array_flow.rb:1325:10:1325:10 | a [element] | array_flow.rb:1325:10:1325:13 | ...[...] |
+| array_flow.rb:1325:10:1325:10 | b [element] | array_flow.rb:1325:10:1325:13 | ...[...] |
 | array_flow.rb:1326:10:1326:10 | a [element] | array_flow.rb:1326:10:1326:13 | ...[...] |
 | array_flow.rb:1327:10:1327:10 | a [element] | array_flow.rb:1327:10:1327:13 | ...[...] |
-| array_flow.rb:1329:5:1329:5 | a [element 2] | array_flow.rb:1330:9:1330:9 | a [element 2] |
-| array_flow.rb:1329:5:1329:5 | a [element 4] | array_flow.rb:1330:9:1330:9 | a [element 4] |
-| array_flow.rb:1329:16:1329:28 | call to source | array_flow.rb:1329:5:1329:5 | a [element 2] |
-| array_flow.rb:1329:34:1329:46 | call to source | array_flow.rb:1329:5:1329:5 | a [element 4] |
-| array_flow.rb:1330:5:1330:5 | b [element] | array_flow.rb:1331:10:1331:10 | b [element] |
-| array_flow.rb:1330:5:1330:5 | b [element] | array_flow.rb:1332:10:1332:10 | b [element] |
-| array_flow.rb:1330:5:1330:5 | b [element] | array_flow.rb:1333:10:1333:10 | b [element] |
-| array_flow.rb:1330:9:1330:9 | [post] a [element] | array_flow.rb:1334:10:1334:10 | a [element] |
-| array_flow.rb:1330:9:1330:9 | [post] a [element] | array_flow.rb:1335:10:1335:10 | a [element] |
-| array_flow.rb:1330:9:1330:9 | [post] a [element] | array_flow.rb:1336:10:1336:10 | a [element] |
-| array_flow.rb:1330:9:1330:9 | a [element 2] | array_flow.rb:1330:9:1330:9 | [post] a [element] |
-| array_flow.rb:1330:9:1330:9 | a [element 2] | array_flow.rb:1330:9:1330:25 | call to slice! [element] |
-| array_flow.rb:1330:9:1330:9 | a [element 4] | array_flow.rb:1330:9:1330:9 | [post] a [element] |
-| array_flow.rb:1330:9:1330:9 | a [element 4] | array_flow.rb:1330:9:1330:25 | call to slice! [element] |
-| array_flow.rb:1330:9:1330:25 | call to slice! [element] | array_flow.rb:1330:5:1330:5 | b [element] |
-| array_flow.rb:1331:10:1331:10 | b [element] | array_flow.rb:1331:10:1331:13 | ...[...] |
+| array_flow.rb:1328:10:1328:10 | a [element] | array_flow.rb:1328:10:1328:13 | ...[...] |
+| array_flow.rb:1330:5:1330:5 | a [element 2] | array_flow.rb:1331:9:1331:9 | a [element 2] |
+| array_flow.rb:1330:5:1330:5 | a [element 4] | array_flow.rb:1331:9:1331:9 | a [element 4] |
+| array_flow.rb:1330:16:1330:28 | call to source | array_flow.rb:1330:5:1330:5 | a [element 2] |
+| array_flow.rb:1330:34:1330:46 | call to source | array_flow.rb:1330:5:1330:5 | a [element 4] |
+| array_flow.rb:1331:5:1331:5 | b [element] | array_flow.rb:1332:10:1332:10 | b [element] |
+| array_flow.rb:1331:5:1331:5 | b [element] | array_flow.rb:1333:10:1333:10 | b [element] |
+| array_flow.rb:1331:5:1331:5 | b [element] | array_flow.rb:1334:10:1334:10 | b [element] |
+| array_flow.rb:1331:9:1331:9 | [post] a [element] | array_flow.rb:1335:10:1335:10 | a [element] |
+| array_flow.rb:1331:9:1331:9 | [post] a [element] | array_flow.rb:1336:10:1336:10 | a [element] |
+| array_flow.rb:1331:9:1331:9 | [post] a [element] | array_flow.rb:1337:10:1337:10 | a [element] |
+| array_flow.rb:1331:9:1331:9 | a [element 2] | array_flow.rb:1331:9:1331:9 | [post] a [element] |
+| array_flow.rb:1331:9:1331:9 | a [element 2] | array_flow.rb:1331:9:1331:25 | call to slice! [element] |
+| array_flow.rb:1331:9:1331:9 | a [element 4] | array_flow.rb:1331:9:1331:9 | [post] a [element] |
+| array_flow.rb:1331:9:1331:9 | a [element 4] | array_flow.rb:1331:9:1331:25 | call to slice! [element] |
+| array_flow.rb:1331:9:1331:25 | call to slice! [element] | array_flow.rb:1331:5:1331:5 | b [element] |
 | array_flow.rb:1332:10:1332:10 | b [element] | array_flow.rb:1332:10:1332:13 | ...[...] |
 | array_flow.rb:1333:10:1333:10 | b [element] | array_flow.rb:1333:10:1333:13 | ...[...] |
-| array_flow.rb:1334:10:1334:10 | a [element] | array_flow.rb:1334:10:1334:13 | ...[...] |
+| array_flow.rb:1334:10:1334:10 | b [element] | array_flow.rb:1334:10:1334:13 | ...[...] |
 | array_flow.rb:1335:10:1335:10 | a [element] | array_flow.rb:1335:10:1335:13 | ...[...] |
 | array_flow.rb:1336:10:1336:10 | a [element] | array_flow.rb:1336:10:1336:13 | ...[...] |
-| array_flow.rb:1338:5:1338:5 | a [element 2] | array_flow.rb:1339:9:1339:9 | a [element 2] |
-| array_flow.rb:1338:5:1338:5 | a [element 4] | array_flow.rb:1339:9:1339:9 | a [element 4] |
-| array_flow.rb:1338:16:1338:28 | call to source | array_flow.rb:1338:5:1338:5 | a [element 2] |
-| array_flow.rb:1338:34:1338:46 | call to source | array_flow.rb:1338:5:1338:5 | a [element 4] |
-| array_flow.rb:1339:5:1339:5 | b [element 2] | array_flow.rb:1342:10:1342:10 | b [element 2] |
-| array_flow.rb:1339:9:1339:9 | [post] a [element 1] | array_flow.rb:1344:10:1344:10 | a [element 1] |
-| array_flow.rb:1339:9:1339:9 | a [element 2] | array_flow.rb:1339:9:1339:21 | call to slice! [element 2] |
-| array_flow.rb:1339:9:1339:9 | a [element 4] | array_flow.rb:1339:9:1339:9 | [post] a [element 1] |
-| array_flow.rb:1339:9:1339:21 | call to slice! [element 2] | array_flow.rb:1339:5:1339:5 | b [element 2] |
-| array_flow.rb:1342:10:1342:10 | b [element 2] | array_flow.rb:1342:10:1342:13 | ...[...] |
-| array_flow.rb:1344:10:1344:10 | a [element 1] | array_flow.rb:1344:10:1344:13 | ...[...] |
-| array_flow.rb:1347:5:1347:5 | a [element 2] | array_flow.rb:1348:9:1348:9 | a [element 2] |
-| array_flow.rb:1347:5:1347:5 | a [element 4] | array_flow.rb:1348:9:1348:9 | a [element 4] |
-| array_flow.rb:1347:16:1347:28 | call to source | array_flow.rb:1347:5:1347:5 | a [element 2] |
-| array_flow.rb:1347:34:1347:46 | call to source | array_flow.rb:1347:5:1347:5 | a [element 4] |
-| array_flow.rb:1348:5:1348:5 | b [element] | array_flow.rb:1349:10:1349:10 | b [element] |
-| array_flow.rb:1348:5:1348:5 | b [element] | array_flow.rb:1350:10:1350:10 | b [element] |
-| array_flow.rb:1348:5:1348:5 | b [element] | array_flow.rb:1351:10:1351:10 | b [element] |
-| array_flow.rb:1348:9:1348:9 | [post] a [element] | array_flow.rb:1352:10:1352:10 | a [element] |
-| array_flow.rb:1348:9:1348:9 | [post] a [element] | array_flow.rb:1353:10:1353:10 | a [element] |
-| array_flow.rb:1348:9:1348:9 | [post] a [element] | array_flow.rb:1354:10:1354:10 | a [element] |
-| array_flow.rb:1348:9:1348:9 | a [element 2] | array_flow.rb:1348:9:1348:9 | [post] a [element] |
-| array_flow.rb:1348:9:1348:9 | a [element 2] | array_flow.rb:1348:9:1348:21 | call to slice! [element] |
-| array_flow.rb:1348:9:1348:9 | a [element 4] | array_flow.rb:1348:9:1348:9 | [post] a [element] |
-| array_flow.rb:1348:9:1348:9 | a [element 4] | array_flow.rb:1348:9:1348:21 | call to slice! [element] |
-| array_flow.rb:1348:9:1348:21 | call to slice! [element] | array_flow.rb:1348:5:1348:5 | b [element] |
-| array_flow.rb:1349:10:1349:10 | b [element] | array_flow.rb:1349:10:1349:13 | ...[...] |
+| array_flow.rb:1337:10:1337:10 | a [element] | array_flow.rb:1337:10:1337:13 | ...[...] |
+| array_flow.rb:1339:5:1339:5 | a [element 2] | array_flow.rb:1340:9:1340:9 | a [element 2] |
+| array_flow.rb:1339:5:1339:5 | a [element 4] | array_flow.rb:1340:9:1340:9 | a [element 4] |
+| array_flow.rb:1339:16:1339:28 | call to source | array_flow.rb:1339:5:1339:5 | a [element 2] |
+| array_flow.rb:1339:34:1339:46 | call to source | array_flow.rb:1339:5:1339:5 | a [element 4] |
+| array_flow.rb:1340:5:1340:5 | b [element 2] | array_flow.rb:1343:10:1343:10 | b [element 2] |
+| array_flow.rb:1340:9:1340:9 | [post] a [element 1] | array_flow.rb:1345:10:1345:10 | a [element 1] |
+| array_flow.rb:1340:9:1340:9 | a [element 2] | array_flow.rb:1340:9:1340:21 | call to slice! [element 2] |
+| array_flow.rb:1340:9:1340:9 | a [element 4] | array_flow.rb:1340:9:1340:9 | [post] a [element 1] |
+| array_flow.rb:1340:9:1340:21 | call to slice! [element 2] | array_flow.rb:1340:5:1340:5 | b [element 2] |
+| array_flow.rb:1343:10:1343:10 | b [element 2] | array_flow.rb:1343:10:1343:13 | ...[...] |
+| array_flow.rb:1345:10:1345:10 | a [element 1] | array_flow.rb:1345:10:1345:13 | ...[...] |
+| array_flow.rb:1348:5:1348:5 | a [element 2] | array_flow.rb:1349:9:1349:9 | a [element 2] |
+| array_flow.rb:1348:5:1348:5 | a [element 4] | array_flow.rb:1349:9:1349:9 | a [element 4] |
+| array_flow.rb:1348:16:1348:28 | call to source | array_flow.rb:1348:5:1348:5 | a [element 2] |
+| array_flow.rb:1348:34:1348:46 | call to source | array_flow.rb:1348:5:1348:5 | a [element 4] |
+| array_flow.rb:1349:5:1349:5 | b [element] | array_flow.rb:1350:10:1350:10 | b [element] |
+| array_flow.rb:1349:5:1349:5 | b [element] | array_flow.rb:1351:10:1351:10 | b [element] |
+| array_flow.rb:1349:5:1349:5 | b [element] | array_flow.rb:1352:10:1352:10 | b [element] |
+| array_flow.rb:1349:9:1349:9 | [post] a [element] | array_flow.rb:1353:10:1353:10 | a [element] |
+| array_flow.rb:1349:9:1349:9 | [post] a [element] | array_flow.rb:1354:10:1354:10 | a [element] |
+| array_flow.rb:1349:9:1349:9 | [post] a [element] | array_flow.rb:1355:10:1355:10 | a [element] |
+| array_flow.rb:1349:9:1349:9 | a [element 2] | array_flow.rb:1349:9:1349:9 | [post] a [element] |
+| array_flow.rb:1349:9:1349:9 | a [element 2] | array_flow.rb:1349:9:1349:21 | call to slice! [element] |
+| array_flow.rb:1349:9:1349:9 | a [element 4] | array_flow.rb:1349:9:1349:9 | [post] a [element] |
+| array_flow.rb:1349:9:1349:9 | a [element 4] | array_flow.rb:1349:9:1349:21 | call to slice! [element] |
+| array_flow.rb:1349:9:1349:21 | call to slice! [element] | array_flow.rb:1349:5:1349:5 | b [element] |
 | array_flow.rb:1350:10:1350:10 | b [element] | array_flow.rb:1350:10:1350:13 | ...[...] |
 | array_flow.rb:1351:10:1351:10 | b [element] | array_flow.rb:1351:10:1351:13 | ...[...] |
-| array_flow.rb:1352:10:1352:10 | a [element] | array_flow.rb:1352:10:1352:13 | ...[...] |
+| array_flow.rb:1352:10:1352:10 | b [element] | array_flow.rb:1352:10:1352:13 | ...[...] |
 | array_flow.rb:1353:10:1353:10 | a [element] | array_flow.rb:1353:10:1353:13 | ...[...] |
 | array_flow.rb:1354:10:1354:10 | a [element] | array_flow.rb:1354:10:1354:13 | ...[...] |
-| array_flow.rb:1358:5:1358:5 | a [element 2] | array_flow.rb:1359:9:1359:9 | a [element 2] |
-| array_flow.rb:1358:16:1358:26 | call to source | array_flow.rb:1358:5:1358:5 | a [element 2] |
-| array_flow.rb:1359:9:1359:9 | a [element 2] | array_flow.rb:1359:27:1359:27 | x |
-| array_flow.rb:1359:27:1359:27 | x | array_flow.rb:1360:14:1360:14 | x |
-| array_flow.rb:1366:5:1366:5 | a [element 2] | array_flow.rb:1367:9:1367:9 | a [element 2] |
-| array_flow.rb:1366:16:1366:26 | call to source | array_flow.rb:1366:5:1366:5 | a [element 2] |
-| array_flow.rb:1367:9:1367:9 | a [element 2] | array_flow.rb:1367:28:1367:28 | x |
-| array_flow.rb:1367:28:1367:28 | x | array_flow.rb:1368:14:1368:14 | x |
-| array_flow.rb:1374:5:1374:5 | a [element 2] | array_flow.rb:1375:9:1375:9 | a [element 2] |
-| array_flow.rb:1374:16:1374:26 | call to source | array_flow.rb:1374:5:1374:5 | a [element 2] |
-| array_flow.rb:1375:9:1375:9 | a [element 2] | array_flow.rb:1375:26:1375:26 | x |
-| array_flow.rb:1375:9:1375:9 | a [element 2] | array_flow.rb:1375:29:1375:29 | y |
-| array_flow.rb:1375:26:1375:26 | x | array_flow.rb:1376:14:1376:14 | x |
-| array_flow.rb:1375:29:1375:29 | y | array_flow.rb:1377:14:1377:14 | y |
-| array_flow.rb:1382:5:1382:5 | a [element 2] | array_flow.rb:1383:9:1383:9 | a [element 2] |
-| array_flow.rb:1382:5:1382:5 | a [element 2] | array_flow.rb:1386:9:1386:9 | a [element 2] |
-| array_flow.rb:1382:16:1382:26 | call to source | array_flow.rb:1382:5:1382:5 | a [element 2] |
-| array_flow.rb:1383:5:1383:5 | b [element] | array_flow.rb:1384:10:1384:10 | b [element] |
-| array_flow.rb:1383:5:1383:5 | b [element] | array_flow.rb:1385:10:1385:10 | b [element] |
-| array_flow.rb:1383:9:1383:9 | a [element 2] | array_flow.rb:1383:9:1383:14 | call to sort [element] |
-| array_flow.rb:1383:9:1383:14 | call to sort [element] | array_flow.rb:1383:5:1383:5 | b [element] |
-| array_flow.rb:1384:10:1384:10 | b [element] | array_flow.rb:1384:10:1384:13 | ...[...] |
+| array_flow.rb:1355:10:1355:10 | a [element] | array_flow.rb:1355:10:1355:13 | ...[...] |
+| array_flow.rb:1359:5:1359:5 | a [element 2] | array_flow.rb:1360:9:1360:9 | a [element 2] |
+| array_flow.rb:1359:16:1359:26 | call to source | array_flow.rb:1359:5:1359:5 | a [element 2] |
+| array_flow.rb:1360:9:1360:9 | a [element 2] | array_flow.rb:1360:27:1360:27 | x |
+| array_flow.rb:1360:27:1360:27 | x | array_flow.rb:1361:14:1361:14 | x |
+| array_flow.rb:1367:5:1367:5 | a [element 2] | array_flow.rb:1368:9:1368:9 | a [element 2] |
+| array_flow.rb:1367:16:1367:26 | call to source | array_flow.rb:1367:5:1367:5 | a [element 2] |
+| array_flow.rb:1368:9:1368:9 | a [element 2] | array_flow.rb:1368:28:1368:28 | x |
+| array_flow.rb:1368:28:1368:28 | x | array_flow.rb:1369:14:1369:14 | x |
+| array_flow.rb:1375:5:1375:5 | a [element 2] | array_flow.rb:1376:9:1376:9 | a [element 2] |
+| array_flow.rb:1375:16:1375:26 | call to source | array_flow.rb:1375:5:1375:5 | a [element 2] |
+| array_flow.rb:1376:9:1376:9 | a [element 2] | array_flow.rb:1376:26:1376:26 | x |
+| array_flow.rb:1376:9:1376:9 | a [element 2] | array_flow.rb:1376:29:1376:29 | y |
+| array_flow.rb:1376:26:1376:26 | x | array_flow.rb:1377:14:1377:14 | x |
+| array_flow.rb:1376:29:1376:29 | y | array_flow.rb:1378:14:1378:14 | y |
+| array_flow.rb:1383:5:1383:5 | a [element 2] | array_flow.rb:1384:9:1384:9 | a [element 2] |
+| array_flow.rb:1383:5:1383:5 | a [element 2] | array_flow.rb:1387:9:1387:9 | a [element 2] |
+| array_flow.rb:1383:16:1383:26 | call to source | array_flow.rb:1383:5:1383:5 | a [element 2] |
+| array_flow.rb:1384:5:1384:5 | b [element] | array_flow.rb:1385:10:1385:10 | b [element] |
+| array_flow.rb:1384:5:1384:5 | b [element] | array_flow.rb:1386:10:1386:10 | b [element] |
+| array_flow.rb:1384:9:1384:9 | a [element 2] | array_flow.rb:1384:9:1384:14 | call to sort [element] |
+| array_flow.rb:1384:9:1384:14 | call to sort [element] | array_flow.rb:1384:5:1384:5 | b [element] |
 | array_flow.rb:1385:10:1385:10 | b [element] | array_flow.rb:1385:10:1385:13 | ...[...] |
-| array_flow.rb:1386:5:1386:5 | c [element] | array_flow.rb:1391:10:1391:10 | c [element] |
-| array_flow.rb:1386:5:1386:5 | c [element] | array_flow.rb:1392:10:1392:10 | c [element] |
-| array_flow.rb:1386:9:1386:9 | a [element 2] | array_flow.rb:1386:9:1390:7 | call to sort [element] |
-| array_flow.rb:1386:9:1386:9 | a [element 2] | array_flow.rb:1386:20:1386:20 | x |
-| array_flow.rb:1386:9:1386:9 | a [element 2] | array_flow.rb:1386:23:1386:23 | y |
-| array_flow.rb:1386:9:1390:7 | call to sort [element] | array_flow.rb:1386:5:1386:5 | c [element] |
-| array_flow.rb:1386:20:1386:20 | x | array_flow.rb:1387:14:1387:14 | x |
-| array_flow.rb:1386:23:1386:23 | y | array_flow.rb:1388:14:1388:14 | y |
-| array_flow.rb:1391:10:1391:10 | c [element] | array_flow.rb:1391:10:1391:13 | ...[...] |
+| array_flow.rb:1386:10:1386:10 | b [element] | array_flow.rb:1386:10:1386:13 | ...[...] |
+| array_flow.rb:1387:5:1387:5 | c [element] | array_flow.rb:1392:10:1392:10 | c [element] |
+| array_flow.rb:1387:5:1387:5 | c [element] | array_flow.rb:1393:10:1393:10 | c [element] |
+| array_flow.rb:1387:9:1387:9 | a [element 2] | array_flow.rb:1387:9:1391:7 | call to sort [element] |
+| array_flow.rb:1387:9:1387:9 | a [element 2] | array_flow.rb:1387:20:1387:20 | x |
+| array_flow.rb:1387:9:1387:9 | a [element 2] | array_flow.rb:1387:23:1387:23 | y |
+| array_flow.rb:1387:9:1391:7 | call to sort [element] | array_flow.rb:1387:5:1387:5 | c [element] |
+| array_flow.rb:1387:20:1387:20 | x | array_flow.rb:1388:14:1388:14 | x |
+| array_flow.rb:1387:23:1387:23 | y | array_flow.rb:1389:14:1389:14 | y |
 | array_flow.rb:1392:10:1392:10 | c [element] | array_flow.rb:1392:10:1392:13 | ...[...] |
-| array_flow.rb:1396:5:1396:5 | a [element 2] | array_flow.rb:1397:9:1397:9 | a [element 2] |
-| array_flow.rb:1396:16:1396:26 | call to source | array_flow.rb:1396:5:1396:5 | a [element 2] |
-| array_flow.rb:1397:5:1397:5 | b [element] | array_flow.rb:1398:10:1398:10 | b [element] |
-| array_flow.rb:1397:5:1397:5 | b [element] | array_flow.rb:1399:10:1399:10 | b [element] |
-| array_flow.rb:1397:9:1397:9 | [post] a [element] | array_flow.rb:1400:10:1400:10 | a [element] |
-| array_flow.rb:1397:9:1397:9 | [post] a [element] | array_flow.rb:1401:10:1401:10 | a [element] |
-| array_flow.rb:1397:9:1397:9 | a [element 2] | array_flow.rb:1397:9:1397:9 | [post] a [element] |
-| array_flow.rb:1397:9:1397:9 | a [element 2] | array_flow.rb:1397:9:1397:15 | call to sort! [element] |
-| array_flow.rb:1397:9:1397:15 | call to sort! [element] | array_flow.rb:1397:5:1397:5 | b [element] |
-| array_flow.rb:1398:10:1398:10 | b [element] | array_flow.rb:1398:10:1398:13 | ...[...] |
+| array_flow.rb:1393:10:1393:10 | c [element] | array_flow.rb:1393:10:1393:13 | ...[...] |
+| array_flow.rb:1397:5:1397:5 | a [element 2] | array_flow.rb:1398:9:1398:9 | a [element 2] |
+| array_flow.rb:1397:16:1397:26 | call to source | array_flow.rb:1397:5:1397:5 | a [element 2] |
+| array_flow.rb:1398:5:1398:5 | b [element] | array_flow.rb:1399:10:1399:10 | b [element] |
+| array_flow.rb:1398:5:1398:5 | b [element] | array_flow.rb:1400:10:1400:10 | b [element] |
+| array_flow.rb:1398:9:1398:9 | [post] a [element] | array_flow.rb:1401:10:1401:10 | a [element] |
+| array_flow.rb:1398:9:1398:9 | [post] a [element] | array_flow.rb:1402:10:1402:10 | a [element] |
+| array_flow.rb:1398:9:1398:9 | a [element 2] | array_flow.rb:1398:9:1398:9 | [post] a [element] |
+| array_flow.rb:1398:9:1398:9 | a [element 2] | array_flow.rb:1398:9:1398:15 | call to sort! [element] |
+| array_flow.rb:1398:9:1398:15 | call to sort! [element] | array_flow.rb:1398:5:1398:5 | b [element] |
 | array_flow.rb:1399:10:1399:10 | b [element] | array_flow.rb:1399:10:1399:13 | ...[...] |
-| array_flow.rb:1400:10:1400:10 | a [element] | array_flow.rb:1400:10:1400:13 | ...[...] |
+| array_flow.rb:1400:10:1400:10 | b [element] | array_flow.rb:1400:10:1400:13 | ...[...] |
 | array_flow.rb:1401:10:1401:10 | a [element] | array_flow.rb:1401:10:1401:13 | ...[...] |
-| array_flow.rb:1403:5:1403:5 | a [element 2] | array_flow.rb:1404:9:1404:9 | a [element 2] |
-| array_flow.rb:1403:16:1403:26 | call to source | array_flow.rb:1403:5:1403:5 | a [element 2] |
-| array_flow.rb:1404:5:1404:5 | b [element] | array_flow.rb:1409:10:1409:10 | b [element] |
-| array_flow.rb:1404:5:1404:5 | b [element] | array_flow.rb:1410:10:1410:10 | b [element] |
-| array_flow.rb:1404:9:1404:9 | [post] a [element] | array_flow.rb:1411:10:1411:10 | a [element] |
-| array_flow.rb:1404:9:1404:9 | [post] a [element] | array_flow.rb:1412:10:1412:10 | a [element] |
-| array_flow.rb:1404:9:1404:9 | a [element 2] | array_flow.rb:1404:9:1404:9 | [post] a [element] |
-| array_flow.rb:1404:9:1404:9 | a [element 2] | array_flow.rb:1404:9:1408:7 | call to sort! [element] |
-| array_flow.rb:1404:9:1404:9 | a [element 2] | array_flow.rb:1404:21:1404:21 | x |
-| array_flow.rb:1404:9:1404:9 | a [element 2] | array_flow.rb:1404:24:1404:24 | y |
-| array_flow.rb:1404:9:1408:7 | call to sort! [element] | array_flow.rb:1404:5:1404:5 | b [element] |
-| array_flow.rb:1404:21:1404:21 | x | array_flow.rb:1405:14:1405:14 | x |
-| array_flow.rb:1404:24:1404:24 | y | array_flow.rb:1406:14:1406:14 | y |
-| array_flow.rb:1409:10:1409:10 | b [element] | array_flow.rb:1409:10:1409:13 | ...[...] |
+| array_flow.rb:1402:10:1402:10 | a [element] | array_flow.rb:1402:10:1402:13 | ...[...] |
+| array_flow.rb:1404:5:1404:5 | a [element 2] | array_flow.rb:1405:9:1405:9 | a [element 2] |
+| array_flow.rb:1404:16:1404:26 | call to source | array_flow.rb:1404:5:1404:5 | a [element 2] |
+| array_flow.rb:1405:5:1405:5 | b [element] | array_flow.rb:1410:10:1410:10 | b [element] |
+| array_flow.rb:1405:5:1405:5 | b [element] | array_flow.rb:1411:10:1411:10 | b [element] |
+| array_flow.rb:1405:9:1405:9 | [post] a [element] | array_flow.rb:1412:10:1412:10 | a [element] |
+| array_flow.rb:1405:9:1405:9 | [post] a [element] | array_flow.rb:1413:10:1413:10 | a [element] |
+| array_flow.rb:1405:9:1405:9 | a [element 2] | array_flow.rb:1405:9:1405:9 | [post] a [element] |
+| array_flow.rb:1405:9:1405:9 | a [element 2] | array_flow.rb:1405:9:1409:7 | call to sort! [element] |
+| array_flow.rb:1405:9:1405:9 | a [element 2] | array_flow.rb:1405:21:1405:21 | x |
+| array_flow.rb:1405:9:1405:9 | a [element 2] | array_flow.rb:1405:24:1405:24 | y |
+| array_flow.rb:1405:9:1409:7 | call to sort! [element] | array_flow.rb:1405:5:1405:5 | b [element] |
+| array_flow.rb:1405:21:1405:21 | x | array_flow.rb:1406:14:1406:14 | x |
+| array_flow.rb:1405:24:1405:24 | y | array_flow.rb:1407:14:1407:14 | y |
 | array_flow.rb:1410:10:1410:10 | b [element] | array_flow.rb:1410:10:1410:13 | ...[...] |
-| array_flow.rb:1411:10:1411:10 | a [element] | array_flow.rb:1411:10:1411:13 | ...[...] |
+| array_flow.rb:1411:10:1411:10 | b [element] | array_flow.rb:1411:10:1411:13 | ...[...] |
 | array_flow.rb:1412:10:1412:10 | a [element] | array_flow.rb:1412:10:1412:13 | ...[...] |
-| array_flow.rb:1416:5:1416:5 | a [element 2] | array_flow.rb:1417:9:1417:9 | a [element 2] |
-| array_flow.rb:1416:16:1416:26 | call to source | array_flow.rb:1416:5:1416:5 | a [element 2] |
-| array_flow.rb:1417:5:1417:5 | b [element] | array_flow.rb:1421:10:1421:10 | b [element] |
-| array_flow.rb:1417:5:1417:5 | b [element] | array_flow.rb:1422:10:1422:10 | b [element] |
-| array_flow.rb:1417:9:1417:9 | a [element 2] | array_flow.rb:1417:9:1420:7 | call to sort_by [element] |
-| array_flow.rb:1417:9:1417:9 | a [element 2] | array_flow.rb:1417:23:1417:23 | x |
-| array_flow.rb:1417:9:1420:7 | call to sort_by [element] | array_flow.rb:1417:5:1417:5 | b [element] |
-| array_flow.rb:1417:23:1417:23 | x | array_flow.rb:1418:14:1418:14 | x |
-| array_flow.rb:1421:10:1421:10 | b [element] | array_flow.rb:1421:10:1421:13 | ...[...] |
+| array_flow.rb:1413:10:1413:10 | a [element] | array_flow.rb:1413:10:1413:13 | ...[...] |
+| array_flow.rb:1417:5:1417:5 | a [element 2] | array_flow.rb:1418:9:1418:9 | a [element 2] |
+| array_flow.rb:1417:16:1417:26 | call to source | array_flow.rb:1417:5:1417:5 | a [element 2] |
+| array_flow.rb:1418:5:1418:5 | b [element] | array_flow.rb:1422:10:1422:10 | b [element] |
+| array_flow.rb:1418:5:1418:5 | b [element] | array_flow.rb:1423:10:1423:10 | b [element] |
+| array_flow.rb:1418:9:1418:9 | a [element 2] | array_flow.rb:1418:9:1421:7 | call to sort_by [element] |
+| array_flow.rb:1418:9:1418:9 | a [element 2] | array_flow.rb:1418:23:1418:23 | x |
+| array_flow.rb:1418:9:1421:7 | call to sort_by [element] | array_flow.rb:1418:5:1418:5 | b [element] |
+| array_flow.rb:1418:23:1418:23 | x | array_flow.rb:1419:14:1419:14 | x |
 | array_flow.rb:1422:10:1422:10 | b [element] | array_flow.rb:1422:10:1422:13 | ...[...] |
-| array_flow.rb:1426:5:1426:5 | a [element 2] | array_flow.rb:1427:9:1427:9 | a [element 2] |
-| array_flow.rb:1426:16:1426:26 | call to source | array_flow.rb:1426:5:1426:5 | a [element 2] |
-| array_flow.rb:1427:5:1427:5 | b [element] | array_flow.rb:1433:10:1433:10 | b [element] |
-| array_flow.rb:1427:5:1427:5 | b [element] | array_flow.rb:1434:10:1434:10 | b [element] |
-| array_flow.rb:1427:9:1427:9 | [post] a [element] | array_flow.rb:1431:10:1431:10 | a [element] |
-| array_flow.rb:1427:9:1427:9 | [post] a [element] | array_flow.rb:1432:10:1432:10 | a [element] |
-| array_flow.rb:1427:9:1427:9 | a [element 2] | array_flow.rb:1427:9:1427:9 | [post] a [element] |
-| array_flow.rb:1427:9:1427:9 | a [element 2] | array_flow.rb:1427:9:1430:7 | call to sort_by! [element] |
-| array_flow.rb:1427:9:1427:9 | a [element 2] | array_flow.rb:1427:24:1427:24 | x |
-| array_flow.rb:1427:9:1430:7 | call to sort_by! [element] | array_flow.rb:1427:5:1427:5 | b [element] |
-| array_flow.rb:1427:24:1427:24 | x | array_flow.rb:1428:14:1428:14 | x |
-| array_flow.rb:1431:10:1431:10 | a [element] | array_flow.rb:1431:10:1431:13 | ...[...] |
+| array_flow.rb:1423:10:1423:10 | b [element] | array_flow.rb:1423:10:1423:13 | ...[...] |
+| array_flow.rb:1427:5:1427:5 | a [element 2] | array_flow.rb:1428:9:1428:9 | a [element 2] |
+| array_flow.rb:1427:16:1427:26 | call to source | array_flow.rb:1427:5:1427:5 | a [element 2] |
+| array_flow.rb:1428:5:1428:5 | b [element] | array_flow.rb:1434:10:1434:10 | b [element] |
+| array_flow.rb:1428:5:1428:5 | b [element] | array_flow.rb:1435:10:1435:10 | b [element] |
+| array_flow.rb:1428:9:1428:9 | [post] a [element] | array_flow.rb:1432:10:1432:10 | a [element] |
+| array_flow.rb:1428:9:1428:9 | [post] a [element] | array_flow.rb:1433:10:1433:10 | a [element] |
+| array_flow.rb:1428:9:1428:9 | a [element 2] | array_flow.rb:1428:9:1428:9 | [post] a [element] |
+| array_flow.rb:1428:9:1428:9 | a [element 2] | array_flow.rb:1428:9:1431:7 | call to sort_by! [element] |
+| array_flow.rb:1428:9:1428:9 | a [element 2] | array_flow.rb:1428:24:1428:24 | x |
+| array_flow.rb:1428:9:1431:7 | call to sort_by! [element] | array_flow.rb:1428:5:1428:5 | b [element] |
+| array_flow.rb:1428:24:1428:24 | x | array_flow.rb:1429:14:1429:14 | x |
 | array_flow.rb:1432:10:1432:10 | a [element] | array_flow.rb:1432:10:1432:13 | ...[...] |
-| array_flow.rb:1433:10:1433:10 | b [element] | array_flow.rb:1433:10:1433:13 | ...[...] |
+| array_flow.rb:1433:10:1433:10 | a [element] | array_flow.rb:1433:10:1433:13 | ...[...] |
 | array_flow.rb:1434:10:1434:10 | b [element] | array_flow.rb:1434:10:1434:13 | ...[...] |
-| array_flow.rb:1438:5:1438:5 | a [element 2] | array_flow.rb:1439:9:1439:9 | a [element 2] |
-| array_flow.rb:1438:16:1438:26 | call to source | array_flow.rb:1438:5:1438:5 | a [element 2] |
-| array_flow.rb:1439:9:1439:9 | a [element 2] | array_flow.rb:1439:19:1439:19 | x |
-| array_flow.rb:1439:19:1439:19 | x | array_flow.rb:1440:14:1440:14 | x |
-| array_flow.rb:1446:5:1446:5 | a [element 2] | array_flow.rb:1447:9:1447:9 | a [element 2] |
-| array_flow.rb:1446:5:1446:5 | a [element 2] | array_flow.rb:1452:9:1452:9 | a [element 2] |
-| array_flow.rb:1446:5:1446:5 | a [element 2] | array_flow.rb:1458:9:1458:9 | a [element 2] |
-| array_flow.rb:1446:5:1446:5 | a [element 2] | array_flow.rb:1465:9:1465:9 | a [element 2] |
-| array_flow.rb:1446:5:1446:5 | a [element 3] | array_flow.rb:1447:9:1447:9 | a [element 3] |
-| array_flow.rb:1446:5:1446:5 | a [element 3] | array_flow.rb:1458:9:1458:9 | a [element 3] |
-| array_flow.rb:1446:16:1446:28 | call to source | array_flow.rb:1446:5:1446:5 | a [element 2] |
-| array_flow.rb:1446:31:1446:43 | call to source | array_flow.rb:1446:5:1446:5 | a [element 3] |
-| array_flow.rb:1447:5:1447:5 | b [element 2] | array_flow.rb:1450:10:1450:10 | b [element 2] |
-| array_flow.rb:1447:5:1447:5 | b [element 3] | array_flow.rb:1451:10:1451:10 | b [element 3] |
-| array_flow.rb:1447:9:1447:9 | a [element 2] | array_flow.rb:1447:9:1447:17 | call to take [element 2] |
-| array_flow.rb:1447:9:1447:9 | a [element 3] | array_flow.rb:1447:9:1447:17 | call to take [element 3] |
-| array_flow.rb:1447:9:1447:17 | call to take [element 2] | array_flow.rb:1447:5:1447:5 | b [element 2] |
-| array_flow.rb:1447:9:1447:17 | call to take [element 3] | array_flow.rb:1447:5:1447:5 | b [element 3] |
-| array_flow.rb:1450:10:1450:10 | b [element 2] | array_flow.rb:1450:10:1450:13 | ...[...] |
-| array_flow.rb:1451:10:1451:10 | b [element 3] | array_flow.rb:1451:10:1451:13 | ...[...] |
-| array_flow.rb:1452:5:1452:5 | b [element 2] | array_flow.rb:1455:10:1455:10 | b [element 2] |
-| array_flow.rb:1452:5:1452:5 | b [element 2] | array_flow.rb:1457:10:1457:10 | b [element 2] |
-| array_flow.rb:1452:9:1452:9 | a [element 2] | array_flow.rb:1452:9:1452:17 | call to take [element 2] |
-| array_flow.rb:1452:9:1452:17 | call to take [element 2] | array_flow.rb:1452:5:1452:5 | b [element 2] |
-| array_flow.rb:1455:10:1455:10 | b [element 2] | array_flow.rb:1455:10:1455:13 | ...[...] |
-| array_flow.rb:1457:10:1457:10 | b [element 2] | array_flow.rb:1457:10:1457:13 | ...[...] |
-| array_flow.rb:1458:5:1458:5 | b [element 2] | array_flow.rb:1461:10:1461:10 | b [element 2] |
-| array_flow.rb:1458:5:1458:5 | b [element 2] | array_flow.rb:1463:10:1463:10 | b [element 2] |
-| array_flow.rb:1458:5:1458:5 | b [element 3] | array_flow.rb:1462:10:1462:10 | b [element 3] |
-| array_flow.rb:1458:5:1458:5 | b [element 3] | array_flow.rb:1463:10:1463:10 | b [element 3] |
-| array_flow.rb:1458:9:1458:9 | a [element 2] | array_flow.rb:1458:9:1458:19 | call to take [element 2] |
-| array_flow.rb:1458:9:1458:9 | a [element 3] | array_flow.rb:1458:9:1458:19 | call to take [element 3] |
-| array_flow.rb:1458:9:1458:19 | call to take [element 2] | array_flow.rb:1458:5:1458:5 | b [element 2] |
-| array_flow.rb:1458:9:1458:19 | call to take [element 3] | array_flow.rb:1458:5:1458:5 | b [element 3] |
-| array_flow.rb:1461:10:1461:10 | b [element 2] | array_flow.rb:1461:10:1461:13 | ...[...] |
-| array_flow.rb:1462:10:1462:10 | b [element 3] | array_flow.rb:1462:10:1462:13 | ...[...] |
-| array_flow.rb:1463:10:1463:10 | b [element 2] | array_flow.rb:1463:10:1463:13 | ...[...] |
+| array_flow.rb:1435:10:1435:10 | b [element] | array_flow.rb:1435:10:1435:13 | ...[...] |
+| array_flow.rb:1439:5:1439:5 | a [element 2] | array_flow.rb:1440:9:1440:9 | a [element 2] |
+| array_flow.rb:1439:16:1439:26 | call to source | array_flow.rb:1439:5:1439:5 | a [element 2] |
+| array_flow.rb:1440:9:1440:9 | a [element 2] | array_flow.rb:1440:19:1440:19 | x |
+| array_flow.rb:1440:19:1440:19 | x | array_flow.rb:1441:14:1441:14 | x |
+| array_flow.rb:1447:5:1447:5 | a [element 2] | array_flow.rb:1448:9:1448:9 | a [element 2] |
+| array_flow.rb:1447:5:1447:5 | a [element 2] | array_flow.rb:1453:9:1453:9 | a [element 2] |
+| array_flow.rb:1447:5:1447:5 | a [element 2] | array_flow.rb:1459:9:1459:9 | a [element 2] |
+| array_flow.rb:1447:5:1447:5 | a [element 2] | array_flow.rb:1466:9:1466:9 | a [element 2] |
+| array_flow.rb:1447:5:1447:5 | a [element 3] | array_flow.rb:1448:9:1448:9 | a [element 3] |
+| array_flow.rb:1447:5:1447:5 | a [element 3] | array_flow.rb:1459:9:1459:9 | a [element 3] |
+| array_flow.rb:1447:16:1447:28 | call to source | array_flow.rb:1447:5:1447:5 | a [element 2] |
+| array_flow.rb:1447:31:1447:43 | call to source | array_flow.rb:1447:5:1447:5 | a [element 3] |
+| array_flow.rb:1448:5:1448:5 | b [element 2] | array_flow.rb:1451:10:1451:10 | b [element 2] |
+| array_flow.rb:1448:5:1448:5 | b [element 3] | array_flow.rb:1452:10:1452:10 | b [element 3] |
+| array_flow.rb:1448:9:1448:9 | a [element 2] | array_flow.rb:1448:9:1448:17 | call to take [element 2] |
+| array_flow.rb:1448:9:1448:9 | a [element 3] | array_flow.rb:1448:9:1448:17 | call to take [element 3] |
+| array_flow.rb:1448:9:1448:17 | call to take [element 2] | array_flow.rb:1448:5:1448:5 | b [element 2] |
+| array_flow.rb:1448:9:1448:17 | call to take [element 3] | array_flow.rb:1448:5:1448:5 | b [element 3] |
+| array_flow.rb:1451:10:1451:10 | b [element 2] | array_flow.rb:1451:10:1451:13 | ...[...] |
+| array_flow.rb:1452:10:1452:10 | b [element 3] | array_flow.rb:1452:10:1452:13 | ...[...] |
+| array_flow.rb:1453:5:1453:5 | b [element 2] | array_flow.rb:1456:10:1456:10 | b [element 2] |
+| array_flow.rb:1453:5:1453:5 | b [element 2] | array_flow.rb:1458:10:1458:10 | b [element 2] |
+| array_flow.rb:1453:9:1453:9 | a [element 2] | array_flow.rb:1453:9:1453:17 | call to take [element 2] |
+| array_flow.rb:1453:9:1453:17 | call to take [element 2] | array_flow.rb:1453:5:1453:5 | b [element 2] |
+| array_flow.rb:1456:10:1456:10 | b [element 2] | array_flow.rb:1456:10:1456:13 | ...[...] |
+| array_flow.rb:1458:10:1458:10 | b [element 2] | array_flow.rb:1458:10:1458:13 | ...[...] |
+| array_flow.rb:1459:5:1459:5 | b [element 2] | array_flow.rb:1462:10:1462:10 | b [element 2] |
+| array_flow.rb:1459:5:1459:5 | b [element 2] | array_flow.rb:1464:10:1464:10 | b [element 2] |
+| array_flow.rb:1459:5:1459:5 | b [element 3] | array_flow.rb:1463:10:1463:10 | b [element 3] |
+| array_flow.rb:1459:5:1459:5 | b [element 3] | array_flow.rb:1464:10:1464:10 | b [element 3] |
+| array_flow.rb:1459:9:1459:9 | a [element 2] | array_flow.rb:1459:9:1459:19 | call to take [element 2] |
+| array_flow.rb:1459:9:1459:9 | a [element 3] | array_flow.rb:1459:9:1459:19 | call to take [element 3] |
+| array_flow.rb:1459:9:1459:19 | call to take [element 2] | array_flow.rb:1459:5:1459:5 | b [element 2] |
+| array_flow.rb:1459:9:1459:19 | call to take [element 3] | array_flow.rb:1459:5:1459:5 | b [element 3] |
+| array_flow.rb:1462:10:1462:10 | b [element 2] | array_flow.rb:1462:10:1462:13 | ...[...] |
 | array_flow.rb:1463:10:1463:10 | b [element 3] | array_flow.rb:1463:10:1463:13 | ...[...] |
-| array_flow.rb:1464:5:1464:5 | [post] a [element] | array_flow.rb:1465:9:1465:9 | a [element] |
-| array_flow.rb:1464:12:1464:24 | call to source | array_flow.rb:1464:5:1464:5 | [post] a [element] |
-| array_flow.rb:1465:5:1465:5 | b [element 2] | array_flow.rb:1466:10:1466:10 | b [element 2] |
-| array_flow.rb:1465:5:1465:5 | b [element] | array_flow.rb:1466:10:1466:10 | b [element] |
-| array_flow.rb:1465:9:1465:9 | a [element 2] | array_flow.rb:1465:9:1465:17 | call to take [element 2] |
-| array_flow.rb:1465:9:1465:9 | a [element] | array_flow.rb:1465:9:1465:17 | call to take [element] |
-| array_flow.rb:1465:9:1465:17 | call to take [element 2] | array_flow.rb:1465:5:1465:5 | b [element 2] |
-| array_flow.rb:1465:9:1465:17 | call to take [element] | array_flow.rb:1465:5:1465:5 | b [element] |
-| array_flow.rb:1466:10:1466:10 | b [element 2] | array_flow.rb:1466:10:1466:13 | ...[...] |
-| array_flow.rb:1466:10:1466:10 | b [element] | array_flow.rb:1466:10:1466:13 | ...[...] |
-| array_flow.rb:1470:5:1470:5 | a [element 2] | array_flow.rb:1471:9:1471:9 | a [element 2] |
-| array_flow.rb:1470:16:1470:26 | call to source | array_flow.rb:1470:5:1470:5 | a [element 2] |
-| array_flow.rb:1471:5:1471:5 | b [element 2] | array_flow.rb:1477:10:1477:10 | b [element 2] |
-| array_flow.rb:1471:9:1471:9 | a [element 2] | array_flow.rb:1471:9:1474:7 | call to take_while [element 2] |
-| array_flow.rb:1471:9:1471:9 | a [element 2] | array_flow.rb:1471:26:1471:26 | x |
-| array_flow.rb:1471:9:1474:7 | call to take_while [element 2] | array_flow.rb:1471:5:1471:5 | b [element 2] |
-| array_flow.rb:1471:26:1471:26 | x | array_flow.rb:1472:14:1472:14 | x |
-| array_flow.rb:1477:10:1477:10 | b [element 2] | array_flow.rb:1477:10:1477:13 | ...[...] |
-| array_flow.rb:1483:5:1483:5 | a [element 3] | array_flow.rb:1484:9:1484:9 | a [element 3] |
-| array_flow.rb:1483:19:1483:29 | call to source | array_flow.rb:1483:5:1483:5 | a [element 3] |
-| array_flow.rb:1484:5:1484:5 | b [element 3] | array_flow.rb:1485:10:1485:10 | b [element 3] |
-| array_flow.rb:1484:9:1484:9 | a [element 3] | array_flow.rb:1484:9:1484:14 | call to to_a [element 3] |
-| array_flow.rb:1484:9:1484:14 | call to to_a [element 3] | array_flow.rb:1484:5:1484:5 | b [element 3] |
-| array_flow.rb:1485:10:1485:10 | b [element 3] | array_flow.rb:1485:10:1485:13 | ...[...] |
-| array_flow.rb:1489:5:1489:5 | a [element 2] | array_flow.rb:1490:9:1490:9 | a [element 2] |
-| array_flow.rb:1489:16:1489:26 | call to source | array_flow.rb:1489:5:1489:5 | a [element 2] |
-| array_flow.rb:1490:5:1490:5 | b [element 2] | array_flow.rb:1493:10:1493:10 | b [element 2] |
-| array_flow.rb:1490:9:1490:9 | a [element 2] | array_flow.rb:1490:9:1490:16 | call to to_ary [element 2] |
-| array_flow.rb:1490:9:1490:16 | call to to_ary [element 2] | array_flow.rb:1490:5:1490:5 | b [element 2] |
-| array_flow.rb:1493:10:1493:10 | b [element 2] | array_flow.rb:1493:10:1493:13 | ...[...] |
-| array_flow.rb:1506:5:1506:5 | a [element 0, element 1] | array_flow.rb:1507:9:1507:9 | a [element 0, element 1] |
-| array_flow.rb:1506:5:1506:5 | a [element 1, element 1] | array_flow.rb:1507:9:1507:9 | a [element 1, element 1] |
-| array_flow.rb:1506:5:1506:5 | a [element 2, element 1] | array_flow.rb:1507:9:1507:9 | a [element 2, element 1] |
-| array_flow.rb:1506:14:1506:26 | call to source | array_flow.rb:1506:5:1506:5 | a [element 0, element 1] |
-| array_flow.rb:1506:34:1506:46 | call to source | array_flow.rb:1506:5:1506:5 | a [element 1, element 1] |
-| array_flow.rb:1506:54:1506:66 | call to source | array_flow.rb:1506:5:1506:5 | a [element 2, element 1] |
-| array_flow.rb:1507:5:1507:5 | b [element 1, element 0] | array_flow.rb:1511:10:1511:10 | b [element 1, element 0] |
-| array_flow.rb:1507:5:1507:5 | b [element 1, element 1] | array_flow.rb:1512:10:1512:10 | b [element 1, element 1] |
-| array_flow.rb:1507:5:1507:5 | b [element 1, element 2] | array_flow.rb:1513:10:1513:10 | b [element 1, element 2] |
-| array_flow.rb:1507:9:1507:9 | a [element 0, element 1] | array_flow.rb:1507:9:1507:19 | call to transpose [element 1, element 0] |
-| array_flow.rb:1507:9:1507:9 | a [element 1, element 1] | array_flow.rb:1507:9:1507:19 | call to transpose [element 1, element 1] |
-| array_flow.rb:1507:9:1507:9 | a [element 2, element 1] | array_flow.rb:1507:9:1507:19 | call to transpose [element 1, element 2] |
-| array_flow.rb:1507:9:1507:19 | call to transpose [element 1, element 0] | array_flow.rb:1507:5:1507:5 | b [element 1, element 0] |
-| array_flow.rb:1507:9:1507:19 | call to transpose [element 1, element 1] | array_flow.rb:1507:5:1507:5 | b [element 1, element 1] |
-| array_flow.rb:1507:9:1507:19 | call to transpose [element 1, element 2] | array_flow.rb:1507:5:1507:5 | b [element 1, element 2] |
-| array_flow.rb:1511:10:1511:10 | b [element 1, element 0] | array_flow.rb:1511:10:1511:13 | ...[...] [element 0] |
-| array_flow.rb:1511:10:1511:13 | ...[...] [element 0] | array_flow.rb:1511:10:1511:16 | ...[...] |
-| array_flow.rb:1512:10:1512:10 | b [element 1, element 1] | array_flow.rb:1512:10:1512:13 | ...[...] [element 1] |
-| array_flow.rb:1512:10:1512:13 | ...[...] [element 1] | array_flow.rb:1512:10:1512:16 | ...[...] |
-| array_flow.rb:1513:10:1513:10 | b [element 1, element 2] | array_flow.rb:1513:10:1513:13 | ...[...] [element 2] |
-| array_flow.rb:1513:10:1513:13 | ...[...] [element 2] | array_flow.rb:1513:10:1513:16 | ...[...] |
-| array_flow.rb:1517:5:1517:5 | a [element 2] | array_flow.rb:1520:9:1520:9 | a [element 2] |
-| array_flow.rb:1517:16:1517:28 | call to source | array_flow.rb:1517:5:1517:5 | a [element 2] |
-| array_flow.rb:1518:5:1518:5 | b [element 1] | array_flow.rb:1520:17:1520:17 | b [element 1] |
-| array_flow.rb:1518:13:1518:25 | call to source | array_flow.rb:1518:5:1518:5 | b [element 1] |
-| array_flow.rb:1519:5:1519:5 | c [element 1] | array_flow.rb:1520:20:1520:20 | c [element 1] |
-| array_flow.rb:1519:13:1519:25 | call to source | array_flow.rb:1519:5:1519:5 | c [element 1] |
-| array_flow.rb:1520:5:1520:5 | d [element] | array_flow.rb:1521:10:1521:10 | d [element] |
-| array_flow.rb:1520:5:1520:5 | d [element] | array_flow.rb:1522:10:1522:10 | d [element] |
-| array_flow.rb:1520:5:1520:5 | d [element] | array_flow.rb:1523:10:1523:10 | d [element] |
-| array_flow.rb:1520:9:1520:9 | a [element 2] | array_flow.rb:1520:9:1520:21 | call to union [element] |
-| array_flow.rb:1520:9:1520:21 | call to union [element] | array_flow.rb:1520:5:1520:5 | d [element] |
-| array_flow.rb:1520:17:1520:17 | b [element 1] | array_flow.rb:1520:9:1520:21 | call to union [element] |
-| array_flow.rb:1520:20:1520:20 | c [element 1] | array_flow.rb:1520:9:1520:21 | call to union [element] |
-| array_flow.rb:1521:10:1521:10 | d [element] | array_flow.rb:1521:10:1521:13 | ...[...] |
+| array_flow.rb:1464:10:1464:10 | b [element 2] | array_flow.rb:1464:10:1464:13 | ...[...] |
+| array_flow.rb:1464:10:1464:10 | b [element 3] | array_flow.rb:1464:10:1464:13 | ...[...] |
+| array_flow.rb:1465:5:1465:5 | [post] a [element] | array_flow.rb:1466:9:1466:9 | a [element] |
+| array_flow.rb:1465:12:1465:24 | call to source | array_flow.rb:1465:5:1465:5 | [post] a [element] |
+| array_flow.rb:1466:5:1466:5 | b [element 2] | array_flow.rb:1467:10:1467:10 | b [element 2] |
+| array_flow.rb:1466:5:1466:5 | b [element] | array_flow.rb:1467:10:1467:10 | b [element] |
+| array_flow.rb:1466:9:1466:9 | a [element 2] | array_flow.rb:1466:9:1466:17 | call to take [element 2] |
+| array_flow.rb:1466:9:1466:9 | a [element] | array_flow.rb:1466:9:1466:17 | call to take [element] |
+| array_flow.rb:1466:9:1466:17 | call to take [element 2] | array_flow.rb:1466:5:1466:5 | b [element 2] |
+| array_flow.rb:1466:9:1466:17 | call to take [element] | array_flow.rb:1466:5:1466:5 | b [element] |
+| array_flow.rb:1467:10:1467:10 | b [element 2] | array_flow.rb:1467:10:1467:13 | ...[...] |
+| array_flow.rb:1467:10:1467:10 | b [element] | array_flow.rb:1467:10:1467:13 | ...[...] |
+| array_flow.rb:1471:5:1471:5 | a [element 2] | array_flow.rb:1472:9:1472:9 | a [element 2] |
+| array_flow.rb:1471:16:1471:26 | call to source | array_flow.rb:1471:5:1471:5 | a [element 2] |
+| array_flow.rb:1472:5:1472:5 | b [element 2] | array_flow.rb:1478:10:1478:10 | b [element 2] |
+| array_flow.rb:1472:9:1472:9 | a [element 2] | array_flow.rb:1472:9:1475:7 | call to take_while [element 2] |
+| array_flow.rb:1472:9:1472:9 | a [element 2] | array_flow.rb:1472:26:1472:26 | x |
+| array_flow.rb:1472:9:1475:7 | call to take_while [element 2] | array_flow.rb:1472:5:1472:5 | b [element 2] |
+| array_flow.rb:1472:26:1472:26 | x | array_flow.rb:1473:14:1473:14 | x |
+| array_flow.rb:1478:10:1478:10 | b [element 2] | array_flow.rb:1478:10:1478:13 | ...[...] |
+| array_flow.rb:1484:5:1484:5 | a [element 3] | array_flow.rb:1485:9:1485:9 | a [element 3] |
+| array_flow.rb:1484:19:1484:29 | call to source | array_flow.rb:1484:5:1484:5 | a [element 3] |
+| array_flow.rb:1485:5:1485:5 | b [element 3] | array_flow.rb:1486:10:1486:10 | b [element 3] |
+| array_flow.rb:1485:9:1485:9 | a [element 3] | array_flow.rb:1485:9:1485:14 | call to to_a [element 3] |
+| array_flow.rb:1485:9:1485:14 | call to to_a [element 3] | array_flow.rb:1485:5:1485:5 | b [element 3] |
+| array_flow.rb:1486:10:1486:10 | b [element 3] | array_flow.rb:1486:10:1486:13 | ...[...] |
+| array_flow.rb:1490:5:1490:5 | a [element 2] | array_flow.rb:1491:9:1491:9 | a [element 2] |
+| array_flow.rb:1490:16:1490:26 | call to source | array_flow.rb:1490:5:1490:5 | a [element 2] |
+| array_flow.rb:1491:5:1491:5 | b [element 2] | array_flow.rb:1494:10:1494:10 | b [element 2] |
+| array_flow.rb:1491:9:1491:9 | a [element 2] | array_flow.rb:1491:9:1491:16 | call to to_ary [element 2] |
+| array_flow.rb:1491:9:1491:16 | call to to_ary [element 2] | array_flow.rb:1491:5:1491:5 | b [element 2] |
+| array_flow.rb:1494:10:1494:10 | b [element 2] | array_flow.rb:1494:10:1494:13 | ...[...] |
+| array_flow.rb:1507:5:1507:5 | a [element 0, element 1] | array_flow.rb:1508:9:1508:9 | a [element 0, element 1] |
+| array_flow.rb:1507:5:1507:5 | a [element 1, element 1] | array_flow.rb:1508:9:1508:9 | a [element 1, element 1] |
+| array_flow.rb:1507:5:1507:5 | a [element 2, element 1] | array_flow.rb:1508:9:1508:9 | a [element 2, element 1] |
+| array_flow.rb:1507:14:1507:26 | call to source | array_flow.rb:1507:5:1507:5 | a [element 0, element 1] |
+| array_flow.rb:1507:34:1507:46 | call to source | array_flow.rb:1507:5:1507:5 | a [element 1, element 1] |
+| array_flow.rb:1507:54:1507:66 | call to source | array_flow.rb:1507:5:1507:5 | a [element 2, element 1] |
+| array_flow.rb:1508:5:1508:5 | b [element 1, element 0] | array_flow.rb:1512:10:1512:10 | b [element 1, element 0] |
+| array_flow.rb:1508:5:1508:5 | b [element 1, element 1] | array_flow.rb:1513:10:1513:10 | b [element 1, element 1] |
+| array_flow.rb:1508:5:1508:5 | b [element 1, element 2] | array_flow.rb:1514:10:1514:10 | b [element 1, element 2] |
+| array_flow.rb:1508:9:1508:9 | a [element 0, element 1] | array_flow.rb:1508:9:1508:19 | call to transpose [element 1, element 0] |
+| array_flow.rb:1508:9:1508:9 | a [element 1, element 1] | array_flow.rb:1508:9:1508:19 | call to transpose [element 1, element 1] |
+| array_flow.rb:1508:9:1508:9 | a [element 2, element 1] | array_flow.rb:1508:9:1508:19 | call to transpose [element 1, element 2] |
+| array_flow.rb:1508:9:1508:19 | call to transpose [element 1, element 0] | array_flow.rb:1508:5:1508:5 | b [element 1, element 0] |
+| array_flow.rb:1508:9:1508:19 | call to transpose [element 1, element 1] | array_flow.rb:1508:5:1508:5 | b [element 1, element 1] |
+| array_flow.rb:1508:9:1508:19 | call to transpose [element 1, element 2] | array_flow.rb:1508:5:1508:5 | b [element 1, element 2] |
+| array_flow.rb:1512:10:1512:10 | b [element 1, element 0] | array_flow.rb:1512:10:1512:13 | ...[...] [element 0] |
+| array_flow.rb:1512:10:1512:13 | ...[...] [element 0] | array_flow.rb:1512:10:1512:16 | ...[...] |
+| array_flow.rb:1513:10:1513:10 | b [element 1, element 1] | array_flow.rb:1513:10:1513:13 | ...[...] [element 1] |
+| array_flow.rb:1513:10:1513:13 | ...[...] [element 1] | array_flow.rb:1513:10:1513:16 | ...[...] |
+| array_flow.rb:1514:10:1514:10 | b [element 1, element 2] | array_flow.rb:1514:10:1514:13 | ...[...] [element 2] |
+| array_flow.rb:1514:10:1514:13 | ...[...] [element 2] | array_flow.rb:1514:10:1514:16 | ...[...] |
+| array_flow.rb:1518:5:1518:5 | a [element 2] | array_flow.rb:1521:9:1521:9 | a [element 2] |
+| array_flow.rb:1518:16:1518:28 | call to source | array_flow.rb:1518:5:1518:5 | a [element 2] |
+| array_flow.rb:1519:5:1519:5 | b [element 1] | array_flow.rb:1521:17:1521:17 | b [element 1] |
+| array_flow.rb:1519:13:1519:25 | call to source | array_flow.rb:1519:5:1519:5 | b [element 1] |
+| array_flow.rb:1520:5:1520:5 | c [element 1] | array_flow.rb:1521:20:1521:20 | c [element 1] |
+| array_flow.rb:1520:13:1520:25 | call to source | array_flow.rb:1520:5:1520:5 | c [element 1] |
+| array_flow.rb:1521:5:1521:5 | d [element] | array_flow.rb:1522:10:1522:10 | d [element] |
+| array_flow.rb:1521:5:1521:5 | d [element] | array_flow.rb:1523:10:1523:10 | d [element] |
+| array_flow.rb:1521:5:1521:5 | d [element] | array_flow.rb:1524:10:1524:10 | d [element] |
+| array_flow.rb:1521:9:1521:9 | a [element 2] | array_flow.rb:1521:9:1521:21 | call to union [element] |
+| array_flow.rb:1521:9:1521:21 | call to union [element] | array_flow.rb:1521:5:1521:5 | d [element] |
+| array_flow.rb:1521:17:1521:17 | b [element 1] | array_flow.rb:1521:9:1521:21 | call to union [element] |
+| array_flow.rb:1521:20:1521:20 | c [element 1] | array_flow.rb:1521:9:1521:21 | call to union [element] |
 | array_flow.rb:1522:10:1522:10 | d [element] | array_flow.rb:1522:10:1522:13 | ...[...] |
 | array_flow.rb:1523:10:1523:10 | d [element] | array_flow.rb:1523:10:1523:13 | ...[...] |
-| array_flow.rb:1527:5:1527:5 | a [element 3] | array_flow.rb:1529:9:1529:9 | a [element 3] |
-| array_flow.rb:1527:5:1527:5 | a [element 3] | array_flow.rb:1533:9:1533:9 | a [element 3] |
-| array_flow.rb:1527:5:1527:5 | a [element 4] | array_flow.rb:1529:9:1529:9 | a [element 4] |
-| array_flow.rb:1527:5:1527:5 | a [element 4] | array_flow.rb:1533:9:1533:9 | a [element 4] |
-| array_flow.rb:1527:19:1527:31 | call to source | array_flow.rb:1527:5:1527:5 | a [element 3] |
-| array_flow.rb:1527:34:1527:46 | call to source | array_flow.rb:1527:5:1527:5 | a [element 4] |
-| array_flow.rb:1529:5:1529:5 | b [element] | array_flow.rb:1530:10:1530:10 | b [element] |
-| array_flow.rb:1529:5:1529:5 | b [element] | array_flow.rb:1531:10:1531:10 | b [element] |
-| array_flow.rb:1529:9:1529:9 | a [element 3] | array_flow.rb:1529:9:1529:14 | call to uniq [element] |
-| array_flow.rb:1529:9:1529:9 | a [element 4] | array_flow.rb:1529:9:1529:14 | call to uniq [element] |
-| array_flow.rb:1529:9:1529:14 | call to uniq [element] | array_flow.rb:1529:5:1529:5 | b [element] |
-| array_flow.rb:1530:10:1530:10 | b [element] | array_flow.rb:1530:10:1530:13 | ...[...] |
+| array_flow.rb:1524:10:1524:10 | d [element] | array_flow.rb:1524:10:1524:13 | ...[...] |
+| array_flow.rb:1528:5:1528:5 | a [element 3] | array_flow.rb:1530:9:1530:9 | a [element 3] |
+| array_flow.rb:1528:5:1528:5 | a [element 3] | array_flow.rb:1534:9:1534:9 | a [element 3] |
+| array_flow.rb:1528:5:1528:5 | a [element 4] | array_flow.rb:1530:9:1530:9 | a [element 4] |
+| array_flow.rb:1528:5:1528:5 | a [element 4] | array_flow.rb:1534:9:1534:9 | a [element 4] |
+| array_flow.rb:1528:19:1528:31 | call to source | array_flow.rb:1528:5:1528:5 | a [element 3] |
+| array_flow.rb:1528:34:1528:46 | call to source | array_flow.rb:1528:5:1528:5 | a [element 4] |
+| array_flow.rb:1530:5:1530:5 | b [element] | array_flow.rb:1531:10:1531:10 | b [element] |
+| array_flow.rb:1530:5:1530:5 | b [element] | array_flow.rb:1532:10:1532:10 | b [element] |
+| array_flow.rb:1530:9:1530:9 | a [element 3] | array_flow.rb:1530:9:1530:14 | call to uniq [element] |
+| array_flow.rb:1530:9:1530:9 | a [element 4] | array_flow.rb:1530:9:1530:14 | call to uniq [element] |
+| array_flow.rb:1530:9:1530:14 | call to uniq [element] | array_flow.rb:1530:5:1530:5 | b [element] |
 | array_flow.rb:1531:10:1531:10 | b [element] | array_flow.rb:1531:10:1531:13 | ...[...] |
-| array_flow.rb:1533:5:1533:5 | c [element] | array_flow.rb:1537:10:1537:10 | c [element] |
-| array_flow.rb:1533:9:1533:9 | a [element 3] | array_flow.rb:1533:9:1536:7 | call to uniq [element] |
-| array_flow.rb:1533:9:1533:9 | a [element 3] | array_flow.rb:1533:20:1533:20 | x |
-| array_flow.rb:1533:9:1533:9 | a [element 4] | array_flow.rb:1533:9:1536:7 | call to uniq [element] |
-| array_flow.rb:1533:9:1533:9 | a [element 4] | array_flow.rb:1533:20:1533:20 | x |
-| array_flow.rb:1533:9:1536:7 | call to uniq [element] | array_flow.rb:1533:5:1533:5 | c [element] |
-| array_flow.rb:1533:20:1533:20 | x | array_flow.rb:1534:14:1534:14 | x |
-| array_flow.rb:1537:10:1537:10 | c [element] | array_flow.rb:1537:10:1537:13 | ...[...] |
-| array_flow.rb:1541:5:1541:5 | a [element 2] | array_flow.rb:1542:9:1542:9 | a [element 2] |
-| array_flow.rb:1541:5:1541:5 | a [element 3] | array_flow.rb:1542:9:1542:9 | a [element 3] |
-| array_flow.rb:1541:16:1541:28 | call to source | array_flow.rb:1541:5:1541:5 | a [element 2] |
-| array_flow.rb:1541:31:1541:43 | call to source | array_flow.rb:1541:5:1541:5 | a [element 3] |
-| array_flow.rb:1542:5:1542:5 | b [element] | array_flow.rb:1543:10:1543:10 | b [element] |
-| array_flow.rb:1542:5:1542:5 | b [element] | array_flow.rb:1544:10:1544:10 | b [element] |
-| array_flow.rb:1542:9:1542:9 | [post] a [element] | array_flow.rb:1545:10:1545:10 | a [element] |
-| array_flow.rb:1542:9:1542:9 | [post] a [element] | array_flow.rb:1546:10:1546:10 | a [element] |
-| array_flow.rb:1542:9:1542:9 | a [element 2] | array_flow.rb:1542:9:1542:9 | [post] a [element] |
-| array_flow.rb:1542:9:1542:9 | a [element 2] | array_flow.rb:1542:9:1542:15 | call to uniq! [element] |
-| array_flow.rb:1542:9:1542:9 | a [element 3] | array_flow.rb:1542:9:1542:9 | [post] a [element] |
-| array_flow.rb:1542:9:1542:9 | a [element 3] | array_flow.rb:1542:9:1542:15 | call to uniq! [element] |
-| array_flow.rb:1542:9:1542:15 | call to uniq! [element] | array_flow.rb:1542:5:1542:5 | b [element] |
-| array_flow.rb:1543:10:1543:10 | b [element] | array_flow.rb:1543:10:1543:13 | ...[...] |
+| array_flow.rb:1532:10:1532:10 | b [element] | array_flow.rb:1532:10:1532:13 | ...[...] |
+| array_flow.rb:1534:5:1534:5 | c [element] | array_flow.rb:1538:10:1538:10 | c [element] |
+| array_flow.rb:1534:9:1534:9 | a [element 3] | array_flow.rb:1534:9:1537:7 | call to uniq [element] |
+| array_flow.rb:1534:9:1534:9 | a [element 3] | array_flow.rb:1534:20:1534:20 | x |
+| array_flow.rb:1534:9:1534:9 | a [element 4] | array_flow.rb:1534:9:1537:7 | call to uniq [element] |
+| array_flow.rb:1534:9:1534:9 | a [element 4] | array_flow.rb:1534:20:1534:20 | x |
+| array_flow.rb:1534:9:1537:7 | call to uniq [element] | array_flow.rb:1534:5:1534:5 | c [element] |
+| array_flow.rb:1534:20:1534:20 | x | array_flow.rb:1535:14:1535:14 | x |
+| array_flow.rb:1538:10:1538:10 | c [element] | array_flow.rb:1538:10:1538:13 | ...[...] |
+| array_flow.rb:1542:5:1542:5 | a [element 2] | array_flow.rb:1543:9:1543:9 | a [element 2] |
+| array_flow.rb:1542:5:1542:5 | a [element 3] | array_flow.rb:1543:9:1543:9 | a [element 3] |
+| array_flow.rb:1542:16:1542:28 | call to source | array_flow.rb:1542:5:1542:5 | a [element 2] |
+| array_flow.rb:1542:31:1542:43 | call to source | array_flow.rb:1542:5:1542:5 | a [element 3] |
+| array_flow.rb:1543:5:1543:5 | b [element] | array_flow.rb:1544:10:1544:10 | b [element] |
+| array_flow.rb:1543:5:1543:5 | b [element] | array_flow.rb:1545:10:1545:10 | b [element] |
+| array_flow.rb:1543:9:1543:9 | [post] a [element] | array_flow.rb:1546:10:1546:10 | a [element] |
+| array_flow.rb:1543:9:1543:9 | [post] a [element] | array_flow.rb:1547:10:1547:10 | a [element] |
+| array_flow.rb:1543:9:1543:9 | a [element 2] | array_flow.rb:1543:9:1543:9 | [post] a [element] |
+| array_flow.rb:1543:9:1543:9 | a [element 2] | array_flow.rb:1543:9:1543:15 | call to uniq! [element] |
+| array_flow.rb:1543:9:1543:9 | a [element 3] | array_flow.rb:1543:9:1543:9 | [post] a [element] |
+| array_flow.rb:1543:9:1543:9 | a [element 3] | array_flow.rb:1543:9:1543:15 | call to uniq! [element] |
+| array_flow.rb:1543:9:1543:15 | call to uniq! [element] | array_flow.rb:1543:5:1543:5 | b [element] |
 | array_flow.rb:1544:10:1544:10 | b [element] | array_flow.rb:1544:10:1544:13 | ...[...] |
-| array_flow.rb:1545:10:1545:10 | a [element] | array_flow.rb:1545:10:1545:13 | ...[...] |
+| array_flow.rb:1545:10:1545:10 | b [element] | array_flow.rb:1545:10:1545:13 | ...[...] |
 | array_flow.rb:1546:10:1546:10 | a [element] | array_flow.rb:1546:10:1546:13 | ...[...] |
-| array_flow.rb:1548:5:1548:5 | a [element 2] | array_flow.rb:1549:9:1549:9 | a [element 2] |
-| array_flow.rb:1548:5:1548:5 | a [element 3] | array_flow.rb:1549:9:1549:9 | a [element 3] |
-| array_flow.rb:1548:16:1548:28 | call to source | array_flow.rb:1548:5:1548:5 | a [element 2] |
-| array_flow.rb:1548:31:1548:43 | call to source | array_flow.rb:1548:5:1548:5 | a [element 3] |
-| array_flow.rb:1549:5:1549:5 | b [element] | array_flow.rb:1553:10:1553:10 | b [element] |
-| array_flow.rb:1549:5:1549:5 | b [element] | array_flow.rb:1554:10:1554:10 | b [element] |
-| array_flow.rb:1549:9:1549:9 | [post] a [element] | array_flow.rb:1555:10:1555:10 | a [element] |
-| array_flow.rb:1549:9:1549:9 | [post] a [element] | array_flow.rb:1556:10:1556:10 | a [element] |
-| array_flow.rb:1549:9:1549:9 | a [element 2] | array_flow.rb:1549:9:1549:9 | [post] a [element] |
-| array_flow.rb:1549:9:1549:9 | a [element 2] | array_flow.rb:1549:9:1552:7 | call to uniq! [element] |
-| array_flow.rb:1549:9:1549:9 | a [element 2] | array_flow.rb:1549:21:1549:21 | x |
-| array_flow.rb:1549:9:1549:9 | a [element 3] | array_flow.rb:1549:9:1549:9 | [post] a [element] |
-| array_flow.rb:1549:9:1549:9 | a [element 3] | array_flow.rb:1549:9:1552:7 | call to uniq! [element] |
-| array_flow.rb:1549:9:1549:9 | a [element 3] | array_flow.rb:1549:21:1549:21 | x |
-| array_flow.rb:1549:9:1552:7 | call to uniq! [element] | array_flow.rb:1549:5:1549:5 | b [element] |
-| array_flow.rb:1549:21:1549:21 | x | array_flow.rb:1550:14:1550:14 | x |
-| array_flow.rb:1553:10:1553:10 | b [element] | array_flow.rb:1553:10:1553:13 | ...[...] |
+| array_flow.rb:1547:10:1547:10 | a [element] | array_flow.rb:1547:10:1547:13 | ...[...] |
+| array_flow.rb:1549:5:1549:5 | a [element 2] | array_flow.rb:1550:9:1550:9 | a [element 2] |
+| array_flow.rb:1549:5:1549:5 | a [element 3] | array_flow.rb:1550:9:1550:9 | a [element 3] |
+| array_flow.rb:1549:16:1549:28 | call to source | array_flow.rb:1549:5:1549:5 | a [element 2] |
+| array_flow.rb:1549:31:1549:43 | call to source | array_flow.rb:1549:5:1549:5 | a [element 3] |
+| array_flow.rb:1550:5:1550:5 | b [element] | array_flow.rb:1554:10:1554:10 | b [element] |
+| array_flow.rb:1550:5:1550:5 | b [element] | array_flow.rb:1555:10:1555:10 | b [element] |
+| array_flow.rb:1550:9:1550:9 | [post] a [element] | array_flow.rb:1556:10:1556:10 | a [element] |
+| array_flow.rb:1550:9:1550:9 | [post] a [element] | array_flow.rb:1557:10:1557:10 | a [element] |
+| array_flow.rb:1550:9:1550:9 | a [element 2] | array_flow.rb:1550:9:1550:9 | [post] a [element] |
+| array_flow.rb:1550:9:1550:9 | a [element 2] | array_flow.rb:1550:9:1553:7 | call to uniq! [element] |
+| array_flow.rb:1550:9:1550:9 | a [element 2] | array_flow.rb:1550:21:1550:21 | x |
+| array_flow.rb:1550:9:1550:9 | a [element 3] | array_flow.rb:1550:9:1550:9 | [post] a [element] |
+| array_flow.rb:1550:9:1550:9 | a [element 3] | array_flow.rb:1550:9:1553:7 | call to uniq! [element] |
+| array_flow.rb:1550:9:1550:9 | a [element 3] | array_flow.rb:1550:21:1550:21 | x |
+| array_flow.rb:1550:9:1553:7 | call to uniq! [element] | array_flow.rb:1550:5:1550:5 | b [element] |
+| array_flow.rb:1550:21:1550:21 | x | array_flow.rb:1551:14:1551:14 | x |
 | array_flow.rb:1554:10:1554:10 | b [element] | array_flow.rb:1554:10:1554:13 | ...[...] |
-| array_flow.rb:1555:10:1555:10 | a [element] | array_flow.rb:1555:10:1555:13 | ...[...] |
+| array_flow.rb:1555:10:1555:10 | b [element] | array_flow.rb:1555:10:1555:13 | ...[...] |
 | array_flow.rb:1556:10:1556:10 | a [element] | array_flow.rb:1556:10:1556:13 | ...[...] |
-| array_flow.rb:1560:5:1560:5 | a [element 2] | array_flow.rb:1561:5:1561:5 | a [element 2] |
-| array_flow.rb:1560:16:1560:28 | call to source | array_flow.rb:1560:5:1560:5 | a [element 2] |
-| array_flow.rb:1561:5:1561:5 | [post] a [element 2] | array_flow.rb:1564:10:1564:10 | a [element 2] |
-| array_flow.rb:1561:5:1561:5 | [post] a [element 5] | array_flow.rb:1567:10:1567:10 | a [element 5] |
-| array_flow.rb:1561:5:1561:5 | a [element 2] | array_flow.rb:1561:5:1561:5 | [post] a [element 5] |
-| array_flow.rb:1561:21:1561:33 | call to source | array_flow.rb:1561:5:1561:5 | [post] a [element 2] |
-| array_flow.rb:1564:10:1564:10 | a [element 2] | array_flow.rb:1564:10:1564:13 | ...[...] |
-| array_flow.rb:1567:10:1567:10 | a [element 5] | array_flow.rb:1567:10:1567:13 | ...[...] |
-| array_flow.rb:1571:5:1571:5 | a [element 1] | array_flow.rb:1573:9:1573:9 | a [element 1] |
-| array_flow.rb:1571:5:1571:5 | a [element 1] | array_flow.rb:1579:9:1579:9 | a [element 1] |
-| array_flow.rb:1571:5:1571:5 | a [element 1] | array_flow.rb:1583:9:1583:9 | a [element 1] |
-| array_flow.rb:1571:5:1571:5 | a [element 1] | array_flow.rb:1587:9:1587:9 | a [element 1] |
-| array_flow.rb:1571:5:1571:5 | a [element 3] | array_flow.rb:1579:9:1579:9 | a [element 3] |
-| array_flow.rb:1571:5:1571:5 | a [element 3] | array_flow.rb:1583:9:1583:9 | a [element 3] |
-| array_flow.rb:1571:5:1571:5 | a [element 3] | array_flow.rb:1587:9:1587:9 | a [element 3] |
-| array_flow.rb:1571:13:1571:25 | call to source | array_flow.rb:1571:5:1571:5 | a [element 1] |
-| array_flow.rb:1571:31:1571:43 | call to source | array_flow.rb:1571:5:1571:5 | a [element 3] |
-| array_flow.rb:1573:5:1573:5 | b [element 1] | array_flow.rb:1575:10:1575:10 | b [element 1] |
-| array_flow.rb:1573:5:1573:5 | b [element 3] | array_flow.rb:1577:10:1577:10 | b [element 3] |
-| array_flow.rb:1573:9:1573:9 | a [element 1] | array_flow.rb:1573:9:1573:31 | call to values_at [element 1] |
-| array_flow.rb:1573:9:1573:9 | a [element 1] | array_flow.rb:1573:9:1573:31 | call to values_at [element 3] |
-| array_flow.rb:1573:9:1573:31 | call to values_at [element 1] | array_flow.rb:1573:5:1573:5 | b [element 1] |
-| array_flow.rb:1573:9:1573:31 | call to values_at [element 3] | array_flow.rb:1573:5:1573:5 | b [element 3] |
-| array_flow.rb:1575:10:1575:10 | b [element 1] | array_flow.rb:1575:10:1575:13 | ...[...] |
-| array_flow.rb:1577:10:1577:10 | b [element 3] | array_flow.rb:1577:10:1577:13 | ...[...] |
-| array_flow.rb:1579:5:1579:5 | b [element] | array_flow.rb:1580:10:1580:10 | b [element] |
-| array_flow.rb:1579:5:1579:5 | b [element] | array_flow.rb:1581:10:1581:10 | b [element] |
-| array_flow.rb:1579:9:1579:9 | a [element 1] | array_flow.rb:1579:9:1579:25 | call to values_at [element] |
-| array_flow.rb:1579:9:1579:9 | a [element 3] | array_flow.rb:1579:9:1579:25 | call to values_at [element] |
-| array_flow.rb:1579:9:1579:25 | call to values_at [element] | array_flow.rb:1579:5:1579:5 | b [element] |
-| array_flow.rb:1580:10:1580:10 | b [element] | array_flow.rb:1580:10:1580:13 | ...[...] |
+| array_flow.rb:1557:10:1557:10 | a [element] | array_flow.rb:1557:10:1557:13 | ...[...] |
+| array_flow.rb:1561:5:1561:5 | a [element 2] | array_flow.rb:1562:5:1562:5 | a [element 2] |
+| array_flow.rb:1561:16:1561:28 | call to source | array_flow.rb:1561:5:1561:5 | a [element 2] |
+| array_flow.rb:1562:5:1562:5 | [post] a [element 2] | array_flow.rb:1565:10:1565:10 | a [element 2] |
+| array_flow.rb:1562:5:1562:5 | [post] a [element 5] | array_flow.rb:1568:10:1568:10 | a [element 5] |
+| array_flow.rb:1562:5:1562:5 | a [element 2] | array_flow.rb:1562:5:1562:5 | [post] a [element 5] |
+| array_flow.rb:1562:21:1562:33 | call to source | array_flow.rb:1562:5:1562:5 | [post] a [element 2] |
+| array_flow.rb:1565:10:1565:10 | a [element 2] | array_flow.rb:1565:10:1565:13 | ...[...] |
+| array_flow.rb:1568:10:1568:10 | a [element 5] | array_flow.rb:1568:10:1568:13 | ...[...] |
+| array_flow.rb:1572:5:1572:5 | a [element 1] | array_flow.rb:1574:9:1574:9 | a [element 1] |
+| array_flow.rb:1572:5:1572:5 | a [element 1] | array_flow.rb:1580:9:1580:9 | a [element 1] |
+| array_flow.rb:1572:5:1572:5 | a [element 1] | array_flow.rb:1584:9:1584:9 | a [element 1] |
+| array_flow.rb:1572:5:1572:5 | a [element 1] | array_flow.rb:1588:9:1588:9 | a [element 1] |
+| array_flow.rb:1572:5:1572:5 | a [element 3] | array_flow.rb:1580:9:1580:9 | a [element 3] |
+| array_flow.rb:1572:5:1572:5 | a [element 3] | array_flow.rb:1584:9:1584:9 | a [element 3] |
+| array_flow.rb:1572:5:1572:5 | a [element 3] | array_flow.rb:1588:9:1588:9 | a [element 3] |
+| array_flow.rb:1572:13:1572:25 | call to source | array_flow.rb:1572:5:1572:5 | a [element 1] |
+| array_flow.rb:1572:31:1572:43 | call to source | array_flow.rb:1572:5:1572:5 | a [element 3] |
+| array_flow.rb:1574:5:1574:5 | b [element 1] | array_flow.rb:1576:10:1576:10 | b [element 1] |
+| array_flow.rb:1574:5:1574:5 | b [element 3] | array_flow.rb:1578:10:1578:10 | b [element 3] |
+| array_flow.rb:1574:9:1574:9 | a [element 1] | array_flow.rb:1574:9:1574:31 | call to values_at [element 1] |
+| array_flow.rb:1574:9:1574:9 | a [element 1] | array_flow.rb:1574:9:1574:31 | call to values_at [element 3] |
+| array_flow.rb:1574:9:1574:31 | call to values_at [element 1] | array_flow.rb:1574:5:1574:5 | b [element 1] |
+| array_flow.rb:1574:9:1574:31 | call to values_at [element 3] | array_flow.rb:1574:5:1574:5 | b [element 3] |
+| array_flow.rb:1576:10:1576:10 | b [element 1] | array_flow.rb:1576:10:1576:13 | ...[...] |
+| array_flow.rb:1578:10:1578:10 | b [element 3] | array_flow.rb:1578:10:1578:13 | ...[...] |
+| array_flow.rb:1580:5:1580:5 | b [element] | array_flow.rb:1581:10:1581:10 | b [element] |
+| array_flow.rb:1580:5:1580:5 | b [element] | array_flow.rb:1582:10:1582:10 | b [element] |
+| array_flow.rb:1580:9:1580:9 | a [element 1] | array_flow.rb:1580:9:1580:25 | call to values_at [element] |
+| array_flow.rb:1580:9:1580:9 | a [element 3] | array_flow.rb:1580:9:1580:25 | call to values_at [element] |
+| array_flow.rb:1580:9:1580:25 | call to values_at [element] | array_flow.rb:1580:5:1580:5 | b [element] |
 | array_flow.rb:1581:10:1581:10 | b [element] | array_flow.rb:1581:10:1581:13 | ...[...] |
-| array_flow.rb:1583:5:1583:5 | b [element] | array_flow.rb:1584:10:1584:10 | b [element] |
-| array_flow.rb:1583:5:1583:5 | b [element] | array_flow.rb:1585:10:1585:10 | b [element] |
-| array_flow.rb:1583:9:1583:9 | a [element 1] | array_flow.rb:1583:9:1583:26 | call to values_at [element] |
-| array_flow.rb:1583:9:1583:9 | a [element 3] | array_flow.rb:1583:9:1583:26 | call to values_at [element] |
-| array_flow.rb:1583:9:1583:26 | call to values_at [element] | array_flow.rb:1583:5:1583:5 | b [element] |
-| array_flow.rb:1584:10:1584:10 | b [element] | array_flow.rb:1584:10:1584:13 | ...[...] |
+| array_flow.rb:1582:10:1582:10 | b [element] | array_flow.rb:1582:10:1582:13 | ...[...] |
+| array_flow.rb:1584:5:1584:5 | b [element] | array_flow.rb:1585:10:1585:10 | b [element] |
+| array_flow.rb:1584:5:1584:5 | b [element] | array_flow.rb:1586:10:1586:10 | b [element] |
+| array_flow.rb:1584:9:1584:9 | a [element 1] | array_flow.rb:1584:9:1584:26 | call to values_at [element] |
+| array_flow.rb:1584:9:1584:9 | a [element 3] | array_flow.rb:1584:9:1584:26 | call to values_at [element] |
+| array_flow.rb:1584:9:1584:26 | call to values_at [element] | array_flow.rb:1584:5:1584:5 | b [element] |
 | array_flow.rb:1585:10:1585:10 | b [element] | array_flow.rb:1585:10:1585:13 | ...[...] |
-| array_flow.rb:1587:5:1587:5 | b [element 1] | array_flow.rb:1589:10:1589:10 | b [element 1] |
-| array_flow.rb:1587:5:1587:5 | b [element] | array_flow.rb:1588:10:1588:10 | b [element] |
-| array_flow.rb:1587:5:1587:5 | b [element] | array_flow.rb:1589:10:1589:10 | b [element] |
-| array_flow.rb:1587:5:1587:5 | b [element] | array_flow.rb:1590:10:1590:10 | b [element] |
-| array_flow.rb:1587:5:1587:5 | b [element] | array_flow.rb:1591:10:1591:10 | b [element] |
-| array_flow.rb:1587:9:1587:9 | a [element 1] | array_flow.rb:1587:9:1587:28 | call to values_at [element] |
-| array_flow.rb:1587:9:1587:9 | a [element 3] | array_flow.rb:1587:9:1587:28 | call to values_at [element 1] |
-| array_flow.rb:1587:9:1587:9 | a [element 3] | array_flow.rb:1587:9:1587:28 | call to values_at [element] |
-| array_flow.rb:1587:9:1587:28 | call to values_at [element 1] | array_flow.rb:1587:5:1587:5 | b [element 1] |
-| array_flow.rb:1587:9:1587:28 | call to values_at [element] | array_flow.rb:1587:5:1587:5 | b [element] |
-| array_flow.rb:1588:10:1588:10 | b [element] | array_flow.rb:1588:10:1588:13 | ...[...] |
-| array_flow.rb:1589:10:1589:10 | b [element 1] | array_flow.rb:1589:10:1589:13 | ...[...] |
+| array_flow.rb:1586:10:1586:10 | b [element] | array_flow.rb:1586:10:1586:13 | ...[...] |
+| array_flow.rb:1588:5:1588:5 | b [element 1] | array_flow.rb:1590:10:1590:10 | b [element 1] |
+| array_flow.rb:1588:5:1588:5 | b [element] | array_flow.rb:1589:10:1589:10 | b [element] |
+| array_flow.rb:1588:5:1588:5 | b [element] | array_flow.rb:1590:10:1590:10 | b [element] |
+| array_flow.rb:1588:5:1588:5 | b [element] | array_flow.rb:1591:10:1591:10 | b [element] |
+| array_flow.rb:1588:5:1588:5 | b [element] | array_flow.rb:1592:10:1592:10 | b [element] |
+| array_flow.rb:1588:9:1588:9 | a [element 1] | array_flow.rb:1588:9:1588:28 | call to values_at [element] |
+| array_flow.rb:1588:9:1588:9 | a [element 3] | array_flow.rb:1588:9:1588:28 | call to values_at [element 1] |
+| array_flow.rb:1588:9:1588:9 | a [element 3] | array_flow.rb:1588:9:1588:28 | call to values_at [element] |
+| array_flow.rb:1588:9:1588:28 | call to values_at [element 1] | array_flow.rb:1588:5:1588:5 | b [element 1] |
+| array_flow.rb:1588:9:1588:28 | call to values_at [element] | array_flow.rb:1588:5:1588:5 | b [element] |
 | array_flow.rb:1589:10:1589:10 | b [element] | array_flow.rb:1589:10:1589:13 | ...[...] |
+| array_flow.rb:1590:10:1590:10 | b [element 1] | array_flow.rb:1590:10:1590:13 | ...[...] |
 | array_flow.rb:1590:10:1590:10 | b [element] | array_flow.rb:1590:10:1590:13 | ...[...] |
 | array_flow.rb:1591:10:1591:10 | b [element] | array_flow.rb:1591:10:1591:13 | ...[...] |
-| array_flow.rb:1595:5:1595:5 | a [element 2] | array_flow.rb:1598:9:1598:9 | a [element 2] |
-| array_flow.rb:1595:5:1595:5 | a [element 2] | array_flow.rb:1603:5:1603:5 | a [element 2] |
-| array_flow.rb:1595:16:1595:28 | call to source | array_flow.rb:1595:5:1595:5 | a [element 2] |
-| array_flow.rb:1596:5:1596:5 | b [element 1] | array_flow.rb:1598:15:1598:15 | b [element 1] |
-| array_flow.rb:1596:5:1596:5 | b [element 1] | array_flow.rb:1603:11:1603:11 | b [element 1] |
-| array_flow.rb:1596:13:1596:25 | call to source | array_flow.rb:1596:5:1596:5 | b [element 1] |
-| array_flow.rb:1597:5:1597:5 | c [element 0] | array_flow.rb:1598:18:1598:18 | c [element 0] |
-| array_flow.rb:1597:5:1597:5 | c [element 0] | array_flow.rb:1603:14:1603:14 | c [element 0] |
-| array_flow.rb:1597:10:1597:22 | call to source | array_flow.rb:1597:5:1597:5 | c [element 0] |
-| array_flow.rb:1598:5:1598:5 | d [element 0, element 2] | array_flow.rb:1600:10:1600:10 | d [element 0, element 2] |
-| array_flow.rb:1598:5:1598:5 | d [element 1, element 1] | array_flow.rb:1601:10:1601:10 | d [element 1, element 1] |
-| array_flow.rb:1598:5:1598:5 | d [element 2, element 0] | array_flow.rb:1602:10:1602:10 | d [element 2, element 0] |
-| array_flow.rb:1598:9:1598:9 | a [element 2] | array_flow.rb:1598:9:1598:19 | call to zip [element 2, element 0] |
-| array_flow.rb:1598:9:1598:19 | call to zip [element 0, element 2] | array_flow.rb:1598:5:1598:5 | d [element 0, element 2] |
-| array_flow.rb:1598:9:1598:19 | call to zip [element 1, element 1] | array_flow.rb:1598:5:1598:5 | d [element 1, element 1] |
-| array_flow.rb:1598:9:1598:19 | call to zip [element 2, element 0] | array_flow.rb:1598:5:1598:5 | d [element 2, element 0] |
-| array_flow.rb:1598:15:1598:15 | b [element 1] | array_flow.rb:1598:9:1598:19 | call to zip [element 1, element 1] |
-| array_flow.rb:1598:18:1598:18 | c [element 0] | array_flow.rb:1598:9:1598:19 | call to zip [element 0, element 2] |
-| array_flow.rb:1600:10:1600:10 | d [element 0, element 2] | array_flow.rb:1600:10:1600:13 | ...[...] [element 2] |
-| array_flow.rb:1600:10:1600:13 | ...[...] [element 2] | array_flow.rb:1600:10:1600:16 | ...[...] |
-| array_flow.rb:1601:10:1601:10 | d [element 1, element 1] | array_flow.rb:1601:10:1601:13 | ...[...] [element 1] |
-| array_flow.rb:1601:10:1601:13 | ...[...] [element 1] | array_flow.rb:1601:10:1601:16 | ...[...] |
-| array_flow.rb:1602:10:1602:10 | d [element 2, element 0] | array_flow.rb:1602:10:1602:13 | ...[...] [element 0] |
-| array_flow.rb:1602:10:1602:13 | ...[...] [element 0] | array_flow.rb:1602:10:1602:16 | ...[...] |
-| array_flow.rb:1603:5:1603:5 | a [element 2] | array_flow.rb:1603:21:1603:21 | x [element 0] |
-| array_flow.rb:1603:11:1603:11 | b [element 1] | array_flow.rb:1603:21:1603:21 | x [element 1] |
-| array_flow.rb:1603:14:1603:14 | c [element 0] | array_flow.rb:1603:21:1603:21 | x [element 2] |
-| array_flow.rb:1603:21:1603:21 | x [element 0] | array_flow.rb:1604:14:1604:14 | x [element 0] |
-| array_flow.rb:1603:21:1603:21 | x [element 1] | array_flow.rb:1605:14:1605:14 | x [element 1] |
-| array_flow.rb:1603:21:1603:21 | x [element 2] | array_flow.rb:1606:14:1606:14 | x [element 2] |
-| array_flow.rb:1604:14:1604:14 | x [element 0] | array_flow.rb:1604:14:1604:17 | ...[...] |
-| array_flow.rb:1605:14:1605:14 | x [element 1] | array_flow.rb:1605:14:1605:17 | ...[...] |
-| array_flow.rb:1606:14:1606:14 | x [element 2] | array_flow.rb:1606:14:1606:17 | ...[...] |
-| array_flow.rb:1611:5:1611:5 | a [element 2] | array_flow.rb:1613:9:1613:9 | a [element 2] |
-| array_flow.rb:1611:16:1611:28 | call to source | array_flow.rb:1611:5:1611:5 | a [element 2] |
-| array_flow.rb:1612:5:1612:5 | b [element 1] | array_flow.rb:1613:13:1613:13 | b [element 1] |
-| array_flow.rb:1612:13:1612:25 | call to source | array_flow.rb:1612:5:1612:5 | b [element 1] |
-| array_flow.rb:1613:5:1613:5 | c [element] | array_flow.rb:1614:10:1614:10 | c [element] |
-| array_flow.rb:1613:5:1613:5 | c [element] | array_flow.rb:1615:10:1615:10 | c [element] |
-| array_flow.rb:1613:5:1613:5 | c [element] | array_flow.rb:1616:10:1616:10 | c [element] |
-| array_flow.rb:1613:9:1613:9 | a [element 2] | array_flow.rb:1613:9:1613:13 | ... \| ... [element] |
-| array_flow.rb:1613:9:1613:13 | ... \| ... [element] | array_flow.rb:1613:5:1613:5 | c [element] |
-| array_flow.rb:1613:13:1613:13 | b [element 1] | array_flow.rb:1613:9:1613:13 | ... \| ... [element] |
-| array_flow.rb:1614:10:1614:10 | c [element] | array_flow.rb:1614:10:1614:13 | ...[...] |
+| array_flow.rb:1592:10:1592:10 | b [element] | array_flow.rb:1592:10:1592:13 | ...[...] |
+| array_flow.rb:1596:5:1596:5 | a [element 2] | array_flow.rb:1599:9:1599:9 | a [element 2] |
+| array_flow.rb:1596:5:1596:5 | a [element 2] | array_flow.rb:1604:5:1604:5 | a [element 2] |
+| array_flow.rb:1596:16:1596:28 | call to source | array_flow.rb:1596:5:1596:5 | a [element 2] |
+| array_flow.rb:1597:5:1597:5 | b [element 1] | array_flow.rb:1599:15:1599:15 | b [element 1] |
+| array_flow.rb:1597:5:1597:5 | b [element 1] | array_flow.rb:1604:11:1604:11 | b [element 1] |
+| array_flow.rb:1597:13:1597:25 | call to source | array_flow.rb:1597:5:1597:5 | b [element 1] |
+| array_flow.rb:1598:5:1598:5 | c [element 0] | array_flow.rb:1599:18:1599:18 | c [element 0] |
+| array_flow.rb:1598:5:1598:5 | c [element 0] | array_flow.rb:1604:14:1604:14 | c [element 0] |
+| array_flow.rb:1598:10:1598:22 | call to source | array_flow.rb:1598:5:1598:5 | c [element 0] |
+| array_flow.rb:1599:5:1599:5 | d [element 0, element 2] | array_flow.rb:1601:10:1601:10 | d [element 0, element 2] |
+| array_flow.rb:1599:5:1599:5 | d [element 1, element 1] | array_flow.rb:1602:10:1602:10 | d [element 1, element 1] |
+| array_flow.rb:1599:5:1599:5 | d [element 2, element 0] | array_flow.rb:1603:10:1603:10 | d [element 2, element 0] |
+| array_flow.rb:1599:9:1599:9 | a [element 2] | array_flow.rb:1599:9:1599:19 | call to zip [element 2, element 0] |
+| array_flow.rb:1599:9:1599:19 | call to zip [element 0, element 2] | array_flow.rb:1599:5:1599:5 | d [element 0, element 2] |
+| array_flow.rb:1599:9:1599:19 | call to zip [element 1, element 1] | array_flow.rb:1599:5:1599:5 | d [element 1, element 1] |
+| array_flow.rb:1599:9:1599:19 | call to zip [element 2, element 0] | array_flow.rb:1599:5:1599:5 | d [element 2, element 0] |
+| array_flow.rb:1599:15:1599:15 | b [element 1] | array_flow.rb:1599:9:1599:19 | call to zip [element 1, element 1] |
+| array_flow.rb:1599:18:1599:18 | c [element 0] | array_flow.rb:1599:9:1599:19 | call to zip [element 0, element 2] |
+| array_flow.rb:1601:10:1601:10 | d [element 0, element 2] | array_flow.rb:1601:10:1601:13 | ...[...] [element 2] |
+| array_flow.rb:1601:10:1601:13 | ...[...] [element 2] | array_flow.rb:1601:10:1601:16 | ...[...] |
+| array_flow.rb:1602:10:1602:10 | d [element 1, element 1] | array_flow.rb:1602:10:1602:13 | ...[...] [element 1] |
+| array_flow.rb:1602:10:1602:13 | ...[...] [element 1] | array_flow.rb:1602:10:1602:16 | ...[...] |
+| array_flow.rb:1603:10:1603:10 | d [element 2, element 0] | array_flow.rb:1603:10:1603:13 | ...[...] [element 0] |
+| array_flow.rb:1603:10:1603:13 | ...[...] [element 0] | array_flow.rb:1603:10:1603:16 | ...[...] |
+| array_flow.rb:1604:5:1604:5 | a [element 2] | array_flow.rb:1604:21:1604:21 | x [element 0] |
+| array_flow.rb:1604:11:1604:11 | b [element 1] | array_flow.rb:1604:21:1604:21 | x [element 1] |
+| array_flow.rb:1604:14:1604:14 | c [element 0] | array_flow.rb:1604:21:1604:21 | x [element 2] |
+| array_flow.rb:1604:21:1604:21 | x [element 0] | array_flow.rb:1605:14:1605:14 | x [element 0] |
+| array_flow.rb:1604:21:1604:21 | x [element 1] | array_flow.rb:1606:14:1606:14 | x [element 1] |
+| array_flow.rb:1604:21:1604:21 | x [element 2] | array_flow.rb:1607:14:1607:14 | x [element 2] |
+| array_flow.rb:1605:14:1605:14 | x [element 0] | array_flow.rb:1605:14:1605:17 | ...[...] |
+| array_flow.rb:1606:14:1606:14 | x [element 1] | array_flow.rb:1606:14:1606:17 | ...[...] |
+| array_flow.rb:1607:14:1607:14 | x [element 2] | array_flow.rb:1607:14:1607:17 | ...[...] |
+| array_flow.rb:1612:5:1612:5 | a [element 2] | array_flow.rb:1614:9:1614:9 | a [element 2] |
+| array_flow.rb:1612:16:1612:28 | call to source | array_flow.rb:1612:5:1612:5 | a [element 2] |
+| array_flow.rb:1613:5:1613:5 | b [element 1] | array_flow.rb:1614:13:1614:13 | b [element 1] |
+| array_flow.rb:1613:13:1613:25 | call to source | array_flow.rb:1613:5:1613:5 | b [element 1] |
+| array_flow.rb:1614:5:1614:5 | c [element] | array_flow.rb:1615:10:1615:10 | c [element] |
+| array_flow.rb:1614:5:1614:5 | c [element] | array_flow.rb:1616:10:1616:10 | c [element] |
+| array_flow.rb:1614:5:1614:5 | c [element] | array_flow.rb:1617:10:1617:10 | c [element] |
+| array_flow.rb:1614:9:1614:9 | a [element 2] | array_flow.rb:1614:9:1614:13 | ... \| ... [element] |
+| array_flow.rb:1614:9:1614:13 | ... \| ... [element] | array_flow.rb:1614:5:1614:5 | c [element] |
+| array_flow.rb:1614:13:1614:13 | b [element 1] | array_flow.rb:1614:9:1614:13 | ... \| ... [element] |
 | array_flow.rb:1615:10:1615:10 | c [element] | array_flow.rb:1615:10:1615:13 | ...[...] |
 | array_flow.rb:1616:10:1616:10 | c [element] | array_flow.rb:1616:10:1616:13 | ...[...] |
-| array_flow.rb:1621:5:1621:5 | [post] a [element, element 0] | array_flow.rb:1622:10:1622:10 | a [element, element 0] |
-| array_flow.rb:1621:5:1621:5 | [post] a [element, element 0] | array_flow.rb:1625:10:1625:10 | a [element, element 0] |
-| array_flow.rb:1621:5:1621:5 | [post] a [element, element 0] | array_flow.rb:1626:10:1626:10 | a [element, element 0] |
-| array_flow.rb:1621:5:1621:8 | [post] ...[...] [element 0] | array_flow.rb:1621:5:1621:5 | [post] a [element, element 0] |
-| array_flow.rb:1621:15:1621:27 | call to source | array_flow.rb:1621:5:1621:8 | [post] ...[...] [element 0] |
-| array_flow.rb:1622:10:1622:10 | a [element, element 0] | array_flow.rb:1622:10:1622:13 | ...[...] [element 0] |
-| array_flow.rb:1622:10:1622:13 | ...[...] [element 0] | array_flow.rb:1622:10:1622:16 | ...[...] |
-| array_flow.rb:1624:5:1624:5 | [post] a [element 1, element 0] | array_flow.rb:1625:10:1625:10 | a [element 1, element 0] |
-| array_flow.rb:1624:5:1624:8 | [post] ...[...] [element 0] | array_flow.rb:1624:5:1624:5 | [post] a [element 1, element 0] |
-| array_flow.rb:1624:15:1624:27 | call to source | array_flow.rb:1624:5:1624:8 | [post] ...[...] [element 0] |
-| array_flow.rb:1625:10:1625:10 | a [element 1, element 0] | array_flow.rb:1625:10:1625:13 | ...[...] [element 0] |
-| array_flow.rb:1625:10:1625:10 | a [element, element 0] | array_flow.rb:1625:10:1625:13 | ...[...] [element 0] |
-| array_flow.rb:1625:10:1625:13 | ...[...] [element 0] | array_flow.rb:1625:10:1625:16 | ...[...] |
+| array_flow.rb:1617:10:1617:10 | c [element] | array_flow.rb:1617:10:1617:13 | ...[...] |
+| array_flow.rb:1622:5:1622:5 | [post] a [element, element 0] | array_flow.rb:1623:10:1623:10 | a [element, element 0] |
+| array_flow.rb:1622:5:1622:5 | [post] a [element, element 0] | array_flow.rb:1626:10:1626:10 | a [element, element 0] |
+| array_flow.rb:1622:5:1622:5 | [post] a [element, element 0] | array_flow.rb:1627:10:1627:10 | a [element, element 0] |
+| array_flow.rb:1622:5:1622:8 | [post] ...[...] [element 0] | array_flow.rb:1622:5:1622:5 | [post] a [element, element 0] |
+| array_flow.rb:1622:15:1622:27 | call to source | array_flow.rb:1622:5:1622:8 | [post] ...[...] [element 0] |
+| array_flow.rb:1623:10:1623:10 | a [element, element 0] | array_flow.rb:1623:10:1623:13 | ...[...] [element 0] |
+| array_flow.rb:1623:10:1623:13 | ...[...] [element 0] | array_flow.rb:1623:10:1623:16 | ...[...] |
+| array_flow.rb:1625:5:1625:5 | [post] a [element 1, element 0] | array_flow.rb:1626:10:1626:10 | a [element 1, element 0] |
+| array_flow.rb:1625:5:1625:8 | [post] ...[...] [element 0] | array_flow.rb:1625:5:1625:5 | [post] a [element 1, element 0] |
+| array_flow.rb:1625:15:1625:27 | call to source | array_flow.rb:1625:5:1625:8 | [post] ...[...] [element 0] |
+| array_flow.rb:1626:10:1626:10 | a [element 1, element 0] | array_flow.rb:1626:10:1626:13 | ...[...] [element 0] |
 | array_flow.rb:1626:10:1626:10 | a [element, element 0] | array_flow.rb:1626:10:1626:13 | ...[...] [element 0] |
 | array_flow.rb:1626:10:1626:13 | ...[...] [element 0] | array_flow.rb:1626:10:1626:16 | ...[...] |
-| array_flow.rb:1631:5:1631:5 | [post] a [element 0] | array_flow.rb:1640:10:1640:10 | a [element 0] |
-| array_flow.rb:1631:5:1631:5 | [post] a [element 0] | array_flow.rb:1642:10:1642:10 | a [element 0] |
-| array_flow.rb:1631:12:1631:24 | call to source | array_flow.rb:1631:5:1631:5 | [post] a [element 0] |
-| array_flow.rb:1633:5:1633:5 | [post] a [element] | array_flow.rb:1638:10:1638:10 | a [element] |
-| array_flow.rb:1633:5:1633:5 | [post] a [element] | array_flow.rb:1640:10:1640:10 | a [element] |
-| array_flow.rb:1633:5:1633:5 | [post] a [element] | array_flow.rb:1642:10:1642:10 | a [element] |
-| array_flow.rb:1633:16:1633:28 | call to source | array_flow.rb:1633:5:1633:5 | [post] a [element] |
-| array_flow.rb:1635:5:1635:5 | [post] a [element] | array_flow.rb:1638:10:1638:10 | a [element] |
-| array_flow.rb:1635:5:1635:5 | [post] a [element] | array_flow.rb:1640:10:1640:10 | a [element] |
-| array_flow.rb:1635:5:1635:5 | [post] a [element] | array_flow.rb:1642:10:1642:10 | a [element] |
-| array_flow.rb:1635:14:1635:26 | call to source | array_flow.rb:1635:5:1635:5 | [post] a [element] |
-| array_flow.rb:1637:5:1637:5 | [post] a [element] | array_flow.rb:1638:10:1638:10 | a [element] |
-| array_flow.rb:1637:5:1637:5 | [post] a [element] | array_flow.rb:1640:10:1640:10 | a [element] |
-| array_flow.rb:1637:5:1637:5 | [post] a [element] | array_flow.rb:1642:10:1642:10 | a [element] |
-| array_flow.rb:1637:16:1637:28 | call to source | array_flow.rb:1637:5:1637:5 | [post] a [element] |
-| array_flow.rb:1638:10:1638:10 | a [element] | array_flow.rb:1638:10:1638:13 | ...[...] |
-| array_flow.rb:1640:10:1640:10 | a [element 0] | array_flow.rb:1640:10:1640:17 | ...[...] |
-| array_flow.rb:1640:10:1640:10 | a [element] | array_flow.rb:1640:10:1640:17 | ...[...] |
-| array_flow.rb:1642:10:1642:10 | a [element 0] | array_flow.rb:1642:10:1642:15 | ...[...] |
-| array_flow.rb:1642:10:1642:10 | a [element] | array_flow.rb:1642:10:1642:15 | ...[...] |
+| array_flow.rb:1627:10:1627:10 | a [element, element 0] | array_flow.rb:1627:10:1627:13 | ...[...] [element 0] |
+| array_flow.rb:1627:10:1627:13 | ...[...] [element 0] | array_flow.rb:1627:10:1627:16 | ...[...] |
+| array_flow.rb:1632:5:1632:5 | [post] a [element 0] | array_flow.rb:1641:10:1641:10 | a [element 0] |
+| array_flow.rb:1632:5:1632:5 | [post] a [element 0] | array_flow.rb:1643:10:1643:10 | a [element 0] |
+| array_flow.rb:1632:12:1632:24 | call to source | array_flow.rb:1632:5:1632:5 | [post] a [element 0] |
+| array_flow.rb:1634:5:1634:5 | [post] a [element] | array_flow.rb:1639:10:1639:10 | a [element] |
+| array_flow.rb:1634:5:1634:5 | [post] a [element] | array_flow.rb:1641:10:1641:10 | a [element] |
+| array_flow.rb:1634:5:1634:5 | [post] a [element] | array_flow.rb:1643:10:1643:10 | a [element] |
+| array_flow.rb:1634:16:1634:28 | call to source | array_flow.rb:1634:5:1634:5 | [post] a [element] |
+| array_flow.rb:1636:5:1636:5 | [post] a [element] | array_flow.rb:1639:10:1639:10 | a [element] |
+| array_flow.rb:1636:5:1636:5 | [post] a [element] | array_flow.rb:1641:10:1641:10 | a [element] |
+| array_flow.rb:1636:5:1636:5 | [post] a [element] | array_flow.rb:1643:10:1643:10 | a [element] |
+| array_flow.rb:1636:14:1636:26 | call to source | array_flow.rb:1636:5:1636:5 | [post] a [element] |
+| array_flow.rb:1638:5:1638:5 | [post] a [element] | array_flow.rb:1639:10:1639:10 | a [element] |
+| array_flow.rb:1638:5:1638:5 | [post] a [element] | array_flow.rb:1641:10:1641:10 | a [element] |
+| array_flow.rb:1638:5:1638:5 | [post] a [element] | array_flow.rb:1643:10:1643:10 | a [element] |
+| array_flow.rb:1638:16:1638:28 | call to source | array_flow.rb:1638:5:1638:5 | [post] a [element] |
+| array_flow.rb:1639:10:1639:10 | a [element] | array_flow.rb:1639:10:1639:13 | ...[...] |
+| array_flow.rb:1641:10:1641:10 | a [element 0] | array_flow.rb:1641:10:1641:17 | ...[...] |
+| array_flow.rb:1641:10:1641:10 | a [element] | array_flow.rb:1641:10:1641:17 | ...[...] |
+| array_flow.rb:1643:10:1643:10 | a [element 0] | array_flow.rb:1643:10:1643:15 | ...[...] |
+| array_flow.rb:1643:10:1643:10 | a [element] | array_flow.rb:1643:10:1643:15 | ...[...] |
 nodes
 | array_flow.rb:2:5:2:5 | a [element 0] | semmle.label | a [element 0] |
 | array_flow.rb:2:9:2:20 | * ... [element 0] | semmle.label | * ... [element 0] |
@@ -3717,646 +3712,642 @@ nodes
 | array_flow.rb:1211:9:1211:19 | call to slice | semmle.label | call to slice |
 | array_flow.rb:1212:10:1212:10 | b | semmle.label | b |
 | array_flow.rb:1214:5:1214:5 | b | semmle.label | b |
-| array_flow.rb:1214:5:1214:5 | b [element] | semmle.label | b [element] |
 | array_flow.rb:1214:9:1214:9 | a [element 2] | semmle.label | a [element 2] |
 | array_flow.rb:1214:9:1214:9 | a [element 4] | semmle.label | a [element 4] |
 | array_flow.rb:1214:9:1214:17 | call to slice | semmle.label | call to slice |
-| array_flow.rb:1214:9:1214:17 | call to slice [element] | semmle.label | call to slice [element] |
 | array_flow.rb:1216:10:1216:10 | b | semmle.label | b |
-| array_flow.rb:1218:10:1218:10 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1218:10:1218:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1220:5:1220:5 | b [element 0] | semmle.label | b [element 0] |
-| array_flow.rb:1220:5:1220:5 | b [element 2] | semmle.label | b [element 2] |
-| array_flow.rb:1220:9:1220:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1220:9:1220:9 | a [element 4] | semmle.label | a [element 4] |
-| array_flow.rb:1220:9:1220:21 | call to slice [element 0] | semmle.label | call to slice [element 0] |
-| array_flow.rb:1220:9:1220:21 | call to slice [element 2] | semmle.label | call to slice [element 2] |
-| array_flow.rb:1221:10:1221:10 | b [element 0] | semmle.label | b [element 0] |
-| array_flow.rb:1221:10:1221:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1223:10:1223:10 | b [element 2] | semmle.label | b [element 2] |
-| array_flow.rb:1223:10:1223:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1225:5:1225:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1225:9:1225:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1225:9:1225:9 | a [element 4] | semmle.label | a [element 4] |
-| array_flow.rb:1225:9:1225:21 | call to slice [element] | semmle.label | call to slice [element] |
-| array_flow.rb:1226:10:1226:10 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1226:10:1226:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1221:5:1221:5 | b [element 0] | semmle.label | b [element 0] |
+| array_flow.rb:1221:5:1221:5 | b [element 2] | semmle.label | b [element 2] |
+| array_flow.rb:1221:9:1221:9 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1221:9:1221:9 | a [element 4] | semmle.label | a [element 4] |
+| array_flow.rb:1221:9:1221:21 | call to slice [element 0] | semmle.label | call to slice [element 0] |
+| array_flow.rb:1221:9:1221:21 | call to slice [element 2] | semmle.label | call to slice [element 2] |
+| array_flow.rb:1222:10:1222:10 | b [element 0] | semmle.label | b [element 0] |
+| array_flow.rb:1222:10:1222:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1224:10:1224:10 | b [element 2] | semmle.label | b [element 2] |
+| array_flow.rb:1224:10:1224:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1226:5:1226:5 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1226:9:1226:9 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1226:9:1226:9 | a [element 4] | semmle.label | a [element 4] |
+| array_flow.rb:1226:9:1226:21 | call to slice [element] | semmle.label | call to slice [element] |
 | array_flow.rb:1227:10:1227:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:1227:10:1227:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1229:5:1229:5 | b [element 0] | semmle.label | b [element 0] |
-| array_flow.rb:1229:9:1229:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1229:9:1229:21 | call to slice [element 0] | semmle.label | call to slice [element 0] |
-| array_flow.rb:1230:10:1230:10 | b [element 0] | semmle.label | b [element 0] |
-| array_flow.rb:1230:10:1230:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1234:5:1234:5 | b [element 0] | semmle.label | b [element 0] |
-| array_flow.rb:1234:9:1234:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1234:9:1234:22 | call to slice [element 0] | semmle.label | call to slice [element 0] |
-| array_flow.rb:1235:10:1235:10 | b [element 0] | semmle.label | b [element 0] |
-| array_flow.rb:1235:10:1235:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1239:5:1239:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1239:9:1239:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1239:9:1239:9 | a [element 4] | semmle.label | a [element 4] |
-| array_flow.rb:1239:9:1239:21 | call to slice [element] | semmle.label | call to slice [element] |
-| array_flow.rb:1240:10:1240:10 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1240:10:1240:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1228:10:1228:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1228:10:1228:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1230:5:1230:5 | b [element 0] | semmle.label | b [element 0] |
+| array_flow.rb:1230:9:1230:9 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1230:9:1230:21 | call to slice [element 0] | semmle.label | call to slice [element 0] |
+| array_flow.rb:1231:10:1231:10 | b [element 0] | semmle.label | b [element 0] |
+| array_flow.rb:1231:10:1231:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1235:5:1235:5 | b [element 0] | semmle.label | b [element 0] |
+| array_flow.rb:1235:9:1235:9 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1235:9:1235:22 | call to slice [element 0] | semmle.label | call to slice [element 0] |
+| array_flow.rb:1236:10:1236:10 | b [element 0] | semmle.label | b [element 0] |
+| array_flow.rb:1236:10:1236:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1240:5:1240:5 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1240:9:1240:9 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1240:9:1240:9 | a [element 4] | semmle.label | a [element 4] |
+| array_flow.rb:1240:9:1240:21 | call to slice [element] | semmle.label | call to slice [element] |
 | array_flow.rb:1241:10:1241:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:1241:10:1241:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1243:5:1243:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1243:9:1243:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1243:9:1243:9 | a [element 4] | semmle.label | a [element 4] |
-| array_flow.rb:1243:9:1243:24 | call to slice [element] | semmle.label | call to slice [element] |
-| array_flow.rb:1244:10:1244:10 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1244:10:1244:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1242:10:1242:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1242:10:1242:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1244:5:1244:5 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1244:9:1244:9 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1244:9:1244:9 | a [element 4] | semmle.label | a [element 4] |
+| array_flow.rb:1244:9:1244:24 | call to slice [element] | semmle.label | call to slice [element] |
 | array_flow.rb:1245:10:1245:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:1245:10:1245:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1247:5:1247:5 | b [element 2] | semmle.label | b [element 2] |
-| array_flow.rb:1247:9:1247:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1247:9:1247:20 | call to slice [element 2] | semmle.label | call to slice [element 2] |
-| array_flow.rb:1250:10:1250:10 | b [element 2] | semmle.label | b [element 2] |
-| array_flow.rb:1250:10:1250:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1252:5:1252:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1252:9:1252:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1252:9:1252:9 | a [element 4] | semmle.label | a [element 4] |
-| array_flow.rb:1252:9:1252:20 | call to slice [element] | semmle.label | call to slice [element] |
-| array_flow.rb:1253:10:1253:10 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1253:10:1253:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1246:10:1246:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1246:10:1246:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1248:5:1248:5 | b [element 2] | semmle.label | b [element 2] |
+| array_flow.rb:1248:9:1248:9 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1248:9:1248:20 | call to slice [element 2] | semmle.label | call to slice [element 2] |
+| array_flow.rb:1251:10:1251:10 | b [element 2] | semmle.label | b [element 2] |
+| array_flow.rb:1251:10:1251:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1253:5:1253:5 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1253:9:1253:9 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1253:9:1253:9 | a [element 4] | semmle.label | a [element 4] |
+| array_flow.rb:1253:9:1253:20 | call to slice [element] | semmle.label | call to slice [element] |
 | array_flow.rb:1254:10:1254:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:1254:10:1254:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1255:10:1255:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:1255:10:1255:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1259:5:1259:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1259:5:1259:5 | a [element 4] | semmle.label | a [element 4] |
-| array_flow.rb:1259:16:1259:28 | call to source | semmle.label | call to source |
-| array_flow.rb:1259:34:1259:46 | call to source | semmle.label | call to source |
-| array_flow.rb:1260:5:1260:5 | b | semmle.label | b |
-| array_flow.rb:1260:9:1260:9 | [post] a [element 3] | semmle.label | [post] a [element 3] |
-| array_flow.rb:1260:9:1260:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1260:9:1260:9 | a [element 4] | semmle.label | a [element 4] |
-| array_flow.rb:1260:9:1260:19 | call to slice! | semmle.label | call to slice! |
-| array_flow.rb:1261:10:1261:10 | b | semmle.label | b |
-| array_flow.rb:1265:10:1265:10 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:1265:10:1265:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1267:5:1267:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1267:5:1267:5 | a [element 4] | semmle.label | a [element 4] |
-| array_flow.rb:1267:16:1267:28 | call to source | semmle.label | call to source |
-| array_flow.rb:1267:34:1267:46 | call to source | semmle.label | call to source |
-| array_flow.rb:1268:5:1268:5 | b | semmle.label | b |
-| array_flow.rb:1268:5:1268:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1268:9:1268:9 | [post] a [element] | semmle.label | [post] a [element] |
-| array_flow.rb:1268:9:1268:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1268:9:1268:9 | a [element 4] | semmle.label | a [element 4] |
-| array_flow.rb:1268:9:1268:19 | call to slice! | semmle.label | call to slice! |
-| array_flow.rb:1268:9:1268:19 | call to slice! [element] | semmle.label | call to slice! [element] |
-| array_flow.rb:1269:10:1269:10 | a [element] | semmle.label | a [element] |
-| array_flow.rb:1269:10:1269:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1256:10:1256:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1256:10:1256:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1260:5:1260:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1260:5:1260:5 | a [element 4] | semmle.label | a [element 4] |
+| array_flow.rb:1260:16:1260:28 | call to source | semmle.label | call to source |
+| array_flow.rb:1260:34:1260:46 | call to source | semmle.label | call to source |
+| array_flow.rb:1261:5:1261:5 | b | semmle.label | b |
+| array_flow.rb:1261:9:1261:9 | [post] a [element 3] | semmle.label | [post] a [element 3] |
+| array_flow.rb:1261:9:1261:9 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1261:9:1261:9 | a [element 4] | semmle.label | a [element 4] |
+| array_flow.rb:1261:9:1261:19 | call to slice! | semmle.label | call to slice! |
+| array_flow.rb:1262:10:1262:10 | b | semmle.label | b |
+| array_flow.rb:1266:10:1266:10 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:1266:10:1266:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1268:5:1268:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1268:5:1268:5 | a [element 4] | semmle.label | a [element 4] |
+| array_flow.rb:1268:16:1268:28 | call to source | semmle.label | call to source |
+| array_flow.rb:1268:34:1268:46 | call to source | semmle.label | call to source |
+| array_flow.rb:1269:5:1269:5 | b | semmle.label | b |
+| array_flow.rb:1269:5:1269:5 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1269:9:1269:9 | [post] a [element] | semmle.label | [post] a [element] |
+| array_flow.rb:1269:9:1269:9 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1269:9:1269:9 | a [element 4] | semmle.label | a [element 4] |
+| array_flow.rb:1269:9:1269:19 | call to slice! | semmle.label | call to slice! |
+| array_flow.rb:1269:9:1269:19 | call to slice! [element] | semmle.label | call to slice! [element] |
 | array_flow.rb:1270:10:1270:10 | a [element] | semmle.label | a [element] |
 | array_flow.rb:1270:10:1270:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1271:10:1271:10 | a [element] | semmle.label | a [element] |
 | array_flow.rb:1271:10:1271:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1272:10:1272:10 | a [element] | semmle.label | a [element] |
 | array_flow.rb:1272:10:1272:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1274:10:1274:10 | b | semmle.label | b |
-| array_flow.rb:1276:10:1276:10 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1276:10:1276:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1278:5:1278:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1278:5:1278:5 | a [element 4] | semmle.label | a [element 4] |
-| array_flow.rb:1278:16:1278:28 | call to source | semmle.label | call to source |
-| array_flow.rb:1278:34:1278:46 | call to source | semmle.label | call to source |
-| array_flow.rb:1279:5:1279:5 | b [element 0] | semmle.label | b [element 0] |
-| array_flow.rb:1279:5:1279:5 | b [element 2] | semmle.label | b [element 2] |
-| array_flow.rb:1279:9:1279:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1279:9:1279:9 | a [element 4] | semmle.label | a [element 4] |
-| array_flow.rb:1279:9:1279:22 | call to slice! [element 0] | semmle.label | call to slice! [element 0] |
-| array_flow.rb:1279:9:1279:22 | call to slice! [element 2] | semmle.label | call to slice! [element 2] |
-| array_flow.rb:1280:10:1280:10 | b [element 0] | semmle.label | b [element 0] |
-| array_flow.rb:1280:10:1280:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1282:10:1282:10 | b [element 2] | semmle.label | b [element 2] |
-| array_flow.rb:1282:10:1282:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1289:5:1289:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1289:5:1289:5 | a [element 4] | semmle.label | a [element 4] |
-| array_flow.rb:1289:16:1289:28 | call to source | semmle.label | call to source |
-| array_flow.rb:1289:34:1289:46 | call to source | semmle.label | call to source |
-| array_flow.rb:1290:5:1290:5 | b [element 0] | semmle.label | b [element 0] |
-| array_flow.rb:1290:9:1290:9 | [post] a [element 2] | semmle.label | [post] a [element 2] |
-| array_flow.rb:1290:9:1290:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1290:9:1290:9 | a [element 4] | semmle.label | a [element 4] |
-| array_flow.rb:1290:9:1290:22 | call to slice! [element 0] | semmle.label | call to slice! [element 0] |
-| array_flow.rb:1291:10:1291:10 | b [element 0] | semmle.label | b [element 0] |
-| array_flow.rb:1291:10:1291:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1296:10:1296:10 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1296:10:1296:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1300:5:1300:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1300:5:1300:5 | a [element 4] | semmle.label | a [element 4] |
-| array_flow.rb:1300:16:1300:28 | call to source | semmle.label | call to source |
-| array_flow.rb:1300:34:1300:46 | call to source | semmle.label | call to source |
-| array_flow.rb:1301:5:1301:5 | b [element 0] | semmle.label | b [element 0] |
-| array_flow.rb:1301:9:1301:9 | [post] a [element 2] | semmle.label | [post] a [element 2] |
-| array_flow.rb:1301:9:1301:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1301:9:1301:9 | a [element 4] | semmle.label | a [element 4] |
-| array_flow.rb:1301:9:1301:23 | call to slice! [element 0] | semmle.label | call to slice! [element 0] |
-| array_flow.rb:1302:10:1302:10 | b [element 0] | semmle.label | b [element 0] |
-| array_flow.rb:1302:10:1302:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1307:10:1307:10 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1307:10:1307:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1311:5:1311:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1311:5:1311:5 | a [element 4] | semmle.label | a [element 4] |
-| array_flow.rb:1311:16:1311:28 | call to source | semmle.label | call to source |
-| array_flow.rb:1311:34:1311:46 | call to source | semmle.label | call to source |
-| array_flow.rb:1312:5:1312:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1312:9:1312:9 | [post] a [element] | semmle.label | [post] a [element] |
-| array_flow.rb:1312:9:1312:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1312:9:1312:9 | a [element 4] | semmle.label | a [element 4] |
-| array_flow.rb:1312:9:1312:22 | call to slice! [element] | semmle.label | call to slice! [element] |
-| array_flow.rb:1313:10:1313:10 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1313:10:1313:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1273:10:1273:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1273:10:1273:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1275:10:1275:10 | b | semmle.label | b |
+| array_flow.rb:1277:10:1277:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1277:10:1277:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1279:5:1279:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1279:5:1279:5 | a [element 4] | semmle.label | a [element 4] |
+| array_flow.rb:1279:16:1279:28 | call to source | semmle.label | call to source |
+| array_flow.rb:1279:34:1279:46 | call to source | semmle.label | call to source |
+| array_flow.rb:1280:5:1280:5 | b [element 0] | semmle.label | b [element 0] |
+| array_flow.rb:1280:5:1280:5 | b [element 2] | semmle.label | b [element 2] |
+| array_flow.rb:1280:9:1280:9 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1280:9:1280:9 | a [element 4] | semmle.label | a [element 4] |
+| array_flow.rb:1280:9:1280:22 | call to slice! [element 0] | semmle.label | call to slice! [element 0] |
+| array_flow.rb:1280:9:1280:22 | call to slice! [element 2] | semmle.label | call to slice! [element 2] |
+| array_flow.rb:1281:10:1281:10 | b [element 0] | semmle.label | b [element 0] |
+| array_flow.rb:1281:10:1281:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1283:10:1283:10 | b [element 2] | semmle.label | b [element 2] |
+| array_flow.rb:1283:10:1283:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1290:5:1290:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1290:5:1290:5 | a [element 4] | semmle.label | a [element 4] |
+| array_flow.rb:1290:16:1290:28 | call to source | semmle.label | call to source |
+| array_flow.rb:1290:34:1290:46 | call to source | semmle.label | call to source |
+| array_flow.rb:1291:5:1291:5 | b [element 0] | semmle.label | b [element 0] |
+| array_flow.rb:1291:9:1291:9 | [post] a [element 2] | semmle.label | [post] a [element 2] |
+| array_flow.rb:1291:9:1291:9 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1291:9:1291:9 | a [element 4] | semmle.label | a [element 4] |
+| array_flow.rb:1291:9:1291:22 | call to slice! [element 0] | semmle.label | call to slice! [element 0] |
+| array_flow.rb:1292:10:1292:10 | b [element 0] | semmle.label | b [element 0] |
+| array_flow.rb:1292:10:1292:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1297:10:1297:10 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1297:10:1297:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1301:5:1301:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1301:5:1301:5 | a [element 4] | semmle.label | a [element 4] |
+| array_flow.rb:1301:16:1301:28 | call to source | semmle.label | call to source |
+| array_flow.rb:1301:34:1301:46 | call to source | semmle.label | call to source |
+| array_flow.rb:1302:5:1302:5 | b [element 0] | semmle.label | b [element 0] |
+| array_flow.rb:1302:9:1302:9 | [post] a [element 2] | semmle.label | [post] a [element 2] |
+| array_flow.rb:1302:9:1302:9 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1302:9:1302:9 | a [element 4] | semmle.label | a [element 4] |
+| array_flow.rb:1302:9:1302:23 | call to slice! [element 0] | semmle.label | call to slice! [element 0] |
+| array_flow.rb:1303:10:1303:10 | b [element 0] | semmle.label | b [element 0] |
+| array_flow.rb:1303:10:1303:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1308:10:1308:10 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1308:10:1308:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1312:5:1312:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1312:5:1312:5 | a [element 4] | semmle.label | a [element 4] |
+| array_flow.rb:1312:16:1312:28 | call to source | semmle.label | call to source |
+| array_flow.rb:1312:34:1312:46 | call to source | semmle.label | call to source |
+| array_flow.rb:1313:5:1313:5 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1313:9:1313:9 | [post] a [element] | semmle.label | [post] a [element] |
+| array_flow.rb:1313:9:1313:9 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1313:9:1313:9 | a [element 4] | semmle.label | a [element 4] |
+| array_flow.rb:1313:9:1313:22 | call to slice! [element] | semmle.label | call to slice! [element] |
 | array_flow.rb:1314:10:1314:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:1314:10:1314:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1315:10:1315:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:1315:10:1315:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1316:10:1316:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1316:10:1316:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:1316:10:1316:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1317:10:1317:10 | a [element] | semmle.label | a [element] |
 | array_flow.rb:1317:10:1317:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1318:10:1318:10 | a [element] | semmle.label | a [element] |
 | array_flow.rb:1318:10:1318:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1320:5:1320:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1320:5:1320:5 | a [element 4] | semmle.label | a [element 4] |
-| array_flow.rb:1320:16:1320:28 | call to source | semmle.label | call to source |
-| array_flow.rb:1320:34:1320:46 | call to source | semmle.label | call to source |
-| array_flow.rb:1321:5:1321:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1321:9:1321:9 | [post] a [element] | semmle.label | [post] a [element] |
-| array_flow.rb:1321:9:1321:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1321:9:1321:9 | a [element 4] | semmle.label | a [element 4] |
-| array_flow.rb:1321:9:1321:22 | call to slice! [element] | semmle.label | call to slice! [element] |
-| array_flow.rb:1322:10:1322:10 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1322:10:1322:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1319:10:1319:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1319:10:1319:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1321:5:1321:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1321:5:1321:5 | a [element 4] | semmle.label | a [element 4] |
+| array_flow.rb:1321:16:1321:28 | call to source | semmle.label | call to source |
+| array_flow.rb:1321:34:1321:46 | call to source | semmle.label | call to source |
+| array_flow.rb:1322:5:1322:5 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1322:9:1322:9 | [post] a [element] | semmle.label | [post] a [element] |
+| array_flow.rb:1322:9:1322:9 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1322:9:1322:9 | a [element 4] | semmle.label | a [element 4] |
+| array_flow.rb:1322:9:1322:22 | call to slice! [element] | semmle.label | call to slice! [element] |
 | array_flow.rb:1323:10:1323:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:1323:10:1323:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1324:10:1324:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:1324:10:1324:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1325:10:1325:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1325:10:1325:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:1325:10:1325:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1326:10:1326:10 | a [element] | semmle.label | a [element] |
 | array_flow.rb:1326:10:1326:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1327:10:1327:10 | a [element] | semmle.label | a [element] |
 | array_flow.rb:1327:10:1327:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1329:5:1329:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1329:5:1329:5 | a [element 4] | semmle.label | a [element 4] |
-| array_flow.rb:1329:16:1329:28 | call to source | semmle.label | call to source |
-| array_flow.rb:1329:34:1329:46 | call to source | semmle.label | call to source |
-| array_flow.rb:1330:5:1330:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1330:9:1330:9 | [post] a [element] | semmle.label | [post] a [element] |
-| array_flow.rb:1330:9:1330:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1330:9:1330:9 | a [element 4] | semmle.label | a [element 4] |
-| array_flow.rb:1330:9:1330:25 | call to slice! [element] | semmle.label | call to slice! [element] |
-| array_flow.rb:1331:10:1331:10 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1331:10:1331:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1328:10:1328:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1328:10:1328:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1330:5:1330:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1330:5:1330:5 | a [element 4] | semmle.label | a [element 4] |
+| array_flow.rb:1330:16:1330:28 | call to source | semmle.label | call to source |
+| array_flow.rb:1330:34:1330:46 | call to source | semmle.label | call to source |
+| array_flow.rb:1331:5:1331:5 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1331:9:1331:9 | [post] a [element] | semmle.label | [post] a [element] |
+| array_flow.rb:1331:9:1331:9 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1331:9:1331:9 | a [element 4] | semmle.label | a [element 4] |
+| array_flow.rb:1331:9:1331:25 | call to slice! [element] | semmle.label | call to slice! [element] |
 | array_flow.rb:1332:10:1332:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:1332:10:1332:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1333:10:1333:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:1333:10:1333:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1334:10:1334:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1334:10:1334:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:1334:10:1334:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1335:10:1335:10 | a [element] | semmle.label | a [element] |
 | array_flow.rb:1335:10:1335:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1336:10:1336:10 | a [element] | semmle.label | a [element] |
 | array_flow.rb:1336:10:1336:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1338:5:1338:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1338:5:1338:5 | a [element 4] | semmle.label | a [element 4] |
-| array_flow.rb:1338:16:1338:28 | call to source | semmle.label | call to source |
-| array_flow.rb:1338:34:1338:46 | call to source | semmle.label | call to source |
-| array_flow.rb:1339:5:1339:5 | b [element 2] | semmle.label | b [element 2] |
-| array_flow.rb:1339:9:1339:9 | [post] a [element 1] | semmle.label | [post] a [element 1] |
-| array_flow.rb:1339:9:1339:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1339:9:1339:9 | a [element 4] | semmle.label | a [element 4] |
-| array_flow.rb:1339:9:1339:21 | call to slice! [element 2] | semmle.label | call to slice! [element 2] |
-| array_flow.rb:1342:10:1342:10 | b [element 2] | semmle.label | b [element 2] |
-| array_flow.rb:1342:10:1342:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1344:10:1344:10 | a [element 1] | semmle.label | a [element 1] |
-| array_flow.rb:1344:10:1344:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1347:5:1347:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1347:5:1347:5 | a [element 4] | semmle.label | a [element 4] |
-| array_flow.rb:1347:16:1347:28 | call to source | semmle.label | call to source |
-| array_flow.rb:1347:34:1347:46 | call to source | semmle.label | call to source |
-| array_flow.rb:1348:5:1348:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1348:9:1348:9 | [post] a [element] | semmle.label | [post] a [element] |
-| array_flow.rb:1348:9:1348:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1348:9:1348:9 | a [element 4] | semmle.label | a [element 4] |
-| array_flow.rb:1348:9:1348:21 | call to slice! [element] | semmle.label | call to slice! [element] |
-| array_flow.rb:1349:10:1349:10 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1349:10:1349:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1337:10:1337:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1337:10:1337:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1339:5:1339:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1339:5:1339:5 | a [element 4] | semmle.label | a [element 4] |
+| array_flow.rb:1339:16:1339:28 | call to source | semmle.label | call to source |
+| array_flow.rb:1339:34:1339:46 | call to source | semmle.label | call to source |
+| array_flow.rb:1340:5:1340:5 | b [element 2] | semmle.label | b [element 2] |
+| array_flow.rb:1340:9:1340:9 | [post] a [element 1] | semmle.label | [post] a [element 1] |
+| array_flow.rb:1340:9:1340:9 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1340:9:1340:9 | a [element 4] | semmle.label | a [element 4] |
+| array_flow.rb:1340:9:1340:21 | call to slice! [element 2] | semmle.label | call to slice! [element 2] |
+| array_flow.rb:1343:10:1343:10 | b [element 2] | semmle.label | b [element 2] |
+| array_flow.rb:1343:10:1343:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1345:10:1345:10 | a [element 1] | semmle.label | a [element 1] |
+| array_flow.rb:1345:10:1345:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1348:5:1348:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1348:5:1348:5 | a [element 4] | semmle.label | a [element 4] |
+| array_flow.rb:1348:16:1348:28 | call to source | semmle.label | call to source |
+| array_flow.rb:1348:34:1348:46 | call to source | semmle.label | call to source |
+| array_flow.rb:1349:5:1349:5 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1349:9:1349:9 | [post] a [element] | semmle.label | [post] a [element] |
+| array_flow.rb:1349:9:1349:9 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1349:9:1349:9 | a [element 4] | semmle.label | a [element 4] |
+| array_flow.rb:1349:9:1349:21 | call to slice! [element] | semmle.label | call to slice! [element] |
 | array_flow.rb:1350:10:1350:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:1350:10:1350:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1351:10:1351:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:1351:10:1351:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1352:10:1352:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1352:10:1352:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:1352:10:1352:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1353:10:1353:10 | a [element] | semmle.label | a [element] |
 | array_flow.rb:1353:10:1353:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1354:10:1354:10 | a [element] | semmle.label | a [element] |
 | array_flow.rb:1354:10:1354:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1358:5:1358:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1358:16:1358:26 | call to source | semmle.label | call to source |
-| array_flow.rb:1359:9:1359:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1359:27:1359:27 | x | semmle.label | x |
-| array_flow.rb:1360:14:1360:14 | x | semmle.label | x |
-| array_flow.rb:1366:5:1366:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1366:16:1366:26 | call to source | semmle.label | call to source |
-| array_flow.rb:1367:9:1367:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1367:28:1367:28 | x | semmle.label | x |
-| array_flow.rb:1368:14:1368:14 | x | semmle.label | x |
-| array_flow.rb:1374:5:1374:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1374:16:1374:26 | call to source | semmle.label | call to source |
-| array_flow.rb:1375:9:1375:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1375:26:1375:26 | x | semmle.label | x |
-| array_flow.rb:1375:29:1375:29 | y | semmle.label | y |
-| array_flow.rb:1376:14:1376:14 | x | semmle.label | x |
-| array_flow.rb:1377:14:1377:14 | y | semmle.label | y |
-| array_flow.rb:1382:5:1382:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1382:16:1382:26 | call to source | semmle.label | call to source |
-| array_flow.rb:1383:5:1383:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1383:9:1383:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1383:9:1383:14 | call to sort [element] | semmle.label | call to sort [element] |
-| array_flow.rb:1384:10:1384:10 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1384:10:1384:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1355:10:1355:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1355:10:1355:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1359:5:1359:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1359:16:1359:26 | call to source | semmle.label | call to source |
+| array_flow.rb:1360:9:1360:9 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1360:27:1360:27 | x | semmle.label | x |
+| array_flow.rb:1361:14:1361:14 | x | semmle.label | x |
+| array_flow.rb:1367:5:1367:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1367:16:1367:26 | call to source | semmle.label | call to source |
+| array_flow.rb:1368:9:1368:9 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1368:28:1368:28 | x | semmle.label | x |
+| array_flow.rb:1369:14:1369:14 | x | semmle.label | x |
+| array_flow.rb:1375:5:1375:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1375:16:1375:26 | call to source | semmle.label | call to source |
+| array_flow.rb:1376:9:1376:9 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1376:26:1376:26 | x | semmle.label | x |
+| array_flow.rb:1376:29:1376:29 | y | semmle.label | y |
+| array_flow.rb:1377:14:1377:14 | x | semmle.label | x |
+| array_flow.rb:1378:14:1378:14 | y | semmle.label | y |
+| array_flow.rb:1383:5:1383:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1383:16:1383:26 | call to source | semmle.label | call to source |
+| array_flow.rb:1384:5:1384:5 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1384:9:1384:9 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1384:9:1384:14 | call to sort [element] | semmle.label | call to sort [element] |
 | array_flow.rb:1385:10:1385:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:1385:10:1385:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1386:5:1386:5 | c [element] | semmle.label | c [element] |
-| array_flow.rb:1386:9:1386:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1386:9:1390:7 | call to sort [element] | semmle.label | call to sort [element] |
-| array_flow.rb:1386:20:1386:20 | x | semmle.label | x |
-| array_flow.rb:1386:23:1386:23 | y | semmle.label | y |
-| array_flow.rb:1387:14:1387:14 | x | semmle.label | x |
-| array_flow.rb:1388:14:1388:14 | y | semmle.label | y |
-| array_flow.rb:1391:10:1391:10 | c [element] | semmle.label | c [element] |
-| array_flow.rb:1391:10:1391:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1386:10:1386:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1386:10:1386:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1387:5:1387:5 | c [element] | semmle.label | c [element] |
+| array_flow.rb:1387:9:1387:9 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1387:9:1391:7 | call to sort [element] | semmle.label | call to sort [element] |
+| array_flow.rb:1387:20:1387:20 | x | semmle.label | x |
+| array_flow.rb:1387:23:1387:23 | y | semmle.label | y |
+| array_flow.rb:1388:14:1388:14 | x | semmle.label | x |
+| array_flow.rb:1389:14:1389:14 | y | semmle.label | y |
 | array_flow.rb:1392:10:1392:10 | c [element] | semmle.label | c [element] |
 | array_flow.rb:1392:10:1392:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1396:5:1396:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1396:16:1396:26 | call to source | semmle.label | call to source |
-| array_flow.rb:1397:5:1397:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1397:9:1397:9 | [post] a [element] | semmle.label | [post] a [element] |
-| array_flow.rb:1397:9:1397:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1397:9:1397:15 | call to sort! [element] | semmle.label | call to sort! [element] |
-| array_flow.rb:1398:10:1398:10 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1398:10:1398:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1393:10:1393:10 | c [element] | semmle.label | c [element] |
+| array_flow.rb:1393:10:1393:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1397:5:1397:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1397:16:1397:26 | call to source | semmle.label | call to source |
+| array_flow.rb:1398:5:1398:5 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1398:9:1398:9 | [post] a [element] | semmle.label | [post] a [element] |
+| array_flow.rb:1398:9:1398:9 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1398:9:1398:15 | call to sort! [element] | semmle.label | call to sort! [element] |
 | array_flow.rb:1399:10:1399:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:1399:10:1399:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1400:10:1400:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1400:10:1400:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:1400:10:1400:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1401:10:1401:10 | a [element] | semmle.label | a [element] |
 | array_flow.rb:1401:10:1401:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1403:5:1403:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1403:16:1403:26 | call to source | semmle.label | call to source |
-| array_flow.rb:1404:5:1404:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1404:9:1404:9 | [post] a [element] | semmle.label | [post] a [element] |
-| array_flow.rb:1404:9:1404:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1404:9:1408:7 | call to sort! [element] | semmle.label | call to sort! [element] |
-| array_flow.rb:1404:21:1404:21 | x | semmle.label | x |
-| array_flow.rb:1404:24:1404:24 | y | semmle.label | y |
-| array_flow.rb:1405:14:1405:14 | x | semmle.label | x |
-| array_flow.rb:1406:14:1406:14 | y | semmle.label | y |
-| array_flow.rb:1409:10:1409:10 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1409:10:1409:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1402:10:1402:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1402:10:1402:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1404:5:1404:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1404:16:1404:26 | call to source | semmle.label | call to source |
+| array_flow.rb:1405:5:1405:5 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1405:9:1405:9 | [post] a [element] | semmle.label | [post] a [element] |
+| array_flow.rb:1405:9:1405:9 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1405:9:1409:7 | call to sort! [element] | semmle.label | call to sort! [element] |
+| array_flow.rb:1405:21:1405:21 | x | semmle.label | x |
+| array_flow.rb:1405:24:1405:24 | y | semmle.label | y |
+| array_flow.rb:1406:14:1406:14 | x | semmle.label | x |
+| array_flow.rb:1407:14:1407:14 | y | semmle.label | y |
 | array_flow.rb:1410:10:1410:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:1410:10:1410:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1411:10:1411:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1411:10:1411:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:1411:10:1411:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1412:10:1412:10 | a [element] | semmle.label | a [element] |
 | array_flow.rb:1412:10:1412:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1416:5:1416:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1416:16:1416:26 | call to source | semmle.label | call to source |
-| array_flow.rb:1417:5:1417:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1417:9:1417:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1417:9:1420:7 | call to sort_by [element] | semmle.label | call to sort_by [element] |
-| array_flow.rb:1417:23:1417:23 | x | semmle.label | x |
-| array_flow.rb:1418:14:1418:14 | x | semmle.label | x |
-| array_flow.rb:1421:10:1421:10 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1421:10:1421:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1413:10:1413:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1413:10:1413:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1417:5:1417:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1417:16:1417:26 | call to source | semmle.label | call to source |
+| array_flow.rb:1418:5:1418:5 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1418:9:1418:9 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1418:9:1421:7 | call to sort_by [element] | semmle.label | call to sort_by [element] |
+| array_flow.rb:1418:23:1418:23 | x | semmle.label | x |
+| array_flow.rb:1419:14:1419:14 | x | semmle.label | x |
 | array_flow.rb:1422:10:1422:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:1422:10:1422:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1426:5:1426:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1426:16:1426:26 | call to source | semmle.label | call to source |
-| array_flow.rb:1427:5:1427:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1427:9:1427:9 | [post] a [element] | semmle.label | [post] a [element] |
-| array_flow.rb:1427:9:1427:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1427:9:1430:7 | call to sort_by! [element] | semmle.label | call to sort_by! [element] |
-| array_flow.rb:1427:24:1427:24 | x | semmle.label | x |
-| array_flow.rb:1428:14:1428:14 | x | semmle.label | x |
-| array_flow.rb:1431:10:1431:10 | a [element] | semmle.label | a [element] |
-| array_flow.rb:1431:10:1431:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1423:10:1423:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1423:10:1423:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1427:5:1427:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1427:16:1427:26 | call to source | semmle.label | call to source |
+| array_flow.rb:1428:5:1428:5 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1428:9:1428:9 | [post] a [element] | semmle.label | [post] a [element] |
+| array_flow.rb:1428:9:1428:9 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1428:9:1431:7 | call to sort_by! [element] | semmle.label | call to sort_by! [element] |
+| array_flow.rb:1428:24:1428:24 | x | semmle.label | x |
+| array_flow.rb:1429:14:1429:14 | x | semmle.label | x |
 | array_flow.rb:1432:10:1432:10 | a [element] | semmle.label | a [element] |
 | array_flow.rb:1432:10:1432:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1433:10:1433:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1433:10:1433:10 | a [element] | semmle.label | a [element] |
 | array_flow.rb:1433:10:1433:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1434:10:1434:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:1434:10:1434:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1438:5:1438:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1438:16:1438:26 | call to source | semmle.label | call to source |
-| array_flow.rb:1439:9:1439:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1439:19:1439:19 | x | semmle.label | x |
-| array_flow.rb:1440:14:1440:14 | x | semmle.label | x |
-| array_flow.rb:1446:5:1446:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1446:5:1446:5 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:1446:16:1446:28 | call to source | semmle.label | call to source |
-| array_flow.rb:1446:31:1446:43 | call to source | semmle.label | call to source |
-| array_flow.rb:1447:5:1447:5 | b [element 2] | semmle.label | b [element 2] |
-| array_flow.rb:1447:5:1447:5 | b [element 3] | semmle.label | b [element 3] |
-| array_flow.rb:1447:9:1447:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1447:9:1447:9 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:1447:9:1447:17 | call to take [element 2] | semmle.label | call to take [element 2] |
-| array_flow.rb:1447:9:1447:17 | call to take [element 3] | semmle.label | call to take [element 3] |
-| array_flow.rb:1450:10:1450:10 | b [element 2] | semmle.label | b [element 2] |
-| array_flow.rb:1450:10:1450:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1451:10:1451:10 | b [element 3] | semmle.label | b [element 3] |
+| array_flow.rb:1435:10:1435:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1435:10:1435:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1439:5:1439:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1439:16:1439:26 | call to source | semmle.label | call to source |
+| array_flow.rb:1440:9:1440:9 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1440:19:1440:19 | x | semmle.label | x |
+| array_flow.rb:1441:14:1441:14 | x | semmle.label | x |
+| array_flow.rb:1447:5:1447:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1447:5:1447:5 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:1447:16:1447:28 | call to source | semmle.label | call to source |
+| array_flow.rb:1447:31:1447:43 | call to source | semmle.label | call to source |
+| array_flow.rb:1448:5:1448:5 | b [element 2] | semmle.label | b [element 2] |
+| array_flow.rb:1448:5:1448:5 | b [element 3] | semmle.label | b [element 3] |
+| array_flow.rb:1448:9:1448:9 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1448:9:1448:9 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:1448:9:1448:17 | call to take [element 2] | semmle.label | call to take [element 2] |
+| array_flow.rb:1448:9:1448:17 | call to take [element 3] | semmle.label | call to take [element 3] |
+| array_flow.rb:1451:10:1451:10 | b [element 2] | semmle.label | b [element 2] |
 | array_flow.rb:1451:10:1451:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1452:5:1452:5 | b [element 2] | semmle.label | b [element 2] |
-| array_flow.rb:1452:9:1452:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1452:9:1452:17 | call to take [element 2] | semmle.label | call to take [element 2] |
-| array_flow.rb:1455:10:1455:10 | b [element 2] | semmle.label | b [element 2] |
-| array_flow.rb:1455:10:1455:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1457:10:1457:10 | b [element 2] | semmle.label | b [element 2] |
-| array_flow.rb:1457:10:1457:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1458:5:1458:5 | b [element 2] | semmle.label | b [element 2] |
-| array_flow.rb:1458:5:1458:5 | b [element 3] | semmle.label | b [element 3] |
-| array_flow.rb:1458:9:1458:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1458:9:1458:9 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:1458:9:1458:19 | call to take [element 2] | semmle.label | call to take [element 2] |
-| array_flow.rb:1458:9:1458:19 | call to take [element 3] | semmle.label | call to take [element 3] |
-| array_flow.rb:1461:10:1461:10 | b [element 2] | semmle.label | b [element 2] |
-| array_flow.rb:1461:10:1461:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1462:10:1462:10 | b [element 3] | semmle.label | b [element 3] |
+| array_flow.rb:1452:10:1452:10 | b [element 3] | semmle.label | b [element 3] |
+| array_flow.rb:1452:10:1452:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1453:5:1453:5 | b [element 2] | semmle.label | b [element 2] |
+| array_flow.rb:1453:9:1453:9 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1453:9:1453:17 | call to take [element 2] | semmle.label | call to take [element 2] |
+| array_flow.rb:1456:10:1456:10 | b [element 2] | semmle.label | b [element 2] |
+| array_flow.rb:1456:10:1456:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1458:10:1458:10 | b [element 2] | semmle.label | b [element 2] |
+| array_flow.rb:1458:10:1458:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1459:5:1459:5 | b [element 2] | semmle.label | b [element 2] |
+| array_flow.rb:1459:5:1459:5 | b [element 3] | semmle.label | b [element 3] |
+| array_flow.rb:1459:9:1459:9 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1459:9:1459:9 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:1459:9:1459:19 | call to take [element 2] | semmle.label | call to take [element 2] |
+| array_flow.rb:1459:9:1459:19 | call to take [element 3] | semmle.label | call to take [element 3] |
+| array_flow.rb:1462:10:1462:10 | b [element 2] | semmle.label | b [element 2] |
 | array_flow.rb:1462:10:1462:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1463:10:1463:10 | b [element 2] | semmle.label | b [element 2] |
 | array_flow.rb:1463:10:1463:10 | b [element 3] | semmle.label | b [element 3] |
 | array_flow.rb:1463:10:1463:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1464:5:1464:5 | [post] a [element] | semmle.label | [post] a [element] |
-| array_flow.rb:1464:12:1464:24 | call to source | semmle.label | call to source |
-| array_flow.rb:1465:5:1465:5 | b [element 2] | semmle.label | b [element 2] |
-| array_flow.rb:1465:5:1465:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1465:9:1465:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1465:9:1465:9 | a [element] | semmle.label | a [element] |
-| array_flow.rb:1465:9:1465:17 | call to take [element 2] | semmle.label | call to take [element 2] |
-| array_flow.rb:1465:9:1465:17 | call to take [element] | semmle.label | call to take [element] |
-| array_flow.rb:1466:10:1466:10 | b [element 2] | semmle.label | b [element 2] |
-| array_flow.rb:1466:10:1466:10 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1466:10:1466:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1470:5:1470:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1470:16:1470:26 | call to source | semmle.label | call to source |
-| array_flow.rb:1471:5:1471:5 | b [element 2] | semmle.label | b [element 2] |
-| array_flow.rb:1471:9:1471:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1471:9:1474:7 | call to take_while [element 2] | semmle.label | call to take_while [element 2] |
-| array_flow.rb:1471:26:1471:26 | x | semmle.label | x |
-| array_flow.rb:1472:14:1472:14 | x | semmle.label | x |
-| array_flow.rb:1477:10:1477:10 | b [element 2] | semmle.label | b [element 2] |
-| array_flow.rb:1477:10:1477:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1483:5:1483:5 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:1483:19:1483:29 | call to source | semmle.label | call to source |
-| array_flow.rb:1484:5:1484:5 | b [element 3] | semmle.label | b [element 3] |
-| array_flow.rb:1484:9:1484:9 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:1484:9:1484:14 | call to to_a [element 3] | semmle.label | call to to_a [element 3] |
-| array_flow.rb:1485:10:1485:10 | b [element 3] | semmle.label | b [element 3] |
-| array_flow.rb:1485:10:1485:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1489:5:1489:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1489:16:1489:26 | call to source | semmle.label | call to source |
-| array_flow.rb:1490:5:1490:5 | b [element 2] | semmle.label | b [element 2] |
-| array_flow.rb:1490:9:1490:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1490:9:1490:16 | call to to_ary [element 2] | semmle.label | call to to_ary [element 2] |
-| array_flow.rb:1493:10:1493:10 | b [element 2] | semmle.label | b [element 2] |
-| array_flow.rb:1493:10:1493:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1506:5:1506:5 | a [element 0, element 1] | semmle.label | a [element 0, element 1] |
-| array_flow.rb:1506:5:1506:5 | a [element 1, element 1] | semmle.label | a [element 1, element 1] |
-| array_flow.rb:1506:5:1506:5 | a [element 2, element 1] | semmle.label | a [element 2, element 1] |
-| array_flow.rb:1506:14:1506:26 | call to source | semmle.label | call to source |
-| array_flow.rb:1506:34:1506:46 | call to source | semmle.label | call to source |
-| array_flow.rb:1506:54:1506:66 | call to source | semmle.label | call to source |
-| array_flow.rb:1507:5:1507:5 | b [element 1, element 0] | semmle.label | b [element 1, element 0] |
-| array_flow.rb:1507:5:1507:5 | b [element 1, element 1] | semmle.label | b [element 1, element 1] |
-| array_flow.rb:1507:5:1507:5 | b [element 1, element 2] | semmle.label | b [element 1, element 2] |
-| array_flow.rb:1507:9:1507:9 | a [element 0, element 1] | semmle.label | a [element 0, element 1] |
-| array_flow.rb:1507:9:1507:9 | a [element 1, element 1] | semmle.label | a [element 1, element 1] |
-| array_flow.rb:1507:9:1507:9 | a [element 2, element 1] | semmle.label | a [element 2, element 1] |
-| array_flow.rb:1507:9:1507:19 | call to transpose [element 1, element 0] | semmle.label | call to transpose [element 1, element 0] |
-| array_flow.rb:1507:9:1507:19 | call to transpose [element 1, element 1] | semmle.label | call to transpose [element 1, element 1] |
-| array_flow.rb:1507:9:1507:19 | call to transpose [element 1, element 2] | semmle.label | call to transpose [element 1, element 2] |
-| array_flow.rb:1511:10:1511:10 | b [element 1, element 0] | semmle.label | b [element 1, element 0] |
-| array_flow.rb:1511:10:1511:13 | ...[...] [element 0] | semmle.label | ...[...] [element 0] |
-| array_flow.rb:1511:10:1511:16 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1512:10:1512:10 | b [element 1, element 1] | semmle.label | b [element 1, element 1] |
-| array_flow.rb:1512:10:1512:13 | ...[...] [element 1] | semmle.label | ...[...] [element 1] |
+| array_flow.rb:1464:10:1464:10 | b [element 2] | semmle.label | b [element 2] |
+| array_flow.rb:1464:10:1464:10 | b [element 3] | semmle.label | b [element 3] |
+| array_flow.rb:1464:10:1464:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1465:5:1465:5 | [post] a [element] | semmle.label | [post] a [element] |
+| array_flow.rb:1465:12:1465:24 | call to source | semmle.label | call to source |
+| array_flow.rb:1466:5:1466:5 | b [element 2] | semmle.label | b [element 2] |
+| array_flow.rb:1466:5:1466:5 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1466:9:1466:9 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1466:9:1466:9 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1466:9:1466:17 | call to take [element 2] | semmle.label | call to take [element 2] |
+| array_flow.rb:1466:9:1466:17 | call to take [element] | semmle.label | call to take [element] |
+| array_flow.rb:1467:10:1467:10 | b [element 2] | semmle.label | b [element 2] |
+| array_flow.rb:1467:10:1467:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1467:10:1467:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1471:5:1471:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1471:16:1471:26 | call to source | semmle.label | call to source |
+| array_flow.rb:1472:5:1472:5 | b [element 2] | semmle.label | b [element 2] |
+| array_flow.rb:1472:9:1472:9 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1472:9:1475:7 | call to take_while [element 2] | semmle.label | call to take_while [element 2] |
+| array_flow.rb:1472:26:1472:26 | x | semmle.label | x |
+| array_flow.rb:1473:14:1473:14 | x | semmle.label | x |
+| array_flow.rb:1478:10:1478:10 | b [element 2] | semmle.label | b [element 2] |
+| array_flow.rb:1478:10:1478:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1484:5:1484:5 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:1484:19:1484:29 | call to source | semmle.label | call to source |
+| array_flow.rb:1485:5:1485:5 | b [element 3] | semmle.label | b [element 3] |
+| array_flow.rb:1485:9:1485:9 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:1485:9:1485:14 | call to to_a [element 3] | semmle.label | call to to_a [element 3] |
+| array_flow.rb:1486:10:1486:10 | b [element 3] | semmle.label | b [element 3] |
+| array_flow.rb:1486:10:1486:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1490:5:1490:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1490:16:1490:26 | call to source | semmle.label | call to source |
+| array_flow.rb:1491:5:1491:5 | b [element 2] | semmle.label | b [element 2] |
+| array_flow.rb:1491:9:1491:9 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1491:9:1491:16 | call to to_ary [element 2] | semmle.label | call to to_ary [element 2] |
+| array_flow.rb:1494:10:1494:10 | b [element 2] | semmle.label | b [element 2] |
+| array_flow.rb:1494:10:1494:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1507:5:1507:5 | a [element 0, element 1] | semmle.label | a [element 0, element 1] |
+| array_flow.rb:1507:5:1507:5 | a [element 1, element 1] | semmle.label | a [element 1, element 1] |
+| array_flow.rb:1507:5:1507:5 | a [element 2, element 1] | semmle.label | a [element 2, element 1] |
+| array_flow.rb:1507:14:1507:26 | call to source | semmle.label | call to source |
+| array_flow.rb:1507:34:1507:46 | call to source | semmle.label | call to source |
+| array_flow.rb:1507:54:1507:66 | call to source | semmle.label | call to source |
+| array_flow.rb:1508:5:1508:5 | b [element 1, element 0] | semmle.label | b [element 1, element 0] |
+| array_flow.rb:1508:5:1508:5 | b [element 1, element 1] | semmle.label | b [element 1, element 1] |
+| array_flow.rb:1508:5:1508:5 | b [element 1, element 2] | semmle.label | b [element 1, element 2] |
+| array_flow.rb:1508:9:1508:9 | a [element 0, element 1] | semmle.label | a [element 0, element 1] |
+| array_flow.rb:1508:9:1508:9 | a [element 1, element 1] | semmle.label | a [element 1, element 1] |
+| array_flow.rb:1508:9:1508:9 | a [element 2, element 1] | semmle.label | a [element 2, element 1] |
+| array_flow.rb:1508:9:1508:19 | call to transpose [element 1, element 0] | semmle.label | call to transpose [element 1, element 0] |
+| array_flow.rb:1508:9:1508:19 | call to transpose [element 1, element 1] | semmle.label | call to transpose [element 1, element 1] |
+| array_flow.rb:1508:9:1508:19 | call to transpose [element 1, element 2] | semmle.label | call to transpose [element 1, element 2] |
+| array_flow.rb:1512:10:1512:10 | b [element 1, element 0] | semmle.label | b [element 1, element 0] |
+| array_flow.rb:1512:10:1512:13 | ...[...] [element 0] | semmle.label | ...[...] [element 0] |
 | array_flow.rb:1512:10:1512:16 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1513:10:1513:10 | b [element 1, element 2] | semmle.label | b [element 1, element 2] |
-| array_flow.rb:1513:10:1513:13 | ...[...] [element 2] | semmle.label | ...[...] [element 2] |
+| array_flow.rb:1513:10:1513:10 | b [element 1, element 1] | semmle.label | b [element 1, element 1] |
+| array_flow.rb:1513:10:1513:13 | ...[...] [element 1] | semmle.label | ...[...] [element 1] |
 | array_flow.rb:1513:10:1513:16 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1517:5:1517:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1517:16:1517:28 | call to source | semmle.label | call to source |
-| array_flow.rb:1518:5:1518:5 | b [element 1] | semmle.label | b [element 1] |
-| array_flow.rb:1518:13:1518:25 | call to source | semmle.label | call to source |
-| array_flow.rb:1519:5:1519:5 | c [element 1] | semmle.label | c [element 1] |
+| array_flow.rb:1514:10:1514:10 | b [element 1, element 2] | semmle.label | b [element 1, element 2] |
+| array_flow.rb:1514:10:1514:13 | ...[...] [element 2] | semmle.label | ...[...] [element 2] |
+| array_flow.rb:1514:10:1514:16 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1518:5:1518:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1518:16:1518:28 | call to source | semmle.label | call to source |
+| array_flow.rb:1519:5:1519:5 | b [element 1] | semmle.label | b [element 1] |
 | array_flow.rb:1519:13:1519:25 | call to source | semmle.label | call to source |
-| array_flow.rb:1520:5:1520:5 | d [element] | semmle.label | d [element] |
-| array_flow.rb:1520:9:1520:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1520:9:1520:21 | call to union [element] | semmle.label | call to union [element] |
-| array_flow.rb:1520:17:1520:17 | b [element 1] | semmle.label | b [element 1] |
-| array_flow.rb:1520:20:1520:20 | c [element 1] | semmle.label | c [element 1] |
-| array_flow.rb:1521:10:1521:10 | d [element] | semmle.label | d [element] |
-| array_flow.rb:1521:10:1521:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1520:5:1520:5 | c [element 1] | semmle.label | c [element 1] |
+| array_flow.rb:1520:13:1520:25 | call to source | semmle.label | call to source |
+| array_flow.rb:1521:5:1521:5 | d [element] | semmle.label | d [element] |
+| array_flow.rb:1521:9:1521:9 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1521:9:1521:21 | call to union [element] | semmle.label | call to union [element] |
+| array_flow.rb:1521:17:1521:17 | b [element 1] | semmle.label | b [element 1] |
+| array_flow.rb:1521:20:1521:20 | c [element 1] | semmle.label | c [element 1] |
 | array_flow.rb:1522:10:1522:10 | d [element] | semmle.label | d [element] |
 | array_flow.rb:1522:10:1522:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1523:10:1523:10 | d [element] | semmle.label | d [element] |
 | array_flow.rb:1523:10:1523:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1527:5:1527:5 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:1527:5:1527:5 | a [element 4] | semmle.label | a [element 4] |
-| array_flow.rb:1527:19:1527:31 | call to source | semmle.label | call to source |
-| array_flow.rb:1527:34:1527:46 | call to source | semmle.label | call to source |
-| array_flow.rb:1529:5:1529:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1529:9:1529:9 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:1529:9:1529:9 | a [element 4] | semmle.label | a [element 4] |
-| array_flow.rb:1529:9:1529:14 | call to uniq [element] | semmle.label | call to uniq [element] |
-| array_flow.rb:1530:10:1530:10 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1530:10:1530:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1524:10:1524:10 | d [element] | semmle.label | d [element] |
+| array_flow.rb:1524:10:1524:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1528:5:1528:5 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:1528:5:1528:5 | a [element 4] | semmle.label | a [element 4] |
+| array_flow.rb:1528:19:1528:31 | call to source | semmle.label | call to source |
+| array_flow.rb:1528:34:1528:46 | call to source | semmle.label | call to source |
+| array_flow.rb:1530:5:1530:5 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1530:9:1530:9 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:1530:9:1530:9 | a [element 4] | semmle.label | a [element 4] |
+| array_flow.rb:1530:9:1530:14 | call to uniq [element] | semmle.label | call to uniq [element] |
 | array_flow.rb:1531:10:1531:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:1531:10:1531:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1533:5:1533:5 | c [element] | semmle.label | c [element] |
-| array_flow.rb:1533:9:1533:9 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:1533:9:1533:9 | a [element 4] | semmle.label | a [element 4] |
-| array_flow.rb:1533:9:1536:7 | call to uniq [element] | semmle.label | call to uniq [element] |
-| array_flow.rb:1533:20:1533:20 | x | semmle.label | x |
-| array_flow.rb:1534:14:1534:14 | x | semmle.label | x |
-| array_flow.rb:1537:10:1537:10 | c [element] | semmle.label | c [element] |
-| array_flow.rb:1537:10:1537:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1541:5:1541:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1541:5:1541:5 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:1541:16:1541:28 | call to source | semmle.label | call to source |
-| array_flow.rb:1541:31:1541:43 | call to source | semmle.label | call to source |
-| array_flow.rb:1542:5:1542:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1542:9:1542:9 | [post] a [element] | semmle.label | [post] a [element] |
-| array_flow.rb:1542:9:1542:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1542:9:1542:9 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:1542:9:1542:15 | call to uniq! [element] | semmle.label | call to uniq! [element] |
-| array_flow.rb:1543:10:1543:10 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1543:10:1543:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1532:10:1532:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1532:10:1532:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1534:5:1534:5 | c [element] | semmle.label | c [element] |
+| array_flow.rb:1534:9:1534:9 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:1534:9:1534:9 | a [element 4] | semmle.label | a [element 4] |
+| array_flow.rb:1534:9:1537:7 | call to uniq [element] | semmle.label | call to uniq [element] |
+| array_flow.rb:1534:20:1534:20 | x | semmle.label | x |
+| array_flow.rb:1535:14:1535:14 | x | semmle.label | x |
+| array_flow.rb:1538:10:1538:10 | c [element] | semmle.label | c [element] |
+| array_flow.rb:1538:10:1538:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1542:5:1542:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1542:5:1542:5 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:1542:16:1542:28 | call to source | semmle.label | call to source |
+| array_flow.rb:1542:31:1542:43 | call to source | semmle.label | call to source |
+| array_flow.rb:1543:5:1543:5 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1543:9:1543:9 | [post] a [element] | semmle.label | [post] a [element] |
+| array_flow.rb:1543:9:1543:9 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1543:9:1543:9 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:1543:9:1543:15 | call to uniq! [element] | semmle.label | call to uniq! [element] |
 | array_flow.rb:1544:10:1544:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:1544:10:1544:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1545:10:1545:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1545:10:1545:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:1545:10:1545:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1546:10:1546:10 | a [element] | semmle.label | a [element] |
 | array_flow.rb:1546:10:1546:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1548:5:1548:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1548:5:1548:5 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:1548:16:1548:28 | call to source | semmle.label | call to source |
-| array_flow.rb:1548:31:1548:43 | call to source | semmle.label | call to source |
-| array_flow.rb:1549:5:1549:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1549:9:1549:9 | [post] a [element] | semmle.label | [post] a [element] |
-| array_flow.rb:1549:9:1549:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1549:9:1549:9 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:1549:9:1552:7 | call to uniq! [element] | semmle.label | call to uniq! [element] |
-| array_flow.rb:1549:21:1549:21 | x | semmle.label | x |
-| array_flow.rb:1550:14:1550:14 | x | semmle.label | x |
-| array_flow.rb:1553:10:1553:10 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1553:10:1553:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1547:10:1547:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1547:10:1547:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1549:5:1549:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1549:5:1549:5 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:1549:16:1549:28 | call to source | semmle.label | call to source |
+| array_flow.rb:1549:31:1549:43 | call to source | semmle.label | call to source |
+| array_flow.rb:1550:5:1550:5 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1550:9:1550:9 | [post] a [element] | semmle.label | [post] a [element] |
+| array_flow.rb:1550:9:1550:9 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1550:9:1550:9 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:1550:9:1553:7 | call to uniq! [element] | semmle.label | call to uniq! [element] |
+| array_flow.rb:1550:21:1550:21 | x | semmle.label | x |
+| array_flow.rb:1551:14:1551:14 | x | semmle.label | x |
 | array_flow.rb:1554:10:1554:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:1554:10:1554:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1555:10:1555:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1555:10:1555:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:1555:10:1555:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1556:10:1556:10 | a [element] | semmle.label | a [element] |
 | array_flow.rb:1556:10:1556:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1560:5:1560:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1560:16:1560:28 | call to source | semmle.label | call to source |
-| array_flow.rb:1561:5:1561:5 | [post] a [element 2] | semmle.label | [post] a [element 2] |
-| array_flow.rb:1561:5:1561:5 | [post] a [element 5] | semmle.label | [post] a [element 5] |
+| array_flow.rb:1557:10:1557:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1557:10:1557:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1561:5:1561:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1561:21:1561:33 | call to source | semmle.label | call to source |
-| array_flow.rb:1564:10:1564:10 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1564:10:1564:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1567:10:1567:10 | a [element 5] | semmle.label | a [element 5] |
-| array_flow.rb:1567:10:1567:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1571:5:1571:5 | a [element 1] | semmle.label | a [element 1] |
-| array_flow.rb:1571:5:1571:5 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:1571:13:1571:25 | call to source | semmle.label | call to source |
-| array_flow.rb:1571:31:1571:43 | call to source | semmle.label | call to source |
-| array_flow.rb:1573:5:1573:5 | b [element 1] | semmle.label | b [element 1] |
-| array_flow.rb:1573:5:1573:5 | b [element 3] | semmle.label | b [element 3] |
-| array_flow.rb:1573:9:1573:9 | a [element 1] | semmle.label | a [element 1] |
-| array_flow.rb:1573:9:1573:31 | call to values_at [element 1] | semmle.label | call to values_at [element 1] |
-| array_flow.rb:1573:9:1573:31 | call to values_at [element 3] | semmle.label | call to values_at [element 3] |
-| array_flow.rb:1575:10:1575:10 | b [element 1] | semmle.label | b [element 1] |
-| array_flow.rb:1575:10:1575:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1577:10:1577:10 | b [element 3] | semmle.label | b [element 3] |
-| array_flow.rb:1577:10:1577:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1579:5:1579:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1579:9:1579:9 | a [element 1] | semmle.label | a [element 1] |
-| array_flow.rb:1579:9:1579:9 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:1579:9:1579:25 | call to values_at [element] | semmle.label | call to values_at [element] |
-| array_flow.rb:1580:10:1580:10 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1580:10:1580:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1561:16:1561:28 | call to source | semmle.label | call to source |
+| array_flow.rb:1562:5:1562:5 | [post] a [element 2] | semmle.label | [post] a [element 2] |
+| array_flow.rb:1562:5:1562:5 | [post] a [element 5] | semmle.label | [post] a [element 5] |
+| array_flow.rb:1562:5:1562:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1562:21:1562:33 | call to source | semmle.label | call to source |
+| array_flow.rb:1565:10:1565:10 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1565:10:1565:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1568:10:1568:10 | a [element 5] | semmle.label | a [element 5] |
+| array_flow.rb:1568:10:1568:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1572:5:1572:5 | a [element 1] | semmle.label | a [element 1] |
+| array_flow.rb:1572:5:1572:5 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:1572:13:1572:25 | call to source | semmle.label | call to source |
+| array_flow.rb:1572:31:1572:43 | call to source | semmle.label | call to source |
+| array_flow.rb:1574:5:1574:5 | b [element 1] | semmle.label | b [element 1] |
+| array_flow.rb:1574:5:1574:5 | b [element 3] | semmle.label | b [element 3] |
+| array_flow.rb:1574:9:1574:9 | a [element 1] | semmle.label | a [element 1] |
+| array_flow.rb:1574:9:1574:31 | call to values_at [element 1] | semmle.label | call to values_at [element 1] |
+| array_flow.rb:1574:9:1574:31 | call to values_at [element 3] | semmle.label | call to values_at [element 3] |
+| array_flow.rb:1576:10:1576:10 | b [element 1] | semmle.label | b [element 1] |
+| array_flow.rb:1576:10:1576:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1578:10:1578:10 | b [element 3] | semmle.label | b [element 3] |
+| array_flow.rb:1578:10:1578:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1580:5:1580:5 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1580:9:1580:9 | a [element 1] | semmle.label | a [element 1] |
+| array_flow.rb:1580:9:1580:9 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:1580:9:1580:25 | call to values_at [element] | semmle.label | call to values_at [element] |
 | array_flow.rb:1581:10:1581:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:1581:10:1581:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1583:5:1583:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1583:9:1583:9 | a [element 1] | semmle.label | a [element 1] |
-| array_flow.rb:1583:9:1583:9 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:1583:9:1583:26 | call to values_at [element] | semmle.label | call to values_at [element] |
-| array_flow.rb:1584:10:1584:10 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1584:10:1584:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1582:10:1582:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1582:10:1582:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1584:5:1584:5 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1584:9:1584:9 | a [element 1] | semmle.label | a [element 1] |
+| array_flow.rb:1584:9:1584:9 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:1584:9:1584:26 | call to values_at [element] | semmle.label | call to values_at [element] |
 | array_flow.rb:1585:10:1585:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:1585:10:1585:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1587:5:1587:5 | b [element 1] | semmle.label | b [element 1] |
-| array_flow.rb:1587:5:1587:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1587:9:1587:9 | a [element 1] | semmle.label | a [element 1] |
-| array_flow.rb:1587:9:1587:9 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:1587:9:1587:28 | call to values_at [element 1] | semmle.label | call to values_at [element 1] |
-| array_flow.rb:1587:9:1587:28 | call to values_at [element] | semmle.label | call to values_at [element] |
-| array_flow.rb:1588:10:1588:10 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1588:10:1588:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1589:10:1589:10 | b [element 1] | semmle.label | b [element 1] |
+| array_flow.rb:1586:10:1586:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1586:10:1586:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1588:5:1588:5 | b [element 1] | semmle.label | b [element 1] |
+| array_flow.rb:1588:5:1588:5 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1588:9:1588:9 | a [element 1] | semmle.label | a [element 1] |
+| array_flow.rb:1588:9:1588:9 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:1588:9:1588:28 | call to values_at [element 1] | semmle.label | call to values_at [element 1] |
+| array_flow.rb:1588:9:1588:28 | call to values_at [element] | semmle.label | call to values_at [element] |
 | array_flow.rb:1589:10:1589:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:1589:10:1589:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1590:10:1590:10 | b [element 1] | semmle.label | b [element 1] |
 | array_flow.rb:1590:10:1590:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:1590:10:1590:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1591:10:1591:10 | b [element] | semmle.label | b [element] |
 | array_flow.rb:1591:10:1591:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1595:5:1595:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1595:16:1595:28 | call to source | semmle.label | call to source |
-| array_flow.rb:1596:5:1596:5 | b [element 1] | semmle.label | b [element 1] |
-| array_flow.rb:1596:13:1596:25 | call to source | semmle.label | call to source |
-| array_flow.rb:1597:5:1597:5 | c [element 0] | semmle.label | c [element 0] |
-| array_flow.rb:1597:10:1597:22 | call to source | semmle.label | call to source |
-| array_flow.rb:1598:5:1598:5 | d [element 0, element 2] | semmle.label | d [element 0, element 2] |
-| array_flow.rb:1598:5:1598:5 | d [element 1, element 1] | semmle.label | d [element 1, element 1] |
-| array_flow.rb:1598:5:1598:5 | d [element 2, element 0] | semmle.label | d [element 2, element 0] |
-| array_flow.rb:1598:9:1598:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1598:9:1598:19 | call to zip [element 0, element 2] | semmle.label | call to zip [element 0, element 2] |
-| array_flow.rb:1598:9:1598:19 | call to zip [element 1, element 1] | semmle.label | call to zip [element 1, element 1] |
-| array_flow.rb:1598:9:1598:19 | call to zip [element 2, element 0] | semmle.label | call to zip [element 2, element 0] |
-| array_flow.rb:1598:15:1598:15 | b [element 1] | semmle.label | b [element 1] |
-| array_flow.rb:1598:18:1598:18 | c [element 0] | semmle.label | c [element 0] |
-| array_flow.rb:1600:10:1600:10 | d [element 0, element 2] | semmle.label | d [element 0, element 2] |
-| array_flow.rb:1600:10:1600:13 | ...[...] [element 2] | semmle.label | ...[...] [element 2] |
-| array_flow.rb:1600:10:1600:16 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1601:10:1601:10 | d [element 1, element 1] | semmle.label | d [element 1, element 1] |
-| array_flow.rb:1601:10:1601:13 | ...[...] [element 1] | semmle.label | ...[...] [element 1] |
+| array_flow.rb:1592:10:1592:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1592:10:1592:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1596:5:1596:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1596:16:1596:28 | call to source | semmle.label | call to source |
+| array_flow.rb:1597:5:1597:5 | b [element 1] | semmle.label | b [element 1] |
+| array_flow.rb:1597:13:1597:25 | call to source | semmle.label | call to source |
+| array_flow.rb:1598:5:1598:5 | c [element 0] | semmle.label | c [element 0] |
+| array_flow.rb:1598:10:1598:22 | call to source | semmle.label | call to source |
+| array_flow.rb:1599:5:1599:5 | d [element 0, element 2] | semmle.label | d [element 0, element 2] |
+| array_flow.rb:1599:5:1599:5 | d [element 1, element 1] | semmle.label | d [element 1, element 1] |
+| array_flow.rb:1599:5:1599:5 | d [element 2, element 0] | semmle.label | d [element 2, element 0] |
+| array_flow.rb:1599:9:1599:9 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1599:9:1599:19 | call to zip [element 0, element 2] | semmle.label | call to zip [element 0, element 2] |
+| array_flow.rb:1599:9:1599:19 | call to zip [element 1, element 1] | semmle.label | call to zip [element 1, element 1] |
+| array_flow.rb:1599:9:1599:19 | call to zip [element 2, element 0] | semmle.label | call to zip [element 2, element 0] |
+| array_flow.rb:1599:15:1599:15 | b [element 1] | semmle.label | b [element 1] |
+| array_flow.rb:1599:18:1599:18 | c [element 0] | semmle.label | c [element 0] |
+| array_flow.rb:1601:10:1601:10 | d [element 0, element 2] | semmle.label | d [element 0, element 2] |
+| array_flow.rb:1601:10:1601:13 | ...[...] [element 2] | semmle.label | ...[...] [element 2] |
 | array_flow.rb:1601:10:1601:16 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1602:10:1602:10 | d [element 2, element 0] | semmle.label | d [element 2, element 0] |
-| array_flow.rb:1602:10:1602:13 | ...[...] [element 0] | semmle.label | ...[...] [element 0] |
+| array_flow.rb:1602:10:1602:10 | d [element 1, element 1] | semmle.label | d [element 1, element 1] |
+| array_flow.rb:1602:10:1602:13 | ...[...] [element 1] | semmle.label | ...[...] [element 1] |
 | array_flow.rb:1602:10:1602:16 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1603:5:1603:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1603:11:1603:11 | b [element 1] | semmle.label | b [element 1] |
-| array_flow.rb:1603:14:1603:14 | c [element 0] | semmle.label | c [element 0] |
-| array_flow.rb:1603:21:1603:21 | x [element 0] | semmle.label | x [element 0] |
-| array_flow.rb:1603:21:1603:21 | x [element 1] | semmle.label | x [element 1] |
-| array_flow.rb:1603:21:1603:21 | x [element 2] | semmle.label | x [element 2] |
-| array_flow.rb:1604:14:1604:14 | x [element 0] | semmle.label | x [element 0] |
-| array_flow.rb:1604:14:1604:17 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1605:14:1605:14 | x [element 1] | semmle.label | x [element 1] |
+| array_flow.rb:1603:10:1603:10 | d [element 2, element 0] | semmle.label | d [element 2, element 0] |
+| array_flow.rb:1603:10:1603:13 | ...[...] [element 0] | semmle.label | ...[...] [element 0] |
+| array_flow.rb:1603:10:1603:16 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1604:5:1604:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1604:11:1604:11 | b [element 1] | semmle.label | b [element 1] |
+| array_flow.rb:1604:14:1604:14 | c [element 0] | semmle.label | c [element 0] |
+| array_flow.rb:1604:21:1604:21 | x [element 0] | semmle.label | x [element 0] |
+| array_flow.rb:1604:21:1604:21 | x [element 1] | semmle.label | x [element 1] |
+| array_flow.rb:1604:21:1604:21 | x [element 2] | semmle.label | x [element 2] |
+| array_flow.rb:1605:14:1605:14 | x [element 0] | semmle.label | x [element 0] |
 | array_flow.rb:1605:14:1605:17 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1606:14:1606:14 | x [element 2] | semmle.label | x [element 2] |
+| array_flow.rb:1606:14:1606:14 | x [element 1] | semmle.label | x [element 1] |
 | array_flow.rb:1606:14:1606:17 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1611:5:1611:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1611:16:1611:28 | call to source | semmle.label | call to source |
-| array_flow.rb:1612:5:1612:5 | b [element 1] | semmle.label | b [element 1] |
-| array_flow.rb:1612:13:1612:25 | call to source | semmle.label | call to source |
-| array_flow.rb:1613:5:1613:5 | c [element] | semmle.label | c [element] |
-| array_flow.rb:1613:9:1613:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1613:9:1613:13 | ... \| ... [element] | semmle.label | ... \| ... [element] |
-| array_flow.rb:1613:13:1613:13 | b [element 1] | semmle.label | b [element 1] |
-| array_flow.rb:1614:10:1614:10 | c [element] | semmle.label | c [element] |
-| array_flow.rb:1614:10:1614:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1607:14:1607:14 | x [element 2] | semmle.label | x [element 2] |
+| array_flow.rb:1607:14:1607:17 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1612:5:1612:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1612:16:1612:28 | call to source | semmle.label | call to source |
+| array_flow.rb:1613:5:1613:5 | b [element 1] | semmle.label | b [element 1] |
+| array_flow.rb:1613:13:1613:25 | call to source | semmle.label | call to source |
+| array_flow.rb:1614:5:1614:5 | c [element] | semmle.label | c [element] |
+| array_flow.rb:1614:9:1614:9 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1614:9:1614:13 | ... \| ... [element] | semmle.label | ... \| ... [element] |
+| array_flow.rb:1614:13:1614:13 | b [element 1] | semmle.label | b [element 1] |
 | array_flow.rb:1615:10:1615:10 | c [element] | semmle.label | c [element] |
 | array_flow.rb:1615:10:1615:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1616:10:1616:10 | c [element] | semmle.label | c [element] |
 | array_flow.rb:1616:10:1616:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1621:5:1621:5 | [post] a [element, element 0] | semmle.label | [post] a [element, element 0] |
-| array_flow.rb:1621:5:1621:8 | [post] ...[...] [element 0] | semmle.label | [post] ...[...] [element 0] |
-| array_flow.rb:1621:15:1621:27 | call to source | semmle.label | call to source |
-| array_flow.rb:1622:10:1622:10 | a [element, element 0] | semmle.label | a [element, element 0] |
-| array_flow.rb:1622:10:1622:13 | ...[...] [element 0] | semmle.label | ...[...] [element 0] |
-| array_flow.rb:1622:10:1622:16 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1624:5:1624:5 | [post] a [element 1, element 0] | semmle.label | [post] a [element 1, element 0] |
-| array_flow.rb:1624:5:1624:8 | [post] ...[...] [element 0] | semmle.label | [post] ...[...] [element 0] |
-| array_flow.rb:1624:15:1624:27 | call to source | semmle.label | call to source |
-| array_flow.rb:1625:10:1625:10 | a [element 1, element 0] | semmle.label | a [element 1, element 0] |
-| array_flow.rb:1625:10:1625:10 | a [element, element 0] | semmle.label | a [element, element 0] |
-| array_flow.rb:1625:10:1625:13 | ...[...] [element 0] | semmle.label | ...[...] [element 0] |
-| array_flow.rb:1625:10:1625:16 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1617:10:1617:10 | c [element] | semmle.label | c [element] |
+| array_flow.rb:1617:10:1617:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1622:5:1622:5 | [post] a [element, element 0] | semmle.label | [post] a [element, element 0] |
+| array_flow.rb:1622:5:1622:8 | [post] ...[...] [element 0] | semmle.label | [post] ...[...] [element 0] |
+| array_flow.rb:1622:15:1622:27 | call to source | semmle.label | call to source |
+| array_flow.rb:1623:10:1623:10 | a [element, element 0] | semmle.label | a [element, element 0] |
+| array_flow.rb:1623:10:1623:13 | ...[...] [element 0] | semmle.label | ...[...] [element 0] |
+| array_flow.rb:1623:10:1623:16 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1625:5:1625:5 | [post] a [element 1, element 0] | semmle.label | [post] a [element 1, element 0] |
+| array_flow.rb:1625:5:1625:8 | [post] ...[...] [element 0] | semmle.label | [post] ...[...] [element 0] |
+| array_flow.rb:1625:15:1625:27 | call to source | semmle.label | call to source |
+| array_flow.rb:1626:10:1626:10 | a [element 1, element 0] | semmle.label | a [element 1, element 0] |
 | array_flow.rb:1626:10:1626:10 | a [element, element 0] | semmle.label | a [element, element 0] |
 | array_flow.rb:1626:10:1626:13 | ...[...] [element 0] | semmle.label | ...[...] [element 0] |
 | array_flow.rb:1626:10:1626:16 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1631:5:1631:5 | [post] a [element 0] | semmle.label | [post] a [element 0] |
-| array_flow.rb:1631:12:1631:24 | call to source | semmle.label | call to source |
-| array_flow.rb:1633:5:1633:5 | [post] a [element] | semmle.label | [post] a [element] |
-| array_flow.rb:1633:16:1633:28 | call to source | semmle.label | call to source |
-| array_flow.rb:1635:5:1635:5 | [post] a [element] | semmle.label | [post] a [element] |
-| array_flow.rb:1635:14:1635:26 | call to source | semmle.label | call to source |
-| array_flow.rb:1637:5:1637:5 | [post] a [element] | semmle.label | [post] a [element] |
-| array_flow.rb:1637:16:1637:28 | call to source | semmle.label | call to source |
-| array_flow.rb:1638:10:1638:10 | a [element] | semmle.label | a [element] |
-| array_flow.rb:1638:10:1638:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1640:10:1640:10 | a [element 0] | semmle.label | a [element 0] |
-| array_flow.rb:1640:10:1640:10 | a [element] | semmle.label | a [element] |
-| array_flow.rb:1640:10:1640:17 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1642:10:1642:10 | a [element 0] | semmle.label | a [element 0] |
-| array_flow.rb:1642:10:1642:10 | a [element] | semmle.label | a [element] |
-| array_flow.rb:1642:10:1642:15 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1627:10:1627:10 | a [element, element 0] | semmle.label | a [element, element 0] |
+| array_flow.rb:1627:10:1627:13 | ...[...] [element 0] | semmle.label | ...[...] [element 0] |
+| array_flow.rb:1627:10:1627:16 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1632:5:1632:5 | [post] a [element 0] | semmle.label | [post] a [element 0] |
+| array_flow.rb:1632:12:1632:24 | call to source | semmle.label | call to source |
+| array_flow.rb:1634:5:1634:5 | [post] a [element] | semmle.label | [post] a [element] |
+| array_flow.rb:1634:16:1634:28 | call to source | semmle.label | call to source |
+| array_flow.rb:1636:5:1636:5 | [post] a [element] | semmle.label | [post] a [element] |
+| array_flow.rb:1636:14:1636:26 | call to source | semmle.label | call to source |
+| array_flow.rb:1638:5:1638:5 | [post] a [element] | semmle.label | [post] a [element] |
+| array_flow.rb:1638:16:1638:28 | call to source | semmle.label | call to source |
+| array_flow.rb:1639:10:1639:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1639:10:1639:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1641:10:1641:10 | a [element 0] | semmle.label | a [element 0] |
+| array_flow.rb:1641:10:1641:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1641:10:1641:17 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:1643:10:1643:10 | a [element 0] | semmle.label | a [element 0] |
+| array_flow.rb:1643:10:1643:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1643:10:1643:15 | ...[...] | semmle.label | ...[...] |
 subpaths
 #select
 | array_flow.rb:3:10:3:13 | ...[...] | array_flow.rb:2:10:2:20 | call to source | array_flow.rb:3:10:3:13 | ...[...] | $@ | array_flow.rb:2:10:2:20 | call to source | call to source |
@@ -4833,226 +4824,224 @@ subpaths
 | array_flow.rb:1212:10:1212:10 | b | array_flow.rb:1206:34:1206:46 | call to source | array_flow.rb:1212:10:1212:10 | b | $@ | array_flow.rb:1206:34:1206:46 | call to source | call to source |
 | array_flow.rb:1216:10:1216:10 | b | array_flow.rb:1206:16:1206:28 | call to source | array_flow.rb:1216:10:1216:10 | b | $@ | array_flow.rb:1206:16:1206:28 | call to source | call to source |
 | array_flow.rb:1216:10:1216:10 | b | array_flow.rb:1206:34:1206:46 | call to source | array_flow.rb:1216:10:1216:10 | b | $@ | array_flow.rb:1206:34:1206:46 | call to source | call to source |
-| array_flow.rb:1218:10:1218:13 | ...[...] | array_flow.rb:1206:16:1206:28 | call to source | array_flow.rb:1218:10:1218:13 | ...[...] | $@ | array_flow.rb:1206:16:1206:28 | call to source | call to source |
-| array_flow.rb:1218:10:1218:13 | ...[...] | array_flow.rb:1206:34:1206:46 | call to source | array_flow.rb:1218:10:1218:13 | ...[...] | $@ | array_flow.rb:1206:34:1206:46 | call to source | call to source |
-| array_flow.rb:1221:10:1221:13 | ...[...] | array_flow.rb:1206:16:1206:28 | call to source | array_flow.rb:1221:10:1221:13 | ...[...] | $@ | array_flow.rb:1206:16:1206:28 | call to source | call to source |
-| array_flow.rb:1223:10:1223:13 | ...[...] | array_flow.rb:1206:34:1206:46 | call to source | array_flow.rb:1223:10:1223:13 | ...[...] | $@ | array_flow.rb:1206:34:1206:46 | call to source | call to source |
-| array_flow.rb:1226:10:1226:13 | ...[...] | array_flow.rb:1206:16:1206:28 | call to source | array_flow.rb:1226:10:1226:13 | ...[...] | $@ | array_flow.rb:1206:16:1206:28 | call to source | call to source |
-| array_flow.rb:1226:10:1226:13 | ...[...] | array_flow.rb:1206:34:1206:46 | call to source | array_flow.rb:1226:10:1226:13 | ...[...] | $@ | array_flow.rb:1206:34:1206:46 | call to source | call to source |
+| array_flow.rb:1222:10:1222:13 | ...[...] | array_flow.rb:1206:16:1206:28 | call to source | array_flow.rb:1222:10:1222:13 | ...[...] | $@ | array_flow.rb:1206:16:1206:28 | call to source | call to source |
+| array_flow.rb:1224:10:1224:13 | ...[...] | array_flow.rb:1206:34:1206:46 | call to source | array_flow.rb:1224:10:1224:13 | ...[...] | $@ | array_flow.rb:1206:34:1206:46 | call to source | call to source |
 | array_flow.rb:1227:10:1227:13 | ...[...] | array_flow.rb:1206:16:1206:28 | call to source | array_flow.rb:1227:10:1227:13 | ...[...] | $@ | array_flow.rb:1206:16:1206:28 | call to source | call to source |
 | array_flow.rb:1227:10:1227:13 | ...[...] | array_flow.rb:1206:34:1206:46 | call to source | array_flow.rb:1227:10:1227:13 | ...[...] | $@ | array_flow.rb:1206:34:1206:46 | call to source | call to source |
-| array_flow.rb:1230:10:1230:13 | ...[...] | array_flow.rb:1206:16:1206:28 | call to source | array_flow.rb:1230:10:1230:13 | ...[...] | $@ | array_flow.rb:1206:16:1206:28 | call to source | call to source |
-| array_flow.rb:1235:10:1235:13 | ...[...] | array_flow.rb:1206:16:1206:28 | call to source | array_flow.rb:1235:10:1235:13 | ...[...] | $@ | array_flow.rb:1206:16:1206:28 | call to source | call to source |
-| array_flow.rb:1240:10:1240:13 | ...[...] | array_flow.rb:1206:16:1206:28 | call to source | array_flow.rb:1240:10:1240:13 | ...[...] | $@ | array_flow.rb:1206:16:1206:28 | call to source | call to source |
-| array_flow.rb:1240:10:1240:13 | ...[...] | array_flow.rb:1206:34:1206:46 | call to source | array_flow.rb:1240:10:1240:13 | ...[...] | $@ | array_flow.rb:1206:34:1206:46 | call to source | call to source |
+| array_flow.rb:1228:10:1228:13 | ...[...] | array_flow.rb:1206:16:1206:28 | call to source | array_flow.rb:1228:10:1228:13 | ...[...] | $@ | array_flow.rb:1206:16:1206:28 | call to source | call to source |
+| array_flow.rb:1228:10:1228:13 | ...[...] | array_flow.rb:1206:34:1206:46 | call to source | array_flow.rb:1228:10:1228:13 | ...[...] | $@ | array_flow.rb:1206:34:1206:46 | call to source | call to source |
+| array_flow.rb:1231:10:1231:13 | ...[...] | array_flow.rb:1206:16:1206:28 | call to source | array_flow.rb:1231:10:1231:13 | ...[...] | $@ | array_flow.rb:1206:16:1206:28 | call to source | call to source |
+| array_flow.rb:1236:10:1236:13 | ...[...] | array_flow.rb:1206:16:1206:28 | call to source | array_flow.rb:1236:10:1236:13 | ...[...] | $@ | array_flow.rb:1206:16:1206:28 | call to source | call to source |
 | array_flow.rb:1241:10:1241:13 | ...[...] | array_flow.rb:1206:16:1206:28 | call to source | array_flow.rb:1241:10:1241:13 | ...[...] | $@ | array_flow.rb:1206:16:1206:28 | call to source | call to source |
 | array_flow.rb:1241:10:1241:13 | ...[...] | array_flow.rb:1206:34:1206:46 | call to source | array_flow.rb:1241:10:1241:13 | ...[...] | $@ | array_flow.rb:1206:34:1206:46 | call to source | call to source |
-| array_flow.rb:1244:10:1244:13 | ...[...] | array_flow.rb:1206:16:1206:28 | call to source | array_flow.rb:1244:10:1244:13 | ...[...] | $@ | array_flow.rb:1206:16:1206:28 | call to source | call to source |
-| array_flow.rb:1244:10:1244:13 | ...[...] | array_flow.rb:1206:34:1206:46 | call to source | array_flow.rb:1244:10:1244:13 | ...[...] | $@ | array_flow.rb:1206:34:1206:46 | call to source | call to source |
+| array_flow.rb:1242:10:1242:13 | ...[...] | array_flow.rb:1206:16:1206:28 | call to source | array_flow.rb:1242:10:1242:13 | ...[...] | $@ | array_flow.rb:1206:16:1206:28 | call to source | call to source |
+| array_flow.rb:1242:10:1242:13 | ...[...] | array_flow.rb:1206:34:1206:46 | call to source | array_flow.rb:1242:10:1242:13 | ...[...] | $@ | array_flow.rb:1206:34:1206:46 | call to source | call to source |
 | array_flow.rb:1245:10:1245:13 | ...[...] | array_flow.rb:1206:16:1206:28 | call to source | array_flow.rb:1245:10:1245:13 | ...[...] | $@ | array_flow.rb:1206:16:1206:28 | call to source | call to source |
 | array_flow.rb:1245:10:1245:13 | ...[...] | array_flow.rb:1206:34:1206:46 | call to source | array_flow.rb:1245:10:1245:13 | ...[...] | $@ | array_flow.rb:1206:34:1206:46 | call to source | call to source |
-| array_flow.rb:1250:10:1250:13 | ...[...] | array_flow.rb:1206:16:1206:28 | call to source | array_flow.rb:1250:10:1250:13 | ...[...] | $@ | array_flow.rb:1206:16:1206:28 | call to source | call to source |
-| array_flow.rb:1253:10:1253:13 | ...[...] | array_flow.rb:1206:16:1206:28 | call to source | array_flow.rb:1253:10:1253:13 | ...[...] | $@ | array_flow.rb:1206:16:1206:28 | call to source | call to source |
-| array_flow.rb:1253:10:1253:13 | ...[...] | array_flow.rb:1206:34:1206:46 | call to source | array_flow.rb:1253:10:1253:13 | ...[...] | $@ | array_flow.rb:1206:34:1206:46 | call to source | call to source |
+| array_flow.rb:1246:10:1246:13 | ...[...] | array_flow.rb:1206:16:1206:28 | call to source | array_flow.rb:1246:10:1246:13 | ...[...] | $@ | array_flow.rb:1206:16:1206:28 | call to source | call to source |
+| array_flow.rb:1246:10:1246:13 | ...[...] | array_flow.rb:1206:34:1206:46 | call to source | array_flow.rb:1246:10:1246:13 | ...[...] | $@ | array_flow.rb:1206:34:1206:46 | call to source | call to source |
+| array_flow.rb:1251:10:1251:13 | ...[...] | array_flow.rb:1206:16:1206:28 | call to source | array_flow.rb:1251:10:1251:13 | ...[...] | $@ | array_flow.rb:1206:16:1206:28 | call to source | call to source |
 | array_flow.rb:1254:10:1254:13 | ...[...] | array_flow.rb:1206:16:1206:28 | call to source | array_flow.rb:1254:10:1254:13 | ...[...] | $@ | array_flow.rb:1206:16:1206:28 | call to source | call to source |
 | array_flow.rb:1254:10:1254:13 | ...[...] | array_flow.rb:1206:34:1206:46 | call to source | array_flow.rb:1254:10:1254:13 | ...[...] | $@ | array_flow.rb:1206:34:1206:46 | call to source | call to source |
 | array_flow.rb:1255:10:1255:13 | ...[...] | array_flow.rb:1206:16:1206:28 | call to source | array_flow.rb:1255:10:1255:13 | ...[...] | $@ | array_flow.rb:1206:16:1206:28 | call to source | call to source |
 | array_flow.rb:1255:10:1255:13 | ...[...] | array_flow.rb:1206:34:1206:46 | call to source | array_flow.rb:1255:10:1255:13 | ...[...] | $@ | array_flow.rb:1206:34:1206:46 | call to source | call to source |
-| array_flow.rb:1261:10:1261:10 | b | array_flow.rb:1259:16:1259:28 | call to source | array_flow.rb:1261:10:1261:10 | b | $@ | array_flow.rb:1259:16:1259:28 | call to source | call to source |
-| array_flow.rb:1265:10:1265:13 | ...[...] | array_flow.rb:1259:34:1259:46 | call to source | array_flow.rb:1265:10:1265:13 | ...[...] | $@ | array_flow.rb:1259:34:1259:46 | call to source | call to source |
-| array_flow.rb:1269:10:1269:13 | ...[...] | array_flow.rb:1267:16:1267:28 | call to source | array_flow.rb:1269:10:1269:13 | ...[...] | $@ | array_flow.rb:1267:16:1267:28 | call to source | call to source |
-| array_flow.rb:1269:10:1269:13 | ...[...] | array_flow.rb:1267:34:1267:46 | call to source | array_flow.rb:1269:10:1269:13 | ...[...] | $@ | array_flow.rb:1267:34:1267:46 | call to source | call to source |
-| array_flow.rb:1270:10:1270:13 | ...[...] | array_flow.rb:1267:16:1267:28 | call to source | array_flow.rb:1270:10:1270:13 | ...[...] | $@ | array_flow.rb:1267:16:1267:28 | call to source | call to source |
-| array_flow.rb:1270:10:1270:13 | ...[...] | array_flow.rb:1267:34:1267:46 | call to source | array_flow.rb:1270:10:1270:13 | ...[...] | $@ | array_flow.rb:1267:34:1267:46 | call to source | call to source |
-| array_flow.rb:1271:10:1271:13 | ...[...] | array_flow.rb:1267:16:1267:28 | call to source | array_flow.rb:1271:10:1271:13 | ...[...] | $@ | array_flow.rb:1267:16:1267:28 | call to source | call to source |
-| array_flow.rb:1271:10:1271:13 | ...[...] | array_flow.rb:1267:34:1267:46 | call to source | array_flow.rb:1271:10:1271:13 | ...[...] | $@ | array_flow.rb:1267:34:1267:46 | call to source | call to source |
-| array_flow.rb:1272:10:1272:13 | ...[...] | array_flow.rb:1267:16:1267:28 | call to source | array_flow.rb:1272:10:1272:13 | ...[...] | $@ | array_flow.rb:1267:16:1267:28 | call to source | call to source |
-| array_flow.rb:1272:10:1272:13 | ...[...] | array_flow.rb:1267:34:1267:46 | call to source | array_flow.rb:1272:10:1272:13 | ...[...] | $@ | array_flow.rb:1267:34:1267:46 | call to source | call to source |
-| array_flow.rb:1274:10:1274:10 | b | array_flow.rb:1267:16:1267:28 | call to source | array_flow.rb:1274:10:1274:10 | b | $@ | array_flow.rb:1267:16:1267:28 | call to source | call to source |
-| array_flow.rb:1274:10:1274:10 | b | array_flow.rb:1267:34:1267:46 | call to source | array_flow.rb:1274:10:1274:10 | b | $@ | array_flow.rb:1267:34:1267:46 | call to source | call to source |
-| array_flow.rb:1276:10:1276:13 | ...[...] | array_flow.rb:1267:16:1267:28 | call to source | array_flow.rb:1276:10:1276:13 | ...[...] | $@ | array_flow.rb:1267:16:1267:28 | call to source | call to source |
-| array_flow.rb:1276:10:1276:13 | ...[...] | array_flow.rb:1267:34:1267:46 | call to source | array_flow.rb:1276:10:1276:13 | ...[...] | $@ | array_flow.rb:1267:34:1267:46 | call to source | call to source |
-| array_flow.rb:1280:10:1280:13 | ...[...] | array_flow.rb:1278:16:1278:28 | call to source | array_flow.rb:1280:10:1280:13 | ...[...] | $@ | array_flow.rb:1278:16:1278:28 | call to source | call to source |
-| array_flow.rb:1282:10:1282:13 | ...[...] | array_flow.rb:1278:34:1278:46 | call to source | array_flow.rb:1282:10:1282:13 | ...[...] | $@ | array_flow.rb:1278:34:1278:46 | call to source | call to source |
-| array_flow.rb:1291:10:1291:13 | ...[...] | array_flow.rb:1289:16:1289:28 | call to source | array_flow.rb:1291:10:1291:13 | ...[...] | $@ | array_flow.rb:1289:16:1289:28 | call to source | call to source |
-| array_flow.rb:1296:10:1296:13 | ...[...] | array_flow.rb:1289:34:1289:46 | call to source | array_flow.rb:1296:10:1296:13 | ...[...] | $@ | array_flow.rb:1289:34:1289:46 | call to source | call to source |
-| array_flow.rb:1302:10:1302:13 | ...[...] | array_flow.rb:1300:16:1300:28 | call to source | array_flow.rb:1302:10:1302:13 | ...[...] | $@ | array_flow.rb:1300:16:1300:28 | call to source | call to source |
-| array_flow.rb:1307:10:1307:13 | ...[...] | array_flow.rb:1300:34:1300:46 | call to source | array_flow.rb:1307:10:1307:13 | ...[...] | $@ | array_flow.rb:1300:34:1300:46 | call to source | call to source |
-| array_flow.rb:1313:10:1313:13 | ...[...] | array_flow.rb:1311:16:1311:28 | call to source | array_flow.rb:1313:10:1313:13 | ...[...] | $@ | array_flow.rb:1311:16:1311:28 | call to source | call to source |
-| array_flow.rb:1313:10:1313:13 | ...[...] | array_flow.rb:1311:34:1311:46 | call to source | array_flow.rb:1313:10:1313:13 | ...[...] | $@ | array_flow.rb:1311:34:1311:46 | call to source | call to source |
-| array_flow.rb:1314:10:1314:13 | ...[...] | array_flow.rb:1311:16:1311:28 | call to source | array_flow.rb:1314:10:1314:13 | ...[...] | $@ | array_flow.rb:1311:16:1311:28 | call to source | call to source |
-| array_flow.rb:1314:10:1314:13 | ...[...] | array_flow.rb:1311:34:1311:46 | call to source | array_flow.rb:1314:10:1314:13 | ...[...] | $@ | array_flow.rb:1311:34:1311:46 | call to source | call to source |
-| array_flow.rb:1315:10:1315:13 | ...[...] | array_flow.rb:1311:16:1311:28 | call to source | array_flow.rb:1315:10:1315:13 | ...[...] | $@ | array_flow.rb:1311:16:1311:28 | call to source | call to source |
-| array_flow.rb:1315:10:1315:13 | ...[...] | array_flow.rb:1311:34:1311:46 | call to source | array_flow.rb:1315:10:1315:13 | ...[...] | $@ | array_flow.rb:1311:34:1311:46 | call to source | call to source |
-| array_flow.rb:1316:10:1316:13 | ...[...] | array_flow.rb:1311:16:1311:28 | call to source | array_flow.rb:1316:10:1316:13 | ...[...] | $@ | array_flow.rb:1311:16:1311:28 | call to source | call to source |
-| array_flow.rb:1316:10:1316:13 | ...[...] | array_flow.rb:1311:34:1311:46 | call to source | array_flow.rb:1316:10:1316:13 | ...[...] | $@ | array_flow.rb:1311:34:1311:46 | call to source | call to source |
-| array_flow.rb:1317:10:1317:13 | ...[...] | array_flow.rb:1311:16:1311:28 | call to source | array_flow.rb:1317:10:1317:13 | ...[...] | $@ | array_flow.rb:1311:16:1311:28 | call to source | call to source |
-| array_flow.rb:1317:10:1317:13 | ...[...] | array_flow.rb:1311:34:1311:46 | call to source | array_flow.rb:1317:10:1317:13 | ...[...] | $@ | array_flow.rb:1311:34:1311:46 | call to source | call to source |
-| array_flow.rb:1318:10:1318:13 | ...[...] | array_flow.rb:1311:16:1311:28 | call to source | array_flow.rb:1318:10:1318:13 | ...[...] | $@ | array_flow.rb:1311:16:1311:28 | call to source | call to source |
-| array_flow.rb:1318:10:1318:13 | ...[...] | array_flow.rb:1311:34:1311:46 | call to source | array_flow.rb:1318:10:1318:13 | ...[...] | $@ | array_flow.rb:1311:34:1311:46 | call to source | call to source |
-| array_flow.rb:1322:10:1322:13 | ...[...] | array_flow.rb:1320:16:1320:28 | call to source | array_flow.rb:1322:10:1322:13 | ...[...] | $@ | array_flow.rb:1320:16:1320:28 | call to source | call to source |
-| array_flow.rb:1322:10:1322:13 | ...[...] | array_flow.rb:1320:34:1320:46 | call to source | array_flow.rb:1322:10:1322:13 | ...[...] | $@ | array_flow.rb:1320:34:1320:46 | call to source | call to source |
-| array_flow.rb:1323:10:1323:13 | ...[...] | array_flow.rb:1320:16:1320:28 | call to source | array_flow.rb:1323:10:1323:13 | ...[...] | $@ | array_flow.rb:1320:16:1320:28 | call to source | call to source |
-| array_flow.rb:1323:10:1323:13 | ...[...] | array_flow.rb:1320:34:1320:46 | call to source | array_flow.rb:1323:10:1323:13 | ...[...] | $@ | array_flow.rb:1320:34:1320:46 | call to source | call to source |
-| array_flow.rb:1324:10:1324:13 | ...[...] | array_flow.rb:1320:16:1320:28 | call to source | array_flow.rb:1324:10:1324:13 | ...[...] | $@ | array_flow.rb:1320:16:1320:28 | call to source | call to source |
-| array_flow.rb:1324:10:1324:13 | ...[...] | array_flow.rb:1320:34:1320:46 | call to source | array_flow.rb:1324:10:1324:13 | ...[...] | $@ | array_flow.rb:1320:34:1320:46 | call to source | call to source |
-| array_flow.rb:1325:10:1325:13 | ...[...] | array_flow.rb:1320:16:1320:28 | call to source | array_flow.rb:1325:10:1325:13 | ...[...] | $@ | array_flow.rb:1320:16:1320:28 | call to source | call to source |
-| array_flow.rb:1325:10:1325:13 | ...[...] | array_flow.rb:1320:34:1320:46 | call to source | array_flow.rb:1325:10:1325:13 | ...[...] | $@ | array_flow.rb:1320:34:1320:46 | call to source | call to source |
-| array_flow.rb:1326:10:1326:13 | ...[...] | array_flow.rb:1320:16:1320:28 | call to source | array_flow.rb:1326:10:1326:13 | ...[...] | $@ | array_flow.rb:1320:16:1320:28 | call to source | call to source |
-| array_flow.rb:1326:10:1326:13 | ...[...] | array_flow.rb:1320:34:1320:46 | call to source | array_flow.rb:1326:10:1326:13 | ...[...] | $@ | array_flow.rb:1320:34:1320:46 | call to source | call to source |
-| array_flow.rb:1327:10:1327:13 | ...[...] | array_flow.rb:1320:16:1320:28 | call to source | array_flow.rb:1327:10:1327:13 | ...[...] | $@ | array_flow.rb:1320:16:1320:28 | call to source | call to source |
-| array_flow.rb:1327:10:1327:13 | ...[...] | array_flow.rb:1320:34:1320:46 | call to source | array_flow.rb:1327:10:1327:13 | ...[...] | $@ | array_flow.rb:1320:34:1320:46 | call to source | call to source |
-| array_flow.rb:1331:10:1331:13 | ...[...] | array_flow.rb:1329:16:1329:28 | call to source | array_flow.rb:1331:10:1331:13 | ...[...] | $@ | array_flow.rb:1329:16:1329:28 | call to source | call to source |
-| array_flow.rb:1331:10:1331:13 | ...[...] | array_flow.rb:1329:34:1329:46 | call to source | array_flow.rb:1331:10:1331:13 | ...[...] | $@ | array_flow.rb:1329:34:1329:46 | call to source | call to source |
-| array_flow.rb:1332:10:1332:13 | ...[...] | array_flow.rb:1329:16:1329:28 | call to source | array_flow.rb:1332:10:1332:13 | ...[...] | $@ | array_flow.rb:1329:16:1329:28 | call to source | call to source |
-| array_flow.rb:1332:10:1332:13 | ...[...] | array_flow.rb:1329:34:1329:46 | call to source | array_flow.rb:1332:10:1332:13 | ...[...] | $@ | array_flow.rb:1329:34:1329:46 | call to source | call to source |
-| array_flow.rb:1333:10:1333:13 | ...[...] | array_flow.rb:1329:16:1329:28 | call to source | array_flow.rb:1333:10:1333:13 | ...[...] | $@ | array_flow.rb:1329:16:1329:28 | call to source | call to source |
-| array_flow.rb:1333:10:1333:13 | ...[...] | array_flow.rb:1329:34:1329:46 | call to source | array_flow.rb:1333:10:1333:13 | ...[...] | $@ | array_flow.rb:1329:34:1329:46 | call to source | call to source |
-| array_flow.rb:1334:10:1334:13 | ...[...] | array_flow.rb:1329:16:1329:28 | call to source | array_flow.rb:1334:10:1334:13 | ...[...] | $@ | array_flow.rb:1329:16:1329:28 | call to source | call to source |
-| array_flow.rb:1334:10:1334:13 | ...[...] | array_flow.rb:1329:34:1329:46 | call to source | array_flow.rb:1334:10:1334:13 | ...[...] | $@ | array_flow.rb:1329:34:1329:46 | call to source | call to source |
-| array_flow.rb:1335:10:1335:13 | ...[...] | array_flow.rb:1329:16:1329:28 | call to source | array_flow.rb:1335:10:1335:13 | ...[...] | $@ | array_flow.rb:1329:16:1329:28 | call to source | call to source |
-| array_flow.rb:1335:10:1335:13 | ...[...] | array_flow.rb:1329:34:1329:46 | call to source | array_flow.rb:1335:10:1335:13 | ...[...] | $@ | array_flow.rb:1329:34:1329:46 | call to source | call to source |
-| array_flow.rb:1336:10:1336:13 | ...[...] | array_flow.rb:1329:16:1329:28 | call to source | array_flow.rb:1336:10:1336:13 | ...[...] | $@ | array_flow.rb:1329:16:1329:28 | call to source | call to source |
-| array_flow.rb:1336:10:1336:13 | ...[...] | array_flow.rb:1329:34:1329:46 | call to source | array_flow.rb:1336:10:1336:13 | ...[...] | $@ | array_flow.rb:1329:34:1329:46 | call to source | call to source |
-| array_flow.rb:1342:10:1342:13 | ...[...] | array_flow.rb:1338:16:1338:28 | call to source | array_flow.rb:1342:10:1342:13 | ...[...] | $@ | array_flow.rb:1338:16:1338:28 | call to source | call to source |
-| array_flow.rb:1344:10:1344:13 | ...[...] | array_flow.rb:1338:34:1338:46 | call to source | array_flow.rb:1344:10:1344:13 | ...[...] | $@ | array_flow.rb:1338:34:1338:46 | call to source | call to source |
-| array_flow.rb:1349:10:1349:13 | ...[...] | array_flow.rb:1347:16:1347:28 | call to source | array_flow.rb:1349:10:1349:13 | ...[...] | $@ | array_flow.rb:1347:16:1347:28 | call to source | call to source |
-| array_flow.rb:1349:10:1349:13 | ...[...] | array_flow.rb:1347:34:1347:46 | call to source | array_flow.rb:1349:10:1349:13 | ...[...] | $@ | array_flow.rb:1347:34:1347:46 | call to source | call to source |
-| array_flow.rb:1350:10:1350:13 | ...[...] | array_flow.rb:1347:16:1347:28 | call to source | array_flow.rb:1350:10:1350:13 | ...[...] | $@ | array_flow.rb:1347:16:1347:28 | call to source | call to source |
-| array_flow.rb:1350:10:1350:13 | ...[...] | array_flow.rb:1347:34:1347:46 | call to source | array_flow.rb:1350:10:1350:13 | ...[...] | $@ | array_flow.rb:1347:34:1347:46 | call to source | call to source |
-| array_flow.rb:1351:10:1351:13 | ...[...] | array_flow.rb:1347:16:1347:28 | call to source | array_flow.rb:1351:10:1351:13 | ...[...] | $@ | array_flow.rb:1347:16:1347:28 | call to source | call to source |
-| array_flow.rb:1351:10:1351:13 | ...[...] | array_flow.rb:1347:34:1347:46 | call to source | array_flow.rb:1351:10:1351:13 | ...[...] | $@ | array_flow.rb:1347:34:1347:46 | call to source | call to source |
-| array_flow.rb:1352:10:1352:13 | ...[...] | array_flow.rb:1347:16:1347:28 | call to source | array_flow.rb:1352:10:1352:13 | ...[...] | $@ | array_flow.rb:1347:16:1347:28 | call to source | call to source |
-| array_flow.rb:1352:10:1352:13 | ...[...] | array_flow.rb:1347:34:1347:46 | call to source | array_flow.rb:1352:10:1352:13 | ...[...] | $@ | array_flow.rb:1347:34:1347:46 | call to source | call to source |
-| array_flow.rb:1353:10:1353:13 | ...[...] | array_flow.rb:1347:16:1347:28 | call to source | array_flow.rb:1353:10:1353:13 | ...[...] | $@ | array_flow.rb:1347:16:1347:28 | call to source | call to source |
-| array_flow.rb:1353:10:1353:13 | ...[...] | array_flow.rb:1347:34:1347:46 | call to source | array_flow.rb:1353:10:1353:13 | ...[...] | $@ | array_flow.rb:1347:34:1347:46 | call to source | call to source |
-| array_flow.rb:1354:10:1354:13 | ...[...] | array_flow.rb:1347:16:1347:28 | call to source | array_flow.rb:1354:10:1354:13 | ...[...] | $@ | array_flow.rb:1347:16:1347:28 | call to source | call to source |
-| array_flow.rb:1354:10:1354:13 | ...[...] | array_flow.rb:1347:34:1347:46 | call to source | array_flow.rb:1354:10:1354:13 | ...[...] | $@ | array_flow.rb:1347:34:1347:46 | call to source | call to source |
-| array_flow.rb:1360:14:1360:14 | x | array_flow.rb:1358:16:1358:26 | call to source | array_flow.rb:1360:14:1360:14 | x | $@ | array_flow.rb:1358:16:1358:26 | call to source | call to source |
-| array_flow.rb:1368:14:1368:14 | x | array_flow.rb:1366:16:1366:26 | call to source | array_flow.rb:1368:14:1368:14 | x | $@ | array_flow.rb:1366:16:1366:26 | call to source | call to source |
-| array_flow.rb:1376:14:1376:14 | x | array_flow.rb:1374:16:1374:26 | call to source | array_flow.rb:1376:14:1376:14 | x | $@ | array_flow.rb:1374:16:1374:26 | call to source | call to source |
-| array_flow.rb:1377:14:1377:14 | y | array_flow.rb:1374:16:1374:26 | call to source | array_flow.rb:1377:14:1377:14 | y | $@ | array_flow.rb:1374:16:1374:26 | call to source | call to source |
-| array_flow.rb:1384:10:1384:13 | ...[...] | array_flow.rb:1382:16:1382:26 | call to source | array_flow.rb:1384:10:1384:13 | ...[...] | $@ | array_flow.rb:1382:16:1382:26 | call to source | call to source |
-| array_flow.rb:1385:10:1385:13 | ...[...] | array_flow.rb:1382:16:1382:26 | call to source | array_flow.rb:1385:10:1385:13 | ...[...] | $@ | array_flow.rb:1382:16:1382:26 | call to source | call to source |
-| array_flow.rb:1387:14:1387:14 | x | array_flow.rb:1382:16:1382:26 | call to source | array_flow.rb:1387:14:1387:14 | x | $@ | array_flow.rb:1382:16:1382:26 | call to source | call to source |
-| array_flow.rb:1388:14:1388:14 | y | array_flow.rb:1382:16:1382:26 | call to source | array_flow.rb:1388:14:1388:14 | y | $@ | array_flow.rb:1382:16:1382:26 | call to source | call to source |
-| array_flow.rb:1391:10:1391:13 | ...[...] | array_flow.rb:1382:16:1382:26 | call to source | array_flow.rb:1391:10:1391:13 | ...[...] | $@ | array_flow.rb:1382:16:1382:26 | call to source | call to source |
-| array_flow.rb:1392:10:1392:13 | ...[...] | array_flow.rb:1382:16:1382:26 | call to source | array_flow.rb:1392:10:1392:13 | ...[...] | $@ | array_flow.rb:1382:16:1382:26 | call to source | call to source |
-| array_flow.rb:1398:10:1398:13 | ...[...] | array_flow.rb:1396:16:1396:26 | call to source | array_flow.rb:1398:10:1398:13 | ...[...] | $@ | array_flow.rb:1396:16:1396:26 | call to source | call to source |
-| array_flow.rb:1399:10:1399:13 | ...[...] | array_flow.rb:1396:16:1396:26 | call to source | array_flow.rb:1399:10:1399:13 | ...[...] | $@ | array_flow.rb:1396:16:1396:26 | call to source | call to source |
-| array_flow.rb:1400:10:1400:13 | ...[...] | array_flow.rb:1396:16:1396:26 | call to source | array_flow.rb:1400:10:1400:13 | ...[...] | $@ | array_flow.rb:1396:16:1396:26 | call to source | call to source |
-| array_flow.rb:1401:10:1401:13 | ...[...] | array_flow.rb:1396:16:1396:26 | call to source | array_flow.rb:1401:10:1401:13 | ...[...] | $@ | array_flow.rb:1396:16:1396:26 | call to source | call to source |
-| array_flow.rb:1405:14:1405:14 | x | array_flow.rb:1403:16:1403:26 | call to source | array_flow.rb:1405:14:1405:14 | x | $@ | array_flow.rb:1403:16:1403:26 | call to source | call to source |
-| array_flow.rb:1406:14:1406:14 | y | array_flow.rb:1403:16:1403:26 | call to source | array_flow.rb:1406:14:1406:14 | y | $@ | array_flow.rb:1403:16:1403:26 | call to source | call to source |
-| array_flow.rb:1409:10:1409:13 | ...[...] | array_flow.rb:1403:16:1403:26 | call to source | array_flow.rb:1409:10:1409:13 | ...[...] | $@ | array_flow.rb:1403:16:1403:26 | call to source | call to source |
-| array_flow.rb:1410:10:1410:13 | ...[...] | array_flow.rb:1403:16:1403:26 | call to source | array_flow.rb:1410:10:1410:13 | ...[...] | $@ | array_flow.rb:1403:16:1403:26 | call to source | call to source |
-| array_flow.rb:1411:10:1411:13 | ...[...] | array_flow.rb:1403:16:1403:26 | call to source | array_flow.rb:1411:10:1411:13 | ...[...] | $@ | array_flow.rb:1403:16:1403:26 | call to source | call to source |
-| array_flow.rb:1412:10:1412:13 | ...[...] | array_flow.rb:1403:16:1403:26 | call to source | array_flow.rb:1412:10:1412:13 | ...[...] | $@ | array_flow.rb:1403:16:1403:26 | call to source | call to source |
-| array_flow.rb:1418:14:1418:14 | x | array_flow.rb:1416:16:1416:26 | call to source | array_flow.rb:1418:14:1418:14 | x | $@ | array_flow.rb:1416:16:1416:26 | call to source | call to source |
-| array_flow.rb:1421:10:1421:13 | ...[...] | array_flow.rb:1416:16:1416:26 | call to source | array_flow.rb:1421:10:1421:13 | ...[...] | $@ | array_flow.rb:1416:16:1416:26 | call to source | call to source |
-| array_flow.rb:1422:10:1422:13 | ...[...] | array_flow.rb:1416:16:1416:26 | call to source | array_flow.rb:1422:10:1422:13 | ...[...] | $@ | array_flow.rb:1416:16:1416:26 | call to source | call to source |
-| array_flow.rb:1428:14:1428:14 | x | array_flow.rb:1426:16:1426:26 | call to source | array_flow.rb:1428:14:1428:14 | x | $@ | array_flow.rb:1426:16:1426:26 | call to source | call to source |
-| array_flow.rb:1431:10:1431:13 | ...[...] | array_flow.rb:1426:16:1426:26 | call to source | array_flow.rb:1431:10:1431:13 | ...[...] | $@ | array_flow.rb:1426:16:1426:26 | call to source | call to source |
-| array_flow.rb:1432:10:1432:13 | ...[...] | array_flow.rb:1426:16:1426:26 | call to source | array_flow.rb:1432:10:1432:13 | ...[...] | $@ | array_flow.rb:1426:16:1426:26 | call to source | call to source |
-| array_flow.rb:1433:10:1433:13 | ...[...] | array_flow.rb:1426:16:1426:26 | call to source | array_flow.rb:1433:10:1433:13 | ...[...] | $@ | array_flow.rb:1426:16:1426:26 | call to source | call to source |
-| array_flow.rb:1434:10:1434:13 | ...[...] | array_flow.rb:1426:16:1426:26 | call to source | array_flow.rb:1434:10:1434:13 | ...[...] | $@ | array_flow.rb:1426:16:1426:26 | call to source | call to source |
-| array_flow.rb:1440:14:1440:14 | x | array_flow.rb:1438:16:1438:26 | call to source | array_flow.rb:1440:14:1440:14 | x | $@ | array_flow.rb:1438:16:1438:26 | call to source | call to source |
-| array_flow.rb:1450:10:1450:13 | ...[...] | array_flow.rb:1446:16:1446:28 | call to source | array_flow.rb:1450:10:1450:13 | ...[...] | $@ | array_flow.rb:1446:16:1446:28 | call to source | call to source |
-| array_flow.rb:1451:10:1451:13 | ...[...] | array_flow.rb:1446:31:1446:43 | call to source | array_flow.rb:1451:10:1451:13 | ...[...] | $@ | array_flow.rb:1446:31:1446:43 | call to source | call to source |
-| array_flow.rb:1455:10:1455:13 | ...[...] | array_flow.rb:1446:16:1446:28 | call to source | array_flow.rb:1455:10:1455:13 | ...[...] | $@ | array_flow.rb:1446:16:1446:28 | call to source | call to source |
-| array_flow.rb:1457:10:1457:13 | ...[...] | array_flow.rb:1446:16:1446:28 | call to source | array_flow.rb:1457:10:1457:13 | ...[...] | $@ | array_flow.rb:1446:16:1446:28 | call to source | call to source |
-| array_flow.rb:1461:10:1461:13 | ...[...] | array_flow.rb:1446:16:1446:28 | call to source | array_flow.rb:1461:10:1461:13 | ...[...] | $@ | array_flow.rb:1446:16:1446:28 | call to source | call to source |
-| array_flow.rb:1462:10:1462:13 | ...[...] | array_flow.rb:1446:31:1446:43 | call to source | array_flow.rb:1462:10:1462:13 | ...[...] | $@ | array_flow.rb:1446:31:1446:43 | call to source | call to source |
-| array_flow.rb:1463:10:1463:13 | ...[...] | array_flow.rb:1446:16:1446:28 | call to source | array_flow.rb:1463:10:1463:13 | ...[...] | $@ | array_flow.rb:1446:16:1446:28 | call to source | call to source |
-| array_flow.rb:1463:10:1463:13 | ...[...] | array_flow.rb:1446:31:1446:43 | call to source | array_flow.rb:1463:10:1463:13 | ...[...] | $@ | array_flow.rb:1446:31:1446:43 | call to source | call to source |
-| array_flow.rb:1466:10:1466:13 | ...[...] | array_flow.rb:1446:16:1446:28 | call to source | array_flow.rb:1466:10:1466:13 | ...[...] | $@ | array_flow.rb:1446:16:1446:28 | call to source | call to source |
-| array_flow.rb:1466:10:1466:13 | ...[...] | array_flow.rb:1464:12:1464:24 | call to source | array_flow.rb:1466:10:1466:13 | ...[...] | $@ | array_flow.rb:1464:12:1464:24 | call to source | call to source |
-| array_flow.rb:1472:14:1472:14 | x | array_flow.rb:1470:16:1470:26 | call to source | array_flow.rb:1472:14:1472:14 | x | $@ | array_flow.rb:1470:16:1470:26 | call to source | call to source |
-| array_flow.rb:1477:10:1477:13 | ...[...] | array_flow.rb:1470:16:1470:26 | call to source | array_flow.rb:1477:10:1477:13 | ...[...] | $@ | array_flow.rb:1470:16:1470:26 | call to source | call to source |
-| array_flow.rb:1485:10:1485:13 | ...[...] | array_flow.rb:1483:19:1483:29 | call to source | array_flow.rb:1485:10:1485:13 | ...[...] | $@ | array_flow.rb:1483:19:1483:29 | call to source | call to source |
-| array_flow.rb:1493:10:1493:13 | ...[...] | array_flow.rb:1489:16:1489:26 | call to source | array_flow.rb:1493:10:1493:13 | ...[...] | $@ | array_flow.rb:1489:16:1489:26 | call to source | call to source |
-| array_flow.rb:1511:10:1511:16 | ...[...] | array_flow.rb:1506:14:1506:26 | call to source | array_flow.rb:1511:10:1511:16 | ...[...] | $@ | array_flow.rb:1506:14:1506:26 | call to source | call to source |
-| array_flow.rb:1512:10:1512:16 | ...[...] | array_flow.rb:1506:34:1506:46 | call to source | array_flow.rb:1512:10:1512:16 | ...[...] | $@ | array_flow.rb:1506:34:1506:46 | call to source | call to source |
-| array_flow.rb:1513:10:1513:16 | ...[...] | array_flow.rb:1506:54:1506:66 | call to source | array_flow.rb:1513:10:1513:16 | ...[...] | $@ | array_flow.rb:1506:54:1506:66 | call to source | call to source |
-| array_flow.rb:1521:10:1521:13 | ...[...] | array_flow.rb:1517:16:1517:28 | call to source | array_flow.rb:1521:10:1521:13 | ...[...] | $@ | array_flow.rb:1517:16:1517:28 | call to source | call to source |
-| array_flow.rb:1521:10:1521:13 | ...[...] | array_flow.rb:1518:13:1518:25 | call to source | array_flow.rb:1521:10:1521:13 | ...[...] | $@ | array_flow.rb:1518:13:1518:25 | call to source | call to source |
-| array_flow.rb:1521:10:1521:13 | ...[...] | array_flow.rb:1519:13:1519:25 | call to source | array_flow.rb:1521:10:1521:13 | ...[...] | $@ | array_flow.rb:1519:13:1519:25 | call to source | call to source |
-| array_flow.rb:1522:10:1522:13 | ...[...] | array_flow.rb:1517:16:1517:28 | call to source | array_flow.rb:1522:10:1522:13 | ...[...] | $@ | array_flow.rb:1517:16:1517:28 | call to source | call to source |
-| array_flow.rb:1522:10:1522:13 | ...[...] | array_flow.rb:1518:13:1518:25 | call to source | array_flow.rb:1522:10:1522:13 | ...[...] | $@ | array_flow.rb:1518:13:1518:25 | call to source | call to source |
+| array_flow.rb:1256:10:1256:13 | ...[...] | array_flow.rb:1206:16:1206:28 | call to source | array_flow.rb:1256:10:1256:13 | ...[...] | $@ | array_flow.rb:1206:16:1206:28 | call to source | call to source |
+| array_flow.rb:1256:10:1256:13 | ...[...] | array_flow.rb:1206:34:1206:46 | call to source | array_flow.rb:1256:10:1256:13 | ...[...] | $@ | array_flow.rb:1206:34:1206:46 | call to source | call to source |
+| array_flow.rb:1262:10:1262:10 | b | array_flow.rb:1260:16:1260:28 | call to source | array_flow.rb:1262:10:1262:10 | b | $@ | array_flow.rb:1260:16:1260:28 | call to source | call to source |
+| array_flow.rb:1266:10:1266:13 | ...[...] | array_flow.rb:1260:34:1260:46 | call to source | array_flow.rb:1266:10:1266:13 | ...[...] | $@ | array_flow.rb:1260:34:1260:46 | call to source | call to source |
+| array_flow.rb:1270:10:1270:13 | ...[...] | array_flow.rb:1268:16:1268:28 | call to source | array_flow.rb:1270:10:1270:13 | ...[...] | $@ | array_flow.rb:1268:16:1268:28 | call to source | call to source |
+| array_flow.rb:1270:10:1270:13 | ...[...] | array_flow.rb:1268:34:1268:46 | call to source | array_flow.rb:1270:10:1270:13 | ...[...] | $@ | array_flow.rb:1268:34:1268:46 | call to source | call to source |
+| array_flow.rb:1271:10:1271:13 | ...[...] | array_flow.rb:1268:16:1268:28 | call to source | array_flow.rb:1271:10:1271:13 | ...[...] | $@ | array_flow.rb:1268:16:1268:28 | call to source | call to source |
+| array_flow.rb:1271:10:1271:13 | ...[...] | array_flow.rb:1268:34:1268:46 | call to source | array_flow.rb:1271:10:1271:13 | ...[...] | $@ | array_flow.rb:1268:34:1268:46 | call to source | call to source |
+| array_flow.rb:1272:10:1272:13 | ...[...] | array_flow.rb:1268:16:1268:28 | call to source | array_flow.rb:1272:10:1272:13 | ...[...] | $@ | array_flow.rb:1268:16:1268:28 | call to source | call to source |
+| array_flow.rb:1272:10:1272:13 | ...[...] | array_flow.rb:1268:34:1268:46 | call to source | array_flow.rb:1272:10:1272:13 | ...[...] | $@ | array_flow.rb:1268:34:1268:46 | call to source | call to source |
+| array_flow.rb:1273:10:1273:13 | ...[...] | array_flow.rb:1268:16:1268:28 | call to source | array_flow.rb:1273:10:1273:13 | ...[...] | $@ | array_flow.rb:1268:16:1268:28 | call to source | call to source |
+| array_flow.rb:1273:10:1273:13 | ...[...] | array_flow.rb:1268:34:1268:46 | call to source | array_flow.rb:1273:10:1273:13 | ...[...] | $@ | array_flow.rb:1268:34:1268:46 | call to source | call to source |
+| array_flow.rb:1275:10:1275:10 | b | array_flow.rb:1268:16:1268:28 | call to source | array_flow.rb:1275:10:1275:10 | b | $@ | array_flow.rb:1268:16:1268:28 | call to source | call to source |
+| array_flow.rb:1275:10:1275:10 | b | array_flow.rb:1268:34:1268:46 | call to source | array_flow.rb:1275:10:1275:10 | b | $@ | array_flow.rb:1268:34:1268:46 | call to source | call to source |
+| array_flow.rb:1277:10:1277:13 | ...[...] | array_flow.rb:1268:16:1268:28 | call to source | array_flow.rb:1277:10:1277:13 | ...[...] | $@ | array_flow.rb:1268:16:1268:28 | call to source | call to source |
+| array_flow.rb:1277:10:1277:13 | ...[...] | array_flow.rb:1268:34:1268:46 | call to source | array_flow.rb:1277:10:1277:13 | ...[...] | $@ | array_flow.rb:1268:34:1268:46 | call to source | call to source |
+| array_flow.rb:1281:10:1281:13 | ...[...] | array_flow.rb:1279:16:1279:28 | call to source | array_flow.rb:1281:10:1281:13 | ...[...] | $@ | array_flow.rb:1279:16:1279:28 | call to source | call to source |
+| array_flow.rb:1283:10:1283:13 | ...[...] | array_flow.rb:1279:34:1279:46 | call to source | array_flow.rb:1283:10:1283:13 | ...[...] | $@ | array_flow.rb:1279:34:1279:46 | call to source | call to source |
+| array_flow.rb:1292:10:1292:13 | ...[...] | array_flow.rb:1290:16:1290:28 | call to source | array_flow.rb:1292:10:1292:13 | ...[...] | $@ | array_flow.rb:1290:16:1290:28 | call to source | call to source |
+| array_flow.rb:1297:10:1297:13 | ...[...] | array_flow.rb:1290:34:1290:46 | call to source | array_flow.rb:1297:10:1297:13 | ...[...] | $@ | array_flow.rb:1290:34:1290:46 | call to source | call to source |
+| array_flow.rb:1303:10:1303:13 | ...[...] | array_flow.rb:1301:16:1301:28 | call to source | array_flow.rb:1303:10:1303:13 | ...[...] | $@ | array_flow.rb:1301:16:1301:28 | call to source | call to source |
+| array_flow.rb:1308:10:1308:13 | ...[...] | array_flow.rb:1301:34:1301:46 | call to source | array_flow.rb:1308:10:1308:13 | ...[...] | $@ | array_flow.rb:1301:34:1301:46 | call to source | call to source |
+| array_flow.rb:1314:10:1314:13 | ...[...] | array_flow.rb:1312:16:1312:28 | call to source | array_flow.rb:1314:10:1314:13 | ...[...] | $@ | array_flow.rb:1312:16:1312:28 | call to source | call to source |
+| array_flow.rb:1314:10:1314:13 | ...[...] | array_flow.rb:1312:34:1312:46 | call to source | array_flow.rb:1314:10:1314:13 | ...[...] | $@ | array_flow.rb:1312:34:1312:46 | call to source | call to source |
+| array_flow.rb:1315:10:1315:13 | ...[...] | array_flow.rb:1312:16:1312:28 | call to source | array_flow.rb:1315:10:1315:13 | ...[...] | $@ | array_flow.rb:1312:16:1312:28 | call to source | call to source |
+| array_flow.rb:1315:10:1315:13 | ...[...] | array_flow.rb:1312:34:1312:46 | call to source | array_flow.rb:1315:10:1315:13 | ...[...] | $@ | array_flow.rb:1312:34:1312:46 | call to source | call to source |
+| array_flow.rb:1316:10:1316:13 | ...[...] | array_flow.rb:1312:16:1312:28 | call to source | array_flow.rb:1316:10:1316:13 | ...[...] | $@ | array_flow.rb:1312:16:1312:28 | call to source | call to source |
+| array_flow.rb:1316:10:1316:13 | ...[...] | array_flow.rb:1312:34:1312:46 | call to source | array_flow.rb:1316:10:1316:13 | ...[...] | $@ | array_flow.rb:1312:34:1312:46 | call to source | call to source |
+| array_flow.rb:1317:10:1317:13 | ...[...] | array_flow.rb:1312:16:1312:28 | call to source | array_flow.rb:1317:10:1317:13 | ...[...] | $@ | array_flow.rb:1312:16:1312:28 | call to source | call to source |
+| array_flow.rb:1317:10:1317:13 | ...[...] | array_flow.rb:1312:34:1312:46 | call to source | array_flow.rb:1317:10:1317:13 | ...[...] | $@ | array_flow.rb:1312:34:1312:46 | call to source | call to source |
+| array_flow.rb:1318:10:1318:13 | ...[...] | array_flow.rb:1312:16:1312:28 | call to source | array_flow.rb:1318:10:1318:13 | ...[...] | $@ | array_flow.rb:1312:16:1312:28 | call to source | call to source |
+| array_flow.rb:1318:10:1318:13 | ...[...] | array_flow.rb:1312:34:1312:46 | call to source | array_flow.rb:1318:10:1318:13 | ...[...] | $@ | array_flow.rb:1312:34:1312:46 | call to source | call to source |
+| array_flow.rb:1319:10:1319:13 | ...[...] | array_flow.rb:1312:16:1312:28 | call to source | array_flow.rb:1319:10:1319:13 | ...[...] | $@ | array_flow.rb:1312:16:1312:28 | call to source | call to source |
+| array_flow.rb:1319:10:1319:13 | ...[...] | array_flow.rb:1312:34:1312:46 | call to source | array_flow.rb:1319:10:1319:13 | ...[...] | $@ | array_flow.rb:1312:34:1312:46 | call to source | call to source |
+| array_flow.rb:1323:10:1323:13 | ...[...] | array_flow.rb:1321:16:1321:28 | call to source | array_flow.rb:1323:10:1323:13 | ...[...] | $@ | array_flow.rb:1321:16:1321:28 | call to source | call to source |
+| array_flow.rb:1323:10:1323:13 | ...[...] | array_flow.rb:1321:34:1321:46 | call to source | array_flow.rb:1323:10:1323:13 | ...[...] | $@ | array_flow.rb:1321:34:1321:46 | call to source | call to source |
+| array_flow.rb:1324:10:1324:13 | ...[...] | array_flow.rb:1321:16:1321:28 | call to source | array_flow.rb:1324:10:1324:13 | ...[...] | $@ | array_flow.rb:1321:16:1321:28 | call to source | call to source |
+| array_flow.rb:1324:10:1324:13 | ...[...] | array_flow.rb:1321:34:1321:46 | call to source | array_flow.rb:1324:10:1324:13 | ...[...] | $@ | array_flow.rb:1321:34:1321:46 | call to source | call to source |
+| array_flow.rb:1325:10:1325:13 | ...[...] | array_flow.rb:1321:16:1321:28 | call to source | array_flow.rb:1325:10:1325:13 | ...[...] | $@ | array_flow.rb:1321:16:1321:28 | call to source | call to source |
+| array_flow.rb:1325:10:1325:13 | ...[...] | array_flow.rb:1321:34:1321:46 | call to source | array_flow.rb:1325:10:1325:13 | ...[...] | $@ | array_flow.rb:1321:34:1321:46 | call to source | call to source |
+| array_flow.rb:1326:10:1326:13 | ...[...] | array_flow.rb:1321:16:1321:28 | call to source | array_flow.rb:1326:10:1326:13 | ...[...] | $@ | array_flow.rb:1321:16:1321:28 | call to source | call to source |
+| array_flow.rb:1326:10:1326:13 | ...[...] | array_flow.rb:1321:34:1321:46 | call to source | array_flow.rb:1326:10:1326:13 | ...[...] | $@ | array_flow.rb:1321:34:1321:46 | call to source | call to source |
+| array_flow.rb:1327:10:1327:13 | ...[...] | array_flow.rb:1321:16:1321:28 | call to source | array_flow.rb:1327:10:1327:13 | ...[...] | $@ | array_flow.rb:1321:16:1321:28 | call to source | call to source |
+| array_flow.rb:1327:10:1327:13 | ...[...] | array_flow.rb:1321:34:1321:46 | call to source | array_flow.rb:1327:10:1327:13 | ...[...] | $@ | array_flow.rb:1321:34:1321:46 | call to source | call to source |
+| array_flow.rb:1328:10:1328:13 | ...[...] | array_flow.rb:1321:16:1321:28 | call to source | array_flow.rb:1328:10:1328:13 | ...[...] | $@ | array_flow.rb:1321:16:1321:28 | call to source | call to source |
+| array_flow.rb:1328:10:1328:13 | ...[...] | array_flow.rb:1321:34:1321:46 | call to source | array_flow.rb:1328:10:1328:13 | ...[...] | $@ | array_flow.rb:1321:34:1321:46 | call to source | call to source |
+| array_flow.rb:1332:10:1332:13 | ...[...] | array_flow.rb:1330:16:1330:28 | call to source | array_flow.rb:1332:10:1332:13 | ...[...] | $@ | array_flow.rb:1330:16:1330:28 | call to source | call to source |
+| array_flow.rb:1332:10:1332:13 | ...[...] | array_flow.rb:1330:34:1330:46 | call to source | array_flow.rb:1332:10:1332:13 | ...[...] | $@ | array_flow.rb:1330:34:1330:46 | call to source | call to source |
+| array_flow.rb:1333:10:1333:13 | ...[...] | array_flow.rb:1330:16:1330:28 | call to source | array_flow.rb:1333:10:1333:13 | ...[...] | $@ | array_flow.rb:1330:16:1330:28 | call to source | call to source |
+| array_flow.rb:1333:10:1333:13 | ...[...] | array_flow.rb:1330:34:1330:46 | call to source | array_flow.rb:1333:10:1333:13 | ...[...] | $@ | array_flow.rb:1330:34:1330:46 | call to source | call to source |
+| array_flow.rb:1334:10:1334:13 | ...[...] | array_flow.rb:1330:16:1330:28 | call to source | array_flow.rb:1334:10:1334:13 | ...[...] | $@ | array_flow.rb:1330:16:1330:28 | call to source | call to source |
+| array_flow.rb:1334:10:1334:13 | ...[...] | array_flow.rb:1330:34:1330:46 | call to source | array_flow.rb:1334:10:1334:13 | ...[...] | $@ | array_flow.rb:1330:34:1330:46 | call to source | call to source |
+| array_flow.rb:1335:10:1335:13 | ...[...] | array_flow.rb:1330:16:1330:28 | call to source | array_flow.rb:1335:10:1335:13 | ...[...] | $@ | array_flow.rb:1330:16:1330:28 | call to source | call to source |
+| array_flow.rb:1335:10:1335:13 | ...[...] | array_flow.rb:1330:34:1330:46 | call to source | array_flow.rb:1335:10:1335:13 | ...[...] | $@ | array_flow.rb:1330:34:1330:46 | call to source | call to source |
+| array_flow.rb:1336:10:1336:13 | ...[...] | array_flow.rb:1330:16:1330:28 | call to source | array_flow.rb:1336:10:1336:13 | ...[...] | $@ | array_flow.rb:1330:16:1330:28 | call to source | call to source |
+| array_flow.rb:1336:10:1336:13 | ...[...] | array_flow.rb:1330:34:1330:46 | call to source | array_flow.rb:1336:10:1336:13 | ...[...] | $@ | array_flow.rb:1330:34:1330:46 | call to source | call to source |
+| array_flow.rb:1337:10:1337:13 | ...[...] | array_flow.rb:1330:16:1330:28 | call to source | array_flow.rb:1337:10:1337:13 | ...[...] | $@ | array_flow.rb:1330:16:1330:28 | call to source | call to source |
+| array_flow.rb:1337:10:1337:13 | ...[...] | array_flow.rb:1330:34:1330:46 | call to source | array_flow.rb:1337:10:1337:13 | ...[...] | $@ | array_flow.rb:1330:34:1330:46 | call to source | call to source |
+| array_flow.rb:1343:10:1343:13 | ...[...] | array_flow.rb:1339:16:1339:28 | call to source | array_flow.rb:1343:10:1343:13 | ...[...] | $@ | array_flow.rb:1339:16:1339:28 | call to source | call to source |
+| array_flow.rb:1345:10:1345:13 | ...[...] | array_flow.rb:1339:34:1339:46 | call to source | array_flow.rb:1345:10:1345:13 | ...[...] | $@ | array_flow.rb:1339:34:1339:46 | call to source | call to source |
+| array_flow.rb:1350:10:1350:13 | ...[...] | array_flow.rb:1348:16:1348:28 | call to source | array_flow.rb:1350:10:1350:13 | ...[...] | $@ | array_flow.rb:1348:16:1348:28 | call to source | call to source |
+| array_flow.rb:1350:10:1350:13 | ...[...] | array_flow.rb:1348:34:1348:46 | call to source | array_flow.rb:1350:10:1350:13 | ...[...] | $@ | array_flow.rb:1348:34:1348:46 | call to source | call to source |
+| array_flow.rb:1351:10:1351:13 | ...[...] | array_flow.rb:1348:16:1348:28 | call to source | array_flow.rb:1351:10:1351:13 | ...[...] | $@ | array_flow.rb:1348:16:1348:28 | call to source | call to source |
+| array_flow.rb:1351:10:1351:13 | ...[...] | array_flow.rb:1348:34:1348:46 | call to source | array_flow.rb:1351:10:1351:13 | ...[...] | $@ | array_flow.rb:1348:34:1348:46 | call to source | call to source |
+| array_flow.rb:1352:10:1352:13 | ...[...] | array_flow.rb:1348:16:1348:28 | call to source | array_flow.rb:1352:10:1352:13 | ...[...] | $@ | array_flow.rb:1348:16:1348:28 | call to source | call to source |
+| array_flow.rb:1352:10:1352:13 | ...[...] | array_flow.rb:1348:34:1348:46 | call to source | array_flow.rb:1352:10:1352:13 | ...[...] | $@ | array_flow.rb:1348:34:1348:46 | call to source | call to source |
+| array_flow.rb:1353:10:1353:13 | ...[...] | array_flow.rb:1348:16:1348:28 | call to source | array_flow.rb:1353:10:1353:13 | ...[...] | $@ | array_flow.rb:1348:16:1348:28 | call to source | call to source |
+| array_flow.rb:1353:10:1353:13 | ...[...] | array_flow.rb:1348:34:1348:46 | call to source | array_flow.rb:1353:10:1353:13 | ...[...] | $@ | array_flow.rb:1348:34:1348:46 | call to source | call to source |
+| array_flow.rb:1354:10:1354:13 | ...[...] | array_flow.rb:1348:16:1348:28 | call to source | array_flow.rb:1354:10:1354:13 | ...[...] | $@ | array_flow.rb:1348:16:1348:28 | call to source | call to source |
+| array_flow.rb:1354:10:1354:13 | ...[...] | array_flow.rb:1348:34:1348:46 | call to source | array_flow.rb:1354:10:1354:13 | ...[...] | $@ | array_flow.rb:1348:34:1348:46 | call to source | call to source |
+| array_flow.rb:1355:10:1355:13 | ...[...] | array_flow.rb:1348:16:1348:28 | call to source | array_flow.rb:1355:10:1355:13 | ...[...] | $@ | array_flow.rb:1348:16:1348:28 | call to source | call to source |
+| array_flow.rb:1355:10:1355:13 | ...[...] | array_flow.rb:1348:34:1348:46 | call to source | array_flow.rb:1355:10:1355:13 | ...[...] | $@ | array_flow.rb:1348:34:1348:46 | call to source | call to source |
+| array_flow.rb:1361:14:1361:14 | x | array_flow.rb:1359:16:1359:26 | call to source | array_flow.rb:1361:14:1361:14 | x | $@ | array_flow.rb:1359:16:1359:26 | call to source | call to source |
+| array_flow.rb:1369:14:1369:14 | x | array_flow.rb:1367:16:1367:26 | call to source | array_flow.rb:1369:14:1369:14 | x | $@ | array_flow.rb:1367:16:1367:26 | call to source | call to source |
+| array_flow.rb:1377:14:1377:14 | x | array_flow.rb:1375:16:1375:26 | call to source | array_flow.rb:1377:14:1377:14 | x | $@ | array_flow.rb:1375:16:1375:26 | call to source | call to source |
+| array_flow.rb:1378:14:1378:14 | y | array_flow.rb:1375:16:1375:26 | call to source | array_flow.rb:1378:14:1378:14 | y | $@ | array_flow.rb:1375:16:1375:26 | call to source | call to source |
+| array_flow.rb:1385:10:1385:13 | ...[...] | array_flow.rb:1383:16:1383:26 | call to source | array_flow.rb:1385:10:1385:13 | ...[...] | $@ | array_flow.rb:1383:16:1383:26 | call to source | call to source |
+| array_flow.rb:1386:10:1386:13 | ...[...] | array_flow.rb:1383:16:1383:26 | call to source | array_flow.rb:1386:10:1386:13 | ...[...] | $@ | array_flow.rb:1383:16:1383:26 | call to source | call to source |
+| array_flow.rb:1388:14:1388:14 | x | array_flow.rb:1383:16:1383:26 | call to source | array_flow.rb:1388:14:1388:14 | x | $@ | array_flow.rb:1383:16:1383:26 | call to source | call to source |
+| array_flow.rb:1389:14:1389:14 | y | array_flow.rb:1383:16:1383:26 | call to source | array_flow.rb:1389:14:1389:14 | y | $@ | array_flow.rb:1383:16:1383:26 | call to source | call to source |
+| array_flow.rb:1392:10:1392:13 | ...[...] | array_flow.rb:1383:16:1383:26 | call to source | array_flow.rb:1392:10:1392:13 | ...[...] | $@ | array_flow.rb:1383:16:1383:26 | call to source | call to source |
+| array_flow.rb:1393:10:1393:13 | ...[...] | array_flow.rb:1383:16:1383:26 | call to source | array_flow.rb:1393:10:1393:13 | ...[...] | $@ | array_flow.rb:1383:16:1383:26 | call to source | call to source |
+| array_flow.rb:1399:10:1399:13 | ...[...] | array_flow.rb:1397:16:1397:26 | call to source | array_flow.rb:1399:10:1399:13 | ...[...] | $@ | array_flow.rb:1397:16:1397:26 | call to source | call to source |
+| array_flow.rb:1400:10:1400:13 | ...[...] | array_flow.rb:1397:16:1397:26 | call to source | array_flow.rb:1400:10:1400:13 | ...[...] | $@ | array_flow.rb:1397:16:1397:26 | call to source | call to source |
+| array_flow.rb:1401:10:1401:13 | ...[...] | array_flow.rb:1397:16:1397:26 | call to source | array_flow.rb:1401:10:1401:13 | ...[...] | $@ | array_flow.rb:1397:16:1397:26 | call to source | call to source |
+| array_flow.rb:1402:10:1402:13 | ...[...] | array_flow.rb:1397:16:1397:26 | call to source | array_flow.rb:1402:10:1402:13 | ...[...] | $@ | array_flow.rb:1397:16:1397:26 | call to source | call to source |
+| array_flow.rb:1406:14:1406:14 | x | array_flow.rb:1404:16:1404:26 | call to source | array_flow.rb:1406:14:1406:14 | x | $@ | array_flow.rb:1404:16:1404:26 | call to source | call to source |
+| array_flow.rb:1407:14:1407:14 | y | array_flow.rb:1404:16:1404:26 | call to source | array_flow.rb:1407:14:1407:14 | y | $@ | array_flow.rb:1404:16:1404:26 | call to source | call to source |
+| array_flow.rb:1410:10:1410:13 | ...[...] | array_flow.rb:1404:16:1404:26 | call to source | array_flow.rb:1410:10:1410:13 | ...[...] | $@ | array_flow.rb:1404:16:1404:26 | call to source | call to source |
+| array_flow.rb:1411:10:1411:13 | ...[...] | array_flow.rb:1404:16:1404:26 | call to source | array_flow.rb:1411:10:1411:13 | ...[...] | $@ | array_flow.rb:1404:16:1404:26 | call to source | call to source |
+| array_flow.rb:1412:10:1412:13 | ...[...] | array_flow.rb:1404:16:1404:26 | call to source | array_flow.rb:1412:10:1412:13 | ...[...] | $@ | array_flow.rb:1404:16:1404:26 | call to source | call to source |
+| array_flow.rb:1413:10:1413:13 | ...[...] | array_flow.rb:1404:16:1404:26 | call to source | array_flow.rb:1413:10:1413:13 | ...[...] | $@ | array_flow.rb:1404:16:1404:26 | call to source | call to source |
+| array_flow.rb:1419:14:1419:14 | x | array_flow.rb:1417:16:1417:26 | call to source | array_flow.rb:1419:14:1419:14 | x | $@ | array_flow.rb:1417:16:1417:26 | call to source | call to source |
+| array_flow.rb:1422:10:1422:13 | ...[...] | array_flow.rb:1417:16:1417:26 | call to source | array_flow.rb:1422:10:1422:13 | ...[...] | $@ | array_flow.rb:1417:16:1417:26 | call to source | call to source |
+| array_flow.rb:1423:10:1423:13 | ...[...] | array_flow.rb:1417:16:1417:26 | call to source | array_flow.rb:1423:10:1423:13 | ...[...] | $@ | array_flow.rb:1417:16:1417:26 | call to source | call to source |
+| array_flow.rb:1429:14:1429:14 | x | array_flow.rb:1427:16:1427:26 | call to source | array_flow.rb:1429:14:1429:14 | x | $@ | array_flow.rb:1427:16:1427:26 | call to source | call to source |
+| array_flow.rb:1432:10:1432:13 | ...[...] | array_flow.rb:1427:16:1427:26 | call to source | array_flow.rb:1432:10:1432:13 | ...[...] | $@ | array_flow.rb:1427:16:1427:26 | call to source | call to source |
+| array_flow.rb:1433:10:1433:13 | ...[...] | array_flow.rb:1427:16:1427:26 | call to source | array_flow.rb:1433:10:1433:13 | ...[...] | $@ | array_flow.rb:1427:16:1427:26 | call to source | call to source |
+| array_flow.rb:1434:10:1434:13 | ...[...] | array_flow.rb:1427:16:1427:26 | call to source | array_flow.rb:1434:10:1434:13 | ...[...] | $@ | array_flow.rb:1427:16:1427:26 | call to source | call to source |
+| array_flow.rb:1435:10:1435:13 | ...[...] | array_flow.rb:1427:16:1427:26 | call to source | array_flow.rb:1435:10:1435:13 | ...[...] | $@ | array_flow.rb:1427:16:1427:26 | call to source | call to source |
+| array_flow.rb:1441:14:1441:14 | x | array_flow.rb:1439:16:1439:26 | call to source | array_flow.rb:1441:14:1441:14 | x | $@ | array_flow.rb:1439:16:1439:26 | call to source | call to source |
+| array_flow.rb:1451:10:1451:13 | ...[...] | array_flow.rb:1447:16:1447:28 | call to source | array_flow.rb:1451:10:1451:13 | ...[...] | $@ | array_flow.rb:1447:16:1447:28 | call to source | call to source |
+| array_flow.rb:1452:10:1452:13 | ...[...] | array_flow.rb:1447:31:1447:43 | call to source | array_flow.rb:1452:10:1452:13 | ...[...] | $@ | array_flow.rb:1447:31:1447:43 | call to source | call to source |
+| array_flow.rb:1456:10:1456:13 | ...[...] | array_flow.rb:1447:16:1447:28 | call to source | array_flow.rb:1456:10:1456:13 | ...[...] | $@ | array_flow.rb:1447:16:1447:28 | call to source | call to source |
+| array_flow.rb:1458:10:1458:13 | ...[...] | array_flow.rb:1447:16:1447:28 | call to source | array_flow.rb:1458:10:1458:13 | ...[...] | $@ | array_flow.rb:1447:16:1447:28 | call to source | call to source |
+| array_flow.rb:1462:10:1462:13 | ...[...] | array_flow.rb:1447:16:1447:28 | call to source | array_flow.rb:1462:10:1462:13 | ...[...] | $@ | array_flow.rb:1447:16:1447:28 | call to source | call to source |
+| array_flow.rb:1463:10:1463:13 | ...[...] | array_flow.rb:1447:31:1447:43 | call to source | array_flow.rb:1463:10:1463:13 | ...[...] | $@ | array_flow.rb:1447:31:1447:43 | call to source | call to source |
+| array_flow.rb:1464:10:1464:13 | ...[...] | array_flow.rb:1447:16:1447:28 | call to source | array_flow.rb:1464:10:1464:13 | ...[...] | $@ | array_flow.rb:1447:16:1447:28 | call to source | call to source |
+| array_flow.rb:1464:10:1464:13 | ...[...] | array_flow.rb:1447:31:1447:43 | call to source | array_flow.rb:1464:10:1464:13 | ...[...] | $@ | array_flow.rb:1447:31:1447:43 | call to source | call to source |
+| array_flow.rb:1467:10:1467:13 | ...[...] | array_flow.rb:1447:16:1447:28 | call to source | array_flow.rb:1467:10:1467:13 | ...[...] | $@ | array_flow.rb:1447:16:1447:28 | call to source | call to source |
+| array_flow.rb:1467:10:1467:13 | ...[...] | array_flow.rb:1465:12:1465:24 | call to source | array_flow.rb:1467:10:1467:13 | ...[...] | $@ | array_flow.rb:1465:12:1465:24 | call to source | call to source |
+| array_flow.rb:1473:14:1473:14 | x | array_flow.rb:1471:16:1471:26 | call to source | array_flow.rb:1473:14:1473:14 | x | $@ | array_flow.rb:1471:16:1471:26 | call to source | call to source |
+| array_flow.rb:1478:10:1478:13 | ...[...] | array_flow.rb:1471:16:1471:26 | call to source | array_flow.rb:1478:10:1478:13 | ...[...] | $@ | array_flow.rb:1471:16:1471:26 | call to source | call to source |
+| array_flow.rb:1486:10:1486:13 | ...[...] | array_flow.rb:1484:19:1484:29 | call to source | array_flow.rb:1486:10:1486:13 | ...[...] | $@ | array_flow.rb:1484:19:1484:29 | call to source | call to source |
+| array_flow.rb:1494:10:1494:13 | ...[...] | array_flow.rb:1490:16:1490:26 | call to source | array_flow.rb:1494:10:1494:13 | ...[...] | $@ | array_flow.rb:1490:16:1490:26 | call to source | call to source |
+| array_flow.rb:1512:10:1512:16 | ...[...] | array_flow.rb:1507:14:1507:26 | call to source | array_flow.rb:1512:10:1512:16 | ...[...] | $@ | array_flow.rb:1507:14:1507:26 | call to source | call to source |
+| array_flow.rb:1513:10:1513:16 | ...[...] | array_flow.rb:1507:34:1507:46 | call to source | array_flow.rb:1513:10:1513:16 | ...[...] | $@ | array_flow.rb:1507:34:1507:46 | call to source | call to source |
+| array_flow.rb:1514:10:1514:16 | ...[...] | array_flow.rb:1507:54:1507:66 | call to source | array_flow.rb:1514:10:1514:16 | ...[...] | $@ | array_flow.rb:1507:54:1507:66 | call to source | call to source |
+| array_flow.rb:1522:10:1522:13 | ...[...] | array_flow.rb:1518:16:1518:28 | call to source | array_flow.rb:1522:10:1522:13 | ...[...] | $@ | array_flow.rb:1518:16:1518:28 | call to source | call to source |
 | array_flow.rb:1522:10:1522:13 | ...[...] | array_flow.rb:1519:13:1519:25 | call to source | array_flow.rb:1522:10:1522:13 | ...[...] | $@ | array_flow.rb:1519:13:1519:25 | call to source | call to source |
-| array_flow.rb:1523:10:1523:13 | ...[...] | array_flow.rb:1517:16:1517:28 | call to source | array_flow.rb:1523:10:1523:13 | ...[...] | $@ | array_flow.rb:1517:16:1517:28 | call to source | call to source |
-| array_flow.rb:1523:10:1523:13 | ...[...] | array_flow.rb:1518:13:1518:25 | call to source | array_flow.rb:1523:10:1523:13 | ...[...] | $@ | array_flow.rb:1518:13:1518:25 | call to source | call to source |
+| array_flow.rb:1522:10:1522:13 | ...[...] | array_flow.rb:1520:13:1520:25 | call to source | array_flow.rb:1522:10:1522:13 | ...[...] | $@ | array_flow.rb:1520:13:1520:25 | call to source | call to source |
+| array_flow.rb:1523:10:1523:13 | ...[...] | array_flow.rb:1518:16:1518:28 | call to source | array_flow.rb:1523:10:1523:13 | ...[...] | $@ | array_flow.rb:1518:16:1518:28 | call to source | call to source |
 | array_flow.rb:1523:10:1523:13 | ...[...] | array_flow.rb:1519:13:1519:25 | call to source | array_flow.rb:1523:10:1523:13 | ...[...] | $@ | array_flow.rb:1519:13:1519:25 | call to source | call to source |
-| array_flow.rb:1530:10:1530:13 | ...[...] | array_flow.rb:1527:19:1527:31 | call to source | array_flow.rb:1530:10:1530:13 | ...[...] | $@ | array_flow.rb:1527:19:1527:31 | call to source | call to source |
-| array_flow.rb:1530:10:1530:13 | ...[...] | array_flow.rb:1527:34:1527:46 | call to source | array_flow.rb:1530:10:1530:13 | ...[...] | $@ | array_flow.rb:1527:34:1527:46 | call to source | call to source |
-| array_flow.rb:1531:10:1531:13 | ...[...] | array_flow.rb:1527:19:1527:31 | call to source | array_flow.rb:1531:10:1531:13 | ...[...] | $@ | array_flow.rb:1527:19:1527:31 | call to source | call to source |
-| array_flow.rb:1531:10:1531:13 | ...[...] | array_flow.rb:1527:34:1527:46 | call to source | array_flow.rb:1531:10:1531:13 | ...[...] | $@ | array_flow.rb:1527:34:1527:46 | call to source | call to source |
-| array_flow.rb:1534:14:1534:14 | x | array_flow.rb:1527:19:1527:31 | call to source | array_flow.rb:1534:14:1534:14 | x | $@ | array_flow.rb:1527:19:1527:31 | call to source | call to source |
-| array_flow.rb:1534:14:1534:14 | x | array_flow.rb:1527:34:1527:46 | call to source | array_flow.rb:1534:14:1534:14 | x | $@ | array_flow.rb:1527:34:1527:46 | call to source | call to source |
-| array_flow.rb:1537:10:1537:13 | ...[...] | array_flow.rb:1527:19:1527:31 | call to source | array_flow.rb:1537:10:1537:13 | ...[...] | $@ | array_flow.rb:1527:19:1527:31 | call to source | call to source |
-| array_flow.rb:1537:10:1537:13 | ...[...] | array_flow.rb:1527:34:1527:46 | call to source | array_flow.rb:1537:10:1537:13 | ...[...] | $@ | array_flow.rb:1527:34:1527:46 | call to source | call to source |
-| array_flow.rb:1543:10:1543:13 | ...[...] | array_flow.rb:1541:16:1541:28 | call to source | array_flow.rb:1543:10:1543:13 | ...[...] | $@ | array_flow.rb:1541:16:1541:28 | call to source | call to source |
-| array_flow.rb:1543:10:1543:13 | ...[...] | array_flow.rb:1541:31:1541:43 | call to source | array_flow.rb:1543:10:1543:13 | ...[...] | $@ | array_flow.rb:1541:31:1541:43 | call to source | call to source |
-| array_flow.rb:1544:10:1544:13 | ...[...] | array_flow.rb:1541:16:1541:28 | call to source | array_flow.rb:1544:10:1544:13 | ...[...] | $@ | array_flow.rb:1541:16:1541:28 | call to source | call to source |
-| array_flow.rb:1544:10:1544:13 | ...[...] | array_flow.rb:1541:31:1541:43 | call to source | array_flow.rb:1544:10:1544:13 | ...[...] | $@ | array_flow.rb:1541:31:1541:43 | call to source | call to source |
-| array_flow.rb:1545:10:1545:13 | ...[...] | array_flow.rb:1541:16:1541:28 | call to source | array_flow.rb:1545:10:1545:13 | ...[...] | $@ | array_flow.rb:1541:16:1541:28 | call to source | call to source |
-| array_flow.rb:1545:10:1545:13 | ...[...] | array_flow.rb:1541:31:1541:43 | call to source | array_flow.rb:1545:10:1545:13 | ...[...] | $@ | array_flow.rb:1541:31:1541:43 | call to source | call to source |
-| array_flow.rb:1546:10:1546:13 | ...[...] | array_flow.rb:1541:16:1541:28 | call to source | array_flow.rb:1546:10:1546:13 | ...[...] | $@ | array_flow.rb:1541:16:1541:28 | call to source | call to source |
-| array_flow.rb:1546:10:1546:13 | ...[...] | array_flow.rb:1541:31:1541:43 | call to source | array_flow.rb:1546:10:1546:13 | ...[...] | $@ | array_flow.rb:1541:31:1541:43 | call to source | call to source |
-| array_flow.rb:1550:14:1550:14 | x | array_flow.rb:1548:16:1548:28 | call to source | array_flow.rb:1550:14:1550:14 | x | $@ | array_flow.rb:1548:16:1548:28 | call to source | call to source |
-| array_flow.rb:1550:14:1550:14 | x | array_flow.rb:1548:31:1548:43 | call to source | array_flow.rb:1550:14:1550:14 | x | $@ | array_flow.rb:1548:31:1548:43 | call to source | call to source |
-| array_flow.rb:1553:10:1553:13 | ...[...] | array_flow.rb:1548:16:1548:28 | call to source | array_flow.rb:1553:10:1553:13 | ...[...] | $@ | array_flow.rb:1548:16:1548:28 | call to source | call to source |
-| array_flow.rb:1553:10:1553:13 | ...[...] | array_flow.rb:1548:31:1548:43 | call to source | array_flow.rb:1553:10:1553:13 | ...[...] | $@ | array_flow.rb:1548:31:1548:43 | call to source | call to source |
-| array_flow.rb:1554:10:1554:13 | ...[...] | array_flow.rb:1548:16:1548:28 | call to source | array_flow.rb:1554:10:1554:13 | ...[...] | $@ | array_flow.rb:1548:16:1548:28 | call to source | call to source |
-| array_flow.rb:1554:10:1554:13 | ...[...] | array_flow.rb:1548:31:1548:43 | call to source | array_flow.rb:1554:10:1554:13 | ...[...] | $@ | array_flow.rb:1548:31:1548:43 | call to source | call to source |
-| array_flow.rb:1555:10:1555:13 | ...[...] | array_flow.rb:1548:16:1548:28 | call to source | array_flow.rb:1555:10:1555:13 | ...[...] | $@ | array_flow.rb:1548:16:1548:28 | call to source | call to source |
-| array_flow.rb:1555:10:1555:13 | ...[...] | array_flow.rb:1548:31:1548:43 | call to source | array_flow.rb:1555:10:1555:13 | ...[...] | $@ | array_flow.rb:1548:31:1548:43 | call to source | call to source |
-| array_flow.rb:1556:10:1556:13 | ...[...] | array_flow.rb:1548:16:1548:28 | call to source | array_flow.rb:1556:10:1556:13 | ...[...] | $@ | array_flow.rb:1548:16:1548:28 | call to source | call to source |
-| array_flow.rb:1556:10:1556:13 | ...[...] | array_flow.rb:1548:31:1548:43 | call to source | array_flow.rb:1556:10:1556:13 | ...[...] | $@ | array_flow.rb:1548:31:1548:43 | call to source | call to source |
-| array_flow.rb:1564:10:1564:13 | ...[...] | array_flow.rb:1561:21:1561:33 | call to source | array_flow.rb:1564:10:1564:13 | ...[...] | $@ | array_flow.rb:1561:21:1561:33 | call to source | call to source |
-| array_flow.rb:1567:10:1567:13 | ...[...] | array_flow.rb:1560:16:1560:28 | call to source | array_flow.rb:1567:10:1567:13 | ...[...] | $@ | array_flow.rb:1560:16:1560:28 | call to source | call to source |
-| array_flow.rb:1575:10:1575:13 | ...[...] | array_flow.rb:1571:13:1571:25 | call to source | array_flow.rb:1575:10:1575:13 | ...[...] | $@ | array_flow.rb:1571:13:1571:25 | call to source | call to source |
-| array_flow.rb:1577:10:1577:13 | ...[...] | array_flow.rb:1571:13:1571:25 | call to source | array_flow.rb:1577:10:1577:13 | ...[...] | $@ | array_flow.rb:1571:13:1571:25 | call to source | call to source |
-| array_flow.rb:1580:10:1580:13 | ...[...] | array_flow.rb:1571:13:1571:25 | call to source | array_flow.rb:1580:10:1580:13 | ...[...] | $@ | array_flow.rb:1571:13:1571:25 | call to source | call to source |
-| array_flow.rb:1580:10:1580:13 | ...[...] | array_flow.rb:1571:31:1571:43 | call to source | array_flow.rb:1580:10:1580:13 | ...[...] | $@ | array_flow.rb:1571:31:1571:43 | call to source | call to source |
-| array_flow.rb:1581:10:1581:13 | ...[...] | array_flow.rb:1571:13:1571:25 | call to source | array_flow.rb:1581:10:1581:13 | ...[...] | $@ | array_flow.rb:1571:13:1571:25 | call to source | call to source |
-| array_flow.rb:1581:10:1581:13 | ...[...] | array_flow.rb:1571:31:1571:43 | call to source | array_flow.rb:1581:10:1581:13 | ...[...] | $@ | array_flow.rb:1571:31:1571:43 | call to source | call to source |
-| array_flow.rb:1584:10:1584:13 | ...[...] | array_flow.rb:1571:13:1571:25 | call to source | array_flow.rb:1584:10:1584:13 | ...[...] | $@ | array_flow.rb:1571:13:1571:25 | call to source | call to source |
-| array_flow.rb:1584:10:1584:13 | ...[...] | array_flow.rb:1571:31:1571:43 | call to source | array_flow.rb:1584:10:1584:13 | ...[...] | $@ | array_flow.rb:1571:31:1571:43 | call to source | call to source |
-| array_flow.rb:1585:10:1585:13 | ...[...] | array_flow.rb:1571:13:1571:25 | call to source | array_flow.rb:1585:10:1585:13 | ...[...] | $@ | array_flow.rb:1571:13:1571:25 | call to source | call to source |
-| array_flow.rb:1585:10:1585:13 | ...[...] | array_flow.rb:1571:31:1571:43 | call to source | array_flow.rb:1585:10:1585:13 | ...[...] | $@ | array_flow.rb:1571:31:1571:43 | call to source | call to source |
-| array_flow.rb:1588:10:1588:13 | ...[...] | array_flow.rb:1571:13:1571:25 | call to source | array_flow.rb:1588:10:1588:13 | ...[...] | $@ | array_flow.rb:1571:13:1571:25 | call to source | call to source |
-| array_flow.rb:1588:10:1588:13 | ...[...] | array_flow.rb:1571:31:1571:43 | call to source | array_flow.rb:1588:10:1588:13 | ...[...] | $@ | array_flow.rb:1571:31:1571:43 | call to source | call to source |
-| array_flow.rb:1589:10:1589:13 | ...[...] | array_flow.rb:1571:13:1571:25 | call to source | array_flow.rb:1589:10:1589:13 | ...[...] | $@ | array_flow.rb:1571:13:1571:25 | call to source | call to source |
-| array_flow.rb:1589:10:1589:13 | ...[...] | array_flow.rb:1571:31:1571:43 | call to source | array_flow.rb:1589:10:1589:13 | ...[...] | $@ | array_flow.rb:1571:31:1571:43 | call to source | call to source |
-| array_flow.rb:1590:10:1590:13 | ...[...] | array_flow.rb:1571:13:1571:25 | call to source | array_flow.rb:1590:10:1590:13 | ...[...] | $@ | array_flow.rb:1571:13:1571:25 | call to source | call to source |
-| array_flow.rb:1590:10:1590:13 | ...[...] | array_flow.rb:1571:31:1571:43 | call to source | array_flow.rb:1590:10:1590:13 | ...[...] | $@ | array_flow.rb:1571:31:1571:43 | call to source | call to source |
-| array_flow.rb:1591:10:1591:13 | ...[...] | array_flow.rb:1571:13:1571:25 | call to source | array_flow.rb:1591:10:1591:13 | ...[...] | $@ | array_flow.rb:1571:13:1571:25 | call to source | call to source |
-| array_flow.rb:1591:10:1591:13 | ...[...] | array_flow.rb:1571:31:1571:43 | call to source | array_flow.rb:1591:10:1591:13 | ...[...] | $@ | array_flow.rb:1571:31:1571:43 | call to source | call to source |
-| array_flow.rb:1600:10:1600:16 | ...[...] | array_flow.rb:1597:10:1597:22 | call to source | array_flow.rb:1600:10:1600:16 | ...[...] | $@ | array_flow.rb:1597:10:1597:22 | call to source | call to source |
-| array_flow.rb:1601:10:1601:16 | ...[...] | array_flow.rb:1596:13:1596:25 | call to source | array_flow.rb:1601:10:1601:16 | ...[...] | $@ | array_flow.rb:1596:13:1596:25 | call to source | call to source |
-| array_flow.rb:1602:10:1602:16 | ...[...] | array_flow.rb:1595:16:1595:28 | call to source | array_flow.rb:1602:10:1602:16 | ...[...] | $@ | array_flow.rb:1595:16:1595:28 | call to source | call to source |
-| array_flow.rb:1604:14:1604:17 | ...[...] | array_flow.rb:1595:16:1595:28 | call to source | array_flow.rb:1604:14:1604:17 | ...[...] | $@ | array_flow.rb:1595:16:1595:28 | call to source | call to source |
-| array_flow.rb:1605:14:1605:17 | ...[...] | array_flow.rb:1596:13:1596:25 | call to source | array_flow.rb:1605:14:1605:17 | ...[...] | $@ | array_flow.rb:1596:13:1596:25 | call to source | call to source |
-| array_flow.rb:1606:14:1606:17 | ...[...] | array_flow.rb:1597:10:1597:22 | call to source | array_flow.rb:1606:14:1606:17 | ...[...] | $@ | array_flow.rb:1597:10:1597:22 | call to source | call to source |
-| array_flow.rb:1614:10:1614:13 | ...[...] | array_flow.rb:1611:16:1611:28 | call to source | array_flow.rb:1614:10:1614:13 | ...[...] | $@ | array_flow.rb:1611:16:1611:28 | call to source | call to source |
-| array_flow.rb:1614:10:1614:13 | ...[...] | array_flow.rb:1612:13:1612:25 | call to source | array_flow.rb:1614:10:1614:13 | ...[...] | $@ | array_flow.rb:1612:13:1612:25 | call to source | call to source |
-| array_flow.rb:1615:10:1615:13 | ...[...] | array_flow.rb:1611:16:1611:28 | call to source | array_flow.rb:1615:10:1615:13 | ...[...] | $@ | array_flow.rb:1611:16:1611:28 | call to source | call to source |
-| array_flow.rb:1615:10:1615:13 | ...[...] | array_flow.rb:1612:13:1612:25 | call to source | array_flow.rb:1615:10:1615:13 | ...[...] | $@ | array_flow.rb:1612:13:1612:25 | call to source | call to source |
-| array_flow.rb:1616:10:1616:13 | ...[...] | array_flow.rb:1611:16:1611:28 | call to source | array_flow.rb:1616:10:1616:13 | ...[...] | $@ | array_flow.rb:1611:16:1611:28 | call to source | call to source |
-| array_flow.rb:1616:10:1616:13 | ...[...] | array_flow.rb:1612:13:1612:25 | call to source | array_flow.rb:1616:10:1616:13 | ...[...] | $@ | array_flow.rb:1612:13:1612:25 | call to source | call to source |
-| array_flow.rb:1622:10:1622:16 | ...[...] | array_flow.rb:1621:15:1621:27 | call to source | array_flow.rb:1622:10:1622:16 | ...[...] | $@ | array_flow.rb:1621:15:1621:27 | call to source | call to source |
-| array_flow.rb:1625:10:1625:16 | ...[...] | array_flow.rb:1621:15:1621:27 | call to source | array_flow.rb:1625:10:1625:16 | ...[...] | $@ | array_flow.rb:1621:15:1621:27 | call to source | call to source |
-| array_flow.rb:1625:10:1625:16 | ...[...] | array_flow.rb:1624:15:1624:27 | call to source | array_flow.rb:1625:10:1625:16 | ...[...] | $@ | array_flow.rb:1624:15:1624:27 | call to source | call to source |
-| array_flow.rb:1626:10:1626:16 | ...[...] | array_flow.rb:1621:15:1621:27 | call to source | array_flow.rb:1626:10:1626:16 | ...[...] | $@ | array_flow.rb:1621:15:1621:27 | call to source | call to source |
-| array_flow.rb:1638:10:1638:13 | ...[...] | array_flow.rb:1633:16:1633:28 | call to source | array_flow.rb:1638:10:1638:13 | ...[...] | $@ | array_flow.rb:1633:16:1633:28 | call to source | call to source |
-| array_flow.rb:1638:10:1638:13 | ...[...] | array_flow.rb:1635:14:1635:26 | call to source | array_flow.rb:1638:10:1638:13 | ...[...] | $@ | array_flow.rb:1635:14:1635:26 | call to source | call to source |
-| array_flow.rb:1638:10:1638:13 | ...[...] | array_flow.rb:1637:16:1637:28 | call to source | array_flow.rb:1638:10:1638:13 | ...[...] | $@ | array_flow.rb:1637:16:1637:28 | call to source | call to source |
-| array_flow.rb:1640:10:1640:17 | ...[...] | array_flow.rb:1631:12:1631:24 | call to source | array_flow.rb:1640:10:1640:17 | ...[...] | $@ | array_flow.rb:1631:12:1631:24 | call to source | call to source |
-| array_flow.rb:1640:10:1640:17 | ...[...] | array_flow.rb:1633:16:1633:28 | call to source | array_flow.rb:1640:10:1640:17 | ...[...] | $@ | array_flow.rb:1633:16:1633:28 | call to source | call to source |
-| array_flow.rb:1640:10:1640:17 | ...[...] | array_flow.rb:1635:14:1635:26 | call to source | array_flow.rb:1640:10:1640:17 | ...[...] | $@ | array_flow.rb:1635:14:1635:26 | call to source | call to source |
-| array_flow.rb:1640:10:1640:17 | ...[...] | array_flow.rb:1637:16:1637:28 | call to source | array_flow.rb:1640:10:1640:17 | ...[...] | $@ | array_flow.rb:1637:16:1637:28 | call to source | call to source |
-| array_flow.rb:1642:10:1642:15 | ...[...] | array_flow.rb:1631:12:1631:24 | call to source | array_flow.rb:1642:10:1642:15 | ...[...] | $@ | array_flow.rb:1631:12:1631:24 | call to source | call to source |
-| array_flow.rb:1642:10:1642:15 | ...[...] | array_flow.rb:1633:16:1633:28 | call to source | array_flow.rb:1642:10:1642:15 | ...[...] | $@ | array_flow.rb:1633:16:1633:28 | call to source | call to source |
-| array_flow.rb:1642:10:1642:15 | ...[...] | array_flow.rb:1635:14:1635:26 | call to source | array_flow.rb:1642:10:1642:15 | ...[...] | $@ | array_flow.rb:1635:14:1635:26 | call to source | call to source |
-| array_flow.rb:1642:10:1642:15 | ...[...] | array_flow.rb:1637:16:1637:28 | call to source | array_flow.rb:1642:10:1642:15 | ...[...] | $@ | array_flow.rb:1637:16:1637:28 | call to source | call to source |
+| array_flow.rb:1523:10:1523:13 | ...[...] | array_flow.rb:1520:13:1520:25 | call to source | array_flow.rb:1523:10:1523:13 | ...[...] | $@ | array_flow.rb:1520:13:1520:25 | call to source | call to source |
+| array_flow.rb:1524:10:1524:13 | ...[...] | array_flow.rb:1518:16:1518:28 | call to source | array_flow.rb:1524:10:1524:13 | ...[...] | $@ | array_flow.rb:1518:16:1518:28 | call to source | call to source |
+| array_flow.rb:1524:10:1524:13 | ...[...] | array_flow.rb:1519:13:1519:25 | call to source | array_flow.rb:1524:10:1524:13 | ...[...] | $@ | array_flow.rb:1519:13:1519:25 | call to source | call to source |
+| array_flow.rb:1524:10:1524:13 | ...[...] | array_flow.rb:1520:13:1520:25 | call to source | array_flow.rb:1524:10:1524:13 | ...[...] | $@ | array_flow.rb:1520:13:1520:25 | call to source | call to source |
+| array_flow.rb:1531:10:1531:13 | ...[...] | array_flow.rb:1528:19:1528:31 | call to source | array_flow.rb:1531:10:1531:13 | ...[...] | $@ | array_flow.rb:1528:19:1528:31 | call to source | call to source |
+| array_flow.rb:1531:10:1531:13 | ...[...] | array_flow.rb:1528:34:1528:46 | call to source | array_flow.rb:1531:10:1531:13 | ...[...] | $@ | array_flow.rb:1528:34:1528:46 | call to source | call to source |
+| array_flow.rb:1532:10:1532:13 | ...[...] | array_flow.rb:1528:19:1528:31 | call to source | array_flow.rb:1532:10:1532:13 | ...[...] | $@ | array_flow.rb:1528:19:1528:31 | call to source | call to source |
+| array_flow.rb:1532:10:1532:13 | ...[...] | array_flow.rb:1528:34:1528:46 | call to source | array_flow.rb:1532:10:1532:13 | ...[...] | $@ | array_flow.rb:1528:34:1528:46 | call to source | call to source |
+| array_flow.rb:1535:14:1535:14 | x | array_flow.rb:1528:19:1528:31 | call to source | array_flow.rb:1535:14:1535:14 | x | $@ | array_flow.rb:1528:19:1528:31 | call to source | call to source |
+| array_flow.rb:1535:14:1535:14 | x | array_flow.rb:1528:34:1528:46 | call to source | array_flow.rb:1535:14:1535:14 | x | $@ | array_flow.rb:1528:34:1528:46 | call to source | call to source |
+| array_flow.rb:1538:10:1538:13 | ...[...] | array_flow.rb:1528:19:1528:31 | call to source | array_flow.rb:1538:10:1538:13 | ...[...] | $@ | array_flow.rb:1528:19:1528:31 | call to source | call to source |
+| array_flow.rb:1538:10:1538:13 | ...[...] | array_flow.rb:1528:34:1528:46 | call to source | array_flow.rb:1538:10:1538:13 | ...[...] | $@ | array_flow.rb:1528:34:1528:46 | call to source | call to source |
+| array_flow.rb:1544:10:1544:13 | ...[...] | array_flow.rb:1542:16:1542:28 | call to source | array_flow.rb:1544:10:1544:13 | ...[...] | $@ | array_flow.rb:1542:16:1542:28 | call to source | call to source |
+| array_flow.rb:1544:10:1544:13 | ...[...] | array_flow.rb:1542:31:1542:43 | call to source | array_flow.rb:1544:10:1544:13 | ...[...] | $@ | array_flow.rb:1542:31:1542:43 | call to source | call to source |
+| array_flow.rb:1545:10:1545:13 | ...[...] | array_flow.rb:1542:16:1542:28 | call to source | array_flow.rb:1545:10:1545:13 | ...[...] | $@ | array_flow.rb:1542:16:1542:28 | call to source | call to source |
+| array_flow.rb:1545:10:1545:13 | ...[...] | array_flow.rb:1542:31:1542:43 | call to source | array_flow.rb:1545:10:1545:13 | ...[...] | $@ | array_flow.rb:1542:31:1542:43 | call to source | call to source |
+| array_flow.rb:1546:10:1546:13 | ...[...] | array_flow.rb:1542:16:1542:28 | call to source | array_flow.rb:1546:10:1546:13 | ...[...] | $@ | array_flow.rb:1542:16:1542:28 | call to source | call to source |
+| array_flow.rb:1546:10:1546:13 | ...[...] | array_flow.rb:1542:31:1542:43 | call to source | array_flow.rb:1546:10:1546:13 | ...[...] | $@ | array_flow.rb:1542:31:1542:43 | call to source | call to source |
+| array_flow.rb:1547:10:1547:13 | ...[...] | array_flow.rb:1542:16:1542:28 | call to source | array_flow.rb:1547:10:1547:13 | ...[...] | $@ | array_flow.rb:1542:16:1542:28 | call to source | call to source |
+| array_flow.rb:1547:10:1547:13 | ...[...] | array_flow.rb:1542:31:1542:43 | call to source | array_flow.rb:1547:10:1547:13 | ...[...] | $@ | array_flow.rb:1542:31:1542:43 | call to source | call to source |
+| array_flow.rb:1551:14:1551:14 | x | array_flow.rb:1549:16:1549:28 | call to source | array_flow.rb:1551:14:1551:14 | x | $@ | array_flow.rb:1549:16:1549:28 | call to source | call to source |
+| array_flow.rb:1551:14:1551:14 | x | array_flow.rb:1549:31:1549:43 | call to source | array_flow.rb:1551:14:1551:14 | x | $@ | array_flow.rb:1549:31:1549:43 | call to source | call to source |
+| array_flow.rb:1554:10:1554:13 | ...[...] | array_flow.rb:1549:16:1549:28 | call to source | array_flow.rb:1554:10:1554:13 | ...[...] | $@ | array_flow.rb:1549:16:1549:28 | call to source | call to source |
+| array_flow.rb:1554:10:1554:13 | ...[...] | array_flow.rb:1549:31:1549:43 | call to source | array_flow.rb:1554:10:1554:13 | ...[...] | $@ | array_flow.rb:1549:31:1549:43 | call to source | call to source |
+| array_flow.rb:1555:10:1555:13 | ...[...] | array_flow.rb:1549:16:1549:28 | call to source | array_flow.rb:1555:10:1555:13 | ...[...] | $@ | array_flow.rb:1549:16:1549:28 | call to source | call to source |
+| array_flow.rb:1555:10:1555:13 | ...[...] | array_flow.rb:1549:31:1549:43 | call to source | array_flow.rb:1555:10:1555:13 | ...[...] | $@ | array_flow.rb:1549:31:1549:43 | call to source | call to source |
+| array_flow.rb:1556:10:1556:13 | ...[...] | array_flow.rb:1549:16:1549:28 | call to source | array_flow.rb:1556:10:1556:13 | ...[...] | $@ | array_flow.rb:1549:16:1549:28 | call to source | call to source |
+| array_flow.rb:1556:10:1556:13 | ...[...] | array_flow.rb:1549:31:1549:43 | call to source | array_flow.rb:1556:10:1556:13 | ...[...] | $@ | array_flow.rb:1549:31:1549:43 | call to source | call to source |
+| array_flow.rb:1557:10:1557:13 | ...[...] | array_flow.rb:1549:16:1549:28 | call to source | array_flow.rb:1557:10:1557:13 | ...[...] | $@ | array_flow.rb:1549:16:1549:28 | call to source | call to source |
+| array_flow.rb:1557:10:1557:13 | ...[...] | array_flow.rb:1549:31:1549:43 | call to source | array_flow.rb:1557:10:1557:13 | ...[...] | $@ | array_flow.rb:1549:31:1549:43 | call to source | call to source |
+| array_flow.rb:1565:10:1565:13 | ...[...] | array_flow.rb:1562:21:1562:33 | call to source | array_flow.rb:1565:10:1565:13 | ...[...] | $@ | array_flow.rb:1562:21:1562:33 | call to source | call to source |
+| array_flow.rb:1568:10:1568:13 | ...[...] | array_flow.rb:1561:16:1561:28 | call to source | array_flow.rb:1568:10:1568:13 | ...[...] | $@ | array_flow.rb:1561:16:1561:28 | call to source | call to source |
+| array_flow.rb:1576:10:1576:13 | ...[...] | array_flow.rb:1572:13:1572:25 | call to source | array_flow.rb:1576:10:1576:13 | ...[...] | $@ | array_flow.rb:1572:13:1572:25 | call to source | call to source |
+| array_flow.rb:1578:10:1578:13 | ...[...] | array_flow.rb:1572:13:1572:25 | call to source | array_flow.rb:1578:10:1578:13 | ...[...] | $@ | array_flow.rb:1572:13:1572:25 | call to source | call to source |
+| array_flow.rb:1581:10:1581:13 | ...[...] | array_flow.rb:1572:13:1572:25 | call to source | array_flow.rb:1581:10:1581:13 | ...[...] | $@ | array_flow.rb:1572:13:1572:25 | call to source | call to source |
+| array_flow.rb:1581:10:1581:13 | ...[...] | array_flow.rb:1572:31:1572:43 | call to source | array_flow.rb:1581:10:1581:13 | ...[...] | $@ | array_flow.rb:1572:31:1572:43 | call to source | call to source |
+| array_flow.rb:1582:10:1582:13 | ...[...] | array_flow.rb:1572:13:1572:25 | call to source | array_flow.rb:1582:10:1582:13 | ...[...] | $@ | array_flow.rb:1572:13:1572:25 | call to source | call to source |
+| array_flow.rb:1582:10:1582:13 | ...[...] | array_flow.rb:1572:31:1572:43 | call to source | array_flow.rb:1582:10:1582:13 | ...[...] | $@ | array_flow.rb:1572:31:1572:43 | call to source | call to source |
+| array_flow.rb:1585:10:1585:13 | ...[...] | array_flow.rb:1572:13:1572:25 | call to source | array_flow.rb:1585:10:1585:13 | ...[...] | $@ | array_flow.rb:1572:13:1572:25 | call to source | call to source |
+| array_flow.rb:1585:10:1585:13 | ...[...] | array_flow.rb:1572:31:1572:43 | call to source | array_flow.rb:1585:10:1585:13 | ...[...] | $@ | array_flow.rb:1572:31:1572:43 | call to source | call to source |
+| array_flow.rb:1586:10:1586:13 | ...[...] | array_flow.rb:1572:13:1572:25 | call to source | array_flow.rb:1586:10:1586:13 | ...[...] | $@ | array_flow.rb:1572:13:1572:25 | call to source | call to source |
+| array_flow.rb:1586:10:1586:13 | ...[...] | array_flow.rb:1572:31:1572:43 | call to source | array_flow.rb:1586:10:1586:13 | ...[...] | $@ | array_flow.rb:1572:31:1572:43 | call to source | call to source |
+| array_flow.rb:1589:10:1589:13 | ...[...] | array_flow.rb:1572:13:1572:25 | call to source | array_flow.rb:1589:10:1589:13 | ...[...] | $@ | array_flow.rb:1572:13:1572:25 | call to source | call to source |
+| array_flow.rb:1589:10:1589:13 | ...[...] | array_flow.rb:1572:31:1572:43 | call to source | array_flow.rb:1589:10:1589:13 | ...[...] | $@ | array_flow.rb:1572:31:1572:43 | call to source | call to source |
+| array_flow.rb:1590:10:1590:13 | ...[...] | array_flow.rb:1572:13:1572:25 | call to source | array_flow.rb:1590:10:1590:13 | ...[...] | $@ | array_flow.rb:1572:13:1572:25 | call to source | call to source |
+| array_flow.rb:1590:10:1590:13 | ...[...] | array_flow.rb:1572:31:1572:43 | call to source | array_flow.rb:1590:10:1590:13 | ...[...] | $@ | array_flow.rb:1572:31:1572:43 | call to source | call to source |
+| array_flow.rb:1591:10:1591:13 | ...[...] | array_flow.rb:1572:13:1572:25 | call to source | array_flow.rb:1591:10:1591:13 | ...[...] | $@ | array_flow.rb:1572:13:1572:25 | call to source | call to source |
+| array_flow.rb:1591:10:1591:13 | ...[...] | array_flow.rb:1572:31:1572:43 | call to source | array_flow.rb:1591:10:1591:13 | ...[...] | $@ | array_flow.rb:1572:31:1572:43 | call to source | call to source |
+| array_flow.rb:1592:10:1592:13 | ...[...] | array_flow.rb:1572:13:1572:25 | call to source | array_flow.rb:1592:10:1592:13 | ...[...] | $@ | array_flow.rb:1572:13:1572:25 | call to source | call to source |
+| array_flow.rb:1592:10:1592:13 | ...[...] | array_flow.rb:1572:31:1572:43 | call to source | array_flow.rb:1592:10:1592:13 | ...[...] | $@ | array_flow.rb:1572:31:1572:43 | call to source | call to source |
+| array_flow.rb:1601:10:1601:16 | ...[...] | array_flow.rb:1598:10:1598:22 | call to source | array_flow.rb:1601:10:1601:16 | ...[...] | $@ | array_flow.rb:1598:10:1598:22 | call to source | call to source |
+| array_flow.rb:1602:10:1602:16 | ...[...] | array_flow.rb:1597:13:1597:25 | call to source | array_flow.rb:1602:10:1602:16 | ...[...] | $@ | array_flow.rb:1597:13:1597:25 | call to source | call to source |
+| array_flow.rb:1603:10:1603:16 | ...[...] | array_flow.rb:1596:16:1596:28 | call to source | array_flow.rb:1603:10:1603:16 | ...[...] | $@ | array_flow.rb:1596:16:1596:28 | call to source | call to source |
+| array_flow.rb:1605:14:1605:17 | ...[...] | array_flow.rb:1596:16:1596:28 | call to source | array_flow.rb:1605:14:1605:17 | ...[...] | $@ | array_flow.rb:1596:16:1596:28 | call to source | call to source |
+| array_flow.rb:1606:14:1606:17 | ...[...] | array_flow.rb:1597:13:1597:25 | call to source | array_flow.rb:1606:14:1606:17 | ...[...] | $@ | array_flow.rb:1597:13:1597:25 | call to source | call to source |
+| array_flow.rb:1607:14:1607:17 | ...[...] | array_flow.rb:1598:10:1598:22 | call to source | array_flow.rb:1607:14:1607:17 | ...[...] | $@ | array_flow.rb:1598:10:1598:22 | call to source | call to source |
+| array_flow.rb:1615:10:1615:13 | ...[...] | array_flow.rb:1612:16:1612:28 | call to source | array_flow.rb:1615:10:1615:13 | ...[...] | $@ | array_flow.rb:1612:16:1612:28 | call to source | call to source |
+| array_flow.rb:1615:10:1615:13 | ...[...] | array_flow.rb:1613:13:1613:25 | call to source | array_flow.rb:1615:10:1615:13 | ...[...] | $@ | array_flow.rb:1613:13:1613:25 | call to source | call to source |
+| array_flow.rb:1616:10:1616:13 | ...[...] | array_flow.rb:1612:16:1612:28 | call to source | array_flow.rb:1616:10:1616:13 | ...[...] | $@ | array_flow.rb:1612:16:1612:28 | call to source | call to source |
+| array_flow.rb:1616:10:1616:13 | ...[...] | array_flow.rb:1613:13:1613:25 | call to source | array_flow.rb:1616:10:1616:13 | ...[...] | $@ | array_flow.rb:1613:13:1613:25 | call to source | call to source |
+| array_flow.rb:1617:10:1617:13 | ...[...] | array_flow.rb:1612:16:1612:28 | call to source | array_flow.rb:1617:10:1617:13 | ...[...] | $@ | array_flow.rb:1612:16:1612:28 | call to source | call to source |
+| array_flow.rb:1617:10:1617:13 | ...[...] | array_flow.rb:1613:13:1613:25 | call to source | array_flow.rb:1617:10:1617:13 | ...[...] | $@ | array_flow.rb:1613:13:1613:25 | call to source | call to source |
+| array_flow.rb:1623:10:1623:16 | ...[...] | array_flow.rb:1622:15:1622:27 | call to source | array_flow.rb:1623:10:1623:16 | ...[...] | $@ | array_flow.rb:1622:15:1622:27 | call to source | call to source |
+| array_flow.rb:1626:10:1626:16 | ...[...] | array_flow.rb:1622:15:1622:27 | call to source | array_flow.rb:1626:10:1626:16 | ...[...] | $@ | array_flow.rb:1622:15:1622:27 | call to source | call to source |
+| array_flow.rb:1626:10:1626:16 | ...[...] | array_flow.rb:1625:15:1625:27 | call to source | array_flow.rb:1626:10:1626:16 | ...[...] | $@ | array_flow.rb:1625:15:1625:27 | call to source | call to source |
+| array_flow.rb:1627:10:1627:16 | ...[...] | array_flow.rb:1622:15:1622:27 | call to source | array_flow.rb:1627:10:1627:16 | ...[...] | $@ | array_flow.rb:1622:15:1622:27 | call to source | call to source |
+| array_flow.rb:1639:10:1639:13 | ...[...] | array_flow.rb:1634:16:1634:28 | call to source | array_flow.rb:1639:10:1639:13 | ...[...] | $@ | array_flow.rb:1634:16:1634:28 | call to source | call to source |
+| array_flow.rb:1639:10:1639:13 | ...[...] | array_flow.rb:1636:14:1636:26 | call to source | array_flow.rb:1639:10:1639:13 | ...[...] | $@ | array_flow.rb:1636:14:1636:26 | call to source | call to source |
+| array_flow.rb:1639:10:1639:13 | ...[...] | array_flow.rb:1638:16:1638:28 | call to source | array_flow.rb:1639:10:1639:13 | ...[...] | $@ | array_flow.rb:1638:16:1638:28 | call to source | call to source |
+| array_flow.rb:1641:10:1641:17 | ...[...] | array_flow.rb:1632:12:1632:24 | call to source | array_flow.rb:1641:10:1641:17 | ...[...] | $@ | array_flow.rb:1632:12:1632:24 | call to source | call to source |
+| array_flow.rb:1641:10:1641:17 | ...[...] | array_flow.rb:1634:16:1634:28 | call to source | array_flow.rb:1641:10:1641:17 | ...[...] | $@ | array_flow.rb:1634:16:1634:28 | call to source | call to source |
+| array_flow.rb:1641:10:1641:17 | ...[...] | array_flow.rb:1636:14:1636:26 | call to source | array_flow.rb:1641:10:1641:17 | ...[...] | $@ | array_flow.rb:1636:14:1636:26 | call to source | call to source |
+| array_flow.rb:1641:10:1641:17 | ...[...] | array_flow.rb:1638:16:1638:28 | call to source | array_flow.rb:1641:10:1641:17 | ...[...] | $@ | array_flow.rb:1638:16:1638:28 | call to source | call to source |
+| array_flow.rb:1643:10:1643:15 | ...[...] | array_flow.rb:1632:12:1632:24 | call to source | array_flow.rb:1643:10:1643:15 | ...[...] | $@ | array_flow.rb:1632:12:1632:24 | call to source | call to source |
+| array_flow.rb:1643:10:1643:15 | ...[...] | array_flow.rb:1634:16:1634:28 | call to source | array_flow.rb:1643:10:1643:15 | ...[...] | $@ | array_flow.rb:1634:16:1634:28 | call to source | call to source |
+| array_flow.rb:1643:10:1643:15 | ...[...] | array_flow.rb:1636:14:1636:26 | call to source | array_flow.rb:1643:10:1643:15 | ...[...] | $@ | array_flow.rb:1636:14:1636:26 | call to source | call to source |
+| array_flow.rb:1643:10:1643:15 | ...[...] | array_flow.rb:1638:16:1638:28 | call to source | array_flow.rb:1643:10:1643:15 | ...[...] | $@ | array_flow.rb:1638:16:1638:28 | call to source | call to source |

--- a/ruby/ql/test/library-tests/dataflow/array-flow/array_flow.rb
+++ b/ruby/ql/test/library-tests/dataflow/array-flow/array_flow.rb
@@ -355,7 +355,7 @@ def m40(i)
     a = [0, 1, source(40.1), [0, source(40.2)]]
     sink(a.dig(0))
     sink(a.dig(2)) # $ hasValueFlow=40.1
-    sink(a.dig(i)) # $ hasValueFlow=40.1
+    sink(a.dig(i)) # $ hasValueFlow=40.1 $ hasTaintFlow=40.2
     sink(a.dig(3,0))
     sink(a.dig(3,1)) # $ hasValueFlow=40.2
 end
@@ -1214,8 +1214,9 @@ def m111(i)
     b = a.slice i
     # If `i` is an integer:
     sink b # $ hasValueFlow=111.1 $ hasValueFlow=111.2
-    # If `i` is a range/aseq:
-    sink b[0] # $ hasValueFlow=111.1 $ hasValueFlow=111.2
+    # Could in principle happen if `i` is a range/aseq, but we don't model that
+    # Instead, flow happens because the array read is lifted to a taint step
+    sink b[0] # $ SPURIOUS: hasTaintFlow=111.1 $ SPURIOUS: hasTaintFlow=111.2
 
     b = a.slice(2, 3)
     sink b[0] # $ hasValueFlow=111.1

--- a/ruby/ql/test/library-tests/dataflow/array-flow/type-tracking-array-flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/array-flow/type-tracking-array-flow.expected
@@ -1,4 +1,3 @@
-failures
 testFailures
 | array_flow.rb:107:10:107:13 | ...[...] | Unexpected result: hasValueFlow=11.2 |
 | array_flow.rb:179:28:179:46 | # $ hasValueFlow=19 | Missing result:hasValueFlow=19 |
@@ -109,55 +108,56 @@ testFailures
 | array_flow.rb:1168:10:1168:13 | ...[...] | Unexpected result: hasValueFlow=108.2 |
 | array_flow.rb:1170:10:1170:13 | ...[...] | Unexpected result: hasValueFlow=108.1 |
 | array_flow.rb:1172:10:1172:13 | ...[...] | Unexpected result: hasValueFlow=108.2 |
-| array_flow.rb:1223:10:1223:13 | ...[...] | Unexpected result: hasValueFlow=111.1 |
-| array_flow.rb:1232:10:1232:13 | ...[...] | Unexpected result: hasValueFlow=111.1 |
-| array_flow.rb:1237:10:1237:13 | ...[...] | Unexpected result: hasValueFlow=111.1 |
-| array_flow.rb:1261:10:1261:10 | b | Unexpected result: hasValueFlow=112.2 |
-| array_flow.rb:1264:10:1264:13 | ...[...] | Unexpected result: hasValueFlow=112.1 |
-| array_flow.rb:1264:10:1264:13 | ...[...] | Unexpected result: hasValueFlow=112.2 |
-| array_flow.rb:1285:10:1285:13 | ...[...] | Unexpected result: hasValueFlow=112.1 |
-| array_flow.rb:1287:10:1287:13 | ...[...] | Unexpected result: hasValueFlow=112.2 |
-| array_flow.rb:1291:10:1291:13 | ...[...] | Unexpected result: hasValueFlow=112.2 |
-| array_flow.rb:1296:10:1296:13 | ...[...] | Unexpected result: hasValueFlow=112.1 |
-| array_flow.rb:1298:10:1298:13 | ...[...] | Unexpected result: hasValueFlow=112.2 |
-| array_flow.rb:1302:10:1302:13 | ...[...] | Unexpected result: hasValueFlow=112.2 |
-| array_flow.rb:1307:10:1307:13 | ...[...] | Unexpected result: hasValueFlow=112.1 |
-| array_flow.rb:1309:10:1309:13 | ...[...] | Unexpected result: hasValueFlow=112.2 |
-| array_flow.rb:1341:10:1341:13 | ...[...] | Unexpected result: hasValueFlow=112.2 |
-| array_flow.rb:1345:10:1345:13 | ...[...] | Unexpected result: hasValueFlow=112.1 |
-| array_flow.rb:1448:10:1448:13 | ...[...] | Unexpected result: hasValueFlow=121.3 |
+| array_flow.rb:1224:10:1224:13 | ...[...] | Unexpected result: hasValueFlow=111.1 |
+| array_flow.rb:1233:10:1233:13 | ...[...] | Unexpected result: hasValueFlow=111.1 |
+| array_flow.rb:1238:10:1238:13 | ...[...] | Unexpected result: hasValueFlow=111.1 |
+| array_flow.rb:1262:10:1262:10 | b | Unexpected result: hasValueFlow=112.2 |
+| array_flow.rb:1265:10:1265:13 | ...[...] | Unexpected result: hasValueFlow=112.1 |
+| array_flow.rb:1265:10:1265:13 | ...[...] | Unexpected result: hasValueFlow=112.2 |
+| array_flow.rb:1286:10:1286:13 | ...[...] | Unexpected result: hasValueFlow=112.1 |
+| array_flow.rb:1288:10:1288:13 | ...[...] | Unexpected result: hasValueFlow=112.2 |
+| array_flow.rb:1292:10:1292:13 | ...[...] | Unexpected result: hasValueFlow=112.2 |
+| array_flow.rb:1297:10:1297:13 | ...[...] | Unexpected result: hasValueFlow=112.1 |
+| array_flow.rb:1299:10:1299:13 | ...[...] | Unexpected result: hasValueFlow=112.2 |
+| array_flow.rb:1303:10:1303:13 | ...[...] | Unexpected result: hasValueFlow=112.2 |
+| array_flow.rb:1308:10:1308:13 | ...[...] | Unexpected result: hasValueFlow=112.1 |
+| array_flow.rb:1310:10:1310:13 | ...[...] | Unexpected result: hasValueFlow=112.2 |
+| array_flow.rb:1342:10:1342:13 | ...[...] | Unexpected result: hasValueFlow=112.2 |
+| array_flow.rb:1346:10:1346:13 | ...[...] | Unexpected result: hasValueFlow=112.1 |
 | array_flow.rb:1449:10:1449:13 | ...[...] | Unexpected result: hasValueFlow=121.3 |
 | array_flow.rb:1450:10:1450:13 | ...[...] | Unexpected result: hasValueFlow=121.3 |
 | array_flow.rb:1451:10:1451:13 | ...[...] | Unexpected result: hasValueFlow=121.3 |
-| array_flow.rb:1453:10:1453:13 | ...[...] | Unexpected result: hasValueFlow=121.3 |
+| array_flow.rb:1452:10:1452:13 | ...[...] | Unexpected result: hasValueFlow=121.3 |
 | array_flow.rb:1454:10:1454:13 | ...[...] | Unexpected result: hasValueFlow=121.3 |
 | array_flow.rb:1455:10:1455:13 | ...[...] | Unexpected result: hasValueFlow=121.3 |
-| array_flow.rb:1456:10:1456:13 | ...[...] | Unexpected result: hasValueFlow=121.2 |
 | array_flow.rb:1456:10:1456:13 | ...[...] | Unexpected result: hasValueFlow=121.3 |
 | array_flow.rb:1457:10:1457:13 | ...[...] | Unexpected result: hasValueFlow=121.2 |
 | array_flow.rb:1457:10:1457:13 | ...[...] | Unexpected result: hasValueFlow=121.3 |
-| array_flow.rb:1459:10:1459:13 | ...[...] | Unexpected result: hasValueFlow=121.3 |
+| array_flow.rb:1458:10:1458:13 | ...[...] | Unexpected result: hasValueFlow=121.2 |
+| array_flow.rb:1458:10:1458:13 | ...[...] | Unexpected result: hasValueFlow=121.3 |
 | array_flow.rb:1460:10:1460:13 | ...[...] | Unexpected result: hasValueFlow=121.3 |
 | array_flow.rb:1461:10:1461:13 | ...[...] | Unexpected result: hasValueFlow=121.3 |
 | array_flow.rb:1462:10:1462:13 | ...[...] | Unexpected result: hasValueFlow=121.3 |
 | array_flow.rb:1463:10:1463:13 | ...[...] | Unexpected result: hasValueFlow=121.3 |
-| array_flow.rb:1511:18:1511:39 | # $ hasValueFlow=128.1 | Missing result:hasValueFlow=128.1 |
-| array_flow.rb:1512:18:1512:39 | # $ hasValueFlow=128.2 | Missing result:hasValueFlow=128.2 |
-| array_flow.rb:1513:18:1513:39 | # $ hasValueFlow=128.3 | Missing result:hasValueFlow=128.3 |
-| array_flow.rb:1562:10:1562:13 | ...[...] | Unexpected result: hasValueFlow=132.1 |
-| array_flow.rb:1562:10:1562:13 | ...[...] | Unexpected result: hasValueFlow=132.2 |
+| array_flow.rb:1464:10:1464:13 | ...[...] | Unexpected result: hasValueFlow=121.3 |
+| array_flow.rb:1512:18:1512:39 | # $ hasValueFlow=128.1 | Missing result:hasValueFlow=128.1 |
+| array_flow.rb:1513:18:1513:39 | # $ hasValueFlow=128.2 | Missing result:hasValueFlow=128.2 |
+| array_flow.rb:1514:18:1514:39 | # $ hasValueFlow=128.3 | Missing result:hasValueFlow=128.3 |
 | array_flow.rb:1563:10:1563:13 | ...[...] | Unexpected result: hasValueFlow=132.1 |
 | array_flow.rb:1563:10:1563:13 | ...[...] | Unexpected result: hasValueFlow=132.2 |
 | array_flow.rb:1564:10:1564:13 | ...[...] | Unexpected result: hasValueFlow=132.1 |
+| array_flow.rb:1564:10:1564:13 | ...[...] | Unexpected result: hasValueFlow=132.2 |
 | array_flow.rb:1565:10:1565:13 | ...[...] | Unexpected result: hasValueFlow=132.1 |
-| array_flow.rb:1565:10:1565:13 | ...[...] | Unexpected result: hasValueFlow=132.2 |
 | array_flow.rb:1566:10:1566:13 | ...[...] | Unexpected result: hasValueFlow=132.1 |
 | array_flow.rb:1566:10:1566:13 | ...[...] | Unexpected result: hasValueFlow=132.2 |
+| array_flow.rb:1567:10:1567:13 | ...[...] | Unexpected result: hasValueFlow=132.1 |
 | array_flow.rb:1567:10:1567:13 | ...[...] | Unexpected result: hasValueFlow=132.2 |
-| array_flow.rb:1600:18:1600:39 | # $ hasValueFlow=134.3 | Missing result:hasValueFlow=134.3 |
-| array_flow.rb:1601:18:1601:39 | # $ hasValueFlow=134.2 | Missing result:hasValueFlow=134.2 |
-| array_flow.rb:1602:18:1602:39 | # $ hasValueFlow=134.1 | Missing result:hasValueFlow=134.1 |
-| array_flow.rb:1622:19:1622:40 | # $ hasValueFlow=136.1 | Missing result:hasValueFlow=136.1 |
-| array_flow.rb:1625:19:1625:70 | # $ hasValueFlow=136.2 $ SPURIOUS hasValueFlow=136.1 | Missing result:hasValueFlow=136.1 |
-| array_flow.rb:1625:19:1625:70 | # $ hasValueFlow=136.2 $ SPURIOUS hasValueFlow=136.1 | Missing result:hasValueFlow=136.2 |
-| array_flow.rb:1626:19:1626:40 | # $ hasValueFlow=136.1 | Missing result:hasValueFlow=136.1 |
+| array_flow.rb:1568:10:1568:13 | ...[...] | Unexpected result: hasValueFlow=132.2 |
+| array_flow.rb:1601:18:1601:39 | # $ hasValueFlow=134.3 | Missing result:hasValueFlow=134.3 |
+| array_flow.rb:1602:18:1602:39 | # $ hasValueFlow=134.2 | Missing result:hasValueFlow=134.2 |
+| array_flow.rb:1603:18:1603:39 | # $ hasValueFlow=134.1 | Missing result:hasValueFlow=134.1 |
+| array_flow.rb:1623:19:1623:40 | # $ hasValueFlow=136.1 | Missing result:hasValueFlow=136.1 |
+| array_flow.rb:1626:19:1626:70 | # $ hasValueFlow=136.2 $ SPURIOUS hasValueFlow=136.1 | Missing result:hasValueFlow=136.1 |
+| array_flow.rb:1626:19:1626:70 | # $ hasValueFlow=136.2 $ SPURIOUS hasValueFlow=136.1 | Missing result:hasValueFlow=136.2 |
+| array_flow.rb:1627:19:1627:40 | # $ hasValueFlow=136.1 | Missing result:hasValueFlow=136.1 |
+failures

--- a/ruby/ql/test/library-tests/dataflow/flow-summaries/semantics.expected
+++ b/ruby/ql/test/library-tests/dataflow/flow-summaries/semantics.expected
@@ -74,10 +74,14 @@ edges
 | semantics.rb:60:5:60:5 | a | semantics.rb:66:14:66:15 | &... |
 | semantics.rb:60:9:60:18 | call to source | semantics.rb:60:5:60:5 | a |
 | semantics.rb:60:9:60:18 | call to source | semantics.rb:60:5:60:5 | a |
+| semantics.rb:61:10:61:15 | call to s10 [element 0] | semantics.rb:61:10:61:15 | call to s10 |
 | semantics.rb:61:14:61:14 | a | semantics.rb:61:10:61:15 | call to s10 |
 | semantics.rb:61:14:61:14 | a | semantics.rb:61:10:61:15 | call to s10 |
+| semantics.rb:61:14:61:14 | a | semantics.rb:61:10:61:15 | call to s10 [element 0] |
+| semantics.rb:62:10:62:18 | call to s10 [element 1] | semantics.rb:62:10:62:18 | call to s10 |
 | semantics.rb:62:17:62:17 | a | semantics.rb:62:10:62:18 | call to s10 |
 | semantics.rb:62:17:62:17 | a | semantics.rb:62:10:62:18 | call to s10 |
+| semantics.rb:62:17:62:17 | a | semantics.rb:62:10:62:18 | call to s10 [element 1] |
 | semantics.rb:63:19:63:19 | a | semantics.rb:63:10:63:20 | call to s10 |
 | semantics.rb:63:19:63:19 | a | semantics.rb:63:10:63:20 | call to s10 |
 | semantics.rb:64:27:64:27 | a | semantics.rb:64:10:64:28 | call to s10 |
@@ -1118,10 +1122,12 @@ nodes
 | semantics.rb:60:9:60:18 | call to source | semmle.label | call to source |
 | semantics.rb:61:10:61:15 | call to s10 | semmle.label | call to s10 |
 | semantics.rb:61:10:61:15 | call to s10 | semmle.label | call to s10 |
+| semantics.rb:61:10:61:15 | call to s10 [element 0] | semmle.label | call to s10 [element 0] |
 | semantics.rb:61:14:61:14 | a | semmle.label | a |
 | semantics.rb:61:14:61:14 | a | semmle.label | a |
 | semantics.rb:62:10:62:18 | call to s10 | semmle.label | call to s10 |
 | semantics.rb:62:10:62:18 | call to s10 | semmle.label | call to s10 |
+| semantics.rb:62:10:62:18 | call to s10 [element 1] | semmle.label | call to s10 [element 1] |
 | semantics.rb:62:17:62:17 | a | semmle.label | a |
 | semantics.rb:62:17:62:17 | a | semmle.label | a |
 | semantics.rb:63:10:63:20 | call to s10 | semmle.label | call to s10 |

--- a/ruby/ql/test/library-tests/dataflow/string-flow/string_flow.rb
+++ b/ruby/ql/test/library-tests/dataflow/string-flow/string_flow.rb
@@ -216,7 +216,7 @@ def m_partition
     sink b[0] # $ hasTaintFlow=a
     sink b[1] # $ hasTaintFlow=a
     sink b[2] # $ hasTaintFlow=a
-    sink b[3]
+    sink b[3] # $ hasTaintFlow=a (because of the flow summary for Array#partition)
 end
 
 def m_replace

--- a/ruby/ql/test/library-tests/dataflow/summaries/Summaries.expected
+++ b/ruby/ql/test/library-tests/dataflow/summaries/Summaries.expected
@@ -28,6 +28,7 @@ edges
 | summaries.rb:1:11:1:36 | call to identity | summaries.rb:128:14:128:20 | tainted |
 | summaries.rb:1:11:1:36 | call to identity | summaries.rb:131:16:131:22 | tainted |
 | summaries.rb:1:11:1:36 | call to identity | summaries.rb:131:16:131:22 | tainted |
+| summaries.rb:1:11:1:36 | call to identity | summaries.rb:131:16:131:22 | tainted |
 | summaries.rb:1:11:1:36 | call to identity | summaries.rb:132:21:132:27 | tainted |
 | summaries.rb:1:11:1:36 | call to identity | summaries.rb:132:21:132:27 | tainted |
 | summaries.rb:1:11:1:36 | call to identity | summaries.rb:135:26:135:32 | tainted |
@@ -229,6 +230,7 @@ edges
 | summaries.rb:112:6:112:6 | x [@value] | summaries.rb:112:6:112:16 | call to get_value |
 | summaries.rb:122:16:122:22 | [post] tainted | summaries.rb:128:14:128:20 | tainted |
 | summaries.rb:122:16:122:22 | [post] tainted | summaries.rb:131:16:131:22 | tainted |
+| summaries.rb:122:16:122:22 | [post] tainted | summaries.rb:131:16:131:22 | tainted |
 | summaries.rb:122:16:122:22 | [post] tainted | summaries.rb:132:21:132:27 | tainted |
 | summaries.rb:122:16:122:22 | [post] tainted | summaries.rb:135:26:135:32 | tainted |
 | summaries.rb:122:16:122:22 | [post] tainted | summaries.rb:137:23:137:29 | tainted |
@@ -248,6 +250,7 @@ edges
 | summaries.rb:122:33:122:33 | [post] z | summaries.rb:125:6:125:6 | z |
 | summaries.rb:128:1:128:1 | [post] x | summaries.rb:129:6:129:6 | x |
 | summaries.rb:128:14:128:20 | tainted | summaries.rb:128:1:128:1 | [post] x |
+| summaries.rb:131:16:131:22 | tainted | summaries.rb:131:1:131:23 | * |
 | summaries.rb:157:14:160:3 | do ... end [captured tainted] | summaries.rb:158:15:158:21 | tainted |
 | summaries.rb:157:14:160:3 | do ... end [captured tainted] | summaries.rb:158:15:158:21 | tainted |
 nodes
@@ -466,6 +469,8 @@ nodes
 | summaries.rb:128:1:128:1 | [post] x | semmle.label | [post] x |
 | summaries.rb:128:14:128:20 | tainted | semmle.label | tainted |
 | summaries.rb:129:6:129:6 | x | semmle.label | x |
+| summaries.rb:131:1:131:23 | * | semmle.label | * |
+| summaries.rb:131:16:131:22 | tainted | semmle.label | tainted |
 | summaries.rb:131:16:131:22 | tainted | semmle.label | tainted |
 | summaries.rb:131:16:131:22 | tainted | semmle.label | tainted |
 | summaries.rb:132:21:132:27 | tainted | semmle.label | tainted |
@@ -579,6 +584,7 @@ invalidSpecComponent
 | summaries.rb:124:6:124:6 | y | summaries.rb:1:20:1:36 | call to source | summaries.rb:124:6:124:6 | y | $@ | summaries.rb:1:20:1:36 | call to source | call to source |
 | summaries.rb:125:6:125:6 | z | summaries.rb:1:20:1:36 | call to source | summaries.rb:125:6:125:6 | z | $@ | summaries.rb:1:20:1:36 | call to source | call to source |
 | summaries.rb:129:6:129:6 | x | summaries.rb:1:20:1:36 | call to source | summaries.rb:129:6:129:6 | x | $@ | summaries.rb:1:20:1:36 | call to source | call to source |
+| summaries.rb:131:1:131:23 | * | summaries.rb:1:20:1:36 | call to source | summaries.rb:131:1:131:23 | * | $@ | summaries.rb:1:20:1:36 | call to source | call to source |
 | summaries.rb:131:16:131:22 | tainted | summaries.rb:1:20:1:36 | call to source | summaries.rb:131:16:131:22 | tainted | $@ | summaries.rb:1:20:1:36 | call to source | call to source |
 | summaries.rb:131:16:131:22 | tainted | summaries.rb:1:20:1:36 | call to source | summaries.rb:131:16:131:22 | tainted | $@ | summaries.rb:1:20:1:36 | call to source | call to source |
 | summaries.rb:132:21:132:27 | tainted | summaries.rb:1:20:1:36 | call to source | summaries.rb:132:21:132:27 | tainted | $@ | summaries.rb:1:20:1:36 | call to source | call to source |

--- a/ruby/ql/test/library-tests/dataflow/summaries/summaries.rb
+++ b/ruby/ql/test/library-tests/dataflow/summaries/summaries.rb
@@ -128,7 +128,7 @@ x = Foo.new
 x.flowToSelf(tainted)
 sink(x) # $ hasTaintFlow=tainted
 
-Foo.sinkAnyArg(tainted) # $ hasValueFlow=tainted
+Foo.sinkAnyArg(tainted) # $ hasValueFlow=tainted $ hasTaintFlow=tainted
 Foo.sinkAnyArg(key: tainted) # $ hasValueFlow=tainted
 
 Foo.sinkAnyNamedArg(tainted)

--- a/ruby/ql/test/library-tests/dataflow/type-tracker/TypeTracker.expected
+++ b/ruby/ql/test/library-tests/dataflow/type-tracker/TypeTracker.expected
@@ -159,9 +159,7 @@ track
 | type_tracker.rb:34:18:34:20 | obj | type tracker without call steps | type_tracker.rb:44:5:44:13 | ...[...] |
 | type_tracker.rb:34:18:34:20 | obj | type tracker without call steps | type_tracker.rb:52:5:52:13 | ...[...] |
 | type_tracker.rb:34:18:34:20 | obj | type tracker without call steps with content element | type_tracker.rb:38:13:38:25 | call to [] |
-| type_tracker.rb:34:18:34:20 | obj | type tracker without call steps with content element | type_tracker.rb:44:5:44:13 | ...[...] |
 | type_tracker.rb:34:18:34:20 | obj | type tracker without call steps with content element | type_tracker.rb:50:14:50:26 | call to [] |
-| type_tracker.rb:34:18:34:20 | obj | type tracker without call steps with content element | type_tracker.rb:52:5:52:13 | ...[...] |
 | type_tracker.rb:34:18:34:20 | obj | type tracker without call steps with content element 0 | type_tracker.rb:35:11:35:15 | * |
 | type_tracker.rb:34:18:34:20 | obj | type tracker without call steps with content element 0 or unknown | type_tracker.rb:35:11:35:15 | call to [] |
 | type_tracker.rb:34:18:34:20 | obj | type tracker without call steps with content element 0 or unknown | type_tracker.rb:42:14:42:26 | call to [] |
@@ -223,32 +221,26 @@ track
 | type_tracker.rb:42:14:42:26 | call to [] | type tracker without call steps | type_tracker.rb:42:14:42:26 | call to [] |
 | type_tracker.rb:42:15:42:15 | 1 | type tracker without call steps | type_tracker.rb:42:15:42:15 | 1 |
 | type_tracker.rb:42:15:42:15 | 1 | type tracker without call steps | type_tracker.rb:44:5:44:13 | ...[...] |
-| type_tracker.rb:42:15:42:15 | 1 | type tracker without call steps with content element | type_tracker.rb:44:5:44:13 | ...[...] |
 | type_tracker.rb:42:15:42:15 | 1 | type tracker without call steps with content element 0 | type_tracker.rb:42:14:42:26 | * |
 | type_tracker.rb:42:15:42:15 | 1 | type tracker without call steps with content element 0 or unknown | type_tracker.rb:42:14:42:26 | call to [] |
 | type_tracker.rb:42:17:42:17 | 2 | type tracker without call steps | type_tracker.rb:42:17:42:17 | 2 |
 | type_tracker.rb:42:17:42:17 | 2 | type tracker without call steps | type_tracker.rb:44:5:44:13 | ...[...] |
-| type_tracker.rb:42:17:42:17 | 2 | type tracker without call steps with content element | type_tracker.rb:44:5:44:13 | ...[...] |
 | type_tracker.rb:42:17:42:17 | 2 | type tracker without call steps with content element 1 | type_tracker.rb:42:14:42:26 | * |
 | type_tracker.rb:42:17:42:17 | 2 | type tracker without call steps with content element 1 or unknown | type_tracker.rb:42:14:42:26 | call to [] |
 | type_tracker.rb:42:19:42:19 | 3 | type tracker without call steps | type_tracker.rb:42:19:42:19 | 3 |
 | type_tracker.rb:42:19:42:19 | 3 | type tracker without call steps | type_tracker.rb:44:5:44:13 | ...[...] |
-| type_tracker.rb:42:19:42:19 | 3 | type tracker without call steps with content element | type_tracker.rb:44:5:44:13 | ...[...] |
 | type_tracker.rb:42:19:42:19 | 3 | type tracker without call steps with content element 2 | type_tracker.rb:42:14:42:26 | * |
 | type_tracker.rb:42:19:42:19 | 3 | type tracker without call steps with content element 2 or unknown | type_tracker.rb:42:14:42:26 | call to [] |
 | type_tracker.rb:42:21:42:21 | 4 | type tracker without call steps | type_tracker.rb:42:21:42:21 | 4 |
 | type_tracker.rb:42:21:42:21 | 4 | type tracker without call steps | type_tracker.rb:44:5:44:13 | ...[...] |
-| type_tracker.rb:42:21:42:21 | 4 | type tracker without call steps with content element | type_tracker.rb:44:5:44:13 | ...[...] |
 | type_tracker.rb:42:21:42:21 | 4 | type tracker without call steps with content element 3 | type_tracker.rb:42:14:42:26 | * |
 | type_tracker.rb:42:21:42:21 | 4 | type tracker without call steps with content element 3 or unknown | type_tracker.rb:42:14:42:26 | call to [] |
 | type_tracker.rb:42:23:42:23 | 5 | type tracker without call steps | type_tracker.rb:42:23:42:23 | 5 |
 | type_tracker.rb:42:23:42:23 | 5 | type tracker without call steps | type_tracker.rb:44:5:44:13 | ...[...] |
-| type_tracker.rb:42:23:42:23 | 5 | type tracker without call steps with content element | type_tracker.rb:44:5:44:13 | ...[...] |
 | type_tracker.rb:42:23:42:23 | 5 | type tracker without call steps with content element 4 | type_tracker.rb:42:14:42:26 | * |
 | type_tracker.rb:42:23:42:23 | 5 | type tracker without call steps with content element 4 or unknown | type_tracker.rb:42:14:42:26 | call to [] |
 | type_tracker.rb:42:25:42:25 | 6 | type tracker without call steps | type_tracker.rb:42:25:42:25 | 6 |
 | type_tracker.rb:42:25:42:25 | 6 | type tracker without call steps | type_tracker.rb:44:5:44:13 | ...[...] |
-| type_tracker.rb:42:25:42:25 | 6 | type tracker without call steps with content element | type_tracker.rb:44:5:44:13 | ...[...] |
 | type_tracker.rb:42:25:42:25 | 6 | type tracker without call steps with content element 5 | type_tracker.rb:42:14:42:26 | * |
 | type_tracker.rb:42:25:42:25 | 6 | type tracker without call steps with content element 5 or unknown | type_tracker.rb:42:14:42:26 | call to [] |
 | type_tracker.rb:43:5:43:10 | [post] array2 | type tracker without call steps | type_tracker.rb:43:5:43:10 | [post] array2 |
@@ -298,32 +290,26 @@ track
 | type_tracker.rb:50:14:50:26 | call to [] | type tracker without call steps | type_tracker.rb:50:14:50:26 | call to [] |
 | type_tracker.rb:50:15:50:15 | 1 | type tracker without call steps | type_tracker.rb:50:15:50:15 | 1 |
 | type_tracker.rb:50:15:50:15 | 1 | type tracker without call steps | type_tracker.rb:52:5:52:13 | ...[...] |
-| type_tracker.rb:50:15:50:15 | 1 | type tracker without call steps with content element | type_tracker.rb:52:5:52:13 | ...[...] |
 | type_tracker.rb:50:15:50:15 | 1 | type tracker without call steps with content element 0 | type_tracker.rb:50:14:50:26 | * |
 | type_tracker.rb:50:15:50:15 | 1 | type tracker without call steps with content element 0 or unknown | type_tracker.rb:50:14:50:26 | call to [] |
 | type_tracker.rb:50:17:50:17 | 2 | type tracker without call steps | type_tracker.rb:50:17:50:17 | 2 |
 | type_tracker.rb:50:17:50:17 | 2 | type tracker without call steps | type_tracker.rb:52:5:52:13 | ...[...] |
-| type_tracker.rb:50:17:50:17 | 2 | type tracker without call steps with content element | type_tracker.rb:52:5:52:13 | ...[...] |
 | type_tracker.rb:50:17:50:17 | 2 | type tracker without call steps with content element 1 | type_tracker.rb:50:14:50:26 | * |
 | type_tracker.rb:50:17:50:17 | 2 | type tracker without call steps with content element 1 or unknown | type_tracker.rb:50:14:50:26 | call to [] |
 | type_tracker.rb:50:19:50:19 | 3 | type tracker without call steps | type_tracker.rb:50:19:50:19 | 3 |
 | type_tracker.rb:50:19:50:19 | 3 | type tracker without call steps | type_tracker.rb:52:5:52:13 | ...[...] |
-| type_tracker.rb:50:19:50:19 | 3 | type tracker without call steps with content element | type_tracker.rb:52:5:52:13 | ...[...] |
 | type_tracker.rb:50:19:50:19 | 3 | type tracker without call steps with content element 2 | type_tracker.rb:50:14:50:26 | * |
 | type_tracker.rb:50:19:50:19 | 3 | type tracker without call steps with content element 2 or unknown | type_tracker.rb:50:14:50:26 | call to [] |
 | type_tracker.rb:50:21:50:21 | 4 | type tracker without call steps | type_tracker.rb:50:21:50:21 | 4 |
 | type_tracker.rb:50:21:50:21 | 4 | type tracker without call steps | type_tracker.rb:52:5:52:13 | ...[...] |
-| type_tracker.rb:50:21:50:21 | 4 | type tracker without call steps with content element | type_tracker.rb:52:5:52:13 | ...[...] |
 | type_tracker.rb:50:21:50:21 | 4 | type tracker without call steps with content element 3 | type_tracker.rb:50:14:50:26 | * |
 | type_tracker.rb:50:21:50:21 | 4 | type tracker without call steps with content element 3 or unknown | type_tracker.rb:50:14:50:26 | call to [] |
 | type_tracker.rb:50:23:50:23 | 5 | type tracker without call steps | type_tracker.rb:50:23:50:23 | 5 |
 | type_tracker.rb:50:23:50:23 | 5 | type tracker without call steps | type_tracker.rb:52:5:52:13 | ...[...] |
-| type_tracker.rb:50:23:50:23 | 5 | type tracker without call steps with content element | type_tracker.rb:52:5:52:13 | ...[...] |
 | type_tracker.rb:50:23:50:23 | 5 | type tracker without call steps with content element 4 | type_tracker.rb:50:14:50:26 | * |
 | type_tracker.rb:50:23:50:23 | 5 | type tracker without call steps with content element 4 or unknown | type_tracker.rb:50:14:50:26 | call to [] |
 | type_tracker.rb:50:25:50:25 | 6 | type tracker without call steps | type_tracker.rb:50:25:50:25 | 6 |
 | type_tracker.rb:50:25:50:25 | 6 | type tracker without call steps | type_tracker.rb:52:5:52:13 | ...[...] |
-| type_tracker.rb:50:25:50:25 | 6 | type tracker without call steps with content element | type_tracker.rb:52:5:52:13 | ...[...] |
 | type_tracker.rb:50:25:50:25 | 6 | type tracker without call steps with content element 5 | type_tracker.rb:50:14:50:26 | * |
 | type_tracker.rb:50:25:50:25 | 6 | type tracker without call steps with content element 5 or unknown | type_tracker.rb:50:14:50:26 | call to [] |
 | type_tracker.rb:51:5:51:10 | [post] array4 | type tracker without call steps | type_tracker.rb:51:5:51:10 | [post] array4 |

--- a/ruby/ql/test/library-tests/frameworks/action_controller/params-flow.expected
+++ b/ruby/ql/test/library-tests/frameworks/action_controller/params-flow.expected
@@ -60,20 +60,32 @@ edges
 | params_flow.rb:83:10:83:15 | call to params | params_flow.rb:83:10:83:27 | call to to_unsafe_h |
 | params_flow.rb:87:10:87:15 | call to params | params_flow.rb:87:10:87:30 | call to to_unsafe_hash |
 | params_flow.rb:91:10:91:15 | call to params | params_flow.rb:91:10:91:40 | call to transform_keys |
+| params_flow.rb:91:10:91:15 | call to params | params_flow.rb:91:10:91:40 | call to transform_keys [element] |
+| params_flow.rb:91:10:91:40 | call to transform_keys [element] | params_flow.rb:91:10:91:40 | call to transform_keys |
 | params_flow.rb:95:10:95:15 | call to params | params_flow.rb:95:10:95:41 | call to transform_keys! |
 | params_flow.rb:99:10:99:15 | call to params | params_flow.rb:99:10:99:42 | call to transform_values |
 | params_flow.rb:103:10:103:15 | call to params | params_flow.rb:103:10:103:43 | call to transform_values! |
 | params_flow.rb:107:10:107:15 | call to params | params_flow.rb:107:10:107:33 | call to values_at |
+| params_flow.rb:107:10:107:15 | call to params | params_flow.rb:107:10:107:33 | call to values_at [element 0] |
+| params_flow.rb:107:10:107:15 | call to params | params_flow.rb:107:10:107:33 | call to values_at [element 1] |
+| params_flow.rb:107:10:107:33 | call to values_at [element 0] | params_flow.rb:107:10:107:33 | call to values_at |
+| params_flow.rb:107:10:107:33 | call to values_at [element 1] | params_flow.rb:107:10:107:33 | call to values_at |
 | params_flow.rb:111:10:111:15 | call to params | params_flow.rb:111:10:111:29 | call to merge |
+| params_flow.rb:112:10:112:29 | call to merge [element 0] | params_flow.rb:112:10:112:29 | call to merge |
 | params_flow.rb:112:23:112:28 | call to params | params_flow.rb:112:10:112:29 | call to merge |
+| params_flow.rb:112:23:112:28 | call to params | params_flow.rb:112:10:112:29 | call to merge [element 0] |
 | params_flow.rb:116:10:116:15 | call to params | params_flow.rb:116:10:116:37 | call to reverse_merge |
 | params_flow.rb:117:31:117:36 | call to params | params_flow.rb:117:10:117:37 | call to reverse_merge |
 | params_flow.rb:121:10:121:15 | call to params | params_flow.rb:121:10:121:43 | call to with_defaults |
 | params_flow.rb:122:31:122:36 | call to params | params_flow.rb:122:10:122:37 | call to with_defaults |
 | params_flow.rb:126:10:126:15 | call to params | params_flow.rb:126:10:126:30 | call to merge! |
+| params_flow.rb:127:10:127:30 | call to merge! [element 0] | params_flow.rb:127:10:127:30 | call to merge! |
 | params_flow.rb:127:24:127:29 | call to params | params_flow.rb:127:10:127:30 | call to merge! |
+| params_flow.rb:127:24:127:29 | call to params | params_flow.rb:127:10:127:30 | call to merge! [element 0] |
 | params_flow.rb:130:5:130:5 | [post] p | params_flow.rb:131:10:131:10 | p |
+| params_flow.rb:130:5:130:5 | [post] p [element 0] | params_flow.rb:131:10:131:10 | p |
 | params_flow.rb:130:14:130:19 | call to params | params_flow.rb:130:5:130:5 | [post] p |
+| params_flow.rb:130:14:130:19 | call to params | params_flow.rb:130:5:130:5 | [post] p [element 0] |
 | params_flow.rb:135:10:135:15 | call to params | params_flow.rb:135:10:135:38 | call to reverse_merge! |
 | params_flow.rb:136:32:136:37 | call to params | params_flow.rb:136:10:136:38 | call to reverse_merge! |
 | params_flow.rb:139:5:139:5 | [post] p | params_flow.rb:140:10:140:10 | p |
@@ -172,6 +184,7 @@ nodes
 | params_flow.rb:87:10:87:30 | call to to_unsafe_hash | semmle.label | call to to_unsafe_hash |
 | params_flow.rb:91:10:91:15 | call to params | semmle.label | call to params |
 | params_flow.rb:91:10:91:40 | call to transform_keys | semmle.label | call to transform_keys |
+| params_flow.rb:91:10:91:40 | call to transform_keys [element] | semmle.label | call to transform_keys [element] |
 | params_flow.rb:95:10:95:15 | call to params | semmle.label | call to params |
 | params_flow.rb:95:10:95:41 | call to transform_keys! | semmle.label | call to transform_keys! |
 | params_flow.rb:99:10:99:15 | call to params | semmle.label | call to params |
@@ -180,9 +193,12 @@ nodes
 | params_flow.rb:103:10:103:43 | call to transform_values! | semmle.label | call to transform_values! |
 | params_flow.rb:107:10:107:15 | call to params | semmle.label | call to params |
 | params_flow.rb:107:10:107:33 | call to values_at | semmle.label | call to values_at |
+| params_flow.rb:107:10:107:33 | call to values_at [element 0] | semmle.label | call to values_at [element 0] |
+| params_flow.rb:107:10:107:33 | call to values_at [element 1] | semmle.label | call to values_at [element 1] |
 | params_flow.rb:111:10:111:15 | call to params | semmle.label | call to params |
 | params_flow.rb:111:10:111:29 | call to merge | semmle.label | call to merge |
 | params_flow.rb:112:10:112:29 | call to merge | semmle.label | call to merge |
+| params_flow.rb:112:10:112:29 | call to merge [element 0] | semmle.label | call to merge [element 0] |
 | params_flow.rb:112:23:112:28 | call to params | semmle.label | call to params |
 | params_flow.rb:116:10:116:15 | call to params | semmle.label | call to params |
 | params_flow.rb:116:10:116:37 | call to reverse_merge | semmle.label | call to reverse_merge |
@@ -195,8 +211,10 @@ nodes
 | params_flow.rb:126:10:126:15 | call to params | semmle.label | call to params |
 | params_flow.rb:126:10:126:30 | call to merge! | semmle.label | call to merge! |
 | params_flow.rb:127:10:127:30 | call to merge! | semmle.label | call to merge! |
+| params_flow.rb:127:10:127:30 | call to merge! [element 0] | semmle.label | call to merge! [element 0] |
 | params_flow.rb:127:24:127:29 | call to params | semmle.label | call to params |
 | params_flow.rb:130:5:130:5 | [post] p | semmle.label | [post] p |
+| params_flow.rb:130:5:130:5 | [post] p [element 0] | semmle.label | [post] p [element 0] |
 | params_flow.rb:130:14:130:19 | call to params | semmle.label | call to params |
 | params_flow.rb:131:10:131:10 | p | semmle.label | p |
 | params_flow.rb:135:10:135:15 | call to params | semmle.label | call to params |

--- a/ruby/ql/test/library-tests/frameworks/active_record/ActiveRecord.expected
+++ b/ruby/ql/test/library-tests/frameworks/active_record/ActiveRecord.expected
@@ -109,7 +109,6 @@ activeRecordSqlExecutionRanges
 | ActiveRecord.rb:28:30:28:44 | ...[...] |
 | ActiveRecord.rb:29:20:29:42 | "id = '#{...}'" |
 | ActiveRecord.rb:30:21:30:45 | call to [] |
-| ActiveRecord.rb:30:22:30:44 | "id = '#{...}'" |
 | ActiveRecord.rb:31:16:31:21 | <<-SQL |
 | ActiveRecord.rb:34:20:34:47 | "user.id = '#{...}'" |
 | ActiveRecord.rb:46:20:46:32 | ... + ... |

--- a/ruby/ql/test/library-tests/frameworks/active_support/active_support.rb
+++ b/ruby/ql/test/library-tests/frameworks/active_support/active_support.rb
@@ -244,7 +244,7 @@ def m_safe_buffer_insert
   b = source "b"
   x = ActionView::SafeBuffer.new(a)
   y = x.insert(i, b)
-  sink y # $hasTaintFlow=a
+  sink y # $hasTaintFlow=a $hasTaintFlow=b
 end
 
 def m_safe_buffer_prepend

--- a/ruby/ql/test/query-tests/security/cwe-079/ReflectedXSS.expected
+++ b/ruby/ql/test/query-tests/security/cwe-079/ReflectedXSS.expected
@@ -24,13 +24,19 @@ edges
 | app/controllers/foo/bars_controller.rb:30:5:30:7 | str | app/controllers/foo/bars_controller.rb:31:5:31:7 | str |
 | app/controllers/foo/bars_controller.rb:30:11:30:16 | call to params | app/controllers/foo/bars_controller.rb:30:11:30:28 | ...[...] |
 | app/controllers/foo/bars_controller.rb:30:11:30:28 | ...[...] | app/controllers/foo/bars_controller.rb:30:5:30:7 | str |
+| app/views/foo/bars/_widget.html.erb:5:9:5:20 | call to display_text [element] | app/views/foo/bars/_widget.html.erb:5:9:5:20 | call to display_text |
+| app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns [element :display_text, element] | app/views/foo/bars/_widget.html.erb:8:9:8:36 | ...[...] [element] |
 | app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns [element :display_text] | app/views/foo/bars/_widget.html.erb:8:9:8:36 | ...[...] |
+| app/views/foo/bars/_widget.html.erb:8:9:8:36 | ...[...] [element] | app/views/foo/bars/_widget.html.erb:8:9:8:36 | ...[...] |
 | app/views/foo/bars/show.html.erb:8:9:8:21 | call to local_assigns [element :display_text] | app/views/foo/bars/show.html.erb:8:9:8:36 | ...[...] |
 | app/views/foo/bars/show.html.erb:12:9:12:21 | call to local_assigns [element :display_text] | app/views/foo/bars/show.html.erb:12:9:12:26 | ...[...] |
 | app/views/foo/bars/show.html.erb:17:15:17:27 | call to local_assigns [element :display_text] | app/views/foo/bars/show.html.erb:17:15:17:32 | ...[...] |
 | app/views/foo/bars/show.html.erb:43:64:43:87 | ... + ... | app/views/foo/bars/_widget.html.erb:5:9:5:20 | call to display_text |
 | app/views/foo/bars/show.html.erb:43:64:43:87 | ... + ... | app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns [element :display_text] |
+| app/views/foo/bars/show.html.erb:43:64:43:87 | ... + ... [element] | app/views/foo/bars/_widget.html.erb:5:9:5:20 | call to display_text [element] |
+| app/views/foo/bars/show.html.erb:43:64:43:87 | ... + ... [element] | app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns [element :display_text, element] |
 | app/views/foo/bars/show.html.erb:43:76:43:87 | call to display_text | app/views/foo/bars/show.html.erb:43:64:43:87 | ... + ... |
+| app/views/foo/bars/show.html.erb:43:76:43:87 | call to display_text | app/views/foo/bars/show.html.erb:43:64:43:87 | ... + ... [element] |
 | app/views/foo/bars/show.html.erb:53:29:53:34 | call to params | app/views/foo/bars/show.html.erb:53:29:53:44 | ...[...] |
 | app/views/foo/bars/show.html.erb:56:13:56:18 | call to params | app/views/foo/bars/show.html.erb:56:13:56:28 | ...[...] |
 | app/views/foo/bars/show.html.erb:73:19:73:24 | call to params | app/views/foo/bars/show.html.erb:73:19:73:34 | ...[...] |
@@ -56,8 +62,11 @@ nodes
 | app/controllers/foo/bars_controller.rb:30:11:30:28 | ...[...] | semmle.label | ...[...] |
 | app/controllers/foo/bars_controller.rb:31:5:31:7 | str | semmle.label | str |
 | app/views/foo/bars/_widget.html.erb:5:9:5:20 | call to display_text | semmle.label | call to display_text |
+| app/views/foo/bars/_widget.html.erb:5:9:5:20 | call to display_text [element] | semmle.label | call to display_text [element] |
+| app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns [element :display_text, element] | semmle.label | call to local_assigns [element :display_text, element] |
 | app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns [element :display_text] | semmle.label | call to local_assigns [element :display_text] |
 | app/views/foo/bars/_widget.html.erb:8:9:8:36 | ...[...] | semmle.label | ...[...] |
+| app/views/foo/bars/_widget.html.erb:8:9:8:36 | ...[...] [element] | semmle.label | ...[...] [element] |
 | app/views/foo/bars/show.html.erb:2:18:2:30 | @user_website | semmle.label | @user_website |
 | app/views/foo/bars/show.html.erb:5:9:5:20 | call to display_text | semmle.label | call to display_text |
 | app/views/foo/bars/show.html.erb:8:9:8:21 | call to local_assigns [element :display_text] | semmle.label | call to local_assigns [element :display_text] |
@@ -69,6 +78,7 @@ nodes
 | app/views/foo/bars/show.html.erb:35:3:35:14 | call to display_text | semmle.label | call to display_text |
 | app/views/foo/bars/show.html.erb:40:3:40:16 | @instance_text | semmle.label | @instance_text |
 | app/views/foo/bars/show.html.erb:43:64:43:87 | ... + ... | semmle.label | ... + ... |
+| app/views/foo/bars/show.html.erb:43:64:43:87 | ... + ... [element] | semmle.label | ... + ... [element] |
 | app/views/foo/bars/show.html.erb:43:76:43:87 | call to display_text | semmle.label | call to display_text |
 | app/views/foo/bars/show.html.erb:46:5:46:13 | call to user_name | semmle.label | call to user_name |
 | app/views/foo/bars/show.html.erb:50:5:50:18 | call to user_name_memo | semmle.label | call to user_name_memo |

--- a/ruby/ql/test/query-tests/security/cwe-079/StoredXSS.expected
+++ b/ruby/ql/test/query-tests/security/cwe-079/StoredXSS.expected
@@ -9,13 +9,19 @@ edges
 | app/controllers/foo/stores_controller.rb:13:55:13:56 | dt | app/views/foo/stores/show.html.erb:14:15:14:27 | call to local_assigns [element :display_text] |
 | app/controllers/foo/stores_controller.rb:13:55:13:56 | dt | app/views/foo/stores/show.html.erb:32:3:32:14 | call to display_text |
 | app/controllers/foo/stores_controller.rb:13:55:13:56 | dt | app/views/foo/stores/show.html.erb:40:76:40:87 | call to display_text |
+| app/views/foo/bars/_widget.html.erb:5:9:5:20 | call to display_text [element] | app/views/foo/bars/_widget.html.erb:5:9:5:20 | call to display_text |
+| app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns [element :display_text, element] | app/views/foo/bars/_widget.html.erb:8:9:8:36 | ...[...] [element] |
 | app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns [element :display_text] | app/views/foo/bars/_widget.html.erb:8:9:8:36 | ...[...] |
+| app/views/foo/bars/_widget.html.erb:8:9:8:36 | ...[...] [element] | app/views/foo/bars/_widget.html.erb:8:9:8:36 | ...[...] |
 | app/views/foo/stores/show.html.erb:5:9:5:21 | call to local_assigns [element :display_text] | app/views/foo/stores/show.html.erb:5:9:5:36 | ...[...] |
 | app/views/foo/stores/show.html.erb:9:9:9:21 | call to local_assigns [element :display_text] | app/views/foo/stores/show.html.erb:9:9:9:26 | ...[...] |
 | app/views/foo/stores/show.html.erb:14:15:14:27 | call to local_assigns [element :display_text] | app/views/foo/stores/show.html.erb:14:15:14:32 | ...[...] |
 | app/views/foo/stores/show.html.erb:40:64:40:87 | ... + ... | app/views/foo/bars/_widget.html.erb:5:9:5:20 | call to display_text |
 | app/views/foo/stores/show.html.erb:40:64:40:87 | ... + ... | app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns [element :display_text] |
+| app/views/foo/stores/show.html.erb:40:64:40:87 | ... + ... [element] | app/views/foo/bars/_widget.html.erb:5:9:5:20 | call to display_text [element] |
+| app/views/foo/stores/show.html.erb:40:64:40:87 | ... + ... [element] | app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns [element :display_text, element] |
 | app/views/foo/stores/show.html.erb:40:76:40:87 | call to display_text | app/views/foo/stores/show.html.erb:40:64:40:87 | ... + ... |
+| app/views/foo/stores/show.html.erb:40:76:40:87 | call to display_text | app/views/foo/stores/show.html.erb:40:64:40:87 | ... + ... [element] |
 | app/views/foo/stores/show.html.erb:86:17:86:28 | call to handle | app/views/foo/stores/show.html.erb:86:3:86:29 | call to sprintf |
 nodes
 | app/controllers/foo/stores_controller.rb:8:5:8:6 | dt | semmle.label | dt |
@@ -23,8 +29,11 @@ nodes
 | app/controllers/foo/stores_controller.rb:9:22:9:23 | dt | semmle.label | dt |
 | app/controllers/foo/stores_controller.rb:13:55:13:56 | dt | semmle.label | dt |
 | app/views/foo/bars/_widget.html.erb:5:9:5:20 | call to display_text | semmle.label | call to display_text |
+| app/views/foo/bars/_widget.html.erb:5:9:5:20 | call to display_text [element] | semmle.label | call to display_text [element] |
+| app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns [element :display_text, element] | semmle.label | call to local_assigns [element :display_text, element] |
 | app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns [element :display_text] | semmle.label | call to local_assigns [element :display_text] |
 | app/views/foo/bars/_widget.html.erb:8:9:8:36 | ...[...] | semmle.label | ...[...] |
+| app/views/foo/bars/_widget.html.erb:8:9:8:36 | ...[...] [element] | semmle.label | ...[...] [element] |
 | app/views/foo/stores/show.html.erb:2:9:2:20 | call to display_text | semmle.label | call to display_text |
 | app/views/foo/stores/show.html.erb:5:9:5:21 | call to local_assigns [element :display_text] | semmle.label | call to local_assigns [element :display_text] |
 | app/views/foo/stores/show.html.erb:5:9:5:36 | ...[...] | semmle.label | ...[...] |
@@ -35,6 +44,7 @@ nodes
 | app/views/foo/stores/show.html.erb:32:3:32:14 | call to display_text | semmle.label | call to display_text |
 | app/views/foo/stores/show.html.erb:37:3:37:16 | @instance_text | semmle.label | @instance_text |
 | app/views/foo/stores/show.html.erb:40:64:40:87 | ... + ... | semmle.label | ... + ... |
+| app/views/foo/stores/show.html.erb:40:64:40:87 | ... + ... [element] | semmle.label | ... + ... [element] |
 | app/views/foo/stores/show.html.erb:40:76:40:87 | call to display_text | semmle.label | call to display_text |
 | app/views/foo/stores/show.html.erb:46:5:46:16 | call to handle | semmle.label | call to handle |
 | app/views/foo/stores/show.html.erb:63:3:63:18 | call to handle | semmle.label | call to handle |

--- a/ruby/ql/test/query-tests/security/cwe-089/SqlInjection.expected
+++ b/ruby/ql/test/query-tests/security/cwe-089/SqlInjection.expected
@@ -8,8 +8,10 @@ edges
 | ActiveRecordInjection.rb:43:29:43:39 | ...[...] | ActiveRecordInjection.rb:43:20:43:42 | "id = '#{...}'" |
 | ActiveRecordInjection.rb:48:30:48:35 | call to params | ActiveRecordInjection.rb:48:30:48:40 | ...[...] |
 | ActiveRecordInjection.rb:48:30:48:40 | ...[...] | ActiveRecordInjection.rb:48:21:48:43 | "id = '#{...}'" |
+| ActiveRecordInjection.rb:52:22:52:44 | "id = '#{...}'" | ActiveRecordInjection.rb:52:21:52:45 | call to [] |
 | ActiveRecordInjection.rb:52:31:52:36 | call to params | ActiveRecordInjection.rb:52:31:52:41 | ...[...] |
 | ActiveRecordInjection.rb:52:31:52:41 | ...[...] | ActiveRecordInjection.rb:52:22:52:44 | "id = '#{...}'" |
+| ActiveRecordInjection.rb:57:23:57:45 | "id = '#{...}'" | ActiveRecordInjection.rb:57:22:57:46 | call to [] |
 | ActiveRecordInjection.rb:57:32:57:37 | call to params | ActiveRecordInjection.rb:57:32:57:42 | ...[...] |
 | ActiveRecordInjection.rb:57:32:57:42 | ...[...] | ActiveRecordInjection.rb:57:23:57:45 | "id = '#{...}'" |
 | ActiveRecordInjection.rb:62:21:62:26 | call to params | ActiveRecordInjection.rb:62:21:62:35 | ...[...] |
@@ -35,6 +37,9 @@ edges
 | ActiveRecordInjection.rb:103:11:103:12 | ps | ActiveRecordInjection.rb:103:11:103:17 | ...[...] |
 | ActiveRecordInjection.rb:103:11:103:17 | ...[...] | ActiveRecordInjection.rb:103:5:103:7 | uid |
 | ActiveRecordInjection.rb:104:5:104:9 | uidEq | ActiveRecordInjection.rb:108:20:108:32 | ... + ... |
+| ActiveRecordInjection.rb:104:5:104:9 | uidEq | ActiveRecordInjection.rb:108:28:108:32 | uidEq |
+| ActiveRecordInjection.rb:108:20:108:32 | ... + ... [element] | ActiveRecordInjection.rb:108:20:108:32 | ... + ... |
+| ActiveRecordInjection.rb:108:28:108:32 | uidEq | ActiveRecordInjection.rb:108:20:108:32 | ... + ... [element] |
 | ActiveRecordInjection.rb:141:21:141:26 | call to params | ActiveRecordInjection.rb:141:21:141:44 | ...[...] |
 | ActiveRecordInjection.rb:141:21:141:26 | call to params | ActiveRecordInjection.rb:141:21:141:44 | ...[...] |
 | ActiveRecordInjection.rb:141:21:141:44 | ...[...] | ActiveRecordInjection.rb:20:22:20:30 | condition |
@@ -85,9 +90,11 @@ nodes
 | ActiveRecordInjection.rb:48:21:48:43 | "id = '#{...}'" | semmle.label | "id = '#{...}'" |
 | ActiveRecordInjection.rb:48:30:48:35 | call to params | semmle.label | call to params |
 | ActiveRecordInjection.rb:48:30:48:40 | ...[...] | semmle.label | ...[...] |
+| ActiveRecordInjection.rb:52:21:52:45 | call to [] | semmle.label | call to [] |
 | ActiveRecordInjection.rb:52:22:52:44 | "id = '#{...}'" | semmle.label | "id = '#{...}'" |
 | ActiveRecordInjection.rb:52:31:52:36 | call to params | semmle.label | call to params |
 | ActiveRecordInjection.rb:52:31:52:41 | ...[...] | semmle.label | ...[...] |
+| ActiveRecordInjection.rb:57:22:57:46 | call to [] | semmle.label | call to [] |
 | ActiveRecordInjection.rb:57:23:57:45 | "id = '#{...}'" | semmle.label | "id = '#{...}'" |
 | ActiveRecordInjection.rb:57:32:57:37 | call to params | semmle.label | call to params |
 | ActiveRecordInjection.rb:57:32:57:42 | ...[...] | semmle.label | ...[...] |
@@ -125,6 +132,8 @@ nodes
 | ActiveRecordInjection.rb:103:11:103:17 | ...[...] | semmle.label | ...[...] |
 | ActiveRecordInjection.rb:104:5:104:9 | uidEq | semmle.label | uidEq |
 | ActiveRecordInjection.rb:108:20:108:32 | ... + ... | semmle.label | ... + ... |
+| ActiveRecordInjection.rb:108:20:108:32 | ... + ... [element] | semmle.label | ... + ... [element] |
+| ActiveRecordInjection.rb:108:28:108:32 | uidEq | semmle.label | uidEq |
 | ActiveRecordInjection.rb:141:21:141:26 | call to params | semmle.label | call to params |
 | ActiveRecordInjection.rb:141:21:141:44 | ...[...] | semmle.label | ...[...] |
 | ActiveRecordInjection.rb:141:21:141:44 | ...[...] | semmle.label | ...[...] |
@@ -172,8 +181,8 @@ subpaths
 | ActiveRecordInjection.rb:39:18:39:32 | ...[...] | ActiveRecordInjection.rb:39:18:39:23 | call to params | ActiveRecordInjection.rb:39:18:39:32 | ...[...] | This SQL query depends on a $@. | ActiveRecordInjection.rb:39:18:39:23 | call to params | user-provided value |
 | ActiveRecordInjection.rb:43:20:43:42 | "id = '#{...}'" | ActiveRecordInjection.rb:43:29:43:34 | call to params | ActiveRecordInjection.rb:43:20:43:42 | "id = '#{...}'" | This SQL query depends on a $@. | ActiveRecordInjection.rb:43:29:43:34 | call to params | user-provided value |
 | ActiveRecordInjection.rb:48:21:48:43 | "id = '#{...}'" | ActiveRecordInjection.rb:48:30:48:35 | call to params | ActiveRecordInjection.rb:48:21:48:43 | "id = '#{...}'" | This SQL query depends on a $@. | ActiveRecordInjection.rb:48:30:48:35 | call to params | user-provided value |
-| ActiveRecordInjection.rb:52:22:52:44 | "id = '#{...}'" | ActiveRecordInjection.rb:52:31:52:36 | call to params | ActiveRecordInjection.rb:52:22:52:44 | "id = '#{...}'" | This SQL query depends on a $@. | ActiveRecordInjection.rb:52:31:52:36 | call to params | user-provided value |
-| ActiveRecordInjection.rb:57:23:57:45 | "id = '#{...}'" | ActiveRecordInjection.rb:57:32:57:37 | call to params | ActiveRecordInjection.rb:57:23:57:45 | "id = '#{...}'" | This SQL query depends on a $@. | ActiveRecordInjection.rb:57:32:57:37 | call to params | user-provided value |
+| ActiveRecordInjection.rb:52:21:52:45 | call to [] | ActiveRecordInjection.rb:52:31:52:36 | call to params | ActiveRecordInjection.rb:52:21:52:45 | call to [] | This SQL query depends on a $@. | ActiveRecordInjection.rb:52:31:52:36 | call to params | user-provided value |
+| ActiveRecordInjection.rb:57:22:57:46 | call to [] | ActiveRecordInjection.rb:57:32:57:37 | call to params | ActiveRecordInjection.rb:57:22:57:46 | call to [] | This SQL query depends on a $@. | ActiveRecordInjection.rb:57:32:57:37 | call to params | user-provided value |
 | ActiveRecordInjection.rb:61:16:61:21 | <<-SQL | ActiveRecordInjection.rb:62:21:62:26 | call to params | ActiveRecordInjection.rb:61:16:61:21 | <<-SQL | This SQL query depends on a $@. | ActiveRecordInjection.rb:62:21:62:26 | call to params | user-provided value |
 | ActiveRecordInjection.rb:68:20:68:47 | "user.id = '#{...}'" | ActiveRecordInjection.rb:68:34:68:39 | call to params | ActiveRecordInjection.rb:68:20:68:47 | "user.id = '#{...}'" | This SQL query depends on a $@. | ActiveRecordInjection.rb:68:34:68:39 | call to params | user-provided value |
 | ActiveRecordInjection.rb:74:32:74:54 | "id = '#{...}'" | ActiveRecordInjection.rb:74:41:74:46 | call to params | ActiveRecordInjection.rb:74:32:74:54 | "id = '#{...}'" | This SQL query depends on a $@. | ActiveRecordInjection.rb:74:41:74:46 | call to params | user-provided value |

--- a/ruby/ql/test/query-tests/security/cwe-094/CodeInjection/CodeInjection.expected
+++ b/ruby/ql/test/query-tests/security/cwe-094/CodeInjection/CodeInjection.expected
@@ -17,7 +17,9 @@ edges
 | CodeInjection.rb:38:24:38:27 | code | CodeInjection.rb:38:10:38:28 | call to escape |
 | CodeInjection.rb:38:24:38:27 | code | CodeInjection.rb:38:10:38:28 | call to escape |
 | CodeInjection.rb:78:5:78:8 | code | CodeInjection.rb:80:16:80:19 | code |
+| CodeInjection.rb:78:5:78:8 | code | CodeInjection.rb:86:10:86:25 | ... + ... |
 | CodeInjection.rb:78:5:78:8 | code | CodeInjection.rb:86:10:86:37 | ... + ... |
+| CodeInjection.rb:78:5:78:8 | code | CodeInjection.rb:86:22:86:25 | code |
 | CodeInjection.rb:78:5:78:8 | code | CodeInjection.rb:88:10:88:32 | "prefix_#{...}_suffix" |
 | CodeInjection.rb:78:5:78:8 | code | CodeInjection.rb:90:10:90:13 | code |
 | CodeInjection.rb:78:5:78:8 | code | CodeInjection.rb:90:10:90:13 | code |
@@ -25,6 +27,10 @@ edges
 | CodeInjection.rb:78:12:78:17 | call to params | CodeInjection.rb:78:12:78:24 | ...[...] |
 | CodeInjection.rb:78:12:78:24 | ...[...] | CodeInjection.rb:78:5:78:8 | code |
 | CodeInjection.rb:78:12:78:24 | ...[...] | CodeInjection.rb:78:5:78:8 | code |
+| CodeInjection.rb:86:10:86:25 | ... + ... | CodeInjection.rb:86:10:86:37 | ... + ... |
+| CodeInjection.rb:86:10:86:25 | ... + ... [element] | CodeInjection.rb:86:10:86:37 | ... + ... [element] |
+| CodeInjection.rb:86:10:86:37 | ... + ... [element] | CodeInjection.rb:86:10:86:37 | ... + ... |
+| CodeInjection.rb:86:22:86:25 | code | CodeInjection.rb:86:10:86:25 | ... + ... [element] |
 | CodeInjection.rb:101:3:102:5 | self in index [@foo] | CodeInjection.rb:111:3:113:5 | self in baz [@foo] |
 | CodeInjection.rb:101:3:102:5 | self in index [@foo] | CodeInjection.rb:111:3:113:5 | self in baz [@foo] |
 | CodeInjection.rb:105:5:105:8 | [post] self [@foo] | CodeInjection.rb:108:3:109:5 | self in bar [@foo] |
@@ -68,7 +74,11 @@ nodes
 | CodeInjection.rb:78:12:78:24 | ...[...] | semmle.label | ...[...] |
 | CodeInjection.rb:78:12:78:24 | ...[...] | semmle.label | ...[...] |
 | CodeInjection.rb:80:16:80:19 | code | semmle.label | code |
+| CodeInjection.rb:86:10:86:25 | ... + ... | semmle.label | ... + ... |
+| CodeInjection.rb:86:10:86:25 | ... + ... [element] | semmle.label | ... + ... [element] |
 | CodeInjection.rb:86:10:86:37 | ... + ... | semmle.label | ... + ... |
+| CodeInjection.rb:86:10:86:37 | ... + ... [element] | semmle.label | ... + ... [element] |
+| CodeInjection.rb:86:22:86:25 | code | semmle.label | code |
 | CodeInjection.rb:88:10:88:32 | "prefix_#{...}_suffix" | semmle.label | "prefix_#{...}_suffix" |
 | CodeInjection.rb:90:10:90:13 | code | semmle.label | code |
 | CodeInjection.rb:90:10:90:13 | code | semmle.label | code |

--- a/ruby/ql/test/query-tests/security/cwe-117/LogInjection.expected
+++ b/ruby/ql/test/query-tests/security/cwe-117/LogInjection.expected
@@ -1,19 +1,27 @@
 edges
 | app/controllers/users_controller.rb:15:5:15:15 | unsanitized | app/controllers/users_controller.rb:16:19:16:29 | unsanitized |
 | app/controllers/users_controller.rb:15:5:15:15 | unsanitized | app/controllers/users_controller.rb:17:19:17:41 | ... + ... |
+| app/controllers/users_controller.rb:15:5:15:15 | unsanitized | app/controllers/users_controller.rb:17:31:17:41 | unsanitized |
 | app/controllers/users_controller.rb:15:5:15:15 | unsanitized | app/controllers/users_controller.rb:23:20:23:30 | unsanitized |
 | app/controllers/users_controller.rb:15:19:15:24 | call to params | app/controllers/users_controller.rb:15:19:15:30 | ...[...] |
 | app/controllers/users_controller.rb:15:19:15:30 | ...[...] | app/controllers/users_controller.rb:15:5:15:15 | unsanitized |
+| app/controllers/users_controller.rb:17:19:17:41 | ... + ... [element] | app/controllers/users_controller.rb:17:19:17:41 | ... + ... |
+| app/controllers/users_controller.rb:17:31:17:41 | unsanitized | app/controllers/users_controller.rb:17:19:17:41 | ... + ... [element] |
 | app/controllers/users_controller.rb:23:20:23:30 | unsanitized | app/controllers/users_controller.rb:23:20:23:44 | call to sub |
 | app/controllers/users_controller.rb:23:20:23:44 | call to sub | app/controllers/users_controller.rb:24:18:26:7 | do ... end [captured unsanitized2] |
 | app/controllers/users_controller.rb:23:20:23:44 | call to sub | app/controllers/users_controller.rb:27:16:27:39 | ... + ... |
+| app/controllers/users_controller.rb:23:20:23:44 | call to sub | app/controllers/users_controller.rb:27:28:27:39 | unsanitized2 |
 | app/controllers/users_controller.rb:24:18:26:7 | do ... end [captured unsanitized2] | app/controllers/users_controller.rb:25:7:25:18 | unsanitized2 |
+| app/controllers/users_controller.rb:27:16:27:39 | ... + ... [element] | app/controllers/users_controller.rb:27:16:27:39 | ... + ... |
+| app/controllers/users_controller.rb:27:28:27:39 | unsanitized2 | app/controllers/users_controller.rb:27:16:27:39 | ... + ... [element] |
 | app/controllers/users_controller.rb:33:19:33:25 | call to cookies | app/controllers/users_controller.rb:33:19:33:31 | ...[...] |
 | app/controllers/users_controller.rb:33:19:33:31 | ...[...] | app/controllers/users_controller.rb:34:31:34:45 | { ... } [captured unsanitized] |
 | app/controllers/users_controller.rb:33:19:33:31 | ...[...] | app/controllers/users_controller.rb:35:31:35:57 | { ... } [captured unsanitized] |
 | app/controllers/users_controller.rb:34:31:34:45 | { ... } [captured unsanitized] | app/controllers/users_controller.rb:34:33:34:43 | unsanitized |
 | app/controllers/users_controller.rb:35:31:35:57 | { ... } [captured unsanitized] | app/controllers/users_controller.rb:35:45:35:55 | unsanitized |
+| app/controllers/users_controller.rb:35:33:35:55 | ... + ... [element] | app/controllers/users_controller.rb:35:33:35:55 | ... + ... |
 | app/controllers/users_controller.rb:35:45:35:55 | unsanitized | app/controllers/users_controller.rb:35:33:35:55 | ... + ... |
+| app/controllers/users_controller.rb:35:45:35:55 | unsanitized | app/controllers/users_controller.rb:35:33:35:55 | ... + ... [element] |
 | app/controllers/users_controller.rb:49:19:49:24 | call to params | app/controllers/users_controller.rb:49:19:49:30 | ...[...] |
 nodes
 | app/controllers/users_controller.rb:15:5:15:15 | unsanitized | semmle.label | unsanitized |
@@ -21,17 +29,22 @@ nodes
 | app/controllers/users_controller.rb:15:19:15:30 | ...[...] | semmle.label | ...[...] |
 | app/controllers/users_controller.rb:16:19:16:29 | unsanitized | semmle.label | unsanitized |
 | app/controllers/users_controller.rb:17:19:17:41 | ... + ... | semmle.label | ... + ... |
+| app/controllers/users_controller.rb:17:19:17:41 | ... + ... [element] | semmle.label | ... + ... [element] |
+| app/controllers/users_controller.rb:17:31:17:41 | unsanitized | semmle.label | unsanitized |
 | app/controllers/users_controller.rb:23:20:23:30 | unsanitized | semmle.label | unsanitized |
 | app/controllers/users_controller.rb:23:20:23:44 | call to sub | semmle.label | call to sub |
 | app/controllers/users_controller.rb:24:18:26:7 | do ... end [captured unsanitized2] | semmle.label | do ... end [captured unsanitized2] |
 | app/controllers/users_controller.rb:25:7:25:18 | unsanitized2 | semmle.label | unsanitized2 |
 | app/controllers/users_controller.rb:27:16:27:39 | ... + ... | semmle.label | ... + ... |
+| app/controllers/users_controller.rb:27:16:27:39 | ... + ... [element] | semmle.label | ... + ... [element] |
+| app/controllers/users_controller.rb:27:28:27:39 | unsanitized2 | semmle.label | unsanitized2 |
 | app/controllers/users_controller.rb:33:19:33:25 | call to cookies | semmle.label | call to cookies |
 | app/controllers/users_controller.rb:33:19:33:31 | ...[...] | semmle.label | ...[...] |
 | app/controllers/users_controller.rb:34:31:34:45 | { ... } [captured unsanitized] | semmle.label | { ... } [captured unsanitized] |
 | app/controllers/users_controller.rb:34:33:34:43 | unsanitized | semmle.label | unsanitized |
 | app/controllers/users_controller.rb:35:31:35:57 | { ... } [captured unsanitized] | semmle.label | { ... } [captured unsanitized] |
 | app/controllers/users_controller.rb:35:33:35:55 | ... + ... | semmle.label | ... + ... |
+| app/controllers/users_controller.rb:35:33:35:55 | ... + ... [element] | semmle.label | ... + ... [element] |
 | app/controllers/users_controller.rb:35:45:35:55 | unsanitized | semmle.label | unsanitized |
 | app/controllers/users_controller.rb:49:19:49:24 | call to params | semmle.label | call to params |
 | app/controllers/users_controller.rb:49:19:49:30 | ...[...] | semmle.label | ...[...] |

--- a/ruby/ql/test/query-tests/security/cwe-1333-regexp-injection/RegExpInjection.expected
+++ b/ruby/ql/test/query-tests/security/cwe-1333-regexp-injection/RegExpInjection.expected
@@ -9,11 +9,17 @@ edges
 | RegExpInjection.rb:16:12:16:17 | call to params | RegExpInjection.rb:16:12:16:24 | ...[...] |
 | RegExpInjection.rb:16:12:16:24 | ...[...] | RegExpInjection.rb:16:5:16:8 | name |
 | RegExpInjection.rb:22:5:22:8 | name | RegExpInjection.rb:23:24:23:33 | ... + ... |
+| RegExpInjection.rb:22:5:22:8 | name | RegExpInjection.rb:23:30:23:33 | name |
 | RegExpInjection.rb:22:12:22:17 | call to params | RegExpInjection.rb:22:12:22:24 | ...[...] |
 | RegExpInjection.rb:22:12:22:24 | ...[...] | RegExpInjection.rb:22:5:22:8 | name |
+| RegExpInjection.rb:23:24:23:33 | ... + ... [element] | RegExpInjection.rb:23:24:23:33 | ... + ... |
+| RegExpInjection.rb:23:30:23:33 | name | RegExpInjection.rb:23:24:23:33 | ... + ... [element] |
 | RegExpInjection.rb:54:5:54:8 | name | RegExpInjection.rb:55:28:55:37 | ... + ... |
+| RegExpInjection.rb:54:5:54:8 | name | RegExpInjection.rb:55:34:55:37 | name |
 | RegExpInjection.rb:54:12:54:17 | call to params | RegExpInjection.rb:54:12:54:24 | ...[...] |
 | RegExpInjection.rb:54:12:54:24 | ...[...] | RegExpInjection.rb:54:5:54:8 | name |
+| RegExpInjection.rb:55:28:55:37 | ... + ... [element] | RegExpInjection.rb:55:28:55:37 | ... + ... |
+| RegExpInjection.rb:55:34:55:37 | name | RegExpInjection.rb:55:28:55:37 | ... + ... [element] |
 nodes
 | RegExpInjection.rb:4:5:4:8 | name | semmle.label | name |
 | RegExpInjection.rb:4:12:4:17 | call to params | semmle.label | call to params |
@@ -31,10 +37,14 @@ nodes
 | RegExpInjection.rb:22:12:22:17 | call to params | semmle.label | call to params |
 | RegExpInjection.rb:22:12:22:24 | ...[...] | semmle.label | ...[...] |
 | RegExpInjection.rb:23:24:23:33 | ... + ... | semmle.label | ... + ... |
+| RegExpInjection.rb:23:24:23:33 | ... + ... [element] | semmle.label | ... + ... [element] |
+| RegExpInjection.rb:23:30:23:33 | name | semmle.label | name |
 | RegExpInjection.rb:54:5:54:8 | name | semmle.label | name |
 | RegExpInjection.rb:54:12:54:17 | call to params | semmle.label | call to params |
 | RegExpInjection.rb:54:12:54:24 | ...[...] | semmle.label | ...[...] |
 | RegExpInjection.rb:55:28:55:37 | ... + ... | semmle.label | ... + ... |
+| RegExpInjection.rb:55:28:55:37 | ... + ... [element] | semmle.label | ... + ... [element] |
+| RegExpInjection.rb:55:34:55:37 | name | semmle.label | name |
 subpaths
 #select
 | RegExpInjection.rb:5:13:5:21 | /#{...}/ | RegExpInjection.rb:4:12:4:17 | call to params | RegExpInjection.rb:5:13:5:21 | /#{...}/ | This regular expression depends on a $@. | RegExpInjection.rb:4:12:4:17 | call to params | user-provided value |

--- a/ruby/ql/test/query-tests/security/cwe-134/TaintedFormatString.expected
+++ b/ruby/ql/test/query-tests/security/cwe-134/TaintedFormatString.expected
@@ -8,8 +8,10 @@ edges
 | tainted_format_string.rb:21:27:21:32 | call to params | tainted_format_string.rb:21:27:21:41 | ...[...] |
 | tainted_format_string.rb:22:20:22:25 | call to params | tainted_format_string.rb:22:20:22:34 | ...[...] |
 | tainted_format_string.rb:28:19:28:24 | call to params | tainted_format_string.rb:28:19:28:33 | ...[...] |
+| tainted_format_string.rb:33:12:33:46 | ... + ... [element] | tainted_format_string.rb:33:12:33:46 | ... + ... |
 | tainted_format_string.rb:33:32:33:37 | call to params | tainted_format_string.rb:33:32:33:46 | ...[...] |
 | tainted_format_string.rb:33:32:33:46 | ...[...] | tainted_format_string.rb:33:12:33:46 | ... + ... |
+| tainted_format_string.rb:33:32:33:46 | ...[...] | tainted_format_string.rb:33:12:33:46 | ... + ... [element] |
 | tainted_format_string.rb:36:30:36:35 | call to params | tainted_format_string.rb:36:30:36:44 | ...[...] |
 | tainted_format_string.rb:36:30:36:44 | ...[...] | tainted_format_string.rb:36:12:36:46 | "A log message: #{...}" |
 | tainted_format_string.rb:39:22:39:27 | call to params | tainted_format_string.rb:39:22:39:36 | ...[...] |
@@ -36,6 +38,7 @@ nodes
 | tainted_format_string.rb:28:19:28:24 | call to params | semmle.label | call to params |
 | tainted_format_string.rb:28:19:28:33 | ...[...] | semmle.label | ...[...] |
 | tainted_format_string.rb:33:12:33:46 | ... + ... | semmle.label | ... + ... |
+| tainted_format_string.rb:33:12:33:46 | ... + ... [element] | semmle.label | ... + ... [element] |
 | tainted_format_string.rb:33:32:33:37 | call to params | semmle.label | call to params |
 | tainted_format_string.rb:33:32:33:46 | ...[...] | semmle.label | ...[...] |
 | tainted_format_string.rb:36:12:36:46 | "A log message: #{...}" | semmle.label | "A log message: #{...}" |


### PR DESCRIPTION
In this PR we allow for data to be stored inside an array (possibly nested) when reaching a sink in taint tracking. In order to avoid spurious flow, I had to limit the flow summary for `[]` (`ElementReferenceReadUnknownSummary`) to no longer account for the (very unlikely?) case that the unknown index expression might be a range.