### PR TITLE
Java: switch `url-open-stream` sink models to `experimentalSinkModel`

### DIFF
--- a/docs/codeql/codeql-language-guides/customizing-library-models-for-java.rst
+++ b/docs/codeql/codeql-language-guides/customizing-library-models-for-java.rst
@@ -84,7 +84,7 @@ The remaining values are used to define the **access path**, the **kind**, and t
 - The seventh value **Argument[0]** is the **access path** to the first argument passed to the method, which means that this is the location of the sink.
 - The eighth value **sql** is the kind of the sink. The sink kind is used to define the queries where the sink is in scope. In this case - the SQL injection queries.
 - The ninth value **manual** is the provenance of the sink, which is used to identify the origin of the sink.
- 
+
 Example: Taint source from the **java.net** package
 ----------------------------------------------------
 In this example we show how to model the return value from the **getInputStream** method as a **remote** source.
@@ -241,7 +241,7 @@ A neutral model is used to define that there is no flow through a method.
 Note that the neutral model for the **now** method is already added to the CodeQL Java analysis.
 
 .. code-block:: java
-   
+
    public static void taintflow() {
        Instant t = Instant.now(); // There is no flow from now to t.
        ...
@@ -334,7 +334,7 @@ Below is an enumeration of the remaining sinks, but they are out of scope for th
 
 - **open-url**, **jndi-injection**, **ldap**, **jdbc-url**
 - **mvel**, **xpath**, **groovy**, **ognl-injection**
-- **intent-start**, **pending-intent-sent**, **url-open-stream**, **url-redirect**
+- **intent-start**, **pending-intent-sent**, **url-redirect**
 - **create-file**, **read-file**, **write-file**, **set-hostname-verifier**
 - **header-splitting**, **information-leak**, **xslt**, **jexl**
 - **bean-validation**, **ssti**, **fragment-injection**, **regex-use[**\ `arg`\ **]**

--- a/java/documentation/library-coverage/cwe-sink.csv
+++ b/java/documentation/library-coverage/cwe-sink.csv
@@ -1,7 +1,6 @@
 CWE,Sink identifier,Label
 CWE‑089,sql,SQL injection
 CWE‑022,create-file,Path injection
-CWE‑036,url-open-stream,Path traversal
 CWE‑094,bean-validation,Code injection
 CWE‑319,open-url,Cleartext transmission
 CWE‑079,xss,Cross-site scripting

--- a/java/ql/lib/change-notes/2023-05-03-url-open-stream-as-experimental.md
+++ b/java/ql/lib/change-notes/2023-05-03-url-open-stream-as-experimental.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Moved the `url-open-stream` sink models to experimental and removed `url-open-stream` as a sink option from the [Customizing Library Models for Java](https://github.com/github/codeql/blob/733a00039efdb39c3dd76ddffad5e6d6c85e6774/docs/codeql/codeql-language-guides/customizing-library-models-for-java.rst#customizing-library-models-for-java) documentation.

--- a/java/ql/lib/ext/com.google.common.io.model.yml
+++ b/java/ql/lib/ext/com.google.common.io.model.yml
@@ -11,12 +11,6 @@ extensions:
       - ["com.google.common.io", "Files", False, "toString", "(File,Charset)", "", "Argument[0]", "read-file", "ai-manual"]
       - ["com.google.common.io", "Files", False, "write", "(byte[],File)", "", "Argument[0]", "write-file", "ai-manual"]
       - ["com.google.common.io", "Files", False, "write", "(byte[],File)", "", "Argument[1]", "create-file", "manual"]
-      - ["com.google.common.io", "Resources", False, "asByteSource", "(URL)", "", "Argument[0]", "url-open-stream", "manual"]
-      - ["com.google.common.io", "Resources", False, "asCharSource", "(URL,Charset)", "", "Argument[0]", "url-open-stream", "manual"]
-      - ["com.google.common.io", "Resources", False, "copy", "(URL,OutputStream)", "", "Argument[0]", "url-open-stream", "manual"]
-      - ["com.google.common.io", "Resources", False, "readLines", "", "", "Argument[0]", "url-open-stream", "manual"]
-      - ["com.google.common.io", "Resources", False, "toByteArray", "(URL)", "", "Argument[0]", "url-open-stream", "manual"]
-      - ["com.google.common.io", "Resources", False, "toString", "(URL,Charset)", "", "Argument[0]", "url-open-stream", "manual"]
   - addsTo:
       pack: codeql/java-all
       extensible: summaryModel

--- a/java/ql/lib/ext/experimental/com.google.common.io.model.yml
+++ b/java/ql/lib/ext/experimental/com.google.common.io.model.yml
@@ -1,0 +1,11 @@
+extensions:
+  - addsTo:
+      pack: codeql/java-all
+      extensible: experimentalSinkModel
+    data:
+      - ["com.google.common.io", "Resources", False, "asByteSource", "(URL)", "", "Argument[0]", "url-open-stream", "manual"]
+      - ["com.google.common.io", "Resources", False, "asCharSource", "(URL,Charset)", "", "Argument[0]", "url-open-stream", "manual"]
+      - ["com.google.common.io", "Resources", False, "copy", "(URL,OutputStream)", "", "Argument[0]", "url-open-stream", "manual"]
+      - ["com.google.common.io", "Resources", False, "readLines", "", "", "Argument[0]", "url-open-stream", "manual"]
+      - ["com.google.common.io", "Resources", False, "toByteArray", "(URL)", "", "Argument[0]", "url-open-stream", "manual"]
+      - ["com.google.common.io", "Resources", False, "toString", "(URL,Charset)", "", "Argument[0]", "url-open-stream", "manual"]

--- a/java/ql/lib/ext/experimental/com.google.common.io.model.yml
+++ b/java/ql/lib/ext/experimental/com.google.common.io.model.yml
@@ -3,9 +3,9 @@ extensions:
       pack: codeql/java-all
       extensible: experimentalSinkModel
     data:
-      - ["com.google.common.io", "Resources", False, "asByteSource", "(URL)", "", "Argument[0]", "url-open-stream", "manual"]
-      - ["com.google.common.io", "Resources", False, "asCharSource", "(URL,Charset)", "", "Argument[0]", "url-open-stream", "manual"]
-      - ["com.google.common.io", "Resources", False, "copy", "(URL,OutputStream)", "", "Argument[0]", "url-open-stream", "manual"]
-      - ["com.google.common.io", "Resources", False, "readLines", "", "", "Argument[0]", "url-open-stream", "manual"]
-      - ["com.google.common.io", "Resources", False, "toByteArray", "(URL)", "", "Argument[0]", "url-open-stream", "manual"]
-      - ["com.google.common.io", "Resources", False, "toString", "(URL,Charset)", "", "Argument[0]", "url-open-stream", "manual"]
+      - ["com.google.common.io", "Resources", False, "asByteSource", "(URL)", "", "Argument[0]", "url-open-stream", "manual", "openstream-called-on-tainted-url"]
+      - ["com.google.common.io", "Resources", False, "asCharSource", "(URL,Charset)", "", "Argument[0]", "url-open-stream", "manual", "openstream-called-on-tainted-url"]
+      - ["com.google.common.io", "Resources", False, "copy", "(URL,OutputStream)", "", "Argument[0]", "url-open-stream", "manual", "openstream-called-on-tainted-url"]
+      - ["com.google.common.io", "Resources", False, "readLines", "", "", "Argument[0]", "url-open-stream", "manual", "openstream-called-on-tainted-url"]
+      - ["com.google.common.io", "Resources", False, "toByteArray", "(URL)", "", "Argument[0]", "url-open-stream", "manual", "openstream-called-on-tainted-url"]
+      - ["com.google.common.io", "Resources", False, "toString", "(URL,Charset)", "", "Argument[0]", "url-open-stream", "manual", "openstream-called-on-tainted-url"]

--- a/java/ql/lib/semmle/code/java/dataflow/ExternalFlow.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/ExternalFlow.qll
@@ -273,10 +273,10 @@ module ModelValidation {
       not kind =
         [
           "open-url", "jndi-injection", "ldap", "sql", "jdbc-url", "logging", "mvel", "xpath",
-          "groovy", "xss", "ognl-injection", "intent-start", "pending-intent-sent",
-          "url-open-stream", "url-redirect", "create-file", "read-file", "write-file",
-          "set-hostname-verifier", "header-splitting", "information-leak", "xslt", "jexl",
-          "bean-validation", "ssti", "fragment-injection", "command-injection"
+          "groovy", "xss", "ognl-injection", "intent-start", "pending-intent-sent", "url-redirect",
+          "create-file", "read-file", "write-file", "set-hostname-verifier", "header-splitting",
+          "information-leak", "xslt", "jexl", "bean-validation", "ssti", "fragment-injection",
+          "command-injection"
         ] and
       not kind.matches("regex-use%") and
       not kind.matches("qltest%") and

--- a/java/ql/src/experimental/Security/CWE/CWE-036/OpenStream.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-036/OpenStream.ql
@@ -17,6 +17,10 @@ import semmle.code.java.dataflow.FlowSources
 import semmle.code.java.dataflow.ExternalFlow
 import RemoteUrlToOpenStreamFlow::PathGraph
 
+private class ActivateModels extends ActiveExperimentalModels {
+  ActivateModels() { this = "openstream-called-on-tainted-url" }
+}
+
 class UrlConstructor extends ClassInstanceExpr {
   UrlConstructor() { this.getConstructor().getDeclaringType() instanceof TypeUrl }
 


### PR DESCRIPTION
### Description

This PR switches the `url-open-stream` models to `experimentalSink Model` since they are only used in the experimental query, `java/openstream-called-on-tainted-url`.

Specifically, this PR:
- Switches the `url-open-stream` models to `experimentalSinkModel` and activates them in the `java/openstream-called-on-tainted-url` query.
- Removes `url-open-stream` from the _Customizing Library Models for Java_ documentation.
- Removes `url-open-stream` from the `getInvalidModelKind` predicate in the `ModelValidation` module.
- Removes the CWE related to the `url-open-stream` kinds from the `cwe-sink.csv` file which is used in the framework coverage reports.

### Consideration
Let me know if the change note needs any edits. Should I specifically mention the removal of CWE-036 from the framework coverage report in the change note?