### PR TITLE
Swift: bump all versions to 0.1.0

### DIFF
--- a/swift/codeql-extractor.yml
+++ b/swift/codeql-extractor.yml
@@ -1,6 +1,6 @@
 name: "swift"
 display_name: "Swift"
-version: 0.0.1
+version: 0.1.0
 column_kind: "utf8"
 legacy_qltest_extraction: true
 github_api_languages:

--- a/swift/ql/lib/qlpack.yml
+++ b/swift/ql/lib/qlpack.yml
@@ -1,5 +1,5 @@
 name: codeql/swift-all
-version: 0.0.0
+version: 0.1.0
 groups: swift
 extractor: swift
 dbscheme: swift.dbscheme

--- a/swift/ql/src/qlpack.yml
+++ b/swift/ql/src/qlpack.yml
@@ -1,5 +1,5 @@
 name: codeql/swift-queries
-version: 0.0.0
+version: 0.1.0
 groups:
   - swift
   - queries


### PR DESCRIPTION
These new versions are rather arbitrary, but probably better than `0.0.0`.