### PR TITLE
Ruby/Python: add meta-queries for calls to summarised callables

### DIFF
--- a/python/ql/src/meta/analysis-quality/SummarizedCallableCallSites.ql
+++ b/python/ql/src/meta/analysis-quality/SummarizedCallableCallSites.ql
@@ -1,0 +1,24 @@
+/**
+ * @name Summarized callable call sites
+ * @description A call site for which we have a summarized callable
+ * @kind problem
+ * @problem.severity recommendation
+ * @id py/meta/summarized-callable-call-sites
+ * @tags meta
+ * @precision very-low
+ */
+
+import python
+import semmle.python.dataflow.new.DataFlow
+import semmle.python.dataflow.new.FlowSummary
+import meta.MetaMetrics
+
+from DataFlow::Node useSite, SummarizedCallable target, string kind
+where
+  (
+    useSite = target.getACall() and kind = "Call"
+    or
+    useSite = target.getACallback() and kind = "Callback"
+  ) and
+  not useSite.getLocation().getFile() instanceof IgnoredFile
+select useSite, kind + " to " + target

--- a/ruby/ql/src/queries/meta/SummarizedCallableCallSites.ql
+++ b/ruby/ql/src/queries/meta/SummarizedCallableCallSites.ql
@@ -1,0 +1,16 @@
+/**
+ * @name Summarized callable call sites
+ * @description A call site for which we have a summarized callable
+ * @kind problem
+ * @problem.severity recommendation
+ * @id rb/meta/summarized-callable-call-sites
+ * @tags meta
+ * @precision very-low
+ */
+
+import codeql.ruby.AST
+import codeql.ruby.dataflow.FlowSummary
+
+from Call invoke, SummarizedCallable f
+where f.getACall() = invoke or f.getACallSimple() = invoke
+select invoke, "Call to " + f


### PR DESCRIPTION
Adds meta-queries which are similar to `CallGraph.ql`, except they show calls to `SummarizedCallable`.