### PR TITLE
C#: Re-factor data flow unit tests to use the new API.

### DIFF
--- a/csharp/ql/test/library-tests/cil/dataflow/TaintTracking.ql
+++ b/csharp/ql/test/library-tests/cil/dataflow/TaintTracking.ql
@@ -6,16 +6,16 @@ import semmle.code.csharp.dataflow.TaintTracking3
 import semmle.code.csharp.dataflow.TaintTracking4
 import semmle.code.csharp.dataflow.TaintTracking5
 
-class FlowConfig extends TaintTracking::Configuration {
-  FlowConfig() { this = "FlowConfig" }
+module FlowConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { source.asExpr() instanceof Literal }
 
-  override predicate isSource(DataFlow::Node source) { source.asExpr() instanceof Literal }
-
-  override predicate isSink(DataFlow::Node sink) {
+  predicate isSink(DataFlow::Node sink) {
     exists(LocalVariable decl | sink.asExpr() = decl.getInitializer())
   }
 }
 
-from FlowConfig config, DataFlow::Node source, DataFlow::Node sink
-where config.hasFlow(source, sink)
+module Flow = TaintTracking::Global<FlowConfig>;
+
+from DataFlow::Node source, DataFlow::Node sink
+where Flow::flow(source, sink)
 select source, sink

--- a/csharp/ql/test/library-tests/csharp7/GlobalTaintTracking.ql
+++ b/csharp/ql/test/library-tests/csharp7/GlobalTaintTracking.ql
@@ -3,20 +3,18 @@
  */
 
 import csharp
-import DataFlow::PathGraph
+import Taint::PathGraph
 
-class DataflowConfiguration extends TaintTracking::Configuration {
-  DataflowConfiguration() { this = "taint tracking configuration" }
+module TaintConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { source.asExpr().(Expr).getValue() = "tainted" }
 
-  override predicate isSource(DataFlow::Node source) {
-    source.asExpr().(Expr).getValue() = "tainted"
-  }
-
-  override predicate isSink(DataFlow::Node sink) {
+  predicate isSink(DataFlow::Node sink) {
     exists(LocalVariable v | sink.asExpr() = v.getInitializer())
   }
 }
 
-from DataFlow::PathNode source, DataFlow::PathNode sink, DataflowConfiguration conf
-where conf.hasFlowPath(source, sink)
+module Taint = TaintTracking::Global<TaintConfig>;
+
+from Taint::PathNode source, Taint::PathNode sink
+where Taint::flowPath(source, sink)
 select source, source, sink, "$@", sink, sink.toString()

--- a/csharp/ql/test/library-tests/dataflow/async/Async.ql
+++ b/csharp/ql/test/library-tests/dataflow/async/Async.ql
@@ -1,5 +1,5 @@
 import csharp
-import semmle.code.csharp.dataflow.DataFlow::DataFlow::PathGraph
+import Taint::PathGraph
 
 class MySink extends DataFlow::ExprNode {
   MySink() {
@@ -19,15 +19,15 @@ class MySource extends DataFlow::ParameterNode {
   }
 }
 
-class MyConfig extends TaintTracking::Configuration {
-  MyConfig() { this = "MyConfig" }
+module TaintConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { source instanceof MySource }
 
-  override predicate isSource(DataFlow::Node source) { source instanceof MySource }
-
-  override predicate isSink(DataFlow::Node sink) { sink instanceof MySink }
+  predicate isSink(DataFlow::Node sink) { sink instanceof MySink }
 }
 
-from MyConfig c, DataFlow::PathNode source, DataFlow::PathNode sink
-where c.hasFlowPath(source, sink)
+module Taint = TaintTracking::Global<TaintConfig>;
+
+from Taint::PathNode source, Taint::PathNode sink
+where Taint::flowPath(source, sink)
 select sink.getNode(), source, sink, "$@ flows to here and is used.", source.getNode(),
   "User-provided value"

--- a/csharp/ql/test/library-tests/dataflow/callablereturnsarg/Common.qll
+++ b/csharp/ql/test/library-tests/dataflow/callablereturnsarg/Common.qll
@@ -10,34 +10,38 @@ private predicate outRefDef(DataFlow::ExprNode ne, int outRef) {
   )
 }
 
-class Configuration extends DataFlow::Configuration {
-  Configuration() { this = "Configuration" }
+module Config implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { source instanceof DataFlow::ParameterNode }
 
-  override predicate isSource(DataFlow::Node source) { source instanceof DataFlow::ParameterNode }
-
-  override predicate isSink(DataFlow::Node sink) {
+  predicate isSink(DataFlow::Node sink) {
     any(Callable c).canReturn(sink.asExpr()) or outRefDef(sink, _)
   }
 
-  override predicate isBarrier(DataFlow::Node node) {
+  predicate isBarrier(DataFlow::Node node) {
     exists(AbstractValues::NullValue nv | node.(GuardedDataFlowNode).mustHaveValue(nv) |
       nv.isNull()
     )
   }
 }
 
-predicate flowOutFromParameter(DataFlow::Configuration c, Parameter p) {
-  exists(DataFlow::ExprNode ne, DataFlow::ParameterNode np |
-    p.getCallable().canReturn(ne.getExpr()) and
-    np.getParameter() = p and
-    c.hasFlow(np, ne)
-  )
+module FlowOut<DataFlow::GlobalFlowSig Input> {
+  predicate flowOutFromParameter(Parameter p) {
+    exists(DataFlow::ExprNode ne, DataFlow::ParameterNode np |
+      p.getCallable().canReturn(ne.getExpr()) and
+      np.getParameter() = p and
+      Input::flow(np, ne)
+    )
+  }
+
+  predicate flowOutFromParameterOutOrRef(Parameter p, int outRef) {
+    exists(DataFlow::ExprNode ne, DataFlow::ParameterNode np |
+      outRefDef(ne, outRef) and
+      np.getParameter() = p and
+      Input::flow(np, ne)
+    )
+  }
 }
 
-predicate flowOutFromParameterOutOrRef(DataFlow::Configuration c, Parameter p, int outRef) {
-  exists(DataFlow::ExprNode ne, DataFlow::ParameterNode np |
-    outRefDef(ne, outRef) and
-    np.getParameter() = p and
-    c.hasFlow(np, ne)
-  )
-}
+module Data = FlowOut<DataFlow::Global<Config>>;
+
+module Taint = FlowOut<TaintTracking::Global<Config>>;

--- a/csharp/ql/test/library-tests/dataflow/callablereturnsarg/DataFlow.ql
+++ b/csharp/ql/test/library-tests/dataflow/callablereturnsarg/DataFlow.ql
@@ -1,9 +1,9 @@
 import csharp
 import Common
 
-from Configuration c, Parameter p, int outRefArg
+from Parameter p, int outRefArg
 where
-  flowOutFromParameter(c, p) and outRefArg = -1
+  Data::flowOutFromParameter(p) and outRefArg = -1
   or
-  flowOutFromParameterOutOrRef(c, p, outRefArg)
+  Data::flowOutFromParameterOutOrRef(p, outRefArg)
 select p.getCallable(), p.getPosition(), outRefArg

--- a/csharp/ql/test/library-tests/dataflow/callablereturnsarg/TaintTracking.ql
+++ b/csharp/ql/test/library-tests/dataflow/callablereturnsarg/TaintTracking.ql
@@ -1,21 +1,9 @@
 import csharp
 import Common
 
-class TaintTrackingConfiguration extends TaintTracking::Configuration {
-  Configuration c;
-
-  TaintTrackingConfiguration() { this = "Taint " + c }
-
-  override predicate isSource(DataFlow::Node source) { c.isSource(source) }
-
-  override predicate isSink(DataFlow::Node sink) { c.isSink(sink) }
-
-  override predicate isSanitizer(DataFlow::Node node) { c.isBarrier(node) }
-}
-
-from TaintTrackingConfiguration c, Parameter p, int outRefArg
+from Parameter p, int outRefArg
 where
-  flowOutFromParameter(c, p) and outRefArg = -1
+  Taint::flowOutFromParameter(p) and outRefArg = -1
   or
-  flowOutFromParameterOutOrRef(c, p, outRefArg)
+  Taint::flowOutFromParameterOutOrRef(p, outRefArg)
 select p.getCallable(), p.getPosition(), outRefArg

--- a/csharp/ql/test/library-tests/dataflow/external-models/ExternalFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/external-models/ExternalFlow.expected
@@ -1,3 +1,4 @@
+invalidModelRow
 edges
 | ExternalFlow.cs:9:27:9:38 | object creation of type Object : Object | ExternalFlow.cs:10:29:10:32 | access to local variable arg1 : Object |
 | ExternalFlow.cs:10:29:10:32 | access to local variable arg1 : Object | ExternalFlow.cs:10:18:10:33 | call to method StepArgRes |
@@ -162,7 +163,6 @@ nodes
 | ExternalFlow.cs:206:18:206:40 | call to method MixedFlowArgs | semmle.label | call to method MixedFlowArgs |
 | ExternalFlow.cs:206:38:206:39 | access to local variable o2 : Object | semmle.label | access to local variable o2 : Object |
 subpaths
-invalidModelRow
 #select
 | ExternalFlow.cs:10:18:10:33 | call to method StepArgRes | ExternalFlow.cs:9:27:9:38 | object creation of type Object : Object | ExternalFlow.cs:10:18:10:33 | call to method StepArgRes | $@ | ExternalFlow.cs:9:27:9:38 | object creation of type Object : Object | object creation of type Object : Object |
 | ExternalFlow.cs:18:18:18:24 | access to local variable argOut1 | ExternalFlow.cs:15:29:15:40 | object creation of type Object : Object | ExternalFlow.cs:18:18:18:24 | access to local variable argOut1 | $@ | ExternalFlow.cs:15:29:15:40 | object creation of type Object : Object | object creation of type Object : Object |

--- a/csharp/ql/test/library-tests/dataflow/external-models/ExternalFlow.ql
+++ b/csharp/ql/test/library-tests/dataflow/external-models/ExternalFlow.ql
@@ -3,22 +3,22 @@
  */
 
 import csharp
-import DataFlow::PathGraph
 import semmle.code.csharp.dataflow.ExternalFlow
+import Taint::PathGraph
 import ModelValidation
 
-class Conf extends TaintTracking::Configuration {
-  Conf() { this = "ExternalFlow" }
+module TaintConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node src) { src.asExpr() instanceof ObjectCreation }
 
-  override predicate isSource(DataFlow::Node src) { src.asExpr() instanceof ObjectCreation }
-
-  override predicate isSink(DataFlow::Node sink) {
+  predicate isSink(DataFlow::Node sink) {
     exists(MethodCall mc |
       mc.getTarget().hasName("Sink") and
       mc.getAnArgument() = sink.asExpr()
     )
   }
 }
+
+module Taint = TaintTracking::Global<TaintConfig>;
 
 /**
  * Simulate that methods with summaries are not included in the source code.
@@ -28,6 +28,6 @@ private class MyMethod extends Method {
   override predicate fromSource() { none() }
 }
 
-from DataFlow::PathNode source, DataFlow::PathNode sink, Conf conf
-where conf.hasFlowPath(source, sink)
+from Taint::PathNode source, Taint::PathNode sink
+where Taint::flowPath(source, sink)
 select sink, source, sink, "$@", source, source.toString()

--- a/csharp/ql/test/library-tests/dataflow/fields/FieldFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/fields/FieldFlow.expected
@@ -1,2050 +1,1028 @@
 failures
 edges
 | A.cs:5:17:5:28 | call to method Source<C> : C | A.cs:6:24:6:24 | access to local variable c : C |
-| A.cs:5:17:5:28 | call to method Source<C> : C | A.cs:6:24:6:24 | access to local variable c : C |
-| A.cs:6:17:6:25 | call to method Make [field c] : C | A.cs:7:14:7:14 | access to local variable b [field c] : C |
 | A.cs:6:17:6:25 | call to method Make [field c] : C | A.cs:7:14:7:14 | access to local variable b [field c] : C |
 | A.cs:6:24:6:24 | access to local variable c : C | A.cs:6:17:6:25 | call to method Make [field c] : C |
-| A.cs:6:24:6:24 | access to local variable c : C | A.cs:6:17:6:25 | call to method Make [field c] : C |
-| A.cs:6:24:6:24 | access to local variable c : C | A.cs:147:32:147:32 | c : C |
 | A.cs:6:24:6:24 | access to local variable c : C | A.cs:147:32:147:32 | c : C |
 | A.cs:7:14:7:14 | access to local variable b [field c] : C | A.cs:7:14:7:16 | access to field c |
-| A.cs:7:14:7:14 | access to local variable b [field c] : C | A.cs:7:14:7:16 | access to field c |
-| A.cs:13:9:13:9 | [post] access to local variable b [field c] : C1 | A.cs:14:14:14:14 | access to local variable b [field c] : C1 |
 | A.cs:13:9:13:9 | [post] access to local variable b [field c] : C1 | A.cs:14:14:14:14 | access to local variable b [field c] : C1 |
 | A.cs:13:15:13:29 | call to method Source<C1> : C1 | A.cs:13:9:13:9 | [post] access to local variable b [field c] : C1 |
-| A.cs:13:15:13:29 | call to method Source<C1> : C1 | A.cs:13:9:13:9 | [post] access to local variable b [field c] : C1 |
-| A.cs:13:15:13:29 | call to method Source<C1> : C1 | A.cs:145:27:145:27 | c : C1 |
 | A.cs:13:15:13:29 | call to method Source<C1> : C1 | A.cs:145:27:145:27 | c : C1 |
 | A.cs:14:14:14:14 | access to local variable b [field c] : C1 | A.cs:14:14:14:20 | call to method Get |
-| A.cs:14:14:14:14 | access to local variable b [field c] : C1 | A.cs:14:14:14:20 | call to method Get |
-| A.cs:14:14:14:14 | access to local variable b [field c] : C1 | A.cs:146:18:146:20 | this [field c] : C1 |
 | A.cs:14:14:14:14 | access to local variable b [field c] : C1 | A.cs:146:18:146:20 | this [field c] : C1 |
 | A.cs:15:15:15:35 | object creation of type B [field c] : C | A.cs:15:14:15:42 | call to method Get |
-| A.cs:15:15:15:35 | object creation of type B [field c] : C | A.cs:15:14:15:42 | call to method Get |
-| A.cs:15:15:15:35 | object creation of type B [field c] : C | A.cs:146:18:146:20 | this [field c] : C |
 | A.cs:15:15:15:35 | object creation of type B [field c] : C | A.cs:146:18:146:20 | this [field c] : C |
 | A.cs:15:21:15:34 | call to method Source<C> : C | A.cs:15:15:15:35 | object creation of type B [field c] : C |
-| A.cs:15:21:15:34 | call to method Source<C> : C | A.cs:15:15:15:35 | object creation of type B [field c] : C |
-| A.cs:15:21:15:34 | call to method Source<C> : C | A.cs:141:20:141:20 | c : C |
 | A.cs:15:21:15:34 | call to method Source<C> : C | A.cs:141:20:141:20 | c : C |
 | A.cs:22:14:22:38 | call to method SetOnB [field c] : C2 | A.cs:24:14:24:15 | access to local variable b2 [field c] : C2 |
-| A.cs:22:14:22:38 | call to method SetOnB [field c] : C2 | A.cs:24:14:24:15 | access to local variable b2 [field c] : C2 |
-| A.cs:22:25:22:37 | call to method Source<C2> : C2 | A.cs:22:14:22:38 | call to method SetOnB [field c] : C2 |
 | A.cs:22:25:22:37 | call to method Source<C2> : C2 | A.cs:22:14:22:38 | call to method SetOnB [field c] : C2 |
 | A.cs:22:25:22:37 | call to method Source<C2> : C2 | A.cs:42:29:42:29 | c : C2 |
-| A.cs:22:25:22:37 | call to method Source<C2> : C2 | A.cs:42:29:42:29 | c : C2 |
-| A.cs:24:14:24:15 | access to local variable b2 [field c] : C2 | A.cs:24:14:24:17 | access to field c |
 | A.cs:24:14:24:15 | access to local variable b2 [field c] : C2 | A.cs:24:14:24:17 | access to field c |
 | A.cs:31:14:31:42 | call to method SetOnBWrap [field c] : C2 | A.cs:33:14:33:15 | access to local variable b2 [field c] : C2 |
-| A.cs:31:14:31:42 | call to method SetOnBWrap [field c] : C2 | A.cs:33:14:33:15 | access to local variable b2 [field c] : C2 |
-| A.cs:31:29:31:41 | call to method Source<C2> : C2 | A.cs:31:14:31:42 | call to method SetOnBWrap [field c] : C2 |
 | A.cs:31:29:31:41 | call to method Source<C2> : C2 | A.cs:31:14:31:42 | call to method SetOnBWrap [field c] : C2 |
 | A.cs:31:29:31:41 | call to method Source<C2> : C2 | A.cs:36:33:36:33 | c : C2 |
-| A.cs:31:29:31:41 | call to method Source<C2> : C2 | A.cs:36:33:36:33 | c : C2 |
-| A.cs:33:14:33:15 | access to local variable b2 [field c] : C2 | A.cs:33:14:33:17 | access to field c |
 | A.cs:33:14:33:15 | access to local variable b2 [field c] : C2 | A.cs:33:14:33:17 | access to field c |
 | A.cs:36:33:36:33 | c : C2 | A.cs:38:29:38:29 | access to parameter c : C2 |
-| A.cs:36:33:36:33 | c : C2 | A.cs:38:29:38:29 | access to parameter c : C2 |
-| A.cs:38:18:38:30 | call to method SetOnB [field c] : C2 | A.cs:39:16:39:28 | ... ? ... : ... [field c] : C2 |
 | A.cs:38:18:38:30 | call to method SetOnB [field c] : C2 | A.cs:39:16:39:28 | ... ? ... : ... [field c] : C2 |
 | A.cs:38:29:38:29 | access to parameter c : C2 | A.cs:38:18:38:30 | call to method SetOnB [field c] : C2 |
-| A.cs:38:29:38:29 | access to parameter c : C2 | A.cs:38:18:38:30 | call to method SetOnB [field c] : C2 |
-| A.cs:38:29:38:29 | access to parameter c : C2 | A.cs:42:29:42:29 | c : C2 |
 | A.cs:38:29:38:29 | access to parameter c : C2 | A.cs:42:29:42:29 | c : C2 |
 | A.cs:42:29:42:29 | c : C2 | A.cs:47:20:47:20 | access to parameter c : C2 |
-| A.cs:42:29:42:29 | c : C2 | A.cs:47:20:47:20 | access to parameter c : C2 |
-| A.cs:47:13:47:14 | [post] access to local variable b2 [field c] : C2 | A.cs:48:20:48:21 | access to local variable b2 [field c] : C2 |
 | A.cs:47:13:47:14 | [post] access to local variable b2 [field c] : C2 | A.cs:48:20:48:21 | access to local variable b2 [field c] : C2 |
 | A.cs:47:20:47:20 | access to parameter c : C2 | A.cs:47:13:47:14 | [post] access to local variable b2 [field c] : C2 |
-| A.cs:47:20:47:20 | access to parameter c : C2 | A.cs:47:13:47:14 | [post] access to local variable b2 [field c] : C2 |
-| A.cs:47:20:47:20 | access to parameter c : C2 | A.cs:145:27:145:27 | c : C2 |
 | A.cs:47:20:47:20 | access to parameter c : C2 | A.cs:145:27:145:27 | c : C2 |
 | A.cs:55:17:55:28 | call to method Source<A> : A | A.cs:57:16:57:16 | access to local variable a : A |
-| A.cs:55:17:55:28 | call to method Source<A> : A | A.cs:57:16:57:16 | access to local variable a : A |
-| A.cs:57:9:57:10 | [post] access to local variable c1 [field a] : A | A.cs:58:12:58:13 | access to local variable c1 [field a] : A |
 | A.cs:57:9:57:10 | [post] access to local variable c1 [field a] : A | A.cs:58:12:58:13 | access to local variable c1 [field a] : A |
 | A.cs:57:16:57:16 | access to local variable a : A | A.cs:57:9:57:10 | [post] access to local variable c1 [field a] : A |
-| A.cs:57:16:57:16 | access to local variable a : A | A.cs:57:9:57:10 | [post] access to local variable c1 [field a] : A |
-| A.cs:58:12:58:13 | access to local variable c1 [field a] : A | A.cs:60:22:60:22 | c [field a] : A |
 | A.cs:58:12:58:13 | access to local variable c1 [field a] : A | A.cs:60:22:60:22 | c [field a] : A |
 | A.cs:60:22:60:22 | c [field a] : A | A.cs:64:19:64:23 | (...) ... [field a] : A |
-| A.cs:60:22:60:22 | c [field a] : A | A.cs:64:19:64:23 | (...) ... [field a] : A |
-| A.cs:64:19:64:23 | (...) ... [field a] : A | A.cs:64:18:64:26 | access to field a |
 | A.cs:64:19:64:23 | (...) ... [field a] : A | A.cs:64:18:64:26 | access to field a |
 | A.cs:83:9:83:9 | [post] access to parameter b [field c] : C | A.cs:88:12:88:12 | [post] access to local variable b [field c] : C |
-| A.cs:83:9:83:9 | [post] access to parameter b [field c] : C | A.cs:88:12:88:12 | [post] access to local variable b [field c] : C |
-| A.cs:83:15:83:26 | call to method Source<C> : C | A.cs:83:9:83:9 | [post] access to parameter b [field c] : C |
 | A.cs:83:15:83:26 | call to method Source<C> : C | A.cs:83:9:83:9 | [post] access to parameter b [field c] : C |
 | A.cs:83:15:83:26 | call to method Source<C> : C | A.cs:145:27:145:27 | c : C |
-| A.cs:83:15:83:26 | call to method Source<C> : C | A.cs:145:27:145:27 | c : C |
-| A.cs:88:12:88:12 | [post] access to local variable b [field c] : C | A.cs:89:14:89:14 | access to local variable b [field c] : C |
 | A.cs:88:12:88:12 | [post] access to local variable b [field c] : C | A.cs:89:14:89:14 | access to local variable b [field c] : C |
 | A.cs:89:14:89:14 | access to local variable b [field c] : C | A.cs:89:14:89:16 | access to field c |
-| A.cs:89:14:89:14 | access to local variable b [field c] : C | A.cs:89:14:89:16 | access to field c |
-| A.cs:95:20:95:20 | b : B | A.cs:97:13:97:13 | access to parameter b : B |
 | A.cs:95:20:95:20 | b : B | A.cs:97:13:97:13 | access to parameter b : B |
 | A.cs:97:13:97:13 | [post] access to parameter b [field c] : C | A.cs:98:22:98:43 | ... ? ... : ... [field c] : C |
-| A.cs:97:13:97:13 | [post] access to parameter b [field c] : C | A.cs:98:22:98:43 | ... ? ... : ... [field c] : C |
-| A.cs:97:13:97:13 | [post] access to parameter b [field c] : C | A.cs:105:23:105:23 | [post] access to local variable b [field c] : C |
 | A.cs:97:13:97:13 | [post] access to parameter b [field c] : C | A.cs:105:23:105:23 | [post] access to local variable b [field c] : C |
 | A.cs:97:13:97:13 | access to parameter b : B | A.cs:98:22:98:43 | ... ? ... : ... : B |
-| A.cs:97:13:97:13 | access to parameter b : B | A.cs:98:22:98:43 | ... ? ... : ... : B |
-| A.cs:97:19:97:32 | call to method Source<C> : C | A.cs:97:13:97:13 | [post] access to parameter b [field c] : C |
 | A.cs:97:19:97:32 | call to method Source<C> : C | A.cs:97:13:97:13 | [post] access to parameter b [field c] : C |
 | A.cs:98:13:98:16 | [post] this access [field b, field c] : C | A.cs:105:17:105:29 | object creation of type D [field b, field c] : C |
-| A.cs:98:13:98:16 | [post] this access [field b, field c] : C | A.cs:105:17:105:29 | object creation of type D [field b, field c] : C |
-| A.cs:98:13:98:16 | [post] this access [field b] : B | A.cs:105:17:105:29 | object creation of type D [field b] : B |
 | A.cs:98:13:98:16 | [post] this access [field b] : B | A.cs:105:17:105:29 | object creation of type D [field b] : B |
 | A.cs:98:22:98:43 | ... ? ... : ... : B | A.cs:98:13:98:16 | [post] this access [field b] : B |
 | A.cs:98:22:98:43 | ... ? ... : ... : B | A.cs:98:13:98:16 | [post] this access [field b] : B |
-| A.cs:98:22:98:43 | ... ? ... : ... : B | A.cs:98:13:98:16 | [post] this access [field b] : B |
-| A.cs:98:22:98:43 | ... ? ... : ... : B | A.cs:98:13:98:16 | [post] this access [field b] : B |
-| A.cs:98:22:98:43 | ... ? ... : ... [field c] : C | A.cs:98:13:98:16 | [post] this access [field b, field c] : C |
 | A.cs:98:22:98:43 | ... ? ... : ... [field c] : C | A.cs:98:13:98:16 | [post] this access [field b, field c] : C |
 | A.cs:98:30:98:43 | call to method Source<B> : B | A.cs:98:22:98:43 | ... ? ... : ... : B |
-| A.cs:98:30:98:43 | call to method Source<B> : B | A.cs:98:22:98:43 | ... ? ... : ... : B |
-| A.cs:104:17:104:30 | call to method Source<B> : B | A.cs:105:23:105:23 | access to local variable b : B |
 | A.cs:104:17:104:30 | call to method Source<B> : B | A.cs:105:23:105:23 | access to local variable b : B |
 | A.cs:105:17:105:29 | object creation of type D [field b, field c] : C | A.cs:107:14:107:14 | access to local variable d [field b, field c] : C |
-| A.cs:105:17:105:29 | object creation of type D [field b, field c] : C | A.cs:107:14:107:14 | access to local variable d [field b, field c] : C |
-| A.cs:105:17:105:29 | object creation of type D [field b] : B | A.cs:106:14:106:14 | access to local variable d [field b] : B |
 | A.cs:105:17:105:29 | object creation of type D [field b] : B | A.cs:106:14:106:14 | access to local variable d [field b] : B |
 | A.cs:105:23:105:23 | [post] access to local variable b [field c] : C | A.cs:108:14:108:14 | access to local variable b [field c] : C |
-| A.cs:105:23:105:23 | [post] access to local variable b [field c] : C | A.cs:108:14:108:14 | access to local variable b [field c] : C |
-| A.cs:105:23:105:23 | access to local variable b : B | A.cs:95:20:95:20 | b : B |
 | A.cs:105:23:105:23 | access to local variable b : B | A.cs:95:20:95:20 | b : B |
 | A.cs:105:23:105:23 | access to local variable b : B | A.cs:105:17:105:29 | object creation of type D [field b] : B |
-| A.cs:105:23:105:23 | access to local variable b : B | A.cs:105:17:105:29 | object creation of type D [field b] : B |
-| A.cs:106:14:106:14 | access to local variable d [field b] : B | A.cs:106:14:106:16 | access to field b |
 | A.cs:106:14:106:14 | access to local variable d [field b] : B | A.cs:106:14:106:16 | access to field b |
 | A.cs:107:14:107:14 | access to local variable d [field b, field c] : C | A.cs:107:14:107:16 | access to field b [field c] : C |
-| A.cs:107:14:107:14 | access to local variable d [field b, field c] : C | A.cs:107:14:107:16 | access to field b [field c] : C |
-| A.cs:107:14:107:16 | access to field b [field c] : C | A.cs:107:14:107:18 | access to field c |
 | A.cs:107:14:107:16 | access to field b [field c] : C | A.cs:107:14:107:18 | access to field c |
 | A.cs:108:14:108:14 | access to local variable b [field c] : C | A.cs:108:14:108:16 | access to field c |
-| A.cs:108:14:108:14 | access to local variable b [field c] : C | A.cs:108:14:108:16 | access to field c |
-| A.cs:113:17:113:29 | call to method Source<B> : B | A.cs:114:29:114:29 | access to local variable b : B |
 | A.cs:113:17:113:29 | call to method Source<B> : B | A.cs:114:29:114:29 | access to local variable b : B |
 | A.cs:114:18:114:54 | object creation of type MyList [field head] : B | A.cs:115:35:115:36 | access to local variable l1 [field head] : B |
-| A.cs:114:18:114:54 | object creation of type MyList [field head] : B | A.cs:115:35:115:36 | access to local variable l1 [field head] : B |
-| A.cs:114:29:114:29 | access to local variable b : B | A.cs:114:18:114:54 | object creation of type MyList [field head] : B |
 | A.cs:114:29:114:29 | access to local variable b : B | A.cs:114:18:114:54 | object creation of type MyList [field head] : B |
 | A.cs:114:29:114:29 | access to local variable b : B | A.cs:157:25:157:28 | head : B |
-| A.cs:114:29:114:29 | access to local variable b : B | A.cs:157:25:157:28 | head : B |
-| A.cs:115:18:115:37 | object creation of type MyList [field next, field head] : B | A.cs:116:35:116:36 | access to local variable l2 [field next, field head] : B |
 | A.cs:115:18:115:37 | object creation of type MyList [field next, field head] : B | A.cs:116:35:116:36 | access to local variable l2 [field next, field head] : B |
 | A.cs:115:35:115:36 | access to local variable l1 [field head] : B | A.cs:115:18:115:37 | object creation of type MyList [field next, field head] : B |
-| A.cs:115:35:115:36 | access to local variable l1 [field head] : B | A.cs:115:18:115:37 | object creation of type MyList [field next, field head] : B |
-| A.cs:115:35:115:36 | access to local variable l1 [field head] : B | A.cs:157:38:157:41 | next [field head] : B |
 | A.cs:115:35:115:36 | access to local variable l1 [field head] : B | A.cs:157:38:157:41 | next [field head] : B |
 | A.cs:116:18:116:37 | object creation of type MyList [field next, field next, field head] : B | A.cs:119:14:119:15 | access to local variable l3 [field next, field next, field head] : B |
-| A.cs:116:18:116:37 | object creation of type MyList [field next, field next, field head] : B | A.cs:119:14:119:15 | access to local variable l3 [field next, field next, field head] : B |
-| A.cs:116:18:116:37 | object creation of type MyList [field next, field next, field head] : B | A.cs:121:41:121:41 | access to local variable l [field next, field next, field head] : B |
 | A.cs:116:18:116:37 | object creation of type MyList [field next, field next, field head] : B | A.cs:121:41:121:41 | access to local variable l [field next, field next, field head] : B |
 | A.cs:116:35:116:36 | access to local variable l2 [field next, field head] : B | A.cs:116:18:116:37 | object creation of type MyList [field next, field next, field head] : B |
-| A.cs:116:35:116:36 | access to local variable l2 [field next, field head] : B | A.cs:116:18:116:37 | object creation of type MyList [field next, field next, field head] : B |
-| A.cs:116:35:116:36 | access to local variable l2 [field next, field head] : B | A.cs:157:38:157:41 | next [field next, field head] : B |
 | A.cs:116:35:116:36 | access to local variable l2 [field next, field head] : B | A.cs:157:38:157:41 | next [field next, field head] : B |
 | A.cs:119:14:119:15 | access to local variable l3 [field next, field next, field head] : B | A.cs:119:14:119:20 | access to field next [field next, field head] : B |
-| A.cs:119:14:119:15 | access to local variable l3 [field next, field next, field head] : B | A.cs:119:14:119:20 | access to field next [field next, field head] : B |
-| A.cs:119:14:119:20 | access to field next [field next, field head] : B | A.cs:119:14:119:25 | access to field next [field head] : B |
 | A.cs:119:14:119:20 | access to field next [field next, field head] : B | A.cs:119:14:119:25 | access to field next [field head] : B |
 | A.cs:119:14:119:25 | access to field next [field head] : B | A.cs:119:14:119:30 | access to field head |
-| A.cs:119:14:119:25 | access to field next [field head] : B | A.cs:119:14:119:30 | access to field head |
-| A.cs:121:41:121:41 | access to local variable l [field next, field head] : B | A.cs:121:41:121:46 | access to field next [field head] : B |
 | A.cs:121:41:121:41 | access to local variable l [field next, field head] : B | A.cs:121:41:121:46 | access to field next [field head] : B |
 | A.cs:121:41:121:41 | access to local variable l [field next, field next, field head] : B | A.cs:121:41:121:46 | access to field next [field next, field head] : B |
-| A.cs:121:41:121:41 | access to local variable l [field next, field next, field head] : B | A.cs:121:41:121:46 | access to field next [field next, field head] : B |
-| A.cs:121:41:121:46 | access to field next [field head] : B | A.cs:123:18:123:18 | access to local variable l [field head] : B |
 | A.cs:121:41:121:46 | access to field next [field head] : B | A.cs:123:18:123:18 | access to local variable l [field head] : B |
 | A.cs:121:41:121:46 | access to field next [field next, field head] : B | A.cs:121:41:121:41 | access to local variable l [field next, field head] : B |
-| A.cs:121:41:121:46 | access to field next [field next, field head] : B | A.cs:121:41:121:41 | access to local variable l [field next, field head] : B |
-| A.cs:123:18:123:18 | access to local variable l [field head] : B | A.cs:123:18:123:23 | access to field head |
 | A.cs:123:18:123:18 | access to local variable l [field head] : B | A.cs:123:18:123:23 | access to field head |
 | A.cs:141:20:141:20 | c : C | A.cs:143:22:143:22 | access to parameter c : C |
-| A.cs:141:20:141:20 | c : C | A.cs:143:22:143:22 | access to parameter c : C |
-| A.cs:143:22:143:22 | access to parameter c : C | A.cs:143:13:143:16 | [post] this access [field c] : C |
 | A.cs:143:22:143:22 | access to parameter c : C | A.cs:143:13:143:16 | [post] this access [field c] : C |
 | A.cs:145:27:145:27 | c : C | A.cs:145:41:145:41 | access to parameter c : C |
-| A.cs:145:27:145:27 | c : C | A.cs:145:41:145:41 | access to parameter c : C |
-| A.cs:145:27:145:27 | c : C1 | A.cs:145:41:145:41 | access to parameter c : C1 |
 | A.cs:145:27:145:27 | c : C1 | A.cs:145:41:145:41 | access to parameter c : C1 |
 | A.cs:145:27:145:27 | c : C2 | A.cs:145:41:145:41 | access to parameter c : C2 |
-| A.cs:145:27:145:27 | c : C2 | A.cs:145:41:145:41 | access to parameter c : C2 |
-| A.cs:145:41:145:41 | access to parameter c : C | A.cs:145:32:145:35 | [post] this access [field c] : C |
 | A.cs:145:41:145:41 | access to parameter c : C | A.cs:145:32:145:35 | [post] this access [field c] : C |
 | A.cs:145:41:145:41 | access to parameter c : C1 | A.cs:145:32:145:35 | [post] this access [field c] : C1 |
-| A.cs:145:41:145:41 | access to parameter c : C1 | A.cs:145:32:145:35 | [post] this access [field c] : C1 |
-| A.cs:145:41:145:41 | access to parameter c : C2 | A.cs:145:32:145:35 | [post] this access [field c] : C2 |
 | A.cs:145:41:145:41 | access to parameter c : C2 | A.cs:145:32:145:35 | [post] this access [field c] : C2 |
 | A.cs:146:18:146:20 | this [field c] : C | A.cs:146:33:146:36 | this access [field c] : C |
-| A.cs:146:18:146:20 | this [field c] : C | A.cs:146:33:146:36 | this access [field c] : C |
-| A.cs:146:18:146:20 | this [field c] : C1 | A.cs:146:33:146:36 | this access [field c] : C1 |
 | A.cs:146:18:146:20 | this [field c] : C1 | A.cs:146:33:146:36 | this access [field c] : C1 |
 | A.cs:146:33:146:36 | this access [field c] : C | A.cs:146:33:146:38 | access to field c : C |
-| A.cs:146:33:146:36 | this access [field c] : C | A.cs:146:33:146:38 | access to field c : C |
-| A.cs:146:33:146:36 | this access [field c] : C1 | A.cs:146:33:146:38 | access to field c : C1 |
 | A.cs:146:33:146:36 | this access [field c] : C1 | A.cs:146:33:146:38 | access to field c : C1 |
 | A.cs:147:32:147:32 | c : C | A.cs:149:26:149:26 | access to parameter c : C |
-| A.cs:147:32:147:32 | c : C | A.cs:149:26:149:26 | access to parameter c : C |
-| A.cs:149:26:149:26 | access to parameter c : C | A.cs:141:20:141:20 | c : C |
 | A.cs:149:26:149:26 | access to parameter c : C | A.cs:141:20:141:20 | c : C |
 | A.cs:149:26:149:26 | access to parameter c : C | A.cs:149:20:149:27 | object creation of type B [field c] : C |
-| A.cs:149:26:149:26 | access to parameter c : C | A.cs:149:20:149:27 | object creation of type B [field c] : C |
-| A.cs:157:25:157:28 | head : B | A.cs:159:25:159:28 | access to parameter head : B |
 | A.cs:157:25:157:28 | head : B | A.cs:159:25:159:28 | access to parameter head : B |
 | A.cs:157:38:157:41 | next [field head] : B | A.cs:160:25:160:28 | access to parameter next [field head] : B |
-| A.cs:157:38:157:41 | next [field head] : B | A.cs:160:25:160:28 | access to parameter next [field head] : B |
-| A.cs:157:38:157:41 | next [field next, field head] : B | A.cs:160:25:160:28 | access to parameter next [field next, field head] : B |
 | A.cs:157:38:157:41 | next [field next, field head] : B | A.cs:160:25:160:28 | access to parameter next [field next, field head] : B |
 | A.cs:159:25:159:28 | access to parameter head : B | A.cs:159:13:159:16 | [post] this access [field head] : B |
-| A.cs:159:25:159:28 | access to parameter head : B | A.cs:159:13:159:16 | [post] this access [field head] : B |
-| A.cs:160:25:160:28 | access to parameter next [field head] : B | A.cs:160:13:160:16 | [post] this access [field next, field head] : B |
 | A.cs:160:25:160:28 | access to parameter next [field head] : B | A.cs:160:13:160:16 | [post] this access [field next, field head] : B |
 | A.cs:160:25:160:28 | access to parameter next [field next, field head] : B | A.cs:160:13:160:16 | [post] this access [field next, field next, field head] : B |
-| A.cs:160:25:160:28 | access to parameter next [field next, field head] : B | A.cs:160:13:160:16 | [post] this access [field next, field next, field head] : B |
-| B.cs:5:17:5:31 | call to method Source<Elem> : Elem | B.cs:6:27:6:27 | access to local variable e : Elem |
 | B.cs:5:17:5:31 | call to method Source<Elem> : Elem | B.cs:6:27:6:27 | access to local variable e : Elem |
 | B.cs:6:18:6:34 | object creation of type Box1 [field elem1] : Elem | B.cs:7:27:7:28 | access to local variable b1 [field elem1] : Elem |
-| B.cs:6:18:6:34 | object creation of type Box1 [field elem1] : Elem | B.cs:7:27:7:28 | access to local variable b1 [field elem1] : Elem |
-| B.cs:6:27:6:27 | access to local variable e : Elem | B.cs:6:18:6:34 | object creation of type Box1 [field elem1] : Elem |
 | B.cs:6:27:6:27 | access to local variable e : Elem | B.cs:6:18:6:34 | object creation of type Box1 [field elem1] : Elem |
 | B.cs:6:27:6:27 | access to local variable e : Elem | B.cs:29:26:29:27 | e1 : Elem |
-| B.cs:6:27:6:27 | access to local variable e : Elem | B.cs:29:26:29:27 | e1 : Elem |
-| B.cs:7:18:7:29 | object creation of type Box2 [field box1, field elem1] : Elem | B.cs:8:14:8:15 | access to local variable b2 [field box1, field elem1] : Elem |
 | B.cs:7:18:7:29 | object creation of type Box2 [field box1, field elem1] : Elem | B.cs:8:14:8:15 | access to local variable b2 [field box1, field elem1] : Elem |
 | B.cs:7:27:7:28 | access to local variable b1 [field elem1] : Elem | B.cs:7:18:7:29 | object creation of type Box2 [field box1, field elem1] : Elem |
-| B.cs:7:27:7:28 | access to local variable b1 [field elem1] : Elem | B.cs:7:18:7:29 | object creation of type Box2 [field box1, field elem1] : Elem |
-| B.cs:7:27:7:28 | access to local variable b1 [field elem1] : Elem | B.cs:39:26:39:27 | b1 [field elem1] : Elem |
 | B.cs:7:27:7:28 | access to local variable b1 [field elem1] : Elem | B.cs:39:26:39:27 | b1 [field elem1] : Elem |
 | B.cs:8:14:8:15 | access to local variable b2 [field box1, field elem1] : Elem | B.cs:8:14:8:20 | access to field box1 [field elem1] : Elem |
-| B.cs:8:14:8:15 | access to local variable b2 [field box1, field elem1] : Elem | B.cs:8:14:8:20 | access to field box1 [field elem1] : Elem |
-| B.cs:8:14:8:20 | access to field box1 [field elem1] : Elem | B.cs:8:14:8:26 | access to field elem1 |
 | B.cs:8:14:8:20 | access to field box1 [field elem1] : Elem | B.cs:8:14:8:26 | access to field elem1 |
 | B.cs:14:17:14:31 | call to method Source<Elem> : Elem | B.cs:15:33:15:33 | access to local variable e : Elem |
-| B.cs:14:17:14:31 | call to method Source<Elem> : Elem | B.cs:15:33:15:33 | access to local variable e : Elem |
-| B.cs:15:18:15:34 | object creation of type Box1 [field elem2] : Elem | B.cs:16:27:16:28 | access to local variable b1 [field elem2] : Elem |
 | B.cs:15:18:15:34 | object creation of type Box1 [field elem2] : Elem | B.cs:16:27:16:28 | access to local variable b1 [field elem2] : Elem |
 | B.cs:15:33:15:33 | access to local variable e : Elem | B.cs:15:18:15:34 | object creation of type Box1 [field elem2] : Elem |
-| B.cs:15:33:15:33 | access to local variable e : Elem | B.cs:15:18:15:34 | object creation of type Box1 [field elem2] : Elem |
-| B.cs:15:33:15:33 | access to local variable e : Elem | B.cs:29:35:29:36 | e2 : Elem |
 | B.cs:15:33:15:33 | access to local variable e : Elem | B.cs:29:35:29:36 | e2 : Elem |
 | B.cs:16:18:16:29 | object creation of type Box2 [field box1, field elem2] : Elem | B.cs:18:14:18:15 | access to local variable b2 [field box1, field elem2] : Elem |
-| B.cs:16:18:16:29 | object creation of type Box2 [field box1, field elem2] : Elem | B.cs:18:14:18:15 | access to local variable b2 [field box1, field elem2] : Elem |
-| B.cs:16:27:16:28 | access to local variable b1 [field elem2] : Elem | B.cs:16:18:16:29 | object creation of type Box2 [field box1, field elem2] : Elem |
 | B.cs:16:27:16:28 | access to local variable b1 [field elem2] : Elem | B.cs:16:18:16:29 | object creation of type Box2 [field box1, field elem2] : Elem |
 | B.cs:16:27:16:28 | access to local variable b1 [field elem2] : Elem | B.cs:39:26:39:27 | b1 [field elem2] : Elem |
-| B.cs:16:27:16:28 | access to local variable b1 [field elem2] : Elem | B.cs:39:26:39:27 | b1 [field elem2] : Elem |
-| B.cs:18:14:18:15 | access to local variable b2 [field box1, field elem2] : Elem | B.cs:18:14:18:20 | access to field box1 [field elem2] : Elem |
 | B.cs:18:14:18:15 | access to local variable b2 [field box1, field elem2] : Elem | B.cs:18:14:18:20 | access to field box1 [field elem2] : Elem |
 | B.cs:18:14:18:20 | access to field box1 [field elem2] : Elem | B.cs:18:14:18:26 | access to field elem2 |
-| B.cs:18:14:18:20 | access to field box1 [field elem2] : Elem | B.cs:18:14:18:26 | access to field elem2 |
-| B.cs:29:26:29:27 | e1 : Elem | B.cs:31:26:31:27 | access to parameter e1 : Elem |
 | B.cs:29:26:29:27 | e1 : Elem | B.cs:31:26:31:27 | access to parameter e1 : Elem |
 | B.cs:29:35:29:36 | e2 : Elem | B.cs:32:26:32:27 | access to parameter e2 : Elem |
-| B.cs:29:35:29:36 | e2 : Elem | B.cs:32:26:32:27 | access to parameter e2 : Elem |
-| B.cs:31:26:31:27 | access to parameter e1 : Elem | B.cs:31:13:31:16 | [post] this access [field elem1] : Elem |
 | B.cs:31:26:31:27 | access to parameter e1 : Elem | B.cs:31:13:31:16 | [post] this access [field elem1] : Elem |
 | B.cs:32:26:32:27 | access to parameter e2 : Elem | B.cs:32:13:32:16 | [post] this access [field elem2] : Elem |
-| B.cs:32:26:32:27 | access to parameter e2 : Elem | B.cs:32:13:32:16 | [post] this access [field elem2] : Elem |
-| B.cs:39:26:39:27 | b1 [field elem1] : Elem | B.cs:41:25:41:26 | access to parameter b1 [field elem1] : Elem |
 | B.cs:39:26:39:27 | b1 [field elem1] : Elem | B.cs:41:25:41:26 | access to parameter b1 [field elem1] : Elem |
 | B.cs:39:26:39:27 | b1 [field elem2] : Elem | B.cs:41:25:41:26 | access to parameter b1 [field elem2] : Elem |
-| B.cs:39:26:39:27 | b1 [field elem2] : Elem | B.cs:41:25:41:26 | access to parameter b1 [field elem2] : Elem |
-| B.cs:41:25:41:26 | access to parameter b1 [field elem1] : Elem | B.cs:41:13:41:16 | [post] this access [field box1, field elem1] : Elem |
 | B.cs:41:25:41:26 | access to parameter b1 [field elem1] : Elem | B.cs:41:13:41:16 | [post] this access [field box1, field elem1] : Elem |
 | B.cs:41:25:41:26 | access to parameter b1 [field elem2] : Elem | B.cs:41:13:41:16 | [post] this access [field box1, field elem2] : Elem |
-| B.cs:41:25:41:26 | access to parameter b1 [field elem2] : Elem | B.cs:41:13:41:16 | [post] this access [field box1, field elem2] : Elem |
-| C.cs:3:18:3:19 | [post] this access [field s1] : Elem | C.cs:12:15:12:21 | object creation of type C [field s1] : Elem |
 | C.cs:3:18:3:19 | [post] this access [field s1] : Elem | C.cs:12:15:12:21 | object creation of type C [field s1] : Elem |
 | C.cs:3:23:3:37 | call to method Source<Elem> : Elem | C.cs:3:18:3:19 | [post] this access [field s1] : Elem |
-| C.cs:3:23:3:37 | call to method Source<Elem> : Elem | C.cs:3:18:3:19 | [post] this access [field s1] : Elem |
-| C.cs:4:27:4:28 | [post] this access [field s2] : Elem | C.cs:12:15:12:21 | object creation of type C [field s2] : Elem |
 | C.cs:4:27:4:28 | [post] this access [field s2] : Elem | C.cs:12:15:12:21 | object creation of type C [field s2] : Elem |
 | C.cs:4:32:4:46 | call to method Source<Elem> : Elem | C.cs:4:27:4:28 | [post] this access [field s2] : Elem |
-| C.cs:4:32:4:46 | call to method Source<Elem> : Elem | C.cs:4:27:4:28 | [post] this access [field s2] : Elem |
-| C.cs:6:30:6:44 | call to method Source<Elem> : Elem | C.cs:26:14:26:15 | access to field s4 |
 | C.cs:6:30:6:44 | call to method Source<Elem> : Elem | C.cs:26:14:26:15 | access to field s4 |
 | C.cs:7:18:7:19 | [post] this access [property s5] : Elem | C.cs:12:15:12:21 | object creation of type C [property s5] : Elem |
-| C.cs:7:18:7:19 | [post] this access [property s5] : Elem | C.cs:12:15:12:21 | object creation of type C [property s5] : Elem |
-| C.cs:7:37:7:51 | call to method Source<Elem> : Elem | C.cs:7:18:7:19 | [post] this access [property s5] : Elem |
 | C.cs:7:37:7:51 | call to method Source<Elem> : Elem | C.cs:7:18:7:19 | [post] this access [property s5] : Elem |
 | C.cs:8:30:8:44 | call to method Source<Elem> : Elem | C.cs:28:14:28:15 | access to property s6 |
-| C.cs:8:30:8:44 | call to method Source<Elem> : Elem | C.cs:28:14:28:15 | access to property s6 |
-| C.cs:12:15:12:21 | object creation of type C [field s1] : Elem | C.cs:13:9:13:9 | access to local variable c [field s1] : Elem |
 | C.cs:12:15:12:21 | object creation of type C [field s1] : Elem | C.cs:13:9:13:9 | access to local variable c [field s1] : Elem |
 | C.cs:12:15:12:21 | object creation of type C [field s2] : Elem | C.cs:13:9:13:9 | access to local variable c [field s2] : Elem |
-| C.cs:12:15:12:21 | object creation of type C [field s2] : Elem | C.cs:13:9:13:9 | access to local variable c [field s2] : Elem |
-| C.cs:12:15:12:21 | object creation of type C [field s3] : Elem | C.cs:13:9:13:9 | access to local variable c [field s3] : Elem |
 | C.cs:12:15:12:21 | object creation of type C [field s3] : Elem | C.cs:13:9:13:9 | access to local variable c [field s3] : Elem |
 | C.cs:12:15:12:21 | object creation of type C [property s5] : Elem | C.cs:13:9:13:9 | access to local variable c [property s5] : Elem |
-| C.cs:12:15:12:21 | object creation of type C [property s5] : Elem | C.cs:13:9:13:9 | access to local variable c [property s5] : Elem |
-| C.cs:13:9:13:9 | access to local variable c [field s1] : Elem | C.cs:21:17:21:18 | this [field s1] : Elem |
 | C.cs:13:9:13:9 | access to local variable c [field s1] : Elem | C.cs:21:17:21:18 | this [field s1] : Elem |
 | C.cs:13:9:13:9 | access to local variable c [field s2] : Elem | C.cs:21:17:21:18 | this [field s2] : Elem |
-| C.cs:13:9:13:9 | access to local variable c [field s2] : Elem | C.cs:21:17:21:18 | this [field s2] : Elem |
-| C.cs:13:9:13:9 | access to local variable c [field s3] : Elem | C.cs:21:17:21:18 | this [field s3] : Elem |
 | C.cs:13:9:13:9 | access to local variable c [field s3] : Elem | C.cs:21:17:21:18 | this [field s3] : Elem |
 | C.cs:13:9:13:9 | access to local variable c [property s5] : Elem | C.cs:21:17:21:18 | this [property s5] : Elem |
-| C.cs:13:9:13:9 | access to local variable c [property s5] : Elem | C.cs:21:17:21:18 | this [property s5] : Elem |
-| C.cs:18:9:18:12 | [post] this access [field s3] : Elem | C.cs:12:15:12:21 | object creation of type C [field s3] : Elem |
 | C.cs:18:9:18:12 | [post] this access [field s3] : Elem | C.cs:12:15:12:21 | object creation of type C [field s3] : Elem |
 | C.cs:18:19:18:33 | call to method Source<Elem> : Elem | C.cs:18:9:18:12 | [post] this access [field s3] : Elem |
-| C.cs:18:19:18:33 | call to method Source<Elem> : Elem | C.cs:18:9:18:12 | [post] this access [field s3] : Elem |
-| C.cs:21:17:21:18 | this [field s1] : Elem | C.cs:23:14:23:15 | this access [field s1] : Elem |
 | C.cs:21:17:21:18 | this [field s1] : Elem | C.cs:23:14:23:15 | this access [field s1] : Elem |
 | C.cs:21:17:21:18 | this [field s2] : Elem | C.cs:24:14:24:15 | this access [field s2] : Elem |
-| C.cs:21:17:21:18 | this [field s2] : Elem | C.cs:24:14:24:15 | this access [field s2] : Elem |
-| C.cs:21:17:21:18 | this [field s3] : Elem | C.cs:25:14:25:15 | this access [field s3] : Elem |
 | C.cs:21:17:21:18 | this [field s3] : Elem | C.cs:25:14:25:15 | this access [field s3] : Elem |
 | C.cs:21:17:21:18 | this [property s5] : Elem | C.cs:27:14:27:15 | this access [property s5] : Elem |
-| C.cs:21:17:21:18 | this [property s5] : Elem | C.cs:27:14:27:15 | this access [property s5] : Elem |
-| C.cs:23:14:23:15 | this access [field s1] : Elem | C.cs:23:14:23:15 | access to field s1 |
 | C.cs:23:14:23:15 | this access [field s1] : Elem | C.cs:23:14:23:15 | access to field s1 |
 | C.cs:24:14:24:15 | this access [field s2] : Elem | C.cs:24:14:24:15 | access to field s2 |
-| C.cs:24:14:24:15 | this access [field s2] : Elem | C.cs:24:14:24:15 | access to field s2 |
-| C.cs:25:14:25:15 | this access [field s3] : Elem | C.cs:25:14:25:15 | access to field s3 |
 | C.cs:25:14:25:15 | this access [field s3] : Elem | C.cs:25:14:25:15 | access to field s3 |
 | C.cs:27:14:27:15 | this access [property s5] : Elem | C.cs:27:14:27:15 | access to property s5 |
-| C.cs:27:14:27:15 | this access [property s5] : Elem | C.cs:27:14:27:15 | access to property s5 |
-| C_ctor.cs:3:18:3:19 | [post] this access [field s1] : Elem | C_ctor.cs:7:23:7:37 | object creation of type C_no_ctor [field s1] : Elem |
 | C_ctor.cs:3:18:3:19 | [post] this access [field s1] : Elem | C_ctor.cs:7:23:7:37 | object creation of type C_no_ctor [field s1] : Elem |
 | C_ctor.cs:3:23:3:42 | call to method Source<Elem> : Elem | C_ctor.cs:3:18:3:19 | [post] this access [field s1] : Elem |
-| C_ctor.cs:3:23:3:42 | call to method Source<Elem> : Elem | C_ctor.cs:3:18:3:19 | [post] this access [field s1] : Elem |
-| C_ctor.cs:7:23:7:37 | object creation of type C_no_ctor [field s1] : Elem | C_ctor.cs:8:9:8:9 | access to local variable c [field s1] : Elem |
 | C_ctor.cs:7:23:7:37 | object creation of type C_no_ctor [field s1] : Elem | C_ctor.cs:8:9:8:9 | access to local variable c [field s1] : Elem |
 | C_ctor.cs:8:9:8:9 | access to local variable c [field s1] : Elem | C_ctor.cs:11:17:11:18 | this [field s1] : Elem |
-| C_ctor.cs:8:9:8:9 | access to local variable c [field s1] : Elem | C_ctor.cs:11:17:11:18 | this [field s1] : Elem |
-| C_ctor.cs:11:17:11:18 | this [field s1] : Elem | C_ctor.cs:13:19:13:20 | this access [field s1] : Elem |
 | C_ctor.cs:11:17:11:18 | this [field s1] : Elem | C_ctor.cs:13:19:13:20 | this access [field s1] : Elem |
 | C_ctor.cs:13:19:13:20 | this access [field s1] : Elem | C_ctor.cs:13:19:13:20 | access to field s1 |
-| C_ctor.cs:13:19:13:20 | this access [field s1] : Elem | C_ctor.cs:13:19:13:20 | access to field s1 |
-| C_ctor.cs:19:18:19:19 | [post] this access [field s1] : Elem | C_ctor.cs:23:25:23:41 | object creation of type C_with_ctor [field s1] : Elem |
 | C_ctor.cs:19:18:19:19 | [post] this access [field s1] : Elem | C_ctor.cs:23:25:23:41 | object creation of type C_with_ctor [field s1] : Elem |
 | C_ctor.cs:19:23:19:42 | call to method Source<Elem> : Elem | C_ctor.cs:19:18:19:19 | [post] this access [field s1] : Elem |
-| C_ctor.cs:19:23:19:42 | call to method Source<Elem> : Elem | C_ctor.cs:19:18:19:19 | [post] this access [field s1] : Elem |
-| C_ctor.cs:23:25:23:41 | object creation of type C_with_ctor [field s1] : Elem | C_ctor.cs:24:9:24:9 | access to local variable c [field s1] : Elem |
 | C_ctor.cs:23:25:23:41 | object creation of type C_with_ctor [field s1] : Elem | C_ctor.cs:24:9:24:9 | access to local variable c [field s1] : Elem |
 | C_ctor.cs:24:9:24:9 | access to local variable c [field s1] : Elem | C_ctor.cs:29:17:29:18 | this [field s1] : Elem |
-| C_ctor.cs:24:9:24:9 | access to local variable c [field s1] : Elem | C_ctor.cs:29:17:29:18 | this [field s1] : Elem |
-| C_ctor.cs:29:17:29:18 | this [field s1] : Elem | C_ctor.cs:31:19:31:20 | this access [field s1] : Elem |
 | C_ctor.cs:29:17:29:18 | this [field s1] : Elem | C_ctor.cs:31:19:31:20 | this access [field s1] : Elem |
 | C_ctor.cs:31:19:31:20 | this access [field s1] : Elem | C_ctor.cs:31:19:31:20 | access to field s1 |
-| C_ctor.cs:31:19:31:20 | this access [field s1] : Elem | C_ctor.cs:31:19:31:20 | access to field s1 |
-| D.cs:8:9:8:11 | this [field trivialPropField] : Object | D.cs:8:22:8:25 | this access [field trivialPropField] : Object |
 | D.cs:8:9:8:11 | this [field trivialPropField] : Object | D.cs:8:22:8:25 | this access [field trivialPropField] : Object |
 | D.cs:8:22:8:25 | this access [field trivialPropField] : Object | D.cs:8:22:8:42 | access to field trivialPropField : Object |
-| D.cs:8:22:8:25 | this access [field trivialPropField] : Object | D.cs:8:22:8:42 | access to field trivialPropField : Object |
-| D.cs:9:9:9:11 | value : Object | D.cs:9:39:9:43 | access to parameter value : Object |
 | D.cs:9:9:9:11 | value : Object | D.cs:9:39:9:43 | access to parameter value : Object |
 | D.cs:9:39:9:43 | access to parameter value : Object | D.cs:9:15:9:18 | [post] this access [field trivialPropField] : Object |
-| D.cs:9:39:9:43 | access to parameter value : Object | D.cs:9:15:9:18 | [post] this access [field trivialPropField] : Object |
-| D.cs:14:9:14:11 | this [field trivialPropField] : Object | D.cs:14:22:14:25 | this access [field trivialPropField] : Object |
 | D.cs:14:9:14:11 | this [field trivialPropField] : Object | D.cs:14:22:14:25 | this access [field trivialPropField] : Object |
 | D.cs:14:22:14:25 | this access [field trivialPropField] : Object | D.cs:14:22:14:42 | access to field trivialPropField : Object |
-| D.cs:14:22:14:25 | this access [field trivialPropField] : Object | D.cs:14:22:14:42 | access to field trivialPropField : Object |
-| D.cs:15:9:15:11 | value : Object | D.cs:15:34:15:38 | access to parameter value : Object |
 | D.cs:15:9:15:11 | value : Object | D.cs:15:34:15:38 | access to parameter value : Object |
 | D.cs:15:34:15:38 | access to parameter value : Object | D.cs:9:9:9:11 | value : Object |
-| D.cs:15:34:15:38 | access to parameter value : Object | D.cs:9:9:9:11 | value : Object |
-| D.cs:15:34:15:38 | access to parameter value : Object | D.cs:15:15:15:18 | [post] this access [field trivialPropField] : Object |
 | D.cs:15:34:15:38 | access to parameter value : Object | D.cs:15:15:15:18 | [post] this access [field trivialPropField] : Object |
 | D.cs:18:28:18:29 | o1 : Object | D.cs:21:24:21:25 | access to parameter o1 : Object |
-| D.cs:18:28:18:29 | o1 : Object | D.cs:21:24:21:25 | access to parameter o1 : Object |
-| D.cs:18:39:18:40 | o2 : Object | D.cs:22:27:22:28 | access to parameter o2 : Object |
 | D.cs:18:39:18:40 | o2 : Object | D.cs:22:27:22:28 | access to parameter o2 : Object |
 | D.cs:18:50:18:51 | o3 : Object | D.cs:23:27:23:28 | access to parameter o3 : Object |
-| D.cs:18:50:18:51 | o3 : Object | D.cs:23:27:23:28 | access to parameter o3 : Object |
-| D.cs:21:9:21:11 | [post] access to local variable ret [property AutoProp] : Object | D.cs:24:16:24:18 | access to local variable ret [property AutoProp] : Object |
 | D.cs:21:9:21:11 | [post] access to local variable ret [property AutoProp] : Object | D.cs:24:16:24:18 | access to local variable ret [property AutoProp] : Object |
 | D.cs:21:24:21:25 | access to parameter o1 : Object | D.cs:21:9:21:11 | [post] access to local variable ret [property AutoProp] : Object |
-| D.cs:21:24:21:25 | access to parameter o1 : Object | D.cs:21:9:21:11 | [post] access to local variable ret [property AutoProp] : Object |
-| D.cs:22:9:22:11 | [post] access to local variable ret [field trivialPropField] : Object | D.cs:24:16:24:18 | access to local variable ret [field trivialPropField] : Object |
 | D.cs:22:9:22:11 | [post] access to local variable ret [field trivialPropField] : Object | D.cs:24:16:24:18 | access to local variable ret [field trivialPropField] : Object |
 | D.cs:22:27:22:28 | access to parameter o2 : Object | D.cs:9:9:9:11 | value : Object |
-| D.cs:22:27:22:28 | access to parameter o2 : Object | D.cs:9:9:9:11 | value : Object |
-| D.cs:22:27:22:28 | access to parameter o2 : Object | D.cs:22:9:22:11 | [post] access to local variable ret [field trivialPropField] : Object |
 | D.cs:22:27:22:28 | access to parameter o2 : Object | D.cs:22:9:22:11 | [post] access to local variable ret [field trivialPropField] : Object |
 | D.cs:23:9:23:11 | [post] access to local variable ret [field trivialPropField] : Object | D.cs:24:16:24:18 | access to local variable ret [field trivialPropField] : Object |
-| D.cs:23:9:23:11 | [post] access to local variable ret [field trivialPropField] : Object | D.cs:24:16:24:18 | access to local variable ret [field trivialPropField] : Object |
-| D.cs:23:27:23:28 | access to parameter o3 : Object | D.cs:15:9:15:11 | value : Object |
 | D.cs:23:27:23:28 | access to parameter o3 : Object | D.cs:15:9:15:11 | value : Object |
 | D.cs:23:27:23:28 | access to parameter o3 : Object | D.cs:23:9:23:11 | [post] access to local variable ret [field trivialPropField] : Object |
-| D.cs:23:27:23:28 | access to parameter o3 : Object | D.cs:23:9:23:11 | [post] access to local variable ret [field trivialPropField] : Object |
-| D.cs:29:17:29:33 | call to method Source<Object> : Object | D.cs:31:24:31:24 | access to local variable o : Object |
 | D.cs:29:17:29:33 | call to method Source<Object> : Object | D.cs:31:24:31:24 | access to local variable o : Object |
 | D.cs:31:17:31:37 | call to method Create [property AutoProp] : Object | D.cs:32:14:32:14 | access to local variable d [property AutoProp] : Object |
-| D.cs:31:17:31:37 | call to method Create [property AutoProp] : Object | D.cs:32:14:32:14 | access to local variable d [property AutoProp] : Object |
-| D.cs:31:24:31:24 | access to local variable o : Object | D.cs:18:28:18:29 | o1 : Object |
 | D.cs:31:24:31:24 | access to local variable o : Object | D.cs:18:28:18:29 | o1 : Object |
 | D.cs:31:24:31:24 | access to local variable o : Object | D.cs:31:17:31:37 | call to method Create [property AutoProp] : Object |
-| D.cs:31:24:31:24 | access to local variable o : Object | D.cs:31:17:31:37 | call to method Create [property AutoProp] : Object |
-| D.cs:32:14:32:14 | access to local variable d [property AutoProp] : Object | D.cs:32:14:32:23 | access to property AutoProp |
 | D.cs:32:14:32:14 | access to local variable d [property AutoProp] : Object | D.cs:32:14:32:23 | access to property AutoProp |
 | D.cs:37:13:37:49 | call to method Create [field trivialPropField] : Object | D.cs:39:14:39:14 | access to local variable d [field trivialPropField] : Object |
-| D.cs:37:13:37:49 | call to method Create [field trivialPropField] : Object | D.cs:39:14:39:14 | access to local variable d [field trivialPropField] : Object |
-| D.cs:37:13:37:49 | call to method Create [field trivialPropField] : Object | D.cs:40:14:40:14 | access to local variable d [field trivialPropField] : Object |
 | D.cs:37:13:37:49 | call to method Create [field trivialPropField] : Object | D.cs:40:14:40:14 | access to local variable d [field trivialPropField] : Object |
 | D.cs:37:13:37:49 | call to method Create [field trivialPropField] : Object | D.cs:41:14:41:14 | access to local variable d [field trivialPropField] : Object |
-| D.cs:37:13:37:49 | call to method Create [field trivialPropField] : Object | D.cs:41:14:41:14 | access to local variable d [field trivialPropField] : Object |
-| D.cs:37:26:37:42 | call to method Source<Object> : Object | D.cs:18:39:18:40 | o2 : Object |
 | D.cs:37:26:37:42 | call to method Source<Object> : Object | D.cs:18:39:18:40 | o2 : Object |
 | D.cs:37:26:37:42 | call to method Source<Object> : Object | D.cs:37:13:37:49 | call to method Create [field trivialPropField] : Object |
-| D.cs:37:26:37:42 | call to method Source<Object> : Object | D.cs:37:13:37:49 | call to method Create [field trivialPropField] : Object |
-| D.cs:39:14:39:14 | access to local variable d [field trivialPropField] : Object | D.cs:8:9:8:11 | this [field trivialPropField] : Object |
 | D.cs:39:14:39:14 | access to local variable d [field trivialPropField] : Object | D.cs:8:9:8:11 | this [field trivialPropField] : Object |
 | D.cs:39:14:39:14 | access to local variable d [field trivialPropField] : Object | D.cs:39:14:39:26 | access to property TrivialProp |
-| D.cs:39:14:39:14 | access to local variable d [field trivialPropField] : Object | D.cs:39:14:39:26 | access to property TrivialProp |
-| D.cs:40:14:40:14 | access to local variable d [field trivialPropField] : Object | D.cs:40:14:40:31 | access to field trivialPropField |
 | D.cs:40:14:40:14 | access to local variable d [field trivialPropField] : Object | D.cs:40:14:40:31 | access to field trivialPropField |
 | D.cs:41:14:41:14 | access to local variable d [field trivialPropField] : Object | D.cs:14:9:14:11 | this [field trivialPropField] : Object |
-| D.cs:41:14:41:14 | access to local variable d [field trivialPropField] : Object | D.cs:14:9:14:11 | this [field trivialPropField] : Object |
-| D.cs:41:14:41:14 | access to local variable d [field trivialPropField] : Object | D.cs:41:14:41:26 | access to property ComplexProp |
 | D.cs:41:14:41:14 | access to local variable d [field trivialPropField] : Object | D.cs:41:14:41:26 | access to property ComplexProp |
 | D.cs:43:13:43:49 | call to method Create [field trivialPropField] : Object | D.cs:45:14:45:14 | access to local variable d [field trivialPropField] : Object |
-| D.cs:43:13:43:49 | call to method Create [field trivialPropField] : Object | D.cs:45:14:45:14 | access to local variable d [field trivialPropField] : Object |
-| D.cs:43:13:43:49 | call to method Create [field trivialPropField] : Object | D.cs:46:14:46:14 | access to local variable d [field trivialPropField] : Object |
 | D.cs:43:13:43:49 | call to method Create [field trivialPropField] : Object | D.cs:46:14:46:14 | access to local variable d [field trivialPropField] : Object |
 | D.cs:43:13:43:49 | call to method Create [field trivialPropField] : Object | D.cs:47:14:47:14 | access to local variable d [field trivialPropField] : Object |
-| D.cs:43:13:43:49 | call to method Create [field trivialPropField] : Object | D.cs:47:14:47:14 | access to local variable d [field trivialPropField] : Object |
-| D.cs:43:32:43:48 | call to method Source<Object> : Object | D.cs:18:50:18:51 | o3 : Object |
 | D.cs:43:32:43:48 | call to method Source<Object> : Object | D.cs:18:50:18:51 | o3 : Object |
 | D.cs:43:32:43:48 | call to method Source<Object> : Object | D.cs:43:13:43:49 | call to method Create [field trivialPropField] : Object |
-| D.cs:43:32:43:48 | call to method Source<Object> : Object | D.cs:43:13:43:49 | call to method Create [field trivialPropField] : Object |
-| D.cs:45:14:45:14 | access to local variable d [field trivialPropField] : Object | D.cs:8:9:8:11 | this [field trivialPropField] : Object |
 | D.cs:45:14:45:14 | access to local variable d [field trivialPropField] : Object | D.cs:8:9:8:11 | this [field trivialPropField] : Object |
 | D.cs:45:14:45:14 | access to local variable d [field trivialPropField] : Object | D.cs:45:14:45:26 | access to property TrivialProp |
-| D.cs:45:14:45:14 | access to local variable d [field trivialPropField] : Object | D.cs:45:14:45:26 | access to property TrivialProp |
-| D.cs:46:14:46:14 | access to local variable d [field trivialPropField] : Object | D.cs:46:14:46:31 | access to field trivialPropField |
 | D.cs:46:14:46:14 | access to local variable d [field trivialPropField] : Object | D.cs:46:14:46:31 | access to field trivialPropField |
 | D.cs:47:14:47:14 | access to local variable d [field trivialPropField] : Object | D.cs:14:9:14:11 | this [field trivialPropField] : Object |
-| D.cs:47:14:47:14 | access to local variable d [field trivialPropField] : Object | D.cs:14:9:14:11 | this [field trivialPropField] : Object |
-| D.cs:47:14:47:14 | access to local variable d [field trivialPropField] : Object | D.cs:47:14:47:26 | access to property ComplexProp |
 | D.cs:47:14:47:14 | access to local variable d [field trivialPropField] : Object | D.cs:47:14:47:26 | access to property ComplexProp |
 | E.cs:8:29:8:29 | o : Object | E.cs:11:21:11:21 | access to parameter o : Object |
-| E.cs:8:29:8:29 | o : Object | E.cs:11:21:11:21 | access to parameter o : Object |
-| E.cs:11:9:11:11 | [post] access to local variable ret [field Field] : Object | E.cs:12:16:12:18 | access to local variable ret [field Field] : Object |
 | E.cs:11:9:11:11 | [post] access to local variable ret [field Field] : Object | E.cs:12:16:12:18 | access to local variable ret [field Field] : Object |
 | E.cs:11:21:11:21 | access to parameter o : Object | E.cs:11:9:11:11 | [post] access to local variable ret [field Field] : Object |
-| E.cs:11:21:11:21 | access to parameter o : Object | E.cs:11:9:11:11 | [post] access to local variable ret [field Field] : Object |
-| E.cs:22:17:22:33 | call to method Source<Object> : Object | E.cs:23:25:23:25 | access to local variable o : Object |
 | E.cs:22:17:22:33 | call to method Source<Object> : Object | E.cs:23:25:23:25 | access to local variable o : Object |
 | E.cs:23:17:23:26 | call to method CreateS [field Field] : Object | E.cs:24:14:24:14 | access to local variable s [field Field] : Object |
-| E.cs:23:17:23:26 | call to method CreateS [field Field] : Object | E.cs:24:14:24:14 | access to local variable s [field Field] : Object |
-| E.cs:23:25:23:25 | access to local variable o : Object | E.cs:8:29:8:29 | o : Object |
 | E.cs:23:25:23:25 | access to local variable o : Object | E.cs:8:29:8:29 | o : Object |
 | E.cs:23:25:23:25 | access to local variable o : Object | E.cs:23:17:23:26 | call to method CreateS [field Field] : Object |
-| E.cs:23:25:23:25 | access to local variable o : Object | E.cs:23:17:23:26 | call to method CreateS [field Field] : Object |
-| E.cs:24:14:24:14 | access to local variable s [field Field] : Object | E.cs:24:14:24:20 | access to field Field |
 | E.cs:24:14:24:14 | access to local variable s [field Field] : Object | E.cs:24:14:24:20 | access to field Field |
 | F.cs:6:28:6:29 | o1 : Object | F.cs:6:65:6:66 | access to parameter o1 : Object |
-| F.cs:6:28:6:29 | o1 : Object | F.cs:6:65:6:66 | access to parameter o1 : Object |
-| F.cs:6:39:6:40 | o2 : Object | F.cs:6:78:6:79 | access to parameter o2 : Object |
 | F.cs:6:39:6:40 | o2 : Object | F.cs:6:78:6:79 | access to parameter o2 : Object |
 | F.cs:6:54:6:81 | { ..., ... } [field Field1] : Object | F.cs:6:46:6:81 | object creation of type F [field Field1] : Object |
-| F.cs:6:54:6:81 | { ..., ... } [field Field1] : Object | F.cs:6:46:6:81 | object creation of type F [field Field1] : Object |
-| F.cs:6:54:6:81 | { ..., ... } [field Field2] : Object | F.cs:6:46:6:81 | object creation of type F [field Field2] : Object |
 | F.cs:6:54:6:81 | { ..., ... } [field Field2] : Object | F.cs:6:46:6:81 | object creation of type F [field Field2] : Object |
 | F.cs:6:65:6:66 | access to parameter o1 : Object | F.cs:6:54:6:81 | { ..., ... } [field Field1] : Object |
-| F.cs:6:65:6:66 | access to parameter o1 : Object | F.cs:6:54:6:81 | { ..., ... } [field Field1] : Object |
-| F.cs:6:78:6:79 | access to parameter o2 : Object | F.cs:6:54:6:81 | { ..., ... } [field Field2] : Object |
 | F.cs:6:78:6:79 | access to parameter o2 : Object | F.cs:6:54:6:81 | { ..., ... } [field Field2] : Object |
 | F.cs:10:17:10:33 | call to method Source<Object> : Object | F.cs:11:24:11:24 | access to local variable o : Object |
-| F.cs:10:17:10:33 | call to method Source<Object> : Object | F.cs:11:24:11:24 | access to local variable o : Object |
-| F.cs:11:17:11:31 | call to method Create [field Field1] : Object | F.cs:12:14:12:14 | access to local variable f [field Field1] : Object |
 | F.cs:11:17:11:31 | call to method Create [field Field1] : Object | F.cs:12:14:12:14 | access to local variable f [field Field1] : Object |
 | F.cs:11:24:11:24 | access to local variable o : Object | F.cs:6:28:6:29 | o1 : Object |
-| F.cs:11:24:11:24 | access to local variable o : Object | F.cs:6:28:6:29 | o1 : Object |
-| F.cs:11:24:11:24 | access to local variable o : Object | F.cs:11:17:11:31 | call to method Create [field Field1] : Object |
 | F.cs:11:24:11:24 | access to local variable o : Object | F.cs:11:17:11:31 | call to method Create [field Field1] : Object |
 | F.cs:12:14:12:14 | access to local variable f [field Field1] : Object | F.cs:12:14:12:21 | access to field Field1 |
-| F.cs:12:14:12:14 | access to local variable f [field Field1] : Object | F.cs:12:14:12:21 | access to field Field1 |
-| F.cs:15:13:15:43 | call to method Create [field Field2] : Object | F.cs:17:14:17:14 | access to local variable f [field Field2] : Object |
 | F.cs:15:13:15:43 | call to method Create [field Field2] : Object | F.cs:17:14:17:14 | access to local variable f [field Field2] : Object |
 | F.cs:15:26:15:42 | call to method Source<Object> : Object | F.cs:6:39:6:40 | o2 : Object |
-| F.cs:15:26:15:42 | call to method Source<Object> : Object | F.cs:6:39:6:40 | o2 : Object |
-| F.cs:15:26:15:42 | call to method Source<Object> : Object | F.cs:15:13:15:43 | call to method Create [field Field2] : Object |
 | F.cs:15:26:15:42 | call to method Source<Object> : Object | F.cs:15:13:15:43 | call to method Create [field Field2] : Object |
 | F.cs:17:14:17:14 | access to local variable f [field Field2] : Object | F.cs:17:14:17:21 | access to field Field2 |
-| F.cs:17:14:17:14 | access to local variable f [field Field2] : Object | F.cs:17:14:17:21 | access to field Field2 |
-| F.cs:19:21:19:50 | { ..., ... } [field Field1] : Object | F.cs:20:14:20:14 | access to local variable f [field Field1] : Object |
 | F.cs:19:21:19:50 | { ..., ... } [field Field1] : Object | F.cs:20:14:20:14 | access to local variable f [field Field1] : Object |
 | F.cs:19:32:19:48 | call to method Source<Object> : Object | F.cs:19:21:19:50 | { ..., ... } [field Field1] : Object |
-| F.cs:19:32:19:48 | call to method Source<Object> : Object | F.cs:19:21:19:50 | { ..., ... } [field Field1] : Object |
-| F.cs:20:14:20:14 | access to local variable f [field Field1] : Object | F.cs:20:14:20:21 | access to field Field1 |
 | F.cs:20:14:20:14 | access to local variable f [field Field1] : Object | F.cs:20:14:20:21 | access to field Field1 |
 | F.cs:23:21:23:50 | { ..., ... } [field Field2] : Object | F.cs:25:14:25:14 | access to local variable f [field Field2] : Object |
-| F.cs:23:21:23:50 | { ..., ... } [field Field2] : Object | F.cs:25:14:25:14 | access to local variable f [field Field2] : Object |
-| F.cs:23:32:23:48 | call to method Source<Object> : Object | F.cs:23:21:23:50 | { ..., ... } [field Field2] : Object |
 | F.cs:23:32:23:48 | call to method Source<Object> : Object | F.cs:23:21:23:50 | { ..., ... } [field Field2] : Object |
 | F.cs:25:14:25:14 | access to local variable f [field Field2] : Object | F.cs:25:14:25:21 | access to field Field2 |
-| F.cs:25:14:25:14 | access to local variable f [field Field2] : Object | F.cs:25:14:25:21 | access to field Field2 |
-| F.cs:30:17:30:33 | call to method Source<Object> : Object | F.cs:32:27:32:27 | access to local variable o : Object |
 | F.cs:30:17:30:33 | call to method Source<Object> : Object | F.cs:32:27:32:27 | access to local variable o : Object |
 | F.cs:32:17:32:40 | { ..., ... } [property X] : Object | F.cs:33:14:33:14 | access to local variable a [property X] : Object |
-| F.cs:32:17:32:40 | { ..., ... } [property X] : Object | F.cs:33:14:33:14 | access to local variable a [property X] : Object |
-| F.cs:32:27:32:27 | access to local variable o : Object | F.cs:32:17:32:40 | { ..., ... } [property X] : Object |
 | F.cs:32:27:32:27 | access to local variable o : Object | F.cs:32:17:32:40 | { ..., ... } [property X] : Object |
 | F.cs:33:14:33:14 | access to local variable a [property X] : Object | F.cs:33:14:33:16 | access to property X |
-| F.cs:33:14:33:14 | access to local variable a [property X] : Object | F.cs:33:14:33:16 | access to property X |
-| G.cs:7:18:7:32 | call to method Source<Elem> : Elem | G.cs:9:23:9:23 | access to local variable e : Elem |
 | G.cs:7:18:7:32 | call to method Source<Elem> : Elem | G.cs:9:23:9:23 | access to local variable e : Elem |
 | G.cs:9:9:9:9 | [post] access to local variable b [field Box1, field Elem] : Elem | G.cs:10:18:10:18 | access to local variable b [field Box1, field Elem] : Elem |
-| G.cs:9:9:9:9 | [post] access to local variable b [field Box1, field Elem] : Elem | G.cs:10:18:10:18 | access to local variable b [field Box1, field Elem] : Elem |
-| G.cs:9:9:9:14 | [post] access to field Box1 [field Elem] : Elem | G.cs:9:9:9:9 | [post] access to local variable b [field Box1, field Elem] : Elem |
 | G.cs:9:9:9:14 | [post] access to field Box1 [field Elem] : Elem | G.cs:9:9:9:9 | [post] access to local variable b [field Box1, field Elem] : Elem |
 | G.cs:9:23:9:23 | access to local variable e : Elem | G.cs:9:9:9:14 | [post] access to field Box1 [field Elem] : Elem |
-| G.cs:9:23:9:23 | access to local variable e : Elem | G.cs:9:9:9:14 | [post] access to field Box1 [field Elem] : Elem |
-| G.cs:10:18:10:18 | access to local variable b [field Box1, field Elem] : Elem | G.cs:37:38:37:39 | b2 [field Box1, field Elem] : Elem |
 | G.cs:10:18:10:18 | access to local variable b [field Box1, field Elem] : Elem | G.cs:37:38:37:39 | b2 [field Box1, field Elem] : Elem |
 | G.cs:15:18:15:32 | call to method Source<Elem> : Elem | G.cs:17:24:17:24 | access to local variable e : Elem |
-| G.cs:15:18:15:32 | call to method Source<Elem> : Elem | G.cs:17:24:17:24 | access to local variable e : Elem |
-| G.cs:17:9:17:9 | [post] access to local variable b [field Box1, field Elem] : Elem | G.cs:18:18:18:18 | access to local variable b [field Box1, field Elem] : Elem |
 | G.cs:17:9:17:9 | [post] access to local variable b [field Box1, field Elem] : Elem | G.cs:18:18:18:18 | access to local variable b [field Box1, field Elem] : Elem |
 | G.cs:17:9:17:14 | [post] access to field Box1 [field Elem] : Elem | G.cs:17:9:17:9 | [post] access to local variable b [field Box1, field Elem] : Elem |
-| G.cs:17:9:17:14 | [post] access to field Box1 [field Elem] : Elem | G.cs:17:9:17:9 | [post] access to local variable b [field Box1, field Elem] : Elem |
-| G.cs:17:24:17:24 | access to local variable e : Elem | G.cs:17:9:17:14 | [post] access to field Box1 [field Elem] : Elem |
 | G.cs:17:24:17:24 | access to local variable e : Elem | G.cs:17:9:17:14 | [post] access to field Box1 [field Elem] : Elem |
 | G.cs:17:24:17:24 | access to local variable e : Elem | G.cs:64:34:64:34 | e : Elem |
-| G.cs:17:24:17:24 | access to local variable e : Elem | G.cs:64:34:64:34 | e : Elem |
-| G.cs:18:18:18:18 | access to local variable b [field Box1, field Elem] : Elem | G.cs:37:38:37:39 | b2 [field Box1, field Elem] : Elem |
 | G.cs:18:18:18:18 | access to local variable b [field Box1, field Elem] : Elem | G.cs:37:38:37:39 | b2 [field Box1, field Elem] : Elem |
 | G.cs:23:18:23:32 | call to method Source<Elem> : Elem | G.cs:25:28:25:28 | access to local variable e : Elem |
-| G.cs:23:18:23:32 | call to method Source<Elem> : Elem | G.cs:25:28:25:28 | access to local variable e : Elem |
-| G.cs:25:9:25:9 | [post] access to local variable b [field Box1, field Elem] : Elem | G.cs:26:18:26:18 | access to local variable b [field Box1, field Elem] : Elem |
 | G.cs:25:9:25:9 | [post] access to local variable b [field Box1, field Elem] : Elem | G.cs:26:18:26:18 | access to local variable b [field Box1, field Elem] : Elem |
 | G.cs:25:9:25:19 | [post] call to method GetBox1 [field Elem] : Elem | G.cs:25:9:25:9 | [post] access to local variable b [field Box1, field Elem] : Elem |
-| G.cs:25:9:25:19 | [post] call to method GetBox1 [field Elem] : Elem | G.cs:25:9:25:9 | [post] access to local variable b [field Box1, field Elem] : Elem |
-| G.cs:25:28:25:28 | access to local variable e : Elem | G.cs:25:9:25:19 | [post] call to method GetBox1 [field Elem] : Elem |
 | G.cs:25:28:25:28 | access to local variable e : Elem | G.cs:25:9:25:19 | [post] call to method GetBox1 [field Elem] : Elem |
 | G.cs:26:18:26:18 | access to local variable b [field Box1, field Elem] : Elem | G.cs:37:38:37:39 | b2 [field Box1, field Elem] : Elem |
-| G.cs:26:18:26:18 | access to local variable b [field Box1, field Elem] : Elem | G.cs:37:38:37:39 | b2 [field Box1, field Elem] : Elem |
-| G.cs:31:18:31:32 | call to method Source<Elem> : Elem | G.cs:33:29:33:29 | access to local variable e : Elem |
 | G.cs:31:18:31:32 | call to method Source<Elem> : Elem | G.cs:33:29:33:29 | access to local variable e : Elem |
 | G.cs:33:9:33:9 | [post] access to local variable b [field Box1, field Elem] : Elem | G.cs:34:18:34:18 | access to local variable b [field Box1, field Elem] : Elem |
-| G.cs:33:9:33:9 | [post] access to local variable b [field Box1, field Elem] : Elem | G.cs:34:18:34:18 | access to local variable b [field Box1, field Elem] : Elem |
-| G.cs:33:9:33:19 | [post] call to method GetBox1 [field Elem] : Elem | G.cs:33:9:33:9 | [post] access to local variable b [field Box1, field Elem] : Elem |
 | G.cs:33:9:33:19 | [post] call to method GetBox1 [field Elem] : Elem | G.cs:33:9:33:9 | [post] access to local variable b [field Box1, field Elem] : Elem |
 | G.cs:33:29:33:29 | access to local variable e : Elem | G.cs:33:9:33:19 | [post] call to method GetBox1 [field Elem] : Elem |
-| G.cs:33:29:33:29 | access to local variable e : Elem | G.cs:33:9:33:19 | [post] call to method GetBox1 [field Elem] : Elem |
-| G.cs:33:29:33:29 | access to local variable e : Elem | G.cs:64:34:64:34 | e : Elem |
 | G.cs:33:29:33:29 | access to local variable e : Elem | G.cs:64:34:64:34 | e : Elem |
 | G.cs:34:18:34:18 | access to local variable b [field Box1, field Elem] : Elem | G.cs:37:38:37:39 | b2 [field Box1, field Elem] : Elem |
-| G.cs:34:18:34:18 | access to local variable b [field Box1, field Elem] : Elem | G.cs:37:38:37:39 | b2 [field Box1, field Elem] : Elem |
-| G.cs:37:38:37:39 | b2 [field Box1, field Elem] : Elem | G.cs:39:14:39:15 | access to parameter b2 [field Box1, field Elem] : Elem |
 | G.cs:37:38:37:39 | b2 [field Box1, field Elem] : Elem | G.cs:39:14:39:15 | access to parameter b2 [field Box1, field Elem] : Elem |
 | G.cs:39:14:39:15 | access to parameter b2 [field Box1, field Elem] : Elem | G.cs:39:14:39:25 | call to method GetBox1 [field Elem] : Elem |
-| G.cs:39:14:39:15 | access to parameter b2 [field Box1, field Elem] : Elem | G.cs:39:14:39:25 | call to method GetBox1 [field Elem] : Elem |
-| G.cs:39:14:39:15 | access to parameter b2 [field Box1, field Elem] : Elem | G.cs:71:21:71:27 | this [field Box1, field Elem] : Elem |
 | G.cs:39:14:39:15 | access to parameter b2 [field Box1, field Elem] : Elem | G.cs:71:21:71:27 | this [field Box1, field Elem] : Elem |
 | G.cs:39:14:39:25 | call to method GetBox1 [field Elem] : Elem | G.cs:39:14:39:35 | call to method GetElem |
-| G.cs:39:14:39:25 | call to method GetBox1 [field Elem] : Elem | G.cs:39:14:39:35 | call to method GetElem |
-| G.cs:39:14:39:25 | call to method GetBox1 [field Elem] : Elem | G.cs:63:21:63:27 | this [field Elem] : Elem |
 | G.cs:39:14:39:25 | call to method GetBox1 [field Elem] : Elem | G.cs:63:21:63:27 | this [field Elem] : Elem |
 | G.cs:44:18:44:32 | call to method Source<Elem> : Elem | G.cs:46:30:46:30 | access to local variable e : Elem |
-| G.cs:44:18:44:32 | call to method Source<Elem> : Elem | G.cs:46:30:46:30 | access to local variable e : Elem |
-| G.cs:46:9:46:16 | [post] access to field boxfield [field Box1, field Elem] : Elem | G.cs:46:9:46:16 | [post] this access [field boxfield, field Box1, field Elem] : Elem |
 | G.cs:46:9:46:16 | [post] access to field boxfield [field Box1, field Elem] : Elem | G.cs:46:9:46:16 | [post] this access [field boxfield, field Box1, field Elem] : Elem |
 | G.cs:46:9:46:16 | [post] this access [field boxfield, field Box1, field Elem] : Elem | G.cs:47:9:47:13 | this access [field boxfield, field Box1, field Elem] : Elem |
-| G.cs:46:9:46:16 | [post] this access [field boxfield, field Box1, field Elem] : Elem | G.cs:47:9:47:13 | this access [field boxfield, field Box1, field Elem] : Elem |
-| G.cs:46:9:46:21 | [post] access to field Box1 [field Elem] : Elem | G.cs:46:9:46:16 | [post] access to field boxfield [field Box1, field Elem] : Elem |
 | G.cs:46:9:46:21 | [post] access to field Box1 [field Elem] : Elem | G.cs:46:9:46:16 | [post] access to field boxfield [field Box1, field Elem] : Elem |
 | G.cs:46:30:46:30 | access to local variable e : Elem | G.cs:46:9:46:21 | [post] access to field Box1 [field Elem] : Elem |
-| G.cs:46:30:46:30 | access to local variable e : Elem | G.cs:46:9:46:21 | [post] access to field Box1 [field Elem] : Elem |
-| G.cs:47:9:47:13 | this access [field boxfield, field Box1, field Elem] : Elem | G.cs:50:18:50:20 | this [field boxfield, field Box1, field Elem] : Elem |
 | G.cs:47:9:47:13 | this access [field boxfield, field Box1, field Elem] : Elem | G.cs:50:18:50:20 | this [field boxfield, field Box1, field Elem] : Elem |
 | G.cs:50:18:50:20 | this [field boxfield, field Box1, field Elem] : Elem | G.cs:52:14:52:21 | this access [field boxfield, field Box1, field Elem] : Elem |
-| G.cs:50:18:50:20 | this [field boxfield, field Box1, field Elem] : Elem | G.cs:52:14:52:21 | this access [field boxfield, field Box1, field Elem] : Elem |
-| G.cs:52:14:52:21 | access to field boxfield [field Box1, field Elem] : Elem | G.cs:52:14:52:26 | access to field Box1 [field Elem] : Elem |
 | G.cs:52:14:52:21 | access to field boxfield [field Box1, field Elem] : Elem | G.cs:52:14:52:26 | access to field Box1 [field Elem] : Elem |
 | G.cs:52:14:52:21 | this access [field boxfield, field Box1, field Elem] : Elem | G.cs:52:14:52:21 | access to field boxfield [field Box1, field Elem] : Elem |
-| G.cs:52:14:52:21 | this access [field boxfield, field Box1, field Elem] : Elem | G.cs:52:14:52:21 | access to field boxfield [field Box1, field Elem] : Elem |
-| G.cs:52:14:52:26 | access to field Box1 [field Elem] : Elem | G.cs:52:14:52:31 | access to field Elem |
 | G.cs:52:14:52:26 | access to field Box1 [field Elem] : Elem | G.cs:52:14:52:31 | access to field Elem |
 | G.cs:63:21:63:27 | this [field Elem] : Elem | G.cs:63:34:63:37 | this access [field Elem] : Elem |
-| G.cs:63:21:63:27 | this [field Elem] : Elem | G.cs:63:34:63:37 | this access [field Elem] : Elem |
-| G.cs:63:34:63:37 | this access [field Elem] : Elem | G.cs:63:34:63:37 | access to field Elem : Elem |
 | G.cs:63:34:63:37 | this access [field Elem] : Elem | G.cs:63:34:63:37 | access to field Elem : Elem |
 | G.cs:64:34:64:34 | e : Elem | G.cs:64:46:64:46 | access to parameter e : Elem |
-| G.cs:64:34:64:34 | e : Elem | G.cs:64:46:64:46 | access to parameter e : Elem |
-| G.cs:64:46:64:46 | access to parameter e : Elem | G.cs:64:39:64:42 | [post] this access [field Elem] : Elem |
 | G.cs:64:46:64:46 | access to parameter e : Elem | G.cs:64:39:64:42 | [post] this access [field Elem] : Elem |
 | G.cs:71:21:71:27 | this [field Box1, field Elem] : Elem | G.cs:71:34:71:37 | this access [field Box1, field Elem] : Elem |
-| G.cs:71:21:71:27 | this [field Box1, field Elem] : Elem | G.cs:71:34:71:37 | this access [field Box1, field Elem] : Elem |
-| G.cs:71:34:71:37 | this access [field Box1, field Elem] : Elem | G.cs:71:34:71:37 | access to field Box1 [field Elem] : Elem |
 | G.cs:71:34:71:37 | this access [field Box1, field Elem] : Elem | G.cs:71:34:71:37 | access to field Box1 [field Elem] : Elem |
 | H.cs:13:15:13:15 | a [field FieldA] : Object | H.cs:16:22:16:22 | access to parameter a [field FieldA] : Object |
-| H.cs:13:15:13:15 | a [field FieldA] : Object | H.cs:16:22:16:22 | access to parameter a [field FieldA] : Object |
-| H.cs:16:9:16:11 | [post] access to local variable ret [field FieldA] : Object | H.cs:17:16:17:18 | access to local variable ret [field FieldA] : Object |
 | H.cs:16:9:16:11 | [post] access to local variable ret [field FieldA] : Object | H.cs:17:16:17:18 | access to local variable ret [field FieldA] : Object |
 | H.cs:16:22:16:22 | access to parameter a [field FieldA] : Object | H.cs:16:22:16:29 | access to field FieldA : Object |
-| H.cs:16:22:16:22 | access to parameter a [field FieldA] : Object | H.cs:16:22:16:29 | access to field FieldA : Object |
-| H.cs:16:22:16:29 | access to field FieldA : Object | H.cs:16:9:16:11 | [post] access to local variable ret [field FieldA] : Object |
 | H.cs:16:22:16:29 | access to field FieldA : Object | H.cs:16:9:16:11 | [post] access to local variable ret [field FieldA] : Object |
 | H.cs:23:9:23:9 | [post] access to local variable a [field FieldA] : Object | H.cs:24:27:24:27 | access to local variable a [field FieldA] : Object |
-| H.cs:23:9:23:9 | [post] access to local variable a [field FieldA] : Object | H.cs:24:27:24:27 | access to local variable a [field FieldA] : Object |
-| H.cs:23:20:23:36 | call to method Source<Object> : Object | H.cs:23:9:23:9 | [post] access to local variable a [field FieldA] : Object |
 | H.cs:23:20:23:36 | call to method Source<Object> : Object | H.cs:23:9:23:9 | [post] access to local variable a [field FieldA] : Object |
 | H.cs:24:21:24:28 | call to method Clone [field FieldA] : Object | H.cs:25:14:25:18 | access to local variable clone [field FieldA] : Object |
-| H.cs:24:21:24:28 | call to method Clone [field FieldA] : Object | H.cs:25:14:25:18 | access to local variable clone [field FieldA] : Object |
-| H.cs:24:27:24:27 | access to local variable a [field FieldA] : Object | H.cs:13:15:13:15 | a [field FieldA] : Object |
 | H.cs:24:27:24:27 | access to local variable a [field FieldA] : Object | H.cs:13:15:13:15 | a [field FieldA] : Object |
 | H.cs:24:27:24:27 | access to local variable a [field FieldA] : Object | H.cs:24:21:24:28 | call to method Clone [field FieldA] : Object |
-| H.cs:24:27:24:27 | access to local variable a [field FieldA] : Object | H.cs:24:21:24:28 | call to method Clone [field FieldA] : Object |
-| H.cs:25:14:25:18 | access to local variable clone [field FieldA] : Object | H.cs:25:14:25:25 | access to field FieldA |
 | H.cs:25:14:25:18 | access to local variable clone [field FieldA] : Object | H.cs:25:14:25:25 | access to field FieldA |
 | H.cs:33:19:33:19 | a [field FieldA] : A | H.cs:36:20:36:20 | access to parameter a [field FieldA] : A |
-| H.cs:33:19:33:19 | a [field FieldA] : A | H.cs:36:20:36:20 | access to parameter a [field FieldA] : A |
-| H.cs:33:19:33:19 | a [field FieldA] : Object | H.cs:36:20:36:20 | access to parameter a [field FieldA] : Object |
 | H.cs:33:19:33:19 | a [field FieldA] : Object | H.cs:36:20:36:20 | access to parameter a [field FieldA] : Object |
 | H.cs:36:9:36:9 | [post] access to local variable b [field FieldB] : A | H.cs:37:16:37:16 | access to local variable b [field FieldB] : A |
-| H.cs:36:9:36:9 | [post] access to local variable b [field FieldB] : A | H.cs:37:16:37:16 | access to local variable b [field FieldB] : A |
-| H.cs:36:9:36:9 | [post] access to local variable b [field FieldB] : Object | H.cs:37:16:37:16 | access to local variable b [field FieldB] : Object |
 | H.cs:36:9:36:9 | [post] access to local variable b [field FieldB] : Object | H.cs:37:16:37:16 | access to local variable b [field FieldB] : Object |
 | H.cs:36:20:36:20 | access to parameter a [field FieldA] : A | H.cs:36:20:36:27 | access to field FieldA : A |
-| H.cs:36:20:36:20 | access to parameter a [field FieldA] : A | H.cs:36:20:36:27 | access to field FieldA : A |
-| H.cs:36:20:36:20 | access to parameter a [field FieldA] : Object | H.cs:36:20:36:27 | access to field FieldA : Object |
 | H.cs:36:20:36:20 | access to parameter a [field FieldA] : Object | H.cs:36:20:36:27 | access to field FieldA : Object |
 | H.cs:36:20:36:27 | access to field FieldA : A | H.cs:36:9:36:9 | [post] access to local variable b [field FieldB] : A |
-| H.cs:36:20:36:27 | access to field FieldA : A | H.cs:36:9:36:9 | [post] access to local variable b [field FieldB] : A |
-| H.cs:36:20:36:27 | access to field FieldA : Object | H.cs:36:9:36:9 | [post] access to local variable b [field FieldB] : Object |
 | H.cs:36:20:36:27 | access to field FieldA : Object | H.cs:36:9:36:9 | [post] access to local variable b [field FieldB] : Object |
 | H.cs:43:9:43:9 | [post] access to local variable a [field FieldA] : Object | H.cs:44:27:44:27 | access to local variable a [field FieldA] : Object |
-| H.cs:43:9:43:9 | [post] access to local variable a [field FieldA] : Object | H.cs:44:27:44:27 | access to local variable a [field FieldA] : Object |
-| H.cs:43:20:43:36 | call to method Source<Object> : Object | H.cs:43:9:43:9 | [post] access to local variable a [field FieldA] : Object |
 | H.cs:43:20:43:36 | call to method Source<Object> : Object | H.cs:43:9:43:9 | [post] access to local variable a [field FieldA] : Object |
 | H.cs:44:17:44:28 | call to method Transform [field FieldB] : Object | H.cs:45:14:45:14 | access to local variable b [field FieldB] : Object |
-| H.cs:44:17:44:28 | call to method Transform [field FieldB] : Object | H.cs:45:14:45:14 | access to local variable b [field FieldB] : Object |
-| H.cs:44:27:44:27 | access to local variable a [field FieldA] : Object | H.cs:33:19:33:19 | a [field FieldA] : Object |
 | H.cs:44:27:44:27 | access to local variable a [field FieldA] : Object | H.cs:33:19:33:19 | a [field FieldA] : Object |
 | H.cs:44:27:44:27 | access to local variable a [field FieldA] : Object | H.cs:44:17:44:28 | call to method Transform [field FieldB] : Object |
-| H.cs:44:27:44:27 | access to local variable a [field FieldA] : Object | H.cs:44:17:44:28 | call to method Transform [field FieldB] : Object |
-| H.cs:45:14:45:14 | access to local variable b [field FieldB] : Object | H.cs:45:14:45:21 | access to field FieldB |
 | H.cs:45:14:45:14 | access to local variable b [field FieldB] : Object | H.cs:45:14:45:21 | access to field FieldB |
 | H.cs:53:25:53:25 | a [field FieldA] : Object | H.cs:55:21:55:21 | access to parameter a [field FieldA] : Object |
-| H.cs:53:25:53:25 | a [field FieldA] : Object | H.cs:55:21:55:21 | access to parameter a [field FieldA] : Object |
-| H.cs:55:21:55:21 | access to parameter a [field FieldA] : Object | H.cs:55:21:55:28 | access to field FieldA : Object |
 | H.cs:55:21:55:21 | access to parameter a [field FieldA] : Object | H.cs:55:21:55:28 | access to field FieldA : Object |
 | H.cs:55:21:55:28 | access to field FieldA : Object | H.cs:55:9:55:10 | [post] access to parameter b1 [field FieldB] : Object |
-| H.cs:55:21:55:28 | access to field FieldA : Object | H.cs:55:9:55:10 | [post] access to parameter b1 [field FieldB] : Object |
-| H.cs:63:9:63:9 | [post] access to local variable a [field FieldA] : Object | H.cs:64:22:64:22 | access to local variable a [field FieldA] : Object |
 | H.cs:63:9:63:9 | [post] access to local variable a [field FieldA] : Object | H.cs:64:22:64:22 | access to local variable a [field FieldA] : Object |
 | H.cs:63:20:63:36 | call to method Source<Object> : Object | H.cs:63:9:63:9 | [post] access to local variable a [field FieldA] : Object |
-| H.cs:63:20:63:36 | call to method Source<Object> : Object | H.cs:63:9:63:9 | [post] access to local variable a [field FieldA] : Object |
-| H.cs:64:22:64:22 | access to local variable a [field FieldA] : Object | H.cs:53:25:53:25 | a [field FieldA] : Object |
 | H.cs:64:22:64:22 | access to local variable a [field FieldA] : Object | H.cs:53:25:53:25 | a [field FieldA] : Object |
 | H.cs:64:22:64:22 | access to local variable a [field FieldA] : Object | H.cs:64:25:64:26 | [post] access to local variable b1 [field FieldB] : Object |
-| H.cs:64:22:64:22 | access to local variable a [field FieldA] : Object | H.cs:64:25:64:26 | [post] access to local variable b1 [field FieldB] : Object |
-| H.cs:64:25:64:26 | [post] access to local variable b1 [field FieldB] : Object | H.cs:65:14:65:15 | access to local variable b1 [field FieldB] : Object |
 | H.cs:64:25:64:26 | [post] access to local variable b1 [field FieldB] : Object | H.cs:65:14:65:15 | access to local variable b1 [field FieldB] : Object |
 | H.cs:65:14:65:15 | access to local variable b1 [field FieldB] : Object | H.cs:65:14:65:22 | access to field FieldB |
-| H.cs:65:14:65:15 | access to local variable b1 [field FieldB] : Object | H.cs:65:14:65:22 | access to field FieldB |
-| H.cs:77:30:77:30 | o : Object | H.cs:79:20:79:20 | access to parameter o : Object |
 | H.cs:77:30:77:30 | o : Object | H.cs:79:20:79:20 | access to parameter o : Object |
 | H.cs:79:9:79:9 | [post] access to parameter a [field FieldA] : Object | H.cs:80:22:80:22 | access to parameter a [field FieldA] : Object |
-| H.cs:79:9:79:9 | [post] access to parameter a [field FieldA] : Object | H.cs:80:22:80:22 | access to parameter a [field FieldA] : Object |
-| H.cs:79:20:79:20 | access to parameter o : Object | H.cs:79:9:79:9 | [post] access to parameter a [field FieldA] : Object |
 | H.cs:79:20:79:20 | access to parameter o : Object | H.cs:79:9:79:9 | [post] access to parameter a [field FieldA] : Object |
 | H.cs:80:22:80:22 | access to parameter a [field FieldA] : Object | H.cs:53:25:53:25 | a [field FieldA] : Object |
-| H.cs:80:22:80:22 | access to parameter a [field FieldA] : Object | H.cs:53:25:53:25 | a [field FieldA] : Object |
-| H.cs:80:22:80:22 | access to parameter a [field FieldA] : Object | H.cs:80:25:80:26 | [post] access to parameter b1 [field FieldB] : Object |
 | H.cs:80:22:80:22 | access to parameter a [field FieldA] : Object | H.cs:80:25:80:26 | [post] access to parameter b1 [field FieldB] : Object |
 | H.cs:88:17:88:17 | [post] access to local variable a [field FieldA] : Object | H.cs:89:14:89:14 | access to local variable a [field FieldA] : Object |
-| H.cs:88:17:88:17 | [post] access to local variable a [field FieldA] : Object | H.cs:89:14:89:14 | access to local variable a [field FieldA] : Object |
-| H.cs:88:20:88:36 | call to method Source<Object> : Object | H.cs:77:30:77:30 | o : Object |
 | H.cs:88:20:88:36 | call to method Source<Object> : Object | H.cs:77:30:77:30 | o : Object |
 | H.cs:88:20:88:36 | call to method Source<Object> : Object | H.cs:88:17:88:17 | [post] access to local variable a [field FieldA] : Object |
-| H.cs:88:20:88:36 | call to method Source<Object> : Object | H.cs:88:17:88:17 | [post] access to local variable a [field FieldA] : Object |
-| H.cs:88:20:88:36 | call to method Source<Object> : Object | H.cs:88:39:88:40 | [post] access to local variable b1 [field FieldB] : Object |
 | H.cs:88:20:88:36 | call to method Source<Object> : Object | H.cs:88:39:88:40 | [post] access to local variable b1 [field FieldB] : Object |
 | H.cs:88:39:88:40 | [post] access to local variable b1 [field FieldB] : Object | H.cs:90:14:90:15 | access to local variable b1 [field FieldB] : Object |
-| H.cs:88:39:88:40 | [post] access to local variable b1 [field FieldB] : Object | H.cs:90:14:90:15 | access to local variable b1 [field FieldB] : Object |
-| H.cs:89:14:89:14 | access to local variable a [field FieldA] : Object | H.cs:89:14:89:21 | access to field FieldA |
 | H.cs:89:14:89:14 | access to local variable a [field FieldA] : Object | H.cs:89:14:89:21 | access to field FieldA |
 | H.cs:90:14:90:15 | access to local variable b1 [field FieldB] : Object | H.cs:90:14:90:22 | access to field FieldB |
-| H.cs:90:14:90:15 | access to local variable b1 [field FieldB] : Object | H.cs:90:14:90:22 | access to field FieldB |
-| H.cs:102:23:102:23 | a [field FieldA] : Object | H.cs:105:23:105:23 | access to parameter a [field FieldA] : Object |
 | H.cs:102:23:102:23 | a [field FieldA] : Object | H.cs:105:23:105:23 | access to parameter a [field FieldA] : Object |
 | H.cs:105:9:105:12 | [post] access to local variable temp [field FieldB, field FieldA] : Object | H.cs:106:29:106:32 | access to local variable temp [field FieldB, field FieldA] : Object |
-| H.cs:105:9:105:12 | [post] access to local variable temp [field FieldB, field FieldA] : Object | H.cs:106:29:106:32 | access to local variable temp [field FieldB, field FieldA] : Object |
-| H.cs:105:23:105:23 | access to parameter a [field FieldA] : Object | H.cs:105:9:105:12 | [post] access to local variable temp [field FieldB, field FieldA] : Object |
 | H.cs:105:23:105:23 | access to parameter a [field FieldA] : Object | H.cs:105:9:105:12 | [post] access to local variable temp [field FieldB, field FieldA] : Object |
 | H.cs:106:26:106:39 | (...) ... [field FieldA] : Object | H.cs:33:19:33:19 | a [field FieldA] : Object |
-| H.cs:106:26:106:39 | (...) ... [field FieldA] : Object | H.cs:33:19:33:19 | a [field FieldA] : Object |
-| H.cs:106:26:106:39 | (...) ... [field FieldA] : Object | H.cs:106:16:106:40 | call to method Transform [field FieldB] : Object |
 | H.cs:106:26:106:39 | (...) ... [field FieldA] : Object | H.cs:106:16:106:40 | call to method Transform [field FieldB] : Object |
 | H.cs:106:29:106:32 | access to local variable temp [field FieldB, field FieldA] : Object | H.cs:106:29:106:39 | access to field FieldB [field FieldA] : Object |
-| H.cs:106:29:106:32 | access to local variable temp [field FieldB, field FieldA] : Object | H.cs:106:29:106:39 | access to field FieldB [field FieldA] : Object |
-| H.cs:106:29:106:39 | access to field FieldB [field FieldA] : Object | H.cs:106:26:106:39 | (...) ... [field FieldA] : Object |
 | H.cs:106:29:106:39 | access to field FieldB [field FieldA] : Object | H.cs:106:26:106:39 | (...) ... [field FieldA] : Object |
 | H.cs:112:9:112:9 | [post] access to local variable a [field FieldA] : Object | H.cs:113:31:113:31 | access to local variable a [field FieldA] : Object |
-| H.cs:112:9:112:9 | [post] access to local variable a [field FieldA] : Object | H.cs:113:31:113:31 | access to local variable a [field FieldA] : Object |
-| H.cs:112:20:112:36 | call to method Source<Object> : Object | H.cs:112:9:112:9 | [post] access to local variable a [field FieldA] : Object |
 | H.cs:112:20:112:36 | call to method Source<Object> : Object | H.cs:112:9:112:9 | [post] access to local variable a [field FieldA] : Object |
 | H.cs:113:17:113:32 | call to method TransformWrap [field FieldB] : Object | H.cs:114:14:114:14 | access to local variable b [field FieldB] : Object |
-| H.cs:113:17:113:32 | call to method TransformWrap [field FieldB] : Object | H.cs:114:14:114:14 | access to local variable b [field FieldB] : Object |
-| H.cs:113:31:113:31 | access to local variable a [field FieldA] : Object | H.cs:102:23:102:23 | a [field FieldA] : Object |
 | H.cs:113:31:113:31 | access to local variable a [field FieldA] : Object | H.cs:102:23:102:23 | a [field FieldA] : Object |
 | H.cs:113:31:113:31 | access to local variable a [field FieldA] : Object | H.cs:113:17:113:32 | call to method TransformWrap [field FieldB] : Object |
-| H.cs:113:31:113:31 | access to local variable a [field FieldA] : Object | H.cs:113:17:113:32 | call to method TransformWrap [field FieldB] : Object |
-| H.cs:114:14:114:14 | access to local variable b [field FieldB] : Object | H.cs:114:14:114:21 | access to field FieldB |
 | H.cs:114:14:114:14 | access to local variable b [field FieldB] : Object | H.cs:114:14:114:21 | access to field FieldB |
 | H.cs:122:18:122:18 | a [field FieldA] : Object | H.cs:124:26:124:26 | access to parameter a [field FieldA] : Object |
-| H.cs:122:18:122:18 | a [field FieldA] : Object | H.cs:124:26:124:26 | access to parameter a [field FieldA] : Object |
-| H.cs:124:16:124:27 | call to method Transform [field FieldB] : Object | H.cs:124:16:124:34 | access to field FieldB : Object |
 | H.cs:124:16:124:27 | call to method Transform [field FieldB] : Object | H.cs:124:16:124:34 | access to field FieldB : Object |
 | H.cs:124:26:124:26 | access to parameter a [field FieldA] : Object | H.cs:33:19:33:19 | a [field FieldA] : Object |
-| H.cs:124:26:124:26 | access to parameter a [field FieldA] : Object | H.cs:33:19:33:19 | a [field FieldA] : Object |
-| H.cs:124:26:124:26 | access to parameter a [field FieldA] : Object | H.cs:124:16:124:27 | call to method Transform [field FieldB] : Object |
 | H.cs:124:26:124:26 | access to parameter a [field FieldA] : Object | H.cs:124:16:124:27 | call to method Transform [field FieldB] : Object |
 | H.cs:130:9:130:9 | [post] access to local variable a [field FieldA] : Object | H.cs:131:18:131:18 | access to local variable a [field FieldA] : Object |
-| H.cs:130:9:130:9 | [post] access to local variable a [field FieldA] : Object | H.cs:131:18:131:18 | access to local variable a [field FieldA] : Object |
-| H.cs:130:20:130:36 | call to method Source<Object> : Object | H.cs:130:9:130:9 | [post] access to local variable a [field FieldA] : Object |
 | H.cs:130:20:130:36 | call to method Source<Object> : Object | H.cs:130:9:130:9 | [post] access to local variable a [field FieldA] : Object |
 | H.cs:131:18:131:18 | access to local variable a [field FieldA] : Object | H.cs:122:18:122:18 | a [field FieldA] : Object |
-| H.cs:131:18:131:18 | access to local variable a [field FieldA] : Object | H.cs:122:18:122:18 | a [field FieldA] : Object |
-| H.cs:131:18:131:18 | access to local variable a [field FieldA] : Object | H.cs:131:14:131:19 | call to method Get |
 | H.cs:131:18:131:18 | access to local variable a [field FieldA] : Object | H.cs:131:14:131:19 | call to method Get |
 | H.cs:138:27:138:27 | o : A | H.cs:141:20:141:25 | ... as ... : A |
-| H.cs:138:27:138:27 | o : A | H.cs:141:20:141:25 | ... as ... : A |
-| H.cs:141:9:141:9 | [post] access to local variable a [field FieldA] : A | H.cs:142:26:142:26 | access to local variable a [field FieldA] : A |
 | H.cs:141:9:141:9 | [post] access to local variable a [field FieldA] : A | H.cs:142:26:142:26 | access to local variable a [field FieldA] : A |
 | H.cs:141:20:141:25 | ... as ... : A | H.cs:141:9:141:9 | [post] access to local variable a [field FieldA] : A |
-| H.cs:141:20:141:25 | ... as ... : A | H.cs:141:9:141:9 | [post] access to local variable a [field FieldA] : A |
-| H.cs:142:16:142:27 | call to method Transform [field FieldB] : A | H.cs:142:16:142:34 | access to field FieldB : A |
 | H.cs:142:16:142:27 | call to method Transform [field FieldB] : A | H.cs:142:16:142:34 | access to field FieldB : A |
 | H.cs:142:26:142:26 | access to local variable a [field FieldA] : A | H.cs:33:19:33:19 | a [field FieldA] : A |
-| H.cs:142:26:142:26 | access to local variable a [field FieldA] : A | H.cs:33:19:33:19 | a [field FieldA] : A |
-| H.cs:142:26:142:26 | access to local variable a [field FieldA] : A | H.cs:142:16:142:27 | call to method Transform [field FieldB] : A |
 | H.cs:142:26:142:26 | access to local variable a [field FieldA] : A | H.cs:142:16:142:27 | call to method Transform [field FieldB] : A |
 | H.cs:147:17:147:39 | call to method Through : A | H.cs:148:14:148:14 | access to local variable a |
-| H.cs:147:17:147:39 | call to method Through : A | H.cs:148:14:148:14 | access to local variable a |
-| H.cs:147:25:147:38 | call to method Source<A> : A | H.cs:138:27:138:27 | o : A |
 | H.cs:147:25:147:38 | call to method Source<A> : A | H.cs:138:27:138:27 | o : A |
 | H.cs:147:25:147:38 | call to method Source<A> : A | H.cs:147:17:147:39 | call to method Through : A |
-| H.cs:147:25:147:38 | call to method Source<A> : A | H.cs:147:17:147:39 | call to method Through : A |
-| H.cs:153:32:153:32 | o : Object | H.cs:156:20:156:20 | access to parameter o : Object |
 | H.cs:153:32:153:32 | o : Object | H.cs:156:20:156:20 | access to parameter o : Object |
 | H.cs:155:17:155:30 | call to method Source<B> : B | H.cs:156:9:156:9 | access to local variable b : B |
-| H.cs:155:17:155:30 | call to method Source<B> : B | H.cs:156:9:156:9 | access to local variable b : B |
-| H.cs:156:9:156:9 | [post] access to local variable b [field FieldB] : Object | H.cs:157:20:157:20 | access to local variable b [field FieldB] : Object |
 | H.cs:156:9:156:9 | [post] access to local variable b [field FieldB] : Object | H.cs:157:20:157:20 | access to local variable b [field FieldB] : Object |
 | H.cs:156:9:156:9 | access to local variable b : B | H.cs:157:20:157:20 | access to local variable b : B |
-| H.cs:156:9:156:9 | access to local variable b : B | H.cs:157:20:157:20 | access to local variable b : B |
-| H.cs:156:20:156:20 | access to parameter o : Object | H.cs:156:9:156:9 | [post] access to local variable b [field FieldB] : Object |
 | H.cs:156:20:156:20 | access to parameter o : Object | H.cs:156:9:156:9 | [post] access to local variable b [field FieldB] : Object |
 | H.cs:157:9:157:9 | [post] access to parameter a [field FieldA] : B | H.cs:164:19:164:19 | [post] access to local variable a [field FieldA] : B |
-| H.cs:157:9:157:9 | [post] access to parameter a [field FieldA] : B | H.cs:164:19:164:19 | [post] access to local variable a [field FieldA] : B |
-| H.cs:157:20:157:20 | access to local variable b : B | H.cs:157:9:157:9 | [post] access to parameter a [field FieldA] : B |
 | H.cs:157:20:157:20 | access to local variable b : B | H.cs:157:9:157:9 | [post] access to parameter a [field FieldA] : B |
 | H.cs:157:20:157:20 | access to local variable b [field FieldB] : Object | H.cs:157:9:157:9 | [post] access to parameter a [field FieldA, field FieldB] : Object |
-| H.cs:157:20:157:20 | access to local variable b [field FieldB] : Object | H.cs:157:9:157:9 | [post] access to parameter a [field FieldA, field FieldB] : Object |
-| H.cs:163:17:163:35 | call to method Source<Object> : Object | H.cs:164:22:164:22 | access to local variable o : Object |
 | H.cs:163:17:163:35 | call to method Source<Object> : Object | H.cs:164:22:164:22 | access to local variable o : Object |
 | H.cs:164:19:164:19 | [post] access to local variable a [field FieldA, field FieldB] : Object | H.cs:165:20:165:20 | access to local variable a [field FieldA, field FieldB] : Object |
-| H.cs:164:19:164:19 | [post] access to local variable a [field FieldA, field FieldB] : Object | H.cs:165:20:165:20 | access to local variable a [field FieldA, field FieldB] : Object |
-| H.cs:164:19:164:19 | [post] access to local variable a [field FieldA] : B | H.cs:165:20:165:20 | access to local variable a [field FieldA] : B |
 | H.cs:164:19:164:19 | [post] access to local variable a [field FieldA] : B | H.cs:165:20:165:20 | access to local variable a [field FieldA] : B |
 | H.cs:164:22:164:22 | access to local variable o : Object | H.cs:153:32:153:32 | o : Object |
-| H.cs:164:22:164:22 | access to local variable o : Object | H.cs:153:32:153:32 | o : Object |
-| H.cs:164:22:164:22 | access to local variable o : Object | H.cs:164:19:164:19 | [post] access to local variable a [field FieldA, field FieldB] : Object |
 | H.cs:164:22:164:22 | access to local variable o : Object | H.cs:164:19:164:19 | [post] access to local variable a [field FieldA, field FieldB] : Object |
 | H.cs:165:17:165:27 | (...) ... : B | H.cs:166:14:166:14 | access to local variable b |
-| H.cs:165:17:165:27 | (...) ... : B | H.cs:166:14:166:14 | access to local variable b |
-| H.cs:165:17:165:27 | (...) ... [field FieldB] : Object | H.cs:167:14:167:14 | access to local variable b [field FieldB] : Object |
 | H.cs:165:17:165:27 | (...) ... [field FieldB] : Object | H.cs:167:14:167:14 | access to local variable b [field FieldB] : Object |
 | H.cs:165:20:165:20 | access to local variable a [field FieldA, field FieldB] : Object | H.cs:165:20:165:27 | access to field FieldA [field FieldB] : Object |
-| H.cs:165:20:165:20 | access to local variable a [field FieldA, field FieldB] : Object | H.cs:165:20:165:27 | access to field FieldA [field FieldB] : Object |
-| H.cs:165:20:165:20 | access to local variable a [field FieldA] : B | H.cs:165:20:165:27 | access to field FieldA : B |
 | H.cs:165:20:165:20 | access to local variable a [field FieldA] : B | H.cs:165:20:165:27 | access to field FieldA : B |
 | H.cs:165:20:165:27 | access to field FieldA : B | H.cs:165:17:165:27 | (...) ... : B |
-| H.cs:165:20:165:27 | access to field FieldA : B | H.cs:165:17:165:27 | (...) ... : B |
-| H.cs:165:20:165:27 | access to field FieldA [field FieldB] : Object | H.cs:165:17:165:27 | (...) ... [field FieldB] : Object |
 | H.cs:165:20:165:27 | access to field FieldA [field FieldB] : Object | H.cs:165:17:165:27 | (...) ... [field FieldB] : Object |
 | H.cs:167:14:167:14 | access to local variable b [field FieldB] : Object | H.cs:167:14:167:21 | access to field FieldB |
-| H.cs:167:14:167:14 | access to local variable b [field FieldB] : Object | H.cs:167:14:167:21 | access to field FieldB |
-| I.cs:7:9:7:14 | [post] this access [field Field1] : Object | I.cs:21:13:21:19 | object creation of type I [field Field1] : Object |
 | I.cs:7:9:7:14 | [post] this access [field Field1] : Object | I.cs:21:13:21:19 | object creation of type I [field Field1] : Object |
 | I.cs:7:9:7:14 | [post] this access [field Field1] : Object | I.cs:26:13:26:37 | [pre-initializer] object creation of type I [field Field1] : Object |
-| I.cs:7:9:7:14 | [post] this access [field Field1] : Object | I.cs:26:13:26:37 | [pre-initializer] object creation of type I [field Field1] : Object |
-| I.cs:7:18:7:34 | call to method Source<Object> : Object | I.cs:7:9:7:14 | [post] this access [field Field1] : Object |
 | I.cs:7:18:7:34 | call to method Source<Object> : Object | I.cs:7:9:7:14 | [post] this access [field Field1] : Object |
 | I.cs:13:17:13:33 | call to method Source<Object> : Object | I.cs:15:20:15:20 | access to local variable o : Object |
-| I.cs:13:17:13:33 | call to method Source<Object> : Object | I.cs:15:20:15:20 | access to local variable o : Object |
-| I.cs:15:9:15:9 | [post] access to local variable i [field Field1] : Object | I.cs:16:9:16:9 | access to local variable i [field Field1] : Object |
 | I.cs:15:9:15:9 | [post] access to local variable i [field Field1] : Object | I.cs:16:9:16:9 | access to local variable i [field Field1] : Object |
 | I.cs:15:20:15:20 | access to local variable o : Object | I.cs:15:9:15:9 | [post] access to local variable i [field Field1] : Object |
-| I.cs:15:20:15:20 | access to local variable o : Object | I.cs:15:9:15:9 | [post] access to local variable i [field Field1] : Object |
-| I.cs:16:9:16:9 | access to local variable i [field Field1] : Object | I.cs:17:9:17:9 | access to local variable i [field Field1] : Object |
 | I.cs:16:9:16:9 | access to local variable i [field Field1] : Object | I.cs:17:9:17:9 | access to local variable i [field Field1] : Object |
 | I.cs:17:9:17:9 | access to local variable i [field Field1] : Object | I.cs:18:14:18:14 | access to local variable i [field Field1] : Object |
-| I.cs:17:9:17:9 | access to local variable i [field Field1] : Object | I.cs:18:14:18:14 | access to local variable i [field Field1] : Object |
-| I.cs:18:14:18:14 | access to local variable i [field Field1] : Object | I.cs:18:14:18:21 | access to field Field1 |
 | I.cs:18:14:18:14 | access to local variable i [field Field1] : Object | I.cs:18:14:18:21 | access to field Field1 |
 | I.cs:21:13:21:19 | object creation of type I [field Field1] : Object | I.cs:22:9:22:9 | access to local variable i [field Field1] : Object |
-| I.cs:21:13:21:19 | object creation of type I [field Field1] : Object | I.cs:22:9:22:9 | access to local variable i [field Field1] : Object |
-| I.cs:22:9:22:9 | access to local variable i [field Field1] : Object | I.cs:23:14:23:14 | access to local variable i [field Field1] : Object |
 | I.cs:22:9:22:9 | access to local variable i [field Field1] : Object | I.cs:23:14:23:14 | access to local variable i [field Field1] : Object |
 | I.cs:23:14:23:14 | access to local variable i [field Field1] : Object | I.cs:23:14:23:21 | access to field Field1 |
-| I.cs:23:14:23:14 | access to local variable i [field Field1] : Object | I.cs:23:14:23:21 | access to field Field1 |
-| I.cs:26:13:26:37 | [pre-initializer] object creation of type I [field Field1] : Object | I.cs:27:14:27:14 | access to local variable i [field Field1] : Object |
 | I.cs:26:13:26:37 | [pre-initializer] object creation of type I [field Field1] : Object | I.cs:27:14:27:14 | access to local variable i [field Field1] : Object |
 | I.cs:27:14:27:14 | access to local variable i [field Field1] : Object | I.cs:27:14:27:21 | access to field Field1 |
-| I.cs:27:14:27:14 | access to local variable i [field Field1] : Object | I.cs:27:14:27:21 | access to field Field1 |
-| I.cs:31:13:31:29 | call to method Source<Object> : Object | I.cs:32:20:32:20 | access to local variable o : Object |
 | I.cs:31:13:31:29 | call to method Source<Object> : Object | I.cs:32:20:32:20 | access to local variable o : Object |
 | I.cs:32:9:32:9 | [post] access to local variable i [field Field1] : Object | I.cs:33:9:33:9 | access to local variable i [field Field1] : Object |
-| I.cs:32:9:32:9 | [post] access to local variable i [field Field1] : Object | I.cs:33:9:33:9 | access to local variable i [field Field1] : Object |
-| I.cs:32:20:32:20 | access to local variable o : Object | I.cs:32:9:32:9 | [post] access to local variable i [field Field1] : Object |
 | I.cs:32:20:32:20 | access to local variable o : Object | I.cs:32:9:32:9 | [post] access to local variable i [field Field1] : Object |
 | I.cs:33:9:33:9 | access to local variable i [field Field1] : Object | I.cs:34:12:34:12 | access to local variable i [field Field1] : Object |
-| I.cs:33:9:33:9 | access to local variable i [field Field1] : Object | I.cs:34:12:34:12 | access to local variable i [field Field1] : Object |
-| I.cs:34:12:34:12 | access to local variable i [field Field1] : Object | I.cs:37:23:37:23 | i [field Field1] : Object |
 | I.cs:34:12:34:12 | access to local variable i [field Field1] : Object | I.cs:37:23:37:23 | i [field Field1] : Object |
 | I.cs:37:23:37:23 | i [field Field1] : Object | I.cs:39:9:39:9 | access to parameter i [field Field1] : Object |
-| I.cs:37:23:37:23 | i [field Field1] : Object | I.cs:39:9:39:9 | access to parameter i [field Field1] : Object |
-| I.cs:39:9:39:9 | access to parameter i [field Field1] : Object | I.cs:40:14:40:14 | access to parameter i [field Field1] : Object |
 | I.cs:39:9:39:9 | access to parameter i [field Field1] : Object | I.cs:40:14:40:14 | access to parameter i [field Field1] : Object |
 | I.cs:40:14:40:14 | access to parameter i [field Field1] : Object | I.cs:40:14:40:21 | access to field Field1 |
-| I.cs:40:14:40:14 | access to parameter i [field Field1] : Object | I.cs:40:14:40:21 | access to field Field1 |
-| J.cs:14:26:14:30 | field : Object | J.cs:14:66:14:70 | access to parameter field : Object |
 | J.cs:14:26:14:30 | field : Object | J.cs:14:66:14:70 | access to parameter field : Object |
 | J.cs:14:40:14:43 | prop : Object | J.cs:14:73:14:76 | access to parameter prop : Object |
-| J.cs:14:40:14:43 | prop : Object | J.cs:14:73:14:76 | access to parameter prop : Object |
-| J.cs:14:66:14:70 | access to parameter field : Object | J.cs:14:50:14:54 | [post] this access [field Field] : Object |
 | J.cs:14:66:14:70 | access to parameter field : Object | J.cs:14:50:14:54 | [post] this access [field Field] : Object |
 | J.cs:14:73:14:76 | access to parameter prop : Object | J.cs:14:57:14:60 | [post] this access [property Prop] : Object |
-| J.cs:14:73:14:76 | access to parameter prop : Object | J.cs:14:57:14:60 | [post] this access [property Prop] : Object |
-| J.cs:21:17:21:33 | call to method Source<Object> : Object | J.cs:22:34:22:34 | access to local variable o : Object |
 | J.cs:21:17:21:33 | call to method Source<Object> : Object | J.cs:22:34:22:34 | access to local variable o : Object |
 | J.cs:22:18:22:41 | object creation of type RecordClass [property Prop1] : Object | J.cs:23:14:23:15 | access to local variable r1 [property Prop1] : Object |
-| J.cs:22:18:22:41 | object creation of type RecordClass [property Prop1] : Object | J.cs:23:14:23:15 | access to local variable r1 [property Prop1] : Object |
-| J.cs:22:18:22:41 | object creation of type RecordClass [property Prop1] : Object | J.cs:27:14:27:15 | access to local variable r2 [property Prop1] : Object |
 | J.cs:22:18:22:41 | object creation of type RecordClass [property Prop1] : Object | J.cs:27:14:27:15 | access to local variable r2 [property Prop1] : Object |
 | J.cs:22:18:22:41 | object creation of type RecordClass [property Prop1] : Object | J.cs:31:14:31:15 | access to local variable r3 [property Prop1] : Object |
-| J.cs:22:18:22:41 | object creation of type RecordClass [property Prop1] : Object | J.cs:31:14:31:15 | access to local variable r3 [property Prop1] : Object |
-| J.cs:22:34:22:34 | access to local variable o : Object | J.cs:22:18:22:41 | object creation of type RecordClass [property Prop1] : Object |
 | J.cs:22:34:22:34 | access to local variable o : Object | J.cs:22:18:22:41 | object creation of type RecordClass [property Prop1] : Object |
 | J.cs:23:14:23:15 | access to local variable r1 [property Prop1] : Object | J.cs:23:14:23:21 | access to property Prop1 |
-| J.cs:23:14:23:15 | access to local variable r1 [property Prop1] : Object | J.cs:23:14:23:21 | access to property Prop1 |
-| J.cs:27:14:27:15 | access to local variable r2 [property Prop1] : Object | J.cs:27:14:27:21 | access to property Prop1 |
 | J.cs:27:14:27:15 | access to local variable r2 [property Prop1] : Object | J.cs:27:14:27:21 | access to property Prop1 |
 | J.cs:30:18:30:54 | ... with { ... } [property Prop2] : Object | J.cs:32:14:32:15 | access to local variable r3 [property Prop2] : Object |
-| J.cs:30:18:30:54 | ... with { ... } [property Prop2] : Object | J.cs:32:14:32:15 | access to local variable r3 [property Prop2] : Object |
-| J.cs:30:36:30:52 | call to method Source<Object> : Object | J.cs:30:18:30:54 | ... with { ... } [property Prop2] : Object |
 | J.cs:30:36:30:52 | call to method Source<Object> : Object | J.cs:30:18:30:54 | ... with { ... } [property Prop2] : Object |
 | J.cs:31:14:31:15 | access to local variable r3 [property Prop1] : Object | J.cs:31:14:31:21 | access to property Prop1 |
-| J.cs:31:14:31:15 | access to local variable r3 [property Prop1] : Object | J.cs:31:14:31:21 | access to property Prop1 |
-| J.cs:32:14:32:15 | access to local variable r3 [property Prop2] : Object | J.cs:32:14:32:21 | access to property Prop2 |
 | J.cs:32:14:32:15 | access to local variable r3 [property Prop2] : Object | J.cs:32:14:32:21 | access to property Prop2 |
 | J.cs:41:17:41:33 | call to method Source<Object> : Object | J.cs:42:35:42:35 | access to local variable o : Object |
-| J.cs:41:17:41:33 | call to method Source<Object> : Object | J.cs:42:35:42:35 | access to local variable o : Object |
-| J.cs:42:18:42:42 | object creation of type RecordStruct [property Prop1] : Object | J.cs:43:14:43:15 | access to local variable r1 [property Prop1] : Object |
 | J.cs:42:18:42:42 | object creation of type RecordStruct [property Prop1] : Object | J.cs:43:14:43:15 | access to local variable r1 [property Prop1] : Object |
 | J.cs:42:18:42:42 | object creation of type RecordStruct [property Prop1] : Object | J.cs:47:14:47:15 | access to local variable r2 [property Prop1] : Object |
-| J.cs:42:18:42:42 | object creation of type RecordStruct [property Prop1] : Object | J.cs:47:14:47:15 | access to local variable r2 [property Prop1] : Object |
-| J.cs:42:18:42:42 | object creation of type RecordStruct [property Prop1] : Object | J.cs:51:14:51:15 | access to local variable r3 [property Prop1] : Object |
 | J.cs:42:18:42:42 | object creation of type RecordStruct [property Prop1] : Object | J.cs:51:14:51:15 | access to local variable r3 [property Prop1] : Object |
 | J.cs:42:35:42:35 | access to local variable o : Object | J.cs:42:18:42:42 | object creation of type RecordStruct [property Prop1] : Object |
-| J.cs:42:35:42:35 | access to local variable o : Object | J.cs:42:18:42:42 | object creation of type RecordStruct [property Prop1] : Object |
-| J.cs:43:14:43:15 | access to local variable r1 [property Prop1] : Object | J.cs:43:14:43:21 | access to property Prop1 |
 | J.cs:43:14:43:15 | access to local variable r1 [property Prop1] : Object | J.cs:43:14:43:21 | access to property Prop1 |
 | J.cs:47:14:47:15 | access to local variable r2 [property Prop1] : Object | J.cs:47:14:47:21 | access to property Prop1 |
-| J.cs:47:14:47:15 | access to local variable r2 [property Prop1] : Object | J.cs:47:14:47:21 | access to property Prop1 |
-| J.cs:50:18:50:54 | ... with { ... } [property Prop2] : Object | J.cs:52:14:52:15 | access to local variable r3 [property Prop2] : Object |
 | J.cs:50:18:50:54 | ... with { ... } [property Prop2] : Object | J.cs:52:14:52:15 | access to local variable r3 [property Prop2] : Object |
 | J.cs:50:36:50:52 | call to method Source<Object> : Object | J.cs:50:18:50:54 | ... with { ... } [property Prop2] : Object |
-| J.cs:50:36:50:52 | call to method Source<Object> : Object | J.cs:50:18:50:54 | ... with { ... } [property Prop2] : Object |
-| J.cs:51:14:51:15 | access to local variable r3 [property Prop1] : Object | J.cs:51:14:51:21 | access to property Prop1 |
 | J.cs:51:14:51:15 | access to local variable r3 [property Prop1] : Object | J.cs:51:14:51:21 | access to property Prop1 |
 | J.cs:52:14:52:15 | access to local variable r3 [property Prop2] : Object | J.cs:52:14:52:21 | access to property Prop2 |
-| J.cs:52:14:52:15 | access to local variable r3 [property Prop2] : Object | J.cs:52:14:52:21 | access to property Prop2 |
-| J.cs:61:17:61:33 | call to method Source<Object> : Object | J.cs:62:29:62:29 | access to local variable o : Object |
 | J.cs:61:17:61:33 | call to method Source<Object> : Object | J.cs:62:29:62:29 | access to local variable o : Object |
 | J.cs:62:18:62:36 | object creation of type Struct [field Field] : Object | J.cs:65:14:65:15 | access to local variable s2 [field Field] : Object |
-| J.cs:62:18:62:36 | object creation of type Struct [field Field] : Object | J.cs:65:14:65:15 | access to local variable s2 [field Field] : Object |
-| J.cs:62:18:62:36 | object creation of type Struct [field Field] : Object | J.cs:69:14:69:15 | access to local variable s3 [field Field] : Object |
 | J.cs:62:18:62:36 | object creation of type Struct [field Field] : Object | J.cs:69:14:69:15 | access to local variable s3 [field Field] : Object |
 | J.cs:62:29:62:29 | access to local variable o : Object | J.cs:14:26:14:30 | field : Object |
-| J.cs:62:29:62:29 | access to local variable o : Object | J.cs:14:26:14:30 | field : Object |
-| J.cs:62:29:62:29 | access to local variable o : Object | J.cs:62:18:62:36 | object creation of type Struct [field Field] : Object |
 | J.cs:62:29:62:29 | access to local variable o : Object | J.cs:62:18:62:36 | object creation of type Struct [field Field] : Object |
 | J.cs:65:14:65:15 | access to local variable s2 [field Field] : Object | J.cs:65:14:65:21 | access to field Field |
-| J.cs:65:14:65:15 | access to local variable s2 [field Field] : Object | J.cs:65:14:65:21 | access to field Field |
-| J.cs:68:18:68:53 | ... with { ... } [property Prop] : Object | J.cs:70:14:70:15 | access to local variable s3 [property Prop] : Object |
 | J.cs:68:18:68:53 | ... with { ... } [property Prop] : Object | J.cs:70:14:70:15 | access to local variable s3 [property Prop] : Object |
 | J.cs:68:35:68:51 | call to method Source<Object> : Object | J.cs:68:18:68:53 | ... with { ... } [property Prop] : Object |
-| J.cs:68:35:68:51 | call to method Source<Object> : Object | J.cs:68:18:68:53 | ... with { ... } [property Prop] : Object |
-| J.cs:69:14:69:15 | access to local variable s3 [field Field] : Object | J.cs:69:14:69:21 | access to field Field |
 | J.cs:69:14:69:15 | access to local variable s3 [field Field] : Object | J.cs:69:14:69:21 | access to field Field |
 | J.cs:70:14:70:15 | access to local variable s3 [property Prop] : Object | J.cs:70:14:70:20 | access to property Prop |
-| J.cs:70:14:70:15 | access to local variable s3 [property Prop] : Object | J.cs:70:14:70:20 | access to property Prop |
-| J.cs:79:17:79:33 | call to method Source<Object> : Object | J.cs:80:35:80:35 | access to local variable o : Object |
 | J.cs:79:17:79:33 | call to method Source<Object> : Object | J.cs:80:35:80:35 | access to local variable o : Object |
 | J.cs:80:18:80:36 | object creation of type Struct [property Prop] : Object | J.cs:84:14:84:15 | access to local variable s2 [property Prop] : Object |
-| J.cs:80:18:80:36 | object creation of type Struct [property Prop] : Object | J.cs:84:14:84:15 | access to local variable s2 [property Prop] : Object |
-| J.cs:80:18:80:36 | object creation of type Struct [property Prop] : Object | J.cs:88:14:88:15 | access to local variable s3 [property Prop] : Object |
 | J.cs:80:18:80:36 | object creation of type Struct [property Prop] : Object | J.cs:88:14:88:15 | access to local variable s3 [property Prop] : Object |
 | J.cs:80:35:80:35 | access to local variable o : Object | J.cs:14:40:14:43 | prop : Object |
-| J.cs:80:35:80:35 | access to local variable o : Object | J.cs:14:40:14:43 | prop : Object |
-| J.cs:80:35:80:35 | access to local variable o : Object | J.cs:80:18:80:36 | object creation of type Struct [property Prop] : Object |
 | J.cs:80:35:80:35 | access to local variable o : Object | J.cs:80:18:80:36 | object creation of type Struct [property Prop] : Object |
 | J.cs:84:14:84:15 | access to local variable s2 [property Prop] : Object | J.cs:84:14:84:20 | access to property Prop |
-| J.cs:84:14:84:15 | access to local variable s2 [property Prop] : Object | J.cs:84:14:84:20 | access to property Prop |
-| J.cs:86:18:86:54 | ... with { ... } [field Field] : Object | J.cs:87:14:87:15 | access to local variable s3 [field Field] : Object |
 | J.cs:86:18:86:54 | ... with { ... } [field Field] : Object | J.cs:87:14:87:15 | access to local variable s3 [field Field] : Object |
 | J.cs:86:36:86:52 | call to method Source<Object> : Object | J.cs:86:18:86:54 | ... with { ... } [field Field] : Object |
-| J.cs:86:36:86:52 | call to method Source<Object> : Object | J.cs:86:18:86:54 | ... with { ... } [field Field] : Object |
-| J.cs:87:14:87:15 | access to local variable s3 [field Field] : Object | J.cs:87:14:87:21 | access to field Field |
 | J.cs:87:14:87:15 | access to local variable s3 [field Field] : Object | J.cs:87:14:87:21 | access to field Field |
 | J.cs:88:14:88:15 | access to local variable s3 [property Prop] : Object | J.cs:88:14:88:20 | access to property Prop |
-| J.cs:88:14:88:15 | access to local variable s3 [property Prop] : Object | J.cs:88:14:88:20 | access to property Prop |
-| J.cs:97:17:97:33 | call to method Source<Object> : Object | J.cs:99:28:99:28 | access to local variable o : Object |
 | J.cs:97:17:97:33 | call to method Source<Object> : Object | J.cs:99:28:99:28 | access to local variable o : Object |
 | J.cs:99:18:99:41 | { ..., ... } [property X] : Object | J.cs:102:14:102:15 | access to local variable a2 [property X] : Object |
-| J.cs:99:18:99:41 | { ..., ... } [property X] : Object | J.cs:102:14:102:15 | access to local variable a2 [property X] : Object |
-| J.cs:99:18:99:41 | { ..., ... } [property X] : Object | J.cs:106:14:106:15 | access to local variable a3 [property X] : Object |
 | J.cs:99:18:99:41 | { ..., ... } [property X] : Object | J.cs:106:14:106:15 | access to local variable a3 [property X] : Object |
 | J.cs:99:28:99:28 | access to local variable o : Object | J.cs:99:18:99:41 | { ..., ... } [property X] : Object |
-| J.cs:99:28:99:28 | access to local variable o : Object | J.cs:99:18:99:41 | { ..., ... } [property X] : Object |
-| J.cs:102:14:102:15 | access to local variable a2 [property X] : Object | J.cs:102:14:102:17 | access to property X |
 | J.cs:102:14:102:15 | access to local variable a2 [property X] : Object | J.cs:102:14:102:17 | access to property X |
 | J.cs:105:18:105:50 | ... with { ... } [property Y] : Object | J.cs:107:14:107:15 | access to local variable a3 [property Y] : Object |
-| J.cs:105:18:105:50 | ... with { ... } [property Y] : Object | J.cs:107:14:107:15 | access to local variable a3 [property Y] : Object |
-| J.cs:105:32:105:48 | call to method Source<Object> : Object | J.cs:105:18:105:50 | ... with { ... } [property Y] : Object |
 | J.cs:105:32:105:48 | call to method Source<Object> : Object | J.cs:105:18:105:50 | ... with { ... } [property Y] : Object |
 | J.cs:106:14:106:15 | access to local variable a3 [property X] : Object | J.cs:106:14:106:17 | access to property X |
-| J.cs:106:14:106:15 | access to local variable a3 [property X] : Object | J.cs:106:14:106:17 | access to property X |
-| J.cs:107:14:107:15 | access to local variable a3 [property Y] : Object | J.cs:107:14:107:17 | access to property Y |
 | J.cs:107:14:107:15 | access to local variable a3 [property Y] : Object | J.cs:107:14:107:17 | access to property Y |
 | J.cs:119:13:119:13 | [post] access to local variable a [element] : Int32 | J.cs:125:14:125:14 | access to local variable a [element] : Int32 |
-| J.cs:119:13:119:13 | [post] access to local variable a [element] : Int32 | J.cs:125:14:125:14 | access to local variable a [element] : Int32 |
-| J.cs:119:20:119:34 | call to method Source<Int32> : Int32 | J.cs:119:13:119:13 | [post] access to local variable a [element] : Int32 |
 | J.cs:119:20:119:34 | call to method Source<Int32> : Int32 | J.cs:119:13:119:13 | [post] access to local variable a [element] : Int32 |
 | J.cs:125:14:125:14 | access to local variable a [element] : Int32 | J.cs:125:14:125:17 | access to array element : Int32 |
-| J.cs:125:14:125:14 | access to local variable a [element] : Int32 | J.cs:125:14:125:17 | access to array element : Int32 |
-| J.cs:125:14:125:17 | access to array element : Int32 | J.cs:125:14:125:17 | (...) ... |
 | J.cs:125:14:125:17 | access to array element : Int32 | J.cs:125:14:125:17 | (...) ... |
 nodes
 | A.cs:5:17:5:28 | call to method Source<C> : C | semmle.label | call to method Source<C> : C |
-| A.cs:5:17:5:28 | call to method Source<C> : C | semmle.label | call to method Source<C> : C |
-| A.cs:6:17:6:25 | call to method Make [field c] : C | semmle.label | call to method Make [field c] : C |
 | A.cs:6:17:6:25 | call to method Make [field c] : C | semmle.label | call to method Make [field c] : C |
 | A.cs:6:24:6:24 | access to local variable c : C | semmle.label | access to local variable c : C |
-| A.cs:6:24:6:24 | access to local variable c : C | semmle.label | access to local variable c : C |
-| A.cs:7:14:7:14 | access to local variable b [field c] : C | semmle.label | access to local variable b [field c] : C |
 | A.cs:7:14:7:14 | access to local variable b [field c] : C | semmle.label | access to local variable b [field c] : C |
 | A.cs:7:14:7:16 | access to field c | semmle.label | access to field c |
-| A.cs:7:14:7:16 | access to field c | semmle.label | access to field c |
-| A.cs:13:9:13:9 | [post] access to local variable b [field c] : C1 | semmle.label | [post] access to local variable b [field c] : C1 |
 | A.cs:13:9:13:9 | [post] access to local variable b [field c] : C1 | semmle.label | [post] access to local variable b [field c] : C1 |
 | A.cs:13:15:13:29 | call to method Source<C1> : C1 | semmle.label | call to method Source<C1> : C1 |
-| A.cs:13:15:13:29 | call to method Source<C1> : C1 | semmle.label | call to method Source<C1> : C1 |
-| A.cs:14:14:14:14 | access to local variable b [field c] : C1 | semmle.label | access to local variable b [field c] : C1 |
 | A.cs:14:14:14:14 | access to local variable b [field c] : C1 | semmle.label | access to local variable b [field c] : C1 |
 | A.cs:14:14:14:20 | call to method Get | semmle.label | call to method Get |
-| A.cs:14:14:14:20 | call to method Get | semmle.label | call to method Get |
-| A.cs:15:14:15:42 | call to method Get | semmle.label | call to method Get |
 | A.cs:15:14:15:42 | call to method Get | semmle.label | call to method Get |
 | A.cs:15:15:15:35 | object creation of type B [field c] : C | semmle.label | object creation of type B [field c] : C |
-| A.cs:15:15:15:35 | object creation of type B [field c] : C | semmle.label | object creation of type B [field c] : C |
-| A.cs:15:21:15:34 | call to method Source<C> : C | semmle.label | call to method Source<C> : C |
 | A.cs:15:21:15:34 | call to method Source<C> : C | semmle.label | call to method Source<C> : C |
 | A.cs:22:14:22:38 | call to method SetOnB [field c] : C2 | semmle.label | call to method SetOnB [field c] : C2 |
-| A.cs:22:14:22:38 | call to method SetOnB [field c] : C2 | semmle.label | call to method SetOnB [field c] : C2 |
-| A.cs:22:25:22:37 | call to method Source<C2> : C2 | semmle.label | call to method Source<C2> : C2 |
 | A.cs:22:25:22:37 | call to method Source<C2> : C2 | semmle.label | call to method Source<C2> : C2 |
 | A.cs:24:14:24:15 | access to local variable b2 [field c] : C2 | semmle.label | access to local variable b2 [field c] : C2 |
-| A.cs:24:14:24:15 | access to local variable b2 [field c] : C2 | semmle.label | access to local variable b2 [field c] : C2 |
-| A.cs:24:14:24:17 | access to field c | semmle.label | access to field c |
 | A.cs:24:14:24:17 | access to field c | semmle.label | access to field c |
 | A.cs:31:14:31:42 | call to method SetOnBWrap [field c] : C2 | semmle.label | call to method SetOnBWrap [field c] : C2 |
-| A.cs:31:14:31:42 | call to method SetOnBWrap [field c] : C2 | semmle.label | call to method SetOnBWrap [field c] : C2 |
-| A.cs:31:29:31:41 | call to method Source<C2> : C2 | semmle.label | call to method Source<C2> : C2 |
 | A.cs:31:29:31:41 | call to method Source<C2> : C2 | semmle.label | call to method Source<C2> : C2 |
 | A.cs:33:14:33:15 | access to local variable b2 [field c] : C2 | semmle.label | access to local variable b2 [field c] : C2 |
-| A.cs:33:14:33:15 | access to local variable b2 [field c] : C2 | semmle.label | access to local variable b2 [field c] : C2 |
-| A.cs:33:14:33:17 | access to field c | semmle.label | access to field c |
 | A.cs:33:14:33:17 | access to field c | semmle.label | access to field c |
 | A.cs:36:33:36:33 | c : C2 | semmle.label | c : C2 |
-| A.cs:36:33:36:33 | c : C2 | semmle.label | c : C2 |
-| A.cs:38:18:38:30 | call to method SetOnB [field c] : C2 | semmle.label | call to method SetOnB [field c] : C2 |
 | A.cs:38:18:38:30 | call to method SetOnB [field c] : C2 | semmle.label | call to method SetOnB [field c] : C2 |
 | A.cs:38:29:38:29 | access to parameter c : C2 | semmle.label | access to parameter c : C2 |
-| A.cs:38:29:38:29 | access to parameter c : C2 | semmle.label | access to parameter c : C2 |
-| A.cs:39:16:39:28 | ... ? ... : ... [field c] : C2 | semmle.label | ... ? ... : ... [field c] : C2 |
 | A.cs:39:16:39:28 | ... ? ... : ... [field c] : C2 | semmle.label | ... ? ... : ... [field c] : C2 |
 | A.cs:42:29:42:29 | c : C2 | semmle.label | c : C2 |
-| A.cs:42:29:42:29 | c : C2 | semmle.label | c : C2 |
-| A.cs:47:13:47:14 | [post] access to local variable b2 [field c] : C2 | semmle.label | [post] access to local variable b2 [field c] : C2 |
 | A.cs:47:13:47:14 | [post] access to local variable b2 [field c] : C2 | semmle.label | [post] access to local variable b2 [field c] : C2 |
 | A.cs:47:20:47:20 | access to parameter c : C2 | semmle.label | access to parameter c : C2 |
-| A.cs:47:20:47:20 | access to parameter c : C2 | semmle.label | access to parameter c : C2 |
-| A.cs:48:20:48:21 | access to local variable b2 [field c] : C2 | semmle.label | access to local variable b2 [field c] : C2 |
 | A.cs:48:20:48:21 | access to local variable b2 [field c] : C2 | semmle.label | access to local variable b2 [field c] : C2 |
 | A.cs:55:17:55:28 | call to method Source<A> : A | semmle.label | call to method Source<A> : A |
-| A.cs:55:17:55:28 | call to method Source<A> : A | semmle.label | call to method Source<A> : A |
-| A.cs:57:9:57:10 | [post] access to local variable c1 [field a] : A | semmle.label | [post] access to local variable c1 [field a] : A |
 | A.cs:57:9:57:10 | [post] access to local variable c1 [field a] : A | semmle.label | [post] access to local variable c1 [field a] : A |
 | A.cs:57:16:57:16 | access to local variable a : A | semmle.label | access to local variable a : A |
-| A.cs:57:16:57:16 | access to local variable a : A | semmle.label | access to local variable a : A |
-| A.cs:58:12:58:13 | access to local variable c1 [field a] : A | semmle.label | access to local variable c1 [field a] : A |
 | A.cs:58:12:58:13 | access to local variable c1 [field a] : A | semmle.label | access to local variable c1 [field a] : A |
 | A.cs:60:22:60:22 | c [field a] : A | semmle.label | c [field a] : A |
-| A.cs:60:22:60:22 | c [field a] : A | semmle.label | c [field a] : A |
-| A.cs:64:18:64:26 | access to field a | semmle.label | access to field a |
 | A.cs:64:18:64:26 | access to field a | semmle.label | access to field a |
 | A.cs:64:19:64:23 | (...) ... [field a] : A | semmle.label | (...) ... [field a] : A |
-| A.cs:64:19:64:23 | (...) ... [field a] : A | semmle.label | (...) ... [field a] : A |
-| A.cs:83:9:83:9 | [post] access to parameter b [field c] : C | semmle.label | [post] access to parameter b [field c] : C |
 | A.cs:83:9:83:9 | [post] access to parameter b [field c] : C | semmle.label | [post] access to parameter b [field c] : C |
 | A.cs:83:15:83:26 | call to method Source<C> : C | semmle.label | call to method Source<C> : C |
-| A.cs:83:15:83:26 | call to method Source<C> : C | semmle.label | call to method Source<C> : C |
-| A.cs:88:12:88:12 | [post] access to local variable b [field c] : C | semmle.label | [post] access to local variable b [field c] : C |
 | A.cs:88:12:88:12 | [post] access to local variable b [field c] : C | semmle.label | [post] access to local variable b [field c] : C |
 | A.cs:89:14:89:14 | access to local variable b [field c] : C | semmle.label | access to local variable b [field c] : C |
-| A.cs:89:14:89:14 | access to local variable b [field c] : C | semmle.label | access to local variable b [field c] : C |
-| A.cs:89:14:89:16 | access to field c | semmle.label | access to field c |
 | A.cs:89:14:89:16 | access to field c | semmle.label | access to field c |
 | A.cs:95:20:95:20 | b : B | semmle.label | b : B |
-| A.cs:95:20:95:20 | b : B | semmle.label | b : B |
-| A.cs:97:13:97:13 | [post] access to parameter b [field c] : C | semmle.label | [post] access to parameter b [field c] : C |
 | A.cs:97:13:97:13 | [post] access to parameter b [field c] : C | semmle.label | [post] access to parameter b [field c] : C |
 | A.cs:97:13:97:13 | access to parameter b : B | semmle.label | access to parameter b : B |
-| A.cs:97:13:97:13 | access to parameter b : B | semmle.label | access to parameter b : B |
-| A.cs:97:19:97:32 | call to method Source<C> : C | semmle.label | call to method Source<C> : C |
 | A.cs:97:19:97:32 | call to method Source<C> : C | semmle.label | call to method Source<C> : C |
 | A.cs:98:13:98:16 | [post] this access [field b, field c] : C | semmle.label | [post] this access [field b, field c] : C |
-| A.cs:98:13:98:16 | [post] this access [field b, field c] : C | semmle.label | [post] this access [field b, field c] : C |
 | A.cs:98:13:98:16 | [post] this access [field b] : B | semmle.label | [post] this access [field b] : B |
 | A.cs:98:13:98:16 | [post] this access [field b] : B | semmle.label | [post] this access [field b] : B |
-| A.cs:98:13:98:16 | [post] this access [field b] : B | semmle.label | [post] this access [field b] : B |
-| A.cs:98:13:98:16 | [post] this access [field b] : B | semmle.label | [post] this access [field b] : B |
-| A.cs:98:22:98:43 | ... ? ... : ... : B | semmle.label | ... ? ... : ... : B |
-| A.cs:98:22:98:43 | ... ? ... : ... : B | semmle.label | ... ? ... : ... : B |
 | A.cs:98:22:98:43 | ... ? ... : ... : B | semmle.label | ... ? ... : ... : B |
 | A.cs:98:22:98:43 | ... ? ... : ... : B | semmle.label | ... ? ... : ... : B |
 | A.cs:98:22:98:43 | ... ? ... : ... [field c] : C | semmle.label | ... ? ... : ... [field c] : C |
-| A.cs:98:22:98:43 | ... ? ... : ... [field c] : C | semmle.label | ... ? ... : ... [field c] : C |
-| A.cs:98:30:98:43 | call to method Source<B> : B | semmle.label | call to method Source<B> : B |
 | A.cs:98:30:98:43 | call to method Source<B> : B | semmle.label | call to method Source<B> : B |
 | A.cs:104:17:104:30 | call to method Source<B> : B | semmle.label | call to method Source<B> : B |
-| A.cs:104:17:104:30 | call to method Source<B> : B | semmle.label | call to method Source<B> : B |
-| A.cs:105:17:105:29 | object creation of type D [field b, field c] : C | semmle.label | object creation of type D [field b, field c] : C |
 | A.cs:105:17:105:29 | object creation of type D [field b, field c] : C | semmle.label | object creation of type D [field b, field c] : C |
 | A.cs:105:17:105:29 | object creation of type D [field b] : B | semmle.label | object creation of type D [field b] : B |
-| A.cs:105:17:105:29 | object creation of type D [field b] : B | semmle.label | object creation of type D [field b] : B |
-| A.cs:105:23:105:23 | [post] access to local variable b [field c] : C | semmle.label | [post] access to local variable b [field c] : C |
 | A.cs:105:23:105:23 | [post] access to local variable b [field c] : C | semmle.label | [post] access to local variable b [field c] : C |
 | A.cs:105:23:105:23 | access to local variable b : B | semmle.label | access to local variable b : B |
-| A.cs:105:23:105:23 | access to local variable b : B | semmle.label | access to local variable b : B |
-| A.cs:106:14:106:14 | access to local variable d [field b] : B | semmle.label | access to local variable d [field b] : B |
 | A.cs:106:14:106:14 | access to local variable d [field b] : B | semmle.label | access to local variable d [field b] : B |
 | A.cs:106:14:106:16 | access to field b | semmle.label | access to field b |
-| A.cs:106:14:106:16 | access to field b | semmle.label | access to field b |
-| A.cs:107:14:107:14 | access to local variable d [field b, field c] : C | semmle.label | access to local variable d [field b, field c] : C |
 | A.cs:107:14:107:14 | access to local variable d [field b, field c] : C | semmle.label | access to local variable d [field b, field c] : C |
 | A.cs:107:14:107:16 | access to field b [field c] : C | semmle.label | access to field b [field c] : C |
-| A.cs:107:14:107:16 | access to field b [field c] : C | semmle.label | access to field b [field c] : C |
-| A.cs:107:14:107:18 | access to field c | semmle.label | access to field c |
 | A.cs:107:14:107:18 | access to field c | semmle.label | access to field c |
 | A.cs:108:14:108:14 | access to local variable b [field c] : C | semmle.label | access to local variable b [field c] : C |
-| A.cs:108:14:108:14 | access to local variable b [field c] : C | semmle.label | access to local variable b [field c] : C |
-| A.cs:108:14:108:16 | access to field c | semmle.label | access to field c |
 | A.cs:108:14:108:16 | access to field c | semmle.label | access to field c |
 | A.cs:113:17:113:29 | call to method Source<B> : B | semmle.label | call to method Source<B> : B |
-| A.cs:113:17:113:29 | call to method Source<B> : B | semmle.label | call to method Source<B> : B |
-| A.cs:114:18:114:54 | object creation of type MyList [field head] : B | semmle.label | object creation of type MyList [field head] : B |
 | A.cs:114:18:114:54 | object creation of type MyList [field head] : B | semmle.label | object creation of type MyList [field head] : B |
 | A.cs:114:29:114:29 | access to local variable b : B | semmle.label | access to local variable b : B |
-| A.cs:114:29:114:29 | access to local variable b : B | semmle.label | access to local variable b : B |
-| A.cs:115:18:115:37 | object creation of type MyList [field next, field head] : B | semmle.label | object creation of type MyList [field next, field head] : B |
 | A.cs:115:18:115:37 | object creation of type MyList [field next, field head] : B | semmle.label | object creation of type MyList [field next, field head] : B |
 | A.cs:115:35:115:36 | access to local variable l1 [field head] : B | semmle.label | access to local variable l1 [field head] : B |
-| A.cs:115:35:115:36 | access to local variable l1 [field head] : B | semmle.label | access to local variable l1 [field head] : B |
-| A.cs:116:18:116:37 | object creation of type MyList [field next, field next, field head] : B | semmle.label | object creation of type MyList [field next, field next, field head] : B |
 | A.cs:116:18:116:37 | object creation of type MyList [field next, field next, field head] : B | semmle.label | object creation of type MyList [field next, field next, field head] : B |
 | A.cs:116:35:116:36 | access to local variable l2 [field next, field head] : B | semmle.label | access to local variable l2 [field next, field head] : B |
-| A.cs:116:35:116:36 | access to local variable l2 [field next, field head] : B | semmle.label | access to local variable l2 [field next, field head] : B |
-| A.cs:119:14:119:15 | access to local variable l3 [field next, field next, field head] : B | semmle.label | access to local variable l3 [field next, field next, field head] : B |
 | A.cs:119:14:119:15 | access to local variable l3 [field next, field next, field head] : B | semmle.label | access to local variable l3 [field next, field next, field head] : B |
 | A.cs:119:14:119:20 | access to field next [field next, field head] : B | semmle.label | access to field next [field next, field head] : B |
-| A.cs:119:14:119:20 | access to field next [field next, field head] : B | semmle.label | access to field next [field next, field head] : B |
-| A.cs:119:14:119:25 | access to field next [field head] : B | semmle.label | access to field next [field head] : B |
 | A.cs:119:14:119:25 | access to field next [field head] : B | semmle.label | access to field next [field head] : B |
 | A.cs:119:14:119:30 | access to field head | semmle.label | access to field head |
-| A.cs:119:14:119:30 | access to field head | semmle.label | access to field head |
-| A.cs:121:41:121:41 | access to local variable l [field next, field head] : B | semmle.label | access to local variable l [field next, field head] : B |
 | A.cs:121:41:121:41 | access to local variable l [field next, field head] : B | semmle.label | access to local variable l [field next, field head] : B |
 | A.cs:121:41:121:41 | access to local variable l [field next, field next, field head] : B | semmle.label | access to local variable l [field next, field next, field head] : B |
-| A.cs:121:41:121:41 | access to local variable l [field next, field next, field head] : B | semmle.label | access to local variable l [field next, field next, field head] : B |
-| A.cs:121:41:121:46 | access to field next [field head] : B | semmle.label | access to field next [field head] : B |
 | A.cs:121:41:121:46 | access to field next [field head] : B | semmle.label | access to field next [field head] : B |
 | A.cs:121:41:121:46 | access to field next [field next, field head] : B | semmle.label | access to field next [field next, field head] : B |
-| A.cs:121:41:121:46 | access to field next [field next, field head] : B | semmle.label | access to field next [field next, field head] : B |
-| A.cs:123:18:123:18 | access to local variable l [field head] : B | semmle.label | access to local variable l [field head] : B |
 | A.cs:123:18:123:18 | access to local variable l [field head] : B | semmle.label | access to local variable l [field head] : B |
 | A.cs:123:18:123:23 | access to field head | semmle.label | access to field head |
-| A.cs:123:18:123:23 | access to field head | semmle.label | access to field head |
-| A.cs:141:20:141:20 | c : C | semmle.label | c : C |
 | A.cs:141:20:141:20 | c : C | semmle.label | c : C |
 | A.cs:143:13:143:16 | [post] this access [field c] : C | semmle.label | [post] this access [field c] : C |
-| A.cs:143:13:143:16 | [post] this access [field c] : C | semmle.label | [post] this access [field c] : C |
-| A.cs:143:22:143:22 | access to parameter c : C | semmle.label | access to parameter c : C |
 | A.cs:143:22:143:22 | access to parameter c : C | semmle.label | access to parameter c : C |
 | A.cs:145:27:145:27 | c : C | semmle.label | c : C |
-| A.cs:145:27:145:27 | c : C | semmle.label | c : C |
-| A.cs:145:27:145:27 | c : C1 | semmle.label | c : C1 |
 | A.cs:145:27:145:27 | c : C1 | semmle.label | c : C1 |
 | A.cs:145:27:145:27 | c : C2 | semmle.label | c : C2 |
-| A.cs:145:27:145:27 | c : C2 | semmle.label | c : C2 |
-| A.cs:145:32:145:35 | [post] this access [field c] : C | semmle.label | [post] this access [field c] : C |
 | A.cs:145:32:145:35 | [post] this access [field c] : C | semmle.label | [post] this access [field c] : C |
 | A.cs:145:32:145:35 | [post] this access [field c] : C1 | semmle.label | [post] this access [field c] : C1 |
-| A.cs:145:32:145:35 | [post] this access [field c] : C1 | semmle.label | [post] this access [field c] : C1 |
-| A.cs:145:32:145:35 | [post] this access [field c] : C2 | semmle.label | [post] this access [field c] : C2 |
 | A.cs:145:32:145:35 | [post] this access [field c] : C2 | semmle.label | [post] this access [field c] : C2 |
 | A.cs:145:41:145:41 | access to parameter c : C | semmle.label | access to parameter c : C |
-| A.cs:145:41:145:41 | access to parameter c : C | semmle.label | access to parameter c : C |
-| A.cs:145:41:145:41 | access to parameter c : C1 | semmle.label | access to parameter c : C1 |
 | A.cs:145:41:145:41 | access to parameter c : C1 | semmle.label | access to parameter c : C1 |
 | A.cs:145:41:145:41 | access to parameter c : C2 | semmle.label | access to parameter c : C2 |
-| A.cs:145:41:145:41 | access to parameter c : C2 | semmle.label | access to parameter c : C2 |
-| A.cs:146:18:146:20 | this [field c] : C | semmle.label | this [field c] : C |
 | A.cs:146:18:146:20 | this [field c] : C | semmle.label | this [field c] : C |
 | A.cs:146:18:146:20 | this [field c] : C1 | semmle.label | this [field c] : C1 |
-| A.cs:146:18:146:20 | this [field c] : C1 | semmle.label | this [field c] : C1 |
-| A.cs:146:33:146:36 | this access [field c] : C | semmle.label | this access [field c] : C |
 | A.cs:146:33:146:36 | this access [field c] : C | semmle.label | this access [field c] : C |
 | A.cs:146:33:146:36 | this access [field c] : C1 | semmle.label | this access [field c] : C1 |
-| A.cs:146:33:146:36 | this access [field c] : C1 | semmle.label | this access [field c] : C1 |
-| A.cs:146:33:146:38 | access to field c : C | semmle.label | access to field c : C |
 | A.cs:146:33:146:38 | access to field c : C | semmle.label | access to field c : C |
 | A.cs:146:33:146:38 | access to field c : C1 | semmle.label | access to field c : C1 |
-| A.cs:146:33:146:38 | access to field c : C1 | semmle.label | access to field c : C1 |
-| A.cs:147:32:147:32 | c : C | semmle.label | c : C |
 | A.cs:147:32:147:32 | c : C | semmle.label | c : C |
 | A.cs:149:20:149:27 | object creation of type B [field c] : C | semmle.label | object creation of type B [field c] : C |
-| A.cs:149:20:149:27 | object creation of type B [field c] : C | semmle.label | object creation of type B [field c] : C |
-| A.cs:149:26:149:26 | access to parameter c : C | semmle.label | access to parameter c : C |
 | A.cs:149:26:149:26 | access to parameter c : C | semmle.label | access to parameter c : C |
 | A.cs:157:25:157:28 | head : B | semmle.label | head : B |
-| A.cs:157:25:157:28 | head : B | semmle.label | head : B |
-| A.cs:157:38:157:41 | next [field head] : B | semmle.label | next [field head] : B |
 | A.cs:157:38:157:41 | next [field head] : B | semmle.label | next [field head] : B |
 | A.cs:157:38:157:41 | next [field next, field head] : B | semmle.label | next [field next, field head] : B |
-| A.cs:157:38:157:41 | next [field next, field head] : B | semmle.label | next [field next, field head] : B |
-| A.cs:159:13:159:16 | [post] this access [field head] : B | semmle.label | [post] this access [field head] : B |
 | A.cs:159:13:159:16 | [post] this access [field head] : B | semmle.label | [post] this access [field head] : B |
 | A.cs:159:25:159:28 | access to parameter head : B | semmle.label | access to parameter head : B |
-| A.cs:159:25:159:28 | access to parameter head : B | semmle.label | access to parameter head : B |
-| A.cs:160:13:160:16 | [post] this access [field next, field head] : B | semmle.label | [post] this access [field next, field head] : B |
 | A.cs:160:13:160:16 | [post] this access [field next, field head] : B | semmle.label | [post] this access [field next, field head] : B |
 | A.cs:160:13:160:16 | [post] this access [field next, field next, field head] : B | semmle.label | [post] this access [field next, field next, field head] : B |
-| A.cs:160:13:160:16 | [post] this access [field next, field next, field head] : B | semmle.label | [post] this access [field next, field next, field head] : B |
-| A.cs:160:25:160:28 | access to parameter next [field head] : B | semmle.label | access to parameter next [field head] : B |
 | A.cs:160:25:160:28 | access to parameter next [field head] : B | semmle.label | access to parameter next [field head] : B |
 | A.cs:160:25:160:28 | access to parameter next [field next, field head] : B | semmle.label | access to parameter next [field next, field head] : B |
-| A.cs:160:25:160:28 | access to parameter next [field next, field head] : B | semmle.label | access to parameter next [field next, field head] : B |
-| B.cs:5:17:5:31 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
 | B.cs:5:17:5:31 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
 | B.cs:6:18:6:34 | object creation of type Box1 [field elem1] : Elem | semmle.label | object creation of type Box1 [field elem1] : Elem |
-| B.cs:6:18:6:34 | object creation of type Box1 [field elem1] : Elem | semmle.label | object creation of type Box1 [field elem1] : Elem |
-| B.cs:6:27:6:27 | access to local variable e : Elem | semmle.label | access to local variable e : Elem |
 | B.cs:6:27:6:27 | access to local variable e : Elem | semmle.label | access to local variable e : Elem |
 | B.cs:7:18:7:29 | object creation of type Box2 [field box1, field elem1] : Elem | semmle.label | object creation of type Box2 [field box1, field elem1] : Elem |
-| B.cs:7:18:7:29 | object creation of type Box2 [field box1, field elem1] : Elem | semmle.label | object creation of type Box2 [field box1, field elem1] : Elem |
-| B.cs:7:27:7:28 | access to local variable b1 [field elem1] : Elem | semmle.label | access to local variable b1 [field elem1] : Elem |
 | B.cs:7:27:7:28 | access to local variable b1 [field elem1] : Elem | semmle.label | access to local variable b1 [field elem1] : Elem |
 | B.cs:8:14:8:15 | access to local variable b2 [field box1, field elem1] : Elem | semmle.label | access to local variable b2 [field box1, field elem1] : Elem |
-| B.cs:8:14:8:15 | access to local variable b2 [field box1, field elem1] : Elem | semmle.label | access to local variable b2 [field box1, field elem1] : Elem |
-| B.cs:8:14:8:20 | access to field box1 [field elem1] : Elem | semmle.label | access to field box1 [field elem1] : Elem |
 | B.cs:8:14:8:20 | access to field box1 [field elem1] : Elem | semmle.label | access to field box1 [field elem1] : Elem |
 | B.cs:8:14:8:26 | access to field elem1 | semmle.label | access to field elem1 |
-| B.cs:8:14:8:26 | access to field elem1 | semmle.label | access to field elem1 |
-| B.cs:14:17:14:31 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
 | B.cs:14:17:14:31 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
 | B.cs:15:18:15:34 | object creation of type Box1 [field elem2] : Elem | semmle.label | object creation of type Box1 [field elem2] : Elem |
-| B.cs:15:18:15:34 | object creation of type Box1 [field elem2] : Elem | semmle.label | object creation of type Box1 [field elem2] : Elem |
-| B.cs:15:33:15:33 | access to local variable e : Elem | semmle.label | access to local variable e : Elem |
 | B.cs:15:33:15:33 | access to local variable e : Elem | semmle.label | access to local variable e : Elem |
 | B.cs:16:18:16:29 | object creation of type Box2 [field box1, field elem2] : Elem | semmle.label | object creation of type Box2 [field box1, field elem2] : Elem |
-| B.cs:16:18:16:29 | object creation of type Box2 [field box1, field elem2] : Elem | semmle.label | object creation of type Box2 [field box1, field elem2] : Elem |
-| B.cs:16:27:16:28 | access to local variable b1 [field elem2] : Elem | semmle.label | access to local variable b1 [field elem2] : Elem |
 | B.cs:16:27:16:28 | access to local variable b1 [field elem2] : Elem | semmle.label | access to local variable b1 [field elem2] : Elem |
 | B.cs:18:14:18:15 | access to local variable b2 [field box1, field elem2] : Elem | semmle.label | access to local variable b2 [field box1, field elem2] : Elem |
-| B.cs:18:14:18:15 | access to local variable b2 [field box1, field elem2] : Elem | semmle.label | access to local variable b2 [field box1, field elem2] : Elem |
-| B.cs:18:14:18:20 | access to field box1 [field elem2] : Elem | semmle.label | access to field box1 [field elem2] : Elem |
 | B.cs:18:14:18:20 | access to field box1 [field elem2] : Elem | semmle.label | access to field box1 [field elem2] : Elem |
 | B.cs:18:14:18:26 | access to field elem2 | semmle.label | access to field elem2 |
-| B.cs:18:14:18:26 | access to field elem2 | semmle.label | access to field elem2 |
-| B.cs:29:26:29:27 | e1 : Elem | semmle.label | e1 : Elem |
 | B.cs:29:26:29:27 | e1 : Elem | semmle.label | e1 : Elem |
 | B.cs:29:35:29:36 | e2 : Elem | semmle.label | e2 : Elem |
-| B.cs:29:35:29:36 | e2 : Elem | semmle.label | e2 : Elem |
-| B.cs:31:13:31:16 | [post] this access [field elem1] : Elem | semmle.label | [post] this access [field elem1] : Elem |
 | B.cs:31:13:31:16 | [post] this access [field elem1] : Elem | semmle.label | [post] this access [field elem1] : Elem |
 | B.cs:31:26:31:27 | access to parameter e1 : Elem | semmle.label | access to parameter e1 : Elem |
-| B.cs:31:26:31:27 | access to parameter e1 : Elem | semmle.label | access to parameter e1 : Elem |
-| B.cs:32:13:32:16 | [post] this access [field elem2] : Elem | semmle.label | [post] this access [field elem2] : Elem |
 | B.cs:32:13:32:16 | [post] this access [field elem2] : Elem | semmle.label | [post] this access [field elem2] : Elem |
 | B.cs:32:26:32:27 | access to parameter e2 : Elem | semmle.label | access to parameter e2 : Elem |
-| B.cs:32:26:32:27 | access to parameter e2 : Elem | semmle.label | access to parameter e2 : Elem |
-| B.cs:39:26:39:27 | b1 [field elem1] : Elem | semmle.label | b1 [field elem1] : Elem |
 | B.cs:39:26:39:27 | b1 [field elem1] : Elem | semmle.label | b1 [field elem1] : Elem |
 | B.cs:39:26:39:27 | b1 [field elem2] : Elem | semmle.label | b1 [field elem2] : Elem |
-| B.cs:39:26:39:27 | b1 [field elem2] : Elem | semmle.label | b1 [field elem2] : Elem |
-| B.cs:41:13:41:16 | [post] this access [field box1, field elem1] : Elem | semmle.label | [post] this access [field box1, field elem1] : Elem |
 | B.cs:41:13:41:16 | [post] this access [field box1, field elem1] : Elem | semmle.label | [post] this access [field box1, field elem1] : Elem |
 | B.cs:41:13:41:16 | [post] this access [field box1, field elem2] : Elem | semmle.label | [post] this access [field box1, field elem2] : Elem |
-| B.cs:41:13:41:16 | [post] this access [field box1, field elem2] : Elem | semmle.label | [post] this access [field box1, field elem2] : Elem |
-| B.cs:41:25:41:26 | access to parameter b1 [field elem1] : Elem | semmle.label | access to parameter b1 [field elem1] : Elem |
 | B.cs:41:25:41:26 | access to parameter b1 [field elem1] : Elem | semmle.label | access to parameter b1 [field elem1] : Elem |
 | B.cs:41:25:41:26 | access to parameter b1 [field elem2] : Elem | semmle.label | access to parameter b1 [field elem2] : Elem |
-| B.cs:41:25:41:26 | access to parameter b1 [field elem2] : Elem | semmle.label | access to parameter b1 [field elem2] : Elem |
-| C.cs:3:18:3:19 | [post] this access [field s1] : Elem | semmle.label | [post] this access [field s1] : Elem |
 | C.cs:3:18:3:19 | [post] this access [field s1] : Elem | semmle.label | [post] this access [field s1] : Elem |
 | C.cs:3:23:3:37 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
-| C.cs:3:23:3:37 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
-| C.cs:4:27:4:28 | [post] this access [field s2] : Elem | semmle.label | [post] this access [field s2] : Elem |
 | C.cs:4:27:4:28 | [post] this access [field s2] : Elem | semmle.label | [post] this access [field s2] : Elem |
 | C.cs:4:32:4:46 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
-| C.cs:4:32:4:46 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
-| C.cs:6:30:6:44 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
 | C.cs:6:30:6:44 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
 | C.cs:7:18:7:19 | [post] this access [property s5] : Elem | semmle.label | [post] this access [property s5] : Elem |
-| C.cs:7:18:7:19 | [post] this access [property s5] : Elem | semmle.label | [post] this access [property s5] : Elem |
-| C.cs:7:37:7:51 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
 | C.cs:7:37:7:51 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
 | C.cs:8:30:8:44 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
-| C.cs:8:30:8:44 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
-| C.cs:12:15:12:21 | object creation of type C [field s1] : Elem | semmle.label | object creation of type C [field s1] : Elem |
 | C.cs:12:15:12:21 | object creation of type C [field s1] : Elem | semmle.label | object creation of type C [field s1] : Elem |
 | C.cs:12:15:12:21 | object creation of type C [field s2] : Elem | semmle.label | object creation of type C [field s2] : Elem |
-| C.cs:12:15:12:21 | object creation of type C [field s2] : Elem | semmle.label | object creation of type C [field s2] : Elem |
-| C.cs:12:15:12:21 | object creation of type C [field s3] : Elem | semmle.label | object creation of type C [field s3] : Elem |
 | C.cs:12:15:12:21 | object creation of type C [field s3] : Elem | semmle.label | object creation of type C [field s3] : Elem |
 | C.cs:12:15:12:21 | object creation of type C [property s5] : Elem | semmle.label | object creation of type C [property s5] : Elem |
-| C.cs:12:15:12:21 | object creation of type C [property s5] : Elem | semmle.label | object creation of type C [property s5] : Elem |
-| C.cs:13:9:13:9 | access to local variable c [field s1] : Elem | semmle.label | access to local variable c [field s1] : Elem |
 | C.cs:13:9:13:9 | access to local variable c [field s1] : Elem | semmle.label | access to local variable c [field s1] : Elem |
 | C.cs:13:9:13:9 | access to local variable c [field s2] : Elem | semmle.label | access to local variable c [field s2] : Elem |
-| C.cs:13:9:13:9 | access to local variable c [field s2] : Elem | semmle.label | access to local variable c [field s2] : Elem |
-| C.cs:13:9:13:9 | access to local variable c [field s3] : Elem | semmle.label | access to local variable c [field s3] : Elem |
 | C.cs:13:9:13:9 | access to local variable c [field s3] : Elem | semmle.label | access to local variable c [field s3] : Elem |
 | C.cs:13:9:13:9 | access to local variable c [property s5] : Elem | semmle.label | access to local variable c [property s5] : Elem |
-| C.cs:13:9:13:9 | access to local variable c [property s5] : Elem | semmle.label | access to local variable c [property s5] : Elem |
-| C.cs:18:9:18:12 | [post] this access [field s3] : Elem | semmle.label | [post] this access [field s3] : Elem |
 | C.cs:18:9:18:12 | [post] this access [field s3] : Elem | semmle.label | [post] this access [field s3] : Elem |
 | C.cs:18:19:18:33 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
-| C.cs:18:19:18:33 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
-| C.cs:21:17:21:18 | this [field s1] : Elem | semmle.label | this [field s1] : Elem |
 | C.cs:21:17:21:18 | this [field s1] : Elem | semmle.label | this [field s1] : Elem |
 | C.cs:21:17:21:18 | this [field s2] : Elem | semmle.label | this [field s2] : Elem |
-| C.cs:21:17:21:18 | this [field s2] : Elem | semmle.label | this [field s2] : Elem |
-| C.cs:21:17:21:18 | this [field s3] : Elem | semmle.label | this [field s3] : Elem |
 | C.cs:21:17:21:18 | this [field s3] : Elem | semmle.label | this [field s3] : Elem |
 | C.cs:21:17:21:18 | this [property s5] : Elem | semmle.label | this [property s5] : Elem |
-| C.cs:21:17:21:18 | this [property s5] : Elem | semmle.label | this [property s5] : Elem |
-| C.cs:23:14:23:15 | access to field s1 | semmle.label | access to field s1 |
 | C.cs:23:14:23:15 | access to field s1 | semmle.label | access to field s1 |
 | C.cs:23:14:23:15 | this access [field s1] : Elem | semmle.label | this access [field s1] : Elem |
-| C.cs:23:14:23:15 | this access [field s1] : Elem | semmle.label | this access [field s1] : Elem |
-| C.cs:24:14:24:15 | access to field s2 | semmle.label | access to field s2 |
 | C.cs:24:14:24:15 | access to field s2 | semmle.label | access to field s2 |
 | C.cs:24:14:24:15 | this access [field s2] : Elem | semmle.label | this access [field s2] : Elem |
-| C.cs:24:14:24:15 | this access [field s2] : Elem | semmle.label | this access [field s2] : Elem |
-| C.cs:25:14:25:15 | access to field s3 | semmle.label | access to field s3 |
 | C.cs:25:14:25:15 | access to field s3 | semmle.label | access to field s3 |
 | C.cs:25:14:25:15 | this access [field s3] : Elem | semmle.label | this access [field s3] : Elem |
-| C.cs:25:14:25:15 | this access [field s3] : Elem | semmle.label | this access [field s3] : Elem |
-| C.cs:26:14:26:15 | access to field s4 | semmle.label | access to field s4 |
 | C.cs:26:14:26:15 | access to field s4 | semmle.label | access to field s4 |
 | C.cs:27:14:27:15 | access to property s5 | semmle.label | access to property s5 |
-| C.cs:27:14:27:15 | access to property s5 | semmle.label | access to property s5 |
-| C.cs:27:14:27:15 | this access [property s5] : Elem | semmle.label | this access [property s5] : Elem |
 | C.cs:27:14:27:15 | this access [property s5] : Elem | semmle.label | this access [property s5] : Elem |
 | C.cs:28:14:28:15 | access to property s6 | semmle.label | access to property s6 |
-| C.cs:28:14:28:15 | access to property s6 | semmle.label | access to property s6 |
-| C_ctor.cs:3:18:3:19 | [post] this access [field s1] : Elem | semmle.label | [post] this access [field s1] : Elem |
 | C_ctor.cs:3:18:3:19 | [post] this access [field s1] : Elem | semmle.label | [post] this access [field s1] : Elem |
 | C_ctor.cs:3:23:3:42 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
-| C_ctor.cs:3:23:3:42 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
-| C_ctor.cs:7:23:7:37 | object creation of type C_no_ctor [field s1] : Elem | semmle.label | object creation of type C_no_ctor [field s1] : Elem |
 | C_ctor.cs:7:23:7:37 | object creation of type C_no_ctor [field s1] : Elem | semmle.label | object creation of type C_no_ctor [field s1] : Elem |
 | C_ctor.cs:8:9:8:9 | access to local variable c [field s1] : Elem | semmle.label | access to local variable c [field s1] : Elem |
-| C_ctor.cs:8:9:8:9 | access to local variable c [field s1] : Elem | semmle.label | access to local variable c [field s1] : Elem |
-| C_ctor.cs:11:17:11:18 | this [field s1] : Elem | semmle.label | this [field s1] : Elem |
 | C_ctor.cs:11:17:11:18 | this [field s1] : Elem | semmle.label | this [field s1] : Elem |
 | C_ctor.cs:13:19:13:20 | access to field s1 | semmle.label | access to field s1 |
-| C_ctor.cs:13:19:13:20 | access to field s1 | semmle.label | access to field s1 |
-| C_ctor.cs:13:19:13:20 | this access [field s1] : Elem | semmle.label | this access [field s1] : Elem |
 | C_ctor.cs:13:19:13:20 | this access [field s1] : Elem | semmle.label | this access [field s1] : Elem |
 | C_ctor.cs:19:18:19:19 | [post] this access [field s1] : Elem | semmle.label | [post] this access [field s1] : Elem |
-| C_ctor.cs:19:18:19:19 | [post] this access [field s1] : Elem | semmle.label | [post] this access [field s1] : Elem |
-| C_ctor.cs:19:23:19:42 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
 | C_ctor.cs:19:23:19:42 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
 | C_ctor.cs:23:25:23:41 | object creation of type C_with_ctor [field s1] : Elem | semmle.label | object creation of type C_with_ctor [field s1] : Elem |
-| C_ctor.cs:23:25:23:41 | object creation of type C_with_ctor [field s1] : Elem | semmle.label | object creation of type C_with_ctor [field s1] : Elem |
-| C_ctor.cs:24:9:24:9 | access to local variable c [field s1] : Elem | semmle.label | access to local variable c [field s1] : Elem |
 | C_ctor.cs:24:9:24:9 | access to local variable c [field s1] : Elem | semmle.label | access to local variable c [field s1] : Elem |
 | C_ctor.cs:29:17:29:18 | this [field s1] : Elem | semmle.label | this [field s1] : Elem |
-| C_ctor.cs:29:17:29:18 | this [field s1] : Elem | semmle.label | this [field s1] : Elem |
-| C_ctor.cs:31:19:31:20 | access to field s1 | semmle.label | access to field s1 |
 | C_ctor.cs:31:19:31:20 | access to field s1 | semmle.label | access to field s1 |
 | C_ctor.cs:31:19:31:20 | this access [field s1] : Elem | semmle.label | this access [field s1] : Elem |
-| C_ctor.cs:31:19:31:20 | this access [field s1] : Elem | semmle.label | this access [field s1] : Elem |
-| D.cs:8:9:8:11 | this [field trivialPropField] : Object | semmle.label | this [field trivialPropField] : Object |
 | D.cs:8:9:8:11 | this [field trivialPropField] : Object | semmle.label | this [field trivialPropField] : Object |
 | D.cs:8:22:8:25 | this access [field trivialPropField] : Object | semmle.label | this access [field trivialPropField] : Object |
-| D.cs:8:22:8:25 | this access [field trivialPropField] : Object | semmle.label | this access [field trivialPropField] : Object |
-| D.cs:8:22:8:42 | access to field trivialPropField : Object | semmle.label | access to field trivialPropField : Object |
 | D.cs:8:22:8:42 | access to field trivialPropField : Object | semmle.label | access to field trivialPropField : Object |
 | D.cs:9:9:9:11 | value : Object | semmle.label | value : Object |
-| D.cs:9:9:9:11 | value : Object | semmle.label | value : Object |
-| D.cs:9:15:9:18 | [post] this access [field trivialPropField] : Object | semmle.label | [post] this access [field trivialPropField] : Object |
 | D.cs:9:15:9:18 | [post] this access [field trivialPropField] : Object | semmle.label | [post] this access [field trivialPropField] : Object |
 | D.cs:9:39:9:43 | access to parameter value : Object | semmle.label | access to parameter value : Object |
-| D.cs:9:39:9:43 | access to parameter value : Object | semmle.label | access to parameter value : Object |
-| D.cs:14:9:14:11 | this [field trivialPropField] : Object | semmle.label | this [field trivialPropField] : Object |
 | D.cs:14:9:14:11 | this [field trivialPropField] : Object | semmle.label | this [field trivialPropField] : Object |
 | D.cs:14:22:14:25 | this access [field trivialPropField] : Object | semmle.label | this access [field trivialPropField] : Object |
-| D.cs:14:22:14:25 | this access [field trivialPropField] : Object | semmle.label | this access [field trivialPropField] : Object |
-| D.cs:14:22:14:42 | access to field trivialPropField : Object | semmle.label | access to field trivialPropField : Object |
 | D.cs:14:22:14:42 | access to field trivialPropField : Object | semmle.label | access to field trivialPropField : Object |
 | D.cs:15:9:15:11 | value : Object | semmle.label | value : Object |
-| D.cs:15:9:15:11 | value : Object | semmle.label | value : Object |
-| D.cs:15:15:15:18 | [post] this access [field trivialPropField] : Object | semmle.label | [post] this access [field trivialPropField] : Object |
 | D.cs:15:15:15:18 | [post] this access [field trivialPropField] : Object | semmle.label | [post] this access [field trivialPropField] : Object |
 | D.cs:15:34:15:38 | access to parameter value : Object | semmle.label | access to parameter value : Object |
-| D.cs:15:34:15:38 | access to parameter value : Object | semmle.label | access to parameter value : Object |
-| D.cs:18:28:18:29 | o1 : Object | semmle.label | o1 : Object |
 | D.cs:18:28:18:29 | o1 : Object | semmle.label | o1 : Object |
 | D.cs:18:39:18:40 | o2 : Object | semmle.label | o2 : Object |
-| D.cs:18:39:18:40 | o2 : Object | semmle.label | o2 : Object |
-| D.cs:18:50:18:51 | o3 : Object | semmle.label | o3 : Object |
 | D.cs:18:50:18:51 | o3 : Object | semmle.label | o3 : Object |
 | D.cs:21:9:21:11 | [post] access to local variable ret [property AutoProp] : Object | semmle.label | [post] access to local variable ret [property AutoProp] : Object |
-| D.cs:21:9:21:11 | [post] access to local variable ret [property AutoProp] : Object | semmle.label | [post] access to local variable ret [property AutoProp] : Object |
-| D.cs:21:24:21:25 | access to parameter o1 : Object | semmle.label | access to parameter o1 : Object |
 | D.cs:21:24:21:25 | access to parameter o1 : Object | semmle.label | access to parameter o1 : Object |
 | D.cs:22:9:22:11 | [post] access to local variable ret [field trivialPropField] : Object | semmle.label | [post] access to local variable ret [field trivialPropField] : Object |
-| D.cs:22:9:22:11 | [post] access to local variable ret [field trivialPropField] : Object | semmle.label | [post] access to local variable ret [field trivialPropField] : Object |
-| D.cs:22:27:22:28 | access to parameter o2 : Object | semmle.label | access to parameter o2 : Object |
 | D.cs:22:27:22:28 | access to parameter o2 : Object | semmle.label | access to parameter o2 : Object |
 | D.cs:23:9:23:11 | [post] access to local variable ret [field trivialPropField] : Object | semmle.label | [post] access to local variable ret [field trivialPropField] : Object |
-| D.cs:23:9:23:11 | [post] access to local variable ret [field trivialPropField] : Object | semmle.label | [post] access to local variable ret [field trivialPropField] : Object |
-| D.cs:23:27:23:28 | access to parameter o3 : Object | semmle.label | access to parameter o3 : Object |
 | D.cs:23:27:23:28 | access to parameter o3 : Object | semmle.label | access to parameter o3 : Object |
 | D.cs:24:16:24:18 | access to local variable ret [field trivialPropField] : Object | semmle.label | access to local variable ret [field trivialPropField] : Object |
 | D.cs:24:16:24:18 | access to local variable ret [field trivialPropField] : Object | semmle.label | access to local variable ret [field trivialPropField] : Object |
-| D.cs:24:16:24:18 | access to local variable ret [field trivialPropField] : Object | semmle.label | access to local variable ret [field trivialPropField] : Object |
-| D.cs:24:16:24:18 | access to local variable ret [field trivialPropField] : Object | semmle.label | access to local variable ret [field trivialPropField] : Object |
-| D.cs:24:16:24:18 | access to local variable ret [property AutoProp] : Object | semmle.label | access to local variable ret [property AutoProp] : Object |
 | D.cs:24:16:24:18 | access to local variable ret [property AutoProp] : Object | semmle.label | access to local variable ret [property AutoProp] : Object |
 | D.cs:29:17:29:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
-| D.cs:29:17:29:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
-| D.cs:31:17:31:37 | call to method Create [property AutoProp] : Object | semmle.label | call to method Create [property AutoProp] : Object |
 | D.cs:31:17:31:37 | call to method Create [property AutoProp] : Object | semmle.label | call to method Create [property AutoProp] : Object |
 | D.cs:31:24:31:24 | access to local variable o : Object | semmle.label | access to local variable o : Object |
-| D.cs:31:24:31:24 | access to local variable o : Object | semmle.label | access to local variable o : Object |
-| D.cs:32:14:32:14 | access to local variable d [property AutoProp] : Object | semmle.label | access to local variable d [property AutoProp] : Object |
 | D.cs:32:14:32:14 | access to local variable d [property AutoProp] : Object | semmle.label | access to local variable d [property AutoProp] : Object |
 | D.cs:32:14:32:23 | access to property AutoProp | semmle.label | access to property AutoProp |
-| D.cs:32:14:32:23 | access to property AutoProp | semmle.label | access to property AutoProp |
-| D.cs:37:13:37:49 | call to method Create [field trivialPropField] : Object | semmle.label | call to method Create [field trivialPropField] : Object |
 | D.cs:37:13:37:49 | call to method Create [field trivialPropField] : Object | semmle.label | call to method Create [field trivialPropField] : Object |
 | D.cs:37:26:37:42 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
-| D.cs:37:26:37:42 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
-| D.cs:39:14:39:14 | access to local variable d [field trivialPropField] : Object | semmle.label | access to local variable d [field trivialPropField] : Object |
 | D.cs:39:14:39:14 | access to local variable d [field trivialPropField] : Object | semmle.label | access to local variable d [field trivialPropField] : Object |
 | D.cs:39:14:39:26 | access to property TrivialProp | semmle.label | access to property TrivialProp |
-| D.cs:39:14:39:26 | access to property TrivialProp | semmle.label | access to property TrivialProp |
-| D.cs:40:14:40:14 | access to local variable d [field trivialPropField] : Object | semmle.label | access to local variable d [field trivialPropField] : Object |
 | D.cs:40:14:40:14 | access to local variable d [field trivialPropField] : Object | semmle.label | access to local variable d [field trivialPropField] : Object |
 | D.cs:40:14:40:31 | access to field trivialPropField | semmle.label | access to field trivialPropField |
-| D.cs:40:14:40:31 | access to field trivialPropField | semmle.label | access to field trivialPropField |
-| D.cs:41:14:41:14 | access to local variable d [field trivialPropField] : Object | semmle.label | access to local variable d [field trivialPropField] : Object |
 | D.cs:41:14:41:14 | access to local variable d [field trivialPropField] : Object | semmle.label | access to local variable d [field trivialPropField] : Object |
 | D.cs:41:14:41:26 | access to property ComplexProp | semmle.label | access to property ComplexProp |
-| D.cs:41:14:41:26 | access to property ComplexProp | semmle.label | access to property ComplexProp |
-| D.cs:43:13:43:49 | call to method Create [field trivialPropField] : Object | semmle.label | call to method Create [field trivialPropField] : Object |
 | D.cs:43:13:43:49 | call to method Create [field trivialPropField] : Object | semmle.label | call to method Create [field trivialPropField] : Object |
 | D.cs:43:32:43:48 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
-| D.cs:43:32:43:48 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
-| D.cs:45:14:45:14 | access to local variable d [field trivialPropField] : Object | semmle.label | access to local variable d [field trivialPropField] : Object |
 | D.cs:45:14:45:14 | access to local variable d [field trivialPropField] : Object | semmle.label | access to local variable d [field trivialPropField] : Object |
 | D.cs:45:14:45:26 | access to property TrivialProp | semmle.label | access to property TrivialProp |
-| D.cs:45:14:45:26 | access to property TrivialProp | semmle.label | access to property TrivialProp |
-| D.cs:46:14:46:14 | access to local variable d [field trivialPropField] : Object | semmle.label | access to local variable d [field trivialPropField] : Object |
 | D.cs:46:14:46:14 | access to local variable d [field trivialPropField] : Object | semmle.label | access to local variable d [field trivialPropField] : Object |
 | D.cs:46:14:46:31 | access to field trivialPropField | semmle.label | access to field trivialPropField |
-| D.cs:46:14:46:31 | access to field trivialPropField | semmle.label | access to field trivialPropField |
-| D.cs:47:14:47:14 | access to local variable d [field trivialPropField] : Object | semmle.label | access to local variable d [field trivialPropField] : Object |
 | D.cs:47:14:47:14 | access to local variable d [field trivialPropField] : Object | semmle.label | access to local variable d [field trivialPropField] : Object |
 | D.cs:47:14:47:26 | access to property ComplexProp | semmle.label | access to property ComplexProp |
-| D.cs:47:14:47:26 | access to property ComplexProp | semmle.label | access to property ComplexProp |
-| E.cs:8:29:8:29 | o : Object | semmle.label | o : Object |
 | E.cs:8:29:8:29 | o : Object | semmle.label | o : Object |
 | E.cs:11:9:11:11 | [post] access to local variable ret [field Field] : Object | semmle.label | [post] access to local variable ret [field Field] : Object |
-| E.cs:11:9:11:11 | [post] access to local variable ret [field Field] : Object | semmle.label | [post] access to local variable ret [field Field] : Object |
-| E.cs:11:21:11:21 | access to parameter o : Object | semmle.label | access to parameter o : Object |
 | E.cs:11:21:11:21 | access to parameter o : Object | semmle.label | access to parameter o : Object |
 | E.cs:12:16:12:18 | access to local variable ret [field Field] : Object | semmle.label | access to local variable ret [field Field] : Object |
-| E.cs:12:16:12:18 | access to local variable ret [field Field] : Object | semmle.label | access to local variable ret [field Field] : Object |
-| E.cs:22:17:22:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
 | E.cs:22:17:22:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
 | E.cs:23:17:23:26 | call to method CreateS [field Field] : Object | semmle.label | call to method CreateS [field Field] : Object |
-| E.cs:23:17:23:26 | call to method CreateS [field Field] : Object | semmle.label | call to method CreateS [field Field] : Object |
-| E.cs:23:25:23:25 | access to local variable o : Object | semmle.label | access to local variable o : Object |
 | E.cs:23:25:23:25 | access to local variable o : Object | semmle.label | access to local variable o : Object |
 | E.cs:24:14:24:14 | access to local variable s [field Field] : Object | semmle.label | access to local variable s [field Field] : Object |
-| E.cs:24:14:24:14 | access to local variable s [field Field] : Object | semmle.label | access to local variable s [field Field] : Object |
-| E.cs:24:14:24:20 | access to field Field | semmle.label | access to field Field |
 | E.cs:24:14:24:20 | access to field Field | semmle.label | access to field Field |
 | F.cs:6:28:6:29 | o1 : Object | semmle.label | o1 : Object |
-| F.cs:6:28:6:29 | o1 : Object | semmle.label | o1 : Object |
-| F.cs:6:39:6:40 | o2 : Object | semmle.label | o2 : Object |
 | F.cs:6:39:6:40 | o2 : Object | semmle.label | o2 : Object |
 | F.cs:6:46:6:81 | object creation of type F [field Field1] : Object | semmle.label | object creation of type F [field Field1] : Object |
-| F.cs:6:46:6:81 | object creation of type F [field Field1] : Object | semmle.label | object creation of type F [field Field1] : Object |
-| F.cs:6:46:6:81 | object creation of type F [field Field2] : Object | semmle.label | object creation of type F [field Field2] : Object |
 | F.cs:6:46:6:81 | object creation of type F [field Field2] : Object | semmle.label | object creation of type F [field Field2] : Object |
 | F.cs:6:54:6:81 | { ..., ... } [field Field1] : Object | semmle.label | { ..., ... } [field Field1] : Object |
-| F.cs:6:54:6:81 | { ..., ... } [field Field1] : Object | semmle.label | { ..., ... } [field Field1] : Object |
-| F.cs:6:54:6:81 | { ..., ... } [field Field2] : Object | semmle.label | { ..., ... } [field Field2] : Object |
 | F.cs:6:54:6:81 | { ..., ... } [field Field2] : Object | semmle.label | { ..., ... } [field Field2] : Object |
 | F.cs:6:65:6:66 | access to parameter o1 : Object | semmle.label | access to parameter o1 : Object |
-| F.cs:6:65:6:66 | access to parameter o1 : Object | semmle.label | access to parameter o1 : Object |
-| F.cs:6:78:6:79 | access to parameter o2 : Object | semmle.label | access to parameter o2 : Object |
 | F.cs:6:78:6:79 | access to parameter o2 : Object | semmle.label | access to parameter o2 : Object |
 | F.cs:10:17:10:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
-| F.cs:10:17:10:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
-| F.cs:11:17:11:31 | call to method Create [field Field1] : Object | semmle.label | call to method Create [field Field1] : Object |
 | F.cs:11:17:11:31 | call to method Create [field Field1] : Object | semmle.label | call to method Create [field Field1] : Object |
 | F.cs:11:24:11:24 | access to local variable o : Object | semmle.label | access to local variable o : Object |
-| F.cs:11:24:11:24 | access to local variable o : Object | semmle.label | access to local variable o : Object |
-| F.cs:12:14:12:14 | access to local variable f [field Field1] : Object | semmle.label | access to local variable f [field Field1] : Object |
 | F.cs:12:14:12:14 | access to local variable f [field Field1] : Object | semmle.label | access to local variable f [field Field1] : Object |
 | F.cs:12:14:12:21 | access to field Field1 | semmle.label | access to field Field1 |
-| F.cs:12:14:12:21 | access to field Field1 | semmle.label | access to field Field1 |
-| F.cs:15:13:15:43 | call to method Create [field Field2] : Object | semmle.label | call to method Create [field Field2] : Object |
 | F.cs:15:13:15:43 | call to method Create [field Field2] : Object | semmle.label | call to method Create [field Field2] : Object |
 | F.cs:15:26:15:42 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
-| F.cs:15:26:15:42 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
-| F.cs:17:14:17:14 | access to local variable f [field Field2] : Object | semmle.label | access to local variable f [field Field2] : Object |
 | F.cs:17:14:17:14 | access to local variable f [field Field2] : Object | semmle.label | access to local variable f [field Field2] : Object |
 | F.cs:17:14:17:21 | access to field Field2 | semmle.label | access to field Field2 |
-| F.cs:17:14:17:21 | access to field Field2 | semmle.label | access to field Field2 |
-| F.cs:19:21:19:50 | { ..., ... } [field Field1] : Object | semmle.label | { ..., ... } [field Field1] : Object |
 | F.cs:19:21:19:50 | { ..., ... } [field Field1] : Object | semmle.label | { ..., ... } [field Field1] : Object |
 | F.cs:19:32:19:48 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
-| F.cs:19:32:19:48 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
-| F.cs:20:14:20:14 | access to local variable f [field Field1] : Object | semmle.label | access to local variable f [field Field1] : Object |
 | F.cs:20:14:20:14 | access to local variable f [field Field1] : Object | semmle.label | access to local variable f [field Field1] : Object |
 | F.cs:20:14:20:21 | access to field Field1 | semmle.label | access to field Field1 |
-| F.cs:20:14:20:21 | access to field Field1 | semmle.label | access to field Field1 |
-| F.cs:23:21:23:50 | { ..., ... } [field Field2] : Object | semmle.label | { ..., ... } [field Field2] : Object |
 | F.cs:23:21:23:50 | { ..., ... } [field Field2] : Object | semmle.label | { ..., ... } [field Field2] : Object |
 | F.cs:23:32:23:48 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
-| F.cs:23:32:23:48 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
-| F.cs:25:14:25:14 | access to local variable f [field Field2] : Object | semmle.label | access to local variable f [field Field2] : Object |
 | F.cs:25:14:25:14 | access to local variable f [field Field2] : Object | semmle.label | access to local variable f [field Field2] : Object |
 | F.cs:25:14:25:21 | access to field Field2 | semmle.label | access to field Field2 |
-| F.cs:25:14:25:21 | access to field Field2 | semmle.label | access to field Field2 |
-| F.cs:30:17:30:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
 | F.cs:30:17:30:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
 | F.cs:32:17:32:40 | { ..., ... } [property X] : Object | semmle.label | { ..., ... } [property X] : Object |
-| F.cs:32:17:32:40 | { ..., ... } [property X] : Object | semmle.label | { ..., ... } [property X] : Object |
-| F.cs:32:27:32:27 | access to local variable o : Object | semmle.label | access to local variable o : Object |
 | F.cs:32:27:32:27 | access to local variable o : Object | semmle.label | access to local variable o : Object |
 | F.cs:33:14:33:14 | access to local variable a [property X] : Object | semmle.label | access to local variable a [property X] : Object |
-| F.cs:33:14:33:14 | access to local variable a [property X] : Object | semmle.label | access to local variable a [property X] : Object |
-| F.cs:33:14:33:16 | access to property X | semmle.label | access to property X |
 | F.cs:33:14:33:16 | access to property X | semmle.label | access to property X |
 | G.cs:7:18:7:32 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
-| G.cs:7:18:7:32 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
-| G.cs:9:9:9:9 | [post] access to local variable b [field Box1, field Elem] : Elem | semmle.label | [post] access to local variable b [field Box1, field Elem] : Elem |
 | G.cs:9:9:9:9 | [post] access to local variable b [field Box1, field Elem] : Elem | semmle.label | [post] access to local variable b [field Box1, field Elem] : Elem |
 | G.cs:9:9:9:14 | [post] access to field Box1 [field Elem] : Elem | semmle.label | [post] access to field Box1 [field Elem] : Elem |
-| G.cs:9:9:9:14 | [post] access to field Box1 [field Elem] : Elem | semmle.label | [post] access to field Box1 [field Elem] : Elem |
-| G.cs:9:23:9:23 | access to local variable e : Elem | semmle.label | access to local variable e : Elem |
 | G.cs:9:23:9:23 | access to local variable e : Elem | semmle.label | access to local variable e : Elem |
 | G.cs:10:18:10:18 | access to local variable b [field Box1, field Elem] : Elem | semmle.label | access to local variable b [field Box1, field Elem] : Elem |
-| G.cs:10:18:10:18 | access to local variable b [field Box1, field Elem] : Elem | semmle.label | access to local variable b [field Box1, field Elem] : Elem |
-| G.cs:15:18:15:32 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
 | G.cs:15:18:15:32 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
 | G.cs:17:9:17:9 | [post] access to local variable b [field Box1, field Elem] : Elem | semmle.label | [post] access to local variable b [field Box1, field Elem] : Elem |
-| G.cs:17:9:17:9 | [post] access to local variable b [field Box1, field Elem] : Elem | semmle.label | [post] access to local variable b [field Box1, field Elem] : Elem |
-| G.cs:17:9:17:14 | [post] access to field Box1 [field Elem] : Elem | semmle.label | [post] access to field Box1 [field Elem] : Elem |
 | G.cs:17:9:17:14 | [post] access to field Box1 [field Elem] : Elem | semmle.label | [post] access to field Box1 [field Elem] : Elem |
 | G.cs:17:24:17:24 | access to local variable e : Elem | semmle.label | access to local variable e : Elem |
-| G.cs:17:24:17:24 | access to local variable e : Elem | semmle.label | access to local variable e : Elem |
-| G.cs:18:18:18:18 | access to local variable b [field Box1, field Elem] : Elem | semmle.label | access to local variable b [field Box1, field Elem] : Elem |
 | G.cs:18:18:18:18 | access to local variable b [field Box1, field Elem] : Elem | semmle.label | access to local variable b [field Box1, field Elem] : Elem |
 | G.cs:23:18:23:32 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
-| G.cs:23:18:23:32 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
-| G.cs:25:9:25:9 | [post] access to local variable b [field Box1, field Elem] : Elem | semmle.label | [post] access to local variable b [field Box1, field Elem] : Elem |
 | G.cs:25:9:25:9 | [post] access to local variable b [field Box1, field Elem] : Elem | semmle.label | [post] access to local variable b [field Box1, field Elem] : Elem |
 | G.cs:25:9:25:19 | [post] call to method GetBox1 [field Elem] : Elem | semmle.label | [post] call to method GetBox1 [field Elem] : Elem |
-| G.cs:25:9:25:19 | [post] call to method GetBox1 [field Elem] : Elem | semmle.label | [post] call to method GetBox1 [field Elem] : Elem |
-| G.cs:25:28:25:28 | access to local variable e : Elem | semmle.label | access to local variable e : Elem |
 | G.cs:25:28:25:28 | access to local variable e : Elem | semmle.label | access to local variable e : Elem |
 | G.cs:26:18:26:18 | access to local variable b [field Box1, field Elem] : Elem | semmle.label | access to local variable b [field Box1, field Elem] : Elem |
-| G.cs:26:18:26:18 | access to local variable b [field Box1, field Elem] : Elem | semmle.label | access to local variable b [field Box1, field Elem] : Elem |
-| G.cs:31:18:31:32 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
 | G.cs:31:18:31:32 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
 | G.cs:33:9:33:9 | [post] access to local variable b [field Box1, field Elem] : Elem | semmle.label | [post] access to local variable b [field Box1, field Elem] : Elem |
-| G.cs:33:9:33:9 | [post] access to local variable b [field Box1, field Elem] : Elem | semmle.label | [post] access to local variable b [field Box1, field Elem] : Elem |
-| G.cs:33:9:33:19 | [post] call to method GetBox1 [field Elem] : Elem | semmle.label | [post] call to method GetBox1 [field Elem] : Elem |
 | G.cs:33:9:33:19 | [post] call to method GetBox1 [field Elem] : Elem | semmle.label | [post] call to method GetBox1 [field Elem] : Elem |
 | G.cs:33:29:33:29 | access to local variable e : Elem | semmle.label | access to local variable e : Elem |
-| G.cs:33:29:33:29 | access to local variable e : Elem | semmle.label | access to local variable e : Elem |
-| G.cs:34:18:34:18 | access to local variable b [field Box1, field Elem] : Elem | semmle.label | access to local variable b [field Box1, field Elem] : Elem |
 | G.cs:34:18:34:18 | access to local variable b [field Box1, field Elem] : Elem | semmle.label | access to local variable b [field Box1, field Elem] : Elem |
 | G.cs:37:38:37:39 | b2 [field Box1, field Elem] : Elem | semmle.label | b2 [field Box1, field Elem] : Elem |
-| G.cs:37:38:37:39 | b2 [field Box1, field Elem] : Elem | semmle.label | b2 [field Box1, field Elem] : Elem |
-| G.cs:39:14:39:15 | access to parameter b2 [field Box1, field Elem] : Elem | semmle.label | access to parameter b2 [field Box1, field Elem] : Elem |
 | G.cs:39:14:39:15 | access to parameter b2 [field Box1, field Elem] : Elem | semmle.label | access to parameter b2 [field Box1, field Elem] : Elem |
 | G.cs:39:14:39:25 | call to method GetBox1 [field Elem] : Elem | semmle.label | call to method GetBox1 [field Elem] : Elem |
-| G.cs:39:14:39:25 | call to method GetBox1 [field Elem] : Elem | semmle.label | call to method GetBox1 [field Elem] : Elem |
-| G.cs:39:14:39:35 | call to method GetElem | semmle.label | call to method GetElem |
 | G.cs:39:14:39:35 | call to method GetElem | semmle.label | call to method GetElem |
 | G.cs:44:18:44:32 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
-| G.cs:44:18:44:32 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
-| G.cs:46:9:46:16 | [post] access to field boxfield [field Box1, field Elem] : Elem | semmle.label | [post] access to field boxfield [field Box1, field Elem] : Elem |
 | G.cs:46:9:46:16 | [post] access to field boxfield [field Box1, field Elem] : Elem | semmle.label | [post] access to field boxfield [field Box1, field Elem] : Elem |
 | G.cs:46:9:46:16 | [post] this access [field boxfield, field Box1, field Elem] : Elem | semmle.label | [post] this access [field boxfield, field Box1, field Elem] : Elem |
-| G.cs:46:9:46:16 | [post] this access [field boxfield, field Box1, field Elem] : Elem | semmle.label | [post] this access [field boxfield, field Box1, field Elem] : Elem |
-| G.cs:46:9:46:21 | [post] access to field Box1 [field Elem] : Elem | semmle.label | [post] access to field Box1 [field Elem] : Elem |
 | G.cs:46:9:46:21 | [post] access to field Box1 [field Elem] : Elem | semmle.label | [post] access to field Box1 [field Elem] : Elem |
 | G.cs:46:30:46:30 | access to local variable e : Elem | semmle.label | access to local variable e : Elem |
-| G.cs:46:30:46:30 | access to local variable e : Elem | semmle.label | access to local variable e : Elem |
-| G.cs:47:9:47:13 | this access [field boxfield, field Box1, field Elem] : Elem | semmle.label | this access [field boxfield, field Box1, field Elem] : Elem |
 | G.cs:47:9:47:13 | this access [field boxfield, field Box1, field Elem] : Elem | semmle.label | this access [field boxfield, field Box1, field Elem] : Elem |
 | G.cs:50:18:50:20 | this [field boxfield, field Box1, field Elem] : Elem | semmle.label | this [field boxfield, field Box1, field Elem] : Elem |
-| G.cs:50:18:50:20 | this [field boxfield, field Box1, field Elem] : Elem | semmle.label | this [field boxfield, field Box1, field Elem] : Elem |
-| G.cs:52:14:52:21 | access to field boxfield [field Box1, field Elem] : Elem | semmle.label | access to field boxfield [field Box1, field Elem] : Elem |
 | G.cs:52:14:52:21 | access to field boxfield [field Box1, field Elem] : Elem | semmle.label | access to field boxfield [field Box1, field Elem] : Elem |
 | G.cs:52:14:52:21 | this access [field boxfield, field Box1, field Elem] : Elem | semmle.label | this access [field boxfield, field Box1, field Elem] : Elem |
-| G.cs:52:14:52:21 | this access [field boxfield, field Box1, field Elem] : Elem | semmle.label | this access [field boxfield, field Box1, field Elem] : Elem |
-| G.cs:52:14:52:26 | access to field Box1 [field Elem] : Elem | semmle.label | access to field Box1 [field Elem] : Elem |
 | G.cs:52:14:52:26 | access to field Box1 [field Elem] : Elem | semmle.label | access to field Box1 [field Elem] : Elem |
 | G.cs:52:14:52:31 | access to field Elem | semmle.label | access to field Elem |
-| G.cs:52:14:52:31 | access to field Elem | semmle.label | access to field Elem |
-| G.cs:63:21:63:27 | this [field Elem] : Elem | semmle.label | this [field Elem] : Elem |
 | G.cs:63:21:63:27 | this [field Elem] : Elem | semmle.label | this [field Elem] : Elem |
 | G.cs:63:34:63:37 | access to field Elem : Elem | semmle.label | access to field Elem : Elem |
-| G.cs:63:34:63:37 | access to field Elem : Elem | semmle.label | access to field Elem : Elem |
-| G.cs:63:34:63:37 | this access [field Elem] : Elem | semmle.label | this access [field Elem] : Elem |
 | G.cs:63:34:63:37 | this access [field Elem] : Elem | semmle.label | this access [field Elem] : Elem |
 | G.cs:64:34:64:34 | e : Elem | semmle.label | e : Elem |
-| G.cs:64:34:64:34 | e : Elem | semmle.label | e : Elem |
-| G.cs:64:39:64:42 | [post] this access [field Elem] : Elem | semmle.label | [post] this access [field Elem] : Elem |
 | G.cs:64:39:64:42 | [post] this access [field Elem] : Elem | semmle.label | [post] this access [field Elem] : Elem |
 | G.cs:64:46:64:46 | access to parameter e : Elem | semmle.label | access to parameter e : Elem |
-| G.cs:64:46:64:46 | access to parameter e : Elem | semmle.label | access to parameter e : Elem |
-| G.cs:71:21:71:27 | this [field Box1, field Elem] : Elem | semmle.label | this [field Box1, field Elem] : Elem |
 | G.cs:71:21:71:27 | this [field Box1, field Elem] : Elem | semmle.label | this [field Box1, field Elem] : Elem |
 | G.cs:71:34:71:37 | access to field Box1 [field Elem] : Elem | semmle.label | access to field Box1 [field Elem] : Elem |
-| G.cs:71:34:71:37 | access to field Box1 [field Elem] : Elem | semmle.label | access to field Box1 [field Elem] : Elem |
-| G.cs:71:34:71:37 | this access [field Box1, field Elem] : Elem | semmle.label | this access [field Box1, field Elem] : Elem |
 | G.cs:71:34:71:37 | this access [field Box1, field Elem] : Elem | semmle.label | this access [field Box1, field Elem] : Elem |
 | H.cs:13:15:13:15 | a [field FieldA] : Object | semmle.label | a [field FieldA] : Object |
-| H.cs:13:15:13:15 | a [field FieldA] : Object | semmle.label | a [field FieldA] : Object |
-| H.cs:16:9:16:11 | [post] access to local variable ret [field FieldA] : Object | semmle.label | [post] access to local variable ret [field FieldA] : Object |
 | H.cs:16:9:16:11 | [post] access to local variable ret [field FieldA] : Object | semmle.label | [post] access to local variable ret [field FieldA] : Object |
 | H.cs:16:22:16:22 | access to parameter a [field FieldA] : Object | semmle.label | access to parameter a [field FieldA] : Object |
-| H.cs:16:22:16:22 | access to parameter a [field FieldA] : Object | semmle.label | access to parameter a [field FieldA] : Object |
-| H.cs:16:22:16:29 | access to field FieldA : Object | semmle.label | access to field FieldA : Object |
 | H.cs:16:22:16:29 | access to field FieldA : Object | semmle.label | access to field FieldA : Object |
 | H.cs:17:16:17:18 | access to local variable ret [field FieldA] : Object | semmle.label | access to local variable ret [field FieldA] : Object |
-| H.cs:17:16:17:18 | access to local variable ret [field FieldA] : Object | semmle.label | access to local variable ret [field FieldA] : Object |
-| H.cs:23:9:23:9 | [post] access to local variable a [field FieldA] : Object | semmle.label | [post] access to local variable a [field FieldA] : Object |
 | H.cs:23:9:23:9 | [post] access to local variable a [field FieldA] : Object | semmle.label | [post] access to local variable a [field FieldA] : Object |
 | H.cs:23:20:23:36 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
-| H.cs:23:20:23:36 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
-| H.cs:24:21:24:28 | call to method Clone [field FieldA] : Object | semmle.label | call to method Clone [field FieldA] : Object |
 | H.cs:24:21:24:28 | call to method Clone [field FieldA] : Object | semmle.label | call to method Clone [field FieldA] : Object |
 | H.cs:24:27:24:27 | access to local variable a [field FieldA] : Object | semmle.label | access to local variable a [field FieldA] : Object |
-| H.cs:24:27:24:27 | access to local variable a [field FieldA] : Object | semmle.label | access to local variable a [field FieldA] : Object |
-| H.cs:25:14:25:18 | access to local variable clone [field FieldA] : Object | semmle.label | access to local variable clone [field FieldA] : Object |
 | H.cs:25:14:25:18 | access to local variable clone [field FieldA] : Object | semmle.label | access to local variable clone [field FieldA] : Object |
 | H.cs:25:14:25:25 | access to field FieldA | semmle.label | access to field FieldA |
-| H.cs:25:14:25:25 | access to field FieldA | semmle.label | access to field FieldA |
-| H.cs:33:19:33:19 | a [field FieldA] : A | semmle.label | a [field FieldA] : A |
 | H.cs:33:19:33:19 | a [field FieldA] : A | semmle.label | a [field FieldA] : A |
 | H.cs:33:19:33:19 | a [field FieldA] : Object | semmle.label | a [field FieldA] : Object |
-| H.cs:33:19:33:19 | a [field FieldA] : Object | semmle.label | a [field FieldA] : Object |
-| H.cs:36:9:36:9 | [post] access to local variable b [field FieldB] : A | semmle.label | [post] access to local variable b [field FieldB] : A |
 | H.cs:36:9:36:9 | [post] access to local variable b [field FieldB] : A | semmle.label | [post] access to local variable b [field FieldB] : A |
 | H.cs:36:9:36:9 | [post] access to local variable b [field FieldB] : Object | semmle.label | [post] access to local variable b [field FieldB] : Object |
-| H.cs:36:9:36:9 | [post] access to local variable b [field FieldB] : Object | semmle.label | [post] access to local variable b [field FieldB] : Object |
-| H.cs:36:20:36:20 | access to parameter a [field FieldA] : A | semmle.label | access to parameter a [field FieldA] : A |
 | H.cs:36:20:36:20 | access to parameter a [field FieldA] : A | semmle.label | access to parameter a [field FieldA] : A |
 | H.cs:36:20:36:20 | access to parameter a [field FieldA] : Object | semmle.label | access to parameter a [field FieldA] : Object |
-| H.cs:36:20:36:20 | access to parameter a [field FieldA] : Object | semmle.label | access to parameter a [field FieldA] : Object |
-| H.cs:36:20:36:27 | access to field FieldA : A | semmle.label | access to field FieldA : A |
 | H.cs:36:20:36:27 | access to field FieldA : A | semmle.label | access to field FieldA : A |
 | H.cs:36:20:36:27 | access to field FieldA : Object | semmle.label | access to field FieldA : Object |
-| H.cs:36:20:36:27 | access to field FieldA : Object | semmle.label | access to field FieldA : Object |
-| H.cs:37:16:37:16 | access to local variable b [field FieldB] : A | semmle.label | access to local variable b [field FieldB] : A |
 | H.cs:37:16:37:16 | access to local variable b [field FieldB] : A | semmle.label | access to local variable b [field FieldB] : A |
 | H.cs:37:16:37:16 | access to local variable b [field FieldB] : Object | semmle.label | access to local variable b [field FieldB] : Object |
-| H.cs:37:16:37:16 | access to local variable b [field FieldB] : Object | semmle.label | access to local variable b [field FieldB] : Object |
-| H.cs:43:9:43:9 | [post] access to local variable a [field FieldA] : Object | semmle.label | [post] access to local variable a [field FieldA] : Object |
 | H.cs:43:9:43:9 | [post] access to local variable a [field FieldA] : Object | semmle.label | [post] access to local variable a [field FieldA] : Object |
 | H.cs:43:20:43:36 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
-| H.cs:43:20:43:36 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
-| H.cs:44:17:44:28 | call to method Transform [field FieldB] : Object | semmle.label | call to method Transform [field FieldB] : Object |
 | H.cs:44:17:44:28 | call to method Transform [field FieldB] : Object | semmle.label | call to method Transform [field FieldB] : Object |
 | H.cs:44:27:44:27 | access to local variable a [field FieldA] : Object | semmle.label | access to local variable a [field FieldA] : Object |
-| H.cs:44:27:44:27 | access to local variable a [field FieldA] : Object | semmle.label | access to local variable a [field FieldA] : Object |
-| H.cs:45:14:45:14 | access to local variable b [field FieldB] : Object | semmle.label | access to local variable b [field FieldB] : Object |
 | H.cs:45:14:45:14 | access to local variable b [field FieldB] : Object | semmle.label | access to local variable b [field FieldB] : Object |
 | H.cs:45:14:45:21 | access to field FieldB | semmle.label | access to field FieldB |
-| H.cs:45:14:45:21 | access to field FieldB | semmle.label | access to field FieldB |
-| H.cs:53:25:53:25 | a [field FieldA] : Object | semmle.label | a [field FieldA] : Object |
 | H.cs:53:25:53:25 | a [field FieldA] : Object | semmle.label | a [field FieldA] : Object |
 | H.cs:55:9:55:10 | [post] access to parameter b1 [field FieldB] : Object | semmle.label | [post] access to parameter b1 [field FieldB] : Object |
-| H.cs:55:9:55:10 | [post] access to parameter b1 [field FieldB] : Object | semmle.label | [post] access to parameter b1 [field FieldB] : Object |
-| H.cs:55:21:55:21 | access to parameter a [field FieldA] : Object | semmle.label | access to parameter a [field FieldA] : Object |
 | H.cs:55:21:55:21 | access to parameter a [field FieldA] : Object | semmle.label | access to parameter a [field FieldA] : Object |
 | H.cs:55:21:55:28 | access to field FieldA : Object | semmle.label | access to field FieldA : Object |
-| H.cs:55:21:55:28 | access to field FieldA : Object | semmle.label | access to field FieldA : Object |
-| H.cs:63:9:63:9 | [post] access to local variable a [field FieldA] : Object | semmle.label | [post] access to local variable a [field FieldA] : Object |
 | H.cs:63:9:63:9 | [post] access to local variable a [field FieldA] : Object | semmle.label | [post] access to local variable a [field FieldA] : Object |
 | H.cs:63:20:63:36 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
-| H.cs:63:20:63:36 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
-| H.cs:64:22:64:22 | access to local variable a [field FieldA] : Object | semmle.label | access to local variable a [field FieldA] : Object |
 | H.cs:64:22:64:22 | access to local variable a [field FieldA] : Object | semmle.label | access to local variable a [field FieldA] : Object |
 | H.cs:64:25:64:26 | [post] access to local variable b1 [field FieldB] : Object | semmle.label | [post] access to local variable b1 [field FieldB] : Object |
-| H.cs:64:25:64:26 | [post] access to local variable b1 [field FieldB] : Object | semmle.label | [post] access to local variable b1 [field FieldB] : Object |
-| H.cs:65:14:65:15 | access to local variable b1 [field FieldB] : Object | semmle.label | access to local variable b1 [field FieldB] : Object |
 | H.cs:65:14:65:15 | access to local variable b1 [field FieldB] : Object | semmle.label | access to local variable b1 [field FieldB] : Object |
 | H.cs:65:14:65:22 | access to field FieldB | semmle.label | access to field FieldB |
-| H.cs:65:14:65:22 | access to field FieldB | semmle.label | access to field FieldB |
-| H.cs:77:30:77:30 | o : Object | semmle.label | o : Object |
 | H.cs:77:30:77:30 | o : Object | semmle.label | o : Object |
 | H.cs:79:9:79:9 | [post] access to parameter a [field FieldA] : Object | semmle.label | [post] access to parameter a [field FieldA] : Object |
-| H.cs:79:9:79:9 | [post] access to parameter a [field FieldA] : Object | semmle.label | [post] access to parameter a [field FieldA] : Object |
-| H.cs:79:20:79:20 | access to parameter o : Object | semmle.label | access to parameter o : Object |
 | H.cs:79:20:79:20 | access to parameter o : Object | semmle.label | access to parameter o : Object |
 | H.cs:80:22:80:22 | access to parameter a [field FieldA] : Object | semmle.label | access to parameter a [field FieldA] : Object |
-| H.cs:80:22:80:22 | access to parameter a [field FieldA] : Object | semmle.label | access to parameter a [field FieldA] : Object |
-| H.cs:80:25:80:26 | [post] access to parameter b1 [field FieldB] : Object | semmle.label | [post] access to parameter b1 [field FieldB] : Object |
 | H.cs:80:25:80:26 | [post] access to parameter b1 [field FieldB] : Object | semmle.label | [post] access to parameter b1 [field FieldB] : Object |
 | H.cs:88:17:88:17 | [post] access to local variable a [field FieldA] : Object | semmle.label | [post] access to local variable a [field FieldA] : Object |
-| H.cs:88:17:88:17 | [post] access to local variable a [field FieldA] : Object | semmle.label | [post] access to local variable a [field FieldA] : Object |
-| H.cs:88:20:88:36 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
 | H.cs:88:20:88:36 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
 | H.cs:88:39:88:40 | [post] access to local variable b1 [field FieldB] : Object | semmle.label | [post] access to local variable b1 [field FieldB] : Object |
-| H.cs:88:39:88:40 | [post] access to local variable b1 [field FieldB] : Object | semmle.label | [post] access to local variable b1 [field FieldB] : Object |
-| H.cs:89:14:89:14 | access to local variable a [field FieldA] : Object | semmle.label | access to local variable a [field FieldA] : Object |
 | H.cs:89:14:89:14 | access to local variable a [field FieldA] : Object | semmle.label | access to local variable a [field FieldA] : Object |
 | H.cs:89:14:89:21 | access to field FieldA | semmle.label | access to field FieldA |
-| H.cs:89:14:89:21 | access to field FieldA | semmle.label | access to field FieldA |
-| H.cs:90:14:90:15 | access to local variable b1 [field FieldB] : Object | semmle.label | access to local variable b1 [field FieldB] : Object |
 | H.cs:90:14:90:15 | access to local variable b1 [field FieldB] : Object | semmle.label | access to local variable b1 [field FieldB] : Object |
 | H.cs:90:14:90:22 | access to field FieldB | semmle.label | access to field FieldB |
-| H.cs:90:14:90:22 | access to field FieldB | semmle.label | access to field FieldB |
-| H.cs:102:23:102:23 | a [field FieldA] : Object | semmle.label | a [field FieldA] : Object |
 | H.cs:102:23:102:23 | a [field FieldA] : Object | semmle.label | a [field FieldA] : Object |
 | H.cs:105:9:105:12 | [post] access to local variable temp [field FieldB, field FieldA] : Object | semmle.label | [post] access to local variable temp [field FieldB, field FieldA] : Object |
-| H.cs:105:9:105:12 | [post] access to local variable temp [field FieldB, field FieldA] : Object | semmle.label | [post] access to local variable temp [field FieldB, field FieldA] : Object |
-| H.cs:105:23:105:23 | access to parameter a [field FieldA] : Object | semmle.label | access to parameter a [field FieldA] : Object |
 | H.cs:105:23:105:23 | access to parameter a [field FieldA] : Object | semmle.label | access to parameter a [field FieldA] : Object |
 | H.cs:106:16:106:40 | call to method Transform [field FieldB] : Object | semmle.label | call to method Transform [field FieldB] : Object |
-| H.cs:106:16:106:40 | call to method Transform [field FieldB] : Object | semmle.label | call to method Transform [field FieldB] : Object |
-| H.cs:106:26:106:39 | (...) ... [field FieldA] : Object | semmle.label | (...) ... [field FieldA] : Object |
 | H.cs:106:26:106:39 | (...) ... [field FieldA] : Object | semmle.label | (...) ... [field FieldA] : Object |
 | H.cs:106:29:106:32 | access to local variable temp [field FieldB, field FieldA] : Object | semmle.label | access to local variable temp [field FieldB, field FieldA] : Object |
-| H.cs:106:29:106:32 | access to local variable temp [field FieldB, field FieldA] : Object | semmle.label | access to local variable temp [field FieldB, field FieldA] : Object |
-| H.cs:106:29:106:39 | access to field FieldB [field FieldA] : Object | semmle.label | access to field FieldB [field FieldA] : Object |
 | H.cs:106:29:106:39 | access to field FieldB [field FieldA] : Object | semmle.label | access to field FieldB [field FieldA] : Object |
 | H.cs:112:9:112:9 | [post] access to local variable a [field FieldA] : Object | semmle.label | [post] access to local variable a [field FieldA] : Object |
-| H.cs:112:9:112:9 | [post] access to local variable a [field FieldA] : Object | semmle.label | [post] access to local variable a [field FieldA] : Object |
-| H.cs:112:20:112:36 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
 | H.cs:112:20:112:36 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
 | H.cs:113:17:113:32 | call to method TransformWrap [field FieldB] : Object | semmle.label | call to method TransformWrap [field FieldB] : Object |
-| H.cs:113:17:113:32 | call to method TransformWrap [field FieldB] : Object | semmle.label | call to method TransformWrap [field FieldB] : Object |
-| H.cs:113:31:113:31 | access to local variable a [field FieldA] : Object | semmle.label | access to local variable a [field FieldA] : Object |
 | H.cs:113:31:113:31 | access to local variable a [field FieldA] : Object | semmle.label | access to local variable a [field FieldA] : Object |
 | H.cs:114:14:114:14 | access to local variable b [field FieldB] : Object | semmle.label | access to local variable b [field FieldB] : Object |
-| H.cs:114:14:114:14 | access to local variable b [field FieldB] : Object | semmle.label | access to local variable b [field FieldB] : Object |
-| H.cs:114:14:114:21 | access to field FieldB | semmle.label | access to field FieldB |
 | H.cs:114:14:114:21 | access to field FieldB | semmle.label | access to field FieldB |
 | H.cs:122:18:122:18 | a [field FieldA] : Object | semmle.label | a [field FieldA] : Object |
-| H.cs:122:18:122:18 | a [field FieldA] : Object | semmle.label | a [field FieldA] : Object |
-| H.cs:124:16:124:27 | call to method Transform [field FieldB] : Object | semmle.label | call to method Transform [field FieldB] : Object |
 | H.cs:124:16:124:27 | call to method Transform [field FieldB] : Object | semmle.label | call to method Transform [field FieldB] : Object |
 | H.cs:124:16:124:34 | access to field FieldB : Object | semmle.label | access to field FieldB : Object |
-| H.cs:124:16:124:34 | access to field FieldB : Object | semmle.label | access to field FieldB : Object |
-| H.cs:124:26:124:26 | access to parameter a [field FieldA] : Object | semmle.label | access to parameter a [field FieldA] : Object |
 | H.cs:124:26:124:26 | access to parameter a [field FieldA] : Object | semmle.label | access to parameter a [field FieldA] : Object |
 | H.cs:130:9:130:9 | [post] access to local variable a [field FieldA] : Object | semmle.label | [post] access to local variable a [field FieldA] : Object |
-| H.cs:130:9:130:9 | [post] access to local variable a [field FieldA] : Object | semmle.label | [post] access to local variable a [field FieldA] : Object |
-| H.cs:130:20:130:36 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
 | H.cs:130:20:130:36 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
 | H.cs:131:14:131:19 | call to method Get | semmle.label | call to method Get |
-| H.cs:131:14:131:19 | call to method Get | semmle.label | call to method Get |
-| H.cs:131:18:131:18 | access to local variable a [field FieldA] : Object | semmle.label | access to local variable a [field FieldA] : Object |
 | H.cs:131:18:131:18 | access to local variable a [field FieldA] : Object | semmle.label | access to local variable a [field FieldA] : Object |
 | H.cs:138:27:138:27 | o : A | semmle.label | o : A |
-| H.cs:138:27:138:27 | o : A | semmle.label | o : A |
-| H.cs:141:9:141:9 | [post] access to local variable a [field FieldA] : A | semmle.label | [post] access to local variable a [field FieldA] : A |
 | H.cs:141:9:141:9 | [post] access to local variable a [field FieldA] : A | semmle.label | [post] access to local variable a [field FieldA] : A |
 | H.cs:141:20:141:25 | ... as ... : A | semmle.label | ... as ... : A |
-| H.cs:141:20:141:25 | ... as ... : A | semmle.label | ... as ... : A |
-| H.cs:142:16:142:27 | call to method Transform [field FieldB] : A | semmle.label | call to method Transform [field FieldB] : A |
 | H.cs:142:16:142:27 | call to method Transform [field FieldB] : A | semmle.label | call to method Transform [field FieldB] : A |
 | H.cs:142:16:142:34 | access to field FieldB : A | semmle.label | access to field FieldB : A |
-| H.cs:142:16:142:34 | access to field FieldB : A | semmle.label | access to field FieldB : A |
-| H.cs:142:26:142:26 | access to local variable a [field FieldA] : A | semmle.label | access to local variable a [field FieldA] : A |
 | H.cs:142:26:142:26 | access to local variable a [field FieldA] : A | semmle.label | access to local variable a [field FieldA] : A |
 | H.cs:147:17:147:39 | call to method Through : A | semmle.label | call to method Through : A |
-| H.cs:147:17:147:39 | call to method Through : A | semmle.label | call to method Through : A |
-| H.cs:147:25:147:38 | call to method Source<A> : A | semmle.label | call to method Source<A> : A |
 | H.cs:147:25:147:38 | call to method Source<A> : A | semmle.label | call to method Source<A> : A |
 | H.cs:148:14:148:14 | access to local variable a | semmle.label | access to local variable a |
-| H.cs:148:14:148:14 | access to local variable a | semmle.label | access to local variable a |
-| H.cs:153:32:153:32 | o : Object | semmle.label | o : Object |
 | H.cs:153:32:153:32 | o : Object | semmle.label | o : Object |
 | H.cs:155:17:155:30 | call to method Source<B> : B | semmle.label | call to method Source<B> : B |
-| H.cs:155:17:155:30 | call to method Source<B> : B | semmle.label | call to method Source<B> : B |
-| H.cs:156:9:156:9 | [post] access to local variable b [field FieldB] : Object | semmle.label | [post] access to local variable b [field FieldB] : Object |
 | H.cs:156:9:156:9 | [post] access to local variable b [field FieldB] : Object | semmle.label | [post] access to local variable b [field FieldB] : Object |
 | H.cs:156:9:156:9 | access to local variable b : B | semmle.label | access to local variable b : B |
-| H.cs:156:9:156:9 | access to local variable b : B | semmle.label | access to local variable b : B |
-| H.cs:156:20:156:20 | access to parameter o : Object | semmle.label | access to parameter o : Object |
 | H.cs:156:20:156:20 | access to parameter o : Object | semmle.label | access to parameter o : Object |
 | H.cs:157:9:157:9 | [post] access to parameter a [field FieldA, field FieldB] : Object | semmle.label | [post] access to parameter a [field FieldA, field FieldB] : Object |
-| H.cs:157:9:157:9 | [post] access to parameter a [field FieldA, field FieldB] : Object | semmle.label | [post] access to parameter a [field FieldA, field FieldB] : Object |
-| H.cs:157:9:157:9 | [post] access to parameter a [field FieldA] : B | semmle.label | [post] access to parameter a [field FieldA] : B |
 | H.cs:157:9:157:9 | [post] access to parameter a [field FieldA] : B | semmle.label | [post] access to parameter a [field FieldA] : B |
 | H.cs:157:20:157:20 | access to local variable b : B | semmle.label | access to local variable b : B |
-| H.cs:157:20:157:20 | access to local variable b : B | semmle.label | access to local variable b : B |
-| H.cs:157:20:157:20 | access to local variable b [field FieldB] : Object | semmle.label | access to local variable b [field FieldB] : Object |
 | H.cs:157:20:157:20 | access to local variable b [field FieldB] : Object | semmle.label | access to local variable b [field FieldB] : Object |
 | H.cs:163:17:163:35 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
-| H.cs:163:17:163:35 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
-| H.cs:164:19:164:19 | [post] access to local variable a [field FieldA, field FieldB] : Object | semmle.label | [post] access to local variable a [field FieldA, field FieldB] : Object |
 | H.cs:164:19:164:19 | [post] access to local variable a [field FieldA, field FieldB] : Object | semmle.label | [post] access to local variable a [field FieldA, field FieldB] : Object |
 | H.cs:164:19:164:19 | [post] access to local variable a [field FieldA] : B | semmle.label | [post] access to local variable a [field FieldA] : B |
-| H.cs:164:19:164:19 | [post] access to local variable a [field FieldA] : B | semmle.label | [post] access to local variable a [field FieldA] : B |
-| H.cs:164:22:164:22 | access to local variable o : Object | semmle.label | access to local variable o : Object |
 | H.cs:164:22:164:22 | access to local variable o : Object | semmle.label | access to local variable o : Object |
 | H.cs:165:17:165:27 | (...) ... : B | semmle.label | (...) ... : B |
-| H.cs:165:17:165:27 | (...) ... : B | semmle.label | (...) ... : B |
-| H.cs:165:17:165:27 | (...) ... [field FieldB] : Object | semmle.label | (...) ... [field FieldB] : Object |
 | H.cs:165:17:165:27 | (...) ... [field FieldB] : Object | semmle.label | (...) ... [field FieldB] : Object |
 | H.cs:165:20:165:20 | access to local variable a [field FieldA, field FieldB] : Object | semmle.label | access to local variable a [field FieldA, field FieldB] : Object |
-| H.cs:165:20:165:20 | access to local variable a [field FieldA, field FieldB] : Object | semmle.label | access to local variable a [field FieldA, field FieldB] : Object |
-| H.cs:165:20:165:20 | access to local variable a [field FieldA] : B | semmle.label | access to local variable a [field FieldA] : B |
 | H.cs:165:20:165:20 | access to local variable a [field FieldA] : B | semmle.label | access to local variable a [field FieldA] : B |
 | H.cs:165:20:165:27 | access to field FieldA : B | semmle.label | access to field FieldA : B |
-| H.cs:165:20:165:27 | access to field FieldA : B | semmle.label | access to field FieldA : B |
-| H.cs:165:20:165:27 | access to field FieldA [field FieldB] : Object | semmle.label | access to field FieldA [field FieldB] : Object |
 | H.cs:165:20:165:27 | access to field FieldA [field FieldB] : Object | semmle.label | access to field FieldA [field FieldB] : Object |
 | H.cs:166:14:166:14 | access to local variable b | semmle.label | access to local variable b |
-| H.cs:166:14:166:14 | access to local variable b | semmle.label | access to local variable b |
-| H.cs:167:14:167:14 | access to local variable b [field FieldB] : Object | semmle.label | access to local variable b [field FieldB] : Object |
 | H.cs:167:14:167:14 | access to local variable b [field FieldB] : Object | semmle.label | access to local variable b [field FieldB] : Object |
 | H.cs:167:14:167:21 | access to field FieldB | semmle.label | access to field FieldB |
-| H.cs:167:14:167:21 | access to field FieldB | semmle.label | access to field FieldB |
-| I.cs:7:9:7:14 | [post] this access [field Field1] : Object | semmle.label | [post] this access [field Field1] : Object |
 | I.cs:7:9:7:14 | [post] this access [field Field1] : Object | semmle.label | [post] this access [field Field1] : Object |
 | I.cs:7:18:7:34 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
-| I.cs:7:18:7:34 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
-| I.cs:13:17:13:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
 | I.cs:13:17:13:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
 | I.cs:15:9:15:9 | [post] access to local variable i [field Field1] : Object | semmle.label | [post] access to local variable i [field Field1] : Object |
-| I.cs:15:9:15:9 | [post] access to local variable i [field Field1] : Object | semmle.label | [post] access to local variable i [field Field1] : Object |
-| I.cs:15:20:15:20 | access to local variable o : Object | semmle.label | access to local variable o : Object |
 | I.cs:15:20:15:20 | access to local variable o : Object | semmle.label | access to local variable o : Object |
 | I.cs:16:9:16:9 | access to local variable i [field Field1] : Object | semmle.label | access to local variable i [field Field1] : Object |
-| I.cs:16:9:16:9 | access to local variable i [field Field1] : Object | semmle.label | access to local variable i [field Field1] : Object |
-| I.cs:17:9:17:9 | access to local variable i [field Field1] : Object | semmle.label | access to local variable i [field Field1] : Object |
 | I.cs:17:9:17:9 | access to local variable i [field Field1] : Object | semmle.label | access to local variable i [field Field1] : Object |
 | I.cs:18:14:18:14 | access to local variable i [field Field1] : Object | semmle.label | access to local variable i [field Field1] : Object |
-| I.cs:18:14:18:14 | access to local variable i [field Field1] : Object | semmle.label | access to local variable i [field Field1] : Object |
-| I.cs:18:14:18:21 | access to field Field1 | semmle.label | access to field Field1 |
 | I.cs:18:14:18:21 | access to field Field1 | semmle.label | access to field Field1 |
 | I.cs:21:13:21:19 | object creation of type I [field Field1] : Object | semmle.label | object creation of type I [field Field1] : Object |
-| I.cs:21:13:21:19 | object creation of type I [field Field1] : Object | semmle.label | object creation of type I [field Field1] : Object |
-| I.cs:22:9:22:9 | access to local variable i [field Field1] : Object | semmle.label | access to local variable i [field Field1] : Object |
 | I.cs:22:9:22:9 | access to local variable i [field Field1] : Object | semmle.label | access to local variable i [field Field1] : Object |
 | I.cs:23:14:23:14 | access to local variable i [field Field1] : Object | semmle.label | access to local variable i [field Field1] : Object |
-| I.cs:23:14:23:14 | access to local variable i [field Field1] : Object | semmle.label | access to local variable i [field Field1] : Object |
-| I.cs:23:14:23:21 | access to field Field1 | semmle.label | access to field Field1 |
 | I.cs:23:14:23:21 | access to field Field1 | semmle.label | access to field Field1 |
 | I.cs:26:13:26:37 | [pre-initializer] object creation of type I [field Field1] : Object | semmle.label | [pre-initializer] object creation of type I [field Field1] : Object |
-| I.cs:26:13:26:37 | [pre-initializer] object creation of type I [field Field1] : Object | semmle.label | [pre-initializer] object creation of type I [field Field1] : Object |
-| I.cs:27:14:27:14 | access to local variable i [field Field1] : Object | semmle.label | access to local variable i [field Field1] : Object |
 | I.cs:27:14:27:14 | access to local variable i [field Field1] : Object | semmle.label | access to local variable i [field Field1] : Object |
 | I.cs:27:14:27:21 | access to field Field1 | semmle.label | access to field Field1 |
-| I.cs:27:14:27:21 | access to field Field1 | semmle.label | access to field Field1 |
-| I.cs:31:13:31:29 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
 | I.cs:31:13:31:29 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
 | I.cs:32:9:32:9 | [post] access to local variable i [field Field1] : Object | semmle.label | [post] access to local variable i [field Field1] : Object |
-| I.cs:32:9:32:9 | [post] access to local variable i [field Field1] : Object | semmle.label | [post] access to local variable i [field Field1] : Object |
-| I.cs:32:20:32:20 | access to local variable o : Object | semmle.label | access to local variable o : Object |
 | I.cs:32:20:32:20 | access to local variable o : Object | semmle.label | access to local variable o : Object |
 | I.cs:33:9:33:9 | access to local variable i [field Field1] : Object | semmle.label | access to local variable i [field Field1] : Object |
-| I.cs:33:9:33:9 | access to local variable i [field Field1] : Object | semmle.label | access to local variable i [field Field1] : Object |
-| I.cs:34:12:34:12 | access to local variable i [field Field1] : Object | semmle.label | access to local variable i [field Field1] : Object |
 | I.cs:34:12:34:12 | access to local variable i [field Field1] : Object | semmle.label | access to local variable i [field Field1] : Object |
 | I.cs:37:23:37:23 | i [field Field1] : Object | semmle.label | i [field Field1] : Object |
-| I.cs:37:23:37:23 | i [field Field1] : Object | semmle.label | i [field Field1] : Object |
-| I.cs:39:9:39:9 | access to parameter i [field Field1] : Object | semmle.label | access to parameter i [field Field1] : Object |
 | I.cs:39:9:39:9 | access to parameter i [field Field1] : Object | semmle.label | access to parameter i [field Field1] : Object |
 | I.cs:40:14:40:14 | access to parameter i [field Field1] : Object | semmle.label | access to parameter i [field Field1] : Object |
-| I.cs:40:14:40:14 | access to parameter i [field Field1] : Object | semmle.label | access to parameter i [field Field1] : Object |
-| I.cs:40:14:40:21 | access to field Field1 | semmle.label | access to field Field1 |
 | I.cs:40:14:40:21 | access to field Field1 | semmle.label | access to field Field1 |
 | J.cs:14:26:14:30 | field : Object | semmle.label | field : Object |
-| J.cs:14:26:14:30 | field : Object | semmle.label | field : Object |
-| J.cs:14:40:14:43 | prop : Object | semmle.label | prop : Object |
 | J.cs:14:40:14:43 | prop : Object | semmle.label | prop : Object |
 | J.cs:14:50:14:54 | [post] this access [field Field] : Object | semmle.label | [post] this access [field Field] : Object |
-| J.cs:14:50:14:54 | [post] this access [field Field] : Object | semmle.label | [post] this access [field Field] : Object |
-| J.cs:14:57:14:60 | [post] this access [property Prop] : Object | semmle.label | [post] this access [property Prop] : Object |
 | J.cs:14:57:14:60 | [post] this access [property Prop] : Object | semmle.label | [post] this access [property Prop] : Object |
 | J.cs:14:66:14:70 | access to parameter field : Object | semmle.label | access to parameter field : Object |
-| J.cs:14:66:14:70 | access to parameter field : Object | semmle.label | access to parameter field : Object |
-| J.cs:14:73:14:76 | access to parameter prop : Object | semmle.label | access to parameter prop : Object |
 | J.cs:14:73:14:76 | access to parameter prop : Object | semmle.label | access to parameter prop : Object |
 | J.cs:21:17:21:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
-| J.cs:21:17:21:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
-| J.cs:22:18:22:41 | object creation of type RecordClass [property Prop1] : Object | semmle.label | object creation of type RecordClass [property Prop1] : Object |
 | J.cs:22:18:22:41 | object creation of type RecordClass [property Prop1] : Object | semmle.label | object creation of type RecordClass [property Prop1] : Object |
 | J.cs:22:34:22:34 | access to local variable o : Object | semmle.label | access to local variable o : Object |
-| J.cs:22:34:22:34 | access to local variable o : Object | semmle.label | access to local variable o : Object |
-| J.cs:23:14:23:15 | access to local variable r1 [property Prop1] : Object | semmle.label | access to local variable r1 [property Prop1] : Object |
 | J.cs:23:14:23:15 | access to local variable r1 [property Prop1] : Object | semmle.label | access to local variable r1 [property Prop1] : Object |
 | J.cs:23:14:23:21 | access to property Prop1 | semmle.label | access to property Prop1 |
-| J.cs:23:14:23:21 | access to property Prop1 | semmle.label | access to property Prop1 |
-| J.cs:27:14:27:15 | access to local variable r2 [property Prop1] : Object | semmle.label | access to local variable r2 [property Prop1] : Object |
 | J.cs:27:14:27:15 | access to local variable r2 [property Prop1] : Object | semmle.label | access to local variable r2 [property Prop1] : Object |
 | J.cs:27:14:27:21 | access to property Prop1 | semmle.label | access to property Prop1 |
-| J.cs:27:14:27:21 | access to property Prop1 | semmle.label | access to property Prop1 |
-| J.cs:30:18:30:54 | ... with { ... } [property Prop2] : Object | semmle.label | ... with { ... } [property Prop2] : Object |
 | J.cs:30:18:30:54 | ... with { ... } [property Prop2] : Object | semmle.label | ... with { ... } [property Prop2] : Object |
 | J.cs:30:36:30:52 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
-| J.cs:30:36:30:52 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
-| J.cs:31:14:31:15 | access to local variable r3 [property Prop1] : Object | semmle.label | access to local variable r3 [property Prop1] : Object |
 | J.cs:31:14:31:15 | access to local variable r3 [property Prop1] : Object | semmle.label | access to local variable r3 [property Prop1] : Object |
 | J.cs:31:14:31:21 | access to property Prop1 | semmle.label | access to property Prop1 |
-| J.cs:31:14:31:21 | access to property Prop1 | semmle.label | access to property Prop1 |
-| J.cs:32:14:32:15 | access to local variable r3 [property Prop2] : Object | semmle.label | access to local variable r3 [property Prop2] : Object |
 | J.cs:32:14:32:15 | access to local variable r3 [property Prop2] : Object | semmle.label | access to local variable r3 [property Prop2] : Object |
 | J.cs:32:14:32:21 | access to property Prop2 | semmle.label | access to property Prop2 |
-| J.cs:32:14:32:21 | access to property Prop2 | semmle.label | access to property Prop2 |
-| J.cs:41:17:41:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
 | J.cs:41:17:41:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
 | J.cs:42:18:42:42 | object creation of type RecordStruct [property Prop1] : Object | semmle.label | object creation of type RecordStruct [property Prop1] : Object |
-| J.cs:42:18:42:42 | object creation of type RecordStruct [property Prop1] : Object | semmle.label | object creation of type RecordStruct [property Prop1] : Object |
-| J.cs:42:35:42:35 | access to local variable o : Object | semmle.label | access to local variable o : Object |
 | J.cs:42:35:42:35 | access to local variable o : Object | semmle.label | access to local variable o : Object |
 | J.cs:43:14:43:15 | access to local variable r1 [property Prop1] : Object | semmle.label | access to local variable r1 [property Prop1] : Object |
-| J.cs:43:14:43:15 | access to local variable r1 [property Prop1] : Object | semmle.label | access to local variable r1 [property Prop1] : Object |
-| J.cs:43:14:43:21 | access to property Prop1 | semmle.label | access to property Prop1 |
 | J.cs:43:14:43:21 | access to property Prop1 | semmle.label | access to property Prop1 |
 | J.cs:47:14:47:15 | access to local variable r2 [property Prop1] : Object | semmle.label | access to local variable r2 [property Prop1] : Object |
-| J.cs:47:14:47:15 | access to local variable r2 [property Prop1] : Object | semmle.label | access to local variable r2 [property Prop1] : Object |
-| J.cs:47:14:47:21 | access to property Prop1 | semmle.label | access to property Prop1 |
 | J.cs:47:14:47:21 | access to property Prop1 | semmle.label | access to property Prop1 |
 | J.cs:50:18:50:54 | ... with { ... } [property Prop2] : Object | semmle.label | ... with { ... } [property Prop2] : Object |
-| J.cs:50:18:50:54 | ... with { ... } [property Prop2] : Object | semmle.label | ... with { ... } [property Prop2] : Object |
-| J.cs:50:36:50:52 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
 | J.cs:50:36:50:52 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
 | J.cs:51:14:51:15 | access to local variable r3 [property Prop1] : Object | semmle.label | access to local variable r3 [property Prop1] : Object |
-| J.cs:51:14:51:15 | access to local variable r3 [property Prop1] : Object | semmle.label | access to local variable r3 [property Prop1] : Object |
-| J.cs:51:14:51:21 | access to property Prop1 | semmle.label | access to property Prop1 |
 | J.cs:51:14:51:21 | access to property Prop1 | semmle.label | access to property Prop1 |
 | J.cs:52:14:52:15 | access to local variable r3 [property Prop2] : Object | semmle.label | access to local variable r3 [property Prop2] : Object |
-| J.cs:52:14:52:15 | access to local variable r3 [property Prop2] : Object | semmle.label | access to local variable r3 [property Prop2] : Object |
-| J.cs:52:14:52:21 | access to property Prop2 | semmle.label | access to property Prop2 |
 | J.cs:52:14:52:21 | access to property Prop2 | semmle.label | access to property Prop2 |
 | J.cs:61:17:61:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
-| J.cs:61:17:61:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
-| J.cs:62:18:62:36 | object creation of type Struct [field Field] : Object | semmle.label | object creation of type Struct [field Field] : Object |
 | J.cs:62:18:62:36 | object creation of type Struct [field Field] : Object | semmle.label | object creation of type Struct [field Field] : Object |
 | J.cs:62:29:62:29 | access to local variable o : Object | semmle.label | access to local variable o : Object |
-| J.cs:62:29:62:29 | access to local variable o : Object | semmle.label | access to local variable o : Object |
-| J.cs:65:14:65:15 | access to local variable s2 [field Field] : Object | semmle.label | access to local variable s2 [field Field] : Object |
 | J.cs:65:14:65:15 | access to local variable s2 [field Field] : Object | semmle.label | access to local variable s2 [field Field] : Object |
 | J.cs:65:14:65:21 | access to field Field | semmle.label | access to field Field |
-| J.cs:65:14:65:21 | access to field Field | semmle.label | access to field Field |
-| J.cs:68:18:68:53 | ... with { ... } [property Prop] : Object | semmle.label | ... with { ... } [property Prop] : Object |
 | J.cs:68:18:68:53 | ... with { ... } [property Prop] : Object | semmle.label | ... with { ... } [property Prop] : Object |
 | J.cs:68:35:68:51 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
-| J.cs:68:35:68:51 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
-| J.cs:69:14:69:15 | access to local variable s3 [field Field] : Object | semmle.label | access to local variable s3 [field Field] : Object |
 | J.cs:69:14:69:15 | access to local variable s3 [field Field] : Object | semmle.label | access to local variable s3 [field Field] : Object |
 | J.cs:69:14:69:21 | access to field Field | semmle.label | access to field Field |
-| J.cs:69:14:69:21 | access to field Field | semmle.label | access to field Field |
-| J.cs:70:14:70:15 | access to local variable s3 [property Prop] : Object | semmle.label | access to local variable s3 [property Prop] : Object |
 | J.cs:70:14:70:15 | access to local variable s3 [property Prop] : Object | semmle.label | access to local variable s3 [property Prop] : Object |
 | J.cs:70:14:70:20 | access to property Prop | semmle.label | access to property Prop |
-| J.cs:70:14:70:20 | access to property Prop | semmle.label | access to property Prop |
-| J.cs:79:17:79:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
 | J.cs:79:17:79:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
 | J.cs:80:18:80:36 | object creation of type Struct [property Prop] : Object | semmle.label | object creation of type Struct [property Prop] : Object |
-| J.cs:80:18:80:36 | object creation of type Struct [property Prop] : Object | semmle.label | object creation of type Struct [property Prop] : Object |
-| J.cs:80:35:80:35 | access to local variable o : Object | semmle.label | access to local variable o : Object |
 | J.cs:80:35:80:35 | access to local variable o : Object | semmle.label | access to local variable o : Object |
 | J.cs:84:14:84:15 | access to local variable s2 [property Prop] : Object | semmle.label | access to local variable s2 [property Prop] : Object |
-| J.cs:84:14:84:15 | access to local variable s2 [property Prop] : Object | semmle.label | access to local variable s2 [property Prop] : Object |
-| J.cs:84:14:84:20 | access to property Prop | semmle.label | access to property Prop |
 | J.cs:84:14:84:20 | access to property Prop | semmle.label | access to property Prop |
 | J.cs:86:18:86:54 | ... with { ... } [field Field] : Object | semmle.label | ... with { ... } [field Field] : Object |
-| J.cs:86:18:86:54 | ... with { ... } [field Field] : Object | semmle.label | ... with { ... } [field Field] : Object |
-| J.cs:86:36:86:52 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
 | J.cs:86:36:86:52 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
 | J.cs:87:14:87:15 | access to local variable s3 [field Field] : Object | semmle.label | access to local variable s3 [field Field] : Object |
-| J.cs:87:14:87:15 | access to local variable s3 [field Field] : Object | semmle.label | access to local variable s3 [field Field] : Object |
-| J.cs:87:14:87:21 | access to field Field | semmle.label | access to field Field |
 | J.cs:87:14:87:21 | access to field Field | semmle.label | access to field Field |
 | J.cs:88:14:88:15 | access to local variable s3 [property Prop] : Object | semmle.label | access to local variable s3 [property Prop] : Object |
-| J.cs:88:14:88:15 | access to local variable s3 [property Prop] : Object | semmle.label | access to local variable s3 [property Prop] : Object |
-| J.cs:88:14:88:20 | access to property Prop | semmle.label | access to property Prop |
 | J.cs:88:14:88:20 | access to property Prop | semmle.label | access to property Prop |
 | J.cs:97:17:97:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
-| J.cs:97:17:97:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
-| J.cs:99:18:99:41 | { ..., ... } [property X] : Object | semmle.label | { ..., ... } [property X] : Object |
 | J.cs:99:18:99:41 | { ..., ... } [property X] : Object | semmle.label | { ..., ... } [property X] : Object |
 | J.cs:99:28:99:28 | access to local variable o : Object | semmle.label | access to local variable o : Object |
-| J.cs:99:28:99:28 | access to local variable o : Object | semmle.label | access to local variable o : Object |
-| J.cs:102:14:102:15 | access to local variable a2 [property X] : Object | semmle.label | access to local variable a2 [property X] : Object |
 | J.cs:102:14:102:15 | access to local variable a2 [property X] : Object | semmle.label | access to local variable a2 [property X] : Object |
 | J.cs:102:14:102:17 | access to property X | semmle.label | access to property X |
-| J.cs:102:14:102:17 | access to property X | semmle.label | access to property X |
-| J.cs:105:18:105:50 | ... with { ... } [property Y] : Object | semmle.label | ... with { ... } [property Y] : Object |
 | J.cs:105:18:105:50 | ... with { ... } [property Y] : Object | semmle.label | ... with { ... } [property Y] : Object |
 | J.cs:105:32:105:48 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
-| J.cs:105:32:105:48 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
-| J.cs:106:14:106:15 | access to local variable a3 [property X] : Object | semmle.label | access to local variable a3 [property X] : Object |
 | J.cs:106:14:106:15 | access to local variable a3 [property X] : Object | semmle.label | access to local variable a3 [property X] : Object |
 | J.cs:106:14:106:17 | access to property X | semmle.label | access to property X |
-| J.cs:106:14:106:17 | access to property X | semmle.label | access to property X |
-| J.cs:107:14:107:15 | access to local variable a3 [property Y] : Object | semmle.label | access to local variable a3 [property Y] : Object |
 | J.cs:107:14:107:15 | access to local variable a3 [property Y] : Object | semmle.label | access to local variable a3 [property Y] : Object |
 | J.cs:107:14:107:17 | access to property Y | semmle.label | access to property Y |
-| J.cs:107:14:107:17 | access to property Y | semmle.label | access to property Y |
-| J.cs:119:13:119:13 | [post] access to local variable a [element] : Int32 | semmle.label | [post] access to local variable a [element] : Int32 |
 | J.cs:119:13:119:13 | [post] access to local variable a [element] : Int32 | semmle.label | [post] access to local variable a [element] : Int32 |
 | J.cs:119:20:119:34 | call to method Source<Int32> : Int32 | semmle.label | call to method Source<Int32> : Int32 |
-| J.cs:119:20:119:34 | call to method Source<Int32> : Int32 | semmle.label | call to method Source<Int32> : Int32 |
-| J.cs:125:14:125:14 | access to local variable a [element] : Int32 | semmle.label | access to local variable a [element] : Int32 |
 | J.cs:125:14:125:14 | access to local variable a [element] : Int32 | semmle.label | access to local variable a [element] : Int32 |
 | J.cs:125:14:125:17 | (...) ... | semmle.label | (...) ... |
-| J.cs:125:14:125:17 | (...) ... | semmle.label | (...) ... |
-| J.cs:125:14:125:17 | access to array element : Int32 | semmle.label | access to array element : Int32 |
 | J.cs:125:14:125:17 | access to array element : Int32 | semmle.label | access to array element : Int32 |
 subpaths
 | A.cs:6:24:6:24 | access to local variable c : C | A.cs:147:32:147:32 | c : C | A.cs:149:20:149:27 | object creation of type B [field c] : C | A.cs:6:17:6:25 | call to method Make [field c] : C |
-| A.cs:6:24:6:24 | access to local variable c : C | A.cs:147:32:147:32 | c : C | A.cs:149:20:149:27 | object creation of type B [field c] : C | A.cs:6:17:6:25 | call to method Make [field c] : C |
-| A.cs:13:15:13:29 | call to method Source<C1> : C1 | A.cs:145:27:145:27 | c : C1 | A.cs:145:32:145:35 | [post] this access [field c] : C1 | A.cs:13:9:13:9 | [post] access to local variable b [field c] : C1 |
 | A.cs:13:15:13:29 | call to method Source<C1> : C1 | A.cs:145:27:145:27 | c : C1 | A.cs:145:32:145:35 | [post] this access [field c] : C1 | A.cs:13:9:13:9 | [post] access to local variable b [field c] : C1 |
 | A.cs:14:14:14:14 | access to local variable b [field c] : C1 | A.cs:146:18:146:20 | this [field c] : C1 | A.cs:146:33:146:38 | access to field c : C1 | A.cs:14:14:14:20 | call to method Get |
-| A.cs:14:14:14:14 | access to local variable b [field c] : C1 | A.cs:146:18:146:20 | this [field c] : C1 | A.cs:146:33:146:38 | access to field c : C1 | A.cs:14:14:14:20 | call to method Get |
-| A.cs:15:15:15:35 | object creation of type B [field c] : C | A.cs:146:18:146:20 | this [field c] : C | A.cs:146:33:146:38 | access to field c : C | A.cs:15:14:15:42 | call to method Get |
 | A.cs:15:15:15:35 | object creation of type B [field c] : C | A.cs:146:18:146:20 | this [field c] : C | A.cs:146:33:146:38 | access to field c : C | A.cs:15:14:15:42 | call to method Get |
 | A.cs:15:21:15:34 | call to method Source<C> : C | A.cs:141:20:141:20 | c : C | A.cs:143:13:143:16 | [post] this access [field c] : C | A.cs:15:15:15:35 | object creation of type B [field c] : C |
-| A.cs:15:21:15:34 | call to method Source<C> : C | A.cs:141:20:141:20 | c : C | A.cs:143:13:143:16 | [post] this access [field c] : C | A.cs:15:15:15:35 | object creation of type B [field c] : C |
-| A.cs:22:25:22:37 | call to method Source<C2> : C2 | A.cs:42:29:42:29 | c : C2 | A.cs:48:20:48:21 | access to local variable b2 [field c] : C2 | A.cs:22:14:22:38 | call to method SetOnB [field c] : C2 |
 | A.cs:22:25:22:37 | call to method Source<C2> : C2 | A.cs:42:29:42:29 | c : C2 | A.cs:48:20:48:21 | access to local variable b2 [field c] : C2 | A.cs:22:14:22:38 | call to method SetOnB [field c] : C2 |
 | A.cs:31:29:31:41 | call to method Source<C2> : C2 | A.cs:36:33:36:33 | c : C2 | A.cs:39:16:39:28 | ... ? ... : ... [field c] : C2 | A.cs:31:14:31:42 | call to method SetOnBWrap [field c] : C2 |
-| A.cs:31:29:31:41 | call to method Source<C2> : C2 | A.cs:36:33:36:33 | c : C2 | A.cs:39:16:39:28 | ... ? ... : ... [field c] : C2 | A.cs:31:14:31:42 | call to method SetOnBWrap [field c] : C2 |
-| A.cs:38:29:38:29 | access to parameter c : C2 | A.cs:42:29:42:29 | c : C2 | A.cs:48:20:48:21 | access to local variable b2 [field c] : C2 | A.cs:38:18:38:30 | call to method SetOnB [field c] : C2 |
 | A.cs:38:29:38:29 | access to parameter c : C2 | A.cs:42:29:42:29 | c : C2 | A.cs:48:20:48:21 | access to local variable b2 [field c] : C2 | A.cs:38:18:38:30 | call to method SetOnB [field c] : C2 |
 | A.cs:47:20:47:20 | access to parameter c : C2 | A.cs:145:27:145:27 | c : C2 | A.cs:145:32:145:35 | [post] this access [field c] : C2 | A.cs:47:13:47:14 | [post] access to local variable b2 [field c] : C2 |
-| A.cs:47:20:47:20 | access to parameter c : C2 | A.cs:145:27:145:27 | c : C2 | A.cs:145:32:145:35 | [post] this access [field c] : C2 | A.cs:47:13:47:14 | [post] access to local variable b2 [field c] : C2 |
-| A.cs:83:15:83:26 | call to method Source<C> : C | A.cs:145:27:145:27 | c : C | A.cs:145:32:145:35 | [post] this access [field c] : C | A.cs:83:9:83:9 | [post] access to parameter b [field c] : C |
 | A.cs:83:15:83:26 | call to method Source<C> : C | A.cs:145:27:145:27 | c : C | A.cs:145:32:145:35 | [post] this access [field c] : C | A.cs:83:9:83:9 | [post] access to parameter b [field c] : C |
 | A.cs:105:23:105:23 | access to local variable b : B | A.cs:95:20:95:20 | b : B | A.cs:98:13:98:16 | [post] this access [field b] : B | A.cs:105:17:105:29 | object creation of type D [field b] : B |
-| A.cs:105:23:105:23 | access to local variable b : B | A.cs:95:20:95:20 | b : B | A.cs:98:13:98:16 | [post] this access [field b] : B | A.cs:105:17:105:29 | object creation of type D [field b] : B |
-| A.cs:114:29:114:29 | access to local variable b : B | A.cs:157:25:157:28 | head : B | A.cs:159:13:159:16 | [post] this access [field head] : B | A.cs:114:18:114:54 | object creation of type MyList [field head] : B |
 | A.cs:114:29:114:29 | access to local variable b : B | A.cs:157:25:157:28 | head : B | A.cs:159:13:159:16 | [post] this access [field head] : B | A.cs:114:18:114:54 | object creation of type MyList [field head] : B |
 | A.cs:115:35:115:36 | access to local variable l1 [field head] : B | A.cs:157:38:157:41 | next [field head] : B | A.cs:160:13:160:16 | [post] this access [field next, field head] : B | A.cs:115:18:115:37 | object creation of type MyList [field next, field head] : B |
-| A.cs:115:35:115:36 | access to local variable l1 [field head] : B | A.cs:157:38:157:41 | next [field head] : B | A.cs:160:13:160:16 | [post] this access [field next, field head] : B | A.cs:115:18:115:37 | object creation of type MyList [field next, field head] : B |
-| A.cs:116:35:116:36 | access to local variable l2 [field next, field head] : B | A.cs:157:38:157:41 | next [field next, field head] : B | A.cs:160:13:160:16 | [post] this access [field next, field next, field head] : B | A.cs:116:18:116:37 | object creation of type MyList [field next, field next, field head] : B |
 | A.cs:116:35:116:36 | access to local variable l2 [field next, field head] : B | A.cs:157:38:157:41 | next [field next, field head] : B | A.cs:160:13:160:16 | [post] this access [field next, field next, field head] : B | A.cs:116:18:116:37 | object creation of type MyList [field next, field next, field head] : B |
 | A.cs:149:26:149:26 | access to parameter c : C | A.cs:141:20:141:20 | c : C | A.cs:143:13:143:16 | [post] this access [field c] : C | A.cs:149:20:149:27 | object creation of type B [field c] : C |
-| A.cs:149:26:149:26 | access to parameter c : C | A.cs:141:20:141:20 | c : C | A.cs:143:13:143:16 | [post] this access [field c] : C | A.cs:149:20:149:27 | object creation of type B [field c] : C |
-| B.cs:6:27:6:27 | access to local variable e : Elem | B.cs:29:26:29:27 | e1 : Elem | B.cs:31:13:31:16 | [post] this access [field elem1] : Elem | B.cs:6:18:6:34 | object creation of type Box1 [field elem1] : Elem |
 | B.cs:6:27:6:27 | access to local variable e : Elem | B.cs:29:26:29:27 | e1 : Elem | B.cs:31:13:31:16 | [post] this access [field elem1] : Elem | B.cs:6:18:6:34 | object creation of type Box1 [field elem1] : Elem |
 | B.cs:7:27:7:28 | access to local variable b1 [field elem1] : Elem | B.cs:39:26:39:27 | b1 [field elem1] : Elem | B.cs:41:13:41:16 | [post] this access [field box1, field elem1] : Elem | B.cs:7:18:7:29 | object creation of type Box2 [field box1, field elem1] : Elem |
-| B.cs:7:27:7:28 | access to local variable b1 [field elem1] : Elem | B.cs:39:26:39:27 | b1 [field elem1] : Elem | B.cs:41:13:41:16 | [post] this access [field box1, field elem1] : Elem | B.cs:7:18:7:29 | object creation of type Box2 [field box1, field elem1] : Elem |
-| B.cs:15:33:15:33 | access to local variable e : Elem | B.cs:29:35:29:36 | e2 : Elem | B.cs:32:13:32:16 | [post] this access [field elem2] : Elem | B.cs:15:18:15:34 | object creation of type Box1 [field elem2] : Elem |
 | B.cs:15:33:15:33 | access to local variable e : Elem | B.cs:29:35:29:36 | e2 : Elem | B.cs:32:13:32:16 | [post] this access [field elem2] : Elem | B.cs:15:18:15:34 | object creation of type Box1 [field elem2] : Elem |
 | B.cs:16:27:16:28 | access to local variable b1 [field elem2] : Elem | B.cs:39:26:39:27 | b1 [field elem2] : Elem | B.cs:41:13:41:16 | [post] this access [field box1, field elem2] : Elem | B.cs:16:18:16:29 | object creation of type Box2 [field box1, field elem2] : Elem |
-| B.cs:16:27:16:28 | access to local variable b1 [field elem2] : Elem | B.cs:39:26:39:27 | b1 [field elem2] : Elem | B.cs:41:13:41:16 | [post] this access [field box1, field elem2] : Elem | B.cs:16:18:16:29 | object creation of type Box2 [field box1, field elem2] : Elem |
-| D.cs:15:34:15:38 | access to parameter value : Object | D.cs:9:9:9:11 | value : Object | D.cs:9:15:9:18 | [post] this access [field trivialPropField] : Object | D.cs:15:15:15:18 | [post] this access [field trivialPropField] : Object |
 | D.cs:15:34:15:38 | access to parameter value : Object | D.cs:9:9:9:11 | value : Object | D.cs:9:15:9:18 | [post] this access [field trivialPropField] : Object | D.cs:15:15:15:18 | [post] this access [field trivialPropField] : Object |
 | D.cs:22:27:22:28 | access to parameter o2 : Object | D.cs:9:9:9:11 | value : Object | D.cs:9:15:9:18 | [post] this access [field trivialPropField] : Object | D.cs:22:9:22:11 | [post] access to local variable ret [field trivialPropField] : Object |
-| D.cs:22:27:22:28 | access to parameter o2 : Object | D.cs:9:9:9:11 | value : Object | D.cs:9:15:9:18 | [post] this access [field trivialPropField] : Object | D.cs:22:9:22:11 | [post] access to local variable ret [field trivialPropField] : Object |
-| D.cs:23:27:23:28 | access to parameter o3 : Object | D.cs:15:9:15:11 | value : Object | D.cs:15:15:15:18 | [post] this access [field trivialPropField] : Object | D.cs:23:9:23:11 | [post] access to local variable ret [field trivialPropField] : Object |
 | D.cs:23:27:23:28 | access to parameter o3 : Object | D.cs:15:9:15:11 | value : Object | D.cs:15:15:15:18 | [post] this access [field trivialPropField] : Object | D.cs:23:9:23:11 | [post] access to local variable ret [field trivialPropField] : Object |
 | D.cs:31:24:31:24 | access to local variable o : Object | D.cs:18:28:18:29 | o1 : Object | D.cs:24:16:24:18 | access to local variable ret [property AutoProp] : Object | D.cs:31:17:31:37 | call to method Create [property AutoProp] : Object |
-| D.cs:31:24:31:24 | access to local variable o : Object | D.cs:18:28:18:29 | o1 : Object | D.cs:24:16:24:18 | access to local variable ret [property AutoProp] : Object | D.cs:31:17:31:37 | call to method Create [property AutoProp] : Object |
-| D.cs:37:26:37:42 | call to method Source<Object> : Object | D.cs:18:39:18:40 | o2 : Object | D.cs:24:16:24:18 | access to local variable ret [field trivialPropField] : Object | D.cs:37:13:37:49 | call to method Create [field trivialPropField] : Object |
 | D.cs:37:26:37:42 | call to method Source<Object> : Object | D.cs:18:39:18:40 | o2 : Object | D.cs:24:16:24:18 | access to local variable ret [field trivialPropField] : Object | D.cs:37:13:37:49 | call to method Create [field trivialPropField] : Object |
 | D.cs:39:14:39:14 | access to local variable d [field trivialPropField] : Object | D.cs:8:9:8:11 | this [field trivialPropField] : Object | D.cs:8:22:8:42 | access to field trivialPropField : Object | D.cs:39:14:39:26 | access to property TrivialProp |
-| D.cs:39:14:39:14 | access to local variable d [field trivialPropField] : Object | D.cs:8:9:8:11 | this [field trivialPropField] : Object | D.cs:8:22:8:42 | access to field trivialPropField : Object | D.cs:39:14:39:26 | access to property TrivialProp |
-| D.cs:41:14:41:14 | access to local variable d [field trivialPropField] : Object | D.cs:14:9:14:11 | this [field trivialPropField] : Object | D.cs:14:22:14:42 | access to field trivialPropField : Object | D.cs:41:14:41:26 | access to property ComplexProp |
 | D.cs:41:14:41:14 | access to local variable d [field trivialPropField] : Object | D.cs:14:9:14:11 | this [field trivialPropField] : Object | D.cs:14:22:14:42 | access to field trivialPropField : Object | D.cs:41:14:41:26 | access to property ComplexProp |
 | D.cs:43:32:43:48 | call to method Source<Object> : Object | D.cs:18:50:18:51 | o3 : Object | D.cs:24:16:24:18 | access to local variable ret [field trivialPropField] : Object | D.cs:43:13:43:49 | call to method Create [field trivialPropField] : Object |
-| D.cs:43:32:43:48 | call to method Source<Object> : Object | D.cs:18:50:18:51 | o3 : Object | D.cs:24:16:24:18 | access to local variable ret [field trivialPropField] : Object | D.cs:43:13:43:49 | call to method Create [field trivialPropField] : Object |
-| D.cs:45:14:45:14 | access to local variable d [field trivialPropField] : Object | D.cs:8:9:8:11 | this [field trivialPropField] : Object | D.cs:8:22:8:42 | access to field trivialPropField : Object | D.cs:45:14:45:26 | access to property TrivialProp |
 | D.cs:45:14:45:14 | access to local variable d [field trivialPropField] : Object | D.cs:8:9:8:11 | this [field trivialPropField] : Object | D.cs:8:22:8:42 | access to field trivialPropField : Object | D.cs:45:14:45:26 | access to property TrivialProp |
 | D.cs:47:14:47:14 | access to local variable d [field trivialPropField] : Object | D.cs:14:9:14:11 | this [field trivialPropField] : Object | D.cs:14:22:14:42 | access to field trivialPropField : Object | D.cs:47:14:47:26 | access to property ComplexProp |
-| D.cs:47:14:47:14 | access to local variable d [field trivialPropField] : Object | D.cs:14:9:14:11 | this [field trivialPropField] : Object | D.cs:14:22:14:42 | access to field trivialPropField : Object | D.cs:47:14:47:26 | access to property ComplexProp |
-| E.cs:23:25:23:25 | access to local variable o : Object | E.cs:8:29:8:29 | o : Object | E.cs:12:16:12:18 | access to local variable ret [field Field] : Object | E.cs:23:17:23:26 | call to method CreateS [field Field] : Object |
 | E.cs:23:25:23:25 | access to local variable o : Object | E.cs:8:29:8:29 | o : Object | E.cs:12:16:12:18 | access to local variable ret [field Field] : Object | E.cs:23:17:23:26 | call to method CreateS [field Field] : Object |
 | F.cs:11:24:11:24 | access to local variable o : Object | F.cs:6:28:6:29 | o1 : Object | F.cs:6:46:6:81 | object creation of type F [field Field1] : Object | F.cs:11:17:11:31 | call to method Create [field Field1] : Object |
-| F.cs:11:24:11:24 | access to local variable o : Object | F.cs:6:28:6:29 | o1 : Object | F.cs:6:46:6:81 | object creation of type F [field Field1] : Object | F.cs:11:17:11:31 | call to method Create [field Field1] : Object |
-| F.cs:15:26:15:42 | call to method Source<Object> : Object | F.cs:6:39:6:40 | o2 : Object | F.cs:6:46:6:81 | object creation of type F [field Field2] : Object | F.cs:15:13:15:43 | call to method Create [field Field2] : Object |
 | F.cs:15:26:15:42 | call to method Source<Object> : Object | F.cs:6:39:6:40 | o2 : Object | F.cs:6:46:6:81 | object creation of type F [field Field2] : Object | F.cs:15:13:15:43 | call to method Create [field Field2] : Object |
 | G.cs:17:24:17:24 | access to local variable e : Elem | G.cs:64:34:64:34 | e : Elem | G.cs:64:39:64:42 | [post] this access [field Elem] : Elem | G.cs:17:9:17:14 | [post] access to field Box1 [field Elem] : Elem |
-| G.cs:17:24:17:24 | access to local variable e : Elem | G.cs:64:34:64:34 | e : Elem | G.cs:64:39:64:42 | [post] this access [field Elem] : Elem | G.cs:17:9:17:14 | [post] access to field Box1 [field Elem] : Elem |
-| G.cs:33:29:33:29 | access to local variable e : Elem | G.cs:64:34:64:34 | e : Elem | G.cs:64:39:64:42 | [post] this access [field Elem] : Elem | G.cs:33:9:33:19 | [post] call to method GetBox1 [field Elem] : Elem |
 | G.cs:33:29:33:29 | access to local variable e : Elem | G.cs:64:34:64:34 | e : Elem | G.cs:64:39:64:42 | [post] this access [field Elem] : Elem | G.cs:33:9:33:19 | [post] call to method GetBox1 [field Elem] : Elem |
 | G.cs:39:14:39:15 | access to parameter b2 [field Box1, field Elem] : Elem | G.cs:71:21:71:27 | this [field Box1, field Elem] : Elem | G.cs:71:34:71:37 | access to field Box1 [field Elem] : Elem | G.cs:39:14:39:25 | call to method GetBox1 [field Elem] : Elem |
-| G.cs:39:14:39:15 | access to parameter b2 [field Box1, field Elem] : Elem | G.cs:71:21:71:27 | this [field Box1, field Elem] : Elem | G.cs:71:34:71:37 | access to field Box1 [field Elem] : Elem | G.cs:39:14:39:25 | call to method GetBox1 [field Elem] : Elem |
-| G.cs:39:14:39:25 | call to method GetBox1 [field Elem] : Elem | G.cs:63:21:63:27 | this [field Elem] : Elem | G.cs:63:34:63:37 | access to field Elem : Elem | G.cs:39:14:39:35 | call to method GetElem |
 | G.cs:39:14:39:25 | call to method GetBox1 [field Elem] : Elem | G.cs:63:21:63:27 | this [field Elem] : Elem | G.cs:63:34:63:37 | access to field Elem : Elem | G.cs:39:14:39:35 | call to method GetElem |
 | H.cs:24:27:24:27 | access to local variable a [field FieldA] : Object | H.cs:13:15:13:15 | a [field FieldA] : Object | H.cs:17:16:17:18 | access to local variable ret [field FieldA] : Object | H.cs:24:21:24:28 | call to method Clone [field FieldA] : Object |
-| H.cs:24:27:24:27 | access to local variable a [field FieldA] : Object | H.cs:13:15:13:15 | a [field FieldA] : Object | H.cs:17:16:17:18 | access to local variable ret [field FieldA] : Object | H.cs:24:21:24:28 | call to method Clone [field FieldA] : Object |
-| H.cs:44:27:44:27 | access to local variable a [field FieldA] : Object | H.cs:33:19:33:19 | a [field FieldA] : Object | H.cs:37:16:37:16 | access to local variable b [field FieldB] : Object | H.cs:44:17:44:28 | call to method Transform [field FieldB] : Object |
 | H.cs:44:27:44:27 | access to local variable a [field FieldA] : Object | H.cs:33:19:33:19 | a [field FieldA] : Object | H.cs:37:16:37:16 | access to local variable b [field FieldB] : Object | H.cs:44:17:44:28 | call to method Transform [field FieldB] : Object |
 | H.cs:64:22:64:22 | access to local variable a [field FieldA] : Object | H.cs:53:25:53:25 | a [field FieldA] : Object | H.cs:55:9:55:10 | [post] access to parameter b1 [field FieldB] : Object | H.cs:64:25:64:26 | [post] access to local variable b1 [field FieldB] : Object |
-| H.cs:64:22:64:22 | access to local variable a [field FieldA] : Object | H.cs:53:25:53:25 | a [field FieldA] : Object | H.cs:55:9:55:10 | [post] access to parameter b1 [field FieldB] : Object | H.cs:64:25:64:26 | [post] access to local variable b1 [field FieldB] : Object |
-| H.cs:80:22:80:22 | access to parameter a [field FieldA] : Object | H.cs:53:25:53:25 | a [field FieldA] : Object | H.cs:55:9:55:10 | [post] access to parameter b1 [field FieldB] : Object | H.cs:80:25:80:26 | [post] access to parameter b1 [field FieldB] : Object |
 | H.cs:80:22:80:22 | access to parameter a [field FieldA] : Object | H.cs:53:25:53:25 | a [field FieldA] : Object | H.cs:55:9:55:10 | [post] access to parameter b1 [field FieldB] : Object | H.cs:80:25:80:26 | [post] access to parameter b1 [field FieldB] : Object |
 | H.cs:88:20:88:36 | call to method Source<Object> : Object | H.cs:77:30:77:30 | o : Object | H.cs:79:9:79:9 | [post] access to parameter a [field FieldA] : Object | H.cs:88:17:88:17 | [post] access to local variable a [field FieldA] : Object |
-| H.cs:88:20:88:36 | call to method Source<Object> : Object | H.cs:77:30:77:30 | o : Object | H.cs:79:9:79:9 | [post] access to parameter a [field FieldA] : Object | H.cs:88:17:88:17 | [post] access to local variable a [field FieldA] : Object |
-| H.cs:88:20:88:36 | call to method Source<Object> : Object | H.cs:77:30:77:30 | o : Object | H.cs:80:25:80:26 | [post] access to parameter b1 [field FieldB] : Object | H.cs:88:39:88:40 | [post] access to local variable b1 [field FieldB] : Object |
 | H.cs:88:20:88:36 | call to method Source<Object> : Object | H.cs:77:30:77:30 | o : Object | H.cs:80:25:80:26 | [post] access to parameter b1 [field FieldB] : Object | H.cs:88:39:88:40 | [post] access to local variable b1 [field FieldB] : Object |
 | H.cs:106:26:106:39 | (...) ... [field FieldA] : Object | H.cs:33:19:33:19 | a [field FieldA] : Object | H.cs:37:16:37:16 | access to local variable b [field FieldB] : Object | H.cs:106:16:106:40 | call to method Transform [field FieldB] : Object |
-| H.cs:106:26:106:39 | (...) ... [field FieldA] : Object | H.cs:33:19:33:19 | a [field FieldA] : Object | H.cs:37:16:37:16 | access to local variable b [field FieldB] : Object | H.cs:106:16:106:40 | call to method Transform [field FieldB] : Object |
-| H.cs:113:31:113:31 | access to local variable a [field FieldA] : Object | H.cs:102:23:102:23 | a [field FieldA] : Object | H.cs:106:16:106:40 | call to method Transform [field FieldB] : Object | H.cs:113:17:113:32 | call to method TransformWrap [field FieldB] : Object |
 | H.cs:113:31:113:31 | access to local variable a [field FieldA] : Object | H.cs:102:23:102:23 | a [field FieldA] : Object | H.cs:106:16:106:40 | call to method Transform [field FieldB] : Object | H.cs:113:17:113:32 | call to method TransformWrap [field FieldB] : Object |
 | H.cs:124:26:124:26 | access to parameter a [field FieldA] : Object | H.cs:33:19:33:19 | a [field FieldA] : Object | H.cs:37:16:37:16 | access to local variable b [field FieldB] : Object | H.cs:124:16:124:27 | call to method Transform [field FieldB] : Object |
-| H.cs:124:26:124:26 | access to parameter a [field FieldA] : Object | H.cs:33:19:33:19 | a [field FieldA] : Object | H.cs:37:16:37:16 | access to local variable b [field FieldB] : Object | H.cs:124:16:124:27 | call to method Transform [field FieldB] : Object |
-| H.cs:131:18:131:18 | access to local variable a [field FieldA] : Object | H.cs:122:18:122:18 | a [field FieldA] : Object | H.cs:124:16:124:34 | access to field FieldB : Object | H.cs:131:14:131:19 | call to method Get |
 | H.cs:131:18:131:18 | access to local variable a [field FieldA] : Object | H.cs:122:18:122:18 | a [field FieldA] : Object | H.cs:124:16:124:34 | access to field FieldB : Object | H.cs:131:14:131:19 | call to method Get |
 | H.cs:142:26:142:26 | access to local variable a [field FieldA] : A | H.cs:33:19:33:19 | a [field FieldA] : A | H.cs:37:16:37:16 | access to local variable b [field FieldB] : A | H.cs:142:16:142:27 | call to method Transform [field FieldB] : A |
-| H.cs:142:26:142:26 | access to local variable a [field FieldA] : A | H.cs:33:19:33:19 | a [field FieldA] : A | H.cs:37:16:37:16 | access to local variable b [field FieldB] : A | H.cs:142:16:142:27 | call to method Transform [field FieldB] : A |
-| H.cs:147:25:147:38 | call to method Source<A> : A | H.cs:138:27:138:27 | o : A | H.cs:142:16:142:34 | access to field FieldB : A | H.cs:147:17:147:39 | call to method Through : A |
 | H.cs:147:25:147:38 | call to method Source<A> : A | H.cs:138:27:138:27 | o : A | H.cs:142:16:142:34 | access to field FieldB : A | H.cs:147:17:147:39 | call to method Through : A |
 | H.cs:164:22:164:22 | access to local variable o : Object | H.cs:153:32:153:32 | o : Object | H.cs:157:9:157:9 | [post] access to parameter a [field FieldA, field FieldB] : Object | H.cs:164:19:164:19 | [post] access to local variable a [field FieldA, field FieldB] : Object |
-| H.cs:164:22:164:22 | access to local variable o : Object | H.cs:153:32:153:32 | o : Object | H.cs:157:9:157:9 | [post] access to parameter a [field FieldA, field FieldB] : Object | H.cs:164:19:164:19 | [post] access to local variable a [field FieldA, field FieldB] : Object |
 | J.cs:62:29:62:29 | access to local variable o : Object | J.cs:14:26:14:30 | field : Object | J.cs:14:50:14:54 | [post] this access [field Field] : Object | J.cs:62:18:62:36 | object creation of type Struct [field Field] : Object |
-| J.cs:62:29:62:29 | access to local variable o : Object | J.cs:14:26:14:30 | field : Object | J.cs:14:50:14:54 | [post] this access [field Field] : Object | J.cs:62:18:62:36 | object creation of type Struct [field Field] : Object |
-| J.cs:80:35:80:35 | access to local variable o : Object | J.cs:14:40:14:43 | prop : Object | J.cs:14:57:14:60 | [post] this access [property Prop] : Object | J.cs:80:18:80:36 | object creation of type Struct [property Prop] : Object |
 | J.cs:80:35:80:35 | access to local variable o : Object | J.cs:14:40:14:43 | prop : Object | J.cs:14:57:14:60 | [post] this access [property Prop] : Object | J.cs:80:18:80:36 | object creation of type Struct [property Prop] : Object |
 #select
 | A.cs:7:14:7:16 | access to field c | A.cs:5:17:5:28 | call to method Source<C> : C | A.cs:7:14:7:16 | access to field c | $@ | A.cs:5:17:5:28 | call to method Source<C> : C | call to method Source<C> : C |

--- a/csharp/ql/test/library-tests/dataflow/fields/FieldFlow.ql
+++ b/csharp/ql/test/library-tests/dataflow/fields/FieldFlow.ql
@@ -3,9 +3,9 @@
  */
 
 import csharp
-import DataFlow::PathGraph
+import DefaultValueFlow::PathGraph
 import TestUtilities.InlineFlowTest
 
-from DataFlow::PathNode source, DataFlow::PathNode sink, DefaultValueFlowConf conf
-where conf.hasFlowPath(source, sink)
+from DefaultValueFlow::PathNode source, DefaultValueFlow::PathNode sink
+where DefaultValueFlow::flowPath(source, sink)
 select sink, source, sink, "$@", source, source.toString()

--- a/csharp/ql/test/library-tests/dataflow/global/Common.qll
+++ b/csharp/ql/test/library-tests/dataflow/global/Common.qll
@@ -1,18 +1,18 @@
 import csharp
 
-class Config extends DataFlow::Configuration {
-  Config() { this = "Config" }
-
-  override predicate isSource(DataFlow::Node source) {
+module FlowConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) {
     source.asExpr().(StringLiteral).getValue() = "taint source"
     or
     source.asParameter().hasName("tainted")
   }
 
-  override predicate isSink(DataFlow::Node sink) {
+  predicate isSink(DataFlow::Node sink) {
     exists(MethodCall mc |
       mc.getTarget().getUndecoratedName() = "Check" and
       mc.getAnArgument() = sink.asExpr()
     )
   }
 }
+
+module Flow = DataFlow::Global<FlowConfig>;

--- a/csharp/ql/test/library-tests/dataflow/global/DataFlow.ql
+++ b/csharp/ql/test/library-tests/dataflow/global/DataFlow.ql
@@ -1,6 +1,6 @@
 import csharp
 import Common
 
-from Config c, DataFlow::Node source, DataFlow::Node sink
-where c.hasFlow(source, sink)
+from DataFlow::Node source, DataFlow::Node sink
+where Flow::flow(source, sink)
 select sink

--- a/csharp/ql/test/library-tests/dataflow/global/DataFlowPath.ql
+++ b/csharp/ql/test/library-tests/dataflow/global/DataFlowPath.ql
@@ -4,10 +4,10 @@
 
 import csharp
 import Common
-import DataFlow::PathGraph
+import Flow::PathGraph
 
-from Config c, DataFlow::PathNode source, DataFlow::PathNode sink, string s
+from Flow::PathNode source, Flow::PathNode sink, string s
 where
-  c.hasFlowPath(source, sink) and
+  Flow::flowPath(source, sink) and
   s = sink.toString()
 select sink, source, sink, s order by s

--- a/csharp/ql/test/library-tests/dataflow/global/TaintTracking.ql
+++ b/csharp/ql/test/library-tests/dataflow/global/TaintTracking.ql
@@ -1,12 +1,8 @@
 import csharp
 import Common
 
-class TTConfig extends TaintTracking::Configuration instanceof Config {
-  override predicate isSource(DataFlow::Node source) { Config.super.isSource(source) }
+module Taint = TaintTracking::Global<FlowConfig>;
 
-  override predicate isSink(DataFlow::Node sink) { Config.super.isSink(sink) }
-}
-
-from TTConfig c, DataFlow::Node source, DataFlow::Node sink
-where c.hasFlow(source, sink)
+from DataFlow::Node source, DataFlow::Node sink
+where Taint::flow(source, sink)
 select sink

--- a/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.ql
+++ b/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.ql
@@ -4,16 +4,12 @@
 
 import csharp
 import Common
-import DataFlow::PathGraph
+import Taint::PathGraph
 
-class TTConfig extends TaintTracking::Configuration instanceof Config {
-  override predicate isSource(DataFlow::Node source) { Config.super.isSource(source) }
+module Taint = TaintTracking::Global<FlowConfig>;
 
-  override predicate isSink(DataFlow::Node sink) { Config.super.isSink(sink) }
-}
-
-from TTConfig c, DataFlow::PathNode source, DataFlow::PathNode sink, string s
+from Taint::PathNode source, Taint::PathNode sink, string s
 where
-  c.hasFlowPath(source, sink) and
+  Taint::flowPath(source, sink) and
   s = sink.toString()
 select sink, source, sink, s

--- a/csharp/ql/test/library-tests/dataflow/operators/operatorFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/operators/operatorFlow.expected
@@ -1,174 +1,90 @@
 failures
 edges
 | Operator.cs:9:39:9:39 | x : C | Operator.cs:9:50:9:50 | access to parameter x : C |
-| Operator.cs:9:39:9:39 | x : C | Operator.cs:9:50:9:50 | access to parameter x : C |
-| Operator.cs:16:38:16:38 | x : C | Operator.cs:16:49:16:49 | access to parameter x : C |
 | Operator.cs:16:38:16:38 | x : C | Operator.cs:16:49:16:49 | access to parameter x : C |
 | Operator.cs:18:51:18:51 | y : C | Operator.cs:18:57:18:57 | access to parameter y : C |
-| Operator.cs:18:51:18:51 | y : C | Operator.cs:18:57:18:57 | access to parameter y : C |
-| Operator.cs:19:38:19:38 | x : C | Operator.cs:19:49:19:49 | access to parameter x : C |
 | Operator.cs:19:38:19:38 | x : C | Operator.cs:19:49:19:49 | access to parameter x : C |
 | Operator.cs:21:43:21:43 | y : C | Operator.cs:21:49:21:49 | access to parameter y : C |
-| Operator.cs:21:43:21:43 | y : C | Operator.cs:21:49:21:49 | access to parameter y : C |
-| Operator.cs:22:51:22:51 | y : C | Operator.cs:22:57:22:57 | access to parameter y : C |
 | Operator.cs:22:51:22:51 | y : C | Operator.cs:22:57:22:57 | access to parameter y : C |
 | Operator.cs:27:17:27:28 | call to method Source<C> : C | Operator.cs:29:17:29:17 | access to local variable x : C |
-| Operator.cs:27:17:27:28 | call to method Source<C> : C | Operator.cs:29:17:29:17 | access to local variable x : C |
-| Operator.cs:29:17:29:17 | access to local variable x : C | Operator.cs:16:38:16:38 | x : C |
 | Operator.cs:29:17:29:17 | access to local variable x : C | Operator.cs:16:38:16:38 | x : C |
 | Operator.cs:29:17:29:17 | access to local variable x : C | Operator.cs:29:17:29:21 | call to operator + : C |
-| Operator.cs:29:17:29:17 | access to local variable x : C | Operator.cs:29:17:29:21 | call to operator + : C |
-| Operator.cs:29:17:29:21 | call to operator + : C | Operator.cs:30:14:30:14 | access to local variable z |
 | Operator.cs:29:17:29:21 | call to operator + : C | Operator.cs:30:14:30:14 | access to local variable z |
 | Operator.cs:35:17:35:28 | call to method Source<C> : C | Operator.cs:37:27:37:27 | access to local variable x : C |
-| Operator.cs:35:17:35:28 | call to method Source<C> : C | Operator.cs:37:27:37:27 | access to local variable x : C |
-| Operator.cs:37:27:37:27 | access to local variable x : C | Operator.cs:19:38:19:38 | x : C |
 | Operator.cs:37:27:37:27 | access to local variable x : C | Operator.cs:19:38:19:38 | x : C |
 | Operator.cs:37:27:37:27 | access to local variable x : C | Operator.cs:37:27:37:31 | call to operator - : C |
-| Operator.cs:37:27:37:27 | access to local variable x : C | Operator.cs:37:27:37:31 | call to operator - : C |
-| Operator.cs:37:27:37:31 | call to operator - : C | Operator.cs:38:14:38:14 | access to local variable z |
 | Operator.cs:37:27:37:31 | call to operator - : C | Operator.cs:38:14:38:14 | access to local variable z |
 | Operator.cs:44:17:44:28 | call to method Source<C> : C | Operator.cs:45:29:45:29 | access to local variable y : C |
-| Operator.cs:44:17:44:28 | call to method Source<C> : C | Operator.cs:45:29:45:29 | access to local variable y : C |
-| Operator.cs:45:25:45:29 | call to operator checked - : C | Operator.cs:46:14:46:14 | access to local variable z |
 | Operator.cs:45:25:45:29 | call to operator checked - : C | Operator.cs:46:14:46:14 | access to local variable z |
 | Operator.cs:45:29:45:29 | access to local variable y : C | Operator.cs:18:51:18:51 | y : C |
-| Operator.cs:45:29:45:29 | access to local variable y : C | Operator.cs:18:51:18:51 | y : C |
-| Operator.cs:45:29:45:29 | access to local variable y : C | Operator.cs:45:25:45:29 | call to operator checked - : C |
 | Operator.cs:45:29:45:29 | access to local variable y : C | Operator.cs:45:25:45:29 | call to operator checked - : C |
 | Operator.cs:49:28:49:28 | x : C | Operator.cs:51:17:51:17 | access to parameter x : C |
-| Operator.cs:49:28:49:28 | x : C | Operator.cs:51:17:51:17 | access to parameter x : C |
-| Operator.cs:51:17:51:17 | access to parameter x : C | Operator.cs:9:39:9:39 | x : C |
 | Operator.cs:51:17:51:17 | access to parameter x : C | Operator.cs:9:39:9:39 | x : C |
 | Operator.cs:51:17:51:17 | access to parameter x : C | Operator.cs:51:17:51:21 | call to operator * : C |
-| Operator.cs:51:17:51:17 | access to parameter x : C | Operator.cs:51:17:51:21 | call to operator * : C |
-| Operator.cs:51:17:51:21 | call to operator * : C | Operator.cs:52:14:52:14 | (...) ... |
 | Operator.cs:51:17:51:21 | call to operator * : C | Operator.cs:52:14:52:14 | (...) ... |
 | Operator.cs:57:17:57:28 | call to method Source<C> : C | Operator.cs:59:15:59:15 | access to local variable x : C |
-| Operator.cs:57:17:57:28 | call to method Source<C> : C | Operator.cs:59:15:59:15 | access to local variable x : C |
-| Operator.cs:59:15:59:15 | access to local variable x : C | Operator.cs:49:28:49:28 | x : C |
 | Operator.cs:59:15:59:15 | access to local variable x : C | Operator.cs:49:28:49:28 | x : C |
 | Operator.cs:62:33:62:33 | y : C | Operator.cs:64:21:64:21 | access to parameter y : C |
-| Operator.cs:62:33:62:33 | y : C | Operator.cs:64:21:64:21 | access to parameter y : C |
-| Operator.cs:64:17:64:21 | call to operator / : C | Operator.cs:65:14:65:14 | (...) ... |
 | Operator.cs:64:17:64:21 | call to operator / : C | Operator.cs:65:14:65:14 | (...) ... |
 | Operator.cs:64:21:64:21 | access to parameter y : C | Operator.cs:21:43:21:43 | y : C |
-| Operator.cs:64:21:64:21 | access to parameter y : C | Operator.cs:21:43:21:43 | y : C |
-| Operator.cs:64:21:64:21 | access to parameter y : C | Operator.cs:64:17:64:21 | call to operator / : C |
 | Operator.cs:64:21:64:21 | access to parameter y : C | Operator.cs:64:17:64:21 | call to operator / : C |
 | Operator.cs:71:17:71:29 | call to method Source<C> : C | Operator.cs:72:18:72:18 | access to local variable y : C |
-| Operator.cs:71:17:71:29 | call to method Source<C> : C | Operator.cs:72:18:72:18 | access to local variable y : C |
-| Operator.cs:72:18:72:18 | access to local variable y : C | Operator.cs:62:33:62:33 | y : C |
 | Operator.cs:72:18:72:18 | access to local variable y : C | Operator.cs:62:33:62:33 | y : C |
 | Operator.cs:75:33:75:33 | y : C | Operator.cs:77:29:77:29 | access to parameter y : C |
-| Operator.cs:75:33:75:33 | y : C | Operator.cs:77:29:77:29 | access to parameter y : C |
-| Operator.cs:77:25:77:29 | call to operator checked / : C | Operator.cs:78:14:78:14 | (...) ... |
 | Operator.cs:77:25:77:29 | call to operator checked / : C | Operator.cs:78:14:78:14 | (...) ... |
 | Operator.cs:77:29:77:29 | access to parameter y : C | Operator.cs:22:51:22:51 | y : C |
-| Operator.cs:77:29:77:29 | access to parameter y : C | Operator.cs:22:51:22:51 | y : C |
-| Operator.cs:77:29:77:29 | access to parameter y : C | Operator.cs:77:25:77:29 | call to operator checked / : C |
 | Operator.cs:77:29:77:29 | access to parameter y : C | Operator.cs:77:25:77:29 | call to operator checked / : C |
 | Operator.cs:84:17:84:29 | call to method Source<C> : C | Operator.cs:85:18:85:18 | access to local variable y : C |
-| Operator.cs:84:17:84:29 | call to method Source<C> : C | Operator.cs:85:18:85:18 | access to local variable y : C |
-| Operator.cs:85:18:85:18 | access to local variable y : C | Operator.cs:75:33:75:33 | y : C |
 | Operator.cs:85:18:85:18 | access to local variable y : C | Operator.cs:75:33:75:33 | y : C |
 nodes
 | Operator.cs:9:39:9:39 | x : C | semmle.label | x : C |
-| Operator.cs:9:39:9:39 | x : C | semmle.label | x : C |
-| Operator.cs:9:50:9:50 | access to parameter x : C | semmle.label | access to parameter x : C |
 | Operator.cs:9:50:9:50 | access to parameter x : C | semmle.label | access to parameter x : C |
 | Operator.cs:16:38:16:38 | x : C | semmle.label | x : C |
-| Operator.cs:16:38:16:38 | x : C | semmle.label | x : C |
-| Operator.cs:16:49:16:49 | access to parameter x : C | semmle.label | access to parameter x : C |
 | Operator.cs:16:49:16:49 | access to parameter x : C | semmle.label | access to parameter x : C |
 | Operator.cs:18:51:18:51 | y : C | semmle.label | y : C |
-| Operator.cs:18:51:18:51 | y : C | semmle.label | y : C |
-| Operator.cs:18:57:18:57 | access to parameter y : C | semmle.label | access to parameter y : C |
 | Operator.cs:18:57:18:57 | access to parameter y : C | semmle.label | access to parameter y : C |
 | Operator.cs:19:38:19:38 | x : C | semmle.label | x : C |
-| Operator.cs:19:38:19:38 | x : C | semmle.label | x : C |
-| Operator.cs:19:49:19:49 | access to parameter x : C | semmle.label | access to parameter x : C |
 | Operator.cs:19:49:19:49 | access to parameter x : C | semmle.label | access to parameter x : C |
 | Operator.cs:21:43:21:43 | y : C | semmle.label | y : C |
-| Operator.cs:21:43:21:43 | y : C | semmle.label | y : C |
-| Operator.cs:21:49:21:49 | access to parameter y : C | semmle.label | access to parameter y : C |
 | Operator.cs:21:49:21:49 | access to parameter y : C | semmle.label | access to parameter y : C |
 | Operator.cs:22:51:22:51 | y : C | semmle.label | y : C |
-| Operator.cs:22:51:22:51 | y : C | semmle.label | y : C |
-| Operator.cs:22:57:22:57 | access to parameter y : C | semmle.label | access to parameter y : C |
 | Operator.cs:22:57:22:57 | access to parameter y : C | semmle.label | access to parameter y : C |
 | Operator.cs:27:17:27:28 | call to method Source<C> : C | semmle.label | call to method Source<C> : C |
-| Operator.cs:27:17:27:28 | call to method Source<C> : C | semmle.label | call to method Source<C> : C |
-| Operator.cs:29:17:29:17 | access to local variable x : C | semmle.label | access to local variable x : C |
 | Operator.cs:29:17:29:17 | access to local variable x : C | semmle.label | access to local variable x : C |
 | Operator.cs:29:17:29:21 | call to operator + : C | semmle.label | call to operator + : C |
-| Operator.cs:29:17:29:21 | call to operator + : C | semmle.label | call to operator + : C |
-| Operator.cs:30:14:30:14 | access to local variable z | semmle.label | access to local variable z |
 | Operator.cs:30:14:30:14 | access to local variable z | semmle.label | access to local variable z |
 | Operator.cs:35:17:35:28 | call to method Source<C> : C | semmle.label | call to method Source<C> : C |
-| Operator.cs:35:17:35:28 | call to method Source<C> : C | semmle.label | call to method Source<C> : C |
-| Operator.cs:37:27:37:27 | access to local variable x : C | semmle.label | access to local variable x : C |
 | Operator.cs:37:27:37:27 | access to local variable x : C | semmle.label | access to local variable x : C |
 | Operator.cs:37:27:37:31 | call to operator - : C | semmle.label | call to operator - : C |
-| Operator.cs:37:27:37:31 | call to operator - : C | semmle.label | call to operator - : C |
-| Operator.cs:38:14:38:14 | access to local variable z | semmle.label | access to local variable z |
 | Operator.cs:38:14:38:14 | access to local variable z | semmle.label | access to local variable z |
 | Operator.cs:44:17:44:28 | call to method Source<C> : C | semmle.label | call to method Source<C> : C |
-| Operator.cs:44:17:44:28 | call to method Source<C> : C | semmle.label | call to method Source<C> : C |
-| Operator.cs:45:25:45:29 | call to operator checked - : C | semmle.label | call to operator checked - : C |
 | Operator.cs:45:25:45:29 | call to operator checked - : C | semmle.label | call to operator checked - : C |
 | Operator.cs:45:29:45:29 | access to local variable y : C | semmle.label | access to local variable y : C |
-| Operator.cs:45:29:45:29 | access to local variable y : C | semmle.label | access to local variable y : C |
-| Operator.cs:46:14:46:14 | access to local variable z | semmle.label | access to local variable z |
 | Operator.cs:46:14:46:14 | access to local variable z | semmle.label | access to local variable z |
 | Operator.cs:49:28:49:28 | x : C | semmle.label | x : C |
-| Operator.cs:49:28:49:28 | x : C | semmle.label | x : C |
-| Operator.cs:51:17:51:17 | access to parameter x : C | semmle.label | access to parameter x : C |
 | Operator.cs:51:17:51:17 | access to parameter x : C | semmle.label | access to parameter x : C |
 | Operator.cs:51:17:51:21 | call to operator * : C | semmle.label | call to operator * : C |
-| Operator.cs:51:17:51:21 | call to operator * : C | semmle.label | call to operator * : C |
-| Operator.cs:52:14:52:14 | (...) ... | semmle.label | (...) ... |
 | Operator.cs:52:14:52:14 | (...) ... | semmle.label | (...) ... |
 | Operator.cs:57:17:57:28 | call to method Source<C> : C | semmle.label | call to method Source<C> : C |
-| Operator.cs:57:17:57:28 | call to method Source<C> : C | semmle.label | call to method Source<C> : C |
-| Operator.cs:59:15:59:15 | access to local variable x : C | semmle.label | access to local variable x : C |
 | Operator.cs:59:15:59:15 | access to local variable x : C | semmle.label | access to local variable x : C |
 | Operator.cs:62:33:62:33 | y : C | semmle.label | y : C |
-| Operator.cs:62:33:62:33 | y : C | semmle.label | y : C |
-| Operator.cs:64:17:64:21 | call to operator / : C | semmle.label | call to operator / : C |
 | Operator.cs:64:17:64:21 | call to operator / : C | semmle.label | call to operator / : C |
 | Operator.cs:64:21:64:21 | access to parameter y : C | semmle.label | access to parameter y : C |
-| Operator.cs:64:21:64:21 | access to parameter y : C | semmle.label | access to parameter y : C |
-| Operator.cs:65:14:65:14 | (...) ... | semmle.label | (...) ... |
 | Operator.cs:65:14:65:14 | (...) ... | semmle.label | (...) ... |
 | Operator.cs:71:17:71:29 | call to method Source<C> : C | semmle.label | call to method Source<C> : C |
-| Operator.cs:71:17:71:29 | call to method Source<C> : C | semmle.label | call to method Source<C> : C |
-| Operator.cs:72:18:72:18 | access to local variable y : C | semmle.label | access to local variable y : C |
 | Operator.cs:72:18:72:18 | access to local variable y : C | semmle.label | access to local variable y : C |
 | Operator.cs:75:33:75:33 | y : C | semmle.label | y : C |
-| Operator.cs:75:33:75:33 | y : C | semmle.label | y : C |
-| Operator.cs:77:25:77:29 | call to operator checked / : C | semmle.label | call to operator checked / : C |
 | Operator.cs:77:25:77:29 | call to operator checked / : C | semmle.label | call to operator checked / : C |
 | Operator.cs:77:29:77:29 | access to parameter y : C | semmle.label | access to parameter y : C |
-| Operator.cs:77:29:77:29 | access to parameter y : C | semmle.label | access to parameter y : C |
-| Operator.cs:78:14:78:14 | (...) ... | semmle.label | (...) ... |
 | Operator.cs:78:14:78:14 | (...) ... | semmle.label | (...) ... |
 | Operator.cs:84:17:84:29 | call to method Source<C> : C | semmle.label | call to method Source<C> : C |
-| Operator.cs:84:17:84:29 | call to method Source<C> : C | semmle.label | call to method Source<C> : C |
-| Operator.cs:85:18:85:18 | access to local variable y : C | semmle.label | access to local variable y : C |
 | Operator.cs:85:18:85:18 | access to local variable y : C | semmle.label | access to local variable y : C |
 subpaths
 | Operator.cs:29:17:29:17 | access to local variable x : C | Operator.cs:16:38:16:38 | x : C | Operator.cs:16:49:16:49 | access to parameter x : C | Operator.cs:29:17:29:21 | call to operator + : C |
-| Operator.cs:29:17:29:17 | access to local variable x : C | Operator.cs:16:38:16:38 | x : C | Operator.cs:16:49:16:49 | access to parameter x : C | Operator.cs:29:17:29:21 | call to operator + : C |
-| Operator.cs:37:27:37:27 | access to local variable x : C | Operator.cs:19:38:19:38 | x : C | Operator.cs:19:49:19:49 | access to parameter x : C | Operator.cs:37:27:37:31 | call to operator - : C |
 | Operator.cs:37:27:37:27 | access to local variable x : C | Operator.cs:19:38:19:38 | x : C | Operator.cs:19:49:19:49 | access to parameter x : C | Operator.cs:37:27:37:31 | call to operator - : C |
 | Operator.cs:45:29:45:29 | access to local variable y : C | Operator.cs:18:51:18:51 | y : C | Operator.cs:18:57:18:57 | access to parameter y : C | Operator.cs:45:25:45:29 | call to operator checked - : C |
-| Operator.cs:45:29:45:29 | access to local variable y : C | Operator.cs:18:51:18:51 | y : C | Operator.cs:18:57:18:57 | access to parameter y : C | Operator.cs:45:25:45:29 | call to operator checked - : C |
-| Operator.cs:51:17:51:17 | access to parameter x : C | Operator.cs:9:39:9:39 | x : C | Operator.cs:9:50:9:50 | access to parameter x : C | Operator.cs:51:17:51:21 | call to operator * : C |
 | Operator.cs:51:17:51:17 | access to parameter x : C | Operator.cs:9:39:9:39 | x : C | Operator.cs:9:50:9:50 | access to parameter x : C | Operator.cs:51:17:51:21 | call to operator * : C |
 | Operator.cs:64:21:64:21 | access to parameter y : C | Operator.cs:21:43:21:43 | y : C | Operator.cs:21:49:21:49 | access to parameter y : C | Operator.cs:64:17:64:21 | call to operator / : C |
-| Operator.cs:64:21:64:21 | access to parameter y : C | Operator.cs:21:43:21:43 | y : C | Operator.cs:21:49:21:49 | access to parameter y : C | Operator.cs:64:17:64:21 | call to operator / : C |
-| Operator.cs:77:29:77:29 | access to parameter y : C | Operator.cs:22:51:22:51 | y : C | Operator.cs:22:57:22:57 | access to parameter y : C | Operator.cs:77:25:77:29 | call to operator checked / : C |
 | Operator.cs:77:29:77:29 | access to parameter y : C | Operator.cs:22:51:22:51 | y : C | Operator.cs:22:57:22:57 | access to parameter y : C | Operator.cs:77:25:77:29 | call to operator checked / : C |
 #select
 | Operator.cs:30:14:30:14 | access to local variable z | Operator.cs:27:17:27:28 | call to method Source<C> : C | Operator.cs:30:14:30:14 | access to local variable z | $@ | Operator.cs:27:17:27:28 | call to method Source<C> : C | call to method Source<C> : C |

--- a/csharp/ql/test/library-tests/dataflow/operators/operatorFlow.ql
+++ b/csharp/ql/test/library-tests/dataflow/operators/operatorFlow.ql
@@ -3,9 +3,9 @@
  */
 
 import csharp
-import DataFlow::PathGraph
+import DefaultValueFlow::PathGraph
 import TestUtilities.InlineFlowTest
 
-from DataFlow::PathNode source, DataFlow::PathNode sink, DefaultValueFlowConf conf
-where conf.hasFlowPath(source, sink)
+from DefaultValueFlow::PathNode source, DefaultValueFlow::PathNode sink
+where DefaultValueFlow::flowPath(source, sink)
 select sink, source, sink, "$@", source, source.toString()

--- a/csharp/ql/test/library-tests/dataflow/patterns/PatternFlow.ql
+++ b/csharp/ql/test/library-tests/dataflow/patterns/PatternFlow.ql
@@ -3,9 +3,9 @@
  */
 
 import csharp
-import DataFlow::PathGraph
+import DefaultValueFlow::PathGraph
 import TestUtilities.InlineFlowTest
 
-from DataFlow::PathNode source, DataFlow::PathNode sink, DefaultValueFlowConf conf
-where conf.hasFlowPath(source, sink)
+from DefaultValueFlow::PathNode source, DefaultValueFlow::PathNode sink
+where DefaultValueFlow::flowPath(source, sink)
 select sink, source, sink, "$@", source, source.toString()

--- a/csharp/ql/test/library-tests/dataflow/tuples/Tuples.expected
+++ b/csharp/ql/test/library-tests/dataflow/tuples/Tuples.expected
@@ -1,415 +1,210 @@
 failures
 edges
 | Tuples.cs:7:18:7:34 | call to method Source<Object> : Object | Tuples.cs:10:21:10:22 | access to local variable o1 : Object |
-| Tuples.cs:7:18:7:34 | call to method Source<Object> : Object | Tuples.cs:10:21:10:22 | access to local variable o1 : Object |
-| Tuples.cs:8:18:8:34 | call to method Source<Object> : Object | Tuples.cs:10:29:10:30 | access to local variable o2 : Object |
 | Tuples.cs:8:18:8:34 | call to method Source<Object> : Object | Tuples.cs:10:29:10:30 | access to local variable o2 : Object |
 | Tuples.cs:10:17:10:32 | (..., ...) [field Item1] : Object | Tuples.cs:11:9:11:23 | (..., ...) [field Item1] : Object |
-| Tuples.cs:10:17:10:32 | (..., ...) [field Item1] : Object | Tuples.cs:11:9:11:23 | (..., ...) [field Item1] : Object |
-| Tuples.cs:10:17:10:32 | (..., ...) [field Item1] : Object | Tuples.cs:16:9:16:19 | (..., ...) [field Item1] : Object |
 | Tuples.cs:10:17:10:32 | (..., ...) [field Item1] : Object | Tuples.cs:16:9:16:19 | (..., ...) [field Item1] : Object |
 | Tuples.cs:10:17:10:32 | (..., ...) [field Item1] : Object | Tuples.cs:21:9:21:22 | (..., ...) [field Item1] : Object |
-| Tuples.cs:10:17:10:32 | (..., ...) [field Item1] : Object | Tuples.cs:21:9:21:22 | (..., ...) [field Item1] : Object |
-| Tuples.cs:10:17:10:32 | (..., ...) [field Item1] : Object | Tuples.cs:26:14:26:14 | access to local variable x [field Item1] : Object |
 | Tuples.cs:10:17:10:32 | (..., ...) [field Item1] : Object | Tuples.cs:26:14:26:14 | access to local variable x [field Item1] : Object |
 | Tuples.cs:10:17:10:32 | (..., ...) [field Item1] : Object | Tuples.cs:27:14:27:14 | access to local variable x [field Item1] : Object |
-| Tuples.cs:10:17:10:32 | (..., ...) [field Item1] : Object | Tuples.cs:27:14:27:14 | access to local variable x [field Item1] : Object |
-| Tuples.cs:10:17:10:32 | (..., ...) [field Item2, field Item2] : Object | Tuples.cs:11:9:11:23 | (..., ...) [field Item2, field Item2] : Object |
 | Tuples.cs:10:17:10:32 | (..., ...) [field Item2, field Item2] : Object | Tuples.cs:11:9:11:23 | (..., ...) [field Item2, field Item2] : Object |
 | Tuples.cs:10:17:10:32 | (..., ...) [field Item2, field Item2] : Object | Tuples.cs:16:9:16:19 | (..., ...) [field Item2, field Item2] : Object |
-| Tuples.cs:10:17:10:32 | (..., ...) [field Item2, field Item2] : Object | Tuples.cs:16:9:16:19 | (..., ...) [field Item2, field Item2] : Object |
-| Tuples.cs:10:17:10:32 | (..., ...) [field Item2, field Item2] : Object | Tuples.cs:21:9:21:22 | (..., ...) [field Item2, field Item2] : Object |
 | Tuples.cs:10:17:10:32 | (..., ...) [field Item2, field Item2] : Object | Tuples.cs:21:9:21:22 | (..., ...) [field Item2, field Item2] : Object |
 | Tuples.cs:10:17:10:32 | (..., ...) [field Item2, field Item2] : Object | Tuples.cs:29:14:29:14 | access to local variable x [field Item2, field Item2] : Object |
-| Tuples.cs:10:17:10:32 | (..., ...) [field Item2, field Item2] : Object | Tuples.cs:29:14:29:14 | access to local variable x [field Item2, field Item2] : Object |
-| Tuples.cs:10:21:10:22 | access to local variable o1 : Object | Tuples.cs:10:17:10:32 | (..., ...) [field Item1] : Object |
 | Tuples.cs:10:21:10:22 | access to local variable o1 : Object | Tuples.cs:10:17:10:32 | (..., ...) [field Item1] : Object |
 | Tuples.cs:10:25:10:31 | (..., ...) [field Item2] : Object | Tuples.cs:10:17:10:32 | (..., ...) [field Item2, field Item2] : Object |
-| Tuples.cs:10:25:10:31 | (..., ...) [field Item2] : Object | Tuples.cs:10:17:10:32 | (..., ...) [field Item2, field Item2] : Object |
-| Tuples.cs:10:29:10:30 | access to local variable o2 : Object | Tuples.cs:10:25:10:31 | (..., ...) [field Item2] : Object |
 | Tuples.cs:10:29:10:30 | access to local variable o2 : Object | Tuples.cs:10:25:10:31 | (..., ...) [field Item2] : Object |
 | Tuples.cs:11:9:11:23 | (..., ...) [field Item1] : Object | Tuples.cs:11:9:11:27 | SSA def(a) : Object |
-| Tuples.cs:11:9:11:23 | (..., ...) [field Item1] : Object | Tuples.cs:11:9:11:27 | SSA def(a) : Object |
-| Tuples.cs:11:9:11:23 | (..., ...) [field Item2, field Item2] : Object | Tuples.cs:11:9:11:23 | (..., ...) [field Item2] : Object |
 | Tuples.cs:11:9:11:23 | (..., ...) [field Item2, field Item2] : Object | Tuples.cs:11:9:11:23 | (..., ...) [field Item2] : Object |
 | Tuples.cs:11:9:11:23 | (..., ...) [field Item2] : Object | Tuples.cs:11:9:11:27 | SSA def(c) : Object |
-| Tuples.cs:11:9:11:23 | (..., ...) [field Item2] : Object | Tuples.cs:11:9:11:27 | SSA def(c) : Object |
-| Tuples.cs:11:9:11:27 | SSA def(a) : Object | Tuples.cs:12:14:12:14 | access to local variable a |
 | Tuples.cs:11:9:11:27 | SSA def(a) : Object | Tuples.cs:12:14:12:14 | access to local variable a |
 | Tuples.cs:11:9:11:27 | SSA def(c) : Object | Tuples.cs:14:14:14:14 | access to local variable c |
-| Tuples.cs:11:9:11:27 | SSA def(c) : Object | Tuples.cs:14:14:14:14 | access to local variable c |
-| Tuples.cs:16:9:16:19 | (..., ...) [field Item1] : Object | Tuples.cs:16:9:16:23 | SSA def(a) : Object |
 | Tuples.cs:16:9:16:19 | (..., ...) [field Item1] : Object | Tuples.cs:16:9:16:23 | SSA def(a) : Object |
 | Tuples.cs:16:9:16:19 | (..., ...) [field Item2, field Item2] : Object | Tuples.cs:16:13:16:18 | (..., ...) [field Item2] : Object |
-| Tuples.cs:16:9:16:19 | (..., ...) [field Item2, field Item2] : Object | Tuples.cs:16:13:16:18 | (..., ...) [field Item2] : Object |
-| Tuples.cs:16:9:16:23 | SSA def(a) : Object | Tuples.cs:17:14:17:14 | access to local variable a |
 | Tuples.cs:16:9:16:23 | SSA def(a) : Object | Tuples.cs:17:14:17:14 | access to local variable a |
 | Tuples.cs:16:9:16:23 | SSA def(c) : Object | Tuples.cs:19:14:19:14 | access to local variable c |
-| Tuples.cs:16:9:16:23 | SSA def(c) : Object | Tuples.cs:19:14:19:14 | access to local variable c |
-| Tuples.cs:16:13:16:18 | (..., ...) [field Item2] : Object | Tuples.cs:16:9:16:23 | SSA def(c) : Object |
 | Tuples.cs:16:13:16:18 | (..., ...) [field Item2] : Object | Tuples.cs:16:9:16:23 | SSA def(c) : Object |
 | Tuples.cs:21:9:21:22 | (..., ...) [field Item1] : Object | Tuples.cs:21:9:21:26 | SSA def(p) : Object |
-| Tuples.cs:21:9:21:22 | (..., ...) [field Item1] : Object | Tuples.cs:21:9:21:26 | SSA def(p) : Object |
-| Tuples.cs:21:9:21:22 | (..., ...) [field Item2, field Item2] : Object | Tuples.cs:21:9:21:26 | SSA def(q) [field Item2] : Object |
 | Tuples.cs:21:9:21:22 | (..., ...) [field Item2, field Item2] : Object | Tuples.cs:21:9:21:26 | SSA def(q) [field Item2] : Object |
 | Tuples.cs:21:9:21:26 | SSA def(p) : Object | Tuples.cs:22:14:22:14 | access to local variable p |
-| Tuples.cs:21:9:21:26 | SSA def(p) : Object | Tuples.cs:22:14:22:14 | access to local variable p |
-| Tuples.cs:21:9:21:26 | SSA def(q) [field Item2] : Object | Tuples.cs:24:14:24:14 | access to local variable q [field Item2] : Object |
 | Tuples.cs:21:9:21:26 | SSA def(q) [field Item2] : Object | Tuples.cs:24:14:24:14 | access to local variable q [field Item2] : Object |
 | Tuples.cs:24:14:24:14 | access to local variable q [field Item2] : Object | Tuples.cs:24:14:24:20 | access to field Item2 |
-| Tuples.cs:24:14:24:14 | access to local variable q [field Item2] : Object | Tuples.cs:24:14:24:20 | access to field Item2 |
-| Tuples.cs:26:14:26:14 | access to local variable x [field Item1] : Object | Tuples.cs:26:14:26:20 | access to field Item1 |
 | Tuples.cs:26:14:26:14 | access to local variable x [field Item1] : Object | Tuples.cs:26:14:26:20 | access to field Item1 |
 | Tuples.cs:27:14:27:14 | access to local variable x [field Item1] : Object | Tuples.cs:27:14:27:16 | access to field Item1 |
-| Tuples.cs:27:14:27:14 | access to local variable x [field Item1] : Object | Tuples.cs:27:14:27:16 | access to field Item1 |
-| Tuples.cs:29:14:29:14 | access to local variable x [field Item2, field Item2] : Object | Tuples.cs:29:14:29:20 | access to field Item2 [field Item2] : Object |
 | Tuples.cs:29:14:29:14 | access to local variable x [field Item2, field Item2] : Object | Tuples.cs:29:14:29:20 | access to field Item2 [field Item2] : Object |
 | Tuples.cs:29:14:29:20 | access to field Item2 [field Item2] : Object | Tuples.cs:29:14:29:26 | access to field Item2 |
-| Tuples.cs:29:14:29:20 | access to field Item2 [field Item2] : Object | Tuples.cs:29:14:29:26 | access to field Item2 |
-| Tuples.cs:34:18:34:34 | call to method Source<Object> : Object | Tuples.cs:37:18:37:19 | access to local variable o1 : Object |
 | Tuples.cs:34:18:34:34 | call to method Source<Object> : Object | Tuples.cs:37:18:37:19 | access to local variable o1 : Object |
 | Tuples.cs:35:18:35:34 | call to method Source<Object> : Object | Tuples.cs:37:46:37:47 | access to local variable o2 : Object |
-| Tuples.cs:35:18:35:34 | call to method Source<Object> : Object | Tuples.cs:37:46:37:47 | access to local variable o2 : Object |
-| Tuples.cs:37:17:37:48 | (..., ...) [field Item1] : Object | Tuples.cs:38:14:38:14 | access to local variable x [field Item1] : Object |
 | Tuples.cs:37:17:37:48 | (..., ...) [field Item1] : Object | Tuples.cs:38:14:38:14 | access to local variable x [field Item1] : Object |
 | Tuples.cs:37:17:37:48 | (..., ...) [field Item10] : Object | Tuples.cs:40:14:40:14 | access to local variable x [field Item10] : Object |
-| Tuples.cs:37:17:37:48 | (..., ...) [field Item10] : Object | Tuples.cs:40:14:40:14 | access to local variable x [field Item10] : Object |
-| Tuples.cs:37:18:37:19 | access to local variable o1 : Object | Tuples.cs:37:17:37:48 | (..., ...) [field Item1] : Object |
 | Tuples.cs:37:18:37:19 | access to local variable o1 : Object | Tuples.cs:37:17:37:48 | (..., ...) [field Item1] : Object |
 | Tuples.cs:37:46:37:47 | access to local variable o2 : Object | Tuples.cs:37:17:37:48 | (..., ...) [field Item10] : Object |
-| Tuples.cs:37:46:37:47 | access to local variable o2 : Object | Tuples.cs:37:17:37:48 | (..., ...) [field Item10] : Object |
-| Tuples.cs:38:14:38:14 | access to local variable x [field Item1] : Object | Tuples.cs:38:14:38:20 | access to field Item1 |
 | Tuples.cs:38:14:38:14 | access to local variable x [field Item1] : Object | Tuples.cs:38:14:38:20 | access to field Item1 |
 | Tuples.cs:40:14:40:14 | access to local variable x [field Item10] : Object | Tuples.cs:40:14:40:21 | access to field Item10 |
-| Tuples.cs:40:14:40:14 | access to local variable x [field Item10] : Object | Tuples.cs:40:14:40:21 | access to field Item10 |
-| Tuples.cs:45:17:45:33 | call to method Source<String> : String | Tuples.cs:46:48:46:48 | access to local variable o : String |
 | Tuples.cs:45:17:45:33 | call to method Source<String> : String | Tuples.cs:46:48:46:48 | access to local variable o : String |
 | Tuples.cs:46:17:46:55 | (...) ... [field Item1] : String | Tuples.cs:47:14:47:14 | access to local variable x [field Item1] : String |
-| Tuples.cs:46:17:46:55 | (...) ... [field Item1] : String | Tuples.cs:47:14:47:14 | access to local variable x [field Item1] : String |
-| Tuples.cs:46:47:46:55 | (..., ...) [field Item1] : String | Tuples.cs:46:17:46:55 | (...) ... [field Item1] : String |
 | Tuples.cs:46:47:46:55 | (..., ...) [field Item1] : String | Tuples.cs:46:17:46:55 | (...) ... [field Item1] : String |
 | Tuples.cs:46:48:46:48 | access to local variable o : String | Tuples.cs:46:47:46:55 | (..., ...) [field Item1] : String |
-| Tuples.cs:46:48:46:48 | access to local variable o : String | Tuples.cs:46:47:46:55 | (..., ...) [field Item1] : String |
-| Tuples.cs:47:14:47:14 | access to local variable x [field Item1] : String | Tuples.cs:47:14:47:20 | access to field Item1 |
 | Tuples.cs:47:14:47:14 | access to local variable x [field Item1] : String | Tuples.cs:47:14:47:20 | access to field Item1 |
 | Tuples.cs:57:18:57:34 | call to method Source<String> : String | Tuples.cs:59:18:59:19 | access to local variable o1 : String |
-| Tuples.cs:57:18:57:34 | call to method Source<String> : String | Tuples.cs:59:18:59:19 | access to local variable o1 : String |
-| Tuples.cs:58:18:58:34 | call to method Source<String> : String | Tuples.cs:59:26:59:27 | access to local variable o2 : String |
 | Tuples.cs:58:18:58:34 | call to method Source<String> : String | Tuples.cs:59:26:59:27 | access to local variable o2 : String |
 | Tuples.cs:59:17:59:32 | (..., ...) [field Item1] : String | Tuples.cs:62:18:62:57 | SSA def(t) [field Item1] : String |
-| Tuples.cs:59:17:59:32 | (..., ...) [field Item1] : String | Tuples.cs:62:18:62:57 | SSA def(t) [field Item1] : String |
-| Tuples.cs:59:17:59:32 | (..., ...) [field Item1] : String | Tuples.cs:67:18:67:35 | (..., ...) [field Item1] : String |
 | Tuples.cs:59:17:59:32 | (..., ...) [field Item1] : String | Tuples.cs:67:18:67:35 | (..., ...) [field Item1] : String |
 | Tuples.cs:59:17:59:32 | (..., ...) [field Item1] : String | Tuples.cs:87:18:87:35 | (..., ...) [field Item1] : String |
-| Tuples.cs:59:17:59:32 | (..., ...) [field Item1] : String | Tuples.cs:87:18:87:35 | (..., ...) [field Item1] : String |
-| Tuples.cs:59:17:59:32 | (..., ...) [field Item2, field Item2] : String | Tuples.cs:62:18:62:57 | SSA def(t) [field Item2, field Item2] : String |
 | Tuples.cs:59:17:59:32 | (..., ...) [field Item2, field Item2] : String | Tuples.cs:62:18:62:57 | SSA def(t) [field Item2, field Item2] : String |
 | Tuples.cs:59:17:59:32 | (..., ...) [field Item2, field Item2] : String | Tuples.cs:67:18:67:35 | (..., ...) [field Item2, field Item2] : String |
-| Tuples.cs:59:17:59:32 | (..., ...) [field Item2, field Item2] : String | Tuples.cs:67:18:67:35 | (..., ...) [field Item2, field Item2] : String |
-| Tuples.cs:59:17:59:32 | (..., ...) [field Item2, field Item2] : String | Tuples.cs:87:18:87:35 | (..., ...) [field Item2, field Item2] : String |
 | Tuples.cs:59:17:59:32 | (..., ...) [field Item2, field Item2] : String | Tuples.cs:87:18:87:35 | (..., ...) [field Item2, field Item2] : String |
 | Tuples.cs:59:18:59:19 | access to local variable o1 : String | Tuples.cs:59:17:59:32 | (..., ...) [field Item1] : String |
-| Tuples.cs:59:18:59:19 | access to local variable o1 : String | Tuples.cs:59:17:59:32 | (..., ...) [field Item1] : String |
-| Tuples.cs:59:22:59:28 | (..., ...) [field Item2] : String | Tuples.cs:59:17:59:32 | (..., ...) [field Item2, field Item2] : String |
 | Tuples.cs:59:22:59:28 | (..., ...) [field Item2] : String | Tuples.cs:59:17:59:32 | (..., ...) [field Item2, field Item2] : String |
 | Tuples.cs:59:26:59:27 | access to local variable o2 : String | Tuples.cs:59:22:59:28 | (..., ...) [field Item2] : String |
-| Tuples.cs:59:26:59:27 | access to local variable o2 : String | Tuples.cs:59:22:59:28 | (..., ...) [field Item2] : String |
-| Tuples.cs:62:18:62:57 | SSA def(t) [field Item1] : String | Tuples.cs:63:22:63:22 | access to local variable t [field Item1] : String |
 | Tuples.cs:62:18:62:57 | SSA def(t) [field Item1] : String | Tuples.cs:63:22:63:22 | access to local variable t [field Item1] : String |
 | Tuples.cs:62:18:62:57 | SSA def(t) [field Item2, field Item2] : String | Tuples.cs:64:22:64:22 | access to local variable t [field Item2, field Item2] : String |
-| Tuples.cs:62:18:62:57 | SSA def(t) [field Item2, field Item2] : String | Tuples.cs:64:22:64:22 | access to local variable t [field Item2, field Item2] : String |
-| Tuples.cs:63:22:63:22 | access to local variable t [field Item1] : String | Tuples.cs:63:22:63:28 | access to field Item1 |
 | Tuples.cs:63:22:63:22 | access to local variable t [field Item1] : String | Tuples.cs:63:22:63:28 | access to field Item1 |
 | Tuples.cs:64:22:64:22 | access to local variable t [field Item2, field Item2] : String | Tuples.cs:64:22:64:28 | access to field Item2 [field Item2] : String |
-| Tuples.cs:64:22:64:22 | access to local variable t [field Item2, field Item2] : String | Tuples.cs:64:22:64:28 | access to field Item2 [field Item2] : String |
-| Tuples.cs:64:22:64:28 | access to field Item2 [field Item2] : String | Tuples.cs:64:22:64:34 | access to field Item2 |
 | Tuples.cs:64:22:64:28 | access to field Item2 [field Item2] : String | Tuples.cs:64:22:64:34 | access to field Item2 |
 | Tuples.cs:67:18:67:35 | (..., ...) [field Item1] : String | Tuples.cs:67:23:67:23 | SSA def(a) : String |
-| Tuples.cs:67:18:67:35 | (..., ...) [field Item1] : String | Tuples.cs:67:23:67:23 | SSA def(a) : String |
-| Tuples.cs:67:18:67:35 | (..., ...) [field Item2, field Item2] : String | Tuples.cs:67:18:67:35 | (..., ...) [field Item2] : String |
 | Tuples.cs:67:18:67:35 | (..., ...) [field Item2, field Item2] : String | Tuples.cs:67:18:67:35 | (..., ...) [field Item2] : String |
 | Tuples.cs:67:18:67:35 | (..., ...) [field Item2] : String | Tuples.cs:67:30:67:30 | SSA def(c) : String |
-| Tuples.cs:67:18:67:35 | (..., ...) [field Item2] : String | Tuples.cs:67:30:67:30 | SSA def(c) : String |
-| Tuples.cs:67:23:67:23 | SSA def(a) : String | Tuples.cs:68:22:68:22 | access to local variable a |
 | Tuples.cs:67:23:67:23 | SSA def(a) : String | Tuples.cs:68:22:68:22 | access to local variable a |
 | Tuples.cs:67:30:67:30 | SSA def(c) : String | Tuples.cs:69:22:69:22 | access to local variable c |
-| Tuples.cs:67:30:67:30 | SSA def(c) : String | Tuples.cs:69:22:69:22 | access to local variable c |
-| Tuples.cs:87:18:87:35 | (..., ...) [field Item1] : String | Tuples.cs:87:23:87:23 | SSA def(p) : String |
 | Tuples.cs:87:18:87:35 | (..., ...) [field Item1] : String | Tuples.cs:87:23:87:23 | SSA def(p) : String |
 | Tuples.cs:87:18:87:35 | (..., ...) [field Item2, field Item2] : String | Tuples.cs:87:18:87:35 | (..., ...) [field Item2] : String |
-| Tuples.cs:87:18:87:35 | (..., ...) [field Item2, field Item2] : String | Tuples.cs:87:18:87:35 | (..., ...) [field Item2] : String |
-| Tuples.cs:87:18:87:35 | (..., ...) [field Item2] : String | Tuples.cs:87:30:87:30 | SSA def(r) : String |
 | Tuples.cs:87:18:87:35 | (..., ...) [field Item2] : String | Tuples.cs:87:30:87:30 | SSA def(r) : String |
 | Tuples.cs:87:23:87:23 | SSA def(p) : String | Tuples.cs:89:18:89:18 | access to local variable p |
-| Tuples.cs:87:23:87:23 | SSA def(p) : String | Tuples.cs:89:18:89:18 | access to local variable p |
-| Tuples.cs:87:30:87:30 | SSA def(r) : String | Tuples.cs:90:18:90:18 | access to local variable r |
 | Tuples.cs:87:30:87:30 | SSA def(r) : String | Tuples.cs:90:18:90:18 | access to local variable r |
 | Tuples.cs:99:17:99:33 | call to method Source<String> : String | Tuples.cs:100:24:100:24 | access to local variable o : String |
-| Tuples.cs:99:17:99:33 | call to method Source<String> : String | Tuples.cs:100:24:100:24 | access to local variable o : String |
-| Tuples.cs:100:17:100:28 | object creation of type R1 [property i] : String | Tuples.cs:101:14:101:14 | access to local variable r [property i] : String |
 | Tuples.cs:100:17:100:28 | object creation of type R1 [property i] : String | Tuples.cs:101:14:101:14 | access to local variable r [property i] : String |
 | Tuples.cs:100:24:100:24 | access to local variable o : String | Tuples.cs:100:17:100:28 | object creation of type R1 [property i] : String |
-| Tuples.cs:100:24:100:24 | access to local variable o : String | Tuples.cs:100:17:100:28 | object creation of type R1 [property i] : String |
-| Tuples.cs:101:14:101:14 | access to local variable r [property i] : String | Tuples.cs:101:14:101:16 | access to property i |
 | Tuples.cs:101:14:101:14 | access to local variable r [property i] : String | Tuples.cs:101:14:101:16 | access to property i |
 | Tuples.cs:118:17:118:33 | call to method Source<Object> : Object | Tuples.cs:121:28:121:28 | access to local variable o : Object |
-| Tuples.cs:118:17:118:33 | call to method Source<Object> : Object | Tuples.cs:121:28:121:28 | access to local variable o : Object |
-| Tuples.cs:118:17:118:33 | call to method Source<Object> : Object | Tuples.cs:122:14:122:15 | access to local variable x1 |
 | Tuples.cs:118:17:118:33 | call to method Source<Object> : Object | Tuples.cs:122:14:122:15 | access to local variable x1 |
 | Tuples.cs:118:17:118:33 | call to method Source<Object> : Object | Tuples.cs:125:25:125:25 | access to local variable o : Object |
-| Tuples.cs:118:17:118:33 | call to method Source<Object> : Object | Tuples.cs:125:25:125:25 | access to local variable o : Object |
-| Tuples.cs:118:17:118:33 | call to method Source<Object> : Object | Tuples.cs:126:14:126:15 | access to local variable x2 |
 | Tuples.cs:118:17:118:33 | call to method Source<Object> : Object | Tuples.cs:126:14:126:15 | access to local variable x2 |
 | Tuples.cs:118:17:118:33 | call to method Source<Object> : Object | Tuples.cs:129:31:129:31 | access to local variable o : Object |
-| Tuples.cs:118:17:118:33 | call to method Source<Object> : Object | Tuples.cs:129:31:129:31 | access to local variable o : Object |
-| Tuples.cs:118:17:118:33 | call to method Source<Object> : Object | Tuples.cs:130:14:130:15 | access to local variable y3 |
 | Tuples.cs:118:17:118:33 | call to method Source<Object> : Object | Tuples.cs:130:14:130:15 | access to local variable y3 |
 | Tuples.cs:118:17:118:33 | call to method Source<Object> : Object | Tuples.cs:133:28:133:28 | access to local variable o : Object |
-| Tuples.cs:118:17:118:33 | call to method Source<Object> : Object | Tuples.cs:133:28:133:28 | access to local variable o : Object |
-| Tuples.cs:118:17:118:33 | call to method Source<Object> : Object | Tuples.cs:134:14:134:15 | access to local variable y4 |
 | Tuples.cs:118:17:118:33 | call to method Source<Object> : Object | Tuples.cs:134:14:134:15 | access to local variable y4 |
 | Tuples.cs:121:9:121:23 | (..., ...) [field Item1] : Object | Tuples.cs:121:9:121:32 | SSA def(x1) : Object |
-| Tuples.cs:121:9:121:23 | (..., ...) [field Item1] : Object | Tuples.cs:121:9:121:32 | SSA def(x1) : Object |
-| Tuples.cs:121:9:121:32 | SSA def(x1) : Object | Tuples.cs:122:14:122:15 | access to local variable x1 |
 | Tuples.cs:121:9:121:32 | SSA def(x1) : Object | Tuples.cs:122:14:122:15 | access to local variable x1 |
 | Tuples.cs:121:27:121:32 | (..., ...) [field Item1] : Object | Tuples.cs:121:9:121:23 | (..., ...) [field Item1] : Object |
-| Tuples.cs:121:27:121:32 | (..., ...) [field Item1] : Object | Tuples.cs:121:9:121:23 | (..., ...) [field Item1] : Object |
-| Tuples.cs:121:28:121:28 | access to local variable o : Object | Tuples.cs:121:27:121:32 | (..., ...) [field Item1] : Object |
 | Tuples.cs:121:28:121:28 | access to local variable o : Object | Tuples.cs:121:27:121:32 | (..., ...) [field Item1] : Object |
 | Tuples.cs:125:9:125:20 | (..., ...) [field Item1] : Object | Tuples.cs:125:9:125:29 | SSA def(x2) : Object |
-| Tuples.cs:125:9:125:20 | (..., ...) [field Item1] : Object | Tuples.cs:125:9:125:29 | SSA def(x2) : Object |
-| Tuples.cs:125:9:125:29 | SSA def(x2) : Object | Tuples.cs:126:14:126:15 | access to local variable x2 |
 | Tuples.cs:125:9:125:29 | SSA def(x2) : Object | Tuples.cs:126:14:126:15 | access to local variable x2 |
 | Tuples.cs:125:24:125:29 | (..., ...) [field Item1] : Object | Tuples.cs:125:9:125:20 | (..., ...) [field Item1] : Object |
-| Tuples.cs:125:24:125:29 | (..., ...) [field Item1] : Object | Tuples.cs:125:9:125:20 | (..., ...) [field Item1] : Object |
-| Tuples.cs:125:25:125:25 | access to local variable o : Object | Tuples.cs:125:24:125:29 | (..., ...) [field Item1] : Object |
 | Tuples.cs:125:25:125:25 | access to local variable o : Object | Tuples.cs:125:24:125:29 | (..., ...) [field Item1] : Object |
 | Tuples.cs:129:9:129:23 | (..., ...) [field Item2] : Object | Tuples.cs:129:9:129:32 | SSA def(y3) : Object |
-| Tuples.cs:129:9:129:23 | (..., ...) [field Item2] : Object | Tuples.cs:129:9:129:32 | SSA def(y3) : Object |
-| Tuples.cs:129:9:129:32 | SSA def(y3) : Object | Tuples.cs:130:14:130:15 | access to local variable y3 |
 | Tuples.cs:129:9:129:32 | SSA def(y3) : Object | Tuples.cs:130:14:130:15 | access to local variable y3 |
 | Tuples.cs:129:27:129:32 | (..., ...) [field Item2] : Object | Tuples.cs:129:9:129:23 | (..., ...) [field Item2] : Object |
-| Tuples.cs:129:27:129:32 | (..., ...) [field Item2] : Object | Tuples.cs:129:9:129:23 | (..., ...) [field Item2] : Object |
-| Tuples.cs:129:31:129:31 | access to local variable o : Object | Tuples.cs:129:27:129:32 | (..., ...) [field Item2] : Object |
 | Tuples.cs:129:31:129:31 | access to local variable o : Object | Tuples.cs:129:27:129:32 | (..., ...) [field Item2] : Object |
 | Tuples.cs:133:9:133:20 | (..., ...) [field Item2] : Object | Tuples.cs:133:9:133:29 | SSA def(y4) : Object |
-| Tuples.cs:133:9:133:20 | (..., ...) [field Item2] : Object | Tuples.cs:133:9:133:29 | SSA def(y4) : Object |
-| Tuples.cs:133:9:133:29 | SSA def(y4) : Object | Tuples.cs:134:14:134:15 | access to local variable y4 |
 | Tuples.cs:133:9:133:29 | SSA def(y4) : Object | Tuples.cs:134:14:134:15 | access to local variable y4 |
 | Tuples.cs:133:24:133:29 | (..., ...) [field Item2] : Object | Tuples.cs:133:9:133:20 | (..., ...) [field Item2] : Object |
-| Tuples.cs:133:24:133:29 | (..., ...) [field Item2] : Object | Tuples.cs:133:9:133:20 | (..., ...) [field Item2] : Object |
-| Tuples.cs:133:28:133:28 | access to local variable o : Object | Tuples.cs:133:24:133:29 | (..., ...) [field Item2] : Object |
 | Tuples.cs:133:28:133:28 | access to local variable o : Object | Tuples.cs:133:24:133:29 | (..., ...) [field Item2] : Object |
 nodes
 | Tuples.cs:7:18:7:34 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
-| Tuples.cs:7:18:7:34 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
-| Tuples.cs:8:18:8:34 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
 | Tuples.cs:8:18:8:34 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
 | Tuples.cs:10:17:10:32 | (..., ...) [field Item1] : Object | semmle.label | (..., ...) [field Item1] : Object |
-| Tuples.cs:10:17:10:32 | (..., ...) [field Item1] : Object | semmle.label | (..., ...) [field Item1] : Object |
-| Tuples.cs:10:17:10:32 | (..., ...) [field Item2, field Item2] : Object | semmle.label | (..., ...) [field Item2, field Item2] : Object |
 | Tuples.cs:10:17:10:32 | (..., ...) [field Item2, field Item2] : Object | semmle.label | (..., ...) [field Item2, field Item2] : Object |
 | Tuples.cs:10:21:10:22 | access to local variable o1 : Object | semmle.label | access to local variable o1 : Object |
-| Tuples.cs:10:21:10:22 | access to local variable o1 : Object | semmle.label | access to local variable o1 : Object |
-| Tuples.cs:10:25:10:31 | (..., ...) [field Item2] : Object | semmle.label | (..., ...) [field Item2] : Object |
 | Tuples.cs:10:25:10:31 | (..., ...) [field Item2] : Object | semmle.label | (..., ...) [field Item2] : Object |
 | Tuples.cs:10:29:10:30 | access to local variable o2 : Object | semmle.label | access to local variable o2 : Object |
-| Tuples.cs:10:29:10:30 | access to local variable o2 : Object | semmle.label | access to local variable o2 : Object |
-| Tuples.cs:11:9:11:23 | (..., ...) [field Item1] : Object | semmle.label | (..., ...) [field Item1] : Object |
 | Tuples.cs:11:9:11:23 | (..., ...) [field Item1] : Object | semmle.label | (..., ...) [field Item1] : Object |
 | Tuples.cs:11:9:11:23 | (..., ...) [field Item2, field Item2] : Object | semmle.label | (..., ...) [field Item2, field Item2] : Object |
-| Tuples.cs:11:9:11:23 | (..., ...) [field Item2, field Item2] : Object | semmle.label | (..., ...) [field Item2, field Item2] : Object |
-| Tuples.cs:11:9:11:23 | (..., ...) [field Item2] : Object | semmle.label | (..., ...) [field Item2] : Object |
 | Tuples.cs:11:9:11:23 | (..., ...) [field Item2] : Object | semmle.label | (..., ...) [field Item2] : Object |
 | Tuples.cs:11:9:11:27 | SSA def(a) : Object | semmle.label | SSA def(a) : Object |
-| Tuples.cs:11:9:11:27 | SSA def(a) : Object | semmle.label | SSA def(a) : Object |
-| Tuples.cs:11:9:11:27 | SSA def(c) : Object | semmle.label | SSA def(c) : Object |
 | Tuples.cs:11:9:11:27 | SSA def(c) : Object | semmle.label | SSA def(c) : Object |
 | Tuples.cs:12:14:12:14 | access to local variable a | semmle.label | access to local variable a |
-| Tuples.cs:12:14:12:14 | access to local variable a | semmle.label | access to local variable a |
-| Tuples.cs:14:14:14:14 | access to local variable c | semmle.label | access to local variable c |
 | Tuples.cs:14:14:14:14 | access to local variable c | semmle.label | access to local variable c |
 | Tuples.cs:16:9:16:19 | (..., ...) [field Item1] : Object | semmle.label | (..., ...) [field Item1] : Object |
-| Tuples.cs:16:9:16:19 | (..., ...) [field Item1] : Object | semmle.label | (..., ...) [field Item1] : Object |
-| Tuples.cs:16:9:16:19 | (..., ...) [field Item2, field Item2] : Object | semmle.label | (..., ...) [field Item2, field Item2] : Object |
 | Tuples.cs:16:9:16:19 | (..., ...) [field Item2, field Item2] : Object | semmle.label | (..., ...) [field Item2, field Item2] : Object |
 | Tuples.cs:16:9:16:23 | SSA def(a) : Object | semmle.label | SSA def(a) : Object |
-| Tuples.cs:16:9:16:23 | SSA def(a) : Object | semmle.label | SSA def(a) : Object |
-| Tuples.cs:16:9:16:23 | SSA def(c) : Object | semmle.label | SSA def(c) : Object |
 | Tuples.cs:16:9:16:23 | SSA def(c) : Object | semmle.label | SSA def(c) : Object |
 | Tuples.cs:16:13:16:18 | (..., ...) [field Item2] : Object | semmle.label | (..., ...) [field Item2] : Object |
-| Tuples.cs:16:13:16:18 | (..., ...) [field Item2] : Object | semmle.label | (..., ...) [field Item2] : Object |
-| Tuples.cs:17:14:17:14 | access to local variable a | semmle.label | access to local variable a |
 | Tuples.cs:17:14:17:14 | access to local variable a | semmle.label | access to local variable a |
 | Tuples.cs:19:14:19:14 | access to local variable c | semmle.label | access to local variable c |
-| Tuples.cs:19:14:19:14 | access to local variable c | semmle.label | access to local variable c |
-| Tuples.cs:21:9:21:22 | (..., ...) [field Item1] : Object | semmle.label | (..., ...) [field Item1] : Object |
 | Tuples.cs:21:9:21:22 | (..., ...) [field Item1] : Object | semmle.label | (..., ...) [field Item1] : Object |
 | Tuples.cs:21:9:21:22 | (..., ...) [field Item2, field Item2] : Object | semmle.label | (..., ...) [field Item2, field Item2] : Object |
-| Tuples.cs:21:9:21:22 | (..., ...) [field Item2, field Item2] : Object | semmle.label | (..., ...) [field Item2, field Item2] : Object |
-| Tuples.cs:21:9:21:26 | SSA def(p) : Object | semmle.label | SSA def(p) : Object |
 | Tuples.cs:21:9:21:26 | SSA def(p) : Object | semmle.label | SSA def(p) : Object |
 | Tuples.cs:21:9:21:26 | SSA def(q) [field Item2] : Object | semmle.label | SSA def(q) [field Item2] : Object |
-| Tuples.cs:21:9:21:26 | SSA def(q) [field Item2] : Object | semmle.label | SSA def(q) [field Item2] : Object |
-| Tuples.cs:22:14:22:14 | access to local variable p | semmle.label | access to local variable p |
 | Tuples.cs:22:14:22:14 | access to local variable p | semmle.label | access to local variable p |
 | Tuples.cs:24:14:24:14 | access to local variable q [field Item2] : Object | semmle.label | access to local variable q [field Item2] : Object |
-| Tuples.cs:24:14:24:14 | access to local variable q [field Item2] : Object | semmle.label | access to local variable q [field Item2] : Object |
-| Tuples.cs:24:14:24:20 | access to field Item2 | semmle.label | access to field Item2 |
 | Tuples.cs:24:14:24:20 | access to field Item2 | semmle.label | access to field Item2 |
 | Tuples.cs:26:14:26:14 | access to local variable x [field Item1] : Object | semmle.label | access to local variable x [field Item1] : Object |
-| Tuples.cs:26:14:26:14 | access to local variable x [field Item1] : Object | semmle.label | access to local variable x [field Item1] : Object |
-| Tuples.cs:26:14:26:20 | access to field Item1 | semmle.label | access to field Item1 |
 | Tuples.cs:26:14:26:20 | access to field Item1 | semmle.label | access to field Item1 |
 | Tuples.cs:27:14:27:14 | access to local variable x [field Item1] : Object | semmle.label | access to local variable x [field Item1] : Object |
-| Tuples.cs:27:14:27:14 | access to local variable x [field Item1] : Object | semmle.label | access to local variable x [field Item1] : Object |
-| Tuples.cs:27:14:27:16 | access to field Item1 | semmle.label | access to field Item1 |
 | Tuples.cs:27:14:27:16 | access to field Item1 | semmle.label | access to field Item1 |
 | Tuples.cs:29:14:29:14 | access to local variable x [field Item2, field Item2] : Object | semmle.label | access to local variable x [field Item2, field Item2] : Object |
-| Tuples.cs:29:14:29:14 | access to local variable x [field Item2, field Item2] : Object | semmle.label | access to local variable x [field Item2, field Item2] : Object |
-| Tuples.cs:29:14:29:20 | access to field Item2 [field Item2] : Object | semmle.label | access to field Item2 [field Item2] : Object |
 | Tuples.cs:29:14:29:20 | access to field Item2 [field Item2] : Object | semmle.label | access to field Item2 [field Item2] : Object |
 | Tuples.cs:29:14:29:26 | access to field Item2 | semmle.label | access to field Item2 |
-| Tuples.cs:29:14:29:26 | access to field Item2 | semmle.label | access to field Item2 |
-| Tuples.cs:34:18:34:34 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
 | Tuples.cs:34:18:34:34 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
 | Tuples.cs:35:18:35:34 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
-| Tuples.cs:35:18:35:34 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
-| Tuples.cs:37:17:37:48 | (..., ...) [field Item1] : Object | semmle.label | (..., ...) [field Item1] : Object |
 | Tuples.cs:37:17:37:48 | (..., ...) [field Item1] : Object | semmle.label | (..., ...) [field Item1] : Object |
 | Tuples.cs:37:17:37:48 | (..., ...) [field Item10] : Object | semmle.label | (..., ...) [field Item10] : Object |
-| Tuples.cs:37:17:37:48 | (..., ...) [field Item10] : Object | semmle.label | (..., ...) [field Item10] : Object |
-| Tuples.cs:37:18:37:19 | access to local variable o1 : Object | semmle.label | access to local variable o1 : Object |
 | Tuples.cs:37:18:37:19 | access to local variable o1 : Object | semmle.label | access to local variable o1 : Object |
 | Tuples.cs:37:46:37:47 | access to local variable o2 : Object | semmle.label | access to local variable o2 : Object |
-| Tuples.cs:37:46:37:47 | access to local variable o2 : Object | semmle.label | access to local variable o2 : Object |
-| Tuples.cs:38:14:38:14 | access to local variable x [field Item1] : Object | semmle.label | access to local variable x [field Item1] : Object |
 | Tuples.cs:38:14:38:14 | access to local variable x [field Item1] : Object | semmle.label | access to local variable x [field Item1] : Object |
 | Tuples.cs:38:14:38:20 | access to field Item1 | semmle.label | access to field Item1 |
-| Tuples.cs:38:14:38:20 | access to field Item1 | semmle.label | access to field Item1 |
-| Tuples.cs:40:14:40:14 | access to local variable x [field Item10] : Object | semmle.label | access to local variable x [field Item10] : Object |
 | Tuples.cs:40:14:40:14 | access to local variable x [field Item10] : Object | semmle.label | access to local variable x [field Item10] : Object |
 | Tuples.cs:40:14:40:21 | access to field Item10 | semmle.label | access to field Item10 |
-| Tuples.cs:40:14:40:21 | access to field Item10 | semmle.label | access to field Item10 |
-| Tuples.cs:45:17:45:33 | call to method Source<String> : String | semmle.label | call to method Source<String> : String |
 | Tuples.cs:45:17:45:33 | call to method Source<String> : String | semmle.label | call to method Source<String> : String |
 | Tuples.cs:46:17:46:55 | (...) ... [field Item1] : String | semmle.label | (...) ... [field Item1] : String |
-| Tuples.cs:46:17:46:55 | (...) ... [field Item1] : String | semmle.label | (...) ... [field Item1] : String |
-| Tuples.cs:46:47:46:55 | (..., ...) [field Item1] : String | semmle.label | (..., ...) [field Item1] : String |
 | Tuples.cs:46:47:46:55 | (..., ...) [field Item1] : String | semmle.label | (..., ...) [field Item1] : String |
 | Tuples.cs:46:48:46:48 | access to local variable o : String | semmle.label | access to local variable o : String |
-| Tuples.cs:46:48:46:48 | access to local variable o : String | semmle.label | access to local variable o : String |
-| Tuples.cs:47:14:47:14 | access to local variable x [field Item1] : String | semmle.label | access to local variable x [field Item1] : String |
 | Tuples.cs:47:14:47:14 | access to local variable x [field Item1] : String | semmle.label | access to local variable x [field Item1] : String |
 | Tuples.cs:47:14:47:20 | access to field Item1 | semmle.label | access to field Item1 |
-| Tuples.cs:47:14:47:20 | access to field Item1 | semmle.label | access to field Item1 |
-| Tuples.cs:57:18:57:34 | call to method Source<String> : String | semmle.label | call to method Source<String> : String |
 | Tuples.cs:57:18:57:34 | call to method Source<String> : String | semmle.label | call to method Source<String> : String |
 | Tuples.cs:58:18:58:34 | call to method Source<String> : String | semmle.label | call to method Source<String> : String |
-| Tuples.cs:58:18:58:34 | call to method Source<String> : String | semmle.label | call to method Source<String> : String |
-| Tuples.cs:59:17:59:32 | (..., ...) [field Item1] : String | semmle.label | (..., ...) [field Item1] : String |
 | Tuples.cs:59:17:59:32 | (..., ...) [field Item1] : String | semmle.label | (..., ...) [field Item1] : String |
 | Tuples.cs:59:17:59:32 | (..., ...) [field Item2, field Item2] : String | semmle.label | (..., ...) [field Item2, field Item2] : String |
-| Tuples.cs:59:17:59:32 | (..., ...) [field Item2, field Item2] : String | semmle.label | (..., ...) [field Item2, field Item2] : String |
-| Tuples.cs:59:18:59:19 | access to local variable o1 : String | semmle.label | access to local variable o1 : String |
 | Tuples.cs:59:18:59:19 | access to local variable o1 : String | semmle.label | access to local variable o1 : String |
 | Tuples.cs:59:22:59:28 | (..., ...) [field Item2] : String | semmle.label | (..., ...) [field Item2] : String |
-| Tuples.cs:59:22:59:28 | (..., ...) [field Item2] : String | semmle.label | (..., ...) [field Item2] : String |
-| Tuples.cs:59:26:59:27 | access to local variable o2 : String | semmle.label | access to local variable o2 : String |
 | Tuples.cs:59:26:59:27 | access to local variable o2 : String | semmle.label | access to local variable o2 : String |
 | Tuples.cs:62:18:62:57 | SSA def(t) [field Item1] : String | semmle.label | SSA def(t) [field Item1] : String |
-| Tuples.cs:62:18:62:57 | SSA def(t) [field Item1] : String | semmle.label | SSA def(t) [field Item1] : String |
-| Tuples.cs:62:18:62:57 | SSA def(t) [field Item2, field Item2] : String | semmle.label | SSA def(t) [field Item2, field Item2] : String |
 | Tuples.cs:62:18:62:57 | SSA def(t) [field Item2, field Item2] : String | semmle.label | SSA def(t) [field Item2, field Item2] : String |
 | Tuples.cs:63:22:63:22 | access to local variable t [field Item1] : String | semmle.label | access to local variable t [field Item1] : String |
-| Tuples.cs:63:22:63:22 | access to local variable t [field Item1] : String | semmle.label | access to local variable t [field Item1] : String |
-| Tuples.cs:63:22:63:28 | access to field Item1 | semmle.label | access to field Item1 |
 | Tuples.cs:63:22:63:28 | access to field Item1 | semmle.label | access to field Item1 |
 | Tuples.cs:64:22:64:22 | access to local variable t [field Item2, field Item2] : String | semmle.label | access to local variable t [field Item2, field Item2] : String |
-| Tuples.cs:64:22:64:22 | access to local variable t [field Item2, field Item2] : String | semmle.label | access to local variable t [field Item2, field Item2] : String |
-| Tuples.cs:64:22:64:28 | access to field Item2 [field Item2] : String | semmle.label | access to field Item2 [field Item2] : String |
 | Tuples.cs:64:22:64:28 | access to field Item2 [field Item2] : String | semmle.label | access to field Item2 [field Item2] : String |
 | Tuples.cs:64:22:64:34 | access to field Item2 | semmle.label | access to field Item2 |
-| Tuples.cs:64:22:64:34 | access to field Item2 | semmle.label | access to field Item2 |
-| Tuples.cs:67:18:67:35 | (..., ...) [field Item1] : String | semmle.label | (..., ...) [field Item1] : String |
 | Tuples.cs:67:18:67:35 | (..., ...) [field Item1] : String | semmle.label | (..., ...) [field Item1] : String |
 | Tuples.cs:67:18:67:35 | (..., ...) [field Item2, field Item2] : String | semmle.label | (..., ...) [field Item2, field Item2] : String |
-| Tuples.cs:67:18:67:35 | (..., ...) [field Item2, field Item2] : String | semmle.label | (..., ...) [field Item2, field Item2] : String |
-| Tuples.cs:67:18:67:35 | (..., ...) [field Item2] : String | semmle.label | (..., ...) [field Item2] : String |
 | Tuples.cs:67:18:67:35 | (..., ...) [field Item2] : String | semmle.label | (..., ...) [field Item2] : String |
 | Tuples.cs:67:23:67:23 | SSA def(a) : String | semmle.label | SSA def(a) : String |
-| Tuples.cs:67:23:67:23 | SSA def(a) : String | semmle.label | SSA def(a) : String |
-| Tuples.cs:67:30:67:30 | SSA def(c) : String | semmle.label | SSA def(c) : String |
 | Tuples.cs:67:30:67:30 | SSA def(c) : String | semmle.label | SSA def(c) : String |
 | Tuples.cs:68:22:68:22 | access to local variable a | semmle.label | access to local variable a |
-| Tuples.cs:68:22:68:22 | access to local variable a | semmle.label | access to local variable a |
-| Tuples.cs:69:22:69:22 | access to local variable c | semmle.label | access to local variable c |
 | Tuples.cs:69:22:69:22 | access to local variable c | semmle.label | access to local variable c |
 | Tuples.cs:87:18:87:35 | (..., ...) [field Item1] : String | semmle.label | (..., ...) [field Item1] : String |
-| Tuples.cs:87:18:87:35 | (..., ...) [field Item1] : String | semmle.label | (..., ...) [field Item1] : String |
-| Tuples.cs:87:18:87:35 | (..., ...) [field Item2, field Item2] : String | semmle.label | (..., ...) [field Item2, field Item2] : String |
 | Tuples.cs:87:18:87:35 | (..., ...) [field Item2, field Item2] : String | semmle.label | (..., ...) [field Item2, field Item2] : String |
 | Tuples.cs:87:18:87:35 | (..., ...) [field Item2] : String | semmle.label | (..., ...) [field Item2] : String |
-| Tuples.cs:87:18:87:35 | (..., ...) [field Item2] : String | semmle.label | (..., ...) [field Item2] : String |
-| Tuples.cs:87:23:87:23 | SSA def(p) : String | semmle.label | SSA def(p) : String |
 | Tuples.cs:87:23:87:23 | SSA def(p) : String | semmle.label | SSA def(p) : String |
 | Tuples.cs:87:30:87:30 | SSA def(r) : String | semmle.label | SSA def(r) : String |
-| Tuples.cs:87:30:87:30 | SSA def(r) : String | semmle.label | SSA def(r) : String |
-| Tuples.cs:89:18:89:18 | access to local variable p | semmle.label | access to local variable p |
 | Tuples.cs:89:18:89:18 | access to local variable p | semmle.label | access to local variable p |
 | Tuples.cs:90:18:90:18 | access to local variable r | semmle.label | access to local variable r |
-| Tuples.cs:90:18:90:18 | access to local variable r | semmle.label | access to local variable r |
-| Tuples.cs:99:17:99:33 | call to method Source<String> : String | semmle.label | call to method Source<String> : String |
 | Tuples.cs:99:17:99:33 | call to method Source<String> : String | semmle.label | call to method Source<String> : String |
 | Tuples.cs:100:17:100:28 | object creation of type R1 [property i] : String | semmle.label | object creation of type R1 [property i] : String |
-| Tuples.cs:100:17:100:28 | object creation of type R1 [property i] : String | semmle.label | object creation of type R1 [property i] : String |
-| Tuples.cs:100:24:100:24 | access to local variable o : String | semmle.label | access to local variable o : String |
 | Tuples.cs:100:24:100:24 | access to local variable o : String | semmle.label | access to local variable o : String |
 | Tuples.cs:101:14:101:14 | access to local variable r [property i] : String | semmle.label | access to local variable r [property i] : String |
-| Tuples.cs:101:14:101:14 | access to local variable r [property i] : String | semmle.label | access to local variable r [property i] : String |
-| Tuples.cs:101:14:101:16 | access to property i | semmle.label | access to property i |
 | Tuples.cs:101:14:101:16 | access to property i | semmle.label | access to property i |
 | Tuples.cs:118:17:118:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
-| Tuples.cs:118:17:118:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
-| Tuples.cs:121:9:121:23 | (..., ...) [field Item1] : Object | semmle.label | (..., ...) [field Item1] : Object |
 | Tuples.cs:121:9:121:23 | (..., ...) [field Item1] : Object | semmle.label | (..., ...) [field Item1] : Object |
 | Tuples.cs:121:9:121:32 | SSA def(x1) : Object | semmle.label | SSA def(x1) : Object |
-| Tuples.cs:121:9:121:32 | SSA def(x1) : Object | semmle.label | SSA def(x1) : Object |
-| Tuples.cs:121:27:121:32 | (..., ...) [field Item1] : Object | semmle.label | (..., ...) [field Item1] : Object |
 | Tuples.cs:121:27:121:32 | (..., ...) [field Item1] : Object | semmle.label | (..., ...) [field Item1] : Object |
 | Tuples.cs:121:28:121:28 | access to local variable o : Object | semmle.label | access to local variable o : Object |
-| Tuples.cs:121:28:121:28 | access to local variable o : Object | semmle.label | access to local variable o : Object |
-| Tuples.cs:122:14:122:15 | access to local variable x1 | semmle.label | access to local variable x1 |
 | Tuples.cs:122:14:122:15 | access to local variable x1 | semmle.label | access to local variable x1 |
 | Tuples.cs:125:9:125:20 | (..., ...) [field Item1] : Object | semmle.label | (..., ...) [field Item1] : Object |
-| Tuples.cs:125:9:125:20 | (..., ...) [field Item1] : Object | semmle.label | (..., ...) [field Item1] : Object |
-| Tuples.cs:125:9:125:29 | SSA def(x2) : Object | semmle.label | SSA def(x2) : Object |
 | Tuples.cs:125:9:125:29 | SSA def(x2) : Object | semmle.label | SSA def(x2) : Object |
 | Tuples.cs:125:24:125:29 | (..., ...) [field Item1] : Object | semmle.label | (..., ...) [field Item1] : Object |
-| Tuples.cs:125:24:125:29 | (..., ...) [field Item1] : Object | semmle.label | (..., ...) [field Item1] : Object |
-| Tuples.cs:125:25:125:25 | access to local variable o : Object | semmle.label | access to local variable o : Object |
 | Tuples.cs:125:25:125:25 | access to local variable o : Object | semmle.label | access to local variable o : Object |
 | Tuples.cs:126:14:126:15 | access to local variable x2 | semmle.label | access to local variable x2 |
-| Tuples.cs:126:14:126:15 | access to local variable x2 | semmle.label | access to local variable x2 |
-| Tuples.cs:129:9:129:23 | (..., ...) [field Item2] : Object | semmle.label | (..., ...) [field Item2] : Object |
 | Tuples.cs:129:9:129:23 | (..., ...) [field Item2] : Object | semmle.label | (..., ...) [field Item2] : Object |
 | Tuples.cs:129:9:129:32 | SSA def(y3) : Object | semmle.label | SSA def(y3) : Object |
-| Tuples.cs:129:9:129:32 | SSA def(y3) : Object | semmle.label | SSA def(y3) : Object |
-| Tuples.cs:129:27:129:32 | (..., ...) [field Item2] : Object | semmle.label | (..., ...) [field Item2] : Object |
 | Tuples.cs:129:27:129:32 | (..., ...) [field Item2] : Object | semmle.label | (..., ...) [field Item2] : Object |
 | Tuples.cs:129:31:129:31 | access to local variable o : Object | semmle.label | access to local variable o : Object |
-| Tuples.cs:129:31:129:31 | access to local variable o : Object | semmle.label | access to local variable o : Object |
-| Tuples.cs:130:14:130:15 | access to local variable y3 | semmle.label | access to local variable y3 |
 | Tuples.cs:130:14:130:15 | access to local variable y3 | semmle.label | access to local variable y3 |
 | Tuples.cs:133:9:133:20 | (..., ...) [field Item2] : Object | semmle.label | (..., ...) [field Item2] : Object |
-| Tuples.cs:133:9:133:20 | (..., ...) [field Item2] : Object | semmle.label | (..., ...) [field Item2] : Object |
-| Tuples.cs:133:9:133:29 | SSA def(y4) : Object | semmle.label | SSA def(y4) : Object |
 | Tuples.cs:133:9:133:29 | SSA def(y4) : Object | semmle.label | SSA def(y4) : Object |
 | Tuples.cs:133:24:133:29 | (..., ...) [field Item2] : Object | semmle.label | (..., ...) [field Item2] : Object |
-| Tuples.cs:133:24:133:29 | (..., ...) [field Item2] : Object | semmle.label | (..., ...) [field Item2] : Object |
 | Tuples.cs:133:28:133:28 | access to local variable o : Object | semmle.label | access to local variable o : Object |
-| Tuples.cs:133:28:133:28 | access to local variable o : Object | semmle.label | access to local variable o : Object |
-| Tuples.cs:134:14:134:15 | access to local variable y4 | semmle.label | access to local variable y4 |
 | Tuples.cs:134:14:134:15 | access to local variable y4 | semmle.label | access to local variable y4 |
 subpaths
 #select

--- a/csharp/ql/test/library-tests/dataflow/tuples/Tuples.ql
+++ b/csharp/ql/test/library-tests/dataflow/tuples/Tuples.ql
@@ -3,9 +3,9 @@
  */
 
 import csharp
-import DataFlow::PathGraph
+import DefaultValueFlow::PathGraph
 import TestUtilities.InlineFlowTest
 
-from DataFlow::PathNode source, DataFlow::PathNode sink, DefaultValueFlowConf conf
-where conf.hasFlowPath(source, sink)
+from DefaultValueFlow::PathNode source, DefaultValueFlow::PathNode sink
+where DefaultValueFlow::flowPath(source, sink)
 select sink, source, sink, "$@", source, source.toString()

--- a/csharp/ql/test/library-tests/frameworks/EntityFramework/Dataflow.ql
+++ b/csharp/ql/test/library-tests/frameworks/EntityFramework/Dataflow.ql
@@ -3,18 +3,18 @@
  */
 
 import csharp
-import DataFlow::PathGraph
+import Taint::PathGraph
 
-class MyConfiguration extends TaintTracking::Configuration {
-  MyConfiguration() { this = "EntityFramework dataflow" }
+module TaintConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node node) { node.asExpr().getValue() = "tainted" }
 
-  override predicate isSource(DataFlow::Node node) { node.asExpr().getValue() = "tainted" }
-
-  override predicate isSink(DataFlow::Node node) {
+  predicate isSink(DataFlow::Node node) {
     node.asExpr() = any(MethodCall c | c.getTarget().hasName("Sink")).getAnArgument()
   }
 }
 
-from DataFlow::PathNode source, DataFlow::PathNode sink, MyConfiguration conf
-where conf.hasFlowPath(source, sink)
+module Taint = TaintTracking::Global<TaintConfig>;
+
+from Taint::PathNode source, Taint::PathNode sink
+where Taint::flowPath(source, sink)
 select sink, source, sink, "$@", source, source.toString()

--- a/csharp/ql/test/library-tests/frameworks/JsonNET/Json.ql
+++ b/csharp/ql/test/library-tests/frameworks/JsonNET/Json.ql
@@ -1,17 +1,15 @@
 import csharp
 
-class Configuration extends TaintTracking::Configuration {
-  Configuration() { this = "Json.NET test" }
+module TaintConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node src) { src.asExpr().(StringLiteral).getValue() = "tainted" }
 
-  override predicate isSource(DataFlow::Node src) {
-    src.asExpr().(StringLiteral).getValue() = "tainted"
-  }
-
-  override predicate isSink(DataFlow::Node sink) {
+  predicate isSink(DataFlow::Node sink) {
     exists(MethodCall c | c.getArgument(0) = sink.asExpr() and c.getTarget().getName() = "Sink")
   }
 }
 
-from Configuration c, DataFlow::Node source, DataFlow::Node sink
-where c.hasFlow(source, sink)
+module Taint = TaintTracking::Global<TaintConfig>;
+
+from DataFlow::Node source, DataFlow::Node sink
+where Taint::flow(source, sink)
 select source, sink

--- a/csharp/ql/test/library-tests/frameworks/NHibernate/DataFlow.ql
+++ b/csharp/ql/test/library-tests/frameworks/NHibernate/DataFlow.ql
@@ -1,17 +1,15 @@
 import csharp
 
-class MyConfiguration extends TaintTracking::Configuration {
-  MyConfiguration() { this = "MyConfiguration" }
+module TaintConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node node) { node.asExpr().(StringLiteral).getValue() = "tainted" }
 
-  override predicate isSource(DataFlow::Node node) {
-    node.asExpr().(StringLiteral).getValue() = "tainted"
-  }
-
-  override predicate isSink(DataFlow::Node node) {
+  predicate isSink(DataFlow::Node node) {
     exists(MethodCall mc | mc.getTarget().hasName("Sink") and node.asExpr() = mc.getArgument(0))
   }
 }
 
-from MyConfiguration config, DataFlow::Node source, DataFlow::Node sink
-where config.hasFlow(source, sink)
+module Taint = TaintTracking::Global<TaintConfig>;
+
+from DataFlow::Node source, DataFlow::Node sink
+where Taint::flow(source, sink)
 select sink, "Data flow from $@.", source, source.toString()

--- a/csharp/ql/test/library-tests/security/dataflow/flowsources/StoredFlowSources.ql
+++ b/csharp/ql/test/library-tests/security/dataflow/flowsources/StoredFlowSources.ql
@@ -1,13 +1,13 @@
 import semmle.code.csharp.security.dataflow.flowsources.Stored
 
-class StoredConfig extends TaintTracking::Configuration {
-  StoredConfig() { this = "stored" }
+module StoredConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node s) { s instanceof StoredFlowSource }
 
-  override predicate isSource(DataFlow::Node s) { s instanceof StoredFlowSource }
-
-  override predicate isSink(DataFlow::Node s) { s.asExpr().fromSource() }
+  predicate isSink(DataFlow::Node s) { s.asExpr().fromSource() }
 }
 
-from StoredConfig s, DataFlow::Node sink
-where s.hasFlow(any(StoredFlowSource sfs), sink)
+module Stored = TaintTracking::Global<StoredConfig>;
+
+from DataFlow::Node sink
+where Stored::flow(any(StoredFlowSource sfs), sink)
 select sink


### PR DESCRIPTION
In this PR we refactor
- Unit tests
- Inline flow test framework
to the new data flow API.

Note that the inline flow test output has changed. The inline flow tests had two similar configurations in scope during execution which caused the duplicate nodes and edges (these are now removed from the test output).