### PR TITLE
Java: Add `*/test/*` to model generator's list of ignored paths

### DIFF
--- a/java/ql/src/utils/modelgenerator/internal/CaptureModelsSpecific.qll
+++ b/java/ql/src/utils/modelgenerator/internal/CaptureModelsSpecific.qll
@@ -27,8 +27,7 @@ private J::Method superImpl(J::Method m) {
 }
 
 private predicate isInTestFile(J::File file) {
-  file.getAbsolutePath()
-      .matches(["%src/test/%", "%/guava-tests/%", "%/guava-testlib/%", "%/groovy-stubs/test/%"])
+  file.getAbsolutePath().matches(["%/test/%", "%/guava-tests/%", "%/guava-testlib/%"])
 }
 
 private predicate isJdkInternal(J::CompilationUnit cu) {

--- a/java/ql/src/utils/modelgenerator/internal/CaptureModelsSpecific.qll
+++ b/java/ql/src/utils/modelgenerator/internal/CaptureModelsSpecific.qll
@@ -27,7 +27,8 @@ private J::Method superImpl(J::Method m) {
 }
 
 private predicate isInTestFile(J::File file) {
-  file.getAbsolutePath().matches(["%/test/%", "%/guava-tests/%", "%/guava-testlib/%"])
+  file.getAbsolutePath().matches(["%/test/%", "%/guava-tests/%", "%/guava-testlib/%"]) and
+  not file.getAbsolutePath().matches("%/ql/test/%") // allows our test cases to work
 }
 
 private predicate isJdkInternal(J::CompilationUnit cu) {

--- a/java/ql/src/utils/modelgenerator/internal/CaptureModelsSpecific.qll
+++ b/java/ql/src/utils/modelgenerator/internal/CaptureModelsSpecific.qll
@@ -29,7 +29,8 @@ private J::Method superImpl(J::Method m) {
 private predicate isInTestFile(J::File file) {
   file.getAbsolutePath().matches("%src/test/%") or
   file.getAbsolutePath().matches("%/guava-tests/%") or
-  file.getAbsolutePath().matches("%/guava-testlib/%")
+  file.getAbsolutePath().matches("%/guava-testlib/%") or
+  file.getAbsolutePath().matches("%/groovy-stubs/test/%")
 }
 
 private predicate isJdkInternal(J::CompilationUnit cu) {

--- a/java/ql/src/utils/modelgenerator/internal/CaptureModelsSpecific.qll
+++ b/java/ql/src/utils/modelgenerator/internal/CaptureModelsSpecific.qll
@@ -27,10 +27,8 @@ private J::Method superImpl(J::Method m) {
 }
 
 private predicate isInTestFile(J::File file) {
-  file.getAbsolutePath().matches("%src/test/%") or
-  file.getAbsolutePath().matches("%/guava-tests/%") or
-  file.getAbsolutePath().matches("%/guava-testlib/%") or
-  file.getAbsolutePath().matches("%/groovy-stubs/test/%")
+  file.getAbsolutePath()
+      .matches(["%src/test/%", "%/guava-tests/%", "%/guava-testlib/%", "%/groovy-stubs/test/%"])
 }
 
 private predicate isJdkInternal(J::CompilationUnit cu) {


### PR DESCRIPTION
This adds `%/test/%` to the list of ignored paths defined in CaptureModelsSpecific.qll. This helps resolve avoid including test cases when a project places tests in locations other than `src/test`