### PR TITLE
Ruby: Minor fix in NetHttpRequest

### DIFF
--- a/ruby/ql/test/library-tests/frameworks/http_clients/HttpClients.expected
+++ b/ruby/ql/test/library-tests/frameworks/http_clients/HttpClients.expected
@@ -1,80 +1,282 @@
-| Excon.rb:3:9:3:40 | call to get | Excon | Excon.rb:3:19:3:39 | "http://example.com/" | Excon.rb:4:1:4:10 | call to body |
-| Excon.rb:6:9:6:60 | call to post | Excon | Excon.rb:6:20:6:40 | "http://example.com/" | Excon.rb:7:1:7:10 | call to body |
-| Excon.rb:9:9:9:59 | call to put | Excon | Excon.rb:9:19:9:39 | "http://example.com/" | Excon.rb:10:1:10:10 | call to body |
-| Excon.rb:12:9:12:61 | call to patch | Excon | Excon.rb:12:21:12:41 | "http://example.com/" | Excon.rb:13:1:13:10 | call to body |
-| Excon.rb:15:9:15:43 | call to delete | Excon | Excon.rb:15:22:15:42 | "http://example.com/" | Excon.rb:16:1:16:10 | call to body |
-| Excon.rb:18:9:18:41 | call to head | Excon | Excon.rb:18:20:18:40 | "http://example.com/" | Excon.rb:19:1:19:10 | call to body |
-| Excon.rb:21:9:21:44 | call to options | Excon | Excon.rb:21:23:21:43 | "http://example.com/" | Excon.rb:22:1:22:10 | call to body |
-| Excon.rb:24:9:24:42 | call to trace | Excon | Excon.rb:24:21:24:41 | "http://example.com/" | Excon.rb:25:1:25:10 | call to body |
-| Excon.rb:28:9:28:34 | call to get | Excon | Excon.rb:27:25:27:44 | "http://example.com" | Excon.rb:29:1:29:10 | call to body |
-| Excon.rb:28:9:28:34 | call to get | Excon | Excon.rb:28:31:28:33 | "/" | Excon.rb:29:1:29:10 | call to body |
-| Excon.rb:31:10:31:39 | call to post | Excon | Excon.rb:27:25:27:44 | "http://example.com" | Excon.rb:32:1:32:11 | call to body |
-| Excon.rb:31:10:31:39 | call to post | Excon | Excon.rb:31:33:31:38 | "/foo" | Excon.rb:32:1:32:11 | call to body |
-| Excon.rb:35:9:35:34 | call to get | Excon | Excon.rb:34:37:34:56 | "http://example.com" | Excon.rb:36:1:36:10 | call to body |
-| Excon.rb:35:9:35:34 | call to get | Excon | Excon.rb:35:31:35:33 | "/" | Excon.rb:36:1:36:10 | call to body |
-| Excon.rb:38:10:38:39 | call to post | Excon | Excon.rb:34:37:34:56 | "http://example.com" | Excon.rb:39:1:39:11 | call to body |
-| Excon.rb:38:10:38:39 | call to post | Excon | Excon.rb:38:33:38:38 | "/foo" | Excon.rb:39:1:39:11 | call to body |
-| Faraday.rb:3:9:3:42 | call to get | Faraday | Faraday.rb:3:21:3:41 | "http://example.com/" | Faraday.rb:4:1:4:10 | call to body |
-| Faraday.rb:6:9:6:62 | call to post | Faraday | Faraday.rb:6:22:6:42 | "http://example.com/" | Faraday.rb:7:1:7:10 | call to body |
-| Faraday.rb:9:9:9:61 | call to put | Faraday | Faraday.rb:9:21:9:41 | "http://example.com/" | Faraday.rb:10:1:10:10 | call to body |
-| Faraday.rb:12:9:12:63 | call to patch | Faraday | Faraday.rb:12:23:12:43 | "http://example.com/" | Faraday.rb:13:1:13:10 | call to body |
-| Faraday.rb:15:9:15:45 | call to delete | Faraday | Faraday.rb:15:24:15:44 | "http://example.com/" | Faraday.rb:16:1:16:10 | call to body |
-| Faraday.rb:18:9:18:43 | call to head | Faraday | Faraday.rb:18:22:18:42 | "http://example.com/" | Faraday.rb:19:1:19:10 | call to body |
-| Faraday.rb:24:9:24:44 | call to trace | Faraday | Faraday.rb:24:23:24:43 | "http://example.com/" | Faraday.rb:25:1:25:10 | call to body |
-| Faraday.rb:28:9:28:27 | call to get | Faraday | Faraday.rb:27:26:27:45 | "http://example.com" | Faraday.rb:29:1:29:10 | call to body |
-| Faraday.rb:28:9:28:27 | call to get | Faraday | Faraday.rb:28:24:28:26 | "/" | Faraday.rb:29:1:29:10 | call to body |
-| Faraday.rb:31:10:31:46 | call to post | Faraday | Faraday.rb:27:26:27:45 | "http://example.com" | Faraday.rb:32:1:32:11 | call to body |
-| Faraday.rb:31:10:31:46 | call to post | Faraday | Faraday.rb:31:26:31:31 | "/foo" | Faraday.rb:32:1:32:11 | call to body |
-| Faraday.rb:35:10:35:28 | call to get | Faraday | Faraday.rb:34:26:34:50 | Pair | Faraday.rb:36:1:36:11 | call to body |
-| Faraday.rb:35:10:35:28 | call to get | Faraday | Faraday.rb:34:31:34:50 | "http://example.com" | Faraday.rb:36:1:36:11 | call to body |
-| Faraday.rb:35:10:35:28 | call to get | Faraday | Faraday.rb:35:25:35:27 | "/" | Faraday.rb:36:1:36:11 | call to body |
-| Faraday.rb:39:10:39:28 | call to get | Faraday | Faraday.rb:38:38:38:63 | Pair | Faraday.rb:40:1:40:11 | call to body |
-| Faraday.rb:39:10:39:28 | call to get | Faraday | Faraday.rb:38:43:38:63 | "https://example.com" | Faraday.rb:40:1:40:11 | call to body |
-| Faraday.rb:39:10:39:28 | call to get | Faraday | Faraday.rb:39:25:39:27 | "/" | Faraday.rb:40:1:40:11 | call to body |
-| HttpClient.rb:3:9:3:45 | call to get | HTTPClient | HttpClient.rb:3:24:3:44 | "http://example.com/" | HttpClient.rb:4:1:4:10 | call to body |
-| HttpClient.rb:6:9:6:65 | call to post | HTTPClient | HttpClient.rb:6:25:6:45 | "http://example.com/" | HttpClient.rb:7:1:7:13 | call to content |
-| HttpClient.rb:9:9:9:64 | call to put | HTTPClient | HttpClient.rb:9:24:9:44 | "http://example.com/" | HttpClient.rb:10:1:10:15 | call to http_body |
-| HttpClient.rb:12:9:12:48 | call to delete | HTTPClient | HttpClient.rb:12:27:12:47 | "http://example.com/" | HttpClient.rb:13:1:13:10 | call to dump |
-| HttpClient.rb:15:9:15:46 | call to head | HTTPClient | HttpClient.rb:15:25:15:45 | "http://example.com/" | HttpClient.rb:16:1:16:10 | call to body |
-| HttpClient.rb:18:9:18:49 | call to options | HTTPClient | HttpClient.rb:18:28:18:48 | "http://example.com/" | HttpClient.rb:19:1:19:13 | call to content |
-| HttpClient.rb:21:9:21:47 | call to trace | HTTPClient | HttpClient.rb:21:26:21:46 | "http://example.com/" | HttpClient.rb:22:1:22:15 | call to http_body |
-| HttpClient.rb:24:9:24:53 | call to get_content | HTTPClient | HttpClient.rb:24:32:24:52 | "http://example.com/" | HttpClient.rb:24:9:24:53 | call to get_content |
-| HttpClient.rb:26:10:26:74 | call to post_content | HTTPClient | HttpClient.rb:26:34:26:54 | "http://example.com/" | HttpClient.rb:26:10:26:74 | call to post_content |
-| Httparty.rb:5:1:5:35 | call to get | HTTParty | Httparty.rb:5:14:5:34 | "http://example.com/" | Httparty.rb:5:1:5:35 | call to get |
-| Httparty.rb:7:1:7:55 | call to post | HTTParty | Httparty.rb:7:15:7:35 | "http://example.com/" | Httparty.rb:7:1:7:55 | call to post |
-| Httparty.rb:9:1:9:54 | call to put | HTTParty | Httparty.rb:9:14:9:34 | "http://example.com/" | Httparty.rb:9:1:9:54 | call to put |
-| Httparty.rb:11:1:11:56 | call to patch | HTTParty | Httparty.rb:11:16:11:36 | "http://example.com/" | Httparty.rb:11:1:11:56 | call to patch |
-| Httparty.rb:15:9:15:46 | call to delete | HTTParty | Httparty.rb:15:25:15:45 | "http://example.com/" | Httparty.rb:16:1:16:10 | call to body |
-| Httparty.rb:18:9:18:44 | call to head | HTTParty | Httparty.rb:18:23:18:43 | "http://example.com/" | Httparty.rb:19:1:19:10 | call to body |
-| Httparty.rb:21:9:21:47 | call to options | HTTParty | Httparty.rb:21:26:21:46 | "http://example.com/" | Httparty.rb:22:1:22:10 | call to body |
-| NetHttp.rb:4:1:4:18 | call to get | Net::HTTP | NetHttp.rb:4:15:4:17 | uri | NetHttp.rb:4:1:4:18 | call to get |
-| NetHttp.rb:6:8:6:50 | call to post | Net::HTTP | NetHttp.rb:6:23:6:36 | call to parse | NetHttp.rb:7:1:7:9 | call to body |
-| NetHttp.rb:6:8:6:50 | call to post | Net::HTTP | NetHttp.rb:6:23:6:36 | call to parse | NetHttp.rb:8:1:8:14 | call to read_body |
-| NetHttp.rb:6:8:6:50 | call to post | Net::HTTP | NetHttp.rb:6:23:6:36 | call to parse | NetHttp.rb:9:1:9:11 | call to entity |
-| NetHttp.rb:13:6:13:17 | call to get | Net::HTTP | NetHttp.rb:11:21:11:41 | "https://example.com" | NetHttp.rb:18:1:18:7 | call to body |
-| NetHttp.rb:13:6:13:17 | call to get | Net::HTTP | NetHttp.rb:13:14:13:16 | "/" | NetHttp.rb:18:1:18:7 | call to body |
-| NetHttp.rb:14:6:14:18 | call to post | Net::HTTP | NetHttp.rb:11:21:11:41 | "https://example.com" | NetHttp.rb:19:1:19:12 | call to read_body |
-| NetHttp.rb:14:6:14:18 | call to post | Net::HTTP | NetHttp.rb:14:15:14:17 | "/" | NetHttp.rb:19:1:19:12 | call to read_body |
-| NetHttp.rb:15:6:15:17 | call to put | Net::HTTP | NetHttp.rb:11:21:11:41 | "https://example.com" | NetHttp.rb:20:1:20:9 | call to entity |
-| NetHttp.rb:15:6:15:17 | call to put | Net::HTTP | NetHttp.rb:15:14:15:16 | "/" | NetHttp.rb:20:1:20:9 | call to entity |
-| NetHttp.rb:24:3:24:33 | call to get | Net::HTTP | NetHttp.rb:24:17:24:22 | domain | NetHttp.rb:27:1:27:28 | call to body |
-| NetHttp.rb:24:3:24:33 | call to get | Net::HTTP | NetHttp.rb:24:29:24:32 | path | NetHttp.rb:27:1:27:28 | call to body |
-| OpenURI.rb:3:9:3:41 | call to open | OpenURI | OpenURI.rb:3:21:3:40 | "http://example.com" | OpenURI.rb:4:1:4:10 | call to read |
-| OpenURI.rb:6:9:6:34 | call to open | OpenURI | OpenURI.rb:6:14:6:33 | "http://example.com" | OpenURI.rb:7:1:7:15 | call to readlines |
-| OpenURI.rb:9:9:9:38 | call to open | OpenURI | OpenURI.rb:9:18:9:37 | "http://example.com" | OpenURI.rb:10:1:10:10 | call to read |
-| OpenURI.rb:15:9:15:47 | call to open_uri | OpenURI | OpenURI.rb:15:26:15:46 | "https://example.com" | OpenURI.rb:16:1:16:10 | call to read |
-| RestClient.rb:3:9:3:45 | call to get | RestClient | RestClient.rb:3:24:3:44 | "http://example.com/" | RestClient.rb:4:1:4:10 | call to body |
-| RestClient.rb:6:9:6:59 | call to post | RestClient | RestClient.rb:6:25:6:44 | "http://example.com" | RestClient.rb:7:1:7:10 | call to body |
-| RestClient.rb:9:9:9:58 | call to put | RestClient | RestClient.rb:9:24:9:43 | "http://example.com" | RestClient.rb:10:1:10:10 | call to body |
-| RestClient.rb:12:9:12:60 | call to patch | RestClient | RestClient.rb:12:26:12:45 | "http://example.com" | RestClient.rb:13:1:13:10 | call to body |
-| RestClient.rb:15:9:15:47 | call to delete | RestClient | RestClient.rb:15:27:15:46 | "http://example.com" | RestClient.rb:16:1:16:10 | call to body |
-| RestClient.rb:18:9:18:45 | call to head | RestClient | RestClient.rb:18:25:18:44 | "http://example.com" | RestClient.rb:19:1:19:10 | call to body |
-| RestClient.rb:21:9:21:48 | call to options | RestClient | RestClient.rb:21:28:21:47 | "http://example.com" | RestClient.rb:22:1:22:10 | call to body |
-| RestClient.rb:28:9:28:85 | call to execute | RestClient | RestClient.rb:28:56:28:84 | "http://example.com/resource" | RestClient.rb:29:1:29:10 | call to body |
-| Typhoeus.rb:3:9:3:43 | call to get | Typhoeus | Typhoeus.rb:3:22:3:42 | "http://example.com/" | Typhoeus.rb:4:1:4:10 | call to body |
-| Typhoeus.rb:6:9:6:63 | call to post | Typhoeus | Typhoeus.rb:6:23:6:43 | "http://example.com/" | Typhoeus.rb:7:1:7:10 | call to body |
-| Typhoeus.rb:9:9:9:62 | call to put | Typhoeus | Typhoeus.rb:9:22:9:42 | "http://example.com/" | Typhoeus.rb:10:1:10:10 | call to body |
-| Typhoeus.rb:12:9:12:64 | call to patch | Typhoeus | Typhoeus.rb:12:24:12:44 | "http://example.com/" | Typhoeus.rb:13:1:13:10 | call to body |
-| Typhoeus.rb:15:9:15:46 | call to delete | Typhoeus | Typhoeus.rb:15:25:15:45 | "http://example.com/" | Typhoeus.rb:16:1:16:10 | call to body |
-| Typhoeus.rb:18:9:18:44 | call to head | Typhoeus | Typhoeus.rb:18:23:18:43 | "http://example.com/" | Typhoeus.rb:19:1:19:10 | call to body |
-| Typhoeus.rb:21:9:21:47 | call to options | Typhoeus | Typhoeus.rb:21:26:21:46 | "http://example.com/" | Typhoeus.rb:22:1:22:10 | call to body |
+httpRequests
+| Excon.rb:3:9:3:40 | call to get |
+| Excon.rb:6:9:6:60 | call to post |
+| Excon.rb:9:9:9:59 | call to put |
+| Excon.rb:12:9:12:61 | call to patch |
+| Excon.rb:15:9:15:43 | call to delete |
+| Excon.rb:18:9:18:41 | call to head |
+| Excon.rb:21:9:21:44 | call to options |
+| Excon.rb:24:9:24:42 | call to trace |
+| Excon.rb:28:9:28:34 | call to get |
+| Excon.rb:31:10:31:39 | call to post |
+| Excon.rb:35:9:35:34 | call to get |
+| Excon.rb:38:10:38:39 | call to post |
+| Faraday.rb:3:9:3:42 | call to get |
+| Faraday.rb:6:9:6:62 | call to post |
+| Faraday.rb:9:9:9:61 | call to put |
+| Faraday.rb:12:9:12:63 | call to patch |
+| Faraday.rb:15:9:15:45 | call to delete |
+| Faraday.rb:18:9:18:43 | call to head |
+| Faraday.rb:24:9:24:44 | call to trace |
+| Faraday.rb:28:9:28:27 | call to get |
+| Faraday.rb:31:10:31:46 | call to post |
+| Faraday.rb:35:10:35:28 | call to get |
+| Faraday.rb:39:10:39:28 | call to get |
+| HttpClient.rb:3:9:3:45 | call to get |
+| HttpClient.rb:6:9:6:65 | call to post |
+| HttpClient.rb:9:9:9:64 | call to put |
+| HttpClient.rb:12:9:12:48 | call to delete |
+| HttpClient.rb:15:9:15:46 | call to head |
+| HttpClient.rb:18:9:18:49 | call to options |
+| HttpClient.rb:21:9:21:47 | call to trace |
+| HttpClient.rb:24:9:24:53 | call to get_content |
+| HttpClient.rb:26:10:26:74 | call to post_content |
+| Httparty.rb:5:1:5:35 | call to get |
+| Httparty.rb:7:1:7:55 | call to post |
+| Httparty.rb:9:1:9:54 | call to put |
+| Httparty.rb:11:1:11:56 | call to patch |
+| Httparty.rb:15:9:15:46 | call to delete |
+| Httparty.rb:18:9:18:44 | call to head |
+| Httparty.rb:21:9:21:47 | call to options |
+| NetHttp.rb:4:1:4:18 | call to get |
+| NetHttp.rb:6:8:6:50 | call to post |
+| NetHttp.rb:13:6:13:17 | call to get |
+| NetHttp.rb:14:6:14:18 | call to post |
+| NetHttp.rb:15:6:15:17 | call to put |
+| NetHttp.rb:24:3:24:33 | call to get |
+| OpenURI.rb:3:9:3:41 | call to open |
+| OpenURI.rb:6:9:6:34 | call to open |
+| OpenURI.rb:9:9:9:38 | call to open |
+| OpenURI.rb:12:9:12:45 | call to open |
+| OpenURI.rb:15:9:15:47 | call to open_uri |
+| RestClient.rb:3:9:3:45 | call to get |
+| RestClient.rb:6:9:6:59 | call to post |
+| RestClient.rb:9:9:9:58 | call to put |
+| RestClient.rb:12:9:12:60 | call to patch |
+| RestClient.rb:15:9:15:47 | call to delete |
+| RestClient.rb:18:9:18:45 | call to head |
+| RestClient.rb:21:9:21:48 | call to options |
+| RestClient.rb:25:9:25:21 | call to get |
+| RestClient.rb:28:9:28:85 | call to execute |
+| Typhoeus.rb:3:9:3:43 | call to get |
+| Typhoeus.rb:6:9:6:63 | call to post |
+| Typhoeus.rb:9:9:9:62 | call to put |
+| Typhoeus.rb:12:9:12:64 | call to patch |
+| Typhoeus.rb:15:9:15:46 | call to delete |
+| Typhoeus.rb:18:9:18:44 | call to head |
+| Typhoeus.rb:21:9:21:47 | call to options |
+getFramework
+| Excon.rb:3:9:3:40 | call to get | Excon |
+| Excon.rb:6:9:6:60 | call to post | Excon |
+| Excon.rb:9:9:9:59 | call to put | Excon |
+| Excon.rb:12:9:12:61 | call to patch | Excon |
+| Excon.rb:15:9:15:43 | call to delete | Excon |
+| Excon.rb:18:9:18:41 | call to head | Excon |
+| Excon.rb:21:9:21:44 | call to options | Excon |
+| Excon.rb:24:9:24:42 | call to trace | Excon |
+| Excon.rb:28:9:28:34 | call to get | Excon |
+| Excon.rb:31:10:31:39 | call to post | Excon |
+| Excon.rb:35:9:35:34 | call to get | Excon |
+| Excon.rb:38:10:38:39 | call to post | Excon |
+| Faraday.rb:3:9:3:42 | call to get | Faraday |
+| Faraday.rb:6:9:6:62 | call to post | Faraday |
+| Faraday.rb:9:9:9:61 | call to put | Faraday |
+| Faraday.rb:12:9:12:63 | call to patch | Faraday |
+| Faraday.rb:15:9:15:45 | call to delete | Faraday |
+| Faraday.rb:18:9:18:43 | call to head | Faraday |
+| Faraday.rb:24:9:24:44 | call to trace | Faraday |
+| Faraday.rb:28:9:28:27 | call to get | Faraday |
+| Faraday.rb:31:10:31:46 | call to post | Faraday |
+| Faraday.rb:35:10:35:28 | call to get | Faraday |
+| Faraday.rb:39:10:39:28 | call to get | Faraday |
+| HttpClient.rb:3:9:3:45 | call to get | HTTPClient |
+| HttpClient.rb:6:9:6:65 | call to post | HTTPClient |
+| HttpClient.rb:9:9:9:64 | call to put | HTTPClient |
+| HttpClient.rb:12:9:12:48 | call to delete | HTTPClient |
+| HttpClient.rb:15:9:15:46 | call to head | HTTPClient |
+| HttpClient.rb:18:9:18:49 | call to options | HTTPClient |
+| HttpClient.rb:21:9:21:47 | call to trace | HTTPClient |
+| HttpClient.rb:24:9:24:53 | call to get_content | HTTPClient |
+| HttpClient.rb:26:10:26:74 | call to post_content | HTTPClient |
+| Httparty.rb:5:1:5:35 | call to get | HTTParty |
+| Httparty.rb:7:1:7:55 | call to post | HTTParty |
+| Httparty.rb:9:1:9:54 | call to put | HTTParty |
+| Httparty.rb:11:1:11:56 | call to patch | HTTParty |
+| Httparty.rb:15:9:15:46 | call to delete | HTTParty |
+| Httparty.rb:18:9:18:44 | call to head | HTTParty |
+| Httparty.rb:21:9:21:47 | call to options | HTTParty |
+| NetHttp.rb:4:1:4:18 | call to get | Net::HTTP |
+| NetHttp.rb:6:8:6:50 | call to post | Net::HTTP |
+| NetHttp.rb:13:6:13:17 | call to get | Net::HTTP |
+| NetHttp.rb:14:6:14:18 | call to post | Net::HTTP |
+| NetHttp.rb:15:6:15:17 | call to put | Net::HTTP |
+| NetHttp.rb:24:3:24:33 | call to get | Net::HTTP |
+| OpenURI.rb:3:9:3:41 | call to open | OpenURI |
+| OpenURI.rb:6:9:6:34 | call to open | OpenURI |
+| OpenURI.rb:9:9:9:38 | call to open | OpenURI |
+| OpenURI.rb:12:9:12:45 | call to open | OpenURI |
+| OpenURI.rb:15:9:15:47 | call to open_uri | OpenURI |
+| RestClient.rb:3:9:3:45 | call to get | RestClient |
+| RestClient.rb:6:9:6:59 | call to post | RestClient |
+| RestClient.rb:9:9:9:58 | call to put | RestClient |
+| RestClient.rb:12:9:12:60 | call to patch | RestClient |
+| RestClient.rb:15:9:15:47 | call to delete | RestClient |
+| RestClient.rb:18:9:18:45 | call to head | RestClient |
+| RestClient.rb:21:9:21:48 | call to options | RestClient |
+| RestClient.rb:25:9:25:21 | call to get | RestClient |
+| RestClient.rb:28:9:28:85 | call to execute | RestClient |
+| Typhoeus.rb:3:9:3:43 | call to get | Typhoeus |
+| Typhoeus.rb:6:9:6:63 | call to post | Typhoeus |
+| Typhoeus.rb:9:9:9:62 | call to put | Typhoeus |
+| Typhoeus.rb:12:9:12:64 | call to patch | Typhoeus |
+| Typhoeus.rb:15:9:15:46 | call to delete | Typhoeus |
+| Typhoeus.rb:18:9:18:44 | call to head | Typhoeus |
+| Typhoeus.rb:21:9:21:47 | call to options | Typhoeus |
+getResponseBody
+| Excon.rb:3:9:3:40 | call to get | Excon.rb:4:1:4:10 | call to body |
+| Excon.rb:6:9:6:60 | call to post | Excon.rb:7:1:7:10 | call to body |
+| Excon.rb:9:9:9:59 | call to put | Excon.rb:10:1:10:10 | call to body |
+| Excon.rb:12:9:12:61 | call to patch | Excon.rb:13:1:13:10 | call to body |
+| Excon.rb:15:9:15:43 | call to delete | Excon.rb:16:1:16:10 | call to body |
+| Excon.rb:18:9:18:41 | call to head | Excon.rb:19:1:19:10 | call to body |
+| Excon.rb:21:9:21:44 | call to options | Excon.rb:22:1:22:10 | call to body |
+| Excon.rb:24:9:24:42 | call to trace | Excon.rb:25:1:25:10 | call to body |
+| Excon.rb:28:9:28:34 | call to get | Excon.rb:29:1:29:10 | call to body |
+| Excon.rb:31:10:31:39 | call to post | Excon.rb:32:1:32:11 | call to body |
+| Excon.rb:35:9:35:34 | call to get | Excon.rb:36:1:36:10 | call to body |
+| Excon.rb:38:10:38:39 | call to post | Excon.rb:39:1:39:11 | call to body |
+| Faraday.rb:3:9:3:42 | call to get | Faraday.rb:4:1:4:10 | call to body |
+| Faraday.rb:6:9:6:62 | call to post | Faraday.rb:7:1:7:10 | call to body |
+| Faraday.rb:9:9:9:61 | call to put | Faraday.rb:10:1:10:10 | call to body |
+| Faraday.rb:12:9:12:63 | call to patch | Faraday.rb:13:1:13:10 | call to body |
+| Faraday.rb:15:9:15:45 | call to delete | Faraday.rb:16:1:16:10 | call to body |
+| Faraday.rb:18:9:18:43 | call to head | Faraday.rb:19:1:19:10 | call to body |
+| Faraday.rb:24:9:24:44 | call to trace | Faraday.rb:25:1:25:10 | call to body |
+| Faraday.rb:28:9:28:27 | call to get | Faraday.rb:29:1:29:10 | call to body |
+| Faraday.rb:31:10:31:46 | call to post | Faraday.rb:32:1:32:11 | call to body |
+| Faraday.rb:35:10:35:28 | call to get | Faraday.rb:36:1:36:11 | call to body |
+| Faraday.rb:39:10:39:28 | call to get | Faraday.rb:40:1:40:11 | call to body |
+| HttpClient.rb:3:9:3:45 | call to get | HttpClient.rb:4:1:4:10 | call to body |
+| HttpClient.rb:6:9:6:65 | call to post | HttpClient.rb:7:1:7:13 | call to content |
+| HttpClient.rb:9:9:9:64 | call to put | HttpClient.rb:10:1:10:15 | call to http_body |
+| HttpClient.rb:12:9:12:48 | call to delete | HttpClient.rb:13:1:13:10 | call to dump |
+| HttpClient.rb:15:9:15:46 | call to head | HttpClient.rb:16:1:16:10 | call to body |
+| HttpClient.rb:18:9:18:49 | call to options | HttpClient.rb:19:1:19:13 | call to content |
+| HttpClient.rb:21:9:21:47 | call to trace | HttpClient.rb:22:1:22:15 | call to http_body |
+| HttpClient.rb:24:9:24:53 | call to get_content | HttpClient.rb:24:9:24:53 | call to get_content |
+| HttpClient.rb:26:10:26:74 | call to post_content | HttpClient.rb:26:10:26:74 | call to post_content |
+| Httparty.rb:5:1:5:35 | call to get | Httparty.rb:5:1:5:35 | call to get |
+| Httparty.rb:7:1:7:55 | call to post | Httparty.rb:7:1:7:55 | call to post |
+| Httparty.rb:9:1:9:54 | call to put | Httparty.rb:9:1:9:54 | call to put |
+| Httparty.rb:11:1:11:56 | call to patch | Httparty.rb:11:1:11:56 | call to patch |
+| Httparty.rb:15:9:15:46 | call to delete | Httparty.rb:16:1:16:10 | call to body |
+| Httparty.rb:18:9:18:44 | call to head | Httparty.rb:19:1:19:10 | call to body |
+| Httparty.rb:21:9:21:47 | call to options | Httparty.rb:22:1:22:10 | call to body |
+| NetHttp.rb:4:1:4:18 | call to get | NetHttp.rb:4:1:4:18 | call to get |
+| NetHttp.rb:6:8:6:50 | call to post | NetHttp.rb:7:1:7:9 | call to body |
+| NetHttp.rb:6:8:6:50 | call to post | NetHttp.rb:8:1:8:14 | call to read_body |
+| NetHttp.rb:6:8:6:50 | call to post | NetHttp.rb:9:1:9:11 | call to entity |
+| NetHttp.rb:13:6:13:17 | call to get | NetHttp.rb:18:1:18:7 | call to body |
+| NetHttp.rb:14:6:14:18 | call to post | NetHttp.rb:19:1:19:12 | call to read_body |
+| NetHttp.rb:15:6:15:17 | call to put | NetHttp.rb:20:1:20:9 | call to entity |
+| NetHttp.rb:24:3:24:33 | call to get | NetHttp.rb:27:1:27:28 | call to body |
+| OpenURI.rb:3:9:3:41 | call to open | OpenURI.rb:4:1:4:10 | call to read |
+| OpenURI.rb:6:9:6:34 | call to open | OpenURI.rb:7:1:7:15 | call to readlines |
+| OpenURI.rb:9:9:9:38 | call to open | OpenURI.rb:10:1:10:10 | call to read |
+| OpenURI.rb:12:9:12:45 | call to open | OpenURI.rb:13:1:13:10 | call to read |
+| OpenURI.rb:15:9:15:47 | call to open_uri | OpenURI.rb:16:1:16:10 | call to read |
+| RestClient.rb:3:9:3:45 | call to get | RestClient.rb:4:1:4:10 | call to body |
+| RestClient.rb:6:9:6:59 | call to post | RestClient.rb:7:1:7:10 | call to body |
+| RestClient.rb:9:9:9:58 | call to put | RestClient.rb:10:1:10:10 | call to body |
+| RestClient.rb:12:9:12:60 | call to patch | RestClient.rb:13:1:13:10 | call to body |
+| RestClient.rb:15:9:15:47 | call to delete | RestClient.rb:16:1:16:10 | call to body |
+| RestClient.rb:18:9:18:45 | call to head | RestClient.rb:19:1:19:10 | call to body |
+| RestClient.rb:21:9:21:48 | call to options | RestClient.rb:22:1:22:10 | call to body |
+| RestClient.rb:25:9:25:21 | call to get | RestClient.rb:26:1:26:10 | call to body |
+| RestClient.rb:28:9:28:85 | call to execute | RestClient.rb:29:1:29:10 | call to body |
+| Typhoeus.rb:3:9:3:43 | call to get | Typhoeus.rb:4:1:4:10 | call to body |
+| Typhoeus.rb:6:9:6:63 | call to post | Typhoeus.rb:7:1:7:10 | call to body |
+| Typhoeus.rb:9:9:9:62 | call to put | Typhoeus.rb:10:1:10:10 | call to body |
+| Typhoeus.rb:12:9:12:64 | call to patch | Typhoeus.rb:13:1:13:10 | call to body |
+| Typhoeus.rb:15:9:15:46 | call to delete | Typhoeus.rb:16:1:16:10 | call to body |
+| Typhoeus.rb:18:9:18:44 | call to head | Typhoeus.rb:19:1:19:10 | call to body |
+| Typhoeus.rb:21:9:21:47 | call to options | Typhoeus.rb:22:1:22:10 | call to body |
+getAUrlPart
+| Excon.rb:3:9:3:40 | call to get | Excon.rb:3:19:3:39 | "http://example.com/" |
+| Excon.rb:6:9:6:60 | call to post | Excon.rb:6:20:6:40 | "http://example.com/" |
+| Excon.rb:9:9:9:59 | call to put | Excon.rb:9:19:9:39 | "http://example.com/" |
+| Excon.rb:12:9:12:61 | call to patch | Excon.rb:12:21:12:41 | "http://example.com/" |
+| Excon.rb:15:9:15:43 | call to delete | Excon.rb:15:22:15:42 | "http://example.com/" |
+| Excon.rb:18:9:18:41 | call to head | Excon.rb:18:20:18:40 | "http://example.com/" |
+| Excon.rb:21:9:21:44 | call to options | Excon.rb:21:23:21:43 | "http://example.com/" |
+| Excon.rb:24:9:24:42 | call to trace | Excon.rb:24:21:24:41 | "http://example.com/" |
+| Excon.rb:28:9:28:34 | call to get | Excon.rb:27:25:27:44 | "http://example.com" |
+| Excon.rb:28:9:28:34 | call to get | Excon.rb:28:31:28:33 | "/" |
+| Excon.rb:31:10:31:39 | call to post | Excon.rb:27:25:27:44 | "http://example.com" |
+| Excon.rb:31:10:31:39 | call to post | Excon.rb:31:33:31:38 | "/foo" |
+| Excon.rb:35:9:35:34 | call to get | Excon.rb:34:37:34:56 | "http://example.com" |
+| Excon.rb:35:9:35:34 | call to get | Excon.rb:35:31:35:33 | "/" |
+| Excon.rb:38:10:38:39 | call to post | Excon.rb:34:37:34:56 | "http://example.com" |
+| Excon.rb:38:10:38:39 | call to post | Excon.rb:38:33:38:38 | "/foo" |
+| Faraday.rb:3:9:3:42 | call to get | Faraday.rb:3:21:3:41 | "http://example.com/" |
+| Faraday.rb:6:9:6:62 | call to post | Faraday.rb:6:22:6:42 | "http://example.com/" |
+| Faraday.rb:9:9:9:61 | call to put | Faraday.rb:9:21:9:41 | "http://example.com/" |
+| Faraday.rb:12:9:12:63 | call to patch | Faraday.rb:12:23:12:43 | "http://example.com/" |
+| Faraday.rb:15:9:15:45 | call to delete | Faraday.rb:15:24:15:44 | "http://example.com/" |
+| Faraday.rb:18:9:18:43 | call to head | Faraday.rb:18:22:18:42 | "http://example.com/" |
+| Faraday.rb:24:9:24:44 | call to trace | Faraday.rb:24:23:24:43 | "http://example.com/" |
+| Faraday.rb:28:9:28:27 | call to get | Faraday.rb:27:26:27:45 | "http://example.com" |
+| Faraday.rb:28:9:28:27 | call to get | Faraday.rb:28:24:28:26 | "/" |
+| Faraday.rb:31:10:31:46 | call to post | Faraday.rb:27:26:27:45 | "http://example.com" |
+| Faraday.rb:31:10:31:46 | call to post | Faraday.rb:31:26:31:31 | "/foo" |
+| Faraday.rb:35:10:35:28 | call to get | Faraday.rb:34:26:34:50 | Pair |
+| Faraday.rb:35:10:35:28 | call to get | Faraday.rb:34:31:34:50 | "http://example.com" |
+| Faraday.rb:35:10:35:28 | call to get | Faraday.rb:35:25:35:27 | "/" |
+| Faraday.rb:39:10:39:28 | call to get | Faraday.rb:38:38:38:63 | Pair |
+| Faraday.rb:39:10:39:28 | call to get | Faraday.rb:38:43:38:63 | "https://example.com" |
+| Faraday.rb:39:10:39:28 | call to get | Faraday.rb:39:25:39:27 | "/" |
+| HttpClient.rb:3:9:3:45 | call to get | HttpClient.rb:3:24:3:44 | "http://example.com/" |
+| HttpClient.rb:6:9:6:65 | call to post | HttpClient.rb:6:25:6:45 | "http://example.com/" |
+| HttpClient.rb:9:9:9:64 | call to put | HttpClient.rb:9:24:9:44 | "http://example.com/" |
+| HttpClient.rb:12:9:12:48 | call to delete | HttpClient.rb:12:27:12:47 | "http://example.com/" |
+| HttpClient.rb:15:9:15:46 | call to head | HttpClient.rb:15:25:15:45 | "http://example.com/" |
+| HttpClient.rb:18:9:18:49 | call to options | HttpClient.rb:18:28:18:48 | "http://example.com/" |
+| HttpClient.rb:21:9:21:47 | call to trace | HttpClient.rb:21:26:21:46 | "http://example.com/" |
+| HttpClient.rb:24:9:24:53 | call to get_content | HttpClient.rb:24:32:24:52 | "http://example.com/" |
+| HttpClient.rb:26:10:26:74 | call to post_content | HttpClient.rb:26:34:26:54 | "http://example.com/" |
+| Httparty.rb:5:1:5:35 | call to get | Httparty.rb:5:14:5:34 | "http://example.com/" |
+| Httparty.rb:7:1:7:55 | call to post | Httparty.rb:7:15:7:35 | "http://example.com/" |
+| Httparty.rb:9:1:9:54 | call to put | Httparty.rb:9:14:9:34 | "http://example.com/" |
+| Httparty.rb:11:1:11:56 | call to patch | Httparty.rb:11:16:11:36 | "http://example.com/" |
+| Httparty.rb:15:9:15:46 | call to delete | Httparty.rb:15:25:15:45 | "http://example.com/" |
+| Httparty.rb:18:9:18:44 | call to head | Httparty.rb:18:23:18:43 | "http://example.com/" |
+| Httparty.rb:21:9:21:47 | call to options | Httparty.rb:21:26:21:46 | "http://example.com/" |
+| NetHttp.rb:4:1:4:18 | call to get | NetHttp.rb:4:15:4:17 | uri |
+| NetHttp.rb:6:8:6:50 | call to post | NetHttp.rb:6:23:6:36 | call to parse |
+| NetHttp.rb:13:6:13:17 | call to get | NetHttp.rb:11:21:11:41 | "https://example.com" |
+| NetHttp.rb:13:6:13:17 | call to get | NetHttp.rb:13:14:13:16 | "/" |
+| NetHttp.rb:14:6:14:18 | call to post | NetHttp.rb:11:21:11:41 | "https://example.com" |
+| NetHttp.rb:14:6:14:18 | call to post | NetHttp.rb:14:15:14:17 | "/" |
+| NetHttp.rb:15:6:15:17 | call to put | NetHttp.rb:11:21:11:41 | "https://example.com" |
+| NetHttp.rb:15:6:15:17 | call to put | NetHttp.rb:15:14:15:16 | "/" |
+| NetHttp.rb:24:3:24:33 | call to get | NetHttp.rb:24:17:24:22 | domain |
+| NetHttp.rb:24:3:24:33 | call to get | NetHttp.rb:24:29:24:32 | path |
+| OpenURI.rb:3:9:3:41 | call to open | OpenURI.rb:3:21:3:40 | "http://example.com" |
+| OpenURI.rb:6:9:6:34 | call to open | OpenURI.rb:6:14:6:33 | "http://example.com" |
+| OpenURI.rb:9:9:9:38 | call to open | OpenURI.rb:9:18:9:37 | "http://example.com" |
+| OpenURI.rb:15:9:15:47 | call to open_uri | OpenURI.rb:15:26:15:46 | "https://example.com" |
+| RestClient.rb:3:9:3:45 | call to get | RestClient.rb:3:24:3:44 | "http://example.com/" |
+| RestClient.rb:6:9:6:59 | call to post | RestClient.rb:6:25:6:44 | "http://example.com" |
+| RestClient.rb:9:9:9:58 | call to put | RestClient.rb:9:24:9:43 | "http://example.com" |
+| RestClient.rb:12:9:12:60 | call to patch | RestClient.rb:12:26:12:45 | "http://example.com" |
+| RestClient.rb:15:9:15:47 | call to delete | RestClient.rb:15:27:15:46 | "http://example.com" |
+| RestClient.rb:18:9:18:45 | call to head | RestClient.rb:18:25:18:44 | "http://example.com" |
+| RestClient.rb:21:9:21:48 | call to options | RestClient.rb:21:28:21:47 | "http://example.com" |
+| RestClient.rb:28:9:28:85 | call to execute | RestClient.rb:28:56:28:84 | "http://example.com/resource" |
+| Typhoeus.rb:3:9:3:43 | call to get | Typhoeus.rb:3:22:3:42 | "http://example.com/" |
+| Typhoeus.rb:6:9:6:63 | call to post | Typhoeus.rb:6:23:6:43 | "http://example.com/" |
+| Typhoeus.rb:9:9:9:62 | call to put | Typhoeus.rb:9:22:9:42 | "http://example.com/" |
+| Typhoeus.rb:12:9:12:64 | call to patch | Typhoeus.rb:12:24:12:44 | "http://example.com/" |
+| Typhoeus.rb:15:9:15:46 | call to delete | Typhoeus.rb:15:25:15:45 | "http://example.com/" |
+| Typhoeus.rb:18:9:18:44 | call to head | Typhoeus.rb:18:23:18:43 | "http://example.com/" |
+| Typhoeus.rb:21:9:21:47 | call to options | Typhoeus.rb:21:26:21:46 | "http://example.com/" |

--- a/ruby/ql/test/library-tests/frameworks/http_clients/HttpClients.expected
+++ b/ruby/ql/test/library-tests/frameworks/http_clients/HttpClients.expected
@@ -43,7 +43,9 @@ httpRequests
 | NetHttp.rb:13:6:13:17 | call to get |
 | NetHttp.rb:14:6:14:18 | call to post |
 | NetHttp.rb:15:6:15:17 | call to put |
+| NetHttp.rb:16:6:16:19 | call to patch |
 | NetHttp.rb:24:3:24:33 | call to get |
+| NetHttp.rb:29:1:29:32 | call to post |
 | OpenURI.rb:3:9:3:41 | call to open |
 | OpenURI.rb:6:9:6:34 | call to open |
 | OpenURI.rb:9:9:9:38 | call to open |
@@ -110,7 +112,9 @@ getFramework
 | NetHttp.rb:13:6:13:17 | call to get | Net::HTTP |
 | NetHttp.rb:14:6:14:18 | call to post | Net::HTTP |
 | NetHttp.rb:15:6:15:17 | call to put | Net::HTTP |
+| NetHttp.rb:16:6:16:19 | call to patch | Net::HTTP |
 | NetHttp.rb:24:3:24:33 | call to get | Net::HTTP |
+| NetHttp.rb:29:1:29:32 | call to post | Net::HTTP |
 | OpenURI.rb:3:9:3:41 | call to open | OpenURI |
 | OpenURI.rb:6:9:6:34 | call to open | OpenURI |
 | OpenURI.rb:9:9:9:38 | call to open | OpenURI |
@@ -259,8 +263,11 @@ getAUrlPart
 | NetHttp.rb:14:6:14:18 | call to post | NetHttp.rb:14:15:14:17 | "/" |
 | NetHttp.rb:15:6:15:17 | call to put | NetHttp.rb:11:21:11:41 | "https://example.com" |
 | NetHttp.rb:15:6:15:17 | call to put | NetHttp.rb:15:14:15:16 | "/" |
+| NetHttp.rb:16:6:16:19 | call to patch | NetHttp.rb:11:21:11:41 | "https://example.com" |
+| NetHttp.rb:16:6:16:19 | call to patch | NetHttp.rb:16:16:16:18 | "/" |
 | NetHttp.rb:24:3:24:33 | call to get | NetHttp.rb:24:17:24:22 | domain |
 | NetHttp.rb:24:3:24:33 | call to get | NetHttp.rb:24:29:24:32 | path |
+| NetHttp.rb:29:1:29:32 | call to post | NetHttp.rb:29:16:29:18 | uri |
 | OpenURI.rb:3:9:3:41 | call to open | OpenURI.rb:3:21:3:40 | "http://example.com" |
 | OpenURI.rb:6:9:6:34 | call to open | OpenURI.rb:6:14:6:33 | "http://example.com" |
 | OpenURI.rb:9:9:9:38 | call to open | OpenURI.rb:9:18:9:37 | "http://example.com" |

--- a/ruby/ql/test/library-tests/frameworks/http_clients/HttpClients.ql
+++ b/ruby/ql/test/library-tests/frameworks/http_clients/HttpClients.ql
@@ -1,10 +1,10 @@
 import codeql.ruby.Concepts
 import codeql.ruby.DataFlow
 
-query predicate httpRequests(
-  Http::Client::Request r, string framework, DataFlow::Node urlPart, DataFlow::Node responseBody
-) {
-  r.getFramework() = framework and
-  r.getAUrlPart() = urlPart and
-  r.getResponseBody() = responseBody
-}
+query predicate httpRequests(Http::Client::Request r) { any() }
+
+query string getFramework(Http::Client::Request req) { result = req.getFramework() }
+
+query DataFlow::Node getResponseBody(Http::Client::Request req) { result = req.getResponseBody() }
+
+query DataFlow::Node getAUrlPart(Http::Client::Request req) { result = req.getAUrlPart() }

--- a/ruby/ql/test/library-tests/frameworks/http_clients/NetHttp.rb
+++ b/ruby/ql/test/library-tests/frameworks/http_clients/NetHttp.rb
@@ -25,3 +25,5 @@ def get(domain, path)
 end
 
 get("example.com", "/").body
+
+Net::HTTP.post(uri, "some_body") # note: response body not accessed


### PR DESCRIPTION
Previously the `NetHttpRequest` charpred expected to find an access to the response body. As a result, the class would not get instantiated in cases where we can't find an access to the response body.

This logic has now been moved into the corresponding member predicate.

Also refactored the test to not make the same assumption.

[Evaluation](https://github.com/github/codeql-dca-main/issues/12203) shows neutral perf and 106 new SSRF sinks.

Commit-by-commit review recommended mainly due to the test refactoring.