### PR TITLE
Python: Avoid duplicated query-id

### DIFF
--- a/python/ql/src/experimental/Security/CWE-074/paramiko/paramiko.ql
+++ b/python/ql/src/experimental/Security/CWE-074/paramiko/paramiko.ql
@@ -5,7 +5,7 @@
  * @problem.severity error
  * @security-severity 9.3
  * @precision high
- * @id py/command-injection
+ * @id py/paramiko-command-injection
  * @tags security
  *       experimental
  *       external/cwe/cwe-074


### PR DESCRIPTION
When I made this PR I had forgotten that we actually use a different name for the real query :facepalm: anyway, think this change will still be good :+1:

https://github.com/github/codeql/blob/b5bbe6314463b80cd2bbf9a0c749b70b30c21db9/python/ql/src/Security/CWE-078/CommandInjection.ql#L10