### PR TITLE
ReDoS: fix whitespace in the samples in ReDoS.qhelp

### DIFF
--- a/java/ql/src/Security/CWE/CWE-730/ReDoS.qhelp
+++ b/java/ql/src/Security/CWE/CWE-730/ReDoS.qhelp
@@ -11,8 +11,7 @@
 			Consider this regular expression:
 		</p>
 		<sample language="java">
-			^_(__|.)+_$
-		</sample>
+^_(__|.)+_$</sample>
 		<p>
 			Its sub-expression <code>"(__|.)+?"</code> can match the string <code>"__"</code> either by the
 			first alternative <code>"__"</code> to the left of the <code>"|"</code> operator, or by two

--- a/java/ql/src/Security/CWE/CWE-730/ReDoS.qhelp
+++ b/java/ql/src/Security/CWE/CWE-730/ReDoS.qhelp
@@ -25,8 +25,7 @@
 			the two branches of the alternative inside the repetition:
 		</p>
 		<sample language="java">
-			^_(__|[^_])+_$
-		</sample>
+^_(__|[^_])+_$</sample>
 	</example>
 
 	<include src="ReDoSReferences.inc.qhelp"/>

--- a/javascript/ql/src/Performance/ReDoS.qhelp
+++ b/javascript/ql/src/Performance/ReDoS.qhelp
@@ -11,8 +11,7 @@
 			Consider this regular expression:
 		</p>
 		<sample language="javascript">
-			/^_(__|.)+_$/
-		</sample>
+/^_(__|.)+_$/</sample>
 		<p>
 			Its sub-expression <code>"(__|.)+?"</code> can match the string <code>"__"</code> either by the
 			first alternative <code>"__"</code> to the left of the <code>"|"</code> operator, or by two

--- a/javascript/ql/src/Performance/ReDoS.qhelp
+++ b/javascript/ql/src/Performance/ReDoS.qhelp
@@ -25,8 +25,7 @@
 			the two branches of the alternative inside the repetition:
 		</p>
 		<sample language="javascript">
-			/^_(__|[^_])+_$/
-		</sample>
+/^_(__|[^_])+_$/</sample>
 	</example>
 
 	<include src="ReDoSReferences.inc.qhelp"/>

--- a/python/ql/src/Security/CWE-730/ReDoS.qhelp
+++ b/python/ql/src/Security/CWE-730/ReDoS.qhelp
@@ -11,8 +11,7 @@
 			Consider this regular expression:
 		</p>
 		<sample language="python">
-			^_(__|.)+_$
-		</sample>
+^_(__|.)+_$</sample>
 		<p>
 			Its sub-expression <code>"(__|.)+?"</code> can match the string <code>"__"</code> either by the
 			first alternative <code>"__"</code> to the left of the <code>"|"</code> operator, or by two

--- a/python/ql/src/Security/CWE-730/ReDoS.qhelp
+++ b/python/ql/src/Security/CWE-730/ReDoS.qhelp
@@ -25,8 +25,7 @@
 			the two branches of the alternative inside the repetition:
 		</p>
 		<sample language="python">
-			^_(__|[^_])+_$
-		</sample>
+^_(__|[^_])+_$</sample>
 	</example>
 
 	<include src="ReDoSReferences.inc.qhelp"/>

--- a/ruby/ql/src/queries/security/cwe-1333/ReDoS.qhelp
+++ b/ruby/ql/src/queries/security/cwe-1333/ReDoS.qhelp
@@ -21,8 +21,7 @@
       repetition:
     </p>
     <sample language="ruby">
-      /^_(__|[^_])+_$/
-    </sample>
+/^_(__|[^_])+_$/</sample>
   </example>
   <include src="ReDoSReferences.inc.qhelp"/>
 </qhelp>

--- a/ruby/ql/src/queries/security/cwe-1333/ReDoS.qhelp
+++ b/ruby/ql/src/queries/security/cwe-1333/ReDoS.qhelp
@@ -4,8 +4,7 @@
   <example>
     <p>Consider this regular expression:</p>
     <sample language="ruby">
-      /^_(__|.)+_$/
-    </sample>
+/^_(__|.)+_$/</sample>
     <p>
       Its sub-expression <code>"(__|.)+?"</code> can match the string
       <code>"__"</code> either by the first alternative <code>"__"</code> to the


### PR DESCRIPTION
[It's not great how it's rendered now. ](https://codeql.github.com/codeql-query-help/javascript/js-redos/#example)