### PR TITLE
Java: Fix performance issue in the stub generator

### DIFF
--- a/java/ql/src/utils/stub-generator/Stubs.qll
+++ b/java/ql/src/utils/stub-generator/Stubs.qll
@@ -285,14 +285,19 @@ private string stubQualifier(RefType t) {
     else result = ""
 }
 
+pragma[nomagic]
+private predicate needsPackageNameHelper(RefType t, GeneratedTopLevel top, string name) {
+  t.getSourceDeclaration() = [getAReferencedType(top), top].getSourceDeclaration() and
+  name = t.getName()
+}
+
 /**
  * Holds if `t` may clash with another type of the same name, so should be referred to using the fully qualified name
  */
 private predicate needsPackageName(RefType t) {
-  exists(GeneratedTopLevel top, RefType other |
-    t.getSourceDeclaration() = [getAReferencedType(top), top].getSourceDeclaration() and
-    other.getSourceDeclaration() = [getAReferencedType(top), top].getSourceDeclaration() and
-    t.getName() = other.getName() and
+  exists(GeneratedTopLevel top, RefType other, string name |
+    needsPackageNameHelper(t, top, name) and
+    needsPackageNameHelper(other, top, name) and
     t != other
   )
 }


### PR DESCRIPTION
Forces a two-way join on `getSourceDeclaration` and `getName` in `Stubs::needsPackageName`. Credits to @hvitved for the solution.

Before (canceled):

```
[2023-05-26 11:23:21] (30s) Tuple counts for Stubs#f198c315::needsPackageName#1#f/1@0b34bd5o after 24.4s:
                      500       ~0%          {3} r1 = JOIN Type#6144c3fd::RefType::getSourceDeclaration#0#dispred#ff WITH Element#c53922e0::Element::hasName#1#dispred#ff ON FIRST 1 OUTPUT Lhs.1, Lhs.0 't', Rhs.1
                      1346068   ~4%          {3} r2 = JOIN r1 WITH Type#6144c3fd::RefType::getSourceDeclaration#0#dispred#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1 't', Lhs.2
                      
                      0         ~0%          {3} r3 = JOIN r2 WITH Stubs#f198c315::GeneratedTopLevel#f ON FIRST 1 OUTPUT Lhs.0, Lhs.1 't', Lhs.2
                      
                      13922     ~157%        {3} r4 = JOIN r2 WITH Stubs#f198c315::getAReferencedType#1#bf_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1 't', Lhs.2
                      6910      ~67%         {3} r5 = JOIN r4 WITH Stubs#f198c315::GeneratedTopLevel#f ON FIRST 1 OUTPUT Lhs.0, Lhs.1 't', Lhs.2
                      
                      6910      ~67%         {3} r6 = r3 UNION r5
                      5942      ~45%         {3} r7 = JOIN r6 WITH Stubs#f198c315::GeneratedTopLevel#f ON FIRST 1 OUTPUT Lhs.0, Lhs.1 't', Lhs.2
                      
                      773546    ~100%        {3} r8 = JOIN r7 WITH Stubs#f198c315::getAReferencedType#1#bf ON FIRST 1 OUTPUT Rhs.1, Lhs.1 't', Lhs.2
                      
                      778744    ~101%        {3} r9 = r7 UNION r8
                      767704    ~332%        {3} r10 = JOIN r9 WITH Type#6144c3fd::RefType::getSourceDeclaration#0#dispred#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.1 't', Lhs.2
                      331367594 ~1532%       {3} r11 = JOIN r10 WITH Type#6144c3fd::RefType::getSourceDeclaration#0#dispred#ff_10#join_rhs ON FIRST 1 OUTPUT Lhs.1 't', Lhs.2, Rhs.1
                      331358632 ~1535%       {3} r12 = SELECT r11 ON In.0 't' != In.2
                      331358632 ~1654%       {3} r13 = SCAN r12 OUTPUT In.2, In.1, In.0 't'
                      255959    ~129199%     {1} r14 = JOIN r13 WITH Element#c53922e0::Element::hasName#1#dispred#ff ON FIRST 2 OUTPUT Lhs.2 't'
                                             return r14
```

After:

```
[2023-05-26 12:04:15] (9s) Tuple counts for Stubs#f198c315::needsPackageNameHelper#3#fff/3@de488e5i after 9.1s:
                      112757    ~0%       {3} r1 = JOIN Type#6144c3fd::RefType::getSourceDeclaration#0#dispred#ff WITH Element#c53922e0::Element::hasName#1#dispred#ff ON FIRST 1 OUTPUT Lhs.1, Lhs.0 't', Rhs.1 'name'
                      437133995 ~4%       {3} r2 = JOIN r1 WITH Type#6144c3fd::RefType::getSourceDeclaration#0#dispred#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1 'top', Lhs.1 't', Lhs.2 'name'
                      
                      102929    ~5%       {3} r3 = JOIN r2 WITH Stubs#f198c315::GeneratedTopLevel#f ON FIRST 1 OUTPUT Lhs.1 't', Lhs.0 'top', Lhs.2 'name'
                      
                      12709047  ~353%     {3} r4 = JOIN r2 WITH Stubs#f198c315::getAReferencedType#1#bf_10#join_rhs ON FIRST 1 OUTPUT Rhs.1 'top', Lhs.1 't', Lhs.2 'name'
                      4910018   ~125%     {3} r5 = JOIN r4 WITH Stubs#f198c315::GeneratedTopLevel#f ON FIRST 1 OUTPUT Lhs.1 't', Lhs.0 'top', Lhs.2 'name'
                      
                      5012947   ~128%     {3} r6 = r3 UNION r5
                                          return r6
[2023-05-26 12:04:15] (9s)  >>> Created relation Stubs#f198c315::needsPackageNameHelper#3#fff/3@de488e5i with 2318221 rows and digest addf757e5gar4d39p7su745f349.
[2023-05-26 12:04:15] (9s) Starting to evaluate predicate Stubs#f198c315::needsPackageNameHelper#3#fff_120#join_rhs/3@37718fhl
[2023-05-26 12:04:15] (9s) Tuple counts for Stubs#f198c315::needsPackageNameHelper#3#fff_120#join_rhs/3@37718fhl after 424ms:
                      2318221 ~4%     {3} r1 = SCAN Stubs#f198c315::needsPackageNameHelper#3#fff OUTPUT In.1 'arg0', In.2 'arg1', In.0 'arg2'
                                      return r1
[2023-05-26 12:04:15] (9s)  >>> Created relation Stubs#f198c315::needsPackageNameHelper#3#fff_120#join_rhs/3@37718fhl with 2318221 rows and digest e4e42f7t1rdr1eu94oth68ljrf6.
[2023-05-26 12:04:15] (9s) Starting to evaluate predicate Stubs#f198c315::needsPackageName#1#f/1@2229376k
[2023-05-26 12:04:42] (36s) Tuple counts for Stubs#f198c315::needsPackageName#1#f/1@2229376k after 26.5s:
                      444069243 ~4174%       {2} r1 = JOIN Stubs#f198c315::needsPackageNameHelper#3#fff_120#join_rhs WITH Stubs#f198c315::needsPackageNameHelper#3#fff_120#join_rhs ON FIRST 2 OUTPUT Lhs.2 't', Rhs.2 't'
                      441751022 ~4188%       {2} r2 = SELECT r1 ON In.0 't' != In.1
                      441751022 ~417845%     {1} r3 = SCAN r2 OUTPUT In.0 't'
                                             return r3
```

(Apparently there's still room for improvement)