### PR TITLE
CPP: Make implicit this receivers explicit

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/internal/TranslatedElement.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/internal/TranslatedElement.qll
@@ -821,7 +821,7 @@ abstract class TranslatedElement extends TTranslatedElement {
   abstract Locatable getAst();
 
   /** DEPRECATED: Alias for getAst */
-  deprecated Locatable getAST() { result = getAst() }
+  deprecated Locatable getAST() { result = this.getAst() }
 
   /**
    * Get the first instruction to be executed in the evaluation of this element.
@@ -831,7 +831,7 @@ abstract class TranslatedElement extends TTranslatedElement {
   /**
    * Get the immediate child elements of this element.
    */
-  final TranslatedElement getAChild() { result = getChild(_) }
+  final TranslatedElement getAChild() { result = this.getChild(_) }
 
   /**
    * Gets the immediate child element of this element. The `id` is unique
@@ -844,25 +844,25 @@ abstract class TranslatedElement extends TTranslatedElement {
    * Gets the an identifier string for the element. This id is unique within
    * the scope of the element's function.
    */
-  final int getId() { result = getUniqueId() }
+  final int getId() { result = this.getUniqueId() }
 
   private TranslatedElement getChildByRank(int rankIndex) {
     result =
-      rank[rankIndex + 1](TranslatedElement child, int id | child = getChild(id) | child order by id)
+      rank[rankIndex + 1](TranslatedElement child, int id | child = this.getChild(id) | child order by id)
   }
 
   language[monotonicAggregates]
   private int getDescendantCount() {
     result =
-      1 + sum(TranslatedElement child | child = getChildByRank(_) | child.getDescendantCount())
+      1 + sum(TranslatedElement child | child = this.getChildByRank(_) | child.getDescendantCount())
   }
 
   private int getUniqueId() {
-    if not exists(getParent())
+    if not exists(this.getParent())
     then result = 0
     else
       exists(TranslatedElement parent |
-        parent = getParent() and
+        parent = this.getParent() and
         if this = parent.getChildByRank(0)
         then result = 1 + parent.getUniqueId()
         else
@@ -908,7 +908,7 @@ abstract class TranslatedElement extends TTranslatedElement {
    * there is no enclosing `try`.
    */
   Instruction getExceptionSuccessorInstruction() {
-    result = getParent().getExceptionSuccessorInstruction()
+    result = this.getParent().getExceptionSuccessorInstruction()
   }
 
   /**
@@ -1022,14 +1022,14 @@ abstract class TranslatedElement extends TTranslatedElement {
     exists(Locatable ast |
       result.getAst() = ast and
       result.getTag() = tag and
-      hasTempVariableAndAst(tag, ast)
+      this.hasTempVariableAndAst(tag, ast)
     )
   }
 
   pragma[noinline]
   private predicate hasTempVariableAndAst(TempVariableTag tag, Locatable ast) {
-    hasTempVariable(tag, _) and
-    ast = getAst()
+    this.hasTempVariable(tag, _) and
+    ast = this.getAst()
   }
 
   /**

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/internal/TranslatedInitialization.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/internal/TranslatedInitialization.qll
@@ -35,64 +35,64 @@ abstract class InitializationContext extends TranslatedElement {
  * declarations, `return` statements, and `throw` expressions.
  */
 abstract class TranslatedVariableInitialization extends TranslatedElement, InitializationContext {
-  final override TranslatedElement getChild(int id) { id = 0 and result = getInitialization() }
+  final override TranslatedElement getChild(int id) { id = 0 and result = this.getInitialization() }
 
   final override Instruction getFirstInstruction() {
-    result = getInstruction(InitializerVariableAddressTag())
+    result = this.getInstruction(InitializerVariableAddressTag())
   }
 
   override predicate hasInstruction(Opcode opcode, InstructionTag tag, CppType resultType) {
     tag = InitializerVariableAddressTag() and
     opcode instanceof Opcode::VariableAddress and
-    resultType = getTypeForGLValue(getTargetType())
+    resultType = getTypeForGLValue(this.getTargetType())
     or
-    hasUninitializedInstruction() and
+    this.hasUninitializedInstruction() and
     tag = InitializerStoreTag() and
     opcode instanceof Opcode::Uninitialized and
-    resultType = getTypeForPRValue(getTargetType())
+    resultType = getTypeForPRValue(this.getTargetType())
   }
 
   override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) {
     (
       tag = InitializerVariableAddressTag() and
       kind instanceof GotoEdge and
-      if hasUninitializedInstruction()
-      then result = getInstruction(InitializerStoreTag())
-      else result = getInitialization().getFirstInstruction()
+      if this.hasUninitializedInstruction()
+      then result = this.getInstruction(InitializerStoreTag())
+      else result = this.getInitialization().getFirstInstruction()
     )
     or
-    hasUninitializedInstruction() and
+    this.hasUninitializedInstruction() and
     kind instanceof GotoEdge and
     tag = InitializerStoreTag() and
     (
-      result = getInitialization().getFirstInstruction()
+      result = this.getInitialization().getFirstInstruction()
       or
-      not exists(getInitialization()) and result = getInitializationSuccessor()
+      not exists(this.getInitialization()) and resuthis.lt = getInitializationSuccessor()
     )
   }
 
   final override Instruction getChildSuccessor(TranslatedElement child) {
-    child = getInitialization() and result = getInitializationSuccessor()
+    child = this.getInitialization() and resuthis.lt = getInitializationSuccessor()
   }
 
   override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
-    hasUninitializedInstruction() and
+    this.hasUninitializedInstruction() and
     tag = InitializerStoreTag() and
     operandTag instanceof AddressOperandTag and
-    result = getInstruction(InitializerVariableAddressTag())
+    result = this.getInstruction(InitializerVariableAddressTag())
   }
 
   final override IRVariable getInstructionVariable(InstructionTag tag) {
     (
       tag = InitializerVariableAddressTag()
       or
-      hasUninitializedInstruction() and tag = InitializerStoreTag()
+      this.hasUninitializedInstruction() and tag = InitializerStoreTag()
     ) and
-    result = getIRVariable()
+    result = this.getIRVariable()
   }
 
   final override Instruction getTargetAddress() {
-    result = getInstruction(InitializerVariableAddressTag())
+    result = this.getInstruction(InitializerVariableAddressTag())
   }
 
   /**
@@ -116,13 +116,13 @@ abstract class TranslatedVariableInitialization extends TranslatedElement, Initi
    */
   final predicate hasUninitializedInstruction() {
     (
-      not exists(getInitialization()) or
-      getInitialization() instanceof TranslatedListInitialization or
-      getInitialization() instanceof TranslatedConstructorInitialization or
-      getInitialization().(TranslatedStringLiteralInitialization).zeroInitRange(_, _)
+      not exists(this.getInitialization()) or
+      this.getInitialization() instanceof TranslatedListInitialization or
+      this.getInitialization() instanceof TranslatedConstructorInitialization or
+      this.getInitialization().(TranslatedStringLiteralInitialization).zeroInitRange(_, _)
     ) and
     // Variables with static or thread-local storage duration are zero-initialized at program startup.
-    getIRVariable() instanceof IRAutomaticVariable
+    this.getIRVariable() instanceof IRAutomaticVariable
   }
 }
 
@@ -146,7 +146,7 @@ abstract class TranslatedInitialization extends TranslatedElement, TTranslatedIn
   final override Locatable getAst() { result = expr }
 
   /** DEPRECATED: Alias for getAst */
-  deprecated override Locatable getAST() { result = getAst() }
+  deprecated override Locatable getAST() { result = this.getAst() }
 
   /**
    * Gets the expression that is doing the initialization.
@@ -157,7 +157,7 @@ abstract class TranslatedInitialization extends TranslatedElement, TTranslatedIn
    * Gets the initialization context that describes the location being
    * initialized.
    */
-  final InitializationContext getContext() { result = getParent() }
+  final InitializationContext getContext() { result = this.getParent() }
 
   final TranslatedFunction getEnclosingFunction() {
     result = getTranslatedFunction(this.getFunction())
@@ -169,17 +169,17 @@ abstract class TranslatedInitialization extends TranslatedElement, TTranslatedIn
  */
 abstract class TranslatedListInitialization extends TranslatedInitialization, InitializationContext {
   override Instruction getFirstInstruction() {
-    result = getChild(0).getFirstInstruction()
+    result = this.getChild(0).getFirstInstruction()
     or
-    not exists(getChild(0)) and result = getParent().getChildSuccessor(this)
+    not exists(this.getChild(0)) and resuthis.lt = getParent().getChildSuccessor(this)
   }
 
   override Instruction getChildSuccessor(TranslatedElement child) {
     exists(int index |
-      child = getChild(index) and
-      if exists(getChild(index + 1))
-      then result = getChild(index + 1).getFirstInstruction()
-      else result = getParent().getChildSuccessor(this)
+      child = this.getChild(index) and
+      if exists(this.getChild(index + 1))
+      then result = this.getChild(index + 1).getFirstInstruction()
+      else result = this.getParent().getChildSuccessor(this)
     )
   }
 
@@ -189,9 +189,9 @@ abstract class TranslatedListInitialization extends TranslatedInitialization, In
 
   final override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) { none() }
 
-  override Instruction getTargetAddress() { result = getContext().getTargetAddress() }
+  override Instruction getTargetAddress() { result = this.getContext().getTargetAddress() }
 
-  override Type getTargetType() { result = getContext().getTargetType() }
+  override Type getTargetType() { result = this.getContext().getTargetType() }
 }
 
 /**
@@ -237,9 +237,9 @@ class TranslatedArrayListInitialization extends TranslatedListInitialization {
 abstract class TranslatedDirectInitialization extends TranslatedInitialization {
   TranslatedDirectInitialization() { not expr instanceof AggregateLiteral }
 
-  override TranslatedElement getChild(int id) { id = 0 and result = getInitializer() }
+  override TranslatedElement getChild(int id) { id = 0 and result = this.getInitializer() }
 
-  override Instruction getFirstInstruction() { result = getInitializer().getFirstInstruction() }
+  override Instruction getFirstInstruction() { result = this.getInitializer().getFirstInstruction() }
 
   final TranslatedExpr getInitializer() { result = getTranslatedExpr(expr) }
 }
@@ -258,27 +258,27 @@ class TranslatedSimpleDirectInitialization extends TranslatedDirectInitializatio
   override predicate hasInstruction(Opcode opcode, InstructionTag tag, CppType resultType) {
     tag = InitializerStoreTag() and
     opcode instanceof Opcode::Store and
-    resultType = getTypeForPRValue(getContext().getTargetType())
+    resultType = getTypeForPRValue(this.getContext().getTargetType())
   }
 
   override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) {
     tag = InitializerStoreTag() and
-    result = getParent().getChildSuccessor(this) and
+    result = this.getParent().getChildSuccessor(this) and
     kind instanceof GotoEdge
   }
 
   override Instruction getChildSuccessor(TranslatedElement child) {
-    child = getInitializer() and result = getInstruction(InitializerStoreTag())
+    child = this.getInitializer() and result = this.getInstruction(InitializerStoreTag())
   }
 
   override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     tag = InitializerStoreTag() and
     (
       operandTag instanceof AddressOperandTag and
-      result = getContext().getTargetAddress()
+      result = this.getContext().getTargetAddress()
       or
       operandTag instanceof StoreValueOperandTag and
-      result = getInitializer().getResult()
+      result = this.getInitializer().getResult()
     )
   }
 }
@@ -305,13 +305,13 @@ class TranslatedStringLiteralInitialization extends TranslatedDirectInitializati
       // If the initializer string isn't large enough to fill the target, then
       // we have to generate another instruction sequence to store a constant
       // zero into the remainder of the array.
-      zeroInitRange(_, elementCount) and
+      this.zeroInitRange(_, elementCount) and
       (
         // Create a constant zero whose size is the size of the remaining
         // space in the target array.
         tag = ZeroPadStringConstantTag() and
         opcode instanceof Opcode::Constant and
-        resultType = getUnknownOpaqueType(elementCount * getElementType().getSize())
+        resultType = getUnknownOpaqueType(elementCount * this.getElementType().getSize())
         or
         // The index of the first element to be zero initialized.
         tag = ZeroPadStringElementIndexTag() and
@@ -321,12 +321,12 @@ class TranslatedStringLiteralInitialization extends TranslatedDirectInitializati
         // Compute the address of the first element to be zero initialized.
         tag = ZeroPadStringElementAddressTag() and
         opcode instanceof Opcode::PointerAdd and
-        resultType = getTypeForGLValue(getElementType())
+        resultType = getTypeForGLValue(this.getElementType())
         or
         // Store the constant zero into the remainder of the string.
         tag = ZeroPadStringStoreTag() and
         opcode instanceof Opcode::Store and
-        resultType = getUnknownOpaqueType(elementCount * getElementType().getSize())
+        resultType = getUnknownOpaqueType(elementCount * this.getElementType().getSize())
       )
     )
   }
@@ -335,78 +335,78 @@ class TranslatedStringLiteralInitialization extends TranslatedDirectInitializati
     kind instanceof GotoEdge and
     (
       tag = InitializerLoadStringTag() and
-      result = getInstruction(InitializerStoreTag())
+      result = this.getInstruction(InitializerStoreTag())
       or
-      if zeroInitRange(_, _)
+      if this.zeroInitRange(_, _)
       then (
         tag = InitializerStoreTag() and
-        result = getInstruction(ZeroPadStringConstantTag())
+        result = this.getInstruction(ZeroPadStringConstantTag())
         or
         tag = ZeroPadStringConstantTag() and
-        result = getInstruction(ZeroPadStringElementIndexTag())
+        result = this.getInstruction(ZeroPadStringElementIndexTag())
         or
         tag = ZeroPadStringElementIndexTag() and
-        result = getInstruction(ZeroPadStringElementAddressTag())
+        result = this.getInstruction(ZeroPadStringElementAddressTag())
         or
         tag = ZeroPadStringElementAddressTag() and
-        result = getInstruction(ZeroPadStringStoreTag())
+        result = this.getInstruction(ZeroPadStringStoreTag())
         or
         tag = ZeroPadStringStoreTag() and
-        result = getParent().getChildSuccessor(this)
+        result = this.getParent().getChildSuccessor(this)
       ) else (
         tag = InitializerStoreTag() and
-        result = getParent().getChildSuccessor(this)
+        result = this.getParent().getChildSuccessor(this)
       )
     )
   }
 
   override Instruction getChildSuccessor(TranslatedElement child) {
-    child = getInitializer() and result = getInstruction(InitializerLoadStringTag())
+    child = this.getInitializer() and result = this.getInstruction(InitializerLoadStringTag())
   }
 
   override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     tag = InitializerLoadStringTag() and
     (
       operandTag instanceof AddressOperandTag and
-      result = getInitializer().getResult()
+      result = this.getInitializer().getResult()
     )
     or
     tag = InitializerStoreTag() and
     (
       operandTag instanceof AddressOperandTag and
-      result = getContext().getTargetAddress()
+      result = this.getContext().getTargetAddress()
       or
       operandTag instanceof StoreValueOperandTag and
-      result = getInstruction(InitializerLoadStringTag())
+      result = this.getInstruction(InitializerLoadStringTag())
     )
     or
     tag = ZeroPadStringElementAddressTag() and
     (
       operandTag instanceof LeftOperandTag and
-      result = getContext().getTargetAddress()
+      result = this.getContext().getTargetAddress()
       or
       operandTag instanceof RightOperandTag and
-      result = getInstruction(ZeroPadStringElementIndexTag())
+      result = this.getInstruction(ZeroPadStringElementIndexTag())
     )
     or
     tag = ZeroPadStringStoreTag() and
     (
       operandTag instanceof AddressOperandTag and
-      result = getInstruction(ZeroPadStringElementAddressTag())
+      result = this.getInstruction(ZeroPadStringElementAddressTag())
       or
       operandTag instanceof StoreValueOperandTag and
-      result = getInstruction(ZeroPadStringConstantTag())
+      result = this.getInstruction(ZeroPadStringConstantTag())
     )
   }
 
   override int getInstructionElementSize(InstructionTag tag) {
     tag = ZeroPadStringElementAddressTag() and
-    result = max(getElementType().getSize())
+    result = max(this.getElementType().getSize())
   }
 
   override string getInstructionConstantValue(InstructionTag tag) {
     exists(int startIndex |
-      zeroInitRange(startIndex, _) and
+      this.zeroInitRange(startIndex, _) and
       (
         tag = ZeroPadStringConstantTag() and
         result = "0"
@@ -419,13 +419,13 @@ class TranslatedStringLiteralInitialization extends TranslatedDirectInitializati
 
   override predicate needsUnknownOpaqueType(int byteSize) {
     exists(int elementCount |
-      zeroInitRange(_, elementCount) and
-      byteSize = elementCount * getElementType().getSize()
+      this.zeroInitRange(_, elementCount) and
+      byteSize = elementCount * this.getElementType().getSize()
     )
   }
 
   private Type getElementType() {
-    result = getContext().getTargetType().getUnspecifiedType().(ArrayType).getBaseType()
+    result = this.getContext().getTargetType().getUnspecifiedType().(ArrayType).getBaseType()
   }
 
   /**
@@ -435,7 +435,7 @@ class TranslatedStringLiteralInitialization extends TranslatedDirectInitializati
   predicate zeroInitRange(int startIndex, int elementCount) {
     exists(int targetCount |
       startIndex = expr.getUnspecifiedType().(ArrayType).getArraySize() and
-      targetCount = getContext().getTargetType().getUnspecifiedType().(ArrayType).getArraySize() and
+      targetCount = this.getContext().getTargetType().getUnspecifiedType().(ArrayType).getArraySize() and
       elementCount = targetCount - startIndex and
       elementCount > 0
     )
@@ -454,14 +454,14 @@ class TranslatedConstructorInitialization extends TranslatedDirectInitialization
   override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) { none() }
 
   override Instruction getChildSuccessor(TranslatedElement child) {
-    child = getInitializer() and result = getParent().getChildSuccessor(this)
+    child = this.getInitializer() and result = this.getParent().getChildSuccessor(this)
   }
 
   override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     none()
   }
 
-  override Instruction getReceiver() { result = getContext().getTargetAddress() }
+  override Instruction getReceiver() { result = this.getContext().getTargetAddress() }
 }
 
 /**
@@ -491,7 +491,7 @@ abstract class TranslatedFieldInitialization extends TranslatedElement {
   final override Locatable getAst() { result = ast }
 
   /** DEPRECATED: Alias for getAst */
-  deprecated override Locatable getAST() { result = getAst() }
+  deprecated override Locatable getAST() { result = this.getAst() }
 
   final override Declaration getFunction() {
     result = getEnclosingFunction(ast) or
@@ -499,7 +499,7 @@ abstract class TranslatedFieldInitialization extends TranslatedElement {
     result = getEnclosingVariable(ast).(StaticInitializedStaticLocalVariable)
   }
 
-  final override Instruction getFirstInstruction() { result = getInstruction(getFieldAddressTag()) }
+  final override Instruction getFirstInstruction() { result = this.getInstruction(this.getFieldAddressTag()) }
 
   /**
    * Gets the zero-based index describing the order in which this field is to be
@@ -508,19 +508,19 @@ abstract class TranslatedFieldInitialization extends TranslatedElement {
   final int getOrder() { result = field.getInitializationOrder() }
 
   override predicate hasInstruction(Opcode opcode, InstructionTag tag, CppType resultType) {
-    tag = getFieldAddressTag() and
+    tag = this.getFieldAddressTag() and
     opcode instanceof Opcode::FieldAddress and
     resultType = getTypeForGLValue(field.getType())
   }
 
   override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
-    tag = getFieldAddressTag() and
+    tag = this.getFieldAddressTag() and
     operandTag instanceof UnaryOperandTag and
-    result = getParent().(InitializationContext).getTargetAddress()
+    result = this.getParent().(InitializationContext).getTargetAddress()
   }
 
   override Field getInstructionField(InstructionTag tag) {
-    tag = getFieldAddressTag() and result = field
+    tag = this.getFieldAddressTag() and result = field
   }
 
   final InstructionTag getFieldAddressTag() { result = InitializerFieldAddressTag() }
@@ -545,21 +545,21 @@ class TranslatedExplicitFieldInitialization extends TranslatedFieldInitializatio
     this = TTranslatedExplicitFieldInitialization(ast, field, expr, position)
   }
 
-  override Instruction getTargetAddress() { result = getInstruction(getFieldAddressTag()) }
+  override Instruction getTargetAddress() { result = this.getInstruction(this.getFieldAddressTag()) }
 
   override Type getTargetType() { result = field.getUnspecifiedType() }
 
   override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) {
-    tag = getFieldAddressTag() and
-    result = getInitialization().getFirstInstruction() and
+    tag = this.getFieldAddressTag() and
+    result = this.getInitialization().getFirstInstruction() and
     kind instanceof GotoEdge
   }
 
   override Instruction getChildSuccessor(TranslatedElement child) {
-    child = getInitialization() and result = getParent().getChildSuccessor(this)
+    child = this.getInitialization() and resuthis.lt = getParent().getChildSuccessor(this)
   }
 
-  override TranslatedElement getChild(int id) { id = 0 and result = getInitialization() }
+  override TranslatedElement getChild(int id) { id = 0 and result = this.getInitialization() }
 
   private TranslatedInitialization getInitialization() {
     result = getTranslatedInitialization(expr)
@@ -584,11 +584,11 @@ class TranslatedFieldValueInitialization extends TranslatedFieldInitialization,
   override predicate hasInstruction(Opcode opcode, InstructionTag tag, CppType resultType) {
     TranslatedFieldInitialization.super.hasInstruction(opcode, tag, resultType)
     or
-    tag = getFieldDefaultValueTag() and
+    tag = this.getFieldDefaultValueTag() and
     opcode instanceof Opcode::Constant and
     resultType = getTypeForPRValue(field.getType())
     or
-    tag = getFieldDefaultValueStoreTag() and
+    tag = this.getFieldDefaultValueStoreTag() and
     opcode instanceof Opcode::Store and
     resultType = getTypeForPRValue(field.getUnspecifiedType())
   }
@@ -596,32 +596,32 @@ class TranslatedFieldValueInitialization extends TranslatedFieldInitialization,
   override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) {
     kind instanceof GotoEdge and
     (
-      tag = getFieldAddressTag() and
-      result = getInstruction(getFieldDefaultValueTag())
+      tag = this.getFieldAddressTag() and
+      result = this.getInstructhis.tion(getFieldDefaultValueTag())
       or
-      tag = getFieldDefaultValueTag() and
-      result = getInstruction(getFieldDefaultValueStoreTag())
+      tag = this.getFieldDefaultValueTag() and
+      result = this.getInstructhis.tion(getFieldDefaultValueStoreTag())
       or
-      tag = getFieldDefaultValueStoreTag() and
-      result = getParent().getChildSuccessor(this)
+      tag = this.getFieldDefaultValueStoreTag() and
+      result = this.getParent().getChildSuccessor(this)
     )
   }
 
   override string getInstructionConstantValue(InstructionTag tag) {
-    tag = getFieldDefaultValueTag() and
+    tag = this.getFieldDefaultValueTag() and
     result = getZeroValue(field.getUnspecifiedType())
   }
 
   override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     result = TranslatedFieldInitialization.super.getInstructionRegisterOperand(tag, operandTag)
     or
-    tag = getFieldDefaultValueStoreTag() and
+    tag = this.getFieldDefaultValueStoreTag() and
     (
       operandTag instanceof AddressOperandTag and
-      result = getInstruction(getFieldAddressTag())
+      result = this.getInstructhis.tion(getFieldAddressTag())
       or
       operandTag instanceof StoreValueOperandTag and
-      result = getInstruction(getFieldDefaultValueTag())
+      result = this.getInstructhis.tion(getFieldDefaultValueTag())
     )
   }
 
@@ -644,13 +644,13 @@ abstract class TranslatedElementInitialization extends TranslatedElement {
   ArrayOrVectorAggregateLiteral initList;
 
   final override string toString() {
-    result = initList.toString() + "[" + getElementIndex().toString() + "]"
+    result = initList.toString() + "[" + this.getElementIndex().toString() + "]"
   }
 
   final override Locatable getAst() { result = initList }
 
   /** DEPRECATED: Alias for getAst */
-  deprecated override Locatable getAST() { result = getAst() }
+  deprecated override Locatable getAST() { result = this.getAst() }
 
   final override Declaration getFunction() {
     result = getEnclosingFunction(initList)
@@ -660,43 +660,43 @@ abstract class TranslatedElementInitialization extends TranslatedElement {
     result = getEnclosingVariable(initList).(StaticInitializedStaticLocalVariable)
   }
 
-  final override Instruction getFirstInstruction() { result = getInstruction(getElementIndexTag()) }
+  final override Instruction getFirstInstruction() { result = this.getInstruction(this.getElementIndexTag()) }
 
   override predicate hasInstruction(Opcode opcode, InstructionTag tag, CppType resultType) {
-    tag = getElementIndexTag() and
+    tag = this.getElementIndexTag() and
     opcode instanceof Opcode::Constant and
     resultType = getIntType()
     or
-    tag = getElementAddressTag() and
+    tag = this.getElementAddressTag() and
     opcode instanceof Opcode::PointerAdd and
-    resultType = getTypeForGLValue(getElementType())
+    resultType = getTypeForGLValue(this.getElementType())
   }
 
   override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) {
-    tag = getElementIndexTag() and
-    result = getInstruction(getElementAddressTag()) and
+    tag = this.getElementIndexTag() and
+    result = this.getInstruction(this.getElementAddressTag()) and
     kind instanceof GotoEdge
   }
 
   override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
-    tag = getElementAddressTag() and
+    tag = this.getElementAddressTag() and
     (
       operandTag instanceof LeftOperandTag and
-      result = getParent().(InitializationContext).getTargetAddress()
+      result = this.getParent().(InitializationContext).getTargetAddress()
       or
       operandTag instanceof RightOperandTag and
-      result = getInstruction(getElementIndexTag())
+      result = this.getInstructhis.tion(getElementIndexTag())
     )
   }
 
   override int getInstructionElementSize(InstructionTag tag) {
-    tag = getElementAddressTag() and
-    result = max(getElementType().getSize())
+    tag = this.getElementAddressTag() and
+    result = max(this.getElementType().getSize())
   }
 
   override string getInstructionConstantValue(InstructionTag tag) {
-    tag = getElementIndexTag() and
-    result = getElementIndex().toString()
+    tag = this.getElementIndexTag() and
+    result = this.getElementIndex().toString()
   }
 
   abstract int getElementIndex();
@@ -726,23 +726,23 @@ class TranslatedExplicitElementInitialization extends TranslatedElementInitializ
     this = TTranslatedExplicitElementInitialization(initList, elementIndex, position)
   }
 
-  override Instruction getTargetAddress() { result = getInstruction(getElementAddressTag()) }
+  override Instruction getTargetAddress() { result = this.getInstruction(this.getElementAddressTag()) }
 
-  override Type getTargetType() { result = getElementType() }
+  override Type getTargetType() { result = this.getElementType() }
 
   override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) {
     result = TranslatedElementInitialization.super.getInstructionSuccessor(tag, kind)
     or
-    tag = getElementAddressTag() and
-    result = getInitialization().getFirstInstruction() and
+    tag = this.getElementAddressTag() and
+    result = this.getInitialization().getFirstInstruction() and
     kind instanceof GotoEdge
   }
 
   override Instruction getChildSuccessor(TranslatedElement child) {
-    child = getInitialization() and result = getParent().getChildSuccessor(this)
+    child = this.getInitialization() and resuthis.lt = getParent().getChildSuccessor(this)
   }
 
-  override TranslatedElement getChild(int id) { id = 0 and result = getInitialization() }
+  override TranslatedElement getChild(int id) { id = 0 and result = this.getInitialization() }
 
   override int getElementIndex() { result = elementIndex }
 
@@ -773,13 +773,13 @@ class TranslatedElementValueInitialization extends TranslatedElementInitializati
   override predicate hasInstruction(Opcode opcode, InstructionTag tag, CppType resultType) {
     TranslatedElementInitialization.super.hasInstruction(opcode, tag, resultType)
     or
-    tag = getElementDefaultValueTag() and
+    tag = this.getElementDefaultValueTag() and
     opcode instanceof Opcode::Constant and
-    resultType = getDefaultValueType()
+    resultType = this.getDefaultValueType()
     or
-    tag = getElementDefaultValueStoreTag() and
+    tag = this.getElementDefaultValueStoreTag() and
     opcode instanceof Opcode::Store and
-    resultType = getDefaultValueType()
+    resultType = this.getDefaultValueType()
   }
 
   override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) {
@@ -787,34 +787,34 @@ class TranslatedElementValueInitialization extends TranslatedElementInitializati
     or
     kind instanceof GotoEdge and
     (
-      tag = getElementAddressTag() and
-      result = getInstruction(getElementDefaultValueTag())
+      tag = this.getElementAddressTag() and
+      result = this.getInstructhis.tion(getElementDefaultValueTag())
       or
-      tag = getElementDefaultValueTag() and
-      result = getInstruction(getElementDefaultValueStoreTag())
+      tag = this.getElementDefaultValueTag() and
+      result = this.getInstructhis.tion(getElementDefaultValueStoreTag())
       or
-      tag = getElementDefaultValueStoreTag() and
-      result = getParent().getChildSuccessor(this)
+      tag = this.getElementDefaultValueStoreTag() and
+      result = this.getParent().getChildSuccessor(this)
     )
   }
 
   override string getInstructionConstantValue(InstructionTag tag) {
     result = TranslatedElementInitialization.super.getInstructionConstantValue(tag)
     or
-    tag = getElementDefaultValueTag() and
-    result = getZeroValue(getElementType())
+    tag = this.getElementDefaultValueTag() and
+    result = getZeroValue(this.getElementType())
   }
 
   override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     result = TranslatedElementInitialization.super.getInstructionRegisterOperand(tag, operandTag)
     or
-    tag = getElementDefaultValueStoreTag() and
+    tag = this.getElementDefaultValueStoreTag() and
     (
       operandTag instanceof AddressOperandTag and
-      result = getInstruction(getElementAddressTag())
+      result = this.getInstructhis.tion(getElementAddressTag())
       or
       operandTag instanceof StoreValueOperandTag and
-      result = getInstruction(getElementDefaultValueTag())
+      result = this.getInstructhis.tion(getElementDefaultValueTag())
     )
   }
 
@@ -825,7 +825,7 @@ class TranslatedElementValueInitialization extends TranslatedElementInitializati
   override int getElementIndex() { result = elementIndex }
 
   override predicate needsUnknownOpaqueType(int byteSize) {
-    elementCount != 0 and byteSize = elementCount * getElementType().getSize()
+    elementCount != 0 and byteSize = elementCount * this.getElementType().getSize()
   }
 
   private InstructionTag getElementDefaultValueTag() {
@@ -838,8 +838,8 @@ class TranslatedElementValueInitialization extends TranslatedElementInitializati
 
   private CppType getDefaultValueType() {
     if elementCount = 1
-    then result = getTypeForPRValue(getElementType())
-    else result = getUnknownOpaqueType(elementCount * getElementType().getSize())
+    then result = getTypeForPRValue(this.getElementType())
+    else result = getUnknownOpaqueType(elementCount * this.getElementType().getSize())
   }
 }
 
@@ -849,18 +849,18 @@ abstract class TranslatedStructorCallFromStructor extends TranslatedElement, Str
   final override Locatable getAst() { result = call }
 
   /** DEPRECATED: Alias for getAst */
-  deprecated override Locatable getAST() { result = getAst() }
+  deprecated override Locatable getAST() { result = this.getAst() }
 
   final override TranslatedElement getChild(int id) {
     id = 0 and
-    result = getStructorCall()
+    result = this.getStructorCall()
   }
 
   final override Function getFunction() { result = getEnclosingFunction(call) }
 
   final override Instruction getChildSuccessor(TranslatedElement child) {
-    child = getStructorCall() and
-    result = getParent().getChildSuccessor(this)
+    child = this.getStructorCall() and
+    result = this.getParent().getChildSuccessor(this)
   }
 
   final TranslatedExpr getStructorCall() { result = getTranslatedExpr(call) }
@@ -871,7 +871,7 @@ abstract class TranslatedStructorCallFromStructor extends TranslatedElement, Str
  * destructor from within a derived class constructor or destructor.
  */
 abstract class TranslatedBaseStructorCall extends TranslatedStructorCallFromStructor {
-  final override Instruction getFirstInstruction() { result = getInstruction(OnlyInstructionTag()) }
+  final override Instruction getFirstInstruction() { result = this.getInstruction(OnlyInstructionTag()) }
 
   final override predicate hasInstruction(Opcode opcode, InstructionTag tag, CppType resultType) {
     tag = OnlyInstructionTag() and
@@ -882,15 +882,15 @@ abstract class TranslatedBaseStructorCall extends TranslatedStructorCallFromStru
   final override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) {
     tag = OnlyInstructionTag() and
     kind instanceof GotoEdge and
-    result = getStructorCall().getFirstInstruction()
+    result = this.getStructorCall().getFirstInstruction()
   }
 
-  final override Instruction getReceiver() { result = getInstruction(OnlyInstructionTag()) }
+  final override Instruction getReceiver() { result = this.getInstruction(OnlyInstructionTag()) }
 
   final override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     tag = OnlyInstructionTag() and
     operandTag instanceof UnaryOperandTag and
-    result = getTranslatedFunction(getFunction()).getInitializeThisInstruction()
+    result = getTranslatedFunction(this.getFunction()).getInitializeThisInstruction()
   }
 
   final override predicate getInstructionInheritance(
@@ -898,7 +898,7 @@ abstract class TranslatedBaseStructorCall extends TranslatedStructorCallFromStru
   ) {
     tag = OnlyInstructionTag() and
     baseClass = call.getTarget().getDeclaringType().getUnspecifiedType() and
-    derivedClass = getFunction().getDeclaringType().getUnspecifiedType()
+    derivedClass = this.getFunction().getDeclaringType().getUnspecifiedType()
   }
 }
 
@@ -924,7 +924,7 @@ class TranslatedConstructorDelegationInit extends TranslatedConstructorCallFromC
   final override string toString() { result = "delegation construct: " + call.toString() }
 
   final override Instruction getFirstInstruction() {
-    result = getStructorCall().getFirstInstruction()
+    result = this.getStructorCall().getFirstInstruction()
   }
 
   final override predicate hasInstruction(Opcode opcode, InstructionTag tag, CppType resultType) {
@@ -934,7 +934,7 @@ class TranslatedConstructorDelegationInit extends TranslatedConstructorCallFromC
   final override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) { none() }
 
   final override Instruction getReceiver() {
-    result = getTranslatedFunction(getFunction()).getInitializeThisInstruction()
+    result = getTranslatedFunction(this.getFunction()).getInitializeThisInstruction()
   }
 }
 
@@ -981,11 +981,11 @@ class TranslatedConstructorBareInit extends TranslatedElement, TTranslatedConstr
   override Locatable getAst() { result = init }
 
   /** DEPRECATED: Alias for getAst */
-  deprecated override Locatable getAST() { result = getAst() }
+  deprecated override Locatable getAST() { result = this.getAst() }
 
   final override string toString() { result = "construct base (no constructor)" }
 
-  override Instruction getFirstInstruction() { result = getParent().getChildSuccessor(this) }
+  override Instruction getFirstInstruction() { result = this.getParent().getChildSuccessor(this) }
 
   override predicate hasInstruction(Opcode opcode, InstructionTag tag, CppType resultType) {
     none()

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/internal/TranslatedStmt.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/internal/TranslatedStmt.qll
@@ -240,7 +240,7 @@ abstract class TranslatedStmt extends TranslatedElement, TTranslatedStmt {
   final override Locatable getAst() { result = stmt }
 
   /** DEPRECATED: Alias for getAst */
-  deprecated override Locatable getAST() { result = getAst() }
+  deprecated override Locatable getAST() { result = this.getAst() }
 
   final override Function getFunction() { result = stmt.getEnclosingFunction() }
 }
@@ -254,7 +254,7 @@ class TranslatedEmptyStmt extends TranslatedStmt {
 
   override TranslatedElement getChild(int id) { none() }
 
-  override Instruction getFirstInstruction() { result = getInstruction(OnlyInstructionTag()) }
+  override Instruction getFirstInstruction() { result = this.getInstruction(OnlyInstructionTag()) }
 
   override predicate hasInstruction(Opcode opcode, InstructionTag tag, CppType resultType) {
     tag = OnlyInstructionTag() and
@@ -264,7 +264,7 @@ class TranslatedEmptyStmt extends TranslatedStmt {
 
   override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) {
     tag = OnlyInstructionTag() and
-    result = getParent().getChildSuccessor(this) and
+    result = this.getParent().getChildSuccessor(this) and
     kind instanceof GotoEdge
   }
 
@@ -279,19 +279,19 @@ class TranslatedEmptyStmt extends TranslatedStmt {
 class TranslatedDeclStmt extends TranslatedStmt {
   override DeclStmt stmt;
 
-  override TranslatedElement getChild(int id) { result = getDeclarationEntry(id) }
+  override TranslatedElement getChild(int id) { result = this.getDeclarationEntry(id) }
 
   override predicate hasInstruction(Opcode opcode, InstructionTag tag, CppType resultType) {
     none()
   }
 
   override Instruction getFirstInstruction() {
-    result = getDeclarationEntry(0).getFirstInstruction()
+    result = this.getDeclarationEntry(0).getFirstInstruction()
     or
-    not exists(getDeclarationEntry(0)) and result = getParent().getChildSuccessor(this)
+    not exists(this.getDeclarationEntry(0)) and resuthis.lt = getParent().getChildSuccessor(this)
   }
 
-  private int getChildCount() { result = count(getDeclarationEntry(_)) }
+  private int getChildCount() { result = count(this.getDeclarationEntry(_)) }
 
   IRDeclarationEntry getIRDeclarationEntry(int index) {
     result.hasIndex(index) and
@@ -319,10 +319,10 @@ class TranslatedDeclStmt extends TranslatedStmt {
 
   override Instruction getChildSuccessor(TranslatedElement child) {
     exists(int index |
-      child = getDeclarationEntry(index) and
-      if index = (getChildCount() - 1)
-      then result = getParent().getChildSuccessor(this)
-      else result = getDeclarationEntry(index + 1).getFirstInstruction()
+      child = this.getDeclarationEntry(index) and
+      if index = (this.getChildCount() - 1)
+      then result = this.getParent().getChildSuccessor(this)
+      else result = this.getDeclarationEntry(index + 1).getFirstInstruction()
     )
   }
 }
@@ -332,19 +332,19 @@ class TranslatedExprStmt extends TranslatedStmt {
 
   TranslatedExpr getExpr() { result = getTranslatedExpr(stmt.getExpr().getFullyConverted()) }
 
-  override TranslatedElement getChild(int id) { id = 0 and result = getExpr() }
+  override TranslatedElement getChild(int id) { id = 0 and result = this.getExpr() }
 
   override predicate hasInstruction(Opcode opcode, InstructionTag tag, CppType resultType) {
     none()
   }
 
-  override Instruction getFirstInstruction() { result = getExpr().getFirstInstruction() }
+  override Instruction getFirstInstruction() { result = this.getExpr().getFirstInstruction() }
 
   override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) { none() }
 
   override Instruction getChildSuccessor(TranslatedElement child) {
-    child = getExpr() and
-    result = getParent().getChildSuccessor(this)
+    child = this.getExpr() and
+    result = this.getParent().getChildSuccessor(this)
   }
 }
 
@@ -363,16 +363,16 @@ class TranslatedReturnValueStmt extends TranslatedReturnStmt, TranslatedVariable
   TranslatedReturnValueStmt() { stmt.hasExpr() and hasReturnValue(stmt.getEnclosingFunction()) }
 
   final override Instruction getInitializationSuccessor() {
-    result = getEnclosingFunction().getReturnSuccessorInstruction()
+    result = this.getEnclosingFunction().getReturnSuccessorInstruction()
   }
 
-  final override Type getTargetType() { result = getEnclosingFunction().getReturnType() }
+  final override Type getTargetType() { result = this.getEnclosingFunction().getReturnType() }
 
   final override TranslatedInitialization getInitialization() {
     result = getTranslatedInitialization(stmt.getExpr().getFullyConverted())
   }
 
-  final override IRVariable getIRVariable() { result = getEnclosingFunction().getReturnVariable() }
+  final override IRVariable getIRVariable() { result = this.getEnclosingFunction().getReturnVariable() }
 }
 
 /**
@@ -385,10 +385,10 @@ class TranslatedReturnVoidExpressionStmt extends TranslatedReturnStmt {
 
   override TranslatedElement getChild(int id) {
     id = 0 and
-    result = getExpr()
+    result = this.getExpr()
   }
 
-  override Instruction getFirstInstruction() { result = getExpr().getFirstInstruction() }
+  override Instruction getFirstInstruction() { result = this.getExpr().getFirstInstruction() }
 
   override predicate hasInstruction(Opcode opcode, InstructionTag tag, CppType resultType) {
     tag = OnlyInstructionTag() and
@@ -398,13 +398,13 @@ class TranslatedReturnVoidExpressionStmt extends TranslatedReturnStmt {
 
   override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) {
     tag = OnlyInstructionTag() and
-    result = getEnclosingFunction().getReturnSuccessorInstruction() and
+    result = this.getEnclosingFunction().getReturnSuccessorInstruction() and
     kind instanceof GotoEdge
   }
 
   override Instruction getChildSuccessor(TranslatedElement child) {
-    child = getExpr() and
-    result = getInstruction(OnlyInstructionTag())
+    child = this.getExpr() and
+    result = this.getInstruction(OnlyInstructionTag())
   }
 
   private TranslatedExpr getExpr() { result = getTranslatedExpr(stmt.getExpr()) }
@@ -421,7 +421,7 @@ class TranslatedReturnVoidStmt extends TranslatedReturnStmt {
 
   override TranslatedElement getChild(int id) { none() }
 
-  override Instruction getFirstInstruction() { result = getInstruction(OnlyInstructionTag()) }
+  override Instruction getFirstInstruction() { result = this.getInstruction(OnlyInstructionTag()) }
 
   override predicate hasInstruction(Opcode opcode, InstructionTag tag, CppType resultType) {
     tag = OnlyInstructionTag() and
@@ -431,7 +431,7 @@ class TranslatedReturnVoidStmt extends TranslatedReturnStmt {
 
   override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) {
     tag = OnlyInstructionTag() and
-    result = getEnclosingFunction().getReturnSuccessorInstruction() and
+    result = this.getEnclosingFunction().getReturnSuccessorInstruction() and
     kind instanceof GotoEdge
   }
 
@@ -452,7 +452,7 @@ class TranslatedUnreachableReturnStmt extends TranslatedReturnStmt {
 
   override TranslatedElement getChild(int id) { none() }
 
-  override Instruction getFirstInstruction() { result = getInstruction(OnlyInstructionTag()) }
+  override Instruction getFirstInstruction() { result = this.getInstruction(OnlyInstructionTag()) }
 
   override predicate hasInstruction(Opcode opcode, InstructionTag tag, CppType resultType) {
     tag = OnlyInstructionTag() and
@@ -511,9 +511,9 @@ class TranslatedTryStmt extends TranslatedStmt {
   override TryOrMicrosoftTryStmt stmt;
 
   override TranslatedElement getChild(int id) {
-    id = 0 and result = getBody()
+    id = 0 and result = this.getBody()
     or
-    result = getHandler(id - 1)
+    result = this.getHandler(id - 1)
     or
     id = stmt.getNumberOfCatchClauses() + 1 and
     result = this.getFinally()
@@ -525,7 +525,7 @@ class TranslatedTryStmt extends TranslatedStmt {
 
   override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) { none() }
 
-  override Instruction getFirstInstruction() { result = getBody().getFirstInstruction() }
+  override Instruction getFirstInstruction() { result = this.getBody().getFirstInstruction() }
 
   override Instruction getChildSuccessor(TranslatedElement child) {
     // All non-finally children go to the successor of the `try` if
@@ -546,19 +546,19 @@ class TranslatedTryStmt extends TranslatedStmt {
 
   final Instruction getNextHandler(TranslatedHandler handler) {
     exists(int index |
-      handler = getHandler(index) and
-      result = getHandler(index + 1).getFirstInstruction()
+      handler = this.getHandler(index) and
+      result = this.getHandler(index + 1).getFirstInstruction()
     )
     or
     // The last catch clause flows to the exception successor of the parent
     // of the `try`, because the exception successor of the `try` itself is
     // the first catch clause.
-    handler = getHandler(stmt.getNumberOfCatchClauses() - 1) and
-    result = getParent().getExceptionSuccessorInstruction()
+    handler = this.getHandler(stmt.getNumberOfCatchClauses() - 1) and
+    result = this.getParent().getExceptionSuccessorInstruction()
   }
 
   final override Instruction getExceptionSuccessorInstruction() {
-    result = getHandler(0).getFirstInstruction()
+    result = this.getHandler(0).getFirstInstruction()
   }
 
   private TranslatedElement getHandler(int index) { result = stmt.getTranslatedHandler(index) }
@@ -571,19 +571,19 @@ class TranslatedTryStmt extends TranslatedStmt {
 class TranslatedBlock extends TranslatedStmt {
   override BlockStmt stmt;
 
-  override TranslatedElement getChild(int id) { result = getStmt(id) }
+  override TranslatedElement getChild(int id) { result = this.getStmt(id) }
 
   override predicate hasInstruction(Opcode opcode, InstructionTag tag, CppType resultType) {
-    isEmpty() and
+    this.isEmpty() and
     opcode instanceof Opcode::NoOp and
     tag = OnlyInstructionTag() and
     resultType = getVoidType()
   }
 
   override Instruction getFirstInstruction() {
-    if isEmpty()
-    then result = getInstruction(OnlyInstructionTag())
-    else result = getStmt(0).getFirstInstruction()
+    if this.isEmpty()
+    then result = this.getInstruction(OnlyInstructionTag())
+    else result = this.getStmt(0).getFirstInstruction()
   }
 
   private predicate isEmpty() { not exists(stmt.getStmt(0)) }
@@ -594,16 +594,16 @@ class TranslatedBlock extends TranslatedStmt {
 
   override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) {
     tag = OnlyInstructionTag() and
-    result = getParent().getChildSuccessor(this) and
+    result = this.getParent().getChildSuccessor(this) and
     kind instanceof GotoEdge
   }
 
   override Instruction getChildSuccessor(TranslatedElement child) {
     exists(int index |
-      child = getStmt(index) and
-      if index = (getStmtCount() - 1)
-      then result = getParent().getChildSuccessor(this)
-      else result = getStmt(index + 1).getFirstInstruction()
+      child = this.getStmt(index) and
+      if index = (this.getStmtCount() - 1)
+      then result = this.getParent().getChildSuccessor(this)
+      else result = this.getStmt(index + 1).getFirstInstruction()
     )
   }
 }
@@ -614,18 +614,18 @@ class TranslatedBlock extends TranslatedStmt {
 abstract class TranslatedHandler extends TranslatedStmt {
   override Handler stmt;
 
-  override TranslatedElement getChild(int id) { id = 1 and result = getBlock() }
+  override TranslatedElement getChild(int id) { id = 1 and result = this.getBlock() }
 
-  override Instruction getFirstInstruction() { result = getInstruction(CatchTag()) }
+  override Instruction getFirstInstruction() { result = this.getInstruction(CatchTag()) }
 
   override Instruction getChildSuccessor(TranslatedElement child) {
-    child = getBlock() and result = getParent().getChildSuccessor(this)
+    child = this.getBlock() and result = this.getParent().getChildSuccessor(this)
   }
 
   override Instruction getExceptionSuccessorInstruction() {
     // A throw from within a `catch` block flows to the handler for the parent of
     // the `try`.
-    result = getParent().getParent().getExceptionSuccessorInstruction()
+    result = this.getParent().getParent().getExceptionSuccessorInstruction()
   }
 
   TranslatedStmt getBlock() { result = getTranslatedStmt(stmt.getBlock()) }
@@ -647,23 +647,23 @@ class TranslatedCatchByTypeHandler extends TranslatedHandler {
   override TranslatedElement getChild(int id) {
     result = super.getChild(id)
     or
-    id = 0 and result = getParameter()
+    id = 0 and result = this.getParameter()
   }
 
   override Instruction getChildSuccessor(TranslatedElement child) {
     result = super.getChildSuccessor(child)
     or
-    child = getParameter() and result = getBlock().getFirstInstruction()
+    child = this.getParameter() and result = this.getBlock().getFirstInstruction()
   }
 
   override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) {
     tag = CatchTag() and
     (
       kind instanceof GotoEdge and
-      result = getParameter().getFirstInstruction()
+      result = this.getParameter().getFirstInstruction()
       or
       kind instanceof ExceptionEdge and
-      result = getParent().(TranslatedTryStmt).getNextHandler(this)
+      result = this.getParent().(TranslatedTryStmt).getNextHandler(this)
     )
   }
 
@@ -692,7 +692,7 @@ class TranslatedCatchAnyHandler extends TranslatedHandler {
   override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) {
     tag = CatchTag() and
     kind instanceof GotoEdge and
-    result = getBlock().getFirstInstruction()
+    result = this.getBlock().getFirstInstruction()
   }
 }
 
@@ -700,19 +700,19 @@ class TranslatedIfStmt extends TranslatedStmt, ConditionContext {
   override IfStmt stmt;
 
   override Instruction getFirstInstruction() {
-    if hasInitialization()
-    then result = getInitialization().getFirstInstruction()
-    else result = getFirstConditionInstruction()
+    if this.hasInitialization()
+    then result = this.getInitialization().getFirstInstruction()
+    else result = this.getFirstConditionInstruction()
   }
 
   override TranslatedElement getChild(int id) {
-    id = 0 and result = getInitialization()
+    id = 0 and result = this.getInitialization()
     or
-    id = 1 and result = getCondition()
+    id = 1 and result = this.getCondition()
     or
-    id = 2 and result = getThen()
+    id = 2 and result = this.getThen()
     or
-    id = 3 and result = getElse()
+    id = 3 and result = this.getElse()
   }
 
   private predicate hasInitialization() { exists(stmt.getInitialization()) }
@@ -726,7 +726,7 @@ class TranslatedIfStmt extends TranslatedStmt, ConditionContext {
   }
 
   private Instruction getFirstConditionInstruction() {
-    result = getCondition().getFirstInstruction()
+    result = this.getCondition().getFirstInstruction()
   }
 
   private TranslatedStmt getThen() { result = getTranslatedStmt(stmt.getThen()) }
@@ -738,23 +738,23 @@ class TranslatedIfStmt extends TranslatedStmt, ConditionContext {
   override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) { none() }
 
   override Instruction getChildTrueSuccessor(TranslatedCondition child) {
-    child = getCondition() and
-    result = getThen().getFirstInstruction()
+    child = this.getCondition() and
+    result = this.getThen().getFirstInstruction()
   }
 
   override Instruction getChildFalseSuccessor(TranslatedCondition child) {
-    child = getCondition() and
-    if hasElse()
-    then result = getElse().getFirstInstruction()
-    else result = getParent().getChildSuccessor(this)
+    child = this.getCondition() and
+    if this.hasElse()
+    then result = this.getElse().getFirstInstruction()
+    else result = this.getParent().getChildSuccessor(this)
   }
 
   override Instruction getChildSuccessor(TranslatedElement child) {
-    child = getInitialization() and
-    result = getFirstConditionInstruction()
+    child = this.getInitialization() and
+    result = this.getFirstConditionInstruction()
     or
-    (child = getThen() or child = getElse()) and
-    result = getParent().getChildSuccessor(this)
+    (child = this.getThen() or child = this.getElse()) and
+    result = this.getParent().getChildSuccessor(this)
   }
 
   override predicate hasInstruction(Opcode opcode, InstructionTag tag, CppType resultType) {
@@ -772,17 +772,17 @@ abstract class TranslatedLoop extends TranslatedStmt, ConditionContext {
   final TranslatedStmt getBody() { result = getTranslatedStmt(stmt.getStmt()) }
 
   final Instruction getFirstConditionInstruction() {
-    if hasCondition()
-    then result = getCondition().getFirstInstruction()
-    else result = getBody().getFirstInstruction()
+    if this.hasCondition()
+    then result = this.getCondition().getFirstInstruction()
+    else result = this.getBody().getFirstInstruction()
   }
 
   final predicate hasCondition() { exists(stmt.getCondition()) }
 
   override TranslatedElement getChild(int id) {
-    id = 0 and result = getCondition()
+    id = 0 and result = this.getCondition()
     or
-    id = 1 and result = getBody()
+    id = 1 and result = this.getBody()
   }
 
   override predicate hasInstruction(Opcode opcode, InstructionTag tag, CppType resultType) {
@@ -792,31 +792,31 @@ abstract class TranslatedLoop extends TranslatedStmt, ConditionContext {
   final override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) { none() }
 
   final override Instruction getChildTrueSuccessor(TranslatedCondition child) {
-    child = getCondition() and result = getBody().getFirstInstruction()
+    child = this.getCondition() and result = this.getBody().getFirstInstruction()
   }
 
   final override Instruction getChildFalseSuccessor(TranslatedCondition child) {
-    child = getCondition() and result = getParent().getChildSuccessor(this)
+    child = this.getCondition() and result = this.getParent().getChildSuccessor(this)
   }
 }
 
 class TranslatedWhileStmt extends TranslatedLoop {
   TranslatedWhileStmt() { stmt instanceof WhileStmt }
 
-  override Instruction getFirstInstruction() { result = getFirstConditionInstruction() }
+  override Instruction getFirstInstruction() { result = this.getFirstConditionInstruction() }
 
   override Instruction getChildSuccessor(TranslatedElement child) {
-    child = getBody() and result = getFirstConditionInstruction()
+    child = this.getBody() and result = this.getFirstConditionInstruction()
   }
 }
 
 class TranslatedDoStmt extends TranslatedLoop {
   TranslatedDoStmt() { stmt instanceof DoStmt }
 
-  override Instruction getFirstInstruction() { result = getBody().getFirstInstruction() }
+  override Instruction getFirstInstruction() { result = this.getBody().getFirstInstruction() }
 
   override Instruction getChildSuccessor(TranslatedElement child) {
-    child = getBody() and result = getFirstConditionInstruction()
+    child = this.getBody() and result = this.getFirstConditionInstruction()
   }
 }
 
@@ -824,13 +824,13 @@ class TranslatedForStmt extends TranslatedLoop {
   override ForStmt stmt;
 
   override TranslatedElement getChild(int id) {
-    id = 0 and result = getInitialization()
+    id = 0 and result = this.getInitialization()
     or
-    id = 1 and result = getCondition()
+    id = 1 and result = this.getCondition()
     or
-    id = 2 and result = getUpdate()
+    id = 2 and result = this.getUpdate()
     or
-    id = 3 and result = getBody()
+    id = 3 and result = this.getBody()
   }
 
   private TranslatedStmt getInitialization() {
@@ -844,23 +844,23 @@ class TranslatedForStmt extends TranslatedLoop {
   private predicate hasUpdate() { exists(stmt.getUpdate()) }
 
   override Instruction getFirstInstruction() {
-    if hasInitialization()
-    then result = getInitialization().getFirstInstruction()
-    else result = getFirstConditionInstruction()
+    if this.hasInitialization()
+    then result = this.getInitialization().getFirstInstruction()
+    else result = this.getFirstConditionInstruction()
   }
 
   override Instruction getChildSuccessor(TranslatedElement child) {
-    child = getInitialization() and
-    result = getFirstConditionInstruction()
+    child = this.getInitialization() and
+    result = this.getFirstConditionInstruction()
     or
     (
-      child = getBody() and
-      if hasUpdate()
-      then result = getUpdate().getFirstInstruction()
-      else result = getFirstConditionInstruction()
+      child = this.getBody() and
+      if this.hasUpdate()
+      then result = this.getUpdate().getFirstInstruction()
+      else result = this.getFirstConditionInstruction()
     )
     or
-    child = getUpdate() and result = getFirstConditionInstruction()
+    child = this.getUpdate() and resuthis.lt = getFirstConditionInstruction()
   }
 }
 
@@ -875,39 +875,39 @@ class TranslatedRangeBasedForStmt extends TranslatedStmt, ConditionContext {
   override RangeBasedForStmt stmt;
 
   override TranslatedElement getChild(int id) {
-    id = 0 and result = getRangeVariableDeclStmt()
+    id = 0 and result = this.getRangeVariableDeclStmt()
     or
     // Note: `__begin` and `__end` are declared by the same `DeclStmt`
-    id = 1 and result = getBeginEndVariableDeclStmt()
+    id = 1 and result = this.getBeginEndVariableDeclStmt()
     or
-    id = 2 and result = getCondition()
+    id = 2 and result = this.getCondition()
     or
-    id = 3 and result = getUpdate()
+    id = 3 and result = this.getUpdate()
     or
-    id = 4 and result = getVariableDeclStmt()
+    id = 4 and result = this.getVariableDeclStmt()
     or
-    id = 5 and result = getBody()
+    id = 5 and result = this.getBody()
   }
 
   override Instruction getFirstInstruction() {
-    result = getRangeVariableDeclStmt().getFirstInstruction()
+    result = this.getRangeVariableDeclStmt().getFirstInstruction()
   }
 
   override Instruction getChildSuccessor(TranslatedElement child) {
-    child = getRangeVariableDeclStmt() and
-    result = getBeginEndVariableDeclStmt().getFirstInstruction()
+    child = this.getRangeVariableDeclStmt() and
+    result = this.getBeginEndVariableDeclStmt().getFirstInstruction()
     or
-    child = getBeginEndVariableDeclStmt() and
-    result = getCondition().getFirstInstruction()
+    child = this.getBeginEndVariableDeclStmt() and
+    result = this.getCondition().getFirstInstruction()
     or
-    child = getVariableDeclStmt() and
-    result = getBody().getFirstInstruction()
+    child = this.getVariableDeclStmt() and
+    result = this.getBody().getFirstInstruction()
     or
-    child = getBody() and
-    result = getUpdate().getFirstInstruction()
+    child = this.getBody() and
+    result = this.getUpdate().getFirstInstruction()
     or
-    child = getUpdate() and
-    result = getCondition().getFirstInstruction()
+    child = this.getUpdate() and
+    result = this.getCondition().getFirstInstruction()
   }
 
   override predicate hasInstruction(Opcode opcode, InstructionTag tag, CppType resultType) {
@@ -917,11 +917,11 @@ class TranslatedRangeBasedForStmt extends TranslatedStmt, ConditionContext {
   override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) { none() }
 
   override Instruction getChildTrueSuccessor(TranslatedCondition child) {
-    child = getCondition() and result = getVariableDeclStmt().getFirstInstruction()
+    child = this.getCondition() and result = this.getVariableDeclStmt().getFirstInstruction()
   }
 
   override Instruction getChildFalseSuccessor(TranslatedCondition child) {
-    child = getCondition() and result = getParent().getChildSuccessor(this)
+    child = this.getCondition() and result = this.getParent().getChildSuccessor(this)
   }
 
   private TranslatedDeclStmt getRangeVariableDeclStmt() {
@@ -961,7 +961,7 @@ class TranslatedRangeBasedForStmt extends TranslatedStmt, ConditionContext {
 class TranslatedJumpStmt extends TranslatedStmt {
   override JumpStmt stmt;
 
-  override Instruction getFirstInstruction() { result = getInstruction(OnlyInstructionTag()) }
+  override Instruction getFirstInstruction() { result = this.getInstruction(OnlyInstructionTag()) }
 
   override TranslatedElement getChild(int id) { none() }
 
@@ -996,22 +996,22 @@ class TranslatedSwitchStmt extends TranslatedStmt {
     result = getTranslatedExpr(stmt.getExpr().getFullyConverted())
   }
 
-  private Instruction getFirstExprInstruction() { result = getExpr().getFirstInstruction() }
+  private Instruction getFirstExprInstruction() { result = this.getExpr().getFirstInstruction() }
 
   private TranslatedStmt getBody() { result = getTranslatedStmt(stmt.getStmt()) }
 
   override Instruction getFirstInstruction() {
-    if hasInitialization()
-    then result = getInitialization().getFirstInstruction()
-    else result = getFirstExprInstruction()
+    if this.hasInitialization()
+    then result = this.getInitialization().getFirstInstruction()
+    else result = this.getFirstExprInstruction()
   }
 
   override TranslatedElement getChild(int id) {
-    id = 0 and result = getInitialization()
+    id = 0 and result = this.getInitialization()
     or
-    id = 1 and result = getExpr()
+    id = 1 and result = this.getExpr()
     or
-    id = 2 and result = getBody()
+    id = 2 and result = this.getBody()
   }
 
   private predicate hasInitialization() { exists(stmt.getInitialization()) }
@@ -1029,7 +1029,7 @@ class TranslatedSwitchStmt extends TranslatedStmt {
   override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     tag = SwitchBranchTag() and
     operandTag instanceof ConditionOperandTag and
-    result = getExpr().getResult()
+    result = this.getExpr().getResult()
   }
 
   override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) {
@@ -1043,15 +1043,15 @@ class TranslatedSwitchStmt extends TranslatedStmt {
     not stmt.hasDefaultCase() and
     tag = SwitchBranchTag() and
     kind instanceof DefaultEdge and
-    result = getParent().getChildSuccessor(this)
+    result = this.getParent().getChildSuccessor(this)
   }
 
   override Instruction getChildSuccessor(TranslatedElement child) {
-    child = getInitialization() and result = getFirstExprInstruction()
+    child = this.getInitialization() and resuthis.lt = getFirstExprInstruction()
     or
-    child = getExpr() and result = getInstruction(SwitchBranchTag())
+    child = this.getExpr() and result = this.getInstruction(SwitchBranchTag())
     or
-    child = getBody() and result = getParent().getChildSuccessor(this)
+    child = this.getBody() and result = this.getParent().getChildSuccessor(this)
   }
 }
 
@@ -1063,9 +1063,9 @@ class TranslatedAsmStmt extends TranslatedStmt {
   }
 
   override Instruction getFirstInstruction() {
-    if exists(getChild(0))
-    then result = getChild(0).getFirstInstruction()
-    else result = getInstruction(AsmTag())
+    if exists(this.getChild(0))
+    then result = this.getChild(0).getFirstInstruction()
+    else result = this.getInstruction(AsmTag())
   }
 
   override predicate hasInstruction(Opcode opcode, InstructionTag tag, CppType resultType) {
@@ -1078,7 +1078,7 @@ class TranslatedAsmStmt extends TranslatedStmt {
     exists(int index |
       tag = AsmTag() and
       operandTag = asmOperand(index) and
-      result = getChild(index).getResult()
+      result = this.getChild(index).getResult()
     )
   }
 
@@ -1092,16 +1092,16 @@ class TranslatedAsmStmt extends TranslatedStmt {
 
   override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) {
     tag = AsmTag() and
-    result = getParent().getChildSuccessor(this) and
+    result = this.getParent().getChildSuccessor(this) and
     kind instanceof GotoEdge
   }
 
   override Instruction getChildSuccessor(TranslatedElement child) {
     exists(int index |
-      child = getChild(index) and
-      if exists(getChild(index + 1))
-      then result = getChild(index + 1).getFirstInstruction()
-      else result = getInstruction(AsmTag())
+      child = this.getChild(index) and
+      if exists(this.getChild(index + 1))
+      then result = this.getChild(index + 1).getFirstInstruction()
+      else result = this.getInstruction(AsmTag())
     )
   }
 }


### PR DESCRIPTION
Make all implicit this call receivers explicit to align with internal style guidelines. 

Automatically generated from results of QL-for-QL implicit this query as follows:
```
$CODEQL database create $LANG-db -l ql -s $CODEQL_PATH/$LANG/ql --search-path $CODEQL_PATH/ql/extractor-pack
$CODEQL database analyze $LANG-db --format=csv --output=$LANG $CODEQL_PATH/ql/ql/src/queries/style/ImplicitThis.ql
python3 insert-explicit-this.py $LANG $CODEQL_PATH/$LANG/ql
```
using the [insert-explicit-this.py](https://gist.github.com/kaspersv/c5ebde79af68c860624d46d85394793c) script to interpret the results and insert explicit this receivers. 