### PR TITLE
JS: Make `Locatable.toString` cached

### DIFF
--- a/javascript/ql/lib/semmle/javascript/Locations.qll
+++ b/javascript/ql/lib/semmle/javascript/Locations.qll
@@ -127,6 +127,7 @@ class Locatable extends @locatable {
   int getNumLines() { result = this.getLocation().getNumLines() }
 
   /** Gets a textual representation of this element. */
+  cached
   string toString() {
     // to be overridden by subclasses
     none()


### PR DESCRIPTION
This predicate was causing slowdowns when removing the standard order in the optimiser, and those slowdowns were amplified because the predicate was recomputed many times.