### PR TITLE
C++: Add FP for `cpp/overrun-write`

### DIFF
--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-119/OverrunWriteProductFlow.expected
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-119/OverrunWriteProductFlow.expected
@@ -222,6 +222,7 @@ edges
 | test.cpp:243:12:243:14 | str indirection [string] | test.cpp:243:12:243:21 | string |
 | test.cpp:243:12:243:14 | str indirection [string] | test.cpp:243:16:243:21 | string indirection |
 | test.cpp:243:16:243:21 | string indirection | test.cpp:243:12:243:21 | string |
+| test.cpp:249:12:249:24 | new[] | test.cpp:251:30:251:30 | p |
 nodes
 | test.cpp:16:11:16:21 | mk_string_t indirection [string] | semmle.label | mk_string_t indirection [string] |
 | test.cpp:18:5:18:30 | ... = ... | semmle.label | ... = ... |
@@ -402,6 +403,8 @@ nodes
 | test.cpp:243:12:243:14 | str indirection [string] | semmle.label | str indirection [string] |
 | test.cpp:243:12:243:21 | string | semmle.label | string |
 | test.cpp:243:16:243:21 | string indirection | semmle.label | string indirection |
+| test.cpp:249:12:249:24 | new[] | semmle.label | new[] |
+| test.cpp:251:30:251:30 | p | semmle.label | p |
 subpaths
 | test.cpp:242:22:242:27 | buffer | test.cpp:235:40:235:45 | buffer | test.cpp:236:12:236:17 | p_str indirection [post update] [string] | test.cpp:242:16:242:19 | set_string output argument [string] |
 #select
@@ -422,3 +425,4 @@ subpaths
 | test.cpp:207:9:207:15 | call to strncpy | test.cpp:147:19:147:24 | call to malloc | test.cpp:207:22:207:27 | string | This write may overflow $@ by 3 elements. | test.cpp:207:22:207:27 | string | string |
 | test.cpp:232:3:232:8 | call to memset | test.cpp:228:43:228:48 | call to malloc | test.cpp:232:10:232:15 | buffer | This write may overflow $@ by 32 elements. | test.cpp:232:10:232:15 | buffer | buffer |
 | test.cpp:243:5:243:10 | call to memset | test.cpp:241:27:241:32 | call to malloc | test.cpp:243:12:243:21 | string | This write may overflow $@ by 1 element. | test.cpp:243:16:243:21 | string | string |
+| test.cpp:251:18:251:22 | call to write | test.cpp:249:12:249:24 | new[] | test.cpp:251:30:251:30 | p | This write may overflow $@ by 32 elements. | test.cpp:251:30:251:30 | p | p |

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-119/test.cpp
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-119/test.cpp
@@ -243,3 +243,15 @@ void test_flow_through_setter(unsigned size) {
     memset(str.string, 0, size + 1); // BAD
 }
 
+unsigned write(int, const void *, unsigned);
+
+void test_modify_pointer_and_size_in_sync(int sock, unsigned size) {
+  int *p = new int[size];
+  while (size > 0) {
+    unsigned n = write(sock, p, size); // GOOD [FALSE POSITIVE]
+    if (n > 0) {
+      size += 1;
+      p -= 1;
+    }
+  }
+}


### PR DESCRIPTION
This PR adds another reduced FP from a MRVA run of `cpp/overrun-write`.