### PR TITLE
Java: Refactor Kotlin Integration tests to new DataFlow API

### DIFF
--- a/java/ql/integration-tests/all-platforms/kotlin/kotlin-interface-inherited-default/test.ql
+++ b/java/ql/integration-tests/all-platforms/kotlin/kotlin-interface-inherited-default/test.ql
@@ -19,18 +19,18 @@ query predicate superAccesses(
   enclosingType = enclosingCallable.getDeclaringType()
 }
 
-class Config extends DataFlow::Configuration {
-  Config() { this = "testconfig" }
-
-  override predicate isSource(DataFlow::Node x) {
+module Config implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node x) {
     x.asExpr() instanceof IntegerLiteral and x.getEnclosingCallable().fromSource()
   }
 
-  override predicate isSink(DataFlow::Node x) {
+  predicate isSink(DataFlow::Node x) {
     x.asExpr().(Argument).getCall().getCallee().getName() = "sink"
   }
 }
 
-from Config c, DataFlow::Node source, DataFlow::Node sink
-where c.hasFlow(source, sink)
+module Flow = DataFlow::Global<Config>;
+
+from DataFlow::Node source, DataFlow::Node sink
+where Flow::flow(source, sink)
 select source, sink

--- a/java/ql/integration-tests/all-platforms/kotlin/kotlin_java_static_fields/test.ql
+++ b/java/ql/integration-tests/all-platforms/kotlin/kotlin_java_static_fields/test.ql
@@ -2,16 +2,16 @@ import java
 import semmle.code.java.dataflow.DataFlow
 import DataFlow::PathGraph
 
-class Config extends DataFlow::Configuration {
-  Config() { this = "Config" }
+module Config implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node n) { n.asExpr().(StringLiteral).getValue() = "taint" }
 
-  override predicate isSource(DataFlow::Node n) { n.asExpr().(StringLiteral).getValue() = "taint" }
-
-  override predicate isSink(DataFlow::Node n) {
+  predicate isSink(DataFlow::Node n) {
     n.asExpr().(Argument).getCall().getCallee().getName() = "sink"
   }
 }
 
-from DataFlow::PathNode source, DataFlow::PathNode sink, Config c
-where c.hasFlowPath(source, sink)
+module Flow = DataFlow::Global<Config>;
+
+from Flow::PathNode source, Flow::PathNode sink
+where Flow::flowPath(source, sink)
 select source, source, sink, "flow path"


### PR DESCRIPTION
This should *actually* be the end of what's necessary to have everything moved over to the `DataFlow::ConfigSig` API!

When I previously refactored things in `java/ql/test`, these had some issues, so this PR handles them separate from #12812.