### PR TITLE
JS: Enable implicit this receiver warnings

### DIFF
--- a/javascript/ql/lib/qlpack.yml
+++ b/javascript/ql/lib/qlpack.yml
@@ -12,3 +12,4 @@ dependencies:
   codeql/yaml: ${workspace}
 dataExtensions:
   - semmle/javascript/frameworks/**/model.yml
+warnOnImplicitThis: true

--- a/javascript/ql/lib/semmle/javascript/frameworks/AngularJS/AngularJSCore.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/AngularJS/AngularJSCore.qll
@@ -507,7 +507,7 @@ class DirectiveTargetName extends string {
    * `:` and `_` count as component delimiters.
    */
   string getRawComponent(int i) {
-    result = toLowerCase().regexpFind("(?<=^|[-:_])[a-zA-Z0-9]+(?=$|[-:_])", i, _)
+    result = this.toLowerCase().regexpFind("(?<=^|[-:_])[a-zA-Z0-9]+(?=$|[-:_])", i, _)
   }
 
   /**

--- a/javascript/ql/src/qlpack.yml
+++ b/javascript/ql/src/qlpack.yml
@@ -11,3 +11,4 @@ dependencies:
   codeql/suite-helpers: ${workspace}
   codeql/typos: ${workspace}
   codeql/util: ${workspace}
+warnOnImplicitThis: true

--- a/javascript/ql/test/qlpack.yml
+++ b/javascript/ql/test/qlpack.yml
@@ -7,3 +7,4 @@ extractor: javascript
 tests: .
 dataExtensions:
   - library-tests/DataExtensions/*.model.yml
+warnOnImplicitThis: true

--- a/javascript/ql/test/tutorials/Validating RAML-based APIs/query1.ql
+++ b/javascript/ql/test/tutorials/Validating RAML-based APIs/query1.ql
@@ -2,7 +2,7 @@ import javascript
 
 /** A RAML specification. */
 class RamlSpec extends YamlDocument, YamlMapping {
-  RamlSpec() { getLocation().getFile().getExtension() = "raml" }
+  RamlSpec() { this.getLocation().getFile().getExtension() = "raml" }
 }
 
 from RamlSpec s

--- a/javascript/ql/test/tutorials/Validating RAML-based APIs/query2.ql
+++ b/javascript/ql/test/tutorials/Validating RAML-based APIs/query2.ql
@@ -4,13 +4,13 @@ string httpVerb() { result = ["get", "put", "post", "delete"] }
 
 /** A RAML specification. */
 class RamlSpec extends YamlDocument, YamlMapping {
-  RamlSpec() { getLocation().getFile().getExtension() = "raml" }
+  RamlSpec() { this.getLocation().getFile().getExtension() = "raml" }
 }
 
 /** A RAML resource specification. */
 class RamlResource extends YamlMapping {
   RamlResource() {
-    getDocument() instanceof RamlSpec and
+    this.getDocument() instanceof RamlSpec and
     exists(YamlMapping m, string name |
       this = m.lookup(name) and
       name.matches("/%")
@@ -30,14 +30,14 @@ class RamlResource extends YamlMapping {
   /** Get the method for this resource with the given verb. */
   RamlMethod getMethod(string verb) {
     verb = httpVerb() and
-    result = lookup(verb)
+    result = this.lookup(verb)
   }
 }
 
 /** A RAML method specification. */
 class RamlMethod extends YamlValue {
   RamlMethod() {
-    getDocument() instanceof RamlSpec and
+    this.getDocument() instanceof RamlSpec and
     exists(YamlMapping obj | this = obj.lookup(httpVerb()))
   }
 

--- a/javascript/ql/test/tutorials/Validating RAML-based APIs/query3.ql
+++ b/javascript/ql/test/tutorials/Validating RAML-based APIs/query3.ql
@@ -4,13 +4,13 @@ string httpVerb() { result = ["get", "put", "post", "delete"] }
 
 /** A RAML specification. */
 class RamlSpec extends YamlDocument, YamlMapping {
-  RamlSpec() { getLocation().getFile().getExtension() = "raml" }
+  RamlSpec() { this.getLocation().getFile().getExtension() = "raml" }
 }
 
 /** A RAML resource specification. */
 class RamlResource extends YamlMapping {
   RamlResource() {
-    getDocument() instanceof RamlSpec and
+    this.getDocument() instanceof RamlSpec and
     exists(YamlMapping m, string name |
       this = m.lookup(name) and
       name.matches("/%")
@@ -30,13 +30,13 @@ class RamlResource extends YamlMapping {
   /** Get the method for this resource with the given verb. */
   RamlMethod getMethod(string verb) {
     verb = httpVerb() and
-    result = lookup(verb)
+    result = this.lookup(verb)
   }
 }
 
 class RamlMethod extends YamlValue {
   RamlMethod() {
-    getDocument() instanceof RamlSpec and
+    this.getDocument() instanceof RamlSpec and
     exists(YamlMapping obj | this = obj.lookup(httpVerb()))
   }
 }

--- a/javascript/ql/test/tutorials/Validating RAML-based APIs/query4.ql
+++ b/javascript/ql/test/tutorials/Validating RAML-based APIs/query4.ql
@@ -4,13 +4,13 @@ string httpVerb() { result = ["get", "put", "post", "delete"] }
 
 /** A RAML specification. */
 class RamlSpec extends YamlDocument, YamlMapping {
-  RamlSpec() { getLocation().getFile().getExtension() = "raml" }
+  RamlSpec() { this.getLocation().getFile().getExtension() = "raml" }
 }
 
 /** A RAML resource specification. */
 class RamlResource extends YamlMapping {
   RamlResource() {
-    getDocument() instanceof RamlSpec and
+    this.getDocument() instanceof RamlSpec and
     exists(YamlMapping m, string name |
       this = m.lookup(name) and
       name.matches("/%")
@@ -30,14 +30,14 @@ class RamlResource extends YamlMapping {
   /** Get the method for this resource with the given verb. */
   RamlMethod getMethod(string verb) {
     verb = httpVerb() and
-    result = lookup(verb)
+    result = this.lookup(verb)
   }
 }
 
 /** A RAML method specification. */
 class RamlMethod extends YamlValue {
   RamlMethod() {
-    getDocument() instanceof RamlSpec and
+    this.getDocument() instanceof RamlSpec and
     exists(YamlMapping obj | this = obj.lookup(httpVerb()))
   }
 


### PR DESCRIPTION
Enable warnings for member predicate calls with implicit this receivers for Javascript to prevent them from reappearing.