### PR TITLE
C++: Reduce memory pressure from `getInstruction`

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/IRBlock.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/IRBlock.qll
@@ -255,14 +255,27 @@ private module Cached {
   cached
   newtype TIRBlock = MkIRBlock(Instruction firstInstr) { startsBasicBlock(firstInstr) }
 
-  /** Holds if `i` is the `index`th instruction the block starting with `first`. */
-  private Instruction getInstructionFromFirst(Instruction first, int index) =
-    shortestDistances(startsBasicBlock/1, adjacentInBlock/2)(first, result, index)
+  /** Gets the index of `i` in its `IRBlock`. */
+  private int getMemberIndex(Instruction i) {
+    startsBasicBlock(i) and
+    result = 0
+    or
+    exists(Instruction iPrev |
+      adjacentInBlock(iPrev, i) and
+      result = getMemberIndex(iPrev) + 1
+    )
+  }
+
+  private module BlockAdjacency = QlBuiltins::EquivalenceRelation<Instruction, adjacentInBlock/2>;
 
   /** Holds if `i` is the `index`th instruction in `block`. */
   cached
   Instruction getInstruction(TIRBlock block, int index) {
-    result = getInstructionFromFirst(getFirstInstruction(block), index)
+    exists(Instruction first |
+      block = MkIRBlock(first) and
+      index = getMemberIndex(result) and
+      BlockAdjacency::getEquivalenceClass(first) = BlockAdjacency::getEquivalenceClass(result)
+    )
   }
 
   cached

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/IRBlock.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/IRBlock.qll
@@ -271,8 +271,9 @@ private module Cached {
   /** Holds if `i` is the `index`th instruction in `block`. */
   cached
   Instruction getInstruction(TIRBlock block, int index) {
-    exists(Instruction first |
-      block = MkIRBlock(first) and
+    exists(Instruction first | block = MkIRBlock(first) |
+      first = result and index = 0
+      or
       index = getMemberIndex(result) and
       BlockAdjacency::getEquivalenceClass(first) = BlockAdjacency::getEquivalenceClass(result)
     )

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/IRBlock.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/IRBlock.qll
@@ -255,14 +255,27 @@ private module Cached {
   cached
   newtype TIRBlock = MkIRBlock(Instruction firstInstr) { startsBasicBlock(firstInstr) }
 
-  /** Holds if `i` is the `index`th instruction the block starting with `first`. */
-  private Instruction getInstructionFromFirst(Instruction first, int index) =
-    shortestDistances(startsBasicBlock/1, adjacentInBlock/2)(first, result, index)
+  /** Gets the index of `i` in its `IRBlock`. */
+  private int getMemberIndex(Instruction i) {
+    startsBasicBlock(i) and
+    result = 0
+    or
+    exists(Instruction iPrev |
+      adjacentInBlock(iPrev, i) and
+      result = getMemberIndex(iPrev) + 1
+    )
+  }
+
+  private module BlockAdjacency = QlBuiltins::EquivalenceRelation<Instruction, adjacentInBlock/2>;
 
   /** Holds if `i` is the `index`th instruction in `block`. */
   cached
   Instruction getInstruction(TIRBlock block, int index) {
-    result = getInstructionFromFirst(getFirstInstruction(block), index)
+    exists(Instruction first |
+      block = MkIRBlock(first) and
+      index = getMemberIndex(result) and
+      BlockAdjacency::getEquivalenceClass(first) = BlockAdjacency::getEquivalenceClass(result)
+    )
   }
 
   cached

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/IRBlock.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/IRBlock.qll
@@ -271,8 +271,9 @@ private module Cached {
   /** Holds if `i` is the `index`th instruction in `block`. */
   cached
   Instruction getInstruction(TIRBlock block, int index) {
-    exists(Instruction first |
-      block = MkIRBlock(first) and
+    exists(Instruction first | block = MkIRBlock(first) |
+      first = result and index = 0
+      or
       index = getMemberIndex(result) and
       BlockAdjacency::getEquivalenceClass(first) = BlockAdjacency::getEquivalenceClass(result)
     )

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/IRBlock.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/IRBlock.qll
@@ -255,14 +255,27 @@ private module Cached {
   cached
   newtype TIRBlock = MkIRBlock(Instruction firstInstr) { startsBasicBlock(firstInstr) }
 
-  /** Holds if `i` is the `index`th instruction the block starting with `first`. */
-  private Instruction getInstructionFromFirst(Instruction first, int index) =
-    shortestDistances(startsBasicBlock/1, adjacentInBlock/2)(first, result, index)
+  /** Gets the index of `i` in its `IRBlock`. */
+  private int getMemberIndex(Instruction i) {
+    startsBasicBlock(i) and
+    result = 0
+    or
+    exists(Instruction iPrev |
+      adjacentInBlock(iPrev, i) and
+      result = getMemberIndex(iPrev) + 1
+    )
+  }
+
+  private module BlockAdjacency = QlBuiltins::EquivalenceRelation<Instruction, adjacentInBlock/2>;
 
   /** Holds if `i` is the `index`th instruction in `block`. */
   cached
   Instruction getInstruction(TIRBlock block, int index) {
-    result = getInstructionFromFirst(getFirstInstruction(block), index)
+    exists(Instruction first |
+      block = MkIRBlock(first) and
+      index = getMemberIndex(result) and
+      BlockAdjacency::getEquivalenceClass(first) = BlockAdjacency::getEquivalenceClass(result)
+    )
   }
 
   cached

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/IRBlock.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/IRBlock.qll
@@ -271,8 +271,9 @@ private module Cached {
   /** Holds if `i` is the `index`th instruction in `block`. */
   cached
   Instruction getInstruction(TIRBlock block, int index) {
-    exists(Instruction first |
-      block = MkIRBlock(first) and
+    exists(Instruction first | block = MkIRBlock(first) |
+      first = result and index = 0
+      or
       index = getMemberIndex(result) and
       BlockAdjacency::getEquivalenceClass(first) = BlockAdjacency::getEquivalenceClass(result)
     )

--- a/csharp/ql/src/experimental/ir/implementation/raw/IRBlock.qll
+++ b/csharp/ql/src/experimental/ir/implementation/raw/IRBlock.qll
@@ -255,14 +255,27 @@ private module Cached {
   cached
   newtype TIRBlock = MkIRBlock(Instruction firstInstr) { startsBasicBlock(firstInstr) }
 
-  /** Holds if `i` is the `index`th instruction the block starting with `first`. */
-  private Instruction getInstructionFromFirst(Instruction first, int index) =
-    shortestDistances(startsBasicBlock/1, adjacentInBlock/2)(first, result, index)
+  /** Gets the index of `i` in its `IRBlock`. */
+  private int getMemberIndex(Instruction i) {
+    startsBasicBlock(i) and
+    result = 0
+    or
+    exists(Instruction iPrev |
+      adjacentInBlock(iPrev, i) and
+      result = getMemberIndex(iPrev) + 1
+    )
+  }
+
+  private module BlockAdjacency = QlBuiltins::EquivalenceRelation<Instruction, adjacentInBlock/2>;
 
   /** Holds if `i` is the `index`th instruction in `block`. */
   cached
   Instruction getInstruction(TIRBlock block, int index) {
-    result = getInstructionFromFirst(getFirstInstruction(block), index)
+    exists(Instruction first |
+      block = MkIRBlock(first) and
+      index = getMemberIndex(result) and
+      BlockAdjacency::getEquivalenceClass(first) = BlockAdjacency::getEquivalenceClass(result)
+    )
   }
 
   cached

--- a/csharp/ql/src/experimental/ir/implementation/raw/IRBlock.qll
+++ b/csharp/ql/src/experimental/ir/implementation/raw/IRBlock.qll
@@ -271,8 +271,9 @@ private module Cached {
   /** Holds if `i` is the `index`th instruction in `block`. */
   cached
   Instruction getInstruction(TIRBlock block, int index) {
-    exists(Instruction first |
-      block = MkIRBlock(first) and
+    exists(Instruction first | block = MkIRBlock(first) |
+      first = result and index = 0
+      or
       index = getMemberIndex(result) and
       BlockAdjacency::getEquivalenceClass(first) = BlockAdjacency::getEquivalenceClass(result)
     )

--- a/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/IRBlock.qll
+++ b/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/IRBlock.qll
@@ -255,14 +255,27 @@ private module Cached {
   cached
   newtype TIRBlock = MkIRBlock(Instruction firstInstr) { startsBasicBlock(firstInstr) }
 
-  /** Holds if `i` is the `index`th instruction the block starting with `first`. */
-  private Instruction getInstructionFromFirst(Instruction first, int index) =
-    shortestDistances(startsBasicBlock/1, adjacentInBlock/2)(first, result, index)
+  /** Gets the index of `i` in its `IRBlock`. */
+  private int getMemberIndex(Instruction i) {
+    startsBasicBlock(i) and
+    result = 0
+    or
+    exists(Instruction iPrev |
+      adjacentInBlock(iPrev, i) and
+      result = getMemberIndex(iPrev) + 1
+    )
+  }
+
+  private module BlockAdjacency = QlBuiltins::EquivalenceRelation<Instruction, adjacentInBlock/2>;
 
   /** Holds if `i` is the `index`th instruction in `block`. */
   cached
   Instruction getInstruction(TIRBlock block, int index) {
-    result = getInstructionFromFirst(getFirstInstruction(block), index)
+    exists(Instruction first |
+      block = MkIRBlock(first) and
+      index = getMemberIndex(result) and
+      BlockAdjacency::getEquivalenceClass(first) = BlockAdjacency::getEquivalenceClass(result)
+    )
   }
 
   cached

--- a/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/IRBlock.qll
+++ b/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/IRBlock.qll
@@ -271,8 +271,9 @@ private module Cached {
   /** Holds if `i` is the `index`th instruction in `block`. */
   cached
   Instruction getInstruction(TIRBlock block, int index) {
-    exists(Instruction first |
-      block = MkIRBlock(first) and
+    exists(Instruction first | block = MkIRBlock(first) |
+      first = result and index = 0
+      or
       index = getMemberIndex(result) and
       BlockAdjacency::getEquivalenceClass(first) = BlockAdjacency::getEquivalenceClass(result)
     )


### PR DESCRIPTION
Since we merged https://github.com/github/codeql/pull/12900 the Foundations teams internal performance measurements have been OOM'ing when analyzing Wireshark because they're running their experiments with ~6GB of RAM (unlike our DCA analysis of Wireshark which uses a much larger runner).

The analysis was OOM'ing because of the use of the `shortestDistances` HOP. This use was introduced in https://github.com/github/codeql/commit/8368c37781d5fae810f856cf9b1e04f586225a9f to get around an issue where Eclipse was OOM'ing because the log file was too large 😅.

This PR reverts https://github.com/github/codeql/commit/8368c37781d5fae810f856cf9b1e04f586225a9f and replaces the transitive closure of `adjacentInBlock` (which also was OOM'ing when I tried it locally) with an `EquivalenceRelation`-based approach. This succeeds even with 5GB of memory 🎉.

We do, however, now have `148647` iterations of `getMemberIndex` 😱. So we need to run DCA (and maybe even MRVA?) to check if this is a change we want to make.