### PR TITLE
C++: Ensure that the sink instruction occurs last in `cpp/invalid-pointer-deref`

### DIFF
--- a/cpp/ql/src/experimental/Security/CWE/CWE-193/InvalidPointerDeref.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-193/InvalidPointerDeref.ql
@@ -208,8 +208,7 @@ predicate isInvalidPointerDerefSink(DataFlow::Node sink, Instruction i, string o
     s = sink.asInstruction() and
     bounded1(addr.getDef(), s, delta) and
     delta >= 0 and
-    i.getAnOperand() = addr and
-    i = getASuccessor(s)
+    i.getAnOperand() = addr
   |
     i instanceof StoreInstruction and
     operation = "write"
@@ -267,7 +266,8 @@ newtype TMergedPathNode =
   TPathNodeSink(Instruction i) {
     exists(DataFlow::Node n |
       InvalidPointerToDerefFlow::flowTo(n) and
-      isInvalidPointerDerefSink(n, i, _, _)
+      isInvalidPointerDerefSink(n, i, _, _) and
+      i = getASuccessor(n.asInstruction())
     )
   }
 

--- a/cpp/ql/src/experimental/Security/CWE/CWE-193/InvalidPointerDeref.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-193/InvalidPointerDeref.ql
@@ -182,6 +182,8 @@ predicate isSinkImpl(
 /**
  * Yields any instruction that is control-flow reachable from `instr`.
  */
+bindingset[instr, result]
+pragma[inline_late]
 Instruction getASuccessor(Instruction instr) {
   exists(IRBlock b, int instrIndex, int resultIndex |
     result.getBlock() = b and
@@ -202,11 +204,12 @@ Instruction getASuccessor(Instruction instr) {
  */
 pragma[inline]
 predicate isInvalidPointerDerefSink(DataFlow::Node sink, Instruction i, string operation, int delta) {
-  exists(AddressOperand addr |
-    bounded1(addr.getDef(), sink.asInstruction(), delta) and
+  exists(AddressOperand addr, Instruction s |
+    s = sink.asInstruction() and
+    bounded1(addr.getDef(), s, delta) and
     delta >= 0 and
     i.getAnOperand() = addr and
-    i = getASuccessor(sink.asInstruction())
+    i = getASuccessor(s)
   |
     i instanceof StoreInstruction and
     operation = "write"

--- a/cpp/ql/src/experimental/Security/CWE/CWE-193/InvalidPointerDeref.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-193/InvalidPointerDeref.ql
@@ -180,6 +180,22 @@ predicate isSinkImpl(
 }
 
 /**
+ * Yields any instruction that is control-flow reachable from `instr`.
+ */
+Instruction getASuccessor(Instruction instr) {
+  exists(IRBlock b, int instrIndex, int resultIndex |
+    result.getBlock() = b and
+    instr.getBlock() = b and
+    b.getInstruction(instrIndex) = instr and
+    b.getInstruction(resultIndex) = result
+  |
+    resultIndex >= instrIndex
+  )
+  or
+  instr.getBlock().getASuccessor+() = result.getBlock()
+}
+
+/**
  * Holds if `sink` is a sink for `InvalidPointerToDerefConfig` and `i` is a `StoreInstruction` that
  * writes to an address that non-strictly upper-bounds `sink`, or `i` is a `LoadInstruction` that
  * reads from an address that non-strictly upper-bounds `sink`.
@@ -189,7 +205,8 @@ predicate isInvalidPointerDerefSink(DataFlow::Node sink, Instruction i, string o
   exists(AddressOperand addr |
     bounded1(addr.getDef(), sink.asInstruction(), delta) and
     delta >= 0 and
-    i.getAnOperand() = addr
+    i.getAnOperand() = addr and
+    i = getASuccessor(sink.asInstruction())
   |
     i instanceof StoreInstruction and
     operation = "write"

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/InvalidPointerDeref.expected
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/InvalidPointerDeref.expected
@@ -9,15 +9,7 @@ edges
 | test.cpp:5:15:5:15 | p | test.cpp:7:16:7:16 | q |
 | test.cpp:5:15:5:15 | p | test.cpp:7:16:7:16 | q |
 | test.cpp:5:15:5:15 | p | test.cpp:8:16:8:16 | q |
-| test.cpp:5:15:5:15 | p | test.cpp:8:16:8:16 | q |
 | test.cpp:5:15:5:15 | p | test.cpp:8:16:8:20 | ... + ... |
-| test.cpp:5:15:5:15 | p | test.cpp:9:16:9:16 | q |
-| test.cpp:5:15:5:15 | p | test.cpp:9:16:9:16 | q |
-| test.cpp:5:15:5:15 | p | test.cpp:10:16:10:16 | q |
-| test.cpp:5:15:5:15 | p | test.cpp:10:16:10:16 | q |
-| test.cpp:5:15:5:15 | p | test.cpp:11:16:11:16 | q |
-| test.cpp:5:15:5:15 | p | test.cpp:11:16:11:16 | q |
-| test.cpp:5:15:5:15 | p | test.cpp:12:16:12:16 | q |
 | test.cpp:5:15:5:22 | ... + ... | test.cpp:5:15:5:22 | ... + ... |
 | test.cpp:5:15:5:22 | ... + ... | test.cpp:5:15:5:22 | ... + ... |
 | test.cpp:5:15:5:22 | ... + ... | test.cpp:6:14:6:15 | Load: * ... |
@@ -38,22 +30,6 @@ edges
 | test.cpp:5:15:5:22 | ... + ... | test.cpp:8:14:8:21 | Load: * ... |
 | test.cpp:5:15:5:22 | ... + ... | test.cpp:8:16:8:16 | q |
 | test.cpp:5:15:5:22 | ... + ... | test.cpp:8:16:8:16 | q |
-| test.cpp:5:15:5:22 | ... + ... | test.cpp:8:16:8:16 | q |
-| test.cpp:5:15:5:22 | ... + ... | test.cpp:8:16:8:16 | q |
-| test.cpp:5:15:5:22 | ... + ... | test.cpp:9:16:9:16 | q |
-| test.cpp:5:15:5:22 | ... + ... | test.cpp:9:16:9:16 | q |
-| test.cpp:5:15:5:22 | ... + ... | test.cpp:9:16:9:16 | q |
-| test.cpp:5:15:5:22 | ... + ... | test.cpp:9:16:9:16 | q |
-| test.cpp:5:15:5:22 | ... + ... | test.cpp:10:16:10:16 | q |
-| test.cpp:5:15:5:22 | ... + ... | test.cpp:10:16:10:16 | q |
-| test.cpp:5:15:5:22 | ... + ... | test.cpp:10:16:10:16 | q |
-| test.cpp:5:15:5:22 | ... + ... | test.cpp:10:16:10:16 | q |
-| test.cpp:5:15:5:22 | ... + ... | test.cpp:11:16:11:16 | q |
-| test.cpp:5:15:5:22 | ... + ... | test.cpp:11:16:11:16 | q |
-| test.cpp:5:15:5:22 | ... + ... | test.cpp:11:16:11:16 | q |
-| test.cpp:5:15:5:22 | ... + ... | test.cpp:11:16:11:16 | q |
-| test.cpp:5:15:5:22 | ... + ... | test.cpp:12:16:12:16 | q |
-| test.cpp:5:15:5:22 | ... + ... | test.cpp:12:16:12:16 | q |
 | test.cpp:6:15:6:15 | q | test.cpp:6:14:6:15 | Load: * ... |
 | test.cpp:6:15:6:15 | q | test.cpp:6:14:6:15 | Load: * ... |
 | test.cpp:6:15:6:15 | q | test.cpp:7:16:7:16 | q |
@@ -61,62 +37,11 @@ edges
 | test.cpp:6:15:6:15 | q | test.cpp:8:14:8:21 | Load: * ... |
 | test.cpp:6:15:6:15 | q | test.cpp:8:14:8:21 | Load: * ... |
 | test.cpp:6:15:6:15 | q | test.cpp:8:16:8:16 | q |
-| test.cpp:6:15:6:15 | q | test.cpp:8:16:8:16 | q |
-| test.cpp:6:15:6:15 | q | test.cpp:9:16:9:16 | q |
-| test.cpp:6:15:6:15 | q | test.cpp:9:16:9:16 | q |
-| test.cpp:6:15:6:15 | q | test.cpp:10:16:10:16 | q |
-| test.cpp:6:15:6:15 | q | test.cpp:10:16:10:16 | q |
-| test.cpp:6:15:6:15 | q | test.cpp:11:16:11:16 | q |
-| test.cpp:6:15:6:15 | q | test.cpp:11:16:11:16 | q |
-| test.cpp:6:15:6:15 | q | test.cpp:12:16:12:16 | q |
-| test.cpp:7:16:7:16 | q | test.cpp:6:14:6:15 | Load: * ... |
-| test.cpp:7:16:7:16 | q | test.cpp:6:14:6:15 | Load: * ... |
 | test.cpp:7:16:7:16 | q | test.cpp:8:14:8:21 | Load: * ... |
 | test.cpp:7:16:7:16 | q | test.cpp:8:14:8:21 | Load: * ... |
 | test.cpp:7:16:7:16 | q | test.cpp:8:16:8:16 | q |
-| test.cpp:7:16:7:16 | q | test.cpp:8:16:8:16 | q |
-| test.cpp:7:16:7:16 | q | test.cpp:9:16:9:16 | q |
-| test.cpp:7:16:7:16 | q | test.cpp:9:16:9:16 | q |
-| test.cpp:7:16:7:16 | q | test.cpp:10:16:10:16 | q |
-| test.cpp:7:16:7:16 | q | test.cpp:10:16:10:16 | q |
-| test.cpp:7:16:7:16 | q | test.cpp:11:16:11:16 | q |
-| test.cpp:7:16:7:16 | q | test.cpp:11:16:11:16 | q |
-| test.cpp:7:16:7:16 | q | test.cpp:12:16:12:16 | q |
-| test.cpp:8:16:8:16 | q | test.cpp:6:14:6:15 | Load: * ... |
-| test.cpp:8:16:8:16 | q | test.cpp:6:14:6:15 | Load: * ... |
 | test.cpp:8:16:8:16 | q | test.cpp:8:14:8:21 | Load: * ... |
-| test.cpp:8:16:8:16 | q | test.cpp:8:14:8:21 | Load: * ... |
-| test.cpp:8:16:8:16 | q | test.cpp:9:16:9:16 | q |
-| test.cpp:8:16:8:16 | q | test.cpp:9:16:9:16 | q |
-| test.cpp:8:16:8:16 | q | test.cpp:10:16:10:16 | q |
-| test.cpp:8:16:8:16 | q | test.cpp:10:16:10:16 | q |
-| test.cpp:8:16:8:16 | q | test.cpp:11:16:11:16 | q |
-| test.cpp:8:16:8:16 | q | test.cpp:11:16:11:16 | q |
-| test.cpp:8:16:8:16 | q | test.cpp:12:16:12:16 | q |
 | test.cpp:8:16:8:20 | ... + ... | test.cpp:8:14:8:21 | Load: * ... |
-| test.cpp:9:16:9:16 | q | test.cpp:6:14:6:15 | Load: * ... |
-| test.cpp:9:16:9:16 | q | test.cpp:6:14:6:15 | Load: * ... |
-| test.cpp:9:16:9:16 | q | test.cpp:8:14:8:21 | Load: * ... |
-| test.cpp:9:16:9:16 | q | test.cpp:8:14:8:21 | Load: * ... |
-| test.cpp:9:16:9:16 | q | test.cpp:10:16:10:16 | q |
-| test.cpp:9:16:9:16 | q | test.cpp:10:16:10:16 | q |
-| test.cpp:9:16:9:16 | q | test.cpp:11:16:11:16 | q |
-| test.cpp:9:16:9:16 | q | test.cpp:11:16:11:16 | q |
-| test.cpp:9:16:9:16 | q | test.cpp:12:16:12:16 | q |
-| test.cpp:10:16:10:16 | q | test.cpp:6:14:6:15 | Load: * ... |
-| test.cpp:10:16:10:16 | q | test.cpp:6:14:6:15 | Load: * ... |
-| test.cpp:10:16:10:16 | q | test.cpp:8:14:8:21 | Load: * ... |
-| test.cpp:10:16:10:16 | q | test.cpp:8:14:8:21 | Load: * ... |
-| test.cpp:10:16:10:16 | q | test.cpp:11:16:11:16 | q |
-| test.cpp:10:16:10:16 | q | test.cpp:11:16:11:16 | q |
-| test.cpp:10:16:10:16 | q | test.cpp:12:16:12:16 | q |
-| test.cpp:11:16:11:16 | q | test.cpp:6:14:6:15 | Load: * ... |
-| test.cpp:11:16:11:16 | q | test.cpp:6:14:6:15 | Load: * ... |
-| test.cpp:11:16:11:16 | q | test.cpp:8:14:8:21 | Load: * ... |
-| test.cpp:11:16:11:16 | q | test.cpp:8:14:8:21 | Load: * ... |
-| test.cpp:11:16:11:16 | q | test.cpp:12:16:12:16 | q |
-| test.cpp:12:16:12:16 | q | test.cpp:6:14:6:15 | Load: * ... |
-| test.cpp:12:16:12:16 | q | test.cpp:8:14:8:21 | Load: * ... |
 | test.cpp:16:15:16:20 | call to malloc | test.cpp:17:15:17:15 | p |
 | test.cpp:17:15:17:15 | p | test.cpp:17:15:17:22 | ... + ... |
 | test.cpp:17:15:17:15 | p | test.cpp:20:16:20:20 | ... + ... |
@@ -132,15 +57,7 @@ edges
 | test.cpp:29:15:29:15 | p | test.cpp:31:16:31:16 | q |
 | test.cpp:29:15:29:15 | p | test.cpp:31:16:31:16 | q |
 | test.cpp:29:15:29:15 | p | test.cpp:32:16:32:16 | q |
-| test.cpp:29:15:29:15 | p | test.cpp:32:16:32:16 | q |
 | test.cpp:29:15:29:15 | p | test.cpp:32:16:32:20 | ... + ... |
-| test.cpp:29:15:29:15 | p | test.cpp:33:16:33:16 | q |
-| test.cpp:29:15:29:15 | p | test.cpp:33:16:33:16 | q |
-| test.cpp:29:15:29:15 | p | test.cpp:34:16:34:16 | q |
-| test.cpp:29:15:29:15 | p | test.cpp:34:16:34:16 | q |
-| test.cpp:29:15:29:15 | p | test.cpp:35:16:35:16 | q |
-| test.cpp:29:15:29:15 | p | test.cpp:35:16:35:16 | q |
-| test.cpp:29:15:29:15 | p | test.cpp:36:16:36:16 | q |
 | test.cpp:29:15:29:28 | ... + ... | test.cpp:29:15:29:28 | ... + ... |
 | test.cpp:29:15:29:28 | ... + ... | test.cpp:29:15:29:28 | ... + ... |
 | test.cpp:29:15:29:28 | ... + ... | test.cpp:30:14:30:15 | Load: * ... |
@@ -161,22 +78,6 @@ edges
 | test.cpp:29:15:29:28 | ... + ... | test.cpp:32:14:32:21 | Load: * ... |
 | test.cpp:29:15:29:28 | ... + ... | test.cpp:32:16:32:16 | q |
 | test.cpp:29:15:29:28 | ... + ... | test.cpp:32:16:32:16 | q |
-| test.cpp:29:15:29:28 | ... + ... | test.cpp:32:16:32:16 | q |
-| test.cpp:29:15:29:28 | ... + ... | test.cpp:32:16:32:16 | q |
-| test.cpp:29:15:29:28 | ... + ... | test.cpp:33:16:33:16 | q |
-| test.cpp:29:15:29:28 | ... + ... | test.cpp:33:16:33:16 | q |
-| test.cpp:29:15:29:28 | ... + ... | test.cpp:33:16:33:16 | q |
-| test.cpp:29:15:29:28 | ... + ... | test.cpp:33:16:33:16 | q |
-| test.cpp:29:15:29:28 | ... + ... | test.cpp:34:16:34:16 | q |
-| test.cpp:29:15:29:28 | ... + ... | test.cpp:34:16:34:16 | q |
-| test.cpp:29:15:29:28 | ... + ... | test.cpp:34:16:34:16 | q |
-| test.cpp:29:15:29:28 | ... + ... | test.cpp:34:16:34:16 | q |
-| test.cpp:29:15:29:28 | ... + ... | test.cpp:35:16:35:16 | q |
-| test.cpp:29:15:29:28 | ... + ... | test.cpp:35:16:35:16 | q |
-| test.cpp:29:15:29:28 | ... + ... | test.cpp:35:16:35:16 | q |
-| test.cpp:29:15:29:28 | ... + ... | test.cpp:35:16:35:16 | q |
-| test.cpp:29:15:29:28 | ... + ... | test.cpp:36:16:36:16 | q |
-| test.cpp:29:15:29:28 | ... + ... | test.cpp:36:16:36:16 | q |
 | test.cpp:30:15:30:15 | q | test.cpp:30:14:30:15 | Load: * ... |
 | test.cpp:30:15:30:15 | q | test.cpp:30:14:30:15 | Load: * ... |
 | test.cpp:30:15:30:15 | q | test.cpp:31:16:31:16 | q |
@@ -184,62 +85,11 @@ edges
 | test.cpp:30:15:30:15 | q | test.cpp:32:14:32:21 | Load: * ... |
 | test.cpp:30:15:30:15 | q | test.cpp:32:14:32:21 | Load: * ... |
 | test.cpp:30:15:30:15 | q | test.cpp:32:16:32:16 | q |
-| test.cpp:30:15:30:15 | q | test.cpp:32:16:32:16 | q |
-| test.cpp:30:15:30:15 | q | test.cpp:33:16:33:16 | q |
-| test.cpp:30:15:30:15 | q | test.cpp:33:16:33:16 | q |
-| test.cpp:30:15:30:15 | q | test.cpp:34:16:34:16 | q |
-| test.cpp:30:15:30:15 | q | test.cpp:34:16:34:16 | q |
-| test.cpp:30:15:30:15 | q | test.cpp:35:16:35:16 | q |
-| test.cpp:30:15:30:15 | q | test.cpp:35:16:35:16 | q |
-| test.cpp:30:15:30:15 | q | test.cpp:36:16:36:16 | q |
-| test.cpp:31:16:31:16 | q | test.cpp:30:14:30:15 | Load: * ... |
-| test.cpp:31:16:31:16 | q | test.cpp:30:14:30:15 | Load: * ... |
 | test.cpp:31:16:31:16 | q | test.cpp:32:14:32:21 | Load: * ... |
 | test.cpp:31:16:31:16 | q | test.cpp:32:14:32:21 | Load: * ... |
 | test.cpp:31:16:31:16 | q | test.cpp:32:16:32:16 | q |
-| test.cpp:31:16:31:16 | q | test.cpp:32:16:32:16 | q |
-| test.cpp:31:16:31:16 | q | test.cpp:33:16:33:16 | q |
-| test.cpp:31:16:31:16 | q | test.cpp:33:16:33:16 | q |
-| test.cpp:31:16:31:16 | q | test.cpp:34:16:34:16 | q |
-| test.cpp:31:16:31:16 | q | test.cpp:34:16:34:16 | q |
-| test.cpp:31:16:31:16 | q | test.cpp:35:16:35:16 | q |
-| test.cpp:31:16:31:16 | q | test.cpp:35:16:35:16 | q |
-| test.cpp:31:16:31:16 | q | test.cpp:36:16:36:16 | q |
-| test.cpp:32:16:32:16 | q | test.cpp:30:14:30:15 | Load: * ... |
-| test.cpp:32:16:32:16 | q | test.cpp:30:14:30:15 | Load: * ... |
 | test.cpp:32:16:32:16 | q | test.cpp:32:14:32:21 | Load: * ... |
-| test.cpp:32:16:32:16 | q | test.cpp:32:14:32:21 | Load: * ... |
-| test.cpp:32:16:32:16 | q | test.cpp:33:16:33:16 | q |
-| test.cpp:32:16:32:16 | q | test.cpp:33:16:33:16 | q |
-| test.cpp:32:16:32:16 | q | test.cpp:34:16:34:16 | q |
-| test.cpp:32:16:32:16 | q | test.cpp:34:16:34:16 | q |
-| test.cpp:32:16:32:16 | q | test.cpp:35:16:35:16 | q |
-| test.cpp:32:16:32:16 | q | test.cpp:35:16:35:16 | q |
-| test.cpp:32:16:32:16 | q | test.cpp:36:16:36:16 | q |
 | test.cpp:32:16:32:20 | ... + ... | test.cpp:32:14:32:21 | Load: * ... |
-| test.cpp:33:16:33:16 | q | test.cpp:30:14:30:15 | Load: * ... |
-| test.cpp:33:16:33:16 | q | test.cpp:30:14:30:15 | Load: * ... |
-| test.cpp:33:16:33:16 | q | test.cpp:32:14:32:21 | Load: * ... |
-| test.cpp:33:16:33:16 | q | test.cpp:32:14:32:21 | Load: * ... |
-| test.cpp:33:16:33:16 | q | test.cpp:34:16:34:16 | q |
-| test.cpp:33:16:33:16 | q | test.cpp:34:16:34:16 | q |
-| test.cpp:33:16:33:16 | q | test.cpp:35:16:35:16 | q |
-| test.cpp:33:16:33:16 | q | test.cpp:35:16:35:16 | q |
-| test.cpp:33:16:33:16 | q | test.cpp:36:16:36:16 | q |
-| test.cpp:34:16:34:16 | q | test.cpp:30:14:30:15 | Load: * ... |
-| test.cpp:34:16:34:16 | q | test.cpp:30:14:30:15 | Load: * ... |
-| test.cpp:34:16:34:16 | q | test.cpp:32:14:32:21 | Load: * ... |
-| test.cpp:34:16:34:16 | q | test.cpp:32:14:32:21 | Load: * ... |
-| test.cpp:34:16:34:16 | q | test.cpp:35:16:35:16 | q |
-| test.cpp:34:16:34:16 | q | test.cpp:35:16:35:16 | q |
-| test.cpp:34:16:34:16 | q | test.cpp:36:16:36:16 | q |
-| test.cpp:35:16:35:16 | q | test.cpp:30:14:30:15 | Load: * ... |
-| test.cpp:35:16:35:16 | q | test.cpp:30:14:30:15 | Load: * ... |
-| test.cpp:35:16:35:16 | q | test.cpp:32:14:32:21 | Load: * ... |
-| test.cpp:35:16:35:16 | q | test.cpp:32:14:32:21 | Load: * ... |
-| test.cpp:35:16:35:16 | q | test.cpp:36:16:36:16 | q |
-| test.cpp:36:16:36:16 | q | test.cpp:30:14:30:15 | Load: * ... |
-| test.cpp:36:16:36:16 | q | test.cpp:32:14:32:21 | Load: * ... |
 | test.cpp:40:15:40:20 | call to malloc | test.cpp:41:15:41:15 | p |
 | test.cpp:41:15:41:15 | p | test.cpp:41:15:41:28 | ... + ... |
 | test.cpp:41:15:41:15 | p | test.cpp:41:15:41:28 | ... + ... |
@@ -250,15 +100,7 @@ edges
 | test.cpp:41:15:41:15 | p | test.cpp:43:16:43:16 | q |
 | test.cpp:41:15:41:15 | p | test.cpp:43:16:43:16 | q |
 | test.cpp:41:15:41:15 | p | test.cpp:44:16:44:16 | q |
-| test.cpp:41:15:41:15 | p | test.cpp:44:16:44:16 | q |
 | test.cpp:41:15:41:15 | p | test.cpp:44:16:44:20 | ... + ... |
-| test.cpp:41:15:41:15 | p | test.cpp:45:16:45:16 | q |
-| test.cpp:41:15:41:15 | p | test.cpp:45:16:45:16 | q |
-| test.cpp:41:15:41:15 | p | test.cpp:46:16:46:16 | q |
-| test.cpp:41:15:41:15 | p | test.cpp:46:16:46:16 | q |
-| test.cpp:41:15:41:15 | p | test.cpp:47:16:47:16 | q |
-| test.cpp:41:15:41:15 | p | test.cpp:47:16:47:16 | q |
-| test.cpp:41:15:41:15 | p | test.cpp:48:16:48:16 | q |
 | test.cpp:41:15:41:28 | ... + ... | test.cpp:41:15:41:28 | ... + ... |
 | test.cpp:41:15:41:28 | ... + ... | test.cpp:41:15:41:28 | ... + ... |
 | test.cpp:41:15:41:28 | ... + ... | test.cpp:42:14:42:15 | Load: * ... |
@@ -279,22 +121,6 @@ edges
 | test.cpp:41:15:41:28 | ... + ... | test.cpp:44:14:44:21 | Load: * ... |
 | test.cpp:41:15:41:28 | ... + ... | test.cpp:44:16:44:16 | q |
 | test.cpp:41:15:41:28 | ... + ... | test.cpp:44:16:44:16 | q |
-| test.cpp:41:15:41:28 | ... + ... | test.cpp:44:16:44:16 | q |
-| test.cpp:41:15:41:28 | ... + ... | test.cpp:44:16:44:16 | q |
-| test.cpp:41:15:41:28 | ... + ... | test.cpp:45:16:45:16 | q |
-| test.cpp:41:15:41:28 | ... + ... | test.cpp:45:16:45:16 | q |
-| test.cpp:41:15:41:28 | ... + ... | test.cpp:45:16:45:16 | q |
-| test.cpp:41:15:41:28 | ... + ... | test.cpp:45:16:45:16 | q |
-| test.cpp:41:15:41:28 | ... + ... | test.cpp:46:16:46:16 | q |
-| test.cpp:41:15:41:28 | ... + ... | test.cpp:46:16:46:16 | q |
-| test.cpp:41:15:41:28 | ... + ... | test.cpp:46:16:46:16 | q |
-| test.cpp:41:15:41:28 | ... + ... | test.cpp:46:16:46:16 | q |
-| test.cpp:41:15:41:28 | ... + ... | test.cpp:47:16:47:16 | q |
-| test.cpp:41:15:41:28 | ... + ... | test.cpp:47:16:47:16 | q |
-| test.cpp:41:15:41:28 | ... + ... | test.cpp:47:16:47:16 | q |
-| test.cpp:41:15:41:28 | ... + ... | test.cpp:47:16:47:16 | q |
-| test.cpp:41:15:41:28 | ... + ... | test.cpp:48:16:48:16 | q |
-| test.cpp:41:15:41:28 | ... + ... | test.cpp:48:16:48:16 | q |
 | test.cpp:42:15:42:15 | q | test.cpp:42:14:42:15 | Load: * ... |
 | test.cpp:42:15:42:15 | q | test.cpp:42:14:42:15 | Load: * ... |
 | test.cpp:42:15:42:15 | q | test.cpp:43:16:43:16 | q |
@@ -302,62 +128,11 @@ edges
 | test.cpp:42:15:42:15 | q | test.cpp:44:14:44:21 | Load: * ... |
 | test.cpp:42:15:42:15 | q | test.cpp:44:14:44:21 | Load: * ... |
 | test.cpp:42:15:42:15 | q | test.cpp:44:16:44:16 | q |
-| test.cpp:42:15:42:15 | q | test.cpp:44:16:44:16 | q |
-| test.cpp:42:15:42:15 | q | test.cpp:45:16:45:16 | q |
-| test.cpp:42:15:42:15 | q | test.cpp:45:16:45:16 | q |
-| test.cpp:42:15:42:15 | q | test.cpp:46:16:46:16 | q |
-| test.cpp:42:15:42:15 | q | test.cpp:46:16:46:16 | q |
-| test.cpp:42:15:42:15 | q | test.cpp:47:16:47:16 | q |
-| test.cpp:42:15:42:15 | q | test.cpp:47:16:47:16 | q |
-| test.cpp:42:15:42:15 | q | test.cpp:48:16:48:16 | q |
-| test.cpp:43:16:43:16 | q | test.cpp:42:14:42:15 | Load: * ... |
-| test.cpp:43:16:43:16 | q | test.cpp:42:14:42:15 | Load: * ... |
 | test.cpp:43:16:43:16 | q | test.cpp:44:14:44:21 | Load: * ... |
 | test.cpp:43:16:43:16 | q | test.cpp:44:14:44:21 | Load: * ... |
 | test.cpp:43:16:43:16 | q | test.cpp:44:16:44:16 | q |
-| test.cpp:43:16:43:16 | q | test.cpp:44:16:44:16 | q |
-| test.cpp:43:16:43:16 | q | test.cpp:45:16:45:16 | q |
-| test.cpp:43:16:43:16 | q | test.cpp:45:16:45:16 | q |
-| test.cpp:43:16:43:16 | q | test.cpp:46:16:46:16 | q |
-| test.cpp:43:16:43:16 | q | test.cpp:46:16:46:16 | q |
-| test.cpp:43:16:43:16 | q | test.cpp:47:16:47:16 | q |
-| test.cpp:43:16:43:16 | q | test.cpp:47:16:47:16 | q |
-| test.cpp:43:16:43:16 | q | test.cpp:48:16:48:16 | q |
-| test.cpp:44:16:44:16 | q | test.cpp:42:14:42:15 | Load: * ... |
-| test.cpp:44:16:44:16 | q | test.cpp:42:14:42:15 | Load: * ... |
 | test.cpp:44:16:44:16 | q | test.cpp:44:14:44:21 | Load: * ... |
-| test.cpp:44:16:44:16 | q | test.cpp:44:14:44:21 | Load: * ... |
-| test.cpp:44:16:44:16 | q | test.cpp:45:16:45:16 | q |
-| test.cpp:44:16:44:16 | q | test.cpp:45:16:45:16 | q |
-| test.cpp:44:16:44:16 | q | test.cpp:46:16:46:16 | q |
-| test.cpp:44:16:44:16 | q | test.cpp:46:16:46:16 | q |
-| test.cpp:44:16:44:16 | q | test.cpp:47:16:47:16 | q |
-| test.cpp:44:16:44:16 | q | test.cpp:47:16:47:16 | q |
-| test.cpp:44:16:44:16 | q | test.cpp:48:16:48:16 | q |
 | test.cpp:44:16:44:20 | ... + ... | test.cpp:44:14:44:21 | Load: * ... |
-| test.cpp:45:16:45:16 | q | test.cpp:42:14:42:15 | Load: * ... |
-| test.cpp:45:16:45:16 | q | test.cpp:42:14:42:15 | Load: * ... |
-| test.cpp:45:16:45:16 | q | test.cpp:44:14:44:21 | Load: * ... |
-| test.cpp:45:16:45:16 | q | test.cpp:44:14:44:21 | Load: * ... |
-| test.cpp:45:16:45:16 | q | test.cpp:46:16:46:16 | q |
-| test.cpp:45:16:45:16 | q | test.cpp:46:16:46:16 | q |
-| test.cpp:45:16:45:16 | q | test.cpp:47:16:47:16 | q |
-| test.cpp:45:16:45:16 | q | test.cpp:47:16:47:16 | q |
-| test.cpp:45:16:45:16 | q | test.cpp:48:16:48:16 | q |
-| test.cpp:46:16:46:16 | q | test.cpp:42:14:42:15 | Load: * ... |
-| test.cpp:46:16:46:16 | q | test.cpp:42:14:42:15 | Load: * ... |
-| test.cpp:46:16:46:16 | q | test.cpp:44:14:44:21 | Load: * ... |
-| test.cpp:46:16:46:16 | q | test.cpp:44:14:44:21 | Load: * ... |
-| test.cpp:46:16:46:16 | q | test.cpp:47:16:47:16 | q |
-| test.cpp:46:16:46:16 | q | test.cpp:47:16:47:16 | q |
-| test.cpp:46:16:46:16 | q | test.cpp:48:16:48:16 | q |
-| test.cpp:47:16:47:16 | q | test.cpp:42:14:42:15 | Load: * ... |
-| test.cpp:47:16:47:16 | q | test.cpp:42:14:42:15 | Load: * ... |
-| test.cpp:47:16:47:16 | q | test.cpp:44:14:44:21 | Load: * ... |
-| test.cpp:47:16:47:16 | q | test.cpp:44:14:44:21 | Load: * ... |
-| test.cpp:47:16:47:16 | q | test.cpp:48:16:48:16 | q |
-| test.cpp:48:16:48:16 | q | test.cpp:42:14:42:15 | Load: * ... |
-| test.cpp:48:16:48:16 | q | test.cpp:44:14:44:21 | Load: * ... |
 | test.cpp:51:7:51:14 | mk_array indirection | test.cpp:60:19:60:26 | call to mk_array |
 | test.cpp:51:33:51:35 | end | test.cpp:60:34:60:37 | mk_array output argument |
 | test.cpp:52:19:52:24 | call to malloc | test.cpp:51:7:51:14 | mk_array indirection |
@@ -371,10 +146,8 @@ edges
 | test.cpp:60:19:60:26 | call to mk_array | test.cpp:70:38:70:38 | p |
 | test.cpp:60:34:60:37 | mk_array output argument | test.cpp:62:32:62:34 | end |
 | test.cpp:60:34:60:37 | mk_array output argument | test.cpp:66:32:66:34 | end |
-| test.cpp:60:34:60:37 | mk_array output argument | test.cpp:70:31:70:33 | end |
 | test.cpp:62:32:62:34 | end | test.cpp:67:9:67:14 | Store: ... = ... |
 | test.cpp:66:32:66:34 | end | test.cpp:67:9:67:14 | Store: ... = ... |
-| test.cpp:70:31:70:33 | end | test.cpp:67:9:67:14 | Store: ... = ... |
 | test.cpp:80:9:80:16 | mk_array indirection [begin] | test.cpp:89:19:89:26 | call to mk_array [begin] |
 | test.cpp:80:9:80:16 | mk_array indirection [begin] | test.cpp:119:18:119:25 | call to mk_array [begin] |
 | test.cpp:80:9:80:16 | mk_array indirection [end] | test.cpp:89:19:89:26 | call to mk_array [end] |
@@ -395,7 +168,6 @@ edges
 | test.cpp:89:19:89:26 | call to mk_array [begin] | test.cpp:99:20:99:22 | arr indirection [begin] |
 | test.cpp:89:19:89:26 | call to mk_array [end] | test.cpp:91:36:91:38 | arr indirection [end] |
 | test.cpp:89:19:89:26 | call to mk_array [end] | test.cpp:95:36:95:38 | arr indirection [end] |
-| test.cpp:89:19:89:26 | call to mk_array [end] | test.cpp:99:35:99:37 | arr indirection [end] |
 | test.cpp:91:20:91:22 | arr indirection [begin] | test.cpp:91:24:91:28 | begin |
 | test.cpp:91:20:91:22 | arr indirection [begin] | test.cpp:91:24:91:28 | begin indirection |
 | test.cpp:91:24:91:28 | begin | test.cpp:91:47:91:47 | p |
@@ -416,16 +188,11 @@ edges
 | test.cpp:99:20:99:22 | arr indirection [begin] | test.cpp:99:24:99:28 | begin indirection |
 | test.cpp:99:24:99:28 | begin | test.cpp:99:46:99:46 | p |
 | test.cpp:99:24:99:28 | begin indirection | test.cpp:99:46:99:46 | p |
-| test.cpp:99:35:99:37 | arr indirection [end] | test.cpp:99:39:99:41 | end |
-| test.cpp:99:35:99:37 | arr indirection [end] | test.cpp:99:39:99:41 | end indirection |
-| test.cpp:99:39:99:41 | end | test.cpp:96:9:96:14 | Store: ... = ... |
-| test.cpp:99:39:99:41 | end indirection | test.cpp:99:39:99:41 | end |
 | test.cpp:104:27:104:29 | arr [begin] | test.cpp:105:20:105:22 | arr indirection [begin] |
 | test.cpp:104:27:104:29 | arr [begin] | test.cpp:109:20:109:22 | arr indirection [begin] |
 | test.cpp:104:27:104:29 | arr [begin] | test.cpp:113:20:113:22 | arr indirection [begin] |
 | test.cpp:104:27:104:29 | arr [end] | test.cpp:105:36:105:38 | arr indirection [end] |
 | test.cpp:104:27:104:29 | arr [end] | test.cpp:109:36:109:38 | arr indirection [end] |
-| test.cpp:104:27:104:29 | arr [end] | test.cpp:113:35:113:37 | arr indirection [end] |
 | test.cpp:105:20:105:22 | arr indirection [begin] | test.cpp:105:24:105:28 | begin |
 | test.cpp:105:20:105:22 | arr indirection [begin] | test.cpp:105:24:105:28 | begin indirection |
 | test.cpp:105:24:105:28 | begin | test.cpp:105:47:105:47 | p |
@@ -446,10 +213,6 @@ edges
 | test.cpp:113:20:113:22 | arr indirection [begin] | test.cpp:113:24:113:28 | begin indirection |
 | test.cpp:113:24:113:28 | begin | test.cpp:113:46:113:46 | p |
 | test.cpp:113:24:113:28 | begin indirection | test.cpp:113:46:113:46 | p |
-| test.cpp:113:35:113:37 | arr indirection [end] | test.cpp:113:39:113:41 | end |
-| test.cpp:113:35:113:37 | arr indirection [end] | test.cpp:113:39:113:41 | end indirection |
-| test.cpp:113:39:113:41 | end | test.cpp:110:9:110:14 | Store: ... = ... |
-| test.cpp:113:39:113:41 | end indirection | test.cpp:113:39:113:41 | end |
 | test.cpp:119:18:119:25 | call to mk_array [begin] | test.cpp:104:27:104:29 | arr [begin] |
 | test.cpp:119:18:119:25 | call to mk_array [end] | test.cpp:104:27:104:29 | arr [end] |
 | test.cpp:124:15:124:20 | call to malloc | test.cpp:125:5:125:17 | ... = ... |
@@ -504,7 +267,6 @@ edges
 | test.cpp:165:29:165:31 | arr indirection [begin] | test.cpp:174:20:174:22 | arr indirection [begin] |
 | test.cpp:165:29:165:31 | arr indirection [end] | test.cpp:166:37:166:39 | arr indirection [end] |
 | test.cpp:165:29:165:31 | arr indirection [end] | test.cpp:170:37:170:39 | arr indirection [end] |
-| test.cpp:165:29:165:31 | arr indirection [end] | test.cpp:174:36:174:38 | arr indirection [end] |
 | test.cpp:166:20:166:22 | arr indirection [begin] | test.cpp:166:25:166:29 | begin |
 | test.cpp:166:20:166:22 | arr indirection [begin] | test.cpp:166:25:166:29 | begin indirection |
 | test.cpp:166:25:166:29 | begin | test.cpp:166:49:166:49 | p |
@@ -525,10 +287,6 @@ edges
 | test.cpp:174:20:174:22 | arr indirection [begin] | test.cpp:174:25:174:29 | begin indirection |
 | test.cpp:174:25:174:29 | begin | test.cpp:174:48:174:48 | p |
 | test.cpp:174:25:174:29 | begin indirection | test.cpp:174:48:174:48 | p |
-| test.cpp:174:36:174:38 | arr indirection [end] | test.cpp:174:41:174:43 | end |
-| test.cpp:174:36:174:38 | arr indirection [end] | test.cpp:174:41:174:43 | end indirection |
-| test.cpp:174:41:174:43 | end | test.cpp:171:9:171:14 | Store: ... = ... |
-| test.cpp:174:41:174:43 | end indirection | test.cpp:174:41:174:43 | end |
 | test.cpp:180:19:180:28 | call to mk_array_p indirection [begin] | test.cpp:165:29:165:31 | arr indirection [begin] |
 | test.cpp:180:19:180:28 | call to mk_array_p indirection [end] | test.cpp:165:29:165:31 | arr indirection [end] |
 | test.cpp:188:15:188:20 | call to malloc | test.cpp:189:15:189:15 | p |
@@ -655,16 +413,6 @@ edges
 | test.cpp:308:5:308:11 | access to array | test.cpp:308:5:308:29 | Store: ... = ... |
 | test.cpp:313:14:313:27 | new[] | test.cpp:314:15:314:16 | xs |
 | test.cpp:325:14:325:27 | new[] | test.cpp:326:15:326:16 | xs |
-| test.cpp:326:15:326:16 | xs | test.cpp:326:15:326:23 | ... + ... |
-| test.cpp:326:15:326:16 | xs | test.cpp:326:15:326:23 | ... + ... |
-| test.cpp:326:15:326:16 | xs | test.cpp:338:8:338:15 | * ... |
-| test.cpp:326:15:326:16 | xs | test.cpp:341:8:341:17 | * ... |
-| test.cpp:326:15:326:23 | ... + ... | test.cpp:342:8:342:17 | * ... |
-| test.cpp:326:15:326:23 | ... + ... | test.cpp:342:8:342:17 | * ... |
-| test.cpp:338:8:338:15 | * ... | test.cpp:342:8:342:17 | * ... |
-| test.cpp:341:8:341:17 | * ... | test.cpp:342:8:342:17 | * ... |
-| test.cpp:342:8:342:17 | * ... | test.cpp:333:5:333:21 | Store: ... = ... |
-| test.cpp:342:8:342:17 | * ... | test.cpp:341:5:341:21 | Store: ... = ... |
 | test.cpp:347:14:347:27 | new[] | test.cpp:348:15:348:16 | xs |
 | test.cpp:348:15:348:16 | xs | test.cpp:350:16:350:19 | ... ++ |
 | test.cpp:348:15:348:16 | xs | test.cpp:350:16:350:19 | ... ++ |
@@ -720,7 +468,6 @@ edges
 | test.cpp:358:15:358:26 | end_plus_one | test.cpp:359:14:359:32 | Load: * ... |
 | test.cpp:358:15:358:26 | end_plus_one | test.cpp:359:14:359:32 | Load: * ... |
 | test.cpp:358:15:358:26 | end_plus_one | test.cpp:359:16:359:27 | end_plus_one |
-| test.cpp:359:16:359:27 | end_plus_one | test.cpp:358:14:358:26 | Load: * ... |
 | test.cpp:359:16:359:27 | end_plus_one | test.cpp:359:14:359:32 | Load: * ... |
 | test.cpp:359:16:359:31 | ... + ... | test.cpp:359:14:359:32 | Load: * ... |
 | test.cpp:363:14:363:27 | new[] | test.cpp:365:15:365:15 | p |
@@ -746,15 +493,7 @@ nodes
 | test.cpp:7:16:7:16 | q | semmle.label | q |
 | test.cpp:8:14:8:21 | Load: * ... | semmle.label | Load: * ... |
 | test.cpp:8:16:8:16 | q | semmle.label | q |
-| test.cpp:8:16:8:16 | q | semmle.label | q |
 | test.cpp:8:16:8:20 | ... + ... | semmle.label | ... + ... |
-| test.cpp:9:16:9:16 | q | semmle.label | q |
-| test.cpp:9:16:9:16 | q | semmle.label | q |
-| test.cpp:10:16:10:16 | q | semmle.label | q |
-| test.cpp:10:16:10:16 | q | semmle.label | q |
-| test.cpp:11:16:11:16 | q | semmle.label | q |
-| test.cpp:11:16:11:16 | q | semmle.label | q |
-| test.cpp:12:16:12:16 | q | semmle.label | q |
 | test.cpp:16:15:16:20 | call to malloc | semmle.label | call to malloc |
 | test.cpp:17:15:17:15 | p | semmle.label | p |
 | test.cpp:17:15:17:22 | ... + ... | semmle.label | ... + ... |
@@ -773,15 +512,7 @@ nodes
 | test.cpp:31:16:31:16 | q | semmle.label | q |
 | test.cpp:32:14:32:21 | Load: * ... | semmle.label | Load: * ... |
 | test.cpp:32:16:32:16 | q | semmle.label | q |
-| test.cpp:32:16:32:16 | q | semmle.label | q |
 | test.cpp:32:16:32:20 | ... + ... | semmle.label | ... + ... |
-| test.cpp:33:16:33:16 | q | semmle.label | q |
-| test.cpp:33:16:33:16 | q | semmle.label | q |
-| test.cpp:34:16:34:16 | q | semmle.label | q |
-| test.cpp:34:16:34:16 | q | semmle.label | q |
-| test.cpp:35:16:35:16 | q | semmle.label | q |
-| test.cpp:35:16:35:16 | q | semmle.label | q |
-| test.cpp:36:16:36:16 | q | semmle.label | q |
 | test.cpp:40:15:40:20 | call to malloc | semmle.label | call to malloc |
 | test.cpp:41:15:41:15 | p | semmle.label | p |
 | test.cpp:41:15:41:28 | ... + ... | semmle.label | ... + ... |
@@ -795,15 +526,7 @@ nodes
 | test.cpp:43:16:43:16 | q | semmle.label | q |
 | test.cpp:44:14:44:21 | Load: * ... | semmle.label | Load: * ... |
 | test.cpp:44:16:44:16 | q | semmle.label | q |
-| test.cpp:44:16:44:16 | q | semmle.label | q |
 | test.cpp:44:16:44:20 | ... + ... | semmle.label | ... + ... |
-| test.cpp:45:16:45:16 | q | semmle.label | q |
-| test.cpp:45:16:45:16 | q | semmle.label | q |
-| test.cpp:46:16:46:16 | q | semmle.label | q |
-| test.cpp:46:16:46:16 | q | semmle.label | q |
-| test.cpp:47:16:47:16 | q | semmle.label | q |
-| test.cpp:47:16:47:16 | q | semmle.label | q |
-| test.cpp:48:16:48:16 | q | semmle.label | q |
 | test.cpp:51:7:51:14 | mk_array indirection | semmle.label | mk_array indirection |
 | test.cpp:51:33:51:35 | end | semmle.label | end |
 | test.cpp:52:19:52:24 | call to malloc | semmle.label | call to malloc |
@@ -817,7 +540,6 @@ nodes
 | test.cpp:66:32:66:34 | end | semmle.label | end |
 | test.cpp:66:39:66:39 | p | semmle.label | p |
 | test.cpp:67:9:67:14 | Store: ... = ... | semmle.label | Store: ... = ... |
-| test.cpp:70:31:70:33 | end | semmle.label | end |
 | test.cpp:70:38:70:38 | p | semmle.label | p |
 | test.cpp:80:9:80:16 | mk_array indirection [begin] | semmle.label | mk_array indirection [begin] |
 | test.cpp:80:9:80:16 | mk_array indirection [end] | semmle.label | mk_array indirection [end] |
@@ -850,9 +572,6 @@ nodes
 | test.cpp:99:20:99:22 | arr indirection [begin] | semmle.label | arr indirection [begin] |
 | test.cpp:99:24:99:28 | begin | semmle.label | begin |
 | test.cpp:99:24:99:28 | begin indirection | semmle.label | begin indirection |
-| test.cpp:99:35:99:37 | arr indirection [end] | semmle.label | arr indirection [end] |
-| test.cpp:99:39:99:41 | end | semmle.label | end |
-| test.cpp:99:39:99:41 | end indirection | semmle.label | end indirection |
 | test.cpp:99:46:99:46 | p | semmle.label | p |
 | test.cpp:104:27:104:29 | arr [begin] | semmle.label | arr [begin] |
 | test.cpp:104:27:104:29 | arr [end] | semmle.label | arr [end] |
@@ -874,9 +593,6 @@ nodes
 | test.cpp:113:20:113:22 | arr indirection [begin] | semmle.label | arr indirection [begin] |
 | test.cpp:113:24:113:28 | begin | semmle.label | begin |
 | test.cpp:113:24:113:28 | begin indirection | semmle.label | begin indirection |
-| test.cpp:113:35:113:37 | arr indirection [end] | semmle.label | arr indirection [end] |
-| test.cpp:113:39:113:41 | end | semmle.label | end |
-| test.cpp:113:39:113:41 | end indirection | semmle.label | end indirection |
 | test.cpp:113:46:113:46 | p | semmle.label | p |
 | test.cpp:119:18:119:25 | call to mk_array [begin] | semmle.label | call to mk_array [begin] |
 | test.cpp:119:18:119:25 | call to mk_array [end] | semmle.label | call to mk_array [end] |
@@ -942,9 +658,6 @@ nodes
 | test.cpp:174:20:174:22 | arr indirection [begin] | semmle.label | arr indirection [begin] |
 | test.cpp:174:25:174:29 | begin | semmle.label | begin |
 | test.cpp:174:25:174:29 | begin indirection | semmle.label | begin indirection |
-| test.cpp:174:36:174:38 | arr indirection [end] | semmle.label | arr indirection [end] |
-| test.cpp:174:41:174:43 | end | semmle.label | end |
-| test.cpp:174:41:174:43 | end indirection | semmle.label | end indirection |
 | test.cpp:174:48:174:48 | p | semmle.label | p |
 | test.cpp:180:19:180:28 | call to mk_array_p indirection [begin] | semmle.label | call to mk_array_p indirection [begin] |
 | test.cpp:180:19:180:28 | call to mk_array_p indirection [end] | semmle.label | call to mk_array_p indirection [end] |
@@ -1029,13 +742,6 @@ nodes
 | test.cpp:314:15:314:16 | xs | semmle.label | xs |
 | test.cpp:325:14:325:27 | new[] | semmle.label | new[] |
 | test.cpp:326:15:326:16 | xs | semmle.label | xs |
-| test.cpp:326:15:326:23 | ... + ... | semmle.label | ... + ... |
-| test.cpp:326:15:326:23 | ... + ... | semmle.label | ... + ... |
-| test.cpp:333:5:333:21 | Store: ... = ... | semmle.label | Store: ... = ... |
-| test.cpp:338:8:338:15 | * ... | semmle.label | * ... |
-| test.cpp:341:5:341:21 | Store: ... = ... | semmle.label | Store: ... = ... |
-| test.cpp:341:8:341:17 | * ... | semmle.label | * ... |
-| test.cpp:342:8:342:17 | * ... | semmle.label | * ... |
 | test.cpp:347:14:347:27 | new[] | semmle.label | new[] |
 | test.cpp:348:15:348:16 | xs | semmle.label | xs |
 | test.cpp:350:15:350:19 | Load: * ... | semmle.label | Load: * ... |
@@ -1088,8 +794,6 @@ subpaths
 | test.cpp:264:13:264:14 | Load: * ... | test.cpp:260:13:260:24 | new[] | test.cpp:264:13:264:14 | Load: * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:260:13:260:24 | new[] | new[] | test.cpp:261:19:261:21 | len | len |
 | test.cpp:274:5:274:10 | Store: ... = ... | test.cpp:270:13:270:24 | new[] | test.cpp:274:5:274:10 | Store: ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:270:13:270:24 | new[] | new[] | test.cpp:271:19:271:21 | len | len |
 | test.cpp:308:5:308:29 | Store: ... = ... | test.cpp:304:15:304:26 | new[] | test.cpp:308:5:308:29 | Store: ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:304:15:304:26 | new[] | new[] | test.cpp:308:8:308:10 | ... + ... | ... + ... |
-| test.cpp:333:5:333:21 | Store: ... = ... | test.cpp:325:14:325:27 | new[] | test.cpp:333:5:333:21 | Store: ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:325:14:325:27 | new[] | new[] | test.cpp:326:20:326:23 | size | size |
-| test.cpp:341:5:341:21 | Store: ... = ... | test.cpp:325:14:325:27 | new[] | test.cpp:341:5:341:21 | Store: ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:325:14:325:27 | new[] | new[] | test.cpp:326:20:326:23 | size | size |
 | test.cpp:350:15:350:19 | Load: * ... | test.cpp:347:14:347:27 | new[] | test.cpp:350:15:350:19 | Load: * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:347:14:347:27 | new[] | new[] | test.cpp:348:20:348:23 | size | size |
 | test.cpp:358:14:358:26 | Load: * ... | test.cpp:355:14:355:27 | new[] | test.cpp:358:14:358:26 | Load: * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@ + 1. | test.cpp:355:14:355:27 | new[] | new[] | test.cpp:356:20:356:23 | size | size |
 | test.cpp:359:14:359:32 | Load: * ... | test.cpp:355:14:355:27 | new[] | test.cpp:359:14:359:32 | Load: * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@ + 2. | test.cpp:355:14:355:27 | new[] | new[] | test.cpp:356:20:356:23 | size | size |

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/InvalidPointerDeref.expected
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/InvalidPointerDeref.expected
@@ -9,7 +9,15 @@ edges
 | test.cpp:5:15:5:15 | p | test.cpp:7:16:7:16 | q |
 | test.cpp:5:15:5:15 | p | test.cpp:7:16:7:16 | q |
 | test.cpp:5:15:5:15 | p | test.cpp:8:16:8:16 | q |
+| test.cpp:5:15:5:15 | p | test.cpp:8:16:8:16 | q |
 | test.cpp:5:15:5:15 | p | test.cpp:8:16:8:20 | ... + ... |
+| test.cpp:5:15:5:15 | p | test.cpp:9:16:9:16 | q |
+| test.cpp:5:15:5:15 | p | test.cpp:9:16:9:16 | q |
+| test.cpp:5:15:5:15 | p | test.cpp:10:16:10:16 | q |
+| test.cpp:5:15:5:15 | p | test.cpp:10:16:10:16 | q |
+| test.cpp:5:15:5:15 | p | test.cpp:11:16:11:16 | q |
+| test.cpp:5:15:5:15 | p | test.cpp:11:16:11:16 | q |
+| test.cpp:5:15:5:15 | p | test.cpp:12:16:12:16 | q |
 | test.cpp:5:15:5:22 | ... + ... | test.cpp:5:15:5:22 | ... + ... |
 | test.cpp:5:15:5:22 | ... + ... | test.cpp:5:15:5:22 | ... + ... |
 | test.cpp:5:15:5:22 | ... + ... | test.cpp:6:14:6:15 | Load: * ... |
@@ -30,6 +38,22 @@ edges
 | test.cpp:5:15:5:22 | ... + ... | test.cpp:8:14:8:21 | Load: * ... |
 | test.cpp:5:15:5:22 | ... + ... | test.cpp:8:16:8:16 | q |
 | test.cpp:5:15:5:22 | ... + ... | test.cpp:8:16:8:16 | q |
+| test.cpp:5:15:5:22 | ... + ... | test.cpp:8:16:8:16 | q |
+| test.cpp:5:15:5:22 | ... + ... | test.cpp:8:16:8:16 | q |
+| test.cpp:5:15:5:22 | ... + ... | test.cpp:9:16:9:16 | q |
+| test.cpp:5:15:5:22 | ... + ... | test.cpp:9:16:9:16 | q |
+| test.cpp:5:15:5:22 | ... + ... | test.cpp:9:16:9:16 | q |
+| test.cpp:5:15:5:22 | ... + ... | test.cpp:9:16:9:16 | q |
+| test.cpp:5:15:5:22 | ... + ... | test.cpp:10:16:10:16 | q |
+| test.cpp:5:15:5:22 | ... + ... | test.cpp:10:16:10:16 | q |
+| test.cpp:5:15:5:22 | ... + ... | test.cpp:10:16:10:16 | q |
+| test.cpp:5:15:5:22 | ... + ... | test.cpp:10:16:10:16 | q |
+| test.cpp:5:15:5:22 | ... + ... | test.cpp:11:16:11:16 | q |
+| test.cpp:5:15:5:22 | ... + ... | test.cpp:11:16:11:16 | q |
+| test.cpp:5:15:5:22 | ... + ... | test.cpp:11:16:11:16 | q |
+| test.cpp:5:15:5:22 | ... + ... | test.cpp:11:16:11:16 | q |
+| test.cpp:5:15:5:22 | ... + ... | test.cpp:12:16:12:16 | q |
+| test.cpp:5:15:5:22 | ... + ... | test.cpp:12:16:12:16 | q |
 | test.cpp:6:15:6:15 | q | test.cpp:6:14:6:15 | Load: * ... |
 | test.cpp:6:15:6:15 | q | test.cpp:6:14:6:15 | Load: * ... |
 | test.cpp:6:15:6:15 | q | test.cpp:7:16:7:16 | q |
@@ -37,11 +61,62 @@ edges
 | test.cpp:6:15:6:15 | q | test.cpp:8:14:8:21 | Load: * ... |
 | test.cpp:6:15:6:15 | q | test.cpp:8:14:8:21 | Load: * ... |
 | test.cpp:6:15:6:15 | q | test.cpp:8:16:8:16 | q |
+| test.cpp:6:15:6:15 | q | test.cpp:8:16:8:16 | q |
+| test.cpp:6:15:6:15 | q | test.cpp:9:16:9:16 | q |
+| test.cpp:6:15:6:15 | q | test.cpp:9:16:9:16 | q |
+| test.cpp:6:15:6:15 | q | test.cpp:10:16:10:16 | q |
+| test.cpp:6:15:6:15 | q | test.cpp:10:16:10:16 | q |
+| test.cpp:6:15:6:15 | q | test.cpp:11:16:11:16 | q |
+| test.cpp:6:15:6:15 | q | test.cpp:11:16:11:16 | q |
+| test.cpp:6:15:6:15 | q | test.cpp:12:16:12:16 | q |
+| test.cpp:7:16:7:16 | q | test.cpp:6:14:6:15 | Load: * ... |
+| test.cpp:7:16:7:16 | q | test.cpp:6:14:6:15 | Load: * ... |
 | test.cpp:7:16:7:16 | q | test.cpp:8:14:8:21 | Load: * ... |
 | test.cpp:7:16:7:16 | q | test.cpp:8:14:8:21 | Load: * ... |
 | test.cpp:7:16:7:16 | q | test.cpp:8:16:8:16 | q |
+| test.cpp:7:16:7:16 | q | test.cpp:8:16:8:16 | q |
+| test.cpp:7:16:7:16 | q | test.cpp:9:16:9:16 | q |
+| test.cpp:7:16:7:16 | q | test.cpp:9:16:9:16 | q |
+| test.cpp:7:16:7:16 | q | test.cpp:10:16:10:16 | q |
+| test.cpp:7:16:7:16 | q | test.cpp:10:16:10:16 | q |
+| test.cpp:7:16:7:16 | q | test.cpp:11:16:11:16 | q |
+| test.cpp:7:16:7:16 | q | test.cpp:11:16:11:16 | q |
+| test.cpp:7:16:7:16 | q | test.cpp:12:16:12:16 | q |
+| test.cpp:8:16:8:16 | q | test.cpp:6:14:6:15 | Load: * ... |
+| test.cpp:8:16:8:16 | q | test.cpp:6:14:6:15 | Load: * ... |
 | test.cpp:8:16:8:16 | q | test.cpp:8:14:8:21 | Load: * ... |
+| test.cpp:8:16:8:16 | q | test.cpp:8:14:8:21 | Load: * ... |
+| test.cpp:8:16:8:16 | q | test.cpp:9:16:9:16 | q |
+| test.cpp:8:16:8:16 | q | test.cpp:9:16:9:16 | q |
+| test.cpp:8:16:8:16 | q | test.cpp:10:16:10:16 | q |
+| test.cpp:8:16:8:16 | q | test.cpp:10:16:10:16 | q |
+| test.cpp:8:16:8:16 | q | test.cpp:11:16:11:16 | q |
+| test.cpp:8:16:8:16 | q | test.cpp:11:16:11:16 | q |
+| test.cpp:8:16:8:16 | q | test.cpp:12:16:12:16 | q |
 | test.cpp:8:16:8:20 | ... + ... | test.cpp:8:14:8:21 | Load: * ... |
+| test.cpp:9:16:9:16 | q | test.cpp:6:14:6:15 | Load: * ... |
+| test.cpp:9:16:9:16 | q | test.cpp:6:14:6:15 | Load: * ... |
+| test.cpp:9:16:9:16 | q | test.cpp:8:14:8:21 | Load: * ... |
+| test.cpp:9:16:9:16 | q | test.cpp:8:14:8:21 | Load: * ... |
+| test.cpp:9:16:9:16 | q | test.cpp:10:16:10:16 | q |
+| test.cpp:9:16:9:16 | q | test.cpp:10:16:10:16 | q |
+| test.cpp:9:16:9:16 | q | test.cpp:11:16:11:16 | q |
+| test.cpp:9:16:9:16 | q | test.cpp:11:16:11:16 | q |
+| test.cpp:9:16:9:16 | q | test.cpp:12:16:12:16 | q |
+| test.cpp:10:16:10:16 | q | test.cpp:6:14:6:15 | Load: * ... |
+| test.cpp:10:16:10:16 | q | test.cpp:6:14:6:15 | Load: * ... |
+| test.cpp:10:16:10:16 | q | test.cpp:8:14:8:21 | Load: * ... |
+| test.cpp:10:16:10:16 | q | test.cpp:8:14:8:21 | Load: * ... |
+| test.cpp:10:16:10:16 | q | test.cpp:11:16:11:16 | q |
+| test.cpp:10:16:10:16 | q | test.cpp:11:16:11:16 | q |
+| test.cpp:10:16:10:16 | q | test.cpp:12:16:12:16 | q |
+| test.cpp:11:16:11:16 | q | test.cpp:6:14:6:15 | Load: * ... |
+| test.cpp:11:16:11:16 | q | test.cpp:6:14:6:15 | Load: * ... |
+| test.cpp:11:16:11:16 | q | test.cpp:8:14:8:21 | Load: * ... |
+| test.cpp:11:16:11:16 | q | test.cpp:8:14:8:21 | Load: * ... |
+| test.cpp:11:16:11:16 | q | test.cpp:12:16:12:16 | q |
+| test.cpp:12:16:12:16 | q | test.cpp:6:14:6:15 | Load: * ... |
+| test.cpp:12:16:12:16 | q | test.cpp:8:14:8:21 | Load: * ... |
 | test.cpp:16:15:16:20 | call to malloc | test.cpp:17:15:17:15 | p |
 | test.cpp:17:15:17:15 | p | test.cpp:17:15:17:22 | ... + ... |
 | test.cpp:17:15:17:15 | p | test.cpp:20:16:20:20 | ... + ... |
@@ -57,7 +132,15 @@ edges
 | test.cpp:29:15:29:15 | p | test.cpp:31:16:31:16 | q |
 | test.cpp:29:15:29:15 | p | test.cpp:31:16:31:16 | q |
 | test.cpp:29:15:29:15 | p | test.cpp:32:16:32:16 | q |
+| test.cpp:29:15:29:15 | p | test.cpp:32:16:32:16 | q |
 | test.cpp:29:15:29:15 | p | test.cpp:32:16:32:20 | ... + ... |
+| test.cpp:29:15:29:15 | p | test.cpp:33:16:33:16 | q |
+| test.cpp:29:15:29:15 | p | test.cpp:33:16:33:16 | q |
+| test.cpp:29:15:29:15 | p | test.cpp:34:16:34:16 | q |
+| test.cpp:29:15:29:15 | p | test.cpp:34:16:34:16 | q |
+| test.cpp:29:15:29:15 | p | test.cpp:35:16:35:16 | q |
+| test.cpp:29:15:29:15 | p | test.cpp:35:16:35:16 | q |
+| test.cpp:29:15:29:15 | p | test.cpp:36:16:36:16 | q |
 | test.cpp:29:15:29:28 | ... + ... | test.cpp:29:15:29:28 | ... + ... |
 | test.cpp:29:15:29:28 | ... + ... | test.cpp:29:15:29:28 | ... + ... |
 | test.cpp:29:15:29:28 | ... + ... | test.cpp:30:14:30:15 | Load: * ... |
@@ -78,6 +161,22 @@ edges
 | test.cpp:29:15:29:28 | ... + ... | test.cpp:32:14:32:21 | Load: * ... |
 | test.cpp:29:15:29:28 | ... + ... | test.cpp:32:16:32:16 | q |
 | test.cpp:29:15:29:28 | ... + ... | test.cpp:32:16:32:16 | q |
+| test.cpp:29:15:29:28 | ... + ... | test.cpp:32:16:32:16 | q |
+| test.cpp:29:15:29:28 | ... + ... | test.cpp:32:16:32:16 | q |
+| test.cpp:29:15:29:28 | ... + ... | test.cpp:33:16:33:16 | q |
+| test.cpp:29:15:29:28 | ... + ... | test.cpp:33:16:33:16 | q |
+| test.cpp:29:15:29:28 | ... + ... | test.cpp:33:16:33:16 | q |
+| test.cpp:29:15:29:28 | ... + ... | test.cpp:33:16:33:16 | q |
+| test.cpp:29:15:29:28 | ... + ... | test.cpp:34:16:34:16 | q |
+| test.cpp:29:15:29:28 | ... + ... | test.cpp:34:16:34:16 | q |
+| test.cpp:29:15:29:28 | ... + ... | test.cpp:34:16:34:16 | q |
+| test.cpp:29:15:29:28 | ... + ... | test.cpp:34:16:34:16 | q |
+| test.cpp:29:15:29:28 | ... + ... | test.cpp:35:16:35:16 | q |
+| test.cpp:29:15:29:28 | ... + ... | test.cpp:35:16:35:16 | q |
+| test.cpp:29:15:29:28 | ... + ... | test.cpp:35:16:35:16 | q |
+| test.cpp:29:15:29:28 | ... + ... | test.cpp:35:16:35:16 | q |
+| test.cpp:29:15:29:28 | ... + ... | test.cpp:36:16:36:16 | q |
+| test.cpp:29:15:29:28 | ... + ... | test.cpp:36:16:36:16 | q |
 | test.cpp:30:15:30:15 | q | test.cpp:30:14:30:15 | Load: * ... |
 | test.cpp:30:15:30:15 | q | test.cpp:30:14:30:15 | Load: * ... |
 | test.cpp:30:15:30:15 | q | test.cpp:31:16:31:16 | q |
@@ -85,11 +184,62 @@ edges
 | test.cpp:30:15:30:15 | q | test.cpp:32:14:32:21 | Load: * ... |
 | test.cpp:30:15:30:15 | q | test.cpp:32:14:32:21 | Load: * ... |
 | test.cpp:30:15:30:15 | q | test.cpp:32:16:32:16 | q |
+| test.cpp:30:15:30:15 | q | test.cpp:32:16:32:16 | q |
+| test.cpp:30:15:30:15 | q | test.cpp:33:16:33:16 | q |
+| test.cpp:30:15:30:15 | q | test.cpp:33:16:33:16 | q |
+| test.cpp:30:15:30:15 | q | test.cpp:34:16:34:16 | q |
+| test.cpp:30:15:30:15 | q | test.cpp:34:16:34:16 | q |
+| test.cpp:30:15:30:15 | q | test.cpp:35:16:35:16 | q |
+| test.cpp:30:15:30:15 | q | test.cpp:35:16:35:16 | q |
+| test.cpp:30:15:30:15 | q | test.cpp:36:16:36:16 | q |
+| test.cpp:31:16:31:16 | q | test.cpp:30:14:30:15 | Load: * ... |
+| test.cpp:31:16:31:16 | q | test.cpp:30:14:30:15 | Load: * ... |
 | test.cpp:31:16:31:16 | q | test.cpp:32:14:32:21 | Load: * ... |
 | test.cpp:31:16:31:16 | q | test.cpp:32:14:32:21 | Load: * ... |
 | test.cpp:31:16:31:16 | q | test.cpp:32:16:32:16 | q |
+| test.cpp:31:16:31:16 | q | test.cpp:32:16:32:16 | q |
+| test.cpp:31:16:31:16 | q | test.cpp:33:16:33:16 | q |
+| test.cpp:31:16:31:16 | q | test.cpp:33:16:33:16 | q |
+| test.cpp:31:16:31:16 | q | test.cpp:34:16:34:16 | q |
+| test.cpp:31:16:31:16 | q | test.cpp:34:16:34:16 | q |
+| test.cpp:31:16:31:16 | q | test.cpp:35:16:35:16 | q |
+| test.cpp:31:16:31:16 | q | test.cpp:35:16:35:16 | q |
+| test.cpp:31:16:31:16 | q | test.cpp:36:16:36:16 | q |
+| test.cpp:32:16:32:16 | q | test.cpp:30:14:30:15 | Load: * ... |
+| test.cpp:32:16:32:16 | q | test.cpp:30:14:30:15 | Load: * ... |
 | test.cpp:32:16:32:16 | q | test.cpp:32:14:32:21 | Load: * ... |
+| test.cpp:32:16:32:16 | q | test.cpp:32:14:32:21 | Load: * ... |
+| test.cpp:32:16:32:16 | q | test.cpp:33:16:33:16 | q |
+| test.cpp:32:16:32:16 | q | test.cpp:33:16:33:16 | q |
+| test.cpp:32:16:32:16 | q | test.cpp:34:16:34:16 | q |
+| test.cpp:32:16:32:16 | q | test.cpp:34:16:34:16 | q |
+| test.cpp:32:16:32:16 | q | test.cpp:35:16:35:16 | q |
+| test.cpp:32:16:32:16 | q | test.cpp:35:16:35:16 | q |
+| test.cpp:32:16:32:16 | q | test.cpp:36:16:36:16 | q |
 | test.cpp:32:16:32:20 | ... + ... | test.cpp:32:14:32:21 | Load: * ... |
+| test.cpp:33:16:33:16 | q | test.cpp:30:14:30:15 | Load: * ... |
+| test.cpp:33:16:33:16 | q | test.cpp:30:14:30:15 | Load: * ... |
+| test.cpp:33:16:33:16 | q | test.cpp:32:14:32:21 | Load: * ... |
+| test.cpp:33:16:33:16 | q | test.cpp:32:14:32:21 | Load: * ... |
+| test.cpp:33:16:33:16 | q | test.cpp:34:16:34:16 | q |
+| test.cpp:33:16:33:16 | q | test.cpp:34:16:34:16 | q |
+| test.cpp:33:16:33:16 | q | test.cpp:35:16:35:16 | q |
+| test.cpp:33:16:33:16 | q | test.cpp:35:16:35:16 | q |
+| test.cpp:33:16:33:16 | q | test.cpp:36:16:36:16 | q |
+| test.cpp:34:16:34:16 | q | test.cpp:30:14:30:15 | Load: * ... |
+| test.cpp:34:16:34:16 | q | test.cpp:30:14:30:15 | Load: * ... |
+| test.cpp:34:16:34:16 | q | test.cpp:32:14:32:21 | Load: * ... |
+| test.cpp:34:16:34:16 | q | test.cpp:32:14:32:21 | Load: * ... |
+| test.cpp:34:16:34:16 | q | test.cpp:35:16:35:16 | q |
+| test.cpp:34:16:34:16 | q | test.cpp:35:16:35:16 | q |
+| test.cpp:34:16:34:16 | q | test.cpp:36:16:36:16 | q |
+| test.cpp:35:16:35:16 | q | test.cpp:30:14:30:15 | Load: * ... |
+| test.cpp:35:16:35:16 | q | test.cpp:30:14:30:15 | Load: * ... |
+| test.cpp:35:16:35:16 | q | test.cpp:32:14:32:21 | Load: * ... |
+| test.cpp:35:16:35:16 | q | test.cpp:32:14:32:21 | Load: * ... |
+| test.cpp:35:16:35:16 | q | test.cpp:36:16:36:16 | q |
+| test.cpp:36:16:36:16 | q | test.cpp:30:14:30:15 | Load: * ... |
+| test.cpp:36:16:36:16 | q | test.cpp:32:14:32:21 | Load: * ... |
 | test.cpp:40:15:40:20 | call to malloc | test.cpp:41:15:41:15 | p |
 | test.cpp:41:15:41:15 | p | test.cpp:41:15:41:28 | ... + ... |
 | test.cpp:41:15:41:15 | p | test.cpp:41:15:41:28 | ... + ... |
@@ -100,7 +250,15 @@ edges
 | test.cpp:41:15:41:15 | p | test.cpp:43:16:43:16 | q |
 | test.cpp:41:15:41:15 | p | test.cpp:43:16:43:16 | q |
 | test.cpp:41:15:41:15 | p | test.cpp:44:16:44:16 | q |
+| test.cpp:41:15:41:15 | p | test.cpp:44:16:44:16 | q |
 | test.cpp:41:15:41:15 | p | test.cpp:44:16:44:20 | ... + ... |
+| test.cpp:41:15:41:15 | p | test.cpp:45:16:45:16 | q |
+| test.cpp:41:15:41:15 | p | test.cpp:45:16:45:16 | q |
+| test.cpp:41:15:41:15 | p | test.cpp:46:16:46:16 | q |
+| test.cpp:41:15:41:15 | p | test.cpp:46:16:46:16 | q |
+| test.cpp:41:15:41:15 | p | test.cpp:47:16:47:16 | q |
+| test.cpp:41:15:41:15 | p | test.cpp:47:16:47:16 | q |
+| test.cpp:41:15:41:15 | p | test.cpp:48:16:48:16 | q |
 | test.cpp:41:15:41:28 | ... + ... | test.cpp:41:15:41:28 | ... + ... |
 | test.cpp:41:15:41:28 | ... + ... | test.cpp:41:15:41:28 | ... + ... |
 | test.cpp:41:15:41:28 | ... + ... | test.cpp:42:14:42:15 | Load: * ... |
@@ -121,6 +279,22 @@ edges
 | test.cpp:41:15:41:28 | ... + ... | test.cpp:44:14:44:21 | Load: * ... |
 | test.cpp:41:15:41:28 | ... + ... | test.cpp:44:16:44:16 | q |
 | test.cpp:41:15:41:28 | ... + ... | test.cpp:44:16:44:16 | q |
+| test.cpp:41:15:41:28 | ... + ... | test.cpp:44:16:44:16 | q |
+| test.cpp:41:15:41:28 | ... + ... | test.cpp:44:16:44:16 | q |
+| test.cpp:41:15:41:28 | ... + ... | test.cpp:45:16:45:16 | q |
+| test.cpp:41:15:41:28 | ... + ... | test.cpp:45:16:45:16 | q |
+| test.cpp:41:15:41:28 | ... + ... | test.cpp:45:16:45:16 | q |
+| test.cpp:41:15:41:28 | ... + ... | test.cpp:45:16:45:16 | q |
+| test.cpp:41:15:41:28 | ... + ... | test.cpp:46:16:46:16 | q |
+| test.cpp:41:15:41:28 | ... + ... | test.cpp:46:16:46:16 | q |
+| test.cpp:41:15:41:28 | ... + ... | test.cpp:46:16:46:16 | q |
+| test.cpp:41:15:41:28 | ... + ... | test.cpp:46:16:46:16 | q |
+| test.cpp:41:15:41:28 | ... + ... | test.cpp:47:16:47:16 | q |
+| test.cpp:41:15:41:28 | ... + ... | test.cpp:47:16:47:16 | q |
+| test.cpp:41:15:41:28 | ... + ... | test.cpp:47:16:47:16 | q |
+| test.cpp:41:15:41:28 | ... + ... | test.cpp:47:16:47:16 | q |
+| test.cpp:41:15:41:28 | ... + ... | test.cpp:48:16:48:16 | q |
+| test.cpp:41:15:41:28 | ... + ... | test.cpp:48:16:48:16 | q |
 | test.cpp:42:15:42:15 | q | test.cpp:42:14:42:15 | Load: * ... |
 | test.cpp:42:15:42:15 | q | test.cpp:42:14:42:15 | Load: * ... |
 | test.cpp:42:15:42:15 | q | test.cpp:43:16:43:16 | q |
@@ -128,11 +302,62 @@ edges
 | test.cpp:42:15:42:15 | q | test.cpp:44:14:44:21 | Load: * ... |
 | test.cpp:42:15:42:15 | q | test.cpp:44:14:44:21 | Load: * ... |
 | test.cpp:42:15:42:15 | q | test.cpp:44:16:44:16 | q |
+| test.cpp:42:15:42:15 | q | test.cpp:44:16:44:16 | q |
+| test.cpp:42:15:42:15 | q | test.cpp:45:16:45:16 | q |
+| test.cpp:42:15:42:15 | q | test.cpp:45:16:45:16 | q |
+| test.cpp:42:15:42:15 | q | test.cpp:46:16:46:16 | q |
+| test.cpp:42:15:42:15 | q | test.cpp:46:16:46:16 | q |
+| test.cpp:42:15:42:15 | q | test.cpp:47:16:47:16 | q |
+| test.cpp:42:15:42:15 | q | test.cpp:47:16:47:16 | q |
+| test.cpp:42:15:42:15 | q | test.cpp:48:16:48:16 | q |
+| test.cpp:43:16:43:16 | q | test.cpp:42:14:42:15 | Load: * ... |
+| test.cpp:43:16:43:16 | q | test.cpp:42:14:42:15 | Load: * ... |
 | test.cpp:43:16:43:16 | q | test.cpp:44:14:44:21 | Load: * ... |
 | test.cpp:43:16:43:16 | q | test.cpp:44:14:44:21 | Load: * ... |
 | test.cpp:43:16:43:16 | q | test.cpp:44:16:44:16 | q |
+| test.cpp:43:16:43:16 | q | test.cpp:44:16:44:16 | q |
+| test.cpp:43:16:43:16 | q | test.cpp:45:16:45:16 | q |
+| test.cpp:43:16:43:16 | q | test.cpp:45:16:45:16 | q |
+| test.cpp:43:16:43:16 | q | test.cpp:46:16:46:16 | q |
+| test.cpp:43:16:43:16 | q | test.cpp:46:16:46:16 | q |
+| test.cpp:43:16:43:16 | q | test.cpp:47:16:47:16 | q |
+| test.cpp:43:16:43:16 | q | test.cpp:47:16:47:16 | q |
+| test.cpp:43:16:43:16 | q | test.cpp:48:16:48:16 | q |
+| test.cpp:44:16:44:16 | q | test.cpp:42:14:42:15 | Load: * ... |
+| test.cpp:44:16:44:16 | q | test.cpp:42:14:42:15 | Load: * ... |
 | test.cpp:44:16:44:16 | q | test.cpp:44:14:44:21 | Load: * ... |
+| test.cpp:44:16:44:16 | q | test.cpp:44:14:44:21 | Load: * ... |
+| test.cpp:44:16:44:16 | q | test.cpp:45:16:45:16 | q |
+| test.cpp:44:16:44:16 | q | test.cpp:45:16:45:16 | q |
+| test.cpp:44:16:44:16 | q | test.cpp:46:16:46:16 | q |
+| test.cpp:44:16:44:16 | q | test.cpp:46:16:46:16 | q |
+| test.cpp:44:16:44:16 | q | test.cpp:47:16:47:16 | q |
+| test.cpp:44:16:44:16 | q | test.cpp:47:16:47:16 | q |
+| test.cpp:44:16:44:16 | q | test.cpp:48:16:48:16 | q |
 | test.cpp:44:16:44:20 | ... + ... | test.cpp:44:14:44:21 | Load: * ... |
+| test.cpp:45:16:45:16 | q | test.cpp:42:14:42:15 | Load: * ... |
+| test.cpp:45:16:45:16 | q | test.cpp:42:14:42:15 | Load: * ... |
+| test.cpp:45:16:45:16 | q | test.cpp:44:14:44:21 | Load: * ... |
+| test.cpp:45:16:45:16 | q | test.cpp:44:14:44:21 | Load: * ... |
+| test.cpp:45:16:45:16 | q | test.cpp:46:16:46:16 | q |
+| test.cpp:45:16:45:16 | q | test.cpp:46:16:46:16 | q |
+| test.cpp:45:16:45:16 | q | test.cpp:47:16:47:16 | q |
+| test.cpp:45:16:45:16 | q | test.cpp:47:16:47:16 | q |
+| test.cpp:45:16:45:16 | q | test.cpp:48:16:48:16 | q |
+| test.cpp:46:16:46:16 | q | test.cpp:42:14:42:15 | Load: * ... |
+| test.cpp:46:16:46:16 | q | test.cpp:42:14:42:15 | Load: * ... |
+| test.cpp:46:16:46:16 | q | test.cpp:44:14:44:21 | Load: * ... |
+| test.cpp:46:16:46:16 | q | test.cpp:44:14:44:21 | Load: * ... |
+| test.cpp:46:16:46:16 | q | test.cpp:47:16:47:16 | q |
+| test.cpp:46:16:46:16 | q | test.cpp:47:16:47:16 | q |
+| test.cpp:46:16:46:16 | q | test.cpp:48:16:48:16 | q |
+| test.cpp:47:16:47:16 | q | test.cpp:42:14:42:15 | Load: * ... |
+| test.cpp:47:16:47:16 | q | test.cpp:42:14:42:15 | Load: * ... |
+| test.cpp:47:16:47:16 | q | test.cpp:44:14:44:21 | Load: * ... |
+| test.cpp:47:16:47:16 | q | test.cpp:44:14:44:21 | Load: * ... |
+| test.cpp:47:16:47:16 | q | test.cpp:48:16:48:16 | q |
+| test.cpp:48:16:48:16 | q | test.cpp:42:14:42:15 | Load: * ... |
+| test.cpp:48:16:48:16 | q | test.cpp:44:14:44:21 | Load: * ... |
 | test.cpp:51:7:51:14 | mk_array indirection | test.cpp:60:19:60:26 | call to mk_array |
 | test.cpp:51:33:51:35 | end | test.cpp:60:34:60:37 | mk_array output argument |
 | test.cpp:52:19:52:24 | call to malloc | test.cpp:51:7:51:14 | mk_array indirection |
@@ -146,8 +371,10 @@ edges
 | test.cpp:60:19:60:26 | call to mk_array | test.cpp:70:38:70:38 | p |
 | test.cpp:60:34:60:37 | mk_array output argument | test.cpp:62:32:62:34 | end |
 | test.cpp:60:34:60:37 | mk_array output argument | test.cpp:66:32:66:34 | end |
+| test.cpp:60:34:60:37 | mk_array output argument | test.cpp:70:31:70:33 | end |
 | test.cpp:62:32:62:34 | end | test.cpp:67:9:67:14 | Store: ... = ... |
 | test.cpp:66:32:66:34 | end | test.cpp:67:9:67:14 | Store: ... = ... |
+| test.cpp:70:31:70:33 | end | test.cpp:67:9:67:14 | Store: ... = ... |
 | test.cpp:80:9:80:16 | mk_array indirection [begin] | test.cpp:89:19:89:26 | call to mk_array [begin] |
 | test.cpp:80:9:80:16 | mk_array indirection [begin] | test.cpp:119:18:119:25 | call to mk_array [begin] |
 | test.cpp:80:9:80:16 | mk_array indirection [end] | test.cpp:89:19:89:26 | call to mk_array [end] |
@@ -168,6 +395,7 @@ edges
 | test.cpp:89:19:89:26 | call to mk_array [begin] | test.cpp:99:20:99:22 | arr indirection [begin] |
 | test.cpp:89:19:89:26 | call to mk_array [end] | test.cpp:91:36:91:38 | arr indirection [end] |
 | test.cpp:89:19:89:26 | call to mk_array [end] | test.cpp:95:36:95:38 | arr indirection [end] |
+| test.cpp:89:19:89:26 | call to mk_array [end] | test.cpp:99:35:99:37 | arr indirection [end] |
 | test.cpp:91:20:91:22 | arr indirection [begin] | test.cpp:91:24:91:28 | begin |
 | test.cpp:91:20:91:22 | arr indirection [begin] | test.cpp:91:24:91:28 | begin indirection |
 | test.cpp:91:24:91:28 | begin | test.cpp:91:47:91:47 | p |
@@ -188,11 +416,16 @@ edges
 | test.cpp:99:20:99:22 | arr indirection [begin] | test.cpp:99:24:99:28 | begin indirection |
 | test.cpp:99:24:99:28 | begin | test.cpp:99:46:99:46 | p |
 | test.cpp:99:24:99:28 | begin indirection | test.cpp:99:46:99:46 | p |
+| test.cpp:99:35:99:37 | arr indirection [end] | test.cpp:99:39:99:41 | end |
+| test.cpp:99:35:99:37 | arr indirection [end] | test.cpp:99:39:99:41 | end indirection |
+| test.cpp:99:39:99:41 | end | test.cpp:96:9:96:14 | Store: ... = ... |
+| test.cpp:99:39:99:41 | end indirection | test.cpp:99:39:99:41 | end |
 | test.cpp:104:27:104:29 | arr [begin] | test.cpp:105:20:105:22 | arr indirection [begin] |
 | test.cpp:104:27:104:29 | arr [begin] | test.cpp:109:20:109:22 | arr indirection [begin] |
 | test.cpp:104:27:104:29 | arr [begin] | test.cpp:113:20:113:22 | arr indirection [begin] |
 | test.cpp:104:27:104:29 | arr [end] | test.cpp:105:36:105:38 | arr indirection [end] |
 | test.cpp:104:27:104:29 | arr [end] | test.cpp:109:36:109:38 | arr indirection [end] |
+| test.cpp:104:27:104:29 | arr [end] | test.cpp:113:35:113:37 | arr indirection [end] |
 | test.cpp:105:20:105:22 | arr indirection [begin] | test.cpp:105:24:105:28 | begin |
 | test.cpp:105:20:105:22 | arr indirection [begin] | test.cpp:105:24:105:28 | begin indirection |
 | test.cpp:105:24:105:28 | begin | test.cpp:105:47:105:47 | p |
@@ -213,6 +446,10 @@ edges
 | test.cpp:113:20:113:22 | arr indirection [begin] | test.cpp:113:24:113:28 | begin indirection |
 | test.cpp:113:24:113:28 | begin | test.cpp:113:46:113:46 | p |
 | test.cpp:113:24:113:28 | begin indirection | test.cpp:113:46:113:46 | p |
+| test.cpp:113:35:113:37 | arr indirection [end] | test.cpp:113:39:113:41 | end |
+| test.cpp:113:35:113:37 | arr indirection [end] | test.cpp:113:39:113:41 | end indirection |
+| test.cpp:113:39:113:41 | end | test.cpp:110:9:110:14 | Store: ... = ... |
+| test.cpp:113:39:113:41 | end indirection | test.cpp:113:39:113:41 | end |
 | test.cpp:119:18:119:25 | call to mk_array [begin] | test.cpp:104:27:104:29 | arr [begin] |
 | test.cpp:119:18:119:25 | call to mk_array [end] | test.cpp:104:27:104:29 | arr [end] |
 | test.cpp:124:15:124:20 | call to malloc | test.cpp:125:5:125:17 | ... = ... |
@@ -267,6 +504,7 @@ edges
 | test.cpp:165:29:165:31 | arr indirection [begin] | test.cpp:174:20:174:22 | arr indirection [begin] |
 | test.cpp:165:29:165:31 | arr indirection [end] | test.cpp:166:37:166:39 | arr indirection [end] |
 | test.cpp:165:29:165:31 | arr indirection [end] | test.cpp:170:37:170:39 | arr indirection [end] |
+| test.cpp:165:29:165:31 | arr indirection [end] | test.cpp:174:36:174:38 | arr indirection [end] |
 | test.cpp:166:20:166:22 | arr indirection [begin] | test.cpp:166:25:166:29 | begin |
 | test.cpp:166:20:166:22 | arr indirection [begin] | test.cpp:166:25:166:29 | begin indirection |
 | test.cpp:166:25:166:29 | begin | test.cpp:166:49:166:49 | p |
@@ -287,6 +525,10 @@ edges
 | test.cpp:174:20:174:22 | arr indirection [begin] | test.cpp:174:25:174:29 | begin indirection |
 | test.cpp:174:25:174:29 | begin | test.cpp:174:48:174:48 | p |
 | test.cpp:174:25:174:29 | begin indirection | test.cpp:174:48:174:48 | p |
+| test.cpp:174:36:174:38 | arr indirection [end] | test.cpp:174:41:174:43 | end |
+| test.cpp:174:36:174:38 | arr indirection [end] | test.cpp:174:41:174:43 | end indirection |
+| test.cpp:174:41:174:43 | end | test.cpp:171:9:171:14 | Store: ... = ... |
+| test.cpp:174:41:174:43 | end indirection | test.cpp:174:41:174:43 | end |
 | test.cpp:180:19:180:28 | call to mk_array_p indirection [begin] | test.cpp:165:29:165:31 | arr indirection [begin] |
 | test.cpp:180:19:180:28 | call to mk_array_p indirection [end] | test.cpp:165:29:165:31 | arr indirection [end] |
 | test.cpp:188:15:188:20 | call to malloc | test.cpp:189:15:189:15 | p |
@@ -413,6 +655,14 @@ edges
 | test.cpp:308:5:308:11 | access to array | test.cpp:308:5:308:29 | Store: ... = ... |
 | test.cpp:313:14:313:27 | new[] | test.cpp:314:15:314:16 | xs |
 | test.cpp:325:14:325:27 | new[] | test.cpp:326:15:326:16 | xs |
+| test.cpp:326:15:326:16 | xs | test.cpp:326:15:326:23 | ... + ... |
+| test.cpp:326:15:326:16 | xs | test.cpp:326:15:326:23 | ... + ... |
+| test.cpp:326:15:326:16 | xs | test.cpp:338:8:338:15 | * ... |
+| test.cpp:326:15:326:16 | xs | test.cpp:341:8:341:17 | * ... |
+| test.cpp:326:15:326:23 | ... + ... | test.cpp:342:8:342:17 | * ... |
+| test.cpp:326:15:326:23 | ... + ... | test.cpp:342:8:342:17 | * ... |
+| test.cpp:338:8:338:15 | * ... | test.cpp:342:8:342:17 | * ... |
+| test.cpp:341:8:341:17 | * ... | test.cpp:342:8:342:17 | * ... |
 | test.cpp:347:14:347:27 | new[] | test.cpp:348:15:348:16 | xs |
 | test.cpp:348:15:348:16 | xs | test.cpp:350:16:350:19 | ... ++ |
 | test.cpp:348:15:348:16 | xs | test.cpp:350:16:350:19 | ... ++ |
@@ -468,6 +718,7 @@ edges
 | test.cpp:358:15:358:26 | end_plus_one | test.cpp:359:14:359:32 | Load: * ... |
 | test.cpp:358:15:358:26 | end_plus_one | test.cpp:359:14:359:32 | Load: * ... |
 | test.cpp:358:15:358:26 | end_plus_one | test.cpp:359:16:359:27 | end_plus_one |
+| test.cpp:359:16:359:27 | end_plus_one | test.cpp:358:14:358:26 | Load: * ... |
 | test.cpp:359:16:359:27 | end_plus_one | test.cpp:359:14:359:32 | Load: * ... |
 | test.cpp:359:16:359:31 | ... + ... | test.cpp:359:14:359:32 | Load: * ... |
 | test.cpp:363:14:363:27 | new[] | test.cpp:365:15:365:15 | p |
@@ -493,7 +744,15 @@ nodes
 | test.cpp:7:16:7:16 | q | semmle.label | q |
 | test.cpp:8:14:8:21 | Load: * ... | semmle.label | Load: * ... |
 | test.cpp:8:16:8:16 | q | semmle.label | q |
+| test.cpp:8:16:8:16 | q | semmle.label | q |
 | test.cpp:8:16:8:20 | ... + ... | semmle.label | ... + ... |
+| test.cpp:9:16:9:16 | q | semmle.label | q |
+| test.cpp:9:16:9:16 | q | semmle.label | q |
+| test.cpp:10:16:10:16 | q | semmle.label | q |
+| test.cpp:10:16:10:16 | q | semmle.label | q |
+| test.cpp:11:16:11:16 | q | semmle.label | q |
+| test.cpp:11:16:11:16 | q | semmle.label | q |
+| test.cpp:12:16:12:16 | q | semmle.label | q |
 | test.cpp:16:15:16:20 | call to malloc | semmle.label | call to malloc |
 | test.cpp:17:15:17:15 | p | semmle.label | p |
 | test.cpp:17:15:17:22 | ... + ... | semmle.label | ... + ... |
@@ -512,7 +771,15 @@ nodes
 | test.cpp:31:16:31:16 | q | semmle.label | q |
 | test.cpp:32:14:32:21 | Load: * ... | semmle.label | Load: * ... |
 | test.cpp:32:16:32:16 | q | semmle.label | q |
+| test.cpp:32:16:32:16 | q | semmle.label | q |
 | test.cpp:32:16:32:20 | ... + ... | semmle.label | ... + ... |
+| test.cpp:33:16:33:16 | q | semmle.label | q |
+| test.cpp:33:16:33:16 | q | semmle.label | q |
+| test.cpp:34:16:34:16 | q | semmle.label | q |
+| test.cpp:34:16:34:16 | q | semmle.label | q |
+| test.cpp:35:16:35:16 | q | semmle.label | q |
+| test.cpp:35:16:35:16 | q | semmle.label | q |
+| test.cpp:36:16:36:16 | q | semmle.label | q |
 | test.cpp:40:15:40:20 | call to malloc | semmle.label | call to malloc |
 | test.cpp:41:15:41:15 | p | semmle.label | p |
 | test.cpp:41:15:41:28 | ... + ... | semmle.label | ... + ... |
@@ -526,7 +793,15 @@ nodes
 | test.cpp:43:16:43:16 | q | semmle.label | q |
 | test.cpp:44:14:44:21 | Load: * ... | semmle.label | Load: * ... |
 | test.cpp:44:16:44:16 | q | semmle.label | q |
+| test.cpp:44:16:44:16 | q | semmle.label | q |
 | test.cpp:44:16:44:20 | ... + ... | semmle.label | ... + ... |
+| test.cpp:45:16:45:16 | q | semmle.label | q |
+| test.cpp:45:16:45:16 | q | semmle.label | q |
+| test.cpp:46:16:46:16 | q | semmle.label | q |
+| test.cpp:46:16:46:16 | q | semmle.label | q |
+| test.cpp:47:16:47:16 | q | semmle.label | q |
+| test.cpp:47:16:47:16 | q | semmle.label | q |
+| test.cpp:48:16:48:16 | q | semmle.label | q |
 | test.cpp:51:7:51:14 | mk_array indirection | semmle.label | mk_array indirection |
 | test.cpp:51:33:51:35 | end | semmle.label | end |
 | test.cpp:52:19:52:24 | call to malloc | semmle.label | call to malloc |
@@ -540,6 +815,7 @@ nodes
 | test.cpp:66:32:66:34 | end | semmle.label | end |
 | test.cpp:66:39:66:39 | p | semmle.label | p |
 | test.cpp:67:9:67:14 | Store: ... = ... | semmle.label | Store: ... = ... |
+| test.cpp:70:31:70:33 | end | semmle.label | end |
 | test.cpp:70:38:70:38 | p | semmle.label | p |
 | test.cpp:80:9:80:16 | mk_array indirection [begin] | semmle.label | mk_array indirection [begin] |
 | test.cpp:80:9:80:16 | mk_array indirection [end] | semmle.label | mk_array indirection [end] |
@@ -572,6 +848,9 @@ nodes
 | test.cpp:99:20:99:22 | arr indirection [begin] | semmle.label | arr indirection [begin] |
 | test.cpp:99:24:99:28 | begin | semmle.label | begin |
 | test.cpp:99:24:99:28 | begin indirection | semmle.label | begin indirection |
+| test.cpp:99:35:99:37 | arr indirection [end] | semmle.label | arr indirection [end] |
+| test.cpp:99:39:99:41 | end | semmle.label | end |
+| test.cpp:99:39:99:41 | end indirection | semmle.label | end indirection |
 | test.cpp:99:46:99:46 | p | semmle.label | p |
 | test.cpp:104:27:104:29 | arr [begin] | semmle.label | arr [begin] |
 | test.cpp:104:27:104:29 | arr [end] | semmle.label | arr [end] |
@@ -593,6 +872,9 @@ nodes
 | test.cpp:113:20:113:22 | arr indirection [begin] | semmle.label | arr indirection [begin] |
 | test.cpp:113:24:113:28 | begin | semmle.label | begin |
 | test.cpp:113:24:113:28 | begin indirection | semmle.label | begin indirection |
+| test.cpp:113:35:113:37 | arr indirection [end] | semmle.label | arr indirection [end] |
+| test.cpp:113:39:113:41 | end | semmle.label | end |
+| test.cpp:113:39:113:41 | end indirection | semmle.label | end indirection |
 | test.cpp:113:46:113:46 | p | semmle.label | p |
 | test.cpp:119:18:119:25 | call to mk_array [begin] | semmle.label | call to mk_array [begin] |
 | test.cpp:119:18:119:25 | call to mk_array [end] | semmle.label | call to mk_array [end] |
@@ -658,6 +940,9 @@ nodes
 | test.cpp:174:20:174:22 | arr indirection [begin] | semmle.label | arr indirection [begin] |
 | test.cpp:174:25:174:29 | begin | semmle.label | begin |
 | test.cpp:174:25:174:29 | begin indirection | semmle.label | begin indirection |
+| test.cpp:174:36:174:38 | arr indirection [end] | semmle.label | arr indirection [end] |
+| test.cpp:174:41:174:43 | end | semmle.label | end |
+| test.cpp:174:41:174:43 | end indirection | semmle.label | end indirection |
 | test.cpp:174:48:174:48 | p | semmle.label | p |
 | test.cpp:180:19:180:28 | call to mk_array_p indirection [begin] | semmle.label | call to mk_array_p indirection [begin] |
 | test.cpp:180:19:180:28 | call to mk_array_p indirection [end] | semmle.label | call to mk_array_p indirection [end] |
@@ -742,6 +1027,11 @@ nodes
 | test.cpp:314:15:314:16 | xs | semmle.label | xs |
 | test.cpp:325:14:325:27 | new[] | semmle.label | new[] |
 | test.cpp:326:15:326:16 | xs | semmle.label | xs |
+| test.cpp:326:15:326:23 | ... + ... | semmle.label | ... + ... |
+| test.cpp:326:15:326:23 | ... + ... | semmle.label | ... + ... |
+| test.cpp:338:8:338:15 | * ... | semmle.label | * ... |
+| test.cpp:341:8:341:17 | * ... | semmle.label | * ... |
+| test.cpp:342:8:342:17 | * ... | semmle.label | * ... |
 | test.cpp:347:14:347:27 | new[] | semmle.label | new[] |
 | test.cpp:348:15:348:16 | xs | semmle.label | xs |
 | test.cpp:350:15:350:19 | Load: * ... | semmle.label | Load: * ... |

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/test.cpp
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/test.cpp
@@ -330,7 +330,7 @@ void test23(unsigned size, int val) {
     if(*current - xs < 1)
       return;
 
-    *--(*current) = 0; // GOOD [FALSE POSITIVE]
+    *--(*current) = 0; // GOOD
     return;
   }
 
@@ -338,7 +338,7 @@ void test23(unsigned size, int val) {
     if(*current - xs < 2)
       return;
 
-    *--(*current) = 0; // GOOD [FALSE POSITIVE]
+    *--(*current) = 0; // GOOD
     *--(*current) = 0; // GOOD
   }
 }


### PR DESCRIPTION
This avoids some counter-intuitive paths where we would seemingly jump back to an earlier instruction, which might actually have been in bounds.