### PR TITLE
Swift: Make `DoCatchTree` more precise

### DIFF
--- a/swift/ql/lib/codeql/swift/controlflow/internal/ControlFlowGraphImpl.qll
+++ b/swift/ql/lib/codeql/swift/controlflow/internal/ControlFlowGraphImpl.qll
@@ -767,8 +767,7 @@ module Stmts {
       astLast(ast.getACatch().getBody(), last, c)
       or
       // We failed to match on any of the clauses.
-      // TODO: This can actually only happen if the enclosing function is marked with 'throws'.
-      //       So we could make this more precise.
+      ast.getEnclosingFunction().isThrowing() and
       astLast(ast.getLastCatch(), last, c) and
       c = any(MatchingCompletion mc | not mc.isMatch())
     }

--- a/swift/ql/lib/codeql/swift/elements/decl/Function.qll
+++ b/swift/ql/lib/codeql/swift/elements/decl/Function.qll
@@ -1,11 +1,24 @@
+private import swift
 private import codeql.swift.generated.decl.Function
-private import codeql.swift.elements.decl.Method
 
 /**
  * A function.
  */
 class Function extends Generated::Function, Callable {
   override string toString() { result = this.getName() }
+
+  /**
+   * Holds if this is a throwing function.
+   *
+   * For example, this function is a throwing function:
+   *
+   * ```swift
+   * func myFunc() throws -> String {
+   *   // ...
+   * }
+   * ```
+   */
+  predicate isThrowing() { this.getInterfaceType().(AnyFunctionType).isThrowing() }
 }
 
 /**


### PR DESCRIPTION
(Leaving this in draft while I figure out why there are no test changes)