### PR TITLE
C++: Implement the `subpaths` query predicate for `cpp/invalid-pointer-deref`

### DIFF
--- a/cpp/ql/src/experimental/Security/CWE/CWE-193/InvalidPointerDeref.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-193/InvalidPointerDeref.ql
@@ -345,6 +345,16 @@ query predicate edges(MergedPathNode node1, MergedPathNode node2) {
   joinOn2(node1.asPathNode3(), node2.asSinkNode(), _)
 }
 
+query predicate subpaths(
+  MergedPathNode arg, MergedPathNode par, MergedPathNode ret, MergedPathNode out
+) {
+  AllocToInvalidPointerFlow::PathGraph1::subpaths(arg.asPathNode1(), par.asPathNode1(),
+    ret.asPathNode1(), out.asPathNode1())
+  or
+  InvalidPointerToDerefFlow::PathGraph::subpaths(arg.asPathNode3(), par.asPathNode3(),
+    ret.asPathNode3(), out.asPathNode3())
+}
+
 /**
  * Holds if `p1` is a sink of `AllocToInvalidPointerConf` and `p2` is a source
  * of `InvalidPointerToDerefConf`, and they are connected through `pai`.

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/InvalidPointerDeref.expected
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/InvalidPointerDeref.expected
@@ -653,6 +653,7 @@ edges
 | test.cpp:304:15:304:26 | new[] | test.cpp:308:5:308:6 | xs |
 | test.cpp:308:5:308:6 | xs | test.cpp:308:5:308:11 | access to array |
 | test.cpp:308:5:308:11 | access to array | test.cpp:308:5:308:29 | Store: ... = ... |
+subpaths
 #select
 | test.cpp:6:14:6:15 | Load: * ... | test.cpp:4:15:4:20 | call to malloc | test.cpp:6:14:6:15 | Load: * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:4:15:4:20 | call to malloc | call to malloc | test.cpp:5:19:5:22 | size | size |
 | test.cpp:8:14:8:21 | Load: * ... | test.cpp:4:15:4:20 | call to malloc | test.cpp:8:14:8:21 | Load: * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@ + 1. | test.cpp:4:15:4:20 | call to malloc | call to malloc | test.cpp:5:19:5:22 | size | size |


### PR DESCRIPTION
This'll probably need a DCA experiment?