### PR TITLE
C++: Fix Microsoft PCH header variant test

### DIFF
--- a/cpp/ql/test/header-variant-tests/microsoft-pch/b.c
+++ b/cpp/ql/test/header-variant-tests/microsoft-pch/b.c
@@ -1,4 +1,3 @@
-#pragma hdrstop
 #include "b.h"
 
 int b() {


### PR DESCRIPTION
Due to a bug in the extractor, `#pragma hdrstop` is ignored and instead `#include "b.h"` is picked up as the point for PCH insertion (and everything before that point is ignored). However, if `#pragma hdrstop` occurs earlier that should be the point of insertion according to the Microsoft documentation and consequently `#include "b.h` should be picked up as a real `#include`, which is going to fail here once we fix the bug in the extractor, because `b.h` is not a file that exists.

Note that the extractor fix will include a test that properly exercises `#pragma hdrstop`.