### PR TITLE
Ruby: Allow for flow out of callbacks passed to summarized methods in type tracking

### DIFF
--- a/ruby/ql/lib/codeql/ruby/typetracking/TypeTrackerSpecific.qll
+++ b/ruby/ql/lib/codeql/ruby/typetracking/TypeTrackerSpecific.qll
@@ -615,7 +615,7 @@ private DataFlow::Node evaluateSummaryComponentStackLocal(
       head = SummaryComponent::return() and
       ret.getCfgScope() = prev.asExpr().getExpr() and
       // We need to include both `ret` and `ret.getAnInput()`, since in type-tracking
-      // the step from `ret.getAnInput()` to `ret` is considered a call step.
+      // the step from `ret.getAnInput()` to `ret` is considered a return step.
       result = [ret.(DataFlow::Node), ret.getAnInput()]
     )
     or

--- a/ruby/ql/lib/codeql/ruby/typetracking/TypeTrackerSpecific.qll
+++ b/ruby/ql/lib/codeql/ruby/typetracking/TypeTrackerSpecific.qll
@@ -611,8 +611,13 @@ private DataFlow::Node evaluateSummaryComponentStackLocal(
         [p.(DataFlow::Node), DataFlowPrivate::LocalFlow::getParameterDefNode(p.getParameter())]
     )
     or
-    head = SummaryComponent::return() and
-    result.(DataFlowPrivate::SynthReturnNode).getCfgScope() = prev.asExpr().getExpr()
+    exists(DataFlowPrivate::SynthReturnNode ret |
+      head = SummaryComponent::return() and
+      ret.getCfgScope() = prev.asExpr().getExpr() and
+      // We need to include both `ret` and `ret.getAnInput()`, since in type-tracking
+      // the step from `ret.getAnInput()` to `ret` is considered a call step.
+      result = [ret.(DataFlow::Node), ret.getAnInput()]
+    )
     or
     exists(DataFlow::ContentSet content |
       head = SummaryComponent::withoutContent(content) and


### PR DESCRIPTION
Similar to https://github.com/github/codeql/pull/13231.