### PR TITLE
C++: Fix join order in `cpp/unsafe-strncat`

### DIFF
--- a/cpp/ql/src/Likely Bugs/Memory Management/SuspiciousCallToStrncat.ql
+++ b/cpp/ql/src/Likely Bugs/Memory Management/SuspiciousCallToStrncat.ql
@@ -48,11 +48,11 @@ predicate case1(FunctionCall fc, Expr sizeArg, VariableAccess destArg) {
  * Holds if `fc` is a call to `strncat` with size argument `sizeArg` and destination
  * argument `destArg`, and `sizeArg` computes the value `sizeof (dest) - strlen (dest)`.
  */
-predicate case2(FunctionCall fc, Expr sizeArg, VariableAccess destArg) {
-  interestingCallWithArgs(fc, sizeArg, destArg) and
+predicate case2(FunctionCall fc, Expr sizeArg, Expr destArg) {
+  interestingCallWithArgs(fc, pragma[only_bind_into](sizeArg), pragma[only_bind_into](destArg)) and
   exists(SubExpr sub, int n |
     // The destination buffer is an array of size n
-    destArg.getUnspecifiedType().(ArrayType).getSize() = n and
+    pragma[only_bind_out](destArg.getUnspecifiedType().(ArrayType).getSize()) = n and
     // The size argument is equivalent to a subtraction
     globalValueNumber(sizeArg).getAnExpr() = sub and
     // ... where the left side of the subtraction is the constant n


### PR DESCRIPTION
Before:
```ql
Evaluated relational algebra for predicate #select#cpe#1#f@f2abad8d with tuple counts:
        888    ~0%    {2} r1 = SCAN Buffer#834c97d7::BufferSizeExpr::getArg#0#dispred#bf OUTPUT In.1, In.0
        888    ~0%    {2} r2 = JOIN r1 WITH Access#8878f617::Access::getTarget#0#dispred#ff ON FIRST 1 OUTPUT Lhs.1, Rhs.1
        888    ~2%    {3} r3 = JOIN r2 WITH SuspiciousCallToStrncat#a7ff8513::interestingCallWithArgs#3#fff_102#join_rhs ON FIRST 1 OUTPUT Rhs.2, Lhs.1, Rhs.1
          0    ~0%    {1} r4 = JOIN r3 WITH Access#8878f617::Access::getTarget#0#dispred#ff ON FIRST 2 OUTPUT Lhs.2
                  
    3797254    ~0%    {3} r5 = SCAN Expr#ef463c5d::Expr::getValue#0#dispred#ff OUTPUT In.0, In.1, toInt(In.1)
    3797254    ~0%    {2} r6 = SCAN r5 OUTPUT In.2, In.0
     876120    ~0%    {2} r7 = JOIN r6 WITH Type#2e8eb3ef::Type::getSize#0#dispred#bf_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1
     780021    ~0%    {2} r8 = JOIN r7 WITH Type#2e8eb3ef::ArrayType#f ON FIRST 1 OUTPUT Lhs.0, Lhs.1
  182906244    ~0%    {2} r9 = JOIN r8 WITH Expr#ef463c5d::Expr::getUnspecifiedType#0#dispred#bf_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1
  182906244    ~0%    {2} r10 = JOIN r9 WITH Access#8878f617::VariableAccess#f ON FIRST 1 OUTPUT Lhs.0, Lhs.1
  182906244    ~6%    {4} r11 = JOIN r10 WITH SuspiciousCallToStrncat#a7ff8513::interestingCallWithArgs#3#fff_201#join_rhs ON FIRST 1 OUTPUT Lhs.0, Lhs.1, Rhs.1, Rhs.2
  365812488    ~2%    {4} r12 = JOIN r11 WITH ASTValueNumbering#242e2500::GVN::getAnExpr#0#dispred#fb_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3
  365812488  ~111%    {4} r13 = JOIN r12 WITH ASTValueNumbering#242e2500::GVN::getAnExpr#0#dispred#fb ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3
          0    ~0%    {4} r14 = JOIN r13 WITH StringAnalysis#02f5b324::StrlenCall::getStringExpr#0#dispred#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3
          0    ~0%    {4} r15 = JOIN r14 WITH ASTValueNumbering#242e2500::GVN::getAnExpr#0#dispred#fb_10#join_rhs ON FIRST 1 OUTPUT Lhs.1, Lhs.2, Lhs.3, Rhs.1
          0    ~0%    {4} r16 = JOIN r15 WITH ASTValueNumbering#242e2500::GVN::getAnExpr#0#dispred#fb_10#join_rhs ON FIRST 1 OUTPUT Lhs.3, Lhs.1, Lhs.2, Rhs.1
          0    ~0%    {4} r17 = JOIN r16 WITH ASTValueNumbering#242e2500::GVN::getAnExpr#0#dispred#fb ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3
          0    ~0%    {4} r18 = JOIN r17 WITH Expr#ef463c5d::BinaryOperation::getRightOperand#0#dispred#bf_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3
          0    ~0%    {5} r19 = JOIN r18 WITH Expr#ef463c5d::BinaryOperation::getLeftOperand#0#dispred#bf ON FIRST 1 OUTPUT Lhs.3, Rhs.1, Lhs.1, Lhs.2, Lhs.0
          0    ~0%    {3} r20 = JOIN r19 WITH ASTValueNumbering#242e2500::GVN::getAnExpr#0#dispred#fb ON FIRST 2 OUTPUT Lhs.3, Lhs.2, Lhs.4
          0    ~0%    {3} r21 = JOIN r20 WITH ASTValueNumbering#242e2500::GVN::getAnExpr#0#dispred#fb_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.2, Lhs.1
          0    ~0%    {1} r22 = JOIN r21 WITH ASTValueNumbering#242e2500::GVN::getAnExpr#0#dispred#fb ON FIRST 2 OUTPUT Lhs.2
                  
          0    ~0%    {1} r23 = r4 UNION r22
                      return r23
```

After:
```ql
Tuple counts for #select#cpe#1#f/1@964cc76k after 3ms:
  888  ~0%       {2} r1 = SCAN Buffer#834c97d7::BufferSizeExpr::getArg#0#dispred#bf OUTPUT In.1, In.0
  888  ~0%       {2} r2 = JOIN r1 WITH Access#8878f617::Access::getTarget#0#dispred#ff ON FIRST 1 OUTPUT Lhs.1, Rhs.1
  888  ~2%       {3} r3 = JOIN r2 WITH SuspiciousCallToStrncat#a7ff8513::interestingCallWithArgs#3#fff_102#join_rhs ON FIRST 1 OUTPUT Rhs.2, Lhs.1, Rhs.1 'fc'
  0    ~0%       {1} r4 = JOIN r3 WITH Access#8878f617::Access::getTarget#0#dispred#ff ON FIRST 2 OUTPUT Lhs.2 'fc'
  
  5837 ~1%       {3} r5 = SCAN SuspiciousCallToStrncat#a7ff8513::interestingCallWithArgs#3#fff OUTPUT In.2, In.0 'fc', In.1
  5837 ~5%       {4} r6 = JOIN r5 WITH Expr#ef463c5d::Expr::getUnspecifiedType#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.1 'fc', Lhs.2, Lhs.0
  888  ~0%       {4} r7 = JOIN r6 WITH Type#2e8eb3ef::ArrayType#f ON FIRST 1 OUTPUT Lhs.0, Lhs.1 'fc', Lhs.2, Lhs.3
  888  ~1%       {4} r8 = JOIN r7 WITH Type#2e8eb3ef::Type::getSize#0#dispred#bf ON FIRST 1 OUTPUT Lhs.3, Lhs.1 'fc', Lhs.2, Rhs.1
  1776 ~2%       {4} r9 = JOIN r8 WITH ASTValueNumbering#242e2500::GVN::getAnExpr#0#dispred#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1 'fc', Lhs.2, Lhs.3
  3552 ~104%     {4} r10 = JOIN r9 WITH ASTValueNumbering#242e2500::GVN::getAnExpr#0#dispred#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.1 'fc', Lhs.2, Lhs.3
  0    ~0%       {4} r11 = JOIN r10 WITH StringAnalysis#02f5b324::StrlenCall::getStringExpr#0#dispred#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1 'fc', Lhs.2, Lhs.3
  0    ~0%       {4} r12 = JOIN r11 WITH ASTValueNumbering#242e2500::GVN::getAnExpr#0#dispred#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1 'fc', Lhs.2, Lhs.3
  0    ~0%       {4} r13 = JOIN r12 WITH ASTValueNumbering#242e2500::GVN::getAnExpr#0#dispred#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.1 'fc', Lhs.2, Lhs.3
  0    ~0%       {4} r14 = JOIN r13 WITH Expr#ef463c5d::BinaryOperation::getRightOperand#0#dispred#bf_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1 'fc', Lhs.2, Lhs.3
  0    ~0%       {5} r15 = JOIN r14 WITH Expr#ef463c5d::BinaryOperation::getLeftOperand#0#dispred#bf ON FIRST 1 OUTPUT Lhs.2, Lhs.1 'fc', Lhs.3, Lhs.0, Rhs.1
  0    ~0%       {5} r16 = JOIN r15 WITH ASTValueNumbering#242e2500::GVN::getAnExpr#0#dispred#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.3, Lhs.1 'fc', Lhs.2, Lhs.4
  0    ~0%       {3} r17 = JOIN r16 WITH ASTValueNumbering#242e2500::GVN::getAnExpr#0#dispred#ff ON FIRST 2 OUTPUT Lhs.4, Lhs.2 'fc', Lhs.3
  0    ~0%       {3} r18 = JOIN r17 WITH ASTValueNumbering#242e2500::GVN::getAnExpr#0#dispred#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1 'fc', Lhs.2
  0    ~0%       {3} r19 = JOIN r18 WITH ASTValueNumbering#242e2500::GVN::getAnExpr#0#dispred#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.1 'fc', Lhs.2
  0    ~0%       {4} r20 = JOIN r19 WITH Expr#ef463c5d::Expr::getValue#0#dispred#ff ON FIRST 1 OUTPUT Lhs.1 'fc', Lhs.2, Rhs.1, toInt(Rhs.1)
  0    ~0%       {4} r21 = SELECT r20 ON In.3 = In.1
  0    ~0%       {1} r22 = SCAN r21 OUTPUT In.0 'fc'
  
  0    ~0%       {1} r23 = r4 UNION r22
                  return r23
```

I also didn't see any reason to restrict the `destArg` column to be `VariableAccess` only. So I slightly relaxed that as well.