### PR TITLE
C++: Use heuristic allocation functions in `cpp/overrun-write`

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/models/implementations/Allocation.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/implementations/Allocation.qll
@@ -437,7 +437,7 @@ private module HeuristicAllocation {
     int sizeArg;
 
     HeuristicAllocationFunctionByName() {
-      Function.super.getName().matches("%alloc%") and
+      Function.super.getName().matches(["%alloc%", "%Alloc%"]) and
       Function.super.getUnspecifiedType() instanceof PointerType and
       sizeArg = unique( | | getAnUnsignedParameter(this))
     }

--- a/cpp/ql/src/experimental/Likely Bugs/OverrunWriteProductFlow.ql
+++ b/cpp/ql/src/experimental/Likely Bugs/OverrunWriteProductFlow.ql
@@ -47,7 +47,7 @@ VariableAccess getAVariableAccess(Expr e) { e.getAChild*() = result }
  * Holds if `(n, state)` pair represents the source of flow for the size
  * expression associated with `alloc`.
  */
-predicate hasSize(AllocationExpr alloc, DataFlow::Node n, int state) {
+predicate hasSize(HeuristicAllocationExpr alloc, DataFlow::Node n, int state) {
   exists(VariableAccess va, Expr size, int delta |
     size = alloc.getSizeExpr() and
     // Get the unique variable in a size expression like `x` in `malloc(x + 1)`.

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-119/OverrunWriteProductFlow.expected
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-119/OverrunWriteProductFlow.expected
@@ -222,6 +222,7 @@ edges
 | test.cpp:243:12:243:14 | str indirection [string] | test.cpp:243:12:243:21 | string |
 | test.cpp:243:12:243:14 | str indirection [string] | test.cpp:243:16:243:21 | string indirection |
 | test.cpp:243:16:243:21 | string indirection | test.cpp:243:12:243:21 | string |
+| test.cpp:249:20:249:27 | call to my_alloc | test.cpp:250:12:250:12 | p |
 nodes
 | test.cpp:16:11:16:21 | mk_string_t indirection [string] | semmle.label | mk_string_t indirection [string] |
 | test.cpp:18:5:18:30 | ... = ... | semmle.label | ... = ... |
@@ -402,6 +403,8 @@ nodes
 | test.cpp:243:12:243:14 | str indirection [string] | semmle.label | str indirection [string] |
 | test.cpp:243:12:243:21 | string | semmle.label | string |
 | test.cpp:243:16:243:21 | string indirection | semmle.label | string indirection |
+| test.cpp:249:20:249:27 | call to my_alloc | semmle.label | call to my_alloc |
+| test.cpp:250:12:250:12 | p | semmle.label | p |
 subpaths
 | test.cpp:242:22:242:27 | buffer | test.cpp:235:40:235:45 | buffer | test.cpp:236:12:236:17 | p_str indirection [post update] [string] | test.cpp:242:16:242:19 | set_string output argument [string] |
 #select
@@ -422,3 +425,4 @@ subpaths
 | test.cpp:207:9:207:15 | call to strncpy | test.cpp:147:19:147:24 | call to malloc | test.cpp:207:22:207:27 | string | This write may overflow $@ by 3 elements. | test.cpp:207:22:207:27 | string | string |
 | test.cpp:232:3:232:8 | call to memset | test.cpp:228:43:228:48 | call to malloc | test.cpp:232:10:232:15 | buffer | This write may overflow $@ by 32 elements. | test.cpp:232:10:232:15 | buffer | buffer |
 | test.cpp:243:5:243:10 | call to memset | test.cpp:241:27:241:32 | call to malloc | test.cpp:243:12:243:21 | string | This write may overflow $@ by 1 element. | test.cpp:243:16:243:21 | string | string |
+| test.cpp:250:5:250:10 | call to memset | test.cpp:249:20:249:27 | call to my_alloc | test.cpp:250:12:250:12 | p | This write may overflow $@ by 1 element. | test.cpp:250:12:250:12 | p | p |

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-119/test.cpp
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-119/test.cpp
@@ -243,3 +243,9 @@ void test_flow_through_setter(unsigned size) {
     memset(str.string, 0, size + 1); // BAD
 }
 
+void* my_alloc(unsigned size);
+
+void foo(unsigned size) {
+    int* p = (int*)my_alloc(size); // BAD [NOT DETECTED]
+    memset(p, 0, size + 1);
+}

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-119/test.cpp
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-119/test.cpp
@@ -246,6 +246,6 @@ void test_flow_through_setter(unsigned size) {
 void* my_alloc(unsigned size);
 
 void foo(unsigned size) {
-    int* p = (int*)my_alloc(size); // BAD [NOT DETECTED]
+    int* p = (int*)my_alloc(size); // BAD
     memset(p, 0, size + 1);
 }


### PR DESCRIPTION
This expands the set of sources for `cpp/overrun-write` by including heuristic allocation sources. On MRVA this gives about 40 new results - all of which look like good results 🎉.

As an extra bonus I expanded the heuristic to also consider function names including `"Alloc"` (instead of just `"alloc"`). This makes us catch allocations such as these ones: https://github.com/tianocore/edk2/blob/5215cd5baf6609e54050c69909273b7f5161c59e/BaseTools/Source/C/DevicePath/DevicePathUtilities.c#L729-L729 and https://github.com/NVIDIA/open-gpu-kernel-modules/blob/6dd092ddb7c165fb1ec48b937fa6b33daa37f9c1/src/nvidia/src/kernel/platform/nbsi/nbsi_init.c#L2656-L2656