### PR TITLE
C++: Speedup product dataflow

### DIFF
--- a/cpp/ql/lib/experimental/semmle/code/cpp/dataflow/ProductFlow.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/dataflow/ProductFlow.qll
@@ -337,10 +337,7 @@ module ProductFlow {
     private predicate fwdReachableInterprocEntry(Flow1::PathNode node1, Flow2::PathNode node2) {
       isSourcePair(node1, node2)
       or
-      exists(Flow1::PathNode pred1, Flow2::PathNode pred2 |
-        fwdReachableInterprocEntry(pred1, pred2) and
-        isSuccessor(pred1, pred2, node1, node2)
-      )
+      fwdIsSuccessor(_, _, node1, node2)
     }
 
     pragma[assume_small_delta]
@@ -424,11 +421,10 @@ module ProductFlow {
       localPathStep2SuccPlus(n1, n2) or n1 = n2
     }
 
-    bindingset[pred1, pred2]
-    bindingset[succ1, succ2]
-    private predicate isSuccessor(
+    private predicate fwdIsSuccessor(
       Flow1::PathNode pred1, Flow2::PathNode pred2, Flow1::PathNode succ1, Flow2::PathNode succ2
     ) {
+      fwdReachableInterprocEntry(pred1, pred2) and
       exists(Flow1::PathNode mid1, Flow2::PathNode mid2 |
         localPathStep1Tc(pred1, mid1) and
         localPathStep2Tc(pred2, mid2)
@@ -445,13 +441,11 @@ module ProductFlow {
     pragma[nomagic]
     private predicate revReachableInterprocEntry(Flow1::PathNode node1, Flow2::PathNode node2) {
       fwdReachableInterprocEntry(node1, node2) and
-      (
-        isSinkPair(node1, node2)
-        or
-        exists(Flow1::PathNode succ1, Flow2::PathNode succ2 |
-          revReachableInterprocEntry(succ1, succ2) and
-          isSuccessor(node1, node2, succ1, succ2)
-        )
+      isSinkPair(node1, node2)
+      or
+      exists(Flow1::PathNode succ1, Flow2::PathNode succ2 |
+        revReachableInterprocEntry(succ1, succ2) and
+        fwdIsSuccessor(node1, node2, succ1, succ2)
       )
     }
 
@@ -464,7 +458,7 @@ module ProductFlow {
       exists(Flow1::PathNode n11, Flow2::PathNode n12, Flow1::PathNode n21, Flow2::PathNode n22 |
         n1 = TMkNodePair(n11, n12) and
         n2 = TMkNodePair(n21, n22) and
-        isSuccessor(n11, n12, n21, n22)
+        fwdIsSuccessor(n11, n12, n21, n22)
       )
     }
 

--- a/cpp/ql/lib/experimental/semmle/code/cpp/dataflow/ProductFlow.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/dataflow/ProductFlow.qll
@@ -324,24 +324,70 @@ module ProductFlow {
 
     module Flow2 = DataFlow::GlobalWithState<Config2>;
 
+    private predicate isSourcePair(Flow1::PathNode node1, Flow2::PathNode node2) {
+      Config::isSourcePair(node1.getNode(), node1.getState(), node2.getNode(), node2.getState())
+    }
+
+    private predicate isSinkPair(Flow1::PathNode node1, Flow2::PathNode node2) {
+      Config::isSinkPair(node1.getNode(), node1.getState(), node2.getNode(), node2.getState())
+    }
+
+    pragma[assume_small_delta]
     pragma[nomagic]
-    private predicate reachableInterprocEntry(
-      Flow1::PathNode source1, Flow2::PathNode source2, Flow1::PathNode node1, Flow2::PathNode node2
-    ) {
-      Config::isSourcePair(node1.getNode(), node1.getState(), node2.getNode(), node2.getState()) and
-      node1 = source1 and
-      node2 = source2
+    private predicate fwdReachableInterprocEntry(Flow1::PathNode node1, Flow2::PathNode node2) {
+      isSourcePair(node1, node2)
       or
-      exists(
-        Flow1::PathNode midEntry1, Flow2::PathNode midEntry2, Flow1::PathNode midExit1,
-        Flow2::PathNode midExit2
-      |
-        reachableInterprocEntry(source1, source2, midEntry1, midEntry2) and
-        interprocEdgePair(midExit1, midExit2, node1, node2) and
-        localPathStep1*(midEntry1, midExit1) and
-        localPathStep2*(midEntry2, midExit2)
+      exists(Flow1::PathNode pred1, Flow2::PathNode pred2 |
+        fwdReachableInterprocEntry(pred1, pred2) and
+        isSuccessor(pred1, pred2, node1, node2)
       )
     }
+
+    bindingset[pred1, pred2]
+    bindingset[succ1, succ2]
+    private predicate isSuccessor(
+      Flow1::PathNode pred1, Flow2::PathNode pred2, Flow1::PathNode succ1, Flow2::PathNode succ2
+    ) {
+      exists(Flow1::PathNode mid1, Flow2::PathNode mid2 |
+        localPathStep1*(pred1, mid1) and
+        localPathStep2*(pred2, mid2)
+      |
+        isSinkPair(mid1, mid2) and
+        succ1 = mid1 and
+        succ2 = mid2
+        or
+        interprocEdgePair(mid1, mid2, succ1, succ2)
+      )
+    }
+
+    pragma[assume_small_delta]
+    pragma[nomagic]
+    private predicate revReachableInterprocEntry(Flow1::PathNode node1, Flow2::PathNode node2) {
+      fwdReachableInterprocEntry(node1, node2) and
+      (
+        isSinkPair(node1, node2)
+        or
+        exists(Flow1::PathNode succ1, Flow2::PathNode succ2 |
+          revReachableInterprocEntry(succ1, succ2) and
+          isSuccessor(node1, node2, succ1, succ2)
+        )
+      )
+    }
+
+    private newtype TNodePair =
+      TMkNodePair(Flow1::PathNode node1, Flow2::PathNode node2) {
+        revReachableInterprocEntry(node1, node2)
+      }
+
+    private predicate pathSucc(TNodePair n1, TNodePair n2) {
+      exists(Flow1::PathNode n11, Flow2::PathNode n12, Flow1::PathNode n21, Flow2::PathNode n22 |
+        n1 = TMkNodePair(n11, n12) and
+        n2 = TMkNodePair(n21, n22) and
+        isSuccessor(n11, n12, n21, n22)
+      )
+    }
+
+    private predicate pathSuccPlus(TNodePair n1, TNodePair n2) = fastTC(pathSucc/2)(n1, n2)
 
     private predicate localPathStep1(Flow1::PathNode pred, Flow1::PathNode succ) {
       Flow1::PathGraph::edges(pred, succ) and
@@ -474,11 +520,14 @@ module ProductFlow {
     private predicate reachable(
       Flow1::PathNode source1, Flow2::PathNode source2, Flow1::PathNode sink1, Flow2::PathNode sink2
     ) {
-      exists(Flow1::PathNode mid1, Flow2::PathNode mid2 |
-        reachableInterprocEntry(source1, source2, mid1, mid2) and
-        Config::isSinkPair(sink1.getNode(), sink1.getState(), sink2.getNode(), sink2.getState()) and
-        localPathStep1*(mid1, sink1) and
-        localPathStep2*(mid2, sink2)
+      isSourcePair(source1, source2) and
+      isSinkPair(sink1, sink2) and
+      exists(TNodePair n1, TNodePair n2 |
+        n1 = TMkNodePair(source1, source2) and
+        n2 = TMkNodePair(sink1, sink2)
+      |
+        pathSuccPlus(n1, n2) or
+        n1 = n2
       )
     }
   }

--- a/cpp/ql/lib/experimental/semmle/code/cpp/dataflow/ProductFlow.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/dataflow/ProductFlow.qll
@@ -340,19 +340,42 @@ module ProductFlow {
       fwdIsSuccessor(_, _, node1, node2)
     }
 
+    pragma[nomagic]
+    private predicate fwdIsSuccessorExit(
+      Flow1::PathNode mid1, Flow2::PathNode mid2, Flow1::PathNode succ1, Flow2::PathNode succ2
+    ) {
+      isSinkPair(mid1, mid2) and
+      succ1 = mid1 and
+      succ2 = mid2
+      or
+      interprocEdgePair(mid1, mid2, succ1, succ2)
+    }
+
+    private predicate fwdIsSuccessor1(
+      Flow1::PathNode pred1, Flow2::PathNode pred2, Flow1::PathNode mid1, Flow2::PathNode mid2,
+      Flow1::PathNode succ1, Flow2::PathNode succ2
+    ) {
+      fwdReachableInterprocEntry(pred1, pred2) and
+      localPathStep1*(pred1, mid1) and
+      fwdIsSuccessorExit(pragma[only_bind_into](mid1), pragma[only_bind_into](mid2), succ1, succ2)
+    }
+
+    private predicate fwdIsSuccessor2(
+      Flow1::PathNode pred1, Flow2::PathNode pred2, Flow1::PathNode mid1, Flow2::PathNode mid2,
+      Flow1::PathNode succ1, Flow2::PathNode succ2
+    ) {
+      fwdReachableInterprocEntry(pred1, pred2) and
+      localPathStep2*(pred2, mid2) and
+      fwdIsSuccessorExit(pragma[only_bind_into](mid1), pragma[only_bind_into](mid2), succ1, succ2)
+    }
+
+    pragma[assume_small_delta]
     private predicate fwdIsSuccessor(
       Flow1::PathNode pred1, Flow2::PathNode pred2, Flow1::PathNode succ1, Flow2::PathNode succ2
     ) {
-      fwdReachableInterprocEntry(pred1, pred2) and
       exists(Flow1::PathNode mid1, Flow2::PathNode mid2 |
-        localPathStep1*(pred1, mid1) and
-        localPathStep2*(pred2, mid2)
-      |
-        isSinkPair(mid1, mid2) and
-        succ1 = mid1 and
-        succ2 = mid2
-        or
-        interprocEdgePair(mid1, mid2, succ1, succ2)
+        fwdIsSuccessor1(pred1, pred2, mid1, mid2, succ1, succ2) and
+        fwdIsSuccessor2(pred1, pred2, mid1, mid2, succ1, succ2)
       )
     }
 

--- a/cpp/ql/lib/experimental/semmle/code/cpp/dataflow/ProductFlow.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/dataflow/ProductFlow.qll
@@ -340,94 +340,13 @@ module ProductFlow {
       fwdIsSuccessor(_, _, node1, node2)
     }
 
-    pragma[assume_small_delta]
-    pragma[nomagic]
-    private predicate fwdLocalPathStep1(Flow1::PathNode n) {
-      fwdReachableInterprocEntry(n, _)
-      or
-      exists(Flow1::PathNode mid |
-        fwdLocalPathStep1(mid) and
-        localPathStep1(mid, n)
-      )
-    }
-
-    pragma[assume_small_delta]
-    pragma[nomagic]
-    private predicate revLocalPathStep1(Flow1::PathNode n) {
-      fwdLocalPathStep1(n) and
-      (
-        isSinkPair(n, _)
-        or
-        interprocEdgePair(n, _, _, _)
-        or
-        exists(Flow1::PathNode mid |
-          revLocalPathStep1(mid) and
-          localPathStep1(n, mid)
-        )
-      )
-    }
-
-    pragma[assume_small_delta]
-    private predicate prunedLocalPathStep1(Flow1::PathNode n1, Flow1::PathNode n2) {
-      revLocalPathStep1(n1) and
-      revLocalPathStep1(n2) and
-      localPathStep1(n1, n2)
-    }
-
-    pragma[nomagic]
-    private predicate fwdLocalPathStep2(Flow2::PathNode n) {
-      fwdReachableInterprocEntry(_, n)
-      or
-      exists(Flow2::PathNode mid |
-        fwdLocalPathStep2(mid) and
-        localPathStep2(mid, n)
-      )
-    }
-
-    pragma[assume_small_delta]
-    pragma[nomagic]
-    private predicate revLocalPathStep2(Flow2::PathNode n) {
-      fwdLocalPathStep2(n) and
-      (
-        isSinkPair(_, n)
-        or
-        interprocEdgePair(_, n, _, _)
-        or
-        exists(Flow2::PathNode mid |
-          revLocalPathStep2(mid) and
-          localPathStep2(n, mid)
-        )
-      )
-    }
-
-    pragma[assume_small_delta]
-    private predicate prunedLocalPathStep2(Flow2::PathNode n1, Flow2::PathNode n2) {
-      revLocalPathStep2(n1) and
-      revLocalPathStep2(n2) and
-      localPathStep2(n1, n2)
-    }
-
-    private predicate localPathStep1SuccPlus(Flow1::PathNode n1, Flow1::PathNode n2) =
-      fastTC(prunedLocalPathStep1/2)(n1, n2)
-
-    private predicate localPathStep2SuccPlus(Flow2::PathNode n1, Flow2::PathNode n2) =
-      fastTC(prunedLocalPathStep2/2)(n1, n2)
-
-    private predicate localPathStep1Tc(Flow1::PathNode n1, Flow1::PathNode n2) {
-      localPathStep1SuccPlus(n1, n2) or n1 = n2
-    }
-
-    private predicate localPathStep2Tc(Flow2::PathNode n1, Flow2::PathNode n2) {
-      localPathStep2SuccPlus(n1, n2) or n1 = n2
-    }
-
     private predicate fwdIsSuccessor(
       Flow1::PathNode pred1, Flow2::PathNode pred2, Flow1::PathNode succ1, Flow2::PathNode succ2
     ) {
       fwdReachableInterprocEntry(pred1, pred2) and
       exists(Flow1::PathNode mid1, Flow2::PathNode mid2 |
-        localPathStep1Tc(pred1, mid1) and
-        localPathStep2Tc(pred2, mid2)
+        localPathStep1*(pred1, mid1) and
+        localPathStep2*(pred2, mid2)
       |
         isSinkPair(mid1, mid2) and
         succ1 = mid1 and


### PR DESCRIPTION
This PR speeds up the experimental product flow library in three steps:

1. The first commit implements Schack's suggestion from https://github.com/github/codeql/pull/9997#discussion_r963513863
2. The second commit applies manual magic to the transitive closures of the `localPathStep` calls in the forward direction,
3. ... and the last commit does the same in the reverse direction.

This seems to speed up the analysis quite a lot. For example, running `cpp/invalid-pointer-deref` on https://github.com/ptitSeb/box64 goes from ~30 min to ~5 min. There's still something weird on that project, but at least it's a lot more manageable now.

I haven't run DCA on it yet, but I'll do so once Actions feels better 😅.