### PR TITLE
Java: add error message for outdated sink kinds in `getInvalidModelKind`

### DIFF
--- a/java/ql/lib/semmle/code/java/dataflow/ExternalFlow.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/ExternalFlow.qll
@@ -265,8 +265,8 @@ module ModelValidation {
     )
   }
 
-  private class DeprecatedSinkKind extends string {
-    DeprecatedSinkKind() {
+  private class OutdatedSinkKind extends string {
+    OutdatedSinkKind() {
       this =
         [
           "sql", "url-redirect", "xpath", "ssti", "logging", "groovy", "jexl", "mvel", "xslt",
@@ -303,9 +303,9 @@ module ModelValidation {
       this = ["open-url", "jdbc-url"] and result = "request-forgery"
     }
 
-    string deprecationMessage() {
+    string outdatedMessage() {
       result =
-        "The kind \"" + this + "\" is deprecated. Use \"" + this.replacementKind() + "\" instead."
+        "The kind \"" + this + "\" is outdated. Use \"" + this.replacementKind() + "\" instead."
     }
   }
 
@@ -328,9 +328,9 @@ module ModelValidation {
       not kind.matches("regex-use%") and
       not kind.matches("qltest%") and
       msg = "Invalid kind \"" + kind + "\" in sink model." and
-      // The deprecation part of this message can be deleted after June 1st, 2024.
-      if kind instanceof DeprecatedSinkKind
-      then result = msg + " " + kind.(DeprecatedSinkKind).deprecationMessage()
+      // The part of this message that refers to outdated sink kinds can be deleted after June 1st, 2024.
+      if kind instanceof OutdatedSinkKind
+      then result = msg + " " + kind.(OutdatedSinkKind).outdatedMessage()
       else result = msg
     )
     or

--- a/java/ql/lib/semmle/code/java/dataflow/ExternalFlow.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/ExternalFlow.qll
@@ -277,50 +277,35 @@ module ModelValidation {
     }
 
     private string replacementKind() {
-      this = "sql" and result = "\"sql-injection\""
+      this = ["sql", "xpath", "groovy", "jexl", "mvel", "xslt", "ldap"] and
+      result = this + "-injection"
       or
-      this = "url-redirect" and result = "\"url-redirection\""
+      this = "url-redirect" and result = "url-redirection"
       or
-      this = "xpath" and result = "\"xpath-injection\""
+      this = "ssti" and result = "template-injection"
       or
-      this = "ssti" and result = "\"template-injection\""
+      this = "logging" and result = "log-injection"
       or
-      this = "logging" and result = "\"log-injection\""
+      this = "pending-intent-sent" and result = "pending-intents"
       or
-      this = "groovy" and result = "\"groovy-injection\""
+      this = "intent-start" and result = "intent-redirection"
       or
-      this = "jexl" and result = "\"jexl-injection\""
+      this = "set-hostname-verifier" and result = "hostname-verification"
       or
-      this = "mvel" and result = "\"mvel-injection\""
+      this = "header-splitting" and result = "response-splitting"
       or
-      this = "xslt" and result = "\"xslt-injection\""
+      this = "xss" and result = "html-injection\" or \"js-injection"
       or
-      this = "ldap" and result = "\"ldap-injection\""
+      this = "write-file" and result = "file-content-store"
       or
-      this = "pending-intent-sent" and result = "\"pending-intents\""
+      this = ["create-file", "read-file"] and result = "path-injection"
       or
-      this = "intent-start" and result = "\"intent-redirection\""
-      or
-      this = "set-hostname-verifier" and result = "\"hostname-verification\""
-      or
-      this = "header-splitting" and result = "\"response-splitting\""
-      or
-      this = "xss" and result = "\"html-injection\" or \"js-injection\""
-      or
-      this = "write-file" and result = "\"file-content-store\""
-      or
-      this = "create-file" and result = "\"path-injection\""
-      or
-      this = "read-file" and result = "\"path-injection\""
-      or
-      this = "open-url" and result = "\"request-forgery\""
-      or
-      this = "jdbc-url" and result = "\"request-forgery\""
+      this = ["open-url", "jdbc-url"] and result = "request-forgery"
     }
 
     string deprecationMessage() {
       result =
-        "The kind \"" + this + "\" is deprecated. Use " + this.replacementKind() + " instead."
+        "The kind \"" + this + "\" is deprecated. Use \"" + this.replacementKind() + "\" instead."
     }
   }
 

--- a/java/ql/lib/semmle/code/java/dataflow/ExternalFlow.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/ExternalFlow.qll
@@ -247,8 +247,6 @@ module ModelValidation {
     )
   }
 
-  /**
-   */
   private string getInvalidModelOutput() {
     exists(string pred, AccessPath output, AccessPathToken part |
       sourceModel(_, _, _, _, _, _, output, _, _) and pred = "source"

--- a/java/ql/lib/semmle/code/java/dataflow/ExternalFlow.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/ExternalFlow.qll
@@ -247,6 +247,8 @@ module ModelValidation {
     )
   }
 
+  /**
+   */
   private string getInvalidModelOutput() {
     exists(string pred, AccessPath output, AccessPathToken part |
       sourceModel(_, _, _, _, _, _, output, _, _) and pred = "source"
@@ -328,6 +330,7 @@ module ModelValidation {
       not kind.matches("regex-use%") and
       not kind.matches("qltest%") and
       msg = "Invalid kind \"" + kind + "\" in sink model." and
+      // The deprecation part of this message can be deleted after June 1st, 2024.
       if kind instanceof DeprecatedSinkKind
       then result = msg + " " + kind.(DeprecatedSinkKind).deprecationMessage()
       else result = msg


### PR DESCRIPTION
This PR adds an error message in `getInvalidModelKind` for when an outdated sink kind is used and includes instructions on alternate names. 
This was [suggested](https://github.com/github/codeql/pull/12916#pullrequestreview-1423193912) by @aeisenberg for the [Java sink revamp](https://github.com/github/codeql/pull/12916).

Let me know if I should add something similar for other languages (e.g. [JavaScript](https://github.com/github/codeql/pull/13157), [C#](https://github.com/github/codeql/pull/13158)). If so, I'll create a shared version of this in https://github.com/github/codeql/pull/13324.