### PR TITLE
Java: Improve join-order for FunctionalInterface.

### DIFF
--- a/java/ql/lib/semmle/code/java/Type.qll
+++ b/java/ql/lib/semmle/code/java/Type.qll
@@ -987,6 +987,17 @@ private string getAPublicObjectMethodSignature() {
   )
 }
 
+pragma[nomagic]
+private predicate interfaceInheritsOverridingNonAbstractMethod(Interface interface, Method m) {
+  interface.inherits(m) and
+  not m.isAbstract() and
+  m.overrides(_)
+}
+
+bindingset[m]
+pragma[inline_late]
+private Method getAnOverridden(Method m) { m.overrides(result) }
+
 private Method getAnAbstractMethod(Interface interface) {
   interface.inherits(result) and
   result.isAbstract() and
@@ -995,9 +1006,8 @@ private Method getAnAbstractMethod(Interface interface) {
   // Make sure that there is no other non-abstract method
   // (e.g. `default`) which overrides the abstract one
   not exists(Method m |
-    interface.inherits(m) and
-    not m.isAbstract() and
-    m.overrides(result)
+    interfaceInheritsOverridingNonAbstractMethod(interface, m) and
+    result = getAnOverridden(m)
   )
 }
 


### PR DESCRIPTION
Reimplements https://github.com/github/codeql/pull/13357

> As reported by @rvermeulen, for very large code bases the current join order (find all interface abstract methods, join with all overrides of those methods, check if the interface also inherits a concrete override) can blow up