### PR TITLE
Java: Add QL support for automodel application mode

### DIFF
--- a/java/ql/src/Telemetry/AutomodelApplicationModeCharacteristics.qll
+++ b/java/ql/src/Telemetry/AutomodelApplicationModeCharacteristics.qll
@@ -264,7 +264,10 @@ private class IsMaDTaintStepCharacteristic extends CharacteristicsImpl::NotASink
 
 /**
  * A negative characteristic that filters out qualifiers that are classes (i.e. static calls). These
- *are unlikely to have any non-trivial flow going into them.
+ * are unlikely to have any non-trivial flow going into them.
+ *
+ * Technically, an accessed type _could_ come from outside of the source code, but there's not
+ * much likelihood of that being user-controlled.
  */
 private class ClassQualifierCharacteristic extends CharacteristicsImpl::NotASinkCharacteristic {
   ClassQualifierCharacteristic() { this = "class qualifier" }

--- a/java/ql/src/Telemetry/AutomodelApplicationModeCharacteristics.qll
+++ b/java/ql/src/Telemetry/AutomodelApplicationModeCharacteristics.qll
@@ -278,6 +278,29 @@ private class ArgumentToLocalCall extends CharacteristicsImpl::UninterestingToMo
 }
 
 /**
+ * A characteristic that avoids modeling endpoint that are passed to frameworks
+ * in application mode.
+ *
+ * It's much more economical to use framework mode for those.
+ */
+private class SkipFrameworkModeling extends CharacteristicsImpl::UninterestingToModelCharacteristic {
+  SkipFrameworkModeling() { this = "skip modeling of large frameworks" }
+
+  override predicate appliesToEndpoint(Endpoint e) {
+    ApplicationCandidatesImpl::getCallable(e)
+        .getDeclaringType()
+        .getPackage()
+        .getName()
+        .matches([
+            "com.google%", //
+            "java.%", //
+            "javax.%", //
+            "org.apache%", //
+          ])
+  }
+}
+
+/**
  * A Characteristic that marks endpoints as uninteresting to model, according to the Java ModelExclusions module.
  */
 private class ExcludedFromModeling extends CharacteristicsImpl::UninterestingToModelCharacteristic {

--- a/java/ql/src/Telemetry/AutomodelApplicationModeCharacteristics.qll
+++ b/java/ql/src/Telemetry/AutomodelApplicationModeCharacteristics.qll
@@ -111,7 +111,7 @@ module ApplicationCandidatesImpl implements SharedCharacteristics::CandidateSig 
   }
 
   /**
-   * Returns the API callable being modelled.
+   * Returns the API callable being modeled.
    *
    * Each Java mode should implement this predicate.
    */

--- a/java/ql/src/Telemetry/AutomodelApplicationModeCharacteristics.qll
+++ b/java/ql/src/Telemetry/AutomodelApplicationModeCharacteristics.qll
@@ -329,6 +329,17 @@ private class OtherArgumentToModeledMethodCharacteristic extends Characteristics
 }
 
 /**
+ * A characteristic that marks functional expression as likely not sinks.
+ *
+ * These expressions may well _contain_ sinks, but rarely are sinks themselves.
+ */
+private class FunctionValueCharacteristic extends CharacteristicsImpl::LikelyNotASinkCharacteristic {
+  FunctionValueCharacteristic() { this = "function value" }
+
+  override predicate appliesToEndpoint(Endpoint e) { e.asExpr() instanceof FunctionalExpr }
+}
+
+/**
  * A negative characteristic that indicates that an endpoint is not a `to` node for any known taint step. Such a node
  * cannot be tainted, because taint can't flow into it.
  *

--- a/java/ql/src/Telemetry/AutomodelApplicationModeCharacteristics.qll
+++ b/java/ql/src/Telemetry/AutomodelApplicationModeCharacteristics.qll
@@ -291,6 +291,21 @@ private class NonPublicMethodCharacteristic extends CharacteristicsImpl::Uninter
 }
 
 /**
+ * A negative characteristic that filters out qualifiers that are classes (i.e. static calls). These
+ *are unlikely to have any non-trivial flow going into them.
+ */
+private class ClassQualifierCharacteristic extends CharacteristicsImpl::NotASinkCharacteristic {
+  ClassQualifierCharacteristic() { this = "class qualifier" }
+
+  override predicate appliesToEndpoint(Endpoint e) {
+    exists(Call c |
+      e.asExpr() = c.getQualifier() and
+      c.getCallee().isStatic()
+    )
+  }
+}
+
+/**
  * Holds if the given endpoint has a self-contradictory combination of characteristics. Detects errors in our endpoint
  * characteristics. Lists the problematic characteristics and their implications for all such endpoints, together with
  * an error message indicating why this combination is problematic.

--- a/java/ql/src/Telemetry/AutomodelApplicationModeCharacteristics.qll
+++ b/java/ql/src/Telemetry/AutomodelApplicationModeCharacteristics.qll
@@ -345,6 +345,7 @@ private class CannotBeTaintedCharacteristic extends CharacteristicsImpl::LikelyN
    * Holds if the node `n` is known as the predecessor in a modeled flow step.
    */
   private predicate isKnownOutNodeForStep(Endpoint e) {
+    e.asExpr() instanceof Call or // we just assume flow in that case
     TaintTracking::localTaintStep(_, e) or
     FlowSummaryImpl::Private::Steps::summaryThroughStepValue(_, e, _) or
     FlowSummaryImpl::Private::Steps::summaryThroughStepTaint(_, e, _) or

--- a/java/ql/src/Telemetry/AutomodelApplicationModeCharacteristics.qll
+++ b/java/ql/src/Telemetry/AutomodelApplicationModeCharacteristics.qll
@@ -1,0 +1,360 @@
+/**
+ * For internal use only.
+ */
+
+private import java
+private import semmle.code.Location as Location
+private import semmle.code.java.dataflow.DataFlow
+private import semmle.code.java.dataflow.TaintTracking
+private import semmle.code.java.security.PathCreation
+private import semmle.code.java.dataflow.ExternalFlow as ExternalFlow
+private import semmle.code.java.dataflow.internal.FlowSummaryImpl as FlowSummaryImpl
+private import semmle.code.java.security.ExternalAPIs as ExternalAPIs
+private import semmle.code.java.Expr as Expr
+private import semmle.code.java.security.QueryInjection
+private import semmle.code.java.security.RequestForgery
+private import semmle.code.java.dataflow.internal.ModelExclusions as ModelExclusions
+import AutomodelSharedCharacteristics as SharedCharacteristics
+import AutomodelEndpointTypes as AutomodelEndpointTypes
+
+/**
+ * A meta data extractor. Any Java extraction mode needs to implement exactly
+ * one instance of this class.
+ */
+abstract class MetadataExtractor extends string {
+  bindingset[this]
+  MetadataExtractor() { any() }
+
+  abstract predicate hasMetadata(
+    Endpoint e, string package, string type, boolean subtypes, string name, string signature,
+    int input
+  );
+}
+
+newtype JavaRelatedLocationType = CallContext()
+
+/**
+ * A class representing nodes that are arguments to calls.
+ */
+private class ArgumentNode extends DataFlow::Node {
+  ArgumentNode() { this.asExpr() = [any(Call c).getAnArgument(), any(Call c).getQualifier()] }
+}
+
+/**
+ * A candidates implementation for framework mode.
+ *
+ * Some important notes:
+ *  - This mode is using parameters as endpoints.
+ *  - Sink- and neutral-information is being used from MaD models.
+ *  - When available, we use method- and class-java-docs as related locations.
+ */
+module FrameworkCandidatesImpl implements SharedCharacteristics::CandidateSig {
+  // for documentation of the implementations here, see the QLDoc in the CandidateSig signature module.
+  class Endpoint = ArgumentNode;
+
+  class EndpointType = AutomodelEndpointTypes::EndpointType;
+
+  class NegativeEndpointType = AutomodelEndpointTypes::NegativeSinkType;
+
+  class RelatedLocation = Location::Top;
+
+  class RelatedLocationType = JavaRelatedLocationType;
+
+  // Sanitizers are currently not modeled in MaD. TODO: check if this has large negative impact.
+  predicate isSanitizer(Endpoint e, EndpointType t) { none() }
+
+  RelatedLocation asLocation(Endpoint e) { result = e.asExpr() }
+
+  predicate isKnownKind(string kind, string humanReadableKind, EndpointType type) {
+    kind = "read-file" and
+    humanReadableKind = "read file" and
+    type instanceof AutomodelEndpointTypes::TaintedPathSinkType
+    or
+    kind = "create-file" and
+    humanReadableKind = "create file" and
+    type instanceof AutomodelEndpointTypes::TaintedPathSinkType
+    or
+    kind = "sql" and
+    humanReadableKind = "mad modeled sql" and
+    type instanceof AutomodelEndpointTypes::SqlSinkType
+    or
+    kind = "open-url" and
+    humanReadableKind = "open url" and
+    type instanceof AutomodelEndpointTypes::RequestForgerySinkType
+    or
+    kind = "jdbc-url" and
+    humanReadableKind = "jdbc url" and
+    type instanceof AutomodelEndpointTypes::RequestForgerySinkType
+    or
+    kind = "command-injection" and
+    humanReadableKind = "command injection" and
+    type instanceof AutomodelEndpointTypes::CommandInjectionSinkType
+  }
+
+  predicate isSink(Endpoint e, string kind) {
+    exists(string package, string type, string name, string signature, string ext, string input |
+      sinkSpec(e, package, type, name, signature, ext, input) and
+      ExternalFlow::sinkModel(package, type, _, name, [signature, ""], ext, input, kind, _)
+    )
+  }
+
+  predicate isNeutral(Endpoint e) {
+    exists(string package, string type, string name, string signature |
+      sinkSpec(e, package, type, name, signature, _, _) and
+      ExternalFlow::neutralModel(package, type, name, [signature, ""], _, _)
+    )
+  }
+
+  additional predicate sinkSpec(
+    Endpoint e, string package, string type, string name, string signature, string ext, string input
+  ) {
+    FrameworkCandidatesImpl::getCallable(e).hasQualifiedName(package, type, name) and
+    signature = ExternalFlow::paramsString(getCallable(e)) and
+    ext = "" and
+    (
+      exists(Call c, int argIdx |
+        e.asExpr() = c.getArgument(argIdx) and
+        input = "Argument[" + argIdx + "]"
+      )
+      or
+      exists(Call c | e.asExpr() = c.getQualifier() and input = "Argument[this]")
+    )
+    // exists(int paramIdx | e.isParameterOf(_, paramIdx) |
+    //   if paramIdx = -1 then input = "Argument[this]" else input = "Argument[" + paramIdx + "]"
+    // )
+  }
+
+  /**
+   * Returns the related location for the given endpoint.
+   *
+   * Related locations can be JavaDoc comments of the class or the method.
+   */
+  RelatedLocation getRelatedLocation(Endpoint e, RelatedLocationType type) {
+    type = CallContext() and
+    result = asLocation(e)
+  }
+
+  /**
+   * Returns the callable that contains the given endpoint.
+   *
+   * Each Java mode should implement this predicate.
+   */
+  additional Callable getCallable(Endpoint e) {
+    exists(Call c |
+      e.asExpr() = [c.getAnArgument(), c.getQualifier()] and
+      result = c.getCallee()
+    )
+  }
+}
+
+module CharacteristicsImpl = SharedCharacteristics::SharedCharacteristics<FrameworkCandidatesImpl>;
+
+class EndpointCharacteristic = CharacteristicsImpl::EndpointCharacteristic;
+
+class Endpoint = FrameworkCandidatesImpl::Endpoint;
+
+/*
+ * Predicates that are used to surface prompt examples and candidates for classification with an ML model.
+ */
+
+/**
+ * A MetadataExtractor that extracts metadata for framework mode.
+ */
+class FrameworkModeMetadataExtractor extends MetadataExtractor {
+  FrameworkModeMetadataExtractor() { this = "FrameworkModeMetadataExtractor" }
+
+  /**
+   * By convention, the subtypes property of the MaD declaration should only be
+   * true when there _can_ exist any subtypes with a different implementation.
+   *
+   * It would technically be ok to always use the value 'true', but this would
+   * break convention.
+   */
+  boolean considerSubtypes(Callable callable) {
+    if
+      callable.isStatic() or
+      callable.getDeclaringType().isStatic() or
+      callable.isFinal() or
+      callable.getDeclaringType().isFinal()
+    then result = false
+    else result = true
+  }
+
+  override predicate hasMetadata(
+    Endpoint e, string package, string type, boolean subtypes, string name, string signature,
+    int input
+  ) {
+    exists(Call call, Callable callable |
+      call.getCallee() = callable and
+      (
+        e.asExpr() = call.getArgument(input)
+        or
+        e.asExpr() = call.getQualifier() and input = -1
+      ) and
+      package = callable.getDeclaringType().getPackage().getName() and
+      type = callable.getDeclaringType().getErasure().(RefType).nestedName() and
+      subtypes = this.considerSubtypes(callable) and
+      name = callable.getName() and
+      signature = ExternalFlow::paramsString(callable)
+    )
+  }
+}
+
+/*
+ * EndpointCharacteristic classes that are specific to Automodel for Java.
+ */
+
+/**
+ * A negative characteristic that indicates that an is-style boolean method is unexploitable even if it is a sink.
+ *
+ * A sink is highly unlikely to be exploitable if its callable's name starts with `is` and the callable has a boolean return
+ * type (e.g. `isDirectory`). These kinds of calls normally do only checks, and appear before the proper call that does
+ * the dangerous/interesting thing, so we want the latter to be modeled as the sink.
+ *
+ * TODO: this might filter too much, it's possible that methods with more than one parameter contain interesting sinks
+ */
+private class UnexploitableIsCharacteristic extends CharacteristicsImpl::NotASinkCharacteristic {
+  UnexploitableIsCharacteristic() { this = "unexploitable (is-style boolean method)" }
+
+  override predicate appliesToEndpoint(Endpoint e) {
+    not FrameworkCandidatesImpl::isSink(e, _) and
+    FrameworkCandidatesImpl::getCallable(e).getName().matches("is%") and
+    FrameworkCandidatesImpl::getCallable(e).getReturnType() instanceof BooleanType
+  }
+}
+
+/**
+ * A negative characteristic that indicates that an existence-checking boolean method is unexploitable even if it is a
+ * sink.
+ *
+ * A sink is highly unlikely to be exploitable if its callable's name is `exists` or `notExists` and the callable has a
+ * boolean return type. These kinds of calls normally do only checks, and appear before the proper call that does the
+ * dangerous/interesting thing, so we want the latter to be modeled as the sink.
+ */
+private class UnexploitableExistsCharacteristic extends CharacteristicsImpl::NotASinkCharacteristic {
+  UnexploitableExistsCharacteristic() { this = "unexploitable (existence-checking boolean method)" }
+
+  override predicate appliesToEndpoint(Endpoint e) {
+    not FrameworkCandidatesImpl::isSink(e, _) and
+    exists(Callable callable |
+      callable = FrameworkCandidatesImpl::getCallable(e) and
+      callable.getName().toLowerCase() = ["exists", "notexists"] and
+      callable.getReturnType() instanceof BooleanType
+    )
+  }
+}
+
+/**
+ * A negative characteristic that indicates that an endpoint is an argument to an exception, which is not a sink.
+ */
+private class ExceptionCharacteristic extends CharacteristicsImpl::NotASinkCharacteristic {
+  ExceptionCharacteristic() { this = "exception" }
+
+  override predicate appliesToEndpoint(Endpoint e) {
+    FrameworkCandidatesImpl::getCallable(e).getDeclaringType().getASupertype*() instanceof
+      TypeThrowable
+  }
+}
+
+/**
+ * A characteristic that limits candidates to parameters of methods that are recognized as `ModelApi`, iow., APIs that
+ * are considered worth modeling.
+ */
+private class NotAModelApiParameter extends CharacteristicsImpl::UninterestingToModelCharacteristic {
+  NotAModelApiParameter() { this = "not a model API parameter" }
+
+  override predicate appliesToEndpoint(Endpoint e) {
+    not exists(ModelExclusions::ModelApi api |
+      exists(Call c |
+        c.getCallee() = api and
+        exists(int argIdx | exists(api.getParameter(argIdx)) |
+          argIdx = -1 and e.asExpr() = c.getQualifier()
+          or
+          argIdx >= 0 and e.asExpr() = c.getArgument(argIdx)
+        )
+      )
+    )
+  }
+}
+
+/**
+ * A negative characteristic that filters out non-public methods. Non-public methods are not interesting to include in
+ * the standard Java modeling, because they cannot be called from outside the package.
+ */
+private class NonPublicMethodCharacteristic extends CharacteristicsImpl::UninterestingToModelCharacteristic
+{
+  NonPublicMethodCharacteristic() { this = "non-public method" }
+
+  override predicate appliesToEndpoint(Endpoint e) {
+    not FrameworkCandidatesImpl::getCallable(e).isPublic()
+  }
+}
+
+/**
+ * Holds if the given endpoint has a self-contradictory combination of characteristics. Detects errors in our endpoint
+ * characteristics. Lists the problematic characteristics and their implications for all such endpoints, together with
+ * an error message indicating why this combination is problematic.
+ *
+ * Copied from
+ *   javascript/ql/experimental/adaptivethreatmodeling/test/endpoint_large_scale/ContradictoryEndpointCharacteristics.ql
+ */
+predicate erroneousEndpoints(
+  Endpoint endpoint, EndpointCharacteristic characteristic,
+  AutomodelEndpointTypes::EndpointType endpointType, float confidence, string errorMessage,
+  boolean ignoreKnownModelingErrors
+) {
+  // An endpoint's characteristics should not include positive indicators with medium/high confidence for more than one
+  // sink/source type (including the negative type).
+  exists(
+    EndpointCharacteristic characteristic2, AutomodelEndpointTypes::EndpointType endpointClass2,
+    float confidence2
+  |
+    endpointType != endpointClass2 and
+    (
+      endpointType instanceof AutomodelEndpointTypes::SinkType and
+      endpointClass2 instanceof AutomodelEndpointTypes::SinkType
+      or
+      endpointType instanceof AutomodelEndpointTypes::SourceType and
+      endpointClass2 instanceof AutomodelEndpointTypes::SourceType
+    ) and
+    characteristic.appliesToEndpoint(endpoint) and
+    characteristic2.appliesToEndpoint(endpoint) and
+    characteristic.hasImplications(endpointType, true, confidence) and
+    characteristic2.hasImplications(endpointClass2, true, confidence2) and
+    confidence > SharedCharacteristics::mediumConfidence() and
+    confidence2 > SharedCharacteristics::mediumConfidence() and
+    (
+      ignoreKnownModelingErrors = true and
+      not knownOverlappingCharacteristics(characteristic, characteristic2)
+      or
+      ignoreKnownModelingErrors = false
+    )
+  ) and
+  errorMessage = "Endpoint has high-confidence positive indicators for multiple classes"
+  or
+  // An endpoint's characteristics should not include positive indicators with medium/high confidence for some class and
+  // also include negative indicators with medium/high confidence for this same class.
+  exists(EndpointCharacteristic characteristic2, float confidence2 |
+    characteristic.appliesToEndpoint(endpoint) and
+    characteristic2.appliesToEndpoint(endpoint) and
+    characteristic.hasImplications(endpointType, true, confidence) and
+    characteristic2.hasImplications(endpointType, false, confidence2) and
+    confidence > SharedCharacteristics::mediumConfidence() and
+    confidence2 > SharedCharacteristics::mediumConfidence()
+  ) and
+  ignoreKnownModelingErrors = false and
+  errorMessage = "Endpoint has high-confidence positive and negative indicators for the same class"
+}
+
+/**
+ * Holds if `characteristic1` and `characteristic2` are among the pairs of currently known positive characteristics that
+ * have some overlap in their results. This indicates a problem with the underlying Java modeling. Specifically,
+ * `PathCreation` is prone to FPs.
+ */
+private predicate knownOverlappingCharacteristics(
+  EndpointCharacteristic characteristic1, EndpointCharacteristic characteristic2
+) {
+  characteristic1 != characteristic2 and
+  characteristic1 = ["mad taint step", "create path", "read file", "known non-sink"] and
+  characteristic2 = ["mad taint step", "create path", "read file", "known non-sink"]
+}

--- a/java/ql/src/Telemetry/AutomodelApplicationModeCharacteristics.qll
+++ b/java/ql/src/Telemetry/AutomodelApplicationModeCharacteristics.qll
@@ -77,10 +77,12 @@ module ApplicationCandidatesImpl implements SharedCharacteristics::CandidateSig 
     (
       exists(Call c, int argIdx |
         e.asExpr() = c.getArgument(argIdx) and
-        input = "Argument[" + argIdx + "]"
+        input = AutomodelSharedUtil::getArgumentForIndex(argIdx)
       )
       or
-      exists(Call c | e.asExpr() = c.getQualifier() and input = "Argument[this]")
+      exists(Call c |
+        e.asExpr() = c.getQualifier() and input = AutomodelSharedUtil::getArgumentForIndex(-1)
+      )
     )
   }
 
@@ -148,10 +150,11 @@ class ApplicationModeMetadataExtractor extends string {
     exists(Call call, Callable callable, int argIdx |
       call.getCallee() = callable and
       (
-        e.asExpr() = call.getArgument(argIdx) and input = "Argument[" + argIdx + "]"
+        e.asExpr() = call.getArgument(argIdx)
         or
-        e.asExpr() = call.getQualifier() and argIdx = -1 and input = "Argument[this]"
+        e.asExpr() = call.getQualifier() and argIdx = -1
       ) and
+      input = AutomodelSharedUtil::getArgumentForIndex(argIdx) and
       package = callable.getDeclaringType().getPackage().getName() and
       type = callable.getDeclaringType().getErasure().(RefType).nestedName() and
       subtypes = this.considerSubtypes(callable) and
@@ -231,7 +234,7 @@ private class NotAModelApiParameter extends CharacteristicsImpl::UninterestingTo
         exists(int argIdx | exists(api.getParameter(argIdx)) |
           argIdx = -1 and e.asExpr() = c.getQualifier()
           or
-          argIdx >= 0 and e.asExpr() = c.getArgument(argIdx)
+          e.asExpr() = c.getArgument(argIdx)
         )
       )
     )

--- a/java/ql/src/Telemetry/AutomodelApplicationModeCharacteristics.qll
+++ b/java/ql/src/Telemetry/AutomodelApplicationModeCharacteristics.qll
@@ -295,32 +295,6 @@ private class ArgumentToLocalCall extends CharacteristicsImpl::UninterestingToMo
 }
 
 /**
- * A characteristic that avoids modeling endpoint that are passed to frameworks
- * in application mode.
- *
- * It's much more economical to use framework mode for those.
- */
-private class SkipFrameworkModeling extends CharacteristicsImpl::UninterestingToModelCharacteristic {
-  SkipFrameworkModeling() { this = "skip modeling of large frameworks" }
-
-  override predicate appliesToEndpoint(Endpoint e) {
-    ApplicationCandidatesImpl::getCallable(e)
-        .getDeclaringType()
-        .getPackage()
-        .getName()
-        .matches([
-            "com.google%", //
-            "java.%", //
-            "javax.%", //
-            "org.apache%", //
-            "org.eclipse%", //
-            "org.gradle%", //
-            "org.slf4j%", //
-          ])
-  }
-}
-
-/**
  * A Characteristic that marks endpoints as uninteresting to model, according to the Java ModelExclusions module.
  */
 private class ExcludedFromModeling extends CharacteristicsImpl::UninterestingToModelCharacteristic {

--- a/java/ql/src/Telemetry/AutomodelApplicationModeCharacteristics.qll
+++ b/java/ql/src/Telemetry/AutomodelApplicationModeCharacteristics.qll
@@ -49,8 +49,8 @@ module ApplicationCandidatesImpl implements SharedCharacteristics::CandidateSig 
 
   // Sanitizers are currently not modeled in MaD. TODO: check if this has large negative impact.
   predicate isSanitizer(Endpoint e, EndpointType t) {
+    exists(t) and
     (
-      exists(t) and
       e.getType() instanceof BoxedType
       or
       e.getType() instanceof PrimitiveType

--- a/java/ql/src/Telemetry/AutomodelApplicationModeCharacteristics.qll
+++ b/java/ql/src/Telemetry/AutomodelApplicationModeCharacteristics.qll
@@ -14,6 +14,7 @@ private import semmle.code.java.Expr as Expr
 private import semmle.code.java.security.QueryInjection
 private import semmle.code.java.security.RequestForgery
 private import semmle.code.java.dataflow.internal.ModelExclusions as ModelExclusions
+private import AutomodelSharedUtil as AutomodelSharedUtil
 import AutomodelSharedCharacteristics as SharedCharacteristics
 import AutomodelEndpointTypes as AutomodelEndpointTypes
 
@@ -51,31 +52,7 @@ module ApplicationCandidatesImpl implements SharedCharacteristics::CandidateSig 
 
   RelatedLocation asLocation(Endpoint e) { result = e.asExpr() }
 
-  predicate isKnownKind(string kind, string humanReadableKind, EndpointType type) {
-    kind = "read-file" and
-    humanReadableKind = "read file" and
-    type instanceof AutomodelEndpointTypes::TaintedPathSinkType
-    or
-    kind = "create-file" and
-    humanReadableKind = "create file" and
-    type instanceof AutomodelEndpointTypes::TaintedPathSinkType
-    or
-    kind = "sql" and
-    humanReadableKind = "mad modeled sql" and
-    type instanceof AutomodelEndpointTypes::SqlSinkType
-    or
-    kind = "open-url" and
-    humanReadableKind = "open url" and
-    type instanceof AutomodelEndpointTypes::RequestForgerySinkType
-    or
-    kind = "jdbc-url" and
-    humanReadableKind = "jdbc url" and
-    type instanceof AutomodelEndpointTypes::RequestForgerySinkType
-    or
-    kind = "command-injection" and
-    humanReadableKind = "command injection" and
-    type instanceof AutomodelEndpointTypes::CommandInjectionSinkType
-  }
+  predicate isKnownKind = AutomodelSharedUtil::isKnownKind/3;
 
   predicate isSink(Endpoint e, string kind) {
     exists(string package, string type, string name, string signature, string ext, string input |
@@ -105,9 +82,6 @@ module ApplicationCandidatesImpl implements SharedCharacteristics::CandidateSig 
       or
       exists(Call c | e.asExpr() = c.getQualifier() and input = "Argument[this]")
     )
-    // exists(int paramIdx | e.isParameterOf(_, paramIdx) |
-    //   if paramIdx = -1 then input = "Argument[this]" else input = "Argument[" + paramIdx + "]"
-    // )
   }
 
   /**

--- a/java/ql/src/Telemetry/AutomodelApplicationModeCharacteristics.qll
+++ b/java/ql/src/Telemetry/AutomodelApplicationModeCharacteristics.qll
@@ -326,23 +326,6 @@ private class OtherArgumentToModeledMethodCharacteristic extends Characteristics
 }
 
 /**
- * A negative characteristic that indicates that an endpoint is not part of the source code for the project being
- * analyzed.
- *
- * WARNING: These endpoints should not be used as negative samples for training, because they are not necessarily
- * non-sinks. They are merely not interesting sinks to run through the ML model.
- *
- * TODO: Check that this actually does anything.
- */
-private class IsExternalCharacteristic extends CharacteristicsImpl::LikelyNotASinkCharacteristic {
-  IsExternalCharacteristic() { this = "external" }
-
-  override predicate appliesToEndpoint(Endpoint e) {
-    not exists(e.getLocation().getFile().getRelativePath())
-  }
-}
-
-/**
  * A negative characteristic that indicates that an endpoint is not a `to` node for any known taint step. Such a node
  * cannot be tainted, because taint can't flow into it.
  *

--- a/java/ql/src/Telemetry/AutomodelApplicationModeCharacteristics.qll
+++ b/java/ql/src/Telemetry/AutomodelApplicationModeCharacteristics.qll
@@ -190,6 +190,8 @@ class ApplicationModeMetadataExtractor extends string {
       ) and
       input = AutomodelSharedUtil::getArgumentForIndex(argIdx) and
       package = callable.getDeclaringType().getPackage().getName() and
+      // we're using the erased types because the MaD convention is to not specify type parameters.
+      // Whether something is or isn't a sink doesn't usually depend on the type parameters.
       type = callable.getDeclaringType().getErasure().(RefType).nestedName() and
       subtypes = this.considerSubtypes(callable).toString() and
       name = callable.getName() and

--- a/java/ql/src/Telemetry/AutomodelApplicationModeCharacteristics.qll
+++ b/java/ql/src/Telemetry/AutomodelApplicationModeCharacteristics.qll
@@ -102,7 +102,7 @@ module ApplicationCandidatesImpl implements SharedCharacteristics::CandidateSig 
   }
 
   /**
-   * Returns the related location for the given endpoint.
+   * Gets the related location for the given endpoint.
    *
    * The only related location we model is the the call expression surrounding to
    * which the endpoint is either argument or qualifier (known as the call context).

--- a/java/ql/src/Telemetry/AutomodelApplicationModeCharacteristics.qll
+++ b/java/ql/src/Telemetry/AutomodelApplicationModeCharacteristics.qll
@@ -269,20 +269,23 @@ private class ClassQualifierCharacteristic extends CharacteristicsImpl::NotASink
  * A characteristic that limits candidates to parameters of methods that are recognized as `ModelApi`, iow., APIs that
  * are considered worth modeling.
  */
-private class NotAModelApiParameter extends CharacteristicsImpl::UninterestingToModelCharacteristic {
-  NotAModelApiParameter() { this = "not a model API parameter" }
+private class ArgumentToLocalCall extends CharacteristicsImpl::UninterestingToModelCharacteristic {
+  ArgumentToLocalCall() { this = "argument to local call" }
 
   override predicate appliesToEndpoint(Endpoint e) {
-    not exists(ModelExclusions::ModelApi api |
-      exists(Call c |
-        c.getCallee() = api and
-        exists(int argIdx | exists(api.getParameter(argIdx)) |
-          argIdx = -1 and e.asExpr() = c.getQualifier()
-          or
-          e.asExpr() = c.getArgument(argIdx)
-        )
-      )
-    )
+    ApplicationCandidatesImpl::getCallable(e).fromSource()
+  }
+}
+
+/**
+ * A Characteristic that marks endpoints as uninteresting to model, according to the Java ModelExclusions module.
+ */
+private class ExcludedFromModeling extends CharacteristicsImpl::UninterestingToModelCharacteristic {
+  ExcludedFromModeling() { this = "excluded from modeling" }
+
+  override predicate appliesToEndpoint(Endpoint e) {
+    ModelExclusions::isUninterestingForModels(ApplicationCandidatesImpl::getCallable(e)) or
+    ModelExclusions::isUninterestingForModels(e.getEnclosingCallable())
   }
 }
 

--- a/java/ql/src/Telemetry/AutomodelApplicationModeCharacteristics.qll
+++ b/java/ql/src/Telemetry/AutomodelApplicationModeCharacteristics.qll
@@ -171,7 +171,7 @@ class ApplicationModeMetadataExtractor extends string {
   }
 
   predicate hasMetadata(
-    Endpoint e, string package, string type, boolean subtypes, string name, string signature,
+    Endpoint e, string package, string type, string subtypes, string name, string signature,
     string input
   ) {
     exists(Call call, Callable callable, int argIdx |
@@ -184,7 +184,7 @@ class ApplicationModeMetadataExtractor extends string {
       input = AutomodelSharedUtil::getArgumentForIndex(argIdx) and
       package = callable.getDeclaringType().getPackage().getName() and
       type = callable.getDeclaringType().getErasure().(RefType).nestedName() and
-      subtypes = this.considerSubtypes(callable) and
+      subtypes = this.considerSubtypes(callable).toString() and
       name = callable.getName() and
       signature = ExternalFlow::paramsString(callable)
     )

--- a/java/ql/src/Telemetry/AutomodelApplicationModeCharacteristics.qll
+++ b/java/ql/src/Telemetry/AutomodelApplicationModeCharacteristics.qll
@@ -95,7 +95,7 @@ module ApplicationCandidatesImpl implements SharedCharacteristics::CandidateSig 
    */
   RelatedLocation getRelatedLocation(Endpoint e, RelatedLocationType type) {
     type = CallContext() and
-    result = asLocation(e)
+    result = any(Call c | e.asExpr() = [c.getAnArgument(), c.getQualifier()])
   }
 
   /**

--- a/java/ql/src/Telemetry/AutomodelApplicationModeCharacteristics.qll
+++ b/java/ql/src/Telemetry/AutomodelApplicationModeCharacteristics.qll
@@ -27,7 +27,7 @@ abstract class MetadataExtractor extends string {
 
   abstract predicate hasMetadata(
     Endpoint e, string package, string type, boolean subtypes, string name, string signature,
-    int input
+    string input
   );
 }
 
@@ -182,14 +182,14 @@ class FrameworkModeMetadataExtractor extends MetadataExtractor {
 
   override predicate hasMetadata(
     Endpoint e, string package, string type, boolean subtypes, string name, string signature,
-    int input
+    string input
   ) {
-    exists(Call call, Callable callable |
+    exists(Call call, Callable callable, int argIdx |
       call.getCallee() = callable and
       (
-        e.asExpr() = call.getArgument(input)
+        e.asExpr() = call.getArgument(argIdx) and input = "Argument[" + argIdx + "]"
         or
-        e.asExpr() = call.getQualifier() and input = -1
+        e.asExpr() = call.getQualifier() and argIdx = -1 and input = "Argument[this]"
       ) and
       package = callable.getDeclaringType().getPackage().getName() and
       type = callable.getDeclaringType().getErasure().(RefType).nestedName() and

--- a/java/ql/src/Telemetry/AutomodelApplicationModeCharacteristics.qll
+++ b/java/ql/src/Telemetry/AutomodelApplicationModeCharacteristics.qll
@@ -103,7 +103,8 @@ module ApplicationCandidatesImpl implements SharedCharacteristics::CandidateSig 
   /**
    * Returns the related location for the given endpoint.
    *
-   * Related locations can be JavaDoc comments of the class or the method.
+   * The only related location we model is the the call expression surrounding to
+   * which the endpoint is either argument or qualifier (known as the call context).
    */
   RelatedLocation getRelatedLocation(Endpoint e, RelatedLocationType type) {
     type = CallContext() and

--- a/java/ql/src/Telemetry/AutomodelApplicationModeCharacteristics.qll
+++ b/java/ql/src/Telemetry/AutomodelApplicationModeCharacteristics.qll
@@ -15,6 +15,7 @@ private import semmle.code.java.security.QueryInjection
 private import semmle.code.java.security.RequestForgery
 private import semmle.code.java.dataflow.internal.ModelExclusions as ModelExclusions
 private import AutomodelSharedUtil as AutomodelSharedUtil
+private import semmle.code.java.security.PathSanitizer as PathSanitizer
 import AutomodelSharedCharacteristics as SharedCharacteristics
 import AutomodelEndpointTypes as AutomodelEndpointTypes
 
@@ -48,7 +49,19 @@ module ApplicationCandidatesImpl implements SharedCharacteristics::CandidateSig 
   class RelatedLocationType = JavaRelatedLocationType;
 
   // Sanitizers are currently not modeled in MaD. TODO: check if this has large negative impact.
-  predicate isSanitizer(Endpoint e, EndpointType t) { none() }
+  predicate isSanitizer(Endpoint e, EndpointType t) {
+    (
+      exists(t) and
+      e.getType() instanceof BoxedType
+      or
+      e.getType() instanceof PrimitiveType
+      or
+      e.getType() instanceof NumberType
+    )
+    or
+    t instanceof AutomodelEndpointTypes::TaintedPathSinkType and
+    e instanceof PathSanitizer::PathInjectionSanitizer
+  }
 
   RelatedLocation asLocation(Endpoint e) { result = e.asExpr() }
 

--- a/java/ql/src/Telemetry/AutomodelApplicationModeCharacteristics.qll
+++ b/java/ql/src/Telemetry/AutomodelApplicationModeCharacteristics.qll
@@ -32,9 +32,8 @@ private class ArgumentNode extends DataFlow::Node {
  * A candidates implementation.
  *
  * Some important notes:
- *  - This mode is using parameters as endpoints.
- *  - Sink- and neutral-information is being used from MaD models.
- *  - When available, we use method- and class-java-docs as related locations.
+ *  - This mode is using arguments as endpoints.
+ *  - We use the `CallContext` (the surrounding call expression) as related location.
  */
 module ApplicationCandidatesImpl implements SharedCharacteristics::CandidateSig {
   // for documentation of the implementations here, see the QLDoc in the CandidateSig signature module.
@@ -112,7 +111,7 @@ module ApplicationCandidatesImpl implements SharedCharacteristics::CandidateSig 
   }
 
   /**
-   * Returns the callable that contains the given endpoint.
+   * Returns the API callable being modelled.
    *
    * Each Java mode should implement this predicate.
    */
@@ -279,8 +278,10 @@ private class ClassQualifierCharacteristic extends CharacteristicsImpl::NotASink
 }
 
 /**
- * A characteristic that limits candidates to parameters of methods that are recognized as `ModelApi`, iow., APIs that
- * are considered worth modeling.
+ * A call to a method that's known locally will not be considered as a candidate to model.
+ *
+ * The reason is that we would expect data/taint flow into the method implementation to uncover
+ * any sinks that are present there.
  */
 private class ArgumentToLocalCall extends CharacteristicsImpl::UninterestingToModelCharacteristic {
   ArgumentToLocalCall() { this = "argument to local call" }

--- a/java/ql/src/Telemetry/AutomodelApplicationModeCharacteristics.qll
+++ b/java/ql/src/Telemetry/AutomodelApplicationModeCharacteristics.qll
@@ -294,8 +294,7 @@ private class ExcludedFromModeling extends CharacteristicsImpl::UninterestingToM
   ExcludedFromModeling() { this = "excluded from modeling" }
 
   override predicate appliesToEndpoint(Endpoint e) {
-    ModelExclusions::isUninterestingForModels(ApplicationModeGetCallable::getCallable(e)) or
-    ModelExclusions::isUninterestingForModels(e.getEnclosingCallable())
+    ModelExclusions::isUninterestingForModels(ApplicationModeGetCallable::getCallable(e))
   }
 }
 

--- a/java/ql/src/Telemetry/AutomodelApplicationModeCharacteristics.qll
+++ b/java/ql/src/Telemetry/AutomodelApplicationModeCharacteristics.qll
@@ -296,6 +296,9 @@ private class SkipFrameworkModeling extends CharacteristicsImpl::UninterestingTo
             "java.%", //
             "javax.%", //
             "org.apache%", //
+            "org.eclipse%", //
+            "org.gradle%", //
+            "org.slf4j%", //
           ])
   }
 }

--- a/java/ql/src/Telemetry/AutomodelApplicationModeExtractCandidates.ql
+++ b/java/ql/src/Telemetry/AutomodelApplicationModeExtractCandidates.ql
@@ -13,7 +13,7 @@
  */
 
 private import AutomodelApplicationModeCharacteristics
-private import AutomodelSharedUtil
+private import AutomodelJavaUtil
 
 from
   Endpoint endpoint, string message, ApplicationModeMetadataExtractor meta, DollarAtString package,

--- a/java/ql/src/Telemetry/AutomodelApplicationModeExtractCandidates.ql
+++ b/java/ql/src/Telemetry/AutomodelApplicationModeExtractCandidates.ql
@@ -17,7 +17,7 @@ private import AutomodelSharedUtil
 
 from
   Endpoint endpoint, string message, MetadataExtractor meta, string package, string type,
-  boolean subtypes, string name, string signature, int input
+  boolean subtypes, string name, string signature, string input
 where
   not exists(CharacteristicsImpl::UninterestingToModelCharacteristic u |
     u.appliesToEndpoint(endpoint)
@@ -45,4 +45,4 @@ select endpoint, message + "\nrelated locations: $@." + "\nmetadata: $@, $@, $@,
   subtypes.toString().(DollarAtString), "subtypes", //
   name.(DollarAtString), "name", // method name
   signature.(DollarAtString), "signature", //
-  input.toString().(DollarAtString), "input" //
+  input.(DollarAtString), "input" //

--- a/java/ql/src/Telemetry/AutomodelApplicationModeExtractCandidates.ql
+++ b/java/ql/src/Telemetry/AutomodelApplicationModeExtractCandidates.ql
@@ -8,16 +8,16 @@
  * @description A query to extract automodel candidates.
  * @kind problem
  * @severity info
- * @id java/ml/extract-automodel-framework-candidates
+ * @id java/ml/extract-automodel-application-candidates
  * @tags internal automodel extract candidates
  */
 
-private import AutomodelFrameworkModeCharacteristics
+private import AutomodelApplicationModeCharacteristics
 private import AutomodelSharedUtil
 
 from
   Endpoint endpoint, string message, MetadataExtractor meta, string package, string type,
-  boolean subtypes, string name, string signature, int input, string parameterName
+  boolean subtypes, string name, string signature, int input
 where
   not exists(CharacteristicsImpl::UninterestingToModelCharacteristic u |
     u.appliesToEndpoint(endpoint)
@@ -28,7 +28,7 @@ where
   // overlap between our detected sinks and the pre-existing modeling. We assume that, if a sink has already been
   // modeled in a MaD model, then it doesn't belong to any additional sink types, and we don't need to reexamine it.
   not CharacteristicsImpl::isSink(endpoint, _) and
-  meta.hasMetadata(endpoint, package, type, subtypes, name, signature, input, parameterName) and
+  meta.hasMetadata(endpoint, package, type, subtypes, name, signature, input) and
   // The message is the concatenation of all sink types for which this endpoint is known neither to be a sink nor to be
   // a non-sink, and we surface only endpoints that have at least one such sink type.
   message =
@@ -38,14 +38,11 @@ where
     |
       sinkType, ", "
     )
-select endpoint,
-  message + "\nrelated locations: $@, $@." + "\nmetadata: $@, $@, $@, $@, $@, $@, $@.", //
-  CharacteristicsImpl::getRelatedLocationOrCandidate(endpoint, MethodDoc()), "MethodDoc", //
-  CharacteristicsImpl::getRelatedLocationOrCandidate(endpoint, ClassDoc()), "ClassDoc", //
+select endpoint, message + "\nrelated locations: $@." + "\nmetadata: $@, $@, $@, $@, $@, $@.", //
+  CharacteristicsImpl::getRelatedLocationOrCandidate(endpoint, CallContext()), "CallContext", //
   package.(DollarAtString), "package", //
   type.(DollarAtString), "type", //
   subtypes.toString().(DollarAtString), "subtypes", //
-  name.(DollarAtString), "name", //
+  name.(DollarAtString), "name", // method name
   signature.(DollarAtString), "signature", //
-  input.toString().(DollarAtString), "input", //
-  parameterName.(DollarAtString), "parameterName" //
+  input.toString().(DollarAtString), "input" //

--- a/java/ql/src/Telemetry/AutomodelApplicationModeExtractCandidates.ql
+++ b/java/ql/src/Telemetry/AutomodelApplicationModeExtractCandidates.ql
@@ -16,8 +16,9 @@ private import AutomodelApplicationModeCharacteristics
 private import AutomodelSharedUtil
 
 from
-  Endpoint endpoint, string message, ApplicationModeMetadataExtractor meta, string package,
-  string type, boolean subtypes, string name, string signature, string input
+  Endpoint endpoint, string message, ApplicationModeMetadataExtractor meta, DollarAtString package,
+  DollarAtString type, DollarAtString subtypes, DollarAtString name, DollarAtString signature,
+  DollarAtString input
 where
   not exists(CharacteristicsImpl::UninterestingToModelCharacteristic u |
     u.appliesToEndpoint(endpoint)
@@ -40,9 +41,9 @@ where
     )
 select endpoint, message + "\nrelated locations: $@." + "\nmetadata: $@, $@, $@, $@, $@, $@.", //
   CharacteristicsImpl::getRelatedLocationOrCandidate(endpoint, CallContext()), "CallContext", //
-  package.(DollarAtString), "package", //
-  type.(DollarAtString), "type", //
-  subtypes.toString().(DollarAtString), "subtypes", //
-  name.(DollarAtString), "name", // method name
-  signature.(DollarAtString), "signature", //
-  input.(DollarAtString), "input" //
+  package, "package", //
+  type, "type", //
+  subtypes, "subtypes", //
+  name, "name", // method name
+  signature, "signature", //
+  input, "input" //

--- a/java/ql/src/Telemetry/AutomodelApplicationModeExtractCandidates.ql
+++ b/java/ql/src/Telemetry/AutomodelApplicationModeExtractCandidates.ql
@@ -16,8 +16,8 @@ private import AutomodelApplicationModeCharacteristics
 private import AutomodelSharedUtil
 
 from
-  Endpoint endpoint, string message, MetadataExtractor meta, string package, string type,
-  boolean subtypes, string name, string signature, string input
+  Endpoint endpoint, string message, ApplicationModeMetadataExtractor meta, string package,
+  string type, boolean subtypes, string name, string signature, string input
 where
   not exists(CharacteristicsImpl::UninterestingToModelCharacteristic u |
     u.appliesToEndpoint(endpoint)

--- a/java/ql/src/Telemetry/AutomodelApplicationModeExtractCandidates.ql
+++ b/java/ql/src/Telemetry/AutomodelApplicationModeExtractCandidates.ql
@@ -4,12 +4,12 @@
  *
  * Note: This query does not actually classify the endpoints using the model.
  *
- * @name Automodel candidates
- * @description A query to extract automodel candidates.
+ * @name Automodel candidates (application mode)
+ * @description A query to extract automodel candidates in application mode.
  * @kind problem
  * @severity info
  * @id java/ml/extract-automodel-application-candidates
- * @tags internal automodel extract candidates application-mode
+ * @tags internal extract automodel application-mode candidates
  */
 
 private import AutomodelApplicationModeCharacteristics

--- a/java/ql/src/Telemetry/AutomodelApplicationModeExtractCandidates.ql
+++ b/java/ql/src/Telemetry/AutomodelApplicationModeExtractCandidates.ql
@@ -7,7 +7,7 @@
  * @name Automodel candidates (application mode)
  * @description A query to extract automodel candidates in application mode.
  * @kind problem
- * @severity info
+ * @problem.severity recommendation
  * @id java/ml/extract-automodel-application-candidates
  * @tags internal extract automodel application-mode candidates
  */

--- a/java/ql/src/Telemetry/AutomodelApplicationModeExtractCandidates.ql
+++ b/java/ql/src/Telemetry/AutomodelApplicationModeExtractCandidates.ql
@@ -9,7 +9,7 @@
  * @kind problem
  * @severity info
  * @id java/ml/extract-automodel-application-candidates
- * @tags internal automodel extract candidates
+ * @tags internal automodel extract candidates application-mode
  */
 
 private import AutomodelApplicationModeCharacteristics

--- a/java/ql/src/Telemetry/AutomodelApplicationModeExtractNegativeExamples.ql
+++ b/java/ql/src/Telemetry/AutomodelApplicationModeExtractNegativeExamples.ql
@@ -1,21 +1,21 @@
 /**
  * Surfaces endpoints that are non-sinks with high confidence, for use as negative examples in the prompt.
  *
- * @name Negative examples (framework mode)
+ * @name Negative examples (application mode)
  * @kind problem
  * @severity info
- * @id java/ml/extract-automodel-framework-negative-examples
- * @tags internal extract automodel framework-mode negative examples
+ * @id java/ml/extract-automodel-application-negative-examples
+ * @tags internal extract automodel application-mode negative examples
  */
 
-private import AutomodelFrameworkModeCharacteristics
+private import AutomodelApplicationModeCharacteristics
 private import AutomodelEndpointTypes
 private import AutomodelSharedUtil
 
 from
   Endpoint endpoint, EndpointCharacteristic characteristic, float confidence, string message,
   MetadataExtractor meta, string package, string type, boolean subtypes, string name,
-  string signature, string input, string parameterName
+  string signature, string input
 where
   characteristic.appliesToEndpoint(endpoint) and
   confidence >= SharedCharacteristics::highConfidence() and
@@ -23,7 +23,7 @@ where
   // Exclude endpoints that have contradictory endpoint characteristics, because we only want examples we're highly
   // certain about in the prompt.
   not erroneousEndpoints(endpoint, _, _, _, _, false) and
-  meta.hasMetadata(endpoint, package, type, subtypes, name, signature, input, parameterName) and
+  meta.hasMetadata(endpoint, package, type, subtypes, name, signature, input) and
   // It's valid for a node to satisfy the logic for both `isSink` and `isSanitizer`, but in that case it will be
   // treated by the actual query as a sanitizer, since the final logic is something like
   // `isSink(n) and not isSanitizer(n)`. We don't want to include such nodes as negative examples in the prompt, because
@@ -35,14 +35,11 @@ where
     characteristic2.hasImplications(positiveType, true, confidence2)
   ) and
   message = characteristic
-select endpoint,
-  message + "\nrelated locations: $@, $@." + "\nmetadata: $@, $@, $@, $@, $@, $@, $@.", //
-  CharacteristicsImpl::getRelatedLocationOrCandidate(endpoint, MethodDoc()), "MethodDoc", //
-  CharacteristicsImpl::getRelatedLocationOrCandidate(endpoint, ClassDoc()), "ClassDoc", //
+select endpoint, message + "\nrelated locations: $@." + "\nmetadata: $@, $@, $@, $@, $@, $@.", //
+  CharacteristicsImpl::getRelatedLocationOrCandidate(endpoint, CallContext()), "CallContext", //
   package.(DollarAtString), "package", //
   type.(DollarAtString), "type", //
   subtypes.toString().(DollarAtString), "subtypes", //
   name.(DollarAtString), "name", //
   signature.(DollarAtString), "signature", //
-  input.(DollarAtString), "input", //
-  parameterName.(DollarAtString), "parameterName" //
+  input.(DollarAtString), "input" //

--- a/java/ql/src/Telemetry/AutomodelApplicationModeExtractNegativeExamples.ql
+++ b/java/ql/src/Telemetry/AutomodelApplicationModeExtractNegativeExamples.ql
@@ -11,7 +11,7 @@
 private import java
 private import AutomodelApplicationModeCharacteristics
 private import AutomodelEndpointTypes
-private import AutomodelSharedUtil
+private import AutomodelJavaUtil
 
 /**
  * Gets a sample of endpoints (of at most `limit` samples) for which the given characteristic applies.

--- a/java/ql/src/Telemetry/AutomodelApplicationModeExtractNegativeExamples.ql
+++ b/java/ql/src/Telemetry/AutomodelApplicationModeExtractNegativeExamples.ql
@@ -35,8 +35,8 @@ Endpoint getSampleForCharacteristic(EndpointCharacteristic c, int limit) {
 
 from
   Endpoint endpoint, EndpointCharacteristic characteristic, float confidence, string message,
-  ApplicationModeMetadataExtractor meta, string package, string type, boolean subtypes, string name,
-  string signature, string input
+  ApplicationModeMetadataExtractor meta, DollarAtString package, DollarAtString type,
+  DollarAtString subtypes, DollarAtString name, DollarAtString signature, DollarAtString input
 where
   endpoint = getSampleForCharacteristic(characteristic, 100) and
   confidence >= SharedCharacteristics::highConfidence() and
@@ -58,9 +58,9 @@ where
   message = characteristic
 select endpoint, message + "\nrelated locations: $@." + "\nmetadata: $@, $@, $@, $@, $@, $@.", //
   CharacteristicsImpl::getRelatedLocationOrCandidate(endpoint, CallContext()), "CallContext", //
-  package.(DollarAtString), "package", //
-  type.(DollarAtString), "type", //
-  subtypes.toString().(DollarAtString), "subtypes", //
-  name.(DollarAtString), "name", //
-  signature.(DollarAtString), "signature", //
-  input.(DollarAtString), "input" //
+  package, "package", //
+  type, "type", //
+  subtypes, "subtypes", //
+  name, "name", //
+  signature, "signature", //
+  input, "input" //

--- a/java/ql/src/Telemetry/AutomodelApplicationModeExtractNegativeExamples.ql
+++ b/java/ql/src/Telemetry/AutomodelApplicationModeExtractNegativeExamples.ql
@@ -14,7 +14,10 @@ private import AutomodelEndpointTypes
 private import AutomodelSharedUtil
 
 /**
- * Gets a sample of endpoints for which the given characteristic applies.
+ * Gets a sample of endpoints (of at most `limit` samples) for which the given characteristic applies.
+ *
+ * The main purpose of this helper predicate is to avoid selecting too many samples, as this may
+ * cause the SARIF file to exceed the maximum size limit.
  */
 bindingset[limit]
 Endpoint getSampleForCharacteristic(EndpointCharacteristic c, int limit) {
@@ -28,7 +31,11 @@ Endpoint getSampleForCharacteristic(EndpointCharacteristic c, int limit) {
           loc.getFile().getAbsolutePath(), loc.getStartLine(), loc.getStartColumn(),
           loc.getEndLine(), loc.getEndColumn()
       ) and
-    // we order the endpoints by location, but (to avoid bias) we select the indices semi-randomly
+    // To avoid selecting samples that are too close together (as the ranking above goes by file
+    // path first), we select `limit` evenly spaced samples from the ranked list of endpoints. By
+    // default this would always include the first sample, so we add a random-chosen prime offset
+    // to the first sample index, and reduce modulo the number of endpoints.
+    // Finally, we add 1 to the result, as ranking results in a 1-indexed relation.
     n = 1 + (([0 .. limit - 1] * (num_endpoints / limit).floor() + 46337) % num_endpoints)
   )
 }

--- a/java/ql/src/Telemetry/AutomodelApplicationModeExtractNegativeExamples.ql
+++ b/java/ql/src/Telemetry/AutomodelApplicationModeExtractNegativeExamples.ql
@@ -18,7 +18,7 @@ private import AutomodelSharedUtil
  */
 bindingset[limit]
 Endpoint getSampleForCharacteristic(EndpointCharacteristic c, int limit) {
-  exists(int n |
+  exists(int n, int num_endpoints | num_endpoints = count(Endpoint e | c.appliesToEndpoint(e)) |
     result =
       rank[n](Endpoint e, Location loc |
         loc = e.getLocation() and c.appliesToEndpoint(e)
@@ -29,7 +29,7 @@ Endpoint getSampleForCharacteristic(EndpointCharacteristic c, int limit) {
           loc.getEndLine(), loc.getEndColumn()
       ) and
     // we order the endpoints by location, but (to avoid bias) we select the indices semi-randomly
-    n = 1 + (([1 .. limit] * 271) % count(Endpoint e | c.appliesToEndpoint(e)))
+    n = 1 + (([0 .. limit - 1] * (num_endpoints / limit).floor() + 46337) % num_endpoints)
   )
 }
 

--- a/java/ql/src/Telemetry/AutomodelApplicationModeExtractNegativeExamples.ql
+++ b/java/ql/src/Telemetry/AutomodelApplicationModeExtractNegativeExamples.ql
@@ -8,6 +8,7 @@
  * @tags internal extract automodel application-mode negative examples
  */
 
+private import java
 private import AutomodelApplicationModeCharacteristics
 private import AutomodelEndpointTypes
 private import AutomodelSharedUtil
@@ -19,7 +20,14 @@ bindingset[limit]
 Endpoint getSampleForCharacteristic(EndpointCharacteristic c, int limit) {
   exists(int n |
     result =
-      rank[n](Endpoint e2 | c.appliesToEndpoint(e2) | e2 order by e2.getLocation().toString()) and
+      rank[n](Endpoint e, Location loc |
+        loc = e.getLocation() and c.appliesToEndpoint(e)
+      |
+        e
+        order by
+          loc.getFile().getAbsolutePath(), loc.getStartLine(), loc.getStartColumn(),
+          loc.getEndLine(), loc.getEndColumn()
+      ) and
     // we order the endpoints by location, but (to avoid bias) we select the indices semi-randomly
     n = 1 + (([1 .. limit] * 271) % count(Endpoint e | c.appliesToEndpoint(e)))
   )

--- a/java/ql/src/Telemetry/AutomodelApplicationModeExtractNegativeExamples.ql
+++ b/java/ql/src/Telemetry/AutomodelApplicationModeExtractNegativeExamples.ql
@@ -3,7 +3,7 @@
  *
  * @name Negative examples (application mode)
  * @kind problem
- * @severity info
+ * @problem.severity recommendation
  * @id java/ml/extract-automodel-application-negative-examples
  * @tags internal extract automodel application-mode negative examples
  */

--- a/java/ql/src/Telemetry/AutomodelApplicationModeExtractNegativeExamples.ql
+++ b/java/ql/src/Telemetry/AutomodelApplicationModeExtractNegativeExamples.ql
@@ -17,6 +17,7 @@ from
   ApplicationModeMetadataExtractor meta, string package, string type, boolean subtypes, string name,
   string signature, string input
 where
+  endpoint.getLocation().getStartLine() % 100 = 0 and
   characteristic.appliesToEndpoint(endpoint) and
   confidence >= SharedCharacteristics::highConfidence() and
   characteristic.hasImplications(any(NegativeSinkType negative), true, confidence) and

--- a/java/ql/src/Telemetry/AutomodelApplicationModeExtractNegativeExamples.ql
+++ b/java/ql/src/Telemetry/AutomodelApplicationModeExtractNegativeExamples.ql
@@ -14,7 +14,7 @@ private import AutomodelSharedUtil
 
 from
   Endpoint endpoint, EndpointCharacteristic characteristic, float confidence, string message,
-  MetadataExtractor meta, string package, string type, boolean subtypes, string name,
+  ApplicationModeMetadataExtractor meta, string package, string type, boolean subtypes, string name,
   string signature, string input
 where
   characteristic.appliesToEndpoint(endpoint) and

--- a/java/ql/src/Telemetry/AutomodelApplicationModeExtractPositiveExamples.ql
+++ b/java/ql/src/Telemetry/AutomodelApplicationModeExtractPositiveExamples.ql
@@ -13,8 +13,8 @@ private import AutomodelEndpointTypes
 private import AutomodelSharedUtil
 
 from
-  Endpoint endpoint, SinkType sinkType, MetadataExtractor meta, string package, string type,
-  boolean subtypes, string name, string signature, string input
+  Endpoint endpoint, SinkType sinkType, ApplicationModeMetadataExtractor meta, string package,
+  string type, boolean subtypes, string name, string signature, string input
 where
   // Exclude endpoints that have contradictory endpoint characteristics, because we only want examples we're highly
   // certain about in the prompt.

--- a/java/ql/src/Telemetry/AutomodelApplicationModeExtractPositiveExamples.ql
+++ b/java/ql/src/Telemetry/AutomodelApplicationModeExtractPositiveExamples.ql
@@ -1,35 +1,32 @@
 /**
  * Surfaces endpoints that are sinks with high confidence, for use as positive examples in the prompt.
  *
- * @name Positive examples (framework mode)
+ * @name Positive examples (application mode)
  * @kind problem
  * @severity info
- * @id java/ml/extract-automodel-framework-positive-examples
- * @tags internal extract automodel framework-mode positive examples
+ * @id java/ml/extract-automodel-application-positive-examples
+ * @tags internal extract automodel application-mode positive examples
  */
 
-private import AutomodelFrameworkModeCharacteristics
+private import AutomodelApplicationModeCharacteristics
 private import AutomodelEndpointTypes
 private import AutomodelSharedUtil
 
 from
   Endpoint endpoint, SinkType sinkType, MetadataExtractor meta, string package, string type,
-  boolean subtypes, string name, string signature, string input, string parameterName
+  boolean subtypes, string name, string signature, string input
 where
   // Exclude endpoints that have contradictory endpoint characteristics, because we only want examples we're highly
   // certain about in the prompt.
   not erroneousEndpoints(endpoint, _, _, _, _, false) and
-  meta.hasMetadata(endpoint, package, type, subtypes, name, signature, input, parameterName) and
+  meta.hasMetadata(endpoint, package, type, subtypes, name, signature, input) and
   // Extract positive examples of sinks belonging to the existing ATM query configurations.
   CharacteristicsImpl::isKnownSink(endpoint, sinkType)
-select endpoint,
-  sinkType + "\nrelated locations: $@, $@." + "\nmetadata: $@, $@, $@, $@, $@, $@, $@.", //
-  CharacteristicsImpl::getRelatedLocationOrCandidate(endpoint, MethodDoc()), "MethodDoc", //
-  CharacteristicsImpl::getRelatedLocationOrCandidate(endpoint, ClassDoc()), "ClassDoc", //
+select endpoint, sinkType + "\nrelated locations: $@." + "\nmetadata: $@, $@, $@, $@, $@, $@.", //
+  CharacteristicsImpl::getRelatedLocationOrCandidate(endpoint, CallContext()), "CallContext", //
   package.(DollarAtString), "package", //
   type.(DollarAtString), "type", //
   subtypes.toString().(DollarAtString), "subtypes", //
   name.(DollarAtString), "name", //
   signature.(DollarAtString), "signature", //
-  input.(DollarAtString), "input", //
-  parameterName.(DollarAtString), "parameterName" //
+  input.(DollarAtString), "input" //

--- a/java/ql/src/Telemetry/AutomodelApplicationModeExtractPositiveExamples.ql
+++ b/java/ql/src/Telemetry/AutomodelApplicationModeExtractPositiveExamples.ql
@@ -10,7 +10,7 @@
 
 private import AutomodelApplicationModeCharacteristics
 private import AutomodelEndpointTypes
-private import AutomodelSharedUtil
+private import AutomodelJavaUtil
 
 from
   Endpoint endpoint, SinkType sinkType, ApplicationModeMetadataExtractor meta,

--- a/java/ql/src/Telemetry/AutomodelApplicationModeExtractPositiveExamples.ql
+++ b/java/ql/src/Telemetry/AutomodelApplicationModeExtractPositiveExamples.ql
@@ -3,7 +3,7 @@
  *
  * @name Positive examples (application mode)
  * @kind problem
- * @severity info
+ * @problem.severity recommendation
  * @id java/ml/extract-automodel-application-positive-examples
  * @tags internal extract automodel application-mode positive examples
  */

--- a/java/ql/src/Telemetry/AutomodelApplicationModeExtractPositiveExamples.ql
+++ b/java/ql/src/Telemetry/AutomodelApplicationModeExtractPositiveExamples.ql
@@ -13,8 +13,9 @@ private import AutomodelEndpointTypes
 private import AutomodelSharedUtil
 
 from
-  Endpoint endpoint, SinkType sinkType, ApplicationModeMetadataExtractor meta, string package,
-  string type, boolean subtypes, string name, string signature, string input
+  Endpoint endpoint, SinkType sinkType, ApplicationModeMetadataExtractor meta,
+  DollarAtString package, DollarAtString type, DollarAtString subtypes, DollarAtString name,
+  DollarAtString signature, DollarAtString input
 where
   // Exclude endpoints that have contradictory endpoint characteristics, because we only want examples we're highly
   // certain about in the prompt.
@@ -24,9 +25,9 @@ where
   CharacteristicsImpl::isKnownSink(endpoint, sinkType)
 select endpoint, sinkType + "\nrelated locations: $@." + "\nmetadata: $@, $@, $@, $@, $@, $@.", //
   CharacteristicsImpl::getRelatedLocationOrCandidate(endpoint, CallContext()), "CallContext", //
-  package.(DollarAtString), "package", //
-  type.(DollarAtString), "type", //
-  subtypes.toString().(DollarAtString), "subtypes", //
-  name.(DollarAtString), "name", //
-  signature.(DollarAtString), "signature", //
-  input.(DollarAtString), "input" //
+  package, "package", //
+  type, "type", //
+  subtypes, "subtypes", //
+  name, "name", //
+  signature, "signature", //
+  input, "input" //

--- a/java/ql/src/Telemetry/AutomodelFrameworkModeCharacteristics.qll
+++ b/java/ql/src/Telemetry/AutomodelFrameworkModeCharacteristics.qll
@@ -27,7 +27,7 @@ abstract class MetadataExtractor extends string {
 
   abstract predicate hasMetadata(
     DataFlow::ParameterNode e, string package, string type, boolean subtypes, string name,
-    string signature, int input, string parameterName
+    string signature, string input, string parameterName
   );
 }
 
@@ -167,10 +167,11 @@ class FrameworkModeMetadataExtractor extends MetadataExtractor {
 
   override predicate hasMetadata(
     Endpoint e, string package, string type, boolean subtypes, string name, string signature,
-    int input, string parameterName
+    string input, string parameterName
   ) {
-    exists(Callable callable |
-      e.asParameter() = callable.getParameter(input) and
+    exists(Callable callable, int paramIdx |
+      e.asParameter() = callable.getParameter(paramIdx) and
+      (if paramIdx = -1 then input = "Argument[this]" else input = "Argument[" + paramIdx + "]") and
       package = callable.getDeclaringType().getPackage().getName() and
       type = callable.getDeclaringType().getErasure().(RefType).nestedName() and
       subtypes = this.considerSubtypes(callable) and

--- a/java/ql/src/Telemetry/AutomodelFrameworkModeCharacteristics.qll
+++ b/java/ql/src/Telemetry/AutomodelFrameworkModeCharacteristics.qll
@@ -70,7 +70,7 @@ module FrameworkCandidatesImpl implements SharedCharacteristics::CandidateSig {
     signature = ExternalFlow::paramsString(getCallable(e)) and
     ext = "" and
     exists(int paramIdx | e.isParameterOf(_, paramIdx) |
-      if paramIdx = -1 then input = "Argument[this]" else input = "Argument[" + paramIdx + "]"
+      input = AutomodelSharedUtil::getArgumentForIndex(paramIdx)
     )
   }
 
@@ -134,7 +134,7 @@ class FrameworkModeMetadataExtractor extends string {
   ) {
     exists(Callable callable, int paramIdx |
       e.asParameter() = callable.getParameter(paramIdx) and
-      (if paramIdx = -1 then input = "Argument[this]" else input = "Argument[" + paramIdx + "]") and
+      input = AutomodelSharedUtil::getArgumentForIndex(paramIdx) and
       package = callable.getDeclaringType().getPackage().getName() and
       type = callable.getDeclaringType().getErasure().(RefType).nestedName() and
       subtypes = this.considerSubtypes(callable) and

--- a/java/ql/src/Telemetry/AutomodelFrameworkModeCharacteristics.qll
+++ b/java/ql/src/Telemetry/AutomodelFrameworkModeCharacteristics.qll
@@ -76,7 +76,7 @@ module FrameworkCandidatesImpl implements SharedCharacteristics::CandidateSig {
   }
 
   /**
-   * Returns the related location for the given endpoint.
+   * Gets the related location for the given endpoint.
    *
    * Related locations can be JavaDoc comments of the class or the method.
    */

--- a/java/ql/src/Telemetry/AutomodelFrameworkModeCharacteristics.qll
+++ b/java/ql/src/Telemetry/AutomodelFrameworkModeCharacteristics.qll
@@ -14,6 +14,7 @@ private import semmle.code.java.Expr as Expr
 private import semmle.code.java.security.QueryInjection
 private import semmle.code.java.security.RequestForgery
 private import semmle.code.java.dataflow.internal.ModelExclusions as ModelExclusions
+private import AutomodelSharedUtil as AutomodelSharedUtil
 import AutomodelSharedCharacteristics as SharedCharacteristics
 import AutomodelEndpointTypes as AutomodelEndpointTypes
 
@@ -46,31 +47,7 @@ module FrameworkCandidatesImpl implements SharedCharacteristics::CandidateSig {
 
   RelatedLocation asLocation(Endpoint e) { result = e.asParameter() }
 
-  predicate isKnownKind(string kind, string humanReadableKind, EndpointType type) {
-    kind = "read-file" and
-    humanReadableKind = "read file" and
-    type instanceof AutomodelEndpointTypes::TaintedPathSinkType
-    or
-    kind = "create-file" and
-    humanReadableKind = "create file" and
-    type instanceof AutomodelEndpointTypes::TaintedPathSinkType
-    or
-    kind = "sql" and
-    humanReadableKind = "mad modeled sql" and
-    type instanceof AutomodelEndpointTypes::SqlSinkType
-    or
-    kind = "open-url" and
-    humanReadableKind = "open url" and
-    type instanceof AutomodelEndpointTypes::RequestForgerySinkType
-    or
-    kind = "jdbc-url" and
-    humanReadableKind = "jdbc url" and
-    type instanceof AutomodelEndpointTypes::RequestForgerySinkType
-    or
-    kind = "command-injection" and
-    humanReadableKind = "command injection" and
-    type instanceof AutomodelEndpointTypes::CommandInjectionSinkType
-  }
+  predicate isKnownKind = AutomodelSharedUtil::isKnownKind/3;
 
   predicate isSink(Endpoint e, string kind) {
     exists(string package, string type, string name, string signature, string ext, string input |

--- a/java/ql/src/Telemetry/AutomodelFrameworkModeCharacteristics.qll
+++ b/java/ql/src/Telemetry/AutomodelFrameworkModeCharacteristics.qll
@@ -17,20 +17,6 @@ private import semmle.code.java.dataflow.internal.ModelExclusions as ModelExclus
 import AutomodelSharedCharacteristics as SharedCharacteristics
 import AutomodelEndpointTypes as AutomodelEndpointTypes
 
-/**
- * A meta data extractor. Any Java extraction mode needs to implement exactly
- * one instance of this class.
- */
-abstract class MetadataExtractor extends string {
-  bindingset[this]
-  MetadataExtractor() { any() }
-
-  abstract predicate hasMetadata(
-    DataFlow::ParameterNode e, string package, string type, boolean subtypes, string name,
-    string signature, string input, string parameterName
-  );
-}
-
 newtype JavaRelatedLocationType =
   MethodDoc() or
   ClassDoc()
@@ -145,7 +131,7 @@ class Endpoint = FrameworkCandidatesImpl::Endpoint;
 /**
  * A MetadataExtractor that extracts metadata for framework mode.
  */
-class FrameworkModeMetadataExtractor extends MetadataExtractor {
+class FrameworkModeMetadataExtractor extends string {
   FrameworkModeMetadataExtractor() { this = "FrameworkModeMetadataExtractor" }
 
   /**
@@ -165,7 +151,7 @@ class FrameworkModeMetadataExtractor extends MetadataExtractor {
     else result = true
   }
 
-  override predicate hasMetadata(
+  predicate hasMetadata(
     Endpoint e, string package, string type, boolean subtypes, string name, string signature,
     string input, string parameterName
   ) {

--- a/java/ql/src/Telemetry/AutomodelFrameworkModeCharacteristics.qll
+++ b/java/ql/src/Telemetry/AutomodelFrameworkModeCharacteristics.qll
@@ -129,7 +129,7 @@ class FrameworkModeMetadataExtractor extends string {
   }
 
   predicate hasMetadata(
-    Endpoint e, string package, string type, boolean subtypes, string name, string signature,
+    Endpoint e, string package, string type, string subtypes, string name, string signature,
     string input, string parameterName
   ) {
     exists(Callable callable, int paramIdx |
@@ -137,7 +137,7 @@ class FrameworkModeMetadataExtractor extends string {
       input = AutomodelSharedUtil::getArgumentForIndex(paramIdx) and
       package = callable.getDeclaringType().getPackage().getName() and
       type = callable.getDeclaringType().getErasure().(RefType).nestedName() and
-      subtypes = this.considerSubtypes(callable) and
+      subtypes = this.considerSubtypes(callable).toString() and
       name = callable.getName() and
       parameterName = e.asParameter().getName() and
       signature = ExternalFlow::paramsString(callable)

--- a/java/ql/src/Telemetry/AutomodelFrameworkModeExtractCandidates.ql
+++ b/java/ql/src/Telemetry/AutomodelFrameworkModeExtractCandidates.ql
@@ -13,7 +13,7 @@
  */
 
 private import AutomodelFrameworkModeCharacteristics
-private import AutomodelSharedUtil
+private import AutomodelJavaUtil
 
 from
   Endpoint endpoint, string message, FrameworkModeMetadataExtractor meta, DollarAtString package,

--- a/java/ql/src/Telemetry/AutomodelFrameworkModeExtractCandidates.ql
+++ b/java/ql/src/Telemetry/AutomodelFrameworkModeExtractCandidates.ql
@@ -16,8 +16,8 @@ private import AutomodelFrameworkModeCharacteristics
 private import AutomodelSharedUtil
 
 from
-  Endpoint endpoint, string message, MetadataExtractor meta, string package, string type,
-  boolean subtypes, string name, string signature, string input, string parameterName
+  Endpoint endpoint, string message, FrameworkModeMetadataExtractor meta, string package,
+  string type, boolean subtypes, string name, string signature, string input, string parameterName
 where
   not exists(CharacteristicsImpl::UninterestingToModelCharacteristic u |
     u.appliesToEndpoint(endpoint)

--- a/java/ql/src/Telemetry/AutomodelFrameworkModeExtractCandidates.ql
+++ b/java/ql/src/Telemetry/AutomodelFrameworkModeExtractCandidates.ql
@@ -7,7 +7,7 @@
  * @name Automodel candidates (framework mode)
  * @description A query to extract automodel candidates in framework mode.
  * @kind problem
- * @severity info
+ * @problem.severity recommendation
  * @id java/ml/extract-automodel-framework-candidates
  * @tags internal extract automodel framework-mode candidates
  */

--- a/java/ql/src/Telemetry/AutomodelFrameworkModeExtractCandidates.ql
+++ b/java/ql/src/Telemetry/AutomodelFrameworkModeExtractCandidates.ql
@@ -16,8 +16,9 @@ private import AutomodelFrameworkModeCharacteristics
 private import AutomodelSharedUtil
 
 from
-  Endpoint endpoint, string message, FrameworkModeMetadataExtractor meta, string package,
-  string type, boolean subtypes, string name, string signature, string input, string parameterName
+  Endpoint endpoint, string message, FrameworkModeMetadataExtractor meta, DollarAtString package,
+  DollarAtString type, DollarAtString subtypes, DollarAtString name, DollarAtString signature,
+  DollarAtString input, DollarAtString parameterName
 where
   not exists(CharacteristicsImpl::UninterestingToModelCharacteristic u |
     u.appliesToEndpoint(endpoint)
@@ -42,10 +43,10 @@ select endpoint,
   message + "\nrelated locations: $@, $@." + "\nmetadata: $@, $@, $@, $@, $@, $@, $@.", //
   CharacteristicsImpl::getRelatedLocationOrCandidate(endpoint, MethodDoc()), "MethodDoc", //
   CharacteristicsImpl::getRelatedLocationOrCandidate(endpoint, ClassDoc()), "ClassDoc", //
-  package.(DollarAtString), "package", //
-  type.(DollarAtString), "type", //
-  subtypes.toString().(DollarAtString), "subtypes", //
-  name.(DollarAtString), "name", //
-  signature.(DollarAtString), "signature", //
-  input.(DollarAtString), "input", //
-  parameterName.(DollarAtString), "parameterName" //
+  package, "package", //
+  type, "type", //
+  subtypes, "subtypes", //
+  name, "name", //
+  signature, "signature", //
+  input, "input", //
+  parameterName, "parameterName" //

--- a/java/ql/src/Telemetry/AutomodelFrameworkModeExtractCandidates.ql
+++ b/java/ql/src/Telemetry/AutomodelFrameworkModeExtractCandidates.ql
@@ -4,12 +4,12 @@
  *
  * Note: This query does not actually classify the endpoints using the model.
  *
- * @name Automodel candidates
- * @description A query to extract automodel candidates.
+ * @name Automodel candidates (framework mode)
+ * @description A query to extract automodel candidates in framework mode.
  * @kind problem
  * @severity info
  * @id java/ml/extract-automodel-framework-candidates
- * @tags internal automodel extract candidates framework-mode
+ * @tags internal extract automodel framework-mode candidates
  */
 
 private import AutomodelFrameworkModeCharacteristics

--- a/java/ql/src/Telemetry/AutomodelFrameworkModeExtractCandidates.ql
+++ b/java/ql/src/Telemetry/AutomodelFrameworkModeExtractCandidates.ql
@@ -17,7 +17,7 @@ private import AutomodelSharedUtil
 
 from
   Endpoint endpoint, string message, MetadataExtractor meta, string package, string type,
-  boolean subtypes, string name, string signature, int input, string parameterName
+  boolean subtypes, string name, string signature, string input, string parameterName
 where
   not exists(CharacteristicsImpl::UninterestingToModelCharacteristic u |
     u.appliesToEndpoint(endpoint)
@@ -47,5 +47,5 @@ select endpoint,
   subtypes.toString().(DollarAtString), "subtypes", //
   name.(DollarAtString), "name", //
   signature.(DollarAtString), "signature", //
-  input.toString().(DollarAtString), "input", //
+  input.(DollarAtString), "input", //
   parameterName.(DollarAtString), "parameterName" //

--- a/java/ql/src/Telemetry/AutomodelFrameworkModeExtractCandidates.ql
+++ b/java/ql/src/Telemetry/AutomodelFrameworkModeExtractCandidates.ql
@@ -9,7 +9,7 @@
  * @kind problem
  * @severity info
  * @id java/ml/extract-automodel-framework-candidates
- * @tags internal automodel extract candidates
+ * @tags internal automodel extract candidates framework-mode
  */
 
 private import AutomodelFrameworkModeCharacteristics

--- a/java/ql/src/Telemetry/AutomodelFrameworkModeExtractNegativeExamples.ql
+++ b/java/ql/src/Telemetry/AutomodelFrameworkModeExtractNegativeExamples.ql
@@ -10,7 +10,7 @@
 
 private import AutomodelFrameworkModeCharacteristics
 private import AutomodelEndpointTypes
-private import AutomodelSharedUtil
+private import AutomodelJavaUtil
 
 from
   Endpoint endpoint, EndpointCharacteristic characteristic, float confidence,

--- a/java/ql/src/Telemetry/AutomodelFrameworkModeExtractNegativeExamples.ql
+++ b/java/ql/src/Telemetry/AutomodelFrameworkModeExtractNegativeExamples.ql
@@ -15,7 +15,7 @@ private import AutomodelSharedUtil
 from
   Endpoint endpoint, EndpointCharacteristic characteristic, float confidence, string message,
   MetadataExtractor meta, string package, string type, boolean subtypes, string name,
-  string signature, int input, string parameterName
+  string signature, string input, string parameterName
 where
   characteristic.appliesToEndpoint(endpoint) and
   confidence >= SharedCharacteristics::highConfidence() and
@@ -44,5 +44,5 @@ select endpoint,
   subtypes.toString().(DollarAtString), "subtypes", //
   name.(DollarAtString), "name", //
   signature.(DollarAtString), "signature", //
-  input.toString().(DollarAtString), "input", //
+  input.(DollarAtString), "input", //
   parameterName.(DollarAtString), "parameterName" //

--- a/java/ql/src/Telemetry/AutomodelFrameworkModeExtractNegativeExamples.ql
+++ b/java/ql/src/Telemetry/AutomodelFrameworkModeExtractNegativeExamples.ql
@@ -5,7 +5,7 @@
  * @kind problem
  * @severity info
  * @id java/ml/non-sink
- * @tags internal automodel extract examples negative
+ * @tags internal automodel extract examples negative framework-mode
  */
 
 private import AutomodelFrameworkModeCharacteristics

--- a/java/ql/src/Telemetry/AutomodelFrameworkModeExtractNegativeExamples.ql
+++ b/java/ql/src/Telemetry/AutomodelFrameworkModeExtractNegativeExamples.ql
@@ -13,9 +13,10 @@ private import AutomodelEndpointTypes
 private import AutomodelSharedUtil
 
 from
-  Endpoint endpoint, EndpointCharacteristic characteristic, float confidence, string message,
-  FrameworkModeMetadataExtractor meta, string package, string type, boolean subtypes, string name,
-  string signature, string input, string parameterName
+  Endpoint endpoint, EndpointCharacteristic characteristic, float confidence,
+  DollarAtString message, FrameworkModeMetadataExtractor meta, DollarAtString package,
+  DollarAtString type, DollarAtString subtypes, DollarAtString name, DollarAtString signature,
+  DollarAtString input, DollarAtString parameterName
 where
   characteristic.appliesToEndpoint(endpoint) and
   confidence >= SharedCharacteristics::highConfidence() and
@@ -39,10 +40,10 @@ select endpoint,
   message + "\nrelated locations: $@, $@." + "\nmetadata: $@, $@, $@, $@, $@, $@, $@.", //
   CharacteristicsImpl::getRelatedLocationOrCandidate(endpoint, MethodDoc()), "MethodDoc", //
   CharacteristicsImpl::getRelatedLocationOrCandidate(endpoint, ClassDoc()), "ClassDoc", //
-  package.(DollarAtString), "package", //
-  type.(DollarAtString), "type", //
-  subtypes.toString().(DollarAtString), "subtypes", //
-  name.(DollarAtString), "name", //
-  signature.(DollarAtString), "signature", //
-  input.(DollarAtString), "input", //
-  parameterName.(DollarAtString), "parameterName" //
+  package, "package", //
+  type, "type", //
+  subtypes, "subtypes", //
+  name, "name", //
+  signature, "signature", //
+  input, "input", //
+  parameterName, "parameterName" //

--- a/java/ql/src/Telemetry/AutomodelFrameworkModeExtractNegativeExamples.ql
+++ b/java/ql/src/Telemetry/AutomodelFrameworkModeExtractNegativeExamples.ql
@@ -3,7 +3,7 @@
  *
  * @name Negative examples (framework mode)
  * @kind problem
- * @severity info
+ * @problem.severity recommendation
  * @id java/ml/extract-automodel-framework-negative-examples
  * @tags internal extract automodel framework-mode negative examples
  */

--- a/java/ql/src/Telemetry/AutomodelFrameworkModeExtractNegativeExamples.ql
+++ b/java/ql/src/Telemetry/AutomodelFrameworkModeExtractNegativeExamples.ql
@@ -14,7 +14,7 @@ private import AutomodelSharedUtil
 
 from
   Endpoint endpoint, EndpointCharacteristic characteristic, float confidence, string message,
-  MetadataExtractor meta, string package, string type, boolean subtypes, string name,
+  FrameworkModeMetadataExtractor meta, string package, string type, boolean subtypes, string name,
   string signature, string input, string parameterName
 where
   characteristic.appliesToEndpoint(endpoint) and

--- a/java/ql/src/Telemetry/AutomodelFrameworkModeExtractPositiveExamples.ql
+++ b/java/ql/src/Telemetry/AutomodelFrameworkModeExtractPositiveExamples.ql
@@ -10,7 +10,7 @@
 
 private import AutomodelFrameworkModeCharacteristics
 private import AutomodelEndpointTypes
-private import AutomodelSharedUtil
+private import AutomodelJavaUtil
 
 from
   Endpoint endpoint, SinkType sinkType, FrameworkModeMetadataExtractor meta, DollarAtString package,

--- a/java/ql/src/Telemetry/AutomodelFrameworkModeExtractPositiveExamples.ql
+++ b/java/ql/src/Telemetry/AutomodelFrameworkModeExtractPositiveExamples.ql
@@ -13,8 +13,8 @@ private import AutomodelEndpointTypes
 private import AutomodelSharedUtil
 
 from
-  Endpoint endpoint, SinkType sinkType, MetadataExtractor meta, string package, string type,
-  boolean subtypes, string name, string signature, string input, string parameterName
+  Endpoint endpoint, SinkType sinkType, FrameworkModeMetadataExtractor meta, string package,
+  string type, boolean subtypes, string name, string signature, string input, string parameterName
 where
   // Exclude endpoints that have contradictory endpoint characteristics, because we only want examples we're highly
   // certain about in the prompt.

--- a/java/ql/src/Telemetry/AutomodelFrameworkModeExtractPositiveExamples.ql
+++ b/java/ql/src/Telemetry/AutomodelFrameworkModeExtractPositiveExamples.ql
@@ -13,8 +13,9 @@ private import AutomodelEndpointTypes
 private import AutomodelSharedUtil
 
 from
-  Endpoint endpoint, SinkType sinkType, FrameworkModeMetadataExtractor meta, string package,
-  string type, boolean subtypes, string name, string signature, string input, string parameterName
+  Endpoint endpoint, SinkType sinkType, FrameworkModeMetadataExtractor meta, DollarAtString package,
+  DollarAtString type, DollarAtString subtypes, DollarAtString name, DollarAtString signature,
+  DollarAtString input, DollarAtString parameterName
 where
   // Exclude endpoints that have contradictory endpoint characteristics, because we only want examples we're highly
   // certain about in the prompt.
@@ -26,10 +27,10 @@ select endpoint,
   sinkType + "\nrelated locations: $@, $@." + "\nmetadata: $@, $@, $@, $@, $@, $@, $@.", //
   CharacteristicsImpl::getRelatedLocationOrCandidate(endpoint, MethodDoc()), "MethodDoc", //
   CharacteristicsImpl::getRelatedLocationOrCandidate(endpoint, ClassDoc()), "ClassDoc", //
-  package.(DollarAtString), "package", //
-  type.(DollarAtString), "type", //
-  subtypes.toString().(DollarAtString), "subtypes", //
-  name.(DollarAtString), "name", //
-  signature.(DollarAtString), "signature", //
-  input.(DollarAtString), "input", //
-  parameterName.(DollarAtString), "parameterName" //
+  package, "package", //
+  type, "type", //
+  subtypes, "subtypes", //
+  name, "name", //
+  signature, "signature", //
+  input, "input", //
+  parameterName, "parameterName" //

--- a/java/ql/src/Telemetry/AutomodelFrameworkModeExtractPositiveExamples.ql
+++ b/java/ql/src/Telemetry/AutomodelFrameworkModeExtractPositiveExamples.ql
@@ -14,7 +14,7 @@ private import AutomodelSharedUtil
 
 from
   Endpoint endpoint, SinkType sinkType, MetadataExtractor meta, string package, string type,
-  boolean subtypes, string name, string signature, int input, string parameterName
+  boolean subtypes, string name, string signature, string input, string parameterName
 where
   // Exclude endpoints that have contradictory endpoint characteristics, because we only want examples we're highly
   // certain about in the prompt.
@@ -31,5 +31,5 @@ select endpoint,
   subtypes.toString().(DollarAtString), "subtypes", //
   name.(DollarAtString), "name", //
   signature.(DollarAtString), "signature", //
-  input.toString().(DollarAtString), "input", //
+  input.(DollarAtString), "input", //
   parameterName.(DollarAtString), "parameterName" //

--- a/java/ql/src/Telemetry/AutomodelFrameworkModeExtractPositiveExamples.ql
+++ b/java/ql/src/Telemetry/AutomodelFrameworkModeExtractPositiveExamples.ql
@@ -5,7 +5,7 @@
  * @kind problem
  * @severity info
  * @id java/ml/known-sink
- * @tags internal automodel extract examples positive
+ * @tags internal automodel extract examples positive framework-mode
  */
 
 private import AutomodelFrameworkModeCharacteristics

--- a/java/ql/src/Telemetry/AutomodelFrameworkModeExtractPositiveExamples.ql
+++ b/java/ql/src/Telemetry/AutomodelFrameworkModeExtractPositiveExamples.ql
@@ -3,7 +3,7 @@
  *
  * @name Positive examples (framework mode)
  * @kind problem
- * @severity info
+ * @problem.severity recommendation
  * @id java/ml/extract-automodel-framework-positive-examples
  * @tags internal extract automodel framework-mode positive examples
  */

--- a/java/ql/src/Telemetry/AutomodelJavaUtil.qll
+++ b/java/ql/src/Telemetry/AutomodelJavaUtil.qll
@@ -1,3 +1,4 @@
+private import java
 private import AutomodelEndpointTypes as AutomodelEndpointTypes
 
 /**
@@ -60,4 +61,21 @@ string getArgumentForIndex(int index) {
   index = -1 and result = "Argument[this]"
   or
   index >= 0 and result = "Argument[" + index + "]"
+}
+
+/**
+ * By convention, the subtypes property of the MaD declaration should only be
+ * true when there _can_ exist any subtypes with a different implementation.
+ *
+ * It would technically be ok to always use the value 'true', but this would
+ * break convention.
+ */
+boolean considerSubtypes(Callable callable) {
+  if
+    callable.isStatic() or
+    callable.getDeclaringType().isStatic() or
+    callable.isFinal() or
+    callable.getDeclaringType().isFinal()
+  then result = false
+  else result = true
 }

--- a/java/ql/src/Telemetry/AutomodelSharedGetCallable.qll
+++ b/java/ql/src/Telemetry/AutomodelSharedGetCallable.qll
@@ -1,0 +1,21 @@
+/**
+ * An automodel extraction mode instantiates this interface to define how to access
+ * the callable that's associated with an endpoint.
+ */
+signature module GetCallableSig {
+  /**
+   * A callable is the definition of a method, function, etc. - something that can be called.
+   */
+  class Callable;
+
+  /**
+   * An endpoint is a potential candidate for modeling. This will typically be bound to the language's
+   * DataFlow node class, or a subtype thereof.
+   */
+  class Endpoint;
+
+  /**
+   * Gets the callable that's associated with the given endpoint.
+   */
+  Callable getCallable(Endpoint endpoint);
+}

--- a/java/ql/src/Telemetry/AutomodelSharedUtil.qll
+++ b/java/ql/src/Telemetry/AutomodelSharedUtil.qll
@@ -22,6 +22,10 @@ class DollarAtString extends string {
   }
 }
 
+/**
+ * Holds for all combinations of MaD kinds (`kind`) and their human readable
+ * descriptions.
+ */
 predicate isKnownKind(
   string kind, string humanReadableKind, AutomodelEndpointTypes::EndpointType type
 ) {

--- a/java/ql/src/Telemetry/AutomodelSharedUtil.qll
+++ b/java/ql/src/Telemetry/AutomodelSharedUtil.qll
@@ -1,3 +1,5 @@
+import AutomodelEndpointTypes as AutomodelEndpointTypes
+
 /**
  * A helper class to represent a string value that can be returned by a query using $@ notation.
  *
@@ -18,4 +20,32 @@ class DollarAtString extends string {
   predicate hasLocationInfo(string path, int sl, int sc, int el, int ec) {
     path = this and sl = 1 and sc = 1 and el = 1 and ec = 1
   }
+}
+
+predicate isKnownKind(
+  string kind, string humanReadableKind, AutomodelEndpointTypes::EndpointType type
+) {
+  kind = "read-file" and
+  humanReadableKind = "read file" and
+  type instanceof AutomodelEndpointTypes::TaintedPathSinkType
+  or
+  kind = "create-file" and
+  humanReadableKind = "create file" and
+  type instanceof AutomodelEndpointTypes::TaintedPathSinkType
+  or
+  kind = "sql" and
+  humanReadableKind = "mad modeled sql" and
+  type instanceof AutomodelEndpointTypes::SqlSinkType
+  or
+  kind = "open-url" and
+  humanReadableKind = "open url" and
+  type instanceof AutomodelEndpointTypes::RequestForgerySinkType
+  or
+  kind = "jdbc-url" and
+  humanReadableKind = "jdbc url" and
+  type instanceof AutomodelEndpointTypes::RequestForgerySinkType
+  or
+  kind = "command-injection" and
+  humanReadableKind = "command injection" and
+  type instanceof AutomodelEndpointTypes::CommandInjectionSinkType
 }

--- a/java/ql/src/Telemetry/AutomodelSharedUtil.qll
+++ b/java/ql/src/Telemetry/AutomodelSharedUtil.qll
@@ -49,3 +49,11 @@ predicate isKnownKind(
   humanReadableKind = "command injection" and
   type instanceof AutomodelEndpointTypes::CommandInjectionSinkType
 }
+
+/** Gets the argument name for the argument with the index `index`. */
+bindingset[index]
+string getArgumentForIndex(int index) {
+  index = -1 and result = "Argument[this]"
+  or
+  index >= 0 and result = "Argument[" + index + "]"
+}

--- a/java/ql/src/Telemetry/AutomodelSharedUtil.qll
+++ b/java/ql/src/Telemetry/AutomodelSharedUtil.qll
@@ -50,7 +50,7 @@ predicate isKnownKind(
   type instanceof AutomodelEndpointTypes::CommandInjectionSinkType
 }
 
-/** Gets the argument name for the argument with the index `index`. */
+/** Gets the models-as-data description for the method argument with the index `index`. */
 bindingset[index]
 string getArgumentForIndex(int index) {
   index = -1 and result = "Argument[this]"

--- a/java/ql/src/Telemetry/AutomodelSharedUtil.qll
+++ b/java/ql/src/Telemetry/AutomodelSharedUtil.qll
@@ -1,4 +1,4 @@
-import AutomodelEndpointTypes as AutomodelEndpointTypes
+private import AutomodelEndpointTypes as AutomodelEndpointTypes
 
 /**
  * A helper class to represent a string value that can be returned by a query using $@ notation.


### PR DESCRIPTION
This adds application mode extraction queries, using the legacy implementation as a guideline. We expect the behaviour to be mostly equal, but with some differences

 - this includes an `UninterestingToModelCharacteristic` implementation that excludes some well-known frameworks. These would otherwise make up a large fraction of the candidates and we suggest removing them, as we now have framework mode.
 - this limits the number of negative examples to at most 100 per class, as the negative examples could otherwise easily outweigh the candidates by a factor of 15-20x — this seemed overkill, given that only a handful ever make it into our prompts.

When reviewing this, feel free to run the extraction on a DB locally and tell us if you spot anything that should/shouldn't be a candidate, or +/- example in your opinion.

We've split this up in a large number of commits that are mostly rather small, but a review would be easiest to do on the whole code. YMMV.