### PR TITLE
Shared: Add stubs for `identify-environment` scripts

### DIFF
--- a/go/Makefile
+++ b/go/Makefile
@@ -14,7 +14,7 @@ CODEQL_PLATFORM = osx64
 endif
 endif
 
-CODEQL_TOOLS = $(addprefix codeql-tools/,autobuild.cmd autobuild.sh pre-finalize.cmd pre-finalize.sh index.cmd index.sh tracing-config.lua)
+CODEQL_TOOLS = $(addprefix codeql-tools/,autobuild.cmd autobuild.sh pre-finalize.cmd pre-finalize.sh index.cmd index.sh identify-environment.cmd identify-environment.sh tracing-config.lua)
 
 EXTRACTOR_PACK_OUT = build/codeql-extractor-go
 

--- a/go/extractor/cli/go-autobuilder/go-autobuilder.go
+++ b/go/extractor/cli/go-autobuilder/go-autobuilder.go
@@ -44,7 +44,7 @@ Build behavior:
     to 'false' disables the GOPATH set-up, CODEQL_EXTRACTOR_GO_BUILD_COMMAND (or alternatively
     LGTM_INDEX_BUILD_COMMAND), can be set to a newline-separated list of commands to run in order to
     install dependencies, and LGTM_INDEX_IMPORT_PATH can be used to override the package import path,
-    which is otherwise inferred from the SEMMLE_REPO_URL or GITHUB_REPOSITORY environment variables.    
+    which is otherwise inferred from the SEMMLE_REPO_URL or GITHUB_REPOSITORY environment variables.
 
     In resource-constrained environments, the environment variable CODEQL_EXTRACTOR_GO_MAX_GOROUTINES
     (or its legacy alias SEMMLE_MAX_GOROUTINES) can be used to limit the number of parallel goroutines
@@ -931,9 +931,9 @@ func getVersionToInstall(v versionInfo) (msg, version string) {
 func outputEnvironmentJson(version string) {
 	var content string
 	if version == "" {
-		content = `{ "include": [] }`
+		content = `{ "go": {} }`
 	} else {
-		content = `{ "include": [ { "go": { "version": "` + version + `" } } ] }`
+		content = `{ "go": { "version": "` + version + `" } }`
 	}
 	_, err := fmt.Fprint(os.Stdout, content)
 

--- a/swift/tools/BUILD.bazel
+++ b/swift/tools/BUILD.bazel
@@ -11,9 +11,15 @@ sh_binary(
     srcs = ["autobuild.sh"],
 )
 
+sh_binary(
+    name = "identify-environment",
+    srcs = ["identify-environment.sh"],
+)
+
 pkg_files(
     name = "scripts",
     srcs = [
+        ":identify-environment",
         ":autobuild",
         ":qltest",
     ],

--- a/swift/tools/identify-environment.cmd
+++ b/swift/tools/identify-environment.cmd
@@ -1,0 +1,6 @@
+@echo off
+SETLOCAL EnableDelayedExpansion
+
+echo { "swift": { "os": { "name": "macOS" } } }
+
+ENDLOCAL

--- a/swift/tools/identify-environment.cmd
+++ b/swift/tools/identify-environment.cmd
@@ -1,6 +1,0 @@
-@echo off
-SETLOCAL EnableDelayedExpansion
-
-echo { "swift": { "os": { "name": "macOS" } } }
-
-ENDLOCAL

--- a/swift/tools/identify-environment.sh
+++ b/swift/tools/identify-environment.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -eu
+
+echo '{ "swift": { "os": { "name": "macOS" } } }'


### PR DESCRIPTION
The forthcoming `resolve environment` command in the CLI invokes these scripts. Currently only Go supports this fully and already has such a script (although it was left out of the distribution until now), while this PR adds stubs for the other languages.