### PR TITLE
Java: Fix GsonDeserializableField

### DIFF
--- a/java/ql/lib/semmle/code/java/frameworks/google/GsonSerializability.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/google/GsonSerializability.qll
@@ -50,8 +50,7 @@ private class GsonDeserializableField extends DeserializableField {
     exists(GsonDeserializableType superType |
       superType = this.getDeclaringType().getAnAncestor() and
       not superType instanceof TypeObject and
-      //superType.fromSource()
-      not superType.(RefType).getPackage().getName().matches("java%")
+      superType.fromSource()
     )
   }
 }


### PR DESCRIPTION
Small fix of https://github.com/github/codeql/pull/13179 after discussion with @pwntester.

Excluding the JDK seemed arbitrary, and adding the `fromSource` restriction is more consistent with the other `DeserializableField`s. 