### PR TITLE
QL: Don't warn about cached predicates possibly being inlined

### DIFF
--- a/ql/ql/src/queries/performance/MissingNoinline.ql
+++ b/ql/ql/src/queries/performance/MissingNoinline.ql
@@ -17,6 +17,7 @@ where
   not decl.getAnAnnotation() instanceof NoInline and
   not decl.getAnAnnotation() instanceof NoMagic and
   not decl.getAnAnnotation() instanceof NoOpt and
+  not decl.getAnAnnotation().getName() = "cached" and
   // If it's marked as inline it's probably because the QLDoc says something like
   // "this predicate is inlined because it gives a better join-order".
   not decl.getAnAnnotation() instanceof Inline


### PR DESCRIPTION
See some FPs on this PR https://github.com/github/codeql/pull/12804