### PR TITLE
C++: Fix result duplication on `DefaultTaintTracking`

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -1642,6 +1642,10 @@ predicate localInstructionFlow(Instruction e1, Instruction e2) {
 
 /**
  * INTERNAL: Do not use.
+ *
+ * Ideally this module would be private, but the `asExprInternal` predicate is
+ * needed in `DefaultTaintTrackingImpl`. Once `DefaultTaintTrackingImpl` is gone
+ * we can make this module private again.
  */
 cached
 module ExprFlowCached {

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -1640,8 +1640,11 @@ predicate localInstructionFlow(Instruction e1, Instruction e2) {
   localFlow(instructionNode(e1), instructionNode(e2))
 }
 
+/**
+ * INTERNAL: Do not use.
+ */
 cached
-private module ExprFlowCached {
+module ExprFlowCached {
   /**
    * Holds if `n` is an indirect operand of a `PointerArithmeticInstruction`, and
    * `e` is the result of loading from the `PointerArithmeticInstruction`.
@@ -1692,7 +1695,8 @@ private module ExprFlowCached {
    * `x[i]` steps to the expression `x[i - 1]` without traversing the
    * entire chain.
    */
-  private Expr asExpr(Node n) {
+  cached
+  Expr asExprInternal(Node n) {
     isIndirectBaseOfArrayAccess(n, result)
     or
     not isIndirectBaseOfArrayAccess(n, _) and
@@ -1704,7 +1708,7 @@ private module ExprFlowCached {
    * dataflow step.
    */
   private predicate localStepFromNonExpr(Node n1, Node n2) {
-    not exists(asExpr(n1)) and
+    not exists(asExprInternal(n1)) and
     localFlowStep(n1, n2)
   }
 
@@ -1715,7 +1719,7 @@ private module ExprFlowCached {
   pragma[nomagic]
   private predicate localStepsToExpr(Node n1, Node n2, Expr e2) {
     localStepFromNonExpr*(n1, n2) and
-    e2 = asExpr(n2)
+    e2 = asExprInternal(n2)
   }
 
   /**
@@ -1726,7 +1730,7 @@ private module ExprFlowCached {
     exists(Node mid |
       localFlowStep(n1, mid) and
       localStepsToExpr(mid, n2, e2) and
-      e1 = asExpr(n1)
+      e1 = asExprInternal(n1)
     )
   }
 

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -1645,7 +1645,7 @@ predicate localInstructionFlow(Instruction e1, Instruction e2) {
  *
  * Ideally this module would be private, but the `asExprInternal` predicate is
  * needed in `DefaultTaintTrackingImpl`. Once `DefaultTaintTrackingImpl` is gone
- * we can make this module private again.
+ * we can make this module private.
  */
 cached
 module ExprFlowCached {

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DefaultTaintTrackingImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DefaultTaintTrackingImpl.qll
@@ -60,7 +60,7 @@ private DataFlow::Node getNodeForSource(Expr source) {
 }
 
 private DataFlow::Node getNodeForExpr(Expr node) {
-  result = DataFlow::exprNode(node)
+  node = DataFlow::ExprFlowCached::asExprInternal(result)
   or
   // Some of the sources in `isUserInput` are intended to match the value of
   // an expression, while others (those modeled below) are intended to match
@@ -221,7 +221,7 @@ private module Cached {
   predicate nodeIsBarrierIn(DataFlow::Node node) {
     // don't use dataflow into taint sources, as this leads to duplicate results.
     exists(Expr source | isUserInput(source, _) |
-      node = DataFlow::exprNode(source)
+      source = DataFlow::ExprFlowCached::asExprInternal(node)
       or
       // This case goes together with the similar (but not identical) rule in
       // `getNodeForSource`.


### PR DESCRIPTION
The internal `asExpr(Node)` predicate found in the `ExprFlowCached` module is used as a more generous version of `Node.asExpr` that's used to ensure good performance on large sequences of array access operations (see https://github.com/github/codeql/pull/12507 for a slightly longer explanation of this).

However, it turns out we have another place where we do a lot of `Expr` to `Expr` flow: Namely in `DefaultTaintTracking` 😭. So this PR uses this more generous `asExpr` predicate in `DefaultTaintTracking` to make sure that we don't generate many duplicated results on every use of an array access whose base is `argv`.