### PR TITLE
C#: Make sure System.Private.CoreLib is added only once as a reference in standalone extraction

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp.Standalone/BuildAnalysis.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.Standalone/BuildAnalysis.cs
@@ -100,6 +100,18 @@ namespace Semmle.BuildAnalyser
                 dllDirNames.Add(runtimeLocation);
             }
 
+            if (options.UseMscorlib)
+            {
+                // Add mscorlib.dll or System.Private.CoreLib.dll to the list of DLLs to reference.
+                var loc = typeof(object).Assembly.Location;
+                var dir = Path.GetDirectoryName(loc);
+                if (dir != null)
+                {
+                    progressMonitor.Log(Util.Logging.Severity.Debug, $"Adding folder {dir} to DLL search path.");
+                    dllDirNames.Add(dir);
+                }
+            }
+
             // These files can sometimes prevent `dotnet restore` from working correctly.
             using (new FileRenamer(sourceDir.GetFiles("global.json", SearchOption.AllDirectories)))
             using (new FileRenamer(sourceDir.GetFiles("Directory.Build.props", SearchOption.AllDirectories)))
@@ -121,11 +133,6 @@ namespace Semmle.BuildAnalyser
             }
 
             ResolveConflicts();
-
-            if (options.UseMscorlib)
-            {
-                UseReference(typeof(object).Assembly.Location);
-            }
 
             // Output the findings
             foreach (var r in usedReferences.Keys)

--- a/csharp/extractor/Semmle.Extraction.CSharp.Standalone/BuildAnalysis.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.Standalone/BuildAnalysis.cs
@@ -100,18 +100,6 @@ namespace Semmle.BuildAnalyser
                 dllDirNames.Add(runtimeLocation);
             }
 
-            if (options.UseMscorlib)
-            {
-                // Add mscorlib.dll or System.Private.CoreLib.dll to the list of DLLs to reference.
-                var loc = typeof(object).Assembly.Location;
-                var dir = Path.GetDirectoryName(loc);
-                if (dir != null)
-                {
-                    progressMonitor.Log(Util.Logging.Severity.Debug, $"Adding folder {dir} to DLL search path.");
-                    dllDirNames.Add(dir);
-                }
-            }
-
             // These files can sometimes prevent `dotnet restore` from working correctly.
             using (new FileRenamer(sourceDir.GetFiles("global.json", SearchOption.AllDirectories)))
             using (new FileRenamer(sourceDir.GetFiles("Directory.Build.props", SearchOption.AllDirectories)))
@@ -130,6 +118,11 @@ namespace Semmle.BuildAnalyser
 
                 foreach (var filename in assemblyCache.AllAssemblies.Select(a => a.Filename))
                     UseReference(filename);
+            }
+
+            if (options.UseMscorlib)
+            {
+                UseReference(typeof(object).Assembly.Location);
             }
 
             ResolveConflicts();


### PR DESCRIPTION
Standalone extraction collects possible references for the compilation. These assemblies go through some deduplication logic. This logic was not applied to `System.Private.CoreLib.dll`. The PR makes sure there's at most one `System.Private.CoreLib.dll` added to the compilation. ~Additionally it adds assemblies next to this `System.Private.CoreLib.dll` to the possible references.~