### PR TITLE
C++: Add `cpp/invalid-pointer-deref` FP test case

### DIFF
--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/InvalidPointerDeref.expected
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/InvalidPointerDeref.expected
@@ -653,7 +653,18 @@ edges
 | test.cpp:304:15:304:26 | new[] | test.cpp:308:5:308:6 | xs |
 | test.cpp:308:5:308:6 | xs | test.cpp:308:5:308:11 | access to array |
 | test.cpp:308:5:308:11 | access to array | test.cpp:308:5:308:29 | Store: ... = ... |
-| test.cpp:313:16:313:29 | new[] | test.cpp:314:17:314:18 | xs |
+| test.cpp:313:14:313:27 | new[] | test.cpp:314:15:314:16 | xs |
+| test.cpp:325:14:325:27 | new[] | test.cpp:326:15:326:16 | xs |
+| test.cpp:326:15:326:16 | xs | test.cpp:326:15:326:23 | ... + ... |
+| test.cpp:326:15:326:16 | xs | test.cpp:326:15:326:23 | ... + ... |
+| test.cpp:326:15:326:16 | xs | test.cpp:338:8:338:15 | * ... |
+| test.cpp:326:15:326:16 | xs | test.cpp:341:8:341:17 | * ... |
+| test.cpp:326:15:326:23 | ... + ... | test.cpp:342:8:342:17 | * ... |
+| test.cpp:326:15:326:23 | ... + ... | test.cpp:342:8:342:17 | * ... |
+| test.cpp:338:8:338:15 | * ... | test.cpp:342:8:342:17 | * ... |
+| test.cpp:341:8:341:17 | * ... | test.cpp:342:8:342:17 | * ... |
+| test.cpp:342:8:342:17 | * ... | test.cpp:333:5:333:21 | Store: ... = ... |
+| test.cpp:342:8:342:17 | * ... | test.cpp:341:5:341:21 | Store: ... = ... |
 subpaths
 #select
 | test.cpp:6:14:6:15 | Load: * ... | test.cpp:4:15:4:20 | call to malloc | test.cpp:6:14:6:15 | Load: * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:4:15:4:20 | call to malloc | call to malloc | test.cpp:5:19:5:22 | size | size |
@@ -679,3 +690,5 @@ subpaths
 | test.cpp:264:13:264:14 | Load: * ... | test.cpp:260:13:260:24 | new[] | test.cpp:264:13:264:14 | Load: * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:260:13:260:24 | new[] | new[] | test.cpp:261:19:261:21 | len | len |
 | test.cpp:274:5:274:10 | Store: ... = ... | test.cpp:270:13:270:24 | new[] | test.cpp:274:5:274:10 | Store: ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:270:13:270:24 | new[] | new[] | test.cpp:271:19:271:21 | len | len |
 | test.cpp:308:5:308:29 | Store: ... = ... | test.cpp:304:15:304:26 | new[] | test.cpp:308:5:308:29 | Store: ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:304:15:304:26 | new[] | new[] | test.cpp:308:8:308:10 | ... + ... | ... + ... |
+| test.cpp:333:5:333:21 | Store: ... = ... | test.cpp:325:14:325:27 | new[] | test.cpp:333:5:333:21 | Store: ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:325:14:325:27 | new[] | new[] | test.cpp:326:20:326:23 | size | size |
+| test.cpp:341:5:341:21 | Store: ... = ... | test.cpp:325:14:325:27 | new[] | test.cpp:341:5:341:21 | Store: ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:325:14:325:27 | new[] | new[] | test.cpp:326:20:326:23 | size | size |

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/InvalidPointerDeref.expected
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/InvalidPointerDeref.expected
@@ -665,6 +665,12 @@ edges
 | test.cpp:341:8:341:17 | * ... | test.cpp:342:8:342:17 | * ... |
 | test.cpp:342:8:342:17 | * ... | test.cpp:333:5:333:21 | Store: ... = ... |
 | test.cpp:342:8:342:17 | * ... | test.cpp:341:5:341:21 | Store: ... = ... |
+| test.cpp:347:14:347:27 | new[] | test.cpp:348:15:348:16 | xs |
+| test.cpp:348:15:348:16 | xs | test.cpp:350:16:350:19 | ... ++ |
+| test.cpp:348:15:348:16 | xs | test.cpp:350:16:350:19 | ... ++ |
+| test.cpp:350:16:350:19 | ... ++ | test.cpp:350:15:350:19 | Load: * ... |
+| test.cpp:350:16:350:19 | ... ++ | test.cpp:350:16:350:19 | ... ++ |
+| test.cpp:350:16:350:19 | ... ++ | test.cpp:350:16:350:19 | ... ++ |
 subpaths
 #select
 | test.cpp:6:14:6:15 | Load: * ... | test.cpp:4:15:4:20 | call to malloc | test.cpp:6:14:6:15 | Load: * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:4:15:4:20 | call to malloc | call to malloc | test.cpp:5:19:5:22 | size | size |
@@ -692,3 +698,4 @@ subpaths
 | test.cpp:308:5:308:29 | Store: ... = ... | test.cpp:304:15:304:26 | new[] | test.cpp:308:5:308:29 | Store: ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:304:15:304:26 | new[] | new[] | test.cpp:308:8:308:10 | ... + ... | ... + ... |
 | test.cpp:333:5:333:21 | Store: ... = ... | test.cpp:325:14:325:27 | new[] | test.cpp:333:5:333:21 | Store: ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:325:14:325:27 | new[] | new[] | test.cpp:326:20:326:23 | size | size |
 | test.cpp:341:5:341:21 | Store: ... = ... | test.cpp:325:14:325:27 | new[] | test.cpp:341:5:341:21 | Store: ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:325:14:325:27 | new[] | new[] | test.cpp:326:20:326:23 | size | size |
+| test.cpp:350:15:350:19 | Load: * ... | test.cpp:347:14:347:27 | new[] | test.cpp:350:15:350:19 | Load: * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:347:14:347:27 | new[] | new[] | test.cpp:348:20:348:23 | size | size |

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/test.cpp
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/test.cpp
@@ -342,3 +342,11 @@ void test23(unsigned size, int val) {
     *--(*current) = 0; // GOOD
   }
 }
+
+void test24(unsigned size) {
+  char *xs = new char[size];
+  char *end = xs + size;
+  if (xs < end) {
+    int val = *xs++; // GOOD [FALSE POSITIVE]
+  }
+}

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/test.cpp
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/test.cpp
@@ -310,15 +310,35 @@ void test21() {
 }
 
 void test22(unsigned size, int val) {
-    char *xs = new char[size];
-    char *end = xs + size; // GOOD
-    char **current = &end;
-    do
-    {
-        if( *current - xs < 1 ) // GOOD
-            return;
-        *--(*current) = 0; // GOOD
-        val >>= 8;
-    }
-    while( val > 0 );
+  char *xs = new char[size];
+  char *end = xs + size; // GOOD
+  char **current = &end;
+  do {
+    if (*current - xs < 1) // GOOD
+      return;
+    *--(*current) = 0; // GOOD
+      val >>= 8;
+  } while (val > 0);
+}
+
+void test23(unsigned size, int val) {
+  char *xs = new char[size];
+  char *end = xs + size;
+  char **current = &end;
+
+  if (val < 1) {
+    if(*current - xs < 1)
+      return;
+
+    *--(*current) = 0; // GOOD [FALSE POSITIVE]
+    return;
+  }
+
+  if (val < 2) {
+    if(*current - xs < 2)
+      return;
+
+    *--(*current) = 0; // GOOD [FALSE POSITIVE]
+    *--(*current) = 0; // GOOD
+  }
 }


### PR DESCRIPTION
Test case shows that the store may occur before the pointer update, and the number of indirections still seem to be off-by-one 😕 

Also make the formatting in the test file more uniform while we're here.