### PR TITLE
Swift: widen swift/predicate-injection sources

### DIFF
--- a/swift/ql/lib/codeql/swift/security/InsecureTLSQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/InsecureTLSQuery.qll
@@ -6,7 +6,6 @@
 import swift
 import codeql.swift.dataflow.DataFlow
 import codeql.swift.dataflow.TaintTracking
-import codeql.swift.dataflow.FlowSources
 import codeql.swift.security.InsecureTLSExtensions
 
 /**

--- a/swift/ql/lib/codeql/swift/security/PredicateInjectionQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/PredicateInjectionQuery.qll
@@ -15,7 +15,7 @@ private import codeql.swift.security.PredicateInjectionExtensions
 deprecated class PredicateInjectionConf extends TaintTracking::Configuration {
   PredicateInjectionConf() { this = "PredicateInjectionConf" }
 
-  override predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  override predicate isSource(DataFlow::Node source) { source instanceof FlowSource }
 
   override predicate isSink(DataFlow::Node sink) { sink instanceof PredicateInjectionSink }
 
@@ -32,7 +32,7 @@ deprecated class PredicateInjectionConf extends TaintTracking::Configuration {
  * A taint-tracking configuration for predicate injection vulnerabilities.
  */
 module PredicateInjectionConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof FlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof PredicateInjectionSink }
 


### PR DESCRIPTION
Widen the sources for `swift/predicate-injection`.  After a bit of thought it's plain to me that even data from local flow sources should be in a predicate parameter, rather than concatenated into the predicate itself, so they're a legitimate source for this query.

(I also deleted an very loosely related unused import in this PR)