### PR TITLE
Java: Make inputStreamWrapper consider supertypes transitively

### DIFF
--- a/java/ql/lib/change-notes/2023-05-22-inputstreamwrapper-transitive.md
+++ b/java/ql/lib/change-notes/2023-05-22-inputstreamwrapper-transitive.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Dataflow analysis has a new flow step through constructors of transitive subtypes of `java.io.InputStream` that wrap an underlying data source. Previously, the step only existed for direct subtypes of `java.io.InputStream`.

--- a/java/ql/lib/semmle/code/java/dataflow/internal/TaintTrackingUtil.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/TaintTrackingUtil.qll
@@ -255,6 +255,7 @@ private class BulkData extends RefType {
  * status of its argument.
  */
 private predicate inputStreamWrapper(Constructor c, int argi) {
+  not c.fromSource() and
   c.getParameterType(argi) instanceof BulkData and
   c.getDeclaringType().getASourceSupertype+().hasQualifiedName("java.io", "InputStream")
 }

--- a/java/ql/lib/semmle/code/java/dataflow/internal/TaintTrackingUtil.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/TaintTrackingUtil.qll
@@ -256,7 +256,7 @@ private class BulkData extends RefType {
  */
 private predicate inputStreamWrapper(Constructor c, int argi) {
   c.getParameterType(argi) instanceof BulkData and
-  c.getDeclaringType().getASourceSupertype*().hasQualifiedName("java.io", "InputStream")
+  c.getDeclaringType().getASourceSupertype+().hasQualifiedName("java.io", "InputStream")
 }
 
 /** An object construction that preserves the data flow status of any of its arguments. */

--- a/java/ql/lib/semmle/code/java/dataflow/internal/TaintTrackingUtil.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/TaintTrackingUtil.qll
@@ -256,7 +256,7 @@ private class BulkData extends RefType {
  */
 private predicate inputStreamWrapper(Constructor c, int argi) {
   c.getParameterType(argi) instanceof BulkData and
-  c.getDeclaringType().getASourceSupertype().hasQualifiedName("java.io", "InputStream")
+  c.getDeclaringType().getASourceSupertype*().hasQualifiedName("java.io", "InputStream")
 }
 
 /** An object construction that preserves the data flow status of any of its arguments. */


### PR DESCRIPTION
The `inputStreamWrapper` predicate considers constructors of a type that implements `java.io.InputStream` that receive a bulk-data-like argument (like another stream) to be likely dataflow steps. This PR makes it so that it also considers implementations of `java.io.InputStream` transitively, to cover cases like [`org.apache.commons.io.input.BOMInputStream`](https://commons.apache.org/proper/commons-io/javadocs/api-2.4/org/apache/commons/io/input/BOMInputStream.html).