### PR TITLE
Prevent Ruby join order regression

### DIFF
--- a/ruby/ql/lib/codeql/ruby/ast/internal/Synthesis.qll
+++ b/ruby/ql/lib/codeql/ruby/ast/internal/Synthesis.qll
@@ -1169,12 +1169,11 @@ private module ArrayLiteralDesugar {
       child = SynthChild(MethodCallKind("[]", false, al.getNumberOfElements()))
       or
       parent = TMethodCallSynth(al, -1, _, _, _) and
-      (
-        i = 0 and
-        child = SynthChild(ConstantReadAccessKind("::Array"))
-        or
-        child = childRef(al.getElement(i - 1))
-      )
+      i = 0 and
+      child = SynthChild(ConstantReadAccessKind("::Array"))
+      or
+      parent = TMethodCallSynth(al, -1, _, _, _) and
+      child = childRef(al.getElement(i - 1))
     )
   }
 


### PR DESCRIPTION
This PR distributes the `parent = TMethodCallSynth(al, -1, _, _, _)` conjunct into the disjunction to ensure each disjunct binds the same fields to allow the join orderer more freedom when choosing the join order. This prevents a planned join ordering tweak from causing a join order regression. 