### PR TITLE
Go: Fix invalid SemVer version by adding "v" to the front

### DIFF
--- a/go/extractor/cli/go-autobuilder/go-autobuilder.go
+++ b/go/extractor/cli/go-autobuilder/go-autobuilder.go
@@ -318,7 +318,7 @@ func getNeedGopath(depMode DependencyInstallerMode, importpath string) bool {
 
 func tryUpdateGoModAndGoSum(modMode ModMode, depMode DependencyInstallerMode) {
 	// Go 1.16 and later won't automatically attempt to update go.mod / go.sum during package loading, so try to update them here:
-	if modMode != ModVendor && depMode == GoGetWithModules && semver.Compare(getEnvGoSemVer(), "1.16") >= 0 {
+	if modMode != ModVendor && depMode == GoGetWithModules && semver.Compare(getEnvGoSemVer(), "v1.16") >= 0 {
 		// stat go.mod and go.sum
 		beforeGoModFileInfo, beforeGoModErr := os.Stat("go.mod")
 		if beforeGoModErr != nil {


### PR DESCRIPTION
The SemVer library we are using requires all version strings to start with "v".

Because it was missing, that function always returned +1, so we were doing the wrong thing when the Go version installed was lower than 1.16.