### PR TITLE
Swift: Use `...` to find and run all Bazel tests instead of having list them.

### DIFF
--- a/swift/actions/build-and-test/action.yml
+++ b/swift/actions/build-and-test/action.yml
@@ -53,21 +53,16 @@ runs:
       shell: bash
       run: |
         bazel run //swift:create-extractor-pack
-    - name: Run xcode-autobuilder tests
-      if : ${{ github.event_name == 'pull_request' && runner.os == 'macOS' }}
-      shell: bash
-      run: |
-        bazel test //swift/xcode-autobuilder/tests
     - name: Run codegen tests
       if : ${{ github.event_name == 'pull_request' }}
       shell: bash
       run: |
-        bazel test //misc/codegen/test
-    - name: Run qltest tests
-      if : ${{ github.event_name == 'pull_request' }}
+        bazel test //misc/codegen/...
+    - name: Run Swift tests
+      if: ${{ github.event_name == 'pull_request' }}
       shell: bash
       run: |
-        bazel test //swift/tools/test/qltest
+        bazel test //swift/...
     - name: Evict bazel cache
       if: ${{ github.event_name != 'pull_request' }}
       shell: bash


### PR DESCRIPTION
Note that we no longer check whether we're on a macOS runner explicitly since Bazel can automatically determine which tests are compatible (e.g. the XCode autobuild tests depend on `//swift/xcode-autobuilder`, which has a `target_compatible_with = ["@platforms//os:macos"]` attribute).