### PR TITLE
Prevent Ruby join order regression

### DIFF
--- a/ruby/ql/lib/codeql/ruby/ast/internal/Synthesis.qll
+++ b/ruby/ql/lib/codeql/ruby/ast/internal/Synthesis.qll
@@ -1211,12 +1211,11 @@ private module HashLiteralDesugar {
       child = SynthChild(MethodCallKind("[]", false, hl.getNumberOfElements()))
       or
       parent = TMethodCallSynth(hl, -1, _, _, _) and
-      (
-        i = 0 and
-        child = SynthChild(ConstantReadAccessKind("::Hash"))
-        or
-        child = childRef(hl.getElement(i - 1))
-      )
+      i = 0 and
+      child = SynthChild(ConstantReadAccessKind("::Hash"))
+      or
+      parent = TMethodCallSynth(hl, -1, _, _, _) and
+      child = childRef(hl.getElement(i - 1))
     )
   }
 


### PR DESCRIPTION
Similar to https://github.com/github/codeql/pull/12875: This PR distributes the `parent = TMethodCallSynth(hl, -1, _, _, _)` conjunct into the disjunction to ensure each disjunct binds the same fields to allow the join orderer more freedom when choosing the join order. This prevents a planned join ordering tweak from causing a join order regression. There are several other similar conjuncts that could be distributed into disjuncts manually, but I will leave those as is for readability as they do not appear to cause similar regressions with the planned join ordering tweaks. 