### PR TITLE
Add New XSS sink: Next.js router.push/replace

### DIFF
--- a/javascript/ql/lib/semmle/javascript/security/dataflow/ClientSideUrlRedirectCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/ClientSideUrlRedirectCustomizations.qll
@@ -231,6 +231,8 @@ module ClientSideUrlRedirect {
     NextRoutePushUrlSink() {
       this = NextJS::nextRouter().getAMemberCall(["push", "replace"]).getArgument(0)
     }
+
+    override predicate isXssSink() { any() }
   }
 
   private class SinkFromModel extends Sink {

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/Xss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/Xss.expected
@@ -560,6 +560,20 @@ nodes
 | react-use-context.js:16:26:16:36 | window.name |
 | react-use-context.js:16:26:16:36 | window.name |
 | react-use-context.js:16:26:16:36 | window.name |
+| react-use-router.js:5:9:5:28 | router |
+| react-use-router.js:5:18:5:28 | useRouter() |
+| react-use-router.js:9:21:9:26 | router |
+| react-use-router.js:9:21:9:32 | router.query |
+| react-use-router.js:9:21:9:32 | router.query |
+| react-use-router.js:9:21:9:39 | router.query.foobar |
+| react-use-router.js:9:21:9:39 | router.query.foobar |
+| react-use-router.js:20:15:20:24 | router |
+| react-use-router.js:20:17:20:22 | router |
+| react-use-router.js:21:43:21:48 | router |
+| react-use-router.js:21:43:21:54 | router.query |
+| react-use-router.js:21:43:21:54 | router.query |
+| react-use-router.js:21:43:21:61 | router.query.foobar |
+| react-use-router.js:21:43:21:61 | router.query.foobar |
 | react-use-state.js:4:9:4:49 | state |
 | react-use-state.js:4:9:4:49 | state |
 | react-use-state.js:4:10:4:14 | state |
@@ -1700,6 +1714,22 @@ edges
 | react-native.js:7:17:7:33 | req.param("code") | react-native.js:7:7:7:33 | tainted |
 | react-use-context.js:10:22:10:32 | window.name | react-use-context.js:10:22:10:32 | window.name |
 | react-use-context.js:16:26:16:36 | window.name | react-use-context.js:16:26:16:36 | window.name |
+| react-use-router.js:5:9:5:28 | router | react-use-router.js:9:21:9:26 | router |
+| react-use-router.js:5:18:5:28 | useRouter() | react-use-router.js:5:9:5:28 | router |
+| react-use-router.js:9:21:9:26 | router | react-use-router.js:9:21:9:32 | router.query |
+| react-use-router.js:9:21:9:32 | router.query | react-use-router.js:9:21:9:39 | router.query.foobar |
+| react-use-router.js:9:21:9:32 | router.query | react-use-router.js:9:21:9:39 | router.query.foobar |
+| react-use-router.js:9:21:9:32 | router.query | react-use-router.js:9:21:9:39 | router.query.foobar |
+| react-use-router.js:9:21:9:32 | router.query | react-use-router.js:9:21:9:39 | router.query.foobar |
+| react-use-router.js:9:21:9:39 | router.query.foobar | react-use-router.js:5:18:5:28 | useRouter() |
+| react-use-router.js:20:15:20:24 | router | react-use-router.js:21:43:21:48 | router |
+| react-use-router.js:20:17:20:22 | router | react-use-router.js:20:15:20:24 | router |
+| react-use-router.js:21:43:21:48 | router | react-use-router.js:21:43:21:54 | router.query |
+| react-use-router.js:21:43:21:54 | router.query | react-use-router.js:21:43:21:61 | router.query.foobar |
+| react-use-router.js:21:43:21:54 | router.query | react-use-router.js:21:43:21:61 | router.query.foobar |
+| react-use-router.js:21:43:21:54 | router.query | react-use-router.js:21:43:21:61 | router.query.foobar |
+| react-use-router.js:21:43:21:54 | router.query | react-use-router.js:21:43:21:61 | router.query.foobar |
+| react-use-router.js:21:43:21:61 | router.query.foobar | react-use-router.js:20:17:20:22 | router |
 | react-use-state.js:4:9:4:49 | state | react-use-state.js:5:51:5:55 | state |
 | react-use-state.js:4:9:4:49 | state | react-use-state.js:5:51:5:55 | state |
 | react-use-state.js:4:9:4:49 | state | react-use-state.js:5:51:5:55 | state |
@@ -2386,6 +2416,8 @@ edges
 | react-native.js:9:27:9:33 | tainted | react-native.js:7:17:7:33 | req.param("code") | react-native.js:9:27:9:33 | tainted | Cross-site scripting vulnerability due to $@. | react-native.js:7:17:7:33 | req.param("code") | user-provided value |
 | react-use-context.js:10:22:10:32 | window.name | react-use-context.js:10:22:10:32 | window.name | react-use-context.js:10:22:10:32 | window.name | Cross-site scripting vulnerability due to $@. | react-use-context.js:10:22:10:32 | window.name | user-provided value |
 | react-use-context.js:16:26:16:36 | window.name | react-use-context.js:16:26:16:36 | window.name | react-use-context.js:16:26:16:36 | window.name | Cross-site scripting vulnerability due to $@. | react-use-context.js:16:26:16:36 | window.name | user-provided value |
+| react-use-router.js:9:21:9:39 | router.query.foobar | react-use-router.js:9:21:9:32 | router.query | react-use-router.js:9:21:9:39 | router.query.foobar | Cross-site scripting vulnerability due to $@. | react-use-router.js:9:21:9:32 | router.query | user-provided value |
+| react-use-router.js:21:43:21:61 | router.query.foobar | react-use-router.js:21:43:21:54 | router.query | react-use-router.js:21:43:21:61 | router.query.foobar | Cross-site scripting vulnerability due to $@. | react-use-router.js:21:43:21:54 | router.query | user-provided value |
 | react-use-state.js:5:51:5:55 | state | react-use-state.js:4:38:4:48 | window.name | react-use-state.js:5:51:5:55 | state | Cross-site scripting vulnerability due to $@. | react-use-state.js:4:38:4:48 | window.name | user-provided value |
 | react-use-state.js:11:51:11:55 | state | react-use-state.js:10:14:10:24 | window.name | react-use-state.js:11:51:11:55 | state | Cross-site scripting vulnerability due to $@. | react-use-state.js:10:14:10:24 | window.name | user-provided value |
 | react-use-state.js:17:51:17:55 | state | react-use-state.js:16:20:16:30 | window.name | react-use-state.js:17:51:17:55 | state | Cross-site scripting vulnerability due to $@. | react-use-state.js:16:20:16:30 | window.name | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/Xss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/Xss.expected
@@ -560,20 +560,20 @@ nodes
 | react-use-context.js:16:26:16:36 | window.name |
 | react-use-context.js:16:26:16:36 | window.name |
 | react-use-context.js:16:26:16:36 | window.name |
-| react-use-router.js:5:9:5:28 | router |
-| react-use-router.js:5:18:5:28 | useRouter() |
-| react-use-router.js:9:21:9:26 | router |
-| react-use-router.js:9:21:9:32 | router.query |
-| react-use-router.js:9:21:9:32 | router.query |
-| react-use-router.js:9:21:9:39 | router.query.foobar |
-| react-use-router.js:9:21:9:39 | router.query.foobar |
-| react-use-router.js:20:15:20:24 | router |
-| react-use-router.js:20:17:20:22 | router |
-| react-use-router.js:21:43:21:48 | router |
-| react-use-router.js:21:43:21:54 | router.query |
-| react-use-router.js:21:43:21:54 | router.query |
-| react-use-router.js:21:43:21:61 | router.query.foobar |
-| react-use-router.js:21:43:21:61 | router.query.foobar |
+| react-use-router.js:4:9:4:28 | router |
+| react-use-router.js:4:18:4:28 | useRouter() |
+| react-use-router.js:8:21:8:26 | router |
+| react-use-router.js:8:21:8:32 | router.query |
+| react-use-router.js:8:21:8:32 | router.query |
+| react-use-router.js:8:21:8:39 | router.query.foobar |
+| react-use-router.js:8:21:8:39 | router.query.foobar |
+| react-use-router.js:19:15:19:24 | router |
+| react-use-router.js:19:17:19:22 | router |
+| react-use-router.js:20:43:20:48 | router |
+| react-use-router.js:20:43:20:54 | router.query |
+| react-use-router.js:20:43:20:54 | router.query |
+| react-use-router.js:20:43:20:61 | router.query.foobar |
+| react-use-router.js:20:43:20:61 | router.query.foobar |
 | react-use-state.js:4:9:4:49 | state |
 | react-use-state.js:4:9:4:49 | state |
 | react-use-state.js:4:10:4:14 | state |
@@ -1714,22 +1714,22 @@ edges
 | react-native.js:7:17:7:33 | req.param("code") | react-native.js:7:7:7:33 | tainted |
 | react-use-context.js:10:22:10:32 | window.name | react-use-context.js:10:22:10:32 | window.name |
 | react-use-context.js:16:26:16:36 | window.name | react-use-context.js:16:26:16:36 | window.name |
-| react-use-router.js:5:9:5:28 | router | react-use-router.js:9:21:9:26 | router |
-| react-use-router.js:5:18:5:28 | useRouter() | react-use-router.js:5:9:5:28 | router |
-| react-use-router.js:9:21:9:26 | router | react-use-router.js:9:21:9:32 | router.query |
-| react-use-router.js:9:21:9:32 | router.query | react-use-router.js:9:21:9:39 | router.query.foobar |
-| react-use-router.js:9:21:9:32 | router.query | react-use-router.js:9:21:9:39 | router.query.foobar |
-| react-use-router.js:9:21:9:32 | router.query | react-use-router.js:9:21:9:39 | router.query.foobar |
-| react-use-router.js:9:21:9:32 | router.query | react-use-router.js:9:21:9:39 | router.query.foobar |
-| react-use-router.js:9:21:9:39 | router.query.foobar | react-use-router.js:5:18:5:28 | useRouter() |
-| react-use-router.js:20:15:20:24 | router | react-use-router.js:21:43:21:48 | router |
-| react-use-router.js:20:17:20:22 | router | react-use-router.js:20:15:20:24 | router |
-| react-use-router.js:21:43:21:48 | router | react-use-router.js:21:43:21:54 | router.query |
-| react-use-router.js:21:43:21:54 | router.query | react-use-router.js:21:43:21:61 | router.query.foobar |
-| react-use-router.js:21:43:21:54 | router.query | react-use-router.js:21:43:21:61 | router.query.foobar |
-| react-use-router.js:21:43:21:54 | router.query | react-use-router.js:21:43:21:61 | router.query.foobar |
-| react-use-router.js:21:43:21:54 | router.query | react-use-router.js:21:43:21:61 | router.query.foobar |
-| react-use-router.js:21:43:21:61 | router.query.foobar | react-use-router.js:20:17:20:22 | router |
+| react-use-router.js:4:9:4:28 | router | react-use-router.js:8:21:8:26 | router |
+| react-use-router.js:4:18:4:28 | useRouter() | react-use-router.js:4:9:4:28 | router |
+| react-use-router.js:8:21:8:26 | router | react-use-router.js:8:21:8:32 | router.query |
+| react-use-router.js:8:21:8:32 | router.query | react-use-router.js:8:21:8:39 | router.query.foobar |
+| react-use-router.js:8:21:8:32 | router.query | react-use-router.js:8:21:8:39 | router.query.foobar |
+| react-use-router.js:8:21:8:32 | router.query | react-use-router.js:8:21:8:39 | router.query.foobar |
+| react-use-router.js:8:21:8:32 | router.query | react-use-router.js:8:21:8:39 | router.query.foobar |
+| react-use-router.js:8:21:8:39 | router.query.foobar | react-use-router.js:4:18:4:28 | useRouter() |
+| react-use-router.js:19:15:19:24 | router | react-use-router.js:20:43:20:48 | router |
+| react-use-router.js:19:17:19:22 | router | react-use-router.js:19:15:19:24 | router |
+| react-use-router.js:20:43:20:48 | router | react-use-router.js:20:43:20:54 | router.query |
+| react-use-router.js:20:43:20:54 | router.query | react-use-router.js:20:43:20:61 | router.query.foobar |
+| react-use-router.js:20:43:20:54 | router.query | react-use-router.js:20:43:20:61 | router.query.foobar |
+| react-use-router.js:20:43:20:54 | router.query | react-use-router.js:20:43:20:61 | router.query.foobar |
+| react-use-router.js:20:43:20:54 | router.query | react-use-router.js:20:43:20:61 | router.query.foobar |
+| react-use-router.js:20:43:20:61 | router.query.foobar | react-use-router.js:19:17:19:22 | router |
 | react-use-state.js:4:9:4:49 | state | react-use-state.js:5:51:5:55 | state |
 | react-use-state.js:4:9:4:49 | state | react-use-state.js:5:51:5:55 | state |
 | react-use-state.js:4:9:4:49 | state | react-use-state.js:5:51:5:55 | state |
@@ -2416,8 +2416,8 @@ edges
 | react-native.js:9:27:9:33 | tainted | react-native.js:7:17:7:33 | req.param("code") | react-native.js:9:27:9:33 | tainted | Cross-site scripting vulnerability due to $@. | react-native.js:7:17:7:33 | req.param("code") | user-provided value |
 | react-use-context.js:10:22:10:32 | window.name | react-use-context.js:10:22:10:32 | window.name | react-use-context.js:10:22:10:32 | window.name | Cross-site scripting vulnerability due to $@. | react-use-context.js:10:22:10:32 | window.name | user-provided value |
 | react-use-context.js:16:26:16:36 | window.name | react-use-context.js:16:26:16:36 | window.name | react-use-context.js:16:26:16:36 | window.name | Cross-site scripting vulnerability due to $@. | react-use-context.js:16:26:16:36 | window.name | user-provided value |
-| react-use-router.js:9:21:9:39 | router.query.foobar | react-use-router.js:9:21:9:32 | router.query | react-use-router.js:9:21:9:39 | router.query.foobar | Cross-site scripting vulnerability due to $@. | react-use-router.js:9:21:9:32 | router.query | user-provided value |
-| react-use-router.js:21:43:21:61 | router.query.foobar | react-use-router.js:21:43:21:54 | router.query | react-use-router.js:21:43:21:61 | router.query.foobar | Cross-site scripting vulnerability due to $@. | react-use-router.js:21:43:21:54 | router.query | user-provided value |
+| react-use-router.js:8:21:8:39 | router.query.foobar | react-use-router.js:8:21:8:32 | router.query | react-use-router.js:8:21:8:39 | router.query.foobar | Cross-site scripting vulnerability due to $@. | react-use-router.js:8:21:8:32 | router.query | user-provided value |
+| react-use-router.js:20:43:20:61 | router.query.foobar | react-use-router.js:20:43:20:54 | router.query | react-use-router.js:20:43:20:61 | router.query.foobar | Cross-site scripting vulnerability due to $@. | react-use-router.js:20:43:20:54 | router.query | user-provided value |
 | react-use-state.js:5:51:5:55 | state | react-use-state.js:4:38:4:48 | window.name | react-use-state.js:5:51:5:55 | state | Cross-site scripting vulnerability due to $@. | react-use-state.js:4:38:4:48 | window.name | user-provided value |
 | react-use-state.js:11:51:11:55 | state | react-use-state.js:10:14:10:24 | window.name | react-use-state.js:11:51:11:55 | state | Cross-site scripting vulnerability due to $@. | react-use-state.js:10:14:10:24 | window.name | user-provided value |
 | react-use-state.js:17:51:17:55 | state | react-use-state.js:16:20:16:30 | window.name | react-use-state.js:17:51:17:55 | state | Cross-site scripting vulnerability due to $@. | react-use-state.js:16:20:16:30 | window.name | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/Xss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/Xss.expected
@@ -567,13 +567,18 @@ nodes
 | react-use-router.js:8:21:8:32 | router.query |
 | react-use-router.js:8:21:8:39 | router.query.foobar |
 | react-use-router.js:8:21:8:39 | router.query.foobar |
-| react-use-router.js:19:15:19:24 | router |
-| react-use-router.js:19:17:19:22 | router |
-| react-use-router.js:20:43:20:48 | router |
-| react-use-router.js:20:43:20:54 | router.query |
-| react-use-router.js:20:43:20:54 | router.query |
-| react-use-router.js:20:43:20:61 | router.query.foobar |
-| react-use-router.js:20:43:20:61 | router.query.foobar |
+| react-use-router.js:11:24:11:29 | router |
+| react-use-router.js:11:24:11:35 | router.query |
+| react-use-router.js:11:24:11:35 | router.query |
+| react-use-router.js:11:24:11:42 | router.query.foobar |
+| react-use-router.js:11:24:11:42 | router.query.foobar |
+| react-use-router.js:22:15:22:24 | router |
+| react-use-router.js:22:17:22:22 | router |
+| react-use-router.js:23:43:23:48 | router |
+| react-use-router.js:23:43:23:54 | router.query |
+| react-use-router.js:23:43:23:54 | router.query |
+| react-use-router.js:23:43:23:61 | router.query.foobar |
+| react-use-router.js:23:43:23:61 | router.query.foobar |
 | react-use-state.js:4:9:4:49 | state |
 | react-use-state.js:4:9:4:49 | state |
 | react-use-state.js:4:10:4:14 | state |
@@ -1715,6 +1720,7 @@ edges
 | react-use-context.js:10:22:10:32 | window.name | react-use-context.js:10:22:10:32 | window.name |
 | react-use-context.js:16:26:16:36 | window.name | react-use-context.js:16:26:16:36 | window.name |
 | react-use-router.js:4:9:4:28 | router | react-use-router.js:8:21:8:26 | router |
+| react-use-router.js:4:9:4:28 | router | react-use-router.js:11:24:11:29 | router |
 | react-use-router.js:4:18:4:28 | useRouter() | react-use-router.js:4:9:4:28 | router |
 | react-use-router.js:8:21:8:26 | router | react-use-router.js:8:21:8:32 | router.query |
 | react-use-router.js:8:21:8:32 | router.query | react-use-router.js:8:21:8:39 | router.query.foobar |
@@ -1722,14 +1728,19 @@ edges
 | react-use-router.js:8:21:8:32 | router.query | react-use-router.js:8:21:8:39 | router.query.foobar |
 | react-use-router.js:8:21:8:32 | router.query | react-use-router.js:8:21:8:39 | router.query.foobar |
 | react-use-router.js:8:21:8:39 | router.query.foobar | react-use-router.js:4:18:4:28 | useRouter() |
-| react-use-router.js:19:15:19:24 | router | react-use-router.js:20:43:20:48 | router |
-| react-use-router.js:19:17:19:22 | router | react-use-router.js:19:15:19:24 | router |
-| react-use-router.js:20:43:20:48 | router | react-use-router.js:20:43:20:54 | router.query |
-| react-use-router.js:20:43:20:54 | router.query | react-use-router.js:20:43:20:61 | router.query.foobar |
-| react-use-router.js:20:43:20:54 | router.query | react-use-router.js:20:43:20:61 | router.query.foobar |
-| react-use-router.js:20:43:20:54 | router.query | react-use-router.js:20:43:20:61 | router.query.foobar |
-| react-use-router.js:20:43:20:54 | router.query | react-use-router.js:20:43:20:61 | router.query.foobar |
-| react-use-router.js:20:43:20:61 | router.query.foobar | react-use-router.js:19:17:19:22 | router |
+| react-use-router.js:11:24:11:29 | router | react-use-router.js:11:24:11:35 | router.query |
+| react-use-router.js:11:24:11:35 | router.query | react-use-router.js:11:24:11:42 | router.query.foobar |
+| react-use-router.js:11:24:11:35 | router.query | react-use-router.js:11:24:11:42 | router.query.foobar |
+| react-use-router.js:11:24:11:35 | router.query | react-use-router.js:11:24:11:42 | router.query.foobar |
+| react-use-router.js:11:24:11:35 | router.query | react-use-router.js:11:24:11:42 | router.query.foobar |
+| react-use-router.js:22:15:22:24 | router | react-use-router.js:23:43:23:48 | router |
+| react-use-router.js:22:17:22:22 | router | react-use-router.js:22:15:22:24 | router |
+| react-use-router.js:23:43:23:48 | router | react-use-router.js:23:43:23:54 | router.query |
+| react-use-router.js:23:43:23:54 | router.query | react-use-router.js:23:43:23:61 | router.query.foobar |
+| react-use-router.js:23:43:23:54 | router.query | react-use-router.js:23:43:23:61 | router.query.foobar |
+| react-use-router.js:23:43:23:54 | router.query | react-use-router.js:23:43:23:61 | router.query.foobar |
+| react-use-router.js:23:43:23:54 | router.query | react-use-router.js:23:43:23:61 | router.query.foobar |
+| react-use-router.js:23:43:23:61 | router.query.foobar | react-use-router.js:22:17:22:22 | router |
 | react-use-state.js:4:9:4:49 | state | react-use-state.js:5:51:5:55 | state |
 | react-use-state.js:4:9:4:49 | state | react-use-state.js:5:51:5:55 | state |
 | react-use-state.js:4:9:4:49 | state | react-use-state.js:5:51:5:55 | state |
@@ -2417,7 +2428,9 @@ edges
 | react-use-context.js:10:22:10:32 | window.name | react-use-context.js:10:22:10:32 | window.name | react-use-context.js:10:22:10:32 | window.name | Cross-site scripting vulnerability due to $@. | react-use-context.js:10:22:10:32 | window.name | user-provided value |
 | react-use-context.js:16:26:16:36 | window.name | react-use-context.js:16:26:16:36 | window.name | react-use-context.js:16:26:16:36 | window.name | Cross-site scripting vulnerability due to $@. | react-use-context.js:16:26:16:36 | window.name | user-provided value |
 | react-use-router.js:8:21:8:39 | router.query.foobar | react-use-router.js:8:21:8:32 | router.query | react-use-router.js:8:21:8:39 | router.query.foobar | Cross-site scripting vulnerability due to $@. | react-use-router.js:8:21:8:32 | router.query | user-provided value |
-| react-use-router.js:20:43:20:61 | router.query.foobar | react-use-router.js:20:43:20:54 | router.query | react-use-router.js:20:43:20:61 | router.query.foobar | Cross-site scripting vulnerability due to $@. | react-use-router.js:20:43:20:54 | router.query | user-provided value |
+| react-use-router.js:11:24:11:42 | router.query.foobar | react-use-router.js:8:21:8:32 | router.query | react-use-router.js:11:24:11:42 | router.query.foobar | Cross-site scripting vulnerability due to $@. | react-use-router.js:8:21:8:32 | router.query | user-provided value |
+| react-use-router.js:11:24:11:42 | router.query.foobar | react-use-router.js:11:24:11:35 | router.query | react-use-router.js:11:24:11:42 | router.query.foobar | Cross-site scripting vulnerability due to $@. | react-use-router.js:11:24:11:35 | router.query | user-provided value |
+| react-use-router.js:23:43:23:61 | router.query.foobar | react-use-router.js:23:43:23:54 | router.query | react-use-router.js:23:43:23:61 | router.query.foobar | Cross-site scripting vulnerability due to $@. | react-use-router.js:23:43:23:54 | router.query | user-provided value |
 | react-use-state.js:5:51:5:55 | state | react-use-state.js:4:38:4:48 | window.name | react-use-state.js:5:51:5:55 | state | Cross-site scripting vulnerability due to $@. | react-use-state.js:4:38:4:48 | window.name | user-provided value |
 | react-use-state.js:11:51:11:55 | state | react-use-state.js:10:14:10:24 | window.name | react-use-state.js:11:51:11:55 | state | Cross-site scripting vulnerability due to $@. | react-use-state.js:10:14:10:24 | window.name | user-provided value |
 | react-use-state.js:17:51:17:55 | state | react-use-state.js:16:20:16:30 | window.name | react-use-state.js:17:51:17:55 | state | Cross-site scripting vulnerability due to $@. | react-use-state.js:16:20:16:30 | window.name | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.expected
@@ -579,13 +579,18 @@ nodes
 | react-use-router.js:8:21:8:32 | router.query |
 | react-use-router.js:8:21:8:39 | router.query.foobar |
 | react-use-router.js:8:21:8:39 | router.query.foobar |
-| react-use-router.js:19:15:19:24 | router |
-| react-use-router.js:19:17:19:22 | router |
-| react-use-router.js:20:43:20:48 | router |
-| react-use-router.js:20:43:20:54 | router.query |
-| react-use-router.js:20:43:20:54 | router.query |
-| react-use-router.js:20:43:20:61 | router.query.foobar |
-| react-use-router.js:20:43:20:61 | router.query.foobar |
+| react-use-router.js:11:24:11:29 | router |
+| react-use-router.js:11:24:11:35 | router.query |
+| react-use-router.js:11:24:11:35 | router.query |
+| react-use-router.js:11:24:11:42 | router.query.foobar |
+| react-use-router.js:11:24:11:42 | router.query.foobar |
+| react-use-router.js:22:15:22:24 | router |
+| react-use-router.js:22:17:22:22 | router |
+| react-use-router.js:23:43:23:48 | router |
+| react-use-router.js:23:43:23:54 | router.query |
+| react-use-router.js:23:43:23:54 | router.query |
+| react-use-router.js:23:43:23:61 | router.query.foobar |
+| react-use-router.js:23:43:23:61 | router.query.foobar |
 | react-use-state.js:4:9:4:49 | state |
 | react-use-state.js:4:9:4:49 | state |
 | react-use-state.js:4:10:4:14 | state |
@@ -1777,6 +1782,7 @@ edges
 | react-use-context.js:10:22:10:32 | window.name | react-use-context.js:10:22:10:32 | window.name |
 | react-use-context.js:16:26:16:36 | window.name | react-use-context.js:16:26:16:36 | window.name |
 | react-use-router.js:4:9:4:28 | router | react-use-router.js:8:21:8:26 | router |
+| react-use-router.js:4:9:4:28 | router | react-use-router.js:11:24:11:29 | router |
 | react-use-router.js:4:18:4:28 | useRouter() | react-use-router.js:4:9:4:28 | router |
 | react-use-router.js:8:21:8:26 | router | react-use-router.js:8:21:8:32 | router.query |
 | react-use-router.js:8:21:8:32 | router.query | react-use-router.js:8:21:8:39 | router.query.foobar |
@@ -1784,14 +1790,19 @@ edges
 | react-use-router.js:8:21:8:32 | router.query | react-use-router.js:8:21:8:39 | router.query.foobar |
 | react-use-router.js:8:21:8:32 | router.query | react-use-router.js:8:21:8:39 | router.query.foobar |
 | react-use-router.js:8:21:8:39 | router.query.foobar | react-use-router.js:4:18:4:28 | useRouter() |
-| react-use-router.js:19:15:19:24 | router | react-use-router.js:20:43:20:48 | router |
-| react-use-router.js:19:17:19:22 | router | react-use-router.js:19:15:19:24 | router |
-| react-use-router.js:20:43:20:48 | router | react-use-router.js:20:43:20:54 | router.query |
-| react-use-router.js:20:43:20:54 | router.query | react-use-router.js:20:43:20:61 | router.query.foobar |
-| react-use-router.js:20:43:20:54 | router.query | react-use-router.js:20:43:20:61 | router.query.foobar |
-| react-use-router.js:20:43:20:54 | router.query | react-use-router.js:20:43:20:61 | router.query.foobar |
-| react-use-router.js:20:43:20:54 | router.query | react-use-router.js:20:43:20:61 | router.query.foobar |
-| react-use-router.js:20:43:20:61 | router.query.foobar | react-use-router.js:19:17:19:22 | router |
+| react-use-router.js:11:24:11:29 | router | react-use-router.js:11:24:11:35 | router.query |
+| react-use-router.js:11:24:11:35 | router.query | react-use-router.js:11:24:11:42 | router.query.foobar |
+| react-use-router.js:11:24:11:35 | router.query | react-use-router.js:11:24:11:42 | router.query.foobar |
+| react-use-router.js:11:24:11:35 | router.query | react-use-router.js:11:24:11:42 | router.query.foobar |
+| react-use-router.js:11:24:11:35 | router.query | react-use-router.js:11:24:11:42 | router.query.foobar |
+| react-use-router.js:22:15:22:24 | router | react-use-router.js:23:43:23:48 | router |
+| react-use-router.js:22:17:22:22 | router | react-use-router.js:22:15:22:24 | router |
+| react-use-router.js:23:43:23:48 | router | react-use-router.js:23:43:23:54 | router.query |
+| react-use-router.js:23:43:23:54 | router.query | react-use-router.js:23:43:23:61 | router.query.foobar |
+| react-use-router.js:23:43:23:54 | router.query | react-use-router.js:23:43:23:61 | router.query.foobar |
+| react-use-router.js:23:43:23:54 | router.query | react-use-router.js:23:43:23:61 | router.query.foobar |
+| react-use-router.js:23:43:23:54 | router.query | react-use-router.js:23:43:23:61 | router.query.foobar |
+| react-use-router.js:23:43:23:61 | router.query.foobar | react-use-router.js:22:17:22:22 | router |
 | react-use-state.js:4:9:4:49 | state | react-use-state.js:5:51:5:55 | state |
 | react-use-state.js:4:9:4:49 | state | react-use-state.js:5:51:5:55 | state |
 | react-use-state.js:4:9:4:49 | state | react-use-state.js:5:51:5:55 | state |

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.expected
@@ -572,20 +572,20 @@ nodes
 | react-use-context.js:16:26:16:36 | window.name |
 | react-use-context.js:16:26:16:36 | window.name |
 | react-use-context.js:16:26:16:36 | window.name |
-| react-use-router.js:5:9:5:28 | router |
-| react-use-router.js:5:18:5:28 | useRouter() |
-| react-use-router.js:9:21:9:26 | router |
-| react-use-router.js:9:21:9:32 | router.query |
-| react-use-router.js:9:21:9:32 | router.query |
-| react-use-router.js:9:21:9:39 | router.query.foobar |
-| react-use-router.js:9:21:9:39 | router.query.foobar |
-| react-use-router.js:20:15:20:24 | router |
-| react-use-router.js:20:17:20:22 | router |
-| react-use-router.js:21:43:21:48 | router |
-| react-use-router.js:21:43:21:54 | router.query |
-| react-use-router.js:21:43:21:54 | router.query |
-| react-use-router.js:21:43:21:61 | router.query.foobar |
-| react-use-router.js:21:43:21:61 | router.query.foobar |
+| react-use-router.js:4:9:4:28 | router |
+| react-use-router.js:4:18:4:28 | useRouter() |
+| react-use-router.js:8:21:8:26 | router |
+| react-use-router.js:8:21:8:32 | router.query |
+| react-use-router.js:8:21:8:32 | router.query |
+| react-use-router.js:8:21:8:39 | router.query.foobar |
+| react-use-router.js:8:21:8:39 | router.query.foobar |
+| react-use-router.js:19:15:19:24 | router |
+| react-use-router.js:19:17:19:22 | router |
+| react-use-router.js:20:43:20:48 | router |
+| react-use-router.js:20:43:20:54 | router.query |
+| react-use-router.js:20:43:20:54 | router.query |
+| react-use-router.js:20:43:20:61 | router.query.foobar |
+| react-use-router.js:20:43:20:61 | router.query.foobar |
 | react-use-state.js:4:9:4:49 | state |
 | react-use-state.js:4:9:4:49 | state |
 | react-use-state.js:4:10:4:14 | state |
@@ -1776,22 +1776,22 @@ edges
 | react-native.js:7:17:7:33 | req.param("code") | react-native.js:7:7:7:33 | tainted |
 | react-use-context.js:10:22:10:32 | window.name | react-use-context.js:10:22:10:32 | window.name |
 | react-use-context.js:16:26:16:36 | window.name | react-use-context.js:16:26:16:36 | window.name |
-| react-use-router.js:5:9:5:28 | router | react-use-router.js:9:21:9:26 | router |
-| react-use-router.js:5:18:5:28 | useRouter() | react-use-router.js:5:9:5:28 | router |
-| react-use-router.js:9:21:9:26 | router | react-use-router.js:9:21:9:32 | router.query |
-| react-use-router.js:9:21:9:32 | router.query | react-use-router.js:9:21:9:39 | router.query.foobar |
-| react-use-router.js:9:21:9:32 | router.query | react-use-router.js:9:21:9:39 | router.query.foobar |
-| react-use-router.js:9:21:9:32 | router.query | react-use-router.js:9:21:9:39 | router.query.foobar |
-| react-use-router.js:9:21:9:32 | router.query | react-use-router.js:9:21:9:39 | router.query.foobar |
-| react-use-router.js:9:21:9:39 | router.query.foobar | react-use-router.js:5:18:5:28 | useRouter() |
-| react-use-router.js:20:15:20:24 | router | react-use-router.js:21:43:21:48 | router |
-| react-use-router.js:20:17:20:22 | router | react-use-router.js:20:15:20:24 | router |
-| react-use-router.js:21:43:21:48 | router | react-use-router.js:21:43:21:54 | router.query |
-| react-use-router.js:21:43:21:54 | router.query | react-use-router.js:21:43:21:61 | router.query.foobar |
-| react-use-router.js:21:43:21:54 | router.query | react-use-router.js:21:43:21:61 | router.query.foobar |
-| react-use-router.js:21:43:21:54 | router.query | react-use-router.js:21:43:21:61 | router.query.foobar |
-| react-use-router.js:21:43:21:54 | router.query | react-use-router.js:21:43:21:61 | router.query.foobar |
-| react-use-router.js:21:43:21:61 | router.query.foobar | react-use-router.js:20:17:20:22 | router |
+| react-use-router.js:4:9:4:28 | router | react-use-router.js:8:21:8:26 | router |
+| react-use-router.js:4:18:4:28 | useRouter() | react-use-router.js:4:9:4:28 | router |
+| react-use-router.js:8:21:8:26 | router | react-use-router.js:8:21:8:32 | router.query |
+| react-use-router.js:8:21:8:32 | router.query | react-use-router.js:8:21:8:39 | router.query.foobar |
+| react-use-router.js:8:21:8:32 | router.query | react-use-router.js:8:21:8:39 | router.query.foobar |
+| react-use-router.js:8:21:8:32 | router.query | react-use-router.js:8:21:8:39 | router.query.foobar |
+| react-use-router.js:8:21:8:32 | router.query | react-use-router.js:8:21:8:39 | router.query.foobar |
+| react-use-router.js:8:21:8:39 | router.query.foobar | react-use-router.js:4:18:4:28 | useRouter() |
+| react-use-router.js:19:15:19:24 | router | react-use-router.js:20:43:20:48 | router |
+| react-use-router.js:19:17:19:22 | router | react-use-router.js:19:15:19:24 | router |
+| react-use-router.js:20:43:20:48 | router | react-use-router.js:20:43:20:54 | router.query |
+| react-use-router.js:20:43:20:54 | router.query | react-use-router.js:20:43:20:61 | router.query.foobar |
+| react-use-router.js:20:43:20:54 | router.query | react-use-router.js:20:43:20:61 | router.query.foobar |
+| react-use-router.js:20:43:20:54 | router.query | react-use-router.js:20:43:20:61 | router.query.foobar |
+| react-use-router.js:20:43:20:54 | router.query | react-use-router.js:20:43:20:61 | router.query.foobar |
+| react-use-router.js:20:43:20:61 | router.query.foobar | react-use-router.js:19:17:19:22 | router |
 | react-use-state.js:4:9:4:49 | state | react-use-state.js:5:51:5:55 | state |
 | react-use-state.js:4:9:4:49 | state | react-use-state.js:5:51:5:55 | state |
 | react-use-state.js:4:9:4:49 | state | react-use-state.js:5:51:5:55 | state |

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.expected
@@ -572,6 +572,20 @@ nodes
 | react-use-context.js:16:26:16:36 | window.name |
 | react-use-context.js:16:26:16:36 | window.name |
 | react-use-context.js:16:26:16:36 | window.name |
+| react-use-router.js:5:9:5:28 | router |
+| react-use-router.js:5:18:5:28 | useRouter() |
+| react-use-router.js:9:21:9:26 | router |
+| react-use-router.js:9:21:9:32 | router.query |
+| react-use-router.js:9:21:9:32 | router.query |
+| react-use-router.js:9:21:9:39 | router.query.foobar |
+| react-use-router.js:9:21:9:39 | router.query.foobar |
+| react-use-router.js:20:15:20:24 | router |
+| react-use-router.js:20:17:20:22 | router |
+| react-use-router.js:21:43:21:48 | router |
+| react-use-router.js:21:43:21:54 | router.query |
+| react-use-router.js:21:43:21:54 | router.query |
+| react-use-router.js:21:43:21:61 | router.query.foobar |
+| react-use-router.js:21:43:21:61 | router.query.foobar |
 | react-use-state.js:4:9:4:49 | state |
 | react-use-state.js:4:9:4:49 | state |
 | react-use-state.js:4:10:4:14 | state |
@@ -1762,6 +1776,22 @@ edges
 | react-native.js:7:17:7:33 | req.param("code") | react-native.js:7:7:7:33 | tainted |
 | react-use-context.js:10:22:10:32 | window.name | react-use-context.js:10:22:10:32 | window.name |
 | react-use-context.js:16:26:16:36 | window.name | react-use-context.js:16:26:16:36 | window.name |
+| react-use-router.js:5:9:5:28 | router | react-use-router.js:9:21:9:26 | router |
+| react-use-router.js:5:18:5:28 | useRouter() | react-use-router.js:5:9:5:28 | router |
+| react-use-router.js:9:21:9:26 | router | react-use-router.js:9:21:9:32 | router.query |
+| react-use-router.js:9:21:9:32 | router.query | react-use-router.js:9:21:9:39 | router.query.foobar |
+| react-use-router.js:9:21:9:32 | router.query | react-use-router.js:9:21:9:39 | router.query.foobar |
+| react-use-router.js:9:21:9:32 | router.query | react-use-router.js:9:21:9:39 | router.query.foobar |
+| react-use-router.js:9:21:9:32 | router.query | react-use-router.js:9:21:9:39 | router.query.foobar |
+| react-use-router.js:9:21:9:39 | router.query.foobar | react-use-router.js:5:18:5:28 | useRouter() |
+| react-use-router.js:20:15:20:24 | router | react-use-router.js:21:43:21:48 | router |
+| react-use-router.js:20:17:20:22 | router | react-use-router.js:20:15:20:24 | router |
+| react-use-router.js:21:43:21:48 | router | react-use-router.js:21:43:21:54 | router.query |
+| react-use-router.js:21:43:21:54 | router.query | react-use-router.js:21:43:21:61 | router.query.foobar |
+| react-use-router.js:21:43:21:54 | router.query | react-use-router.js:21:43:21:61 | router.query.foobar |
+| react-use-router.js:21:43:21:54 | router.query | react-use-router.js:21:43:21:61 | router.query.foobar |
+| react-use-router.js:21:43:21:54 | router.query | react-use-router.js:21:43:21:61 | router.query.foobar |
+| react-use-router.js:21:43:21:61 | router.query.foobar | react-use-router.js:20:17:20:22 | router |
 | react-use-state.js:4:9:4:49 | state | react-use-state.js:5:51:5:55 | state |
 | react-use-state.js:4:9:4:49 | state | react-use-state.js:5:51:5:55 | state |
 | react-use-state.js:4:9:4:49 | state | react-use-state.js:5:51:5:55 | state |

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/react-use-router.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/react-use-router.js
@@ -1,4 +1,3 @@
-
 import { useRouter } from 'next/router'
 
 export function nextRouter() {

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/react-use-router.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/react-use-router.js
@@ -8,6 +8,9 @@ export function nextRouter() {
         router.push(router.query.foobar) // NOT OK
       }}>Click to XSS 1</span>
       <span onClick={() => {
+        router.replace(router.query.foobar) // NOT OK
+      }}>Click to XSS 2</span>
+      <span onClick={() => {
         router.push('/?foobar=' + router.query.foobar) // OK
       }}>Safe Link</span>
     </div>
@@ -17,6 +20,6 @@ export function nextRouter() {
 import { withRouter } from 'next/router'
 
 function Page({ router }) {
-  return <span onClick={() => router.push(router.query.foobar)}>Click to XSS 2</span> // NOT OK
+  return <span onClick={() => router.push(router.query.foobar)}>Click to XSS 3</span> // NOT OK
 }
 export const pageWithRouter = withRouter(Page);

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/react-use-router.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/react-use-router.js
@@ -1,0 +1,23 @@
+
+import { useRouter } from 'next/router'
+
+export function nextRouter() {
+  const router = useRouter();
+  return (
+    <div>
+      <span onClick={() => {
+        router.push(router.query.foobar) // NOT OK
+      }}>Click to XSS 1</span>
+      <span onClick={() => {
+        router.push('/?foobar=' + router.query.foobar) // OK
+      }}>Safe Link</span>
+    </div>
+  )
+}
+
+import { withRouter } from 'next/router'
+
+function Page({ router }) {
+  return <span onClick={() => router.push(router.query.foobar)}>Click to XSS 2</span> // NOT OK
+}
+export const pageWithRouter = withRouter(Page);


### PR DESCRIPTION
Made Next.js router's push/replace methods as XSS sink.
They should be XSS sink because XSS occurs when their argument is `javascript:alert(1)`.

https://nextjs.org/docs/api-reference/next/router#routerpush
https://nextjs.org/docs/api-reference/next/router#routerreplace

BTW, those methods are considered as XSS sink in the test code of ClientSideUrlRedirect but they are not actually treated as XSS sink.

https://github.com/github/codeql/blob/7f9b8557ac1c2fb3be684960bebdf957efc869ae/javascript/ql/test/query-tests/Security/CWE-601/ClientSideUrlRedirect/react.js#L26-L35