### PR TITLE
Swift: Improve SummaryStats.ql

### DIFF
--- a/swift/ql/lib/codeql/swift/elements/Diagnostics.qll
+++ b/swift/ql/lib/codeql/swift/elements/Diagnostics.qll
@@ -1,8 +1,14 @@
 private import codeql.swift.generated.Diagnostics
 
+/**
+ * A compiler-generated error, warning, note or remark.
+ */
 class Diagnostics extends Generated::Diagnostics {
   override string toString() { result = this.getSeverity() + ": " + this.getText() }
 
+  /**
+   * Gets a string representing the severity of this compiler diagnostic.
+   */
   string getSeverity() {
     this.getKind() = 1 and result = "error"
     or
@@ -14,18 +20,30 @@ class Diagnostics extends Generated::Diagnostics {
   }
 }
 
+/**
+ * A compiler error message.
+ */
 class CompilerError extends Diagnostics {
   CompilerError() { this.getSeverity() = "error" }
 }
 
+/**
+ * A compiler-generated warning.
+ */
 class CompilerWarning extends Diagnostics {
   CompilerWarning() { this.getSeverity() = "warning" }
 }
 
+/**
+ * A compiler-generated note (typically attached to an error or warning).
+ */
 class CompilerNote extends Diagnostics {
   CompilerNote() { this.getSeverity() = "note" }
 }
 
+/**
+ * A compiler-generated remark (milder than a warning, this does not indicate an issue).
+ */
 class CompilerRemark extends Diagnostics {
   CompilerRemark() { this.getSeverity() = "remark" }
 }

--- a/swift/ql/lib/codeql/swift/elements/File.qll
+++ b/swift/ql/lib/codeql/swift/elements/File.qll
@@ -1,4 +1,6 @@
 private import codeql.swift.generated.File
+private import codeql.swift.elements.Location
+private import codeql.swift.elements.UnknownLocation
 
 class File extends Generated::File {
   /** toString */
@@ -16,5 +18,18 @@ class File extends Generated::File {
   /** Gets the base name of this file. */
   string getBaseName() {
     result = this.getAbsolutePath().regexpCapture(".*/(([^/]*?)(?:\\.([^.]*))?)", 1)
+  }
+
+  /**
+   * Gets the number of lines containing code in this file. This value
+   * is approximate.
+   */
+  int getNumberOfLinesOfCode() {
+    result =
+      count(int line |
+        exists(Location loc |
+          not loc instanceof UnknownLocation and loc.getFile() = this and loc.getStartLine() = line
+        )
+      )
   }
 }

--- a/swift/ql/src/diagnostics/SuccessfullyExtractedLines.ql
+++ b/swift/ql/src/diagnostics/SuccessfullyExtractedLines.ql
@@ -8,8 +8,4 @@
 
 import swift
 
-select count(File f, int line |
-    exists(Location loc |
-      not loc instanceof UnknownLocation and loc.getFile() = f and loc.getStartLine() = line
-    )
-  )
+select sum(File f | | f.getNumberOfLinesOfCode())

--- a/swift/ql/src/queries/Summary/SummaryStats.ql
+++ b/swift/ql/src/queries/Summary/SummaryStats.ql
@@ -12,6 +12,15 @@ import codeql.swift.security.SensitiveExprs
 import codeql.swift.dataflow.DataFlow
 import codeql.swift.dataflow.TaintTracking
 
+int linesOfCode() {
+  // approximate number of lines of code in the database
+  result = count(File f, int line |
+    exists(Location loc |
+      not loc instanceof UnknownLocation and loc.getFile() = f and loc.getStartLine() = line
+    )
+  )
+}
+
 /**
  * A taint configuration for tainted data reaching any node.
  */
@@ -36,6 +45,8 @@ float taintReach() { result = (taintedNodesCount() * 1000000.0) / count(DataFlow
 
 predicate statistic(string what, string value) {
   what = "Files" and value = count(File f).toString()
+  or
+  what = "Lines of code" and value = linesOfCode().toString()
   or
   what = "Expressions" and value = count(Expr e | not e.getFile() instanceof UnknownFile).toString()
   or

--- a/swift/ql/src/queries/Summary/SummaryStats.ql
+++ b/swift/ql/src/queries/Summary/SummaryStats.ql
@@ -12,15 +12,6 @@ import codeql.swift.security.SensitiveExprs
 import codeql.swift.dataflow.DataFlow
 import codeql.swift.dataflow.TaintTracking
 
-int linesOfCode() {
-  // approximate number of lines of code in the database
-  result = count(File f, int line |
-    exists(Location loc |
-      not loc instanceof UnknownLocation and loc.getFile() = f and loc.getStartLine() = line
-    )
-  )
-}
-
 /**
  * A taint configuration for tainted data reaching any node.
  */
@@ -46,7 +37,7 @@ float taintReach() { result = (taintedNodesCount() * 1000000.0) / count(DataFlow
 predicate statistic(string what, string value) {
   what = "Files" and value = count(File f).toString()
   or
-  what = "Lines of code" and value = linesOfCode().toString()
+  what = "Lines of code" and value = sum(File f | | f.getNumberOfLinesOfCode()).toString()
   or
   what = "Compiler errors" and value = count(CompilerError d).toString()
   or

--- a/swift/ql/src/queries/Summary/SummaryStats.ql
+++ b/swift/ql/src/queries/Summary/SummaryStats.ql
@@ -48,6 +48,10 @@ predicate statistic(string what, string value) {
   or
   what = "Lines of code" and value = linesOfCode().toString()
   or
+  what = "Compiler errors" and value = count(CompilerError d).toString()
+  or
+  what = "Compiler warnings" and value = count(CompilerWarning d).toString()
+  or
   what = "Expressions" and value = count(Expr e | not e.getFile() instanceof UnknownFile).toString()
   or
   what = "Local flow sources" and value = count(LocalFlowSource s).toString()


### PR DESCRIPTION
Improve `SummaryStats.ql`:
- add total lines of code.
- add compiler errors.
- add compiler warnings.

and make some related changes:
- add `File.getNumberOfLinesOfCode()` to contain the common lines-of-code logic.
- add QLDoc in `Diagnostics.qll`.