### PR TITLE
QL: update regexes used in `QueryDoc.getQueryName()` and in `QueryDoc.getQueryId()/getQueryLanguage()`

### DIFF
--- a/ql/ql/src/codeql_ql/ast/Ast.qll
+++ b/ql/ql/src/codeql_ql/ast/Ast.qll
@@ -211,17 +211,17 @@ class QueryDoc extends QLDoc {
 
   /** Gets the @name for the query */
   string getQueryName() {
-    result = this.getContents().regexpCapture("(?s).*@name ([\\w-\\s]+)(?=\\n).*", 1)
+    result = this.getContents().regexpCapture("(?s).*@name (.+?)(?=\\n).*", 1)
   }
 
   /** Gets the id part (without language) of the @id */
   string getQueryId() {
-    result = this.getContents().regexpCapture("(?s).*@id (\\w+)/([\\w\\-]+)\\s.*", 2)
+    result = this.getContents().regexpCapture("(?s).*@id (\\w+)/([\\w\\-/]+)\\s.*", 2)
   }
 
   /** Gets the language of the @id */
   string getQueryLanguage() {
-    result = this.getContents().regexpCapture("(?s).*@id (\\w+)/([\\w\\-]+)\\s.*", 1)
+    result = this.getContents().regexpCapture("(?s).*@id (\\w+)/([\\w\\-/]+)\\s.*", 1)
   }
 }
 


### PR DESCRIPTION
This PR suggests updating the regexes used in `QueryDoc.getQueryName()` and in `QueryDoc.getQueryId()/getQueryLanguage()`.

The regex in `QueryDoc.getQueryName()` does not work when non-word characters, such as `/`, are used in the query name. For example, it doesn't work with [`@name Depending upon JCenter/Bintray as an artifact repository`](https://github.com/github/codeql/blob/d94ed1b4a31243f9050902b1a3c7c2a7cbd546a6/java/ql/src/Security/CWE/CWE-1104/MavenPomDependsOnBintray.ql#L2).
This PR proposes updating this regex to allow for any character.

The regex in `QueryDoc.getQueryId()/getQueryLanguage()` does not work when a second `/` is used in the id. For example, it doesn't work with [`@id java/maven/dependency-upon-bintray`](https://github.com/github/codeql/blob/d94ed1b4a31243f9050902b1a3c7c2a7cbd546a6/java/ql/src/Security/CWE/CWE-1104/MavenPomDependsOnBintray.ql#L8).
This PR proposes updating this regex to allow for a second slash. Note: the [`ql/consistent-alert-message`](https://github.com/github/codeql/blob/d94ed1b4a31243f9050902b1a3c7c2a7cbd546a6/ql/ql/src/queries/style/ConsistentAlertMessage.ql) query returns additional results once this update is made.

Let me know if there is any reason why either of these updates should not be done.