### PR TITLE
Python: Update expected test output

### DIFF
--- a/python/ql/test/experimental/dataflow/variable-capture/dataflow-consistency.expected
+++ b/python/ql/test/experimental/dataflow/variable-capture/dataflow-consistency.expected
@@ -29,6 +29,6 @@ uniqueParameterNodeAtPosition
 uniqueParameterNodePosition
 uniqueContentApprox
 identityLocalStep
-| collections.py:36:10:36:15 | ControlFlowNode for SOURCE | Node steps to itself |
-| collections.py:45:19:45:21 | ControlFlowNode for mod | Node steps to itself |
-| collections.py:52:13:52:21 | ControlFlowNode for mod_local | Node steps to itself |
+| test_collections.py:36:10:36:15 | ControlFlowNode for SOURCE | Node steps to itself |
+| test_collections.py:45:19:45:21 | ControlFlowNode for mod | Node steps to itself |
+| test_collections.py:52:13:52:21 | ControlFlowNode for mod_local | Node steps to itself |


### PR DESCRIPTION
I am guessing this was introduced via a semantic merge conflict.