### PR TITLE
C#: Remove jump step

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/dataflow/FlowSummary.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/FlowSummary.qll
@@ -64,15 +64,6 @@ module SummaryComponent {
   /** Gets a summary component that represents the return value of a call. */
   SummaryComponent return() { result = return(any(DataFlowDispatch::NormalReturnKind rk)) }
 
-  /** Gets a summary component that represents a jump to `c`. */
-  SummaryComponent jump(Callable c) {
-    result =
-      return(any(DataFlowDispatch::JumpReturnKind jrk |
-          jrk.getTarget() = c.getUnboundDeclaration() and
-          jrk.getTargetReturnKind() instanceof DataFlowDispatch::NormalReturnKind
-        ))
-  }
-
   predicate syntheticGlobal = SummaryComponentInternal::syntheticGlobal/1;
 
   class SyntheticGlobal = SummaryComponentInternal::SyntheticGlobal;
@@ -113,9 +104,6 @@ module SummaryComponentStack {
 
   /** Gets a singleton stack representing the return value of a call. */
   SummaryComponentStack return() { result = singleton(SummaryComponent::return()) }
-
-  /** Gets a singleton stack representing a jump to `c`. */
-  SummaryComponentStack jump(Callable c) { result = singleton(SummaryComponent::jump(c)) }
 
   /** Gets a singleton stack representing a synthetic global with name `name`. */
   SummaryComponentStack syntheticGlobal(string synthetic) {

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowDispatch.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowDispatch.qll
@@ -74,18 +74,6 @@ newtype TReturnKind =
     exists(Ssa::ExplicitDefinition def | def.isCapturedVariableDefinitionFlowOut(_, _) |
       v = def.getSourceVariable().getAssignable()
     )
-  } or
-  TJumpReturnKind(Callable target, ReturnKind rk) {
-    target.isUnboundDeclaration() and
-    (
-      rk instanceof NormalReturnKind and
-      (
-        target instanceof Constructor or
-        not target.getReturnType() instanceof VoidType
-      )
-      or
-      exists(target.getParameter(rk.(OutRefReturnKind).getPosition()))
-    )
   }
 
 /**
@@ -255,27 +243,6 @@ class ImplicitCapturedReturnKind extends ReturnKind, TImplicitCapturedReturnKind
   LocalScopeVariable getVariable() { result = v }
 
   override string toString() { result = "captured " + v }
-}
-
-/**
- * A value returned through the output of another callable.
- *
- * This is currently only used to model flow summaries where data may flow into
- * one API entry point and out of another.
- */
-class JumpReturnKind extends ReturnKind, TJumpReturnKind {
-  private Callable target;
-  private ReturnKind rk;
-
-  JumpReturnKind() { this = TJumpReturnKind(target, rk) }
-
-  /** Gets the target of the jump. */
-  Callable getTarget() { result = target }
-
-  /** Gets the return kind of the target. */
-  ReturnKind getTargetReturnKind() { result = rk }
-
-  override string toString() { result = "jump to " + target }
 }
 
 /** A callable used for data flow. */

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -1457,8 +1457,7 @@ private module ReturnNodes {
     private ReturnKind rk;
 
     SummaryReturnNode() {
-      FlowSummaryImpl::Private::summaryReturnNode(this.getSummaryNode(), rk) and
-      not rk instanceof JumpReturnKind
+      FlowSummaryImpl::Private::summaryReturnNode(this.getSummaryNode(), rk)
       or
       exists(Parameter p, int pos |
         summaryPostUpdateNodeIsOutOrRef(this, p) and
@@ -1706,12 +1705,6 @@ predicate jumpStep(Node pred, Node succ) {
     fl.getAnAccess() = flr and
     flr = succ.asExpr() and
     flr.hasNonlocalValue()
-  )
-  or
-  exists(JumpReturnKind jrk, NonDelegateDataFlowCall call |
-    FlowSummaryImpl::Private::summaryReturnNode(pred.(FlowSummaryNode).getSummaryNode(), jrk) and
-    jrk.getTarget() = call.getATarget(_) and
-    succ = getAnOutNode(call, jrk.getTargetReturnKind())
   )
   or
   FlowSummaryImpl::Private::Steps::summaryJumpStep(pred.(FlowSummaryNode).getSummaryNode(),

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/FlowSummaryImplSpecific.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/FlowSummaryImplSpecific.qll
@@ -61,6 +61,7 @@ DataFlowType getParameterType(SummarizedCallable c, ParameterPosition pos) {
   )
 }
 
+/** Gets the return type of kind `rk` for callable `c`. */
 DataFlowType getReturnType(DotNet::Callable c, ReturnKind rk) {
   exists(Type t | result = Gvn::getGlobalValueNumber(t) |
     rk instanceof NormalReturnKind and

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/FlowSummaryImplSpecific.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/FlowSummaryImplSpecific.qll
@@ -61,7 +61,7 @@ DataFlowType getParameterType(SummarizedCallable c, ParameterPosition pos) {
   )
 }
 
-private DataFlowType getReturnTypeBase(DotNet::Callable c, ReturnKind rk) {
+DataFlowType getReturnType(DotNet::Callable c, ReturnKind rk) {
   exists(Type t | result = Gvn::getGlobalValueNumber(t) |
     rk instanceof NormalReturnKind and
     (
@@ -73,15 +73,6 @@ private DataFlowType getReturnTypeBase(DotNet::Callable c, ReturnKind rk) {
     or
     t = c.getParameter(rk.(OutRefReturnKind).getPosition()).getType()
   )
-}
-
-/** Gets the return type of kind `rk` for callable `c`. */
-bindingset[c]
-DataFlowType getReturnType(SummarizedCallable c, ReturnKind rk) {
-  result = getReturnTypeBase(c, rk)
-  or
-  rk =
-    any(JumpReturnKind jrk | result = getReturnTypeBase(jrk.getTarget(), jrk.getTargetReturnKind()))
 }
 
 /**


### PR DESCRIPTION
In this PR we remove the *jump return kind* and related functionality as it is no longer used.
The last/only use case was re-factored into using *synthetic globals* instead: https://github.com/github/codeql/pull/13147

The only question is, whether we should deprecate this instead of deleting it?
I can't imagine anyone is using it (famous last words).