### PR TITLE
Swift: Upgrade two queries to precision high.

### DIFF
--- a/swift/ql/src/queries/Security/CWE-311/CleartextStorageDatabase.ql
+++ b/swift/ql/src/queries/Security/CWE-311/CleartextStorageDatabase.ql
@@ -5,7 +5,7 @@
  * @kind path-problem
  * @problem.severity warning
  * @security-severity 7.5
- * @precision medium
+ * @precision high
  * @id swift/cleartext-storage-database
  * @tags security
  *       external/cwe/cwe-312

--- a/swift/ql/src/queries/Security/CWE-312/CleartextStoragePreferences.ql
+++ b/swift/ql/src/queries/Security/CWE-312/CleartextStoragePreferences.ql
@@ -4,7 +4,7 @@
  * @kind path-problem
  * @problem.severity warning
  * @security-severity 7.5
- * @precision medium
+ * @precision high
  * @id swift/cleartext-storage-preferences
  * @tags security
  *       external/cwe/cwe-312


### PR DESCRIPTION
Upgrade two queries to `@precision high`.  Justified by a lack of FPs found on the MRVA top 1000 projects.  This is important as `@precision medium` queries will not show up in the [default] `swift-code-scanning.qls` suite.

A related PR, https://github.com/github/codeql/pull/12836/ , temporarily downgrades a query that does currently show false positive results.