### PR TITLE
Change regexp to include released change-notes pattern

### DIFF
--- a/.github/workflows/check-change-note.yml
+++ b/.github/workflows/check-change-note.yml
@@ -2,7 +2,7 @@ name: Check change note
 
 on:
   pull_request_target:
-    types: [labeled, unlabeled, opened, synchronize, reopened, ready_for_review]q
+    types: [labeled, unlabeled, opened, synchronize, reopened, ready_for_review]
     paths:
       - "*/ql/src/**/*.ql"
       - "*/ql/src/**/*.qll"

--- a/.github/workflows/check-change-note.yml
+++ b/.github/workflows/check-change-note.yml
@@ -27,9 +27,9 @@ jobs:
         run: |
           gh api 'repos/${{github.repository}}/pulls/${{github.event.number}}/files' --paginate --jq 'any(.[].filename ; test("/change-notes/.*[.]md$"))' |
           grep true -c
-      - name: Fail if the change note filename doesn't match the expected format. The file name must be of the form 'YYYY-MM-DD.md' or 'YYYY-MM-DD-{title}.md', where '{title}' is arbitrary text.
+      - name: Fail if the change note filename doesn't match the expected format. The file name must be of the form 'YYYY-MM-DD.md', 'YYYY-MM-DD-{title}.md', where '{title}' is arbitrary text, or released/x.y.z.md for released change-notes
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh api 'repos/${{github.repository}}/pulls/${{github.event.number}}/files' --paginate --jq '[.[].filename | select(test("/change-notes/.*[.]md$"))] | all(test("/change-notes/[0-9]{4}-[0-9]{2}-[0-9]{2}.*[.]md$"))' |
-          grep true -c
+          gh api 'repos/${{github.repository}}/pulls/${{github.event.number}}/files' --paginate --jq '[.[].filename | select(test("/change-notes/.*[.]md$") or test("/change-notes/released/.*[.]md$"))] | all(test("/change-notes/[0-9]{4}-[0-9]{2}-[0-9]{2}.*[.]md$") or test("/change-notes/released/[0-9]*[.][0-9]*[.][0-9]*[.]md$"))' |
+          grep true -c 

--- a/.github/workflows/check-change-note.yml
+++ b/.github/workflows/check-change-note.yml
@@ -2,7 +2,7 @@ name: Check change note
 
 on:
   pull_request_target:
-    types: [labeled, unlabeled, opened, synchronize, reopened, ready_for_review]
+    types: [labeled, unlabeled, opened, synchronize, reopened, ready_for_review]q
     paths:
       - "*/ql/src/**/*.ql"
       - "*/ql/src/**/*.qll"
@@ -31,5 +31,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh api 'repos/${{github.repository}}/pulls/${{github.event.number}}/files' --paginate --jq '[.[].filename | select(test("/change-notes/.*[.]md$") or test("/change-notes/released/.*[.]md$"))] | all(test("/change-notes/[0-9]{4}-[0-9]{2}-[0-9]{2}.*[.]md$") or test("/change-notes/released/[0-9]*[.][0-9]*[.][0-9]*[.]md$"))' |
+          gh api 'repos/${{github.repository}}/pulls/${{github.event.number}}/files' --paginate --jq '[.[].filename | select(test("/change-notes/.*[.]md$"))] | all(test("/change-notes/[0-9]{4}-[0-9]{2}-[0-9]{2}.*[.]md$") or test("/change-notes/released/[0-9]*[.][0-9]*[.][0-9]*[.]md$"))' |
           grep true -c 


### PR DESCRIPTION
fixes https://github.com/github/codeql-core/issues/3534

Changed regexp in the check-change-note change to accept change notes like:
```
["cpp/ql/lib/change-notes/released/0.7.1.md","cpp/ql/src/change-notes/2023-04-11-double-free.md","cpp/ql/src/change-notes/2023-04-11-use-after-free.md","cpp/ql/src/change-notes/released/0.6.1.md","csharp/ql/campaigns/Solorigate/lib/change-notes/released/1.5.1.md","csharp/ql/campaigns/Solorigate/src/change-notes/released/1.5.1.md","csharp/ql/lib/change-notes/released/0.6.1.md","csharp/ql/src/change-notes/released/0.6.1.md","go/ql/lib/change-notes/released/0.5.1.md","go/ql/src/change-notes/released/0.5.1.md","java/ql/lib/change-notes/2022-09-22-stringjoiner-summaries.md","java/ql/lib/change-notes/2022-10-06-log-injection-sanitizers.md","java/ql/lib/change-notes/2023-04-05-deprecated-sensitive-result-receiver-predicate.md","java/ql/lib/change-notes/2023-04-06-add-apache-models.md","java/ql/lib/change-notes/2023-04-12-new-models-io.md","java/ql/lib/change-notes/2023-04-24-spring-filecopyutils-sinks.md","java/ql/lib/change-notes/released/0.6.1.md","java/ql/src/change-notes/released/0.6.1.md","javascript/ql/lib/change-notes/released/0.6.1.md","javascript/ql/src/change-notes/2023-04-14-more-call-graph-steps.md","javascript/ql/src/change-notes/2023-04-26-typescript-compiler-crash.md","javascript/ql/src/change-notes/released/0.6.1.md","misc/suite-helpers/change-notes/released/0.5.1.md","python/ql/lib/change-notes/released/0.9.1.md","python/ql/src/change-notes/released/0.7.1.md","ruby/ql/lib/change-notes/released/0.6.1.md","ruby/ql/src/change-notes/released/0.6.1.md","shared/regex/change-notes/released/0.0.12.md","shared/ssa/change-notes/released/0.0.16.md","shared/tutorial/change-notes/released/0.0.9.md","shared/typetracking/change-notes/released/0.0.9.md","shared/typos/change-notes/released/0.0.16.md","shared/util/change-notes/released/0.0.9.md"]
["shared/yaml/change-notes/released/0.0.1.md"]
```

not having this was blocking merge and automated tests for post-release preparation branches such as https://github.com/github/codeql/pull/13168