### PR TITLE
C++: Fix number of join order problems in memory corruption queries

### DIFF
--- a/cpp/ql/src/experimental/Likely Bugs/OverrunWriteProductFlow.ql
+++ b/cpp/ql/src/experimental/Likely Bugs/OverrunWriteProductFlow.ql
@@ -30,7 +30,8 @@ Instruction getABoundIn(SemBound b, IRFunction func) {
 /**
  * Holds if `i <= b + delta`.
  */
-pragma[nomagic]
+bindingset[i]
+pragma[inline_late]
 predicate bounded(Instruction i, Instruction b, int delta) {
   exists(SemBound bound, IRFunction func |
     semBounded(getSemanticExpr(i), bound, delta, true, _) and

--- a/cpp/ql/src/experimental/Security/CWE/CWE-193/ConstantSizeArrayOffByOne.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-193/ConstantSizeArrayOffByOne.ql
@@ -55,11 +55,12 @@ predicate isFieldAddressSource(Field f, DataFlow::Node source) {
  * writes to an address that non-strictly upper-bounds `sink`, or `i` is a `LoadInstruction` that
  * reads from an address that non-strictly upper-bounds `sink`.
  */
+pragma[inline]
 predicate isInvalidPointerDerefSink(DataFlow::Node sink, Instruction i, string operation) {
   exists(AddressOperand addr, int delta |
-    bounded(pragma[only_bind_into](addr).getDef(), sink.asInstruction(), delta) and
+    bounded(addr.getDef(), sink.asInstruction(), delta) and
     delta >= 0 and
-    i.getAnOperand() = pragma[only_bind_into](addr)
+    i.getAnOperand() = addr
   |
     i instanceof StoreInstruction and
     operation = "write"
@@ -88,6 +89,7 @@ module PointerArithmeticToDerefConfig implements DataFlow::ConfigSig {
     isConstantSizeOverflowSource(_, source.asInstruction(), _)
   }
 
+  pragma[inline]
   predicate isSink(DataFlow::Node sink) { isInvalidPointerDerefSink(sink, _, _) }
 }
 

--- a/cpp/ql/src/experimental/Security/CWE/CWE-193/ConstantSizeArrayOffByOne.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-193/ConstantSizeArrayOffByOne.ql
@@ -25,7 +25,8 @@ Instruction getABoundIn(SemBound b, IRFunction func) {
 /**
  * Holds if `i <= b + delta`.
  */
-pragma[nomagic]
+bindingset[i]
+pragma[inline_late]
 predicate bounded(Instruction i, Instruction b, int delta) {
   exists(SemBound bound, IRFunction func |
     semBounded(getSemanticExpr(i), bound, delta, true, _) and
@@ -56,9 +57,9 @@ predicate isFieldAddressSource(Field f, DataFlow::Node source) {
  */
 predicate isInvalidPointerDerefSink(DataFlow::Node sink, Instruction i, string operation) {
   exists(AddressOperand addr, int delta |
-    bounded(addr.getDef(), sink.asInstruction(), delta) and
+    bounded(pragma[only_bind_into](addr).getDef(), sink.asInstruction(), delta) and
     delta >= 0 and
-    i.getAnOperand() = addr
+    i.getAnOperand() = pragma[only_bind_into](addr)
   |
     i instanceof StoreInstruction and
     operation = "write"


### PR DESCRIPTION
Based on https://github.com/MathiasVP/ql/commit/c5bb7fa59d83fe7dbcc7c2ad492756160f0b7eee. 