### PR TITLE
Java: Make implicit this receivers explicit

### DIFF
--- a/java/ql/lib/semmle/code/java/security/CommandArguments.qll
+++ b/java/ql/lib/semmle/code/java/security/CommandArguments.qll
@@ -155,7 +155,7 @@ private class CommandArgArrayImmutableFirst extends CommandArgumentArray {
   Expr getFirstElement() {
     result = this.getAWrite(0)
     or
-    not exists(getAWrite(0)) and
+    not exists(this.getAWrite(0)) and
     result = firstElementOf(this.getDefiningExpr())
   }
 


### PR DESCRIPTION
Make all implicit this call receivers explicit to align with internal style guidelines. Superseeded by https://github.com/github/codeql/pull/13010. 