### PR TITLE
JS: use 1-based column locations for diagnostics

### DIFF
--- a/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
@@ -1245,9 +1245,9 @@ protected DependencyInstallationResult preparePackagesAndDependencies(Set<Path> 
         }
         DiagnosticLocation diagLoc = builder
             .setStartLine(err.getPosition().getLine())
-            .setStartColumn(err.getPosition().getColumn())
+            .setStartColumn(err.getPosition().getColumn() + 1) // convert from 0-based to 1-based
             .setEndLine(err.getPosition().getLine())
-            .setEndColumn(err.getPosition().getColumn())
+            .setEndColumn(err.getPosition().getColumn() + 1) // convert from 0-based to 1-based
             .build();
         writeDiagnostics(msg, JSDiagnosticKind.PARSE_ERROR, diagLoc);
       }

--- a/javascript/ql/integration-tests/all-platforms/diagnostics/syntax-error/diagnostics.expected
+++ b/javascript/ql/integration-tests/all-platforms/diagnostics/syntax-error/diagnostics.expected
@@ -1,9 +1,9 @@
 {
   "location": {
-    "endColumn": 4,
+    "endColumn": 5,
     "endLine": 1,
     "file": "bad.js",
-    "startColumn": 4,
+    "startColumn": 5,
     "startLine": 1
   },
   "markdownMessage": "A parse error occurred: `Unexpected token`. Check the syntax of the file. If the file is invalid, correct the error or [exclude](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/customizing-code-scanning) the file from analysis.",


### PR DESCRIPTION
The diagnostics location was supposed to be 1-based column numbers, but we were using 0-based column numbers.  

See backref for more context. 