### PR TITLE
Merge `rc/3.9` back to `main`

### DIFF
--- a/docs/codeql/reusables/supported-versions-compilers.rst
+++ b/docs/codeql/reusables/supported-versions-compilers.rst
@@ -23,7 +23,7 @@
    Kotlin [6]_,"Kotlin 1.5.0 to 1.8.20","kotlinc",``.kt``
    JavaScript,ECMAScript 2022 or lower,Not applicable,"``.js``, ``.jsx``, ``.mjs``, ``.es``, ``.es6``, ``.htm``, ``.html``, ``.xhtm``, ``.xhtml``, ``.vue``, ``.hbs``, ``.ejs``, ``.njk``, ``.json``, ``.yaml``, ``.yml``, ``.raml``, ``.xml`` [7]_"
    Python [8]_,"2.7, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10, 3.11",Not applicable,``.py``
-   Ruby [9]_,"up to 3.1",Not applicable,"``.rb``, ``.erb``, ``.gemspec``, ``Gemfile``"
+   Ruby [9]_,"up to 3.2",Not applicable,"``.rb``, ``.erb``, ``.gemspec``, ``Gemfile``"
    TypeScript [10]_,"2.6-5.0",Standard TypeScript compiler,"``.ts``, ``.tsx``, ``.mts``, ``.cts``"
 
 .. container:: footnote-group

--- a/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
@@ -1239,12 +1239,11 @@ protected DependencyInstallationResult preparePackagesAndDependencies(Set<Path> 
         String msg = "A parse error occurred: " + StringUtil.quoteWithBackticks(err.getMessage().trim())
             + ". Check the syntax of the file. If the file is invalid, correct the error or [exclude](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/customizing-code-scanning) the file from analysis.";
         // file, relative to the source root
-        String relativeFilePath = null;
+        DiagnosticLocation.Builder builder = DiagnosticLocation.builder();
         if (file.startsWith(LGTM_SRC)) {
-          relativeFilePath = file.subpath(LGTM_SRC.getNameCount(), file.getNameCount()).toString();
+          builder = builder.setFile(file.subpath(LGTM_SRC.getNameCount(), file.getNameCount()).toString());
         }
-        DiagnosticLocation diagLoc = DiagnosticLocation.builder()
-            .setFile(relativeFilePath)
+        DiagnosticLocation diagLoc = builder
             .setStartLine(err.getPosition().getLine())
             .setStartColumn(err.getPosition().getColumn())
             .setEndLine(err.getPosition().getLine())


### PR DESCRIPTION
Resolve the conflict in `docs/codeql/reusables/supported-versions-compilers.rst` in favour of supporting both Ruby 3.2 and TypeScript 5.0.