### PR TITLE
C++: Fix join-order problem in cpp/overrun-write

### DIFF
--- a/cpp/ql/src/experimental/Likely Bugs/OverrunWriteProductFlow.ql
+++ b/cpp/ql/src/experimental/Likely Bugs/OverrunWriteProductFlow.ql
@@ -62,11 +62,16 @@ predicate hasSize(AllocationExpr alloc, DataFlow::Node n, string state) {
 predicate isSinkPairImpl(
   CallInstruction c, DataFlow::Node bufSink, DataFlow::Node sizeSink, int delta, Expr eBuf
 ) {
-  exists(int bufIndex, int sizeIndex, Instruction sizeInstr, Instruction bufInstr |
+  exists(
+    int bufIndex, int sizeIndex, Instruction sizeInstr, Instruction bufInstr, ArrayFunction func
+  |
     bufInstr = bufSink.asInstruction() and
     c.getArgument(bufIndex) = bufInstr and
     sizeInstr = sizeSink.asInstruction() and
-    c.getStaticCallTarget().(ArrayFunction).hasArrayWithVariableSize(bufIndex, sizeIndex) and
+    c.getStaticCallTarget() = func and
+    pragma[only_bind_into](func)
+        .hasArrayWithVariableSize(pragma[only_bind_into](bufIndex),
+          pragma[only_bind_into](sizeIndex)) and
     bounded(c.getArgument(sizeIndex), sizeInstr, delta) and
     eBuf = bufInstr.getUnconvertedResultExpression()
   )


### PR DESCRIPTION
Before on Wireshark:
```
[2023-03-27 12:59:25] Evaluated non-recursive predicate OverrunWriteProductFlow#fb5ce006::isSinkPairImpl#5#fffff@2ba90584 in 99742ms (size: 52640).
Evaluated relational algebra for predicate OverrunWriteProductFlow#fb5ce006::isSinkPairImpl#5#fffff@2ba90584 with tuple counts:
        1047588019  ~1%    {3} r1 = JOIN DataFlowUtil#47741e1f::InstructionNode#fff_20#join_rhs WITH OverrunWriteProductFlow#fb5ce006::bounded#3#fff_102#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Rhs.2
          67558965  ~0%    {4} r2 = JOIN r1 WITH Instruction#577b6a83::CallInstruction::getArgument#fbf_201#join_rhs ON FIRST 1 OUTPUT Rhs.2, Lhs.1, Lhs.2, Rhs.1
         613572640  ~0%    {5} r3 = JOIN r2 WITH ArrayFunction#ca0b6b68::ArrayFunction::hasArrayWithVariableSize#2#dispred#fff_201#join_rhs ON FIRST 1 OUTPUT Lhs.3, Rhs.1, Lhs.1, Lhs.2, Rhs.2
             52640  ~0%    {4} r4 = JOIN r3 WITH Instruction#577b6a83::CallInstruction::getStaticCallTarget#0#dispred#ff ON FIRST 2 OUTPUT Lhs.0, Lhs.4, Lhs.2, Lhs.3
             52640  ~0%    {4} r5 = JOIN r4 WITH Instruction#577b6a83::CallInstruction::getArgument#fbf ON FIRST 2 OUTPUT Rhs.2, Lhs.2, Lhs.3, Lhs.0
             52640  ~0%    {5} r6 = JOIN r5 WITH DataFlowUtil#47741e1f::InstructionNode#fff_20#join_rhs ON FIRST 1 OUTPUT Lhs.0, Lhs.1, Lhs.2, Lhs.3, Rhs.1
             52640  ~0%    {5} r7 = JOIN r6 WITH Instruction#577b6a83::Instruction::getUnconvertedResultExpression#0#dispred#ff ON FIRST 1 OUTPUT Lhs.3, Lhs.4, Lhs.1, Lhs.2, Rhs.1
                           return r7
```

After:
```
[2023-03-27 13:56:36] Evaluated non-recursive predicate OverrunWriteProductFlow#fb5ce006::isSinkPairImpl#5#fffff@f936aapd in 777ms (size: 52640).
Evaluated relational algebra for predicate OverrunWriteProductFlow#fb5ce006::isSinkPairImpl#5#fffff@f936aapd with tuple counts:
        565480  ~5%    {2} r1 = SCAN Instruction#577b6a83::CallInstruction::getStaticCallTarget#0#dispred#ff OUTPUT In.1, In.0
          4420  ~1%    {3} r2 = JOIN r1 WITH ArrayFunction#ca0b6b68::ArrayFunction::hasArrayWithVariableSize#2#dispred#fff ON FIRST 1 OUTPUT Lhs.1, Rhs.1, Rhs.2
          4420  ~0%    {3} r3 = JOIN r2 WITH Instruction#577b6a83::CallInstruction::getArgument#fff ON FIRST 2 OUTPUT Rhs.2, Lhs.2, Lhs.0
          4420  ~0%    {4} r4 = JOIN r3 WITH DataFlowUtil#47741e1f::InstructionNode#fff_20#join_rhs ON FIRST 1 OUTPUT Lhs.0, Lhs.1, Lhs.2, Rhs.1
          4420  ~0%    {4} r5 = JOIN r4 WITH Instruction#577b6a83::Instruction::getUnconvertedResultExpression#0#dispred#ff ON FIRST 1 OUTPUT Lhs.2, Lhs.1, Lhs.3, Rhs.1
          4420  ~3%    {4} r6 = JOIN r5 WITH Instruction#577b6a83::CallInstruction::getArgument#fff ON FIRST 2 OUTPUT Rhs.2, Lhs.0, Lhs.2, Lhs.3
         52825  ~0%    {5} r7 = JOIN r6 WITH OverrunWriteProductFlow#fb5ce006::bounded#3#fff ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3, Rhs.2
         52640  ~0%    {5} r8 = JOIN r7 WITH DataFlowUtil#47741e1f::InstructionNode#fff_20#join_rhs ON FIRST 1 OUTPUT Lhs.1, Lhs.2, Rhs.1, Lhs.4, Lhs.3
                       return r8
```