### PR TITLE
C++: Promote `cpp/redundant-null-check-simple` to Code Scanning

### DIFF
--- a/cpp/ql/src/Likely Bugs/RedundantNullCheckSimple.ql
+++ b/cpp/ql/src/Likely Bugs/RedundantNullCheckSimple.ql
@@ -3,23 +3,21 @@
  * @description Checking a pointer for nullness after dereferencing it is
  *              likely to be a sign that either the check can be removed, or
  *              it should be moved before the dereference.
- * @kind problem
+ * @kind path-problem
  * @problem.severity error
+ * @precision high
  * @id cpp/redundant-null-check-simple
  * @tags reliability
  *       correctness
  *       external/cwe/cwe-476
  */
 
-/*
- * Note: this query is not assigned a precision yet because we don't want it
- * to be included in query suites until its performance is well understood.
- */
-
 import cpp
 import semmle.code.cpp.ir.IR
 import semmle.code.cpp.ir.ValueNumbering
+import PathGraph
 
+/** An instruction that represents a null pointer. */
 class NullInstruction extends ConstantValueInstruction {
   NullInstruction() {
     this.getValue() = "0" and
@@ -27,6 +25,10 @@ class NullInstruction extends ConstantValueInstruction {
   }
 }
 
+/**
+ * Holds if `checked` is an instruction that is checked against a null value,
+ * and `bool` is the instruction that represents the result of the comparison
+ */
 predicate explicitNullTestOfInstruction(Instruction checked, Instruction bool) {
   bool =
     any(CompareInstruction cmp |
@@ -49,12 +51,153 @@ predicate explicitNullTestOfInstruction(Instruction checked, Instruction bool) {
     )
 }
 
-pragma[noinline]
+pragma[nomagic]
 predicate candidateResult(LoadInstruction checked, ValueNumber value, IRBlock dominator) {
   explicitNullTestOfInstruction(checked, _) and
   not checked.getAst().isInMacroExpansion() and
   value.getAnInstruction() = checked and
   dominator.dominates(checked.getBlock())
+}
+
+/**
+ * This module constructs a pretty edges relation out of the results produced by
+ * the `candidateResult` predicate: We create a path using the instruction successor-
+ * relation from the dereference to the null check. To avoid generating very long paths,
+ * we compact the edges relation so that `edges(i1, i2)` only holds when `i2` is the first
+ * instruction that is control-flow reachable from `i1` with the same global value number
+ * as `i1`.
+ */
+module PathGraph {
+  /**
+   * Holds if `deref` is a load instruction that loads a value
+   * from the address `address`. This predicate is restricted to
+   * those pairs for which we will end up reporting a result.
+   */
+  private predicate isSource(Instruction address, LoadInstruction deref) {
+    exists(ValueNumber sourceValue |
+      candidateResult(_, sourceValue, deref.getBlock()) and
+      sourceValue.getAnInstruction() = address and
+      deref.getSourceAddress() = address
+    )
+  }
+
+  /**
+   * Holds if `checked` has global value number `vn` and is an instruction that is
+   * used in a check against a null value.
+   */
+  private predicate isSink(LoadInstruction checked, ValueNumber vn) {
+    candidateResult(checked, vn, _)
+  }
+
+  /** Holds if `i` is control-flow reachable from a relevant `LoadInstruction`. */
+  private predicate fwdFlow(Instruction i) {
+    isSource(i, _)
+    or
+    exists(Instruction mid |
+      fwdFlow(mid) and
+      mid.getASuccessor() = i
+    )
+  }
+
+  /**
+   * Holds if `i` is part of a path from a relevant `LoadInstruction` to a
+   * check against a null value that compares a value against an instruction
+   * with global value number `vn`.
+   */
+  private predicate revFlow(Instruction i, ValueNumber vn) {
+    fwdFlow(i) and
+    (
+      isSink(i, vn)
+      or
+      exists(Instruction mid |
+        revFlow(mid, vn) and
+        i.getASuccessor() = mid
+      )
+    )
+  }
+
+  /**
+   * Gets a first control-flow successor of `i` that has the same
+   * global value number as `i`.
+   */
+  private Instruction getASuccessor(Instruction i) {
+    exists(ValueNumber vn |
+      vn.getAnInstruction() = i and
+      result = getASuccessorWithValueNumber(i, vn)
+    )
+  }
+
+  /**
+   * Gets a first control-flow successor of `i` that has the same
+   * global value number as `i`. Furthermore, `i` has global value
+   * number `vn`.
+   */
+  private Instruction getASuccessorWithValueNumber(Instruction i, ValueNumber vn) {
+    revFlow(i, vn) and
+    result = getASuccessorWithValueNumber0(vn, i.getASuccessor()) and
+    vn.getAnInstruction() = i
+  }
+
+  pragma[nomagic]
+  private Instruction getASuccessorWithValueNumber0(ValueNumber vn, Instruction i) {
+    result = getASuccessorIfDifferentValueNumberTC(vn, i) and
+    vn.getAnInstruction() = result
+  }
+
+  /**
+   * Computes the reflextive transitive closure of `getASuccessorIfDifferentValueNumber`.
+   */
+  private Instruction getASuccessorIfDifferentValueNumberTC(ValueNumber vn, Instruction i) {
+    revFlow(i, vn) and
+    (
+      i = result and
+      vn.getAnInstruction() = i
+      or
+      exists(Instruction mid |
+        mid = getASuccessorIfDifferentValueNumber(vn, i) and
+        result = getASuccessorIfDifferentValueNumberTC(vn, mid)
+      )
+    )
+  }
+
+  /**
+   * Gets an instruction that is a control-flow successor of `i` and which is not assigned
+   * the global value number `vn`.
+   */
+  private Instruction getASuccessorIfDifferentValueNumber(ValueNumber vn, Instruction i) {
+    revFlow(i, vn) and
+    revFlow(result, vn) and
+    not vn.getAnInstruction() = i and
+    pragma[only_bind_into](result) = pragma[only_bind_into](i).getASuccessor()
+  }
+
+  query predicate nodes(Instruction i, string key, string val) {
+    revFlow(i, _) and
+    key = "semmle.label" and
+    val = i.getAst().toString()
+  }
+
+  /**
+   * The control-flow successor relation, compacted by stepping
+   * over instruction that don't preserve the global value number.
+   *
+   * There is one exception to the above preservation rule: The
+   * initial step from the `LoadInstruction` (that is, the sink)
+   * steps to the first control-flow reachable instruction that
+   * has the same value number as the load instruction's address
+   * operand.
+   */
+  query predicate edges(Instruction i1, Instruction i2) {
+    getASuccessor(i1) = i2
+    or
+    // We could write `isSource(i2, i1)` here, but that would
+    // include a not-very-informative step from `*p` to `p`.
+    // So we collapse `*p` -> `p` -> `q` to `*p` -> `q`.
+    exists(Instruction mid |
+      isSource(mid, i1) and
+      getASuccessor(mid) = i2
+    )
+  }
 }
 
 from LoadInstruction checked, LoadInstruction deref, ValueNumber sourceValue, IRBlock dominator
@@ -67,5 +210,5 @@ where
   // the pointer was null. To follow this idea to its full generality, we
   // should also give an alert when `check` post-dominates `deref`.
   deref.getBlock() = dominator
-select checked, "This null check is redundant because $@ in any case.", deref,
+select checked, deref, checked, "This null check is redundant because $@ in any case.", deref,
   "the value is dereferenced"

--- a/cpp/ql/src/Likely Bugs/RedundantNullCheckSimple.ql
+++ b/cpp/ql/src/Likely Bugs/RedundantNullCheckSimple.ql
@@ -145,7 +145,7 @@ module PathGraph {
   }
 
   /**
-   * Computes the reflextive transitive closure of `getASuccessorIfDifferentValueNumber`.
+   * Computes the reflexive transitive closure of `getASuccessorIfDifferentValueNumber`.
    */
   private Instruction getASuccessorIfDifferentValueNumberTC(ValueNumber vn, Instruction i) {
     revFlow(i, vn) and

--- a/cpp/ql/src/change-notes/2023-04-13-redundant-null-check.md
+++ b/cpp/ql/src/change-notes/2023-04-13-redundant-null-check.md
@@ -1,0 +1,4 @@
+---
+category: newQuery
+---
+* The query `cpp/redundant-null-check-simple` has been promoted to Code Scanning. The query finds cases where a pointer is compared to null after it has already been dereferenced. Such comparisons likely indicate a bug at the place where the pointer is dereferenced, or where the pointer is compared to null.

--- a/cpp/ql/test/query-tests/Likely Bugs/RedundantNullCheckSimple/RedundantNullCheckSimple.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/RedundantNullCheckSimple/RedundantNullCheckSimple.expected
@@ -1,6 +1,56 @@
-| RedundantNullCheckSimple.cpp:4:7:4:7 | Load: p | This null check is redundant because $@ in any case. | RedundantNullCheckSimple.cpp:3:7:3:8 | Load: * ... | the value is dereferenced |
-| RedundantNullCheckSimple.cpp:13:8:13:8 | Load: p | This null check is redundant because $@ in any case. | RedundantNullCheckSimple.cpp:10:11:10:12 | Load: * ... | the value is dereferenced |
-| RedundantNullCheckSimple.cpp:20:7:20:8 | Load: * ... | This null check is redundant because $@ in any case. | RedundantNullCheckSimple.cpp:19:7:19:9 | Load: * ... | the value is dereferenced |
-| RedundantNullCheckSimple.cpp:48:12:48:12 | Load: p | This null check is redundant because $@ in any case. | RedundantNullCheckSimple.cpp:51:10:51:11 | Load: * ... | the value is dereferenced |
-| RedundantNullCheckSimple.cpp:79:7:79:9 | Load: * ... | This null check is redundant because $@ in any case. | RedundantNullCheckSimple.cpp:78:7:78:10 | Load: * ... | the value is dereferenced |
-| RedundantNullCheckSimple.cpp:93:13:93:13 | Load: p | This null check is redundant because $@ in any case. | RedundantNullCheckSimple.cpp:92:13:92:18 | Load: * ... | the value is dereferenced |
+nodes
+| RedundantNullCheckSimple.cpp:3:3:3:3 | VariableAddress: x | semmle.label | x |
+| RedundantNullCheckSimple.cpp:3:3:3:8 | Store: ... = ... | semmle.label | ... = ... |
+| RedundantNullCheckSimple.cpp:3:7:3:8 | Load: * ... | semmle.label | * ... |
+| RedundantNullCheckSimple.cpp:3:8:3:8 | Load: p | semmle.label | p |
+| RedundantNullCheckSimple.cpp:4:7:4:7 | Load: p | semmle.label | p |
+| RedundantNullCheckSimple.cpp:4:7:4:7 | VariableAddress: p | semmle.label | p |
+| RedundantNullCheckSimple.cpp:10:11:10:12 | Load: * ... | semmle.label | * ... |
+| RedundantNullCheckSimple.cpp:10:11:10:12 | Store: * ... | semmle.label | * ... |
+| RedundantNullCheckSimple.cpp:10:12:10:12 | Load: p | semmle.label | p |
+| RedundantNullCheckSimple.cpp:11:7:11:7 | Load: x | semmle.label | x |
+| RedundantNullCheckSimple.cpp:11:7:11:7 | VariableAddress: x | semmle.label | x |
+| RedundantNullCheckSimple.cpp:11:7:11:13 | CompareGT: ... > ... | semmle.label | ... > ... |
+| RedundantNullCheckSimple.cpp:11:7:11:13 | ConditionalBranch: ... > ... | semmle.label | ... > ... |
+| RedundantNullCheckSimple.cpp:11:11:11:13 | Constant: 100 | semmle.label | 100 |
+| RedundantNullCheckSimple.cpp:13:8:13:8 | Load: p | semmle.label | p |
+| RedundantNullCheckSimple.cpp:13:8:13:8 | VariableAddress: p | semmle.label | p |
+| RedundantNullCheckSimple.cpp:19:3:19:3 | VariableAddress: x | semmle.label | x |
+| RedundantNullCheckSimple.cpp:19:3:19:9 | Store: ... = ... | semmle.label | ... = ... |
+| RedundantNullCheckSimple.cpp:19:7:19:9 | Load: * ... | semmle.label | * ... |
+| RedundantNullCheckSimple.cpp:19:8:19:9 | Load: * ... | semmle.label | * ... |
+| RedundantNullCheckSimple.cpp:20:7:20:8 | Load: * ... | semmle.label | * ... |
+| RedundantNullCheckSimple.cpp:20:8:20:8 | Load: p | semmle.label | p |
+| RedundantNullCheckSimple.cpp:20:8:20:8 | VariableAddress: p | semmle.label | p |
+| RedundantNullCheckSimple.cpp:78:3:78:3 | VariableAddress: x | semmle.label | x |
+| RedundantNullCheckSimple.cpp:78:3:78:10 | Store: ... = ... | semmle.label | ... = ... |
+| RedundantNullCheckSimple.cpp:78:7:78:10 | Load: * ... | semmle.label | * ... |
+| RedundantNullCheckSimple.cpp:78:8:78:10 | Load: * ... | semmle.label | * ... |
+| RedundantNullCheckSimple.cpp:79:7:79:9 | Load: * ... | semmle.label | * ... |
+| RedundantNullCheckSimple.cpp:79:8:79:9 | Load: pp | semmle.label | pp |
+| RedundantNullCheckSimple.cpp:79:8:79:9 | VariableAddress: pp | semmle.label | pp |
+| RedundantNullCheckSimple.cpp:92:13:92:18 | Load: * ... | semmle.label | * ... |
+| RedundantNullCheckSimple.cpp:92:13:92:18 | Store: * ... | semmle.label | * ... |
+| RedundantNullCheckSimple.cpp:92:18:92:18 | Load: p | semmle.label | p |
+| RedundantNullCheckSimple.cpp:93:9:93:10 | Load: sp | semmle.label | sp |
+| RedundantNullCheckSimple.cpp:93:9:93:10 | VariableAddress: sp | semmle.label | sp |
+| RedundantNullCheckSimple.cpp:93:13:93:13 | FieldAddress: p | semmle.label | p |
+| RedundantNullCheckSimple.cpp:93:13:93:13 | Load: p | semmle.label | p |
+edges
+| RedundantNullCheckSimple.cpp:3:7:3:8 | Load: * ... | RedundantNullCheckSimple.cpp:4:7:4:7 | Load: p |
+| RedundantNullCheckSimple.cpp:3:8:3:8 | Load: p | RedundantNullCheckSimple.cpp:4:7:4:7 | Load: p |
+| RedundantNullCheckSimple.cpp:10:11:10:12 | Load: * ... | RedundantNullCheckSimple.cpp:13:8:13:8 | Load: p |
+| RedundantNullCheckSimple.cpp:10:12:10:12 | Load: p | RedundantNullCheckSimple.cpp:13:8:13:8 | Load: p |
+| RedundantNullCheckSimple.cpp:19:7:19:9 | Load: * ... | RedundantNullCheckSimple.cpp:20:7:20:8 | Load: * ... |
+| RedundantNullCheckSimple.cpp:19:8:19:9 | Load: * ... | RedundantNullCheckSimple.cpp:20:7:20:8 | Load: * ... |
+| RedundantNullCheckSimple.cpp:78:7:78:10 | Load: * ... | RedundantNullCheckSimple.cpp:79:7:79:9 | Load: * ... |
+| RedundantNullCheckSimple.cpp:78:8:78:10 | Load: * ... | RedundantNullCheckSimple.cpp:79:7:79:9 | Load: * ... |
+| RedundantNullCheckSimple.cpp:92:13:92:18 | Load: * ... | RedundantNullCheckSimple.cpp:93:13:93:13 | Load: p |
+| RedundantNullCheckSimple.cpp:92:18:92:18 | Load: p | RedundantNullCheckSimple.cpp:93:13:93:13 | Load: p |
+#select
+| RedundantNullCheckSimple.cpp:4:7:4:7 | Load: p | RedundantNullCheckSimple.cpp:3:7:3:8 | Load: * ... | RedundantNullCheckSimple.cpp:4:7:4:7 | Load: p | This null check is redundant because $@ in any case. | RedundantNullCheckSimple.cpp:3:7:3:8 | Load: * ... | the value is dereferenced |
+| RedundantNullCheckSimple.cpp:13:8:13:8 | Load: p | RedundantNullCheckSimple.cpp:10:11:10:12 | Load: * ... | RedundantNullCheckSimple.cpp:13:8:13:8 | Load: p | This null check is redundant because $@ in any case. | RedundantNullCheckSimple.cpp:10:11:10:12 | Load: * ... | the value is dereferenced |
+| RedundantNullCheckSimple.cpp:20:7:20:8 | Load: * ... | RedundantNullCheckSimple.cpp:19:7:19:9 | Load: * ... | RedundantNullCheckSimple.cpp:20:7:20:8 | Load: * ... | This null check is redundant because $@ in any case. | RedundantNullCheckSimple.cpp:19:7:19:9 | Load: * ... | the value is dereferenced |
+| RedundantNullCheckSimple.cpp:48:12:48:12 | Load: p | RedundantNullCheckSimple.cpp:51:10:51:11 | Load: * ... | RedundantNullCheckSimple.cpp:48:12:48:12 | Load: p | This null check is redundant because $@ in any case. | RedundantNullCheckSimple.cpp:51:10:51:11 | Load: * ... | the value is dereferenced |
+| RedundantNullCheckSimple.cpp:79:7:79:9 | Load: * ... | RedundantNullCheckSimple.cpp:78:7:78:10 | Load: * ... | RedundantNullCheckSimple.cpp:79:7:79:9 | Load: * ... | This null check is redundant because $@ in any case. | RedundantNullCheckSimple.cpp:78:7:78:10 | Load: * ... | the value is dereferenced |
+| RedundantNullCheckSimple.cpp:93:13:93:13 | Load: p | RedundantNullCheckSimple.cpp:92:13:92:18 | Load: * ... | RedundantNullCheckSimple.cpp:93:13:93:13 | Load: p | This null check is redundant because $@ in any case. | RedundantNullCheckSimple.cpp:92:13:92:18 | Load: * ... | the value is dereferenced |


### PR DESCRIPTION
The query produces fantastic results, but has been sitting without a precision for years now with the message:
```ql
/*
 * Note: this query is not assigned a precision yet because we don't want it
 * to be included in query suites until its performance is well understood.
 */
```
However, I don't see any reason why this query should perform poorly. It only uses libraries that we're already evaluating as part of the Code Scanning suite.

In fact, I'm so confident in its performance that I've converted it to a `path-problem` query to help me understand the alerts that the query produces. In all cases, the query has been right so far 🎉