### PR TITLE
JS: Improved coverage for disabled certificate validation

### DIFF
--- a/javascript/ql/src/Security/CWE-295/DisablingCertificateValidation.ql
+++ b/javascript/ql/src/Security/CWE-295/DisablingCertificateValidation.ql
@@ -19,6 +19,8 @@ DataFlow::InvokeNode tlsInvocation() {
   or
   result = DataFlow::moduleMember("https", "Agent").getAnInstantiation()
   or
+  result = DataFlow::moduleMember("https", "createServer").getACall()
+  or
   exists(DataFlow::NewNode new |
     new = DataFlow::moduleMember("tls", "TLSSocket").getAnInstantiation()
   |

--- a/javascript/ql/src/change-notes/2023-03-27-disabling-certificate-validation.md
+++ b/javascript/ql/src/change-notes/2023-03-27-disabling-certificate-validation.md
@@ -1,0 +1,4 @@
+---
+category: majorAnalysis
+---
+* The `DisablingCertificateValidation.ql` query has been updated to check `createServer` from `https` for disabled certificate validation.

--- a/javascript/ql/src/change-notes/2023-03-27-disabling-certificate-validation.md
+++ b/javascript/ql/src/change-notes/2023-03-27-disabling-certificate-validation.md
@@ -1,4 +1,4 @@
 ---
-category: majorAnalysis
+category: minorAnalysis
 ---
 * The `DisablingCertificateValidation.ql` query has been updated to check `createServer` from `https` for disabled certificate validation.

--- a/javascript/ql/test/query-tests/Security/CWE-295/DisablingCertificateValidation.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-295/DisablingCertificateValidation.expected
@@ -9,3 +9,4 @@
 | tst.js:45:2:45:28 | rejectU ... !!false | Disabling certificate validation is strongly discouraged. |
 | tst.js:48:2:48:26 | rejectU ... : !true | Disabling certificate validation is strongly discouraged. |
 | tst.js:74:9:74:33 | rejectU ... : false | Disabling certificate validation is strongly discouraged. |
+| tst.js:80:5:80:29 | rejectU ... : false | Disabling certificate validation is strongly discouraged. |

--- a/javascript/ql/test/query-tests/Security/CWE-295/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-295/tst.js
@@ -75,3 +75,7 @@ function getSomeunsafeOptions() {
     }
 }
 new https.Agent(getSomeunsafeOptions());
+
+https.createServer({
+    rejectUnauthorized: false // NOT OK
+});


### PR DESCRIPTION
The `DisablingCertificateValidation.ql` query has been improved by checking `createServer` from `https` for disabled certificate validation.