### PR TITLE
C++: Delete the constant stage of the new range analysis

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/rangeanalysis/new/SimpleRangeAnalysis.qll
+++ b/cpp/ql/lib/semmle/code/cpp/rangeanalysis/new/SimpleRangeAnalysis.qll
@@ -24,10 +24,10 @@ private import semmle.code.cpp.rangeanalysis.RangeAnalysisUtils
  *    `lowerBound(expr.getFullyConverted())`
  */
 float lowerBound(Expr expr) {
-  exists(Instruction i, ConstantBounds::SemBound b |
-    i.getAst() = expr and b instanceof ConstantBounds::SemZeroBound
+  exists(Instruction i, RelativeBounds::SemBound b |
+    i.getAst() = expr and b instanceof RelativeBounds::SemZeroBound
   |
-    ConstantStage::semBounded(getSemanticExpr(i), b, result, false, _)
+    RelativeStage::semBounded(getSemanticExpr(i), b, result, false, _)
   )
 }
 
@@ -44,10 +44,10 @@ float lowerBound(Expr expr) {
  *    `upperBound(expr.getFullyConverted())`
  */
 float upperBound(Expr expr) {
-  exists(Instruction i, ConstantBounds::SemBound b |
-    i.getAst() = expr and b instanceof ConstantBounds::SemZeroBound
+  exists(Instruction i, RelativeBounds::SemBound b |
+    i.getAst() = expr and b instanceof RelativeBounds::SemZeroBound
   |
-    ConstantStage::semBounded(getSemanticExpr(i), b, result, true, _)
+    RelativeStage::semBounded(getSemanticExpr(i), b, result, true, _)
   )
 }
 
@@ -101,8 +101,8 @@ predicate exprMightOverflowNegatively(Expr expr) {
   or
   exists(SemanticExprConfig::Expr semExpr |
     semExpr.getUnconverted().getAst() = expr and
-    ConstantStage::potentiallyOverflowingExpr(false, semExpr) and
-    not ConstantStage::initialBounded(semExpr, _, _, false, _, _, _)
+    RelativeStage::potentiallyOverflowingExpr(false, semExpr) and
+    not RelativeStage::initialBounded(semExpr, _, _, false, _, _, _)
   )
 }
 
@@ -127,8 +127,8 @@ predicate exprMightOverflowPositively(Expr expr) {
   or
   exists(SemanticExprConfig::Expr semExpr |
     semExpr.getUnconverted().getAst() = expr and
-    ConstantStage::potentiallyOverflowingExpr(true, semExpr) and
-    not ConstantStage::initialBounded(semExpr, _, _, true, _, _, _)
+    RelativeStage::potentiallyOverflowingExpr(true, semExpr) and
+    not RelativeStage::initialBounded(semExpr, _, _, true, _, _, _)
   )
 }
 

--- a/cpp/ql/lib/semmle/code/cpp/rangeanalysis/new/internal/semantic/analysis/FloatDelta.qll
+++ b/cpp/ql/lib/semmle/code/cpp/rangeanalysis/new/internal/semantic/analysis/FloatDelta.qll
@@ -24,7 +24,7 @@ module FloatOverflow implements OverflowSig<FloatDelta> {
   predicate semExprDoesNotOverflow(boolean positively, SemExpr expr) {
     exists(float lb, float ub, float delta |
       typeBounds(expr.getSemType(), lb, ub) and
-      ConstantStage::initialBounded(expr, any(ConstantBounds::SemZeroBound b), delta, positively, _,
+      RelativeStage::initialBounded(expr, any(RelativeBounds::SemZeroBound b), delta, positively, _,
         _, _)
     |
       positively = true and delta < ub
@@ -33,7 +33,7 @@ module FloatOverflow implements OverflowSig<FloatDelta> {
     )
   }
 
-  additional predicate typeBounds(SemType t, float lb, float ub) {
+  private predicate typeBounds(SemType t, float lb, float ub) {
     exists(SemIntegerType integralType, float limit |
       integralType = t and limit = 2.pow(8 * integralType.getByteSize())
     |

--- a/cpp/ql/lib/semmle/code/cpp/rangeanalysis/new/internal/semantic/analysis/RangeAnalysisRelativeSpecific.qll
+++ b/cpp/ql/lib/semmle/code/cpp/rangeanalysis/new/internal/semantic/analysis/RangeAnalysisRelativeSpecific.qll
@@ -24,38 +24,7 @@ module CppLangImplRelative implements LangSig<FloatDelta> {
    * This predicate is to keep the results identical to the original Java implementation. It should be
    * removed once we have the new implementation matching the old results exactly.
    */
-  predicate ignoreExprBound(SemExpr e) {
-    exists(boolean upper, float delta, ConstantBounds::SemZeroBound b, float lb, float ub |
-      ConstantStage::semBounded(e, b, delta, upper, _) and
-      typeBounds(e.getSemType(), lb, ub) and
-      (
-        upper = false and
-        delta < lb
-        or
-        upper = true and
-        delta > ub
-      )
-    )
-  }
-
-  private predicate typeBounds(SemType t, float lb, float ub) {
-    exists(SemIntegerType integralType, float limit |
-      integralType = t and limit = 2.pow(8 * integralType.getByteSize())
-    |
-      if integralType instanceof SemBooleanType
-      then lb = 0 and ub = 1
-      else
-        if integralType.isSigned()
-        then (
-          lb = -(limit / 2) and ub = (limit / 2) - 1
-        ) else (
-          lb = 0 and ub = limit - 1
-        )
-    )
-    or
-    // This covers all floating point types. The range is (-Inf, +Inf).
-    t instanceof SemFloatingPointType and lb = -(1.0 / 0.0) and ub = 1.0 / 0.0
-  }
+  predicate ignoreExprBound(SemExpr e) { none() }
 
   /**
    * Ignore any inferred zero lower bound on this expression.


### PR DESCRIPTION
In https://github.com/github/codeql/pull/11728 we split the new range analysis into two phases: one for constant bounds and one for relative bounds. However, it later turned out that this splitting wasn't actually needed (since we could add all the additional range analysis steps to both stages instead of just to the constant stage as we were initially expecting).

This PR removes the constant stage altogether, and replaces all of the internal uses of the constant stage with the relative stage. Hopefully, this means that the new range analysis library is slightly faster to compute 🤞.

@rdmarsh2 I'm keen to hear your thoughts on this.