### PR TITLE
C++: Make implicit this receivers explicit

### DIFF
--- a/cpp/ql/lib/upgrades/282c13bfdbcbd57a887972b47a471342a4ad5507/member_function_this_type.ql
+++ b/cpp/ql/lib/upgrades/282c13bfdbcbd57a887972b47a471342a4ad5507/member_function_this_type.ql
@@ -24,7 +24,7 @@ class ClassPointerType extends @derivedtype {
 
   Class getBaseType() { derivedtypes(this, _, _, result) }
 
-  string toString() { result = getBaseType().toString() + "*" }
+  string toString() { result = this.getBaseType().toString() + "*" }
 }
 
 class DefinedMemberFunction extends @function {


### PR DESCRIPTION
Make implicit this call receivers explicit to align with internal style guidelines.