### PR TITLE
C++: Fix join in `pointerArithOverflow0`

### DIFF
--- a/cpp/ql/src/experimental/Security/CWE/CWE-193/ConstantSizeArrayOffByOne.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-193/ConstantSizeArrayOffByOne.ql
@@ -78,11 +78,16 @@ predicate isInvalidPointerDerefSink2(DataFlow::Node sink, Instruction i, string 
   )
 }
 
+pragma[nomagic]
+predicate arrayTypeHasSizes(ArrayType arr, int baseTypeSize, int arraySize) {
+  arr.getBaseType().getSize() = baseTypeSize and
+  arr.getArraySize() = arraySize
+}
+
 predicate pointerArithOverflow0(
   PointerArithmeticInstruction pai, Field f, int size, int bound, int delta
 ) {
-  pai.getElementSize() = f.getUnspecifiedType().(ArrayType).getBaseType().getSize() and
-  f.getUnspecifiedType().(ArrayType).getArraySize() = size and
+  arrayTypeHasSizes(f.getUnspecifiedType(), pai.getElementSize(), size) and
   semBounded(getSemanticExpr(pai.getRight()), any(SemZeroBound b), bound, true, _) and
   delta = bound - size and
   delta >= 0 and


### PR DESCRIPTION
Before:
```ql
Tuple counts for ConstantSizeArrayOffByOne#f6a3dbf4::pointerArithOverflow0#5#fffff/5@e762307m after 1m48s:
  96500      ~0%     {2} r1 = JOIN project#RangeAnalysisImpl#edd69a76::Public::semBounded#5#fffbf_102#join_rhs WITH num#Bound#63ed7326::TBoundZero#f ON FIRST 1 OUTPUT Lhs.1, f2i(Lhs.2)
  99000      ~1%     {2} r2 = JOIN r1 WITH EquivalenceRelation#Instruction#577b6a83::Instruction#SemanticExprSpecific#ad5ae873::SemanticExprConfig::idOrSafeConversion#::getEquivalenceClass#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1 'bound'
  16500      ~0%     {2} r3 = JOIN r2 WITH Instruction#577b6a83::BinaryInstruction::getRight#0#dispred#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1 'pai', Lhs.1 'bound'
  16000      ~0%     {3} r4 = JOIN r3 WITH Instruction#577b6a83::PointerArithmeticInstruction#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.1 'bound', Lhs.0 'pai'
  7823143631 ~0%     {3} r5 = JOIN r4 WITH Type#2e8eb3ef::Type::getSize#0#dispred#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1 'bound', Lhs.2 'pai'
  1757646574 ~0%     {3} r6 = JOIN r5 WITH Type#2e8eb3ef::DerivedType::getBaseType#0#dispred#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1 'bound', Lhs.2 'pai'
  8337607    ~0%     {3} r7 = JOIN r6 WITH Type#2e8eb3ef::ArrayType#f ON FIRST 1 OUTPUT Lhs.0, Lhs.1 'bound', Lhs.2 'pai'
  3155094    ~0%     {3} r8 = JOIN r7 WITH Variable#7a968d4e::Variable::getUnspecifiedType#0#dispred#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1 'f', Lhs.1 'bound', Lhs.2 'pai'
  2814813    ~0%     {3} r9 = JOIN r8 WITH Field#1b3cf47e::Field#f ON FIRST 1 OUTPUT Lhs.0 'f', Lhs.1 'bound', Lhs.2 'pai'
  2814374    ~0%     {4} r10 = JOIN r9 WITH Variable#7a968d4e::Variable::getUnspecifiedType#0#dispred#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.1 'bound', Lhs.2 'pai', Lhs.0 'f'
  2775803    ~0%     {4} r11 = JOIN r10 WITH Type#2e8eb3ef::ArrayType::getArraySize#0#dispred#ff ON FIRST 1 OUTPUT Lhs.1 'bound', Lhs.2 'pai', Lhs.3 'f', Rhs.1 'size'
  2772891    ~0%     {4} r12 = SELECT r11 ON In.3 'size' != 0
  2462619    ~1%     {4} r13 = SELECT r12 ON In.3 'size' != 1
  2462619    ~0%     {5} r14 = SCAN r13 OUTPUT In.0 'bound', In.1 'pai', In.2 'f', In.3 'size', (In.0 'bound' - In.3 'size')
  1486289    ~1%     {5} r15 = SELECT r14 ON In.4 'delta' >= 0
  1486289    ~0%     {5} r16 = SCAN r15 OUTPUT In.1 'pai', In.2 'f', In.3 'size', In.0 'bound', In.4 'delta'
                      return r16
```
(I cancelled the query midway.)

After:
```ql
  530146   ~3%     {2} r1 = JOIN project#RangeAnalysisImpl#edd69a76::Public::semBounded#5#fffbf_102#join_rhs WITH num#Bound#63ed7326::TBoundZero#f ON FIRST 1 OUTPUT Lhs.1, f2i(Lhs.2)
  534066   ~0%     {2} r2 = JOIN r1 WITH EquivalenceRelation#Instruction#577b6a83::Instruction#SemanticExprSpecific#ad5ae873::SemanticExprConfig::idOrSafeConversion#::getEquivalenceClass#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1 'bound'
  113625   ~0%     {2} r3 = JOIN r2 WITH Instruction#577b6a83::BinaryInstruction::getRight#0#dispred#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1 'pai', Lhs.1 'bound'
  41856    ~0%     {3} r4 = JOIN r3 WITH Instruction#577b6a83::PointerArithmeticInstruction#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.1 'bound', Lhs.0 'pai'
  27153609 ~0%     {4} r5 = JOIN r4 WITH ConstantSizeArrayOffByOne#f6a3dbf4::arrayTypeHasSizes#3#fff_102#join_rhs ON FIRST 1 OUTPUT Lhs.1 'bound', Lhs.2 'pai', Rhs.1, Rhs.2 'size'
  27140083 ~0%     {4} r6 = SELECT r5 ON In.3 'size' != 0
  26232029 ~0%     {4} r7 = SELECT r6 ON In.3 'size' != 1
  26232029 ~0%     {4} r8 = SCAN r7 OUTPUT In.2, In.0 'bound', In.1 'pai', In.3 'size'
  9164471  ~0%     {4} r9 = JOIN r8 WITH Variable#7a968d4e::Variable::getUnspecifiedType#0#dispred#fb_10#join_rhs ON FIRST 1 OUTPUT Rhs.1 'f', Lhs.1 'bound', Lhs.2 'pai', Lhs.3 'size'
  8594602  ~7%     {5} r10 = JOIN r9 WITH Field#1b3cf47e::Field#f ON FIRST 1 OUTPUT Lhs.1 'bound', Lhs.2 'pai', Lhs.3 'size', Lhs.0 'f', (Lhs.1 'bound' - Lhs.3 'size')
  4306662  ~5%     {5} r11 = SELECT r10 ON In.4 'delta' >= 0
  4306662  ~0%     {5} r12 = SCAN r11 OUTPUT In.1 'pai', In.3 'f', In.2 'size', In.0 'bound', In.4 'delta'
                   return r12
```