### PR TITLE
Swift: Remove empty string DataFlowType in PathNode.

### DIFF
--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPrivate.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPrivate.qll
@@ -802,7 +802,7 @@ DataFlowType getNodeType(NodeImpl n) {
 }
 
 /** Gets a string representation of a `DataFlowType`. */
-string ppReprType(DataFlowType t) { result = t.toString() }
+string ppReprType(DataFlowType t) { none() }
 
 /**
  * Holds if `t1` and `t2` are compatible, that is, whether data can flow from

--- a/swift/ql/test/library-tests/dataflow/dataflow/DataFlow.expected
+++ b/swift/ql/test/library-tests/dataflow/dataflow/DataFlow.expected
@@ -1,691 +1,623 @@
 edges
-| file://:0:0:0:0 | [summary param] this in signum() :  | file://:0:0:0:0 | [summary] to write: return (return) in signum() :  |
-| file://:0:0:0:0 | [summary param] this in signum() [some:0] :  | file://:0:0:0:0 | [summary] to write: return (return) in signum() [some:0] :  |
-| file://:0:0:0:0 | self [a, x] :  | file://:0:0:0:0 | .a [x] :  |
-| file://:0:0:0:0 | self [str] :  | file://:0:0:0:0 | .str :  |
-| file://:0:0:0:0 | self [x, some:0] :  | file://:0:0:0:0 | .x [some:0] :  |
-| file://:0:0:0:0 | self [x] :  | file://:0:0:0:0 | .x :  |
-| file://:0:0:0:0 | value :  | file://:0:0:0:0 | [post] self [x] :  |
-| file://:0:0:0:0 | value [some:0] :  | file://:0:0:0:0 | [post] self [x, some:0] :  |
-| test.swift:6:19:6:26 | call to source() :  | test.swift:7:15:7:15 | t1 |
-| test.swift:6:19:6:26 | call to source() :  | test.swift:9:15:9:15 | t1 |
-| test.swift:6:19:6:26 | call to source() :  | test.swift:10:15:10:15 | t2 |
-| test.swift:25:20:25:27 | call to source() :  | test.swift:29:18:29:21 | x :  |
-| test.swift:26:26:26:33 | call to source() :  | test.swift:29:26:29:29 | y :  |
-| test.swift:29:18:29:21 | x :  | test.swift:30:15:30:15 | x |
-| test.swift:29:26:29:29 | y :  | test.swift:31:15:31:15 | y |
-| test.swift:35:12:35:19 | call to source() :  | test.swift:39:15:39:29 | call to callee_source() |
-| test.swift:43:19:43:26 | call to source() :  | test.swift:50:15:50:15 | t |
-| test.swift:53:1:56:1 | arg[return] :  | test.swift:61:22:61:23 | [post] &... :  |
-| test.swift:54:11:54:18 | call to source() :  | test.swift:53:1:56:1 | arg[return] :  |
-| test.swift:61:22:61:23 | [post] &... :  | test.swift:62:15:62:15 | x |
-| test.swift:65:16:65:28 | arg1 :  | test.swift:65:1:70:1 | arg2[return] :  |
-| test.swift:73:18:73:25 | call to source() :  | test.swift:75:21:75:22 | &... :  |
-| test.swift:73:18:73:25 | call to source() :  | test.swift:76:15:76:15 | x |
-| test.swift:75:21:75:22 | &... :  | test.swift:65:16:65:28 | arg1 :  |
-| test.swift:75:21:75:22 | &... :  | test.swift:75:31:75:32 | [post] &... :  |
-| test.swift:75:31:75:32 | [post] &... :  | test.swift:77:15:77:15 | y |
-| test.swift:80:1:82:1 | arg[return] :  | test.swift:97:39:97:40 | [post] &... :  |
-| test.swift:81:11:81:18 | call to source() :  | test.swift:80:1:82:1 | arg[return] :  |
-| test.swift:84:1:91:1 | arg[return] :  | test.swift:104:40:104:41 | [post] &... :  |
-| test.swift:86:15:86:22 | call to source() :  | test.swift:84:1:91:1 | arg[return] :  |
-| test.swift:89:15:89:22 | call to source() :  | test.swift:84:1:91:1 | arg[return] :  |
-| test.swift:97:39:97:40 | [post] &... :  | test.swift:98:19:98:19 | x |
-| test.swift:104:40:104:41 | [post] &... :  | test.swift:105:19:105:19 | x |
-| test.swift:109:9:109:14 | arg :  | test.swift:110:12:110:12 | arg :  |
-| test.swift:113:14:113:19 | arg :  | test.swift:114:19:114:19 | arg :  |
-| test.swift:113:14:113:19 | arg :  | test.swift:114:19:114:19 | arg :  |
-| test.swift:114:19:114:19 | arg :  | test.swift:109:9:109:14 | arg :  |
-| test.swift:114:19:114:19 | arg :  | test.swift:114:12:114:22 | call to ... :  |
-| test.swift:114:19:114:19 | arg :  | test.swift:114:12:114:22 | call to ... :  |
-| test.swift:114:19:114:19 | arg :  | test.swift:123:10:123:13 | i :  |
-| test.swift:118:18:118:25 | call to source() :  | test.swift:119:31:119:31 | x :  |
-| test.swift:119:18:119:44 | call to forward(arg:lambda:) :  | test.swift:120:15:120:15 | y |
-| test.swift:119:31:119:31 | x :  | test.swift:113:14:113:19 | arg :  |
-| test.swift:119:31:119:31 | x :  | test.swift:119:18:119:44 | call to forward(arg:lambda:) :  |
-| test.swift:122:18:125:6 | call to forward(arg:lambda:) :  | test.swift:126:15:126:15 | z |
-| test.swift:122:31:122:38 | call to source() :  | test.swift:113:14:113:19 | arg :  |
-| test.swift:122:31:122:38 | call to source() :  | test.swift:122:18:125:6 | call to forward(arg:lambda:) :  |
-| test.swift:123:10:123:13 | i :  | test.swift:124:16:124:16 | i :  |
-| test.swift:142:10:142:13 | i :  | test.swift:143:16:143:16 | i :  |
-| test.swift:145:23:145:30 | call to source() :  | test.swift:142:10:142:13 | i :  |
-| test.swift:145:23:145:30 | call to source() :  | test.swift:145:15:145:31 | call to ... |
-| test.swift:149:16:149:23 | call to source() :  | test.swift:151:15:151:28 | call to ... |
-| test.swift:149:16:149:23 | call to source() :  | test.swift:159:16:159:29 | call to ... :  |
-| test.swift:154:10:154:13 | i :  | test.swift:155:19:155:19 | i |
-| test.swift:157:16:157:23 | call to source() :  | test.swift:154:10:154:13 | i :  |
-| test.swift:159:16:159:29 | call to ... :  | test.swift:154:10:154:13 | i :  |
-| test.swift:163:7:163:7 | self [x] :  | file://:0:0:0:0 | self [x] :  |
-| test.swift:163:7:163:7 | value :  | file://:0:0:0:0 | value :  |
-| test.swift:169:12:169:22 | value :  | test.swift:170:9:170:9 | value :  |
-| test.swift:170:5:170:5 | [post] self [x] :  | test.swift:169:3:171:3 | self[return] [x] :  |
-| test.swift:170:9:170:9 | value :  | test.swift:163:7:163:7 | value :  |
-| test.swift:170:9:170:9 | value :  | test.swift:170:5:170:5 | [post] self [x] :  |
-| test.swift:173:8:173:8 | self [x] :  | test.swift:174:12:174:12 | self [x] :  |
-| test.swift:174:12:174:12 | self [x] :  | test.swift:163:7:163:7 | self [x] :  |
-| test.swift:174:12:174:12 | self [x] :  | test.swift:174:12:174:12 | .x :  |
-| test.swift:180:3:180:3 | [post] a [x] :  | test.swift:181:13:181:13 | a [x] :  |
-| test.swift:180:9:180:16 | call to source() :  | test.swift:163:7:163:7 | value :  |
-| test.swift:180:9:180:16 | call to source() :  | test.swift:180:3:180:3 | [post] a [x] :  |
-| test.swift:181:13:181:13 | a [x] :  | test.swift:163:7:163:7 | self [x] :  |
-| test.swift:181:13:181:13 | a [x] :  | test.swift:181:13:181:15 | .x |
-| test.swift:185:7:185:7 | self [a, x] :  | file://:0:0:0:0 | self [a, x] :  |
-| test.swift:194:3:194:3 | [post] b [a, x] :  | test.swift:195:13:195:13 | b [a, x] :  |
-| test.swift:194:3:194:5 | [post] getter for .a [x] :  | test.swift:194:3:194:3 | [post] b [a, x] :  |
-| test.swift:194:11:194:18 | call to source() :  | test.swift:163:7:163:7 | value :  |
-| test.swift:194:11:194:18 | call to source() :  | test.swift:194:3:194:5 | [post] getter for .a [x] :  |
-| test.swift:195:13:195:13 | b [a, x] :  | test.swift:185:7:185:7 | self [a, x] :  |
-| test.swift:195:13:195:13 | b [a, x] :  | test.swift:195:13:195:15 | .a [x] :  |
-| test.swift:195:13:195:15 | .a [x] :  | test.swift:163:7:163:7 | self [x] :  |
-| test.swift:195:13:195:15 | .a [x] :  | test.swift:195:13:195:17 | .x |
-| test.swift:200:3:200:3 | [post] a [x] :  | test.swift:201:13:201:13 | a [x] :  |
-| test.swift:200:9:200:16 | call to source() :  | test.swift:169:12:169:22 | value :  |
-| test.swift:200:9:200:16 | call to source() :  | test.swift:200:3:200:3 | [post] a [x] :  |
-| test.swift:201:13:201:13 | a [x] :  | test.swift:163:7:163:7 | self [x] :  |
-| test.swift:201:13:201:13 | a [x] :  | test.swift:201:13:201:15 | .x |
-| test.swift:206:3:206:3 | [post] a [x] :  | test.swift:207:13:207:13 | a [x] :  |
-| test.swift:206:9:206:16 | call to source() :  | test.swift:163:7:163:7 | value :  |
-| test.swift:206:9:206:16 | call to source() :  | test.swift:206:3:206:3 | [post] a [x] :  |
-| test.swift:207:13:207:13 | a [x] :  | test.swift:173:8:173:8 | self [x] :  |
-| test.swift:207:13:207:13 | a [x] :  | test.swift:207:13:207:19 | call to get() |
-| test.swift:212:3:212:3 | [post] a [x] :  | test.swift:213:13:213:13 | a [x] :  |
-| test.swift:212:9:212:16 | call to source() :  | test.swift:169:12:169:22 | value :  |
-| test.swift:212:9:212:16 | call to source() :  | test.swift:212:3:212:3 | [post] a [x] :  |
-| test.swift:213:13:213:13 | a [x] :  | test.swift:173:8:173:8 | self [x] :  |
-| test.swift:213:13:213:13 | a [x] :  | test.swift:213:13:213:19 | call to get() |
-| test.swift:218:3:218:3 | [post] b [a, x] :  | test.swift:219:13:219:13 | b [a, x] :  |
-| test.swift:218:3:218:5 | [post] getter for .a [x] :  | test.swift:218:3:218:3 | [post] b [a, x] :  |
-| test.swift:218:11:218:18 | call to source() :  | test.swift:169:12:169:22 | value :  |
-| test.swift:218:11:218:18 | call to source() :  | test.swift:218:3:218:5 | [post] getter for .a [x] :  |
-| test.swift:219:13:219:13 | b [a, x] :  | test.swift:185:7:185:7 | self [a, x] :  |
-| test.swift:219:13:219:13 | b [a, x] :  | test.swift:219:13:219:15 | .a [x] :  |
-| test.swift:219:13:219:15 | .a [x] :  | test.swift:163:7:163:7 | self [x] :  |
-| test.swift:219:13:219:15 | .a [x] :  | test.swift:219:13:219:17 | .x |
-| test.swift:225:14:225:21 | call to source() :  | test.swift:235:13:235:15 | .source_value |
-| test.swift:225:14:225:21 | call to source() :  | test.swift:238:13:238:15 | .source_value |
-| test.swift:259:12:259:19 | call to source() :  | test.swift:259:12:259:19 | call to source() [some:0] :  |
-| test.swift:259:12:259:19 | call to source() :  | test.swift:263:13:263:28 | call to optionalSource() :  |
-| test.swift:259:12:259:19 | call to source() [some:0] :  | test.swift:263:13:263:28 | call to optionalSource() [some:0] :  |
-| test.swift:259:12:259:19 | call to source() [some:0] :  | test.swift:486:13:486:28 | call to optionalSource() [some:0] :  |
-| test.swift:259:12:259:19 | call to source() [some:0] :  | test.swift:513:13:513:28 | call to optionalSource() [some:0] :  |
-| test.swift:263:13:263:28 | call to optionalSource() :  | test.swift:265:15:265:15 | x |
-| test.swift:263:13:263:28 | call to optionalSource() :  | test.swift:267:15:267:16 | ...! |
-| test.swift:263:13:263:28 | call to optionalSource() :  | test.swift:271:15:271:16 | ...? :  |
-| test.swift:263:13:263:28 | call to optionalSource() :  | test.swift:274:15:274:20 | ... ??(_:_:) ... |
-| test.swift:263:13:263:28 | call to optionalSource() :  | test.swift:275:15:275:27 | ... ??(_:_:) ... |
-| test.swift:263:13:263:28 | call to optionalSource() :  | test.swift:279:15:279:31 | ... ? ... : ... |
-| test.swift:263:13:263:28 | call to optionalSource() :  | test.swift:280:15:280:38 | ... ? ... : ... |
-| test.swift:263:13:263:28 | call to optionalSource() :  | test.swift:291:16:291:17 | ...? :  |
-| test.swift:263:13:263:28 | call to optionalSource() :  | test.swift:303:15:303:16 | ...! :  |
-| test.swift:263:13:263:28 | call to optionalSource() [some:0] :  | test.swift:284:8:284:12 | let ...? [some:0] :  |
-| test.swift:263:13:263:28 | call to optionalSource() [some:0] :  | test.swift:291:16:291:17 | ...? [some:0] :  |
-| test.swift:263:13:263:28 | call to optionalSource() [some:0] :  | test.swift:298:11:298:15 | let ...? [some:0] :  |
-| test.swift:263:13:263:28 | call to optionalSource() [some:0] :  | test.swift:306:13:306:24 | .some(...) [some:0] :  |
-| test.swift:263:13:263:28 | call to optionalSource() [some:0] :  | test.swift:314:10:314:21 | .some(...) [some:0] :  |
-| test.swift:270:15:270:22 | call to source() :  | file://:0:0:0:0 | [summary param] this in signum() :  |
-| test.swift:270:15:270:22 | call to source() :  | test.swift:270:15:270:31 | call to signum() |
-| test.swift:271:15:271:16 | ...? :  | file://:0:0:0:0 | [summary param] this in signum() :  |
-| test.swift:271:15:271:16 | ...? :  | test.swift:271:15:271:25 | call to signum() :  |
-| test.swift:271:15:271:25 | call to signum() :  | test.swift:271:15:271:25 | OptionalEvaluationExpr |
-| test.swift:280:31:280:38 | call to source() :  | test.swift:280:15:280:38 | ... ? ... : ... |
-| test.swift:282:31:282:38 | call to source() :  | test.swift:282:15:282:38 | ... ? ... : ... |
-| test.swift:284:8:284:12 | let ...? [some:0] :  | test.swift:284:12:284:12 | z :  |
-| test.swift:284:12:284:12 | z :  | test.swift:285:19:285:19 | z |
-| test.swift:291:8:291:12 | let ...? [some:0] :  | test.swift:291:12:291:12 | z :  |
-| test.swift:291:12:291:12 | z :  | test.swift:292:19:292:19 | z |
-| test.swift:291:16:291:17 | ...? :  | file://:0:0:0:0 | [summary param] this in signum() :  |
-| test.swift:291:16:291:17 | ...? :  | test.swift:291:16:291:26 | call to signum() :  |
-| test.swift:291:16:291:17 | ...? [some:0] :  | file://:0:0:0:0 | [summary param] this in signum() [some:0] :  |
-| test.swift:291:16:291:17 | ...? [some:0] :  | test.swift:291:16:291:26 | call to signum() [some:0] :  |
-| test.swift:291:16:291:26 | call to signum() :  | test.swift:291:16:291:26 | call to signum() [some:0] :  |
-| test.swift:291:16:291:26 | call to signum() [some:0] :  | test.swift:291:8:291:12 | let ...? [some:0] :  |
-| test.swift:298:11:298:15 | let ...? [some:0] :  | test.swift:298:15:298:15 | z1 :  |
-| test.swift:298:15:298:15 | z1 :  | test.swift:300:15:300:15 | z1 |
-| test.swift:303:15:303:16 | ...! :  | file://:0:0:0:0 | [summary param] this in signum() :  |
-| test.swift:303:15:303:16 | ...! :  | test.swift:303:15:303:25 | call to signum() |
-| test.swift:306:13:306:24 | .some(...) [some:0] :  | test.swift:306:23:306:23 | z :  |
-| test.swift:306:23:306:23 | z :  | test.swift:307:19:307:19 | z |
-| test.swift:314:10:314:21 | .some(...) [some:0] :  | test.swift:314:20:314:20 | z :  |
-| test.swift:314:20:314:20 | z :  | test.swift:315:19:315:19 | z |
-| test.swift:331:14:331:26 | (...) [Tuple element at index 1] :  | test.swift:335:15:335:15 | t1 [Tuple element at index 1] :  |
-| test.swift:331:18:331:25 | call to source() :  | test.swift:331:14:331:26 | (...) [Tuple element at index 1] :  |
-| test.swift:335:15:335:15 | t1 [Tuple element at index 1] :  | test.swift:335:15:335:18 | .1 |
-| test.swift:343:5:343:5 | [post] t1 [Tuple element at index 0] :  | test.swift:346:15:346:15 | t1 [Tuple element at index 0] :  |
-| test.swift:343:12:343:19 | call to source() :  | test.swift:343:5:343:5 | [post] t1 [Tuple element at index 0] :  |
-| test.swift:346:15:346:15 | t1 [Tuple element at index 0] :  | test.swift:346:15:346:18 | .0 |
-| test.swift:351:14:351:45 | (...) [Tuple element at index 0] :  | test.swift:353:9:353:17 | (...) [Tuple element at index 0] :  |
-| test.swift:351:14:351:45 | (...) [Tuple element at index 0] :  | test.swift:356:15:356:15 | t1 [Tuple element at index 0] :  |
-| test.swift:351:14:351:45 | (...) [Tuple element at index 0] :  | test.swift:360:15:360:15 | t2 [Tuple element at index 0] :  |
-| test.swift:351:14:351:45 | (...) [Tuple element at index 1] :  | test.swift:353:9:353:17 | (...) [Tuple element at index 1] :  |
-| test.swift:351:14:351:45 | (...) [Tuple element at index 1] :  | test.swift:357:15:357:15 | t1 [Tuple element at index 1] :  |
-| test.swift:351:14:351:45 | (...) [Tuple element at index 1] :  | test.swift:361:15:361:15 | t2 [Tuple element at index 1] :  |
-| test.swift:351:18:351:25 | call to source() :  | test.swift:351:14:351:45 | (...) [Tuple element at index 0] :  |
-| test.swift:351:31:351:38 | call to source() :  | test.swift:351:14:351:45 | (...) [Tuple element at index 1] :  |
-| test.swift:353:9:353:17 | (...) [Tuple element at index 0] :  | test.swift:353:10:353:10 | a :  |
-| test.swift:353:9:353:17 | (...) [Tuple element at index 1] :  | test.swift:353:13:353:13 | b :  |
-| test.swift:353:10:353:10 | a :  | test.swift:363:15:363:15 | a |
-| test.swift:353:13:353:13 | b :  | test.swift:364:15:364:15 | b |
-| test.swift:356:15:356:15 | t1 [Tuple element at index 0] :  | test.swift:356:15:356:18 | .0 |
-| test.swift:357:15:357:15 | t1 [Tuple element at index 1] :  | test.swift:357:15:357:18 | .1 |
-| test.swift:360:15:360:15 | t2 [Tuple element at index 0] :  | test.swift:360:15:360:18 | .0 |
-| test.swift:361:15:361:15 | t2 [Tuple element at index 1] :  | test.swift:361:15:361:18 | .1 |
-| test.swift:398:9:398:27 | call to ... [mySingle:0] :  | test.swift:403:10:403:25 | .mySingle(...) [mySingle:0] :  |
-| test.swift:398:9:398:27 | call to ... [mySingle:0] :  | test.swift:412:13:412:28 | .mySingle(...) [mySingle:0] :  |
-| test.swift:398:19:398:26 | call to source() :  | test.swift:398:9:398:27 | call to ... [mySingle:0] :  |
-| test.swift:403:10:403:25 | .mySingle(...) [mySingle:0] :  | test.swift:403:24:403:24 | a :  |
-| test.swift:403:24:403:24 | a :  | test.swift:404:19:404:19 | a |
-| test.swift:412:13:412:28 | .mySingle(...) [mySingle:0] :  | test.swift:412:27:412:27 | x :  |
-| test.swift:412:27:412:27 | x :  | test.swift:413:19:413:19 | x |
-| test.swift:420:9:420:34 | call to ... [myPair:1] :  | test.swift:427:10:427:30 | .myPair(...) [myPair:1] :  |
-| test.swift:420:9:420:34 | call to ... [myPair:1] :  | test.swift:437:13:437:33 | .myPair(...) [myPair:1] :  |
-| test.swift:420:9:420:34 | call to ... [myPair:1] :  | test.swift:442:33:442:33 | a [myPair:1] :  |
-| test.swift:420:9:420:34 | call to ... [myPair:1] :  | test.swift:471:13:471:13 | a [myPair:1] :  |
-| test.swift:420:26:420:33 | call to source() :  | test.swift:420:9:420:34 | call to ... [myPair:1] :  |
-| test.swift:427:10:427:30 | .myPair(...) [myPair:1] :  | test.swift:427:29:427:29 | b :  |
-| test.swift:427:29:427:29 | b :  | test.swift:429:19:429:19 | b |
-| test.swift:437:13:437:33 | .myPair(...) [myPair:1] :  | test.swift:437:32:437:32 | y :  |
-| test.swift:437:32:437:32 | y :  | test.swift:439:19:439:19 | y |
-| test.swift:442:21:442:34 | call to ... [myCons:1, myPair:1] :  | test.swift:452:14:452:38 | .myCons(...) [myCons:1, myPair:1] :  |
-| test.swift:442:21:442:34 | call to ... [myCons:1, myPair:1] :  | test.swift:467:17:467:41 | .myCons(...) [myCons:1, myPair:1] :  |
-| test.swift:442:21:442:34 | call to ... [myCons:1, myPair:1] :  | test.swift:471:16:471:16 | b [myCons:1, myPair:1] :  |
-| test.swift:442:33:442:33 | a [myPair:1] :  | test.swift:442:21:442:34 | call to ... [myCons:1, myPair:1] :  |
-| test.swift:452:14:452:38 | .myCons(...) [myCons:1, myPair:1] :  | test.swift:452:25:452:37 | .myPair(...) [myPair:1] :  |
-| test.swift:452:25:452:37 | .myPair(...) [myPair:1] :  | test.swift:452:36:452:36 | c :  |
-| test.swift:452:36:452:36 | c :  | test.swift:455:19:455:19 | c |
-| test.swift:463:13:463:39 | .myPair(...) [myPair:0] :  | test.swift:463:31:463:31 | x :  |
-| test.swift:463:31:463:31 | x :  | test.swift:464:19:464:19 | x |
-| test.swift:463:43:463:62 | call to ... [myPair:0] :  | test.swift:463:13:463:39 | .myPair(...) [myPair:0] :  |
-| test.swift:463:51:463:58 | call to source() :  | test.swift:463:43:463:62 | call to ... [myPair:0] :  |
-| test.swift:467:17:467:41 | .myCons(...) [myCons:1, myPair:1] :  | test.swift:467:28:467:40 | .myPair(...) [myPair:1] :  |
-| test.swift:467:28:467:40 | .myPair(...) [myPair:1] :  | test.swift:467:39:467:39 | c :  |
-| test.swift:467:39:467:39 | c :  | test.swift:468:19:468:19 | c |
-| test.swift:471:12:471:17 | (...) [Tuple element at index 0, myPair:1] :  | test.swift:472:14:472:55 | (...) [Tuple element at index 0, myPair:1] :  |
-| test.swift:471:12:471:17 | (...) [Tuple element at index 1, myCons:1, myPair:1] :  | test.swift:472:14:472:55 | (...) [Tuple element at index 1, myCons:1, myPair:1] :  |
-| test.swift:471:13:471:13 | a [myPair:1] :  | test.swift:471:12:471:17 | (...) [Tuple element at index 0, myPair:1] :  |
-| test.swift:471:16:471:16 | b [myCons:1, myPair:1] :  | test.swift:471:12:471:17 | (...) [Tuple element at index 1, myCons:1, myPair:1] :  |
-| test.swift:472:14:472:55 | (...) [Tuple element at index 0, myPair:1] :  | test.swift:472:15:472:27 | .myPair(...) [myPair:1] :  |
-| test.swift:472:14:472:55 | (...) [Tuple element at index 1, myCons:1, myPair:1] :  | test.swift:472:30:472:54 | .myCons(...) [myCons:1, myPair:1] :  |
-| test.swift:472:15:472:27 | .myPair(...) [myPair:1] :  | test.swift:472:26:472:26 | b :  |
-| test.swift:472:26:472:26 | b :  | test.swift:474:19:474:19 | b |
-| test.swift:472:30:472:54 | .myCons(...) [myCons:1, myPair:1] :  | test.swift:472:41:472:53 | .myPair(...) [myPair:1] :  |
-| test.swift:472:41:472:53 | .myPair(...) [myPair:1] :  | test.swift:472:52:472:52 | e :  |
-| test.swift:472:52:472:52 | e :  | test.swift:477:19:477:19 | e |
-| test.swift:486:13:486:28 | call to optionalSource() [some:0] :  | test.swift:488:8:488:12 | let ...? [some:0] :  |
-| test.swift:486:13:486:28 | call to optionalSource() [some:0] :  | test.swift:493:19:493:19 | x [some:0] :  |
-| test.swift:488:8:488:12 | let ...? [some:0] :  | test.swift:488:12:488:12 | a :  |
-| test.swift:488:12:488:12 | a :  | test.swift:489:19:489:19 | a |
-| test.swift:493:18:493:23 | (...) [Tuple element at index 0, some:0] :  | test.swift:495:10:495:37 | (...) [Tuple element at index 0, some:0] :  |
-| test.swift:493:19:493:19 | x [some:0] :  | test.swift:493:18:493:23 | (...) [Tuple element at index 0, some:0] :  |
-| test.swift:495:10:495:37 | (...) [Tuple element at index 0, some:0] :  | test.swift:495:11:495:22 | .some(...) [some:0] :  |
-| test.swift:495:11:495:22 | .some(...) [some:0] :  | test.swift:495:21:495:21 | a :  |
-| test.swift:495:21:495:21 | a :  | test.swift:496:19:496:19 | a |
-| test.swift:509:9:509:9 | self [x, some:0] :  | file://:0:0:0:0 | self [x, some:0] :  |
-| test.swift:509:9:509:9 | value [some:0] :  | file://:0:0:0:0 | value [some:0] :  |
-| test.swift:513:13:513:28 | call to optionalSource() [some:0] :  | test.swift:515:12:515:12 | x [some:0] :  |
-| test.swift:515:5:515:5 | [post] cx [x, some:0] :  | test.swift:519:20:519:20 | cx [x, some:0] :  |
-| test.swift:515:12:515:12 | x [some:0] :  | test.swift:509:9:509:9 | value [some:0] :  |
-| test.swift:515:12:515:12 | x [some:0] :  | test.swift:515:5:515:5 | [post] cx [x, some:0] :  |
-| test.swift:519:11:519:15 | let ...? [some:0] :  | test.swift:519:15:519:15 | z1 :  |
-| test.swift:519:15:519:15 | z1 :  | test.swift:520:15:520:15 | z1 |
-| test.swift:519:20:519:20 | cx [x, some:0] :  | test.swift:509:9:509:9 | self [x, some:0] :  |
-| test.swift:519:20:519:20 | cx [x, some:0] :  | test.swift:519:20:519:23 | .x [some:0] :  |
-| test.swift:519:20:519:23 | .x [some:0] :  | test.swift:519:11:519:15 | let ...? [some:0] :  |
-| test.swift:526:14:526:21 | call to source() :  | test.swift:526:13:526:21 | call to +(_:) |
-| test.swift:535:9:535:9 | self [str] :  | file://:0:0:0:0 | self [str] :  |
-| test.swift:536:10:536:13 | s :  | test.swift:537:13:537:13 | s :  |
-| test.swift:537:7:537:7 | [post] self [str] :  | test.swift:536:5:538:5 | self[return] [str] :  |
-| test.swift:537:13:537:13 | s :  | test.swift:537:7:537:7 | [post] self [str] :  |
-| test.swift:542:17:545:5 | self[return] [str] :  | test.swift:550:13:550:41 | call to Self.init(contentsOfFile:) [str] :  |
-| test.swift:543:7:543:7 | [post] self [str] :  | test.swift:542:17:545:5 | self[return] [str] :  |
-| test.swift:543:7:543:7 | [post] self [str] :  | test.swift:544:17:544:17 | self [str] :  |
-| test.swift:543:20:543:28 | call to source3() :  | test.swift:536:10:536:13 | s :  |
-| test.swift:543:20:543:28 | call to source3() :  | test.swift:543:7:543:7 | [post] self [str] :  |
-| test.swift:544:17:544:17 | self [str] :  | test.swift:544:17:544:17 | .str |
-| test.swift:549:13:549:33 | call to MyClass.init(s:) [str] :  | test.swift:535:9:535:9 | self [str] :  |
-| test.swift:549:13:549:33 | call to MyClass.init(s:) [str] :  | test.swift:549:13:549:35 | .str |
-| test.swift:549:24:549:32 | call to source3() :  | test.swift:536:10:536:13 | s :  |
-| test.swift:549:24:549:32 | call to source3() :  | test.swift:549:13:549:33 | call to MyClass.init(s:) [str] :  |
-| test.swift:550:13:550:41 | call to Self.init(contentsOfFile:) [str] :  | test.swift:535:9:535:9 | self [str] :  |
-| test.swift:550:13:550:41 | call to Self.init(contentsOfFile:) [str] :  | test.swift:550:13:550:43 | .str |
-| test.swift:567:8:567:11 | x :  | test.swift:568:14:568:14 | x :  |
-| test.swift:568:5:568:5 | [post] self [x] :  | test.swift:567:3:569:3 | self[return] [x] :  |
-| test.swift:568:14:568:14 | x :  | test.swift:568:5:568:5 | [post] self [x] :  |
-| test.swift:573:11:573:24 | call to S.init(x:) [x] :  | test.swift:575:13:575:13 | s [x] :  |
-| test.swift:573:11:573:24 | call to S.init(x:) [x] :  | test.swift:578:13:578:13 | s [x] :  |
-| test.swift:573:16:573:23 | call to source() :  | test.swift:567:8:567:11 | x :  |
-| test.swift:573:16:573:23 | call to source() :  | test.swift:573:11:573:24 | call to S.init(x:) [x] :  |
-| test.swift:574:11:574:14 | enter #keyPath(...) [x] :  | test.swift:574:14:574:14 | KeyPathComponent [x] :  |
-| test.swift:574:14:574:14 | KeyPathComponent [x] :  | test.swift:574:11:574:14 | exit #keyPath(...) :  |
-| test.swift:575:13:575:13 | s [x] :  | test.swift:574:11:574:14 | enter #keyPath(...) [x] :  |
-| test.swift:575:13:575:13 | s [x] :  | test.swift:575:13:575:25 | \\...[...] |
-| test.swift:577:36:577:38 | enter #keyPath(...) [x] :  | test.swift:577:38:577:38 | KeyPathComponent [x] :  |
-| test.swift:577:38:577:38 | KeyPathComponent [x] :  | test.swift:577:36:577:38 | exit #keyPath(...) :  |
-| test.swift:578:13:578:13 | s [x] :  | test.swift:577:36:577:38 | enter #keyPath(...) [x] :  |
-| test.swift:578:13:578:13 | s [x] :  | test.swift:578:13:578:32 | \\...[...] |
-| test.swift:584:8:584:11 | s [x] :  | test.swift:585:14:585:14 | s [x] :  |
-| test.swift:585:5:585:5 | [post] self [s, x] :  | test.swift:584:3:586:3 | self[return] [s, x] :  |
-| test.swift:585:14:585:14 | s [x] :  | test.swift:585:5:585:5 | [post] self [s, x] :  |
-| test.swift:590:11:590:24 | call to S.init(x:) [x] :  | test.swift:591:18:591:18 | s [x] :  |
-| test.swift:590:16:590:23 | call to source() :  | test.swift:567:8:567:11 | x :  |
-| test.swift:590:16:590:23 | call to source() :  | test.swift:590:11:590:24 | call to S.init(x:) [x] :  |
-| test.swift:591:12:591:19 | call to S2.init(s:) [s, x] :  | test.swift:593:13:593:13 | s2 [s, x] :  |
-| test.swift:591:18:591:18 | s [x] :  | test.swift:584:8:584:11 | s [x] :  |
-| test.swift:591:18:591:18 | s [x] :  | test.swift:591:12:591:19 | call to S2.init(s:) [s, x] :  |
-| test.swift:592:11:592:17 | enter #keyPath(...) [s, x] :  | test.swift:592:15:592:15 | KeyPathComponent [s, x] :  |
-| test.swift:592:15:592:15 | KeyPathComponent [s, x] :  | test.swift:592:17:592:17 | KeyPathComponent [x] :  |
-| test.swift:592:17:592:17 | KeyPathComponent [x] :  | test.swift:592:11:592:17 | exit #keyPath(...) :  |
-| test.swift:593:13:593:13 | s2 [s, x] :  | test.swift:592:11:592:17 | enter #keyPath(...) [s, x] :  |
-| test.swift:593:13:593:13 | s2 [s, x] :  | test.swift:593:13:593:26 | \\...[...] |
+| file://:0:0:0:0 | [summary param] this in signum() | file://:0:0:0:0 | [summary] to write: return (return) in signum() |
+| file://:0:0:0:0 | [summary param] this in signum() [some:0] | file://:0:0:0:0 | [summary] to write: return (return) in signum() [some:0] |
+| file://:0:0:0:0 | self [a, x] | file://:0:0:0:0 | .a [x] |
+| file://:0:0:0:0 | self [str] | file://:0:0:0:0 | .str |
+| file://:0:0:0:0 | self [x, some:0] | file://:0:0:0:0 | .x [some:0] |
+| file://:0:0:0:0 | self [x] | file://:0:0:0:0 | .x |
+| file://:0:0:0:0 | value | file://:0:0:0:0 | [post] self [x] |
+| file://:0:0:0:0 | value [some:0] | file://:0:0:0:0 | [post] self [x, some:0] |
+| test.swift:6:19:6:26 | call to source() | test.swift:7:15:7:15 | t1 |
+| test.swift:6:19:6:26 | call to source() | test.swift:9:15:9:15 | t1 |
+| test.swift:6:19:6:26 | call to source() | test.swift:10:15:10:15 | t2 |
+| test.swift:25:20:25:27 | call to source() | test.swift:29:18:29:21 | x |
+| test.swift:26:26:26:33 | call to source() | test.swift:29:26:29:29 | y |
+| test.swift:29:18:29:21 | x | test.swift:30:15:30:15 | x |
+| test.swift:29:26:29:29 | y | test.swift:31:15:31:15 | y |
+| test.swift:35:12:35:19 | call to source() | test.swift:39:15:39:29 | call to callee_source() |
+| test.swift:43:19:43:26 | call to source() | test.swift:50:15:50:15 | t |
+| test.swift:53:1:56:1 | arg[return] | test.swift:61:22:61:23 | [post] &... |
+| test.swift:54:11:54:18 | call to source() | test.swift:53:1:56:1 | arg[return] |
+| test.swift:61:22:61:23 | [post] &... | test.swift:62:15:62:15 | x |
+| test.swift:65:16:65:28 | arg1 | test.swift:65:1:70:1 | arg2[return] |
+| test.swift:73:18:73:25 | call to source() | test.swift:75:21:75:22 | &... |
+| test.swift:73:18:73:25 | call to source() | test.swift:76:15:76:15 | x |
+| test.swift:75:21:75:22 | &... | test.swift:65:16:65:28 | arg1 |
+| test.swift:75:21:75:22 | &... | test.swift:75:31:75:32 | [post] &... |
+| test.swift:75:31:75:32 | [post] &... | test.swift:77:15:77:15 | y |
+| test.swift:80:1:82:1 | arg[return] | test.swift:97:39:97:40 | [post] &... |
+| test.swift:81:11:81:18 | call to source() | test.swift:80:1:82:1 | arg[return] |
+| test.swift:84:1:91:1 | arg[return] | test.swift:104:40:104:41 | [post] &... |
+| test.swift:86:15:86:22 | call to source() | test.swift:84:1:91:1 | arg[return] |
+| test.swift:89:15:89:22 | call to source() | test.swift:84:1:91:1 | arg[return] |
+| test.swift:97:39:97:40 | [post] &... | test.swift:98:19:98:19 | x |
+| test.swift:104:40:104:41 | [post] &... | test.swift:105:19:105:19 | x |
+| test.swift:109:9:109:14 | arg | test.swift:110:12:110:12 | arg |
+| test.swift:113:14:113:19 | arg | test.swift:114:19:114:19 | arg |
+| test.swift:113:14:113:19 | arg | test.swift:114:19:114:19 | arg |
+| test.swift:114:19:114:19 | arg | test.swift:109:9:109:14 | arg |
+| test.swift:114:19:114:19 | arg | test.swift:114:12:114:22 | call to ... |
+| test.swift:114:19:114:19 | arg | test.swift:114:12:114:22 | call to ... |
+| test.swift:114:19:114:19 | arg | test.swift:123:10:123:13 | i |
+| test.swift:118:18:118:25 | call to source() | test.swift:119:31:119:31 | x |
+| test.swift:119:18:119:44 | call to forward(arg:lambda:) | test.swift:120:15:120:15 | y |
+| test.swift:119:31:119:31 | x | test.swift:113:14:113:19 | arg |
+| test.swift:119:31:119:31 | x | test.swift:119:18:119:44 | call to forward(arg:lambda:) |
+| test.swift:122:18:125:6 | call to forward(arg:lambda:) | test.swift:126:15:126:15 | z |
+| test.swift:122:31:122:38 | call to source() | test.swift:113:14:113:19 | arg |
+| test.swift:122:31:122:38 | call to source() | test.swift:122:18:125:6 | call to forward(arg:lambda:) |
+| test.swift:123:10:123:13 | i | test.swift:124:16:124:16 | i |
+| test.swift:142:10:142:13 | i | test.swift:143:16:143:16 | i |
+| test.swift:145:23:145:30 | call to source() | test.swift:142:10:142:13 | i |
+| test.swift:145:23:145:30 | call to source() | test.swift:145:15:145:31 | call to ... |
+| test.swift:149:16:149:23 | call to source() | test.swift:151:15:151:28 | call to ... |
+| test.swift:149:16:149:23 | call to source() | test.swift:159:16:159:29 | call to ... |
+| test.swift:154:10:154:13 | i | test.swift:155:19:155:19 | i |
+| test.swift:157:16:157:23 | call to source() | test.swift:154:10:154:13 | i |
+| test.swift:159:16:159:29 | call to ... | test.swift:154:10:154:13 | i |
+| test.swift:163:7:163:7 | self [x] | file://:0:0:0:0 | self [x] |
+| test.swift:163:7:163:7 | value | file://:0:0:0:0 | value |
+| test.swift:169:12:169:22 | value | test.swift:170:9:170:9 | value |
+| test.swift:170:5:170:5 | [post] self [x] | test.swift:169:3:171:3 | self[return] [x] |
+| test.swift:170:9:170:9 | value | test.swift:163:7:163:7 | value |
+| test.swift:170:9:170:9 | value | test.swift:170:5:170:5 | [post] self [x] |
+| test.swift:173:8:173:8 | self [x] | test.swift:174:12:174:12 | self [x] |
+| test.swift:174:12:174:12 | self [x] | test.swift:163:7:163:7 | self [x] |
+| test.swift:174:12:174:12 | self [x] | test.swift:174:12:174:12 | .x |
+| test.swift:180:3:180:3 | [post] a [x] | test.swift:181:13:181:13 | a [x] |
+| test.swift:180:9:180:16 | call to source() | test.swift:163:7:163:7 | value |
+| test.swift:180:9:180:16 | call to source() | test.swift:180:3:180:3 | [post] a [x] |
+| test.swift:181:13:181:13 | a [x] | test.swift:163:7:163:7 | self [x] |
+| test.swift:181:13:181:13 | a [x] | test.swift:181:13:181:15 | .x |
+| test.swift:185:7:185:7 | self [a, x] | file://:0:0:0:0 | self [a, x] |
+| test.swift:194:3:194:3 | [post] b [a, x] | test.swift:195:13:195:13 | b [a, x] |
+| test.swift:194:3:194:5 | [post] getter for .a [x] | test.swift:194:3:194:3 | [post] b [a, x] |
+| test.swift:194:11:194:18 | call to source() | test.swift:163:7:163:7 | value |
+| test.swift:194:11:194:18 | call to source() | test.swift:194:3:194:5 | [post] getter for .a [x] |
+| test.swift:195:13:195:13 | b [a, x] | test.swift:185:7:185:7 | self [a, x] |
+| test.swift:195:13:195:13 | b [a, x] | test.swift:195:13:195:15 | .a [x] |
+| test.swift:195:13:195:15 | .a [x] | test.swift:163:7:163:7 | self [x] |
+| test.swift:195:13:195:15 | .a [x] | test.swift:195:13:195:17 | .x |
+| test.swift:200:3:200:3 | [post] a [x] | test.swift:201:13:201:13 | a [x] |
+| test.swift:200:9:200:16 | call to source() | test.swift:169:12:169:22 | value |
+| test.swift:200:9:200:16 | call to source() | test.swift:200:3:200:3 | [post] a [x] |
+| test.swift:201:13:201:13 | a [x] | test.swift:163:7:163:7 | self [x] |
+| test.swift:201:13:201:13 | a [x] | test.swift:201:13:201:15 | .x |
+| test.swift:206:3:206:3 | [post] a [x] | test.swift:207:13:207:13 | a [x] |
+| test.swift:206:9:206:16 | call to source() | test.swift:163:7:163:7 | value |
+| test.swift:206:9:206:16 | call to source() | test.swift:206:3:206:3 | [post] a [x] |
+| test.swift:207:13:207:13 | a [x] | test.swift:173:8:173:8 | self [x] |
+| test.swift:207:13:207:13 | a [x] | test.swift:207:13:207:19 | call to get() |
+| test.swift:212:3:212:3 | [post] a [x] | test.swift:213:13:213:13 | a [x] |
+| test.swift:212:9:212:16 | call to source() | test.swift:169:12:169:22 | value |
+| test.swift:212:9:212:16 | call to source() | test.swift:212:3:212:3 | [post] a [x] |
+| test.swift:213:13:213:13 | a [x] | test.swift:173:8:173:8 | self [x] |
+| test.swift:213:13:213:13 | a [x] | test.swift:213:13:213:19 | call to get() |
+| test.swift:218:3:218:3 | [post] b [a, x] | test.swift:219:13:219:13 | b [a, x] |
+| test.swift:218:3:218:5 | [post] getter for .a [x] | test.swift:218:3:218:3 | [post] b [a, x] |
+| test.swift:218:11:218:18 | call to source() | test.swift:169:12:169:22 | value |
+| test.swift:218:11:218:18 | call to source() | test.swift:218:3:218:5 | [post] getter for .a [x] |
+| test.swift:219:13:219:13 | b [a, x] | test.swift:185:7:185:7 | self [a, x] |
+| test.swift:219:13:219:13 | b [a, x] | test.swift:219:13:219:15 | .a [x] |
+| test.swift:219:13:219:15 | .a [x] | test.swift:163:7:163:7 | self [x] |
+| test.swift:219:13:219:15 | .a [x] | test.swift:219:13:219:17 | .x |
+| test.swift:225:14:225:21 | call to source() | test.swift:235:13:235:15 | .source_value |
+| test.swift:225:14:225:21 | call to source() | test.swift:238:13:238:15 | .source_value |
+| test.swift:259:12:259:19 | call to source() | test.swift:259:12:259:19 | call to source() [some:0] |
+| test.swift:259:12:259:19 | call to source() | test.swift:263:13:263:28 | call to optionalSource() |
+| test.swift:259:12:259:19 | call to source() [some:0] | test.swift:263:13:263:28 | call to optionalSource() [some:0] |
+| test.swift:259:12:259:19 | call to source() [some:0] | test.swift:486:13:486:28 | call to optionalSource() [some:0] |
+| test.swift:259:12:259:19 | call to source() [some:0] | test.swift:513:13:513:28 | call to optionalSource() [some:0] |
+| test.swift:263:13:263:28 | call to optionalSource() | test.swift:265:15:265:15 | x |
+| test.swift:263:13:263:28 | call to optionalSource() | test.swift:267:15:267:16 | ...! |
+| test.swift:263:13:263:28 | call to optionalSource() | test.swift:271:15:271:16 | ...? |
+| test.swift:263:13:263:28 | call to optionalSource() | test.swift:274:15:274:20 | ... ??(_:_:) ... |
+| test.swift:263:13:263:28 | call to optionalSource() | test.swift:275:15:275:27 | ... ??(_:_:) ... |
+| test.swift:263:13:263:28 | call to optionalSource() | test.swift:279:15:279:31 | ... ? ... : ... |
+| test.swift:263:13:263:28 | call to optionalSource() | test.swift:280:15:280:38 | ... ? ... : ... |
+| test.swift:263:13:263:28 | call to optionalSource() | test.swift:291:16:291:17 | ...? |
+| test.swift:263:13:263:28 | call to optionalSource() | test.swift:303:15:303:16 | ...! |
+| test.swift:263:13:263:28 | call to optionalSource() [some:0] | test.swift:284:8:284:12 | let ...? [some:0] |
+| test.swift:263:13:263:28 | call to optionalSource() [some:0] | test.swift:291:16:291:17 | ...? [some:0] |
+| test.swift:263:13:263:28 | call to optionalSource() [some:0] | test.swift:298:11:298:15 | let ...? [some:0] |
+| test.swift:263:13:263:28 | call to optionalSource() [some:0] | test.swift:306:13:306:24 | .some(...) [some:0] |
+| test.swift:263:13:263:28 | call to optionalSource() [some:0] | test.swift:314:10:314:21 | .some(...) [some:0] |
+| test.swift:270:15:270:22 | call to source() | file://:0:0:0:0 | [summary param] this in signum() |
+| test.swift:270:15:270:22 | call to source() | test.swift:270:15:270:31 | call to signum() |
+| test.swift:271:15:271:16 | ...? | file://:0:0:0:0 | [summary param] this in signum() |
+| test.swift:271:15:271:16 | ...? | test.swift:271:15:271:25 | call to signum() |
+| test.swift:271:15:271:25 | call to signum() | test.swift:271:15:271:25 | OptionalEvaluationExpr |
+| test.swift:280:31:280:38 | call to source() | test.swift:280:15:280:38 | ... ? ... : ... |
+| test.swift:282:31:282:38 | call to source() | test.swift:282:15:282:38 | ... ? ... : ... |
+| test.swift:284:8:284:12 | let ...? [some:0] | test.swift:284:12:284:12 | z |
+| test.swift:284:12:284:12 | z | test.swift:285:19:285:19 | z |
+| test.swift:291:8:291:12 | let ...? [some:0] | test.swift:291:12:291:12 | z |
+| test.swift:291:12:291:12 | z | test.swift:292:19:292:19 | z |
+| test.swift:291:16:291:17 | ...? | file://:0:0:0:0 | [summary param] this in signum() |
+| test.swift:291:16:291:17 | ...? | test.swift:291:16:291:26 | call to signum() |
+| test.swift:291:16:291:17 | ...? [some:0] | file://:0:0:0:0 | [summary param] this in signum() [some:0] |
+| test.swift:291:16:291:17 | ...? [some:0] | test.swift:291:16:291:26 | call to signum() [some:0] |
+| test.swift:291:16:291:26 | call to signum() | test.swift:291:16:291:26 | call to signum() [some:0] |
+| test.swift:291:16:291:26 | call to signum() [some:0] | test.swift:291:8:291:12 | let ...? [some:0] |
+| test.swift:298:11:298:15 | let ...? [some:0] | test.swift:298:15:298:15 | z1 |
+| test.swift:298:15:298:15 | z1 | test.swift:300:15:300:15 | z1 |
+| test.swift:303:15:303:16 | ...! | file://:0:0:0:0 | [summary param] this in signum() |
+| test.swift:303:15:303:16 | ...! | test.swift:303:15:303:25 | call to signum() |
+| test.swift:306:13:306:24 | .some(...) [some:0] | test.swift:306:23:306:23 | z |
+| test.swift:306:23:306:23 | z | test.swift:307:19:307:19 | z |
+| test.swift:314:10:314:21 | .some(...) [some:0] | test.swift:314:20:314:20 | z |
+| test.swift:314:20:314:20 | z | test.swift:315:19:315:19 | z |
+| test.swift:331:14:331:26 | (...) [Tuple element at index 1] | test.swift:335:15:335:15 | t1 [Tuple element at index 1] |
+| test.swift:331:18:331:25 | call to source() | test.swift:331:14:331:26 | (...) [Tuple element at index 1] |
+| test.swift:335:15:335:15 | t1 [Tuple element at index 1] | test.swift:335:15:335:18 | .1 |
+| test.swift:343:5:343:5 | [post] t1 [Tuple element at index 0] | test.swift:346:15:346:15 | t1 [Tuple element at index 0] |
+| test.swift:343:12:343:19 | call to source() | test.swift:343:5:343:5 | [post] t1 [Tuple element at index 0] |
+| test.swift:346:15:346:15 | t1 [Tuple element at index 0] | test.swift:346:15:346:18 | .0 |
+| test.swift:351:14:351:45 | (...) [Tuple element at index 0] | test.swift:353:9:353:17 | (...) [Tuple element at index 0] |
+| test.swift:351:14:351:45 | (...) [Tuple element at index 0] | test.swift:356:15:356:15 | t1 [Tuple element at index 0] |
+| test.swift:351:14:351:45 | (...) [Tuple element at index 0] | test.swift:360:15:360:15 | t2 [Tuple element at index 0] |
+| test.swift:351:14:351:45 | (...) [Tuple element at index 1] | test.swift:353:9:353:17 | (...) [Tuple element at index 1] |
+| test.swift:351:14:351:45 | (...) [Tuple element at index 1] | test.swift:357:15:357:15 | t1 [Tuple element at index 1] |
+| test.swift:351:14:351:45 | (...) [Tuple element at index 1] | test.swift:361:15:361:15 | t2 [Tuple element at index 1] |
+| test.swift:351:18:351:25 | call to source() | test.swift:351:14:351:45 | (...) [Tuple element at index 0] |
+| test.swift:351:31:351:38 | call to source() | test.swift:351:14:351:45 | (...) [Tuple element at index 1] |
+| test.swift:353:9:353:17 | (...) [Tuple element at index 0] | test.swift:353:10:353:10 | a |
+| test.swift:353:9:353:17 | (...) [Tuple element at index 1] | test.swift:353:13:353:13 | b |
+| test.swift:353:10:353:10 | a | test.swift:363:15:363:15 | a |
+| test.swift:353:13:353:13 | b | test.swift:364:15:364:15 | b |
+| test.swift:356:15:356:15 | t1 [Tuple element at index 0] | test.swift:356:15:356:18 | .0 |
+| test.swift:357:15:357:15 | t1 [Tuple element at index 1] | test.swift:357:15:357:18 | .1 |
+| test.swift:360:15:360:15 | t2 [Tuple element at index 0] | test.swift:360:15:360:18 | .0 |
+| test.swift:361:15:361:15 | t2 [Tuple element at index 1] | test.swift:361:15:361:18 | .1 |
+| test.swift:398:9:398:27 | call to ... [mySingle:0] | test.swift:403:10:403:25 | .mySingle(...) [mySingle:0] |
+| test.swift:398:9:398:27 | call to ... [mySingle:0] | test.swift:412:13:412:28 | .mySingle(...) [mySingle:0] |
+| test.swift:398:19:398:26 | call to source() | test.swift:398:9:398:27 | call to ... [mySingle:0] |
+| test.swift:403:10:403:25 | .mySingle(...) [mySingle:0] | test.swift:403:24:403:24 | a |
+| test.swift:403:24:403:24 | a | test.swift:404:19:404:19 | a |
+| test.swift:412:13:412:28 | .mySingle(...) [mySingle:0] | test.swift:412:27:412:27 | x |
+| test.swift:412:27:412:27 | x | test.swift:413:19:413:19 | x |
+| test.swift:420:9:420:34 | call to ... [myPair:1] | test.swift:427:10:427:30 | .myPair(...) [myPair:1] |
+| test.swift:420:9:420:34 | call to ... [myPair:1] | test.swift:437:13:437:33 | .myPair(...) [myPair:1] |
+| test.swift:420:9:420:34 | call to ... [myPair:1] | test.swift:442:33:442:33 | a [myPair:1] |
+| test.swift:420:9:420:34 | call to ... [myPair:1] | test.swift:471:13:471:13 | a [myPair:1] |
+| test.swift:420:26:420:33 | call to source() | test.swift:420:9:420:34 | call to ... [myPair:1] |
+| test.swift:427:10:427:30 | .myPair(...) [myPair:1] | test.swift:427:29:427:29 | b |
+| test.swift:427:29:427:29 | b | test.swift:429:19:429:19 | b |
+| test.swift:437:13:437:33 | .myPair(...) [myPair:1] | test.swift:437:32:437:32 | y |
+| test.swift:437:32:437:32 | y | test.swift:439:19:439:19 | y |
+| test.swift:442:21:442:34 | call to ... [myCons:1, myPair:1] | test.swift:452:14:452:38 | .myCons(...) [myCons:1, myPair:1] |
+| test.swift:442:21:442:34 | call to ... [myCons:1, myPair:1] | test.swift:467:17:467:41 | .myCons(...) [myCons:1, myPair:1] |
+| test.swift:442:21:442:34 | call to ... [myCons:1, myPair:1] | test.swift:471:16:471:16 | b [myCons:1, myPair:1] |
+| test.swift:442:33:442:33 | a [myPair:1] | test.swift:442:21:442:34 | call to ... [myCons:1, myPair:1] |
+| test.swift:452:14:452:38 | .myCons(...) [myCons:1, myPair:1] | test.swift:452:25:452:37 | .myPair(...) [myPair:1] |
+| test.swift:452:25:452:37 | .myPair(...) [myPair:1] | test.swift:452:36:452:36 | c |
+| test.swift:452:36:452:36 | c | test.swift:455:19:455:19 | c |
+| test.swift:463:13:463:39 | .myPair(...) [myPair:0] | test.swift:463:31:463:31 | x |
+| test.swift:463:31:463:31 | x | test.swift:464:19:464:19 | x |
+| test.swift:463:43:463:62 | call to ... [myPair:0] | test.swift:463:13:463:39 | .myPair(...) [myPair:0] |
+| test.swift:463:51:463:58 | call to source() | test.swift:463:43:463:62 | call to ... [myPair:0] |
+| test.swift:467:17:467:41 | .myCons(...) [myCons:1, myPair:1] | test.swift:467:28:467:40 | .myPair(...) [myPair:1] |
+| test.swift:467:28:467:40 | .myPair(...) [myPair:1] | test.swift:467:39:467:39 | c |
+| test.swift:467:39:467:39 | c | test.swift:468:19:468:19 | c |
+| test.swift:471:12:471:17 | (...) [Tuple element at index 0, myPair:1] | test.swift:472:14:472:55 | (...) [Tuple element at index 0, myPair:1] |
+| test.swift:471:12:471:17 | (...) [Tuple element at index 1, myCons:1, myPair:1] | test.swift:472:14:472:55 | (...) [Tuple element at index 1, myCons:1, myPair:1] |
+| test.swift:471:13:471:13 | a [myPair:1] | test.swift:471:12:471:17 | (...) [Tuple element at index 0, myPair:1] |
+| test.swift:471:16:471:16 | b [myCons:1, myPair:1] | test.swift:471:12:471:17 | (...) [Tuple element at index 1, myCons:1, myPair:1] |
+| test.swift:472:14:472:55 | (...) [Tuple element at index 0, myPair:1] | test.swift:472:15:472:27 | .myPair(...) [myPair:1] |
+| test.swift:472:14:472:55 | (...) [Tuple element at index 1, myCons:1, myPair:1] | test.swift:472:30:472:54 | .myCons(...) [myCons:1, myPair:1] |
+| test.swift:472:15:472:27 | .myPair(...) [myPair:1] | test.swift:472:26:472:26 | b |
+| test.swift:472:26:472:26 | b | test.swift:474:19:474:19 | b |
+| test.swift:472:30:472:54 | .myCons(...) [myCons:1, myPair:1] | test.swift:472:41:472:53 | .myPair(...) [myPair:1] |
+| test.swift:472:41:472:53 | .myPair(...) [myPair:1] | test.swift:472:52:472:52 | e |
+| test.swift:472:52:472:52 | e | test.swift:477:19:477:19 | e |
+| test.swift:486:13:486:28 | call to optionalSource() [some:0] | test.swift:488:8:488:12 | let ...? [some:0] |
+| test.swift:486:13:486:28 | call to optionalSource() [some:0] | test.swift:493:19:493:19 | x [some:0] |
+| test.swift:488:8:488:12 | let ...? [some:0] | test.swift:488:12:488:12 | a |
+| test.swift:488:12:488:12 | a | test.swift:489:19:489:19 | a |
+| test.swift:493:18:493:23 | (...) [Tuple element at index 0, some:0] | test.swift:495:10:495:37 | (...) [Tuple element at index 0, some:0] |
+| test.swift:493:19:493:19 | x [some:0] | test.swift:493:18:493:23 | (...) [Tuple element at index 0, some:0] |
+| test.swift:495:10:495:37 | (...) [Tuple element at index 0, some:0] | test.swift:495:11:495:22 | .some(...) [some:0] |
+| test.swift:495:11:495:22 | .some(...) [some:0] | test.swift:495:21:495:21 | a |
+| test.swift:495:21:495:21 | a | test.swift:496:19:496:19 | a |
+| test.swift:509:9:509:9 | self [x, some:0] | file://:0:0:0:0 | self [x, some:0] |
+| test.swift:509:9:509:9 | value [some:0] | file://:0:0:0:0 | value [some:0] |
+| test.swift:513:13:513:28 | call to optionalSource() [some:0] | test.swift:515:12:515:12 | x [some:0] |
+| test.swift:515:5:515:5 | [post] cx [x, some:0] | test.swift:519:20:519:20 | cx [x, some:0] |
+| test.swift:515:12:515:12 | x [some:0] | test.swift:509:9:509:9 | value [some:0] |
+| test.swift:515:12:515:12 | x [some:0] | test.swift:515:5:515:5 | [post] cx [x, some:0] |
+| test.swift:519:11:519:15 | let ...? [some:0] | test.swift:519:15:519:15 | z1 |
+| test.swift:519:15:519:15 | z1 | test.swift:520:15:520:15 | z1 |
+| test.swift:519:20:519:20 | cx [x, some:0] | test.swift:509:9:509:9 | self [x, some:0] |
+| test.swift:519:20:519:20 | cx [x, some:0] | test.swift:519:20:519:23 | .x [some:0] |
+| test.swift:519:20:519:23 | .x [some:0] | test.swift:519:11:519:15 | let ...? [some:0] |
+| test.swift:526:14:526:21 | call to source() | test.swift:526:13:526:21 | call to +(_:) |
+| test.swift:535:9:535:9 | self [str] | file://:0:0:0:0 | self [str] |
+| test.swift:536:10:536:13 | s | test.swift:537:13:537:13 | s |
+| test.swift:537:7:537:7 | [post] self [str] | test.swift:536:5:538:5 | self[return] [str] |
+| test.swift:537:13:537:13 | s | test.swift:537:7:537:7 | [post] self [str] |
+| test.swift:542:17:545:5 | self[return] [str] | test.swift:550:13:550:41 | call to Self.init(contentsOfFile:) [str] |
+| test.swift:543:7:543:7 | [post] self [str] | test.swift:542:17:545:5 | self[return] [str] |
+| test.swift:543:7:543:7 | [post] self [str] | test.swift:544:17:544:17 | self [str] |
+| test.swift:543:20:543:28 | call to source3() | test.swift:536:10:536:13 | s |
+| test.swift:543:20:543:28 | call to source3() | test.swift:543:7:543:7 | [post] self [str] |
+| test.swift:544:17:544:17 | self [str] | test.swift:544:17:544:17 | .str |
+| test.swift:549:13:549:33 | call to MyClass.init(s:) [str] | test.swift:535:9:535:9 | self [str] |
+| test.swift:549:13:549:33 | call to MyClass.init(s:) [str] | test.swift:549:13:549:35 | .str |
+| test.swift:549:24:549:32 | call to source3() | test.swift:536:10:536:13 | s |
+| test.swift:549:24:549:32 | call to source3() | test.swift:549:13:549:33 | call to MyClass.init(s:) [str] |
+| test.swift:550:13:550:41 | call to Self.init(contentsOfFile:) [str] | test.swift:535:9:535:9 | self [str] |
+| test.swift:550:13:550:41 | call to Self.init(contentsOfFile:) [str] | test.swift:550:13:550:43 | .str |
 nodes
-| file://:0:0:0:0 | .a [x] :  | semmle.label | .a [x] :  |
-| file://:0:0:0:0 | .str :  | semmle.label | .str :  |
-| file://:0:0:0:0 | .x :  | semmle.label | .x :  |
-| file://:0:0:0:0 | .x [some:0] :  | semmle.label | .x [some:0] :  |
-| file://:0:0:0:0 | [post] self [x, some:0] :  | semmle.label | [post] self [x, some:0] :  |
-| file://:0:0:0:0 | [post] self [x] :  | semmle.label | [post] self [x] :  |
-| file://:0:0:0:0 | [summary param] this in signum() :  | semmle.label | [summary param] this in signum() :  |
-| file://:0:0:0:0 | [summary param] this in signum() [some:0] :  | semmle.label | [summary param] this in signum() [some:0] :  |
-| file://:0:0:0:0 | [summary] to write: return (return) in signum() :  | semmle.label | [summary] to write: return (return) in signum() :  |
-| file://:0:0:0:0 | [summary] to write: return (return) in signum() [some:0] :  | semmle.label | [summary] to write: return (return) in signum() [some:0] :  |
-| file://:0:0:0:0 | self [a, x] :  | semmle.label | self [a, x] :  |
-| file://:0:0:0:0 | self [str] :  | semmle.label | self [str] :  |
-| file://:0:0:0:0 | self [x, some:0] :  | semmle.label | self [x, some:0] :  |
-| file://:0:0:0:0 | self [x] :  | semmle.label | self [x] :  |
-| file://:0:0:0:0 | value :  | semmle.label | value :  |
-| file://:0:0:0:0 | value [some:0] :  | semmle.label | value [some:0] :  |
-| test.swift:6:19:6:26 | call to source() :  | semmle.label | call to source() :  |
+| file://:0:0:0:0 | .a [x] | semmle.label | .a [x] |
+| file://:0:0:0:0 | .str | semmle.label | .str |
+| file://:0:0:0:0 | .x | semmle.label | .x |
+| file://:0:0:0:0 | .x [some:0] | semmle.label | .x [some:0] |
+| file://:0:0:0:0 | [post] self [x, some:0] | semmle.label | [post] self [x, some:0] |
+| file://:0:0:0:0 | [post] self [x] | semmle.label | [post] self [x] |
+| file://:0:0:0:0 | [summary param] this in signum() | semmle.label | [summary param] this in signum() |
+| file://:0:0:0:0 | [summary param] this in signum() [some:0] | semmle.label | [summary param] this in signum() [some:0] |
+| file://:0:0:0:0 | [summary] to write: return (return) in signum() | semmle.label | [summary] to write: return (return) in signum() |
+| file://:0:0:0:0 | [summary] to write: return (return) in signum() [some:0] | semmle.label | [summary] to write: return (return) in signum() [some:0] |
+| file://:0:0:0:0 | self [a, x] | semmle.label | self [a, x] |
+| file://:0:0:0:0 | self [str] | semmle.label | self [str] |
+| file://:0:0:0:0 | self [x, some:0] | semmle.label | self [x, some:0] |
+| file://:0:0:0:0 | self [x] | semmle.label | self [x] |
+| file://:0:0:0:0 | value | semmle.label | value |
+| file://:0:0:0:0 | value [some:0] | semmle.label | value [some:0] |
+| test.swift:6:19:6:26 | call to source() | semmle.label | call to source() |
 | test.swift:7:15:7:15 | t1 | semmle.label | t1 |
 | test.swift:9:15:9:15 | t1 | semmle.label | t1 |
 | test.swift:10:15:10:15 | t2 | semmle.label | t2 |
-| test.swift:25:20:25:27 | call to source() :  | semmle.label | call to source() :  |
-| test.swift:26:26:26:33 | call to source() :  | semmle.label | call to source() :  |
-| test.swift:29:18:29:21 | x :  | semmle.label | x :  |
-| test.swift:29:26:29:29 | y :  | semmle.label | y :  |
+| test.swift:25:20:25:27 | call to source() | semmle.label | call to source() |
+| test.swift:26:26:26:33 | call to source() | semmle.label | call to source() |
+| test.swift:29:18:29:21 | x | semmle.label | x |
+| test.swift:29:26:29:29 | y | semmle.label | y |
 | test.swift:30:15:30:15 | x | semmle.label | x |
 | test.swift:31:15:31:15 | y | semmle.label | y |
-| test.swift:35:12:35:19 | call to source() :  | semmle.label | call to source() :  |
+| test.swift:35:12:35:19 | call to source() | semmle.label | call to source() |
 | test.swift:39:15:39:29 | call to callee_source() | semmle.label | call to callee_source() |
-| test.swift:43:19:43:26 | call to source() :  | semmle.label | call to source() :  |
+| test.swift:43:19:43:26 | call to source() | semmle.label | call to source() |
 | test.swift:50:15:50:15 | t | semmle.label | t |
-| test.swift:53:1:56:1 | arg[return] :  | semmle.label | arg[return] :  |
-| test.swift:54:11:54:18 | call to source() :  | semmle.label | call to source() :  |
-| test.swift:61:22:61:23 | [post] &... :  | semmle.label | [post] &... :  |
+| test.swift:53:1:56:1 | arg[return] | semmle.label | arg[return] |
+| test.swift:54:11:54:18 | call to source() | semmle.label | call to source() |
+| test.swift:61:22:61:23 | [post] &... | semmle.label | [post] &... |
 | test.swift:62:15:62:15 | x | semmle.label | x |
-| test.swift:65:1:70:1 | arg2[return] :  | semmle.label | arg2[return] :  |
-| test.swift:65:16:65:28 | arg1 :  | semmle.label | arg1 :  |
-| test.swift:73:18:73:25 | call to source() :  | semmle.label | call to source() :  |
-| test.swift:75:21:75:22 | &... :  | semmle.label | &... :  |
-| test.swift:75:31:75:32 | [post] &... :  | semmle.label | [post] &... :  |
+| test.swift:65:1:70:1 | arg2[return] | semmle.label | arg2[return] |
+| test.swift:65:16:65:28 | arg1 | semmle.label | arg1 |
+| test.swift:73:18:73:25 | call to source() | semmle.label | call to source() |
+| test.swift:75:21:75:22 | &... | semmle.label | &... |
+| test.swift:75:31:75:32 | [post] &... | semmle.label | [post] &... |
 | test.swift:76:15:76:15 | x | semmle.label | x |
 | test.swift:77:15:77:15 | y | semmle.label | y |
-| test.swift:80:1:82:1 | arg[return] :  | semmle.label | arg[return] :  |
-| test.swift:81:11:81:18 | call to source() :  | semmle.label | call to source() :  |
-| test.swift:84:1:91:1 | arg[return] :  | semmle.label | arg[return] :  |
-| test.swift:86:15:86:22 | call to source() :  | semmle.label | call to source() :  |
-| test.swift:89:15:89:22 | call to source() :  | semmle.label | call to source() :  |
-| test.swift:97:39:97:40 | [post] &... :  | semmle.label | [post] &... :  |
+| test.swift:80:1:82:1 | arg[return] | semmle.label | arg[return] |
+| test.swift:81:11:81:18 | call to source() | semmle.label | call to source() |
+| test.swift:84:1:91:1 | arg[return] | semmle.label | arg[return] |
+| test.swift:86:15:86:22 | call to source() | semmle.label | call to source() |
+| test.swift:89:15:89:22 | call to source() | semmle.label | call to source() |
+| test.swift:97:39:97:40 | [post] &... | semmle.label | [post] &... |
 | test.swift:98:19:98:19 | x | semmle.label | x |
-| test.swift:104:40:104:41 | [post] &... :  | semmle.label | [post] &... :  |
+| test.swift:104:40:104:41 | [post] &... | semmle.label | [post] &... |
 | test.swift:105:19:105:19 | x | semmle.label | x |
-| test.swift:109:9:109:14 | arg :  | semmle.label | arg :  |
-| test.swift:110:12:110:12 | arg :  | semmle.label | arg :  |
-| test.swift:113:14:113:19 | arg :  | semmle.label | arg :  |
-| test.swift:113:14:113:19 | arg :  | semmle.label | arg :  |
-| test.swift:114:12:114:22 | call to ... :  | semmle.label | call to ... :  |
-| test.swift:114:12:114:22 | call to ... :  | semmle.label | call to ... :  |
-| test.swift:114:19:114:19 | arg :  | semmle.label | arg :  |
-| test.swift:114:19:114:19 | arg :  | semmle.label | arg :  |
-| test.swift:118:18:118:25 | call to source() :  | semmle.label | call to source() :  |
-| test.swift:119:18:119:44 | call to forward(arg:lambda:) :  | semmle.label | call to forward(arg:lambda:) :  |
-| test.swift:119:31:119:31 | x :  | semmle.label | x :  |
+| test.swift:109:9:109:14 | arg | semmle.label | arg |
+| test.swift:110:12:110:12 | arg | semmle.label | arg |
+| test.swift:113:14:113:19 | arg | semmle.label | arg |
+| test.swift:113:14:113:19 | arg | semmle.label | arg |
+| test.swift:114:12:114:22 | call to ... | semmle.label | call to ... |
+| test.swift:114:12:114:22 | call to ... | semmle.label | call to ... |
+| test.swift:114:19:114:19 | arg | semmle.label | arg |
+| test.swift:114:19:114:19 | arg | semmle.label | arg |
+| test.swift:118:18:118:25 | call to source() | semmle.label | call to source() |
+| test.swift:119:18:119:44 | call to forward(arg:lambda:) | semmle.label | call to forward(arg:lambda:) |
+| test.swift:119:31:119:31 | x | semmle.label | x |
 | test.swift:120:15:120:15 | y | semmle.label | y |
-| test.swift:122:18:125:6 | call to forward(arg:lambda:) :  | semmle.label | call to forward(arg:lambda:) :  |
-| test.swift:122:31:122:38 | call to source() :  | semmle.label | call to source() :  |
-| test.swift:123:10:123:13 | i :  | semmle.label | i :  |
-| test.swift:124:16:124:16 | i :  | semmle.label | i :  |
+| test.swift:122:18:125:6 | call to forward(arg:lambda:) | semmle.label | call to forward(arg:lambda:) |
+| test.swift:122:31:122:38 | call to source() | semmle.label | call to source() |
+| test.swift:123:10:123:13 | i | semmle.label | i |
+| test.swift:124:16:124:16 | i | semmle.label | i |
 | test.swift:126:15:126:15 | z | semmle.label | z |
 | test.swift:138:19:138:26 | call to source() | semmle.label | call to source() |
-| test.swift:142:10:142:13 | i :  | semmle.label | i :  |
-| test.swift:143:16:143:16 | i :  | semmle.label | i :  |
+| test.swift:142:10:142:13 | i | semmle.label | i |
+| test.swift:143:16:143:16 | i | semmle.label | i |
 | test.swift:145:15:145:31 | call to ... | semmle.label | call to ... |
-| test.swift:145:23:145:30 | call to source() :  | semmle.label | call to source() :  |
-| test.swift:149:16:149:23 | call to source() :  | semmle.label | call to source() :  |
+| test.swift:145:23:145:30 | call to source() | semmle.label | call to source() |
+| test.swift:149:16:149:23 | call to source() | semmle.label | call to source() |
 | test.swift:151:15:151:28 | call to ... | semmle.label | call to ... |
-| test.swift:154:10:154:13 | i :  | semmle.label | i :  |
+| test.swift:154:10:154:13 | i | semmle.label | i |
 | test.swift:155:19:155:19 | i | semmle.label | i |
-| test.swift:157:16:157:23 | call to source() :  | semmle.label | call to source() :  |
-| test.swift:159:16:159:29 | call to ... :  | semmle.label | call to ... :  |
-| test.swift:163:7:163:7 | self [x] :  | semmle.label | self [x] :  |
-| test.swift:163:7:163:7 | value :  | semmle.label | value :  |
-| test.swift:169:3:171:3 | self[return] [x] :  | semmle.label | self[return] [x] :  |
-| test.swift:169:12:169:22 | value :  | semmle.label | value :  |
-| test.swift:170:5:170:5 | [post] self [x] :  | semmle.label | [post] self [x] :  |
-| test.swift:170:9:170:9 | value :  | semmle.label | value :  |
-| test.swift:173:8:173:8 | self [x] :  | semmle.label | self [x] :  |
-| test.swift:174:12:174:12 | .x :  | semmle.label | .x :  |
-| test.swift:174:12:174:12 | self [x] :  | semmle.label | self [x] :  |
-| test.swift:180:3:180:3 | [post] a [x] :  | semmle.label | [post] a [x] :  |
-| test.swift:180:9:180:16 | call to source() :  | semmle.label | call to source() :  |
-| test.swift:181:13:181:13 | a [x] :  | semmle.label | a [x] :  |
+| test.swift:157:16:157:23 | call to source() | semmle.label | call to source() |
+| test.swift:159:16:159:29 | call to ... | semmle.label | call to ... |
+| test.swift:163:7:163:7 | self [x] | semmle.label | self [x] |
+| test.swift:163:7:163:7 | value | semmle.label | value |
+| test.swift:169:3:171:3 | self[return] [x] | semmle.label | self[return] [x] |
+| test.swift:169:12:169:22 | value | semmle.label | value |
+| test.swift:170:5:170:5 | [post] self [x] | semmle.label | [post] self [x] |
+| test.swift:170:9:170:9 | value | semmle.label | value |
+| test.swift:173:8:173:8 | self [x] | semmle.label | self [x] |
+| test.swift:174:12:174:12 | .x | semmle.label | .x |
+| test.swift:174:12:174:12 | self [x] | semmle.label | self [x] |
+| test.swift:180:3:180:3 | [post] a [x] | semmle.label | [post] a [x] |
+| test.swift:180:9:180:16 | call to source() | semmle.label | call to source() |
+| test.swift:181:13:181:13 | a [x] | semmle.label | a [x] |
 | test.swift:181:13:181:15 | .x | semmle.label | .x |
-| test.swift:185:7:185:7 | self [a, x] :  | semmle.label | self [a, x] :  |
-| test.swift:194:3:194:3 | [post] b [a, x] :  | semmle.label | [post] b [a, x] :  |
-| test.swift:194:3:194:5 | [post] getter for .a [x] :  | semmle.label | [post] getter for .a [x] :  |
-| test.swift:194:11:194:18 | call to source() :  | semmle.label | call to source() :  |
-| test.swift:195:13:195:13 | b [a, x] :  | semmle.label | b [a, x] :  |
-| test.swift:195:13:195:15 | .a [x] :  | semmle.label | .a [x] :  |
+| test.swift:185:7:185:7 | self [a, x] | semmle.label | self [a, x] |
+| test.swift:194:3:194:3 | [post] b [a, x] | semmle.label | [post] b [a, x] |
+| test.swift:194:3:194:5 | [post] getter for .a [x] | semmle.label | [post] getter for .a [x] |
+| test.swift:194:11:194:18 | call to source() | semmle.label | call to source() |
+| test.swift:195:13:195:13 | b [a, x] | semmle.label | b [a, x] |
+| test.swift:195:13:195:15 | .a [x] | semmle.label | .a [x] |
 | test.swift:195:13:195:17 | .x | semmle.label | .x |
-| test.swift:200:3:200:3 | [post] a [x] :  | semmle.label | [post] a [x] :  |
-| test.swift:200:9:200:16 | call to source() :  | semmle.label | call to source() :  |
-| test.swift:201:13:201:13 | a [x] :  | semmle.label | a [x] :  |
+| test.swift:200:3:200:3 | [post] a [x] | semmle.label | [post] a [x] |
+| test.swift:200:9:200:16 | call to source() | semmle.label | call to source() |
+| test.swift:201:13:201:13 | a [x] | semmle.label | a [x] |
 | test.swift:201:13:201:15 | .x | semmle.label | .x |
-| test.swift:206:3:206:3 | [post] a [x] :  | semmle.label | [post] a [x] :  |
-| test.swift:206:9:206:16 | call to source() :  | semmle.label | call to source() :  |
-| test.swift:207:13:207:13 | a [x] :  | semmle.label | a [x] :  |
+| test.swift:206:3:206:3 | [post] a [x] | semmle.label | [post] a [x] |
+| test.swift:206:9:206:16 | call to source() | semmle.label | call to source() |
+| test.swift:207:13:207:13 | a [x] | semmle.label | a [x] |
 | test.swift:207:13:207:19 | call to get() | semmle.label | call to get() |
-| test.swift:212:3:212:3 | [post] a [x] :  | semmle.label | [post] a [x] :  |
-| test.swift:212:9:212:16 | call to source() :  | semmle.label | call to source() :  |
-| test.swift:213:13:213:13 | a [x] :  | semmle.label | a [x] :  |
+| test.swift:212:3:212:3 | [post] a [x] | semmle.label | [post] a [x] |
+| test.swift:212:9:212:16 | call to source() | semmle.label | call to source() |
+| test.swift:213:13:213:13 | a [x] | semmle.label | a [x] |
 | test.swift:213:13:213:19 | call to get() | semmle.label | call to get() |
-| test.swift:218:3:218:3 | [post] b [a, x] :  | semmle.label | [post] b [a, x] :  |
-| test.swift:218:3:218:5 | [post] getter for .a [x] :  | semmle.label | [post] getter for .a [x] :  |
-| test.swift:218:11:218:18 | call to source() :  | semmle.label | call to source() :  |
-| test.swift:219:13:219:13 | b [a, x] :  | semmle.label | b [a, x] :  |
-| test.swift:219:13:219:15 | .a [x] :  | semmle.label | .a [x] :  |
+| test.swift:218:3:218:3 | [post] b [a, x] | semmle.label | [post] b [a, x] |
+| test.swift:218:3:218:5 | [post] getter for .a [x] | semmle.label | [post] getter for .a [x] |
+| test.swift:218:11:218:18 | call to source() | semmle.label | call to source() |
+| test.swift:219:13:219:13 | b [a, x] | semmle.label | b [a, x] |
+| test.swift:219:13:219:15 | .a [x] | semmle.label | .a [x] |
 | test.swift:219:13:219:17 | .x | semmle.label | .x |
-| test.swift:225:14:225:21 | call to source() :  | semmle.label | call to source() :  |
+| test.swift:225:14:225:21 | call to source() | semmle.label | call to source() |
 | test.swift:235:13:235:15 | .source_value | semmle.label | .source_value |
 | test.swift:238:13:238:15 | .source_value | semmle.label | .source_value |
-| test.swift:259:12:259:19 | call to source() :  | semmle.label | call to source() :  |
-| test.swift:259:12:259:19 | call to source() [some:0] :  | semmle.label | call to source() [some:0] :  |
-| test.swift:263:13:263:28 | call to optionalSource() :  | semmle.label | call to optionalSource() :  |
-| test.swift:263:13:263:28 | call to optionalSource() [some:0] :  | semmle.label | call to optionalSource() [some:0] :  |
+| test.swift:259:12:259:19 | call to source() | semmle.label | call to source() |
+| test.swift:259:12:259:19 | call to source() [some:0] | semmle.label | call to source() [some:0] |
+| test.swift:263:13:263:28 | call to optionalSource() | semmle.label | call to optionalSource() |
+| test.swift:263:13:263:28 | call to optionalSource() [some:0] | semmle.label | call to optionalSource() [some:0] |
 | test.swift:265:15:265:15 | x | semmle.label | x |
 | test.swift:267:15:267:16 | ...! | semmle.label | ...! |
-| test.swift:270:15:270:22 | call to source() :  | semmle.label | call to source() :  |
+| test.swift:270:15:270:22 | call to source() | semmle.label | call to source() |
 | test.swift:270:15:270:31 | call to signum() | semmle.label | call to signum() |
-| test.swift:271:15:271:16 | ...? :  | semmle.label | ...? :  |
+| test.swift:271:15:271:16 | ...? | semmle.label | ...? |
 | test.swift:271:15:271:25 | OptionalEvaluationExpr | semmle.label | OptionalEvaluationExpr |
-| test.swift:271:15:271:25 | call to signum() :  | semmle.label | call to signum() :  |
+| test.swift:271:15:271:25 | call to signum() | semmle.label | call to signum() |
 | test.swift:274:15:274:20 | ... ??(_:_:) ... | semmle.label | ... ??(_:_:) ... |
 | test.swift:275:15:275:27 | ... ??(_:_:) ... | semmle.label | ... ??(_:_:) ... |
 | test.swift:279:15:279:31 | ... ? ... : ... | semmle.label | ... ? ... : ... |
 | test.swift:280:15:280:38 | ... ? ... : ... | semmle.label | ... ? ... : ... |
-| test.swift:280:31:280:38 | call to source() :  | semmle.label | call to source() :  |
+| test.swift:280:31:280:38 | call to source() | semmle.label | call to source() |
 | test.swift:282:15:282:38 | ... ? ... : ... | semmle.label | ... ? ... : ... |
-| test.swift:282:31:282:38 | call to source() :  | semmle.label | call to source() :  |
-| test.swift:284:8:284:12 | let ...? [some:0] :  | semmle.label | let ...? [some:0] :  |
-| test.swift:284:12:284:12 | z :  | semmle.label | z :  |
+| test.swift:282:31:282:38 | call to source() | semmle.label | call to source() |
+| test.swift:284:8:284:12 | let ...? [some:0] | semmle.label | let ...? [some:0] |
+| test.swift:284:12:284:12 | z | semmle.label | z |
 | test.swift:285:19:285:19 | z | semmle.label | z |
-| test.swift:291:8:291:12 | let ...? [some:0] :  | semmle.label | let ...? [some:0] :  |
-| test.swift:291:12:291:12 | z :  | semmle.label | z :  |
-| test.swift:291:16:291:17 | ...? :  | semmle.label | ...? :  |
-| test.swift:291:16:291:17 | ...? [some:0] :  | semmle.label | ...? [some:0] :  |
-| test.swift:291:16:291:26 | call to signum() :  | semmle.label | call to signum() :  |
-| test.swift:291:16:291:26 | call to signum() [some:0] :  | semmle.label | call to signum() [some:0] :  |
+| test.swift:291:8:291:12 | let ...? [some:0] | semmle.label | let ...? [some:0] |
+| test.swift:291:12:291:12 | z | semmle.label | z |
+| test.swift:291:16:291:17 | ...? | semmle.label | ...? |
+| test.swift:291:16:291:17 | ...? [some:0] | semmle.label | ...? [some:0] |
+| test.swift:291:16:291:26 | call to signum() | semmle.label | call to signum() |
+| test.swift:291:16:291:26 | call to signum() [some:0] | semmle.label | call to signum() [some:0] |
 | test.swift:292:19:292:19 | z | semmle.label | z |
-| test.swift:298:11:298:15 | let ...? [some:0] :  | semmle.label | let ...? [some:0] :  |
-| test.swift:298:15:298:15 | z1 :  | semmle.label | z1 :  |
+| test.swift:298:11:298:15 | let ...? [some:0] | semmle.label | let ...? [some:0] |
+| test.swift:298:15:298:15 | z1 | semmle.label | z1 |
 | test.swift:300:15:300:15 | z1 | semmle.label | z1 |
-| test.swift:303:15:303:16 | ...! :  | semmle.label | ...! :  |
+| test.swift:303:15:303:16 | ...! | semmle.label | ...! |
 | test.swift:303:15:303:25 | call to signum() | semmle.label | call to signum() |
-| test.swift:306:13:306:24 | .some(...) [some:0] :  | semmle.label | .some(...) [some:0] :  |
-| test.swift:306:23:306:23 | z :  | semmle.label | z :  |
+| test.swift:306:13:306:24 | .some(...) [some:0] | semmle.label | .some(...) [some:0] |
+| test.swift:306:23:306:23 | z | semmle.label | z |
 | test.swift:307:19:307:19 | z | semmle.label | z |
-| test.swift:314:10:314:21 | .some(...) [some:0] :  | semmle.label | .some(...) [some:0] :  |
-| test.swift:314:20:314:20 | z :  | semmle.label | z :  |
+| test.swift:314:10:314:21 | .some(...) [some:0] | semmle.label | .some(...) [some:0] |
+| test.swift:314:20:314:20 | z | semmle.label | z |
 | test.swift:315:19:315:19 | z | semmle.label | z |
-| test.swift:331:14:331:26 | (...) [Tuple element at index 1] :  | semmle.label | (...) [Tuple element at index 1] :  |
-| test.swift:331:18:331:25 | call to source() :  | semmle.label | call to source() :  |
-| test.swift:335:15:335:15 | t1 [Tuple element at index 1] :  | semmle.label | t1 [Tuple element at index 1] :  |
+| test.swift:331:14:331:26 | (...) [Tuple element at index 1] | semmle.label | (...) [Tuple element at index 1] |
+| test.swift:331:18:331:25 | call to source() | semmle.label | call to source() |
+| test.swift:335:15:335:15 | t1 [Tuple element at index 1] | semmle.label | t1 [Tuple element at index 1] |
 | test.swift:335:15:335:18 | .1 | semmle.label | .1 |
-| test.swift:343:5:343:5 | [post] t1 [Tuple element at index 0] :  | semmle.label | [post] t1 [Tuple element at index 0] :  |
-| test.swift:343:12:343:19 | call to source() :  | semmle.label | call to source() :  |
-| test.swift:346:15:346:15 | t1 [Tuple element at index 0] :  | semmle.label | t1 [Tuple element at index 0] :  |
+| test.swift:343:5:343:5 | [post] t1 [Tuple element at index 0] | semmle.label | [post] t1 [Tuple element at index 0] |
+| test.swift:343:12:343:19 | call to source() | semmle.label | call to source() |
+| test.swift:346:15:346:15 | t1 [Tuple element at index 0] | semmle.label | t1 [Tuple element at index 0] |
 | test.swift:346:15:346:18 | .0 | semmle.label | .0 |
-| test.swift:351:14:351:45 | (...) [Tuple element at index 0] :  | semmle.label | (...) [Tuple element at index 0] :  |
-| test.swift:351:14:351:45 | (...) [Tuple element at index 1] :  | semmle.label | (...) [Tuple element at index 1] :  |
-| test.swift:351:18:351:25 | call to source() :  | semmle.label | call to source() :  |
-| test.swift:351:31:351:38 | call to source() :  | semmle.label | call to source() :  |
-| test.swift:353:9:353:17 | (...) [Tuple element at index 0] :  | semmle.label | (...) [Tuple element at index 0] :  |
-| test.swift:353:9:353:17 | (...) [Tuple element at index 1] :  | semmle.label | (...) [Tuple element at index 1] :  |
-| test.swift:353:10:353:10 | a :  | semmle.label | a :  |
-| test.swift:353:13:353:13 | b :  | semmle.label | b :  |
-| test.swift:356:15:356:15 | t1 [Tuple element at index 0] :  | semmle.label | t1 [Tuple element at index 0] :  |
+| test.swift:351:14:351:45 | (...) [Tuple element at index 0] | semmle.label | (...) [Tuple element at index 0] |
+| test.swift:351:14:351:45 | (...) [Tuple element at index 1] | semmle.label | (...) [Tuple element at index 1] |
+| test.swift:351:18:351:25 | call to source() | semmle.label | call to source() |
+| test.swift:351:31:351:38 | call to source() | semmle.label | call to source() |
+| test.swift:353:9:353:17 | (...) [Tuple element at index 0] | semmle.label | (...) [Tuple element at index 0] |
+| test.swift:353:9:353:17 | (...) [Tuple element at index 1] | semmle.label | (...) [Tuple element at index 1] |
+| test.swift:353:10:353:10 | a | semmle.label | a |
+| test.swift:353:13:353:13 | b | semmle.label | b |
+| test.swift:356:15:356:15 | t1 [Tuple element at index 0] | semmle.label | t1 [Tuple element at index 0] |
 | test.swift:356:15:356:18 | .0 | semmle.label | .0 |
-| test.swift:357:15:357:15 | t1 [Tuple element at index 1] :  | semmle.label | t1 [Tuple element at index 1] :  |
+| test.swift:357:15:357:15 | t1 [Tuple element at index 1] | semmle.label | t1 [Tuple element at index 1] |
 | test.swift:357:15:357:18 | .1 | semmle.label | .1 |
-| test.swift:360:15:360:15 | t2 [Tuple element at index 0] :  | semmle.label | t2 [Tuple element at index 0] :  |
+| test.swift:360:15:360:15 | t2 [Tuple element at index 0] | semmle.label | t2 [Tuple element at index 0] |
 | test.swift:360:15:360:18 | .0 | semmle.label | .0 |
-| test.swift:361:15:361:15 | t2 [Tuple element at index 1] :  | semmle.label | t2 [Tuple element at index 1] :  |
+| test.swift:361:15:361:15 | t2 [Tuple element at index 1] | semmle.label | t2 [Tuple element at index 1] |
 | test.swift:361:15:361:18 | .1 | semmle.label | .1 |
 | test.swift:363:15:363:15 | a | semmle.label | a |
 | test.swift:364:15:364:15 | b | semmle.label | b |
-| test.swift:398:9:398:27 | call to ... [mySingle:0] :  | semmle.label | call to ... [mySingle:0] :  |
-| test.swift:398:19:398:26 | call to source() :  | semmle.label | call to source() :  |
-| test.swift:403:10:403:25 | .mySingle(...) [mySingle:0] :  | semmle.label | .mySingle(...) [mySingle:0] :  |
-| test.swift:403:24:403:24 | a :  | semmle.label | a :  |
+| test.swift:398:9:398:27 | call to ... [mySingle:0] | semmle.label | call to ... [mySingle:0] |
+| test.swift:398:19:398:26 | call to source() | semmle.label | call to source() |
+| test.swift:403:10:403:25 | .mySingle(...) [mySingle:0] | semmle.label | .mySingle(...) [mySingle:0] |
+| test.swift:403:24:403:24 | a | semmle.label | a |
 | test.swift:404:19:404:19 | a | semmle.label | a |
-| test.swift:412:13:412:28 | .mySingle(...) [mySingle:0] :  | semmle.label | .mySingle(...) [mySingle:0] :  |
-| test.swift:412:27:412:27 | x :  | semmle.label | x :  |
+| test.swift:412:13:412:28 | .mySingle(...) [mySingle:0] | semmle.label | .mySingle(...) [mySingle:0] |
+| test.swift:412:27:412:27 | x | semmle.label | x |
 | test.swift:413:19:413:19 | x | semmle.label | x |
-| test.swift:420:9:420:34 | call to ... [myPair:1] :  | semmle.label | call to ... [myPair:1] :  |
-| test.swift:420:26:420:33 | call to source() :  | semmle.label | call to source() :  |
-| test.swift:427:10:427:30 | .myPair(...) [myPair:1] :  | semmle.label | .myPair(...) [myPair:1] :  |
-| test.swift:427:29:427:29 | b :  | semmle.label | b :  |
+| test.swift:420:9:420:34 | call to ... [myPair:1] | semmle.label | call to ... [myPair:1] |
+| test.swift:420:26:420:33 | call to source() | semmle.label | call to source() |
+| test.swift:427:10:427:30 | .myPair(...) [myPair:1] | semmle.label | .myPair(...) [myPair:1] |
+| test.swift:427:29:427:29 | b | semmle.label | b |
 | test.swift:429:19:429:19 | b | semmle.label | b |
-| test.swift:437:13:437:33 | .myPair(...) [myPair:1] :  | semmle.label | .myPair(...) [myPair:1] :  |
-| test.swift:437:32:437:32 | y :  | semmle.label | y :  |
+| test.swift:437:13:437:33 | .myPair(...) [myPair:1] | semmle.label | .myPair(...) [myPair:1] |
+| test.swift:437:32:437:32 | y | semmle.label | y |
 | test.swift:439:19:439:19 | y | semmle.label | y |
-| test.swift:442:21:442:34 | call to ... [myCons:1, myPair:1] :  | semmle.label | call to ... [myCons:1, myPair:1] :  |
-| test.swift:442:33:442:33 | a [myPair:1] :  | semmle.label | a [myPair:1] :  |
-| test.swift:452:14:452:38 | .myCons(...) [myCons:1, myPair:1] :  | semmle.label | .myCons(...) [myCons:1, myPair:1] :  |
-| test.swift:452:25:452:37 | .myPair(...) [myPair:1] :  | semmle.label | .myPair(...) [myPair:1] :  |
-| test.swift:452:36:452:36 | c :  | semmle.label | c :  |
+| test.swift:442:21:442:34 | call to ... [myCons:1, myPair:1] | semmle.label | call to ... [myCons:1, myPair:1] |
+| test.swift:442:33:442:33 | a [myPair:1] | semmle.label | a [myPair:1] |
+| test.swift:452:14:452:38 | .myCons(...) [myCons:1, myPair:1] | semmle.label | .myCons(...) [myCons:1, myPair:1] |
+| test.swift:452:25:452:37 | .myPair(...) [myPair:1] | semmle.label | .myPair(...) [myPair:1] |
+| test.swift:452:36:452:36 | c | semmle.label | c |
 | test.swift:455:19:455:19 | c | semmle.label | c |
-| test.swift:463:13:463:39 | .myPair(...) [myPair:0] :  | semmle.label | .myPair(...) [myPair:0] :  |
-| test.swift:463:31:463:31 | x :  | semmle.label | x :  |
-| test.swift:463:43:463:62 | call to ... [myPair:0] :  | semmle.label | call to ... [myPair:0] :  |
-| test.swift:463:51:463:58 | call to source() :  | semmle.label | call to source() :  |
+| test.swift:463:13:463:39 | .myPair(...) [myPair:0] | semmle.label | .myPair(...) [myPair:0] |
+| test.swift:463:31:463:31 | x | semmle.label | x |
+| test.swift:463:43:463:62 | call to ... [myPair:0] | semmle.label | call to ... [myPair:0] |
+| test.swift:463:51:463:58 | call to source() | semmle.label | call to source() |
 | test.swift:464:19:464:19 | x | semmle.label | x |
-| test.swift:467:17:467:41 | .myCons(...) [myCons:1, myPair:1] :  | semmle.label | .myCons(...) [myCons:1, myPair:1] :  |
-| test.swift:467:28:467:40 | .myPair(...) [myPair:1] :  | semmle.label | .myPair(...) [myPair:1] :  |
-| test.swift:467:39:467:39 | c :  | semmle.label | c :  |
+| test.swift:467:17:467:41 | .myCons(...) [myCons:1, myPair:1] | semmle.label | .myCons(...) [myCons:1, myPair:1] |
+| test.swift:467:28:467:40 | .myPair(...) [myPair:1] | semmle.label | .myPair(...) [myPair:1] |
+| test.swift:467:39:467:39 | c | semmle.label | c |
 | test.swift:468:19:468:19 | c | semmle.label | c |
-| test.swift:471:12:471:17 | (...) [Tuple element at index 0, myPair:1] :  | semmle.label | (...) [Tuple element at index 0, myPair:1] :  |
-| test.swift:471:12:471:17 | (...) [Tuple element at index 1, myCons:1, myPair:1] :  | semmle.label | (...) [Tuple element at index 1, myCons:1, myPair:1] :  |
-| test.swift:471:13:471:13 | a [myPair:1] :  | semmle.label | a [myPair:1] :  |
-| test.swift:471:16:471:16 | b [myCons:1, myPair:1] :  | semmle.label | b [myCons:1, myPair:1] :  |
-| test.swift:472:14:472:55 | (...) [Tuple element at index 0, myPair:1] :  | semmle.label | (...) [Tuple element at index 0, myPair:1] :  |
-| test.swift:472:14:472:55 | (...) [Tuple element at index 1, myCons:1, myPair:1] :  | semmle.label | (...) [Tuple element at index 1, myCons:1, myPair:1] :  |
-| test.swift:472:15:472:27 | .myPair(...) [myPair:1] :  | semmle.label | .myPair(...) [myPair:1] :  |
-| test.swift:472:26:472:26 | b :  | semmle.label | b :  |
-| test.swift:472:30:472:54 | .myCons(...) [myCons:1, myPair:1] :  | semmle.label | .myCons(...) [myCons:1, myPair:1] :  |
-| test.swift:472:41:472:53 | .myPair(...) [myPair:1] :  | semmle.label | .myPair(...) [myPair:1] :  |
-| test.swift:472:52:472:52 | e :  | semmle.label | e :  |
+| test.swift:471:12:471:17 | (...) [Tuple element at index 0, myPair:1] | semmle.label | (...) [Tuple element at index 0, myPair:1] |
+| test.swift:471:12:471:17 | (...) [Tuple element at index 1, myCons:1, myPair:1] | semmle.label | (...) [Tuple element at index 1, myCons:1, myPair:1] |
+| test.swift:471:13:471:13 | a [myPair:1] | semmle.label | a [myPair:1] |
+| test.swift:471:16:471:16 | b [myCons:1, myPair:1] | semmle.label | b [myCons:1, myPair:1] |
+| test.swift:472:14:472:55 | (...) [Tuple element at index 0, myPair:1] | semmle.label | (...) [Tuple element at index 0, myPair:1] |
+| test.swift:472:14:472:55 | (...) [Tuple element at index 1, myCons:1, myPair:1] | semmle.label | (...) [Tuple element at index 1, myCons:1, myPair:1] |
+| test.swift:472:15:472:27 | .myPair(...) [myPair:1] | semmle.label | .myPair(...) [myPair:1] |
+| test.swift:472:26:472:26 | b | semmle.label | b |
+| test.swift:472:30:472:54 | .myCons(...) [myCons:1, myPair:1] | semmle.label | .myCons(...) [myCons:1, myPair:1] |
+| test.swift:472:41:472:53 | .myPair(...) [myPair:1] | semmle.label | .myPair(...) [myPair:1] |
+| test.swift:472:52:472:52 | e | semmle.label | e |
 | test.swift:474:19:474:19 | b | semmle.label | b |
 | test.swift:477:19:477:19 | e | semmle.label | e |
-| test.swift:486:13:486:28 | call to optionalSource() [some:0] :  | semmle.label | call to optionalSource() [some:0] :  |
-| test.swift:488:8:488:12 | let ...? [some:0] :  | semmle.label | let ...? [some:0] :  |
-| test.swift:488:12:488:12 | a :  | semmle.label | a :  |
+| test.swift:486:13:486:28 | call to optionalSource() [some:0] | semmle.label | call to optionalSource() [some:0] |
+| test.swift:488:8:488:12 | let ...? [some:0] | semmle.label | let ...? [some:0] |
+| test.swift:488:12:488:12 | a | semmle.label | a |
 | test.swift:489:19:489:19 | a | semmle.label | a |
-| test.swift:493:18:493:23 | (...) [Tuple element at index 0, some:0] :  | semmle.label | (...) [Tuple element at index 0, some:0] :  |
-| test.swift:493:19:493:19 | x [some:0] :  | semmle.label | x [some:0] :  |
-| test.swift:495:10:495:37 | (...) [Tuple element at index 0, some:0] :  | semmle.label | (...) [Tuple element at index 0, some:0] :  |
-| test.swift:495:11:495:22 | .some(...) [some:0] :  | semmle.label | .some(...) [some:0] :  |
-| test.swift:495:21:495:21 | a :  | semmle.label | a :  |
+| test.swift:493:18:493:23 | (...) [Tuple element at index 0, some:0] | semmle.label | (...) [Tuple element at index 0, some:0] |
+| test.swift:493:19:493:19 | x [some:0] | semmle.label | x [some:0] |
+| test.swift:495:10:495:37 | (...) [Tuple element at index 0, some:0] | semmle.label | (...) [Tuple element at index 0, some:0] |
+| test.swift:495:11:495:22 | .some(...) [some:0] | semmle.label | .some(...) [some:0] |
+| test.swift:495:21:495:21 | a | semmle.label | a |
 | test.swift:496:19:496:19 | a | semmle.label | a |
-| test.swift:509:9:509:9 | self [x, some:0] :  | semmle.label | self [x, some:0] :  |
-| test.swift:509:9:509:9 | value [some:0] :  | semmle.label | value [some:0] :  |
-| test.swift:513:13:513:28 | call to optionalSource() [some:0] :  | semmle.label | call to optionalSource() [some:0] :  |
-| test.swift:515:5:515:5 | [post] cx [x, some:0] :  | semmle.label | [post] cx [x, some:0] :  |
-| test.swift:515:12:515:12 | x [some:0] :  | semmle.label | x [some:0] :  |
-| test.swift:519:11:519:15 | let ...? [some:0] :  | semmle.label | let ...? [some:0] :  |
-| test.swift:519:15:519:15 | z1 :  | semmle.label | z1 :  |
-| test.swift:519:20:519:20 | cx [x, some:0] :  | semmle.label | cx [x, some:0] :  |
-| test.swift:519:20:519:23 | .x [some:0] :  | semmle.label | .x [some:0] :  |
+| test.swift:509:9:509:9 | self [x, some:0] | semmle.label | self [x, some:0] |
+| test.swift:509:9:509:9 | value [some:0] | semmle.label | value [some:0] |
+| test.swift:513:13:513:28 | call to optionalSource() [some:0] | semmle.label | call to optionalSource() [some:0] |
+| test.swift:515:5:515:5 | [post] cx [x, some:0] | semmle.label | [post] cx [x, some:0] |
+| test.swift:515:12:515:12 | x [some:0] | semmle.label | x [some:0] |
+| test.swift:519:11:519:15 | let ...? [some:0] | semmle.label | let ...? [some:0] |
+| test.swift:519:15:519:15 | z1 | semmle.label | z1 |
+| test.swift:519:20:519:20 | cx [x, some:0] | semmle.label | cx [x, some:0] |
+| test.swift:519:20:519:23 | .x [some:0] | semmle.label | .x [some:0] |
 | test.swift:520:15:520:15 | z1 | semmle.label | z1 |
 | test.swift:526:13:526:21 | call to +(_:) | semmle.label | call to +(_:) |
-| test.swift:526:14:526:21 | call to source() :  | semmle.label | call to source() :  |
+| test.swift:526:14:526:21 | call to source() | semmle.label | call to source() |
 | test.swift:527:14:527:21 | call to source() | semmle.label | call to source() |
-| test.swift:535:9:535:9 | self [str] :  | semmle.label | self [str] :  |
-| test.swift:536:5:538:5 | self[return] [str] :  | semmle.label | self[return] [str] :  |
-| test.swift:536:10:536:13 | s :  | semmle.label | s :  |
-| test.swift:537:7:537:7 | [post] self [str] :  | semmle.label | [post] self [str] :  |
-| test.swift:537:13:537:13 | s :  | semmle.label | s :  |
-| test.swift:542:17:545:5 | self[return] [str] :  | semmle.label | self[return] [str] :  |
-| test.swift:543:7:543:7 | [post] self [str] :  | semmle.label | [post] self [str] :  |
-| test.swift:543:20:543:28 | call to source3() :  | semmle.label | call to source3() :  |
+| test.swift:535:9:535:9 | self [str] | semmle.label | self [str] |
+| test.swift:536:5:538:5 | self[return] [str] | semmle.label | self[return] [str] |
+| test.swift:536:10:536:13 | s | semmle.label | s |
+| test.swift:537:7:537:7 | [post] self [str] | semmle.label | [post] self [str] |
+| test.swift:537:13:537:13 | s | semmle.label | s |
+| test.swift:542:17:545:5 | self[return] [str] | semmle.label | self[return] [str] |
+| test.swift:543:7:543:7 | [post] self [str] | semmle.label | [post] self [str] |
+| test.swift:543:20:543:28 | call to source3() | semmle.label | call to source3() |
 | test.swift:544:17:544:17 | .str | semmle.label | .str |
-| test.swift:544:17:544:17 | self [str] :  | semmle.label | self [str] :  |
-| test.swift:549:13:549:33 | call to MyClass.init(s:) [str] :  | semmle.label | call to MyClass.init(s:) [str] :  |
+| test.swift:544:17:544:17 | self [str] | semmle.label | self [str] |
+| test.swift:549:13:549:33 | call to MyClass.init(s:) [str] | semmle.label | call to MyClass.init(s:) [str] |
 | test.swift:549:13:549:35 | .str | semmle.label | .str |
-| test.swift:549:24:549:32 | call to source3() :  | semmle.label | call to source3() :  |
-| test.swift:550:13:550:41 | call to Self.init(contentsOfFile:) [str] :  | semmle.label | call to Self.init(contentsOfFile:) [str] :  |
+| test.swift:549:24:549:32 | call to source3() | semmle.label | call to source3() |
+| test.swift:550:13:550:41 | call to Self.init(contentsOfFile:) [str] | semmle.label | call to Self.init(contentsOfFile:) [str] |
 | test.swift:550:13:550:43 | .str | semmle.label | .str |
-| test.swift:567:3:569:3 | self[return] [x] :  | semmle.label | self[return] [x] :  |
-| test.swift:567:8:567:11 | x :  | semmle.label | x :  |
-| test.swift:568:5:568:5 | [post] self [x] :  | semmle.label | [post] self [x] :  |
-| test.swift:568:14:568:14 | x :  | semmle.label | x :  |
-| test.swift:573:11:573:24 | call to S.init(x:) [x] :  | semmle.label | call to S.init(x:) [x] :  |
-| test.swift:573:16:573:23 | call to source() :  | semmle.label | call to source() :  |
-| test.swift:574:11:574:14 | enter #keyPath(...) [x] :  | semmle.label | enter #keyPath(...) [x] :  |
-| test.swift:574:11:574:14 | exit #keyPath(...) :  | semmle.label | exit #keyPath(...) :  |
-| test.swift:574:14:574:14 | KeyPathComponent [x] :  | semmle.label | KeyPathComponent [x] :  |
-| test.swift:575:13:575:13 | s [x] :  | semmle.label | s [x] :  |
-| test.swift:575:13:575:25 | \\...[...] | semmle.label | \\...[...] |
-| test.swift:577:36:577:38 | enter #keyPath(...) [x] :  | semmle.label | enter #keyPath(...) [x] :  |
-| test.swift:577:36:577:38 | exit #keyPath(...) :  | semmle.label | exit #keyPath(...) :  |
-| test.swift:577:38:577:38 | KeyPathComponent [x] :  | semmle.label | KeyPathComponent [x] :  |
-| test.swift:578:13:578:13 | s [x] :  | semmle.label | s [x] :  |
-| test.swift:578:13:578:32 | \\...[...] | semmle.label | \\...[...] |
-| test.swift:584:3:586:3 | self[return] [s, x] :  | semmle.label | self[return] [s, x] :  |
-| test.swift:584:8:584:11 | s [x] :  | semmle.label | s [x] :  |
-| test.swift:585:5:585:5 | [post] self [s, x] :  | semmle.label | [post] self [s, x] :  |
-| test.swift:585:14:585:14 | s [x] :  | semmle.label | s [x] :  |
-| test.swift:590:11:590:24 | call to S.init(x:) [x] :  | semmle.label | call to S.init(x:) [x] :  |
-| test.swift:590:16:590:23 | call to source() :  | semmle.label | call to source() :  |
-| test.swift:591:12:591:19 | call to S2.init(s:) [s, x] :  | semmle.label | call to S2.init(s:) [s, x] :  |
-| test.swift:591:18:591:18 | s [x] :  | semmle.label | s [x] :  |
-| test.swift:592:11:592:17 | enter #keyPath(...) [s, x] :  | semmle.label | enter #keyPath(...) [s, x] :  |
-| test.swift:592:11:592:17 | exit #keyPath(...) :  | semmle.label | exit #keyPath(...) :  |
-| test.swift:592:15:592:15 | KeyPathComponent [s, x] :  | semmle.label | KeyPathComponent [s, x] :  |
-| test.swift:592:17:592:17 | KeyPathComponent [x] :  | semmle.label | KeyPathComponent [x] :  |
-| test.swift:593:13:593:13 | s2 [s, x] :  | semmle.label | s2 [s, x] :  |
-| test.swift:593:13:593:26 | \\...[...] | semmle.label | \\...[...] |
 subpaths
-| test.swift:75:21:75:22 | &... :  | test.swift:65:16:65:28 | arg1 :  | test.swift:65:1:70:1 | arg2[return] :  | test.swift:75:31:75:32 | [post] &... :  |
-| test.swift:114:19:114:19 | arg :  | test.swift:109:9:109:14 | arg :  | test.swift:110:12:110:12 | arg :  | test.swift:114:12:114:22 | call to ... :  |
-| test.swift:114:19:114:19 | arg :  | test.swift:123:10:123:13 | i :  | test.swift:124:16:124:16 | i :  | test.swift:114:12:114:22 | call to ... :  |
-| test.swift:119:31:119:31 | x :  | test.swift:113:14:113:19 | arg :  | test.swift:114:12:114:22 | call to ... :  | test.swift:119:18:119:44 | call to forward(arg:lambda:) :  |
-| test.swift:122:31:122:38 | call to source() :  | test.swift:113:14:113:19 | arg :  | test.swift:114:12:114:22 | call to ... :  | test.swift:122:18:125:6 | call to forward(arg:lambda:) :  |
-| test.swift:145:23:145:30 | call to source() :  | test.swift:142:10:142:13 | i :  | test.swift:143:16:143:16 | i :  | test.swift:145:15:145:31 | call to ... |
-| test.swift:170:9:170:9 | value :  | test.swift:163:7:163:7 | value :  | file://:0:0:0:0 | [post] self [x] :  | test.swift:170:5:170:5 | [post] self [x] :  |
-| test.swift:174:12:174:12 | self [x] :  | test.swift:163:7:163:7 | self [x] :  | file://:0:0:0:0 | .x :  | test.swift:174:12:174:12 | .x :  |
-| test.swift:180:9:180:16 | call to source() :  | test.swift:163:7:163:7 | value :  | file://:0:0:0:0 | [post] self [x] :  | test.swift:180:3:180:3 | [post] a [x] :  |
-| test.swift:181:13:181:13 | a [x] :  | test.swift:163:7:163:7 | self [x] :  | file://:0:0:0:0 | .x :  | test.swift:181:13:181:15 | .x |
-| test.swift:194:11:194:18 | call to source() :  | test.swift:163:7:163:7 | value :  | file://:0:0:0:0 | [post] self [x] :  | test.swift:194:3:194:5 | [post] getter for .a [x] :  |
-| test.swift:195:13:195:13 | b [a, x] :  | test.swift:185:7:185:7 | self [a, x] :  | file://:0:0:0:0 | .a [x] :  | test.swift:195:13:195:15 | .a [x] :  |
-| test.swift:195:13:195:15 | .a [x] :  | test.swift:163:7:163:7 | self [x] :  | file://:0:0:0:0 | .x :  | test.swift:195:13:195:17 | .x |
-| test.swift:200:9:200:16 | call to source() :  | test.swift:169:12:169:22 | value :  | test.swift:169:3:171:3 | self[return] [x] :  | test.swift:200:3:200:3 | [post] a [x] :  |
-| test.swift:200:9:200:16 | call to source() :  | test.swift:169:12:169:22 | value :  | test.swift:170:5:170:5 | [post] self [x] :  | test.swift:200:3:200:3 | [post] a [x] :  |
-| test.swift:201:13:201:13 | a [x] :  | test.swift:163:7:163:7 | self [x] :  | file://:0:0:0:0 | .x :  | test.swift:201:13:201:15 | .x |
-| test.swift:206:9:206:16 | call to source() :  | test.swift:163:7:163:7 | value :  | file://:0:0:0:0 | [post] self [x] :  | test.swift:206:3:206:3 | [post] a [x] :  |
-| test.swift:207:13:207:13 | a [x] :  | test.swift:173:8:173:8 | self [x] :  | test.swift:174:12:174:12 | .x :  | test.swift:207:13:207:19 | call to get() |
-| test.swift:212:9:212:16 | call to source() :  | test.swift:169:12:169:22 | value :  | test.swift:169:3:171:3 | self[return] [x] :  | test.swift:212:3:212:3 | [post] a [x] :  |
-| test.swift:212:9:212:16 | call to source() :  | test.swift:169:12:169:22 | value :  | test.swift:170:5:170:5 | [post] self [x] :  | test.swift:212:3:212:3 | [post] a [x] :  |
-| test.swift:213:13:213:13 | a [x] :  | test.swift:173:8:173:8 | self [x] :  | test.swift:174:12:174:12 | .x :  | test.swift:213:13:213:19 | call to get() |
-| test.swift:218:11:218:18 | call to source() :  | test.swift:169:12:169:22 | value :  | test.swift:169:3:171:3 | self[return] [x] :  | test.swift:218:3:218:5 | [post] getter for .a [x] :  |
-| test.swift:218:11:218:18 | call to source() :  | test.swift:169:12:169:22 | value :  | test.swift:170:5:170:5 | [post] self [x] :  | test.swift:218:3:218:5 | [post] getter for .a [x] :  |
-| test.swift:219:13:219:13 | b [a, x] :  | test.swift:185:7:185:7 | self [a, x] :  | file://:0:0:0:0 | .a [x] :  | test.swift:219:13:219:15 | .a [x] :  |
-| test.swift:219:13:219:15 | .a [x] :  | test.swift:163:7:163:7 | self [x] :  | file://:0:0:0:0 | .x :  | test.swift:219:13:219:17 | .x |
-| test.swift:270:15:270:22 | call to source() :  | file://:0:0:0:0 | [summary param] this in signum() :  | file://:0:0:0:0 | [summary] to write: return (return) in signum() :  | test.swift:270:15:270:31 | call to signum() |
-| test.swift:271:15:271:16 | ...? :  | file://:0:0:0:0 | [summary param] this in signum() :  | file://:0:0:0:0 | [summary] to write: return (return) in signum() :  | test.swift:271:15:271:25 | call to signum() :  |
-| test.swift:291:16:291:17 | ...? :  | file://:0:0:0:0 | [summary param] this in signum() :  | file://:0:0:0:0 | [summary] to write: return (return) in signum() :  | test.swift:291:16:291:26 | call to signum() :  |
-| test.swift:291:16:291:17 | ...? [some:0] :  | file://:0:0:0:0 | [summary param] this in signum() [some:0] :  | file://:0:0:0:0 | [summary] to write: return (return) in signum() [some:0] :  | test.swift:291:16:291:26 | call to signum() [some:0] :  |
-| test.swift:303:15:303:16 | ...! :  | file://:0:0:0:0 | [summary param] this in signum() :  | file://:0:0:0:0 | [summary] to write: return (return) in signum() :  | test.swift:303:15:303:25 | call to signum() |
-| test.swift:515:12:515:12 | x [some:0] :  | test.swift:509:9:509:9 | value [some:0] :  | file://:0:0:0:0 | [post] self [x, some:0] :  | test.swift:515:5:515:5 | [post] cx [x, some:0] :  |
-| test.swift:519:20:519:20 | cx [x, some:0] :  | test.swift:509:9:509:9 | self [x, some:0] :  | file://:0:0:0:0 | .x [some:0] :  | test.swift:519:20:519:23 | .x [some:0] :  |
-| test.swift:543:20:543:28 | call to source3() :  | test.swift:536:10:536:13 | s :  | test.swift:537:7:537:7 | [post] self [str] :  | test.swift:543:7:543:7 | [post] self [str] :  |
-| test.swift:549:13:549:33 | call to MyClass.init(s:) [str] :  | test.swift:535:9:535:9 | self [str] :  | file://:0:0:0:0 | .str :  | test.swift:549:13:549:35 | .str |
-| test.swift:549:24:549:32 | call to source3() :  | test.swift:536:10:536:13 | s :  | test.swift:536:5:538:5 | self[return] [str] :  | test.swift:549:13:549:33 | call to MyClass.init(s:) [str] :  |
-| test.swift:550:13:550:41 | call to Self.init(contentsOfFile:) [str] :  | test.swift:535:9:535:9 | self [str] :  | file://:0:0:0:0 | .str :  | test.swift:550:13:550:43 | .str |
-| test.swift:573:16:573:23 | call to source() :  | test.swift:567:8:567:11 | x :  | test.swift:567:3:569:3 | self[return] [x] :  | test.swift:573:11:573:24 | call to S.init(x:) [x] :  |
-| test.swift:575:13:575:13 | s [x] :  | test.swift:574:11:574:14 | enter #keyPath(...) [x] :  | test.swift:574:11:574:14 | exit #keyPath(...) :  | test.swift:575:13:575:25 | \\...[...] |
-| test.swift:578:13:578:13 | s [x] :  | test.swift:577:36:577:38 | enter #keyPath(...) [x] :  | test.swift:577:36:577:38 | exit #keyPath(...) :  | test.swift:578:13:578:32 | \\...[...] |
-| test.swift:590:16:590:23 | call to source() :  | test.swift:567:8:567:11 | x :  | test.swift:567:3:569:3 | self[return] [x] :  | test.swift:590:11:590:24 | call to S.init(x:) [x] :  |
-| test.swift:591:18:591:18 | s [x] :  | test.swift:584:8:584:11 | s [x] :  | test.swift:584:3:586:3 | self[return] [s, x] :  | test.swift:591:12:591:19 | call to S2.init(s:) [s, x] :  |
-| test.swift:593:13:593:13 | s2 [s, x] :  | test.swift:592:11:592:17 | enter #keyPath(...) [s, x] :  | test.swift:592:11:592:17 | exit #keyPath(...) :  | test.swift:593:13:593:26 | \\...[...] |
+| test.swift:75:21:75:22 | &... | test.swift:65:16:65:28 | arg1 | test.swift:65:1:70:1 | arg2[return] | test.swift:75:31:75:32 | [post] &... |
+| test.swift:114:19:114:19 | arg | test.swift:109:9:109:14 | arg | test.swift:110:12:110:12 | arg | test.swift:114:12:114:22 | call to ... |
+| test.swift:114:19:114:19 | arg | test.swift:123:10:123:13 | i | test.swift:124:16:124:16 | i | test.swift:114:12:114:22 | call to ... |
+| test.swift:119:31:119:31 | x | test.swift:113:14:113:19 | arg | test.swift:114:12:114:22 | call to ... | test.swift:119:18:119:44 | call to forward(arg:lambda:) |
+| test.swift:122:31:122:38 | call to source() | test.swift:113:14:113:19 | arg | test.swift:114:12:114:22 | call to ... | test.swift:122:18:125:6 | call to forward(arg:lambda:) |
+| test.swift:145:23:145:30 | call to source() | test.swift:142:10:142:13 | i | test.swift:143:16:143:16 | i | test.swift:145:15:145:31 | call to ... |
+| test.swift:170:9:170:9 | value | test.swift:163:7:163:7 | value | file://:0:0:0:0 | [post] self [x] | test.swift:170:5:170:5 | [post] self [x] |
+| test.swift:174:12:174:12 | self [x] | test.swift:163:7:163:7 | self [x] | file://:0:0:0:0 | .x | test.swift:174:12:174:12 | .x |
+| test.swift:180:9:180:16 | call to source() | test.swift:163:7:163:7 | value | file://:0:0:0:0 | [post] self [x] | test.swift:180:3:180:3 | [post] a [x] |
+| test.swift:181:13:181:13 | a [x] | test.swift:163:7:163:7 | self [x] | file://:0:0:0:0 | .x | test.swift:181:13:181:15 | .x |
+| test.swift:194:11:194:18 | call to source() | test.swift:163:7:163:7 | value | file://:0:0:0:0 | [post] self [x] | test.swift:194:3:194:5 | [post] getter for .a [x] |
+| test.swift:195:13:195:13 | b [a, x] | test.swift:185:7:185:7 | self [a, x] | file://:0:0:0:0 | .a [x] | test.swift:195:13:195:15 | .a [x] |
+| test.swift:195:13:195:15 | .a [x] | test.swift:163:7:163:7 | self [x] | file://:0:0:0:0 | .x | test.swift:195:13:195:17 | .x |
+| test.swift:200:9:200:16 | call to source() | test.swift:169:12:169:22 | value | test.swift:169:3:171:3 | self[return] [x] | test.swift:200:3:200:3 | [post] a [x] |
+| test.swift:200:9:200:16 | call to source() | test.swift:169:12:169:22 | value | test.swift:170:5:170:5 | [post] self [x] | test.swift:200:3:200:3 | [post] a [x] |
+| test.swift:201:13:201:13 | a [x] | test.swift:163:7:163:7 | self [x] | file://:0:0:0:0 | .x | test.swift:201:13:201:15 | .x |
+| test.swift:206:9:206:16 | call to source() | test.swift:163:7:163:7 | value | file://:0:0:0:0 | [post] self [x] | test.swift:206:3:206:3 | [post] a [x] |
+| test.swift:207:13:207:13 | a [x] | test.swift:173:8:173:8 | self [x] | test.swift:174:12:174:12 | .x | test.swift:207:13:207:19 | call to get() |
+| test.swift:212:9:212:16 | call to source() | test.swift:169:12:169:22 | value | test.swift:169:3:171:3 | self[return] [x] | test.swift:212:3:212:3 | [post] a [x] |
+| test.swift:212:9:212:16 | call to source() | test.swift:169:12:169:22 | value | test.swift:170:5:170:5 | [post] self [x] | test.swift:212:3:212:3 | [post] a [x] |
+| test.swift:213:13:213:13 | a [x] | test.swift:173:8:173:8 | self [x] | test.swift:174:12:174:12 | .x | test.swift:213:13:213:19 | call to get() |
+| test.swift:218:11:218:18 | call to source() | test.swift:169:12:169:22 | value | test.swift:169:3:171:3 | self[return] [x] | test.swift:218:3:218:5 | [post] getter for .a [x] |
+| test.swift:218:11:218:18 | call to source() | test.swift:169:12:169:22 | value | test.swift:170:5:170:5 | [post] self [x] | test.swift:218:3:218:5 | [post] getter for .a [x] |
+| test.swift:219:13:219:13 | b [a, x] | test.swift:185:7:185:7 | self [a, x] | file://:0:0:0:0 | .a [x] | test.swift:219:13:219:15 | .a [x] |
+| test.swift:219:13:219:15 | .a [x] | test.swift:163:7:163:7 | self [x] | file://:0:0:0:0 | .x | test.swift:219:13:219:17 | .x |
+| test.swift:270:15:270:22 | call to source() | file://:0:0:0:0 | [summary param] this in signum() | file://:0:0:0:0 | [summary] to write: return (return) in signum() | test.swift:270:15:270:31 | call to signum() |
+| test.swift:271:15:271:16 | ...? | file://:0:0:0:0 | [summary param] this in signum() | file://:0:0:0:0 | [summary] to write: return (return) in signum() | test.swift:271:15:271:25 | call to signum() |
+| test.swift:291:16:291:17 | ...? | file://:0:0:0:0 | [summary param] this in signum() | file://:0:0:0:0 | [summary] to write: return (return) in signum() | test.swift:291:16:291:26 | call to signum() |
+| test.swift:291:16:291:17 | ...? [some:0] | file://:0:0:0:0 | [summary param] this in signum() [some:0] | file://:0:0:0:0 | [summary] to write: return (return) in signum() [some:0] | test.swift:291:16:291:26 | call to signum() [some:0] |
+| test.swift:303:15:303:16 | ...! | file://:0:0:0:0 | [summary param] this in signum() | file://:0:0:0:0 | [summary] to write: return (return) in signum() | test.swift:303:15:303:25 | call to signum() |
+| test.swift:515:12:515:12 | x [some:0] | test.swift:509:9:509:9 | value [some:0] | file://:0:0:0:0 | [post] self [x, some:0] | test.swift:515:5:515:5 | [post] cx [x, some:0] |
+| test.swift:519:20:519:20 | cx [x, some:0] | test.swift:509:9:509:9 | self [x, some:0] | file://:0:0:0:0 | .x [some:0] | test.swift:519:20:519:23 | .x [some:0] |
+| test.swift:543:20:543:28 | call to source3() | test.swift:536:10:536:13 | s | test.swift:537:7:537:7 | [post] self [str] | test.swift:543:7:543:7 | [post] self [str] |
+| test.swift:549:13:549:33 | call to MyClass.init(s:) [str] | test.swift:535:9:535:9 | self [str] | file://:0:0:0:0 | .str | test.swift:549:13:549:35 | .str |
+| test.swift:549:24:549:32 | call to source3() | test.swift:536:10:536:13 | s | test.swift:536:5:538:5 | self[return] [str] | test.swift:549:13:549:33 | call to MyClass.init(s:) [str] |
+| test.swift:550:13:550:41 | call to Self.init(contentsOfFile:) [str] | test.swift:535:9:535:9 | self [str] | file://:0:0:0:0 | .str | test.swift:550:13:550:43 | .str |
 #select
-| test.swift:7:15:7:15 | t1 | test.swift:6:19:6:26 | call to source() :  | test.swift:7:15:7:15 | t1 | result |
-| test.swift:9:15:9:15 | t1 | test.swift:6:19:6:26 | call to source() :  | test.swift:9:15:9:15 | t1 | result |
-| test.swift:10:15:10:15 | t2 | test.swift:6:19:6:26 | call to source() :  | test.swift:10:15:10:15 | t2 | result |
-| test.swift:30:15:30:15 | x | test.swift:25:20:25:27 | call to source() :  | test.swift:30:15:30:15 | x | result |
-| test.swift:31:15:31:15 | y | test.swift:26:26:26:33 | call to source() :  | test.swift:31:15:31:15 | y | result |
-| test.swift:39:15:39:29 | call to callee_source() | test.swift:35:12:35:19 | call to source() :  | test.swift:39:15:39:29 | call to callee_source() | result |
-| test.swift:50:15:50:15 | t | test.swift:43:19:43:26 | call to source() :  | test.swift:50:15:50:15 | t | result |
-| test.swift:62:15:62:15 | x | test.swift:54:11:54:18 | call to source() :  | test.swift:62:15:62:15 | x | result |
-| test.swift:76:15:76:15 | x | test.swift:73:18:73:25 | call to source() :  | test.swift:76:15:76:15 | x | result |
-| test.swift:77:15:77:15 | y | test.swift:73:18:73:25 | call to source() :  | test.swift:77:15:77:15 | y | result |
-| test.swift:98:19:98:19 | x | test.swift:81:11:81:18 | call to source() :  | test.swift:98:19:98:19 | x | result |
-| test.swift:105:19:105:19 | x | test.swift:86:15:86:22 | call to source() :  | test.swift:105:19:105:19 | x | result |
-| test.swift:105:19:105:19 | x | test.swift:89:15:89:22 | call to source() :  | test.swift:105:19:105:19 | x | result |
-| test.swift:120:15:120:15 | y | test.swift:118:18:118:25 | call to source() :  | test.swift:120:15:120:15 | y | result |
-| test.swift:126:15:126:15 | z | test.swift:122:31:122:38 | call to source() :  | test.swift:126:15:126:15 | z | result |
+| test.swift:7:15:7:15 | t1 | test.swift:6:19:6:26 | call to source() | test.swift:7:15:7:15 | t1 | result |
+| test.swift:9:15:9:15 | t1 | test.swift:6:19:6:26 | call to source() | test.swift:9:15:9:15 | t1 | result |
+| test.swift:10:15:10:15 | t2 | test.swift:6:19:6:26 | call to source() | test.swift:10:15:10:15 | t2 | result |
+| test.swift:30:15:30:15 | x | test.swift:25:20:25:27 | call to source() | test.swift:30:15:30:15 | x | result |
+| test.swift:31:15:31:15 | y | test.swift:26:26:26:33 | call to source() | test.swift:31:15:31:15 | y | result |
+| test.swift:39:15:39:29 | call to callee_source() | test.swift:35:12:35:19 | call to source() | test.swift:39:15:39:29 | call to callee_source() | result |
+| test.swift:50:15:50:15 | t | test.swift:43:19:43:26 | call to source() | test.swift:50:15:50:15 | t | result |
+| test.swift:62:15:62:15 | x | test.swift:54:11:54:18 | call to source() | test.swift:62:15:62:15 | x | result |
+| test.swift:76:15:76:15 | x | test.swift:73:18:73:25 | call to source() | test.swift:76:15:76:15 | x | result |
+| test.swift:77:15:77:15 | y | test.swift:73:18:73:25 | call to source() | test.swift:77:15:77:15 | y | result |
+| test.swift:98:19:98:19 | x | test.swift:81:11:81:18 | call to source() | test.swift:98:19:98:19 | x | result |
+| test.swift:105:19:105:19 | x | test.swift:86:15:86:22 | call to source() | test.swift:105:19:105:19 | x | result |
+| test.swift:105:19:105:19 | x | test.swift:89:15:89:22 | call to source() | test.swift:105:19:105:19 | x | result |
+| test.swift:120:15:120:15 | y | test.swift:118:18:118:25 | call to source() | test.swift:120:15:120:15 | y | result |
+| test.swift:126:15:126:15 | z | test.swift:122:31:122:38 | call to source() | test.swift:126:15:126:15 | z | result |
 | test.swift:138:19:138:26 | call to source() | test.swift:138:19:138:26 | call to source() | test.swift:138:19:138:26 | call to source() | result |
-| test.swift:145:15:145:31 | call to ... | test.swift:145:23:145:30 | call to source() :  | test.swift:145:15:145:31 | call to ... | result |
-| test.swift:151:15:151:28 | call to ... | test.swift:149:16:149:23 | call to source() :  | test.swift:151:15:151:28 | call to ... | result |
-| test.swift:155:19:155:19 | i | test.swift:149:16:149:23 | call to source() :  | test.swift:155:19:155:19 | i | result |
-| test.swift:155:19:155:19 | i | test.swift:157:16:157:23 | call to source() :  | test.swift:155:19:155:19 | i | result |
-| test.swift:181:13:181:15 | .x | test.swift:180:9:180:16 | call to source() :  | test.swift:181:13:181:15 | .x | result |
-| test.swift:195:13:195:17 | .x | test.swift:194:11:194:18 | call to source() :  | test.swift:195:13:195:17 | .x | result |
-| test.swift:201:13:201:15 | .x | test.swift:200:9:200:16 | call to source() :  | test.swift:201:13:201:15 | .x | result |
-| test.swift:207:13:207:19 | call to get() | test.swift:206:9:206:16 | call to source() :  | test.swift:207:13:207:19 | call to get() | result |
-| test.swift:213:13:213:19 | call to get() | test.swift:212:9:212:16 | call to source() :  | test.swift:213:13:213:19 | call to get() | result |
-| test.swift:219:13:219:17 | .x | test.swift:218:11:218:18 | call to source() :  | test.swift:219:13:219:17 | .x | result |
-| test.swift:235:13:235:15 | .source_value | test.swift:225:14:225:21 | call to source() :  | test.swift:235:13:235:15 | .source_value | result |
-| test.swift:238:13:238:15 | .source_value | test.swift:225:14:225:21 | call to source() :  | test.swift:238:13:238:15 | .source_value | result |
-| test.swift:265:15:265:15 | x | test.swift:259:12:259:19 | call to source() :  | test.swift:265:15:265:15 | x | result |
-| test.swift:267:15:267:16 | ...! | test.swift:259:12:259:19 | call to source() :  | test.swift:267:15:267:16 | ...! | result |
-| test.swift:270:15:270:31 | call to signum() | test.swift:270:15:270:22 | call to source() :  | test.swift:270:15:270:31 | call to signum() | result |
-| test.swift:271:15:271:25 | OptionalEvaluationExpr | test.swift:259:12:259:19 | call to source() :  | test.swift:271:15:271:25 | OptionalEvaluationExpr | result |
-| test.swift:274:15:274:20 | ... ??(_:_:) ... | test.swift:259:12:259:19 | call to source() :  | test.swift:274:15:274:20 | ... ??(_:_:) ... | result |
-| test.swift:275:15:275:27 | ... ??(_:_:) ... | test.swift:259:12:259:19 | call to source() :  | test.swift:275:15:275:27 | ... ??(_:_:) ... | result |
-| test.swift:279:15:279:31 | ... ? ... : ... | test.swift:259:12:259:19 | call to source() :  | test.swift:279:15:279:31 | ... ? ... : ... | result |
-| test.swift:280:15:280:38 | ... ? ... : ... | test.swift:259:12:259:19 | call to source() :  | test.swift:280:15:280:38 | ... ? ... : ... | result |
-| test.swift:280:15:280:38 | ... ? ... : ... | test.swift:280:31:280:38 | call to source() :  | test.swift:280:15:280:38 | ... ? ... : ... | result |
-| test.swift:282:15:282:38 | ... ? ... : ... | test.swift:282:31:282:38 | call to source() :  | test.swift:282:15:282:38 | ... ? ... : ... | result |
-| test.swift:285:19:285:19 | z | test.swift:259:12:259:19 | call to source() :  | test.swift:285:19:285:19 | z | result |
-| test.swift:292:19:292:19 | z | test.swift:259:12:259:19 | call to source() :  | test.swift:292:19:292:19 | z | result |
-| test.swift:300:15:300:15 | z1 | test.swift:259:12:259:19 | call to source() :  | test.swift:300:15:300:15 | z1 | result |
-| test.swift:303:15:303:25 | call to signum() | test.swift:259:12:259:19 | call to source() :  | test.swift:303:15:303:25 | call to signum() | result |
-| test.swift:307:19:307:19 | z | test.swift:259:12:259:19 | call to source() :  | test.swift:307:19:307:19 | z | result |
-| test.swift:315:19:315:19 | z | test.swift:259:12:259:19 | call to source() :  | test.swift:315:19:315:19 | z | result |
-| test.swift:335:15:335:18 | .1 | test.swift:331:18:331:25 | call to source() :  | test.swift:335:15:335:18 | .1 | result |
-| test.swift:346:15:346:18 | .0 | test.swift:343:12:343:19 | call to source() :  | test.swift:346:15:346:18 | .0 | result |
-| test.swift:356:15:356:18 | .0 | test.swift:351:18:351:25 | call to source() :  | test.swift:356:15:356:18 | .0 | result |
-| test.swift:357:15:357:18 | .1 | test.swift:351:31:351:38 | call to source() :  | test.swift:357:15:357:18 | .1 | result |
-| test.swift:360:15:360:18 | .0 | test.swift:351:18:351:25 | call to source() :  | test.swift:360:15:360:18 | .0 | result |
-| test.swift:361:15:361:18 | .1 | test.swift:351:31:351:38 | call to source() :  | test.swift:361:15:361:18 | .1 | result |
-| test.swift:363:15:363:15 | a | test.swift:351:18:351:25 | call to source() :  | test.swift:363:15:363:15 | a | result |
-| test.swift:364:15:364:15 | b | test.swift:351:31:351:38 | call to source() :  | test.swift:364:15:364:15 | b | result |
-| test.swift:404:19:404:19 | a | test.swift:398:19:398:26 | call to source() :  | test.swift:404:19:404:19 | a | result |
-| test.swift:413:19:413:19 | x | test.swift:398:19:398:26 | call to source() :  | test.swift:413:19:413:19 | x | result |
-| test.swift:429:19:429:19 | b | test.swift:420:26:420:33 | call to source() :  | test.swift:429:19:429:19 | b | result |
-| test.swift:439:19:439:19 | y | test.swift:420:26:420:33 | call to source() :  | test.swift:439:19:439:19 | y | result |
-| test.swift:455:19:455:19 | c | test.swift:420:26:420:33 | call to source() :  | test.swift:455:19:455:19 | c | result |
-| test.swift:464:19:464:19 | x | test.swift:463:51:463:58 | call to source() :  | test.swift:464:19:464:19 | x | result |
-| test.swift:468:19:468:19 | c | test.swift:420:26:420:33 | call to source() :  | test.swift:468:19:468:19 | c | result |
-| test.swift:474:19:474:19 | b | test.swift:420:26:420:33 | call to source() :  | test.swift:474:19:474:19 | b | result |
-| test.swift:477:19:477:19 | e | test.swift:420:26:420:33 | call to source() :  | test.swift:477:19:477:19 | e | result |
-| test.swift:489:19:489:19 | a | test.swift:259:12:259:19 | call to source() :  | test.swift:489:19:489:19 | a | result |
-| test.swift:496:19:496:19 | a | test.swift:259:12:259:19 | call to source() :  | test.swift:496:19:496:19 | a | result |
-| test.swift:520:15:520:15 | z1 | test.swift:259:12:259:19 | call to source() :  | test.swift:520:15:520:15 | z1 | result |
-| test.swift:526:13:526:21 | call to +(_:) | test.swift:526:14:526:21 | call to source() :  | test.swift:526:13:526:21 | call to +(_:) | result |
+| test.swift:145:15:145:31 | call to ... | test.swift:145:23:145:30 | call to source() | test.swift:145:15:145:31 | call to ... | result |
+| test.swift:151:15:151:28 | call to ... | test.swift:149:16:149:23 | call to source() | test.swift:151:15:151:28 | call to ... | result |
+| test.swift:155:19:155:19 | i | test.swift:149:16:149:23 | call to source() | test.swift:155:19:155:19 | i | result |
+| test.swift:155:19:155:19 | i | test.swift:157:16:157:23 | call to source() | test.swift:155:19:155:19 | i | result |
+| test.swift:181:13:181:15 | .x | test.swift:180:9:180:16 | call to source() | test.swift:181:13:181:15 | .x | result |
+| test.swift:195:13:195:17 | .x | test.swift:194:11:194:18 | call to source() | test.swift:195:13:195:17 | .x | result |
+| test.swift:201:13:201:15 | .x | test.swift:200:9:200:16 | call to source() | test.swift:201:13:201:15 | .x | result |
+| test.swift:207:13:207:19 | call to get() | test.swift:206:9:206:16 | call to source() | test.swift:207:13:207:19 | call to get() | result |
+| test.swift:213:13:213:19 | call to get() | test.swift:212:9:212:16 | call to source() | test.swift:213:13:213:19 | call to get() | result |
+| test.swift:219:13:219:17 | .x | test.swift:218:11:218:18 | call to source() | test.swift:219:13:219:17 | .x | result |
+| test.swift:235:13:235:15 | .source_value | test.swift:225:14:225:21 | call to source() | test.swift:235:13:235:15 | .source_value | result |
+| test.swift:238:13:238:15 | .source_value | test.swift:225:14:225:21 | call to source() | test.swift:238:13:238:15 | .source_value | result |
+| test.swift:265:15:265:15 | x | test.swift:259:12:259:19 | call to source() | test.swift:265:15:265:15 | x | result |
+| test.swift:267:15:267:16 | ...! | test.swift:259:12:259:19 | call to source() | test.swift:267:15:267:16 | ...! | result |
+| test.swift:270:15:270:31 | call to signum() | test.swift:270:15:270:22 | call to source() | test.swift:270:15:270:31 | call to signum() | result |
+| test.swift:271:15:271:25 | OptionalEvaluationExpr | test.swift:259:12:259:19 | call to source() | test.swift:271:15:271:25 | OptionalEvaluationExpr | result |
+| test.swift:274:15:274:20 | ... ??(_:_:) ... | test.swift:259:12:259:19 | call to source() | test.swift:274:15:274:20 | ... ??(_:_:) ... | result |
+| test.swift:275:15:275:27 | ... ??(_:_:) ... | test.swift:259:12:259:19 | call to source() | test.swift:275:15:275:27 | ... ??(_:_:) ... | result |
+| test.swift:279:15:279:31 | ... ? ... : ... | test.swift:259:12:259:19 | call to source() | test.swift:279:15:279:31 | ... ? ... : ... | result |
+| test.swift:280:15:280:38 | ... ? ... : ... | test.swift:259:12:259:19 | call to source() | test.swift:280:15:280:38 | ... ? ... : ... | result |
+| test.swift:280:15:280:38 | ... ? ... : ... | test.swift:280:31:280:38 | call to source() | test.swift:280:15:280:38 | ... ? ... : ... | result |
+| test.swift:282:15:282:38 | ... ? ... : ... | test.swift:282:31:282:38 | call to source() | test.swift:282:15:282:38 | ... ? ... : ... | result |
+| test.swift:285:19:285:19 | z | test.swift:259:12:259:19 | call to source() | test.swift:285:19:285:19 | z | result |
+| test.swift:292:19:292:19 | z | test.swift:259:12:259:19 | call to source() | test.swift:292:19:292:19 | z | result |
+| test.swift:300:15:300:15 | z1 | test.swift:259:12:259:19 | call to source() | test.swift:300:15:300:15 | z1 | result |
+| test.swift:303:15:303:25 | call to signum() | test.swift:259:12:259:19 | call to source() | test.swift:303:15:303:25 | call to signum() | result |
+| test.swift:307:19:307:19 | z | test.swift:259:12:259:19 | call to source() | test.swift:307:19:307:19 | z | result |
+| test.swift:315:19:315:19 | z | test.swift:259:12:259:19 | call to source() | test.swift:315:19:315:19 | z | result |
+| test.swift:335:15:335:18 | .1 | test.swift:331:18:331:25 | call to source() | test.swift:335:15:335:18 | .1 | result |
+| test.swift:346:15:346:18 | .0 | test.swift:343:12:343:19 | call to source() | test.swift:346:15:346:18 | .0 | result |
+| test.swift:356:15:356:18 | .0 | test.swift:351:18:351:25 | call to source() | test.swift:356:15:356:18 | .0 | result |
+| test.swift:357:15:357:18 | .1 | test.swift:351:31:351:38 | call to source() | test.swift:357:15:357:18 | .1 | result |
+| test.swift:360:15:360:18 | .0 | test.swift:351:18:351:25 | call to source() | test.swift:360:15:360:18 | .0 | result |
+| test.swift:361:15:361:18 | .1 | test.swift:351:31:351:38 | call to source() | test.swift:361:15:361:18 | .1 | result |
+| test.swift:363:15:363:15 | a | test.swift:351:18:351:25 | call to source() | test.swift:363:15:363:15 | a | result |
+| test.swift:364:15:364:15 | b | test.swift:351:31:351:38 | call to source() | test.swift:364:15:364:15 | b | result |
+| test.swift:404:19:404:19 | a | test.swift:398:19:398:26 | call to source() | test.swift:404:19:404:19 | a | result |
+| test.swift:413:19:413:19 | x | test.swift:398:19:398:26 | call to source() | test.swift:413:19:413:19 | x | result |
+| test.swift:429:19:429:19 | b | test.swift:420:26:420:33 | call to source() | test.swift:429:19:429:19 | b | result |
+| test.swift:439:19:439:19 | y | test.swift:420:26:420:33 | call to source() | test.swift:439:19:439:19 | y | result |
+| test.swift:455:19:455:19 | c | test.swift:420:26:420:33 | call to source() | test.swift:455:19:455:19 | c | result |
+| test.swift:464:19:464:19 | x | test.swift:463:51:463:58 | call to source() | test.swift:464:19:464:19 | x | result |
+| test.swift:468:19:468:19 | c | test.swift:420:26:420:33 | call to source() | test.swift:468:19:468:19 | c | result |
+| test.swift:474:19:474:19 | b | test.swift:420:26:420:33 | call to source() | test.swift:474:19:474:19 | b | result |
+| test.swift:477:19:477:19 | e | test.swift:420:26:420:33 | call to source() | test.swift:477:19:477:19 | e | result |
+| test.swift:489:19:489:19 | a | test.swift:259:12:259:19 | call to source() | test.swift:489:19:489:19 | a | result |
+| test.swift:496:19:496:19 | a | test.swift:259:12:259:19 | call to source() | test.swift:496:19:496:19 | a | result |
+| test.swift:520:15:520:15 | z1 | test.swift:259:12:259:19 | call to source() | test.swift:520:15:520:15 | z1 | result |
+| test.swift:526:13:526:21 | call to +(_:) | test.swift:526:14:526:21 | call to source() | test.swift:526:13:526:21 | call to +(_:) | result |
 | test.swift:527:14:527:21 | call to source() | test.swift:527:14:527:21 | call to source() | test.swift:527:14:527:21 | call to source() | result |
-| test.swift:544:17:544:17 | .str | test.swift:543:20:543:28 | call to source3() :  | test.swift:544:17:544:17 | .str | result |
-| test.swift:549:13:549:35 | .str | test.swift:549:24:549:32 | call to source3() :  | test.swift:549:13:549:35 | .str | result |
-| test.swift:550:13:550:43 | .str | test.swift:543:20:543:28 | call to source3() :  | test.swift:550:13:550:43 | .str | result |
-| test.swift:575:13:575:25 | \\...[...] | test.swift:573:16:573:23 | call to source() :  | test.swift:575:13:575:25 | \\...[...] | result |
-| test.swift:578:13:578:32 | \\...[...] | test.swift:573:16:573:23 | call to source() :  | test.swift:578:13:578:32 | \\...[...] | result |
-| test.swift:593:13:593:26 | \\...[...] | test.swift:590:16:590:23 | call to source() :  | test.swift:593:13:593:26 | \\...[...] | result |
+| test.swift:544:17:544:17 | .str | test.swift:543:20:543:28 | call to source3() | test.swift:544:17:544:17 | .str | result |
+| test.swift:549:13:549:35 | .str | test.swift:549:24:549:32 | call to source3() | test.swift:549:13:549:35 | .str | result |
+| test.swift:550:13:550:43 | .str | test.swift:543:20:543:28 | call to source3() | test.swift:550:13:550:43 | .str | result |

--- a/swift/ql/test/library-tests/dataflow/taint/core/Taint.expected
+++ b/swift/ql/test/library-tests/dataflow/taint/core/Taint.expected
@@ -1,243 +1,243 @@
 edges
-| file://:0:0:0:0 | self [first] :  | file://:0:0:0:0 | .first :  |
-| file://:0:0:0:0 | self [second] :  | file://:0:0:0:0 | .second :  |
-| file://:0:0:0:0 | value :  | file://:0:0:0:0 | [post] self [first] :  |
-| file://:0:0:0:0 | value :  | file://:0:0:0:0 | [post] self [second] :  |
-| simple.swift:12:17:12:24 | call to source() :  | simple.swift:12:13:12:24 | ... .+(_:_:) ... |
-| simple.swift:13:13:13:20 | call to source() :  | simple.swift:13:13:13:24 | ... .+(_:_:) ... |
-| simple.swift:14:17:14:24 | call to source() :  | simple.swift:14:13:14:24 | ... .-(_:_:) ... |
-| simple.swift:15:13:15:20 | call to source() :  | simple.swift:15:13:15:24 | ... .-(_:_:) ... |
-| simple.swift:16:17:16:24 | call to source() :  | simple.swift:16:13:16:24 | ... .*(_:_:) ... |
-| simple.swift:17:13:17:20 | call to source() :  | simple.swift:17:13:17:24 | ... .*(_:_:) ... |
-| simple.swift:18:19:18:26 | call to source() :  | simple.swift:18:13:18:26 | ... ./(_:_:) ... |
-| simple.swift:19:13:19:20 | call to source() :  | simple.swift:19:13:19:24 | ... ./(_:_:) ... |
-| simple.swift:20:19:20:26 | call to source() :  | simple.swift:20:13:20:26 | ... .%(_:_:) ... |
-| simple.swift:21:13:21:20 | call to source() :  | simple.swift:21:13:21:24 | ... .%(_:_:) ... |
-| simple.swift:23:14:23:21 | call to source() :  | simple.swift:23:13:23:21 | call to -(_:) |
-| simple.swift:27:18:27:25 | call to source() :  | simple.swift:27:13:27:25 | ... .&+(_:_:) ... |
-| simple.swift:28:13:28:20 | call to source() :  | simple.swift:28:13:28:25 | ... .&+(_:_:) ... |
-| simple.swift:29:18:29:25 | call to source() :  | simple.swift:29:13:29:25 | ... .&-(_:_:) ... |
-| simple.swift:30:13:30:20 | call to source() :  | simple.swift:30:13:30:25 | ... .&-(_:_:) ... |
-| simple.swift:31:18:31:25 | call to source() :  | simple.swift:31:13:31:25 | ... .&*(_:_:) ... |
-| simple.swift:32:13:32:20 | call to source() :  | simple.swift:32:13:32:25 | ... .&*(_:_:) ... |
-| simple.swift:40:8:40:15 | call to source() :  | simple.swift:41:13:41:13 | a |
-| simple.swift:40:8:40:15 | call to source() :  | simple.swift:43:13:43:13 | a |
-| simple.swift:48:8:48:15 | call to source() :  | simple.swift:49:13:49:13 | b |
-| simple.swift:48:8:48:15 | call to source() :  | simple.swift:51:13:51:13 | b |
-| simple.swift:54:8:54:15 | call to source() :  | simple.swift:55:13:55:13 | c |
-| simple.swift:54:8:54:15 | call to source() :  | simple.swift:57:13:57:13 | c |
-| simple.swift:60:8:60:15 | call to source() :  | simple.swift:61:13:61:13 | d |
-| simple.swift:60:8:60:15 | call to source() :  | simple.swift:63:13:63:13 | d |
-| simple.swift:66:8:66:15 | call to source() :  | simple.swift:67:13:67:13 | e |
-| simple.swift:66:8:66:15 | call to source() :  | simple.swift:69:13:69:13 | e |
-| simple.swift:73:17:73:24 | call to source() :  | simple.swift:73:13:73:24 | ... .\|(_:_:) ... |
-| simple.swift:74:13:74:20 | call to source() :  | simple.swift:74:13:74:24 | ... .\|(_:_:) ... |
-| simple.swift:76:22:76:29 | call to source() :  | simple.swift:76:13:76:29 | ... .&(_:_:) ... |
-| simple.swift:77:13:77:20 | call to source() :  | simple.swift:77:13:77:24 | ... .&(_:_:) ... |
-| simple.swift:79:22:79:29 | call to source() :  | simple.swift:79:13:79:29 | ... .^(_:_:) ... |
-| simple.swift:80:13:80:20 | call to source() :  | simple.swift:80:13:80:24 | ... .^(_:_:) ... |
-| simple.swift:82:13:82:20 | call to source() :  | simple.swift:82:13:82:25 | ... .<<(_:_:) ... |
-| simple.swift:83:13:83:20 | call to source() :  | simple.swift:83:13:83:26 | ... .&<<(_:_:) ... |
-| simple.swift:84:13:84:20 | call to source() :  | simple.swift:84:13:84:25 | ... .>>(_:_:) ... |
-| simple.swift:85:13:85:20 | call to source() :  | simple.swift:85:13:85:26 | ... .&>>(_:_:) ... |
-| simple.swift:87:14:87:21 | call to source() :  | simple.swift:87:13:87:21 | call to ~(_:) |
-| stringinterpolation.swift:6:6:6:6 | self [first] :  | file://:0:0:0:0 | self [first] :  |
-| stringinterpolation.swift:6:6:6:6 | value :  | file://:0:0:0:0 | value :  |
-| stringinterpolation.swift:7:6:7:6 | self [second] :  | file://:0:0:0:0 | self [second] :  |
-| stringinterpolation.swift:7:6:7:6 | value :  | file://:0:0:0:0 | value :  |
-| stringinterpolation.swift:11:36:11:44 | pair [first] :  | stringinterpolation.swift:13:36:13:36 | pair [first] :  |
-| stringinterpolation.swift:13:3:13:3 | [post] &... :  | stringinterpolation.swift:11:11:14:2 | self[return] :  |
-| stringinterpolation.swift:13:36:13:36 | pair [first] :  | stringinterpolation.swift:6:6:6:6 | self [first] :  |
-| stringinterpolation.swift:13:36:13:36 | pair [first] :  | stringinterpolation.swift:13:36:13:41 | .first :  |
-| stringinterpolation.swift:13:36:13:41 | .first :  | stringinterpolation.swift:11:11:14:2 | self[return] :  |
-| stringinterpolation.swift:13:36:13:41 | .first :  | stringinterpolation.swift:13:3:13:3 | [post] &... :  |
-| stringinterpolation.swift:19:2:19:2 | [post] p1 [first] :  | stringinterpolation.swift:20:2:20:2 | p1 [first] :  |
-| stringinterpolation.swift:19:13:19:20 | call to source() :  | stringinterpolation.swift:6:6:6:6 | value :  |
-| stringinterpolation.swift:19:13:19:20 | call to source() :  | stringinterpolation.swift:19:2:19:2 | [post] p1 [first] :  |
-| stringinterpolation.swift:20:2:20:2 | p1 [first] :  | stringinterpolation.swift:22:21:22:21 | p1 [first] :  |
-| stringinterpolation.swift:20:2:20:2 | p1 [first] :  | stringinterpolation.swift:24:21:24:21 | p1 [first] :  |
-| stringinterpolation.swift:22:21:22:21 | p1 [first] :  | stringinterpolation.swift:6:6:6:6 | self [first] :  |
-| stringinterpolation.swift:22:21:22:21 | p1 [first] :  | stringinterpolation.swift:22:21:22:24 | .first :  |
-| stringinterpolation.swift:22:21:22:24 | .first :  | stringinterpolation.swift:22:12:22:12 | "..." |
-| stringinterpolation.swift:24:20:24:20 | [post] &... :  | stringinterpolation.swift:24:12:24:12 | "..." |
-| stringinterpolation.swift:24:21:24:21 | p1 [first] :  | stringinterpolation.swift:11:36:11:44 | pair [first] :  |
-| stringinterpolation.swift:24:21:24:21 | p1 [first] :  | stringinterpolation.swift:24:20:24:20 | [post] &... :  |
-| stringinterpolation.swift:28:2:28:2 | [post] p2 [second] :  | stringinterpolation.swift:31:21:31:21 | p2 [second] :  |
-| stringinterpolation.swift:28:14:28:21 | call to source() :  | stringinterpolation.swift:7:6:7:6 | value :  |
-| stringinterpolation.swift:28:14:28:21 | call to source() :  | stringinterpolation.swift:28:2:28:2 | [post] p2 [second] :  |
-| stringinterpolation.swift:31:21:31:21 | p2 [second] :  | stringinterpolation.swift:7:6:7:6 | self [second] :  |
-| stringinterpolation.swift:31:21:31:21 | p2 [second] :  | stringinterpolation.swift:31:21:31:24 | .second :  |
-| stringinterpolation.swift:31:21:31:24 | .second :  | stringinterpolation.swift:31:12:31:12 | "..." |
-| subscript.swift:13:15:13:22 | call to source() :  | subscript.swift:13:15:13:25 | ...[...] |
-| subscript.swift:14:15:14:23 | call to source2() :  | subscript.swift:14:15:14:26 | ...[...] |
-| try.swift:9:17:9:24 | call to source() :  | try.swift:9:13:9:24 | try ... |
-| try.swift:15:17:15:24 | call to source() :  | try.swift:15:12:15:24 | try! ... |
-| try.swift:18:18:18:25 | call to source() :  | try.swift:18:12:18:27 | ...! |
+| file://:0:0:0:0 | self [first] | file://:0:0:0:0 | .first |
+| file://:0:0:0:0 | self [second] | file://:0:0:0:0 | .second |
+| file://:0:0:0:0 | value | file://:0:0:0:0 | [post] self [first] |
+| file://:0:0:0:0 | value | file://:0:0:0:0 | [post] self [second] |
+| simple.swift:12:17:12:24 | call to source() | simple.swift:12:13:12:24 | ... .+(_:_:) ... |
+| simple.swift:13:13:13:20 | call to source() | simple.swift:13:13:13:24 | ... .+(_:_:) ... |
+| simple.swift:14:17:14:24 | call to source() | simple.swift:14:13:14:24 | ... .-(_:_:) ... |
+| simple.swift:15:13:15:20 | call to source() | simple.swift:15:13:15:24 | ... .-(_:_:) ... |
+| simple.swift:16:17:16:24 | call to source() | simple.swift:16:13:16:24 | ... .*(_:_:) ... |
+| simple.swift:17:13:17:20 | call to source() | simple.swift:17:13:17:24 | ... .*(_:_:) ... |
+| simple.swift:18:19:18:26 | call to source() | simple.swift:18:13:18:26 | ... ./(_:_:) ... |
+| simple.swift:19:13:19:20 | call to source() | simple.swift:19:13:19:24 | ... ./(_:_:) ... |
+| simple.swift:20:19:20:26 | call to source() | simple.swift:20:13:20:26 | ... .%(_:_:) ... |
+| simple.swift:21:13:21:20 | call to source() | simple.swift:21:13:21:24 | ... .%(_:_:) ... |
+| simple.swift:23:14:23:21 | call to source() | simple.swift:23:13:23:21 | call to -(_:) |
+| simple.swift:27:18:27:25 | call to source() | simple.swift:27:13:27:25 | ... .&+(_:_:) ... |
+| simple.swift:28:13:28:20 | call to source() | simple.swift:28:13:28:25 | ... .&+(_:_:) ... |
+| simple.swift:29:18:29:25 | call to source() | simple.swift:29:13:29:25 | ... .&-(_:_:) ... |
+| simple.swift:30:13:30:20 | call to source() | simple.swift:30:13:30:25 | ... .&-(_:_:) ... |
+| simple.swift:31:18:31:25 | call to source() | simple.swift:31:13:31:25 | ... .&*(_:_:) ... |
+| simple.swift:32:13:32:20 | call to source() | simple.swift:32:13:32:25 | ... .&*(_:_:) ... |
+| simple.swift:40:8:40:15 | call to source() | simple.swift:41:13:41:13 | a |
+| simple.swift:40:8:40:15 | call to source() | simple.swift:43:13:43:13 | a |
+| simple.swift:48:8:48:15 | call to source() | simple.swift:49:13:49:13 | b |
+| simple.swift:48:8:48:15 | call to source() | simple.swift:51:13:51:13 | b |
+| simple.swift:54:8:54:15 | call to source() | simple.swift:55:13:55:13 | c |
+| simple.swift:54:8:54:15 | call to source() | simple.swift:57:13:57:13 | c |
+| simple.swift:60:8:60:15 | call to source() | simple.swift:61:13:61:13 | d |
+| simple.swift:60:8:60:15 | call to source() | simple.swift:63:13:63:13 | d |
+| simple.swift:66:8:66:15 | call to source() | simple.swift:67:13:67:13 | e |
+| simple.swift:66:8:66:15 | call to source() | simple.swift:69:13:69:13 | e |
+| simple.swift:73:17:73:24 | call to source() | simple.swift:73:13:73:24 | ... .\|(_:_:) ... |
+| simple.swift:74:13:74:20 | call to source() | simple.swift:74:13:74:24 | ... .\|(_:_:) ... |
+| simple.swift:76:22:76:29 | call to source() | simple.swift:76:13:76:29 | ... .&(_:_:) ... |
+| simple.swift:77:13:77:20 | call to source() | simple.swift:77:13:77:24 | ... .&(_:_:) ... |
+| simple.swift:79:22:79:29 | call to source() | simple.swift:79:13:79:29 | ... .^(_:_:) ... |
+| simple.swift:80:13:80:20 | call to source() | simple.swift:80:13:80:24 | ... .^(_:_:) ... |
+| simple.swift:82:13:82:20 | call to source() | simple.swift:82:13:82:25 | ... .<<(_:_:) ... |
+| simple.swift:83:13:83:20 | call to source() | simple.swift:83:13:83:26 | ... .&<<(_:_:) ... |
+| simple.swift:84:13:84:20 | call to source() | simple.swift:84:13:84:25 | ... .>>(_:_:) ... |
+| simple.swift:85:13:85:20 | call to source() | simple.swift:85:13:85:26 | ... .&>>(_:_:) ... |
+| simple.swift:87:14:87:21 | call to source() | simple.swift:87:13:87:21 | call to ~(_:) |
+| stringinterpolation.swift:6:6:6:6 | self [first] | file://:0:0:0:0 | self [first] |
+| stringinterpolation.swift:6:6:6:6 | value | file://:0:0:0:0 | value |
+| stringinterpolation.swift:7:6:7:6 | self [second] | file://:0:0:0:0 | self [second] |
+| stringinterpolation.swift:7:6:7:6 | value | file://:0:0:0:0 | value |
+| stringinterpolation.swift:11:36:11:44 | pair [first] | stringinterpolation.swift:13:36:13:36 | pair [first] |
+| stringinterpolation.swift:13:3:13:3 | [post] &... | stringinterpolation.swift:11:11:14:2 | self[return] |
+| stringinterpolation.swift:13:36:13:36 | pair [first] | stringinterpolation.swift:6:6:6:6 | self [first] |
+| stringinterpolation.swift:13:36:13:36 | pair [first] | stringinterpolation.swift:13:36:13:41 | .first |
+| stringinterpolation.swift:13:36:13:41 | .first | stringinterpolation.swift:11:11:14:2 | self[return] |
+| stringinterpolation.swift:13:36:13:41 | .first | stringinterpolation.swift:13:3:13:3 | [post] &... |
+| stringinterpolation.swift:19:2:19:2 | [post] p1 [first] | stringinterpolation.swift:20:2:20:2 | p1 [first] |
+| stringinterpolation.swift:19:13:19:20 | call to source() | stringinterpolation.swift:6:6:6:6 | value |
+| stringinterpolation.swift:19:13:19:20 | call to source() | stringinterpolation.swift:19:2:19:2 | [post] p1 [first] |
+| stringinterpolation.swift:20:2:20:2 | p1 [first] | stringinterpolation.swift:22:21:22:21 | p1 [first] |
+| stringinterpolation.swift:20:2:20:2 | p1 [first] | stringinterpolation.swift:24:21:24:21 | p1 [first] |
+| stringinterpolation.swift:22:21:22:21 | p1 [first] | stringinterpolation.swift:6:6:6:6 | self [first] |
+| stringinterpolation.swift:22:21:22:21 | p1 [first] | stringinterpolation.swift:22:21:22:24 | .first |
+| stringinterpolation.swift:22:21:22:24 | .first | stringinterpolation.swift:22:12:22:12 | "..." |
+| stringinterpolation.swift:24:20:24:20 | [post] &... | stringinterpolation.swift:24:12:24:12 | "..." |
+| stringinterpolation.swift:24:21:24:21 | p1 [first] | stringinterpolation.swift:11:36:11:44 | pair [first] |
+| stringinterpolation.swift:24:21:24:21 | p1 [first] | stringinterpolation.swift:24:20:24:20 | [post] &... |
+| stringinterpolation.swift:28:2:28:2 | [post] p2 [second] | stringinterpolation.swift:31:21:31:21 | p2 [second] |
+| stringinterpolation.swift:28:14:28:21 | call to source() | stringinterpolation.swift:7:6:7:6 | value |
+| stringinterpolation.swift:28:14:28:21 | call to source() | stringinterpolation.swift:28:2:28:2 | [post] p2 [second] |
+| stringinterpolation.swift:31:21:31:21 | p2 [second] | stringinterpolation.swift:7:6:7:6 | self [second] |
+| stringinterpolation.swift:31:21:31:21 | p2 [second] | stringinterpolation.swift:31:21:31:24 | .second |
+| stringinterpolation.swift:31:21:31:24 | .second | stringinterpolation.swift:31:12:31:12 | "..." |
+| subscript.swift:13:15:13:22 | call to source() | subscript.swift:13:15:13:25 | ...[...] |
+| subscript.swift:14:15:14:23 | call to source2() | subscript.swift:14:15:14:26 | ...[...] |
+| try.swift:9:17:9:24 | call to source() | try.swift:9:13:9:24 | try ... |
+| try.swift:15:17:15:24 | call to source() | try.swift:15:12:15:24 | try! ... |
+| try.swift:18:18:18:25 | call to source() | try.swift:18:12:18:27 | ...! |
 nodes
-| file://:0:0:0:0 | .first :  | semmle.label | .first :  |
-| file://:0:0:0:0 | .second :  | semmle.label | .second :  |
-| file://:0:0:0:0 | [post] self [first] :  | semmle.label | [post] self [first] :  |
-| file://:0:0:0:0 | [post] self [second] :  | semmle.label | [post] self [second] :  |
-| file://:0:0:0:0 | self [first] :  | semmle.label | self [first] :  |
-| file://:0:0:0:0 | self [second] :  | semmle.label | self [second] :  |
-| file://:0:0:0:0 | value :  | semmle.label | value :  |
-| file://:0:0:0:0 | value :  | semmle.label | value :  |
+| file://:0:0:0:0 | .first | semmle.label | .first |
+| file://:0:0:0:0 | .second | semmle.label | .second |
+| file://:0:0:0:0 | [post] self [first] | semmle.label | [post] self [first] |
+| file://:0:0:0:0 | [post] self [second] | semmle.label | [post] self [second] |
+| file://:0:0:0:0 | self [first] | semmle.label | self [first] |
+| file://:0:0:0:0 | self [second] | semmle.label | self [second] |
+| file://:0:0:0:0 | value | semmle.label | value |
+| file://:0:0:0:0 | value | semmle.label | value |
 | simple.swift:12:13:12:24 | ... .+(_:_:) ... | semmle.label | ... .+(_:_:) ... |
-| simple.swift:12:17:12:24 | call to source() :  | semmle.label | call to source() :  |
-| simple.swift:13:13:13:20 | call to source() :  | semmle.label | call to source() :  |
+| simple.swift:12:17:12:24 | call to source() | semmle.label | call to source() |
+| simple.swift:13:13:13:20 | call to source() | semmle.label | call to source() |
 | simple.swift:13:13:13:24 | ... .+(_:_:) ... | semmle.label | ... .+(_:_:) ... |
 | simple.swift:14:13:14:24 | ... .-(_:_:) ... | semmle.label | ... .-(_:_:) ... |
-| simple.swift:14:17:14:24 | call to source() :  | semmle.label | call to source() :  |
-| simple.swift:15:13:15:20 | call to source() :  | semmle.label | call to source() :  |
+| simple.swift:14:17:14:24 | call to source() | semmle.label | call to source() |
+| simple.swift:15:13:15:20 | call to source() | semmle.label | call to source() |
 | simple.swift:15:13:15:24 | ... .-(_:_:) ... | semmle.label | ... .-(_:_:) ... |
 | simple.swift:16:13:16:24 | ... .*(_:_:) ... | semmle.label | ... .*(_:_:) ... |
-| simple.swift:16:17:16:24 | call to source() :  | semmle.label | call to source() :  |
-| simple.swift:17:13:17:20 | call to source() :  | semmle.label | call to source() :  |
+| simple.swift:16:17:16:24 | call to source() | semmle.label | call to source() |
+| simple.swift:17:13:17:20 | call to source() | semmle.label | call to source() |
 | simple.swift:17:13:17:24 | ... .*(_:_:) ... | semmle.label | ... .*(_:_:) ... |
 | simple.swift:18:13:18:26 | ... ./(_:_:) ... | semmle.label | ... ./(_:_:) ... |
-| simple.swift:18:19:18:26 | call to source() :  | semmle.label | call to source() :  |
-| simple.swift:19:13:19:20 | call to source() :  | semmle.label | call to source() :  |
+| simple.swift:18:19:18:26 | call to source() | semmle.label | call to source() |
+| simple.swift:19:13:19:20 | call to source() | semmle.label | call to source() |
 | simple.swift:19:13:19:24 | ... ./(_:_:) ... | semmle.label | ... ./(_:_:) ... |
 | simple.swift:20:13:20:26 | ... .%(_:_:) ... | semmle.label | ... .%(_:_:) ... |
-| simple.swift:20:19:20:26 | call to source() :  | semmle.label | call to source() :  |
-| simple.swift:21:13:21:20 | call to source() :  | semmle.label | call to source() :  |
+| simple.swift:20:19:20:26 | call to source() | semmle.label | call to source() |
+| simple.swift:21:13:21:20 | call to source() | semmle.label | call to source() |
 | simple.swift:21:13:21:24 | ... .%(_:_:) ... | semmle.label | ... .%(_:_:) ... |
 | simple.swift:23:13:23:21 | call to -(_:) | semmle.label | call to -(_:) |
-| simple.swift:23:14:23:21 | call to source() :  | semmle.label | call to source() :  |
+| simple.swift:23:14:23:21 | call to source() | semmle.label | call to source() |
 | simple.swift:27:13:27:25 | ... .&+(_:_:) ... | semmle.label | ... .&+(_:_:) ... |
-| simple.swift:27:18:27:25 | call to source() :  | semmle.label | call to source() :  |
-| simple.swift:28:13:28:20 | call to source() :  | semmle.label | call to source() :  |
+| simple.swift:27:18:27:25 | call to source() | semmle.label | call to source() |
+| simple.swift:28:13:28:20 | call to source() | semmle.label | call to source() |
 | simple.swift:28:13:28:25 | ... .&+(_:_:) ... | semmle.label | ... .&+(_:_:) ... |
 | simple.swift:29:13:29:25 | ... .&-(_:_:) ... | semmle.label | ... .&-(_:_:) ... |
-| simple.swift:29:18:29:25 | call to source() :  | semmle.label | call to source() :  |
-| simple.swift:30:13:30:20 | call to source() :  | semmle.label | call to source() :  |
+| simple.swift:29:18:29:25 | call to source() | semmle.label | call to source() |
+| simple.swift:30:13:30:20 | call to source() | semmle.label | call to source() |
 | simple.swift:30:13:30:25 | ... .&-(_:_:) ... | semmle.label | ... .&-(_:_:) ... |
 | simple.swift:31:13:31:25 | ... .&*(_:_:) ... | semmle.label | ... .&*(_:_:) ... |
-| simple.swift:31:18:31:25 | call to source() :  | semmle.label | call to source() :  |
-| simple.swift:32:13:32:20 | call to source() :  | semmle.label | call to source() :  |
+| simple.swift:31:18:31:25 | call to source() | semmle.label | call to source() |
+| simple.swift:32:13:32:20 | call to source() | semmle.label | call to source() |
 | simple.swift:32:13:32:25 | ... .&*(_:_:) ... | semmle.label | ... .&*(_:_:) ... |
-| simple.swift:40:8:40:15 | call to source() :  | semmle.label | call to source() :  |
+| simple.swift:40:8:40:15 | call to source() | semmle.label | call to source() |
 | simple.swift:41:13:41:13 | a | semmle.label | a |
 | simple.swift:43:13:43:13 | a | semmle.label | a |
-| simple.swift:48:8:48:15 | call to source() :  | semmle.label | call to source() :  |
+| simple.swift:48:8:48:15 | call to source() | semmle.label | call to source() |
 | simple.swift:49:13:49:13 | b | semmle.label | b |
 | simple.swift:51:13:51:13 | b | semmle.label | b |
-| simple.swift:54:8:54:15 | call to source() :  | semmle.label | call to source() :  |
+| simple.swift:54:8:54:15 | call to source() | semmle.label | call to source() |
 | simple.swift:55:13:55:13 | c | semmle.label | c |
 | simple.swift:57:13:57:13 | c | semmle.label | c |
-| simple.swift:60:8:60:15 | call to source() :  | semmle.label | call to source() :  |
+| simple.swift:60:8:60:15 | call to source() | semmle.label | call to source() |
 | simple.swift:61:13:61:13 | d | semmle.label | d |
 | simple.swift:63:13:63:13 | d | semmle.label | d |
-| simple.swift:66:8:66:15 | call to source() :  | semmle.label | call to source() :  |
+| simple.swift:66:8:66:15 | call to source() | semmle.label | call to source() |
 | simple.swift:67:13:67:13 | e | semmle.label | e |
 | simple.swift:69:13:69:13 | e | semmle.label | e |
 | simple.swift:73:13:73:24 | ... .\|(_:_:) ... | semmle.label | ... .\|(_:_:) ... |
-| simple.swift:73:17:73:24 | call to source() :  | semmle.label | call to source() :  |
-| simple.swift:74:13:74:20 | call to source() :  | semmle.label | call to source() :  |
+| simple.swift:73:17:73:24 | call to source() | semmle.label | call to source() |
+| simple.swift:74:13:74:20 | call to source() | semmle.label | call to source() |
 | simple.swift:74:13:74:24 | ... .\|(_:_:) ... | semmle.label | ... .\|(_:_:) ... |
 | simple.swift:76:13:76:29 | ... .&(_:_:) ... | semmle.label | ... .&(_:_:) ... |
-| simple.swift:76:22:76:29 | call to source() :  | semmle.label | call to source() :  |
-| simple.swift:77:13:77:20 | call to source() :  | semmle.label | call to source() :  |
+| simple.swift:76:22:76:29 | call to source() | semmle.label | call to source() |
+| simple.swift:77:13:77:20 | call to source() | semmle.label | call to source() |
 | simple.swift:77:13:77:24 | ... .&(_:_:) ... | semmle.label | ... .&(_:_:) ... |
 | simple.swift:79:13:79:29 | ... .^(_:_:) ... | semmle.label | ... .^(_:_:) ... |
-| simple.swift:79:22:79:29 | call to source() :  | semmle.label | call to source() :  |
-| simple.swift:80:13:80:20 | call to source() :  | semmle.label | call to source() :  |
+| simple.swift:79:22:79:29 | call to source() | semmle.label | call to source() |
+| simple.swift:80:13:80:20 | call to source() | semmle.label | call to source() |
 | simple.swift:80:13:80:24 | ... .^(_:_:) ... | semmle.label | ... .^(_:_:) ... |
-| simple.swift:82:13:82:20 | call to source() :  | semmle.label | call to source() :  |
+| simple.swift:82:13:82:20 | call to source() | semmle.label | call to source() |
 | simple.swift:82:13:82:25 | ... .<<(_:_:) ... | semmle.label | ... .<<(_:_:) ... |
-| simple.swift:83:13:83:20 | call to source() :  | semmle.label | call to source() :  |
+| simple.swift:83:13:83:20 | call to source() | semmle.label | call to source() |
 | simple.swift:83:13:83:26 | ... .&<<(_:_:) ... | semmle.label | ... .&<<(_:_:) ... |
-| simple.swift:84:13:84:20 | call to source() :  | semmle.label | call to source() :  |
+| simple.swift:84:13:84:20 | call to source() | semmle.label | call to source() |
 | simple.swift:84:13:84:25 | ... .>>(_:_:) ... | semmle.label | ... .>>(_:_:) ... |
-| simple.swift:85:13:85:20 | call to source() :  | semmle.label | call to source() :  |
+| simple.swift:85:13:85:20 | call to source() | semmle.label | call to source() |
 | simple.swift:85:13:85:26 | ... .&>>(_:_:) ... | semmle.label | ... .&>>(_:_:) ... |
 | simple.swift:87:13:87:21 | call to ~(_:) | semmle.label | call to ~(_:) |
-| simple.swift:87:14:87:21 | call to source() :  | semmle.label | call to source() :  |
-| stringinterpolation.swift:6:6:6:6 | self [first] :  | semmle.label | self [first] :  |
-| stringinterpolation.swift:6:6:6:6 | value :  | semmle.label | value :  |
-| stringinterpolation.swift:7:6:7:6 | self [second] :  | semmle.label | self [second] :  |
-| stringinterpolation.swift:7:6:7:6 | value :  | semmle.label | value :  |
-| stringinterpolation.swift:11:11:14:2 | self[return] :  | semmle.label | self[return] :  |
-| stringinterpolation.swift:11:36:11:44 | pair [first] :  | semmle.label | pair [first] :  |
-| stringinterpolation.swift:13:3:13:3 | [post] &... :  | semmle.label | [post] &... :  |
-| stringinterpolation.swift:13:36:13:36 | pair [first] :  | semmle.label | pair [first] :  |
-| stringinterpolation.swift:13:36:13:41 | .first :  | semmle.label | .first :  |
-| stringinterpolation.swift:19:2:19:2 | [post] p1 [first] :  | semmle.label | [post] p1 [first] :  |
-| stringinterpolation.swift:19:13:19:20 | call to source() :  | semmle.label | call to source() :  |
-| stringinterpolation.swift:20:2:20:2 | p1 [first] :  | semmle.label | p1 [first] :  |
+| simple.swift:87:14:87:21 | call to source() | semmle.label | call to source() |
+| stringinterpolation.swift:6:6:6:6 | self [first] | semmle.label | self [first] |
+| stringinterpolation.swift:6:6:6:6 | value | semmle.label | value |
+| stringinterpolation.swift:7:6:7:6 | self [second] | semmle.label | self [second] |
+| stringinterpolation.swift:7:6:7:6 | value | semmle.label | value |
+| stringinterpolation.swift:11:11:14:2 | self[return] | semmle.label | self[return] |
+| stringinterpolation.swift:11:36:11:44 | pair [first] | semmle.label | pair [first] |
+| stringinterpolation.swift:13:3:13:3 | [post] &... | semmle.label | [post] &... |
+| stringinterpolation.swift:13:36:13:36 | pair [first] | semmle.label | pair [first] |
+| stringinterpolation.swift:13:36:13:41 | .first | semmle.label | .first |
+| stringinterpolation.swift:19:2:19:2 | [post] p1 [first] | semmle.label | [post] p1 [first] |
+| stringinterpolation.swift:19:13:19:20 | call to source() | semmle.label | call to source() |
+| stringinterpolation.swift:20:2:20:2 | p1 [first] | semmle.label | p1 [first] |
 | stringinterpolation.swift:22:12:22:12 | "..." | semmle.label | "..." |
-| stringinterpolation.swift:22:21:22:21 | p1 [first] :  | semmle.label | p1 [first] :  |
-| stringinterpolation.swift:22:21:22:24 | .first :  | semmle.label | .first :  |
+| stringinterpolation.swift:22:21:22:21 | p1 [first] | semmle.label | p1 [first] |
+| stringinterpolation.swift:22:21:22:24 | .first | semmle.label | .first |
 | stringinterpolation.swift:24:12:24:12 | "..." | semmle.label | "..." |
-| stringinterpolation.swift:24:20:24:20 | [post] &... :  | semmle.label | [post] &... :  |
-| stringinterpolation.swift:24:21:24:21 | p1 [first] :  | semmle.label | p1 [first] :  |
-| stringinterpolation.swift:28:2:28:2 | [post] p2 [second] :  | semmle.label | [post] p2 [second] :  |
-| stringinterpolation.swift:28:14:28:21 | call to source() :  | semmle.label | call to source() :  |
+| stringinterpolation.swift:24:20:24:20 | [post] &... | semmle.label | [post] &... |
+| stringinterpolation.swift:24:21:24:21 | p1 [first] | semmle.label | p1 [first] |
+| stringinterpolation.swift:28:2:28:2 | [post] p2 [second] | semmle.label | [post] p2 [second] |
+| stringinterpolation.swift:28:14:28:21 | call to source() | semmle.label | call to source() |
 | stringinterpolation.swift:31:12:31:12 | "..." | semmle.label | "..." |
-| stringinterpolation.swift:31:21:31:21 | p2 [second] :  | semmle.label | p2 [second] :  |
-| stringinterpolation.swift:31:21:31:24 | .second :  | semmle.label | .second :  |
-| subscript.swift:13:15:13:22 | call to source() :  | semmle.label | call to source() :  |
+| stringinterpolation.swift:31:21:31:21 | p2 [second] | semmle.label | p2 [second] |
+| stringinterpolation.swift:31:21:31:24 | .second | semmle.label | .second |
+| subscript.swift:13:15:13:22 | call to source() | semmle.label | call to source() |
 | subscript.swift:13:15:13:25 | ...[...] | semmle.label | ...[...] |
-| subscript.swift:14:15:14:23 | call to source2() :  | semmle.label | call to source2() :  |
+| subscript.swift:14:15:14:23 | call to source2() | semmle.label | call to source2() |
 | subscript.swift:14:15:14:26 | ...[...] | semmle.label | ...[...] |
 | try.swift:9:13:9:24 | try ... | semmle.label | try ... |
-| try.swift:9:17:9:24 | call to source() :  | semmle.label | call to source() :  |
+| try.swift:9:17:9:24 | call to source() | semmle.label | call to source() |
 | try.swift:15:12:15:24 | try! ... | semmle.label | try! ... |
-| try.swift:15:17:15:24 | call to source() :  | semmle.label | call to source() :  |
+| try.swift:15:17:15:24 | call to source() | semmle.label | call to source() |
 | try.swift:18:12:18:27 | ...! | semmle.label | ...! |
-| try.swift:18:18:18:25 | call to source() :  | semmle.label | call to source() :  |
+| try.swift:18:18:18:25 | call to source() | semmle.label | call to source() |
 subpaths
-| stringinterpolation.swift:13:36:13:36 | pair [first] :  | stringinterpolation.swift:6:6:6:6 | self [first] :  | file://:0:0:0:0 | .first :  | stringinterpolation.swift:13:36:13:41 | .first :  |
-| stringinterpolation.swift:19:13:19:20 | call to source() :  | stringinterpolation.swift:6:6:6:6 | value :  | file://:0:0:0:0 | [post] self [first] :  | stringinterpolation.swift:19:2:19:2 | [post] p1 [first] :  |
-| stringinterpolation.swift:22:21:22:21 | p1 [first] :  | stringinterpolation.swift:6:6:6:6 | self [first] :  | file://:0:0:0:0 | .first :  | stringinterpolation.swift:22:21:22:24 | .first :  |
-| stringinterpolation.swift:24:21:24:21 | p1 [first] :  | stringinterpolation.swift:11:36:11:44 | pair [first] :  | stringinterpolation.swift:11:11:14:2 | self[return] :  | stringinterpolation.swift:24:20:24:20 | [post] &... :  |
-| stringinterpolation.swift:24:21:24:21 | p1 [first] :  | stringinterpolation.swift:11:36:11:44 | pair [first] :  | stringinterpolation.swift:13:3:13:3 | [post] &... :  | stringinterpolation.swift:24:20:24:20 | [post] &... :  |
-| stringinterpolation.swift:28:14:28:21 | call to source() :  | stringinterpolation.swift:7:6:7:6 | value :  | file://:0:0:0:0 | [post] self [second] :  | stringinterpolation.swift:28:2:28:2 | [post] p2 [second] :  |
-| stringinterpolation.swift:31:21:31:21 | p2 [second] :  | stringinterpolation.swift:7:6:7:6 | self [second] :  | file://:0:0:0:0 | .second :  | stringinterpolation.swift:31:21:31:24 | .second :  |
+| stringinterpolation.swift:13:36:13:36 | pair [first] | stringinterpolation.swift:6:6:6:6 | self [first] | file://:0:0:0:0 | .first | stringinterpolation.swift:13:36:13:41 | .first |
+| stringinterpolation.swift:19:13:19:20 | call to source() | stringinterpolation.swift:6:6:6:6 | value | file://:0:0:0:0 | [post] self [first] | stringinterpolation.swift:19:2:19:2 | [post] p1 [first] |
+| stringinterpolation.swift:22:21:22:21 | p1 [first] | stringinterpolation.swift:6:6:6:6 | self [first] | file://:0:0:0:0 | .first | stringinterpolation.swift:22:21:22:24 | .first |
+| stringinterpolation.swift:24:21:24:21 | p1 [first] | stringinterpolation.swift:11:36:11:44 | pair [first] | stringinterpolation.swift:11:11:14:2 | self[return] | stringinterpolation.swift:24:20:24:20 | [post] &... |
+| stringinterpolation.swift:24:21:24:21 | p1 [first] | stringinterpolation.swift:11:36:11:44 | pair [first] | stringinterpolation.swift:13:3:13:3 | [post] &... | stringinterpolation.swift:24:20:24:20 | [post] &... |
+| stringinterpolation.swift:28:14:28:21 | call to source() | stringinterpolation.swift:7:6:7:6 | value | file://:0:0:0:0 | [post] self [second] | stringinterpolation.swift:28:2:28:2 | [post] p2 [second] |
+| stringinterpolation.swift:31:21:31:21 | p2 [second] | stringinterpolation.swift:7:6:7:6 | self [second] | file://:0:0:0:0 | .second | stringinterpolation.swift:31:21:31:24 | .second |
 #select
-| simple.swift:12:13:12:24 | ... .+(_:_:) ... | simple.swift:12:17:12:24 | call to source() :  | simple.swift:12:13:12:24 | ... .+(_:_:) ... | result |
-| simple.swift:13:13:13:24 | ... .+(_:_:) ... | simple.swift:13:13:13:20 | call to source() :  | simple.swift:13:13:13:24 | ... .+(_:_:) ... | result |
-| simple.swift:14:13:14:24 | ... .-(_:_:) ... | simple.swift:14:17:14:24 | call to source() :  | simple.swift:14:13:14:24 | ... .-(_:_:) ... | result |
-| simple.swift:15:13:15:24 | ... .-(_:_:) ... | simple.swift:15:13:15:20 | call to source() :  | simple.swift:15:13:15:24 | ... .-(_:_:) ... | result |
-| simple.swift:16:13:16:24 | ... .*(_:_:) ... | simple.swift:16:17:16:24 | call to source() :  | simple.swift:16:13:16:24 | ... .*(_:_:) ... | result |
-| simple.swift:17:13:17:24 | ... .*(_:_:) ... | simple.swift:17:13:17:20 | call to source() :  | simple.swift:17:13:17:24 | ... .*(_:_:) ... | result |
-| simple.swift:18:13:18:26 | ... ./(_:_:) ... | simple.swift:18:19:18:26 | call to source() :  | simple.swift:18:13:18:26 | ... ./(_:_:) ... | result |
-| simple.swift:19:13:19:24 | ... ./(_:_:) ... | simple.swift:19:13:19:20 | call to source() :  | simple.swift:19:13:19:24 | ... ./(_:_:) ... | result |
-| simple.swift:20:13:20:26 | ... .%(_:_:) ... | simple.swift:20:19:20:26 | call to source() :  | simple.swift:20:13:20:26 | ... .%(_:_:) ... | result |
-| simple.swift:21:13:21:24 | ... .%(_:_:) ... | simple.swift:21:13:21:20 | call to source() :  | simple.swift:21:13:21:24 | ... .%(_:_:) ... | result |
-| simple.swift:23:13:23:21 | call to -(_:) | simple.swift:23:14:23:21 | call to source() :  | simple.swift:23:13:23:21 | call to -(_:) | result |
-| simple.swift:27:13:27:25 | ... .&+(_:_:) ... | simple.swift:27:18:27:25 | call to source() :  | simple.swift:27:13:27:25 | ... .&+(_:_:) ... | result |
-| simple.swift:28:13:28:25 | ... .&+(_:_:) ... | simple.swift:28:13:28:20 | call to source() :  | simple.swift:28:13:28:25 | ... .&+(_:_:) ... | result |
-| simple.swift:29:13:29:25 | ... .&-(_:_:) ... | simple.swift:29:18:29:25 | call to source() :  | simple.swift:29:13:29:25 | ... .&-(_:_:) ... | result |
-| simple.swift:30:13:30:25 | ... .&-(_:_:) ... | simple.swift:30:13:30:20 | call to source() :  | simple.swift:30:13:30:25 | ... .&-(_:_:) ... | result |
-| simple.swift:31:13:31:25 | ... .&*(_:_:) ... | simple.swift:31:18:31:25 | call to source() :  | simple.swift:31:13:31:25 | ... .&*(_:_:) ... | result |
-| simple.swift:32:13:32:25 | ... .&*(_:_:) ... | simple.swift:32:13:32:20 | call to source() :  | simple.swift:32:13:32:25 | ... .&*(_:_:) ... | result |
-| simple.swift:41:13:41:13 | a | simple.swift:40:8:40:15 | call to source() :  | simple.swift:41:13:41:13 | a | result |
-| simple.swift:43:13:43:13 | a | simple.swift:40:8:40:15 | call to source() :  | simple.swift:43:13:43:13 | a | result |
-| simple.swift:49:13:49:13 | b | simple.swift:48:8:48:15 | call to source() :  | simple.swift:49:13:49:13 | b | result |
-| simple.swift:51:13:51:13 | b | simple.swift:48:8:48:15 | call to source() :  | simple.swift:51:13:51:13 | b | result |
-| simple.swift:55:13:55:13 | c | simple.swift:54:8:54:15 | call to source() :  | simple.swift:55:13:55:13 | c | result |
-| simple.swift:57:13:57:13 | c | simple.swift:54:8:54:15 | call to source() :  | simple.swift:57:13:57:13 | c | result |
-| simple.swift:61:13:61:13 | d | simple.swift:60:8:60:15 | call to source() :  | simple.swift:61:13:61:13 | d | result |
-| simple.swift:63:13:63:13 | d | simple.swift:60:8:60:15 | call to source() :  | simple.swift:63:13:63:13 | d | result |
-| simple.swift:67:13:67:13 | e | simple.swift:66:8:66:15 | call to source() :  | simple.swift:67:13:67:13 | e | result |
-| simple.swift:69:13:69:13 | e | simple.swift:66:8:66:15 | call to source() :  | simple.swift:69:13:69:13 | e | result |
-| simple.swift:73:13:73:24 | ... .\|(_:_:) ... | simple.swift:73:17:73:24 | call to source() :  | simple.swift:73:13:73:24 | ... .\|(_:_:) ... | result |
-| simple.swift:74:13:74:24 | ... .\|(_:_:) ... | simple.swift:74:13:74:20 | call to source() :  | simple.swift:74:13:74:24 | ... .\|(_:_:) ... | result |
-| simple.swift:76:13:76:29 | ... .&(_:_:) ... | simple.swift:76:22:76:29 | call to source() :  | simple.swift:76:13:76:29 | ... .&(_:_:) ... | result |
-| simple.swift:77:13:77:24 | ... .&(_:_:) ... | simple.swift:77:13:77:20 | call to source() :  | simple.swift:77:13:77:24 | ... .&(_:_:) ... | result |
-| simple.swift:79:13:79:29 | ... .^(_:_:) ... | simple.swift:79:22:79:29 | call to source() :  | simple.swift:79:13:79:29 | ... .^(_:_:) ... | result |
-| simple.swift:80:13:80:24 | ... .^(_:_:) ... | simple.swift:80:13:80:20 | call to source() :  | simple.swift:80:13:80:24 | ... .^(_:_:) ... | result |
-| simple.swift:82:13:82:25 | ... .<<(_:_:) ... | simple.swift:82:13:82:20 | call to source() :  | simple.swift:82:13:82:25 | ... .<<(_:_:) ... | result |
-| simple.swift:83:13:83:26 | ... .&<<(_:_:) ... | simple.swift:83:13:83:20 | call to source() :  | simple.swift:83:13:83:26 | ... .&<<(_:_:) ... | result |
-| simple.swift:84:13:84:25 | ... .>>(_:_:) ... | simple.swift:84:13:84:20 | call to source() :  | simple.swift:84:13:84:25 | ... .>>(_:_:) ... | result |
-| simple.swift:85:13:85:26 | ... .&>>(_:_:) ... | simple.swift:85:13:85:20 | call to source() :  | simple.swift:85:13:85:26 | ... .&>>(_:_:) ... | result |
-| simple.swift:87:13:87:21 | call to ~(_:) | simple.swift:87:14:87:21 | call to source() :  | simple.swift:87:13:87:21 | call to ~(_:) | result |
-| stringinterpolation.swift:22:12:22:12 | "..." | stringinterpolation.swift:19:13:19:20 | call to source() :  | stringinterpolation.swift:22:12:22:12 | "..." | result |
-| stringinterpolation.swift:24:12:24:12 | "..." | stringinterpolation.swift:19:13:19:20 | call to source() :  | stringinterpolation.swift:24:12:24:12 | "..." | result |
-| stringinterpolation.swift:31:12:31:12 | "..." | stringinterpolation.swift:28:14:28:21 | call to source() :  | stringinterpolation.swift:31:12:31:12 | "..." | result |
-| subscript.swift:13:15:13:25 | ...[...] | subscript.swift:13:15:13:22 | call to source() :  | subscript.swift:13:15:13:25 | ...[...] | result |
-| subscript.swift:14:15:14:26 | ...[...] | subscript.swift:14:15:14:23 | call to source2() :  | subscript.swift:14:15:14:26 | ...[...] | result |
-| try.swift:9:13:9:24 | try ... | try.swift:9:17:9:24 | call to source() :  | try.swift:9:13:9:24 | try ... | result |
-| try.swift:15:12:15:24 | try! ... | try.swift:15:17:15:24 | call to source() :  | try.swift:15:12:15:24 | try! ... | result |
-| try.swift:18:12:18:27 | ...! | try.swift:18:18:18:25 | call to source() :  | try.swift:18:12:18:27 | ...! | result |
+| simple.swift:12:13:12:24 | ... .+(_:_:) ... | simple.swift:12:17:12:24 | call to source() | simple.swift:12:13:12:24 | ... .+(_:_:) ... | result |
+| simple.swift:13:13:13:24 | ... .+(_:_:) ... | simple.swift:13:13:13:20 | call to source() | simple.swift:13:13:13:24 | ... .+(_:_:) ... | result |
+| simple.swift:14:13:14:24 | ... .-(_:_:) ... | simple.swift:14:17:14:24 | call to source() | simple.swift:14:13:14:24 | ... .-(_:_:) ... | result |
+| simple.swift:15:13:15:24 | ... .-(_:_:) ... | simple.swift:15:13:15:20 | call to source() | simple.swift:15:13:15:24 | ... .-(_:_:) ... | result |
+| simple.swift:16:13:16:24 | ... .*(_:_:) ... | simple.swift:16:17:16:24 | call to source() | simple.swift:16:13:16:24 | ... .*(_:_:) ... | result |
+| simple.swift:17:13:17:24 | ... .*(_:_:) ... | simple.swift:17:13:17:20 | call to source() | simple.swift:17:13:17:24 | ... .*(_:_:) ... | result |
+| simple.swift:18:13:18:26 | ... ./(_:_:) ... | simple.swift:18:19:18:26 | call to source() | simple.swift:18:13:18:26 | ... ./(_:_:) ... | result |
+| simple.swift:19:13:19:24 | ... ./(_:_:) ... | simple.swift:19:13:19:20 | call to source() | simple.swift:19:13:19:24 | ... ./(_:_:) ... | result |
+| simple.swift:20:13:20:26 | ... .%(_:_:) ... | simple.swift:20:19:20:26 | call to source() | simple.swift:20:13:20:26 | ... .%(_:_:) ... | result |
+| simple.swift:21:13:21:24 | ... .%(_:_:) ... | simple.swift:21:13:21:20 | call to source() | simple.swift:21:13:21:24 | ... .%(_:_:) ... | result |
+| simple.swift:23:13:23:21 | call to -(_:) | simple.swift:23:14:23:21 | call to source() | simple.swift:23:13:23:21 | call to -(_:) | result |
+| simple.swift:27:13:27:25 | ... .&+(_:_:) ... | simple.swift:27:18:27:25 | call to source() | simple.swift:27:13:27:25 | ... .&+(_:_:) ... | result |
+| simple.swift:28:13:28:25 | ... .&+(_:_:) ... | simple.swift:28:13:28:20 | call to source() | simple.swift:28:13:28:25 | ... .&+(_:_:) ... | result |
+| simple.swift:29:13:29:25 | ... .&-(_:_:) ... | simple.swift:29:18:29:25 | call to source() | simple.swift:29:13:29:25 | ... .&-(_:_:) ... | result |
+| simple.swift:30:13:30:25 | ... .&-(_:_:) ... | simple.swift:30:13:30:20 | call to source() | simple.swift:30:13:30:25 | ... .&-(_:_:) ... | result |
+| simple.swift:31:13:31:25 | ... .&*(_:_:) ... | simple.swift:31:18:31:25 | call to source() | simple.swift:31:13:31:25 | ... .&*(_:_:) ... | result |
+| simple.swift:32:13:32:25 | ... .&*(_:_:) ... | simple.swift:32:13:32:20 | call to source() | simple.swift:32:13:32:25 | ... .&*(_:_:) ... | result |
+| simple.swift:41:13:41:13 | a | simple.swift:40:8:40:15 | call to source() | simple.swift:41:13:41:13 | a | result |
+| simple.swift:43:13:43:13 | a | simple.swift:40:8:40:15 | call to source() | simple.swift:43:13:43:13 | a | result |
+| simple.swift:49:13:49:13 | b | simple.swift:48:8:48:15 | call to source() | simple.swift:49:13:49:13 | b | result |
+| simple.swift:51:13:51:13 | b | simple.swift:48:8:48:15 | call to source() | simple.swift:51:13:51:13 | b | result |
+| simple.swift:55:13:55:13 | c | simple.swift:54:8:54:15 | call to source() | simple.swift:55:13:55:13 | c | result |
+| simple.swift:57:13:57:13 | c | simple.swift:54:8:54:15 | call to source() | simple.swift:57:13:57:13 | c | result |
+| simple.swift:61:13:61:13 | d | simple.swift:60:8:60:15 | call to source() | simple.swift:61:13:61:13 | d | result |
+| simple.swift:63:13:63:13 | d | simple.swift:60:8:60:15 | call to source() | simple.swift:63:13:63:13 | d | result |
+| simple.swift:67:13:67:13 | e | simple.swift:66:8:66:15 | call to source() | simple.swift:67:13:67:13 | e | result |
+| simple.swift:69:13:69:13 | e | simple.swift:66:8:66:15 | call to source() | simple.swift:69:13:69:13 | e | result |
+| simple.swift:73:13:73:24 | ... .\|(_:_:) ... | simple.swift:73:17:73:24 | call to source() | simple.swift:73:13:73:24 | ... .\|(_:_:) ... | result |
+| simple.swift:74:13:74:24 | ... .\|(_:_:) ... | simple.swift:74:13:74:20 | call to source() | simple.swift:74:13:74:24 | ... .\|(_:_:) ... | result |
+| simple.swift:76:13:76:29 | ... .&(_:_:) ... | simple.swift:76:22:76:29 | call to source() | simple.swift:76:13:76:29 | ... .&(_:_:) ... | result |
+| simple.swift:77:13:77:24 | ... .&(_:_:) ... | simple.swift:77:13:77:20 | call to source() | simple.swift:77:13:77:24 | ... .&(_:_:) ... | result |
+| simple.swift:79:13:79:29 | ... .^(_:_:) ... | simple.swift:79:22:79:29 | call to source() | simple.swift:79:13:79:29 | ... .^(_:_:) ... | result |
+| simple.swift:80:13:80:24 | ... .^(_:_:) ... | simple.swift:80:13:80:20 | call to source() | simple.swift:80:13:80:24 | ... .^(_:_:) ... | result |
+| simple.swift:82:13:82:25 | ... .<<(_:_:) ... | simple.swift:82:13:82:20 | call to source() | simple.swift:82:13:82:25 | ... .<<(_:_:) ... | result |
+| simple.swift:83:13:83:26 | ... .&<<(_:_:) ... | simple.swift:83:13:83:20 | call to source() | simple.swift:83:13:83:26 | ... .&<<(_:_:) ... | result |
+| simple.swift:84:13:84:25 | ... .>>(_:_:) ... | simple.swift:84:13:84:20 | call to source() | simple.swift:84:13:84:25 | ... .>>(_:_:) ... | result |
+| simple.swift:85:13:85:26 | ... .&>>(_:_:) ... | simple.swift:85:13:85:20 | call to source() | simple.swift:85:13:85:26 | ... .&>>(_:_:) ... | result |
+| simple.swift:87:13:87:21 | call to ~(_:) | simple.swift:87:14:87:21 | call to source() | simple.swift:87:13:87:21 | call to ~(_:) | result |
+| stringinterpolation.swift:22:12:22:12 | "..." | stringinterpolation.swift:19:13:19:20 | call to source() | stringinterpolation.swift:22:12:22:12 | "..." | result |
+| stringinterpolation.swift:24:12:24:12 | "..." | stringinterpolation.swift:19:13:19:20 | call to source() | stringinterpolation.swift:24:12:24:12 | "..." | result |
+| stringinterpolation.swift:31:12:31:12 | "..." | stringinterpolation.swift:28:14:28:21 | call to source() | stringinterpolation.swift:31:12:31:12 | "..." | result |
+| subscript.swift:13:15:13:25 | ...[...] | subscript.swift:13:15:13:22 | call to source() | subscript.swift:13:15:13:25 | ...[...] | result |
+| subscript.swift:14:15:14:26 | ...[...] | subscript.swift:14:15:14:23 | call to source2() | subscript.swift:14:15:14:26 | ...[...] | result |
+| try.swift:9:13:9:24 | try ... | try.swift:9:17:9:24 | call to source() | try.swift:9:13:9:24 | try ... | result |
+| try.swift:15:12:15:24 | try! ... | try.swift:15:17:15:24 | call to source() | try.swift:15:12:15:24 | try! ... | result |
+| try.swift:18:12:18:27 | ...! | try.swift:18:18:18:25 | call to source() | try.swift:18:12:18:27 | ...! | result |

--- a/swift/ql/test/query-tests/Security/CWE-311/CleartextStorageDatabase.expected
+++ b/swift/ql/test/query-tests/Security/CWE-311/CleartextStorageDatabase.expected
@@ -1,561 +1,561 @@
 edges
-| file://:0:0:0:0 | self [value] :  | file://:0:0:0:0 | .value :  |
-| file://:0:0:0:0 | value :  | file://:0:0:0:0 | [post] self [data] :  |
-| file://:0:0:0:0 | value :  | file://:0:0:0:0 | [post] self [notStoredBankAccountNumber] :  |
-| file://:0:0:0:0 | value :  | file://:0:0:0:0 | [post] self [password] :  |
-| file://:0:0:0:0 | value :  | file://:0:0:0:0 | [post] self [value] :  |
-| testCoreData2.swift:23:13:23:13 | value :  | file://:0:0:0:0 | value :  |
-| testCoreData2.swift:37:2:37:2 | [post] obj [myValue] :  | testCoreData2.swift:37:2:37:2 | [post] obj |
-| testCoreData2.swift:37:16:37:16 | bankAccountNo :  | testCoreData2.swift:37:2:37:2 | [post] obj [myValue] :  |
-| testCoreData2.swift:39:2:39:2 | [post] obj [myBankAccountNumber] :  | testCoreData2.swift:39:2:39:2 | [post] obj |
-| testCoreData2.swift:39:28:39:28 | bankAccountNo :  | testCoreData2.swift:39:2:39:2 | [post] obj [myBankAccountNumber] :  |
-| testCoreData2.swift:41:2:41:2 | [post] obj [myBankAccountNumber2] :  | testCoreData2.swift:41:2:41:2 | [post] obj |
-| testCoreData2.swift:41:29:41:29 | bankAccountNo :  | testCoreData2.swift:41:2:41:2 | [post] obj [myBankAccountNumber2] :  |
-| testCoreData2.swift:43:2:43:2 | [post] obj [notStoredBankAccountNumber] :  | testCoreData2.swift:43:2:43:2 | [post] obj |
-| testCoreData2.swift:43:35:43:35 | bankAccountNo :  | testCoreData2.swift:23:13:23:13 | value :  |
-| testCoreData2.swift:43:35:43:35 | bankAccountNo :  | testCoreData2.swift:43:2:43:2 | [post] obj [notStoredBankAccountNumber] :  |
-| testCoreData2.swift:46:2:46:10 | [post] ...? [myValue] :  | testCoreData2.swift:46:2:46:10 | [post] ...? |
-| testCoreData2.swift:46:22:46:22 | bankAccountNo :  | testCoreData2.swift:46:2:46:10 | [post] ...? [myValue] :  |
-| testCoreData2.swift:48:2:48:10 | [post] ...? [myBankAccountNumber] :  | testCoreData2.swift:48:2:48:10 | [post] ...? |
-| testCoreData2.swift:48:34:48:34 | bankAccountNo :  | testCoreData2.swift:48:2:48:10 | [post] ...? [myBankAccountNumber] :  |
-| testCoreData2.swift:50:2:50:10 | [post] ...? [myBankAccountNumber2] :  | testCoreData2.swift:50:2:50:10 | [post] ...? |
-| testCoreData2.swift:50:35:50:35 | bankAccountNo :  | testCoreData2.swift:50:2:50:10 | [post] ...? [myBankAccountNumber2] :  |
-| testCoreData2.swift:52:2:52:10 | [post] ...? [notStoredBankAccountNumber] :  | testCoreData2.swift:52:2:52:10 | [post] ...? |
-| testCoreData2.swift:52:41:52:41 | bankAccountNo :  | testCoreData2.swift:23:13:23:13 | value :  |
-| testCoreData2.swift:52:41:52:41 | bankAccountNo :  | testCoreData2.swift:52:2:52:10 | [post] ...? [notStoredBankAccountNumber] :  |
-| testCoreData2.swift:57:3:57:3 | [post] obj [myBankAccountNumber] :  | testCoreData2.swift:57:3:57:3 | [post] obj |
-| testCoreData2.swift:57:29:57:29 | bankAccountNo :  | testCoreData2.swift:57:3:57:3 | [post] obj [myBankAccountNumber] :  |
-| testCoreData2.swift:60:4:60:4 | [post] obj [myBankAccountNumber] :  | testCoreData2.swift:60:4:60:4 | [post] obj |
-| testCoreData2.swift:60:30:60:30 | bankAccountNo :  | testCoreData2.swift:60:4:60:4 | [post] obj [myBankAccountNumber] :  |
-| testCoreData2.swift:62:4:62:4 | [post] obj [myBankAccountNumber] :  | testCoreData2.swift:62:4:62:4 | [post] obj |
-| testCoreData2.swift:62:30:62:30 | bankAccountNo :  | testCoreData2.swift:62:4:62:4 | [post] obj [myBankAccountNumber] :  |
-| testCoreData2.swift:65:3:65:3 | [post] obj [myBankAccountNumber] :  | testCoreData2.swift:65:3:65:3 | [post] obj |
-| testCoreData2.swift:65:29:65:29 | bankAccountNo :  | testCoreData2.swift:65:3:65:3 | [post] obj [myBankAccountNumber] :  |
-| testCoreData2.swift:70:9:70:9 | self :  | file://:0:0:0:0 | .value :  |
-| testCoreData2.swift:70:9:70:9 | self [value] :  | file://:0:0:0:0 | self [value] :  |
-| testCoreData2.swift:70:9:70:9 | value :  | file://:0:0:0:0 | value :  |
-| testCoreData2.swift:71:9:71:9 | self :  | file://:0:0:0:0 | .value2 :  |
-| testCoreData2.swift:79:2:79:2 | [post] dbObj [myValue] :  | testCoreData2.swift:79:2:79:2 | [post] dbObj |
-| testCoreData2.swift:79:18:79:28 | .bankAccountNo :  | testCoreData2.swift:79:2:79:2 | [post] dbObj [myValue] :  |
-| testCoreData2.swift:80:2:80:2 | [post] dbObj [myValue] :  | testCoreData2.swift:80:2:80:2 | [post] dbObj |
-| testCoreData2.swift:80:18:80:28 | ...! :  | testCoreData2.swift:80:2:80:2 | [post] dbObj [myValue] :  |
-| testCoreData2.swift:80:18:80:28 | .bankAccountNo2 :  | testCoreData2.swift:80:18:80:28 | ...! :  |
-| testCoreData2.swift:82:2:82:2 | [post] dbObj [myValue] :  | testCoreData2.swift:82:2:82:2 | [post] dbObj |
-| testCoreData2.swift:82:18:82:18 | bankAccountNo :  | testCoreData2.swift:70:9:70:9 | self :  |
-| testCoreData2.swift:82:18:82:18 | bankAccountNo :  | testCoreData2.swift:82:18:82:32 | .value :  |
-| testCoreData2.swift:82:18:82:32 | .value :  | testCoreData2.swift:82:2:82:2 | [post] dbObj [myValue] :  |
-| testCoreData2.swift:83:2:83:2 | [post] dbObj [myValue] :  | testCoreData2.swift:83:2:83:2 | [post] dbObj |
-| testCoreData2.swift:83:18:83:18 | bankAccountNo :  | testCoreData2.swift:71:9:71:9 | self :  |
-| testCoreData2.swift:83:18:83:18 | bankAccountNo :  | testCoreData2.swift:83:18:83:32 | ...! :  |
-| testCoreData2.swift:83:18:83:18 | bankAccountNo :  | testCoreData2.swift:83:18:83:32 | .value2 :  |
-| testCoreData2.swift:83:18:83:32 | ...! :  | testCoreData2.swift:83:2:83:2 | [post] dbObj [myValue] :  |
-| testCoreData2.swift:83:18:83:32 | .value2 :  | testCoreData2.swift:83:18:83:32 | ...! :  |
-| testCoreData2.swift:84:2:84:2 | [post] dbObj [myValue] :  | testCoreData2.swift:84:2:84:2 | [post] dbObj |
-| testCoreData2.swift:84:18:84:18 | ...! :  | testCoreData2.swift:70:9:70:9 | self :  |
-| testCoreData2.swift:84:18:84:18 | ...! :  | testCoreData2.swift:84:18:84:33 | .value :  |
-| testCoreData2.swift:84:18:84:18 | bankAccountNo2 :  | testCoreData2.swift:84:18:84:18 | ...! :  |
-| testCoreData2.swift:84:18:84:18 | bankAccountNo2 :  | testCoreData2.swift:84:18:84:33 | .value :  |
-| testCoreData2.swift:84:18:84:33 | .value :  | testCoreData2.swift:84:2:84:2 | [post] dbObj [myValue] :  |
-| testCoreData2.swift:85:2:85:2 | [post] dbObj [myValue] :  | testCoreData2.swift:85:2:85:2 | [post] dbObj |
-| testCoreData2.swift:85:18:85:18 | ...! :  | testCoreData2.swift:71:9:71:9 | self :  |
-| testCoreData2.swift:85:18:85:18 | ...! :  | testCoreData2.swift:85:18:85:33 | .value2 :  |
-| testCoreData2.swift:85:18:85:18 | bankAccountNo2 :  | testCoreData2.swift:85:18:85:18 | ...! :  |
-| testCoreData2.swift:85:18:85:18 | bankAccountNo2 :  | testCoreData2.swift:85:18:85:33 | ...! :  |
-| testCoreData2.swift:85:18:85:33 | ...! :  | testCoreData2.swift:85:2:85:2 | [post] dbObj [myValue] :  |
-| testCoreData2.swift:85:18:85:33 | .value2 :  | testCoreData2.swift:85:18:85:33 | ...! :  |
-| testCoreData2.swift:87:2:87:10 | [post] ...? [myValue] :  | testCoreData2.swift:87:2:87:10 | [post] ...? |
-| testCoreData2.swift:87:22:87:32 | .bankAccountNo :  | testCoreData2.swift:87:2:87:10 | [post] ...? [myValue] :  |
-| testCoreData2.swift:88:2:88:10 | [post] ...? [myValue] :  | testCoreData2.swift:88:2:88:10 | [post] ...? |
-| testCoreData2.swift:88:22:88:22 | bankAccountNo :  | testCoreData2.swift:70:9:70:9 | self :  |
-| testCoreData2.swift:88:22:88:22 | bankAccountNo :  | testCoreData2.swift:88:22:88:36 | .value :  |
-| testCoreData2.swift:88:22:88:36 | .value :  | testCoreData2.swift:88:2:88:10 | [post] ...? [myValue] :  |
-| testCoreData2.swift:89:2:89:10 | [post] ...? [myValue] :  | testCoreData2.swift:89:2:89:10 | [post] ...? |
-| testCoreData2.swift:89:22:89:22 | ...! :  | testCoreData2.swift:71:9:71:9 | self :  |
-| testCoreData2.swift:89:22:89:22 | ...! :  | testCoreData2.swift:89:22:89:37 | .value2 :  |
-| testCoreData2.swift:89:22:89:22 | bankAccountNo2 :  | testCoreData2.swift:89:22:89:22 | ...! :  |
-| testCoreData2.swift:89:22:89:22 | bankAccountNo2 :  | testCoreData2.swift:89:22:89:37 | ...! :  |
-| testCoreData2.swift:89:22:89:37 | ...! :  | testCoreData2.swift:89:2:89:10 | [post] ...? [myValue] :  |
-| testCoreData2.swift:89:22:89:37 | .value2 :  | testCoreData2.swift:89:22:89:37 | ...! :  |
-| testCoreData2.swift:91:10:91:10 | bankAccountNo :  | testCoreData2.swift:92:10:92:10 | a :  |
-| testCoreData2.swift:91:10:91:10 | bankAccountNo :  | testCoreData2.swift:93:18:93:18 | b :  |
-| testCoreData2.swift:92:10:92:10 | a :  | testCoreData2.swift:70:9:70:9 | self :  |
-| testCoreData2.swift:92:10:92:10 | a :  | testCoreData2.swift:92:10:92:12 | .value :  |
-| testCoreData2.swift:92:10:92:12 | .value :  | testCoreData2.swift:93:18:93:18 | b :  |
-| testCoreData2.swift:93:2:93:2 | [post] dbObj [myValue] :  | testCoreData2.swift:93:2:93:2 | [post] dbObj |
-| testCoreData2.swift:93:18:93:18 | b :  | testCoreData2.swift:93:2:93:2 | [post] dbObj [myValue] :  |
-| testCoreData2.swift:95:10:95:10 | bankAccountNo :  | testCoreData2.swift:97:12:97:12 | c :  |
-| testCoreData2.swift:95:10:95:10 | bankAccountNo :  | testCoreData2.swift:97:12:97:14 | .value :  |
-| testCoreData2.swift:97:2:97:2 | [post] d [value] :  | testCoreData2.swift:98:18:98:18 | d [value] :  |
-| testCoreData2.swift:97:12:97:12 | c :  | testCoreData2.swift:70:9:70:9 | self :  |
-| testCoreData2.swift:97:12:97:12 | c :  | testCoreData2.swift:97:12:97:14 | .value :  |
-| testCoreData2.swift:97:12:97:14 | .value :  | testCoreData2.swift:70:9:70:9 | value :  |
-| testCoreData2.swift:97:12:97:14 | .value :  | testCoreData2.swift:97:2:97:2 | [post] d [value] :  |
-| testCoreData2.swift:98:2:98:2 | [post] dbObj [myValue] :  | testCoreData2.swift:98:2:98:2 | [post] dbObj |
-| testCoreData2.swift:98:18:98:18 | d [value] :  | testCoreData2.swift:70:9:70:9 | self [value] :  |
-| testCoreData2.swift:98:18:98:18 | d [value] :  | testCoreData2.swift:98:18:98:20 | .value :  |
-| testCoreData2.swift:98:18:98:20 | .value :  | testCoreData2.swift:98:2:98:2 | [post] dbObj [myValue] :  |
-| testCoreData2.swift:101:10:101:10 | bankAccountNo :  | testCoreData2.swift:104:18:104:18 | e :  |
-| testCoreData2.swift:101:10:101:10 | bankAccountNo :  | testCoreData2.swift:104:18:104:20 | .value :  |
-| testCoreData2.swift:101:10:101:10 | bankAccountNo :  | testCoreData2.swift:105:18:105:18 | e :  |
-| testCoreData2.swift:101:10:101:10 | bankAccountNo :  | testCoreData2.swift:105:18:105:20 | ...! :  |
-| testCoreData2.swift:104:2:104:2 | [post] dbObj [myValue] :  | testCoreData2.swift:104:2:104:2 | [post] dbObj |
-| testCoreData2.swift:104:18:104:18 | e :  | testCoreData2.swift:70:9:70:9 | self :  |
-| testCoreData2.swift:104:18:104:18 | e :  | testCoreData2.swift:104:18:104:20 | .value :  |
-| testCoreData2.swift:104:18:104:20 | .value :  | testCoreData2.swift:104:2:104:2 | [post] dbObj [myValue] :  |
-| testCoreData2.swift:105:2:105:2 | [post] dbObj [myValue] :  | testCoreData2.swift:105:2:105:2 | [post] dbObj |
-| testCoreData2.swift:105:18:105:18 | e :  | testCoreData2.swift:71:9:71:9 | self :  |
-| testCoreData2.swift:105:18:105:18 | e :  | testCoreData2.swift:105:18:105:20 | .value2 :  |
-| testCoreData2.swift:105:18:105:20 | ...! :  | testCoreData2.swift:105:2:105:2 | [post] dbObj [myValue] :  |
-| testCoreData2.swift:105:18:105:20 | .value2 :  | testCoreData2.swift:105:18:105:20 | ...! :  |
-| testCoreData.swift:18:19:18:26 | value :  | testCoreData.swift:19:12:19:12 | value |
-| testCoreData.swift:31:3:31:3 | newValue :  | testCoreData.swift:32:13:32:13 | newValue |
-| testCoreData.swift:61:25:61:25 | password :  | testCoreData.swift:18:19:18:26 | value :  |
-| testCoreData.swift:64:2:64:2 | [post] obj [myValue] :  | testCoreData.swift:64:2:64:2 | [post] obj |
-| testCoreData.swift:64:16:64:16 | password :  | testCoreData.swift:31:3:31:3 | newValue :  |
-| testCoreData.swift:64:16:64:16 | password :  | testCoreData.swift:64:2:64:2 | [post] obj [myValue] :  |
-| testCoreData.swift:77:24:77:24 | x :  | testCoreData.swift:78:15:78:15 | x |
-| testCoreData.swift:80:10:80:22 | call to getPassword() :  | testCoreData.swift:81:15:81:15 | y |
-| testCoreData.swift:91:10:91:10 | passwd :  | testCoreData.swift:95:15:95:15 | x |
-| testCoreData.swift:92:10:92:10 | passwd :  | testCoreData.swift:96:15:96:15 | y |
-| testCoreData.swift:93:10:93:10 | passwd :  | testCoreData.swift:97:15:97:15 | z |
-| testGRDB.swift:73:57:73:57 | password :  | testGRDB.swift:73:56:73:65 | [...] |
-| testGRDB.swift:76:43:76:43 | password :  | testGRDB.swift:76:42:76:51 | [...] |
-| testGRDB.swift:81:45:81:45 | password :  | testGRDB.swift:81:44:81:53 | [...] |
-| testGRDB.swift:83:45:83:45 | password :  | testGRDB.swift:83:44:83:53 | [...] |
-| testGRDB.swift:85:45:85:45 | password :  | testGRDB.swift:85:44:85:53 | [...] |
-| testGRDB.swift:87:45:87:45 | password :  | testGRDB.swift:87:44:87:53 | [...] |
-| testGRDB.swift:92:38:92:38 | password :  | testGRDB.swift:92:37:92:46 | [...] |
-| testGRDB.swift:95:37:95:37 | password :  | testGRDB.swift:95:36:95:45 | [...] |
-| testGRDB.swift:100:73:100:73 | password :  | testGRDB.swift:100:72:100:81 | [...] |
-| testGRDB.swift:101:73:101:73 | password :  | testGRDB.swift:101:72:101:81 | [...] |
-| testGRDB.swift:107:53:107:53 | password :  | testGRDB.swift:107:52:107:61 | [...] |
-| testGRDB.swift:109:53:109:53 | password :  | testGRDB.swift:109:52:109:61 | [...] |
-| testGRDB.swift:111:52:111:52 | password :  | testGRDB.swift:111:51:111:60 | [...] |
-| testGRDB.swift:116:48:116:48 | password :  | testGRDB.swift:116:47:116:56 | [...] |
-| testGRDB.swift:118:48:118:48 | password :  | testGRDB.swift:118:47:118:56 | [...] |
-| testGRDB.swift:121:45:121:45 | password :  | testGRDB.swift:121:44:121:53 | [...] |
-| testGRDB.swift:123:45:123:45 | password :  | testGRDB.swift:123:44:123:53 | [...] |
-| testGRDB.swift:126:45:126:45 | password :  | testGRDB.swift:126:44:126:53 | [...] |
-| testGRDB.swift:128:45:128:45 | password :  | testGRDB.swift:128:44:128:53 | [...] |
-| testGRDB.swift:131:45:131:45 | password :  | testGRDB.swift:131:44:131:53 | [...] |
-| testGRDB.swift:133:45:133:45 | password :  | testGRDB.swift:133:44:133:53 | [...] |
-| testGRDB.swift:138:69:138:69 | password :  | testGRDB.swift:138:68:138:77 | [...] |
-| testGRDB.swift:140:69:140:69 | password :  | testGRDB.swift:140:68:140:77 | [...] |
-| testGRDB.swift:143:66:143:66 | password :  | testGRDB.swift:143:65:143:74 | [...] |
-| testGRDB.swift:145:66:145:66 | password :  | testGRDB.swift:145:65:145:74 | [...] |
-| testGRDB.swift:148:66:148:66 | password :  | testGRDB.swift:148:65:148:74 | [...] |
-| testGRDB.swift:150:66:150:66 | password :  | testGRDB.swift:150:65:150:74 | [...] |
-| testGRDB.swift:153:66:153:66 | password :  | testGRDB.swift:153:65:153:74 | [...] |
-| testGRDB.swift:155:66:155:66 | password :  | testGRDB.swift:155:65:155:74 | [...] |
-| testGRDB.swift:160:60:160:60 | password :  | testGRDB.swift:160:59:160:68 | [...] |
-| testGRDB.swift:161:51:161:51 | password :  | testGRDB.swift:161:50:161:59 | [...] |
-| testGRDB.swift:164:60:164:60 | password :  | testGRDB.swift:164:59:164:68 | [...] |
-| testGRDB.swift:165:51:165:51 | password :  | testGRDB.swift:165:50:165:59 | [...] |
-| testGRDB.swift:169:57:169:57 | password :  | testGRDB.swift:169:56:169:65 | [...] |
-| testGRDB.swift:170:48:170:48 | password :  | testGRDB.swift:170:47:170:56 | [...] |
-| testGRDB.swift:173:57:173:57 | password :  | testGRDB.swift:173:56:173:65 | [...] |
-| testGRDB.swift:174:48:174:48 | password :  | testGRDB.swift:174:47:174:56 | [...] |
-| testGRDB.swift:178:57:178:57 | password :  | testGRDB.swift:178:56:178:65 | [...] |
-| testGRDB.swift:179:48:179:48 | password :  | testGRDB.swift:179:47:179:56 | [...] |
-| testGRDB.swift:182:57:182:57 | password :  | testGRDB.swift:182:56:182:65 | [...] |
-| testGRDB.swift:183:48:183:48 | password :  | testGRDB.swift:183:47:183:56 | [...] |
-| testGRDB.swift:187:57:187:57 | password :  | testGRDB.swift:187:56:187:65 | [...] |
-| testGRDB.swift:188:48:188:48 | password :  | testGRDB.swift:188:47:188:56 | [...] |
-| testGRDB.swift:191:57:191:57 | password :  | testGRDB.swift:191:56:191:65 | [...] |
-| testGRDB.swift:192:48:192:48 | password :  | testGRDB.swift:192:47:192:56 | [...] |
-| testGRDB.swift:198:30:198:30 | password :  | testGRDB.swift:198:29:198:38 | [...] |
-| testGRDB.swift:201:24:201:24 | password :  | testGRDB.swift:201:23:201:32 | [...] |
-| testGRDB.swift:206:67:206:67 | password :  | testGRDB.swift:206:66:206:75 | [...] |
-| testGRDB.swift:208:81:208:81 | password :  | testGRDB.swift:208:80:208:89 | [...] |
-| testGRDB.swift:210:85:210:85 | password :  | testGRDB.swift:210:84:210:93 | [...] |
-| testGRDB.swift:212:99:212:99 | password :  | testGRDB.swift:212:98:212:107 | [...] |
-| testRealm.swift:27:6:27:6 | value :  | file://:0:0:0:0 | value :  |
-| testRealm.swift:34:6:34:6 | value :  | file://:0:0:0:0 | value :  |
-| testRealm.swift:41:2:41:2 | [post] a [data] :  | testRealm.swift:41:2:41:2 | [post] a |
-| testRealm.swift:41:11:41:11 | myPassword :  | testRealm.swift:27:6:27:6 | value :  |
-| testRealm.swift:41:11:41:11 | myPassword :  | testRealm.swift:41:2:41:2 | [post] a [data] :  |
-| testRealm.swift:49:2:49:2 | [post] c [data] :  | testRealm.swift:49:2:49:2 | [post] c |
-| testRealm.swift:49:11:49:11 | myPassword :  | testRealm.swift:27:6:27:6 | value :  |
-| testRealm.swift:49:11:49:11 | myPassword :  | testRealm.swift:49:2:49:2 | [post] c [data] :  |
-| testRealm.swift:59:2:59:3 | [post] ...! [data] :  | testRealm.swift:59:2:59:3 | [post] ...! |
-| testRealm.swift:59:12:59:12 | myPassword :  | testRealm.swift:27:6:27:6 | value :  |
-| testRealm.swift:59:12:59:12 | myPassword :  | testRealm.swift:59:2:59:3 | [post] ...! [data] :  |
-| testRealm.swift:66:2:66:2 | [post] g [data] :  | testRealm.swift:66:2:66:2 | [post] g |
-| testRealm.swift:66:11:66:11 | myPassword :  | testRealm.swift:27:6:27:6 | value :  |
-| testRealm.swift:66:11:66:11 | myPassword :  | testRealm.swift:66:2:66:2 | [post] g [data] :  |
-| testRealm.swift:73:2:73:2 | [post] h [password] :  | testRealm.swift:73:2:73:2 | [post] h |
-| testRealm.swift:73:15:73:15 | myPassword :  | testRealm.swift:34:6:34:6 | value :  |
-| testRealm.swift:73:15:73:15 | myPassword :  | testRealm.swift:73:2:73:2 | [post] h [password] :  |
+| file://:0:0:0:0 | self [value] | file://:0:0:0:0 | .value |
+| file://:0:0:0:0 | value | file://:0:0:0:0 | [post] self [data] |
+| file://:0:0:0:0 | value | file://:0:0:0:0 | [post] self [notStoredBankAccountNumber] |
+| file://:0:0:0:0 | value | file://:0:0:0:0 | [post] self [password] |
+| file://:0:0:0:0 | value | file://:0:0:0:0 | [post] self [value] |
+| testCoreData2.swift:23:13:23:13 | value | file://:0:0:0:0 | value |
+| testCoreData2.swift:37:2:37:2 | [post] obj [myValue] | testCoreData2.swift:37:2:37:2 | [post] obj |
+| testCoreData2.swift:37:16:37:16 | bankAccountNo | testCoreData2.swift:37:2:37:2 | [post] obj [myValue] |
+| testCoreData2.swift:39:2:39:2 | [post] obj [myBankAccountNumber] | testCoreData2.swift:39:2:39:2 | [post] obj |
+| testCoreData2.swift:39:28:39:28 | bankAccountNo | testCoreData2.swift:39:2:39:2 | [post] obj [myBankAccountNumber] |
+| testCoreData2.swift:41:2:41:2 | [post] obj [myBankAccountNumber2] | testCoreData2.swift:41:2:41:2 | [post] obj |
+| testCoreData2.swift:41:29:41:29 | bankAccountNo | testCoreData2.swift:41:2:41:2 | [post] obj [myBankAccountNumber2] |
+| testCoreData2.swift:43:2:43:2 | [post] obj [notStoredBankAccountNumber] | testCoreData2.swift:43:2:43:2 | [post] obj |
+| testCoreData2.swift:43:35:43:35 | bankAccountNo | testCoreData2.swift:23:13:23:13 | value |
+| testCoreData2.swift:43:35:43:35 | bankAccountNo | testCoreData2.swift:43:2:43:2 | [post] obj [notStoredBankAccountNumber] |
+| testCoreData2.swift:46:2:46:10 | [post] ...? [myValue] | testCoreData2.swift:46:2:46:10 | [post] ...? |
+| testCoreData2.swift:46:22:46:22 | bankAccountNo | testCoreData2.swift:46:2:46:10 | [post] ...? [myValue] |
+| testCoreData2.swift:48:2:48:10 | [post] ...? [myBankAccountNumber] | testCoreData2.swift:48:2:48:10 | [post] ...? |
+| testCoreData2.swift:48:34:48:34 | bankAccountNo | testCoreData2.swift:48:2:48:10 | [post] ...? [myBankAccountNumber] |
+| testCoreData2.swift:50:2:50:10 | [post] ...? [myBankAccountNumber2] | testCoreData2.swift:50:2:50:10 | [post] ...? |
+| testCoreData2.swift:50:35:50:35 | bankAccountNo | testCoreData2.swift:50:2:50:10 | [post] ...? [myBankAccountNumber2] |
+| testCoreData2.swift:52:2:52:10 | [post] ...? [notStoredBankAccountNumber] | testCoreData2.swift:52:2:52:10 | [post] ...? |
+| testCoreData2.swift:52:41:52:41 | bankAccountNo | testCoreData2.swift:23:13:23:13 | value |
+| testCoreData2.swift:52:41:52:41 | bankAccountNo | testCoreData2.swift:52:2:52:10 | [post] ...? [notStoredBankAccountNumber] |
+| testCoreData2.swift:57:3:57:3 | [post] obj [myBankAccountNumber] | testCoreData2.swift:57:3:57:3 | [post] obj |
+| testCoreData2.swift:57:29:57:29 | bankAccountNo | testCoreData2.swift:57:3:57:3 | [post] obj [myBankAccountNumber] |
+| testCoreData2.swift:60:4:60:4 | [post] obj [myBankAccountNumber] | testCoreData2.swift:60:4:60:4 | [post] obj |
+| testCoreData2.swift:60:30:60:30 | bankAccountNo | testCoreData2.swift:60:4:60:4 | [post] obj [myBankAccountNumber] |
+| testCoreData2.swift:62:4:62:4 | [post] obj [myBankAccountNumber] | testCoreData2.swift:62:4:62:4 | [post] obj |
+| testCoreData2.swift:62:30:62:30 | bankAccountNo | testCoreData2.swift:62:4:62:4 | [post] obj [myBankAccountNumber] |
+| testCoreData2.swift:65:3:65:3 | [post] obj [myBankAccountNumber] | testCoreData2.swift:65:3:65:3 | [post] obj |
+| testCoreData2.swift:65:29:65:29 | bankAccountNo | testCoreData2.swift:65:3:65:3 | [post] obj [myBankAccountNumber] |
+| testCoreData2.swift:70:9:70:9 | self | file://:0:0:0:0 | .value |
+| testCoreData2.swift:70:9:70:9 | self [value] | file://:0:0:0:0 | self [value] |
+| testCoreData2.swift:70:9:70:9 | value | file://:0:0:0:0 | value |
+| testCoreData2.swift:71:9:71:9 | self | file://:0:0:0:0 | .value2 |
+| testCoreData2.swift:79:2:79:2 | [post] dbObj [myValue] | testCoreData2.swift:79:2:79:2 | [post] dbObj |
+| testCoreData2.swift:79:18:79:28 | .bankAccountNo | testCoreData2.swift:79:2:79:2 | [post] dbObj [myValue] |
+| testCoreData2.swift:80:2:80:2 | [post] dbObj [myValue] | testCoreData2.swift:80:2:80:2 | [post] dbObj |
+| testCoreData2.swift:80:18:80:28 | ...! | testCoreData2.swift:80:2:80:2 | [post] dbObj [myValue] |
+| testCoreData2.swift:80:18:80:28 | .bankAccountNo2 | testCoreData2.swift:80:18:80:28 | ...! |
+| testCoreData2.swift:82:2:82:2 | [post] dbObj [myValue] | testCoreData2.swift:82:2:82:2 | [post] dbObj |
+| testCoreData2.swift:82:18:82:18 | bankAccountNo | testCoreData2.swift:70:9:70:9 | self |
+| testCoreData2.swift:82:18:82:18 | bankAccountNo | testCoreData2.swift:82:18:82:32 | .value |
+| testCoreData2.swift:82:18:82:32 | .value | testCoreData2.swift:82:2:82:2 | [post] dbObj [myValue] |
+| testCoreData2.swift:83:2:83:2 | [post] dbObj [myValue] | testCoreData2.swift:83:2:83:2 | [post] dbObj |
+| testCoreData2.swift:83:18:83:18 | bankAccountNo | testCoreData2.swift:71:9:71:9 | self |
+| testCoreData2.swift:83:18:83:18 | bankAccountNo | testCoreData2.swift:83:18:83:32 | ...! |
+| testCoreData2.swift:83:18:83:18 | bankAccountNo | testCoreData2.swift:83:18:83:32 | .value2 |
+| testCoreData2.swift:83:18:83:32 | ...! | testCoreData2.swift:83:2:83:2 | [post] dbObj [myValue] |
+| testCoreData2.swift:83:18:83:32 | .value2 | testCoreData2.swift:83:18:83:32 | ...! |
+| testCoreData2.swift:84:2:84:2 | [post] dbObj [myValue] | testCoreData2.swift:84:2:84:2 | [post] dbObj |
+| testCoreData2.swift:84:18:84:18 | ...! | testCoreData2.swift:70:9:70:9 | self |
+| testCoreData2.swift:84:18:84:18 | ...! | testCoreData2.swift:84:18:84:33 | .value |
+| testCoreData2.swift:84:18:84:18 | bankAccountNo2 | testCoreData2.swift:84:18:84:18 | ...! |
+| testCoreData2.swift:84:18:84:18 | bankAccountNo2 | testCoreData2.swift:84:18:84:33 | .value |
+| testCoreData2.swift:84:18:84:33 | .value | testCoreData2.swift:84:2:84:2 | [post] dbObj [myValue] |
+| testCoreData2.swift:85:2:85:2 | [post] dbObj [myValue] | testCoreData2.swift:85:2:85:2 | [post] dbObj |
+| testCoreData2.swift:85:18:85:18 | ...! | testCoreData2.swift:71:9:71:9 | self |
+| testCoreData2.swift:85:18:85:18 | ...! | testCoreData2.swift:85:18:85:33 | .value2 |
+| testCoreData2.swift:85:18:85:18 | bankAccountNo2 | testCoreData2.swift:85:18:85:18 | ...! |
+| testCoreData2.swift:85:18:85:18 | bankAccountNo2 | testCoreData2.swift:85:18:85:33 | ...! |
+| testCoreData2.swift:85:18:85:33 | ...! | testCoreData2.swift:85:2:85:2 | [post] dbObj [myValue] |
+| testCoreData2.swift:85:18:85:33 | .value2 | testCoreData2.swift:85:18:85:33 | ...! |
+| testCoreData2.swift:87:2:87:10 | [post] ...? [myValue] | testCoreData2.swift:87:2:87:10 | [post] ...? |
+| testCoreData2.swift:87:22:87:32 | .bankAccountNo | testCoreData2.swift:87:2:87:10 | [post] ...? [myValue] |
+| testCoreData2.swift:88:2:88:10 | [post] ...? [myValue] | testCoreData2.swift:88:2:88:10 | [post] ...? |
+| testCoreData2.swift:88:22:88:22 | bankAccountNo | testCoreData2.swift:70:9:70:9 | self |
+| testCoreData2.swift:88:22:88:22 | bankAccountNo | testCoreData2.swift:88:22:88:36 | .value |
+| testCoreData2.swift:88:22:88:36 | .value | testCoreData2.swift:88:2:88:10 | [post] ...? [myValue] |
+| testCoreData2.swift:89:2:89:10 | [post] ...? [myValue] | testCoreData2.swift:89:2:89:10 | [post] ...? |
+| testCoreData2.swift:89:22:89:22 | ...! | testCoreData2.swift:71:9:71:9 | self |
+| testCoreData2.swift:89:22:89:22 | ...! | testCoreData2.swift:89:22:89:37 | .value2 |
+| testCoreData2.swift:89:22:89:22 | bankAccountNo2 | testCoreData2.swift:89:22:89:22 | ...! |
+| testCoreData2.swift:89:22:89:22 | bankAccountNo2 | testCoreData2.swift:89:22:89:37 | ...! |
+| testCoreData2.swift:89:22:89:37 | ...! | testCoreData2.swift:89:2:89:10 | [post] ...? [myValue] |
+| testCoreData2.swift:89:22:89:37 | .value2 | testCoreData2.swift:89:22:89:37 | ...! |
+| testCoreData2.swift:91:10:91:10 | bankAccountNo | testCoreData2.swift:92:10:92:10 | a |
+| testCoreData2.swift:91:10:91:10 | bankAccountNo | testCoreData2.swift:93:18:93:18 | b |
+| testCoreData2.swift:92:10:92:10 | a | testCoreData2.swift:70:9:70:9 | self |
+| testCoreData2.swift:92:10:92:10 | a | testCoreData2.swift:92:10:92:12 | .value |
+| testCoreData2.swift:92:10:92:12 | .value | testCoreData2.swift:93:18:93:18 | b |
+| testCoreData2.swift:93:2:93:2 | [post] dbObj [myValue] | testCoreData2.swift:93:2:93:2 | [post] dbObj |
+| testCoreData2.swift:93:18:93:18 | b | testCoreData2.swift:93:2:93:2 | [post] dbObj [myValue] |
+| testCoreData2.swift:95:10:95:10 | bankAccountNo | testCoreData2.swift:97:12:97:12 | c |
+| testCoreData2.swift:95:10:95:10 | bankAccountNo | testCoreData2.swift:97:12:97:14 | .value |
+| testCoreData2.swift:97:2:97:2 | [post] d [value] | testCoreData2.swift:98:18:98:18 | d [value] |
+| testCoreData2.swift:97:12:97:12 | c | testCoreData2.swift:70:9:70:9 | self |
+| testCoreData2.swift:97:12:97:12 | c | testCoreData2.swift:97:12:97:14 | .value |
+| testCoreData2.swift:97:12:97:14 | .value | testCoreData2.swift:70:9:70:9 | value |
+| testCoreData2.swift:97:12:97:14 | .value | testCoreData2.swift:97:2:97:2 | [post] d [value] |
+| testCoreData2.swift:98:2:98:2 | [post] dbObj [myValue] | testCoreData2.swift:98:2:98:2 | [post] dbObj |
+| testCoreData2.swift:98:18:98:18 | d [value] | testCoreData2.swift:70:9:70:9 | self [value] |
+| testCoreData2.swift:98:18:98:18 | d [value] | testCoreData2.swift:98:18:98:20 | .value |
+| testCoreData2.swift:98:18:98:20 | .value | testCoreData2.swift:98:2:98:2 | [post] dbObj [myValue] |
+| testCoreData2.swift:101:10:101:10 | bankAccountNo | testCoreData2.swift:104:18:104:18 | e |
+| testCoreData2.swift:101:10:101:10 | bankAccountNo | testCoreData2.swift:104:18:104:20 | .value |
+| testCoreData2.swift:101:10:101:10 | bankAccountNo | testCoreData2.swift:105:18:105:18 | e |
+| testCoreData2.swift:101:10:101:10 | bankAccountNo | testCoreData2.swift:105:18:105:20 | ...! |
+| testCoreData2.swift:104:2:104:2 | [post] dbObj [myValue] | testCoreData2.swift:104:2:104:2 | [post] dbObj |
+| testCoreData2.swift:104:18:104:18 | e | testCoreData2.swift:70:9:70:9 | self |
+| testCoreData2.swift:104:18:104:18 | e | testCoreData2.swift:104:18:104:20 | .value |
+| testCoreData2.swift:104:18:104:20 | .value | testCoreData2.swift:104:2:104:2 | [post] dbObj [myValue] |
+| testCoreData2.swift:105:2:105:2 | [post] dbObj [myValue] | testCoreData2.swift:105:2:105:2 | [post] dbObj |
+| testCoreData2.swift:105:18:105:18 | e | testCoreData2.swift:71:9:71:9 | self |
+| testCoreData2.swift:105:18:105:18 | e | testCoreData2.swift:105:18:105:20 | .value2 |
+| testCoreData2.swift:105:18:105:20 | ...! | testCoreData2.swift:105:2:105:2 | [post] dbObj [myValue] |
+| testCoreData2.swift:105:18:105:20 | .value2 | testCoreData2.swift:105:18:105:20 | ...! |
+| testCoreData.swift:18:19:18:26 | value | testCoreData.swift:19:12:19:12 | value |
+| testCoreData.swift:31:3:31:3 | newValue | testCoreData.swift:32:13:32:13 | newValue |
+| testCoreData.swift:61:25:61:25 | password | testCoreData.swift:18:19:18:26 | value |
+| testCoreData.swift:64:2:64:2 | [post] obj [myValue] | testCoreData.swift:64:2:64:2 | [post] obj |
+| testCoreData.swift:64:16:64:16 | password | testCoreData.swift:31:3:31:3 | newValue |
+| testCoreData.swift:64:16:64:16 | password | testCoreData.swift:64:2:64:2 | [post] obj [myValue] |
+| testCoreData.swift:77:24:77:24 | x | testCoreData.swift:78:15:78:15 | x |
+| testCoreData.swift:80:10:80:22 | call to getPassword() | testCoreData.swift:81:15:81:15 | y |
+| testCoreData.swift:91:10:91:10 | passwd | testCoreData.swift:95:15:95:15 | x |
+| testCoreData.swift:92:10:92:10 | passwd | testCoreData.swift:96:15:96:15 | y |
+| testCoreData.swift:93:10:93:10 | passwd | testCoreData.swift:97:15:97:15 | z |
+| testGRDB.swift:73:57:73:57 | password | testGRDB.swift:73:56:73:65 | [...] |
+| testGRDB.swift:76:43:76:43 | password | testGRDB.swift:76:42:76:51 | [...] |
+| testGRDB.swift:81:45:81:45 | password | testGRDB.swift:81:44:81:53 | [...] |
+| testGRDB.swift:83:45:83:45 | password | testGRDB.swift:83:44:83:53 | [...] |
+| testGRDB.swift:85:45:85:45 | password | testGRDB.swift:85:44:85:53 | [...] |
+| testGRDB.swift:87:45:87:45 | password | testGRDB.swift:87:44:87:53 | [...] |
+| testGRDB.swift:92:38:92:38 | password | testGRDB.swift:92:37:92:46 | [...] |
+| testGRDB.swift:95:37:95:37 | password | testGRDB.swift:95:36:95:45 | [...] |
+| testGRDB.swift:100:73:100:73 | password | testGRDB.swift:100:72:100:81 | [...] |
+| testGRDB.swift:101:73:101:73 | password | testGRDB.swift:101:72:101:81 | [...] |
+| testGRDB.swift:107:53:107:53 | password | testGRDB.swift:107:52:107:61 | [...] |
+| testGRDB.swift:109:53:109:53 | password | testGRDB.swift:109:52:109:61 | [...] |
+| testGRDB.swift:111:52:111:52 | password | testGRDB.swift:111:51:111:60 | [...] |
+| testGRDB.swift:116:48:116:48 | password | testGRDB.swift:116:47:116:56 | [...] |
+| testGRDB.swift:118:48:118:48 | password | testGRDB.swift:118:47:118:56 | [...] |
+| testGRDB.swift:121:45:121:45 | password | testGRDB.swift:121:44:121:53 | [...] |
+| testGRDB.swift:123:45:123:45 | password | testGRDB.swift:123:44:123:53 | [...] |
+| testGRDB.swift:126:45:126:45 | password | testGRDB.swift:126:44:126:53 | [...] |
+| testGRDB.swift:128:45:128:45 | password | testGRDB.swift:128:44:128:53 | [...] |
+| testGRDB.swift:131:45:131:45 | password | testGRDB.swift:131:44:131:53 | [...] |
+| testGRDB.swift:133:45:133:45 | password | testGRDB.swift:133:44:133:53 | [...] |
+| testGRDB.swift:138:69:138:69 | password | testGRDB.swift:138:68:138:77 | [...] |
+| testGRDB.swift:140:69:140:69 | password | testGRDB.swift:140:68:140:77 | [...] |
+| testGRDB.swift:143:66:143:66 | password | testGRDB.swift:143:65:143:74 | [...] |
+| testGRDB.swift:145:66:145:66 | password | testGRDB.swift:145:65:145:74 | [...] |
+| testGRDB.swift:148:66:148:66 | password | testGRDB.swift:148:65:148:74 | [...] |
+| testGRDB.swift:150:66:150:66 | password | testGRDB.swift:150:65:150:74 | [...] |
+| testGRDB.swift:153:66:153:66 | password | testGRDB.swift:153:65:153:74 | [...] |
+| testGRDB.swift:155:66:155:66 | password | testGRDB.swift:155:65:155:74 | [...] |
+| testGRDB.swift:160:60:160:60 | password | testGRDB.swift:160:59:160:68 | [...] |
+| testGRDB.swift:161:51:161:51 | password | testGRDB.swift:161:50:161:59 | [...] |
+| testGRDB.swift:164:60:164:60 | password | testGRDB.swift:164:59:164:68 | [...] |
+| testGRDB.swift:165:51:165:51 | password | testGRDB.swift:165:50:165:59 | [...] |
+| testGRDB.swift:169:57:169:57 | password | testGRDB.swift:169:56:169:65 | [...] |
+| testGRDB.swift:170:48:170:48 | password | testGRDB.swift:170:47:170:56 | [...] |
+| testGRDB.swift:173:57:173:57 | password | testGRDB.swift:173:56:173:65 | [...] |
+| testGRDB.swift:174:48:174:48 | password | testGRDB.swift:174:47:174:56 | [...] |
+| testGRDB.swift:178:57:178:57 | password | testGRDB.swift:178:56:178:65 | [...] |
+| testGRDB.swift:179:48:179:48 | password | testGRDB.swift:179:47:179:56 | [...] |
+| testGRDB.swift:182:57:182:57 | password | testGRDB.swift:182:56:182:65 | [...] |
+| testGRDB.swift:183:48:183:48 | password | testGRDB.swift:183:47:183:56 | [...] |
+| testGRDB.swift:187:57:187:57 | password | testGRDB.swift:187:56:187:65 | [...] |
+| testGRDB.swift:188:48:188:48 | password | testGRDB.swift:188:47:188:56 | [...] |
+| testGRDB.swift:191:57:191:57 | password | testGRDB.swift:191:56:191:65 | [...] |
+| testGRDB.swift:192:48:192:48 | password | testGRDB.swift:192:47:192:56 | [...] |
+| testGRDB.swift:198:30:198:30 | password | testGRDB.swift:198:29:198:38 | [...] |
+| testGRDB.swift:201:24:201:24 | password | testGRDB.swift:201:23:201:32 | [...] |
+| testGRDB.swift:206:67:206:67 | password | testGRDB.swift:206:66:206:75 | [...] |
+| testGRDB.swift:208:81:208:81 | password | testGRDB.swift:208:80:208:89 | [...] |
+| testGRDB.swift:210:85:210:85 | password | testGRDB.swift:210:84:210:93 | [...] |
+| testGRDB.swift:212:99:212:99 | password | testGRDB.swift:212:98:212:107 | [...] |
+| testRealm.swift:27:6:27:6 | value | file://:0:0:0:0 | value |
+| testRealm.swift:34:6:34:6 | value | file://:0:0:0:0 | value |
+| testRealm.swift:41:2:41:2 | [post] a [data] | testRealm.swift:41:2:41:2 | [post] a |
+| testRealm.swift:41:11:41:11 | myPassword | testRealm.swift:27:6:27:6 | value |
+| testRealm.swift:41:11:41:11 | myPassword | testRealm.swift:41:2:41:2 | [post] a [data] |
+| testRealm.swift:49:2:49:2 | [post] c [data] | testRealm.swift:49:2:49:2 | [post] c |
+| testRealm.swift:49:11:49:11 | myPassword | testRealm.swift:27:6:27:6 | value |
+| testRealm.swift:49:11:49:11 | myPassword | testRealm.swift:49:2:49:2 | [post] c [data] |
+| testRealm.swift:59:2:59:3 | [post] ...! [data] | testRealm.swift:59:2:59:3 | [post] ...! |
+| testRealm.swift:59:12:59:12 | myPassword | testRealm.swift:27:6:27:6 | value |
+| testRealm.swift:59:12:59:12 | myPassword | testRealm.swift:59:2:59:3 | [post] ...! [data] |
+| testRealm.swift:66:2:66:2 | [post] g [data] | testRealm.swift:66:2:66:2 | [post] g |
+| testRealm.swift:66:11:66:11 | myPassword | testRealm.swift:27:6:27:6 | value |
+| testRealm.swift:66:11:66:11 | myPassword | testRealm.swift:66:2:66:2 | [post] g [data] |
+| testRealm.swift:73:2:73:2 | [post] h [password] | testRealm.swift:73:2:73:2 | [post] h |
+| testRealm.swift:73:15:73:15 | myPassword | testRealm.swift:34:6:34:6 | value |
+| testRealm.swift:73:15:73:15 | myPassword | testRealm.swift:73:2:73:2 | [post] h [password] |
 nodes
-| file://:0:0:0:0 | .value2 :  | semmle.label | .value2 :  |
-| file://:0:0:0:0 | .value :  | semmle.label | .value :  |
-| file://:0:0:0:0 | .value :  | semmle.label | .value :  |
-| file://:0:0:0:0 | [post] self [data] :  | semmle.label | [post] self [data] :  |
-| file://:0:0:0:0 | [post] self [notStoredBankAccountNumber] :  | semmle.label | [post] self [notStoredBankAccountNumber] :  |
-| file://:0:0:0:0 | [post] self [password] :  | semmle.label | [post] self [password] :  |
-| file://:0:0:0:0 | [post] self [value] :  | semmle.label | [post] self [value] :  |
-| file://:0:0:0:0 | self [value] :  | semmle.label | self [value] :  |
-| file://:0:0:0:0 | value :  | semmle.label | value :  |
-| file://:0:0:0:0 | value :  | semmle.label | value :  |
-| file://:0:0:0:0 | value :  | semmle.label | value :  |
-| file://:0:0:0:0 | value :  | semmle.label | value :  |
-| testCoreData2.swift:23:13:23:13 | value :  | semmle.label | value :  |
+| file://:0:0:0:0 | .value | semmle.label | .value |
+| file://:0:0:0:0 | .value | semmle.label | .value |
+| file://:0:0:0:0 | .value2 | semmle.label | .value2 |
+| file://:0:0:0:0 | [post] self [data] | semmle.label | [post] self [data] |
+| file://:0:0:0:0 | [post] self [notStoredBankAccountNumber] | semmle.label | [post] self [notStoredBankAccountNumber] |
+| file://:0:0:0:0 | [post] self [password] | semmle.label | [post] self [password] |
+| file://:0:0:0:0 | [post] self [value] | semmle.label | [post] self [value] |
+| file://:0:0:0:0 | self [value] | semmle.label | self [value] |
+| file://:0:0:0:0 | value | semmle.label | value |
+| file://:0:0:0:0 | value | semmle.label | value |
+| file://:0:0:0:0 | value | semmle.label | value |
+| file://:0:0:0:0 | value | semmle.label | value |
+| testCoreData2.swift:23:13:23:13 | value | semmle.label | value |
 | testCoreData2.swift:37:2:37:2 | [post] obj | semmle.label | [post] obj |
-| testCoreData2.swift:37:2:37:2 | [post] obj [myValue] :  | semmle.label | [post] obj [myValue] :  |
-| testCoreData2.swift:37:16:37:16 | bankAccountNo :  | semmle.label | bankAccountNo :  |
+| testCoreData2.swift:37:2:37:2 | [post] obj [myValue] | semmle.label | [post] obj [myValue] |
+| testCoreData2.swift:37:16:37:16 | bankAccountNo | semmle.label | bankAccountNo |
 | testCoreData2.swift:39:2:39:2 | [post] obj | semmle.label | [post] obj |
-| testCoreData2.swift:39:2:39:2 | [post] obj [myBankAccountNumber] :  | semmle.label | [post] obj [myBankAccountNumber] :  |
-| testCoreData2.swift:39:28:39:28 | bankAccountNo :  | semmle.label | bankAccountNo :  |
+| testCoreData2.swift:39:2:39:2 | [post] obj [myBankAccountNumber] | semmle.label | [post] obj [myBankAccountNumber] |
+| testCoreData2.swift:39:28:39:28 | bankAccountNo | semmle.label | bankAccountNo |
 | testCoreData2.swift:41:2:41:2 | [post] obj | semmle.label | [post] obj |
-| testCoreData2.swift:41:2:41:2 | [post] obj [myBankAccountNumber2] :  | semmle.label | [post] obj [myBankAccountNumber2] :  |
-| testCoreData2.swift:41:29:41:29 | bankAccountNo :  | semmle.label | bankAccountNo :  |
+| testCoreData2.swift:41:2:41:2 | [post] obj [myBankAccountNumber2] | semmle.label | [post] obj [myBankAccountNumber2] |
+| testCoreData2.swift:41:29:41:29 | bankAccountNo | semmle.label | bankAccountNo |
 | testCoreData2.swift:43:2:43:2 | [post] obj | semmle.label | [post] obj |
-| testCoreData2.swift:43:2:43:2 | [post] obj [notStoredBankAccountNumber] :  | semmle.label | [post] obj [notStoredBankAccountNumber] :  |
-| testCoreData2.swift:43:35:43:35 | bankAccountNo :  | semmle.label | bankAccountNo :  |
+| testCoreData2.swift:43:2:43:2 | [post] obj [notStoredBankAccountNumber] | semmle.label | [post] obj [notStoredBankAccountNumber] |
+| testCoreData2.swift:43:35:43:35 | bankAccountNo | semmle.label | bankAccountNo |
 | testCoreData2.swift:46:2:46:10 | [post] ...? | semmle.label | [post] ...? |
-| testCoreData2.swift:46:2:46:10 | [post] ...? [myValue] :  | semmle.label | [post] ...? [myValue] :  |
-| testCoreData2.swift:46:22:46:22 | bankAccountNo :  | semmle.label | bankAccountNo :  |
+| testCoreData2.swift:46:2:46:10 | [post] ...? [myValue] | semmle.label | [post] ...? [myValue] |
+| testCoreData2.swift:46:22:46:22 | bankAccountNo | semmle.label | bankAccountNo |
 | testCoreData2.swift:48:2:48:10 | [post] ...? | semmle.label | [post] ...? |
-| testCoreData2.swift:48:2:48:10 | [post] ...? [myBankAccountNumber] :  | semmle.label | [post] ...? [myBankAccountNumber] :  |
-| testCoreData2.swift:48:34:48:34 | bankAccountNo :  | semmle.label | bankAccountNo :  |
+| testCoreData2.swift:48:2:48:10 | [post] ...? [myBankAccountNumber] | semmle.label | [post] ...? [myBankAccountNumber] |
+| testCoreData2.swift:48:34:48:34 | bankAccountNo | semmle.label | bankAccountNo |
 | testCoreData2.swift:50:2:50:10 | [post] ...? | semmle.label | [post] ...? |
-| testCoreData2.swift:50:2:50:10 | [post] ...? [myBankAccountNumber2] :  | semmle.label | [post] ...? [myBankAccountNumber2] :  |
-| testCoreData2.swift:50:35:50:35 | bankAccountNo :  | semmle.label | bankAccountNo :  |
+| testCoreData2.swift:50:2:50:10 | [post] ...? [myBankAccountNumber2] | semmle.label | [post] ...? [myBankAccountNumber2] |
+| testCoreData2.swift:50:35:50:35 | bankAccountNo | semmle.label | bankAccountNo |
 | testCoreData2.swift:52:2:52:10 | [post] ...? | semmle.label | [post] ...? |
-| testCoreData2.swift:52:2:52:10 | [post] ...? [notStoredBankAccountNumber] :  | semmle.label | [post] ...? [notStoredBankAccountNumber] :  |
-| testCoreData2.swift:52:41:52:41 | bankAccountNo :  | semmle.label | bankAccountNo :  |
+| testCoreData2.swift:52:2:52:10 | [post] ...? [notStoredBankAccountNumber] | semmle.label | [post] ...? [notStoredBankAccountNumber] |
+| testCoreData2.swift:52:41:52:41 | bankAccountNo | semmle.label | bankAccountNo |
 | testCoreData2.swift:57:3:57:3 | [post] obj | semmle.label | [post] obj |
-| testCoreData2.swift:57:3:57:3 | [post] obj [myBankAccountNumber] :  | semmle.label | [post] obj [myBankAccountNumber] :  |
-| testCoreData2.swift:57:29:57:29 | bankAccountNo :  | semmle.label | bankAccountNo :  |
+| testCoreData2.swift:57:3:57:3 | [post] obj [myBankAccountNumber] | semmle.label | [post] obj [myBankAccountNumber] |
+| testCoreData2.swift:57:29:57:29 | bankAccountNo | semmle.label | bankAccountNo |
 | testCoreData2.swift:60:4:60:4 | [post] obj | semmle.label | [post] obj |
-| testCoreData2.swift:60:4:60:4 | [post] obj [myBankAccountNumber] :  | semmle.label | [post] obj [myBankAccountNumber] :  |
-| testCoreData2.swift:60:30:60:30 | bankAccountNo :  | semmle.label | bankAccountNo :  |
+| testCoreData2.swift:60:4:60:4 | [post] obj [myBankAccountNumber] | semmle.label | [post] obj [myBankAccountNumber] |
+| testCoreData2.swift:60:30:60:30 | bankAccountNo | semmle.label | bankAccountNo |
 | testCoreData2.swift:62:4:62:4 | [post] obj | semmle.label | [post] obj |
-| testCoreData2.swift:62:4:62:4 | [post] obj [myBankAccountNumber] :  | semmle.label | [post] obj [myBankAccountNumber] :  |
-| testCoreData2.swift:62:30:62:30 | bankAccountNo :  | semmle.label | bankAccountNo :  |
+| testCoreData2.swift:62:4:62:4 | [post] obj [myBankAccountNumber] | semmle.label | [post] obj [myBankAccountNumber] |
+| testCoreData2.swift:62:30:62:30 | bankAccountNo | semmle.label | bankAccountNo |
 | testCoreData2.swift:65:3:65:3 | [post] obj | semmle.label | [post] obj |
-| testCoreData2.swift:65:3:65:3 | [post] obj [myBankAccountNumber] :  | semmle.label | [post] obj [myBankAccountNumber] :  |
-| testCoreData2.swift:65:29:65:29 | bankAccountNo :  | semmle.label | bankAccountNo :  |
-| testCoreData2.swift:70:9:70:9 | self :  | semmle.label | self :  |
-| testCoreData2.swift:70:9:70:9 | self [value] :  | semmle.label | self [value] :  |
-| testCoreData2.swift:70:9:70:9 | value :  | semmle.label | value :  |
-| testCoreData2.swift:71:9:71:9 | self :  | semmle.label | self :  |
+| testCoreData2.swift:65:3:65:3 | [post] obj [myBankAccountNumber] | semmle.label | [post] obj [myBankAccountNumber] |
+| testCoreData2.swift:65:29:65:29 | bankAccountNo | semmle.label | bankAccountNo |
+| testCoreData2.swift:70:9:70:9 | self | semmle.label | self |
+| testCoreData2.swift:70:9:70:9 | self [value] | semmle.label | self [value] |
+| testCoreData2.swift:70:9:70:9 | value | semmle.label | value |
+| testCoreData2.swift:71:9:71:9 | self | semmle.label | self |
 | testCoreData2.swift:79:2:79:2 | [post] dbObj | semmle.label | [post] dbObj |
-| testCoreData2.swift:79:2:79:2 | [post] dbObj [myValue] :  | semmle.label | [post] dbObj [myValue] :  |
-| testCoreData2.swift:79:18:79:28 | .bankAccountNo :  | semmle.label | .bankAccountNo :  |
+| testCoreData2.swift:79:2:79:2 | [post] dbObj [myValue] | semmle.label | [post] dbObj [myValue] |
+| testCoreData2.swift:79:18:79:28 | .bankAccountNo | semmle.label | .bankAccountNo |
 | testCoreData2.swift:80:2:80:2 | [post] dbObj | semmle.label | [post] dbObj |
-| testCoreData2.swift:80:2:80:2 | [post] dbObj [myValue] :  | semmle.label | [post] dbObj [myValue] :  |
-| testCoreData2.swift:80:18:80:28 | ...! :  | semmle.label | ...! :  |
-| testCoreData2.swift:80:18:80:28 | .bankAccountNo2 :  | semmle.label | .bankAccountNo2 :  |
+| testCoreData2.swift:80:2:80:2 | [post] dbObj [myValue] | semmle.label | [post] dbObj [myValue] |
+| testCoreData2.swift:80:18:80:28 | ...! | semmle.label | ...! |
+| testCoreData2.swift:80:18:80:28 | .bankAccountNo2 | semmle.label | .bankAccountNo2 |
 | testCoreData2.swift:82:2:82:2 | [post] dbObj | semmle.label | [post] dbObj |
-| testCoreData2.swift:82:2:82:2 | [post] dbObj [myValue] :  | semmle.label | [post] dbObj [myValue] :  |
-| testCoreData2.swift:82:18:82:18 | bankAccountNo :  | semmle.label | bankAccountNo :  |
-| testCoreData2.swift:82:18:82:32 | .value :  | semmle.label | .value :  |
+| testCoreData2.swift:82:2:82:2 | [post] dbObj [myValue] | semmle.label | [post] dbObj [myValue] |
+| testCoreData2.swift:82:18:82:18 | bankAccountNo | semmle.label | bankAccountNo |
+| testCoreData2.swift:82:18:82:32 | .value | semmle.label | .value |
 | testCoreData2.swift:83:2:83:2 | [post] dbObj | semmle.label | [post] dbObj |
-| testCoreData2.swift:83:2:83:2 | [post] dbObj [myValue] :  | semmle.label | [post] dbObj [myValue] :  |
-| testCoreData2.swift:83:18:83:18 | bankAccountNo :  | semmle.label | bankAccountNo :  |
-| testCoreData2.swift:83:18:83:32 | ...! :  | semmle.label | ...! :  |
-| testCoreData2.swift:83:18:83:32 | .value2 :  | semmle.label | .value2 :  |
+| testCoreData2.swift:83:2:83:2 | [post] dbObj [myValue] | semmle.label | [post] dbObj [myValue] |
+| testCoreData2.swift:83:18:83:18 | bankAccountNo | semmle.label | bankAccountNo |
+| testCoreData2.swift:83:18:83:32 | ...! | semmle.label | ...! |
+| testCoreData2.swift:83:18:83:32 | .value2 | semmle.label | .value2 |
 | testCoreData2.swift:84:2:84:2 | [post] dbObj | semmle.label | [post] dbObj |
-| testCoreData2.swift:84:2:84:2 | [post] dbObj [myValue] :  | semmle.label | [post] dbObj [myValue] :  |
-| testCoreData2.swift:84:18:84:18 | ...! :  | semmle.label | ...! :  |
-| testCoreData2.swift:84:18:84:18 | bankAccountNo2 :  | semmle.label | bankAccountNo2 :  |
-| testCoreData2.swift:84:18:84:33 | .value :  | semmle.label | .value :  |
+| testCoreData2.swift:84:2:84:2 | [post] dbObj [myValue] | semmle.label | [post] dbObj [myValue] |
+| testCoreData2.swift:84:18:84:18 | ...! | semmle.label | ...! |
+| testCoreData2.swift:84:18:84:18 | bankAccountNo2 | semmle.label | bankAccountNo2 |
+| testCoreData2.swift:84:18:84:33 | .value | semmle.label | .value |
 | testCoreData2.swift:85:2:85:2 | [post] dbObj | semmle.label | [post] dbObj |
-| testCoreData2.swift:85:2:85:2 | [post] dbObj [myValue] :  | semmle.label | [post] dbObj [myValue] :  |
-| testCoreData2.swift:85:18:85:18 | ...! :  | semmle.label | ...! :  |
-| testCoreData2.swift:85:18:85:18 | bankAccountNo2 :  | semmle.label | bankAccountNo2 :  |
-| testCoreData2.swift:85:18:85:33 | ...! :  | semmle.label | ...! :  |
-| testCoreData2.swift:85:18:85:33 | .value2 :  | semmle.label | .value2 :  |
+| testCoreData2.swift:85:2:85:2 | [post] dbObj [myValue] | semmle.label | [post] dbObj [myValue] |
+| testCoreData2.swift:85:18:85:18 | ...! | semmle.label | ...! |
+| testCoreData2.swift:85:18:85:18 | bankAccountNo2 | semmle.label | bankAccountNo2 |
+| testCoreData2.swift:85:18:85:33 | ...! | semmle.label | ...! |
+| testCoreData2.swift:85:18:85:33 | .value2 | semmle.label | .value2 |
 | testCoreData2.swift:87:2:87:10 | [post] ...? | semmle.label | [post] ...? |
-| testCoreData2.swift:87:2:87:10 | [post] ...? [myValue] :  | semmle.label | [post] ...? [myValue] :  |
-| testCoreData2.swift:87:22:87:32 | .bankAccountNo :  | semmle.label | .bankAccountNo :  |
+| testCoreData2.swift:87:2:87:10 | [post] ...? [myValue] | semmle.label | [post] ...? [myValue] |
+| testCoreData2.swift:87:22:87:32 | .bankAccountNo | semmle.label | .bankAccountNo |
 | testCoreData2.swift:88:2:88:10 | [post] ...? | semmle.label | [post] ...? |
-| testCoreData2.swift:88:2:88:10 | [post] ...? [myValue] :  | semmle.label | [post] ...? [myValue] :  |
-| testCoreData2.swift:88:22:88:22 | bankAccountNo :  | semmle.label | bankAccountNo :  |
-| testCoreData2.swift:88:22:88:36 | .value :  | semmle.label | .value :  |
+| testCoreData2.swift:88:2:88:10 | [post] ...? [myValue] | semmle.label | [post] ...? [myValue] |
+| testCoreData2.swift:88:22:88:22 | bankAccountNo | semmle.label | bankAccountNo |
+| testCoreData2.swift:88:22:88:36 | .value | semmle.label | .value |
 | testCoreData2.swift:89:2:89:10 | [post] ...? | semmle.label | [post] ...? |
-| testCoreData2.swift:89:2:89:10 | [post] ...? [myValue] :  | semmle.label | [post] ...? [myValue] :  |
-| testCoreData2.swift:89:22:89:22 | ...! :  | semmle.label | ...! :  |
-| testCoreData2.swift:89:22:89:22 | bankAccountNo2 :  | semmle.label | bankAccountNo2 :  |
-| testCoreData2.swift:89:22:89:37 | ...! :  | semmle.label | ...! :  |
-| testCoreData2.swift:89:22:89:37 | .value2 :  | semmle.label | .value2 :  |
-| testCoreData2.swift:91:10:91:10 | bankAccountNo :  | semmle.label | bankAccountNo :  |
-| testCoreData2.swift:92:10:92:10 | a :  | semmle.label | a :  |
-| testCoreData2.swift:92:10:92:12 | .value :  | semmle.label | .value :  |
+| testCoreData2.swift:89:2:89:10 | [post] ...? [myValue] | semmle.label | [post] ...? [myValue] |
+| testCoreData2.swift:89:22:89:22 | ...! | semmle.label | ...! |
+| testCoreData2.swift:89:22:89:22 | bankAccountNo2 | semmle.label | bankAccountNo2 |
+| testCoreData2.swift:89:22:89:37 | ...! | semmle.label | ...! |
+| testCoreData2.swift:89:22:89:37 | .value2 | semmle.label | .value2 |
+| testCoreData2.swift:91:10:91:10 | bankAccountNo | semmle.label | bankAccountNo |
+| testCoreData2.swift:92:10:92:10 | a | semmle.label | a |
+| testCoreData2.swift:92:10:92:12 | .value | semmle.label | .value |
 | testCoreData2.swift:93:2:93:2 | [post] dbObj | semmle.label | [post] dbObj |
-| testCoreData2.swift:93:2:93:2 | [post] dbObj [myValue] :  | semmle.label | [post] dbObj [myValue] :  |
-| testCoreData2.swift:93:18:93:18 | b :  | semmle.label | b :  |
-| testCoreData2.swift:95:10:95:10 | bankAccountNo :  | semmle.label | bankAccountNo :  |
-| testCoreData2.swift:97:2:97:2 | [post] d [value] :  | semmle.label | [post] d [value] :  |
-| testCoreData2.swift:97:12:97:12 | c :  | semmle.label | c :  |
-| testCoreData2.swift:97:12:97:14 | .value :  | semmle.label | .value :  |
+| testCoreData2.swift:93:2:93:2 | [post] dbObj [myValue] | semmle.label | [post] dbObj [myValue] |
+| testCoreData2.swift:93:18:93:18 | b | semmle.label | b |
+| testCoreData2.swift:95:10:95:10 | bankAccountNo | semmle.label | bankAccountNo |
+| testCoreData2.swift:97:2:97:2 | [post] d [value] | semmle.label | [post] d [value] |
+| testCoreData2.swift:97:12:97:12 | c | semmle.label | c |
+| testCoreData2.swift:97:12:97:14 | .value | semmle.label | .value |
 | testCoreData2.swift:98:2:98:2 | [post] dbObj | semmle.label | [post] dbObj |
-| testCoreData2.swift:98:2:98:2 | [post] dbObj [myValue] :  | semmle.label | [post] dbObj [myValue] :  |
-| testCoreData2.swift:98:18:98:18 | d [value] :  | semmle.label | d [value] :  |
-| testCoreData2.swift:98:18:98:20 | .value :  | semmle.label | .value :  |
-| testCoreData2.swift:101:10:101:10 | bankAccountNo :  | semmle.label | bankAccountNo :  |
+| testCoreData2.swift:98:2:98:2 | [post] dbObj [myValue] | semmle.label | [post] dbObj [myValue] |
+| testCoreData2.swift:98:18:98:18 | d [value] | semmle.label | d [value] |
+| testCoreData2.swift:98:18:98:20 | .value | semmle.label | .value |
+| testCoreData2.swift:101:10:101:10 | bankAccountNo | semmle.label | bankAccountNo |
 | testCoreData2.swift:104:2:104:2 | [post] dbObj | semmle.label | [post] dbObj |
-| testCoreData2.swift:104:2:104:2 | [post] dbObj [myValue] :  | semmle.label | [post] dbObj [myValue] :  |
-| testCoreData2.swift:104:18:104:18 | e :  | semmle.label | e :  |
-| testCoreData2.swift:104:18:104:20 | .value :  | semmle.label | .value :  |
+| testCoreData2.swift:104:2:104:2 | [post] dbObj [myValue] | semmle.label | [post] dbObj [myValue] |
+| testCoreData2.swift:104:18:104:18 | e | semmle.label | e |
+| testCoreData2.swift:104:18:104:20 | .value | semmle.label | .value |
 | testCoreData2.swift:105:2:105:2 | [post] dbObj | semmle.label | [post] dbObj |
-| testCoreData2.swift:105:2:105:2 | [post] dbObj [myValue] :  | semmle.label | [post] dbObj [myValue] :  |
-| testCoreData2.swift:105:18:105:18 | e :  | semmle.label | e :  |
-| testCoreData2.swift:105:18:105:20 | ...! :  | semmle.label | ...! :  |
-| testCoreData2.swift:105:18:105:20 | .value2 :  | semmle.label | .value2 :  |
-| testCoreData.swift:18:19:18:26 | value :  | semmle.label | value :  |
+| testCoreData2.swift:105:2:105:2 | [post] dbObj [myValue] | semmle.label | [post] dbObj [myValue] |
+| testCoreData2.swift:105:18:105:18 | e | semmle.label | e |
+| testCoreData2.swift:105:18:105:20 | ...! | semmle.label | ...! |
+| testCoreData2.swift:105:18:105:20 | .value2 | semmle.label | .value2 |
+| testCoreData.swift:18:19:18:26 | value | semmle.label | value |
 | testCoreData.swift:19:12:19:12 | value | semmle.label | value |
-| testCoreData.swift:31:3:31:3 | newValue :  | semmle.label | newValue :  |
+| testCoreData.swift:31:3:31:3 | newValue | semmle.label | newValue |
 | testCoreData.swift:32:13:32:13 | newValue | semmle.label | newValue |
 | testCoreData.swift:48:15:48:15 | password | semmle.label | password |
 | testCoreData.swift:51:24:51:24 | password | semmle.label | password |
 | testCoreData.swift:58:15:58:15 | password | semmle.label | password |
-| testCoreData.swift:61:25:61:25 | password :  | semmle.label | password :  |
+| testCoreData.swift:61:25:61:25 | password | semmle.label | password |
 | testCoreData.swift:64:2:64:2 | [post] obj | semmle.label | [post] obj |
-| testCoreData.swift:64:2:64:2 | [post] obj [myValue] :  | semmle.label | [post] obj [myValue] :  |
-| testCoreData.swift:64:16:64:16 | password :  | semmle.label | password :  |
-| testCoreData.swift:77:24:77:24 | x :  | semmle.label | x :  |
+| testCoreData.swift:64:2:64:2 | [post] obj [myValue] | semmle.label | [post] obj [myValue] |
+| testCoreData.swift:64:16:64:16 | password | semmle.label | password |
+| testCoreData.swift:77:24:77:24 | x | semmle.label | x |
 | testCoreData.swift:78:15:78:15 | x | semmle.label | x |
-| testCoreData.swift:80:10:80:22 | call to getPassword() :  | semmle.label | call to getPassword() :  |
+| testCoreData.swift:80:10:80:22 | call to getPassword() | semmle.label | call to getPassword() |
 | testCoreData.swift:81:15:81:15 | y | semmle.label | y |
 | testCoreData.swift:85:15:85:17 | .password | semmle.label | .password |
-| testCoreData.swift:91:10:91:10 | passwd :  | semmle.label | passwd :  |
-| testCoreData.swift:92:10:92:10 | passwd :  | semmle.label | passwd :  |
-| testCoreData.swift:93:10:93:10 | passwd :  | semmle.label | passwd :  |
+| testCoreData.swift:91:10:91:10 | passwd | semmle.label | passwd |
+| testCoreData.swift:92:10:92:10 | passwd | semmle.label | passwd |
+| testCoreData.swift:93:10:93:10 | passwd | semmle.label | passwd |
 | testCoreData.swift:95:15:95:15 | x | semmle.label | x |
 | testCoreData.swift:96:15:96:15 | y | semmle.label | y |
 | testCoreData.swift:97:15:97:15 | z | semmle.label | z |
 | testGRDB.swift:73:56:73:65 | [...] | semmle.label | [...] |
-| testGRDB.swift:73:57:73:57 | password :  | semmle.label | password :  |
+| testGRDB.swift:73:57:73:57 | password | semmle.label | password |
 | testGRDB.swift:76:42:76:51 | [...] | semmle.label | [...] |
-| testGRDB.swift:76:43:76:43 | password :  | semmle.label | password :  |
+| testGRDB.swift:76:43:76:43 | password | semmle.label | password |
 | testGRDB.swift:81:44:81:53 | [...] | semmle.label | [...] |
-| testGRDB.swift:81:45:81:45 | password :  | semmle.label | password :  |
+| testGRDB.swift:81:45:81:45 | password | semmle.label | password |
 | testGRDB.swift:83:44:83:53 | [...] | semmle.label | [...] |
-| testGRDB.swift:83:45:83:45 | password :  | semmle.label | password :  |
+| testGRDB.swift:83:45:83:45 | password | semmle.label | password |
 | testGRDB.swift:85:44:85:53 | [...] | semmle.label | [...] |
-| testGRDB.swift:85:45:85:45 | password :  | semmle.label | password :  |
+| testGRDB.swift:85:45:85:45 | password | semmle.label | password |
 | testGRDB.swift:87:44:87:53 | [...] | semmle.label | [...] |
-| testGRDB.swift:87:45:87:45 | password :  | semmle.label | password :  |
+| testGRDB.swift:87:45:87:45 | password | semmle.label | password |
 | testGRDB.swift:92:37:92:46 | [...] | semmle.label | [...] |
-| testGRDB.swift:92:38:92:38 | password :  | semmle.label | password :  |
+| testGRDB.swift:92:38:92:38 | password | semmle.label | password |
 | testGRDB.swift:95:36:95:45 | [...] | semmle.label | [...] |
-| testGRDB.swift:95:37:95:37 | password :  | semmle.label | password :  |
+| testGRDB.swift:95:37:95:37 | password | semmle.label | password |
 | testGRDB.swift:100:72:100:81 | [...] | semmle.label | [...] |
-| testGRDB.swift:100:73:100:73 | password :  | semmle.label | password :  |
+| testGRDB.swift:100:73:100:73 | password | semmle.label | password |
 | testGRDB.swift:101:72:101:81 | [...] | semmle.label | [...] |
-| testGRDB.swift:101:73:101:73 | password :  | semmle.label | password :  |
+| testGRDB.swift:101:73:101:73 | password | semmle.label | password |
 | testGRDB.swift:107:52:107:61 | [...] | semmle.label | [...] |
-| testGRDB.swift:107:53:107:53 | password :  | semmle.label | password :  |
+| testGRDB.swift:107:53:107:53 | password | semmle.label | password |
 | testGRDB.swift:109:52:109:61 | [...] | semmle.label | [...] |
-| testGRDB.swift:109:53:109:53 | password :  | semmle.label | password :  |
+| testGRDB.swift:109:53:109:53 | password | semmle.label | password |
 | testGRDB.swift:111:51:111:60 | [...] | semmle.label | [...] |
-| testGRDB.swift:111:52:111:52 | password :  | semmle.label | password :  |
+| testGRDB.swift:111:52:111:52 | password | semmle.label | password |
 | testGRDB.swift:116:47:116:56 | [...] | semmle.label | [...] |
-| testGRDB.swift:116:48:116:48 | password :  | semmle.label | password :  |
+| testGRDB.swift:116:48:116:48 | password | semmle.label | password |
 | testGRDB.swift:118:47:118:56 | [...] | semmle.label | [...] |
-| testGRDB.swift:118:48:118:48 | password :  | semmle.label | password :  |
+| testGRDB.swift:118:48:118:48 | password | semmle.label | password |
 | testGRDB.swift:121:44:121:53 | [...] | semmle.label | [...] |
-| testGRDB.swift:121:45:121:45 | password :  | semmle.label | password :  |
+| testGRDB.swift:121:45:121:45 | password | semmle.label | password |
 | testGRDB.swift:123:44:123:53 | [...] | semmle.label | [...] |
-| testGRDB.swift:123:45:123:45 | password :  | semmle.label | password :  |
+| testGRDB.swift:123:45:123:45 | password | semmle.label | password |
 | testGRDB.swift:126:44:126:53 | [...] | semmle.label | [...] |
-| testGRDB.swift:126:45:126:45 | password :  | semmle.label | password :  |
+| testGRDB.swift:126:45:126:45 | password | semmle.label | password |
 | testGRDB.swift:128:44:128:53 | [...] | semmle.label | [...] |
-| testGRDB.swift:128:45:128:45 | password :  | semmle.label | password :  |
+| testGRDB.swift:128:45:128:45 | password | semmle.label | password |
 | testGRDB.swift:131:44:131:53 | [...] | semmle.label | [...] |
-| testGRDB.swift:131:45:131:45 | password :  | semmle.label | password :  |
+| testGRDB.swift:131:45:131:45 | password | semmle.label | password |
 | testGRDB.swift:133:44:133:53 | [...] | semmle.label | [...] |
-| testGRDB.swift:133:45:133:45 | password :  | semmle.label | password :  |
+| testGRDB.swift:133:45:133:45 | password | semmle.label | password |
 | testGRDB.swift:138:68:138:77 | [...] | semmle.label | [...] |
-| testGRDB.swift:138:69:138:69 | password :  | semmle.label | password :  |
+| testGRDB.swift:138:69:138:69 | password | semmle.label | password |
 | testGRDB.swift:140:68:140:77 | [...] | semmle.label | [...] |
-| testGRDB.swift:140:69:140:69 | password :  | semmle.label | password :  |
+| testGRDB.swift:140:69:140:69 | password | semmle.label | password |
 | testGRDB.swift:143:65:143:74 | [...] | semmle.label | [...] |
-| testGRDB.swift:143:66:143:66 | password :  | semmle.label | password :  |
+| testGRDB.swift:143:66:143:66 | password | semmle.label | password |
 | testGRDB.swift:145:65:145:74 | [...] | semmle.label | [...] |
-| testGRDB.swift:145:66:145:66 | password :  | semmle.label | password :  |
+| testGRDB.swift:145:66:145:66 | password | semmle.label | password |
 | testGRDB.swift:148:65:148:74 | [...] | semmle.label | [...] |
-| testGRDB.swift:148:66:148:66 | password :  | semmle.label | password :  |
+| testGRDB.swift:148:66:148:66 | password | semmle.label | password |
 | testGRDB.swift:150:65:150:74 | [...] | semmle.label | [...] |
-| testGRDB.swift:150:66:150:66 | password :  | semmle.label | password :  |
+| testGRDB.swift:150:66:150:66 | password | semmle.label | password |
 | testGRDB.swift:153:65:153:74 | [...] | semmle.label | [...] |
-| testGRDB.swift:153:66:153:66 | password :  | semmle.label | password :  |
+| testGRDB.swift:153:66:153:66 | password | semmle.label | password |
 | testGRDB.swift:155:65:155:74 | [...] | semmle.label | [...] |
-| testGRDB.swift:155:66:155:66 | password :  | semmle.label | password :  |
+| testGRDB.swift:155:66:155:66 | password | semmle.label | password |
 | testGRDB.swift:160:59:160:68 | [...] | semmle.label | [...] |
-| testGRDB.swift:160:60:160:60 | password :  | semmle.label | password :  |
+| testGRDB.swift:160:60:160:60 | password | semmle.label | password |
 | testGRDB.swift:161:50:161:59 | [...] | semmle.label | [...] |
-| testGRDB.swift:161:51:161:51 | password :  | semmle.label | password :  |
+| testGRDB.swift:161:51:161:51 | password | semmle.label | password |
 | testGRDB.swift:164:59:164:68 | [...] | semmle.label | [...] |
-| testGRDB.swift:164:60:164:60 | password :  | semmle.label | password :  |
+| testGRDB.swift:164:60:164:60 | password | semmle.label | password |
 | testGRDB.swift:165:50:165:59 | [...] | semmle.label | [...] |
-| testGRDB.swift:165:51:165:51 | password :  | semmle.label | password :  |
+| testGRDB.swift:165:51:165:51 | password | semmle.label | password |
 | testGRDB.swift:169:56:169:65 | [...] | semmle.label | [...] |
-| testGRDB.swift:169:57:169:57 | password :  | semmle.label | password :  |
+| testGRDB.swift:169:57:169:57 | password | semmle.label | password |
 | testGRDB.swift:170:47:170:56 | [...] | semmle.label | [...] |
-| testGRDB.swift:170:48:170:48 | password :  | semmle.label | password :  |
+| testGRDB.swift:170:48:170:48 | password | semmle.label | password |
 | testGRDB.swift:173:56:173:65 | [...] | semmle.label | [...] |
-| testGRDB.swift:173:57:173:57 | password :  | semmle.label | password :  |
+| testGRDB.swift:173:57:173:57 | password | semmle.label | password |
 | testGRDB.swift:174:47:174:56 | [...] | semmle.label | [...] |
-| testGRDB.swift:174:48:174:48 | password :  | semmle.label | password :  |
+| testGRDB.swift:174:48:174:48 | password | semmle.label | password |
 | testGRDB.swift:178:56:178:65 | [...] | semmle.label | [...] |
-| testGRDB.swift:178:57:178:57 | password :  | semmle.label | password :  |
+| testGRDB.swift:178:57:178:57 | password | semmle.label | password |
 | testGRDB.swift:179:47:179:56 | [...] | semmle.label | [...] |
-| testGRDB.swift:179:48:179:48 | password :  | semmle.label | password :  |
+| testGRDB.swift:179:48:179:48 | password | semmle.label | password |
 | testGRDB.swift:182:56:182:65 | [...] | semmle.label | [...] |
-| testGRDB.swift:182:57:182:57 | password :  | semmle.label | password :  |
+| testGRDB.swift:182:57:182:57 | password | semmle.label | password |
 | testGRDB.swift:183:47:183:56 | [...] | semmle.label | [...] |
-| testGRDB.swift:183:48:183:48 | password :  | semmle.label | password :  |
+| testGRDB.swift:183:48:183:48 | password | semmle.label | password |
 | testGRDB.swift:187:56:187:65 | [...] | semmle.label | [...] |
-| testGRDB.swift:187:57:187:57 | password :  | semmle.label | password :  |
+| testGRDB.swift:187:57:187:57 | password | semmle.label | password |
 | testGRDB.swift:188:47:188:56 | [...] | semmle.label | [...] |
-| testGRDB.swift:188:48:188:48 | password :  | semmle.label | password :  |
+| testGRDB.swift:188:48:188:48 | password | semmle.label | password |
 | testGRDB.swift:191:56:191:65 | [...] | semmle.label | [...] |
-| testGRDB.swift:191:57:191:57 | password :  | semmle.label | password :  |
+| testGRDB.swift:191:57:191:57 | password | semmle.label | password |
 | testGRDB.swift:192:47:192:56 | [...] | semmle.label | [...] |
-| testGRDB.swift:192:48:192:48 | password :  | semmle.label | password :  |
+| testGRDB.swift:192:48:192:48 | password | semmle.label | password |
 | testGRDB.swift:198:29:198:38 | [...] | semmle.label | [...] |
-| testGRDB.swift:198:30:198:30 | password :  | semmle.label | password :  |
+| testGRDB.swift:198:30:198:30 | password | semmle.label | password |
 | testGRDB.swift:201:23:201:32 | [...] | semmle.label | [...] |
-| testGRDB.swift:201:24:201:24 | password :  | semmle.label | password :  |
+| testGRDB.swift:201:24:201:24 | password | semmle.label | password |
 | testGRDB.swift:206:66:206:75 | [...] | semmle.label | [...] |
-| testGRDB.swift:206:67:206:67 | password :  | semmle.label | password :  |
+| testGRDB.swift:206:67:206:67 | password | semmle.label | password |
 | testGRDB.swift:208:80:208:89 | [...] | semmle.label | [...] |
-| testGRDB.swift:208:81:208:81 | password :  | semmle.label | password :  |
+| testGRDB.swift:208:81:208:81 | password | semmle.label | password |
 | testGRDB.swift:210:84:210:93 | [...] | semmle.label | [...] |
-| testGRDB.swift:210:85:210:85 | password :  | semmle.label | password :  |
+| testGRDB.swift:210:85:210:85 | password | semmle.label | password |
 | testGRDB.swift:212:98:212:107 | [...] | semmle.label | [...] |
-| testGRDB.swift:212:99:212:99 | password :  | semmle.label | password :  |
-| testRealm.swift:27:6:27:6 | value :  | semmle.label | value :  |
-| testRealm.swift:34:6:34:6 | value :  | semmle.label | value :  |
+| testGRDB.swift:212:99:212:99 | password | semmle.label | password |
+| testRealm.swift:27:6:27:6 | value | semmle.label | value |
+| testRealm.swift:34:6:34:6 | value | semmle.label | value |
 | testRealm.swift:41:2:41:2 | [post] a | semmle.label | [post] a |
-| testRealm.swift:41:2:41:2 | [post] a [data] :  | semmle.label | [post] a [data] :  |
-| testRealm.swift:41:11:41:11 | myPassword :  | semmle.label | myPassword :  |
+| testRealm.swift:41:2:41:2 | [post] a [data] | semmle.label | [post] a [data] |
+| testRealm.swift:41:11:41:11 | myPassword | semmle.label | myPassword |
 | testRealm.swift:49:2:49:2 | [post] c | semmle.label | [post] c |
-| testRealm.swift:49:2:49:2 | [post] c [data] :  | semmle.label | [post] c [data] :  |
-| testRealm.swift:49:11:49:11 | myPassword :  | semmle.label | myPassword :  |
+| testRealm.swift:49:2:49:2 | [post] c [data] | semmle.label | [post] c [data] |
+| testRealm.swift:49:11:49:11 | myPassword | semmle.label | myPassword |
 | testRealm.swift:59:2:59:3 | [post] ...! | semmle.label | [post] ...! |
-| testRealm.swift:59:2:59:3 | [post] ...! [data] :  | semmle.label | [post] ...! [data] :  |
-| testRealm.swift:59:12:59:12 | myPassword :  | semmle.label | myPassword :  |
+| testRealm.swift:59:2:59:3 | [post] ...! [data] | semmle.label | [post] ...! [data] |
+| testRealm.swift:59:12:59:12 | myPassword | semmle.label | myPassword |
 | testRealm.swift:66:2:66:2 | [post] g | semmle.label | [post] g |
-| testRealm.swift:66:2:66:2 | [post] g [data] :  | semmle.label | [post] g [data] :  |
-| testRealm.swift:66:11:66:11 | myPassword :  | semmle.label | myPassword :  |
+| testRealm.swift:66:2:66:2 | [post] g [data] | semmle.label | [post] g [data] |
+| testRealm.swift:66:11:66:11 | myPassword | semmle.label | myPassword |
 | testRealm.swift:73:2:73:2 | [post] h | semmle.label | [post] h |
-| testRealm.swift:73:2:73:2 | [post] h [password] :  | semmle.label | [post] h [password] :  |
-| testRealm.swift:73:15:73:15 | myPassword :  | semmle.label | myPassword :  |
+| testRealm.swift:73:2:73:2 | [post] h [password] | semmle.label | [post] h [password] |
+| testRealm.swift:73:15:73:15 | myPassword | semmle.label | myPassword |
 subpaths
-| testCoreData2.swift:43:35:43:35 | bankAccountNo :  | testCoreData2.swift:23:13:23:13 | value :  | file://:0:0:0:0 | [post] self [notStoredBankAccountNumber] :  | testCoreData2.swift:43:2:43:2 | [post] obj [notStoredBankAccountNumber] :  |
-| testCoreData2.swift:52:41:52:41 | bankAccountNo :  | testCoreData2.swift:23:13:23:13 | value :  | file://:0:0:0:0 | [post] self [notStoredBankAccountNumber] :  | testCoreData2.swift:52:2:52:10 | [post] ...? [notStoredBankAccountNumber] :  |
-| testCoreData2.swift:82:18:82:18 | bankAccountNo :  | testCoreData2.swift:70:9:70:9 | self :  | file://:0:0:0:0 | .value :  | testCoreData2.swift:82:18:82:32 | .value :  |
-| testCoreData2.swift:83:18:83:18 | bankAccountNo :  | testCoreData2.swift:71:9:71:9 | self :  | file://:0:0:0:0 | .value2 :  | testCoreData2.swift:83:18:83:32 | .value2 :  |
-| testCoreData2.swift:84:18:84:18 | ...! :  | testCoreData2.swift:70:9:70:9 | self :  | file://:0:0:0:0 | .value :  | testCoreData2.swift:84:18:84:33 | .value :  |
-| testCoreData2.swift:85:18:85:18 | ...! :  | testCoreData2.swift:71:9:71:9 | self :  | file://:0:0:0:0 | .value2 :  | testCoreData2.swift:85:18:85:33 | .value2 :  |
-| testCoreData2.swift:88:22:88:22 | bankAccountNo :  | testCoreData2.swift:70:9:70:9 | self :  | file://:0:0:0:0 | .value :  | testCoreData2.swift:88:22:88:36 | .value :  |
-| testCoreData2.swift:89:22:89:22 | ...! :  | testCoreData2.swift:71:9:71:9 | self :  | file://:0:0:0:0 | .value2 :  | testCoreData2.swift:89:22:89:37 | .value2 :  |
-| testCoreData2.swift:92:10:92:10 | a :  | testCoreData2.swift:70:9:70:9 | self :  | file://:0:0:0:0 | .value :  | testCoreData2.swift:92:10:92:12 | .value :  |
-| testCoreData2.swift:97:12:97:12 | c :  | testCoreData2.swift:70:9:70:9 | self :  | file://:0:0:0:0 | .value :  | testCoreData2.swift:97:12:97:14 | .value :  |
-| testCoreData2.swift:97:12:97:14 | .value :  | testCoreData2.swift:70:9:70:9 | value :  | file://:0:0:0:0 | [post] self [value] :  | testCoreData2.swift:97:2:97:2 | [post] d [value] :  |
-| testCoreData2.swift:98:18:98:18 | d [value] :  | testCoreData2.swift:70:9:70:9 | self [value] :  | file://:0:0:0:0 | .value :  | testCoreData2.swift:98:18:98:20 | .value :  |
-| testCoreData2.swift:104:18:104:18 | e :  | testCoreData2.swift:70:9:70:9 | self :  | file://:0:0:0:0 | .value :  | testCoreData2.swift:104:18:104:20 | .value :  |
-| testCoreData2.swift:105:18:105:18 | e :  | testCoreData2.swift:71:9:71:9 | self :  | file://:0:0:0:0 | .value2 :  | testCoreData2.swift:105:18:105:20 | .value2 :  |
-| testRealm.swift:41:11:41:11 | myPassword :  | testRealm.swift:27:6:27:6 | value :  | file://:0:0:0:0 | [post] self [data] :  | testRealm.swift:41:2:41:2 | [post] a [data] :  |
-| testRealm.swift:49:11:49:11 | myPassword :  | testRealm.swift:27:6:27:6 | value :  | file://:0:0:0:0 | [post] self [data] :  | testRealm.swift:49:2:49:2 | [post] c [data] :  |
-| testRealm.swift:59:12:59:12 | myPassword :  | testRealm.swift:27:6:27:6 | value :  | file://:0:0:0:0 | [post] self [data] :  | testRealm.swift:59:2:59:3 | [post] ...! [data] :  |
-| testRealm.swift:66:11:66:11 | myPassword :  | testRealm.swift:27:6:27:6 | value :  | file://:0:0:0:0 | [post] self [data] :  | testRealm.swift:66:2:66:2 | [post] g [data] :  |
-| testRealm.swift:73:15:73:15 | myPassword :  | testRealm.swift:34:6:34:6 | value :  | file://:0:0:0:0 | [post] self [password] :  | testRealm.swift:73:2:73:2 | [post] h [password] :  |
+| testCoreData2.swift:43:35:43:35 | bankAccountNo | testCoreData2.swift:23:13:23:13 | value | file://:0:0:0:0 | [post] self [notStoredBankAccountNumber] | testCoreData2.swift:43:2:43:2 | [post] obj [notStoredBankAccountNumber] |
+| testCoreData2.swift:52:41:52:41 | bankAccountNo | testCoreData2.swift:23:13:23:13 | value | file://:0:0:0:0 | [post] self [notStoredBankAccountNumber] | testCoreData2.swift:52:2:52:10 | [post] ...? [notStoredBankAccountNumber] |
+| testCoreData2.swift:82:18:82:18 | bankAccountNo | testCoreData2.swift:70:9:70:9 | self | file://:0:0:0:0 | .value | testCoreData2.swift:82:18:82:32 | .value |
+| testCoreData2.swift:83:18:83:18 | bankAccountNo | testCoreData2.swift:71:9:71:9 | self | file://:0:0:0:0 | .value2 | testCoreData2.swift:83:18:83:32 | .value2 |
+| testCoreData2.swift:84:18:84:18 | ...! | testCoreData2.swift:70:9:70:9 | self | file://:0:0:0:0 | .value | testCoreData2.swift:84:18:84:33 | .value |
+| testCoreData2.swift:85:18:85:18 | ...! | testCoreData2.swift:71:9:71:9 | self | file://:0:0:0:0 | .value2 | testCoreData2.swift:85:18:85:33 | .value2 |
+| testCoreData2.swift:88:22:88:22 | bankAccountNo | testCoreData2.swift:70:9:70:9 | self | file://:0:0:0:0 | .value | testCoreData2.swift:88:22:88:36 | .value |
+| testCoreData2.swift:89:22:89:22 | ...! | testCoreData2.swift:71:9:71:9 | self | file://:0:0:0:0 | .value2 | testCoreData2.swift:89:22:89:37 | .value2 |
+| testCoreData2.swift:92:10:92:10 | a | testCoreData2.swift:70:9:70:9 | self | file://:0:0:0:0 | .value | testCoreData2.swift:92:10:92:12 | .value |
+| testCoreData2.swift:97:12:97:12 | c | testCoreData2.swift:70:9:70:9 | self | file://:0:0:0:0 | .value | testCoreData2.swift:97:12:97:14 | .value |
+| testCoreData2.swift:97:12:97:14 | .value | testCoreData2.swift:70:9:70:9 | value | file://:0:0:0:0 | [post] self [value] | testCoreData2.swift:97:2:97:2 | [post] d [value] |
+| testCoreData2.swift:98:18:98:18 | d [value] | testCoreData2.swift:70:9:70:9 | self [value] | file://:0:0:0:0 | .value | testCoreData2.swift:98:18:98:20 | .value |
+| testCoreData2.swift:104:18:104:18 | e | testCoreData2.swift:70:9:70:9 | self | file://:0:0:0:0 | .value | testCoreData2.swift:104:18:104:20 | .value |
+| testCoreData2.swift:105:18:105:18 | e | testCoreData2.swift:71:9:71:9 | self | file://:0:0:0:0 | .value2 | testCoreData2.swift:105:18:105:20 | .value2 |
+| testRealm.swift:41:11:41:11 | myPassword | testRealm.swift:27:6:27:6 | value | file://:0:0:0:0 | [post] self [data] | testRealm.swift:41:2:41:2 | [post] a [data] |
+| testRealm.swift:49:11:49:11 | myPassword | testRealm.swift:27:6:27:6 | value | file://:0:0:0:0 | [post] self [data] | testRealm.swift:49:2:49:2 | [post] c [data] |
+| testRealm.swift:59:12:59:12 | myPassword | testRealm.swift:27:6:27:6 | value | file://:0:0:0:0 | [post] self [data] | testRealm.swift:59:2:59:3 | [post] ...! [data] |
+| testRealm.swift:66:11:66:11 | myPassword | testRealm.swift:27:6:27:6 | value | file://:0:0:0:0 | [post] self [data] | testRealm.swift:66:2:66:2 | [post] g [data] |
+| testRealm.swift:73:15:73:15 | myPassword | testRealm.swift:34:6:34:6 | value | file://:0:0:0:0 | [post] self [password] | testRealm.swift:73:2:73:2 | [post] h [password] |
 #select
-| testCoreData2.swift:37:2:37:2 | obj | testCoreData2.swift:37:16:37:16 | bankAccountNo :  | testCoreData2.swift:37:2:37:2 | [post] obj | This operation stores 'obj' in a database. It may contain unencrypted sensitive data from $@. | testCoreData2.swift:37:16:37:16 | bankAccountNo :  | bankAccountNo |
-| testCoreData2.swift:39:2:39:2 | obj | testCoreData2.swift:39:28:39:28 | bankAccountNo :  | testCoreData2.swift:39:2:39:2 | [post] obj | This operation stores 'obj' in a database. It may contain unencrypted sensitive data from $@. | testCoreData2.swift:39:28:39:28 | bankAccountNo :  | bankAccountNo |
-| testCoreData2.swift:41:2:41:2 | obj | testCoreData2.swift:41:29:41:29 | bankAccountNo :  | testCoreData2.swift:41:2:41:2 | [post] obj | This operation stores 'obj' in a database. It may contain unencrypted sensitive data from $@. | testCoreData2.swift:41:29:41:29 | bankAccountNo :  | bankAccountNo |
-| testCoreData2.swift:43:2:43:2 | obj | testCoreData2.swift:43:35:43:35 | bankAccountNo :  | testCoreData2.swift:43:2:43:2 | [post] obj | This operation stores 'obj' in a database. It may contain unencrypted sensitive data from $@. | testCoreData2.swift:43:35:43:35 | bankAccountNo :  | bankAccountNo |
-| testCoreData2.swift:46:2:46:10 | ...? | testCoreData2.swift:46:22:46:22 | bankAccountNo :  | testCoreData2.swift:46:2:46:10 | [post] ...? | This operation stores '...?' in a database. It may contain unencrypted sensitive data from $@. | testCoreData2.swift:46:22:46:22 | bankAccountNo :  | bankAccountNo |
-| testCoreData2.swift:48:2:48:10 | ...? | testCoreData2.swift:48:34:48:34 | bankAccountNo :  | testCoreData2.swift:48:2:48:10 | [post] ...? | This operation stores '...?' in a database. It may contain unencrypted sensitive data from $@. | testCoreData2.swift:48:34:48:34 | bankAccountNo :  | bankAccountNo |
-| testCoreData2.swift:50:2:50:10 | ...? | testCoreData2.swift:50:35:50:35 | bankAccountNo :  | testCoreData2.swift:50:2:50:10 | [post] ...? | This operation stores '...?' in a database. It may contain unencrypted sensitive data from $@. | testCoreData2.swift:50:35:50:35 | bankAccountNo :  | bankAccountNo |
-| testCoreData2.swift:52:2:52:10 | ...? | testCoreData2.swift:52:41:52:41 | bankAccountNo :  | testCoreData2.swift:52:2:52:10 | [post] ...? | This operation stores '...?' in a database. It may contain unencrypted sensitive data from $@. | testCoreData2.swift:52:41:52:41 | bankAccountNo :  | bankAccountNo |
-| testCoreData2.swift:57:3:57:3 | obj | testCoreData2.swift:57:29:57:29 | bankAccountNo :  | testCoreData2.swift:57:3:57:3 | [post] obj | This operation stores 'obj' in a database. It may contain unencrypted sensitive data from $@. | testCoreData2.swift:57:29:57:29 | bankAccountNo :  | bankAccountNo |
-| testCoreData2.swift:60:4:60:4 | obj | testCoreData2.swift:60:30:60:30 | bankAccountNo :  | testCoreData2.swift:60:4:60:4 | [post] obj | This operation stores 'obj' in a database. It may contain unencrypted sensitive data from $@. | testCoreData2.swift:60:30:60:30 | bankAccountNo :  | bankAccountNo |
-| testCoreData2.swift:62:4:62:4 | obj | testCoreData2.swift:62:30:62:30 | bankAccountNo :  | testCoreData2.swift:62:4:62:4 | [post] obj | This operation stores 'obj' in a database. It may contain unencrypted sensitive data from $@. | testCoreData2.swift:62:30:62:30 | bankAccountNo :  | bankAccountNo |
-| testCoreData2.swift:65:3:65:3 | obj | testCoreData2.swift:65:29:65:29 | bankAccountNo :  | testCoreData2.swift:65:3:65:3 | [post] obj | This operation stores 'obj' in a database. It may contain unencrypted sensitive data from $@. | testCoreData2.swift:65:29:65:29 | bankAccountNo :  | bankAccountNo |
-| testCoreData2.swift:79:2:79:2 | dbObj | testCoreData2.swift:79:18:79:28 | .bankAccountNo :  | testCoreData2.swift:79:2:79:2 | [post] dbObj | This operation stores 'dbObj' in a database. It may contain unencrypted sensitive data from $@. | testCoreData2.swift:79:18:79:28 | .bankAccountNo :  | .bankAccountNo |
-| testCoreData2.swift:80:2:80:2 | dbObj | testCoreData2.swift:80:18:80:28 | .bankAccountNo2 :  | testCoreData2.swift:80:2:80:2 | [post] dbObj | This operation stores 'dbObj' in a database. It may contain unencrypted sensitive data from $@. | testCoreData2.swift:80:18:80:28 | .bankAccountNo2 :  | .bankAccountNo2 |
-| testCoreData2.swift:82:2:82:2 | dbObj | testCoreData2.swift:82:18:82:18 | bankAccountNo :  | testCoreData2.swift:82:2:82:2 | [post] dbObj | This operation stores 'dbObj' in a database. It may contain unencrypted sensitive data from $@. | testCoreData2.swift:82:18:82:18 | bankAccountNo :  | bankAccountNo |
-| testCoreData2.swift:83:2:83:2 | dbObj | testCoreData2.swift:83:18:83:18 | bankAccountNo :  | testCoreData2.swift:83:2:83:2 | [post] dbObj | This operation stores 'dbObj' in a database. It may contain unencrypted sensitive data from $@. | testCoreData2.swift:83:18:83:18 | bankAccountNo :  | bankAccountNo |
-| testCoreData2.swift:84:2:84:2 | dbObj | testCoreData2.swift:84:18:84:18 | bankAccountNo2 :  | testCoreData2.swift:84:2:84:2 | [post] dbObj | This operation stores 'dbObj' in a database. It may contain unencrypted sensitive data from $@. | testCoreData2.swift:84:18:84:18 | bankAccountNo2 :  | bankAccountNo2 |
-| testCoreData2.swift:85:2:85:2 | dbObj | testCoreData2.swift:85:18:85:18 | bankAccountNo2 :  | testCoreData2.swift:85:2:85:2 | [post] dbObj | This operation stores 'dbObj' in a database. It may contain unencrypted sensitive data from $@. | testCoreData2.swift:85:18:85:18 | bankAccountNo2 :  | bankAccountNo2 |
-| testCoreData2.swift:87:2:87:10 | ...? | testCoreData2.swift:87:22:87:32 | .bankAccountNo :  | testCoreData2.swift:87:2:87:10 | [post] ...? | This operation stores '...?' in a database. It may contain unencrypted sensitive data from $@. | testCoreData2.swift:87:22:87:32 | .bankAccountNo :  | .bankAccountNo |
-| testCoreData2.swift:88:2:88:10 | ...? | testCoreData2.swift:88:22:88:22 | bankAccountNo :  | testCoreData2.swift:88:2:88:10 | [post] ...? | This operation stores '...?' in a database. It may contain unencrypted sensitive data from $@. | testCoreData2.swift:88:22:88:22 | bankAccountNo :  | bankAccountNo |
-| testCoreData2.swift:89:2:89:10 | ...? | testCoreData2.swift:89:22:89:22 | bankAccountNo2 :  | testCoreData2.swift:89:2:89:10 | [post] ...? | This operation stores '...?' in a database. It may contain unencrypted sensitive data from $@. | testCoreData2.swift:89:22:89:22 | bankAccountNo2 :  | bankAccountNo2 |
-| testCoreData2.swift:93:2:93:2 | dbObj | testCoreData2.swift:91:10:91:10 | bankAccountNo :  | testCoreData2.swift:93:2:93:2 | [post] dbObj | This operation stores 'dbObj' in a database. It may contain unencrypted sensitive data from $@. | testCoreData2.swift:91:10:91:10 | bankAccountNo :  | bankAccountNo |
-| testCoreData2.swift:98:2:98:2 | dbObj | testCoreData2.swift:95:10:95:10 | bankAccountNo :  | testCoreData2.swift:98:2:98:2 | [post] dbObj | This operation stores 'dbObj' in a database. It may contain unencrypted sensitive data from $@. | testCoreData2.swift:95:10:95:10 | bankAccountNo :  | bankAccountNo |
-| testCoreData2.swift:104:2:104:2 | dbObj | testCoreData2.swift:101:10:101:10 | bankAccountNo :  | testCoreData2.swift:104:2:104:2 | [post] dbObj | This operation stores 'dbObj' in a database. It may contain unencrypted sensitive data from $@. | testCoreData2.swift:101:10:101:10 | bankAccountNo :  | bankAccountNo |
-| testCoreData2.swift:105:2:105:2 | dbObj | testCoreData2.swift:101:10:101:10 | bankAccountNo :  | testCoreData2.swift:105:2:105:2 | [post] dbObj | This operation stores 'dbObj' in a database. It may contain unencrypted sensitive data from $@. | testCoreData2.swift:101:10:101:10 | bankAccountNo :  | bankAccountNo |
-| testCoreData.swift:19:12:19:12 | value | testCoreData.swift:61:25:61:25 | password :  | testCoreData.swift:19:12:19:12 | value | This operation stores 'value' in a database. It may contain unencrypted sensitive data from $@. | testCoreData.swift:61:25:61:25 | password :  | password |
-| testCoreData.swift:32:13:32:13 | newValue | testCoreData.swift:64:16:64:16 | password :  | testCoreData.swift:32:13:32:13 | newValue | This operation stores 'newValue' in a database. It may contain unencrypted sensitive data from $@. | testCoreData.swift:64:16:64:16 | password :  | password |
+| testCoreData2.swift:37:2:37:2 | obj | testCoreData2.swift:37:16:37:16 | bankAccountNo | testCoreData2.swift:37:2:37:2 | [post] obj | This operation stores 'obj' in a database. It may contain unencrypted sensitive data from $@. | testCoreData2.swift:37:16:37:16 | bankAccountNo | bankAccountNo |
+| testCoreData2.swift:39:2:39:2 | obj | testCoreData2.swift:39:28:39:28 | bankAccountNo | testCoreData2.swift:39:2:39:2 | [post] obj | This operation stores 'obj' in a database. It may contain unencrypted sensitive data from $@. | testCoreData2.swift:39:28:39:28 | bankAccountNo | bankAccountNo |
+| testCoreData2.swift:41:2:41:2 | obj | testCoreData2.swift:41:29:41:29 | bankAccountNo | testCoreData2.swift:41:2:41:2 | [post] obj | This operation stores 'obj' in a database. It may contain unencrypted sensitive data from $@. | testCoreData2.swift:41:29:41:29 | bankAccountNo | bankAccountNo |
+| testCoreData2.swift:43:2:43:2 | obj | testCoreData2.swift:43:35:43:35 | bankAccountNo | testCoreData2.swift:43:2:43:2 | [post] obj | This operation stores 'obj' in a database. It may contain unencrypted sensitive data from $@. | testCoreData2.swift:43:35:43:35 | bankAccountNo | bankAccountNo |
+| testCoreData2.swift:46:2:46:10 | ...? | testCoreData2.swift:46:22:46:22 | bankAccountNo | testCoreData2.swift:46:2:46:10 | [post] ...? | This operation stores '...?' in a database. It may contain unencrypted sensitive data from $@. | testCoreData2.swift:46:22:46:22 | bankAccountNo | bankAccountNo |
+| testCoreData2.swift:48:2:48:10 | ...? | testCoreData2.swift:48:34:48:34 | bankAccountNo | testCoreData2.swift:48:2:48:10 | [post] ...? | This operation stores '...?' in a database. It may contain unencrypted sensitive data from $@. | testCoreData2.swift:48:34:48:34 | bankAccountNo | bankAccountNo |
+| testCoreData2.swift:50:2:50:10 | ...? | testCoreData2.swift:50:35:50:35 | bankAccountNo | testCoreData2.swift:50:2:50:10 | [post] ...? | This operation stores '...?' in a database. It may contain unencrypted sensitive data from $@. | testCoreData2.swift:50:35:50:35 | bankAccountNo | bankAccountNo |
+| testCoreData2.swift:52:2:52:10 | ...? | testCoreData2.swift:52:41:52:41 | bankAccountNo | testCoreData2.swift:52:2:52:10 | [post] ...? | This operation stores '...?' in a database. It may contain unencrypted sensitive data from $@. | testCoreData2.swift:52:41:52:41 | bankAccountNo | bankAccountNo |
+| testCoreData2.swift:57:3:57:3 | obj | testCoreData2.swift:57:29:57:29 | bankAccountNo | testCoreData2.swift:57:3:57:3 | [post] obj | This operation stores 'obj' in a database. It may contain unencrypted sensitive data from $@. | testCoreData2.swift:57:29:57:29 | bankAccountNo | bankAccountNo |
+| testCoreData2.swift:60:4:60:4 | obj | testCoreData2.swift:60:30:60:30 | bankAccountNo | testCoreData2.swift:60:4:60:4 | [post] obj | This operation stores 'obj' in a database. It may contain unencrypted sensitive data from $@. | testCoreData2.swift:60:30:60:30 | bankAccountNo | bankAccountNo |
+| testCoreData2.swift:62:4:62:4 | obj | testCoreData2.swift:62:30:62:30 | bankAccountNo | testCoreData2.swift:62:4:62:4 | [post] obj | This operation stores 'obj' in a database. It may contain unencrypted sensitive data from $@. | testCoreData2.swift:62:30:62:30 | bankAccountNo | bankAccountNo |
+| testCoreData2.swift:65:3:65:3 | obj | testCoreData2.swift:65:29:65:29 | bankAccountNo | testCoreData2.swift:65:3:65:3 | [post] obj | This operation stores 'obj' in a database. It may contain unencrypted sensitive data from $@. | testCoreData2.swift:65:29:65:29 | bankAccountNo | bankAccountNo |
+| testCoreData2.swift:79:2:79:2 | dbObj | testCoreData2.swift:79:18:79:28 | .bankAccountNo | testCoreData2.swift:79:2:79:2 | [post] dbObj | This operation stores 'dbObj' in a database. It may contain unencrypted sensitive data from $@. | testCoreData2.swift:79:18:79:28 | .bankAccountNo | .bankAccountNo |
+| testCoreData2.swift:80:2:80:2 | dbObj | testCoreData2.swift:80:18:80:28 | .bankAccountNo2 | testCoreData2.swift:80:2:80:2 | [post] dbObj | This operation stores 'dbObj' in a database. It may contain unencrypted sensitive data from $@. | testCoreData2.swift:80:18:80:28 | .bankAccountNo2 | .bankAccountNo2 |
+| testCoreData2.swift:82:2:82:2 | dbObj | testCoreData2.swift:82:18:82:18 | bankAccountNo | testCoreData2.swift:82:2:82:2 | [post] dbObj | This operation stores 'dbObj' in a database. It may contain unencrypted sensitive data from $@. | testCoreData2.swift:82:18:82:18 | bankAccountNo | bankAccountNo |
+| testCoreData2.swift:83:2:83:2 | dbObj | testCoreData2.swift:83:18:83:18 | bankAccountNo | testCoreData2.swift:83:2:83:2 | [post] dbObj | This operation stores 'dbObj' in a database. It may contain unencrypted sensitive data from $@. | testCoreData2.swift:83:18:83:18 | bankAccountNo | bankAccountNo |
+| testCoreData2.swift:84:2:84:2 | dbObj | testCoreData2.swift:84:18:84:18 | bankAccountNo2 | testCoreData2.swift:84:2:84:2 | [post] dbObj | This operation stores 'dbObj' in a database. It may contain unencrypted sensitive data from $@. | testCoreData2.swift:84:18:84:18 | bankAccountNo2 | bankAccountNo2 |
+| testCoreData2.swift:85:2:85:2 | dbObj | testCoreData2.swift:85:18:85:18 | bankAccountNo2 | testCoreData2.swift:85:2:85:2 | [post] dbObj | This operation stores 'dbObj' in a database. It may contain unencrypted sensitive data from $@. | testCoreData2.swift:85:18:85:18 | bankAccountNo2 | bankAccountNo2 |
+| testCoreData2.swift:87:2:87:10 | ...? | testCoreData2.swift:87:22:87:32 | .bankAccountNo | testCoreData2.swift:87:2:87:10 | [post] ...? | This operation stores '...?' in a database. It may contain unencrypted sensitive data from $@. | testCoreData2.swift:87:22:87:32 | .bankAccountNo | .bankAccountNo |
+| testCoreData2.swift:88:2:88:10 | ...? | testCoreData2.swift:88:22:88:22 | bankAccountNo | testCoreData2.swift:88:2:88:10 | [post] ...? | This operation stores '...?' in a database. It may contain unencrypted sensitive data from $@. | testCoreData2.swift:88:22:88:22 | bankAccountNo | bankAccountNo |
+| testCoreData2.swift:89:2:89:10 | ...? | testCoreData2.swift:89:22:89:22 | bankAccountNo2 | testCoreData2.swift:89:2:89:10 | [post] ...? | This operation stores '...?' in a database. It may contain unencrypted sensitive data from $@. | testCoreData2.swift:89:22:89:22 | bankAccountNo2 | bankAccountNo2 |
+| testCoreData2.swift:93:2:93:2 | dbObj | testCoreData2.swift:91:10:91:10 | bankAccountNo | testCoreData2.swift:93:2:93:2 | [post] dbObj | This operation stores 'dbObj' in a database. It may contain unencrypted sensitive data from $@. | testCoreData2.swift:91:10:91:10 | bankAccountNo | bankAccountNo |
+| testCoreData2.swift:98:2:98:2 | dbObj | testCoreData2.swift:95:10:95:10 | bankAccountNo | testCoreData2.swift:98:2:98:2 | [post] dbObj | This operation stores 'dbObj' in a database. It may contain unencrypted sensitive data from $@. | testCoreData2.swift:95:10:95:10 | bankAccountNo | bankAccountNo |
+| testCoreData2.swift:104:2:104:2 | dbObj | testCoreData2.swift:101:10:101:10 | bankAccountNo | testCoreData2.swift:104:2:104:2 | [post] dbObj | This operation stores 'dbObj' in a database. It may contain unencrypted sensitive data from $@. | testCoreData2.swift:101:10:101:10 | bankAccountNo | bankAccountNo |
+| testCoreData2.swift:105:2:105:2 | dbObj | testCoreData2.swift:101:10:101:10 | bankAccountNo | testCoreData2.swift:105:2:105:2 | [post] dbObj | This operation stores 'dbObj' in a database. It may contain unencrypted sensitive data from $@. | testCoreData2.swift:101:10:101:10 | bankAccountNo | bankAccountNo |
+| testCoreData.swift:19:12:19:12 | value | testCoreData.swift:61:25:61:25 | password | testCoreData.swift:19:12:19:12 | value | This operation stores 'value' in a database. It may contain unencrypted sensitive data from $@. | testCoreData.swift:61:25:61:25 | password | password |
+| testCoreData.swift:32:13:32:13 | newValue | testCoreData.swift:64:16:64:16 | password | testCoreData.swift:32:13:32:13 | newValue | This operation stores 'newValue' in a database. It may contain unencrypted sensitive data from $@. | testCoreData.swift:64:16:64:16 | password | password |
 | testCoreData.swift:48:15:48:15 | password | testCoreData.swift:48:15:48:15 | password | testCoreData.swift:48:15:48:15 | password | This operation stores 'password' in a database. It may contain unencrypted sensitive data from $@. | testCoreData.swift:48:15:48:15 | password | password |
 | testCoreData.swift:51:24:51:24 | password | testCoreData.swift:51:24:51:24 | password | testCoreData.swift:51:24:51:24 | password | This operation stores 'password' in a database. It may contain unencrypted sensitive data from $@. | testCoreData.swift:51:24:51:24 | password | password |
 | testCoreData.swift:58:15:58:15 | password | testCoreData.swift:58:15:58:15 | password | testCoreData.swift:58:15:58:15 | password | This operation stores 'password' in a database. It may contain unencrypted sensitive data from $@. | testCoreData.swift:58:15:58:15 | password | password |
-| testCoreData.swift:64:2:64:2 | obj | testCoreData.swift:64:16:64:16 | password :  | testCoreData.swift:64:2:64:2 | [post] obj | This operation stores 'obj' in a database. It may contain unencrypted sensitive data from $@. | testCoreData.swift:64:16:64:16 | password :  | password |
-| testCoreData.swift:78:15:78:15 | x | testCoreData.swift:77:24:77:24 | x :  | testCoreData.swift:78:15:78:15 | x | This operation stores 'x' in a database. It may contain unencrypted sensitive data from $@. | testCoreData.swift:77:24:77:24 | x :  | x |
-| testCoreData.swift:81:15:81:15 | y | testCoreData.swift:80:10:80:22 | call to getPassword() :  | testCoreData.swift:81:15:81:15 | y | This operation stores 'y' in a database. It may contain unencrypted sensitive data from $@. | testCoreData.swift:80:10:80:22 | call to getPassword() :  | call to getPassword() |
+| testCoreData.swift:64:2:64:2 | obj | testCoreData.swift:64:16:64:16 | password | testCoreData.swift:64:2:64:2 | [post] obj | This operation stores 'obj' in a database. It may contain unencrypted sensitive data from $@. | testCoreData.swift:64:16:64:16 | password | password |
+| testCoreData.swift:78:15:78:15 | x | testCoreData.swift:77:24:77:24 | x | testCoreData.swift:78:15:78:15 | x | This operation stores 'x' in a database. It may contain unencrypted sensitive data from $@. | testCoreData.swift:77:24:77:24 | x | x |
+| testCoreData.swift:81:15:81:15 | y | testCoreData.swift:80:10:80:22 | call to getPassword() | testCoreData.swift:81:15:81:15 | y | This operation stores 'y' in a database. It may contain unencrypted sensitive data from $@. | testCoreData.swift:80:10:80:22 | call to getPassword() | call to getPassword() |
 | testCoreData.swift:85:15:85:17 | .password | testCoreData.swift:85:15:85:17 | .password | testCoreData.swift:85:15:85:17 | .password | This operation stores '.password' in a database. It may contain unencrypted sensitive data from $@. | testCoreData.swift:85:15:85:17 | .password | .password |
-| testCoreData.swift:95:15:95:15 | x | testCoreData.swift:91:10:91:10 | passwd :  | testCoreData.swift:95:15:95:15 | x | This operation stores 'x' in a database. It may contain unencrypted sensitive data from $@. | testCoreData.swift:91:10:91:10 | passwd :  | passwd |
-| testCoreData.swift:96:15:96:15 | y | testCoreData.swift:92:10:92:10 | passwd :  | testCoreData.swift:96:15:96:15 | y | This operation stores 'y' in a database. It may contain unencrypted sensitive data from $@. | testCoreData.swift:92:10:92:10 | passwd :  | passwd |
-| testCoreData.swift:97:15:97:15 | z | testCoreData.swift:93:10:93:10 | passwd :  | testCoreData.swift:97:15:97:15 | z | This operation stores 'z' in a database. It may contain unencrypted sensitive data from $@. | testCoreData.swift:93:10:93:10 | passwd :  | passwd |
-| testGRDB.swift:73:56:73:65 | [...] | testGRDB.swift:73:57:73:57 | password :  | testGRDB.swift:73:56:73:65 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:73:57:73:57 | password :  | password |
-| testGRDB.swift:76:42:76:51 | [...] | testGRDB.swift:76:43:76:43 | password :  | testGRDB.swift:76:42:76:51 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:76:43:76:43 | password :  | password |
-| testGRDB.swift:81:44:81:53 | [...] | testGRDB.swift:81:45:81:45 | password :  | testGRDB.swift:81:44:81:53 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:81:45:81:45 | password :  | password |
-| testGRDB.swift:83:44:83:53 | [...] | testGRDB.swift:83:45:83:45 | password :  | testGRDB.swift:83:44:83:53 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:83:45:83:45 | password :  | password |
-| testGRDB.swift:85:44:85:53 | [...] | testGRDB.swift:85:45:85:45 | password :  | testGRDB.swift:85:44:85:53 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:85:45:85:45 | password :  | password |
-| testGRDB.swift:87:44:87:53 | [...] | testGRDB.swift:87:45:87:45 | password :  | testGRDB.swift:87:44:87:53 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:87:45:87:45 | password :  | password |
-| testGRDB.swift:92:37:92:46 | [...] | testGRDB.swift:92:38:92:38 | password :  | testGRDB.swift:92:37:92:46 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:92:38:92:38 | password :  | password |
-| testGRDB.swift:95:36:95:45 | [...] | testGRDB.swift:95:37:95:37 | password :  | testGRDB.swift:95:36:95:45 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:95:37:95:37 | password :  | password |
-| testGRDB.swift:100:72:100:81 | [...] | testGRDB.swift:100:73:100:73 | password :  | testGRDB.swift:100:72:100:81 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:100:73:100:73 | password :  | password |
-| testGRDB.swift:101:72:101:81 | [...] | testGRDB.swift:101:73:101:73 | password :  | testGRDB.swift:101:72:101:81 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:101:73:101:73 | password :  | password |
-| testGRDB.swift:107:52:107:61 | [...] | testGRDB.swift:107:53:107:53 | password :  | testGRDB.swift:107:52:107:61 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:107:53:107:53 | password :  | password |
-| testGRDB.swift:109:52:109:61 | [...] | testGRDB.swift:109:53:109:53 | password :  | testGRDB.swift:109:52:109:61 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:109:53:109:53 | password :  | password |
-| testGRDB.swift:111:51:111:60 | [...] | testGRDB.swift:111:52:111:52 | password :  | testGRDB.swift:111:51:111:60 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:111:52:111:52 | password :  | password |
-| testGRDB.swift:116:47:116:56 | [...] | testGRDB.swift:116:48:116:48 | password :  | testGRDB.swift:116:47:116:56 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:116:48:116:48 | password :  | password |
-| testGRDB.swift:118:47:118:56 | [...] | testGRDB.swift:118:48:118:48 | password :  | testGRDB.swift:118:47:118:56 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:118:48:118:48 | password :  | password |
-| testGRDB.swift:121:44:121:53 | [...] | testGRDB.swift:121:45:121:45 | password :  | testGRDB.swift:121:44:121:53 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:121:45:121:45 | password :  | password |
-| testGRDB.swift:123:44:123:53 | [...] | testGRDB.swift:123:45:123:45 | password :  | testGRDB.swift:123:44:123:53 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:123:45:123:45 | password :  | password |
-| testGRDB.swift:126:44:126:53 | [...] | testGRDB.swift:126:45:126:45 | password :  | testGRDB.swift:126:44:126:53 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:126:45:126:45 | password :  | password |
-| testGRDB.swift:128:44:128:53 | [...] | testGRDB.swift:128:45:128:45 | password :  | testGRDB.swift:128:44:128:53 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:128:45:128:45 | password :  | password |
-| testGRDB.swift:131:44:131:53 | [...] | testGRDB.swift:131:45:131:45 | password :  | testGRDB.swift:131:44:131:53 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:131:45:131:45 | password :  | password |
-| testGRDB.swift:133:44:133:53 | [...] | testGRDB.swift:133:45:133:45 | password :  | testGRDB.swift:133:44:133:53 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:133:45:133:45 | password :  | password |
-| testGRDB.swift:138:68:138:77 | [...] | testGRDB.swift:138:69:138:69 | password :  | testGRDB.swift:138:68:138:77 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:138:69:138:69 | password :  | password |
-| testGRDB.swift:140:68:140:77 | [...] | testGRDB.swift:140:69:140:69 | password :  | testGRDB.swift:140:68:140:77 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:140:69:140:69 | password :  | password |
-| testGRDB.swift:143:65:143:74 | [...] | testGRDB.swift:143:66:143:66 | password :  | testGRDB.swift:143:65:143:74 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:143:66:143:66 | password :  | password |
-| testGRDB.swift:145:65:145:74 | [...] | testGRDB.swift:145:66:145:66 | password :  | testGRDB.swift:145:65:145:74 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:145:66:145:66 | password :  | password |
-| testGRDB.swift:148:65:148:74 | [...] | testGRDB.swift:148:66:148:66 | password :  | testGRDB.swift:148:65:148:74 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:148:66:148:66 | password :  | password |
-| testGRDB.swift:150:65:150:74 | [...] | testGRDB.swift:150:66:150:66 | password :  | testGRDB.swift:150:65:150:74 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:150:66:150:66 | password :  | password |
-| testGRDB.swift:153:65:153:74 | [...] | testGRDB.swift:153:66:153:66 | password :  | testGRDB.swift:153:65:153:74 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:153:66:153:66 | password :  | password |
-| testGRDB.swift:155:65:155:74 | [...] | testGRDB.swift:155:66:155:66 | password :  | testGRDB.swift:155:65:155:74 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:155:66:155:66 | password :  | password |
-| testGRDB.swift:160:59:160:68 | [...] | testGRDB.swift:160:60:160:60 | password :  | testGRDB.swift:160:59:160:68 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:160:60:160:60 | password :  | password |
-| testGRDB.swift:161:50:161:59 | [...] | testGRDB.swift:161:51:161:51 | password :  | testGRDB.swift:161:50:161:59 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:161:51:161:51 | password :  | password |
-| testGRDB.swift:164:59:164:68 | [...] | testGRDB.swift:164:60:164:60 | password :  | testGRDB.swift:164:59:164:68 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:164:60:164:60 | password :  | password |
-| testGRDB.swift:165:50:165:59 | [...] | testGRDB.swift:165:51:165:51 | password :  | testGRDB.swift:165:50:165:59 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:165:51:165:51 | password :  | password |
-| testGRDB.swift:169:56:169:65 | [...] | testGRDB.swift:169:57:169:57 | password :  | testGRDB.swift:169:56:169:65 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:169:57:169:57 | password :  | password |
-| testGRDB.swift:170:47:170:56 | [...] | testGRDB.swift:170:48:170:48 | password :  | testGRDB.swift:170:47:170:56 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:170:48:170:48 | password :  | password |
-| testGRDB.swift:173:56:173:65 | [...] | testGRDB.swift:173:57:173:57 | password :  | testGRDB.swift:173:56:173:65 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:173:57:173:57 | password :  | password |
-| testGRDB.swift:174:47:174:56 | [...] | testGRDB.swift:174:48:174:48 | password :  | testGRDB.swift:174:47:174:56 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:174:48:174:48 | password :  | password |
-| testGRDB.swift:178:56:178:65 | [...] | testGRDB.swift:178:57:178:57 | password :  | testGRDB.swift:178:56:178:65 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:178:57:178:57 | password :  | password |
-| testGRDB.swift:179:47:179:56 | [...] | testGRDB.swift:179:48:179:48 | password :  | testGRDB.swift:179:47:179:56 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:179:48:179:48 | password :  | password |
-| testGRDB.swift:182:56:182:65 | [...] | testGRDB.swift:182:57:182:57 | password :  | testGRDB.swift:182:56:182:65 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:182:57:182:57 | password :  | password |
-| testGRDB.swift:183:47:183:56 | [...] | testGRDB.swift:183:48:183:48 | password :  | testGRDB.swift:183:47:183:56 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:183:48:183:48 | password :  | password |
-| testGRDB.swift:187:56:187:65 | [...] | testGRDB.swift:187:57:187:57 | password :  | testGRDB.swift:187:56:187:65 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:187:57:187:57 | password :  | password |
-| testGRDB.swift:188:47:188:56 | [...] | testGRDB.swift:188:48:188:48 | password :  | testGRDB.swift:188:47:188:56 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:188:48:188:48 | password :  | password |
-| testGRDB.swift:191:56:191:65 | [...] | testGRDB.swift:191:57:191:57 | password :  | testGRDB.swift:191:56:191:65 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:191:57:191:57 | password :  | password |
-| testGRDB.swift:192:47:192:56 | [...] | testGRDB.swift:192:48:192:48 | password :  | testGRDB.swift:192:47:192:56 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:192:48:192:48 | password :  | password |
-| testGRDB.swift:198:29:198:38 | [...] | testGRDB.swift:198:30:198:30 | password :  | testGRDB.swift:198:29:198:38 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:198:30:198:30 | password :  | password |
-| testGRDB.swift:201:23:201:32 | [...] | testGRDB.swift:201:24:201:24 | password :  | testGRDB.swift:201:23:201:32 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:201:24:201:24 | password :  | password |
-| testGRDB.swift:206:66:206:75 | [...] | testGRDB.swift:206:67:206:67 | password :  | testGRDB.swift:206:66:206:75 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:206:67:206:67 | password :  | password |
-| testGRDB.swift:208:80:208:89 | [...] | testGRDB.swift:208:81:208:81 | password :  | testGRDB.swift:208:80:208:89 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:208:81:208:81 | password :  | password |
-| testGRDB.swift:210:84:210:93 | [...] | testGRDB.swift:210:85:210:85 | password :  | testGRDB.swift:210:84:210:93 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:210:85:210:85 | password :  | password |
-| testGRDB.swift:212:98:212:107 | [...] | testGRDB.swift:212:99:212:99 | password :  | testGRDB.swift:212:98:212:107 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:212:99:212:99 | password :  | password |
-| testRealm.swift:41:2:41:2 | a | testRealm.swift:41:11:41:11 | myPassword :  | testRealm.swift:41:2:41:2 | [post] a | This operation stores 'a' in a database. It may contain unencrypted sensitive data from $@. | testRealm.swift:41:11:41:11 | myPassword :  | myPassword |
-| testRealm.swift:49:2:49:2 | c | testRealm.swift:49:11:49:11 | myPassword :  | testRealm.swift:49:2:49:2 | [post] c | This operation stores 'c' in a database. It may contain unencrypted sensitive data from $@. | testRealm.swift:49:11:49:11 | myPassword :  | myPassword |
-| testRealm.swift:59:2:59:3 | ...! | testRealm.swift:59:12:59:12 | myPassword :  | testRealm.swift:59:2:59:3 | [post] ...! | This operation stores '...!' in a database. It may contain unencrypted sensitive data from $@. | testRealm.swift:59:12:59:12 | myPassword :  | myPassword |
-| testRealm.swift:66:2:66:2 | g | testRealm.swift:66:11:66:11 | myPassword :  | testRealm.swift:66:2:66:2 | [post] g | This operation stores 'g' in a database. It may contain unencrypted sensitive data from $@. | testRealm.swift:66:11:66:11 | myPassword :  | myPassword |
-| testRealm.swift:73:2:73:2 | h | testRealm.swift:73:15:73:15 | myPassword :  | testRealm.swift:73:2:73:2 | [post] h | This operation stores 'h' in a database. It may contain unencrypted sensitive data from $@. | testRealm.swift:73:15:73:15 | myPassword :  | myPassword |
+| testCoreData.swift:95:15:95:15 | x | testCoreData.swift:91:10:91:10 | passwd | testCoreData.swift:95:15:95:15 | x | This operation stores 'x' in a database. It may contain unencrypted sensitive data from $@. | testCoreData.swift:91:10:91:10 | passwd | passwd |
+| testCoreData.swift:96:15:96:15 | y | testCoreData.swift:92:10:92:10 | passwd | testCoreData.swift:96:15:96:15 | y | This operation stores 'y' in a database. It may contain unencrypted sensitive data from $@. | testCoreData.swift:92:10:92:10 | passwd | passwd |
+| testCoreData.swift:97:15:97:15 | z | testCoreData.swift:93:10:93:10 | passwd | testCoreData.swift:97:15:97:15 | z | This operation stores 'z' in a database. It may contain unencrypted sensitive data from $@. | testCoreData.swift:93:10:93:10 | passwd | passwd |
+| testGRDB.swift:73:56:73:65 | [...] | testGRDB.swift:73:57:73:57 | password | testGRDB.swift:73:56:73:65 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:73:57:73:57 | password | password |
+| testGRDB.swift:76:42:76:51 | [...] | testGRDB.swift:76:43:76:43 | password | testGRDB.swift:76:42:76:51 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:76:43:76:43 | password | password |
+| testGRDB.swift:81:44:81:53 | [...] | testGRDB.swift:81:45:81:45 | password | testGRDB.swift:81:44:81:53 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:81:45:81:45 | password | password |
+| testGRDB.swift:83:44:83:53 | [...] | testGRDB.swift:83:45:83:45 | password | testGRDB.swift:83:44:83:53 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:83:45:83:45 | password | password |
+| testGRDB.swift:85:44:85:53 | [...] | testGRDB.swift:85:45:85:45 | password | testGRDB.swift:85:44:85:53 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:85:45:85:45 | password | password |
+| testGRDB.swift:87:44:87:53 | [...] | testGRDB.swift:87:45:87:45 | password | testGRDB.swift:87:44:87:53 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:87:45:87:45 | password | password |
+| testGRDB.swift:92:37:92:46 | [...] | testGRDB.swift:92:38:92:38 | password | testGRDB.swift:92:37:92:46 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:92:38:92:38 | password | password |
+| testGRDB.swift:95:36:95:45 | [...] | testGRDB.swift:95:37:95:37 | password | testGRDB.swift:95:36:95:45 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:95:37:95:37 | password | password |
+| testGRDB.swift:100:72:100:81 | [...] | testGRDB.swift:100:73:100:73 | password | testGRDB.swift:100:72:100:81 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:100:73:100:73 | password | password |
+| testGRDB.swift:101:72:101:81 | [...] | testGRDB.swift:101:73:101:73 | password | testGRDB.swift:101:72:101:81 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:101:73:101:73 | password | password |
+| testGRDB.swift:107:52:107:61 | [...] | testGRDB.swift:107:53:107:53 | password | testGRDB.swift:107:52:107:61 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:107:53:107:53 | password | password |
+| testGRDB.swift:109:52:109:61 | [...] | testGRDB.swift:109:53:109:53 | password | testGRDB.swift:109:52:109:61 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:109:53:109:53 | password | password |
+| testGRDB.swift:111:51:111:60 | [...] | testGRDB.swift:111:52:111:52 | password | testGRDB.swift:111:51:111:60 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:111:52:111:52 | password | password |
+| testGRDB.swift:116:47:116:56 | [...] | testGRDB.swift:116:48:116:48 | password | testGRDB.swift:116:47:116:56 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:116:48:116:48 | password | password |
+| testGRDB.swift:118:47:118:56 | [...] | testGRDB.swift:118:48:118:48 | password | testGRDB.swift:118:47:118:56 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:118:48:118:48 | password | password |
+| testGRDB.swift:121:44:121:53 | [...] | testGRDB.swift:121:45:121:45 | password | testGRDB.swift:121:44:121:53 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:121:45:121:45 | password | password |
+| testGRDB.swift:123:44:123:53 | [...] | testGRDB.swift:123:45:123:45 | password | testGRDB.swift:123:44:123:53 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:123:45:123:45 | password | password |
+| testGRDB.swift:126:44:126:53 | [...] | testGRDB.swift:126:45:126:45 | password | testGRDB.swift:126:44:126:53 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:126:45:126:45 | password | password |
+| testGRDB.swift:128:44:128:53 | [...] | testGRDB.swift:128:45:128:45 | password | testGRDB.swift:128:44:128:53 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:128:45:128:45 | password | password |
+| testGRDB.swift:131:44:131:53 | [...] | testGRDB.swift:131:45:131:45 | password | testGRDB.swift:131:44:131:53 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:131:45:131:45 | password | password |
+| testGRDB.swift:133:44:133:53 | [...] | testGRDB.swift:133:45:133:45 | password | testGRDB.swift:133:44:133:53 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:133:45:133:45 | password | password |
+| testGRDB.swift:138:68:138:77 | [...] | testGRDB.swift:138:69:138:69 | password | testGRDB.swift:138:68:138:77 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:138:69:138:69 | password | password |
+| testGRDB.swift:140:68:140:77 | [...] | testGRDB.swift:140:69:140:69 | password | testGRDB.swift:140:68:140:77 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:140:69:140:69 | password | password |
+| testGRDB.swift:143:65:143:74 | [...] | testGRDB.swift:143:66:143:66 | password | testGRDB.swift:143:65:143:74 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:143:66:143:66 | password | password |
+| testGRDB.swift:145:65:145:74 | [...] | testGRDB.swift:145:66:145:66 | password | testGRDB.swift:145:65:145:74 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:145:66:145:66 | password | password |
+| testGRDB.swift:148:65:148:74 | [...] | testGRDB.swift:148:66:148:66 | password | testGRDB.swift:148:65:148:74 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:148:66:148:66 | password | password |
+| testGRDB.swift:150:65:150:74 | [...] | testGRDB.swift:150:66:150:66 | password | testGRDB.swift:150:65:150:74 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:150:66:150:66 | password | password |
+| testGRDB.swift:153:65:153:74 | [...] | testGRDB.swift:153:66:153:66 | password | testGRDB.swift:153:65:153:74 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:153:66:153:66 | password | password |
+| testGRDB.swift:155:65:155:74 | [...] | testGRDB.swift:155:66:155:66 | password | testGRDB.swift:155:65:155:74 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:155:66:155:66 | password | password |
+| testGRDB.swift:160:59:160:68 | [...] | testGRDB.swift:160:60:160:60 | password | testGRDB.swift:160:59:160:68 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:160:60:160:60 | password | password |
+| testGRDB.swift:161:50:161:59 | [...] | testGRDB.swift:161:51:161:51 | password | testGRDB.swift:161:50:161:59 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:161:51:161:51 | password | password |
+| testGRDB.swift:164:59:164:68 | [...] | testGRDB.swift:164:60:164:60 | password | testGRDB.swift:164:59:164:68 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:164:60:164:60 | password | password |
+| testGRDB.swift:165:50:165:59 | [...] | testGRDB.swift:165:51:165:51 | password | testGRDB.swift:165:50:165:59 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:165:51:165:51 | password | password |
+| testGRDB.swift:169:56:169:65 | [...] | testGRDB.swift:169:57:169:57 | password | testGRDB.swift:169:56:169:65 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:169:57:169:57 | password | password |
+| testGRDB.swift:170:47:170:56 | [...] | testGRDB.swift:170:48:170:48 | password | testGRDB.swift:170:47:170:56 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:170:48:170:48 | password | password |
+| testGRDB.swift:173:56:173:65 | [...] | testGRDB.swift:173:57:173:57 | password | testGRDB.swift:173:56:173:65 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:173:57:173:57 | password | password |
+| testGRDB.swift:174:47:174:56 | [...] | testGRDB.swift:174:48:174:48 | password | testGRDB.swift:174:47:174:56 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:174:48:174:48 | password | password |
+| testGRDB.swift:178:56:178:65 | [...] | testGRDB.swift:178:57:178:57 | password | testGRDB.swift:178:56:178:65 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:178:57:178:57 | password | password |
+| testGRDB.swift:179:47:179:56 | [...] | testGRDB.swift:179:48:179:48 | password | testGRDB.swift:179:47:179:56 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:179:48:179:48 | password | password |
+| testGRDB.swift:182:56:182:65 | [...] | testGRDB.swift:182:57:182:57 | password | testGRDB.swift:182:56:182:65 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:182:57:182:57 | password | password |
+| testGRDB.swift:183:47:183:56 | [...] | testGRDB.swift:183:48:183:48 | password | testGRDB.swift:183:47:183:56 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:183:48:183:48 | password | password |
+| testGRDB.swift:187:56:187:65 | [...] | testGRDB.swift:187:57:187:57 | password | testGRDB.swift:187:56:187:65 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:187:57:187:57 | password | password |
+| testGRDB.swift:188:47:188:56 | [...] | testGRDB.swift:188:48:188:48 | password | testGRDB.swift:188:47:188:56 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:188:48:188:48 | password | password |
+| testGRDB.swift:191:56:191:65 | [...] | testGRDB.swift:191:57:191:57 | password | testGRDB.swift:191:56:191:65 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:191:57:191:57 | password | password |
+| testGRDB.swift:192:47:192:56 | [...] | testGRDB.swift:192:48:192:48 | password | testGRDB.swift:192:47:192:56 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:192:48:192:48 | password | password |
+| testGRDB.swift:198:29:198:38 | [...] | testGRDB.swift:198:30:198:30 | password | testGRDB.swift:198:29:198:38 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:198:30:198:30 | password | password |
+| testGRDB.swift:201:23:201:32 | [...] | testGRDB.swift:201:24:201:24 | password | testGRDB.swift:201:23:201:32 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:201:24:201:24 | password | password |
+| testGRDB.swift:206:66:206:75 | [...] | testGRDB.swift:206:67:206:67 | password | testGRDB.swift:206:66:206:75 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:206:67:206:67 | password | password |
+| testGRDB.swift:208:80:208:89 | [...] | testGRDB.swift:208:81:208:81 | password | testGRDB.swift:208:80:208:89 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:208:81:208:81 | password | password |
+| testGRDB.swift:210:84:210:93 | [...] | testGRDB.swift:210:85:210:85 | password | testGRDB.swift:210:84:210:93 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:210:85:210:85 | password | password |
+| testGRDB.swift:212:98:212:107 | [...] | testGRDB.swift:212:99:212:99 | password | testGRDB.swift:212:98:212:107 | [...] | This operation stores '[...]' in a database. It may contain unencrypted sensitive data from $@. | testGRDB.swift:212:99:212:99 | password | password |
+| testRealm.swift:41:2:41:2 | a | testRealm.swift:41:11:41:11 | myPassword | testRealm.swift:41:2:41:2 | [post] a | This operation stores 'a' in a database. It may contain unencrypted sensitive data from $@. | testRealm.swift:41:11:41:11 | myPassword | myPassword |
+| testRealm.swift:49:2:49:2 | c | testRealm.swift:49:11:49:11 | myPassword | testRealm.swift:49:2:49:2 | [post] c | This operation stores 'c' in a database. It may contain unencrypted sensitive data from $@. | testRealm.swift:49:11:49:11 | myPassword | myPassword |
+| testRealm.swift:59:2:59:3 | ...! | testRealm.swift:59:12:59:12 | myPassword | testRealm.swift:59:2:59:3 | [post] ...! | This operation stores '...!' in a database. It may contain unencrypted sensitive data from $@. | testRealm.swift:59:12:59:12 | myPassword | myPassword |
+| testRealm.swift:66:2:66:2 | g | testRealm.swift:66:11:66:11 | myPassword | testRealm.swift:66:2:66:2 | [post] g | This operation stores 'g' in a database. It may contain unencrypted sensitive data from $@. | testRealm.swift:66:11:66:11 | myPassword | myPassword |
+| testRealm.swift:73:2:73:2 | h | testRealm.swift:73:15:73:15 | myPassword | testRealm.swift:73:2:73:2 | [post] h | This operation stores 'h' in a database. It may contain unencrypted sensitive data from $@. | testRealm.swift:73:15:73:15 | myPassword | myPassword |

--- a/swift/ql/test/query-tests/Security/CWE-757/InsecureTLS.expected
+++ b/swift/ql/test/query-tests/Security/CWE-757/InsecureTLS.expected
@@ -1,86 +1,86 @@
 edges
-| InsecureTLS.swift:19:7:19:7 | value :  | file://:0:0:0:0 | value |
-| InsecureTLS.swift:20:7:20:7 | value :  | file://:0:0:0:0 | value |
-| InsecureTLS.swift:22:7:22:7 | value :  | file://:0:0:0:0 | value |
-| InsecureTLS.swift:23:7:23:7 | value :  | file://:0:0:0:0 | value |
-| InsecureTLS.swift:40:47:40:70 | .TLSv10 :  | InsecureTLS.swift:19:7:19:7 | value :  |
-| InsecureTLS.swift:45:47:45:70 | .TLSv11 :  | InsecureTLS.swift:19:7:19:7 | value :  |
-| InsecureTLS.swift:57:47:57:70 | .TLSv10 :  | InsecureTLS.swift:20:7:20:7 | value :  |
-| InsecureTLS.swift:64:40:64:52 | .tlsProtocol10 :  | InsecureTLS.swift:22:7:22:7 | value :  |
-| InsecureTLS.swift:76:40:76:52 | .tlsProtocol10 :  | InsecureTLS.swift:23:7:23:7 | value :  |
-| InsecureTLS.swift:102:10:102:33 | .TLSv10 :  | InsecureTLS.swift:111:47:111:64 | call to getBadTLSVersion() |
-| InsecureTLS.swift:102:10:102:33 | .TLSv10 :  | InsecureTLS.swift:111:47:111:64 | call to getBadTLSVersion() :  |
-| InsecureTLS.swift:111:47:111:64 | call to getBadTLSVersion() :  | InsecureTLS.swift:19:7:19:7 | value :  |
-| InsecureTLS.swift:121:55:121:66 | version :  | InsecureTLS.swift:122:47:122:47 | version |
-| InsecureTLS.swift:121:55:121:66 | version :  | InsecureTLS.swift:122:47:122:47 | version :  |
-| InsecureTLS.swift:122:47:122:47 | version :  | InsecureTLS.swift:19:7:19:7 | value :  |
-| InsecureTLS.swift:127:25:127:48 | .TLSv11 :  | InsecureTLS.swift:121:55:121:66 | version :  |
-| InsecureTLS.swift:158:7:158:7 | self [TLSVersion] :  | file://:0:0:0:0 | self [TLSVersion] :  |
-| InsecureTLS.swift:158:7:158:7 | value :  | file://:0:0:0:0 | value :  |
-| InsecureTLS.swift:163:3:163:3 | [post] def [TLSVersion] :  | InsecureTLS.swift:165:47:165:47 | def [TLSVersion] :  |
-| InsecureTLS.swift:163:20:163:43 | .TLSv10 :  | InsecureTLS.swift:158:7:158:7 | value :  |
-| InsecureTLS.swift:163:20:163:43 | .TLSv10 :  | InsecureTLS.swift:163:3:163:3 | [post] def [TLSVersion] :  |
-| InsecureTLS.swift:165:47:165:47 | def [TLSVersion] :  | InsecureTLS.swift:158:7:158:7 | self [TLSVersion] :  |
-| InsecureTLS.swift:165:47:165:47 | def [TLSVersion] :  | InsecureTLS.swift:165:47:165:51 | .TLSVersion |
-| InsecureTLS.swift:165:47:165:47 | def [TLSVersion] :  | InsecureTLS.swift:165:47:165:51 | .TLSVersion :  |
-| InsecureTLS.swift:165:47:165:51 | .TLSVersion :  | InsecureTLS.swift:19:7:19:7 | value :  |
-| file://:0:0:0:0 | self [TLSVersion] :  | file://:0:0:0:0 | .TLSVersion :  |
-| file://:0:0:0:0 | value :  | file://:0:0:0:0 | [post] self [TLSVersion] :  |
+| InsecureTLS.swift:19:7:19:7 | value | file://:0:0:0:0 | value |
+| InsecureTLS.swift:20:7:20:7 | value | file://:0:0:0:0 | value |
+| InsecureTLS.swift:22:7:22:7 | value | file://:0:0:0:0 | value |
+| InsecureTLS.swift:23:7:23:7 | value | file://:0:0:0:0 | value |
+| InsecureTLS.swift:40:47:40:70 | .TLSv10 | InsecureTLS.swift:19:7:19:7 | value |
+| InsecureTLS.swift:45:47:45:70 | .TLSv11 | InsecureTLS.swift:19:7:19:7 | value |
+| InsecureTLS.swift:57:47:57:70 | .TLSv10 | InsecureTLS.swift:20:7:20:7 | value |
+| InsecureTLS.swift:64:40:64:52 | .tlsProtocol10 | InsecureTLS.swift:22:7:22:7 | value |
+| InsecureTLS.swift:76:40:76:52 | .tlsProtocol10 | InsecureTLS.swift:23:7:23:7 | value |
+| InsecureTLS.swift:102:10:102:33 | .TLSv10 | InsecureTLS.swift:111:47:111:64 | call to getBadTLSVersion() |
+| InsecureTLS.swift:102:10:102:33 | .TLSv10 | InsecureTLS.swift:111:47:111:64 | call to getBadTLSVersion() |
+| InsecureTLS.swift:111:47:111:64 | call to getBadTLSVersion() | InsecureTLS.swift:19:7:19:7 | value |
+| InsecureTLS.swift:121:55:121:66 | version | InsecureTLS.swift:122:47:122:47 | version |
+| InsecureTLS.swift:121:55:121:66 | version | InsecureTLS.swift:122:47:122:47 | version |
+| InsecureTLS.swift:122:47:122:47 | version | InsecureTLS.swift:19:7:19:7 | value |
+| InsecureTLS.swift:127:25:127:48 | .TLSv11 | InsecureTLS.swift:121:55:121:66 | version |
+| InsecureTLS.swift:158:7:158:7 | self [TLSVersion] | file://:0:0:0:0 | self [TLSVersion] |
+| InsecureTLS.swift:158:7:158:7 | value | file://:0:0:0:0 | value |
+| InsecureTLS.swift:163:3:163:3 | [post] def [TLSVersion] | InsecureTLS.swift:165:47:165:47 | def [TLSVersion] |
+| InsecureTLS.swift:163:20:163:43 | .TLSv10 | InsecureTLS.swift:158:7:158:7 | value |
+| InsecureTLS.swift:163:20:163:43 | .TLSv10 | InsecureTLS.swift:163:3:163:3 | [post] def [TLSVersion] |
+| InsecureTLS.swift:165:47:165:47 | def [TLSVersion] | InsecureTLS.swift:158:7:158:7 | self [TLSVersion] |
+| InsecureTLS.swift:165:47:165:47 | def [TLSVersion] | InsecureTLS.swift:165:47:165:51 | .TLSVersion |
+| InsecureTLS.swift:165:47:165:47 | def [TLSVersion] | InsecureTLS.swift:165:47:165:51 | .TLSVersion |
+| InsecureTLS.swift:165:47:165:51 | .TLSVersion | InsecureTLS.swift:19:7:19:7 | value |
+| file://:0:0:0:0 | self [TLSVersion] | file://:0:0:0:0 | .TLSVersion |
+| file://:0:0:0:0 | value | file://:0:0:0:0 | [post] self [TLSVersion] |
 nodes
-| InsecureTLS.swift:19:7:19:7 | value :  | semmle.label | value :  |
-| InsecureTLS.swift:20:7:20:7 | value :  | semmle.label | value :  |
-| InsecureTLS.swift:22:7:22:7 | value :  | semmle.label | value :  |
-| InsecureTLS.swift:23:7:23:7 | value :  | semmle.label | value :  |
+| InsecureTLS.swift:19:7:19:7 | value | semmle.label | value |
+| InsecureTLS.swift:20:7:20:7 | value | semmle.label | value |
+| InsecureTLS.swift:22:7:22:7 | value | semmle.label | value |
+| InsecureTLS.swift:23:7:23:7 | value | semmle.label | value |
 | InsecureTLS.swift:40:47:40:70 | .TLSv10 | semmle.label | .TLSv10 |
-| InsecureTLS.swift:40:47:40:70 | .TLSv10 :  | semmle.label | .TLSv10 :  |
+| InsecureTLS.swift:40:47:40:70 | .TLSv10 | semmle.label | .TLSv10 |
 | InsecureTLS.swift:45:47:45:70 | .TLSv11 | semmle.label | .TLSv11 |
-| InsecureTLS.swift:45:47:45:70 | .TLSv11 :  | semmle.label | .TLSv11 :  |
+| InsecureTLS.swift:45:47:45:70 | .TLSv11 | semmle.label | .TLSv11 |
 | InsecureTLS.swift:57:47:57:70 | .TLSv10 | semmle.label | .TLSv10 |
-| InsecureTLS.swift:57:47:57:70 | .TLSv10 :  | semmle.label | .TLSv10 :  |
+| InsecureTLS.swift:57:47:57:70 | .TLSv10 | semmle.label | .TLSv10 |
 | InsecureTLS.swift:64:40:64:52 | .tlsProtocol10 | semmle.label | .tlsProtocol10 |
-| InsecureTLS.swift:64:40:64:52 | .tlsProtocol10 :  | semmle.label | .tlsProtocol10 :  |
+| InsecureTLS.swift:64:40:64:52 | .tlsProtocol10 | semmle.label | .tlsProtocol10 |
 | InsecureTLS.swift:76:40:76:52 | .tlsProtocol10 | semmle.label | .tlsProtocol10 |
-| InsecureTLS.swift:76:40:76:52 | .tlsProtocol10 :  | semmle.label | .tlsProtocol10 :  |
-| InsecureTLS.swift:102:10:102:33 | .TLSv10 :  | semmle.label | .TLSv10 :  |
+| InsecureTLS.swift:76:40:76:52 | .tlsProtocol10 | semmle.label | .tlsProtocol10 |
+| InsecureTLS.swift:102:10:102:33 | .TLSv10 | semmle.label | .TLSv10 |
 | InsecureTLS.swift:111:47:111:64 | call to getBadTLSVersion() | semmle.label | call to getBadTLSVersion() |
-| InsecureTLS.swift:111:47:111:64 | call to getBadTLSVersion() :  | semmle.label | call to getBadTLSVersion() :  |
-| InsecureTLS.swift:121:55:121:66 | version :  | semmle.label | version :  |
+| InsecureTLS.swift:111:47:111:64 | call to getBadTLSVersion() | semmle.label | call to getBadTLSVersion() |
+| InsecureTLS.swift:121:55:121:66 | version | semmle.label | version |
 | InsecureTLS.swift:122:47:122:47 | version | semmle.label | version |
-| InsecureTLS.swift:122:47:122:47 | version :  | semmle.label | version :  |
-| InsecureTLS.swift:127:25:127:48 | .TLSv11 :  | semmle.label | .TLSv11 :  |
-| InsecureTLS.swift:158:7:158:7 | self [TLSVersion] :  | semmle.label | self [TLSVersion] :  |
-| InsecureTLS.swift:158:7:158:7 | value :  | semmle.label | value :  |
-| InsecureTLS.swift:163:3:163:3 | [post] def [TLSVersion] :  | semmle.label | [post] def [TLSVersion] :  |
-| InsecureTLS.swift:163:20:163:43 | .TLSv10 :  | semmle.label | .TLSv10 :  |
-| InsecureTLS.swift:165:47:165:47 | def [TLSVersion] :  | semmle.label | def [TLSVersion] :  |
+| InsecureTLS.swift:122:47:122:47 | version | semmle.label | version |
+| InsecureTLS.swift:127:25:127:48 | .TLSv11 | semmle.label | .TLSv11 |
+| InsecureTLS.swift:158:7:158:7 | self [TLSVersion] | semmle.label | self [TLSVersion] |
+| InsecureTLS.swift:158:7:158:7 | value | semmle.label | value |
+| InsecureTLS.swift:163:3:163:3 | [post] def [TLSVersion] | semmle.label | [post] def [TLSVersion] |
+| InsecureTLS.swift:163:20:163:43 | .TLSv10 | semmle.label | .TLSv10 |
+| InsecureTLS.swift:165:47:165:47 | def [TLSVersion] | semmle.label | def [TLSVersion] |
 | InsecureTLS.swift:165:47:165:51 | .TLSVersion | semmle.label | .TLSVersion |
-| InsecureTLS.swift:165:47:165:51 | .TLSVersion :  | semmle.label | .TLSVersion :  |
-| file://:0:0:0:0 | .TLSVersion :  | semmle.label | .TLSVersion :  |
-| file://:0:0:0:0 | [post] self [TLSVersion] :  | semmle.label | [post] self [TLSVersion] :  |
-| file://:0:0:0:0 | self [TLSVersion] :  | semmle.label | self [TLSVersion] :  |
+| InsecureTLS.swift:165:47:165:51 | .TLSVersion | semmle.label | .TLSVersion |
+| file://:0:0:0:0 | .TLSVersion | semmle.label | .TLSVersion |
+| file://:0:0:0:0 | [post] self [TLSVersion] | semmle.label | [post] self [TLSVersion] |
+| file://:0:0:0:0 | self [TLSVersion] | semmle.label | self [TLSVersion] |
 | file://:0:0:0:0 | value | semmle.label | value |
 | file://:0:0:0:0 | value | semmle.label | value |
 | file://:0:0:0:0 | value | semmle.label | value |
 | file://:0:0:0:0 | value | semmle.label | value |
-| file://:0:0:0:0 | value :  | semmle.label | value :  |
+| file://:0:0:0:0 | value | semmle.label | value |
 subpaths
-| InsecureTLS.swift:163:20:163:43 | .TLSv10 :  | InsecureTLS.swift:158:7:158:7 | value :  | file://:0:0:0:0 | [post] self [TLSVersion] :  | InsecureTLS.swift:163:3:163:3 | [post] def [TLSVersion] :  |
-| InsecureTLS.swift:165:47:165:47 | def [TLSVersion] :  | InsecureTLS.swift:158:7:158:7 | self [TLSVersion] :  | file://:0:0:0:0 | .TLSVersion :  | InsecureTLS.swift:165:47:165:51 | .TLSVersion |
-| InsecureTLS.swift:165:47:165:47 | def [TLSVersion] :  | InsecureTLS.swift:158:7:158:7 | self [TLSVersion] :  | file://:0:0:0:0 | .TLSVersion :  | InsecureTLS.swift:165:47:165:51 | .TLSVersion :  |
+| InsecureTLS.swift:163:20:163:43 | .TLSv10 | InsecureTLS.swift:158:7:158:7 | value | file://:0:0:0:0 | [post] self [TLSVersion] | InsecureTLS.swift:163:3:163:3 | [post] def [TLSVersion] |
+| InsecureTLS.swift:165:47:165:47 | def [TLSVersion] | InsecureTLS.swift:158:7:158:7 | self [TLSVersion] | file://:0:0:0:0 | .TLSVersion | InsecureTLS.swift:165:47:165:51 | .TLSVersion |
+| InsecureTLS.swift:165:47:165:47 | def [TLSVersion] | InsecureTLS.swift:158:7:158:7 | self [TLSVersion] | file://:0:0:0:0 | .TLSVersion | InsecureTLS.swift:165:47:165:51 | .TLSVersion |
 #select
 | InsecureTLS.swift:40:47:40:70 | .TLSv10 | InsecureTLS.swift:40:47:40:70 | .TLSv10 | InsecureTLS.swift:40:47:40:70 | .TLSv10 | This TLS configuration is insecure. |
 | InsecureTLS.swift:45:47:45:70 | .TLSv11 | InsecureTLS.swift:45:47:45:70 | .TLSv11 | InsecureTLS.swift:45:47:45:70 | .TLSv11 | This TLS configuration is insecure. |
 | InsecureTLS.swift:57:47:57:70 | .TLSv10 | InsecureTLS.swift:57:47:57:70 | .TLSv10 | InsecureTLS.swift:57:47:57:70 | .TLSv10 | This TLS configuration is insecure. |
 | InsecureTLS.swift:64:40:64:52 | .tlsProtocol10 | InsecureTLS.swift:64:40:64:52 | .tlsProtocol10 | InsecureTLS.swift:64:40:64:52 | .tlsProtocol10 | This TLS configuration is insecure. |
 | InsecureTLS.swift:76:40:76:52 | .tlsProtocol10 | InsecureTLS.swift:76:40:76:52 | .tlsProtocol10 | InsecureTLS.swift:76:40:76:52 | .tlsProtocol10 | This TLS configuration is insecure. |
-| InsecureTLS.swift:111:47:111:64 | call to getBadTLSVersion() | InsecureTLS.swift:102:10:102:33 | .TLSv10 :  | InsecureTLS.swift:111:47:111:64 | call to getBadTLSVersion() | This TLS configuration is insecure. |
-| InsecureTLS.swift:122:47:122:47 | version | InsecureTLS.swift:127:25:127:48 | .TLSv11 :  | InsecureTLS.swift:122:47:122:47 | version | This TLS configuration is insecure. |
-| InsecureTLS.swift:165:47:165:51 | .TLSVersion | InsecureTLS.swift:163:20:163:43 | .TLSv10 :  | InsecureTLS.swift:165:47:165:51 | .TLSVersion | This TLS configuration is insecure. |
-| file://:0:0:0:0 | value | InsecureTLS.swift:40:47:40:70 | .TLSv10 :  | file://:0:0:0:0 | value | This TLS configuration is insecure. |
-| file://:0:0:0:0 | value | InsecureTLS.swift:45:47:45:70 | .TLSv11 :  | file://:0:0:0:0 | value | This TLS configuration is insecure. |
-| file://:0:0:0:0 | value | InsecureTLS.swift:57:47:57:70 | .TLSv10 :  | file://:0:0:0:0 | value | This TLS configuration is insecure. |
-| file://:0:0:0:0 | value | InsecureTLS.swift:64:40:64:52 | .tlsProtocol10 :  | file://:0:0:0:0 | value | This TLS configuration is insecure. |
-| file://:0:0:0:0 | value | InsecureTLS.swift:76:40:76:52 | .tlsProtocol10 :  | file://:0:0:0:0 | value | This TLS configuration is insecure. |
-| file://:0:0:0:0 | value | InsecureTLS.swift:102:10:102:33 | .TLSv10 :  | file://:0:0:0:0 | value | This TLS configuration is insecure. |
-| file://:0:0:0:0 | value | InsecureTLS.swift:127:25:127:48 | .TLSv11 :  | file://:0:0:0:0 | value | This TLS configuration is insecure. |
-| file://:0:0:0:0 | value | InsecureTLS.swift:163:20:163:43 | .TLSv10 :  | file://:0:0:0:0 | value | This TLS configuration is insecure. |
+| InsecureTLS.swift:111:47:111:64 | call to getBadTLSVersion() | InsecureTLS.swift:102:10:102:33 | .TLSv10 | InsecureTLS.swift:111:47:111:64 | call to getBadTLSVersion() | This TLS configuration is insecure. |
+| InsecureTLS.swift:122:47:122:47 | version | InsecureTLS.swift:127:25:127:48 | .TLSv11 | InsecureTLS.swift:122:47:122:47 | version | This TLS configuration is insecure. |
+| InsecureTLS.swift:165:47:165:51 | .TLSVersion | InsecureTLS.swift:163:20:163:43 | .TLSv10 | InsecureTLS.swift:165:47:165:51 | .TLSVersion | This TLS configuration is insecure. |
+| file://:0:0:0:0 | value | InsecureTLS.swift:40:47:40:70 | .TLSv10 | file://:0:0:0:0 | value | This TLS configuration is insecure. |
+| file://:0:0:0:0 | value | InsecureTLS.swift:45:47:45:70 | .TLSv11 | file://:0:0:0:0 | value | This TLS configuration is insecure. |
+| file://:0:0:0:0 | value | InsecureTLS.swift:57:47:57:70 | .TLSv10 | file://:0:0:0:0 | value | This TLS configuration is insecure. |
+| file://:0:0:0:0 | value | InsecureTLS.swift:64:40:64:52 | .tlsProtocol10 | file://:0:0:0:0 | value | This TLS configuration is insecure. |
+| file://:0:0:0:0 | value | InsecureTLS.swift:76:40:76:52 | .tlsProtocol10 | file://:0:0:0:0 | value | This TLS configuration is insecure. |
+| file://:0:0:0:0 | value | InsecureTLS.swift:102:10:102:33 | .TLSv10 | file://:0:0:0:0 | value | This TLS configuration is insecure. |
+| file://:0:0:0:0 | value | InsecureTLS.swift:127:25:127:48 | .TLSv11 | file://:0:0:0:0 | value | This TLS configuration is insecure. |
+| file://:0:0:0:0 | value | InsecureTLS.swift:163:20:163:43 | .TLSv10 | file://:0:0:0:0 | value | This TLS configuration is insecure. |


### PR DESCRIPTION
Swift doesn't use type pruning in data flow, so there's no need to print an empty type in the toString of PathNode.