### PR TITLE
Java: update provenance of `Connection#nativeSQL` sink to "hq-manual"

### DIFF
--- a/java/ql/lib/ext/java.sql.model.yml
+++ b/java/ql/lib/ext/java.sql.model.yml
@@ -20,7 +20,7 @@ extensions:
       pack: codeql/java-all
       extensible: summaryModel
     data:
-      - ["java.sql", "Connection", True, "nativeSQL", "(String)", "", "Argument[0]", "ReturnValue", "taint", "manual"]
+      - ["java.sql", "Connection", True, "nativeSQL", "(String)", "", "Argument[0]", "ReturnValue", "taint", "hq-manual"]
       - ["java.sql", "PreparedStatement", True, "setString", "(int,String)", "", "Argument[1]", "Argument[this]", "value", "manual"]
       - ["java.sql", "ResultSet", True, "getString", "(String)", "", "Argument[this]", "ReturnValue", "taint", "manual"]
 


### PR DESCRIPTION
Now that https://github.com/github/codeql/pull/12595 has been merged, this PR updates the provenance of the `java.sql.Connection#nativeSQL` sink, which was originally added in https://github.com/github/codeql/pull/12110, to "hq-manual".