### PR TITLE
C#, C++: Make implicit this receivers explicit

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/IRType.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/IRType.qll
@@ -39,7 +39,7 @@ class IRType extends TIRType {
    * Gets a string that uniquely identifies this `IRType`. This string is often the same as the
    * result of `IRType.toString()`, but for some types it may be more verbose to ensure uniqueness.
    */
-  string getIdentityString() { result = toString() }
+  string getIdentityString() { result = this.toString() }
 
   /**
    * Gets the size of the type, in bytes, if known.
@@ -206,7 +206,7 @@ class IRFloatingPointType extends IRNumericType, TIRFloatingPointType {
   IRFloatingPointType() { this = TIRFloatingPointType(_, base, domain) }
 
   final override string toString() {
-    result = getDomainPrefix() + getBaseString() + byteSize.toString()
+    result = this.getDomainPrefix() + this.getBaseString() + byteSize.toString()
   }
 
   final override Language::LanguageType getCanonicalLanguageType() {

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/Opcode.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/Opcode.qll
@@ -135,11 +135,11 @@ class Opcode extends TOpcode {
    * Holds if the instruction must have an operand with the specified `OperandTag`.
    */
   final predicate hasOperand(OperandTag tag) {
-    hasOperandInternal(tag)
+    this.hasOperandInternal(tag)
     or
-    hasAddressOperand() and tag instanceof AddressOperandTag
+    this.hasAddressOperand() and tag instanceof AddressOperandTag
     or
-    hasBufferSizeOperand() and tag instanceof BufferSizeOperandTag
+    this.hasBufferSizeOperand() and tag instanceof BufferSizeOperandTag
   }
 
   /**

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/IRFunction.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/IRFunction.qll
@@ -45,7 +45,9 @@ class IRFunction extends IRFunctionBase {
    * Gets the block containing the entry point of this function.
    */
   pragma[noinline]
-  final IRBlock getEntryBlock() { result.getFirstInstruction() = getEnterFunctionInstruction() }
+  final IRBlock getEntryBlock() {
+    result.getFirstInstruction() = this.getEnterFunctionInstruction()
+  }
 
   /**
    * Gets all instructions in this function.

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/IRVariable.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/IRVariable.qll
@@ -39,12 +39,12 @@ class IRVariable extends TIRVariable {
   /**
    * Gets the type of the variable.
    */
-  final Language::Type getType() { getLanguageType().hasType(result, false) }
+  final Language::Type getType() { this.getLanguageType().hasType(result, false) }
 
   /**
    * Gets the language-neutral type of the variable.
    */
-  final IRType getIRType() { result = getLanguageType().getIRType() }
+  final IRType getIRType() { result = this.getLanguageType().getIRType() }
 
   /**
    * Gets the type of the variable.
@@ -58,7 +58,7 @@ class IRVariable extends TIRVariable {
   Language::AST getAst() { none() }
 
   /** DEPRECATED: Alias for getAst */
-  deprecated Language::AST getAST() { result = getAst() }
+  deprecated Language::AST getAST() { result = this.getAst() }
 
   /**
    * Gets an identifier string for the variable. This identifier is unique
@@ -69,7 +69,7 @@ class IRVariable extends TIRVariable {
   /**
    * Gets the source location of this variable.
    */
-  final Language::Location getLocation() { result = getAst().getLocation() }
+  final Language::Location getLocation() { result = this.getAst().getLocation() }
 
   /**
    * Gets the IR for the function that references this variable.
@@ -91,15 +91,15 @@ class IRUserVariable extends IRVariable, TIRUserVariable {
 
   IRUserVariable() { this = TIRUserVariable(var, type, func) }
 
-  final override string toString() { result = getVariable().toString() }
+  final override string toString() { result = this.getVariable().toString() }
 
   final override Language::AST getAst() { result = var }
 
   /** DEPRECATED: Alias for getAst */
-  deprecated override Language::AST getAST() { result = getAst() }
+  deprecated override Language::AST getAST() { result = this.getAst() }
 
   final override string getUniqueId() {
-    result = getVariable().toString() + " " + getVariable().getLocation().toString()
+    result = this.getVariable().toString() + " " + this.getVariable().getLocation().toString()
   }
 
   final override Language::LanguageType getLanguageType() { result = type }
@@ -166,9 +166,9 @@ class IRGeneratedVariable extends IRVariable {
   final override Language::AST getAst() { result = ast }
 
   /** DEPRECATED: Alias for getAst */
-  deprecated override Language::AST getAST() { result = getAst() }
+  deprecated override Language::AST getAST() { result = this.getAst() }
 
-  override string toString() { result = getBaseString() + getLocationString() }
+  override string toString() { result = this.getBaseString() + this.getLocationString() }
 
   override string getUniqueId() { none() }
 
@@ -272,7 +272,7 @@ class IRStringLiteral extends IRGeneratedVariable, TIRStringLiteral {
   final override predicate isReadOnly() { any() }
 
   final override string getUniqueId() {
-    result = "String: " + getLocationString() + "=" + Language::getStringLiteralText(literal)
+    result = "String: " + this.getLocationString() + "=" + Language::getStringLiteralText(literal)
   }
 
   final override string getBaseString() { result = "#string" }
@@ -303,7 +303,8 @@ class IRDynamicInitializationFlag extends IRGeneratedVariable, TIRDynamicInitial
   final Language::Variable getVariable() { result = var }
 
   final override string getUniqueId() {
-    result = "Init: " + getVariable().toString() + " " + getVariable().getLocation().toString()
+    result =
+      "Init: " + this.getVariable().toString() + " " + this.getVariable().getLocation().toString()
   }
 
   final override string getBaseString() { result = "#init:" + var.toString() + ":" }
@@ -332,5 +333,5 @@ class IRParameter extends IRAutomaticVariable {
  * An IR variable representing a positional parameter.
  */
 class IRPositionalParameter extends IRParameter, IRAutomaticUserVariable {
-  final override int getIndex() { result = getVariable().(Language::Parameter).getIndex() }
+  final override int getIndex() { result = this.getVariable().(Language::Parameter).getIndex() }
 }

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/PrintIR.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/PrintIR.qll
@@ -127,13 +127,13 @@ abstract private class PrintableIRNode extends TPrintableIRNode {
    * Gets the value of the node property with the specified key.
    */
   string getProperty(string key) {
-    key = "semmle.label" and result = getLabel()
+    key = "semmle.label" and result = this.getLabel()
     or
-    key = "semmle.order" and result = getOrder().toString()
+    key = "semmle.order" and result = this.getOrder().toString()
     or
-    key = "semmle.graphKind" and result = getGraphKind()
+    key = "semmle.graphKind" and result = this.getGraphKind()
     or
-    key = "semmle.forceText" and forceText() and result = "true"
+    key = "semmle.forceText" and this.forceText() and result = "true"
   }
 }
 
@@ -178,7 +178,7 @@ private class PrintableIRBlock extends PrintableIRNode, TPrintableIRBlock {
 
   PrintableIRBlock() { this = TPrintableIRBlock(block) }
 
-  override string toString() { result = getLabel() }
+  override string toString() { result = this.getLabel() }
 
   override Language::Location getLocation() { result = block.getLocation() }
 
@@ -223,7 +223,7 @@ private class PrintableInstruction extends PrintableIRNode, TPrintableInstructio
       |
         resultString = instr.getResultString() and
         operationString = instr.getOperationString() and
-        operandsString = getOperandsString() and
+        operandsString = this.getOperandsString() and
         columnWidths(block, resultWidth, operationWidth) and
         result =
           resultString + getPaddingString(resultWidth - resultString.length()) + " = " +

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/gvn/ValueNumbering.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/gvn/ValueNumbering.qll
@@ -7,17 +7,19 @@ private import internal.ValueNumberingImports
 class ValueNumber extends TValueNumber {
   final string toString() { result = "GVN" }
 
-  final string getDebugString() { result = strictconcat(getAnInstruction().getResultId(), ", ") }
+  final string getDebugString() {
+    result = strictconcat(this.getAnInstruction().getResultId(), ", ")
+  }
 
   final Language::Location getLocation() {
     if
       exists(Instruction i |
-        i = getAnInstruction() and not i.getLocation() instanceof Language::UnknownLocation
+        i = this.getAnInstruction() and not i.getLocation() instanceof Language::UnknownLocation
       )
     then
       result =
         min(Language::Location l |
-          l = getAnInstruction().getLocation() and not l instanceof Language::UnknownLocation
+          l = this.getAnInstruction().getLocation() and not l instanceof Language::UnknownLocation
         |
           l
           order by
@@ -40,7 +42,7 @@ class ValueNumber extends TValueNumber {
   final Instruction getExampleInstruction() {
     result =
       min(Instruction instr |
-        instr = getAnInstruction()
+        instr = this.getAnInstruction()
       |
         instr order by instr.getBlock().getDisplayIndex(), instr.getDisplayIndexInBlock()
       )

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/internal/OperandTag.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/internal/OperandTag.qll
@@ -40,7 +40,9 @@ abstract class OperandTag extends TOperandTag {
   /**
    * Gets a label that will appear before the operand when the IR is printed.
    */
-  final string getLabel() { if alwaysPrintLabel() then result = getId() + ":" else result = "" }
+  final string getLabel() {
+    if this.alwaysPrintLabel() then result = this.getId() + ":" else result = ""
+  }
 
   /**
    * Gets an identifier that uniquely identifies this operand within its instruction.

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/IRFunction.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/IRFunction.qll
@@ -45,7 +45,9 @@ class IRFunction extends IRFunctionBase {
    * Gets the block containing the entry point of this function.
    */
   pragma[noinline]
-  final IRBlock getEntryBlock() { result.getFirstInstruction() = getEnterFunctionInstruction() }
+  final IRBlock getEntryBlock() {
+    result.getFirstInstruction() = this.getEnterFunctionInstruction()
+  }
 
   /**
    * Gets all instructions in this function.

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/IRVariable.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/IRVariable.qll
@@ -39,12 +39,12 @@ class IRVariable extends TIRVariable {
   /**
    * Gets the type of the variable.
    */
-  final Language::Type getType() { getLanguageType().hasType(result, false) }
+  final Language::Type getType() { this.getLanguageType().hasType(result, false) }
 
   /**
    * Gets the language-neutral type of the variable.
    */
-  final IRType getIRType() { result = getLanguageType().getIRType() }
+  final IRType getIRType() { result = this.getLanguageType().getIRType() }
 
   /**
    * Gets the type of the variable.
@@ -58,7 +58,7 @@ class IRVariable extends TIRVariable {
   Language::AST getAst() { none() }
 
   /** DEPRECATED: Alias for getAst */
-  deprecated Language::AST getAST() { result = getAst() }
+  deprecated Language::AST getAST() { result = this.getAst() }
 
   /**
    * Gets an identifier string for the variable. This identifier is unique
@@ -69,7 +69,7 @@ class IRVariable extends TIRVariable {
   /**
    * Gets the source location of this variable.
    */
-  final Language::Location getLocation() { result = getAst().getLocation() }
+  final Language::Location getLocation() { result = this.getAst().getLocation() }
 
   /**
    * Gets the IR for the function that references this variable.
@@ -91,15 +91,15 @@ class IRUserVariable extends IRVariable, TIRUserVariable {
 
   IRUserVariable() { this = TIRUserVariable(var, type, func) }
 
-  final override string toString() { result = getVariable().toString() }
+  final override string toString() { result = this.getVariable().toString() }
 
   final override Language::AST getAst() { result = var }
 
   /** DEPRECATED: Alias for getAst */
-  deprecated override Language::AST getAST() { result = getAst() }
+  deprecated override Language::AST getAST() { result = this.getAst() }
 
   final override string getUniqueId() {
-    result = getVariable().toString() + " " + getVariable().getLocation().toString()
+    result = this.getVariable().toString() + " " + this.getVariable().getLocation().toString()
   }
 
   final override Language::LanguageType getLanguageType() { result = type }
@@ -166,9 +166,9 @@ class IRGeneratedVariable extends IRVariable {
   final override Language::AST getAst() { result = ast }
 
   /** DEPRECATED: Alias for getAst */
-  deprecated override Language::AST getAST() { result = getAst() }
+  deprecated override Language::AST getAST() { result = this.getAst() }
 
-  override string toString() { result = getBaseString() + getLocationString() }
+  override string toString() { result = this.getBaseString() + this.getLocationString() }
 
   override string getUniqueId() { none() }
 
@@ -272,7 +272,7 @@ class IRStringLiteral extends IRGeneratedVariable, TIRStringLiteral {
   final override predicate isReadOnly() { any() }
 
   final override string getUniqueId() {
-    result = "String: " + getLocationString() + "=" + Language::getStringLiteralText(literal)
+    result = "String: " + this.getLocationString() + "=" + Language::getStringLiteralText(literal)
   }
 
   final override string getBaseString() { result = "#string" }
@@ -303,7 +303,8 @@ class IRDynamicInitializationFlag extends IRGeneratedVariable, TIRDynamicInitial
   final Language::Variable getVariable() { result = var }
 
   final override string getUniqueId() {
-    result = "Init: " + getVariable().toString() + " " + getVariable().getLocation().toString()
+    result =
+      "Init: " + this.getVariable().toString() + " " + this.getVariable().getLocation().toString()
   }
 
   final override string getBaseString() { result = "#init:" + var.toString() + ":" }
@@ -332,5 +333,5 @@ class IRParameter extends IRAutomaticVariable {
  * An IR variable representing a positional parameter.
  */
 class IRPositionalParameter extends IRParameter, IRAutomaticUserVariable {
-  final override int getIndex() { result = getVariable().(Language::Parameter).getIndex() }
+  final override int getIndex() { result = this.getVariable().(Language::Parameter).getIndex() }
 }

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/PrintIR.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/PrintIR.qll
@@ -127,13 +127,13 @@ abstract private class PrintableIRNode extends TPrintableIRNode {
    * Gets the value of the node property with the specified key.
    */
   string getProperty(string key) {
-    key = "semmle.label" and result = getLabel()
+    key = "semmle.label" and result = this.getLabel()
     or
-    key = "semmle.order" and result = getOrder().toString()
+    key = "semmle.order" and result = this.getOrder().toString()
     or
-    key = "semmle.graphKind" and result = getGraphKind()
+    key = "semmle.graphKind" and result = this.getGraphKind()
     or
-    key = "semmle.forceText" and forceText() and result = "true"
+    key = "semmle.forceText" and this.forceText() and result = "true"
   }
 }
 
@@ -178,7 +178,7 @@ private class PrintableIRBlock extends PrintableIRNode, TPrintableIRBlock {
 
   PrintableIRBlock() { this = TPrintableIRBlock(block) }
 
-  override string toString() { result = getLabel() }
+  override string toString() { result = this.getLabel() }
 
   override Language::Location getLocation() { result = block.getLocation() }
 
@@ -223,7 +223,7 @@ private class PrintableInstruction extends PrintableIRNode, TPrintableInstructio
       |
         resultString = instr.getResultString() and
         operationString = instr.getOperationString() and
-        operandsString = getOperandsString() and
+        operandsString = this.getOperandsString() and
         columnWidths(block, resultWidth, operationWidth) and
         result =
           resultString + getPaddingString(resultWidth - resultString.length()) + " = " +

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/gvn/ValueNumbering.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/gvn/ValueNumbering.qll
@@ -7,17 +7,19 @@ private import internal.ValueNumberingImports
 class ValueNumber extends TValueNumber {
   final string toString() { result = "GVN" }
 
-  final string getDebugString() { result = strictconcat(getAnInstruction().getResultId(), ", ") }
+  final string getDebugString() {
+    result = strictconcat(this.getAnInstruction().getResultId(), ", ")
+  }
 
   final Language::Location getLocation() {
     if
       exists(Instruction i |
-        i = getAnInstruction() and not i.getLocation() instanceof Language::UnknownLocation
+        i = this.getAnInstruction() and not i.getLocation() instanceof Language::UnknownLocation
       )
     then
       result =
         min(Language::Location l |
-          l = getAnInstruction().getLocation() and not l instanceof Language::UnknownLocation
+          l = this.getAnInstruction().getLocation() and not l instanceof Language::UnknownLocation
         |
           l
           order by
@@ -40,7 +42,7 @@ class ValueNumber extends TValueNumber {
   final Instruction getExampleInstruction() {
     result =
       min(Instruction instr |
-        instr = getAnInstruction()
+        instr = this.getAnInstruction()
       |
         instr order by instr.getBlock().getDisplayIndex(), instr.getDisplayIndexInBlock()
       )

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/IRFunction.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/IRFunction.qll
@@ -45,7 +45,9 @@ class IRFunction extends IRFunctionBase {
    * Gets the block containing the entry point of this function.
    */
   pragma[noinline]
-  final IRBlock getEntryBlock() { result.getFirstInstruction() = getEnterFunctionInstruction() }
+  final IRBlock getEntryBlock() {
+    result.getFirstInstruction() = this.getEnterFunctionInstruction()
+  }
 
   /**
    * Gets all instructions in this function.

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/IRVariable.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/IRVariable.qll
@@ -39,12 +39,12 @@ class IRVariable extends TIRVariable {
   /**
    * Gets the type of the variable.
    */
-  final Language::Type getType() { getLanguageType().hasType(result, false) }
+  final Language::Type getType() { this.getLanguageType().hasType(result, false) }
 
   /**
    * Gets the language-neutral type of the variable.
    */
-  final IRType getIRType() { result = getLanguageType().getIRType() }
+  final IRType getIRType() { result = this.getLanguageType().getIRType() }
 
   /**
    * Gets the type of the variable.
@@ -58,7 +58,7 @@ class IRVariable extends TIRVariable {
   Language::AST getAst() { none() }
 
   /** DEPRECATED: Alias for getAst */
-  deprecated Language::AST getAST() { result = getAst() }
+  deprecated Language::AST getAST() { result = this.getAst() }
 
   /**
    * Gets an identifier string for the variable. This identifier is unique
@@ -69,7 +69,7 @@ class IRVariable extends TIRVariable {
   /**
    * Gets the source location of this variable.
    */
-  final Language::Location getLocation() { result = getAst().getLocation() }
+  final Language::Location getLocation() { result = this.getAst().getLocation() }
 
   /**
    * Gets the IR for the function that references this variable.
@@ -91,15 +91,15 @@ class IRUserVariable extends IRVariable, TIRUserVariable {
 
   IRUserVariable() { this = TIRUserVariable(var, type, func) }
 
-  final override string toString() { result = getVariable().toString() }
+  final override string toString() { result = this.getVariable().toString() }
 
   final override Language::AST getAst() { result = var }
 
   /** DEPRECATED: Alias for getAst */
-  deprecated override Language::AST getAST() { result = getAst() }
+  deprecated override Language::AST getAST() { result = this.getAst() }
 
   final override string getUniqueId() {
-    result = getVariable().toString() + " " + getVariable().getLocation().toString()
+    result = this.getVariable().toString() + " " + this.getVariable().getLocation().toString()
   }
 
   final override Language::LanguageType getLanguageType() { result = type }
@@ -166,9 +166,9 @@ class IRGeneratedVariable extends IRVariable {
   final override Language::AST getAst() { result = ast }
 
   /** DEPRECATED: Alias for getAst */
-  deprecated override Language::AST getAST() { result = getAst() }
+  deprecated override Language::AST getAST() { result = this.getAst() }
 
-  override string toString() { result = getBaseString() + getLocationString() }
+  override string toString() { result = this.getBaseString() + this.getLocationString() }
 
   override string getUniqueId() { none() }
 
@@ -272,7 +272,7 @@ class IRStringLiteral extends IRGeneratedVariable, TIRStringLiteral {
   final override predicate isReadOnly() { any() }
 
   final override string getUniqueId() {
-    result = "String: " + getLocationString() + "=" + Language::getStringLiteralText(literal)
+    result = "String: " + this.getLocationString() + "=" + Language::getStringLiteralText(literal)
   }
 
   final override string getBaseString() { result = "#string" }
@@ -303,7 +303,8 @@ class IRDynamicInitializationFlag extends IRGeneratedVariable, TIRDynamicInitial
   final Language::Variable getVariable() { result = var }
 
   final override string getUniqueId() {
-    result = "Init: " + getVariable().toString() + " " + getVariable().getLocation().toString()
+    result =
+      "Init: " + this.getVariable().toString() + " " + this.getVariable().getLocation().toString()
   }
 
   final override string getBaseString() { result = "#init:" + var.toString() + ":" }
@@ -332,5 +333,5 @@ class IRParameter extends IRAutomaticVariable {
  * An IR variable representing a positional parameter.
  */
 class IRPositionalParameter extends IRParameter, IRAutomaticUserVariable {
-  final override int getIndex() { result = getVariable().(Language::Parameter).getIndex() }
+  final override int getIndex() { result = this.getVariable().(Language::Parameter).getIndex() }
 }

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/PrintIR.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/PrintIR.qll
@@ -127,13 +127,13 @@ abstract private class PrintableIRNode extends TPrintableIRNode {
    * Gets the value of the node property with the specified key.
    */
   string getProperty(string key) {
-    key = "semmle.label" and result = getLabel()
+    key = "semmle.label" and result = this.getLabel()
     or
-    key = "semmle.order" and result = getOrder().toString()
+    key = "semmle.order" and result = this.getOrder().toString()
     or
-    key = "semmle.graphKind" and result = getGraphKind()
+    key = "semmle.graphKind" and result = this.getGraphKind()
     or
-    key = "semmle.forceText" and forceText() and result = "true"
+    key = "semmle.forceText" and this.forceText() and result = "true"
   }
 }
 
@@ -178,7 +178,7 @@ private class PrintableIRBlock extends PrintableIRNode, TPrintableIRBlock {
 
   PrintableIRBlock() { this = TPrintableIRBlock(block) }
 
-  override string toString() { result = getLabel() }
+  override string toString() { result = this.getLabel() }
 
   override Language::Location getLocation() { result = block.getLocation() }
 
@@ -223,7 +223,7 @@ private class PrintableInstruction extends PrintableIRNode, TPrintableInstructio
       |
         resultString = instr.getResultString() and
         operationString = instr.getOperationString() and
-        operandsString = getOperandsString() and
+        operandsString = this.getOperandsString() and
         columnWidths(block, resultWidth, operationWidth) and
         result =
           resultString + getPaddingString(resultWidth - resultString.length()) + " = " +

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/gvn/ValueNumbering.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/gvn/ValueNumbering.qll
@@ -7,17 +7,19 @@ private import internal.ValueNumberingImports
 class ValueNumber extends TValueNumber {
   final string toString() { result = "GVN" }
 
-  final string getDebugString() { result = strictconcat(getAnInstruction().getResultId(), ", ") }
+  final string getDebugString() {
+    result = strictconcat(this.getAnInstruction().getResultId(), ", ")
+  }
 
   final Language::Location getLocation() {
     if
       exists(Instruction i |
-        i = getAnInstruction() and not i.getLocation() instanceof Language::UnknownLocation
+        i = this.getAnInstruction() and not i.getLocation() instanceof Language::UnknownLocation
       )
     then
       result =
         min(Language::Location l |
-          l = getAnInstruction().getLocation() and not l instanceof Language::UnknownLocation
+          l = this.getAnInstruction().getLocation() and not l instanceof Language::UnknownLocation
         |
           l
           order by
@@ -40,7 +42,7 @@ class ValueNumber extends TValueNumber {
   final Instruction getExampleInstruction() {
     result =
       min(Instruction instr |
-        instr = getAnInstruction()
+        instr = this.getAnInstruction()
       |
         instr order by instr.getBlock().getDisplayIndex(), instr.getDisplayIndexInBlock()
       )

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/AliasConfiguration.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/AliasConfiguration.qll
@@ -7,7 +7,7 @@ private import AliasConfigurationImports
 class Allocation extends IRAutomaticVariable {
   VariableAddressInstruction getABaseInstruction() { result.getIRVariable() = this }
 
-  final string getAllocationString() { result = toString() }
+  final string getAllocationString() { result = this.toString() }
 
   predicate alwaysEscapes() {
     // An automatic variable only escapes if its address is taken and escapes.

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/SimpleSSA.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/SimpleSSA.qll
@@ -75,7 +75,7 @@ class MemoryLocation extends TMemoryLocation {
   final predicate canReuseSsa() { canReuseSsaForVariable(var) }
 
   /** DEPRECATED: Alias for canReuseSsa */
-  deprecated predicate canReuseSSA() { canReuseSsa() }
+  deprecated predicate canReuseSSA() { this.canReuseSsa() }
 }
 
 predicate canReuseSsaForOldResult(Instruction instr) { none() }

--- a/csharp/ql/src/experimental/ir/implementation/IRType.qll
+++ b/csharp/ql/src/experimental/ir/implementation/IRType.qll
@@ -39,7 +39,7 @@ class IRType extends TIRType {
    * Gets a string that uniquely identifies this `IRType`. This string is often the same as the
    * result of `IRType.toString()`, but for some types it may be more verbose to ensure uniqueness.
    */
-  string getIdentityString() { result = toString() }
+  string getIdentityString() { result = this.toString() }
 
   /**
    * Gets the size of the type, in bytes, if known.
@@ -206,7 +206,7 @@ class IRFloatingPointType extends IRNumericType, TIRFloatingPointType {
   IRFloatingPointType() { this = TIRFloatingPointType(_, base, domain) }
 
   final override string toString() {
-    result = getDomainPrefix() + getBaseString() + byteSize.toString()
+    result = this.getDomainPrefix() + this.getBaseString() + byteSize.toString()
   }
 
   final override Language::LanguageType getCanonicalLanguageType() {

--- a/csharp/ql/src/experimental/ir/implementation/Opcode.qll
+++ b/csharp/ql/src/experimental/ir/implementation/Opcode.qll
@@ -135,11 +135,11 @@ class Opcode extends TOpcode {
    * Holds if the instruction must have an operand with the specified `OperandTag`.
    */
   final predicate hasOperand(OperandTag tag) {
-    hasOperandInternal(tag)
+    this.hasOperandInternal(tag)
     or
-    hasAddressOperand() and tag instanceof AddressOperandTag
+    this.hasAddressOperand() and tag instanceof AddressOperandTag
     or
-    hasBufferSizeOperand() and tag instanceof BufferSizeOperandTag
+    this.hasBufferSizeOperand() and tag instanceof BufferSizeOperandTag
   }
 
   /**

--- a/csharp/ql/src/experimental/ir/implementation/internal/OperandTag.qll
+++ b/csharp/ql/src/experimental/ir/implementation/internal/OperandTag.qll
@@ -40,7 +40,9 @@ abstract class OperandTag extends TOperandTag {
   /**
    * Gets a label that will appear before the operand when the IR is printed.
    */
-  final string getLabel() { if alwaysPrintLabel() then result = getId() + ":" else result = "" }
+  final string getLabel() {
+    if this.alwaysPrintLabel() then result = this.getId() + ":" else result = ""
+  }
 
   /**
    * Gets an identifier that uniquely identifies this operand within its instruction.

--- a/csharp/ql/src/experimental/ir/implementation/raw/IRFunction.qll
+++ b/csharp/ql/src/experimental/ir/implementation/raw/IRFunction.qll
@@ -45,7 +45,9 @@ class IRFunction extends IRFunctionBase {
    * Gets the block containing the entry point of this function.
    */
   pragma[noinline]
-  final IRBlock getEntryBlock() { result.getFirstInstruction() = getEnterFunctionInstruction() }
+  final IRBlock getEntryBlock() {
+    result.getFirstInstruction() = this.getEnterFunctionInstruction()
+  }
 
   /**
    * Gets all instructions in this function.

--- a/csharp/ql/src/experimental/ir/implementation/raw/IRVariable.qll
+++ b/csharp/ql/src/experimental/ir/implementation/raw/IRVariable.qll
@@ -39,12 +39,12 @@ class IRVariable extends TIRVariable {
   /**
    * Gets the type of the variable.
    */
-  final Language::Type getType() { getLanguageType().hasType(result, false) }
+  final Language::Type getType() { this.getLanguageType().hasType(result, false) }
 
   /**
    * Gets the language-neutral type of the variable.
    */
-  final IRType getIRType() { result = getLanguageType().getIRType() }
+  final IRType getIRType() { result = this.getLanguageType().getIRType() }
 
   /**
    * Gets the type of the variable.
@@ -58,7 +58,7 @@ class IRVariable extends TIRVariable {
   Language::AST getAst() { none() }
 
   /** DEPRECATED: Alias for getAst */
-  deprecated Language::AST getAST() { result = getAst() }
+  deprecated Language::AST getAST() { result = this.getAst() }
 
   /**
    * Gets an identifier string for the variable. This identifier is unique
@@ -69,7 +69,7 @@ class IRVariable extends TIRVariable {
   /**
    * Gets the source location of this variable.
    */
-  final Language::Location getLocation() { result = getAst().getLocation() }
+  final Language::Location getLocation() { result = this.getAst().getLocation() }
 
   /**
    * Gets the IR for the function that references this variable.
@@ -91,15 +91,15 @@ class IRUserVariable extends IRVariable, TIRUserVariable {
 
   IRUserVariable() { this = TIRUserVariable(var, type, func) }
 
-  final override string toString() { result = getVariable().toString() }
+  final override string toString() { result = this.getVariable().toString() }
 
   final override Language::AST getAst() { result = var }
 
   /** DEPRECATED: Alias for getAst */
-  deprecated override Language::AST getAST() { result = getAst() }
+  deprecated override Language::AST getAST() { result = this.getAst() }
 
   final override string getUniqueId() {
-    result = getVariable().toString() + " " + getVariable().getLocation().toString()
+    result = this.getVariable().toString() + " " + this.getVariable().getLocation().toString()
   }
 
   final override Language::LanguageType getLanguageType() { result = type }
@@ -166,9 +166,9 @@ class IRGeneratedVariable extends IRVariable {
   final override Language::AST getAst() { result = ast }
 
   /** DEPRECATED: Alias for getAst */
-  deprecated override Language::AST getAST() { result = getAst() }
+  deprecated override Language::AST getAST() { result = this.getAst() }
 
-  override string toString() { result = getBaseString() + getLocationString() }
+  override string toString() { result = this.getBaseString() + this.getLocationString() }
 
   override string getUniqueId() { none() }
 
@@ -272,7 +272,7 @@ class IRStringLiteral extends IRGeneratedVariable, TIRStringLiteral {
   final override predicate isReadOnly() { any() }
 
   final override string getUniqueId() {
-    result = "String: " + getLocationString() + "=" + Language::getStringLiteralText(literal)
+    result = "String: " + this.getLocationString() + "=" + Language::getStringLiteralText(literal)
   }
 
   final override string getBaseString() { result = "#string" }
@@ -303,7 +303,8 @@ class IRDynamicInitializationFlag extends IRGeneratedVariable, TIRDynamicInitial
   final Language::Variable getVariable() { result = var }
 
   final override string getUniqueId() {
-    result = "Init: " + getVariable().toString() + " " + getVariable().getLocation().toString()
+    result =
+      "Init: " + this.getVariable().toString() + " " + this.getVariable().getLocation().toString()
   }
 
   final override string getBaseString() { result = "#init:" + var.toString() + ":" }
@@ -332,5 +333,5 @@ class IRParameter extends IRAutomaticVariable {
  * An IR variable representing a positional parameter.
  */
 class IRPositionalParameter extends IRParameter, IRAutomaticUserVariable {
-  final override int getIndex() { result = getVariable().(Language::Parameter).getIndex() }
+  final override int getIndex() { result = this.getVariable().(Language::Parameter).getIndex() }
 }

--- a/csharp/ql/src/experimental/ir/implementation/raw/PrintIR.qll
+++ b/csharp/ql/src/experimental/ir/implementation/raw/PrintIR.qll
@@ -127,13 +127,13 @@ abstract private class PrintableIRNode extends TPrintableIRNode {
    * Gets the value of the node property with the specified key.
    */
   string getProperty(string key) {
-    key = "semmle.label" and result = getLabel()
+    key = "semmle.label" and result = this.getLabel()
     or
-    key = "semmle.order" and result = getOrder().toString()
+    key = "semmle.order" and result = this.getOrder().toString()
     or
-    key = "semmle.graphKind" and result = getGraphKind()
+    key = "semmle.graphKind" and result = this.getGraphKind()
     or
-    key = "semmle.forceText" and forceText() and result = "true"
+    key = "semmle.forceText" and this.forceText() and result = "true"
   }
 }
 
@@ -178,7 +178,7 @@ private class PrintableIRBlock extends PrintableIRNode, TPrintableIRBlock {
 
   PrintableIRBlock() { this = TPrintableIRBlock(block) }
 
-  override string toString() { result = getLabel() }
+  override string toString() { result = this.getLabel() }
 
   override Language::Location getLocation() { result = block.getLocation() }
 
@@ -223,7 +223,7 @@ private class PrintableInstruction extends PrintableIRNode, TPrintableInstructio
       |
         resultString = instr.getResultString() and
         operationString = instr.getOperationString() and
-        operandsString = getOperandsString() and
+        operandsString = this.getOperandsString() and
         columnWidths(block, resultWidth, operationWidth) and
         result =
           resultString + getPaddingString(resultWidth - resultString.length()) + " = " +

--- a/csharp/ql/src/experimental/ir/implementation/raw/gvn/ValueNumbering.qll
+++ b/csharp/ql/src/experimental/ir/implementation/raw/gvn/ValueNumbering.qll
@@ -7,17 +7,19 @@ private import internal.ValueNumberingImports
 class ValueNumber extends TValueNumber {
   final string toString() { result = "GVN" }
 
-  final string getDebugString() { result = strictconcat(getAnInstruction().getResultId(), ", ") }
+  final string getDebugString() {
+    result = strictconcat(this.getAnInstruction().getResultId(), ", ")
+  }
 
   final Language::Location getLocation() {
     if
       exists(Instruction i |
-        i = getAnInstruction() and not i.getLocation() instanceof Language::UnknownLocation
+        i = this.getAnInstruction() and not i.getLocation() instanceof Language::UnknownLocation
       )
     then
       result =
         min(Language::Location l |
-          l = getAnInstruction().getLocation() and not l instanceof Language::UnknownLocation
+          l = this.getAnInstruction().getLocation() and not l instanceof Language::UnknownLocation
         |
           l
           order by
@@ -40,7 +42,7 @@ class ValueNumber extends TValueNumber {
   final Instruction getExampleInstruction() {
     result =
       min(Instruction instr |
-        instr = getAnInstruction()
+        instr = this.getAnInstruction()
       |
         instr order by instr.getBlock().getDisplayIndex(), instr.getDisplayIndexInBlock()
       )

--- a/csharp/ql/src/experimental/ir/implementation/raw/internal/common/TranslatedCallBase.qll
+++ b/csharp/ql/src/experimental/ir/implementation/raw/internal/common/TranslatedCallBase.qll
@@ -21,26 +21,26 @@ abstract class TranslatedCallBase extends TranslatedElement {
     // though the `this` argument exists and is the result of the instruction
     // that allocated the new object. For those calls, `getQualifier()` should
     // be void.
-    id = -1 and result = getQualifier()
+    id = -1 and result = this.getQualifier()
     or
-    result = getArgument(id)
+    result = this.getArgument(id)
   }
 
   final override Instruction getFirstInstruction() {
-    if exists(getQualifier())
-    then result = getQualifier().getFirstInstruction()
-    else result = getInstruction(CallTargetTag())
+    if exists(this.getQualifier())
+    then result = this.getQualifier().getFirstInstruction()
+    else result = this.getInstruction(CallTargetTag())
   }
 
   override predicate hasInstruction(Opcode opcode, InstructionTag tag, CSharpType resultType) {
     tag = CallTag() and
     opcode instanceof Opcode::Call and
-    resultType = getTypeForPRValue(getCallResultType())
+    resultType = getTypeForPRValue(this.getCallResultType())
     or
-    hasSideEffect() and
+    this.hasSideEffect() and
     tag = CallSideEffectTag() and
     (
-      if hasWriteSideEffect()
+      if this.hasWriteSideEffect()
       then (
         opcode instanceof Opcode::CallSideEffect and
         resultType = getUnknownType()
@@ -58,14 +58,14 @@ abstract class TranslatedCallBase extends TranslatedElement {
   }
 
   override Instruction getChildSuccessor(TranslatedElement child) {
-    child = getQualifier() and
-    result = getInstruction(CallTargetTag())
+    child = this.getQualifier() and
+    result = this.getInstruction(CallTargetTag())
     or
     exists(int argIndex |
-      child = getArgument(argIndex) and
-      if exists(getArgument(argIndex + 1))
-      then result = getArgument(argIndex + 1).getFirstInstruction()
-      else result = getInstruction(CallTag())
+      child = this.getArgument(argIndex) and
+      if exists(this.getArgument(argIndex + 1))
+      then result = this.getArgument(argIndex + 1).getFirstInstruction()
+      else result = this.getInstruction(CallTag())
     )
   }
 
@@ -74,18 +74,18 @@ abstract class TranslatedCallBase extends TranslatedElement {
     (
       (
         tag = CallTag() and
-        if hasSideEffect()
-        then result = getInstruction(CallSideEffectTag())
-        else result = getParent().getChildSuccessor(this)
+        if this.hasSideEffect()
+        then result = this.getInstruction(CallSideEffectTag())
+        else result = this.getParent().getChildSuccessor(this)
       )
       or
-      hasSideEffect() and
+      this.hasSideEffect() and
       tag = CallSideEffectTag() and
-      result = getParent().getChildSuccessor(this)
+      result = this.getParent().getChildSuccessor(this)
       or
       tag = CallTargetTag() and
       kind instanceof GotoEdge and
-      result = getFirstArgumentOrCallInstruction()
+      result = this.getFirstArgumentOrCallInstruction()
     )
   }
 
@@ -93,26 +93,26 @@ abstract class TranslatedCallBase extends TranslatedElement {
     tag = CallTag() and
     (
       operandTag instanceof CallTargetOperandTag and
-      result = getInstruction(CallTargetTag())
+      result = this.getInstruction(CallTargetTag())
       or
       operandTag instanceof ThisArgumentOperandTag and
-      result = getQualifierResult()
+      result = this.getQualifierResult()
       or
       exists(PositionalArgumentOperandTag argTag |
         argTag = operandTag and
-        result = getArgument(argTag.getArgIndex()).getResult()
+        result = this.getArgument(argTag.getArgIndex()).getResult()
       )
     )
   }
 
   final override CSharpType getInstructionOperandType(InstructionTag tag, TypedOperandTag operandTag) {
     tag = CallSideEffectTag() and
-    hasSideEffect() and
+    this.hasSideEffect() and
     operandTag instanceof SideEffectOperandTag and
     result = getUnknownType()
   }
 
-  Instruction getResult() { result = getInstruction(CallTag()) }
+  Instruction getResult() { result = this.getInstruction(CallTag()) }
 
   /**
    * Gets the result type of the call.
@@ -122,7 +122,7 @@ abstract class TranslatedCallBase extends TranslatedElement {
   /**
    * Holds if the call has a `this` argument.
    */
-  predicate hasQualifier() { exists(getQualifier()) }
+  predicate hasQualifier() { exists(this.getQualifier()) }
 
   /**
    * Gets the expr for the qualifier of the call.
@@ -150,25 +150,25 @@ abstract class TranslatedCallBase extends TranslatedElement {
    * argument. Otherwise, returns the call instruction.
    */
   final Instruction getFirstArgumentOrCallInstruction() {
-    if hasArguments()
-    then result = getArgument(0).getFirstInstruction()
-    else result = getInstruction(CallTag())
+    if this.hasArguments()
+    then result = this.getArgument(0).getFirstInstruction()
+    else result = this.getInstruction(CallTag())
   }
 
   /**
    * Holds if the call has any arguments, not counting the `this` argument.
    */
-  final predicate hasArguments() { exists(getArgument(0)) }
+  final predicate hasArguments() { exists(this.getArgument(0)) }
 
   predicate hasReadSideEffect() { any() }
 
   predicate hasWriteSideEffect() { any() }
 
-  private predicate hasSideEffect() { hasReadSideEffect() or hasWriteSideEffect() }
+  private predicate hasSideEffect() { this.hasReadSideEffect() or this.hasWriteSideEffect() }
 
   override Instruction getPrimaryInstructionForSideEffect(InstructionTag tag) {
-    hasSideEffect() and
+    this.hasSideEffect() and
     tag = CallSideEffectTag() and
-    result = getResult()
+    result = this.getResult()
   }
 }

--- a/csharp/ql/src/experimental/ir/implementation/raw/internal/common/TranslatedConditionBase.qll
+++ b/csharp/ql/src/experimental/ir/implementation/raw/internal/common/TranslatedConditionBase.qll
@@ -27,7 +27,7 @@ abstract class ConditionContext extends TranslatedElement {
  * and the compiler generated ones (captures the common patterns).
  */
 abstract class ConditionBase extends TranslatedElement {
-  final ConditionContext getConditionContext() { result = getParent() }
+  final ConditionContext getConditionContext() { result = this.getParent() }
 }
 
 /**
@@ -35,9 +35,9 @@ abstract class ConditionBase extends TranslatedElement {
  * and the compiler generated ones (captures the common patterns).
  */
 abstract class ValueConditionBase extends ConditionBase {
-  override TranslatedElement getChild(int id) { id = 0 and result = getValueExpr() }
+  override TranslatedElement getChild(int id) { id = 0 and result = this.getValueExpr() }
 
-  override Instruction getFirstInstruction() { result = getValueExpr().getFirstInstruction() }
+  override Instruction getFirstInstruction() { result = this.getValueExpr().getFirstInstruction() }
 
   override predicate hasInstruction(Opcode opcode, InstructionTag tag, CSharpType resultType) {
     tag = ValueConditionConditionalBranchTag() and
@@ -46,25 +46,25 @@ abstract class ValueConditionBase extends ConditionBase {
   }
 
   override Instruction getChildSuccessor(TranslatedElement child) {
-    child = getValueExpr() and
-    result = getInstruction(ValueConditionConditionalBranchTag())
+    child = this.getValueExpr() and
+    result = this.getInstruction(ValueConditionConditionalBranchTag())
   }
 
   override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) {
     tag = ValueConditionConditionalBranchTag() and
     (
       kind instanceof TrueEdge and
-      result = getConditionContext().getChildTrueSuccessor(this)
+      result = this.getConditionContext().getChildTrueSuccessor(this)
       or
       kind instanceof FalseEdge and
-      result = getConditionContext().getChildFalseSuccessor(this)
+      result = this.getConditionContext().getChildFalseSuccessor(this)
     )
   }
 
   override Instruction getInstructionOperand(InstructionTag tag, OperandTag operandTag) {
     tag = ValueConditionConditionalBranchTag() and
     operandTag instanceof ConditionOperandTag and
-    result = valueExprResult()
+    result = this.valueExprResult()
   }
 
   /**

--- a/csharp/ql/src/experimental/ir/implementation/raw/internal/common/TranslatedDeclarationBase.qll
+++ b/csharp/ql/src/experimental/ir/implementation/raw/internal/common/TranslatedDeclarationBase.qll
@@ -15,49 +15,49 @@ private import experimental.ir.internal.CSharpType
 private import experimental.ir.internal.IRCSharpLanguage as Language
 
 abstract class LocalVariableDeclarationBase extends TranslatedElement {
-  override TranslatedElement getChild(int id) { id = 0 and result = getInitialization() }
+  override TranslatedElement getChild(int id) { id = 0 and result = this.getInitialization() }
 
-  override Instruction getFirstInstruction() { result = getVarAddress() }
+  override Instruction getFirstInstruction() { result = this.getVarAddress() }
 
   override predicate hasInstruction(Opcode opcode, InstructionTag tag, CSharpType resultType) {
     tag = InitializerVariableAddressTag() and
     opcode instanceof Opcode::VariableAddress and
-    resultType = getTypeForGLValue(getVarType())
+    resultType = getTypeForGLValue(this.getVarType())
     or
-    hasUninitializedInstruction() and
+    this.hasUninitializedInstruction() and
     tag = InitializerStoreTag() and
     opcode instanceof Opcode::Uninitialized and
-    resultType = getTypeForPRValue(getVarType())
+    resultType = getTypeForPRValue(this.getVarType())
   }
 
   override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) {
     (
       tag = InitializerVariableAddressTag() and
       kind instanceof GotoEdge and
-      if hasUninitializedInstruction()
-      then result = getInstruction(InitializerStoreTag())
-      else result = getInitialization().getFirstInstruction()
+      if this.hasUninitializedInstruction()
+      then result = this.getInstruction(InitializerStoreTag())
+      else result = this.getInitialization().getFirstInstruction()
     )
     or
-    hasUninitializedInstruction() and
+    this.hasUninitializedInstruction() and
     kind instanceof GotoEdge and
     tag = InitializerStoreTag() and
     (
-      result = getInitialization().getFirstInstruction()
+      result = this.getInitialization().getFirstInstruction()
       or
-      not exists(getInitialization()) and result = getParent().getChildSuccessor(this)
+      not exists(this.getInitialization()) and result = this.getParent().getChildSuccessor(this)
     )
   }
 
   override Instruction getChildSuccessor(TranslatedElement child) {
-    child = getInitialization() and result = getParent().getChildSuccessor(this)
+    child = this.getInitialization() and result = this.getParent().getChildSuccessor(this)
   }
 
   override Instruction getInstructionOperand(InstructionTag tag, OperandTag operandTag) {
-    hasUninitializedInstruction() and
+    this.hasUninitializedInstruction() and
     tag = InitializerStoreTag() and
     operandTag instanceof AddressOperandTag and
-    result = getVarAddress()
+    result = this.getVarAddress()
   }
 
   /**
@@ -67,11 +67,11 @@ abstract class LocalVariableDeclarationBase extends TranslatedElement {
    * desugaring process.
    */
   predicate hasUninitializedInstruction() {
-    not exists(getInitialization()) or
-    getInitialization() instanceof TranslatedListInitialization
+    not exists(this.getInitialization()) or
+    this.getInitialization() instanceof TranslatedListInitialization
   }
 
-  Instruction getVarAddress() { result = getInstruction(InitializerVariableAddressTag()) }
+  Instruction getVarAddress() { result = this.getInstruction(InitializerVariableAddressTag()) }
 
   /**
    * Gets the declared variable. For compiler generated elements, this

--- a/csharp/ql/src/experimental/ir/implementation/raw/internal/desugar/Common.qll
+++ b/csharp/ql/src/experimental/ir/implementation/raw/internal/desugar/Common.qll
@@ -38,21 +38,21 @@ abstract class TranslatedCompilerGeneratedTry extends TranslatedCompilerGenerate
   override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) { none() }
 
   override TranslatedElement getChild(int id) {
-    id = 0 and result = getBody()
+    id = 0 and result = this.getBody()
     or
-    id = 1 and result = getFinally()
+    id = 1 and result = this.getFinally()
   }
 
-  override Instruction getFirstInstruction() { result = getBody().getFirstInstruction() }
+  override Instruction getFirstInstruction() { result = this.getBody().getFirstInstruction() }
 
   override Instruction getChildSuccessor(TranslatedElement child) {
-    child = getBody() and result = getFinally().getFirstInstruction()
+    child = this.getBody() and result = this.getFinally().getFirstInstruction()
     or
-    child = getFinally() and result = getParent().getChildSuccessor(this)
+    child = this.getFinally() and result = this.getParent().getChildSuccessor(this)
   }
 
   override Instruction getExceptionSuccessorInstruction() {
-    result = getParent().getExceptionSuccessorInstruction()
+    result = this.getParent().getExceptionSuccessorInstruction()
   }
 
   /**
@@ -74,16 +74,16 @@ abstract class TranslatedCompilerGeneratedConstant extends TranslatedCompilerGen
   override predicate hasInstruction(Opcode opcode, InstructionTag tag, CSharpType resultType) {
     opcode instanceof Opcode::Constant and
     tag = OnlyInstructionTag() and
-    resultType = getTypeForPRValue(getResultType())
+    resultType = getTypeForPRValue(this.getResultType())
   }
 
   override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) {
     tag = OnlyInstructionTag() and
     kind instanceof GotoEdge and
-    result = getParent().getChildSuccessor(this)
+    result = this.getParent().getChildSuccessor(this)
   }
 
-  override Instruction getFirstInstruction() { result = getInstruction(OnlyInstructionTag()) }
+  override Instruction getFirstInstruction() { result = this.getInstruction(OnlyInstructionTag()) }
 
   override TranslatedElement getChild(int id) { none() }
 
@@ -96,20 +96,20 @@ abstract class TranslatedCompilerGeneratedConstant extends TranslatedCompilerGen
  * compose the block.
  */
 abstract class TranslatedCompilerGeneratedBlock extends TranslatedCompilerGeneratedStmt {
-  override TranslatedElement getChild(int id) { result = getStmt(id) }
+  override TranslatedElement getChild(int id) { result = this.getStmt(id) }
 
-  override Instruction getFirstInstruction() { result = getStmt(0).getFirstInstruction() }
+  override Instruction getFirstInstruction() { result = this.getStmt(0).getFirstInstruction() }
 
   abstract TranslatedElement getStmt(int index);
 
-  private int getStmtCount() { result = count(getStmt(_)) }
+  private int getStmtCount() { result = count(this.getStmt(_)) }
 
   override Instruction getChildSuccessor(TranslatedElement child) {
     exists(int index |
-      child = getStmt(index) and
-      if index = (getStmtCount() - 1)
-      then result = getParent().getChildSuccessor(this)
-      else result = getStmt(index + 1).getFirstInstruction()
+      child = this.getStmt(index) and
+      if index = (this.getStmtCount() - 1)
+      then result = this.getParent().getChildSuccessor(this)
+      else result = this.getStmt(index + 1).getFirstInstruction()
     )
   }
 
@@ -128,14 +128,14 @@ abstract class TranslatedCompilerGeneratedBlock extends TranslatedCompilerGenera
 abstract class TranslatedCompilerGeneratedIfStmt extends TranslatedCompilerGeneratedStmt,
   ConditionContext
 {
-  override Instruction getFirstInstruction() { result = getCondition().getFirstInstruction() }
+  override Instruction getFirstInstruction() { result = this.getCondition().getFirstInstruction() }
 
   override TranslatedElement getChild(int id) {
-    id = 0 and result = getCondition()
+    id = 0 and result = this.getCondition()
     or
-    id = 1 and result = getThen()
+    id = 1 and result = this.getThen()
     or
-    id = 2 and result = getElse()
+    id = 2 and result = this.getElse()
   }
 
   abstract TranslatedCompilerGeneratedValueCondition getCondition();
@@ -144,25 +144,25 @@ abstract class TranslatedCompilerGeneratedIfStmt extends TranslatedCompilerGener
 
   abstract TranslatedCompilerGeneratedElement getElse();
 
-  private predicate hasElse() { exists(getElse()) }
+  private predicate hasElse() { exists(this.getElse()) }
 
   override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) { none() }
 
   override Instruction getChildTrueSuccessor(ConditionBase child) {
-    child = getCondition() and
-    result = getThen().getFirstInstruction()
+    child = this.getCondition() and
+    result = this.getThen().getFirstInstruction()
   }
 
   override Instruction getChildFalseSuccessor(ConditionBase child) {
-    child = getCondition() and
-    if hasElse()
-    then result = getElse().getFirstInstruction()
-    else result = getParent().getChildSuccessor(this)
+    child = this.getCondition() and
+    if this.hasElse()
+    then result = this.getElse().getFirstInstruction()
+    else result = this.getParent().getChildSuccessor(this)
   }
 
   override Instruction getChildSuccessor(TranslatedElement child) {
-    (child = getThen() or child = getElse()) and
-    result = getParent().getChildSuccessor(this)
+    (child = this.getThen() or child = this.getElse()) and
+    result = this.getParent().getChildSuccessor(this)
   }
 
   override predicate hasInstruction(Opcode opcode, InstructionTag tag, CSharpType resultType) {
@@ -177,7 +177,7 @@ abstract class TranslatedCompilerGeneratedIfStmt extends TranslatedCompilerGener
  * access needs a `Load` instruction or not (eg. `ref` params do not)
  */
 abstract class TranslatedCompilerGeneratedVariableAccess extends TranslatedCompilerGeneratedExpr {
-  override Instruction getFirstInstruction() { result = getInstruction(AddressTag()) }
+  override Instruction getFirstInstruction() { result = this.getInstruction(AddressTag()) }
 
   override TranslatedElement getChild(int id) { none() }
 
@@ -187,45 +187,45 @@ abstract class TranslatedCompilerGeneratedVariableAccess extends TranslatedCompi
    * Returns the type of the accessed variable. Can be overridden when the return
    * type is different than the type of the underlying variable.
    */
-  Type getVariableType() { result = getResultType() }
+  Type getVariableType() { result = this.getResultType() }
 
   override predicate hasInstruction(Opcode opcode, InstructionTag tag, CSharpType resultType) {
     tag = AddressTag() and
     opcode instanceof Opcode::VariableAddress and
-    resultType = getTypeForGLValue(getVariableType())
+    resultType = getTypeForGLValue(this.getVariableType())
     or
-    needsLoad() and
+    this.needsLoad() and
     tag = LoadTag() and
     opcode instanceof Opcode::Load and
-    resultType = getTypeForPRValue(getVariableType())
+    resultType = getTypeForPRValue(this.getVariableType())
   }
 
   override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) {
-    needsLoad() and
+    this.needsLoad() and
     tag = LoadTag() and
-    result = getParent().getChildSuccessor(this) and
+    result = this.getParent().getChildSuccessor(this) and
     kind instanceof GotoEdge
     or
     (
       tag = AddressTag() and
       kind instanceof GotoEdge and
-      if needsLoad()
-      then result = getInstruction(LoadTag())
-      else result = getParent().getChildSuccessor(this)
+      if this.needsLoad()
+      then result = this.getInstruction(LoadTag())
+      else result = this.getParent().getChildSuccessor(this)
     )
   }
 
   override Instruction getResult() {
-    if needsLoad()
-    then result = getInstruction(LoadTag())
-    else result = getInstruction(AddressTag())
+    if this.needsLoad()
+    then result = this.getInstruction(LoadTag())
+    else result = this.getInstruction(AddressTag())
   }
 
   override Instruction getInstructionOperand(InstructionTag tag, OperandTag operandTag) {
-    needsLoad() and
+    this.needsLoad() and
     tag = LoadTag() and
     operandTag instanceof AddressOperandTag and
-    result = getInstruction(AddressTag())
+    result = this.getInstruction(AddressTag())
   }
 
   /**

--- a/csharp/ql/src/experimental/ir/implementation/raw/internal/desugar/Delegate.qll
+++ b/csharp/ql/src/experimental/ir/implementation/raw/internal/desugar/Delegate.qll
@@ -61,7 +61,7 @@ private class TranslatedDelegateConstructorCall extends TranslatedCompilerGenera
 
   override Instruction getQualifierResult() {
     exists(ConstructorCallContext context |
-      context = getParent() and
+      context = this.getParent() and
       result = context.getReceiver()
     )
   }
@@ -101,7 +101,7 @@ private class TranslatedDelegateInvokeCall extends TranslatedCompilerGeneratedCa
 
   override TranslatedExprBase getQualifier() { result = getTranslatedExpr(generatedBy.getExpr()) }
 
-  override Instruction getQualifierResult() { result = getQualifier().getResult() }
+  override Instruction getQualifierResult() { result = this.getQualifier().getResult() }
 
   override TranslatedExpr getArgument(int index) {
     result = getTranslatedExpr(generatedBy.getArgument(index))

--- a/csharp/ql/src/experimental/ir/implementation/raw/internal/desugar/Foreach.qll
+++ b/csharp/ql/src/experimental/ir/implementation/raw/internal/desugar/Foreach.qll
@@ -122,28 +122,28 @@ class TranslatedForeachWhile extends TranslatedCompilerGeneratedStmt, ConditionC
 
   override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) { none() }
 
-  override Instruction getFirstInstruction() { result = getCondition().getFirstInstruction() }
+  override Instruction getFirstInstruction() { result = this.getCondition().getFirstInstruction() }
 
   override Instruction getChildSuccessor(TranslatedElement child) {
-    child = getInit() and result = getBody().getFirstInstruction()
+    child = this.getInit() and result = this.getBody().getFirstInstruction()
     or
-    child = getBody() and result = getCondition().getFirstInstruction()
+    child = this.getBody() and result = this.getCondition().getFirstInstruction()
   }
 
   override TranslatedElement getChild(int id) {
-    id = 0 and result = getCondition()
+    id = 0 and result = this.getCondition()
     or
-    id = 1 and result = getInit()
+    id = 1 and result = this.getInit()
     or
-    id = 2 and result = getBody()
+    id = 2 and result = this.getBody()
   }
 
   final override Instruction getChildTrueSuccessor(ConditionBase child) {
-    child = getCondition() and result = getInit().getFirstInstruction()
+    child = this.getCondition() and result = this.getInit().getFirstInstruction()
   }
 
   final override Instruction getChildFalseSuccessor(ConditionBase child) {
-    child = getCondition() and result = getParent().getChildSuccessor(this)
+    child = this.getCondition() and result = this.getParent().getChildSuccessor(this)
   }
 
   TranslatedStmt getBody() { result = getTranslatedStmt(generatedBy.getBody()) }
@@ -189,7 +189,7 @@ private class TranslatedForeachMoveNext extends TranslatedCompilerGeneratedCall,
     )
   }
 
-  override Instruction getQualifierResult() { result = getQualifier().getResult() }
+  override Instruction getQualifierResult() { result = this.getQualifier().getResult() }
 }
 
 /**
@@ -203,7 +203,7 @@ private class TranslatedForeachGetEnumerator extends TranslatedCompilerGenerated
   TranslatedForeachGetEnumerator() { this = TTranslatedCompilerGeneratedElement(generatedBy, 4) }
 
   final override Type getCallResultType() {
-    result = getInstructionFunction(CallTargetTag()).getReturnType()
+    result = this.getInstructionFunction(CallTargetTag()).getReturnType()
   }
 
   override Callable getInstructionFunction(InstructionTag tag) {
@@ -217,7 +217,7 @@ private class TranslatedForeachGetEnumerator extends TranslatedCompilerGenerated
     result = getTranslatedExpr(generatedBy.getIterableExpr())
   }
 
-  override Instruction getQualifierResult() { result = getQualifier().getResult() }
+  override Instruction getQualifierResult() { result = this.getQualifier().getResult() }
 }
 
 /**
@@ -241,7 +241,7 @@ private class TranslatedForeachCurrent extends TranslatedCompilerGeneratedCall,
     )
   }
 
-  override Instruction getQualifierResult() { result = getQualifier().getResult() }
+  override Instruction getQualifierResult() { result = this.getQualifier().getResult() }
 
   override Callable getInstructionFunction(InstructionTag tag) {
     tag = CallTargetTag() and
@@ -275,7 +275,7 @@ private class TranslatedForeachDispose extends TranslatedCompilerGeneratedCall,
     )
   }
 
-  override Instruction getQualifierResult() { result = getQualifier().getResult() }
+  override Instruction getQualifierResult() { result = this.getQualifier().getResult() }
 }
 
 /**
@@ -295,7 +295,7 @@ private class TranslatedForeachWhileCondition extends TranslatedCompilerGenerate
     )
   }
 
-  override Instruction valueExprResult() { result = getValueExpr().getResult() }
+  override Instruction valueExprResult() { result = this.getValueExpr().getResult() }
 }
 
 /**
@@ -311,7 +311,7 @@ private class TranslatedForeachEnumerator extends TranslatedCompilerGeneratedDec
 
   override predicate hasTempVariable(TempVariableTag tag, CSharpType type) {
     tag = ForeachEnumTempVar() and
-    type = getTypeForPRValue(getInitialization().getCallResultType())
+    type = getTypeForPRValue(this.getInitialization().getCallResultType())
   }
 
   override IRTempVariable getIRVariable() {
@@ -325,7 +325,7 @@ private class TranslatedForeachEnumerator extends TranslatedCompilerGeneratedDec
     )
   }
 
-  override Instruction getInitializationResult() { result = getInitialization().getResult() }
+  override Instruction getInitializationResult() { result = this.getInitialization().getResult() }
 }
 
 /**
@@ -340,11 +340,11 @@ private class TranslatedForeachIterVar extends TranslatedCompilerGeneratedDeclar
 
   override IRVariable getInstructionVariable(InstructionTag tag) {
     tag = InitializerVariableAddressTag() and
-    result = getIRVariable()
+    result = this.getIRVariable()
   }
 
   override IRVariable getIRVariable() {
-    result = getIRUserVariable(getFunction(), generatedBy.getAVariable())
+    result = getIRUserVariable(this.getFunction(), generatedBy.getAVariable())
   }
 
   override TranslatedCompilerGeneratedCall getInitialization() {
@@ -354,7 +354,7 @@ private class TranslatedForeachIterVar extends TranslatedCompilerGeneratedDeclar
     )
   }
 
-  override Instruction getInitializationResult() { result = getInitialization().getResult() }
+  override Instruction getInitializationResult() { result = this.getInitialization().getResult() }
 }
 
 /**
@@ -379,12 +379,12 @@ private class TranslatedMoveNextEnumAcc extends TTranslatedCompilerGeneratedElem
 
   override predicate hasTempVariable(TempVariableTag tag, CSharpType type) {
     tag = ForeachEnumTempVar() and
-    type = getTypeForPRValue(getVariableType())
+    type = getTypeForPRValue(this.getVariableType())
   }
 
   override IRVariable getInstructionVariable(InstructionTag tag) {
     tag = AddressTag() and
-    result = getTempVariable(ForeachEnumTempVar())
+    result = this.getTempVariable(ForeachEnumTempVar())
   }
 
   override predicate needsLoad() { any() }
@@ -412,12 +412,12 @@ private class TranslatedForeachCurrentEnumAcc extends TTranslatedCompilerGenerat
 
   override predicate hasTempVariable(TempVariableTag tag, CSharpType type) {
     tag = ForeachEnumTempVar() and
-    type = getTypeForPRValue(getVariableType())
+    type = getTypeForPRValue(this.getVariableType())
   }
 
   override IRVariable getInstructionVariable(InstructionTag tag) {
     tag = AddressTag() and
-    result = getTempVariable(ForeachEnumTempVar())
+    result = this.getTempVariable(ForeachEnumTempVar())
   }
 
   override predicate needsLoad() { any() }
@@ -445,12 +445,12 @@ private class TranslatedForeachDisposeEnumAcc extends TTranslatedCompilerGenerat
 
   override predicate hasTempVariable(TempVariableTag tag, CSharpType type) {
     tag = ForeachEnumTempVar() and
-    type = getTypeForPRValue(getVariableType())
+    type = getTypeForPRValue(this.getVariableType())
   }
 
   override IRVariable getInstructionVariable(InstructionTag tag) {
     tag = AddressTag() and
-    result = getTempVariable(ForeachEnumTempVar())
+    result = this.getTempVariable(ForeachEnumTempVar())
   }
 
   override predicate needsLoad() { any() }

--- a/csharp/ql/src/experimental/ir/implementation/raw/internal/desugar/Lock.qll
+++ b/csharp/ql/src/experimental/ir/implementation/raw/internal/desugar/Lock.qll
@@ -208,7 +208,7 @@ private class TranslatedIfCondition extends TranslatedCompilerGeneratedValueCond
     )
   }
 
-  override Instruction valueExprResult() { result = getValueExpr().getResult() }
+  override Instruction valueExprResult() { result = this.getValueExpr().getResult() }
 }
 
 /**
@@ -254,7 +254,7 @@ private class TranslatedWasTakenConst extends TranslatedCompilerGeneratedConstan
     result = "false"
   }
 
-  override Instruction getResult() { result = getInstruction(OnlyInstructionTag()) }
+  override Instruction getResult() { result = this.getInstruction(OnlyInstructionTag()) }
 
   override Type getResultType() { result instanceof BoolType }
 }
@@ -285,9 +285,9 @@ private class TranslatedLockWasTakenDecl extends TranslatedCompilerGeneratedDecl
     )
   }
 
-  override Type getVarType() { result = getInitialization().getResultType() }
+  override Type getVarType() { result = this.getInitialization().getResultType() }
 
-  override Instruction getInitializationResult() { result = getInitialization().getResult() }
+  override Instruction getInitializationResult() { result = this.getInitialization().getResult() }
 }
 
 /**
@@ -316,7 +316,7 @@ private class TranslatedLockedVarDecl extends TranslatedCompilerGeneratedDeclara
 
   override Type getVarType() { result = generatedBy.getExpr().getType() }
 
-  override Instruction getInitializationResult() { result = getInitialization().getResult() }
+  override Instruction getInitializationResult() { result = this.getInitialization().getResult() }
 }
 
 /**
@@ -335,12 +335,12 @@ private class TranslatedMonitorEnterVarAcc extends TTranslatedCompilerGeneratedE
 
   override predicate hasTempVariable(TempVariableTag tag, CSharpType type) {
     tag = LockedVarTemp() and
-    type = getTypeForPRValue(getResultType())
+    type = getTypeForPRValue(this.getResultType())
   }
 
   override IRVariable getInstructionVariable(InstructionTag tag) {
     tag = AddressTag() and
-    result = getTempVariable(LockedVarTemp())
+    result = this.getTempVariable(LockedVarTemp())
   }
 
   override predicate needsLoad() { any() }
@@ -362,12 +362,12 @@ private class TranslatedMonitorExitVarAcc extends TTranslatedCompilerGeneratedEl
 
   override IRVariable getInstructionVariable(InstructionTag tag) {
     tag = AddressTag() and
-    result = getTempVariable(LockedVarTemp())
+    result = this.getTempVariable(LockedVarTemp())
   }
 
   override predicate hasTempVariable(TempVariableTag tag, CSharpType type) {
     tag = LockedVarTemp() and
-    type = getTypeForPRValue(getResultType())
+    type = getTypeForPRValue(this.getResultType())
   }
 
   override predicate needsLoad() { any() }
@@ -388,12 +388,12 @@ private class TranslatedLockWasTakenCondVarAcc extends TTranslatedCompilerGenera
 
   override predicate hasTempVariable(TempVariableTag tag, CSharpType type) {
     tag = LockWasTakenTemp() and
-    type = getTypeForPRValue(getResultType())
+    type = getTypeForPRValue(this.getResultType())
   }
 
   override IRVariable getInstructionVariable(InstructionTag tag) {
     tag = AddressTag() and
-    result = getTempVariable(LockWasTakenTemp())
+    result = this.getTempVariable(LockWasTakenTemp())
   }
 
   override predicate needsLoad() { any() }
@@ -414,12 +414,12 @@ private class TranslatedLockWasTakenRefArg extends TTranslatedCompilerGeneratedE
 
   override predicate hasTempVariable(TempVariableTag tag, CSharpType type) {
     tag = LockWasTakenTemp() and
-    type = getTypeForPRValue(getResultType())
+    type = getTypeForPRValue(this.getResultType())
   }
 
   override IRVariable getInstructionVariable(InstructionTag tag) {
     tag = AddressTag() and
-    result = getTempVariable(LockWasTakenTemp())
+    result = this.getTempVariable(LockWasTakenTemp())
   }
 
   override predicate needsLoad() { none() }

--- a/csharp/ql/src/experimental/ir/implementation/raw/internal/desugar/internal/TranslatedCompilerGeneratedDeclaration.qll
+++ b/csharp/ql/src/experimental/ir/implementation/raw/internal/desugar/internal/TranslatedCompilerGeneratedDeclaration.qll
@@ -23,7 +23,7 @@ abstract class TranslatedCompilerGeneratedDeclaration extends LocalVariableDecla
   }
 
   override Instruction getChildSuccessor(TranslatedElement child) {
-    child = getInitialization() and result = getInstruction(InitializerStoreTag())
+    child = this.getInitialization() and result = this.getInstruction(InitializerStoreTag())
   }
 
   override predicate hasInstruction(Opcode opcode, InstructionTag tag, CSharpType resultType) {
@@ -34,14 +34,14 @@ abstract class TranslatedCompilerGeneratedDeclaration extends LocalVariableDecla
     // do not have the `Uninitialized` instruction
     tag = InitializerStoreTag() and
     opcode instanceof Opcode::Store and
-    resultType = getTypeForPRValue(getVarType())
+    resultType = getTypeForPRValue(this.getVarType())
   }
 
   override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) {
     result = LocalVariableDeclarationBase.super.getInstructionSuccessor(tag, kind)
     or
     tag = InitializerStoreTag() and
-    result = getParent().getChildSuccessor(this) and
+    result = this.getParent().getChildSuccessor(this) and
     kind instanceof GotoEdge
   }
 
@@ -51,23 +51,23 @@ abstract class TranslatedCompilerGeneratedDeclaration extends LocalVariableDecla
     tag = InitializerStoreTag() and
     (
       operandTag instanceof AddressOperandTag and
-      result = getInstruction(InitializerVariableAddressTag())
+      result = this.getInstruction(InitializerVariableAddressTag())
       or
       operandTag instanceof StoreValueOperandTag and
-      result = getInitializationResult()
+      result = this.getInitializationResult()
     )
   }
 
   override IRVariable getInstructionVariable(InstructionTag tag) {
     tag = InitializerVariableAddressTag() and
-    result = getIRVariable()
+    result = this.getIRVariable()
   }
 
   // A compiler generated declaration does not have an associated `LocalVariable`
   // element
   override LocalVariable getDeclVar() { none() }
 
-  override Type getVarType() { result = getIRVariable().getType() }
+  override Type getVarType() { result = this.getIRVariable().getType() }
 
   /**
    * Gets the IR variable that corresponds to the declaration.

--- a/csharp/ql/src/experimental/ir/implementation/raw/internal/desugar/internal/TranslatedCompilerGeneratedElement.qll
+++ b/csharp/ql/src/experimental/ir/implementation/raw/internal/desugar/internal/TranslatedCompilerGeneratedElement.qll
@@ -22,5 +22,5 @@ abstract class TranslatedCompilerGeneratedElement extends TranslatedElement,
   final override Language::AST getAst() { result = generatedBy }
 
   /** DEPRECATED: Alias for getAst */
-  deprecated override Language::AST getAST() { result = getAst() }
+  deprecated override Language::AST getAST() { result = this.getAst() }
 }

--- a/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/IRFunction.qll
+++ b/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/IRFunction.qll
@@ -45,7 +45,9 @@ class IRFunction extends IRFunctionBase {
    * Gets the block containing the entry point of this function.
    */
   pragma[noinline]
-  final IRBlock getEntryBlock() { result.getFirstInstruction() = getEnterFunctionInstruction() }
+  final IRBlock getEntryBlock() {
+    result.getFirstInstruction() = this.getEnterFunctionInstruction()
+  }
 
   /**
    * Gets all instructions in this function.

--- a/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/IRVariable.qll
+++ b/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/IRVariable.qll
@@ -39,12 +39,12 @@ class IRVariable extends TIRVariable {
   /**
    * Gets the type of the variable.
    */
-  final Language::Type getType() { getLanguageType().hasType(result, false) }
+  final Language::Type getType() { this.getLanguageType().hasType(result, false) }
 
   /**
    * Gets the language-neutral type of the variable.
    */
-  final IRType getIRType() { result = getLanguageType().getIRType() }
+  final IRType getIRType() { result = this.getLanguageType().getIRType() }
 
   /**
    * Gets the type of the variable.
@@ -58,7 +58,7 @@ class IRVariable extends TIRVariable {
   Language::AST getAst() { none() }
 
   /** DEPRECATED: Alias for getAst */
-  deprecated Language::AST getAST() { result = getAst() }
+  deprecated Language::AST getAST() { result = this.getAst() }
 
   /**
    * Gets an identifier string for the variable. This identifier is unique
@@ -69,7 +69,7 @@ class IRVariable extends TIRVariable {
   /**
    * Gets the source location of this variable.
    */
-  final Language::Location getLocation() { result = getAst().getLocation() }
+  final Language::Location getLocation() { result = this.getAst().getLocation() }
 
   /**
    * Gets the IR for the function that references this variable.
@@ -91,15 +91,15 @@ class IRUserVariable extends IRVariable, TIRUserVariable {
 
   IRUserVariable() { this = TIRUserVariable(var, type, func) }
 
-  final override string toString() { result = getVariable().toString() }
+  final override string toString() { result = this.getVariable().toString() }
 
   final override Language::AST getAst() { result = var }
 
   /** DEPRECATED: Alias for getAst */
-  deprecated override Language::AST getAST() { result = getAst() }
+  deprecated override Language::AST getAST() { result = this.getAst() }
 
   final override string getUniqueId() {
-    result = getVariable().toString() + " " + getVariable().getLocation().toString()
+    result = this.getVariable().toString() + " " + this.getVariable().getLocation().toString()
   }
 
   final override Language::LanguageType getLanguageType() { result = type }
@@ -166,9 +166,9 @@ class IRGeneratedVariable extends IRVariable {
   final override Language::AST getAst() { result = ast }
 
   /** DEPRECATED: Alias for getAst */
-  deprecated override Language::AST getAST() { result = getAst() }
+  deprecated override Language::AST getAST() { result = this.getAst() }
 
-  override string toString() { result = getBaseString() + getLocationString() }
+  override string toString() { result = this.getBaseString() + this.getLocationString() }
 
   override string getUniqueId() { none() }
 
@@ -272,7 +272,7 @@ class IRStringLiteral extends IRGeneratedVariable, TIRStringLiteral {
   final override predicate isReadOnly() { any() }
 
   final override string getUniqueId() {
-    result = "String: " + getLocationString() + "=" + Language::getStringLiteralText(literal)
+    result = "String: " + this.getLocationString() + "=" + Language::getStringLiteralText(literal)
   }
 
   final override string getBaseString() { result = "#string" }
@@ -303,7 +303,8 @@ class IRDynamicInitializationFlag extends IRGeneratedVariable, TIRDynamicInitial
   final Language::Variable getVariable() { result = var }
 
   final override string getUniqueId() {
-    result = "Init: " + getVariable().toString() + " " + getVariable().getLocation().toString()
+    result =
+      "Init: " + this.getVariable().toString() + " " + this.getVariable().getLocation().toString()
   }
 
   final override string getBaseString() { result = "#init:" + var.toString() + ":" }
@@ -332,5 +333,5 @@ class IRParameter extends IRAutomaticVariable {
  * An IR variable representing a positional parameter.
  */
 class IRPositionalParameter extends IRParameter, IRAutomaticUserVariable {
-  final override int getIndex() { result = getVariable().(Language::Parameter).getIndex() }
+  final override int getIndex() { result = this.getVariable().(Language::Parameter).getIndex() }
 }

--- a/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/PrintIR.qll
+++ b/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/PrintIR.qll
@@ -127,13 +127,13 @@ abstract private class PrintableIRNode extends TPrintableIRNode {
    * Gets the value of the node property with the specified key.
    */
   string getProperty(string key) {
-    key = "semmle.label" and result = getLabel()
+    key = "semmle.label" and result = this.getLabel()
     or
-    key = "semmle.order" and result = getOrder().toString()
+    key = "semmle.order" and result = this.getOrder().toString()
     or
-    key = "semmle.graphKind" and result = getGraphKind()
+    key = "semmle.graphKind" and result = this.getGraphKind()
     or
-    key = "semmle.forceText" and forceText() and result = "true"
+    key = "semmle.forceText" and this.forceText() and result = "true"
   }
 }
 
@@ -178,7 +178,7 @@ private class PrintableIRBlock extends PrintableIRNode, TPrintableIRBlock {
 
   PrintableIRBlock() { this = TPrintableIRBlock(block) }
 
-  override string toString() { result = getLabel() }
+  override string toString() { result = this.getLabel() }
 
   override Language::Location getLocation() { result = block.getLocation() }
 
@@ -223,7 +223,7 @@ private class PrintableInstruction extends PrintableIRNode, TPrintableInstructio
       |
         resultString = instr.getResultString() and
         operationString = instr.getOperationString() and
-        operandsString = getOperandsString() and
+        operandsString = this.getOperandsString() and
         columnWidths(block, resultWidth, operationWidth) and
         result =
           resultString + getPaddingString(resultWidth - resultString.length()) + " = " +

--- a/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/gvn/ValueNumbering.qll
+++ b/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/gvn/ValueNumbering.qll
@@ -7,17 +7,19 @@ private import internal.ValueNumberingImports
 class ValueNumber extends TValueNumber {
   final string toString() { result = "GVN" }
 
-  final string getDebugString() { result = strictconcat(getAnInstruction().getResultId(), ", ") }
+  final string getDebugString() {
+    result = strictconcat(this.getAnInstruction().getResultId(), ", ")
+  }
 
   final Language::Location getLocation() {
     if
       exists(Instruction i |
-        i = getAnInstruction() and not i.getLocation() instanceof Language::UnknownLocation
+        i = this.getAnInstruction() and not i.getLocation() instanceof Language::UnknownLocation
       )
     then
       result =
         min(Language::Location l |
-          l = getAnInstruction().getLocation() and not l instanceof Language::UnknownLocation
+          l = this.getAnInstruction().getLocation() and not l instanceof Language::UnknownLocation
         |
           l
           order by
@@ -40,7 +42,7 @@ class ValueNumber extends TValueNumber {
   final Instruction getExampleInstruction() {
     result =
       min(Instruction instr |
-        instr = getAnInstruction()
+        instr = this.getAnInstruction()
       |
         instr order by instr.getBlock().getDisplayIndex(), instr.getDisplayIndexInBlock()
       )

--- a/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/internal/AliasConfiguration.qll
+++ b/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/internal/AliasConfiguration.qll
@@ -7,7 +7,7 @@ private import AliasConfigurationImports
 class Allocation extends IRAutomaticVariable {
   VariableAddressInstruction getABaseInstruction() { result.getIRVariable() = this }
 
-  final string getAllocationString() { result = toString() }
+  final string getAllocationString() { result = this.toString() }
 
   predicate alwaysEscapes() {
     // An automatic variable only escapes if its address is taken and escapes.

--- a/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/internal/SimpleSSA.qll
+++ b/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/internal/SimpleSSA.qll
@@ -75,7 +75,7 @@ class MemoryLocation extends TMemoryLocation {
   final predicate canReuseSsa() { canReuseSsaForVariable(var) }
 
   /** DEPRECATED: Alias for canReuseSsa */
-  deprecated predicate canReuseSSA() { canReuseSsa() }
+  deprecated predicate canReuseSSA() { this.canReuseSsa() }
 }
 
 predicate canReuseSsaForOldResult(Instruction instr) { none() }


### PR DESCRIPTION
Make implicit this call receivers explicit to align with internal style guidelines.