### PR TITLE
java: test type tracking through flow summaries

### DIFF
--- a/java/ql/test/library-tests/dispatch/CallableViaSummary.java
+++ b/java/ql/test/library-tests/dispatch/CallableViaSummary.java
@@ -1,0 +1,31 @@
+import java.util.*;
+
+public class CallableViaSummary {
+    public interface Element {
+        public void handle(String message);
+    }
+
+    public void main(String[] args) {
+        List<Element> elements = new ArrayList<>();
+
+        List<Element> elements2 = new ArrayList<>();
+
+        elements.add(new Element() {
+            @Override
+            public void handle(String message) {
+                System.out.println(message);
+            }
+        });
+
+        elements.add(message -> System.out.println(message));
+
+        // This dispatches to the two added elements because
+        // the summary of ArrayList causes flow via type tracking.
+        elements.get(0).handle("Hello, world!");
+
+        // This does not dispatch to anything, showing that the
+        // open-world assumption does not apply
+        // (and hence that type tracking is necessary above).
+        elements2.get(0).handle("Hello, world!");
+    }
+}

--- a/java/ql/test/library-tests/dispatch/viaSummary.expected
+++ b/java/ql/test/library-tests/dispatch/viaSummary.expected
@@ -1,0 +1,2 @@
+| CallableViaSummary.java:24:9:24:47 | handle(...) | CallableViaSummary.java:15:25:15:30 | handle |
+| CallableViaSummary.java:24:9:24:47 | handle(...) | CallableViaSummary.java:20:22:20:59 | handle |

--- a/java/ql/test/library-tests/dispatch/viaSummary.ql
+++ b/java/ql/test/library-tests/dispatch/viaSummary.ql
@@ -1,0 +1,9 @@
+import java
+import semmle.code.java.dispatch.VirtualDispatch
+
+from MethodAccess ma, Method m
+where
+  m = viableImpl(ma) and
+  m.fromSource() and
+  ma.getFile().toString().matches("CallableViaSummary")
+select ma, m

--- a/java/ql/test/library-tests/dispatch/viaSummary.ql
+++ b/java/ql/test/library-tests/dispatch/viaSummary.ql
@@ -5,5 +5,5 @@ from MethodAccess ma, Method m
 where
   m = viableImpl(ma) and
   m.fromSource() and
-  ma.getFile().toString().matches("CallableViaSummary")
+  ma.getFile().toString() = "CallableViaSummary"
 select ma, m


### PR DESCRIPTION
Type tracking in Java is used to enhance the dispatch relation by establishing flow to certain callables, thereby making them viable callables.

This test shows that type tracking can step through flow summaries and establish flow to a lambda inside an `ArrayList`. A second, empty `ArrayList` from which no dispatch happens, serves to show that the flow was necessary for the dispatch to occur. 