### PR TITLE
Java: Force high precision for MapValueContent.

### DIFF
--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowPrivate.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowPrivate.qll
@@ -374,7 +374,7 @@ int accessPathLimit() { result = 5 }
  * precision. This disables adaptive access path precision for such access paths.
  */
 predicate forceHighPrecision(Content c) {
-  c instanceof ArrayContent or c instanceof CollectionContent
+  c instanceof ArrayContent or c instanceof CollectionContent or c instanceof MapValueContent
 }
 
 /** Holds if `n` should be hidden from path explanations. */


### PR DESCRIPTION
Recent query result investigations highlighted that this could potentially be a relevant precision and hopefully performance improvement. Let's see what DCA says.