### PR TITLE
Prevent JS join order regression

### DIFF
--- a/javascript/ql/lib/semmle/javascript/InclusionTests.qll
+++ b/javascript/ql/lib/semmle/javascript/InclusionTests.qll
@@ -69,6 +69,7 @@ module InclusionTest {
       inner.getContainerNode().getALocalSource() = DataFlow::parameterNode(callee.getAParameter())
     }
 
+    pragma[assume_small_delta]
     override DataFlow::Node getContainerNode() {
       exists(int arg |
         inner.getContainerNode().getALocalSource() =
@@ -77,6 +78,7 @@ module InclusionTest {
       )
     }
 
+    pragma[assume_small_delta]
     override DataFlow::Node getContainedNode() {
       exists(int arg |
         inner.getContainedNode().getALocalSource() =

--- a/javascript/ql/lib/semmle/javascript/StringOps.qll
+++ b/javascript/ql/lib/semmle/javascript/StringOps.qll
@@ -67,6 +67,7 @@ module StringOps {
         inner.getSubstring().getALocalSource().getEnclosingExpr() = callee.getAParameter()
       }
 
+      pragma[assume_small_delta]
       override DataFlow::Node getBaseString() {
         exists(int arg |
           inner.getBaseString().getALocalSource().getEnclosingExpr() = callee.getParameter(arg) and
@@ -74,6 +75,7 @@ module StringOps {
         )
       }
 
+      pragma[assume_small_delta]
       override DataFlow::Node getSubstring() {
         exists(int arg |
           inner.getSubstring().getALocalSource().getEnclosingExpr() = callee.getParameter(arg) and
@@ -292,6 +294,7 @@ module StringOps {
         inner.getSubstring().getALocalSource().getEnclosingExpr() = callee.getAParameter()
       }
 
+      pragma[assume_small_delta]
       override DataFlow::Node getBaseString() {
         exists(int arg |
           inner.getBaseString().getALocalSource().getEnclosingExpr() = callee.getParameter(arg) and
@@ -299,6 +302,7 @@ module StringOps {
         )
       }
 
+      pragma[assume_small_delta]
       override DataFlow::Node getSubstring() {
         exists(int arg |
           inner.getSubstring().getALocalSource().getEnclosingExpr() = callee.getParameter(arg) and


### PR DESCRIPTION
Add pragmas to prevent join order regressions (specifically joins on the low-cardinality integer `arg` column) from planned tweaks to the join ordering heuristic. 