### PR TITLE
Ruby: update tree-sitter to 0.20.10

### DIFF
--- a/ruby/extractor/Cargo.lock
+++ b/ruby/extractor/Cargo.lock
@@ -634,9 +634,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.20.7"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "549a9faf45679ad50b7f603253635598cf5e007d8ceb806a23f95355938f76a0"
+checksum = "e747b1f9b7b931ed39a548c1fae149101497de3c1fc8d9e18c62c1a66c683d3d"
 dependencies = [
  "cc",
  "regex",


### PR DESCRIPTION
The 0.20.10 release includes the [fix](https://github.com/tree-sitter/tree-sitter/pull/1952) for a [stackoverflow](https://github.com/tree-sitter/tree-sitter/issues/2071) we observed.