### PR TITLE
Dataflow: Refactor access paths to split TypedContent into an explicit pair

### DIFF
--- a/csharp/ql/src/utils/modelgenerator/internal/CaptureModels.qll
+++ b/csharp/ql/src/utils/modelgenerator/internal/CaptureModels.qll
@@ -139,9 +139,9 @@ module ThroughFlowConfig implements DataFlow::StateConfigSig {
   predicate isAdditionalFlowStep(
     DataFlow::Node node1, FlowState state1, DataFlow::Node node2, FlowState state2
   ) {
-    exists(DataFlowImplCommon::TypedContent tc |
-      DataFlowImplCommon::store(node1, tc, node2, _) and
-      isRelevantContent(tc.getContent()) and
+    exists(DataFlow::Content c |
+      DataFlowImplCommon::store(node1, c, node2, _, _) and
+      isRelevantContent(c) and
       (
         state1 instanceof TaintRead and state2.(TaintStore).getStep() = 1
         or

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -392,7 +392,7 @@ module Impl<FullStateConfigSig Config> {
 
   pragma[nomagic]
   private predicate storeEx(NodeEx node1, Content c, NodeEx node2, DataFlowType contentType, DataFlowType containerType) {
-    store(pragma[only_bind_into](node1.asNode()), _, c, pragma[only_bind_into](node2.asNode()),
+    store(pragma[only_bind_into](node1.asNode()), c, pragma[only_bind_into](node2.asNode()),
       contentType, containerType) and
     hasReadStep(c) and
     stepFilter(node1, node2)

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -391,7 +391,9 @@ module Impl<FullStateConfigSig Config> {
   private predicate hasReadStep(Content c) { read(_, c, _) }
 
   pragma[nomagic]
-  private predicate storeEx(NodeEx node1, Content c, NodeEx node2, DataFlowType contentType, DataFlowType containerType) {
+  private predicate storeEx(
+    NodeEx node1, Content c, NodeEx node2, DataFlowType contentType, DataFlowType containerType
+  ) {
     store(pragma[only_bind_into](node1.asNode()), c, pragma[only_bind_into](node2.asNode()),
       contentType, containerType) and
     hasReadStep(c) and
@@ -802,7 +804,8 @@ module Impl<FullStateConfigSig Config> {
 
     pragma[nomagic]
     predicate storeStepCand(
-      NodeEx node1, Ap ap1, Content c, NodeEx node2, DataFlowType contentType, DataFlowType containerType
+      NodeEx node1, Ap ap1, Content c, NodeEx node2, DataFlowType contentType,
+      DataFlowType containerType
     ) {
       revFlowIsReadAndStored(c) and
       revFlow(node2) and
@@ -1049,7 +1052,8 @@ module Impl<FullStateConfigSig Config> {
     predicate returnMayFlowThrough(RetNodeEx ret, Ap argAp, Ap ap, ReturnKindExt kind);
 
     predicate storeStepCand(
-      NodeEx node1, Ap ap1, Content c, NodeEx node2, DataFlowType contentType, DataFlowType containerType
+      NodeEx node1, Ap ap1, Content c, NodeEx node2, DataFlowType contentType,
+      DataFlowType containerType
     );
 
     predicate readStepCand(NodeEx n1, Content c, NodeEx n2);
@@ -1192,8 +1196,8 @@ module Impl<FullStateConfigSig Config> {
        */
       pragma[nomagic]
       additional predicate fwdFlow(
-        NodeEx node, FlowState state, Cc cc, ParamNodeOption summaryCtx, TypOption argT, ApOption argAp, Typ t, Ap ap,
-        ApApprox apa
+        NodeEx node, FlowState state, Cc cc, ParamNodeOption summaryCtx, TypOption argT,
+        ApOption argAp, Typ t, Ap ap, ApApprox apa
       ) {
         fwdFlow0(node, state, cc, summaryCtx, argT, argAp, t, ap, apa) and
         PrevStage::revFlow(node, state, apa) and
@@ -1202,7 +1206,8 @@ module Impl<FullStateConfigSig Config> {
 
       pragma[inline]
       additional predicate fwdFlow(
-        NodeEx node, FlowState state, Cc cc, ParamNodeOption summaryCtx, TypOption argT, ApOption argAp, Typ t, Ap ap
+        NodeEx node, FlowState state, Cc cc, ParamNodeOption summaryCtx, TypOption argT,
+        ApOption argAp, Typ t, Ap ap
       ) {
         fwdFlow(node, state, cc, summaryCtx, argT, argAp, t, ap, _)
       }
@@ -1210,8 +1215,8 @@ module Impl<FullStateConfigSig Config> {
       pragma[assume_small_delta]
       pragma[nomagic]
       private predicate fwdFlow0(
-        NodeEx node, FlowState state, Cc cc, ParamNodeOption summaryCtx, TypOption argT, ApOption argAp, Typ t, Ap ap,
-        ApApprox apa
+        NodeEx node, FlowState state, Cc cc, ParamNodeOption summaryCtx, TypOption argT,
+        ApOption argAp, Typ t, Ap ap, ApApprox apa
       ) {
         sourceNode(node, state) and
         (if hasSourceCallCtx() then cc = ccSomeCall() else cc = ccNone()) and
@@ -1380,8 +1385,7 @@ module Impl<FullStateConfigSig Config> {
       ) {
         exists(ReturnKindExt kind |
           fwdFlow(pragma[only_bind_into](ret), state, ccc,
-            TParamNodeSome(pragma[only_bind_into](summaryCtx.asNode())),
-            TypOption::some(argT),
+            TParamNodeSome(pragma[only_bind_into](summaryCtx.asNode())), TypOption::some(argT),
             pragma[only_bind_into](apSome(argAp)), t, ap, pragma[only_bind_into](apa)) and
           kind = ret.getKind() and
           parameterFlowThroughAllowed(summaryCtx, kind) and
@@ -1392,20 +1396,24 @@ module Impl<FullStateConfigSig Config> {
 
       pragma[inline]
       private predicate fwdFlowThrough0(
-        DataFlowCall call, Cc cc, FlowState state, CcCall ccc, ParamNodeOption summaryCtx, TypOption argT,
-        ApOption argAp, Typ t, Ap ap, ApApprox apa, RetNodeEx ret, ParamNodeEx innerSummaryCtx,
-        Typ innerArgT, Ap innerArgAp, ApApprox innerArgApa
+        DataFlowCall call, Cc cc, FlowState state, CcCall ccc, ParamNodeOption summaryCtx,
+        TypOption argT, ApOption argAp, Typ t, Ap ap, ApApprox apa, RetNodeEx ret,
+        ParamNodeEx innerSummaryCtx, Typ innerArgT, Ap innerArgAp, ApApprox innerArgApa
       ) {
-        fwdFlowRetFromArg(ret, state, ccc, innerSummaryCtx, innerArgT, innerArgAp, innerArgApa, t, ap, apa) and
-        fwdFlowIsEntered(call, cc, ccc, summaryCtx, argT, argAp, innerSummaryCtx, innerArgT, innerArgAp)
+        fwdFlowRetFromArg(ret, state, ccc, innerSummaryCtx, innerArgT, innerArgAp, innerArgApa, t,
+          ap, apa) and
+        fwdFlowIsEntered(call, cc, ccc, summaryCtx, argT, argAp, innerSummaryCtx, innerArgT,
+          innerArgAp)
       }
 
       pragma[nomagic]
       private predicate fwdFlowThrough(
         DataFlowCall call, Cc cc, FlowState state, CcCall ccc, ParamNodeOption summaryCtx,
-        TypOption argT, ApOption argAp, Typ t, Ap ap, ApApprox apa, RetNodeEx ret, ApApprox innerArgApa
+        TypOption argT, ApOption argAp, Typ t, Ap ap, ApApprox apa, RetNodeEx ret,
+        ApApprox innerArgApa
       ) {
-        fwdFlowThrough0(call, cc, state, ccc, summaryCtx, argT, argAp, t, ap, apa, ret, _, _, _, innerArgApa)
+        fwdFlowThrough0(call, cc, state, ccc, summaryCtx, argT, argAp, t, ap, apa, ret, _, _, _,
+          innerArgApa)
       }
 
       /**
@@ -1414,8 +1422,8 @@ module Impl<FullStateConfigSig Config> {
        */
       pragma[nomagic]
       private predicate fwdFlowIsEntered(
-        DataFlowCall call, Cc cc, CcCall innerCc, ParamNodeOption summaryCtx, TypOption argT, ApOption argAp,
-        ParamNodeEx p, Typ t, Ap ap
+        DataFlowCall call, Cc cc, CcCall innerCc, ParamNodeOption summaryCtx, TypOption argT,
+        ApOption argAp, ParamNodeEx p, Typ t, Ap ap
       ) {
         exists(ApApprox apa |
           fwdFlowIn(call, pragma[only_bind_into](p), _, cc, innerCc, summaryCtx, argT, argAp, t, ap,
@@ -1445,14 +1453,14 @@ module Impl<FullStateConfigSig Config> {
         DataFlowCall call, FlowState state, CcCall ccc, Ap ap, ApApprox apa, RetNodeEx ret,
         ParamNodeEx innerSummaryCtx, Typ innerArgT, Ap innerArgAp, ApApprox innerArgApa
       ) {
-        fwdFlowThrough0(call, _, state, ccc, _, _, _, _, ap, apa, ret, innerSummaryCtx, innerArgT, innerArgAp,
-          innerArgApa)
+        fwdFlowThrough0(call, _, state, ccc, _, _, _, _, ap, apa, ret, innerSummaryCtx, innerArgT,
+          innerArgAp, innerArgApa)
       }
 
       pragma[nomagic]
       private predicate returnFlowsThrough(
-        RetNodeEx ret, ReturnPosition pos, FlowState state, CcCall ccc, ParamNodeEx p, Typ argT, Ap argAp,
-        Ap ap
+        RetNodeEx ret, ReturnPosition pos, FlowState state, CcCall ccc, ParamNodeEx p, Typ argT,
+        Ap argAp, Ap ap
       ) {
         exists(DataFlowCall call, ApApprox apa, boolean allowsFieldFlow, ApApprox innerArgApa |
           returnFlowsThrough0(call, state, ccc, ap, apa, ret, p, argT, argAp, innerArgApa) and
@@ -1469,8 +1477,10 @@ module Impl<FullStateConfigSig Config> {
         exists(ApApprox argApa, Typ argT |
           flowIntoCallApa(call, pragma[only_bind_into](arg), pragma[only_bind_into](p),
             allowsFieldFlow, argApa) and
-          fwdFlow(arg, _, _, _, _, _, pragma[only_bind_into](argT), pragma[only_bind_into](argAp), argApa) and
-          returnFlowsThrough(_, _, _, _, p, pragma[only_bind_into](argT), pragma[only_bind_into](argAp), ap) and
+          fwdFlow(arg, _, _, _, _, _, pragma[only_bind_into](argT), pragma[only_bind_into](argAp),
+            argApa) and
+          returnFlowsThrough(_, _, _, _, p, pragma[only_bind_into](argT),
+            pragma[only_bind_into](argAp), ap) and
           if allowsFieldFlow = false then argAp instanceof ApNil else any()
         )
       }
@@ -1671,7 +1681,8 @@ module Impl<FullStateConfigSig Config> {
 
       pragma[nomagic]
       predicate storeStepCand(
-        NodeEx node1, Ap ap1, Content c, NodeEx node2, DataFlowType contentType, DataFlowType containerType
+        NodeEx node1, Ap ap1, Content c, NodeEx node2, DataFlowType contentType,
+        DataFlowType containerType
       ) {
         exists(Ap ap2 |
           PrevStage::storeStepCand(node1, _, c, node2, contentType, containerType) and
@@ -1774,9 +1785,8 @@ module Impl<FullStateConfigSig Config> {
         conscand = count(Content f0, Typ t, Ap ap | fwdConsCand(f0, t, ap)) and
         states = count(FlowState state | fwdFlow(_, state, _, _, _, _, _, _)) and
         tuples =
-          count(NodeEx n, FlowState state, Cc cc, ParamNodeOption summaryCtx, TypOption argT, ApOption argAp, Typ t, Ap ap |
-            fwdFlow(n, state, cc, summaryCtx, argT, argAp, t, ap)
-          )
+          count(NodeEx n, FlowState state, Cc cc, ParamNodeOption summaryCtx, TypOption argT,
+            ApOption argAp, Typ t, Ap ap | fwdFlow(n, state, cc, summaryCtx, argT, argAp, t, ap))
         or
         fwd = false and
         nodes = count(NodeEx node | revFlow(node, _, _, _, _)) and
@@ -1898,7 +1908,9 @@ module Impl<FullStateConfigSig Config> {
     Typ getTyp(DataFlowType t) { any() }
 
     bindingset[c, t, tail]
-    Ap apCons(Content c, Typ t, Ap tail) { result = true and exists(c) and exists(t) and exists(tail) }
+    Ap apCons(Content c, Typ t, Ap tail) {
+      result = true and exists(c) and exists(t) and exists(tail)
+    }
 
     class ApHeadContent = Unit;
 
@@ -1919,8 +1931,8 @@ module Impl<FullStateConfigSig Config> {
     bindingset[node1, state1]
     bindingset[node2, state2]
     predicate localStep(
-      NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
-      Typ t, LocalCc lcc
+      NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue, Typ t,
+      LocalCc lcc
     ) {
       (
         preservesValue = true and
@@ -2355,7 +2367,8 @@ module Impl<FullStateConfigSig Config> {
   private predicate flowCandSummaryCtx(NodeEx node, FlowState state, AccessPathFront argApf) {
     exists(AccessPathFront apf |
       Stage4::revFlow(node, state, TReturnCtxMaybeFlowThrough(_), _, apf) and
-      Stage4::fwdFlow(node, state, any(Stage4::CcCall ccc), _, _, TAccessPathFrontSome(argApf), _, apf)
+      Stage4::fwdFlow(node, state, any(Stage4::CcCall ccc), _, _, TAccessPathFrontSome(argApf), _,
+        apf)
     )
   }
 
@@ -2447,7 +2460,9 @@ module Impl<FullStateConfigSig Config> {
 
     override AccessPathFront getFront() { result = TFrontHead(c) }
 
-    override predicate isCons(Content head, DataFlowType typ, AccessPathApprox tail) { head = c and typ = t and tail = TNil() }
+    override predicate isCons(Content head, DataFlowType typ, AccessPathApprox tail) {
+      head = c and typ = t and tail = TNil()
+    }
   }
 
   private class AccessPathApproxConsCons extends AccessPathApproxCons, TConsCons {
@@ -2681,7 +2696,8 @@ module Impl<FullStateConfigSig Config> {
       len = apa.len() and
       result =
         strictcount(DataFlowType t, AccessPathFront apf |
-          Stage5::consCand(c, t, any(AccessPathApprox ap | ap.getFront() = apf and ap.len() = len - 1))
+          Stage5::consCand(c, t,
+            any(AccessPathApprox ap | ap.getFront() = apf and ap.len() = len - 1))
         )
     )
   }
@@ -2756,7 +2772,8 @@ module Impl<FullStateConfigSig Config> {
   private int countPotentialAps(AccessPathApprox apa) {
     apa instanceof AccessPathApproxNil and result = 1
     or
-    result = strictsum(DataFlowType t, AccessPathApprox tail | hasTail(apa, t, tail) | countAps(tail))
+    result =
+      strictsum(DataFlowType t, AccessPathApprox tail | hasTail(apa, t, tail) | countAps(tail))
   }
 
   private newtype TAccessPath =
@@ -2789,7 +2806,9 @@ module Impl<FullStateConfigSig Config> {
 
   private newtype TPathNode =
     pragma[assume_small_delta]
-    TPathNodeMid(NodeEx node, FlowState state, CallContext cc, SummaryCtx sc, DataFlowType t, AccessPath ap) {
+    TPathNodeMid(
+      NodeEx node, FlowState state, CallContext cc, SummaryCtx sc, DataFlowType t, AccessPath ap
+    ) {
       // A PathNode is introduced by a source ...
       Stage5::revFlow(node, state) and
       sourceNode(node, state) and
@@ -2957,7 +2976,8 @@ module Impl<FullStateConfigSig Config> {
 
     override predicate isCons(Content head, DataFlowType typ, AccessPath tail) {
       head = head_ and
-      Stage5::consCand(head_, typ, tail.getApprox()) and tail.length() = len - 1
+      Stage5::consCand(head_, typ, tail.getApprox()) and
+      tail.length() = len - 1
     }
 
     override AccessPathFrontHead getFront() { result = TFrontHead(head_) }
@@ -3303,8 +3323,8 @@ module Impl<FullStateConfigSig Config> {
   }
 
   private predicate pathNode(
-    PathNodeMid mid, NodeEx midnode, FlowState state, CallContext cc, SummaryCtx sc, DataFlowType t, AccessPath ap,
-    LocalCallContext localCC
+    PathNodeMid mid, NodeEx midnode, FlowState state, CallContext cc, SummaryCtx sc, DataFlowType t,
+    AccessPath ap, LocalCallContext localCC
   ) {
     midnode = mid.getNodeEx() and
     state = mid.getState() and
@@ -3324,7 +3344,8 @@ module Impl<FullStateConfigSig Config> {
   pragma[assume_small_delta]
   pragma[nomagic]
   private predicate pathStep(
-    PathNodeMid mid, NodeEx node, FlowState state, CallContext cc, SummaryCtx sc, DataFlowType t, AccessPath ap
+    PathNodeMid mid, NodeEx node, FlowState state, CallContext cc, SummaryCtx sc, DataFlowType t,
+    AccessPath ap
   ) {
     exists(NodeEx midnode, FlowState state0, LocalCallContext localCC |
       pathNode(mid, midnode, state0, cc, sc, t, ap, localCC) and
@@ -3373,7 +3394,10 @@ module Impl<FullStateConfigSig Config> {
     or
     pathIntoCallable(mid, node, state, _, cc, sc, _) and t = mid.getType() and ap = mid.getAp()
     or
-    pathOutOfCallable(mid, node, state, cc) and t = mid.getType() and ap = mid.getAp() and sc instanceof SummaryCtxNone
+    pathOutOfCallable(mid, node, state, cc) and
+    t = mid.getType() and
+    ap = mid.getAp() and
+    sc instanceof SummaryCtxNone
     or
     pathThroughCallable(mid, node, state, cc, t, ap) and sc = mid.getSummaryCtx()
   }
@@ -3391,7 +3415,8 @@ module Impl<FullStateConfigSig Config> {
 
   pragma[nomagic]
   private predicate pathStoreStep(
-    PathNodeMid mid, NodeEx node, FlowState state, DataFlowType t0, AccessPath ap0, Content c, DataFlowType t, CallContext cc
+    PathNodeMid mid, NodeEx node, FlowState state, DataFlowType t0, AccessPath ap0, Content c,
+    DataFlowType t, CallContext cc
   ) {
     t0 = mid.getType() and
     ap0 = mid.getAp() and
@@ -3515,8 +3540,8 @@ module Impl<FullStateConfigSig Config> {
   /** Holds if data may flow from a parameter given by `sc` to a return of kind `kind`. */
   pragma[nomagic]
   private predicate paramFlowsThrough(
-    ReturnKindExt kind, FlowState state, CallContextCall cc, SummaryCtxSome sc, DataFlowType t, AccessPath ap,
-    AccessPathApprox apa
+    ReturnKindExt kind, FlowState state, CallContextCall cc, SummaryCtxSome sc, DataFlowType t,
+    AccessPath ap, AccessPathApprox apa
   ) {
     exists(RetNodeEx ret |
       pathNode(_, ret, state, cc, sc, t, ap, _) and
@@ -3562,10 +3587,11 @@ module Impl<FullStateConfigSig Config> {
       PathNodeImpl arg, ParamNodeEx par, SummaryCtxSome sc, CallContext innercc, ReturnKindExt kind,
       NodeEx out, FlowState sout, DataFlowType t, AccessPath apout
     ) {
-      pathThroughCallable(arg, out, pragma[only_bind_into](sout), _, pragma[only_bind_into](t), pragma[only_bind_into](apout)) and
+      pathThroughCallable(arg, out, pragma[only_bind_into](sout), _, pragma[only_bind_into](t),
+        pragma[only_bind_into](apout)) and
       pathIntoCallable(arg, par, _, _, innercc, sc, _) and
-      paramFlowsThrough(kind, pragma[only_bind_into](sout), innercc, sc,
-        pragma[only_bind_into](t), pragma[only_bind_into](apout), _) and
+      paramFlowsThrough(kind, pragma[only_bind_into](sout), innercc, sc, pragma[only_bind_into](t),
+        pragma[only_bind_into](apout), _) and
       not arg.isHidden()
     }
 
@@ -3619,7 +3645,9 @@ module Impl<FullStateConfigSig Config> {
      * `ret -> out` is summarized as the edge `arg -> out`.
      */
     predicate subpaths(PathNodeImpl arg, PathNodeImpl par, PathNodeImpl ret, PathNodeImpl out) {
-      exists(ParamNodeEx p, NodeEx o, FlowState sout, DataFlowType t, AccessPath apout, PathNodeMid out0 |
+      exists(
+        ParamNodeEx p, NodeEx o, FlowState sout, DataFlowType t, AccessPath apout, PathNodeMid out0
+      |
         pragma[only_bind_into](arg).getANonHiddenSuccessor() = pragma[only_bind_into](out0) and
         subpaths03(pragma[only_bind_into](arg), p, localStepToHidden*(ret), o, sout, t, apout) and
         hasSuccessor(pragma[only_bind_into](arg), par, p) and
@@ -3706,8 +3734,7 @@ module Impl<FullStateConfigSig Config> {
     or
     fwd = false and
     nodes = count(NodeEx n0 | exists(PathNodeImpl pn | pn.getNodeEx() = n0 and reach(pn))) and
-    fields =
-      count(Content f0 | exists(PathNodeMid pn | pn.getAp().getHead() = f0 and reach(pn))) and
+    fields = count(Content f0 | exists(PathNodeMid pn | pn.getAp().getHead() = f0 and reach(pn))) and
     conscand = count(AccessPath ap | exists(PathNodeMid pn | pn.getAp() = ap and reach(pn))) and
     states = count(FlowState state | exists(PathNodeMid pn | pn.getState() = state and reach(pn))) and
     tuples = count(PathNode pn)
@@ -4075,7 +4102,9 @@ module Impl<FullStateConfigSig Config> {
       DataFlowType t;
       PartialAccessPath ap;
 
-      PartialPathNodeFwd() { this = TPartialPathNodeFwd(node, state, cc, sc1, sc2, sc3, sc4, t, ap) }
+      PartialPathNodeFwd() {
+        this = TPartialPathNodeFwd(node, state, cc, sc1, sc2, sc3, sc4, t, ap)
+      }
 
       NodeEx getNodeEx() { result = node }
 
@@ -4097,7 +4126,8 @@ module Impl<FullStateConfigSig Config> {
 
       override PartialPathNodeFwd getASuccessor() {
         partialPathStep(this, result.getNodeEx(), result.getState(), result.getCallContext(),
-          result.getSummaryCtx1(), result.getSummaryCtx2(), result.getSummaryCtx3(), result.getSummaryCtx4(), result.getType(), result.getAp())
+          result.getSummaryCtx1(), result.getSummaryCtx2(), result.getSummaryCtx3(),
+          result.getSummaryCtx4(), result.getType(), result.getAp())
       }
 
       predicate isSource() {
@@ -4269,13 +4299,16 @@ module Impl<FullStateConfigSig Config> {
     }
 
     pragma[nomagic]
-    private predicate apConsFwd(DataFlowType t1, PartialAccessPath ap1, Content c, DataFlowType t2, PartialAccessPath ap2) {
+    private predicate apConsFwd(
+      DataFlowType t1, PartialAccessPath ap1, Content c, DataFlowType t2, PartialAccessPath ap2
+    ) {
       partialPathStoreStep(_, t1, ap1, c, _, t2, ap2)
     }
 
     pragma[nomagic]
     private predicate partialPathReadStep(
-      PartialPathNodeFwd mid, DataFlowType t, PartialAccessPath ap, Content c, NodeEx node, CallContext cc
+      PartialPathNodeFwd mid, DataFlowType t, PartialAccessPath ap, Content c, NodeEx node,
+      CallContext cc
     ) {
       exists(NodeEx midNode |
         midNode = mid.getNodeEx() and
@@ -4315,7 +4348,8 @@ module Impl<FullStateConfigSig Config> {
     }
 
     private predicate partialPathOutOfCallable(
-      PartialPathNodeFwd mid, NodeEx out, FlowState state, CallContext cc, DataFlowType t, PartialAccessPath ap
+      PartialPathNodeFwd mid, NodeEx out, FlowState state, CallContext cc, DataFlowType t,
+      PartialAccessPath ap
     ) {
       exists(ReturnKindExt kind, DataFlowCall call |
         partialPathOutOfCallable1(mid, call, kind, state, cc, t, ap)
@@ -4392,14 +4426,17 @@ module Impl<FullStateConfigSig Config> {
       DataFlowCall call, PartialPathNodeFwd mid, ReturnKindExt kind, FlowState state,
       CallContext cc, DataFlowType t, PartialAccessPath ap
     ) {
-      exists(CallContext innercc, TSummaryCtx1 sc1, TSummaryCtx2 sc2, TSummaryCtx3 sc3, TSummaryCtx4 sc4 |
+      exists(
+        CallContext innercc, TSummaryCtx1 sc1, TSummaryCtx2 sc2, TSummaryCtx3 sc3, TSummaryCtx4 sc4
+      |
         partialPathIntoCallable(mid, _, _, cc, innercc, sc1, sc2, sc3, sc4, call, _, _) and
         paramFlowsThroughInPartialPath(kind, state, innercc, sc1, sc2, sc3, sc4, t, ap)
       )
     }
 
     private predicate partialPathThroughCallable(
-      PartialPathNodeFwd mid, NodeEx out, FlowState state, CallContext cc, DataFlowType t, PartialAccessPath ap
+      PartialPathNodeFwd mid, NodeEx out, FlowState state, CallContext cc, DataFlowType t,
+      PartialAccessPath ap
     ) {
       exists(DataFlowCall call, ReturnKindExt kind |
         partialPathThroughCallable0(call, mid, kind, state, cc, t, ap) and
@@ -4497,8 +4534,7 @@ module Impl<FullStateConfigSig Config> {
 
     pragma[inline]
     private predicate revPartialPathReadStep(
-      PartialPathNodeRev mid, PartialAccessPath ap1, Content c, NodeEx node,
-      PartialAccessPath ap2
+      PartialPathNodeRev mid, PartialAccessPath ap1, Content c, NodeEx node, PartialAccessPath ap2
     ) {
       exists(NodeEx midNode |
         midNode = mid.getNodeEx() and

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -3987,7 +3987,11 @@ module Impl<FullStateConfigSig Config> {
 
     private newtype TSummaryCtx3 =
       TSummaryCtx3None() or
-      TSummaryCtx3Some(PartialAccessPath ap)
+      TSummaryCtx3Some(DataFlowType t)
+
+    private newtype TSummaryCtx4 =
+      TSummaryCtx4None() or
+      TSummaryCtx4Some(PartialAccessPath ap)
 
     private newtype TRevSummaryCtx1 =
       TRevSummaryCtx1None() or
@@ -4004,18 +4008,19 @@ module Impl<FullStateConfigSig Config> {
     private newtype TPartialPathNode =
       TPartialPathNodeFwd(
         NodeEx node, FlowState state, CallContext cc, TSummaryCtx1 sc1, TSummaryCtx2 sc2,
-        TSummaryCtx3 sc3, DataFlowType t, PartialAccessPath ap
+        TSummaryCtx3 sc3, TSummaryCtx4 sc4, DataFlowType t, PartialAccessPath ap
       ) {
         sourceNode(node, state) and
         cc instanceof CallContextAny and
         sc1 = TSummaryCtx1None() and
         sc2 = TSummaryCtx2None() and
         sc3 = TSummaryCtx3None() and
+        sc4 = TSummaryCtx4None() and
         t = node.getDataFlowType() and
         ap = TPartialNil(node.getDataFlowType()) and
         exists(explorationLimit())
         or
-        partialPathNodeMk0(node, state, cc, sc1, sc2, sc3, t, ap) and
+        partialPathNodeMk0(node, state, cc, sc1, sc2, sc3, sc4, t, ap) and
         distSrc(node.getEnclosingCallable()) <= explorationLimit()
       } or
       TPartialPathNodeRev(
@@ -4043,9 +4048,9 @@ module Impl<FullStateConfigSig Config> {
     pragma[nomagic]
     private predicate partialPathNodeMk0(
       NodeEx node, FlowState state, CallContext cc, TSummaryCtx1 sc1, TSummaryCtx2 sc2,
-      TSummaryCtx3 sc3, DataFlowType t, PartialAccessPath ap
+      TSummaryCtx3 sc3, TSummaryCtx4 sc4, DataFlowType t, PartialAccessPath ap
     ) {
-      partialPathStep(_, node, state, cc, sc1, sc2, sc3, t, ap) and
+      partialPathStep(_, node, state, cc, sc1, sc2, sc3, sc4, t, ap) and
       not fullBarrier(node) and
       not stateBarrier(node, state) and
       not clearsContentEx(node, ap.getHead().getContent()) and
@@ -4155,10 +4160,11 @@ module Impl<FullStateConfigSig Config> {
       TSummaryCtx1 sc1;
       TSummaryCtx2 sc2;
       TSummaryCtx3 sc3;
+      TSummaryCtx4 sc4;
       DataFlowType t;
       PartialAccessPath ap;
 
-      PartialPathNodeFwd() { this = TPartialPathNodeFwd(node, state, cc, sc1, sc2, sc3, t, ap) }
+      PartialPathNodeFwd() { this = TPartialPathNodeFwd(node, state, cc, sc1, sc2, sc3, sc4, t, ap) }
 
       NodeEx getNodeEx() { result = node }
 
@@ -4172,13 +4178,15 @@ module Impl<FullStateConfigSig Config> {
 
       TSummaryCtx3 getSummaryCtx3() { result = sc3 }
 
+      TSummaryCtx4 getSummaryCtx4() { result = sc4 }
+
       DataFlowType getType() { result = t }
 
       PartialAccessPath getAp() { result = ap }
 
       override PartialPathNodeFwd getASuccessor() {
         partialPathStep(this, result.getNodeEx(), result.getState(), result.getCallContext(),
-          result.getSummaryCtx1(), result.getSummaryCtx2(), result.getSummaryCtx3(), result.getType(), result.getAp())
+          result.getSummaryCtx1(), result.getSummaryCtx2(), result.getSummaryCtx3(), result.getSummaryCtx4(), result.getType(), result.getAp())
       }
 
       predicate isSource() {
@@ -4187,6 +4195,7 @@ module Impl<FullStateConfigSig Config> {
         sc1 = TSummaryCtx1None() and
         sc2 = TSummaryCtx2None() and
         sc3 = TSummaryCtx3None() and
+        sc4 = TSummaryCtx4None() and
         ap instanceof TPartialNil
       }
     }
@@ -4229,7 +4238,7 @@ module Impl<FullStateConfigSig Config> {
 
     private predicate partialPathStep(
       PartialPathNodeFwd mid, NodeEx node, FlowState state, CallContext cc, TSummaryCtx1 sc1,
-      TSummaryCtx2 sc2, TSummaryCtx3 sc3, DataFlowType t, PartialAccessPath ap
+      TSummaryCtx2 sc2, TSummaryCtx3 sc3, TSummaryCtx4 sc4, DataFlowType t, PartialAccessPath ap
     ) {
       not isUnreachableInCallCached(node.asNode(), cc.(CallContextSpecificCall).getCall()) and
       (
@@ -4239,6 +4248,7 @@ module Impl<FullStateConfigSig Config> {
         sc1 = mid.getSummaryCtx1() and
         sc2 = mid.getSummaryCtx2() and
         sc3 = mid.getSummaryCtx3() and
+        sc4 = mid.getSummaryCtx4() and
         t = mid.getType() and
         ap = mid.getAp()
         or
@@ -4248,6 +4258,7 @@ module Impl<FullStateConfigSig Config> {
         sc1 = mid.getSummaryCtx1() and
         sc2 = mid.getSummaryCtx2() and
         sc3 = mid.getSummaryCtx3() and
+        sc4 = mid.getSummaryCtx4() and
         mid.getAp() instanceof PartialAccessPathNil and
         t = node.getDataFlowType() and
         ap = TPartialNil(node.getDataFlowType())
@@ -4257,6 +4268,7 @@ module Impl<FullStateConfigSig Config> {
         sc1 = mid.getSummaryCtx1() and
         sc2 = mid.getSummaryCtx2() and
         sc3 = mid.getSummaryCtx3() and
+        sc4 = mid.getSummaryCtx4() and
         mid.getAp() instanceof PartialAccessPathNil and
         t = node.getDataFlowType() and
         ap = TPartialNil(node.getDataFlowType())
@@ -4268,7 +4280,8 @@ module Impl<FullStateConfigSig Config> {
       sc1 = TSummaryCtx1None() and
       sc2 = TSummaryCtx2None() and
       sc3 = TSummaryCtx3None() and
-        t = mid.getType() and
+      sc4 = TSummaryCtx4None() and
+      t = mid.getType() and
       ap = mid.getAp()
       or
       additionalJumpStep(mid.getNodeEx(), node) and
@@ -4277,6 +4290,7 @@ module Impl<FullStateConfigSig Config> {
       sc1 = TSummaryCtx1None() and
       sc2 = TSummaryCtx2None() and
       sc3 = TSummaryCtx3None() and
+      sc4 = TSummaryCtx4None() and
       mid.getAp() instanceof PartialAccessPathNil and
       t = node.getDataFlowType() and
       ap = TPartialNil(node.getDataFlowType())
@@ -4286,6 +4300,7 @@ module Impl<FullStateConfigSig Config> {
       sc1 = TSummaryCtx1None() and
       sc2 = TSummaryCtx2None() and
       sc3 = TSummaryCtx3None() and
+      sc4 = TSummaryCtx4None() and
       mid.getAp() instanceof PartialAccessPathNil and
       t = node.getDataFlowType() and
       ap = TPartialNil(node.getDataFlowType())
@@ -4295,7 +4310,8 @@ module Impl<FullStateConfigSig Config> {
       cc = mid.getCallContext() and
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
-      sc3 = mid.getSummaryCtx3()
+      sc3 = mid.getSummaryCtx3() and
+      sc4 = mid.getSummaryCtx4()
       or
       exists(DataFlowType t0, PartialAccessPath ap0, Content c |
         partialPathReadStep(mid, t0, ap0, c, node, cc) and
@@ -4303,20 +4319,23 @@ module Impl<FullStateConfigSig Config> {
         sc1 = mid.getSummaryCtx1() and
         sc2 = mid.getSummaryCtx2() and
         sc3 = mid.getSummaryCtx3() and
+        sc4 = mid.getSummaryCtx4() and
         apConsFwd(t, ap, c, t0, ap0)
       )
       or
-      partialPathIntoCallable(mid, node, state, _, cc, sc1, sc2, sc3, _, t, ap)
+      partialPathIntoCallable(mid, node, state, _, cc, sc1, sc2, sc3, sc4, _, t, ap)
       or
       partialPathOutOfCallable(mid, node, state, cc, t, ap) and
       sc1 = TSummaryCtx1None() and
       sc2 = TSummaryCtx2None() and
-      sc3 = TSummaryCtx3None()
+      sc3 = TSummaryCtx3None() and
+      sc4 = TSummaryCtx4None()
       or
       partialPathThroughCallable(mid, node, state, cc, t, ap) and
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
-      sc3 = mid.getSummaryCtx3()
+      sc3 = mid.getSummaryCtx3() and
+      sc4 = mid.getSummaryCtx4()
     }
 
     bindingset[result, i]
@@ -4422,14 +4441,15 @@ module Impl<FullStateConfigSig Config> {
     private predicate partialPathIntoCallable(
       PartialPathNodeFwd mid, ParamNodeEx p, FlowState state, CallContext outercc,
       CallContextCall innercc, TSummaryCtx1 sc1, TSummaryCtx2 sc2, TSummaryCtx3 sc3,
-      DataFlowCall call, DataFlowType t, PartialAccessPath ap
+      TSummaryCtx4 sc4, DataFlowCall call, DataFlowType t, PartialAccessPath ap
     ) {
       exists(ParameterPosition pos, DataFlowCallable callable |
         partialPathIntoCallable0(mid, callable, pos, state, outercc, call, t, ap) and
         p.isParameterOf(callable, pos) and
         sc1 = TSummaryCtx1Param(p) and
         sc2 = TSummaryCtx2Some(state) and
-        sc3 = TSummaryCtx3Some(ap)
+        sc3 = TSummaryCtx3Some(t) and
+        sc4 = TSummaryCtx4Some(ap)
       |
         if recordDataFlowCallSite(call, callable)
         then innercc = TSpecificCall(call)
@@ -4440,7 +4460,7 @@ module Impl<FullStateConfigSig Config> {
     pragma[nomagic]
     private predicate paramFlowsThroughInPartialPath(
       ReturnKindExt kind, FlowState state, CallContextCall cc, TSummaryCtx1 sc1, TSummaryCtx2 sc2,
-      TSummaryCtx3 sc3, DataFlowType t, PartialAccessPath ap
+      TSummaryCtx3 sc3, TSummaryCtx4 sc4, DataFlowType t, PartialAccessPath ap
     ) {
       exists(PartialPathNodeFwd mid, RetNodeEx ret |
         mid.getNodeEx() = ret and
@@ -4450,6 +4470,7 @@ module Impl<FullStateConfigSig Config> {
         sc1 = mid.getSummaryCtx1() and
         sc2 = mid.getSummaryCtx2() and
         sc3 = mid.getSummaryCtx3() and
+        sc4 = mid.getSummaryCtx4() and
         t = mid.getType() and
         ap = mid.getAp()
       )
@@ -4460,9 +4481,9 @@ module Impl<FullStateConfigSig Config> {
       DataFlowCall call, PartialPathNodeFwd mid, ReturnKindExt kind, FlowState state,
       CallContext cc, DataFlowType t, PartialAccessPath ap
     ) {
-      exists(CallContext innercc, TSummaryCtx1 sc1, TSummaryCtx2 sc2, TSummaryCtx3 sc3 |
-        partialPathIntoCallable(mid, _, _, cc, innercc, sc1, sc2, sc3, call, _, _) and
-        paramFlowsThroughInPartialPath(kind, state, innercc, sc1, sc2, sc3, t, ap)
+      exists(CallContext innercc, TSummaryCtx1 sc1, TSummaryCtx2 sc2, TSummaryCtx3 sc3, TSummaryCtx4 sc4 |
+        partialPathIntoCallable(mid, _, _, cc, innercc, sc1, sc2, sc3, sc4, call, _, _) and
+        paramFlowsThroughInPartialPath(kind, state, innercc, sc1, sc2, sc3, sc4, t, ap)
       )
     }
 

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -2521,9 +2521,6 @@ module Impl<FullStateConfigSig Config> {
     }
   }
 
-  /** Gets the access path obtained by pushing `c` onto the `t,apa` pair. */
-  private AccessPathApprox push(Content c, DataFlowType t, AccessPathApprox apa) { result.isCons(c, t, apa) }
-
   private newtype TAccessPathApproxOption =
     TAccessPathApproxNone() or
     TAccessPathApproxSome(AccessPathApprox apa)
@@ -2551,7 +2548,7 @@ module Impl<FullStateConfigSig Config> {
     Typ getTyp(DataFlowType t) { result = t }
 
     bindingset[c, t, tail]
-    Ap apCons(Content c, Typ t, Ap tail) { result = push(c, t, tail) }
+    Ap apCons(Content c, Typ t, Ap tail) { result.isCons(c, t, tail) }
 
     class ApHeadContent = Content;
 
@@ -2663,8 +2660,6 @@ module Impl<FullStateConfigSig Config> {
     private AccessPath ap;
 
     SummaryCtxSome() { this = TSummaryCtxSome(p, s, t, ap) }
-
-    ParameterPosition getParameterPos() { p.isParameterOf(_, result) }
 
     ParamNodeEx getParamNode() { result = p }
 
@@ -2832,9 +2827,6 @@ module Impl<FullStateConfigSig Config> {
     /** Gets the head of this access path, if any. */
     abstract Content getHead();
 
-    /** Gets the tail of this access path, if any. */
-    abstract AccessPath getTail();
-
     /** Holds if this is a representation of `head` followed by the `typ,tail` pair. */
     abstract predicate isCons(Content head, DataFlowType typ, AccessPath tail);
 
@@ -2853,8 +2845,6 @@ module Impl<FullStateConfigSig Config> {
 
   private class AccessPathNil extends AccessPath, TAccessPathNil {
     override Content getHead() { none() }
-
-    override AccessPath getTail() { none() }
 
     override predicate isCons(Content head, DataFlowType typ, AccessPath tail) { none() }
 
@@ -2875,8 +2865,6 @@ module Impl<FullStateConfigSig Config> {
     AccessPathCons() { this = TAccessPathCons(head_, t, tail_) }
 
     override Content getHead() { result = head_ }
-
-    override AccessPath getTail() { result = tail_ }
 
     override predicate isCons(Content head, DataFlowType typ, AccessPath tail) {
       head = head_ and typ = t and tail = tail_
@@ -2933,12 +2921,6 @@ module Impl<FullStateConfigSig Config> {
 
     override Content getHead() { result = head1 }
 
-    override AccessPath getTail() {
-      Stage5::consCand(head1, t, result.getApprox()) and
-      result.getHead() = head2 and
-      result.length() = len - 1
-    }
-
     override predicate isCons(Content head, DataFlowType typ, AccessPath tail) {
       head = head1 and
       typ = t and
@@ -2972,10 +2954,6 @@ module Impl<FullStateConfigSig Config> {
     AccessPathCons1() { this = TAccessPathCons1(head_, len) }
 
     override Content getHead() { result = head_ }
-
-    override AccessPath getTail() {
-      Stage5::consCand(head_, _, result.getApprox()) and result.length() = len - 1
-    }
 
     override predicate isCons(Content head, DataFlowType typ, AccessPath tail) {
       head = head_ and

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -391,8 +391,8 @@ module Impl<FullStateConfigSig Config> {
   private predicate hasReadStep(Content c) { read(_, c, _) }
 
   pragma[nomagic]
-  private predicate storeEx(NodeEx node1, TypedContent tc, Content c, NodeEx node2, DataFlowType contentType, DataFlowType containerType) {
-    store(pragma[only_bind_into](node1.asNode()), tc, c, pragma[only_bind_into](node2.asNode()),
+  private predicate storeEx(NodeEx node1, Content c, NodeEx node2, DataFlowType contentType, DataFlowType containerType) {
+    store(pragma[only_bind_into](node1.asNode()), _, c, pragma[only_bind_into](node2.asNode()),
       contentType, containerType) and
     hasReadStep(c) and
     stepFilter(node1, node2)
@@ -479,7 +479,7 @@ module Impl<FullStateConfigSig Config> {
       exists(NodeEx mid |
         useFieldFlow() and
         fwdFlow(mid, cc) and
-        storeEx(mid, _, _, node, _, _)
+        storeEx(mid, _, node, _, _)
       )
       or
       // read
@@ -575,7 +575,7 @@ module Impl<FullStateConfigSig Config> {
         not fullBarrier(node) and
         useFieldFlow() and
         fwdFlow(mid, _) and
-        storeEx(mid, _, c, node, _, _)
+        storeEx(mid, c, node, _, _)
       )
     }
 
@@ -712,7 +712,7 @@ module Impl<FullStateConfigSig Config> {
       exists(NodeEx mid |
         revFlow(mid, toReturn) and
         fwdFlowConsCand(c) and
-        storeEx(node, _, c, mid, _, _)
+        storeEx(node, c, mid, _, _)
       )
     }
 
@@ -802,11 +802,11 @@ module Impl<FullStateConfigSig Config> {
 
     pragma[nomagic]
     predicate storeStepCand(
-      NodeEx node1, Ap ap1, TypedContent tc, Content c, NodeEx node2, DataFlowType contentType, DataFlowType containerType
+      NodeEx node1, Ap ap1, Content c, NodeEx node2, DataFlowType contentType, DataFlowType containerType
     ) {
       revFlowIsReadAndStored(c) and
       revFlow(node2) and
-      storeEx(node1, tc, c, node2, contentType, containerType) and
+      storeEx(node1, c, node2, contentType, containerType) and
       exists(ap1)
     }
 
@@ -1049,7 +1049,7 @@ module Impl<FullStateConfigSig Config> {
     predicate returnMayFlowThrough(RetNodeEx ret, Ap argAp, Ap ap, ReturnKindExt kind);
 
     predicate storeStepCand(
-      NodeEx node1, Ap ap1, TypedContent tc, Content c, NodeEx node2, DataFlowType contentType, DataFlowType containerType
+      NodeEx node1, Ap ap1, Content c, NodeEx node2, DataFlowType contentType, DataFlowType containerType
     );
 
     predicate readStepCand(NodeEx n1, Content c, NodeEx n2);
@@ -1319,7 +1319,7 @@ module Impl<FullStateConfigSig Config> {
       ) {
         exists(DataFlowType contentType, DataFlowType containerType, ApApprox apa1 |
           fwdFlow(node1, state, cc, summaryCtx, argT, argAp, t1, ap1, apa1) and
-          PrevStage::storeStepCand(node1, apa1, _, c, node2, contentType, containerType) and
+          PrevStage::storeStepCand(node1, apa1, c, node2, contentType, containerType) and
           t2 = getTyp(containerType) and
           typecheckStore(t1, contentType)
         )
@@ -1671,10 +1671,10 @@ module Impl<FullStateConfigSig Config> {
 
       pragma[nomagic]
       predicate storeStepCand(
-        NodeEx node1, Ap ap1, TypedContent tc, Content c, NodeEx node2, DataFlowType contentType, DataFlowType containerType
+        NodeEx node1, Ap ap1, Content c, NodeEx node2, DataFlowType contentType, DataFlowType containerType
       ) {
         exists(Ap ap2 |
-          PrevStage::storeStepCand(node1, _, tc, c, node2, contentType, containerType) and
+          PrevStage::storeStepCand(node1, _, c, node2, contentType, containerType) and
           revFlowStore(ap2, c, ap1, _, node1, _, node2, _, _) and
           revFlowConsCand(ap2, c, ap1)
         )
@@ -2023,7 +2023,7 @@ module Impl<FullStateConfigSig Config> {
         or
         node.asNode() instanceof OutNodeExt
         or
-        Stage2::storeStepCand(_, _, _, _, node, _, _)
+        Stage2::storeStepCand(_, _, _, node, _, _)
         or
         Stage2::readStepCand(_, _, node)
         or
@@ -2046,7 +2046,7 @@ module Impl<FullStateConfigSig Config> {
         additionalJumpStep(node, next) or
         flowIntoCallNodeCand2(_, node, next, _) or
         flowOutOfCallNodeCand2(_, node, _, next, _) or
-        Stage2::storeStepCand(node, _, _, _, next, _, _) or
+        Stage2::storeStepCand(node, _, _, next, _, _) or
         Stage2::readStepCand(node, _, next)
       )
       or
@@ -3417,7 +3417,7 @@ module Impl<FullStateConfigSig Config> {
   ) {
     t0 = mid.getType() and
     ap0 = mid.getAp() and
-    Stage5::storeStepCand(mid.getNodeEx(), _, _, c, node, _, t) and
+    Stage5::storeStepCand(mid.getNodeEx(), _, c, node, _, t) and
     state = mid.getState() and
     cc = mid.getCallContext()
   }
@@ -3624,7 +3624,7 @@ module Impl<FullStateConfigSig Config> {
       result.isHidden() and
       exists(NodeEx n1, NodeEx n2 | n1 = n.getNodeEx() and n2 = result.getNodeEx() |
         localFlowBigStep(n1, _, n2, _, _, _, _) or
-        storeEx(n1, _, _, n2, _, _) or
+        storeEx(n1, _, n2, _, _) or
         readSetEx(n1, _, n2)
       )
     }
@@ -4283,7 +4283,7 @@ module Impl<FullStateConfigSig Config> {
         midNode = mid.getNodeEx() and
         t1 = mid.getType() and
         ap1 = mid.getAp() and
-        storeEx(midNode, _, c, node, contentType, t2) and
+        storeEx(midNode, c, node, contentType, t2) and
         ap2.getHead() = c and
         ap2.len() = unbindInt(ap1.len() + 1) and
         compatibleTypes(t1, contentType)
@@ -4543,7 +4543,7 @@ module Impl<FullStateConfigSig Config> {
       exists(NodeEx midNode |
         midNode = mid.getNodeEx() and
         ap = mid.getAp() and
-        storeEx(node, _, c, midNode, _, _) and
+        storeEx(node, c, midNode, _, _) and
         ap.getHead() = c
       )
     }

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -1130,8 +1130,8 @@ module Impl<FullStateConfigSig Config> {
         DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow
       );
 
-      bindingset[node, state, ap]
-      predicate filter(NodeEx node, FlowState state, Ap ap);
+      bindingset[node, state, t, ap]
+      predicate filter(NodeEx node, FlowState state, Typ t, Ap ap);
 
       bindingset[typ, contentType]
       predicate typecheckStore(Typ typ, DataFlowType contentType);
@@ -1192,7 +1192,7 @@ module Impl<FullStateConfigSig Config> {
       ) {
         fwdFlow0(node, state, cc, summaryCtx, argAp, t, ap, apa) and
         PrevStage::revFlow(node, state, apa) and
-        filter(node, state, ap)
+        filter(node, state, t, ap)
       }
 
       pragma[inline]
@@ -1955,9 +1955,10 @@ module Impl<FullStateConfigSig Config> {
       )
     }
 
-    bindingset[node, state, ap]
-    predicate filter(NodeEx node, FlowState state, Ap ap) {
+    bindingset[node, state, t, ap]
+    predicate filter(NodeEx node, FlowState state, Typ t, Ap ap) {
       PrevStage::revFlowState(state) and
+      exists(t) and
       exists(ap) and
       not stateBarrier(node, state) and
       (
@@ -2214,10 +2215,10 @@ module Impl<FullStateConfigSig Config> {
     pragma[nomagic]
     private predicate castingNodeEx(NodeEx node) { node.asNode() instanceof CastingNode }
 
-    bindingset[node, state, ap]
-    predicate filter(NodeEx node, FlowState state, Ap ap) {
+    bindingset[node, state, t, ap]
+    predicate filter(NodeEx node, FlowState state, Typ t, Ap ap) {
       exists(state) and
-      (if castingNodeEx(node) then compatibleTypes(node.getDataFlowType(), ap.getType()) else any()) and
+      (if castingNodeEx(node) then compatibleTypes(node.getDataFlowType(), t) else any()) and
       (
         notExpectsContent(node)
         or
@@ -2337,11 +2338,11 @@ module Impl<FullStateConfigSig Config> {
     pragma[nomagic]
     private predicate castingNodeEx(NodeEx node) { node.asNode() instanceof CastingNode }
 
-    bindingset[node, state, ap]
-    predicate filter(NodeEx node, FlowState state, Ap ap) {
+    bindingset[node, state, t, ap]
+    predicate filter(NodeEx node, FlowState state, Typ t, Ap ap) {
       exists(state) and
       not clear(node, ap) and
-      (if castingNodeEx(node) then compatibleTypes(node.getDataFlowType(), ap.getType()) else any()) and
+      (if castingNodeEx(node) then compatibleTypes(node.getDataFlowType(), t) else any()) and
       (
         notExpectsContent(node)
         or
@@ -2633,8 +2634,8 @@ module Impl<FullStateConfigSig Config> {
       )
     }
 
-    bindingset[node, state, ap]
-    predicate filter(NodeEx node, FlowState state, Ap ap) { any() }
+    bindingset[node, state, t, ap]
+    predicate filter(NodeEx node, FlowState state, Typ t, Ap ap) { any() }
 
     // Type checking is not necessary here as it has already been done in stage 3.
     bindingset[typ, contentType]

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -3077,9 +3077,7 @@ module Impl<FullStateConfigSig Config> {
     private string ppType() {
       this instanceof PathNodeSink and result = ""
       or
-      this.(PathNodeMid).getAp() instanceof AccessPathNil and result = ""
-      or
-      exists(DataFlowType t | t = this.(PathNodeMid).getAp().getHead().getContainerType() |
+      exists(DataFlowType t | t = this.(PathNodeMid).getType() |
         // The `concat` becomes "" if `ppReprType` has no result.
         result = concat(" : " + ppReprType(t))
       )

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -2168,12 +2168,12 @@ module Impl<FullStateConfigSig Config> {
     Typ getTyp(DataFlowType t) { result = t }
 
     bindingset[tc, t, tail]
-    Ap apCons(TypedContent tc, Typ t, Ap tail) { result.getAHead() = tc and exists(t) and exists(tail) }
+    Ap apCons(TypedContent tc, Typ t, Ap tail) { result.getAHead() = tc.getContent() and exists(t) and exists(tail) }
 
     class ApHeadContent = ContentApprox;
 
     pragma[noinline]
-    ApHeadContent getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+    ApHeadContent getHeadContent(Ap ap) { result = ap.getHead() }
 
     predicate projectToHeadContent = getContentApprox/1;
 
@@ -2203,7 +2203,7 @@ module Impl<FullStateConfigSig Config> {
         PrevStage::revFlow(node) and
         PrevStage::readStepCand(_, c, _) and
         expectsContentEx(node, c) and
-        c = ap.getAHead().getContent()
+        c = ap.getAHead()
       )
     }
 

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -2247,12 +2247,12 @@ module Impl<FullStateConfigSig Config> {
     Typ getTyp(DataFlowType t) { result = t }
 
     bindingset[tc, t, tail]
-    Ap apCons(TypedContent tc, Typ t, Ap tail) { result.getHead() = tc and exists(t) and exists(tail) }
+    Ap apCons(TypedContent tc, Typ t, Ap tail) { result.getHead() = tc.getContent() and exists(t) and exists(tail) }
 
     class ApHeadContent = Content;
 
     pragma[noinline]
-    ApHeadContent getHeadContent(Ap ap) { result = ap.getHead().getContent() }
+    ApHeadContent getHeadContent(Ap ap) { result = ap.getHead() }
 
     ApHeadContent projectToHeadContent(Content c) { result = c }
 
@@ -2313,7 +2313,7 @@ module Impl<FullStateConfigSig Config> {
     }
 
     pragma[nomagic]
-    private predicate clear(NodeEx node, Ap ap) { clearContent(node, ap.getHead().getContent()) }
+    private predicate clear(NodeEx node, Ap ap) { clearContent(node, ap.getHead()) }
 
     pragma[nomagic]
     private predicate expectsContentCand(NodeEx node, Ap ap) {
@@ -2321,7 +2321,7 @@ module Impl<FullStateConfigSig Config> {
         PrevStage::revFlow(node) and
         PrevStage::readStepCand(_, c, _) and
         expectsContentEx(node, c) and
-        c = ap.getHead().getContent()
+        c = ap.getHead()
       )
     }
 
@@ -2372,9 +2372,9 @@ module Impl<FullStateConfigSig Config> {
       tails = strictcount(DataFlowType t, AccessPathFront apf | Stage4::consCand(tc, t, apf)) and
       nodes =
         strictcount(NodeEx n, FlowState state |
-          Stage4::revFlow(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc))
+          Stage4::revFlow(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc.getContent()))
           or
-          flowCandSummaryCtx(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc))
+          flowCandSummaryCtx(n, state, any(AccessPathFrontHead apf | apf.getHead() = tc.getContent()))
         ) and
       accessPathApproxCostLimits(apLimit, tupleLimit) and
       apLimit < tails and
@@ -2390,7 +2390,7 @@ module Impl<FullStateConfigSig Config> {
       not expensiveLen2unfolding(tc)
     } or
     TConsCons(TypedContent tc1, DataFlowType t, TypedContent tc2, int len) {
-      Stage4::consCand(tc1, t, TFrontHead(tc2)) and
+      Stage4::consCand(tc1, t, TFrontHead(tc2.getContent())) and
       len in [2 .. accessPathLimit()] and
       not expensiveLen2unfolding(tc1)
     } or
@@ -2448,7 +2448,7 @@ module Impl<FullStateConfigSig Config> {
 
     override int len() { result = 1 }
 
-    override AccessPathFront getFront() { result = TFrontHead(tc) }
+    override AccessPathFront getFront() { result = TFrontHead(tc.getContent()) }
 
     override predicate isCons(TypedContent head, DataFlowType typ, AccessPathApprox tail) { head = tc and typ = t and tail = TNil() }
   }
@@ -2471,7 +2471,7 @@ module Impl<FullStateConfigSig Config> {
 
     override int len() { result = len }
 
-    override AccessPathFront getFront() { result = TFrontHead(tc1) }
+    override AccessPathFront getFront() { result = TFrontHead(tc1.getContent()) }
 
     override predicate isCons(TypedContent head, DataFlowType typ, AccessPathApprox tail) {
       head = tc1 and
@@ -2503,12 +2503,12 @@ module Impl<FullStateConfigSig Config> {
 
     override int len() { result = len }
 
-    override AccessPathFront getFront() { result = TFrontHead(tc) }
+    override AccessPathFront getFront() { result = TFrontHead(tc.getContent()) }
 
     override predicate isCons(TypedContent head, DataFlowType typ, AccessPathApprox tail) {
       head = tc and
       (
-        exists(TypedContent tc2 | Stage4::consCand(tc, typ, TFrontHead(tc2)) |
+        exists(TypedContent tc2 | Stage4::consCand(tc, typ, TFrontHead(tc2.getContent())) |
           tail = TConsCons(tc2, _, _, len - 1)
           or
           len = 2 and
@@ -2884,7 +2884,7 @@ module Impl<FullStateConfigSig Config> {
       head = head_ and typ = t and tail = tail_
     }
 
-    override AccessPathFrontHead getFront() { result = TFrontHead(head_) }
+    override AccessPathFrontHead getFront() { result = TFrontHead(head_.getContent()) }
 
     pragma[assume_small_delta]
     override AccessPathApproxCons getApprox() {
@@ -2949,7 +2949,7 @@ module Impl<FullStateConfigSig Config> {
       tail.length() = len - 1
     }
 
-    override AccessPathFrontHead getFront() { result = TFrontHead(head1) }
+    override AccessPathFrontHead getFront() { result = TFrontHead(head1.getContent()) }
 
     override AccessPathApproxCons getApprox() {
       result = TConsCons(head1, t, head2, len) or
@@ -2984,7 +2984,7 @@ module Impl<FullStateConfigSig Config> {
       Stage5::consCand(head_, typ, tail.getApprox()) and tail.length() = len - 1
     }
 
-    override AccessPathFrontHead getFront() { result = TFrontHead(head_) }
+    override AccessPathFrontHead getFront() { result = TFrontHead(head_.getContent()) }
 
     override AccessPathApproxCons getApprox() { result = TCons1(head_, len) }
 

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -2412,8 +2412,8 @@ module Impl<FullStateConfigSig Config> {
       Stage4::consCand(tc, t, TFrontNil(t)) and
       not expensiveLen2unfolding(tc)
     } or
-    TConsCons(TypedContent tc1, TypedContent tc2, int len) {
-      Stage4::consCand(tc1, _, TFrontHead(tc2)) and
+    TConsCons(TypedContent tc1, DataFlowType t, TypedContent tc2, int len) {
+      Stage4::consCand(tc1, t, TFrontHead(tc2)) and
       len in [2 .. accessPathLimit()] and
       not expensiveLen2unfolding(tc1)
     } or
@@ -2488,10 +2488,11 @@ module Impl<FullStateConfigSig Config> {
 
   private class AccessPathApproxConsCons extends AccessPathApproxCons, TConsCons {
     private TypedContent tc1;
+    private DataFlowType t;
     private TypedContent tc2;
     private int len;
 
-    AccessPathApproxConsCons() { this = TConsCons(tc1, tc2, len) }
+    AccessPathApproxConsCons() { this = TConsCons(tc1, t, tc2, len) }
 
     override string toString() {
       if len = 2
@@ -2509,9 +2510,9 @@ module Impl<FullStateConfigSig Config> {
 
     override predicate isCons(TypedContent head, DataFlowType typ, AccessPathApprox tail) {
       head = tc1 and
-      typ = tc2.getContainerType() and
+      typ = t and
       (
-        tail = TConsCons(tc2, _, len - 1)
+        tail = TConsCons(tc2, _, _, len - 1)
         or
         len = 2 and
         tail = TConsNil(tc2, _)
@@ -2545,7 +2546,7 @@ module Impl<FullStateConfigSig Config> {
       head = tc and
       (
         exists(TypedContent tc2 | Stage4::consCand(tc, typ, TFrontHead(tc2)) |
-          tail = TConsCons(tc2, _, len - 1)
+          tail = TConsCons(tc2, _, _, len - 1)
           or
           len = 2 and
           tail = TConsNil(tc2, _)
@@ -2940,7 +2941,7 @@ module Impl<FullStateConfigSig Config> {
     override AccessPathApproxCons getApprox() {
       result = TConsNil(head_, t) and tail_ instanceof AccessPathNil
       or
-      result = TConsCons(head_, tail_.getHead(), this.length())
+      result = TConsCons(head_, t, tail_.getHead(), this.length())
       or
       result = TCons1(head_, this.length())
     }
@@ -3002,7 +3003,7 @@ module Impl<FullStateConfigSig Config> {
     override AccessPathFrontHead getFront() { result = TFrontHead(head1) }
 
     override AccessPathApproxCons getApprox() {
-      result = TConsCons(head1, head2, len) or
+      result = TConsCons(head1, t, head2, len) or
       result = TCons1(head1, len)
     }
 

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplCommon.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplCommon.qll
@@ -815,26 +815,20 @@ private module Cached {
     )
   }
 
-  private predicate store(
-    Node node1, Content c, Node node2, DataFlowType contentType, DataFlowType containerType
-  ) {
-    exists(ContentSet cs |
-      c = cs.getAStoreContent() and storeSet(node1, cs, node2, contentType, containerType)
-    )
-  }
-
   /**
    * Holds if data can flow from `node1` to `node2` via a direct assignment to
-   * `f`.
+   * `c`.
    *
    * This includes reverse steps through reads when the result of the read has
    * been stored into, in order to handle cases like `x.f1.f2 = y`.
    */
   cached
-  predicate store(Node node1, TypedContent tc, Content c, Node node2, DataFlowType contentType, DataFlowType containerType) {
-    tc.getContent() = c and
-    tc.getContainerType() = containerType and
-    store(node1, c, node2, contentType, containerType)
+  predicate store(
+    Node node1, Content c, Node node2, DataFlowType contentType, DataFlowType containerType
+  ) {
+    exists(ContentSet cs |
+      c = cs.getAStoreContent() and storeSet(node1, cs, node2, contentType, containerType)
+    )
   }
 
   /**
@@ -933,9 +927,6 @@ private module Cached {
     TReturnCtxNone() or
     TReturnCtxNoFlowThrough() or
     TReturnCtxMaybeFlowThrough(ReturnPosition pos)
-
-  cached
-  newtype TTypedContent = MkTypedContent(Content c, DataFlowType t) { store(_, c, _, _, t) }
 
   cached
   newtype TAccessPathFront =
@@ -1413,30 +1404,6 @@ class ApproxAccessPathFrontOption extends TApproxAccessPathFrontOption {
     or
     this = TApproxAccessPathFrontSome(any(ApproxAccessPathFront apf | result = apf.toString()))
   }
-}
-
-/** A `Content` tagged with the type of a containing object. */
-class TypedContent extends MkTypedContent {
-  private Content c;
-  private DataFlowType t;
-
-  TypedContent() { this = MkTypedContent(c, t) }
-
-  /** Gets the content. */
-  Content getContent() { result = c }
-
-  /** Gets the container type. */
-  DataFlowType getContainerType() { result = t }
-
-  /** Gets a textual representation of this content. */
-  string toString() { result = c.toString() }
-
-  /**
-   * Holds if access paths with this `TypedContent` at their head always should
-   * be tracked at high precision. This disables adaptive access path precision
-   * for such access paths.
-   */
-  predicate forceHighPrecision() { forceHighPrecision(c) }
 }
 
 /**

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplCommon.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplCommon.qll
@@ -957,12 +957,12 @@ private module Cached {
 
   cached
   newtype TAccessPathFront =
-    TFrontNil(DataFlowType t) or
+    TFrontNil() or
     TFrontHead(TypedContent tc)
 
   cached
   newtype TApproxAccessPathFront =
-    TApproxFrontNil(DataFlowType t) or
+    TApproxFrontNil() or
     TApproxFrontHead(TypedContentApprox tc)
 
   cached
@@ -1415,8 +1415,6 @@ class TypedContentApprox extends MkTypedContentApprox {
 abstract class ApproxAccessPathFront extends TApproxAccessPathFront {
   abstract string toString();
 
-  abstract DataFlowType getType();
-
   abstract boolean toBoolNonEmpty();
 
   TypedContentApprox getHead() { this = TApproxFrontHead(result) }
@@ -1431,13 +1429,7 @@ abstract class ApproxAccessPathFront extends TApproxAccessPathFront {
 }
 
 class ApproxAccessPathFrontNil extends ApproxAccessPathFront, TApproxFrontNil {
-  private DataFlowType t;
-
-  ApproxAccessPathFrontNil() { this = TApproxFrontNil(t) }
-
-  override string toString() { result = ppReprType(t) }
-
-  override DataFlowType getType() { result = t }
+  override string toString() { result = "nil" }
 
   override boolean toBoolNonEmpty() { result = false }
 }
@@ -1448,8 +1440,6 @@ class ApproxAccessPathFrontHead extends ApproxAccessPathFront, TApproxFrontHead 
   ApproxAccessPathFrontHead() { this = TApproxFrontHead(tc) }
 
   override string toString() { result = tc.toString() }
-
-  override DataFlowType getType() { result = tc.getContainerType() }
 
   override boolean toBoolNonEmpty() { result = true }
 }
@@ -1493,23 +1483,15 @@ class TypedContent extends MkTypedContent {
 abstract class AccessPathFront extends TAccessPathFront {
   abstract string toString();
 
-  abstract DataFlowType getType();
-
   abstract ApproxAccessPathFront toApprox();
 
   TypedContent getHead() { this = TFrontHead(result) }
 }
 
 class AccessPathFrontNil extends AccessPathFront, TFrontNil {
-  private DataFlowType t;
+  override string toString() { result = "nil" }
 
-  AccessPathFrontNil() { this = TFrontNil(t) }
-
-  override string toString() { result = ppReprType(t) }
-
-  override DataFlowType getType() { result = t }
-
-  override ApproxAccessPathFront toApprox() { result = TApproxFrontNil(t) }
+  override ApproxAccessPathFront toApprox() { result = TApproxFrontNil() }
 }
 
 class AccessPathFrontHead extends AccessPathFront, TFrontHead {
@@ -1518,8 +1500,6 @@ class AccessPathFrontHead extends AccessPathFront, TFrontHead {
   AccessPathFrontHead() { this = TFrontHead(tc) }
 
   override string toString() { result = tc.toString() }
-
-  override DataFlowType getType() { result = tc.getContainerType() }
 
   override ApproxAccessPathFront toApprox() { result.getAHead() = tc }
 }

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplCommon.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplCommon.qll
@@ -831,8 +831,10 @@ private module Cached {
    * been stored into, in order to handle cases like `x.f1.f2 = y`.
    */
   cached
-  predicate store(Node node1, TypedContent tc, Node node2, DataFlowType contentType) {
-    store(node1, tc.getContent(), node2, contentType, tc.getContainerType())
+  predicate store(Node node1, TypedContent tc, Content c, Node node2, DataFlowType contentType, DataFlowType containerType) {
+    tc.getContent() = c and
+    tc.getContainerType() = containerType and
+    store(node1, c, node2, contentType, containerType)
   }
 
   /**

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplCommon.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplCommon.qll
@@ -940,7 +940,7 @@ private module Cached {
   cached
   newtype TAccessPathFront =
     TFrontNil() or
-    TFrontHead(TypedContent tc)
+    TFrontHead(Content c)
 
   cached
   newtype TApproxAccessPathFront =
@@ -1447,7 +1447,7 @@ abstract class AccessPathFront extends TAccessPathFront {
 
   abstract ApproxAccessPathFront toApprox();
 
-  TypedContent getHead() { this = TFrontHead(result) }
+  Content getHead() { this = TFrontHead(result) }
 }
 
 class AccessPathFrontNil extends AccessPathFront, TFrontNil {
@@ -1457,13 +1457,13 @@ class AccessPathFrontNil extends AccessPathFront, TFrontNil {
 }
 
 class AccessPathFrontHead extends AccessPathFront, TFrontHead {
-  private TypedContent tc;
+  private Content c;
 
-  AccessPathFrontHead() { this = TFrontHead(tc) }
+  AccessPathFrontHead() { this = TFrontHead(c) }
 
-  override string toString() { result = tc.toString() }
+  override string toString() { result = c.toString() }
 
-  override ApproxAccessPathFront toApprox() { result.getAHead() = tc.getContent() }
+  override ApproxAccessPathFront toApprox() { result.getAHead() = c }
 }
 
 /** An optional access path front. */

--- a/java/ql/src/utils/modelgenerator/internal/CaptureModels.qll
+++ b/java/ql/src/utils/modelgenerator/internal/CaptureModels.qll
@@ -139,9 +139,9 @@ module ThroughFlowConfig implements DataFlow::StateConfigSig {
   predicate isAdditionalFlowStep(
     DataFlow::Node node1, FlowState state1, DataFlow::Node node2, FlowState state2
   ) {
-    exists(DataFlowImplCommon::TypedContent tc |
-      DataFlowImplCommon::store(node1, tc, node2, _) and
-      isRelevantContent(tc.getContent()) and
+    exists(DataFlow::Content c |
+      DataFlowImplCommon::store(node1, c, node2, _, _) and
+      isRelevantContent(c) and
       (
         state1 instanceof TaintRead and state2.(TaintStore).getStep() = 1
         or


### PR DESCRIPTION
In data flow we're tracking both a type and an access path. These two things are somewhat intertwined as we want to be able to reestablish the tracked type after a store-to-read step sequence.
We used to achieve this by merging the type into the front of the access paths resulting in a list of the form `(typ1, content1) :: (typ2, content2) :: ... :: nil(typn)`. This refactor pulls the front type out of the access path, such that it becomes an explicit pair rather than being merged with `Content`. We still need the types nested inside the access path tails, so now, instead of being a list of `TypedContent`s, access paths are a list of `Content`s where each nested tail is paired with a `DataFlowType`, i.e. `(typ1, content1 :: (typ2, content2 :: ... :: (typn, nil)) ... ))`.
In the automaton view of access paths, we're switching from a graph with access-path nodes and type-content-pair-labelled edges to a graph where the nodes are type-access-path pairs and the edges are merely content-labelled.
This refactor is intended to pave the way for a future enhancement where we'll be able to update the tracked type independently from the access path to improve precision.

This PR is intended to be reviewed commit-by-commit. The commits progress by first duplicating the type information from the access paths where needed before replacing `TypedContent` with `Content`.