### PR TITLE
Swift: Modernize the encryption queries

### DIFF
--- a/swift/ql/lib/codeql/swift/security/ConstantPasswordExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/ConstantPasswordExtensions.qll
@@ -5,3 +5,62 @@
 
 import swift
 import codeql.swift.dataflow.DataFlow
+
+/**
+ * A dataflow sink for constant password vulnerabilities. That is,
+ * a `DataFlow::Node` of something that is used as a password.
+ */
+abstract class ConstantPasswordSink extends DataFlow::Node { }
+
+/**
+ * A sanitizer for constant password vulnerabilities.
+ */
+abstract class ConstantPasswordSanitizer extends DataFlow::Node { }
+
+/**
+ * A unit class for adding additional taint steps.
+ */
+class ConstantPasswordAdditionalTaintStep extends Unit {
+  /**
+   * Holds if the step from `node1` to `node2` should be considered a taint
+   * step for paths related to constant password vulnerabilities.
+   */
+  abstract predicate step(DataFlow::Node nodeFrom, DataFlow::Node nodeTo);
+}
+
+/**
+ * A password sink for the CryptoSwift library.
+ */
+private class DefaultConstantPasswordSink extends ConstantPasswordSink {
+  DefaultConstantPasswordSink() {
+    // `password` arg in `init` is a sink
+    exists(ClassOrStructDecl c, ConstructorDecl f, CallExpr call |
+      c.getName() = ["HKDF", "PBKDF1", "PBKDF2", "Scrypt"] and
+      c.getAMember() = f and
+      call.getStaticTarget() = f and
+      call.getArgumentWithLabel("password").getExpr() = this.asExpr()
+    )
+  }
+}
+
+/**
+ * A password sink for the RNCryptor library.
+ */
+private class RnCryptorPasswordSink extends ConstantPasswordSink {
+  RnCryptorPasswordSink() {
+    // RNCryptor (labelled arguments)
+    exists(ClassOrStructDecl c, MethodDecl f, CallExpr call |
+      c.getName() = ["RNCryptor", "RNEncryptor", "RNDecryptor"] and
+      c.getAMember() = f and
+      call.getStaticTarget() = f and
+      call.getArgumentWithLabel(["password", "withPassword", "forPassword"]).getExpr() = this.asExpr()
+    )
+    or
+    // RNCryptor (unlabelled arguments)
+    exists(MethodDecl f, CallExpr call |
+      f.hasQualifiedName("RNCryptor", "keyForPassword(_:salt:settings:)") and
+      call.getStaticTarget() = f and
+      call.getArgument(0).getExpr() = this.asExpr()
+    )
+  }
+}

--- a/swift/ql/lib/codeql/swift/security/ConstantPasswordExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/ConstantPasswordExtensions.qll
@@ -53,7 +53,8 @@ private class RnCryptorPasswordSink extends ConstantPasswordSink {
       c.getName() = ["RNCryptor", "RNEncryptor", "RNDecryptor"] and
       c.getAMember() = f and
       call.getStaticTarget() = f and
-      call.getArgumentWithLabel(["password", "withPassword", "forPassword"]).getExpr() = this.asExpr()
+      call.getArgumentWithLabel(["password", "withPassword", "forPassword"]).getExpr() =
+        this.asExpr()
     )
     or
     // RNCryptor (unlabelled arguments)

--- a/swift/ql/lib/codeql/swift/security/ConstantPasswordExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/ConstantPasswordExtensions.qll
@@ -1,0 +1,7 @@
+/**
+ * Provides classes and predicates for reasoning about constant password
+ * vulnerabilities.
+ */
+
+import swift
+import codeql.swift.dataflow.DataFlow

--- a/swift/ql/lib/codeql/swift/security/ConstantPasswordQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/ConstantPasswordQuery.qll
@@ -28,7 +28,7 @@ module ConstantPasswordConfig implements DataFlow::ConfigSig {
 
   predicate isSink(DataFlow::Node node) { node instanceof ConstantPasswordSink }
 
-  predicate isBarrier(DataFlow::Node node) { node instanceof ConstantPasswordSanitizer}
+  predicate isBarrier(DataFlow::Node node) { node instanceof ConstantPasswordSanitizer }
 
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
     any(ConstantPasswordAdditionalTaintStep s).step(nodeFrom, nodeTo)

--- a/swift/ql/lib/codeql/swift/security/ConstantPasswordQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/ConstantPasswordQuery.qll
@@ -1,0 +1,62 @@
+/**
+ * Provides a taint tracking configuration to find constant password
+ * vulnerabilities.
+ */
+
+import swift
+import codeql.swift.dataflow.DataFlow
+import codeql.swift.dataflow.TaintTracking
+import codeql.swift.dataflow.FlowSteps
+import codeql.swift.security.ConstantPasswordExtensions
+
+/**
+ * A constant password is created through either a byte array or string literals.
+ */
+class ConstantPasswordSource extends Expr {
+  ConstantPasswordSource() {
+    this = any(ArrayExpr arr | arr.getType().getName() = "Array<UInt8>") or
+    this instanceof StringLiteralExpr
+  }
+}
+
+/**
+ * A class for all ways to use a constant password.
+ */
+class ConstantPasswordSink extends Expr {
+  ConstantPasswordSink() {
+    // `password` arg in `init` is a sink
+    exists(ClassOrStructDecl c, ConstructorDecl f, CallExpr call |
+      c.getName() = ["HKDF", "PBKDF1", "PBKDF2", "Scrypt"] and
+      c.getAMember() = f and
+      call.getStaticTarget() = f and
+      call.getArgumentWithLabel("password").getExpr() = this
+    )
+    or
+    // RNCryptor (labelled arguments)
+    exists(ClassOrStructDecl c, MethodDecl f, CallExpr call |
+      c.getName() = ["RNCryptor", "RNEncryptor", "RNDecryptor"] and
+      c.getAMember() = f and
+      call.getStaticTarget() = f and
+      call.getArgumentWithLabel(["password", "withPassword", "forPassword"]).getExpr() = this
+    )
+    or
+    // RNCryptor (unlabelled arguments)
+    exists(MethodDecl f, CallExpr call |
+      f.hasQualifiedName("RNCryptor", "keyForPassword(_:salt:settings:)") and
+      call.getStaticTarget() = f and
+      call.getArgument(0).getExpr() = this
+    )
+  }
+}
+
+/**
+ * A taint configuration from the source of constants passwords to expressions that use
+ * them to initialize password-based encryption keys.
+ */
+module ConstantPasswordConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node node) { node.asExpr() instanceof ConstantPasswordSource }
+
+  predicate isSink(DataFlow::Node node) { node.asExpr() instanceof ConstantPasswordSink }
+}
+
+module ConstantPasswordFlow = TaintTracking::Global<ConstantPasswordConfig>;

--- a/swift/ql/lib/codeql/swift/security/ConstantPasswordQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/ConstantPasswordQuery.qll
@@ -20,43 +20,19 @@ class ConstantPasswordSource extends Expr {
 }
 
 /**
- * A class for all ways to use a constant password.
- */
-class ConstantPasswordSink extends Expr {
-  ConstantPasswordSink() {
-    // `password` arg in `init` is a sink
-    exists(ClassOrStructDecl c, ConstructorDecl f, CallExpr call |
-      c.getName() = ["HKDF", "PBKDF1", "PBKDF2", "Scrypt"] and
-      c.getAMember() = f and
-      call.getStaticTarget() = f and
-      call.getArgumentWithLabel("password").getExpr() = this
-    )
-    or
-    // RNCryptor (labelled arguments)
-    exists(ClassOrStructDecl c, MethodDecl f, CallExpr call |
-      c.getName() = ["RNCryptor", "RNEncryptor", "RNDecryptor"] and
-      c.getAMember() = f and
-      call.getStaticTarget() = f and
-      call.getArgumentWithLabel(["password", "withPassword", "forPassword"]).getExpr() = this
-    )
-    or
-    // RNCryptor (unlabelled arguments)
-    exists(MethodDecl f, CallExpr call |
-      f.hasQualifiedName("RNCryptor", "keyForPassword(_:salt:settings:)") and
-      call.getStaticTarget() = f and
-      call.getArgument(0).getExpr() = this
-    )
-  }
-}
-
-/**
  * A taint configuration from the source of constants passwords to expressions that use
  * them to initialize password-based encryption keys.
  */
 module ConstantPasswordConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node node) { node.asExpr() instanceof ConstantPasswordSource }
 
-  predicate isSink(DataFlow::Node node) { node.asExpr() instanceof ConstantPasswordSink }
+  predicate isSink(DataFlow::Node node) { node instanceof ConstantPasswordSink }
+
+  predicate isBarrier(DataFlow::Node node) { node instanceof ConstantPasswordSanitizer}
+
+  predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
+    any(ConstantPasswordAdditionalTaintStep s).step(nodeFrom, nodeTo)
+  }
 }
 
 module ConstantPasswordFlow = TaintTracking::Global<ConstantPasswordConfig>;

--- a/swift/ql/lib/codeql/swift/security/ConstantSaltExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/ConstantSaltExtensions.qll
@@ -28,7 +28,6 @@ class ConstantSaltAdditionalTaintStep extends Unit {
   abstract predicate step(DataFlow::Node nodeFrom, DataFlow::Node nodeTo);
 }
 
-
 /**
  * A sink for the CryptoSwift library.
  */
@@ -47,13 +46,14 @@ private class CryptoSwiftSaltSink extends ConstantSaltSink {
 /**
  * A sink for the RNCryptor library.
  */
- private class RnCryptorSaltSink extends ConstantSaltSink {
+private class RnCryptorSaltSink extends ConstantSaltSink {
   RnCryptorSaltSink() {
     exists(ClassOrStructDecl c, MethodDecl f, CallExpr call |
       c.getName() = ["RNCryptor", "RNEncryptor", "RNDecryptor"] and
       c.getAMember() = f and
       call.getStaticTarget() = f and
-      call.getArgumentWithLabel(["salt", "encryptionSalt", "hmacSalt", "HMACSalt"]).getExpr() = this.asExpr()
+      call.getArgumentWithLabel(["salt", "encryptionSalt", "hmacSalt", "HMACSalt"]).getExpr() =
+        this.asExpr()
     )
   }
 }

--- a/swift/ql/lib/codeql/swift/security/ConstantSaltExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/ConstantSaltExtensions.qll
@@ -5,3 +5,55 @@
 
 import swift
 import codeql.swift.dataflow.DataFlow
+
+/**
+ * A dataflow sink for constant salt vulnerabilities. That is,
+ * a `DataFlow::Node` of something that is used as a salt.
+ */
+abstract class ConstantSaltSink extends DataFlow::Node { }
+
+/**
+ * A sanitizer for constant salt vulnerabilities.
+ */
+abstract class ConstantSaltSanitizer extends DataFlow::Node { }
+
+/**
+ * A unit class for adding additional taint steps.
+ */
+class ConstantSaltAdditionalTaintStep extends Unit {
+  /**
+   * Holds if the step from `node1` to `node2` should be considered a taint
+   * step for paths related to constant salt vulnerabilities.
+   */
+  abstract predicate step(DataFlow::Node nodeFrom, DataFlow::Node nodeTo);
+}
+
+
+/**
+ * A sink for the CryptoSwift library.
+ */
+private class CryptoSwiftSaltSink extends ConstantSaltSink {
+  CryptoSwiftSaltSink() {
+    // `salt` arg in `init` is a sink
+    exists(ClassOrStructDecl c, ConstructorDecl f, CallExpr call |
+      c.getName() = ["HKDF", "PBKDF1", "PBKDF2", "Scrypt"] and
+      c.getAMember() = f and
+      call.getStaticTarget() = f and
+      call.getArgumentWithLabel("salt").getExpr() = this.asExpr()
+    )
+  }
+}
+
+/**
+ * A sink for the RNCryptor library.
+ */
+ private class RnCryptorSaltSink extends ConstantSaltSink {
+  RnCryptorSaltSink() {
+    exists(ClassOrStructDecl c, MethodDecl f, CallExpr call |
+      c.getName() = ["RNCryptor", "RNEncryptor", "RNDecryptor"] and
+      c.getAMember() = f and
+      call.getStaticTarget() = f and
+      call.getArgumentWithLabel(["salt", "encryptionSalt", "hmacSalt", "HMACSalt"]).getExpr() = this.asExpr()
+    )
+  }
+}

--- a/swift/ql/lib/codeql/swift/security/ConstantSaltExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/ConstantSaltExtensions.qll
@@ -1,0 +1,7 @@
+/**
+ * Provides classes and predicates for reasoning about use of constant salts
+ * for password hashing.
+ */
+
+import swift
+import codeql.swift.dataflow.DataFlow

--- a/swift/ql/lib/codeql/swift/security/ConstantSaltQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/ConstantSaltQuery.qll
@@ -21,36 +21,19 @@ class ConstantSaltSource extends Expr {
 }
 
 /**
- * A class for all ways to use a constant salt.
- */
-class ConstantSaltSink extends Expr {
-  ConstantSaltSink() {
-    // `salt` arg in `init` is a sink
-    exists(ClassOrStructDecl c, ConstructorDecl f, CallExpr call |
-      c.getName() = ["HKDF", "PBKDF1", "PBKDF2", "Scrypt"] and
-      c.getAMember() = f and
-      call.getStaticTarget() = f and
-      call.getArgumentWithLabel("salt").getExpr() = this
-    )
-    or
-    // RNCryptor
-    exists(ClassOrStructDecl c, MethodDecl f, CallExpr call |
-      c.getName() = ["RNCryptor", "RNEncryptor", "RNDecryptor"] and
-      c.getAMember() = f and
-      call.getStaticTarget() = f and
-      call.getArgumentWithLabel(["salt", "encryptionSalt", "hmacSalt", "HMACSalt"]).getExpr() = this
-    )
-  }
-}
-
-/**
  * A taint configuration from the source of constants salts to expressions that use
  * them to initialize password-based encryption keys.
  */
 module ConstantSaltConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node node) { node.asExpr() instanceof ConstantSaltSource }
 
-  predicate isSink(DataFlow::Node node) { node.asExpr() instanceof ConstantSaltSink }
+  predicate isSink(DataFlow::Node node) { node instanceof ConstantSaltSink }
+
+  predicate isBarrier(DataFlow::Node node) { node instanceof ConstantSaltSanitizer}
+
+  predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
+    any(ConstantSaltAdditionalTaintStep s).step(nodeFrom, nodeTo)
+  }
 }
 
 module ConstantSaltFlow = TaintTracking::Global<ConstantSaltConfig>;

--- a/swift/ql/lib/codeql/swift/security/ConstantSaltQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/ConstantSaltQuery.qll
@@ -1,0 +1,56 @@
+/**
+ * Provides a taint tracking configuration to find use of constant salts
+ * for password hashing.
+ */
+
+import swift
+import codeql.swift.dataflow.DataFlow
+import codeql.swift.dataflow.TaintTracking
+import codeql.swift.dataflow.FlowSteps
+import codeql.swift.security.ConstantSaltExtensions
+
+/**
+ * A constant salt is created through either a byte array or string literals.
+ */
+class ConstantSaltSource extends Expr {
+  ConstantSaltSource() {
+    this = any(ArrayExpr arr | arr.getType().getName() = "Array<UInt8>") or
+    this instanceof StringLiteralExpr or
+    this instanceof NumberLiteralExpr
+  }
+}
+
+/**
+ * A class for all ways to use a constant salt.
+ */
+class ConstantSaltSink extends Expr {
+  ConstantSaltSink() {
+    // `salt` arg in `init` is a sink
+    exists(ClassOrStructDecl c, ConstructorDecl f, CallExpr call |
+      c.getName() = ["HKDF", "PBKDF1", "PBKDF2", "Scrypt"] and
+      c.getAMember() = f and
+      call.getStaticTarget() = f and
+      call.getArgumentWithLabel("salt").getExpr() = this
+    )
+    or
+    // RNCryptor
+    exists(ClassOrStructDecl c, MethodDecl f, CallExpr call |
+      c.getName() = ["RNCryptor", "RNEncryptor", "RNDecryptor"] and
+      c.getAMember() = f and
+      call.getStaticTarget() = f and
+      call.getArgumentWithLabel(["salt", "encryptionSalt", "hmacSalt", "HMACSalt"]).getExpr() = this
+    )
+  }
+}
+
+/**
+ * A taint configuration from the source of constants salts to expressions that use
+ * them to initialize password-based encryption keys.
+ */
+module ConstantSaltConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node node) { node.asExpr() instanceof ConstantSaltSource }
+
+  predicate isSink(DataFlow::Node node) { node.asExpr() instanceof ConstantSaltSink }
+}
+
+module ConstantSaltFlow = TaintTracking::Global<ConstantSaltConfig>;

--- a/swift/ql/lib/codeql/swift/security/ConstantSaltQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/ConstantSaltQuery.qll
@@ -29,7 +29,7 @@ module ConstantSaltConfig implements DataFlow::ConfigSig {
 
   predicate isSink(DataFlow::Node node) { node instanceof ConstantSaltSink }
 
-  predicate isBarrier(DataFlow::Node node) { node instanceof ConstantSaltSanitizer}
+  predicate isBarrier(DataFlow::Node node) { node instanceof ConstantSaltSanitizer }
 
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
     any(ConstantSaltAdditionalTaintStep s).step(nodeFrom, nodeTo)

--- a/swift/ql/lib/codeql/swift/security/ECBEncryptionExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/ECBEncryptionExtensions.qll
@@ -1,0 +1,7 @@
+/**
+ * Provides classes and predicates for reasoning about encryption using the
+ * ECB encrpytion mode.
+ */
+
+import swift
+import codeql.swift.dataflow.DataFlow

--- a/swift/ql/lib/codeql/swift/security/ECBEncryptionExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/ECBEncryptionExtensions.qll
@@ -1,7 +1,60 @@
 /**
  * Provides classes and predicates for reasoning about encryption using the
- * ECB encrpytion mode.
+ * ECB encryption mode.
  */
 
 import swift
 import codeql.swift.dataflow.DataFlow
+
+/**
+ * A dataflow sink for ECB encryption vulnerabilities. That is,
+ * a `DataFlow::Node` of something that is used as the block mode
+ * of a cipher.
+ */
+abstract class EcbEncryptionSink extends DataFlow::Node { }
+
+/**
+ * A sanitizer for ECB encryption vulnerabilities.
+ */
+abstract class EcbEncryptionSanitizer extends DataFlow::Node { }
+
+/**
+ * A unit class for adding additional taint steps.
+ */
+class EcbEncryptionAdditionalTaintStep extends Unit {
+  /**
+   * Holds if the step from `node1` to `node2` should be considered a taint
+   * step for paths related to ECB encryption vulnerabilities.
+   */
+  abstract predicate step(DataFlow::Node nodeFrom, DataFlow::Node nodeTo);
+}
+
+/**
+ * A block mode being used to form an `AES` cipher.
+ */
+private class AES extends EcbEncryptionSink {
+  AES() {
+    // `blockMode` arg in `AES.init` is a sink
+    exists(CallExpr call |
+      call.getStaticTarget()
+          .(MethodDecl)
+          .hasQualifiedName("AES", ["init(key:blockMode:)", "init(key:blockMode:padding:)"]) and
+      call.getArgument(1).getExpr() = this.asExpr()
+    )
+  }
+}
+
+/**
+ * A block mode being used to form a `Blowfish` cipher.
+ */
+private class Blowfish extends EcbEncryptionSink {
+  Blowfish() {
+    // `blockMode` arg in `Blowfish.init` is a sink
+    exists(CallExpr call |
+      call.getStaticTarget()
+          .(MethodDecl)
+          .hasQualifiedName("Blowfish", "init(key:blockMode:padding:)") and
+      call.getArgument(1).getExpr() = this.asExpr()
+    )
+  }
+}

--- a/swift/ql/lib/codeql/swift/security/ECBEncryptionExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/ECBEncryptionExtensions.qll
@@ -7,6 +7,13 @@ import swift
 import codeql.swift.dataflow.DataFlow
 
 /**
+ * A dataflow source for ECB encryption vulnerabilities. That is,
+ * a `DataFlow::Node` of something that specifies a block mode
+ * cipher.
+ */
+abstract class EcbEncryptionSource extends DataFlow::Node { }
+
+/**
  * A dataflow sink for ECB encryption vulnerabilities. That is,
  * a `DataFlow::Node` of something that is used as the block mode
  * of a cipher.
@@ -30,7 +37,19 @@ class EcbEncryptionAdditionalTaintStep extends Unit {
 }
 
 /**
- * A block mode being used to form an `AES` cipher.
+ * A block mode for the CryptoSwift library.
+ */
+private class CryptoSwiftEcb extends EcbEncryptionSource {
+  CryptoSwiftEcb() {
+    exists(CallExpr call |
+      call.getStaticTarget().(MethodDecl).hasQualifiedName("ECB", "init()") and
+      this.asExpr() = call
+    )
+  }
+}
+
+/**
+ * A block mode being used to form a CryptoSwift `AES` cipher.
  */
 private class AES extends EcbEncryptionSink {
   AES() {
@@ -45,7 +64,7 @@ private class AES extends EcbEncryptionSink {
 }
 
 /**
- * A block mode being used to form a `Blowfish` cipher.
+ * A block mode being used to form a CryptoSwift `Blowfish` cipher.
  */
 private class Blowfish extends EcbEncryptionSink {
   Blowfish() {

--- a/swift/ql/lib/codeql/swift/security/ECBEncryptionQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/ECBEncryptionQuery.qll
@@ -1,0 +1,61 @@
+/**
+ * Provides a taint tracking configuration to find encryption using the
+ * ECB encrpytion mode.
+ */
+
+import swift
+import codeql.swift.dataflow.DataFlow
+import codeql.swift.dataflow.TaintTracking
+import codeql.swift.security.ECBEncryptionExtensions
+
+/**
+ * An `Expr` that is used to initialize the block mode of a cipher.
+ */
+abstract class BlockMode extends Expr { }
+
+/**
+ * An `Expr` that is used to form an `AES` cipher.
+ */
+class AES extends BlockMode {
+  AES() {
+    // `blockMode` arg in `AES.init` is a sink
+    exists(CallExpr call |
+      call.getStaticTarget()
+          .(MethodDecl)
+          .hasQualifiedName("AES", ["init(key:blockMode:)", "init(key:blockMode:padding:)"]) and
+      call.getArgument(1).getExpr() = this
+    )
+  }
+}
+
+/**
+ * An `Expr` that is used to form a `Blowfish` cipher.
+ */
+class Blowfish extends BlockMode {
+  Blowfish() {
+    // `blockMode` arg in `Blowfish.init` is a sink
+    exists(CallExpr call |
+      call.getStaticTarget()
+          .(MethodDecl)
+          .hasQualifiedName("Blowfish", "init(key:blockMode:padding:)") and
+      call.getArgument(1).getExpr() = this
+    )
+  }
+}
+
+/**
+ * A taint configuration from the constructor of ECB mode to expressions that use
+ * it to initialize a cipher.
+ */
+module EcbEncryptionConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node node) {
+    exists(CallExpr call |
+      call.getStaticTarget().(MethodDecl).hasQualifiedName("ECB", "init()") and
+      node.asExpr() = call
+    )
+  }
+
+  predicate isSink(DataFlow::Node node) { node.asExpr() instanceof BlockMode }
+}
+
+module EcbEncryptionFlow = DataFlow::Global<EcbEncryptionConfig>;

--- a/swift/ql/lib/codeql/swift/security/ECBEncryptionQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/ECBEncryptionQuery.qll
@@ -17,7 +17,7 @@ module EcbEncryptionConfig implements DataFlow::ConfigSig {
 
   predicate isSink(DataFlow::Node node) { node instanceof EcbEncryptionSink }
 
-  predicate isBarrier(DataFlow::Node node) { node instanceof EcbEncryptionSanitizer}
+  predicate isBarrier(DataFlow::Node node) { node instanceof EcbEncryptionSanitizer }
 
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
     any(EcbEncryptionAdditionalTaintStep s).step(nodeFrom, nodeTo)

--- a/swift/ql/lib/codeql/swift/security/ECBEncryptionQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/ECBEncryptionQuery.qll
@@ -13,12 +13,7 @@ import codeql.swift.security.ECBEncryptionExtensions
  * it to initialize a cipher.
  */
 module EcbEncryptionConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node node) {
-    exists(CallExpr call |
-      call.getStaticTarget().(MethodDecl).hasQualifiedName("ECB", "init()") and
-      node.asExpr() = call
-    )
-  }
+  predicate isSource(DataFlow::Node node) { node instanceof EcbEncryptionSource }
 
   predicate isSink(DataFlow::Node node) { node instanceof EcbEncryptionSink }
 

--- a/swift/ql/lib/codeql/swift/security/HardcodedEncryptionKeyExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/HardcodedEncryptionKeyExtensions.qll
@@ -5,3 +5,57 @@
 
 import swift
 import codeql.swift.dataflow.DataFlow
+
+/**
+ * A dataflow sink for hard-coded encryption key vulnerabilities. That is,
+ * a `DataFlow::Node` of something that is used as a key.
+ */
+abstract class HardcodedEncryptionKeySink extends DataFlow::Node { }
+
+/**
+ * A sanitizer for hard-coded encryption key vulnerabilities.
+ */
+abstract class HardcodedEncryptionKeySanitizer extends DataFlow::Node { }
+
+/**
+ * A unit class for adding additional taint steps.
+ */
+class HardcodedEncryptionKeyAdditionalTaintStep extends Unit {
+  /**
+   * Holds if the step from `node1` to `node2` should be considered a taint
+   * step for paths related to hard-coded encryption key vulnerabilities.
+   */
+  abstract predicate step(DataFlow::Node nodeFrom, DataFlow::Node nodeTo);
+}
+
+/**
+ * A sink for the CryptoSwift library.
+ */
+private class CryptoSwiftEncryptionKeySink extends HardcodedEncryptionKeySink {
+  CryptoSwiftEncryptionKeySink() {
+    // `key` arg in `init` is a sink
+    exists(CallExpr call, string fName |
+      call.getStaticTarget()
+          .(MethodDecl)
+          .hasQualifiedName([
+              "AES", "HMAC", "ChaCha20", "CBCMAC", "CMAC", "Poly1305", "Blowfish", "Rabbit"
+            ], fName) and
+      fName.matches("init(key:%") and
+      call.getArgument(0).getExpr() = this.asExpr()
+    )
+  }
+}
+
+/**
+ * A sink for the RNCryptor library.
+ */
+private class RnCryptorEncryptionKeySink extends HardcodedEncryptionKeySink {
+  RnCryptorEncryptionKeySink() {
+    exists(ClassOrStructDecl c, MethodDecl f, CallExpr call |
+      c.getFullName() = ["RNCryptor", "RNEncryptor", "RNDecryptor"] and
+      c.getAMember() = f and
+      call.getStaticTarget() = f and
+      call.getArgumentWithLabel(["encryptionKey", "withEncryptionKey"]).getExpr() = this.asExpr()
+    )
+  }
+}

--- a/swift/ql/lib/codeql/swift/security/HardcodedEncryptionKeyExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/HardcodedEncryptionKeyExtensions.qll
@@ -1,0 +1,7 @@
+/**
+ * Provides classes and predicates for reasoning about hard-coded encryption
+ * key vulnerabilities.
+ */
+
+import swift
+import codeql.swift.dataflow.DataFlow

--- a/swift/ql/lib/codeql/swift/security/HardcodedEncryptionKeyQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/HardcodedEncryptionKeyQuery.qll
@@ -1,0 +1,64 @@
+/**
+ * Provides a taint tracking configuration to find hard-coded encryption
+ * key vulnerabilities.
+ */
+
+import swift
+import codeql.swift.dataflow.DataFlow
+import codeql.swift.dataflow.TaintTracking
+import codeql.swift.security.HardcodedEncryptionKeyExtensions
+
+/**
+ * An `Expr` that is used to initialize a key.
+ */
+abstract class KeySource extends Expr { }
+
+/**
+ * A literal byte array is a key source.
+ */
+class ByteArrayLiteralSource extends KeySource {
+  ByteArrayLiteralSource() { this = any(ArrayExpr arr | arr.getType().getName() = "Array<UInt8>") }
+}
+
+/**
+ * A string literal is a key source.
+ */
+class StringLiteralSource extends KeySource instanceof StringLiteralExpr { }
+
+/**
+ * A class for all ways to set a key.
+ */
+class EncryptionKeySink extends Expr {
+  EncryptionKeySink() {
+    // `key` arg in `init` is a sink
+    exists(CallExpr call, string fName |
+      call.getStaticTarget()
+          .(MethodDecl)
+          .hasQualifiedName([
+              "AES", "HMAC", "ChaCha20", "CBCMAC", "CMAC", "Poly1305", "Blowfish", "Rabbit"
+            ], fName) and
+      fName.matches("init(key:%") and
+      call.getArgument(0).getExpr() = this
+    )
+    or
+    // RNCryptor
+    exists(ClassOrStructDecl c, MethodDecl f, CallExpr call |
+      c.getFullName() = ["RNCryptor", "RNEncryptor", "RNDecryptor"] and
+      c.getAMember() = f and
+      call.getStaticTarget() = f and
+      call.getArgumentWithLabel(["encryptionKey", "withEncryptionKey"]).getExpr() = this
+    )
+  }
+}
+
+/**
+ * A taint configuration from the key source to expressions that use
+ * it to initialize a cipher.
+ */
+module HardcodedKeyConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node node) { node.asExpr() instanceof KeySource }
+
+  predicate isSink(DataFlow::Node node) { node.asExpr() instanceof EncryptionKeySink }
+}
+
+module HardcodedKeyFlow = TaintTracking::Global<HardcodedKeyConfig>;

--- a/swift/ql/lib/codeql/swift/security/HardcodedEncryptionKeyQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/HardcodedEncryptionKeyQuery.qll
@@ -34,7 +34,7 @@ module HardcodedKeyConfig implements DataFlow::ConfigSig {
 
   predicate isSink(DataFlow::Node node) { node instanceof HardcodedEncryptionKeySink }
 
-  predicate isBarrier(DataFlow::Node node) { node instanceof HardcodedEncryptionKeySanitizer}
+  predicate isBarrier(DataFlow::Node node) { node instanceof HardcodedEncryptionKeySanitizer }
 
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
     any(HardcodedEncryptionKeyAdditionalTaintStep s).step(nodeFrom, nodeTo)

--- a/swift/ql/lib/codeql/swift/security/InsecureTLSExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/InsecureTLSExtensions.qll
@@ -1,0 +1,7 @@
+/**
+ * Provides classes and predicates for reasoning about insecure TLS
+ * configurations.
+ */
+
+import swift
+import codeql.swift.dataflow.DataFlow

--- a/swift/ql/lib/codeql/swift/security/InsecureTLSExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/InsecureTLSExtensions.qll
@@ -7,6 +7,12 @@ import swift
 import codeql.swift.dataflow.DataFlow
 
 /**
+ * A dataflow source for insecure TLS configuration vulnerabilities. That is,
+ * a `DataFlow::Node` for something that is an insecure TLS version.
+ */
+abstract class InsecureTlsExtensionsSource extends DataFlow::Node { }
+
+/**
  * A dataflow sink for insecure TLS configuration vulnerabilities. That is,
  * a `DataFlow::Node` of something that is used as a TLS version.
  */
@@ -26,6 +32,16 @@ class InsecureTlsExtensionsAdditionalTaintStep extends Unit {
    * step for paths related to insecure TLS configuration vulnerabilities.
    */
   abstract predicate step(DataFlow::Node nodeFrom, DataFlow::Node nodeTo);
+}
+
+/**
+ * A source for enum values that represent an insecure version of TLS.
+ */
+private class EnumInsecureTlsExtensionsSource extends InsecureTlsExtensionsSource {
+  EnumInsecureTlsExtensionsSource() {
+    this.asExpr().(MethodLookupExpr).getMember().(EnumElementDecl).getName() =
+      ["TLSv10", "TLSv11", "tlsProtocol10", "tlsProtocol11"]
+  }
 }
 
 /**

--- a/swift/ql/lib/codeql/swift/security/InsecureTLSExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/InsecureTLSExtensions.qll
@@ -5,3 +5,41 @@
 
 import swift
 import codeql.swift.dataflow.DataFlow
+
+/**
+ * A dataflow sink for insecure TLS configuration vulnerabilities. That is,
+ * a `DataFlow::Node` of something that is used as a TLS version.
+ */
+abstract class InsecureTlsExtensionsSink extends DataFlow::Node { }
+
+/**
+ * A sanitizer for insecure TLS configuration vulnerabilities.
+ */
+abstract class InsecureTlsExtensionsSanitizer extends DataFlow::Node { }
+
+/**
+ * A unit class for adding additional taint steps.
+ */
+class InsecureTlsExtensionsAdditionalTaintStep extends Unit {
+  /**
+   * Holds if the step from `node1` to `node2` should be considered a taint
+   * step for paths related to insecure TLS configuration vulnerabilities.
+   */
+  abstract predicate step(DataFlow::Node nodeFrom, DataFlow::Node nodeTo);
+}
+
+/**
+ * A sink for assignment of TLS-related properties of `NSURLSessionConfiguration`.
+ */
+private class NsUrlTlsExtensionsSink extends InsecureTlsExtensionsSink {
+  NsUrlTlsExtensionsSink() {
+    exists(AssignExpr assign |
+      assign.getSource() = this.asExpr() and
+      assign.getDest().(MemberRefExpr).getMember().(ConcreteVarDecl).getName() =
+        [
+          "tlsMinimumSupportedProtocolVersion", "tlsMinimumSupportedProtocol",
+          "tlsMaximumSupportedProtocolVersion", "tlsMaximumSupportedProtocol"
+        ]
+    )
+  }
+}

--- a/swift/ql/lib/codeql/swift/security/InsecureTLSQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/InsecureTLSQuery.qll
@@ -10,7 +10,7 @@ import codeql.swift.dataflow.FlowSources
 import codeql.swift.security.InsecureTLSExtensions
 
 /**
- * A taint config to detect insecure configuration of `NSURLSessionConfiguration`
+ * A taint config to detect insecure configuration of `NSURLSessionConfiguration`.
  */
 module InsecureTlsConfig implements DataFlow::ConfigSig {
   /**
@@ -21,18 +21,12 @@ module InsecureTlsConfig implements DataFlow::ConfigSig {
       ["TLSv10", "TLSv11", "tlsProtocol10", "tlsProtocol11"]
   }
 
-  /**
-   * Holds for assignment of TLS-related properties of `NSURLSessionConfiguration`
-   */
-  predicate isSink(DataFlow::Node node) {
-    exists(AssignExpr assign |
-      assign.getSource() = node.asExpr() and
-      assign.getDest().(MemberRefExpr).getMember().(ConcreteVarDecl).getName() =
-        [
-          "tlsMinimumSupportedProtocolVersion", "tlsMinimumSupportedProtocol",
-          "tlsMaximumSupportedProtocolVersion", "tlsMaximumSupportedProtocol"
-        ]
-    )
+  predicate isSink(DataFlow::Node node) { node instanceof InsecureTlsExtensionsSink }
+
+  predicate isBarrier(DataFlow::Node node) { node instanceof InsecureTlsExtensionsSanitizer}
+
+  predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
+    any(InsecureTlsExtensionsAdditionalTaintStep s).step(nodeFrom, nodeTo)
   }
 }
 

--- a/swift/ql/lib/codeql/swift/security/InsecureTLSQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/InsecureTLSQuery.qll
@@ -1,0 +1,39 @@
+/**
+ * Provides a taint tracking configuration to find insecure TLS
+ * configurations.
+ */
+
+import swift
+import codeql.swift.dataflow.DataFlow
+import codeql.swift.dataflow.TaintTracking
+import codeql.swift.dataflow.FlowSources
+import codeql.swift.security.InsecureTLSExtensions
+
+/**
+ * A taint config to detect insecure configuration of `NSURLSessionConfiguration`
+ */
+module InsecureTlsConfig implements DataFlow::ConfigSig {
+  /**
+   * Holds for enum values that represent an insecure version of TLS
+   */
+  predicate isSource(DataFlow::Node node) {
+    node.asExpr().(MethodLookupExpr).getMember().(EnumElementDecl).getName() =
+      ["TLSv10", "TLSv11", "tlsProtocol10", "tlsProtocol11"]
+  }
+
+  /**
+   * Holds for assignment of TLS-related properties of `NSURLSessionConfiguration`
+   */
+  predicate isSink(DataFlow::Node node) {
+    exists(AssignExpr assign |
+      assign.getSource() = node.asExpr() and
+      assign.getDest().(MemberRefExpr).getMember().(ConcreteVarDecl).getName() =
+        [
+          "tlsMinimumSupportedProtocolVersion", "tlsMinimumSupportedProtocol",
+          "tlsMaximumSupportedProtocolVersion", "tlsMaximumSupportedProtocol"
+        ]
+    )
+  }
+}
+
+module InsecureTlsFlow = TaintTracking::Global<InsecureTlsConfig>;

--- a/swift/ql/lib/codeql/swift/security/InsecureTLSQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/InsecureTLSQuery.qll
@@ -13,13 +13,7 @@ import codeql.swift.security.InsecureTLSExtensions
  * A taint config to detect insecure configuration of `NSURLSessionConfiguration`.
  */
 module InsecureTlsConfig implements DataFlow::ConfigSig {
-  /**
-   * Holds for enum values that represent an insecure version of TLS
-   */
-  predicate isSource(DataFlow::Node node) {
-    node.asExpr().(MethodLookupExpr).getMember().(EnumElementDecl).getName() =
-      ["TLSv10", "TLSv11", "tlsProtocol10", "tlsProtocol11"]
-  }
+  predicate isSource(DataFlow::Node node) {  node instanceof InsecureTlsExtensionsSource }
 
   predicate isSink(DataFlow::Node node) { node instanceof InsecureTlsExtensionsSink }
 

--- a/swift/ql/lib/codeql/swift/security/InsufficientHashIterationsExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/InsufficientHashIterationsExtensions.qll
@@ -5,3 +5,41 @@
 
 import swift
 import codeql.swift.dataflow.DataFlow
+
+/**
+ * A dataflow sink for insufficient hash interation vulnerabilities. That is,
+ * a `DataFlow::Node` of something that is used as the iteration count of a
+ * hash function.
+ */
+abstract class InsufficientHashIterationsSink extends DataFlow::Node { }
+
+/**
+ * A sanitizer for insufficient hash interation vulnerabilities.
+ */
+abstract class InsufficientHashIterationsSanitizer extends DataFlow::Node { }
+
+/**
+ * A unit class for adding additional taint steps.
+ */
+class InsufficientHashIterationsAdditionalTaintStep extends Unit {
+  /**
+   * Holds if the step from `node1` to `node2` should be considered a taint
+   * step for paths related to insufficient hash interation vulnerabilities.
+   */
+  abstract predicate step(DataFlow::Node nodeFrom, DataFlow::Node nodeTo);
+}
+
+/**
+ * A sink for the CryptoSwift library.
+ */
+private class CryptoSwiftHashIterationsSink extends InsufficientHashIterationsSink {
+  CryptoSwiftHashIterationsSink() {
+    // `iterations` arg in `init` is a sink
+    exists(ClassOrStructDecl c, ConstructorDecl f, CallExpr call |
+      c.getName() = ["PBKDF1", "PBKDF2"] and
+      c.getAMember() = f and
+      call.getStaticTarget() = f and
+      call.getArgumentWithLabel("iterations").getExpr() = this.asExpr()
+    )
+  }
+}

--- a/swift/ql/lib/codeql/swift/security/InsufficientHashIterationsExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/InsufficientHashIterationsExtensions.qll
@@ -1,0 +1,7 @@
+/**
+ * Provides classes and predicates for reasoning about insufficient hash
+ * iteration vulnerabilities.
+ */
+
+import swift
+import codeql.swift.dataflow.DataFlow

--- a/swift/ql/lib/codeql/swift/security/InsufficientHashIterationsQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/InsufficientHashIterationsQuery.qll
@@ -21,7 +21,7 @@ private class IntLiteralSource extends IterationsSource instanceof IntegerLitera
 }
 
 /**
- * A dataflow configuration from the hash iterations source to expressions that use
+ * A taint tracking configuration from the hash iterations source to expressions that use
  * it to initialize hash functions.
  */
 module InsufficientHashIterationsConfig implements DataFlow::ConfigSig {

--- a/swift/ql/lib/codeql/swift/security/InsufficientHashIterationsQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/InsufficientHashIterationsQuery.qll
@@ -11,7 +11,7 @@ import codeql.swift.security.InsufficientHashIterationsExtensions
 /**
  * An `Expr` that is used to initialize a password-based encryption key.
  */
-private abstract class IterationsSource extends Expr { }
+abstract private class IterationsSource extends Expr { }
 
 /**
  * A literal integer that is 120,000 or less is a source of taint for iterations.
@@ -29,7 +29,7 @@ module InsufficientHashIterationsConfig implements DataFlow::ConfigSig {
 
   predicate isSink(DataFlow::Node node) { node instanceof InsufficientHashIterationsSink }
 
-  predicate isBarrier(DataFlow::Node node) { node instanceof InsufficientHashIterationsSanitizer}
+  predicate isBarrier(DataFlow::Node node) { node instanceof InsufficientHashIterationsSanitizer }
 
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
     any(InsufficientHashIterationsAdditionalTaintStep s).step(nodeFrom, nodeTo)

--- a/swift/ql/lib/codeql/swift/security/InsufficientHashIterationsQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/InsufficientHashIterationsQuery.qll
@@ -1,0 +1,48 @@
+/**
+ * Provides a taint tracking configuration to find insufficient hash
+ * iteration vulnerabilities.
+ */
+
+import swift
+import codeql.swift.dataflow.DataFlow
+import codeql.swift.dataflow.TaintTracking
+import codeql.swift.security.InsufficientHashIterationsQuery
+
+/**
+ * An `Expr` that is used to initialize a password-based encryption key.
+ */
+abstract class IterationsSource extends Expr { }
+
+/**
+ * A literal integer that is 120,000 or less is a source of taint for iterations.
+ */
+class IntLiteralSource extends IterationsSource instanceof IntegerLiteralExpr {
+  IntLiteralSource() { this.getStringValue().toInt() < 120000 }
+}
+
+/**
+ * A class for all ways to set the iterations of hash function.
+ */
+class InsufficientHashIterationsSink extends Expr {
+  InsufficientHashIterationsSink() {
+    // `iterations` arg in `init` is a sink
+    exists(ClassOrStructDecl c, ConstructorDecl f, CallExpr call |
+      c.getName() = ["PBKDF1", "PBKDF2"] and
+      c.getAMember() = f and
+      call.getStaticTarget() = f and
+      call.getArgumentWithLabel("iterations").getExpr() = this
+    )
+  }
+}
+
+/**
+ * A dataflow configuration from the hash iterations source to expressions that use
+ * it to initialize hash functions.
+ */
+module InsufficientHashIterationsConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node node) { node.asExpr() instanceof IterationsSource }
+
+  predicate isSink(DataFlow::Node node) { node.asExpr() instanceof InsufficientHashIterationsSink }
+}
+
+module InsufficientHashIterationsFlow = TaintTracking::Global<InsufficientHashIterationsConfig>;

--- a/swift/ql/lib/codeql/swift/security/InsufficientHashIterationsQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/InsufficientHashIterationsQuery.qll
@@ -11,12 +11,12 @@ import codeql.swift.security.InsufficientHashIterationsExtensions
 /**
  * An `Expr` that is used to initialize a password-based encryption key.
  */
-abstract class IterationsSource extends Expr { }
+private abstract class IterationsSource extends Expr { }
 
 /**
  * A literal integer that is 120,000 or less is a source of taint for iterations.
  */
-class IntLiteralSource extends IterationsSource instanceof IntegerLiteralExpr {
+private class IntLiteralSource extends IterationsSource instanceof IntegerLiteralExpr {
   IntLiteralSource() { this.getStringValue().toInt() < 120000 }
 }
 

--- a/swift/ql/lib/codeql/swift/security/StaticInitializationVectorExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/StaticInitializationVectorExtensions.qll
@@ -1,0 +1,7 @@
+/**
+ * Provides classes and predicates for reasoning about use of static
+ * initialization vectors for encryption.
+ */
+
+import swift
+import codeql.swift.dataflow.DataFlow

--- a/swift/ql/lib/codeql/swift/security/StaticInitializationVectorExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/StaticInitializationVectorExtensions.qll
@@ -5,3 +5,56 @@
 
 import swift
 import codeql.swift.dataflow.DataFlow
+
+/**
+ * A dataflow sink for static initialization vector vulnerabilities. That is,
+ * a `DataFlow::Node` that is something used as an initialization vector.
+ */
+abstract class StaticInitializationVectorSink extends DataFlow::Node { }
+
+/**
+ * A sanitizer for static initialization vector vulnerabilities.
+ */
+abstract class StaticInitializationVectorSanitizer extends DataFlow::Node { }
+
+/**
+ * A unit class for adding additional taint steps.
+ */
+class StaticInitializationVectorAdditionalTaintStep extends Unit {
+  /**
+   * Holds if the step from `node1` to `node2` should be considered a taint
+   * step for paths related to static initialization vector vulnerabilities.
+   */
+  abstract predicate step(DataFlow::Node nodeFrom, DataFlow::Node nodeTo);
+}
+
+/**
+ * An initialization vector sink for various CryptoSwift encryption classes.
+ */
+private class CryptoSwiftInitializationVectorSink extends StaticInitializationVectorSink {
+  CryptoSwiftInitializationVectorSink() {
+    // `iv` arg in `init` is a sink
+    exists(InitializerCallExpr call |
+      call.getStaticTarget()
+          .hasQualifiedName([
+              "AES", "ChaCha20", "Blowfish", "Rabbit", "CBC", "CFB", "GCM", "OCB", "OFB", "PCBC",
+              "CCM", "CTR"
+            ], _) and
+      call.getArgumentWithLabel("iv").getExpr() = this.asExpr()
+    )
+  }
+}
+
+/**
+ * An initialization vector sink for the `RNCryptor` library.
+ */
+private class RnCryptorInitializationVectorSink extends StaticInitializationVectorSink {
+  RnCryptorInitializationVectorSink() {
+    exists(ClassOrStructDecl c, MethodDecl f, CallExpr call |
+      c.getFullName() = ["RNCryptor", "RNEncryptor", "RNDecryptor"] and
+      c.getAMember() = f and
+      call.getStaticTarget() = f and
+      call.getArgumentWithLabel(["iv", "IV"]).getExpr() = this.asExpr()
+    )
+  }
+}

--- a/swift/ql/lib/codeql/swift/security/StaticInitializationVectorQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/StaticInitializationVectorQuery.qll
@@ -1,0 +1,59 @@
+/**
+ * Provides a taint tracking configuration to find use of static
+ * initialization vectors for encryption.
+ */
+
+import swift
+import codeql.swift.dataflow.DataFlow
+import codeql.swift.dataflow.TaintTracking
+import codeql.swift.security.StaticInitializationVectorExtensions
+
+/**
+ * A static IV is created through either a byte array or string literals.
+ */
+class StaticInitializationVectorSource extends Expr {
+  StaticInitializationVectorSource() {
+    this instanceof ArrayExpr or
+    this instanceof StringLiteralExpr or
+    this instanceof NumberLiteralExpr
+  }
+}
+
+/**
+ * A class for all ways to set an IV.
+ */
+class EncryptionInitializationSink extends Expr {
+  EncryptionInitializationSink() {
+    // `iv` arg in `init` is a sink
+    exists(InitializerCallExpr call |
+      call.getStaticTarget()
+          .hasQualifiedName([
+              "AES", "ChaCha20", "Blowfish", "Rabbit", "CBC", "CFB", "GCM", "OCB", "OFB", "PCBC",
+              "CCM", "CTR"
+            ], _) and
+      call.getArgumentWithLabel("iv").getExpr() = this
+    )
+    or
+    // RNCryptor
+    exists(ClassOrStructDecl c, MethodDecl f, CallExpr call |
+      c.getFullName() = ["RNCryptor", "RNEncryptor", "RNDecryptor"] and
+      c.getAMember() = f and
+      call.getStaticTarget() = f and
+      call.getArgumentWithLabel(["iv", "IV"]).getExpr() = this
+    )
+  }
+}
+
+/**
+ * A dataflow configuration from the source of a static IV to expressions that use
+ * it to initialize a cipher.
+ */
+module StaticInitializationVectorConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node node) {
+    node.asExpr() instanceof StaticInitializationVectorSource
+  }
+
+  predicate isSink(DataFlow::Node node) { node.asExpr() instanceof EncryptionInitializationSink }
+}
+
+module StaticInitializationVectorFlow = TaintTracking::Global<StaticInitializationVectorConfig>;

--- a/swift/ql/lib/codeql/swift/security/StaticInitializationVectorQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/StaticInitializationVectorQuery.qll
@@ -30,7 +30,7 @@ module StaticInitializationVectorConfig implements DataFlow::ConfigSig {
 
   predicate isSink(DataFlow::Node node) { node instanceof StaticInitializationVectorSink }
 
-  predicate isBarrier(DataFlow::Node node) { node instanceof StaticInitializationVectorSanitizer}
+  predicate isBarrier(DataFlow::Node node) { node instanceof StaticInitializationVectorSanitizer }
 
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
     any(StaticInitializationVectorAdditionalTaintStep s).step(nodeFrom, nodeTo)

--- a/swift/ql/lib/codeql/swift/security/WeakSensitiveDataHashingExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/WeakSensitiveDataHashingExtensions.qll
@@ -1,0 +1,8 @@
+/**
+ * Provides classes and predicates for reasoning about use of broken or weak
+ * cryptographic hashing algorithms on sensitive data.
+ */
+
+import swift
+import codeql.swift.security.SensitiveExprs
+import codeql.swift.dataflow.DataFlow

--- a/swift/ql/lib/codeql/swift/security/WeakSensitiveDataHashingExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/WeakSensitiveDataHashingExtensions.qll
@@ -6,3 +6,48 @@
 import swift
 import codeql.swift.security.SensitiveExprs
 import codeql.swift.dataflow.DataFlow
+
+/**
+ * A dataflow sink for weak sensitive data hashing vulnerabilities.
+ */
+abstract class WeakSensitiveDataHashingSink extends DataFlow::Node {
+  /**
+   * Gets the name of the hashing algorithm, for display.
+   */
+  abstract string getAlgorithm();
+}
+
+/**
+ * A sanitizer for weak sensitive data hashing vulnerabilities.
+ */
+abstract class WeakSensitiveDataHashingSanitizer extends DataFlow::Node { }
+
+/**
+ * A unit class for adding additional taint steps.
+ */
+class WeakSensitiveDataHashingAdditionalTaintStep extends Unit {
+  /**
+   * Holds if the step from `node1` to `node2` should be considered a taint
+   * step for paths related to weak sensitive data hashing vulnerabilities.
+   */
+  abstract predicate step(DataFlow::Node nodeFrom, DataFlow::Node nodeTo);
+}
+
+/**
+ * A sink for the CryptoSwift library.
+ */
+private class CryptoSwiftWeakHashingSink extends WeakSensitiveDataHashingSink {
+  string algorithm;
+
+  CryptoSwiftWeakHashingSink() {
+    exists(ApplyExpr call, FuncDecl func |
+      call.getAnArgument().getExpr() = this.asExpr() and
+      call.getStaticTarget() = func and
+      func.getName().matches(["hash(%", "update(%"]) and
+      algorithm = func.getEnclosingDecl().(ClassOrStructDecl).getName() and
+      algorithm = ["MD5", "SHA1"]
+    )
+  }
+
+  override string getAlgorithm() { result = algorithm }
+}

--- a/swift/ql/lib/codeql/swift/security/WeakSensitiveDataHashingQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/WeakSensitiveDataHashingQuery.qll
@@ -14,7 +14,7 @@ module WeakHashingConfig implements DataFlow::ConfigSig {
 
   predicate isSink(DataFlow::Node node) { node instanceof WeakSensitiveDataHashingSink }
 
-  predicate isBarrier(DataFlow::Node node) { node instanceof WeakSensitiveDataHashingSanitizer}
+  predicate isBarrier(DataFlow::Node node) { node instanceof WeakSensitiveDataHashingSanitizer }
 
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
     any(WeakSensitiveDataHashingAdditionalTaintStep s).step(nodeFrom, nodeTo)

--- a/swift/ql/lib/codeql/swift/security/WeakSensitiveDataHashingQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/WeakSensitiveDataHashingQuery.qll
@@ -9,6 +9,10 @@ import codeql.swift.dataflow.DataFlow
 import codeql.swift.dataflow.TaintTracking
 import codeql.swift.security.WeakSensitiveDataHashingExtensions
 
+/**
+ * A taint tracking configuration from sensitive expressions to broken or weak
+ * hashing sinks.
+ */
 module WeakHashingConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node node) { node.asExpr() instanceof SensitiveExpr }
 

--- a/swift/ql/lib/codeql/swift/security/WeakSensitiveDataHashingQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/WeakSensitiveDataHashingQuery.qll
@@ -10,7 +10,7 @@ import codeql.swift.dataflow.TaintTracking
 import codeql.swift.security.WeakSensitiveDataHashingExtensions
 
 module WeakHashingConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node node) { node instanceof WeakHashingConfigImpl::Source }
+  predicate isSource(DataFlow::Node node) { node.asExpr() instanceof SensitiveExpr }
 
   predicate isSink(DataFlow::Node node) { node instanceof WeakSensitiveDataHashingSink }
 
@@ -22,9 +22,3 @@ module WeakHashingConfig implements DataFlow::ConfigSig {
 }
 
 module WeakHashingFlow = TaintTracking::Global<WeakHashingConfig>;
-
-module WeakHashingConfigImpl {
-  class Source extends DataFlow::Node {
-    Source() { this.asExpr() instanceof SensitiveExpr }
-  }
-}

--- a/swift/ql/lib/codeql/swift/security/WeakSensitiveDataHashingQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/WeakSensitiveDataHashingQuery.qll
@@ -1,0 +1,44 @@
+/**
+ * Provides a taint tracking configuration to find use of broken or weak
+ * cryptographic hashing algorithms on sensitive data.
+ */
+
+import swift
+import codeql.swift.security.SensitiveExprs
+import codeql.swift.dataflow.DataFlow
+import codeql.swift.dataflow.TaintTracking
+import codeql.swift.security.WeakSensitiveDataHashingExtensions
+
+module WeakHashingConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node node) { node instanceof WeakHashingConfigImpl::Source }
+
+  predicate isSink(DataFlow::Node node) { node instanceof WeakHashingConfigImpl::Sink }
+}
+
+module WeakHashingFlow = TaintTracking::Global<WeakHashingConfig>;
+
+module WeakHashingConfigImpl {
+  class Source extends DataFlow::Node {
+    Source() { this.asExpr() instanceof SensitiveExpr }
+  }
+
+  abstract class Sink extends DataFlow::Node {
+    abstract string getAlgorithm();
+  }
+
+  class CryptoHash extends Sink {
+    string algorithm;
+
+    CryptoHash() {
+      exists(ApplyExpr call, FuncDecl func |
+        call.getAnArgument().getExpr() = this.asExpr() and
+        call.getStaticTarget() = func and
+        func.getName().matches(["hash(%", "update(%"]) and
+        algorithm = func.getEnclosingDecl().(ClassOrStructDecl).getName() and
+        algorithm = ["MD5", "SHA1"]
+      )
+    }
+
+    override string getAlgorithm() { result = algorithm }
+  }
+}

--- a/swift/ql/src/queries/Security/CWE-1204/StaticInitializationVector.ql
+++ b/swift/ql/src/queries/Security/CWE-1204/StaticInitializationVector.ql
@@ -12,61 +12,9 @@
  */
 
 import swift
-import codeql.swift.dataflow.DataFlow
-import codeql.swift.dataflow.TaintTracking
+import codeql.swift.security.StaticInitializationVectorQuery
 import StaticInitializationVectorFlow::PathGraph
 
-/**
- * A static IV is created through either a byte array or string literals.
- */
-class StaticInitializationVectorSource extends Expr {
-  StaticInitializationVectorSource() {
-    this instanceof ArrayExpr or
-    this instanceof StringLiteralExpr or
-    this instanceof NumberLiteralExpr
-  }
-}
-
-/**
- * A class for all ways to set an IV.
- */
-class EncryptionInitializationSink extends Expr {
-  EncryptionInitializationSink() {
-    // `iv` arg in `init` is a sink
-    exists(InitializerCallExpr call |
-      call.getStaticTarget()
-          .hasQualifiedName([
-              "AES", "ChaCha20", "Blowfish", "Rabbit", "CBC", "CFB", "GCM", "OCB", "OFB", "PCBC",
-              "CCM", "CTR"
-            ], _) and
-      call.getArgumentWithLabel("iv").getExpr() = this
-    )
-    or
-    // RNCryptor
-    exists(ClassOrStructDecl c, MethodDecl f, CallExpr call |
-      c.getFullName() = ["RNCryptor", "RNEncryptor", "RNDecryptor"] and
-      c.getAMember() = f and
-      call.getStaticTarget() = f and
-      call.getArgumentWithLabel(["iv", "IV"]).getExpr() = this
-    )
-  }
-}
-
-/**
- * A dataflow configuration from the source of a static IV to expressions that use
- * it to initialize a cipher.
- */
-module StaticInitializationVectorConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node node) {
-    node.asExpr() instanceof StaticInitializationVectorSource
-  }
-
-  predicate isSink(DataFlow::Node node) { node.asExpr() instanceof EncryptionInitializationSink }
-}
-
-module StaticInitializationVectorFlow = TaintTracking::Global<StaticInitializationVectorConfig>;
-
-// The query itself
 from
   StaticInitializationVectorFlow::PathNode sourceNode,
   StaticInitializationVectorFlow::PathNode sinkNode

--- a/swift/ql/src/queries/Security/CWE-259/ConstantPassword.ql
+++ b/swift/ql/src/queries/Security/CWE-259/ConstantPassword.ql
@@ -11,64 +11,9 @@
  */
 
 import swift
-import codeql.swift.dataflow.DataFlow
-import codeql.swift.dataflow.TaintTracking
-import codeql.swift.dataflow.FlowSteps
+import codeql.swift.security.ConstantPasswordQuery
 import ConstantPasswordFlow::PathGraph
 
-/**
- * A constant password is created through either a byte array or string literals.
- */
-class ConstantPasswordSource extends Expr {
-  ConstantPasswordSource() {
-    this = any(ArrayExpr arr | arr.getType().getName() = "Array<UInt8>") or
-    this instanceof StringLiteralExpr
-  }
-}
-
-/**
- * A class for all ways to use a constant password.
- */
-class ConstantPasswordSink extends Expr {
-  ConstantPasswordSink() {
-    // `password` arg in `init` is a sink
-    exists(ClassOrStructDecl c, ConstructorDecl f, CallExpr call |
-      c.getName() = ["HKDF", "PBKDF1", "PBKDF2", "Scrypt"] and
-      c.getAMember() = f and
-      call.getStaticTarget() = f and
-      call.getArgumentWithLabel("password").getExpr() = this
-    )
-    or
-    // RNCryptor (labelled arguments)
-    exists(ClassOrStructDecl c, MethodDecl f, CallExpr call |
-      c.getName() = ["RNCryptor", "RNEncryptor", "RNDecryptor"] and
-      c.getAMember() = f and
-      call.getStaticTarget() = f and
-      call.getArgumentWithLabel(["password", "withPassword", "forPassword"]).getExpr() = this
-    )
-    or
-    // RNCryptor (unlabelled arguments)
-    exists(MethodDecl f, CallExpr call |
-      f.hasQualifiedName("RNCryptor", "keyForPassword(_:salt:settings:)") and
-      call.getStaticTarget() = f and
-      call.getArgument(0).getExpr() = this
-    )
-  }
-}
-
-/**
- * A taint configuration from the source of constants passwords to expressions that use
- * them to initialize password-based encryption keys.
- */
-module ConstantPasswordConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node node) { node.asExpr() instanceof ConstantPasswordSource }
-
-  predicate isSink(DataFlow::Node node) { node.asExpr() instanceof ConstantPasswordSink }
-}
-
-module ConstantPasswordFlow = TaintTracking::Global<ConstantPasswordConfig>;
-
-// The query itself
 from ConstantPasswordFlow::PathNode sourceNode, ConstantPasswordFlow::PathNode sinkNode
 where ConstantPasswordFlow::flowPath(sourceNode, sinkNode)
 select sinkNode.getNode(), sourceNode, sinkNode,

--- a/swift/ql/src/queries/Security/CWE-321/HardcodedEncryptionKey.ql
+++ b/swift/ql/src/queries/Security/CWE-321/HardcodedEncryptionKey.ql
@@ -11,66 +11,9 @@
  */
 
 import swift
-import codeql.swift.dataflow.DataFlow
-import codeql.swift.dataflow.TaintTracking
+import codeql.swift.security.HardcodedEncryptionKeyQuery
 import HardcodedKeyFlow::PathGraph
 
-/**
- * An `Expr` that is used to initialize a key.
- */
-abstract class KeySource extends Expr { }
-
-/**
- * A literal byte array is a key source.
- */
-class ByteArrayLiteralSource extends KeySource {
-  ByteArrayLiteralSource() { this = any(ArrayExpr arr | arr.getType().getName() = "Array<UInt8>") }
-}
-
-/**
- * A string literal is a key source.
- */
-class StringLiteralSource extends KeySource instanceof StringLiteralExpr { }
-
-/**
- * A class for all ways to set a key.
- */
-class EncryptionKeySink extends Expr {
-  EncryptionKeySink() {
-    // `key` arg in `init` is a sink
-    exists(CallExpr call, string fName |
-      call.getStaticTarget()
-          .(MethodDecl)
-          .hasQualifiedName([
-              "AES", "HMAC", "ChaCha20", "CBCMAC", "CMAC", "Poly1305", "Blowfish", "Rabbit"
-            ], fName) and
-      fName.matches("init(key:%") and
-      call.getArgument(0).getExpr() = this
-    )
-    or
-    // RNCryptor
-    exists(ClassOrStructDecl c, MethodDecl f, CallExpr call |
-      c.getFullName() = ["RNCryptor", "RNEncryptor", "RNDecryptor"] and
-      c.getAMember() = f and
-      call.getStaticTarget() = f and
-      call.getArgumentWithLabel(["encryptionKey", "withEncryptionKey"]).getExpr() = this
-    )
-  }
-}
-
-/**
- * A taint configuration from the key source to expressions that use
- * it to initialize a cipher.
- */
-module HardcodedKeyConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node node) { node.asExpr() instanceof KeySource }
-
-  predicate isSink(DataFlow::Node node) { node.asExpr() instanceof EncryptionKeySink }
-}
-
-module HardcodedKeyFlow = TaintTracking::Global<HardcodedKeyConfig>;
-
-// The query itself
 from HardcodedKeyFlow::PathNode sourceNode, HardcodedKeyFlow::PathNode sinkNode
 where HardcodedKeyFlow::flowPath(sourceNode, sinkNode)
 select sinkNode.getNode(), sourceNode, sinkNode,

--- a/swift/ql/src/queries/Security/CWE-327/ECBEncryption.ql
+++ b/swift/ql/src/queries/Security/CWE-327/ECBEncryption.ql
@@ -11,63 +11,9 @@
  */
 
 import swift
-import codeql.swift.dataflow.DataFlow
-import codeql.swift.dataflow.TaintTracking
+import codeql.swift.security.ECBEncryptionQuery
 import EcbEncryptionFlow::PathGraph
 
-/**
- * An `Expr` that is used to initialize the block mode of a cipher.
- */
-abstract class BlockMode extends Expr { }
-
-/**
- * An `Expr` that is used to form an `AES` cipher.
- */
-class AES extends BlockMode {
-  AES() {
-    // `blockMode` arg in `AES.init` is a sink
-    exists(CallExpr call |
-      call.getStaticTarget()
-          .(MethodDecl)
-          .hasQualifiedName("AES", ["init(key:blockMode:)", "init(key:blockMode:padding:)"]) and
-      call.getArgument(1).getExpr() = this
-    )
-  }
-}
-
-/**
- * An `Expr` that is used to form a `Blowfish` cipher.
- */
-class Blowfish extends BlockMode {
-  Blowfish() {
-    // `blockMode` arg in `Blowfish.init` is a sink
-    exists(CallExpr call |
-      call.getStaticTarget()
-          .(MethodDecl)
-          .hasQualifiedName("Blowfish", "init(key:blockMode:padding:)") and
-      call.getArgument(1).getExpr() = this
-    )
-  }
-}
-
-/**
- * A taint configuration from the constructor of ECB mode to expressions that use
- * it to initialize a cipher.
- */
-module EcbEncryptionConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node node) {
-    exists(CallExpr call |
-      call.getStaticTarget().(MethodDecl).hasQualifiedName("ECB", "init()") and
-      node.asExpr() = call
-    )
-  }
-
-  predicate isSink(DataFlow::Node node) { node.asExpr() instanceof BlockMode }
-}
-
-module EcbEncryptionFlow = DataFlow::Global<EcbEncryptionConfig>;
-
-// The query itself
 from EcbEncryptionFlow::PathNode sourceNode, EcbEncryptionFlow::PathNode sinkNode
 where EcbEncryptionFlow::flowPath(sourceNode, sinkNode)
 select sinkNode.getNode(), sourceNode, sinkNode,

--- a/swift/ql/src/queries/Security/CWE-328/WeakSensitiveDataHashing.ql
+++ b/swift/ql/src/queries/Security/CWE-328/WeakSensitiveDataHashing.ql
@@ -20,7 +20,7 @@ from
   SensitiveExpr expr
 where
   WeakHashingFlow::flowPath(source, sink) and
-  algorithm = sink.getNode().(WeakHashingConfigImpl::Sink).getAlgorithm() and
+  algorithm = sink.getNode().(WeakSensitiveDataHashingSink).getAlgorithm() and
   expr = source.getNode().asExpr()
 select sink.getNode(), source, sink,
   "Insecure hashing algorithm (" + algorithm + ") depends on $@.", source.getNode(),

--- a/swift/ql/src/queries/Security/CWE-328/WeakSensitiveDataHashing.ql
+++ b/swift/ql/src/queries/Security/CWE-328/WeakSensitiveDataHashing.ql
@@ -12,44 +12,8 @@
  */
 
 import swift
-import codeql.swift.security.SensitiveExprs
-import codeql.swift.dataflow.DataFlow
-import codeql.swift.dataflow.TaintTracking
+import codeql.swift.security.WeakSensitiveDataHashingQuery
 import WeakHashingFlow::PathGraph
-
-module WeakHashingConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node node) { node instanceof WeakHashingConfigImpl::Source }
-
-  predicate isSink(DataFlow::Node node) { node instanceof WeakHashingConfigImpl::Sink }
-}
-
-module WeakHashingFlow = TaintTracking::Global<WeakHashingConfig>;
-
-module WeakHashingConfigImpl {
-  class Source extends DataFlow::Node {
-    Source() { this.asExpr() instanceof SensitiveExpr }
-  }
-
-  abstract class Sink extends DataFlow::Node {
-    abstract string getAlgorithm();
-  }
-
-  class CryptoHash extends Sink {
-    string algorithm;
-
-    CryptoHash() {
-      exists(ApplyExpr call, FuncDecl func |
-        call.getAnArgument().getExpr() = this.asExpr() and
-        call.getStaticTarget() = func and
-        func.getName().matches(["hash(%", "update(%"]) and
-        algorithm = func.getEnclosingDecl().(ClassOrStructDecl).getName() and
-        algorithm = ["MD5", "SHA1"]
-      )
-    }
-
-    override string getAlgorithm() { result = algorithm }
-  }
-}
 
 from
   WeakHashingFlow::PathNode source, WeakHashingFlow::PathNode sink, string algorithm,

--- a/swift/ql/src/queries/Security/CWE-757/InsecureTLS.ql
+++ b/swift/ql/src/queries/Security/CWE-757/InsecureTLS.ql
@@ -11,39 +11,8 @@
  */
 
 import swift
-import codeql.swift.dataflow.DataFlow
-import codeql.swift.dataflow.TaintTracking
-import codeql.swift.dataflow.FlowSources
+import codeql.swift.security.InsecureTLSQuery
 import InsecureTlsFlow::PathGraph
-
-/**
- * A taint config to detect insecure configuration of `NSURLSessionConfiguration`
- */
-module InsecureTlsConfig implements DataFlow::ConfigSig {
-  /**
-   * Holds for enum values that represent an insecure version of TLS
-   */
-  predicate isSource(DataFlow::Node node) {
-    node.asExpr().(MethodLookupExpr).getMember().(EnumElementDecl).getName() =
-      ["TLSv10", "TLSv11", "tlsProtocol10", "tlsProtocol11"]
-  }
-
-  /**
-   * Holds for assignment of TLS-related properties of `NSURLSessionConfiguration`
-   */
-  predicate isSink(DataFlow::Node node) {
-    exists(AssignExpr assign |
-      assign.getSource() = node.asExpr() and
-      assign.getDest().(MemberRefExpr).getMember().(ConcreteVarDecl).getName() =
-        [
-          "tlsMinimumSupportedProtocolVersion", "tlsMinimumSupportedProtocol",
-          "tlsMaximumSupportedProtocolVersion", "tlsMaximumSupportedProtocol"
-        ]
-    )
-  }
-}
-
-module InsecureTlsFlow = TaintTracking::Global<InsecureTlsConfig>;
 
 from InsecureTlsFlow::PathNode sourceNode, InsecureTlsFlow::PathNode sinkNode
 where InsecureTlsFlow::flowPath(sourceNode, sinkNode)

--- a/swift/ql/src/queries/Security/CWE-760/ConstantSalt.ql
+++ b/swift/ql/src/queries/Security/CWE-760/ConstantSalt.ql
@@ -11,58 +11,9 @@
  */
 
 import swift
-import codeql.swift.dataflow.DataFlow
-import codeql.swift.dataflow.TaintTracking
-import codeql.swift.dataflow.FlowSteps
+import codeql.swift.security.ConstantSaltQuery
 import ConstantSaltFlow::PathGraph
 
-/**
- * A constant salt is created through either a byte array or string literals.
- */
-class ConstantSaltSource extends Expr {
-  ConstantSaltSource() {
-    this = any(ArrayExpr arr | arr.getType().getName() = "Array<UInt8>") or
-    this instanceof StringLiteralExpr or
-    this instanceof NumberLiteralExpr
-  }
-}
-
-/**
- * A class for all ways to use a constant salt.
- */
-class ConstantSaltSink extends Expr {
-  ConstantSaltSink() {
-    // `salt` arg in `init` is a sink
-    exists(ClassOrStructDecl c, ConstructorDecl f, CallExpr call |
-      c.getName() = ["HKDF", "PBKDF1", "PBKDF2", "Scrypt"] and
-      c.getAMember() = f and
-      call.getStaticTarget() = f and
-      call.getArgumentWithLabel("salt").getExpr() = this
-    )
-    or
-    // RNCryptor
-    exists(ClassOrStructDecl c, MethodDecl f, CallExpr call |
-      c.getName() = ["RNCryptor", "RNEncryptor", "RNDecryptor"] and
-      c.getAMember() = f and
-      call.getStaticTarget() = f and
-      call.getArgumentWithLabel(["salt", "encryptionSalt", "hmacSalt", "HMACSalt"]).getExpr() = this
-    )
-  }
-}
-
-/**
- * A taint configuration from the source of constants salts to expressions that use
- * them to initialize password-based encryption keys.
- */
-module ConstantSaltConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node node) { node.asExpr() instanceof ConstantSaltSource }
-
-  predicate isSink(DataFlow::Node node) { node.asExpr() instanceof ConstantSaltSink }
-}
-
-module ConstantSaltFlow = TaintTracking::Global<ConstantSaltConfig>;
-
-// The query itself
 from ConstantSaltFlow::PathNode sourceNode, ConstantSaltFlow::PathNode sinkNode
 where ConstantSaltFlow::flowPath(sourceNode, sinkNode)
 select sinkNode.getNode(), sourceNode, sinkNode,

--- a/swift/ql/src/queries/Security/CWE-916/InsufficientHashIterations.ql
+++ b/swift/ql/src/queries/Security/CWE-916/InsufficientHashIterations.ql
@@ -11,50 +11,9 @@
  */
 
 import swift
-import codeql.swift.dataflow.DataFlow
-import codeql.swift.dataflow.TaintTracking
+import codeql.swift.security.InsufficientHashIterationsQuery
 import InsufficientHashIterationsFlow::PathGraph
 
-/**
- * An `Expr` that is used to initialize a password-based encryption key.
- */
-abstract class IterationsSource extends Expr { }
-
-/**
- * A literal integer that is 120,000 or less is a source of taint for iterations.
- */
-class IntLiteralSource extends IterationsSource instanceof IntegerLiteralExpr {
-  IntLiteralSource() { this.getStringValue().toInt() < 120000 }
-}
-
-/**
- * A class for all ways to set the iterations of hash function.
- */
-class InsufficientHashIterationsSink extends Expr {
-  InsufficientHashIterationsSink() {
-    // `iterations` arg in `init` is a sink
-    exists(ClassOrStructDecl c, ConstructorDecl f, CallExpr call |
-      c.getName() = ["PBKDF1", "PBKDF2"] and
-      c.getAMember() = f and
-      call.getStaticTarget() = f and
-      call.getArgumentWithLabel("iterations").getExpr() = this
-    )
-  }
-}
-
-/**
- * A dataflow configuration from the hash iterations source to expressions that use
- * it to initialize hash functions.
- */
-module InsufficientHashIterationsConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node node) { node.asExpr() instanceof IterationsSource }
-
-  predicate isSink(DataFlow::Node node) { node.asExpr() instanceof InsufficientHashIterationsSink }
-}
-
-module InsufficientHashIterationsFlow = TaintTracking::Global<InsufficientHashIterationsConfig>;
-
-// The query itself
 from
   InsufficientHashIterationsFlow::PathNode sourceNode,
   InsufficientHashIterationsFlow::PathNode sinkNode


### PR DESCRIPTION
Modernize the 8 Swift encryption queries.  By 'modernize', I mean split into three files with standard layouts, extendable sinks etc in the usual way.  Conversion to `DataFlow::ConfigSig` is a separate process and has in fact already been done for these queries.

I haven't yet added CSV extension points.  That will be follow-up as, from past experience, it sometimes involves a bit more work and testing on individual queries.

I also haven't unified the various 'constant' sources some of these queries define - there's a separate issue for that at some point.  And I haven't dealt with `IntLiteralSource` from `swift/insufficient-hash-iterations`, as I want to redesign it a bit before making it extendable / public.  I'm creating an issue for that as well.