### PR TITLE
C++: Enable implicit this warnings

### DIFF
--- a/cpp/ql/lib/qlpack.yml
+++ b/cpp/ql/lib/qlpack.yml
@@ -9,3 +9,4 @@ dependencies:
   codeql/ssa: ${workspace}
   codeql/tutorial: ${workspace}
   codeql/util: ${workspace}
+warnOnImplicitThis: true

--- a/cpp/ql/lib/semmle/code/cpp/controlflow/StackVariableReachability.qll
+++ b/cpp/ql/lib/semmle/code/cpp/controlflow/StackVariableReachability.qll
@@ -25,7 +25,7 @@ import cpp
  */
 abstract class StackVariableReachability extends string {
   bindingset[this]
-  StackVariableReachability() { length() >= 0 }
+  StackVariableReachability() { this.length() >= 0 }
 
   /** Holds if `node` is a source for the reachability analysis using variable `v`. */
   abstract predicate isSource(ControlFlowNode node, StackVariable v);
@@ -227,7 +227,7 @@ predicate bbSuccessorEntryReachesLoopInvariant(
  */
 abstract class StackVariableReachabilityWithReassignment extends StackVariableReachability {
   bindingset[this]
-  StackVariableReachabilityWithReassignment() { length() >= 0 }
+  StackVariableReachabilityWithReassignment() { this.length() >= 0 }
 
   /** Override this predicate rather than `isSource` (`isSource` is used internally). */
   abstract predicate isSourceActual(ControlFlowNode node, StackVariable v);
@@ -330,7 +330,7 @@ abstract class StackVariableReachabilityWithReassignment extends StackVariableRe
  */
 abstract class StackVariableReachabilityExt extends string {
   bindingset[this]
-  StackVariableReachabilityExt() { length() >= 0 }
+  StackVariableReachabilityExt() { this.length() >= 0 }
 
   /** `node` is a source for the reachability analysis using variable `v`. */
   abstract predicate isSource(ControlFlowNode node, StackVariable v);

--- a/cpp/ql/lib/semmle/code/cpp/rangeanalysis/new/internal/semantic/analysis/RangeAnalysisStage.qll
+++ b/cpp/ql/lib/semmle/code/cpp/rangeanalysis/new/internal/semantic/analysis/RangeAnalysisStage.qll
@@ -277,7 +277,7 @@ module RangeStage<
    */
   private class SafeCastExpr extends ConvertOrBoxExpr {
     SafeCastExpr() {
-      conversionCannotOverflow(getTrackedType(pragma[only_bind_into](getOperand())),
+      conversionCannotOverflow(getTrackedType(pragma[only_bind_into](this.getOperand())),
         pragma[only_bind_out](getTrackedType(this)))
     }
   }

--- a/cpp/ql/src/qlpack.yml
+++ b/cpp/ql/src/qlpack.yml
@@ -10,3 +10,4 @@ dependencies:
 suites: codeql-suites
 extractor: cpp
 defaultSuiteFile: codeql-suites/cpp-code-scanning.qls
+warnOnImplicitThis: true

--- a/cpp/ql/test/qlpack.yml
+++ b/cpp/ql/test/qlpack.yml
@@ -5,3 +5,4 @@ dependencies:
   codeql/cpp-queries: ${workspace}
 extractor: cpp
 tests: .
+warnOnImplicitThis: true


### PR DESCRIPTION
Enable warnings for member predicate calls with implicit this receivers for C++ to prevent them from reappearing.