### PR TITLE
Hotfix: Go: count passing to a vararg function as escaping

### DIFF
--- a/go/ql/src/RedundantCode/DeadStoreOfField.ql
+++ b/go/ql/src/RedundantCode/DeadStoreOfField.ql
@@ -36,7 +36,7 @@ predicate escapes(DataFlow::Node nd) {
   exists(SendStmt s | nd.asExpr() = s.getValue())
   or
   // if `nd` is passed to a function, then it escapes
-  nd instanceof DataFlow::ArgumentNode
+  nd = any(DataFlow::CallNode c).getASyntacticArgument()
   or
   // if `nd` has its address taken, then it escapes
   exists(AddressExpr ae | nd.asExpr() = ae.getOperand())


### PR DESCRIPTION
Fixes a regression caused by https://github.com/github/codeql/pull/11732