### PR TITLE
Java: Use empty toolchains.xml for java-version-too-old

### DIFF
--- a/java/ql/integration-tests/all-platforms/java/diagnostics/java-version-too-old/test.py
+++ b/java/ql/integration-tests/all-platforms/java/diagnostics/java-version-too-old/test.py
@@ -13,6 +13,12 @@ for k in ["JAVA_HOME_11_X64", "JAVA_HOME_17_X64"]:
   if k in os.environ:
     del os.environ[k]
 
-run_codeql_database_create([], lang="java", runFunction = runUnsuccessfully, db = None)
+# Use a custom, empty toolchains.xml file so the autobuilder doesn't see any Java versions that may be
+# in a system-level toolchains file
+toolchains_path = os.path.join(os.getcwd(), 'toolchains.xml')
+
+run_codeql_database_create([], lang="java", runFunction = runUnsuccessfully, db = None, extra_env={
+  'LGTM_INDEX_MAVEN_TOOLCHAINS_FILE': toolchains_path
+})
 
 check_diagnostics()

--- a/java/ql/integration-tests/all-platforms/java/diagnostics/java-version-too-old/toolchains.xml
+++ b/java/ql/integration-tests/all-platforms/java/diagnostics/java-version-too-old/toolchains.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<toolchains xmlns="https://maven.apache.org/TOOLCHAINS/1.1.0"
+  xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="https://maven.apache.org/TOOLCHAINS/1.1.0 https://maven.apache.org/xsd/toolchains-1.1.0.xsd">
+</toolchains>


### PR DESCRIPTION
Follow-up to #13180 which didn't fix the `java-version-too-old` enough to prevent test failures in future work. This change now also makes sure that the test completely disregards any `toolchain.xml` files that may be present on a given system. 