### PR TITLE
JS: require arguments to be shell interpreted to be flagged by indirect-command-injection

### DIFF
--- a/javascript/ql/lib/semmle/javascript/frameworks/ActionsLib.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/ActionsLib.qll
@@ -78,5 +78,10 @@ private class ExecActionsCall extends SystemCommandExecution, DataFlow::CallNode
 
   override DataFlow::Node getOptionsArg() { result = this.getArgument(2) }
 
+  override predicate isShellInterpreted(DataFlow::Node arg) {
+    arg = this.getACommandArgument() and
+    not this.getArgumentList().getALocalSource() instanceof DataFlow::ArrayCreationNode
+  }
+
   override predicate isSync() { none() }
 }

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/IndirectCommandInjectionCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/IndirectCommandInjectionCustomizations.qll
@@ -199,9 +199,13 @@ module IndirectCommandInjection {
   }
 
   /**
-   * A command argument to a function that initiates an operating system command.
+   * A command argument to a function that initiates an operating system command as a shell invocation.
    */
   private class SystemCommandExecutionSink extends Sink, DataFlow::ValueNode {
-    SystemCommandExecutionSink() { this = any(SystemCommandExecution sys).getACommandArgument() }
+    SystemCommandExecutionSink() {
+      exists(SystemCommandExecution sys |
+        sys.isShellInterpreted(this) and this = sys.getACommandArgument()
+      )
+    }
   }
 }

--- a/javascript/ql/src/change-notes/2023-05-17-indirect-shell.md
+++ b/javascript/ql/src/change-notes/2023-05-17-indirect-shell.md
@@ -1,4 +1,4 @@
 ---
 category: minorAnalysis
 ---
-* The `js/indirect-command-line-injection` query no command arguments that cannot be interpreted as a shell string.
+* The `js/indirect-command-line-injection` query no longer flags command arguments that cannot be interpreted as a shell string.

--- a/javascript/ql/src/change-notes/2023-05-17-indirect-shell.md
+++ b/javascript/ql/src/change-notes/2023-05-17-indirect-shell.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The `js/indirect-command-line-injection` query no command arguments that cannot be interpreted as a shell string.

--- a/javascript/ql/test/query-tests/Security/CWE-078/IndirectCommandInjection/command-line-parameter-command-injection.js
+++ b/javascript/ql/test/query-tests/Security/CWE-078/IndirectCommandInjection/command-line-parameter-command-injection.js
@@ -144,4 +144,6 @@ cp.exec("cmd.sh " + require("optimist").argv.foo); // NOT OK
 
 	cp.exec("cmd.sh " + program.opts().pizzaType); // NOT OK
 	cp.exec("cmd.sh " + program.pizzaType); // NOT OK
+
+	cp.execFile(program.opts().pizzaType, ["foo", "bar"]); // OK
 });


### PR DESCRIPTION
I'm not sure if the previous behavior was intentional or not, but we had no test for "command argument, but not shell interpreted", so it seems like it was unintentional.  

Fixing the behavior revealed that `ExecActionsCall` had no implementation of `isShellInterpreted`.  

/cc @max-schaefer 