### PR TITLE
JS: stop recursive fromRhs related to getLaterBaseAccess

### DIFF
--- a/javascript/ql/lib/semmle/javascript/GlobalAccessPaths.qll
+++ b/javascript/ql/lib/semmle/javascript/GlobalAccessPaths.qll
@@ -234,7 +234,8 @@ module AccessPath {
       or
       baseName = fromRhs(write.getBase(), root)
       or
-      baseName = fromRhs(GetLaterAccess::getLaterBaseAccess(write), root)
+      baseName = fromRhs(GetLaterAccess::getLaterBaseAccess(write), root) and
+      not baseName.matches("%.%")
     )
     or
     exists(GlobalVariable var |

--- a/javascript/ql/test/library-tests/GlobalAccessPaths/stress.js
+++ b/javascript/ql/test/library-tests/GlobalAccessPaths/stress.js
@@ -1,0 +1,33 @@
+
+// stress test for global access path computation
+var MyObject = {}
+MyObject.Foo1 = { inner: MyObject };
+MyObject.Foo2 = { inner: MyObject };
+MyObject.Foo3 = { inner: MyObject };
+MyObject.Foo4 = { inner: MyObject };
+MyObject.Foo5 = { inner: MyObject };
+MyObject.Foo6 = { inner: MyObject };
+MyObject.Foo7 = { inner: MyObject };
+MyObject.Foo8 = { inner: MyObject };
+MyObject.Foo9 = { inner: MyObject };
+MyObject.Fooa = { inner: MyObject };
+MyObject.Foob = { inner: MyObject };
+MyObject.Fooc = { inner: MyObject };
+MyObject.Food = { inner: MyObject };
+MyObject.Fooe = { inner: MyObject };
+MyObject.Foof = { inner: MyObject };
+MyObject.Foog = { inner: MyObject };
+MyObject.Fooh = { inner: MyObject };
+MyObject.Fooi = { inner: MyObject };
+MyObject.Fooj = { inner: MyObject };
+MyObject.Fook = { inner: MyObject };
+MyObject.Fool = { inner: MyObject };
+MyObject.Foom = { inner: MyObject };
+MyObject.Foon = { inner: MyObject };
+MyObject.Fooo = { inner: MyObject };
+MyObject.Foop = { inner: MyObject };
+MyObject.Fooq = { inner: MyObject };
+MyObject.Foor = { inner: MyObject };
+MyObject.Foos = { inner: MyObject };
+MyObject.Foot = { inner: MyObject };
+exports.MyObject = MyObject;


### PR DESCRIPTION
Fixes an internally reported performance issue (see backref).  