### PR TITLE
Swift: Use asNominalTypeDecl more.

### DIFF
--- a/swift/ql/lib/codeql/swift/elements/AstNode.qll
+++ b/swift/ql/lib/codeql/swift/elements/AstNode.qll
@@ -57,6 +57,9 @@ class AstNode extends Generated::AstNode {
 
   /**
    * Gets the nearest declaration that contains this AST node, if any.
+   *
+   * Note that the nearest declaration may be an extension of a type declaration. If you always
+   * want the type declaration and not the extension, use `getEnclosingDecl().asNominalTypeDecl()`.
    */
   final Decl getEnclosingDecl() { result = Cached::getEnclosingDecl(this) }
 

--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/Collection.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/Collection.qll
@@ -48,11 +48,7 @@ private class CollectionFieldsInheritTaint extends TaintInheritingContent,
 {
   CollectionFieldsInheritTaint() {
     exists(FieldDecl f | this.getField() = f |
-      (
-        f.getEnclosingDecl().(NominalTypeDecl).getName() = ["Collection", "BidirectionalCollection"] or
-        f.getEnclosingDecl().(ExtensionDecl).getExtendedTypeDecl().getName() =
-          ["Collection", "BidirectionalCollection"]
-      ) and
+      f.getEnclosingDecl().asNominalTypeDecl().getName() = ["Collection", "BidirectionalCollection"] and
       f.getName() = ["first", "last"]
     )
   }

--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/CustomUrlSchemes.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/CustomUrlSchemes.qll
@@ -49,14 +49,14 @@ private class UrlLaunchOptionsRemoteFlowSource extends RemoteFlowSource {
 private class ApplicationWithLaunchOptionsFunc extends Function {
   ApplicationWithLaunchOptionsFunc() {
     this.getName() = "application(_:" + ["did", "will"] + "FinishLaunchingWithOptions:)" and
-    this.getEnclosingDecl().(ClassOrStructDecl).getABaseTypeDecl*().(ProtocolDecl).getName() =
+    this.getEnclosingDecl().asNominalTypeDecl().getABaseTypeDecl*().(ProtocolDecl).getName() =
       "UIApplicationDelegate"
   }
 }
 
 private class LaunchOptionsUrlVarDecl extends VarDecl {
   LaunchOptionsUrlVarDecl() {
-    this.getEnclosingDecl().(StructDecl).getFullName() = "UIApplication.LaunchOptionsKey" and
+    this.getEnclosingDecl().asNominalTypeDecl().getFullName() = "UIApplication.LaunchOptionsKey" and
     this.getName() = "url"
   }
 }
@@ -68,7 +68,7 @@ private class UiOpenUrlContextUrlInheritTaint extends TaintInheritingContent,
   DataFlow::Content::FieldContent
 {
   UiOpenUrlContextUrlInheritTaint() {
-    this.getField().getEnclosingDecl().(NominalTypeDecl).getName() = "UIOpenURLContext" and
+    this.getField().getEnclosingDecl().asNominalTypeDecl().getName() = "UIOpenURLContext" and
     this.getField().getName() = "url"
   }
 }
@@ -80,7 +80,7 @@ private class UserActivityUrlInheritTaint extends TaintInheritingContent,
   DataFlow::Content::FieldContent
 {
   UserActivityUrlInheritTaint() {
-    this.getField().getEnclosingDecl().(NominalTypeDecl).getName() = "NSUserActivity" and
+    this.getField().getEnclosingDecl().asNominalTypeDecl().getName() = "NSUserActivity" and
     this.getField().getName() = "webpageURL"
   }
 }
@@ -93,7 +93,7 @@ private class ConnectionOptionsFieldsInheritTaint extends TaintInheritingContent
   DataFlow::Content::FieldContent
 {
   ConnectionOptionsFieldsInheritTaint() {
-    this.getField().getEnclosingDecl().(NominalTypeDecl).getName() = "ConnectionOptions" and
+    this.getField().getEnclosingDecl().asNominalTypeDecl().getName() = "ConnectionOptions" and
     this.getField().getName() = ["userActivities", "urlContexts"]
   }
 }

--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/FilePath.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/FilePath.qll
@@ -60,10 +60,7 @@ private class FilePathFieldsInheritTaint extends TaintInheritingContent,
 {
   FilePathFieldsInheritTaint() {
     exists(FieldDecl f | this.getField() = f |
-      (
-        f.getEnclosingDecl().(NominalTypeDecl) instanceof FilePath or
-        f.getEnclosingDecl().(ExtensionDecl).getExtendedTypeDecl() instanceof FilePath
-      ) and
+      f.getEnclosingDecl().asNominalTypeDecl() instanceof FilePath and
       f.getName() =
         [
           "description", "debugDescription", "components", "extension", "lastComponent", "root",
@@ -82,12 +79,8 @@ private class FilePathComponentFieldsInheritTaint extends TaintInheritingContent
 {
   FilePathComponentFieldsInheritTaint() {
     exists(FieldDecl f | this.getField() = f |
-      (
-        f.getEnclosingDecl().(NominalTypeDecl).getFullName() =
-          ["FilePath.Component", "FilePath.Root"] or
-        f.getEnclosingDecl().(ExtensionDecl).getExtendedTypeDecl().getFullName() =
-          ["FilePath.Component", "FilePath.Root"]
-      ) and
+      f.getEnclosingDecl().asNominalTypeDecl().getFullName() =
+        ["FilePath.Component", "FilePath.Root"] and
       f.getName() = ["extension", "stem", "string"]
     )
   }

--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/NsData.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/NsData.qll
@@ -75,7 +75,7 @@ private class NsMutableDataSummaries extends SummaryModelCsv {
 private class NsDataTaintedFields extends TaintInheritingContent, DataFlow::Content::FieldContent {
   NsDataTaintedFields() {
     exists(FieldDecl f | this.getField() = f |
-      f.getEnclosingDecl() instanceof NsData and
+      f.getEnclosingDecl().asNominalTypeDecl() instanceof NsData and
       f.getName() = ["bytes", "description"]
     )
   }
@@ -87,7 +87,7 @@ private class NsMutableDataTaintedFields extends TaintInheritingContent,
 {
   NsMutableDataTaintedFields() {
     exists(FieldDecl f | this.getField() = f |
-      f.getEnclosingDecl() instanceof NsMutableData and
+      f.getEnclosingDecl().asNominalTypeDecl() instanceof NsMutableData and
       f.getName() = "mutableBytes"
     )
   }

--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/NsString.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/NsString.qll
@@ -133,10 +133,7 @@ private class NsStringFieldsInheritTaint extends TaintInheritingContent,
 {
   NsStringFieldsInheritTaint() {
     exists(FieldDecl f | this.getField() = f |
-      (
-        f.getEnclosingDecl().(NominalTypeDecl).getName() = "NSString" or
-        f.getEnclosingDecl().(ExtensionDecl).getExtendedTypeDecl().getName() = "NSString"
-      ) and
+      f.getEnclosingDecl().asNominalTypeDecl().getName() = "NSString" and
       f.getName() =
         [
           "utf8String", "lowercased", "localizedLowedCase", "uppercased", "localizedUppercase",

--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/Sequence.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/Sequence.qll
@@ -38,10 +38,7 @@ private class SequenceFieldsInheritTaint extends TaintInheritingContent,
 {
   SequenceFieldsInheritTaint() {
     exists(FieldDecl f | this.getField() = f |
-      (
-        f.getEnclosingDecl().(NominalTypeDecl).getName() = "Sequence" or
-        f.getEnclosingDecl().(ExtensionDecl).getExtendedTypeDecl().getName() = "Sequence"
-      ) and
+      f.getEnclosingDecl().asNominalTypeDecl().getName() = "Sequence" and
       f.getName() = "lazy"
     )
   }

--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/String.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/String.qll
@@ -125,11 +125,7 @@ private class StringFieldsInheritTaint extends TaintInheritingContent,
 {
   StringFieldsInheritTaint() {
     exists(FieldDecl f | this.getField() = f |
-      (
-        f.getEnclosingDecl().(NominalTypeDecl).getName() = ["String", "StringProtocol"] or
-        f.getEnclosingDecl().(ExtensionDecl).getExtendedTypeDecl().getName() =
-          ["String", "StringProtocol"]
-      ) and
+      f.getEnclosingDecl().asNominalTypeDecl().getName() = ["String", "StringProtocol"] and
       f.getName() =
         [
           "unicodeScalars", "utf8", "utf16", "lazy", "utf8CString", "description",

--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/Url.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/Url.qll
@@ -16,7 +16,9 @@ class UrlDecl extends StructDecl {
  * A content implying that, if a `URL` is tainted, then all its fields are tainted.
  */
 private class UriFieldsInheritTaint extends TaintInheritingContent, DataFlow::Content::FieldContent {
-  UriFieldsInheritTaint() { this.getField().getEnclosingDecl() instanceof UrlDecl }
+  UriFieldsInheritTaint() {
+    this.getField().getEnclosingDecl().asNominalTypeDecl() instanceof UrlDecl
+  }
 }
 
 /**
@@ -27,7 +29,7 @@ private class UrlRequestFieldsInheritTaint extends TaintInheritingContent,
   DataFlow::Content::FieldContent
 {
   UrlRequestFieldsInheritTaint() {
-    this.getField().getEnclosingDecl().(NominalTypeDecl).getName() = "URLRequest" and
+    this.getField().getEnclosingDecl().asNominalTypeDecl().getName() = "URLRequest" and
     this.getField().getName() =
       ["url", "httpBody", "httpBodyStream", "mainDocument", "allHTTPHeaderFields"]
   }

--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/WebView.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/WebView.qll
@@ -32,7 +32,7 @@ private class WKScriptMessageBodyInheritsTaint extends TaintInheritingContent,
 {
   WKScriptMessageBodyInheritsTaint() {
     exists(FieldDecl f | this.getField() = f |
-      f.getEnclosingDecl() instanceof WKScriptMessageDecl and
+      f.getEnclosingDecl().asNominalTypeDecl() instanceof WKScriptMessageDecl and
       f.getName() = "body"
     )
   }
@@ -170,16 +170,16 @@ private class JsExportedType extends ClassOrStructDecl {
 private class JsExportedSource extends RemoteFlowSource {
   JsExportedSource() {
     exists(Method adopter, Method base |
-      base.getEnclosingDecl() instanceof JsExportedProto and
-      adopter.getEnclosingDecl() instanceof JsExportedType
+      base.getEnclosingDecl().asNominalTypeDecl() instanceof JsExportedProto and
+      adopter.getEnclosingDecl().asNominalTypeDecl() instanceof JsExportedType
     |
       this.(DataFlow::ParameterNode).getParameter().getDeclaringFunction() = adopter and
       pragma[only_bind_out](adopter.getName()) = pragma[only_bind_out](base.getName())
     )
     or
     exists(FieldDecl adopter, FieldDecl base |
-      base.getEnclosingDecl() instanceof JsExportedProto and
-      adopter.getEnclosingDecl() instanceof JsExportedType
+      base.getEnclosingDecl().asNominalTypeDecl() instanceof JsExportedProto and
+      adopter.getEnclosingDecl().asNominalTypeDecl() instanceof JsExportedType
     |
       this.asExpr().(MemberRefExpr).getMember() = adopter and
       pragma[only_bind_out](adopter.getName()) = pragma[only_bind_out](base.getName())
@@ -210,7 +210,7 @@ private class WKUserScriptInheritsTaint extends TaintInheritingContent,
 {
   WKUserScriptInheritsTaint() {
     exists(FieldDecl f | this.getField() = f |
-      f.getEnclosingDecl().(ClassOrStructDecl).getName() = "WKUserScript" and
+      f.getEnclosingDecl().asNominalTypeDecl().getName() = "WKUserScript" and
       f.getName() = "source"
     )
   }

--- a/swift/ql/lib/codeql/swift/frameworks/Xml/AEXML.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/Xml/AEXML.qll
@@ -7,14 +7,16 @@ import swift
 /** The creation of an `AEXMLParser`. */
 class AexmlParser extends ApplyExpr {
   AexmlParser() {
-    this.getStaticTarget().(Initializer).getEnclosingDecl() instanceof AexmlParserDecl
+    this.getStaticTarget().(Initializer).getEnclosingDecl().asNominalTypeDecl() instanceof
+      AexmlParserDecl
   }
 }
 
 /** The creation of an `AEXMLDocument`. */
 class AexmlDocument extends ApplyExpr {
   AexmlDocument() {
-    this.getStaticTarget().(Initializer).getEnclosingDecl() instanceof AexmlDocumentDecl
+    this.getStaticTarget().(Initializer).getEnclosingDecl().asNominalTypeDecl() instanceof
+      AexmlDocumentDecl
   }
 }
 
@@ -24,7 +26,7 @@ class AexmlDocumentLoadXml extends MethodApplyExpr {
     exists(Method f |
       this.getStaticTarget() = f and
       f.hasName("loadXML(_:)") and
-      f.getEnclosingDecl() instanceof AexmlDocumentDecl
+      f.getEnclosingDecl().asNominalTypeDecl() instanceof AexmlDocumentDecl
     )
   }
 }
@@ -44,7 +46,7 @@ class AexmlShouldResolveExternalEntities extends MemberRefExpr {
   AexmlShouldResolveExternalEntities() {
     exists(FieldDecl f | this.getMember() = f |
       f.getName() = "shouldResolveExternalEntities" and
-      f.getEnclosingDecl().(NominalTypeDecl).getType() instanceof AexmlOptionsParserSettingsType
+      f.getEnclosingDecl().asNominalTypeDecl().getType() instanceof AexmlOptionsParserSettingsType
     )
   }
 }

--- a/swift/ql/lib/codeql/swift/security/CleartextLoggingExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/CleartextLoggingExtensions.qll
@@ -64,7 +64,7 @@ private class OsLogPrivacyRef extends MemberRefExpr {
 
   OsLogPrivacyRef() {
     exists(FieldDecl f | this.getMember() = f |
-      f.getEnclosingDecl().(NominalTypeDecl).getName() = "OSLogPrivacy" and
+      f.getEnclosingDecl().asNominalTypeDecl().getName() = "OSLogPrivacy" and
       optionName = f.getName()
     )
   }

--- a/swift/ql/lib/codeql/swift/security/PathInjectionExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/PathInjectionExtensions.qll
@@ -38,9 +38,9 @@ private class DefaultPathInjectionBarrier extends PathInjectionBarrier {
     // This is a simplified implementation.
     exists(CallExpr starts, CallExpr normalize, DataFlow::Node validated |
       starts.getStaticTarget().getName() = "starts(with:)" and
-      starts.getStaticTarget().getEnclosingDecl() instanceof FilePath and
+      starts.getStaticTarget().getEnclosingDecl().asNominalTypeDecl() instanceof FilePath and
       normalize.getStaticTarget().getName() = "lexicallyNormalized()" and
-      normalize.getStaticTarget().getEnclosingDecl() instanceof FilePath
+      normalize.getStaticTarget().getEnclosingDecl().asNominalTypeDecl() instanceof FilePath
     |
       TaintTracking::localTaint(validated, DataFlow::exprNode(normalize.getQualifier())) and
       DataFlow::localExprFlow(normalize, starts.getQualifier()) and

--- a/swift/ql/lib/codeql/swift/security/XXEExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/XXEExtensions.qll
@@ -80,7 +80,7 @@ private class XmlDocumentXxeSink extends XxeSink {
 /** An `XMLDocument` that sets `nodeLoadExternalEntitiesAlways` in its options. */
 private class VulnerableXmlDocument extends ApplyExpr {
   VulnerableXmlDocument() {
-    this.getStaticTarget().(Initializer).getEnclosingDecl().(NominalTypeDecl).getFullName() =
+    this.getStaticTarget().(Initializer).getEnclosingDecl().asNominalTypeDecl().getFullName() =
       "XMLDocument" and
     this.getArgument(1).getExpr().(ArrayExpr).getAnElement().(MemberRefExpr).getMember() instanceof
       NodeLoadExternalEntitiesAlways
@@ -91,7 +91,7 @@ private class VulnerableXmlDocument extends ApplyExpr {
 private class NodeLoadExternalEntitiesAlways extends VarDecl {
   NodeLoadExternalEntitiesAlways() {
     this.getName() = "nodeLoadExternalEntitiesAlways" and
-    this.getEnclosingDecl().(StructDecl).getFullName() = "XMLNode.Options"
+    this.getEnclosingDecl().asNominalTypeDecl().(StructDecl).getFullName() = "XMLNode.Options"
   }
 }
 

--- a/swift/ql/lib/codeql/swift/security/XXEExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/XXEExtensions.qll
@@ -190,13 +190,8 @@ private predicate lib2xmlOptionLocalTaintStep(DataFlow::Node source, DataFlow::N
   )
   or
   exists(ApplyExpr int32Init |
-    int32Init
-        .getStaticTarget()
-        .(Initializer)
-        .getEnclosingDecl()
-        .(ExtensionDecl)
-        .getExtendedTypeDecl()
-        .getName() = "SignedInteger"
+    int32Init.getStaticTarget().(Initializer).getEnclosingDecl().asNominalTypeDecl().getName() =
+      "SignedInteger"
   |
     source.asExpr() = int32Init.getAnArgument().getExpr() and sink.asExpr() = int32Init
   )


### PR DESCRIPTION
Use `asNominalTypeDecl` more:
- to resolve methods and variables declared in extensions correctly.  We've had models fail in both tests and real world query runs in the past because they were looking for something in a particular named type declaration, but that thing was actually in an extension of it.
- to avoid needing special case disjuncts to do so.

Some of these changes could affect results, so I'll do a DCA run to be safe.