### PR TITLE
Java: Add SrcCallable.isImplicitlyPublic convenience predicate.

### DIFF
--- a/java/ql/lib/semmle/code/java/Member.qll
+++ b/java/ql/lib/semmle/code/java/Member.qll
@@ -379,6 +379,19 @@ class SrcCallable extends Callable {
       this.isProtected() and not tsub.isFinal()
     )
   }
+
+  /**
+   * Holds if this callable is implicitly public in the sense that it can be the
+   * target of virtual dispatch by a call from outside the codebase.
+   */
+  predicate isImplicitlyPublic() {
+    this.isEffectivelyPublic()
+    or
+    exists(SrcMethod m |
+      m.(SrcCallable).isEffectivelyPublic() and
+      m.getAPossibleImplementationOfSrcMethod() = this
+    )
+  }
 }
 
 /** Gets the erasure of `t1` if it is a raw type, or `t1` itself otherwise. */


### PR DESCRIPTION
I'll need this predicate for some future work, but I thought it made sense to add on its own.