### PR TITLE
Swift: Add CSV extension points to the encryption queries.

### DIFF
--- a/swift/ql/lib/codeql/swift/security/ConstantPasswordExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/ConstantPasswordExtensions.qll
@@ -32,8 +32,8 @@ class ConstantPasswordAdditionalTaintStep extends Unit {
 /**
  * A password sink for the CryptoSwift library.
  */
-private class DefaultConstantPasswordSink extends ConstantPasswordSink {
-  DefaultConstantPasswordSink() {
+private class CryptoSwiftPasswordSink extends ConstantPasswordSink {
+  CryptoSwiftPasswordSink() {
     // `password` arg in `init` is a sink
     exists(ClassOrStructDecl c, ConstructorDecl f, CallExpr call |
       c.getName() = ["HKDF", "PBKDF1", "PBKDF2", "Scrypt"] and

--- a/swift/ql/lib/codeql/swift/security/ConstantPasswordExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/ConstantPasswordExtensions.qll
@@ -35,7 +35,7 @@ class ConstantPasswordAdditionalTaintStep extends Unit {
 private class CryptoSwiftPasswordSink extends ConstantPasswordSink {
   CryptoSwiftPasswordSink() {
     // `password` arg in `init` is a sink
-    exists(ClassOrStructDecl c, ConstructorDecl f, CallExpr call |
+    exists(NominalTypeDecl c, ConstructorDecl f, CallExpr call |
       c.getName() = ["HKDF", "PBKDF1", "PBKDF2", "Scrypt"] and
       c.getAMember() = f and
       call.getStaticTarget() = f and

--- a/swift/ql/lib/codeql/swift/security/ConstantPasswordExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/ConstantPasswordExtensions.qll
@@ -5,6 +5,7 @@
 
 import swift
 import codeql.swift.dataflow.DataFlow
+import codeql.swift.dataflow.ExternalFlow
 
 /**
  * A dataflow sink for constant password vulnerabilities. That is,
@@ -64,4 +65,11 @@ private class RnCryptorPasswordSink extends ConstantPasswordSink {
       call.getArgument(0).getExpr() = this.asExpr()
     )
   }
+}
+
+/**
+ * A sink defined in a CSV model.
+ */
+private class DefaultPasswordSink extends ConstantPasswordSink {
+  DefaultPasswordSink() { sinkNode(this, "encryption-password") }
 }

--- a/swift/ql/lib/codeql/swift/security/ConstantPasswordExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/ConstantPasswordExtensions.qll
@@ -50,8 +50,12 @@ private class DefaultConstantPasswordSink extends ConstantPasswordSink {
 private class RnCryptorPasswordSink extends ConstantPasswordSink {
   RnCryptorPasswordSink() {
     // RNCryptor (labelled arguments)
-    exists(ClassOrStructDecl c, MethodDecl f, CallExpr call |
-      c.getName() = ["RNCryptor", "RNEncryptor", "RNDecryptor"] and
+    exists(NominalTypeDecl c, MethodDecl f, CallExpr call |
+      c.getName() =
+        [
+          "RNCryptor", "RNEncryptor", "RNDecryptor", "RNCryptor.EncryptorV3",
+          "RNCryptor.DecryptorV3"
+        ] and
       c.getAMember() = f and
       call.getStaticTarget() = f and
       call.getArgumentWithLabel(["password", "withPassword", "forPassword"]).getExpr() =

--- a/swift/ql/lib/codeql/swift/security/ConstantPasswordExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/ConstantPasswordExtensions.qll
@@ -51,7 +51,7 @@ private class RnCryptorPasswordSink extends ConstantPasswordSink {
   RnCryptorPasswordSink() {
     // RNCryptor (labelled arguments)
     exists(NominalTypeDecl c, MethodDecl f, CallExpr call |
-      c.getName() =
+      c.getFullName() =
         [
           "RNCryptor", "RNEncryptor", "RNDecryptor", "RNCryptor.EncryptorV3",
           "RNCryptor.DecryptorV3"

--- a/swift/ql/lib/codeql/swift/security/ConstantSaltExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/ConstantSaltExtensions.qll
@@ -5,6 +5,7 @@
 
 import swift
 import codeql.swift.dataflow.DataFlow
+import codeql.swift.dataflow.ExternalFlow
 
 /**
  * A dataflow sink for constant salt vulnerabilities. That is,
@@ -56,4 +57,11 @@ private class RnCryptorSaltSink extends ConstantSaltSink {
         this.asExpr()
     )
   }
+}
+
+/**
+ * A sink defined in a CSV model.
+ */
+private class DefaultSaltSink extends ConstantSaltSink {
+  DefaultSaltSink() { sinkNode(this, "encryption-salt") }
 }

--- a/swift/ql/lib/codeql/swift/security/ConstantSaltExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/ConstantSaltExtensions.qll
@@ -35,7 +35,7 @@ class ConstantSaltAdditionalTaintStep extends Unit {
 private class CryptoSwiftSaltSink extends ConstantSaltSink {
   CryptoSwiftSaltSink() {
     // `salt` arg in `init` is a sink
-    exists(ClassOrStructDecl c, ConstructorDecl f, CallExpr call |
+    exists(NominalTypeDecl c, ConstructorDecl f, CallExpr call |
       c.getName() = ["HKDF", "PBKDF1", "PBKDF2", "Scrypt"] and
       c.getAMember() = f and
       call.getStaticTarget() = f and

--- a/swift/ql/lib/codeql/swift/security/ConstantSaltExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/ConstantSaltExtensions.qll
@@ -50,7 +50,7 @@ private class CryptoSwiftSaltSink extends ConstantSaltSink {
 private class RnCryptorSaltSink extends ConstantSaltSink {
   RnCryptorSaltSink() {
     exists(NominalTypeDecl c, MethodDecl f, CallExpr call |
-      c.getName() =
+      c.getFullName() =
         [
           "RNCryptor", "RNEncryptor", "RNDecryptor", "RNCryptor.EncryptorV3",
           "RNCryptor.DecryptorV3"

--- a/swift/ql/lib/codeql/swift/security/ConstantSaltExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/ConstantSaltExtensions.qll
@@ -49,8 +49,12 @@ private class CryptoSwiftSaltSink extends ConstantSaltSink {
  */
 private class RnCryptorSaltSink extends ConstantSaltSink {
   RnCryptorSaltSink() {
-    exists(ClassOrStructDecl c, MethodDecl f, CallExpr call |
-      c.getName() = ["RNCryptor", "RNEncryptor", "RNDecryptor"] and
+    exists(NominalTypeDecl c, MethodDecl f, CallExpr call |
+      c.getName() =
+        [
+          "RNCryptor", "RNEncryptor", "RNDecryptor", "RNCryptor.EncryptorV3",
+          "RNCryptor.DecryptorV3"
+        ] and
       c.getAMember() = f and
       call.getStaticTarget() = f and
       call.getArgumentWithLabel(["salt", "encryptionSalt", "hmacSalt", "HMACSalt"]).getExpr() =

--- a/swift/ql/lib/codeql/swift/security/ECBEncryptionExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/ECBEncryptionExtensions.qll
@@ -5,6 +5,7 @@
 
 import swift
 import codeql.swift.dataflow.DataFlow
+import codeql.swift.dataflow.ExternalFlow
 
 /**
  * A dataflow source for ECB encryption vulnerabilities. That is,
@@ -76,4 +77,11 @@ private class Blowfish extends EcbEncryptionSink {
       call.getArgument(1).getExpr() = this.asExpr()
     )
   }
+}
+
+/**
+ * A sink defined in a CSV model.
+ */
+private class DefaultEcbEncryptionSink extends EcbEncryptionSink {
+  DefaultEcbEncryptionSink() { sinkNode(this, "encryption-block-mode") }
 }

--- a/swift/ql/lib/codeql/swift/security/ECBEncryptionExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/ECBEncryptionExtensions.qll
@@ -49,33 +49,16 @@ private class CryptoSwiftEcb extends EcbEncryptionSource {
   }
 }
 
-/**
- * A block mode being used to form a CryptoSwift `AES` cipher.
- */
-private class AES extends EcbEncryptionSink {
-  AES() {
-    // `blockMode` arg in `AES.init` is a sink
-    exists(CallExpr call |
-      call.getStaticTarget()
-          .(MethodDecl)
-          .hasQualifiedName("AES", ["init(key:blockMode:)", "init(key:blockMode:padding:)"]) and
-      call.getArgument(1).getExpr() = this.asExpr()
-    )
-  }
-}
-
-/**
- * A block mode being used to form a CryptoSwift `Blowfish` cipher.
- */
-private class Blowfish extends EcbEncryptionSink {
-  Blowfish() {
-    // `blockMode` arg in `Blowfish.init` is a sink
-    exists(CallExpr call |
-      call.getStaticTarget()
-          .(MethodDecl)
-          .hasQualifiedName("Blowfish", "init(key:blockMode:padding:)") and
-      call.getArgument(1).getExpr() = this.asExpr()
-    )
+private class EcbEncryptionSinks extends SinkModelCsv {
+  override predicate row(string row) {
+    row =
+      [
+        // CryptoSwift `AES.init` block mode
+        ";AES;true;init(key:blockMode:);;;Argument[1];encryption-block-mode",
+        ";AES;true;init(key:blockMode:padding:);;;Argument[1];encryption-block-mode",
+        // CryptoSwift `Blowfish.init` block mode
+        ";Blowfish;true;init(key:blockMode:padding:);;;Argument[1];encryption-block-mode",
+      ]
   }
 }
 

--- a/swift/ql/lib/codeql/swift/security/HardcodedEncryptionKeyExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/HardcodedEncryptionKeyExtensions.qll
@@ -52,8 +52,12 @@ private class CryptoSwiftEncryptionKeySink extends HardcodedEncryptionKeySink {
  */
 private class RnCryptorEncryptionKeySink extends HardcodedEncryptionKeySink {
   RnCryptorEncryptionKeySink() {
-    exists(ClassOrStructDecl c, MethodDecl f, CallExpr call |
-      c.getFullName() = ["RNCryptor", "RNEncryptor", "RNDecryptor"] and
+    exists(NominalTypeDecl c, MethodDecl f, CallExpr call |
+      c.getFullName() =
+        [
+          "RNCryptor", "RNEncryptor", "RNDecryptor", "RNCryptor.EncryptorV3",
+          "RNCryptor.DecryptorV3"
+        ] and
       c.getAMember() = f and
       call.getStaticTarget() = f and
       call.getArgumentWithLabel(["encryptionKey", "withEncryptionKey"]).getExpr() = this.asExpr()

--- a/swift/ql/lib/codeql/swift/security/HardcodedEncryptionKeyExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/HardcodedEncryptionKeyExtensions.qll
@@ -35,14 +35,11 @@ class HardcodedEncryptionKeyAdditionalTaintStep extends Unit {
 private class CryptoSwiftEncryptionKeySink extends HardcodedEncryptionKeySink {
   CryptoSwiftEncryptionKeySink() {
     // `key` arg in `init` is a sink
-    exists(CallExpr call, string fName |
-      call.getStaticTarget()
-          .(MethodDecl)
-          .hasQualifiedName([
-              "AES", "HMAC", "ChaCha20", "CBCMAC", "CMAC", "Poly1305", "Blowfish", "Rabbit"
-            ], fName) and
-      fName.matches("init(key:%") and
-      call.getArgument(0).getExpr() = this.asExpr()
+    exists(NominalTypeDecl c, ConstructorDecl f, CallExpr call |
+      c.getName() = ["AES", "HMAC", "ChaCha20", "CBCMAC", "CMAC", "Poly1305", "Blowfish", "Rabbit"] and
+      c.getAMember() = f and
+      call.getStaticTarget() = f and
+      call.getArgumentWithLabel("key").getExpr() = this.asExpr()
     )
   }
 }

--- a/swift/ql/lib/codeql/swift/security/HardcodedEncryptionKeyExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/HardcodedEncryptionKeyExtensions.qll
@@ -5,6 +5,7 @@
 
 import swift
 import codeql.swift.dataflow.DataFlow
+import codeql.swift.dataflow.ExternalFlow
 
 /**
  * A dataflow sink for hard-coded encryption key vulnerabilities. That is,
@@ -58,4 +59,11 @@ private class RnCryptorEncryptionKeySink extends HardcodedEncryptionKeySink {
       call.getArgumentWithLabel(["encryptionKey", "withEncryptionKey"]).getExpr() = this.asExpr()
     )
   }
+}
+
+/**
+ * A sink defined in a CSV model.
+ */
+private class DefaultEncryptionKeySink extends HardcodedEncryptionKeySink {
+  DefaultEncryptionKeySink() { sinkNode(this, "encryption-key") }
 }

--- a/swift/ql/lib/codeql/swift/security/InsecureTLSExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/InsecureTLSExtensions.qll
@@ -5,6 +5,7 @@
 
 import swift
 import codeql.swift.dataflow.DataFlow
+import codeql.swift.dataflow.ExternalFlow
 
 /**
  * A dataflow source for insecure TLS configuration vulnerabilities. That is,
@@ -58,4 +59,11 @@ private class NsUrlTlsExtensionsSink extends InsecureTlsExtensionsSink {
         ]
     )
   }
+}
+
+/**
+ * A sink defined in a CSV model.
+ */
+private class DefaultTlsExtensionsSink extends InsecureTlsExtensionsSink {
+  DefaultTlsExtensionsSink() { sinkNode(this, "tls-protocol-version") }
 }

--- a/swift/ql/lib/codeql/swift/security/InsufficientHashIterationsExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/InsufficientHashIterationsExtensions.qll
@@ -36,7 +36,7 @@ class InsufficientHashIterationsAdditionalTaintStep extends Unit {
 private class CryptoSwiftHashIterationsSink extends InsufficientHashIterationsSink {
   CryptoSwiftHashIterationsSink() {
     // `iterations` arg in `init` is a sink
-    exists(ClassOrStructDecl c, ConstructorDecl f, CallExpr call |
+    exists(NominalTypeDecl c, ConstructorDecl f, CallExpr call |
       c.getName() = ["PBKDF1", "PBKDF2"] and
       c.getAMember() = f and
       call.getStaticTarget() = f and

--- a/swift/ql/lib/codeql/swift/security/InsufficientHashIterationsExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/InsufficientHashIterationsExtensions.qll
@@ -5,6 +5,7 @@
 
 import swift
 import codeql.swift.dataflow.DataFlow
+import codeql.swift.dataflow.ExternalFlow
 
 /**
  * A dataflow sink for insufficient hash interation vulnerabilities. That is,
@@ -42,4 +43,11 @@ private class CryptoSwiftHashIterationsSink extends InsufficientHashIterationsSi
       call.getArgumentWithLabel("iterations").getExpr() = this.asExpr()
     )
   }
+}
+
+/**
+ * A sink defined in a CSV model.
+ */
+private class DefaultHashIterationsSink extends InsufficientHashIterationsSink {
+  DefaultHashIterationsSink() { sinkNode(this, "hash-iteration-count") }
 }

--- a/swift/ql/lib/codeql/swift/security/StaticInitializationVectorExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/StaticInitializationVectorExtensions.qll
@@ -5,6 +5,7 @@
 
 import swift
 import codeql.swift.dataflow.DataFlow
+import codeql.swift.dataflow.ExternalFlow
 
 /**
  * A dataflow sink for static initialization vector vulnerabilities. That is,
@@ -57,4 +58,11 @@ private class RnCryptorInitializationVectorSink extends StaticInitializationVect
       call.getArgumentWithLabel(["iv", "IV"]).getExpr() = this.asExpr()
     )
   }
+}
+
+/**
+ * A sink defined in a CSV model.
+ */
+private class DefaultInitializationVectorSink extends StaticInitializationVectorSink {
+  DefaultInitializationVectorSink() { sinkNode(this, "encryption-iv") }
 }

--- a/swift/ql/lib/codeql/swift/security/StaticInitializationVectorExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/StaticInitializationVectorExtensions.qll
@@ -51,8 +51,12 @@ private class CryptoSwiftInitializationVectorSink extends StaticInitializationVe
  */
 private class RnCryptorInitializationVectorSink extends StaticInitializationVectorSink {
   RnCryptorInitializationVectorSink() {
-    exists(ClassOrStructDecl c, MethodDecl f, CallExpr call |
-      c.getFullName() = ["RNCryptor", "RNEncryptor", "RNDecryptor"] and
+    exists(NominalTypeDecl c, MethodDecl f, CallExpr call |
+      c.getFullName() =
+        [
+          "RNCryptor", "RNEncryptor", "RNDecryptor", "RNCryptor.EncryptorV3",
+          "RNCryptor.DecryptorV3"
+        ] and
       c.getAMember() = f and
       call.getStaticTarget() = f and
       call.getArgumentWithLabel(["iv", "IV"]).getExpr() = this.asExpr()

--- a/swift/ql/lib/codeql/swift/security/WeakSensitiveDataHashingExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/WeakSensitiveDataHashingExtensions.qll
@@ -35,23 +35,19 @@ class WeakSensitiveDataHashingAdditionalTaintStep extends Unit {
   abstract predicate step(DataFlow::Node nodeFrom, DataFlow::Node nodeTo);
 }
 
-/**
- * A sink for the CryptoSwift library.
- */
-private class CryptoSwiftWeakHashingSink extends WeakSensitiveDataHashingSink {
-  string algorithm;
-
-  CryptoSwiftWeakHashingSink() {
-    exists(ApplyExpr call, FuncDecl func |
-      call.getAnArgument().getExpr() = this.asExpr() and
-      call.getStaticTarget() = func and
-      func.getName().matches(["hash(%", "update(%"]) and
-      algorithm = func.getEnclosingDecl().(ClassOrStructDecl).getName() and
-      algorithm = ["MD5", "SHA1"]
-    )
+private class WeakHashingSinks extends SinkModelCsv {
+  override predicate row(string row) {
+    row =
+      [
+        // CryptoKit
+        ";Insecure.MD5;true;hash(data:);;;Argument[0];weak-hash-input-MD5",
+        ";Insecure.MD5;true;update(data:);;;Argument[0];weak-hash-input-MD5",
+        ";Insecure.MD5;true;update(bufferPointer:);;;Argument[0];weak-hash-input-MD5",
+        ";Insecure.SHA1;true;hash(data:);;;Argument[0];weak-hash-input-SHA1",
+        ";Insecure.SHA1;true;update(data:);;;Argument[0];weak-hash-input-SHA1",
+        ";Insecure.SHA1;true;update(bufferPointer:);;;Argument[0];weak-hash-input-SHA1",
+      ]
   }
-
-  override string getAlgorithm() { result = algorithm }
 }
 
 /**

--- a/swift/ql/lib/codeql/swift/security/WeakSensitiveDataHashingExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/WeakSensitiveDataHashingExtensions.qll
@@ -6,9 +6,11 @@
 import swift
 import codeql.swift.security.SensitiveExprs
 import codeql.swift.dataflow.DataFlow
+import codeql.swift.dataflow.ExternalFlow
 
 /**
- * A dataflow sink for weak sensitive data hashing vulnerabilities.
+ * A dataflow sink for weak sensitive data hashing vulnerabilities. That is,
+ * a `DataFlow::Node` that is passed into a weak hashing function.
  */
 abstract class WeakSensitiveDataHashingSink extends DataFlow::Node {
   /**
@@ -48,6 +50,17 @@ private class CryptoSwiftWeakHashingSink extends WeakSensitiveDataHashingSink {
       algorithm = ["MD5", "SHA1"]
     )
   }
+
+  override string getAlgorithm() { result = algorithm }
+}
+
+/**
+ * A sink defined in a CSV model.
+ */
+private class DefaultWeakHashingSink extends WeakSensitiveDataHashingSink {
+  string algorithm;
+
+  DefaultWeakHashingSink() { sinkNode(this, "weak-hash-input-" + algorithm) }
 
   override string getAlgorithm() { result = algorithm }
 }


### PR DESCRIPTION
Add MaD/CSV extension points to the eight encryption queries.  Use them in two of the queries (I intend to take this a bit further at some point).  Fix a few other bits and pieces around sinks for better reliability and consistency.