### PR TITLE
C++: Fix the `++` problem

### DIFF
--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/InvalidPointerDeref.expected
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/InvalidPointerDeref.expected
@@ -664,11 +664,6 @@ edges
 | test.cpp:338:8:338:15 | * ... | test.cpp:342:8:342:17 | * ... |
 | test.cpp:341:8:341:17 | * ... | test.cpp:342:8:342:17 | * ... |
 | test.cpp:347:14:347:27 | new[] | test.cpp:348:15:348:16 | xs |
-| test.cpp:348:15:348:16 | xs | test.cpp:350:16:350:19 | ... ++ |
-| test.cpp:348:15:348:16 | xs | test.cpp:350:16:350:19 | ... ++ |
-| test.cpp:350:16:350:19 | ... ++ | test.cpp:350:15:350:19 | Load: * ... |
-| test.cpp:350:16:350:19 | ... ++ | test.cpp:350:16:350:19 | ... ++ |
-| test.cpp:350:16:350:19 | ... ++ | test.cpp:350:16:350:19 | ... ++ |
 | test.cpp:355:14:355:27 | new[] | test.cpp:356:15:356:16 | xs |
 | test.cpp:356:15:356:16 | xs | test.cpp:356:15:356:23 | ... + ... |
 | test.cpp:356:15:356:16 | xs | test.cpp:356:15:356:23 | ... + ... |
@@ -1057,10 +1052,6 @@ nodes
 | test.cpp:342:8:342:17 | * ... | semmle.label | * ... |
 | test.cpp:347:14:347:27 | new[] | semmle.label | new[] |
 | test.cpp:348:15:348:16 | xs | semmle.label | xs |
-| test.cpp:350:15:350:19 | Load: * ... | semmle.label | Load: * ... |
-| test.cpp:350:16:350:19 | ... ++ | semmle.label | ... ++ |
-| test.cpp:350:16:350:19 | ... ++ | semmle.label | ... ++ |
-| test.cpp:350:16:350:19 | ... ++ | semmle.label | ... ++ |
 | test.cpp:355:14:355:27 | new[] | semmle.label | new[] |
 | test.cpp:356:15:356:16 | xs | semmle.label | xs |
 | test.cpp:356:15:356:23 | ... + ... | semmle.label | ... + ... |
@@ -1118,7 +1109,6 @@ subpaths
 | test.cpp:264:13:264:14 | Load: * ... | test.cpp:260:13:260:24 | new[] | test.cpp:264:13:264:14 | Load: * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:260:13:260:24 | new[] | new[] | test.cpp:261:19:261:21 | len | len |
 | test.cpp:274:5:274:10 | Store: ... = ... | test.cpp:270:13:270:24 | new[] | test.cpp:274:5:274:10 | Store: ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:270:13:270:24 | new[] | new[] | test.cpp:271:19:271:21 | len | len |
 | test.cpp:308:5:308:29 | Store: ... = ... | test.cpp:304:15:304:26 | new[] | test.cpp:308:5:308:29 | Store: ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:304:15:304:26 | new[] | new[] | test.cpp:308:8:308:10 | ... + ... | ... + ... |
-| test.cpp:350:15:350:19 | Load: * ... | test.cpp:347:14:347:27 | new[] | test.cpp:350:15:350:19 | Load: * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:347:14:347:27 | new[] | new[] | test.cpp:348:20:348:23 | size | size |
 | test.cpp:358:14:358:26 | Load: * ... | test.cpp:355:14:355:27 | new[] | test.cpp:358:14:358:26 | Load: * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@ + 1. | test.cpp:355:14:355:27 | new[] | new[] | test.cpp:356:20:356:23 | size | size |
 | test.cpp:359:14:359:32 | Load: * ... | test.cpp:355:14:355:27 | new[] | test.cpp:359:14:359:32 | Load: * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@ + 2. | test.cpp:355:14:355:27 | new[] | new[] | test.cpp:356:20:356:23 | size | size |
 | test.cpp:372:15:372:16 | Load: * ... | test.cpp:363:14:363:27 | new[] | test.cpp:372:15:372:16 | Load: * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:363:14:363:27 | new[] | new[] | test.cpp:365:19:365:22 | size | size |

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/test.cpp
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/test.cpp
@@ -347,7 +347,7 @@ void test24(unsigned size) {
   char *xs = new char[size];
   char *end = xs + size;
   if (xs < end) {
-    int val = *xs++; // GOOD [FALSE POSITIVE]
+    int val = *xs++; // GOOD
   }
 }
 

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
@@ -6584,6 +6584,13 @@
 | taint.cpp:691:18:691:18 | s [post update] | taint.cpp:695:7:695:7 | s |  |
 | taint.cpp:691:20:691:20 | ref arg x | taint.cpp:694:9:694:9 | x |  |
 | taint.cpp:694:7:694:7 | s [post update] | taint.cpp:695:7:695:7 | s |  |
+| taint.cpp:700:13:700:18 | call to source | taint.cpp:702:11:702:11 | s |  |
+| taint.cpp:701:9:701:9 | p | taint.cpp:702:4:702:4 | p |  |
+| taint.cpp:702:4:702:4 | p | taint.cpp:702:4:702:6 | ... ++ |  |
+| taint.cpp:702:4:702:6 | ... ++ | taint.cpp:702:3:702:6 | * ... | TAINT |
+| taint.cpp:702:4:702:6 | ... ++ | taint.cpp:703:8:703:8 | p | TAINT |
+| taint.cpp:702:10:702:11 | * ... | taint.cpp:702:3:702:11 | ... = ... |  |
+| taint.cpp:702:11:702:11 | s | taint.cpp:702:10:702:11 | * ... | TAINT |
 | vector.cpp:16:43:16:49 | source1 | vector.cpp:17:26:17:32 | source1 |  |
 | vector.cpp:16:43:16:49 | source1 | vector.cpp:31:38:31:44 | source1 |  |
 | vector.cpp:17:21:17:33 | call to vector | vector.cpp:19:14:19:14 | v |  |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.cpp
@@ -694,3 +694,12 @@ void test_argument_source_field_to_obj() {
 	sink(s.x); // $ ast,ir
 	sink(s.y); // clean
 }
+
+namespace strings {
+	void test_write_to_read_then_incr_then_deref() {
+		char* s = source();
+		char* p;
+		*p++ = *s;
+		sink(p); // $ ast ir
+	}
+}


### PR DESCRIPTION
This is a much simpler solution to the problem described in https://github.com/github/codeql/pull/13326. Instead of tweaking the generated IR, we identify the problematic case in dataflow SSA and modify the `hasIndexInBlock` predicate so that the use of `p` that represents the result of `p++` has the same index as the use of `p` that represents the value read by `p++`. Specifically, the IR for `x = p++` looks like:
```cpp
r1(glval<int>) = VariableAddress[x]     :
r2(glval<int>) = VariableAddress[p]     :
r3(int)        = Load[p]                : &:r2, m1
r4(int)        = Constant[1]            :
r5(int)        = Add                    : r3, r4
m2(int)        = Store[p]               : &:r2, r5
r7(int)        = CopyValue              : r3
m3(int)        = Store[x]               : &:r1, r7
```
and we now assign the SSA use that wraps `r7` on the `Store` instruction the same index as the SSA use of `r3` in the `Add` instruction.