### PR TITLE
Java: Tweak java.nio.file.Files.copy models

### DIFF
--- a/java/ql/lib/change-notes/2023-05-23-java-nio-file-files-copy-models-tweak.md
+++ b/java/ql/lib/change-notes/2023-05-23-java-nio-file-files-copy-models-tweak.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+Modified the models related to `java.nio.file.Files.copy` so that generic `[Input|Output]Stream` arguments are not considered file-related sinks.

--- a/java/ql/lib/ext/java.nio.file.model.yml
+++ b/java/ql/lib/ext/java.nio.file.model.yml
@@ -3,9 +3,11 @@ extensions:
       pack: codeql/java-all
       extensible: sinkModel
     data:
-      - ["java.nio.file", "Files", False, "copy", "", "", "Argument[0]", "read-file", "manual"]
+      - ["java.nio.file", "Files", False, "copy", "(Path,OutputStream)", "", "Argument[0]", "read-file", "manual"]
+      - ["java.nio.file", "Files", False, "copy", "(Path,Path,CopyOption[])", "", "Argument[0]", "read-file", "manual"]
+      - ["java.nio.file", "Files", False, "copy", "(Path,Path,CopyOption[])", "", "Argument[1]", "create-file", "manual"]
       - ["java.nio.file", "Files", False, "copy", "(InputStream,Path,CopyOption[])", "", "Argument[0]", "write-file", "manual"]
-      - ["java.nio.file", "Files", False, "copy", "", "", "Argument[1]", "create-file", "manual"]
+      - ["java.nio.file", "Files", False, "copy", "(InputStream,Path,CopyOption[])", "", "Argument[1]", "create-file", "manual"]
       - ["java.nio.file", "Files", False, "createDirectories", "", "", "Argument[0]", "create-file", "manual"]
       - ["java.nio.file", "Files", False, "createDirectory", "", "", "Argument[0]", "create-file", "manual"]
       - ["java.nio.file", "Files", False, "createFile", "", "", "Argument[0]", "create-file", "manual"]

--- a/java/ql/test/query-tests/security/CWE-022/semmle/tests/TaintedPath.expected
+++ b/java/ql/test/query-tests/security/CWE-022/semmle/tests/TaintedPath.expected
@@ -23,10 +23,8 @@ edges
 | mad/Test.java:29:16:29:36 | getHostName(...) : String | mad/Test.java:46:31:46:38 | source(...) : String |
 | mad/Test.java:29:16:29:36 | getHostName(...) : String | mad/Test.java:48:33:48:40 | source(...) : String |
 | mad/Test.java:29:16:29:36 | getHostName(...) : String | mad/Test.java:50:27:50:34 | source(...) : String |
-| mad/Test.java:29:16:29:36 | getHostName(...) : String | mad/Test.java:51:27:51:34 | source(...) : String |
-| mad/Test.java:29:16:29:36 | getHostName(...) : String | mad/Test.java:52:34:52:41 | source(...) : String |
+| mad/Test.java:29:16:29:36 | getHostName(...) : String | mad/Test.java:52:27:52:34 | source(...) : String |
 | mad/Test.java:29:16:29:36 | getHostName(...) : String | mad/Test.java:54:40:54:47 | source(...) : String |
-| mad/Test.java:29:16:29:36 | getHostName(...) : String | mad/Test.java:55:48:55:55 | source(...) : String |
 | mad/Test.java:29:16:29:36 | getHostName(...) : String | mad/Test.java:56:47:56:54 | source(...) : String |
 | mad/Test.java:29:16:29:36 | getHostName(...) : String | mad/Test.java:58:40:58:47 | source(...) : String |
 | mad/Test.java:29:16:29:36 | getHostName(...) : String | mad/Test.java:60:38:60:45 | source(...) : String |
@@ -77,10 +75,8 @@ edges
 | mad/Test.java:46:31:46:38 | source(...) : String | mad/Test.java:46:24:46:38 | (...)... |
 | mad/Test.java:48:33:48:40 | source(...) : String | mad/Test.java:48:24:48:40 | (...)... |
 | mad/Test.java:50:27:50:34 | source(...) : String | mad/Test.java:50:20:50:34 | (...)... |
-| mad/Test.java:51:27:51:34 | source(...) : String | mad/Test.java:51:20:51:34 | (...)... |
-| mad/Test.java:52:34:52:41 | source(...) : String | mad/Test.java:52:20:52:41 | (...)... |
+| mad/Test.java:52:27:52:34 | source(...) : String | mad/Test.java:52:20:52:34 | (...)... |
 | mad/Test.java:54:40:54:47 | source(...) : String | mad/Test.java:54:33:54:47 | (...)... |
-| mad/Test.java:55:48:55:55 | source(...) : String | mad/Test.java:55:33:55:55 | (...)... |
 | mad/Test.java:56:47:56:54 | source(...) : String | mad/Test.java:56:40:56:54 | (...)... |
 | mad/Test.java:58:40:58:47 | source(...) : String | mad/Test.java:58:33:58:47 | (...)... |
 | mad/Test.java:60:38:60:45 | source(...) : String | mad/Test.java:60:31:60:45 | (...)... |
@@ -161,14 +157,10 @@ nodes
 | mad/Test.java:48:33:48:40 | source(...) : String | semmle.label | source(...) : String |
 | mad/Test.java:50:20:50:34 | (...)... | semmle.label | (...)... |
 | mad/Test.java:50:27:50:34 | source(...) : String | semmle.label | source(...) : String |
-| mad/Test.java:51:20:51:34 | (...)... | semmle.label | (...)... |
-| mad/Test.java:51:27:51:34 | source(...) : String | semmle.label | source(...) : String |
-| mad/Test.java:52:20:52:41 | (...)... | semmle.label | (...)... |
-| mad/Test.java:52:34:52:41 | source(...) : String | semmle.label | source(...) : String |
+| mad/Test.java:52:20:52:34 | (...)... | semmle.label | (...)... |
+| mad/Test.java:52:27:52:34 | source(...) : String | semmle.label | source(...) : String |
 | mad/Test.java:54:33:54:47 | (...)... | semmle.label | (...)... |
 | mad/Test.java:54:40:54:47 | source(...) : String | semmle.label | source(...) : String |
-| mad/Test.java:55:33:55:55 | (...)... | semmle.label | (...)... |
-| mad/Test.java:55:48:55:55 | source(...) : String | semmle.label | source(...) : String |
 | mad/Test.java:56:40:56:54 | (...)... | semmle.label | (...)... |
 | mad/Test.java:56:47:56:54 | source(...) : String | semmle.label | source(...) : String |
 | mad/Test.java:58:33:58:47 | (...)... | semmle.label | (...)... |
@@ -273,10 +265,8 @@ subpaths
 | mad/Test.java:46:24:46:38 | (...)... | mad/Test.java:29:16:29:36 | getHostName(...) : String | mad/Test.java:46:24:46:38 | (...)... | This path depends on a $@. | mad/Test.java:29:16:29:36 | getHostName(...) | user-provided value |
 | mad/Test.java:48:9:48:41 | new FileReader(...) | mad/Test.java:29:16:29:36 | getHostName(...) : String | mad/Test.java:48:24:48:40 | (...)... | This path depends on a $@. | mad/Test.java:29:16:29:36 | getHostName(...) | user-provided value |
 | mad/Test.java:50:20:50:34 | (...)... | mad/Test.java:29:16:29:36 | getHostName(...) : String | mad/Test.java:50:20:50:34 | (...)... | This path depends on a $@. | mad/Test.java:29:16:29:36 | getHostName(...) | user-provided value |
-| mad/Test.java:51:20:51:34 | (...)... | mad/Test.java:29:16:29:36 | getHostName(...) : String | mad/Test.java:51:20:51:34 | (...)... | This path depends on a $@. | mad/Test.java:29:16:29:36 | getHostName(...) | user-provided value |
-| mad/Test.java:52:20:52:41 | (...)... | mad/Test.java:29:16:29:36 | getHostName(...) : String | mad/Test.java:52:20:52:41 | (...)... | This path depends on a $@. | mad/Test.java:29:16:29:36 | getHostName(...) | user-provided value |
+| mad/Test.java:52:20:52:34 | (...)... | mad/Test.java:29:16:29:36 | getHostName(...) : String | mad/Test.java:52:20:52:34 | (...)... | This path depends on a $@. | mad/Test.java:29:16:29:36 | getHostName(...) | user-provided value |
 | mad/Test.java:54:33:54:47 | (...)... | mad/Test.java:29:16:29:36 | getHostName(...) : String | mad/Test.java:54:33:54:47 | (...)... | This path depends on a $@. | mad/Test.java:29:16:29:36 | getHostName(...) | user-provided value |
-| mad/Test.java:55:33:55:55 | (...)... | mad/Test.java:29:16:29:36 | getHostName(...) : String | mad/Test.java:55:33:55:55 | (...)... | This path depends on a $@. | mad/Test.java:29:16:29:36 | getHostName(...) | user-provided value |
 | mad/Test.java:56:40:56:54 | (...)... | mad/Test.java:29:16:29:36 | getHostName(...) : String | mad/Test.java:56:40:56:54 | (...)... | This path depends on a $@. | mad/Test.java:29:16:29:36 | getHostName(...) | user-provided value |
 | mad/Test.java:58:33:58:47 | (...)... | mad/Test.java:29:16:29:36 | getHostName(...) : String | mad/Test.java:58:33:58:47 | (...)... | This path depends on a $@. | mad/Test.java:29:16:29:36 | getHostName(...) | user-provided value |
 | mad/Test.java:60:31:60:45 | (...)... | mad/Test.java:29:16:29:36 | getHostName(...) : String | mad/Test.java:60:31:60:45 | (...)... | This path depends on a $@. | mad/Test.java:29:16:29:36 | getHostName(...) | user-provided value |

--- a/java/ql/test/query-tests/security/CWE-022/semmle/tests/mad/Test.java
+++ b/java/ql/test/query-tests/security/CWE-022/semmle/tests/mad/Test.java
@@ -46,13 +46,13 @@ public class Test {
         new FileReader((File) source());
         // "java.io;FileReader;true;FileReader;(String);;Argument[0];read-file;ai-generated"
         new FileReader((String) source());
-        // "java.nio.file;Files;false;copy;;;Argument[0];read-file;manual"
-        Files.copy((Path) source(), (Path) null);
+        // "java.nio.file;Files;false;copy;(Path,OutputStream);;Argument[0];read-file;manual"
         Files.copy((Path) source(), (OutputStream) null);
-        Files.copy((InputStream) source(), null);
-        // "java.nio.file;Files;false;copy;;;Argument[1];create-file;manual"
+        // "java.nio.file;Files;false;copy;(Path,Path,CopyOption[]);;Argument[0];read-file;manual"
+        Files.copy((Path) source(), (Path) null);
+        // "java.nio.file;Files;false;copy;(Path,Path,CopyOption[]);;Argument[1];create-file;manual"
         Files.copy((Path) null, (Path) source());
-        Files.copy((Path) null, (OutputStream) source());
+        // "java.nio.file;Files;false;copy;(InputStream,Path,CopyOption[]);;Argument[1];create-file;manual"
         Files.copy((InputStream) null, (Path) source());
         // "java.nio.file;Files;false;createDirectories;;;Argument[0];create-file;manual"
         Files.createDirectories((Path) source());


### PR DESCRIPTION
Avoid considering generic `[Input|Output]Stream` arguments as file-related sinks, since they could be other things (like `ByteArray[Input|Output]Stream`s).