### PR TITLE
Java: Fix sink model generator for instance parameters

### DIFF
--- a/java/ql/src/utils/modelgenerator/internal/CaptureModelsSpecific.qll
+++ b/java/ql/src/utils/modelgenerator/internal/CaptureModelsSpecific.qll
@@ -236,7 +236,7 @@ predicate apiSource(DataFlow::Node source) {
 string asInputArgumentSpecific(DataFlow::Node source) {
   exists(int pos |
     source.(DataFlow::ParameterNode).isParameterOf(_, pos) and
-    result = "Argument[" + pos + "]"
+    if pos >= 0 then result = "Argument[" + pos + "]" else result = qualifierString()
   )
   or
   source.asExpr() instanceof J::FieldAccess and


### PR DESCRIPTION
This PR fixes the model generator when it's generating sinks that are `InstanceParameterNode`s. Previously it generated `input` columns like `Argument[-1]`,  but they should be `Argument[this]`.