### PR TITLE
C#: Improve error message for missing explicit interface implementation

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Method.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Method.cs
@@ -243,7 +243,12 @@ namespace Semmle.Extraction.CSharp.Entities
             if (methodKind == MethodKind.ExplicitInterfaceImplementation)
             {
                 // Retrieve the original method kind
-                methodKind = methodDecl.ExplicitInterfaceImplementations.Select(m => m.MethodKind).FirstOrDefault();
+                if (methodDecl.ExplicitInterfaceImplementations.IsEmpty)
+                {
+                    throw new InternalError(methodDecl, $"Couldn't get the original method kind for explicit interface implementation");
+                }
+
+                methodKind = methodDecl.ExplicitInterfaceImplementations.Select(m => m.MethodKind).First();
             }
 
             switch (methodKind)


### PR DESCRIPTION
 In standalone extraction I observed that `.FirstOrDefault()` was in fact returning the default value, which is `MethodKind.AnonymousFunction`. This led to an extraction error with the message `"Attempt to create a lambda"`. This PR checks if the explicit interface implementation is available or not. If not, it raises an exception with a proper error message. 