### PR TITLE
JS: Modernize crypto libraries

### DIFF
--- a/javascript/ql/lib/semmle/javascript/frameworks/CryptoLibraries.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/CryptoLibraries.qll
@@ -321,10 +321,7 @@ private module CryptoJS {
    */
   private API::Node getAlgorithmNode(CryptographicAlgorithm algorithm) {
     exists(string algorithmName | algorithm.matchesName(algorithmName) |
-      exists(API::Node mod | mod = API::moduleImport("crypto-js") |
-        result = mod.getMember(algorithmName) or
-        result = mod.getMember("Hmac" + algorithmName) // they prefix Hmac
-      )
+      result = API::moduleImport("crypto-js").getMember([algorithmName, "Hmac" + algorithmName])
       or
       result = API::moduleImport("crypto-js/" + algorithmName)
     )

--- a/javascript/ql/lib/semmle/javascript/frameworks/CryptoLibraries.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/CryptoLibraries.qll
@@ -291,13 +291,13 @@ private module CryptoJS {
        *       ```
        */
 
-      exists(DataFlow::SourceNode mod, DataFlow::PropRead propRead |
-        mod = DataFlow::moduleImport("crypto-js") and
-        propRead = mod.getAPropertyRead("algo").getAPropertyRead() and
-        this = propRead.getAMemberCall("create") and
-        algorithmName = propRead.getPropertyName() and
-        not isStrongPasswordHashingAlgorithm(algorithmName)
-      )
+      this =
+        API::moduleImport("crypto-js")
+            .getMember("algo")
+            .getMember(algorithmName)
+            .getMember("create")
+            .getACall() and
+      not isStrongPasswordHashingAlgorithm(algorithmName)
     }
 
     CryptographicAlgorithm getAlgorithm() { result.matchesName(algorithmName) }


### PR DESCRIPTION
- Use API graphs instead of local DataFlow
- Use set literals
- Prefer chaining over local variables in some cases

[Evaluation](https://github.com/github/codeql-dca-main/issues/12214) was neutral.