### PR TITLE
Java: Add constraint to `HostnameSanitizingPrefix` to prevent false negatives in SSRF queries

### DIFF
--- a/java/ql/lib/change-notes/2023-05-17-change-hostnamesanitizingprefix-regex.md
+++ b/java/ql/lib/change-notes/2023-05-17-change-hostnamesanitizingprefix-regex.md
@@ -1,0 +1,5 @@
+---
+category: minorAnalysis
+---
+* Updated the regular expression in the `HostnameSanitizer` sanitizer in the `semmle.code.java.security.RequestForgery` library to better detect strings prefixed with a hostname.
+

--- a/java/ql/lib/semmle/code/java/security/RequestForgery.qll
+++ b/java/ql/lib/semmle/code/java/security/RequestForgery.qll
@@ -79,10 +79,7 @@ private class HostnameSanitizingPrefix extends InterestingPrefix {
     // the host or entity addressed: for example, anything containing `?` or `#`, or a slash that
     // doesn't appear to be a protocol specifier (e.g. `http://` is not sanitizing), or specifically
     // the string "/".
-    exists(
-      this.getStringValue()
-          .regexpFind(".*([?#]|[^?#:/\\\\][/\\\\]).*|[/\\\\][^/\\\\].*|^/$", 0, offset)
-    )
+    exists(this.getStringValue().regexpFind("([?#]|[^?#:/\\\\][/\\\\])|^/$", 0, offset))
   }
 
   override int getOffset() { result = offset }

--- a/java/ql/test/query-tests/security/CWE-918/SanitizationTests.java
+++ b/java/ql/test/query-tests/security/CWE-918/SanitizationTests.java
@@ -116,6 +116,9 @@ public class SanitizationTests extends HttpServlet {
             HttpRequest unsafer9 = HttpRequest.newBuilder(new URI(unsafeUri9)).build(); // $ SSRF
             client.send(unsafer9, null);
 
+            String unsafeUri10 = String.format("%s://%s:%s%s", "http", "myserver.com", "80", request.getParameter("baduri10"));
+            HttpRequest unsafer10 = HttpRequest.newBuilder(new URI(unsafeUri10)).build(); // $ SSRF
+            client.send(unsafer10, null);
         } catch (Exception e) {
             // TODO: handle exception
         }


### PR DESCRIPTION
Adds a check to make sure the sanitizing prefix is not the second `/` in the `://` of a protocol specifier.