### PR TITLE
Python: Make implicit this receivers explicit

### DIFF
--- a/python/ql/lib/semmle/python/security/dataflow/ChainedConfigs12.qll
+++ b/python/ql/lib/semmle/python/security/dataflow/ChainedConfigs12.qll
@@ -55,16 +55,16 @@ deprecated class CustomPathNode extends TCustomPathNode {
   predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    asNode1().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    this.asNode1().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
     or
-    asNode2().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    this.asNode2().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 
   /** Gets a textual representation of this element. */
   string toString() {
-    result = asNode1().toString()
+    result = this.asNode1().toString()
     or
-    result = asNode2().toString()
+    result = this.asNode2().toString()
   }
 }
 

--- a/python/ql/src/Security/CWE-020-ExternalAPIs/ExternalAPIs.qll
+++ b/python/ql/src/Security/CWE-020-ExternalAPIs/ExternalAPIs.qll
@@ -224,7 +224,7 @@ class ExternalApiUsedWithUntrustedData extends MkExternalApi {
 
   /** Gets the number of untrusted sources used with this external API. */
   int getNumberOfUntrustedSources() {
-    result = count(getUntrustedDataNode().getAnUntrustedSource())
+    result = count(this.getUntrustedDataNode().getAnUntrustedSource())
   }
 
   /** Gets a textual representation of this element. */

--- a/python/ql/src/Variables/Undefined.qll
+++ b/python/ql/src/Variables/Undefined.qll
@@ -73,11 +73,11 @@ class UninitializedConfig extends TaintTracking::Configuration {
   override predicate isBarrier(DataFlow::Node node, TaintKind kind) {
     kind instanceof Uninitialized and
     (
-      definition(node.asVariable())
+      this.definition(node.asVariable())
       or
-      use(node.asVariable())
+      this.use(node.asVariable())
       or
-      sanitizingNode(node.asCfgNode())
+      this.sanitizingNode(node.asCfgNode())
     )
   }
 

--- a/python/ql/src/experimental/semmle/python/Concepts.qll
+++ b/python/ql/src/experimental/semmle/python/Concepts.qll
@@ -169,7 +169,7 @@ module LdapBind {
     abstract predicate useSsl();
 
     /** DEPRECATED: Alias for useSsl */
-    deprecated predicate useSSL() { useSsl() }
+    deprecated predicate useSSL() { this.useSsl() }
   }
 }
 
@@ -199,7 +199,7 @@ class LdapBind extends DataFlow::Node instanceof LdapBind::Range {
   predicate useSsl() { super.useSsl() }
 
   /** DEPRECATED: Alias for useSsl */
-  deprecated predicate useSSL() { useSsl() }
+  deprecated predicate useSSL() { this.useSsl() }
 }
 
 /** DEPRECATED: Alias for LdapBind */

--- a/python/ql/src/external/DefectFilter.qll
+++ b/python/ql/src/external/DefectFilter.qll
@@ -65,8 +65,8 @@ class DefectResult extends int {
   /** Gets the URL corresponding to the location of this query result. */
   string getURL() {
     result =
-      "file://" + getFile().getAbsolutePath() + ":" + getStartLine() + ":" + getStartColumn() + ":" +
-        getEndLine() + ":" + getEndColumn()
+      "file://" + this.getFile().getAbsolutePath() + ":" + this.getStartLine() + ":" +
+        this.getStartColumn() + ":" + this.getEndLine() + ":" + this.getEndColumn()
   }
 }
 


### PR DESCRIPTION
Make all implicit this call receivers explicit to align with internal style guidelines.