### PR TITLE
Java: Refactor CommandLineQuery.qll and RequestForgeryConfig.qll

### DIFF
--- a/java/ql/lib/change-notes/2023-03-28-deprecated-exectainted.md
+++ b/java/ql/lib/change-notes/2023-03-28-deprecated-exectainted.md
@@ -1,0 +1,5 @@
+---
+category: deprecated
+---
+* The `execTainted` predicate in `CommandLineQuery.qll` has been deprecated and replaced with the predicate `execIsTainted`.
+

--- a/java/ql/lib/semmle/code/java/security/CommandLineQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/CommandLineQuery.qll
@@ -52,7 +52,7 @@ module RemoteUserInputToArgumentToExecFlowConfig implements DataFlow::ConfigSig 
 }
 
 module RemoteUserInputToArgumentToExecFlow =
-  TaintTracking::Make<RemoteUserInputToArgumentToExecFlowConfig>;
+  TaintTracking::Global<RemoteUserInputToArgumentToExecFlowConfig>;
 
 /**
  * Implementation of `ExecTainted.ql`. It is extracted to a QLL
@@ -63,6 +63,6 @@ predicate execTainted(
   RemoteUserInputToArgumentToExecFlow::PathNode source,
   RemoteUserInputToArgumentToExecFlow::PathNode sink, ArgumentToExec execArg
 ) {
-  RemoteUserInputToArgumentToExecFlow::hasFlowPath(source, sink) and
+  RemoteUserInputToArgumentToExecFlow::flowPath(source, sink) and
   sink.getNode() = DataFlow::exprNode(execArg)
 }

--- a/java/ql/lib/semmle/code/java/security/CommandLineQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/CommandLineQuery.qll
@@ -55,11 +55,26 @@ module RemoteUserInputToArgumentToExecFlow =
   TaintTracking::Global<RemoteUserInputToArgumentToExecFlowConfig>;
 
 /**
+ * DEPRECATED: Use `execIsTainted` instead.
+ *
  * Implementation of `ExecTainted.ql`. It is extracted to a QLL
  * so that it can be excluded from `ExecUnescaped.ql` to avoid
  * reporting overlapping results.
  */
-predicate execTainted(
+deprecated predicate execTainted(
+  DataFlow::PathNode source, DataFlow::PathNode sink, ArgumentToExec execArg
+) {
+  exists(RemoteUserInputToArgumentToExecFlowConfig conf |
+    conf.hasFlowPath(source, sink) and sink.getNode() = DataFlow::exprNode(execArg)
+  )
+}
+
+/**
+ * Implementation of `ExecTainted.ql`. It is extracted to a QLL
+ * so that it can be excluded from `ExecUnescaped.ql` to avoid
+ * reporting overlapping results.
+ */
+predicate execIsTainted(
   RemoteUserInputToArgumentToExecFlow::PathNode source,
   RemoteUserInputToArgumentToExecFlow::PathNode sink, ArgumentToExec execArg
 ) {

--- a/java/ql/lib/semmle/code/java/security/CommandLineQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/CommandLineQuery.qll
@@ -12,9 +12,11 @@ import semmle.code.java.security.ExternalProcess
 import semmle.code.java.security.CommandArguments
 
 /**
+ * DEPRECATED: Use `RemoteUserInputToArgumentToExecFlow` instead.
+ *
  * A taint-tracking configuration for unvalidated user input that is used to run an external process.
  */
-class RemoteUserInputToArgumentToExecFlowConfig extends TaintTracking::Configuration {
+deprecated class RemoteUserInputToArgumentToExecFlowConfig extends TaintTracking::Configuration {
   RemoteUserInputToArgumentToExecFlowConfig() {
     this = "ExecCommon::RemoteUserInputToArgumentToExecFlowConfig"
   }
@@ -33,12 +35,34 @@ class RemoteUserInputToArgumentToExecFlowConfig extends TaintTracking::Configura
 }
 
 /**
+ * A taint-tracking configuration for unvalidated user input that is used to run an external process.
+ */
+private module RemoteUserInputToArgumentToExecFlowConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node src) { src instanceof RemoteFlowSource }
+
+  predicate isSink(DataFlow::Node sink) { sink.asExpr() instanceof ArgumentToExec }
+
+  predicate isBarrier(DataFlow::Node node) {
+    node.getType() instanceof PrimitiveType
+    or
+    node.getType() instanceof BoxedType
+    or
+    isSafeCommandArgument(node.asExpr())
+  }
+}
+
+module RemoteUserInputToArgumentToExecFlow =
+  TaintTracking::Make<RemoteUserInputToArgumentToExecFlowConfig>;
+
+/**
  * Implementation of `ExecTainted.ql`. It is extracted to a QLL
  * so that it can be excluded from `ExecUnescaped.ql` to avoid
  * reporting overlapping results.
  */
-predicate execTainted(DataFlow::PathNode source, DataFlow::PathNode sink, ArgumentToExec execArg) {
-  exists(RemoteUserInputToArgumentToExecFlowConfig conf |
-    conf.hasFlowPath(source, sink) and sink.getNode() = DataFlow::exprNode(execArg)
-  )
+predicate execTainted(
+  RemoteUserInputToArgumentToExecFlow::PathNode source,
+  RemoteUserInputToArgumentToExecFlow::PathNode sink, ArgumentToExec execArg
+) {
+  RemoteUserInputToArgumentToExecFlow::hasFlowPath(source, sink) and
+  sink.getNode() = DataFlow::exprNode(execArg)
 }

--- a/java/ql/lib/semmle/code/java/security/CommandLineQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/CommandLineQuery.qll
@@ -51,6 +51,9 @@ module RemoteUserInputToArgumentToExecFlowConfig implements DataFlow::ConfigSig 
   }
 }
 
+/**
+ * Taint-tracking flow for unvalidated user input that is used to run an external process.
+ */
 module RemoteUserInputToArgumentToExecFlow =
   TaintTracking::Global<RemoteUserInputToArgumentToExecFlowConfig>;
 

--- a/java/ql/lib/semmle/code/java/security/CommandLineQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/CommandLineQuery.qll
@@ -37,7 +37,7 @@ deprecated class RemoteUserInputToArgumentToExecFlowConfig extends TaintTracking
 /**
  * A taint-tracking configuration for unvalidated user input that is used to run an external process.
  */
-private module RemoteUserInputToArgumentToExecFlowConfig implements DataFlow::ConfigSig {
+module RemoteUserInputToArgumentToExecFlowConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node src) { src instanceof RemoteFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink.asExpr() instanceof ArgumentToExec }

--- a/java/ql/lib/semmle/code/java/security/RequestForgeryConfig.qll
+++ b/java/ql/lib/semmle/code/java/security/RequestForgeryConfig.qll
@@ -35,7 +35,7 @@ deprecated class RequestForgeryConfiguration extends TaintTracking::Configuratio
 /**
  * A taint-tracking configuration characterising request-forgery risks.
  */
-private module RequestForgeryConfig implements DataFlow::ConfigSig {
+module RequestForgeryConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) {
     source instanceof RemoteFlowSource and
     // Exclude results of remote HTTP requests: fetching something else based on that result

--- a/java/ql/src/Security/CWE/CWE-078/ExecTainted.ql
+++ b/java/ql/src/Security/CWE/CWE-078/ExecTainted.ql
@@ -16,9 +16,11 @@ import java
 import semmle.code.java.dataflow.FlowSources
 import semmle.code.java.security.ExternalProcess
 import semmle.code.java.security.CommandLineQuery
-import DataFlow::PathGraph
+import RemoteUserInputToArgumentToExecFlow::PathGraph
 
-from DataFlow::PathNode source, DataFlow::PathNode sink, ArgumentToExec execArg
+from
+  RemoteUserInputToArgumentToExecFlow::PathNode source,
+  RemoteUserInputToArgumentToExecFlow::PathNode sink, ArgumentToExec execArg
 where execTainted(source, sink, execArg)
 select execArg, source, sink, "This command line depends on a $@.", source.getNode(),
   "user-provided value"

--- a/java/ql/src/Security/CWE/CWE-078/ExecTainted.ql
+++ b/java/ql/src/Security/CWE/CWE-078/ExecTainted.ql
@@ -21,6 +21,6 @@ import RemoteUserInputToArgumentToExecFlow::PathGraph
 from
   RemoteUserInputToArgumentToExecFlow::PathNode source,
   RemoteUserInputToArgumentToExecFlow::PathNode sink, ArgumentToExec execArg
-where execTainted(source, sink, execArg)
+where execIsTainted(source, sink, execArg)
 select execArg, source, sink, "This command line depends on a $@.", source.getNode(),
   "user-provided value"

--- a/java/ql/src/Security/CWE/CWE-078/ExecUnescaped.ql
+++ b/java/ql/src/Security/CWE/CWE-078/ExecUnescaped.ql
@@ -48,5 +48,5 @@ predicate builtFromUncontrolledConcat(Expr expr) {
 from StringArgumentToExec argument
 where
   builtFromUncontrolledConcat(argument) and
-  not execTainted(_, _, argument)
+  not execIsTainted(_, _, argument)
 select argument, "Command line is built with string concatenation."

--- a/java/ql/src/experimental/Security/CWE/CWE-078/ExecTainted.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-078/ExecTainted.ql
@@ -23,6 +23,6 @@ import RemoteUserInputToArgumentToExecFlow::PathGraph
 from
   RemoteUserInputToArgumentToExecFlow::PathNode source,
   RemoteUserInputToArgumentToExecFlow::PathNode sink, ArgumentToExec execArg
-where execTainted(source, sink, execArg)
+where execIsTainted(source, sink, execArg)
 select execArg, source, sink, "This command line depends on a $@.", source.getNode(),
   "user-provided value"

--- a/java/ql/src/experimental/Security/CWE/CWE-078/ExecTainted.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-078/ExecTainted.ql
@@ -17,10 +17,12 @@ import semmle.code.java.dataflow.FlowSources
 import semmle.code.java.security.ExternalProcess
 import semmle.code.java.security.CommandLineQuery
 import JSchOSInjection
-import DataFlow::PathGraph
+import RemoteUserInputToArgumentToExecFlow::PathGraph
 
 // This is a clone of query `java/command-line-injection` that also includes experimental sinks.
-from DataFlow::PathNode source, DataFlow::PathNode sink, ArgumentToExec execArg
+from
+  RemoteUserInputToArgumentToExecFlow::PathNode source,
+  RemoteUserInputToArgumentToExecFlow::PathNode sink, ArgumentToExec execArg
 where execTainted(source, sink, execArg)
 select execArg, source, sink, "This command line depends on a $@.", source.getNode(),
   "user-provided value"


### PR DESCRIPTION
- Refactor CommandLineQuery.qll to the new dataflow api
- Refactor RequestForgeryConfig.qll to make the configuration public