### PR TITLE
Python: Enable implicit this warnings

### DIFF
--- a/python/ql/lib/qlpack.yml
+++ b/python/ql/lib/qlpack.yml
@@ -12,3 +12,4 @@ dependencies:
   codeql/yaml: ${workspace}
 dataExtensions:
   - semmle/python/frameworks/**/model.yml
+warnOnImplicitThis: true

--- a/python/ql/src/qlpack.yml
+++ b/python/ql/src/qlpack.yml
@@ -9,3 +9,4 @@ dependencies:
 suites: codeql-suites
 extractor: python
 defaultSuiteFile: codeql-suites/python-code-scanning.qls
+warnOnImplicitThis: true

--- a/python/ql/test/experimental/meta/ConceptsTest.qll
+++ b/python/ql/test/experimental/meta/ConceptsTest.qll
@@ -297,7 +297,7 @@ class HttpServerHttpResponseTest extends InlineExpectationsTest {
     location.getFile() = file and
     exists(file.getRelativePath()) and
     // we need to do this step since we expect subclasses could override getARelevantTag
-    tag = getARelevantTag() and
+    tag = this.getARelevantTag() and
     (
       exists(Http::Server::HttpResponse response |
         location = response.getLocation() and

--- a/python/ql/test/library-tests/ApiGraphs/py2/use.ql
+++ b/python/ql/test/library-tests/ApiGraphs/py2/use.ql
@@ -13,12 +13,12 @@ class ApiUseTest extends InlineExpectationsTest {
   }
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
-    exists(DataFlow::Node n | relevant_node(_, n, location) |
+    exists(DataFlow::Node n | this.relevant_node(_, n, location) |
       tag = "use" and
       // Only report the longest path on this line:
       value =
         max(API::Node a2, Location l2 |
-          relevant_node(a2, _, l2) and
+          this.relevant_node(a2, _, l2) and
           l2.getFile() = location.getFile() and
           l2.getStartLine() = location.getStartLine()
         |

--- a/python/ql/test/qlpack.yml
+++ b/python/ql/test/qlpack.yml
@@ -5,3 +5,4 @@ dependencies:
     codeql/python-queries: ${workspace}
 extractor: python
 tests: .
+warnOnImplicitThis: true

--- a/python/ql/test/query-tests/Functions/ModificationOfParameterWithDefault/test.ql
+++ b/python/ql/test/query-tests/Functions/ModificationOfParameterWithDefault/test.ql
@@ -14,7 +14,7 @@ class ModificationOfParameterWithDefaultTest extends InlineExpectationsTest {
   }
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
-    exists(DataFlow::Node n | relevant_node(n) |
+    exists(DataFlow::Node n | this.relevant_node(n) |
       n.getLocation() = location and
       tag = "modification" and
       value = prettyNode(n) and


### PR DESCRIPTION
Enable warnings for member predicate calls with implicit this receivers for Python to prevent them from reappearing.