### PR TITLE
Ruby: Add MySQL as SQL Injection Sink

### DIFF
--- a/ruby/ql/lib/change-notes/2023-05-06-mysql2.md
+++ b/ruby/ql/lib/change-notes/2023-05-06-mysql2.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Support for the `mysql2` gem has been added. Method calls that execute queries against an MySQL database that may be vulnerable to injection attacks will now be recognized.

--- a/ruby/ql/lib/codeql/ruby/frameworks/Mysql2.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/Mysql2.qll
@@ -1,0 +1,49 @@
+/**
+ * Provides modeling for mysql2, a Ruby library (gem) for interacting with MySql databases.
+ */
+
+private import codeql.ruby.ApiGraphs
+private import codeql.ruby.dataflow.FlowSummary
+private import codeql.ruby.Concepts
+
+/**
+ * Provides modeling for mysql2, a Ruby library (gem) for interacting with MySql databases.
+ */
+module Mysql2 {
+  /**
+   * Flow summary for `Mysql2::Client.new()`.
+   */
+  private class SqlSummary extends SummarizedCallable {
+    SqlSummary() { this = "Mysql2::Client.new()" }
+
+    override MethodCall getACall() { result = any(Mysql2Connection c).asExpr().getExpr() }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      input = "Argument[0]" and output = "ReturnValue" and preservesValue = false
+    }
+  }
+
+  /** A call to Mysql2::Client.new() is used to establish a connection to a MySql database. */
+  private class Mysql2Connection extends DataFlow::CallNode {
+    Mysql2Connection() {
+      this = API::getTopLevelMember("Mysql2").getMember("Client").getAnInstantiation()
+    }
+  }
+
+  /** A call that executes SQL statements against a MySQL database. */
+  private class Mysql2Execution extends SqlExecution::Range, DataFlow::CallNode {
+    private DataFlow::Node query;
+
+    Mysql2Execution() {
+      exists(Mysql2Connection mysql2Connection, DataFlow::CallNode prepareCall |
+        this = mysql2Connection.getAMethodCall("query") and query = this.getArgument(0)
+        or
+        prepareCall = mysql2Connection.getAMethodCall("prepare") and
+        query = prepareCall.getArgument(0) and
+        this = prepareCall.getAMethodCall("execute")
+      )
+    }
+
+    override DataFlow::Node getSql() { result = query }
+  }
+}

--- a/ruby/ql/lib/codeql/ruby/security/SqlInjectionCustomizations.qll
+++ b/ruby/ql/lib/codeql/ruby/security/SqlInjectionCustomizations.qll
@@ -7,6 +7,7 @@ private import codeql.ruby.Concepts
 private import codeql.ruby.DataFlow
 private import codeql.ruby.dataflow.BarrierGuards
 private import codeql.ruby.dataflow.RemoteFlowSources
+private import codeql.ruby.ApiGraphs
 
 /**
  * Provides default sources, sinks and sanitizers for detecting SQL injection
@@ -51,6 +52,23 @@ module SqlInjection {
    * sanitizer-guard.
    */
   class StringConstArrayInclusionCallAsSanitizer extends Sanitizer,
-    StringConstArrayInclusionCallBarrier
-  { }
+    StringConstArrayInclusionCallBarrier { }
+
+  /**
+   * A call to `Mysql2::Client.escape`, considered as a sanitizer.
+   */
+  class Mysql2EscapeSanitization extends Sanitizer {
+    Mysql2EscapeSanitization() {
+      this = API::getTopLevelMember("Mysql2").getMember("Client").getAMethodCall("escape")
+    }
+  }
+
+  /**
+   * A call to `SQLite3::Database.quote`, considered as a sanitizer.
+   */
+  class SQLite3EscapeSanitization extends Sanitizer {
+    SQLite3EscapeSanitization() {
+      this = API::getTopLevelMember("SQLite3").getMember("Database").getAMethodCall("quote")
+    }
+  }
 }

--- a/ruby/ql/test/library-tests/frameworks/mysql2/Mysql2.expected
+++ b/ruby/ql/test/library-tests/frameworks/mysql2/Mysql2.expected
@@ -1,0 +1,5 @@
+| Mysql2.rb:10:16:10:48 | call to query | Mysql2.rb:10:27:10:47 | "SELECT * FROM users" |
+| Mysql2.rb:13:16:13:73 | call to query | Mysql2.rb:13:27:13:72 | "SELECT * FROM users WHERE use..." |
+| Mysql2.rb:17:16:17:76 | call to query | Mysql2.rb:17:27:17:75 | "SELECT * FROM users WHERE use..." |
+| Mysql2.rb:21:16:21:57 | call to execute | Mysql2.rb:20:31:20:82 | "SELECT * FROM users WHERE id ..." |
+| Mysql2.rb:25:16:25:60 | call to execute | Mysql2.rb:24:31:24:93 | "SELECT * FROM users WHERE use..." |

--- a/ruby/ql/test/library-tests/frameworks/mysql2/Mysql2.ql
+++ b/ruby/ql/test/library-tests/frameworks/mysql2/Mysql2.ql
@@ -1,0 +1,5 @@
+private import codeql.ruby.DataFlow
+private import codeql.ruby.Concepts
+private import codeql.ruby.frameworks.Mysql2
+
+query predicate mysql2SqlExecution(SqlExecution e, DataFlow::Node sql) { sql = e.getSql() }

--- a/ruby/ql/test/library-tests/frameworks/mysql2/Mysql2.rb
+++ b/ruby/ql/test/library-tests/frameworks/mysql2/Mysql2.rb
@@ -1,0 +1,30 @@
+class UsersController < ActionController::Base
+  def mysql2_handler(event:, context:)
+    name = params[:user_name]
+
+    conn = Mysql2::Client.new(
+        host: "127.0.0.1",
+        username: "root"
+    )
+    # GOOD: SQL statement is not constructed from user input
+    results1 = conn.query("SELECT * FROM users")
+
+    # BAD: SQL statement constructed from user input
+    results2 = conn.query("SELECT * FROM users WHERE username='#{name}'")
+
+    # GOOD: user input is escaped
+    escaped = Mysql2::Client.escape(name)
+    results3 = conn.query("SELECT * FROM users WHERE username='#{escaped}'")
+
+    # GOOD: user input is escaped
+    statement1 = conn.prepare("SELECT * FROM users WHERE id >= ? AND username = ?")
+    results4 = statement1.execute(1, name, :as => :array)
+
+    # BAD: SQL statement constructed from user input
+    statement2 = conn.prepare("SELECT * FROM users WHERE username='#{name}' AND password = ?")
+    results4 = statement2.execute("password", :as => :array)
+
+    # NOT EXECUTED
+    statement3 = conn.prepare("SELECT * FROM users WHERE username = ?")
+  end
+end


### PR DESCRIPTION
This pull request adds `mysql2` library Sinks for SQL injection. I have also added `escape` and `quote` (`mysql2` and `sqlite3`) as sanitizers

Looking forward to your suggestions.