### PR TITLE
Java/Kotlin: Split lines of code by language

### DIFF
--- a/java/ql/src/Metrics/Summaries/LinesOfCode.ql
+++ b/java/ql/src/Metrics/Summaries/LinesOfCode.ql
@@ -1,8 +1,8 @@
 /**
  * @id java/summary/lines-of-code
  * @name Total lines of Java code in the database
- * @description The total number of lines of code across all files. This is a useful metric of the size of a database.
- *              For all files that were seen during the build, this query counts the lines of code, excluding whitespace
+ * @description The total number of lines of code across all Java files. This is a useful metric of the size of a database.
+ *              For all Java files that were seen during the build, this query counts the lines of code, excluding whitespace
  *              or comments.
  * @kind metric
  * @tags summary
@@ -11,4 +11,4 @@
 
 import java
 
-select sum(CompilationUnit f | f.fromSource() | f.getNumberOfLinesOfCode())
+select sum(CompilationUnit f | f.fromSource() and f.isJavaSourceFile() | f.getNumberOfLinesOfCode())

--- a/java/ql/src/Metrics/Summaries/LinesOfCodeKotlin.ql
+++ b/java/ql/src/Metrics/Summaries/LinesOfCodeKotlin.ql
@@ -1,0 +1,18 @@
+/**
+ * @id java/summary/lines-of-code-kotlin
+ * @name Total lines of Kotlin code in the database
+ * @description The total number of lines of code across all Kotlin files. This is a useful metric of the size of a database.
+ *              For all Kotlin files that were seen during the build, this query counts the lines of code, excluding whitespace
+ *              or comments.
+ * @kind metric
+ * @tags summary
+ *       lines-of-code
+ */
+
+import java
+
+select sum(CompilationUnit f |
+    f.fromSource() and f.isKotlinSourceFile()
+  |
+    f.getNumberOfLinesOfCode()
+  )

--- a/java/ql/src/change-notes/2023-06-05-lines-of-code.md
+++ b/java/ql/src/change-notes/2023-06-05-lines-of-code.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The `java/summary/lines-of-code` query now only counts lines of Java code. The new `java/summary/lines-of-code-kotlin` counts lines of Kotlin code.


### PR DESCRIPTION
We were giving the sum of all lines for both languages, but labelling it as "Total lines of Java code in the database", which was confusing.

Now we give separate sums for Kotlin and Java lines.