### PR TITLE
C#: Never treat warnings as error in the extractor

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp/Extractor/CompilerVersion.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Extractor/CompilerVersion.cs
@@ -130,9 +130,14 @@ namespace Semmle.Extraction.CSharp
         /// <returns>Modified list of arguments.</returns>
         private static IEnumerable<string> AddDefaultResponse(string responseFile, IEnumerable<string> args)
         {
-            return SuppressDefaultResponseFile(args) || !File.Exists(responseFile) ?
+            var ret = SuppressDefaultResponseFile(args) || !File.Exists(responseFile) ?
                 args :
                 new[] { "@" + responseFile }.Concat(args);
+
+            // make sure to never treat warnings as errors in the extractor:
+            // our version of Roslyn may report warnings that the actual build
+            // doesn't
+            return ret.Concat(new[] { "/warnaserror-" });
         }
 
         private static bool SuppressDefaultResponseFile(IEnumerable<string> args)

--- a/csharp/ql/integration-tests/posix-only/warn_as_error/Errors.ql
+++ b/csharp/ql/integration-tests/posix-only/warn_as_error/Errors.ql
@@ -1,0 +1,6 @@
+import csharp
+import semmle.code.csharp.commons.Diagnostics
+
+from Diagnostic d
+where d.getSeverity() >= 3
+select d

--- a/csharp/ql/integration-tests/posix-only/warn_as_error/Program.cs
+++ b/csharp/ql/integration-tests/posix-only/warn_as_error/Program.cs
@@ -1,0 +1,4 @@
+﻿// See https://aka.ms/new-console-template for more information
+Console.WriteLine("Hello, World!");
+
+var x = "unused";

--- a/csharp/ql/integration-tests/posix-only/warn_as_error/WarnAsError.csproj
+++ b/csharp/ql/integration-tests/posix-only/warn_as_error/WarnAsError.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+</Project>

--- a/csharp/ql/integration-tests/posix-only/warn_as_error/build.sh
+++ b/csharp/ql/integration-tests/posix-only/warn_as_error/build.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Will fail because of a warning
+dotnet build
+
+# Pretend it didn't fail, so extraction succeeds (which doesn't treat warnings as errors)
+exit 0

--- a/csharp/ql/integration-tests/posix-only/warn_as_error/test.py
+++ b/csharp/ql/integration-tests/posix-only/warn_as_error/test.py
@@ -1,0 +1,7 @@
+import os
+from create_database_utils import *
+from diagnostics_test_utils import *
+
+run_codeql_database_create(["./build.sh"], lang="csharp", extra_args=["--extractor-option=cil=false"])
+
+check_diagnostics()


### PR DESCRIPTION
This PR ensures that the extractor never treats warnings as errors. Since the extractor may be using another version of Roslyn than the actual build, our extractor may produce warnings that the actual build doesn't.

DCA run confirms that we now have less extraction errors:
![image](https://github.com/github/codeql/assets/3667920/dc5d38c9-9f9a-41b6-af24-72624716ddbe)
