### PR TITLE
Swift: consider declarations from non-swift modules as lazy

### DIFF
--- a/swift/extractor/infra/SwiftDispatcher.h
+++ b/swift/extractor/infra/SwiftDispatcher.h
@@ -265,7 +265,8 @@ class SwiftDispatcher {
  private:
   bool isLazyDeclaration(const swift::Decl& decl) {
     swift::ModuleDecl* module = decl.getModuleContext();
-    return module->isBuiltinModule() || module->getName().str() == "__ObjC";
+    return module->isBuiltinModule() || module->getName().str() == "__ObjC" ||
+           module->isNonSwiftModule();
   }
 
   template <typename T, typename = void>


### PR DESCRIPTION
This change fixes all of the VALUE_NOT_IN_TYPE errors I'm seeing with the integration tests on macOS.