### PR TITLE
Swift: fix cmake generation

### DIFF
--- a/misc/bazel/cmake/cmake.bzl
+++ b/misc/bazel/cmake/cmake.bzl
@@ -11,8 +11,7 @@ CmakeInfo = provider(
         "includes": "",
         "quote_includes": "",
         "stripped_includes": "",
-        "imported_static_libs": "",
-        "imported_dynamic_libs": "",
+        "imported_libs": "",
         "copts": "",
         "linkopts": "",
         "force_cxx_compilation": "",
@@ -41,10 +40,8 @@ def _file_kind(file):
         return "src"
     if ext in ("h", "hh", "hpp", "def", "inc"):
         return "hdr"
-    if ext == "a":
-        return "static_lib"
-    if ext in ("so", "dylib"):
-        return "dynamic_lib"
+    if ext in ("a", "so", "dylib"):
+        return "lib"
     return None
 
 def _get_includes(includes):
@@ -70,8 +67,7 @@ def _cmake_aspect_impl(target, ctx):
         by_kind.setdefault(_file_kind(f), []).append(_cmake_file(f))
     hdrs = by_kind.get("hdr", [])
     srcs = by_kind.get("src", [])
-    static_libs = by_kind.get("static_lib", [])
-    dynamic_libs = by_kind.get("dynamic_lib", [])
+    libs = by_kind.get("lib", [])
     if not srcs and is_binary:
         empty = ctx.actions.declare_file(name + "_empty.cpp")
         ctx.actions.write(empty, "")
@@ -134,12 +130,15 @@ def _cmake_aspect_impl(target, ctx):
             system_includes = system_includes,
             quote_includes = quote_includes,
             stripped_includes = stripped_includes,
-            imported_static_libs = static_libs,
-            imported_dynamic_libs = dynamic_libs,
+            imported_libs = libs,
             copts = copts,
             linkopts = linkopts,
             defines = compilation_ctx.defines.to_list(),
-            local_defines = compilation_ctx.local_defines.to_list(),
+            local_defines = [
+                d
+                for d in compilation_ctx.local_defines.to_list()
+                if not d.startswith("BAZEL_CURRENT_REPOSITORY")
+            ],
             force_cxx_compilation = force_cxx_compilation,
             transitive_deps = depset(deps, transitive = [dep.transitive_deps for dep in deps]),
         ),
@@ -156,20 +155,10 @@ def _map_cmake_info(info, is_windows):
     commands = [
         "add_%s(%s)" % (info.kind, args),
     ]
-    if info.imported_static_libs and info.imported_dynamic_libs:
-        commands += [
-            "if(BUILD_SHARED_LIBS)",
-            "  target_link_libraries(%s %s %s)" %
-            (info.name, info.modifier or "PUBLIC", " ".join(info.imported_dynamic_libs)),
-            "else()",
-            "  target_link_libraries(%s %s %s)" %
-            (info.name, info.modifier or "PUBLIC", " ".join(info.imported_static_libs)),
-            "endif()",
-        ]
-    elif info.imported_static_libs or info.imported_dynamic_libs:
+    if info.imported_libs:
         commands += [
             "target_link_libraries(%s %s %s)" %
-            (info.name, info.modifier or "PUBLIC", " ".join(info.imported_dynamic_lib + info.imported_static_libs)),
+            (info.name, info.modifier or "PUBLIC", " ".join(info.imported_libs)),
         ]
     if info.deps:
         libs = {}

--- a/swift/BUILD.bazel
+++ b/swift/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_pkg//:mappings.bzl", "pkg_attributes", "pkg_filegroup", "pkg_files"
 load("@rules_pkg//:install.bzl", "pkg_install")
 load("//:defs.bzl", "codeql_platform")
 load("//misc/bazel:pkg_runfiles.bzl", "pkg_runfiles")
+load("//misc/bazel/cmake:cmake.bzl", "generate_cmake")
 
 filegroup(
     name = "schema",
@@ -105,4 +106,16 @@ py_binary(
     srcs = ["create_extractor_pack.py"],
     main = "create_extractor_pack.py",
     deps = [":_create_extractor_pack"],
+)
+
+generate_cmake(
+    name = "cmake",
+    targets = [
+        "//swift/extractor:extractor.real",
+        "//swift/logging/tests/assertion-diagnostics:assert-false",
+    ] + select({
+        "@platforms//os:linux": ["//swift/tools/autobuilder-diagnostics:incompatible-os"],
+        "@platforms//os:macos": ["//swift/xcode-autobuilder"],
+    }),
+    visibility = ["//visibility:public"],
 )

--- a/swift/CMakeLists.txt
+++ b/swift/CMakeLists.txt
@@ -17,7 +17,4 @@ project(codeql)
 
 include(../misc/bazel/cmake/setup.cmake)
 
-include_generated(//swift/extractor:cmake)
-if (APPLE)
-    include_generated(//swift/xcode-autobuilder:cmake)
-endif ()
+include_generated(//swift:cmake)

--- a/swift/extractor/BUILD.bazel
+++ b/swift/extractor/BUILD.bazel
@@ -8,6 +8,7 @@ swift_cc_binary(
         "*.h",
         "*.cpp",
     ]),
+    visibility = ["//swift:__pkg__"],
     deps = [
         "//swift/extractor/config",
         "//swift/extractor/infra",
@@ -17,12 +18,6 @@ swift_cc_binary(
         "//swift/third_party/swift-llvm-support",
         "@absl//absl/strings",
     ],
-)
-
-generate_cmake(
-    name = "cmake",
-    targets = [":extractor.real"],
-    visibility = ["//visibility:public"],
 )
 
 sh_binary(

--- a/swift/logging/tests/assertion-diagnostics/BUILD.bazel
+++ b/swift/logging/tests/assertion-diagnostics/BUILD.bazel
@@ -4,7 +4,7 @@ load("//misc/bazel/cmake:cmake.bzl", "generate_cmake")
 swift_cc_binary(
     name = "assert-false",
     srcs = ["AssertFalse.cpp"],
-    visibility = ["//visibility:private"],
+    visibility = ["//swift:__pkg__"],
     deps = [
         "//swift/logging",
     ],
@@ -14,12 +14,9 @@ py_test(
     name = "test",
     size = "small",
     srcs = ["test.py"],
+    data = [
+        "diagnostics.expected",
+        ":assert-false",
+    ],
     deps = ["//swift/integration-tests:integration_tests"],
-    data = [":assert-false", "diagnostics.expected"],
-)
-
-generate_cmake(
-    name = "cmake",
-    targets = [":assert-false"],
-    visibility = ["//visibility:public"],
 )

--- a/swift/tools/autobuilder-diagnostics/BUILD.bazel
+++ b/swift/tools/autobuilder-diagnostics/BUILD.bazel
@@ -1,5 +1,4 @@
 load("//swift:rules.bzl", "swift_cc_binary")
-load("//misc/bazel/cmake:cmake.bzl", "generate_cmake")
 
 swift_cc_binary(
     name = "incompatible-os",
@@ -8,10 +7,4 @@ swift_cc_binary(
     deps = [
         "//swift/logging",
     ],
-)
-
-generate_cmake(
-    name = "cmake",
-    targets = [":incompatible-os"],
-    visibility = ["//visibility:public"],
 )

--- a/swift/xcode-autobuilder/BUILD.bazel
+++ b/swift/xcode-autobuilder/BUILD.bazel
@@ -1,5 +1,4 @@
 load("//swift:rules.bzl", "swift_cc_binary")
-load("//misc/bazel/cmake:cmake.bzl", "generate_cmake")
 
 swift_cc_binary(
     name = "xcode-autobuilder",
@@ -7,20 +6,14 @@ swift_cc_binary(
         "*.cpp",
         "*.h",
     ]),
-    visibility = ["//swift:__subpackages__"],
     linkopts = [
         "-lxml2",
         "-framework CoreFoundation",
     ],
     target_compatible_with = ["@platforms//os:macos"],
+    visibility = ["//swift:__subpackages__"],
     deps = [
-        "@absl//absl/strings",
         "//swift/logging",
+        "@absl//absl/strings",
     ],
-)
-
-generate_cmake(
-    name = "cmake",
-    targets = [":xcode-autobuilder"],
-    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
The bazel -> cmake generator is currently not capable of handling separate included generated cmake files making use of common C/C++ dependencies.

To work around this limitation, a single generated cmake is now in place. Long-term, we should either:
* make the cmake generator handle common dependencies gracefully, or
* make the cmake generation aspect travel up `pkg_` rules `srcs` attributes

so to avoid having to list the targets to be generated in the top-level `BUILD` file.

Other things fixed:
* removed some warning spam about redefined `BAZEL_CURRENT_REPOSITORY`
* fixed the final link step, that was failing because `libswiftCore.so` was not being linked.