### PR TITLE
C++: Restrict flow-state space of `cpp/overrun-write`

### DIFF
--- a/cpp/ql/src/experimental/Likely Bugs/OverrunWriteProductFlow.ql
+++ b/cpp/ql/src/experimental/Likely Bugs/OverrunWriteProductFlow.ql
@@ -159,17 +159,12 @@ module ValidState {
       // For a dataflow sink any `value` that is strictly smaller than the delta
       // needs to be a valid flow-state. That is, for a snippet like:
       // ```
-      // p = new char[size];
+      // p = b ? new char[size] : new char[size + 1];
       // memset(p, 0, size + 2);
       // ```
-      // the valid flow-states at the `memset` must include `0` since the flow-state
-      // at the source is `0`. Similarly, for an example such as:
-      // ```
-      // p = new char[size + 1];
-      // memset(p, 0, size + 2);
-      // ```
-      // the flow-state at the `memset` must include `1` since `1` is the flow-state
-      // after the source.
+      // the valid flow-states at the `memset` must include set set `{0, 1}` since the
+      // flow-state at `new char[size]` is `0`, and the flow-state at `new char[size + 1]`
+      // is `1`.
       //
       // So we find a valid flow-state at the sink's predecessor, and use the definition
       // of our sink predicate to compute the valid flow-states at the sink.

--- a/cpp/ql/src/experimental/Likely Bugs/OverrunWriteProductFlow.ql
+++ b/cpp/ql/src/experimental/Likely Bugs/OverrunWriteProductFlow.ql
@@ -162,7 +162,7 @@ module ValidState {
       // p = b ? new char[size] : new char[size + 1];
       // memset(p, 0, size + 2);
       // ```
-      // the valid flow-states at the `memset` must include set set `{0, 1}` since the
+      // the valid flow-states at the `memset` must include the set `{0, 1}` since the
       // flow-state at `new char[size]` is `0`, and the flow-state at `new char[size + 1]`
       // is `1`.
       //

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-119/OverrunWriteProductFlow.expected
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-119/OverrunWriteProductFlow.expected
@@ -1,202 +1,62 @@
 edges
-| test.cpp:16:11:16:21 | mk_string_t indirection [string] | test.cpp:24:21:24:31 | call to mk_string_t indirection [string] |
-| test.cpp:16:11:16:21 | mk_string_t indirection [string] | test.cpp:34:21:34:31 | call to mk_string_t indirection [string] |
 | test.cpp:16:11:16:21 | mk_string_t indirection [string] | test.cpp:39:21:39:31 | call to mk_string_t indirection [string] |
 | test.cpp:18:5:18:30 | ... = ... | test.cpp:18:10:18:15 | str indirection [post update] [string] |
 | test.cpp:18:10:18:15 | str indirection [post update] [string] | test.cpp:16:11:16:21 | mk_string_t indirection [string] |
 | test.cpp:18:19:18:24 | call to malloc | test.cpp:18:5:18:30 | ... = ... |
-| test.cpp:24:21:24:31 | call to mk_string_t indirection [string] | test.cpp:26:13:26:15 | str indirection [string] |
-| test.cpp:26:13:26:15 | str indirection [string] | test.cpp:26:18:26:23 | string |
-| test.cpp:26:13:26:15 | str indirection [string] | test.cpp:26:18:26:23 | string indirection |
-| test.cpp:26:18:26:23 | string indirection | test.cpp:26:18:26:23 | string |
-| test.cpp:29:32:29:34 | str indirection [string] | test.cpp:30:13:30:15 | str indirection [string] |
-| test.cpp:30:13:30:15 | str indirection [string] | test.cpp:30:18:30:23 | string |
-| test.cpp:30:13:30:15 | str indirection [string] | test.cpp:30:18:30:23 | string indirection |
-| test.cpp:30:18:30:23 | string indirection | test.cpp:30:18:30:23 | string |
-| test.cpp:34:21:34:31 | call to mk_string_t indirection [string] | test.cpp:35:21:35:23 | str indirection [string] |
-| test.cpp:35:21:35:23 | str indirection [string] | test.cpp:29:32:29:34 | str indirection [string] |
-| test.cpp:39:21:39:31 | call to mk_string_t indirection [string] | test.cpp:41:13:41:15 | str indirection [string] |
 | test.cpp:39:21:39:31 | call to mk_string_t indirection [string] | test.cpp:42:13:42:15 | str indirection [string] |
-| test.cpp:39:21:39:31 | call to mk_string_t indirection [string] | test.cpp:44:13:44:15 | str indirection [string] |
-| test.cpp:39:21:39:31 | call to mk_string_t indirection [string] | test.cpp:45:13:45:15 | str indirection [string] |
-| test.cpp:39:21:39:31 | call to mk_string_t indirection [string] | test.cpp:48:17:48:19 | str indirection [string] |
-| test.cpp:39:21:39:31 | call to mk_string_t indirection [string] | test.cpp:52:17:52:19 | str indirection [string] |
-| test.cpp:39:21:39:31 | call to mk_string_t indirection [string] | test.cpp:56:17:56:19 | str indirection [string] |
-| test.cpp:39:21:39:31 | call to mk_string_t indirection [string] | test.cpp:60:17:60:19 | str indirection [string] |
-| test.cpp:39:21:39:31 | call to mk_string_t indirection [string] | test.cpp:64:17:64:19 | str indirection [string] |
-| test.cpp:39:21:39:31 | call to mk_string_t indirection [string] | test.cpp:68:17:68:19 | str indirection [string] |
 | test.cpp:39:21:39:31 | call to mk_string_t indirection [string] | test.cpp:72:17:72:19 | str indirection [string] |
-| test.cpp:39:21:39:31 | call to mk_string_t indirection [string] | test.cpp:76:17:76:19 | str indirection [string] |
 | test.cpp:39:21:39:31 | call to mk_string_t indirection [string] | test.cpp:80:17:80:19 | str indirection [string] |
-| test.cpp:39:21:39:31 | call to mk_string_t indirection [string] | test.cpp:84:17:84:19 | str indirection [string] |
-| test.cpp:41:13:41:15 | str indirection [string] | test.cpp:41:18:41:23 | string |
-| test.cpp:41:13:41:15 | str indirection [string] | test.cpp:41:18:41:23 | string indirection |
-| test.cpp:41:18:41:23 | string indirection | test.cpp:41:18:41:23 | string |
 | test.cpp:42:13:42:15 | str indirection [string] | test.cpp:42:18:42:23 | string |
 | test.cpp:42:13:42:15 | str indirection [string] | test.cpp:42:18:42:23 | string indirection |
 | test.cpp:42:18:42:23 | string indirection | test.cpp:42:18:42:23 | string |
-| test.cpp:44:13:44:15 | str indirection [string] | test.cpp:44:18:44:23 | string |
-| test.cpp:44:13:44:15 | str indirection [string] | test.cpp:44:18:44:23 | string indirection |
-| test.cpp:44:18:44:23 | string indirection | test.cpp:44:18:44:23 | string |
-| test.cpp:45:13:45:15 | str indirection [string] | test.cpp:45:18:45:23 | string |
-| test.cpp:45:13:45:15 | str indirection [string] | test.cpp:45:18:45:23 | string indirection |
-| test.cpp:45:18:45:23 | string indirection | test.cpp:45:18:45:23 | string |
-| test.cpp:48:17:48:19 | str indirection [string] | test.cpp:48:22:48:27 | string |
-| test.cpp:48:17:48:19 | str indirection [string] | test.cpp:48:22:48:27 | string indirection |
-| test.cpp:48:22:48:27 | string indirection | test.cpp:48:22:48:27 | string |
-| test.cpp:52:17:52:19 | str indirection [string] | test.cpp:52:22:52:27 | string |
-| test.cpp:52:17:52:19 | str indirection [string] | test.cpp:52:22:52:27 | string indirection |
-| test.cpp:52:22:52:27 | string indirection | test.cpp:52:22:52:27 | string |
-| test.cpp:56:17:56:19 | str indirection [string] | test.cpp:56:22:56:27 | string |
-| test.cpp:56:17:56:19 | str indirection [string] | test.cpp:56:22:56:27 | string indirection |
-| test.cpp:56:22:56:27 | string indirection | test.cpp:56:22:56:27 | string |
-| test.cpp:60:17:60:19 | str indirection [string] | test.cpp:60:22:60:27 | string |
-| test.cpp:60:17:60:19 | str indirection [string] | test.cpp:60:22:60:27 | string indirection |
-| test.cpp:60:22:60:27 | string indirection | test.cpp:60:22:60:27 | string |
-| test.cpp:64:17:64:19 | str indirection [string] | test.cpp:64:22:64:27 | string |
-| test.cpp:64:17:64:19 | str indirection [string] | test.cpp:64:22:64:27 | string indirection |
-| test.cpp:64:22:64:27 | string indirection | test.cpp:64:22:64:27 | string |
-| test.cpp:68:17:68:19 | str indirection [string] | test.cpp:68:22:68:27 | string |
-| test.cpp:68:17:68:19 | str indirection [string] | test.cpp:68:22:68:27 | string indirection |
-| test.cpp:68:22:68:27 | string indirection | test.cpp:68:22:68:27 | string |
 | test.cpp:72:17:72:19 | str indirection [string] | test.cpp:72:22:72:27 | string |
 | test.cpp:72:17:72:19 | str indirection [string] | test.cpp:72:22:72:27 | string indirection |
 | test.cpp:72:22:72:27 | string indirection | test.cpp:72:22:72:27 | string |
-| test.cpp:76:17:76:19 | str indirection [string] | test.cpp:76:22:76:27 | string |
-| test.cpp:76:17:76:19 | str indirection [string] | test.cpp:76:22:76:27 | string indirection |
-| test.cpp:76:22:76:27 | string indirection | test.cpp:76:22:76:27 | string |
 | test.cpp:80:17:80:19 | str indirection [string] | test.cpp:80:22:80:27 | string |
 | test.cpp:80:17:80:19 | str indirection [string] | test.cpp:80:22:80:27 | string indirection |
 | test.cpp:80:22:80:27 | string indirection | test.cpp:80:22:80:27 | string |
-| test.cpp:84:17:84:19 | str indirection [string] | test.cpp:84:22:84:27 | string |
-| test.cpp:84:17:84:19 | str indirection [string] | test.cpp:84:22:84:27 | string indirection |
-| test.cpp:84:22:84:27 | string indirection | test.cpp:84:22:84:27 | string |
 | test.cpp:88:11:88:30 | mk_string_t_plus_one indirection [string] | test.cpp:96:21:96:40 | call to mk_string_t_plus_one indirection [string] |
 | test.cpp:90:5:90:34 | ... = ... | test.cpp:90:10:90:15 | str indirection [post update] [string] |
 | test.cpp:90:10:90:15 | str indirection [post update] [string] | test.cpp:88:11:88:30 | mk_string_t_plus_one indirection [string] |
 | test.cpp:90:19:90:24 | call to malloc | test.cpp:90:5:90:34 | ... = ... |
-| test.cpp:96:21:96:40 | call to mk_string_t_plus_one indirection [string] | test.cpp:98:13:98:15 | str indirection [string] |
 | test.cpp:96:21:96:40 | call to mk_string_t_plus_one indirection [string] | test.cpp:99:13:99:15 | str indirection [string] |
-| test.cpp:96:21:96:40 | call to mk_string_t_plus_one indirection [string] | test.cpp:101:13:101:15 | str indirection [string] |
-| test.cpp:96:21:96:40 | call to mk_string_t_plus_one indirection [string] | test.cpp:102:13:102:15 | str indirection [string] |
-| test.cpp:96:21:96:40 | call to mk_string_t_plus_one indirection [string] | test.cpp:105:17:105:19 | str indirection [string] |
-| test.cpp:96:21:96:40 | call to mk_string_t_plus_one indirection [string] | test.cpp:109:17:109:19 | str indirection [string] |
-| test.cpp:96:21:96:40 | call to mk_string_t_plus_one indirection [string] | test.cpp:113:17:113:19 | str indirection [string] |
-| test.cpp:96:21:96:40 | call to mk_string_t_plus_one indirection [string] | test.cpp:117:17:117:19 | str indirection [string] |
-| test.cpp:96:21:96:40 | call to mk_string_t_plus_one indirection [string] | test.cpp:121:17:121:19 | str indirection [string] |
-| test.cpp:96:21:96:40 | call to mk_string_t_plus_one indirection [string] | test.cpp:125:17:125:19 | str indirection [string] |
 | test.cpp:96:21:96:40 | call to mk_string_t_plus_one indirection [string] | test.cpp:129:17:129:19 | str indirection [string] |
-| test.cpp:96:21:96:40 | call to mk_string_t_plus_one indirection [string] | test.cpp:133:17:133:19 | str indirection [string] |
 | test.cpp:96:21:96:40 | call to mk_string_t_plus_one indirection [string] | test.cpp:137:17:137:19 | str indirection [string] |
-| test.cpp:96:21:96:40 | call to mk_string_t_plus_one indirection [string] | test.cpp:141:17:141:19 | str indirection [string] |
-| test.cpp:98:13:98:15 | str indirection [string] | test.cpp:98:18:98:23 | string |
-| test.cpp:98:13:98:15 | str indirection [string] | test.cpp:98:18:98:23 | string indirection |
-| test.cpp:98:18:98:23 | string indirection | test.cpp:98:18:98:23 | string |
 | test.cpp:99:13:99:15 | str indirection [string] | test.cpp:99:18:99:23 | string |
 | test.cpp:99:13:99:15 | str indirection [string] | test.cpp:99:18:99:23 | string indirection |
 | test.cpp:99:18:99:23 | string indirection | test.cpp:99:18:99:23 | string |
-| test.cpp:101:13:101:15 | str indirection [string] | test.cpp:101:18:101:23 | string |
-| test.cpp:101:13:101:15 | str indirection [string] | test.cpp:101:18:101:23 | string indirection |
-| test.cpp:101:18:101:23 | string indirection | test.cpp:101:18:101:23 | string |
-| test.cpp:102:13:102:15 | str indirection [string] | test.cpp:102:18:102:23 | string |
-| test.cpp:102:13:102:15 | str indirection [string] | test.cpp:102:18:102:23 | string indirection |
-| test.cpp:102:18:102:23 | string indirection | test.cpp:102:18:102:23 | string |
-| test.cpp:105:17:105:19 | str indirection [string] | test.cpp:105:22:105:27 | string |
-| test.cpp:105:17:105:19 | str indirection [string] | test.cpp:105:22:105:27 | string indirection |
-| test.cpp:105:22:105:27 | string indirection | test.cpp:105:22:105:27 | string |
-| test.cpp:109:17:109:19 | str indirection [string] | test.cpp:109:22:109:27 | string |
-| test.cpp:109:17:109:19 | str indirection [string] | test.cpp:109:22:109:27 | string indirection |
-| test.cpp:109:22:109:27 | string indirection | test.cpp:109:22:109:27 | string |
-| test.cpp:113:17:113:19 | str indirection [string] | test.cpp:113:22:113:27 | string |
-| test.cpp:113:17:113:19 | str indirection [string] | test.cpp:113:22:113:27 | string indirection |
-| test.cpp:113:22:113:27 | string indirection | test.cpp:113:22:113:27 | string |
-| test.cpp:117:17:117:19 | str indirection [string] | test.cpp:117:22:117:27 | string |
-| test.cpp:117:17:117:19 | str indirection [string] | test.cpp:117:22:117:27 | string indirection |
-| test.cpp:117:22:117:27 | string indirection | test.cpp:117:22:117:27 | string |
-| test.cpp:121:17:121:19 | str indirection [string] | test.cpp:121:22:121:27 | string |
-| test.cpp:121:17:121:19 | str indirection [string] | test.cpp:121:22:121:27 | string indirection |
-| test.cpp:121:22:121:27 | string indirection | test.cpp:121:22:121:27 | string |
-| test.cpp:125:17:125:19 | str indirection [string] | test.cpp:125:22:125:27 | string |
-| test.cpp:125:17:125:19 | str indirection [string] | test.cpp:125:22:125:27 | string indirection |
-| test.cpp:125:22:125:27 | string indirection | test.cpp:125:22:125:27 | string |
 | test.cpp:129:17:129:19 | str indirection [string] | test.cpp:129:22:129:27 | string |
 | test.cpp:129:17:129:19 | str indirection [string] | test.cpp:129:22:129:27 | string indirection |
 | test.cpp:129:22:129:27 | string indirection | test.cpp:129:22:129:27 | string |
-| test.cpp:133:17:133:19 | str indirection [string] | test.cpp:133:22:133:27 | string |
-| test.cpp:133:17:133:19 | str indirection [string] | test.cpp:133:22:133:27 | string indirection |
-| test.cpp:133:22:133:27 | string indirection | test.cpp:133:22:133:27 | string |
 | test.cpp:137:17:137:19 | str indirection [string] | test.cpp:137:22:137:27 | string |
 | test.cpp:137:17:137:19 | str indirection [string] | test.cpp:137:22:137:27 | string indirection |
 | test.cpp:137:22:137:27 | string indirection | test.cpp:137:22:137:27 | string |
-| test.cpp:141:17:141:19 | str indirection [string] | test.cpp:141:22:141:27 | string |
-| test.cpp:141:17:141:19 | str indirection [string] | test.cpp:141:22:141:27 | string indirection |
-| test.cpp:141:22:141:27 | string indirection | test.cpp:141:22:141:27 | string |
 | test.cpp:147:5:147:34 | ... = ... | test.cpp:147:10:147:15 | str indirection [post update] [string] |
-| test.cpp:147:10:147:15 | str indirection [post update] [string] | test.cpp:150:13:150:15 | str indirection [string] |
-| test.cpp:147:10:147:15 | str indirection [post update] [string] | test.cpp:151:13:151:15 | str indirection [string] |
 | test.cpp:147:10:147:15 | str indirection [post update] [string] | test.cpp:152:13:152:15 | str indirection [string] |
 | test.cpp:147:10:147:15 | str indirection [post update] [string] | test.cpp:154:13:154:15 | str indirection [string] |
-| test.cpp:147:10:147:15 | str indirection [post update] [string] | test.cpp:155:13:155:15 | str indirection [string] |
 | test.cpp:147:10:147:15 | str indirection [post update] [string] | test.cpp:156:13:156:15 | str indirection [string] |
-| test.cpp:147:10:147:15 | str indirection [post update] [string] | test.cpp:159:17:159:19 | str indirection [string] |
-| test.cpp:147:10:147:15 | str indirection [post update] [string] | test.cpp:163:17:163:19 | str indirection [string] |
-| test.cpp:147:10:147:15 | str indirection [post update] [string] | test.cpp:167:17:167:19 | str indirection [string] |
-| test.cpp:147:10:147:15 | str indirection [post update] [string] | test.cpp:171:17:171:19 | str indirection [string] |
 | test.cpp:147:10:147:15 | str indirection [post update] [string] | test.cpp:175:17:175:19 | str indirection [string] |
-| test.cpp:147:10:147:15 | str indirection [post update] [string] | test.cpp:179:17:179:19 | str indirection [string] |
-| test.cpp:147:10:147:15 | str indirection [post update] [string] | test.cpp:183:17:183:19 | str indirection [string] |
 | test.cpp:147:10:147:15 | str indirection [post update] [string] | test.cpp:187:17:187:19 | str indirection [string] |
-| test.cpp:147:10:147:15 | str indirection [post update] [string] | test.cpp:191:17:191:19 | str indirection [string] |
 | test.cpp:147:10:147:15 | str indirection [post update] [string] | test.cpp:195:17:195:19 | str indirection [string] |
 | test.cpp:147:10:147:15 | str indirection [post update] [string] | test.cpp:199:17:199:19 | str indirection [string] |
 | test.cpp:147:10:147:15 | str indirection [post update] [string] | test.cpp:203:17:203:19 | str indirection [string] |
 | test.cpp:147:10:147:15 | str indirection [post update] [string] | test.cpp:207:17:207:19 | str indirection [string] |
 | test.cpp:147:19:147:24 | call to malloc | test.cpp:147:5:147:34 | ... = ... |
-| test.cpp:150:13:150:15 | str indirection [string] | test.cpp:150:18:150:23 | string |
-| test.cpp:150:13:150:15 | str indirection [string] | test.cpp:150:18:150:23 | string indirection |
-| test.cpp:150:18:150:23 | string indirection | test.cpp:150:18:150:23 | string |
-| test.cpp:151:13:151:15 | str indirection [string] | test.cpp:151:18:151:23 | string |
-| test.cpp:151:13:151:15 | str indirection [string] | test.cpp:151:18:151:23 | string indirection |
-| test.cpp:151:18:151:23 | string indirection | test.cpp:151:18:151:23 | string |
 | test.cpp:152:13:152:15 | str indirection [string] | test.cpp:152:18:152:23 | string |
 | test.cpp:152:13:152:15 | str indirection [string] | test.cpp:152:18:152:23 | string indirection |
 | test.cpp:152:18:152:23 | string indirection | test.cpp:152:18:152:23 | string |
 | test.cpp:154:13:154:15 | str indirection [string] | test.cpp:154:18:154:23 | string |
 | test.cpp:154:13:154:15 | str indirection [string] | test.cpp:154:18:154:23 | string indirection |
 | test.cpp:154:18:154:23 | string indirection | test.cpp:154:18:154:23 | string |
-| test.cpp:155:13:155:15 | str indirection [string] | test.cpp:155:18:155:23 | string |
-| test.cpp:155:13:155:15 | str indirection [string] | test.cpp:155:18:155:23 | string indirection |
-| test.cpp:155:18:155:23 | string indirection | test.cpp:155:18:155:23 | string |
 | test.cpp:156:13:156:15 | str indirection [string] | test.cpp:156:18:156:23 | string |
 | test.cpp:156:13:156:15 | str indirection [string] | test.cpp:156:18:156:23 | string indirection |
 | test.cpp:156:18:156:23 | string indirection | test.cpp:156:18:156:23 | string |
-| test.cpp:159:17:159:19 | str indirection [string] | test.cpp:159:22:159:27 | string |
-| test.cpp:159:17:159:19 | str indirection [string] | test.cpp:159:22:159:27 | string indirection |
-| test.cpp:159:22:159:27 | string indirection | test.cpp:159:22:159:27 | string |
-| test.cpp:163:17:163:19 | str indirection [string] | test.cpp:163:22:163:27 | string |
-| test.cpp:163:17:163:19 | str indirection [string] | test.cpp:163:22:163:27 | string indirection |
-| test.cpp:163:22:163:27 | string indirection | test.cpp:163:22:163:27 | string |
-| test.cpp:167:17:167:19 | str indirection [string] | test.cpp:167:22:167:27 | string |
-| test.cpp:167:17:167:19 | str indirection [string] | test.cpp:167:22:167:27 | string indirection |
-| test.cpp:167:22:167:27 | string indirection | test.cpp:167:22:167:27 | string |
-| test.cpp:171:17:171:19 | str indirection [string] | test.cpp:171:22:171:27 | string |
-| test.cpp:171:17:171:19 | str indirection [string] | test.cpp:171:22:171:27 | string indirection |
-| test.cpp:171:22:171:27 | string indirection | test.cpp:171:22:171:27 | string |
 | test.cpp:175:17:175:19 | str indirection [string] | test.cpp:175:22:175:27 | string |
 | test.cpp:175:17:175:19 | str indirection [string] | test.cpp:175:22:175:27 | string indirection |
 | test.cpp:175:22:175:27 | string indirection | test.cpp:175:22:175:27 | string |
-| test.cpp:179:17:179:19 | str indirection [string] | test.cpp:179:22:179:27 | string |
-| test.cpp:179:17:179:19 | str indirection [string] | test.cpp:179:22:179:27 | string indirection |
-| test.cpp:179:22:179:27 | string indirection | test.cpp:179:22:179:27 | string |
-| test.cpp:183:17:183:19 | str indirection [string] | test.cpp:183:22:183:27 | string |
-| test.cpp:183:17:183:19 | str indirection [string] | test.cpp:183:22:183:27 | string indirection |
-| test.cpp:183:22:183:27 | string indirection | test.cpp:183:22:183:27 | string |
 | test.cpp:187:17:187:19 | str indirection [string] | test.cpp:187:22:187:27 | string |
 | test.cpp:187:17:187:19 | str indirection [string] | test.cpp:187:22:187:27 | string indirection |
 | test.cpp:187:22:187:27 | string indirection | test.cpp:187:22:187:27 | string |
-| test.cpp:191:17:191:19 | str indirection [string] | test.cpp:191:22:191:27 | string |
-| test.cpp:191:17:191:19 | str indirection [string] | test.cpp:191:22:191:27 | string indirection |
-| test.cpp:191:22:191:27 | string indirection | test.cpp:191:22:191:27 | string |
 | test.cpp:195:17:195:19 | str indirection [string] | test.cpp:195:22:195:27 | string |
 | test.cpp:195:17:195:19 | str indirection [string] | test.cpp:195:22:195:27 | string indirection |
 | test.cpp:195:22:195:27 | string indirection | test.cpp:195:22:195:27 | string |
@@ -228,154 +88,48 @@ nodes
 | test.cpp:18:5:18:30 | ... = ... | semmle.label | ... = ... |
 | test.cpp:18:10:18:15 | str indirection [post update] [string] | semmle.label | str indirection [post update] [string] |
 | test.cpp:18:19:18:24 | call to malloc | semmle.label | call to malloc |
-| test.cpp:24:21:24:31 | call to mk_string_t indirection [string] | semmle.label | call to mk_string_t indirection [string] |
-| test.cpp:26:13:26:15 | str indirection [string] | semmle.label | str indirection [string] |
-| test.cpp:26:18:26:23 | string | semmle.label | string |
-| test.cpp:26:18:26:23 | string indirection | semmle.label | string indirection |
-| test.cpp:29:32:29:34 | str indirection [string] | semmle.label | str indirection [string] |
-| test.cpp:30:13:30:15 | str indirection [string] | semmle.label | str indirection [string] |
-| test.cpp:30:18:30:23 | string | semmle.label | string |
-| test.cpp:30:18:30:23 | string indirection | semmle.label | string indirection |
-| test.cpp:34:21:34:31 | call to mk_string_t indirection [string] | semmle.label | call to mk_string_t indirection [string] |
-| test.cpp:35:21:35:23 | str indirection [string] | semmle.label | str indirection [string] |
 | test.cpp:39:21:39:31 | call to mk_string_t indirection [string] | semmle.label | call to mk_string_t indirection [string] |
-| test.cpp:41:13:41:15 | str indirection [string] | semmle.label | str indirection [string] |
-| test.cpp:41:18:41:23 | string | semmle.label | string |
-| test.cpp:41:18:41:23 | string indirection | semmle.label | string indirection |
 | test.cpp:42:13:42:15 | str indirection [string] | semmle.label | str indirection [string] |
 | test.cpp:42:18:42:23 | string | semmle.label | string |
 | test.cpp:42:18:42:23 | string indirection | semmle.label | string indirection |
-| test.cpp:44:13:44:15 | str indirection [string] | semmle.label | str indirection [string] |
-| test.cpp:44:18:44:23 | string | semmle.label | string |
-| test.cpp:44:18:44:23 | string indirection | semmle.label | string indirection |
-| test.cpp:45:13:45:15 | str indirection [string] | semmle.label | str indirection [string] |
-| test.cpp:45:18:45:23 | string | semmle.label | string |
-| test.cpp:45:18:45:23 | string indirection | semmle.label | string indirection |
-| test.cpp:48:17:48:19 | str indirection [string] | semmle.label | str indirection [string] |
-| test.cpp:48:22:48:27 | string | semmle.label | string |
-| test.cpp:48:22:48:27 | string indirection | semmle.label | string indirection |
-| test.cpp:52:17:52:19 | str indirection [string] | semmle.label | str indirection [string] |
-| test.cpp:52:22:52:27 | string | semmle.label | string |
-| test.cpp:52:22:52:27 | string indirection | semmle.label | string indirection |
-| test.cpp:56:17:56:19 | str indirection [string] | semmle.label | str indirection [string] |
-| test.cpp:56:22:56:27 | string | semmle.label | string |
-| test.cpp:56:22:56:27 | string indirection | semmle.label | string indirection |
-| test.cpp:60:17:60:19 | str indirection [string] | semmle.label | str indirection [string] |
-| test.cpp:60:22:60:27 | string | semmle.label | string |
-| test.cpp:60:22:60:27 | string indirection | semmle.label | string indirection |
-| test.cpp:64:17:64:19 | str indirection [string] | semmle.label | str indirection [string] |
-| test.cpp:64:22:64:27 | string | semmle.label | string |
-| test.cpp:64:22:64:27 | string indirection | semmle.label | string indirection |
-| test.cpp:68:17:68:19 | str indirection [string] | semmle.label | str indirection [string] |
-| test.cpp:68:22:68:27 | string | semmle.label | string |
-| test.cpp:68:22:68:27 | string indirection | semmle.label | string indirection |
 | test.cpp:72:17:72:19 | str indirection [string] | semmle.label | str indirection [string] |
 | test.cpp:72:22:72:27 | string | semmle.label | string |
 | test.cpp:72:22:72:27 | string indirection | semmle.label | string indirection |
-| test.cpp:76:17:76:19 | str indirection [string] | semmle.label | str indirection [string] |
-| test.cpp:76:22:76:27 | string | semmle.label | string |
-| test.cpp:76:22:76:27 | string indirection | semmle.label | string indirection |
 | test.cpp:80:17:80:19 | str indirection [string] | semmle.label | str indirection [string] |
 | test.cpp:80:22:80:27 | string | semmle.label | string |
 | test.cpp:80:22:80:27 | string indirection | semmle.label | string indirection |
-| test.cpp:84:17:84:19 | str indirection [string] | semmle.label | str indirection [string] |
-| test.cpp:84:22:84:27 | string | semmle.label | string |
-| test.cpp:84:22:84:27 | string indirection | semmle.label | string indirection |
 | test.cpp:88:11:88:30 | mk_string_t_plus_one indirection [string] | semmle.label | mk_string_t_plus_one indirection [string] |
 | test.cpp:90:5:90:34 | ... = ... | semmle.label | ... = ... |
 | test.cpp:90:10:90:15 | str indirection [post update] [string] | semmle.label | str indirection [post update] [string] |
 | test.cpp:90:19:90:24 | call to malloc | semmle.label | call to malloc |
 | test.cpp:96:21:96:40 | call to mk_string_t_plus_one indirection [string] | semmle.label | call to mk_string_t_plus_one indirection [string] |
-| test.cpp:98:13:98:15 | str indirection [string] | semmle.label | str indirection [string] |
-| test.cpp:98:18:98:23 | string | semmle.label | string |
-| test.cpp:98:18:98:23 | string indirection | semmle.label | string indirection |
 | test.cpp:99:13:99:15 | str indirection [string] | semmle.label | str indirection [string] |
 | test.cpp:99:18:99:23 | string | semmle.label | string |
 | test.cpp:99:18:99:23 | string indirection | semmle.label | string indirection |
-| test.cpp:101:13:101:15 | str indirection [string] | semmle.label | str indirection [string] |
-| test.cpp:101:18:101:23 | string | semmle.label | string |
-| test.cpp:101:18:101:23 | string indirection | semmle.label | string indirection |
-| test.cpp:102:13:102:15 | str indirection [string] | semmle.label | str indirection [string] |
-| test.cpp:102:18:102:23 | string | semmle.label | string |
-| test.cpp:102:18:102:23 | string indirection | semmle.label | string indirection |
-| test.cpp:105:17:105:19 | str indirection [string] | semmle.label | str indirection [string] |
-| test.cpp:105:22:105:27 | string | semmle.label | string |
-| test.cpp:105:22:105:27 | string indirection | semmle.label | string indirection |
-| test.cpp:109:17:109:19 | str indirection [string] | semmle.label | str indirection [string] |
-| test.cpp:109:22:109:27 | string | semmle.label | string |
-| test.cpp:109:22:109:27 | string indirection | semmle.label | string indirection |
-| test.cpp:113:17:113:19 | str indirection [string] | semmle.label | str indirection [string] |
-| test.cpp:113:22:113:27 | string | semmle.label | string |
-| test.cpp:113:22:113:27 | string indirection | semmle.label | string indirection |
-| test.cpp:117:17:117:19 | str indirection [string] | semmle.label | str indirection [string] |
-| test.cpp:117:22:117:27 | string | semmle.label | string |
-| test.cpp:117:22:117:27 | string indirection | semmle.label | string indirection |
-| test.cpp:121:17:121:19 | str indirection [string] | semmle.label | str indirection [string] |
-| test.cpp:121:22:121:27 | string | semmle.label | string |
-| test.cpp:121:22:121:27 | string indirection | semmle.label | string indirection |
-| test.cpp:125:17:125:19 | str indirection [string] | semmle.label | str indirection [string] |
-| test.cpp:125:22:125:27 | string | semmle.label | string |
-| test.cpp:125:22:125:27 | string indirection | semmle.label | string indirection |
 | test.cpp:129:17:129:19 | str indirection [string] | semmle.label | str indirection [string] |
 | test.cpp:129:22:129:27 | string | semmle.label | string |
 | test.cpp:129:22:129:27 | string indirection | semmle.label | string indirection |
-| test.cpp:133:17:133:19 | str indirection [string] | semmle.label | str indirection [string] |
-| test.cpp:133:22:133:27 | string | semmle.label | string |
-| test.cpp:133:22:133:27 | string indirection | semmle.label | string indirection |
 | test.cpp:137:17:137:19 | str indirection [string] | semmle.label | str indirection [string] |
 | test.cpp:137:22:137:27 | string | semmle.label | string |
 | test.cpp:137:22:137:27 | string indirection | semmle.label | string indirection |
-| test.cpp:141:17:141:19 | str indirection [string] | semmle.label | str indirection [string] |
-| test.cpp:141:22:141:27 | string | semmle.label | string |
-| test.cpp:141:22:141:27 | string indirection | semmle.label | string indirection |
 | test.cpp:147:5:147:34 | ... = ... | semmle.label | ... = ... |
 | test.cpp:147:10:147:15 | str indirection [post update] [string] | semmle.label | str indirection [post update] [string] |
 | test.cpp:147:19:147:24 | call to malloc | semmle.label | call to malloc |
-| test.cpp:150:13:150:15 | str indirection [string] | semmle.label | str indirection [string] |
-| test.cpp:150:18:150:23 | string | semmle.label | string |
-| test.cpp:150:18:150:23 | string indirection | semmle.label | string indirection |
-| test.cpp:151:13:151:15 | str indirection [string] | semmle.label | str indirection [string] |
-| test.cpp:151:18:151:23 | string | semmle.label | string |
-| test.cpp:151:18:151:23 | string indirection | semmle.label | string indirection |
 | test.cpp:152:13:152:15 | str indirection [string] | semmle.label | str indirection [string] |
 | test.cpp:152:18:152:23 | string | semmle.label | string |
 | test.cpp:152:18:152:23 | string indirection | semmle.label | string indirection |
 | test.cpp:154:13:154:15 | str indirection [string] | semmle.label | str indirection [string] |
 | test.cpp:154:18:154:23 | string | semmle.label | string |
 | test.cpp:154:18:154:23 | string indirection | semmle.label | string indirection |
-| test.cpp:155:13:155:15 | str indirection [string] | semmle.label | str indirection [string] |
-| test.cpp:155:18:155:23 | string | semmle.label | string |
-| test.cpp:155:18:155:23 | string indirection | semmle.label | string indirection |
 | test.cpp:156:13:156:15 | str indirection [string] | semmle.label | str indirection [string] |
 | test.cpp:156:18:156:23 | string | semmle.label | string |
 | test.cpp:156:18:156:23 | string indirection | semmle.label | string indirection |
-| test.cpp:159:17:159:19 | str indirection [string] | semmle.label | str indirection [string] |
-| test.cpp:159:22:159:27 | string | semmle.label | string |
-| test.cpp:159:22:159:27 | string indirection | semmle.label | string indirection |
-| test.cpp:163:17:163:19 | str indirection [string] | semmle.label | str indirection [string] |
-| test.cpp:163:22:163:27 | string | semmle.label | string |
-| test.cpp:163:22:163:27 | string indirection | semmle.label | string indirection |
-| test.cpp:167:17:167:19 | str indirection [string] | semmle.label | str indirection [string] |
-| test.cpp:167:22:167:27 | string | semmle.label | string |
-| test.cpp:167:22:167:27 | string indirection | semmle.label | string indirection |
-| test.cpp:171:17:171:19 | str indirection [string] | semmle.label | str indirection [string] |
-| test.cpp:171:22:171:27 | string | semmle.label | string |
-| test.cpp:171:22:171:27 | string indirection | semmle.label | string indirection |
 | test.cpp:175:17:175:19 | str indirection [string] | semmle.label | str indirection [string] |
 | test.cpp:175:22:175:27 | string | semmle.label | string |
 | test.cpp:175:22:175:27 | string indirection | semmle.label | string indirection |
-| test.cpp:179:17:179:19 | str indirection [string] | semmle.label | str indirection [string] |
-| test.cpp:179:22:179:27 | string | semmle.label | string |
-| test.cpp:179:22:179:27 | string indirection | semmle.label | string indirection |
-| test.cpp:183:17:183:19 | str indirection [string] | semmle.label | str indirection [string] |
-| test.cpp:183:22:183:27 | string | semmle.label | string |
-| test.cpp:183:22:183:27 | string indirection | semmle.label | string indirection |
 | test.cpp:187:17:187:19 | str indirection [string] | semmle.label | str indirection [string] |
 | test.cpp:187:22:187:27 | string | semmle.label | string |
 | test.cpp:187:22:187:27 | string indirection | semmle.label | string indirection |
-| test.cpp:191:17:191:19 | str indirection [string] | semmle.label | str indirection [string] |
-| test.cpp:191:22:191:27 | string | semmle.label | string |
-| test.cpp:191:22:191:27 | string indirection | semmle.label | string indirection |
 | test.cpp:195:17:195:19 | str indirection [string] | semmle.label | str indirection [string] |
 | test.cpp:195:22:195:27 | string | semmle.label | string |
 | test.cpp:195:22:195:27 | string indirection | semmle.label | string indirection |
@@ -423,6 +177,6 @@ subpaths
 | test.cpp:199:9:199:15 | call to strncpy | test.cpp:147:19:147:24 | call to malloc | test.cpp:199:22:199:27 | string | This write may overflow $@ by 2 elements. | test.cpp:199:22:199:27 | string | string |
 | test.cpp:203:9:203:15 | call to strncpy | test.cpp:147:19:147:24 | call to malloc | test.cpp:203:22:203:27 | string | This write may overflow $@ by 2 elements. | test.cpp:203:22:203:27 | string | string |
 | test.cpp:207:9:207:15 | call to strncpy | test.cpp:147:19:147:24 | call to malloc | test.cpp:207:22:207:27 | string | This write may overflow $@ by 3 elements. | test.cpp:207:22:207:27 | string | string |
-| test.cpp:232:3:232:8 | call to memset | test.cpp:228:43:228:48 | call to malloc | test.cpp:232:10:232:15 | buffer | This write may overflow $@ by 32 elements. | test.cpp:232:10:232:15 | buffer | buffer |
+| test.cpp:232:3:232:8 | call to memset | test.cpp:228:43:228:48 | call to malloc | test.cpp:232:10:232:15 | buffer | This write may overflow $@ by 2 elements. | test.cpp:232:10:232:15 | buffer | buffer |
 | test.cpp:243:5:243:10 | call to memset | test.cpp:241:27:241:32 | call to malloc | test.cpp:243:12:243:21 | string | This write may overflow $@ by 1 element. | test.cpp:243:16:243:21 | string | string |
 | test.cpp:250:5:250:10 | call to memset | test.cpp:249:20:249:27 | call to my_alloc | test.cpp:250:12:250:12 | p | This write may overflow $@ by 1 element. | test.cpp:250:12:250:12 | p | p |


### PR DESCRIPTION
This fixes the performance regression we got from https://github.com/github/codeql/pull/13099.

Keeping this in draft until we can run DCA.