### PR TITLE
Ruby: Allow for flow through callbacks to summarized methods in type tracking

### DIFF
--- a/ruby/ql/lib/codeql/ruby/typetracking/TypeTrackerSpecific.qll
+++ b/ruby/ql/lib/codeql/ruby/typetracking/TypeTrackerSpecific.qll
@@ -598,10 +598,17 @@ private DataFlow::Node evaluateSummaryComponentStackLocal(
       pragma[only_bind_out](tail)) and
     stack = SCS::push(pragma[only_bind_out](head), pragma[only_bind_out](tail))
   |
-    exists(DataFlowDispatch::ArgumentPosition apos, DataFlowDispatch::ParameterPosition ppos |
+    exists(
+      DataFlowDispatch::ArgumentPosition apos, DataFlowDispatch::ParameterPosition ppos,
+      DataFlowPrivate::ParameterNodeImpl p
+    |
       head = SummaryComponent::parameter(apos) and
       DataFlowDispatch::parameterMatch(ppos, apos) and
-      result.(DataFlowPrivate::ParameterNodeImpl).isSourceParameterOf(prev.asExpr().getExpr(), ppos)
+      p.isSourceParameterOf(prev.asExpr().getExpr(), ppos) and
+      // We need to include both `p` and the SSA definition for `p`, since in type-tracking
+      // the step from `p` to the SSA definition is considered a call step.
+      result =
+        [p.(DataFlow::Node), DataFlowPrivate::LocalFlow::getParameterDefNode(p.getParameter())]
     )
     or
     head = SummaryComponent::return() and


### PR DESCRIPTION
This should not give rise to spurious flow (flow in via one call and out via another call), since we are limited to callbacks that are direct arguments (e.g. blocks).