### PR TITLE
Swift: Add missing import.

### DIFF
--- a/swift/ql/lib/codeql/swift/dataflow/ExternalFlow.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/ExternalFlow.qll
@@ -99,6 +99,7 @@ private module Frameworks {
   private import codeql.swift.security.CleartextStorageDatabaseExtensions
   private import codeql.swift.security.PathInjectionExtensions
   private import codeql.swift.security.PredicateInjectionExtensions
+  private import codeql.swift.security.StringLengthConflationExtensions
 }
 
 /**


### PR DESCRIPTION
Add missing import in `ExternalFlow.qll`.  This should have been part of https://github.com/github/codeql/pull/12642 .