### PR TITLE
Go: Add `go-autobuilder --identify-environment`

### DIFF
--- a/go/extractor/cli/go-autobuilder/go-autobuilder.go
+++ b/go/extractor/cli/go-autobuilder/go-autobuilder.go
@@ -22,7 +22,8 @@ import (
 
 func usage() {
 	fmt.Fprintf(os.Stderr,
-		`%s is a wrapper script that installs dependencies and calls the extractor.
+		`%s is a wrapper script that installs dependencies and calls the extractor, or if '--identify-environment'
+is passed then it produces a file 'environment.json' which specifies what go version is needed.
 
 When LGTM_SRC is not set, the script installs dependencies as described below, and then invokes the
 extractor in the working directory.
@@ -601,12 +602,7 @@ func extract(depMode DependencyInstallerMode, modMode ModMode) {
 	}
 }
 
-func main() {
-	if len(os.Args) > 1 {
-		usage()
-		os.Exit(2)
-	}
-
+func installDependenciesAndBuild() {
 	log.Printf("Autobuilder was built with %s, environment has %s\n", runtime.Version(), getEnvGoVersion())
 
 	srcdir := getSourceDir()
@@ -691,4 +687,19 @@ func main() {
 	}
 
 	extract(depMode, modMode)
+}
+
+func identifyEnvironment() {
+
+}
+
+func main() {
+	if len(os.Args) == 0 {
+		installDependenciesAndBuild()
+	} else if len(os.Args) == 2 && os.Args[1] == "--identify-environment" {
+		identifyEnvironment()
+	} else {
+		usage()
+		os.Exit(2)
+	}
 }

--- a/go/extractor/cli/go-autobuilder/go-autobuilder.go
+++ b/go/extractor/cli/go-autobuilder/go-autobuilder.go
@@ -880,7 +880,7 @@ func isGoInstalled() bool {
 	return err == nil
 }
 
-// Get the version of Go to install in the environment and write to an environment file.
+// Get the version of Go to install and write it to an environment file.
 func identifyEnvironment() {
 	var v versionInfo
 	depMode := getDepMode()
@@ -892,10 +892,7 @@ func identifyEnvironment() {
 	}
 
 	msg, versionToInstall := getVersionToInstall(v)
-
-	if msg != "" {
-		log.Println(msg)
-	}
+	log.Println(msg)
 
 	writeEnvironmentFile(versionToInstall)
 }

--- a/go/extractor/cli/go-autobuilder/go-autobuilder.go
+++ b/go/extractor/cli/go-autobuilder/go-autobuilder.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/url"
 	"os"
@@ -278,7 +277,7 @@ func fixGoVendorIssues(modMode ModMode, depMode DependencyInstallerMode, goDirec
 		if depMode == GoGetWithModules {
 			if !goDirectiveFound {
 				// if the go.mod does not contain a version line
-				modulesTxt, err := ioutil.ReadFile("vendor/modules.txt")
+				modulesTxt, err := os.ReadFile("vendor/modules.txt")
 				if err != nil {
 					log.Println("Failed to read vendor/modules.txt to check for mismatched Go version")
 				} else if explicitRe := regexp.MustCompile("(?m)^## explicit$"); !explicitRe.Match(modulesTxt) {
@@ -365,7 +364,7 @@ type moveGopathInfo struct {
 func moveToTemporaryGopath(srcdir string, importpath string) moveGopathInfo {
 	// a temporary directory where everything is moved while the correct
 	// directory structure is created.
-	scratch, err := ioutil.TempDir(srcdir, "scratch")
+	scratch, err := os.MkdirTemp(srcdir, "scratch")
 	if err != nil {
 		log.Fatalf("Failed to create temporary directory %s in directory %s: %s\n",
 			scratch, srcdir, err.Error())
@@ -431,7 +430,7 @@ func createPathTransformerFile(newdir string) *os.File {
 
 	// set up SEMMLE_PATH_TRANSFORMER to ensure paths in the source archive and the snapshot
 	// match the original source location, not the location we moved it to
-	pt, err := ioutil.TempFile("", "path-transformer")
+	pt, err := os.CreateTemp("", "path-transformer")
 	if err != nil {
 		log.Fatalf("Unable to create path transformer file: %s.", err.Error())
 	}
@@ -506,7 +505,7 @@ func buildWithCustomCommands(inst string) {
 		ext = ".sh"
 		header = "#! /bin/bash\nset -xe +u\n"
 	}
-	script, err := ioutil.TempFile("", "go-build-command-*"+ext)
+	script, err := os.CreateTemp("", "go-build-command-*"+ext)
 	if err != nil {
 		log.Fatalf("Unable to create temporary script holding custom build commands: %s\n", err.Error())
 	}
@@ -619,7 +618,7 @@ func installDependenciesAndBuild() {
 	}
 	if depMode == GoGetWithModules {
 		versionRe := regexp.MustCompile(`(?m)^go[ \t\r]+([0-9]+\.[0-9]+)$`)
-		goMod, err := ioutil.ReadFile("go.mod")
+		goMod, err := os.ReadFile("go.mod")
 		if err != nil {
 			log.Println("Failed to read go.mod to check for missing Go version")
 		} else {

--- a/go/extractor/cli/go-autobuilder/go-autobuilder.go
+++ b/go/extractor/cli/go-autobuilder/go-autobuilder.go
@@ -709,14 +709,14 @@ func checkForUnsupportedVersions(v versionInfo) (msg, version string) {
 		msg = "The version of Go found in the `go.mod` file (" + v.goModVersion +
 			") is outside of the supported range (" + minGoVersion + "-" + maxGoVersion + ")."
 		version = ""
-		//TODO: emit diagnostic
+		diagnostics.EmitUnsupportedVersionGoMod(msg)
 	}
 
 	if v.goInstallationFound && outsideSupportedRange(v.goEnvVersion) {
 		msg = "The version of Go installed in the environment (" + v.goEnvVersion +
 			") is outside of the supported range (" + minGoVersion + "-" + maxGoVersion + ")."
 		version = ""
-		//TODO: emit diagnostic
+		diagnostics.EmitUnsupportedVersionEnvironment(msg)
 	}
 
 	return msg, version
@@ -728,17 +728,20 @@ func checkForVersionsNotFound(v versionInfo) (msg, version string) {
 			"`environment.json` file specifying the maximum supported version of Go (" +
 			maxGoVersion + ")."
 		version = maxGoVersion
+		diagnostics.EmitNoGoModAndNoGoEnv(msg)
 	}
 
 	if !v.goInstallationFound && v.goDirectiveFound {
 		msg = "No version of Go installed. Writing an `environment.json` file specifying the " +
 			"version of Go found in the `go.mod` file (" + v.goModVersion + ")."
 		version = v.goModVersion
+		diagnostics.EmitNoGoEnv(msg)
 	}
 
 	if v.goInstallationFound && !v.goDirectiveFound {
 		msg = "No `go.mod` file found. Version " + v.goEnvVersion + " installed in the environment."
 		version = ""
+		diagnostics.EmitNoGoMod(msg)
 	}
 
 	return msg, version
@@ -751,10 +754,12 @@ func compareVersions(v versionInfo) (msg, version string) {
 			").\nWriting an `environment.json` file specifying the version of Go from the " +
 			"`go.mod` file (" + v.goModVersion + ")."
 		version = v.goModVersion
+		diagnostics.EmitVersionGoModHigherVersionEnvironment(msg)
 	} else {
 		msg = "The version of Go installed in the environment (" + v.goEnvVersion +
 			") is high enough for the version found in the `go.mod` file (" + v.goModVersion + ")."
 		version = ""
+		diagnostics.EmitVersionGoModNotHigherVersionEnvironment(msg)
 	}
 
 	return msg, version

--- a/go/extractor/cli/go-autobuilder/go-autobuilder.go
+++ b/go/extractor/cli/go-autobuilder/go-autobuilder.go
@@ -21,33 +21,37 @@ import (
 
 func usage() {
 	fmt.Fprintf(os.Stderr,
-		`When '--identify-environment' is passed then %s produces a file which specifies what Go
-version is needed. The location of this file is controlled by the environment variable
-CODEQL_EXTRACTOR_ENVIRONMENT_JSON, or defaults to "environment.json" if that is not set.
+		`%s is a wrapper script that installs dependencies and calls the extractor
 
-When no command line arguments are passed, %[1]s is a wrapper script that installs dependencies and
-calls the extractor.
+Options:
+  --identify-environment
+    Produce an environment file specifying which Go version should be installed in the environment
+	so that autobuilding will be successful. The location of this file is controlled by the
+    environment variable CODEQL_EXTRACTOR_ENVIRONMENT_JSON, or defaults to 'environment.json' if
+	that is not set.
 
-When LGTM_SRC is not set, the script installs dependencies as described below, and then invokes the
-extractor in the working directory.
+Build behavior:
 
-If LGTM_SRC is set, it checks for the presence of the files 'go.mod', 'Gopkg.toml', and
-'glide.yaml' to determine how to install dependencies: if a 'Gopkg.toml' file is present, it uses
-'dep ensure', if there is a 'glide.yaml' it uses 'glide install', and otherwise 'go get'.
-Additionally, unless a 'go.mod' file is detected, it sets up a temporary GOPATH and moves all
-source files into a folder corresponding to the package's import path before installing
-dependencies.
+    When LGTM_SRC is not set, the script installs dependencies as described below, and then invokes the
+    extractor in the working directory.
 
-This behavior can be further customized using environment variables: setting LGTM_INDEX_NEED_GOPATH
-to 'false' disables the GOPATH set-up, CODEQL_EXTRACTOR_GO_BUILD_COMMAND (or alternatively
-LGTM_INDEX_BUILD_COMMAND), can be set to a newline-separated list of commands to run in order to
-install dependencies, and LGTM_INDEX_IMPORT_PATH can be used to override the package import path,
-which is otherwise inferred from the SEMMLE_REPO_URL or GITHUB_REPOSITORY environment variables.
+    If LGTM_SRC is set, it checks for the presence of the files 'go.mod', 'Gopkg.toml', and
+    'glide.yaml' to determine how to install dependencies: if a 'Gopkg.toml' file is present, it uses
+    'dep ensure', if there is a 'glide.yaml' it uses 'glide install', and otherwise 'go get'.
+    Additionally, unless a 'go.mod' file is detected, it sets up a temporary GOPATH and moves all
+    source files into a folder corresponding to the package's import path before installing
+    dependencies.
 
-In resource-constrained environments, the environment variable CODEQL_EXTRACTOR_GO_MAX_GOROUTINES
-(or its legacy alias SEMMLE_MAX_GOROUTINES) can be used to limit the number of parallel goroutines
-started by the extractor, which reduces CPU and memory requirements. The default value for this
-variable is 32.
+    This behavior can be further customized using environment variables: setting LGTM_INDEX_NEED_GOPATH
+    to 'false' disables the GOPATH set-up, CODEQL_EXTRACTOR_GO_BUILD_COMMAND (or alternatively
+    LGTM_INDEX_BUILD_COMMAND), can be set to a newline-separated list of commands to run in order to
+    install dependencies, and LGTM_INDEX_IMPORT_PATH can be used to override the package import path,
+    which is otherwise inferred from the SEMMLE_REPO_URL or GITHUB_REPOSITORY environment variables.    
+
+    In resource-constrained environments, the environment variable CODEQL_EXTRACTOR_GO_MAX_GOROUTINES
+    (or its legacy alias SEMMLE_MAX_GOROUTINES) can be used to limit the number of parallel goroutines
+    started by the extractor, which reduces CPU and memory requirements. The default value for this
+    variable is 32.
 `,
 		os.Args[0])
 	fmt.Fprintf(os.Stderr, "Usage:\n\n  %s\n", os.Args[0])

--- a/go/extractor/cli/go-autobuilder/go-autobuilder.go
+++ b/go/extractor/cli/go-autobuilder/go-autobuilder.go
@@ -871,7 +871,9 @@ type versionInfo struct {
 }
 
 func (v versionInfo) String() string {
-	return fmt.Sprintf("go.mod version: %s, go.mod directive found: %t, go env version: %s, go installation found: %t", v.goModVersion, v.goDirectiveFound, v.goEnvVersion, v.goInstallationFound)
+	return fmt.Sprintf(
+		"go.mod version: %s, go.mod directive found: %t, go env version: %s, go installation found: %t",
+		v.goModVersion, v.goDirectiveFound, v.goEnvVersion, v.goInstallationFound)
 }
 
 // Check if Go is installed in the environment.

--- a/go/extractor/cli/go-autobuilder/go-autobuilder_test.go
+++ b/go/extractor/cli/go-autobuilder/go-autobuilder_test.go
@@ -33,3 +33,56 @@ func TestParseGoVersion(t *testing.T) {
 		}
 	}
 }
+
+func TestGetVersionToInstall(t *testing.T) {
+	tests := map[versionInfo]string{
+		// checkForUnsupportedVersions()
+
+		// go.mod version below minGoVersion
+		{"0.0", true, "1.20.3", true}: "",
+		{"0.0", true, "9999.0", true}: "",
+		{"0.0", true, "1.2.2", true}:  "",
+		{"0.0", true, "", false}:      "",
+		// go.mod version above maxGoVersion
+		{"9999.0", true, "1.20.3", true}:   "",
+		{"9999.0", true, "9999.0.1", true}: "",
+		{"9999.0", true, "1.1", true}:      "",
+		{"9999.0", true, "", false}:        "",
+		// Go installation found with version below minGoVersion
+		{"1.20", true, "1.2.2", true}: "",
+		{"1.11", true, "1.2.2", true}: "",
+		{"", false, "1.2.2", true}:    "",
+		// Go installation found with version above maxGoVersion
+		{"1.20", true, "9999.0.1", true}: "",
+		{"1.11", true, "9999.0.1", true}: "",
+		{"", false, "9999.0.1", true}:    "",
+
+		// checkForVersionsNotFound()
+
+		// Go installation not found, go.mod version in supported range
+		{"1.20", true, "", false}: "1.20",
+		{"1.11", true, "", false}: "1.11",
+		// Go installation not found, go.mod not found
+		{"", false, "", false}: maxGoVersion,
+		// Go installation found with version in supported range, go.mod not found
+		{"", false, "1.11.13", true}: "",
+		{"", false, "1.20.3", true}:  "",
+
+		// compareVersions()
+
+		// Go installation found with version in supported range, go.mod version in supported range and go.mod version > go installation version
+		{"1.20", true, "1.11.13", true}: "1.20",
+		{"1.20", true, "1.12", true}:    "1.20",
+		// Go installation found with version in supported range, go.mod version in supported range and go.mod version <= go installation version
+		// (Note comparisons ignore the patch version)
+		{"1.11", true, "1.20", true}:   "",
+		{"1.11", true, "1.20.3", true}: "",
+		{"1.20", true, "1.20.3", true}: "",
+	}
+	for input, expected := range tests {
+		_, actual := getVersionToInstall(input)
+		if actual != expected {
+			t.Errorf("Expected getVersionToInstall(\"%s\") to be \"%s\", but got \"%s\".", input, expected, actual)
+		}
+	}
+}

--- a/go/extractor/cli/go-bootstrap/go-bootstrap.go
+++ b/go/extractor/cli/go-bootstrap/go-bootstrap.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"regexp"
@@ -22,7 +21,7 @@ func main() {
 	buildSteps := os.Args[2]
 
 	haveRepo := false
-	content, err := ioutil.ReadFile(vars)
+	content, err := os.ReadFile(vars)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -34,7 +33,7 @@ func main() {
 		additionalVars += "SEMMLE_REPO_URL=${repository}\n"
 	}
 	content = append(content, []byte(additionalVars)...)
-	err = ioutil.WriteFile(vars, content, 0644)
+	err = os.WriteFile(vars, content, 0644)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -47,7 +46,7 @@ func main() {
   <build export="%s">${semmle_dist}/language-packs/go/tools/platform/${semmle_platform}/bin/go-autobuilder</build>
 </autoupdate>
 `, export))
-	err = ioutil.WriteFile(buildSteps, content, 0644)
+	err = os.WriteFile(buildSteps, content, 0644)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/go/extractor/cli/go-tokenizer/go-tokenizer.go
+++ b/go/extractor/cli/go-tokenizer/go-tokenizer.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"go/scanner"
 	"go/token"
-	"io/ioutil"
 	"log"
 	"os"
 	"strings"
@@ -20,7 +19,7 @@ func main() {
 	defer csv.Flush()
 
 	for _, fileName := range flag.Args() {
-		src, err := ioutil.ReadFile(fileName)
+		src, err := os.ReadFile(fileName)
 		if err != nil {
 			log.Fatalf("Unable to read file %s.", fileName)
 		}

--- a/go/extractor/diagnostics/diagnostics.go
+++ b/go/extractor/diagnostics/diagnostics.go
@@ -30,6 +30,7 @@ type visibilityStruct struct {
 }
 
 var fullVisibility *visibilityStruct = &visibilityStruct{true, true, true}
+var telemetryOnly *visibilityStruct = &visibilityStruct{false, false, true}
 
 type locationStruct struct {
 	File        string `json:"file,omitempty"`
@@ -189,6 +190,83 @@ func EmitRelativeImportPaths() {
 		"You should replace relative package paths (that contain `.` or `..`) with absolute paths. Alternatively you can [use a Go module](https://go.dev/blog/using-go-modules).",
 		severityError,
 		fullVisibility,
+		noLocation,
+	)
+}
+
+func EmitUnsupportedVersionGoMod(msg string) {
+	emitDiagnostic(
+		"go/identify-environment/unsupported-version-in-go-mod",
+		"Unsupported Go version in `go.mod` file",
+		msg,
+		severityError,
+		telemetryOnly,
+		noLocation,
+	)
+}
+
+func EmitUnsupportedVersionEnvironment(msg string) {
+	emitDiagnostic(
+		"go/identify-environment/unsupported-version-in-environment",
+		"Unsupported Go version in environment",
+		msg,
+		severityError,
+		telemetryOnly,
+		noLocation,
+	)
+}
+
+func EmitNoGoModAndNoGoEnv(msg string) {
+	emitDiagnostic(
+		"go/identify-environment/no-go-mod-and-no-go-env",
+		"No `go.mod` file found and no Go version in environment",
+		msg,
+		severityNote,
+		telemetryOnly,
+		noLocation,
+	)
+}
+
+func EmitNoGoEnv(msg string) {
+	emitDiagnostic(
+		"go/identify-environment/no-go-mod-and-no-go-env",
+		"No Go version in environment",
+		msg,
+		severityNote,
+		telemetryOnly,
+		noLocation,
+	)
+}
+
+func EmitNoGoMod(msg string) {
+	emitDiagnostic(
+		"go/identify-environment/no-go-mod",
+		"No `go.mod` file found",
+		msg,
+		severityNote,
+		telemetryOnly,
+		noLocation,
+	)
+}
+
+func EmitVersionGoModHigherVersionEnvironment(msg string) {
+	emitDiagnostic(
+		"go/identify-environment/version-go-mod-higher-than-go-env",
+		"The Go version in `go.mod` file is higher than the Go version in environment",
+		msg,
+		severityWarning,
+		telemetryOnly,
+		noLocation,
+	)
+}
+
+func EmitVersionGoModNotHigherVersionEnvironment(msg string) {
+	emitDiagnostic(
+		"go/identify-environment/version-go-mod-not-higher-than-go-env",
+		"The Go version in `go.mod` file is not higher than the Go version in environment",
+		msg,
+		severityNote,
+		telemetryOnly,
 		noLocation,
 	)
 }

--- a/go/extractor/diagnostics/diagnostics.go
+++ b/go/extractor/diagnostics/diagnostics.go
@@ -199,7 +199,7 @@ func EmitUnsupportedVersionGoMod(msg string) {
 		"go/autobuilder/env-unsupported-version-in-go-mod",
 		"Unsupported Go version in `go.mod` file",
 		msg,
-		severityError,
+		severityNote,
 		telemetryOnly,
 		noLocation,
 	)
@@ -210,7 +210,7 @@ func EmitUnsupportedVersionEnvironment(msg string) {
 		"go/autobuilder/env-unsupported-version-in-environment",
 		"Unsupported Go version in environment",
 		msg,
-		severityError,
+		severityNote,
 		telemetryOnly,
 		noLocation,
 	)
@@ -254,7 +254,7 @@ func EmitVersionGoModHigherVersionEnvironment(msg string) {
 		"go/autobuilder/env-version-go-mod-higher-than-go-env",
 		"The Go version in `go.mod` file is higher than the Go version in environment",
 		msg,
-		severityWarning,
+		severityNote,
 		telemetryOnly,
 		noLocation,
 	)

--- a/go/extractor/diagnostics/diagnostics.go
+++ b/go/extractor/diagnostics/diagnostics.go
@@ -196,7 +196,7 @@ func EmitRelativeImportPaths() {
 
 func EmitUnsupportedVersionGoMod(msg string) {
 	emitDiagnostic(
-		"go/identify-environment/unsupported-version-in-go-mod",
+		"go/autobuilder/env-unsupported-version-in-go-mod",
 		"Unsupported Go version in `go.mod` file",
 		msg,
 		severityError,
@@ -207,7 +207,7 @@ func EmitUnsupportedVersionGoMod(msg string) {
 
 func EmitUnsupportedVersionEnvironment(msg string) {
 	emitDiagnostic(
-		"go/identify-environment/unsupported-version-in-environment",
+		"go/autobuilder/env-unsupported-version-in-environment",
 		"Unsupported Go version in environment",
 		msg,
 		severityError,
@@ -218,7 +218,7 @@ func EmitUnsupportedVersionEnvironment(msg string) {
 
 func EmitNoGoModAndNoGoEnv(msg string) {
 	emitDiagnostic(
-		"go/identify-environment/no-go-mod-and-no-go-env",
+		"go/autobuilder/env-no-go-mod-and-no-go-env",
 		"No `go.mod` file found and no Go version in environment",
 		msg,
 		severityNote,
@@ -229,7 +229,7 @@ func EmitNoGoModAndNoGoEnv(msg string) {
 
 func EmitNoGoEnv(msg string) {
 	emitDiagnostic(
-		"go/identify-environment/no-go-mod-and-no-go-env",
+		"go/autobuilder/env-no-go-env",
 		"No Go version in environment",
 		msg,
 		severityNote,
@@ -240,7 +240,7 @@ func EmitNoGoEnv(msg string) {
 
 func EmitNoGoMod(msg string) {
 	emitDiagnostic(
-		"go/identify-environment/no-go-mod",
+		"go/autobuilder/env-no-go-mod",
 		"No `go.mod` file found",
 		msg,
 		severityNote,
@@ -251,7 +251,7 @@ func EmitNoGoMod(msg string) {
 
 func EmitVersionGoModHigherVersionEnvironment(msg string) {
 	emitDiagnostic(
-		"go/identify-environment/version-go-mod-higher-than-go-env",
+		"go/autobuilder/env-version-go-mod-higher-than-go-env",
 		"The Go version in `go.mod` file is higher than the Go version in environment",
 		msg,
 		severityWarning,
@@ -262,8 +262,8 @@ func EmitVersionGoModHigherVersionEnvironment(msg string) {
 
 func EmitVersionGoModNotHigherVersionEnvironment(msg string) {
 	emitDiagnostic(
-		"go/identify-environment/version-go-mod-not-higher-than-go-env",
-		"The Go version in `go.mod` file is not higher than the Go version in environment",
+		"go/autobuilder/env-version-go-mod-lower-than-or-equal-to-go-env",
+		"The Go version in `go.mod` file is lower than or equal to the Go version in environment",
 		msg,
 		severityNote,
 		telemetryOnly,

--- a/go/extractor/extractor.go
+++ b/go/extractor/extractor.go
@@ -10,7 +10,6 @@ import (
 	"go/token"
 	"go/types"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -1807,7 +1806,7 @@ func extractNumLines(tw *trap.Writer, fileName string, ast *ast.File) {
 
 	// count lines of code by tokenizing
 	linesOfCode := 0
-	src, err := ioutil.ReadFile(fileName)
+	src, err := os.ReadFile(fileName)
 	if err != nil {
 		log.Fatalf("Unable to read file %s.", fileName)
 	}

--- a/go/extractor/gomodextractor.go
+++ b/go/extractor/gomodextractor.go
@@ -2,12 +2,13 @@ package extractor
 
 import (
 	"fmt"
-	"golang.org/x/mod/modfile"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"golang.org/x/mod/modfile"
 
 	"github.com/github/codeql-go/extractor/dbscheme"
 	"github.com/github/codeql-go/extractor/srcarchive"
@@ -45,7 +46,7 @@ func (extraction *Extraction) extractGoMod(path string) error {
 	if err != nil {
 		return fmt.Errorf("failed to open go.mod file %s: %s", path, err.Error())
 	}
-	data, err := ioutil.ReadAll(file)
+	data, err := io.ReadAll(file)
 	if err != nil {
 		return fmt.Errorf("failed to read go.mod file %s: %s", path, err.Error())
 	}

--- a/go/extractor/srcarchive/projectlayout_test.go
+++ b/go/extractor/srcarchive/projectlayout_test.go
@@ -1,13 +1,12 @@
 package srcarchive
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 )
 
 func mkProjectLayout(projectLayoutSource string, t *testing.T) (*ProjectLayout, error) {
-	pt, err := ioutil.TempFile("", "path-transformer")
+	pt, err := os.CreateTemp("", "path-transformer")
 	if err != nil {
 		t.Fatalf("Unable to create temporary file for project layout: %s", err.Error())
 	}

--- a/go/extractor/trap/trapwriter.go
+++ b/go/extractor/trap/trapwriter.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"go/ast"
 	"go/types"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"unicode/utf8"
@@ -51,7 +50,7 @@ func NewWriter(path string, pkg *packages.Package) (*Writer, error) {
 	if err != nil {
 		return nil, err
 	}
-	tmpFile, err := ioutil.TempFile(trapFileDir, filepath.Base(trapFilePath))
+	tmpFile, err := os.CreateTemp(trapFileDir, filepath.Base(trapFilePath))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Step 1 of https://github.com/github/codeql-go-team/issues/329.

Integration tests look tricky. I will instead use unit tests in `ql/go/extractor/cli/go-autobuilder/go-autobuilder_test.go` and some manual end-to-end testing. Once other languages have also implemented this flag we can set up everything up to make integration testing possible.