### PR TITLE
Fix "Introducing the JavaScript libraries" query12.qll and add test case

### DIFF
--- a/javascript/ql/test/tutorials/Introducing the JavaScript libraries/query12.qll
+++ b/javascript/ql/test/tutorials/Introducing the JavaScript libraries/query12.qll
@@ -4,7 +4,7 @@ query predicate test_query12(MethodCallExpr send) {
   exists(SimpleParameter res, DataFlow::Node resNode |
     res.getName() = "res" and
     resNode = DataFlow::parameterNode(res) and
-    resNode.getASuccessor() = DataFlow::valueNode(send.getReceiver()) and
+    resNode.getASuccessor+() = DataFlow::valueNode(send.getReceiver()) and
     send.getMethodName() = "send"
   |
     any()

--- a/javascript/ql/test/tutorials/Introducing the JavaScript libraries/tests.expected
+++ b/javascript/ql/test/tutorials/Introducing the JavaScript libraries/tests.expected
@@ -21,6 +21,7 @@ test_query11
 | tst.js:31:18:31:18 | x | Dead store of local variable. |
 | tst.js:38:7:38:23 | password = "blah" | Dead store of local variable. |
 test_query12
+| tst.js:42:3:42:12 | res.send() |
 test_query20
 test_query3
 | tst.js:27:1:27:4 | <!-- | Do not use HTML comments. |

--- a/javascript/ql/test/tutorials/Introducing the JavaScript libraries/tst.js
+++ b/javascript/ql/test/tutorials/Introducing the JavaScript libraries/tst.js
@@ -37,3 +37,7 @@ var j, j;
 function foo() {
   var password = "blah";
 }
+
+function m(res) {
+  res.send()
+}


### PR DESCRIPTION
Just noticed that `query12.qll` was missing a `+` in the getASuccessor predicate and added a test case for the query in the test file `tst.js`, confirming that the query finds an invocation then.