### PR TITLE
Python: Summaries for container store step 

### DIFF
--- a/python/ql/lib/semmle/python/dataflow/new/FlowSummary.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/FlowSummary.qll
@@ -28,6 +28,27 @@ module SummaryComponent {
   /** Gets a summary component that represents a list element. */
   SummaryComponent listElement() { result = content(any(ListElementContent c)) }
 
+  /** Gets a summary component that represents a set element. */
+  SummaryComponent setElement() { result = content(any(SetElementContent c)) }
+
+  /** Gets a summary component that represents a tuple element. */
+  SummaryComponent tupleElement(int index) {
+    exists(TupleElementContent c | c.getIndex() = index and result = content(c))
+  }
+
+  /** Gets a summary component that represents a dictionary element. */
+  SummaryComponent dictionaryElement(string key) {
+    exists(DictionaryElementContent c | c.getKey() = key and result = content(c))
+  }
+
+  /** Gets a summary component that represents a dictionary element at any key. */
+  SummaryComponent dictionaryElementAny() { result = content(any(DictionaryElementAnyContent c)) }
+
+  /** Gets a summary component that represents an attribute element. */
+  SummaryComponent attribute(string attr) {
+    exists(AttributeContent c | c.getAttribute() = attr and result = content(c))
+  }
+
   /** Gets a summary component that represents the return value of a call. */
   SummaryComponent return() { result = SC::return(any(ReturnKind rk)) }
 }

--- a/python/ql/lib/semmle/python/dataflow/new/internal/FlowSummaryImplSpecific.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/FlowSummaryImplSpecific.qll
@@ -105,6 +105,27 @@ predicate neutralElement(FlowSummary::SummarizedCallable c, string provenance) {
 SummaryComponent interpretComponentSpecific(AccessPathToken c) {
   c = "ListElement" and
   result = FlowSummary::SummaryComponent::listElement()
+  or
+  c = "SetElement" and
+  result = FlowSummary::SummaryComponent::setElement()
+  or
+  exists(int index |
+    c.getAnArgument("TupleElement") = index.toString() and
+    result = FlowSummary::SummaryComponent::tupleElement(index)
+  )
+  or
+  exists(string key |
+    c.getAnArgument("DictionaryElement") = key and
+    result = FlowSummary::SummaryComponent::dictionaryElement(key)
+  )
+  or
+  c = "DictionaryElementAny" and
+  result = FlowSummary::SummaryComponent::dictionaryElementAny()
+  or
+  exists(string attr |
+    c.getAnArgument("Attribute") = attr and
+    result = FlowSummary::SummaryComponent::attribute(attr)
+  )
 }
 
 /** Gets the textual representation of a summary component in the format used for flow summaries. */

--- a/python/ql/lib/semmle/python/dataflow/new/internal/TaintTrackingPrivate.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/TaintTrackingPrivate.qll
@@ -162,7 +162,7 @@ predicate stringManipulation(DataFlow::CfgNode nodeFrom, DataFlow::CfgNode nodeT
  * is currently very imprecise, as an example, since we model `dict.get`, we treat any
  * `<tainted object>.get(<arg>)` will be tainted, whether it's true or not.
  */
-predicate containerStep(DataFlow::CfgNode nodeFrom, DataFlow::Node nodeTo) {
+predicate containerStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
   // construction by literal
   //
   // TODO: once we have proper flow-summary modeling, we might not need this step any

--- a/python/ql/lib/semmle/python/frameworks/Stdlib.qll
+++ b/python/ql/lib/semmle/python/frameworks/Stdlib.qll
@@ -3779,6 +3779,62 @@ private module StdlibPrivate {
     override DataFlow::Node getAPathArgument() { result = this.getAnInput() }
   }
 
+  // ---------------------------------------------------------------------------
+  // Flow summaries for funtions contructing containers
+  // ---------------------------------------------------------------------------
+  /** A flow summary for `dict`. */
+  class DictSummary extends SummarizedCallable {
+    DictSummary() { this = "builtins.dict" }
+
+    override DataFlow::CallCfgNode getACall() { result = API::builtin("dict").getACall() }
+
+    override DataFlow::ArgumentNode getACallback() {
+      result = API::builtin("dict").getAValueReachableFromSource()
+    }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      exists(DataFlow::DictionaryElementContent dc, string key | key = dc.getKey() |
+        input = "Argument[0].DictionaryElement[" + key + "]" and
+        output = "ReturnValue.DictionaryElement[" + key + "]" and
+        preservesValue = true
+      )
+      or
+      exists(DataFlow::DictionaryElementContent dc, string key | key = dc.getKey() |
+        input = "Argument[" + key + ":]" and
+        output = "ReturnValue.DictionaryElement[" + key + "]" and
+        preservesValue = true
+      )
+      or
+      input = "Argument[0]" and
+      output = "ReturnValue" and
+      preservesValue = false
+    }
+  }
+
+  /** A flow summary for `list`. */
+  class ListSummary extends SummarizedCallable {
+    ListSummary() { this = "builtins.list" }
+
+    override DataFlow::CallCfgNode getACall() { result = API::builtin("list").getACall() }
+
+    override DataFlow::ArgumentNode getACallback() {
+      result = API::builtin("list").getAValueReachableFromSource()
+    }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      input = "Argument[0].ListElement" and
+      output = "ReturnValue.ListElement" and
+      preservesValue = true
+      or
+      input = "Argument[0]" and
+      output = "ReturnValue" and
+      preservesValue = false
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Flow summaries for functions operating on containers
+  // ---------------------------------------------------------------------------
   /** A flow summary for `reversed`. */
   class ReversedSummary extends SummarizedCallable {
     ReversedSummary() { this = "builtins.reversed" }
@@ -3792,6 +3848,73 @@ private module StdlibPrivate {
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       input = "Argument[0].ListElement" and
       output = "ReturnValue.ListElement" and
+      preservesValue = true
+      or
+      input = "Argument[0]" and
+      output = "ReturnValue" and
+      preservesValue = false
+    }
+  }
+
+  /** A flow summary for `sorted`. */
+  class SortedSummary extends SummarizedCallable {
+    SortedSummary() { this = "builtins.sorted" }
+
+    override DataFlow::CallCfgNode getACall() { result = API::builtin("sorted").getACall() }
+
+    override DataFlow::ArgumentNode getACallback() {
+      result = API::builtin("sorted").getAValueReachableFromSource()
+    }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      input = "Argument[0].ListElement" and
+      output = "ReturnValue.ListElement" and
+      preservesValue = true
+      or
+      input = "Argument[0]" and
+      output = "ReturnValue" and
+      preservesValue = false
+    }
+  }
+
+  /** A flow summary for `iter`. */
+  class IterSummary extends SummarizedCallable {
+    IterSummary() { this = "builtins.iter" }
+
+    override DataFlow::CallCfgNode getACall() { result = API::builtin("iter").getACall() }
+
+    override DataFlow::ArgumentNode getACallback() {
+      result = API::builtin("iter").getAValueReachableFromSource()
+    }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      input = "Argument[0].ListElement" and
+      output = "ReturnValue.ListElement" and
+      preservesValue = true
+      or
+      input = "Argument[0]" and
+      output = "ReturnValue" and
+      preservesValue = false
+    }
+  }
+
+  /** A flow summary for `next`. */
+  class NextSummary extends SummarizedCallable {
+    NextSummary() { this = "builtins.next" }
+
+    override DataFlow::CallCfgNode getACall() { result = API::builtin("next").getACall() }
+
+    override DataFlow::ArgumentNode getACallback() {
+      result = API::builtin("next").getAValueReachableFromSource()
+    }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      input = "Argument[0].ListElement" and
+      output = "ReturnValue" and
+      preservesValue = true
+      or
+      input = "Argument[1]" and
+      output = "ReturnValue" and
       preservesValue = true
     }
   }

--- a/python/ql/test/experimental/dataflow/tainttracking/defaultAdditionalTaintStep/test_collections.py
+++ b/python/ql/test/experimental/dataflow/tainttracking/defaultAdditionalTaintStep/test_collections.py
@@ -37,6 +37,14 @@ def test_construction():
         tuple(tainted_list), # $ tainted
         set(tainted_list), # $ tainted
         frozenset(tainted_list), # $ tainted
+        dict(tainted_dict), # $ tainted
+        dict(k = tainted_string)["k"], # $ tainted
+        dict(dict(k = tainted_string))["k"], # $ tainted
+        dict(["k", tainted_string]), # $ tainted
+    )
+
+    ensure_not_tainted(
+        dict(k = tainted_string)["k1"]
     )
 
 
@@ -50,6 +58,31 @@ def test_access(x, y, z):
 
         sorted(tainted_list), # $ tainted
         reversed(tainted_list), # $ tainted
+        iter(tainted_list), # $ tainted
+        next(iter(tainted_list)), # $ tainted
+        [i for i in tainted_list], # $ tainted
+        [tainted_list for _i in [1,2,3]], # $ MISSING: tainted
+    )
+
+    a, b, c = tainted_list[0:3]
+    ensure_tainted(a, b, c) # $ tainted
+
+    for h in tainted_list:
+        ensure_tainted(h) # $ tainted
+    for i in reversed(tainted_list):
+        ensure_tainted(i) # $ tainted
+
+
+def test_access_explicit(x, y, z):
+    tainted_list = [TAINTED_STRING]
+
+    ensure_tainted(
+        tainted_list[0], # $ tainted
+        tainted_list[x], # $ tainted
+        tainted_list[y:z], # $ tainted
+
+        sorted(tainted_list)[0], # $ tainted
+        reversed(tainted_list)[0], # $ tainted
         iter(tainted_list), # $ tainted
         next(iter(tainted_list)), # $ tainted
         [i for i in tainted_list], # $ tainted


### PR DESCRIPTION
This will turn all the bespoke store steps in `TaintTrackingPrivate::containerStep` into flow summaries.

I expect to rebase and clean up the history at some point. But for now, this PR allows visibility into the progress.