### PR TITLE
JS: fixup in the qhelp for `js/prototype-polluting-assignment`

### DIFF
--- a/javascript/ql/src/Security/CWE-915/PrototypePollutingAssignment.inc.qhelp
+++ b/javascript/ql/src/Security/CWE-915/PrototypePollutingAssignment.inc.qhelp
@@ -35,8 +35,8 @@
   <p>
     In the example below, the untrusted value <code>req.params.id</code> is used as the property name
     <code>req.session.todos[id]</code>. If a malicious user passes in the ID value <code>__proto__</code>,
-    the variable <code>todo</code> will then refer to <code>Object.prototype</code>.
-    Finally, the modification of <code>todo</code> then allows the attacker to inject arbitrary properties
+    the variable <code>items</code> will then refer to <code>Object.prototype</code>.
+    Finally, the modification of <code>items</code> then allows the attacker to inject arbitrary properties
     onto <code>Object.prototype</code>.
   </p>
 

--- a/javascript/ql/src/Security/CWE-915/PrototypePollutingAssignment.inc.qhelp
+++ b/javascript/ql/src/Security/CWE-915/PrototypePollutingAssignment.inc.qhelp
@@ -48,6 +48,12 @@
   </p>
 
   <sample src="examples/PrototypePollutingAssignmentFixed.js"/>
+
+  <p>
+    Another way to fix it is to prevent the <code>__proto__</code> property from being used as a key, as shown below:
+  </p>
+
+  <sample src="examples/PrototypePollutingAssignmentFixed2.js"/>
   
 </example>
 

--- a/javascript/ql/src/Security/CWE-915/examples/PrototypePollutingAssignmentFixed2.js
+++ b/javascript/ql/src/Security/CWE-915/examples/PrototypePollutingAssignmentFixed2.js
@@ -1,0 +1,16 @@
+let express = require('express');
+let app = express()
+
+app.put('/todos/:id', (req, res) => {
+    let id = req.params.id;
+    if (id === '__proto__' || id === 'constructor' || id === 'prototype') {
+        res.end(403);
+        return;
+    }
+    let items = req.session.todos[id];
+    if (!items) {
+        items = req.session.todos[id] = {};
+    }
+    items[req.query.name] = req.query.text;
+    res.end(200);
+});


### PR DESCRIPTION
QHelp preview doesn't handle `.inc` file changes too well, so ignore the comment below. 

The commits messages should explain what is changed. 