### PR TITLE
Swift: Downgrade swift/unsafe-js-eval to precision medium.

### DIFF
--- a/swift/ql/src/queries/Security/CWE-094/UnsafeJsEval.ql
+++ b/swift/ql/src/queries/Security/CWE-094/UnsafeJsEval.ql
@@ -4,7 +4,7 @@
  * @kind path-problem
  * @problem.severity warning
  * @security-severity 9.3
- * @precision high
+ * @precision medium
  * @id swift/unsafe-js-eval
  * @tags security
  *       external/cwe/cwe-094


### PR DESCRIPTION
Downgrade `swift/unsafe-js-eval` to `@precision medium`, because in https://github.com/github/codeql-c-team/issues/1099 I found false positive results for this query in three projects.

Fixing the FPs should come out of https://github.com/github/codeql-c-team/issues/1268 .  I've added a note to that issue to upgrade this query back to `@precision high` it's done.