### PR TITLE
JS: Fix broken message in example query

### DIFF
--- a/javascript/ql/examples/queries/dataflow/DecodingAfterSanitization/DecodingAfterSanitizationGeneralized.ql
+++ b/javascript/ql/examples/queries/dataflow/DecodingAfterSanitization/DecodingAfterSanitizationGeneralized.ql
@@ -48,5 +48,5 @@ from DecodingAfterSanitization cfg, PathNode source, PathNode sink, DecodingCall
 where
   cfg.hasFlowPath(source, sink) and
   decoder.getInput() = sink.getNode()
-select sink.getNode(), source, sink, decoder.getKind() + " invalidates .", source.getNode(),
-  "this HTML sanitization performed"
+select sink.getNode(), source, sink, decoder.getKind() + " invalidates $@.", source.getNode(),
+  "this HTML sanitization"


### PR DESCRIPTION
The alert message was broken by [this commit](https://github.com/github/codeql/commit/368f84785b7c232628a3e07e948c965e4ab074bb). But since this is an example query it seems to have gone unnoticed.