### PR TITLE
Revert #13207

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/IRBlock.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/IRBlock.qll
@@ -255,28 +255,14 @@ private module Cached {
   cached
   newtype TIRBlock = MkIRBlock(Instruction firstInstr) { startsBasicBlock(firstInstr) }
 
-  /** Gets the index of `i` in its `IRBlock`. */
-  private int getMemberIndex(Instruction i) {
-    startsBasicBlock(i) and
-    result = 0
-    or
-    exists(Instruction iPrev |
-      adjacentInBlock(iPrev, i) and
-      result = getMemberIndex(iPrev) + 1
-    )
-  }
-
-  private module BlockAdjacency = QlBuiltins::EquivalenceRelation<Instruction, adjacentInBlock/2>;
+  /** Holds if `i` is the `index`th instruction the block starting with `first`. */
+  private Instruction getInstructionFromFirst(Instruction first, int index) =
+    shortestDistances(startsBasicBlock/1, adjacentInBlock/2)(first, result, index)
 
   /** Holds if `i` is the `index`th instruction in `block`. */
   cached
   Instruction getInstruction(TIRBlock block, int index) {
-    exists(Instruction first | block = MkIRBlock(first) |
-      first = result and index = 0
-      or
-      index = getMemberIndex(result) and
-      BlockAdjacency::getEquivalenceClass(first) = BlockAdjacency::getEquivalenceClass(result)
-    )
+    result = getInstructionFromFirst(getFirstInstruction(block), index)
   }
 
   cached

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/IRBlock.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/IRBlock.qll
@@ -255,28 +255,14 @@ private module Cached {
   cached
   newtype TIRBlock = MkIRBlock(Instruction firstInstr) { startsBasicBlock(firstInstr) }
 
-  /** Gets the index of `i` in its `IRBlock`. */
-  private int getMemberIndex(Instruction i) {
-    startsBasicBlock(i) and
-    result = 0
-    or
-    exists(Instruction iPrev |
-      adjacentInBlock(iPrev, i) and
-      result = getMemberIndex(iPrev) + 1
-    )
-  }
-
-  private module BlockAdjacency = QlBuiltins::EquivalenceRelation<Instruction, adjacentInBlock/2>;
+  /** Holds if `i` is the `index`th instruction the block starting with `first`. */
+  private Instruction getInstructionFromFirst(Instruction first, int index) =
+    shortestDistances(startsBasicBlock/1, adjacentInBlock/2)(first, result, index)
 
   /** Holds if `i` is the `index`th instruction in `block`. */
   cached
   Instruction getInstruction(TIRBlock block, int index) {
-    exists(Instruction first | block = MkIRBlock(first) |
-      first = result and index = 0
-      or
-      index = getMemberIndex(result) and
-      BlockAdjacency::getEquivalenceClass(first) = BlockAdjacency::getEquivalenceClass(result)
-    )
+    result = getInstructionFromFirst(getFirstInstruction(block), index)
   }
 
   cached

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/IRBlock.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/IRBlock.qll
@@ -255,28 +255,14 @@ private module Cached {
   cached
   newtype TIRBlock = MkIRBlock(Instruction firstInstr) { startsBasicBlock(firstInstr) }
 
-  /** Gets the index of `i` in its `IRBlock`. */
-  private int getMemberIndex(Instruction i) {
-    startsBasicBlock(i) and
-    result = 0
-    or
-    exists(Instruction iPrev |
-      adjacentInBlock(iPrev, i) and
-      result = getMemberIndex(iPrev) + 1
-    )
-  }
-
-  private module BlockAdjacency = QlBuiltins::EquivalenceRelation<Instruction, adjacentInBlock/2>;
+  /** Holds if `i` is the `index`th instruction the block starting with `first`. */
+  private Instruction getInstructionFromFirst(Instruction first, int index) =
+    shortestDistances(startsBasicBlock/1, adjacentInBlock/2)(first, result, index)
 
   /** Holds if `i` is the `index`th instruction in `block`. */
   cached
   Instruction getInstruction(TIRBlock block, int index) {
-    exists(Instruction first | block = MkIRBlock(first) |
-      first = result and index = 0
-      or
-      index = getMemberIndex(result) and
-      BlockAdjacency::getEquivalenceClass(first) = BlockAdjacency::getEquivalenceClass(result)
-    )
+    result = getInstructionFromFirst(getFirstInstruction(block), index)
   }
 
   cached

--- a/csharp/ql/src/experimental/ir/implementation/raw/IRBlock.qll
+++ b/csharp/ql/src/experimental/ir/implementation/raw/IRBlock.qll
@@ -255,28 +255,14 @@ private module Cached {
   cached
   newtype TIRBlock = MkIRBlock(Instruction firstInstr) { startsBasicBlock(firstInstr) }
 
-  /** Gets the index of `i` in its `IRBlock`. */
-  private int getMemberIndex(Instruction i) {
-    startsBasicBlock(i) and
-    result = 0
-    or
-    exists(Instruction iPrev |
-      adjacentInBlock(iPrev, i) and
-      result = getMemberIndex(iPrev) + 1
-    )
-  }
-
-  private module BlockAdjacency = QlBuiltins::EquivalenceRelation<Instruction, adjacentInBlock/2>;
+  /** Holds if `i` is the `index`th instruction the block starting with `first`. */
+  private Instruction getInstructionFromFirst(Instruction first, int index) =
+    shortestDistances(startsBasicBlock/1, adjacentInBlock/2)(first, result, index)
 
   /** Holds if `i` is the `index`th instruction in `block`. */
   cached
   Instruction getInstruction(TIRBlock block, int index) {
-    exists(Instruction first | block = MkIRBlock(first) |
-      first = result and index = 0
-      or
-      index = getMemberIndex(result) and
-      BlockAdjacency::getEquivalenceClass(first) = BlockAdjacency::getEquivalenceClass(result)
-    )
+    result = getInstructionFromFirst(getFirstInstruction(block), index)
   }
 
   cached

--- a/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/IRBlock.qll
+++ b/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/IRBlock.qll
@@ -255,28 +255,14 @@ private module Cached {
   cached
   newtype TIRBlock = MkIRBlock(Instruction firstInstr) { startsBasicBlock(firstInstr) }
 
-  /** Gets the index of `i` in its `IRBlock`. */
-  private int getMemberIndex(Instruction i) {
-    startsBasicBlock(i) and
-    result = 0
-    or
-    exists(Instruction iPrev |
-      adjacentInBlock(iPrev, i) and
-      result = getMemberIndex(iPrev) + 1
-    )
-  }
-
-  private module BlockAdjacency = QlBuiltins::EquivalenceRelation<Instruction, adjacentInBlock/2>;
+  /** Holds if `i` is the `index`th instruction the block starting with `first`. */
+  private Instruction getInstructionFromFirst(Instruction first, int index) =
+    shortestDistances(startsBasicBlock/1, adjacentInBlock/2)(first, result, index)
 
   /** Holds if `i` is the `index`th instruction in `block`. */
   cached
   Instruction getInstruction(TIRBlock block, int index) {
-    exists(Instruction first | block = MkIRBlock(first) |
-      first = result and index = 0
-      or
-      index = getMemberIndex(result) and
-      BlockAdjacency::getEquivalenceClass(first) = BlockAdjacency::getEquivalenceClass(result)
-    )
+    result = getInstructionFromFirst(getFirstInstruction(block), index)
   }
 
   cached


### PR DESCRIPTION
https://github.com/github/codeql/pull/13207 was merged to solve an OOM problem the Foundations team was encountering in their benchmark tests, but we fixed it by bumping the RAM setting on their end. And it seems like this PR is causing more trouble than it solves since the `getMemberIndex` predicate is simply too slow on https://github.com/github/codeql/blob/main/cpp/ql/test/query-tests/Likely%20Bugs/Format/NonConstantFormat/performance.c (which contains basic block with many many many instructions).