### PR TITLE
C++: Fix joins in `cpp/constant-array-overflow`

### DIFF
--- a/cpp/ql/src/experimental/Security/CWE/CWE-193/ConstantSizeArrayOffByOne.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-193/ConstantSizeArrayOffByOne.ql
@@ -25,15 +25,22 @@ Instruction getABoundIn(SemBound b, IRFunction func) {
 /**
  * Holds if `i <= b + delta`.
  */
-bindingset[i]
-pragma[inline_late]
-predicate bounded(Instruction i, Instruction b, int delta) {
+pragma[inline]
+predicate boundedImpl(Instruction i, Instruction b, int delta) {
   exists(SemBound bound, IRFunction func |
     semBounded(getSemanticExpr(i), bound, delta, true, _) and
     b = getABoundIn(bound, func) and
-    i.getEnclosingIRFunction() = func
+    pragma[only_bind_out](i.getEnclosingIRFunction()) = func
   )
 }
+
+bindingset[i]
+pragma[inline_late]
+predicate bounded1(Instruction i, Instruction b, int delta) { boundedImpl(i, b, delta) }
+
+bindingset[b]
+pragma[inline_late]
+predicate bounded2(Instruction i, Instruction b, int delta) { boundedImpl(i, b, delta) }
 
 module FieldAddressToPointerArithmeticConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) { isFieldAddressSource(_, source) }
@@ -50,23 +57,39 @@ predicate isFieldAddressSource(Field f, DataFlow::Node source) {
   source.asInstruction().(FieldAddressInstruction).getField() = f
 }
 
+bindingset[delta]
+predicate isInvalidPointerDerefSinkImpl(
+  int delta, Instruction i, AddressOperand addr, string operation
+) {
+  delta >= 0 and
+  i.getAnOperand() = addr and
+  (
+    i instanceof StoreInstruction and
+    operation = "write"
+    or
+    i instanceof LoadInstruction and
+    operation = "read"
+  )
+}
+
 /**
  * Holds if `sink` is a sink for `InvalidPointerToDerefConf` and `i` is a `StoreInstruction` that
  * writes to an address that non-strictly upper-bounds `sink`, or `i` is a `LoadInstruction` that
  * reads from an address that non-strictly upper-bounds `sink`.
  */
 pragma[inline]
-predicate isInvalidPointerDerefSink(DataFlow::Node sink, Instruction i, string operation) {
+predicate isInvalidPointerDerefSink1(DataFlow::Node sink, Instruction i, string operation) {
   exists(AddressOperand addr, int delta |
-    bounded(addr.getDef(), sink.asInstruction(), delta) and
-    delta >= 0 and
-    i.getAnOperand() = addr
-  |
-    i instanceof StoreInstruction and
-    operation = "write"
-    or
-    i instanceof LoadInstruction and
-    operation = "read"
+    bounded1(addr.getDef(), sink.asInstruction(), delta) and
+    isInvalidPointerDerefSinkImpl(delta, i, addr, operation)
+  )
+}
+
+pragma[inline]
+predicate isInvalidPointerDerefSink2(DataFlow::Node sink, Instruction i, string operation) {
+  exists(AddressOperand addr, int delta |
+    bounded2(addr.getDef(), sink.asInstruction(), delta) and
+    isInvalidPointerDerefSinkImpl(delta, i, addr, operation)
   )
 }
 
@@ -90,7 +113,7 @@ module PointerArithmeticToDerefConfig implements DataFlow::ConfigSig {
   }
 
   pragma[inline]
-  predicate isSink(DataFlow::Node sink) { isInvalidPointerDerefSink(sink, _, _) }
+  predicate isSink(DataFlow::Node sink) { isInvalidPointerDerefSink1(sink, _, _) }
 }
 
 module PointerArithmeticToDerefFlow = DataFlow::Global<PointerArithmeticToDerefConfig>;
@@ -100,7 +123,7 @@ from
   PointerArithmeticToDerefFlow::PathNode sink, Instruction deref, string operation, int delta
 where
   PointerArithmeticToDerefFlow::flowPath(source, sink) and
-  isInvalidPointerDerefSink(sink.getNode(), deref, operation) and
+  isInvalidPointerDerefSink2(sink.getNode(), deref, operation) and
   isConstantSizeOverflowSource(f, source.getNode().asInstruction(), delta)
 select source, source, sink,
   "This pointer arithmetic may have an off-by-" + (delta + 1) +


### PR DESCRIPTION
This PR fixes the joins in the `select` predicate that we couldn't find a simple fix for in https://github.com/github/codeql/pull/12777. The fix ended up being similar to the ones in `cpp/invalid-pointer-deref`.

Before:

```ql
[2023-04-12 12:00:25] Evaluated non-recursive predicate #select#ffffffff@1ae7f7dj in 11103ms (size: 10).
Evaluated relational algebra for predicate #select#ffffffff@1ae7f7dj with tuple counts:
    7155907   ~6%    {2} r1 = JOIN Instruction#577b6a83::Instruction::getAnOperand#0#dispred#ff_10#join_rhs WITH Operand#27b358ab::AddressOperand#ffff ON FIRST 1 OUTPUT Lhs.0, Lhs.1
    7155907   ~0%    {2} r2 = JOIN r1 WITH Operand#27b358ab::Operand::getDef#0#dispred#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.1
    7155775   ~0%    {3} r3 = JOIN r2 WITH EquivalenceRelation#Instruction#577b6a83::Instruction#SemanticExprSpecific#ad5ae873::SemanticExprConfig::idOrSafeConversion#::getEquivalenceClass#ff ON FIRST 1 OUTPUT Lhs.0, Lhs.1, Rhs.1
    7155775   ~1%    {3} r4 = JOIN r3 WITH SSAConstruction#2b11997e::Cached::getInstructionEnclosingIRFunction#1#ff ON FIRST 1 OUTPUT Lhs.2, Lhs.1, Rhs.1
    7190204   ~0%    {4} r5 = JOIN r4 WITH project#RangeAnalysisImpl#edd69a76::semBounded#5#fffbf ON FIRST 1 OUTPUT Lhs.1, Lhs.2, Rhs.1, f2i(Rhs.2)
    7189805   ~0%    {4} r6 = SELECT r5 ON In.3 >= 0
    7189805   ~2%    {3} r7 = SCAN r6 OUTPUT In.2, In.1, In.0
  272153412   ~3%    {2} r8 = JOIN r7 WITH ConstantSizeArrayOffByOne#f6a3dbf4::getABoundIn#2#fff ON FIRST 2 OUTPUT Rhs.2, Lhs.2
  272096400   ~0%    {2} r9 = JOIN r8 WITH DataFlowUtil#47741e1f::Node::asInstruction#0#dispred#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1
         10   ~0%    {2} r10 = JOIN r9 WITH DataFlowImpl#9021cc4c::Impl#DataFlow#6c4a6647::Global#ConstantSizeArrayOffByOne#f6a3dbf4::PointerArithmeticToDerefConfig#::C#::PathNode::getNode#0#dispred#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1
         10   ~0%    {3} r11 = JOIN r10 WITH DataFlowImpl#9021cc4c::Impl#DataFlow#6c4a6647::Global#ConstantSizeArrayOffByOne#f6a3dbf4::PointerArithmeticToDerefConfig#::C#::flowPath#2#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.0
         10   ~0%    {5} r12 = JOIN r11 WITH DataFlowImpl#9021cc4c::Impl#DataFlow#6c4a6647::Global#ConstantSizeArrayOffByOne#f6a3dbf4::PointerArithmeticToDerefConfig#::C#::PathNode::getNode#0#dispred#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.0, Lhs.0
         10   ~0%    {5} r13 = JOIN r12 WITH DataFlowUtil#47741e1f::Node::asInstruction#0#dispred#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3, Lhs.4
         10   ~0%    {6} r14 = JOIN r13 WITH ConstantSizeArrayOffByOne#f6a3dbf4::isConstantSizeOverflowSource#3#fff_102#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Rhs.2
         10   ~0%    {7} r15 = JOIN r14 WITH Variable#7a968d4e::MemberVariable::getName#0#dispred#ff ON FIRST 1 OUTPUT Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.0, Rhs.1, ("This pointer arithmetic may have an off-by-" ++ toString((Lhs.5 + 1)) ++ " error allowing it to overrun $@ at this $@.")
                
          8   ~0%    {8} r16 = JOIN r15 WITH Instruction#577b6a83::LoadInstruction#f ON FIRST 1 OUTPUT Lhs.2, Lhs.3, Lhs.1, Lhs.6, Lhs.4, Lhs.5, Lhs.0, "read"
                
          2   ~0%    {8} r17 = JOIN r15 WITH Instruction#577b6a83::StoreInstruction#f ON FIRST 1 OUTPUT Lhs.2, Lhs.3, Lhs.1, Lhs.6, Lhs.4, Lhs.5, Lhs.0, "write"
                
        10   ~0%    {8} r18 = r16 UNION r17
                    return r18
```

After:
```ql
[2023-04-12 11:57:27] Evaluated non-recursive predicate #select#ffffffff@a94668q4 in 2ms (size: 10).
Evaluated relational algebra for predicate #select#ffffffff@a94668q4 with tuple counts:
    19   ~5%    {4} r1 = JOIN Variable#7a968d4e::MemberVariable::getName#0#dispred#ff WITH ConstantSizeArrayOffByOne#f6a3dbf4::isConstantSizeOverflowSource#3#fff ON FIRST 1 OUTPUT Rhs.1, Lhs.0, Lhs.1, ("This pointer arithmetic may have an off-by-" ++ toString((Rhs.2 + 1)) ++ " error allowing it to overrun $@ at this $@.")
    19   ~0%    {4} r2 = JOIN r1 WITH DataFlowUtil#47741e1f::Node::asInstruction#0#dispred#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3
    6   ~0%     {5} r3 = JOIN r2 WITH DataFlowImpl#9021cc4c::Impl#DataFlow#6c4a6647::Global#ConstantSizeArrayOffByOne#f6a3dbf4::PointerArithmeticToDerefConfig#::C#::PathNode::getNode#0#dispred#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3, Lhs.0
    6   ~0%     {6} r4 = JOIN r3 WITH DataFlowImpl#9021cc4c::Impl#DataFlow#6c4a6647::Global#ConstantSizeArrayOffByOne#f6a3dbf4::PointerArithmeticToDerefConfig#::C#::flowPath#2#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.0
    6   ~0%     {7} r5 = JOIN r4 WITH DataFlowImpl#9021cc4c::Impl#DataFlow#6c4a6647::Global#ConstantSizeArrayOffByOne#f6a3dbf4::PointerArithmeticToDerefConfig#::C#::PathNode::getNode#0#dispred#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5, Lhs.0
    6   ~0%     {7} r6 = JOIN r5 WITH DataFlowUtil#47741e1f::Node::asInstruction#0#dispred#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5, Lhs.6
    6   ~0%     {8} r7 = JOIN r6 WITH ConstantSizeArrayOffByOne#f6a3dbf4::getABoundIn#2#fff_201#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5, Lhs.6, Rhs.2
    10   ~0%    {9} r8 = JOIN r7 WITH project#RangeAnalysisImpl#edd69a76::semBounded#5#fffbf_102#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5, Lhs.6, Lhs.7, Rhs.2
    10   ~0%    {9} r9 = JOIN r8 WITH EquivalenceRelation#Instruction#577b6a83::Instruction#SemanticExprSpecific#ad5ae873::SemanticExprConfig::idOrSafeConversion#::getEquivalenceClass#ff_10#join_rhs ON FIRST 1 OUTPUT Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5, Lhs.6, Lhs.7, Rhs.1, f2i(Lhs.8)
    10   ~0%    {9} r10 = SELECT r9 ON In.8 >= 0
    10   ~0%    {8} r11 = SCAN r10 OUTPUT In.7, In.6, In.0, In.1, In.2, In.3, In.4, In.5
    10   ~0%    {7} r12 = JOIN r11 WITH SSAConstruction#2b11997e::Cached::getInstructionEnclosingIRFunction#1#ff ON FIRST 2 OUTPUT Lhs.0, Lhs.2, Lhs.3, Lhs.4, Lhs.5, Lhs.6, Lhs.7
    10   ~0%    {7} r13 = JOIN r12 WITH Operand#27b358ab::Operand::getDef#0#dispred#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5, Lhs.6
    10   ~0%    {7} r14 = JOIN r13 WITH Operand#27b358ab::AddressOperand#ffff ON FIRST 1 OUTPUT Lhs.0, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5, Lhs.6
    10   ~0%    {7} r15 = JOIN r14 WITH Instruction#577b6a83::Instruction::getAnOperand#0#dispred#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5, Lhs.6
            
    8   ~0%     {8} r16 = JOIN r15 WITH Instruction#577b6a83::LoadInstruction#f ON FIRST 1 OUTPUT Lhs.4, Lhs.5, Lhs.6, Lhs.3, Lhs.1, Lhs.2, Lhs.0, "read"
          
    2   ~0%     {8} r17 = JOIN r15 WITH Instruction#577b6a83::StoreInstruction#f ON FIRST 1 OUTPUT Lhs.4, Lhs.5, Lhs.6, Lhs.3, Lhs.1, Lhs.2, Lhs.0, "write"
            
    10   ~0%    {8} r18 = r16 UNION r17
                return r18
```