### PR TITLE
JS: Track interfile useRouter

### DIFF
--- a/javascript/ql/lib/semmle/javascript/frameworks/Next.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Next.qll
@@ -248,7 +248,7 @@ module NextJS {
    * Gets a reference to a [Next.js router](https://nextjs.org/docs/api-reference/next/router).
    */
   DataFlow::SourceNode nextRouter() {
-    result = DataFlow::moduleMember("next/router", "useRouter").getACall()
+    result = API::moduleImport("next/router").getMember("useRouter").getACall()
     or
     result =
       API::moduleImport("next/router")

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/Xss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/Xss.expected
@@ -579,6 +579,13 @@ nodes
 | react-use-router.js:23:43:23:54 | router.query |
 | react-use-router.js:23:43:23:61 | router.query.foobar |
 | react-use-router.js:23:43:23:61 | router.query.foobar |
+| react-use-router.js:29:9:29:30 | router |
+| react-use-router.js:29:18:29:30 | myUseRouter() |
+| react-use-router.js:33:21:33:26 | router |
+| react-use-router.js:33:21:33:32 | router.query |
+| react-use-router.js:33:21:33:32 | router.query |
+| react-use-router.js:33:21:33:39 | router.query.foobar |
+| react-use-router.js:33:21:33:39 | router.query.foobar |
 | react-use-state.js:4:9:4:49 | state |
 | react-use-state.js:4:9:4:49 | state |
 | react-use-state.js:4:10:4:14 | state |
@@ -1749,6 +1756,14 @@ edges
 | react-use-router.js:23:43:23:54 | router.query | react-use-router.js:23:43:23:61 | router.query.foobar |
 | react-use-router.js:23:43:23:54 | router.query | react-use-router.js:23:43:23:61 | router.query.foobar |
 | react-use-router.js:23:43:23:61 | router.query.foobar | react-use-router.js:22:17:22:22 | router |
+| react-use-router.js:29:9:29:30 | router | react-use-router.js:33:21:33:26 | router |
+| react-use-router.js:29:18:29:30 | myUseRouter() | react-use-router.js:29:9:29:30 | router |
+| react-use-router.js:33:21:33:26 | router | react-use-router.js:33:21:33:32 | router.query |
+| react-use-router.js:33:21:33:32 | router.query | react-use-router.js:33:21:33:39 | router.query.foobar |
+| react-use-router.js:33:21:33:32 | router.query | react-use-router.js:33:21:33:39 | router.query.foobar |
+| react-use-router.js:33:21:33:32 | router.query | react-use-router.js:33:21:33:39 | router.query.foobar |
+| react-use-router.js:33:21:33:32 | router.query | react-use-router.js:33:21:33:39 | router.query.foobar |
+| react-use-router.js:33:21:33:39 | router.query.foobar | react-use-router.js:29:18:29:30 | myUseRouter() |
 | react-use-state.js:4:9:4:49 | state | react-use-state.js:5:51:5:55 | state |
 | react-use-state.js:4:9:4:49 | state | react-use-state.js:5:51:5:55 | state |
 | react-use-state.js:4:9:4:49 | state | react-use-state.js:5:51:5:55 | state |
@@ -2447,6 +2462,7 @@ edges
 | react-use-router.js:11:24:11:42 | router.query.foobar | react-use-router.js:8:21:8:32 | router.query | react-use-router.js:11:24:11:42 | router.query.foobar | Cross-site scripting vulnerability due to $@. | react-use-router.js:8:21:8:32 | router.query | user-provided value |
 | react-use-router.js:11:24:11:42 | router.query.foobar | react-use-router.js:11:24:11:35 | router.query | react-use-router.js:11:24:11:42 | router.query.foobar | Cross-site scripting vulnerability due to $@. | react-use-router.js:11:24:11:35 | router.query | user-provided value |
 | react-use-router.js:23:43:23:61 | router.query.foobar | react-use-router.js:23:43:23:54 | router.query | react-use-router.js:23:43:23:61 | router.query.foobar | Cross-site scripting vulnerability due to $@. | react-use-router.js:23:43:23:54 | router.query | user-provided value |
+| react-use-router.js:33:21:33:39 | router.query.foobar | react-use-router.js:33:21:33:32 | router.query | react-use-router.js:33:21:33:39 | router.query.foobar | Cross-site scripting vulnerability due to $@. | react-use-router.js:33:21:33:32 | router.query | user-provided value |
 | react-use-state.js:5:51:5:55 | state | react-use-state.js:4:38:4:48 | window.name | react-use-state.js:5:51:5:55 | state | Cross-site scripting vulnerability due to $@. | react-use-state.js:4:38:4:48 | window.name | user-provided value |
 | react-use-state.js:11:51:11:55 | state | react-use-state.js:10:14:10:24 | window.name | react-use-state.js:11:51:11:55 | state | Cross-site scripting vulnerability due to $@. | react-use-state.js:10:14:10:24 | window.name | user-provided value |
 | react-use-state.js:17:51:17:55 | state | react-use-state.js:16:20:16:30 | window.name | react-use-state.js:17:51:17:55 | state | Cross-site scripting vulnerability due to $@. | react-use-state.js:16:20:16:30 | window.name | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.expected
@@ -591,6 +591,13 @@ nodes
 | react-use-router.js:23:43:23:54 | router.query |
 | react-use-router.js:23:43:23:61 | router.query.foobar |
 | react-use-router.js:23:43:23:61 | router.query.foobar |
+| react-use-router.js:29:9:29:30 | router |
+| react-use-router.js:29:18:29:30 | myUseRouter() |
+| react-use-router.js:33:21:33:26 | router |
+| react-use-router.js:33:21:33:32 | router.query |
+| react-use-router.js:33:21:33:32 | router.query |
+| react-use-router.js:33:21:33:39 | router.query.foobar |
+| react-use-router.js:33:21:33:39 | router.query.foobar |
 | react-use-state.js:4:9:4:49 | state |
 | react-use-state.js:4:9:4:49 | state |
 | react-use-state.js:4:10:4:14 | state |
@@ -1811,6 +1818,14 @@ edges
 | react-use-router.js:23:43:23:54 | router.query | react-use-router.js:23:43:23:61 | router.query.foobar |
 | react-use-router.js:23:43:23:54 | router.query | react-use-router.js:23:43:23:61 | router.query.foobar |
 | react-use-router.js:23:43:23:61 | router.query.foobar | react-use-router.js:22:17:22:22 | router |
+| react-use-router.js:29:9:29:30 | router | react-use-router.js:33:21:33:26 | router |
+| react-use-router.js:29:18:29:30 | myUseRouter() | react-use-router.js:29:9:29:30 | router |
+| react-use-router.js:33:21:33:26 | router | react-use-router.js:33:21:33:32 | router.query |
+| react-use-router.js:33:21:33:32 | router.query | react-use-router.js:33:21:33:39 | router.query.foobar |
+| react-use-router.js:33:21:33:32 | router.query | react-use-router.js:33:21:33:39 | router.query.foobar |
+| react-use-router.js:33:21:33:32 | router.query | react-use-router.js:33:21:33:39 | router.query.foobar |
+| react-use-router.js:33:21:33:32 | router.query | react-use-router.js:33:21:33:39 | router.query.foobar |
+| react-use-router.js:33:21:33:39 | router.query.foobar | react-use-router.js:29:18:29:30 | myUseRouter() |
 | react-use-state.js:4:9:4:49 | state | react-use-state.js:5:51:5:55 | state |
 | react-use-state.js:4:9:4:49 | state | react-use-state.js:5:51:5:55 | state |
 | react-use-state.js:4:9:4:49 | state | react-use-state.js:5:51:5:55 | state |

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/react-use-router-lib.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/react-use-router-lib.js
@@ -1,0 +1,2 @@
+import { useRouter } from "next/router";
+export let myUseRouter = useRouter;

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/react-use-router.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/react-use-router.js
@@ -23,3 +23,15 @@ function Page({ router }) {
   return <span onClick={() => router.push(router.query.foobar)}>Click to XSS 3</span> // NOT OK
 }
 export const pageWithRouter = withRouter(Page);
+
+import { myUseRouter } from './react-use-router-lib';
+export function nextRouterWithLib() {
+  const router = myUseRouter()
+  return (
+    <div>
+      <span onClick={() => {
+        router.push(router.query.foobar) // NOT OK
+      }}>Click to XSS 1</span>
+    </div>
+  )
+}


### PR DESCRIPTION
I can't find the reason but `DataFlow::moduleMember("next/router", "useRouter").getACall()` doesn't detect a function call if `useRouter` comes from other file.

`API::moduleImport("next/router").getMember("useRouter").getACall()` can resolve this situation like this.


a.js
```
let router = require("next/router");
export let myUseRouter = router.useRouter;
```

b.js
```
import { myUseRouter } from './a'
const router = myUseRouter() // <- want to detect this
```

