### PR TITLE
C++: Add FP for `cpp/invalid-pointer-deref`

### DIFF
--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/InvalidPointerDeref.expected
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/InvalidPointerDeref.expected
@@ -583,9 +583,9 @@ edges
 | test.cpp:239:5:239:18 | access to array | test.cpp:239:5:239:22 | Store: ... = ... |
 | test.cpp:248:24:248:30 | call to realloc | test.cpp:249:9:249:9 | p |
 | test.cpp:248:24:248:30 | call to realloc | test.cpp:250:22:250:22 | p |
-| test.cpp:248:24:248:30 | call to realloc | test.cpp:253:9:253:9 | p |
-| test.cpp:253:9:253:9 | p | test.cpp:253:9:253:12 | access to array |
-| test.cpp:253:9:253:12 | access to array | test.cpp:253:9:253:16 | Store: ... = ... |
+| test.cpp:248:24:248:30 | call to realloc | test.cpp:254:9:254:9 | p |
+| test.cpp:254:9:254:9 | p | test.cpp:254:9:254:12 | access to array |
+| test.cpp:254:9:254:12 | access to array | test.cpp:254:9:254:16 | Store: ... = ... |
 #select
 | test.cpp:6:14:6:15 | Load: * ... | test.cpp:4:15:4:20 | call to malloc | test.cpp:6:14:6:15 | Load: * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:4:15:4:20 | call to malloc | call to malloc | test.cpp:5:19:5:22 | size | size |
 | test.cpp:8:14:8:21 | Load: * ... | test.cpp:4:15:4:20 | call to malloc | test.cpp:8:14:8:21 | Load: * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@ + 1. | test.cpp:4:15:4:20 | call to malloc | call to malloc | test.cpp:5:19:5:22 | size | size |
@@ -606,4 +606,4 @@ edges
 | test.cpp:213:5:213:13 | Store: ... = ... | test.cpp:205:23:205:28 | call to malloc | test.cpp:213:5:213:13 | Store: ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:205:23:205:28 | call to malloc | call to malloc | test.cpp:206:21:206:23 | len | len |
 | test.cpp:232:3:232:20 | Store: ... = ... | test.cpp:231:18:231:30 | new[] | test.cpp:232:3:232:20 | Store: ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:231:18:231:30 | new[] | new[] | test.cpp:232:11:232:15 | index | index |
 | test.cpp:239:5:239:22 | Store: ... = ... | test.cpp:238:20:238:32 | new[] | test.cpp:239:5:239:22 | Store: ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:238:20:238:32 | new[] | new[] | test.cpp:239:13:239:17 | index | index |
-| test.cpp:253:9:253:16 | Store: ... = ... | test.cpp:248:24:248:30 | call to realloc | test.cpp:253:9:253:16 | Store: ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:248:24:248:30 | call to realloc | call to realloc | test.cpp:253:11:253:11 | i | i |
+| test.cpp:254:9:254:16 | Store: ... = ... | test.cpp:248:24:248:30 | call to realloc | test.cpp:254:9:254:16 | Store: ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:248:24:248:30 | call to realloc | call to realloc | test.cpp:254:11:254:11 | i | i |

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/InvalidPointerDeref.expected
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/InvalidPointerDeref.expected
@@ -575,6 +575,12 @@ edges
 | test.cpp:213:6:213:6 | q | test.cpp:213:5:213:13 | Store: ... = ... |
 | test.cpp:213:6:213:6 | q | test.cpp:213:5:213:13 | Store: ... = ... |
 | test.cpp:221:17:221:22 | call to malloc | test.cpp:222:5:222:5 | p |
+| test.cpp:231:18:231:30 | new[] | test.cpp:232:3:232:9 | newname |
+| test.cpp:232:3:232:9 | newname | test.cpp:232:3:232:16 | access to array |
+| test.cpp:232:3:232:16 | access to array | test.cpp:232:3:232:20 | Store: ... = ... |
+| test.cpp:238:20:238:32 | new[] | test.cpp:239:5:239:11 | newname |
+| test.cpp:239:5:239:11 | newname | test.cpp:239:5:239:18 | access to array |
+| test.cpp:239:5:239:18 | access to array | test.cpp:239:5:239:22 | Store: ... = ... |
 #select
 | test.cpp:6:14:6:15 | Load: * ... | test.cpp:4:15:4:20 | call to malloc | test.cpp:6:14:6:15 | Load: * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:4:15:4:20 | call to malloc | call to malloc | test.cpp:5:19:5:22 | size | size |
 | test.cpp:8:14:8:21 | Load: * ... | test.cpp:4:15:4:20 | call to malloc | test.cpp:8:14:8:21 | Load: * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@ + 1. | test.cpp:4:15:4:20 | call to malloc | call to malloc | test.cpp:5:19:5:22 | size | size |
@@ -593,3 +599,5 @@ edges
 | test.cpp:171:9:171:14 | Store: ... = ... | test.cpp:143:18:143:23 | call to malloc | test.cpp:171:9:171:14 | Store: ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:143:18:143:23 | call to malloc | call to malloc | test.cpp:144:29:144:32 | size | size |
 | test.cpp:201:5:201:19 | Store: ... = ... | test.cpp:194:23:194:28 | call to malloc | test.cpp:201:5:201:19 | Store: ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:194:23:194:28 | call to malloc | call to malloc | test.cpp:195:21:195:23 | len | len |
 | test.cpp:213:5:213:13 | Store: ... = ... | test.cpp:205:23:205:28 | call to malloc | test.cpp:213:5:213:13 | Store: ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:205:23:205:28 | call to malloc | call to malloc | test.cpp:206:21:206:23 | len | len |
+| test.cpp:232:3:232:20 | Store: ... = ... | test.cpp:231:18:231:30 | new[] | test.cpp:232:3:232:20 | Store: ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:231:18:231:30 | new[] | new[] | test.cpp:232:11:232:15 | index | index |
+| test.cpp:239:5:239:22 | Store: ... = ... | test.cpp:238:20:238:32 | new[] | test.cpp:239:5:239:22 | Store: ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:238:20:238:32 | new[] | new[] | test.cpp:239:13:239:17 | index | index |

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/InvalidPointerDeref.expected
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/InvalidPointerDeref.expected
@@ -581,6 +581,11 @@ edges
 | test.cpp:238:20:238:32 | new[] | test.cpp:239:5:239:11 | newname |
 | test.cpp:239:5:239:11 | newname | test.cpp:239:5:239:18 | access to array |
 | test.cpp:239:5:239:18 | access to array | test.cpp:239:5:239:22 | Store: ... = ... |
+| test.cpp:248:24:248:30 | call to realloc | test.cpp:249:9:249:9 | p |
+| test.cpp:248:24:248:30 | call to realloc | test.cpp:250:22:250:22 | p |
+| test.cpp:248:24:248:30 | call to realloc | test.cpp:253:9:253:9 | p |
+| test.cpp:253:9:253:9 | p | test.cpp:253:9:253:12 | access to array |
+| test.cpp:253:9:253:12 | access to array | test.cpp:253:9:253:16 | Store: ... = ... |
 #select
 | test.cpp:6:14:6:15 | Load: * ... | test.cpp:4:15:4:20 | call to malloc | test.cpp:6:14:6:15 | Load: * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:4:15:4:20 | call to malloc | call to malloc | test.cpp:5:19:5:22 | size | size |
 | test.cpp:8:14:8:21 | Load: * ... | test.cpp:4:15:4:20 | call to malloc | test.cpp:8:14:8:21 | Load: * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@ + 1. | test.cpp:4:15:4:20 | call to malloc | call to malloc | test.cpp:5:19:5:22 | size | size |
@@ -601,3 +606,4 @@ edges
 | test.cpp:213:5:213:13 | Store: ... = ... | test.cpp:205:23:205:28 | call to malloc | test.cpp:213:5:213:13 | Store: ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:205:23:205:28 | call to malloc | call to malloc | test.cpp:206:21:206:23 | len | len |
 | test.cpp:232:3:232:20 | Store: ... = ... | test.cpp:231:18:231:30 | new[] | test.cpp:232:3:232:20 | Store: ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:231:18:231:30 | new[] | new[] | test.cpp:232:11:232:15 | index | index |
 | test.cpp:239:5:239:22 | Store: ... = ... | test.cpp:238:20:238:32 | new[] | test.cpp:239:5:239:22 | Store: ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:238:20:238:32 | new[] | new[] | test.cpp:239:13:239:17 | index | index |
+| test.cpp:253:9:253:16 | Store: ... = ... | test.cpp:248:24:248:30 | call to realloc | test.cpp:253:9:253:16 | Store: ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:248:24:248:30 | call to realloc | call to realloc | test.cpp:253:11:253:11 | i | i |

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/test.cpp
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/test.cpp
@@ -249,7 +249,8 @@ void test17(unsigned *p, unsigned x, unsigned k) {
         p[0] = n;
         unsigned i = p[1];
         // The following access is okay because:
-        // n = 2*p[0] + k >= p[0] + k >= p[1] + k > p[1] = i
+        // n = 3*p[0] + k >= p[0] + k >= p[1] + k > p[1] = i
+        // (where p[0] denotes the original value for p[0])
         p[i] = x; // GOOD [FALSE POSITIVE]
     }
 }

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/test.cpp
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/test.cpp
@@ -239,3 +239,17 @@ void test16(unsigned index) {
     newname[index] = 0; // GOOD [FALSE POSITIVE]
   }
 }
+
+void *realloc(void *, unsigned);
+
+void test17(unsigned *p, unsigned x, unsigned k) {
+    if(k > 0 && p[1] <= p[0]){
+        unsigned n = 3*p[0] + k;
+        p = (unsigned*)realloc(p, n);
+        p[0] = n;
+        unsigned i = p[1];
+        // The following access is okay because:
+        // n = 2*p[0] + k >= p[0] + k >= p[1] + k > p[1] = i
+        p[i] = x; // GOOD [FALSE POSITIVE]
+    }
+}

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/test.cpp
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/test.cpp
@@ -222,3 +222,20 @@ void test14(unsigned long n, char *p) {
     p[n - 1] = 'a'; // GOOD
   }
 }
+
+void test15(unsigned index) {
+  unsigned size = index + 13;
+  if(size < index) {
+    return;
+  }
+  int* newname = new int[size];
+  newname[index] = 0; // GOOD [FALSE POSITIVE]
+}
+
+void test16(unsigned index) {
+  unsigned size = index + 13;
+  if(size >= index) {
+    int* newname = new int[size];
+    newname[index] = 0; // GOOD [FALSE POSITIVE]
+  }
+}


### PR DESCRIPTION
I haven't investigated what's going on yet, but this test is a minified version of a result I was seeing on MRVA.