### PR TITLE
Python: Hide `ModuleVariableNode` in data-flow paths

### DIFF
--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
@@ -928,6 +928,8 @@ predicate forceHighPrecision(Content c) { none() }
 
 /** Holds if `n` should be hidden from path explanations. */
 predicate nodeIsHidden(Node n) {
+  n instanceof ModuleVariableNode
+  or
   n instanceof SummaryNode
   or
   n instanceof SummaryParameterNode

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowPublic.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowPublic.qll
@@ -407,7 +407,7 @@ class ModuleVariableNode extends Node, TModuleVariableNode {
   override Scope getScope() { result = mod }
 
   override string toString() {
-    result = "ModuleVariableNode for " + mod.getName() + "." + var.getId()
+    result = "ModuleVariableNode in " + mod.toString() + " for " + var.getId()
   }
 
   /** Gets the module in which this variable appears. */


### PR DESCRIPTION
They just add an extra step, and don't actually contribute any good information for end-users.

(also fixed their .toString() implementation)

This will generate a lot of changes in .expected files, which I will fix up once tests have indicated which ones :D