### PR TITLE
Fix `addsTo.pack` references

### DIFF
--- a/java/ql/lib/ext/org.apache.hc.core5.http.impl.bootstrap.model.yml
+++ b/java/ql/lib/ext/org.apache.hc.core5.http.impl.bootstrap.model.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
-      pack: codeql/java-tests
+      pack: codeql/java-all
       extensible: sinkModel
     data:
       - ["org.apache.hc.core5.http.impl.bootstrap", "HttpAsyncRequester", True, "connect", "(HttpHost,Timeout)", "", "Argument[0]", "open-url", "hq-manual"]

--- a/java/ql/src/utils/flowtestcasegenerator/GenerateFlowTestCase.py
+++ b/java/ql/src/utils/flowtestcasegenerator/GenerateFlowTestCase.py
@@ -18,7 +18,7 @@ GenerateFlowTestCase.py specsToTest projectPom.xml outdir [--force]
 This generates test cases exercising function model specifications found in specsToTest
 producing files Test.java, test.ql, test.ext.yml and test.expected in outdir.
 
-specsToTest should either be a .csv file, a .yml file, or a directory of .yml files, containing the 
+specsToTest should either be a .csv file, a .yml file, or a directory of .yml files, containing the
 model specifications to test.
 
 projectPom.xml should be a Maven pom sufficient to resolve the classes named in specsToTest.csv.
@@ -276,7 +276,7 @@ if len(supportModelRows) != 0:
                            modelSpecRow[0].strip() for modelSpecRow in supportModelRows)
         dataextensions = f"""extensions:
   - addsTo:
-      pack: codeql/java-tests
+      pack: codeql/java-all
       extensible: summaryModel
     data:
 {models}

--- a/java/ql/test/ext/TestModels/test.ext.yml
+++ b/java/ql/test/ext/TestModels/test.ext.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
-      pack: codeql/java-tests
+      pack: codeql/java-all
       extensible: summaryModel
     data:
       - ["generatedtest", "Test", False, "newWithMapValueDefault", "(Object)", "", "Argument[0]", "ReturnValue.MapValue", "value", "manual"]

--- a/java/ql/test/kotlin/library-tests/dataflow/notnullexpr/test.ext.yml
+++ b/java/ql/test/kotlin/library-tests/dataflow/notnullexpr/test.ext.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
-      pack: codeql/java-tests
+      pack: codeql/java-all
       extensible: summaryModel
     data:
       - ["", "Uri", False, "getQueryParameter", "", "", "Argument[this]", "ReturnValue", "taint", "manual"]

--- a/java/ql/test/kotlin/library-tests/dataflow/whenexpr/test.ext.yml
+++ b/java/ql/test/kotlin/library-tests/dataflow/whenexpr/test.ext.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
-      pack: codeql/java-tests
+      pack: codeql/java-all
       extensible: summaryModel
     data:
       - ["", "Uri", False, "getQueryParameter", "", "", "Argument[this]", "ReturnValue", "taint", "manual"]

--- a/java/ql/test/library-tests/dataflow/callback-dispatch/test.ext.yml
+++ b/java/ql/test/library-tests/dataflow/callback-dispatch/test.ext.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
-      pack: codeql/java-tests
+      pack: codeql/java-all
       extensible: summaryModel
     data:
       - ["my.callback.qltest", "A", False, "applyConsumer1", "(Object,Consumer1)", "", "Argument[0]", "Argument[1].Parameter[0]", "value", "manual"]
@@ -15,4 +15,3 @@ extensions:
       - ["my.callback.qltest", "A", False, "produceConsume", "(Producer1,Consumer3)", "", "Argument[1].Parameter[0]", "ReturnValue", "value", "manual"]
       - ["my.callback.qltest", "A", False, "applyConverter1", "(Object,Converter1)", "", "Argument[0]", "Argument[1].Parameter[0]", "value", "manual"]
       - ["my.callback.qltest", "A", False, "applyConverter1", "(Object,Converter1)", "", "Argument[1].ReturnValue", "ReturnValue", "value", "manual"]
-

--- a/java/ql/test/library-tests/dataflow/collections/containerflow.ext.yml
+++ b/java/ql/test/library-tests/dataflow/collections/containerflow.ext.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
-      pack: codeql/java-tests
+      pack: codeql/java-all
       extensible: summaryModel
     data:
       - ["", "B", False, "readElement", "(Spliterator)", "", "Argument[0].Element", "ReturnValue", "value", "manual"]

--- a/java/ql/test/library-tests/dataflow/external-models/sinks.ext.yml
+++ b/java/ql/test/library-tests/dataflow/external-models/sinks.ext.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
-      pack: codeql/java-tests
+      pack: codeql/java-all
       extensible: sinkModel
     data:
       - ["my.qltest", "B", False, "sink1", "(Object)", "", "Argument[0]", "qltest", "manual"]

--- a/java/ql/test/library-tests/dataflow/external-models/srcs.ext.yml
+++ b/java/ql/test/library-tests/dataflow/external-models/srcs.ext.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
-      pack: codeql/java-tests
+      pack: codeql/java-all
       extensible: sourceModel
     data:
       - ["my.qltest", "A", False, "src1", "()", "", "ReturnValue", "qltest", "manual"]

--- a/java/ql/test/library-tests/dataflow/external-models/steps.ext.yml
+++ b/java/ql/test/library-tests/dataflow/external-models/steps.ext.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
-      pack: codeql/java-tests
+      pack: codeql/java-all
       extensible: summaryModel
     data:
       - ["my.qltest", "C", False, "stepArgRes", "(Object)", "", "Argument[0]", "ReturnValue", "taint", "manual"]

--- a/java/ql/test/library-tests/dataflow/synth-global/test.ext.yml
+++ b/java/ql/test/library-tests/dataflow/synth-global/test.ext.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
-      pack: codeql/java-tests
+      pack: codeql/java-all
       extensible: summaryModel
     data:
       - ["my.qltest.synth", "A", False, "storeInArray", "(String)", "", "Argument[0]", "SyntheticGlobal[db1].ArrayElement", "value", "manual"]

--- a/java/ql/test/library-tests/frameworks/android/content-provider-summaries/test.ext.yml
+++ b/java/ql/test/library-tests/frameworks/android/content-provider-summaries/test.ext.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
-      pack: codeql/java-tests
+      pack: codeql/java-all
       extensible: summaryModel
     data:
       - ["generatedtest", "Test", False, "newWithMapValueDefault", "(Object)", "", "Argument[0]", "ReturnValue.MapValue", "value", "manual"]

--- a/java/ql/test/library-tests/frameworks/android/intent/test.ext.yml
+++ b/java/ql/test/library-tests/frameworks/android/intent/test.ext.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
-      pack: codeql/java-tests
+      pack: codeql/java-all
       extensible: summaryModel
     data:
       - ["generatedtest", "Test", False, "newBundleWithMapValue", "(Object)", "", "Argument[0]", "ReturnValue.MapValue", "value", "manual"]

--- a/java/ql/test/library-tests/frameworks/android/notification/test.ext.yml
+++ b/java/ql/test/library-tests/frameworks/android/notification/test.ext.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
-      pack: codeql/java-tests
+      pack: codeql/java-all
       extensible: summaryModel
     data:
       - ["generatedtest", "Test", False, "getMapKeyDefault", "(Bundle)", "", "Argument[0].MapKey", "ReturnValue", "value", "manual"]

--- a/java/ql/test/library-tests/frameworks/apache-collections/test.ext.yml
+++ b/java/ql/test/library-tests/frameworks/apache-collections/test.ext.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
-      pack: codeql/java-tests
+      pack: codeql/java-all
       extensible: summaryModel
     data:
       - ["generatedtest", "Test", False, "newRBWithMapValue", "", "", "Argument[0]", "ReturnValue.MapValue", "value", "manual"]

--- a/java/ql/test/library-tests/frameworks/apache-http/flow.ext.yml
+++ b/java/ql/test/library-tests/frameworks/apache-http/flow.ext.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
-      pack: codeql/java-tests
+      pack: codeql/java-all
       extensible: summaryModel
     data:
       - ["generatedtest", "Client", False, "getURIBuilder_pathDefault", "(Object)", "", "Argument[0].SyntheticField[org.apache.http.client.utils.URIBuilder.path]", "ReturnValue", "taint", "manual"]

--- a/java/ql/test/library-tests/frameworks/guava/generated/collect/test.ext.yml
+++ b/java/ql/test/library-tests/frameworks/guava/generated/collect/test.ext.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
-      pack: codeql/java-tests
+      pack: codeql/java-all
       extensible: summaryModel
     data:
       - ["generatedtest", "Test", False, "newWithElementDefault", "(Object)", "", "Argument[0]", "ReturnValue.Element", "value", "manual"]

--- a/java/ql/test/library-tests/frameworks/jdk/java.io/test.ext.yml
+++ b/java/ql/test/library-tests/frameworks/jdk/java.io/test.ext.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
-      pack: codeql/java-tests
+      pack: codeql/java-all
       extensible: summaryModel
     data:
       - ["generatedtest", "Test", False, "getThrowable_messageDefault", "(Object)", "", "Argument[0].SyntheticField[java.lang.Throwable.message]", "ReturnValue", "value", "manual"]

--- a/java/ql/test/library-tests/frameworks/netty/generated/test.ext.yml
+++ b/java/ql/test/library-tests/frameworks/netty/generated/test.ext.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
-      pack: codeql/java-tests
+      pack: codeql/java-all
       extensible: summaryModel
     data:
       - ["generatedtest", "Test", False, "newWithMapValueDefault", "(Object)", "", "Argument[0]", "ReturnValue.MapValue", "value", "manual"]

--- a/java/ql/test/library-tests/frameworks/stream/test.ext.yml
+++ b/java/ql/test/library-tests/frameworks/stream/test.ext.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
-      pack: codeql/java-tests
+      pack: codeql/java-all
       extensible: summaryModel
     data:
       - ["generatedtest", "Test", False, "getElementSpliterator", "(Spliterator)", "", "Argument[0].Element", "ReturnValue", "value", "manual"]

--- a/java/ql/test/library-tests/optional/test.ext.yml
+++ b/java/ql/test/library-tests/optional/test.ext.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
-      pack: codeql/java-tests
+      pack: codeql/java-all
       extensible: summaryModel
     data:
       - ["generatedtest", "Test", False, "getStreamElement", "", "", "Argument[0].Element", "ReturnValue", "value", "manual"]


### PR DESCRIPTION
This change is a prerequisite for a CLI change where there will be strict testing of the `addsTo.pack` values. It must resolve to a pack reference that is a transitive dependency of the current query's pack.