### PR TITLE
C++: Make Macro.getName() more efficient.

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/Macro.qll
+++ b/cpp/ql/lib/semmle/code/cpp/Macro.qll
@@ -34,7 +34,7 @@ class Macro extends PreprocessorDirective, @ppd_define {
    * Gets the name of the macro.  For example, `MAX` in
    * `#define MAX(x,y) (((x)>(y))?(x):(y))`.
    */
-  string getName() { result = this.getHead().splitAt("(", 0) }
+  string getName() { result = this.getHead().regexpCapture("([^(]*+).*", 1) }
 
   /** Holds if the macro has name `name`. */
   predicate hasName(string name) { this.getName() = name }


### PR DESCRIPTION
Make `Macro.getName()` more efficient.  Inspired by @MathiasVP s comment [here](https://github.com/github/codeql/pull/13190#discussion_r1210637896).  Macro names get a lot of use in CPP, so I'll do a DCA run to be sure this is safe.