### PR TITLE
C++: Work around poor codegen for `forex` in IR-based range analysis

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/rangeanalysis/new/internal/semantic/analysis/ModulusAnalysis.qll
+++ b/cpp/ql/lib/semmle/code/cpp/rangeanalysis/new/internal/semantic/analysis/ModulusAnalysis.qll
@@ -121,13 +121,6 @@ module ModulusAnalysis<DeltaSig D, BoundSig<D> Bounds, UtilSig<D> U> {
   }
 
   /**
-   * Holds if `rix` is the number of input edges to `phi`.
-   */
-  private predicate maxPhiInputRank(SemSsaPhiNode phi, int rix) {
-    rix = max(int r | rankedPhiInput(phi, _, _, r))
-  }
-
-  /**
    * Gets the remainder of `val` modulo `mod`.
    *
    * For `mod = 0` the result equals `val` and for `mod > 1` the result is within
@@ -321,21 +314,5 @@ module ModulusAnalysis<DeltaSig D, BoundSig<D> Bounds, UtilSig<D> U> {
       or
       semExprModulus(rarg, b, val, mod) and isLeft = false
     )
-  }
-
-  /**
-   * Holds if `inp` is an input to `phi` along `edge` and this input has index `r`
-   * in an arbitrary 1-based numbering of the input edges to `phi`.
-   */
-  private predicate rankedPhiInput(
-    SemSsaPhiNode phi, SemSsaVariable inp, SemSsaReadPositionPhiInputEdge edge, int r
-  ) {
-    edge.phiInput(phi, inp) and
-    edge =
-      rank[r](SemSsaReadPositionPhiInputEdge e |
-        e.phiInput(phi, _)
-      |
-        e order by e.getOrigBlock().getUniqueId()
-      )
   }
 }

--- a/cpp/ql/lib/semmle/code/cpp/rangeanalysis/new/internal/semantic/analysis/RangeUtils.qll
+++ b/cpp/ql/lib/semmle/code/cpp/rangeanalysis/new/internal/semantic/analysis/RangeUtils.qll
@@ -138,3 +138,26 @@ module RangeUtil<Range::DeltaSig D, Range::LangSig<D> Lang> implements Range::Ut
     not exists(Lang::getAlternateTypeForSsaVariable(var)) and result = var.getType()
   }
 }
+
+/**
+ * Holds if `rix` is the number of input edges to `phi`.
+ */
+predicate maxPhiInputRank(SemSsaPhiNode phi, int rix) {
+  rix = max(int r | rankedPhiInput(phi, _, _, r))
+}
+
+/**
+ * Holds if `inp` is an input to `phi` along `edge` and this input has index `r`
+ * in an arbitrary 1-based numbering of the input edges to `phi`.
+ */
+predicate rankedPhiInput(
+  SemSsaPhiNode phi, SemSsaVariable inp, SemSsaReadPositionPhiInputEdge edge, int r
+) {
+  edge.phiInput(phi, inp) and
+  edge =
+    rank[r](SemSsaReadPositionPhiInputEdge e |
+      e.phiInput(phi, _)
+    |
+      e order by e.getOrigBlock().getUniqueId()
+    )
+}


### PR DESCRIPTION
Recursion through `forall` and `forex` needs special care in QL. During the modulus-analysis phase of the IR-based range analysis such care is already taken, but the same level of care wasn't taken in the main range analysis module. This resulted in horrible antijoins on some projects. Here is one such example:
```ql
Tuple counts for antijoin_rhs#3/9@i7#L1#982a1web after 31.3s:
  259071899 ~88%        {11} r1 = JOIN boundedPhiCandValidForEdge#9#fffffffff#prev_delta WITH SemanticSSA#aa9d1d08::SemSsaReadPositionPhiInputEdge::phiInput#2#dispred#fff_102#join_rhs ON FIRST 1 OUTPUT Lhs.0 'arg0', Lhs.1 'arg1', Lhs.2 'arg2', Lhs.3 'arg3', Lhs.4 'arg4', Lhs.5 'arg5', Lhs.6 'arg6', Lhs.7 'arg7', Lhs.8 'arg8', Rhs.1, Rhs.2
  83255000  ~80%        {11} r2 = r1 AND NOT boundedPhiCandValidForEdge#9#fffffffff#prev(Lhs.0 'arg0', Lhs.1 'arg1', Lhs.2 'arg2', Lhs.3 'arg3', Lhs.4 'arg4', Lhs.5 'arg5', Lhs.6 'arg6', Lhs.10, Lhs.9)
  83255000  ~23702%     {9} r3 = SCAN r2 OUTPUT In.0 'arg0', In.1 'arg1', In.2 'arg2', In.3 'arg3', In.4 'arg4', In.5 'arg5', In.6 'arg6', In.7 'arg7', In.8 'arg8'
                        return r3
```
(I cancelled the evaluation midway)

This PR moves the modulus-analysis tricks to the `Utils` file, and uses it in the main range analysis module. This results in a much better pipeline:
```ql
Pipeline order_500000 for boundedPhi#7#fffffff@76642xk3 was evaluated in 1740 iterations totaling 282ms (delta sizes total: 36475).
        580384  ~11%    {8} r1 = SCAN boundedPhiRankStep#8#ffffffff#prev_delta OUTPUT In.0, In.7, In.1, In.2, In.3, In.4, In.5, In.6
        580384  ~11%    {8} r2 = r1 AND NOT boundedPhi#7#fffffff#prev(Lhs.0, Lhs.2, Lhs.3, Lhs.4, Lhs.5, Lhs.6, Lhs.7)
        36850   ~10%    {7} r3 = JOIN r2 WITH RangeUtils#6da26777::maxPhiInputRank#2#ff ON FIRST 2 OUTPUT Lhs.0, Lhs.2, Lhs.3, Lhs.4, Lhs.5, Lhs.6, Lhs.7
                        return r3
```
The "trick" is to replace code such as:
```ql
predicate p() { forex(X x | range(x) | recPred(x)) }
```
with
```ql
X getElement(int i) { ... }

predicate pFromIndex(int i) {
  recPred(getElement(i)) and
  if i = 1 then any() else pFromIndex(i - 1)
}

predicate p() { pFromIndex(max(int i | exists(getElement(i))) }
```