### PR TITLE
JS: Add pragma[only_bind_out] to Locatable::toString() calls

### DIFF
--- a/javascript/ql/lib/semmle/javascript/CFG.qll
+++ b/javascript/ql/lib/semmle/javascript/CFG.qll
@@ -364,7 +364,9 @@ class SyntheticControlFlowNode extends @synthetic_cfg_node, ControlFlowNode {
 class ControlFlowEntryNode extends SyntheticControlFlowNode, @entry_node {
   override predicate isUnreachable() { none() }
 
-  override string toString() { result = "entry node of " + this.getContainer().toString() }
+  override string toString() {
+    result = "entry node of " + pragma[only_bind_out](this.getContainer()).toString()
+  }
 }
 
 /** A synthetic CFG node marking the exit of a function or toplevel script. */
@@ -373,7 +375,9 @@ class ControlFlowExitNode extends SyntheticControlFlowNode, @exit_node {
     exit_cfg_node(this, container)
   }
 
-  override string toString() { result = "exit node of " + this.getContainer().toString() }
+  override string toString() {
+    result = "exit node of " + pragma[only_bind_out](this.getContainer()).toString()
+  }
 }
 
 /**


### PR DESCRIPTION
This PR adds `pragma[only_bind_out]` to recursive `Locatable::ToString()` calls to fix bad join order `order_3163` for `Locations#c853d51f::Locatable::toString#0#dispred#ff`.  With this change `order_3163` becomes folded into `standard` join order.

This change currently does not have any performance implication, positive or negative, because for large deltas the evaluator would choose the standard order. But it will help with performance if we remove the standard order, as seen in the following before-and-after comparison:

```
Predicate Locations#c853d51f::Locatable::toString#0#dispred#ff: order_3163 -> standard:
  142ms -> 2ms, Locations#c853d51f::Locatable::toString#0#dispred#ff@daa91bcf @0ed22b53 iteration 3 (UnusedVariable.ql stage 3)
  5538ms -> 79ms, Locations#c853d51f::Locatable::toString#0#dispred#ff@daa91bcf @0ed22b53 iteration 2 (UnusedVariable.ql stage 3)

  > Evaluated relational algebra for predicate Locations#c853d51f::Locatable::toString#0#dispred#ff@daa91bcf on iteration 2 running pipeline order_3163 with tuple counts:
  > 6297018   ~2%    {2} r1 = SCAN Locations#c853d51f::Locatable::toString#0#dispred#ff#prev_delta OUTPUT In.0, ("exit node of " ++ In.1)
  > 2692104   ~5%    {2} r2 = JOIN r1 WITH StmtContainers#f9b78d9f::getStmtContainer#1#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1
  > 62735   ~1%    {2} r3 = JOIN r2 WITH exit_cfg_node ON FIRST 1 OUTPUT Lhs.0, Lhs.1
  > 
  > 6297018   ~0%    {2} r4 = SCAN Locations#c853d51f::Locatable::toString#0#dispred#ff#prev_delta OUTPUT In.0, ("entry node of " ++ In.1)
  > 2692104   ~1%    {2} r5 = JOIN r4 WITH StmtContainers#f9b78d9f::getStmtContainer#1#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1
  > 62735   ~2%    {2} r6 = JOIN r5 WITH entry_cfg_node ON FIRST 1 OUTPUT Lhs.0, Lhs.1
  > 
  > 125470   ~1%    {2} r7 = r3 UNION r6
  > 125470   ~1%    {2} r8 = r7 AND NOT Locations#c853d51f::Locatable::toString#0#dispred#ff#prev(Lhs.0, Lhs.1)
  > return r8

  < Evaluated relational algebra for predicate Locations#c853d51f::Locatable::toString#0#dispred#ff@0ed22b53 on iteration 2 running pipeline standard with tuple counts:
  < 62735   ~0%    {2} r1 = JOIN Locations#c853d51f::Locatable::toString#0#dispred#ff#prev_delta WITH _StmtContainers#f9b78d9f::getStmtContainer#1#ff_exit_cfg_node#join_rhs ON FIRST 1 OUTPUT Rhs.1, ("exit node of " ++ Lhs.1)
  < 
  < 62735   ~1%    {2} r2 = JOIN Locations#c853d51f::Locatable::toString#0#dispred#ff#prev_delta WITH _StmtContainers#f9b78d9f::getStmtContainer#1#ff_entry_cfg_node#join_rhs ON FIRST 1 OUTPUT Rhs.1, ("entry node of " ++ Lhs.1)
  < 
  < 125470   ~0%    {2} r3 = r1 UNION r2
  < 125470   ~0%    {2} r4 = r3 AND NOT Locations#c853d51f::Locatable::toString#0#dispred#ff#prev(Lhs.0, Lhs.1)
  < return r4
```