### PR TITLE
C#: Change standalone extraction to allow unsafe code

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp.Standalone/Extractor.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.Standalone/Extractor.cs
@@ -33,7 +33,9 @@ namespace Semmle.Extraction.CSharp.Standalone
             CSharp.Extractor.Analyse(stopwatch, analyser, options,
                 references => GetResolvedReferencesStandalone(referencePaths, references),
                 (analyser, syntaxTrees) => CSharp.Extractor.ReadSyntaxTrees(sources, analyser, null, null, syntaxTrees),
-                (syntaxTrees, references) => CSharpCompilation.Create("csharp.dll", syntaxTrees, references),
+                (syntaxTrees, references) => CSharpCompilation.Create(
+                    "csharp.dll", syntaxTrees, references, new CSharpCompilationOptions(OutputKind.ConsoleApplication, allowUnsafe: true)
+                    ),
                 (compilation, options) => analyser.Initialize(compilation, options),
                 () => { },
                 _ => { },


### PR DESCRIPTION
This PR changes standalone extraction to allow unsafe code. I don't think this change is observable through the extracted DB, but the underlying Roslyn compilation object reported corresponding (avoidable) diagnostics.