### PR TITLE
Java: Improve FunctionalInterface computation join order

### DIFF
--- a/java/ql/lib/semmle/code/java/Type.qll
+++ b/java/ql/lib/semmle/code/java/Type.qll
@@ -987,6 +987,12 @@ private string getAPublicObjectMethodSignature() {
   )
 }
 
+pragma[noinline]
+private Method getAnInterfaceConcreteMethod(Interface interface) {
+  interface.inherits(result) and
+  not result.isAbstract()
+}
+
 private Method getAnAbstractMethod(Interface interface) {
   interface.inherits(result) and
   result.isAbstract() and
@@ -995,9 +1001,8 @@ private Method getAnAbstractMethod(Interface interface) {
   // Make sure that there is no other non-abstract method
   // (e.g. `default`) which overrides the abstract one
   not exists(Method m |
-    interface.inherits(m) and
-    not m.isAbstract() and
-    m.overrides(result)
+    m = getAnInterfaceConcreteMethod(interface) and
+    pragma[only_bind_out](m).overrides(result)
   )
 }
 


### PR DESCRIPTION
As reported by @rvermeulen, for very large code bases the current join order (find all interface abstract methods, join with all overrides of those methods, check if the interface also inherits a concrete override) can blow up. This tries hacking the order to instead take the product with concrete methods that interface inherits (potentially a lot, if the interface has lots of methods and lots of defaults!) then check whether one overrides the other.

Awaiting a performance check.