### PR TITLE
Update `SimpleXmlRpcServer.ql` to avoid incorrect detection as a trojan by Mcafee

### DIFF
--- a/python/ql/src/experimental/Security/CWE-611/SimpleXmlRpcServer.ql
+++ b/python/ql/src/experimental/Security/CWE-611/SimpleXmlRpcServer.ql
@@ -1,6 +1,6 @@
 /**
- * @name SimpleXMLRPCServer DoS vulnerability
- * @description SimpleXMLRPCServer is vulnerable to DoS attacks from untrusted user input
+ * @name SimpleXMLRPCServer denial of service
+ * @description SimpleXMLRPCServer is vulnerable to denial of service attacks from untrusted user input
  * @kind problem
  * @problem.severity warning
  * @precision high


### PR DESCRIPTION
This file was being flagged by McAfee as an `Exploit-Generic.src` trojan. We have attempted to report this to Mcafee without success so far. I've therefore modified this file to avoid the false positive detection. It turned out to be quite straightforward - the heuristic appears to be including the words "SimpleXMLRPCServer" and "DoS" on the same line.

I've resolved this by expanding the acronym to "denial of service", and used virustotal to show that it was flagged before but not afterwards.

Before:
https://www.virustotal.com/gui/file/046515358490621ca7494c0d9da0b9d4cf8e136342858e950c689fbc46f03ba9

After:
https://www.virustotal.com/gui/file/68fad1baaa66a3e717ec7c03f6ca317b2bc2fd2c1f7d17272df6ce210b5ccf96?nocache=1

/cc @adityasharad @panoslith