### PR TITLE
Ruby: Remove canonical return nodes

### DIFF
--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowDispatch.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowDispatch.qll
@@ -38,6 +38,7 @@ private import DataFlowPrivate
 private import FlowSummaryImpl as FlowSummaryImpl
 private import FlowSummaryImplSpecific as FlowSummaryImplSpecific
 private import semmle.python.internal.CachedStages
+private import semmle.python.dataflow.new.internal.TypeTracker::CallGraphConstruction as CallGraphConstruction
 
 newtype TParameterPosition =
   /** Used for `self` in methods, and `cls` in classmethods. */
@@ -464,189 +465,105 @@ private predicate ignoreForCallGraph(File f) {
   f.getAbsolutePath().matches("%/site-packages/sympy/%")
 }
 
-bindingset[n]
-pragma[inline_late]
-private predicate includeInCallGraph(TypeTrackingNode n) {
-  not ignoreForCallGraph(n.getLocation().getFile())
-}
+private module TrackFunctionInput implements CallGraphConstruction::Simple::InputSig {
+  class State = Function;
 
-pragma[nomagic]
-private predicate stepCallProj(TypeTrackingNode nodeFrom, StepSummary summary) {
-  StepSummary::stepCall(nodeFrom, _, summary)
-}
-
-bindingset[t, summary]
-pragma[inline_late]
-private TypeTracker append(TypeTracker t, StepSummary summary) { result = t.append(summary) }
-
-/**
- * Gets a reference to the function `func`.
- */
-private TypeTrackingNode functionTracker(TypeTracker t, Function func) {
-  includeInCallGraph(result) and
-  (
-    t.start() and
-    (
-      result.asExpr() = func.getDefinition()
-      or
-      // when a function is decorated, it's the result of the (last) decorator call that
-      // is used
-      result.asExpr() = func.getDefinition().(FunctionExpr).getADecoratorCall()
-    )
+  predicate start(Node start, Function func) {
+    start.asExpr() = func.getDefinition()
     or
-    (
-      exists(TypeTracker t2 | t = t2.stepNoCall(functionTracker(t2, func), result))
-      or
-      exists(StepSummary summary |
-        // non-linear recursion
-        StepSummary::stepCall(functionTrackerCall(t, func, summary), result, summary)
-      )
-    )
-  )
-}
+    // when a function is decorated, it's the result of the (last) decorator call that
+    // is used
+    start.asExpr() = func.getDefinition().(FunctionExpr).getADecoratorCall()
+  }
 
-pragma[nomagic]
-private TypeTrackingNode functionTrackerCall(TypeTracker t, Function func, StepSummary summary) {
-  exists(TypeTracker t2 |
-    // non-linear recursion
-    result = functionTracker(t2, func) and
-    stepCallProj(result, summary) and
-    t = append(t2, summary)
-  )
+  predicate filter(Node n) { ignoreForCallGraph(n.getLocation().getFile()) }
 }
 
 /**
  * Gets a reference to the function `func`.
  */
-Node functionTracker(Function func) { functionTracker(TypeTracker::end(), func).flowsTo(result) }
+Node functionTracker(Function func) {
+  CallGraphConstruction::Simple::Make<TrackFunctionInput>::track(func)
+      .(LocalSourceNode)
+      .flowsTo(result)
+}
 
-/**
- * Gets a reference to the class `cls`.
- */
-private TypeTrackingNode classTracker(TypeTracker t, Class cls) {
-  includeInCallGraph(result) and
-  (
-    t.start() and
-    (
-      result.asExpr() = cls.getParent()
-      or
-      // when a class is decorated, it's the result of the (last) decorator call that
-      // is used
-      result.asExpr() = cls.getParent().getADecoratorCall()
-      or
-      // `type(obj)`, where obj is an instance of this class
-      result = getTypeCall() and
-      result.(CallCfgNode).getArg(0) = classInstanceTracker(cls)
-    )
+private module TrackClassInput implements CallGraphConstruction::Simple::InputSig {
+  class State = Class;
+
+  predicate start(Node start, Class cls) {
+    start.asExpr() = cls.getParent()
     or
-    not result.(ParameterNodeImpl).isParameterOf(_, any(ParameterPosition pp | pp.isSelf())) and
-    (
-      exists(TypeTracker t2 | t = t2.stepNoCall(classTracker(t2, cls), result))
-      or
-      exists(StepSummary summary |
-        // non-linear recursion
-        StepSummary::stepCall(classTrackerCall(t, cls, summary), result, summary)
-      )
-    )
-  )
-}
+    // when a class is decorated, it's the result of the (last) decorator call that
+    // is used
+    start.asExpr() = cls.getParent().getADecoratorCall()
+    or
+    // `type(obj)`, where obj is an instance of this class
+    start = getTypeCall() and
+    start.(CallCfgNode).getArg(0) = classInstanceTracker(cls)
+  }
 
-pragma[nomagic]
-private TypeTrackingNode classTrackerCall(TypeTracker t, Class cls, StepSummary summary) {
-  exists(TypeTracker t2 |
-    // non-linear recursion
-    result = classTracker(t2, cls) and
-    stepCallProj(result, summary) and
-    t = append(t2, summary)
-  )
+  predicate filter(Node n) {
+    ignoreForCallGraph(n.getLocation().getFile())
+    or
+    n.(ParameterNodeImpl).isParameterOf(_, any(ParameterPosition pp | pp.isSelf()))
+  }
 }
 
 /**
  * Gets a reference to the class `cls`.
  */
-Node classTracker(Class cls) { classTracker(TypeTracker::end(), cls).flowsTo(result) }
+Node classTracker(Class cls) {
+  CallGraphConstruction::Simple::Make<TrackClassInput>::track(cls).(LocalSourceNode).flowsTo(result)
+}
 
-/**
- * Gets a reference to an instance of the class `cls`.
- */
-private TypeTrackingNode classInstanceTracker(TypeTracker t, Class cls) {
-  includeInCallGraph(result) and
-  (
-    t.start() and
-    resolveClassCall(result.(CallCfgNode).asCfgNode(), cls)
+private module TrackClassInstanceInput implements CallGraphConstruction::Simple::InputSig {
+  class State = Class;
+
+  predicate start(Node start, Class cls) {
+    resolveClassCall(start.(CallCfgNode).asCfgNode(), cls)
     or
     // result of `super().__new__` as used in a `__new__` method implementation
-    t.start() and
     exists(Class classUsedInSuper |
-      fromSuperNewCall(result.(CallCfgNode).asCfgNode(), classUsedInSuper, _, _) and
+      fromSuperNewCall(start.(CallCfgNode).asCfgNode(), classUsedInSuper, _, _) and
       classUsedInSuper = getADirectSuperclass*(cls)
     )
-    or
-    not result.(ParameterNodeImpl).isParameterOf(_, any(ParameterPosition pp | pp.isSelf())) and
-    (
-      exists(TypeTracker t2 | t = t2.stepNoCall(classInstanceTracker(t2, cls), result))
-      or
-      exists(StepSummary summary |
-        // non-linear recursion
-        StepSummary::stepCall(classInstanceTrackerCall(t, cls, summary), result, summary)
-      )
-    )
-  )
-}
+  }
 
-pragma[nomagic]
-private TypeTrackingNode classInstanceTrackerCall(TypeTracker t, Class cls, StepSummary summary) {
-  exists(TypeTracker t2 |
-    // non-linear recursion
-    result = classInstanceTracker(t2, cls) and
-    stepCallProj(result, summary) and
-    t = append(t2, summary)
-  )
+  predicate filter(Node n) {
+    ignoreForCallGraph(n.getLocation().getFile())
+    or
+    n.(ParameterNodeImpl).isParameterOf(_, any(ParameterPosition pp | pp.isSelf()))
+  }
 }
 
 /**
  * Gets a reference to an instance of the class `cls`.
  */
 Node classInstanceTracker(Class cls) {
-  classInstanceTracker(TypeTracker::end(), cls).flowsTo(result)
+  CallGraphConstruction::Simple::Make<TrackClassInstanceInput>::track(cls)
+      .(LocalSourceNode)
+      .flowsTo(result)
 }
 
-/**
- * Gets a reference to the `self` argument of a method on class `classWithMethod`.
- * The method cannot be a `staticmethod` or `classmethod`.
- */
-private TypeTrackingNode selfTracker(TypeTracker t, Class classWithMethod) {
-  includeInCallGraph(result) and
-  (
-    t.start() and
+private module TrackSelfInput implements CallGraphConstruction::Simple::InputSig {
+  class State = Class;
+
+  predicate start(Node start, Class classWithMethod) {
     exists(Function func |
       func = classWithMethod.getAMethod() and
       not isStaticmethod(func) and
       not isClassmethod(func)
     |
-      result.asExpr() = func.getArg(0)
+      start.asExpr() = func.getArg(0)
     )
-    or
-    not result.(ParameterNodeImpl).isParameterOf(_, any(ParameterPosition pp | pp.isSelf())) and
-    (
-      exists(TypeTracker t2 | t = t2.stepNoCall(selfTracker(t2, classWithMethod), result))
-      or
-      exists(StepSummary summary |
-        // non-linear recursion
-        StepSummary::stepCall(selfTrackerCall(t, classWithMethod, summary), result, summary)
-      )
-    )
-  )
-}
+  }
 
-pragma[nomagic]
-private TypeTrackingNode selfTrackerCall(TypeTracker t, Class classWithMethod, StepSummary summary) {
-  exists(TypeTracker t2 |
-    // non-linear recursion
-    result = selfTracker(t2, classWithMethod) and
-    stepCallProj(result, summary) and
-    t = append(t2, summary)
-  )
+  predicate filter(Node n) {
+    ignoreForCallGraph(n.getLocation().getFile())
+    or
+    n.(ParameterNodeImpl).isParameterOf(_, any(ParameterPosition pp | pp.isSelf()))
+  }
 }
 
 /**
@@ -654,53 +571,32 @@ private TypeTrackingNode selfTrackerCall(TypeTracker t, Class classWithMethod, S
  * The method cannot be a `staticmethod` or `classmethod`.
  */
 Node selfTracker(Class classWithMethod) {
-  selfTracker(TypeTracker::end(), classWithMethod).flowsTo(result)
+  CallGraphConstruction::Simple::Make<TrackSelfInput>::track(classWithMethod)
+      .(LocalSourceNode)
+      .flowsTo(result)
 }
 
-/**
- * Gets a reference to the enclosing class `classWithMethod` from within one of its
- * methods, either through the `cls` argument from a `classmethod` or from `type(self)`
- * from a normal method.
- */
-private TypeTrackingNode clsArgumentTracker(TypeTracker t, Class classWithMethod) {
-  includeInCallGraph(result) and
-  (
-    t.start() and
-    (
-      exists(Function func |
-        func = classWithMethod.getAMethod() and
-        isClassmethod(func)
-      |
-        result.asExpr() = func.getArg(0)
-      )
-      or
-      // type(self)
-      result = getTypeCall() and
-      result.(CallCfgNode).getArg(0) = selfTracker(classWithMethod)
+private module TrackClsArgumentInput implements CallGraphConstruction::Simple::InputSig {
+  class State = Class;
+
+  predicate start(Node start, Class classWithMethod) {
+    exists(Function func |
+      func = classWithMethod.getAMethod() and
+      isClassmethod(func)
+    |
+      start.asExpr() = func.getArg(0)
     )
     or
-    not result.(ParameterNodeImpl).isParameterOf(_, any(ParameterPosition pp | pp.isSelf())) and
-    (
-      exists(TypeTracker t2 | t = t2.stepNoCall(clsArgumentTracker(t2, classWithMethod), result))
-      or
-      exists(StepSummary summary |
-        // non-linear recursion
-        StepSummary::stepCall(clsArgumentTrackerCall(t, classWithMethod, summary), result, summary)
-      )
-    )
-  )
-}
+    // type(self)
+    start = getTypeCall() and
+    start.(CallCfgNode).getArg(0) = selfTracker(classWithMethod)
+  }
 
-pragma[nomagic]
-private TypeTrackingNode clsArgumentTrackerCall(
-  TypeTracker t, Class classWithMethod, StepSummary summary
-) {
-  exists(TypeTracker t2 |
-    // non-linear recursion
-    result = clsArgumentTracker(t2, classWithMethod) and
-    stepCallProj(result, summary) and
-    t = append(t2, summary)
-  )
+  predicate filter(Node n) {
+    ignoreForCallGraph(n.getLocation().getFile())
+    or
+    n.(ParameterNodeImpl).isParameterOf(_, any(ParameterPosition pp | pp.isSelf()))
+  }
 }
 
 /**
@@ -709,46 +605,28 @@ private TypeTrackingNode clsArgumentTrackerCall(
  * from a normal method.
  */
 Node clsArgumentTracker(Class classWithMethod) {
-  clsArgumentTracker(TypeTracker::end(), classWithMethod).flowsTo(result)
+  CallGraphConstruction::Simple::Make<TrackClsArgumentInput>::track(classWithMethod)
+      .(LocalSourceNode)
+      .flowsTo(result)
 }
 
-/**
- * Gets a reference to the result of calling `super` without any argument, where the
- * call happened in the method `func` (either a method or a classmethod).
- */
-private TypeTrackingNode superCallNoArgumentTracker(TypeTracker t, Function func) {
-  includeInCallGraph(result) and
-  (
-    t.start() and
+private module TrackSuperCallNoArgumentInput implements CallGraphConstruction::Simple::InputSig {
+  class State = Function;
+
+  predicate start(Node start, Function func) {
     not isStaticmethod(func) and
-    exists(CallCfgNode call | result = call |
+    exists(CallCfgNode call | start = call |
       call = getSuperCall() and
       not exists(call.getArg(_)) and
       call.getScope() = func
     )
-    or
-    not result.(ParameterNodeImpl).isParameterOf(_, any(ParameterPosition pp | pp.isSelf())) and
-    (
-      exists(TypeTracker t2 | t = t2.stepNoCall(superCallNoArgumentTracker(t2, func), result))
-      or
-      exists(StepSummary summary |
-        // non-linear recursion
-        StepSummary::stepCall(superCallNoArgumentTrackerCall(t, func, summary), result, summary)
-      )
-    )
-  )
-}
+  }
 
-pragma[nomagic]
-private TypeTrackingNode superCallNoArgumentTrackerCall(
-  TypeTracker t, Function func, StepSummary summary
-) {
-  exists(TypeTracker t2 |
-    // non-linear recursion
-    result = functionTracker(t2, func) and
-    stepCallProj(result, summary) and
-    t = append(t2, summary)
-  )
+  predicate filter(Node n) {
+    ignoreForCallGraph(n.getLocation().getFile())
+    or
+    n.(ParameterNodeImpl).isParameterOf(_, any(ParameterPosition pp | pp.isSelf()))
+  }
 }
 
 /**
@@ -756,45 +634,30 @@ private TypeTrackingNode superCallNoArgumentTrackerCall(
  * call happened in the method `func` (either a method or a classmethod).
  */
 Node superCallNoArgumentTracker(Function func) {
-  superCallNoArgumentTracker(TypeTracker::end(), func).flowsTo(result)
+  CallGraphConstruction::Simple::Make<TrackSuperCallNoArgumentInput>::track(func)
+      .(LocalSourceNode)
+      .flowsTo(result)
 }
 
-/**
- * Gets a reference to the result of calling `super` with 2 arguments, where the
- * first is a reference to the class `cls`, and the second argument is `obj`.
- */
-private TypeTrackingNode superCallTwoArgumentTracker(TypeTracker t, Class cls, Node obj) {
-  includeInCallGraph(result) and
-  (
-    t.start() and
-    exists(CallCfgNode call | result = call |
-      call = getSuperCall() and
-      call.getArg(0) = classTracker(cls) and
-      call.getArg(1) = obj
-    )
+private module TrackSuperCallTwoArgumentInput implements CallGraphConstruction::Simple::InputSig {
+  additional predicate superCall(CallCfgNode call, Class cls, Node obj) {
+    call = getSuperCall() and
+    call.getArg(0) = classTracker(cls) and
+    call.getArg(1) = obj
+  }
+
+  class State = CallCfgNode;
+
+  predicate start(Node start, CallCfgNode call) {
+    superCall(call, _, _) and
+    start = call
+  }
+
+  predicate filter(Node n) {
+    ignoreForCallGraph(n.getLocation().getFile())
     or
-    not result.(ParameterNodeImpl).isParameterOf(_, any(ParameterPosition pp | pp.isSelf())) and
-    (
-      exists(TypeTracker t2 | t = t2.stepNoCall(superCallTwoArgumentTracker(t2, cls, obj), result))
-      or
-      exists(StepSummary summary |
-        // non-linear recursion
-        StepSummary::stepCall(superCallTwoArgumentTrackerCall(t, cls, obj, summary), result, summary)
-      )
-    )
-  )
-}
-
-pragma[nomagic]
-private TypeTrackingNode superCallTwoArgumentTrackerCall(
-  TypeTracker t, Class cls, Node obj, StepSummary summary
-) {
-  exists(TypeTracker t2 |
-    // non-linear recursion
-    result = superCallTwoArgumentTracker(t2, cls, obj) and
-    stepCallProj(result, summary) and
-    t = append(t2, summary)
-  )
+    n.(ParameterNodeImpl).isParameterOf(_, any(ParameterPosition pp | pp.isSelf()))
+  }
 }
 
 /**
@@ -802,7 +665,12 @@ private TypeTrackingNode superCallTwoArgumentTrackerCall(
  * first is a reference to the class `cls`, and the second argument is `obj`.
  */
 Node superCallTwoArgumentTracker(Class cls, Node obj) {
-  superCallTwoArgumentTracker(TypeTracker::end(), cls, obj).flowsTo(result)
+  exists(CallCfgNode call |
+    TrackSuperCallTwoArgumentInput::superCall(call, cls, obj) and
+    CallGraphConstruction::Simple::Make<TrackSuperCallTwoArgumentInput>::track(call)
+        .(LocalSourceNode)
+        .flowsTo(result)
+  )
 }
 
 // =============================================================================
@@ -946,35 +814,30 @@ Function findFunctionAccordingToMroKnownStartingClass(Class startingClass, strin
 // =============================================================================
 // attribute trackers
 // =============================================================================
-/** Gets a reference to the attribute read `attr` */
-private TypeTrackingNode attrReadTracker(TypeTracker t, AttrRead attr) {
-  t.start() and
-  result = attr and
-  attr.getObject() in [
-      classTracker(_), classInstanceTracker(_), selfTracker(_), clsArgumentTracker(_),
-      superCallNoArgumentTracker(_), superCallTwoArgumentTracker(_, _)
-    ]
-  or
-  exists(TypeTracker t2 | t = t2.stepNoCall(attrReadTracker(t2, attr), result))
-  or
-  exists(StepSummary summary |
-    // non-linear recursion
-    StepSummary::stepCall(attrReadTrackerCall(t, attr, summary), result, summary)
-  )
-}
+private module TrackAttrReadInput implements CallGraphConstruction::Simple::InputSig {
+  class State = AttrRead;
 
-pragma[nomagic]
-private TypeTrackingNode attrReadTrackerCall(TypeTracker t, AttrRead attr, StepSummary summary) {
-  exists(TypeTracker t2 |
-    // non-linear recursion
-    result = attrReadTracker(t2, attr) and
-    stepCallProj(result, summary) and
-    t = append(t2, summary)
-  )
+  predicate start(Node start, AttrRead attr) {
+    start = attr and
+    attr.getObject() in [
+        classTracker(_), classInstanceTracker(_), selfTracker(_), clsArgumentTracker(_),
+        superCallNoArgumentTracker(_), superCallTwoArgumentTracker(_, _)
+      ]
+  }
+
+  predicate filter(Node n) {
+    ignoreForCallGraph(n.getLocation().getFile())
+    or
+    n.(ParameterNodeImpl).isParameterOf(_, any(ParameterPosition pp | pp.isSelf()))
+  }
 }
 
 /** Gets a reference to the attribute read `attr` */
-Node attrReadTracker(AttrRead attr) { attrReadTracker(TypeTracker::end(), attr).flowsTo(result) }
+Node attrReadTracker(AttrRead attr) {
+  CallGraphConstruction::Simple::Make<TrackAttrReadInput>::track(attr)
+      .(LocalSourceNode)
+      .flowsTo(result)
+}
 
 // =============================================================================
 // call and argument resolution

--- a/python/ql/lib/semmle/python/dataflow/new/internal/TypeTracker.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/TypeTracker.qll
@@ -224,71 +224,47 @@ private module Cached {
 
 private import Cached
 
+private predicate step(TypeTrackingNode nodeFrom, TypeTrackingNode nodeTo, StepSummary summary) {
+  stepNoCall(nodeFrom, nodeTo, summary)
+  or
+  stepCall(nodeFrom, nodeTo, summary)
+}
+
 pragma[nomagic]
-private predicate stepNoCallProj(TypeTrackingNode nodeFrom, StepSummary summary) {
-  stepNoCall(nodeFrom, _, summary)
+private predicate stepProj(TypeTrackingNode nodeFrom, StepSummary summary) {
+  step(nodeFrom, _, summary)
 }
 
 bindingset[nodeFrom, t]
 pragma[inline_late]
 pragma[noopt]
-private TypeTracker stepNoCallInlineLate(
-  TypeTracker t, TypeTrackingNode nodeFrom, TypeTrackingNode nodeTo
-) {
+private TypeTracker stepInlineLate(TypeTracker t, TypeTrackingNode nodeFrom, TypeTrackingNode nodeTo) {
   exists(StepSummary summary |
-    stepNoCallProj(nodeFrom, summary) and
+    stepProj(nodeFrom, summary) and
     result = t.append(summary) and
-    stepNoCall(nodeFrom, nodeTo, summary)
+    step(nodeFrom, nodeTo, summary)
   )
 }
 
+private predicate smallstep(Node nodeFrom, TypeTrackingNode nodeTo, StepSummary summary) {
+  smallstepNoCall(nodeFrom, nodeTo, summary)
+  or
+  smallstepCall(nodeFrom, nodeTo, summary)
+}
+
 pragma[nomagic]
-private predicate stepCallProj(TypeTrackingNode nodeFrom, StepSummary summary) {
-  stepCall(nodeFrom, _, summary)
+private predicate smallstepProj(Node nodeFrom, StepSummary summary) {
+  smallstep(nodeFrom, _, summary)
 }
 
 bindingset[nodeFrom, t]
 pragma[inline_late]
 pragma[noopt]
-private TypeTracker stepCallInlineLate(
-  TypeTracker t, TypeTrackingNode nodeFrom, TypeTrackingNode nodeTo
-) {
+private TypeTracker smallstepInlineLate(TypeTracker t, Node nodeFrom, Node nodeTo) {
   exists(StepSummary summary |
-    stepCallProj(nodeFrom, summary) and
+    smallstepProj(nodeFrom, summary) and
     result = t.append(summary) and
-    stepCall(nodeFrom, nodeTo, summary)
-  )
-}
-
-pragma[nomagic]
-private predicate smallstepNoCallProj(Node nodeFrom, StepSummary summary) {
-  smallstepNoCall(nodeFrom, _, summary)
-}
-
-bindingset[nodeFrom, t]
-pragma[inline_late]
-pragma[noopt]
-private TypeTracker smallstepNoCallInlineLate(TypeTracker t, Node nodeFrom, Node nodeTo) {
-  exists(StepSummary summary |
-    smallstepNoCallProj(nodeFrom, summary) and
-    result = t.append(summary) and
-    smallstepNoCall(nodeFrom, nodeTo, summary)
-  )
-}
-
-pragma[nomagic]
-private predicate smallstepCallProj(Node nodeFrom, StepSummary summary) {
-  smallstepCall(nodeFrom, _, summary)
-}
-
-bindingset[nodeFrom, t]
-pragma[inline_late]
-pragma[noopt]
-private TypeTracker smallstepCallInlineLate(TypeTracker t, Node nodeFrom, Node nodeTo) {
-  exists(StepSummary summary |
-    smallstepCallProj(nodeFrom, summary) and
-    result = t.append(summary) and
-    smallstepCall(nodeFrom, nodeTo, summary)
+    smallstep(nodeFrom, nodeTo, summary)
   )
 }
 
@@ -385,14 +361,7 @@ module StepSummary {
   /**
    * Gets the summary that corresponds to having taken a forwards
    * heap and/or inter-procedural step from `nodeFrom` to `nodeTo`.
-   *
-   * This predicate is inlined, which enables better join-orders when
-   * the call graph construction and type tracking are mutually recursive.
-   * In such cases, non-linear recursion involving `step` will be limited
-   * to non-linear recursion for the parts of `step` that involve the
-   * call graph.
    */
-  pragma[inline]
   predicate step(TypeTrackingNode nodeFrom, TypeTrackingNode nodeTo, StepSummary summary) {
     stepNoCall(nodeFrom, nodeTo, summary)
     or
@@ -424,7 +393,6 @@ module StepSummary {
    * Unlike `StepSummary::step`, this predicate does not compress
    * type-preserving steps.
    */
-  pragma[inline]
   predicate smallstep(Node nodeFrom, TypeTrackingNode nodeTo, StepSummary summary) {
     smallstepNoCall(nodeFrom, nodeTo, summary)
     or
@@ -531,64 +499,11 @@ class TypeTracker extends TTypeTracker {
 
   /**
    * Gets the summary that corresponds to having taken a forwards
-   * intra-procedural step from `nodeFrom` to `nodeTo`.
-   *
-   * This predicate should normally not be used; consider using `step`
-   * instead.
-   */
-  pragma[inline]
-  TypeTracker stepNoCall(TypeTrackingNode nodeFrom, TypeTrackingNode nodeTo) {
-    result = stepNoCallInlineLate(this, nodeFrom, nodeTo)
-  }
-
-  /**
-   * Gets the summary that corresponds to having taken a forwards
-   * inter-procedural step from `nodeFrom` to `nodeTo`.
-   *
-   * This predicate should normally not be used; consider using `step`
-   * instead.
-   */
-  pragma[inline]
-  TypeTracker stepCall(TypeTrackingNode nodeFrom, TypeTrackingNode nodeTo) {
-    result = stepCallInlineLate(this, nodeFrom, nodeTo)
-  }
-
-  /**
-   * Gets the summary that corresponds to having taken a forwards
    * heap and/or inter-procedural step from `nodeFrom` to `nodeTo`.
    */
   pragma[inline]
   TypeTracker step(TypeTrackingNode nodeFrom, TypeTrackingNode nodeTo) {
-    result = this.stepNoCall(nodeFrom, nodeTo)
-    or
-    result = this.stepCall(nodeFrom, nodeTo)
-  }
-
-  /**
-   * Gets the summary that corresponds to having taken a forwards
-   * intra-procedural step from `nodeFrom` to `nodeTo`.
-   *
-   * This predicate should normally not be used; consider using `step`
-   * instead.
-   */
-  pragma[inline]
-  TypeTracker smallstepNoCall(Node nodeFrom, Node nodeTo) {
-    result = smallstepNoCallInlineLate(this, nodeFrom, nodeTo)
-    or
-    simpleLocalFlowStep(nodeFrom, nodeTo) and
-    result = this
-  }
-
-  /**
-   * Gets the summary that corresponds to having taken a forwards
-   * inter-procedural step from `nodeFrom` to `nodeTo`.
-   *
-   * This predicate should normally not be used; consider using `step`
-   * instead.
-   */
-  pragma[inline]
-  TypeTracker smallstepCall(Node nodeFrom, Node nodeTo) {
-    result = smallstepCallInlineLate(this, nodeFrom, nodeTo)
+    result = stepInlineLate(this, nodeFrom, nodeTo)
   }
 
   /**
@@ -617,9 +532,10 @@ class TypeTracker extends TTypeTracker {
    */
   pragma[inline]
   TypeTracker smallstep(Node nodeFrom, Node nodeTo) {
-    result = this.smallstepNoCall(nodeFrom, nodeTo)
+    result = smallstepInlineLate(this, nodeFrom, nodeTo)
     or
-    result = this.smallstepCall(nodeFrom, nodeTo)
+    simpleLocalFlowStep(nodeFrom, nodeTo) and
+    result = this
   }
 }
 
@@ -629,6 +545,39 @@ module TypeTracker {
    * Gets a valid end point of type tracking.
    */
   TypeTracker end() { result.end() }
+}
+
+pragma[nomagic]
+private predicate backStepProj(TypeTrackingNode nodeTo, StepSummary summary) {
+  step(_, nodeTo, summary)
+}
+
+bindingset[nodeTo, t]
+pragma[inline_late]
+pragma[noopt]
+private TypeBackTracker backStepInlineLate(
+  TypeBackTracker t, TypeTrackingNode nodeFrom, TypeTrackingNode nodeTo
+) {
+  exists(StepSummary summary |
+    backStepProj(nodeTo, summary) and
+    result = t.prepend(summary) and
+    step(nodeFrom, nodeTo, summary)
+  )
+}
+
+private predicate backSmallstepProj(TypeTrackingNode nodeTo, StepSummary summary) {
+  smallstep(_, nodeTo, summary)
+}
+
+bindingset[nodeTo, t]
+pragma[inline_late]
+pragma[noopt]
+private TypeBackTracker backSmallstepInlineLate(TypeBackTracker t, Node nodeFrom, Node nodeTo) {
+  exists(StepSummary summary |
+    backSmallstepProj(nodeTo, summary) and
+    result = t.prepend(summary) and
+    smallstep(nodeFrom, nodeTo, summary)
+  )
 }
 
 /**
@@ -714,10 +663,7 @@ class TypeBackTracker extends TTypeBackTracker {
    */
   pragma[inline]
   TypeBackTracker step(TypeTrackingNode nodeFrom, TypeTrackingNode nodeTo) {
-    exists(StepSummary summary |
-      StepSummary::step(pragma[only_bind_out](nodeFrom), nodeTo, pragma[only_bind_into](summary)) and
-      this = result.prepend(pragma[only_bind_into](summary))
-    )
+    this = backStepInlineLate(result, nodeFrom, nodeTo)
   }
 
   /**
@@ -746,10 +692,7 @@ class TypeBackTracker extends TTypeBackTracker {
    */
   pragma[inline]
   TypeBackTracker smallstep(Node nodeFrom, Node nodeTo) {
-    exists(StepSummary summary |
-      StepSummary::smallstep(nodeFrom, nodeTo, summary) and
-      this = result.prepend(summary)
-    )
+    this = backSmallstepInlineLate(result, nodeFrom, nodeTo)
     or
     simpleLocalFlowStep(nodeFrom, nodeTo) and
     this = result
@@ -784,4 +727,170 @@ module TypeBackTracker {
    * Gets a valid end point of type back-tracking.
    */
   TypeBackTracker end() { result.end() }
+}
+
+/**
+ * INTERNAL: Do not use.
+ *
+ * Provides logic for constructing a call graph in mutual recursion with type tracking.
+ *
+ * When type tracking is used to construct a call graph, we cannot use the join-order
+ * from `stepInlineLate`, because `step` becomes a recursive call, which means that we
+ * will have a conjunct with 3 recursive calls: the call to `step`, the call to `stepProj`,
+ * and the recursive type tracking call itself. The solution is to split the three-way
+ * non-linear recursion into two non-linear predicates: one that first joins with the
+ * projected `stepCall` relation, followed by a predicate that joins with the full
+ * `stepCall` relation (`stepNoCall` not being recursive, can be join-ordered in the
+ * same way as in `stepInlineLate`).
+ */
+module CallGraphConstruction {
+  /** The input to call graph construction. */
+  signature module InputSig {
+    /** A state to track during type tracking. */
+    class State;
+
+    /** Holds if type tracking should start at `start` in state `state`. */
+    predicate start(Node start, State state);
+
+    /**
+     * Holds if type tracking should use the step from `nodeFrom` to `nodeTo`,
+     * which _does not_ depend on the call graph.
+     *
+     * Implementing this predicate using `StepSummary::[small]stepNoCall` yields
+     * standard type tracking.
+     */
+    predicate stepNoCall(Node nodeFrom, Node nodeTo, StepSummary summary);
+
+    /**
+     * Holds if type tracking should use the step from `nodeFrom` to `nodeTo`,
+     * which _does_ depend on the call graph.
+     *
+     * Implementing this predicate using `StepSummary::[small]stepCall` yields
+     * standard type tracking.
+     */
+    predicate stepCall(Node nodeFrom, Node nodeTo, StepSummary summary);
+
+    /** A projection of an element from the state space. */
+    class StateProj;
+
+    /** Gets the projection of `state`. */
+    StateProj stateProj(State state);
+
+    /** Holds if type tracking should stop at `n` when we are tracking projected state `stateProj`. */
+    predicate filter(Node n, StateProj stateProj);
+  }
+
+  /** Provides the `track` predicate for use in call graph construction. */
+  module Make<InputSig Input> {
+    pragma[nomagic]
+    private predicate stepNoCallProj(Node nodeFrom, StepSummary summary) {
+      Input::stepNoCall(nodeFrom, _, summary)
+    }
+
+    pragma[nomagic]
+    private predicate stepCallProj(Node nodeFrom, StepSummary summary) {
+      Input::stepCall(nodeFrom, _, summary)
+    }
+
+    bindingset[nodeFrom, t]
+    pragma[inline_late]
+    pragma[noopt]
+    private TypeTracker stepNoCallInlineLate(
+      TypeTracker t, TypeTrackingNode nodeFrom, TypeTrackingNode nodeTo
+    ) {
+      exists(StepSummary summary |
+        stepNoCallProj(nodeFrom, summary) and
+        result = t.append(summary) and
+        Input::stepNoCall(nodeFrom, nodeTo, summary)
+      )
+    }
+
+    bindingset[state]
+    pragma[inline_late]
+    private Input::StateProj stateProjInlineLate(Input::State state) {
+      result = Input::stateProj(state)
+    }
+
+    pragma[nomagic]
+    private Node track(Input::State state, TypeTracker t) {
+      t.start() and Input::start(result, state)
+      or
+      exists(Input::StateProj stateProj |
+        stateProj = stateProjInlineLate(state) and
+        not Input::filter(result, stateProj)
+      |
+        exists(TypeTracker t2 | t = stepNoCallInlineLate(t2, track(state, t2), result))
+        or
+        exists(StepSummary summary |
+          // non-linear recursion
+          Input::stepCall(trackCall(state, t, summary), result, summary)
+        )
+      )
+    }
+
+    bindingset[t, summary]
+    pragma[inline_late]
+    private TypeTracker appendInlineLate(TypeTracker t, StepSummary summary) {
+      result = t.append(summary)
+    }
+
+    pragma[nomagic]
+    private Node trackCall(Input::State state, TypeTracker t, StepSummary summary) {
+      exists(TypeTracker t2 |
+        // non-linear recursion
+        result = track(state, t2) and
+        stepCallProj(result, summary) and
+        t = appendInlineLate(t2, summary)
+      )
+    }
+
+    /** Gets a node that can be reached from _some_ start node in state `state`. */
+    pragma[nomagic]
+    Node track(Input::State state) { result = track(state, TypeTracker::end()) }
+  }
+
+  /** A simple version of `CallGraphConstruction` that uses standard type tracking. */
+  module Simple {
+    /** The input to call graph construction. */
+    signature module InputSig {
+      /** A state to track during type tracking. */
+      class State;
+
+      /** Holds if type tracking should start at `start` in state `state`. */
+      predicate start(Node start, State state);
+
+      /** Holds if type tracking should stop at `n`. */
+      predicate filter(Node n);
+    }
+
+    /** Provides the `track` predicate for use in call graph construction. */
+    module Make<InputSig Input> {
+      private module I implements CallGraphConstruction::InputSig {
+        private import codeql.util.Unit
+
+        class State = Input::State;
+
+        predicate start(Node start, State state) { Input::start(start, state) }
+
+        predicate stepNoCall(Node nodeFrom, Node nodeTo, StepSummary summary) {
+          StepSummary::stepNoCall(nodeFrom, nodeTo, summary)
+        }
+
+        predicate stepCall(Node nodeFrom, Node nodeTo, StepSummary summary) {
+          StepSummary::stepCall(nodeFrom, nodeTo, summary)
+        }
+
+        class StateProj = Unit;
+
+        Unit stateProj(State state) { exists(state) and exists(result) }
+
+        predicate filter(Node n, Unit u) {
+          Input::filter(n) and
+          exists(u)
+        }
+      }
+
+      import CallGraphConstruction::Make<I>
+    }
+  }
 }

--- a/ruby/ql/lib/codeql/ruby/ApiGraphs.qll
+++ b/ruby/ql/lib/codeql/ruby/ApiGraphs.qll
@@ -778,7 +778,7 @@ module API {
       or
       exists(TypeTracker t2 |
         result = trackUseNode(src, t2).track(t2, t) and
-        not result instanceof DataFlowPrivate::SelfParameterNode
+        not result instanceof DataFlow::SelfParameterNode
       )
     }
 
@@ -800,7 +800,7 @@ module API {
       or
       exists(TypeBackTracker t2, DataFlow::LocalSourceNode mid |
         mid = trackDefNode(rhs, t2) and
-        not mid instanceof DataFlowPrivate::SelfParameterNode and
+        not mid instanceof DataFlow::SelfParameterNode and
         result = mid.backtrack(t2, t)
       )
     }

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
@@ -131,10 +131,10 @@ module LocalFlow {
   /**
    * Holds if `nodeFrom` is a parameter node, and `nodeTo` is a corresponding SSA node.
    */
-  predicate localFlowSsaParamInput(Node nodeFrom, Node nodeTo) {
+  predicate localFlowSsaParamInput(Node nodeFrom, SsaDefinitionExtNode nodeTo) {
     nodeTo = getParameterDefNode(nodeFrom.(ParameterNodeImpl).getParameter())
     or
-    nodeTo = getSelfParameterDefNode(nodeFrom.(SelfParameterNode).getMethod())
+    nodeTo = getSelfParameterDefNode(nodeFrom.(SelfParameterNodeImpl).getMethod())
   }
 
   /**
@@ -143,14 +143,13 @@ module LocalFlow {
    *
    * This is intended to recover from flow not currently recognised by ordinary capture flow.
    */
-  predicate localFlowSsaParamCaptureInput(Node nodeFrom, Node nodeTo) {
-    exists(Ssa::CapturedEntryDefinition def, ParameterNodeImpl p |
-      (nodeFrom = p or LocalFlow::localFlowSsaParamInput(p, nodeFrom)) and
+  predicate localFlowSsaParamCaptureInput(ParameterNodeImpl nodeFrom, Node nodeTo) {
+    exists(Ssa::CapturedEntryDefinition def |
       nodeTo.(SsaDefinitionExtNode).getDefinitionExt() = def
     |
-      p.getParameter().(NamedParameter).getVariable() = def.getSourceVariable()
+      nodeFrom.getParameter().(NamedParameter).getVariable() = def.getSourceVariable()
       or
-      p.(SelfParameterNode).getSelfVariable() = def.getSourceVariable()
+      nodeFrom.(SelfParameterNode).getSelfVariable() = def.getSourceVariable()
     )
   }
 
@@ -164,7 +163,7 @@ module LocalFlow {
 
   /**
    * Holds if there is a local flow step from `nodeFrom` to `nodeTo` involving
-   * SSA definition `def`.
+   * some SSA definition.
    */
   private predicate localSsaFlowStep(Node nodeFrom, Node nodeTo) {
     exists(SsaImpl::DefinitionExt def |
@@ -182,6 +181,8 @@ module LocalFlow {
       // Flow into phi (read) SSA definition node from def
       localFlowSsaInputFromDef(nodeFrom, def, nodeTo)
     )
+    or
+    localFlowSsaParamInput(nodeFrom, nodeTo)
     // TODO
     // or
     // // Flow into uncertain SSA definition
@@ -222,6 +223,13 @@ module LocalFlow {
       any(CfgNodes::ExprNodes::BinaryOperationCfgNode op |
         op.getExpr() instanceof BinaryLogicalOperation and
         nodeFrom.asExpr() = op.getAnOperand()
+      )
+    or
+    nodeTo.(ParameterNodeImpl).getParameter() =
+      any(NamedParameter p |
+        p.(OptionalParameter).getDefaultValue() = nodeFrom.asExpr().getExpr()
+        or
+        p.(KeywordParameter).getDefaultValue() = nodeFrom.asExpr().getExpr()
       )
   }
 }
@@ -279,12 +287,6 @@ private module Cached {
   newtype TNode =
     TExprNode(CfgNodes::ExprCfgNode n) { TaintTrackingPrivate::forceCachingInSameStage() } or
     TReturningNode(CfgNodes::ReturningCfgNode n) or
-    TSynthReturnNode(CfgScope scope, ReturnKind kind) {
-      exists(ReturningNode ret |
-        ret.(NodeImpl).getCfgScope() = scope and
-        ret.getKind() = kind
-      )
-    } or
     TSsaDefinitionExtNode(SsaImpl::DefinitionExt def) or
     TNormalParameterNode(Parameter p) {
       p instanceof SimpleParameter or
@@ -326,12 +328,6 @@ private module Cached {
     TNormalParameterNode or TBlockParameterNode or TSelfParameterNode or
         TSynthHashSplatParameterNode or TSummaryParameterNode;
 
-  private predicate defaultValueFlow(NamedParameter p, ExprNode e) {
-    p.(OptionalParameter).getDefaultValue() = e.getExprNode().getExpr()
-    or
-    p.(KeywordParameter).getDefaultValue() = e.getExprNode().getExpr()
-  }
-
   cached
   Location getLocation(NodeImpl n) { result = n.getLocationImpl() }
 
@@ -345,12 +341,6 @@ private module Cached {
   cached
   predicate simpleLocalFlowStep(Node nodeFrom, Node nodeTo) {
     LocalFlow::localFlowStepCommon(nodeFrom, nodeTo)
-    or
-    defaultValueFlow(nodeTo.(ParameterNodeImpl).getParameter(), nodeFrom)
-    or
-    LocalFlow::localFlowSsaParamInput(nodeFrom, nodeTo)
-    or
-    nodeTo.(SynthReturnNode).getAnInput() = nodeFrom
     or
     LocalFlow::localSsaFlowStepUseUse(_, nodeFrom, nodeTo) and
     not FlowSummaryImpl::Private::Steps::prohibitsUseUseFlow(nodeFrom, _)
@@ -373,10 +363,6 @@ private module Cached {
   predicate localFlowStepImpl(Node nodeFrom, Node nodeTo) {
     LocalFlow::localFlowStepCommon(nodeFrom, nodeTo)
     or
-    defaultValueFlow(nodeTo.(ParameterNodeImpl).getParameter(), nodeFrom)
-    or
-    LocalFlow::localFlowSsaParamInput(nodeFrom, nodeTo)
-    or
     LocalFlow::localSsaFlowStepUseUse(_, nodeFrom, nodeTo)
     or
     // Simple flow through library code is included in the exposed local
@@ -386,18 +372,10 @@ private module Cached {
 
   /**
    * This is the local flow predicate that is used in type tracking.
-   *
-   * This needs to exclude `localFlowSsaParamInput` due to a performance trick
-   * in type tracking, where such steps are treated as call steps.
    */
   cached
   predicate localFlowStepTypeTracker(Node nodeFrom, Node nodeTo) {
     LocalFlow::localFlowStepCommon(nodeFrom, nodeTo)
-    or
-    exists(NamedParameter p |
-      defaultValueFlow(p, nodeFrom) and
-      nodeTo = LocalFlow::getParameterDefNode(p)
-    )
     or
     LocalFlow::localSsaFlowStepUseUse(_, nodeFrom, nodeTo)
     or
@@ -440,12 +418,10 @@ private module Cached {
     n instanceof ExprNode and
     not reachedFromExprOrEntrySsaDef(n)
     or
-    // Ensure all entry SSA definitions are local sources -- for parameters, this
-    // is needed by type tracking
-    entrySsaDefinition(n)
-    or
-    // Needed for flow out in type tracking
-    n instanceof SynthReturnNode
+    // Ensure all entry SSA definitions are local sources, except those that correspond
+    // to parameters (which are themselves local sources)
+    entrySsaDefinition(n) and
+    not LocalFlow::localFlowSsaParamInput(_, n)
     or
     // Needed for stores in type tracking
     TypeTrackerSpecific::storeStepIntoSourceNode(_, n, _)
@@ -507,7 +483,7 @@ private module Cached {
    */
   cached
   predicate exprNodeReturnedFromCached(ExprNode e, Callable c) {
-    exists(ReturningNode r |
+    exists(ReturnNode r |
       nodeGetEnclosingCallable(r).asCallable() = c and
       (
         r.(ExplicitReturnNode).getReturningNode().getReturnedValueNode() = e.asExpr() or
@@ -541,8 +517,6 @@ predicate nodeIsHidden(Node n) {
   n instanceof SummaryNode
   or
   n instanceof SummaryParameterNode
-  or
-  n instanceof SynthReturnNode
   or
   n instanceof SynthHashSplatParameterNode
   or
@@ -658,10 +632,10 @@ private module ParameterNodes {
    * The value of the `self` parameter at function entry, viewed as a node in a data
    * flow graph.
    */
-  class SelfParameterNode extends ParameterNodeImpl, TSelfParameterNode {
+  class SelfParameterNodeImpl extends ParameterNodeImpl, TSelfParameterNode {
     private MethodBase method;
 
-    SelfParameterNode() { this = TSelfParameterNode(method) }
+    SelfParameterNodeImpl() { this = TSelfParameterNode(method) }
 
     final MethodBase getMethod() { result = method }
 
@@ -937,22 +911,24 @@ private class NewCall extends DataFlowCall {
   NewCall() { this.asCall().getExpr().(MethodCall).getMethodName() = "new" }
 }
 
-/** A data-flow node that represents a value syntactically returned by a callable. */
-abstract class ReturningNode extends Node {
-  /** Gets the kind of this return node. */
-  abstract ReturnKind getKind();
-
-  pragma[nomagic]
-  predicate hasKind(ReturnKind kind, CfgScope scope) {
-    kind = this.getKind() and
-    scope = this.(NodeImpl).getCfgScope()
-  }
-}
-
 /** A data-flow node that represents a value returned by a callable. */
 abstract class ReturnNode extends Node {
   /** Gets the kind of this return node. */
   abstract ReturnKind getKind();
+}
+
+/** A data-flow node that represents a value returned by a callable. */
+abstract class SourceReturnNode extends ReturnNode {
+  /** Gets the kind of this return node. */
+  abstract ReturnKind getKindSource(); // only exists to avoid spurious negative recursion
+
+  final override ReturnKind getKind() { result = this.getKindSource() }
+
+  pragma[nomagic]
+  predicate hasKind(ReturnKind kind, CfgScope scope) {
+    kind = this.getKindSource() and
+    scope = this.(NodeImpl).getCfgScope()
+  }
 }
 
 private module ReturnNodes {
@@ -976,14 +952,14 @@ private module ReturnNodes {
    * A data-flow node that represents an expression explicitly returned by
    * a callable.
    */
-  class ExplicitReturnNode extends ReturningNode, ReturningStatementNode {
+  class ExplicitReturnNode extends SourceReturnNode, ReturningStatementNode {
     ExplicitReturnNode() {
       isValid(n) and
       n.getASuccessor().(CfgNodes::AnnotatedExitNode).isNormal() and
       n.getScope() instanceof Callable
     }
 
-    override ReturnKind getKind() {
+    override ReturnKind getKindSource() {
       if n.getNode() instanceof BreakStmt
       then result instanceof BreakReturnKind
       else
@@ -1012,10 +988,10 @@ private module ReturnNodes {
    * a callable. An implicit return happens when an expression can be the
    * last thing that is evaluated in the body of the callable.
    */
-  class ExprReturnNode extends ReturningNode, ExprNode {
+  class ExprReturnNode extends SourceReturnNode, ExprNode {
     ExprReturnNode() { exists(Callable c | implicitReturn(c, this) = c.getAStmt()) }
 
-    override ReturnKind getKind() {
+    override ReturnKind getKindSource() {
       exists(CfgScope scope | scope = this.(NodeImpl).getCfgScope() |
         if isUserDefinedNew(scope)
         then result instanceof NewReturnKind
@@ -1040,7 +1016,7 @@ private module ReturnNodes {
    * the implicit `self` reference in `@x` will return data stored in the field
    * `x` out to the call `C.new`.
    */
-  class InitializeReturnNode extends ExprPostUpdateNode, ReturningNode {
+  class InitializeReturnNode extends ExprPostUpdateNode, ReturnNode {
     InitializeReturnNode() {
       exists(Method initialize |
         this.getCfgScope() = initialize and
@@ -1051,32 +1027,6 @@ private module ReturnNodes {
     }
 
     override ReturnKind getKind() { result instanceof NewReturnKind }
-  }
-
-  /**
-   * A synthetic data-flow node for joining flow from different syntactic
-   * returns into a single node.
-   *
-   * This node only exists to avoid computing the product of a large fan-in
-   * with a large fan-out.
-   */
-  class SynthReturnNode extends NodeImpl, ReturnNode, TSynthReturnNode {
-    private CfgScope scope;
-    private ReturnKind kind;
-
-    SynthReturnNode() { this = TSynthReturnNode(scope, kind) }
-
-    /** Gets a syntactic return node that flows into this synthetic node. */
-    pragma[nomagic]
-    ReturningNode getAnInput() { result.hasKind(kind, scope) }
-
-    override ReturnKind getKind() { result = kind }
-
-    override CfgScope getCfgScope() { result = scope }
-
-    override Location getLocationImpl() { result = scope.getLocation() }
-
-    override string toStringImpl() { result = "return " + kind + " in " + scope }
   }
 
   private class SummaryReturnNode extends SummaryNode, ReturnNode {
@@ -1339,9 +1289,6 @@ private import PostUpdateNodes
 /** A node that performs a type cast. */
 class CastNode extends Node {
   CastNode() {
-    // ensure that actual return nodes are included in the path graph
-    this instanceof ReturningNode
-    or
     // ensure that all variable assignments are included in the path graph
     this.(SsaDefinitionExtNode).getDefinitionExt() instanceof Ssa::WriteDefinition
   }

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPublic.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPublic.qll
@@ -195,8 +195,20 @@ class ParameterNode extends LocalSourceNode, TParameterNode instanceof Parameter
   /** Gets the parameter corresponding to this node, if any. */
   final Parameter getParameter() { result = super.getParameter() }
 
+  /** Gets the callable that this parameter belongs to. */
+  final Callable getCallable() { result = super.getCfgScope() }
+
   /** Gets the name of the parameter, if any. */
   final string getName() { result = this.getParameter().(NamedParameter).getName() }
+}
+
+/**
+ * The value of an implicit `self` parameter at function entry, viewed as a node in a data
+ * flow graph.
+ */
+class SelfParameterNode extends ParameterNode instanceof SelfParameterNodeImpl {
+  /** Gets the underlying `self` variable. */
+  final SelfVariable getSelfVariable() { result = super.getSelfVariable() }
 }
 
 /**
@@ -327,9 +339,6 @@ private module Cached {
     or
     exists(Node mid | hasLocalSource(mid, source) |
       localFlowStepTypeTracker(mid, sink)
-      or
-      // Explicitly include the SSA param input step as type-tracking omits this step.
-      LocalFlow::localFlowSsaParamInput(mid, sink)
       or
       LocalFlow::localFlowSsaParamCaptureInput(mid, sink)
     )
@@ -1177,18 +1186,14 @@ class CallableNode extends StmtSequenceNode {
   }
 
   /**
-   * Gets the canonical return node from this callable.
-   *
-   * Each callable has exactly one such node, and its location may not correspond
-   * to any particular return site - consider using `getAReturningNode` to get nodes
-   * whose locations correspond to return sites.
-   */
-  Node getReturn() { result.(SynthReturnNode).getCfgScope() = callable }
-
-  /**
    * Gets a data flow node whose value is about to be returned by this callable.
    */
-  Node getAReturningNode() { result = this.getReturn().(SynthReturnNode).getAnInput() }
+  Node getAReturnNode() { result.(ReturnNode).(NodeImpl).getCfgScope() = callable }
+
+  /**
+   * DEPRECATED. Use `getAReturnNode` instead.
+   */
+  deprecated Node getAReturningNode() { result = this.getAReturnNode() }
 }
 
 /**

--- a/ruby/ql/lib/codeql/ruby/frameworks/ActiveRecord.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/ActiveRecord.qll
@@ -7,7 +7,6 @@ private import codeql.ruby.Concepts
 private import codeql.ruby.controlflow.CfgNodes
 private import codeql.ruby.DataFlow
 private import codeql.ruby.dataflow.internal.DataFlowDispatch
-private import codeql.ruby.dataflow.internal.DataFlowPrivate
 private import codeql.ruby.ApiGraphs
 private import codeql.ruby.frameworks.Stdlib
 private import codeql.ruby.frameworks.Core
@@ -319,19 +318,19 @@ private class ActiveRecordModelFinderCall extends ActiveRecordModelInstantiation
 
 // A `self` reference that may resolve to an active record model object
 private class ActiveRecordModelClassSelfReference extends ActiveRecordModelInstantiation,
-  SsaSelfDefinitionNode
+  DataFlow::SelfParameterNode
 {
   private ActiveRecordModelClass cls;
 
   ActiveRecordModelClassSelfReference() {
     exists(MethodBase m |
-      m = this.getCfgScope() and
+      m = this.getCallable() and
       m.getEnclosingModule() = cls and
       m = cls.getAMethod()
     ) and
     // In a singleton method, `self` refers to the class itself rather than an
     // instance of that class
-    not this.getSelfScope() instanceof SingletonMethod
+    not this.getSelfVariable().getDeclaringScope() instanceof SingletonMethod
   }
 
   final override ActiveRecordModelClass getClass() { result = cls }

--- a/ruby/ql/lib/codeql/ruby/frameworks/Rack.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/Rack.qll
@@ -21,7 +21,7 @@ module Rack {
     AppCandidate() {
       call = this.getInstanceMethod("call") and
       call.getNumberOfParameters() = 1 and
-      call.getReturn() = trackRackResponse()
+      call.getAReturnNode() = trackRackResponse()
     }
 
     /**

--- a/ruby/ql/lib/codeql/ruby/frameworks/actioncontroller/Filters.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/actioncontroller/Filters.qll
@@ -412,9 +412,7 @@ module Filters {
   /**
    * Holds if `n` is the self parameter of method `m`.
    */
-  private predicate selfParameter(DataFlowPrivate::SelfParameterNode n, Method m) {
-    m = n.getMethod()
-  }
+  private predicate selfParameter(DataFlow::SelfParameterNode n, Method m) { m = n.getCallable() }
 
   /**
    * A class defining additional jump steps arising from filters.

--- a/ruby/ql/lib/codeql/ruby/typetracking/TypeTracker.qll
+++ b/ruby/ql/lib/codeql/ruby/typetracking/TypeTracker.qll
@@ -224,71 +224,47 @@ private module Cached {
 
 private import Cached
 
+private predicate step(TypeTrackingNode nodeFrom, TypeTrackingNode nodeTo, StepSummary summary) {
+  stepNoCall(nodeFrom, nodeTo, summary)
+  or
+  stepCall(nodeFrom, nodeTo, summary)
+}
+
 pragma[nomagic]
-private predicate stepNoCallProj(TypeTrackingNode nodeFrom, StepSummary summary) {
-  stepNoCall(nodeFrom, _, summary)
+private predicate stepProj(TypeTrackingNode nodeFrom, StepSummary summary) {
+  step(nodeFrom, _, summary)
 }
 
 bindingset[nodeFrom, t]
 pragma[inline_late]
 pragma[noopt]
-private TypeTracker stepNoCallInlineLate(
-  TypeTracker t, TypeTrackingNode nodeFrom, TypeTrackingNode nodeTo
-) {
+private TypeTracker stepInlineLate(TypeTracker t, TypeTrackingNode nodeFrom, TypeTrackingNode nodeTo) {
   exists(StepSummary summary |
-    stepNoCallProj(nodeFrom, summary) and
+    stepProj(nodeFrom, summary) and
     result = t.append(summary) and
-    stepNoCall(nodeFrom, nodeTo, summary)
+    step(nodeFrom, nodeTo, summary)
   )
 }
 
+private predicate smallstep(Node nodeFrom, TypeTrackingNode nodeTo, StepSummary summary) {
+  smallstepNoCall(nodeFrom, nodeTo, summary)
+  or
+  smallstepCall(nodeFrom, nodeTo, summary)
+}
+
 pragma[nomagic]
-private predicate stepCallProj(TypeTrackingNode nodeFrom, StepSummary summary) {
-  stepCall(nodeFrom, _, summary)
+private predicate smallstepProj(Node nodeFrom, StepSummary summary) {
+  smallstep(nodeFrom, _, summary)
 }
 
 bindingset[nodeFrom, t]
 pragma[inline_late]
 pragma[noopt]
-private TypeTracker stepCallInlineLate(
-  TypeTracker t, TypeTrackingNode nodeFrom, TypeTrackingNode nodeTo
-) {
+private TypeTracker smallstepInlineLate(TypeTracker t, Node nodeFrom, Node nodeTo) {
   exists(StepSummary summary |
-    stepCallProj(nodeFrom, summary) and
+    smallstepProj(nodeFrom, summary) and
     result = t.append(summary) and
-    stepCall(nodeFrom, nodeTo, summary)
-  )
-}
-
-pragma[nomagic]
-private predicate smallstepNoCallProj(Node nodeFrom, StepSummary summary) {
-  smallstepNoCall(nodeFrom, _, summary)
-}
-
-bindingset[nodeFrom, t]
-pragma[inline_late]
-pragma[noopt]
-private TypeTracker smallstepNoCallInlineLate(TypeTracker t, Node nodeFrom, Node nodeTo) {
-  exists(StepSummary summary |
-    smallstepNoCallProj(nodeFrom, summary) and
-    result = t.append(summary) and
-    smallstepNoCall(nodeFrom, nodeTo, summary)
-  )
-}
-
-pragma[nomagic]
-private predicate smallstepCallProj(Node nodeFrom, StepSummary summary) {
-  smallstepCall(nodeFrom, _, summary)
-}
-
-bindingset[nodeFrom, t]
-pragma[inline_late]
-pragma[noopt]
-private TypeTracker smallstepCallInlineLate(TypeTracker t, Node nodeFrom, Node nodeTo) {
-  exists(StepSummary summary |
-    smallstepCallProj(nodeFrom, summary) and
-    result = t.append(summary) and
-    smallstepCall(nodeFrom, nodeTo, summary)
+    smallstep(nodeFrom, nodeTo, summary)
   )
 }
 
@@ -385,14 +361,7 @@ module StepSummary {
   /**
    * Gets the summary that corresponds to having taken a forwards
    * heap and/or inter-procedural step from `nodeFrom` to `nodeTo`.
-   *
-   * This predicate is inlined, which enables better join-orders when
-   * the call graph construction and type tracking are mutually recursive.
-   * In such cases, non-linear recursion involving `step` will be limited
-   * to non-linear recursion for the parts of `step` that involve the
-   * call graph.
    */
-  pragma[inline]
   predicate step(TypeTrackingNode nodeFrom, TypeTrackingNode nodeTo, StepSummary summary) {
     stepNoCall(nodeFrom, nodeTo, summary)
     or
@@ -424,7 +393,6 @@ module StepSummary {
    * Unlike `StepSummary::step`, this predicate does not compress
    * type-preserving steps.
    */
-  pragma[inline]
   predicate smallstep(Node nodeFrom, TypeTrackingNode nodeTo, StepSummary summary) {
     smallstepNoCall(nodeFrom, nodeTo, summary)
     or
@@ -531,64 +499,11 @@ class TypeTracker extends TTypeTracker {
 
   /**
    * Gets the summary that corresponds to having taken a forwards
-   * intra-procedural step from `nodeFrom` to `nodeTo`.
-   *
-   * This predicate should normally not be used; consider using `step`
-   * instead.
-   */
-  pragma[inline]
-  TypeTracker stepNoCall(TypeTrackingNode nodeFrom, TypeTrackingNode nodeTo) {
-    result = stepNoCallInlineLate(this, nodeFrom, nodeTo)
-  }
-
-  /**
-   * Gets the summary that corresponds to having taken a forwards
-   * inter-procedural step from `nodeFrom` to `nodeTo`.
-   *
-   * This predicate should normally not be used; consider using `step`
-   * instead.
-   */
-  pragma[inline]
-  TypeTracker stepCall(TypeTrackingNode nodeFrom, TypeTrackingNode nodeTo) {
-    result = stepCallInlineLate(this, nodeFrom, nodeTo)
-  }
-
-  /**
-   * Gets the summary that corresponds to having taken a forwards
    * heap and/or inter-procedural step from `nodeFrom` to `nodeTo`.
    */
   pragma[inline]
   TypeTracker step(TypeTrackingNode nodeFrom, TypeTrackingNode nodeTo) {
-    result = this.stepNoCall(nodeFrom, nodeTo)
-    or
-    result = this.stepCall(nodeFrom, nodeTo)
-  }
-
-  /**
-   * Gets the summary that corresponds to having taken a forwards
-   * intra-procedural step from `nodeFrom` to `nodeTo`.
-   *
-   * This predicate should normally not be used; consider using `step`
-   * instead.
-   */
-  pragma[inline]
-  TypeTracker smallstepNoCall(Node nodeFrom, Node nodeTo) {
-    result = smallstepNoCallInlineLate(this, nodeFrom, nodeTo)
-    or
-    simpleLocalFlowStep(nodeFrom, nodeTo) and
-    result = this
-  }
-
-  /**
-   * Gets the summary that corresponds to having taken a forwards
-   * inter-procedural step from `nodeFrom` to `nodeTo`.
-   *
-   * This predicate should normally not be used; consider using `step`
-   * instead.
-   */
-  pragma[inline]
-  TypeTracker smallstepCall(Node nodeFrom, Node nodeTo) {
-    result = smallstepCallInlineLate(this, nodeFrom, nodeTo)
+    result = stepInlineLate(this, nodeFrom, nodeTo)
   }
 
   /**
@@ -617,9 +532,10 @@ class TypeTracker extends TTypeTracker {
    */
   pragma[inline]
   TypeTracker smallstep(Node nodeFrom, Node nodeTo) {
-    result = this.smallstepNoCall(nodeFrom, nodeTo)
+    result = smallstepInlineLate(this, nodeFrom, nodeTo)
     or
-    result = this.smallstepCall(nodeFrom, nodeTo)
+    simpleLocalFlowStep(nodeFrom, nodeTo) and
+    result = this
   }
 }
 
@@ -629,6 +545,39 @@ module TypeTracker {
    * Gets a valid end point of type tracking.
    */
   TypeTracker end() { result.end() }
+}
+
+pragma[nomagic]
+private predicate backStepProj(TypeTrackingNode nodeTo, StepSummary summary) {
+  step(_, nodeTo, summary)
+}
+
+bindingset[nodeTo, t]
+pragma[inline_late]
+pragma[noopt]
+private TypeBackTracker backStepInlineLate(
+  TypeBackTracker t, TypeTrackingNode nodeFrom, TypeTrackingNode nodeTo
+) {
+  exists(StepSummary summary |
+    backStepProj(nodeTo, summary) and
+    result = t.prepend(summary) and
+    step(nodeFrom, nodeTo, summary)
+  )
+}
+
+private predicate backSmallstepProj(TypeTrackingNode nodeTo, StepSummary summary) {
+  smallstep(_, nodeTo, summary)
+}
+
+bindingset[nodeTo, t]
+pragma[inline_late]
+pragma[noopt]
+private TypeBackTracker backSmallstepInlineLate(TypeBackTracker t, Node nodeFrom, Node nodeTo) {
+  exists(StepSummary summary |
+    backSmallstepProj(nodeTo, summary) and
+    result = t.prepend(summary) and
+    smallstep(nodeFrom, nodeTo, summary)
+  )
 }
 
 /**
@@ -714,10 +663,7 @@ class TypeBackTracker extends TTypeBackTracker {
    */
   pragma[inline]
   TypeBackTracker step(TypeTrackingNode nodeFrom, TypeTrackingNode nodeTo) {
-    exists(StepSummary summary |
-      StepSummary::step(pragma[only_bind_out](nodeFrom), nodeTo, pragma[only_bind_into](summary)) and
-      this = result.prepend(pragma[only_bind_into](summary))
-    )
+    this = backStepInlineLate(result, nodeFrom, nodeTo)
   }
 
   /**
@@ -746,10 +692,7 @@ class TypeBackTracker extends TTypeBackTracker {
    */
   pragma[inline]
   TypeBackTracker smallstep(Node nodeFrom, Node nodeTo) {
-    exists(StepSummary summary |
-      StepSummary::smallstep(nodeFrom, nodeTo, summary) and
-      this = result.prepend(summary)
-    )
+    this = backSmallstepInlineLate(result, nodeFrom, nodeTo)
     or
     simpleLocalFlowStep(nodeFrom, nodeTo) and
     this = result
@@ -784,4 +727,170 @@ module TypeBackTracker {
    * Gets a valid end point of type back-tracking.
    */
   TypeBackTracker end() { result.end() }
+}
+
+/**
+ * INTERNAL: Do not use.
+ *
+ * Provides logic for constructing a call graph in mutual recursion with type tracking.
+ *
+ * When type tracking is used to construct a call graph, we cannot use the join-order
+ * from `stepInlineLate`, because `step` becomes a recursive call, which means that we
+ * will have a conjunct with 3 recursive calls: the call to `step`, the call to `stepProj`,
+ * and the recursive type tracking call itself. The solution is to split the three-way
+ * non-linear recursion into two non-linear predicates: one that first joins with the
+ * projected `stepCall` relation, followed by a predicate that joins with the full
+ * `stepCall` relation (`stepNoCall` not being recursive, can be join-ordered in the
+ * same way as in `stepInlineLate`).
+ */
+module CallGraphConstruction {
+  /** The input to call graph construction. */
+  signature module InputSig {
+    /** A state to track during type tracking. */
+    class State;
+
+    /** Holds if type tracking should start at `start` in state `state`. */
+    predicate start(Node start, State state);
+
+    /**
+     * Holds if type tracking should use the step from `nodeFrom` to `nodeTo`,
+     * which _does not_ depend on the call graph.
+     *
+     * Implementing this predicate using `StepSummary::[small]stepNoCall` yields
+     * standard type tracking.
+     */
+    predicate stepNoCall(Node nodeFrom, Node nodeTo, StepSummary summary);
+
+    /**
+     * Holds if type tracking should use the step from `nodeFrom` to `nodeTo`,
+     * which _does_ depend on the call graph.
+     *
+     * Implementing this predicate using `StepSummary::[small]stepCall` yields
+     * standard type tracking.
+     */
+    predicate stepCall(Node nodeFrom, Node nodeTo, StepSummary summary);
+
+    /** A projection of an element from the state space. */
+    class StateProj;
+
+    /** Gets the projection of `state`. */
+    StateProj stateProj(State state);
+
+    /** Holds if type tracking should stop at `n` when we are tracking projected state `stateProj`. */
+    predicate filter(Node n, StateProj stateProj);
+  }
+
+  /** Provides the `track` predicate for use in call graph construction. */
+  module Make<InputSig Input> {
+    pragma[nomagic]
+    private predicate stepNoCallProj(Node nodeFrom, StepSummary summary) {
+      Input::stepNoCall(nodeFrom, _, summary)
+    }
+
+    pragma[nomagic]
+    private predicate stepCallProj(Node nodeFrom, StepSummary summary) {
+      Input::stepCall(nodeFrom, _, summary)
+    }
+
+    bindingset[nodeFrom, t]
+    pragma[inline_late]
+    pragma[noopt]
+    private TypeTracker stepNoCallInlineLate(
+      TypeTracker t, TypeTrackingNode nodeFrom, TypeTrackingNode nodeTo
+    ) {
+      exists(StepSummary summary |
+        stepNoCallProj(nodeFrom, summary) and
+        result = t.append(summary) and
+        Input::stepNoCall(nodeFrom, nodeTo, summary)
+      )
+    }
+
+    bindingset[state]
+    pragma[inline_late]
+    private Input::StateProj stateProjInlineLate(Input::State state) {
+      result = Input::stateProj(state)
+    }
+
+    pragma[nomagic]
+    private Node track(Input::State state, TypeTracker t) {
+      t.start() and Input::start(result, state)
+      or
+      exists(Input::StateProj stateProj |
+        stateProj = stateProjInlineLate(state) and
+        not Input::filter(result, stateProj)
+      |
+        exists(TypeTracker t2 | t = stepNoCallInlineLate(t2, track(state, t2), result))
+        or
+        exists(StepSummary summary |
+          // non-linear recursion
+          Input::stepCall(trackCall(state, t, summary), result, summary)
+        )
+      )
+    }
+
+    bindingset[t, summary]
+    pragma[inline_late]
+    private TypeTracker appendInlineLate(TypeTracker t, StepSummary summary) {
+      result = t.append(summary)
+    }
+
+    pragma[nomagic]
+    private Node trackCall(Input::State state, TypeTracker t, StepSummary summary) {
+      exists(TypeTracker t2 |
+        // non-linear recursion
+        result = track(state, t2) and
+        stepCallProj(result, summary) and
+        t = appendInlineLate(t2, summary)
+      )
+    }
+
+    /** Gets a node that can be reached from _some_ start node in state `state`. */
+    pragma[nomagic]
+    Node track(Input::State state) { result = track(state, TypeTracker::end()) }
+  }
+
+  /** A simple version of `CallGraphConstruction` that uses standard type tracking. */
+  module Simple {
+    /** The input to call graph construction. */
+    signature module InputSig {
+      /** A state to track during type tracking. */
+      class State;
+
+      /** Holds if type tracking should start at `start` in state `state`. */
+      predicate start(Node start, State state);
+
+      /** Holds if type tracking should stop at `n`. */
+      predicate filter(Node n);
+    }
+
+    /** Provides the `track` predicate for use in call graph construction. */
+    module Make<InputSig Input> {
+      private module I implements CallGraphConstruction::InputSig {
+        private import codeql.util.Unit
+
+        class State = Input::State;
+
+        predicate start(Node start, State state) { Input::start(start, state) }
+
+        predicate stepNoCall(Node nodeFrom, Node nodeTo, StepSummary summary) {
+          StepSummary::stepNoCall(nodeFrom, nodeTo, summary)
+        }
+
+        predicate stepCall(Node nodeFrom, Node nodeTo, StepSummary summary) {
+          StepSummary::stepCall(nodeFrom, nodeTo, summary)
+        }
+
+        class StateProj = Unit;
+
+        Unit stateProj(State state) { exists(state) and exists(result) }
+
+        predicate filter(Node n, Unit u) {
+          Input::filter(n) and
+          exists(u)
+        }
+      }
+
+      import CallGraphConstruction::Make<I>
+    }
+  }
 }

--- a/ruby/ql/lib/codeql/ruby/typetracking/TypeTrackerSpecific.qll
+++ b/ruby/ql/lib/codeql/ruby/typetracking/TypeTrackerSpecific.qll
@@ -79,7 +79,7 @@ predicate jumpStep = DataFlowPrivate::jumpStep/2;
 /** Holds if there is direct flow from `param` to a return. */
 pragma[nomagic]
 private predicate flowThrough(DataFlowPublic::ParameterNode param) {
-  exists(DataFlowPrivate::ReturningNode returnNode, DataFlowDispatch::ReturnKind rk |
+  exists(DataFlowPrivate::SourceReturnNode returnNode, DataFlowDispatch::ReturnKind rk |
     param.flowsTo(returnNode) and
     returnNode.hasKind(rk, param.(DataFlowPrivate::NodeImpl).getCfgScope())
   |
@@ -210,15 +210,7 @@ predicate callStep(ExprNodes::CallCfgNode call, Node arg, DataFlowPrivate::Param
  * recursion (or, at best, terrible performance), since identifying calls to library
  * methods is done using API graphs (which uses type tracking).
  */
-predicate callStep(Node nodeFrom, Node nodeTo) {
-  callStep(_, nodeFrom, nodeTo)
-  or
-  // In normal data-flow, this will be a local flow step. But for type tracking
-  // we model it as a call step, in order to avoid computing a potential
-  // self-cross product of all calls to a function that returns one of its parameters
-  // (only to later filter that flow out using `TypeTracker::append`).
-  DataFlowPrivate::LocalFlow::localFlowSsaParamInput(nodeFrom, nodeTo)
-}
+predicate callStep(Node nodeFrom, Node nodeTo) { callStep(_, nodeFrom, nodeTo) }
 
 /**
  * Holds if `nodeFrom` steps to `nodeTo` by being returned from a call.
@@ -230,19 +222,13 @@ predicate callStep(Node nodeFrom, Node nodeTo) {
 predicate returnStep(Node nodeFrom, Node nodeTo) {
   exists(ExprNodes::CallCfgNode call |
     nodeFrom instanceof DataFlowPrivate::ReturnNode and
+    not nodeFrom instanceof DataFlowPrivate::InitializeReturnNode and
     nodeFrom.(DataFlowPrivate::NodeImpl).getCfgScope() = DataFlowDispatch::getTarget(call) and
     // deliberately do not include `getInitializeTarget`, since calls to `new` should not
     // get the return value from `initialize`. Any fields being set in the initializer
     // will reach all reads via `callStep` and `localFieldStep`.
     nodeTo.asExpr().getNode() = call.getNode()
   )
-  or
-  // In normal data-flow, this will be a local flow step. But for type tracking
-  // we model it as a returning flow step, in order to avoid computing a potential
-  // self-cross product of all calls to a function that returns one of its parameters
-  // (only to later filter that flow out using `TypeTracker::append`).
-  nodeTo.(DataFlowPrivate::SynthReturnNode).getAnInput() = nodeFrom and
-  not nodeFrom instanceof DataFlowPrivate::InitializeReturnNode
 }
 
 /**
@@ -598,26 +584,15 @@ private DataFlow::Node evaluateSummaryComponentStackLocal(
       pragma[only_bind_out](tail)) and
     stack = SCS::push(pragma[only_bind_out](head), pragma[only_bind_out](tail))
   |
-    exists(
-      DataFlowDispatch::ArgumentPosition apos, DataFlowDispatch::ParameterPosition ppos,
-      DataFlowPrivate::ParameterNodeImpl p
-    |
+    exists(DataFlowDispatch::ArgumentPosition apos, DataFlowDispatch::ParameterPosition ppos |
       head = SummaryComponent::parameter(apos) and
       DataFlowDispatch::parameterMatch(ppos, apos) and
-      p.isSourceParameterOf(prev.asExpr().getExpr(), ppos) and
-      // We need to include both `p` and the SSA definition for `p`, since in type-tracking
-      // the step from `p` to the SSA definition is considered a call step.
-      result =
-        [p.(DataFlow::Node), DataFlowPrivate::LocalFlow::getParameterDefNode(p.getParameter())]
+      result.(DataFlowPrivate::ParameterNodeImpl).isSourceParameterOf(prev.asExpr().getExpr(), ppos)
     )
     or
-    exists(DataFlowPrivate::SynthReturnNode ret |
-      head = SummaryComponent::return() and
-      ret.getCfgScope() = prev.asExpr().getExpr() and
-      // We need to include both `ret` and `ret.getAnInput()`, since in type-tracking
-      // the step from `ret.getAnInput()` to `ret` is considered a return step.
-      result = [ret.(DataFlow::Node), ret.getAnInput()]
-    )
+    head = SummaryComponent::return() and
+    result.(DataFlowPrivate::ReturnNode).(DataFlowPrivate::NodeImpl).getCfgScope() =
+      prev.asExpr().getExpr()
     or
     exists(DataFlow::ContentSet content |
       head = SummaryComponent::withoutContent(content) and

--- a/ruby/ql/test/library-tests/dataflow/local/Nodes.ql
+++ b/ruby/ql/test/library-tests/dataflow/local/Nodes.ql
@@ -2,7 +2,7 @@ import codeql.ruby.AST
 import codeql.ruby.dataflow.internal.DataFlowPrivate
 import codeql.ruby.dataflow.internal.DataFlowDispatch
 
-query predicate ret(ReturningNode node) { any() }
+query predicate ret(SourceReturnNode node) { any() }
 
 query predicate arg(ArgumentNode n, DataFlowCall call, ArgumentPosition pos) {
   n.argumentOf(call, pos) and

--- a/ruby/ql/test/library-tests/dataflow/type-tracker/TypeTracker.expected
+++ b/ruby/ql/test/library-tests/dataflow/type-tracker/TypeTracker.expected
@@ -1,129 +1,72 @@
 track
 | type_tracker.rb:1:1:10:3 | self (Container) | type tracker without call steps | type_tracker.rb:1:1:10:3 | self (Container) |
-| type_tracker.rb:1:1:53:4 | self (type_tracker.rb) | type tracker with call steps | type_tracker.rb:18:1:21:3 | self (positional) |
 | type_tracker.rb:1:1:53:4 | self (type_tracker.rb) | type tracker with call steps | type_tracker.rb:18:1:21:3 | self in positional |
-| type_tracker.rb:1:1:53:4 | self (type_tracker.rb) | type tracker with call steps | type_tracker.rb:25:1:28:3 | self (keyword) |
 | type_tracker.rb:1:1:53:4 | self (type_tracker.rb) | type tracker with call steps | type_tracker.rb:25:1:28:3 | self in keyword |
 | type_tracker.rb:1:1:53:4 | self (type_tracker.rb) | type tracker without call steps | type_tracker.rb:1:1:53:4 | self (type_tracker.rb) |
 | type_tracker.rb:2:5:5:7 | &block | type tracker without call steps | type_tracker.rb:2:5:5:7 | &block |
 | type_tracker.rb:2:5:5:7 | field= | type tracker without call steps | type_tracker.rb:2:5:5:7 | field= |
-| type_tracker.rb:2:5:5:7 | return return in field= | type tracker without call steps | type_tracker.rb:2:5:5:7 | return return in field= |
-| type_tracker.rb:2:5:5:7 | return return in field= | type tracker without call steps | type_tracker.rb:14:5:14:13 | call to field= |
-| type_tracker.rb:2:5:5:7 | self (field=) | type tracker with call steps | type_tracker.rb:7:5:9:7 | self (field) |
-| type_tracker.rb:2:5:5:7 | self (field=) | type tracker with call steps | type_tracker.rb:7:5:9:7 | self in field |
-| type_tracker.rb:2:5:5:7 | self (field=) | type tracker without call steps | type_tracker.rb:2:5:5:7 | self (field=) |
-| type_tracker.rb:2:5:5:7 | self in field= | type tracker with call steps | type_tracker.rb:2:5:5:7 | self (field=) |
-| type_tracker.rb:2:5:5:7 | self in field= | type tracker with call steps | type_tracker.rb:7:5:9:7 | self (field) |
 | type_tracker.rb:2:5:5:7 | self in field= | type tracker with call steps | type_tracker.rb:7:5:9:7 | self in field |
 | type_tracker.rb:2:5:5:7 | self in field= | type tracker without call steps | type_tracker.rb:2:5:5:7 | self in field= |
-| type_tracker.rb:2:16:2:18 | val | type tracker with call steps | type_tracker.rb:2:16:2:18 | val |
-| type_tracker.rb:2:16:2:18 | val | type tracker with call steps | type_tracker.rb:8:9:8:14 | @field |
-| type_tracker.rb:2:16:2:18 | val | type tracker without call steps | type_tracker.rb:2:5:5:7 | return return in field= |
-| type_tracker.rb:2:16:2:18 | val | type tracker without call steps | type_tracker.rb:2:5:5:7 | return return in field= |
-| type_tracker.rb:2:16:2:18 | val | type tracker without call steps | type_tracker.rb:2:16:2:18 | val |
 | type_tracker.rb:2:16:2:18 | val | type tracker without call steps | type_tracker.rb:2:16:2:18 | val |
 | type_tracker.rb:2:16:2:18 | val | type tracker without call steps | type_tracker.rb:2:16:2:18 | val |
 | type_tracker.rb:2:16:2:18 | val | type tracker without call steps | type_tracker.rb:3:14:3:23 | call to field |
-| type_tracker.rb:2:16:2:18 | val | type tracker without call steps | type_tracker.rb:3:14:3:23 | call to field |
-| type_tracker.rb:2:16:2:18 | val | type tracker without call steps | type_tracker.rb:7:5:9:7 | return return in field |
-| type_tracker.rb:2:16:2:18 | val | type tracker without call steps | type_tracker.rb:7:5:9:7 | return return in field |
-| type_tracker.rb:2:16:2:18 | val | type tracker without call steps | type_tracker.rb:8:9:8:14 | @field |
 | type_tracker.rb:2:16:2:18 | val | type tracker without call steps | type_tracker.rb:8:9:8:14 | @field |
 | type_tracker.rb:2:16:2:18 | val | type tracker without call steps | type_tracker.rb:14:5:14:13 | call to field= |
-| type_tracker.rb:2:16:2:18 | val | type tracker without call steps | type_tracker.rb:14:5:14:13 | call to field= |
-| type_tracker.rb:2:16:2:18 | val | type tracker without call steps | type_tracker.rb:15:10:15:18 | call to field |
 | type_tracker.rb:2:16:2:18 | val | type tracker without call steps | type_tracker.rb:15:10:15:18 | call to field |
 | type_tracker.rb:3:9:3:23 | call to puts | type tracker without call steps | type_tracker.rb:3:9:3:23 | call to puts |
 | type_tracker.rb:3:14:3:23 | call to field | type tracker without call steps | type_tracker.rb:3:14:3:23 | call to field |
 | type_tracker.rb:4:9:4:14 | @field | type tracker without call steps | type_tracker.rb:4:9:4:14 | @field |
 | type_tracker.rb:7:5:9:7 | &block | type tracker without call steps | type_tracker.rb:7:5:9:7 | &block |
 | type_tracker.rb:7:5:9:7 | field | type tracker without call steps | type_tracker.rb:7:5:9:7 | field |
-| type_tracker.rb:7:5:9:7 | return return in field | type tracker without call steps | type_tracker.rb:3:14:3:23 | call to field |
-| type_tracker.rb:7:5:9:7 | return return in field | type tracker without call steps | type_tracker.rb:7:5:9:7 | return return in field |
-| type_tracker.rb:7:5:9:7 | return return in field | type tracker without call steps | type_tracker.rb:15:10:15:18 | call to field |
-| type_tracker.rb:7:5:9:7 | self (field) | type tracker without call steps | type_tracker.rb:7:5:9:7 | self (field) |
-| type_tracker.rb:7:5:9:7 | self in field | type tracker with call steps | type_tracker.rb:7:5:9:7 | self (field) |
 | type_tracker.rb:7:5:9:7 | self in field | type tracker without call steps | type_tracker.rb:7:5:9:7 | self in field |
 | type_tracker.rb:8:9:8:14 | @field | type tracker without call steps | type_tracker.rb:3:14:3:23 | call to field |
-| type_tracker.rb:8:9:8:14 | @field | type tracker without call steps | type_tracker.rb:7:5:9:7 | return return in field |
 | type_tracker.rb:8:9:8:14 | @field | type tracker without call steps | type_tracker.rb:8:9:8:14 | @field |
 | type_tracker.rb:8:9:8:14 | @field | type tracker without call steps | type_tracker.rb:15:10:15:18 | call to field |
 | type_tracker.rb:12:1:16:3 | &block | type tracker without call steps | type_tracker.rb:12:1:16:3 | &block |
 | type_tracker.rb:12:1:16:3 | m | type tracker without call steps | type_tracker.rb:12:1:16:3 | m |
-| type_tracker.rb:12:1:16:3 | return return in m | type tracker without call steps | type_tracker.rb:12:1:16:3 | return return in m |
-| type_tracker.rb:12:1:16:3 | self (m) | type tracker without call steps | type_tracker.rb:12:1:16:3 | self (m) |
-| type_tracker.rb:12:1:16:3 | self in m | type tracker with call steps | type_tracker.rb:12:1:16:3 | self (m) |
 | type_tracker.rb:12:1:16:3 | self in m | type tracker without call steps | type_tracker.rb:12:1:16:3 | self in m |
 | type_tracker.rb:13:5:13:7 | var | type tracker without call steps | type_tracker.rb:13:5:13:7 | var |
 | type_tracker.rb:13:11:13:19 | Container | type tracker without call steps | type_tracker.rb:13:11:13:19 | Container |
-| type_tracker.rb:13:11:13:23 | call to new | type tracker with call steps | type_tracker.rb:2:5:5:7 | self (field=) |
 | type_tracker.rb:13:11:13:23 | call to new | type tracker with call steps | type_tracker.rb:2:5:5:7 | self in field= |
-| type_tracker.rb:13:11:13:23 | call to new | type tracker with call steps | type_tracker.rb:7:5:9:7 | self (field) |
 | type_tracker.rb:13:11:13:23 | call to new | type tracker with call steps | type_tracker.rb:7:5:9:7 | self in field |
 | type_tracker.rb:13:11:13:23 | call to new | type tracker without call steps | type_tracker.rb:13:11:13:23 | call to new |
-| type_tracker.rb:14:5:14:7 | [post] var | type tracker with call steps | type_tracker.rb:7:5:9:7 | self (field) |
 | type_tracker.rb:14:5:14:7 | [post] var | type tracker with call steps | type_tracker.rb:7:5:9:7 | self in field |
 | type_tracker.rb:14:5:14:7 | [post] var | type tracker without call steps | type_tracker.rb:14:5:14:7 | [post] var |
 | type_tracker.rb:14:5:14:13 | call to field= | type tracker without call steps | type_tracker.rb:14:5:14:13 | call to field= |
 | type_tracker.rb:14:17:14:23 | "hello" | type tracker with call steps | type_tracker.rb:2:16:2:18 | val |
-| type_tracker.rb:14:17:14:23 | "hello" | type tracker with call steps | type_tracker.rb:2:16:2:18 | val |
 | type_tracker.rb:14:17:14:23 | "hello" | type tracker with call steps | type_tracker.rb:8:9:8:14 | @field |
-| type_tracker.rb:14:17:14:23 | "hello" | type tracker with call steps with content attribute field | type_tracker.rb:7:5:9:7 | self (field) |
 | type_tracker.rb:14:17:14:23 | "hello" | type tracker with call steps with content attribute field | type_tracker.rb:7:5:9:7 | self in field |
 | type_tracker.rb:14:17:14:23 | "hello" | type tracker without call steps | type_tracker.rb:14:5:14:13 | call to field= |
 | type_tracker.rb:14:17:14:23 | "hello" | type tracker without call steps | type_tracker.rb:14:17:14:23 | "hello" |
 | type_tracker.rb:14:17:14:23 | "hello" | type tracker without call steps | type_tracker.rb:15:10:15:18 | call to field |
 | type_tracker.rb:14:17:14:23 | "hello" | type tracker without call steps with content attribute field | type_tracker.rb:14:5:14:7 | [post] var |
 | type_tracker.rb:14:17:14:23 | __synth__0 | type tracker without call steps | type_tracker.rb:14:17:14:23 | __synth__0 |
-| type_tracker.rb:15:5:15:18 | call to puts | type tracker without call steps | type_tracker.rb:12:1:16:3 | return return in m |
 | type_tracker.rb:15:5:15:18 | call to puts | type tracker without call steps | type_tracker.rb:15:5:15:18 | call to puts |
 | type_tracker.rb:15:10:15:18 | call to field | type tracker without call steps | type_tracker.rb:15:10:15:18 | call to field |
 | type_tracker.rb:18:1:21:3 | &block | type tracker without call steps | type_tracker.rb:18:1:21:3 | &block |
 | type_tracker.rb:18:1:21:3 | positional | type tracker without call steps | type_tracker.rb:18:1:21:3 | positional |
-| type_tracker.rb:18:1:21:3 | return return in positional | type tracker without call steps | type_tracker.rb:18:1:21:3 | return return in positional |
-| type_tracker.rb:18:1:21:3 | return return in positional | type tracker without call steps | type_tracker.rb:23:1:23:16 | call to positional |
-| type_tracker.rb:18:1:21:3 | self (positional) | type tracker without call steps | type_tracker.rb:18:1:21:3 | self (positional) |
-| type_tracker.rb:18:1:21:3 | self in positional | type tracker with call steps | type_tracker.rb:18:1:21:3 | self (positional) |
 | type_tracker.rb:18:1:21:3 | self in positional | type tracker without call steps | type_tracker.rb:18:1:21:3 | self in positional |
-| type_tracker.rb:18:16:18:17 | p1 | type tracker with call steps | type_tracker.rb:18:16:18:17 | p1 |
 | type_tracker.rb:18:16:18:17 | p1 | type tracker without call steps | type_tracker.rb:18:16:18:17 | p1 |
 | type_tracker.rb:18:16:18:17 | p1 | type tracker without call steps | type_tracker.rb:18:16:18:17 | p1 |
-| type_tracker.rb:18:16:18:17 | p1 | type tracker without call steps | type_tracker.rb:18:16:18:17 | p1 |
-| type_tracker.rb:18:20:18:21 | p2 | type tracker with call steps | type_tracker.rb:18:20:18:21 | p2 |
-| type_tracker.rb:18:20:18:21 | p2 | type tracker without call steps | type_tracker.rb:18:20:18:21 | p2 |
 | type_tracker.rb:18:20:18:21 | p2 | type tracker without call steps | type_tracker.rb:18:20:18:21 | p2 |
 | type_tracker.rb:18:20:18:21 | p2 | type tracker without call steps | type_tracker.rb:18:20:18:21 | p2 |
 | type_tracker.rb:19:5:19:11 | call to puts | type tracker without call steps | type_tracker.rb:19:5:19:11 | call to puts |
-| type_tracker.rb:20:5:20:11 | call to puts | type tracker without call steps | type_tracker.rb:18:1:21:3 | return return in positional |
 | type_tracker.rb:20:5:20:11 | call to puts | type tracker without call steps | type_tracker.rb:20:5:20:11 | call to puts |
 | type_tracker.rb:20:5:20:11 | call to puts | type tracker without call steps | type_tracker.rb:23:1:23:16 | call to positional |
 | type_tracker.rb:23:1:23:16 | call to positional | type tracker without call steps | type_tracker.rb:23:1:23:16 | call to positional |
 | type_tracker.rb:23:12:23:12 | 1 | type tracker with call steps | type_tracker.rb:18:16:18:17 | p1 |
-| type_tracker.rb:23:12:23:12 | 1 | type tracker with call steps | type_tracker.rb:18:16:18:17 | p1 |
 | type_tracker.rb:23:12:23:12 | 1 | type tracker without call steps | type_tracker.rb:23:12:23:12 | 1 |
-| type_tracker.rb:23:15:23:15 | 2 | type tracker with call steps | type_tracker.rb:18:20:18:21 | p2 |
 | type_tracker.rb:23:15:23:15 | 2 | type tracker with call steps | type_tracker.rb:18:20:18:21 | p2 |
 | type_tracker.rb:23:15:23:15 | 2 | type tracker without call steps | type_tracker.rb:23:15:23:15 | 2 |
 | type_tracker.rb:25:1:28:3 | &block | type tracker without call steps | type_tracker.rb:25:1:28:3 | &block |
 | type_tracker.rb:25:1:28:3 | **kwargs | type tracker without call steps | type_tracker.rb:25:1:28:3 | **kwargs |
 | type_tracker.rb:25:1:28:3 | keyword | type tracker without call steps | type_tracker.rb:25:1:28:3 | keyword |
-| type_tracker.rb:25:1:28:3 | return return in keyword | type tracker without call steps | type_tracker.rb:25:1:28:3 | return return in keyword |
-| type_tracker.rb:25:1:28:3 | return return in keyword | type tracker without call steps | type_tracker.rb:30:1:30:21 | call to keyword |
-| type_tracker.rb:25:1:28:3 | return return in keyword | type tracker without call steps | type_tracker.rb:31:1:31:21 | call to keyword |
-| type_tracker.rb:25:1:28:3 | return return in keyword | type tracker without call steps | type_tracker.rb:32:1:32:27 | call to keyword |
-| type_tracker.rb:25:1:28:3 | self (keyword) | type tracker without call steps | type_tracker.rb:25:1:28:3 | self (keyword) |
-| type_tracker.rb:25:1:28:3 | self in keyword | type tracker with call steps | type_tracker.rb:25:1:28:3 | self (keyword) |
 | type_tracker.rb:25:1:28:3 | self in keyword | type tracker without call steps | type_tracker.rb:25:1:28:3 | self in keyword |
-| type_tracker.rb:25:13:25:14 | p1 | type tracker with call steps | type_tracker.rb:25:13:25:14 | p1 |
 | type_tracker.rb:25:13:25:14 | p1 | type tracker without call steps | type_tracker.rb:25:13:25:14 | p1 |
 | type_tracker.rb:25:13:25:14 | p1 | type tracker without call steps | type_tracker.rb:25:13:25:14 | p1 |
-| type_tracker.rb:25:13:25:14 | p1 | type tracker without call steps | type_tracker.rb:25:13:25:14 | p1 |
-| type_tracker.rb:25:18:25:19 | p2 | type tracker with call steps | type_tracker.rb:25:18:25:19 | p2 |
-| type_tracker.rb:25:18:25:19 | p2 | type tracker without call steps | type_tracker.rb:25:18:25:19 | p2 |
 | type_tracker.rb:25:18:25:19 | p2 | type tracker without call steps | type_tracker.rb:25:18:25:19 | p2 |
 | type_tracker.rb:25:18:25:19 | p2 | type tracker without call steps | type_tracker.rb:25:18:25:19 | p2 |
 | type_tracker.rb:26:5:26:11 | call to puts | type tracker without call steps | type_tracker.rb:26:5:26:11 | call to puts |
-| type_tracker.rb:27:5:27:11 | call to puts | type tracker without call steps | type_tracker.rb:25:1:28:3 | return return in keyword |
 | type_tracker.rb:27:5:27:11 | call to puts | type tracker without call steps | type_tracker.rb:27:5:27:11 | call to puts |
 | type_tracker.rb:27:5:27:11 | call to puts | type tracker without call steps | type_tracker.rb:30:1:30:21 | call to keyword |
 | type_tracker.rb:27:5:27:11 | call to puts | type tracker without call steps | type_tracker.rb:31:1:31:21 | call to keyword |
@@ -134,13 +77,11 @@ track
 | type_tracker.rb:30:9:30:10 | :p1 | type tracker without call steps | type_tracker.rb:30:9:30:10 | :p1 |
 | type_tracker.rb:30:9:30:13 | Pair | type tracker without call steps | type_tracker.rb:30:9:30:13 | Pair |
 | type_tracker.rb:30:13:30:13 | 3 | type tracker with call steps | type_tracker.rb:25:13:25:14 | p1 |
-| type_tracker.rb:30:13:30:13 | 3 | type tracker with call steps | type_tracker.rb:25:13:25:14 | p1 |
 | type_tracker.rb:30:13:30:13 | 3 | type tracker with call steps with content element :p1 | type_tracker.rb:25:1:28:3 | **kwargs |
 | type_tracker.rb:30:13:30:13 | 3 | type tracker without call steps | type_tracker.rb:30:13:30:13 | 3 |
 | type_tracker.rb:30:13:30:13 | 3 | type tracker without call steps with content element :p1 | type_tracker.rb:30:1:30:21 | ** |
 | type_tracker.rb:30:16:30:17 | :p2 | type tracker without call steps | type_tracker.rb:30:16:30:17 | :p2 |
 | type_tracker.rb:30:16:30:20 | Pair | type tracker without call steps | type_tracker.rb:30:16:30:20 | Pair |
-| type_tracker.rb:30:20:30:20 | 4 | type tracker with call steps | type_tracker.rb:25:18:25:19 | p2 |
 | type_tracker.rb:30:20:30:20 | 4 | type tracker with call steps | type_tracker.rb:25:18:25:19 | p2 |
 | type_tracker.rb:30:20:30:20 | 4 | type tracker with call steps with content element :p2 | type_tracker.rb:25:1:28:3 | **kwargs |
 | type_tracker.rb:30:20:30:20 | 4 | type tracker without call steps | type_tracker.rb:30:20:30:20 | 4 |
@@ -151,13 +92,11 @@ track
 | type_tracker.rb:31:9:31:10 | :p2 | type tracker without call steps | type_tracker.rb:31:9:31:10 | :p2 |
 | type_tracker.rb:31:9:31:13 | Pair | type tracker without call steps | type_tracker.rb:31:9:31:13 | Pair |
 | type_tracker.rb:31:13:31:13 | 5 | type tracker with call steps | type_tracker.rb:25:18:25:19 | p2 |
-| type_tracker.rb:31:13:31:13 | 5 | type tracker with call steps | type_tracker.rb:25:18:25:19 | p2 |
 | type_tracker.rb:31:13:31:13 | 5 | type tracker with call steps with content element :p2 | type_tracker.rb:25:1:28:3 | **kwargs |
 | type_tracker.rb:31:13:31:13 | 5 | type tracker without call steps | type_tracker.rb:31:13:31:13 | 5 |
 | type_tracker.rb:31:13:31:13 | 5 | type tracker without call steps with content element :p2 | type_tracker.rb:31:1:31:21 | ** |
 | type_tracker.rb:31:16:31:17 | :p1 | type tracker without call steps | type_tracker.rb:31:16:31:17 | :p1 |
 | type_tracker.rb:31:16:31:20 | Pair | type tracker without call steps | type_tracker.rb:31:16:31:20 | Pair |
-| type_tracker.rb:31:20:31:20 | 6 | type tracker with call steps | type_tracker.rb:25:13:25:14 | p1 |
 | type_tracker.rb:31:20:31:20 | 6 | type tracker with call steps | type_tracker.rb:25:13:25:14 | p1 |
 | type_tracker.rb:31:20:31:20 | 6 | type tracker with call steps with content element :p1 | type_tracker.rb:25:1:28:3 | **kwargs |
 | type_tracker.rb:31:20:31:20 | 6 | type tracker without call steps | type_tracker.rb:31:20:31:20 | 6 |
@@ -168,68 +107,33 @@ track
 | type_tracker.rb:32:9:32:11 | :p2 | type tracker without call steps | type_tracker.rb:32:9:32:11 | :p2 |
 | type_tracker.rb:32:9:32:16 | Pair | type tracker without call steps | type_tracker.rb:32:9:32:16 | Pair |
 | type_tracker.rb:32:16:32:16 | 7 | type tracker with call steps | type_tracker.rb:25:18:25:19 | p2 |
-| type_tracker.rb:32:16:32:16 | 7 | type tracker with call steps | type_tracker.rb:25:18:25:19 | p2 |
 | type_tracker.rb:32:16:32:16 | 7 | type tracker with call steps with content element :p2 | type_tracker.rb:25:1:28:3 | **kwargs |
 | type_tracker.rb:32:16:32:16 | 7 | type tracker without call steps | type_tracker.rb:32:16:32:16 | 7 |
 | type_tracker.rb:32:16:32:16 | 7 | type tracker without call steps with content element :p2 | type_tracker.rb:32:1:32:27 | ** |
 | type_tracker.rb:32:19:32:21 | :p1 | type tracker without call steps | type_tracker.rb:32:19:32:21 | :p1 |
 | type_tracker.rb:32:19:32:26 | Pair | type tracker without call steps | type_tracker.rb:32:19:32:26 | Pair |
 | type_tracker.rb:32:26:32:26 | 8 | type tracker with call steps | type_tracker.rb:25:13:25:14 | p1 |
-| type_tracker.rb:32:26:32:26 | 8 | type tracker with call steps | type_tracker.rb:25:13:25:14 | p1 |
 | type_tracker.rb:32:26:32:26 | 8 | type tracker with call steps with content element :p1 | type_tracker.rb:25:1:28:3 | **kwargs |
 | type_tracker.rb:32:26:32:26 | 8 | type tracker without call steps | type_tracker.rb:32:26:32:26 | 8 |
 | type_tracker.rb:32:26:32:26 | 8 | type tracker without call steps with content element :p1 | type_tracker.rb:32:1:32:27 | ** |
 | type_tracker.rb:34:1:53:3 | &block | type tracker without call steps | type_tracker.rb:34:1:53:3 | &block |
-| type_tracker.rb:34:1:53:3 | return return in throughArray | type tracker without call steps | type_tracker.rb:34:1:53:3 | return return in throughArray |
 | type_tracker.rb:34:1:53:3 | self in throughArray | type tracker without call steps | type_tracker.rb:34:1:53:3 | self in throughArray |
 | type_tracker.rb:34:1:53:3 | throughArray | type tracker without call steps | type_tracker.rb:34:1:53:3 | throughArray |
-| type_tracker.rb:34:18:34:20 | obj | type tracker with call steps | type_tracker.rb:34:18:34:20 | obj |
-| type_tracker.rb:34:18:34:20 | obj | type tracker with call steps | type_tracker.rb:36:5:36:10 | ...[...] |
-| type_tracker.rb:34:18:34:20 | obj | type tracker with call steps | type_tracker.rb:40:5:40:12 | ...[...] |
-| type_tracker.rb:34:18:34:20 | obj | type tracker with call steps | type_tracker.rb:44:5:44:13 | ...[...] |
-| type_tracker.rb:34:18:34:20 | obj | type tracker with call steps | type_tracker.rb:52:5:52:13 | ...[...] |
-| type_tracker.rb:34:18:34:20 | obj | type tracker with call steps with content element | type_tracker.rb:38:13:38:25 | call to [] |
-| type_tracker.rb:34:18:34:20 | obj | type tracker with call steps with content element | type_tracker.rb:44:5:44:13 | ...[...] |
-| type_tracker.rb:34:18:34:20 | obj | type tracker with call steps with content element | type_tracker.rb:50:14:50:26 | call to [] |
-| type_tracker.rb:34:18:34:20 | obj | type tracker with call steps with content element | type_tracker.rb:52:5:52:13 | ...[...] |
-| type_tracker.rb:34:18:34:20 | obj | type tracker with call steps with content element 0 or unknown | type_tracker.rb:35:11:35:15 | call to [] |
-| type_tracker.rb:34:18:34:20 | obj | type tracker with call steps with content element 0 or unknown | type_tracker.rb:42:14:42:26 | call to [] |
-| type_tracker.rb:34:18:34:20 | obj | type tracker with call steps with content element 0 or unknown | type_tracker.rb:46:14:46:26 | call to [] |
-| type_tracker.rb:34:18:34:20 | obj | type tracker without call steps | type_tracker.rb:34:1:53:3 | return return in throughArray |
-| type_tracker.rb:34:18:34:20 | obj | type tracker without call steps | type_tracker.rb:34:1:53:3 | return return in throughArray |
-| type_tracker.rb:34:18:34:20 | obj | type tracker without call steps | type_tracker.rb:34:18:34:20 | obj |
 | type_tracker.rb:34:18:34:20 | obj | type tracker without call steps | type_tracker.rb:34:18:34:20 | obj |
 | type_tracker.rb:34:18:34:20 | obj | type tracker without call steps | type_tracker.rb:34:18:34:20 | obj |
 | type_tracker.rb:34:18:34:20 | obj | type tracker without call steps | type_tracker.rb:36:5:36:10 | ...[...] |
-| type_tracker.rb:34:18:34:20 | obj | type tracker without call steps | type_tracker.rb:36:5:36:10 | ...[...] |
-| type_tracker.rb:34:18:34:20 | obj | type tracker without call steps | type_tracker.rb:40:5:40:12 | ...[...] |
 | type_tracker.rb:34:18:34:20 | obj | type tracker without call steps | type_tracker.rb:40:5:40:12 | ...[...] |
 | type_tracker.rb:34:18:34:20 | obj | type tracker without call steps | type_tracker.rb:44:5:44:13 | ...[...] |
-| type_tracker.rb:34:18:34:20 | obj | type tracker without call steps | type_tracker.rb:44:5:44:13 | ...[...] |
 | type_tracker.rb:34:18:34:20 | obj | type tracker without call steps | type_tracker.rb:52:5:52:13 | ...[...] |
-| type_tracker.rb:34:18:34:20 | obj | type tracker without call steps | type_tracker.rb:52:5:52:13 | ...[...] |
-| type_tracker.rb:34:18:34:20 | obj | type tracker without call steps with content element | type_tracker.rb:34:1:53:3 | return return in throughArray |
-| type_tracker.rb:34:18:34:20 | obj | type tracker without call steps with content element | type_tracker.rb:34:1:53:3 | return return in throughArray |
-| type_tracker.rb:34:18:34:20 | obj | type tracker without call steps with content element | type_tracker.rb:38:13:38:25 | call to [] |
 | type_tracker.rb:34:18:34:20 | obj | type tracker without call steps with content element | type_tracker.rb:38:13:38:25 | call to [] |
 | type_tracker.rb:34:18:34:20 | obj | type tracker without call steps with content element | type_tracker.rb:44:5:44:13 | ...[...] |
-| type_tracker.rb:34:18:34:20 | obj | type tracker without call steps with content element | type_tracker.rb:44:5:44:13 | ...[...] |
-| type_tracker.rb:34:18:34:20 | obj | type tracker without call steps with content element | type_tracker.rb:50:14:50:26 | call to [] |
 | type_tracker.rb:34:18:34:20 | obj | type tracker without call steps with content element | type_tracker.rb:50:14:50:26 | call to [] |
 | type_tracker.rb:34:18:34:20 | obj | type tracker without call steps with content element | type_tracker.rb:52:5:52:13 | ...[...] |
-| type_tracker.rb:34:18:34:20 | obj | type tracker without call steps with content element | type_tracker.rb:52:5:52:13 | ...[...] |
-| type_tracker.rb:34:18:34:20 | obj | type tracker without call steps with content element 0 or unknown | type_tracker.rb:35:11:35:15 | call to [] |
 | type_tracker.rb:34:18:34:20 | obj | type tracker without call steps with content element 0 or unknown | type_tracker.rb:35:11:35:15 | call to [] |
 | type_tracker.rb:34:18:34:20 | obj | type tracker without call steps with content element 0 or unknown | type_tracker.rb:42:14:42:26 | call to [] |
-| type_tracker.rb:34:18:34:20 | obj | type tracker without call steps with content element 0 or unknown | type_tracker.rb:42:14:42:26 | call to [] |
 | type_tracker.rb:34:18:34:20 | obj | type tracker without call steps with content element 0 or unknown | type_tracker.rb:46:14:46:26 | call to [] |
-| type_tracker.rb:34:18:34:20 | obj | type tracker without call steps with content element 0 or unknown | type_tracker.rb:46:14:46:26 | call to [] |
-| type_tracker.rb:34:23:34:23 | y | type tracker with call steps | type_tracker.rb:34:23:34:23 | y |
 | type_tracker.rb:34:23:34:23 | y | type tracker without call steps | type_tracker.rb:34:23:34:23 | y |
 | type_tracker.rb:34:23:34:23 | y | type tracker without call steps | type_tracker.rb:34:23:34:23 | y |
-| type_tracker.rb:34:23:34:23 | y | type tracker without call steps | type_tracker.rb:34:23:34:23 | y |
-| type_tracker.rb:34:26:34:26 | z | type tracker with call steps | type_tracker.rb:34:26:34:26 | z |
-| type_tracker.rb:34:26:34:26 | z | type tracker without call steps | type_tracker.rb:34:26:34:26 | z |
 | type_tracker.rb:34:26:34:26 | z | type tracker without call steps | type_tracker.rb:34:26:34:26 | z |
 | type_tracker.rb:34:26:34:26 | z | type tracker without call steps | type_tracker.rb:34:26:34:26 | z |
 | type_tracker.rb:35:5:35:7 | tmp | type tracker without call steps | type_tracker.rb:35:5:35:7 | tmp |
@@ -315,46 +219,33 @@ track
 | type_tracker.rb:50:5:50:10 | array4 | type tracker without call steps | type_tracker.rb:50:5:50:10 | array4 |
 | type_tracker.rb:50:14:50:26 | Array | type tracker without call steps | type_tracker.rb:50:14:50:26 | Array |
 | type_tracker.rb:50:14:50:26 | call to [] | type tracker without call steps | type_tracker.rb:50:14:50:26 | call to [] |
-| type_tracker.rb:50:15:50:15 | 1 | type tracker without call steps | type_tracker.rb:34:1:53:3 | return return in throughArray |
 | type_tracker.rb:50:15:50:15 | 1 | type tracker without call steps | type_tracker.rb:50:15:50:15 | 1 |
 | type_tracker.rb:50:15:50:15 | 1 | type tracker without call steps | type_tracker.rb:52:5:52:13 | ...[...] |
-| type_tracker.rb:50:15:50:15 | 1 | type tracker without call steps with content element | type_tracker.rb:34:1:53:3 | return return in throughArray |
 | type_tracker.rb:50:15:50:15 | 1 | type tracker without call steps with content element | type_tracker.rb:52:5:52:13 | ...[...] |
 | type_tracker.rb:50:15:50:15 | 1 | type tracker without call steps with content element 0 or unknown | type_tracker.rb:50:14:50:26 | call to [] |
-| type_tracker.rb:50:17:50:17 | 2 | type tracker without call steps | type_tracker.rb:34:1:53:3 | return return in throughArray |
 | type_tracker.rb:50:17:50:17 | 2 | type tracker without call steps | type_tracker.rb:50:17:50:17 | 2 |
 | type_tracker.rb:50:17:50:17 | 2 | type tracker without call steps | type_tracker.rb:52:5:52:13 | ...[...] |
-| type_tracker.rb:50:17:50:17 | 2 | type tracker without call steps with content element | type_tracker.rb:34:1:53:3 | return return in throughArray |
 | type_tracker.rb:50:17:50:17 | 2 | type tracker without call steps with content element | type_tracker.rb:52:5:52:13 | ...[...] |
 | type_tracker.rb:50:17:50:17 | 2 | type tracker without call steps with content element 1 or unknown | type_tracker.rb:50:14:50:26 | call to [] |
-| type_tracker.rb:50:19:50:19 | 3 | type tracker without call steps | type_tracker.rb:34:1:53:3 | return return in throughArray |
 | type_tracker.rb:50:19:50:19 | 3 | type tracker without call steps | type_tracker.rb:50:19:50:19 | 3 |
 | type_tracker.rb:50:19:50:19 | 3 | type tracker without call steps | type_tracker.rb:52:5:52:13 | ...[...] |
-| type_tracker.rb:50:19:50:19 | 3 | type tracker without call steps with content element | type_tracker.rb:34:1:53:3 | return return in throughArray |
 | type_tracker.rb:50:19:50:19 | 3 | type tracker without call steps with content element | type_tracker.rb:52:5:52:13 | ...[...] |
 | type_tracker.rb:50:19:50:19 | 3 | type tracker without call steps with content element 2 or unknown | type_tracker.rb:50:14:50:26 | call to [] |
-| type_tracker.rb:50:21:50:21 | 4 | type tracker without call steps | type_tracker.rb:34:1:53:3 | return return in throughArray |
 | type_tracker.rb:50:21:50:21 | 4 | type tracker without call steps | type_tracker.rb:50:21:50:21 | 4 |
 | type_tracker.rb:50:21:50:21 | 4 | type tracker without call steps | type_tracker.rb:52:5:52:13 | ...[...] |
-| type_tracker.rb:50:21:50:21 | 4 | type tracker without call steps with content element | type_tracker.rb:34:1:53:3 | return return in throughArray |
 | type_tracker.rb:50:21:50:21 | 4 | type tracker without call steps with content element | type_tracker.rb:52:5:52:13 | ...[...] |
 | type_tracker.rb:50:21:50:21 | 4 | type tracker without call steps with content element 3 or unknown | type_tracker.rb:50:14:50:26 | call to [] |
-| type_tracker.rb:50:23:50:23 | 5 | type tracker without call steps | type_tracker.rb:34:1:53:3 | return return in throughArray |
 | type_tracker.rb:50:23:50:23 | 5 | type tracker without call steps | type_tracker.rb:50:23:50:23 | 5 |
 | type_tracker.rb:50:23:50:23 | 5 | type tracker without call steps | type_tracker.rb:52:5:52:13 | ...[...] |
-| type_tracker.rb:50:23:50:23 | 5 | type tracker without call steps with content element | type_tracker.rb:34:1:53:3 | return return in throughArray |
 | type_tracker.rb:50:23:50:23 | 5 | type tracker without call steps with content element | type_tracker.rb:52:5:52:13 | ...[...] |
 | type_tracker.rb:50:23:50:23 | 5 | type tracker without call steps with content element 4 or unknown | type_tracker.rb:50:14:50:26 | call to [] |
-| type_tracker.rb:50:25:50:25 | 6 | type tracker without call steps | type_tracker.rb:34:1:53:3 | return return in throughArray |
 | type_tracker.rb:50:25:50:25 | 6 | type tracker without call steps | type_tracker.rb:50:25:50:25 | 6 |
 | type_tracker.rb:50:25:50:25 | 6 | type tracker without call steps | type_tracker.rb:52:5:52:13 | ...[...] |
-| type_tracker.rb:50:25:50:25 | 6 | type tracker without call steps with content element | type_tracker.rb:34:1:53:3 | return return in throughArray |
 | type_tracker.rb:50:25:50:25 | 6 | type tracker without call steps with content element | type_tracker.rb:52:5:52:13 | ...[...] |
 | type_tracker.rb:50:25:50:25 | 6 | type tracker without call steps with content element 5 or unknown | type_tracker.rb:50:14:50:26 | call to [] |
 | type_tracker.rb:51:5:51:10 | [post] array4 | type tracker without call steps | type_tracker.rb:51:5:51:10 | [post] array4 |
 | type_tracker.rb:51:5:51:13 | call to []= | type tracker without call steps | type_tracker.rb:51:5:51:13 | call to []= |
 | type_tracker.rb:51:17:51:19 | __synth__0 | type tracker without call steps | type_tracker.rb:51:17:51:19 | __synth__0 |
-| type_tracker.rb:52:5:52:13 | ...[...] | type tracker without call steps | type_tracker.rb:34:1:53:3 | return return in throughArray |
 | type_tracker.rb:52:5:52:13 | ...[...] | type tracker without call steps | type_tracker.rb:52:5:52:13 | ...[...] |
 trackEnd
 | type_tracker.rb:1:1:10:3 | self (Container) | type_tracker.rb:1:1:10:3 | self (Container) |
@@ -373,15 +264,6 @@ trackEnd
 | type_tracker.rb:1:1:53:4 | self (type_tracker.rb) | type_tracker.rb:32:1:32:27 | self |
 | type_tracker.rb:2:5:5:7 | &block | type_tracker.rb:2:5:5:7 | &block |
 | type_tracker.rb:2:5:5:7 | field= | type_tracker.rb:2:5:5:7 | field= |
-| type_tracker.rb:2:5:5:7 | return return in field= | type_tracker.rb:2:5:5:7 | return return in field= |
-| type_tracker.rb:2:5:5:7 | return return in field= | type_tracker.rb:14:5:14:13 | call to field= |
-| type_tracker.rb:2:5:5:7 | self (field=) | type_tracker.rb:2:5:5:7 | self (field=) |
-| type_tracker.rb:2:5:5:7 | self (field=) | type_tracker.rb:3:9:3:23 | self |
-| type_tracker.rb:2:5:5:7 | self (field=) | type_tracker.rb:3:14:3:17 | self |
-| type_tracker.rb:2:5:5:7 | self (field=) | type_tracker.rb:4:9:4:14 | self |
-| type_tracker.rb:2:5:5:7 | self (field=) | type_tracker.rb:7:5:9:7 | self (field) |
-| type_tracker.rb:2:5:5:7 | self (field=) | type_tracker.rb:7:5:9:7 | self in field |
-| type_tracker.rb:2:5:5:7 | self (field=) | type_tracker.rb:8:9:8:14 | self |
 | type_tracker.rb:2:5:5:7 | self in field= | type_tracker.rb:2:5:5:7 | self (field=) |
 | type_tracker.rb:2:5:5:7 | self in field= | type_tracker.rb:2:5:5:7 | self in field= |
 | type_tracker.rb:2:5:5:7 | self in field= | type_tracker.rb:3:9:3:23 | self |
@@ -390,25 +272,14 @@ trackEnd
 | type_tracker.rb:2:5:5:7 | self in field= | type_tracker.rb:7:5:9:7 | self (field) |
 | type_tracker.rb:2:5:5:7 | self in field= | type_tracker.rb:7:5:9:7 | self in field |
 | type_tracker.rb:2:5:5:7 | self in field= | type_tracker.rb:8:9:8:14 | self |
-| type_tracker.rb:2:16:2:18 | val | type_tracker.rb:2:5:5:7 | return return in field= |
-| type_tracker.rb:2:16:2:18 | val | type_tracker.rb:2:5:5:7 | return return in field= |
-| type_tracker.rb:2:16:2:18 | val | type_tracker.rb:2:16:2:18 | val |
 | type_tracker.rb:2:16:2:18 | val | type_tracker.rb:2:16:2:18 | val |
 | type_tracker.rb:2:16:2:18 | val | type_tracker.rb:2:16:2:18 | val |
 | type_tracker.rb:2:16:2:18 | val | type_tracker.rb:2:16:2:18 | val |
 | type_tracker.rb:2:16:2:18 | val | type_tracker.rb:3:14:3:23 | call to field |
-| type_tracker.rb:2:16:2:18 | val | type_tracker.rb:3:14:3:23 | call to field |
-| type_tracker.rb:2:16:2:18 | val | type_tracker.rb:4:9:4:20 | ... = ... |
 | type_tracker.rb:2:16:2:18 | val | type_tracker.rb:4:9:4:20 | ... = ... |
 | type_tracker.rb:2:16:2:18 | val | type_tracker.rb:4:18:4:20 | val |
-| type_tracker.rb:2:16:2:18 | val | type_tracker.rb:4:18:4:20 | val |
-| type_tracker.rb:2:16:2:18 | val | type_tracker.rb:7:5:9:7 | return return in field |
-| type_tracker.rb:2:16:2:18 | val | type_tracker.rb:7:5:9:7 | return return in field |
-| type_tracker.rb:2:16:2:18 | val | type_tracker.rb:8:9:8:14 | @field |
 | type_tracker.rb:2:16:2:18 | val | type_tracker.rb:8:9:8:14 | @field |
 | type_tracker.rb:2:16:2:18 | val | type_tracker.rb:14:5:14:13 | call to field= |
-| type_tracker.rb:2:16:2:18 | val | type_tracker.rb:14:5:14:13 | call to field= |
-| type_tracker.rb:2:16:2:18 | val | type_tracker.rb:15:10:15:18 | call to field |
 | type_tracker.rb:2:16:2:18 | val | type_tracker.rb:15:10:15:18 | call to field |
 | type_tracker.rb:3:9:3:23 | call to puts | type_tracker.rb:3:9:3:23 | call to puts |
 | type_tracker.rb:3:14:3:23 | call to field | type_tracker.rb:3:14:3:23 | call to field |
@@ -416,23 +287,14 @@ trackEnd
 | type_tracker.rb:7:5:9:7 | &block | type_tracker.rb:7:5:9:7 | &block |
 | type_tracker.rb:7:5:9:7 | field | type_tracker.rb:1:1:10:3 | Container |
 | type_tracker.rb:7:5:9:7 | field | type_tracker.rb:7:5:9:7 | field |
-| type_tracker.rb:7:5:9:7 | return return in field | type_tracker.rb:3:14:3:23 | call to field |
-| type_tracker.rb:7:5:9:7 | return return in field | type_tracker.rb:7:5:9:7 | return return in field |
-| type_tracker.rb:7:5:9:7 | return return in field | type_tracker.rb:15:10:15:18 | call to field |
-| type_tracker.rb:7:5:9:7 | self (field) | type_tracker.rb:7:5:9:7 | self (field) |
-| type_tracker.rb:7:5:9:7 | self (field) | type_tracker.rb:8:9:8:14 | self |
 | type_tracker.rb:7:5:9:7 | self in field | type_tracker.rb:7:5:9:7 | self (field) |
 | type_tracker.rb:7:5:9:7 | self in field | type_tracker.rb:7:5:9:7 | self in field |
 | type_tracker.rb:7:5:9:7 | self in field | type_tracker.rb:8:9:8:14 | self |
 | type_tracker.rb:8:9:8:14 | @field | type_tracker.rb:3:14:3:23 | call to field |
-| type_tracker.rb:8:9:8:14 | @field | type_tracker.rb:7:5:9:7 | return return in field |
 | type_tracker.rb:8:9:8:14 | @field | type_tracker.rb:8:9:8:14 | @field |
 | type_tracker.rb:8:9:8:14 | @field | type_tracker.rb:15:10:15:18 | call to field |
 | type_tracker.rb:12:1:16:3 | &block | type_tracker.rb:12:1:16:3 | &block |
 | type_tracker.rb:12:1:16:3 | m | type_tracker.rb:12:1:16:3 | m |
-| type_tracker.rb:12:1:16:3 | return return in m | type_tracker.rb:12:1:16:3 | return return in m |
-| type_tracker.rb:12:1:16:3 | self (m) | type_tracker.rb:12:1:16:3 | self (m) |
-| type_tracker.rb:12:1:16:3 | self (m) | type_tracker.rb:15:5:15:18 | self |
 | type_tracker.rb:12:1:16:3 | self in m | type_tracker.rb:12:1:16:3 | self (m) |
 | type_tracker.rb:12:1:16:3 | self in m | type_tracker.rb:12:1:16:3 | self in m |
 | type_tracker.rb:12:1:16:3 | self in m | type_tracker.rb:15:5:15:18 | self |
@@ -470,16 +332,10 @@ trackEnd
 | type_tracker.rb:14:17:14:23 | "hello" | type_tracker.rb:14:17:14:23 | __synth__0 |
 | type_tracker.rb:14:17:14:23 | "hello" | type_tracker.rb:15:10:15:18 | call to field |
 | type_tracker.rb:14:17:14:23 | __synth__0 | type_tracker.rb:14:17:14:23 | __synth__0 |
-| type_tracker.rb:15:5:15:18 | call to puts | type_tracker.rb:12:1:16:3 | return return in m |
 | type_tracker.rb:15:5:15:18 | call to puts | type_tracker.rb:15:5:15:18 | call to puts |
 | type_tracker.rb:15:10:15:18 | call to field | type_tracker.rb:15:10:15:18 | call to field |
 | type_tracker.rb:18:1:21:3 | &block | type_tracker.rb:18:1:21:3 | &block |
 | type_tracker.rb:18:1:21:3 | positional | type_tracker.rb:18:1:21:3 | positional |
-| type_tracker.rb:18:1:21:3 | return return in positional | type_tracker.rb:18:1:21:3 | return return in positional |
-| type_tracker.rb:18:1:21:3 | return return in positional | type_tracker.rb:23:1:23:16 | call to positional |
-| type_tracker.rb:18:1:21:3 | self (positional) | type_tracker.rb:18:1:21:3 | self (positional) |
-| type_tracker.rb:18:1:21:3 | self (positional) | type_tracker.rb:19:5:19:11 | self |
-| type_tracker.rb:18:1:21:3 | self (positional) | type_tracker.rb:20:5:20:11 | self |
 | type_tracker.rb:18:1:21:3 | self in positional | type_tracker.rb:18:1:21:3 | self (positional) |
 | type_tracker.rb:18:1:21:3 | self in positional | type_tracker.rb:18:1:21:3 | self in positional |
 | type_tracker.rb:18:1:21:3 | self in positional | type_tracker.rb:19:5:19:11 | self |
@@ -487,17 +343,12 @@ trackEnd
 | type_tracker.rb:18:16:18:17 | p1 | type_tracker.rb:18:16:18:17 | p1 |
 | type_tracker.rb:18:16:18:17 | p1 | type_tracker.rb:18:16:18:17 | p1 |
 | type_tracker.rb:18:16:18:17 | p1 | type_tracker.rb:18:16:18:17 | p1 |
-| type_tracker.rb:18:16:18:17 | p1 | type_tracker.rb:18:16:18:17 | p1 |
-| type_tracker.rb:18:16:18:17 | p1 | type_tracker.rb:19:10:19:11 | p1 |
 | type_tracker.rb:18:16:18:17 | p1 | type_tracker.rb:19:10:19:11 | p1 |
 | type_tracker.rb:18:20:18:21 | p2 | type_tracker.rb:18:20:18:21 | p2 |
 | type_tracker.rb:18:20:18:21 | p2 | type_tracker.rb:18:20:18:21 | p2 |
 | type_tracker.rb:18:20:18:21 | p2 | type_tracker.rb:18:20:18:21 | p2 |
-| type_tracker.rb:18:20:18:21 | p2 | type_tracker.rb:18:20:18:21 | p2 |
-| type_tracker.rb:18:20:18:21 | p2 | type_tracker.rb:20:10:20:11 | p2 |
 | type_tracker.rb:18:20:18:21 | p2 | type_tracker.rb:20:10:20:11 | p2 |
 | type_tracker.rb:19:5:19:11 | call to puts | type_tracker.rb:19:5:19:11 | call to puts |
-| type_tracker.rb:20:5:20:11 | call to puts | type_tracker.rb:18:1:21:3 | return return in positional |
 | type_tracker.rb:20:5:20:11 | call to puts | type_tracker.rb:20:5:20:11 | call to puts |
 | type_tracker.rb:20:5:20:11 | call to puts | type_tracker.rb:23:1:23:16 | call to positional |
 | type_tracker.rb:23:1:23:16 | call to positional | type_tracker.rb:23:1:23:16 | call to positional |
@@ -512,13 +363,6 @@ trackEnd
 | type_tracker.rb:25:1:28:3 | &block | type_tracker.rb:25:1:28:3 | &block |
 | type_tracker.rb:25:1:28:3 | **kwargs | type_tracker.rb:25:1:28:3 | **kwargs |
 | type_tracker.rb:25:1:28:3 | keyword | type_tracker.rb:25:1:28:3 | keyword |
-| type_tracker.rb:25:1:28:3 | return return in keyword | type_tracker.rb:25:1:28:3 | return return in keyword |
-| type_tracker.rb:25:1:28:3 | return return in keyword | type_tracker.rb:30:1:30:21 | call to keyword |
-| type_tracker.rb:25:1:28:3 | return return in keyword | type_tracker.rb:31:1:31:21 | call to keyword |
-| type_tracker.rb:25:1:28:3 | return return in keyword | type_tracker.rb:32:1:32:27 | call to keyword |
-| type_tracker.rb:25:1:28:3 | self (keyword) | type_tracker.rb:25:1:28:3 | self (keyword) |
-| type_tracker.rb:25:1:28:3 | self (keyword) | type_tracker.rb:26:5:26:11 | self |
-| type_tracker.rb:25:1:28:3 | self (keyword) | type_tracker.rb:27:5:27:11 | self |
 | type_tracker.rb:25:1:28:3 | self in keyword | type_tracker.rb:25:1:28:3 | self (keyword) |
 | type_tracker.rb:25:1:28:3 | self in keyword | type_tracker.rb:25:1:28:3 | self in keyword |
 | type_tracker.rb:25:1:28:3 | self in keyword | type_tracker.rb:26:5:26:11 | self |
@@ -526,17 +370,12 @@ trackEnd
 | type_tracker.rb:25:13:25:14 | p1 | type_tracker.rb:25:13:25:14 | p1 |
 | type_tracker.rb:25:13:25:14 | p1 | type_tracker.rb:25:13:25:14 | p1 |
 | type_tracker.rb:25:13:25:14 | p1 | type_tracker.rb:25:13:25:14 | p1 |
-| type_tracker.rb:25:13:25:14 | p1 | type_tracker.rb:25:13:25:14 | p1 |
-| type_tracker.rb:25:13:25:14 | p1 | type_tracker.rb:26:10:26:11 | p1 |
 | type_tracker.rb:25:13:25:14 | p1 | type_tracker.rb:26:10:26:11 | p1 |
 | type_tracker.rb:25:18:25:19 | p2 | type_tracker.rb:25:18:25:19 | p2 |
 | type_tracker.rb:25:18:25:19 | p2 | type_tracker.rb:25:18:25:19 | p2 |
 | type_tracker.rb:25:18:25:19 | p2 | type_tracker.rb:25:18:25:19 | p2 |
-| type_tracker.rb:25:18:25:19 | p2 | type_tracker.rb:25:18:25:19 | p2 |
-| type_tracker.rb:25:18:25:19 | p2 | type_tracker.rb:27:10:27:11 | p2 |
 | type_tracker.rb:25:18:25:19 | p2 | type_tracker.rb:27:10:27:11 | p2 |
 | type_tracker.rb:26:5:26:11 | call to puts | type_tracker.rb:26:5:26:11 | call to puts |
-| type_tracker.rb:27:5:27:11 | call to puts | type_tracker.rb:25:1:28:3 | return return in keyword |
 | type_tracker.rb:27:5:27:11 | call to puts | type_tracker.rb:27:5:27:11 | call to puts |
 | type_tracker.rb:27:5:27:11 | call to puts | type_tracker.rb:30:1:30:21 | call to keyword |
 | type_tracker.rb:27:5:27:11 | call to puts | type_tracker.rb:31:1:31:21 | call to keyword |
@@ -587,80 +426,45 @@ trackEnd
 | type_tracker.rb:32:26:32:26 | 8 | type_tracker.rb:26:10:26:11 | p1 |
 | type_tracker.rb:32:26:32:26 | 8 | type_tracker.rb:32:26:32:26 | 8 |
 | type_tracker.rb:34:1:53:3 | &block | type_tracker.rb:34:1:53:3 | &block |
-| type_tracker.rb:34:1:53:3 | return return in throughArray | type_tracker.rb:34:1:53:3 | return return in throughArray |
 | type_tracker.rb:34:1:53:3 | self in throughArray | type_tracker.rb:34:1:53:3 | self in throughArray |
 | type_tracker.rb:34:1:53:3 | throughArray | type_tracker.rb:34:1:53:3 | throughArray |
-| type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:34:1:53:3 | return return in throughArray |
-| type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:34:1:53:3 | return return in throughArray |
-| type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:34:18:34:20 | obj |
 | type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:34:18:34:20 | obj |
 | type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:34:18:34:20 | obj |
 | type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:34:18:34:20 | obj |
 | type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:35:12:35:14 | obj |
-| type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:35:12:35:14 | obj |
-| type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:36:5:36:10 | ...[...] |
 | type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:36:5:36:10 | ...[...] |
 | type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:39:5:39:12 | __synth__0 |
-| type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:39:5:39:12 | __synth__0 |
-| type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:39:5:39:18 | ... |
 | type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:39:5:39:18 | ... |
 | type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:39:16:39:18 | ... = ... |
-| type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:39:16:39:18 | ... = ... |
-| type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:39:16:39:18 | __synth__0 |
 | type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:39:16:39:18 | __synth__0 |
 | type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:39:16:39:18 | obj |
-| type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:39:16:39:18 | obj |
-| type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:40:5:40:12 | ...[...] |
 | type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:40:5:40:12 | ...[...] |
 | type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:43:5:43:13 | __synth__0 |
-| type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:43:5:43:13 | __synth__0 |
-| type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:43:5:43:19 | ... |
 | type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:43:5:43:19 | ... |
 | type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:43:17:43:19 | ... = ... |
-| type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:43:17:43:19 | ... = ... |
-| type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:43:17:43:19 | __synth__0 |
 | type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:43:17:43:19 | __synth__0 |
 | type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:43:17:43:19 | obj |
-| type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:43:17:43:19 | obj |
-| type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:44:5:44:13 | ...[...] |
 | type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:44:5:44:13 | ...[...] |
 | type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:47:5:47:13 | __synth__0 |
-| type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:47:5:47:13 | __synth__0 |
-| type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:47:5:47:19 | ... |
 | type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:47:5:47:19 | ... |
 | type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:47:17:47:19 | ... = ... |
-| type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:47:17:47:19 | ... = ... |
-| type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:47:17:47:19 | __synth__0 |
 | type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:47:17:47:19 | __synth__0 |
 | type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:47:17:47:19 | obj |
-| type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:47:17:47:19 | obj |
-| type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:51:5:51:13 | __synth__0 |
 | type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:51:5:51:13 | __synth__0 |
 | type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:51:5:51:19 | ... |
-| type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:51:5:51:19 | ... |
-| type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:51:17:51:19 | ... = ... |
 | type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:51:17:51:19 | ... = ... |
 | type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:51:17:51:19 | __synth__0 |
-| type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:51:17:51:19 | __synth__0 |
-| type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:51:17:51:19 | obj |
 | type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:51:17:51:19 | obj |
 | type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:52:5:52:13 | ...[...] |
-| type_tracker.rb:34:18:34:20 | obj | type_tracker.rb:52:5:52:13 | ...[...] |
-| type_tracker.rb:34:23:34:23 | y | type_tracker.rb:34:23:34:23 | y |
 | type_tracker.rb:34:23:34:23 | y | type_tracker.rb:34:23:34:23 | y |
 | type_tracker.rb:34:23:34:23 | y | type_tracker.rb:34:23:34:23 | y |
 | type_tracker.rb:34:23:34:23 | y | type_tracker.rb:34:23:34:23 | y |
 | type_tracker.rb:34:23:34:23 | y | type_tracker.rb:39:11:39:11 | y |
-| type_tracker.rb:34:23:34:23 | y | type_tracker.rb:39:11:39:11 | y |
-| type_tracker.rb:34:23:34:23 | y | type_tracker.rb:44:12:44:12 | y |
 | type_tracker.rb:34:23:34:23 | y | type_tracker.rb:44:12:44:12 | y |
 | type_tracker.rb:34:23:34:23 | y | type_tracker.rb:51:12:51:12 | y |
-| type_tracker.rb:34:23:34:23 | y | type_tracker.rb:51:12:51:12 | y |
 | type_tracker.rb:34:26:34:26 | z | type_tracker.rb:34:26:34:26 | z |
 | type_tracker.rb:34:26:34:26 | z | type_tracker.rb:34:26:34:26 | z |
 | type_tracker.rb:34:26:34:26 | z | type_tracker.rb:34:26:34:26 | z |
-| type_tracker.rb:34:26:34:26 | z | type_tracker.rb:34:26:34:26 | z |
-| type_tracker.rb:34:26:34:26 | z | type_tracker.rb:52:12:52:12 | z |
 | type_tracker.rb:34:26:34:26 | z | type_tracker.rb:52:12:52:12 | z |
 | type_tracker.rb:35:5:35:7 | tmp | type_tracker.rb:35:5:35:7 | tmp |
 | type_tracker.rb:35:11:35:15 | Array | type_tracker.rb:35:11:35:15 | Array |
@@ -743,29 +547,22 @@ trackEnd
 | type_tracker.rb:50:14:50:26 | call to [] | type_tracker.rb:50:14:50:26 | call to [] |
 | type_tracker.rb:50:14:50:26 | call to [] | type_tracker.rb:51:5:51:10 | array4 |
 | type_tracker.rb:50:14:50:26 | call to [] | type_tracker.rb:52:5:52:10 | array4 |
-| type_tracker.rb:50:15:50:15 | 1 | type_tracker.rb:34:1:53:3 | return return in throughArray |
 | type_tracker.rb:50:15:50:15 | 1 | type_tracker.rb:50:15:50:15 | 1 |
 | type_tracker.rb:50:15:50:15 | 1 | type_tracker.rb:52:5:52:13 | ...[...] |
-| type_tracker.rb:50:17:50:17 | 2 | type_tracker.rb:34:1:53:3 | return return in throughArray |
 | type_tracker.rb:50:17:50:17 | 2 | type_tracker.rb:50:17:50:17 | 2 |
 | type_tracker.rb:50:17:50:17 | 2 | type_tracker.rb:52:5:52:13 | ...[...] |
-| type_tracker.rb:50:19:50:19 | 3 | type_tracker.rb:34:1:53:3 | return return in throughArray |
 | type_tracker.rb:50:19:50:19 | 3 | type_tracker.rb:50:19:50:19 | 3 |
 | type_tracker.rb:50:19:50:19 | 3 | type_tracker.rb:52:5:52:13 | ...[...] |
-| type_tracker.rb:50:21:50:21 | 4 | type_tracker.rb:34:1:53:3 | return return in throughArray |
 | type_tracker.rb:50:21:50:21 | 4 | type_tracker.rb:50:21:50:21 | 4 |
 | type_tracker.rb:50:21:50:21 | 4 | type_tracker.rb:52:5:52:13 | ...[...] |
-| type_tracker.rb:50:23:50:23 | 5 | type_tracker.rb:34:1:53:3 | return return in throughArray |
 | type_tracker.rb:50:23:50:23 | 5 | type_tracker.rb:50:23:50:23 | 5 |
 | type_tracker.rb:50:23:50:23 | 5 | type_tracker.rb:52:5:52:13 | ...[...] |
-| type_tracker.rb:50:25:50:25 | 6 | type_tracker.rb:34:1:53:3 | return return in throughArray |
 | type_tracker.rb:50:25:50:25 | 6 | type_tracker.rb:50:25:50:25 | 6 |
 | type_tracker.rb:50:25:50:25 | 6 | type_tracker.rb:52:5:52:13 | ...[...] |
 | type_tracker.rb:51:5:51:10 | [post] array4 | type_tracker.rb:51:5:51:10 | [post] array4 |
 | type_tracker.rb:51:5:51:10 | [post] array4 | type_tracker.rb:52:5:52:10 | array4 |
 | type_tracker.rb:51:5:51:13 | call to []= | type_tracker.rb:51:5:51:13 | call to []= |
 | type_tracker.rb:51:17:51:19 | __synth__0 | type_tracker.rb:51:17:51:19 | __synth__0 |
-| type_tracker.rb:52:5:52:13 | ...[...] | type_tracker.rb:34:1:53:3 | return return in throughArray |
 | type_tracker.rb:52:5:52:13 | ...[...] | type_tracker.rb:52:5:52:13 | ...[...] |
 forwardButNoBackwardFlow
 backwardButNoForwardFlow


### PR DESCRIPTION
This PR is about porting the join-order improvement from https://github.com/github/codeql/pull/12979 to the type tracking library shared between Ruby and Python. The motivation for Ruby is to be able to get rid of canonical return nodes, which were only introduced to avoid bad joins during type tracking (and dually, to have steps from parameter nodes to their corresponding SSA node be simple local flow steps instead of call steps).

The join-order from https://github.com/github/codeql/pull/12979 is implemented in the first commit, and it is about getting exactly this join-order in the various step relations:

```ql
TypeTracker step(TypeTracker t, LocalSourceNode nodeFrom, LocalSourceNode nodeTo) {
    exists(StepSummary summary |
      step(nodeFrom, _, summary) and
      result = t.append(summary) and
      step(nodeFrom, nodeTo, summary) // important to only perform this join after `nodeFrom` and `summary` have been restricted above
    )
  }
```

The above, however, does not work when type tracking is used in mutual recursion with the call graph construction, because `step` becomes a recursive call (or, actually the subset of `step` that is `stepCall` becomes recursive), which means that we will have a conjunct with 3 recursive calls (the two `stepCall` calls and the recursive type tracking call itself). The solution is to split this non-linear recursion into two non-linear predicates: one that first joins with the projected `stepCall` relation (e.g. https://github.com/github/codeql/pull/12964/commits/13ada1e6ad4643bf146b456c26fbd844d752dbdb#diff-26e3a30a43f4e4f576971a851f3a70fd7c796624c81c5387d6cf6b2db3ed58edR506-R507), followed by a predicate that joins with the full `stepCall` relation (e.g. https://github.com/github/codeql/pull/12964/commits/13ada1e6ad4643bf146b456c26fbd844d752dbdb#diff-26e3a30a43f4e4f576971a851f3a70fd7c796624c81c5387d6cf6b2db3ed58edR493).

The second commit does the above for Ruby, and additionally (1) gets rid of canonical return nodes (`SynthReturnNode`), (2) no longer treats SSA definitions for parameters as local source nodes, (3) treats the step from parameter to SSA definition as a normal local flow step in type tracking, as in normal data flow, and (4) exposes `SelfParameterNode` publicly, for use in queries/libraries.

The third commit applies the same call graph join-order improvements to Python, as mentioned above.

CC: @aschackmull 