### PR TITLE
Java: Enable implicit this receiver warnings

### DIFF
--- a/java/ql/lib/qlpack.yml
+++ b/java/ql/lib/qlpack.yml
@@ -14,3 +14,4 @@ dataExtensions:
   - ext/*.model.yml
   - ext/generated/*.model.yml
   - ext/experimental/*.model.yml
+warnOnImplicitThis: true

--- a/java/ql/src/qlpack.yml
+++ b/java/ql/src/qlpack.yml
@@ -12,3 +12,4 @@ dependencies:
   codeql/util: ${workspace}
 dataExtensions:
   - Telemetry/ExtractorInformation.yml
+warnOmImplicitThis: true

--- a/java/ql/test/qlpack.yml
+++ b/java/ql/test/qlpack.yml
@@ -5,3 +5,4 @@ dependencies:
     codeql/java-queries: ${workspace}
 extractor: java
 tests: .
+warnOnImplicitThis: true


### PR DESCRIPTION
Enable warnings for member predicate calls with implicit this receivers for Java to prevent them from reappearing.