### PR TITLE
Ruby: do not depend on trackDefNode in isDef

### DIFF
--- a/ruby/ql/lib/codeql/ruby/ApiGraphs.qll
+++ b/ruby/ql/lib/codeql/ruby/ApiGraphs.qll
@@ -584,7 +584,7 @@ module API {
       // If a call node is relevant as a use-node, treat its arguments as def-nodes
       argumentStep(_, useCandFwd(), rhs)
       or
-      defStep(_, trackDefNode(_), rhs)
+      defStep(_, defCand(), rhs)
       or
       rhs = any(EntryPoint entry).getASink()
     }


### PR DESCRIPTION
Ensure isDef/isUse can be computed as an SCC before the trackUseNode/trackDefNode SCC.

[Evaluation](https://github.com/github/codeql-dca-main/issues/12144) doesn't show much of a difference.