### PR TITLE
Java: Minor perf fix for typePrefixContainsAux1.

### DIFF
--- a/java/ql/lib/semmle/code/java/Type.qll
+++ b/java/ql/lib/semmle/code/java/Type.qll
@@ -192,13 +192,18 @@ private predicate typePrefixContains_ext_neq(ParameterizedPrefix pps, Parameteri
 }
 
 pragma[nomagic]
+private TTypeParam parameterizedPrefixWithWildcard(ParameterizedPrefix pps0, Wildcard s) {
+  result = TTypeParam(pps0, s)
+}
+
+pragma[nomagic]
 private predicate typePrefixContainsAux1(
   ParameterizedPrefix pps, ParameterizedPrefix ppt0, RefType s
 ) {
   exists(ParameterizedPrefix pps0 |
     typePrefixContains(pps0, ppt0) and
-    pps = TTypeParam(pps0, s) and
-    s instanceof Wildcard // manual magic, implied by `typeArgumentContains(_, s, t, _)`
+    // `s instanceof Wildcard` is manual magic, implied by `typeArgumentContains(_, s, t, _)`
+    pps = parameterizedPrefixWithWildcard(pps0, s)
   )
 }
 


### PR DESCRIPTION
This was found to be needed for certain extreme corner-cases when testing disabling the standard order.

As it's just materialising a filter on an already materialised predicate as a loop-invariant (this already happened to be used in the std order, btw), it is pretty much as safe as perf tweaks go, and I've also inspected the RA, which only amounts to a tiny diff - promoting the current standard order to be used for all delta sizes.