### PR TITLE
Swift: Fix TODO on regex literals's `toString`

### DIFF
--- a/swift/ql/lib/codeql/swift/elements/expr/RegexLiteralExpr.qll
+++ b/swift/ql/lib/codeql/swift/elements/expr/RegexLiteralExpr.qll
@@ -1,7 +1,5 @@
 private import codeql.swift.generated.expr.RegexLiteralExpr
 
 class RegexLiteralExpr extends Generated::RegexLiteralExpr {
-  override string toString() {
-    result = "..." // TODO: We can improve this once we extract the regex
-  }
+  override string toString() { result = this.getPattern() }
 }


### PR DESCRIPTION
This fixes a super small TODO. We don't actually have any tests for regex literals yet (because the right macOS version may not be available on Actions), so this doesn't affect any test output. It should, however, be a very change 🤞.