### PR TITLE
C++: Add example with conflation in dataflow

### DIFF
--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/dataflow-consistency.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/dataflow-consistency.expected
@@ -125,6 +125,8 @@ postWithInFlow
 | test.cpp:681:3:681:3 | s [post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:689:3:689:3 | s [post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:690:3:690:3 | s [post update] | PostUpdateNode should not be the target of local flow. |
+| test.cpp:694:4:694:6 | buf [inner post update] | PostUpdateNode should not be the target of local flow. |
+| test.cpp:704:23:704:25 | buf [inner post update] | PostUpdateNode should not be the target of local flow. |
 viableImplInCallContextTooLarge
 uniqueParameterNodeAtPosition
 uniqueParameterNodePosition

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
@@ -690,3 +690,16 @@ void test_static_local_9() {
   s = 0;
 }
 
+void increment_buf(int** buf) { // $ ast-def=buf ir-def=*buf ir-def=**buf
+  *buf += 10;
+  sink(buf); // $ SPURIOUS: ast,ir // should only be flow to the indirect argument, but there's also flow to the non-indirect argument
+}
+
+void call_increment_buf(int** buf) { // $ ast-def=buf
+  increment_buf(buf);
+}
+
+void test_conflation_regression(int* source) { // $ ast-def=source
+  int* buf = source;
+  call_increment_buf(&buf);
+}


### PR DESCRIPTION
This seems to reproduce some strange pointer/pointee conflation that @jketema and I were seeing on a project with the `cpp/invalid-pointer-deref` query. This may also be related to the pointer/pointee conflation I saw with `@andersfugmann`.