### PR TITLE
C++: Consider ArrayExpr with non-constant size expressions as a BufferAccess

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/security/BufferAccess.qll
+++ b/cpp/ql/lib/semmle/code/cpp/security/BufferAccess.qll
@@ -314,9 +314,8 @@ class FreadBA extends BufferAccess {
  * but not:
  *  &buffer[ix]
  */
-class ArrayExprBA extends BufferAccess {
+class ArrayExprBA extends BufferAccess, ArrayExpr {
   ArrayExprBA() {
-    exists(this.(ArrayExpr).getArrayOffset().getValue().toInt()) and
     not exists(AddressOfExpr aoe | aoe.getAChild() = this) and
     // exclude accesses in macro implementation of `strcmp`,
     // which are carefully controlled but can look dangerous.


### PR DESCRIPTION
I noticed that `buf[x]` where `x` is not a constant was not being treated as a `BufferAccess`. I feel like this restriction is unnecessary, so I've removed it. Most queries with `BufferAccess` will likely call `getSize()`, which will filter these results out and so there will be no change there. But any queries that don't call `getSize()`, or are specifically looking for `not exists(bufferAccess.getSize())`, will have many more results.