### PR TITLE
Ruby: Improvements to `RegExpTracking`

### DIFF
--- a/python/ql/lib/semmle/python/dataflow/new/internal/TypeTracker.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/TypeTracker.qll
@@ -613,8 +613,17 @@ class TypeBackTracker extends TTypeBackTracker {
    * also flow to `sink`.
    */
   TypeTracker getACompatibleTypeTracker() {
-    exists(boolean hasCall | result = MkTypeTracker(hasCall, content) |
-      hasCall = false or this.hasReturn() = false
+    exists(boolean hasCall, OptionalTypeTrackerContent c |
+      result = MkTypeTracker(hasCall, c) and
+      (
+        compatibleContents(c, content)
+        or
+        content = noContent() and c = content
+      )
+    |
+      hasCall = false
+      or
+      this.hasReturn() = false
     )
   }
 }

--- a/ruby/ql/lib/codeql/ruby/controlflow/CfgNodes.qll
+++ b/ruby/ql/lib/codeql/ruby/controlflow/CfgNodes.qll
@@ -936,10 +936,10 @@ module ExprNodes {
   }
 
   /** A control-flow node that wraps a `StringLiteral` AST expression. */
-  class StringLiteralCfgNode extends ExprCfgNode {
-    override string getAPrimaryQlClass() { result = "StringLiteralCfgNode" }
+  class StringLiteralCfgNode extends StringlikeLiteralCfgNode {
+    StringLiteralCfgNode() { e instanceof StringLiteral }
 
-    override StringLiteral e;
+    override string getAPrimaryQlClass() { result = "StringLiteralCfgNode" }
 
     final override StringLiteral getExpr() { result = super.getExpr() }
   }

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/TaintTrackingPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/TaintTrackingPrivate.qll
@@ -112,6 +112,13 @@ private module Cached {
     )
   }
 
+  cached
+  predicate summaryThroughStepTaint(
+    DataFlow::Node arg, DataFlow::Node out, FlowSummaryImpl::Public::SummarizedCallable sc
+  ) {
+    FlowSummaryImpl::Private::Steps::summaryThroughStepTaint(arg, out, sc)
+  }
+
   /**
    * Holds if taint propagates from `nodeFrom` to `nodeTo` in exactly one local
    * (intra-procedural) step.
@@ -122,7 +129,7 @@ private module Cached {
     defaultAdditionalTaintStep(nodeFrom, nodeTo) or
     // Simple flow through library code is included in the exposed local
     // step relation, even though flow is technically inter-procedural
-    FlowSummaryImpl::Private::Steps::summaryThroughStepTaint(nodeFrom, nodeTo, _)
+    summaryThroughStepTaint(nodeFrom, nodeTo, _)
   }
 }
 

--- a/ruby/ql/lib/codeql/ruby/regexp/internal/RegExpTracking.qll
+++ b/ruby/ql/lib/codeql/ruby/regexp/internal/RegExpTracking.qll
@@ -108,6 +108,7 @@ private module Reach<ReachInputSig Input> {
     )
   }
 
+  /** Holds if `n` is forwards and backwards reachable with type tracker `t`. */
   pragma[nomagic]
   predicate reached(DataFlow::LocalSourceNode n, TypeTracker t) {
     n = forward(t) and
@@ -132,10 +133,11 @@ private module Reach<ReachInputSig Input> {
   }
 }
 
+/** Holds if `inputStr` is compiled to a regular expression that is returned at `call`. */
 pragma[nomagic]
-private predicate regFromString(DataFlow::LocalSourceNode n, DataFlow::CallNode call) {
+private predicate regFromString(DataFlow::LocalSourceNode inputStr, DataFlow::CallNode call) {
   exists(DataFlow::Node mid |
-    n.flowsTo(mid) and
+    inputStr.flowsTo(mid) and
     call = API::getTopLevelMember("Regexp").getAMethodCall(["compile", "new"]) and
     mid = call.getArgument(0)
   )
@@ -183,9 +185,10 @@ private DataFlow::LocalSourceNode trackStrings(DataFlow::Node start, TypeTracker
   exists(TypeTracker t2 | t = StringReach::stepReached(t2, trackStrings(start, t2), result))
 }
 
+/** Holds if `strConst` flows to a regex compilation (tracked by `t`), where the resulting regular expression is stored in `reg`. */
 pragma[nomagic]
-private predicate regFromStringStart(DataFlow::Node start, TypeTracker t, DataFlow::CallNode nodeTo) {
-  regFromString(trackStrings(start, t), nodeTo) and
+private predicate regFromStringStart(DataFlow::Node strConst, TypeTracker t, DataFlow::CallNode reg) {
+  regFromString(trackStrings(strConst, t), reg) and
   exists(t.continue())
 }
 

--- a/ruby/ql/lib/codeql/ruby/typetracking/TypeTracker.qll
+++ b/ruby/ql/lib/codeql/ruby/typetracking/TypeTracker.qll
@@ -613,8 +613,17 @@ class TypeBackTracker extends TTypeBackTracker {
    * also flow to `sink`.
    */
   TypeTracker getACompatibleTypeTracker() {
-    exists(boolean hasCall | result = MkTypeTracker(hasCall, content) |
-      hasCall = false or this.hasReturn() = false
+    exists(boolean hasCall, OptionalTypeTrackerContent c |
+      result = MkTypeTracker(hasCall, c) and
+      (
+        compatibleContents(c, content)
+        or
+        content = noContent() and c = content
+      )
+    |
+      hasCall = false
+      or
+      this.hasReturn() = false
     )
   }
 }


### PR DESCRIPTION
When https://github.com/github/codeql/pull/11879 switched from using global data flow to using type tracking, for identifying regular expressions, we lost flow through built-in string methods. This is because the conjunct
```ql
TaintTracking::localTaintStep(nodeFrom, nodeTo) and
nodeFrom.(DataFlowPrivate::SummaryNode).getSummarizedCallable() instanceof String::SummarizedCallable
```
doesn't work in type tracking, where we don't have flow-through. Instead, we should be using `FlowSummaryImpl::Private::Steps::summaryThroughStepTaint`, which this PR does.

Moreover, this PR improves on performance by strengthening the initial forwards/backwards pruning, which also revealed a bug in the existing `TypeBackTracker::getACompatibleTypeTracker` predicate.

DCA shows a nice speedup on `artichoke__artichoke`.