### PR TITLE
C++: Fix more conflation in dataflow

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -323,7 +323,7 @@ private class SideEffectArgumentNode extends ArgumentNode, SideEffectOperandNode
   override predicate argumentOf(DataFlowCall dfCall, ArgumentPosition pos) {
     this.getCallInstruction() = dfCall and
     pos.(IndirectionPosition).getArgumentIndex() = this.getArgumentIndex() and
-    pos.(IndirectionPosition).getIndirectionIndex() = super.getIndirectionIndex()
+    super.hasAddressOperandAndIndirectionIndex(_, pos.(IndirectionPosition).getIndirectionIndex())
   }
 }
 

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -848,7 +848,7 @@ predicate additionalLambdaFlowStep(Node nodeFrom, Node nodeTo, boolean preserves
  * One example would be to allow flow like `p.foo = p.bar;`, which is disallowed
  * by default as a heuristic.
  */
-predicate allowParameterReturnInSelf(ParameterNode p) { none() }
+predicate allowParameterReturnInSelf(ParameterNode p) { p instanceof IndirectParameterNode }
 
 private predicate fieldHasApproxName(Field f, string s) {
   s = f.getName().charAt(0) and

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -193,85 +193,88 @@ private class SingleUseOperandNode0 extends OperandNode0, TSingleUseOperandNode0
   SingleUseOperandNode0() { this = TSingleUseOperandNode0(op) }
 }
 
-/**
- * INTERNAL: Do not use.
- *
- * A node that represents the indirect value of an operand in the IR
- * after `index` number of loads.
- *
- * Note: Unlike `RawIndirectOperand`, a value of type `IndirectOperand` may
- * be an `OperandNode`.
- */
-class IndirectOperand extends Node {
-  Operand operand;
-  int indirectionIndex;
-
-  IndirectOperand() {
-    this.(RawIndirectOperand).getOperand() = operand and
-    this.(RawIndirectOperand).getIndirectionIndex() = indirectionIndex
-    or
-    nodeHasOperand(this, Ssa::getIRRepresentationOfIndirectOperand(operand, indirectionIndex),
-      indirectionIndex - 1)
+private module IndirectOperands {
+  /**
+   * INTERNAL: Do not use.
+   *
+   * A node that represents the indirect value of an operand in the IR
+   * after `index` number of loads.
+   *
+   * Note: Unlike `RawIndirectOperand`, a value of type `IndirectOperand` may
+   * be an `OperandNode`.
+   */
+  abstract class IndirectOperand extends Node {
+    /** Gets the underlying operand. */
+    abstract predicate hasOperandAndIndirectionIndex(Operand operand, int indirectionIndex);
   }
 
-  /** Gets the underlying operand. */
-  Operand getOperand() { result = operand }
+  private class IndirectOperandFromRaw extends IndirectOperand instanceof RawIndirectOperand {
+    override predicate hasOperandAndIndirectionIndex(Operand operand, int indirectionIndex) {
+      operand = RawIndirectOperand.super.getOperand() and
+      indirectionIndex = RawIndirectOperand.super.getIndirectionIndex()
+    }
+  }
 
-  /** Gets the underlying indirection index. */
-  int getIndirectionIndex() { result = indirectionIndex }
+  private class IndirectOperandFromIRRepr extends IndirectOperand {
+    Operand operand;
+    int indirectionIndex;
 
-  /**
-   * Holds if this `IndirectOperand` is represented directly in the IR instead of
-   * a `RawIndirectionOperand` with operand `op` and indirection index `index`.
-   */
-  predicate isIRRepresentationOf(Operand op, int index) {
-    this instanceof OperandNode and
-    (
-      op = operand and
-      index = indirectionIndex
-    )
+    IndirectOperandFromIRRepr() {
+      exists(Operand repr |
+        repr = Ssa::getIRRepresentationOfIndirectOperand(operand, indirectionIndex) and
+        nodeHasOperand(this, repr, indirectionIndex - 1)
+      )
+    }
+
+    override predicate hasOperandAndIndirectionIndex(Operand op, int index) {
+      op = operand and index = indirectionIndex
+    }
   }
 }
 
-/**
- * INTERNAL: Do not use.
- *
- * A node that represents the indirect value of an instruction in the IR
- * after `index` number of loads.
- *
- * Note: Unlike `RawIndirectInstruction`, a value of type `IndirectInstruction` may
- * be an `InstructionNode`.
- */
-class IndirectInstruction extends Node {
-  Instruction instr;
-  int indirectionIndex;
+import IndirectOperands
 
-  IndirectInstruction() {
-    this.(RawIndirectInstruction).getInstruction() = instr and
-    this.(RawIndirectInstruction).getIndirectionIndex() = indirectionIndex
-    or
-    nodeHasInstruction(this, Ssa::getIRRepresentationOfIndirectInstruction(instr, indirectionIndex),
-      indirectionIndex - 1)
+private module IndirectInstructions {
+  /**
+   * INTERNAL: Do not use.
+   *
+   * A node that represents the indirect value of an instruction in the IR
+   * after `index` number of loads.
+   *
+   * Note: Unlike `RawIndirectInstruction`, a value of type `IndirectInstruction` may
+   * be an `InstructionNode`.
+   */
+  abstract class IndirectInstruction extends Node {
+    /** Gets the underlying instruction. */
+    abstract predicate hasInstructionAndIndirectionIndex(Instruction instr, int index);
   }
 
-  /** Gets the underlying instruction. */
-  Instruction getInstruction() { result = instr }
+  private class IndirectInstructionFromRaw extends IndirectInstruction instanceof RawIndirectInstruction
+  {
+    override predicate hasInstructionAndIndirectionIndex(Instruction instr, int index) {
+      instr = RawIndirectInstruction.super.getInstruction() and
+      index = RawIndirectInstruction.super.getIndirectionIndex()
+    }
+  }
 
-  /** Gets the underlying indirection index. */
-  int getIndirectionIndex() { result = indirectionIndex }
+  private class IndirectInstructionFromIRRepr extends IndirectInstruction {
+    Instruction instr;
+    int indirectionIndex;
 
-  /**
-   * Holds if this `IndirectInstruction` is represented directly in the IR instead of
-   * a `RawIndirectionInstruction` with instruction `i` and indirection index `index`.
-   */
-  predicate isIRRepresentationOf(Instruction i, int index) {
-    this instanceof InstructionNode and
-    (
-      i = instr and
-      index = indirectionIndex
-    )
+    IndirectInstructionFromIRRepr() {
+      exists(Instruction repr |
+        repr = Ssa::getIRRepresentationOfIndirectInstruction(instr, indirectionIndex) and
+        nodeHasInstruction(this, repr, indirectionIndex - 1)
+      )
+    }
+
+    override predicate hasInstructionAndIndirectionIndex(Instruction i, int index) {
+      i = instr and index = indirectionIndex
+    }
   }
 }
+
+import IndirectInstructions
 
 /** Gets the callable in which this node occurs. */
 DataFlowCallable nodeGetEnclosingCallable(Node n) { result = n.getEnclosingCallable() }

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -245,7 +245,7 @@ private module IndirectInstructions {
    * be an `InstructionNode`.
    */
   abstract class IndirectInstruction extends Node {
-    /** Gets the underlying instruction. */
+    /** Gets the underlying operand and the underlying indirection index. */
     abstract predicate hasInstructionAndIndirectionIndex(Instruction instr, int index);
   }
 

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -204,7 +204,7 @@ private module IndirectOperands {
    * be an `OperandNode`.
    */
   abstract class IndirectOperand extends Node {
-    /** Gets the underlying operand. */
+    /** Gets the underlying operand and the underlying indirection index. */
     abstract predicate hasOperandAndIndirectionIndex(Operand operand, int indirectionIndex);
   }
 

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -587,6 +587,7 @@ class SideEffectOperandNode extends Node instanceof IndirectOperand {
 
   CallInstruction getCallInstruction() { result = call }
 
+  /** Gets the underlying operand and the underlying indirection index. */
   predicate hasAddressOperandAndIndirectionIndex(Operand operand, int indirectionIndex) {
     IndirectOperand.super.hasOperandAndIndirectionIndex(operand, indirectionIndex)
   }

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -684,7 +684,7 @@ class IndirectParameterNode extends Node instanceof IndirectInstruction {
 
   override Declaration getFunction() { result = init.getEnclosingFunction() }
 
-  /** Gets the underlying instruction. */
+  /** Gets the underlying operand and the underlying indirection index. */
   predicate hasInstructionAndIndirectionIndex(Instruction instr, int index) {
     IndirectInstruction.super.hasInstructionAndIndirectionIndex(instr, index)
   }

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -274,7 +274,7 @@ class Node extends TIRDataFlowNode {
    * represents the value of `**x` going into `f`.
    */
   Expr asIndirectArgument(int index) {
-    this.(SideEffectOperandNode).getIndirectionIndex() = index and
+    this.(SideEffectOperandNode).hasAddressOperandAndIndirectionIndex(_, index) and
     result = this.(SideEffectOperandNode).getArgument()
   }
 
@@ -317,7 +317,7 @@ class Node extends TIRDataFlowNode {
     index = 0 and
     result = this.(ExplicitParameterNode).getParameter()
     or
-    this.(IndirectParameterNode).getIndirectionIndex() = index and
+    this.(IndirectParameterNode).hasInstructionAndIndirectionIndex(_, index) and
     result = this.(IndirectParameterNode).getParameter()
   }
 
@@ -577,15 +577,19 @@ class SsaPhiNode extends Node, TSsaPhiNode {
  *
  * A node representing a value after leaving a function.
  */
-class SideEffectOperandNode extends Node, IndirectOperand {
+class SideEffectOperandNode extends Node instanceof IndirectOperand {
   CallInstruction call;
   int argumentIndex;
 
-  SideEffectOperandNode() { operand = call.getArgumentOperand(argumentIndex) }
+  SideEffectOperandNode() {
+    IndirectOperand.super.hasOperandAndIndirectionIndex(call.getArgumentOperand(argumentIndex), _)
+  }
 
   CallInstruction getCallInstruction() { result = call }
 
-  Operand getAddressOperand() { result = operand }
+  predicate hasAddressOperandAndIndirectionIndex(Operand operand, int indirectionIndex) {
+    IndirectOperand.super.hasOperandAndIndirectionIndex(operand, indirectionIndex)
+  }
 
   int getArgumentIndex() { result = argumentIndex }
 
@@ -665,10 +669,10 @@ class InitialGlobalValue extends Node, TInitialGlobalValue {
  *
  * A node representing an indirection of a parameter.
  */
-class IndirectParameterNode extends Node, IndirectInstruction {
+class IndirectParameterNode extends Node instanceof IndirectInstruction {
   InitializeParameterInstruction init;
 
-  IndirectParameterNode() { this.getInstruction() = init }
+  IndirectParameterNode() { IndirectInstruction.super.hasInstructionAndIndirectionIndex(init, _) }
 
   int getArgumentIndex() { init.hasIndex(result) }
 
@@ -677,7 +681,12 @@ class IndirectParameterNode extends Node, IndirectInstruction {
 
   override Declaration getEnclosingCallable() { result = this.getFunction() }
 
-  override Declaration getFunction() { result = this.getInstruction().getEnclosingFunction() }
+  override Declaration getFunction() { result = init.getEnclosingFunction() }
+
+  /** Gets the underlying instruction. */
+  predicate hasInstructionAndIndirectionIndex(Instruction instr, int index) {
+    IndirectInstruction.super.hasInstructionAndIndirectionIndex(instr, index)
+  }
 
   override Location getLocationImpl() { result = this.getParameter().getLocation() }
 
@@ -699,7 +708,8 @@ class IndirectReturnNode extends Node {
   IndirectReturnNode() {
     this instanceof FinalParameterNode
     or
-    this.(IndirectOperand).getOperand() = any(ReturnValueInstruction ret).getReturnAddressOperand()
+    this.(IndirectOperand)
+        .hasOperandAndIndirectionIndex(any(ReturnValueInstruction ret).getReturnAddressOperand(), _)
   }
 
   override Declaration getEnclosingCallable() { result = this.getFunction() }
@@ -722,7 +732,7 @@ class IndirectReturnNode extends Node {
   int getIndirectionIndex() {
     result = this.(FinalParameterNode).getIndirectionIndex()
     or
-    result = this.(IndirectOperand).getIndirectionIndex()
+    this.(IndirectOperand).hasOperandAndIndirectionIndex(_, result)
   }
 }
 
@@ -1106,7 +1116,8 @@ predicate exprNodeShouldBeInstruction(Node node, Expr e) {
 /** Holds if `node` should be an `IndirectInstruction` that maps `node.asIndirectExpr()` to `e`. */
 predicate indirectExprNodeShouldBeIndirectInstruction(IndirectInstruction node, Expr e) {
   exists(Instruction instr |
-    instr = node.getInstruction() and not indirectExprNodeShouldBeIndirectOperand(_, e)
+    node.hasInstructionAndIndirectionIndex(instr, _) and
+    not indirectExprNodeShouldBeIndirectOperand(_, e)
   |
     e = instr.(VariableAddressInstruction).getAst().(Expr).getFullyConverted()
     or
@@ -1307,8 +1318,8 @@ pragma[noinline]
 private predicate indirectParameterNodeHasArgumentIndexAndIndex(
   IndirectParameterNode node, int argumentIndex, int indirectionIndex
 ) {
-  node.getArgumentIndex() = argumentIndex and
-  node.getIndirectionIndex() = indirectionIndex
+  node.hasInstructionAndIndirectionIndex(_, indirectionIndex) and
+  node.getArgumentIndex() = argumentIndex
 }
 
 /** A synthetic parameter to model the pointed-to object of a pointer parameter. */
@@ -1479,18 +1490,14 @@ VariableNode variableNode(Variable v) {
  */
 Node uninitializedNode(LocalVariable v) { none() }
 
-pragma[noinline]
 predicate hasOperandAndIndex(IndirectOperand indirectOperand, Operand operand, int indirectionIndex) {
-  indirectOperand.getOperand() = operand and
-  indirectOperand.getIndirectionIndex() = indirectionIndex
+  indirectOperand.hasOperandAndIndirectionIndex(operand, indirectionIndex)
 }
 
-pragma[noinline]
 predicate hasInstructionAndIndex(
   IndirectInstruction indirectInstr, Instruction instr, int indirectionIndex
 ) {
-  indirectInstr.getInstruction() = instr and
-  indirectInstr.getIndirectionIndex() = indirectionIndex
+  indirectInstr.hasInstructionAndIndirectionIndex(instr, indirectionIndex)
 }
 
 cached
@@ -1656,8 +1663,7 @@ module ExprFlowCached {
   private predicate isIndirectBaseOfArrayAccess(IndirectOperand n, Expr e) {
     exists(LoadInstruction load, PointerArithmeticInstruction pai |
       pai = load.getSourceAddress() and
-      pai.getLeftOperand() = n.getOperand() and
-      n.getIndirectionIndex() = 1 and
+      n.hasOperandAndIndirectionIndex(pai.getLeftOperand(), 1) and
       e = load.getConvertedResultExpression()
     )
   }

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/PrintIRFieldFlowSteps.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/PrintIRFieldFlowSteps.qll
@@ -13,7 +13,7 @@ class FieldFlowPropertyProvider extends IRPropertyProvider {
   override string getOperandProperty(Operand operand, string key) {
     exists(PostFieldUpdateNode pfun, Content content |
       key = "store " + content.toString() and
-      operand = pfun.getPreUpdateNode().(IndirectOperand).getOperand() and
+      pfun.getPreUpdateNode().(IndirectOperand).hasOperandAndIndirectionIndex(operand, _) and
       result =
         strictconcat(string element, Node node |
           storeStep(node, content, pfun) and
@@ -25,7 +25,7 @@ class FieldFlowPropertyProvider extends IRPropertyProvider {
     or
     exists(Node node2, Content content |
       key = "read " + content.toString() and
-      operand = node2.(IndirectOperand).getOperand() and
+      node2.(IndirectOperand).hasOperandAndIndirectionIndex(operand, _) and
       result =
         strictconcat(string element, Node node1 |
           readStep(node1, content, node2) and

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/PrintIRUtilities.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/PrintIRUtilities.qll
@@ -18,9 +18,12 @@ private string stars(int k) {
 }
 
 string starsForNode(Node node) {
-  result = stars(node.(IndirectInstruction).getIndirectionIndex())
-  or
-  result = stars(node.(IndirectOperand).getIndirectionIndex())
+  exists(int indirectionIndex |
+    node.(IndirectInstruction).hasInstructionAndIndirectionIndex(_, indirectionIndex) or
+    node.(IndirectOperand).hasOperandAndIndirectionIndex(_, indirectionIndex)
+  |
+    result = stars(indirectionIndex)
+  )
   or
   not node instanceof IndirectInstruction and
   not node instanceof IndirectOperand and

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternalsCommon.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternalsCommon.qll
@@ -796,7 +796,7 @@ private module Cached {
       address.getDef() = instr and
       isDereference(load, address) and
       isUseImpl(address, _, indirectionIndex - 1) and
-      result = instr
+      result = load
     )
   }
 

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternalsCommon.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternalsCommon.qll
@@ -263,7 +263,7 @@ private module IteratorIndirections {
         // Taint through `operator+=` and `operator-=` on iterators.
         call.getStaticCallTarget() instanceof Iterator::IteratorAssignArithmeticOperator and
         node2.(IndirectArgumentOutNode).getPreUpdateNode() = node1 and
-        node1.(IndirectOperand).getOperand() = call.getArgumentOperand(0) and
+        node1.(IndirectOperand).hasOperandAndIndirectionIndex(call.getArgumentOperand(0), _) and
         node1.getType().getUnspecifiedType() = this
       )
     }

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/TaintTrackingUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/TaintTrackingUtil.qll
@@ -160,7 +160,7 @@ predicate modeledTaintStep(DataFlow::Node nodeIn, DataFlow::Node nodeOut) {
     FunctionInput modelIn, FunctionOutput modelOut
   |
     indirectArgument = callInput(call, modelIn) and
-    indirectArgument.getAddressOperand() = nodeIn.asOperand() and
+    indirectArgument.hasAddressOperandAndIndirectionIndex(nodeIn.asOperand(), _) and
     call.getStaticCallTarget() = func and
     (
       func.(DataFlowFunction).hasDataFlow(modelIn, modelOut)

--- a/cpp/ql/lib/semmle/code/cpp/models/implementations/Strcpy.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/implementations/Strcpy.qll
@@ -108,7 +108,7 @@ class StrcpyFunction extends ArrayFunction, DataFlowFunction, TaintFunction, Sid
     // these may do only a partial copy of the input buffer to the output
     // buffer
     exists(this.getParamSize()) and
-    input.isParameter(this.getParamSrc()) and
+    input.isParameterDeref(this.getParamSrc()) and
     (
       output.isParameterDeref(this.getParamDest()) or
       output.isReturnValueDeref()

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/dataflow-consistency.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/dataflow-consistency.expected
@@ -67,6 +67,8 @@ postWithInFlow
 | ref.cpp:109:9:109:11 | val [post update] | PostUpdateNode should not be the target of local flow. |
 | ref.cpp:113:11:113:13 | val [post update] | PostUpdateNode should not be the target of local flow. |
 | ref.cpp:115:11:115:13 | val [post update] | PostUpdateNode should not be the target of local flow. |
+| self_parameter_flow.cpp:3:4:3:5 | ps [inner post update] | PostUpdateNode should not be the target of local flow. |
+| self_parameter_flow.cpp:8:9:8:9 | s [inner post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:91:3:91:9 | source1 [post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:115:3:115:6 | * ... [post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:115:4:115:6 | out [inner post update] | PostUpdateNode should not be the target of local flow. |

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/dataflow-consistency.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/dataflow-consistency.expected
@@ -128,6 +128,7 @@ postWithInFlow
 | test.cpp:690:3:690:3 | s [post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:694:4:694:6 | buf [inner post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:704:23:704:25 | buf [inner post update] | PostUpdateNode should not be the target of local flow. |
+| test.cpp:715:25:715:25 | c [inner post update] | PostUpdateNode should not be the target of local flow. |
 viableImplInCallContextTooLarge
 uniqueParameterNodeAtPosition
 uniqueParameterNodePosition

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/dataflow-consistency.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/dataflow-consistency.expected
@@ -129,6 +129,9 @@ postWithInFlow
 | test.cpp:694:4:694:6 | buf [inner post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:704:23:704:25 | buf [inner post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:715:25:715:25 | c [inner post update] | PostUpdateNode should not be the target of local flow. |
+| test.cpp:728:3:728:4 | * ... [post update] | PostUpdateNode should not be the target of local flow. |
+| test.cpp:728:4:728:4 | p [inner post update] | PostUpdateNode should not be the target of local flow. |
+| test.cpp:734:41:734:41 | x [inner post update] | PostUpdateNode should not be the target of local flow. |
 viableImplInCallContextTooLarge
 uniqueParameterNodeAtPosition
 uniqueParameterNodePosition

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/self_parameter_flow.cpp
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/self_parameter_flow.cpp
@@ -10,5 +10,5 @@ void callincr(unsigned char *s) // $ ast-def=s
 
 void test(unsigned char *s) // $ ast-def=s
 {
-  callincr(s); // $ MISSING: flow
+  callincr(s); // $ flow
 }

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/self_parameter_flow.cpp
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/self_parameter_flow.cpp
@@ -1,0 +1,14 @@
+void incr(unsigned char **ps) // $ ast-def=ps ir-def=*ps ir-def=**ps 
+{
+  *ps += 1;
+}
+
+void callincr(unsigned char *s) // $ ast-def=s 
+{
+  incr(&s);
+}
+
+void test(unsigned char *s) // $ ast-def=s
+{
+  callincr(s); // $ MISSING: flow
+}

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
@@ -703,3 +703,20 @@ void test_conflation_regression(int* source) { // $ ast-def=source
   int* buf = source;
   call_increment_buf(&buf);
 }
+
+void write_to_star_star_p(unsigned char **p) // $ ast-def=p ir-def=**p ir-def=*p
+{
+  **p = 0;
+}
+
+void write_to_star_buf(unsigned char *buf) // $ ast-def=buf
+{
+  unsigned char *c = buf;
+  write_to_star_star_p(&c);
+}
+
+void test(unsigned char *source) // $ ast-def=source
+{
+  write_to_star_buf(source);
+  sink(*source); // $ SPURIOUS: ir
+}

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
@@ -718,5 +718,5 @@ void write_to_star_buf(unsigned char *buf) // $ ast-def=buf
 void test(unsigned char *source) // $ ast-def=source
 {
   write_to_star_buf(source);
-  sink(*source); // $ SPURIOUS: ir
+  sink(*source); // clean
 }

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
@@ -715,8 +715,22 @@ void write_to_star_buf(unsigned char *buf) // $ ast-def=buf
   write_to_star_star_p(&c);
 }
 
-void test(unsigned char *source) // $ ast-def=source
+void test_write_to_star_buf(unsigned char *source) // $ ast-def=source
 {
   write_to_star_buf(source);
   sink(*source); // clean
+}
+
+void does_not_write_source_to_dereference(int *p) // $ ast-def=p ir-def=*p
+{
+  int x = source();
+  p = &x;
+  *p = 42;
+}
+
+void test_does_not_write_source_to_dereference()
+{
+  int x;
+  does_not_write_source_to_dereference(&x);
+  sink(x); // $ ast,ir=733:7 SPURIOUS: ast,ir=726:11
 }

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test_self_parameter_flow.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test_self_parameter_flow.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test_self_parameter_flow.ql
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test_self_parameter_flow.ql
@@ -1,0 +1,34 @@
+import cpp
+import semmle.code.cpp.dataflow.new.DataFlow
+import TestUtilities.InlineExpectationsTest
+
+module TestConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) {
+    source.getLocation().getFile().getBaseName() = "self_parameter_flow.cpp" and
+    source.asIndirectArgument() =
+      any(Call call | call.getTarget().hasName("callincr")).getAnArgument()
+  }
+
+  predicate isSink(DataFlow::Node sink) {
+    sink.asDefiningArgument() =
+      any(Call call | call.getTarget().hasName("callincr")).getAnArgument()
+  }
+}
+
+import DataFlow::Global<TestConfig>
+
+module TestSelfParameterFlow implements TestSig {
+  string getARelevantTag() { result = "flow" }
+
+  predicate hasActualResult(Location location, string element, string tag, string value) {
+    exists(DataFlow::Node sink |
+      flowTo(sink) and
+      location = sink.getLocation() and
+      element = sink.toString() and
+      tag = "flow" and
+      value = ""
+    )
+  }
+}
+
+import MakeTest<TestSelfParameterFlow>

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/uninitialized.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/uninitialized.expected
@@ -42,3 +42,5 @@
 | test.cpp:551:9:551:9 | y | test.cpp:552:28:552:28 | y |
 | test.cpp:595:8:595:9 | xs | test.cpp:596:3:596:4 | xs |
 | test.cpp:595:8:595:9 | xs | test.cpp:597:9:597:10 | xs |
+| test.cpp:733:7:733:7 | x | test.cpp:734:41:734:41 | x |
+| test.cpp:733:7:733:7 | x | test.cpp:735:8:735:8 | x |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
@@ -6591,6 +6591,20 @@
 | taint.cpp:702:4:702:6 | ... ++ | taint.cpp:703:8:703:8 | p | TAINT |
 | taint.cpp:702:10:702:11 | * ... | taint.cpp:702:3:702:11 | ... = ... |  |
 | taint.cpp:702:11:702:11 | s | taint.cpp:702:10:702:11 | * ... | TAINT |
+| taint.cpp:709:25:709:25 | d | taint.cpp:709:25:709:25 | d |  |
+| taint.cpp:709:25:709:25 | d | taint.cpp:711:10:711:10 | d |  |
+| taint.cpp:709:25:709:25 | d | taint.cpp:712:7:712:7 | d |  |
+| taint.cpp:709:34:709:34 | s | taint.cpp:709:34:709:34 | s |  |
+| taint.cpp:709:34:709:34 | s | taint.cpp:710:18:710:18 | s |  |
+| taint.cpp:709:34:709:34 | s | taint.cpp:711:13:711:13 | s |  |
+| taint.cpp:710:18:710:18 | ref arg s | taint.cpp:709:34:709:34 | s |  |
+| taint.cpp:710:18:710:18 | ref arg s | taint.cpp:711:13:711:13 | s |  |
+| taint.cpp:711:10:711:10 | d | taint.cpp:711:2:711:8 | call to strncpy |  |
+| taint.cpp:711:10:711:10 | ref arg d | taint.cpp:709:25:709:25 | d |  |
+| taint.cpp:711:10:711:10 | ref arg d | taint.cpp:712:7:712:7 | d |  |
+| taint.cpp:711:13:711:13 | s | taint.cpp:711:2:711:8 | call to strncpy | TAINT |
+| taint.cpp:711:13:711:13 | s | taint.cpp:711:10:711:10 | ref arg d | TAINT |
+| taint.cpp:712:7:712:7 | ref arg d | taint.cpp:709:25:709:25 | d |  |
 | vector.cpp:16:43:16:49 | source1 | vector.cpp:17:26:17:32 | source1 |  |
 | vector.cpp:16:43:16:49 | source1 | vector.cpp:31:38:31:44 | source1 |  |
 | vector.cpp:17:21:17:33 | call to vector | vector.cpp:19:14:19:14 | v |  |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.cpp
@@ -709,5 +709,5 @@ char * strncpy (char *, const char *, unsigned long);
 void test_strncpy(char* d, char* s) {
 	argument_source(s);
 	strncpy(d, s, 16);
-	sink(d); // $ ast MISSING: ir
+	sink(d); // $ ast ir
 }

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.cpp
@@ -703,3 +703,11 @@ namespace strings {
 		sink(p); // $ ast ir
 	}
 }
+
+char * strncpy (char *, const char *, unsigned long);
+
+void test_strncpy(char* d, char* s) {
+	argument_source(s);
+	strncpy(d, s, 16);
+	sink(d); // $ ast MISSING: ir
+}

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-119/semmle/tests/OverflowDestination.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-119/semmle/tests/OverflowDestination.expected
@@ -8,13 +8,19 @@ edges
 | overflowdestination.cpp:23:45:23:48 | argv indirection | overflowdestination.cpp:30:17:30:20 | arg1 indirection |
 | overflowdestination.cpp:23:45:23:48 | argv indirection | overflowdestination.cpp:30:17:30:20 | arg1 indirection |
 | overflowdestination.cpp:43:8:43:10 | fgets output argument | overflowdestination.cpp:46:15:46:17 | src indirection |
+| overflowdestination.cpp:50:52:50:54 | src indirection | overflowdestination.cpp:53:9:53:12 | memcpy output argument |
 | overflowdestination.cpp:50:52:50:54 | src indirection | overflowdestination.cpp:53:15:53:17 | src indirection |
 | overflowdestination.cpp:50:52:50:54 | src indirection | overflowdestination.cpp:53:15:53:17 | src indirection |
+| overflowdestination.cpp:50:52:50:54 | src indirection | overflowdestination.cpp:54:9:54:12 | memcpy output argument |
+| overflowdestination.cpp:53:9:53:12 | memcpy output argument | overflowdestination.cpp:54:9:54:12 | memcpy output argument |
+| overflowdestination.cpp:54:9:54:12 | memcpy output argument | overflowdestination.cpp:54:9:54:12 | memcpy output argument |
 | overflowdestination.cpp:57:52:57:54 | src indirection | overflowdestination.cpp:64:16:64:19 | src2 indirection |
 | overflowdestination.cpp:57:52:57:54 | src indirection | overflowdestination.cpp:64:16:64:19 | src2 indirection |
 | overflowdestination.cpp:73:8:73:10 | fgets output argument | overflowdestination.cpp:75:30:75:32 | src indirection |
 | overflowdestination.cpp:73:8:73:10 | fgets output argument | overflowdestination.cpp:76:30:76:32 | src indirection |
+| overflowdestination.cpp:75:30:75:32 | overflowdest_test2 output argument | overflowdestination.cpp:76:30:76:32 | src indirection |
 | overflowdestination.cpp:75:30:75:32 | src indirection | overflowdestination.cpp:50:52:50:54 | src indirection |
+| overflowdestination.cpp:75:30:75:32 | src indirection | overflowdestination.cpp:75:30:75:32 | overflowdest_test2 output argument |
 | overflowdestination.cpp:76:30:76:32 | src indirection | overflowdestination.cpp:57:52:57:54 | src indirection |
 nodes
 | main.cpp:6:27:6:30 | argv indirection | semmle.label | argv indirection |
@@ -28,15 +34,20 @@ nodes
 | overflowdestination.cpp:43:8:43:10 | fgets output argument | semmle.label | fgets output argument |
 | overflowdestination.cpp:46:15:46:17 | src indirection | semmle.label | src indirection |
 | overflowdestination.cpp:50:52:50:54 | src indirection | semmle.label | src indirection |
+| overflowdestination.cpp:53:9:53:12 | memcpy output argument | semmle.label | memcpy output argument |
 | overflowdestination.cpp:53:15:53:17 | src indirection | semmle.label | src indirection |
 | overflowdestination.cpp:53:15:53:17 | src indirection | semmle.label | src indirection |
+| overflowdestination.cpp:54:9:54:12 | memcpy output argument | semmle.label | memcpy output argument |
 | overflowdestination.cpp:57:52:57:54 | src indirection | semmle.label | src indirection |
 | overflowdestination.cpp:64:16:64:19 | src2 indirection | semmle.label | src2 indirection |
 | overflowdestination.cpp:64:16:64:19 | src2 indirection | semmle.label | src2 indirection |
 | overflowdestination.cpp:73:8:73:10 | fgets output argument | semmle.label | fgets output argument |
+| overflowdestination.cpp:75:30:75:32 | overflowdest_test2 output argument | semmle.label | overflowdest_test2 output argument |
 | overflowdestination.cpp:75:30:75:32 | src indirection | semmle.label | src indirection |
 | overflowdestination.cpp:76:30:76:32 | src indirection | semmle.label | src indirection |
 subpaths
+| overflowdestination.cpp:75:30:75:32 | src indirection | overflowdestination.cpp:50:52:50:54 | src indirection | overflowdestination.cpp:53:9:53:12 | memcpy output argument | overflowdestination.cpp:75:30:75:32 | overflowdest_test2 output argument |
+| overflowdestination.cpp:75:30:75:32 | src indirection | overflowdestination.cpp:50:52:50:54 | src indirection | overflowdestination.cpp:54:9:54:12 | memcpy output argument | overflowdestination.cpp:75:30:75:32 | overflowdest_test2 output argument |
 #select
 | overflowdestination.cpp:30:2:30:8 | call to strncpy | main.cpp:6:27:6:30 | argv indirection | overflowdestination.cpp:30:17:30:20 | arg1 indirection | To avoid overflow, this operation should be bounded by destination-buffer size, not source-buffer size. |
 | overflowdestination.cpp:30:2:30:8 | call to strncpy | main.cpp:6:27:6:30 | argv indirection | overflowdestination.cpp:30:17:30:20 | arg1 indirection | To avoid overflow, this operation should be bounded by destination-buffer size, not source-buffer size. |


### PR DESCRIPTION
This PR fixes two conflation issues that were giving us a bunch of FPs on https://github.com/lief-project/lief.

The first fix is very simple (see 153df2cc82307833bee07ac75e260303cce399e5), and the second fix took a couple of days of debugging (see 7c32721238892ef0f900648188d5dca08fd0b3f8) 😂.

Commit-by-commit review recommended.