### PR TITLE
Java: Refactor Test DataFlow configurations to new API

### DIFF
--- a/java/ql/test/kotlin/library-tests/dataflow/extensionMethod/test.ql
+++ b/java/ql/test/kotlin/library-tests/dataflow/extensionMethod/test.ql
@@ -1,18 +1,16 @@
 import java
 import semmle.code.java.dataflow.TaintTracking
 
-class Conf extends TaintTracking::Configuration {
-  Conf() { this = "qltest:extension-method" }
-
-  override predicate isSource(DataFlow::Node n) {
+module Config implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node n) {
     n.asExpr().(Argument).getCall().getCallee().hasName("taint")
   }
 
-  override predicate isSink(DataFlow::Node n) {
-    n.asExpr().(Argument).getCall().getCallee().hasName("sink")
-  }
+  predicate isSink(DataFlow::Node n) { n.asExpr().(Argument).getCall().getCallee().hasName("sink") }
 }
 
-from DataFlow::Node src, DataFlow::Node sink, Conf conf
-where conf.hasFlow(src, sink)
+module Flow = TaintTracking::Global<Config>;
+
+from DataFlow::Node src, DataFlow::Node sink
+where Flow::flow(src, sink)
 select src, sink

--- a/java/ql/test/kotlin/library-tests/dataflow/foreach/test.ql
+++ b/java/ql/test/kotlin/library-tests/dataflow/foreach/test.ql
@@ -1,18 +1,16 @@
 import java
 import semmle.code.java.dataflow.TaintTracking
 
-class Conf extends TaintTracking::Configuration {
-  Conf() { this = "qltest:foreach-array-iterator" }
-
-  override predicate isSource(DataFlow::Node n) {
+module Config implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node n) {
     n.asExpr().(Argument).getCall().getCallee().hasName("taint")
   }
 
-  override predicate isSink(DataFlow::Node n) {
-    n.asExpr().(Argument).getCall().getCallee().hasName("sink")
-  }
+  predicate isSink(DataFlow::Node n) { n.asExpr().(Argument).getCall().getCallee().hasName("sink") }
 }
 
-from DataFlow::Node src, DataFlow::Node sink, Conf conf
-where conf.hasFlow(src, sink)
+module Flow = TaintTracking::Global<Config>;
+
+from DataFlow::Node src, DataFlow::Node sink
+where Flow::flow(src, sink)
 select src, sink

--- a/java/ql/test/kotlin/library-tests/dataflow/func/test.ql
+++ b/java/ql/test/kotlin/library-tests/dataflow/func/test.ql
@@ -1,18 +1,14 @@
 import java
 import semmle.code.java.dataflow.TaintTracking
 
-class Conf extends TaintTracking::Configuration {
-  Conf() { this = "qltest:lambdaFlow" }
+module Config implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node n) { n.asExpr().(MethodAccess).getMethod().hasName("taint") }
 
-  override predicate isSource(DataFlow::Node n) {
-    n.asExpr().(MethodAccess).getMethod().hasName("taint")
-  }
-
-  override predicate isSink(DataFlow::Node n) {
-    n.asExpr().(Argument).getCall().getCallee().hasName("sink")
-  }
+  predicate isSink(DataFlow::Node n) { n.asExpr().(Argument).getCall().getCallee().hasName("sink") }
 }
 
-from DataFlow::Node src, DataFlow::Node sink, Conf conf
-where conf.hasFlow(src, sink)
+module Flow = TaintTracking::Global<Config>;
+
+from DataFlow::Node src, DataFlow::Node sink
+where Flow::flow(src, sink)
 select src, sink

--- a/java/ql/test/kotlin/library-tests/dataflow/notnullexpr/test.ql
+++ b/java/ql/test/kotlin/library-tests/dataflow/notnullexpr/test.ql
@@ -1,18 +1,14 @@
 import java
 import semmle.code.java.dataflow.TaintTracking
 
-class Conf extends TaintTracking::Configuration {
-  Conf() { this = "qltest:notNullExprFlow" }
+module Config implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node n) { n.asExpr().(MethodAccess).getMethod().hasName("taint") }
 
-  override predicate isSource(DataFlow::Node n) {
-    n.asExpr().(MethodAccess).getMethod().hasName("taint")
-  }
-
-  override predicate isSink(DataFlow::Node n) {
-    n.asExpr().(Argument).getCall().getCallee().hasName("sink")
-  }
+  predicate isSink(DataFlow::Node n) { n.asExpr().(Argument).getCall().getCallee().hasName("sink") }
 }
 
-from DataFlow::Node src, DataFlow::Node sink, Conf conf
-where conf.hasFlow(src, sink)
+module Flow = TaintTracking::Global<Config>;
+
+from DataFlow::Node src, DataFlow::Node sink
+where Flow::flow(src, sink)
 select src, sink

--- a/java/ql/test/kotlin/library-tests/dataflow/stmtexpr/test.ql
+++ b/java/ql/test/kotlin/library-tests/dataflow/stmtexpr/test.ql
@@ -1,18 +1,16 @@
 import java
 import semmle.code.java.dataflow.DataFlow
 
-class Conf extends DataFlow::Configuration {
-  Conf() { this = "qltest:exprStmtFlow" }
-
-  override predicate isSource(DataFlow::Node n) {
+module Config implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node n) {
     n.asExpr().(ClassInstanceExpr).getType().(RefType).getASupertype*().hasName("Source")
   }
 
-  override predicate isSink(DataFlow::Node n) {
-    n.asExpr().(Argument).getCall().getCallee().hasName("sink")
-  }
+  predicate isSink(DataFlow::Node n) { n.asExpr().(Argument).getCall().getCallee().hasName("sink") }
 }
 
-from DataFlow::Node src, DataFlow::Node sink, Conf conf
-where conf.hasFlow(src, sink)
+module Flow = DataFlow::Global<Config>;
+
+from DataFlow::Node src, DataFlow::Node sink
+where Flow::flow(src, sink)
 select src, sink

--- a/java/ql/test/kotlin/library-tests/dataflow/taint/test.ql
+++ b/java/ql/test/kotlin/library-tests/dataflow/taint/test.ql
@@ -1,18 +1,14 @@
 import java
 import semmle.code.java.dataflow.TaintTracking
 
-class Conf extends TaintTracking::Configuration {
-  Conf() { this = "kttaintconf" }
+module Config implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node n) { n.asExpr().(MethodAccess).getMethod().hasName("taint") }
 
-  override predicate isSource(DataFlow::Node n) {
-    n.asExpr().(MethodAccess).getMethod().hasName("taint")
-  }
-
-  override predicate isSink(DataFlow::Node n) {
-    n.asExpr().(Argument).getCall().getCallee().hasName("sink")
-  }
+  predicate isSink(DataFlow::Node n) { n.asExpr().(Argument).getCall().getCallee().hasName("sink") }
 }
 
-from DataFlow::Node src, DataFlow::Node sink, Conf conf
-where conf.hasFlow(src, sink)
+module Flow = TaintTracking::Global<Config>;
+
+from DataFlow::Node src, DataFlow::Node sink
+where Flow::flow(src, sink)
 select src, sink

--- a/java/ql/test/kotlin/library-tests/dataflow/whenexpr/test.ql
+++ b/java/ql/test/kotlin/library-tests/dataflow/whenexpr/test.ql
@@ -1,18 +1,14 @@
 import java
 import semmle.code.java.dataflow.TaintTracking
 
-class Conf extends TaintTracking::Configuration {
-  Conf() { this = "qltest:notNullExprFlow" }
+module Config implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node n) { n.asExpr().(MethodAccess).getMethod().hasName("taint") }
 
-  override predicate isSource(DataFlow::Node n) {
-    n.asExpr().(MethodAccess).getMethod().hasName("taint")
-  }
-
-  override predicate isSink(DataFlow::Node n) {
-    n.asExpr().(Argument).getCall().getCallee().hasName("sink")
-  }
+  predicate isSink(DataFlow::Node n) { n.asExpr().(Argument).getCall().getCallee().hasName("sink") }
 }
 
-from DataFlow::Node src, DataFlow::Node sink, Conf conf
-where conf.hasFlow(src, sink)
+module Flow = TaintTracking::Global<Config>;
+
+from DataFlow::Node src, DataFlow::Node sink
+where Flow::flow(src, sink)
 select src, sink

--- a/java/ql/test/kotlin/library-tests/field-initializer-flow/test.ql
+++ b/java/ql/test/kotlin/library-tests/field-initializer-flow/test.ql
@@ -1,20 +1,20 @@
 import java
 import semmle.code.java.dataflow.DataFlow
 
-class Config extends DataFlow::Configuration {
-  Config() { this = "Config" }
+module Config implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node n) { n.asExpr().(StringLiteral).getValue() = "Source" }
 
-  override predicate isSource(DataFlow::Node n) { n.asExpr().(StringLiteral).getValue() = "Source" }
-
-  override predicate isSink(DataFlow::Node n) {
+  predicate isSink(DataFlow::Node n) {
     n.asExpr().(Argument).getCall().getCallee().getName() = "sink"
   }
 }
+
+module Flow = DataFlow::Global<Config>;
 
 query predicate isFinalField(Field f) {
   exists(FieldDeclaration f2 | f = f2.getAField()) and f.isFinal()
 }
 
 from DataFlow::Node source, DataFlow::Node sink
-where any(Config c).hasFlow(source, sink)
+where Flow::flow(source, sink)
 select source, sink

--- a/java/ql/test/kotlin/library-tests/jvmoverloads_flow/test.ql
+++ b/java/ql/test/kotlin/library-tests/jvmoverloads_flow/test.ql
@@ -1,18 +1,18 @@
 import java
 import semmle.code.java.dataflow.DataFlow
 
-class Config extends DataFlow::Configuration {
-  Config() { this = "config" }
-
-  override predicate isSource(DataFlow::Node n) {
+module Config implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node n) {
     n.asExpr().(MethodAccess).getCallee().getName() = "source"
   }
 
-  override predicate isSink(DataFlow::Node n) {
+  predicate isSink(DataFlow::Node n) {
     n.asExpr().(Argument).getCall().getCallee().getName() = "sink"
   }
 }
 
-from Config c, DataFlow::Node source, DataFlow::Node sink
-where c.hasFlow(source, sink)
+module Flow = DataFlow::Global<Config>;
+
+from DataFlow::Node source, DataFlow::Node sink
+where Flow::flow(source, sink)
 select source, sink, source.getEnclosingCallable()

--- a/java/ql/test/kotlin/library-tests/parameter-defaults/flowTest.ql
+++ b/java/ql/test/kotlin/library-tests/parameter-defaults/flowTest.ql
@@ -13,13 +13,12 @@ class ShouldBeSunk extends StringLiteral {
 }
 
 module Config implements DataFlow::ConfigSig {
-
- predicate isSource(DataFlow::Node n) {
+  predicate isSource(DataFlow::Node n) {
     n.asExpr() instanceof ShouldBeSunk or
     n.asExpr() instanceof ShouldNotBeSunk
   }
 
- predicate isSink(DataFlow::Node n) {
+  predicate isSink(DataFlow::Node n) {
     n.asExpr().(Argument).getCall().getCallee().getName() = "sink"
   }
 }

--- a/java/ql/test/kotlin/library-tests/parameter-defaults/flowTest.ql
+++ b/java/ql/test/kotlin/library-tests/parameter-defaults/flowTest.ql
@@ -12,21 +12,22 @@ class ShouldBeSunk extends StringLiteral {
   }
 }
 
-class Config extends DataFlow::Configuration {
-  Config() { this = "Config" }
+module Config implements DataFlow::ConfigSig {
 
-  override predicate isSource(DataFlow::Node n) {
+ predicate isSource(DataFlow::Node n) {
     n.asExpr() instanceof ShouldBeSunk or
     n.asExpr() instanceof ShouldNotBeSunk
   }
 
-  override predicate isSink(DataFlow::Node n) {
+ predicate isSink(DataFlow::Node n) {
     n.asExpr().(Argument).getCall().getCallee().getName() = "sink"
   }
 }
 
+module Flow = DataFlow::Global<Config>;
+
 predicate isSunk(StringLiteral sl) {
-  exists(Config c, DataFlow::Node source | c.hasFlow(source, _) and sl = source.asExpr())
+  exists(DataFlow::Node source | Flow::flow(source, _) and sl = source.asExpr())
 }
 
 query predicate shouldBeSunkButIsnt(ShouldBeSunk src) { not isSunk(src) }

--- a/java/ql/test/kotlin/library-tests/super-method-calls/test.ql
+++ b/java/ql/test/kotlin/library-tests/super-method-calls/test.ql
@@ -1,18 +1,18 @@
 import java
 import semmle.code.java.dataflow.DataFlow
 
-class Config extends DataFlow::Configuration {
-  Config() { this = "abc" }
-
-  override predicate isSource(DataFlow::Node n) {
+module Config implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node n) {
     n.asExpr().(MethodAccess).getMethod().getName() = "source"
   }
 
-  override predicate isSink(DataFlow::Node n) {
+  predicate isSink(DataFlow::Node n) {
     n.asExpr().(Argument).getCall().getCallee().getName() = "sink"
   }
 }
 
-from Config c, DataFlow::Node n1, DataFlow::Node n2
-where c.hasFlow(n1, n2)
+module Flow = DataFlow::Global<Config>;
+
+from DataFlow::Node n1, DataFlow::Node n2
+where Flow::flow(n1, n2)
 select n1, n2

--- a/java/ql/test/kotlin/library-tests/vararg/dataflow.ql
+++ b/java/ql/test/kotlin/library-tests/vararg/dataflow.ql
@@ -2,11 +2,11 @@ import java
 import semmle.code.java.dataflow.DataFlow
 
 module Config implements DataFlow::ConfigSig {
- predicate isSource(DataFlow::Node n) {
+  predicate isSource(DataFlow::Node n) {
     n.asExpr().(CompileTimeConstantExpr).getEnclosingCallable().fromSource()
   }
 
- predicate isSink(DataFlow::Node n) {
+  predicate isSink(DataFlow::Node n) {
     n.asExpr() = any(MethodAccess ma | ma.getMethod().getName() = "sink").getAnArgument()
   }
 }

--- a/java/ql/test/kotlin/library-tests/vararg/dataflow.ql
+++ b/java/ql/test/kotlin/library-tests/vararg/dataflow.ql
@@ -1,18 +1,18 @@
 import java
 import semmle.code.java.dataflow.DataFlow
 
-class Config extends DataFlow::Configuration {
-  Config() { this = "varargs-dataflow-test" }
-
-  override predicate isSource(DataFlow::Node n) {
+module Config implements DataFlow::ConfigSig {
+ predicate isSource(DataFlow::Node n) {
     n.asExpr().(CompileTimeConstantExpr).getEnclosingCallable().fromSource()
   }
 
-  override predicate isSink(DataFlow::Node n) {
+ predicate isSink(DataFlow::Node n) {
     n.asExpr() = any(MethodAccess ma | ma.getMethod().getName() = "sink").getAnArgument()
   }
 }
 
-from DataFlow::Node source, DataFlow::Node sink, Config c
-where c.hasFlow(source, sink)
+module Flow = DataFlow::Global<Config>;
+
+from DataFlow::Node source, DataFlow::Node sink
+where Flow::flow(source, sink)
 select source, sink

--- a/java/ql/test/library-tests/dataflow/call-sensitivity/flow.ql
+++ b/java/ql/test/library-tests/dataflow/call-sensitivity/flow.ql
@@ -4,14 +4,12 @@
 
 import java
 import semmle.code.java.dataflow.DataFlow
-import DataFlow::PathGraph
+import Flow::PathGraph
 
-class Conf extends DataFlow::Configuration {
-  Conf() { this = "CallSensitiveFlowConf" }
+module Config implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node src) { src.asExpr() instanceof ClassInstanceExpr }
 
-  override predicate isSource(DataFlow::Node src) { src.asExpr() instanceof ClassInstanceExpr }
-
-  override predicate isSink(DataFlow::Node sink) {
+  predicate isSink(DataFlow::Node sink) {
     exists(MethodAccess ma |
       ma.getMethod().hasName("sink") and
       ma.getAnArgument() = sink.asExpr()
@@ -19,6 +17,8 @@ class Conf extends DataFlow::Configuration {
   }
 }
 
-from DataFlow::PathNode source, DataFlow::PathNode sink, Conf conf
-where conf.hasFlowPath(source, sink)
+module Flow = DataFlow::Global<Config>;
+
+from Flow::PathNode source, Flow::PathNode sink
+where Flow::flowPath(source, sink)
 select source, source, sink, "$@", sink, sink.toString()

--- a/java/ql/test/library-tests/dataflow/capture/test.ql
+++ b/java/ql/test/library-tests/dataflow/capture/test.ql
@@ -1,17 +1,16 @@
 import java
 import semmle.code.java.dataflow.DataFlow
-import DataFlow
 
 StringLiteral src() { result.getCompilationUnit().fromSource() }
 
-class Conf extends Configuration {
-  Conf() { this = "qq capture" }
+module Config implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node n) { n.asExpr() = src() }
 
-  override predicate isSource(Node n) { n.asExpr() = src() }
-
-  override predicate isSink(Node n) { any() }
+  predicate isSink(DataFlow::Node n) { any() }
 }
 
-from Node src, Node sink, Conf conf
-where conf.hasFlow(src, sink)
+module Flow = DataFlow::Global<Config>;
+
+from DataFlow::Node src, DataFlow::Node sink
+where Flow::flow(src, sink)
 select src, sink

--- a/java/ql/test/library-tests/dataflow/collections/flow.ql
+++ b/java/ql/test/library-tests/dataflow/collections/flow.ql
@@ -1,10 +1,8 @@
 import java
 import semmle.code.java.dataflow.TaintTracking
 
-class Conf extends TaintTracking::Configuration {
-  Conf() { this = "conf" }
-
-  override predicate isSource(DataFlow::Node src) {
+module Config implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node src) {
     (
       src.asExpr().(VarAccess).getVariable().hasName("tainted")
       or
@@ -14,7 +12,7 @@ class Conf extends TaintTracking::Configuration {
     )
   }
 
-  override predicate isSink(DataFlow::Node sink) {
+  predicate isSink(DataFlow::Node sink) {
     exists(MethodAccess ma |
       sink.asExpr() = ma.getAnArgument() and
       ma.getMethod().hasName("sink")
@@ -25,6 +23,8 @@ class Conf extends TaintTracking::Configuration {
   }
 }
 
-from Conf c, DataFlow::Node src, DataFlow::Node sink
-where c.hasFlow(src, sink)
+module Flow = TaintTracking::Global<Config>;
+
+from DataFlow::Node src, DataFlow::Node sink
+where Flow::flow(src, sink)
 select src, sink

--- a/java/ql/test/library-tests/dataflow/fields/flow.ql
+++ b/java/ql/test/library-tests/dataflow/fields/flow.ql
@@ -1,12 +1,10 @@
 import java
 import semmle.code.java.dataflow.DataFlow
 
-class Conf extends DataFlow::Configuration {
-  Conf() { this = "FieldFlowConf" }
+module Config implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node src) { src.asExpr() instanceof ClassInstanceExpr }
 
-  override predicate isSource(DataFlow::Node src) { src.asExpr() instanceof ClassInstanceExpr }
-
-  override predicate isSink(DataFlow::Node sink) {
+  predicate isSink(DataFlow::Node sink) {
     exists(MethodAccess ma |
       ma.getMethod().hasName("sink") and
       ma.getAnArgument() = sink.asExpr()
@@ -14,6 +12,8 @@ class Conf extends DataFlow::Configuration {
   }
 }
 
-from DataFlow::Node src, DataFlow::Node sink, Conf conf
-where conf.hasFlow(src, sink)
+module Flow = DataFlow::Global<Config>;
+
+from DataFlow::Node src, DataFlow::Node sink
+where Flow::flow(src, sink)
 select src, sink

--- a/java/ql/test/library-tests/dataflow/lambda/flow.ql
+++ b/java/ql/test/library-tests/dataflow/lambda/flow.ql
@@ -1,16 +1,14 @@
 import java
 import semmle.code.java.dataflow.TaintTracking
 
-class Conf extends TaintTracking::Configuration {
-  Conf() { this = "qltest lambda" }
-
-  override predicate isSource(DataFlow::Node src) {
+module Config implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node src) {
     src.asExpr().(VarAccess).getVariable().hasName("args")
     or
     src.asExpr().(MethodAccess).getMethod().hasName("source")
   }
 
-  override predicate isSink(DataFlow::Node sink) {
+  predicate isSink(DataFlow::Node sink) {
     sink.asExpr().(Argument).getCall() =
       any(MethodAccess ma |
         ma.getMethod().hasName("exec") and
@@ -19,6 +17,8 @@ class Conf extends TaintTracking::Configuration {
   }
 }
 
-from DataFlow::Node src, DataFlow::Node sink, Conf c
-where c.hasFlow(src, sink)
+module Flow = TaintTracking::Global<Config>;
+
+from DataFlow::Node src, DataFlow::Node sink
+where Flow::flow(src, sink)
 select src, sink

--- a/java/ql/test/library-tests/dataflow/local-flow/flow.ql
+++ b/java/ql/test/library-tests/dataflow/local-flow/flow.ql
@@ -1,14 +1,12 @@
 import java
 import semmle.code.java.dataflow.DataFlow
 
-class Conf extends DataFlow::Configuration {
-  Conf() { this = "conf" }
-
-  override predicate isSource(DataFlow::Node src) {
+module Config implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node src) {
     src.asExpr().(MethodAccess).getMethod().hasName("source")
   }
 
-  override predicate isSink(DataFlow::Node sink) {
+  predicate isSink(DataFlow::Node sink) {
     exists(MethodAccess ma |
       sink.asExpr() = ma.getAnArgument() and
       ma.getMethod().hasName("sink")
@@ -16,6 +14,8 @@ class Conf extends DataFlow::Configuration {
   }
 }
 
-from Conf c, DataFlow::Node src, DataFlow::Node sink
-where c.hasFlow(src, sink)
+module Flow = DataFlow::Global<Config>;
+
+from DataFlow::Node src, DataFlow::Node sink
+where Flow::flow(src, sink)
 select src, sink

--- a/java/ql/test/library-tests/dataflow/null/testnullflow.ql
+++ b/java/ql/test/library-tests/dataflow/null/testnullflow.ql
@@ -1,14 +1,14 @@
 import java
 import semmle.code.java.dataflow.DataFlow
 
-class Conf extends DataFlow::Configuration {
-  Conf() { this = "qqconf" }
+module Config implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node n) { n.asExpr() instanceof NullLiteral }
 
-  override predicate isSource(DataFlow::Node n) { n.asExpr() instanceof NullLiteral }
-
-  override predicate isSink(DataFlow::Node n) { any() }
+  predicate isSink(DataFlow::Node n) { any() }
 }
 
-from Conf conf, DataFlow::Node src, DataFlow::Node sink
-where conf.hasFlow(src, sink)
+module Flow = DataFlow::Global<Config>;
+
+from DataFlow::Node src, DataFlow::Node sink
+where Flow::flow(src, sink)
 select src, sink

--- a/java/ql/test/library-tests/dataflow/records/test.ql
+++ b/java/ql/test/library-tests/dataflow/records/test.ql
@@ -1,15 +1,14 @@
 import java
 import semmle.code.java.dataflow.DataFlow
-import DataFlow
 
-class Conf extends Configuration {
-  Conf() { this = "qqconf" }
+module Config implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node n) { n.asExpr().(MethodAccess).getMethod().hasName("source") }
 
-  override predicate isSource(Node n) { n.asExpr().(MethodAccess).getMethod().hasName("source") }
-
-  override predicate isSink(Node n) { n.asExpr().(Argument).getCall().getCallee().hasName("sink") }
+  predicate isSink(DataFlow::Node n) { n.asExpr().(Argument).getCall().getCallee().hasName("sink") }
 }
 
-from Conf conf, Node src, Node sink
-where conf.hasFlow(src, sink)
+module Flow = DataFlow::Global<Config>;
+
+from DataFlow::Node src, DataFlow::Node sink
+where Flow::flow(src, sink)
 select src, sink

--- a/java/ql/test/library-tests/dataflow/switchexpr/switchexprflow.ql
+++ b/java/ql/test/library-tests/dataflow/switchexpr/switchexprflow.ql
@@ -1,15 +1,14 @@
 import java
 import semmle.code.java.dataflow.DataFlow
-import DataFlow
 
-class Conf extends Configuration {
-  Conf() { this = "qqconf" }
+module Config implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node n) { n.asExpr().(MethodAccess).getMethod().hasName("source") }
 
-  override predicate isSource(Node n) { n.asExpr().(MethodAccess).getMethod().hasName("source") }
-
-  override predicate isSink(Node n) { any() }
+  predicate isSink(DataFlow::Node n) { any() }
 }
 
-from Conf c, Node sink
-where c.hasFlow(_, sink)
+module Flow = DataFlow::Global<Config>;
+
+from DataFlow::Node sink
+where Flow::flowTo(sink)
 select sink

--- a/java/ql/test/library-tests/dataflow/taint-ioutils/dataFlow.ql
+++ b/java/ql/test/library-tests/dataflow/taint-ioutils/dataFlow.ql
@@ -2,14 +2,14 @@ import semmle.code.java.dataflow.DataFlow
 import semmle.code.java.dataflow.TaintTracking
 import semmle.code.java.dataflow.FlowSources
 
-class Conf extends TaintTracking::Configuration {
-  Conf() { this = "qltest:dataflow:ioutils" }
+module Config implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { source instanceof UserInput }
 
-  override predicate isSource(DataFlow::Node source) { source instanceof UserInput }
-
-  override predicate isSink(DataFlow::Node sink) { any() }
+  predicate isSink(DataFlow::Node sink) { any() }
 }
 
-from UserInput u, DataFlow::Node e, Conf config
-where config.hasFlow(u, e) and e.getEnclosingCallable().hasName("ioutils")
+module Flow = TaintTracking::Global<Config>;
+
+from UserInput u, DataFlow::Node e
+where Flow::flow(u, e) and e.getEnclosingCallable().hasName("ioutils")
 select e

--- a/java/ql/test/library-tests/dataflow/taint/test.ql
+++ b/java/ql/test/library-tests/dataflow/taint/test.ql
@@ -1,18 +1,14 @@
 import java
 import semmle.code.java.dataflow.TaintTracking
 
-class Conf extends TaintTracking::Configuration {
-  Conf() { this = "qqconf" }
+module Config implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node n) { n.asExpr().(MethodAccess).getMethod().hasName("taint") }
 
-  override predicate isSource(DataFlow::Node n) {
-    n.asExpr().(MethodAccess).getMethod().hasName("taint")
-  }
-
-  override predicate isSink(DataFlow::Node n) {
-    n.asExpr().(Argument).getCall().getCallee().hasName("sink")
-  }
+  predicate isSink(DataFlow::Node n) { n.asExpr().(Argument).getCall().getCallee().hasName("sink") }
 }
 
-from DataFlow::Node src, DataFlow::Node sink, Conf conf
-where conf.hasFlow(src, sink)
+module Flow = TaintTracking::Global<Config>;
+
+from DataFlow::Node src, DataFlow::Node sink
+where Flow::flow(src, sink)
 select src, sink

--- a/java/ql/test/library-tests/dataflow/taintgettersetter/taintgettersetter.ql
+++ b/java/ql/test/library-tests/dataflow/taintgettersetter/taintgettersetter.ql
@@ -1,25 +1,24 @@
 import java
 import semmle.code.java.dataflow.DataFlow
-import DataFlow
 
-class Conf extends Configuration {
-  Conf() { this = "taintgettersetter" }
+module Config implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node n) { n.asExpr().(MethodAccess).getMethod().hasName("taint") }
 
-  override predicate isSource(Node n) { n.asExpr().(MethodAccess).getMethod().hasName("taint") }
-
-  override predicate isSink(Node n) {
+  predicate isSink(DataFlow::Node n) {
     exists(MethodAccess sink |
       sink.getAnArgument() = n.asExpr() and sink.getMethod().hasName("sink")
     )
   }
 
-  override predicate isAdditionalFlowStep(Node n1, Node n2) {
+  predicate isAdditionalFlowStep(DataFlow::Node n1, DataFlow::Node n2) {
     exists(AddExpr add |
       add.getType() instanceof TypeString and add.getAnOperand() = n1.asExpr() and n2.asExpr() = add
     )
   }
 }
 
-from Node src, Node sink, Conf conf
-where conf.hasFlow(src, sink)
+module Flow = DataFlow::Global<Config>;
+
+from DataFlow::Node src, DataFlow::Node sink
+where Flow::flow(src, sink)
 select src, sink

--- a/java/ql/test/library-tests/dataflow/taintreturn/taintreturn.ql
+++ b/java/ql/test/library-tests/dataflow/taintreturn/taintreturn.ql
@@ -1,6 +1,5 @@
 import java
 import semmle.code.java.dataflow.TaintTracking
-import DataFlow
 
 predicate step(Expr e1, Expr e2) {
   exists(MethodAccess ma |
@@ -17,28 +16,35 @@ predicate isSink0(Expr sink) {
   )
 }
 
-class Conf1 extends Configuration {
-  Conf1() { this = "testconf1" }
+module FirstConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node n) { n.asExpr().(MethodAccess).getMethod().hasName("src") }
 
-  override predicate isSource(Node n) { n.asExpr().(MethodAccess).getMethod().hasName("src") }
+  predicate isSink(DataFlow::Node n) { any() }
 
-  override predicate isSink(Node n) { any() }
-
-  override predicate isAdditionalFlowStep(Node n1, Node n2) { step(n1.asExpr(), n2.asExpr()) }
+  predicate isAdditionalFlowStep(DataFlow::Node n1, DataFlow::Node n2) {
+    step(n1.asExpr(), n2.asExpr())
+  }
 }
 
-class Conf2 extends Configuration {
-  Conf2() { this = "testconf2" }
+module FirstFlow = DataFlow::Global<FirstConfig>;
 
-  override predicate isSource(Node n) { n.asExpr().(MethodAccess).getMethod().hasName("src") }
+module SecondConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node n) { n.asExpr().(MethodAccess).getMethod().hasName("src") }
 
-  override predicate isSink(Node n) { isSink0(n.asExpr()) }
+  predicate isSink(DataFlow::Node n) { isSink0(n.asExpr()) }
 
-  override predicate isAdditionalFlowStep(Node n1, Node n2) { step(n1.asExpr(), n2.asExpr()) }
+  predicate isAdditionalFlowStep(DataFlow::Node n1, DataFlow::Node n2) {
+    step(n1.asExpr(), n2.asExpr())
+  }
 }
+
+module SecondFlow = DataFlow::Global<SecondConfig>;
 
 from int i1, int i2
 where
-  i1 = count(Node src, Node sink, Conf1 c | c.hasFlow(src, sink) and isSink0(sink.asExpr())) and
-  i2 = count(Node src, Node sink, Conf2 c | c.hasFlow(src, sink))
+  i1 =
+    count(DataFlow::Node src, DataFlow::Node sink |
+      FirstFlow::flow(src, sink) and isSink0(sink.asExpr())
+    ) and
+  i2 = count(DataFlow::Node src, DataFlow::Node sink | SecondFlow::flow(src, sink))
 select i1, i2

--- a/java/ql/test/library-tests/dataflow/taintsources/local.ql
+++ b/java/ql/test/library-tests/dataflow/taintsources/local.ql
@@ -10,21 +10,21 @@ predicate isTestSink(DataFlow::Node n) {
   exists(MethodAccess ma | ma.getMethod().hasName("sink") | n.asExpr() = ma.getAnArgument())
 }
 
-class LocalValueConf extends DataFlow::Configuration {
-  LocalValueConf() { this = "LocalValueConf" }
+module LocalValueConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node n) { n instanceof LocalSource }
 
-  override predicate isSource(DataFlow::Node n) { n instanceof LocalSource }
-
-  override predicate isSink(DataFlow::Node n) { isTestSink(n) }
+  predicate isSink(DataFlow::Node n) { isTestSink(n) }
 }
 
-class LocalTaintConf extends TaintTracking::Configuration {
-  LocalTaintConf() { this = "LocalTaintConf" }
+module LocalValueFlow = DataFlow::Global<LocalValueConfig>;
 
-  override predicate isSource(DataFlow::Node n) { n instanceof LocalSource }
+module LocalTaintConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node n) { n instanceof LocalSource }
 
-  override predicate isSink(DataFlow::Node n) { isTestSink(n) }
+  predicate isSink(DataFlow::Node n) { isTestSink(n) }
 }
+
+module LocalTaintFlow = TaintTracking::Global<LocalTaintConfig>;
 
 class LocalFlowTest extends InlineExpectationsTest {
   LocalFlowTest() { this = "LocalFlowTest" }
@@ -33,7 +33,7 @@ class LocalFlowTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "hasLocalValueFlow" and
-    exists(DataFlow::Node sink | any(LocalValueConf c).hasFlowTo(sink) |
+    exists(DataFlow::Node sink | LocalValueFlow::flowTo(sink) |
       sink.getLocation() = location and
       element = sink.toString() and
       value = ""
@@ -41,7 +41,7 @@ class LocalFlowTest extends InlineExpectationsTest {
     or
     tag = "hasLocalTaintFlow" and
     exists(DataFlow::Node src, DataFlow::Node sink |
-      any(LocalTaintConf c).hasFlow(src, sink) and not any(LocalValueConf c).hasFlow(src, sink)
+      LocalTaintFlow::flow(src, sink) and not LocalValueFlow::flow(src, sink)
     |
       sink.getLocation() = location and
       element = sink.toString() and

--- a/java/ql/test/library-tests/dataflow/taintsources/remote.ql
+++ b/java/ql/test/library-tests/dataflow/taintsources/remote.ql
@@ -6,21 +6,21 @@ predicate isTestSink(DataFlow::Node n) {
   exists(MethodAccess ma | ma.getMethod().hasName("sink") | n.asExpr() = ma.getAnArgument())
 }
 
-class RemoteValueConf extends DataFlow::Configuration {
-  RemoteValueConf() { this = "RemoteValueConf" }
+module RemoteValueConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node n) { n instanceof RemoteFlowSource }
 
-  override predicate isSource(DataFlow::Node n) { n instanceof RemoteFlowSource }
-
-  override predicate isSink(DataFlow::Node n) { isTestSink(n) }
+  predicate isSink(DataFlow::Node n) { isTestSink(n) }
 }
 
-class RemoteTaintConf extends TaintTracking::Configuration {
-  RemoteTaintConf() { this = "RemoteTaintConf" }
+module RemoteValueFlow = DataFlow::Global<RemoteValueConfig>;
 
-  override predicate isSource(DataFlow::Node n) { n instanceof RemoteFlowSource }
+module RemoteTaintConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node n) { n instanceof RemoteFlowSource }
 
-  override predicate isSink(DataFlow::Node n) { isTestSink(n) }
+  predicate isSink(DataFlow::Node n) { isTestSink(n) }
 }
+
+module RemoteTaintFlow = TaintTracking::Global<RemoteTaintConfig>;
 
 class RemoteFlowTest extends InlineExpectationsTest {
   RemoteFlowTest() { this = "RemoteFlowTest" }
@@ -29,7 +29,7 @@ class RemoteFlowTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "hasRemoteValueFlow" and
-    exists(DataFlow::Node sink | any(RemoteValueConf c).hasFlowTo(sink) |
+    exists(DataFlow::Node sink | RemoteValueFlow::flowTo(sink) |
       sink.getLocation() = location and
       element = sink.toString() and
       value = ""
@@ -37,7 +37,7 @@ class RemoteFlowTest extends InlineExpectationsTest {
     or
     tag = "hasRemoteTaintFlow" and
     exists(DataFlow::Node src, DataFlow::Node sink |
-      any(RemoteTaintConf c).hasFlow(src, sink) and not any(RemoteValueConf c).hasFlow(src, sink)
+      RemoteTaintFlow::flow(src, sink) and not RemoteValueFlow::flow(src, sink)
     |
       sink.getLocation() = location and
       element = sink.toString() and

--- a/java/ql/test/library-tests/dataflow/this-flow/this-flow.ql
+++ b/java/ql/test/library-tests/dataflow/this-flow/this-flow.ql
@@ -1,19 +1,18 @@
 import java
 import semmle.code.java.dataflow.DataFlow
-import DataFlow
 
-class ThisFlowConfig extends Configuration {
-  ThisFlowConfig() { this = "ThisFlowConfig" }
-
-  override predicate isSource(Node src) {
-    exists(PostUpdateNode cie | cie.asExpr() instanceof ClassInstanceExpr |
+module ThisFlowConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node src) {
+    exists(DataFlow::PostUpdateNode cie | cie.asExpr() instanceof ClassInstanceExpr |
       cie.getPreUpdateNode() = src or cie = src
     )
   }
 
-  override predicate isSink(Node sink) { any() }
+  predicate isSink(DataFlow::Node sink) { any() }
 }
 
-from Node n, ThisFlowConfig conf
-where conf.hasFlow(_, n)
+module ThisFlow = DataFlow::Global<ThisFlowConfig>;
+
+from DataFlow::Node n
+where ThisFlow::flowTo(n)
 select n

--- a/java/ql/test/library-tests/dataflow/typepruning/test.ql
+++ b/java/ql/test/library-tests/dataflow/typepruning/test.ql
@@ -2,18 +2,16 @@ import java
 import semmle.code.java.dataflow.DataFlow
 import DataFlow
 
-class Conf extends Configuration {
-  Conf() { this = "test types" }
+module Config implements DataFlow::ConfigSig {
+  predicate isSource(Node n) { n.asExpr().(MethodAccess).getMethod().hasName("source") }
 
-  override predicate isSource(Node n) { n.asExpr().(MethodAccess).getMethod().hasName("source") }
-
-  override predicate isSink(Node n) {
+  predicate isSink(Node n) {
     exists(MethodAccess sink |
       sink.getAnArgument() = n.asExpr() and sink.getMethod().hasName("sink")
     )
   }
 
-  override predicate isAdditionalFlowStep(Node n1, Node n2) {
+  predicate isAdditionalFlowStep(Node n1, Node n2) {
     exists(MethodAccess ma |
       ma.getMethod().hasName("customStep") and
       ma.getAnArgument() = n1.asExpr() and
@@ -22,6 +20,8 @@ class Conf extends Configuration {
   }
 }
 
-from Node src, Node sink, Conf conf
-where conf.hasFlow(src, sink)
+module Flow = DataFlow::Global<Config>;
+
+from Node src, Node sink
+where Flow::flow(src, sink)
 select src, sink, sink.getEnclosingCallable()

--- a/java/ql/test/library-tests/frameworks/android/content-provider/test.ql
+++ b/java/ql/test/library-tests/frameworks/android/content-provider/test.ql
@@ -2,14 +2,20 @@ import java
 import semmle.code.java.dataflow.FlowSources
 import TestUtilities.InlineFlowTest
 
-class EnableLegacy extends EnableLegacyConfiguration {
-  EnableLegacy() { exists(this) }
+module ProviderTaintFlowConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node n) { n instanceof RemoteFlowSource }
+
+  predicate isSink(DataFlow::Node n) { DefaultFlowConfig::isSink(n) }
+
+  int fieldFlowBranchLimit() { result = DefaultFlowConfig::fieldFlowBranchLimit() }
 }
 
-class ProviderTaintFlowConf extends DefaultTaintFlowConf {
-  override predicate isSource(DataFlow::Node n) { n instanceof RemoteFlowSource }
-}
+module ProviderTaintFlow = TaintTracking::Global<ProviderTaintFlowConfig>;
 
 class ProviderInlineFlowTest extends InlineFlowTest {
-  override DataFlow::Configuration getValueFlowConfig() { none() }
+  override predicate hasValueFlow(DataFlow::Node src, DataFlow::Node sink) { none() }
+
+  override predicate hasTaintFlow(DataFlow::Node src, DataFlow::Node sink) {
+    ProviderTaintFlow::flow(src, sink)
+  }
 }

--- a/java/ql/test/library-tests/frameworks/android/external-storage/test.ql
+++ b/java/ql/test/library-tests/frameworks/android/external-storage/test.ql
@@ -3,22 +3,18 @@ import semmle.code.java.dataflow.DataFlow
 import semmle.code.java.dataflow.FlowSources
 import TestUtilities.InlineFlowTest
 
-class EnableLegacy extends EnableLegacyConfiguration {
-  EnableLegacy() { exists(this) }
-}
+module Config implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node src) { src instanceof RemoteFlowSource }
 
-class Conf extends TaintTracking::Configuration {
-  Conf() { this = "test:AndroidExternalFlowConf" }
-
-  override predicate isSource(DataFlow::Node src) { src instanceof RemoteFlowSource }
-
-  override predicate isSink(DataFlow::Node sink) {
+  predicate isSink(DataFlow::Node sink) {
     sink.asExpr().(Argument).getCall().getCallee().hasName("sink")
   }
 }
 
-class ExternalStorageTest extends InlineFlowTest {
-  override DataFlow::Configuration getValueFlowConfig() { none() }
+module Flow = TaintTracking::Global<Config>;
 
-  override DataFlow::Configuration getTaintFlowConfig() { result instanceof Conf }
+class ExternalStorageTest extends InlineFlowTest {
+  override predicate hasValueFlow(DataFlow::Node src, DataFlow::Node sink) { none() }
+
+  override predicate hasTaintFlow(DataFlow::Node src, DataFlow::Node sink) { Flow::flow(src, sink) }
 }

--- a/java/ql/test/library-tests/frameworks/android/sources/OnActivityResultSourceTest.ql
+++ b/java/ql/test/library-tests/frameworks/android/sources/OnActivityResultSourceTest.ql
@@ -2,14 +2,20 @@ import java
 import semmle.code.java.dataflow.FlowSources
 import TestUtilities.InlineFlowTest
 
-class EnableLegacy extends EnableLegacyConfiguration {
-  EnableLegacy() { exists(this) }
+module SourceValueFlowConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node src) { src instanceof RemoteFlowSource }
+
+  predicate isSink(DataFlow::Node sink) { DefaultFlowConfig::isSink(sink) }
+
+  int fieldFlowBranchLimit() { result = DefaultFlowConfig::fieldFlowBranchLimit() }
 }
 
-class SourceValueFlowConf extends DefaultValueFlowConf {
-  override predicate isSource(DataFlow::Node src) { src instanceof RemoteFlowSource }
-}
+module SourceValueFlow = DataFlow::Global<SourceValueFlowConfig>;
 
 class SourceInlineFlowTest extends InlineFlowTest {
-  override DataFlow::Configuration getTaintFlowConfig() { none() }
+  override predicate hasValueFlow(DataFlow::Node src, DataFlow::Node sink) {
+    SourceValueFlow::flow(src, sink)
+  }
+
+  override predicate hasTaintFlow(DataFlow::Node src, DataFlow::Node sink) { none() }
 }

--- a/java/ql/test/library-tests/frameworks/android/taint-database/flowSteps.ql
+++ b/java/ql/test/library-tests/frameworks/android/taint-database/flowSteps.ql
@@ -4,15 +4,15 @@ import semmle.code.java.dataflow.FlowSources
 import semmle.code.java.security.QueryInjection
 import TestUtilities.InlineExpectationsTest
 
-class Conf extends TaintTracking::Configuration {
-  Conf() { this = "qltest:dataflow:android::flow" }
-
-  override predicate isSource(DataFlow::Node source) {
+module Config implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) {
     source.asExpr().(MethodAccess).getMethod().hasName("taint")
   }
 
-  override predicate isSink(DataFlow::Node sink) { sink.asExpr() = any(ReturnStmt r).getResult() }
+  predicate isSink(DataFlow::Node sink) { sink.asExpr() = any(ReturnStmt r).getResult() }
 }
+
+module Flow = TaintTracking::Global<Config>;
 
 class FlowStepTest extends InlineExpectationsTest {
   FlowStepTest() { this = "FlowStepTest" }
@@ -22,8 +22,7 @@ class FlowStepTest extends InlineExpectationsTest {
   override predicate hasActualResult(Location l, string element, string tag, string value) {
     tag = "taintReachesReturn" and
     value = "" and
-    exists(Conf conf, DataFlow::Node source |
-      conf.hasFlow(source, _) and
+    exists(DataFlow::Node source | Flow::flow(source, _) |
       l = source.getLocation() and
       element = source.toString()
     )

--- a/java/ql/test/library-tests/frameworks/android/taint-database/sinks.ql
+++ b/java/ql/test/library-tests/frameworks/android/taint-database/sinks.ql
@@ -4,15 +4,15 @@ import semmle.code.java.dataflow.FlowSources
 import semmle.code.java.security.QueryInjection
 import TestUtilities.InlineExpectationsTest
 
-class Conf extends TaintTracking::Configuration {
-  Conf() { this = "qltest:dataflow:android::flow" }
-
-  override predicate isSource(DataFlow::Node source) {
+module Config implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) {
     source.asExpr().(MethodAccess).getMethod().hasName("taint")
   }
 
-  override predicate isSink(DataFlow::Node sink) { sink instanceof QueryInjectionSink }
+  predicate isSink(DataFlow::Node sink) { sink instanceof QueryInjectionSink }
 }
+
+module Flow = TaintTracking::Global<Config>;
 
 class SinkTest extends InlineExpectationsTest {
   SinkTest() { this = "SinkTest" }
@@ -22,8 +22,7 @@ class SinkTest extends InlineExpectationsTest {
   override predicate hasActualResult(Location l, string element, string tag, string value) {
     tag = "taintReachesSink" and
     value = "" and
-    exists(Conf conf, DataFlow::Node source |
-      conf.hasFlow(source, _) and
+    exists(DataFlow::Node source | Flow::flow(source, _) |
       l = source.getLocation() and
       element = source.toString()
     )

--- a/java/ql/test/library-tests/frameworks/apache-http/flow.ql
+++ b/java/ql/test/library-tests/frameworks/apache-http/flow.ql
@@ -5,20 +5,14 @@ import semmle.code.java.security.XSS
 import semmle.code.java.security.UrlRedirect
 import TestUtilities.InlineFlowTest
 
-class EnableLegacy extends EnableLegacyConfiguration {
-  EnableLegacy() { exists(this) }
-}
-
-class Conf extends TaintTracking::Configuration {
-  Conf() { this = "qltest:frameworks:apache-http" }
-
-  override predicate isSource(DataFlow::Node n) {
+module Config implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node n) {
     n.asExpr().(MethodAccess).getMethod().hasName("taint")
     or
     n instanceof RemoteFlowSource
   }
 
-  override predicate isSink(DataFlow::Node n) {
+  predicate isSink(DataFlow::Node n) {
     exists(MethodAccess ma | ma.getMethod().hasName("sink") | n.asExpr() = ma.getAnArgument())
     or
     n instanceof XssSink
@@ -27,8 +21,10 @@ class Conf extends TaintTracking::Configuration {
   }
 }
 
-class HasFlowTest extends InlineFlowTest {
-  override DataFlow::Configuration getValueFlowConfig() { none() }
+module Flow = TaintTracking::Global<Config>;
 
-  override DataFlow::Configuration getTaintFlowConfig() { result = any(Conf c) }
+class HasFlowTest extends InlineFlowTest {
+  override predicate hasValueFlow(DataFlow::Node src, DataFlow::Node sink) { none() }
+
+  override predicate hasTaintFlow(DataFlow::Node src, DataFlow::Node sink) { Flow::flow(src, sink) }
 }

--- a/java/ql/test/library-tests/frameworks/guava/handwritten/flow.ql
+++ b/java/ql/test/library-tests/frameworks/guava/handwritten/flow.ql
@@ -2,31 +2,27 @@ import java
 import semmle.code.java.dataflow.TaintTracking
 import TestUtilities.InlineExpectationsTest
 
-class TaintFlowConf extends TaintTracking::Configuration {
-  TaintFlowConf() { this = "qltest:frameworks:guava-taint" }
+module TaintFlowConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node n) { n.asExpr().(MethodAccess).getMethod().hasName("taint") }
 
-  override predicate isSource(DataFlow::Node n) {
-    n.asExpr().(MethodAccess).getMethod().hasName("taint")
-  }
-
-  override predicate isSink(DataFlow::Node n) {
+  predicate isSink(DataFlow::Node n) {
     exists(MethodAccess ma | ma.getMethod().hasName("sink") | n.asExpr() = ma.getAnArgument())
   }
 }
 
-class ValueFlowConf extends DataFlow::Configuration {
-  ValueFlowConf() { this = "qltest:frameworks:guava-value" }
+module TaintFlow = TaintTracking::Global<TaintFlowConfig>;
 
-  override predicate isSource(DataFlow::Node n) {
-    n.asExpr().(MethodAccess).getMethod().hasName("taint")
-  }
+module ValueFlowConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node n) { n.asExpr().(MethodAccess).getMethod().hasName("taint") }
 
-  override predicate isSink(DataFlow::Node n) {
+  predicate isSink(DataFlow::Node n) {
     exists(MethodAccess ma | ma.getMethod().hasName("sink") | n.asExpr() = ma.getAnArgument())
   }
 
-  override int fieldFlowBranchLimit() { result = 100 }
+  int fieldFlowBranchLimit() { result = 100 }
 }
+
+module ValueFlow = DataFlow::Global<ValueFlowConfig>;
 
 class HasFlowTest extends InlineExpectationsTest {
   HasFlowTest() { this = "HasFlowTest" }
@@ -35,22 +31,20 @@ class HasFlowTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "numTaintFlow" and
-    exists(DataFlow::Node src, DataFlow::Node sink, TaintFlowConf tconf, int num |
-      tconf.hasFlow(src, sink)
-    |
-      not any(ValueFlowConf vconf).hasFlow(src, sink) and
+    exists(DataFlow::Node src, DataFlow::Node sink, int num | TaintFlow::flow(src, sink) |
+      not ValueFlow::flow(src, sink) and
       value = num.toString() and
       sink.getLocation() = location and
       element = sink.toString() and
-      num = strictcount(DataFlow::Node src2 | tconf.hasFlow(src2, sink))
+      num = strictcount(DataFlow::Node src2 | TaintFlow::flow(src2, sink))
     )
     or
     tag = "numValueFlow" and
-    exists(DataFlow::Node sink, ValueFlowConf vconf, int num | vconf.hasFlowTo(sink) |
+    exists(DataFlow::Node sink, int num | ValueFlow::flowTo(sink) |
       value = num.toString() and
       sink.getLocation() = location and
       element = sink.toString() and
-      num = strictcount(DataFlow::Node src2 | vconf.hasFlow(src2, sink))
+      num = strictcount(DataFlow::Node src2 | ValueFlow::flow(src2, sink))
     )
   }
 }

--- a/java/ql/test/library-tests/frameworks/guice/flow.ql
+++ b/java/ql/test/library-tests/frameworks/guice/flow.ql
@@ -2,12 +2,10 @@ import java
 import semmle.code.java.dataflow.FlowSources
 import semmle.code.java.dataflow.TaintTracking
 
-class Conf extends TaintTracking::Configuration {
-  Conf() { this = "conf" }
+module Config implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node src) { src instanceof RemoteFlowSource }
 
-  override predicate isSource(DataFlow::Node src) { src instanceof RemoteFlowSource }
-
-  override predicate isSink(DataFlow::Node sink) {
+  predicate isSink(DataFlow::Node sink) {
     exists(MethodAccess ma |
       sink.asExpr() = ma.getAnArgument() and
       ma.getMethod().hasName("sink")
@@ -16,6 +14,8 @@ class Conf extends TaintTracking::Configuration {
   }
 }
 
-from Conf c, DataFlow::Node src, DataFlow::Node sink
-where c.hasFlow(src, sink)
+module Flow = TaintTracking::Global<Config>;
+
+from DataFlow::Node src, DataFlow::Node sink
+where Flow::flow(src, sink)
 select src, sink

--- a/java/ql/test/library-tests/frameworks/jms/FlowTest.ql
+++ b/java/ql/test/library-tests/frameworks/jms/FlowTest.ql
@@ -2,17 +2,17 @@ import java
 import semmle.code.java.dataflow.FlowSources
 import TestUtilities.InlineExpectationsTest
 
-class TestConfig extends TaintTracking::Configuration {
-  TestConfig() { this = "TestConfig" }
+module TestConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
 
-  override predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
-
-  override predicate isSink(DataFlow::Node sink) {
+  predicate isSink(DataFlow::Node sink) {
     exists(MethodAccess call |
       call.getMethod().hasName("sink") and call.getArgument(0) = sink.asExpr()
     )
   }
 }
+
+module TestFlow = TaintTracking::Global<TestConfig>;
 
 class JmsFlowTest extends InlineExpectationsTest {
   JmsFlowTest() { this = "JmsFlowTest" }
@@ -21,7 +21,7 @@ class JmsFlowTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "tainted" and
-    exists(DataFlow::PathNode sink, TestConfig conf | conf.hasFlowPath(_, sink) |
+    exists(TestFlow::PathNode sink | TestFlow::flowPath(_, sink) |
       location = sink.getNode().getLocation() and element = sink.getNode().toString() and value = ""
     )
   }

--- a/java/ql/test/library-tests/frameworks/rabbitmq/FlowTest.ql
+++ b/java/ql/test/library-tests/frameworks/rabbitmq/FlowTest.ql
@@ -3,22 +3,18 @@ import semmle.code.java.dataflow.TaintTracking
 import semmle.code.java.dataflow.FlowSources
 import TestUtilities.InlineFlowTest
 
-class EnableLegacy extends EnableLegacyConfiguration {
-  EnableLegacy() { exists(this) }
-}
+module Config implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node node) { node instanceof RemoteFlowSource }
 
-class Conf extends TaintTracking::Configuration {
-  Conf() { this = "qltest:frameworks:rabbitmq" }
-
-  override predicate isSource(DataFlow::Node node) { node instanceof RemoteFlowSource }
-
-  override predicate isSink(DataFlow::Node node) {
+  predicate isSink(DataFlow::Node node) {
     exists(MethodAccess ma | ma.getMethod().hasName("sink") | node.asExpr() = ma.getAnArgument())
   }
 }
 
-class HasFlowTest extends InlineFlowTest {
-  override DataFlow::Configuration getValueFlowConfig() { none() }
+module Flow = TaintTracking::Global<Config>;
 
-  override DataFlow::Configuration getTaintFlowConfig() { result = any(Conf c) }
+class HasFlowTest extends InlineFlowTest {
+  override predicate hasValueFlow(DataFlow::Node src, DataFlow::Node sink) { none() }
+
+  override predicate hasTaintFlow(DataFlow::Node src, DataFlow::Node sink) { Flow::flow(src, sink) }
 }

--- a/java/ql/test/library-tests/frameworks/ratpack/flow.ql
+++ b/java/ql/test/library-tests/frameworks/ratpack/flow.ql
@@ -1,7 +1,7 @@
 import java
 import semmle.code.java.dataflow.TaintTracking
 import semmle.code.java.dataflow.FlowSources
-import TestUtilities.InlineExpectationsTest
+import TestUtilities.InlineFlowTest
 
 module Config implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node n) {
@@ -17,17 +17,10 @@ module Config implements DataFlow::ConfigSig {
 
 module Flow = TaintTracking::Global<Config>;
 
-class HasFlowTest extends InlineExpectationsTest {
+class HasFlowTest extends InlineFlowTest {
   HasFlowTest() { this = "HasFlowTest" }
 
-  override string getARelevantTag() { result = "hasTaintFlow" }
+  override predicate hasValueFlow(DataFlow::Node src, DataFlow::Node sink) { none() }
 
-  override predicate hasActualResult(Location location, string element, string tag, string value) {
-    tag = "hasTaintFlow" and
-    exists(DataFlow::Node sink | Flow::flowTo(sink) |
-      sink.getLocation() = location and
-      element = sink.toString() and
-      value = ""
-    )
-  }
+  override predicate hasTaintFlow(DataFlow::Node src, DataFlow::Node sink) { Flow::flow(src, sink) }
 }

--- a/java/ql/test/library-tests/frameworks/spring/controller/test.ql
+++ b/java/ql/test/library-tests/frameworks/spring/controller/test.ql
@@ -2,20 +2,18 @@ import java
 import semmle.code.java.dataflow.FlowSources
 import TestUtilities.InlineFlowTest
 
-class EnableLegacy extends EnableLegacyConfiguration {
-  EnableLegacy() { exists(this) }
-}
+module ValueFlowConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
 
-class ValueFlowConf extends DataFlow::Configuration {
-  ValueFlowConf() { this = "ValueFlowConf" }
-
-  override predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
-
-  override predicate isSink(DataFlow::Node sink) {
+  predicate isSink(DataFlow::Node sink) {
     sink.asExpr().(Argument).getCall().getCallee().hasName("sink")
   }
 }
 
+module ValueFlow = DataFlow::Global<ValueFlowConfig>;
+
 class Test extends InlineFlowTest {
-  override DataFlow::Configuration getValueFlowConfig() { result = any(ValueFlowConf config) }
+  override predicate hasValueFlow(DataFlow::Node src, DataFlow::Node sink) {
+    ValueFlow::flow(src, sink)
+  }
 }

--- a/java/ql/test/query-tests/security/CWE-079/semmle/tests/XSS.ql
+++ b/java/ql/test/query-tests/security/CWE-079/semmle/tests/XSS.ql
@@ -1,22 +1,6 @@
 import java
-import semmle.code.java.dataflow.TaintTracking
-import semmle.code.java.dataflow.FlowSources
-import semmle.code.java.security.XSS
+import semmle.code.java.security.XssQuery
 import TestUtilities.InlineExpectationsTest
-
-module XssConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
-
-  predicate isSink(DataFlow::Node sink) { sink instanceof XssSink }
-
-  predicate isBarrier(DataFlow::Node node) { node instanceof XssSanitizer }
-
-  predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
-    any(XssAdditionalTaintStep s).step(node1, node2)
-  }
-}
-
-module XssFlow = TaintTracking::Global<XssConfig>;
 
 class XssTest extends InlineExpectationsTest {
   XssTest() { this = "XssTest" }

--- a/java/ql/test/query-tests/security/CWE-079/semmle/tests/XSS.ql
+++ b/java/ql/test/query-tests/security/CWE-079/semmle/tests/XSS.ql
@@ -1,21 +1,22 @@
 import java
+import semmle.code.java.dataflow.TaintTracking
 import semmle.code.java.dataflow.FlowSources
 import semmle.code.java.security.XSS
 import TestUtilities.InlineExpectationsTest
 
-class XssConfig extends TaintTracking::Configuration {
-  XssConfig() { this = "XSSConfig" }
+module XssConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
 
-  override predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSink(DataFlow::Node sink) { sink instanceof XssSink }
 
-  override predicate isSink(DataFlow::Node sink) { sink instanceof XssSink }
+  predicate isBarrier(DataFlow::Node node) { node instanceof XssSanitizer }
 
-  override predicate isSanitizer(DataFlow::Node node) { node instanceof XssSanitizer }
-
-  override predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) {
+  predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
     any(XssAdditionalTaintStep s).step(node1, node2)
   }
 }
+
+module XssFlow = TaintTracking::Global<XssConfig>;
 
 class XssTest extends InlineExpectationsTest {
   XssTest() { this = "XssTest" }
@@ -24,7 +25,7 @@ class XssTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "xss" and
-    exists(DataFlow::Node sink, XssConfig conf | conf.hasFlowTo(sink) |
+    exists(DataFlow::Node sink | XssFlow::flowTo(sink) |
       sink.getLocation() = location and
       element = sink.toString() and
       value = ""

--- a/java/ql/test/query-tests/security/CWE-089/semmle/examples/springjdbc.ql
+++ b/java/ql/test/query-tests/security/CWE-089/semmle/examples/springjdbc.ql
@@ -1,27 +1,13 @@
 import java
-import semmle.code.java.dataflow.TaintTracking
-import semmle.code.java.security.QueryInjection
+import semmle.code.java.dataflow.FlowSources
+import semmle.code.java.security.SqlInjectionQuery
 import TestUtilities.InlineExpectationsTest
 
-private module QueryInjectionFlowConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node src) {
-    src.asExpr() = any(MethodAccess ma | ma.getMethod().hasName("source"))
-  }
+private class SourceMethodSource extends RemoteFlowSource {
+  SourceMethodSource() { this.asExpr().(MethodAccess).getMethod().hasName("source") }
 
-  predicate isSink(DataFlow::Node sink) { sink instanceof QueryInjectionSink }
-
-  predicate isBarrier(DataFlow::Node node) {
-    node.getType() instanceof PrimitiveType or
-    node.getType() instanceof BoxedType or
-    node.getType() instanceof NumberType
-  }
-
-  predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
-    any(AdditionalQueryInjectionTaintStep s).step(node1, node2)
-  }
+  override string getSourceType() { result = "source" }
 }
-
-private module QueryInjectionFlow = TaintTracking::Global<QueryInjectionFlowConfig>;
 
 class HasFlowTest extends InlineExpectationsTest {
   HasFlowTest() { this = "HasFlowTest" }

--- a/java/ql/test/query-tests/security/CWE-643/XPathInjectionTest.ql
+++ b/java/ql/test/query-tests/security/CWE-643/XPathInjectionTest.ql
@@ -4,13 +4,13 @@ import semmle.code.java.dataflow.FlowSources
 import semmle.code.java.security.XPath
 import TestUtilities.InlineExpectationsTest
 
-class Conf extends TaintTracking::Configuration {
-  Conf() { this = "test:xml:xpathinjection" }
+module Config implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
 
-  override predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
-
-  override predicate isSink(DataFlow::Node sink) { sink instanceof XPathInjectionSink }
+  predicate isSink(DataFlow::Node sink) { sink instanceof XPathInjectionSink }
 }
+
+module Flow = TaintTracking::Global<Config>;
 
 class HasXPathInjectionTest extends InlineExpectationsTest {
   HasXPathInjectionTest() { this = "HasXPathInjectionTest" }
@@ -19,7 +19,7 @@ class HasXPathInjectionTest extends InlineExpectationsTest {
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "hasXPathInjection" and
-    exists(DataFlow::Node sink, Conf conf | conf.hasFlowTo(sink) |
+    exists(DataFlow::Node sink | Flow::flowTo(sink) |
       sink.getLocation() = location and
       element = sink.toString() and
       value = ""


### PR DESCRIPTION
Moves test cases under `java/ql/test` to the new dataflow api.