### PR TITLE
Swift: Standardize terminology for ConfigSig queries

### DIFF
--- a/swift/ql/lib/codeql/swift/security/CleartextLoggingExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/CleartextLoggingExtensions.qll
@@ -13,9 +13,6 @@ abstract class CleartextLoggingBarrier extends DataFlow::Node { }
 
 /**
  * A unit class for adding additional flow steps.
- *
- * Extend this class to add additional flow steps that should apply to paths related to
- * cleartext logging of sensitive data vulnerabilities.
  */
 class CleartextLoggingAdditionalFlowStep extends Unit {
   /**

--- a/swift/ql/lib/codeql/swift/security/CleartextLoggingExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/CleartextLoggingExtensions.qll
@@ -12,14 +12,14 @@ abstract class CleartextLoggingSink extends DataFlow::Node { }
 abstract class CleartextLoggingBarrier extends DataFlow::Node { }
 
 /**
- * A unit class for adding additional taint steps.
+ * A unit class for adding additional flow steps.
  *
- * Extend this class to add additional taint steps that should apply to paths related to
+ * Extend this class to add additional flow steps that should apply to paths related to
  * cleartext logging of sensitive data vulnerabilities.
  */
-class CleartextLoggingAdditionalTaintStep extends Unit {
+class CleartextLoggingAdditionalFlowStep extends Unit {
   /**
-   * Holds if the step from `n1` to `n2` should be considered a taint
+   * Holds if the step from `n1` to `n2` should be considered a flow
    * step for flows related to cleartext logging of sensitive data vulnerabilities.
    */
   abstract predicate step(DataFlow::Node n1, DataFlow::Node n2);

--- a/swift/ql/lib/codeql/swift/security/CleartextLoggingExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/CleartextLoggingExtensions.qll
@@ -8,8 +8,8 @@ private import codeql.swift.security.SensitiveExprs
 /** A data flow sink for cleartext logging of sensitive data vulnerabilities. */
 abstract class CleartextLoggingSink extends DataFlow::Node { }
 
-/** A sanitizer for cleartext logging of sensitive data vulnerabilities. */
-abstract class CleartextLoggingSanitizer extends DataFlow::Node { }
+/** A barrier for cleartext logging of sensitive data vulnerabilities. */
+abstract class CleartextLoggingBarrier extends DataFlow::Node { }
 
 /**
  * A unit class for adding additional taint steps.
@@ -33,12 +33,12 @@ private class DefaultCleartextLoggingSink extends CleartextLoggingSink {
 }
 
 /**
- * A sanitizer for `OSLogMessage`s configured with the appropriate privacy option.
+ * A barrier for `OSLogMessage`s configured with the appropriate privacy option.
  * Numeric and boolean arguments aren't redacted unless the `private` or `sensitive` options are used.
  * Arguments of other types are always redacted unless the `public` option is used.
  */
-private class OsLogPrivacyCleartextLoggingSanitizer extends CleartextLoggingSanitizer {
-  OsLogPrivacyCleartextLoggingSanitizer() {
+private class OsLogPrivacyCleartextLoggingBarrier extends CleartextLoggingBarrier {
+  OsLogPrivacyCleartextLoggingBarrier() {
     exists(CallExpr c, AutoClosureExpr e |
       c.getStaticTarget().getName().matches("appendInterpolation(_:%privacy:%)") and
       c.getArgument(0).getExpr() = e and

--- a/swift/ql/lib/codeql/swift/security/CleartextLoggingQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/CleartextLoggingQuery.qll
@@ -23,7 +23,7 @@ module CleartextLoggingConfig implements DataFlow::ConfigSig {
   predicate isBarrierIn(DataFlow::Node node) { isSource(node) }
 
   predicate isAdditionalFlowStep(DataFlow::Node n1, DataFlow::Node n2) {
-    any(CleartextLoggingAdditionalTaintStep s).step(n1, n2)
+    any(CleartextLoggingAdditionalFlowStep s).step(n1, n2)
   }
 }
 

--- a/swift/ql/lib/codeql/swift/security/CleartextLoggingQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/CleartextLoggingQuery.qll
@@ -17,7 +17,7 @@ module CleartextLoggingConfig implements DataFlow::ConfigSig {
 
   predicate isSink(DataFlow::Node sink) { sink instanceof CleartextLoggingSink }
 
-  predicate isBarrier(DataFlow::Node sanitizer) { sanitizer instanceof CleartextLoggingSanitizer }
+  predicate isBarrier(DataFlow::Node barrier) { barrier instanceof CleartextLoggingBarrier }
 
   // Disregard paths that contain other paths. This helps with performance.
   predicate isBarrierIn(DataFlow::Node node) { isSource(node) }

--- a/swift/ql/lib/codeql/swift/security/CleartextStorageDatabaseExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/CleartextStorageDatabaseExtensions.qll
@@ -15,9 +15,9 @@ import codeql.swift.dataflow.ExternalFlow
 abstract class CleartextStorageDatabaseSink extends DataFlow::Node { }
 
 /**
- * A sanitizer for cleartext database storage vulnerabilities.
+ * A barrier for cleartext database storage vulnerabilities.
  */
-abstract class CleartextStorageDatabaseSanitizer extends DataFlow::Node { }
+abstract class CleartextStorageDatabaseBarrier extends DataFlow::Node { }
 
 /**
  * A unit class for adding additional taint steps.
@@ -114,10 +114,10 @@ private class CleartextStorageDatabaseSinks extends SinkModelCsv {
 }
 
 /**
- * An encryption sanitizer for cleartext database storage vulnerabilities.
+ * An encryption barrier for cleartext database storage vulnerabilities.
  */
-private class CleartextStorageDatabaseEncryptionSanitizer extends CleartextStorageDatabaseSanitizer {
-  CleartextStorageDatabaseEncryptionSanitizer() { this.asExpr() instanceof EncryptedExpr }
+private class CleartextStorageDatabaseEncryptionBarrier extends CleartextStorageDatabaseBarrier {
+  CleartextStorageDatabaseEncryptionBarrier() { this.asExpr() instanceof EncryptedExpr }
 }
 
 /**

--- a/swift/ql/lib/codeql/swift/security/CleartextStorageDatabaseExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/CleartextStorageDatabaseExtensions.qll
@@ -20,11 +20,11 @@ abstract class CleartextStorageDatabaseSink extends DataFlow::Node { }
 abstract class CleartextStorageDatabaseBarrier extends DataFlow::Node { }
 
 /**
- * A unit class for adding additional taint steps.
+ * A unit class for adding additional flow steps.
  */
-class CleartextStorageDatabaseAdditionalTaintStep extends Unit {
+class CleartextStorageDatabaseAdditionalFlowStep extends Unit {
   /**
-   * Holds if the step from `node1` to `node2` should be considered a taint
+   * Holds if the step from `node1` to `node2` should be considered a flow
    * step for paths related to cleartext database storage vulnerabilities.
    */
   abstract predicate step(DataFlow::Node nodeFrom, DataFlow::Node nodeTo);
@@ -123,7 +123,7 @@ private class CleartextStorageDatabaseEncryptionBarrier extends CleartextStorage
 /**
  * An additional taint step for cleartext database storage vulnerabilities.
  */
-private class CleartextStorageDatabaseArrayAdditionalTaintStep extends CleartextStorageDatabaseAdditionalTaintStep
+private class CleartextStorageDatabaseArrayAdditionalFlowStep extends CleartextStorageDatabaseAdditionalFlowStep
 {
   override predicate step(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
     // needed until we have proper content flow through arrays.

--- a/swift/ql/lib/codeql/swift/security/CleartextStorageDatabaseQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/CleartextStorageDatabaseQuery.qll
@@ -18,12 +18,10 @@ module CleartextStorageDatabaseConfig implements DataFlow::ConfigSig {
 
   predicate isSink(DataFlow::Node node) { node instanceof CleartextStorageDatabaseSink }
 
-  predicate isBarrier(DataFlow::Node barrier) {
-    barrier instanceof CleartextStorageDatabaseBarrier
-  }
+  predicate isBarrier(DataFlow::Node barrier) { barrier instanceof CleartextStorageDatabaseBarrier }
 
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
-    any(CleartextStorageDatabaseAdditionalTaintStep s).step(nodeFrom, nodeTo)
+    any(CleartextStorageDatabaseAdditionalFlowStep s).step(nodeFrom, nodeTo)
   }
 
   predicate isBarrierIn(DataFlow::Node node) {

--- a/swift/ql/lib/codeql/swift/security/CleartextStorageDatabaseQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/CleartextStorageDatabaseQuery.qll
@@ -18,8 +18,8 @@ module CleartextStorageDatabaseConfig implements DataFlow::ConfigSig {
 
   predicate isSink(DataFlow::Node node) { node instanceof CleartextStorageDatabaseSink }
 
-  predicate isBarrier(DataFlow::Node sanitizer) {
-    sanitizer instanceof CleartextStorageDatabaseSanitizer
+  predicate isBarrier(DataFlow::Node barrier) {
+    barrier instanceof CleartextStorageDatabaseBarrier
   }
 
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {

--- a/swift/ql/lib/codeql/swift/security/CleartextStoragePreferencesExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/CleartextStoragePreferencesExtensions.qll
@@ -18,9 +18,9 @@ abstract class CleartextStoragePreferencesSink extends DataFlow::Node {
 }
 
 /**
- * A sanitizer for cleartext preferences storage vulnerabilities.
+ * A barrier for cleartext preferences storage vulnerabilities.
  */
-abstract class CleartextStoragePreferencesSanitizer extends DataFlow::Node { }
+abstract class CleartextStoragePreferencesBarrier extends DataFlow::Node { }
 
 /**
  * A unit class for adding additional taint steps.
@@ -72,11 +72,11 @@ private class NSUserDefaultsControllerStore extends CleartextStoragePreferencesS
 }
 
 /**
- * An encryption sanitizer for cleartext preferences storage vulnerabilities.
+ * An encryption barrier for cleartext preferences storage vulnerabilities.
  */
-private class CleartextStoragePreferencesEncryptionSanitizer extends CleartextStoragePreferencesSanitizer
+private class CleartextStoragePreferencesEncryptionBarrier extends CleartextStoragePreferencesBarrier
 {
-  CleartextStoragePreferencesEncryptionSanitizer() { this.asExpr() instanceof EncryptedExpr }
+  CleartextStoragePreferencesEncryptionBarrier() { this.asExpr() instanceof EncryptedExpr }
 }
 
 /**

--- a/swift/ql/lib/codeql/swift/security/CleartextStoragePreferencesExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/CleartextStoragePreferencesExtensions.qll
@@ -23,11 +23,11 @@ abstract class CleartextStoragePreferencesSink extends DataFlow::Node {
 abstract class CleartextStoragePreferencesBarrier extends DataFlow::Node { }
 
 /**
- * A unit class for adding additional taint steps.
+ * A unit class for adding additional flow steps.
  */
-class CleartextStoragePreferencesAdditionalTaintStep extends Unit {
+class CleartextStoragePreferencesAdditionalFlowStep extends Unit {
   /**
-   * Holds if the step from `node1` to `node2` should be considered a taint
+   * Holds if the step from `node1` to `node2` should be considered a flow
    * step for paths related to cleartext preferences storage vulnerabilities.
    */
   abstract predicate step(DataFlow::Node nodeFrom, DataFlow::Node nodeTo);

--- a/swift/ql/lib/codeql/swift/security/CleartextStoragePreferencesQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/CleartextStoragePreferencesQuery.qll
@@ -23,7 +23,7 @@ module CleartextStoragePreferencesConfig implements DataFlow::ConfigSig {
   }
 
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
-    any(CleartextStoragePreferencesAdditionalTaintStep s).step(nodeFrom, nodeTo)
+    any(CleartextStoragePreferencesAdditionalFlowStep s).step(nodeFrom, nodeTo)
   }
 
   predicate isBarrierIn(DataFlow::Node node) {

--- a/swift/ql/lib/codeql/swift/security/CleartextStoragePreferencesQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/CleartextStoragePreferencesQuery.qll
@@ -18,8 +18,8 @@ module CleartextStoragePreferencesConfig implements DataFlow::ConfigSig {
 
   predicate isSink(DataFlow::Node node) { node instanceof CleartextStoragePreferencesSink }
 
-  predicate isBarrier(DataFlow::Node sanitizer) {
-    sanitizer instanceof CleartextStoragePreferencesSanitizer
+  predicate isBarrier(DataFlow::Node barrier) {
+    barrier instanceof CleartextStoragePreferencesBarrier
   }
 
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {

--- a/swift/ql/lib/codeql/swift/security/CleartextTransmissionExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/CleartextTransmissionExtensions.qll
@@ -15,9 +15,9 @@ import codeql.swift.dataflow.ExternalFlow
 abstract class CleartextTransmissionSink extends DataFlow::Node { }
 
 /**
- * A sanitizer for cleartext transmission vulnerabilities.
+ * A barrier for cleartext transmission vulnerabilities.
  */
-abstract class CleartextTransmissionSanitizer extends DataFlow::Node { }
+abstract class CleartextTransmissionBarrier extends DataFlow::Node { }
 
 /**
  * A unit class for adding additional taint steps.
@@ -81,10 +81,10 @@ private class AlamofireTransmittedSink extends CleartextTransmissionSink {
 }
 
 /**
- * An encryption sanitizer for cleartext transmission vulnerabilities.
+ * An encryption barrier for cleartext transmission vulnerabilities.
  */
-private class CleartextTransmissionEncryptionSanitizer extends CleartextTransmissionSanitizer {
-  CleartextTransmissionEncryptionSanitizer() { this.asExpr() instanceof EncryptedExpr }
+private class CleartextTransmissionEncryptionBarrier extends CleartextTransmissionBarrier {
+  CleartextTransmissionEncryptionBarrier() { this.asExpr() instanceof EncryptedExpr }
 }
 
 /**

--- a/swift/ql/lib/codeql/swift/security/CleartextTransmissionExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/CleartextTransmissionExtensions.qll
@@ -20,11 +20,11 @@ abstract class CleartextTransmissionSink extends DataFlow::Node { }
 abstract class CleartextTransmissionBarrier extends DataFlow::Node { }
 
 /**
- * A unit class for adding additional taint steps.
+ * A unit class for adding additional flow steps.
  */
-class CleartextTransmissionAdditionalTaintStep extends Unit {
+class CleartextTransmissionAdditionalFlowStep extends Unit {
   /**
-   * Holds if the step from `node1` to `node2` should be considered a taint
+   * Holds if the step from `node1` to `node2` should be considered a flow
    * step for paths related to cleartext transmission vulnerabilities.
    */
   abstract predicate step(DataFlow::Node nodeFrom, DataFlow::Node nodeTo);

--- a/swift/ql/lib/codeql/swift/security/CleartextTransmissionQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/CleartextTransmissionQuery.qll
@@ -18,9 +18,7 @@ module CleartextTransmissionConfig implements DataFlow::ConfigSig {
 
   predicate isSink(DataFlow::Node node) { node instanceof CleartextTransmissionSink }
 
-  predicate isBarrier(DataFlow::Node sanitizer) {
-    sanitizer instanceof CleartextTransmissionSanitizer
-  }
+  predicate isBarrier(DataFlow::Node barrier) { barrier instanceof CleartextTransmissionBarrier }
 
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
     any(CleartextTransmissionAdditionalTaintStep s).step(nodeFrom, nodeTo)

--- a/swift/ql/lib/codeql/swift/security/CleartextTransmissionQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/CleartextTransmissionQuery.qll
@@ -21,7 +21,7 @@ module CleartextTransmissionConfig implements DataFlow::ConfigSig {
   predicate isBarrier(DataFlow::Node barrier) { barrier instanceof CleartextTransmissionBarrier }
 
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
-    any(CleartextTransmissionAdditionalTaintStep s).step(nodeFrom, nodeTo)
+    any(CleartextTransmissionAdditionalFlowStep s).step(nodeFrom, nodeTo)
   }
 
   predicate isBarrierIn(DataFlow::Node node) {

--- a/swift/ql/lib/codeql/swift/security/ConstantPasswordExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/ConstantPasswordExtensions.qll
@@ -14,9 +14,9 @@ import codeql.swift.dataflow.ExternalFlow
 abstract class ConstantPasswordSink extends DataFlow::Node { }
 
 /**
- * A sanitizer for constant password vulnerabilities.
+ * A barrier for constant password vulnerabilities.
  */
-abstract class ConstantPasswordSanitizer extends DataFlow::Node { }
+abstract class ConstantPasswordBarrier extends DataFlow::Node { }
 
 /**
  * A unit class for adding additional taint steps.

--- a/swift/ql/lib/codeql/swift/security/ConstantPasswordExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/ConstantPasswordExtensions.qll
@@ -19,11 +19,11 @@ abstract class ConstantPasswordSink extends DataFlow::Node { }
 abstract class ConstantPasswordBarrier extends DataFlow::Node { }
 
 /**
- * A unit class for adding additional taint steps.
+ * A unit class for adding additional flow steps.
  */
-class ConstantPasswordAdditionalTaintStep extends Unit {
+class ConstantPasswordAdditionalFlowStep extends Unit {
   /**
-   * Holds if the step from `node1` to `node2` should be considered a taint
+   * Holds if the step from `node1` to `node2` should be considered a flow
    * step for paths related to constant password vulnerabilities.
    */
   abstract predicate step(DataFlow::Node nodeFrom, DataFlow::Node nodeTo);

--- a/swift/ql/lib/codeql/swift/security/ConstantPasswordQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/ConstantPasswordQuery.qll
@@ -31,7 +31,7 @@ module ConstantPasswordConfig implements DataFlow::ConfigSig {
   predicate isBarrier(DataFlow::Node node) { node instanceof ConstantPasswordBarrier }
 
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
-    any(ConstantPasswordAdditionalTaintStep s).step(nodeFrom, nodeTo)
+    any(ConstantPasswordAdditionalFlowStep s).step(nodeFrom, nodeTo)
   }
 }
 

--- a/swift/ql/lib/codeql/swift/security/ConstantPasswordQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/ConstantPasswordQuery.qll
@@ -28,7 +28,7 @@ module ConstantPasswordConfig implements DataFlow::ConfigSig {
 
   predicate isSink(DataFlow::Node node) { node instanceof ConstantPasswordSink }
 
-  predicate isBarrier(DataFlow::Node node) { node instanceof ConstantPasswordSanitizer }
+  predicate isBarrier(DataFlow::Node node) { node instanceof ConstantPasswordBarrier }
 
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
     any(ConstantPasswordAdditionalTaintStep s).step(nodeFrom, nodeTo)

--- a/swift/ql/lib/codeql/swift/security/ConstantSaltExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/ConstantSaltExtensions.qll
@@ -19,11 +19,11 @@ abstract class ConstantSaltSink extends DataFlow::Node { }
 abstract class ConstantSaltBarrier extends DataFlow::Node { }
 
 /**
- * A unit class for adding additional taint steps.
+ * A unit class for adding additional flow steps.
  */
-class ConstantSaltAdditionalTaintStep extends Unit {
+class ConstantSaltAdditionalFlowStep extends Unit {
   /**
-   * Holds if the step from `node1` to `node2` should be considered a taint
+   * Holds if the step from `node1` to `node2` should be considered a flow
    * step for paths related to constant salt vulnerabilities.
    */
   abstract predicate step(DataFlow::Node nodeFrom, DataFlow::Node nodeTo);

--- a/swift/ql/lib/codeql/swift/security/ConstantSaltExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/ConstantSaltExtensions.qll
@@ -14,9 +14,9 @@ import codeql.swift.dataflow.ExternalFlow
 abstract class ConstantSaltSink extends DataFlow::Node { }
 
 /**
- * A sanitizer for constant salt vulnerabilities.
+ * A barrier for constant salt vulnerabilities.
  */
-abstract class ConstantSaltSanitizer extends DataFlow::Node { }
+abstract class ConstantSaltBarrier extends DataFlow::Node { }
 
 /**
  * A unit class for adding additional taint steps.

--- a/swift/ql/lib/codeql/swift/security/ConstantSaltQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/ConstantSaltQuery.qll
@@ -32,7 +32,7 @@ module ConstantSaltConfig implements DataFlow::ConfigSig {
   predicate isBarrier(DataFlow::Node node) { node instanceof ConstantSaltBarrier }
 
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
-    any(ConstantSaltAdditionalTaintStep s).step(nodeFrom, nodeTo)
+    any(ConstantSaltAdditionalFlowStep s).step(nodeFrom, nodeTo)
   }
 }
 

--- a/swift/ql/lib/codeql/swift/security/ConstantSaltQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/ConstantSaltQuery.qll
@@ -29,7 +29,7 @@ module ConstantSaltConfig implements DataFlow::ConfigSig {
 
   predicate isSink(DataFlow::Node node) { node instanceof ConstantSaltSink }
 
-  predicate isBarrier(DataFlow::Node node) { node instanceof ConstantSaltSanitizer }
+  predicate isBarrier(DataFlow::Node node) { node instanceof ConstantSaltBarrier }
 
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
     any(ConstantSaltAdditionalTaintStep s).step(nodeFrom, nodeTo)

--- a/swift/ql/lib/codeql/swift/security/ECBEncryptionExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/ECBEncryptionExtensions.qll
@@ -27,11 +27,11 @@ abstract class EcbEncryptionSink extends DataFlow::Node { }
 abstract class EcbEncryptionBarrier extends DataFlow::Node { }
 
 /**
- * A unit class for adding additional taint steps.
+ * A unit class for adding additional flow steps.
  */
-class EcbEncryptionAdditionalTaintStep extends Unit {
+class EcbEncryptionAdditionalFlowStep extends Unit {
   /**
-   * Holds if the step from `node1` to `node2` should be considered a taint
+   * Holds if the step from `node1` to `node2` should be considered a flow
    * step for paths related to ECB encryption vulnerabilities.
    */
   abstract predicate step(DataFlow::Node nodeFrom, DataFlow::Node nodeTo);

--- a/swift/ql/lib/codeql/swift/security/ECBEncryptionExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/ECBEncryptionExtensions.qll
@@ -22,9 +22,9 @@ abstract class EcbEncryptionSource extends DataFlow::Node { }
 abstract class EcbEncryptionSink extends DataFlow::Node { }
 
 /**
- * A sanitizer for ECB encryption vulnerabilities.
+ * A barrier for ECB encryption vulnerabilities.
  */
-abstract class EcbEncryptionSanitizer extends DataFlow::Node { }
+abstract class EcbEncryptionBarrier extends DataFlow::Node { }
 
 /**
  * A unit class for adding additional taint steps.

--- a/swift/ql/lib/codeql/swift/security/ECBEncryptionQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/ECBEncryptionQuery.qll
@@ -20,7 +20,7 @@ module EcbEncryptionConfig implements DataFlow::ConfigSig {
   predicate isBarrier(DataFlow::Node node) { node instanceof EcbEncryptionBarrier }
 
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
-    any(EcbEncryptionAdditionalTaintStep s).step(nodeFrom, nodeTo)
+    any(EcbEncryptionAdditionalFlowStep s).step(nodeFrom, nodeTo)
   }
 }
 

--- a/swift/ql/lib/codeql/swift/security/ECBEncryptionQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/ECBEncryptionQuery.qll
@@ -17,7 +17,7 @@ module EcbEncryptionConfig implements DataFlow::ConfigSig {
 
   predicate isSink(DataFlow::Node node) { node instanceof EcbEncryptionSink }
 
-  predicate isBarrier(DataFlow::Node node) { node instanceof EcbEncryptionSanitizer }
+  predicate isBarrier(DataFlow::Node node) { node instanceof EcbEncryptionBarrier }
 
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
     any(EcbEncryptionAdditionalTaintStep s).step(nodeFrom, nodeTo)

--- a/swift/ql/lib/codeql/swift/security/HardcodedEncryptionKeyExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/HardcodedEncryptionKeyExtensions.qll
@@ -14,9 +14,9 @@ import codeql.swift.dataflow.ExternalFlow
 abstract class HardcodedEncryptionKeySink extends DataFlow::Node { }
 
 /**
- * A sanitizer for hard-coded encryption key vulnerabilities.
+ * A barrier for hard-coded encryption key vulnerabilities.
  */
-abstract class HardcodedEncryptionKeySanitizer extends DataFlow::Node { }
+abstract class HardcodedEncryptionKeyBarrier extends DataFlow::Node { }
 
 /**
  * A unit class for adding additional taint steps.

--- a/swift/ql/lib/codeql/swift/security/HardcodedEncryptionKeyExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/HardcodedEncryptionKeyExtensions.qll
@@ -19,11 +19,11 @@ abstract class HardcodedEncryptionKeySink extends DataFlow::Node { }
 abstract class HardcodedEncryptionKeyBarrier extends DataFlow::Node { }
 
 /**
- * A unit class for adding additional taint steps.
+ * A unit class for adding additional flow steps.
  */
-class HardcodedEncryptionKeyAdditionalTaintStep extends Unit {
+class HardcodedEncryptionKeyAdditionalFlowStep extends Unit {
   /**
-   * Holds if the step from `node1` to `node2` should be considered a taint
+   * Holds if the step from `node1` to `node2` should be considered a flow
    * step for paths related to hard-coded encryption key vulnerabilities.
    */
   abstract predicate step(DataFlow::Node nodeFrom, DataFlow::Node nodeTo);

--- a/swift/ql/lib/codeql/swift/security/HardcodedEncryptionKeyQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/HardcodedEncryptionKeyQuery.qll
@@ -34,7 +34,7 @@ module HardcodedKeyConfig implements DataFlow::ConfigSig {
 
   predicate isSink(DataFlow::Node node) { node instanceof HardcodedEncryptionKeySink }
 
-  predicate isBarrier(DataFlow::Node node) { node instanceof HardcodedEncryptionKeySanitizer }
+  predicate isBarrier(DataFlow::Node node) { node instanceof HardcodedEncryptionKeyBarrier }
 
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
     any(HardcodedEncryptionKeyAdditionalTaintStep s).step(nodeFrom, nodeTo)

--- a/swift/ql/lib/codeql/swift/security/HardcodedEncryptionKeyQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/HardcodedEncryptionKeyQuery.qll
@@ -37,7 +37,7 @@ module HardcodedKeyConfig implements DataFlow::ConfigSig {
   predicate isBarrier(DataFlow::Node node) { node instanceof HardcodedEncryptionKeyBarrier }
 
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
-    any(HardcodedEncryptionKeyAdditionalTaintStep s).step(nodeFrom, nodeTo)
+    any(HardcodedEncryptionKeyAdditionalFlowStep s).step(nodeFrom, nodeTo)
   }
 }
 

--- a/swift/ql/lib/codeql/swift/security/InsecureTLSExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/InsecureTLSExtensions.qll
@@ -20,9 +20,9 @@ abstract class InsecureTlsExtensionsSource extends DataFlow::Node { }
 abstract class InsecureTlsExtensionsSink extends DataFlow::Node { }
 
 /**
- * A sanitizer for insecure TLS configuration vulnerabilities.
+ * A barrier for insecure TLS configuration vulnerabilities.
  */
-abstract class InsecureTlsExtensionsSanitizer extends DataFlow::Node { }
+abstract class InsecureTlsExtensionsBarrier extends DataFlow::Node { }
 
 /**
  * A unit class for adding additional taint steps.

--- a/swift/ql/lib/codeql/swift/security/InsecureTLSExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/InsecureTLSExtensions.qll
@@ -25,11 +25,11 @@ abstract class InsecureTlsExtensionsSink extends DataFlow::Node { }
 abstract class InsecureTlsExtensionsBarrier extends DataFlow::Node { }
 
 /**
- * A unit class for adding additional taint steps.
+ * A unit class for adding additional flow steps.
  */
-class InsecureTlsExtensionsAdditionalTaintStep extends Unit {
+class InsecureTlsExtensionsAdditionalFlowStep extends Unit {
   /**
-   * Holds if the step from `node1` to `node2` should be considered a taint
+   * Holds if the step from `node1` to `node2` should be considered a flow
    * step for paths related to insecure TLS configuration vulnerabilities.
    */
   abstract predicate step(DataFlow::Node nodeFrom, DataFlow::Node nodeTo);

--- a/swift/ql/lib/codeql/swift/security/InsecureTLSQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/InsecureTLSQuery.qll
@@ -19,7 +19,7 @@ module InsecureTlsConfig implements DataFlow::ConfigSig {
   predicate isBarrier(DataFlow::Node node) { node instanceof InsecureTlsExtensionsBarrier }
 
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
-    any(InsecureTlsExtensionsAdditionalTaintStep s).step(nodeFrom, nodeTo)
+    any(InsecureTlsExtensionsAdditionalFlowStep s).step(nodeFrom, nodeTo)
   }
 }
 

--- a/swift/ql/lib/codeql/swift/security/InsecureTLSQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/InsecureTLSQuery.qll
@@ -16,7 +16,7 @@ module InsecureTlsConfig implements DataFlow::ConfigSig {
 
   predicate isSink(DataFlow::Node node) { node instanceof InsecureTlsExtensionsSink }
 
-  predicate isBarrier(DataFlow::Node node) { node instanceof InsecureTlsExtensionsSanitizer }
+  predicate isBarrier(DataFlow::Node node) { node instanceof InsecureTlsExtensionsBarrier }
 
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
     any(InsecureTlsExtensionsAdditionalTaintStep s).step(nodeFrom, nodeTo)

--- a/swift/ql/lib/codeql/swift/security/InsufficientHashIterationsExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/InsufficientHashIterationsExtensions.qll
@@ -15,9 +15,9 @@ import codeql.swift.dataflow.ExternalFlow
 abstract class InsufficientHashIterationsSink extends DataFlow::Node { }
 
 /**
- * A sanitizer for insufficient hash interation vulnerabilities.
+ * A barrier for insufficient hash interation vulnerabilities.
  */
-abstract class InsufficientHashIterationsSanitizer extends DataFlow::Node { }
+abstract class InsufficientHashIterationsBarrier extends DataFlow::Node { }
 
 /**
  * A unit class for adding additional taint steps.

--- a/swift/ql/lib/codeql/swift/security/InsufficientHashIterationsExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/InsufficientHashIterationsExtensions.qll
@@ -20,11 +20,11 @@ abstract class InsufficientHashIterationsSink extends DataFlow::Node { }
 abstract class InsufficientHashIterationsBarrier extends DataFlow::Node { }
 
 /**
- * A unit class for adding additional taint steps.
+ * A unit class for adding additional flow steps.
  */
-class InsufficientHashIterationsAdditionalTaintStep extends Unit {
+class InsufficientHashIterationsAdditionalFlowStep extends Unit {
   /**
-   * Holds if the step from `node1` to `node2` should be considered a taint
+   * Holds if the step from `node1` to `node2` should be considered a flow
    * step for paths related to insufficient hash interation vulnerabilities.
    */
   abstract predicate step(DataFlow::Node nodeFrom, DataFlow::Node nodeTo);

--- a/swift/ql/lib/codeql/swift/security/InsufficientHashIterationsQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/InsufficientHashIterationsQuery.qll
@@ -32,7 +32,7 @@ module InsufficientHashIterationsConfig implements DataFlow::ConfigSig {
   predicate isBarrier(DataFlow::Node node) { node instanceof InsufficientHashIterationsBarrier }
 
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
-    any(InsufficientHashIterationsAdditionalTaintStep s).step(nodeFrom, nodeTo)
+    any(InsufficientHashIterationsAdditionalFlowStep s).step(nodeFrom, nodeTo)
   }
 }
 

--- a/swift/ql/lib/codeql/swift/security/InsufficientHashIterationsQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/InsufficientHashIterationsQuery.qll
@@ -29,7 +29,7 @@ module InsufficientHashIterationsConfig implements DataFlow::ConfigSig {
 
   predicate isSink(DataFlow::Node node) { node instanceof InsufficientHashIterationsSink }
 
-  predicate isBarrier(DataFlow::Node node) { node instanceof InsufficientHashIterationsSanitizer }
+  predicate isBarrier(DataFlow::Node node) { node instanceof InsufficientHashIterationsBarrier }
 
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
     any(InsufficientHashIterationsAdditionalTaintStep s).step(nodeFrom, nodeTo)

--- a/swift/ql/lib/codeql/swift/security/PathInjectionExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/PathInjectionExtensions.qll
@@ -12,8 +12,8 @@ private import codeql.swift.frameworks.StandardLibrary.FilePath
 /** A data flow sink for path injection vulnerabilities. */
 abstract class PathInjectionSink extends DataFlow::Node { }
 
-/** A sanitizer for path injection vulnerabilities. */
-abstract class PathInjectionSanitizer extends DataFlow::Node { }
+/** A barrier for path injection vulnerabilities. */
+abstract class PathInjectionBarrier extends DataFlow::Node { }
 
 /**
  * A unit class for adding additional taint steps.
@@ -36,10 +36,10 @@ private class DefaultPathInjectionSink extends PathInjectionSink {
   DefaultPathInjectionSink() { sinkNode(this, "path-injection") }
 }
 
-private class DefaultPathInjectionSanitizer extends PathInjectionSanitizer {
-  DefaultPathInjectionSanitizer() {
+private class DefaultPathInjectionBarrier extends PathInjectionBarrier {
+  DefaultPathInjectionBarrier() {
     // This is a simplified implementation.
-    // TODO: Implement a complete path sanitizer when Guards are available.
+    // TODO: Implement a complete path barrier when Guards are available.
     exists(CallExpr starts, CallExpr normalize, DataFlow::Node validated |
       starts.getStaticTarget().getName() = "starts(with:)" and
       starts.getStaticTarget().getEnclosingDecl() instanceof FilePath and

--- a/swift/ql/lib/codeql/swift/security/PathInjectionExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/PathInjectionExtensions.qll
@@ -17,9 +17,6 @@ abstract class PathInjectionBarrier extends DataFlow::Node { }
 
 /**
  * A unit class for adding additional flow steps.
- *
- * Extend this class to add additional flow steps that should apply to paths related to
- * path injection vulnerabilities.
  */
 class PathInjectionAdditionalFlowStep extends Unit {
   /**

--- a/swift/ql/lib/codeql/swift/security/PathInjectionExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/PathInjectionExtensions.qll
@@ -16,14 +16,14 @@ abstract class PathInjectionSink extends DataFlow::Node { }
 abstract class PathInjectionBarrier extends DataFlow::Node { }
 
 /**
- * A unit class for adding additional taint steps.
+ * A unit class for adding additional flow steps.
  *
- * Extend this class to add additional taint steps that should apply to paths related to
+ * Extend this class to add additional flow steps that should apply to paths related to
  * path injection vulnerabilities.
  */
-class PathInjectionAdditionalTaintStep extends Unit {
+class PathInjectionAdditionalFlowStep extends Unit {
   /**
-   * Holds if the step from `node1` to `node2` should be considered a taint
+   * Holds if the step from `node1` to `node2` should be considered a flow
    * step for paths related to path injection vulnerabilities.
    */
   abstract predicate step(DataFlow::Node node1, DataFlow::Node node2);

--- a/swift/ql/lib/codeql/swift/security/PathInjectionQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/PathInjectionQuery.qll
@@ -18,7 +18,7 @@ module PathInjectionConfig implements DataFlow::ConfigSig {
 
   predicate isSink(DataFlow::Node sink) { sink instanceof PathInjectionSink }
 
-  predicate isBarrier(DataFlow::Node sanitizer) { sanitizer instanceof PathInjectionSanitizer }
+  predicate isBarrier(DataFlow::Node barrier) { barrier instanceof PathInjectionBarrier }
 
   predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
     any(PathInjectionAdditionalTaintStep s).step(node1, node2)

--- a/swift/ql/lib/codeql/swift/security/PathInjectionQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/PathInjectionQuery.qll
@@ -21,7 +21,7 @@ module PathInjectionConfig implements DataFlow::ConfigSig {
   predicate isBarrier(DataFlow::Node barrier) { barrier instanceof PathInjectionBarrier }
 
   predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
-    any(PathInjectionAdditionalTaintStep s).step(node1, node2)
+    any(PathInjectionAdditionalFlowStep s).step(node1, node2)
   }
 }
 

--- a/swift/ql/lib/codeql/swift/security/PredicateInjectionExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/PredicateInjectionExtensions.qll
@@ -12,9 +12,6 @@ abstract class PredicateInjectionBarrier extends DataFlow::Node { }
 
 /**
  * A unit class for adding additional flow steps.
- *
- * Extend this class to add additional flow steps that should apply to paths related to
- * predicate injection vulnerabilities.
  */
 class PredicateInjectionAdditionalFlowStep extends Unit {
   /**

--- a/swift/ql/lib/codeql/swift/security/PredicateInjectionExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/PredicateInjectionExtensions.qll
@@ -7,8 +7,8 @@ private import codeql.swift.dataflow.ExternalFlow
 /** A data flow sink for predicate injection vulnerabilities. */
 abstract class PredicateInjectionSink extends DataFlow::Node { }
 
-/** A sanitizer for predicate injection vulnerabilities. */
-abstract class PredicateInjectionSanitizer extends DataFlow::Node { }
+/** A barrier for predicate injection vulnerabilities. */
+abstract class PredicateInjectionBarrier extends DataFlow::Node { }
 
 /**
  * A unit class for adding additional taint steps.

--- a/swift/ql/lib/codeql/swift/security/PredicateInjectionExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/PredicateInjectionExtensions.qll
@@ -11,14 +11,14 @@ abstract class PredicateInjectionSink extends DataFlow::Node { }
 abstract class PredicateInjectionBarrier extends DataFlow::Node { }
 
 /**
- * A unit class for adding additional taint steps.
+ * A unit class for adding additional flow steps.
  *
- * Extend this class to add additional taint steps that should apply to paths related to
+ * Extend this class to add additional flow steps that should apply to paths related to
  * predicate injection vulnerabilities.
  */
-class PredicateInjectionAdditionalTaintStep extends Unit {
+class PredicateInjectionAdditionalFlowStep extends Unit {
   /**
-   * Holds if the step from `node1` to `node2` should be considered a taint
+   * Holds if the step from `node1` to `node2` should be considered a flow
    * step for paths related to predicate injection vulnerabilities.
    */
   abstract predicate step(DataFlow::Node n1, DataFlow::Node n2);

--- a/swift/ql/lib/codeql/swift/security/PredicateInjectionQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/PredicateInjectionQuery.qll
@@ -20,7 +20,7 @@ module PredicateInjectionConfig implements DataFlow::ConfigSig {
   predicate isBarrier(DataFlow::Node barrier) { barrier instanceof PredicateInjectionBarrier }
 
   predicate isAdditionalFlowStep(DataFlow::Node n1, DataFlow::Node n2) {
-    any(PredicateInjectionAdditionalTaintStep s).step(n1, n2)
+    any(PredicateInjectionAdditionalFlowStep s).step(n1, n2)
   }
 }
 

--- a/swift/ql/lib/codeql/swift/security/PredicateInjectionQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/PredicateInjectionQuery.qll
@@ -17,7 +17,7 @@ module PredicateInjectionConfig implements DataFlow::ConfigSig {
 
   predicate isSink(DataFlow::Node sink) { sink instanceof PredicateInjectionSink }
 
-  predicate isBarrier(DataFlow::Node sanitizer) { sanitizer instanceof PredicateInjectionSanitizer }
+  predicate isBarrier(DataFlow::Node barrier) { barrier instanceof PredicateInjectionBarrier }
 
   predicate isAdditionalFlowStep(DataFlow::Node n1, DataFlow::Node n2) {
     any(PredicateInjectionAdditionalTaintStep s).step(n1, n2)

--- a/swift/ql/lib/codeql/swift/security/SqlInjectionExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/SqlInjectionExtensions.qll
@@ -14,9 +14,9 @@ import codeql.swift.dataflow.ExternalFlow
 abstract class SqlInjectionSink extends DataFlow::Node { }
 
 /**
- * A sanitizer for SQL injection vulnerabilities.
+ * A barrier for SQL injection vulnerabilities.
  */
-abstract class SqlInjectionSanitizer extends DataFlow::Node { }
+abstract class SqlInjectionBarrier extends DataFlow::Node { }
 
 /**
  * A unit class for adding additional taint steps.

--- a/swift/ql/lib/codeql/swift/security/SqlInjectionExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/SqlInjectionExtensions.qll
@@ -22,6 +22,10 @@ abstract class SqlInjectionBarrier extends DataFlow::Node { }
  * A unit class for adding additional flow steps.
  */
 class SqlInjectionAdditionalFlowStep extends Unit {
+  /**
+   * Holds if the step from `node1` to `node2` should be considered a flow
+   * step for paths related to SQL injection vulnerabilities.
+   */
   abstract predicate step(DataFlow::Node nodeFrom, DataFlow::Node nodeTo);
 }
 

--- a/swift/ql/lib/codeql/swift/security/SqlInjectionExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/SqlInjectionExtensions.qll
@@ -19,9 +19,9 @@ abstract class SqlInjectionSink extends DataFlow::Node { }
 abstract class SqlInjectionBarrier extends DataFlow::Node { }
 
 /**
- * A unit class for adding additional taint steps.
+ * A unit class for adding additional flow steps.
  */
-class SqlInjectionAdditionalTaintStep extends Unit {
+class SqlInjectionAdditionalFlowStep extends Unit {
   abstract predicate step(DataFlow::Node nodeFrom, DataFlow::Node nodeTo);
 }
 

--- a/swift/ql/lib/codeql/swift/security/SqlInjectionQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/SqlInjectionQuery.qll
@@ -21,7 +21,7 @@ module SqlInjectionConfig implements DataFlow::ConfigSig {
   predicate isBarrier(DataFlow::Node barrier) { barrier instanceof SqlInjectionBarrier }
 
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
-    any(SqlInjectionAdditionalTaintStep s).step(nodeFrom, nodeTo)
+    any(SqlInjectionAdditionalFlowStep s).step(nodeFrom, nodeTo)
   }
 }
 

--- a/swift/ql/lib/codeql/swift/security/SqlInjectionQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/SqlInjectionQuery.qll
@@ -18,7 +18,7 @@ module SqlInjectionConfig implements DataFlow::ConfigSig {
 
   predicate isSink(DataFlow::Node node) { node instanceof SqlInjectionSink }
 
-  predicate isBarrier(DataFlow::Node sanitizer) { sanitizer instanceof SqlInjectionSanitizer }
+  predicate isBarrier(DataFlow::Node barrier) { barrier instanceof SqlInjectionBarrier }
 
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
     any(SqlInjectionAdditionalTaintStep s).step(nodeFrom, nodeTo)

--- a/swift/ql/lib/codeql/swift/security/StaticInitializationVectorExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/StaticInitializationVectorExtensions.qll
@@ -19,11 +19,11 @@ abstract class StaticInitializationVectorSink extends DataFlow::Node { }
 abstract class StaticInitializationVectorBarrier extends DataFlow::Node { }
 
 /**
- * A unit class for adding additional taint steps.
+ * A unit class for adding additional flow steps.
  */
-class StaticInitializationVectorAdditionalTaintStep extends Unit {
+class StaticInitializationVectorAdditionalFlowStep extends Unit {
   /**
-   * Holds if the step from `node1` to `node2` should be considered a taint
+   * Holds if the step from `node1` to `node2` should be considered a flow
    * step for paths related to static initialization vector vulnerabilities.
    */
   abstract predicate step(DataFlow::Node nodeFrom, DataFlow::Node nodeTo);

--- a/swift/ql/lib/codeql/swift/security/StaticInitializationVectorExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/StaticInitializationVectorExtensions.qll
@@ -14,9 +14,9 @@ import codeql.swift.dataflow.ExternalFlow
 abstract class StaticInitializationVectorSink extends DataFlow::Node { }
 
 /**
- * A sanitizer for static initialization vector vulnerabilities.
+ * A barrier for static initialization vector vulnerabilities.
  */
-abstract class StaticInitializationVectorSanitizer extends DataFlow::Node { }
+abstract class StaticInitializationVectorBarrier extends DataFlow::Node { }
 
 /**
  * A unit class for adding additional taint steps.

--- a/swift/ql/lib/codeql/swift/security/StaticInitializationVectorQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/StaticInitializationVectorQuery.qll
@@ -30,7 +30,7 @@ module StaticInitializationVectorConfig implements DataFlow::ConfigSig {
 
   predicate isSink(DataFlow::Node node) { node instanceof StaticInitializationVectorSink }
 
-  predicate isBarrier(DataFlow::Node node) { node instanceof StaticInitializationVectorSanitizer }
+  predicate isBarrier(DataFlow::Node node) { node instanceof StaticInitializationVectorBarrier }
 
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
     any(StaticInitializationVectorAdditionalTaintStep s).step(nodeFrom, nodeTo)

--- a/swift/ql/lib/codeql/swift/security/StaticInitializationVectorQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/StaticInitializationVectorQuery.qll
@@ -33,7 +33,7 @@ module StaticInitializationVectorConfig implements DataFlow::ConfigSig {
   predicate isBarrier(DataFlow::Node node) { node instanceof StaticInitializationVectorBarrier }
 
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
-    any(StaticInitializationVectorAdditionalTaintStep s).step(nodeFrom, nodeTo)
+    any(StaticInitializationVectorAdditionalFlowStep s).step(nodeFrom, nodeTo)
   }
 }
 

--- a/swift/ql/lib/codeql/swift/security/StringLengthConflationExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/StringLengthConflationExtensions.qll
@@ -104,11 +104,11 @@ abstract class StringLengthConflationSink extends DataFlow::Node {
 abstract class StringLengthConflationBarrier extends DataFlow::Node { }
 
 /**
- * A unit class for adding additional taint steps.
+ * A unit class for adding additional flow steps.
  */
-class StringLengthConflationAdditionalTaintStep extends Unit {
+class StringLengthConflationAdditionalFlowStep extends Unit {
   /**
-   * Holds if the step from `node1` to `node2` should be considered a taint
+   * Holds if the step from `node1` to `node2` should be considered a flow
    * step for paths related to string length conflation vulnerabilities.
    */
   abstract predicate step(DataFlow::Node nodeFrom, DataFlow::Node nodeTo);

--- a/swift/ql/lib/codeql/swift/security/StringLengthConflationExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/StringLengthConflationExtensions.qll
@@ -99,9 +99,9 @@ abstract class StringLengthConflationSink extends DataFlow::Node {
 }
 
 /**
- * A sanitizer for string length conflation vulnerabilities.
+ * A barrier for string length conflation vulnerabilities.
  */
-abstract class StringLengthConflationSanitizer extends DataFlow::Node { }
+abstract class StringLengthConflationBarrier extends DataFlow::Node { }
 
 /**
  * A unit class for adding additional taint steps.

--- a/swift/ql/lib/codeql/swift/security/StringLengthConflationQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/StringLengthConflationQuery.qll
@@ -29,11 +29,9 @@ module StringLengthConflationConfig implements DataFlow::StateConfigSig {
     )
   }
 
-  predicate isBarrier(DataFlow::Node sanitizer) {
-    sanitizer instanceof StringLengthConflationSanitizer
-  }
+  predicate isBarrier(DataFlow::Node barrier) { barrier instanceof StringLengthConflationBarrier }
 
-  predicate isBarrier(DataFlow::Node sanitizer, FlowState flowstate) { none() }
+  predicate isBarrier(DataFlow::Node barrier, FlowState flowstate) { none() }
 
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
     any(StringLengthConflationAdditionalTaintStep s).step(nodeFrom, nodeTo)

--- a/swift/ql/lib/codeql/swift/security/StringLengthConflationQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/StringLengthConflationQuery.qll
@@ -34,7 +34,7 @@ module StringLengthConflationConfig implements DataFlow::StateConfigSig {
   predicate isBarrier(DataFlow::Node barrier, FlowState flowstate) { none() }
 
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
-    any(StringLengthConflationAdditionalTaintStep s).step(nodeFrom, nodeTo)
+    any(StringLengthConflationAdditionalFlowStep s).step(nodeFrom, nodeTo)
   }
 
   predicate isAdditionalFlowStep(

--- a/swift/ql/lib/codeql/swift/security/UncontrolledFormatStringExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/UncontrolledFormatStringExtensions.qll
@@ -15,9 +15,9 @@ private import codeql.swift.dataflow.ExternalFlow
 abstract class UncontrolledFormatStringSink extends DataFlow::Node { }
 
 /**
- * A sanitizer for uncontrolled format string vulnerabilities.
+ * A barrier for uncontrolled format string vulnerabilities.
  */
-abstract class UncontrolledFormatStringSanitizer extends DataFlow::Node { }
+abstract class UncontrolledFormatStringBarrier extends DataFlow::Node { }
 
 /**
  * A unit class for adding additional taint steps.

--- a/swift/ql/lib/codeql/swift/security/UncontrolledFormatStringExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/UncontrolledFormatStringExtensions.qll
@@ -23,6 +23,10 @@ abstract class UncontrolledFormatStringBarrier extends DataFlow::Node { }
  * A unit class for adding additional flow steps.
  */
 class UncontrolledFormatStringAdditionalFlowStep extends Unit {
+  /**
+   * Holds if the step from `node1` to `node2` should be considered a flow
+   * step for paths related to uncontrolled format string vulnerabilities.
+   */
   abstract predicate step(DataFlow::Node nodeFrom, DataFlow::Node nodeTo);
 }
 

--- a/swift/ql/lib/codeql/swift/security/UncontrolledFormatStringExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/UncontrolledFormatStringExtensions.qll
@@ -20,9 +20,9 @@ abstract class UncontrolledFormatStringSink extends DataFlow::Node { }
 abstract class UncontrolledFormatStringBarrier extends DataFlow::Node { }
 
 /**
- * A unit class for adding additional taint steps.
+ * A unit class for adding additional flow steps.
  */
-class UncontrolledFormatStringAdditionalTaintStep extends Unit {
+class UncontrolledFormatStringAdditionalFlowStep extends Unit {
   abstract predicate step(DataFlow::Node nodeFrom, DataFlow::Node nodeTo);
 }
 

--- a/swift/ql/lib/codeql/swift/security/UncontrolledFormatStringQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/UncontrolledFormatStringQuery.qll
@@ -21,7 +21,7 @@ module TaintedFormatConfig implements DataFlow::ConfigSig {
   predicate isBarrier(DataFlow::Node barrier) { barrier instanceof UncontrolledFormatStringBarrier }
 
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
-    any(UncontrolledFormatStringAdditionalTaintStep s).step(nodeFrom, nodeTo)
+    any(UncontrolledFormatStringAdditionalFlowStep s).step(nodeFrom, nodeTo)
   }
 }
 

--- a/swift/ql/lib/codeql/swift/security/UncontrolledFormatStringQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/UncontrolledFormatStringQuery.qll
@@ -18,9 +18,7 @@ module TaintedFormatConfig implements DataFlow::ConfigSig {
 
   predicate isSink(DataFlow::Node node) { node instanceof UncontrolledFormatStringSink }
 
-  predicate isBarrier(DataFlow::Node sanitizer) {
-    sanitizer instanceof UncontrolledFormatStringSanitizer
-  }
+  predicate isBarrier(DataFlow::Node barrier) { barrier instanceof UncontrolledFormatStringBarrier }
 
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
     any(UncontrolledFormatStringAdditionalTaintStep s).step(nodeFrom, nodeTo)

--- a/swift/ql/lib/codeql/swift/security/UnsafeJsEvalExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/UnsafeJsEvalExtensions.qll
@@ -22,6 +22,10 @@ abstract class UnsafeJsEvalBarrier extends DataFlow::Node { }
  * A unit class for adding additional flow steps.
  */
 class UnsafeJsEvalAdditionalFlowStep extends Unit {
+  /**
+   * Holds if the step from `node1` to `node2` should be considered a flow
+   * step for paths related to javascript evaluation vulnerabilities.
+   */
   abstract predicate step(DataFlow::Node nodeFrom, DataFlow::Node nodeTo);
 }
 

--- a/swift/ql/lib/codeql/swift/security/UnsafeJsEvalExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/UnsafeJsEvalExtensions.qll
@@ -14,9 +14,9 @@ private import codeql.swift.dataflow.ExternalFlow
 abstract class UnsafeJsEvalSink extends DataFlow::Node { }
 
 /**
- * A sanitizer for javascript evaluation vulnerabilities.
+ * A barrier for javascript evaluation vulnerabilities.
  */
-abstract class UnsafeJsEvalSanitizer extends DataFlow::Node { }
+abstract class UnsafeJsEvalBarrier extends DataFlow::Node { }
 
 /**
  * A unit class for adding additional taint steps.
@@ -94,7 +94,7 @@ private class JSEvaluateScriptDefaultUnsafeJsEvalSink extends UnsafeJsEvalSink {
 }
 
 /**
- * A default SQL injection sanitizer.
+ * A default SQL injection additional taint step.
  */
 private class DefaultUnsafeJsEvalAdditionalTaintStep extends UnsafeJsEvalAdditionalTaintStep {
   override predicate step(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {

--- a/swift/ql/lib/codeql/swift/security/UnsafeJsEvalExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/UnsafeJsEvalExtensions.qll
@@ -19,9 +19,9 @@ abstract class UnsafeJsEvalSink extends DataFlow::Node { }
 abstract class UnsafeJsEvalBarrier extends DataFlow::Node { }
 
 /**
- * A unit class for adding additional taint steps.
+ * A unit class for adding additional flow steps.
  */
-class UnsafeJsEvalAdditionalTaintStep extends Unit {
+class UnsafeJsEvalAdditionalFlowStep extends Unit {
   abstract predicate step(DataFlow::Node nodeFrom, DataFlow::Node nodeTo);
 }
 
@@ -96,7 +96,7 @@ private class JSEvaluateScriptDefaultUnsafeJsEvalSink extends UnsafeJsEvalSink {
 /**
  * A default SQL injection additional taint step.
  */
-private class DefaultUnsafeJsEvalAdditionalTaintStep extends UnsafeJsEvalAdditionalTaintStep {
+private class DefaultUnsafeJsEvalAdditionalFlowStep extends UnsafeJsEvalAdditionalFlowStep {
   override predicate step(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
     exists(Argument arg |
       arg =

--- a/swift/ql/lib/codeql/swift/security/UnsafeJsEvalQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/UnsafeJsEvalQuery.qll
@@ -17,7 +17,7 @@ module UnsafeJsEvalConfig implements DataFlow::ConfigSig {
 
   predicate isSink(DataFlow::Node node) { node instanceof UnsafeJsEvalSink }
 
-  predicate isBarrier(DataFlow::Node sanitizer) { sanitizer instanceof UnsafeJsEvalSanitizer }
+  predicate isBarrier(DataFlow::Node barrier) { barrier instanceof UnsafeJsEvalBarrier }
 
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
     any(UnsafeJsEvalAdditionalTaintStep s).step(nodeFrom, nodeTo)

--- a/swift/ql/lib/codeql/swift/security/UnsafeJsEvalQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/UnsafeJsEvalQuery.qll
@@ -20,7 +20,7 @@ module UnsafeJsEvalConfig implements DataFlow::ConfigSig {
   predicate isBarrier(DataFlow::Node barrier) { barrier instanceof UnsafeJsEvalBarrier }
 
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
-    any(UnsafeJsEvalAdditionalTaintStep s).step(nodeFrom, nodeTo)
+    any(UnsafeJsEvalAdditionalFlowStep s).step(nodeFrom, nodeTo)
   }
 }
 

--- a/swift/ql/lib/codeql/swift/security/UnsafeWebViewFetchExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/UnsafeWebViewFetchExtensions.qll
@@ -24,9 +24,9 @@ abstract class UnsafeWebViewFetchSink extends DataFlow::Node {
 abstract class UnsafeWebViewFetchBarrier extends DataFlow::Node { }
 
 /**
- * A unit class for adding additional taint steps.
+ * A unit class for adding additional flow steps.
  */
-class UnsafeWebViewFetchAdditionalTaintStep extends Unit {
+class UnsafeWebViewFetchAdditionalFlowStep extends Unit {
   abstract predicate step(DataFlow::Node nodeFrom, DataFlow::Node nodeTo);
 }
 

--- a/swift/ql/lib/codeql/swift/security/UnsafeWebViewFetchExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/UnsafeWebViewFetchExtensions.qll
@@ -19,9 +19,9 @@ abstract class UnsafeWebViewFetchSink extends DataFlow::Node {
 }
 
 /**
- * A sanitizer for unsafe webview fetch vulnerabilities.
+ * A barrier for unsafe webview fetch vulnerabilities.
  */
-abstract class UnsafeWebViewFetchSanitizer extends DataFlow::Node { }
+abstract class UnsafeWebViewFetchBarrier extends DataFlow::Node { }
 
 /**
  * A unit class for adding additional taint steps.

--- a/swift/ql/lib/codeql/swift/security/UnsafeWebViewFetchExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/UnsafeWebViewFetchExtensions.qll
@@ -27,6 +27,10 @@ abstract class UnsafeWebViewFetchBarrier extends DataFlow::Node { }
  * A unit class for adding additional flow steps.
  */
 class UnsafeWebViewFetchAdditionalFlowStep extends Unit {
+  /**
+   * Holds if the step from `node1` to `node2` should be considered a flow
+   * step for paths related to unsafe webview fetch vulnerabilities.
+   */
   abstract predicate step(DataFlow::Node nodeFrom, DataFlow::Node nodeTo);
 }
 

--- a/swift/ql/lib/codeql/swift/security/UnsafeWebViewFetchQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/UnsafeWebViewFetchQuery.qll
@@ -23,7 +23,7 @@ module UnsafeWebViewFetchConfig implements DataFlow::ConfigSig {
     )
   }
 
-  predicate isBarrier(DataFlow::Node sanitizer) { sanitizer instanceof UnsafeWebViewFetchSanitizer }
+  predicate isBarrier(DataFlow::Node barrier) { barrier instanceof UnsafeWebViewFetchBarrier }
 
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
     any(UnsafeWebViewFetchAdditionalTaintStep s).step(nodeFrom, nodeTo)

--- a/swift/ql/lib/codeql/swift/security/UnsafeWebViewFetchQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/UnsafeWebViewFetchQuery.qll
@@ -26,7 +26,7 @@ module UnsafeWebViewFetchConfig implements DataFlow::ConfigSig {
   predicate isBarrier(DataFlow::Node barrier) { barrier instanceof UnsafeWebViewFetchBarrier }
 
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
-    any(UnsafeWebViewFetchAdditionalTaintStep s).step(nodeFrom, nodeTo)
+    any(UnsafeWebViewFetchAdditionalFlowStep s).step(nodeFrom, nodeTo)
   }
 }
 

--- a/swift/ql/lib/codeql/swift/security/WeakSensitiveDataHashingExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/WeakSensitiveDataHashingExtensions.qll
@@ -25,11 +25,11 @@ abstract class WeakSensitiveDataHashingSink extends DataFlow::Node {
 abstract class WeakSensitiveDataHashingBarrier extends DataFlow::Node { }
 
 /**
- * A unit class for adding additional taint steps.
+ * A unit class for adding additional flow steps.
  */
-class WeakSensitiveDataHashingAdditionalTaintStep extends Unit {
+class WeakSensitiveDataHashingAdditionalFlowStep extends Unit {
   /**
-   * Holds if the step from `node1` to `node2` should be considered a taint
+   * Holds if the step from `node1` to `node2` should be considered a flow
    * step for paths related to weak sensitive data hashing vulnerabilities.
    */
   abstract predicate step(DataFlow::Node nodeFrom, DataFlow::Node nodeTo);

--- a/swift/ql/lib/codeql/swift/security/WeakSensitiveDataHashingExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/WeakSensitiveDataHashingExtensions.qll
@@ -20,9 +20,9 @@ abstract class WeakSensitiveDataHashingSink extends DataFlow::Node {
 }
 
 /**
- * A sanitizer for weak sensitive data hashing vulnerabilities.
+ * A barrier for weak sensitive data hashing vulnerabilities.
  */
-abstract class WeakSensitiveDataHashingSanitizer extends DataFlow::Node { }
+abstract class WeakSensitiveDataHashingBarrier extends DataFlow::Node { }
 
 /**
  * A unit class for adding additional taint steps.

--- a/swift/ql/lib/codeql/swift/security/WeakSensitiveDataHashingQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/WeakSensitiveDataHashingQuery.qll
@@ -31,7 +31,7 @@ module WeakHashingConfig implements DataFlow::ConfigSig {
   }
 
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
-    any(WeakSensitiveDataHashingAdditionalTaintStep s).step(nodeFrom, nodeTo)
+    any(WeakSensitiveDataHashingAdditionalFlowStep s).step(nodeFrom, nodeTo)
   }
 }
 

--- a/swift/ql/lib/codeql/swift/security/WeakSensitiveDataHashingQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/WeakSensitiveDataHashingQuery.qll
@@ -18,7 +18,7 @@ module WeakHashingConfig implements DataFlow::ConfigSig {
 
   predicate isSink(DataFlow::Node node) { node instanceof WeakSensitiveDataHashingSink }
 
-  predicate isBarrier(DataFlow::Node node) { node instanceof WeakSensitiveDataHashingSanitizer }
+  predicate isBarrier(DataFlow::Node node) { node instanceof WeakSensitiveDataHashingBarrier }
 
   predicate isBarrierIn(DataFlow::Node node) {
     // make sources barriers so that we only report the closest instance

--- a/swift/ql/lib/codeql/swift/security/XXEExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/XXEExtensions.qll
@@ -13,12 +13,12 @@ abstract class XxeSink extends DataFlow::Node { }
 abstract class XxeBarrier extends DataFlow::Node { }
 
 /**
- * A unit class for adding additional taint steps.
+ * A unit class for adding additional flow steps.
  *
- * Extend this class to add additional taint steps that should apply to paths related to
+ * Extend this class to add additional flow steps that should apply to paths related to
  * XML external entities (XXE) vulnerabilities.
  */
-class XxeAdditionalTaintStep extends Unit {
+class XxeAdditionalFlowStep extends Unit {
   abstract predicate step(DataFlow::Node n1, DataFlow::Node n2);
 }
 

--- a/swift/ql/lib/codeql/swift/security/XXEExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/XXEExtensions.qll
@@ -14,11 +14,12 @@ abstract class XxeBarrier extends DataFlow::Node { }
 
 /**
  * A unit class for adding additional flow steps.
- *
- * Extend this class to add additional flow steps that should apply to paths related to
- * XML external entities (XXE) vulnerabilities.
  */
 class XxeAdditionalFlowStep extends Unit {
+  /**
+   * Holds if the step from `node1` to `node2` should be considered a flow
+   * step for paths related to XML external entities (XXE) vulnerabilities.
+   */
   abstract predicate step(DataFlow::Node n1, DataFlow::Node n2);
 }
 

--- a/swift/ql/lib/codeql/swift/security/XXEExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/XXEExtensions.qll
@@ -9,8 +9,8 @@ private import codeql.swift.dataflow.ExternalFlow
 /** A data flow sink for XML external entities (XXE) vulnerabilities. */
 abstract class XxeSink extends DataFlow::Node { }
 
-/** A sanitizer for XML external entities (XXE) vulnerabilities. */
-abstract class XxeSanitizer extends DataFlow::Node { }
+/** A barrier for XML external entities (XXE) vulnerabilities. */
+abstract class XxeBarrier extends DataFlow::Node { }
 
 /**
  * A unit class for adding additional taint steps.

--- a/swift/ql/lib/codeql/swift/security/XXEQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/XXEQuery.qll
@@ -17,7 +17,7 @@ module XxeConfig implements DataFlow::ConfigSig {
 
   predicate isSink(DataFlow::Node sink) { sink instanceof XxeSink }
 
-  predicate isBarrier(DataFlow::Node sanitizer) { sanitizer instanceof XxeSanitizer }
+  predicate isBarrier(DataFlow::Node barrier) { barrier instanceof XxeBarrier }
 
   predicate isAdditionalFlowStep(DataFlow::Node n1, DataFlow::Node n2) {
     any(XxeAdditionalTaintStep s).step(n1, n2)

--- a/swift/ql/lib/codeql/swift/security/XXEQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/XXEQuery.qll
@@ -20,7 +20,7 @@ module XxeConfig implements DataFlow::ConfigSig {
   predicate isBarrier(DataFlow::Node barrier) { barrier instanceof XxeBarrier }
 
   predicate isAdditionalFlowStep(DataFlow::Node n1, DataFlow::Node n2) {
-    any(XxeAdditionalTaintStep s).step(n1, n2)
+    any(XxeAdditionalFlowStep s).step(n1, n2)
   }
 }
 

--- a/swift/ql/test/query-tests/Security/CWE-022/testPathInjection.swift
+++ b/swift/ql/test/query-tests/Security/CWE-022/testPathInjection.swift
@@ -322,7 +322,7 @@ func test() {
 	config.seedFilePath = remoteUrl // $ MISSING: hasPathInjection=208
 }
 
-func testSanitizers() {
+func testBarriers() {
     let remoteString = String(contentsOf: URL(string: "http://example.com/")!)
 
     let fm = FileManager()


### PR DESCRIPTION
Standardize our terminology in data flow queries, to be consistent with `ConfigSig`:
 - "sanitizer" is now "barrier" (regardless of whether the query is dataflow or taint tracking)
 - "taint step" is now "flow step" (regardless of whether the query is dataflow or taint tracking)