### PR TITLE
Remove ql/implicit-this restriction to files with explicit this

### DIFF
--- a/ql/ql/src/codeql_ql/style/ImplicitThisQuery.qll
+++ b/ql/ql/src/codeql_ql/style/ImplicitThisQuery.qll
@@ -1,12 +1,5 @@
 import ql
 
-MemberCall explicitThisCallInFile(File f) {
-  result.getLocation().getFile() = f and
-  result.getBase() instanceof ThisAccess and
-  // Exclude `this.(Type).whatever(...)`, as some files have that as their only instance of `this`.
-  not result = any(InlineCast c).getBase()
-}
-
 PredicateCall implicitThisCallInFile(File f) {
   result.getLocation().getFile() = f and
   exists(result.getTarget().getDeclaringType().getASuperType()) and
@@ -14,7 +7,4 @@ PredicateCall implicitThisCallInFile(File f) {
   not exists(result.getQualifier())
 }
 
-PredicateCall confusingImplicitThisCall(File f) {
-  result = implicitThisCallInFile(f) and
-  exists(explicitThisCallInFile(f))
-}
+PredicateCall confusingImplicitThisCall(File f) { result = implicitThisCallInFile(f) }

--- a/ql/ql/test/queries/style/ImplicitThis/Bad2.qll
+++ b/ql/ql/test/queries/style/ImplicitThis/Bad2.qll
@@ -1,0 +1,9 @@
+import ql
+
+class Foo extends string {
+  Foo() { this = "hello" }
+
+  string getBar() { result = "bar" }
+
+  string getBarWithoutThis() { result = getBar() }
+}

--- a/ql/ql/test/queries/style/ImplicitThis/ImplicitThis.expected
+++ b/ql/ql/test/queries/style/ImplicitThis/ImplicitThis.expected
@@ -1,1 +1,2 @@
+| Bad2.qll:8:41:8:48 | PredicateCall | Use of implicit `this`. |
 | Bad.qll:10:41:10:48 | PredicateCall | Use of implicit `this`. |

--- a/ql/ql/test/queries/style/ImplicitThis/Okay.qll
+++ b/ql/ql/test/queries/style/ImplicitThis/Okay.qll
@@ -5,9 +5,6 @@ class Foo extends string {
 
   string getBar() { result = "bar" }
 
-  /* Okay, because we don't write `this.some_method` anywhere */
-  string getBarWithoutThis() { result = getBar() }
-
   /* Okay, because this is the only way to cast `this`. */
   string useThisWithInlineCast() { result = this.(string).toUpperCase() }
 }


### PR DESCRIPTION
Update `ql/implicit-this` query to flag implicit this receivers in all files, including files without any explicit this receivers. This restriction was originally added to reduce noise, but since all implicit this receivers should now have been converted to explicit this receivers, it is safe to remove the restriction. 