### PR TITLE
Java: Make `SafeSnakeYamlConstruction` also find custom extensions of `SafeConstructor`

### DIFF
--- a/java/ql/lib/semmle/code/java/frameworks/SnakeYaml.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/SnakeYaml.qll
@@ -18,7 +18,10 @@ class SnakeYamlSafeConstructor extends RefType {
  * An instance of `SafeConstructor`.
  */
 class SafeSnakeYamlConstruction extends ClassInstanceExpr {
-  SafeSnakeYamlConstruction() { this.getConstructedType() instanceof SnakeYamlSafeConstructor }
+  SafeSnakeYamlConstruction() {
+    this.getConstructedType() instanceof SnakeYamlSafeConstructor or
+    this.getConstructedType().extendsOrImplements(any(SnakeYamlSafeConstructor s))
+  }
 }
 
 /**


### PR DESCRIPTION
This small PR makes `java/unsafe-deserialization` to not flag situations in which the parser provided to `Yaml` is a custom parser being extended from `SafeConstructor`.

eg:

```java
public static <T> T loadAs(String content, Class<T> type) {
    return new Yaml(new CustomSafeConstructor()).loadAs(content, type);
}

public static class CustomSafeConstructor extends SafeConstructor {
    ...
}
```