### PR TITLE
Kotlin: Refactor extractTypeAccessRecursive

### DIFF
--- a/java/ql/integration-tests/all-platforms/kotlin/gradle_kotlinx_serialization/PrintAst.expected
+++ b/java/ql/integration-tests/all-platforms/kotlin/gradle_kotlinx_serialization/PrintAst.expected
@@ -261,6 +261,7 @@ app/src/main/kotlin/testProject/App.kt:
 #    7|             0: [ArrayCreationExpr] new KSerializer<?>[]
 #    7|               -2: [ArrayInit] {...}
 #    7|               -1: [TypeAccess] KSerializer<?>
+#    7|                 0: [WildcardTypeAccess] ? ...
 #    7|               0: [IntegerLiteral] 2
 #    0|       3: [Method] deserialize
 #-----|         1: (Annotations)
@@ -658,6 +659,7 @@ app/src/main/kotlin/testProject/App.kt:
 #   14|             0: [ArrayCreationExpr] new KSerializer<?>[]
 #   14|               -2: [ArrayInit] {...}
 #   14|               -1: [TypeAccess] KSerializer<?>
+#   14|                 0: [WildcardTypeAccess] ? ...
 #   14|               0: [IntegerLiteral] 1
 #    0|       3: [Method] deserialize
 #-----|         1: (Annotations)

--- a/java/ql/test/kotlin/library-tests/methods/exprs.expected
+++ b/java/ql/test/kotlin/library-tests/methods/exprs.expected
@@ -206,6 +206,7 @@
 | delegates.kt:8:35:11:5 | observable(...) | MethodAccess |
 | delegates.kt:8:57:8:62 | "<none>" | StringLiteral |
 | delegates.kt:8:66:11:5 | ...->... | LambdaExpr |
+| delegates.kt:8:66:11:5 | ? ... | WildcardTypeAccess |
 | delegates.kt:8:66:11:5 | Function3<KProperty<?>,String,String,Unit> | TypeAccess |
 | delegates.kt:8:66:11:5 | KProperty<?> | TypeAccess |
 | delegates.kt:8:66:11:5 | String | TypeAccess |

--- a/java/ql/test/kotlin/library-tests/reflection/PrintAst.expected
+++ b/java/ql/test/kotlin/library-tests/reflection/PrintAst.expected
@@ -1006,6 +1006,7 @@ reflection.kt:
 #   24|                 2: [TypeAccess] Integer
 #   24|               1: [MethodAccess] single(...)
 #   24|                 -2: [TypeAccess] KCallable<?>
+#   24|                   0: [WildcardTypeAccess] ? ...
 #   24|                 -1: [TypeAccess] CollectionsKt
 #   24|                 0: [MethodAccess] getMembers(...)
 #   24|                   -1: [TypeLiteral] C.class
@@ -1029,6 +1030,7 @@ reflection.kt:
 #   24|                             1: [StringLiteral] "p3"
 #   24|                   -3: [TypeAccess] Function1<KCallable<?>,Boolean>
 #   24|                     0: [TypeAccess] KCallable<?>
+#   24|                       0: [WildcardTypeAccess] ? ...
 #   24|                     1: [TypeAccess] Boolean
 #   25|         15: [LocalVariableDeclStmt] var ...;
 #   25|           1: [LocalVariableDeclExpr] z0


### PR DESCRIPTION
This also changes behaviour slightly.

@tamasvajk do you know why the behaviour of the two `extractTypeAccessRecursive` functions was different? Is it for compatibility with Java? If so, I wonder if we can instead add a boolean argument to select the behaviours, to make it clearer what is happening and why?