### PR TITLE
C#: Enable implicit this receiver warnings

### DIFF
--- a/csharp/ql/lib/qlpack.yml
+++ b/csharp/ql/lib/qlpack.yml
@@ -12,3 +12,4 @@ dependencies:
 dataExtensions:
   - ext/*.model.yml
   - ext/generated/*.model.yml
+warnOnImplicitThis: true

--- a/csharp/ql/src/qlpack.yml
+++ b/csharp/ql/src/qlpack.yml
@@ -10,3 +10,4 @@ dependencies:
   codeql/csharp-all: ${workspace}
   codeql/suite-helpers: ${workspace}
   codeql/util: ${workspace}
+warnOnImplicitThis: true

--- a/csharp/ql/test/qlpack.yml
+++ b/csharp/ql/test/qlpack.yml
@@ -5,3 +5,4 @@ dependencies:
   codeql/csharp-queries: ${workspace}
 extractor: csharp
 tests: .
+warnOnImplicitThis: true


### PR DESCRIPTION
Enable warnings for member predicate calls with implicit this receivers for C# to prevent them from reappearing.