### PR TITLE
Swift: surface errors about no viable swift targets found

### DIFF
--- a/swift/integration-tests/osx-only/autobuilder/no-swift-with-spm/diagnostics.expected
+++ b/swift/integration-tests/osx-only/autobuilder/no-swift-with-spm/diagnostics.expected
@@ -1,0 +1,18 @@
+{
+  "helpLinks": [
+    "https://docs.github.com/en/enterprise-server/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/customizing-code-scanning",
+    "https://docs.github.com/en/enterprise-server/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-the-codeql-workflow-for-compiled-languages#adding-build-steps-for-a-compiled-language"
+  ],
+  "plaintextMessage": "No viable Swift Xcode target was found but a Swift package was detected. Swift Package Manager builds are not yet supported by the autobuilder.\n\nSet up a manual build command.",
+  "severity": "error",
+  "source": {
+    "extractorName": "swift",
+    "id": "swift/autobuilder/spm-not-supported",
+    "name": "Swift Package Manager build unsupported by autobuild"
+  },
+  "visibility": {
+    "cliSummaryTable": true,
+    "statusPage": true,
+    "telemetry": true
+  }
+}

--- a/swift/integration-tests/osx-only/autobuilder/no-swift-with-spm/hello-objective.xcodeproj/project.pbxproj
+++ b/swift/integration-tests/osx-only/autobuilder/no-swift-with-spm/hello-objective.xcodeproj/project.pbxproj
@@ -1,0 +1,278 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		57B14B1A2A0A512A002820C5 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 57B14B192A0A512A002820C5 /* main.m */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		57B14B142A0A512A002820C5 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		57B14B162A0A512A002820C5 /* hello-objective */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "hello-objective"; sourceTree = BUILT_PRODUCTS_DIR; };
+		57B14B192A0A512A002820C5 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		57B14B132A0A512A002820C5 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		57B14B0D2A0A512A002820C5 = {
+			isa = PBXGroup;
+			children = (
+				57B14B182A0A512A002820C5 /* hello-objective */,
+				57B14B172A0A512A002820C5 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		57B14B172A0A512A002820C5 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				57B14B162A0A512A002820C5 /* hello-objective */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		57B14B182A0A512A002820C5 /* hello-objective */ = {
+			isa = PBXGroup;
+			children = (
+				57B14B192A0A512A002820C5 /* main.m */,
+			);
+			path = "hello-objective";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		57B14B152A0A512A002820C5 /* hello-objective */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 57B14B1D2A0A512A002820C5 /* Build configuration list for PBXNativeTarget "hello-objective" */;
+			buildPhases = (
+				57B14B122A0A512A002820C5 /* Sources */,
+				57B14B132A0A512A002820C5 /* Frameworks */,
+				57B14B142A0A512A002820C5 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "hello-objective";
+			productName = "hello-objective";
+			productReference = 57B14B162A0A512A002820C5 /* hello-objective */;
+			productType = "com.apple.product-type.tool";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		57B14B0E2A0A512A002820C5 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastUpgradeCheck = 1430;
+				TargetAttributes = {
+					57B14B152A0A512A002820C5 = {
+						CreatedOnToolsVersion = 14.3;
+					};
+				};
+			};
+			buildConfigurationList = 57B14B112A0A512A002820C5 /* Build configuration list for PBXProject "hello-objective" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 57B14B0D2A0A512A002820C5;
+			productRefGroup = 57B14B172A0A512A002820C5 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				57B14B152A0A512A002820C5 /* hello-objective */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		57B14B122A0A512A002820C5 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				57B14B1A2A0A512A002820C5 /* main.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		57B14B1B2A0A512A002820C5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 13.2;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		57B14B1C2A0A512A002820C5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 13.2;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
+		57B14B1E2A0A512A002820C5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		57B14B1F2A0A512A002820C5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		57B14B112A0A512A002820C5 /* Build configuration list for PBXProject "hello-objective" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				57B14B1B2A0A512A002820C5 /* Debug */,
+				57B14B1C2A0A512A002820C5 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		57B14B1D2A0A512A002820C5 /* Build configuration list for PBXNativeTarget "hello-objective" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				57B14B1E2A0A512A002820C5 /* Debug */,
+				57B14B1F2A0A512A002820C5 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 57B14B0E2A0A512A002820C5 /* Project object */;
+}

--- a/swift/integration-tests/osx-only/autobuilder/no-swift-with-spm/hello-objective.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/swift/integration-tests/osx-only/autobuilder/no-swift-with-spm/hello-objective.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/swift/integration-tests/osx-only/autobuilder/no-swift-with-spm/hello-objective.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/swift/integration-tests/osx-only/autobuilder/no-swift-with-spm/hello-objective.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/swift/integration-tests/osx-only/autobuilder/no-swift-with-spm/hello-objective/Package.swift
+++ b/swift/integration-tests/osx-only/autobuilder/no-swift-with-spm/hello-objective/Package.swift
@@ -1,0 +1,1 @@
+// swift-tools-version:5.0

--- a/swift/integration-tests/osx-only/autobuilder/no-swift-with-spm/hello-objective/main.m
+++ b/swift/integration-tests/osx-only/autobuilder/no-swift-with-spm/hello-objective/main.m
@@ -1,0 +1,16 @@
+//
+//  main.m
+//  hello-objective
+//
+//  Created by ec2-user on 5/9/23.
+//
+
+#import <Foundation/Foundation.h>
+
+int main(int argc, const char * argv[]) {
+    @autoreleasepool {
+        // insert code here...
+        NSLog(@"Hello, World!");
+    }
+    return 0;
+}

--- a/swift/integration-tests/osx-only/autobuilder/no-swift-with-spm/test.py
+++ b/swift/integration-tests/osx-only/autobuilder/no-swift-with-spm/test.py
@@ -1,0 +1,5 @@
+from create_database_utils import *
+from diagnostics_test_utils import *
+
+run_codeql_database_create([], lang='swift', keep_trap=True, db=None, runFunction=runUnsuccessfully)
+check_diagnostics()

--- a/swift/integration-tests/osx-only/autobuilder/no-swift/diagnostics.expected
+++ b/swift/integration-tests/osx-only/autobuilder/no-swift/diagnostics.expected
@@ -1,0 +1,18 @@
+{
+  "helpLinks": [
+    "https://docs.github.com/en/enterprise-server/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/customizing-code-scanning",
+    "https://docs.github.com/en/enterprise-server/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-the-codeql-workflow-for-compiled-languages#adding-build-steps-for-a-compiled-language"
+  ],
+  "plaintextMessage": "All targets found within Xcode projects or workspaces either have no Swift sources or are tests.\n\nSet up a manual build command.",
+  "severity": "error",
+  "source": {
+    "extractorName": "swift",
+    "id": "swift/autobuilder/no-swift-target",
+    "name": "No Swift compilation target found"
+  },
+  "visibility": {
+    "cliSummaryTable": true,
+    "statusPage": true,
+    "telemetry": true
+  }
+}

--- a/swift/integration-tests/osx-only/autobuilder/no-swift/hello-objective.xcodeproj/project.pbxproj
+++ b/swift/integration-tests/osx-only/autobuilder/no-swift/hello-objective.xcodeproj/project.pbxproj
@@ -1,0 +1,278 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		57B14B1A2A0A512A002820C5 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 57B14B192A0A512A002820C5 /* main.m */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		57B14B142A0A512A002820C5 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		57B14B162A0A512A002820C5 /* hello-objective */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "hello-objective"; sourceTree = BUILT_PRODUCTS_DIR; };
+		57B14B192A0A512A002820C5 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		57B14B132A0A512A002820C5 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		57B14B0D2A0A512A002820C5 = {
+			isa = PBXGroup;
+			children = (
+				57B14B182A0A512A002820C5 /* hello-objective */,
+				57B14B172A0A512A002820C5 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		57B14B172A0A512A002820C5 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				57B14B162A0A512A002820C5 /* hello-objective */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		57B14B182A0A512A002820C5 /* hello-objective */ = {
+			isa = PBXGroup;
+			children = (
+				57B14B192A0A512A002820C5 /* main.m */,
+			);
+			path = "hello-objective";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		57B14B152A0A512A002820C5 /* hello-objective */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 57B14B1D2A0A512A002820C5 /* Build configuration list for PBXNativeTarget "hello-objective" */;
+			buildPhases = (
+				57B14B122A0A512A002820C5 /* Sources */,
+				57B14B132A0A512A002820C5 /* Frameworks */,
+				57B14B142A0A512A002820C5 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "hello-objective";
+			productName = "hello-objective";
+			productReference = 57B14B162A0A512A002820C5 /* hello-objective */;
+			productType = "com.apple.product-type.tool";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		57B14B0E2A0A512A002820C5 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastUpgradeCheck = 1430;
+				TargetAttributes = {
+					57B14B152A0A512A002820C5 = {
+						CreatedOnToolsVersion = 14.3;
+					};
+				};
+			};
+			buildConfigurationList = 57B14B112A0A512A002820C5 /* Build configuration list for PBXProject "hello-objective" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 57B14B0D2A0A512A002820C5;
+			productRefGroup = 57B14B172A0A512A002820C5 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				57B14B152A0A512A002820C5 /* hello-objective */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		57B14B122A0A512A002820C5 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				57B14B1A2A0A512A002820C5 /* main.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		57B14B1B2A0A512A002820C5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 13.2;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		57B14B1C2A0A512A002820C5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 13.2;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
+		57B14B1E2A0A512A002820C5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		57B14B1F2A0A512A002820C5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		57B14B112A0A512A002820C5 /* Build configuration list for PBXProject "hello-objective" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				57B14B1B2A0A512A002820C5 /* Debug */,
+				57B14B1C2A0A512A002820C5 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		57B14B1D2A0A512A002820C5 /* Build configuration list for PBXNativeTarget "hello-objective" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				57B14B1E2A0A512A002820C5 /* Debug */,
+				57B14B1F2A0A512A002820C5 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 57B14B0E2A0A512A002820C5 /* Project object */;
+}

--- a/swift/integration-tests/osx-only/autobuilder/no-swift/hello-objective.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/swift/integration-tests/osx-only/autobuilder/no-swift/hello-objective.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/swift/integration-tests/osx-only/autobuilder/no-swift/hello-objective.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/swift/integration-tests/osx-only/autobuilder/no-swift/hello-objective.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/swift/integration-tests/osx-only/autobuilder/no-swift/hello-objective/main.m
+++ b/swift/integration-tests/osx-only/autobuilder/no-swift/hello-objective/main.m
@@ -1,0 +1,16 @@
+//
+//  main.m
+//  hello-objective
+//
+//  Created by ec2-user on 5/9/23.
+//
+
+#import <Foundation/Foundation.h>
+
+int main(int argc, const char * argv[]) {
+    @autoreleasepool {
+        // insert code here...
+        NSLog(@"Hello, World!");
+    }
+    return 0;
+}

--- a/swift/integration-tests/osx-only/autobuilder/no-swift/test.py
+++ b/swift/integration-tests/osx-only/autobuilder/no-swift/test.py
@@ -1,0 +1,5 @@
+from create_database_utils import *
+from diagnostics_test_utils import *
+
+run_codeql_database_create([], lang='swift', keep_trap=True, db=None, runFunction=runUnsuccessfully)
+check_diagnostics()

--- a/swift/integration-tests/osx-only/autobuilder/no-xcode-with-spm/Package.swift
+++ b/swift/integration-tests/osx-only/autobuilder/no-xcode-with-spm/Package.swift
@@ -1,0 +1,1 @@
+// swift-tools-version:5.0

--- a/swift/integration-tests/osx-only/autobuilder/no-xcode-with-spm/diagnostics.expected
+++ b/swift/integration-tests/osx-only/autobuilder/no-xcode-with-spm/diagnostics.expected
@@ -1,0 +1,18 @@
+{
+  "helpLinks": [
+    "https://docs.github.com/en/enterprise-server/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/customizing-code-scanning",
+    "https://docs.github.com/en/enterprise-server/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-the-codeql-workflow-for-compiled-languages#adding-build-steps-for-a-compiled-language"
+  ],
+  "plaintextMessage": "No viable Swift Xcode target was found but a Swift package was detected. Swift Package Manager builds are not yet supported by the autobuilder.\n\nSet up a manual build command.",
+  "severity": "error",
+  "source": {
+    "extractorName": "swift",
+    "id": "swift/autobuilder/spm-not-supported",
+    "name": "Swift Package Manager build unsupported by autobuild"
+  },
+  "visibility": {
+    "cliSummaryTable": true,
+    "statusPage": true,
+    "telemetry": true
+  }
+}

--- a/swift/integration-tests/osx-only/autobuilder/no-xcode-with-spm/test.py
+++ b/swift/integration-tests/osx-only/autobuilder/no-xcode-with-spm/test.py
@@ -1,0 +1,5 @@
+from create_database_utils import *
+from diagnostics_test_utils import *
+
+run_codeql_database_create([], lang='swift', keep_trap=True, db=None, runFunction=runUnsuccessfully)
+check_diagnostics()

--- a/swift/integration-tests/osx-only/autobuilder/only-tests-with-spm/Package.swift
+++ b/swift/integration-tests/osx-only/autobuilder/only-tests-with-spm/Package.swift
@@ -1,0 +1,1 @@
+// swift-tools-version:5.0

--- a/swift/integration-tests/osx-only/autobuilder/only-tests-with-spm/diagnostics.expected
+++ b/swift/integration-tests/osx-only/autobuilder/only-tests-with-spm/diagnostics.expected
@@ -1,0 +1,18 @@
+{
+  "helpLinks": [
+    "https://docs.github.com/en/enterprise-server/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/customizing-code-scanning",
+    "https://docs.github.com/en/enterprise-server/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-the-codeql-workflow-for-compiled-languages#adding-build-steps-for-a-compiled-language"
+  ],
+  "plaintextMessage": "No viable Swift Xcode target was found but a Swift package was detected. Swift Package Manager builds are not yet supported by the autobuilder.\n\nSet up a manual build command.",
+  "severity": "error",
+  "source": {
+    "extractorName": "swift",
+    "id": "swift/autobuilder/spm-not-supported",
+    "name": "Swift Package Manager build unsupported by autobuild"
+  },
+  "visibility": {
+    "cliSummaryTable": true,
+    "statusPage": true,
+    "telemetry": true
+  }
+}

--- a/swift/integration-tests/osx-only/autobuilder/only-tests-with-spm/hello-tests.xcodeproj/project.pbxproj
+++ b/swift/integration-tests/osx-only/autobuilder/only-tests-with-spm/hello-tests.xcodeproj/project.pbxproj
@@ -1,0 +1,430 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		57B14B762A0A881B002820C5 /* hello_testsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B14B752A0A881B002820C5 /* hello_testsTests.swift */; };
+		57B14B802A0A881B002820C5 /* hello_testsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B14B7F2A0A881B002820C5 /* hello_testsUITests.swift */; };
+		57B14B822A0A881B002820C5 /* hello_testsUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B14B812A0A881B002820C5 /* hello_testsUITestsLaunchTests.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		57B14B632A0A8819002820C5 /* hello_testsApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = hello_testsApp.swift; sourceTree = "<group>"; };
+		57B14B652A0A8819002820C5 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		57B14B672A0A881B002820C5 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		57B14B6A2A0A881B002820C5 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		57B14B6C2A0A881B002820C5 /* hello_tests.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = hello_tests.entitlements; sourceTree = "<group>"; };
+		57B14B712A0A881B002820C5 /* hello-testsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "hello-testsTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		57B14B752A0A881B002820C5 /* hello_testsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = hello_testsTests.swift; sourceTree = "<group>"; };
+		57B14B7B2A0A881B002820C5 /* hello-testsUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "hello-testsUITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		57B14B7F2A0A881B002820C5 /* hello_testsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = hello_testsUITests.swift; sourceTree = "<group>"; };
+		57B14B812A0A881B002820C5 /* hello_testsUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = hello_testsUITestsLaunchTests.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		57B14B6E2A0A881B002820C5 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		57B14B782A0A881B002820C5 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		57B14B572A0A8819002820C5 = {
+			isa = PBXGroup;
+			children = (
+				57B14B622A0A8819002820C5 /* hello-tests */,
+				57B14B742A0A881B002820C5 /* hello-testsTests */,
+				57B14B7E2A0A881B002820C5 /* hello-testsUITests */,
+				57B14B612A0A8819002820C5 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		57B14B612A0A8819002820C5 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				57B14B712A0A881B002820C5 /* hello-testsTests.xctest */,
+				57B14B7B2A0A881B002820C5 /* hello-testsUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		57B14B622A0A8819002820C5 /* hello-tests */ = {
+			isa = PBXGroup;
+			children = (
+				57B14B632A0A8819002820C5 /* hello_testsApp.swift */,
+				57B14B652A0A8819002820C5 /* ContentView.swift */,
+				57B14B672A0A881B002820C5 /* Assets.xcassets */,
+				57B14B6C2A0A881B002820C5 /* hello_tests.entitlements */,
+				57B14B692A0A881B002820C5 /* Preview Content */,
+			);
+			path = "hello-tests";
+			sourceTree = "<group>";
+		};
+		57B14B692A0A881B002820C5 /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				57B14B6A2A0A881B002820C5 /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		57B14B742A0A881B002820C5 /* hello-testsTests */ = {
+			isa = PBXGroup;
+			children = (
+				57B14B752A0A881B002820C5 /* hello_testsTests.swift */,
+			);
+			path = "hello-testsTests";
+			sourceTree = "<group>";
+		};
+		57B14B7E2A0A881B002820C5 /* hello-testsUITests */ = {
+			isa = PBXGroup;
+			children = (
+				57B14B7F2A0A881B002820C5 /* hello_testsUITests.swift */,
+				57B14B812A0A881B002820C5 /* hello_testsUITestsLaunchTests.swift */,
+			);
+			path = "hello-testsUITests";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		57B14B702A0A881B002820C5 /* hello-testsTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 57B14B882A0A881B002820C5 /* Build configuration list for PBXNativeTarget "hello-testsTests" */;
+			buildPhases = (
+				57B14B6D2A0A881B002820C5 /* Sources */,
+				57B14B6E2A0A881B002820C5 /* Frameworks */,
+				57B14B6F2A0A881B002820C5 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "hello-testsTests";
+			productName = "hello-testsTests";
+			productReference = 57B14B712A0A881B002820C5 /* hello-testsTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		57B14B7A2A0A881B002820C5 /* hello-testsUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 57B14B8B2A0A881B002820C5 /* Build configuration list for PBXNativeTarget "hello-testsUITests" */;
+			buildPhases = (
+				57B14B772A0A881B002820C5 /* Sources */,
+				57B14B782A0A881B002820C5 /* Frameworks */,
+				57B14B792A0A881B002820C5 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "hello-testsUITests";
+			productName = "hello-testsUITests";
+			productReference = 57B14B7B2A0A881B002820C5 /* hello-testsUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		57B14B582A0A8819002820C5 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1430;
+				LastUpgradeCheck = 1430;
+				TargetAttributes = {
+					57B14B702A0A881B002820C5 = {
+						CreatedOnToolsVersion = 14.3;
+						TestTargetID = 57B14B5F2A0A8819002820C5;
+					};
+					57B14B7A2A0A881B002820C5 = {
+						CreatedOnToolsVersion = 14.3;
+						TestTargetID = 57B14B5F2A0A8819002820C5;
+					};
+				};
+			};
+			buildConfigurationList = 57B14B5B2A0A8819002820C5 /* Build configuration list for PBXProject "hello-tests" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 57B14B572A0A8819002820C5;
+			productRefGroup = 57B14B612A0A8819002820C5 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				57B14B702A0A881B002820C5 /* hello-testsTests */,
+				57B14B7A2A0A881B002820C5 /* hello-testsUITests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		57B14B6F2A0A881B002820C5 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		57B14B792A0A881B002820C5 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		57B14B6D2A0A881B002820C5 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				57B14B762A0A881B002820C5 /* hello_testsTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		57B14B772A0A881B002820C5 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				57B14B802A0A881B002820C5 /* hello_testsUITests.swift in Sources */,
+				57B14B822A0A881B002820C5 /* hello_testsUITestsLaunchTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		57B14B832A0A881B002820C5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 13.2;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		57B14B842A0A881B002820C5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 13.2;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+			};
+			name = Release;
+		};
+		57B14B892A0A881B002820C5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 13.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.hello-testsTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/hello-tests.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/hello-tests";
+			};
+			name = Debug;
+		};
+		57B14B8A2A0A881B002820C5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 13.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.hello-testsTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/hello-tests.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/hello-tests";
+			};
+			name = Release;
+		};
+		57B14B8C2A0A881B002820C5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.hello-testsUITests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TEST_TARGET_NAME = "hello-tests";
+			};
+			name = Debug;
+		};
+		57B14B8D2A0A881B002820C5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.hello-testsUITests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TEST_TARGET_NAME = "hello-tests";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		57B14B5B2A0A8819002820C5 /* Build configuration list for PBXProject "hello-tests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				57B14B832A0A881B002820C5 /* Debug */,
+				57B14B842A0A881B002820C5 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		57B14B882A0A881B002820C5 /* Build configuration list for PBXNativeTarget "hello-testsTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				57B14B892A0A881B002820C5 /* Debug */,
+				57B14B8A2A0A881B002820C5 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		57B14B8B2A0A881B002820C5 /* Build configuration list for PBXNativeTarget "hello-testsUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				57B14B8C2A0A881B002820C5 /* Debug */,
+				57B14B8D2A0A881B002820C5 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 57B14B582A0A8819002820C5 /* Project object */;
+}

--- a/swift/integration-tests/osx-only/autobuilder/only-tests-with-spm/hello-tests.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/swift/integration-tests/osx-only/autobuilder/only-tests-with-spm/hello-tests.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/swift/integration-tests/osx-only/autobuilder/only-tests-with-spm/test.py
+++ b/swift/integration-tests/osx-only/autobuilder/only-tests-with-spm/test.py
@@ -1,0 +1,5 @@
+from create_database_utils import *
+from diagnostics_test_utils import *
+
+run_codeql_database_create([], lang='swift', keep_trap=True, db=None, runFunction=runUnsuccessfully)
+check_diagnostics()

--- a/swift/integration-tests/osx-only/autobuilder/only-tests/diagnostics.expected
+++ b/swift/integration-tests/osx-only/autobuilder/only-tests/diagnostics.expected
@@ -1,0 +1,18 @@
+{
+  "helpLinks": [
+    "https://docs.github.com/en/enterprise-server/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/customizing-code-scanning",
+    "https://docs.github.com/en/enterprise-server/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-the-codeql-workflow-for-compiled-languages#adding-build-steps-for-a-compiled-language"
+  ],
+  "plaintextMessage": "All targets found within Xcode projects or workspaces either have no Swift sources or are tests.\n\nSet up a manual build command.",
+  "severity": "error",
+  "source": {
+    "extractorName": "swift",
+    "id": "swift/autobuilder/no-swift-target",
+    "name": "No Swift compilation target found"
+  },
+  "visibility": {
+    "cliSummaryTable": true,
+    "statusPage": true,
+    "telemetry": true
+  }
+}

--- a/swift/integration-tests/osx-only/autobuilder/only-tests/hello-tests.xcodeproj/project.pbxproj
+++ b/swift/integration-tests/osx-only/autobuilder/only-tests/hello-tests.xcodeproj/project.pbxproj
@@ -1,0 +1,430 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		57B14B762A0A881B002820C5 /* hello_testsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B14B752A0A881B002820C5 /* hello_testsTests.swift */; };
+		57B14B802A0A881B002820C5 /* hello_testsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B14B7F2A0A881B002820C5 /* hello_testsUITests.swift */; };
+		57B14B822A0A881B002820C5 /* hello_testsUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B14B812A0A881B002820C5 /* hello_testsUITestsLaunchTests.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		57B14B632A0A8819002820C5 /* hello_testsApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = hello_testsApp.swift; sourceTree = "<group>"; };
+		57B14B652A0A8819002820C5 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		57B14B672A0A881B002820C5 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		57B14B6A2A0A881B002820C5 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		57B14B6C2A0A881B002820C5 /* hello_tests.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = hello_tests.entitlements; sourceTree = "<group>"; };
+		57B14B712A0A881B002820C5 /* hello-testsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "hello-testsTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		57B14B752A0A881B002820C5 /* hello_testsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = hello_testsTests.swift; sourceTree = "<group>"; };
+		57B14B7B2A0A881B002820C5 /* hello-testsUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "hello-testsUITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		57B14B7F2A0A881B002820C5 /* hello_testsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = hello_testsUITests.swift; sourceTree = "<group>"; };
+		57B14B812A0A881B002820C5 /* hello_testsUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = hello_testsUITestsLaunchTests.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		57B14B6E2A0A881B002820C5 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		57B14B782A0A881B002820C5 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		57B14B572A0A8819002820C5 = {
+			isa = PBXGroup;
+			children = (
+				57B14B622A0A8819002820C5 /* hello-tests */,
+				57B14B742A0A881B002820C5 /* hello-testsTests */,
+				57B14B7E2A0A881B002820C5 /* hello-testsUITests */,
+				57B14B612A0A8819002820C5 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		57B14B612A0A8819002820C5 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				57B14B712A0A881B002820C5 /* hello-testsTests.xctest */,
+				57B14B7B2A0A881B002820C5 /* hello-testsUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		57B14B622A0A8819002820C5 /* hello-tests */ = {
+			isa = PBXGroup;
+			children = (
+				57B14B632A0A8819002820C5 /* hello_testsApp.swift */,
+				57B14B652A0A8819002820C5 /* ContentView.swift */,
+				57B14B672A0A881B002820C5 /* Assets.xcassets */,
+				57B14B6C2A0A881B002820C5 /* hello_tests.entitlements */,
+				57B14B692A0A881B002820C5 /* Preview Content */,
+			);
+			path = "hello-tests";
+			sourceTree = "<group>";
+		};
+		57B14B692A0A881B002820C5 /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				57B14B6A2A0A881B002820C5 /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		57B14B742A0A881B002820C5 /* hello-testsTests */ = {
+			isa = PBXGroup;
+			children = (
+				57B14B752A0A881B002820C5 /* hello_testsTests.swift */,
+			);
+			path = "hello-testsTests";
+			sourceTree = "<group>";
+		};
+		57B14B7E2A0A881B002820C5 /* hello-testsUITests */ = {
+			isa = PBXGroup;
+			children = (
+				57B14B7F2A0A881B002820C5 /* hello_testsUITests.swift */,
+				57B14B812A0A881B002820C5 /* hello_testsUITestsLaunchTests.swift */,
+			);
+			path = "hello-testsUITests";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		57B14B702A0A881B002820C5 /* hello-testsTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 57B14B882A0A881B002820C5 /* Build configuration list for PBXNativeTarget "hello-testsTests" */;
+			buildPhases = (
+				57B14B6D2A0A881B002820C5 /* Sources */,
+				57B14B6E2A0A881B002820C5 /* Frameworks */,
+				57B14B6F2A0A881B002820C5 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "hello-testsTests";
+			productName = "hello-testsTests";
+			productReference = 57B14B712A0A881B002820C5 /* hello-testsTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		57B14B7A2A0A881B002820C5 /* hello-testsUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 57B14B8B2A0A881B002820C5 /* Build configuration list for PBXNativeTarget "hello-testsUITests" */;
+			buildPhases = (
+				57B14B772A0A881B002820C5 /* Sources */,
+				57B14B782A0A881B002820C5 /* Frameworks */,
+				57B14B792A0A881B002820C5 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "hello-testsUITests";
+			productName = "hello-testsUITests";
+			productReference = 57B14B7B2A0A881B002820C5 /* hello-testsUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		57B14B582A0A8819002820C5 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1430;
+				LastUpgradeCheck = 1430;
+				TargetAttributes = {
+					57B14B702A0A881B002820C5 = {
+						CreatedOnToolsVersion = 14.3;
+						TestTargetID = 57B14B5F2A0A8819002820C5;
+					};
+					57B14B7A2A0A881B002820C5 = {
+						CreatedOnToolsVersion = 14.3;
+						TestTargetID = 57B14B5F2A0A8819002820C5;
+					};
+				};
+			};
+			buildConfigurationList = 57B14B5B2A0A8819002820C5 /* Build configuration list for PBXProject "hello-tests" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 57B14B572A0A8819002820C5;
+			productRefGroup = 57B14B612A0A8819002820C5 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				57B14B702A0A881B002820C5 /* hello-testsTests */,
+				57B14B7A2A0A881B002820C5 /* hello-testsUITests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		57B14B6F2A0A881B002820C5 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		57B14B792A0A881B002820C5 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		57B14B6D2A0A881B002820C5 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				57B14B762A0A881B002820C5 /* hello_testsTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		57B14B772A0A881B002820C5 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				57B14B802A0A881B002820C5 /* hello_testsUITests.swift in Sources */,
+				57B14B822A0A881B002820C5 /* hello_testsUITestsLaunchTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		57B14B832A0A881B002820C5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 13.2;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		57B14B842A0A881B002820C5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 13.2;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+			};
+			name = Release;
+		};
+		57B14B892A0A881B002820C5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 13.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.hello-testsTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/hello-tests.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/hello-tests";
+			};
+			name = Debug;
+		};
+		57B14B8A2A0A881B002820C5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 13.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.hello-testsTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/hello-tests.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/hello-tests";
+			};
+			name = Release;
+		};
+		57B14B8C2A0A881B002820C5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.hello-testsUITests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TEST_TARGET_NAME = "hello-tests";
+			};
+			name = Debug;
+		};
+		57B14B8D2A0A881B002820C5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.hello-testsUITests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TEST_TARGET_NAME = "hello-tests";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		57B14B5B2A0A8819002820C5 /* Build configuration list for PBXProject "hello-tests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				57B14B832A0A881B002820C5 /* Debug */,
+				57B14B842A0A881B002820C5 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		57B14B882A0A881B002820C5 /* Build configuration list for PBXNativeTarget "hello-testsTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				57B14B892A0A881B002820C5 /* Debug */,
+				57B14B8A2A0A881B002820C5 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		57B14B8B2A0A881B002820C5 /* Build configuration list for PBXNativeTarget "hello-testsUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				57B14B8C2A0A881B002820C5 /* Debug */,
+				57B14B8D2A0A881B002820C5 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 57B14B582A0A8819002820C5 /* Project object */;
+}

--- a/swift/integration-tests/osx-only/autobuilder/only-tests/hello-tests.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/swift/integration-tests/osx-only/autobuilder/only-tests/hello-tests.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/swift/integration-tests/osx-only/autobuilder/only-tests/test.py
+++ b/swift/integration-tests/osx-only/autobuilder/only-tests/test.py
@@ -1,0 +1,5 @@
+from create_database_utils import *
+from diagnostics_test_utils import *
+
+run_codeql_database_create([], lang='swift', keep_trap=True, db=None, runFunction=runUnsuccessfully)
+check_diagnostics()

--- a/swift/xcode-autobuilder/XcodeProjectParser.cpp
+++ b/swift/xcode-autobuilder/XcodeProjectParser.cpp
@@ -1,5 +1,6 @@
 #include "swift/xcode-autobuilder/XcodeProjectParser.h"
 
+#include <array>
 #include <iostream>
 #include <filesystem>
 #include <unordered_map>
@@ -232,7 +233,6 @@ static std::unordered_map<std::string, std::vector<std::string>> collectWorkspac
   std::unordered_set<std::string> projectsBelongingToWorkspace;
   std::vector<fs::path> files = collectFiles(workingDir);
   for (auto& path : files) {
-    std::cerr << path.c_str() << '\n';
     if (path.extension() == ".xcworkspace") {
       auto projects = readProjectsFromWorkspace(path.string());
       for (auto& project : projects) {
@@ -243,11 +243,11 @@ static std::unordered_map<std::string, std::vector<std::string>> collectWorkspac
       // a package manifest must begin with a specific header comment
       // see https://docs.swift.org/package-manager/PackageDescription/PackageDescription.html
       static constexpr std::string_view packageHeader = "// swift-tools-version:";
-      char buffer[packageHeader.size()];
-      if (std::ifstream{path}.read(buffer, packageHeader.size()) && buffer == packageHeader) {
+      std::array<char, packageHeader.size()> buffer;
+      std::string_view bufferView{buffer.data(), buffer.size()};
+      if (std::ifstream{path}.read(buffer.data(), buffer.size()) && bufferView == packageHeader) {
         swiftPackageEncountered = true;
       }
-      std::cerr << "  " << std::string_view{buffer} << '\n';
     }
   }
   // Collect all projects not belonging to any workspace into a separate empty bucket

--- a/swift/xcode-autobuilder/XcodeProjectParser.cpp
+++ b/swift/xcode-autobuilder/XcodeProjectParser.cpp
@@ -243,7 +243,7 @@ static std::unordered_map<std::string, std::vector<std::string>> collectWorkspac
       // a package manifest must begin with a specific header comment
       // see https://docs.swift.org/package-manager/PackageDescription/PackageDescription.html
       static constexpr std::string_view packageHeader = "// swift-tools-version:";
-      std::array<char, packageHeader.size()> buffer;
+      std::array<char, packageHeader.size()> buffer{};
       std::string_view bufferView{buffer.data(), buffer.size()};
       if (std::ifstream{path}.read(buffer.data(), buffer.size()) && bufferView == packageHeader) {
         swiftPackageEncountered = true;

--- a/swift/xcode-autobuilder/XcodeProjectParser.cpp
+++ b/swift/xcode-autobuilder/XcodeProjectParser.cpp
@@ -9,21 +9,8 @@
 
 #include "swift/xcode-autobuilder/XcodeWorkspaceParser.h"
 #include "swift/xcode-autobuilder/CFHelpers.h"
-#include "swift/logging/SwiftLogging.h"
-#include "swift/xcode-autobuilder/CustomizingBuildDiagnostics.h"
-
-namespace codeql_diagnostics {
-constexpr codeql::SwiftDiagnosticsSource no_project_found{
-    "no_project_found", "No Xcode project or workspace detected", customizingBuildAction,
-    customizingBuildHelpLinks};
-}  // namespace codeql_diagnostics
 
 namespace fs = std::filesystem;
-
-static codeql::Logger& logger() {
-  static codeql::Logger ret{"project"};
-  return ret;
-}
 
 struct TargetData {
   std::string workspace;
@@ -31,14 +18,14 @@ struct TargetData {
   std::string type;
 };
 
-typedef std::unordered_map<std::string, CFDictionaryRef> Targets;
-typedef std::unordered_map<std::string, std::vector<std::string>> Dependencies;
-typedef std::unordered_map<std::string, std::vector<std::pair<std::string, CFDictionaryRef>>>
-    BuildFiles;
+using TargetMap = std::unordered_map<std::string, CFDictionaryRef>;
+using DependencyMap = std::unordered_map<std::string, std::vector<std::string>>;
+using FileMap =
+    std::unordered_map<std::string, std::vector<std::pair<std::string, CFDictionaryRef>>>;
 
 static size_t totalFilesCount(const std::string& target,
-                              const Dependencies& dependencies,
-                              const BuildFiles& buildFiles) {
+                              const DependencyMap& dependencies,
+                              const FileMap& buildFiles) {
   size_t sum = buildFiles.at(target).size();
   for (auto& dep : dependencies.at(target)) {
     sum += totalFilesCount(dep, dependencies, buildFiles);
@@ -61,9 +48,9 @@ static bool objectIsTarget(CFDictionaryRef object) {
 
 static void mapTargetsToSourceFiles(CFDictionaryRef objects,
                                     std::unordered_map<std::string, size_t>& fileCounts) {
-  Targets targets;
-  Dependencies dependencies;
-  BuildFiles buildFiles;
+  TargetMap targets;
+  DependencyMap dependencies;
+  FileMap buildFiles;
 
   auto kv = CFKeyValues::fromDictionary(objects);
   for (size_t i = 0; i < kv.size; i++) {
@@ -213,42 +200,54 @@ static std::unordered_map<std::string, TargetData> mapTargetsToWorkspace(
 static std::vector<fs::path> collectFiles(const std::string& workingDir) {
   fs::path workDir(workingDir);
   std::vector<fs::path> files;
-  auto iterator = fs::recursive_directory_iterator(workDir);
   auto end = fs::recursive_directory_iterator();
-  for (; iterator != end; iterator++) {
-    auto filename = iterator->path().filename();
-    if (filename == "DerivedData" || filename == ".git" || filename == "build") {
+  for (auto it = fs::recursive_directory_iterator(workDir); it != end; ++it) {
+    const auto& p = it->path();
+    if (p.filename() == "Package.swift") {
+      files.push_back(p);
+      continue;
+    }
+    if (!it->is_directory()) {
+      continue;
+    }
+    if (p.filename() == "DerivedData" || p.filename() == ".git" || p.filename() == "build") {
       // Skip these folders
-      iterator.disable_recursion_pending();
+      it.disable_recursion_pending();
       continue;
     }
-    auto dirEntry = *iterator;
-    if (!dirEntry.is_directory()) {
-      continue;
+    if (p.extension() == ".xcodeproj" || p.extension() == ".xcworkspace") {
+      files.push_back(p);
     }
-    if (dirEntry.path().extension() != fs::path(".xcodeproj") &&
-        dirEntry.path().extension() != fs::path(".xcworkspace")) {
-      continue;
-    }
-    files.push_back(dirEntry.path());
   }
   return files;
 }
 
 static std::unordered_map<std::string, std::vector<std::string>> collectWorkspaces(
-    const std::string& workingDir) {
+    const std::string& workingDir,
+    bool& swiftPackageEncountered) {
   // Here we are collecting list of all workspaces and Xcode projects corresponding to them
   // Projects without workspaces go into the same "empty-workspace" bucket
+  swiftPackageEncountered = false;
   std::unordered_map<std::string, std::vector<std::string>> workspaces;
   std::unordered_set<std::string> projectsBelongingToWorkspace;
   std::vector<fs::path> files = collectFiles(workingDir);
   for (auto& path : files) {
+    std::cerr << path.c_str() << '\n';
     if (path.extension() == ".xcworkspace") {
       auto projects = readProjectsFromWorkspace(path.string());
       for (auto& project : projects) {
         projectsBelongingToWorkspace.insert(project.string());
         workspaces[path.string()].push_back(project.string());
       }
+    } else if (!swiftPackageEncountered && path.filename() == "Package.swift") {
+      // a package manifest must begin with a specific header comment
+      // see https://docs.swift.org/package-manager/PackageDescription/PackageDescription.html
+      static constexpr std::string_view packageHeader = "// swift-tools-version:";
+      char buffer[packageHeader.size()];
+      if (std::ifstream{path}.read(buffer, packageHeader.size()) && buffer == packageHeader) {
+        swiftPackageEncountered = true;
+      }
+      std::cerr << "  " << std::string_view{buffer} << '\n';
     }
   }
   // Collect all projects not belonging to any workspace into a separate empty bucket
@@ -263,12 +262,13 @@ static std::unordered_map<std::string, std::vector<std::string>> collectWorkspac
   return workspaces;
 }
 
-std::vector<Target> collectTargets(const std::string& workingDir) {
+Targets collectTargets(const std::string& workingDir) {
+  Targets ret;
   // Getting a list of workspaces and the project that belong to them
-  auto workspaces = collectWorkspaces(workingDir);
-  if (workspaces.empty()) {
-    DIAGNOSE_ERROR(no_project_found, "No Xcode project or workspace was found");
-    exit(1);
+  auto workspaces = collectWorkspaces(workingDir, ret.swiftPackageEncountered);
+  ret.xcodeEncountered = !workspaces.empty();
+  if (!ret.xcodeEncountered) {
+    return ret;
   }
 
   // Mapping each target to the workspace/project it belongs to
@@ -277,11 +277,9 @@ std::vector<Target> collectTargets(const std::string& workingDir) {
   // Mapping each target to the number of source files it contains
   auto targetFilesMapping = mapTargetsToSourceFiles(workspaces);
 
-  std::vector<Target> targets;
-
   for (auto& [targetName, data] : targetMapping) {
-    targets.push_back(Target{data.workspace, data.project, targetName, data.type,
-                             targetFilesMapping[targetName]});
+    ret.targets.push_back(Target{data.workspace, data.project, targetName, data.type,
+                                 targetFilesMapping[targetName]});
   }
-  return targets;
+  return ret;
 }

--- a/swift/xcode-autobuilder/XcodeProjectParser.h
+++ b/swift/xcode-autobuilder/XcodeProjectParser.h
@@ -4,4 +4,10 @@
 #include <vector>
 #include <string>
 
-std::vector<Target> collectTargets(const std::string& workingDir);
+struct Targets {
+  std::vector<Target> targets;
+  bool xcodeEncountered;
+  bool swiftPackageEncountered;
+};
+
+Targets collectTargets(const std::string& workingDir);

--- a/swift/xcode-autobuilder/XcodeTarget.h
+++ b/swift/xcode-autobuilder/XcodeTarget.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <binlog/adapt_struct.hpp>
 
 struct Target {
   std::string workspace;
@@ -9,3 +10,5 @@ struct Target {
   std::string type;
   size_t fileCount;
 };
+
+BINLOG_ADAPT_STRUCT(Target, workspace, project, name, type, fileCount);

--- a/swift/xcode-autobuilder/tests/autobuild_tester.py
+++ b/swift/xcode-autobuilder/tests/autobuild_tester.py
@@ -11,11 +11,14 @@ test_dir = pathlib.Path(sys.argv[2])
 expected = test_dir / 'commands.expected'
 actual = pathlib.Path('commands.actual')
 
-with open(actual, 'wb') as out:
-    ret = subprocess.run([str(autobuilder), '-dry-run', '.'], capture_output=True, check=True, cwd=test_dir)
+os.environ["CODEQL_EXTRACTOR_SWIFT_LOG_LEVELS"] = "text:no_logs,diagnostics:no_logs,console:info"
+
+with open(actual, 'w') as out:
+    ret = subprocess.run([str(autobuilder), '-dry-run', '.'], stdout=subprocess.PIPE,
+                         check=True, cwd=test_dir, text=True)
     for line in ret.stdout.splitlines():
         out.write(line.rstrip())
-        out.write(b'\n')
+        out.write('\n')
 
 subprocess.run(['diff', '-u', expected, actual], check=True)
 

--- a/swift/xcode-autobuilder/tests/hello-tests/commands.expected
+++ b/swift/xcode-autobuilder/tests/hello-tests/commands.expected
@@ -1,0 +1,1 @@
+/usr/bin/xcodebuild build -project ./hello-tests.xcodeproj -target hello-tests CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO

--- a/swift/xcode-autobuilder/tests/hello-tests/hello-tests.xcodeproj/project.pbxproj
+++ b/swift/xcode-autobuilder/tests/hello-tests/hello-tests.xcodeproj/project.pbxproj
@@ -1,0 +1,573 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		57B14B642A0A8819002820C5 /* hello_testsApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B14B632A0A8819002820C5 /* hello_testsApp.swift */; };
+		57B14B662A0A8819002820C5 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B14B652A0A8819002820C5 /* ContentView.swift */; };
+		57B14B682A0A881B002820C5 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 57B14B672A0A881B002820C5 /* Assets.xcassets */; };
+		57B14B6B2A0A881B002820C5 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 57B14B6A2A0A881B002820C5 /* Preview Assets.xcassets */; };
+		57B14B762A0A881B002820C5 /* hello_testsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B14B752A0A881B002820C5 /* hello_testsTests.swift */; };
+		57B14B802A0A881B002820C5 /* hello_testsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B14B7F2A0A881B002820C5 /* hello_testsUITests.swift */; };
+		57B14B822A0A881B002820C5 /* hello_testsUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B14B812A0A881B002820C5 /* hello_testsUITestsLaunchTests.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		57B14B722A0A881B002820C5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 57B14B582A0A8819002820C5 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 57B14B5F2A0A8819002820C5;
+			remoteInfo = "hello-tests";
+		};
+		57B14B7C2A0A881B002820C5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 57B14B582A0A8819002820C5 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 57B14B5F2A0A8819002820C5;
+			remoteInfo = "hello-tests";
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		57B14B602A0A8819002820C5 /* hello-tests.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "hello-tests.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		57B14B632A0A8819002820C5 /* hello_testsApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = hello_testsApp.swift; sourceTree = "<group>"; };
+		57B14B652A0A8819002820C5 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		57B14B672A0A881B002820C5 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		57B14B6A2A0A881B002820C5 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		57B14B6C2A0A881B002820C5 /* hello_tests.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = hello_tests.entitlements; sourceTree = "<group>"; };
+		57B14B712A0A881B002820C5 /* hello-testsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "hello-testsTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		57B14B752A0A881B002820C5 /* hello_testsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = hello_testsTests.swift; sourceTree = "<group>"; };
+		57B14B7B2A0A881B002820C5 /* hello-testsUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "hello-testsUITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		57B14B7F2A0A881B002820C5 /* hello_testsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = hello_testsUITests.swift; sourceTree = "<group>"; };
+		57B14B812A0A881B002820C5 /* hello_testsUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = hello_testsUITestsLaunchTests.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		57B14B5D2A0A8819002820C5 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		57B14B6E2A0A881B002820C5 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		57B14B782A0A881B002820C5 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		57B14B572A0A8819002820C5 = {
+			isa = PBXGroup;
+			children = (
+				57B14B622A0A8819002820C5 /* hello-tests */,
+				57B14B742A0A881B002820C5 /* hello-testsTests */,
+				57B14B7E2A0A881B002820C5 /* hello-testsUITests */,
+				57B14B612A0A8819002820C5 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		57B14B612A0A8819002820C5 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				57B14B602A0A8819002820C5 /* hello-tests.app */,
+				57B14B712A0A881B002820C5 /* hello-testsTests.xctest */,
+				57B14B7B2A0A881B002820C5 /* hello-testsUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		57B14B622A0A8819002820C5 /* hello-tests */ = {
+			isa = PBXGroup;
+			children = (
+				57B14B632A0A8819002820C5 /* hello_testsApp.swift */,
+				57B14B652A0A8819002820C5 /* ContentView.swift */,
+				57B14B672A0A881B002820C5 /* Assets.xcassets */,
+				57B14B6C2A0A881B002820C5 /* hello_tests.entitlements */,
+				57B14B692A0A881B002820C5 /* Preview Content */,
+			);
+			path = "hello-tests";
+			sourceTree = "<group>";
+		};
+		57B14B692A0A881B002820C5 /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				57B14B6A2A0A881B002820C5 /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		57B14B742A0A881B002820C5 /* hello-testsTests */ = {
+			isa = PBXGroup;
+			children = (
+				57B14B752A0A881B002820C5 /* hello_testsTests.swift */,
+			);
+			path = "hello-testsTests";
+			sourceTree = "<group>";
+		};
+		57B14B7E2A0A881B002820C5 /* hello-testsUITests */ = {
+			isa = PBXGroup;
+			children = (
+				57B14B7F2A0A881B002820C5 /* hello_testsUITests.swift */,
+				57B14B812A0A881B002820C5 /* hello_testsUITestsLaunchTests.swift */,
+			);
+			path = "hello-testsUITests";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		57B14B5F2A0A8819002820C5 /* hello-tests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 57B14B852A0A881B002820C5 /* Build configuration list for PBXNativeTarget "hello-tests" */;
+			buildPhases = (
+				57B14B5C2A0A8819002820C5 /* Sources */,
+				57B14B5D2A0A8819002820C5 /* Frameworks */,
+				57B14B5E2A0A8819002820C5 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "hello-tests";
+			productName = "hello-tests";
+			productReference = 57B14B602A0A8819002820C5 /* hello-tests.app */;
+			productType = "com.apple.product-type.application";
+		};
+		57B14B702A0A881B002820C5 /* hello-testsTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 57B14B882A0A881B002820C5 /* Build configuration list for PBXNativeTarget "hello-testsTests" */;
+			buildPhases = (
+				57B14B6D2A0A881B002820C5 /* Sources */,
+				57B14B6E2A0A881B002820C5 /* Frameworks */,
+				57B14B6F2A0A881B002820C5 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				57B14B732A0A881B002820C5 /* PBXTargetDependency */,
+			);
+			name = "hello-testsTests";
+			productName = "hello-testsTests";
+			productReference = 57B14B712A0A881B002820C5 /* hello-testsTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		57B14B7A2A0A881B002820C5 /* hello-testsUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 57B14B8B2A0A881B002820C5 /* Build configuration list for PBXNativeTarget "hello-testsUITests" */;
+			buildPhases = (
+				57B14B772A0A881B002820C5 /* Sources */,
+				57B14B782A0A881B002820C5 /* Frameworks */,
+				57B14B792A0A881B002820C5 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				57B14B7D2A0A881B002820C5 /* PBXTargetDependency */,
+			);
+			name = "hello-testsUITests";
+			productName = "hello-testsUITests";
+			productReference = 57B14B7B2A0A881B002820C5 /* hello-testsUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		57B14B582A0A8819002820C5 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1430;
+				LastUpgradeCheck = 1430;
+				TargetAttributes = {
+					57B14B5F2A0A8819002820C5 = {
+						CreatedOnToolsVersion = 14.3;
+					};
+					57B14B702A0A881B002820C5 = {
+						CreatedOnToolsVersion = 14.3;
+						TestTargetID = 57B14B5F2A0A8819002820C5;
+					};
+					57B14B7A2A0A881B002820C5 = {
+						CreatedOnToolsVersion = 14.3;
+						TestTargetID = 57B14B5F2A0A8819002820C5;
+					};
+				};
+			};
+			buildConfigurationList = 57B14B5B2A0A8819002820C5 /* Build configuration list for PBXProject "hello-tests" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 57B14B572A0A8819002820C5;
+			productRefGroup = 57B14B612A0A8819002820C5 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				57B14B5F2A0A8819002820C5 /* hello-tests */,
+				57B14B702A0A881B002820C5 /* hello-testsTests */,
+				57B14B7A2A0A881B002820C5 /* hello-testsUITests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		57B14B5E2A0A8819002820C5 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				57B14B6B2A0A881B002820C5 /* Preview Assets.xcassets in Resources */,
+				57B14B682A0A881B002820C5 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		57B14B6F2A0A881B002820C5 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		57B14B792A0A881B002820C5 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		57B14B5C2A0A8819002820C5 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				57B14B662A0A8819002820C5 /* ContentView.swift in Sources */,
+				57B14B642A0A8819002820C5 /* hello_testsApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		57B14B6D2A0A881B002820C5 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				57B14B762A0A881B002820C5 /* hello_testsTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		57B14B772A0A881B002820C5 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				57B14B802A0A881B002820C5 /* hello_testsUITests.swift in Sources */,
+				57B14B822A0A881B002820C5 /* hello_testsUITestsLaunchTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		57B14B732A0A881B002820C5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 57B14B5F2A0A8819002820C5 /* hello-tests */;
+			targetProxy = 57B14B722A0A881B002820C5 /* PBXContainerItemProxy */;
+		};
+		57B14B7D2A0A881B002820C5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 57B14B5F2A0A8819002820C5 /* hello-tests */;
+			targetProxy = 57B14B7C2A0A881B002820C5 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		57B14B832A0A881B002820C5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 13.2;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		57B14B842A0A881B002820C5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 13.2;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+			};
+			name = Release;
+		};
+		57B14B862A0A881B002820C5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = "hello-tests/hello_tests.entitlements";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"hello-tests/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.hello-tests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		57B14B872A0A881B002820C5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = "hello-tests/hello_tests.entitlements";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"hello-tests/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.hello-tests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		57B14B892A0A881B002820C5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 13.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.hello-testsTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/hello-tests.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/hello-tests";
+			};
+			name = Debug;
+		};
+		57B14B8A2A0A881B002820C5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 13.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.hello-testsTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/hello-tests.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/hello-tests";
+			};
+			name = Release;
+		};
+		57B14B8C2A0A881B002820C5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.hello-testsUITests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TEST_TARGET_NAME = "hello-tests";
+			};
+			name = Debug;
+		};
+		57B14B8D2A0A881B002820C5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.hello-testsUITests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TEST_TARGET_NAME = "hello-tests";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		57B14B5B2A0A8819002820C5 /* Build configuration list for PBXProject "hello-tests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				57B14B832A0A881B002820C5 /* Debug */,
+				57B14B842A0A881B002820C5 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		57B14B852A0A881B002820C5 /* Build configuration list for PBXNativeTarget "hello-tests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				57B14B862A0A881B002820C5 /* Debug */,
+				57B14B872A0A881B002820C5 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		57B14B882A0A881B002820C5 /* Build configuration list for PBXNativeTarget "hello-testsTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				57B14B892A0A881B002820C5 /* Debug */,
+				57B14B8A2A0A881B002820C5 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		57B14B8B2A0A881B002820C5 /* Build configuration list for PBXNativeTarget "hello-testsUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				57B14B8C2A0A881B002820C5 /* Debug */,
+				57B14B8D2A0A881B002820C5 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 57B14B582A0A8819002820C5 /* Project object */;
+}

--- a/swift/xcode-autobuilder/tests/hello-tests/hello-tests.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/swift/xcode-autobuilder/tests/hello-tests/hello-tests.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/swift/xcode-autobuilder/xcode-autobuilder.cpp
+++ b/swift/xcode-autobuilder/xcode-autobuilder.cpp
@@ -5,11 +5,23 @@
 #include "swift/xcode-autobuilder/XcodeBuildRunner.h"
 #include "swift/xcode-autobuilder/XcodeProjectParser.h"
 #include "swift/logging/SwiftLogging.h"
+#include "swift/xcode-autobuilder/CustomizingBuildDiagnostics.h"
 
-static const char* Application = "com.apple.product-type.application";
-static const char* Framework = "com.apple.product-type.framework";
+static const char* uiTest = "com.apple.product-type.bundle.ui-testing";
+static const char* unitTest = "com.apple.product-type.bundle.unit-test";
 
 const std::string_view codeql::programName = "autobuilder";
+
+namespace codeql_diagnostics {
+constexpr codeql::SwiftDiagnosticsSource no_swift_target{
+    "no_swift_target", "No Swift compilation target found", customizingBuildAction,
+    customizingBuildHelpLinks};
+}  // namespace codeql_diagnostics
+
+static codeql::Logger& logger() {
+  static codeql::Logger ret{"main"};
+  return ret;
+}
 
 struct CLIArgs {
   std::string workingDir;
@@ -18,11 +30,13 @@ struct CLIArgs {
 
 static void autobuild(const CLIArgs& args) {
   auto targets = collectTargets(args.workingDir);
-
-  // Filter out non-application/framework targets
+  for (const auto& t : targets) {
+    LOG_INFO("{}", t);
+  }
+  // Filter out targets that are tests or have no swift source files
   targets.erase(std::remove_if(std::begin(targets), std::end(targets),
                                [&](Target& t) -> bool {
-                                 return t.type != Application && t.type != Framework;
+                                 return t.fileCount == 0 || t.type == uiTest || t.type == unitTest;
                                }),
                 std::end(targets));
 
@@ -30,15 +44,12 @@ static void autobuild(const CLIArgs& args) {
   std::sort(std::begin(targets), std::end(targets),
             [](Target& lhs, Target& rhs) { return lhs.fileCount > rhs.fileCount; });
 
-  for (auto& t : targets) {
-    std::cerr << t.workspace << " " << t.project << " " << t.type << " " << t.name << " "
-              << t.fileCount << "\n";
-  }
   if (targets.empty()) {
-    std::cerr << "[xcode autobuilder] Suitable targets not found\n";
+    DIAGNOSE_ERROR(no_swift_target, "All targets found within Xcode projects or workspaces either "
+                                    "have no Swift sources or are tests");
     exit(1);
   }
-
+  LOG_INFO("Selected {}", targets.front());
   buildTarget(targets.front(), args.dryRun);
 }
 
@@ -61,5 +72,6 @@ static CLIArgs parseCLIArgs(int argc, char** argv) {
 int main(int argc, char** argv) {
   auto args = parseCLIArgs(argc, argv);
   autobuild(args);
+  codeql::Log::flush();
   return 0;
 }


### PR DESCRIPTION
This introduces two new diagnostics source: no viable swift targets found (when no non-test target with Swift source is found within the Xcode project or workspace) and a message about autobuilder not supporting SPM yet.

This changes the target selection: while before we were selecting Application and Framework target only, without looking at the swift count, now we allow more target types, excluding those that are either test targets or have no Swift source.