### PR TITLE
C#: avoid calls to `Location::toString()`

### DIFF
--- a/csharp/ql/src/Bad Practices/Implementation Hiding/ExposeRepresentation.ql
+++ b/csharp/ql/src/Bad Practices/Implementation Hiding/ExposeRepresentation.ql
@@ -78,4 +78,4 @@ where
   exposesByStore(c, f, why, whyText)
 select c,
   "'" + c.getName() + "' exposes the internal representation stored in field '" + f.getName() +
-    "'. The value may be modified $@.", why.getLocation(), whyText
+    "'. The value may be modified $@.", why, whyText

--- a/csharp/ql/src/Complexity/ComplexCondition.ql
+++ b/csharp/ql/src/Complexity/ComplexCondition.ql
@@ -26,4 +26,4 @@ where
   operators =
     count(BinaryLogicalOperation op | logicalParent*(op, e) and nontrivialLogicalOperator(op)) and
   operators > 3
-select e.getLocation(), "Complex condition: too many logical operations in this expression."
+select e, "Complex condition: too many logical operations in this expression."

--- a/csharp/ql/test/query-tests/Bad Practices/Implementation Hiding/ExposeRepresentation/ExposeRepresentation.expected
+++ b/csharp/ql/test/query-tests/Bad Practices/Implementation Hiding/ExposeRepresentation/ExposeRepresentation.expected
@@ -1,2 +1,2 @@
-| ExposeRepresentation.cs:8:21:8:23 | Set | 'Set' exposes the internal representation stored in field 'rarray'. The value may be modified $@. | ExposeRepresentation.cs:16:9:16:9 | ExposeRepresentation.cs:16:9:16:9 | through the variable a |
-| ExposeRepresentationBad.cs:18:22:18:24 | Get | 'Get' exposes the internal representation stored in field 'rarray'. The value may be modified $@. | ExposeRepresentationBad.cs:24:23:24:29 | ExposeRepresentationBad.cs:24:23:24:29 | after this call to Get |
+| ExposeRepresentation.cs:8:21:8:23 | Set | 'Set' exposes the internal representation stored in field 'rarray'. The value may be modified $@. | ExposeRepresentation.cs:16:9:16:9 | access to local variable a | through the variable a |
+| ExposeRepresentationBad.cs:18:22:18:24 | Get | 'Get' exposes the internal representation stored in field 'rarray'. The value may be modified $@. | ExposeRepresentationBad.cs:24:23:24:29 | call to method Get | after this call to Get |


### PR DESCRIPTION
### Before
```
Most expensive predicates for completed query ComplexCondition.ql:
        time  | evals |   max @ iter | predicate
        ------|-------|--------------|----------
        22.5s |       |              | Location#a178a2aa::Location::toString#0#dispred#ff@736e93jb
         4.2s |       |              | locations_default_234501#join_rhs@ad8924cn
           2s |       |              | boundedFastTC:ExprOrStmtParent#051be664::Cached::parent#2#ff_10#higher_order_body:project#Callable#f85cebf6::Callable::getBody#0#dispred#ff@37a64ask
           2s |       |              | boundedFastTC:ExprOrStmtParent#051be664::Cached::parent#2#ff_10#higher_order_body:Callable#f85cebf6::Constructor::getInitializer#0#dispred#ff_1#higher_order_body@6cf8660h
```

It's not just slow, it also results in a lot of string-pool insertions:
```
Evaluated non-recursive predicate Location#a178a2aa::Location::toString#0#dispred#ff@736e93jb in 22467ms (size: 14941648).
Evaluated relational algebra for predicate Location#a178a2aa::Location::toString#0#dispred#ff@736e93jb with tuple counts:
             702   ~0%    {2} r1 = SCAN assemblies OUTPUT In.0, In.2
                      
        14940946   ~0%    {2} r2 = SCAN Location#a178a2aa::SourceLocation::hasLocationInfo#5#dispred#ffffff OUTPUT In.0, (In.1 ++ ":" ++ toString(In.2) ++ ":" ++ toString(In.3) ++ ":" ++ toString(In.4) ++ ":" ++ toString(In.5))
                      
        14941648   ~0%    {2} r3 = r1 UNION r2
                          return r3
```

### After
```
Most expensive predicates for completed query ComplexCondition.ql:
        time  | evals |   max @ iter | predicate
        ------|-------|--------------|----------
         9.5s |       |              | Element#5e6df1e8::Element::toString#0#dispred#ff@fcfdfe7e
         4.8s |    22 |  1.3s @ 9    | Element#5e6df1e8::NamedElement::getQualifiedName#0#dispred#ff@0ab92y65
         3.8s |       |              | locations_default_234501#join_rhs@ad8924cn
         3.4s |    22 | 227ms @ 6    | Generics#b6772a26::getTypeArgumentsQualifiedNames#1#ff@0ab92w65
```

It looks like this still results in an expensive call to `Element::toString()`, which is not ideal, but I think it's still a slight improvement.

## Test?
There doesn't appear to be a test for this query.