### PR TITLE
Swift: Doc review for swift/unsafe-webview-fetch

### DIFF
--- a/swift/ql/src/queries/Security/CWE-079/UnsafeWebViewFetch.qhelp
+++ b/swift/ql/src/queries/Security/CWE-079/UnsafeWebViewFetch.qhelp
@@ -4,7 +4,7 @@
 <qhelp>
 <overview>
 
-<p>Fetching data in a WebView without restricting the base URL may allow an attacker to access sensitive local data, for example using <code>file://</code>. Data can then be extracted from the software using the URL of a machine under the attackers control. More generally, an attacker may use a URL under their control as part of a cross-site scripting attack.</p>
+<p>Fetching data in a WebView without restricting the base URL may allow an attacker to access sensitive local data, for example using <code>file://</code>. Data can then be extracted from the software using the URL of a machine under the attacker's control. More generally, an attacker may use a URL under their control as part of a cross-site scripting attack.</p>
 
 </overview>
 <recommendation>

--- a/swift/ql/src/queries/Security/CWE-079/UnsafeWebViewFetch.qhelp
+++ b/swift/ql/src/queries/Security/CWE-079/UnsafeWebViewFetch.qhelp
@@ -3,6 +3,7 @@
   "qhelp.dtd">
 <qhelp>
 <overview>
+
 <p>Fetching data in a WebView without restricting the base URL may allow an attacker to access sensitive local data, for example using <code>file://</code>. Data can then be extracted from the software using the URL of a machine under the attackers control. More generally, an attacker may use a URL under their control as part of a cross-site scripting attack.</p>
 
 </overview>

--- a/swift/ql/src/queries/Security/CWE-079/UnsafeWebViewFetch.qhelp
+++ b/swift/ql/src/queries/Security/CWE-079/UnsafeWebViewFetch.qhelp
@@ -26,7 +26,7 @@
 <references>
 
 <li>
-  <a href="https://www.allysonomalley.com/2018/12/03/ios-bug-hunting-web-view-xss/">iOS Bug Hunting - Web View XSS</a>
+  <a href="https://www.allysonomalley.com/2018/12/03/ios-bug-hunting-web-view-xss/">iOS Bug Hunting - Web View XSS</a>.
 </li>
 
 </references>

--- a/swift/ql/src/queries/Security/CWE-079/UnsafeWebViewFetch.qhelp
+++ b/swift/ql/src/queries/Security/CWE-079/UnsafeWebViewFetch.qhelp
@@ -4,7 +4,7 @@
 <qhelp>
 <overview>
 
-<p>Fetching data in a WebView without restricting the base URL may allow an attacker to access sensitive local data, for example using <code>file://</code>. Data can then be extracted from the software using the URL of a machine under the attacker's control. More generally, an attacker may use a URL under their control as part of a cross-site scripting attack.</p>
+<p>Fetching data in a web view without restricting the base URL may allow an attacker to access sensitive local data, for example using <code>file://</code>. Data can then be extracted from the software using the URL of a machine under the attacker's control. More generally, an attacker may use a URL under their control as part of a cross-site scripting attack.</p>
 
 </overview>
 <recommendation>


### PR DESCRIPTION
It appears we forgot to get a doc review for the query `swift/unsafe-webview-fetch` in the [original PR here](https://github.com/github/codeql/pull/9964).  With public beta coming up, it's time to remedy that.  This PR is a space for that doc review and any changes that come from it.