### PR TITLE
Go: Downgrade go/autobuilder/package-not-found diagnostic to warning

### DIFF
--- a/go/extractor/diagnostics/diagnostics.go
+++ b/go/extractor/diagnostics/diagnostics.go
@@ -155,7 +155,7 @@ func EmitCannotFindPackages(pkgPaths []string) {
 		"go/autobuilder/package-not-found",
 		"Some packages could not be found",
 		fmt.Sprintf("%d package%s could not be found.\n\n%s.\n\nCheck that the paths are correct and make sure any private packages can be accessed. If any of the packages are present in the repository then you may need a [custom build command](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-the-codeql-workflow-for-compiled-languages).", numPkgPaths, ending, secondLine),
-		severityError,
+		severityWarning,
 		fullVisibility,
 		noLocation,
 	)

--- a/go/ql/integration-tests/all-platforms/go/diagnostics/package-not-found-with-go-mod/diagnostics.expected
+++ b/go/ql/integration-tests/all-platforms/go/diagnostics/package-not-found-with-go-mod/diagnostics.expected
@@ -1,6 +1,6 @@
 {
   "markdownMessage": "110 packages could not be found.\n\n`github.com/nosuchorg/nosuchrepo000`, `github.com/nosuchorg/nosuchrepo001`, `github.com/nosuchorg/nosuchrepo002`, `github.com/nosuchorg/nosuchrepo003`, `github.com/nosuchorg/nosuchrepo004` and 105 more.\n\nCheck that the paths are correct and make sure any private packages can be accessed. If any of the packages are present in the repository then you may need a [custom build command](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-the-codeql-workflow-for-compiled-languages).",
-  "severity": "error",
+  "severity": "warning",
   "source": {
     "extractorName": "go",
     "id": "go/autobuilder/package-not-found",

--- a/go/ql/integration-tests/all-platforms/go/diagnostics/package-not-found-without-go-mod/diagnostics.expected
+++ b/go/ql/integration-tests/all-platforms/go/diagnostics/package-not-found-without-go-mod/diagnostics.expected
@@ -1,6 +1,6 @@
 {
   "markdownMessage": "1 package could not be found.\n\n`github.com/linode/linode-docs-theme`.\n\nCheck that the paths are correct and make sure any private packages can be accessed. If any of the packages are present in the repository then you may need a [custom build command](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-the-codeql-workflow-for-compiled-languages).",
-  "severity": "error",
+  "severity": "warning",
   "source": {
     "extractorName": "go",
     "id": "go/autobuilder/package-not-found",


### PR DESCRIPTION
error is reserved for when the build fails.