### PR TITLE
Java: Add pragma[only_bind_out] to Top::toString() calls

### DIFF
--- a/java/ql/lib/semmle/code/java/Exception.qll
+++ b/java/ql/lib/semmle/code/java/Exception.qll
@@ -26,7 +26,7 @@ class Exception extends Element, @exception {
   /** Holds if this exception has the specified `name`. */
   override predicate hasName(string name) { this.getType().hasName(name) }
 
-  override string toString() { result = this.getType().toString() }
+  override string toString() { result = pragma[only_bind_out](this.getType()).toString() }
 
   override string getAPrimaryQlClass() { result = "Exception" }
 }

--- a/java/ql/lib/semmle/code/java/Expr.qll
+++ b/java/ql/lib/semmle/code/java/Expr.qll
@@ -1644,7 +1644,9 @@ class TypeLiteral extends Expr, @typeliteral {
   Type getReferencedType() { result = this.getTypeName().getType() }
 
   /** Gets a printable representation of this expression. */
-  override string toString() { result = this.getTypeName().toString() + ".class" }
+  override string toString() {
+    result = pragma[only_bind_out](this.getTypeName()).toString() + ".class"
+  }
 
   override string getAPrimaryQlClass() { result = "TypeLiteral" }
 }
@@ -1752,7 +1754,7 @@ class VarAccess extends Expr, @varaccess {
     exists(Expr q | q = this.getQualifier() |
       if q.isParenthesized()
       then result = "(...)." + this.getVariable().getName()
-      else result = q.toString() + "." + this.getVariable().getName()
+      else result = pragma[only_bind_out](q).toString() + "." + this.getVariable().getName()
     )
     or
     not this.hasQualifier() and result = this.getVariable().getName()

--- a/java/ql/lib/semmle/code/java/Import.qll
+++ b/java/ql/lib/semmle/code/java/Import.qll
@@ -27,7 +27,9 @@ class ImportType extends Import {
   /** Gets the imported type. */
   ClassOrInterface getImportedType() { imports(this, result, _, _) }
 
-  override string toString() { result = "import " + this.getImportedType().toString() }
+  override string toString() {
+    result = "import " + pragma[only_bind_out](this.getImportedType()).toString()
+  }
 
   override string getAPrimaryQlClass() { result = "ImportType" }
 }
@@ -49,7 +51,9 @@ class ImportOnDemandFromType extends Import {
   /** Gets an imported type. */
   NestedType getAnImport() { result.getEnclosingType() = this.getTypeHoldingImport() }
 
-  override string toString() { result = "import " + this.getTypeHoldingImport().toString() + ".*" }
+  override string toString() {
+    result = "import " + pragma[only_bind_out](this.getTypeHoldingImport()).toString() + ".*"
+  }
 
   override string getAPrimaryQlClass() { result = "ImportOnDemandFromType" }
 }
@@ -71,7 +75,7 @@ class ImportOnDemandFromPackage extends Import {
 
   /** Gets a printable representation of this import declaration. */
   override string toString() {
-    result = "import " + this.getPackageHoldingImport().toString() + ".*"
+    result = "import " + pragma[only_bind_out](this.getPackageHoldingImport()).toString() + ".*"
   }
 
   override string getAPrimaryQlClass() { result = "ImportOnDemandFromPackage" }
@@ -100,7 +104,7 @@ class ImportStaticOnDemand extends Import {
 
   /** Gets a printable representation of this import declaration. */
   override string toString() {
-    result = "import static " + this.getTypeHoldingImport().toString() + ".*"
+    result = "import static " + pragma[only_bind_out](this.getTypeHoldingImport()).toString() + ".*"
   }
 
   override string getAPrimaryQlClass() { result = "ImportStaticOnDemand" }
@@ -141,7 +145,9 @@ class ImportStaticTypeMember extends Import {
 
   /** Gets a printable representation of this import declaration. */
   override string toString() {
-    result = "import static " + this.getTypeHoldingImport().toString() + "." + this.getName()
+    result =
+      "import static " + pragma[only_bind_out](this.getTypeHoldingImport()).toString() + "." +
+        this.getName()
   }
 
   override string getAPrimaryQlClass() { result = "ImportStaticTypeMember" }

--- a/java/ql/lib/semmle/code/java/Type.qll
+++ b/java/ql/lib/semmle/code/java/Type.qll
@@ -804,7 +804,9 @@ class AnonymousClass extends NestedClass {
     // Include super.toString, i.e. the name given in the database, because for Kotlin anonymous
     // classes we can get specialisations of anonymous generic types, and this will supply the
     // trailing type arguments.
-    result = "new " + this.getClassInstanceExpr().getTypeName() + "(...) { ... }" + super.toString()
+    result =
+      "new " + pragma[only_bind_out](this.getClassInstanceExpr().getTypeName()).toString() +
+        "(...) { ... }" + super.toString()
   }
 
   /**


### PR DESCRIPTION
This PR adds `pragma[only_bind_out]` to `Location::Top::ToString()` calls to fix bad join order `order_500000` for `Location#77b33c41::Top::toString#0#dispred#ff`.

This change currently does not have any performance implication, positive or negative, because for large deltas the evaluator would choose the standard order.  But it will help with performance if we remove the standard order, as seen in the following before-and-after comparison:

```
Predicate Location#77b33c41::Top::toString#0#dispred#ff: order_500000 -> order_500000:
  9357ms -> 13ms, Location#77b33c41::Top::toString#0#dispred#ff@ee468wpa @5abb2wft iteration 2 (AbstractToConcreteCollection.ql stage 3)

  > Evaluated relational algebra for predicate Location#77b33c41::Top::toString#0#dispred#ff@ee468wpa on iteration 2 running pipeline order_500000 with tuple counts:
  > 0   ~0%    {2} r1 = Expr#20226873::TypeAccess::toString#ff#prev_delta UNION Member#9eba3c33::FieldDeclaration::toString#ff#prev_delta
  > 
  > 0   ~0%    {2} r2 = JOIN Location#77b33c41::Top::toString#0#dispred#ff#prev_delta WITH Compose#5a270a32::LiveLiteral::getValue#0#dispred#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1
  > 
  > 7   ~0%    {2} r3 = JOIN Location#77b33c41::Top::toString#0#dispred#ff#prev_delta WITH _Expr#20226873::Expr::getType#0#dispred#ff__exprs_10#join_rhs#antijoin_rhs#17#join_rhs ON FIRST 1 OUTPUT Rhs.1, ("new " ++ Lhs.1)
  > 
  > 7   ~0%    {2} r4 = r2 UNION r3
  > 7   ~0%    {2} r5 = r1 UNION r4
  > 
  > 3916437   ~2%    {2} r6 = JOIN Location#77b33c41::Top::toString#0#dispred#ff#prev_delta WITH @reftype#f ON FIRST 1 OUTPUT Lhs.0, Lhs.1
  > 8815   ~1%    {2} r7 = JOIN r6 WITH exceptions_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1
  > 
  > 0   ~0%    {2} r8 = JOIN Location#77b33c41::Top::toString#0#dispred#ff#prev_delta WITH kt_notnull_types_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, ("Kotlin not-null " ++ Lhs.1)
  > 
  > 8815   ~1%    {2} r9 = r7 UNION r8
  > 
  > 0   ~0%    {2} r10 = JOIN Location#77b33c41::Top::toString#0#dispred#ff#prev_delta WITH kt_nullable_types_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, ("Kotlin nullable " ++ Lhs.1)
  > 
  > 1220478   ~2%    {3} r11 = JOIN Location#77b33c41::Top::toString#0#dispred#ff#prev_delta WITH exprs ON FIRST 1 OUTPUT Rhs.3, 57, Lhs.1
  > 3   ~0%    {2} r12 = JOIN r11 WITH exprs ON FIRST 2 OUTPUT Lhs.0, (Lhs.2 ++ ".class")
  > 
  > 5429   ~0%    {2} r13 = JOIN Location#77b33c41::Top::toString#0#dispred#ff#prev_delta WITH Javadoc#9657445a::JavadocParent::getChild#1#dispred#fbf#cpe#13_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1
  > 1689   ~0%    {3} r14 = JOIN r13 WITH Javadoc#9657445a::Javadoc::toStringPrefix#0#dispred#ff ON FIRST 1 OUTPUT Lhs.0, Lhs.1, Rhs.1
  > 1689   ~2%    {2} r15 = JOIN r14 WITH Javadoc#9657445a::Javadoc::toStringPostfix#0#dispred#ff ON FIRST 1 OUTPUT Lhs.0, (Lhs.2 ++ Lhs.1 ++ Rhs.1)
  > 
  > 1692   ~2%    {2} r16 = r12 UNION r15
  > 1692   ~2%    {2} r17 = r10 UNION r16
  > 10507   ~0%    {2} r18 = r9 UNION r17
  > 10514   ~0%    {2} r19 = r5 UNION r18
  > 
  > 0   ~0%    {3} r20 = JOIN Location#77b33c41::Top::toString#0#dispred#ff#prev_delta WITH Expr#20226873::InstanceAccess::getQualifier#0#dispred#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, 58, Lhs.1
  > 0   ~0%    {2} r21 = JOIN r20 WITH exprs ON FIRST 2 OUTPUT Lhs.0, (Lhs.2 ++ ".this")
  > 
  > 0   ~0%    {3} r22 = JOIN Location#77b33c41::Top::toString#0#dispred#ff#prev_delta WITH Expr#20226873::InstanceAccess::getQualifier#0#dispred#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, 59, Lhs.1
  > 0   ~0%    {2} r23 = JOIN r22 WITH exprs ON FIRST 2 OUTPUT Lhs.0, (Lhs.2 ++ ".super")
  > 
  > 0   ~0%    {2} r24 = r21 UNION r23
  > 
  > 127   ~1%    {3} r25 = JOIN Location#77b33c41::Top::toString#0#dispred#ff#prev_delta WITH packages ON FIRST 1 OUTPUT Lhs.0, 3, ("import " ++ Lhs.1 ++ ".*")
  > 4   ~0%    {2} r26 = JOIN r25 WITH imports_130#join_rhs ON FIRST 2 OUTPUT Rhs.2, Lhs.2
  > 
  > 3850373   ~2%    {3} r27 = JOIN Location#77b33c41::Top::toString#0#dispred#ff#prev_delta WITH classes_or_interfaces ON FIRST 1 OUTPUT Lhs.0, 1, ("import " ++ Lhs.1)
  > 3249   ~0%    {2} r28 = JOIN r27 WITH imports_130#join_rhs ON FIRST 2 OUTPUT Rhs.2, Lhs.2
  > 
  > 3253   ~0%    {2} r29 = r26 UNION r28
  > 3253   ~0%    {2} r30 = r24 UNION r29
  > 
  > 3850373   ~0%    {3} r31 = JOIN Location#77b33c41::Top::toString#0#dispred#ff#prev_delta WITH classes_or_interfaces ON FIRST 1 OUTPUT Lhs.0, 2, ("import " ++ Lhs.1 ++ ".*")
  > 0   ~0%    {2} r32 = JOIN r31 WITH imports_130#join_rhs ON FIRST 2 OUTPUT Rhs.2, Lhs.2
  > 
  > 5890339   ~1%    {3} r33 = SCAN Location#77b33c41::Top::toString#0#dispred#ff#prev_delta OUTPUT In.0, -3, In.1
  > 0   ~0%    {2} r34 = JOIN r33 WITH exprs_043#join_rhs ON FIRST 2 OUTPUT Rhs.2, Lhs.2
  > 0   ~0%    {2} r35 = JOIN r34 WITH Type#6144c3fd::AnonymousClass::getClassInstanceExpr#0#dispred#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1
  > 0   ~0%    {2} r36 = JOIN r35 WITH Location#77b33c41::hasName#2#ff ON FIRST 1 OUTPUT Lhs.0, ("new " ++ Lhs.1 ++ "(...) { ... }" ++ Rhs.1)
  > 
  > 0   ~0%    {2} r37 = r32 UNION r36
  > 
  > 3850373   ~0%    {3} r38 = JOIN Location#77b33c41::Top::toString#0#dispred#ff#prev_delta WITH classes_or_interfaces ON FIRST 1 OUTPUT Lhs.0, 4, ("import static " ++ Lhs.1 ++ ".*")
  > 1   ~0%    {2} r39 = JOIN r38 WITH imports_130#join_rhs ON FIRST 2 OUTPUT Rhs.2, Lhs.2
  > 
  > 3850373   ~1%    {3} r40 = JOIN Location#77b33c41::Top::toString#0#dispred#ff#prev_delta WITH classes_or_interfaces ON FIRST 1 OUTPUT Lhs.0, 5, Lhs.1
  > 2395   ~1%    {2} r41 = JOIN r40 WITH imports_1302#join_rhs ON FIRST 2 OUTPUT Rhs.2, ("import static " ++ Lhs.2 ++ "." ++ Rhs.3)
  > 
  > 5890251   ~0%    {2} r42 = Location#77b33c41::Top::toString#0#dispred#ff#prev_delta AND NOT isParenthesized_0#antijoin_rhs(Lhs.0)
  > 233   ~0%    {2} r43 = JOIN r42 WITH Expr#20226873::VarAccess::getQualifier#0#dispred#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1
  > 233   ~0%    {2} r44 = r43 AND NOT Expr#20226873::ExtensionReceiverAccess#f(Lhs.0)
  > 233   ~0%    {2} r45 = r44 AND NOT Expr#20226873::ExtensionReceiverAccess#f(Lhs.0)
  > 233   ~1%    {3} r46 = JOIN r45 WITH variableBinding ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.0
  > 233   ~0%    {2} r47 = JOIN r46 WITH Element#c53922e0::Element::hasName#1#dispred#ff ON FIRST 1 OUTPUT Lhs.2, (Lhs.1 ++ "." ++ Rhs.1)
  > 
  > 2628   ~0%    {2} r48 = r41 UNION r47
  > 2629   ~0%    {2} r49 = r39 UNION r48
  > 2629   ~0%    {2} r50 = r37 UNION r49
  > 5882   ~0%    {2} r51 = r30 UNION r50
  > 16396   ~3%    {2} r52 = r19 UNION r51
  > 16396   ~3%    {2} r53 = r52 AND NOT Location#77b33c41::Top::toString#0#dispred#ff#prev(Lhs.0, Lhs.1)
  > return r53

  < Evaluated relational algebra for predicate Location#77b33c41::Top::toString#0#dispred#ff@5abb2wft on iteration 2 running pipeline order_500000 with tuple counts:
  < 0   ~0%    {2} r1 = Expr#20226873::TypeAccess::toString#ff#prev_delta UNION Member#9eba3c33::FieldDeclaration::toString#ff#prev_delta
  < 
  < 8815   ~1%    {2} r2 = JOIN Location#77b33c41::Top::toString#0#dispred#ff#prev_delta WITH _@reftype#f_exceptions#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1
  < 
  < 0   ~0%    {2} r3 = JOIN Location#77b33c41::Top::toString#0#dispred#ff#prev_delta WITH Compose#5a270a32::LiveLiteral::getValue#0#dispred#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1
  < 
  < 8815   ~1%    {2} r4 = r2 UNION r3
  < 8815   ~1%    {2} r5 = r1 UNION r4
  < 
  < 7   ~0%    {2} r6 = JOIN Location#77b33c41::Top::toString#0#dispred#ff#prev_delta WITH _Expr#20226873::Expr::getType#0#dispred#ff__exprs_10#join_rhs#antijoin_rhs#17#join_rhs ON FIRST 1 OUTPUT Rhs.1, ("new " ++ Lhs.1)
  < 
  < 233   ~0%    {2} r7 = JOIN Location#77b33c41::Top::toString#0#dispred#ff#prev_delta WITH _Element#c53922e0::Element::hasName#1#dispred#ff_Expr#20226873::ExtensionReceiverAccess#f_Expr#20226__#join_rhs ON FIRST 1 OUTPUT Rhs.1, (Lhs.1 ++ "." ++ Rhs.2)
  < 
  < 240   ~0%    {2} r8 = r6 UNION r7
  < 
  < 3   ~0%    {2} r9 = JOIN Location#77b33c41::Top::toString#0#dispred#ff#prev_delta WITH __exprs_10#join_rhs#antijoin_rhs#32_exprs_30#join_rhs#join_rhs ON FIRST 1 OUTPUT Rhs.1, (Lhs.1 ++ ".class")
  < 
  < 3249   ~0%    {2} r10 = JOIN Location#77b33c41::Top::toString#0#dispred#ff#prev_delta WITH _classes_or_interfaces_imports_301#join_rhs#join_rhs#2 ON FIRST 1 OUTPUT Rhs.1, ("import " ++ Lhs.1)
  < 
  < 0   ~0%    {2} r11 = JOIN Location#77b33c41::Top::toString#0#dispred#ff#prev_delta WITH _classes_or_interfaces_imports_301#join_rhs#join_rhs ON FIRST 1 OUTPUT Rhs.1, ("import " ++ Lhs.1 ++ ".*")
  < 
  < 3249   ~0%    {2} r12 = r10 UNION r11
  < 3252   ~0%    {2} r13 = r9 UNION r12
  < 3492   ~0%    {2} r14 = r8 UNION r13
  < 12307   ~0%    {2} r15 = r5 UNION r14
  < 
  < 0   ~0%    {2} r16 = JOIN Location#77b33c41::Top::toString#0#dispred#ff#prev_delta WITH kt_notnull_types_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, ("Kotlin not-null " ++ Lhs.1)
  < 
  < 0   ~0%    {2} r17 = JOIN Location#77b33c41::Top::toString#0#dispred#ff#prev_delta WITH kt_nullable_types_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, ("Kotlin nullable " ++ Lhs.1)
  < 
  < 0   ~0%    {2} r18 = r16 UNION r17
  < 
  < 1   ~0%    {2} r19 = JOIN Location#77b33c41::Top::toString#0#dispred#ff#prev_delta WITH _classes_or_interfaces_imports_301#join_rhs#join_rhs#1 ON FIRST 1 OUTPUT Rhs.1, ("import static " ++ Lhs.1 ++ ".*")
  < 
  < 2395   ~0%    {2} r20 = JOIN Location#77b33c41::Top::toString#0#dispred#ff#prev_delta WITH _classes_or_interfaces_imports_3012#join_rhs#join_rhs ON FIRST 1 OUTPUT Rhs.1, ("import static " ++ Lhs.1 ++ "." ++ Rhs.2)
  < 
  < 2396   ~0%    {2} r21 = r19 UNION r20
  < 2396   ~0%    {2} r22 = r18 UNION r21
  < 
  < 5429   ~0%    {2} r23 = JOIN Location#77b33c41::Top::toString#0#dispred#ff#prev_delta WITH Javadoc#9657445a::JavadocParent::getChild#1#dispred#fbf#cpe#13_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1
  < 1689   ~0%    {3} r24 = JOIN r23 WITH Javadoc#9657445a::Javadoc::toStringPrefix#0#dispred#ff ON FIRST 1 OUTPUT Lhs.0, Lhs.1, Rhs.1
  < 1689   ~7%    {2} r25 = JOIN r24 WITH Javadoc#9657445a::Javadoc::toStringPostfix#0#dispred#ff ON FIRST 1 OUTPUT Lhs.0, (Lhs.2 ++ Lhs.1 ++ Rhs.1)
  < 
  < 0   ~0%    {3} r26 = JOIN Location#77b33c41::Top::toString#0#dispred#ff#prev_delta WITH Expr#20226873::InstanceAccess::getQualifier#0#dispred#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, 58, Lhs.1
  < 0   ~0%    {2} r27 = JOIN r26 WITH exprs ON FIRST 2 OUTPUT Lhs.0, (Lhs.2 ++ ".this")
  < 
  < 1689   ~7%    {2} r28 = r25 UNION r27
  < 
  < 127   ~0%    {3} r29 = JOIN Location#77b33c41::Top::toString#0#dispred#ff#prev_delta WITH packages_00#join_rhs ON FIRST 1 OUTPUT Rhs.1, 3, ("import " ++ Lhs.1 ++ ".*")
  < 4   ~0%    {2} r30 = JOIN r29 WITH imports_130#join_rhs ON FIRST 2 OUTPUT Rhs.2, Lhs.2
  < 
  < 0   ~0%    {3} r31 = JOIN Location#77b33c41::Top::toString#0#dispred#ff#prev_delta WITH Expr#20226873::InstanceAccess::getQualifier#0#dispred#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, 59, Lhs.1
  < 0   ~0%    {2} r32 = JOIN r31 WITH exprs ON FIRST 2 OUTPUT Lhs.0, (Lhs.2 ++ ".super")
  < 
  < 0   ~0%    {2} r33 = JOIN Location#77b33c41::Top::toString#0#dispred#ff#prev_delta WITH _Type#6144c3fd::AnonymousClass::getClassInstanceExpr#0#dispred#ff_exprs_340#join_rhs#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1
  < 0   ~0%    {2} r34 = JOIN r33 WITH Location#77b33c41::hasName#2#ff ON FIRST 1 OUTPUT Lhs.0, ("new " ++ Lhs.1 ++ "(...) { ... }" ++ Rhs.1)
  < 
  < 0   ~0%    {2} r35 = r32 UNION r34
  < 4   ~0%    {2} r36 = r30 UNION r35
  < 1693   ~8%    {2} r37 = r28 UNION r36
  < 4089   ~5%    {2} r38 = r22 UNION r37
  < 16396   ~2%    {2} r39 = r15 UNION r38
  < 16396   ~2%    {2} r40 = r39 AND NOT Location#77b33c41::Top::toString#0#dispred#ff#prev(Lhs.0, Lhs.1)
  < return r40
```