### PR TITLE
Ruby: Fix bad join in `DestructuredAssignDesugar`

### DIFF
--- a/ruby/ql/lib/codeql/ruby/ast/internal/Synthesis.qll
+++ b/ruby/ql/lib/codeql/ruby/ast/internal/Synthesis.qll
@@ -952,6 +952,8 @@ private module DestructuredAssignDesugar {
   }
 
   abstract private class LhsWithReceiver extends Expr {
+    LhsWithReceiver() { this = any(DestructuredAssignExpr dae).getElement(_) }
+
     abstract Expr getReceiver();
 
     abstract SynthKind getSynthKind();
@@ -960,8 +962,14 @@ private module DestructuredAssignDesugar {
   private class LhsCall extends LhsWithReceiver instanceof MethodCall {
     final override Expr getReceiver() { result = MethodCall.super.getReceiver() }
 
+    pragma[nomagic]
+    private string getMethodName(int args) {
+      result = super.getMethodName() and
+      args = super.getNumberOfArguments()
+    }
+
     final override SynthKind getSynthKind() {
-      result = MethodCallKind(super.getMethodName(), false, super.getNumberOfArguments())
+      exists(int args | result = MethodCallKind(this.getMethodName(args), false, args))
     }
   }
 
@@ -1154,9 +1162,7 @@ private module DestructuredAssignDesugar {
       )
     }
 
-    final override predicate excludeFromControlFlowTree(AstNode n) {
-      n = any(DestructuredAssignExpr tae).getElement(_).(LhsWithReceiver)
-    }
+    final override predicate excludeFromControlFlowTree(AstNode n) { n instanceof LhsWithReceiver }
   }
 }
 


### PR DESCRIPTION
```
Evaluated relational algebra for predicate Synthesis#d9ff06b1::DestructuredAssignDesugar::LhsWithReceiver::getSynthKind#0#dispred#ff@0c55fb0w on iteration 4 running pipeline order_500000 with tuple counts:
                 0   ~0%    {2} r1 = JOIN Synthesis#d9ff06b1::ConstantWriteAccessKind#ff#prev_delta WITH Constant#c70e4e0a::ScopeResolutionConstantAccess::getName#0#dispred#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1
                 0   ~0%    {2} r2 = JOIN r1 WITH Constant#c70e4e0a::ScopeResolutionConstantAccess::getScopeExpr#0#dispred#ff#prev ON FIRST 1 OUTPUT Lhs.0, Lhs.1

                 0   ~0%    {4} r3 = JOIN Call#841c84e8::MethodCall::getMethodName#0#dispred#ff#prev_delta WITH Call#841c84e8::Call::getNumberOfArguments#0#dispred#ff#prev ON FIRST 1 OUTPUT Lhs.1, false, Rhs.1, Lhs.0
                 0   ~0%    {2} r4 = JOIN r3 WITH Synthesis#d9ff06b1::MethodCallKind#ffff#prev ON FIRST 3 OUTPUT Lhs.3, Rhs.3

                 0   ~0%    {2} r5 = r2 UNION r4

            336618   ~3%    {1} r6 = SCAN Constant#c70e4e0a::ScopeResolutionConstantAccess::getScopeExpr#0#dispred#ff#prev_delta OUTPUT In.0
            336618   ~0%    {2} r7 = JOIN r6 WITH Constant#c70e4e0a::ScopeResolutionConstantAccess::getName#0#dispred#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.0
                 0   ~0%    {2} r8 = JOIN r7 WITH Synthesis#d9ff06b1::ConstantWriteAccessKind#ff#prev ON FIRST 1 OUTPUT Lhs.1, Rhs.1

                 0   ~0%    {3} r9 = SCAN Call#841c84e8::Call::getNumberOfArguments#0#dispred#ff#prev_delta OUTPUT false, In.1, In.0
                 0   ~0%    {3} r10 = JOIN r9 WITH Synthesis#d9ff06b1::MethodCallKind#ffff#reorder_1_2_0_3#prev ON FIRST 2 OUTPUT Lhs.2, Rhs.2, Rhs.3
                 0   ~0%    {2} r11 = JOIN r10 WITH Call#841c84e8::MethodCall::getMethodName#0#dispred#ff#prev ON FIRST 2 OUTPUT Lhs.0, Lhs.2

              2119   ~2%    {3} r12 = JOIN Synthesis#d9ff06b1::MethodCallKind#ffff#reorder_1_2_0_3#prev_delta WITH const_false ON FIRST 1 OUTPUT Lhs.1, Lhs.2, Lhs.3
        2657005103   ~5%    {3} r13 = JOIN r12 WITH Call#841c84e8::Call::getNumberOfArguments#0#dispred#ff#reorder_1_0#prev ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2
           1184200   ~0%    {2} r14 = JOIN r13 WITH Call#841c84e8::MethodCall::getMethodName#0#dispred#ff#prev ON FIRST 2 OUTPUT Lhs.0, Lhs.2

           1184200   ~0%    {2} r15 = r11 UNION r14
           1184200   ~0%    {2} r16 = r8 UNION r15
           1184200   ~0%    {2} r17 = r5 UNION r16
           1184200   ~0%    {2} r18 = r17 AND NOT Synthesis#d9ff06b1::DestructuredAssignDesugar::LhsWithReceiver::getSynthKind#0#dispred#ff#prev(Lhs.0, Lhs.1)
                            return r18
```