### PR TITLE
JS: Make implicit this receivers explicit

### DIFF
--- a/javascript/ql/test/tutorials/Validating RAML-based APIs/RAML.qll
+++ b/javascript/ql/test/tutorials/Validating RAML-based APIs/RAML.qll
@@ -34,7 +34,7 @@ class RamlResource extends YamlMapping {
   /** Get the method for this resource with the given verb. */
   RamlMethod getMethod(string verb) {
     verb = httpVerb() and
-    result = lookup(verb)
+    result = this.lookup(verb)
   }
 }
 


### PR DESCRIPTION
Not sure how this last implicit this slipped through, but it was [caught by QL-for-QL](https://github.com/github/codeql/security/code-scanning/82840). 