### PR TITLE
Dataflow: Remove accidentally exposed predicates.

### DIFF
--- a/cpp/ql/lib/change-notes/2023-03-28-dataflow-rm-footgun.md
+++ b/cpp/ql/lib/change-notes/2023-03-28-dataflow-rm-footgun.md
@@ -1,0 +1,4 @@
+---
+category: fix
+---
+* Fixed some accidental predicate visibility in the backwards-compatible wrapper for data flow configurations. In particular `DataFlow::hasFlowPath`, `DataFlow::hasFlow`, `DataFlow::hasFlowTo`, and `DataFlow::hasFlowToExpr` were accidentally exposed in a single version.

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl1.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl1.qll
@@ -328,7 +328,6 @@ private module Config implements FullStateConfigSig {
 }
 
 private import Impl<Config> as I
-import I
 
 /**
  * A `Node` augmented with a call context (except for sinks), an access path, and a configuration.
@@ -379,6 +378,8 @@ class PathNode instanceof I::PathNode {
   final predicate isSinkGroup(string group) { super.isSinkGroup(group) }
 }
 
+module PathGraph = I::PathGraph;
+
 private predicate hasFlow(Node source, Node sink, Configuration config) {
   exists(PathNode source0, PathNode sink0 |
     hasFlowPath(source0, sink0, config) and
@@ -388,7 +389,7 @@ private predicate hasFlow(Node source, Node sink, Configuration config) {
 }
 
 private predicate hasFlowPath(PathNode source, PathNode sink, Configuration config) {
-  flowPath(source, sink) and source.getConfiguration() = config
+  I::flowPath(source, sink) and source.getConfiguration() = config
 }
 
 private predicate hasFlowTo(Node sink, Configuration config) { hasFlow(_, sink, config) }

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
@@ -328,7 +328,6 @@ private module Config implements FullStateConfigSig {
 }
 
 private import Impl<Config> as I
-import I
 
 /**
  * A `Node` augmented with a call context (except for sinks), an access path, and a configuration.
@@ -379,6 +378,8 @@ class PathNode instanceof I::PathNode {
   final predicate isSinkGroup(string group) { super.isSinkGroup(group) }
 }
 
+module PathGraph = I::PathGraph;
+
 private predicate hasFlow(Node source, Node sink, Configuration config) {
   exists(PathNode source0, PathNode sink0 |
     hasFlowPath(source0, sink0, config) and
@@ -388,7 +389,7 @@ private predicate hasFlow(Node source, Node sink, Configuration config) {
 }
 
 private predicate hasFlowPath(PathNode source, PathNode sink, Configuration config) {
-  flowPath(source, sink) and source.getConfiguration() = config
+  I::flowPath(source, sink) and source.getConfiguration() = config
 }
 
 private predicate hasFlowTo(Node sink, Configuration config) { hasFlow(_, sink, config) }

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
@@ -328,7 +328,6 @@ private module Config implements FullStateConfigSig {
 }
 
 private import Impl<Config> as I
-import I
 
 /**
  * A `Node` augmented with a call context (except for sinks), an access path, and a configuration.
@@ -379,6 +378,8 @@ class PathNode instanceof I::PathNode {
   final predicate isSinkGroup(string group) { super.isSinkGroup(group) }
 }
 
+module PathGraph = I::PathGraph;
+
 private predicate hasFlow(Node source, Node sink, Configuration config) {
   exists(PathNode source0, PathNode sink0 |
     hasFlowPath(source0, sink0, config) and
@@ -388,7 +389,7 @@ private predicate hasFlow(Node source, Node sink, Configuration config) {
 }
 
 private predicate hasFlowPath(PathNode source, PathNode sink, Configuration config) {
-  flowPath(source, sink) and source.getConfiguration() = config
+  I::flowPath(source, sink) and source.getConfiguration() = config
 }
 
 private predicate hasFlowTo(Node sink, Configuration config) { hasFlow(_, sink, config) }

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
@@ -328,7 +328,6 @@ private module Config implements FullStateConfigSig {
 }
 
 private import Impl<Config> as I
-import I
 
 /**
  * A `Node` augmented with a call context (except for sinks), an access path, and a configuration.
@@ -379,6 +378,8 @@ class PathNode instanceof I::PathNode {
   final predicate isSinkGroup(string group) { super.isSinkGroup(group) }
 }
 
+module PathGraph = I::PathGraph;
+
 private predicate hasFlow(Node source, Node sink, Configuration config) {
   exists(PathNode source0, PathNode sink0 |
     hasFlowPath(source0, sink0, config) and
@@ -388,7 +389,7 @@ private predicate hasFlow(Node source, Node sink, Configuration config) {
 }
 
 private predicate hasFlowPath(PathNode source, PathNode sink, Configuration config) {
-  flowPath(source, sink) and source.getConfiguration() = config
+  I::flowPath(source, sink) and source.getConfiguration() = config
 }
 
 private predicate hasFlowTo(Node sink, Configuration config) { hasFlow(_, sink, config) }

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
@@ -328,7 +328,6 @@ private module Config implements FullStateConfigSig {
 }
 
 private import Impl<Config> as I
-import I
 
 /**
  * A `Node` augmented with a call context (except for sinks), an access path, and a configuration.
@@ -379,6 +378,8 @@ class PathNode instanceof I::PathNode {
   final predicate isSinkGroup(string group) { super.isSinkGroup(group) }
 }
 
+module PathGraph = I::PathGraph;
+
 private predicate hasFlow(Node source, Node sink, Configuration config) {
   exists(PathNode source0, PathNode sink0 |
     hasFlowPath(source0, sink0, config) and
@@ -388,7 +389,7 @@ private predicate hasFlow(Node source, Node sink, Configuration config) {
 }
 
 private predicate hasFlowPath(PathNode source, PathNode sink, Configuration config) {
-  flowPath(source, sink) and source.getConfiguration() = config
+  I::flowPath(source, sink) and source.getConfiguration() = config
 }
 
 private predicate hasFlowTo(Node sink, Configuration config) { hasFlow(_, sink, config) }

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl1.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl1.qll
@@ -328,7 +328,6 @@ private module Config implements FullStateConfigSig {
 }
 
 private import Impl<Config> as I
-import I
 
 /**
  * A `Node` augmented with a call context (except for sinks), an access path, and a configuration.
@@ -379,6 +378,8 @@ class PathNode instanceof I::PathNode {
   final predicate isSinkGroup(string group) { super.isSinkGroup(group) }
 }
 
+module PathGraph = I::PathGraph;
+
 private predicate hasFlow(Node source, Node sink, Configuration config) {
   exists(PathNode source0, PathNode sink0 |
     hasFlowPath(source0, sink0, config) and
@@ -388,7 +389,7 @@ private predicate hasFlow(Node source, Node sink, Configuration config) {
 }
 
 private predicate hasFlowPath(PathNode source, PathNode sink, Configuration config) {
-  flowPath(source, sink) and source.getConfiguration() = config
+  I::flowPath(source, sink) and source.getConfiguration() = config
 }
 
 private predicate hasFlowTo(Node sink, Configuration config) { hasFlow(_, sink, config) }

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -328,7 +328,6 @@ private module Config implements FullStateConfigSig {
 }
 
 private import Impl<Config> as I
-import I
 
 /**
  * A `Node` augmented with a call context (except for sinks), an access path, and a configuration.
@@ -379,6 +378,8 @@ class PathNode instanceof I::PathNode {
   final predicate isSinkGroup(string group) { super.isSinkGroup(group) }
 }
 
+module PathGraph = I::PathGraph;
+
 private predicate hasFlow(Node source, Node sink, Configuration config) {
   exists(PathNode source0, PathNode sink0 |
     hasFlowPath(source0, sink0, config) and
@@ -388,7 +389,7 @@ private predicate hasFlow(Node source, Node sink, Configuration config) {
 }
 
 private predicate hasFlowPath(PathNode source, PathNode sink, Configuration config) {
-  flowPath(source, sink) and source.getConfiguration() = config
+  I::flowPath(source, sink) and source.getConfiguration() = config
 }
 
 private predicate hasFlowTo(Node sink, Configuration config) { hasFlow(_, sink, config) }

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -328,7 +328,6 @@ private module Config implements FullStateConfigSig {
 }
 
 private import Impl<Config> as I
-import I
 
 /**
  * A `Node` augmented with a call context (except for sinks), an access path, and a configuration.
@@ -379,6 +378,8 @@ class PathNode instanceof I::PathNode {
   final predicate isSinkGroup(string group) { super.isSinkGroup(group) }
 }
 
+module PathGraph = I::PathGraph;
+
 private predicate hasFlow(Node source, Node sink, Configuration config) {
   exists(PathNode source0, PathNode sink0 |
     hasFlowPath(source0, sink0, config) and
@@ -388,7 +389,7 @@ private predicate hasFlow(Node source, Node sink, Configuration config) {
 }
 
 private predicate hasFlowPath(PathNode source, PathNode sink, Configuration config) {
-  flowPath(source, sink) and source.getConfiguration() = config
+  I::flowPath(source, sink) and source.getConfiguration() = config
 }
 
 private predicate hasFlowTo(Node sink, Configuration config) { hasFlow(_, sink, config) }

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -328,7 +328,6 @@ private module Config implements FullStateConfigSig {
 }
 
 private import Impl<Config> as I
-import I
 
 /**
  * A `Node` augmented with a call context (except for sinks), an access path, and a configuration.
@@ -379,6 +378,8 @@ class PathNode instanceof I::PathNode {
   final predicate isSinkGroup(string group) { super.isSinkGroup(group) }
 }
 
+module PathGraph = I::PathGraph;
+
 private predicate hasFlow(Node source, Node sink, Configuration config) {
   exists(PathNode source0, PathNode sink0 |
     hasFlowPath(source0, sink0, config) and
@@ -388,7 +389,7 @@ private predicate hasFlow(Node source, Node sink, Configuration config) {
 }
 
 private predicate hasFlowPath(PathNode source, PathNode sink, Configuration config) {
-  flowPath(source, sink) and source.getConfiguration() = config
+  I::flowPath(source, sink) and source.getConfiguration() = config
 }
 
 private predicate hasFlowTo(Node sink, Configuration config) { hasFlow(_, sink, config) }

--- a/csharp/ql/lib/change-notes/2023-03-28-dataflow-rm-footgun.md
+++ b/csharp/ql/lib/change-notes/2023-03-28-dataflow-rm-footgun.md
@@ -1,0 +1,4 @@
+---
+category: fix
+---
+* Fixed some accidental predicate visibility in the backwards-compatible wrapper for data flow configurations. In particular `DataFlow::hasFlowPath`, `DataFlow::hasFlow`, `DataFlow::hasFlowTo`, and `DataFlow::hasFlowToExpr` were accidentally exposed in a single version.

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl1.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl1.qll
@@ -328,7 +328,6 @@ private module Config implements FullStateConfigSig {
 }
 
 private import Impl<Config> as I
-import I
 
 /**
  * A `Node` augmented with a call context (except for sinks), an access path, and a configuration.
@@ -379,6 +378,8 @@ class PathNode instanceof I::PathNode {
   final predicate isSinkGroup(string group) { super.isSinkGroup(group) }
 }
 
+module PathGraph = I::PathGraph;
+
 private predicate hasFlow(Node source, Node sink, Configuration config) {
   exists(PathNode source0, PathNode sink0 |
     hasFlowPath(source0, sink0, config) and
@@ -388,7 +389,7 @@ private predicate hasFlow(Node source, Node sink, Configuration config) {
 }
 
 private predicate hasFlowPath(PathNode source, PathNode sink, Configuration config) {
-  flowPath(source, sink) and source.getConfiguration() = config
+  I::flowPath(source, sink) and source.getConfiguration() = config
 }
 
 private predicate hasFlowTo(Node sink, Configuration config) { hasFlow(_, sink, config) }

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
@@ -328,7 +328,6 @@ private module Config implements FullStateConfigSig {
 }
 
 private import Impl<Config> as I
-import I
 
 /**
  * A `Node` augmented with a call context (except for sinks), an access path, and a configuration.
@@ -379,6 +378,8 @@ class PathNode instanceof I::PathNode {
   final predicate isSinkGroup(string group) { super.isSinkGroup(group) }
 }
 
+module PathGraph = I::PathGraph;
+
 private predicate hasFlow(Node source, Node sink, Configuration config) {
   exists(PathNode source0, PathNode sink0 |
     hasFlowPath(source0, sink0, config) and
@@ -388,7 +389,7 @@ private predicate hasFlow(Node source, Node sink, Configuration config) {
 }
 
 private predicate hasFlowPath(PathNode source, PathNode sink, Configuration config) {
-  flowPath(source, sink) and source.getConfiguration() = config
+  I::flowPath(source, sink) and source.getConfiguration() = config
 }
 
 private predicate hasFlowTo(Node sink, Configuration config) { hasFlow(_, sink, config) }

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
@@ -328,7 +328,6 @@ private module Config implements FullStateConfigSig {
 }
 
 private import Impl<Config> as I
-import I
 
 /**
  * A `Node` augmented with a call context (except for sinks), an access path, and a configuration.
@@ -379,6 +378,8 @@ class PathNode instanceof I::PathNode {
   final predicate isSinkGroup(string group) { super.isSinkGroup(group) }
 }
 
+module PathGraph = I::PathGraph;
+
 private predicate hasFlow(Node source, Node sink, Configuration config) {
   exists(PathNode source0, PathNode sink0 |
     hasFlowPath(source0, sink0, config) and
@@ -388,7 +389,7 @@ private predicate hasFlow(Node source, Node sink, Configuration config) {
 }
 
 private predicate hasFlowPath(PathNode source, PathNode sink, Configuration config) {
-  flowPath(source, sink) and source.getConfiguration() = config
+  I::flowPath(source, sink) and source.getConfiguration() = config
 }
 
 private predicate hasFlowTo(Node sink, Configuration config) { hasFlow(_, sink, config) }

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
@@ -328,7 +328,6 @@ private module Config implements FullStateConfigSig {
 }
 
 private import Impl<Config> as I
-import I
 
 /**
  * A `Node` augmented with a call context (except for sinks), an access path, and a configuration.
@@ -379,6 +378,8 @@ class PathNode instanceof I::PathNode {
   final predicate isSinkGroup(string group) { super.isSinkGroup(group) }
 }
 
+module PathGraph = I::PathGraph;
+
 private predicate hasFlow(Node source, Node sink, Configuration config) {
   exists(PathNode source0, PathNode sink0 |
     hasFlowPath(source0, sink0, config) and
@@ -388,7 +389,7 @@ private predicate hasFlow(Node source, Node sink, Configuration config) {
 }
 
 private predicate hasFlowPath(PathNode source, PathNode sink, Configuration config) {
-  flowPath(source, sink) and source.getConfiguration() = config
+  I::flowPath(source, sink) and source.getConfiguration() = config
 }
 
 private predicate hasFlowTo(Node sink, Configuration config) { hasFlow(_, sink, config) }

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
@@ -328,7 +328,6 @@ private module Config implements FullStateConfigSig {
 }
 
 private import Impl<Config> as I
-import I
 
 /**
  * A `Node` augmented with a call context (except for sinks), an access path, and a configuration.
@@ -379,6 +378,8 @@ class PathNode instanceof I::PathNode {
   final predicate isSinkGroup(string group) { super.isSinkGroup(group) }
 }
 
+module PathGraph = I::PathGraph;
+
 private predicate hasFlow(Node source, Node sink, Configuration config) {
   exists(PathNode source0, PathNode sink0 |
     hasFlowPath(source0, sink0, config) and
@@ -388,7 +389,7 @@ private predicate hasFlow(Node source, Node sink, Configuration config) {
 }
 
 private predicate hasFlowPath(PathNode source, PathNode sink, Configuration config) {
-  flowPath(source, sink) and source.getConfiguration() = config
+  I::flowPath(source, sink) and source.getConfiguration() = config
 }
 
 private predicate hasFlowTo(Node sink, Configuration config) { hasFlow(_, sink, config) }

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImplForContentDataFlow.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImplForContentDataFlow.qll
@@ -328,7 +328,6 @@ private module Config implements FullStateConfigSig {
 }
 
 private import Impl<Config> as I
-import I
 
 /**
  * A `Node` augmented with a call context (except for sinks), an access path, and a configuration.
@@ -379,6 +378,8 @@ class PathNode instanceof I::PathNode {
   final predicate isSinkGroup(string group) { super.isSinkGroup(group) }
 }
 
+module PathGraph = I::PathGraph;
+
 private predicate hasFlow(Node source, Node sink, Configuration config) {
   exists(PathNode source0, PathNode sink0 |
     hasFlowPath(source0, sink0, config) and
@@ -388,7 +389,7 @@ private predicate hasFlow(Node source, Node sink, Configuration config) {
 }
 
 private predicate hasFlowPath(PathNode source, PathNode sink, Configuration config) {
-  flowPath(source, sink) and source.getConfiguration() = config
+  I::flowPath(source, sink) and source.getConfiguration() = config
 }
 
 private predicate hasFlowTo(Node sink, Configuration config) { hasFlow(_, sink, config) }

--- a/go/ql/lib/change-notes/2023-03-28-dataflow-rm-footgun.md
+++ b/go/ql/lib/change-notes/2023-03-28-dataflow-rm-footgun.md
@@ -1,0 +1,4 @@
+---
+category: fix
+---
+* Fixed some accidental predicate visibility in the backwards-compatible wrapper for data flow configurations. In particular `DataFlow::hasFlowPath`, `DataFlow::hasFlow`, `DataFlow::hasFlowTo`, and `DataFlow::hasFlowToExpr` were accidentally exposed in a single version.

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowImpl1.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowImpl1.qll
@@ -328,7 +328,6 @@ private module Config implements FullStateConfigSig {
 }
 
 private import Impl<Config> as I
-import I
 
 /**
  * A `Node` augmented with a call context (except for sinks), an access path, and a configuration.
@@ -379,6 +378,8 @@ class PathNode instanceof I::PathNode {
   final predicate isSinkGroup(string group) { super.isSinkGroup(group) }
 }
 
+module PathGraph = I::PathGraph;
+
 private predicate hasFlow(Node source, Node sink, Configuration config) {
   exists(PathNode source0, PathNode sink0 |
     hasFlowPath(source0, sink0, config) and
@@ -388,7 +389,7 @@ private predicate hasFlow(Node source, Node sink, Configuration config) {
 }
 
 private predicate hasFlowPath(PathNode source, PathNode sink, Configuration config) {
-  flowPath(source, sink) and source.getConfiguration() = config
+  I::flowPath(source, sink) and source.getConfiguration() = config
 }
 
 private predicate hasFlowTo(Node sink, Configuration config) { hasFlow(_, sink, config) }

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowImpl2.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowImpl2.qll
@@ -328,7 +328,6 @@ private module Config implements FullStateConfigSig {
 }
 
 private import Impl<Config> as I
-import I
 
 /**
  * A `Node` augmented with a call context (except for sinks), an access path, and a configuration.
@@ -379,6 +378,8 @@ class PathNode instanceof I::PathNode {
   final predicate isSinkGroup(string group) { super.isSinkGroup(group) }
 }
 
+module PathGraph = I::PathGraph;
+
 private predicate hasFlow(Node source, Node sink, Configuration config) {
   exists(PathNode source0, PathNode sink0 |
     hasFlowPath(source0, sink0, config) and
@@ -388,7 +389,7 @@ private predicate hasFlow(Node source, Node sink, Configuration config) {
 }
 
 private predicate hasFlowPath(PathNode source, PathNode sink, Configuration config) {
-  flowPath(source, sink) and source.getConfiguration() = config
+  I::flowPath(source, sink) and source.getConfiguration() = config
 }
 
 private predicate hasFlowTo(Node sink, Configuration config) { hasFlow(_, sink, config) }

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowImplForStringsNewReplacer.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowImplForStringsNewReplacer.qll
@@ -328,7 +328,6 @@ private module Config implements FullStateConfigSig {
 }
 
 private import Impl<Config> as I
-import I
 
 /**
  * A `Node` augmented with a call context (except for sinks), an access path, and a configuration.
@@ -379,6 +378,8 @@ class PathNode instanceof I::PathNode {
   final predicate isSinkGroup(string group) { super.isSinkGroup(group) }
 }
 
+module PathGraph = I::PathGraph;
+
 private predicate hasFlow(Node source, Node sink, Configuration config) {
   exists(PathNode source0, PathNode sink0 |
     hasFlowPath(source0, sink0, config) and
@@ -388,7 +389,7 @@ private predicate hasFlow(Node source, Node sink, Configuration config) {
 }
 
 private predicate hasFlowPath(PathNode source, PathNode sink, Configuration config) {
-  flowPath(source, sink) and source.getConfiguration() = config
+  I::flowPath(source, sink) and source.getConfiguration() = config
 }
 
 private predicate hasFlowTo(Node sink, Configuration config) { hasFlow(_, sink, config) }

--- a/java/ql/lib/change-notes/2023-03-28-dataflow-rm-footgun.md
+++ b/java/ql/lib/change-notes/2023-03-28-dataflow-rm-footgun.md
@@ -1,0 +1,4 @@
+---
+category: fix
+---
+* Fixed some accidental predicate visibility in the backwards-compatible wrapper for data flow configurations. In particular `DataFlow::hasFlowPath`, `DataFlow::hasFlow`, `DataFlow::hasFlowTo`, and `DataFlow::hasFlowToExpr` were accidentally exposed in a single version.

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl1.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl1.qll
@@ -328,7 +328,6 @@ private module Config implements FullStateConfigSig {
 }
 
 private import Impl<Config> as I
-import I
 
 /**
  * A `Node` augmented with a call context (except for sinks), an access path, and a configuration.
@@ -379,6 +378,8 @@ class PathNode instanceof I::PathNode {
   final predicate isSinkGroup(string group) { super.isSinkGroup(group) }
 }
 
+module PathGraph = I::PathGraph;
+
 private predicate hasFlow(Node source, Node sink, Configuration config) {
   exists(PathNode source0, PathNode sink0 |
     hasFlowPath(source0, sink0, config) and
@@ -388,7 +389,7 @@ private predicate hasFlow(Node source, Node sink, Configuration config) {
 }
 
 private predicate hasFlowPath(PathNode source, PathNode sink, Configuration config) {
-  flowPath(source, sink) and source.getConfiguration() = config
+  I::flowPath(source, sink) and source.getConfiguration() = config
 }
 
 private predicate hasFlowTo(Node sink, Configuration config) { hasFlow(_, sink, config) }

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
@@ -328,7 +328,6 @@ private module Config implements FullStateConfigSig {
 }
 
 private import Impl<Config> as I
-import I
 
 /**
  * A `Node` augmented with a call context (except for sinks), an access path, and a configuration.
@@ -379,6 +378,8 @@ class PathNode instanceof I::PathNode {
   final predicate isSinkGroup(string group) { super.isSinkGroup(group) }
 }
 
+module PathGraph = I::PathGraph;
+
 private predicate hasFlow(Node source, Node sink, Configuration config) {
   exists(PathNode source0, PathNode sink0 |
     hasFlowPath(source0, sink0, config) and
@@ -388,7 +389,7 @@ private predicate hasFlow(Node source, Node sink, Configuration config) {
 }
 
 private predicate hasFlowPath(PathNode source, PathNode sink, Configuration config) {
-  flowPath(source, sink) and source.getConfiguration() = config
+  I::flowPath(source, sink) and source.getConfiguration() = config
 }
 
 private predicate hasFlowTo(Node sink, Configuration config) { hasFlow(_, sink, config) }

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
@@ -328,7 +328,6 @@ private module Config implements FullStateConfigSig {
 }
 
 private import Impl<Config> as I
-import I
 
 /**
  * A `Node` augmented with a call context (except for sinks), an access path, and a configuration.
@@ -379,6 +378,8 @@ class PathNode instanceof I::PathNode {
   final predicate isSinkGroup(string group) { super.isSinkGroup(group) }
 }
 
+module PathGraph = I::PathGraph;
+
 private predicate hasFlow(Node source, Node sink, Configuration config) {
   exists(PathNode source0, PathNode sink0 |
     hasFlowPath(source0, sink0, config) and
@@ -388,7 +389,7 @@ private predicate hasFlow(Node source, Node sink, Configuration config) {
 }
 
 private predicate hasFlowPath(PathNode source, PathNode sink, Configuration config) {
-  flowPath(source, sink) and source.getConfiguration() = config
+  I::flowPath(source, sink) and source.getConfiguration() = config
 }
 
 private predicate hasFlowTo(Node sink, Configuration config) { hasFlow(_, sink, config) }

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
@@ -328,7 +328,6 @@ private module Config implements FullStateConfigSig {
 }
 
 private import Impl<Config> as I
-import I
 
 /**
  * A `Node` augmented with a call context (except for sinks), an access path, and a configuration.
@@ -379,6 +378,8 @@ class PathNode instanceof I::PathNode {
   final predicate isSinkGroup(string group) { super.isSinkGroup(group) }
 }
 
+module PathGraph = I::PathGraph;
+
 private predicate hasFlow(Node source, Node sink, Configuration config) {
   exists(PathNode source0, PathNode sink0 |
     hasFlowPath(source0, sink0, config) and
@@ -388,7 +389,7 @@ private predicate hasFlow(Node source, Node sink, Configuration config) {
 }
 
 private predicate hasFlowPath(PathNode source, PathNode sink, Configuration config) {
-  flowPath(source, sink) and source.getConfiguration() = config
+  I::flowPath(source, sink) and source.getConfiguration() = config
 }
 
 private predicate hasFlowTo(Node sink, Configuration config) { hasFlow(_, sink, config) }

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
@@ -328,7 +328,6 @@ private module Config implements FullStateConfigSig {
 }
 
 private import Impl<Config> as I
-import I
 
 /**
  * A `Node` augmented with a call context (except for sinks), an access path, and a configuration.
@@ -379,6 +378,8 @@ class PathNode instanceof I::PathNode {
   final predicate isSinkGroup(string group) { super.isSinkGroup(group) }
 }
 
+module PathGraph = I::PathGraph;
+
 private predicate hasFlow(Node source, Node sink, Configuration config) {
   exists(PathNode source0, PathNode sink0 |
     hasFlowPath(source0, sink0, config) and
@@ -388,7 +389,7 @@ private predicate hasFlow(Node source, Node sink, Configuration config) {
 }
 
 private predicate hasFlowPath(PathNode source, PathNode sink, Configuration config) {
-  flowPath(source, sink) and source.getConfiguration() = config
+  I::flowPath(source, sink) and source.getConfiguration() = config
 }
 
 private predicate hasFlowTo(Node sink, Configuration config) { hasFlow(_, sink, config) }

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl6.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl6.qll
@@ -328,7 +328,6 @@ private module Config implements FullStateConfigSig {
 }
 
 private import Impl<Config> as I
-import I
 
 /**
  * A `Node` augmented with a call context (except for sinks), an access path, and a configuration.
@@ -379,6 +378,8 @@ class PathNode instanceof I::PathNode {
   final predicate isSinkGroup(string group) { super.isSinkGroup(group) }
 }
 
+module PathGraph = I::PathGraph;
+
 private predicate hasFlow(Node source, Node sink, Configuration config) {
   exists(PathNode source0, PathNode sink0 |
     hasFlowPath(source0, sink0, config) and
@@ -388,7 +389,7 @@ private predicate hasFlow(Node source, Node sink, Configuration config) {
 }
 
 private predicate hasFlowPath(PathNode source, PathNode sink, Configuration config) {
-  flowPath(source, sink) and source.getConfiguration() = config
+  I::flowPath(source, sink) and source.getConfiguration() = config
 }
 
 private predicate hasFlowTo(Node sink, Configuration config) { hasFlow(_, sink, config) }

--- a/python/ql/lib/change-notes/2023-03-28-dataflow-rm-footgun.md
+++ b/python/ql/lib/change-notes/2023-03-28-dataflow-rm-footgun.md
@@ -1,0 +1,4 @@
+---
+category: fix
+---
+* Fixed some accidental predicate visibility in the backwards-compatible wrapper for data flow configurations. In particular `DataFlow::hasFlowPath`, `DataFlow::hasFlow`, `DataFlow::hasFlowTo`, and `DataFlow::hasFlowToExpr` were accidentally exposed in a single version.

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl1.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl1.qll
@@ -328,7 +328,6 @@ private module Config implements FullStateConfigSig {
 }
 
 private import Impl<Config> as I
-import I
 
 /**
  * A `Node` augmented with a call context (except for sinks), an access path, and a configuration.
@@ -379,6 +378,8 @@ class PathNode instanceof I::PathNode {
   final predicate isSinkGroup(string group) { super.isSinkGroup(group) }
 }
 
+module PathGraph = I::PathGraph;
+
 private predicate hasFlow(Node source, Node sink, Configuration config) {
   exists(PathNode source0, PathNode sink0 |
     hasFlowPath(source0, sink0, config) and
@@ -388,7 +389,7 @@ private predicate hasFlow(Node source, Node sink, Configuration config) {
 }
 
 private predicate hasFlowPath(PathNode source, PathNode sink, Configuration config) {
-  flowPath(source, sink) and source.getConfiguration() = config
+  I::flowPath(source, sink) and source.getConfiguration() = config
 }
 
 private predicate hasFlowTo(Node sink, Configuration config) { hasFlow(_, sink, config) }

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl2.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl2.qll
@@ -328,7 +328,6 @@ private module Config implements FullStateConfigSig {
 }
 
 private import Impl<Config> as I
-import I
 
 /**
  * A `Node` augmented with a call context (except for sinks), an access path, and a configuration.
@@ -379,6 +378,8 @@ class PathNode instanceof I::PathNode {
   final predicate isSinkGroup(string group) { super.isSinkGroup(group) }
 }
 
+module PathGraph = I::PathGraph;
+
 private predicate hasFlow(Node source, Node sink, Configuration config) {
   exists(PathNode source0, PathNode sink0 |
     hasFlowPath(source0, sink0, config) and
@@ -388,7 +389,7 @@ private predicate hasFlow(Node source, Node sink, Configuration config) {
 }
 
 private predicate hasFlowPath(PathNode source, PathNode sink, Configuration config) {
-  flowPath(source, sink) and source.getConfiguration() = config
+  I::flowPath(source, sink) and source.getConfiguration() = config
 }
 
 private predicate hasFlowTo(Node sink, Configuration config) { hasFlow(_, sink, config) }

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl3.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl3.qll
@@ -328,7 +328,6 @@ private module Config implements FullStateConfigSig {
 }
 
 private import Impl<Config> as I
-import I
 
 /**
  * A `Node` augmented with a call context (except for sinks), an access path, and a configuration.
@@ -379,6 +378,8 @@ class PathNode instanceof I::PathNode {
   final predicate isSinkGroup(string group) { super.isSinkGroup(group) }
 }
 
+module PathGraph = I::PathGraph;
+
 private predicate hasFlow(Node source, Node sink, Configuration config) {
   exists(PathNode source0, PathNode sink0 |
     hasFlowPath(source0, sink0, config) and
@@ -388,7 +389,7 @@ private predicate hasFlow(Node source, Node sink, Configuration config) {
 }
 
 private predicate hasFlowPath(PathNode source, PathNode sink, Configuration config) {
-  flowPath(source, sink) and source.getConfiguration() = config
+  I::flowPath(source, sink) and source.getConfiguration() = config
 }
 
 private predicate hasFlowTo(Node sink, Configuration config) { hasFlow(_, sink, config) }

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl4.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl4.qll
@@ -328,7 +328,6 @@ private module Config implements FullStateConfigSig {
 }
 
 private import Impl<Config> as I
-import I
 
 /**
  * A `Node` augmented with a call context (except for sinks), an access path, and a configuration.
@@ -379,6 +378,8 @@ class PathNode instanceof I::PathNode {
   final predicate isSinkGroup(string group) { super.isSinkGroup(group) }
 }
 
+module PathGraph = I::PathGraph;
+
 private predicate hasFlow(Node source, Node sink, Configuration config) {
   exists(PathNode source0, PathNode sink0 |
     hasFlowPath(source0, sink0, config) and
@@ -388,7 +389,7 @@ private predicate hasFlow(Node source, Node sink, Configuration config) {
 }
 
 private predicate hasFlowPath(PathNode source, PathNode sink, Configuration config) {
-  flowPath(source, sink) and source.getConfiguration() = config
+  I::flowPath(source, sink) and source.getConfiguration() = config
 }
 
 private predicate hasFlowTo(Node sink, Configuration config) { hasFlow(_, sink, config) }

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImplForRegExp.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImplForRegExp.qll
@@ -328,7 +328,6 @@ private module Config implements FullStateConfigSig {
 }
 
 private import Impl<Config> as I
-import I
 
 /**
  * A `Node` augmented with a call context (except for sinks), an access path, and a configuration.
@@ -379,6 +378,8 @@ class PathNode instanceof I::PathNode {
   final predicate isSinkGroup(string group) { super.isSinkGroup(group) }
 }
 
+module PathGraph = I::PathGraph;
+
 private predicate hasFlow(Node source, Node sink, Configuration config) {
   exists(PathNode source0, PathNode sink0 |
     hasFlowPath(source0, sink0, config) and
@@ -388,7 +389,7 @@ private predicate hasFlow(Node source, Node sink, Configuration config) {
 }
 
 private predicate hasFlowPath(PathNode source, PathNode sink, Configuration config) {
-  flowPath(source, sink) and source.getConfiguration() = config
+  I::flowPath(source, sink) and source.getConfiguration() = config
 }
 
 private predicate hasFlowTo(Node sink, Configuration config) { hasFlow(_, sink, config) }

--- a/ruby/ql/lib/change-notes/2023-03-28-dataflow-rm-footgun.md
+++ b/ruby/ql/lib/change-notes/2023-03-28-dataflow-rm-footgun.md
@@ -1,0 +1,4 @@
+---
+category: fix
+---
+* Fixed some accidental predicate visibility in the backwards-compatible wrapper for data flow configurations. In particular `DataFlow::hasFlowPath`, `DataFlow::hasFlow`, `DataFlow::hasFlowTo`, and `DataFlow::hasFlowToExpr` were accidentally exposed in a single version.

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl1.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl1.qll
@@ -328,7 +328,6 @@ private module Config implements FullStateConfigSig {
 }
 
 private import Impl<Config> as I
-import I
 
 /**
  * A `Node` augmented with a call context (except for sinks), an access path, and a configuration.
@@ -379,6 +378,8 @@ class PathNode instanceof I::PathNode {
   final predicate isSinkGroup(string group) { super.isSinkGroup(group) }
 }
 
+module PathGraph = I::PathGraph;
+
 private predicate hasFlow(Node source, Node sink, Configuration config) {
   exists(PathNode source0, PathNode sink0 |
     hasFlowPath(source0, sink0, config) and
@@ -388,7 +389,7 @@ private predicate hasFlow(Node source, Node sink, Configuration config) {
 }
 
 private predicate hasFlowPath(PathNode source, PathNode sink, Configuration config) {
-  flowPath(source, sink) and source.getConfiguration() = config
+  I::flowPath(source, sink) and source.getConfiguration() = config
 }
 
 private predicate hasFlowTo(Node sink, Configuration config) { hasFlow(_, sink, config) }

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl2.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl2.qll
@@ -328,7 +328,6 @@ private module Config implements FullStateConfigSig {
 }
 
 private import Impl<Config> as I
-import I
 
 /**
  * A `Node` augmented with a call context (except for sinks), an access path, and a configuration.
@@ -379,6 +378,8 @@ class PathNode instanceof I::PathNode {
   final predicate isSinkGroup(string group) { super.isSinkGroup(group) }
 }
 
+module PathGraph = I::PathGraph;
+
 private predicate hasFlow(Node source, Node sink, Configuration config) {
   exists(PathNode source0, PathNode sink0 |
     hasFlowPath(source0, sink0, config) and
@@ -388,7 +389,7 @@ private predicate hasFlow(Node source, Node sink, Configuration config) {
 }
 
 private predicate hasFlowPath(PathNode source, PathNode sink, Configuration config) {
-  flowPath(source, sink) and source.getConfiguration() = config
+  I::flowPath(source, sink) and source.getConfiguration() = config
 }
 
 private predicate hasFlowTo(Node sink, Configuration config) { hasFlow(_, sink, config) }

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplForHttpClientLibraries.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplForHttpClientLibraries.qll
@@ -328,7 +328,6 @@ private module Config implements FullStateConfigSig {
 }
 
 private import Impl<Config> as I
-import I
 
 /**
  * A `Node` augmented with a call context (except for sinks), an access path, and a configuration.
@@ -379,6 +378,8 @@ class PathNode instanceof I::PathNode {
   final predicate isSinkGroup(string group) { super.isSinkGroup(group) }
 }
 
+module PathGraph = I::PathGraph;
+
 private predicate hasFlow(Node source, Node sink, Configuration config) {
   exists(PathNode source0, PathNode sink0 |
     hasFlowPath(source0, sink0, config) and
@@ -388,7 +389,7 @@ private predicate hasFlow(Node source, Node sink, Configuration config) {
 }
 
 private predicate hasFlowPath(PathNode source, PathNode sink, Configuration config) {
-  flowPath(source, sink) and source.getConfiguration() = config
+  I::flowPath(source, sink) and source.getConfiguration() = config
 }
 
 private predicate hasFlowTo(Node sink, Configuration config) { hasFlow(_, sink, config) }

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplForPathname.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplForPathname.qll
@@ -328,7 +328,6 @@ private module Config implements FullStateConfigSig {
 }
 
 private import Impl<Config> as I
-import I
 
 /**
  * A `Node` augmented with a call context (except for sinks), an access path, and a configuration.
@@ -379,6 +378,8 @@ class PathNode instanceof I::PathNode {
   final predicate isSinkGroup(string group) { super.isSinkGroup(group) }
 }
 
+module PathGraph = I::PathGraph;
+
 private predicate hasFlow(Node source, Node sink, Configuration config) {
   exists(PathNode source0, PathNode sink0 |
     hasFlowPath(source0, sink0, config) and
@@ -388,7 +389,7 @@ private predicate hasFlow(Node source, Node sink, Configuration config) {
 }
 
 private predicate hasFlowPath(PathNode source, PathNode sink, Configuration config) {
-  flowPath(source, sink) and source.getConfiguration() = config
+  I::flowPath(source, sink) and source.getConfiguration() = config
 }
 
 private predicate hasFlowTo(Node sink, Configuration config) { hasFlow(_, sink, config) }

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImpl1.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImpl1.qll
@@ -328,7 +328,6 @@ private module Config implements FullStateConfigSig {
 }
 
 private import Impl<Config> as I
-import I
 
 /**
  * A `Node` augmented with a call context (except for sinks), an access path, and a configuration.
@@ -379,6 +378,8 @@ class PathNode instanceof I::PathNode {
   final predicate isSinkGroup(string group) { super.isSinkGroup(group) }
 }
 
+module PathGraph = I::PathGraph;
+
 private predicate hasFlow(Node source, Node sink, Configuration config) {
   exists(PathNode source0, PathNode sink0 |
     hasFlowPath(source0, sink0, config) and
@@ -388,7 +389,7 @@ private predicate hasFlow(Node source, Node sink, Configuration config) {
 }
 
 private predicate hasFlowPath(PathNode source, PathNode sink, Configuration config) {
-  flowPath(source, sink) and source.getConfiguration() = config
+  I::flowPath(source, sink) and source.getConfiguration() = config
 }
 
 private predicate hasFlowTo(Node sink, Configuration config) { hasFlow(_, sink, config) }


### PR DESCRIPTION
We should really only expose `PathGraph` directly from the module instantiation.