### PR TITLE
JS: Prevent join order regression

### DIFF
--- a/javascript/ql/lib/semmle/javascript/security/dataflow/SecondOrderCommandInjectionCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/SecondOrderCommandInjectionCustomizations.qll
@@ -117,6 +117,7 @@ module SecondOrderCommandInjection {
     int cmdIndex;
     int argIndex;
 
+    pragma[assume_small_delta]
     IndirectCmdFunc() {
       exists(CommandExecutingCall call |
         this.getParameter(cmdIndex).flowsTo(call.getCommandArg()) and


### PR DESCRIPTION
Add pragma to prevent join order regressions from planned tweaks to the join ordering heuristic.