### PR TITLE
Swift: Add path injection sinks for sqlite3 and SQLite.swift

### DIFF
--- a/swift/ql/lib/change-notes/2023-05-23-path-injection-sinks.md
+++ b/swift/ql/lib/change-notes/2023-05-23-path-injection-sinks.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Added sqlite3 and SQLite.swift path injection sinks for the `swift/path-injection` query.

--- a/swift/ql/lib/codeql/swift/security/PathInjectionExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/PathInjectionExtensions.qll
@@ -130,6 +130,19 @@ private class PathInjectionSinks extends SinkModelCsv {
         ";Realm.Configuration;true;init(fileURL:inMemoryIdentifier:syncConfiguration:encryptionKey:readOnly:schemaVersion:migrationBlock:deleteRealmIfMigrationNeeded:shouldCompactOnLaunch:objectTypes:seedFilePath:);;;Argument[10];path-injection",
         ";Realm.Configuration;true;fileURL;;;PostUpdate;path-injection",
         ";Realm.Configuration;true;seedFilePath;;;PostUpdate;path-injection",
+        // sqlite3
+        ";;false;sqlite3_open(_:_:);;;Argument[0];path-injection",
+        ";;false;sqlite3_open16(_:_:);;;Argument[0];path-injection",
+        ";;false;sqlite3_open_v2(_:_:_:_:);;;Argument[0];path-injection",
+        ";;false;sqlite3_database_file_object(_:);;;Argument[0];path-injection",
+        ";;false;sqlite3_filename_database(_:);;;Argument[0];path-injection",
+        ";;false;sqlite3_filename_journal(_:);;;Argument[0];path-injection",
+        ";;false;sqlite3_filename_wal(_:);;;Argument[0];path-injection",
+        ";;false;sqlite3_free_filename(_:);;;Argument[0];path-injection",
+        ";;false;sqlite3_temp_directory;;;PostUpdate;path-injection",
+        // SQLite.swift
+        ";Connection.Location.uri;true;init(_:parameters:);;;Argument[0];path-injection",
+        ";Connection;true;init(_:readonly:);;;Argument[0];path-injection",
       ]
   }
 }

--- a/swift/ql/test/query-tests/Security/CWE-022/testPathInjection.swift
+++ b/swift/ql/test/query-tests/Security/CWE-022/testPathInjection.swift
@@ -45,7 +45,7 @@ class NSString {
 }
 
 class Data {
-	struct ReadingOptions : OptionSet { let rawValue: Int }
+    struct ReadingOptions : OptionSet { let rawValue: Int }
     struct WritingOptions : OptionSet { let rawValue: Int }
 
     init<S>(_ elements: S) { count = 0 }
@@ -369,10 +369,10 @@ func test(buffer1: UnsafeMutablePointer<UInt8>, buffer2: UnsafeMutablePointer<UI
     // sqlite3
 
     var db: OpaquePointer?
-	let localData = Data(0)
-	let remoteData = Data(contentsOf: URL(string: "http://example.com/")!, options: [])
-	localData.copyBytes(to: buffer1, count: localData.count)
-	remoteData.copyBytes(to: buffer2, count: remoteData.count)
+    let localData = Data(0)
+    let remoteData = Data(contentsOf: URL(string: "http://example.com/")!, options: [])
+    localData.copyBytes(to: buffer1, count: localData.count)
+    remoteData.copyBytes(to: buffer2, count: remoteData.count)
 
     _ = sqlite3_open("myFile.sqlite3", &db) // GOOD
     _ = sqlite3_open(remoteString, &db) // $ hasPathInjection=253
@@ -386,7 +386,7 @@ func test(buffer1: UnsafeMutablePointer<UInt8>, buffer2: UnsafeMutablePointer<UI
 
     // SQLite.swift
 
-	try! _ = Connection()
+    try! _ = Connection()
     try! _ = Connection(Connection.Location.uri("myFile.sqlite3")) // GOOD
     try! _ = Connection(Connection.Location.uri(remoteString)) // $ MISSING: hasPathInjection=253
     try! _ = Connection("myFile.sqlite3") // GOOD

--- a/swift/ql/test/query-tests/Security/CWE-022/testPathInjection.swift
+++ b/swift/ql/test/query-tests/Security/CWE-022/testPathInjection.swift
@@ -375,11 +375,11 @@ func test(buffer1: UnsafeMutablePointer<UInt8>, buffer2: UnsafeMutablePointer<UI
 	remoteData.copyBytes(to: buffer2, count: remoteData.count)
 
     _ = sqlite3_open("myFile.sqlite3", &db) // GOOD
-    _ = sqlite3_open(remoteString, &db) // $ MISSING: hasPathInjection=253
+    _ = sqlite3_open(remoteString, &db) // $ hasPathInjection=253
     _ = sqlite3_open16(buffer1, &db) // GOOD
-    _ = sqlite3_open16(buffer2, &db) // $ MISSING: hasPathInjection=253
+    _ = sqlite3_open16(buffer2, &db) // $ hasPathInjection=373
     _ = sqlite3_open_v2("myFile.sqlite3", &db, 0, nil) // GOOD
-    _ = sqlite3_open_v2(remoteString, &db, 0, nil) // $ MISSING: hasPathInjection=253
+    _ = sqlite3_open_v2(remoteString, &db, 0, nil) // $ hasPathInjection=253
 
     sqlite3_temp_directory = UnsafeMutablePointer<CChar>(mutating: NSString(string: "myFile.sqlite3").utf8String) // GOOD
     sqlite3_temp_directory = UnsafeMutablePointer<CChar>(mutating: NSString(string: remoteString).utf8String) // $ MISSING: hasPathInjection=253
@@ -390,7 +390,7 @@ func test(buffer1: UnsafeMutablePointer<UInt8>, buffer2: UnsafeMutablePointer<UI
     try! _ = Connection(Connection.Location.uri("myFile.sqlite3")) // GOOD
     try! _ = Connection(Connection.Location.uri(remoteString)) // $ MISSING: hasPathInjection=253
     try! _ = Connection("myFile.sqlite3") // GOOD
-    try! _ = Connection(remoteString) // $ MISSING: hasPathInjection=253
+    try! _ = Connection(remoteString) // $ hasPathInjection=253
 }
 
 func testBarriers() {


### PR DESCRIPTION
Add `swift/path-injection` sinks for the sqlite3 and SQLite.swift libraries.  There are two missing results that will require follow-up work after this PR:
- CSV sinks don't seem to be able to match `EnumElementExpr`s (i.e. `enum` constructor calls).
- CSV sinks don't seem to be able to match writes to global (non-member) variables.

This is my first PR for a while that has a [change note](https://github.com/github/codeql/blob/main/docs/change-notes.md), and possibly the first PR for Swift with a change note.  Does it look right?  Do we need to flip any switches to enable change note generation / publishing / the pull request check?