### PR TITLE
Revert "Ruby: update tree-sitter-ruby"

### DIFF
--- a/ruby/extractor/Cargo.lock
+++ b/ruby/extractor/Cargo.lock
@@ -911,7 +911,7 @@ dependencies = [
 [[package]]
 name = "tree-sitter-ruby"
 version = "0.20.0"
-source = "git+https://github.com/tree-sitter/tree-sitter-ruby.git?rev=74fde5e5fb2bb5978aaee7895188eb199f7facf0#74fde5e5fb2bb5978aaee7895188eb199f7facf0"
+source = "git+https://github.com/tree-sitter/tree-sitter-ruby.git?rev=206c7077164372c596ffa8eaadb9435c28941364#206c7077164372c596ffa8eaadb9435c28941364"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/ruby/extractor/Cargo.toml
+++ b/ruby/extractor/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 [dependencies]
 tree-sitter = "0.20"
 tree-sitter-embedded-template = { git = "https://github.com/tree-sitter/tree-sitter-embedded-template.git", rev = "203f7bd3c1bbfbd98fc19add4b8fcb213c059205" }
-tree-sitter-ruby = { git = "https://github.com/tree-sitter/tree-sitter-ruby.git", rev = "74fde5e5fb2bb5978aaee7895188eb199f7facf0" }
+tree-sitter-ruby = { git = "https://github.com/tree-sitter/tree-sitter-ruby.git", rev = "206c7077164372c596ffa8eaadb9435c28941364" }
 clap = { version = "4.2", features = ["derive"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }


### PR DESCRIPTION
Reverts github/codeql#13399

Extraction seems to be failing on DCA but the cause has not yet been confirmed. Since DCA was not run on the above PR I'm opening this PR in case it needs to be reverted.