### PR TITLE
C++: Exclude `StdNamespace` sources in `cpp/constant-size-array-off-by-one`

### DIFF
--- a/cpp/ql/src/experimental/Security/CWE/CWE-193/ConstantSizeArrayOffByOne.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-193/ConstantSizeArrayOffByOne.ql
@@ -87,6 +87,7 @@ predicate arrayTypeHasSizes(ArrayType arr, int baseTypeSize, int arraySize) {
 predicate pointerArithOverflow0(
   PointerArithmeticInstruction pai, Field f, int size, int bound, int delta
 ) {
+  not f.getNamespace() instanceof StdNamespace and
   arrayTypeHasSizes(f.getUnspecifiedType(), pai.getElementSize(), size) and
   semBounded(getSemanticExpr(pai.getRight()), any(SemZeroBound b), bound, true, _) and
   delta = bound - size and


### PR DESCRIPTION
Various containers in the standard library apply the small string optimization, and we can't currently reason about the path conditions that makes it clear that these accesses are safe. So for now we decided to just exclude them from the query to reduce the number of results.