### PR TITLE
Swift: Update final two queries to use `DataFlow::ConfigSig`

### DIFF
--- a/swift/ql/lib/codeql/swift/security/CleartextStorageDatabaseQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/CleartextStorageDatabaseQuery.qll
@@ -13,7 +13,7 @@ import codeql.swift.security.CleartextStorageDatabaseExtensions
  * A taint configuration from sensitive information to expressions that are
  * transmitted over a network.
  */
-class CleartextStorageConfig extends TaintTracking::Configuration {
+deprecated class CleartextStorageConfig extends TaintTracking::Configuration {
   CleartextStorageConfig() { this = "CleartextStorageConfig" }
 
   override predicate isSource(DataFlow::Node node) { node.asExpr() instanceof SensitiveExpr }
@@ -48,3 +48,44 @@ class CleartextStorageConfig extends TaintTracking::Configuration {
     super.allowImplicitRead(node, c)
   }
 }
+
+/**
+ * A taint configuration from sensitive information to expressions that are
+ * transmitted over a network.
+ */
+module CleartextStorageConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node node) { node.asExpr() instanceof SensitiveExpr }
+
+  predicate isSink(DataFlow::Node node) { node instanceof CleartextStorageDatabaseSink }
+
+  predicate isBarrier(DataFlow::Node sanitizer) {
+    sanitizer instanceof CleartextStorageDatabaseSanitizer
+  }
+
+  predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
+    any(CleartextStorageDatabaseAdditionalTaintStep s).step(nodeFrom, nodeTo)
+  }
+
+  predicate isBarrierIn(DataFlow::Node node) {
+    // make sources barriers so that we only report the closest instance
+    isSource(node)
+  }
+
+  predicate allowImplicitRead(DataFlow::Node node, DataFlow::ContentSet c) {
+    // flow out from fields of an `NSManagedObject` or `RealmSwiftObject` at the sink,
+    // for example in `realmObj.data = sensitive`.
+    isSink(node) and
+    exists(NominalTypeDecl d, Decl cx |
+      d.getType().getABaseType*().getUnderlyingType().getName() =
+        ["NSManagedObject", "RealmSwiftObject"] and
+      cx.asNominalTypeDecl() = d and
+      c.getAReadContent().(DataFlow::Content::FieldContent).getField() = cx.getAMember()
+    )
+  }
+}
+
+/**
+ * Detect taint flow of sensitive information to expressions that are
+ * transmitted over a network.
+ */
+module CleartextStorageFlow = TaintTracking::Global<CleartextStorageConfig>;

--- a/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
+++ b/swift/ql/src/queries/Security/CWE-135/StringLengthConflation.ql
@@ -13,14 +13,14 @@
 import swift
 import codeql.swift.dataflow.DataFlow
 import codeql.swift.security.StringLengthConflationQuery
-import DataFlow::PathGraph
+import StringLengthConflationFlow::PathGraph
 
 from
-  StringLengthConflationConfiguration config, DataFlow::PathNode source, DataFlow::PathNode sink,
+  StringLengthConflationFlow::PathNode source, StringLengthConflationFlow::PathNode sink,
   StringType sourceType, StringType sinkType, string message
 where
-  config.hasFlowPath(source, sink) and
-  config.isSource(source.getNode(), sourceType) and
+  StringLengthConflationFlow::flowPath(source, sink) and
+  StringLengthConflationConfig::isSource(source.getNode(), sourceType) and
   sinkType = sink.getNode().(StringLengthConflationSink).getCorrectStringType() and
   message =
     "This " + sourceType + " length is used in " + sinkType.getSingular() +

--- a/swift/ql/src/queries/Security/CWE-311/CleartextStorageDatabase.ql
+++ b/swift/ql/src/queries/Security/CWE-311/CleartextStorageDatabase.ql
@@ -14,7 +14,7 @@
 import swift
 import codeql.swift.dataflow.DataFlow
 import codeql.swift.security.CleartextStorageDatabaseQuery
-import DataFlow::PathGraph
+import CleartextStorageFlow::PathGraph
 
 /**
  * Gets a prettier node to use in the results.
@@ -27,10 +27,10 @@ DataFlow::Node cleanupNode(DataFlow::Node n) {
 }
 
 from
-  CleartextStorageConfig config, DataFlow::PathNode sourceNode, DataFlow::PathNode sinkNode,
+  CleartextStorageFlow::PathNode sourceNode, CleartextStorageFlow::PathNode sinkNode,
   DataFlow::Node cleanSink
 where
-  config.hasFlowPath(sourceNode, sinkNode) and
+  CleartextStorageFlow::flowPath(sourceNode, sinkNode) and
   cleanSink = cleanupNode(sinkNode.getNode())
 select cleanSink, sourceNode, sinkNode,
   "This operation stores '" + cleanSink.toString() +


### PR DESCRIPTION
My assumption was that I could freely rewrite the string length conflation query, as the `lib`-part will not have ended up in any (beta) release yet, as the `lib`-part was created only two weeks ago. In the case of all other queries where the configuration lives in `lib` I took the approach of properly deprecating the configuration class.

I'm not sure whether `TStringType` should actually be public. I made it private for now.

Note that the QLDoc CI failure is expected. We're omitting QLDoc for predicates that implement a signature and our tooling currently expects QLDoc although this can be taken from the signature. This is a known issue. See also here: https://github.com/github/codeql/pull/12541#discussion_r1142013715