### PR TITLE
Go: hide summary nodes from path explanations

### DIFF
--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowPrivate.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowPrivate.qll
@@ -352,7 +352,7 @@ Node getArgument(CallNode c, int i) {
 }
 
 /** Holds if `n` should be hidden from path explanations. */
-predicate nodeIsHidden(Node n) { none() }
+predicate nodeIsHidden(Node n) { n instanceof SummaryNode or n instanceof SummarizedParameterNode }
 
 class LambdaCallKind = Unit;
 

--- a/go/ql/test/library-tests/semmle/go/dataflow/HiddenNodes/test.expected
+++ b/go/ql/test/library-tests/semmle/go/dataflow/HiddenNodes/test.expected
@@ -1,0 +1,12 @@
+edges
+| test.go:14:8:14:15 | call to source | test.go:15:34:15:35 | fi |
+| test.go:15:2:15:44 | ... := ...[0] | test.go:16:7:16:12 | header |
+| test.go:15:34:15:35 | fi | test.go:15:2:15:44 | ... := ...[0] |
+nodes
+| test.go:14:8:14:15 | call to source | semmle.label | call to source |
+| test.go:15:2:15:44 | ... := ...[0] | semmle.label | ... := ...[0] |
+| test.go:15:34:15:35 | fi | semmle.label | fi |
+| test.go:16:7:16:12 | header | semmle.label | header |
+subpaths
+#select
+| test.go:14:8:14:15 | call to source | test.go:14:8:14:15 | call to source | test.go:16:7:16:12 | header | Path |

--- a/go/ql/test/library-tests/semmle/go/dataflow/HiddenNodes/test.go
+++ b/go/ql/test/library-tests/semmle/go/dataflow/HiddenNodes/test.go
@@ -1,0 +1,18 @@
+package test
+
+import (
+	"archive/tar"
+	"os"
+)
+
+func source() interface{} { return nil }
+
+func sink(x interface{}) {}
+
+func test() {
+
+	fi := source().(os.FileInfo)
+	header, _ := tar.FileInfoHeader(fi, "link")
+	sink(header)
+
+}

--- a/go/ql/test/library-tests/semmle/go/dataflow/HiddenNodes/test.ql
+++ b/go/ql/test/library-tests/semmle/go/dataflow/HiddenNodes/test.ql
@@ -1,0 +1,22 @@
+/**
+ * @kind path-problem
+ */
+
+import go
+import DataFlow::PathGraph
+
+class Config extends TaintTracking::Configuration {
+  Config() { this = "config" }
+
+  override predicate isSource(DataFlow::Node n) {
+    n = any(DataFlow::CallNode call | call.getTarget().getName() = "source").getResult()
+  }
+
+  override predicate isSink(DataFlow::Node n) {
+    n = any(DataFlow::CallNode call | call.getTarget().getName() = "sink").getAnArgument()
+  }
+}
+
+from DataFlow::PathNode source, DataFlow::PathNode sink, Config c
+where c.hasFlowPath(source, sink)
+select source, source, sink, "Path"


### PR DESCRIPTION
This mirrors behaviours in other languages with MaD summaries