### PR TITLE
Shared: Fix clippy in shared extractor

### DIFF
--- a/.github/workflows/tree-sitter-extractor-test.yml
+++ b/.github/workflows/tree-sitter-extractor-test.yml
@@ -43,4 +43,4 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Run clippy
-        run: cargo clippy -- --no-deps # -D warnings
+        run: cargo clippy -- --no-deps -D warnings -A clippy::new_without_default -A clippy::too_many_arguments

--- a/shared/tree-sitter-extractor/rust-toolchain.toml
+++ b/shared/tree-sitter-extractor/rust-toolchain.toml
@@ -1,0 +1,7 @@
+# This file specifies the Rust version used to develop and test the shared
+# extractor. It is set to the lowest version of Rust we want to support.
+
+[toolchain]
+channel = "1.68"
+profile = "minimal"
+components = [ "clippy", "rustfmt" ]

--- a/shared/tree-sitter-extractor/src/extractor/simple.rs
+++ b/shared/tree-sitter-extractor/src/extractor/simple.rs
@@ -62,7 +62,7 @@ impl Extractor {
                 main_thread_logger.write(
                     main_thread_logger
                         .new_entry("configuration-error", "Configuration error")
-                        .message("{}; using gzip.", &[diagnostics::MessageArg::Code(&e)])
+                        .message("{}; using gzip.", &[diagnostics::MessageArg::Code(e)])
                         .severity(diagnostics::Severity::Warning),
                 );
                 trap::Compression::Gzip

--- a/shared/tree-sitter-extractor/src/node_types.rs
+++ b/shared/tree-sitter-extractor/src/node_types.rs
@@ -83,10 +83,7 @@ pub enum Storage {
 
 impl Storage {
     pub fn is_column(&self) -> bool {
-        match self {
-            Storage::Column { .. } => true,
-            _ => false,
-        }
+        matches!(self, Storage::Column { .. })
     }
 }
 pub fn read_node_types(prefix: &str, node_types_path: &Path) -> std::io::Result<NodeTypeMap> {


### PR DESCRIPTION
Fix the clippy CI check for the shared extractor by fixing a few issues and ignoring some that seem too noisy to me. I've also pinned the rust version to 1.68 (same as the Ruby and QL extractors) so that the clippy version doesn't change suddenly and break the CI check.