### PR TITLE
Kotlin: Add flow through kotlin.io.use and kotlin.with

### DIFF
--- a/java/ql/lib/change-notes/2023-06-06-kotlin-use-with-flow.md
+++ b/java/ql/lib/change-notes/2023-06-06-kotlin-use-with-flow.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Added flow through the block arguments of `kotlin.io.use` and `kotlin.with`.

--- a/java/ql/lib/ext/kotlin.io.model.yml
+++ b/java/ql/lib/ext/kotlin.io.model.yml
@@ -11,6 +11,8 @@ extensions:
       pack: codeql/java-all
       extensible: summaryModel
     data:
+      - ["kotlin.io", "CloseableKt", False, "use", "", "", "Argument[0]", "Argument[1].Parameter[0]", "value", "manual"]
+      - ["kotlin.io", "CloseableKt", False, "use", "", "", "Argument[1].ReturnValue", "ReturnValue", "value", "manual"]
       - ["kotlin.io", "FilesKt", False, "normalize", "(File)", "", "Argument[0]", "ReturnValue", "taint", "ai-manual"]
       - ["kotlin.io", "FilesKt", False, "relativeTo", "(File,File)", "", "Argument[0]", "ReturnValue", "taint", "ai-manual"]
       - ["kotlin.io", "FilesKt", False, "relativeTo", "(File,File)", "", "Argument[1]", "ReturnValue", "taint", "ai-manual"]

--- a/java/ql/lib/ext/kotlin.model.yml
+++ b/java/ql/lib/ext/kotlin.model.yml
@@ -1,0 +1,7 @@
+extensions:
+  - addsTo:
+      pack: codeql/java-all
+      extensible: summaryModel
+    data:
+      - ["kotlin", "StandardKt", False, "with", "", "", "Argument[0]", "Argument[1].Parameter[0]", "value", "manual"]
+      - ["kotlin", "StandardKt", False, "with", "", "", "Argument[1].ReturnValue", "ReturnValue", "value", "manual"]

--- a/java/ql/test/kotlin/library-tests/dataflow/summaries/use.kt
+++ b/java/ql/test/kotlin/library-tests/dataflow/summaries/use.kt
@@ -1,0 +1,11 @@
+import java.io.Closeable
+
+class UseFlowTest {
+    fun <T> taint(t: T) = t
+    fun sink(s: Closeable) { }
+
+    fun test(input: Closeable) {
+        taint(input).use { it -> sink(it) } // $ hasValueFlow
+        sink(taint(input).use { it }) // $ hasValueFlow
+    }
+}

--- a/java/ql/test/kotlin/library-tests/dataflow/summaries/with.kt
+++ b/java/ql/test/kotlin/library-tests/dataflow/summaries/with.kt
@@ -1,0 +1,9 @@
+class WithFlowTest {
+    fun <T> taint(t: T) = t
+    fun sink(s: String) { }
+
+    fun test(input: String) {
+        with(taint(input)) { sink(this) } // $ hasValueFlow
+        sink(with(taint(input)) { this }) // $ hasValueFlow
+    }
+}


### PR DESCRIPTION
Adds flow through the block arguments of [kotlin.io.use](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.io/use.html) and [kotlin.with](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/with.html).