### PR TITLE
C++: Use the shortestDistances HOP to count indirections (rebased copy of #13323)

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternalsCommon.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternalsCommon.qll
@@ -139,6 +139,20 @@ class AllocationInstruction extends CallInstruction {
   AllocationInstruction() { this.getStaticCallTarget() instanceof Cpp::AllocationFunction }
 }
 
+private predicate isIndirectionType(Type t) { t instanceof Indirection }
+
+private predicate hasUnspecifiedBaseType(Indirection t, Type base) {
+  base = t.getBaseType().getUnspecifiedType()
+}
+
+/**
+ * Holds if `t2` is the same type as `t1`, but after stripping away `result` number
+ * of indirections.
+ * Furthermore, specifies in `t2` been deeply stripped and typedefs has been resolved.
+ */
+private int getNumberOfIndirectionsImpl(Type t1, Type t2) =
+  shortestDistances(isIndirectionType/1, hasUnspecifiedBaseType/2)(t1, t2, result)
+
 /**
  * An abstract class for handling indirections.
  *
@@ -157,7 +171,10 @@ abstract class Indirection extends Type {
    * For example, the number of indirections of a variable `p` of type
    * `int**` is `3` (i.e., `p`, `*p` and `**p`).
    */
-  abstract int getNumberOfIndirections();
+  final int getNumberOfIndirections() {
+    result =
+      getNumberOfIndirectionsImpl(this.getType(), any(Type end | not end instanceof Indirection))
+  }
 
   /**
    * Holds if `deref` is an instruction that behaves as a `LoadInstruction`
@@ -195,18 +212,10 @@ private class PointerOrArrayOrReferenceTypeIndirection extends Indirection insta
   PointerOrArrayOrReferenceTypeIndirection() {
     baseType = PointerOrArrayOrReferenceType.super.getBaseType()
   }
-
-  override int getNumberOfIndirections() {
-    result = 1 + countIndirections(this.getBaseType().getUnspecifiedType())
-  }
 }
 
 private class PointerWrapperTypeIndirection extends Indirection instanceof PointerWrapper {
   PointerWrapperTypeIndirection() { baseType = PointerWrapper.super.getBaseType() }
-
-  override int getNumberOfIndirections() {
-    result = 1 + countIndirections(this.getBaseType().getUnspecifiedType())
-  }
 
   override predicate isAdditionalDereference(Instruction deref, Operand address) {
     exists(CallInstruction call |
@@ -226,10 +235,6 @@ private module IteratorIndirections {
     IteratorIndirection() {
       not this instanceof PointerOrArrayOrReferenceTypeIndirection and
       baseType = super.getValueType()
-    }
-
-    override int getNumberOfIndirections() {
-      result = 1 + countIndirections(this.getBaseType().getUnspecifiedType())
     }
 
     override predicate isAdditionalDereference(Instruction deref, Operand address) {


### PR DESCRIPTION
This PR is a copy of #13323, rebased on the 2.12.7 branch.

For a given type, we count the number of indirect dataflow nodes a value of a given type needs by counting how many indirections exist on the type (i.e., `int` has 0 indirections, `int*` and `int&` has 1, etc.). However, if a malformed type exists in the database (i.e., an indirect type `t` such that `t.getBaseType() = t`) then the predicate that counts indirections goes into an infinite loop.

This PR swaps out the manual recursion with a use of the `shortestDistances` HOP which doesn't suffer from this problem. On normal (i.e., acyclic) types this shouldn't change any behavior, and on a malformed type with cycles this won't cause infinite recursion. That is, if there is a non-cyclic path all the way to the base type this path will be found (and the length will be used as the number of indirections), and if there isn't a path all the way to the base type, then the type won't have any indirections. Missing indirect dataflow nodes likely means losing dataflow results, but given that this only happens on malformed types I'm not too concerned about this. It's certainly better than being stuck in an infinite loop 😄.

@MathiasVP 