### PR TITLE
update the **Identifier** section of the QL specification

### DIFF
--- a/docs/codeql/ql-language-reference/ql-language-specification.rst
+++ b/docs/codeql/ql-language-reference/ql-language-specification.rst
@@ -638,6 +638,7 @@ Identifiers are used in following syntactic constructs:
    classname           ::= upperId
    dbasetype           ::= atLowerId
    predicateRef        ::= (moduleExpr "::")? literalId
+   signatureExpr       ::= (moduleExpr "::")? simpleId ("/" Integer | arguments)?;
    predicateName       ::= lowerId
    varname             ::= lowerId
    literalId           ::= lowerId | atLowerId

--- a/docs/codeql/ql-language-reference/ql-language-specification.rst
+++ b/docs/codeql/ql-language-reference/ql-language-specification.rst
@@ -349,7 +349,7 @@ A QL signature definition has the following syntax:
 
    predicateSignature ::= qldoc? annotations "signature" head ";"
 
-   typeSignature ::= qldoc? annotations "signature" "class" upperId ("extends" type ("," type)*)? (";" | "{" signaturePredicate* "}")
+   typeSignature ::= qldoc? annotations "signature" "class" classname ("extends" type ("," type)*)? (";" | "{" signaturePredicate* "}")
 
    moduleSignature ::= qldoc? annotation* "signature" "module" moduleSignatureName parameters? "{" moduleSignatureBody "}"
 
@@ -359,7 +359,7 @@ A QL signature definition has the following syntax:
 
    defaultPredicate ::= qldoc? annotations "default" head "{" formula "}"
 
-   signatureType ::= qldoc? annotations "class" upperId ("extends" type ("," type)*)? "{" signaturePredicate* "}"
+   signatureType ::= qldoc? annotations "class" classname ("extends" type ("," type)*)? "{" signaturePredicate* "}"
 
 
 A predicate signature definition extends the current module's declared predicate signature environment with a mapping from the predicate signature name and arity to the predicate signature definition.
@@ -2126,7 +2126,7 @@ The complete grammar for QL is as follows:
 
    predicateSignature ::= qldoc? annotations "signature" head ";"
 
-   typeSignature ::= qldoc? annotations "signature" "class" upperId ("extends" type ("," type)*)? (";" | "{" signaturePredicate* "}")
+   typeSignature ::= qldoc? annotations "signature" "class" classname ("extends" type ("," type)*)? (";" | "{" signaturePredicate* "}")
 
    moduleSignature ::= qldoc? annotation* "signature" "module" moduleSignatureName parameters? "{" moduleSignatureBody "}"
 
@@ -2136,7 +2136,7 @@ The complete grammar for QL is as follows:
 
    defaultPredicate ::= qldoc? annotations "default" head "{" formula "}"
 
-   signatureType ::= qldoc? annotations "class" upperId ("extends" type ("," type)*)? "{" signaturePredicate* "}"
+   signatureType ::= qldoc? annotations "class" classname ("extends" type ("," type)*)? "{" signaturePredicate* "}"
 
    select ::= ("from" var_decls)? ("where" formula)? "select" as_exprs ("order" "by" orderbys)?
 

--- a/docs/codeql/ql-language-reference/ql-language-specification.rst
+++ b/docs/codeql/ql-language-reference/ql-language-specification.rst
@@ -178,7 +178,7 @@ A QL module definition has the following syntax:
 
    module ::= annotation* "module" modulename parameters? implements? "{" moduleBody "}"
 
-   parameters ::= "<" signatureExpr simpleId ("," signatureExpr simpleId)* ">"
+   parameters ::= "<" signatureExpr parameterName ("," signatureExpr parameterName)* ">"
 
    implements ::= "implements" moduleSignatureExpr ("," moduleSignatureExpr)*
 
@@ -640,6 +640,7 @@ Identifiers are used in following syntactic constructs:
    predicateRef        ::= (moduleExpr "::")? literalId
    signatureExpr       ::= (moduleExpr "::")? simpleId ("/" Integer | arguments)?;
    predicateName       ::= lowerId
+   parameterName       ::= simpleId
    varname             ::= lowerId
    literalId           ::= lowerId | atLowerId
 
@@ -2107,7 +2108,7 @@ The complete grammar for QL is as follows:
 
    module ::= annotation* "module" modulename parameters? implements? "{" moduleBody "}"
 
-   parameters ::= "<" signatureExpr simpleId ("," signatureExpr simpleId)* ">"
+   parameters ::= "<" signatureExpr parameterName ("," signatureExpr parameterName)* ">"
 
    implements ::= "implements" moduleSignatureExpr ("," moduleSignatureExpr)*
 
@@ -2322,6 +2323,8 @@ The complete grammar for QL is as follows:
    predicateRef ::= (moduleExpr "::")? literalId
 
    predicateName ::= lowerId
+
+   parameterName ::= simpleId
 
    varname ::= lowerId
 

--- a/docs/codeql/ql-language-reference/ql-language-specification.rst
+++ b/docs/codeql/ql-language-reference/ql-language-specification.rst
@@ -628,8 +628,6 @@ There are several kinds of identifiers:
 
 -  ``atLowerId``: an identifier that starts with an "@" sign and then a lower-case letter.
 
--  ``atUpperId``: an identifier that starts with an "@" sign and then an upper-case letter.
-
 Identifiers are used in following syntactic constructs:
 
 ::

--- a/docs/codeql/ql-language-reference/ql-language-specification.rst
+++ b/docs/codeql/ql-language-reference/ql-language-specification.rst
@@ -216,7 +216,7 @@ An import directive refers to a module identifier:
 
    qualId ::= simpleId | qualId "." simpleId
 
-   importModuleExpr ::= qualId | importModuleExpr "::" simpleId arguments?
+   importModuleExpr ::= qualId | importModuleExpr "::" modulename arguments?
 
    arguments ::= "<" argument ("," argument)* ">"
 
@@ -289,7 +289,7 @@ With the exception of class domain types and character types (which cannot be re
 
    type ::= (moduleExpr "::")? classname | dbasetype | "boolean" | "date" | "float" | "int" | "string"
 
-   moduleExpr ::= simpleId arguments? | moduleExpr "::" simpleId arguments?
+   moduleExpr ::= modulename arguments? | moduleExpr "::" modulename arguments?
 
 A type reference is resolved to a type as follows:
 
@@ -2116,7 +2116,7 @@ The complete grammar for QL is as follows:
 
    qualId ::= simpleId | qualId "." simpleId
 
-   importModuleExpr ::= qualId | importModuleExpr "::" simpleId arguments?
+   importModuleExpr ::= qualId | importModuleExpr "::" modulename arguments?
 
    arguments ::= "<" argument ("," argument)* ">"
 
@@ -2183,7 +2183,7 @@ The complete grammar for QL is as follows:
 
    field ::= qldoc? annotations var_decl ";"
 
-   moduleExpr ::= simpleId arguments? | moduleExpr "::" simpleId arguments?
+   moduleExpr ::= modulename arguments? | moduleExpr "::" modulename arguments?
 
    moduleSignatureExpr ::= (moduleExpr "::")? moduleSignatureName arguments?
 

--- a/docs/codeql/ql-language-reference/ql-language-specification.rst
+++ b/docs/codeql/ql-language-reference/ql-language-specification.rst
@@ -351,7 +351,7 @@ A QL signature definition has the following syntax:
 
    typeSignature ::= qldoc? annotations "signature" "class" upperId ("extends" type ("," type)*)? (";" | "{" signaturePredicate* "}")
 
-   moduleSignature ::= qldoc? annotation* "signature" "module" upperId parameters? "{" moduleSignatureBody "}"
+   moduleSignature ::= qldoc? annotation* "signature" "module" moduleSignatureName parameters? "{" moduleSignatureBody "}"
 
    moduleSignatureBody ::= (signaturePredicate | defaultPredicate | signatureType)*
 
@@ -632,14 +632,15 @@ Identifiers are used in following syntactic constructs:
 
 ::
 
-   simpleId      ::= lowerId | upperId
-   modulename    ::= simpleId
-   classname     ::= upperId
-   dbasetype     ::= atLowerId
-   predicateRef  ::= (moduleExpr "::")? literalId
-   predicateName ::= lowerId
-   varname       ::= lowerId
-   literalId     ::= lowerId | atLowerId
+   simpleId            ::= lowerId | upperId
+   modulename          ::= simpleId
+   moduleSignatureName ::= upperId
+   classname           ::= upperId
+   dbasetype           ::= atLowerId
+   predicateRef        ::= (moduleExpr "::")? literalId
+   predicateName       ::= lowerId
+   varname             ::= lowerId
+   literalId           ::= lowerId | atLowerId
 
 Integer literals (int)
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -2127,7 +2128,7 @@ The complete grammar for QL is as follows:
 
    typeSignature ::= qldoc? annotations "signature" "class" upperId ("extends" type ("," type)*)? (";" | "{" signaturePredicate* "}")
 
-   moduleSignature ::= qldoc? annotation* "signature" "module" upperId parameters? "{" moduleSignatureBody "}"
+   moduleSignature ::= qldoc? annotation* "signature" "module" moduleSignatureName parameters? "{" moduleSignatureBody "}"
 
    moduleSignatureBody ::= (signaturePredicate | defaultPredicate | signatureType)*
 
@@ -2184,7 +2185,7 @@ The complete grammar for QL is as follows:
 
    moduleExpr ::= simpleId arguments? | moduleExpr "::" simpleId arguments?
 
-   moduleSignatureExpr ::= (moduleExpr "::")? upperId arguments?
+   moduleSignatureExpr ::= (moduleExpr "::")? moduleSignatureName arguments?
 
    signatureExpr : (moduleExpr "::")? simpleId ("/" Integer | arguments)?;
 
@@ -2310,6 +2311,8 @@ The complete grammar for QL is as follows:
    simpleId ::= lowerId | upperId
 
    modulename ::= simpleId
+
+   moduleSignatureName ::= upperId
 
    classname ::= upperId
 


### PR DESCRIPTION
The specification was set up so that all rules that use `lowerId`, `simpleId`, `upperId` were introduced in the **Identifier** section (aside from `qualId`, which is introduced before in the section on **Import directives**). This meant that there was one convenient central place where users could look up the allowed identifier syntax for everything.

This PR restores this principle in two ways:

1. Rules that previously circumvented some "redundant" redirections (such as type signatures using `upperId` directly rather than referring to `classname`) are changed to follow the existing behaviour of older rules.
2. Rules `moduleSignatureName`, `signatureExpr`, and `parameterName` and are added to the `Identifier` section.