### PR TITLE
Swift: Convert dataflow / taint tests to DataFlow::ConfigSig.

### DIFF
--- a/swift/ql/test/library-tests/dataflow/dataflow/DataFlow.ql
+++ b/swift/ql/test/library-tests/dataflow/dataflow/DataFlow.ql
@@ -3,10 +3,9 @@
  */
 
 import swift
-import codeql.swift.dataflow.DataFlow::DataFlow
 import FlowConfig
-import DataFlow::PathGraph
+import TestFlow::PathGraph
 
-from DataFlow::PathNode src, DataFlow::PathNode sink, TestConfiguration test
-where test.hasFlowPath(src, sink)
+from TestFlow::PathNode src, TestFlow::PathNode sink
+where TestFlow::flowPath(src, sink)
 select sink, src, sink, "result"

--- a/swift/ql/test/library-tests/dataflow/dataflow/DataFlowInline.ql
+++ b/swift/ql/test/library-tests/dataflow/dataflow/DataFlowInline.ql
@@ -1,5 +1,4 @@
 import swift
-import DataFlow
 import FlowConfig
 import TestUtilities.InlineExpectationsTest
 
@@ -9,8 +8,8 @@ class TaintTest extends InlineExpectationsTest {
   override string getARelevantTag() { result = "flow" }
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
-    exists(TestConfiguration config, Node source, Node sink, Expr sinkExpr |
-      config.hasFlow(source, sink) and
+    exists(DataFlow::Node source, DataFlow::Node sink, Expr sinkExpr |
+      TestFlow::flow(source, sink) and
       sinkExpr = sink.asExpr() and
       location = sinkExpr.getLocation() and
       element = sinkExpr.toString() and

--- a/swift/ql/test/library-tests/dataflow/dataflow/FlowConfig.qll
+++ b/swift/ql/test/library-tests/dataflow/dataflow/FlowConfig.qll
@@ -6,21 +6,17 @@ import swift
 import codeql.swift.dataflow.DataFlow
 import codeql.swift.dataflow.ExternalFlow
 
-class TestConfiguration extends DataFlow::Configuration {
-  TestConfiguration() { this = "TestConfiguration" }
-
-  override predicate isSource(DataFlow::Node src) {
+module TestConfiguration implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node src) {
     src.asExpr().(CallExpr).getStaticTarget().getName().matches("source%()")
   }
 
-  override predicate isSink(DataFlow::Node sink) {
+  predicate isSink(DataFlow::Node sink) {
     exists(CallExpr sinkCall |
       sinkCall.getStaticTarget().getName() = ["sink(arg:)", "sink(opt:)", "sink(str:)"] and
       sinkCall.getAnArgument().getExpr() = sink.asExpr()
     )
   }
-
-  override int explorationLimit() { result = 100 }
 }
 
 private class TestSummaries extends SummaryModelCsv {
@@ -29,3 +25,5 @@ private class TestSummaries extends SummaryModelCsv {
     row = ";Int;true;signum();;;Argument[-1];ReturnValue;value"
   }
 }
+
+module TestFlow = DataFlow::Global<TestConfiguration>;

--- a/swift/ql/test/library-tests/dataflow/taint/core/Taint.ql
+++ b/swift/ql/test/library-tests/dataflow/taint/core/Taint.ql
@@ -4,8 +4,8 @@
 
 import swift
 import Taint
-import PathGraph
+import TestFlow::PathGraph
 
-from PathNode src, PathNode sink, TestConfiguration test
-where test.hasFlowPath(src, sink)
+from TestFlow::PathNode src, TestFlow::PathNode sink
+where TestFlow::flowPath(src, sink)
 select sink, src, sink, "result"

--- a/swift/ql/test/library-tests/dataflow/taint/core/Taint.qll
+++ b/swift/ql/test/library-tests/dataflow/taint/core/Taint.qll
@@ -1,20 +1,20 @@
 import swift
 import codeql.swift.dataflow.TaintTracking
-import codeql.swift.dataflow.DataFlow::DataFlow
+import codeql.swift.dataflow.DataFlow
 
-class TestConfiguration extends TaintTracking::Configuration {
-  TestConfiguration() { this = "TestConfiguration" }
-
-  override predicate isSource(Node src) {
+module TestConfiguration implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node src) {
     src.asExpr().(CallExpr).getStaticTarget().getName().matches("source%")
   }
 
-  override predicate isSink(Node sink) {
+  predicate isSink(DataFlow::Node sink) {
     exists(CallExpr sinkCall |
       sinkCall.getStaticTarget().getName().matches("sink%") and
       sinkCall.getAnArgument().getExpr() = sink.asExpr()
     )
   }
 
-  override int explorationLimit() { result = 100 }
+  //override int explorationLimit() { result = 100 }
 }
+
+module TestFlow = TaintTracking::Global<TestConfiguration>;

--- a/swift/ql/test/library-tests/dataflow/taint/core/Taint.qll
+++ b/swift/ql/test/library-tests/dataflow/taint/core/Taint.qll
@@ -13,8 +13,6 @@ module TestConfiguration implements DataFlow::ConfigSig {
       sinkCall.getAnArgument().getExpr() = sink.asExpr()
     )
   }
-
-  //override int explorationLimit() { result = 100 }
 }
 
 module TestFlow = TaintTracking::Global<TestConfiguration>;

--- a/swift/ql/test/library-tests/dataflow/taint/core/TaintInline.ql
+++ b/swift/ql/test/library-tests/dataflow/taint/core/TaintInline.ql
@@ -8,8 +8,8 @@ class TaintTest extends InlineExpectationsTest {
   override string getARelevantTag() { result = "tainted" }
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
-    exists(TestConfiguration config, Node source, Node sink, Expr sinkExpr |
-      config.hasFlow(source, sink) and
+    exists(DataFlow::Node source, DataFlow::Node sink, Expr sinkExpr |
+      TestFlow::flow(source, sink) and
       sinkExpr = sink.asExpr() and
       location = sinkExpr.getLocation() and
       element = sinkExpr.toString() and

--- a/swift/ql/test/library-tests/dataflow/taint/libraries/Taint.qll
+++ b/swift/ql/test/library-tests/dataflow/taint/libraries/Taint.qll
@@ -1,20 +1,18 @@
 import swift
 import codeql.swift.dataflow.TaintTracking
-import codeql.swift.dataflow.DataFlow::DataFlow
+import codeql.swift.dataflow.DataFlow
 
-class TestConfiguration extends TaintTracking::Configuration {
-  TestConfiguration() { this = "TestConfiguration" }
-
-  override predicate isSource(Node src) {
+module TestConfiguration implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node src) {
     src.asExpr().(CallExpr).getStaticTarget().getName().matches("source%")
   }
 
-  override predicate isSink(Node sink) {
+  predicate isSink(DataFlow::Node sink) {
     exists(CallExpr sinkCall |
       sinkCall.getStaticTarget().getName().matches("sink%") and
       sinkCall.getAnArgument().getExpr() = sink.asExpr()
     )
   }
-
-  override int explorationLimit() { result = 100 }
 }
+
+module TestFlow = TaintTracking::Global<TestConfiguration>;

--- a/swift/ql/test/library-tests/dataflow/taint/libraries/TaintInline.ql
+++ b/swift/ql/test/library-tests/dataflow/taint/libraries/TaintInline.ql
@@ -8,8 +8,8 @@ class TaintTest extends InlineExpectationsTest {
   override string getARelevantTag() { result = "tainted" }
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
-    exists(TestConfiguration config, Node source, Node sink, Expr sinkExpr |
-      config.hasFlow(source, sink) and
+    exists(DataFlow::Node source, DataFlow::Node sink, Expr sinkExpr |
+      TestFlow::flow(source, sink) and
       sinkExpr = sink.asExpr() and
       location = sinkExpr.getLocation() and
       element = sinkExpr.toString() and


### PR DESCRIPTION
Convert dataflow / taint tests to `DataFlow::ConfigSig`.

@jketema 