### PR TITLE
JS: Fix qhelp after file rename

### DIFF
--- a/javascript/ql/src/Security/CWE-916/InsufficientPasswordHash.qhelp
+++ b/javascript/ql/src/Security/CWE-916/InsufficientPasswordHash.qhelp
@@ -37,7 +37,7 @@
 		the hash of a password.
 	</p>
 
-	<sample src="examples/InsufficientPasswordHash.js"/>
+	<sample src="examples/InsufficientPasswordHash_NodeJS.js"/>
 
 	<p>
 		This is not secure, since the password can be efficiently
@@ -46,7 +46,7 @@
 		algorithm:
 	</p>
 
-	<sample src="examples/InsufficientPasswordHash_fixed.js"/>
+	<sample src="examples/InsufficientPasswordHash_NodeJS_fixed.js"/>
 </example>
 
 <references>


### PR DESCRIPTION
This broke in https://github.com/github/codeql/pull/12666 The qhelp probably needs a more substantial update, as an example has been added which is not referred to in the qhelp.