### PR TITLE
C++: Fix bad self-join in `cpp/use-after-free`

### DIFF
--- a/cpp/ql/src/Critical/UseAfterFree.ql
+++ b/cpp/ql/src/Critical/UseAfterFree.ql
@@ -128,7 +128,8 @@ module ParameterSinks {
       callHasTargetAndArgument(f, i, call, argument) and
       initializeParameterInFunction(f, i, p) and
       p = getAnAlwaysDereferencedParameter() and
-      result = pragma[only_bind_out](valueNumber(argument).getAnInstruction()) and
+      result =
+        pragma[only_bind_out](pragma[only_bind_into](valueNumber(argument)).getAnInstruction()) and
       call = getAnAlwaysReachedCallInstruction(_)
     )
   }


### PR DESCRIPTION
Before:
```ql
[2023-04-18 09:17:24] Evaluated non-recursive predicate _ValueNumberingInternal#c9f42560::tvalueNumber#1#ff_10#join_rhs_project#Instruction#577b6a83::Initia__#loop_invariant_prefix@ae046923 in 3903ms (size: 130544).
Evaluated relational algebra for predicate _ValueNumberingInternal#c9f42560::tvalueNumber#1#ff_10#join_rhs_project#Instruction#577b6a83::Initia__#loop_invariant_prefix@ae046923 with tuple counts:
        533787724  ~0%    {2} r1 = JOIN ValueNumberingInternal#c9f42560::tvalueNumber#1#ff_10#join_rhs WITH ValueNumberingInternal#c9f42560::tvalueNumber#1#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1
           130544  ~0%    {2} r2 = JOIN r1 WITH project#Instruction#577b6a83::InitializeParameterInstruction#ff ON FIRST 1 OUTPUT Lhs.1, Lhs.0
                          return r2
```

After:
```ql
[2023-04-18 10:09:34] Evaluated non-recursive predicate _ValueNumberingInternal#c9f42560::tvalueNumber#1#ff_project#Instruction#577b6a83::InitializeParamete__#loop_invariant_prefix@eb90a6fk in 2ms (size: 18380).
Evaluated relational algebra for predicate _ValueNumberingInternal#c9f42560::tvalueNumber#1#ff_project#Instruction#577b6a83::InitializeParamete__#loop_invariant_prefix@eb90a6fk with tuple counts:
        18380  ~0%    {2} r1 = JOIN ValueNumberingInternal#c9f42560::tvalueNumber#1#ff WITH project#Instruction#577b6a83::InitializeParameterInstruction#ff ON FIRST 1 OUTPUT Lhs.1, Lhs.0
                      return r1
```