### PR TITLE
Go: Refactor autobuilder

### DIFF
--- a/.github/workflows/go-tests-other-os.yml
+++ b/.github/workflows/go-tests-other-os.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go 1.20
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20.0
+          go-version: '1.20'
         id: go
 
       - name: Check out code
@@ -50,7 +50,7 @@ jobs:
       - name: Set up Go 1.20
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20.0
+          go-version: '1.20'
         id: go
 
       - name: Check out code

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go 1.20
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20.0
+          go-version: '1.20'
         id: go
 
       - name: Check out code

--- a/go/extractor/cli/go-autobuilder/go-autobuilder.go
+++ b/go/extractor/cli/go-autobuilder/go-autobuilder.go
@@ -350,8 +350,7 @@ func main() {
 	log.Printf("Autobuilder was built with %s, environment has %s\n", runtime.Version(), getEnvGoVersion())
 
 	srcdir := os.Getenv("LGTM_SRC")
-	inLGTM := srcdir != ""
-	if inLGTM {
+	if srcdir != "" {
 		log.Printf("LGTM_SRC is %s\n", srcdir)
 	} else {
 		cwd, err := os.Getwd()
@@ -399,9 +398,7 @@ func main() {
 	importpath := getImportPath()
 	needGopath := getNeedGopath(depMode, importpath)
 
-	if os.Getenv("LGTM_INDEX_NEED_GOPATH") != "" {
-		inLGTM = true
-	}
+	inLGTM := os.Getenv("LGTM_SRC") != "" || os.Getenv("LGTM_INDEX_NEED_GOPATH") != ""
 
 	if inLGTM && needGopath {
 		// a temporary directory where everything is moved while the correct

--- a/go/extractor/cli/go-autobuilder/go-autobuilder.go
+++ b/go/extractor/cli/go-autobuilder/go-autobuilder.go
@@ -221,6 +221,21 @@ func checkVendor() bool {
 	return true
 }
 
+func getSourceDir() string {
+	srcdir := os.Getenv("LGTM_SRC")
+	if srcdir != "" {
+		log.Printf("LGTM_SRC is %s\n", srcdir)
+	} else {
+		cwd, err := os.Getwd()
+		if err != nil {
+			log.Fatalln("Failed to get current working directory.")
+		}
+		log.Printf("LGTM_SRC is not set; defaulting to current working directory %s\n", cwd)
+		srcdir = cwd
+	}
+	return srcdir
+}
+
 func getDepMode() DependencyInstallerMode {
 	if util.FileExists("go.mod") {
 		log.Println("Found go.mod, enabling go modules")
@@ -349,17 +364,7 @@ func main() {
 
 	log.Printf("Autobuilder was built with %s, environment has %s\n", runtime.Version(), getEnvGoVersion())
 
-	srcdir := os.Getenv("LGTM_SRC")
-	if srcdir != "" {
-		log.Printf("LGTM_SRC is %s\n", srcdir)
-	} else {
-		cwd, err := os.Getwd()
-		if err != nil {
-			log.Fatalln("Failed to get current working directory.")
-		}
-		log.Printf("LGTM_SRC is not set; defaulting to current working directory %s\n", cwd)
-		srcdir = cwd
-	}
+	srcdir := getSourceDir()
 
 	// we set `SEMMLE_PATH_TRANSFORMER` ourselves in some cases, so blank it out first for consistency
 	os.Setenv("SEMMLE_PATH_TRANSFORMER", "")

--- a/go/extractor/cli/go-autobuilder/go-autobuilder.go
+++ b/go/extractor/cli/go-autobuilder/go-autobuilder.go
@@ -413,7 +413,13 @@ func moveToTemporaryGopath(srcdir string, importpath string) moveGopathInfo {
 		log.Fatalf("Failed to rename %s to %s: %s\n", scratch, newdir, err.Error())
 	}
 
-	return moveGopathInfo{scratch, realSrc, root, newdir, files}
+	return moveGopathInfo{
+		scratch: scratch,
+		realSrc: realSrc,
+		root:    root,
+		newdir:  newdir,
+		files:   files,
+	}
 }
 
 func createPathTransformerFile(newdir string) *os.File {

--- a/go/extractor/cli/go-autobuilder/go-autobuilder.go
+++ b/go/extractor/cli/go-autobuilder/go-autobuilder.go
@@ -557,6 +557,33 @@ func installDependencies(depMode DependencyInstallerMode) {
 	util.RunCmd(install)
 }
 
+func extract(depMode DependencyInstallerMode, modMode ModMode) {
+	extractor, err := util.GetExtractorPath()
+	if err != nil {
+		log.Fatalf("Could not determine path of extractor: %v.\n", err)
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		log.Fatalf("Unable to determine current directory: %s\n", err.Error())
+	}
+
+	extractorArgs := []string{}
+	if depMode == GoGetWithModules {
+		extractorArgs = append(extractorArgs, modMode.argsForGoVersion(getEnvGoSemVer())...)
+	}
+	extractorArgs = append(extractorArgs, "./...")
+
+	log.Printf("Running extractor command '%s %v' from directory '%s'.\n", extractor, extractorArgs, cwd)
+	cmd := exec.Command(extractor, extractorArgs...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err = cmd.Run()
+	if err != nil {
+		log.Fatalf("Extraction failed: %s\n", err.Error())
+	}
+}
+
 func main() {
 	if len(os.Args) > 1 {
 		usage()
@@ -637,29 +664,5 @@ func main() {
 		}
 	}
 
-	// extract
-	extractor, err := util.GetExtractorPath()
-	if err != nil {
-		log.Fatalf("Could not determine path of extractor: %v.\n", err)
-	}
-
-	cwd, err := os.Getwd()
-	if err != nil {
-		log.Fatalf("Unable to determine current directory: %s\n", err.Error())
-	}
-
-	extractorArgs := []string{}
-	if depMode == GoGetWithModules {
-		extractorArgs = append(extractorArgs, modMode.argsForGoVersion(getEnvGoSemVer())...)
-	}
-	extractorArgs = append(extractorArgs, "./...")
-
-	log.Printf("Running extractor command '%s %v' from directory '%s'.\n", extractor, extractorArgs, cwd)
-	cmd := exec.Command(extractor, extractorArgs...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	err = cmd.Run()
-	if err != nil {
-		log.Fatalf("Extraction failed: %s\n", err.Error())
-	}
+	extract(depMode, modMode)
 }

--- a/go/extractor/util/util.go
+++ b/go/extractor/util/util.go
@@ -183,7 +183,7 @@ func DepErrors(pkgpath string, flags ...string) bool {
 // FileExists tests whether the file at `filename` exists and is not a directory.
 func FileExists(filename string) bool {
 	info, err := os.Stat(filename)
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		log.Printf("Unable to stat %s: %s\n", filename, err.Error())
 	}
 	return err == nil && !info.IsDir()
@@ -192,7 +192,7 @@ func FileExists(filename string) bool {
 // DirExists tests whether `filename` exists and is a directory.
 func DirExists(filename string) bool {
 	info, err := os.Stat(filename)
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		log.Printf("Unable to stat %s: %s\n", filename, err.Error())
 	}
 	return err == nil && info.IsDir()

--- a/go/ql/test/library-tests/semmle/go/dataflow/FlowSteps/LocalTaintStep.expected
+++ b/go/ql/test/library-tests/semmle/go/dataflow/FlowSteps/LocalTaintStep.expected
@@ -73,7 +73,6 @@
 | file://:0:0:0:0 | parameter 0 of Store | file://:0:0:0:0 | [summary] to write: argument -1 in Store |
 | file://:0:0:0:0 | parameter 0 of StringBytePtr | file://:0:0:0:0 | [summary] to write: return (return[0]) in StringBytePtr |
 | file://:0:0:0:0 | parameter 0 of StringByteSlice | file://:0:0:0:0 | [summary] to write: return (return[0]) in StringByteSlice |
-| file://:0:0:0:0 | parameter 0 of StringSlicePtr | file://:0:0:0:0 | [summary] to write: return (return[0]) in StringSlicePtr |
 | file://:0:0:0:0 | parameter 0 of Sub | file://:0:0:0:0 | [summary] to write: return (return[0]) in Sub |
 | file://:0:0:0:0 | parameter 0 of Swap | file://:0:0:0:0 | [summary] to write: argument -1 in Swap |
 | file://:0:0:0:0 | parameter 0 of Swap | file://:0:0:0:0 | [summary] to write: argument -1 in Swap |
@@ -184,7 +183,6 @@
 | file://:0:0:0:0 | parameter -1 of Info | file://:0:0:0:0 | [summary] to write: return (return[0]) in Info |
 | file://:0:0:0:0 | parameter -1 of Info | file://:0:0:0:0 | [summary] to write: return (return[0]) in Info |
 | file://:0:0:0:0 | parameter -1 of Info | file://:0:0:0:0 | [summary] to write: return (return[0]) in Info |
-| file://:0:0:0:0 | parameter -1 of Info | file://:0:0:0:0 | [summary] to write: return (return[0]) in Info |
 | file://:0:0:0:0 | parameter -1 of Interface | file://:0:0:0:0 | [summary] to write: return (return[0]) in Interface |
 | file://:0:0:0:0 | parameter -1 of InterfaceData | file://:0:0:0:0 | [summary] to write: return (return[0]) in InterfaceData |
 | file://:0:0:0:0 | parameter -1 of Key | file://:0:0:0:0 | [summary] to write: return (return[0]) in Key |
@@ -200,7 +198,6 @@
 | file://:0:0:0:0 | parameter -1 of MarshalBinary | file://:0:0:0:0 | [summary] to write: return (return[0]) in MarshalBinary |
 | file://:0:0:0:0 | parameter -1 of Method | file://:0:0:0:0 | [summary] to write: return (return[0]) in Method |
 | file://:0:0:0:0 | parameter -1 of MethodByName | file://:0:0:0:0 | [summary] to write: return (return[0]) in MethodByName |
-| file://:0:0:0:0 | parameter -1 of Name | file://:0:0:0:0 | [summary] to write: return (return[0]) in Name |
 | file://:0:0:0:0 | parameter -1 of Name | file://:0:0:0:0 | [summary] to write: return (return[0]) in Name |
 | file://:0:0:0:0 | parameter -1 of Name | file://:0:0:0:0 | [summary] to write: return (return[0]) in Name |
 | file://:0:0:0:0 | parameter -1 of Name | file://:0:0:0:0 | [summary] to write: return (return[0]) in Name |

--- a/go/ql/test/library-tests/semmle/go/dataflow/FlowSteps/LocalTaintStep.ql
+++ b/go/ql/test/library-tests/semmle/go/dataflow/FlowSteps/LocalTaintStep.ql
@@ -4,5 +4,17 @@ from DataFlow::Node nd, DataFlow::Node succ
 where
   TaintTracking::localTaintStep(nd, succ) and
   // exclude data-flow steps
-  not DataFlow::localFlowStep(nd, succ)
+  not DataFlow::localFlowStep(nd, succ) and
+  // Exclude results which only appear on unix to avoid platform-specific results
+  not exists(string pkg, string name |
+    nd.(DataFlow::SummarizedParameterNode)
+        .getCallable()
+        .asSummarizedCallable()
+        .asFunction()
+        .hasQualifiedName(pkg, name)
+  |
+    pkg = "syscall" and name = "StringSlicePtr"
+    or
+    pkg = ["os.dirEntry", "os.unixDirent"] and name = ["Info", "Name"]
+  )
 select nd, succ

--- a/go/ql/test/library-tests/semmle/go/frameworks/TaintSteps/TaintStep.expected
+++ b/go/ql/test/library-tests/semmle/go/frameworks/TaintSteps/TaintStep.expected
@@ -191,7 +191,6 @@
 | file://:0:0:0:0 | parameter 0 of Store | file://:0:0:0:0 | [summary] to write: argument -1 in Store |
 | file://:0:0:0:0 | parameter 0 of StringBytePtr | file://:0:0:0:0 | [summary] to write: return (return[0]) in StringBytePtr |
 | file://:0:0:0:0 | parameter 0 of StringByteSlice | file://:0:0:0:0 | [summary] to write: return (return[0]) in StringByteSlice |
-| file://:0:0:0:0 | parameter 0 of StringSlicePtr | file://:0:0:0:0 | [summary] to write: return (return[0]) in StringSlicePtr |
 | file://:0:0:0:0 | parameter 0 of Sub | file://:0:0:0:0 | [summary] to write: return (return[0]) in Sub |
 | file://:0:0:0:0 | parameter 0 of Swap | file://:0:0:0:0 | [summary] to write: argument -1 in Swap |
 | file://:0:0:0:0 | parameter 0 of Swap | file://:0:0:0:0 | [summary] to write: argument -1 in Swap |
@@ -274,6 +273,7 @@
 | file://:0:0:0:0 | parameter 0 of WithDeadline | file://:0:0:0:0 | [summary] to write: return (return[0]) in WithDeadline |
 | file://:0:0:0:0 | parameter 0 of WithTimeout | file://:0:0:0:0 | [summary] to write: return (return[0]) in WithTimeout |
 | file://:0:0:0:0 | parameter 0 of WithValue | file://:0:0:0:0 | [summary] to write: return (return[0]) in WithValue |
+| file://:0:0:0:0 | parameter 0 of Write | file://:0:0:0:0 | [summary] to write: argument -1 in Write |
 | file://:0:0:0:0 | parameter 0 of Write | file://:0:0:0:0 | [summary] to write: argument -1 in Write |
 | file://:0:0:0:0 | parameter 0 of Write | file://:0:0:0:0 | [summary] to write: argument -1 in Write |
 | file://:0:0:0:0 | parameter 0 of Write | file://:0:0:0:0 | [summary] to write: argument -1 in Write |
@@ -537,7 +537,6 @@
 | file://:0:0:0:0 | parameter -1 of Info | file://:0:0:0:0 | [summary] to write: return (return[0]) in Info |
 | file://:0:0:0:0 | parameter -1 of Info | file://:0:0:0:0 | [summary] to write: return (return[0]) in Info |
 | file://:0:0:0:0 | parameter -1 of Info | file://:0:0:0:0 | [summary] to write: return (return[0]) in Info |
-| file://:0:0:0:0 | parameter -1 of Info | file://:0:0:0:0 | [summary] to write: return (return[0]) in Info |
 | file://:0:0:0:0 | parameter -1 of Init | file://:0:0:0:0 | [summary] to write: return (return[0]) in Init |
 | file://:0:0:0:0 | parameter -1 of Interface | file://:0:0:0:0 | [summary] to write: return (return[0]) in Interface |
 | file://:0:0:0:0 | parameter -1 of InterfaceData | file://:0:0:0:0 | [summary] to write: return (return[0]) in InterfaceData |
@@ -583,7 +582,6 @@
 | file://:0:0:0:0 | parameter -1 of Name | file://:0:0:0:0 | [summary] to write: return (return[0]) in Name |
 | file://:0:0:0:0 | parameter -1 of Name | file://:0:0:0:0 | [summary] to write: return (return[0]) in Name |
 | file://:0:0:0:0 | parameter -1 of Name | file://:0:0:0:0 | [summary] to write: return (return[0]) in Name |
-| file://:0:0:0:0 | parameter -1 of Name | file://:0:0:0:0 | [summary] to write: return (return[0]) in Name |
 | file://:0:0:0:0 | parameter -1 of Next | file://:0:0:0:0 | [summary] to write: return (return[0]) in Next |
 | file://:0:0:0:0 | parameter -1 of Next | file://:0:0:0:0 | [summary] to write: return (return[0]) in Next |
 | file://:0:0:0:0 | parameter -1 of NextPart | file://:0:0:0:0 | [summary] to write: return (return[0]) in NextPart |
@@ -600,8 +598,6 @@
 | file://:0:0:0:0 | parameter -1 of Port | file://:0:0:0:0 | [summary] to write: return (return[0]) in Port |
 | file://:0:0:0:0 | parameter -1 of Prev | file://:0:0:0:0 | [summary] to write: return (return[0]) in Prev |
 | file://:0:0:0:0 | parameter -1 of Query | file://:0:0:0:0 | [summary] to write: return (return[0]) in Query |
-| file://:0:0:0:0 | parameter -1 of Read | file://:0:0:0:0 | [summary] to write: argument 0 in Read |
-| file://:0:0:0:0 | parameter -1 of Read | file://:0:0:0:0 | [summary] to write: argument 0 in Read |
 | file://:0:0:0:0 | parameter -1 of Read | file://:0:0:0:0 | [summary] to write: argument 0 in Read |
 | file://:0:0:0:0 | parameter -1 of Read | file://:0:0:0:0 | [summary] to write: argument 0 in Read |
 | file://:0:0:0:0 | parameter -1 of Read | file://:0:0:0:0 | [summary] to write: argument 0 in Read |

--- a/go/ql/test/library-tests/semmle/go/frameworks/TaintSteps/TaintStep.ql
+++ b/go/ql/test/library-tests/semmle/go/frameworks/TaintSteps/TaintStep.ql
@@ -3,5 +3,20 @@ import go
 from DataFlow::Node pred, DataFlow::Node succ
 where
   TaintTracking::localTaintStep(pred, succ) and
-  not DataFlow::localFlowStep(pred, succ)
+  not DataFlow::localFlowStep(pred, succ) and
+  // Exclude results which only appear on unix to avoid platform-specific results
+  not exists(string pkg, string name |
+    pred.(DataFlow::SummarizedParameterNode)
+        .getCallable()
+        .asSummarizedCallable()
+        .asFunction()
+        .hasQualifiedName(pkg, name)
+  |
+    pkg = "syscall" and name = "StringSlicePtr"
+    or
+    pkg.matches("crypto/rand.%") and
+    name = "Read"
+    or
+    pkg = ["os.dirEntry", "os.unixDirent"] and name = ["Info", "Name"]
+  )
 select pred, succ


### PR DESCRIPTION
The main method of `go-autobuilder.go` was almost 400 lines long, and it wasn't clear which variables depended on which other variables, which ones would be used again, etc. This is a very simple refactor to factor different calculations out into their own functions. I recommend reviewing it commit-by-commit.