### PR TITLE
Swift: Delete deprecated classes

### DIFF
--- a/swift/ql/lib/codeql/swift/security/CleartextLoggingQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/CleartextLoggingQuery.qll
@@ -12,28 +12,6 @@ private import codeql.swift.security.SensitiveExprs
 /**
  * A taint-tracking configuration for cleartext logging of sensitive data vulnerabilities.
  */
-deprecated class CleartextLoggingConfiguration extends TaintTracking::Configuration {
-  CleartextLoggingConfiguration() { this = "CleartextLoggingConfiguration" }
-
-  override predicate isSource(DataFlow::Node source) { source.asExpr() instanceof SensitiveExpr }
-
-  override predicate isSink(DataFlow::Node sink) { sink instanceof CleartextLoggingSink }
-
-  override predicate isSanitizer(DataFlow::Node sanitizer) {
-    sanitizer instanceof CleartextLoggingSanitizer
-  }
-
-  // Disregard paths that contain other paths. This helps with performance.
-  override predicate isSanitizerIn(DataFlow::Node node) { this.isSource(node) }
-
-  override predicate isAdditionalTaintStep(DataFlow::Node n1, DataFlow::Node n2) {
-    any(CleartextLoggingAdditionalTaintStep s).step(n1, n2)
-  }
-}
-
-/**
- * A taint-tracking configuration for cleartext logging of sensitive data vulnerabilities.
- */
 module CleartextLoggingConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) { source.asExpr() instanceof SensitiveExpr }
 

--- a/swift/ql/lib/codeql/swift/security/CleartextStorageDatabaseQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/CleartextStorageDatabaseQuery.qll
@@ -13,46 +13,6 @@ import codeql.swift.security.CleartextStorageDatabaseExtensions
  * A taint configuration from sensitive information to expressions that are
  * transmitted over a network.
  */
-deprecated class CleartextStorageConfig extends TaintTracking::Configuration {
-  CleartextStorageConfig() { this = "CleartextStorageConfig" }
-
-  override predicate isSource(DataFlow::Node node) { node.asExpr() instanceof SensitiveExpr }
-
-  override predicate isSink(DataFlow::Node node) { node instanceof CleartextStorageDatabaseSink }
-
-  override predicate isSanitizer(DataFlow::Node sanitizer) {
-    sanitizer instanceof CleartextStorageDatabaseSanitizer
-  }
-
-  override predicate isAdditionalTaintStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
-    any(CleartextStorageDatabaseAdditionalTaintStep s).step(nodeFrom, nodeTo)
-  }
-
-  override predicate isSanitizerIn(DataFlow::Node node) {
-    // make sources barriers so that we only report the closest instance
-    isSource(node)
-  }
-
-  override predicate allowImplicitRead(DataFlow::Node node, DataFlow::ContentSet c) {
-    // flow out from fields of an `NSManagedObject` or `RealmSwiftObject` at the sink,
-    // for example in `realmObj.data = sensitive`.
-    isSink(node) and
-    exists(NominalTypeDecl d, Decl cx |
-      d.getType().getABaseType*().getUnderlyingType().getName() =
-        ["NSManagedObject", "RealmSwiftObject"] and
-      cx.asNominalTypeDecl() = d and
-      c.getAReadContent().(DataFlow::Content::FieldContent).getField() = cx.getAMember()
-    )
-    or
-    // any default implicit reads
-    super.allowImplicitRead(node, c)
-  }
-}
-
-/**
- * A taint configuration from sensitive information to expressions that are
- * transmitted over a network.
- */
 module CleartextStorageConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node node) { node.asExpr() instanceof SensitiveExpr }
 

--- a/swift/ql/lib/codeql/swift/security/CleartextStorageDatabaseQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/CleartextStorageDatabaseQuery.qll
@@ -13,7 +13,7 @@ import codeql.swift.security.CleartextStorageDatabaseExtensions
  * A taint configuration from sensitive information to expressions that are
  * transmitted over a network.
  */
-module CleartextStorageConfig implements DataFlow::ConfigSig {
+module CleartextStorageDatabaseConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node node) { node.asExpr() instanceof SensitiveExpr }
 
   predicate isSink(DataFlow::Node node) { node instanceof CleartextStorageDatabaseSink }
@@ -48,4 +48,4 @@ module CleartextStorageConfig implements DataFlow::ConfigSig {
  * Detect taint flow of sensitive information to expressions that are
  * transmitted over a network.
  */
-module CleartextStorageFlow = TaintTracking::Global<CleartextStorageConfig>;
+module CleartextStorageDatabaseFlow = TaintTracking::Global<CleartextStorageDatabaseConfig>;

--- a/swift/ql/lib/codeql/swift/security/CleartextStoragePreferencesQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/CleartextStoragePreferencesQuery.qll
@@ -13,31 +13,6 @@ import codeql.swift.security.CleartextStoragePreferencesExtensions
  * A taint configuration from sensitive information to expressions that are
  * stored as preferences.
  */
-deprecated class CleartextStorageConfig extends TaintTracking::Configuration {
-  CleartextStorageConfig() { this = "CleartextStorageConfig" }
-
-  override predicate isSource(DataFlow::Node node) { node.asExpr() instanceof SensitiveExpr }
-
-  override predicate isSink(DataFlow::Node node) { node instanceof CleartextStoragePreferencesSink }
-
-  override predicate isSanitizer(DataFlow::Node sanitizer) {
-    sanitizer instanceof CleartextStoragePreferencesSanitizer
-  }
-
-  override predicate isAdditionalTaintStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
-    any(CleartextStoragePreferencesAdditionalTaintStep s).step(nodeFrom, nodeTo)
-  }
-
-  override predicate isSanitizerIn(DataFlow::Node node) {
-    // make sources barriers so that we only report the closest instance
-    this.isSource(node)
-  }
-}
-
-/**
- * A taint configuration from sensitive information to expressions that are
- * stored as preferences.
- */
 module CleartextStorageConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node node) { node.asExpr() instanceof SensitiveExpr }
 

--- a/swift/ql/lib/codeql/swift/security/CleartextStoragePreferencesQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/CleartextStoragePreferencesQuery.qll
@@ -13,7 +13,7 @@ import codeql.swift.security.CleartextStoragePreferencesExtensions
  * A taint configuration from sensitive information to expressions that are
  * stored as preferences.
  */
-module CleartextStorageConfig implements DataFlow::ConfigSig {
+module CleartextStoragePreferencesConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node node) { node.asExpr() instanceof SensitiveExpr }
 
   predicate isSink(DataFlow::Node node) { node instanceof CleartextStoragePreferencesSink }
@@ -36,4 +36,4 @@ module CleartextStorageConfig implements DataFlow::ConfigSig {
  * Detect taint flow of sensitive information to expressions that are stored
  * as preferences.
  */
-module CleartextStorageFlow = TaintTracking::Global<CleartextStorageConfig>;
+module CleartextStoragePreferencesFlow = TaintTracking::Global<CleartextStoragePreferencesConfig>;

--- a/swift/ql/lib/codeql/swift/security/CleartextTransmissionQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/CleartextTransmissionQuery.qll
@@ -13,31 +13,6 @@ import codeql.swift.security.CleartextTransmissionExtensions
  * A taint configuration from sensitive information to expressions that are
  * transmitted over a network.
  */
-deprecated class CleartextTransmissionConfig extends TaintTracking::Configuration {
-  CleartextTransmissionConfig() { this = "CleartextTransmissionConfig" }
-
-  override predicate isSource(DataFlow::Node node) { node.asExpr() instanceof SensitiveExpr }
-
-  override predicate isSink(DataFlow::Node node) { node instanceof CleartextTransmissionSink }
-
-  override predicate isSanitizer(DataFlow::Node sanitizer) {
-    sanitizer instanceof CleartextTransmissionSanitizer
-  }
-
-  override predicate isAdditionalTaintStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
-    any(CleartextTransmissionAdditionalTaintStep s).step(nodeFrom, nodeTo)
-  }
-
-  override predicate isSanitizerIn(DataFlow::Node node) {
-    // make sources barriers so that we only report the closest instance
-    isSource(node)
-  }
-}
-
-/**
- * A taint configuration from sensitive information to expressions that are
- * transmitted over a network.
- */
 module CleartextTransmissionConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node node) { node.asExpr() instanceof SensitiveExpr }
 

--- a/swift/ql/lib/codeql/swift/security/PathInjectionQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/PathInjectionQuery.qll
@@ -13,25 +13,6 @@ private import codeql.swift.security.PathInjectionExtensions
 /**
  * A taint-tracking configuration for path injection vulnerabilities.
  */
-deprecated class PathInjectionConfiguration extends TaintTracking::Configuration {
-  PathInjectionConfiguration() { this = "PathInjectionConfiguration" }
-
-  override predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
-
-  override predicate isSink(DataFlow::Node sink) { sink instanceof PathInjectionSink }
-
-  override predicate isSanitizer(DataFlow::Node sanitizer) {
-    sanitizer instanceof PathInjectionSanitizer
-  }
-
-  override predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) {
-    any(PathInjectionAdditionalTaintStep s).step(node1, node2)
-  }
-}
-
-/**
- * A taint-tracking configuration for path injection vulnerabilities.
- */
 module PathInjectionConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
 

--- a/swift/ql/lib/codeql/swift/security/PredicateInjectionQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/PredicateInjectionQuery.qll
@@ -12,25 +12,6 @@ private import codeql.swift.security.PredicateInjectionExtensions
 /**
  * A taint-tracking configuration for predicate injection vulnerabilities.
  */
-deprecated class PredicateInjectionConf extends TaintTracking::Configuration {
-  PredicateInjectionConf() { this = "PredicateInjectionConf" }
-
-  override predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
-
-  override predicate isSink(DataFlow::Node sink) { sink instanceof PredicateInjectionSink }
-
-  override predicate isSanitizer(DataFlow::Node sanitizer) {
-    sanitizer instanceof PredicateInjectionSanitizer
-  }
-
-  override predicate isAdditionalTaintStep(DataFlow::Node n1, DataFlow::Node n2) {
-    any(PredicateInjectionAdditionalTaintStep s).step(n1, n2)
-  }
-}
-
-/**
- * A taint-tracking configuration for predicate injection vulnerabilities.
- */
 module PredicateInjectionConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
 

--- a/swift/ql/lib/codeql/swift/security/SqlInjectionQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/SqlInjectionQuery.qll
@@ -13,25 +13,6 @@ import codeql.swift.security.SqlInjectionExtensions
 /**
  * A taint configuration for tainted data that reaches a SQL sink.
  */
-deprecated class SqlInjectionConfig extends TaintTracking::Configuration {
-  SqlInjectionConfig() { this = "SqlInjectionConfig" }
-
-  override predicate isSource(DataFlow::Node node) { node instanceof FlowSource }
-
-  override predicate isSink(DataFlow::Node node) { node instanceof SqlInjectionSink }
-
-  override predicate isSanitizer(DataFlow::Node sanitizer) {
-    sanitizer instanceof SqlInjectionSanitizer
-  }
-
-  override predicate isAdditionalTaintStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
-    any(SqlInjectionAdditionalTaintStep s).step(nodeFrom, nodeTo)
-  }
-}
-
-/**
- * A taint configuration for tainted data that reaches a SQL sink.
- */
 module SqlInjectionConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node node) { node instanceof FlowSource }
 

--- a/swift/ql/lib/codeql/swift/security/UncontrolledFormatStringQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/UncontrolledFormatStringQuery.qll
@@ -13,25 +13,6 @@ import codeql.swift.security.UncontrolledFormatStringExtensions
 /**
  * A taint configuration for tainted data that reaches a format string.
  */
-deprecated class TaintedFormatConfiguration extends TaintTracking::Configuration {
-  TaintedFormatConfiguration() { this = "TaintedFormatConfiguration" }
-
-  override predicate isSource(DataFlow::Node node) { node instanceof FlowSource }
-
-  override predicate isSink(DataFlow::Node node) { node instanceof UncontrolledFormatStringSink }
-
-  override predicate isSanitizer(DataFlow::Node sanitizer) {
-    sanitizer instanceof UncontrolledFormatStringSanitizer
-  }
-
-  override predicate isAdditionalTaintStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
-    any(UncontrolledFormatStringAdditionalTaintStep s).step(nodeFrom, nodeTo)
-  }
-}
-
-/**
- * A taint configuration for tainted data that reaches a format string.
- */
 module TaintedFormatConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node node) { node instanceof FlowSource }
 

--- a/swift/ql/lib/codeql/swift/security/UnsafeJsEvalQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/UnsafeJsEvalQuery.qll
@@ -12,25 +12,6 @@ import codeql.swift.security.UnsafeJsEvalExtensions
 /**
  * A taint configuration from taint sources to sinks for this query.
  */
-deprecated class UnsafeJsEvalConfig extends TaintTracking::Configuration {
-  UnsafeJsEvalConfig() { this = "UnsafeJsEvalConfig" }
-
-  override predicate isSource(DataFlow::Node node) { node instanceof FlowSource }
-
-  override predicate isSink(DataFlow::Node node) { node instanceof UnsafeJsEvalSink }
-
-  override predicate isSanitizer(DataFlow::Node sanitizer) {
-    sanitizer instanceof UnsafeJsEvalSanitizer
-  }
-
-  override predicate isAdditionalTaintStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
-    any(UnsafeJsEvalAdditionalTaintStep s).step(nodeFrom, nodeTo)
-  }
-}
-
-/**
- * A taint configuration from taint sources to sinks for this query.
- */
 module UnsafeJsEvalConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node node) { node instanceof FlowSource }
 

--- a/swift/ql/lib/codeql/swift/security/UnsafeWebViewFetchQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/UnsafeWebViewFetchQuery.qll
@@ -13,31 +13,6 @@ import codeql.swift.security.UnsafeWebViewFetchExtensions
  * A taint configuration from taint sources to sinks (and `baseURL` arguments)
  * for this query.
  */
-deprecated class UnsafeWebViewFetchConfig extends TaintTracking::Configuration {
-  UnsafeWebViewFetchConfig() { this = "UnsafeWebViewFetchConfig" }
-
-  override predicate isSource(DataFlow::Node node) { node instanceof RemoteFlowSource }
-
-  override predicate isSink(DataFlow::Node node) {
-    exists(UnsafeWebViewFetchSink sink |
-      node = sink or
-      node.asExpr() = sink.getBaseUrl()
-    )
-  }
-
-  override predicate isSanitizer(DataFlow::Node sanitizer) {
-    sanitizer instanceof UnsafeWebViewFetchSanitizer
-  }
-
-  override predicate isAdditionalTaintStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
-    any(UnsafeWebViewFetchAdditionalTaintStep s).step(nodeFrom, nodeTo)
-  }
-}
-
-/**
- * A taint configuration from taint sources to sinks (and `baseURL` arguments)
- * for this query.
- */
 module UnsafeWebViewFetchConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node node) { node instanceof RemoteFlowSource }
 

--- a/swift/ql/lib/codeql/swift/security/XXEQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/XXEQuery.qll
@@ -12,23 +12,6 @@ import codeql.swift.security.XXEExtensions
 /**
  * A taint-tracking configuration for XML external entities (XXE) vulnerabilities.
  */
-deprecated class XxeConfiguration extends TaintTracking::Configuration {
-  XxeConfiguration() { this = "XxeConfiguration" }
-
-  override predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
-
-  override predicate isSink(DataFlow::Node sink) { sink instanceof XxeSink }
-
-  override predicate isSanitizer(DataFlow::Node sanitizer) { sanitizer instanceof XxeSanitizer }
-
-  override predicate isAdditionalTaintStep(DataFlow::Node n1, DataFlow::Node n2) {
-    any(XxeAdditionalTaintStep s).step(n1, n2)
-  }
-}
-
-/**
- * A taint-tracking configuration for XML external entities (XXE) vulnerabilities.
- */
 module XxeConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
 

--- a/swift/ql/src/queries/Security/CWE-311/CleartextStorageDatabase.ql
+++ b/swift/ql/src/queries/Security/CWE-311/CleartextStorageDatabase.ql
@@ -14,7 +14,7 @@
 import swift
 import codeql.swift.dataflow.DataFlow
 import codeql.swift.security.CleartextStorageDatabaseQuery
-import CleartextStorageFlow::PathGraph
+import CleartextStorageDatabaseFlow::PathGraph
 
 /**
  * Gets a prettier node to use in the results.
@@ -27,10 +27,10 @@ DataFlow::Node cleanupNode(DataFlow::Node n) {
 }
 
 from
-  CleartextStorageFlow::PathNode sourceNode, CleartextStorageFlow::PathNode sinkNode,
+CleartextStorageDatabaseFlow::PathNode sourceNode, CleartextStorageDatabaseFlow::PathNode sinkNode,
   DataFlow::Node cleanSink
 where
-  CleartextStorageFlow::flowPath(sourceNode, sinkNode) and
+CleartextStorageDatabaseFlow::flowPath(sourceNode, sinkNode) and
   cleanSink = cleanupNode(sinkNode.getNode())
 select cleanSink, sourceNode, sinkNode,
   "This operation stores '" + cleanSink.toString() +

--- a/swift/ql/src/queries/Security/CWE-311/CleartextStorageDatabase.ql
+++ b/swift/ql/src/queries/Security/CWE-311/CleartextStorageDatabase.ql
@@ -27,10 +27,10 @@ DataFlow::Node cleanupNode(DataFlow::Node n) {
 }
 
 from
-CleartextStorageDatabaseFlow::PathNode sourceNode, CleartextStorageDatabaseFlow::PathNode sinkNode,
-  DataFlow::Node cleanSink
+  CleartextStorageDatabaseFlow::PathNode sourceNode,
+  CleartextStorageDatabaseFlow::PathNode sinkNode, DataFlow::Node cleanSink
 where
-CleartextStorageDatabaseFlow::flowPath(sourceNode, sinkNode) and
+  CleartextStorageDatabaseFlow::flowPath(sourceNode, sinkNode) and
   cleanSink = cleanupNode(sinkNode.getNode())
 select cleanSink, sourceNode, sinkNode,
   "This operation stores '" + cleanSink.toString() +

--- a/swift/ql/src/queries/Security/CWE-312/CleartextStoragePreferences.ql
+++ b/swift/ql/src/queries/Security/CWE-312/CleartextStoragePreferences.ql
@@ -26,10 +26,10 @@ DataFlow::Node cleanupNode(DataFlow::Node n) {
 }
 
 from
-CleartextStoragePreferencesFlow::PathNode sourceNode, CleartextStoragePreferencesFlow::PathNode sinkNode,
-  DataFlow::Node cleanSink
+  CleartextStoragePreferencesFlow::PathNode sourceNode,
+  CleartextStoragePreferencesFlow::PathNode sinkNode, DataFlow::Node cleanSink
 where
-CleartextStoragePreferencesFlow::flowPath(sourceNode, sinkNode) and
+  CleartextStoragePreferencesFlow::flowPath(sourceNode, sinkNode) and
   cleanSink = cleanupNode(sinkNode.getNode())
 select cleanSink, sourceNode, sinkNode,
   "This operation stores '" + cleanSink.toString() + "' in " +

--- a/swift/ql/src/queries/Security/CWE-312/CleartextStoragePreferences.ql
+++ b/swift/ql/src/queries/Security/CWE-312/CleartextStoragePreferences.ql
@@ -13,7 +13,7 @@
 import swift
 import codeql.swift.dataflow.DataFlow
 import codeql.swift.security.CleartextStoragePreferencesQuery
-import CleartextStorageFlow::PathGraph
+import CleartextStoragePreferencesFlow::PathGraph
 
 /**
  * Gets a prettier node to use in the results.
@@ -26,10 +26,10 @@ DataFlow::Node cleanupNode(DataFlow::Node n) {
 }
 
 from
-  CleartextStorageFlow::PathNode sourceNode, CleartextStorageFlow::PathNode sinkNode,
+CleartextStoragePreferencesFlow::PathNode sourceNode, CleartextStoragePreferencesFlow::PathNode sinkNode,
   DataFlow::Node cleanSink
 where
-  CleartextStorageFlow::flowPath(sourceNode, sinkNode) and
+CleartextStoragePreferencesFlow::flowPath(sourceNode, sinkNode) and
   cleanSink = cleanupNode(sinkNode.getNode())
 select cleanSink, sourceNode, sinkNode,
   "This operation stores '" + cleanSink.toString() + "' in " +


### PR DESCRIPTION
Delete deprecated classes in Swift, before the public beta.  After public beta we will have a short (1 release) deprecation cycle, after general release we will have the full (1 year) deprecation cycle.  It seems best to start from a clean state.

This excludes files shared with other languages (these things will follow the normal deprecation cycle in sync with other languages) and `BarrierGuard` in `DataFlowPublic.qll` (coupled to the above).

I've also renamed a couple of dataflow modules for different queries that had ended up with the same names - not ideal if someone ever wants to use them together for whatever reason.