### PR TITLE
Swift: Initial language guides documentation for Swift

### DIFF
--- a/docs/codeql/codeql-language-guides/analyzing-data-flow-in-swift.rst
+++ b/docs/codeql/codeql-language-guides/analyzing-data-flow-in-swift.rst
@@ -1,0 +1,290 @@
+.. _analyzing-data-flow-in-swift:
+
+Analyzing data flow in Swift
+============================
+
+You can use CodeQL to track the flow of data through a Swift program to places where the data is used.
+
+About this article
+------------------
+
+This article describes how data flow analysis is implemented in the CodeQL libraries for Swift and includes examples to help you write your own data flow queries.
+The following sections describe how to use the libraries for local data flow, global data flow, and taint tracking.
+For a more general introduction to modeling data flow, see ":ref:`About data flow analysis <about-data-flow-analysis>`."
+
+Local data flow
+---------------
+
+Local data flow tracks the flow of data within a single method or callable. Local data flow is easier, faster, and more precise than global data flow. Before looking at more complex tracking, you should always consider local tracking because it is sufficient for many queries.
+
+Using local data flow
+~~~~~~~~~~~~~~~~~~~~~
+
+You can use the local data flow library by importing the ``DataFlow`` module. The library uses the class ``Node`` to represent any element through which data can flow.
+The ``Node`` class has a number of useful subclasses, such as ``ExprNode`` for expressions and ``ParameterNode`` for parameters. You can map between data flow nodes and expressions/control-flow nodes using the member predicates ``asExpr`` and ``getCfgNode``:
+
+.. code-block:: ql
+
+     class Node {
+       /**
+        * Gets this node's underlying expression, if any.
+        */
+       Expr asExpr() { none() }
+
+       /**
+        * Gets this data flow node's corresponding control flow node.
+        */
+       ControlFlowNode getCfgNode() { none() }
+
+      ...
+     }
+
+You can use the predicates ``exprNode`` and ``parameterNode`` to map from expressions and parameters to their data-flow node:
+
+.. code-block:: ql
+
+     /** Gets a node corresponding to expression `e`. */
+     ExprNode exprNode(DataFlowExpr e) { result.asExpr() = e }
+
+     /**
+      * Gets the node corresponding to the value of parameter `p` at function entry.
+      */
+     ParameterNode parameterNode(DataFlowParameter p) { result.getParameter() = p }
+
+There can be multiple data-flow nodes associated with a single expression node in the AST.
+
+The predicate ``localFlowStep(Node nodeFrom, Node nodeTo)`` holds if there is an immediate data flow edge from the node ``nodeFrom`` to the node ``nodeTo``.
+You can apply the predicate recursively, by using the ``+`` and ``*`` operators, or you can use the predefined recursive predicate ``localFlow``.
+
+For example, you can find flow from an expression ``source`` to an expression ``sink`` in zero or more local steps:
+
+.. code-block:: ql
+
+     DataFlow::localFlow(DataFlow::exprNode(source), DataFlow::exprNode(sink))
+
+Using local taint tracking
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Local taint tracking extends local data flow to include flow steps where values are not preserved, for example, string manipulation.
+For example:
+
+.. code-block:: swift
+
+     temp = x
+     y = temp + ", " + temp
+
+If ``x`` is a tainted string then ``y`` is also tainted.
+
+The local taint tracking library is in the module ``TaintTracking``.
+Like local data flow, a predicate ``localTaintStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo)`` holds if there is an immediate taint propagation edge from the node ``nodeFrom`` to the node ``nodeTo``.
+You can apply the predicate recursively, by using the ``+`` and ``*`` operators, or you can use the predefined recursive predicate ``localTaint``.
+
+For example, you can find taint propagation from an expression ``source`` to an expression ``sink`` in zero or more local steps:
+
+.. code-block:: ql
+
+     TaintTracking::localTaint(DataFlow::exprNode(source), DataFlow::exprNode(sink))
+
+Examples of local data flow
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This query finds the ``format`` argument passed into each call to ``String.init(format:_:)``:
+
+.. code-block:: ql
+
+    import swift
+
+    from CallExpr call, MethodDecl method
+    where
+      call.getStaticTarget() = method and
+      method.hasQualifiedName("String", "init(format:_:)")
+    select call.getArgument(0).getExpr()
+
+Unfortunately this will only give the expression in the argument, not the values which could be passed to it.
+So we use local data flow to find all expressions that flow into the argument:
+
+.. code-block:: ql
+
+    import swift
+    import codeql.swift.dataflow.DataFlow
+
+    from CallExpr call, MethodDecl method, Expr sourceExpr, Expr sinkExpr
+    where
+      call.getStaticTarget() = method and
+      method.hasQualifiedName("String", "init(format:_:)") and
+      sinkExpr = call.getArgument(0).getExpr() and
+      DataFlow::localFlow(DataFlow::exprNode(sourceExpr), DataFlow::exprNode(sinkExpr))
+    select sourceExpr, sinkExpr
+
+We can vary the source, for example, making the source the parameter of a function rather than an expression. The following query finds where a parameter is used for the format:
+
+.. code-block:: ql
+
+    import swift
+    import codeql.swift.dataflow.DataFlow
+
+    from CallExpr call, MethodDecl method, ParamDecl sourceParam, Expr sinkExpr
+    where
+      call.getStaticTarget() = method and
+      method.hasQualifiedName("String", "init(format:_:)") and
+      sinkExpr = call.getArgument(0).getExpr() and
+      DataFlow::localFlow(DataFlow::parameterNode(sourceParam), DataFlow::exprNode(sinkExpr))
+    select sourceParam, sinkExpr
+
+The following example finds calls to ``String.init(format:_:)`` where the format string is not a hard-coded string literal:
+
+.. code-block:: ql
+
+    import swift
+    import codeql.swift.dataflow.DataFlow
+
+    from CallExpr call, MethodDecl method, Expr sinkExpr
+    where
+      call.getStaticTarget() = method and
+      method.hasQualifiedName("String", "init(format:_:)") and
+      sinkExpr = call.getArgument(0).getExpr() and
+      not exists(StringLiteralExpr sourceLiteral |
+        DataFlow::localFlow(DataFlow::exprNode(sourceLiteral), DataFlow::exprNode(sinkExpr))
+      )
+    select call, "Format argument to " + method.getName() + " isn't hard-coded."
+
+Global data flow
+----------------
+
+Global data flow tracks data flow throughout the entire program, and is therefore more powerful than local data flow.
+However, global data flow is less precise than local data flow, and the analysis typically requires significantly more time and memory to perform.
+
+.. pull-quote:: Note
+
+   .. include:: ../reusables/path-problem.rst
+
+Using global data flow
+~~~~~~~~~~~~~~~~~~~~~~
+
+You can use the global data flow library by implementing the module ``DataFlow::ConfigSig``:
+
+.. code-block:: ql
+
+   import codeql.swift.dataflow.DataFlow
+
+   module MyDataFlowConfiguration implements DataFlow::ConfigSig {
+     predicate isSource(DataFlow::Node source) {
+       ...
+     }
+
+     predicate isSink(DataFlow::Node sink) {
+       ...
+     }
+   }
+
+   module MyDataFlow = DataFlow::Global<MyDataFlowConfiguration>;
+
+These predicates are defined in the configuration:
+
+-  ``isSource`` - defines where data may flow from.
+-  ``isSink`` - defines where data may flow to.
+-  ``isBarrier`` - optionally, restricts the data flow.
+-  ``isAdditionalFlowStep`` - optionally, adds additional flow steps.
+
+The last line (``module MyDataFlow = ...``) performs data flow analysis using the configuration, and its results can be accessed with ``MyDataFlow::flow(DataFlow::Node source, DataFlow::Node sink)``:
+
+.. code-block:: ql
+
+   from DataFlow::Node source, DataFlow::Node sink
+   where MyDataFlow::flow(source, sink)
+   select source, "Dataflow to $@.", sink, sink.toString()
+
+Using global taint tracking
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Global taint tracking is to global data flow what local taint tracking is to local data flow.
+That is, global taint tracking extends global data flow with additional non-value-preserving steps.
+The global taint tracking library uses the same configuration module as the global data flow library but taint flow analysis is performed with ``TaintTracking::Global``:
+
+.. code-block:: ql
+
+   module MyTaintFlow = TaintTracking::Global<MyDataFlowConfiguration>;
+
+   from DataFlow::Node source, DataFlow::Node sink
+   where MyTaintFlow::flow(source, sink)
+   select source, "Taint flow to $@.", sink, sink.toString()
+
+Predefined sources and sinks
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The data flow library module ``codeql.swift.dataflow.FlowSources`` contains a number of predefined sources and sinks, providing a good starting point for defining data flow and taint flow based security queries.
+
+-  The class ``RemoteFlowSource`` represents data flow from remote network inputs and from other applications.
+-  The class ``LocalFlowSource`` represents data flow from local user input.
+-  The class ``FlowSource`` includes both of the above.
+
+Examples of global data flow
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following global taint-tracking query finds places where a string literal is used in a function call argument called "password".
+  - Since this is a taint-tracking query, the ``TaintTracking::Global`` module is used.
+  - The ``isSource`` predicate defines sources as any ``StringLiteralExpr``.
+  - The ``isSink`` predicate defines sinks as arguments to a ``CallExpr`` called "password".
+  - The sources and sinks may need tuning to a particular use case, for example if passwords are represented by a type other than ``String`` or passed in arguments of a different name than "password".
+
+.. code-block:: ql
+
+   import swift
+   import codeql.swift.dataflow.DataFlow
+   import codeql.swift.dataflow.TaintTracking
+
+   module ConstantPasswordConfig implements DataFlow::ConfigSig {
+     predicate isSource(DataFlow::Node node) { node.asExpr() instanceof StringLiteralExpr }
+
+     predicate isSink(DataFlow::Node node) {
+       // any argument called `password`
+       exists(CallExpr call | call.getArgumentWithLabel("password").getExpr() = node.asExpr())
+     }
+
+   module ConstantPasswordFlow = TaintTracking::Global<ConstantPasswordConfig>;
+
+   from DataFlow::Node sourceNode, DataFlow::Node sinkNode
+   where ConstantPasswordFlow::flow(sourceNode, sinkNode)
+   select sinkNode, sourceNode, sinkNode,
+     "The value '" + sourceNode.toString() + "' is used as a constant password."
+
+
+The following global taint-tracking query finds places where a value from a remote or local user input is used as an argument to the SQLite ``Connection.execute(_:)`` function.
+  - Since this is a taint-tracking query, the ``TaintTracking::Global`` module is used.
+  - The ``isSource`` predicate defines sources as a ``FlowSource`` (remote or local user input).
+  - The ``isSink`` predicate defines sinks as the first argument in any call to ``Connection.execute(_:)``.
+
+.. code-block:: ql
+
+
+   import swift
+   import codeql.swift.dataflow.DataFlow
+   import codeql.swift.dataflow.TaintTracking
+   import codeql.swift.dataflow.FlowSources
+
+   module SqlInjectionConfig implements DataFlow::ConfigSig {
+     predicate isSource(DataFlow::Node node) { node instanceof FlowSource }
+
+     predicate isSink(DataFlow::Node node) {
+       exists(CallExpr call |
+         call.getStaticTarget().(MethodDecl).hasQualifiedName("Connection", ["execute(_:)"]) and
+         call.getArgument(0).getExpr() = node.asExpr()
+       )
+     }
+   }
+
+   module SqlInjectionFlow = TaintTracking::Global<SqlInjectionConfig>;
+
+   from DataFlow::Node sourceNode, DataFlow::Node sinkNode
+   where SqlInjectionFlow::flow(sourceNode, sinkNode)
+   select sinkNode, sourceNode, sinkNode, "This query depends on a $@.", sourceNode,
+     "user-provided value"
+
+Further reading
+---------------
+
+- ":ref:`Exploring data flow with path queries <exploring-data-flow-with-path-queries>`"
+
+
+.. include:: ../reusables/swift-further-reading.rst
+.. include:: ../reusables/codeql-ref-tools-further-reading.rst

--- a/docs/codeql/codeql-language-guides/analyzing-data-flow-in-swift.rst
+++ b/docs/codeql/codeql-language-guides/analyzing-data-flow-in-swift.rst
@@ -15,7 +15,7 @@ For a more general introduction to modeling data flow, see ":ref:`About data flo
 Local data flow
 ---------------
 
-Local data flow tracks the flow of data within a single method or callable. Local data flow is easier, faster, and more precise than global data flow. Before looking at more complex tracking, you should always consider local tracking because it is sufficient for many queries.
+Local data flow tracks the flow of data within a single function. Local data flow is easier, faster, and more precise than global data flow. Before looking at more complex tracking, you should always consider local tracking because it is sufficient for many queries.
 
 Using local data flow
 ~~~~~~~~~~~~~~~~~~~~~
@@ -36,7 +36,7 @@ The ``Node`` class has a number of useful subclasses, such as ``ExprNode`` for e
         */
        ControlFlowNode getCfgNode() { none() }
 
-      ...
+       ...
      }
 
 You can use the predicates ``exprNode`` and ``parameterNode`` to map from expressions and parameters to their data-flow node:
@@ -65,7 +65,7 @@ For example, you can find flow from an expression ``source`` to an expression ``
 Using local taint tracking
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Local taint tracking extends local data flow to include flow steps where values are not preserved, for example, string manipulation.
+Local taint tracking extends local data flow to include flow steps where values are not preserved, such as string manipulation.
 For example:
 
 .. code-block:: swift
@@ -209,10 +209,10 @@ The global taint tracking library uses the same configuration module as the glob
    where MyTaintFlow::flow(source, sink)
    select source, "Taint flow to $@.", sink, sink.toString()
 
-Predefined sources and sinks
+Predefined sources
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The data flow library module ``codeql.swift.dataflow.FlowSources`` contains a number of predefined sources and sinks, providing a good starting point for defining data flow and taint flow based security queries.
+The data flow library module ``codeql.swift.dataflow.FlowSources`` contains a number of predefined sources, providing a good starting point for defining data flow and taint flow based security queries.
 
 -  The class ``RemoteFlowSource`` represents data flow from remote network inputs and from other applications.
 -  The class ``LocalFlowSource`` represents data flow from local user input.
@@ -221,11 +221,11 @@ The data flow library module ``codeql.swift.dataflow.FlowSources`` contains a nu
 Examples of global data flow
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The following global taint-tracking query finds places where a string literal is used in a function call argument called "password".
+The following global taint-tracking query finds places where a string literal is used in a function call argument named "password".
   - Since this is a taint-tracking query, the ``TaintTracking::Global`` module is used.
   - The ``isSource`` predicate defines sources as any ``StringLiteralExpr``.
   - The ``isSink`` predicate defines sinks as arguments to a ``CallExpr`` called "password".
-  - The sources and sinks may need tuning to a particular use case, for example if passwords are represented by a type other than ``String`` or passed in arguments of a different name than "password".
+  - The sources and sinks may need tuning to a particular use, for example if passwords are represented by a type other than ``String`` or passed in arguments of a different name than "password".
 
 .. code-block:: ql
 
@@ -245,8 +245,7 @@ The following global taint-tracking query finds places where a string literal is
 
    from DataFlow::Node sourceNode, DataFlow::Node sinkNode
    where ConstantPasswordFlow::flow(sourceNode, sinkNode)
-   select sinkNode, sourceNode, sinkNode,
-     "The value '" + sourceNode.toString() + "' is used as a constant password."
+   select sinkNode, "The value '" + sourceNode.toString() + "' is used as a constant password."
 
 
 The following global taint-tracking query finds places where a value from a remote or local user input is used as an argument to the SQLite ``Connection.execute(_:)`` function.
@@ -255,7 +254,6 @@ The following global taint-tracking query finds places where a value from a remo
   - The ``isSink`` predicate defines sinks as the first argument in any call to ``Connection.execute(_:)``.
 
 .. code-block:: ql
-
 
    import swift
    import codeql.swift.dataflow.DataFlow
@@ -277,8 +275,7 @@ The following global taint-tracking query finds places where a value from a remo
 
    from DataFlow::Node sourceNode, DataFlow::Node sinkNode
    where SqlInjectionFlow::flow(sourceNode, sinkNode)
-   select sinkNode, sourceNode, sinkNode, "This query depends on a $@.", sourceNode,
-     "user-provided value"
+   select sinkNode, "This query depends on a $@.", sourceNode, "user-provided value"
 
 Further reading
 ---------------

--- a/docs/codeql/codeql-language-guides/basic-query-for-swift-code.rst
+++ b/docs/codeql/codeql-language-guides/basic-query-for-swift-code.rst
@@ -1,0 +1,130 @@
+.. _basic-query-for-swift-code:
+
+Basic query for Swift code
+=========================
+
+Learn to write and run a simple CodeQL query using Visual Studio Code with the CodeQL extension.
+
+.. include:: ../reusables/vs-code-basic-instructions/setup-to-run-queries.rst
+
+About the query
+---------------
+
+The query we're going to run performs a basic search of the code for ``if`` expressions that are redundant, in the sense that they have an empty ``then`` branch. For example, code such as:
+
+.. code-block:: swift
+
+   if error {
+     // we should handle the error
+   }
+
+.. include:: ../reusables/vs-code-basic-instructions/find-database.rst
+
+Running a quick query
+---------------------
+
+.. include:: ../reusables/vs-code-basic-instructions/run-quick-query-1.rst
+
+#. In the quick query tab, delete the content and paste in the following query.
+
+   .. code-block:: ql
+
+      import swift
+
+      from IfStmt ifStmt
+      where ifStmt.getThen().(BraceStmt).getNumberOfElements() = 0
+      select ifStmt, "This 'if' statement is redundant."
+
+.. include:: ../reusables/vs-code-basic-instructions/run-quick-query-2.rst
+
+.. image:: ../images/codeql-for-visual-studio-code/basic-swift-query-results-1.png
+   :align: center
+
+If any matching code is found, click a link in the ``ifStmt`` column to open the file and highlight the matching ``if`` statement.
+
+.. image:: ../images/codeql-for-visual-studio-code/basic-swift-query-results-2.png
+   :align: center
+
+.. include:: ../reusables/vs-code-basic-instructions/note-store-quick-query.rst
+
+About the query structure
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+After the initial ``import`` statement, this simple query comprises three parts that serve similar purposes to the FROM, WHERE, and SELECT parts of an SQL query.
+
++------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------+
+| Query part                                                       | Purpose                                                                                                           | Details                                                                                         |
++==================================================================+===================================================================================================================+=================================================================================================+
+| ``import swift``                                                 | Imports the standard CodeQL AST libraries for Swift.                                                              | Every query begins with one or more ``import`` statements.                                      |
++------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------+
+| ``from IfStmt ifStmt``                                           | Defines the variables for the query.                                                                              | We use: an ``IfStmt`` variable for ``if`` statements.                                           |
+|                                                                  | Declarations are of the form:                                                                                     |                                                                                                 |
+|                                                                  | ``<type> <variable name>``                                                                                        |                                                                                                 |
++------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------+
+| ``where ifStmt.getThen().(BraceStmt).getNumberOfElements() = 0`` | Defines a condition on the variables.                                                                             | ``ifStmt.getThen()``: gets the ``then`` branch of the ``if`` expression.                        |
+|                                                                  |                                                                                                                   | ``.(BraceStmt)``: requires that the ``then`` branch is a brace statement (``{ }``).             |
+|                                                                  |                                                                                                                   | ``.getNumberOfElements() = 0``: requires that the brace statement contains no child statements. |
++------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------+
+| ``select ifStmt, "This 'if' statement is redundant."``           | Defines what to report for each match.                                                                            | Reports the resulting ``if`` statement with a string that explains the problem.                 |
+|                                                                  |                                                                                                                   |                                                                                                 |
+|                                                                  | ``select`` statements for queries that are used to find instances of poor coding practice are always in the form: |                                                                                                 |
+|                                                                  | ``select <program element>, "<alert message>"``                                                                   |                                                                                                 |
++------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------+
+
+Extend the query
+----------------
+
+Query writing is an inherently iterative process. You write a simple query and then, when you run it, you discover examples that you had not previously considered, or opportunities for improvement.
+
+Remove false positive results
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Browsing the results of our basic query shows that it could be improved. Among the results you are likely to find examples of ``if`` statements with an ``else`` branch, where an empty ``then`` branch does serve a purpose. For example:
+
+.. code-block:: swift
+
+   if (option == "-verbose") {
+     // nothing to do - handled earlier
+   } else {
+     handleError("unrecognized option")
+   }
+
+In this case, identifying the ``if`` statement with the empty ``then`` branch as redundant is a false positive. One solution to this is to modify the query to select ``if`` statements where both the ``then`` and ``else`` branches are missing.
+
+To exclude ``if`` statements that have an ``else`` branch:
+
+#. Add the following to the where clause:
+
+   .. code-block:: ql
+
+      and not exists(ifStmt.getElse())
+
+   The ``where`` clause is now:
+
+   .. code-block:: ql
+
+      where
+        ifStmt.getThen().(BraceStmt).getNumberOfElements() = 0 and
+        not exists(ifStmt.getElse())
+
+#. Re-run the query.
+
+   There are now fewer results because ``if`` expressions with an ``else`` branch are no longer included.
+
+Further reading
+---------------
+
+.. include:: ../reusables/swift-further-reading.rst
+.. include:: ../reusables/codeql-ref-tools-further-reading.rst
+
+.. Article-specific substitutions for the reusables used in docs/codeql/reusables/vs-code-basic-instructions
+
+.. |language-text| replace:: Swift
+
+.. |language-code| replace:: ``swift``
+
+.. |example-url| replace:: https://github.com/alamofire/alamofire
+
+.. |image-quick-query| image:: ../images/codeql-for-visual-studio-code/quick-query-tab-swift.png
+
+.. |result-col-1|  replace:: The first column corresponds to the expression ``ifStmt`` and is linked to the location in the source code of the project where ``ifStmt`` occurs.

--- a/docs/codeql/codeql-language-guides/codeql-for-swift.rst
+++ b/docs/codeql/codeql-language-guides/codeql-for-swift.rst
@@ -1,0 +1,13 @@
+.. _codeql-for-swift:
+
+CodeQL for Swift
+===============
+
+Experiment and learn how to write effective and efficient queries for CodeQL databases generated from Swift codebases.
+
+.. toctree::
+   :hidden:
+
+   basic-query-for-swift-code
+
+-  :doc:`Basic query for Swift code <basic-query-for-swift-code>`: Learn to write and run a simple CodeQL query.

--- a/docs/codeql/codeql-language-guides/codeql-for-swift.rst
+++ b/docs/codeql/codeql-language-guides/codeql-for-swift.rst
@@ -9,5 +9,8 @@ Experiment and learn how to write effective and efficient queries for CodeQL dat
    :hidden:
 
    basic-query-for-swift-code
+   analyzing-data-flow-in-swift
 
 -  :doc:`Basic query for Swift code <basic-query-for-swift-code>`: Learn to write and run a simple CodeQL query.
+
+-  :doc:`Analyzing data flow in Swift <analyzing-data-flow-in-swift>`: You can use CodeQL to track the flow of data through a Swift program to places where the data is used.

--- a/docs/codeql/codeql-language-guides/index.rst
+++ b/docs/codeql/codeql-language-guides/index.rst
@@ -14,3 +14,4 @@ Experiment and learn how to write effective and efficient queries for CodeQL dat
    codeql-for-javascript
    codeql-for-python
    codeql-for-ruby
+   codeql-for-swift


### PR DESCRIPTION
Initial language guides documentation for Swift analysis.  This is essentially a port of some of the language-specific documentation from other languages, though there are numerous small changes in the examples and specifics.

I'd like someone from the codeql-c-team to review this first, following the steps to make sure everything is clear and works correctly.  After that I'll add a bit more polish, get a docs review, and we should check the links all work.

TODO:
- [ ] team review
- [ ] add the referenced images (`basic-swift-query-results-1.png`, `basic-swift-query-results-2.png`, `quick-query-tab-swift.png`)
- [ ] add the referenced further reading doc (`reusables/swift-further-reading.rst`)
- [ ] check all markup and links work correctly
- [ ] docs review
- [ ] when should we merge this?