### PR TITLE
C++: Replace `C18` with `C17` in documentation

### DIFF
--- a/docs/codeql/reusables/supported-versions-compilers.rst
+++ b/docs/codeql/reusables/supported-versions-compilers.rst
@@ -4,7 +4,7 @@
    :stub-columns: 1
 
    Language,Variants,Compilers,Extensions
-   C/C++,"C89, C99, C11, C18, C++98, C++03, C++11, C++14, C++17, C++20 [1]_","Clang (and clang-cl [2]_) extensions (up to Clang 12.0),
+   C/C++,"C89, C99, C11, C17, C++98, C++03, C++11, C++14, C++17, C++20 [1]_","Clang (and clang-cl [2]_) extensions (up to Clang 12.0),
 
    GNU extensions (up to GCC 11.1),
 


### PR DESCRIPTION
It seems like everyone agrees on calling it C17 (see https://en.wikipedia.org/wiki/Talk:C17_(C_standard_revision)) so we should probably follow this convention.

cc @lcartey.