### PR TITLE
Swift: Recommend a proper source of randomness in `swift/hardcoded-key`

### DIFF
--- a/swift/ql/src/queries/Security/CWE-321/HardcodedEncryptionKey.swift
+++ b/swift/ql/src/queries/Security/CWE-321/HardcodedEncryptionKey.swift
@@ -14,7 +14,7 @@ func encrypt(padding : Padding) {
 
 	// GOOD: Using randomly generated keys for encryption
 	var key = [Int8](repeating: 0, count: 10)
-	let status = SecRandomCopyBytes(kSecRandomDefault, key.count, &key)
+	let status = SecRandomCopyBytes(kSecRandomDefault, key.count - 1, &key)
 	if status == errSecSuccess {
 		let keyString = String(cString: key)
 		let ivString = getRandomIV()

--- a/swift/ql/src/queries/Security/CWE-321/HardcodedEncryptionKey.swift
+++ b/swift/ql/src/queries/Security/CWE-321/HardcodedEncryptionKey.swift
@@ -13,13 +13,16 @@ func encrypt(padding : Padding) {
 
 
 	// GOOD: Using randomly generated keys for encryption
-	let key = (0..<10).map({ _ in UInt8.random(in: 0...UInt8.max) })
-	let keyString = String(cString: key)
-	let ivString = getRandomIV()
-	_ = try AES(key: key, blockMode: CBC(), padding: padding)
-	_ = try AES(key: keyString, iv: ivString)
-	_ = try Blowfish(key: key, blockMode: CBC(), padding: padding)
-	_ = try Blowfish(key: keyString, iv: ivString)
+	var key = [Int8](repeating: 0, count: 10)
+	let status = SecRandomCopyBytes(kSecRandomDefault, key.count, &key)
+	if status == errSecSuccess {
+		let keyString = String(cString: key)
+		let ivString = getRandomIV()
+		_ = try AES(key: key, blockMode: CBC(), padding: padding)
+		_ = try AES(key: keyString, iv: ivString)
+		_ = try Blowfish(key: key, blockMode: CBC(), padding: padding)
+		_ = try Blowfish(key: keyString, iv: ivString)
+	}
 
 	// ...
 }


### PR DESCRIPTION
@GeekMasher pointed out that `UInt8.random` uses a "cryptographically secure algorithm _whenever possible_.", which isn't the kind of thing we want to suggest for cryptographic use-cases. So this PR rewrites the recommendation to use `SecRandomCopyBytes` instead.

I also found some more discussions of this online: https://forums.swift.org/t/random-data-uint8-random-or-secrandomcopybytes/56165/3. They seem to agree with the choice of `SecRandomCopyBytes`.