### PR TITLE
JS: remove the second argument of findByIdAndUpdate as a NoSQL sink

### DIFF
--- a/javascript/ql/lib/semmle/javascript/security/TaintedObject.qll
+++ b/javascript/ql/lib/semmle/javascript/security/TaintedObject.qll
@@ -120,6 +120,22 @@ module TaintedObject {
     override predicate sanitizes(boolean outcome, Expr e) { e = x and outcome = polarity }
   }
 
+  /** A guard that checks whether an input a valid string identifier using `mongoose.Types.ObjectId.isValid` */
+  class ObjectIdGuard extends SanitizerGuard instanceof API::CallNode {
+    ObjectIdGuard() {
+      this =
+        API::moduleImport("mongoose")
+            .getMember("Types")
+            .getMember("ObjectId")
+            .getMember("isValid")
+            .getACall()
+    }
+
+    override predicate sanitizes(boolean outcome, Expr e, FlowLabel lbl) {
+      e = super.getAnArgument().asExpr() and outcome = true and lbl = label()
+    }
+  }
+
   /**
    * A sanitizer guard that validates an input against a JSON schema.
    */

--- a/javascript/ql/test/query-tests/Security/CWE-089/untyped/DatabaseAccesses.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-089/untyped/DatabaseAccesses.expected
@@ -27,7 +27,7 @@
 | mongoose.js:63:2:63:34 | Documen ... then(X) |
 | mongoose.js:65:2:65:51 | Documen ... on(){}) |
 | mongoose.js:67:2:68:27 | new Mon ... on(){}) |
-| mongoose.js:71:5:78:9 | Documen ... .exec() |
+| mongoose.js:71:2:78:9 | Documen ... .exec() |
 | mongoose.js:85:2:85:52 | Documen ... query)) |
 | mongoose.js:86:2:86:52 | Documen ... query)) |
 | mongoose.js:87:2:87:57 | Documen ... query)) |
@@ -42,8 +42,8 @@
 | mongoose.js:97:2:97:52 | Documen ... query)) |
 | mongoose.js:99:2:99:50 | Documen ... query)) |
 | mongoose.js:113:2:113:53 | Documen ... () { }) |
-| mongoose.js:134:6:134:55 | Documen ... on(){}) |
-| mongoose.js:136:6:136:55 | Documen ... on(){}) |
+| mongoose.js:134:3:134:52 | Documen ... on(){}) |
+| mongoose.js:136:3:136:52 | Documen ... on(){}) |
 | mysql.js:8:9:11:47 | connect ... ds) {}) |
 | mysql.js:14:9:16:47 | connect ... ds) {}) |
 | mysql.js:19:9:20:48 | connect ... ds) {}) |

--- a/javascript/ql/test/query-tests/Security/CWE-089/untyped/DatabaseAccesses.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-089/untyped/DatabaseAccesses.expected
@@ -42,6 +42,8 @@
 | mongoose.js:97:2:97:52 | Documen ... query)) |
 | mongoose.js:99:2:99:50 | Documen ... query)) |
 | mongoose.js:113:2:113:53 | Documen ... () { }) |
+| mongoose.js:134:6:134:55 | Documen ... on(){}) |
+| mongoose.js:136:6:136:55 | Documen ... on(){}) |
 | mysql.js:8:9:11:47 | connect ... ds) {}) |
 | mysql.js:14:9:16:47 | connect ... ds) {}) |
 | mysql.js:19:9:20:48 | connect ... ds) {}) |

--- a/javascript/ql/test/query-tests/Security/CWE-089/untyped/SqlInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-089/untyped/SqlInjection.expected
@@ -174,38 +174,38 @@ nodes
 | mongodb_bodySafe.js:24:19:24:33 | req.query.title |
 | mongodb_bodySafe.js:29:16:29:20 | query |
 | mongodb_bodySafe.js:29:16:29:20 | query |
-| mongoose.js:20:11:20:20 | query |
-| mongoose.js:20:19:20:20 | {} |
-| mongoose.js:21:19:21:26 | req.body |
-| mongoose.js:21:19:21:26 | req.body |
-| mongoose.js:21:19:21:32 | req.body.title |
-| mongoose.js:24:24:24:30 | [query] |
-| mongoose.js:24:24:24:30 | [query] |
-| mongoose.js:24:25:24:29 | query |
-| mongoose.js:27:20:27:24 | query |
-| mongoose.js:27:20:27:24 | query |
-| mongoose.js:30:25:30:29 | query |
-| mongoose.js:30:25:30:29 | query |
-| mongoose.js:33:24:33:28 | query |
-| mongoose.js:33:24:33:28 | query |
-| mongoose.js:36:31:36:35 | query |
-| mongoose.js:36:31:36:35 | query |
-| mongoose.js:39:19:39:23 | query |
-| mongoose.js:39:19:39:23 | query |
-| mongoose.js:42:22:42:26 | query |
-| mongoose.js:42:22:42:26 | query |
-| mongoose.js:45:31:45:35 | query |
-| mongoose.js:45:31:45:35 | query |
-| mongoose.js:48:31:48:35 | query |
-| mongoose.js:48:31:48:35 | query |
-| mongoose.js:51:31:51:35 | query |
-| mongoose.js:51:31:51:35 | query |
-| mongoose.js:54:25:54:29 | query |
-| mongoose.js:54:25:54:29 | query |
-| mongoose.js:57:21:57:25 | query |
-| mongoose.js:57:21:57:25 | query |
-| mongoose.js:60:25:60:29 | query |
-| mongoose.js:60:25:60:29 | query |
+| mongoose.js:20:8:20:17 | query |
+| mongoose.js:20:16:20:17 | {} |
+| mongoose.js:21:16:21:23 | req.body |
+| mongoose.js:21:16:21:23 | req.body |
+| mongoose.js:21:16:21:29 | req.body.title |
+| mongoose.js:24:21:24:27 | [query] |
+| mongoose.js:24:21:24:27 | [query] |
+| mongoose.js:24:22:24:26 | query |
+| mongoose.js:27:17:27:21 | query |
+| mongoose.js:27:17:27:21 | query |
+| mongoose.js:30:22:30:26 | query |
+| mongoose.js:30:22:30:26 | query |
+| mongoose.js:33:21:33:25 | query |
+| mongoose.js:33:21:33:25 | query |
+| mongoose.js:36:28:36:32 | query |
+| mongoose.js:36:28:36:32 | query |
+| mongoose.js:39:16:39:20 | query |
+| mongoose.js:39:16:39:20 | query |
+| mongoose.js:42:19:42:23 | query |
+| mongoose.js:42:19:42:23 | query |
+| mongoose.js:45:28:45:32 | query |
+| mongoose.js:45:28:45:32 | query |
+| mongoose.js:48:28:48:32 | query |
+| mongoose.js:48:28:48:32 | query |
+| mongoose.js:51:28:51:32 | query |
+| mongoose.js:51:28:51:32 | query |
+| mongoose.js:54:22:54:26 | query |
+| mongoose.js:54:22:54:26 | query |
+| mongoose.js:57:18:57:22 | query |
+| mongoose.js:57:18:57:22 | query |
+| mongoose.js:60:22:60:26 | query |
+| mongoose.js:60:22:60:26 | query |
 | mongoose.js:63:21:63:25 | query |
 | mongoose.js:63:21:63:25 | query |
 | mongoose.js:65:32:65:36 | query |
@@ -214,10 +214,10 @@ nodes
 | mongoose.js:67:27:67:31 | query |
 | mongoose.js:68:8:68:12 | query |
 | mongoose.js:68:8:68:12 | query |
-| mongoose.js:71:20:71:24 | query |
-| mongoose.js:71:20:71:24 | query |
-| mongoose.js:72:16:72:20 | query |
-| mongoose.js:72:16:72:20 | query |
+| mongoose.js:71:17:71:21 | query |
+| mongoose.js:71:17:71:21 | query |
+| mongoose.js:72:10:72:14 | query |
+| mongoose.js:72:10:72:14 | query |
 | mongoose.js:73:8:73:12 | query |
 | mongoose.js:73:8:73:12 | query |
 | mongoose.js:74:7:74:11 | query |
@@ -283,8 +283,8 @@ nodes
 | mongoose.js:130:16:130:26 | { _id: id } |
 | mongoose.js:130:16:130:26 | { _id: id } |
 | mongoose.js:130:23:130:24 | id |
-| mongoose.js:136:33:136:37 | query |
-| mongoose.js:136:33:136:37 | query |
+| mongoose.js:136:30:136:34 | query |
+| mongoose.js:136:30:136:34 | query |
 | mongooseJsonParse.js:19:11:19:20 | query |
 | mongooseJsonParse.js:19:19:19:20 | {} |
 | mongooseJsonParse.js:20:19:20:44 | JSON.pa ... y.data) |
@@ -625,147 +625,147 @@ edges
 | mongodb_bodySafe.js:24:19:24:33 | req.query.title | mongodb_bodySafe.js:29:16:29:20 | query |
 | mongodb_bodySafe.js:24:19:24:33 | req.query.title | mongodb_bodySafe.js:29:16:29:20 | query |
 | mongodb_bodySafe.js:24:19:24:33 | req.query.title | mongodb_bodySafe.js:29:16:29:20 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:24:25:24:29 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:27:20:27:24 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:27:20:27:24 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:30:25:30:29 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:30:25:30:29 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:33:24:33:28 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:33:24:33:28 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:36:31:36:35 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:36:31:36:35 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:39:19:39:23 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:39:19:39:23 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:42:22:42:26 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:42:22:42:26 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:45:31:45:35 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:45:31:45:35 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:48:31:48:35 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:48:31:48:35 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:51:31:51:35 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:51:31:51:35 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:54:25:54:29 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:54:25:54:29 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:57:21:57:25 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:57:21:57:25 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:60:25:60:29 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:60:25:60:29 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:63:21:63:25 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:63:21:63:25 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:65:32:65:36 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:65:32:65:36 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:67:27:67:31 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:67:27:67:31 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:68:8:68:12 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:68:8:68:12 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:71:20:71:24 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:71:20:71:24 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:72:16:72:20 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:72:16:72:20 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:73:8:73:12 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:73:8:73:12 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:74:7:74:11 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:74:7:74:11 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:75:16:75:20 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:75:16:75:20 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:77:10:77:14 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:77:10:77:14 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:82:46:82:50 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:82:46:82:50 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:83:47:83:51 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:83:47:83:51 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:85:46:85:50 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:85:46:85:50 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:87:51:87:55 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:87:51:87:55 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:89:46:89:50 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:89:46:89:50 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:92:46:92:50 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:92:46:92:50 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:94:51:94:55 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:94:51:94:55 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:96:46:96:50 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:96:46:96:50 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:111:14:111:18 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:111:14:111:18 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:113:31:113:35 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:113:31:113:35 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:136:33:136:37 | query |
-| mongoose.js:20:11:20:20 | query | mongoose.js:136:33:136:37 | query |
-| mongoose.js:20:19:20:20 | {} | mongoose.js:20:11:20:20 | query |
-| mongoose.js:21:19:21:26 | req.body | mongoose.js:21:19:21:32 | req.body.title |
-| mongoose.js:21:19:21:26 | req.body | mongoose.js:21:19:21:32 | req.body.title |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:20:11:20:20 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:20:19:20:20 | {} |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:24:25:24:29 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:27:20:27:24 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:27:20:27:24 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:30:25:30:29 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:30:25:30:29 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:33:24:33:28 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:33:24:33:28 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:36:31:36:35 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:36:31:36:35 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:39:19:39:23 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:39:19:39:23 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:42:22:42:26 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:42:22:42:26 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:45:31:45:35 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:45:31:45:35 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:48:31:48:35 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:48:31:48:35 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:51:31:51:35 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:51:31:51:35 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:54:25:54:29 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:54:25:54:29 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:57:21:57:25 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:57:21:57:25 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:60:25:60:29 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:60:25:60:29 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:63:21:63:25 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:63:21:63:25 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:65:32:65:36 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:65:32:65:36 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:67:27:67:31 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:67:27:67:31 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:68:8:68:12 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:68:8:68:12 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:71:20:71:24 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:71:20:71:24 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:72:16:72:20 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:72:16:72:20 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:73:8:73:12 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:73:8:73:12 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:74:7:74:11 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:74:7:74:11 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:75:16:75:20 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:75:16:75:20 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:77:10:77:14 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:77:10:77:14 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:82:46:82:50 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:82:46:82:50 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:83:47:83:51 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:83:47:83:51 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:85:46:85:50 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:85:46:85:50 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:87:51:87:55 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:87:51:87:55 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:89:46:89:50 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:89:46:89:50 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:92:46:92:50 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:92:46:92:50 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:94:51:94:55 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:94:51:94:55 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:96:46:96:50 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:96:46:96:50 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:111:14:111:18 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:111:14:111:18 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:113:31:113:35 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:113:31:113:35 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:136:33:136:37 | query |
-| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:136:33:136:37 | query |
-| mongoose.js:24:25:24:29 | query | mongoose.js:24:24:24:30 | [query] |
-| mongoose.js:24:25:24:29 | query | mongoose.js:24:24:24:30 | [query] |
+| mongoose.js:20:8:20:17 | query | mongoose.js:24:22:24:26 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:27:17:27:21 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:27:17:27:21 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:30:22:30:26 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:30:22:30:26 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:33:21:33:25 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:33:21:33:25 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:36:28:36:32 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:36:28:36:32 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:39:16:39:20 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:39:16:39:20 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:42:19:42:23 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:42:19:42:23 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:45:28:45:32 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:45:28:45:32 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:48:28:48:32 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:48:28:48:32 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:51:28:51:32 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:51:28:51:32 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:54:22:54:26 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:54:22:54:26 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:57:18:57:22 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:57:18:57:22 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:60:22:60:26 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:60:22:60:26 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:63:21:63:25 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:63:21:63:25 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:65:32:65:36 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:65:32:65:36 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:67:27:67:31 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:67:27:67:31 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:68:8:68:12 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:68:8:68:12 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:71:17:71:21 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:71:17:71:21 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:72:10:72:14 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:72:10:72:14 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:73:8:73:12 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:73:8:73:12 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:74:7:74:11 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:74:7:74:11 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:75:16:75:20 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:75:16:75:20 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:77:10:77:14 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:77:10:77:14 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:82:46:82:50 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:82:46:82:50 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:83:47:83:51 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:83:47:83:51 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:85:46:85:50 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:85:46:85:50 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:87:51:87:55 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:87:51:87:55 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:89:46:89:50 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:89:46:89:50 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:92:46:92:50 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:92:46:92:50 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:94:51:94:55 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:94:51:94:55 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:96:46:96:50 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:96:46:96:50 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:111:14:111:18 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:111:14:111:18 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:113:31:113:35 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:113:31:113:35 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:136:30:136:34 | query |
+| mongoose.js:20:8:20:17 | query | mongoose.js:136:30:136:34 | query |
+| mongoose.js:20:16:20:17 | {} | mongoose.js:20:8:20:17 | query |
+| mongoose.js:21:16:21:23 | req.body | mongoose.js:21:16:21:29 | req.body.title |
+| mongoose.js:21:16:21:23 | req.body | mongoose.js:21:16:21:29 | req.body.title |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:20:8:20:17 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:20:16:20:17 | {} |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:24:22:24:26 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:27:17:27:21 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:27:17:27:21 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:30:22:30:26 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:30:22:30:26 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:33:21:33:25 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:33:21:33:25 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:36:28:36:32 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:36:28:36:32 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:39:16:39:20 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:39:16:39:20 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:42:19:42:23 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:42:19:42:23 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:45:28:45:32 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:45:28:45:32 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:48:28:48:32 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:48:28:48:32 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:51:28:51:32 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:51:28:51:32 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:54:22:54:26 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:54:22:54:26 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:57:18:57:22 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:57:18:57:22 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:60:22:60:26 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:60:22:60:26 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:63:21:63:25 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:63:21:63:25 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:65:32:65:36 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:65:32:65:36 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:67:27:67:31 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:67:27:67:31 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:68:8:68:12 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:68:8:68:12 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:71:17:71:21 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:71:17:71:21 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:72:10:72:14 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:72:10:72:14 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:73:8:73:12 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:73:8:73:12 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:74:7:74:11 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:74:7:74:11 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:75:16:75:20 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:75:16:75:20 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:77:10:77:14 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:77:10:77:14 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:82:46:82:50 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:82:46:82:50 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:83:47:83:51 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:83:47:83:51 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:85:46:85:50 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:85:46:85:50 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:87:51:87:55 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:87:51:87:55 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:89:46:89:50 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:89:46:89:50 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:92:46:92:50 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:92:46:92:50 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:94:51:94:55 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:94:51:94:55 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:96:46:96:50 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:96:46:96:50 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:111:14:111:18 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:111:14:111:18 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:113:31:113:35 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:113:31:113:35 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:136:30:136:34 | query |
+| mongoose.js:21:16:21:29 | req.body.title | mongoose.js:136:30:136:34 | query |
+| mongoose.js:24:22:24:26 | query | mongoose.js:24:21:24:27 | [query] |
+| mongoose.js:24:22:24:26 | query | mongoose.js:24:21:24:27 | [query] |
 | mongoose.js:115:6:115:22 | id | mongoose.js:123:20:123:21 | id |
 | mongoose.js:115:6:115:22 | id | mongoose.js:123:20:123:21 | id |
 | mongoose.js:115:6:115:22 | id | mongoose.js:130:23:130:24 | id |
@@ -966,39 +966,39 @@ edges
 | mongodb.js:85:12:85:24 | { tags: tag } | mongodb.js:70:13:70:25 | req.query.tag | mongodb.js:85:12:85:24 | { tags: tag } | This query object depends on a $@. | mongodb.js:70:13:70:25 | req.query.tag | user-provided value |
 | mongodb.js:112:14:112:18 | query | mongodb.js:107:17:107:29 | queries.title | mongodb.js:112:14:112:18 | query | This query object depends on a $@. | mongodb.js:107:17:107:29 | queries.title | user-provided value |
 | mongodb_bodySafe.js:29:16:29:20 | query | mongodb_bodySafe.js:24:19:24:33 | req.query.title | mongodb_bodySafe.js:29:16:29:20 | query | This query object depends on a $@. | mongodb_bodySafe.js:24:19:24:33 | req.query.title | user-provided value |
-| mongoose.js:24:24:24:30 | [query] | mongoose.js:21:19:21:26 | req.body | mongoose.js:24:24:24:30 | [query] | This query object depends on a $@. | mongoose.js:21:19:21:26 | req.body | user-provided value |
-| mongoose.js:27:20:27:24 | query | mongoose.js:21:19:21:26 | req.body | mongoose.js:27:20:27:24 | query | This query object depends on a $@. | mongoose.js:21:19:21:26 | req.body | user-provided value |
-| mongoose.js:30:25:30:29 | query | mongoose.js:21:19:21:26 | req.body | mongoose.js:30:25:30:29 | query | This query object depends on a $@. | mongoose.js:21:19:21:26 | req.body | user-provided value |
-| mongoose.js:33:24:33:28 | query | mongoose.js:21:19:21:26 | req.body | mongoose.js:33:24:33:28 | query | This query object depends on a $@. | mongoose.js:21:19:21:26 | req.body | user-provided value |
-| mongoose.js:36:31:36:35 | query | mongoose.js:21:19:21:26 | req.body | mongoose.js:36:31:36:35 | query | This query object depends on a $@. | mongoose.js:21:19:21:26 | req.body | user-provided value |
-| mongoose.js:39:19:39:23 | query | mongoose.js:21:19:21:26 | req.body | mongoose.js:39:19:39:23 | query | This query object depends on a $@. | mongoose.js:21:19:21:26 | req.body | user-provided value |
-| mongoose.js:42:22:42:26 | query | mongoose.js:21:19:21:26 | req.body | mongoose.js:42:22:42:26 | query | This query object depends on a $@. | mongoose.js:21:19:21:26 | req.body | user-provided value |
-| mongoose.js:45:31:45:35 | query | mongoose.js:21:19:21:26 | req.body | mongoose.js:45:31:45:35 | query | This query object depends on a $@. | mongoose.js:21:19:21:26 | req.body | user-provided value |
-| mongoose.js:48:31:48:35 | query | mongoose.js:21:19:21:26 | req.body | mongoose.js:48:31:48:35 | query | This query object depends on a $@. | mongoose.js:21:19:21:26 | req.body | user-provided value |
-| mongoose.js:51:31:51:35 | query | mongoose.js:21:19:21:26 | req.body | mongoose.js:51:31:51:35 | query | This query object depends on a $@. | mongoose.js:21:19:21:26 | req.body | user-provided value |
-| mongoose.js:54:25:54:29 | query | mongoose.js:21:19:21:26 | req.body | mongoose.js:54:25:54:29 | query | This query object depends on a $@. | mongoose.js:21:19:21:26 | req.body | user-provided value |
-| mongoose.js:57:21:57:25 | query | mongoose.js:21:19:21:26 | req.body | mongoose.js:57:21:57:25 | query | This query object depends on a $@. | mongoose.js:21:19:21:26 | req.body | user-provided value |
-| mongoose.js:60:25:60:29 | query | mongoose.js:21:19:21:26 | req.body | mongoose.js:60:25:60:29 | query | This query object depends on a $@. | mongoose.js:21:19:21:26 | req.body | user-provided value |
-| mongoose.js:63:21:63:25 | query | mongoose.js:21:19:21:26 | req.body | mongoose.js:63:21:63:25 | query | This query object depends on a $@. | mongoose.js:21:19:21:26 | req.body | user-provided value |
-| mongoose.js:65:32:65:36 | query | mongoose.js:21:19:21:26 | req.body | mongoose.js:65:32:65:36 | query | This query object depends on a $@. | mongoose.js:21:19:21:26 | req.body | user-provided value |
-| mongoose.js:67:27:67:31 | query | mongoose.js:21:19:21:26 | req.body | mongoose.js:67:27:67:31 | query | This query object depends on a $@. | mongoose.js:21:19:21:26 | req.body | user-provided value |
-| mongoose.js:68:8:68:12 | query | mongoose.js:21:19:21:26 | req.body | mongoose.js:68:8:68:12 | query | This query object depends on a $@. | mongoose.js:21:19:21:26 | req.body | user-provided value |
-| mongoose.js:71:20:71:24 | query | mongoose.js:21:19:21:26 | req.body | mongoose.js:71:20:71:24 | query | This query object depends on a $@. | mongoose.js:21:19:21:26 | req.body | user-provided value |
-| mongoose.js:72:16:72:20 | query | mongoose.js:21:19:21:26 | req.body | mongoose.js:72:16:72:20 | query | This query object depends on a $@. | mongoose.js:21:19:21:26 | req.body | user-provided value |
-| mongoose.js:73:8:73:12 | query | mongoose.js:21:19:21:26 | req.body | mongoose.js:73:8:73:12 | query | This query object depends on a $@. | mongoose.js:21:19:21:26 | req.body | user-provided value |
-| mongoose.js:74:7:74:11 | query | mongoose.js:21:19:21:26 | req.body | mongoose.js:74:7:74:11 | query | This query object depends on a $@. | mongoose.js:21:19:21:26 | req.body | user-provided value |
-| mongoose.js:75:16:75:20 | query | mongoose.js:21:19:21:26 | req.body | mongoose.js:75:16:75:20 | query | This query object depends on a $@. | mongoose.js:21:19:21:26 | req.body | user-provided value |
-| mongoose.js:77:10:77:14 | query | mongoose.js:21:19:21:26 | req.body | mongoose.js:77:10:77:14 | query | This query object depends on a $@. | mongoose.js:21:19:21:26 | req.body | user-provided value |
-| mongoose.js:82:46:82:50 | query | mongoose.js:21:19:21:26 | req.body | mongoose.js:82:46:82:50 | query | This query object depends on a $@. | mongoose.js:21:19:21:26 | req.body | user-provided value |
-| mongoose.js:83:47:83:51 | query | mongoose.js:21:19:21:26 | req.body | mongoose.js:83:47:83:51 | query | This query object depends on a $@. | mongoose.js:21:19:21:26 | req.body | user-provided value |
-| mongoose.js:85:46:85:50 | query | mongoose.js:21:19:21:26 | req.body | mongoose.js:85:46:85:50 | query | This query object depends on a $@. | mongoose.js:21:19:21:26 | req.body | user-provided value |
-| mongoose.js:87:51:87:55 | query | mongoose.js:21:19:21:26 | req.body | mongoose.js:87:51:87:55 | query | This query object depends on a $@. | mongoose.js:21:19:21:26 | req.body | user-provided value |
-| mongoose.js:89:46:89:50 | query | mongoose.js:21:19:21:26 | req.body | mongoose.js:89:46:89:50 | query | This query object depends on a $@. | mongoose.js:21:19:21:26 | req.body | user-provided value |
-| mongoose.js:92:46:92:50 | query | mongoose.js:21:19:21:26 | req.body | mongoose.js:92:46:92:50 | query | This query object depends on a $@. | mongoose.js:21:19:21:26 | req.body | user-provided value |
-| mongoose.js:94:51:94:55 | query | mongoose.js:21:19:21:26 | req.body | mongoose.js:94:51:94:55 | query | This query object depends on a $@. | mongoose.js:21:19:21:26 | req.body | user-provided value |
-| mongoose.js:96:46:96:50 | query | mongoose.js:21:19:21:26 | req.body | mongoose.js:96:46:96:50 | query | This query object depends on a $@. | mongoose.js:21:19:21:26 | req.body | user-provided value |
-| mongoose.js:111:14:111:18 | query | mongoose.js:21:19:21:26 | req.body | mongoose.js:111:14:111:18 | query | This query object depends on a $@. | mongoose.js:21:19:21:26 | req.body | user-provided value |
-| mongoose.js:113:31:113:35 | query | mongoose.js:21:19:21:26 | req.body | mongoose.js:113:31:113:35 | query | This query object depends on a $@. | mongoose.js:21:19:21:26 | req.body | user-provided value |
+| mongoose.js:24:21:24:27 | [query] | mongoose.js:21:16:21:23 | req.body | mongoose.js:24:21:24:27 | [query] | This query object depends on a $@. | mongoose.js:21:16:21:23 | req.body | user-provided value |
+| mongoose.js:27:17:27:21 | query | mongoose.js:21:16:21:23 | req.body | mongoose.js:27:17:27:21 | query | This query object depends on a $@. | mongoose.js:21:16:21:23 | req.body | user-provided value |
+| mongoose.js:30:22:30:26 | query | mongoose.js:21:16:21:23 | req.body | mongoose.js:30:22:30:26 | query | This query object depends on a $@. | mongoose.js:21:16:21:23 | req.body | user-provided value |
+| mongoose.js:33:21:33:25 | query | mongoose.js:21:16:21:23 | req.body | mongoose.js:33:21:33:25 | query | This query object depends on a $@. | mongoose.js:21:16:21:23 | req.body | user-provided value |
+| mongoose.js:36:28:36:32 | query | mongoose.js:21:16:21:23 | req.body | mongoose.js:36:28:36:32 | query | This query object depends on a $@. | mongoose.js:21:16:21:23 | req.body | user-provided value |
+| mongoose.js:39:16:39:20 | query | mongoose.js:21:16:21:23 | req.body | mongoose.js:39:16:39:20 | query | This query object depends on a $@. | mongoose.js:21:16:21:23 | req.body | user-provided value |
+| mongoose.js:42:19:42:23 | query | mongoose.js:21:16:21:23 | req.body | mongoose.js:42:19:42:23 | query | This query object depends on a $@. | mongoose.js:21:16:21:23 | req.body | user-provided value |
+| mongoose.js:45:28:45:32 | query | mongoose.js:21:16:21:23 | req.body | mongoose.js:45:28:45:32 | query | This query object depends on a $@. | mongoose.js:21:16:21:23 | req.body | user-provided value |
+| mongoose.js:48:28:48:32 | query | mongoose.js:21:16:21:23 | req.body | mongoose.js:48:28:48:32 | query | This query object depends on a $@. | mongoose.js:21:16:21:23 | req.body | user-provided value |
+| mongoose.js:51:28:51:32 | query | mongoose.js:21:16:21:23 | req.body | mongoose.js:51:28:51:32 | query | This query object depends on a $@. | mongoose.js:21:16:21:23 | req.body | user-provided value |
+| mongoose.js:54:22:54:26 | query | mongoose.js:21:16:21:23 | req.body | mongoose.js:54:22:54:26 | query | This query object depends on a $@. | mongoose.js:21:16:21:23 | req.body | user-provided value |
+| mongoose.js:57:18:57:22 | query | mongoose.js:21:16:21:23 | req.body | mongoose.js:57:18:57:22 | query | This query object depends on a $@. | mongoose.js:21:16:21:23 | req.body | user-provided value |
+| mongoose.js:60:22:60:26 | query | mongoose.js:21:16:21:23 | req.body | mongoose.js:60:22:60:26 | query | This query object depends on a $@. | mongoose.js:21:16:21:23 | req.body | user-provided value |
+| mongoose.js:63:21:63:25 | query | mongoose.js:21:16:21:23 | req.body | mongoose.js:63:21:63:25 | query | This query object depends on a $@. | mongoose.js:21:16:21:23 | req.body | user-provided value |
+| mongoose.js:65:32:65:36 | query | mongoose.js:21:16:21:23 | req.body | mongoose.js:65:32:65:36 | query | This query object depends on a $@. | mongoose.js:21:16:21:23 | req.body | user-provided value |
+| mongoose.js:67:27:67:31 | query | mongoose.js:21:16:21:23 | req.body | mongoose.js:67:27:67:31 | query | This query object depends on a $@. | mongoose.js:21:16:21:23 | req.body | user-provided value |
+| mongoose.js:68:8:68:12 | query | mongoose.js:21:16:21:23 | req.body | mongoose.js:68:8:68:12 | query | This query object depends on a $@. | mongoose.js:21:16:21:23 | req.body | user-provided value |
+| mongoose.js:71:17:71:21 | query | mongoose.js:21:16:21:23 | req.body | mongoose.js:71:17:71:21 | query | This query object depends on a $@. | mongoose.js:21:16:21:23 | req.body | user-provided value |
+| mongoose.js:72:10:72:14 | query | mongoose.js:21:16:21:23 | req.body | mongoose.js:72:10:72:14 | query | This query object depends on a $@. | mongoose.js:21:16:21:23 | req.body | user-provided value |
+| mongoose.js:73:8:73:12 | query | mongoose.js:21:16:21:23 | req.body | mongoose.js:73:8:73:12 | query | This query object depends on a $@. | mongoose.js:21:16:21:23 | req.body | user-provided value |
+| mongoose.js:74:7:74:11 | query | mongoose.js:21:16:21:23 | req.body | mongoose.js:74:7:74:11 | query | This query object depends on a $@. | mongoose.js:21:16:21:23 | req.body | user-provided value |
+| mongoose.js:75:16:75:20 | query | mongoose.js:21:16:21:23 | req.body | mongoose.js:75:16:75:20 | query | This query object depends on a $@. | mongoose.js:21:16:21:23 | req.body | user-provided value |
+| mongoose.js:77:10:77:14 | query | mongoose.js:21:16:21:23 | req.body | mongoose.js:77:10:77:14 | query | This query object depends on a $@. | mongoose.js:21:16:21:23 | req.body | user-provided value |
+| mongoose.js:82:46:82:50 | query | mongoose.js:21:16:21:23 | req.body | mongoose.js:82:46:82:50 | query | This query object depends on a $@. | mongoose.js:21:16:21:23 | req.body | user-provided value |
+| mongoose.js:83:47:83:51 | query | mongoose.js:21:16:21:23 | req.body | mongoose.js:83:47:83:51 | query | This query object depends on a $@. | mongoose.js:21:16:21:23 | req.body | user-provided value |
+| mongoose.js:85:46:85:50 | query | mongoose.js:21:16:21:23 | req.body | mongoose.js:85:46:85:50 | query | This query object depends on a $@. | mongoose.js:21:16:21:23 | req.body | user-provided value |
+| mongoose.js:87:51:87:55 | query | mongoose.js:21:16:21:23 | req.body | mongoose.js:87:51:87:55 | query | This query object depends on a $@. | mongoose.js:21:16:21:23 | req.body | user-provided value |
+| mongoose.js:89:46:89:50 | query | mongoose.js:21:16:21:23 | req.body | mongoose.js:89:46:89:50 | query | This query object depends on a $@. | mongoose.js:21:16:21:23 | req.body | user-provided value |
+| mongoose.js:92:46:92:50 | query | mongoose.js:21:16:21:23 | req.body | mongoose.js:92:46:92:50 | query | This query object depends on a $@. | mongoose.js:21:16:21:23 | req.body | user-provided value |
+| mongoose.js:94:51:94:55 | query | mongoose.js:21:16:21:23 | req.body | mongoose.js:94:51:94:55 | query | This query object depends on a $@. | mongoose.js:21:16:21:23 | req.body | user-provided value |
+| mongoose.js:96:46:96:50 | query | mongoose.js:21:16:21:23 | req.body | mongoose.js:96:46:96:50 | query | This query object depends on a $@. | mongoose.js:21:16:21:23 | req.body | user-provided value |
+| mongoose.js:111:14:111:18 | query | mongoose.js:21:16:21:23 | req.body | mongoose.js:111:14:111:18 | query | This query object depends on a $@. | mongoose.js:21:16:21:23 | req.body | user-provided value |
+| mongoose.js:113:31:113:35 | query | mongoose.js:21:16:21:23 | req.body | mongoose.js:113:31:113:35 | query | This query object depends on a $@. | mongoose.js:21:16:21:23 | req.body | user-provided value |
 | mongoose.js:116:22:116:25 | cond | mongoose.js:115:32:115:45 | req.query.cond | mongoose.js:116:22:116:25 | cond | This query object depends on a $@. | mongoose.js:115:32:115:45 | req.query.cond | user-provided value |
 | mongoose.js:117:21:117:24 | cond | mongoose.js:115:32:115:45 | req.query.cond | mongoose.js:117:21:117:24 | cond | This query object depends on a $@. | mongoose.js:115:32:115:45 | req.query.cond | user-provided value |
 | mongoose.js:118:21:118:24 | cond | mongoose.js:115:32:115:45 | req.query.cond | mongoose.js:118:21:118:24 | cond | This query object depends on a $@. | mongoose.js:115:32:115:45 | req.query.cond | user-provided value |
@@ -1014,7 +1014,7 @@ edges
 | mongoose.js:128:22:128:25 | cond | mongoose.js:115:32:115:45 | req.query.cond | mongoose.js:128:22:128:25 | cond | This query object depends on a $@. | mongoose.js:115:32:115:45 | req.query.cond | user-provided value |
 | mongoose.js:129:21:129:24 | cond | mongoose.js:115:32:115:45 | req.query.cond | mongoose.js:129:21:129:24 | cond | This query object depends on a $@. | mongoose.js:115:32:115:45 | req.query.cond | user-provided value |
 | mongoose.js:130:16:130:26 | { _id: id } | mongoose.js:115:11:115:22 | req.query.id | mongoose.js:130:16:130:26 | { _id: id } | This query object depends on a $@. | mongoose.js:115:11:115:22 | req.query.id | user-provided value |
-| mongoose.js:136:33:136:37 | query | mongoose.js:21:19:21:26 | req.body | mongoose.js:136:33:136:37 | query | This query object depends on a $@. | mongoose.js:21:19:21:26 | req.body | user-provided value |
+| mongoose.js:136:30:136:34 | query | mongoose.js:21:16:21:23 | req.body | mongoose.js:136:30:136:34 | query | This query object depends on a $@. | mongoose.js:21:16:21:23 | req.body | user-provided value |
 | mongooseJsonParse.js:23:19:23:23 | query | mongooseJsonParse.js:20:30:20:43 | req.query.data | mongooseJsonParse.js:23:19:23:23 | query | This query object depends on a $@. | mongooseJsonParse.js:20:30:20:43 | req.query.data | user-provided value |
 | mongooseModelClient.js:11:16:11:24 | { id: v } | mongooseModelClient.js:10:22:10:29 | req.body | mongooseModelClient.js:11:16:11:24 | { id: v } | This query object depends on a $@. | mongooseModelClient.js:10:22:10:29 | req.body | user-provided value |
 | mongooseModelClient.js:12:16:12:34 | { id: req.body.id } | mongooseModelClient.js:12:22:12:29 | req.body | mongooseModelClient.js:12:16:12:34 | { id: req.body.id } | This query object depends on a $@. | mongooseModelClient.js:12:22:12:29 | req.body | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-089/untyped/SqlInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-089/untyped/SqlInjection.expected
@@ -283,6 +283,8 @@ nodes
 | mongoose.js:130:16:130:26 | { _id: id } |
 | mongoose.js:130:16:130:26 | { _id: id } |
 | mongoose.js:130:23:130:24 | id |
+| mongoose.js:136:33:136:37 | query |
+| mongoose.js:136:33:136:37 | query |
 | mongooseJsonParse.js:19:11:19:20 | query |
 | mongooseJsonParse.js:19:19:19:20 | {} |
 | mongooseJsonParse.js:20:19:20:44 | JSON.pa ... y.data) |
@@ -688,6 +690,8 @@ edges
 | mongoose.js:20:11:20:20 | query | mongoose.js:111:14:111:18 | query |
 | mongoose.js:20:11:20:20 | query | mongoose.js:113:31:113:35 | query |
 | mongoose.js:20:11:20:20 | query | mongoose.js:113:31:113:35 | query |
+| mongoose.js:20:11:20:20 | query | mongoose.js:136:33:136:37 | query |
+| mongoose.js:20:11:20:20 | query | mongoose.js:136:33:136:37 | query |
 | mongoose.js:20:19:20:20 | {} | mongoose.js:20:11:20:20 | query |
 | mongoose.js:21:19:21:26 | req.body | mongoose.js:21:19:21:32 | req.body.title |
 | mongoose.js:21:19:21:26 | req.body | mongoose.js:21:19:21:32 | req.body.title |
@@ -758,6 +762,8 @@ edges
 | mongoose.js:21:19:21:32 | req.body.title | mongoose.js:111:14:111:18 | query |
 | mongoose.js:21:19:21:32 | req.body.title | mongoose.js:113:31:113:35 | query |
 | mongoose.js:21:19:21:32 | req.body.title | mongoose.js:113:31:113:35 | query |
+| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:136:33:136:37 | query |
+| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:136:33:136:37 | query |
 | mongoose.js:24:25:24:29 | query | mongoose.js:24:24:24:30 | [query] |
 | mongoose.js:24:25:24:29 | query | mongoose.js:24:24:24:30 | [query] |
 | mongoose.js:115:6:115:22 | id | mongoose.js:123:20:123:21 | id |
@@ -1008,6 +1014,7 @@ edges
 | mongoose.js:128:22:128:25 | cond | mongoose.js:115:32:115:45 | req.query.cond | mongoose.js:128:22:128:25 | cond | This query object depends on a $@. | mongoose.js:115:32:115:45 | req.query.cond | user-provided value |
 | mongoose.js:129:21:129:24 | cond | mongoose.js:115:32:115:45 | req.query.cond | mongoose.js:129:21:129:24 | cond | This query object depends on a $@. | mongoose.js:115:32:115:45 | req.query.cond | user-provided value |
 | mongoose.js:130:16:130:26 | { _id: id } | mongoose.js:115:11:115:22 | req.query.id | mongoose.js:130:16:130:26 | { _id: id } | This query object depends on a $@. | mongoose.js:115:11:115:22 | req.query.id | user-provided value |
+| mongoose.js:136:33:136:37 | query | mongoose.js:21:19:21:26 | req.body | mongoose.js:136:33:136:37 | query | This query object depends on a $@. | mongoose.js:21:19:21:26 | req.body | user-provided value |
 | mongooseJsonParse.js:23:19:23:23 | query | mongooseJsonParse.js:20:30:20:43 | req.query.data | mongooseJsonParse.js:23:19:23:23 | query | This query object depends on a $@. | mongooseJsonParse.js:20:30:20:43 | req.query.data | user-provided value |
 | mongooseModelClient.js:11:16:11:24 | { id: v } | mongooseModelClient.js:10:22:10:29 | req.body | mongooseModelClient.js:11:16:11:24 | { id: v } | This query object depends on a $@. | mongooseModelClient.js:10:22:10:29 | req.body | user-provided value |
 | mongooseModelClient.js:12:16:12:34 | { id: req.body.id } | mongooseModelClient.js:12:22:12:29 | req.body | mongooseModelClient.js:12:16:12:34 | { id: req.body.id } | This query object depends on a $@. | mongooseModelClient.js:12:22:12:29 | req.body | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-089/untyped/mongoose.js
+++ b/javascript/ql/test/query-tests/Security/CWE-089/untyped/mongoose.js
@@ -104,7 +104,7 @@ app.post('/documents/find', (req, res) => {
 	new innocent(X, Y, query);
 
 	function getQueryConstructor() {
-		return Mongoose.Query;
+	return Mongoose.Query;
 	}
 
 	var C = getQueryConstructor();
@@ -129,4 +129,10 @@ app.post('/documents/find', (req, res) => {
 	Document.updateOne(cond, Y); // NOT OK
 	Document.find({ _id: id }); // NOT OK
 	Document.find({ _id: { $eq: id } }); // OK
+
+    if (Mongoose.Types.ObjectId.isValid(query)) {
+    	Document.findByIdAndUpdate(query, X, function(){}); // OK - is sanitized
+    } else {
+    	Document.findByIdAndUpdate(query, X, function(){}); // NOT OK
+    }
 });

--- a/javascript/ql/test/query-tests/Security/CWE-089/untyped/mongoose.js
+++ b/javascript/ql/test/query-tests/Security/CWE-089/untyped/mongoose.js
@@ -9,57 +9,57 @@ const app = Express();
 app.use(BodyParser.json());
 
 const Document = Mongoose.model('Document', {
-    title: {
-        type: String,
-        unique: true
-    },
-    type: String
+	title: {
+		type: String,
+		unique: true
+	},
+	type: String
 });
 
 app.post('/documents/find', (req, res) => {
-    const query = {};
-    query.title = req.body.title;
+	const query = {};
+	query.title = req.body.title;
 
-    // NOT OK: query is tainted by user-provided object value
-    Document.aggregate([query]);
+	// NOT OK: query is tainted by user-provided object value
+	Document.aggregate([query]);
 
-    // NOT OK: query is tainted by user-provided object value
-    Document.count(query);
+	// NOT OK: query is tainted by user-provided object value
+	Document.count(query);
 
-    // NOT OK: query is tainted by user-provided object value
-    Document.deleteMany(query);
+	// NOT OK: query is tainted by user-provided object value
+	Document.deleteMany(query);
 
-    // NOT OK: query is tainted by user-provided object value
-    Document.deleteOne(query);
+	// NOT OK: query is tainted by user-provided object value
+	Document.deleteOne(query);
 
-    // NOT OK: query is tainted by user-provided object value
-    Document.distinct('type', query);
+	// NOT OK: query is tainted by user-provided object value
+	Document.distinct('type', query);
 
-    // NOT OK: query is tainted by user-provided object value
-    Document.find(query);
+	// NOT OK: query is tainted by user-provided object value
+	Document.find(query);
 
-    // NOT OK: query is tainted by user-provided object value
-    Document.findOne(query);
+	// NOT OK: query is tainted by user-provided object value
+	Document.findOne(query);
 
-    // NOT OK: query is tainted by user-provided object value
-    Document.findOneAndDelete(query);
+	// NOT OK: query is tainted by user-provided object value
+	Document.findOneAndDelete(query);
 
-    // NOT OK: query is tainted by user-provided object value
-    Document.findOneAndRemove(query);
+	// NOT OK: query is tainted by user-provided object value
+	Document.findOneAndRemove(query);
 
-    // NOT OK: query is tainted by user-provided object value
-    Document.findOneAndUpdate(query);
+	// NOT OK: query is tainted by user-provided object value
+	Document.findOneAndUpdate(query);
 
-    // NOT OK: query is tainted by user-provided object value
-    Document.replaceOne(query);
+	// NOT OK: query is tainted by user-provided object value
+	Document.replaceOne(query);
 
-    // NOT OK: query is tainted by user-provided object value
-    Document.update(query);
+	// NOT OK: query is tainted by user-provided object value
+	Document.update(query);
 
-    // NOT OK: query is tainted by user-provided object value
-    Document.updateMany(query);
+	// NOT OK: query is tainted by user-provided object value
+	Document.updateMany(query);
 
-    // NOT OK: query is tainted by user-provided object value
+	// NOT OK: query is tainted by user-provided object value
 	Document.updateOne(query).then(X);
 
 	Document.findByIdAndUpdate(X, query, function(){}); // NOT OK
@@ -68,8 +68,8 @@ app.post('/documents/find', (req, res) => {
 		.and(query, function(){}) // NOT OK
 	;
 
-    Document.where(query)	// NOT OK - `.where()` on a Model. 
-        .where(query)	// NOT OK - `.where()` on a Query. 
+	Document.where(query)	// NOT OK - `.where()` on a Model. 
+		.where(query)	// NOT OK - `.where()` on a Query. 
 		.and(query) // NOT OK
 		.or(query) // NOT OK
 		.distinct(X, query) // NOT OK
@@ -97,7 +97,7 @@ app.post('/documents/find', (req, res) => {
 	Document.find(X).then(Y, (err) => err.count(query)); // OK
 
 	Document.count(X, (err, res) => res.count(query)); // OK (res is a number)
-    
+	
 	function innocent(X, Y, query) { // To detect if API-graphs were used incorrectly.
 		return new Mongoose.Query("constant", "constant", "constant");
 	}
@@ -130,9 +130,9 @@ app.post('/documents/find', (req, res) => {
 	Document.find({ _id: id }); // NOT OK
 	Document.find({ _id: { $eq: id } }); // OK
 
-    if (Mongoose.Types.ObjectId.isValid(query)) {
-    	Document.findByIdAndUpdate(query, X, function(){}); // OK - is sanitized
-    } else {
-    	Document.findByIdAndUpdate(query, X, function(){}); // NOT OK
-    }
+	if (Mongoose.Types.ObjectId.isValid(query)) {
+		Document.findByIdAndUpdate(query, X, function(){}); // OK - is sanitized
+	} else {
+		Document.findByIdAndUpdate(query, X, function(){}); // NOT OK
+	}
 });


### PR DESCRIPTION
2 things:  

1) I was looking at `findByIdAndUpdate`, and I was surprised we flag the second argument as a NoSQL sink.   
See doc: https://mongoosejs.com/docs/tutorials/findoneandupdate.html. The second argument is the data given to the update function, so I'm unsure how that could be unsafe? 

2) A friend of mine likes to use `mongoose.Types.ObjectId.isValid` as a sanitizer for NoSQL injection.  
The function checks if an input is a string of a certain length, so it is a nice sanitizer for object-injection in general.  
I therefore decided to put it in `TaintedObject.qll`, let me know if you want it somewhere else.    
[The function is used a decent amount in the wild.](https://github.com/search?type=code&q=mongoose.Types.ObjectId.isValid)

[Evaluation looks good](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/pr-13381-d504c9__nightly-old__code-scanning/reports).  
There is one lost result, where we no longer flag the second argument on a call to `update`.  
(We still flag the first argument to that same call).  