### PR TITLE
JS: Stop complaining about comments in JSON files

### DIFF
--- a/javascript/extractor/tests/json/output/trap/comments.json.trap
+++ b/javascript/extractor/tests/json/output/trap/comments.json.trap
@@ -18,15 +18,5 @@ locations_default(#20003,#10000,3,12,3,18)
 json_locations(#20002,#20003)
 json_literals("world","""world""",#20002)
 json_properties(#20000,"hello",#20002)
-#20004=*
-json_errors(#20004,"Error: Comments are not legal in JSON.")
-#20005=@"loc,{#10000},2,3,2,3"
-locations_default(#20005,#10000,2,3,2,3)
-json_locations(#20004,#20005)
-#20006=*
-json_errors(#20006,"Error: Comments are not legal in JSON.")
-#20007=@"loc,{#10000},4,3,4,3"
-locations_default(#20007,#10000,4,3,4,3)
-json_locations(#20006,#20007)
 numlines(#10000,5,0,0)
 filetype(#10000,"json")

--- a/javascript/ql/src/change-notes/2023-04-28-json-with-comments.md
+++ b/javascript/ql/src/change-notes/2023-04-28-json-with-comments.md
@@ -1,0 +1,5 @@
+---
+category: fix
+---
+* Fixed a spurious diagnostic warning about comments in JSON files being illegal.
+  Comments in JSON files are in fact fully supported, and the diagnostic message was misleading.

--- a/javascript/ql/test/library-tests/JSON/JSONError.expected
+++ b/javascript/ql/test/library-tests/JSON/JSONError.expected
@@ -1,1 +1,0 @@
-| invalid.json:3:1:3:1 | Error: Comments are not legal in JSON. |


### PR DESCRIPTION
Our parser already supports comments and simply treats them as recoverable parse errors. This means the JSON files would be fully extracted, but the errors would be reported in two places:
- As diagnostic message suggesting that something went wrong. This was actually misleading because the file was in fact fully extracted.
- As syntax errors in the `SyntaxError.ql` query. For this use-case I just don't think anyone actually cares.

Rather than marking the errors as "non-reportable" or something like that, we just stop recording them, with the rationale that there is simply no use-case for this information anymore.