### PR TITLE
Java: Automodel Extraction Parameter Name Fix

### DIFF
--- a/java/ql/src/Telemetry/AutomodelFrameworkModeCharacteristics.qll
+++ b/java/ql/src/Telemetry/AutomodelFrameworkModeCharacteristics.qll
@@ -175,7 +175,7 @@ class FrameworkModeMetadataExtractor extends MetadataExtractor {
       type = callable.getDeclaringType().getErasure().(RefType).nestedName() and
       subtypes = this.considerSubtypes(callable) and
       name = callable.getName() and
-      parameterName = e.toString() and
+      parameterName = e.asParameter().getName() and
       signature = ExternalFlow::paramsString(callable)
     )
   }

--- a/java/ql/src/Telemetry/AutomodelFrameworkModeCharacteristics.qll
+++ b/java/ql/src/Telemetry/AutomodelFrameworkModeCharacteristics.qll
@@ -27,7 +27,7 @@ abstract class MetadataExtractor extends string {
 
   abstract predicate hasMetadata(
     DataFlow::ParameterNode e, string package, string type, boolean subtypes, string name,
-    string signature, int input
+    string signature, int input, string parameterName
   );
 }
 
@@ -167,14 +167,15 @@ class FrameworkModeMetadataExtractor extends MetadataExtractor {
 
   override predicate hasMetadata(
     Endpoint e, string package, string type, boolean subtypes, string name, string signature,
-    int input
+    int input, string parameterName
   ) {
     exists(Callable callable |
       e.asParameter() = callable.getParameter(input) and
       package = callable.getDeclaringType().getPackage().getName() and
       type = callable.getDeclaringType().getErasure().(RefType).nestedName() and
       subtypes = this.considerSubtypes(callable) and
-      name = e.toString() and
+      name = callable.getName() and
+      parameterName = e.toString() and
       signature = ExternalFlow::paramsString(callable)
     )
   }

--- a/java/ql/src/Telemetry/AutomodelFrameworkModeExtractCandidates.ql
+++ b/java/ql/src/Telemetry/AutomodelFrameworkModeExtractCandidates.ql
@@ -17,7 +17,7 @@ private import AutomodelSharedUtil
 
 from
   Endpoint endpoint, string message, MetadataExtractor meta, string package, string type,
-  boolean subtypes, string name, string signature, int input
+  boolean subtypes, string name, string signature, int input, string parameterName
 where
   not exists(CharacteristicsImpl::UninterestingToModelCharacteristic u |
     u.appliesToEndpoint(endpoint)
@@ -28,7 +28,7 @@ where
   // overlap between our detected sinks and the pre-existing modeling. We assume that, if a sink has already been
   // modeled in a MaD model, then it doesn't belong to any additional sink types, and we don't need to reexamine it.
   not CharacteristicsImpl::isSink(endpoint, _) and
-  meta.hasMetadata(endpoint, package, type, subtypes, name, signature, input) and
+  meta.hasMetadata(endpoint, package, type, subtypes, name, signature, input, parameterName) and
   // The message is the concatenation of all sink types for which this endpoint is known neither to be a sink nor to be
   // a non-sink, and we surface only endpoints that have at least one such sink type.
   message =
@@ -47,4 +47,5 @@ select endpoint,
   subtypes.toString().(DollarAtString), "subtypes", //
   name.(DollarAtString), "name", //
   signature.(DollarAtString), "signature", //
-  input.toString().(DollarAtString), "input" //
+  input.toString().(DollarAtString), "input", //
+  parameterName.(DollarAtString), "parameterName" //

--- a/java/ql/src/Telemetry/AutomodelFrameworkModeExtractCandidates.ql
+++ b/java/ql/src/Telemetry/AutomodelFrameworkModeExtractCandidates.ql
@@ -39,7 +39,7 @@ where
       sinkType, ", "
     )
 select endpoint,
-  message + "\nrelated locations: $@, $@." + "\nmetadata: $@, $@, $@, $@, $@, $@.", //
+  message + "\nrelated locations: $@, $@." + "\nmetadata: $@, $@, $@, $@, $@, $@, $@.", //
   CharacteristicsImpl::getRelatedLocationOrCandidate(endpoint, MethodDoc()), "MethodDoc", //
   CharacteristicsImpl::getRelatedLocationOrCandidate(endpoint, ClassDoc()), "ClassDoc", //
   package.(DollarAtString), "package", //

--- a/java/ql/src/Telemetry/AutomodelFrameworkModeExtractNegativeExamples.ql
+++ b/java/ql/src/Telemetry/AutomodelFrameworkModeExtractNegativeExamples.ql
@@ -36,7 +36,7 @@ where
   ) and
   message = characteristic
 select endpoint,
-  message + "\nrelated locations: $@, $@." + "\nmetadata: $@, $@, $@, $@, $@, $@.", //
+  message + "\nrelated locations: $@, $@." + "\nmetadata: $@, $@, $@, $@, $@, $@, $@.", //
   CharacteristicsImpl::getRelatedLocationOrCandidate(endpoint, MethodDoc()), "MethodDoc", //
   CharacteristicsImpl::getRelatedLocationOrCandidate(endpoint, ClassDoc()), "ClassDoc", //
   package.(DollarAtString), "package", //

--- a/java/ql/src/Telemetry/AutomodelFrameworkModeExtractNegativeExamples.ql
+++ b/java/ql/src/Telemetry/AutomodelFrameworkModeExtractNegativeExamples.ql
@@ -15,7 +15,7 @@ private import AutomodelSharedUtil
 from
   Endpoint endpoint, EndpointCharacteristic characteristic, float confidence, string message,
   MetadataExtractor meta, string package, string type, boolean subtypes, string name,
-  string signature, int input
+  string signature, int input, string parameterName
 where
   characteristic.appliesToEndpoint(endpoint) and
   confidence >= SharedCharacteristics::highConfidence() and
@@ -23,7 +23,7 @@ where
   // Exclude endpoints that have contradictory endpoint characteristics, because we only want examples we're highly
   // certain about in the prompt.
   not erroneousEndpoints(endpoint, _, _, _, _, false) and
-  meta.hasMetadata(endpoint, package, type, subtypes, name, signature, input) and
+  meta.hasMetadata(endpoint, package, type, subtypes, name, signature, input, parameterName) and
   // It's valid for a node to satisfy the logic for both `isSink` and `isSanitizer`, but in that case it will be
   // treated by the actual query as a sanitizer, since the final logic is something like
   // `isSink(n) and not isSanitizer(n)`. We don't want to include such nodes as negative examples in the prompt, because
@@ -44,4 +44,5 @@ select endpoint,
   subtypes.toString().(DollarAtString), "subtypes", //
   name.(DollarAtString), "name", //
   signature.(DollarAtString), "signature", //
-  input.toString().(DollarAtString), "input" //
+  input.toString().(DollarAtString), "input", //
+  parameterName.(DollarAtString), "parameterName" //

--- a/java/ql/src/Telemetry/AutomodelFrameworkModeExtractPositiveExamples.ql
+++ b/java/ql/src/Telemetry/AutomodelFrameworkModeExtractPositiveExamples.ql
@@ -14,12 +14,12 @@ private import AutomodelSharedUtil
 
 from
   Endpoint endpoint, SinkType sinkType, MetadataExtractor meta, string package, string type,
-  boolean subtypes, string name, string signature, int input
+  boolean subtypes, string name, string signature, int input, string parameterName
 where
   // Exclude endpoints that have contradictory endpoint characteristics, because we only want examples we're highly
   // certain about in the prompt.
   not erroneousEndpoints(endpoint, _, _, _, _, false) and
-  meta.hasMetadata(endpoint, package, type, subtypes, name, signature, input) and
+  meta.hasMetadata(endpoint, package, type, subtypes, name, signature, input, parameterName) and
   // Extract positive examples of sinks belonging to the existing ATM query configurations.
   CharacteristicsImpl::isKnownSink(endpoint, sinkType)
 select endpoint,
@@ -31,4 +31,5 @@ select endpoint,
   subtypes.toString().(DollarAtString), "subtypes", //
   name.(DollarAtString), "name", //
   signature.(DollarAtString), "signature", //
-  input.toString().(DollarAtString), "input" //
+  input.toString().(DollarAtString), "input", //
+  parameterName.(DollarAtString), "parameterName" //

--- a/java/ql/src/Telemetry/AutomodelFrameworkModeExtractPositiveExamples.ql
+++ b/java/ql/src/Telemetry/AutomodelFrameworkModeExtractPositiveExamples.ql
@@ -23,7 +23,7 @@ where
   // Extract positive examples of sinks belonging to the existing ATM query configurations.
   CharacteristicsImpl::isKnownSink(endpoint, sinkType)
 select endpoint,
-  sinkType + "\nrelated locations: $@, $@." + "\nmetadata: $@, $@, $@, $@, $@, $@.", //
+  sinkType + "\nrelated locations: $@, $@." + "\nmetadata: $@, $@, $@, $@, $@, $@, $@.", //
   CharacteristicsImpl::getRelatedLocationOrCandidate(endpoint, MethodDoc()), "MethodDoc", //
   CharacteristicsImpl::getRelatedLocationOrCandidate(endpoint, ClassDoc()), "ClassDoc", //
   package.(DollarAtString), "package", //


### PR DESCRIPTION
The exported `name` metadata parameter used to wrongly contain the _parameter_ name, but should've contained the _method_ name.

This fixes the bug, and exports the parameter name as `parameterName` metadata parameter.
