### PR TITLE
Go: Fix platform specific tests

### DIFF
--- a/.github/workflows/go-tests-other-os.yml
+++ b/.github/workflows/go-tests-other-os.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go 1.20
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20.0
+          go-version: '1.20'
         id: go
 
       - name: Check out code
@@ -50,7 +50,7 @@ jobs:
       - name: Set up Go 1.20
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20.0
+          go-version: '1.20'
         id: go
 
       - name: Check out code

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go 1.20
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20.0
+          go-version: '1.20'
         id: go
 
       - name: Check out code

--- a/go/ql/test/library-tests/semmle/go/dataflow/FlowSteps/LocalTaintStep.expected
+++ b/go/ql/test/library-tests/semmle/go/dataflow/FlowSteps/LocalTaintStep.expected
@@ -73,7 +73,6 @@
 | file://:0:0:0:0 | parameter 0 of Store | file://:0:0:0:0 | [summary] to write: argument -1 in Store |
 | file://:0:0:0:0 | parameter 0 of StringBytePtr | file://:0:0:0:0 | [summary] to write: return (return[0]) in StringBytePtr |
 | file://:0:0:0:0 | parameter 0 of StringByteSlice | file://:0:0:0:0 | [summary] to write: return (return[0]) in StringByteSlice |
-| file://:0:0:0:0 | parameter 0 of StringSlicePtr | file://:0:0:0:0 | [summary] to write: return (return[0]) in StringSlicePtr |
 | file://:0:0:0:0 | parameter 0 of Sub | file://:0:0:0:0 | [summary] to write: return (return[0]) in Sub |
 | file://:0:0:0:0 | parameter 0 of Swap | file://:0:0:0:0 | [summary] to write: argument -1 in Swap |
 | file://:0:0:0:0 | parameter 0 of Swap | file://:0:0:0:0 | [summary] to write: argument -1 in Swap |
@@ -184,7 +183,6 @@
 | file://:0:0:0:0 | parameter -1 of Info | file://:0:0:0:0 | [summary] to write: return (return[0]) in Info |
 | file://:0:0:0:0 | parameter -1 of Info | file://:0:0:0:0 | [summary] to write: return (return[0]) in Info |
 | file://:0:0:0:0 | parameter -1 of Info | file://:0:0:0:0 | [summary] to write: return (return[0]) in Info |
-| file://:0:0:0:0 | parameter -1 of Info | file://:0:0:0:0 | [summary] to write: return (return[0]) in Info |
 | file://:0:0:0:0 | parameter -1 of Interface | file://:0:0:0:0 | [summary] to write: return (return[0]) in Interface |
 | file://:0:0:0:0 | parameter -1 of InterfaceData | file://:0:0:0:0 | [summary] to write: return (return[0]) in InterfaceData |
 | file://:0:0:0:0 | parameter -1 of Key | file://:0:0:0:0 | [summary] to write: return (return[0]) in Key |
@@ -200,7 +198,6 @@
 | file://:0:0:0:0 | parameter -1 of MarshalBinary | file://:0:0:0:0 | [summary] to write: return (return[0]) in MarshalBinary |
 | file://:0:0:0:0 | parameter -1 of Method | file://:0:0:0:0 | [summary] to write: return (return[0]) in Method |
 | file://:0:0:0:0 | parameter -1 of MethodByName | file://:0:0:0:0 | [summary] to write: return (return[0]) in MethodByName |
-| file://:0:0:0:0 | parameter -1 of Name | file://:0:0:0:0 | [summary] to write: return (return[0]) in Name |
 | file://:0:0:0:0 | parameter -1 of Name | file://:0:0:0:0 | [summary] to write: return (return[0]) in Name |
 | file://:0:0:0:0 | parameter -1 of Name | file://:0:0:0:0 | [summary] to write: return (return[0]) in Name |
 | file://:0:0:0:0 | parameter -1 of Name | file://:0:0:0:0 | [summary] to write: return (return[0]) in Name |

--- a/go/ql/test/library-tests/semmle/go/dataflow/FlowSteps/LocalTaintStep.ql
+++ b/go/ql/test/library-tests/semmle/go/dataflow/FlowSteps/LocalTaintStep.ql
@@ -4,5 +4,17 @@ from DataFlow::Node nd, DataFlow::Node succ
 where
   TaintTracking::localTaintStep(nd, succ) and
   // exclude data-flow steps
-  not DataFlow::localFlowStep(nd, succ)
+  not DataFlow::localFlowStep(nd, succ) and
+  // Exclude results which only appear on unix to avoid platform-specific results
+  not exists(string pkg, string name |
+    nd.(DataFlow::SummarizedParameterNode)
+        .getCallable()
+        .asSummarizedCallable()
+        .asFunction()
+        .hasQualifiedName(pkg, name)
+  |
+    pkg = "syscall" and name = "StringSlicePtr"
+    or
+    pkg = ["os.dirEntry", "os.unixDirent"] and name = ["Info", "Name"]
+  )
 select nd, succ

--- a/go/ql/test/library-tests/semmle/go/frameworks/TaintSteps/TaintStep.expected
+++ b/go/ql/test/library-tests/semmle/go/frameworks/TaintSteps/TaintStep.expected
@@ -191,7 +191,6 @@
 | file://:0:0:0:0 | parameter 0 of Store | file://:0:0:0:0 | [summary] to write: argument -1 in Store |
 | file://:0:0:0:0 | parameter 0 of StringBytePtr | file://:0:0:0:0 | [summary] to write: return (return[0]) in StringBytePtr |
 | file://:0:0:0:0 | parameter 0 of StringByteSlice | file://:0:0:0:0 | [summary] to write: return (return[0]) in StringByteSlice |
-| file://:0:0:0:0 | parameter 0 of StringSlicePtr | file://:0:0:0:0 | [summary] to write: return (return[0]) in StringSlicePtr |
 | file://:0:0:0:0 | parameter 0 of Sub | file://:0:0:0:0 | [summary] to write: return (return[0]) in Sub |
 | file://:0:0:0:0 | parameter 0 of Swap | file://:0:0:0:0 | [summary] to write: argument -1 in Swap |
 | file://:0:0:0:0 | parameter 0 of Swap | file://:0:0:0:0 | [summary] to write: argument -1 in Swap |
@@ -274,6 +273,7 @@
 | file://:0:0:0:0 | parameter 0 of WithDeadline | file://:0:0:0:0 | [summary] to write: return (return[0]) in WithDeadline |
 | file://:0:0:0:0 | parameter 0 of WithTimeout | file://:0:0:0:0 | [summary] to write: return (return[0]) in WithTimeout |
 | file://:0:0:0:0 | parameter 0 of WithValue | file://:0:0:0:0 | [summary] to write: return (return[0]) in WithValue |
+| file://:0:0:0:0 | parameter 0 of Write | file://:0:0:0:0 | [summary] to write: argument -1 in Write |
 | file://:0:0:0:0 | parameter 0 of Write | file://:0:0:0:0 | [summary] to write: argument -1 in Write |
 | file://:0:0:0:0 | parameter 0 of Write | file://:0:0:0:0 | [summary] to write: argument -1 in Write |
 | file://:0:0:0:0 | parameter 0 of Write | file://:0:0:0:0 | [summary] to write: argument -1 in Write |
@@ -537,7 +537,6 @@
 | file://:0:0:0:0 | parameter -1 of Info | file://:0:0:0:0 | [summary] to write: return (return[0]) in Info |
 | file://:0:0:0:0 | parameter -1 of Info | file://:0:0:0:0 | [summary] to write: return (return[0]) in Info |
 | file://:0:0:0:0 | parameter -1 of Info | file://:0:0:0:0 | [summary] to write: return (return[0]) in Info |
-| file://:0:0:0:0 | parameter -1 of Info | file://:0:0:0:0 | [summary] to write: return (return[0]) in Info |
 | file://:0:0:0:0 | parameter -1 of Init | file://:0:0:0:0 | [summary] to write: return (return[0]) in Init |
 | file://:0:0:0:0 | parameter -1 of Interface | file://:0:0:0:0 | [summary] to write: return (return[0]) in Interface |
 | file://:0:0:0:0 | parameter -1 of InterfaceData | file://:0:0:0:0 | [summary] to write: return (return[0]) in InterfaceData |
@@ -583,7 +582,6 @@
 | file://:0:0:0:0 | parameter -1 of Name | file://:0:0:0:0 | [summary] to write: return (return[0]) in Name |
 | file://:0:0:0:0 | parameter -1 of Name | file://:0:0:0:0 | [summary] to write: return (return[0]) in Name |
 | file://:0:0:0:0 | parameter -1 of Name | file://:0:0:0:0 | [summary] to write: return (return[0]) in Name |
-| file://:0:0:0:0 | parameter -1 of Name | file://:0:0:0:0 | [summary] to write: return (return[0]) in Name |
 | file://:0:0:0:0 | parameter -1 of Next | file://:0:0:0:0 | [summary] to write: return (return[0]) in Next |
 | file://:0:0:0:0 | parameter -1 of Next | file://:0:0:0:0 | [summary] to write: return (return[0]) in Next |
 | file://:0:0:0:0 | parameter -1 of NextPart | file://:0:0:0:0 | [summary] to write: return (return[0]) in NextPart |
@@ -600,8 +598,6 @@
 | file://:0:0:0:0 | parameter -1 of Port | file://:0:0:0:0 | [summary] to write: return (return[0]) in Port |
 | file://:0:0:0:0 | parameter -1 of Prev | file://:0:0:0:0 | [summary] to write: return (return[0]) in Prev |
 | file://:0:0:0:0 | parameter -1 of Query | file://:0:0:0:0 | [summary] to write: return (return[0]) in Query |
-| file://:0:0:0:0 | parameter -1 of Read | file://:0:0:0:0 | [summary] to write: argument 0 in Read |
-| file://:0:0:0:0 | parameter -1 of Read | file://:0:0:0:0 | [summary] to write: argument 0 in Read |
 | file://:0:0:0:0 | parameter -1 of Read | file://:0:0:0:0 | [summary] to write: argument 0 in Read |
 | file://:0:0:0:0 | parameter -1 of Read | file://:0:0:0:0 | [summary] to write: argument 0 in Read |
 | file://:0:0:0:0 | parameter -1 of Read | file://:0:0:0:0 | [summary] to write: argument 0 in Read |

--- a/go/ql/test/library-tests/semmle/go/frameworks/TaintSteps/TaintStep.ql
+++ b/go/ql/test/library-tests/semmle/go/frameworks/TaintSteps/TaintStep.ql
@@ -3,5 +3,20 @@ import go
 from DataFlow::Node pred, DataFlow::Node succ
 where
   TaintTracking::localTaintStep(pred, succ) and
-  not DataFlow::localFlowStep(pred, succ)
+  not DataFlow::localFlowStep(pred, succ) and
+  // Exclude results which only appear on unix to avoid platform-specific results
+  not exists(string pkg, string name |
+    pred.(DataFlow::SummarizedParameterNode)
+        .getCallable()
+        .asSummarizedCallable()
+        .asFunction()
+        .hasQualifiedName(pkg, name)
+  |
+    pkg = "syscall" and name = "StringSlicePtr"
+    or
+    pkg.matches("crypto/rand.%") and
+    name = "Read"
+    or
+    pkg = ["os.dirEntry", "os.unixDirent"] and name = ["Info", "Name"]
+  )
 select pred, succ


### PR DESCRIPTION
Some of the expected test results introduced in https://github.com/github/codeql/pull/12750 are platform-specific. This PR excludes those functions from the tests. It also (horrifyingly) turns out that the results differ between Go 1.20.0 and Go 1.20.3, so this PR updates the tests to run on the latest patch version of Go 1.20.