### PR TITLE
C#: Re-refactor UnsafeDeserializationUntrustedInput to use the new API.

### DIFF
--- a/csharp/ql/src/Security Features/CWE-502/UnsafeDeserializationUntrustedInput.ql
+++ b/csharp/ql/src/Security Features/CWE-502/UnsafeDeserializationUntrustedInput.ql
@@ -23,20 +23,14 @@ where
   ) and
   // intersect with strong types, but user controlled or weak types deserialization usages
   (
-    exists(
-      DataFlow::Node weakTypeUsage,
-      WeakTypeCreationToUsageTrackingConfig weakTypeDeserializerTracking, MethodCall mc
-    |
-      weakTypeDeserializerTracking.hasFlowTo(weakTypeUsage) and
+    exists(DataFlow::Node weakTypeUsage, MethodCall mc |
+      WeakTypeCreationToUsageTracking::flowTo(weakTypeUsage) and
       mc.getQualifier() = weakTypeUsage.asExpr() and
       mc.getAnArgument() = deserializeCallArg.getNode().asExpr()
     )
     or
-    exists(
-      TaintToObjectTypeTrackingConfig userControlledTypeTracking, DataFlow::Node taintedTypeUsage,
-      MethodCall mc
-    |
-      userControlledTypeTracking.hasFlowTo(taintedTypeUsage) and
+    exists(DataFlow::Node taintedTypeUsage, MethodCall mc |
+      TaintToObjectTypeTracking::flowTo(taintedTypeUsage) and
       mc.getQualifier() = taintedTypeUsage.asExpr() and
       mc.getAnArgument() = deserializeCallArg.getNode().asExpr()
     )

--- a/csharp/ql/test/query-tests/Security Features/CWE-502/UnsafeDeserializationUntrustedInputNewtonsoftJson/UnsafeDeserializationUntrustedInput.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-502/UnsafeDeserializationUntrustedInputNewtonsoftJson/UnsafeDeserializationUntrustedInput.expected
@@ -1,19 +1,12 @@
 edges
-| ../../../../resources/stubs/Newtonsoft.Json/13.0.1/Newtonsoft.Json.cs:930:20:930:20 | 4 : Int32 | Test.cs:19:32:19:52 | access to constant Auto : Int32 |
 | Test.cs:9:46:9:49 | access to parameter data : TextBox | Test.cs:9:46:9:54 | access to property Text |
 | Test.cs:17:46:17:49 | access to parameter data : TextBox | Test.cs:17:46:17:54 | access to property Text |
-| Test.cs:19:32:19:52 | access to constant Auto : Int32 | Test.cs:17:57:20:9 | object creation of type JsonSerializerSettings |
-| Test.cs:19:32:19:52 | access to constant Auto : TypeNameHandling | Test.cs:17:57:20:9 | object creation of type JsonSerializerSettings |
 | Test.cs:25:46:25:49 | access to parameter data : TextBox | Test.cs:25:46:25:54 | access to property Text |
 nodes
-| ../../../../resources/stubs/Newtonsoft.Json/13.0.1/Newtonsoft.Json.cs:930:20:930:20 | 4 : Int32 | semmle.label | 4 : Int32 |
 | Test.cs:9:46:9:49 | access to parameter data : TextBox | semmle.label | access to parameter data : TextBox |
 | Test.cs:9:46:9:54 | access to property Text | semmle.label | access to property Text |
 | Test.cs:17:46:17:49 | access to parameter data : TextBox | semmle.label | access to parameter data : TextBox |
 | Test.cs:17:46:17:54 | access to property Text | semmle.label | access to property Text |
-| Test.cs:17:57:20:9 | object creation of type JsonSerializerSettings | semmle.label | object creation of type JsonSerializerSettings |
-| Test.cs:19:32:19:52 | access to constant Auto : Int32 | semmle.label | access to constant Auto : Int32 |
-| Test.cs:19:32:19:52 | access to constant Auto : TypeNameHandling | semmle.label | access to constant Auto : TypeNameHandling |
 | Test.cs:25:46:25:49 | access to parameter data : TextBox | semmle.label | access to parameter data : TextBox |
 | Test.cs:25:46:25:54 | access to property Text | semmle.label | access to property Text |
 subpaths


### PR DESCRIPTION
In this PR we re-write some of the old dataflow configurations to use the new API.
The problem we are facing here is that the query uses three different configurations, which to my understanding means that the constructed graph (and pathnodes) are based on the union of some notion of reachability from sources.

The solution presented here might not be ideal and all feedback is more than welcome.

The idea is that we construct three new separate "configurations" using the new API, but then also create a PathGraph representation that consists of the union of these. It is my (maybe incorrect) understanding that for path problems it is required to have `edges`, `nodes` and `subpaths` query predicate in scope for the results to be presented correctly.