### PR TITLE
Go: Add identify-environment scripts

### DIFF
--- a/go/codeql-tools/identify-environment.cmd
+++ b/go/codeql-tools/identify-environment.cmd
@@ -1,0 +1,8 @@
+@echo off
+SETLOCAL EnableDelayedExpansion
+
+type NUL && "%CODEQL_EXTRACTOR_GO_ROOT%/tools/%CODEQL_PLATFORM%/go-autobuilder.exe" --identify-environment
+
+exit /b %ERRORLEVEL%
+
+ENDLOCAL

--- a/go/codeql-tools/identify-environment.sh
+++ b/go/codeql-tools/identify-environment.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -eu
+
+if [ "$CODEQL_PLATFORM" != "linux64" ] && [ "$CODEQL_PLATFORM" != "osx64" ] ; then
+    echo "Automatic build detection for $CODEQL_PLATFORM is not implemented."
+    exit 1
+fi
+
+"$CODEQL_EXTRACTOR_GO_ROOT/tools/$CODEQL_PLATFORM/go-autobuilder" --identify-environment


### PR DESCRIPTION
This adds scripts that the CLI can use to call the go autobuilder with the `--identify-environment` flag. This is similar to `autobuild.cmd` and `autobuild.sh`, which they are based on.