### PR TITLE
RB: use the new ConfigSig

### DIFF
--- a/ruby/ql/lib/codeql/ruby/experimental/ZipSlipQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/experimental/ZipSlipQuery.qll
@@ -13,12 +13,12 @@ private import codeql.ruby.ApiGraphs
  * A taint-tracking configuration for reasoning about zip slip
  * vulnerabilities.
  */
-class Configuration extends TaintTracking::Configuration {
-  Configuration() { this = "ZipSlip" }
+module ConfigurationInst = TaintTracking::Global<ConfigurationImpl>;
 
-  override predicate isSource(DataFlow::Node source) { source instanceof ZipSlip::Source }
+private module ConfigurationImpl implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { source instanceof ZipSlip::Source }
 
-  override predicate isSink(DataFlow::Node sink) { sink instanceof ZipSlip::Sink }
+  predicate isSink(DataFlow::Node sink) { sink instanceof ZipSlip::Sink }
 
   /**
    * This should actually be
@@ -26,7 +26,7 @@ class Configuration extends TaintTracking::Configuration {
    * but I couldn't make it work so there's only check for the method name called on the entry. It is `full_name` for `Gem::Package::TarReader::Entry` and `Zlib`
    * and `name` for `Zip::File`
    */
-  override predicate isAdditionalTaintStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
+  predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
     exists(DataFlow::CallNode cn |
       cn.getReceiver() = nodeFrom and
       cn.getMethodName() in ["full_name", "name"] and
@@ -34,5 +34,5 @@ class Configuration extends TaintTracking::Configuration {
     )
   }
 
-  override predicate isSanitizer(DataFlow::Node node) { node instanceof ZipSlip::Sanitizer }
+  predicate isBarrier(DataFlow::Node node) { node instanceof ZipSlip::Sanitizer }
 }

--- a/ruby/ql/lib/codeql/ruby/security/CleartextLoggingQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/CleartextLoggingQuery.qll
@@ -15,20 +15,16 @@ private import CleartextLoggingCustomizations::CleartextLogging as CleartextLogg
 /**
  * A taint-tracking configuration for detecting "Clear-text logging of sensitive information".
  */
-class Configuration extends TaintTracking::Configuration {
-  Configuration() { this = "CleartextLogging" }
+module ConfigurationInst = TaintTracking::Global<ConfigurationImpl>;
 
-  override predicate isSource(DataFlow::Node source) { source instanceof CleartextLogging::Source }
+private module ConfigurationImpl implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { source instanceof CleartextLogging::Source }
 
-  override predicate isSink(DataFlow::Node sink) { sink instanceof CleartextLogging::Sink }
+  predicate isSink(DataFlow::Node sink) { sink instanceof CleartextLogging::Sink }
 
-  override predicate isSanitizer(DataFlow::Node node) {
-    super.isSanitizer(node)
-    or
-    node instanceof CleartextLogging::Sanitizer
-  }
+  predicate isBarrier(DataFlow::Node node) { node instanceof CleartextLogging::Sanitizer }
 
-  override predicate isAdditionalTaintStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
+  predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
     CleartextLogging::isAdditionalTaintStep(nodeFrom, nodeTo)
   }
 }

--- a/ruby/ql/lib/codeql/ruby/security/CleartextStorageQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/CleartextStorageQuery.qll
@@ -14,20 +14,16 @@ private import CleartextStorageCustomizations::CleartextStorage as CleartextStor
 /**
  * A taint-tracking configuration for detecting "Clear-text storage of sensitive information".
  */
-class Configuration extends TaintTracking::Configuration {
-  Configuration() { this = "CleartextStorage" }
+module ConfigurationInst = TaintTracking::Global<ConfigurationImpl>;
 
-  override predicate isSource(DataFlow::Node source) { source instanceof CleartextStorage::Source }
+private module ConfigurationImpl implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { source instanceof CleartextStorage::Source }
 
-  override predicate isSink(DataFlow::Node sink) { sink instanceof CleartextStorage::Sink }
+  predicate isSink(DataFlow::Node sink) { sink instanceof CleartextStorage::Sink }
 
-  override predicate isSanitizer(DataFlow::Node node) {
-    super.isSanitizer(node)
-    or
-    node instanceof CleartextStorage::Sanitizer
-  }
+  predicate isBarrier(DataFlow::Node node) { node instanceof CleartextStorage::Sanitizer }
 
-  override predicate isAdditionalTaintStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
+  predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
     CleartextStorage::isAdditionalTaintStep(nodeFrom, nodeTo)
   }
 }

--- a/ruby/ql/lib/codeql/ruby/security/CommandInjectionQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/CommandInjectionQuery.qll
@@ -16,14 +16,14 @@ import codeql.ruby.dataflow.BarrierGuards
 /**
  * A taint-tracking configuration for reasoning about command-injection vulnerabilities.
  */
-class Configuration extends TaintTracking::Configuration {
-  Configuration() { this = "CommandInjection" }
+module ConfigurationInst = TaintTracking::Global<ConfigurationImpl>;
 
-  override predicate isSource(DataFlow::Node source) { source instanceof Source }
+private module ConfigurationImpl implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { source instanceof Source }
 
-  override predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
+  predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
 
-  override predicate isSanitizer(DataFlow::Node node) {
+  predicate isBarrier(DataFlow::Node node) {
     node instanceof Sanitizer or
     node instanceof StringConstCompareBarrier or
     node instanceof StringConstArrayInclusionCallBarrier

--- a/ruby/ql/lib/codeql/ruby/security/HttpToFileAccessQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/HttpToFileAccessQuery.qll
@@ -11,15 +11,12 @@ private import HttpToFileAccessCustomizations::HttpToFileAccess
 /**
  * A taint tracking configuration for writing user-controlled data to files.
  */
-class Configuration extends TaintTracking::Configuration {
-  Configuration() { this = "HttpToFileAccess" }
+module ConfigurationInst = TaintTracking::Global<ConfigurationImpl>;
 
-  override predicate isSource(DataFlow::Node source) { source instanceof Source }
+private module ConfigurationImpl implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { source instanceof Source }
 
-  override predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
+  predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
 
-  override predicate isSanitizer(DataFlow::Node node) {
-    super.isSanitizer(node) or
-    node instanceof Sanitizer
-  }
+  predicate isBarrier(DataFlow::Node node) { node instanceof Sanitizer }
 }

--- a/ruby/ql/lib/codeql/ruby/security/LogInjectionQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/LogInjectionQuery.qll
@@ -27,14 +27,14 @@ abstract class Sanitizer extends DataFlow::Node { }
 /**
  * A taint-tracking configuration for untrusted user input used in log entries.
  */
-class LogInjectionConfiguration extends TaintTracking::Configuration {
-  LogInjectionConfiguration() { this = "LogInjection" }
+module LogInjectionConfigurationInst = TaintTracking::Global<LogInjectionConfigurationImpl>;
 
-  override predicate isSource(DataFlow::Node source) { source instanceof Source }
+private module LogInjectionConfigurationImpl implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { source instanceof Source }
 
-  override predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
+  predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
 
-  override predicate isSanitizer(DataFlow::Node node) { node instanceof Sanitizer }
+  predicate isBarrier(DataFlow::Node node) { node instanceof Sanitizer }
 }
 
 /**

--- a/ruby/ql/lib/codeql/ruby/security/PathInjectionQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/PathInjectionQuery.qll
@@ -16,18 +16,18 @@ private import codeql.ruby.TaintTracking
  * A taint-tracking configuration for reasoning about path injection
  * vulnerabilities.
  */
-class Configuration extends TaintTracking::Configuration {
-  Configuration() { this = "PathInjection" }
+module ConfigurationInst = TaintTracking::Global<ConfigurationImpl>;
 
-  override predicate isSource(DataFlow::Node source) { source instanceof PathInjection::Source }
+private module ConfigurationImpl implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { source instanceof PathInjection::Source }
 
-  override predicate isSink(DataFlow::Node sink) { sink instanceof PathInjection::Sink }
+  predicate isSink(DataFlow::Node sink) { sink instanceof PathInjection::Sink }
 
-  override predicate isSanitizer(DataFlow::Node node) {
+  predicate isBarrier(DataFlow::Node node) {
     node instanceof Path::PathSanitization or node instanceof PathInjection::Sanitizer
   }
 
-  deprecated override predicate isSanitizerGuard(DataFlow::BarrierGuard guard) {
+  additional deprecated predicate isSanitizerGuard(DataFlow::BarrierGuard guard) {
     guard instanceof PathInjection::SanitizerGuard
   }
 }

--- a/ruby/ql/lib/codeql/ruby/security/ReflectedXSSQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/ReflectedXSSQuery.qll
@@ -19,20 +19,20 @@ module ReflectedXss {
   /**
    * A taint-tracking configuration for detecting "reflected server-side cross-site scripting" vulnerabilities.
    */
-  class Configuration extends TaintTracking::Configuration {
-    Configuration() { this = "ReflectedXSS" }
+  module ConfigurationInst = TaintTracking::Global<ConfigurationImpl>;
 
-    override predicate isSource(DataFlow::Node source) { source instanceof Source }
+  private module ConfigurationImpl implements DataFlow::ConfigSig {
+    predicate isSource(DataFlow::Node source) { source instanceof Source }
 
-    override predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
+    predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
 
-    override predicate isSanitizer(DataFlow::Node node) { node instanceof Sanitizer }
+    predicate isBarrier(DataFlow::Node node) { node instanceof Sanitizer }
 
-    deprecated override predicate isSanitizerGuard(DataFlow::BarrierGuard guard) {
+    additional deprecated predicate isSanitizerGuard(DataFlow::BarrierGuard guard) {
       guard instanceof SanitizerGuard
     }
 
-    override predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) {
+    predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
       isAdditionalXssTaintStep(node1, node2)
     }
   }

--- a/ruby/ql/lib/codeql/ruby/security/ServerSideRequestForgeryQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/ServerSideRequestForgeryQuery.qll
@@ -15,20 +15,20 @@ import codeql.ruby.dataflow.BarrierGuards
  * A taint-tracking configuration for detecting
  * "Server side request forgery" vulnerabilities.
  */
-class Configuration extends TaintTracking::Configuration {
-  Configuration() { this = "ServerSideRequestForgery" }
+module ConfigurationInst = TaintTracking::Global<ConfigurationImpl>;
 
-  override predicate isSource(DataFlow::Node source) { source instanceof Source }
+private module ConfigurationImpl implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { source instanceof Source }
 
-  override predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
+  predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
 
-  override predicate isSanitizer(DataFlow::Node node) {
+  predicate isBarrier(DataFlow::Node node) {
     node instanceof Sanitizer or
     node instanceof StringConstCompareBarrier or
     node instanceof StringConstArrayInclusionCallBarrier
   }
 
-  deprecated override predicate isSanitizerGuard(DataFlow::BarrierGuard guard) {
+  additional deprecated predicate isSanitizerGuard(DataFlow::BarrierGuard guard) {
     guard instanceof SanitizerGuard
   }
 }

--- a/ruby/ql/lib/codeql/ruby/security/SqlInjectionQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/SqlInjectionQuery.qll
@@ -10,12 +10,12 @@ import SqlInjectionCustomizations::SqlInjection
 /**
  * A taint-tracking configuration for detecting SQL injection vulnerabilities.
  */
-class Configuration extends TaintTracking::Configuration {
-  Configuration() { this = "SqlInjectionConfiguration" }
+module ConfigurationInst = TaintTracking::Global<ConfigurationImpl>;
 
-  override predicate isSource(DataFlow::Node source) { source instanceof Source }
+private module ConfigurationImpl implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { source instanceof Source }
 
-  override predicate isSink(DataFlow::Node source) { source instanceof Sink }
+  predicate isSink(DataFlow::Node source) { source instanceof Sink }
 
-  override predicate isSanitizer(DataFlow::Node node) { node instanceof Sanitizer }
+  predicate isBarrier(DataFlow::Node node) { node instanceof Sanitizer }
 }

--- a/ruby/ql/lib/codeql/ruby/security/StackTraceExposureQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/StackTraceExposureQuery.qll
@@ -14,12 +14,12 @@ private import StackTraceExposureCustomizations::StackTraceExposure
 /**
  * A taint-tracking configuration for detecting "stack trace exposure" vulnerabilities.
  */
-class Configuration extends TaintTracking::Configuration {
-  Configuration() { this = "StackTraceExposure" }
+module ConfigurationInst = TaintTracking::Global<ConfigurationImpl>;
 
-  override predicate isSource(DataFlow::Node source) { source instanceof Source }
+private module ConfigurationImpl implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { source instanceof Source }
 
-  override predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
+  predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
 
-  override predicate isSanitizer(DataFlow::Node node) { node instanceof Sanitizer }
+  predicate isBarrier(DataFlow::Node node) { node instanceof Sanitizer }
 }

--- a/ruby/ql/lib/codeql/ruby/security/TaintedFormatStringQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/TaintedFormatStringQuery.qll
@@ -13,14 +13,14 @@ private import TaintedFormatStringCustomizations::TaintedFormatString
 /**
  * A taint-tracking configuration for format injections.
  */
-class Configuration extends TaintTracking::Configuration {
-  Configuration() { this = "TaintedFormatString" }
+module ConfigurationInst = TaintTracking::Global<ConfigurationImpl>;
 
-  override predicate isSource(DataFlow::Node source) { source instanceof Source }
+private module ConfigurationImpl implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { source instanceof Source }
 
-  override predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
+  predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
 
-  override predicate isSanitizer(DataFlow::Node node) {
+  predicate isBarrier(DataFlow::Node node) {
     super.isSanitizer(node) or
     node instanceof Sanitizer
   }

--- a/ruby/ql/lib/codeql/ruby/security/TemplateInjectionQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/TemplateInjectionQuery.qll
@@ -10,12 +10,12 @@ import TemplateInjectionCustomizations::TemplateInjection
 /**
  * A taint-tracking configuration for detecting Server Side Template Injections vulnerabilities.
  */
-class Configuration extends TaintTracking::Configuration {
-  Configuration() { this = "TemplateInjection" }
+module ConfigurationInst = TaintTracking::Global<ConfigurationImpl>;
 
-  override predicate isSource(DataFlow::Node source) { source instanceof Source }
+private module ConfigurationImpl implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { source instanceof Source }
 
-  override predicate isSink(DataFlow::Node source) { source instanceof Sink }
+  predicate isSink(DataFlow::Node source) { source instanceof Sink }
 
-  override predicate isSanitizer(DataFlow::Node node) { node instanceof Sanitizer }
+  predicate isBarrier(DataFlow::Node node) { node instanceof Sanitizer }
 }

--- a/ruby/ql/lib/codeql/ruby/security/UnsafeCodeConstructionQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/UnsafeCodeConstructionQuery.qll
@@ -14,24 +14,22 @@ private import codeql.ruby.dataflow.BarrierGuards
 /**
  * A taint-tracking configuration for detecting code constructed from library input vulnerabilities.
  */
-class Configuration extends TaintTracking::Configuration {
-  Configuration() { this = "UnsafeShellCommandConstruction" }
+module ConfigurationInst = TaintTracking::Global<ConfigurationImpl>;
 
-  override predicate isSource(DataFlow::Node source) { source instanceof Source }
+private module ConfigurationImpl implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { source instanceof Source }
 
-  override predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
+  predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
 
-  override predicate isSanitizer(DataFlow::Node node) {
+  predicate isBarrier(DataFlow::Node node) {
     node instanceof StringConstCompareBarrier or
     node instanceof StringConstArrayInclusionCallBarrier
   }
 
   // override to require the path doesn't have unmatched return steps
-  override DataFlow::FlowFeature getAFeature() {
-    result instanceof DataFlow::FeatureHasSourceCallContext
-  }
+  DataFlow::FlowFeature getAFeature() { result instanceof DataFlow::FeatureHasSourceCallContext }
 
-  override predicate allowImplicitRead(DataFlow::Node node, DataFlow::ContentSet set) {
+  predicate allowImplicitRead(DataFlow::Node node, DataFlow::ContentSet set) {
     // allow implicit reads of array elements
     this.isSink(node) and
     set.isElementOfTypeOrUnknown("int")

--- a/ruby/ql/lib/codeql/ruby/security/UnsafeDeserializationQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/UnsafeDeserializationQuery.qll
@@ -14,17 +14,12 @@ import UnsafeDeserializationCustomizations
 /**
  * A taint-tracking configuration for reasoning about unsafe deserialization.
  */
-class Configuration extends TaintTracking::Configuration {
-  Configuration() { this = "UnsafeDeserialization" }
+module ConfigurationInst = TaintTracking::Global<ConfigurationImpl>;
 
-  override predicate isSource(DataFlow::Node source) {
-    source instanceof UnsafeDeserialization::Source
-  }
+private module ConfigurationImpl implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { source instanceof UnsafeDeserialization::Source }
 
-  override predicate isSink(DataFlow::Node sink) { sink instanceof UnsafeDeserialization::Sink }
+  predicate isSink(DataFlow::Node sink) { sink instanceof UnsafeDeserialization::Sink }
 
-  override predicate isSanitizer(DataFlow::Node node) {
-    super.isSanitizer(node) or
-    node instanceof UnsafeDeserialization::Sanitizer
-  }
+  predicate isBarrier(DataFlow::Node node) { node instanceof UnsafeDeserialization::Sanitizer }
 }

--- a/ruby/ql/lib/codeql/ruby/security/UnsafeShellCommandConstructionQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/UnsafeShellCommandConstructionQuery.qll
@@ -15,27 +15,25 @@ private import codeql.ruby.dataflow.BarrierGuards
 /**
  * A taint-tracking configuration for detecting shell command constructed from library input vulnerabilities.
  */
-class Configuration extends TaintTracking::Configuration {
-  Configuration() { this = "UnsafeShellCommandConstruction" }
+module ConfigurationInst = TaintTracking::Global<ConfigurationImpl>;
 
-  override predicate isSource(DataFlow::Node source) { source instanceof Source }
+private module ConfigurationImpl implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { source instanceof Source }
 
-  override predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
+  predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
 
-  override predicate isSanitizer(DataFlow::Node node) {
+  predicate isBarrier(DataFlow::Node node) {
     node instanceof CommandInjection::Sanitizer or // using all sanitizers from `rb/command-injection`
     node instanceof StringConstCompareBarrier or
     node instanceof StringConstArrayInclusionCallBarrier
   }
 
   // override to require the path doesn't have unmatched return steps
-  override DataFlow::FlowFeature getAFeature() {
-    result instanceof DataFlow::FeatureHasSourceCallContext
-  }
+  DataFlow::FlowFeature getAFeature() { result instanceof DataFlow::FeatureHasSourceCallContext }
 
-  override predicate allowImplicitRead(DataFlow::Node node, DataFlow::ContentSet set) {
+  predicate allowImplicitRead(DataFlow::Node node, DataFlow::ContentSet set) {
     // allow implicit reads of array elements
-    this.isSink(node) and
+    isSink(node) and
     set.isElementOfTypeOrUnknown("int")
   }
 }

--- a/ruby/ql/lib/codeql/ruby/security/UrlRedirectQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/UrlRedirectQuery.qll
@@ -14,20 +14,20 @@ import UrlRedirectCustomizations::UrlRedirect
 /**
  * A taint-tracking configuration for detecting "URL redirection" vulnerabilities.
  */
-class Configuration extends TaintTracking::Configuration {
-  Configuration() { this = "UrlRedirect" }
+module ConfigurationInst = TaintTracking::Global<ConfigurationImpl>;
 
-  override predicate isSource(DataFlow::Node source) { source instanceof Source }
+private module ConfigurationImpl implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { source instanceof Source }
 
-  override predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
+  predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
 
-  override predicate isSanitizer(DataFlow::Node node) { node instanceof Sanitizer }
+  predicate isBarrier(DataFlow::Node node) { node instanceof Sanitizer }
 
-  deprecated override predicate isSanitizerGuard(DataFlow::BarrierGuard guard) {
+  additional deprecated predicate isSanitizerGuard(DataFlow::BarrierGuard guard) {
     guard instanceof SanitizerGuard
   }
 
-  override predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) {
+  predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
     UrlRedirect::isAdditionalTaintStep(node1, node2)
   }
 }

--- a/ruby/ql/lib/codeql/ruby/security/regexp/MissingFullAnchorQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/regexp/MissingFullAnchorQuery.qll
@@ -15,12 +15,12 @@ import MissingFullAnchorCustomizations::MissingFullAnchor
  * A taint tracking configuration for reasoning about
  * missing full-anchored regular expressions.
  */
-class Configuration extends TaintTracking::Configuration {
-  Configuration() { this = "MissingFullAnchor" }
+module ConfigurationInst = TaintTracking::Global<ConfigurationImpl>;
 
-  override predicate isSource(DataFlow::Node source) { source instanceof Source }
+private module ConfigurationImpl implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { source instanceof Source }
 
-  override predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
+  predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
 
-  override predicate isSanitizer(DataFlow::Node node) { node instanceof Sanitizer }
+  predicate isBarrier(DataFlow::Node node) { node instanceof Sanitizer }
 }

--- a/ruby/ql/lib/codeql/ruby/security/regexp/PolynomialReDoSQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/regexp/PolynomialReDoSQuery.qll
@@ -21,16 +21,16 @@ module PolynomialReDoS {
    * A taint-tracking configuration for detecting polynomial regular expression
    * denial of service vulnerabilities.
    */
-  class Configuration extends TaintTracking::Configuration {
-    Configuration() { this = "PolynomialReDoS" }
+  module ConfigurationInst = TaintTracking::Global<ConfigurationImpl>;
 
-    override predicate isSource(DataFlow::Node source) { source instanceof Source }
+  private module ConfigurationImpl implements DataFlow::ConfigSig {
+    predicate isSource(DataFlow::Node source) { source instanceof Source }
 
-    override predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
+    predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
 
-    override predicate isSanitizer(DataFlow::Node node) { node instanceof Sanitizer }
+    predicate isBarrier(DataFlow::Node node) { node instanceof Sanitizer }
 
-    deprecated override predicate isSanitizerGuard(DataFlow::BarrierGuard node) {
+    additional deprecated predicate isSanitizerGuard(DataFlow::BarrierGuard node) {
       node instanceof SanitizerGuard
     }
   }

--- a/ruby/ql/lib/codeql/ruby/security/regexp/RegExpInjectionQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/regexp/RegExpInjectionQuery.qll
@@ -13,16 +13,16 @@ import codeql.ruby.dataflow.BarrierGuards
 /**
  * A taint-tracking configuration for detecting regexp injection vulnerabilities.
  */
-class Configuration extends TaintTracking::Configuration {
-  Configuration() { this = "RegExpInjection" }
+module ConfigurationInst = TaintTracking::Global<ConfigurationImpl>;
 
-  override predicate isSource(DataFlow::Node source) { source instanceof RegExpInjection::Source }
+private module ConfigurationImpl implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { source instanceof RegExpInjection::Source }
 
-  override predicate isSink(DataFlow::Node sink) { sink instanceof RegExpInjection::Sink }
+  predicate isSink(DataFlow::Node sink) { sink instanceof RegExpInjection::Sink }
 
-  deprecated override predicate isSanitizerGuard(DataFlow::BarrierGuard guard) {
+  additional deprecated predicate isSanitizerGuard(DataFlow::BarrierGuard guard) {
     guard instanceof RegExpInjection::SanitizerGuard
   }
 
-  override predicate isSanitizer(DataFlow::Node node) { node instanceof RegExpInjection::Sanitizer }
+  predicate isBarrier(DataFlow::Node node) { node instanceof RegExpInjection::Sanitizer }
 }

--- a/ruby/ql/src/experimental/cwe-022-zipslip/ZipSlip.ql
+++ b/ruby/ql/src/experimental/cwe-022-zipslip/ZipSlip.ql
@@ -14,9 +14,9 @@
 
 import ruby
 import codeql.ruby.experimental.ZipSlipQuery
-import DataFlow::PathGraph
+import ConfigurationInst::PathGraph
 
-from Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink
-where cfg.hasFlowPath(source, sink)
+from ConfigurationInst::PathNode source, ConfigurationInst::PathNode sink
+where ConfigurationInst::flowPath(source, sink)
 select sink.getNode(), source, sink, "This file extraction depends on a $@.", source.getNode(),
   "potentially untrusted source"

--- a/ruby/ql/src/experimental/decompression-api/DecompressionApi.ql
+++ b/ruby/ql/src/experimental/decompression-api/DecompressionApi.ql
@@ -16,7 +16,7 @@ import codeql.ruby.ApiGraphs
 import codeql.ruby.DataFlow
 import codeql.ruby.dataflow.RemoteFlowSources
 import codeql.ruby.TaintTracking
-import DataFlow::PathGraph
+import ConfigurationInst::PathGraph
 
 class DecompressionApiUse extends DataFlow::Node {
   private DataFlow::CallNode call;
@@ -34,18 +34,18 @@ class DecompressionApiUse extends DataFlow::Node {
   DataFlow::CallNode getCall() { result = call }
 }
 
-class Configuration extends TaintTracking::Configuration {
-  Configuration() { this = "DecompressionApiUse" }
+module ConfigurationInst = TaintTracking::Global<ConfigurationImpl>;
 
+private module ConfigurationImpl implements DataFlow::ConfigSig {
   // this predicate will be used to constrain our query to find instances where only remote user-controlled data flows to the sink
-  override predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
 
   // our Decompression APIs defined above will be the sinks we use for this query
-  override predicate isSink(DataFlow::Node sink) { sink instanceof DecompressionApiUse }
+  predicate isSink(DataFlow::Node sink) { sink instanceof DecompressionApiUse }
 }
 
-from Configuration config, DataFlow::PathNode source, DataFlow::PathNode sink
-where config.hasFlowPath(source, sink)
+from ConfigurationInst::PathNode source, ConfigurationInst::PathNode sink
+where ConfigurationInst::flowPath(source, sink)
 select sink.getNode().(DecompressionApiUse), source, sink,
   "This call to $@ is unsafe because user-controlled data is used to set the object being decompressed, which could lead to a denial of service attack or malicious code extracted from an unknown source.",
   sink.getNode().(DecompressionApiUse).getCall(),

--- a/ruby/ql/src/experimental/template-injection/TemplateInjection.ql
+++ b/ruby/ql/src/experimental/template-injection/TemplateInjection.ql
@@ -13,9 +13,9 @@
 
 import codeql.ruby.DataFlow
 import codeql.ruby.security.TemplateInjectionQuery
-import DataFlow::PathGraph
+import ConfigurationInst::PathGraph
 
-from Configuration config, DataFlow::PathNode source, DataFlow::PathNode sink
-where config.hasFlowPath(source, sink)
+from ConfigurationInst::PathNode source, ConfigurationInst::PathNode sink
+where ConfigurationInst::flowPath(source, sink)
 select sink.getNode(), source, sink, "This template depends on a $@.", source.getNode(),
   "user-provided value"

--- a/ruby/ql/src/queries/security/cwe-020/MissingFullAnchor.ql
+++ b/ruby/ql/src/queries/security/cwe-020/MissingFullAnchor.ql
@@ -12,10 +12,10 @@
  */
 
 import codeql.ruby.security.regexp.MissingFullAnchorQuery
-import DataFlow::PathGraph
+import ConfigurationInst::PathGraph
 
-from Configuration config, DataFlow::PathNode source, DataFlow::PathNode sink, Sink sinkNode
-where config.hasFlowPath(source, sink) and sink.getNode() = sinkNode
+from ConfigurationInst::PathNode source, ConfigurationInst::PathNode sink, Sink sinkNode
+where ConfigurationInst::flowPath(source, sink) and sink.getNode() = sinkNode
 select sink, source, sink, "This value depends on $@, and is $@ against a $@.", source.getNode(),
   source.getNode().(Source).describe(), sinkNode.getCallNode(), "checked", sinkNode.getRegex(),
   "badly anchored regular expression"

--- a/ruby/ql/src/queries/security/cwe-022/PathInjection.ql
+++ b/ruby/ql/src/queries/security/cwe-022/PathInjection.ql
@@ -17,9 +17,9 @@
 
 import ruby
 import codeql.ruby.security.PathInjectionQuery
-import DataFlow::PathGraph
+import ConfigurationInst::PathGraph
 
-from Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink
-where cfg.hasFlowPath(source, sink)
+from ConfigurationInst::PathNode source, ConfigurationInst::PathNode sink
+where ConfigurationInst::flowPath(source, sink)
 select sink.getNode(), source, sink, "This path depends on a $@.", source.getNode(),
   "user-provided value"

--- a/ruby/ql/src/queries/security/cwe-078/CommandInjection.ql
+++ b/ruby/ql/src/queries/security/cwe-078/CommandInjection.ql
@@ -15,11 +15,11 @@
 
 import codeql.ruby.AST
 import codeql.ruby.security.CommandInjectionQuery
-import DataFlow::PathGraph
+import ConfigurationInst::PathGraph
 
-from Configuration config, DataFlow::PathNode source, DataFlow::PathNode sink, Source sourceNode
+from ConfigurationInst::PathNode source, ConfigurationInst::PathNode sink, Source sourceNode
 where
-  config.hasFlowPath(source, sink) and
+  ConfigurationInst::flowPath(source, sink) and
   sourceNode = source.getNode()
 select sink.getNode(), source, sink, "This command depends on a $@.", sourceNode,
   sourceNode.getSourceType()

--- a/ruby/ql/src/queries/security/cwe-078/UnsafeShellCommandConstruction.ql
+++ b/ruby/ql/src/queries/security/cwe-078/UnsafeShellCommandConstruction.ql
@@ -15,11 +15,11 @@
  */
 
 import codeql.ruby.security.UnsafeShellCommandConstructionQuery
-import DataFlow::PathGraph
+import ConfigurationInst::PathGraph
 
-from Configuration config, DataFlow::PathNode source, DataFlow::PathNode sink, Sink sinkNode
+from ConfigurationInst::PathNode source, ConfigurationInst::PathNode sink, Sink sinkNode
 where
-  config.hasFlowPath(source, sink) and
+  ConfigurationInst::flowPath(source, sink) and
   sinkNode = sink.getNode()
 select sinkNode.getStringConstruction(), source, sink,
   "This " + sinkNode.describe() + " which depends on $@ is later used in a $@.", source.getNode(),

--- a/ruby/ql/src/queries/security/cwe-079/ReflectedXSS.ql
+++ b/ruby/ql/src/queries/security/cwe-079/ReflectedXSS.ql
@@ -15,9 +15,9 @@
 
 import codeql.ruby.AST
 import codeql.ruby.security.ReflectedXSSQuery
-import DataFlow::PathGraph
+import ConfigurationInst::PathGraph
 
-from ReflectedXss::Configuration config, DataFlow::PathNode source, DataFlow::PathNode sink
-where config.hasFlowPath(source, sink)
+from ConfigurationInst::PathNode source, ConfigurationInst::PathNode sink
+where ConfigurationInst::flowPath(source, sink)
 select sink.getNode(), source, sink, "Cross-site scripting vulnerability due to a $@.",
   source.getNode(), "user-provided value"

--- a/ruby/ql/src/queries/security/cwe-089/SqlInjection.ql
+++ b/ruby/ql/src/queries/security/cwe-089/SqlInjection.ql
@@ -13,9 +13,9 @@
 
 import codeql.ruby.DataFlow
 import codeql.ruby.security.SqlInjectionQuery
-import DataFlow::PathGraph
+import ConfigurationInst::PathGraph
 
-from Configuration config, DataFlow::PathNode source, DataFlow::PathNode sink
-where config.hasFlowPath(source, sink)
+from ConfigurationInst::PathNode source, ConfigurationInst::PathNode sink
+where ConfigurationInst::flowPath(source, sink)
 select sink.getNode(), source, sink, "This SQL query depends on a $@.", source.getNode(),
   "user-provided value"

--- a/ruby/ql/src/queries/security/cwe-094/UnsafeCodeConstruction.ql
+++ b/ruby/ql/src/queries/security/cwe-094/UnsafeCodeConstruction.ql
@@ -14,10 +14,10 @@
  */
 
 import codeql.ruby.security.UnsafeCodeConstructionQuery
-import DataFlow::PathGraph
+import ConfigurationInst::PathGraph
 
-from Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink, Sink sinkNode
-where cfg.hasFlowPath(source, sink) and sinkNode = sink.getNode()
+from ConfigurationInst::PathNode source, ConfigurationInst::PathNode sink, Sink sinkNode
+where ConfigurationInst::flowPath(source, sink) and sinkNode = sink.getNode()
 select sink.getNode(), source, sink,
   "This " + sinkNode.getSinkType() + " which depends on $@ is later $@.", source.getNode(),
   "library input", sinkNode.getCodeSink(), "interpreted as code"

--- a/ruby/ql/src/queries/security/cwe-117/LogInjection.ql
+++ b/ruby/ql/src/queries/security/cwe-117/LogInjection.ql
@@ -12,10 +12,10 @@
  */
 
 import codeql.ruby.AST
-import DataFlow::PathGraph
+import LogInjectionConfigurationInst::PathGraph
 import codeql.ruby.security.LogInjectionQuery
 
-from LogInjectionConfiguration config, DataFlow::PathNode source, DataFlow::PathNode sink
-where config.hasFlowPath(source, sink)
+from LogInjectionConfigurationInst::PathNode source, LogInjectionConfigurationInst::PathNode sink
+where LogInjectionConfigurationInst::flowPath(source, sink)
 select sink.getNode(), source, sink, "Log entry depends on a $@.", source.getNode(),
   "user-provided value"

--- a/ruby/ql/src/queries/security/cwe-1333/PolynomialReDoS.ql
+++ b/ruby/ql/src/queries/security/cwe-1333/PolynomialReDoS.ql
@@ -13,15 +13,15 @@
  *       external/cwe/cwe-400
  */
 
-import DataFlow::PathGraph
+import ConfigurationInst::PathGraph
 import codeql.ruby.DataFlow
 import codeql.ruby.security.regexp.PolynomialReDoSQuery
 
 from
-  PolynomialReDoS::Configuration config, DataFlow::PathNode source, DataFlow::PathNode sink,
+  ConfigurationInst::PathNode source, ConfigurationInst::PathNode sink,
   PolynomialReDoS::Sink sinkNode, PolynomialReDoS::PolynomialBackTrackingTerm regexp
 where
-  config.hasFlowPath(source, sink) and
+  ConfigurationInst::flowPath(source, sink) and
   sinkNode = sink.getNode() and
   regexp = sinkNode.getRegExp()
 select sinkNode.getHighlight(), source, sink,

--- a/ruby/ql/src/queries/security/cwe-1333/RegExpInjection.ql
+++ b/ruby/ql/src/queries/security/cwe-1333/RegExpInjection.ql
@@ -16,11 +16,11 @@
  */
 
 import codeql.ruby.AST
-import DataFlow::PathGraph
+import ConfigurationInst::PathGraph
 import codeql.ruby.DataFlow
 import codeql.ruby.security.regexp.RegExpInjectionQuery
 
-from Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink
-where cfg.hasFlowPath(source, sink)
+from ConfigurationInst::PathNode source, ConfigurationInst::PathNode sink
+where ConfigurationInst::flowPath(source, sink)
 select sink.getNode(), source, sink, "This regular expression depends on a $@.", source.getNode(),
   "user-provided value"

--- a/ruby/ql/src/queries/security/cwe-134/TaintedFormatString.ql
+++ b/ruby/ql/src/queries/security/cwe-134/TaintedFormatString.ql
@@ -13,9 +13,9 @@
 import codeql.ruby.AST
 import codeql.ruby.DataFlow
 import codeql.ruby.security.TaintedFormatStringQuery
-import DataFlow::PathGraph
+import ConfigurationInst::PathGraph
 
-from Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink
-where cfg.hasFlowPath(source, sink)
+from ConfigurationInst::PathNode source, ConfigurationInst::PathNode sink
+where ConfigurationInst::flowPath(source, sink)
 select sink.getNode(), source, sink, "Format string depends on a $@.", source.getNode(),
   "user-provided value"

--- a/ruby/ql/src/queries/security/cwe-209/StackTraceExposure.ql
+++ b/ruby/ql/src/queries/security/cwe-209/StackTraceExposure.ql
@@ -15,9 +15,9 @@
 
 import codeql.ruby.DataFlow
 import codeql.ruby.security.StackTraceExposureQuery
-import DataFlow::PathGraph
+import ConfigurationInst::PathGraph
 
-from Configuration config, DataFlow::PathNode source, DataFlow::PathNode sink
-where config.hasFlowPath(source, sink)
+from ConfigurationInst::PathNode source, ConfigurationInst::PathNode sink
+where ConfigurationInst::flowPath(source, sink)
 select sink.getNode(), source, sink, "$@ can be exposed to an external user.", source.getNode(),
   "Error information"

--- a/ruby/ql/src/queries/security/cwe-312/CleartextLogging.ql
+++ b/ruby/ql/src/queries/security/cwe-312/CleartextLogging.ql
@@ -16,9 +16,9 @@
 import codeql.ruby.AST
 import codeql.ruby.security.CleartextLoggingQuery
 import codeql.ruby.DataFlow
-import DataFlow::PathGraph
+import ConfigurationInst::PathGraph
 
-from Configuration config, DataFlow::PathNode source, DataFlow::PathNode sink
-where config.hasFlowPath(source, sink)
+from ConfigurationInst::PathNode source, ConfigurationInst::PathNode sink
+where ConfigurationInst::flowPath(source, sink)
 select sink.getNode(), source, sink, "This logs sensitive data returned by $@ as clear text.",
   source.getNode(), source.getNode().(Source).describe()

--- a/ruby/ql/src/queries/security/cwe-312/CleartextStorage.ql
+++ b/ruby/ql/src/queries/security/cwe-312/CleartextStorage.ql
@@ -17,9 +17,9 @@ import codeql.ruby.AST
 import codeql.ruby.security.CleartextStorageQuery
 import codeql.ruby.security.CleartextStorageCustomizations::CleartextStorage
 import codeql.ruby.DataFlow
-import DataFlow::PathGraph
+import ConfigurationInst::PathGraph
 
-from Configuration config, DataFlow::PathNode source, DataFlow::PathNode sink
-where config.hasFlowPath(source, sink)
+from ConfigurationInst::PathNode source, ConfigurationInst::PathNode sink
+where ConfigurationInst::flowPath(source, sink)
 select sink.getNode(), source, sink, "This stores sensitive data returned by $@ as clear text.",
   source.getNode(), source.getNode().(Source).describe()

--- a/ruby/ql/src/queries/security/cwe-502/UnsafeDeserialization.ql
+++ b/ruby/ql/src/queries/security/cwe-502/UnsafeDeserialization.ql
@@ -13,9 +13,9 @@
 
 import ruby
 import codeql.ruby.security.UnsafeDeserializationQuery
-import DataFlow::PathGraph
+import ConfigurationInst::PathGraph
 
-from Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink
-where cfg.hasFlowPath(source, sink)
+from ConfigurationInst::PathNode source, ConfigurationInst::PathNode sink
+where ConfigurationInst::flowPath(source, sink)
 select sink.getNode(), source, sink, "Unsafe deserialization depends on a $@.", source.getNode(),
   source.getNode().(UnsafeDeserialization::Source).describe()

--- a/ruby/ql/src/queries/security/cwe-601/UrlRedirect.ql
+++ b/ruby/ql/src/queries/security/cwe-601/UrlRedirect.ql
@@ -14,9 +14,9 @@
 
 import codeql.ruby.AST
 import codeql.ruby.security.UrlRedirectQuery
-import codeql.ruby.DataFlow::DataFlow::PathGraph
+import ConfigurationInst::PathGraph
 
-from Configuration config, DataFlow::PathNode source, DataFlow::PathNode sink
-where config.hasFlowPath(source, sink)
+from ConfigurationInst::PathNode source, ConfigurationInst::PathNode sink
+where ConfigurationInst::flowPath(source, sink)
 select sink.getNode(), source, sink, "Untrusted URL redirection depends on a $@.", source.getNode(),
   "user-provided value"

--- a/ruby/ql/src/queries/security/cwe-912/HttpToFileAccess.ql
+++ b/ruby/ql/src/queries/security/cwe-912/HttpToFileAccess.ql
@@ -13,10 +13,10 @@
 
 import codeql.ruby.AST
 import codeql.ruby.DataFlow
-import codeql.ruby.DataFlow::DataFlow::PathGraph
+import ConfigurationInst::PathGraph
 import codeql.ruby.security.HttpToFileAccessQuery
 
-from Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink
-where cfg.hasFlowPath(source, sink)
+from ConfigurationInst::PathNode source, ConfigurationInst::PathNode sink
+where ConfigurationInst::flowPath(source, sink)
 select sink.getNode(), source, sink, "Write to file system depends on $@.", source.getNode(),
   "untrusted data"

--- a/ruby/ql/src/queries/security/cwe-918/ServerSideRequestForgery.ql
+++ b/ruby/ql/src/queries/security/cwe-918/ServerSideRequestForgery.ql
@@ -13,9 +13,9 @@
 import codeql.ruby.AST
 import codeql.ruby.DataFlow
 import codeql.ruby.security.ServerSideRequestForgeryQuery
-import DataFlow::PathGraph
+import ConfigurationInst::PathGraph
 
-from Configuration config, DataFlow::PathNode source, DataFlow::PathNode sink
-where config.hasFlowPath(source, sink)
+from ConfigurationInst::PathNode source, ConfigurationInst::PathNode sink
+where ConfigurationInst::flowPath(source, sink)
 select sink.getNode(), source, sink, "The URL of this request depends on a $@.", source.getNode(),
   "user-provided value"


### PR DESCRIPTION
I wrote an automated patch for rewriting (some) `DataFlow/TaintTracking::Configuration` to the new `ConfigSig`.  

I'm doing Ruby because you have the simplest `Configuration` classes that are the easiest to rewrite.  

There is no attempt to rewrite any `Configuration` that use `FlowState`.   
(I haven't even checked how FlowState work in the new shared library).  

The names are terrible, but it's hard to write an automated patch that outputs nice names. 

This is not meant to be merged as is, but will require some further renaming, and a change note, leaving behind deprecated aliases (I might do that last part, but that requires 2 patches that run one after the other)