### PR TITLE
Swift: Fix TODOs in `FlowSummary.qll`

### DIFF
--- a/swift/ql/lib/codeql/swift/dataflow/FlowSummary.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/FlowSummary.qll
@@ -21,25 +21,11 @@ module SummaryComponent {
 
   predicate content = SummaryComponentInternal::content/1;
 
-  /** Gets a summary component for parameter `i`. */
-  SummaryComponent parameter(int i) {
-    none() // TODO
-  }
+  predicate parameter = SummaryComponentInternal::parameter/1;
 
-  /** Gets a summary component for argument `i`. */
-  SummaryComponent argument(int i) {
-    none() // TODO
-  }
+  predicate argument = SummaryComponentInternal::argument/1;
 
   predicate return = SummaryComponentInternal::return/1;
-
-  /** Gets a summary component that represents a qualifier. */
-  SummaryComponent qualifier() {
-    none() // TODO
-  }
-
-  /** Gets a summary component that represents the return value of a call. */
-  SummaryComponent return() { result = return(any(DataFlowDispatch::NormalReturnKind rk)) }
 }
 
 class SummaryComponentStack = Impl::Public::SummaryComponentStack;
@@ -52,16 +38,9 @@ module SummaryComponentStack {
 
   predicate push = SummaryComponentStackInternal::push/2;
 
-  /** Gets a singleton stack for argument `i`. */
-  SummaryComponentStack argument(int i) { result = singleton(SummaryComponent::argument(i)) }
+  predicate argument = SummaryComponentStackInternal::argument/1;
 
   predicate return = SummaryComponentStackInternal::return/1;
-
-  /** Gets a singleton stack representing a qualifier. */
-  SummaryComponentStack qualifier() { result = singleton(SummaryComponent::qualifier()) }
-
-  /** Gets a singleton stack representing the return value of a call. */
-  SummaryComponentStack return() { result = singleton(SummaryComponent::return()) }
 }
 
 class SummarizedCallable = Impl::Public::SummarizedCallable;


### PR DESCRIPTION
We're not actually using these wrapper for anything yet. But we might as well implement them in a more meaningful way (and get rid of the TODOs) for when we actually start to depend on them.