### PR TITLE
Java: Allow keys to be omitted from ExtractorInformation.ql

### DIFF
--- a/java/ql/src/Telemetry/ExtractorInformation.ql
+++ b/java/ql/src/Telemetry/ExtractorInformation.ql
@@ -9,6 +9,8 @@
 import java
 import semmle.code.java.Diagnostics
 
+extensible predicate extractorInformationSkipKey(string key);
+
 predicate compilationInfo(string key, int value) {
   exists(Compilation c, string infoKey |
     key = infoKey + ": " + c.getInfo(infoKey) and
@@ -85,13 +87,16 @@ predicate extractorTotalDiagnostics(string key, int value) {
 
 from string key, int value
 where
-  compilationInfo(key, value) or
-  fileCount(key, value) or
-  fileCountByExtension(key, value) or
-  totalNumberOfLines(key, value) or
-  numberOfLinesOfCode(key, value) or
-  totalNumberOfLinesByExtension(key, value) or
-  numberOfLinesOfCodeByExtension(key, value) or
-  extractorDiagnostics(key, value) or
-  extractorTotalDiagnostics(key, value)
+  not extractorInformationSkipKey(key) and
+  (
+    compilationInfo(key, value) or
+    fileCount(key, value) or
+    fileCountByExtension(key, value) or
+    totalNumberOfLines(key, value) or
+    numberOfLinesOfCode(key, value) or
+    totalNumberOfLinesByExtension(key, value) or
+    numberOfLinesOfCodeByExtension(key, value) or
+    extractorDiagnostics(key, value) or
+    extractorTotalDiagnostics(key, value)
+  )
 select key, value

--- a/java/ql/src/Telemetry/ExtractorInformation.yml
+++ b/java/ql/src/Telemetry/ExtractorInformation.yml
@@ -1,0 +1,5 @@
+extensions:
+  - addsTo:
+      pack: codeql/java-queries
+      extensible: extractorInformationSkipKey
+    data: []

--- a/java/ql/src/qlpack.yml
+++ b/java/ql/src/qlpack.yml
@@ -10,3 +10,5 @@ dependencies:
   codeql/java-all: ${workspace}
   codeql/suite-helpers: ${workspace}
   codeql/util: ${workspace}
+dataExtensions:
+  - Telemetry/ExtractorInformation.yml


### PR DESCRIPTION
This is useful in tests, as some keys contain unstable information.