### PR TITLE
Swift: Make implicit this receivers explicit

### DIFF
--- a/swift/ql/lib/codeql/swift/elements/AvailabilityInfo.qll
+++ b/swift/ql/lib/codeql/swift/elements/AvailabilityInfo.qll
@@ -2,8 +2,8 @@ private import codeql.swift.generated.AvailabilityInfo
 
 class AvailabilityInfo extends Generated::AvailabilityInfo {
   override string toString() {
-    result = "#available" and not isUnavailable()
+    result = "#available" and not this.isUnavailable()
     or
-    result = "#unavailable" and isUnavailable()
+    result = "#unavailable" and this.isUnavailable()
   }
 }

--- a/swift/ql/lib/codeql/swift/elements/KeyPathComponent.qll
+++ b/swift/ql/lib/codeql/swift/elements/KeyPathComponent.qll
@@ -5,37 +5,37 @@ class KeyPathComponent extends Generated::KeyPathComponent {
   /**
    * Property access like `.bar` in `\Foo.bar`.
    */
-  predicate isProperty() { getKind() = 3 }
+  predicate isProperty() { this.getKind() = 3 }
 
   /**
    * Array or dictionary subscript like `[1]` or `["a", "b"]`.
    */
-  predicate isSubscript() { getKind() = 4 }
+  predicate isSubscript() { this.getKind() = 4 }
 
   /**
    * Optional forcing `!`.
    */
-  predicate isOptionalForcing() { getKind() = 5 }
+  predicate isOptionalForcing() { this.getKind() = 5 }
 
   /**
    * Optional chaining `?`.
    */
-  predicate isOptionalChaining() { getKind() = 6 }
+  predicate isOptionalChaining() { this.getKind() = 6 }
 
   /**
    * Implicit optional wrapping component inserted by the compiler when an optional chain ends in a non-optional value.
    */
-  predicate isOptionalWrapping() { getKind() = 7 }
+  predicate isOptionalWrapping() { this.getKind() = 7 }
 
   /**
    * Reference to the entire object; the `self` in `\Foo.self`.
    */
-  predicate isSelf() { getKind() = 8 }
+  predicate isSelf() { this.getKind() = 8 }
 
   /**
    * Tuple indexing like `.1`.
    */
-  predicate isTupleIndexing() { getKind() = 9 }
+  predicate isTupleIndexing() { this.getKind() = 9 }
 
   /** Gets the underlying key-path expression which this is a component of. */
   KeyPathExpr getKeyPathExpr() { result.getAComponent() = this }

--- a/swift/ql/lib/codeql/swift/elements/Locatable.qll
+++ b/swift/ql/lib/codeql/swift/elements/Locatable.qll
@@ -14,5 +14,5 @@ class Locatable extends Generated::Locatable {
   /**
    * Gets the primary file where this element occurs.
    */
-  File getFile() { result = getLocation().getFile() }
+  File getFile() { result = this.getLocation().getFile() }
 }

--- a/swift/ql/lib/codeql/swift/elements/PlatformVersionAvailabilitySpec.qll
+++ b/swift/ql/lib/codeql/swift/elements/PlatformVersionAvailabilitySpec.qll
@@ -1,5 +1,5 @@
 private import codeql.swift.generated.PlatformVersionAvailabilitySpec
 
 class PlatformVersionAvailabilitySpec extends Generated::PlatformVersionAvailabilitySpec {
-  override string toString() { result = getPlatform() + " " + getVersion() }
+  override string toString() { result = this.getPlatform() + " " + this.getVersion() }
 }

--- a/swift/ql/lib/codeql/swift/elements/decl/ExtensionDecl.qll
+++ b/swift/ql/lib/codeql/swift/elements/decl/ExtensionDecl.qll
@@ -2,9 +2,9 @@ private import codeql.swift.generated.decl.ExtensionDecl
 
 class ExtensionDecl extends Generated::ExtensionDecl {
   override string toString() {
-    result = "extension of " + getExtendedTypeDecl().toString()
+    result = "extension of " + this.getExtendedTypeDecl().toString()
     or
-    not exists(getExtendedTypeDecl()) and
+    not exists(this.getExtendedTypeDecl()) and
     result = "extension"
   }
 }

--- a/swift/ql/lib/codeql/swift/elements/expr/IdentityExpr.qll
+++ b/swift/ql/lib/codeql/swift/elements/expr/IdentityExpr.qll
@@ -1,5 +1,5 @@
 private import codeql.swift.generated.expr.IdentityExpr
 
 class IdentityExpr extends Generated::IdentityExpr {
-  override predicate convertsFrom(Expr e) { e = getImmediateSubExpr() }
+  override predicate convertsFrom(Expr e) { e = this.getImmediateSubExpr() }
 }

--- a/swift/ql/lib/codeql/swift/elements/expr/UnresolvedDeclRefExpr.qll
+++ b/swift/ql/lib/codeql/swift/elements/expr/UnresolvedDeclRefExpr.qll
@@ -2,8 +2,8 @@ private import codeql.swift.generated.expr.UnresolvedDeclRefExpr
 
 class UnresolvedDeclRefExpr extends Generated::UnresolvedDeclRefExpr {
   override string toString() {
-    result = getName() + " (unresolved)"
+    result = this.getName() + " (unresolved)"
     or
-    not hasName() and result = "(unresolved)"
+    not this.hasName() and result = "(unresolved)"
   }
 }

--- a/swift/ql/lib/codeql/swift/elements/expr/UnresolvedDotExpr.qll
+++ b/swift/ql/lib/codeql/swift/elements/expr/UnresolvedDotExpr.qll
@@ -1,5 +1,5 @@
 private import codeql.swift.generated.expr.UnresolvedDotExpr
 
 class UnresolvedDotExpr extends Generated::UnresolvedDotExpr {
-  override string toString() { result = "... ." + getName() }
+  override string toString() { result = "... ." + this.getName() }
 }

--- a/swift/ql/lib/codeql/swift/elements/pattern/BindingPattern.qll
+++ b/swift/ql/lib/codeql/swift/elements/pattern/BindingPattern.qll
@@ -1,7 +1,7 @@
 private import codeql.swift.generated.pattern.BindingPattern
 
 class BindingPattern extends Generated::BindingPattern {
-  final override Pattern getResolveStep() { result = getImmediateSubPattern() }
+  final override Pattern getResolveStep() { result = this.getImmediateSubPattern() }
 
   override string toString() { result = "let ..." }
 }

--- a/swift/ql/lib/codeql/swift/elements/pattern/ParenPattern.qll
+++ b/swift/ql/lib/codeql/swift/elements/pattern/ParenPattern.qll
@@ -1,7 +1,7 @@
 private import codeql.swift.generated.pattern.ParenPattern
 
 class ParenPattern extends Generated::ParenPattern {
-  final override Pattern getResolveStep() { result = getImmediateSubPattern() }
+  final override Pattern getResolveStep() { result = this.getImmediateSubPattern() }
 
   override string toString() { result = "(...)" }
 }

--- a/swift/ql/lib/codeql/swift/elements/type/TypeRepr.qll
+++ b/swift/ql/lib/codeql/swift/elements/type/TypeRepr.qll
@@ -1,5 +1,5 @@
 private import codeql.swift.generated.type.TypeRepr
 
 class TypeRepr extends Generated::TypeRepr {
-  override string toString() { result = getType().toString() }
+  override string toString() { result = this.getType().toString() }
 }


### PR DESCRIPTION
Make implicit this call receivers explicit to align with internal style guidelines.