### PR TITLE
C++: Add more FPs for `cpp/invalid-pointer-deref`

### DIFF
--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/InvalidPointerDeref.expected
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/InvalidPointerDeref.expected
@@ -586,118 +586,118 @@ edges
 | test.cpp:248:24:248:30 | call to realloc | test.cpp:254:9:254:9 | p |
 | test.cpp:254:9:254:9 | p | test.cpp:254:9:254:12 | access to array |
 | test.cpp:254:9:254:12 | access to array | test.cpp:254:9:254:16 | Store: ... = ... |
-| test.cpp:266:13:266:24 | new[] | test.cpp:267:14:267:15 | xs |
-| test.cpp:267:14:267:15 | xs | test.cpp:267:14:267:21 | ... + ... |
-| test.cpp:267:14:267:15 | xs | test.cpp:267:14:267:21 | ... + ... |
-| test.cpp:267:14:267:15 | xs | test.cpp:267:14:267:21 | ... + ... |
-| test.cpp:267:14:267:15 | xs | test.cpp:267:14:267:21 | ... + ... |
-| test.cpp:267:14:267:15 | xs | test.cpp:268:26:268:28 | end |
-| test.cpp:267:14:267:15 | xs | test.cpp:268:26:268:28 | end |
-| test.cpp:267:14:267:15 | xs | test.cpp:268:31:268:31 | x |
-| test.cpp:267:14:267:15 | xs | test.cpp:268:31:268:33 | ... ++ |
-| test.cpp:267:14:267:15 | xs | test.cpp:268:31:268:33 | ... ++ |
-| test.cpp:267:14:267:15 | xs | test.cpp:270:14:270:14 | x |
-| test.cpp:267:14:267:15 | xs | test.cpp:270:14:270:14 | x |
-| test.cpp:267:14:267:21 | ... + ... | test.cpp:267:14:267:21 | ... + ... |
-| test.cpp:267:14:267:21 | ... + ... | test.cpp:267:14:267:21 | ... + ... |
-| test.cpp:267:14:267:21 | ... + ... | test.cpp:268:26:268:28 | end |
-| test.cpp:267:14:267:21 | ... + ... | test.cpp:268:26:268:28 | end |
-| test.cpp:267:14:267:21 | ... + ... | test.cpp:268:26:268:28 | end |
-| test.cpp:267:14:267:21 | ... + ... | test.cpp:268:26:268:28 | end |
-| test.cpp:267:14:267:21 | ... + ... | test.cpp:270:13:270:14 | Load: * ... |
-| test.cpp:267:14:267:21 | ... + ... | test.cpp:270:13:270:14 | Load: * ... |
-| test.cpp:267:14:267:21 | ... + ... | test.cpp:270:13:270:14 | Load: * ... |
-| test.cpp:267:14:267:21 | ... + ... | test.cpp:270:13:270:14 | Load: * ... |
-| test.cpp:268:21:268:21 | x | test.cpp:270:13:270:14 | Load: * ... |
-| test.cpp:268:26:268:28 | end | test.cpp:268:26:268:28 | end |
-| test.cpp:268:26:268:28 | end | test.cpp:268:26:268:28 | end |
-| test.cpp:268:26:268:28 | end | test.cpp:270:13:270:14 | Load: * ... |
-| test.cpp:268:26:268:28 | end | test.cpp:270:13:270:14 | Load: * ... |
-| test.cpp:268:31:268:31 | x | test.cpp:270:13:270:14 | Load: * ... |
-| test.cpp:268:31:268:33 | ... ++ | test.cpp:268:21:268:21 | x |
-| test.cpp:268:31:268:33 | ... ++ | test.cpp:268:21:268:21 | x |
-| test.cpp:268:31:268:33 | ... ++ | test.cpp:268:31:268:31 | x |
-| test.cpp:268:31:268:33 | ... ++ | test.cpp:268:31:268:31 | x |
-| test.cpp:268:31:268:33 | ... ++ | test.cpp:270:14:270:14 | x |
-| test.cpp:268:31:268:33 | ... ++ | test.cpp:270:14:270:14 | x |
-| test.cpp:268:31:268:33 | ... ++ | test.cpp:270:14:270:14 | x |
-| test.cpp:268:31:268:33 | ... ++ | test.cpp:270:14:270:14 | x |
-| test.cpp:270:14:270:14 | x | test.cpp:268:31:268:31 | x |
-| test.cpp:270:14:270:14 | x | test.cpp:270:13:270:14 | Load: * ... |
-| test.cpp:270:14:270:14 | x | test.cpp:270:13:270:14 | Load: * ... |
-| test.cpp:276:13:276:24 | new[] | test.cpp:277:14:277:15 | xs |
-| test.cpp:276:13:276:24 | new[] | test.cpp:278:31:278:31 | x |
-| test.cpp:277:14:277:15 | xs | test.cpp:277:14:277:21 | ... + ... |
-| test.cpp:277:14:277:15 | xs | test.cpp:277:14:277:21 | ... + ... |
-| test.cpp:277:14:277:15 | xs | test.cpp:277:14:277:21 | ... + ... |
-| test.cpp:277:14:277:15 | xs | test.cpp:277:14:277:21 | ... + ... |
-| test.cpp:277:14:277:15 | xs | test.cpp:278:26:278:28 | end |
-| test.cpp:277:14:277:15 | xs | test.cpp:278:26:278:28 | end |
-| test.cpp:277:14:277:15 | xs | test.cpp:278:31:278:31 | x |
-| test.cpp:277:14:277:15 | xs | test.cpp:278:31:278:33 | ... ++ |
-| test.cpp:277:14:277:15 | xs | test.cpp:278:31:278:33 | ... ++ |
-| test.cpp:277:14:277:15 | xs | test.cpp:280:5:280:6 | * ... |
-| test.cpp:277:14:277:15 | xs | test.cpp:280:6:280:6 | x |
-| test.cpp:277:14:277:15 | xs | test.cpp:280:6:280:6 | x |
-| test.cpp:277:14:277:21 | ... + ... | test.cpp:277:14:277:21 | ... + ... |
-| test.cpp:277:14:277:21 | ... + ... | test.cpp:277:14:277:21 | ... + ... |
-| test.cpp:277:14:277:21 | ... + ... | test.cpp:278:26:278:28 | end |
-| test.cpp:277:14:277:21 | ... + ... | test.cpp:278:26:278:28 | end |
-| test.cpp:277:14:277:21 | ... + ... | test.cpp:278:26:278:28 | end |
-| test.cpp:277:14:277:21 | ... + ... | test.cpp:278:26:278:28 | end |
-| test.cpp:277:14:277:21 | ... + ... | test.cpp:280:5:280:10 | Store: ... = ... |
-| test.cpp:277:14:277:21 | ... + ... | test.cpp:280:5:280:10 | Store: ... = ... |
-| test.cpp:277:14:277:21 | ... + ... | test.cpp:280:5:280:10 | Store: ... = ... |
-| test.cpp:277:14:277:21 | ... + ... | test.cpp:280:5:280:10 | Store: ... = ... |
-| test.cpp:278:21:278:21 | x | test.cpp:280:5:280:10 | Store: ... = ... |
-| test.cpp:278:26:278:28 | end | test.cpp:278:26:278:28 | end |
-| test.cpp:278:26:278:28 | end | test.cpp:278:26:278:28 | end |
-| test.cpp:278:26:278:28 | end | test.cpp:280:5:280:10 | Store: ... = ... |
-| test.cpp:278:26:278:28 | end | test.cpp:280:5:280:10 | Store: ... = ... |
-| test.cpp:278:31:278:31 | x | test.cpp:280:5:280:10 | Store: ... = ... |
-| test.cpp:278:31:278:33 | ... ++ | test.cpp:278:21:278:21 | x |
-| test.cpp:278:31:278:33 | ... ++ | test.cpp:278:21:278:21 | x |
-| test.cpp:278:31:278:33 | ... ++ | test.cpp:278:31:278:31 | x |
-| test.cpp:278:31:278:33 | ... ++ | test.cpp:278:31:278:31 | x |
-| test.cpp:278:31:278:33 | ... ++ | test.cpp:280:5:280:6 | * ... |
-| test.cpp:278:31:278:33 | ... ++ | test.cpp:280:5:280:6 | * ... |
-| test.cpp:278:31:278:33 | ... ++ | test.cpp:280:6:280:6 | x |
-| test.cpp:278:31:278:33 | ... ++ | test.cpp:280:6:280:6 | x |
-| test.cpp:278:31:278:33 | ... ++ | test.cpp:280:6:280:6 | x |
-| test.cpp:278:31:278:33 | ... ++ | test.cpp:280:6:280:6 | x |
-| test.cpp:280:5:280:6 | * ... | test.cpp:280:5:280:10 | Store: ... = ... |
-| test.cpp:280:6:280:6 | x | test.cpp:278:31:278:31 | x |
-| test.cpp:280:6:280:6 | x | test.cpp:280:5:280:6 | * ... |
-| test.cpp:280:6:280:6 | x | test.cpp:280:5:280:10 | Store: ... = ... |
-| test.cpp:280:6:280:6 | x | test.cpp:280:5:280:10 | Store: ... = ... |
-| test.cpp:286:13:286:24 | new[] | test.cpp:287:14:287:15 | xs |
-| test.cpp:287:14:287:15 | xs | test.cpp:288:30:288:32 | ... ++ |
-| test.cpp:287:14:287:15 | xs | test.cpp:288:30:288:32 | ... ++ |
-| test.cpp:288:21:288:21 | x | test.cpp:290:13:290:14 | Load: * ... |
-| test.cpp:288:30:288:30 | x | test.cpp:290:13:290:14 | Load: * ... |
-| test.cpp:288:30:288:32 | ... ++ | test.cpp:288:21:288:21 | x |
-| test.cpp:288:30:288:32 | ... ++ | test.cpp:288:21:288:21 | x |
-| test.cpp:288:30:288:32 | ... ++ | test.cpp:288:30:288:30 | x |
-| test.cpp:288:30:288:32 | ... ++ | test.cpp:288:30:288:30 | x |
-| test.cpp:288:30:288:32 | ... ++ | test.cpp:290:14:290:14 | x |
-| test.cpp:288:30:288:32 | ... ++ | test.cpp:290:14:290:14 | x |
-| test.cpp:290:14:290:14 | x | test.cpp:290:13:290:14 | Load: * ... |
-| test.cpp:296:13:296:24 | new[] | test.cpp:297:14:297:15 | xs |
-| test.cpp:296:13:296:24 | new[] | test.cpp:298:30:298:30 | x |
-| test.cpp:297:14:297:15 | xs | test.cpp:298:30:298:32 | ... ++ |
-| test.cpp:297:14:297:15 | xs | test.cpp:298:30:298:32 | ... ++ |
-| test.cpp:298:21:298:21 | x | test.cpp:300:5:300:10 | Store: ... = ... |
-| test.cpp:298:30:298:30 | x | test.cpp:300:5:300:10 | Store: ... = ... |
-| test.cpp:298:30:298:32 | ... ++ | test.cpp:298:21:298:21 | x |
-| test.cpp:298:30:298:32 | ... ++ | test.cpp:298:21:298:21 | x |
-| test.cpp:298:30:298:32 | ... ++ | test.cpp:298:30:298:30 | x |
-| test.cpp:298:30:298:32 | ... ++ | test.cpp:298:30:298:30 | x |
-| test.cpp:298:30:298:32 | ... ++ | test.cpp:300:5:300:6 | * ... |
-| test.cpp:298:30:298:32 | ... ++ | test.cpp:300:5:300:6 | * ... |
-| test.cpp:298:30:298:32 | ... ++ | test.cpp:300:6:300:6 | x |
-| test.cpp:298:30:298:32 | ... ++ | test.cpp:300:6:300:6 | x |
-| test.cpp:300:5:300:6 | * ... | test.cpp:300:5:300:10 | Store: ... = ... |
-| test.cpp:300:6:300:6 | x | test.cpp:300:5:300:10 | Store: ... = ... |
+| test.cpp:260:13:260:24 | new[] | test.cpp:261:14:261:15 | xs |
+| test.cpp:261:14:261:15 | xs | test.cpp:261:14:261:21 | ... + ... |
+| test.cpp:261:14:261:15 | xs | test.cpp:261:14:261:21 | ... + ... |
+| test.cpp:261:14:261:15 | xs | test.cpp:261:14:261:21 | ... + ... |
+| test.cpp:261:14:261:15 | xs | test.cpp:261:14:261:21 | ... + ... |
+| test.cpp:261:14:261:15 | xs | test.cpp:262:26:262:28 | end |
+| test.cpp:261:14:261:15 | xs | test.cpp:262:26:262:28 | end |
+| test.cpp:261:14:261:15 | xs | test.cpp:262:31:262:31 | x |
+| test.cpp:261:14:261:15 | xs | test.cpp:262:31:262:33 | ... ++ |
+| test.cpp:261:14:261:15 | xs | test.cpp:262:31:262:33 | ... ++ |
+| test.cpp:261:14:261:15 | xs | test.cpp:264:14:264:14 | x |
+| test.cpp:261:14:261:15 | xs | test.cpp:264:14:264:14 | x |
+| test.cpp:261:14:261:21 | ... + ... | test.cpp:261:14:261:21 | ... + ... |
+| test.cpp:261:14:261:21 | ... + ... | test.cpp:261:14:261:21 | ... + ... |
+| test.cpp:261:14:261:21 | ... + ... | test.cpp:262:26:262:28 | end |
+| test.cpp:261:14:261:21 | ... + ... | test.cpp:262:26:262:28 | end |
+| test.cpp:261:14:261:21 | ... + ... | test.cpp:262:26:262:28 | end |
+| test.cpp:261:14:261:21 | ... + ... | test.cpp:262:26:262:28 | end |
+| test.cpp:261:14:261:21 | ... + ... | test.cpp:264:13:264:14 | Load: * ... |
+| test.cpp:261:14:261:21 | ... + ... | test.cpp:264:13:264:14 | Load: * ... |
+| test.cpp:261:14:261:21 | ... + ... | test.cpp:264:13:264:14 | Load: * ... |
+| test.cpp:261:14:261:21 | ... + ... | test.cpp:264:13:264:14 | Load: * ... |
+| test.cpp:262:21:262:21 | x | test.cpp:264:13:264:14 | Load: * ... |
+| test.cpp:262:26:262:28 | end | test.cpp:262:26:262:28 | end |
+| test.cpp:262:26:262:28 | end | test.cpp:262:26:262:28 | end |
+| test.cpp:262:26:262:28 | end | test.cpp:264:13:264:14 | Load: * ... |
+| test.cpp:262:26:262:28 | end | test.cpp:264:13:264:14 | Load: * ... |
+| test.cpp:262:31:262:31 | x | test.cpp:264:13:264:14 | Load: * ... |
+| test.cpp:262:31:262:33 | ... ++ | test.cpp:262:21:262:21 | x |
+| test.cpp:262:31:262:33 | ... ++ | test.cpp:262:21:262:21 | x |
+| test.cpp:262:31:262:33 | ... ++ | test.cpp:262:31:262:31 | x |
+| test.cpp:262:31:262:33 | ... ++ | test.cpp:262:31:262:31 | x |
+| test.cpp:262:31:262:33 | ... ++ | test.cpp:264:14:264:14 | x |
+| test.cpp:262:31:262:33 | ... ++ | test.cpp:264:14:264:14 | x |
+| test.cpp:262:31:262:33 | ... ++ | test.cpp:264:14:264:14 | x |
+| test.cpp:262:31:262:33 | ... ++ | test.cpp:264:14:264:14 | x |
+| test.cpp:264:14:264:14 | x | test.cpp:262:31:262:31 | x |
+| test.cpp:264:14:264:14 | x | test.cpp:264:13:264:14 | Load: * ... |
+| test.cpp:264:14:264:14 | x | test.cpp:264:13:264:14 | Load: * ... |
+| test.cpp:270:13:270:24 | new[] | test.cpp:271:14:271:15 | xs |
+| test.cpp:270:13:270:24 | new[] | test.cpp:272:31:272:31 | x |
+| test.cpp:271:14:271:15 | xs | test.cpp:271:14:271:21 | ... + ... |
+| test.cpp:271:14:271:15 | xs | test.cpp:271:14:271:21 | ... + ... |
+| test.cpp:271:14:271:15 | xs | test.cpp:271:14:271:21 | ... + ... |
+| test.cpp:271:14:271:15 | xs | test.cpp:271:14:271:21 | ... + ... |
+| test.cpp:271:14:271:15 | xs | test.cpp:272:26:272:28 | end |
+| test.cpp:271:14:271:15 | xs | test.cpp:272:26:272:28 | end |
+| test.cpp:271:14:271:15 | xs | test.cpp:272:31:272:31 | x |
+| test.cpp:271:14:271:15 | xs | test.cpp:272:31:272:33 | ... ++ |
+| test.cpp:271:14:271:15 | xs | test.cpp:272:31:272:33 | ... ++ |
+| test.cpp:271:14:271:15 | xs | test.cpp:274:5:274:6 | * ... |
+| test.cpp:271:14:271:15 | xs | test.cpp:274:6:274:6 | x |
+| test.cpp:271:14:271:15 | xs | test.cpp:274:6:274:6 | x |
+| test.cpp:271:14:271:21 | ... + ... | test.cpp:271:14:271:21 | ... + ... |
+| test.cpp:271:14:271:21 | ... + ... | test.cpp:271:14:271:21 | ... + ... |
+| test.cpp:271:14:271:21 | ... + ... | test.cpp:272:26:272:28 | end |
+| test.cpp:271:14:271:21 | ... + ... | test.cpp:272:26:272:28 | end |
+| test.cpp:271:14:271:21 | ... + ... | test.cpp:272:26:272:28 | end |
+| test.cpp:271:14:271:21 | ... + ... | test.cpp:272:26:272:28 | end |
+| test.cpp:271:14:271:21 | ... + ... | test.cpp:274:5:274:10 | Store: ... = ... |
+| test.cpp:271:14:271:21 | ... + ... | test.cpp:274:5:274:10 | Store: ... = ... |
+| test.cpp:271:14:271:21 | ... + ... | test.cpp:274:5:274:10 | Store: ... = ... |
+| test.cpp:271:14:271:21 | ... + ... | test.cpp:274:5:274:10 | Store: ... = ... |
+| test.cpp:272:21:272:21 | x | test.cpp:274:5:274:10 | Store: ... = ... |
+| test.cpp:272:26:272:28 | end | test.cpp:272:26:272:28 | end |
+| test.cpp:272:26:272:28 | end | test.cpp:272:26:272:28 | end |
+| test.cpp:272:26:272:28 | end | test.cpp:274:5:274:10 | Store: ... = ... |
+| test.cpp:272:26:272:28 | end | test.cpp:274:5:274:10 | Store: ... = ... |
+| test.cpp:272:31:272:31 | x | test.cpp:274:5:274:10 | Store: ... = ... |
+| test.cpp:272:31:272:33 | ... ++ | test.cpp:272:21:272:21 | x |
+| test.cpp:272:31:272:33 | ... ++ | test.cpp:272:21:272:21 | x |
+| test.cpp:272:31:272:33 | ... ++ | test.cpp:272:31:272:31 | x |
+| test.cpp:272:31:272:33 | ... ++ | test.cpp:272:31:272:31 | x |
+| test.cpp:272:31:272:33 | ... ++ | test.cpp:274:5:274:6 | * ... |
+| test.cpp:272:31:272:33 | ... ++ | test.cpp:274:5:274:6 | * ... |
+| test.cpp:272:31:272:33 | ... ++ | test.cpp:274:6:274:6 | x |
+| test.cpp:272:31:272:33 | ... ++ | test.cpp:274:6:274:6 | x |
+| test.cpp:272:31:272:33 | ... ++ | test.cpp:274:6:274:6 | x |
+| test.cpp:272:31:272:33 | ... ++ | test.cpp:274:6:274:6 | x |
+| test.cpp:274:5:274:6 | * ... | test.cpp:274:5:274:10 | Store: ... = ... |
+| test.cpp:274:6:274:6 | x | test.cpp:272:31:272:31 | x |
+| test.cpp:274:6:274:6 | x | test.cpp:274:5:274:6 | * ... |
+| test.cpp:274:6:274:6 | x | test.cpp:274:5:274:10 | Store: ... = ... |
+| test.cpp:274:6:274:6 | x | test.cpp:274:5:274:10 | Store: ... = ... |
+| test.cpp:280:13:280:24 | new[] | test.cpp:281:14:281:15 | xs |
+| test.cpp:281:14:281:15 | xs | test.cpp:282:30:282:32 | ... ++ |
+| test.cpp:281:14:281:15 | xs | test.cpp:282:30:282:32 | ... ++ |
+| test.cpp:282:21:282:21 | x | test.cpp:284:13:284:14 | Load: * ... |
+| test.cpp:282:30:282:30 | x | test.cpp:284:13:284:14 | Load: * ... |
+| test.cpp:282:30:282:32 | ... ++ | test.cpp:282:21:282:21 | x |
+| test.cpp:282:30:282:32 | ... ++ | test.cpp:282:21:282:21 | x |
+| test.cpp:282:30:282:32 | ... ++ | test.cpp:282:30:282:30 | x |
+| test.cpp:282:30:282:32 | ... ++ | test.cpp:282:30:282:30 | x |
+| test.cpp:282:30:282:32 | ... ++ | test.cpp:284:14:284:14 | x |
+| test.cpp:282:30:282:32 | ... ++ | test.cpp:284:14:284:14 | x |
+| test.cpp:284:14:284:14 | x | test.cpp:284:13:284:14 | Load: * ... |
+| test.cpp:290:13:290:24 | new[] | test.cpp:291:14:291:15 | xs |
+| test.cpp:290:13:290:24 | new[] | test.cpp:292:30:292:30 | x |
+| test.cpp:291:14:291:15 | xs | test.cpp:292:30:292:32 | ... ++ |
+| test.cpp:291:14:291:15 | xs | test.cpp:292:30:292:32 | ... ++ |
+| test.cpp:292:21:292:21 | x | test.cpp:294:5:294:10 | Store: ... = ... |
+| test.cpp:292:30:292:30 | x | test.cpp:294:5:294:10 | Store: ... = ... |
+| test.cpp:292:30:292:32 | ... ++ | test.cpp:292:21:292:21 | x |
+| test.cpp:292:30:292:32 | ... ++ | test.cpp:292:21:292:21 | x |
+| test.cpp:292:30:292:32 | ... ++ | test.cpp:292:30:292:30 | x |
+| test.cpp:292:30:292:32 | ... ++ | test.cpp:292:30:292:30 | x |
+| test.cpp:292:30:292:32 | ... ++ | test.cpp:294:5:294:6 | * ... |
+| test.cpp:292:30:292:32 | ... ++ | test.cpp:294:5:294:6 | * ... |
+| test.cpp:292:30:292:32 | ... ++ | test.cpp:294:6:294:6 | x |
+| test.cpp:292:30:292:32 | ... ++ | test.cpp:294:6:294:6 | x |
+| test.cpp:294:5:294:6 | * ... | test.cpp:294:5:294:10 | Store: ... = ... |
+| test.cpp:294:6:294:6 | x | test.cpp:294:5:294:10 | Store: ... = ... |
 #select
 | test.cpp:6:14:6:15 | Load: * ... | test.cpp:4:15:4:20 | call to malloc | test.cpp:6:14:6:15 | Load: * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:4:15:4:20 | call to malloc | call to malloc | test.cpp:5:19:5:22 | size | size |
 | test.cpp:8:14:8:21 | Load: * ... | test.cpp:4:15:4:20 | call to malloc | test.cpp:8:14:8:21 | Load: * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@ + 1. | test.cpp:4:15:4:20 | call to malloc | call to malloc | test.cpp:5:19:5:22 | size | size |
@@ -719,9 +719,9 @@ edges
 | test.cpp:232:3:232:20 | Store: ... = ... | test.cpp:231:18:231:30 | new[] | test.cpp:232:3:232:20 | Store: ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:231:18:231:30 | new[] | new[] | test.cpp:232:11:232:15 | index | index |
 | test.cpp:239:5:239:22 | Store: ... = ... | test.cpp:238:20:238:32 | new[] | test.cpp:239:5:239:22 | Store: ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:238:20:238:32 | new[] | new[] | test.cpp:239:13:239:17 | index | index |
 | test.cpp:254:9:254:16 | Store: ... = ... | test.cpp:248:24:248:30 | call to realloc | test.cpp:254:9:254:16 | Store: ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:248:24:248:30 | call to realloc | call to realloc | test.cpp:254:11:254:11 | i | i |
-| test.cpp:270:13:270:14 | Load: * ... | test.cpp:266:13:266:24 | new[] | test.cpp:270:13:270:14 | Load: * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@ + 1. | test.cpp:266:13:266:24 | new[] | new[] | test.cpp:267:19:267:21 | len | len |
-| test.cpp:270:13:270:14 | Load: * ... | test.cpp:266:13:266:24 | new[] | test.cpp:270:13:270:14 | Load: * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:266:13:266:24 | new[] | new[] | test.cpp:267:19:267:21 | len | len |
-| test.cpp:280:5:280:10 | Store: ... = ... | test.cpp:276:13:276:24 | new[] | test.cpp:280:5:280:10 | Store: ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@ + 1. | test.cpp:276:13:276:24 | new[] | new[] | test.cpp:277:19:277:21 | len | len |
-| test.cpp:280:5:280:10 | Store: ... = ... | test.cpp:276:13:276:24 | new[] | test.cpp:280:5:280:10 | Store: ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:276:13:276:24 | new[] | new[] | test.cpp:277:19:277:21 | len | len |
-| test.cpp:290:13:290:14 | Load: * ... | test.cpp:286:13:286:24 | new[] | test.cpp:290:13:290:14 | Load: * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:286:13:286:24 | new[] | new[] | test.cpp:287:19:287:21 | len | len |
-| test.cpp:300:5:300:10 | Store: ... = ... | test.cpp:296:13:296:24 | new[] | test.cpp:300:5:300:10 | Store: ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:296:13:296:24 | new[] | new[] | test.cpp:297:19:297:21 | len | len |
+| test.cpp:264:13:264:14 | Load: * ... | test.cpp:260:13:260:24 | new[] | test.cpp:264:13:264:14 | Load: * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@ + 1. | test.cpp:260:13:260:24 | new[] | new[] | test.cpp:261:19:261:21 | len | len |
+| test.cpp:264:13:264:14 | Load: * ... | test.cpp:260:13:260:24 | new[] | test.cpp:264:13:264:14 | Load: * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:260:13:260:24 | new[] | new[] | test.cpp:261:19:261:21 | len | len |
+| test.cpp:274:5:274:10 | Store: ... = ... | test.cpp:270:13:270:24 | new[] | test.cpp:274:5:274:10 | Store: ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@ + 1. | test.cpp:270:13:270:24 | new[] | new[] | test.cpp:271:19:271:21 | len | len |
+| test.cpp:274:5:274:10 | Store: ... = ... | test.cpp:270:13:270:24 | new[] | test.cpp:274:5:274:10 | Store: ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:270:13:270:24 | new[] | new[] | test.cpp:271:19:271:21 | len | len |
+| test.cpp:284:13:284:14 | Load: * ... | test.cpp:280:13:280:24 | new[] | test.cpp:284:13:284:14 | Load: * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:280:13:280:24 | new[] | new[] | test.cpp:281:19:281:21 | len | len |
+| test.cpp:294:5:294:10 | Store: ... = ... | test.cpp:290:13:290:24 | new[] | test.cpp:294:5:294:10 | Store: ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:290:13:290:24 | new[] | new[] | test.cpp:291:19:291:21 | len | len |

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/InvalidPointerDeref.expected
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/InvalidPointerDeref.expected
@@ -586,6 +586,118 @@ edges
 | test.cpp:248:24:248:30 | call to realloc | test.cpp:254:9:254:9 | p |
 | test.cpp:254:9:254:9 | p | test.cpp:254:9:254:12 | access to array |
 | test.cpp:254:9:254:12 | access to array | test.cpp:254:9:254:16 | Store: ... = ... |
+| test.cpp:266:13:266:24 | new[] | test.cpp:267:14:267:15 | xs |
+| test.cpp:267:14:267:15 | xs | test.cpp:267:14:267:21 | ... + ... |
+| test.cpp:267:14:267:15 | xs | test.cpp:267:14:267:21 | ... + ... |
+| test.cpp:267:14:267:15 | xs | test.cpp:267:14:267:21 | ... + ... |
+| test.cpp:267:14:267:15 | xs | test.cpp:267:14:267:21 | ... + ... |
+| test.cpp:267:14:267:15 | xs | test.cpp:268:26:268:28 | end |
+| test.cpp:267:14:267:15 | xs | test.cpp:268:26:268:28 | end |
+| test.cpp:267:14:267:15 | xs | test.cpp:268:31:268:31 | x |
+| test.cpp:267:14:267:15 | xs | test.cpp:268:31:268:33 | ... ++ |
+| test.cpp:267:14:267:15 | xs | test.cpp:268:31:268:33 | ... ++ |
+| test.cpp:267:14:267:15 | xs | test.cpp:270:14:270:14 | x |
+| test.cpp:267:14:267:15 | xs | test.cpp:270:14:270:14 | x |
+| test.cpp:267:14:267:21 | ... + ... | test.cpp:267:14:267:21 | ... + ... |
+| test.cpp:267:14:267:21 | ... + ... | test.cpp:267:14:267:21 | ... + ... |
+| test.cpp:267:14:267:21 | ... + ... | test.cpp:268:26:268:28 | end |
+| test.cpp:267:14:267:21 | ... + ... | test.cpp:268:26:268:28 | end |
+| test.cpp:267:14:267:21 | ... + ... | test.cpp:268:26:268:28 | end |
+| test.cpp:267:14:267:21 | ... + ... | test.cpp:268:26:268:28 | end |
+| test.cpp:267:14:267:21 | ... + ... | test.cpp:270:13:270:14 | Load: * ... |
+| test.cpp:267:14:267:21 | ... + ... | test.cpp:270:13:270:14 | Load: * ... |
+| test.cpp:267:14:267:21 | ... + ... | test.cpp:270:13:270:14 | Load: * ... |
+| test.cpp:267:14:267:21 | ... + ... | test.cpp:270:13:270:14 | Load: * ... |
+| test.cpp:268:21:268:21 | x | test.cpp:270:13:270:14 | Load: * ... |
+| test.cpp:268:26:268:28 | end | test.cpp:268:26:268:28 | end |
+| test.cpp:268:26:268:28 | end | test.cpp:268:26:268:28 | end |
+| test.cpp:268:26:268:28 | end | test.cpp:270:13:270:14 | Load: * ... |
+| test.cpp:268:26:268:28 | end | test.cpp:270:13:270:14 | Load: * ... |
+| test.cpp:268:31:268:31 | x | test.cpp:270:13:270:14 | Load: * ... |
+| test.cpp:268:31:268:33 | ... ++ | test.cpp:268:21:268:21 | x |
+| test.cpp:268:31:268:33 | ... ++ | test.cpp:268:21:268:21 | x |
+| test.cpp:268:31:268:33 | ... ++ | test.cpp:268:31:268:31 | x |
+| test.cpp:268:31:268:33 | ... ++ | test.cpp:268:31:268:31 | x |
+| test.cpp:268:31:268:33 | ... ++ | test.cpp:270:14:270:14 | x |
+| test.cpp:268:31:268:33 | ... ++ | test.cpp:270:14:270:14 | x |
+| test.cpp:268:31:268:33 | ... ++ | test.cpp:270:14:270:14 | x |
+| test.cpp:268:31:268:33 | ... ++ | test.cpp:270:14:270:14 | x |
+| test.cpp:270:14:270:14 | x | test.cpp:268:31:268:31 | x |
+| test.cpp:270:14:270:14 | x | test.cpp:270:13:270:14 | Load: * ... |
+| test.cpp:270:14:270:14 | x | test.cpp:270:13:270:14 | Load: * ... |
+| test.cpp:276:13:276:24 | new[] | test.cpp:277:14:277:15 | xs |
+| test.cpp:276:13:276:24 | new[] | test.cpp:278:31:278:31 | x |
+| test.cpp:277:14:277:15 | xs | test.cpp:277:14:277:21 | ... + ... |
+| test.cpp:277:14:277:15 | xs | test.cpp:277:14:277:21 | ... + ... |
+| test.cpp:277:14:277:15 | xs | test.cpp:277:14:277:21 | ... + ... |
+| test.cpp:277:14:277:15 | xs | test.cpp:277:14:277:21 | ... + ... |
+| test.cpp:277:14:277:15 | xs | test.cpp:278:26:278:28 | end |
+| test.cpp:277:14:277:15 | xs | test.cpp:278:26:278:28 | end |
+| test.cpp:277:14:277:15 | xs | test.cpp:278:31:278:31 | x |
+| test.cpp:277:14:277:15 | xs | test.cpp:278:31:278:33 | ... ++ |
+| test.cpp:277:14:277:15 | xs | test.cpp:278:31:278:33 | ... ++ |
+| test.cpp:277:14:277:15 | xs | test.cpp:280:5:280:6 | * ... |
+| test.cpp:277:14:277:15 | xs | test.cpp:280:6:280:6 | x |
+| test.cpp:277:14:277:15 | xs | test.cpp:280:6:280:6 | x |
+| test.cpp:277:14:277:21 | ... + ... | test.cpp:277:14:277:21 | ... + ... |
+| test.cpp:277:14:277:21 | ... + ... | test.cpp:277:14:277:21 | ... + ... |
+| test.cpp:277:14:277:21 | ... + ... | test.cpp:278:26:278:28 | end |
+| test.cpp:277:14:277:21 | ... + ... | test.cpp:278:26:278:28 | end |
+| test.cpp:277:14:277:21 | ... + ... | test.cpp:278:26:278:28 | end |
+| test.cpp:277:14:277:21 | ... + ... | test.cpp:278:26:278:28 | end |
+| test.cpp:277:14:277:21 | ... + ... | test.cpp:280:5:280:10 | Store: ... = ... |
+| test.cpp:277:14:277:21 | ... + ... | test.cpp:280:5:280:10 | Store: ... = ... |
+| test.cpp:277:14:277:21 | ... + ... | test.cpp:280:5:280:10 | Store: ... = ... |
+| test.cpp:277:14:277:21 | ... + ... | test.cpp:280:5:280:10 | Store: ... = ... |
+| test.cpp:278:21:278:21 | x | test.cpp:280:5:280:10 | Store: ... = ... |
+| test.cpp:278:26:278:28 | end | test.cpp:278:26:278:28 | end |
+| test.cpp:278:26:278:28 | end | test.cpp:278:26:278:28 | end |
+| test.cpp:278:26:278:28 | end | test.cpp:280:5:280:10 | Store: ... = ... |
+| test.cpp:278:26:278:28 | end | test.cpp:280:5:280:10 | Store: ... = ... |
+| test.cpp:278:31:278:31 | x | test.cpp:280:5:280:10 | Store: ... = ... |
+| test.cpp:278:31:278:33 | ... ++ | test.cpp:278:21:278:21 | x |
+| test.cpp:278:31:278:33 | ... ++ | test.cpp:278:21:278:21 | x |
+| test.cpp:278:31:278:33 | ... ++ | test.cpp:278:31:278:31 | x |
+| test.cpp:278:31:278:33 | ... ++ | test.cpp:278:31:278:31 | x |
+| test.cpp:278:31:278:33 | ... ++ | test.cpp:280:5:280:6 | * ... |
+| test.cpp:278:31:278:33 | ... ++ | test.cpp:280:5:280:6 | * ... |
+| test.cpp:278:31:278:33 | ... ++ | test.cpp:280:6:280:6 | x |
+| test.cpp:278:31:278:33 | ... ++ | test.cpp:280:6:280:6 | x |
+| test.cpp:278:31:278:33 | ... ++ | test.cpp:280:6:280:6 | x |
+| test.cpp:278:31:278:33 | ... ++ | test.cpp:280:6:280:6 | x |
+| test.cpp:280:5:280:6 | * ... | test.cpp:280:5:280:10 | Store: ... = ... |
+| test.cpp:280:6:280:6 | x | test.cpp:278:31:278:31 | x |
+| test.cpp:280:6:280:6 | x | test.cpp:280:5:280:6 | * ... |
+| test.cpp:280:6:280:6 | x | test.cpp:280:5:280:10 | Store: ... = ... |
+| test.cpp:280:6:280:6 | x | test.cpp:280:5:280:10 | Store: ... = ... |
+| test.cpp:286:13:286:24 | new[] | test.cpp:287:14:287:15 | xs |
+| test.cpp:287:14:287:15 | xs | test.cpp:288:30:288:32 | ... ++ |
+| test.cpp:287:14:287:15 | xs | test.cpp:288:30:288:32 | ... ++ |
+| test.cpp:288:21:288:21 | x | test.cpp:290:13:290:14 | Load: * ... |
+| test.cpp:288:30:288:30 | x | test.cpp:290:13:290:14 | Load: * ... |
+| test.cpp:288:30:288:32 | ... ++ | test.cpp:288:21:288:21 | x |
+| test.cpp:288:30:288:32 | ... ++ | test.cpp:288:21:288:21 | x |
+| test.cpp:288:30:288:32 | ... ++ | test.cpp:288:30:288:30 | x |
+| test.cpp:288:30:288:32 | ... ++ | test.cpp:288:30:288:30 | x |
+| test.cpp:288:30:288:32 | ... ++ | test.cpp:290:14:290:14 | x |
+| test.cpp:288:30:288:32 | ... ++ | test.cpp:290:14:290:14 | x |
+| test.cpp:290:14:290:14 | x | test.cpp:290:13:290:14 | Load: * ... |
+| test.cpp:296:13:296:24 | new[] | test.cpp:297:14:297:15 | xs |
+| test.cpp:296:13:296:24 | new[] | test.cpp:298:30:298:30 | x |
+| test.cpp:297:14:297:15 | xs | test.cpp:298:30:298:32 | ... ++ |
+| test.cpp:297:14:297:15 | xs | test.cpp:298:30:298:32 | ... ++ |
+| test.cpp:298:21:298:21 | x | test.cpp:300:5:300:10 | Store: ... = ... |
+| test.cpp:298:30:298:30 | x | test.cpp:300:5:300:10 | Store: ... = ... |
+| test.cpp:298:30:298:32 | ... ++ | test.cpp:298:21:298:21 | x |
+| test.cpp:298:30:298:32 | ... ++ | test.cpp:298:21:298:21 | x |
+| test.cpp:298:30:298:32 | ... ++ | test.cpp:298:30:298:30 | x |
+| test.cpp:298:30:298:32 | ... ++ | test.cpp:298:30:298:30 | x |
+| test.cpp:298:30:298:32 | ... ++ | test.cpp:300:5:300:6 | * ... |
+| test.cpp:298:30:298:32 | ... ++ | test.cpp:300:5:300:6 | * ... |
+| test.cpp:298:30:298:32 | ... ++ | test.cpp:300:6:300:6 | x |
+| test.cpp:298:30:298:32 | ... ++ | test.cpp:300:6:300:6 | x |
+| test.cpp:300:5:300:6 | * ... | test.cpp:300:5:300:10 | Store: ... = ... |
+| test.cpp:300:6:300:6 | x | test.cpp:300:5:300:10 | Store: ... = ... |
 #select
 | test.cpp:6:14:6:15 | Load: * ... | test.cpp:4:15:4:20 | call to malloc | test.cpp:6:14:6:15 | Load: * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:4:15:4:20 | call to malloc | call to malloc | test.cpp:5:19:5:22 | size | size |
 | test.cpp:8:14:8:21 | Load: * ... | test.cpp:4:15:4:20 | call to malloc | test.cpp:8:14:8:21 | Load: * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@ + 1. | test.cpp:4:15:4:20 | call to malloc | call to malloc | test.cpp:5:19:5:22 | size | size |
@@ -607,3 +719,9 @@ edges
 | test.cpp:232:3:232:20 | Store: ... = ... | test.cpp:231:18:231:30 | new[] | test.cpp:232:3:232:20 | Store: ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:231:18:231:30 | new[] | new[] | test.cpp:232:11:232:15 | index | index |
 | test.cpp:239:5:239:22 | Store: ... = ... | test.cpp:238:20:238:32 | new[] | test.cpp:239:5:239:22 | Store: ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:238:20:238:32 | new[] | new[] | test.cpp:239:13:239:17 | index | index |
 | test.cpp:254:9:254:16 | Store: ... = ... | test.cpp:248:24:248:30 | call to realloc | test.cpp:254:9:254:16 | Store: ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:248:24:248:30 | call to realloc | call to realloc | test.cpp:254:11:254:11 | i | i |
+| test.cpp:270:13:270:14 | Load: * ... | test.cpp:266:13:266:24 | new[] | test.cpp:270:13:270:14 | Load: * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@ + 1. | test.cpp:266:13:266:24 | new[] | new[] | test.cpp:267:19:267:21 | len | len |
+| test.cpp:270:13:270:14 | Load: * ... | test.cpp:266:13:266:24 | new[] | test.cpp:270:13:270:14 | Load: * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:266:13:266:24 | new[] | new[] | test.cpp:267:19:267:21 | len | len |
+| test.cpp:280:5:280:10 | Store: ... = ... | test.cpp:276:13:276:24 | new[] | test.cpp:280:5:280:10 | Store: ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@ + 1. | test.cpp:276:13:276:24 | new[] | new[] | test.cpp:277:19:277:21 | len | len |
+| test.cpp:280:5:280:10 | Store: ... = ... | test.cpp:276:13:276:24 | new[] | test.cpp:280:5:280:10 | Store: ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:276:13:276:24 | new[] | new[] | test.cpp:277:19:277:21 | len | len |
+| test.cpp:290:13:290:14 | Load: * ... | test.cpp:286:13:286:24 | new[] | test.cpp:290:13:290:14 | Load: * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:286:13:286:24 | new[] | new[] | test.cpp:287:19:287:21 | len | len |
+| test.cpp:300:5:300:10 | Store: ... = ... | test.cpp:296:13:296:24 | new[] | test.cpp:300:5:300:10 | Store: ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:296:13:296:24 | new[] | new[] | test.cpp:297:19:297:21 | len | len |

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/test.cpp
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/test.cpp
@@ -255,13 +255,7 @@ void test17(unsigned *p, unsigned x, unsigned k) {
     }
 }
 
-struct array_with_size
-{
-  int *xs;
-  unsigned len;
-};
-
-void test17(unsigned len, array_with_size *s)
+void test17(unsigned len)
 {
   int *xs = new int[len];
   int *end = xs + len;
@@ -271,7 +265,7 @@ void test17(unsigned len, array_with_size *s)
   }
 }
 
-void test18(unsigned len, array_with_size *s)
+void test18(unsigned len)
 {
   int *xs = new int[len];
   int *end = xs + len;
@@ -281,7 +275,7 @@ void test18(unsigned len, array_with_size *s)
   }
 }
 
-void test19(unsigned len, array_with_size *s)
+void test19(unsigned len)
 {
   int *xs = new int[len];
   int *end = xs + len;
@@ -291,7 +285,7 @@ void test19(unsigned len, array_with_size *s)
   }
 }
 
-void test20(unsigned len, array_with_size *s)
+void test20(unsigned len)
 {
   int *xs = new int[len];
   int *end = xs + len;

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/test.cpp
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/test.cpp
@@ -254,3 +254,49 @@ void test17(unsigned *p, unsigned x, unsigned k) {
         p[i] = x; // GOOD [FALSE POSITIVE]
     }
 }
+
+struct array_with_size
+{
+  int *xs;
+  unsigned len;
+};
+
+void test17(unsigned len, array_with_size *s)
+{
+  int *xs = new int[len];
+  int *end = xs + len;
+  for (int *x = xs; x <= end; x++)
+  {
+    int i = *x; // BAD
+  }
+}
+
+void test18(unsigned len, array_with_size *s)
+{
+  int *xs = new int[len];
+  int *end = xs + len;
+  for (int *x = xs; x <= end; x++)
+  {
+    *x = 0; // BAD
+  }
+}
+
+void test19(unsigned len, array_with_size *s)
+{
+  int *xs = new int[len];
+  int *end = xs + len;
+  for (int *x = xs; x < end; x++)
+  {
+    int i = *x; // GOOD [FALSE POSITIVE]
+  }
+}
+
+void test20(unsigned len, array_with_size *s)
+{
+  int *xs = new int[len];
+  int *end = xs + len;
+  for (int *x = xs; x < end; x++)
+  {
+    *x = 0; // GOOD [FALSE POSITIVE]
+  }
+}


### PR DESCRIPTION
Once again: I have no idea why we're getting these FPs when very similar cases are properly handled further up in the file 😂. But I'll leave fixing (and even _understanding_) them to a future PR.