### PR TITLE
Update inline flow tests to use parameterized module

### DIFF
--- a/csharp/ql/test/TestUtilities/InlineFlowTest.qll
+++ b/csharp/ql/test/TestUtilities/InlineFlowTest.qll
@@ -4,11 +4,12 @@
  * Example for a test.ql:
  * ```ql
  * import csharp
- * import DefaultValueFlow::PathGraph
  * import TestUtilities.InlineFlowTest
+ * import DefaultFlowTest
+ * import ValueFlow::PathGraph
  *
- * from DefaultValueFlow::PathNode source, DefaultValueFlow::PathNode sink
- * where DefaultValueFlow::flowPath(source, sink)
+ * from ValueFlow::PathNode source, ValueFlow::PathNode sink
+ * where ValueFlow::flowPath(source, sink)
  * select sink, source, sink, "$@", source, source.toString()
  *
  * ```
@@ -32,14 +33,10 @@
  * }
  * ```
  *
- * If you're not interested in a specific flow type, you can disable either value or taint flow expectations as follows:
- * ```ql
- * class HasFlowTest extends InlineFlowTest {
- *   override DataFlow::Configuration getTaintFlowConfig() { none() }
- *
- *   override DataFlow::Configuration getValueFlowConfig() { none() }
- * }
- * ```
+ * If you are only interested in value flow, then instead of importing `DefaultFlowTest`, you can import
+ * `ValueFlowTest<DefaultFlowConfig>`. Similarly, if you are only interested in taint flow, then instead of
+ * importing `DefaultFlowTest`, you can import `TaintFlowTest<DefaultFlowConfig>`. In both cases
+ * `DefaultFlowConfig` can be replaced by another implementation of `DataFlow::ConfigSig`.
  *
  * If you need more fine-grained tuning, consider implementing a test using `InlineExpectationsTest`.
  */
@@ -47,8 +44,8 @@
 import csharp
 import TestUtilities.InlineExpectationsTest
 
-private predicate defaultSource(DataFlow::Node src) {
-  src.asExpr().(MethodCall).getTarget().getUndecoratedName() = ["Source", "Taint"]
+private predicate defaultSource(DataFlow::Node source) {
+  source.asExpr().(MethodCall).getTarget().getUndecoratedName() = ["Source", "Taint"]
 }
 
 private predicate defaultSink(DataFlow::Node sink) {
@@ -58,42 +55,60 @@ private predicate defaultSink(DataFlow::Node sink) {
 }
 
 module DefaultFlowConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node n) { defaultSource(n) }
+  predicate isSource(DataFlow::Node source) { defaultSource(source) }
 
-  predicate isSink(DataFlow::Node n) { defaultSink(n) }
+  predicate isSink(DataFlow::Node sink) { defaultSink(sink) }
 
   int fieldFlowBranchLimit() { result = 1000 }
 }
 
-module DefaultValueFlow = DataFlow::Global<DefaultFlowConfig>;
+private module NoFlowConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { none() }
 
-module DefaultTaintFlow = TaintTracking::Global<DefaultFlowConfig>;
+  predicate isSink(DataFlow::Node sink) { none() }
+}
 
 private string getSourceArgString(DataFlow::Node src) {
   defaultSource(src) and
   src.asExpr().(MethodCall).getAnArgument().getValue() = result
 }
 
-class InlineFlowTest extends InlineExpectationsTest {
-  InlineFlowTest() { this = "HasFlowTest" }
+module FlowTest<DataFlow::ConfigSig ValueFlowConfig, DataFlow::ConfigSig TaintFlowConfig> {
+  module ValueFlow = DataFlow::Global<ValueFlowConfig>;
 
-  override string getARelevantTag() { result = ["hasValueFlow", "hasTaintFlow"] }
+  module TaintFlow = TaintTracking::Global<TaintFlowConfig>;
 
-  override predicate hasActualResult(Location location, string element, string tag, string value) {
-    tag = "hasValueFlow" and
-    exists(DataFlow::Node src, DataFlow::Node sink | DefaultValueFlow::flow(src, sink) |
-      sink.getLocation() = location and
-      element = sink.toString() and
-      if exists(getSourceArgString(src)) then value = getSourceArgString(src) else value = ""
-    )
-    or
-    tag = "hasTaintFlow" and
-    exists(DataFlow::Node src, DataFlow::Node sink |
-      DefaultTaintFlow::flow(src, sink) and not DefaultValueFlow::flow(src, sink)
-    |
-      sink.getLocation() = location and
-      element = sink.toString() and
-      if exists(getSourceArgString(src)) then value = getSourceArgString(src) else value = ""
-    )
+  private module InlineTest implements TestSig {
+    string getARelevantTag() { result = ["hasValueFlow", "hasTaintFlow"] }
+
+    predicate hasActualResult(Location location, string element, string tag, string value) {
+      tag = "hasValueFlow" and
+      exists(DataFlow::Node src, DataFlow::Node sink | ValueFlow::flow(src, sink) |
+        sink.getLocation() = location and
+        element = sink.toString() and
+        if exists(getSourceArgString(src)) then value = getSourceArgString(src) else value = ""
+      )
+      or
+      tag = "hasTaintFlow" and
+      exists(DataFlow::Node src, DataFlow::Node sink |
+        TaintFlow::flow(src, sink) and not ValueFlow::flow(src, sink)
+      |
+        sink.getLocation() = location and
+        element = sink.toString() and
+        if exists(getSourceArgString(src)) then value = getSourceArgString(src) else value = ""
+      )
+    }
   }
+
+  import MakeTest<InlineTest>
+}
+
+module DefaultFlowTest = FlowTest<DefaultFlowConfig, DefaultFlowConfig>;
+
+module ValueFlowTest<DataFlow::ConfigSig ValueFlowConfig> {
+  import FlowTest<ValueFlowConfig, NoFlowConfig>
+}
+
+module TaintFlowTest<DataFlow::ConfigSig TaintFlowConfig> {
+  import FlowTest<NoFlowConfig, TaintFlowConfig>
 }

--- a/csharp/ql/test/TestUtilities/InlineFlowTest.qll
+++ b/csharp/ql/test/TestUtilities/InlineFlowTest.qll
@@ -6,10 +6,10 @@
  * import csharp
  * import TestUtilities.InlineFlowTest
  * import DefaultFlowTest
- * import ValueFlow::PathGraph
+ * import PathGraph
  *
- * from ValueFlow::PathNode source, ValueFlow::PathNode sink
- * where ValueFlow::flowPath(source, sink)
+ * from PathNode source, PathNode sink
+ * where flowPath(source, sink)
  * select sink, source, sink, "$@", source, source.toString()
  *
  * ```
@@ -101,6 +101,12 @@ module FlowTest<DataFlow::ConfigSig ValueFlowConfig, DataFlow::ConfigSig TaintFl
   }
 
   import MakeTest<InlineTest>
+  import DataFlow::MergePathGraph<ValueFlow::PathNode, TaintFlow::PathNode, ValueFlow::PathGraph, TaintFlow::PathGraph>
+
+  predicate flowPath(PathNode source, PathNode sink) {
+    ValueFlow::flowPath(source.asPathNode1(), sink.asPathNode1()) or
+    TaintFlow::flowPath(source.asPathNode2(), sink.asPathNode2())
+  }
 }
 
 module DefaultFlowTest = FlowTest<DefaultFlowConfig, DefaultFlowConfig>;

--- a/csharp/ql/test/library-tests/dataflow/fields/FieldFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/fields/FieldFlow.expected
@@ -1,4 +1,5 @@
 failures
+testFailures
 edges
 | A.cs:5:17:5:28 | call to method Source<C> : C | A.cs:6:24:6:24 | access to local variable c : C |
 | A.cs:6:17:6:25 | call to method Make : B [field c] : C | A.cs:7:14:7:14 | access to local variable b : B [field c] : C |

--- a/csharp/ql/test/library-tests/dataflow/fields/FieldFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/fields/FieldFlow.expected
@@ -2,1100 +2,2195 @@ failures
 testFailures
 edges
 | A.cs:5:17:5:28 | call to method Source<C> : C | A.cs:6:24:6:24 | access to local variable c : C |
+| A.cs:5:17:5:28 | call to method Source<C> : C | A.cs:6:24:6:24 | access to local variable c : C |
+| A.cs:6:17:6:25 | call to method Make : B [field c] : C | A.cs:7:14:7:14 | access to local variable b : B [field c] : C |
 | A.cs:6:17:6:25 | call to method Make : B [field c] : C | A.cs:7:14:7:14 | access to local variable b : B [field c] : C |
 | A.cs:6:24:6:24 | access to local variable c : C | A.cs:6:17:6:25 | call to method Make : B [field c] : C |
+| A.cs:6:24:6:24 | access to local variable c : C | A.cs:6:17:6:25 | call to method Make : B [field c] : C |
+| A.cs:6:24:6:24 | access to local variable c : C | A.cs:147:32:147:32 | c : C |
 | A.cs:6:24:6:24 | access to local variable c : C | A.cs:147:32:147:32 | c : C |
 | A.cs:7:14:7:14 | access to local variable b : B [field c] : C | A.cs:7:14:7:16 | access to field c |
+| A.cs:7:14:7:14 | access to local variable b : B [field c] : C | A.cs:7:14:7:16 | access to field c |
+| A.cs:13:9:13:9 | [post] access to local variable b : B [field c] : C1 | A.cs:14:14:14:14 | access to local variable b : B [field c] : C1 |
 | A.cs:13:9:13:9 | [post] access to local variable b : B [field c] : C1 | A.cs:14:14:14:14 | access to local variable b : B [field c] : C1 |
 | A.cs:13:15:13:29 | call to method Source<C1> : C1 | A.cs:13:9:13:9 | [post] access to local variable b : B [field c] : C1 |
+| A.cs:13:15:13:29 | call to method Source<C1> : C1 | A.cs:13:9:13:9 | [post] access to local variable b : B [field c] : C1 |
+| A.cs:13:15:13:29 | call to method Source<C1> : C1 | A.cs:145:27:145:27 | c : C1 |
 | A.cs:13:15:13:29 | call to method Source<C1> : C1 | A.cs:145:27:145:27 | c : C1 |
 | A.cs:14:14:14:14 | access to local variable b : B [field c] : C1 | A.cs:14:14:14:20 | call to method Get |
+| A.cs:14:14:14:14 | access to local variable b : B [field c] : C1 | A.cs:14:14:14:20 | call to method Get |
+| A.cs:14:14:14:14 | access to local variable b : B [field c] : C1 | A.cs:146:18:146:20 | this : B [field c] : C1 |
 | A.cs:14:14:14:14 | access to local variable b : B [field c] : C1 | A.cs:146:18:146:20 | this : B [field c] : C1 |
 | A.cs:15:15:15:35 | object creation of type B : B [field c] : C | A.cs:15:14:15:42 | call to method Get |
+| A.cs:15:15:15:35 | object creation of type B : B [field c] : C | A.cs:15:14:15:42 | call to method Get |
+| A.cs:15:15:15:35 | object creation of type B : B [field c] : C | A.cs:146:18:146:20 | this : B [field c] : C |
 | A.cs:15:15:15:35 | object creation of type B : B [field c] : C | A.cs:146:18:146:20 | this : B [field c] : C |
 | A.cs:15:21:15:34 | call to method Source<C> : C | A.cs:15:15:15:35 | object creation of type B : B [field c] : C |
+| A.cs:15:21:15:34 | call to method Source<C> : C | A.cs:15:15:15:35 | object creation of type B : B [field c] : C |
+| A.cs:15:21:15:34 | call to method Source<C> : C | A.cs:141:20:141:20 | c : C |
 | A.cs:15:21:15:34 | call to method Source<C> : C | A.cs:141:20:141:20 | c : C |
 | A.cs:22:14:22:38 | call to method SetOnB : B [field c] : C2 | A.cs:24:14:24:15 | access to local variable b2 : B [field c] : C2 |
+| A.cs:22:14:22:38 | call to method SetOnB : B [field c] : C2 | A.cs:24:14:24:15 | access to local variable b2 : B [field c] : C2 |
+| A.cs:22:25:22:37 | call to method Source<C2> : C2 | A.cs:22:14:22:38 | call to method SetOnB : B [field c] : C2 |
 | A.cs:22:25:22:37 | call to method Source<C2> : C2 | A.cs:22:14:22:38 | call to method SetOnB : B [field c] : C2 |
 | A.cs:22:25:22:37 | call to method Source<C2> : C2 | A.cs:42:29:42:29 | c : C2 |
+| A.cs:22:25:22:37 | call to method Source<C2> : C2 | A.cs:42:29:42:29 | c : C2 |
+| A.cs:24:14:24:15 | access to local variable b2 : B [field c] : C2 | A.cs:24:14:24:17 | access to field c |
 | A.cs:24:14:24:15 | access to local variable b2 : B [field c] : C2 | A.cs:24:14:24:17 | access to field c |
 | A.cs:31:14:31:42 | call to method SetOnBWrap : B [field c] : C2 | A.cs:33:14:33:15 | access to local variable b2 : B [field c] : C2 |
+| A.cs:31:14:31:42 | call to method SetOnBWrap : B [field c] : C2 | A.cs:33:14:33:15 | access to local variable b2 : B [field c] : C2 |
+| A.cs:31:29:31:41 | call to method Source<C2> : C2 | A.cs:31:14:31:42 | call to method SetOnBWrap : B [field c] : C2 |
 | A.cs:31:29:31:41 | call to method Source<C2> : C2 | A.cs:31:14:31:42 | call to method SetOnBWrap : B [field c] : C2 |
 | A.cs:31:29:31:41 | call to method Source<C2> : C2 | A.cs:36:33:36:33 | c : C2 |
+| A.cs:31:29:31:41 | call to method Source<C2> : C2 | A.cs:36:33:36:33 | c : C2 |
+| A.cs:33:14:33:15 | access to local variable b2 : B [field c] : C2 | A.cs:33:14:33:17 | access to field c |
 | A.cs:33:14:33:15 | access to local variable b2 : B [field c] : C2 | A.cs:33:14:33:17 | access to field c |
 | A.cs:36:33:36:33 | c : C2 | A.cs:38:29:38:29 | access to parameter c : C2 |
+| A.cs:36:33:36:33 | c : C2 | A.cs:38:29:38:29 | access to parameter c : C2 |
+| A.cs:38:18:38:30 | call to method SetOnB : B [field c] : C2 | A.cs:39:16:39:28 | ... ? ... : ... : B [field c] : C2 |
 | A.cs:38:18:38:30 | call to method SetOnB : B [field c] : C2 | A.cs:39:16:39:28 | ... ? ... : ... : B [field c] : C2 |
 | A.cs:38:29:38:29 | access to parameter c : C2 | A.cs:38:18:38:30 | call to method SetOnB : B [field c] : C2 |
+| A.cs:38:29:38:29 | access to parameter c : C2 | A.cs:38:18:38:30 | call to method SetOnB : B [field c] : C2 |
+| A.cs:38:29:38:29 | access to parameter c : C2 | A.cs:42:29:42:29 | c : C2 |
 | A.cs:38:29:38:29 | access to parameter c : C2 | A.cs:42:29:42:29 | c : C2 |
 | A.cs:42:29:42:29 | c : C2 | A.cs:47:20:47:20 | access to parameter c : C2 |
+| A.cs:42:29:42:29 | c : C2 | A.cs:47:20:47:20 | access to parameter c : C2 |
+| A.cs:47:13:47:14 | [post] access to local variable b2 : B [field c] : C2 | A.cs:48:20:48:21 | access to local variable b2 : B [field c] : C2 |
 | A.cs:47:13:47:14 | [post] access to local variable b2 : B [field c] : C2 | A.cs:48:20:48:21 | access to local variable b2 : B [field c] : C2 |
 | A.cs:47:20:47:20 | access to parameter c : C2 | A.cs:47:13:47:14 | [post] access to local variable b2 : B [field c] : C2 |
+| A.cs:47:20:47:20 | access to parameter c : C2 | A.cs:47:13:47:14 | [post] access to local variable b2 : B [field c] : C2 |
+| A.cs:47:20:47:20 | access to parameter c : C2 | A.cs:145:27:145:27 | c : C2 |
 | A.cs:47:20:47:20 | access to parameter c : C2 | A.cs:145:27:145:27 | c : C2 |
 | A.cs:55:17:55:28 | call to method Source<A> : A | A.cs:57:16:57:16 | access to local variable a : A |
+| A.cs:55:17:55:28 | call to method Source<A> : A | A.cs:57:16:57:16 | access to local variable a : A |
+| A.cs:57:9:57:10 | [post] access to local variable c1 : C1 [field a] : A | A.cs:58:12:58:13 | access to local variable c1 : C1 [field a] : A |
 | A.cs:57:9:57:10 | [post] access to local variable c1 : C1 [field a] : A | A.cs:58:12:58:13 | access to local variable c1 : C1 [field a] : A |
 | A.cs:57:16:57:16 | access to local variable a : A | A.cs:57:9:57:10 | [post] access to local variable c1 : C1 [field a] : A |
+| A.cs:57:16:57:16 | access to local variable a : A | A.cs:57:9:57:10 | [post] access to local variable c1 : C1 [field a] : A |
+| A.cs:58:12:58:13 | access to local variable c1 : C1 [field a] : A | A.cs:60:22:60:22 | c : C1 [field a] : A |
 | A.cs:58:12:58:13 | access to local variable c1 : C1 [field a] : A | A.cs:60:22:60:22 | c : C1 [field a] : A |
 | A.cs:60:22:60:22 | c : C1 [field a] : A | A.cs:64:19:64:23 | (...) ... : C1 [field a] : A |
+| A.cs:60:22:60:22 | c : C1 [field a] : A | A.cs:64:19:64:23 | (...) ... : C1 [field a] : A |
+| A.cs:64:19:64:23 | (...) ... : C1 [field a] : A | A.cs:64:18:64:26 | access to field a |
 | A.cs:64:19:64:23 | (...) ... : C1 [field a] : A | A.cs:64:18:64:26 | access to field a |
 | A.cs:83:9:83:9 | [post] access to parameter b : B [field c] : C | A.cs:88:12:88:12 | [post] access to local variable b : B [field c] : C |
+| A.cs:83:9:83:9 | [post] access to parameter b : B [field c] : C | A.cs:88:12:88:12 | [post] access to local variable b : B [field c] : C |
+| A.cs:83:15:83:26 | call to method Source<C> : C | A.cs:83:9:83:9 | [post] access to parameter b : B [field c] : C |
 | A.cs:83:15:83:26 | call to method Source<C> : C | A.cs:83:9:83:9 | [post] access to parameter b : B [field c] : C |
 | A.cs:83:15:83:26 | call to method Source<C> : C | A.cs:145:27:145:27 | c : C |
+| A.cs:83:15:83:26 | call to method Source<C> : C | A.cs:145:27:145:27 | c : C |
+| A.cs:88:12:88:12 | [post] access to local variable b : B [field c] : C | A.cs:89:14:89:14 | access to local variable b : B [field c] : C |
 | A.cs:88:12:88:12 | [post] access to local variable b : B [field c] : C | A.cs:89:14:89:14 | access to local variable b : B [field c] : C |
 | A.cs:89:14:89:14 | access to local variable b : B [field c] : C | A.cs:89:14:89:16 | access to field c |
+| A.cs:89:14:89:14 | access to local variable b : B [field c] : C | A.cs:89:14:89:16 | access to field c |
+| A.cs:95:20:95:20 | b : B | A.cs:97:13:97:13 | access to parameter b : B |
 | A.cs:95:20:95:20 | b : B | A.cs:97:13:97:13 | access to parameter b : B |
 | A.cs:97:13:97:13 | [post] access to parameter b : B [field c] : C | A.cs:98:22:98:43 | ... ? ... : ... : B [field c] : C |
+| A.cs:97:13:97:13 | [post] access to parameter b : B [field c] : C | A.cs:98:22:98:43 | ... ? ... : ... : B [field c] : C |
+| A.cs:97:13:97:13 | [post] access to parameter b : B [field c] : C | A.cs:105:23:105:23 | [post] access to local variable b : B [field c] : C |
 | A.cs:97:13:97:13 | [post] access to parameter b : B [field c] : C | A.cs:105:23:105:23 | [post] access to local variable b : B [field c] : C |
 | A.cs:97:13:97:13 | access to parameter b : B | A.cs:98:22:98:43 | ... ? ... : ... : B |
+| A.cs:97:13:97:13 | access to parameter b : B | A.cs:98:22:98:43 | ... ? ... : ... : B |
+| A.cs:97:19:97:32 | call to method Source<C> : C | A.cs:97:13:97:13 | [post] access to parameter b : B [field c] : C |
 | A.cs:97:19:97:32 | call to method Source<C> : C | A.cs:97:13:97:13 | [post] access to parameter b : B [field c] : C |
 | A.cs:98:13:98:16 | [post] this access : D [field b, field c] : C | A.cs:105:17:105:29 | object creation of type D : D [field b, field c] : C |
+| A.cs:98:13:98:16 | [post] this access : D [field b, field c] : C | A.cs:105:17:105:29 | object creation of type D : D [field b, field c] : C |
+| A.cs:98:13:98:16 | [post] this access : D [field b] : B | A.cs:105:17:105:29 | object creation of type D : D [field b] : B |
 | A.cs:98:13:98:16 | [post] this access : D [field b] : B | A.cs:105:17:105:29 | object creation of type D : D [field b] : B |
 | A.cs:98:22:98:43 | ... ? ... : ... : B | A.cs:98:13:98:16 | [post] this access : D [field b] : B |
 | A.cs:98:22:98:43 | ... ? ... : ... : B | A.cs:98:13:98:16 | [post] this access : D [field b] : B |
+| A.cs:98:22:98:43 | ... ? ... : ... : B | A.cs:98:13:98:16 | [post] this access : D [field b] : B |
+| A.cs:98:22:98:43 | ... ? ... : ... : B | A.cs:98:13:98:16 | [post] this access : D [field b] : B |
+| A.cs:98:22:98:43 | ... ? ... : ... : B [field c] : C | A.cs:98:13:98:16 | [post] this access : D [field b, field c] : C |
 | A.cs:98:22:98:43 | ... ? ... : ... : B [field c] : C | A.cs:98:13:98:16 | [post] this access : D [field b, field c] : C |
 | A.cs:98:30:98:43 | call to method Source<B> : B | A.cs:98:22:98:43 | ... ? ... : ... : B |
+| A.cs:98:30:98:43 | call to method Source<B> : B | A.cs:98:22:98:43 | ... ? ... : ... : B |
+| A.cs:104:17:104:30 | call to method Source<B> : B | A.cs:105:23:105:23 | access to local variable b : B |
 | A.cs:104:17:104:30 | call to method Source<B> : B | A.cs:105:23:105:23 | access to local variable b : B |
 | A.cs:105:17:105:29 | object creation of type D : D [field b, field c] : C | A.cs:107:14:107:14 | access to local variable d : D [field b, field c] : C |
+| A.cs:105:17:105:29 | object creation of type D : D [field b, field c] : C | A.cs:107:14:107:14 | access to local variable d : D [field b, field c] : C |
+| A.cs:105:17:105:29 | object creation of type D : D [field b] : B | A.cs:106:14:106:14 | access to local variable d : D [field b] : B |
 | A.cs:105:17:105:29 | object creation of type D : D [field b] : B | A.cs:106:14:106:14 | access to local variable d : D [field b] : B |
 | A.cs:105:23:105:23 | [post] access to local variable b : B [field c] : C | A.cs:108:14:108:14 | access to local variable b : B [field c] : C |
+| A.cs:105:23:105:23 | [post] access to local variable b : B [field c] : C | A.cs:108:14:108:14 | access to local variable b : B [field c] : C |
+| A.cs:105:23:105:23 | access to local variable b : B | A.cs:95:20:95:20 | b : B |
 | A.cs:105:23:105:23 | access to local variable b : B | A.cs:95:20:95:20 | b : B |
 | A.cs:105:23:105:23 | access to local variable b : B | A.cs:105:17:105:29 | object creation of type D : D [field b] : B |
+| A.cs:105:23:105:23 | access to local variable b : B | A.cs:105:17:105:29 | object creation of type D : D [field b] : B |
+| A.cs:106:14:106:14 | access to local variable d : D [field b] : B | A.cs:106:14:106:16 | access to field b |
 | A.cs:106:14:106:14 | access to local variable d : D [field b] : B | A.cs:106:14:106:16 | access to field b |
 | A.cs:107:14:107:14 | access to local variable d : D [field b, field c] : C | A.cs:107:14:107:16 | access to field b : B [field c] : C |
+| A.cs:107:14:107:14 | access to local variable d : D [field b, field c] : C | A.cs:107:14:107:16 | access to field b : B [field c] : C |
+| A.cs:107:14:107:16 | access to field b : B [field c] : C | A.cs:107:14:107:18 | access to field c |
 | A.cs:107:14:107:16 | access to field b : B [field c] : C | A.cs:107:14:107:18 | access to field c |
 | A.cs:108:14:108:14 | access to local variable b : B [field c] : C | A.cs:108:14:108:16 | access to field c |
+| A.cs:108:14:108:14 | access to local variable b : B [field c] : C | A.cs:108:14:108:16 | access to field c |
+| A.cs:113:17:113:29 | call to method Source<B> : B | A.cs:114:29:114:29 | access to local variable b : B |
 | A.cs:113:17:113:29 | call to method Source<B> : B | A.cs:114:29:114:29 | access to local variable b : B |
 | A.cs:114:18:114:54 | object creation of type MyList : MyList [field head] : B | A.cs:115:35:115:36 | access to local variable l1 : MyList [field head] : B |
+| A.cs:114:18:114:54 | object creation of type MyList : MyList [field head] : B | A.cs:115:35:115:36 | access to local variable l1 : MyList [field head] : B |
+| A.cs:114:29:114:29 | access to local variable b : B | A.cs:114:18:114:54 | object creation of type MyList : MyList [field head] : B |
 | A.cs:114:29:114:29 | access to local variable b : B | A.cs:114:18:114:54 | object creation of type MyList : MyList [field head] : B |
 | A.cs:114:29:114:29 | access to local variable b : B | A.cs:157:25:157:28 | head : B |
+| A.cs:114:29:114:29 | access to local variable b : B | A.cs:157:25:157:28 | head : B |
+| A.cs:115:18:115:37 | object creation of type MyList : MyList [field next, field head] : B | A.cs:116:35:116:36 | access to local variable l2 : MyList [field next, field head] : B |
 | A.cs:115:18:115:37 | object creation of type MyList : MyList [field next, field head] : B | A.cs:116:35:116:36 | access to local variable l2 : MyList [field next, field head] : B |
 | A.cs:115:35:115:36 | access to local variable l1 : MyList [field head] : B | A.cs:115:18:115:37 | object creation of type MyList : MyList [field next, field head] : B |
+| A.cs:115:35:115:36 | access to local variable l1 : MyList [field head] : B | A.cs:115:18:115:37 | object creation of type MyList : MyList [field next, field head] : B |
+| A.cs:115:35:115:36 | access to local variable l1 : MyList [field head] : B | A.cs:157:38:157:41 | next : MyList [field head] : B |
 | A.cs:115:35:115:36 | access to local variable l1 : MyList [field head] : B | A.cs:157:38:157:41 | next : MyList [field head] : B |
 | A.cs:116:18:116:37 | object creation of type MyList : MyList [field next, field next, field head] : B | A.cs:119:14:119:15 | access to local variable l3 : MyList [field next, field next, field head] : B |
+| A.cs:116:18:116:37 | object creation of type MyList : MyList [field next, field next, field head] : B | A.cs:119:14:119:15 | access to local variable l3 : MyList [field next, field next, field head] : B |
+| A.cs:116:18:116:37 | object creation of type MyList : MyList [field next, field next, field head] : B | A.cs:121:41:121:41 | access to local variable l : MyList [field next, field next, field head] : B |
 | A.cs:116:18:116:37 | object creation of type MyList : MyList [field next, field next, field head] : B | A.cs:121:41:121:41 | access to local variable l : MyList [field next, field next, field head] : B |
 | A.cs:116:35:116:36 | access to local variable l2 : MyList [field next, field head] : B | A.cs:116:18:116:37 | object creation of type MyList : MyList [field next, field next, field head] : B |
+| A.cs:116:35:116:36 | access to local variable l2 : MyList [field next, field head] : B | A.cs:116:18:116:37 | object creation of type MyList : MyList [field next, field next, field head] : B |
+| A.cs:116:35:116:36 | access to local variable l2 : MyList [field next, field head] : B | A.cs:157:38:157:41 | next : MyList [field next, field head] : B |
 | A.cs:116:35:116:36 | access to local variable l2 : MyList [field next, field head] : B | A.cs:157:38:157:41 | next : MyList [field next, field head] : B |
 | A.cs:119:14:119:15 | access to local variable l3 : MyList [field next, field next, field head] : B | A.cs:119:14:119:20 | access to field next : MyList [field next, field head] : B |
+| A.cs:119:14:119:15 | access to local variable l3 : MyList [field next, field next, field head] : B | A.cs:119:14:119:20 | access to field next : MyList [field next, field head] : B |
+| A.cs:119:14:119:20 | access to field next : MyList [field next, field head] : B | A.cs:119:14:119:25 | access to field next : MyList [field head] : B |
 | A.cs:119:14:119:20 | access to field next : MyList [field next, field head] : B | A.cs:119:14:119:25 | access to field next : MyList [field head] : B |
 | A.cs:119:14:119:25 | access to field next : MyList [field head] : B | A.cs:119:14:119:30 | access to field head |
+| A.cs:119:14:119:25 | access to field next : MyList [field head] : B | A.cs:119:14:119:30 | access to field head |
+| A.cs:121:41:121:41 | access to local variable l : MyList [field next, field head] : B | A.cs:121:41:121:46 | access to field next : MyList [field head] : B |
 | A.cs:121:41:121:41 | access to local variable l : MyList [field next, field head] : B | A.cs:121:41:121:46 | access to field next : MyList [field head] : B |
 | A.cs:121:41:121:41 | access to local variable l : MyList [field next, field next, field head] : B | A.cs:121:41:121:46 | access to field next : MyList [field next, field head] : B |
+| A.cs:121:41:121:41 | access to local variable l : MyList [field next, field next, field head] : B | A.cs:121:41:121:46 | access to field next : MyList [field next, field head] : B |
+| A.cs:121:41:121:46 | access to field next : MyList [field head] : B | A.cs:123:18:123:18 | access to local variable l : MyList [field head] : B |
 | A.cs:121:41:121:46 | access to field next : MyList [field head] : B | A.cs:123:18:123:18 | access to local variable l : MyList [field head] : B |
 | A.cs:121:41:121:46 | access to field next : MyList [field next, field head] : B | A.cs:121:41:121:41 | access to local variable l : MyList [field next, field head] : B |
+| A.cs:121:41:121:46 | access to field next : MyList [field next, field head] : B | A.cs:121:41:121:41 | access to local variable l : MyList [field next, field head] : B |
+| A.cs:123:18:123:18 | access to local variable l : MyList [field head] : B | A.cs:123:18:123:23 | access to field head |
 | A.cs:123:18:123:18 | access to local variable l : MyList [field head] : B | A.cs:123:18:123:23 | access to field head |
 | A.cs:141:20:141:20 | c : C | A.cs:143:22:143:22 | access to parameter c : C |
+| A.cs:141:20:141:20 | c : C | A.cs:143:22:143:22 | access to parameter c : C |
+| A.cs:143:22:143:22 | access to parameter c : C | A.cs:143:13:143:16 | [post] this access : B [field c] : C |
 | A.cs:143:22:143:22 | access to parameter c : C | A.cs:143:13:143:16 | [post] this access : B [field c] : C |
 | A.cs:145:27:145:27 | c : C | A.cs:145:41:145:41 | access to parameter c : C |
+| A.cs:145:27:145:27 | c : C | A.cs:145:41:145:41 | access to parameter c : C |
+| A.cs:145:27:145:27 | c : C1 | A.cs:145:41:145:41 | access to parameter c : C1 |
 | A.cs:145:27:145:27 | c : C1 | A.cs:145:41:145:41 | access to parameter c : C1 |
 | A.cs:145:27:145:27 | c : C2 | A.cs:145:41:145:41 | access to parameter c : C2 |
+| A.cs:145:27:145:27 | c : C2 | A.cs:145:41:145:41 | access to parameter c : C2 |
+| A.cs:145:41:145:41 | access to parameter c : C | A.cs:145:32:145:35 | [post] this access : B [field c] : C |
 | A.cs:145:41:145:41 | access to parameter c : C | A.cs:145:32:145:35 | [post] this access : B [field c] : C |
 | A.cs:145:41:145:41 | access to parameter c : C1 | A.cs:145:32:145:35 | [post] this access : B [field c] : C1 |
+| A.cs:145:41:145:41 | access to parameter c : C1 | A.cs:145:32:145:35 | [post] this access : B [field c] : C1 |
+| A.cs:145:41:145:41 | access to parameter c : C2 | A.cs:145:32:145:35 | [post] this access : B [field c] : C2 |
 | A.cs:145:41:145:41 | access to parameter c : C2 | A.cs:145:32:145:35 | [post] this access : B [field c] : C2 |
 | A.cs:146:18:146:20 | this : B [field c] : C | A.cs:146:33:146:36 | this access : B [field c] : C |
+| A.cs:146:18:146:20 | this : B [field c] : C | A.cs:146:33:146:36 | this access : B [field c] : C |
+| A.cs:146:18:146:20 | this : B [field c] : C1 | A.cs:146:33:146:36 | this access : B [field c] : C1 |
 | A.cs:146:18:146:20 | this : B [field c] : C1 | A.cs:146:33:146:36 | this access : B [field c] : C1 |
 | A.cs:146:33:146:36 | this access : B [field c] : C | A.cs:146:33:146:38 | access to field c : C |
+| A.cs:146:33:146:36 | this access : B [field c] : C | A.cs:146:33:146:38 | access to field c : C |
+| A.cs:146:33:146:36 | this access : B [field c] : C1 | A.cs:146:33:146:38 | access to field c : C1 |
 | A.cs:146:33:146:36 | this access : B [field c] : C1 | A.cs:146:33:146:38 | access to field c : C1 |
 | A.cs:147:32:147:32 | c : C | A.cs:149:26:149:26 | access to parameter c : C |
+| A.cs:147:32:147:32 | c : C | A.cs:149:26:149:26 | access to parameter c : C |
+| A.cs:149:26:149:26 | access to parameter c : C | A.cs:141:20:141:20 | c : C |
 | A.cs:149:26:149:26 | access to parameter c : C | A.cs:141:20:141:20 | c : C |
 | A.cs:149:26:149:26 | access to parameter c : C | A.cs:149:20:149:27 | object creation of type B : B [field c] : C |
+| A.cs:149:26:149:26 | access to parameter c : C | A.cs:149:20:149:27 | object creation of type B : B [field c] : C |
+| A.cs:157:25:157:28 | head : B | A.cs:159:25:159:28 | access to parameter head : B |
 | A.cs:157:25:157:28 | head : B | A.cs:159:25:159:28 | access to parameter head : B |
 | A.cs:157:38:157:41 | next : MyList [field head] : B | A.cs:160:25:160:28 | access to parameter next : MyList [field head] : B |
+| A.cs:157:38:157:41 | next : MyList [field head] : B | A.cs:160:25:160:28 | access to parameter next : MyList [field head] : B |
+| A.cs:157:38:157:41 | next : MyList [field next, field head] : B | A.cs:160:25:160:28 | access to parameter next : MyList [field next, field head] : B |
 | A.cs:157:38:157:41 | next : MyList [field next, field head] : B | A.cs:160:25:160:28 | access to parameter next : MyList [field next, field head] : B |
 | A.cs:159:25:159:28 | access to parameter head : B | A.cs:159:13:159:16 | [post] this access : MyList [field head] : B |
+| A.cs:159:25:159:28 | access to parameter head : B | A.cs:159:13:159:16 | [post] this access : MyList [field head] : B |
+| A.cs:160:25:160:28 | access to parameter next : MyList [field head] : B | A.cs:160:13:160:16 | [post] this access : MyList [field next, field head] : B |
 | A.cs:160:25:160:28 | access to parameter next : MyList [field head] : B | A.cs:160:13:160:16 | [post] this access : MyList [field next, field head] : B |
 | A.cs:160:25:160:28 | access to parameter next : MyList [field next, field head] : B | A.cs:160:13:160:16 | [post] this access : MyList [field next, field next, field head] : B |
+| A.cs:160:25:160:28 | access to parameter next : MyList [field next, field head] : B | A.cs:160:13:160:16 | [post] this access : MyList [field next, field next, field head] : B |
+| B.cs:5:17:5:31 | call to method Source<Elem> : Elem | B.cs:6:27:6:27 | access to local variable e : Elem |
 | B.cs:5:17:5:31 | call to method Source<Elem> : Elem | B.cs:6:27:6:27 | access to local variable e : Elem |
 | B.cs:6:18:6:34 | object creation of type Box1 : Box1 [field elem1] : Elem | B.cs:7:27:7:28 | access to local variable b1 : Box1 [field elem1] : Elem |
+| B.cs:6:18:6:34 | object creation of type Box1 : Box1 [field elem1] : Elem | B.cs:7:27:7:28 | access to local variable b1 : Box1 [field elem1] : Elem |
+| B.cs:6:27:6:27 | access to local variable e : Elem | B.cs:6:18:6:34 | object creation of type Box1 : Box1 [field elem1] : Elem |
 | B.cs:6:27:6:27 | access to local variable e : Elem | B.cs:6:18:6:34 | object creation of type Box1 : Box1 [field elem1] : Elem |
 | B.cs:6:27:6:27 | access to local variable e : Elem | B.cs:29:26:29:27 | e1 : Elem |
+| B.cs:6:27:6:27 | access to local variable e : Elem | B.cs:29:26:29:27 | e1 : Elem |
+| B.cs:7:18:7:29 | object creation of type Box2 : Box2 [field box1, field elem1] : Elem | B.cs:8:14:8:15 | access to local variable b2 : Box2 [field box1, field elem1] : Elem |
 | B.cs:7:18:7:29 | object creation of type Box2 : Box2 [field box1, field elem1] : Elem | B.cs:8:14:8:15 | access to local variable b2 : Box2 [field box1, field elem1] : Elem |
 | B.cs:7:27:7:28 | access to local variable b1 : Box1 [field elem1] : Elem | B.cs:7:18:7:29 | object creation of type Box2 : Box2 [field box1, field elem1] : Elem |
+| B.cs:7:27:7:28 | access to local variable b1 : Box1 [field elem1] : Elem | B.cs:7:18:7:29 | object creation of type Box2 : Box2 [field box1, field elem1] : Elem |
+| B.cs:7:27:7:28 | access to local variable b1 : Box1 [field elem1] : Elem | B.cs:39:26:39:27 | b1 : Box1 [field elem1] : Elem |
 | B.cs:7:27:7:28 | access to local variable b1 : Box1 [field elem1] : Elem | B.cs:39:26:39:27 | b1 : Box1 [field elem1] : Elem |
 | B.cs:8:14:8:15 | access to local variable b2 : Box2 [field box1, field elem1] : Elem | B.cs:8:14:8:20 | access to field box1 : Box1 [field elem1] : Elem |
+| B.cs:8:14:8:15 | access to local variable b2 : Box2 [field box1, field elem1] : Elem | B.cs:8:14:8:20 | access to field box1 : Box1 [field elem1] : Elem |
+| B.cs:8:14:8:20 | access to field box1 : Box1 [field elem1] : Elem | B.cs:8:14:8:26 | access to field elem1 |
 | B.cs:8:14:8:20 | access to field box1 : Box1 [field elem1] : Elem | B.cs:8:14:8:26 | access to field elem1 |
 | B.cs:14:17:14:31 | call to method Source<Elem> : Elem | B.cs:15:33:15:33 | access to local variable e : Elem |
+| B.cs:14:17:14:31 | call to method Source<Elem> : Elem | B.cs:15:33:15:33 | access to local variable e : Elem |
+| B.cs:15:18:15:34 | object creation of type Box1 : Box1 [field elem2] : Elem | B.cs:16:27:16:28 | access to local variable b1 : Box1 [field elem2] : Elem |
 | B.cs:15:18:15:34 | object creation of type Box1 : Box1 [field elem2] : Elem | B.cs:16:27:16:28 | access to local variable b1 : Box1 [field elem2] : Elem |
 | B.cs:15:33:15:33 | access to local variable e : Elem | B.cs:15:18:15:34 | object creation of type Box1 : Box1 [field elem2] : Elem |
+| B.cs:15:33:15:33 | access to local variable e : Elem | B.cs:15:18:15:34 | object creation of type Box1 : Box1 [field elem2] : Elem |
+| B.cs:15:33:15:33 | access to local variable e : Elem | B.cs:29:35:29:36 | e2 : Elem |
 | B.cs:15:33:15:33 | access to local variable e : Elem | B.cs:29:35:29:36 | e2 : Elem |
 | B.cs:16:18:16:29 | object creation of type Box2 : Box2 [field box1, field elem2] : Elem | B.cs:18:14:18:15 | access to local variable b2 : Box2 [field box1, field elem2] : Elem |
+| B.cs:16:18:16:29 | object creation of type Box2 : Box2 [field box1, field elem2] : Elem | B.cs:18:14:18:15 | access to local variable b2 : Box2 [field box1, field elem2] : Elem |
+| B.cs:16:27:16:28 | access to local variable b1 : Box1 [field elem2] : Elem | B.cs:16:18:16:29 | object creation of type Box2 : Box2 [field box1, field elem2] : Elem |
 | B.cs:16:27:16:28 | access to local variable b1 : Box1 [field elem2] : Elem | B.cs:16:18:16:29 | object creation of type Box2 : Box2 [field box1, field elem2] : Elem |
 | B.cs:16:27:16:28 | access to local variable b1 : Box1 [field elem2] : Elem | B.cs:39:26:39:27 | b1 : Box1 [field elem2] : Elem |
+| B.cs:16:27:16:28 | access to local variable b1 : Box1 [field elem2] : Elem | B.cs:39:26:39:27 | b1 : Box1 [field elem2] : Elem |
+| B.cs:18:14:18:15 | access to local variable b2 : Box2 [field box1, field elem2] : Elem | B.cs:18:14:18:20 | access to field box1 : Box1 [field elem2] : Elem |
 | B.cs:18:14:18:15 | access to local variable b2 : Box2 [field box1, field elem2] : Elem | B.cs:18:14:18:20 | access to field box1 : Box1 [field elem2] : Elem |
 | B.cs:18:14:18:20 | access to field box1 : Box1 [field elem2] : Elem | B.cs:18:14:18:26 | access to field elem2 |
+| B.cs:18:14:18:20 | access to field box1 : Box1 [field elem2] : Elem | B.cs:18:14:18:26 | access to field elem2 |
+| B.cs:29:26:29:27 | e1 : Elem | B.cs:31:26:31:27 | access to parameter e1 : Elem |
 | B.cs:29:26:29:27 | e1 : Elem | B.cs:31:26:31:27 | access to parameter e1 : Elem |
 | B.cs:29:35:29:36 | e2 : Elem | B.cs:32:26:32:27 | access to parameter e2 : Elem |
+| B.cs:29:35:29:36 | e2 : Elem | B.cs:32:26:32:27 | access to parameter e2 : Elem |
+| B.cs:31:26:31:27 | access to parameter e1 : Elem | B.cs:31:13:31:16 | [post] this access : Box1 [field elem1] : Elem |
 | B.cs:31:26:31:27 | access to parameter e1 : Elem | B.cs:31:13:31:16 | [post] this access : Box1 [field elem1] : Elem |
 | B.cs:32:26:32:27 | access to parameter e2 : Elem | B.cs:32:13:32:16 | [post] this access : Box1 [field elem2] : Elem |
+| B.cs:32:26:32:27 | access to parameter e2 : Elem | B.cs:32:13:32:16 | [post] this access : Box1 [field elem2] : Elem |
+| B.cs:39:26:39:27 | b1 : Box1 [field elem1] : Elem | B.cs:41:25:41:26 | access to parameter b1 : Box1 [field elem1] : Elem |
 | B.cs:39:26:39:27 | b1 : Box1 [field elem1] : Elem | B.cs:41:25:41:26 | access to parameter b1 : Box1 [field elem1] : Elem |
 | B.cs:39:26:39:27 | b1 : Box1 [field elem2] : Elem | B.cs:41:25:41:26 | access to parameter b1 : Box1 [field elem2] : Elem |
+| B.cs:39:26:39:27 | b1 : Box1 [field elem2] : Elem | B.cs:41:25:41:26 | access to parameter b1 : Box1 [field elem2] : Elem |
+| B.cs:41:25:41:26 | access to parameter b1 : Box1 [field elem1] : Elem | B.cs:41:13:41:16 | [post] this access : Box2 [field box1, field elem1] : Elem |
 | B.cs:41:25:41:26 | access to parameter b1 : Box1 [field elem1] : Elem | B.cs:41:13:41:16 | [post] this access : Box2 [field box1, field elem1] : Elem |
 | B.cs:41:25:41:26 | access to parameter b1 : Box1 [field elem2] : Elem | B.cs:41:13:41:16 | [post] this access : Box2 [field box1, field elem2] : Elem |
+| B.cs:41:25:41:26 | access to parameter b1 : Box1 [field elem2] : Elem | B.cs:41:13:41:16 | [post] this access : Box2 [field box1, field elem2] : Elem |
+| C.cs:3:18:3:19 | [post] this access : C [field s1] : Elem | C.cs:12:15:12:21 | object creation of type C : C [field s1] : Elem |
 | C.cs:3:18:3:19 | [post] this access : C [field s1] : Elem | C.cs:12:15:12:21 | object creation of type C : C [field s1] : Elem |
 | C.cs:3:23:3:37 | call to method Source<Elem> : Elem | C.cs:3:18:3:19 | [post] this access : C [field s1] : Elem |
+| C.cs:3:23:3:37 | call to method Source<Elem> : Elem | C.cs:3:18:3:19 | [post] this access : C [field s1] : Elem |
+| C.cs:4:27:4:28 | [post] this access : C [field s2] : Elem | C.cs:12:15:12:21 | object creation of type C : C [field s2] : Elem |
 | C.cs:4:27:4:28 | [post] this access : C [field s2] : Elem | C.cs:12:15:12:21 | object creation of type C : C [field s2] : Elem |
 | C.cs:4:32:4:46 | call to method Source<Elem> : Elem | C.cs:4:27:4:28 | [post] this access : C [field s2] : Elem |
+| C.cs:4:32:4:46 | call to method Source<Elem> : Elem | C.cs:4:27:4:28 | [post] this access : C [field s2] : Elem |
+| C.cs:6:30:6:44 | call to method Source<Elem> : Elem | C.cs:26:14:26:15 | access to field s4 |
 | C.cs:6:30:6:44 | call to method Source<Elem> : Elem | C.cs:26:14:26:15 | access to field s4 |
 | C.cs:7:18:7:19 | [post] this access : C [property s5] : Elem | C.cs:12:15:12:21 | object creation of type C : C [property s5] : Elem |
+| C.cs:7:18:7:19 | [post] this access : C [property s5] : Elem | C.cs:12:15:12:21 | object creation of type C : C [property s5] : Elem |
+| C.cs:7:37:7:51 | call to method Source<Elem> : Elem | C.cs:7:18:7:19 | [post] this access : C [property s5] : Elem |
 | C.cs:7:37:7:51 | call to method Source<Elem> : Elem | C.cs:7:18:7:19 | [post] this access : C [property s5] : Elem |
 | C.cs:8:30:8:44 | call to method Source<Elem> : Elem | C.cs:28:14:28:15 | access to property s6 |
+| C.cs:8:30:8:44 | call to method Source<Elem> : Elem | C.cs:28:14:28:15 | access to property s6 |
+| C.cs:12:15:12:21 | object creation of type C : C [field s1] : Elem | C.cs:13:9:13:9 | access to local variable c : C [field s1] : Elem |
 | C.cs:12:15:12:21 | object creation of type C : C [field s1] : Elem | C.cs:13:9:13:9 | access to local variable c : C [field s1] : Elem |
 | C.cs:12:15:12:21 | object creation of type C : C [field s2] : Elem | C.cs:13:9:13:9 | access to local variable c : C [field s2] : Elem |
+| C.cs:12:15:12:21 | object creation of type C : C [field s2] : Elem | C.cs:13:9:13:9 | access to local variable c : C [field s2] : Elem |
+| C.cs:12:15:12:21 | object creation of type C : C [field s3] : Elem | C.cs:13:9:13:9 | access to local variable c : C [field s3] : Elem |
 | C.cs:12:15:12:21 | object creation of type C : C [field s3] : Elem | C.cs:13:9:13:9 | access to local variable c : C [field s3] : Elem |
 | C.cs:12:15:12:21 | object creation of type C : C [property s5] : Elem | C.cs:13:9:13:9 | access to local variable c : C [property s5] : Elem |
+| C.cs:12:15:12:21 | object creation of type C : C [property s5] : Elem | C.cs:13:9:13:9 | access to local variable c : C [property s5] : Elem |
+| C.cs:13:9:13:9 | access to local variable c : C [field s1] : Elem | C.cs:21:17:21:18 | this : C [field s1] : Elem |
 | C.cs:13:9:13:9 | access to local variable c : C [field s1] : Elem | C.cs:21:17:21:18 | this : C [field s1] : Elem |
 | C.cs:13:9:13:9 | access to local variable c : C [field s2] : Elem | C.cs:21:17:21:18 | this : C [field s2] : Elem |
+| C.cs:13:9:13:9 | access to local variable c : C [field s2] : Elem | C.cs:21:17:21:18 | this : C [field s2] : Elem |
+| C.cs:13:9:13:9 | access to local variable c : C [field s3] : Elem | C.cs:21:17:21:18 | this : C [field s3] : Elem |
 | C.cs:13:9:13:9 | access to local variable c : C [field s3] : Elem | C.cs:21:17:21:18 | this : C [field s3] : Elem |
 | C.cs:13:9:13:9 | access to local variable c : C [property s5] : Elem | C.cs:21:17:21:18 | this : C [property s5] : Elem |
+| C.cs:13:9:13:9 | access to local variable c : C [property s5] : Elem | C.cs:21:17:21:18 | this : C [property s5] : Elem |
+| C.cs:18:9:18:12 | [post] this access : C [field s3] : Elem | C.cs:12:15:12:21 | object creation of type C : C [field s3] : Elem |
 | C.cs:18:9:18:12 | [post] this access : C [field s3] : Elem | C.cs:12:15:12:21 | object creation of type C : C [field s3] : Elem |
 | C.cs:18:19:18:33 | call to method Source<Elem> : Elem | C.cs:18:9:18:12 | [post] this access : C [field s3] : Elem |
+| C.cs:18:19:18:33 | call to method Source<Elem> : Elem | C.cs:18:9:18:12 | [post] this access : C [field s3] : Elem |
+| C.cs:21:17:21:18 | this : C [field s1] : Elem | C.cs:23:14:23:15 | this access : C [field s1] : Elem |
 | C.cs:21:17:21:18 | this : C [field s1] : Elem | C.cs:23:14:23:15 | this access : C [field s1] : Elem |
 | C.cs:21:17:21:18 | this : C [field s2] : Elem | C.cs:24:14:24:15 | this access : C [field s2] : Elem |
+| C.cs:21:17:21:18 | this : C [field s2] : Elem | C.cs:24:14:24:15 | this access : C [field s2] : Elem |
+| C.cs:21:17:21:18 | this : C [field s3] : Elem | C.cs:25:14:25:15 | this access : C [field s3] : Elem |
 | C.cs:21:17:21:18 | this : C [field s3] : Elem | C.cs:25:14:25:15 | this access : C [field s3] : Elem |
 | C.cs:21:17:21:18 | this : C [property s5] : Elem | C.cs:27:14:27:15 | this access : C [property s5] : Elem |
+| C.cs:21:17:21:18 | this : C [property s5] : Elem | C.cs:27:14:27:15 | this access : C [property s5] : Elem |
+| C.cs:23:14:23:15 | this access : C [field s1] : Elem | C.cs:23:14:23:15 | access to field s1 |
 | C.cs:23:14:23:15 | this access : C [field s1] : Elem | C.cs:23:14:23:15 | access to field s1 |
 | C.cs:24:14:24:15 | this access : C [field s2] : Elem | C.cs:24:14:24:15 | access to field s2 |
+| C.cs:24:14:24:15 | this access : C [field s2] : Elem | C.cs:24:14:24:15 | access to field s2 |
+| C.cs:25:14:25:15 | this access : C [field s3] : Elem | C.cs:25:14:25:15 | access to field s3 |
 | C.cs:25:14:25:15 | this access : C [field s3] : Elem | C.cs:25:14:25:15 | access to field s3 |
 | C.cs:27:14:27:15 | this access : C [property s5] : Elem | C.cs:27:14:27:15 | access to property s5 |
+| C.cs:27:14:27:15 | this access : C [property s5] : Elem | C.cs:27:14:27:15 | access to property s5 |
+| C_ctor.cs:3:18:3:19 | [post] this access : C_no_ctor [field s1] : Elem | C_ctor.cs:7:23:7:37 | object creation of type C_no_ctor : C_no_ctor [field s1] : Elem |
 | C_ctor.cs:3:18:3:19 | [post] this access : C_no_ctor [field s1] : Elem | C_ctor.cs:7:23:7:37 | object creation of type C_no_ctor : C_no_ctor [field s1] : Elem |
 | C_ctor.cs:3:23:3:42 | call to method Source<Elem> : Elem | C_ctor.cs:3:18:3:19 | [post] this access : C_no_ctor [field s1] : Elem |
+| C_ctor.cs:3:23:3:42 | call to method Source<Elem> : Elem | C_ctor.cs:3:18:3:19 | [post] this access : C_no_ctor [field s1] : Elem |
+| C_ctor.cs:7:23:7:37 | object creation of type C_no_ctor : C_no_ctor [field s1] : Elem | C_ctor.cs:8:9:8:9 | access to local variable c : C_no_ctor [field s1] : Elem |
 | C_ctor.cs:7:23:7:37 | object creation of type C_no_ctor : C_no_ctor [field s1] : Elem | C_ctor.cs:8:9:8:9 | access to local variable c : C_no_ctor [field s1] : Elem |
 | C_ctor.cs:8:9:8:9 | access to local variable c : C_no_ctor [field s1] : Elem | C_ctor.cs:11:17:11:18 | this : C_no_ctor [field s1] : Elem |
+| C_ctor.cs:8:9:8:9 | access to local variable c : C_no_ctor [field s1] : Elem | C_ctor.cs:11:17:11:18 | this : C_no_ctor [field s1] : Elem |
+| C_ctor.cs:11:17:11:18 | this : C_no_ctor [field s1] : Elem | C_ctor.cs:13:19:13:20 | this access : C_no_ctor [field s1] : Elem |
 | C_ctor.cs:11:17:11:18 | this : C_no_ctor [field s1] : Elem | C_ctor.cs:13:19:13:20 | this access : C_no_ctor [field s1] : Elem |
 | C_ctor.cs:13:19:13:20 | this access : C_no_ctor [field s1] : Elem | C_ctor.cs:13:19:13:20 | access to field s1 |
+| C_ctor.cs:13:19:13:20 | this access : C_no_ctor [field s1] : Elem | C_ctor.cs:13:19:13:20 | access to field s1 |
+| C_ctor.cs:19:18:19:19 | [post] this access : C_with_ctor [field s1] : Elem | C_ctor.cs:23:25:23:41 | object creation of type C_with_ctor : C_with_ctor [field s1] : Elem |
 | C_ctor.cs:19:18:19:19 | [post] this access : C_with_ctor [field s1] : Elem | C_ctor.cs:23:25:23:41 | object creation of type C_with_ctor : C_with_ctor [field s1] : Elem |
 | C_ctor.cs:19:23:19:42 | call to method Source<Elem> : Elem | C_ctor.cs:19:18:19:19 | [post] this access : C_with_ctor [field s1] : Elem |
+| C_ctor.cs:19:23:19:42 | call to method Source<Elem> : Elem | C_ctor.cs:19:18:19:19 | [post] this access : C_with_ctor [field s1] : Elem |
+| C_ctor.cs:23:25:23:41 | object creation of type C_with_ctor : C_with_ctor [field s1] : Elem | C_ctor.cs:24:9:24:9 | access to local variable c : C_with_ctor [field s1] : Elem |
 | C_ctor.cs:23:25:23:41 | object creation of type C_with_ctor : C_with_ctor [field s1] : Elem | C_ctor.cs:24:9:24:9 | access to local variable c : C_with_ctor [field s1] : Elem |
 | C_ctor.cs:24:9:24:9 | access to local variable c : C_with_ctor [field s1] : Elem | C_ctor.cs:29:17:29:18 | this : C_with_ctor [field s1] : Elem |
+| C_ctor.cs:24:9:24:9 | access to local variable c : C_with_ctor [field s1] : Elem | C_ctor.cs:29:17:29:18 | this : C_with_ctor [field s1] : Elem |
+| C_ctor.cs:29:17:29:18 | this : C_with_ctor [field s1] : Elem | C_ctor.cs:31:19:31:20 | this access : C_with_ctor [field s1] : Elem |
 | C_ctor.cs:29:17:29:18 | this : C_with_ctor [field s1] : Elem | C_ctor.cs:31:19:31:20 | this access : C_with_ctor [field s1] : Elem |
 | C_ctor.cs:31:19:31:20 | this access : C_with_ctor [field s1] : Elem | C_ctor.cs:31:19:31:20 | access to field s1 |
+| C_ctor.cs:31:19:31:20 | this access : C_with_ctor [field s1] : Elem | C_ctor.cs:31:19:31:20 | access to field s1 |
+| D.cs:8:9:8:11 | this : D [field trivialPropField] : Object | D.cs:8:22:8:25 | this access : D [field trivialPropField] : Object |
 | D.cs:8:9:8:11 | this : D [field trivialPropField] : Object | D.cs:8:22:8:25 | this access : D [field trivialPropField] : Object |
 | D.cs:8:22:8:25 | this access : D [field trivialPropField] : Object | D.cs:8:22:8:42 | access to field trivialPropField : Object |
+| D.cs:8:22:8:25 | this access : D [field trivialPropField] : Object | D.cs:8:22:8:42 | access to field trivialPropField : Object |
+| D.cs:9:9:9:11 | value : Object | D.cs:9:39:9:43 | access to parameter value : Object |
 | D.cs:9:9:9:11 | value : Object | D.cs:9:39:9:43 | access to parameter value : Object |
 | D.cs:9:39:9:43 | access to parameter value : Object | D.cs:9:15:9:18 | [post] this access : D [field trivialPropField] : Object |
+| D.cs:9:39:9:43 | access to parameter value : Object | D.cs:9:15:9:18 | [post] this access : D [field trivialPropField] : Object |
+| D.cs:14:9:14:11 | this : D [field trivialPropField] : Object | D.cs:14:22:14:25 | this access : D [field trivialPropField] : Object |
 | D.cs:14:9:14:11 | this : D [field trivialPropField] : Object | D.cs:14:22:14:25 | this access : D [field trivialPropField] : Object |
 | D.cs:14:22:14:25 | this access : D [field trivialPropField] : Object | D.cs:14:22:14:42 | access to field trivialPropField : Object |
+| D.cs:14:22:14:25 | this access : D [field trivialPropField] : Object | D.cs:14:22:14:42 | access to field trivialPropField : Object |
+| D.cs:15:9:15:11 | value : Object | D.cs:15:34:15:38 | access to parameter value : Object |
 | D.cs:15:9:15:11 | value : Object | D.cs:15:34:15:38 | access to parameter value : Object |
 | D.cs:15:34:15:38 | access to parameter value : Object | D.cs:9:9:9:11 | value : Object |
+| D.cs:15:34:15:38 | access to parameter value : Object | D.cs:9:9:9:11 | value : Object |
+| D.cs:15:34:15:38 | access to parameter value : Object | D.cs:15:15:15:18 | [post] this access : D [field trivialPropField] : Object |
 | D.cs:15:34:15:38 | access to parameter value : Object | D.cs:15:15:15:18 | [post] this access : D [field trivialPropField] : Object |
 | D.cs:18:28:18:29 | o1 : Object | D.cs:21:24:21:25 | access to parameter o1 : Object |
+| D.cs:18:28:18:29 | o1 : Object | D.cs:21:24:21:25 | access to parameter o1 : Object |
+| D.cs:18:39:18:40 | o2 : Object | D.cs:22:27:22:28 | access to parameter o2 : Object |
 | D.cs:18:39:18:40 | o2 : Object | D.cs:22:27:22:28 | access to parameter o2 : Object |
 | D.cs:18:50:18:51 | o3 : Object | D.cs:23:27:23:28 | access to parameter o3 : Object |
+| D.cs:18:50:18:51 | o3 : Object | D.cs:23:27:23:28 | access to parameter o3 : Object |
+| D.cs:21:9:21:11 | [post] access to local variable ret : D [property AutoProp] : Object | D.cs:24:16:24:18 | access to local variable ret : D [property AutoProp] : Object |
 | D.cs:21:9:21:11 | [post] access to local variable ret : D [property AutoProp] : Object | D.cs:24:16:24:18 | access to local variable ret : D [property AutoProp] : Object |
 | D.cs:21:24:21:25 | access to parameter o1 : Object | D.cs:21:9:21:11 | [post] access to local variable ret : D [property AutoProp] : Object |
+| D.cs:21:24:21:25 | access to parameter o1 : Object | D.cs:21:9:21:11 | [post] access to local variable ret : D [property AutoProp] : Object |
+| D.cs:22:9:22:11 | [post] access to local variable ret : D [field trivialPropField] : Object | D.cs:24:16:24:18 | access to local variable ret : D [field trivialPropField] : Object |
 | D.cs:22:9:22:11 | [post] access to local variable ret : D [field trivialPropField] : Object | D.cs:24:16:24:18 | access to local variable ret : D [field trivialPropField] : Object |
 | D.cs:22:27:22:28 | access to parameter o2 : Object | D.cs:9:9:9:11 | value : Object |
+| D.cs:22:27:22:28 | access to parameter o2 : Object | D.cs:9:9:9:11 | value : Object |
+| D.cs:22:27:22:28 | access to parameter o2 : Object | D.cs:22:9:22:11 | [post] access to local variable ret : D [field trivialPropField] : Object |
 | D.cs:22:27:22:28 | access to parameter o2 : Object | D.cs:22:9:22:11 | [post] access to local variable ret : D [field trivialPropField] : Object |
 | D.cs:23:9:23:11 | [post] access to local variable ret : D [field trivialPropField] : Object | D.cs:24:16:24:18 | access to local variable ret : D [field trivialPropField] : Object |
+| D.cs:23:9:23:11 | [post] access to local variable ret : D [field trivialPropField] : Object | D.cs:24:16:24:18 | access to local variable ret : D [field trivialPropField] : Object |
+| D.cs:23:27:23:28 | access to parameter o3 : Object | D.cs:15:9:15:11 | value : Object |
 | D.cs:23:27:23:28 | access to parameter o3 : Object | D.cs:15:9:15:11 | value : Object |
 | D.cs:23:27:23:28 | access to parameter o3 : Object | D.cs:23:9:23:11 | [post] access to local variable ret : D [field trivialPropField] : Object |
+| D.cs:23:27:23:28 | access to parameter o3 : Object | D.cs:23:9:23:11 | [post] access to local variable ret : D [field trivialPropField] : Object |
+| D.cs:29:17:29:33 | call to method Source<Object> : Object | D.cs:31:24:31:24 | access to local variable o : Object |
 | D.cs:29:17:29:33 | call to method Source<Object> : Object | D.cs:31:24:31:24 | access to local variable o : Object |
 | D.cs:31:17:31:37 | call to method Create : D [property AutoProp] : Object | D.cs:32:14:32:14 | access to local variable d : D [property AutoProp] : Object |
+| D.cs:31:17:31:37 | call to method Create : D [property AutoProp] : Object | D.cs:32:14:32:14 | access to local variable d : D [property AutoProp] : Object |
+| D.cs:31:24:31:24 | access to local variable o : Object | D.cs:18:28:18:29 | o1 : Object |
 | D.cs:31:24:31:24 | access to local variable o : Object | D.cs:18:28:18:29 | o1 : Object |
 | D.cs:31:24:31:24 | access to local variable o : Object | D.cs:31:17:31:37 | call to method Create : D [property AutoProp] : Object |
+| D.cs:31:24:31:24 | access to local variable o : Object | D.cs:31:17:31:37 | call to method Create : D [property AutoProp] : Object |
+| D.cs:32:14:32:14 | access to local variable d : D [property AutoProp] : Object | D.cs:32:14:32:23 | access to property AutoProp |
 | D.cs:32:14:32:14 | access to local variable d : D [property AutoProp] : Object | D.cs:32:14:32:23 | access to property AutoProp |
 | D.cs:37:13:37:49 | call to method Create : D [field trivialPropField] : Object | D.cs:39:14:39:14 | access to local variable d : D [field trivialPropField] : Object |
+| D.cs:37:13:37:49 | call to method Create : D [field trivialPropField] : Object | D.cs:39:14:39:14 | access to local variable d : D [field trivialPropField] : Object |
+| D.cs:37:13:37:49 | call to method Create : D [field trivialPropField] : Object | D.cs:40:14:40:14 | access to local variable d : D [field trivialPropField] : Object |
 | D.cs:37:13:37:49 | call to method Create : D [field trivialPropField] : Object | D.cs:40:14:40:14 | access to local variable d : D [field trivialPropField] : Object |
 | D.cs:37:13:37:49 | call to method Create : D [field trivialPropField] : Object | D.cs:41:14:41:14 | access to local variable d : D [field trivialPropField] : Object |
+| D.cs:37:13:37:49 | call to method Create : D [field trivialPropField] : Object | D.cs:41:14:41:14 | access to local variable d : D [field trivialPropField] : Object |
+| D.cs:37:26:37:42 | call to method Source<Object> : Object | D.cs:18:39:18:40 | o2 : Object |
 | D.cs:37:26:37:42 | call to method Source<Object> : Object | D.cs:18:39:18:40 | o2 : Object |
 | D.cs:37:26:37:42 | call to method Source<Object> : Object | D.cs:37:13:37:49 | call to method Create : D [field trivialPropField] : Object |
+| D.cs:37:26:37:42 | call to method Source<Object> : Object | D.cs:37:13:37:49 | call to method Create : D [field trivialPropField] : Object |
+| D.cs:39:14:39:14 | access to local variable d : D [field trivialPropField] : Object | D.cs:8:9:8:11 | this : D [field trivialPropField] : Object |
 | D.cs:39:14:39:14 | access to local variable d : D [field trivialPropField] : Object | D.cs:8:9:8:11 | this : D [field trivialPropField] : Object |
 | D.cs:39:14:39:14 | access to local variable d : D [field trivialPropField] : Object | D.cs:39:14:39:26 | access to property TrivialProp |
+| D.cs:39:14:39:14 | access to local variable d : D [field trivialPropField] : Object | D.cs:39:14:39:26 | access to property TrivialProp |
+| D.cs:40:14:40:14 | access to local variable d : D [field trivialPropField] : Object | D.cs:40:14:40:31 | access to field trivialPropField |
 | D.cs:40:14:40:14 | access to local variable d : D [field trivialPropField] : Object | D.cs:40:14:40:31 | access to field trivialPropField |
 | D.cs:41:14:41:14 | access to local variable d : D [field trivialPropField] : Object | D.cs:14:9:14:11 | this : D [field trivialPropField] : Object |
+| D.cs:41:14:41:14 | access to local variable d : D [field trivialPropField] : Object | D.cs:14:9:14:11 | this : D [field trivialPropField] : Object |
+| D.cs:41:14:41:14 | access to local variable d : D [field trivialPropField] : Object | D.cs:41:14:41:26 | access to property ComplexProp |
 | D.cs:41:14:41:14 | access to local variable d : D [field trivialPropField] : Object | D.cs:41:14:41:26 | access to property ComplexProp |
 | D.cs:43:13:43:49 | call to method Create : D [field trivialPropField] : Object | D.cs:45:14:45:14 | access to local variable d : D [field trivialPropField] : Object |
+| D.cs:43:13:43:49 | call to method Create : D [field trivialPropField] : Object | D.cs:45:14:45:14 | access to local variable d : D [field trivialPropField] : Object |
+| D.cs:43:13:43:49 | call to method Create : D [field trivialPropField] : Object | D.cs:46:14:46:14 | access to local variable d : D [field trivialPropField] : Object |
 | D.cs:43:13:43:49 | call to method Create : D [field trivialPropField] : Object | D.cs:46:14:46:14 | access to local variable d : D [field trivialPropField] : Object |
 | D.cs:43:13:43:49 | call to method Create : D [field trivialPropField] : Object | D.cs:47:14:47:14 | access to local variable d : D [field trivialPropField] : Object |
+| D.cs:43:13:43:49 | call to method Create : D [field trivialPropField] : Object | D.cs:47:14:47:14 | access to local variable d : D [field trivialPropField] : Object |
+| D.cs:43:32:43:48 | call to method Source<Object> : Object | D.cs:18:50:18:51 | o3 : Object |
 | D.cs:43:32:43:48 | call to method Source<Object> : Object | D.cs:18:50:18:51 | o3 : Object |
 | D.cs:43:32:43:48 | call to method Source<Object> : Object | D.cs:43:13:43:49 | call to method Create : D [field trivialPropField] : Object |
+| D.cs:43:32:43:48 | call to method Source<Object> : Object | D.cs:43:13:43:49 | call to method Create : D [field trivialPropField] : Object |
+| D.cs:45:14:45:14 | access to local variable d : D [field trivialPropField] : Object | D.cs:8:9:8:11 | this : D [field trivialPropField] : Object |
 | D.cs:45:14:45:14 | access to local variable d : D [field trivialPropField] : Object | D.cs:8:9:8:11 | this : D [field trivialPropField] : Object |
 | D.cs:45:14:45:14 | access to local variable d : D [field trivialPropField] : Object | D.cs:45:14:45:26 | access to property TrivialProp |
+| D.cs:45:14:45:14 | access to local variable d : D [field trivialPropField] : Object | D.cs:45:14:45:26 | access to property TrivialProp |
+| D.cs:46:14:46:14 | access to local variable d : D [field trivialPropField] : Object | D.cs:46:14:46:31 | access to field trivialPropField |
 | D.cs:46:14:46:14 | access to local variable d : D [field trivialPropField] : Object | D.cs:46:14:46:31 | access to field trivialPropField |
 | D.cs:47:14:47:14 | access to local variable d : D [field trivialPropField] : Object | D.cs:14:9:14:11 | this : D [field trivialPropField] : Object |
+| D.cs:47:14:47:14 | access to local variable d : D [field trivialPropField] : Object | D.cs:14:9:14:11 | this : D [field trivialPropField] : Object |
+| D.cs:47:14:47:14 | access to local variable d : D [field trivialPropField] : Object | D.cs:47:14:47:26 | access to property ComplexProp |
 | D.cs:47:14:47:14 | access to local variable d : D [field trivialPropField] : Object | D.cs:47:14:47:26 | access to property ComplexProp |
 | E.cs:8:29:8:29 | o : Object | E.cs:11:21:11:21 | access to parameter o : Object |
+| E.cs:8:29:8:29 | o : Object | E.cs:11:21:11:21 | access to parameter o : Object |
+| E.cs:11:9:11:11 | [post] access to local variable ret : S [field Field] : Object | E.cs:12:16:12:18 | access to local variable ret : S [field Field] : Object |
 | E.cs:11:9:11:11 | [post] access to local variable ret : S [field Field] : Object | E.cs:12:16:12:18 | access to local variable ret : S [field Field] : Object |
 | E.cs:11:21:11:21 | access to parameter o : Object | E.cs:11:9:11:11 | [post] access to local variable ret : S [field Field] : Object |
+| E.cs:11:21:11:21 | access to parameter o : Object | E.cs:11:9:11:11 | [post] access to local variable ret : S [field Field] : Object |
+| E.cs:22:17:22:33 | call to method Source<Object> : Object | E.cs:23:25:23:25 | access to local variable o : Object |
 | E.cs:22:17:22:33 | call to method Source<Object> : Object | E.cs:23:25:23:25 | access to local variable o : Object |
 | E.cs:23:17:23:26 | call to method CreateS : S [field Field] : Object | E.cs:24:14:24:14 | access to local variable s : S [field Field] : Object |
+| E.cs:23:17:23:26 | call to method CreateS : S [field Field] : Object | E.cs:24:14:24:14 | access to local variable s : S [field Field] : Object |
+| E.cs:23:25:23:25 | access to local variable o : Object | E.cs:8:29:8:29 | o : Object |
 | E.cs:23:25:23:25 | access to local variable o : Object | E.cs:8:29:8:29 | o : Object |
 | E.cs:23:25:23:25 | access to local variable o : Object | E.cs:23:17:23:26 | call to method CreateS : S [field Field] : Object |
+| E.cs:23:25:23:25 | access to local variable o : Object | E.cs:23:17:23:26 | call to method CreateS : S [field Field] : Object |
+| E.cs:24:14:24:14 | access to local variable s : S [field Field] : Object | E.cs:24:14:24:20 | access to field Field |
 | E.cs:24:14:24:14 | access to local variable s : S [field Field] : Object | E.cs:24:14:24:20 | access to field Field |
 | F.cs:6:28:6:29 | o1 : Object | F.cs:6:65:6:66 | access to parameter o1 : Object |
+| F.cs:6:28:6:29 | o1 : Object | F.cs:6:65:6:66 | access to parameter o1 : Object |
+| F.cs:6:39:6:40 | o2 : Object | F.cs:6:78:6:79 | access to parameter o2 : Object |
 | F.cs:6:39:6:40 | o2 : Object | F.cs:6:78:6:79 | access to parameter o2 : Object |
 | F.cs:6:54:6:81 | { ..., ... } : F [field Field1] : Object | F.cs:6:46:6:81 | object creation of type F : F [field Field1] : Object |
+| F.cs:6:54:6:81 | { ..., ... } : F [field Field1] : Object | F.cs:6:46:6:81 | object creation of type F : F [field Field1] : Object |
+| F.cs:6:54:6:81 | { ..., ... } : F [field Field2] : Object | F.cs:6:46:6:81 | object creation of type F : F [field Field2] : Object |
 | F.cs:6:54:6:81 | { ..., ... } : F [field Field2] : Object | F.cs:6:46:6:81 | object creation of type F : F [field Field2] : Object |
 | F.cs:6:65:6:66 | access to parameter o1 : Object | F.cs:6:54:6:81 | { ..., ... } : F [field Field1] : Object |
+| F.cs:6:65:6:66 | access to parameter o1 : Object | F.cs:6:54:6:81 | { ..., ... } : F [field Field1] : Object |
+| F.cs:6:78:6:79 | access to parameter o2 : Object | F.cs:6:54:6:81 | { ..., ... } : F [field Field2] : Object |
 | F.cs:6:78:6:79 | access to parameter o2 : Object | F.cs:6:54:6:81 | { ..., ... } : F [field Field2] : Object |
 | F.cs:10:17:10:33 | call to method Source<Object> : Object | F.cs:11:24:11:24 | access to local variable o : Object |
+| F.cs:10:17:10:33 | call to method Source<Object> : Object | F.cs:11:24:11:24 | access to local variable o : Object |
+| F.cs:11:17:11:31 | call to method Create : F [field Field1] : Object | F.cs:12:14:12:14 | access to local variable f : F [field Field1] : Object |
 | F.cs:11:17:11:31 | call to method Create : F [field Field1] : Object | F.cs:12:14:12:14 | access to local variable f : F [field Field1] : Object |
 | F.cs:11:24:11:24 | access to local variable o : Object | F.cs:6:28:6:29 | o1 : Object |
+| F.cs:11:24:11:24 | access to local variable o : Object | F.cs:6:28:6:29 | o1 : Object |
+| F.cs:11:24:11:24 | access to local variable o : Object | F.cs:11:17:11:31 | call to method Create : F [field Field1] : Object |
 | F.cs:11:24:11:24 | access to local variable o : Object | F.cs:11:17:11:31 | call to method Create : F [field Field1] : Object |
 | F.cs:12:14:12:14 | access to local variable f : F [field Field1] : Object | F.cs:12:14:12:21 | access to field Field1 |
+| F.cs:12:14:12:14 | access to local variable f : F [field Field1] : Object | F.cs:12:14:12:21 | access to field Field1 |
+| F.cs:15:13:15:43 | call to method Create : F [field Field2] : Object | F.cs:17:14:17:14 | access to local variable f : F [field Field2] : Object |
 | F.cs:15:13:15:43 | call to method Create : F [field Field2] : Object | F.cs:17:14:17:14 | access to local variable f : F [field Field2] : Object |
 | F.cs:15:26:15:42 | call to method Source<Object> : Object | F.cs:6:39:6:40 | o2 : Object |
+| F.cs:15:26:15:42 | call to method Source<Object> : Object | F.cs:6:39:6:40 | o2 : Object |
+| F.cs:15:26:15:42 | call to method Source<Object> : Object | F.cs:15:13:15:43 | call to method Create : F [field Field2] : Object |
 | F.cs:15:26:15:42 | call to method Source<Object> : Object | F.cs:15:13:15:43 | call to method Create : F [field Field2] : Object |
 | F.cs:17:14:17:14 | access to local variable f : F [field Field2] : Object | F.cs:17:14:17:21 | access to field Field2 |
+| F.cs:17:14:17:14 | access to local variable f : F [field Field2] : Object | F.cs:17:14:17:21 | access to field Field2 |
+| F.cs:19:21:19:50 | { ..., ... } : F [field Field1] : Object | F.cs:20:14:20:14 | access to local variable f : F [field Field1] : Object |
 | F.cs:19:21:19:50 | { ..., ... } : F [field Field1] : Object | F.cs:20:14:20:14 | access to local variable f : F [field Field1] : Object |
 | F.cs:19:32:19:48 | call to method Source<Object> : Object | F.cs:19:21:19:50 | { ..., ... } : F [field Field1] : Object |
+| F.cs:19:32:19:48 | call to method Source<Object> : Object | F.cs:19:21:19:50 | { ..., ... } : F [field Field1] : Object |
+| F.cs:20:14:20:14 | access to local variable f : F [field Field1] : Object | F.cs:20:14:20:21 | access to field Field1 |
 | F.cs:20:14:20:14 | access to local variable f : F [field Field1] : Object | F.cs:20:14:20:21 | access to field Field1 |
 | F.cs:23:21:23:50 | { ..., ... } : F [field Field2] : Object | F.cs:25:14:25:14 | access to local variable f : F [field Field2] : Object |
+| F.cs:23:21:23:50 | { ..., ... } : F [field Field2] : Object | F.cs:25:14:25:14 | access to local variable f : F [field Field2] : Object |
+| F.cs:23:32:23:48 | call to method Source<Object> : Object | F.cs:23:21:23:50 | { ..., ... } : F [field Field2] : Object |
 | F.cs:23:32:23:48 | call to method Source<Object> : Object | F.cs:23:21:23:50 | { ..., ... } : F [field Field2] : Object |
 | F.cs:25:14:25:14 | access to local variable f : F [field Field2] : Object | F.cs:25:14:25:21 | access to field Field2 |
+| F.cs:25:14:25:14 | access to local variable f : F [field Field2] : Object | F.cs:25:14:25:21 | access to field Field2 |
+| F.cs:30:17:30:33 | call to method Source<Object> : Object | F.cs:32:27:32:27 | access to local variable o : Object |
 | F.cs:30:17:30:33 | call to method Source<Object> : Object | F.cs:32:27:32:27 | access to local variable o : Object |
 | F.cs:32:17:32:40 | { ..., ... } : <>__AnonType0<Object,Object> [property X] : Object | F.cs:33:14:33:14 | access to local variable a : <>__AnonType0<Object,Object> [property X] : Object |
+| F.cs:32:17:32:40 | { ..., ... } : <>__AnonType0<Object,Object> [property X] : Object | F.cs:33:14:33:14 | access to local variable a : <>__AnonType0<Object,Object> [property X] : Object |
+| F.cs:32:27:32:27 | access to local variable o : Object | F.cs:32:17:32:40 | { ..., ... } : <>__AnonType0<Object,Object> [property X] : Object |
 | F.cs:32:27:32:27 | access to local variable o : Object | F.cs:32:17:32:40 | { ..., ... } : <>__AnonType0<Object,Object> [property X] : Object |
 | F.cs:33:14:33:14 | access to local variable a : <>__AnonType0<Object,Object> [property X] : Object | F.cs:33:14:33:16 | access to property X |
+| F.cs:33:14:33:14 | access to local variable a : <>__AnonType0<Object,Object> [property X] : Object | F.cs:33:14:33:16 | access to property X |
+| G.cs:7:18:7:32 | call to method Source<Elem> : Elem | G.cs:9:23:9:23 | access to local variable e : Elem |
 | G.cs:7:18:7:32 | call to method Source<Elem> : Elem | G.cs:9:23:9:23 | access to local variable e : Elem |
 | G.cs:9:9:9:9 | [post] access to local variable b : Box2 [field Box1, field Elem] : Elem | G.cs:10:18:10:18 | access to local variable b : Box2 [field Box1, field Elem] : Elem |
+| G.cs:9:9:9:9 | [post] access to local variable b : Box2 [field Box1, field Elem] : Elem | G.cs:10:18:10:18 | access to local variable b : Box2 [field Box1, field Elem] : Elem |
+| G.cs:9:9:9:14 | [post] access to field Box1 : Box1 [field Elem] : Elem | G.cs:9:9:9:9 | [post] access to local variable b : Box2 [field Box1, field Elem] : Elem |
 | G.cs:9:9:9:14 | [post] access to field Box1 : Box1 [field Elem] : Elem | G.cs:9:9:9:9 | [post] access to local variable b : Box2 [field Box1, field Elem] : Elem |
 | G.cs:9:23:9:23 | access to local variable e : Elem | G.cs:9:9:9:14 | [post] access to field Box1 : Box1 [field Elem] : Elem |
+| G.cs:9:23:9:23 | access to local variable e : Elem | G.cs:9:9:9:14 | [post] access to field Box1 : Box1 [field Elem] : Elem |
+| G.cs:10:18:10:18 | access to local variable b : Box2 [field Box1, field Elem] : Elem | G.cs:37:38:37:39 | b2 : Box2 [field Box1, field Elem] : Elem |
 | G.cs:10:18:10:18 | access to local variable b : Box2 [field Box1, field Elem] : Elem | G.cs:37:38:37:39 | b2 : Box2 [field Box1, field Elem] : Elem |
 | G.cs:15:18:15:32 | call to method Source<Elem> : Elem | G.cs:17:24:17:24 | access to local variable e : Elem |
+| G.cs:15:18:15:32 | call to method Source<Elem> : Elem | G.cs:17:24:17:24 | access to local variable e : Elem |
+| G.cs:17:9:17:9 | [post] access to local variable b : Box2 [field Box1, field Elem] : Elem | G.cs:18:18:18:18 | access to local variable b : Box2 [field Box1, field Elem] : Elem |
 | G.cs:17:9:17:9 | [post] access to local variable b : Box2 [field Box1, field Elem] : Elem | G.cs:18:18:18:18 | access to local variable b : Box2 [field Box1, field Elem] : Elem |
 | G.cs:17:9:17:14 | [post] access to field Box1 : Box1 [field Elem] : Elem | G.cs:17:9:17:9 | [post] access to local variable b : Box2 [field Box1, field Elem] : Elem |
+| G.cs:17:9:17:14 | [post] access to field Box1 : Box1 [field Elem] : Elem | G.cs:17:9:17:9 | [post] access to local variable b : Box2 [field Box1, field Elem] : Elem |
+| G.cs:17:24:17:24 | access to local variable e : Elem | G.cs:17:9:17:14 | [post] access to field Box1 : Box1 [field Elem] : Elem |
 | G.cs:17:24:17:24 | access to local variable e : Elem | G.cs:17:9:17:14 | [post] access to field Box1 : Box1 [field Elem] : Elem |
 | G.cs:17:24:17:24 | access to local variable e : Elem | G.cs:64:34:64:34 | e : Elem |
+| G.cs:17:24:17:24 | access to local variable e : Elem | G.cs:64:34:64:34 | e : Elem |
+| G.cs:18:18:18:18 | access to local variable b : Box2 [field Box1, field Elem] : Elem | G.cs:37:38:37:39 | b2 : Box2 [field Box1, field Elem] : Elem |
 | G.cs:18:18:18:18 | access to local variable b : Box2 [field Box1, field Elem] : Elem | G.cs:37:38:37:39 | b2 : Box2 [field Box1, field Elem] : Elem |
 | G.cs:23:18:23:32 | call to method Source<Elem> : Elem | G.cs:25:28:25:28 | access to local variable e : Elem |
+| G.cs:23:18:23:32 | call to method Source<Elem> : Elem | G.cs:25:28:25:28 | access to local variable e : Elem |
+| G.cs:25:9:25:9 | [post] access to local variable b : Box2 [field Box1, field Elem] : Elem | G.cs:26:18:26:18 | access to local variable b : Box2 [field Box1, field Elem] : Elem |
 | G.cs:25:9:25:9 | [post] access to local variable b : Box2 [field Box1, field Elem] : Elem | G.cs:26:18:26:18 | access to local variable b : Box2 [field Box1, field Elem] : Elem |
 | G.cs:25:9:25:19 | [post] call to method GetBox1 : Box1 [field Elem] : Elem | G.cs:25:9:25:9 | [post] access to local variable b : Box2 [field Box1, field Elem] : Elem |
+| G.cs:25:9:25:19 | [post] call to method GetBox1 : Box1 [field Elem] : Elem | G.cs:25:9:25:9 | [post] access to local variable b : Box2 [field Box1, field Elem] : Elem |
+| G.cs:25:28:25:28 | access to local variable e : Elem | G.cs:25:9:25:19 | [post] call to method GetBox1 : Box1 [field Elem] : Elem |
 | G.cs:25:28:25:28 | access to local variable e : Elem | G.cs:25:9:25:19 | [post] call to method GetBox1 : Box1 [field Elem] : Elem |
 | G.cs:26:18:26:18 | access to local variable b : Box2 [field Box1, field Elem] : Elem | G.cs:37:38:37:39 | b2 : Box2 [field Box1, field Elem] : Elem |
+| G.cs:26:18:26:18 | access to local variable b : Box2 [field Box1, field Elem] : Elem | G.cs:37:38:37:39 | b2 : Box2 [field Box1, field Elem] : Elem |
+| G.cs:31:18:31:32 | call to method Source<Elem> : Elem | G.cs:33:29:33:29 | access to local variable e : Elem |
 | G.cs:31:18:31:32 | call to method Source<Elem> : Elem | G.cs:33:29:33:29 | access to local variable e : Elem |
 | G.cs:33:9:33:9 | [post] access to local variable b : Box2 [field Box1, field Elem] : Elem | G.cs:34:18:34:18 | access to local variable b : Box2 [field Box1, field Elem] : Elem |
+| G.cs:33:9:33:9 | [post] access to local variable b : Box2 [field Box1, field Elem] : Elem | G.cs:34:18:34:18 | access to local variable b : Box2 [field Box1, field Elem] : Elem |
+| G.cs:33:9:33:19 | [post] call to method GetBox1 : Box1 [field Elem] : Elem | G.cs:33:9:33:9 | [post] access to local variable b : Box2 [field Box1, field Elem] : Elem |
 | G.cs:33:9:33:19 | [post] call to method GetBox1 : Box1 [field Elem] : Elem | G.cs:33:9:33:9 | [post] access to local variable b : Box2 [field Box1, field Elem] : Elem |
 | G.cs:33:29:33:29 | access to local variable e : Elem | G.cs:33:9:33:19 | [post] call to method GetBox1 : Box1 [field Elem] : Elem |
+| G.cs:33:29:33:29 | access to local variable e : Elem | G.cs:33:9:33:19 | [post] call to method GetBox1 : Box1 [field Elem] : Elem |
+| G.cs:33:29:33:29 | access to local variable e : Elem | G.cs:64:34:64:34 | e : Elem |
 | G.cs:33:29:33:29 | access to local variable e : Elem | G.cs:64:34:64:34 | e : Elem |
 | G.cs:34:18:34:18 | access to local variable b : Box2 [field Box1, field Elem] : Elem | G.cs:37:38:37:39 | b2 : Box2 [field Box1, field Elem] : Elem |
+| G.cs:34:18:34:18 | access to local variable b : Box2 [field Box1, field Elem] : Elem | G.cs:37:38:37:39 | b2 : Box2 [field Box1, field Elem] : Elem |
+| G.cs:37:38:37:39 | b2 : Box2 [field Box1, field Elem] : Elem | G.cs:39:14:39:15 | access to parameter b2 : Box2 [field Box1, field Elem] : Elem |
 | G.cs:37:38:37:39 | b2 : Box2 [field Box1, field Elem] : Elem | G.cs:39:14:39:15 | access to parameter b2 : Box2 [field Box1, field Elem] : Elem |
 | G.cs:39:14:39:15 | access to parameter b2 : Box2 [field Box1, field Elem] : Elem | G.cs:39:14:39:25 | call to method GetBox1 : Box1 [field Elem] : Elem |
+| G.cs:39:14:39:15 | access to parameter b2 : Box2 [field Box1, field Elem] : Elem | G.cs:39:14:39:25 | call to method GetBox1 : Box1 [field Elem] : Elem |
+| G.cs:39:14:39:15 | access to parameter b2 : Box2 [field Box1, field Elem] : Elem | G.cs:71:21:71:27 | this : Box2 [field Box1, field Elem] : Elem |
 | G.cs:39:14:39:15 | access to parameter b2 : Box2 [field Box1, field Elem] : Elem | G.cs:71:21:71:27 | this : Box2 [field Box1, field Elem] : Elem |
 | G.cs:39:14:39:25 | call to method GetBox1 : Box1 [field Elem] : Elem | G.cs:39:14:39:35 | call to method GetElem |
+| G.cs:39:14:39:25 | call to method GetBox1 : Box1 [field Elem] : Elem | G.cs:39:14:39:35 | call to method GetElem |
+| G.cs:39:14:39:25 | call to method GetBox1 : Box1 [field Elem] : Elem | G.cs:63:21:63:27 | this : Box1 [field Elem] : Elem |
 | G.cs:39:14:39:25 | call to method GetBox1 : Box1 [field Elem] : Elem | G.cs:63:21:63:27 | this : Box1 [field Elem] : Elem |
 | G.cs:44:18:44:32 | call to method Source<Elem> : Elem | G.cs:46:30:46:30 | access to local variable e : Elem |
+| G.cs:44:18:44:32 | call to method Source<Elem> : Elem | G.cs:46:30:46:30 | access to local variable e : Elem |
+| G.cs:46:9:46:16 | [post] access to field boxfield : Box2 [field Box1, field Elem] : Elem | G.cs:46:9:46:16 | [post] this access : G [field boxfield, field Box1, field Elem] : Elem |
 | G.cs:46:9:46:16 | [post] access to field boxfield : Box2 [field Box1, field Elem] : Elem | G.cs:46:9:46:16 | [post] this access : G [field boxfield, field Box1, field Elem] : Elem |
 | G.cs:46:9:46:16 | [post] this access : G [field boxfield, field Box1, field Elem] : Elem | G.cs:47:9:47:13 | this access : G [field boxfield, field Box1, field Elem] : Elem |
+| G.cs:46:9:46:16 | [post] this access : G [field boxfield, field Box1, field Elem] : Elem | G.cs:47:9:47:13 | this access : G [field boxfield, field Box1, field Elem] : Elem |
+| G.cs:46:9:46:21 | [post] access to field Box1 : Box1 [field Elem] : Elem | G.cs:46:9:46:16 | [post] access to field boxfield : Box2 [field Box1, field Elem] : Elem |
 | G.cs:46:9:46:21 | [post] access to field Box1 : Box1 [field Elem] : Elem | G.cs:46:9:46:16 | [post] access to field boxfield : Box2 [field Box1, field Elem] : Elem |
 | G.cs:46:30:46:30 | access to local variable e : Elem | G.cs:46:9:46:21 | [post] access to field Box1 : Box1 [field Elem] : Elem |
+| G.cs:46:30:46:30 | access to local variable e : Elem | G.cs:46:9:46:21 | [post] access to field Box1 : Box1 [field Elem] : Elem |
+| G.cs:47:9:47:13 | this access : G [field boxfield, field Box1, field Elem] : Elem | G.cs:50:18:50:20 | this : G [field boxfield, field Box1, field Elem] : Elem |
 | G.cs:47:9:47:13 | this access : G [field boxfield, field Box1, field Elem] : Elem | G.cs:50:18:50:20 | this : G [field boxfield, field Box1, field Elem] : Elem |
 | G.cs:50:18:50:20 | this : G [field boxfield, field Box1, field Elem] : Elem | G.cs:52:14:52:21 | this access : G [field boxfield, field Box1, field Elem] : Elem |
+| G.cs:50:18:50:20 | this : G [field boxfield, field Box1, field Elem] : Elem | G.cs:52:14:52:21 | this access : G [field boxfield, field Box1, field Elem] : Elem |
+| G.cs:52:14:52:21 | access to field boxfield : Box2 [field Box1, field Elem] : Elem | G.cs:52:14:52:26 | access to field Box1 : Box1 [field Elem] : Elem |
 | G.cs:52:14:52:21 | access to field boxfield : Box2 [field Box1, field Elem] : Elem | G.cs:52:14:52:26 | access to field Box1 : Box1 [field Elem] : Elem |
 | G.cs:52:14:52:21 | this access : G [field boxfield, field Box1, field Elem] : Elem | G.cs:52:14:52:21 | access to field boxfield : Box2 [field Box1, field Elem] : Elem |
+| G.cs:52:14:52:21 | this access : G [field boxfield, field Box1, field Elem] : Elem | G.cs:52:14:52:21 | access to field boxfield : Box2 [field Box1, field Elem] : Elem |
+| G.cs:52:14:52:26 | access to field Box1 : Box1 [field Elem] : Elem | G.cs:52:14:52:31 | access to field Elem |
 | G.cs:52:14:52:26 | access to field Box1 : Box1 [field Elem] : Elem | G.cs:52:14:52:31 | access to field Elem |
 | G.cs:63:21:63:27 | this : Box1 [field Elem] : Elem | G.cs:63:34:63:37 | this access : Box1 [field Elem] : Elem |
+| G.cs:63:21:63:27 | this : Box1 [field Elem] : Elem | G.cs:63:34:63:37 | this access : Box1 [field Elem] : Elem |
+| G.cs:63:34:63:37 | this access : Box1 [field Elem] : Elem | G.cs:63:34:63:37 | access to field Elem : Elem |
 | G.cs:63:34:63:37 | this access : Box1 [field Elem] : Elem | G.cs:63:34:63:37 | access to field Elem : Elem |
 | G.cs:64:34:64:34 | e : Elem | G.cs:64:46:64:46 | access to parameter e : Elem |
+| G.cs:64:34:64:34 | e : Elem | G.cs:64:46:64:46 | access to parameter e : Elem |
+| G.cs:64:46:64:46 | access to parameter e : Elem | G.cs:64:39:64:42 | [post] this access : Box1 [field Elem] : Elem |
 | G.cs:64:46:64:46 | access to parameter e : Elem | G.cs:64:39:64:42 | [post] this access : Box1 [field Elem] : Elem |
 | G.cs:71:21:71:27 | this : Box2 [field Box1, field Elem] : Elem | G.cs:71:34:71:37 | this access : Box2 [field Box1, field Elem] : Elem |
+| G.cs:71:21:71:27 | this : Box2 [field Box1, field Elem] : Elem | G.cs:71:34:71:37 | this access : Box2 [field Box1, field Elem] : Elem |
+| G.cs:71:34:71:37 | this access : Box2 [field Box1, field Elem] : Elem | G.cs:71:34:71:37 | access to field Box1 : Box1 [field Elem] : Elem |
 | G.cs:71:34:71:37 | this access : Box2 [field Box1, field Elem] : Elem | G.cs:71:34:71:37 | access to field Box1 : Box1 [field Elem] : Elem |
 | H.cs:13:15:13:15 | a : A [field FieldA] : Object | H.cs:16:22:16:22 | access to parameter a : A [field FieldA] : Object |
+| H.cs:13:15:13:15 | a : A [field FieldA] : Object | H.cs:16:22:16:22 | access to parameter a : A [field FieldA] : Object |
+| H.cs:16:9:16:11 | [post] access to local variable ret : A [field FieldA] : Object | H.cs:17:16:17:18 | access to local variable ret : A [field FieldA] : Object |
 | H.cs:16:9:16:11 | [post] access to local variable ret : A [field FieldA] : Object | H.cs:17:16:17:18 | access to local variable ret : A [field FieldA] : Object |
 | H.cs:16:22:16:22 | access to parameter a : A [field FieldA] : Object | H.cs:16:22:16:29 | access to field FieldA : Object |
+| H.cs:16:22:16:22 | access to parameter a : A [field FieldA] : Object | H.cs:16:22:16:29 | access to field FieldA : Object |
+| H.cs:16:22:16:29 | access to field FieldA : Object | H.cs:16:9:16:11 | [post] access to local variable ret : A [field FieldA] : Object |
 | H.cs:16:22:16:29 | access to field FieldA : Object | H.cs:16:9:16:11 | [post] access to local variable ret : A [field FieldA] : Object |
 | H.cs:23:9:23:9 | [post] access to local variable a : A [field FieldA] : Object | H.cs:24:27:24:27 | access to local variable a : A [field FieldA] : Object |
+| H.cs:23:9:23:9 | [post] access to local variable a : A [field FieldA] : Object | H.cs:24:27:24:27 | access to local variable a : A [field FieldA] : Object |
+| H.cs:23:20:23:36 | call to method Source<Object> : Object | H.cs:23:9:23:9 | [post] access to local variable a : A [field FieldA] : Object |
 | H.cs:23:20:23:36 | call to method Source<Object> : Object | H.cs:23:9:23:9 | [post] access to local variable a : A [field FieldA] : Object |
 | H.cs:24:21:24:28 | call to method Clone : A [field FieldA] : Object | H.cs:25:14:25:18 | access to local variable clone : A [field FieldA] : Object |
+| H.cs:24:21:24:28 | call to method Clone : A [field FieldA] : Object | H.cs:25:14:25:18 | access to local variable clone : A [field FieldA] : Object |
+| H.cs:24:27:24:27 | access to local variable a : A [field FieldA] : Object | H.cs:13:15:13:15 | a : A [field FieldA] : Object |
 | H.cs:24:27:24:27 | access to local variable a : A [field FieldA] : Object | H.cs:13:15:13:15 | a : A [field FieldA] : Object |
 | H.cs:24:27:24:27 | access to local variable a : A [field FieldA] : Object | H.cs:24:21:24:28 | call to method Clone : A [field FieldA] : Object |
+| H.cs:24:27:24:27 | access to local variable a : A [field FieldA] : Object | H.cs:24:21:24:28 | call to method Clone : A [field FieldA] : Object |
+| H.cs:25:14:25:18 | access to local variable clone : A [field FieldA] : Object | H.cs:25:14:25:25 | access to field FieldA |
 | H.cs:25:14:25:18 | access to local variable clone : A [field FieldA] : Object | H.cs:25:14:25:25 | access to field FieldA |
 | H.cs:33:19:33:19 | a : A [field FieldA] : A | H.cs:36:20:36:20 | access to parameter a : A [field FieldA] : A |
+| H.cs:33:19:33:19 | a : A [field FieldA] : A | H.cs:36:20:36:20 | access to parameter a : A [field FieldA] : A |
+| H.cs:33:19:33:19 | a : A [field FieldA] : Object | H.cs:36:20:36:20 | access to parameter a : A [field FieldA] : Object |
 | H.cs:33:19:33:19 | a : A [field FieldA] : Object | H.cs:36:20:36:20 | access to parameter a : A [field FieldA] : Object |
 | H.cs:36:9:36:9 | [post] access to local variable b : B [field FieldB] : A | H.cs:37:16:37:16 | access to local variable b : B [field FieldB] : A |
+| H.cs:36:9:36:9 | [post] access to local variable b : B [field FieldB] : A | H.cs:37:16:37:16 | access to local variable b : B [field FieldB] : A |
+| H.cs:36:9:36:9 | [post] access to local variable b : B [field FieldB] : Object | H.cs:37:16:37:16 | access to local variable b : B [field FieldB] : Object |
 | H.cs:36:9:36:9 | [post] access to local variable b : B [field FieldB] : Object | H.cs:37:16:37:16 | access to local variable b : B [field FieldB] : Object |
 | H.cs:36:20:36:20 | access to parameter a : A [field FieldA] : A | H.cs:36:20:36:27 | access to field FieldA : A |
+| H.cs:36:20:36:20 | access to parameter a : A [field FieldA] : A | H.cs:36:20:36:27 | access to field FieldA : A |
+| H.cs:36:20:36:20 | access to parameter a : A [field FieldA] : Object | H.cs:36:20:36:27 | access to field FieldA : Object |
 | H.cs:36:20:36:20 | access to parameter a : A [field FieldA] : Object | H.cs:36:20:36:27 | access to field FieldA : Object |
 | H.cs:36:20:36:27 | access to field FieldA : A | H.cs:36:9:36:9 | [post] access to local variable b : B [field FieldB] : A |
+| H.cs:36:20:36:27 | access to field FieldA : A | H.cs:36:9:36:9 | [post] access to local variable b : B [field FieldB] : A |
+| H.cs:36:20:36:27 | access to field FieldA : Object | H.cs:36:9:36:9 | [post] access to local variable b : B [field FieldB] : Object |
 | H.cs:36:20:36:27 | access to field FieldA : Object | H.cs:36:9:36:9 | [post] access to local variable b : B [field FieldB] : Object |
 | H.cs:43:9:43:9 | [post] access to local variable a : A [field FieldA] : Object | H.cs:44:27:44:27 | access to local variable a : A [field FieldA] : Object |
+| H.cs:43:9:43:9 | [post] access to local variable a : A [field FieldA] : Object | H.cs:44:27:44:27 | access to local variable a : A [field FieldA] : Object |
+| H.cs:43:20:43:36 | call to method Source<Object> : Object | H.cs:43:9:43:9 | [post] access to local variable a : A [field FieldA] : Object |
 | H.cs:43:20:43:36 | call to method Source<Object> : Object | H.cs:43:9:43:9 | [post] access to local variable a : A [field FieldA] : Object |
 | H.cs:44:17:44:28 | call to method Transform : B [field FieldB] : Object | H.cs:45:14:45:14 | access to local variable b : B [field FieldB] : Object |
+| H.cs:44:17:44:28 | call to method Transform : B [field FieldB] : Object | H.cs:45:14:45:14 | access to local variable b : B [field FieldB] : Object |
+| H.cs:44:27:44:27 | access to local variable a : A [field FieldA] : Object | H.cs:33:19:33:19 | a : A [field FieldA] : Object |
 | H.cs:44:27:44:27 | access to local variable a : A [field FieldA] : Object | H.cs:33:19:33:19 | a : A [field FieldA] : Object |
 | H.cs:44:27:44:27 | access to local variable a : A [field FieldA] : Object | H.cs:44:17:44:28 | call to method Transform : B [field FieldB] : Object |
+| H.cs:44:27:44:27 | access to local variable a : A [field FieldA] : Object | H.cs:44:17:44:28 | call to method Transform : B [field FieldB] : Object |
+| H.cs:45:14:45:14 | access to local variable b : B [field FieldB] : Object | H.cs:45:14:45:21 | access to field FieldB |
 | H.cs:45:14:45:14 | access to local variable b : B [field FieldB] : Object | H.cs:45:14:45:21 | access to field FieldB |
 | H.cs:53:25:53:25 | a : A [field FieldA] : Object | H.cs:55:21:55:21 | access to parameter a : A [field FieldA] : Object |
+| H.cs:53:25:53:25 | a : A [field FieldA] : Object | H.cs:55:21:55:21 | access to parameter a : A [field FieldA] : Object |
+| H.cs:55:21:55:21 | access to parameter a : A [field FieldA] : Object | H.cs:55:21:55:28 | access to field FieldA : Object |
 | H.cs:55:21:55:21 | access to parameter a : A [field FieldA] : Object | H.cs:55:21:55:28 | access to field FieldA : Object |
 | H.cs:55:21:55:28 | access to field FieldA : Object | H.cs:55:9:55:10 | [post] access to parameter b1 : B [field FieldB] : Object |
+| H.cs:55:21:55:28 | access to field FieldA : Object | H.cs:55:9:55:10 | [post] access to parameter b1 : B [field FieldB] : Object |
+| H.cs:63:9:63:9 | [post] access to local variable a : A [field FieldA] : Object | H.cs:64:22:64:22 | access to local variable a : A [field FieldA] : Object |
 | H.cs:63:9:63:9 | [post] access to local variable a : A [field FieldA] : Object | H.cs:64:22:64:22 | access to local variable a : A [field FieldA] : Object |
 | H.cs:63:20:63:36 | call to method Source<Object> : Object | H.cs:63:9:63:9 | [post] access to local variable a : A [field FieldA] : Object |
+| H.cs:63:20:63:36 | call to method Source<Object> : Object | H.cs:63:9:63:9 | [post] access to local variable a : A [field FieldA] : Object |
+| H.cs:64:22:64:22 | access to local variable a : A [field FieldA] : Object | H.cs:53:25:53:25 | a : A [field FieldA] : Object |
 | H.cs:64:22:64:22 | access to local variable a : A [field FieldA] : Object | H.cs:53:25:53:25 | a : A [field FieldA] : Object |
 | H.cs:64:22:64:22 | access to local variable a : A [field FieldA] : Object | H.cs:64:25:64:26 | [post] access to local variable b1 : B [field FieldB] : Object |
+| H.cs:64:22:64:22 | access to local variable a : A [field FieldA] : Object | H.cs:64:25:64:26 | [post] access to local variable b1 : B [field FieldB] : Object |
+| H.cs:64:25:64:26 | [post] access to local variable b1 : B [field FieldB] : Object | H.cs:65:14:65:15 | access to local variable b1 : B [field FieldB] : Object |
 | H.cs:64:25:64:26 | [post] access to local variable b1 : B [field FieldB] : Object | H.cs:65:14:65:15 | access to local variable b1 : B [field FieldB] : Object |
 | H.cs:65:14:65:15 | access to local variable b1 : B [field FieldB] : Object | H.cs:65:14:65:22 | access to field FieldB |
+| H.cs:65:14:65:15 | access to local variable b1 : B [field FieldB] : Object | H.cs:65:14:65:22 | access to field FieldB |
+| H.cs:77:30:77:30 | o : Object | H.cs:79:20:79:20 | access to parameter o : Object |
 | H.cs:77:30:77:30 | o : Object | H.cs:79:20:79:20 | access to parameter o : Object |
 | H.cs:79:9:79:9 | [post] access to parameter a : A [field FieldA] : Object | H.cs:80:22:80:22 | access to parameter a : A [field FieldA] : Object |
+| H.cs:79:9:79:9 | [post] access to parameter a : A [field FieldA] : Object | H.cs:80:22:80:22 | access to parameter a : A [field FieldA] : Object |
+| H.cs:79:20:79:20 | access to parameter o : Object | H.cs:79:9:79:9 | [post] access to parameter a : A [field FieldA] : Object |
 | H.cs:79:20:79:20 | access to parameter o : Object | H.cs:79:9:79:9 | [post] access to parameter a : A [field FieldA] : Object |
 | H.cs:80:22:80:22 | access to parameter a : A [field FieldA] : Object | H.cs:53:25:53:25 | a : A [field FieldA] : Object |
+| H.cs:80:22:80:22 | access to parameter a : A [field FieldA] : Object | H.cs:53:25:53:25 | a : A [field FieldA] : Object |
+| H.cs:80:22:80:22 | access to parameter a : A [field FieldA] : Object | H.cs:80:25:80:26 | [post] access to parameter b1 : B [field FieldB] : Object |
 | H.cs:80:22:80:22 | access to parameter a : A [field FieldA] : Object | H.cs:80:25:80:26 | [post] access to parameter b1 : B [field FieldB] : Object |
 | H.cs:88:17:88:17 | [post] access to local variable a : A [field FieldA] : Object | H.cs:89:14:89:14 | access to local variable a : A [field FieldA] : Object |
+| H.cs:88:17:88:17 | [post] access to local variable a : A [field FieldA] : Object | H.cs:89:14:89:14 | access to local variable a : A [field FieldA] : Object |
+| H.cs:88:20:88:36 | call to method Source<Object> : Object | H.cs:77:30:77:30 | o : Object |
 | H.cs:88:20:88:36 | call to method Source<Object> : Object | H.cs:77:30:77:30 | o : Object |
 | H.cs:88:20:88:36 | call to method Source<Object> : Object | H.cs:88:17:88:17 | [post] access to local variable a : A [field FieldA] : Object |
+| H.cs:88:20:88:36 | call to method Source<Object> : Object | H.cs:88:17:88:17 | [post] access to local variable a : A [field FieldA] : Object |
+| H.cs:88:20:88:36 | call to method Source<Object> : Object | H.cs:88:39:88:40 | [post] access to local variable b1 : B [field FieldB] : Object |
 | H.cs:88:20:88:36 | call to method Source<Object> : Object | H.cs:88:39:88:40 | [post] access to local variable b1 : B [field FieldB] : Object |
 | H.cs:88:39:88:40 | [post] access to local variable b1 : B [field FieldB] : Object | H.cs:90:14:90:15 | access to local variable b1 : B [field FieldB] : Object |
+| H.cs:88:39:88:40 | [post] access to local variable b1 : B [field FieldB] : Object | H.cs:90:14:90:15 | access to local variable b1 : B [field FieldB] : Object |
+| H.cs:89:14:89:14 | access to local variable a : A [field FieldA] : Object | H.cs:89:14:89:21 | access to field FieldA |
 | H.cs:89:14:89:14 | access to local variable a : A [field FieldA] : Object | H.cs:89:14:89:21 | access to field FieldA |
 | H.cs:90:14:90:15 | access to local variable b1 : B [field FieldB] : Object | H.cs:90:14:90:22 | access to field FieldB |
+| H.cs:90:14:90:15 | access to local variable b1 : B [field FieldB] : Object | H.cs:90:14:90:22 | access to field FieldB |
+| H.cs:102:23:102:23 | a : A [field FieldA] : Object | H.cs:105:23:105:23 | access to parameter a : A [field FieldA] : Object |
 | H.cs:102:23:102:23 | a : A [field FieldA] : Object | H.cs:105:23:105:23 | access to parameter a : A [field FieldA] : Object |
 | H.cs:105:9:105:12 | [post] access to local variable temp : B [field FieldB, field FieldA] : Object | H.cs:106:29:106:32 | access to local variable temp : B [field FieldB, field FieldA] : Object |
+| H.cs:105:9:105:12 | [post] access to local variable temp : B [field FieldB, field FieldA] : Object | H.cs:106:29:106:32 | access to local variable temp : B [field FieldB, field FieldA] : Object |
+| H.cs:105:23:105:23 | access to parameter a : A [field FieldA] : Object | H.cs:105:9:105:12 | [post] access to local variable temp : B [field FieldB, field FieldA] : Object |
 | H.cs:105:23:105:23 | access to parameter a : A [field FieldA] : Object | H.cs:105:9:105:12 | [post] access to local variable temp : B [field FieldB, field FieldA] : Object |
 | H.cs:106:26:106:39 | (...) ... : A [field FieldA] : Object | H.cs:33:19:33:19 | a : A [field FieldA] : Object |
+| H.cs:106:26:106:39 | (...) ... : A [field FieldA] : Object | H.cs:33:19:33:19 | a : A [field FieldA] : Object |
+| H.cs:106:26:106:39 | (...) ... : A [field FieldA] : Object | H.cs:106:16:106:40 | call to method Transform : B [field FieldB] : Object |
 | H.cs:106:26:106:39 | (...) ... : A [field FieldA] : Object | H.cs:106:16:106:40 | call to method Transform : B [field FieldB] : Object |
 | H.cs:106:29:106:32 | access to local variable temp : B [field FieldB, field FieldA] : Object | H.cs:106:29:106:39 | access to field FieldB : A [field FieldA] : Object |
+| H.cs:106:29:106:32 | access to local variable temp : B [field FieldB, field FieldA] : Object | H.cs:106:29:106:39 | access to field FieldB : A [field FieldA] : Object |
+| H.cs:106:29:106:39 | access to field FieldB : A [field FieldA] : Object | H.cs:106:26:106:39 | (...) ... : A [field FieldA] : Object |
 | H.cs:106:29:106:39 | access to field FieldB : A [field FieldA] : Object | H.cs:106:26:106:39 | (...) ... : A [field FieldA] : Object |
 | H.cs:112:9:112:9 | [post] access to local variable a : A [field FieldA] : Object | H.cs:113:31:113:31 | access to local variable a : A [field FieldA] : Object |
+| H.cs:112:9:112:9 | [post] access to local variable a : A [field FieldA] : Object | H.cs:113:31:113:31 | access to local variable a : A [field FieldA] : Object |
+| H.cs:112:20:112:36 | call to method Source<Object> : Object | H.cs:112:9:112:9 | [post] access to local variable a : A [field FieldA] : Object |
 | H.cs:112:20:112:36 | call to method Source<Object> : Object | H.cs:112:9:112:9 | [post] access to local variable a : A [field FieldA] : Object |
 | H.cs:113:17:113:32 | call to method TransformWrap : B [field FieldB] : Object | H.cs:114:14:114:14 | access to local variable b : B [field FieldB] : Object |
+| H.cs:113:17:113:32 | call to method TransformWrap : B [field FieldB] : Object | H.cs:114:14:114:14 | access to local variable b : B [field FieldB] : Object |
+| H.cs:113:31:113:31 | access to local variable a : A [field FieldA] : Object | H.cs:102:23:102:23 | a : A [field FieldA] : Object |
 | H.cs:113:31:113:31 | access to local variable a : A [field FieldA] : Object | H.cs:102:23:102:23 | a : A [field FieldA] : Object |
 | H.cs:113:31:113:31 | access to local variable a : A [field FieldA] : Object | H.cs:113:17:113:32 | call to method TransformWrap : B [field FieldB] : Object |
+| H.cs:113:31:113:31 | access to local variable a : A [field FieldA] : Object | H.cs:113:17:113:32 | call to method TransformWrap : B [field FieldB] : Object |
+| H.cs:114:14:114:14 | access to local variable b : B [field FieldB] : Object | H.cs:114:14:114:21 | access to field FieldB |
 | H.cs:114:14:114:14 | access to local variable b : B [field FieldB] : Object | H.cs:114:14:114:21 | access to field FieldB |
 | H.cs:122:18:122:18 | a : A [field FieldA] : Object | H.cs:124:26:124:26 | access to parameter a : A [field FieldA] : Object |
+| H.cs:122:18:122:18 | a : A [field FieldA] : Object | H.cs:124:26:124:26 | access to parameter a : A [field FieldA] : Object |
+| H.cs:124:16:124:27 | call to method Transform : B [field FieldB] : Object | H.cs:124:16:124:34 | access to field FieldB : Object |
 | H.cs:124:16:124:27 | call to method Transform : B [field FieldB] : Object | H.cs:124:16:124:34 | access to field FieldB : Object |
 | H.cs:124:26:124:26 | access to parameter a : A [field FieldA] : Object | H.cs:33:19:33:19 | a : A [field FieldA] : Object |
+| H.cs:124:26:124:26 | access to parameter a : A [field FieldA] : Object | H.cs:33:19:33:19 | a : A [field FieldA] : Object |
+| H.cs:124:26:124:26 | access to parameter a : A [field FieldA] : Object | H.cs:124:16:124:27 | call to method Transform : B [field FieldB] : Object |
 | H.cs:124:26:124:26 | access to parameter a : A [field FieldA] : Object | H.cs:124:16:124:27 | call to method Transform : B [field FieldB] : Object |
 | H.cs:130:9:130:9 | [post] access to local variable a : A [field FieldA] : Object | H.cs:131:18:131:18 | access to local variable a : A [field FieldA] : Object |
+| H.cs:130:9:130:9 | [post] access to local variable a : A [field FieldA] : Object | H.cs:131:18:131:18 | access to local variable a : A [field FieldA] : Object |
+| H.cs:130:20:130:36 | call to method Source<Object> : Object | H.cs:130:9:130:9 | [post] access to local variable a : A [field FieldA] : Object |
 | H.cs:130:20:130:36 | call to method Source<Object> : Object | H.cs:130:9:130:9 | [post] access to local variable a : A [field FieldA] : Object |
 | H.cs:131:18:131:18 | access to local variable a : A [field FieldA] : Object | H.cs:122:18:122:18 | a : A [field FieldA] : Object |
+| H.cs:131:18:131:18 | access to local variable a : A [field FieldA] : Object | H.cs:122:18:122:18 | a : A [field FieldA] : Object |
+| H.cs:131:18:131:18 | access to local variable a : A [field FieldA] : Object | H.cs:131:14:131:19 | call to method Get |
 | H.cs:131:18:131:18 | access to local variable a : A [field FieldA] : Object | H.cs:131:14:131:19 | call to method Get |
 | H.cs:138:27:138:27 | o : A | H.cs:141:20:141:25 | ... as ... : A |
+| H.cs:138:27:138:27 | o : A | H.cs:141:20:141:25 | ... as ... : A |
+| H.cs:141:9:141:9 | [post] access to local variable a : A [field FieldA] : A | H.cs:142:26:142:26 | access to local variable a : A [field FieldA] : A |
 | H.cs:141:9:141:9 | [post] access to local variable a : A [field FieldA] : A | H.cs:142:26:142:26 | access to local variable a : A [field FieldA] : A |
 | H.cs:141:20:141:25 | ... as ... : A | H.cs:141:9:141:9 | [post] access to local variable a : A [field FieldA] : A |
+| H.cs:141:20:141:25 | ... as ... : A | H.cs:141:9:141:9 | [post] access to local variable a : A [field FieldA] : A |
+| H.cs:142:16:142:27 | call to method Transform : B [field FieldB] : A | H.cs:142:16:142:34 | access to field FieldB : A |
 | H.cs:142:16:142:27 | call to method Transform : B [field FieldB] : A | H.cs:142:16:142:34 | access to field FieldB : A |
 | H.cs:142:26:142:26 | access to local variable a : A [field FieldA] : A | H.cs:33:19:33:19 | a : A [field FieldA] : A |
+| H.cs:142:26:142:26 | access to local variable a : A [field FieldA] : A | H.cs:33:19:33:19 | a : A [field FieldA] : A |
+| H.cs:142:26:142:26 | access to local variable a : A [field FieldA] : A | H.cs:142:16:142:27 | call to method Transform : B [field FieldB] : A |
 | H.cs:142:26:142:26 | access to local variable a : A [field FieldA] : A | H.cs:142:16:142:27 | call to method Transform : B [field FieldB] : A |
 | H.cs:147:17:147:39 | call to method Through : A | H.cs:148:14:148:14 | access to local variable a |
+| H.cs:147:17:147:39 | call to method Through : A | H.cs:148:14:148:14 | access to local variable a |
+| H.cs:147:25:147:38 | call to method Source<A> : A | H.cs:138:27:138:27 | o : A |
 | H.cs:147:25:147:38 | call to method Source<A> : A | H.cs:138:27:138:27 | o : A |
 | H.cs:147:25:147:38 | call to method Source<A> : A | H.cs:147:17:147:39 | call to method Through : A |
+| H.cs:147:25:147:38 | call to method Source<A> : A | H.cs:147:17:147:39 | call to method Through : A |
+| H.cs:153:32:153:32 | o : Object | H.cs:156:20:156:20 | access to parameter o : Object |
 | H.cs:153:32:153:32 | o : Object | H.cs:156:20:156:20 | access to parameter o : Object |
 | H.cs:155:17:155:30 | call to method Source<B> : B | H.cs:156:9:156:9 | access to local variable b : B |
+| H.cs:155:17:155:30 | call to method Source<B> : B | H.cs:156:9:156:9 | access to local variable b : B |
+| H.cs:156:9:156:9 | [post] access to local variable b : B [field FieldB] : Object | H.cs:157:20:157:20 | access to local variable b : B [field FieldB] : Object |
 | H.cs:156:9:156:9 | [post] access to local variable b : B [field FieldB] : Object | H.cs:157:20:157:20 | access to local variable b : B [field FieldB] : Object |
 | H.cs:156:9:156:9 | access to local variable b : B | H.cs:157:20:157:20 | access to local variable b : B |
+| H.cs:156:9:156:9 | access to local variable b : B | H.cs:157:20:157:20 | access to local variable b : B |
+| H.cs:156:20:156:20 | access to parameter o : Object | H.cs:156:9:156:9 | [post] access to local variable b : B [field FieldB] : Object |
 | H.cs:156:20:156:20 | access to parameter o : Object | H.cs:156:9:156:9 | [post] access to local variable b : B [field FieldB] : Object |
 | H.cs:157:9:157:9 | [post] access to parameter a : A [field FieldA] : B | H.cs:164:19:164:19 | [post] access to local variable a : A [field FieldA] : B |
+| H.cs:157:9:157:9 | [post] access to parameter a : A [field FieldA] : B | H.cs:164:19:164:19 | [post] access to local variable a : A [field FieldA] : B |
+| H.cs:157:20:157:20 | access to local variable b : B | H.cs:157:9:157:9 | [post] access to parameter a : A [field FieldA] : B |
 | H.cs:157:20:157:20 | access to local variable b : B | H.cs:157:9:157:9 | [post] access to parameter a : A [field FieldA] : B |
 | H.cs:157:20:157:20 | access to local variable b : B [field FieldB] : Object | H.cs:157:9:157:9 | [post] access to parameter a : A [field FieldA, field FieldB] : Object |
+| H.cs:157:20:157:20 | access to local variable b : B [field FieldB] : Object | H.cs:157:9:157:9 | [post] access to parameter a : A [field FieldA, field FieldB] : Object |
+| H.cs:163:17:163:35 | call to method Source<Object> : Object | H.cs:164:22:164:22 | access to local variable o : Object |
 | H.cs:163:17:163:35 | call to method Source<Object> : Object | H.cs:164:22:164:22 | access to local variable o : Object |
 | H.cs:164:19:164:19 | [post] access to local variable a : A [field FieldA, field FieldB] : Object | H.cs:165:20:165:20 | access to local variable a : A [field FieldA, field FieldB] : Object |
+| H.cs:164:19:164:19 | [post] access to local variable a : A [field FieldA, field FieldB] : Object | H.cs:165:20:165:20 | access to local variable a : A [field FieldA, field FieldB] : Object |
+| H.cs:164:19:164:19 | [post] access to local variable a : A [field FieldA] : B | H.cs:165:20:165:20 | access to local variable a : A [field FieldA] : B |
 | H.cs:164:19:164:19 | [post] access to local variable a : A [field FieldA] : B | H.cs:165:20:165:20 | access to local variable a : A [field FieldA] : B |
 | H.cs:164:22:164:22 | access to local variable o : Object | H.cs:153:32:153:32 | o : Object |
+| H.cs:164:22:164:22 | access to local variable o : Object | H.cs:153:32:153:32 | o : Object |
+| H.cs:164:22:164:22 | access to local variable o : Object | H.cs:164:19:164:19 | [post] access to local variable a : A [field FieldA, field FieldB] : Object |
 | H.cs:164:22:164:22 | access to local variable o : Object | H.cs:164:19:164:19 | [post] access to local variable a : A [field FieldA, field FieldB] : Object |
 | H.cs:165:17:165:27 | (...) ... : B | H.cs:166:14:166:14 | access to local variable b |
+| H.cs:165:17:165:27 | (...) ... : B | H.cs:166:14:166:14 | access to local variable b |
+| H.cs:165:17:165:27 | (...) ... : B [field FieldB] : Object | H.cs:167:14:167:14 | access to local variable b : B [field FieldB] : Object |
 | H.cs:165:17:165:27 | (...) ... : B [field FieldB] : Object | H.cs:167:14:167:14 | access to local variable b : B [field FieldB] : Object |
 | H.cs:165:20:165:20 | access to local variable a : A [field FieldA, field FieldB] : Object | H.cs:165:20:165:27 | access to field FieldA : B [field FieldB] : Object |
+| H.cs:165:20:165:20 | access to local variable a : A [field FieldA, field FieldB] : Object | H.cs:165:20:165:27 | access to field FieldA : B [field FieldB] : Object |
+| H.cs:165:20:165:20 | access to local variable a : A [field FieldA] : B | H.cs:165:20:165:27 | access to field FieldA : B |
 | H.cs:165:20:165:20 | access to local variable a : A [field FieldA] : B | H.cs:165:20:165:27 | access to field FieldA : B |
 | H.cs:165:20:165:27 | access to field FieldA : B | H.cs:165:17:165:27 | (...) ... : B |
+| H.cs:165:20:165:27 | access to field FieldA : B | H.cs:165:17:165:27 | (...) ... : B |
+| H.cs:165:20:165:27 | access to field FieldA : B [field FieldB] : Object | H.cs:165:17:165:27 | (...) ... : B [field FieldB] : Object |
 | H.cs:165:20:165:27 | access to field FieldA : B [field FieldB] : Object | H.cs:165:17:165:27 | (...) ... : B [field FieldB] : Object |
 | H.cs:167:14:167:14 | access to local variable b : B [field FieldB] : Object | H.cs:167:14:167:21 | access to field FieldB |
+| H.cs:167:14:167:14 | access to local variable b : B [field FieldB] : Object | H.cs:167:14:167:21 | access to field FieldB |
+| I.cs:7:9:7:14 | [post] this access : I [field Field1] : Object | I.cs:21:13:21:19 | object creation of type I : I [field Field1] : Object |
 | I.cs:7:9:7:14 | [post] this access : I [field Field1] : Object | I.cs:21:13:21:19 | object creation of type I : I [field Field1] : Object |
 | I.cs:7:9:7:14 | [post] this access : I [field Field1] : Object | I.cs:26:13:26:37 | [pre-initializer] object creation of type I : I [field Field1] : Object |
+| I.cs:7:9:7:14 | [post] this access : I [field Field1] : Object | I.cs:26:13:26:37 | [pre-initializer] object creation of type I : I [field Field1] : Object |
+| I.cs:7:18:7:34 | call to method Source<Object> : Object | I.cs:7:9:7:14 | [post] this access : I [field Field1] : Object |
 | I.cs:7:18:7:34 | call to method Source<Object> : Object | I.cs:7:9:7:14 | [post] this access : I [field Field1] : Object |
 | I.cs:13:17:13:33 | call to method Source<Object> : Object | I.cs:15:20:15:20 | access to local variable o : Object |
+| I.cs:13:17:13:33 | call to method Source<Object> : Object | I.cs:15:20:15:20 | access to local variable o : Object |
+| I.cs:15:9:15:9 | [post] access to local variable i : I [field Field1] : Object | I.cs:16:9:16:9 | access to local variable i : I [field Field1] : Object |
 | I.cs:15:9:15:9 | [post] access to local variable i : I [field Field1] : Object | I.cs:16:9:16:9 | access to local variable i : I [field Field1] : Object |
 | I.cs:15:20:15:20 | access to local variable o : Object | I.cs:15:9:15:9 | [post] access to local variable i : I [field Field1] : Object |
+| I.cs:15:20:15:20 | access to local variable o : Object | I.cs:15:9:15:9 | [post] access to local variable i : I [field Field1] : Object |
+| I.cs:16:9:16:9 | access to local variable i : I [field Field1] : Object | I.cs:17:9:17:9 | access to local variable i : I [field Field1] : Object |
 | I.cs:16:9:16:9 | access to local variable i : I [field Field1] : Object | I.cs:17:9:17:9 | access to local variable i : I [field Field1] : Object |
 | I.cs:17:9:17:9 | access to local variable i : I [field Field1] : Object | I.cs:18:14:18:14 | access to local variable i : I [field Field1] : Object |
+| I.cs:17:9:17:9 | access to local variable i : I [field Field1] : Object | I.cs:18:14:18:14 | access to local variable i : I [field Field1] : Object |
+| I.cs:18:14:18:14 | access to local variable i : I [field Field1] : Object | I.cs:18:14:18:21 | access to field Field1 |
 | I.cs:18:14:18:14 | access to local variable i : I [field Field1] : Object | I.cs:18:14:18:21 | access to field Field1 |
 | I.cs:21:13:21:19 | object creation of type I : I [field Field1] : Object | I.cs:22:9:22:9 | access to local variable i : I [field Field1] : Object |
+| I.cs:21:13:21:19 | object creation of type I : I [field Field1] : Object | I.cs:22:9:22:9 | access to local variable i : I [field Field1] : Object |
+| I.cs:22:9:22:9 | access to local variable i : I [field Field1] : Object | I.cs:23:14:23:14 | access to local variable i : I [field Field1] : Object |
 | I.cs:22:9:22:9 | access to local variable i : I [field Field1] : Object | I.cs:23:14:23:14 | access to local variable i : I [field Field1] : Object |
 | I.cs:23:14:23:14 | access to local variable i : I [field Field1] : Object | I.cs:23:14:23:21 | access to field Field1 |
+| I.cs:23:14:23:14 | access to local variable i : I [field Field1] : Object | I.cs:23:14:23:21 | access to field Field1 |
+| I.cs:26:13:26:37 | [pre-initializer] object creation of type I : I [field Field1] : Object | I.cs:27:14:27:14 | access to local variable i : I [field Field1] : Object |
 | I.cs:26:13:26:37 | [pre-initializer] object creation of type I : I [field Field1] : Object | I.cs:27:14:27:14 | access to local variable i : I [field Field1] : Object |
 | I.cs:27:14:27:14 | access to local variable i : I [field Field1] : Object | I.cs:27:14:27:21 | access to field Field1 |
+| I.cs:27:14:27:14 | access to local variable i : I [field Field1] : Object | I.cs:27:14:27:21 | access to field Field1 |
+| I.cs:31:13:31:29 | call to method Source<Object> : Object | I.cs:32:20:32:20 | access to local variable o : Object |
 | I.cs:31:13:31:29 | call to method Source<Object> : Object | I.cs:32:20:32:20 | access to local variable o : Object |
 | I.cs:32:9:32:9 | [post] access to local variable i : I [field Field1] : Object | I.cs:33:9:33:9 | access to local variable i : I [field Field1] : Object |
+| I.cs:32:9:32:9 | [post] access to local variable i : I [field Field1] : Object | I.cs:33:9:33:9 | access to local variable i : I [field Field1] : Object |
+| I.cs:32:20:32:20 | access to local variable o : Object | I.cs:32:9:32:9 | [post] access to local variable i : I [field Field1] : Object |
 | I.cs:32:20:32:20 | access to local variable o : Object | I.cs:32:9:32:9 | [post] access to local variable i : I [field Field1] : Object |
 | I.cs:33:9:33:9 | access to local variable i : I [field Field1] : Object | I.cs:34:12:34:12 | access to local variable i : I [field Field1] : Object |
+| I.cs:33:9:33:9 | access to local variable i : I [field Field1] : Object | I.cs:34:12:34:12 | access to local variable i : I [field Field1] : Object |
+| I.cs:34:12:34:12 | access to local variable i : I [field Field1] : Object | I.cs:37:23:37:23 | i : I [field Field1] : Object |
 | I.cs:34:12:34:12 | access to local variable i : I [field Field1] : Object | I.cs:37:23:37:23 | i : I [field Field1] : Object |
 | I.cs:37:23:37:23 | i : I [field Field1] : Object | I.cs:39:9:39:9 | access to parameter i : I [field Field1] : Object |
+| I.cs:37:23:37:23 | i : I [field Field1] : Object | I.cs:39:9:39:9 | access to parameter i : I [field Field1] : Object |
+| I.cs:39:9:39:9 | access to parameter i : I [field Field1] : Object | I.cs:40:14:40:14 | access to parameter i : I [field Field1] : Object |
 | I.cs:39:9:39:9 | access to parameter i : I [field Field1] : Object | I.cs:40:14:40:14 | access to parameter i : I [field Field1] : Object |
 | I.cs:40:14:40:14 | access to parameter i : I [field Field1] : Object | I.cs:40:14:40:21 | access to field Field1 |
+| I.cs:40:14:40:14 | access to parameter i : I [field Field1] : Object | I.cs:40:14:40:21 | access to field Field1 |
+| J.cs:14:26:14:30 | field : Object | J.cs:14:66:14:70 | access to parameter field : Object |
 | J.cs:14:26:14:30 | field : Object | J.cs:14:66:14:70 | access to parameter field : Object |
 | J.cs:14:40:14:43 | prop : Object | J.cs:14:73:14:76 | access to parameter prop : Object |
+| J.cs:14:40:14:43 | prop : Object | J.cs:14:73:14:76 | access to parameter prop : Object |
+| J.cs:14:66:14:70 | access to parameter field : Object | J.cs:14:50:14:54 | [post] this access : Struct [field Field] : Object |
 | J.cs:14:66:14:70 | access to parameter field : Object | J.cs:14:50:14:54 | [post] this access : Struct [field Field] : Object |
 | J.cs:14:73:14:76 | access to parameter prop : Object | J.cs:14:57:14:60 | [post] this access : Struct [property Prop] : Object |
+| J.cs:14:73:14:76 | access to parameter prop : Object | J.cs:14:57:14:60 | [post] this access : Struct [property Prop] : Object |
+| J.cs:21:17:21:33 | call to method Source<Object> : Object | J.cs:22:34:22:34 | access to local variable o : Object |
 | J.cs:21:17:21:33 | call to method Source<Object> : Object | J.cs:22:34:22:34 | access to local variable o : Object |
 | J.cs:22:18:22:41 | object creation of type RecordClass : RecordClass [property Prop1] : Object | J.cs:23:14:23:15 | access to local variable r1 : RecordClass [property Prop1] : Object |
+| J.cs:22:18:22:41 | object creation of type RecordClass : RecordClass [property Prop1] : Object | J.cs:23:14:23:15 | access to local variable r1 : RecordClass [property Prop1] : Object |
+| J.cs:22:18:22:41 | object creation of type RecordClass : RecordClass [property Prop1] : Object | J.cs:27:14:27:15 | access to local variable r2 : RecordClass [property Prop1] : Object |
 | J.cs:22:18:22:41 | object creation of type RecordClass : RecordClass [property Prop1] : Object | J.cs:27:14:27:15 | access to local variable r2 : RecordClass [property Prop1] : Object |
 | J.cs:22:18:22:41 | object creation of type RecordClass : RecordClass [property Prop1] : Object | J.cs:31:14:31:15 | access to local variable r3 : RecordClass [property Prop1] : Object |
+| J.cs:22:18:22:41 | object creation of type RecordClass : RecordClass [property Prop1] : Object | J.cs:31:14:31:15 | access to local variable r3 : RecordClass [property Prop1] : Object |
+| J.cs:22:34:22:34 | access to local variable o : Object | J.cs:22:18:22:41 | object creation of type RecordClass : RecordClass [property Prop1] : Object |
 | J.cs:22:34:22:34 | access to local variable o : Object | J.cs:22:18:22:41 | object creation of type RecordClass : RecordClass [property Prop1] : Object |
 | J.cs:23:14:23:15 | access to local variable r1 : RecordClass [property Prop1] : Object | J.cs:23:14:23:21 | access to property Prop1 |
+| J.cs:23:14:23:15 | access to local variable r1 : RecordClass [property Prop1] : Object | J.cs:23:14:23:21 | access to property Prop1 |
+| J.cs:27:14:27:15 | access to local variable r2 : RecordClass [property Prop1] : Object | J.cs:27:14:27:21 | access to property Prop1 |
 | J.cs:27:14:27:15 | access to local variable r2 : RecordClass [property Prop1] : Object | J.cs:27:14:27:21 | access to property Prop1 |
 | J.cs:30:18:30:54 | ... with { ... } : RecordClass [property Prop2] : Object | J.cs:32:14:32:15 | access to local variable r3 : RecordClass [property Prop2] : Object |
+| J.cs:30:18:30:54 | ... with { ... } : RecordClass [property Prop2] : Object | J.cs:32:14:32:15 | access to local variable r3 : RecordClass [property Prop2] : Object |
+| J.cs:30:36:30:52 | call to method Source<Object> : Object | J.cs:30:18:30:54 | ... with { ... } : RecordClass [property Prop2] : Object |
 | J.cs:30:36:30:52 | call to method Source<Object> : Object | J.cs:30:18:30:54 | ... with { ... } : RecordClass [property Prop2] : Object |
 | J.cs:31:14:31:15 | access to local variable r3 : RecordClass [property Prop1] : Object | J.cs:31:14:31:21 | access to property Prop1 |
+| J.cs:31:14:31:15 | access to local variable r3 : RecordClass [property Prop1] : Object | J.cs:31:14:31:21 | access to property Prop1 |
+| J.cs:32:14:32:15 | access to local variable r3 : RecordClass [property Prop2] : Object | J.cs:32:14:32:21 | access to property Prop2 |
 | J.cs:32:14:32:15 | access to local variable r3 : RecordClass [property Prop2] : Object | J.cs:32:14:32:21 | access to property Prop2 |
 | J.cs:41:17:41:33 | call to method Source<Object> : Object | J.cs:42:35:42:35 | access to local variable o : Object |
+| J.cs:41:17:41:33 | call to method Source<Object> : Object | J.cs:42:35:42:35 | access to local variable o : Object |
+| J.cs:42:18:42:42 | object creation of type RecordStruct : RecordStruct [property Prop1] : Object | J.cs:43:14:43:15 | access to local variable r1 : RecordStruct [property Prop1] : Object |
 | J.cs:42:18:42:42 | object creation of type RecordStruct : RecordStruct [property Prop1] : Object | J.cs:43:14:43:15 | access to local variable r1 : RecordStruct [property Prop1] : Object |
 | J.cs:42:18:42:42 | object creation of type RecordStruct : RecordStruct [property Prop1] : Object | J.cs:47:14:47:15 | access to local variable r2 : RecordStruct [property Prop1] : Object |
+| J.cs:42:18:42:42 | object creation of type RecordStruct : RecordStruct [property Prop1] : Object | J.cs:47:14:47:15 | access to local variable r2 : RecordStruct [property Prop1] : Object |
+| J.cs:42:18:42:42 | object creation of type RecordStruct : RecordStruct [property Prop1] : Object | J.cs:51:14:51:15 | access to local variable r3 : RecordStruct [property Prop1] : Object |
 | J.cs:42:18:42:42 | object creation of type RecordStruct : RecordStruct [property Prop1] : Object | J.cs:51:14:51:15 | access to local variable r3 : RecordStruct [property Prop1] : Object |
 | J.cs:42:35:42:35 | access to local variable o : Object | J.cs:42:18:42:42 | object creation of type RecordStruct : RecordStruct [property Prop1] : Object |
+| J.cs:42:35:42:35 | access to local variable o : Object | J.cs:42:18:42:42 | object creation of type RecordStruct : RecordStruct [property Prop1] : Object |
+| J.cs:43:14:43:15 | access to local variable r1 : RecordStruct [property Prop1] : Object | J.cs:43:14:43:21 | access to property Prop1 |
 | J.cs:43:14:43:15 | access to local variable r1 : RecordStruct [property Prop1] : Object | J.cs:43:14:43:21 | access to property Prop1 |
 | J.cs:47:14:47:15 | access to local variable r2 : RecordStruct [property Prop1] : Object | J.cs:47:14:47:21 | access to property Prop1 |
+| J.cs:47:14:47:15 | access to local variable r2 : RecordStruct [property Prop1] : Object | J.cs:47:14:47:21 | access to property Prop1 |
+| J.cs:50:18:50:54 | ... with { ... } : RecordStruct [property Prop2] : Object | J.cs:52:14:52:15 | access to local variable r3 : RecordStruct [property Prop2] : Object |
 | J.cs:50:18:50:54 | ... with { ... } : RecordStruct [property Prop2] : Object | J.cs:52:14:52:15 | access to local variable r3 : RecordStruct [property Prop2] : Object |
 | J.cs:50:36:50:52 | call to method Source<Object> : Object | J.cs:50:18:50:54 | ... with { ... } : RecordStruct [property Prop2] : Object |
+| J.cs:50:36:50:52 | call to method Source<Object> : Object | J.cs:50:18:50:54 | ... with { ... } : RecordStruct [property Prop2] : Object |
+| J.cs:51:14:51:15 | access to local variable r3 : RecordStruct [property Prop1] : Object | J.cs:51:14:51:21 | access to property Prop1 |
 | J.cs:51:14:51:15 | access to local variable r3 : RecordStruct [property Prop1] : Object | J.cs:51:14:51:21 | access to property Prop1 |
 | J.cs:52:14:52:15 | access to local variable r3 : RecordStruct [property Prop2] : Object | J.cs:52:14:52:21 | access to property Prop2 |
+| J.cs:52:14:52:15 | access to local variable r3 : RecordStruct [property Prop2] : Object | J.cs:52:14:52:21 | access to property Prop2 |
+| J.cs:61:17:61:33 | call to method Source<Object> : Object | J.cs:62:29:62:29 | access to local variable o : Object |
 | J.cs:61:17:61:33 | call to method Source<Object> : Object | J.cs:62:29:62:29 | access to local variable o : Object |
 | J.cs:62:18:62:36 | object creation of type Struct : Struct [field Field] : Object | J.cs:65:14:65:15 | access to local variable s2 : Struct [field Field] : Object |
+| J.cs:62:18:62:36 | object creation of type Struct : Struct [field Field] : Object | J.cs:65:14:65:15 | access to local variable s2 : Struct [field Field] : Object |
+| J.cs:62:18:62:36 | object creation of type Struct : Struct [field Field] : Object | J.cs:69:14:69:15 | access to local variable s3 : Struct [field Field] : Object |
 | J.cs:62:18:62:36 | object creation of type Struct : Struct [field Field] : Object | J.cs:69:14:69:15 | access to local variable s3 : Struct [field Field] : Object |
 | J.cs:62:29:62:29 | access to local variable o : Object | J.cs:14:26:14:30 | field : Object |
+| J.cs:62:29:62:29 | access to local variable o : Object | J.cs:14:26:14:30 | field : Object |
+| J.cs:62:29:62:29 | access to local variable o : Object | J.cs:62:18:62:36 | object creation of type Struct : Struct [field Field] : Object |
 | J.cs:62:29:62:29 | access to local variable o : Object | J.cs:62:18:62:36 | object creation of type Struct : Struct [field Field] : Object |
 | J.cs:65:14:65:15 | access to local variable s2 : Struct [field Field] : Object | J.cs:65:14:65:21 | access to field Field |
+| J.cs:65:14:65:15 | access to local variable s2 : Struct [field Field] : Object | J.cs:65:14:65:21 | access to field Field |
+| J.cs:68:18:68:53 | ... with { ... } : Struct [property Prop] : Object | J.cs:70:14:70:15 | access to local variable s3 : Struct [property Prop] : Object |
 | J.cs:68:18:68:53 | ... with { ... } : Struct [property Prop] : Object | J.cs:70:14:70:15 | access to local variable s3 : Struct [property Prop] : Object |
 | J.cs:68:35:68:51 | call to method Source<Object> : Object | J.cs:68:18:68:53 | ... with { ... } : Struct [property Prop] : Object |
+| J.cs:68:35:68:51 | call to method Source<Object> : Object | J.cs:68:18:68:53 | ... with { ... } : Struct [property Prop] : Object |
+| J.cs:69:14:69:15 | access to local variable s3 : Struct [field Field] : Object | J.cs:69:14:69:21 | access to field Field |
 | J.cs:69:14:69:15 | access to local variable s3 : Struct [field Field] : Object | J.cs:69:14:69:21 | access to field Field |
 | J.cs:70:14:70:15 | access to local variable s3 : Struct [property Prop] : Object | J.cs:70:14:70:20 | access to property Prop |
+| J.cs:70:14:70:15 | access to local variable s3 : Struct [property Prop] : Object | J.cs:70:14:70:20 | access to property Prop |
+| J.cs:79:17:79:33 | call to method Source<Object> : Object | J.cs:80:35:80:35 | access to local variable o : Object |
 | J.cs:79:17:79:33 | call to method Source<Object> : Object | J.cs:80:35:80:35 | access to local variable o : Object |
 | J.cs:80:18:80:36 | object creation of type Struct : Struct [property Prop] : Object | J.cs:84:14:84:15 | access to local variable s2 : Struct [property Prop] : Object |
+| J.cs:80:18:80:36 | object creation of type Struct : Struct [property Prop] : Object | J.cs:84:14:84:15 | access to local variable s2 : Struct [property Prop] : Object |
+| J.cs:80:18:80:36 | object creation of type Struct : Struct [property Prop] : Object | J.cs:88:14:88:15 | access to local variable s3 : Struct [property Prop] : Object |
 | J.cs:80:18:80:36 | object creation of type Struct : Struct [property Prop] : Object | J.cs:88:14:88:15 | access to local variable s3 : Struct [property Prop] : Object |
 | J.cs:80:35:80:35 | access to local variable o : Object | J.cs:14:40:14:43 | prop : Object |
+| J.cs:80:35:80:35 | access to local variable o : Object | J.cs:14:40:14:43 | prop : Object |
+| J.cs:80:35:80:35 | access to local variable o : Object | J.cs:80:18:80:36 | object creation of type Struct : Struct [property Prop] : Object |
 | J.cs:80:35:80:35 | access to local variable o : Object | J.cs:80:18:80:36 | object creation of type Struct : Struct [property Prop] : Object |
 | J.cs:84:14:84:15 | access to local variable s2 : Struct [property Prop] : Object | J.cs:84:14:84:20 | access to property Prop |
+| J.cs:84:14:84:15 | access to local variable s2 : Struct [property Prop] : Object | J.cs:84:14:84:20 | access to property Prop |
+| J.cs:86:18:86:54 | ... with { ... } : Struct [field Field] : Object | J.cs:87:14:87:15 | access to local variable s3 : Struct [field Field] : Object |
 | J.cs:86:18:86:54 | ... with { ... } : Struct [field Field] : Object | J.cs:87:14:87:15 | access to local variable s3 : Struct [field Field] : Object |
 | J.cs:86:36:86:52 | call to method Source<Object> : Object | J.cs:86:18:86:54 | ... with { ... } : Struct [field Field] : Object |
+| J.cs:86:36:86:52 | call to method Source<Object> : Object | J.cs:86:18:86:54 | ... with { ... } : Struct [field Field] : Object |
+| J.cs:87:14:87:15 | access to local variable s3 : Struct [field Field] : Object | J.cs:87:14:87:21 | access to field Field |
 | J.cs:87:14:87:15 | access to local variable s3 : Struct [field Field] : Object | J.cs:87:14:87:21 | access to field Field |
 | J.cs:88:14:88:15 | access to local variable s3 : Struct [property Prop] : Object | J.cs:88:14:88:20 | access to property Prop |
+| J.cs:88:14:88:15 | access to local variable s3 : Struct [property Prop] : Object | J.cs:88:14:88:20 | access to property Prop |
+| J.cs:97:17:97:33 | call to method Source<Object> : Object | J.cs:99:28:99:28 | access to local variable o : Object |
 | J.cs:97:17:97:33 | call to method Source<Object> : Object | J.cs:99:28:99:28 | access to local variable o : Object |
 | J.cs:99:18:99:41 | { ..., ... } : <>__AnonType0<Object,Object> [property X] : Object | J.cs:102:14:102:15 | access to local variable a2 : <>__AnonType0<Object,Object> [property X] : Object |
+| J.cs:99:18:99:41 | { ..., ... } : <>__AnonType0<Object,Object> [property X] : Object | J.cs:102:14:102:15 | access to local variable a2 : <>__AnonType0<Object,Object> [property X] : Object |
+| J.cs:99:18:99:41 | { ..., ... } : <>__AnonType0<Object,Object> [property X] : Object | J.cs:106:14:106:15 | access to local variable a3 : <>__AnonType0<Object,Object> [property X] : Object |
 | J.cs:99:18:99:41 | { ..., ... } : <>__AnonType0<Object,Object> [property X] : Object | J.cs:106:14:106:15 | access to local variable a3 : <>__AnonType0<Object,Object> [property X] : Object |
 | J.cs:99:28:99:28 | access to local variable o : Object | J.cs:99:18:99:41 | { ..., ... } : <>__AnonType0<Object,Object> [property X] : Object |
+| J.cs:99:28:99:28 | access to local variable o : Object | J.cs:99:18:99:41 | { ..., ... } : <>__AnonType0<Object,Object> [property X] : Object |
+| J.cs:102:14:102:15 | access to local variable a2 : <>__AnonType0<Object,Object> [property X] : Object | J.cs:102:14:102:17 | access to property X |
 | J.cs:102:14:102:15 | access to local variable a2 : <>__AnonType0<Object,Object> [property X] : Object | J.cs:102:14:102:17 | access to property X |
 | J.cs:105:18:105:50 | ... with { ... } : <>__AnonType0<Object,Object> [property Y] : Object | J.cs:107:14:107:15 | access to local variable a3 : <>__AnonType0<Object,Object> [property Y] : Object |
+| J.cs:105:18:105:50 | ... with { ... } : <>__AnonType0<Object,Object> [property Y] : Object | J.cs:107:14:107:15 | access to local variable a3 : <>__AnonType0<Object,Object> [property Y] : Object |
+| J.cs:105:32:105:48 | call to method Source<Object> : Object | J.cs:105:18:105:50 | ... with { ... } : <>__AnonType0<Object,Object> [property Y] : Object |
 | J.cs:105:32:105:48 | call to method Source<Object> : Object | J.cs:105:18:105:50 | ... with { ... } : <>__AnonType0<Object,Object> [property Y] : Object |
 | J.cs:106:14:106:15 | access to local variable a3 : <>__AnonType0<Object,Object> [property X] : Object | J.cs:106:14:106:17 | access to property X |
+| J.cs:106:14:106:15 | access to local variable a3 : <>__AnonType0<Object,Object> [property X] : Object | J.cs:106:14:106:17 | access to property X |
+| J.cs:107:14:107:15 | access to local variable a3 : <>__AnonType0<Object,Object> [property Y] : Object | J.cs:107:14:107:17 | access to property Y |
 | J.cs:107:14:107:15 | access to local variable a3 : <>__AnonType0<Object,Object> [property Y] : Object | J.cs:107:14:107:17 | access to property Y |
 | J.cs:119:13:119:13 | [post] access to local variable a : Int32[] [element] : Int32 | J.cs:125:14:125:14 | access to local variable a : Int32[] [element] : Int32 |
+| J.cs:119:13:119:13 | [post] access to local variable a : Int32[] [element] : Int32 | J.cs:125:14:125:14 | access to local variable a : Int32[] [element] : Int32 |
+| J.cs:119:20:119:34 | call to method Source<Int32> : Int32 | J.cs:119:13:119:13 | [post] access to local variable a : Int32[] [element] : Int32 |
 | J.cs:119:20:119:34 | call to method Source<Int32> : Int32 | J.cs:119:13:119:13 | [post] access to local variable a : Int32[] [element] : Int32 |
 | J.cs:125:14:125:14 | access to local variable a : Int32[] [element] : Int32 | J.cs:125:14:125:17 | access to array element : Int32 |
+| J.cs:125:14:125:14 | access to local variable a : Int32[] [element] : Int32 | J.cs:125:14:125:17 | access to array element : Int32 |
+| J.cs:125:14:125:17 | access to array element : Int32 | J.cs:125:14:125:17 | (...) ... |
 | J.cs:125:14:125:17 | access to array element : Int32 | J.cs:125:14:125:17 | (...) ... |
 nodes
 | A.cs:5:17:5:28 | call to method Source<C> : C | semmle.label | call to method Source<C> : C |
+| A.cs:5:17:5:28 | call to method Source<C> : C | semmle.label | call to method Source<C> : C |
+| A.cs:6:17:6:25 | call to method Make : B [field c] : C | semmle.label | call to method Make : B [field c] : C |
 | A.cs:6:17:6:25 | call to method Make : B [field c] : C | semmle.label | call to method Make : B [field c] : C |
 | A.cs:6:24:6:24 | access to local variable c : C | semmle.label | access to local variable c : C |
+| A.cs:6:24:6:24 | access to local variable c : C | semmle.label | access to local variable c : C |
+| A.cs:7:14:7:14 | access to local variable b : B [field c] : C | semmle.label | access to local variable b : B [field c] : C |
 | A.cs:7:14:7:14 | access to local variable b : B [field c] : C | semmle.label | access to local variable b : B [field c] : C |
 | A.cs:7:14:7:16 | access to field c | semmle.label | access to field c |
+| A.cs:7:14:7:16 | access to field c | semmle.label | access to field c |
+| A.cs:13:9:13:9 | [post] access to local variable b : B [field c] : C1 | semmle.label | [post] access to local variable b : B [field c] : C1 |
 | A.cs:13:9:13:9 | [post] access to local variable b : B [field c] : C1 | semmle.label | [post] access to local variable b : B [field c] : C1 |
 | A.cs:13:15:13:29 | call to method Source<C1> : C1 | semmle.label | call to method Source<C1> : C1 |
+| A.cs:13:15:13:29 | call to method Source<C1> : C1 | semmle.label | call to method Source<C1> : C1 |
+| A.cs:14:14:14:14 | access to local variable b : B [field c] : C1 | semmle.label | access to local variable b : B [field c] : C1 |
 | A.cs:14:14:14:14 | access to local variable b : B [field c] : C1 | semmle.label | access to local variable b : B [field c] : C1 |
 | A.cs:14:14:14:20 | call to method Get | semmle.label | call to method Get |
+| A.cs:14:14:14:20 | call to method Get | semmle.label | call to method Get |
+| A.cs:15:14:15:42 | call to method Get | semmle.label | call to method Get |
 | A.cs:15:14:15:42 | call to method Get | semmle.label | call to method Get |
 | A.cs:15:15:15:35 | object creation of type B : B [field c] : C | semmle.label | object creation of type B : B [field c] : C |
+| A.cs:15:15:15:35 | object creation of type B : B [field c] : C | semmle.label | object creation of type B : B [field c] : C |
+| A.cs:15:21:15:34 | call to method Source<C> : C | semmle.label | call to method Source<C> : C |
 | A.cs:15:21:15:34 | call to method Source<C> : C | semmle.label | call to method Source<C> : C |
 | A.cs:22:14:22:38 | call to method SetOnB : B [field c] : C2 | semmle.label | call to method SetOnB : B [field c] : C2 |
+| A.cs:22:14:22:38 | call to method SetOnB : B [field c] : C2 | semmle.label | call to method SetOnB : B [field c] : C2 |
+| A.cs:22:25:22:37 | call to method Source<C2> : C2 | semmle.label | call to method Source<C2> : C2 |
 | A.cs:22:25:22:37 | call to method Source<C2> : C2 | semmle.label | call to method Source<C2> : C2 |
 | A.cs:24:14:24:15 | access to local variable b2 : B [field c] : C2 | semmle.label | access to local variable b2 : B [field c] : C2 |
+| A.cs:24:14:24:15 | access to local variable b2 : B [field c] : C2 | semmle.label | access to local variable b2 : B [field c] : C2 |
+| A.cs:24:14:24:17 | access to field c | semmle.label | access to field c |
 | A.cs:24:14:24:17 | access to field c | semmle.label | access to field c |
 | A.cs:31:14:31:42 | call to method SetOnBWrap : B [field c] : C2 | semmle.label | call to method SetOnBWrap : B [field c] : C2 |
+| A.cs:31:14:31:42 | call to method SetOnBWrap : B [field c] : C2 | semmle.label | call to method SetOnBWrap : B [field c] : C2 |
+| A.cs:31:29:31:41 | call to method Source<C2> : C2 | semmle.label | call to method Source<C2> : C2 |
 | A.cs:31:29:31:41 | call to method Source<C2> : C2 | semmle.label | call to method Source<C2> : C2 |
 | A.cs:33:14:33:15 | access to local variable b2 : B [field c] : C2 | semmle.label | access to local variable b2 : B [field c] : C2 |
+| A.cs:33:14:33:15 | access to local variable b2 : B [field c] : C2 | semmle.label | access to local variable b2 : B [field c] : C2 |
+| A.cs:33:14:33:17 | access to field c | semmle.label | access to field c |
 | A.cs:33:14:33:17 | access to field c | semmle.label | access to field c |
 | A.cs:36:33:36:33 | c : C2 | semmle.label | c : C2 |
+| A.cs:36:33:36:33 | c : C2 | semmle.label | c : C2 |
+| A.cs:38:18:38:30 | call to method SetOnB : B [field c] : C2 | semmle.label | call to method SetOnB : B [field c] : C2 |
 | A.cs:38:18:38:30 | call to method SetOnB : B [field c] : C2 | semmle.label | call to method SetOnB : B [field c] : C2 |
 | A.cs:38:29:38:29 | access to parameter c : C2 | semmle.label | access to parameter c : C2 |
+| A.cs:38:29:38:29 | access to parameter c : C2 | semmle.label | access to parameter c : C2 |
+| A.cs:39:16:39:28 | ... ? ... : ... : B [field c] : C2 | semmle.label | ... ? ... : ... : B [field c] : C2 |
 | A.cs:39:16:39:28 | ... ? ... : ... : B [field c] : C2 | semmle.label | ... ? ... : ... : B [field c] : C2 |
 | A.cs:42:29:42:29 | c : C2 | semmle.label | c : C2 |
+| A.cs:42:29:42:29 | c : C2 | semmle.label | c : C2 |
+| A.cs:47:13:47:14 | [post] access to local variable b2 : B [field c] : C2 | semmle.label | [post] access to local variable b2 : B [field c] : C2 |
 | A.cs:47:13:47:14 | [post] access to local variable b2 : B [field c] : C2 | semmle.label | [post] access to local variable b2 : B [field c] : C2 |
 | A.cs:47:20:47:20 | access to parameter c : C2 | semmle.label | access to parameter c : C2 |
+| A.cs:47:20:47:20 | access to parameter c : C2 | semmle.label | access to parameter c : C2 |
+| A.cs:48:20:48:21 | access to local variable b2 : B [field c] : C2 | semmle.label | access to local variable b2 : B [field c] : C2 |
 | A.cs:48:20:48:21 | access to local variable b2 : B [field c] : C2 | semmle.label | access to local variable b2 : B [field c] : C2 |
 | A.cs:55:17:55:28 | call to method Source<A> : A | semmle.label | call to method Source<A> : A |
+| A.cs:55:17:55:28 | call to method Source<A> : A | semmle.label | call to method Source<A> : A |
+| A.cs:57:9:57:10 | [post] access to local variable c1 : C1 [field a] : A | semmle.label | [post] access to local variable c1 : C1 [field a] : A |
 | A.cs:57:9:57:10 | [post] access to local variable c1 : C1 [field a] : A | semmle.label | [post] access to local variable c1 : C1 [field a] : A |
 | A.cs:57:16:57:16 | access to local variable a : A | semmle.label | access to local variable a : A |
+| A.cs:57:16:57:16 | access to local variable a : A | semmle.label | access to local variable a : A |
+| A.cs:58:12:58:13 | access to local variable c1 : C1 [field a] : A | semmle.label | access to local variable c1 : C1 [field a] : A |
 | A.cs:58:12:58:13 | access to local variable c1 : C1 [field a] : A | semmle.label | access to local variable c1 : C1 [field a] : A |
 | A.cs:60:22:60:22 | c : C1 [field a] : A | semmle.label | c : C1 [field a] : A |
+| A.cs:60:22:60:22 | c : C1 [field a] : A | semmle.label | c : C1 [field a] : A |
+| A.cs:64:18:64:26 | access to field a | semmle.label | access to field a |
 | A.cs:64:18:64:26 | access to field a | semmle.label | access to field a |
 | A.cs:64:19:64:23 | (...) ... : C1 [field a] : A | semmle.label | (...) ... : C1 [field a] : A |
+| A.cs:64:19:64:23 | (...) ... : C1 [field a] : A | semmle.label | (...) ... : C1 [field a] : A |
+| A.cs:83:9:83:9 | [post] access to parameter b : B [field c] : C | semmle.label | [post] access to parameter b : B [field c] : C |
 | A.cs:83:9:83:9 | [post] access to parameter b : B [field c] : C | semmle.label | [post] access to parameter b : B [field c] : C |
 | A.cs:83:15:83:26 | call to method Source<C> : C | semmle.label | call to method Source<C> : C |
+| A.cs:83:15:83:26 | call to method Source<C> : C | semmle.label | call to method Source<C> : C |
+| A.cs:88:12:88:12 | [post] access to local variable b : B [field c] : C | semmle.label | [post] access to local variable b : B [field c] : C |
 | A.cs:88:12:88:12 | [post] access to local variable b : B [field c] : C | semmle.label | [post] access to local variable b : B [field c] : C |
 | A.cs:89:14:89:14 | access to local variable b : B [field c] : C | semmle.label | access to local variable b : B [field c] : C |
+| A.cs:89:14:89:14 | access to local variable b : B [field c] : C | semmle.label | access to local variable b : B [field c] : C |
+| A.cs:89:14:89:16 | access to field c | semmle.label | access to field c |
 | A.cs:89:14:89:16 | access to field c | semmle.label | access to field c |
 | A.cs:95:20:95:20 | b : B | semmle.label | b : B |
+| A.cs:95:20:95:20 | b : B | semmle.label | b : B |
+| A.cs:97:13:97:13 | [post] access to parameter b : B [field c] : C | semmle.label | [post] access to parameter b : B [field c] : C |
 | A.cs:97:13:97:13 | [post] access to parameter b : B [field c] : C | semmle.label | [post] access to parameter b : B [field c] : C |
 | A.cs:97:13:97:13 | access to parameter b : B | semmle.label | access to parameter b : B |
+| A.cs:97:13:97:13 | access to parameter b : B | semmle.label | access to parameter b : B |
 | A.cs:97:19:97:32 | call to method Source<C> : C | semmle.label | call to method Source<C> : C |
+| A.cs:97:19:97:32 | call to method Source<C> : C | semmle.label | call to method Source<C> : C |
+| A.cs:98:13:98:16 | [post] this access : D [field b, field c] : C | semmle.label | [post] this access : D [field b, field c] : C |
 | A.cs:98:13:98:16 | [post] this access : D [field b, field c] : C | semmle.label | [post] this access : D [field b, field c] : C |
 | A.cs:98:13:98:16 | [post] this access : D [field b] : B | semmle.label | [post] this access : D [field b] : B |
 | A.cs:98:13:98:16 | [post] this access : D [field b] : B | semmle.label | [post] this access : D [field b] : B |
+| A.cs:98:13:98:16 | [post] this access : D [field b] : B | semmle.label | [post] this access : D [field b] : B |
+| A.cs:98:13:98:16 | [post] this access : D [field b] : B | semmle.label | [post] this access : D [field b] : B |
+| A.cs:98:22:98:43 | ... ? ... : ... : B | semmle.label | ... ? ... : ... : B |
+| A.cs:98:22:98:43 | ... ? ... : ... : B | semmle.label | ... ? ... : ... : B |
 | A.cs:98:22:98:43 | ... ? ... : ... : B | semmle.label | ... ? ... : ... : B |
 | A.cs:98:22:98:43 | ... ? ... : ... : B | semmle.label | ... ? ... : ... : B |
 | A.cs:98:22:98:43 | ... ? ... : ... : B [field c] : C | semmle.label | ... ? ... : ... : B [field c] : C |
+| A.cs:98:22:98:43 | ... ? ... : ... : B [field c] : C | semmle.label | ... ? ... : ... : B [field c] : C |
+| A.cs:98:30:98:43 | call to method Source<B> : B | semmle.label | call to method Source<B> : B |
 | A.cs:98:30:98:43 | call to method Source<B> : B | semmle.label | call to method Source<B> : B |
 | A.cs:104:17:104:30 | call to method Source<B> : B | semmle.label | call to method Source<B> : B |
+| A.cs:104:17:104:30 | call to method Source<B> : B | semmle.label | call to method Source<B> : B |
+| A.cs:105:17:105:29 | object creation of type D : D [field b, field c] : C | semmle.label | object creation of type D : D [field b, field c] : C |
 | A.cs:105:17:105:29 | object creation of type D : D [field b, field c] : C | semmle.label | object creation of type D : D [field b, field c] : C |
 | A.cs:105:17:105:29 | object creation of type D : D [field b] : B | semmle.label | object creation of type D : D [field b] : B |
+| A.cs:105:17:105:29 | object creation of type D : D [field b] : B | semmle.label | object creation of type D : D [field b] : B |
+| A.cs:105:23:105:23 | [post] access to local variable b : B [field c] : C | semmle.label | [post] access to local variable b : B [field c] : C |
 | A.cs:105:23:105:23 | [post] access to local variable b : B [field c] : C | semmle.label | [post] access to local variable b : B [field c] : C |
 | A.cs:105:23:105:23 | access to local variable b : B | semmle.label | access to local variable b : B |
+| A.cs:105:23:105:23 | access to local variable b : B | semmle.label | access to local variable b : B |
+| A.cs:106:14:106:14 | access to local variable d : D [field b] : B | semmle.label | access to local variable d : D [field b] : B |
 | A.cs:106:14:106:14 | access to local variable d : D [field b] : B | semmle.label | access to local variable d : D [field b] : B |
 | A.cs:106:14:106:16 | access to field b | semmle.label | access to field b |
+| A.cs:106:14:106:16 | access to field b | semmle.label | access to field b |
+| A.cs:107:14:107:14 | access to local variable d : D [field b, field c] : C | semmle.label | access to local variable d : D [field b, field c] : C |
 | A.cs:107:14:107:14 | access to local variable d : D [field b, field c] : C | semmle.label | access to local variable d : D [field b, field c] : C |
 | A.cs:107:14:107:16 | access to field b : B [field c] : C | semmle.label | access to field b : B [field c] : C |
+| A.cs:107:14:107:16 | access to field b : B [field c] : C | semmle.label | access to field b : B [field c] : C |
+| A.cs:107:14:107:18 | access to field c | semmle.label | access to field c |
 | A.cs:107:14:107:18 | access to field c | semmle.label | access to field c |
 | A.cs:108:14:108:14 | access to local variable b : B [field c] : C | semmle.label | access to local variable b : B [field c] : C |
+| A.cs:108:14:108:14 | access to local variable b : B [field c] : C | semmle.label | access to local variable b : B [field c] : C |
+| A.cs:108:14:108:16 | access to field c | semmle.label | access to field c |
 | A.cs:108:14:108:16 | access to field c | semmle.label | access to field c |
 | A.cs:113:17:113:29 | call to method Source<B> : B | semmle.label | call to method Source<B> : B |
+| A.cs:113:17:113:29 | call to method Source<B> : B | semmle.label | call to method Source<B> : B |
+| A.cs:114:18:114:54 | object creation of type MyList : MyList [field head] : B | semmle.label | object creation of type MyList : MyList [field head] : B |
 | A.cs:114:18:114:54 | object creation of type MyList : MyList [field head] : B | semmle.label | object creation of type MyList : MyList [field head] : B |
 | A.cs:114:29:114:29 | access to local variable b : B | semmle.label | access to local variable b : B |
+| A.cs:114:29:114:29 | access to local variable b : B | semmle.label | access to local variable b : B |
+| A.cs:115:18:115:37 | object creation of type MyList : MyList [field next, field head] : B | semmle.label | object creation of type MyList : MyList [field next, field head] : B |
 | A.cs:115:18:115:37 | object creation of type MyList : MyList [field next, field head] : B | semmle.label | object creation of type MyList : MyList [field next, field head] : B |
 | A.cs:115:35:115:36 | access to local variable l1 : MyList [field head] : B | semmle.label | access to local variable l1 : MyList [field head] : B |
+| A.cs:115:35:115:36 | access to local variable l1 : MyList [field head] : B | semmle.label | access to local variable l1 : MyList [field head] : B |
+| A.cs:116:18:116:37 | object creation of type MyList : MyList [field next, field next, field head] : B | semmle.label | object creation of type MyList : MyList [field next, field next, field head] : B |
 | A.cs:116:18:116:37 | object creation of type MyList : MyList [field next, field next, field head] : B | semmle.label | object creation of type MyList : MyList [field next, field next, field head] : B |
 | A.cs:116:35:116:36 | access to local variable l2 : MyList [field next, field head] : B | semmle.label | access to local variable l2 : MyList [field next, field head] : B |
+| A.cs:116:35:116:36 | access to local variable l2 : MyList [field next, field head] : B | semmle.label | access to local variable l2 : MyList [field next, field head] : B |
+| A.cs:119:14:119:15 | access to local variable l3 : MyList [field next, field next, field head] : B | semmle.label | access to local variable l3 : MyList [field next, field next, field head] : B |
 | A.cs:119:14:119:15 | access to local variable l3 : MyList [field next, field next, field head] : B | semmle.label | access to local variable l3 : MyList [field next, field next, field head] : B |
 | A.cs:119:14:119:20 | access to field next : MyList [field next, field head] : B | semmle.label | access to field next : MyList [field next, field head] : B |
+| A.cs:119:14:119:20 | access to field next : MyList [field next, field head] : B | semmle.label | access to field next : MyList [field next, field head] : B |
+| A.cs:119:14:119:25 | access to field next : MyList [field head] : B | semmle.label | access to field next : MyList [field head] : B |
 | A.cs:119:14:119:25 | access to field next : MyList [field head] : B | semmle.label | access to field next : MyList [field head] : B |
 | A.cs:119:14:119:30 | access to field head | semmle.label | access to field head |
+| A.cs:119:14:119:30 | access to field head | semmle.label | access to field head |
+| A.cs:121:41:121:41 | access to local variable l : MyList [field next, field head] : B | semmle.label | access to local variable l : MyList [field next, field head] : B |
 | A.cs:121:41:121:41 | access to local variable l : MyList [field next, field head] : B | semmle.label | access to local variable l : MyList [field next, field head] : B |
 | A.cs:121:41:121:41 | access to local variable l : MyList [field next, field next, field head] : B | semmle.label | access to local variable l : MyList [field next, field next, field head] : B |
+| A.cs:121:41:121:41 | access to local variable l : MyList [field next, field next, field head] : B | semmle.label | access to local variable l : MyList [field next, field next, field head] : B |
+| A.cs:121:41:121:46 | access to field next : MyList [field head] : B | semmle.label | access to field next : MyList [field head] : B |
 | A.cs:121:41:121:46 | access to field next : MyList [field head] : B | semmle.label | access to field next : MyList [field head] : B |
 | A.cs:121:41:121:46 | access to field next : MyList [field next, field head] : B | semmle.label | access to field next : MyList [field next, field head] : B |
+| A.cs:121:41:121:46 | access to field next : MyList [field next, field head] : B | semmle.label | access to field next : MyList [field next, field head] : B |
+| A.cs:123:18:123:18 | access to local variable l : MyList [field head] : B | semmle.label | access to local variable l : MyList [field head] : B |
 | A.cs:123:18:123:18 | access to local variable l : MyList [field head] : B | semmle.label | access to local variable l : MyList [field head] : B |
 | A.cs:123:18:123:23 | access to field head | semmle.label | access to field head |
+| A.cs:123:18:123:23 | access to field head | semmle.label | access to field head |
+| A.cs:141:20:141:20 | c : C | semmle.label | c : C |
 | A.cs:141:20:141:20 | c : C | semmle.label | c : C |
 | A.cs:143:13:143:16 | [post] this access : B [field c] : C | semmle.label | [post] this access : B [field c] : C |
+| A.cs:143:13:143:16 | [post] this access : B [field c] : C | semmle.label | [post] this access : B [field c] : C |
+| A.cs:143:22:143:22 | access to parameter c : C | semmle.label | access to parameter c : C |
 | A.cs:143:22:143:22 | access to parameter c : C | semmle.label | access to parameter c : C |
 | A.cs:145:27:145:27 | c : C | semmle.label | c : C |
+| A.cs:145:27:145:27 | c : C | semmle.label | c : C |
+| A.cs:145:27:145:27 | c : C1 | semmle.label | c : C1 |
 | A.cs:145:27:145:27 | c : C1 | semmle.label | c : C1 |
 | A.cs:145:27:145:27 | c : C2 | semmle.label | c : C2 |
+| A.cs:145:27:145:27 | c : C2 | semmle.label | c : C2 |
+| A.cs:145:32:145:35 | [post] this access : B [field c] : C | semmle.label | [post] this access : B [field c] : C |
 | A.cs:145:32:145:35 | [post] this access : B [field c] : C | semmle.label | [post] this access : B [field c] : C |
 | A.cs:145:32:145:35 | [post] this access : B [field c] : C1 | semmle.label | [post] this access : B [field c] : C1 |
+| A.cs:145:32:145:35 | [post] this access : B [field c] : C1 | semmle.label | [post] this access : B [field c] : C1 |
+| A.cs:145:32:145:35 | [post] this access : B [field c] : C2 | semmle.label | [post] this access : B [field c] : C2 |
 | A.cs:145:32:145:35 | [post] this access : B [field c] : C2 | semmle.label | [post] this access : B [field c] : C2 |
 | A.cs:145:41:145:41 | access to parameter c : C | semmle.label | access to parameter c : C |
+| A.cs:145:41:145:41 | access to parameter c : C | semmle.label | access to parameter c : C |
+| A.cs:145:41:145:41 | access to parameter c : C1 | semmle.label | access to parameter c : C1 |
 | A.cs:145:41:145:41 | access to parameter c : C1 | semmle.label | access to parameter c : C1 |
 | A.cs:145:41:145:41 | access to parameter c : C2 | semmle.label | access to parameter c : C2 |
+| A.cs:145:41:145:41 | access to parameter c : C2 | semmle.label | access to parameter c : C2 |
+| A.cs:146:18:146:20 | this : B [field c] : C | semmle.label | this : B [field c] : C |
 | A.cs:146:18:146:20 | this : B [field c] : C | semmle.label | this : B [field c] : C |
 | A.cs:146:18:146:20 | this : B [field c] : C1 | semmle.label | this : B [field c] : C1 |
+| A.cs:146:18:146:20 | this : B [field c] : C1 | semmle.label | this : B [field c] : C1 |
+| A.cs:146:33:146:36 | this access : B [field c] : C | semmle.label | this access : B [field c] : C |
 | A.cs:146:33:146:36 | this access : B [field c] : C | semmle.label | this access : B [field c] : C |
 | A.cs:146:33:146:36 | this access : B [field c] : C1 | semmle.label | this access : B [field c] : C1 |
+| A.cs:146:33:146:36 | this access : B [field c] : C1 | semmle.label | this access : B [field c] : C1 |
+| A.cs:146:33:146:38 | access to field c : C | semmle.label | access to field c : C |
 | A.cs:146:33:146:38 | access to field c : C | semmle.label | access to field c : C |
 | A.cs:146:33:146:38 | access to field c : C1 | semmle.label | access to field c : C1 |
+| A.cs:146:33:146:38 | access to field c : C1 | semmle.label | access to field c : C1 |
+| A.cs:147:32:147:32 | c : C | semmle.label | c : C |
 | A.cs:147:32:147:32 | c : C | semmle.label | c : C |
 | A.cs:149:20:149:27 | object creation of type B : B [field c] : C | semmle.label | object creation of type B : B [field c] : C |
+| A.cs:149:20:149:27 | object creation of type B : B [field c] : C | semmle.label | object creation of type B : B [field c] : C |
+| A.cs:149:26:149:26 | access to parameter c : C | semmle.label | access to parameter c : C |
 | A.cs:149:26:149:26 | access to parameter c : C | semmle.label | access to parameter c : C |
 | A.cs:157:25:157:28 | head : B | semmle.label | head : B |
+| A.cs:157:25:157:28 | head : B | semmle.label | head : B |
+| A.cs:157:38:157:41 | next : MyList [field head] : B | semmle.label | next : MyList [field head] : B |
 | A.cs:157:38:157:41 | next : MyList [field head] : B | semmle.label | next : MyList [field head] : B |
 | A.cs:157:38:157:41 | next : MyList [field next, field head] : B | semmle.label | next : MyList [field next, field head] : B |
+| A.cs:157:38:157:41 | next : MyList [field next, field head] : B | semmle.label | next : MyList [field next, field head] : B |
+| A.cs:159:13:159:16 | [post] this access : MyList [field head] : B | semmle.label | [post] this access : MyList [field head] : B |
 | A.cs:159:13:159:16 | [post] this access : MyList [field head] : B | semmle.label | [post] this access : MyList [field head] : B |
 | A.cs:159:25:159:28 | access to parameter head : B | semmle.label | access to parameter head : B |
+| A.cs:159:25:159:28 | access to parameter head : B | semmle.label | access to parameter head : B |
+| A.cs:160:13:160:16 | [post] this access : MyList [field next, field head] : B | semmle.label | [post] this access : MyList [field next, field head] : B |
 | A.cs:160:13:160:16 | [post] this access : MyList [field next, field head] : B | semmle.label | [post] this access : MyList [field next, field head] : B |
 | A.cs:160:13:160:16 | [post] this access : MyList [field next, field next, field head] : B | semmle.label | [post] this access : MyList [field next, field next, field head] : B |
+| A.cs:160:13:160:16 | [post] this access : MyList [field next, field next, field head] : B | semmle.label | [post] this access : MyList [field next, field next, field head] : B |
+| A.cs:160:25:160:28 | access to parameter next : MyList [field head] : B | semmle.label | access to parameter next : MyList [field head] : B |
 | A.cs:160:25:160:28 | access to parameter next : MyList [field head] : B | semmle.label | access to parameter next : MyList [field head] : B |
 | A.cs:160:25:160:28 | access to parameter next : MyList [field next, field head] : B | semmle.label | access to parameter next : MyList [field next, field head] : B |
+| A.cs:160:25:160:28 | access to parameter next : MyList [field next, field head] : B | semmle.label | access to parameter next : MyList [field next, field head] : B |
+| B.cs:5:17:5:31 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
 | B.cs:5:17:5:31 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
 | B.cs:6:18:6:34 | object creation of type Box1 : Box1 [field elem1] : Elem | semmle.label | object creation of type Box1 : Box1 [field elem1] : Elem |
+| B.cs:6:18:6:34 | object creation of type Box1 : Box1 [field elem1] : Elem | semmle.label | object creation of type Box1 : Box1 [field elem1] : Elem |
+| B.cs:6:27:6:27 | access to local variable e : Elem | semmle.label | access to local variable e : Elem |
 | B.cs:6:27:6:27 | access to local variable e : Elem | semmle.label | access to local variable e : Elem |
 | B.cs:7:18:7:29 | object creation of type Box2 : Box2 [field box1, field elem1] : Elem | semmle.label | object creation of type Box2 : Box2 [field box1, field elem1] : Elem |
+| B.cs:7:18:7:29 | object creation of type Box2 : Box2 [field box1, field elem1] : Elem | semmle.label | object creation of type Box2 : Box2 [field box1, field elem1] : Elem |
+| B.cs:7:27:7:28 | access to local variable b1 : Box1 [field elem1] : Elem | semmle.label | access to local variable b1 : Box1 [field elem1] : Elem |
 | B.cs:7:27:7:28 | access to local variable b1 : Box1 [field elem1] : Elem | semmle.label | access to local variable b1 : Box1 [field elem1] : Elem |
 | B.cs:8:14:8:15 | access to local variable b2 : Box2 [field box1, field elem1] : Elem | semmle.label | access to local variable b2 : Box2 [field box1, field elem1] : Elem |
+| B.cs:8:14:8:15 | access to local variable b2 : Box2 [field box1, field elem1] : Elem | semmle.label | access to local variable b2 : Box2 [field box1, field elem1] : Elem |
+| B.cs:8:14:8:20 | access to field box1 : Box1 [field elem1] : Elem | semmle.label | access to field box1 : Box1 [field elem1] : Elem |
 | B.cs:8:14:8:20 | access to field box1 : Box1 [field elem1] : Elem | semmle.label | access to field box1 : Box1 [field elem1] : Elem |
 | B.cs:8:14:8:26 | access to field elem1 | semmle.label | access to field elem1 |
+| B.cs:8:14:8:26 | access to field elem1 | semmle.label | access to field elem1 |
+| B.cs:14:17:14:31 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
 | B.cs:14:17:14:31 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
 | B.cs:15:18:15:34 | object creation of type Box1 : Box1 [field elem2] : Elem | semmle.label | object creation of type Box1 : Box1 [field elem2] : Elem |
+| B.cs:15:18:15:34 | object creation of type Box1 : Box1 [field elem2] : Elem | semmle.label | object creation of type Box1 : Box1 [field elem2] : Elem |
+| B.cs:15:33:15:33 | access to local variable e : Elem | semmle.label | access to local variable e : Elem |
 | B.cs:15:33:15:33 | access to local variable e : Elem | semmle.label | access to local variable e : Elem |
 | B.cs:16:18:16:29 | object creation of type Box2 : Box2 [field box1, field elem2] : Elem | semmle.label | object creation of type Box2 : Box2 [field box1, field elem2] : Elem |
+| B.cs:16:18:16:29 | object creation of type Box2 : Box2 [field box1, field elem2] : Elem | semmle.label | object creation of type Box2 : Box2 [field box1, field elem2] : Elem |
+| B.cs:16:27:16:28 | access to local variable b1 : Box1 [field elem2] : Elem | semmle.label | access to local variable b1 : Box1 [field elem2] : Elem |
 | B.cs:16:27:16:28 | access to local variable b1 : Box1 [field elem2] : Elem | semmle.label | access to local variable b1 : Box1 [field elem2] : Elem |
 | B.cs:18:14:18:15 | access to local variable b2 : Box2 [field box1, field elem2] : Elem | semmle.label | access to local variable b2 : Box2 [field box1, field elem2] : Elem |
+| B.cs:18:14:18:15 | access to local variable b2 : Box2 [field box1, field elem2] : Elem | semmle.label | access to local variable b2 : Box2 [field box1, field elem2] : Elem |
+| B.cs:18:14:18:20 | access to field box1 : Box1 [field elem2] : Elem | semmle.label | access to field box1 : Box1 [field elem2] : Elem |
 | B.cs:18:14:18:20 | access to field box1 : Box1 [field elem2] : Elem | semmle.label | access to field box1 : Box1 [field elem2] : Elem |
 | B.cs:18:14:18:26 | access to field elem2 | semmle.label | access to field elem2 |
+| B.cs:18:14:18:26 | access to field elem2 | semmle.label | access to field elem2 |
+| B.cs:29:26:29:27 | e1 : Elem | semmle.label | e1 : Elem |
 | B.cs:29:26:29:27 | e1 : Elem | semmle.label | e1 : Elem |
 | B.cs:29:35:29:36 | e2 : Elem | semmle.label | e2 : Elem |
+| B.cs:29:35:29:36 | e2 : Elem | semmle.label | e2 : Elem |
+| B.cs:31:13:31:16 | [post] this access : Box1 [field elem1] : Elem | semmle.label | [post] this access : Box1 [field elem1] : Elem |
 | B.cs:31:13:31:16 | [post] this access : Box1 [field elem1] : Elem | semmle.label | [post] this access : Box1 [field elem1] : Elem |
 | B.cs:31:26:31:27 | access to parameter e1 : Elem | semmle.label | access to parameter e1 : Elem |
+| B.cs:31:26:31:27 | access to parameter e1 : Elem | semmle.label | access to parameter e1 : Elem |
+| B.cs:32:13:32:16 | [post] this access : Box1 [field elem2] : Elem | semmle.label | [post] this access : Box1 [field elem2] : Elem |
 | B.cs:32:13:32:16 | [post] this access : Box1 [field elem2] : Elem | semmle.label | [post] this access : Box1 [field elem2] : Elem |
 | B.cs:32:26:32:27 | access to parameter e2 : Elem | semmle.label | access to parameter e2 : Elem |
+| B.cs:32:26:32:27 | access to parameter e2 : Elem | semmle.label | access to parameter e2 : Elem |
+| B.cs:39:26:39:27 | b1 : Box1 [field elem1] : Elem | semmle.label | b1 : Box1 [field elem1] : Elem |
 | B.cs:39:26:39:27 | b1 : Box1 [field elem1] : Elem | semmle.label | b1 : Box1 [field elem1] : Elem |
 | B.cs:39:26:39:27 | b1 : Box1 [field elem2] : Elem | semmle.label | b1 : Box1 [field elem2] : Elem |
+| B.cs:39:26:39:27 | b1 : Box1 [field elem2] : Elem | semmle.label | b1 : Box1 [field elem2] : Elem |
+| B.cs:41:13:41:16 | [post] this access : Box2 [field box1, field elem1] : Elem | semmle.label | [post] this access : Box2 [field box1, field elem1] : Elem |
 | B.cs:41:13:41:16 | [post] this access : Box2 [field box1, field elem1] : Elem | semmle.label | [post] this access : Box2 [field box1, field elem1] : Elem |
 | B.cs:41:13:41:16 | [post] this access : Box2 [field box1, field elem2] : Elem | semmle.label | [post] this access : Box2 [field box1, field elem2] : Elem |
+| B.cs:41:13:41:16 | [post] this access : Box2 [field box1, field elem2] : Elem | semmle.label | [post] this access : Box2 [field box1, field elem2] : Elem |
+| B.cs:41:25:41:26 | access to parameter b1 : Box1 [field elem1] : Elem | semmle.label | access to parameter b1 : Box1 [field elem1] : Elem |
 | B.cs:41:25:41:26 | access to parameter b1 : Box1 [field elem1] : Elem | semmle.label | access to parameter b1 : Box1 [field elem1] : Elem |
 | B.cs:41:25:41:26 | access to parameter b1 : Box1 [field elem2] : Elem | semmle.label | access to parameter b1 : Box1 [field elem2] : Elem |
+| B.cs:41:25:41:26 | access to parameter b1 : Box1 [field elem2] : Elem | semmle.label | access to parameter b1 : Box1 [field elem2] : Elem |
+| C.cs:3:18:3:19 | [post] this access : C [field s1] : Elem | semmle.label | [post] this access : C [field s1] : Elem |
 | C.cs:3:18:3:19 | [post] this access : C [field s1] : Elem | semmle.label | [post] this access : C [field s1] : Elem |
 | C.cs:3:23:3:37 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
+| C.cs:3:23:3:37 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
+| C.cs:4:27:4:28 | [post] this access : C [field s2] : Elem | semmle.label | [post] this access : C [field s2] : Elem |
 | C.cs:4:27:4:28 | [post] this access : C [field s2] : Elem | semmle.label | [post] this access : C [field s2] : Elem |
 | C.cs:4:32:4:46 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
+| C.cs:4:32:4:46 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
+| C.cs:6:30:6:44 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
 | C.cs:6:30:6:44 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
 | C.cs:7:18:7:19 | [post] this access : C [property s5] : Elem | semmle.label | [post] this access : C [property s5] : Elem |
+| C.cs:7:18:7:19 | [post] this access : C [property s5] : Elem | semmle.label | [post] this access : C [property s5] : Elem |
+| C.cs:7:37:7:51 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
 | C.cs:7:37:7:51 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
 | C.cs:8:30:8:44 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
+| C.cs:8:30:8:44 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
+| C.cs:12:15:12:21 | object creation of type C : C [field s1] : Elem | semmle.label | object creation of type C : C [field s1] : Elem |
 | C.cs:12:15:12:21 | object creation of type C : C [field s1] : Elem | semmle.label | object creation of type C : C [field s1] : Elem |
 | C.cs:12:15:12:21 | object creation of type C : C [field s2] : Elem | semmle.label | object creation of type C : C [field s2] : Elem |
+| C.cs:12:15:12:21 | object creation of type C : C [field s2] : Elem | semmle.label | object creation of type C : C [field s2] : Elem |
+| C.cs:12:15:12:21 | object creation of type C : C [field s3] : Elem | semmle.label | object creation of type C : C [field s3] : Elem |
 | C.cs:12:15:12:21 | object creation of type C : C [field s3] : Elem | semmle.label | object creation of type C : C [field s3] : Elem |
 | C.cs:12:15:12:21 | object creation of type C : C [property s5] : Elem | semmle.label | object creation of type C : C [property s5] : Elem |
+| C.cs:12:15:12:21 | object creation of type C : C [property s5] : Elem | semmle.label | object creation of type C : C [property s5] : Elem |
+| C.cs:13:9:13:9 | access to local variable c : C [field s1] : Elem | semmle.label | access to local variable c : C [field s1] : Elem |
 | C.cs:13:9:13:9 | access to local variable c : C [field s1] : Elem | semmle.label | access to local variable c : C [field s1] : Elem |
 | C.cs:13:9:13:9 | access to local variable c : C [field s2] : Elem | semmle.label | access to local variable c : C [field s2] : Elem |
+| C.cs:13:9:13:9 | access to local variable c : C [field s2] : Elem | semmle.label | access to local variable c : C [field s2] : Elem |
+| C.cs:13:9:13:9 | access to local variable c : C [field s3] : Elem | semmle.label | access to local variable c : C [field s3] : Elem |
 | C.cs:13:9:13:9 | access to local variable c : C [field s3] : Elem | semmle.label | access to local variable c : C [field s3] : Elem |
 | C.cs:13:9:13:9 | access to local variable c : C [property s5] : Elem | semmle.label | access to local variable c : C [property s5] : Elem |
+| C.cs:13:9:13:9 | access to local variable c : C [property s5] : Elem | semmle.label | access to local variable c : C [property s5] : Elem |
+| C.cs:18:9:18:12 | [post] this access : C [field s3] : Elem | semmle.label | [post] this access : C [field s3] : Elem |
 | C.cs:18:9:18:12 | [post] this access : C [field s3] : Elem | semmle.label | [post] this access : C [field s3] : Elem |
 | C.cs:18:19:18:33 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
+| C.cs:18:19:18:33 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
+| C.cs:21:17:21:18 | this : C [field s1] : Elem | semmle.label | this : C [field s1] : Elem |
 | C.cs:21:17:21:18 | this : C [field s1] : Elem | semmle.label | this : C [field s1] : Elem |
 | C.cs:21:17:21:18 | this : C [field s2] : Elem | semmle.label | this : C [field s2] : Elem |
+| C.cs:21:17:21:18 | this : C [field s2] : Elem | semmle.label | this : C [field s2] : Elem |
+| C.cs:21:17:21:18 | this : C [field s3] : Elem | semmle.label | this : C [field s3] : Elem |
 | C.cs:21:17:21:18 | this : C [field s3] : Elem | semmle.label | this : C [field s3] : Elem |
 | C.cs:21:17:21:18 | this : C [property s5] : Elem | semmle.label | this : C [property s5] : Elem |
+| C.cs:21:17:21:18 | this : C [property s5] : Elem | semmle.label | this : C [property s5] : Elem |
+| C.cs:23:14:23:15 | access to field s1 | semmle.label | access to field s1 |
 | C.cs:23:14:23:15 | access to field s1 | semmle.label | access to field s1 |
 | C.cs:23:14:23:15 | this access : C [field s1] : Elem | semmle.label | this access : C [field s1] : Elem |
+| C.cs:23:14:23:15 | this access : C [field s1] : Elem | semmle.label | this access : C [field s1] : Elem |
+| C.cs:24:14:24:15 | access to field s2 | semmle.label | access to field s2 |
 | C.cs:24:14:24:15 | access to field s2 | semmle.label | access to field s2 |
 | C.cs:24:14:24:15 | this access : C [field s2] : Elem | semmle.label | this access : C [field s2] : Elem |
+| C.cs:24:14:24:15 | this access : C [field s2] : Elem | semmle.label | this access : C [field s2] : Elem |
+| C.cs:25:14:25:15 | access to field s3 | semmle.label | access to field s3 |
 | C.cs:25:14:25:15 | access to field s3 | semmle.label | access to field s3 |
 | C.cs:25:14:25:15 | this access : C [field s3] : Elem | semmle.label | this access : C [field s3] : Elem |
+| C.cs:25:14:25:15 | this access : C [field s3] : Elem | semmle.label | this access : C [field s3] : Elem |
+| C.cs:26:14:26:15 | access to field s4 | semmle.label | access to field s4 |
 | C.cs:26:14:26:15 | access to field s4 | semmle.label | access to field s4 |
 | C.cs:27:14:27:15 | access to property s5 | semmle.label | access to property s5 |
+| C.cs:27:14:27:15 | access to property s5 | semmle.label | access to property s5 |
+| C.cs:27:14:27:15 | this access : C [property s5] : Elem | semmle.label | this access : C [property s5] : Elem |
 | C.cs:27:14:27:15 | this access : C [property s5] : Elem | semmle.label | this access : C [property s5] : Elem |
 | C.cs:28:14:28:15 | access to property s6 | semmle.label | access to property s6 |
+| C.cs:28:14:28:15 | access to property s6 | semmle.label | access to property s6 |
+| C_ctor.cs:3:18:3:19 | [post] this access : C_no_ctor [field s1] : Elem | semmle.label | [post] this access : C_no_ctor [field s1] : Elem |
 | C_ctor.cs:3:18:3:19 | [post] this access : C_no_ctor [field s1] : Elem | semmle.label | [post] this access : C_no_ctor [field s1] : Elem |
 | C_ctor.cs:3:23:3:42 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
+| C_ctor.cs:3:23:3:42 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
+| C_ctor.cs:7:23:7:37 | object creation of type C_no_ctor : C_no_ctor [field s1] : Elem | semmle.label | object creation of type C_no_ctor : C_no_ctor [field s1] : Elem |
 | C_ctor.cs:7:23:7:37 | object creation of type C_no_ctor : C_no_ctor [field s1] : Elem | semmle.label | object creation of type C_no_ctor : C_no_ctor [field s1] : Elem |
 | C_ctor.cs:8:9:8:9 | access to local variable c : C_no_ctor [field s1] : Elem | semmle.label | access to local variable c : C_no_ctor [field s1] : Elem |
+| C_ctor.cs:8:9:8:9 | access to local variable c : C_no_ctor [field s1] : Elem | semmle.label | access to local variable c : C_no_ctor [field s1] : Elem |
+| C_ctor.cs:11:17:11:18 | this : C_no_ctor [field s1] : Elem | semmle.label | this : C_no_ctor [field s1] : Elem |
 | C_ctor.cs:11:17:11:18 | this : C_no_ctor [field s1] : Elem | semmle.label | this : C_no_ctor [field s1] : Elem |
 | C_ctor.cs:13:19:13:20 | access to field s1 | semmle.label | access to field s1 |
+| C_ctor.cs:13:19:13:20 | access to field s1 | semmle.label | access to field s1 |
+| C_ctor.cs:13:19:13:20 | this access : C_no_ctor [field s1] : Elem | semmle.label | this access : C_no_ctor [field s1] : Elem |
 | C_ctor.cs:13:19:13:20 | this access : C_no_ctor [field s1] : Elem | semmle.label | this access : C_no_ctor [field s1] : Elem |
 | C_ctor.cs:19:18:19:19 | [post] this access : C_with_ctor [field s1] : Elem | semmle.label | [post] this access : C_with_ctor [field s1] : Elem |
+| C_ctor.cs:19:18:19:19 | [post] this access : C_with_ctor [field s1] : Elem | semmle.label | [post] this access : C_with_ctor [field s1] : Elem |
+| C_ctor.cs:19:23:19:42 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
 | C_ctor.cs:19:23:19:42 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
 | C_ctor.cs:23:25:23:41 | object creation of type C_with_ctor : C_with_ctor [field s1] : Elem | semmle.label | object creation of type C_with_ctor : C_with_ctor [field s1] : Elem |
+| C_ctor.cs:23:25:23:41 | object creation of type C_with_ctor : C_with_ctor [field s1] : Elem | semmle.label | object creation of type C_with_ctor : C_with_ctor [field s1] : Elem |
+| C_ctor.cs:24:9:24:9 | access to local variable c : C_with_ctor [field s1] : Elem | semmle.label | access to local variable c : C_with_ctor [field s1] : Elem |
 | C_ctor.cs:24:9:24:9 | access to local variable c : C_with_ctor [field s1] : Elem | semmle.label | access to local variable c : C_with_ctor [field s1] : Elem |
 | C_ctor.cs:29:17:29:18 | this : C_with_ctor [field s1] : Elem | semmle.label | this : C_with_ctor [field s1] : Elem |
+| C_ctor.cs:29:17:29:18 | this : C_with_ctor [field s1] : Elem | semmle.label | this : C_with_ctor [field s1] : Elem |
+| C_ctor.cs:31:19:31:20 | access to field s1 | semmle.label | access to field s1 |
 | C_ctor.cs:31:19:31:20 | access to field s1 | semmle.label | access to field s1 |
 | C_ctor.cs:31:19:31:20 | this access : C_with_ctor [field s1] : Elem | semmle.label | this access : C_with_ctor [field s1] : Elem |
+| C_ctor.cs:31:19:31:20 | this access : C_with_ctor [field s1] : Elem | semmle.label | this access : C_with_ctor [field s1] : Elem |
+| D.cs:8:9:8:11 | this : D [field trivialPropField] : Object | semmle.label | this : D [field trivialPropField] : Object |
 | D.cs:8:9:8:11 | this : D [field trivialPropField] : Object | semmle.label | this : D [field trivialPropField] : Object |
 | D.cs:8:22:8:25 | this access : D [field trivialPropField] : Object | semmle.label | this access : D [field trivialPropField] : Object |
+| D.cs:8:22:8:25 | this access : D [field trivialPropField] : Object | semmle.label | this access : D [field trivialPropField] : Object |
+| D.cs:8:22:8:42 | access to field trivialPropField : Object | semmle.label | access to field trivialPropField : Object |
 | D.cs:8:22:8:42 | access to field trivialPropField : Object | semmle.label | access to field trivialPropField : Object |
 | D.cs:9:9:9:11 | value : Object | semmle.label | value : Object |
+| D.cs:9:9:9:11 | value : Object | semmle.label | value : Object |
+| D.cs:9:15:9:18 | [post] this access : D [field trivialPropField] : Object | semmle.label | [post] this access : D [field trivialPropField] : Object |
 | D.cs:9:15:9:18 | [post] this access : D [field trivialPropField] : Object | semmle.label | [post] this access : D [field trivialPropField] : Object |
 | D.cs:9:39:9:43 | access to parameter value : Object | semmle.label | access to parameter value : Object |
+| D.cs:9:39:9:43 | access to parameter value : Object | semmle.label | access to parameter value : Object |
+| D.cs:14:9:14:11 | this : D [field trivialPropField] : Object | semmle.label | this : D [field trivialPropField] : Object |
 | D.cs:14:9:14:11 | this : D [field trivialPropField] : Object | semmle.label | this : D [field trivialPropField] : Object |
 | D.cs:14:22:14:25 | this access : D [field trivialPropField] : Object | semmle.label | this access : D [field trivialPropField] : Object |
+| D.cs:14:22:14:25 | this access : D [field trivialPropField] : Object | semmle.label | this access : D [field trivialPropField] : Object |
+| D.cs:14:22:14:42 | access to field trivialPropField : Object | semmle.label | access to field trivialPropField : Object |
 | D.cs:14:22:14:42 | access to field trivialPropField : Object | semmle.label | access to field trivialPropField : Object |
 | D.cs:15:9:15:11 | value : Object | semmle.label | value : Object |
+| D.cs:15:9:15:11 | value : Object | semmle.label | value : Object |
+| D.cs:15:15:15:18 | [post] this access : D [field trivialPropField] : Object | semmle.label | [post] this access : D [field trivialPropField] : Object |
 | D.cs:15:15:15:18 | [post] this access : D [field trivialPropField] : Object | semmle.label | [post] this access : D [field trivialPropField] : Object |
 | D.cs:15:34:15:38 | access to parameter value : Object | semmle.label | access to parameter value : Object |
+| D.cs:15:34:15:38 | access to parameter value : Object | semmle.label | access to parameter value : Object |
+| D.cs:18:28:18:29 | o1 : Object | semmle.label | o1 : Object |
 | D.cs:18:28:18:29 | o1 : Object | semmle.label | o1 : Object |
 | D.cs:18:39:18:40 | o2 : Object | semmle.label | o2 : Object |
+| D.cs:18:39:18:40 | o2 : Object | semmle.label | o2 : Object |
+| D.cs:18:50:18:51 | o3 : Object | semmle.label | o3 : Object |
 | D.cs:18:50:18:51 | o3 : Object | semmle.label | o3 : Object |
 | D.cs:21:9:21:11 | [post] access to local variable ret : D [property AutoProp] : Object | semmle.label | [post] access to local variable ret : D [property AutoProp] : Object |
+| D.cs:21:9:21:11 | [post] access to local variable ret : D [property AutoProp] : Object | semmle.label | [post] access to local variable ret : D [property AutoProp] : Object |
+| D.cs:21:24:21:25 | access to parameter o1 : Object | semmle.label | access to parameter o1 : Object |
 | D.cs:21:24:21:25 | access to parameter o1 : Object | semmle.label | access to parameter o1 : Object |
 | D.cs:22:9:22:11 | [post] access to local variable ret : D [field trivialPropField] : Object | semmle.label | [post] access to local variable ret : D [field trivialPropField] : Object |
+| D.cs:22:9:22:11 | [post] access to local variable ret : D [field trivialPropField] : Object | semmle.label | [post] access to local variable ret : D [field trivialPropField] : Object |
+| D.cs:22:27:22:28 | access to parameter o2 : Object | semmle.label | access to parameter o2 : Object |
 | D.cs:22:27:22:28 | access to parameter o2 : Object | semmle.label | access to parameter o2 : Object |
 | D.cs:23:9:23:11 | [post] access to local variable ret : D [field trivialPropField] : Object | semmle.label | [post] access to local variable ret : D [field trivialPropField] : Object |
+| D.cs:23:9:23:11 | [post] access to local variable ret : D [field trivialPropField] : Object | semmle.label | [post] access to local variable ret : D [field trivialPropField] : Object |
+| D.cs:23:27:23:28 | access to parameter o3 : Object | semmle.label | access to parameter o3 : Object |
 | D.cs:23:27:23:28 | access to parameter o3 : Object | semmle.label | access to parameter o3 : Object |
 | D.cs:24:16:24:18 | access to local variable ret : D [field trivialPropField] : Object | semmle.label | access to local variable ret : D [field trivialPropField] : Object |
 | D.cs:24:16:24:18 | access to local variable ret : D [field trivialPropField] : Object | semmle.label | access to local variable ret : D [field trivialPropField] : Object |
+| D.cs:24:16:24:18 | access to local variable ret : D [field trivialPropField] : Object | semmle.label | access to local variable ret : D [field trivialPropField] : Object |
+| D.cs:24:16:24:18 | access to local variable ret : D [field trivialPropField] : Object | semmle.label | access to local variable ret : D [field trivialPropField] : Object |
+| D.cs:24:16:24:18 | access to local variable ret : D [property AutoProp] : Object | semmle.label | access to local variable ret : D [property AutoProp] : Object |
 | D.cs:24:16:24:18 | access to local variable ret : D [property AutoProp] : Object | semmle.label | access to local variable ret : D [property AutoProp] : Object |
 | D.cs:29:17:29:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| D.cs:29:17:29:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| D.cs:31:17:31:37 | call to method Create : D [property AutoProp] : Object | semmle.label | call to method Create : D [property AutoProp] : Object |
 | D.cs:31:17:31:37 | call to method Create : D [property AutoProp] : Object | semmle.label | call to method Create : D [property AutoProp] : Object |
 | D.cs:31:24:31:24 | access to local variable o : Object | semmle.label | access to local variable o : Object |
+| D.cs:31:24:31:24 | access to local variable o : Object | semmle.label | access to local variable o : Object |
+| D.cs:32:14:32:14 | access to local variable d : D [property AutoProp] : Object | semmle.label | access to local variable d : D [property AutoProp] : Object |
 | D.cs:32:14:32:14 | access to local variable d : D [property AutoProp] : Object | semmle.label | access to local variable d : D [property AutoProp] : Object |
 | D.cs:32:14:32:23 | access to property AutoProp | semmle.label | access to property AutoProp |
+| D.cs:32:14:32:23 | access to property AutoProp | semmle.label | access to property AutoProp |
+| D.cs:37:13:37:49 | call to method Create : D [field trivialPropField] : Object | semmle.label | call to method Create : D [field trivialPropField] : Object |
 | D.cs:37:13:37:49 | call to method Create : D [field trivialPropField] : Object | semmle.label | call to method Create : D [field trivialPropField] : Object |
 | D.cs:37:26:37:42 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| D.cs:37:26:37:42 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| D.cs:39:14:39:14 | access to local variable d : D [field trivialPropField] : Object | semmle.label | access to local variable d : D [field trivialPropField] : Object |
 | D.cs:39:14:39:14 | access to local variable d : D [field trivialPropField] : Object | semmle.label | access to local variable d : D [field trivialPropField] : Object |
 | D.cs:39:14:39:26 | access to property TrivialProp | semmle.label | access to property TrivialProp |
+| D.cs:39:14:39:26 | access to property TrivialProp | semmle.label | access to property TrivialProp |
+| D.cs:40:14:40:14 | access to local variable d : D [field trivialPropField] : Object | semmle.label | access to local variable d : D [field trivialPropField] : Object |
 | D.cs:40:14:40:14 | access to local variable d : D [field trivialPropField] : Object | semmle.label | access to local variable d : D [field trivialPropField] : Object |
 | D.cs:40:14:40:31 | access to field trivialPropField | semmle.label | access to field trivialPropField |
+| D.cs:40:14:40:31 | access to field trivialPropField | semmle.label | access to field trivialPropField |
+| D.cs:41:14:41:14 | access to local variable d : D [field trivialPropField] : Object | semmle.label | access to local variable d : D [field trivialPropField] : Object |
 | D.cs:41:14:41:14 | access to local variable d : D [field trivialPropField] : Object | semmle.label | access to local variable d : D [field trivialPropField] : Object |
 | D.cs:41:14:41:26 | access to property ComplexProp | semmle.label | access to property ComplexProp |
+| D.cs:41:14:41:26 | access to property ComplexProp | semmle.label | access to property ComplexProp |
+| D.cs:43:13:43:49 | call to method Create : D [field trivialPropField] : Object | semmle.label | call to method Create : D [field trivialPropField] : Object |
 | D.cs:43:13:43:49 | call to method Create : D [field trivialPropField] : Object | semmle.label | call to method Create : D [field trivialPropField] : Object |
 | D.cs:43:32:43:48 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| D.cs:43:32:43:48 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| D.cs:45:14:45:14 | access to local variable d : D [field trivialPropField] : Object | semmle.label | access to local variable d : D [field trivialPropField] : Object |
 | D.cs:45:14:45:14 | access to local variable d : D [field trivialPropField] : Object | semmle.label | access to local variable d : D [field trivialPropField] : Object |
 | D.cs:45:14:45:26 | access to property TrivialProp | semmle.label | access to property TrivialProp |
+| D.cs:45:14:45:26 | access to property TrivialProp | semmle.label | access to property TrivialProp |
+| D.cs:46:14:46:14 | access to local variable d : D [field trivialPropField] : Object | semmle.label | access to local variable d : D [field trivialPropField] : Object |
 | D.cs:46:14:46:14 | access to local variable d : D [field trivialPropField] : Object | semmle.label | access to local variable d : D [field trivialPropField] : Object |
 | D.cs:46:14:46:31 | access to field trivialPropField | semmle.label | access to field trivialPropField |
+| D.cs:46:14:46:31 | access to field trivialPropField | semmle.label | access to field trivialPropField |
+| D.cs:47:14:47:14 | access to local variable d : D [field trivialPropField] : Object | semmle.label | access to local variable d : D [field trivialPropField] : Object |
 | D.cs:47:14:47:14 | access to local variable d : D [field trivialPropField] : Object | semmle.label | access to local variable d : D [field trivialPropField] : Object |
 | D.cs:47:14:47:26 | access to property ComplexProp | semmle.label | access to property ComplexProp |
+| D.cs:47:14:47:26 | access to property ComplexProp | semmle.label | access to property ComplexProp |
+| E.cs:8:29:8:29 | o : Object | semmle.label | o : Object |
 | E.cs:8:29:8:29 | o : Object | semmle.label | o : Object |
 | E.cs:11:9:11:11 | [post] access to local variable ret : S [field Field] : Object | semmle.label | [post] access to local variable ret : S [field Field] : Object |
+| E.cs:11:9:11:11 | [post] access to local variable ret : S [field Field] : Object | semmle.label | [post] access to local variable ret : S [field Field] : Object |
+| E.cs:11:21:11:21 | access to parameter o : Object | semmle.label | access to parameter o : Object |
 | E.cs:11:21:11:21 | access to parameter o : Object | semmle.label | access to parameter o : Object |
 | E.cs:12:16:12:18 | access to local variable ret : S [field Field] : Object | semmle.label | access to local variable ret : S [field Field] : Object |
+| E.cs:12:16:12:18 | access to local variable ret : S [field Field] : Object | semmle.label | access to local variable ret : S [field Field] : Object |
+| E.cs:22:17:22:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
 | E.cs:22:17:22:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
 | E.cs:23:17:23:26 | call to method CreateS : S [field Field] : Object | semmle.label | call to method CreateS : S [field Field] : Object |
+| E.cs:23:17:23:26 | call to method CreateS : S [field Field] : Object | semmle.label | call to method CreateS : S [field Field] : Object |
+| E.cs:23:25:23:25 | access to local variable o : Object | semmle.label | access to local variable o : Object |
 | E.cs:23:25:23:25 | access to local variable o : Object | semmle.label | access to local variable o : Object |
 | E.cs:24:14:24:14 | access to local variable s : S [field Field] : Object | semmle.label | access to local variable s : S [field Field] : Object |
+| E.cs:24:14:24:14 | access to local variable s : S [field Field] : Object | semmle.label | access to local variable s : S [field Field] : Object |
+| E.cs:24:14:24:20 | access to field Field | semmle.label | access to field Field |
 | E.cs:24:14:24:20 | access to field Field | semmle.label | access to field Field |
 | F.cs:6:28:6:29 | o1 : Object | semmle.label | o1 : Object |
+| F.cs:6:28:6:29 | o1 : Object | semmle.label | o1 : Object |
+| F.cs:6:39:6:40 | o2 : Object | semmle.label | o2 : Object |
 | F.cs:6:39:6:40 | o2 : Object | semmle.label | o2 : Object |
 | F.cs:6:46:6:81 | object creation of type F : F [field Field1] : Object | semmle.label | object creation of type F : F [field Field1] : Object |
+| F.cs:6:46:6:81 | object creation of type F : F [field Field1] : Object | semmle.label | object creation of type F : F [field Field1] : Object |
+| F.cs:6:46:6:81 | object creation of type F : F [field Field2] : Object | semmle.label | object creation of type F : F [field Field2] : Object |
 | F.cs:6:46:6:81 | object creation of type F : F [field Field2] : Object | semmle.label | object creation of type F : F [field Field2] : Object |
 | F.cs:6:54:6:81 | { ..., ... } : F [field Field1] : Object | semmle.label | { ..., ... } : F [field Field1] : Object |
+| F.cs:6:54:6:81 | { ..., ... } : F [field Field1] : Object | semmle.label | { ..., ... } : F [field Field1] : Object |
+| F.cs:6:54:6:81 | { ..., ... } : F [field Field2] : Object | semmle.label | { ..., ... } : F [field Field2] : Object |
 | F.cs:6:54:6:81 | { ..., ... } : F [field Field2] : Object | semmle.label | { ..., ... } : F [field Field2] : Object |
 | F.cs:6:65:6:66 | access to parameter o1 : Object | semmle.label | access to parameter o1 : Object |
+| F.cs:6:65:6:66 | access to parameter o1 : Object | semmle.label | access to parameter o1 : Object |
+| F.cs:6:78:6:79 | access to parameter o2 : Object | semmle.label | access to parameter o2 : Object |
 | F.cs:6:78:6:79 | access to parameter o2 : Object | semmle.label | access to parameter o2 : Object |
 | F.cs:10:17:10:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| F.cs:10:17:10:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| F.cs:11:17:11:31 | call to method Create : F [field Field1] : Object | semmle.label | call to method Create : F [field Field1] : Object |
 | F.cs:11:17:11:31 | call to method Create : F [field Field1] : Object | semmle.label | call to method Create : F [field Field1] : Object |
 | F.cs:11:24:11:24 | access to local variable o : Object | semmle.label | access to local variable o : Object |
+| F.cs:11:24:11:24 | access to local variable o : Object | semmle.label | access to local variable o : Object |
+| F.cs:12:14:12:14 | access to local variable f : F [field Field1] : Object | semmle.label | access to local variable f : F [field Field1] : Object |
 | F.cs:12:14:12:14 | access to local variable f : F [field Field1] : Object | semmle.label | access to local variable f : F [field Field1] : Object |
 | F.cs:12:14:12:21 | access to field Field1 | semmle.label | access to field Field1 |
+| F.cs:12:14:12:21 | access to field Field1 | semmle.label | access to field Field1 |
+| F.cs:15:13:15:43 | call to method Create : F [field Field2] : Object | semmle.label | call to method Create : F [field Field2] : Object |
 | F.cs:15:13:15:43 | call to method Create : F [field Field2] : Object | semmle.label | call to method Create : F [field Field2] : Object |
 | F.cs:15:26:15:42 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| F.cs:15:26:15:42 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| F.cs:17:14:17:14 | access to local variable f : F [field Field2] : Object | semmle.label | access to local variable f : F [field Field2] : Object |
 | F.cs:17:14:17:14 | access to local variable f : F [field Field2] : Object | semmle.label | access to local variable f : F [field Field2] : Object |
 | F.cs:17:14:17:21 | access to field Field2 | semmle.label | access to field Field2 |
+| F.cs:17:14:17:21 | access to field Field2 | semmle.label | access to field Field2 |
+| F.cs:19:21:19:50 | { ..., ... } : F [field Field1] : Object | semmle.label | { ..., ... } : F [field Field1] : Object |
 | F.cs:19:21:19:50 | { ..., ... } : F [field Field1] : Object | semmle.label | { ..., ... } : F [field Field1] : Object |
 | F.cs:19:32:19:48 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| F.cs:19:32:19:48 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| F.cs:20:14:20:14 | access to local variable f : F [field Field1] : Object | semmle.label | access to local variable f : F [field Field1] : Object |
 | F.cs:20:14:20:14 | access to local variable f : F [field Field1] : Object | semmle.label | access to local variable f : F [field Field1] : Object |
 | F.cs:20:14:20:21 | access to field Field1 | semmle.label | access to field Field1 |
+| F.cs:20:14:20:21 | access to field Field1 | semmle.label | access to field Field1 |
+| F.cs:23:21:23:50 | { ..., ... } : F [field Field2] : Object | semmle.label | { ..., ... } : F [field Field2] : Object |
 | F.cs:23:21:23:50 | { ..., ... } : F [field Field2] : Object | semmle.label | { ..., ... } : F [field Field2] : Object |
 | F.cs:23:32:23:48 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| F.cs:23:32:23:48 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| F.cs:25:14:25:14 | access to local variable f : F [field Field2] : Object | semmle.label | access to local variable f : F [field Field2] : Object |
 | F.cs:25:14:25:14 | access to local variable f : F [field Field2] : Object | semmle.label | access to local variable f : F [field Field2] : Object |
 | F.cs:25:14:25:21 | access to field Field2 | semmle.label | access to field Field2 |
+| F.cs:25:14:25:21 | access to field Field2 | semmle.label | access to field Field2 |
+| F.cs:30:17:30:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
 | F.cs:30:17:30:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
 | F.cs:32:17:32:40 | { ..., ... } : <>__AnonType0<Object,Object> [property X] : Object | semmle.label | { ..., ... } : <>__AnonType0<Object,Object> [property X] : Object |
+| F.cs:32:17:32:40 | { ..., ... } : <>__AnonType0<Object,Object> [property X] : Object | semmle.label | { ..., ... } : <>__AnonType0<Object,Object> [property X] : Object |
+| F.cs:32:27:32:27 | access to local variable o : Object | semmle.label | access to local variable o : Object |
 | F.cs:32:27:32:27 | access to local variable o : Object | semmle.label | access to local variable o : Object |
 | F.cs:33:14:33:14 | access to local variable a : <>__AnonType0<Object,Object> [property X] : Object | semmle.label | access to local variable a : <>__AnonType0<Object,Object> [property X] : Object |
+| F.cs:33:14:33:14 | access to local variable a : <>__AnonType0<Object,Object> [property X] : Object | semmle.label | access to local variable a : <>__AnonType0<Object,Object> [property X] : Object |
+| F.cs:33:14:33:16 | access to property X | semmle.label | access to property X |
 | F.cs:33:14:33:16 | access to property X | semmle.label | access to property X |
 | G.cs:7:18:7:32 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
+| G.cs:7:18:7:32 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
+| G.cs:9:9:9:9 | [post] access to local variable b : Box2 [field Box1, field Elem] : Elem | semmle.label | [post] access to local variable b : Box2 [field Box1, field Elem] : Elem |
 | G.cs:9:9:9:9 | [post] access to local variable b : Box2 [field Box1, field Elem] : Elem | semmle.label | [post] access to local variable b : Box2 [field Box1, field Elem] : Elem |
 | G.cs:9:9:9:14 | [post] access to field Box1 : Box1 [field Elem] : Elem | semmle.label | [post] access to field Box1 : Box1 [field Elem] : Elem |
+| G.cs:9:9:9:14 | [post] access to field Box1 : Box1 [field Elem] : Elem | semmle.label | [post] access to field Box1 : Box1 [field Elem] : Elem |
+| G.cs:9:23:9:23 | access to local variable e : Elem | semmle.label | access to local variable e : Elem |
 | G.cs:9:23:9:23 | access to local variable e : Elem | semmle.label | access to local variable e : Elem |
 | G.cs:10:18:10:18 | access to local variable b : Box2 [field Box1, field Elem] : Elem | semmle.label | access to local variable b : Box2 [field Box1, field Elem] : Elem |
+| G.cs:10:18:10:18 | access to local variable b : Box2 [field Box1, field Elem] : Elem | semmle.label | access to local variable b : Box2 [field Box1, field Elem] : Elem |
+| G.cs:15:18:15:32 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
 | G.cs:15:18:15:32 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
 | G.cs:17:9:17:9 | [post] access to local variable b : Box2 [field Box1, field Elem] : Elem | semmle.label | [post] access to local variable b : Box2 [field Box1, field Elem] : Elem |
+| G.cs:17:9:17:9 | [post] access to local variable b : Box2 [field Box1, field Elem] : Elem | semmle.label | [post] access to local variable b : Box2 [field Box1, field Elem] : Elem |
+| G.cs:17:9:17:14 | [post] access to field Box1 : Box1 [field Elem] : Elem | semmle.label | [post] access to field Box1 : Box1 [field Elem] : Elem |
 | G.cs:17:9:17:14 | [post] access to field Box1 : Box1 [field Elem] : Elem | semmle.label | [post] access to field Box1 : Box1 [field Elem] : Elem |
 | G.cs:17:24:17:24 | access to local variable e : Elem | semmle.label | access to local variable e : Elem |
+| G.cs:17:24:17:24 | access to local variable e : Elem | semmle.label | access to local variable e : Elem |
+| G.cs:18:18:18:18 | access to local variable b : Box2 [field Box1, field Elem] : Elem | semmle.label | access to local variable b : Box2 [field Box1, field Elem] : Elem |
 | G.cs:18:18:18:18 | access to local variable b : Box2 [field Box1, field Elem] : Elem | semmle.label | access to local variable b : Box2 [field Box1, field Elem] : Elem |
 | G.cs:23:18:23:32 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
+| G.cs:23:18:23:32 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
+| G.cs:25:9:25:9 | [post] access to local variable b : Box2 [field Box1, field Elem] : Elem | semmle.label | [post] access to local variable b : Box2 [field Box1, field Elem] : Elem |
 | G.cs:25:9:25:9 | [post] access to local variable b : Box2 [field Box1, field Elem] : Elem | semmle.label | [post] access to local variable b : Box2 [field Box1, field Elem] : Elem |
 | G.cs:25:9:25:19 | [post] call to method GetBox1 : Box1 [field Elem] : Elem | semmle.label | [post] call to method GetBox1 : Box1 [field Elem] : Elem |
+| G.cs:25:9:25:19 | [post] call to method GetBox1 : Box1 [field Elem] : Elem | semmle.label | [post] call to method GetBox1 : Box1 [field Elem] : Elem |
+| G.cs:25:28:25:28 | access to local variable e : Elem | semmle.label | access to local variable e : Elem |
 | G.cs:25:28:25:28 | access to local variable e : Elem | semmle.label | access to local variable e : Elem |
 | G.cs:26:18:26:18 | access to local variable b : Box2 [field Box1, field Elem] : Elem | semmle.label | access to local variable b : Box2 [field Box1, field Elem] : Elem |
+| G.cs:26:18:26:18 | access to local variable b : Box2 [field Box1, field Elem] : Elem | semmle.label | access to local variable b : Box2 [field Box1, field Elem] : Elem |
+| G.cs:31:18:31:32 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
 | G.cs:31:18:31:32 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
 | G.cs:33:9:33:9 | [post] access to local variable b : Box2 [field Box1, field Elem] : Elem | semmle.label | [post] access to local variable b : Box2 [field Box1, field Elem] : Elem |
+| G.cs:33:9:33:9 | [post] access to local variable b : Box2 [field Box1, field Elem] : Elem | semmle.label | [post] access to local variable b : Box2 [field Box1, field Elem] : Elem |
+| G.cs:33:9:33:19 | [post] call to method GetBox1 : Box1 [field Elem] : Elem | semmle.label | [post] call to method GetBox1 : Box1 [field Elem] : Elem |
 | G.cs:33:9:33:19 | [post] call to method GetBox1 : Box1 [field Elem] : Elem | semmle.label | [post] call to method GetBox1 : Box1 [field Elem] : Elem |
 | G.cs:33:29:33:29 | access to local variable e : Elem | semmle.label | access to local variable e : Elem |
+| G.cs:33:29:33:29 | access to local variable e : Elem | semmle.label | access to local variable e : Elem |
+| G.cs:34:18:34:18 | access to local variable b : Box2 [field Box1, field Elem] : Elem | semmle.label | access to local variable b : Box2 [field Box1, field Elem] : Elem |
 | G.cs:34:18:34:18 | access to local variable b : Box2 [field Box1, field Elem] : Elem | semmle.label | access to local variable b : Box2 [field Box1, field Elem] : Elem |
 | G.cs:37:38:37:39 | b2 : Box2 [field Box1, field Elem] : Elem | semmle.label | b2 : Box2 [field Box1, field Elem] : Elem |
+| G.cs:37:38:37:39 | b2 : Box2 [field Box1, field Elem] : Elem | semmle.label | b2 : Box2 [field Box1, field Elem] : Elem |
+| G.cs:39:14:39:15 | access to parameter b2 : Box2 [field Box1, field Elem] : Elem | semmle.label | access to parameter b2 : Box2 [field Box1, field Elem] : Elem |
 | G.cs:39:14:39:15 | access to parameter b2 : Box2 [field Box1, field Elem] : Elem | semmle.label | access to parameter b2 : Box2 [field Box1, field Elem] : Elem |
 | G.cs:39:14:39:25 | call to method GetBox1 : Box1 [field Elem] : Elem | semmle.label | call to method GetBox1 : Box1 [field Elem] : Elem |
+| G.cs:39:14:39:25 | call to method GetBox1 : Box1 [field Elem] : Elem | semmle.label | call to method GetBox1 : Box1 [field Elem] : Elem |
+| G.cs:39:14:39:35 | call to method GetElem | semmle.label | call to method GetElem |
 | G.cs:39:14:39:35 | call to method GetElem | semmle.label | call to method GetElem |
 | G.cs:44:18:44:32 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
+| G.cs:44:18:44:32 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
+| G.cs:46:9:46:16 | [post] access to field boxfield : Box2 [field Box1, field Elem] : Elem | semmle.label | [post] access to field boxfield : Box2 [field Box1, field Elem] : Elem |
 | G.cs:46:9:46:16 | [post] access to field boxfield : Box2 [field Box1, field Elem] : Elem | semmle.label | [post] access to field boxfield : Box2 [field Box1, field Elem] : Elem |
 | G.cs:46:9:46:16 | [post] this access : G [field boxfield, field Box1, field Elem] : Elem | semmle.label | [post] this access : G [field boxfield, field Box1, field Elem] : Elem |
+| G.cs:46:9:46:16 | [post] this access : G [field boxfield, field Box1, field Elem] : Elem | semmle.label | [post] this access : G [field boxfield, field Box1, field Elem] : Elem |
+| G.cs:46:9:46:21 | [post] access to field Box1 : Box1 [field Elem] : Elem | semmle.label | [post] access to field Box1 : Box1 [field Elem] : Elem |
 | G.cs:46:9:46:21 | [post] access to field Box1 : Box1 [field Elem] : Elem | semmle.label | [post] access to field Box1 : Box1 [field Elem] : Elem |
 | G.cs:46:30:46:30 | access to local variable e : Elem | semmle.label | access to local variable e : Elem |
+| G.cs:46:30:46:30 | access to local variable e : Elem | semmle.label | access to local variable e : Elem |
+| G.cs:47:9:47:13 | this access : G [field boxfield, field Box1, field Elem] : Elem | semmle.label | this access : G [field boxfield, field Box1, field Elem] : Elem |
 | G.cs:47:9:47:13 | this access : G [field boxfield, field Box1, field Elem] : Elem | semmle.label | this access : G [field boxfield, field Box1, field Elem] : Elem |
 | G.cs:50:18:50:20 | this : G [field boxfield, field Box1, field Elem] : Elem | semmle.label | this : G [field boxfield, field Box1, field Elem] : Elem |
+| G.cs:50:18:50:20 | this : G [field boxfield, field Box1, field Elem] : Elem | semmle.label | this : G [field boxfield, field Box1, field Elem] : Elem |
+| G.cs:52:14:52:21 | access to field boxfield : Box2 [field Box1, field Elem] : Elem | semmle.label | access to field boxfield : Box2 [field Box1, field Elem] : Elem |
 | G.cs:52:14:52:21 | access to field boxfield : Box2 [field Box1, field Elem] : Elem | semmle.label | access to field boxfield : Box2 [field Box1, field Elem] : Elem |
 | G.cs:52:14:52:21 | this access : G [field boxfield, field Box1, field Elem] : Elem | semmle.label | this access : G [field boxfield, field Box1, field Elem] : Elem |
+| G.cs:52:14:52:21 | this access : G [field boxfield, field Box1, field Elem] : Elem | semmle.label | this access : G [field boxfield, field Box1, field Elem] : Elem |
+| G.cs:52:14:52:26 | access to field Box1 : Box1 [field Elem] : Elem | semmle.label | access to field Box1 : Box1 [field Elem] : Elem |
 | G.cs:52:14:52:26 | access to field Box1 : Box1 [field Elem] : Elem | semmle.label | access to field Box1 : Box1 [field Elem] : Elem |
 | G.cs:52:14:52:31 | access to field Elem | semmle.label | access to field Elem |
+| G.cs:52:14:52:31 | access to field Elem | semmle.label | access to field Elem |
+| G.cs:63:21:63:27 | this : Box1 [field Elem] : Elem | semmle.label | this : Box1 [field Elem] : Elem |
 | G.cs:63:21:63:27 | this : Box1 [field Elem] : Elem | semmle.label | this : Box1 [field Elem] : Elem |
 | G.cs:63:34:63:37 | access to field Elem : Elem | semmle.label | access to field Elem : Elem |
+| G.cs:63:34:63:37 | access to field Elem : Elem | semmle.label | access to field Elem : Elem |
+| G.cs:63:34:63:37 | this access : Box1 [field Elem] : Elem | semmle.label | this access : Box1 [field Elem] : Elem |
 | G.cs:63:34:63:37 | this access : Box1 [field Elem] : Elem | semmle.label | this access : Box1 [field Elem] : Elem |
 | G.cs:64:34:64:34 | e : Elem | semmle.label | e : Elem |
+| G.cs:64:34:64:34 | e : Elem | semmle.label | e : Elem |
+| G.cs:64:39:64:42 | [post] this access : Box1 [field Elem] : Elem | semmle.label | [post] this access : Box1 [field Elem] : Elem |
 | G.cs:64:39:64:42 | [post] this access : Box1 [field Elem] : Elem | semmle.label | [post] this access : Box1 [field Elem] : Elem |
 | G.cs:64:46:64:46 | access to parameter e : Elem | semmle.label | access to parameter e : Elem |
+| G.cs:64:46:64:46 | access to parameter e : Elem | semmle.label | access to parameter e : Elem |
+| G.cs:71:21:71:27 | this : Box2 [field Box1, field Elem] : Elem | semmle.label | this : Box2 [field Box1, field Elem] : Elem |
 | G.cs:71:21:71:27 | this : Box2 [field Box1, field Elem] : Elem | semmle.label | this : Box2 [field Box1, field Elem] : Elem |
 | G.cs:71:34:71:37 | access to field Box1 : Box1 [field Elem] : Elem | semmle.label | access to field Box1 : Box1 [field Elem] : Elem |
+| G.cs:71:34:71:37 | access to field Box1 : Box1 [field Elem] : Elem | semmle.label | access to field Box1 : Box1 [field Elem] : Elem |
+| G.cs:71:34:71:37 | this access : Box2 [field Box1, field Elem] : Elem | semmle.label | this access : Box2 [field Box1, field Elem] : Elem |
 | G.cs:71:34:71:37 | this access : Box2 [field Box1, field Elem] : Elem | semmle.label | this access : Box2 [field Box1, field Elem] : Elem |
 | H.cs:13:15:13:15 | a : A [field FieldA] : Object | semmle.label | a : A [field FieldA] : Object |
+| H.cs:13:15:13:15 | a : A [field FieldA] : Object | semmle.label | a : A [field FieldA] : Object |
+| H.cs:16:9:16:11 | [post] access to local variable ret : A [field FieldA] : Object | semmle.label | [post] access to local variable ret : A [field FieldA] : Object |
 | H.cs:16:9:16:11 | [post] access to local variable ret : A [field FieldA] : Object | semmle.label | [post] access to local variable ret : A [field FieldA] : Object |
 | H.cs:16:22:16:22 | access to parameter a : A [field FieldA] : Object | semmle.label | access to parameter a : A [field FieldA] : Object |
+| H.cs:16:22:16:22 | access to parameter a : A [field FieldA] : Object | semmle.label | access to parameter a : A [field FieldA] : Object |
+| H.cs:16:22:16:29 | access to field FieldA : Object | semmle.label | access to field FieldA : Object |
 | H.cs:16:22:16:29 | access to field FieldA : Object | semmle.label | access to field FieldA : Object |
 | H.cs:17:16:17:18 | access to local variable ret : A [field FieldA] : Object | semmle.label | access to local variable ret : A [field FieldA] : Object |
+| H.cs:17:16:17:18 | access to local variable ret : A [field FieldA] : Object | semmle.label | access to local variable ret : A [field FieldA] : Object |
+| H.cs:23:9:23:9 | [post] access to local variable a : A [field FieldA] : Object | semmle.label | [post] access to local variable a : A [field FieldA] : Object |
 | H.cs:23:9:23:9 | [post] access to local variable a : A [field FieldA] : Object | semmle.label | [post] access to local variable a : A [field FieldA] : Object |
 | H.cs:23:20:23:36 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| H.cs:23:20:23:36 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| H.cs:24:21:24:28 | call to method Clone : A [field FieldA] : Object | semmle.label | call to method Clone : A [field FieldA] : Object |
 | H.cs:24:21:24:28 | call to method Clone : A [field FieldA] : Object | semmle.label | call to method Clone : A [field FieldA] : Object |
 | H.cs:24:27:24:27 | access to local variable a : A [field FieldA] : Object | semmle.label | access to local variable a : A [field FieldA] : Object |
+| H.cs:24:27:24:27 | access to local variable a : A [field FieldA] : Object | semmle.label | access to local variable a : A [field FieldA] : Object |
+| H.cs:25:14:25:18 | access to local variable clone : A [field FieldA] : Object | semmle.label | access to local variable clone : A [field FieldA] : Object |
 | H.cs:25:14:25:18 | access to local variable clone : A [field FieldA] : Object | semmle.label | access to local variable clone : A [field FieldA] : Object |
 | H.cs:25:14:25:25 | access to field FieldA | semmle.label | access to field FieldA |
+| H.cs:25:14:25:25 | access to field FieldA | semmle.label | access to field FieldA |
+| H.cs:33:19:33:19 | a : A [field FieldA] : A | semmle.label | a : A [field FieldA] : A |
 | H.cs:33:19:33:19 | a : A [field FieldA] : A | semmle.label | a : A [field FieldA] : A |
 | H.cs:33:19:33:19 | a : A [field FieldA] : Object | semmle.label | a : A [field FieldA] : Object |
+| H.cs:33:19:33:19 | a : A [field FieldA] : Object | semmle.label | a : A [field FieldA] : Object |
+| H.cs:36:9:36:9 | [post] access to local variable b : B [field FieldB] : A | semmle.label | [post] access to local variable b : B [field FieldB] : A |
 | H.cs:36:9:36:9 | [post] access to local variable b : B [field FieldB] : A | semmle.label | [post] access to local variable b : B [field FieldB] : A |
 | H.cs:36:9:36:9 | [post] access to local variable b : B [field FieldB] : Object | semmle.label | [post] access to local variable b : B [field FieldB] : Object |
+| H.cs:36:9:36:9 | [post] access to local variable b : B [field FieldB] : Object | semmle.label | [post] access to local variable b : B [field FieldB] : Object |
+| H.cs:36:20:36:20 | access to parameter a : A [field FieldA] : A | semmle.label | access to parameter a : A [field FieldA] : A |
 | H.cs:36:20:36:20 | access to parameter a : A [field FieldA] : A | semmle.label | access to parameter a : A [field FieldA] : A |
 | H.cs:36:20:36:20 | access to parameter a : A [field FieldA] : Object | semmle.label | access to parameter a : A [field FieldA] : Object |
+| H.cs:36:20:36:20 | access to parameter a : A [field FieldA] : Object | semmle.label | access to parameter a : A [field FieldA] : Object |
+| H.cs:36:20:36:27 | access to field FieldA : A | semmle.label | access to field FieldA : A |
 | H.cs:36:20:36:27 | access to field FieldA : A | semmle.label | access to field FieldA : A |
 | H.cs:36:20:36:27 | access to field FieldA : Object | semmle.label | access to field FieldA : Object |
+| H.cs:36:20:36:27 | access to field FieldA : Object | semmle.label | access to field FieldA : Object |
+| H.cs:37:16:37:16 | access to local variable b : B [field FieldB] : A | semmle.label | access to local variable b : B [field FieldB] : A |
 | H.cs:37:16:37:16 | access to local variable b : B [field FieldB] : A | semmle.label | access to local variable b : B [field FieldB] : A |
 | H.cs:37:16:37:16 | access to local variable b : B [field FieldB] : Object | semmle.label | access to local variable b : B [field FieldB] : Object |
+| H.cs:37:16:37:16 | access to local variable b : B [field FieldB] : Object | semmle.label | access to local variable b : B [field FieldB] : Object |
+| H.cs:43:9:43:9 | [post] access to local variable a : A [field FieldA] : Object | semmle.label | [post] access to local variable a : A [field FieldA] : Object |
 | H.cs:43:9:43:9 | [post] access to local variable a : A [field FieldA] : Object | semmle.label | [post] access to local variable a : A [field FieldA] : Object |
 | H.cs:43:20:43:36 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| H.cs:43:20:43:36 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| H.cs:44:17:44:28 | call to method Transform : B [field FieldB] : Object | semmle.label | call to method Transform : B [field FieldB] : Object |
 | H.cs:44:17:44:28 | call to method Transform : B [field FieldB] : Object | semmle.label | call to method Transform : B [field FieldB] : Object |
 | H.cs:44:27:44:27 | access to local variable a : A [field FieldA] : Object | semmle.label | access to local variable a : A [field FieldA] : Object |
+| H.cs:44:27:44:27 | access to local variable a : A [field FieldA] : Object | semmle.label | access to local variable a : A [field FieldA] : Object |
+| H.cs:45:14:45:14 | access to local variable b : B [field FieldB] : Object | semmle.label | access to local variable b : B [field FieldB] : Object |
 | H.cs:45:14:45:14 | access to local variable b : B [field FieldB] : Object | semmle.label | access to local variable b : B [field FieldB] : Object |
 | H.cs:45:14:45:21 | access to field FieldB | semmle.label | access to field FieldB |
+| H.cs:45:14:45:21 | access to field FieldB | semmle.label | access to field FieldB |
+| H.cs:53:25:53:25 | a : A [field FieldA] : Object | semmle.label | a : A [field FieldA] : Object |
 | H.cs:53:25:53:25 | a : A [field FieldA] : Object | semmle.label | a : A [field FieldA] : Object |
 | H.cs:55:9:55:10 | [post] access to parameter b1 : B [field FieldB] : Object | semmle.label | [post] access to parameter b1 : B [field FieldB] : Object |
+| H.cs:55:9:55:10 | [post] access to parameter b1 : B [field FieldB] : Object | semmle.label | [post] access to parameter b1 : B [field FieldB] : Object |
+| H.cs:55:21:55:21 | access to parameter a : A [field FieldA] : Object | semmle.label | access to parameter a : A [field FieldA] : Object |
 | H.cs:55:21:55:21 | access to parameter a : A [field FieldA] : Object | semmle.label | access to parameter a : A [field FieldA] : Object |
 | H.cs:55:21:55:28 | access to field FieldA : Object | semmle.label | access to field FieldA : Object |
+| H.cs:55:21:55:28 | access to field FieldA : Object | semmle.label | access to field FieldA : Object |
+| H.cs:63:9:63:9 | [post] access to local variable a : A [field FieldA] : Object | semmle.label | [post] access to local variable a : A [field FieldA] : Object |
 | H.cs:63:9:63:9 | [post] access to local variable a : A [field FieldA] : Object | semmle.label | [post] access to local variable a : A [field FieldA] : Object |
 | H.cs:63:20:63:36 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| H.cs:63:20:63:36 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| H.cs:64:22:64:22 | access to local variable a : A [field FieldA] : Object | semmle.label | access to local variable a : A [field FieldA] : Object |
 | H.cs:64:22:64:22 | access to local variable a : A [field FieldA] : Object | semmle.label | access to local variable a : A [field FieldA] : Object |
 | H.cs:64:25:64:26 | [post] access to local variable b1 : B [field FieldB] : Object | semmle.label | [post] access to local variable b1 : B [field FieldB] : Object |
+| H.cs:64:25:64:26 | [post] access to local variable b1 : B [field FieldB] : Object | semmle.label | [post] access to local variable b1 : B [field FieldB] : Object |
+| H.cs:65:14:65:15 | access to local variable b1 : B [field FieldB] : Object | semmle.label | access to local variable b1 : B [field FieldB] : Object |
 | H.cs:65:14:65:15 | access to local variable b1 : B [field FieldB] : Object | semmle.label | access to local variable b1 : B [field FieldB] : Object |
 | H.cs:65:14:65:22 | access to field FieldB | semmle.label | access to field FieldB |
+| H.cs:65:14:65:22 | access to field FieldB | semmle.label | access to field FieldB |
+| H.cs:77:30:77:30 | o : Object | semmle.label | o : Object |
 | H.cs:77:30:77:30 | o : Object | semmle.label | o : Object |
 | H.cs:79:9:79:9 | [post] access to parameter a : A [field FieldA] : Object | semmle.label | [post] access to parameter a : A [field FieldA] : Object |
+| H.cs:79:9:79:9 | [post] access to parameter a : A [field FieldA] : Object | semmle.label | [post] access to parameter a : A [field FieldA] : Object |
+| H.cs:79:20:79:20 | access to parameter o : Object | semmle.label | access to parameter o : Object |
 | H.cs:79:20:79:20 | access to parameter o : Object | semmle.label | access to parameter o : Object |
 | H.cs:80:22:80:22 | access to parameter a : A [field FieldA] : Object | semmle.label | access to parameter a : A [field FieldA] : Object |
+| H.cs:80:22:80:22 | access to parameter a : A [field FieldA] : Object | semmle.label | access to parameter a : A [field FieldA] : Object |
+| H.cs:80:25:80:26 | [post] access to parameter b1 : B [field FieldB] : Object | semmle.label | [post] access to parameter b1 : B [field FieldB] : Object |
 | H.cs:80:25:80:26 | [post] access to parameter b1 : B [field FieldB] : Object | semmle.label | [post] access to parameter b1 : B [field FieldB] : Object |
 | H.cs:88:17:88:17 | [post] access to local variable a : A [field FieldA] : Object | semmle.label | [post] access to local variable a : A [field FieldA] : Object |
+| H.cs:88:17:88:17 | [post] access to local variable a : A [field FieldA] : Object | semmle.label | [post] access to local variable a : A [field FieldA] : Object |
+| H.cs:88:20:88:36 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
 | H.cs:88:20:88:36 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
 | H.cs:88:39:88:40 | [post] access to local variable b1 : B [field FieldB] : Object | semmle.label | [post] access to local variable b1 : B [field FieldB] : Object |
+| H.cs:88:39:88:40 | [post] access to local variable b1 : B [field FieldB] : Object | semmle.label | [post] access to local variable b1 : B [field FieldB] : Object |
+| H.cs:89:14:89:14 | access to local variable a : A [field FieldA] : Object | semmle.label | access to local variable a : A [field FieldA] : Object |
 | H.cs:89:14:89:14 | access to local variable a : A [field FieldA] : Object | semmle.label | access to local variable a : A [field FieldA] : Object |
 | H.cs:89:14:89:21 | access to field FieldA | semmle.label | access to field FieldA |
+| H.cs:89:14:89:21 | access to field FieldA | semmle.label | access to field FieldA |
+| H.cs:90:14:90:15 | access to local variable b1 : B [field FieldB] : Object | semmle.label | access to local variable b1 : B [field FieldB] : Object |
 | H.cs:90:14:90:15 | access to local variable b1 : B [field FieldB] : Object | semmle.label | access to local variable b1 : B [field FieldB] : Object |
 | H.cs:90:14:90:22 | access to field FieldB | semmle.label | access to field FieldB |
+| H.cs:90:14:90:22 | access to field FieldB | semmle.label | access to field FieldB |
+| H.cs:102:23:102:23 | a : A [field FieldA] : Object | semmle.label | a : A [field FieldA] : Object |
 | H.cs:102:23:102:23 | a : A [field FieldA] : Object | semmle.label | a : A [field FieldA] : Object |
 | H.cs:105:9:105:12 | [post] access to local variable temp : B [field FieldB, field FieldA] : Object | semmle.label | [post] access to local variable temp : B [field FieldB, field FieldA] : Object |
+| H.cs:105:9:105:12 | [post] access to local variable temp : B [field FieldB, field FieldA] : Object | semmle.label | [post] access to local variable temp : B [field FieldB, field FieldA] : Object |
+| H.cs:105:23:105:23 | access to parameter a : A [field FieldA] : Object | semmle.label | access to parameter a : A [field FieldA] : Object |
 | H.cs:105:23:105:23 | access to parameter a : A [field FieldA] : Object | semmle.label | access to parameter a : A [field FieldA] : Object |
 | H.cs:106:16:106:40 | call to method Transform : B [field FieldB] : Object | semmle.label | call to method Transform : B [field FieldB] : Object |
+| H.cs:106:16:106:40 | call to method Transform : B [field FieldB] : Object | semmle.label | call to method Transform : B [field FieldB] : Object |
+| H.cs:106:26:106:39 | (...) ... : A [field FieldA] : Object | semmle.label | (...) ... : A [field FieldA] : Object |
 | H.cs:106:26:106:39 | (...) ... : A [field FieldA] : Object | semmle.label | (...) ... : A [field FieldA] : Object |
 | H.cs:106:29:106:32 | access to local variable temp : B [field FieldB, field FieldA] : Object | semmle.label | access to local variable temp : B [field FieldB, field FieldA] : Object |
+| H.cs:106:29:106:32 | access to local variable temp : B [field FieldB, field FieldA] : Object | semmle.label | access to local variable temp : B [field FieldB, field FieldA] : Object |
+| H.cs:106:29:106:39 | access to field FieldB : A [field FieldA] : Object | semmle.label | access to field FieldB : A [field FieldA] : Object |
 | H.cs:106:29:106:39 | access to field FieldB : A [field FieldA] : Object | semmle.label | access to field FieldB : A [field FieldA] : Object |
 | H.cs:112:9:112:9 | [post] access to local variable a : A [field FieldA] : Object | semmle.label | [post] access to local variable a : A [field FieldA] : Object |
+| H.cs:112:9:112:9 | [post] access to local variable a : A [field FieldA] : Object | semmle.label | [post] access to local variable a : A [field FieldA] : Object |
+| H.cs:112:20:112:36 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
 | H.cs:112:20:112:36 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
 | H.cs:113:17:113:32 | call to method TransformWrap : B [field FieldB] : Object | semmle.label | call to method TransformWrap : B [field FieldB] : Object |
+| H.cs:113:17:113:32 | call to method TransformWrap : B [field FieldB] : Object | semmle.label | call to method TransformWrap : B [field FieldB] : Object |
+| H.cs:113:31:113:31 | access to local variable a : A [field FieldA] : Object | semmle.label | access to local variable a : A [field FieldA] : Object |
 | H.cs:113:31:113:31 | access to local variable a : A [field FieldA] : Object | semmle.label | access to local variable a : A [field FieldA] : Object |
 | H.cs:114:14:114:14 | access to local variable b : B [field FieldB] : Object | semmle.label | access to local variable b : B [field FieldB] : Object |
+| H.cs:114:14:114:14 | access to local variable b : B [field FieldB] : Object | semmle.label | access to local variable b : B [field FieldB] : Object |
+| H.cs:114:14:114:21 | access to field FieldB | semmle.label | access to field FieldB |
 | H.cs:114:14:114:21 | access to field FieldB | semmle.label | access to field FieldB |
 | H.cs:122:18:122:18 | a : A [field FieldA] : Object | semmle.label | a : A [field FieldA] : Object |
+| H.cs:122:18:122:18 | a : A [field FieldA] : Object | semmle.label | a : A [field FieldA] : Object |
+| H.cs:124:16:124:27 | call to method Transform : B [field FieldB] : Object | semmle.label | call to method Transform : B [field FieldB] : Object |
 | H.cs:124:16:124:27 | call to method Transform : B [field FieldB] : Object | semmle.label | call to method Transform : B [field FieldB] : Object |
 | H.cs:124:16:124:34 | access to field FieldB : Object | semmle.label | access to field FieldB : Object |
+| H.cs:124:16:124:34 | access to field FieldB : Object | semmle.label | access to field FieldB : Object |
+| H.cs:124:26:124:26 | access to parameter a : A [field FieldA] : Object | semmle.label | access to parameter a : A [field FieldA] : Object |
 | H.cs:124:26:124:26 | access to parameter a : A [field FieldA] : Object | semmle.label | access to parameter a : A [field FieldA] : Object |
 | H.cs:130:9:130:9 | [post] access to local variable a : A [field FieldA] : Object | semmle.label | [post] access to local variable a : A [field FieldA] : Object |
+| H.cs:130:9:130:9 | [post] access to local variable a : A [field FieldA] : Object | semmle.label | [post] access to local variable a : A [field FieldA] : Object |
+| H.cs:130:20:130:36 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
 | H.cs:130:20:130:36 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
 | H.cs:131:14:131:19 | call to method Get | semmle.label | call to method Get |
+| H.cs:131:14:131:19 | call to method Get | semmle.label | call to method Get |
+| H.cs:131:18:131:18 | access to local variable a : A [field FieldA] : Object | semmle.label | access to local variable a : A [field FieldA] : Object |
 | H.cs:131:18:131:18 | access to local variable a : A [field FieldA] : Object | semmle.label | access to local variable a : A [field FieldA] : Object |
 | H.cs:138:27:138:27 | o : A | semmle.label | o : A |
+| H.cs:138:27:138:27 | o : A | semmle.label | o : A |
+| H.cs:141:9:141:9 | [post] access to local variable a : A [field FieldA] : A | semmle.label | [post] access to local variable a : A [field FieldA] : A |
 | H.cs:141:9:141:9 | [post] access to local variable a : A [field FieldA] : A | semmle.label | [post] access to local variable a : A [field FieldA] : A |
 | H.cs:141:20:141:25 | ... as ... : A | semmle.label | ... as ... : A |
+| H.cs:141:20:141:25 | ... as ... : A | semmle.label | ... as ... : A |
+| H.cs:142:16:142:27 | call to method Transform : B [field FieldB] : A | semmle.label | call to method Transform : B [field FieldB] : A |
 | H.cs:142:16:142:27 | call to method Transform : B [field FieldB] : A | semmle.label | call to method Transform : B [field FieldB] : A |
 | H.cs:142:16:142:34 | access to field FieldB : A | semmle.label | access to field FieldB : A |
+| H.cs:142:16:142:34 | access to field FieldB : A | semmle.label | access to field FieldB : A |
+| H.cs:142:26:142:26 | access to local variable a : A [field FieldA] : A | semmle.label | access to local variable a : A [field FieldA] : A |
 | H.cs:142:26:142:26 | access to local variable a : A [field FieldA] : A | semmle.label | access to local variable a : A [field FieldA] : A |
 | H.cs:147:17:147:39 | call to method Through : A | semmle.label | call to method Through : A |
+| H.cs:147:17:147:39 | call to method Through : A | semmle.label | call to method Through : A |
+| H.cs:147:25:147:38 | call to method Source<A> : A | semmle.label | call to method Source<A> : A |
 | H.cs:147:25:147:38 | call to method Source<A> : A | semmle.label | call to method Source<A> : A |
 | H.cs:148:14:148:14 | access to local variable a | semmle.label | access to local variable a |
+| H.cs:148:14:148:14 | access to local variable a | semmle.label | access to local variable a |
+| H.cs:153:32:153:32 | o : Object | semmle.label | o : Object |
 | H.cs:153:32:153:32 | o : Object | semmle.label | o : Object |
 | H.cs:155:17:155:30 | call to method Source<B> : B | semmle.label | call to method Source<B> : B |
+| H.cs:155:17:155:30 | call to method Source<B> : B | semmle.label | call to method Source<B> : B |
+| H.cs:156:9:156:9 | [post] access to local variable b : B [field FieldB] : Object | semmle.label | [post] access to local variable b : B [field FieldB] : Object |
 | H.cs:156:9:156:9 | [post] access to local variable b : B [field FieldB] : Object | semmle.label | [post] access to local variable b : B [field FieldB] : Object |
 | H.cs:156:9:156:9 | access to local variable b : B | semmle.label | access to local variable b : B |
+| H.cs:156:9:156:9 | access to local variable b : B | semmle.label | access to local variable b : B |
+| H.cs:156:20:156:20 | access to parameter o : Object | semmle.label | access to parameter o : Object |
 | H.cs:156:20:156:20 | access to parameter o : Object | semmle.label | access to parameter o : Object |
 | H.cs:157:9:157:9 | [post] access to parameter a : A [field FieldA, field FieldB] : Object | semmle.label | [post] access to parameter a : A [field FieldA, field FieldB] : Object |
+| H.cs:157:9:157:9 | [post] access to parameter a : A [field FieldA, field FieldB] : Object | semmle.label | [post] access to parameter a : A [field FieldA, field FieldB] : Object |
+| H.cs:157:9:157:9 | [post] access to parameter a : A [field FieldA] : B | semmle.label | [post] access to parameter a : A [field FieldA] : B |
 | H.cs:157:9:157:9 | [post] access to parameter a : A [field FieldA] : B | semmle.label | [post] access to parameter a : A [field FieldA] : B |
 | H.cs:157:20:157:20 | access to local variable b : B | semmle.label | access to local variable b : B |
+| H.cs:157:20:157:20 | access to local variable b : B | semmle.label | access to local variable b : B |
+| H.cs:157:20:157:20 | access to local variable b : B [field FieldB] : Object | semmle.label | access to local variable b : B [field FieldB] : Object |
 | H.cs:157:20:157:20 | access to local variable b : B [field FieldB] : Object | semmle.label | access to local variable b : B [field FieldB] : Object |
 | H.cs:163:17:163:35 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| H.cs:163:17:163:35 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| H.cs:164:19:164:19 | [post] access to local variable a : A [field FieldA, field FieldB] : Object | semmle.label | [post] access to local variable a : A [field FieldA, field FieldB] : Object |
 | H.cs:164:19:164:19 | [post] access to local variable a : A [field FieldA, field FieldB] : Object | semmle.label | [post] access to local variable a : A [field FieldA, field FieldB] : Object |
 | H.cs:164:19:164:19 | [post] access to local variable a : A [field FieldA] : B | semmle.label | [post] access to local variable a : A [field FieldA] : B |
+| H.cs:164:19:164:19 | [post] access to local variable a : A [field FieldA] : B | semmle.label | [post] access to local variable a : A [field FieldA] : B |
+| H.cs:164:22:164:22 | access to local variable o : Object | semmle.label | access to local variable o : Object |
 | H.cs:164:22:164:22 | access to local variable o : Object | semmle.label | access to local variable o : Object |
 | H.cs:165:17:165:27 | (...) ... : B | semmle.label | (...) ... : B |
+| H.cs:165:17:165:27 | (...) ... : B | semmle.label | (...) ... : B |
+| H.cs:165:17:165:27 | (...) ... : B [field FieldB] : Object | semmle.label | (...) ... : B [field FieldB] : Object |
 | H.cs:165:17:165:27 | (...) ... : B [field FieldB] : Object | semmle.label | (...) ... : B [field FieldB] : Object |
 | H.cs:165:20:165:20 | access to local variable a : A [field FieldA, field FieldB] : Object | semmle.label | access to local variable a : A [field FieldA, field FieldB] : Object |
+| H.cs:165:20:165:20 | access to local variable a : A [field FieldA, field FieldB] : Object | semmle.label | access to local variable a : A [field FieldA, field FieldB] : Object |
+| H.cs:165:20:165:20 | access to local variable a : A [field FieldA] : B | semmle.label | access to local variable a : A [field FieldA] : B |
 | H.cs:165:20:165:20 | access to local variable a : A [field FieldA] : B | semmle.label | access to local variable a : A [field FieldA] : B |
 | H.cs:165:20:165:27 | access to field FieldA : B | semmle.label | access to field FieldA : B |
+| H.cs:165:20:165:27 | access to field FieldA : B | semmle.label | access to field FieldA : B |
+| H.cs:165:20:165:27 | access to field FieldA : B [field FieldB] : Object | semmle.label | access to field FieldA : B [field FieldB] : Object |
 | H.cs:165:20:165:27 | access to field FieldA : B [field FieldB] : Object | semmle.label | access to field FieldA : B [field FieldB] : Object |
 | H.cs:166:14:166:14 | access to local variable b | semmle.label | access to local variable b |
+| H.cs:166:14:166:14 | access to local variable b | semmle.label | access to local variable b |
+| H.cs:167:14:167:14 | access to local variable b : B [field FieldB] : Object | semmle.label | access to local variable b : B [field FieldB] : Object |
 | H.cs:167:14:167:14 | access to local variable b : B [field FieldB] : Object | semmle.label | access to local variable b : B [field FieldB] : Object |
 | H.cs:167:14:167:21 | access to field FieldB | semmle.label | access to field FieldB |
+| H.cs:167:14:167:21 | access to field FieldB | semmle.label | access to field FieldB |
+| I.cs:7:9:7:14 | [post] this access : I [field Field1] : Object | semmle.label | [post] this access : I [field Field1] : Object |
 | I.cs:7:9:7:14 | [post] this access : I [field Field1] : Object | semmle.label | [post] this access : I [field Field1] : Object |
 | I.cs:7:18:7:34 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| I.cs:7:18:7:34 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| I.cs:13:17:13:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
 | I.cs:13:17:13:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
 | I.cs:15:9:15:9 | [post] access to local variable i : I [field Field1] : Object | semmle.label | [post] access to local variable i : I [field Field1] : Object |
+| I.cs:15:9:15:9 | [post] access to local variable i : I [field Field1] : Object | semmle.label | [post] access to local variable i : I [field Field1] : Object |
+| I.cs:15:20:15:20 | access to local variable o : Object | semmle.label | access to local variable o : Object |
 | I.cs:15:20:15:20 | access to local variable o : Object | semmle.label | access to local variable o : Object |
 | I.cs:16:9:16:9 | access to local variable i : I [field Field1] : Object | semmle.label | access to local variable i : I [field Field1] : Object |
+| I.cs:16:9:16:9 | access to local variable i : I [field Field1] : Object | semmle.label | access to local variable i : I [field Field1] : Object |
+| I.cs:17:9:17:9 | access to local variable i : I [field Field1] : Object | semmle.label | access to local variable i : I [field Field1] : Object |
 | I.cs:17:9:17:9 | access to local variable i : I [field Field1] : Object | semmle.label | access to local variable i : I [field Field1] : Object |
 | I.cs:18:14:18:14 | access to local variable i : I [field Field1] : Object | semmle.label | access to local variable i : I [field Field1] : Object |
+| I.cs:18:14:18:14 | access to local variable i : I [field Field1] : Object | semmle.label | access to local variable i : I [field Field1] : Object |
+| I.cs:18:14:18:21 | access to field Field1 | semmle.label | access to field Field1 |
 | I.cs:18:14:18:21 | access to field Field1 | semmle.label | access to field Field1 |
 | I.cs:21:13:21:19 | object creation of type I : I [field Field1] : Object | semmle.label | object creation of type I : I [field Field1] : Object |
+| I.cs:21:13:21:19 | object creation of type I : I [field Field1] : Object | semmle.label | object creation of type I : I [field Field1] : Object |
+| I.cs:22:9:22:9 | access to local variable i : I [field Field1] : Object | semmle.label | access to local variable i : I [field Field1] : Object |
 | I.cs:22:9:22:9 | access to local variable i : I [field Field1] : Object | semmle.label | access to local variable i : I [field Field1] : Object |
 | I.cs:23:14:23:14 | access to local variable i : I [field Field1] : Object | semmle.label | access to local variable i : I [field Field1] : Object |
+| I.cs:23:14:23:14 | access to local variable i : I [field Field1] : Object | semmle.label | access to local variable i : I [field Field1] : Object |
+| I.cs:23:14:23:21 | access to field Field1 | semmle.label | access to field Field1 |
 | I.cs:23:14:23:21 | access to field Field1 | semmle.label | access to field Field1 |
 | I.cs:26:13:26:37 | [pre-initializer] object creation of type I : I [field Field1] : Object | semmle.label | [pre-initializer] object creation of type I : I [field Field1] : Object |
+| I.cs:26:13:26:37 | [pre-initializer] object creation of type I : I [field Field1] : Object | semmle.label | [pre-initializer] object creation of type I : I [field Field1] : Object |
+| I.cs:27:14:27:14 | access to local variable i : I [field Field1] : Object | semmle.label | access to local variable i : I [field Field1] : Object |
 | I.cs:27:14:27:14 | access to local variable i : I [field Field1] : Object | semmle.label | access to local variable i : I [field Field1] : Object |
 | I.cs:27:14:27:21 | access to field Field1 | semmle.label | access to field Field1 |
+| I.cs:27:14:27:21 | access to field Field1 | semmle.label | access to field Field1 |
+| I.cs:31:13:31:29 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
 | I.cs:31:13:31:29 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
 | I.cs:32:9:32:9 | [post] access to local variable i : I [field Field1] : Object | semmle.label | [post] access to local variable i : I [field Field1] : Object |
+| I.cs:32:9:32:9 | [post] access to local variable i : I [field Field1] : Object | semmle.label | [post] access to local variable i : I [field Field1] : Object |
+| I.cs:32:20:32:20 | access to local variable o : Object | semmle.label | access to local variable o : Object |
 | I.cs:32:20:32:20 | access to local variable o : Object | semmle.label | access to local variable o : Object |
 | I.cs:33:9:33:9 | access to local variable i : I [field Field1] : Object | semmle.label | access to local variable i : I [field Field1] : Object |
+| I.cs:33:9:33:9 | access to local variable i : I [field Field1] : Object | semmle.label | access to local variable i : I [field Field1] : Object |
+| I.cs:34:12:34:12 | access to local variable i : I [field Field1] : Object | semmle.label | access to local variable i : I [field Field1] : Object |
 | I.cs:34:12:34:12 | access to local variable i : I [field Field1] : Object | semmle.label | access to local variable i : I [field Field1] : Object |
 | I.cs:37:23:37:23 | i : I [field Field1] : Object | semmle.label | i : I [field Field1] : Object |
+| I.cs:37:23:37:23 | i : I [field Field1] : Object | semmle.label | i : I [field Field1] : Object |
+| I.cs:39:9:39:9 | access to parameter i : I [field Field1] : Object | semmle.label | access to parameter i : I [field Field1] : Object |
 | I.cs:39:9:39:9 | access to parameter i : I [field Field1] : Object | semmle.label | access to parameter i : I [field Field1] : Object |
 | I.cs:40:14:40:14 | access to parameter i : I [field Field1] : Object | semmle.label | access to parameter i : I [field Field1] : Object |
+| I.cs:40:14:40:14 | access to parameter i : I [field Field1] : Object | semmle.label | access to parameter i : I [field Field1] : Object |
+| I.cs:40:14:40:21 | access to field Field1 | semmle.label | access to field Field1 |
 | I.cs:40:14:40:21 | access to field Field1 | semmle.label | access to field Field1 |
 | J.cs:14:26:14:30 | field : Object | semmle.label | field : Object |
+| J.cs:14:26:14:30 | field : Object | semmle.label | field : Object |
+| J.cs:14:40:14:43 | prop : Object | semmle.label | prop : Object |
 | J.cs:14:40:14:43 | prop : Object | semmle.label | prop : Object |
 | J.cs:14:50:14:54 | [post] this access : Struct [field Field] : Object | semmle.label | [post] this access : Struct [field Field] : Object |
+| J.cs:14:50:14:54 | [post] this access : Struct [field Field] : Object | semmle.label | [post] this access : Struct [field Field] : Object |
+| J.cs:14:57:14:60 | [post] this access : Struct [property Prop] : Object | semmle.label | [post] this access : Struct [property Prop] : Object |
 | J.cs:14:57:14:60 | [post] this access : Struct [property Prop] : Object | semmle.label | [post] this access : Struct [property Prop] : Object |
 | J.cs:14:66:14:70 | access to parameter field : Object | semmle.label | access to parameter field : Object |
+| J.cs:14:66:14:70 | access to parameter field : Object | semmle.label | access to parameter field : Object |
+| J.cs:14:73:14:76 | access to parameter prop : Object | semmle.label | access to parameter prop : Object |
 | J.cs:14:73:14:76 | access to parameter prop : Object | semmle.label | access to parameter prop : Object |
 | J.cs:21:17:21:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| J.cs:21:17:21:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| J.cs:22:18:22:41 | object creation of type RecordClass : RecordClass [property Prop1] : Object | semmle.label | object creation of type RecordClass : RecordClass [property Prop1] : Object |
 | J.cs:22:18:22:41 | object creation of type RecordClass : RecordClass [property Prop1] : Object | semmle.label | object creation of type RecordClass : RecordClass [property Prop1] : Object |
 | J.cs:22:34:22:34 | access to local variable o : Object | semmle.label | access to local variable o : Object |
+| J.cs:22:34:22:34 | access to local variable o : Object | semmle.label | access to local variable o : Object |
+| J.cs:23:14:23:15 | access to local variable r1 : RecordClass [property Prop1] : Object | semmle.label | access to local variable r1 : RecordClass [property Prop1] : Object |
 | J.cs:23:14:23:15 | access to local variable r1 : RecordClass [property Prop1] : Object | semmle.label | access to local variable r1 : RecordClass [property Prop1] : Object |
 | J.cs:23:14:23:21 | access to property Prop1 | semmle.label | access to property Prop1 |
+| J.cs:23:14:23:21 | access to property Prop1 | semmle.label | access to property Prop1 |
+| J.cs:27:14:27:15 | access to local variable r2 : RecordClass [property Prop1] : Object | semmle.label | access to local variable r2 : RecordClass [property Prop1] : Object |
 | J.cs:27:14:27:15 | access to local variable r2 : RecordClass [property Prop1] : Object | semmle.label | access to local variable r2 : RecordClass [property Prop1] : Object |
 | J.cs:27:14:27:21 | access to property Prop1 | semmle.label | access to property Prop1 |
+| J.cs:27:14:27:21 | access to property Prop1 | semmle.label | access to property Prop1 |
+| J.cs:30:18:30:54 | ... with { ... } : RecordClass [property Prop2] : Object | semmle.label | ... with { ... } : RecordClass [property Prop2] : Object |
 | J.cs:30:18:30:54 | ... with { ... } : RecordClass [property Prop2] : Object | semmle.label | ... with { ... } : RecordClass [property Prop2] : Object |
 | J.cs:30:36:30:52 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| J.cs:30:36:30:52 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| J.cs:31:14:31:15 | access to local variable r3 : RecordClass [property Prop1] : Object | semmle.label | access to local variable r3 : RecordClass [property Prop1] : Object |
 | J.cs:31:14:31:15 | access to local variable r3 : RecordClass [property Prop1] : Object | semmle.label | access to local variable r3 : RecordClass [property Prop1] : Object |
 | J.cs:31:14:31:21 | access to property Prop1 | semmle.label | access to property Prop1 |
+| J.cs:31:14:31:21 | access to property Prop1 | semmle.label | access to property Prop1 |
+| J.cs:32:14:32:15 | access to local variable r3 : RecordClass [property Prop2] : Object | semmle.label | access to local variable r3 : RecordClass [property Prop2] : Object |
 | J.cs:32:14:32:15 | access to local variable r3 : RecordClass [property Prop2] : Object | semmle.label | access to local variable r3 : RecordClass [property Prop2] : Object |
 | J.cs:32:14:32:21 | access to property Prop2 | semmle.label | access to property Prop2 |
+| J.cs:32:14:32:21 | access to property Prop2 | semmle.label | access to property Prop2 |
+| J.cs:41:17:41:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
 | J.cs:41:17:41:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
 | J.cs:42:18:42:42 | object creation of type RecordStruct : RecordStruct [property Prop1] : Object | semmle.label | object creation of type RecordStruct : RecordStruct [property Prop1] : Object |
+| J.cs:42:18:42:42 | object creation of type RecordStruct : RecordStruct [property Prop1] : Object | semmle.label | object creation of type RecordStruct : RecordStruct [property Prop1] : Object |
+| J.cs:42:35:42:35 | access to local variable o : Object | semmle.label | access to local variable o : Object |
 | J.cs:42:35:42:35 | access to local variable o : Object | semmle.label | access to local variable o : Object |
 | J.cs:43:14:43:15 | access to local variable r1 : RecordStruct [property Prop1] : Object | semmle.label | access to local variable r1 : RecordStruct [property Prop1] : Object |
+| J.cs:43:14:43:15 | access to local variable r1 : RecordStruct [property Prop1] : Object | semmle.label | access to local variable r1 : RecordStruct [property Prop1] : Object |
+| J.cs:43:14:43:21 | access to property Prop1 | semmle.label | access to property Prop1 |
 | J.cs:43:14:43:21 | access to property Prop1 | semmle.label | access to property Prop1 |
 | J.cs:47:14:47:15 | access to local variable r2 : RecordStruct [property Prop1] : Object | semmle.label | access to local variable r2 : RecordStruct [property Prop1] : Object |
+| J.cs:47:14:47:15 | access to local variable r2 : RecordStruct [property Prop1] : Object | semmle.label | access to local variable r2 : RecordStruct [property Prop1] : Object |
+| J.cs:47:14:47:21 | access to property Prop1 | semmle.label | access to property Prop1 |
 | J.cs:47:14:47:21 | access to property Prop1 | semmle.label | access to property Prop1 |
 | J.cs:50:18:50:54 | ... with { ... } : RecordStruct [property Prop2] : Object | semmle.label | ... with { ... } : RecordStruct [property Prop2] : Object |
+| J.cs:50:18:50:54 | ... with { ... } : RecordStruct [property Prop2] : Object | semmle.label | ... with { ... } : RecordStruct [property Prop2] : Object |
+| J.cs:50:36:50:52 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
 | J.cs:50:36:50:52 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
 | J.cs:51:14:51:15 | access to local variable r3 : RecordStruct [property Prop1] : Object | semmle.label | access to local variable r3 : RecordStruct [property Prop1] : Object |
+| J.cs:51:14:51:15 | access to local variable r3 : RecordStruct [property Prop1] : Object | semmle.label | access to local variable r3 : RecordStruct [property Prop1] : Object |
+| J.cs:51:14:51:21 | access to property Prop1 | semmle.label | access to property Prop1 |
 | J.cs:51:14:51:21 | access to property Prop1 | semmle.label | access to property Prop1 |
 | J.cs:52:14:52:15 | access to local variable r3 : RecordStruct [property Prop2] : Object | semmle.label | access to local variable r3 : RecordStruct [property Prop2] : Object |
+| J.cs:52:14:52:15 | access to local variable r3 : RecordStruct [property Prop2] : Object | semmle.label | access to local variable r3 : RecordStruct [property Prop2] : Object |
+| J.cs:52:14:52:21 | access to property Prop2 | semmle.label | access to property Prop2 |
 | J.cs:52:14:52:21 | access to property Prop2 | semmle.label | access to property Prop2 |
 | J.cs:61:17:61:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| J.cs:61:17:61:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| J.cs:62:18:62:36 | object creation of type Struct : Struct [field Field] : Object | semmle.label | object creation of type Struct : Struct [field Field] : Object |
 | J.cs:62:18:62:36 | object creation of type Struct : Struct [field Field] : Object | semmle.label | object creation of type Struct : Struct [field Field] : Object |
 | J.cs:62:29:62:29 | access to local variable o : Object | semmle.label | access to local variable o : Object |
+| J.cs:62:29:62:29 | access to local variable o : Object | semmle.label | access to local variable o : Object |
+| J.cs:65:14:65:15 | access to local variable s2 : Struct [field Field] : Object | semmle.label | access to local variable s2 : Struct [field Field] : Object |
 | J.cs:65:14:65:15 | access to local variable s2 : Struct [field Field] : Object | semmle.label | access to local variable s2 : Struct [field Field] : Object |
 | J.cs:65:14:65:21 | access to field Field | semmle.label | access to field Field |
+| J.cs:65:14:65:21 | access to field Field | semmle.label | access to field Field |
+| J.cs:68:18:68:53 | ... with { ... } : Struct [property Prop] : Object | semmle.label | ... with { ... } : Struct [property Prop] : Object |
 | J.cs:68:18:68:53 | ... with { ... } : Struct [property Prop] : Object | semmle.label | ... with { ... } : Struct [property Prop] : Object |
 | J.cs:68:35:68:51 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| J.cs:68:35:68:51 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| J.cs:69:14:69:15 | access to local variable s3 : Struct [field Field] : Object | semmle.label | access to local variable s3 : Struct [field Field] : Object |
 | J.cs:69:14:69:15 | access to local variable s3 : Struct [field Field] : Object | semmle.label | access to local variable s3 : Struct [field Field] : Object |
 | J.cs:69:14:69:21 | access to field Field | semmle.label | access to field Field |
+| J.cs:69:14:69:21 | access to field Field | semmle.label | access to field Field |
+| J.cs:70:14:70:15 | access to local variable s3 : Struct [property Prop] : Object | semmle.label | access to local variable s3 : Struct [property Prop] : Object |
 | J.cs:70:14:70:15 | access to local variable s3 : Struct [property Prop] : Object | semmle.label | access to local variable s3 : Struct [property Prop] : Object |
 | J.cs:70:14:70:20 | access to property Prop | semmle.label | access to property Prop |
+| J.cs:70:14:70:20 | access to property Prop | semmle.label | access to property Prop |
+| J.cs:79:17:79:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
 | J.cs:79:17:79:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
 | J.cs:80:18:80:36 | object creation of type Struct : Struct [property Prop] : Object | semmle.label | object creation of type Struct : Struct [property Prop] : Object |
+| J.cs:80:18:80:36 | object creation of type Struct : Struct [property Prop] : Object | semmle.label | object creation of type Struct : Struct [property Prop] : Object |
+| J.cs:80:35:80:35 | access to local variable o : Object | semmle.label | access to local variable o : Object |
 | J.cs:80:35:80:35 | access to local variable o : Object | semmle.label | access to local variable o : Object |
 | J.cs:84:14:84:15 | access to local variable s2 : Struct [property Prop] : Object | semmle.label | access to local variable s2 : Struct [property Prop] : Object |
+| J.cs:84:14:84:15 | access to local variable s2 : Struct [property Prop] : Object | semmle.label | access to local variable s2 : Struct [property Prop] : Object |
+| J.cs:84:14:84:20 | access to property Prop | semmle.label | access to property Prop |
 | J.cs:84:14:84:20 | access to property Prop | semmle.label | access to property Prop |
 | J.cs:86:18:86:54 | ... with { ... } : Struct [field Field] : Object | semmle.label | ... with { ... } : Struct [field Field] : Object |
+| J.cs:86:18:86:54 | ... with { ... } : Struct [field Field] : Object | semmle.label | ... with { ... } : Struct [field Field] : Object |
+| J.cs:86:36:86:52 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
 | J.cs:86:36:86:52 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
 | J.cs:87:14:87:15 | access to local variable s3 : Struct [field Field] : Object | semmle.label | access to local variable s3 : Struct [field Field] : Object |
+| J.cs:87:14:87:15 | access to local variable s3 : Struct [field Field] : Object | semmle.label | access to local variable s3 : Struct [field Field] : Object |
+| J.cs:87:14:87:21 | access to field Field | semmle.label | access to field Field |
 | J.cs:87:14:87:21 | access to field Field | semmle.label | access to field Field |
 | J.cs:88:14:88:15 | access to local variable s3 : Struct [property Prop] : Object | semmle.label | access to local variable s3 : Struct [property Prop] : Object |
+| J.cs:88:14:88:15 | access to local variable s3 : Struct [property Prop] : Object | semmle.label | access to local variable s3 : Struct [property Prop] : Object |
+| J.cs:88:14:88:20 | access to property Prop | semmle.label | access to property Prop |
 | J.cs:88:14:88:20 | access to property Prop | semmle.label | access to property Prop |
 | J.cs:97:17:97:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| J.cs:97:17:97:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| J.cs:99:18:99:41 | { ..., ... } : <>__AnonType0<Object,Object> [property X] : Object | semmle.label | { ..., ... } : <>__AnonType0<Object,Object> [property X] : Object |
 | J.cs:99:18:99:41 | { ..., ... } : <>__AnonType0<Object,Object> [property X] : Object | semmle.label | { ..., ... } : <>__AnonType0<Object,Object> [property X] : Object |
 | J.cs:99:28:99:28 | access to local variable o : Object | semmle.label | access to local variable o : Object |
+| J.cs:99:28:99:28 | access to local variable o : Object | semmle.label | access to local variable o : Object |
+| J.cs:102:14:102:15 | access to local variable a2 : <>__AnonType0<Object,Object> [property X] : Object | semmle.label | access to local variable a2 : <>__AnonType0<Object,Object> [property X] : Object |
 | J.cs:102:14:102:15 | access to local variable a2 : <>__AnonType0<Object,Object> [property X] : Object | semmle.label | access to local variable a2 : <>__AnonType0<Object,Object> [property X] : Object |
 | J.cs:102:14:102:17 | access to property X | semmle.label | access to property X |
+| J.cs:102:14:102:17 | access to property X | semmle.label | access to property X |
+| J.cs:105:18:105:50 | ... with { ... } : <>__AnonType0<Object,Object> [property Y] : Object | semmle.label | ... with { ... } : <>__AnonType0<Object,Object> [property Y] : Object |
 | J.cs:105:18:105:50 | ... with { ... } : <>__AnonType0<Object,Object> [property Y] : Object | semmle.label | ... with { ... } : <>__AnonType0<Object,Object> [property Y] : Object |
 | J.cs:105:32:105:48 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| J.cs:105:32:105:48 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| J.cs:106:14:106:15 | access to local variable a3 : <>__AnonType0<Object,Object> [property X] : Object | semmle.label | access to local variable a3 : <>__AnonType0<Object,Object> [property X] : Object |
 | J.cs:106:14:106:15 | access to local variable a3 : <>__AnonType0<Object,Object> [property X] : Object | semmle.label | access to local variable a3 : <>__AnonType0<Object,Object> [property X] : Object |
 | J.cs:106:14:106:17 | access to property X | semmle.label | access to property X |
+| J.cs:106:14:106:17 | access to property X | semmle.label | access to property X |
+| J.cs:107:14:107:15 | access to local variable a3 : <>__AnonType0<Object,Object> [property Y] : Object | semmle.label | access to local variable a3 : <>__AnonType0<Object,Object> [property Y] : Object |
 | J.cs:107:14:107:15 | access to local variable a3 : <>__AnonType0<Object,Object> [property Y] : Object | semmle.label | access to local variable a3 : <>__AnonType0<Object,Object> [property Y] : Object |
 | J.cs:107:14:107:17 | access to property Y | semmle.label | access to property Y |
+| J.cs:107:14:107:17 | access to property Y | semmle.label | access to property Y |
+| J.cs:119:13:119:13 | [post] access to local variable a : Int32[] [element] : Int32 | semmle.label | [post] access to local variable a : Int32[] [element] : Int32 |
 | J.cs:119:13:119:13 | [post] access to local variable a : Int32[] [element] : Int32 | semmle.label | [post] access to local variable a : Int32[] [element] : Int32 |
 | J.cs:119:20:119:34 | call to method Source<Int32> : Int32 | semmle.label | call to method Source<Int32> : Int32 |
+| J.cs:119:20:119:34 | call to method Source<Int32> : Int32 | semmle.label | call to method Source<Int32> : Int32 |
+| J.cs:125:14:125:14 | access to local variable a : Int32[] [element] : Int32 | semmle.label | access to local variable a : Int32[] [element] : Int32 |
 | J.cs:125:14:125:14 | access to local variable a : Int32[] [element] : Int32 | semmle.label | access to local variable a : Int32[] [element] : Int32 |
 | J.cs:125:14:125:17 | (...) ... | semmle.label | (...) ... |
+| J.cs:125:14:125:17 | (...) ... | semmle.label | (...) ... |
+| J.cs:125:14:125:17 | access to array element : Int32 | semmle.label | access to array element : Int32 |
 | J.cs:125:14:125:17 | access to array element : Int32 | semmle.label | access to array element : Int32 |
 subpaths
 | A.cs:6:24:6:24 | access to local variable c : C | A.cs:147:32:147:32 | c : C | A.cs:149:20:149:27 | object creation of type B : B [field c] : C | A.cs:6:17:6:25 | call to method Make : B [field c] : C |
+| A.cs:6:24:6:24 | access to local variable c : C | A.cs:147:32:147:32 | c : C | A.cs:149:20:149:27 | object creation of type B : B [field c] : C | A.cs:6:17:6:25 | call to method Make : B [field c] : C |
+| A.cs:13:15:13:29 | call to method Source<C1> : C1 | A.cs:145:27:145:27 | c : C1 | A.cs:145:32:145:35 | [post] this access : B [field c] : C1 | A.cs:13:9:13:9 | [post] access to local variable b : B [field c] : C1 |
 | A.cs:13:15:13:29 | call to method Source<C1> : C1 | A.cs:145:27:145:27 | c : C1 | A.cs:145:32:145:35 | [post] this access : B [field c] : C1 | A.cs:13:9:13:9 | [post] access to local variable b : B [field c] : C1 |
 | A.cs:14:14:14:14 | access to local variable b : B [field c] : C1 | A.cs:146:18:146:20 | this : B [field c] : C1 | A.cs:146:33:146:38 | access to field c : C1 | A.cs:14:14:14:20 | call to method Get |
+| A.cs:14:14:14:14 | access to local variable b : B [field c] : C1 | A.cs:146:18:146:20 | this : B [field c] : C1 | A.cs:146:33:146:38 | access to field c : C1 | A.cs:14:14:14:20 | call to method Get |
+| A.cs:15:15:15:35 | object creation of type B : B [field c] : C | A.cs:146:18:146:20 | this : B [field c] : C | A.cs:146:33:146:38 | access to field c : C | A.cs:15:14:15:42 | call to method Get |
 | A.cs:15:15:15:35 | object creation of type B : B [field c] : C | A.cs:146:18:146:20 | this : B [field c] : C | A.cs:146:33:146:38 | access to field c : C | A.cs:15:14:15:42 | call to method Get |
 | A.cs:15:21:15:34 | call to method Source<C> : C | A.cs:141:20:141:20 | c : C | A.cs:143:13:143:16 | [post] this access : B [field c] : C | A.cs:15:15:15:35 | object creation of type B : B [field c] : C |
+| A.cs:15:21:15:34 | call to method Source<C> : C | A.cs:141:20:141:20 | c : C | A.cs:143:13:143:16 | [post] this access : B [field c] : C | A.cs:15:15:15:35 | object creation of type B : B [field c] : C |
+| A.cs:22:25:22:37 | call to method Source<C2> : C2 | A.cs:42:29:42:29 | c : C2 | A.cs:48:20:48:21 | access to local variable b2 : B [field c] : C2 | A.cs:22:14:22:38 | call to method SetOnB : B [field c] : C2 |
 | A.cs:22:25:22:37 | call to method Source<C2> : C2 | A.cs:42:29:42:29 | c : C2 | A.cs:48:20:48:21 | access to local variable b2 : B [field c] : C2 | A.cs:22:14:22:38 | call to method SetOnB : B [field c] : C2 |
 | A.cs:31:29:31:41 | call to method Source<C2> : C2 | A.cs:36:33:36:33 | c : C2 | A.cs:39:16:39:28 | ... ? ... : ... : B [field c] : C2 | A.cs:31:14:31:42 | call to method SetOnBWrap : B [field c] : C2 |
+| A.cs:31:29:31:41 | call to method Source<C2> : C2 | A.cs:36:33:36:33 | c : C2 | A.cs:39:16:39:28 | ... ? ... : ... : B [field c] : C2 | A.cs:31:14:31:42 | call to method SetOnBWrap : B [field c] : C2 |
+| A.cs:38:29:38:29 | access to parameter c : C2 | A.cs:42:29:42:29 | c : C2 | A.cs:48:20:48:21 | access to local variable b2 : B [field c] : C2 | A.cs:38:18:38:30 | call to method SetOnB : B [field c] : C2 |
 | A.cs:38:29:38:29 | access to parameter c : C2 | A.cs:42:29:42:29 | c : C2 | A.cs:48:20:48:21 | access to local variable b2 : B [field c] : C2 | A.cs:38:18:38:30 | call to method SetOnB : B [field c] : C2 |
 | A.cs:47:20:47:20 | access to parameter c : C2 | A.cs:145:27:145:27 | c : C2 | A.cs:145:32:145:35 | [post] this access : B [field c] : C2 | A.cs:47:13:47:14 | [post] access to local variable b2 : B [field c] : C2 |
+| A.cs:47:20:47:20 | access to parameter c : C2 | A.cs:145:27:145:27 | c : C2 | A.cs:145:32:145:35 | [post] this access : B [field c] : C2 | A.cs:47:13:47:14 | [post] access to local variable b2 : B [field c] : C2 |
+| A.cs:83:15:83:26 | call to method Source<C> : C | A.cs:145:27:145:27 | c : C | A.cs:145:32:145:35 | [post] this access : B [field c] : C | A.cs:83:9:83:9 | [post] access to parameter b : B [field c] : C |
 | A.cs:83:15:83:26 | call to method Source<C> : C | A.cs:145:27:145:27 | c : C | A.cs:145:32:145:35 | [post] this access : B [field c] : C | A.cs:83:9:83:9 | [post] access to parameter b : B [field c] : C |
 | A.cs:105:23:105:23 | access to local variable b : B | A.cs:95:20:95:20 | b : B | A.cs:98:13:98:16 | [post] this access : D [field b] : B | A.cs:105:17:105:29 | object creation of type D : D [field b] : B |
+| A.cs:105:23:105:23 | access to local variable b : B | A.cs:95:20:95:20 | b : B | A.cs:98:13:98:16 | [post] this access : D [field b] : B | A.cs:105:17:105:29 | object creation of type D : D [field b] : B |
+| A.cs:114:29:114:29 | access to local variable b : B | A.cs:157:25:157:28 | head : B | A.cs:159:13:159:16 | [post] this access : MyList [field head] : B | A.cs:114:18:114:54 | object creation of type MyList : MyList [field head] : B |
 | A.cs:114:29:114:29 | access to local variable b : B | A.cs:157:25:157:28 | head : B | A.cs:159:13:159:16 | [post] this access : MyList [field head] : B | A.cs:114:18:114:54 | object creation of type MyList : MyList [field head] : B |
 | A.cs:115:35:115:36 | access to local variable l1 : MyList [field head] : B | A.cs:157:38:157:41 | next : MyList [field head] : B | A.cs:160:13:160:16 | [post] this access : MyList [field next, field head] : B | A.cs:115:18:115:37 | object creation of type MyList : MyList [field next, field head] : B |
+| A.cs:115:35:115:36 | access to local variable l1 : MyList [field head] : B | A.cs:157:38:157:41 | next : MyList [field head] : B | A.cs:160:13:160:16 | [post] this access : MyList [field next, field head] : B | A.cs:115:18:115:37 | object creation of type MyList : MyList [field next, field head] : B |
+| A.cs:116:35:116:36 | access to local variable l2 : MyList [field next, field head] : B | A.cs:157:38:157:41 | next : MyList [field next, field head] : B | A.cs:160:13:160:16 | [post] this access : MyList [field next, field next, field head] : B | A.cs:116:18:116:37 | object creation of type MyList : MyList [field next, field next, field head] : B |
 | A.cs:116:35:116:36 | access to local variable l2 : MyList [field next, field head] : B | A.cs:157:38:157:41 | next : MyList [field next, field head] : B | A.cs:160:13:160:16 | [post] this access : MyList [field next, field next, field head] : B | A.cs:116:18:116:37 | object creation of type MyList : MyList [field next, field next, field head] : B |
 | A.cs:149:26:149:26 | access to parameter c : C | A.cs:141:20:141:20 | c : C | A.cs:143:13:143:16 | [post] this access : B [field c] : C | A.cs:149:20:149:27 | object creation of type B : B [field c] : C |
+| A.cs:149:26:149:26 | access to parameter c : C | A.cs:141:20:141:20 | c : C | A.cs:143:13:143:16 | [post] this access : B [field c] : C | A.cs:149:20:149:27 | object creation of type B : B [field c] : C |
+| B.cs:6:27:6:27 | access to local variable e : Elem | B.cs:29:26:29:27 | e1 : Elem | B.cs:31:13:31:16 | [post] this access : Box1 [field elem1] : Elem | B.cs:6:18:6:34 | object creation of type Box1 : Box1 [field elem1] : Elem |
 | B.cs:6:27:6:27 | access to local variable e : Elem | B.cs:29:26:29:27 | e1 : Elem | B.cs:31:13:31:16 | [post] this access : Box1 [field elem1] : Elem | B.cs:6:18:6:34 | object creation of type Box1 : Box1 [field elem1] : Elem |
 | B.cs:7:27:7:28 | access to local variable b1 : Box1 [field elem1] : Elem | B.cs:39:26:39:27 | b1 : Box1 [field elem1] : Elem | B.cs:41:13:41:16 | [post] this access : Box2 [field box1, field elem1] : Elem | B.cs:7:18:7:29 | object creation of type Box2 : Box2 [field box1, field elem1] : Elem |
+| B.cs:7:27:7:28 | access to local variable b1 : Box1 [field elem1] : Elem | B.cs:39:26:39:27 | b1 : Box1 [field elem1] : Elem | B.cs:41:13:41:16 | [post] this access : Box2 [field box1, field elem1] : Elem | B.cs:7:18:7:29 | object creation of type Box2 : Box2 [field box1, field elem1] : Elem |
+| B.cs:15:33:15:33 | access to local variable e : Elem | B.cs:29:35:29:36 | e2 : Elem | B.cs:32:13:32:16 | [post] this access : Box1 [field elem2] : Elem | B.cs:15:18:15:34 | object creation of type Box1 : Box1 [field elem2] : Elem |
 | B.cs:15:33:15:33 | access to local variable e : Elem | B.cs:29:35:29:36 | e2 : Elem | B.cs:32:13:32:16 | [post] this access : Box1 [field elem2] : Elem | B.cs:15:18:15:34 | object creation of type Box1 : Box1 [field elem2] : Elem |
 | B.cs:16:27:16:28 | access to local variable b1 : Box1 [field elem2] : Elem | B.cs:39:26:39:27 | b1 : Box1 [field elem2] : Elem | B.cs:41:13:41:16 | [post] this access : Box2 [field box1, field elem2] : Elem | B.cs:16:18:16:29 | object creation of type Box2 : Box2 [field box1, field elem2] : Elem |
+| B.cs:16:27:16:28 | access to local variable b1 : Box1 [field elem2] : Elem | B.cs:39:26:39:27 | b1 : Box1 [field elem2] : Elem | B.cs:41:13:41:16 | [post] this access : Box2 [field box1, field elem2] : Elem | B.cs:16:18:16:29 | object creation of type Box2 : Box2 [field box1, field elem2] : Elem |
+| D.cs:15:34:15:38 | access to parameter value : Object | D.cs:9:9:9:11 | value : Object | D.cs:9:15:9:18 | [post] this access : D [field trivialPropField] : Object | D.cs:15:15:15:18 | [post] this access : D [field trivialPropField] : Object |
 | D.cs:15:34:15:38 | access to parameter value : Object | D.cs:9:9:9:11 | value : Object | D.cs:9:15:9:18 | [post] this access : D [field trivialPropField] : Object | D.cs:15:15:15:18 | [post] this access : D [field trivialPropField] : Object |
 | D.cs:22:27:22:28 | access to parameter o2 : Object | D.cs:9:9:9:11 | value : Object | D.cs:9:15:9:18 | [post] this access : D [field trivialPropField] : Object | D.cs:22:9:22:11 | [post] access to local variable ret : D [field trivialPropField] : Object |
+| D.cs:22:27:22:28 | access to parameter o2 : Object | D.cs:9:9:9:11 | value : Object | D.cs:9:15:9:18 | [post] this access : D [field trivialPropField] : Object | D.cs:22:9:22:11 | [post] access to local variable ret : D [field trivialPropField] : Object |
+| D.cs:23:27:23:28 | access to parameter o3 : Object | D.cs:15:9:15:11 | value : Object | D.cs:15:15:15:18 | [post] this access : D [field trivialPropField] : Object | D.cs:23:9:23:11 | [post] access to local variable ret : D [field trivialPropField] : Object |
 | D.cs:23:27:23:28 | access to parameter o3 : Object | D.cs:15:9:15:11 | value : Object | D.cs:15:15:15:18 | [post] this access : D [field trivialPropField] : Object | D.cs:23:9:23:11 | [post] access to local variable ret : D [field trivialPropField] : Object |
 | D.cs:31:24:31:24 | access to local variable o : Object | D.cs:18:28:18:29 | o1 : Object | D.cs:24:16:24:18 | access to local variable ret : D [property AutoProp] : Object | D.cs:31:17:31:37 | call to method Create : D [property AutoProp] : Object |
+| D.cs:31:24:31:24 | access to local variable o : Object | D.cs:18:28:18:29 | o1 : Object | D.cs:24:16:24:18 | access to local variable ret : D [property AutoProp] : Object | D.cs:31:17:31:37 | call to method Create : D [property AutoProp] : Object |
+| D.cs:37:26:37:42 | call to method Source<Object> : Object | D.cs:18:39:18:40 | o2 : Object | D.cs:24:16:24:18 | access to local variable ret : D [field trivialPropField] : Object | D.cs:37:13:37:49 | call to method Create : D [field trivialPropField] : Object |
 | D.cs:37:26:37:42 | call to method Source<Object> : Object | D.cs:18:39:18:40 | o2 : Object | D.cs:24:16:24:18 | access to local variable ret : D [field trivialPropField] : Object | D.cs:37:13:37:49 | call to method Create : D [field trivialPropField] : Object |
 | D.cs:39:14:39:14 | access to local variable d : D [field trivialPropField] : Object | D.cs:8:9:8:11 | this : D [field trivialPropField] : Object | D.cs:8:22:8:42 | access to field trivialPropField : Object | D.cs:39:14:39:26 | access to property TrivialProp |
+| D.cs:39:14:39:14 | access to local variable d : D [field trivialPropField] : Object | D.cs:8:9:8:11 | this : D [field trivialPropField] : Object | D.cs:8:22:8:42 | access to field trivialPropField : Object | D.cs:39:14:39:26 | access to property TrivialProp |
+| D.cs:41:14:41:14 | access to local variable d : D [field trivialPropField] : Object | D.cs:14:9:14:11 | this : D [field trivialPropField] : Object | D.cs:14:22:14:42 | access to field trivialPropField : Object | D.cs:41:14:41:26 | access to property ComplexProp |
 | D.cs:41:14:41:14 | access to local variable d : D [field trivialPropField] : Object | D.cs:14:9:14:11 | this : D [field trivialPropField] : Object | D.cs:14:22:14:42 | access to field trivialPropField : Object | D.cs:41:14:41:26 | access to property ComplexProp |
 | D.cs:43:32:43:48 | call to method Source<Object> : Object | D.cs:18:50:18:51 | o3 : Object | D.cs:24:16:24:18 | access to local variable ret : D [field trivialPropField] : Object | D.cs:43:13:43:49 | call to method Create : D [field trivialPropField] : Object |
+| D.cs:43:32:43:48 | call to method Source<Object> : Object | D.cs:18:50:18:51 | o3 : Object | D.cs:24:16:24:18 | access to local variable ret : D [field trivialPropField] : Object | D.cs:43:13:43:49 | call to method Create : D [field trivialPropField] : Object |
+| D.cs:45:14:45:14 | access to local variable d : D [field trivialPropField] : Object | D.cs:8:9:8:11 | this : D [field trivialPropField] : Object | D.cs:8:22:8:42 | access to field trivialPropField : Object | D.cs:45:14:45:26 | access to property TrivialProp |
 | D.cs:45:14:45:14 | access to local variable d : D [field trivialPropField] : Object | D.cs:8:9:8:11 | this : D [field trivialPropField] : Object | D.cs:8:22:8:42 | access to field trivialPropField : Object | D.cs:45:14:45:26 | access to property TrivialProp |
 | D.cs:47:14:47:14 | access to local variable d : D [field trivialPropField] : Object | D.cs:14:9:14:11 | this : D [field trivialPropField] : Object | D.cs:14:22:14:42 | access to field trivialPropField : Object | D.cs:47:14:47:26 | access to property ComplexProp |
+| D.cs:47:14:47:14 | access to local variable d : D [field trivialPropField] : Object | D.cs:14:9:14:11 | this : D [field trivialPropField] : Object | D.cs:14:22:14:42 | access to field trivialPropField : Object | D.cs:47:14:47:26 | access to property ComplexProp |
+| E.cs:23:25:23:25 | access to local variable o : Object | E.cs:8:29:8:29 | o : Object | E.cs:12:16:12:18 | access to local variable ret : S [field Field] : Object | E.cs:23:17:23:26 | call to method CreateS : S [field Field] : Object |
 | E.cs:23:25:23:25 | access to local variable o : Object | E.cs:8:29:8:29 | o : Object | E.cs:12:16:12:18 | access to local variable ret : S [field Field] : Object | E.cs:23:17:23:26 | call to method CreateS : S [field Field] : Object |
 | F.cs:11:24:11:24 | access to local variable o : Object | F.cs:6:28:6:29 | o1 : Object | F.cs:6:46:6:81 | object creation of type F : F [field Field1] : Object | F.cs:11:17:11:31 | call to method Create : F [field Field1] : Object |
+| F.cs:11:24:11:24 | access to local variable o : Object | F.cs:6:28:6:29 | o1 : Object | F.cs:6:46:6:81 | object creation of type F : F [field Field1] : Object | F.cs:11:17:11:31 | call to method Create : F [field Field1] : Object |
+| F.cs:15:26:15:42 | call to method Source<Object> : Object | F.cs:6:39:6:40 | o2 : Object | F.cs:6:46:6:81 | object creation of type F : F [field Field2] : Object | F.cs:15:13:15:43 | call to method Create : F [field Field2] : Object |
 | F.cs:15:26:15:42 | call to method Source<Object> : Object | F.cs:6:39:6:40 | o2 : Object | F.cs:6:46:6:81 | object creation of type F : F [field Field2] : Object | F.cs:15:13:15:43 | call to method Create : F [field Field2] : Object |
 | G.cs:17:24:17:24 | access to local variable e : Elem | G.cs:64:34:64:34 | e : Elem | G.cs:64:39:64:42 | [post] this access : Box1 [field Elem] : Elem | G.cs:17:9:17:14 | [post] access to field Box1 : Box1 [field Elem] : Elem |
+| G.cs:17:24:17:24 | access to local variable e : Elem | G.cs:64:34:64:34 | e : Elem | G.cs:64:39:64:42 | [post] this access : Box1 [field Elem] : Elem | G.cs:17:9:17:14 | [post] access to field Box1 : Box1 [field Elem] : Elem |
+| G.cs:33:29:33:29 | access to local variable e : Elem | G.cs:64:34:64:34 | e : Elem | G.cs:64:39:64:42 | [post] this access : Box1 [field Elem] : Elem | G.cs:33:9:33:19 | [post] call to method GetBox1 : Box1 [field Elem] : Elem |
 | G.cs:33:29:33:29 | access to local variable e : Elem | G.cs:64:34:64:34 | e : Elem | G.cs:64:39:64:42 | [post] this access : Box1 [field Elem] : Elem | G.cs:33:9:33:19 | [post] call to method GetBox1 : Box1 [field Elem] : Elem |
 | G.cs:39:14:39:15 | access to parameter b2 : Box2 [field Box1, field Elem] : Elem | G.cs:71:21:71:27 | this : Box2 [field Box1, field Elem] : Elem | G.cs:71:34:71:37 | access to field Box1 : Box1 [field Elem] : Elem | G.cs:39:14:39:25 | call to method GetBox1 : Box1 [field Elem] : Elem |
+| G.cs:39:14:39:15 | access to parameter b2 : Box2 [field Box1, field Elem] : Elem | G.cs:71:21:71:27 | this : Box2 [field Box1, field Elem] : Elem | G.cs:71:34:71:37 | access to field Box1 : Box1 [field Elem] : Elem | G.cs:39:14:39:25 | call to method GetBox1 : Box1 [field Elem] : Elem |
+| G.cs:39:14:39:25 | call to method GetBox1 : Box1 [field Elem] : Elem | G.cs:63:21:63:27 | this : Box1 [field Elem] : Elem | G.cs:63:34:63:37 | access to field Elem : Elem | G.cs:39:14:39:35 | call to method GetElem |
 | G.cs:39:14:39:25 | call to method GetBox1 : Box1 [field Elem] : Elem | G.cs:63:21:63:27 | this : Box1 [field Elem] : Elem | G.cs:63:34:63:37 | access to field Elem : Elem | G.cs:39:14:39:35 | call to method GetElem |
 | H.cs:24:27:24:27 | access to local variable a : A [field FieldA] : Object | H.cs:13:15:13:15 | a : A [field FieldA] : Object | H.cs:17:16:17:18 | access to local variable ret : A [field FieldA] : Object | H.cs:24:21:24:28 | call to method Clone : A [field FieldA] : Object |
+| H.cs:24:27:24:27 | access to local variable a : A [field FieldA] : Object | H.cs:13:15:13:15 | a : A [field FieldA] : Object | H.cs:17:16:17:18 | access to local variable ret : A [field FieldA] : Object | H.cs:24:21:24:28 | call to method Clone : A [field FieldA] : Object |
+| H.cs:44:27:44:27 | access to local variable a : A [field FieldA] : Object | H.cs:33:19:33:19 | a : A [field FieldA] : Object | H.cs:37:16:37:16 | access to local variable b : B [field FieldB] : Object | H.cs:44:17:44:28 | call to method Transform : B [field FieldB] : Object |
 | H.cs:44:27:44:27 | access to local variable a : A [field FieldA] : Object | H.cs:33:19:33:19 | a : A [field FieldA] : Object | H.cs:37:16:37:16 | access to local variable b : B [field FieldB] : Object | H.cs:44:17:44:28 | call to method Transform : B [field FieldB] : Object |
 | H.cs:64:22:64:22 | access to local variable a : A [field FieldA] : Object | H.cs:53:25:53:25 | a : A [field FieldA] : Object | H.cs:55:9:55:10 | [post] access to parameter b1 : B [field FieldB] : Object | H.cs:64:25:64:26 | [post] access to local variable b1 : B [field FieldB] : Object |
+| H.cs:64:22:64:22 | access to local variable a : A [field FieldA] : Object | H.cs:53:25:53:25 | a : A [field FieldA] : Object | H.cs:55:9:55:10 | [post] access to parameter b1 : B [field FieldB] : Object | H.cs:64:25:64:26 | [post] access to local variable b1 : B [field FieldB] : Object |
+| H.cs:80:22:80:22 | access to parameter a : A [field FieldA] : Object | H.cs:53:25:53:25 | a : A [field FieldA] : Object | H.cs:55:9:55:10 | [post] access to parameter b1 : B [field FieldB] : Object | H.cs:80:25:80:26 | [post] access to parameter b1 : B [field FieldB] : Object |
 | H.cs:80:22:80:22 | access to parameter a : A [field FieldA] : Object | H.cs:53:25:53:25 | a : A [field FieldA] : Object | H.cs:55:9:55:10 | [post] access to parameter b1 : B [field FieldB] : Object | H.cs:80:25:80:26 | [post] access to parameter b1 : B [field FieldB] : Object |
 | H.cs:88:20:88:36 | call to method Source<Object> : Object | H.cs:77:30:77:30 | o : Object | H.cs:79:9:79:9 | [post] access to parameter a : A [field FieldA] : Object | H.cs:88:17:88:17 | [post] access to local variable a : A [field FieldA] : Object |
+| H.cs:88:20:88:36 | call to method Source<Object> : Object | H.cs:77:30:77:30 | o : Object | H.cs:79:9:79:9 | [post] access to parameter a : A [field FieldA] : Object | H.cs:88:17:88:17 | [post] access to local variable a : A [field FieldA] : Object |
+| H.cs:88:20:88:36 | call to method Source<Object> : Object | H.cs:77:30:77:30 | o : Object | H.cs:80:25:80:26 | [post] access to parameter b1 : B [field FieldB] : Object | H.cs:88:39:88:40 | [post] access to local variable b1 : B [field FieldB] : Object |
 | H.cs:88:20:88:36 | call to method Source<Object> : Object | H.cs:77:30:77:30 | o : Object | H.cs:80:25:80:26 | [post] access to parameter b1 : B [field FieldB] : Object | H.cs:88:39:88:40 | [post] access to local variable b1 : B [field FieldB] : Object |
 | H.cs:106:26:106:39 | (...) ... : A [field FieldA] : Object | H.cs:33:19:33:19 | a : A [field FieldA] : Object | H.cs:37:16:37:16 | access to local variable b : B [field FieldB] : Object | H.cs:106:16:106:40 | call to method Transform : B [field FieldB] : Object |
+| H.cs:106:26:106:39 | (...) ... : A [field FieldA] : Object | H.cs:33:19:33:19 | a : A [field FieldA] : Object | H.cs:37:16:37:16 | access to local variable b : B [field FieldB] : Object | H.cs:106:16:106:40 | call to method Transform : B [field FieldB] : Object |
+| H.cs:113:31:113:31 | access to local variable a : A [field FieldA] : Object | H.cs:102:23:102:23 | a : A [field FieldA] : Object | H.cs:106:16:106:40 | call to method Transform : B [field FieldB] : Object | H.cs:113:17:113:32 | call to method TransformWrap : B [field FieldB] : Object |
 | H.cs:113:31:113:31 | access to local variable a : A [field FieldA] : Object | H.cs:102:23:102:23 | a : A [field FieldA] : Object | H.cs:106:16:106:40 | call to method Transform : B [field FieldB] : Object | H.cs:113:17:113:32 | call to method TransformWrap : B [field FieldB] : Object |
 | H.cs:124:26:124:26 | access to parameter a : A [field FieldA] : Object | H.cs:33:19:33:19 | a : A [field FieldA] : Object | H.cs:37:16:37:16 | access to local variable b : B [field FieldB] : Object | H.cs:124:16:124:27 | call to method Transform : B [field FieldB] : Object |
+| H.cs:124:26:124:26 | access to parameter a : A [field FieldA] : Object | H.cs:33:19:33:19 | a : A [field FieldA] : Object | H.cs:37:16:37:16 | access to local variable b : B [field FieldB] : Object | H.cs:124:16:124:27 | call to method Transform : B [field FieldB] : Object |
+| H.cs:131:18:131:18 | access to local variable a : A [field FieldA] : Object | H.cs:122:18:122:18 | a : A [field FieldA] : Object | H.cs:124:16:124:34 | access to field FieldB : Object | H.cs:131:14:131:19 | call to method Get |
 | H.cs:131:18:131:18 | access to local variable a : A [field FieldA] : Object | H.cs:122:18:122:18 | a : A [field FieldA] : Object | H.cs:124:16:124:34 | access to field FieldB : Object | H.cs:131:14:131:19 | call to method Get |
 | H.cs:142:26:142:26 | access to local variable a : A [field FieldA] : A | H.cs:33:19:33:19 | a : A [field FieldA] : A | H.cs:37:16:37:16 | access to local variable b : B [field FieldB] : A | H.cs:142:16:142:27 | call to method Transform : B [field FieldB] : A |
+| H.cs:142:26:142:26 | access to local variable a : A [field FieldA] : A | H.cs:33:19:33:19 | a : A [field FieldA] : A | H.cs:37:16:37:16 | access to local variable b : B [field FieldB] : A | H.cs:142:16:142:27 | call to method Transform : B [field FieldB] : A |
+| H.cs:147:25:147:38 | call to method Source<A> : A | H.cs:138:27:138:27 | o : A | H.cs:142:16:142:34 | access to field FieldB : A | H.cs:147:17:147:39 | call to method Through : A |
 | H.cs:147:25:147:38 | call to method Source<A> : A | H.cs:138:27:138:27 | o : A | H.cs:142:16:142:34 | access to field FieldB : A | H.cs:147:17:147:39 | call to method Through : A |
 | H.cs:164:22:164:22 | access to local variable o : Object | H.cs:153:32:153:32 | o : Object | H.cs:157:9:157:9 | [post] access to parameter a : A [field FieldA, field FieldB] : Object | H.cs:164:19:164:19 | [post] access to local variable a : A [field FieldA, field FieldB] : Object |
+| H.cs:164:22:164:22 | access to local variable o : Object | H.cs:153:32:153:32 | o : Object | H.cs:157:9:157:9 | [post] access to parameter a : A [field FieldA, field FieldB] : Object | H.cs:164:19:164:19 | [post] access to local variable a : A [field FieldA, field FieldB] : Object |
 | J.cs:62:29:62:29 | access to local variable o : Object | J.cs:14:26:14:30 | field : Object | J.cs:14:50:14:54 | [post] this access : Struct [field Field] : Object | J.cs:62:18:62:36 | object creation of type Struct : Struct [field Field] : Object |
+| J.cs:62:29:62:29 | access to local variable o : Object | J.cs:14:26:14:30 | field : Object | J.cs:14:50:14:54 | [post] this access : Struct [field Field] : Object | J.cs:62:18:62:36 | object creation of type Struct : Struct [field Field] : Object |
+| J.cs:80:35:80:35 | access to local variable o : Object | J.cs:14:40:14:43 | prop : Object | J.cs:14:57:14:60 | [post] this access : Struct [property Prop] : Object | J.cs:80:18:80:36 | object creation of type Struct : Struct [property Prop] : Object |
 | J.cs:80:35:80:35 | access to local variable o : Object | J.cs:14:40:14:43 | prop : Object | J.cs:14:57:14:60 | [post] this access : Struct [property Prop] : Object | J.cs:80:18:80:36 | object creation of type Struct : Struct [property Prop] : Object |
 #select
 | A.cs:7:14:7:16 | access to field c | A.cs:5:17:5:28 | call to method Source<C> : C | A.cs:7:14:7:16 | access to field c | $@ | A.cs:5:17:5:28 | call to method Source<C> : C | call to method Source<C> : C |
+| A.cs:7:14:7:16 | access to field c | A.cs:5:17:5:28 | call to method Source<C> : C | A.cs:7:14:7:16 | access to field c | $@ | A.cs:5:17:5:28 | call to method Source<C> : C | call to method Source<C> : C |
+| A.cs:14:14:14:20 | call to method Get | A.cs:13:15:13:29 | call to method Source<C1> : C1 | A.cs:14:14:14:20 | call to method Get | $@ | A.cs:13:15:13:29 | call to method Source<C1> : C1 | call to method Source<C1> : C1 |
 | A.cs:14:14:14:20 | call to method Get | A.cs:13:15:13:29 | call to method Source<C1> : C1 | A.cs:14:14:14:20 | call to method Get | $@ | A.cs:13:15:13:29 | call to method Source<C1> : C1 | call to method Source<C1> : C1 |
 | A.cs:15:14:15:42 | call to method Get | A.cs:15:21:15:34 | call to method Source<C> : C | A.cs:15:14:15:42 | call to method Get | $@ | A.cs:15:21:15:34 | call to method Source<C> : C | call to method Source<C> : C |
+| A.cs:15:14:15:42 | call to method Get | A.cs:15:21:15:34 | call to method Source<C> : C | A.cs:15:14:15:42 | call to method Get | $@ | A.cs:15:21:15:34 | call to method Source<C> : C | call to method Source<C> : C |
+| A.cs:24:14:24:17 | access to field c | A.cs:22:25:22:37 | call to method Source<C2> : C2 | A.cs:24:14:24:17 | access to field c | $@ | A.cs:22:25:22:37 | call to method Source<C2> : C2 | call to method Source<C2> : C2 |
 | A.cs:24:14:24:17 | access to field c | A.cs:22:25:22:37 | call to method Source<C2> : C2 | A.cs:24:14:24:17 | access to field c | $@ | A.cs:22:25:22:37 | call to method Source<C2> : C2 | call to method Source<C2> : C2 |
 | A.cs:33:14:33:17 | access to field c | A.cs:31:29:31:41 | call to method Source<C2> : C2 | A.cs:33:14:33:17 | access to field c | $@ | A.cs:31:29:31:41 | call to method Source<C2> : C2 | call to method Source<C2> : C2 |
+| A.cs:33:14:33:17 | access to field c | A.cs:31:29:31:41 | call to method Source<C2> : C2 | A.cs:33:14:33:17 | access to field c | $@ | A.cs:31:29:31:41 | call to method Source<C2> : C2 | call to method Source<C2> : C2 |
+| A.cs:64:18:64:26 | access to field a | A.cs:55:17:55:28 | call to method Source<A> : A | A.cs:64:18:64:26 | access to field a | $@ | A.cs:55:17:55:28 | call to method Source<A> : A | call to method Source<A> : A |
 | A.cs:64:18:64:26 | access to field a | A.cs:55:17:55:28 | call to method Source<A> : A | A.cs:64:18:64:26 | access to field a | $@ | A.cs:55:17:55:28 | call to method Source<A> : A | call to method Source<A> : A |
 | A.cs:89:14:89:16 | access to field c | A.cs:83:15:83:26 | call to method Source<C> : C | A.cs:89:14:89:16 | access to field c | $@ | A.cs:83:15:83:26 | call to method Source<C> : C | call to method Source<C> : C |
+| A.cs:89:14:89:16 | access to field c | A.cs:83:15:83:26 | call to method Source<C> : C | A.cs:89:14:89:16 | access to field c | $@ | A.cs:83:15:83:26 | call to method Source<C> : C | call to method Source<C> : C |
+| A.cs:106:14:106:16 | access to field b | A.cs:98:30:98:43 | call to method Source<B> : B | A.cs:106:14:106:16 | access to field b | $@ | A.cs:98:30:98:43 | call to method Source<B> : B | call to method Source<B> : B |
 | A.cs:106:14:106:16 | access to field b | A.cs:98:30:98:43 | call to method Source<B> : B | A.cs:106:14:106:16 | access to field b | $@ | A.cs:98:30:98:43 | call to method Source<B> : B | call to method Source<B> : B |
 | A.cs:106:14:106:16 | access to field b | A.cs:104:17:104:30 | call to method Source<B> : B | A.cs:106:14:106:16 | access to field b | $@ | A.cs:104:17:104:30 | call to method Source<B> : B | call to method Source<B> : B |
+| A.cs:106:14:106:16 | access to field b | A.cs:104:17:104:30 | call to method Source<B> : B | A.cs:106:14:106:16 | access to field b | $@ | A.cs:104:17:104:30 | call to method Source<B> : B | call to method Source<B> : B |
+| A.cs:107:14:107:18 | access to field c | A.cs:97:19:97:32 | call to method Source<C> : C | A.cs:107:14:107:18 | access to field c | $@ | A.cs:97:19:97:32 | call to method Source<C> : C | call to method Source<C> : C |
 | A.cs:107:14:107:18 | access to field c | A.cs:97:19:97:32 | call to method Source<C> : C | A.cs:107:14:107:18 | access to field c | $@ | A.cs:97:19:97:32 | call to method Source<C> : C | call to method Source<C> : C |
 | A.cs:108:14:108:16 | access to field c | A.cs:97:19:97:32 | call to method Source<C> : C | A.cs:108:14:108:16 | access to field c | $@ | A.cs:97:19:97:32 | call to method Source<C> : C | call to method Source<C> : C |
+| A.cs:108:14:108:16 | access to field c | A.cs:97:19:97:32 | call to method Source<C> : C | A.cs:108:14:108:16 | access to field c | $@ | A.cs:97:19:97:32 | call to method Source<C> : C | call to method Source<C> : C |
+| A.cs:119:14:119:30 | access to field head | A.cs:113:17:113:29 | call to method Source<B> : B | A.cs:119:14:119:30 | access to field head | $@ | A.cs:113:17:113:29 | call to method Source<B> : B | call to method Source<B> : B |
 | A.cs:119:14:119:30 | access to field head | A.cs:113:17:113:29 | call to method Source<B> : B | A.cs:119:14:119:30 | access to field head | $@ | A.cs:113:17:113:29 | call to method Source<B> : B | call to method Source<B> : B |
 | A.cs:123:18:123:23 | access to field head | A.cs:113:17:113:29 | call to method Source<B> : B | A.cs:123:18:123:23 | access to field head | $@ | A.cs:113:17:113:29 | call to method Source<B> : B | call to method Source<B> : B |
+| A.cs:123:18:123:23 | access to field head | A.cs:113:17:113:29 | call to method Source<B> : B | A.cs:123:18:123:23 | access to field head | $@ | A.cs:113:17:113:29 | call to method Source<B> : B | call to method Source<B> : B |
+| B.cs:8:14:8:26 | access to field elem1 | B.cs:5:17:5:31 | call to method Source<Elem> : Elem | B.cs:8:14:8:26 | access to field elem1 | $@ | B.cs:5:17:5:31 | call to method Source<Elem> : Elem | call to method Source<Elem> : Elem |
 | B.cs:8:14:8:26 | access to field elem1 | B.cs:5:17:5:31 | call to method Source<Elem> : Elem | B.cs:8:14:8:26 | access to field elem1 | $@ | B.cs:5:17:5:31 | call to method Source<Elem> : Elem | call to method Source<Elem> : Elem |
 | B.cs:18:14:18:26 | access to field elem2 | B.cs:14:17:14:31 | call to method Source<Elem> : Elem | B.cs:18:14:18:26 | access to field elem2 | $@ | B.cs:14:17:14:31 | call to method Source<Elem> : Elem | call to method Source<Elem> : Elem |
+| B.cs:18:14:18:26 | access to field elem2 | B.cs:14:17:14:31 | call to method Source<Elem> : Elem | B.cs:18:14:18:26 | access to field elem2 | $@ | B.cs:14:17:14:31 | call to method Source<Elem> : Elem | call to method Source<Elem> : Elem |
+| C.cs:23:14:23:15 | access to field s1 | C.cs:3:23:3:37 | call to method Source<Elem> : Elem | C.cs:23:14:23:15 | access to field s1 | $@ | C.cs:3:23:3:37 | call to method Source<Elem> : Elem | call to method Source<Elem> : Elem |
 | C.cs:23:14:23:15 | access to field s1 | C.cs:3:23:3:37 | call to method Source<Elem> : Elem | C.cs:23:14:23:15 | access to field s1 | $@ | C.cs:3:23:3:37 | call to method Source<Elem> : Elem | call to method Source<Elem> : Elem |
 | C.cs:24:14:24:15 | access to field s2 | C.cs:4:32:4:46 | call to method Source<Elem> : Elem | C.cs:24:14:24:15 | access to field s2 | $@ | C.cs:4:32:4:46 | call to method Source<Elem> : Elem | call to method Source<Elem> : Elem |
+| C.cs:24:14:24:15 | access to field s2 | C.cs:4:32:4:46 | call to method Source<Elem> : Elem | C.cs:24:14:24:15 | access to field s2 | $@ | C.cs:4:32:4:46 | call to method Source<Elem> : Elem | call to method Source<Elem> : Elem |
+| C.cs:25:14:25:15 | access to field s3 | C.cs:18:19:18:33 | call to method Source<Elem> : Elem | C.cs:25:14:25:15 | access to field s3 | $@ | C.cs:18:19:18:33 | call to method Source<Elem> : Elem | call to method Source<Elem> : Elem |
 | C.cs:25:14:25:15 | access to field s3 | C.cs:18:19:18:33 | call to method Source<Elem> : Elem | C.cs:25:14:25:15 | access to field s3 | $@ | C.cs:18:19:18:33 | call to method Source<Elem> : Elem | call to method Source<Elem> : Elem |
 | C.cs:26:14:26:15 | access to field s4 | C.cs:6:30:6:44 | call to method Source<Elem> : Elem | C.cs:26:14:26:15 | access to field s4 | $@ | C.cs:6:30:6:44 | call to method Source<Elem> : Elem | call to method Source<Elem> : Elem |
+| C.cs:26:14:26:15 | access to field s4 | C.cs:6:30:6:44 | call to method Source<Elem> : Elem | C.cs:26:14:26:15 | access to field s4 | $@ | C.cs:6:30:6:44 | call to method Source<Elem> : Elem | call to method Source<Elem> : Elem |
+| C.cs:27:14:27:15 | access to property s5 | C.cs:7:37:7:51 | call to method Source<Elem> : Elem | C.cs:27:14:27:15 | access to property s5 | $@ | C.cs:7:37:7:51 | call to method Source<Elem> : Elem | call to method Source<Elem> : Elem |
 | C.cs:27:14:27:15 | access to property s5 | C.cs:7:37:7:51 | call to method Source<Elem> : Elem | C.cs:27:14:27:15 | access to property s5 | $@ | C.cs:7:37:7:51 | call to method Source<Elem> : Elem | call to method Source<Elem> : Elem |
 | C.cs:28:14:28:15 | access to property s6 | C.cs:8:30:8:44 | call to method Source<Elem> : Elem | C.cs:28:14:28:15 | access to property s6 | $@ | C.cs:8:30:8:44 | call to method Source<Elem> : Elem | call to method Source<Elem> : Elem |
+| C.cs:28:14:28:15 | access to property s6 | C.cs:8:30:8:44 | call to method Source<Elem> : Elem | C.cs:28:14:28:15 | access to property s6 | $@ | C.cs:8:30:8:44 | call to method Source<Elem> : Elem | call to method Source<Elem> : Elem |
+| C_ctor.cs:13:19:13:20 | access to field s1 | C_ctor.cs:3:23:3:42 | call to method Source<Elem> : Elem | C_ctor.cs:13:19:13:20 | access to field s1 | $@ | C_ctor.cs:3:23:3:42 | call to method Source<Elem> : Elem | call to method Source<Elem> : Elem |
 | C_ctor.cs:13:19:13:20 | access to field s1 | C_ctor.cs:3:23:3:42 | call to method Source<Elem> : Elem | C_ctor.cs:13:19:13:20 | access to field s1 | $@ | C_ctor.cs:3:23:3:42 | call to method Source<Elem> : Elem | call to method Source<Elem> : Elem |
 | C_ctor.cs:31:19:31:20 | access to field s1 | C_ctor.cs:19:23:19:42 | call to method Source<Elem> : Elem | C_ctor.cs:31:19:31:20 | access to field s1 | $@ | C_ctor.cs:19:23:19:42 | call to method Source<Elem> : Elem | call to method Source<Elem> : Elem |
+| C_ctor.cs:31:19:31:20 | access to field s1 | C_ctor.cs:19:23:19:42 | call to method Source<Elem> : Elem | C_ctor.cs:31:19:31:20 | access to field s1 | $@ | C_ctor.cs:19:23:19:42 | call to method Source<Elem> : Elem | call to method Source<Elem> : Elem |
+| D.cs:32:14:32:23 | access to property AutoProp | D.cs:29:17:29:33 | call to method Source<Object> : Object | D.cs:32:14:32:23 | access to property AutoProp | $@ | D.cs:29:17:29:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | D.cs:32:14:32:23 | access to property AutoProp | D.cs:29:17:29:33 | call to method Source<Object> : Object | D.cs:32:14:32:23 | access to property AutoProp | $@ | D.cs:29:17:29:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | D.cs:39:14:39:26 | access to property TrivialProp | D.cs:37:26:37:42 | call to method Source<Object> : Object | D.cs:39:14:39:26 | access to property TrivialProp | $@ | D.cs:37:26:37:42 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| D.cs:39:14:39:26 | access to property TrivialProp | D.cs:37:26:37:42 | call to method Source<Object> : Object | D.cs:39:14:39:26 | access to property TrivialProp | $@ | D.cs:37:26:37:42 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| D.cs:40:14:40:31 | access to field trivialPropField | D.cs:37:26:37:42 | call to method Source<Object> : Object | D.cs:40:14:40:31 | access to field trivialPropField | $@ | D.cs:37:26:37:42 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | D.cs:40:14:40:31 | access to field trivialPropField | D.cs:37:26:37:42 | call to method Source<Object> : Object | D.cs:40:14:40:31 | access to field trivialPropField | $@ | D.cs:37:26:37:42 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | D.cs:41:14:41:26 | access to property ComplexProp | D.cs:37:26:37:42 | call to method Source<Object> : Object | D.cs:41:14:41:26 | access to property ComplexProp | $@ | D.cs:37:26:37:42 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| D.cs:41:14:41:26 | access to property ComplexProp | D.cs:37:26:37:42 | call to method Source<Object> : Object | D.cs:41:14:41:26 | access to property ComplexProp | $@ | D.cs:37:26:37:42 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| D.cs:45:14:45:26 | access to property TrivialProp | D.cs:43:32:43:48 | call to method Source<Object> : Object | D.cs:45:14:45:26 | access to property TrivialProp | $@ | D.cs:43:32:43:48 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | D.cs:45:14:45:26 | access to property TrivialProp | D.cs:43:32:43:48 | call to method Source<Object> : Object | D.cs:45:14:45:26 | access to property TrivialProp | $@ | D.cs:43:32:43:48 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | D.cs:46:14:46:31 | access to field trivialPropField | D.cs:43:32:43:48 | call to method Source<Object> : Object | D.cs:46:14:46:31 | access to field trivialPropField | $@ | D.cs:43:32:43:48 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| D.cs:46:14:46:31 | access to field trivialPropField | D.cs:43:32:43:48 | call to method Source<Object> : Object | D.cs:46:14:46:31 | access to field trivialPropField | $@ | D.cs:43:32:43:48 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| D.cs:47:14:47:26 | access to property ComplexProp | D.cs:43:32:43:48 | call to method Source<Object> : Object | D.cs:47:14:47:26 | access to property ComplexProp | $@ | D.cs:43:32:43:48 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | D.cs:47:14:47:26 | access to property ComplexProp | D.cs:43:32:43:48 | call to method Source<Object> : Object | D.cs:47:14:47:26 | access to property ComplexProp | $@ | D.cs:43:32:43:48 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | E.cs:24:14:24:20 | access to field Field | E.cs:22:17:22:33 | call to method Source<Object> : Object | E.cs:24:14:24:20 | access to field Field | $@ | E.cs:22:17:22:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| E.cs:24:14:24:20 | access to field Field | E.cs:22:17:22:33 | call to method Source<Object> : Object | E.cs:24:14:24:20 | access to field Field | $@ | E.cs:22:17:22:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| F.cs:12:14:12:21 | access to field Field1 | F.cs:10:17:10:33 | call to method Source<Object> : Object | F.cs:12:14:12:21 | access to field Field1 | $@ | F.cs:10:17:10:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | F.cs:12:14:12:21 | access to field Field1 | F.cs:10:17:10:33 | call to method Source<Object> : Object | F.cs:12:14:12:21 | access to field Field1 | $@ | F.cs:10:17:10:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | F.cs:17:14:17:21 | access to field Field2 | F.cs:15:26:15:42 | call to method Source<Object> : Object | F.cs:17:14:17:21 | access to field Field2 | $@ | F.cs:15:26:15:42 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| F.cs:17:14:17:21 | access to field Field2 | F.cs:15:26:15:42 | call to method Source<Object> : Object | F.cs:17:14:17:21 | access to field Field2 | $@ | F.cs:15:26:15:42 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| F.cs:20:14:20:21 | access to field Field1 | F.cs:19:32:19:48 | call to method Source<Object> : Object | F.cs:20:14:20:21 | access to field Field1 | $@ | F.cs:19:32:19:48 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | F.cs:20:14:20:21 | access to field Field1 | F.cs:19:32:19:48 | call to method Source<Object> : Object | F.cs:20:14:20:21 | access to field Field1 | $@ | F.cs:19:32:19:48 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | F.cs:25:14:25:21 | access to field Field2 | F.cs:23:32:23:48 | call to method Source<Object> : Object | F.cs:25:14:25:21 | access to field Field2 | $@ | F.cs:23:32:23:48 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| F.cs:25:14:25:21 | access to field Field2 | F.cs:23:32:23:48 | call to method Source<Object> : Object | F.cs:25:14:25:21 | access to field Field2 | $@ | F.cs:23:32:23:48 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| F.cs:33:14:33:16 | access to property X | F.cs:30:17:30:33 | call to method Source<Object> : Object | F.cs:33:14:33:16 | access to property X | $@ | F.cs:30:17:30:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | F.cs:33:14:33:16 | access to property X | F.cs:30:17:30:33 | call to method Source<Object> : Object | F.cs:33:14:33:16 | access to property X | $@ | F.cs:30:17:30:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | G.cs:39:14:39:35 | call to method GetElem | G.cs:7:18:7:32 | call to method Source<Elem> : Elem | G.cs:39:14:39:35 | call to method GetElem | $@ | G.cs:7:18:7:32 | call to method Source<Elem> : Elem | call to method Source<Elem> : Elem |
+| G.cs:39:14:39:35 | call to method GetElem | G.cs:7:18:7:32 | call to method Source<Elem> : Elem | G.cs:39:14:39:35 | call to method GetElem | $@ | G.cs:7:18:7:32 | call to method Source<Elem> : Elem | call to method Source<Elem> : Elem |
+| G.cs:39:14:39:35 | call to method GetElem | G.cs:15:18:15:32 | call to method Source<Elem> : Elem | G.cs:39:14:39:35 | call to method GetElem | $@ | G.cs:15:18:15:32 | call to method Source<Elem> : Elem | call to method Source<Elem> : Elem |
 | G.cs:39:14:39:35 | call to method GetElem | G.cs:15:18:15:32 | call to method Source<Elem> : Elem | G.cs:39:14:39:35 | call to method GetElem | $@ | G.cs:15:18:15:32 | call to method Source<Elem> : Elem | call to method Source<Elem> : Elem |
 | G.cs:39:14:39:35 | call to method GetElem | G.cs:23:18:23:32 | call to method Source<Elem> : Elem | G.cs:39:14:39:35 | call to method GetElem | $@ | G.cs:23:18:23:32 | call to method Source<Elem> : Elem | call to method Source<Elem> : Elem |
+| G.cs:39:14:39:35 | call to method GetElem | G.cs:23:18:23:32 | call to method Source<Elem> : Elem | G.cs:39:14:39:35 | call to method GetElem | $@ | G.cs:23:18:23:32 | call to method Source<Elem> : Elem | call to method Source<Elem> : Elem |
+| G.cs:39:14:39:35 | call to method GetElem | G.cs:31:18:31:32 | call to method Source<Elem> : Elem | G.cs:39:14:39:35 | call to method GetElem | $@ | G.cs:31:18:31:32 | call to method Source<Elem> : Elem | call to method Source<Elem> : Elem |
 | G.cs:39:14:39:35 | call to method GetElem | G.cs:31:18:31:32 | call to method Source<Elem> : Elem | G.cs:39:14:39:35 | call to method GetElem | $@ | G.cs:31:18:31:32 | call to method Source<Elem> : Elem | call to method Source<Elem> : Elem |
 | G.cs:52:14:52:31 | access to field Elem | G.cs:44:18:44:32 | call to method Source<Elem> : Elem | G.cs:52:14:52:31 | access to field Elem | $@ | G.cs:44:18:44:32 | call to method Source<Elem> : Elem | call to method Source<Elem> : Elem |
+| G.cs:52:14:52:31 | access to field Elem | G.cs:44:18:44:32 | call to method Source<Elem> : Elem | G.cs:52:14:52:31 | access to field Elem | $@ | G.cs:44:18:44:32 | call to method Source<Elem> : Elem | call to method Source<Elem> : Elem |
+| H.cs:25:14:25:25 | access to field FieldA | H.cs:23:20:23:36 | call to method Source<Object> : Object | H.cs:25:14:25:25 | access to field FieldA | $@ | H.cs:23:20:23:36 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | H.cs:25:14:25:25 | access to field FieldA | H.cs:23:20:23:36 | call to method Source<Object> : Object | H.cs:25:14:25:25 | access to field FieldA | $@ | H.cs:23:20:23:36 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | H.cs:45:14:45:21 | access to field FieldB | H.cs:43:20:43:36 | call to method Source<Object> : Object | H.cs:45:14:45:21 | access to field FieldB | $@ | H.cs:43:20:43:36 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| H.cs:45:14:45:21 | access to field FieldB | H.cs:43:20:43:36 | call to method Source<Object> : Object | H.cs:45:14:45:21 | access to field FieldB | $@ | H.cs:43:20:43:36 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| H.cs:65:14:65:22 | access to field FieldB | H.cs:63:20:63:36 | call to method Source<Object> : Object | H.cs:65:14:65:22 | access to field FieldB | $@ | H.cs:63:20:63:36 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | H.cs:65:14:65:22 | access to field FieldB | H.cs:63:20:63:36 | call to method Source<Object> : Object | H.cs:65:14:65:22 | access to field FieldB | $@ | H.cs:63:20:63:36 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | H.cs:89:14:89:21 | access to field FieldA | H.cs:88:20:88:36 | call to method Source<Object> : Object | H.cs:89:14:89:21 | access to field FieldA | $@ | H.cs:88:20:88:36 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| H.cs:89:14:89:21 | access to field FieldA | H.cs:88:20:88:36 | call to method Source<Object> : Object | H.cs:89:14:89:21 | access to field FieldA | $@ | H.cs:88:20:88:36 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| H.cs:90:14:90:22 | access to field FieldB | H.cs:88:20:88:36 | call to method Source<Object> : Object | H.cs:90:14:90:22 | access to field FieldB | $@ | H.cs:88:20:88:36 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | H.cs:90:14:90:22 | access to field FieldB | H.cs:88:20:88:36 | call to method Source<Object> : Object | H.cs:90:14:90:22 | access to field FieldB | $@ | H.cs:88:20:88:36 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | H.cs:114:14:114:21 | access to field FieldB | H.cs:112:20:112:36 | call to method Source<Object> : Object | H.cs:114:14:114:21 | access to field FieldB | $@ | H.cs:112:20:112:36 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| H.cs:114:14:114:21 | access to field FieldB | H.cs:112:20:112:36 | call to method Source<Object> : Object | H.cs:114:14:114:21 | access to field FieldB | $@ | H.cs:112:20:112:36 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| H.cs:131:14:131:19 | call to method Get | H.cs:130:20:130:36 | call to method Source<Object> : Object | H.cs:131:14:131:19 | call to method Get | $@ | H.cs:130:20:130:36 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | H.cs:131:14:131:19 | call to method Get | H.cs:130:20:130:36 | call to method Source<Object> : Object | H.cs:131:14:131:19 | call to method Get | $@ | H.cs:130:20:130:36 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | H.cs:148:14:148:14 | access to local variable a | H.cs:147:25:147:38 | call to method Source<A> : A | H.cs:148:14:148:14 | access to local variable a | $@ | H.cs:147:25:147:38 | call to method Source<A> : A | call to method Source<A> : A |
+| H.cs:148:14:148:14 | access to local variable a | H.cs:147:25:147:38 | call to method Source<A> : A | H.cs:148:14:148:14 | access to local variable a | $@ | H.cs:147:25:147:38 | call to method Source<A> : A | call to method Source<A> : A |
+| H.cs:166:14:166:14 | access to local variable b | H.cs:155:17:155:30 | call to method Source<B> : B | H.cs:166:14:166:14 | access to local variable b | $@ | H.cs:155:17:155:30 | call to method Source<B> : B | call to method Source<B> : B |
 | H.cs:166:14:166:14 | access to local variable b | H.cs:155:17:155:30 | call to method Source<B> : B | H.cs:166:14:166:14 | access to local variable b | $@ | H.cs:155:17:155:30 | call to method Source<B> : B | call to method Source<B> : B |
 | H.cs:167:14:167:21 | access to field FieldB | H.cs:163:17:163:35 | call to method Source<Object> : Object | H.cs:167:14:167:21 | access to field FieldB | $@ | H.cs:163:17:163:35 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| H.cs:167:14:167:21 | access to field FieldB | H.cs:163:17:163:35 | call to method Source<Object> : Object | H.cs:167:14:167:21 | access to field FieldB | $@ | H.cs:163:17:163:35 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| I.cs:18:14:18:21 | access to field Field1 | I.cs:13:17:13:33 | call to method Source<Object> : Object | I.cs:18:14:18:21 | access to field Field1 | $@ | I.cs:13:17:13:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | I.cs:18:14:18:21 | access to field Field1 | I.cs:13:17:13:33 | call to method Source<Object> : Object | I.cs:18:14:18:21 | access to field Field1 | $@ | I.cs:13:17:13:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | I.cs:23:14:23:21 | access to field Field1 | I.cs:7:18:7:34 | call to method Source<Object> : Object | I.cs:23:14:23:21 | access to field Field1 | $@ | I.cs:7:18:7:34 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| I.cs:23:14:23:21 | access to field Field1 | I.cs:7:18:7:34 | call to method Source<Object> : Object | I.cs:23:14:23:21 | access to field Field1 | $@ | I.cs:7:18:7:34 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| I.cs:27:14:27:21 | access to field Field1 | I.cs:7:18:7:34 | call to method Source<Object> : Object | I.cs:27:14:27:21 | access to field Field1 | $@ | I.cs:7:18:7:34 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | I.cs:27:14:27:21 | access to field Field1 | I.cs:7:18:7:34 | call to method Source<Object> : Object | I.cs:27:14:27:21 | access to field Field1 | $@ | I.cs:7:18:7:34 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | I.cs:40:14:40:21 | access to field Field1 | I.cs:31:13:31:29 | call to method Source<Object> : Object | I.cs:40:14:40:21 | access to field Field1 | $@ | I.cs:31:13:31:29 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| I.cs:40:14:40:21 | access to field Field1 | I.cs:31:13:31:29 | call to method Source<Object> : Object | I.cs:40:14:40:21 | access to field Field1 | $@ | I.cs:31:13:31:29 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| J.cs:23:14:23:21 | access to property Prop1 | J.cs:21:17:21:33 | call to method Source<Object> : Object | J.cs:23:14:23:21 | access to property Prop1 | $@ | J.cs:21:17:21:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | J.cs:23:14:23:21 | access to property Prop1 | J.cs:21:17:21:33 | call to method Source<Object> : Object | J.cs:23:14:23:21 | access to property Prop1 | $@ | J.cs:21:17:21:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | J.cs:27:14:27:21 | access to property Prop1 | J.cs:21:17:21:33 | call to method Source<Object> : Object | J.cs:27:14:27:21 | access to property Prop1 | $@ | J.cs:21:17:21:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| J.cs:27:14:27:21 | access to property Prop1 | J.cs:21:17:21:33 | call to method Source<Object> : Object | J.cs:27:14:27:21 | access to property Prop1 | $@ | J.cs:21:17:21:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| J.cs:31:14:31:21 | access to property Prop1 | J.cs:21:17:21:33 | call to method Source<Object> : Object | J.cs:31:14:31:21 | access to property Prop1 | $@ | J.cs:21:17:21:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | J.cs:31:14:31:21 | access to property Prop1 | J.cs:21:17:21:33 | call to method Source<Object> : Object | J.cs:31:14:31:21 | access to property Prop1 | $@ | J.cs:21:17:21:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | J.cs:32:14:32:21 | access to property Prop2 | J.cs:30:36:30:52 | call to method Source<Object> : Object | J.cs:32:14:32:21 | access to property Prop2 | $@ | J.cs:30:36:30:52 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| J.cs:32:14:32:21 | access to property Prop2 | J.cs:30:36:30:52 | call to method Source<Object> : Object | J.cs:32:14:32:21 | access to property Prop2 | $@ | J.cs:30:36:30:52 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| J.cs:43:14:43:21 | access to property Prop1 | J.cs:41:17:41:33 | call to method Source<Object> : Object | J.cs:43:14:43:21 | access to property Prop1 | $@ | J.cs:41:17:41:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | J.cs:43:14:43:21 | access to property Prop1 | J.cs:41:17:41:33 | call to method Source<Object> : Object | J.cs:43:14:43:21 | access to property Prop1 | $@ | J.cs:41:17:41:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | J.cs:47:14:47:21 | access to property Prop1 | J.cs:41:17:41:33 | call to method Source<Object> : Object | J.cs:47:14:47:21 | access to property Prop1 | $@ | J.cs:41:17:41:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| J.cs:47:14:47:21 | access to property Prop1 | J.cs:41:17:41:33 | call to method Source<Object> : Object | J.cs:47:14:47:21 | access to property Prop1 | $@ | J.cs:41:17:41:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| J.cs:51:14:51:21 | access to property Prop1 | J.cs:41:17:41:33 | call to method Source<Object> : Object | J.cs:51:14:51:21 | access to property Prop1 | $@ | J.cs:41:17:41:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | J.cs:51:14:51:21 | access to property Prop1 | J.cs:41:17:41:33 | call to method Source<Object> : Object | J.cs:51:14:51:21 | access to property Prop1 | $@ | J.cs:41:17:41:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | J.cs:52:14:52:21 | access to property Prop2 | J.cs:50:36:50:52 | call to method Source<Object> : Object | J.cs:52:14:52:21 | access to property Prop2 | $@ | J.cs:50:36:50:52 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| J.cs:52:14:52:21 | access to property Prop2 | J.cs:50:36:50:52 | call to method Source<Object> : Object | J.cs:52:14:52:21 | access to property Prop2 | $@ | J.cs:50:36:50:52 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| J.cs:65:14:65:21 | access to field Field | J.cs:61:17:61:33 | call to method Source<Object> : Object | J.cs:65:14:65:21 | access to field Field | $@ | J.cs:61:17:61:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | J.cs:65:14:65:21 | access to field Field | J.cs:61:17:61:33 | call to method Source<Object> : Object | J.cs:65:14:65:21 | access to field Field | $@ | J.cs:61:17:61:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | J.cs:69:14:69:21 | access to field Field | J.cs:61:17:61:33 | call to method Source<Object> : Object | J.cs:69:14:69:21 | access to field Field | $@ | J.cs:61:17:61:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| J.cs:69:14:69:21 | access to field Field | J.cs:61:17:61:33 | call to method Source<Object> : Object | J.cs:69:14:69:21 | access to field Field | $@ | J.cs:61:17:61:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| J.cs:70:14:70:20 | access to property Prop | J.cs:68:35:68:51 | call to method Source<Object> : Object | J.cs:70:14:70:20 | access to property Prop | $@ | J.cs:68:35:68:51 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | J.cs:70:14:70:20 | access to property Prop | J.cs:68:35:68:51 | call to method Source<Object> : Object | J.cs:70:14:70:20 | access to property Prop | $@ | J.cs:68:35:68:51 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | J.cs:84:14:84:20 | access to property Prop | J.cs:79:17:79:33 | call to method Source<Object> : Object | J.cs:84:14:84:20 | access to property Prop | $@ | J.cs:79:17:79:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| J.cs:84:14:84:20 | access to property Prop | J.cs:79:17:79:33 | call to method Source<Object> : Object | J.cs:84:14:84:20 | access to property Prop | $@ | J.cs:79:17:79:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| J.cs:87:14:87:21 | access to field Field | J.cs:86:36:86:52 | call to method Source<Object> : Object | J.cs:87:14:87:21 | access to field Field | $@ | J.cs:86:36:86:52 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | J.cs:87:14:87:21 | access to field Field | J.cs:86:36:86:52 | call to method Source<Object> : Object | J.cs:87:14:87:21 | access to field Field | $@ | J.cs:86:36:86:52 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | J.cs:88:14:88:20 | access to property Prop | J.cs:79:17:79:33 | call to method Source<Object> : Object | J.cs:88:14:88:20 | access to property Prop | $@ | J.cs:79:17:79:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| J.cs:88:14:88:20 | access to property Prop | J.cs:79:17:79:33 | call to method Source<Object> : Object | J.cs:88:14:88:20 | access to property Prop | $@ | J.cs:79:17:79:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| J.cs:102:14:102:17 | access to property X | J.cs:97:17:97:33 | call to method Source<Object> : Object | J.cs:102:14:102:17 | access to property X | $@ | J.cs:97:17:97:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | J.cs:102:14:102:17 | access to property X | J.cs:97:17:97:33 | call to method Source<Object> : Object | J.cs:102:14:102:17 | access to property X | $@ | J.cs:97:17:97:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | J.cs:106:14:106:17 | access to property X | J.cs:97:17:97:33 | call to method Source<Object> : Object | J.cs:106:14:106:17 | access to property X | $@ | J.cs:97:17:97:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| J.cs:106:14:106:17 | access to property X | J.cs:97:17:97:33 | call to method Source<Object> : Object | J.cs:106:14:106:17 | access to property X | $@ | J.cs:97:17:97:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | J.cs:107:14:107:17 | access to property Y | J.cs:105:32:105:48 | call to method Source<Object> : Object | J.cs:107:14:107:17 | access to property Y | $@ | J.cs:105:32:105:48 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| J.cs:107:14:107:17 | access to property Y | J.cs:105:32:105:48 | call to method Source<Object> : Object | J.cs:107:14:107:17 | access to property Y | $@ | J.cs:105:32:105:48 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| J.cs:125:14:125:17 | (...) ... | J.cs:119:20:119:34 | call to method Source<Int32> : Int32 | J.cs:125:14:125:17 | (...) ... | $@ | J.cs:119:20:119:34 | call to method Source<Int32> : Int32 | call to method Source<Int32> : Int32 |
 | J.cs:125:14:125:17 | (...) ... | J.cs:119:20:119:34 | call to method Source<Int32> : Int32 | J.cs:125:14:125:17 | (...) ... | $@ | J.cs:119:20:119:34 | call to method Source<Int32> : Int32 | call to method Source<Int32> : Int32 |

--- a/csharp/ql/test/library-tests/dataflow/fields/FieldFlow.ql
+++ b/csharp/ql/test/library-tests/dataflow/fields/FieldFlow.ql
@@ -3,9 +3,10 @@
  */
 
 import csharp
-import DefaultValueFlow::PathGraph
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest
+import ValueFlow::PathGraph
 
-from DefaultValueFlow::PathNode source, DefaultValueFlow::PathNode sink
-where DefaultValueFlow::flowPath(source, sink)
+from ValueFlow::PathNode source, ValueFlow::PathNode sink
+where ValueFlow::flowPath(source, sink)
 select sink, source, sink, "$@", source, source.toString()

--- a/csharp/ql/test/library-tests/dataflow/fields/FieldFlow.ql
+++ b/csharp/ql/test/library-tests/dataflow/fields/FieldFlow.ql
@@ -5,8 +5,8 @@
 import csharp
 import TestUtilities.InlineFlowTest
 import DefaultFlowTest
-import ValueFlow::PathGraph
+import PathGraph
 
-from ValueFlow::PathNode source, ValueFlow::PathNode sink
-where ValueFlow::flowPath(source, sink)
+from PathNode source, PathNode sink
+where flowPath(source, sink)
 select sink, source, sink, "$@", source, source.toString()

--- a/csharp/ql/test/library-tests/dataflow/operators/operatorFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/operators/operatorFlow.expected
@@ -1,4 +1,5 @@
 failures
+testFailures
 edges
 | Operator.cs:9:39:9:39 | x : C | Operator.cs:9:50:9:50 | access to parameter x : C |
 | Operator.cs:16:38:16:38 | x : C | Operator.cs:16:49:16:49 | access to parameter x : C |

--- a/csharp/ql/test/library-tests/dataflow/operators/operatorFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/operators/operatorFlow.expected
@@ -2,95 +2,185 @@ failures
 testFailures
 edges
 | Operator.cs:9:39:9:39 | x : C | Operator.cs:9:50:9:50 | access to parameter x : C |
+| Operator.cs:9:39:9:39 | x : C | Operator.cs:9:50:9:50 | access to parameter x : C |
+| Operator.cs:16:38:16:38 | x : C | Operator.cs:16:49:16:49 | access to parameter x : C |
 | Operator.cs:16:38:16:38 | x : C | Operator.cs:16:49:16:49 | access to parameter x : C |
 | Operator.cs:18:51:18:51 | y : C | Operator.cs:18:57:18:57 | access to parameter y : C |
+| Operator.cs:18:51:18:51 | y : C | Operator.cs:18:57:18:57 | access to parameter y : C |
+| Operator.cs:19:38:19:38 | x : C | Operator.cs:19:49:19:49 | access to parameter x : C |
 | Operator.cs:19:38:19:38 | x : C | Operator.cs:19:49:19:49 | access to parameter x : C |
 | Operator.cs:21:43:21:43 | y : C | Operator.cs:21:49:21:49 | access to parameter y : C |
+| Operator.cs:21:43:21:43 | y : C | Operator.cs:21:49:21:49 | access to parameter y : C |
+| Operator.cs:22:51:22:51 | y : C | Operator.cs:22:57:22:57 | access to parameter y : C |
 | Operator.cs:22:51:22:51 | y : C | Operator.cs:22:57:22:57 | access to parameter y : C |
 | Operator.cs:27:17:27:28 | call to method Source<C> : C | Operator.cs:29:17:29:17 | access to local variable x : C |
+| Operator.cs:27:17:27:28 | call to method Source<C> : C | Operator.cs:29:17:29:17 | access to local variable x : C |
+| Operator.cs:29:17:29:17 | access to local variable x : C | Operator.cs:16:38:16:38 | x : C |
 | Operator.cs:29:17:29:17 | access to local variable x : C | Operator.cs:16:38:16:38 | x : C |
 | Operator.cs:29:17:29:17 | access to local variable x : C | Operator.cs:29:17:29:21 | call to operator + : C |
+| Operator.cs:29:17:29:17 | access to local variable x : C | Operator.cs:29:17:29:21 | call to operator + : C |
+| Operator.cs:29:17:29:21 | call to operator + : C | Operator.cs:30:14:30:14 | access to local variable z |
 | Operator.cs:29:17:29:21 | call to operator + : C | Operator.cs:30:14:30:14 | access to local variable z |
 | Operator.cs:35:17:35:28 | call to method Source<C> : C | Operator.cs:37:27:37:27 | access to local variable x : C |
+| Operator.cs:35:17:35:28 | call to method Source<C> : C | Operator.cs:37:27:37:27 | access to local variable x : C |
+| Operator.cs:37:27:37:27 | access to local variable x : C | Operator.cs:19:38:19:38 | x : C |
 | Operator.cs:37:27:37:27 | access to local variable x : C | Operator.cs:19:38:19:38 | x : C |
 | Operator.cs:37:27:37:27 | access to local variable x : C | Operator.cs:37:27:37:31 | call to operator - : C |
+| Operator.cs:37:27:37:27 | access to local variable x : C | Operator.cs:37:27:37:31 | call to operator - : C |
+| Operator.cs:37:27:37:31 | call to operator - : C | Operator.cs:38:14:38:14 | access to local variable z |
 | Operator.cs:37:27:37:31 | call to operator - : C | Operator.cs:38:14:38:14 | access to local variable z |
 | Operator.cs:44:17:44:28 | call to method Source<C> : C | Operator.cs:45:29:45:29 | access to local variable y : C |
+| Operator.cs:44:17:44:28 | call to method Source<C> : C | Operator.cs:45:29:45:29 | access to local variable y : C |
+| Operator.cs:45:25:45:29 | call to operator checked - : C | Operator.cs:46:14:46:14 | access to local variable z |
 | Operator.cs:45:25:45:29 | call to operator checked - : C | Operator.cs:46:14:46:14 | access to local variable z |
 | Operator.cs:45:29:45:29 | access to local variable y : C | Operator.cs:18:51:18:51 | y : C |
+| Operator.cs:45:29:45:29 | access to local variable y : C | Operator.cs:18:51:18:51 | y : C |
+| Operator.cs:45:29:45:29 | access to local variable y : C | Operator.cs:45:25:45:29 | call to operator checked - : C |
 | Operator.cs:45:29:45:29 | access to local variable y : C | Operator.cs:45:25:45:29 | call to operator checked - : C |
 | Operator.cs:49:28:49:28 | x : C | Operator.cs:51:17:51:17 | access to parameter x : C |
+| Operator.cs:49:28:49:28 | x : C | Operator.cs:51:17:51:17 | access to parameter x : C |
+| Operator.cs:51:17:51:17 | access to parameter x : C | Operator.cs:9:39:9:39 | x : C |
 | Operator.cs:51:17:51:17 | access to parameter x : C | Operator.cs:9:39:9:39 | x : C |
 | Operator.cs:51:17:51:17 | access to parameter x : C | Operator.cs:51:17:51:21 | call to operator * : C |
+| Operator.cs:51:17:51:17 | access to parameter x : C | Operator.cs:51:17:51:21 | call to operator * : C |
+| Operator.cs:51:17:51:21 | call to operator * : C | Operator.cs:52:14:52:14 | (...) ... |
 | Operator.cs:51:17:51:21 | call to operator * : C | Operator.cs:52:14:52:14 | (...) ... |
 | Operator.cs:57:17:57:28 | call to method Source<C> : C | Operator.cs:59:15:59:15 | access to local variable x : C |
+| Operator.cs:57:17:57:28 | call to method Source<C> : C | Operator.cs:59:15:59:15 | access to local variable x : C |
+| Operator.cs:59:15:59:15 | access to local variable x : C | Operator.cs:49:28:49:28 | x : C |
 | Operator.cs:59:15:59:15 | access to local variable x : C | Operator.cs:49:28:49:28 | x : C |
 | Operator.cs:62:33:62:33 | y : C | Operator.cs:64:21:64:21 | access to parameter y : C |
+| Operator.cs:62:33:62:33 | y : C | Operator.cs:64:21:64:21 | access to parameter y : C |
+| Operator.cs:64:17:64:21 | call to operator / : C | Operator.cs:65:14:65:14 | (...) ... |
 | Operator.cs:64:17:64:21 | call to operator / : C | Operator.cs:65:14:65:14 | (...) ... |
 | Operator.cs:64:21:64:21 | access to parameter y : C | Operator.cs:21:43:21:43 | y : C |
+| Operator.cs:64:21:64:21 | access to parameter y : C | Operator.cs:21:43:21:43 | y : C |
+| Operator.cs:64:21:64:21 | access to parameter y : C | Operator.cs:64:17:64:21 | call to operator / : C |
 | Operator.cs:64:21:64:21 | access to parameter y : C | Operator.cs:64:17:64:21 | call to operator / : C |
 | Operator.cs:71:17:71:29 | call to method Source<C> : C | Operator.cs:72:18:72:18 | access to local variable y : C |
+| Operator.cs:71:17:71:29 | call to method Source<C> : C | Operator.cs:72:18:72:18 | access to local variable y : C |
+| Operator.cs:72:18:72:18 | access to local variable y : C | Operator.cs:62:33:62:33 | y : C |
 | Operator.cs:72:18:72:18 | access to local variable y : C | Operator.cs:62:33:62:33 | y : C |
 | Operator.cs:75:33:75:33 | y : C | Operator.cs:77:29:77:29 | access to parameter y : C |
+| Operator.cs:75:33:75:33 | y : C | Operator.cs:77:29:77:29 | access to parameter y : C |
+| Operator.cs:77:25:77:29 | call to operator checked / : C | Operator.cs:78:14:78:14 | (...) ... |
 | Operator.cs:77:25:77:29 | call to operator checked / : C | Operator.cs:78:14:78:14 | (...) ... |
 | Operator.cs:77:29:77:29 | access to parameter y : C | Operator.cs:22:51:22:51 | y : C |
+| Operator.cs:77:29:77:29 | access to parameter y : C | Operator.cs:22:51:22:51 | y : C |
+| Operator.cs:77:29:77:29 | access to parameter y : C | Operator.cs:77:25:77:29 | call to operator checked / : C |
 | Operator.cs:77:29:77:29 | access to parameter y : C | Operator.cs:77:25:77:29 | call to operator checked / : C |
 | Operator.cs:84:17:84:29 | call to method Source<C> : C | Operator.cs:85:18:85:18 | access to local variable y : C |
+| Operator.cs:84:17:84:29 | call to method Source<C> : C | Operator.cs:85:18:85:18 | access to local variable y : C |
+| Operator.cs:85:18:85:18 | access to local variable y : C | Operator.cs:75:33:75:33 | y : C |
 | Operator.cs:85:18:85:18 | access to local variable y : C | Operator.cs:75:33:75:33 | y : C |
 nodes
 | Operator.cs:9:39:9:39 | x : C | semmle.label | x : C |
+| Operator.cs:9:39:9:39 | x : C | semmle.label | x : C |
+| Operator.cs:9:50:9:50 | access to parameter x : C | semmle.label | access to parameter x : C |
 | Operator.cs:9:50:9:50 | access to parameter x : C | semmle.label | access to parameter x : C |
 | Operator.cs:16:38:16:38 | x : C | semmle.label | x : C |
+| Operator.cs:16:38:16:38 | x : C | semmle.label | x : C |
+| Operator.cs:16:49:16:49 | access to parameter x : C | semmle.label | access to parameter x : C |
 | Operator.cs:16:49:16:49 | access to parameter x : C | semmle.label | access to parameter x : C |
 | Operator.cs:18:51:18:51 | y : C | semmle.label | y : C |
+| Operator.cs:18:51:18:51 | y : C | semmle.label | y : C |
+| Operator.cs:18:57:18:57 | access to parameter y : C | semmle.label | access to parameter y : C |
 | Operator.cs:18:57:18:57 | access to parameter y : C | semmle.label | access to parameter y : C |
 | Operator.cs:19:38:19:38 | x : C | semmle.label | x : C |
+| Operator.cs:19:38:19:38 | x : C | semmle.label | x : C |
+| Operator.cs:19:49:19:49 | access to parameter x : C | semmle.label | access to parameter x : C |
 | Operator.cs:19:49:19:49 | access to parameter x : C | semmle.label | access to parameter x : C |
 | Operator.cs:21:43:21:43 | y : C | semmle.label | y : C |
+| Operator.cs:21:43:21:43 | y : C | semmle.label | y : C |
+| Operator.cs:21:49:21:49 | access to parameter y : C | semmle.label | access to parameter y : C |
 | Operator.cs:21:49:21:49 | access to parameter y : C | semmle.label | access to parameter y : C |
 | Operator.cs:22:51:22:51 | y : C | semmle.label | y : C |
+| Operator.cs:22:51:22:51 | y : C | semmle.label | y : C |
+| Operator.cs:22:57:22:57 | access to parameter y : C | semmle.label | access to parameter y : C |
 | Operator.cs:22:57:22:57 | access to parameter y : C | semmle.label | access to parameter y : C |
 | Operator.cs:27:17:27:28 | call to method Source<C> : C | semmle.label | call to method Source<C> : C |
+| Operator.cs:27:17:27:28 | call to method Source<C> : C | semmle.label | call to method Source<C> : C |
+| Operator.cs:29:17:29:17 | access to local variable x : C | semmle.label | access to local variable x : C |
 | Operator.cs:29:17:29:17 | access to local variable x : C | semmle.label | access to local variable x : C |
 | Operator.cs:29:17:29:21 | call to operator + : C | semmle.label | call to operator + : C |
+| Operator.cs:29:17:29:21 | call to operator + : C | semmle.label | call to operator + : C |
+| Operator.cs:30:14:30:14 | access to local variable z | semmle.label | access to local variable z |
 | Operator.cs:30:14:30:14 | access to local variable z | semmle.label | access to local variable z |
 | Operator.cs:35:17:35:28 | call to method Source<C> : C | semmle.label | call to method Source<C> : C |
+| Operator.cs:35:17:35:28 | call to method Source<C> : C | semmle.label | call to method Source<C> : C |
+| Operator.cs:37:27:37:27 | access to local variable x : C | semmle.label | access to local variable x : C |
 | Operator.cs:37:27:37:27 | access to local variable x : C | semmle.label | access to local variable x : C |
 | Operator.cs:37:27:37:31 | call to operator - : C | semmle.label | call to operator - : C |
+| Operator.cs:37:27:37:31 | call to operator - : C | semmle.label | call to operator - : C |
+| Operator.cs:38:14:38:14 | access to local variable z | semmle.label | access to local variable z |
 | Operator.cs:38:14:38:14 | access to local variable z | semmle.label | access to local variable z |
 | Operator.cs:44:17:44:28 | call to method Source<C> : C | semmle.label | call to method Source<C> : C |
+| Operator.cs:44:17:44:28 | call to method Source<C> : C | semmle.label | call to method Source<C> : C |
+| Operator.cs:45:25:45:29 | call to operator checked - : C | semmle.label | call to operator checked - : C |
 | Operator.cs:45:25:45:29 | call to operator checked - : C | semmle.label | call to operator checked - : C |
 | Operator.cs:45:29:45:29 | access to local variable y : C | semmle.label | access to local variable y : C |
+| Operator.cs:45:29:45:29 | access to local variable y : C | semmle.label | access to local variable y : C |
+| Operator.cs:46:14:46:14 | access to local variable z | semmle.label | access to local variable z |
 | Operator.cs:46:14:46:14 | access to local variable z | semmle.label | access to local variable z |
 | Operator.cs:49:28:49:28 | x : C | semmle.label | x : C |
+| Operator.cs:49:28:49:28 | x : C | semmle.label | x : C |
+| Operator.cs:51:17:51:17 | access to parameter x : C | semmle.label | access to parameter x : C |
 | Operator.cs:51:17:51:17 | access to parameter x : C | semmle.label | access to parameter x : C |
 | Operator.cs:51:17:51:21 | call to operator * : C | semmle.label | call to operator * : C |
+| Operator.cs:51:17:51:21 | call to operator * : C | semmle.label | call to operator * : C |
+| Operator.cs:52:14:52:14 | (...) ... | semmle.label | (...) ... |
 | Operator.cs:52:14:52:14 | (...) ... | semmle.label | (...) ... |
 | Operator.cs:57:17:57:28 | call to method Source<C> : C | semmle.label | call to method Source<C> : C |
+| Operator.cs:57:17:57:28 | call to method Source<C> : C | semmle.label | call to method Source<C> : C |
+| Operator.cs:59:15:59:15 | access to local variable x : C | semmle.label | access to local variable x : C |
 | Operator.cs:59:15:59:15 | access to local variable x : C | semmle.label | access to local variable x : C |
 | Operator.cs:62:33:62:33 | y : C | semmle.label | y : C |
+| Operator.cs:62:33:62:33 | y : C | semmle.label | y : C |
+| Operator.cs:64:17:64:21 | call to operator / : C | semmle.label | call to operator / : C |
 | Operator.cs:64:17:64:21 | call to operator / : C | semmle.label | call to operator / : C |
 | Operator.cs:64:21:64:21 | access to parameter y : C | semmle.label | access to parameter y : C |
+| Operator.cs:64:21:64:21 | access to parameter y : C | semmle.label | access to parameter y : C |
+| Operator.cs:65:14:65:14 | (...) ... | semmle.label | (...) ... |
 | Operator.cs:65:14:65:14 | (...) ... | semmle.label | (...) ... |
 | Operator.cs:71:17:71:29 | call to method Source<C> : C | semmle.label | call to method Source<C> : C |
+| Operator.cs:71:17:71:29 | call to method Source<C> : C | semmle.label | call to method Source<C> : C |
+| Operator.cs:72:18:72:18 | access to local variable y : C | semmle.label | access to local variable y : C |
 | Operator.cs:72:18:72:18 | access to local variable y : C | semmle.label | access to local variable y : C |
 | Operator.cs:75:33:75:33 | y : C | semmle.label | y : C |
+| Operator.cs:75:33:75:33 | y : C | semmle.label | y : C |
+| Operator.cs:77:25:77:29 | call to operator checked / : C | semmle.label | call to operator checked / : C |
 | Operator.cs:77:25:77:29 | call to operator checked / : C | semmle.label | call to operator checked / : C |
 | Operator.cs:77:29:77:29 | access to parameter y : C | semmle.label | access to parameter y : C |
+| Operator.cs:77:29:77:29 | access to parameter y : C | semmle.label | access to parameter y : C |
+| Operator.cs:78:14:78:14 | (...) ... | semmle.label | (...) ... |
 | Operator.cs:78:14:78:14 | (...) ... | semmle.label | (...) ... |
 | Operator.cs:84:17:84:29 | call to method Source<C> : C | semmle.label | call to method Source<C> : C |
+| Operator.cs:84:17:84:29 | call to method Source<C> : C | semmle.label | call to method Source<C> : C |
+| Operator.cs:85:18:85:18 | access to local variable y : C | semmle.label | access to local variable y : C |
 | Operator.cs:85:18:85:18 | access to local variable y : C | semmle.label | access to local variable y : C |
 subpaths
 | Operator.cs:29:17:29:17 | access to local variable x : C | Operator.cs:16:38:16:38 | x : C | Operator.cs:16:49:16:49 | access to parameter x : C | Operator.cs:29:17:29:21 | call to operator + : C |
+| Operator.cs:29:17:29:17 | access to local variable x : C | Operator.cs:16:38:16:38 | x : C | Operator.cs:16:49:16:49 | access to parameter x : C | Operator.cs:29:17:29:21 | call to operator + : C |
+| Operator.cs:37:27:37:27 | access to local variable x : C | Operator.cs:19:38:19:38 | x : C | Operator.cs:19:49:19:49 | access to parameter x : C | Operator.cs:37:27:37:31 | call to operator - : C |
 | Operator.cs:37:27:37:27 | access to local variable x : C | Operator.cs:19:38:19:38 | x : C | Operator.cs:19:49:19:49 | access to parameter x : C | Operator.cs:37:27:37:31 | call to operator - : C |
 | Operator.cs:45:29:45:29 | access to local variable y : C | Operator.cs:18:51:18:51 | y : C | Operator.cs:18:57:18:57 | access to parameter y : C | Operator.cs:45:25:45:29 | call to operator checked - : C |
+| Operator.cs:45:29:45:29 | access to local variable y : C | Operator.cs:18:51:18:51 | y : C | Operator.cs:18:57:18:57 | access to parameter y : C | Operator.cs:45:25:45:29 | call to operator checked - : C |
+| Operator.cs:51:17:51:17 | access to parameter x : C | Operator.cs:9:39:9:39 | x : C | Operator.cs:9:50:9:50 | access to parameter x : C | Operator.cs:51:17:51:21 | call to operator * : C |
 | Operator.cs:51:17:51:17 | access to parameter x : C | Operator.cs:9:39:9:39 | x : C | Operator.cs:9:50:9:50 | access to parameter x : C | Operator.cs:51:17:51:21 | call to operator * : C |
 | Operator.cs:64:21:64:21 | access to parameter y : C | Operator.cs:21:43:21:43 | y : C | Operator.cs:21:49:21:49 | access to parameter y : C | Operator.cs:64:17:64:21 | call to operator / : C |
+| Operator.cs:64:21:64:21 | access to parameter y : C | Operator.cs:21:43:21:43 | y : C | Operator.cs:21:49:21:49 | access to parameter y : C | Operator.cs:64:17:64:21 | call to operator / : C |
+| Operator.cs:77:29:77:29 | access to parameter y : C | Operator.cs:22:51:22:51 | y : C | Operator.cs:22:57:22:57 | access to parameter y : C | Operator.cs:77:25:77:29 | call to operator checked / : C |
 | Operator.cs:77:29:77:29 | access to parameter y : C | Operator.cs:22:51:22:51 | y : C | Operator.cs:22:57:22:57 | access to parameter y : C | Operator.cs:77:25:77:29 | call to operator checked / : C |
 #select
 | Operator.cs:30:14:30:14 | access to local variable z | Operator.cs:27:17:27:28 | call to method Source<C> : C | Operator.cs:30:14:30:14 | access to local variable z | $@ | Operator.cs:27:17:27:28 | call to method Source<C> : C | call to method Source<C> : C |
+| Operator.cs:30:14:30:14 | access to local variable z | Operator.cs:27:17:27:28 | call to method Source<C> : C | Operator.cs:30:14:30:14 | access to local variable z | $@ | Operator.cs:27:17:27:28 | call to method Source<C> : C | call to method Source<C> : C |
+| Operator.cs:38:14:38:14 | access to local variable z | Operator.cs:35:17:35:28 | call to method Source<C> : C | Operator.cs:38:14:38:14 | access to local variable z | $@ | Operator.cs:35:17:35:28 | call to method Source<C> : C | call to method Source<C> : C |
 | Operator.cs:38:14:38:14 | access to local variable z | Operator.cs:35:17:35:28 | call to method Source<C> : C | Operator.cs:38:14:38:14 | access to local variable z | $@ | Operator.cs:35:17:35:28 | call to method Source<C> : C | call to method Source<C> : C |
 | Operator.cs:46:14:46:14 | access to local variable z | Operator.cs:44:17:44:28 | call to method Source<C> : C | Operator.cs:46:14:46:14 | access to local variable z | $@ | Operator.cs:44:17:44:28 | call to method Source<C> : C | call to method Source<C> : C |
+| Operator.cs:46:14:46:14 | access to local variable z | Operator.cs:44:17:44:28 | call to method Source<C> : C | Operator.cs:46:14:46:14 | access to local variable z | $@ | Operator.cs:44:17:44:28 | call to method Source<C> : C | call to method Source<C> : C |
+| Operator.cs:52:14:52:14 | (...) ... | Operator.cs:57:17:57:28 | call to method Source<C> : C | Operator.cs:52:14:52:14 | (...) ... | $@ | Operator.cs:57:17:57:28 | call to method Source<C> : C | call to method Source<C> : C |
 | Operator.cs:52:14:52:14 | (...) ... | Operator.cs:57:17:57:28 | call to method Source<C> : C | Operator.cs:52:14:52:14 | (...) ... | $@ | Operator.cs:57:17:57:28 | call to method Source<C> : C | call to method Source<C> : C |
 | Operator.cs:65:14:65:14 | (...) ... | Operator.cs:71:17:71:29 | call to method Source<C> : C | Operator.cs:65:14:65:14 | (...) ... | $@ | Operator.cs:71:17:71:29 | call to method Source<C> : C | call to method Source<C> : C |
+| Operator.cs:65:14:65:14 | (...) ... | Operator.cs:71:17:71:29 | call to method Source<C> : C | Operator.cs:65:14:65:14 | (...) ... | $@ | Operator.cs:71:17:71:29 | call to method Source<C> : C | call to method Source<C> : C |
+| Operator.cs:78:14:78:14 | (...) ... | Operator.cs:84:17:84:29 | call to method Source<C> : C | Operator.cs:78:14:78:14 | (...) ... | $@ | Operator.cs:84:17:84:29 | call to method Source<C> : C | call to method Source<C> : C |
 | Operator.cs:78:14:78:14 | (...) ... | Operator.cs:84:17:84:29 | call to method Source<C> : C | Operator.cs:78:14:78:14 | (...) ... | $@ | Operator.cs:84:17:84:29 | call to method Source<C> : C | call to method Source<C> : C |

--- a/csharp/ql/test/library-tests/dataflow/operators/operatorFlow.ql
+++ b/csharp/ql/test/library-tests/dataflow/operators/operatorFlow.ql
@@ -3,9 +3,10 @@
  */
 
 import csharp
-import DefaultValueFlow::PathGraph
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest
+import ValueFlow::PathGraph
 
-from DefaultValueFlow::PathNode source, DefaultValueFlow::PathNode sink
-where DefaultValueFlow::flowPath(source, sink)
+from ValueFlow::PathNode source, ValueFlow::PathNode sink
+where ValueFlow::flowPath(source, sink)
 select sink, source, sink, "$@", source, source.toString()

--- a/csharp/ql/test/library-tests/dataflow/operators/operatorFlow.ql
+++ b/csharp/ql/test/library-tests/dataflow/operators/operatorFlow.ql
@@ -5,8 +5,8 @@
 import csharp
 import TestUtilities.InlineFlowTest
 import DefaultFlowTest
-import ValueFlow::PathGraph
+import PathGraph
 
-from ValueFlow::PathNode source, ValueFlow::PathNode sink
-where ValueFlow::flowPath(source, sink)
+from PathNode source, PathNode sink
+where flowPath(source, sink)
 select sink, source, sink, "$@", source, source.toString()

--- a/csharp/ql/test/library-tests/dataflow/patterns/PatternFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/patterns/PatternFlow.expected
@@ -1,4 +1,5 @@
 failures
+testFailures
 edges
 nodes
 subpaths

--- a/csharp/ql/test/library-tests/dataflow/patterns/PatternFlow.ql
+++ b/csharp/ql/test/library-tests/dataflow/patterns/PatternFlow.ql
@@ -3,9 +3,10 @@
  */
 
 import csharp
-import DefaultValueFlow::PathGraph
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest
+import ValueFlow::PathGraph
 
-from DefaultValueFlow::PathNode source, DefaultValueFlow::PathNode sink
-where DefaultValueFlow::flowPath(source, sink)
+from ValueFlow::PathNode source, ValueFlow::PathNode sink
+where ValueFlow::flowPath(source, sink)
 select sink, source, sink, "$@", source, source.toString()

--- a/csharp/ql/test/library-tests/dataflow/patterns/PatternFlow.ql
+++ b/csharp/ql/test/library-tests/dataflow/patterns/PatternFlow.ql
@@ -5,8 +5,8 @@
 import csharp
 import TestUtilities.InlineFlowTest
 import DefaultFlowTest
-import ValueFlow::PathGraph
+import PathGraph
 
-from ValueFlow::PathNode source, ValueFlow::PathNode sink
-where ValueFlow::flowPath(source, sink)
+from PathNode source, PathNode sink
+where flowPath(source, sink)
 select sink, source, sink, "$@", source, source.toString()

--- a/csharp/ql/test/library-tests/dataflow/tuples/Tuples.expected
+++ b/csharp/ql/test/library-tests/dataflow/tuples/Tuples.expected
@@ -1,4 +1,5 @@
 failures
+testFailures
 edges
 | Tuples.cs:7:18:7:34 | call to method Source<Object> : Object | Tuples.cs:10:21:10:22 | access to local variable o1 : Object |
 | Tuples.cs:8:18:8:34 | call to method Source<Object> : Object | Tuples.cs:10:29:10:30 | access to local variable o2 : Object |

--- a/csharp/ql/test/library-tests/dataflow/tuples/Tuples.expected
+++ b/csharp/ql/test/library-tests/dataflow/tuples/Tuples.expected
@@ -2,233 +2,461 @@ failures
 testFailures
 edges
 | Tuples.cs:7:18:7:34 | call to method Source<Object> : Object | Tuples.cs:10:21:10:22 | access to local variable o1 : Object |
+| Tuples.cs:7:18:7:34 | call to method Source<Object> : Object | Tuples.cs:10:21:10:22 | access to local variable o1 : Object |
+| Tuples.cs:8:18:8:34 | call to method Source<Object> : Object | Tuples.cs:10:29:10:30 | access to local variable o2 : Object |
 | Tuples.cs:8:18:8:34 | call to method Source<Object> : Object | Tuples.cs:10:29:10:30 | access to local variable o2 : Object |
 | Tuples.cs:10:17:10:32 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item1] : Object | Tuples.cs:11:9:11:23 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item1] : Object |
+| Tuples.cs:10:17:10:32 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item1] : Object | Tuples.cs:11:9:11:23 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item1] : Object |
+| Tuples.cs:10:17:10:32 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item1] : Object | Tuples.cs:16:9:16:19 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item1] : Object |
 | Tuples.cs:10:17:10:32 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item1] : Object | Tuples.cs:16:9:16:19 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item1] : Object |
 | Tuples.cs:10:17:10:32 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item1] : Object | Tuples.cs:21:9:21:22 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item1] : Object |
+| Tuples.cs:10:17:10:32 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item1] : Object | Tuples.cs:21:9:21:22 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item1] : Object |
+| Tuples.cs:10:17:10:32 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item1] : Object | Tuples.cs:26:14:26:14 | access to local variable x : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item1] : Object |
 | Tuples.cs:10:17:10:32 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item1] : Object | Tuples.cs:26:14:26:14 | access to local variable x : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item1] : Object |
 | Tuples.cs:10:17:10:32 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item1] : Object | Tuples.cs:27:14:27:14 | access to local variable x : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item1] : Object |
+| Tuples.cs:10:17:10:32 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item1] : Object | Tuples.cs:27:14:27:14 | access to local variable x : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item1] : Object |
+| Tuples.cs:10:17:10:32 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item2, field Item2] : Object | Tuples.cs:11:9:11:23 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item2, field Item2] : Object |
 | Tuples.cs:10:17:10:32 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item2, field Item2] : Object | Tuples.cs:11:9:11:23 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item2, field Item2] : Object |
 | Tuples.cs:10:17:10:32 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item2, field Item2] : Object | Tuples.cs:16:9:16:19 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item2, field Item2] : Object |
+| Tuples.cs:10:17:10:32 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item2, field Item2] : Object | Tuples.cs:16:9:16:19 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item2, field Item2] : Object |
+| Tuples.cs:10:17:10:32 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item2, field Item2] : Object | Tuples.cs:21:9:21:22 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item2, field Item2] : Object |
 | Tuples.cs:10:17:10:32 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item2, field Item2] : Object | Tuples.cs:21:9:21:22 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item2, field Item2] : Object |
 | Tuples.cs:10:17:10:32 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item2, field Item2] : Object | Tuples.cs:29:14:29:14 | access to local variable x : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item2, field Item2] : Object |
+| Tuples.cs:10:17:10:32 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item2, field Item2] : Object | Tuples.cs:29:14:29:14 | access to local variable x : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item2, field Item2] : Object |
+| Tuples.cs:10:21:10:22 | access to local variable o1 : Object | Tuples.cs:10:17:10:32 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item1] : Object |
 | Tuples.cs:10:21:10:22 | access to local variable o1 : Object | Tuples.cs:10:17:10:32 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item1] : Object |
 | Tuples.cs:10:25:10:31 | (..., ...) : ValueTuple<Int32,Object> [field Item2] : Object | Tuples.cs:10:17:10:32 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item2, field Item2] : Object |
+| Tuples.cs:10:25:10:31 | (..., ...) : ValueTuple<Int32,Object> [field Item2] : Object | Tuples.cs:10:17:10:32 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item2, field Item2] : Object |
+| Tuples.cs:10:29:10:30 | access to local variable o2 : Object | Tuples.cs:10:25:10:31 | (..., ...) : ValueTuple<Int32,Object> [field Item2] : Object |
 | Tuples.cs:10:29:10:30 | access to local variable o2 : Object | Tuples.cs:10:25:10:31 | (..., ...) : ValueTuple<Int32,Object> [field Item2] : Object |
 | Tuples.cs:11:9:11:23 | (..., ...) : ValueTuple<Int32,Object> [field Item2] : Object | Tuples.cs:11:9:11:27 | SSA def(c) : Object |
+| Tuples.cs:11:9:11:23 | (..., ...) : ValueTuple<Int32,Object> [field Item2] : Object | Tuples.cs:11:9:11:27 | SSA def(c) : Object |
+| Tuples.cs:11:9:11:23 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item1] : Object | Tuples.cs:11:9:11:27 | SSA def(a) : Object |
 | Tuples.cs:11:9:11:23 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item1] : Object | Tuples.cs:11:9:11:27 | SSA def(a) : Object |
 | Tuples.cs:11:9:11:23 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item2, field Item2] : Object | Tuples.cs:11:9:11:23 | (..., ...) : ValueTuple<Int32,Object> [field Item2] : Object |
+| Tuples.cs:11:9:11:23 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item2, field Item2] : Object | Tuples.cs:11:9:11:23 | (..., ...) : ValueTuple<Int32,Object> [field Item2] : Object |
+| Tuples.cs:11:9:11:27 | SSA def(a) : Object | Tuples.cs:12:14:12:14 | access to local variable a |
 | Tuples.cs:11:9:11:27 | SSA def(a) : Object | Tuples.cs:12:14:12:14 | access to local variable a |
 | Tuples.cs:11:9:11:27 | SSA def(c) : Object | Tuples.cs:14:14:14:14 | access to local variable c |
+| Tuples.cs:11:9:11:27 | SSA def(c) : Object | Tuples.cs:14:14:14:14 | access to local variable c |
+| Tuples.cs:16:9:16:19 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item1] : Object | Tuples.cs:16:9:16:23 | SSA def(a) : Object |
 | Tuples.cs:16:9:16:19 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item1] : Object | Tuples.cs:16:9:16:23 | SSA def(a) : Object |
 | Tuples.cs:16:9:16:19 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item2, field Item2] : Object | Tuples.cs:16:13:16:18 | (..., ...) : ValueTuple<Int32,Object> [field Item2] : Object |
+| Tuples.cs:16:9:16:19 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item2, field Item2] : Object | Tuples.cs:16:13:16:18 | (..., ...) : ValueTuple<Int32,Object> [field Item2] : Object |
+| Tuples.cs:16:9:16:23 | SSA def(a) : Object | Tuples.cs:17:14:17:14 | access to local variable a |
 | Tuples.cs:16:9:16:23 | SSA def(a) : Object | Tuples.cs:17:14:17:14 | access to local variable a |
 | Tuples.cs:16:9:16:23 | SSA def(c) : Object | Tuples.cs:19:14:19:14 | access to local variable c |
+| Tuples.cs:16:9:16:23 | SSA def(c) : Object | Tuples.cs:19:14:19:14 | access to local variable c |
+| Tuples.cs:16:13:16:18 | (..., ...) : ValueTuple<Int32,Object> [field Item2] : Object | Tuples.cs:16:9:16:23 | SSA def(c) : Object |
 | Tuples.cs:16:13:16:18 | (..., ...) : ValueTuple<Int32,Object> [field Item2] : Object | Tuples.cs:16:9:16:23 | SSA def(c) : Object |
 | Tuples.cs:21:9:21:22 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item1] : Object | Tuples.cs:21:9:21:26 | SSA def(p) : Object |
+| Tuples.cs:21:9:21:22 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item1] : Object | Tuples.cs:21:9:21:26 | SSA def(p) : Object |
+| Tuples.cs:21:9:21:22 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item2, field Item2] : Object | Tuples.cs:21:9:21:26 | SSA def(q) : ValueTuple<Int32,Object> [field Item2] : Object |
 | Tuples.cs:21:9:21:22 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item2, field Item2] : Object | Tuples.cs:21:9:21:26 | SSA def(q) : ValueTuple<Int32,Object> [field Item2] : Object |
 | Tuples.cs:21:9:21:26 | SSA def(p) : Object | Tuples.cs:22:14:22:14 | access to local variable p |
+| Tuples.cs:21:9:21:26 | SSA def(p) : Object | Tuples.cs:22:14:22:14 | access to local variable p |
+| Tuples.cs:21:9:21:26 | SSA def(q) : ValueTuple<Int32,Object> [field Item2] : Object | Tuples.cs:24:14:24:14 | access to local variable q : ValueTuple<Int32,Object> [field Item2] : Object |
 | Tuples.cs:21:9:21:26 | SSA def(q) : ValueTuple<Int32,Object> [field Item2] : Object | Tuples.cs:24:14:24:14 | access to local variable q : ValueTuple<Int32,Object> [field Item2] : Object |
 | Tuples.cs:24:14:24:14 | access to local variable q : ValueTuple<Int32,Object> [field Item2] : Object | Tuples.cs:24:14:24:20 | access to field Item2 |
+| Tuples.cs:24:14:24:14 | access to local variable q : ValueTuple<Int32,Object> [field Item2] : Object | Tuples.cs:24:14:24:20 | access to field Item2 |
+| Tuples.cs:26:14:26:14 | access to local variable x : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item1] : Object | Tuples.cs:26:14:26:20 | access to field Item1 |
 | Tuples.cs:26:14:26:14 | access to local variable x : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item1] : Object | Tuples.cs:26:14:26:20 | access to field Item1 |
 | Tuples.cs:27:14:27:14 | access to local variable x : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item1] : Object | Tuples.cs:27:14:27:16 | access to field Item1 |
+| Tuples.cs:27:14:27:14 | access to local variable x : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item1] : Object | Tuples.cs:27:14:27:16 | access to field Item1 |
+| Tuples.cs:29:14:29:14 | access to local variable x : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item2, field Item2] : Object | Tuples.cs:29:14:29:20 | access to field Item2 : ValueTuple<Int32,Object> [field Item2] : Object |
 | Tuples.cs:29:14:29:14 | access to local variable x : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item2, field Item2] : Object | Tuples.cs:29:14:29:20 | access to field Item2 : ValueTuple<Int32,Object> [field Item2] : Object |
 | Tuples.cs:29:14:29:20 | access to field Item2 : ValueTuple<Int32,Object> [field Item2] : Object | Tuples.cs:29:14:29:26 | access to field Item2 |
+| Tuples.cs:29:14:29:20 | access to field Item2 : ValueTuple<Int32,Object> [field Item2] : Object | Tuples.cs:29:14:29:26 | access to field Item2 |
+| Tuples.cs:34:18:34:34 | call to method Source<Object> : Object | Tuples.cs:37:18:37:19 | access to local variable o1 : Object |
 | Tuples.cs:34:18:34:34 | call to method Source<Object> : Object | Tuples.cs:37:18:37:19 | access to local variable o1 : Object |
 | Tuples.cs:35:18:35:34 | call to method Source<Object> : Object | Tuples.cs:37:46:37:47 | access to local variable o2 : Object |
+| Tuples.cs:35:18:35:34 | call to method Source<Object> : Object | Tuples.cs:37:46:37:47 | access to local variable o2 : Object |
+| Tuples.cs:37:17:37:48 | (..., ...) : ValueTuple<Object,Int32,Int32,Int32,Int32,Int32,Int32,ValueTuple<Int32,Int32,Object>> [field Item1] : Object | Tuples.cs:38:14:38:14 | access to local variable x : ValueTuple<Object,Int32,Int32,Int32,Int32,Int32,Int32,ValueTuple<Int32,Int32,Object>> [field Item1] : Object |
 | Tuples.cs:37:17:37:48 | (..., ...) : ValueTuple<Object,Int32,Int32,Int32,Int32,Int32,Int32,ValueTuple<Int32,Int32,Object>> [field Item1] : Object | Tuples.cs:38:14:38:14 | access to local variable x : ValueTuple<Object,Int32,Int32,Int32,Int32,Int32,Int32,ValueTuple<Int32,Int32,Object>> [field Item1] : Object |
 | Tuples.cs:37:17:37:48 | (..., ...) : ValueTuple<Object,Int32,Int32,Int32,Int32,Int32,Int32,ValueTuple<Int32,Int32,Object>> [field Item10] : Object | Tuples.cs:40:14:40:14 | access to local variable x : ValueTuple<Object,Int32,Int32,Int32,Int32,Int32,Int32,ValueTuple<Int32,Int32,Object>> [field Item10] : Object |
+| Tuples.cs:37:17:37:48 | (..., ...) : ValueTuple<Object,Int32,Int32,Int32,Int32,Int32,Int32,ValueTuple<Int32,Int32,Object>> [field Item10] : Object | Tuples.cs:40:14:40:14 | access to local variable x : ValueTuple<Object,Int32,Int32,Int32,Int32,Int32,Int32,ValueTuple<Int32,Int32,Object>> [field Item10] : Object |
+| Tuples.cs:37:18:37:19 | access to local variable o1 : Object | Tuples.cs:37:17:37:48 | (..., ...) : ValueTuple<Object,Int32,Int32,Int32,Int32,Int32,Int32,ValueTuple<Int32,Int32,Object>> [field Item1] : Object |
 | Tuples.cs:37:18:37:19 | access to local variable o1 : Object | Tuples.cs:37:17:37:48 | (..., ...) : ValueTuple<Object,Int32,Int32,Int32,Int32,Int32,Int32,ValueTuple<Int32,Int32,Object>> [field Item1] : Object |
 | Tuples.cs:37:46:37:47 | access to local variable o2 : Object | Tuples.cs:37:17:37:48 | (..., ...) : ValueTuple<Object,Int32,Int32,Int32,Int32,Int32,Int32,ValueTuple<Int32,Int32,Object>> [field Item10] : Object |
+| Tuples.cs:37:46:37:47 | access to local variable o2 : Object | Tuples.cs:37:17:37:48 | (..., ...) : ValueTuple<Object,Int32,Int32,Int32,Int32,Int32,Int32,ValueTuple<Int32,Int32,Object>> [field Item10] : Object |
+| Tuples.cs:38:14:38:14 | access to local variable x : ValueTuple<Object,Int32,Int32,Int32,Int32,Int32,Int32,ValueTuple<Int32,Int32,Object>> [field Item1] : Object | Tuples.cs:38:14:38:20 | access to field Item1 |
 | Tuples.cs:38:14:38:14 | access to local variable x : ValueTuple<Object,Int32,Int32,Int32,Int32,Int32,Int32,ValueTuple<Int32,Int32,Object>> [field Item1] : Object | Tuples.cs:38:14:38:20 | access to field Item1 |
 | Tuples.cs:40:14:40:14 | access to local variable x : ValueTuple<Object,Int32,Int32,Int32,Int32,Int32,Int32,ValueTuple<Int32,Int32,Object>> [field Item10] : Object | Tuples.cs:40:14:40:21 | access to field Item10 |
+| Tuples.cs:40:14:40:14 | access to local variable x : ValueTuple<Object,Int32,Int32,Int32,Int32,Int32,Int32,ValueTuple<Int32,Int32,Object>> [field Item10] : Object | Tuples.cs:40:14:40:21 | access to field Item10 |
+| Tuples.cs:45:17:45:33 | call to method Source<String> : String | Tuples.cs:46:48:46:48 | access to local variable o : String |
 | Tuples.cs:45:17:45:33 | call to method Source<String> : String | Tuples.cs:46:48:46:48 | access to local variable o : String |
 | Tuples.cs:46:17:46:55 | (...) ... : ValueTuple<String,Int32,Int32> [field Item1] : String | Tuples.cs:47:14:47:14 | access to local variable x : ValueTuple<String,Int32,Int32> [field Item1] : String |
+| Tuples.cs:46:17:46:55 | (...) ... : ValueTuple<String,Int32,Int32> [field Item1] : String | Tuples.cs:47:14:47:14 | access to local variable x : ValueTuple<String,Int32,Int32> [field Item1] : String |
+| Tuples.cs:46:47:46:55 | (..., ...) : ValueTuple<String,Int32,Int32> [field Item1] : String | Tuples.cs:46:17:46:55 | (...) ... : ValueTuple<String,Int32,Int32> [field Item1] : String |
 | Tuples.cs:46:47:46:55 | (..., ...) : ValueTuple<String,Int32,Int32> [field Item1] : String | Tuples.cs:46:17:46:55 | (...) ... : ValueTuple<String,Int32,Int32> [field Item1] : String |
 | Tuples.cs:46:48:46:48 | access to local variable o : String | Tuples.cs:46:47:46:55 | (..., ...) : ValueTuple<String,Int32,Int32> [field Item1] : String |
+| Tuples.cs:46:48:46:48 | access to local variable o : String | Tuples.cs:46:47:46:55 | (..., ...) : ValueTuple<String,Int32,Int32> [field Item1] : String |
+| Tuples.cs:47:14:47:14 | access to local variable x : ValueTuple<String,Int32,Int32> [field Item1] : String | Tuples.cs:47:14:47:20 | access to field Item1 |
 | Tuples.cs:47:14:47:14 | access to local variable x : ValueTuple<String,Int32,Int32> [field Item1] : String | Tuples.cs:47:14:47:20 | access to field Item1 |
 | Tuples.cs:57:18:57:34 | call to method Source<String> : String | Tuples.cs:59:18:59:19 | access to local variable o1 : String |
+| Tuples.cs:57:18:57:34 | call to method Source<String> : String | Tuples.cs:59:18:59:19 | access to local variable o1 : String |
+| Tuples.cs:58:18:58:34 | call to method Source<String> : String | Tuples.cs:59:26:59:27 | access to local variable o2 : String |
 | Tuples.cs:58:18:58:34 | call to method Source<String> : String | Tuples.cs:59:26:59:27 | access to local variable o2 : String |
 | Tuples.cs:59:17:59:32 | (..., ...) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item1] : String | Tuples.cs:62:18:62:57 | SSA def(t) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item1] : String |
+| Tuples.cs:59:17:59:32 | (..., ...) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item1] : String | Tuples.cs:62:18:62:57 | SSA def(t) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item1] : String |
+| Tuples.cs:59:17:59:32 | (..., ...) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item1] : String | Tuples.cs:67:18:67:35 | (..., ...) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item1] : String |
 | Tuples.cs:59:17:59:32 | (..., ...) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item1] : String | Tuples.cs:67:18:67:35 | (..., ...) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item1] : String |
 | Tuples.cs:59:17:59:32 | (..., ...) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item1] : String | Tuples.cs:87:18:87:35 | (..., ...) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item1] : String |
+| Tuples.cs:59:17:59:32 | (..., ...) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item1] : String | Tuples.cs:87:18:87:35 | (..., ...) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item1] : String |
+| Tuples.cs:59:17:59:32 | (..., ...) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item2, field Item2] : String | Tuples.cs:62:18:62:57 | SSA def(t) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item2, field Item2] : String |
 | Tuples.cs:59:17:59:32 | (..., ...) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item2, field Item2] : String | Tuples.cs:62:18:62:57 | SSA def(t) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item2, field Item2] : String |
 | Tuples.cs:59:17:59:32 | (..., ...) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item2, field Item2] : String | Tuples.cs:67:18:67:35 | (..., ...) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item2, field Item2] : String |
+| Tuples.cs:59:17:59:32 | (..., ...) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item2, field Item2] : String | Tuples.cs:67:18:67:35 | (..., ...) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item2, field Item2] : String |
+| Tuples.cs:59:17:59:32 | (..., ...) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item2, field Item2] : String | Tuples.cs:87:18:87:35 | (..., ...) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item2, field Item2] : String |
 | Tuples.cs:59:17:59:32 | (..., ...) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item2, field Item2] : String | Tuples.cs:87:18:87:35 | (..., ...) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item2, field Item2] : String |
 | Tuples.cs:59:18:59:19 | access to local variable o1 : String | Tuples.cs:59:17:59:32 | (..., ...) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item1] : String |
+| Tuples.cs:59:18:59:19 | access to local variable o1 : String | Tuples.cs:59:17:59:32 | (..., ...) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item1] : String |
+| Tuples.cs:59:22:59:28 | (..., ...) : ValueTuple<Int32,String> [field Item2] : String | Tuples.cs:59:17:59:32 | (..., ...) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item2, field Item2] : String |
 | Tuples.cs:59:22:59:28 | (..., ...) : ValueTuple<Int32,String> [field Item2] : String | Tuples.cs:59:17:59:32 | (..., ...) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item2, field Item2] : String |
 | Tuples.cs:59:26:59:27 | access to local variable o2 : String | Tuples.cs:59:22:59:28 | (..., ...) : ValueTuple<Int32,String> [field Item2] : String |
+| Tuples.cs:59:26:59:27 | access to local variable o2 : String | Tuples.cs:59:22:59:28 | (..., ...) : ValueTuple<Int32,String> [field Item2] : String |
+| Tuples.cs:62:18:62:57 | SSA def(t) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item1] : String | Tuples.cs:63:22:63:22 | access to local variable t : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item1] : String |
 | Tuples.cs:62:18:62:57 | SSA def(t) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item1] : String | Tuples.cs:63:22:63:22 | access to local variable t : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item1] : String |
 | Tuples.cs:62:18:62:57 | SSA def(t) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item2, field Item2] : String | Tuples.cs:64:22:64:22 | access to local variable t : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item2, field Item2] : String |
+| Tuples.cs:62:18:62:57 | SSA def(t) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item2, field Item2] : String | Tuples.cs:64:22:64:22 | access to local variable t : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item2, field Item2] : String |
+| Tuples.cs:63:22:63:22 | access to local variable t : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item1] : String | Tuples.cs:63:22:63:28 | access to field Item1 |
 | Tuples.cs:63:22:63:22 | access to local variable t : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item1] : String | Tuples.cs:63:22:63:28 | access to field Item1 |
 | Tuples.cs:64:22:64:22 | access to local variable t : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item2, field Item2] : String | Tuples.cs:64:22:64:28 | access to field Item2 : ValueTuple<Int32,String> [field Item2] : String |
+| Tuples.cs:64:22:64:22 | access to local variable t : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item2, field Item2] : String | Tuples.cs:64:22:64:28 | access to field Item2 : ValueTuple<Int32,String> [field Item2] : String |
+| Tuples.cs:64:22:64:28 | access to field Item2 : ValueTuple<Int32,String> [field Item2] : String | Tuples.cs:64:22:64:34 | access to field Item2 |
 | Tuples.cs:64:22:64:28 | access to field Item2 : ValueTuple<Int32,String> [field Item2] : String | Tuples.cs:64:22:64:34 | access to field Item2 |
 | Tuples.cs:67:18:67:35 | (..., ...) : ValueTuple<Int32,String> [field Item2] : String | Tuples.cs:67:30:67:30 | SSA def(c) : String |
+| Tuples.cs:67:18:67:35 | (..., ...) : ValueTuple<Int32,String> [field Item2] : String | Tuples.cs:67:30:67:30 | SSA def(c) : String |
+| Tuples.cs:67:18:67:35 | (..., ...) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item1] : String | Tuples.cs:67:23:67:23 | SSA def(a) : String |
 | Tuples.cs:67:18:67:35 | (..., ...) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item1] : String | Tuples.cs:67:23:67:23 | SSA def(a) : String |
 | Tuples.cs:67:18:67:35 | (..., ...) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item2, field Item2] : String | Tuples.cs:67:18:67:35 | (..., ...) : ValueTuple<Int32,String> [field Item2] : String |
+| Tuples.cs:67:18:67:35 | (..., ...) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item2, field Item2] : String | Tuples.cs:67:18:67:35 | (..., ...) : ValueTuple<Int32,String> [field Item2] : String |
+| Tuples.cs:67:23:67:23 | SSA def(a) : String | Tuples.cs:68:22:68:22 | access to local variable a |
 | Tuples.cs:67:23:67:23 | SSA def(a) : String | Tuples.cs:68:22:68:22 | access to local variable a |
 | Tuples.cs:67:30:67:30 | SSA def(c) : String | Tuples.cs:69:22:69:22 | access to local variable c |
+| Tuples.cs:67:30:67:30 | SSA def(c) : String | Tuples.cs:69:22:69:22 | access to local variable c |
+| Tuples.cs:87:18:87:35 | (..., ...) : ValueTuple<Int32,String> [field Item2] : String | Tuples.cs:87:30:87:30 | SSA def(r) : String |
 | Tuples.cs:87:18:87:35 | (..., ...) : ValueTuple<Int32,String> [field Item2] : String | Tuples.cs:87:30:87:30 | SSA def(r) : String |
 | Tuples.cs:87:18:87:35 | (..., ...) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item1] : String | Tuples.cs:87:23:87:23 | SSA def(p) : String |
+| Tuples.cs:87:18:87:35 | (..., ...) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item1] : String | Tuples.cs:87:23:87:23 | SSA def(p) : String |
+| Tuples.cs:87:18:87:35 | (..., ...) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item2, field Item2] : String | Tuples.cs:87:18:87:35 | (..., ...) : ValueTuple<Int32,String> [field Item2] : String |
 | Tuples.cs:87:18:87:35 | (..., ...) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item2, field Item2] : String | Tuples.cs:87:18:87:35 | (..., ...) : ValueTuple<Int32,String> [field Item2] : String |
 | Tuples.cs:87:23:87:23 | SSA def(p) : String | Tuples.cs:89:18:89:18 | access to local variable p |
+| Tuples.cs:87:23:87:23 | SSA def(p) : String | Tuples.cs:89:18:89:18 | access to local variable p |
+| Tuples.cs:87:30:87:30 | SSA def(r) : String | Tuples.cs:90:18:90:18 | access to local variable r |
 | Tuples.cs:87:30:87:30 | SSA def(r) : String | Tuples.cs:90:18:90:18 | access to local variable r |
 | Tuples.cs:99:17:99:33 | call to method Source<String> : String | Tuples.cs:100:24:100:24 | access to local variable o : String |
+| Tuples.cs:99:17:99:33 | call to method Source<String> : String | Tuples.cs:100:24:100:24 | access to local variable o : String |
+| Tuples.cs:100:17:100:28 | object creation of type R1 : R1 [property i] : String | Tuples.cs:101:14:101:14 | access to local variable r : R1 [property i] : String |
 | Tuples.cs:100:17:100:28 | object creation of type R1 : R1 [property i] : String | Tuples.cs:101:14:101:14 | access to local variable r : R1 [property i] : String |
 | Tuples.cs:100:24:100:24 | access to local variable o : String | Tuples.cs:100:17:100:28 | object creation of type R1 : R1 [property i] : String |
+| Tuples.cs:100:24:100:24 | access to local variable o : String | Tuples.cs:100:17:100:28 | object creation of type R1 : R1 [property i] : String |
+| Tuples.cs:101:14:101:14 | access to local variable r : R1 [property i] : String | Tuples.cs:101:14:101:16 | access to property i |
 | Tuples.cs:101:14:101:14 | access to local variable r : R1 [property i] : String | Tuples.cs:101:14:101:16 | access to property i |
 | Tuples.cs:118:17:118:33 | call to method Source<Object> : Object | Tuples.cs:121:28:121:28 | access to local variable o : Object |
+| Tuples.cs:118:17:118:33 | call to method Source<Object> : Object | Tuples.cs:121:28:121:28 | access to local variable o : Object |
+| Tuples.cs:118:17:118:33 | call to method Source<Object> : Object | Tuples.cs:122:14:122:15 | access to local variable x1 |
 | Tuples.cs:118:17:118:33 | call to method Source<Object> : Object | Tuples.cs:122:14:122:15 | access to local variable x1 |
 | Tuples.cs:118:17:118:33 | call to method Source<Object> : Object | Tuples.cs:125:25:125:25 | access to local variable o : Object |
+| Tuples.cs:118:17:118:33 | call to method Source<Object> : Object | Tuples.cs:125:25:125:25 | access to local variable o : Object |
+| Tuples.cs:118:17:118:33 | call to method Source<Object> : Object | Tuples.cs:126:14:126:15 | access to local variable x2 |
 | Tuples.cs:118:17:118:33 | call to method Source<Object> : Object | Tuples.cs:126:14:126:15 | access to local variable x2 |
 | Tuples.cs:118:17:118:33 | call to method Source<Object> : Object | Tuples.cs:129:31:129:31 | access to local variable o : Object |
+| Tuples.cs:118:17:118:33 | call to method Source<Object> : Object | Tuples.cs:129:31:129:31 | access to local variable o : Object |
+| Tuples.cs:118:17:118:33 | call to method Source<Object> : Object | Tuples.cs:130:14:130:15 | access to local variable y3 |
 | Tuples.cs:118:17:118:33 | call to method Source<Object> : Object | Tuples.cs:130:14:130:15 | access to local variable y3 |
 | Tuples.cs:118:17:118:33 | call to method Source<Object> : Object | Tuples.cs:133:28:133:28 | access to local variable o : Object |
+| Tuples.cs:118:17:118:33 | call to method Source<Object> : Object | Tuples.cs:133:28:133:28 | access to local variable o : Object |
+| Tuples.cs:118:17:118:33 | call to method Source<Object> : Object | Tuples.cs:134:14:134:15 | access to local variable y4 |
 | Tuples.cs:118:17:118:33 | call to method Source<Object> : Object | Tuples.cs:134:14:134:15 | access to local variable y4 |
 | Tuples.cs:121:9:121:23 | (..., ...) : ValueTuple<Object,Int32> [field Item1] : Object | Tuples.cs:121:9:121:32 | SSA def(x1) : Object |
+| Tuples.cs:121:9:121:23 | (..., ...) : ValueTuple<Object,Int32> [field Item1] : Object | Tuples.cs:121:9:121:32 | SSA def(x1) : Object |
+| Tuples.cs:121:9:121:32 | SSA def(x1) : Object | Tuples.cs:122:14:122:15 | access to local variable x1 |
 | Tuples.cs:121:9:121:32 | SSA def(x1) : Object | Tuples.cs:122:14:122:15 | access to local variable x1 |
 | Tuples.cs:121:27:121:32 | (..., ...) : ValueTuple<Object,Int32> [field Item1] : Object | Tuples.cs:121:9:121:23 | (..., ...) : ValueTuple<Object,Int32> [field Item1] : Object |
+| Tuples.cs:121:27:121:32 | (..., ...) : ValueTuple<Object,Int32> [field Item1] : Object | Tuples.cs:121:9:121:23 | (..., ...) : ValueTuple<Object,Int32> [field Item1] : Object |
+| Tuples.cs:121:28:121:28 | access to local variable o : Object | Tuples.cs:121:27:121:32 | (..., ...) : ValueTuple<Object,Int32> [field Item1] : Object |
 | Tuples.cs:121:28:121:28 | access to local variable o : Object | Tuples.cs:121:27:121:32 | (..., ...) : ValueTuple<Object,Int32> [field Item1] : Object |
 | Tuples.cs:125:9:125:20 | (..., ...) : ValueTuple<Object,Int32> [field Item1] : Object | Tuples.cs:125:9:125:29 | SSA def(x2) : Object |
+| Tuples.cs:125:9:125:20 | (..., ...) : ValueTuple<Object,Int32> [field Item1] : Object | Tuples.cs:125:9:125:29 | SSA def(x2) : Object |
+| Tuples.cs:125:9:125:29 | SSA def(x2) : Object | Tuples.cs:126:14:126:15 | access to local variable x2 |
 | Tuples.cs:125:9:125:29 | SSA def(x2) : Object | Tuples.cs:126:14:126:15 | access to local variable x2 |
 | Tuples.cs:125:24:125:29 | (..., ...) : ValueTuple<Object,Int32> [field Item1] : Object | Tuples.cs:125:9:125:20 | (..., ...) : ValueTuple<Object,Int32> [field Item1] : Object |
+| Tuples.cs:125:24:125:29 | (..., ...) : ValueTuple<Object,Int32> [field Item1] : Object | Tuples.cs:125:9:125:20 | (..., ...) : ValueTuple<Object,Int32> [field Item1] : Object |
+| Tuples.cs:125:25:125:25 | access to local variable o : Object | Tuples.cs:125:24:125:29 | (..., ...) : ValueTuple<Object,Int32> [field Item1] : Object |
 | Tuples.cs:125:25:125:25 | access to local variable o : Object | Tuples.cs:125:24:125:29 | (..., ...) : ValueTuple<Object,Int32> [field Item1] : Object |
 | Tuples.cs:129:9:129:23 | (..., ...) : ValueTuple<Int32,Object> [field Item2] : Object | Tuples.cs:129:9:129:32 | SSA def(y3) : Object |
+| Tuples.cs:129:9:129:23 | (..., ...) : ValueTuple<Int32,Object> [field Item2] : Object | Tuples.cs:129:9:129:32 | SSA def(y3) : Object |
+| Tuples.cs:129:9:129:32 | SSA def(y3) : Object | Tuples.cs:130:14:130:15 | access to local variable y3 |
 | Tuples.cs:129:9:129:32 | SSA def(y3) : Object | Tuples.cs:130:14:130:15 | access to local variable y3 |
 | Tuples.cs:129:27:129:32 | (..., ...) : ValueTuple<Int32,Object> [field Item2] : Object | Tuples.cs:129:9:129:23 | (..., ...) : ValueTuple<Int32,Object> [field Item2] : Object |
+| Tuples.cs:129:27:129:32 | (..., ...) : ValueTuple<Int32,Object> [field Item2] : Object | Tuples.cs:129:9:129:23 | (..., ...) : ValueTuple<Int32,Object> [field Item2] : Object |
+| Tuples.cs:129:31:129:31 | access to local variable o : Object | Tuples.cs:129:27:129:32 | (..., ...) : ValueTuple<Int32,Object> [field Item2] : Object |
 | Tuples.cs:129:31:129:31 | access to local variable o : Object | Tuples.cs:129:27:129:32 | (..., ...) : ValueTuple<Int32,Object> [field Item2] : Object |
 | Tuples.cs:133:9:133:20 | (..., ...) : ValueTuple<Int32,Object> [field Item2] : Object | Tuples.cs:133:9:133:29 | SSA def(y4) : Object |
+| Tuples.cs:133:9:133:20 | (..., ...) : ValueTuple<Int32,Object> [field Item2] : Object | Tuples.cs:133:9:133:29 | SSA def(y4) : Object |
+| Tuples.cs:133:9:133:29 | SSA def(y4) : Object | Tuples.cs:134:14:134:15 | access to local variable y4 |
 | Tuples.cs:133:9:133:29 | SSA def(y4) : Object | Tuples.cs:134:14:134:15 | access to local variable y4 |
 | Tuples.cs:133:24:133:29 | (..., ...) : ValueTuple<Int32,Object> [field Item2] : Object | Tuples.cs:133:9:133:20 | (..., ...) : ValueTuple<Int32,Object> [field Item2] : Object |
+| Tuples.cs:133:24:133:29 | (..., ...) : ValueTuple<Int32,Object> [field Item2] : Object | Tuples.cs:133:9:133:20 | (..., ...) : ValueTuple<Int32,Object> [field Item2] : Object |
+| Tuples.cs:133:28:133:28 | access to local variable o : Object | Tuples.cs:133:24:133:29 | (..., ...) : ValueTuple<Int32,Object> [field Item2] : Object |
 | Tuples.cs:133:28:133:28 | access to local variable o : Object | Tuples.cs:133:24:133:29 | (..., ...) : ValueTuple<Int32,Object> [field Item2] : Object |
 nodes
 | Tuples.cs:7:18:7:34 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| Tuples.cs:7:18:7:34 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| Tuples.cs:8:18:8:34 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
 | Tuples.cs:8:18:8:34 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
 | Tuples.cs:10:17:10:32 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item1] : Object | semmle.label | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item1] : Object |
+| Tuples.cs:10:17:10:32 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item1] : Object | semmle.label | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item1] : Object |
+| Tuples.cs:10:17:10:32 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item2, field Item2] : Object | semmle.label | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item2, field Item2] : Object |
 | Tuples.cs:10:17:10:32 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item2, field Item2] : Object | semmle.label | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item2, field Item2] : Object |
 | Tuples.cs:10:21:10:22 | access to local variable o1 : Object | semmle.label | access to local variable o1 : Object |
+| Tuples.cs:10:21:10:22 | access to local variable o1 : Object | semmle.label | access to local variable o1 : Object |
+| Tuples.cs:10:25:10:31 | (..., ...) : ValueTuple<Int32,Object> [field Item2] : Object | semmle.label | (..., ...) : ValueTuple<Int32,Object> [field Item2] : Object |
 | Tuples.cs:10:25:10:31 | (..., ...) : ValueTuple<Int32,Object> [field Item2] : Object | semmle.label | (..., ...) : ValueTuple<Int32,Object> [field Item2] : Object |
 | Tuples.cs:10:29:10:30 | access to local variable o2 : Object | semmle.label | access to local variable o2 : Object |
+| Tuples.cs:10:29:10:30 | access to local variable o2 : Object | semmle.label | access to local variable o2 : Object |
+| Tuples.cs:11:9:11:23 | (..., ...) : ValueTuple<Int32,Object> [field Item2] : Object | semmle.label | (..., ...) : ValueTuple<Int32,Object> [field Item2] : Object |
 | Tuples.cs:11:9:11:23 | (..., ...) : ValueTuple<Int32,Object> [field Item2] : Object | semmle.label | (..., ...) : ValueTuple<Int32,Object> [field Item2] : Object |
 | Tuples.cs:11:9:11:23 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item1] : Object | semmle.label | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item1] : Object |
+| Tuples.cs:11:9:11:23 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item1] : Object | semmle.label | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item1] : Object |
+| Tuples.cs:11:9:11:23 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item2, field Item2] : Object | semmle.label | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item2, field Item2] : Object |
 | Tuples.cs:11:9:11:23 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item2, field Item2] : Object | semmle.label | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item2, field Item2] : Object |
 | Tuples.cs:11:9:11:27 | SSA def(a) : Object | semmle.label | SSA def(a) : Object |
+| Tuples.cs:11:9:11:27 | SSA def(a) : Object | semmle.label | SSA def(a) : Object |
+| Tuples.cs:11:9:11:27 | SSA def(c) : Object | semmle.label | SSA def(c) : Object |
 | Tuples.cs:11:9:11:27 | SSA def(c) : Object | semmle.label | SSA def(c) : Object |
 | Tuples.cs:12:14:12:14 | access to local variable a | semmle.label | access to local variable a |
+| Tuples.cs:12:14:12:14 | access to local variable a | semmle.label | access to local variable a |
+| Tuples.cs:14:14:14:14 | access to local variable c | semmle.label | access to local variable c |
 | Tuples.cs:14:14:14:14 | access to local variable c | semmle.label | access to local variable c |
 | Tuples.cs:16:9:16:19 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item1] : Object | semmle.label | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item1] : Object |
+| Tuples.cs:16:9:16:19 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item1] : Object | semmle.label | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item1] : Object |
+| Tuples.cs:16:9:16:19 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item2, field Item2] : Object | semmle.label | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item2, field Item2] : Object |
 | Tuples.cs:16:9:16:19 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item2, field Item2] : Object | semmle.label | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item2, field Item2] : Object |
 | Tuples.cs:16:9:16:23 | SSA def(a) : Object | semmle.label | SSA def(a) : Object |
+| Tuples.cs:16:9:16:23 | SSA def(a) : Object | semmle.label | SSA def(a) : Object |
+| Tuples.cs:16:9:16:23 | SSA def(c) : Object | semmle.label | SSA def(c) : Object |
 | Tuples.cs:16:9:16:23 | SSA def(c) : Object | semmle.label | SSA def(c) : Object |
 | Tuples.cs:16:13:16:18 | (..., ...) : ValueTuple<Int32,Object> [field Item2] : Object | semmle.label | (..., ...) : ValueTuple<Int32,Object> [field Item2] : Object |
+| Tuples.cs:16:13:16:18 | (..., ...) : ValueTuple<Int32,Object> [field Item2] : Object | semmle.label | (..., ...) : ValueTuple<Int32,Object> [field Item2] : Object |
+| Tuples.cs:17:14:17:14 | access to local variable a | semmle.label | access to local variable a |
 | Tuples.cs:17:14:17:14 | access to local variable a | semmle.label | access to local variable a |
 | Tuples.cs:19:14:19:14 | access to local variable c | semmle.label | access to local variable c |
+| Tuples.cs:19:14:19:14 | access to local variable c | semmle.label | access to local variable c |
+| Tuples.cs:21:9:21:22 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item1] : Object | semmle.label | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item1] : Object |
 | Tuples.cs:21:9:21:22 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item1] : Object | semmle.label | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item1] : Object |
 | Tuples.cs:21:9:21:22 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item2, field Item2] : Object | semmle.label | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item2, field Item2] : Object |
+| Tuples.cs:21:9:21:22 | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item2, field Item2] : Object | semmle.label | (..., ...) : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item2, field Item2] : Object |
+| Tuples.cs:21:9:21:26 | SSA def(p) : Object | semmle.label | SSA def(p) : Object |
 | Tuples.cs:21:9:21:26 | SSA def(p) : Object | semmle.label | SSA def(p) : Object |
 | Tuples.cs:21:9:21:26 | SSA def(q) : ValueTuple<Int32,Object> [field Item2] : Object | semmle.label | SSA def(q) : ValueTuple<Int32,Object> [field Item2] : Object |
+| Tuples.cs:21:9:21:26 | SSA def(q) : ValueTuple<Int32,Object> [field Item2] : Object | semmle.label | SSA def(q) : ValueTuple<Int32,Object> [field Item2] : Object |
+| Tuples.cs:22:14:22:14 | access to local variable p | semmle.label | access to local variable p |
 | Tuples.cs:22:14:22:14 | access to local variable p | semmle.label | access to local variable p |
 | Tuples.cs:24:14:24:14 | access to local variable q : ValueTuple<Int32,Object> [field Item2] : Object | semmle.label | access to local variable q : ValueTuple<Int32,Object> [field Item2] : Object |
+| Tuples.cs:24:14:24:14 | access to local variable q : ValueTuple<Int32,Object> [field Item2] : Object | semmle.label | access to local variable q : ValueTuple<Int32,Object> [field Item2] : Object |
+| Tuples.cs:24:14:24:20 | access to field Item2 | semmle.label | access to field Item2 |
 | Tuples.cs:24:14:24:20 | access to field Item2 | semmle.label | access to field Item2 |
 | Tuples.cs:26:14:26:14 | access to local variable x : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item1] : Object | semmle.label | access to local variable x : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item1] : Object |
+| Tuples.cs:26:14:26:14 | access to local variable x : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item1] : Object | semmle.label | access to local variable x : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item1] : Object |
+| Tuples.cs:26:14:26:20 | access to field Item1 | semmle.label | access to field Item1 |
 | Tuples.cs:26:14:26:20 | access to field Item1 | semmle.label | access to field Item1 |
 | Tuples.cs:27:14:27:14 | access to local variable x : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item1] : Object | semmle.label | access to local variable x : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item1] : Object |
+| Tuples.cs:27:14:27:14 | access to local variable x : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item1] : Object | semmle.label | access to local variable x : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item1] : Object |
+| Tuples.cs:27:14:27:16 | access to field Item1 | semmle.label | access to field Item1 |
 | Tuples.cs:27:14:27:16 | access to field Item1 | semmle.label | access to field Item1 |
 | Tuples.cs:29:14:29:14 | access to local variable x : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item2, field Item2] : Object | semmle.label | access to local variable x : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item2, field Item2] : Object |
+| Tuples.cs:29:14:29:14 | access to local variable x : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item2, field Item2] : Object | semmle.label | access to local variable x : ValueTuple<Object,ValueTuple<Int32,Object>> [field Item2, field Item2] : Object |
+| Tuples.cs:29:14:29:20 | access to field Item2 : ValueTuple<Int32,Object> [field Item2] : Object | semmle.label | access to field Item2 : ValueTuple<Int32,Object> [field Item2] : Object |
 | Tuples.cs:29:14:29:20 | access to field Item2 : ValueTuple<Int32,Object> [field Item2] : Object | semmle.label | access to field Item2 : ValueTuple<Int32,Object> [field Item2] : Object |
 | Tuples.cs:29:14:29:26 | access to field Item2 | semmle.label | access to field Item2 |
+| Tuples.cs:29:14:29:26 | access to field Item2 | semmle.label | access to field Item2 |
+| Tuples.cs:34:18:34:34 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
 | Tuples.cs:34:18:34:34 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
 | Tuples.cs:35:18:35:34 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| Tuples.cs:35:18:35:34 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| Tuples.cs:37:17:37:48 | (..., ...) : ValueTuple<Object,Int32,Int32,Int32,Int32,Int32,Int32,ValueTuple<Int32,Int32,Object>> [field Item1] : Object | semmle.label | (..., ...) : ValueTuple<Object,Int32,Int32,Int32,Int32,Int32,Int32,ValueTuple<Int32,Int32,Object>> [field Item1] : Object |
 | Tuples.cs:37:17:37:48 | (..., ...) : ValueTuple<Object,Int32,Int32,Int32,Int32,Int32,Int32,ValueTuple<Int32,Int32,Object>> [field Item1] : Object | semmle.label | (..., ...) : ValueTuple<Object,Int32,Int32,Int32,Int32,Int32,Int32,ValueTuple<Int32,Int32,Object>> [field Item1] : Object |
 | Tuples.cs:37:17:37:48 | (..., ...) : ValueTuple<Object,Int32,Int32,Int32,Int32,Int32,Int32,ValueTuple<Int32,Int32,Object>> [field Item10] : Object | semmle.label | (..., ...) : ValueTuple<Object,Int32,Int32,Int32,Int32,Int32,Int32,ValueTuple<Int32,Int32,Object>> [field Item10] : Object |
+| Tuples.cs:37:17:37:48 | (..., ...) : ValueTuple<Object,Int32,Int32,Int32,Int32,Int32,Int32,ValueTuple<Int32,Int32,Object>> [field Item10] : Object | semmle.label | (..., ...) : ValueTuple<Object,Int32,Int32,Int32,Int32,Int32,Int32,ValueTuple<Int32,Int32,Object>> [field Item10] : Object |
+| Tuples.cs:37:18:37:19 | access to local variable o1 : Object | semmle.label | access to local variable o1 : Object |
 | Tuples.cs:37:18:37:19 | access to local variable o1 : Object | semmle.label | access to local variable o1 : Object |
 | Tuples.cs:37:46:37:47 | access to local variable o2 : Object | semmle.label | access to local variable o2 : Object |
+| Tuples.cs:37:46:37:47 | access to local variable o2 : Object | semmle.label | access to local variable o2 : Object |
+| Tuples.cs:38:14:38:14 | access to local variable x : ValueTuple<Object,Int32,Int32,Int32,Int32,Int32,Int32,ValueTuple<Int32,Int32,Object>> [field Item1] : Object | semmle.label | access to local variable x : ValueTuple<Object,Int32,Int32,Int32,Int32,Int32,Int32,ValueTuple<Int32,Int32,Object>> [field Item1] : Object |
 | Tuples.cs:38:14:38:14 | access to local variable x : ValueTuple<Object,Int32,Int32,Int32,Int32,Int32,Int32,ValueTuple<Int32,Int32,Object>> [field Item1] : Object | semmle.label | access to local variable x : ValueTuple<Object,Int32,Int32,Int32,Int32,Int32,Int32,ValueTuple<Int32,Int32,Object>> [field Item1] : Object |
 | Tuples.cs:38:14:38:20 | access to field Item1 | semmle.label | access to field Item1 |
+| Tuples.cs:38:14:38:20 | access to field Item1 | semmle.label | access to field Item1 |
+| Tuples.cs:40:14:40:14 | access to local variable x : ValueTuple<Object,Int32,Int32,Int32,Int32,Int32,Int32,ValueTuple<Int32,Int32,Object>> [field Item10] : Object | semmle.label | access to local variable x : ValueTuple<Object,Int32,Int32,Int32,Int32,Int32,Int32,ValueTuple<Int32,Int32,Object>> [field Item10] : Object |
 | Tuples.cs:40:14:40:14 | access to local variable x : ValueTuple<Object,Int32,Int32,Int32,Int32,Int32,Int32,ValueTuple<Int32,Int32,Object>> [field Item10] : Object | semmle.label | access to local variable x : ValueTuple<Object,Int32,Int32,Int32,Int32,Int32,Int32,ValueTuple<Int32,Int32,Object>> [field Item10] : Object |
 | Tuples.cs:40:14:40:21 | access to field Item10 | semmle.label | access to field Item10 |
+| Tuples.cs:40:14:40:21 | access to field Item10 | semmle.label | access to field Item10 |
+| Tuples.cs:45:17:45:33 | call to method Source<String> : String | semmle.label | call to method Source<String> : String |
 | Tuples.cs:45:17:45:33 | call to method Source<String> : String | semmle.label | call to method Source<String> : String |
 | Tuples.cs:46:17:46:55 | (...) ... : ValueTuple<String,Int32,Int32> [field Item1] : String | semmle.label | (...) ... : ValueTuple<String,Int32,Int32> [field Item1] : String |
+| Tuples.cs:46:17:46:55 | (...) ... : ValueTuple<String,Int32,Int32> [field Item1] : String | semmle.label | (...) ... : ValueTuple<String,Int32,Int32> [field Item1] : String |
+| Tuples.cs:46:47:46:55 | (..., ...) : ValueTuple<String,Int32,Int32> [field Item1] : String | semmle.label | (..., ...) : ValueTuple<String,Int32,Int32> [field Item1] : String |
 | Tuples.cs:46:47:46:55 | (..., ...) : ValueTuple<String,Int32,Int32> [field Item1] : String | semmle.label | (..., ...) : ValueTuple<String,Int32,Int32> [field Item1] : String |
 | Tuples.cs:46:48:46:48 | access to local variable o : String | semmle.label | access to local variable o : String |
+| Tuples.cs:46:48:46:48 | access to local variable o : String | semmle.label | access to local variable o : String |
+| Tuples.cs:47:14:47:14 | access to local variable x : ValueTuple<String,Int32,Int32> [field Item1] : String | semmle.label | access to local variable x : ValueTuple<String,Int32,Int32> [field Item1] : String |
 | Tuples.cs:47:14:47:14 | access to local variable x : ValueTuple<String,Int32,Int32> [field Item1] : String | semmle.label | access to local variable x : ValueTuple<String,Int32,Int32> [field Item1] : String |
 | Tuples.cs:47:14:47:20 | access to field Item1 | semmle.label | access to field Item1 |
+| Tuples.cs:47:14:47:20 | access to field Item1 | semmle.label | access to field Item1 |
+| Tuples.cs:57:18:57:34 | call to method Source<String> : String | semmle.label | call to method Source<String> : String |
 | Tuples.cs:57:18:57:34 | call to method Source<String> : String | semmle.label | call to method Source<String> : String |
 | Tuples.cs:58:18:58:34 | call to method Source<String> : String | semmle.label | call to method Source<String> : String |
+| Tuples.cs:58:18:58:34 | call to method Source<String> : String | semmle.label | call to method Source<String> : String |
+| Tuples.cs:59:17:59:32 | (..., ...) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item1] : String | semmle.label | (..., ...) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item1] : String |
 | Tuples.cs:59:17:59:32 | (..., ...) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item1] : String | semmle.label | (..., ...) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item1] : String |
 | Tuples.cs:59:17:59:32 | (..., ...) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item2, field Item2] : String | semmle.label | (..., ...) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item2, field Item2] : String |
+| Tuples.cs:59:17:59:32 | (..., ...) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item2, field Item2] : String | semmle.label | (..., ...) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item2, field Item2] : String |
+| Tuples.cs:59:18:59:19 | access to local variable o1 : String | semmle.label | access to local variable o1 : String |
 | Tuples.cs:59:18:59:19 | access to local variable o1 : String | semmle.label | access to local variable o1 : String |
 | Tuples.cs:59:22:59:28 | (..., ...) : ValueTuple<Int32,String> [field Item2] : String | semmle.label | (..., ...) : ValueTuple<Int32,String> [field Item2] : String |
+| Tuples.cs:59:22:59:28 | (..., ...) : ValueTuple<Int32,String> [field Item2] : String | semmle.label | (..., ...) : ValueTuple<Int32,String> [field Item2] : String |
+| Tuples.cs:59:26:59:27 | access to local variable o2 : String | semmle.label | access to local variable o2 : String |
 | Tuples.cs:59:26:59:27 | access to local variable o2 : String | semmle.label | access to local variable o2 : String |
 | Tuples.cs:62:18:62:57 | SSA def(t) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item1] : String | semmle.label | SSA def(t) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item1] : String |
+| Tuples.cs:62:18:62:57 | SSA def(t) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item1] : String | semmle.label | SSA def(t) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item1] : String |
+| Tuples.cs:62:18:62:57 | SSA def(t) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item2, field Item2] : String | semmle.label | SSA def(t) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item2, field Item2] : String |
 | Tuples.cs:62:18:62:57 | SSA def(t) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item2, field Item2] : String | semmle.label | SSA def(t) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item2, field Item2] : String |
 | Tuples.cs:63:22:63:22 | access to local variable t : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item1] : String | semmle.label | access to local variable t : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item1] : String |
+| Tuples.cs:63:22:63:22 | access to local variable t : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item1] : String | semmle.label | access to local variable t : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item1] : String |
+| Tuples.cs:63:22:63:28 | access to field Item1 | semmle.label | access to field Item1 |
 | Tuples.cs:63:22:63:28 | access to field Item1 | semmle.label | access to field Item1 |
 | Tuples.cs:64:22:64:22 | access to local variable t : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item2, field Item2] : String | semmle.label | access to local variable t : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item2, field Item2] : String |
+| Tuples.cs:64:22:64:22 | access to local variable t : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item2, field Item2] : String | semmle.label | access to local variable t : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item2, field Item2] : String |
+| Tuples.cs:64:22:64:28 | access to field Item2 : ValueTuple<Int32,String> [field Item2] : String | semmle.label | access to field Item2 : ValueTuple<Int32,String> [field Item2] : String |
 | Tuples.cs:64:22:64:28 | access to field Item2 : ValueTuple<Int32,String> [field Item2] : String | semmle.label | access to field Item2 : ValueTuple<Int32,String> [field Item2] : String |
 | Tuples.cs:64:22:64:34 | access to field Item2 | semmle.label | access to field Item2 |
+| Tuples.cs:64:22:64:34 | access to field Item2 | semmle.label | access to field Item2 |
+| Tuples.cs:67:18:67:35 | (..., ...) : ValueTuple<Int32,String> [field Item2] : String | semmle.label | (..., ...) : ValueTuple<Int32,String> [field Item2] : String |
 | Tuples.cs:67:18:67:35 | (..., ...) : ValueTuple<Int32,String> [field Item2] : String | semmle.label | (..., ...) : ValueTuple<Int32,String> [field Item2] : String |
 | Tuples.cs:67:18:67:35 | (..., ...) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item1] : String | semmle.label | (..., ...) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item1] : String |
+| Tuples.cs:67:18:67:35 | (..., ...) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item1] : String | semmle.label | (..., ...) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item1] : String |
+| Tuples.cs:67:18:67:35 | (..., ...) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item2, field Item2] : String | semmle.label | (..., ...) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item2, field Item2] : String |
 | Tuples.cs:67:18:67:35 | (..., ...) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item2, field Item2] : String | semmle.label | (..., ...) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item2, field Item2] : String |
 | Tuples.cs:67:23:67:23 | SSA def(a) : String | semmle.label | SSA def(a) : String |
+| Tuples.cs:67:23:67:23 | SSA def(a) : String | semmle.label | SSA def(a) : String |
+| Tuples.cs:67:30:67:30 | SSA def(c) : String | semmle.label | SSA def(c) : String |
 | Tuples.cs:67:30:67:30 | SSA def(c) : String | semmle.label | SSA def(c) : String |
 | Tuples.cs:68:22:68:22 | access to local variable a | semmle.label | access to local variable a |
+| Tuples.cs:68:22:68:22 | access to local variable a | semmle.label | access to local variable a |
+| Tuples.cs:69:22:69:22 | access to local variable c | semmle.label | access to local variable c |
 | Tuples.cs:69:22:69:22 | access to local variable c | semmle.label | access to local variable c |
 | Tuples.cs:87:18:87:35 | (..., ...) : ValueTuple<Int32,String> [field Item2] : String | semmle.label | (..., ...) : ValueTuple<Int32,String> [field Item2] : String |
+| Tuples.cs:87:18:87:35 | (..., ...) : ValueTuple<Int32,String> [field Item2] : String | semmle.label | (..., ...) : ValueTuple<Int32,String> [field Item2] : String |
+| Tuples.cs:87:18:87:35 | (..., ...) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item1] : String | semmle.label | (..., ...) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item1] : String |
 | Tuples.cs:87:18:87:35 | (..., ...) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item1] : String | semmle.label | (..., ...) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item1] : String |
 | Tuples.cs:87:18:87:35 | (..., ...) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item2, field Item2] : String | semmle.label | (..., ...) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item2, field Item2] : String |
+| Tuples.cs:87:18:87:35 | (..., ...) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item2, field Item2] : String | semmle.label | (..., ...) : ValueTuple<String,ValueTuple<Int32,String>,Int32> [field Item2, field Item2] : String |
+| Tuples.cs:87:23:87:23 | SSA def(p) : String | semmle.label | SSA def(p) : String |
 | Tuples.cs:87:23:87:23 | SSA def(p) : String | semmle.label | SSA def(p) : String |
 | Tuples.cs:87:30:87:30 | SSA def(r) : String | semmle.label | SSA def(r) : String |
+| Tuples.cs:87:30:87:30 | SSA def(r) : String | semmle.label | SSA def(r) : String |
+| Tuples.cs:89:18:89:18 | access to local variable p | semmle.label | access to local variable p |
 | Tuples.cs:89:18:89:18 | access to local variable p | semmle.label | access to local variable p |
 | Tuples.cs:90:18:90:18 | access to local variable r | semmle.label | access to local variable r |
+| Tuples.cs:90:18:90:18 | access to local variable r | semmle.label | access to local variable r |
+| Tuples.cs:99:17:99:33 | call to method Source<String> : String | semmle.label | call to method Source<String> : String |
 | Tuples.cs:99:17:99:33 | call to method Source<String> : String | semmle.label | call to method Source<String> : String |
 | Tuples.cs:100:17:100:28 | object creation of type R1 : R1 [property i] : String | semmle.label | object creation of type R1 : R1 [property i] : String |
+| Tuples.cs:100:17:100:28 | object creation of type R1 : R1 [property i] : String | semmle.label | object creation of type R1 : R1 [property i] : String |
+| Tuples.cs:100:24:100:24 | access to local variable o : String | semmle.label | access to local variable o : String |
 | Tuples.cs:100:24:100:24 | access to local variable o : String | semmle.label | access to local variable o : String |
 | Tuples.cs:101:14:101:14 | access to local variable r : R1 [property i] : String | semmle.label | access to local variable r : R1 [property i] : String |
+| Tuples.cs:101:14:101:14 | access to local variable r : R1 [property i] : String | semmle.label | access to local variable r : R1 [property i] : String |
+| Tuples.cs:101:14:101:16 | access to property i | semmle.label | access to property i |
 | Tuples.cs:101:14:101:16 | access to property i | semmle.label | access to property i |
 | Tuples.cs:118:17:118:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| Tuples.cs:118:17:118:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| Tuples.cs:121:9:121:23 | (..., ...) : ValueTuple<Object,Int32> [field Item1] : Object | semmle.label | (..., ...) : ValueTuple<Object,Int32> [field Item1] : Object |
 | Tuples.cs:121:9:121:23 | (..., ...) : ValueTuple<Object,Int32> [field Item1] : Object | semmle.label | (..., ...) : ValueTuple<Object,Int32> [field Item1] : Object |
 | Tuples.cs:121:9:121:32 | SSA def(x1) : Object | semmle.label | SSA def(x1) : Object |
+| Tuples.cs:121:9:121:32 | SSA def(x1) : Object | semmle.label | SSA def(x1) : Object |
+| Tuples.cs:121:27:121:32 | (..., ...) : ValueTuple<Object,Int32> [field Item1] : Object | semmle.label | (..., ...) : ValueTuple<Object,Int32> [field Item1] : Object |
 | Tuples.cs:121:27:121:32 | (..., ...) : ValueTuple<Object,Int32> [field Item1] : Object | semmle.label | (..., ...) : ValueTuple<Object,Int32> [field Item1] : Object |
 | Tuples.cs:121:28:121:28 | access to local variable o : Object | semmle.label | access to local variable o : Object |
+| Tuples.cs:121:28:121:28 | access to local variable o : Object | semmle.label | access to local variable o : Object |
+| Tuples.cs:122:14:122:15 | access to local variable x1 | semmle.label | access to local variable x1 |
 | Tuples.cs:122:14:122:15 | access to local variable x1 | semmle.label | access to local variable x1 |
 | Tuples.cs:125:9:125:20 | (..., ...) : ValueTuple<Object,Int32> [field Item1] : Object | semmle.label | (..., ...) : ValueTuple<Object,Int32> [field Item1] : Object |
+| Tuples.cs:125:9:125:20 | (..., ...) : ValueTuple<Object,Int32> [field Item1] : Object | semmle.label | (..., ...) : ValueTuple<Object,Int32> [field Item1] : Object |
+| Tuples.cs:125:9:125:29 | SSA def(x2) : Object | semmle.label | SSA def(x2) : Object |
 | Tuples.cs:125:9:125:29 | SSA def(x2) : Object | semmle.label | SSA def(x2) : Object |
 | Tuples.cs:125:24:125:29 | (..., ...) : ValueTuple<Object,Int32> [field Item1] : Object | semmle.label | (..., ...) : ValueTuple<Object,Int32> [field Item1] : Object |
+| Tuples.cs:125:24:125:29 | (..., ...) : ValueTuple<Object,Int32> [field Item1] : Object | semmle.label | (..., ...) : ValueTuple<Object,Int32> [field Item1] : Object |
+| Tuples.cs:125:25:125:25 | access to local variable o : Object | semmle.label | access to local variable o : Object |
 | Tuples.cs:125:25:125:25 | access to local variable o : Object | semmle.label | access to local variable o : Object |
 | Tuples.cs:126:14:126:15 | access to local variable x2 | semmle.label | access to local variable x2 |
+| Tuples.cs:126:14:126:15 | access to local variable x2 | semmle.label | access to local variable x2 |
+| Tuples.cs:129:9:129:23 | (..., ...) : ValueTuple<Int32,Object> [field Item2] : Object | semmle.label | (..., ...) : ValueTuple<Int32,Object> [field Item2] : Object |
 | Tuples.cs:129:9:129:23 | (..., ...) : ValueTuple<Int32,Object> [field Item2] : Object | semmle.label | (..., ...) : ValueTuple<Int32,Object> [field Item2] : Object |
 | Tuples.cs:129:9:129:32 | SSA def(y3) : Object | semmle.label | SSA def(y3) : Object |
+| Tuples.cs:129:9:129:32 | SSA def(y3) : Object | semmle.label | SSA def(y3) : Object |
+| Tuples.cs:129:27:129:32 | (..., ...) : ValueTuple<Int32,Object> [field Item2] : Object | semmle.label | (..., ...) : ValueTuple<Int32,Object> [field Item2] : Object |
 | Tuples.cs:129:27:129:32 | (..., ...) : ValueTuple<Int32,Object> [field Item2] : Object | semmle.label | (..., ...) : ValueTuple<Int32,Object> [field Item2] : Object |
 | Tuples.cs:129:31:129:31 | access to local variable o : Object | semmle.label | access to local variable o : Object |
+| Tuples.cs:129:31:129:31 | access to local variable o : Object | semmle.label | access to local variable o : Object |
+| Tuples.cs:130:14:130:15 | access to local variable y3 | semmle.label | access to local variable y3 |
 | Tuples.cs:130:14:130:15 | access to local variable y3 | semmle.label | access to local variable y3 |
 | Tuples.cs:133:9:133:20 | (..., ...) : ValueTuple<Int32,Object> [field Item2] : Object | semmle.label | (..., ...) : ValueTuple<Int32,Object> [field Item2] : Object |
+| Tuples.cs:133:9:133:20 | (..., ...) : ValueTuple<Int32,Object> [field Item2] : Object | semmle.label | (..., ...) : ValueTuple<Int32,Object> [field Item2] : Object |
+| Tuples.cs:133:9:133:29 | SSA def(y4) : Object | semmle.label | SSA def(y4) : Object |
 | Tuples.cs:133:9:133:29 | SSA def(y4) : Object | semmle.label | SSA def(y4) : Object |
 | Tuples.cs:133:24:133:29 | (..., ...) : ValueTuple<Int32,Object> [field Item2] : Object | semmle.label | (..., ...) : ValueTuple<Int32,Object> [field Item2] : Object |
+| Tuples.cs:133:24:133:29 | (..., ...) : ValueTuple<Int32,Object> [field Item2] : Object | semmle.label | (..., ...) : ValueTuple<Int32,Object> [field Item2] : Object |
 | Tuples.cs:133:28:133:28 | access to local variable o : Object | semmle.label | access to local variable o : Object |
+| Tuples.cs:133:28:133:28 | access to local variable o : Object | semmle.label | access to local variable o : Object |
+| Tuples.cs:134:14:134:15 | access to local variable y4 | semmle.label | access to local variable y4 |
 | Tuples.cs:134:14:134:15 | access to local variable y4 | semmle.label | access to local variable y4 |
 subpaths
 #select
 | Tuples.cs:12:14:12:14 | access to local variable a | Tuples.cs:7:18:7:34 | call to method Source<Object> : Object | Tuples.cs:12:14:12:14 | access to local variable a | $@ | Tuples.cs:7:18:7:34 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| Tuples.cs:12:14:12:14 | access to local variable a | Tuples.cs:7:18:7:34 | call to method Source<Object> : Object | Tuples.cs:12:14:12:14 | access to local variable a | $@ | Tuples.cs:7:18:7:34 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| Tuples.cs:14:14:14:14 | access to local variable c | Tuples.cs:8:18:8:34 | call to method Source<Object> : Object | Tuples.cs:14:14:14:14 | access to local variable c | $@ | Tuples.cs:8:18:8:34 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | Tuples.cs:14:14:14:14 | access to local variable c | Tuples.cs:8:18:8:34 | call to method Source<Object> : Object | Tuples.cs:14:14:14:14 | access to local variable c | $@ | Tuples.cs:8:18:8:34 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | Tuples.cs:17:14:17:14 | access to local variable a | Tuples.cs:7:18:7:34 | call to method Source<Object> : Object | Tuples.cs:17:14:17:14 | access to local variable a | $@ | Tuples.cs:7:18:7:34 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| Tuples.cs:17:14:17:14 | access to local variable a | Tuples.cs:7:18:7:34 | call to method Source<Object> : Object | Tuples.cs:17:14:17:14 | access to local variable a | $@ | Tuples.cs:7:18:7:34 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| Tuples.cs:19:14:19:14 | access to local variable c | Tuples.cs:8:18:8:34 | call to method Source<Object> : Object | Tuples.cs:19:14:19:14 | access to local variable c | $@ | Tuples.cs:8:18:8:34 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | Tuples.cs:19:14:19:14 | access to local variable c | Tuples.cs:8:18:8:34 | call to method Source<Object> : Object | Tuples.cs:19:14:19:14 | access to local variable c | $@ | Tuples.cs:8:18:8:34 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | Tuples.cs:22:14:22:14 | access to local variable p | Tuples.cs:7:18:7:34 | call to method Source<Object> : Object | Tuples.cs:22:14:22:14 | access to local variable p | $@ | Tuples.cs:7:18:7:34 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| Tuples.cs:22:14:22:14 | access to local variable p | Tuples.cs:7:18:7:34 | call to method Source<Object> : Object | Tuples.cs:22:14:22:14 | access to local variable p | $@ | Tuples.cs:7:18:7:34 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| Tuples.cs:24:14:24:20 | access to field Item2 | Tuples.cs:8:18:8:34 | call to method Source<Object> : Object | Tuples.cs:24:14:24:20 | access to field Item2 | $@ | Tuples.cs:8:18:8:34 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | Tuples.cs:24:14:24:20 | access to field Item2 | Tuples.cs:8:18:8:34 | call to method Source<Object> : Object | Tuples.cs:24:14:24:20 | access to field Item2 | $@ | Tuples.cs:8:18:8:34 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | Tuples.cs:26:14:26:20 | access to field Item1 | Tuples.cs:7:18:7:34 | call to method Source<Object> : Object | Tuples.cs:26:14:26:20 | access to field Item1 | $@ | Tuples.cs:7:18:7:34 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| Tuples.cs:26:14:26:20 | access to field Item1 | Tuples.cs:7:18:7:34 | call to method Source<Object> : Object | Tuples.cs:26:14:26:20 | access to field Item1 | $@ | Tuples.cs:7:18:7:34 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| Tuples.cs:27:14:27:16 | access to field Item1 | Tuples.cs:7:18:7:34 | call to method Source<Object> : Object | Tuples.cs:27:14:27:16 | access to field Item1 | $@ | Tuples.cs:7:18:7:34 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | Tuples.cs:27:14:27:16 | access to field Item1 | Tuples.cs:7:18:7:34 | call to method Source<Object> : Object | Tuples.cs:27:14:27:16 | access to field Item1 | $@ | Tuples.cs:7:18:7:34 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | Tuples.cs:29:14:29:26 | access to field Item2 | Tuples.cs:8:18:8:34 | call to method Source<Object> : Object | Tuples.cs:29:14:29:26 | access to field Item2 | $@ | Tuples.cs:8:18:8:34 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| Tuples.cs:29:14:29:26 | access to field Item2 | Tuples.cs:8:18:8:34 | call to method Source<Object> : Object | Tuples.cs:29:14:29:26 | access to field Item2 | $@ | Tuples.cs:8:18:8:34 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| Tuples.cs:38:14:38:20 | access to field Item1 | Tuples.cs:34:18:34:34 | call to method Source<Object> : Object | Tuples.cs:38:14:38:20 | access to field Item1 | $@ | Tuples.cs:34:18:34:34 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | Tuples.cs:38:14:38:20 | access to field Item1 | Tuples.cs:34:18:34:34 | call to method Source<Object> : Object | Tuples.cs:38:14:38:20 | access to field Item1 | $@ | Tuples.cs:34:18:34:34 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | Tuples.cs:40:14:40:21 | access to field Item10 | Tuples.cs:35:18:35:34 | call to method Source<Object> : Object | Tuples.cs:40:14:40:21 | access to field Item10 | $@ | Tuples.cs:35:18:35:34 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| Tuples.cs:40:14:40:21 | access to field Item10 | Tuples.cs:35:18:35:34 | call to method Source<Object> : Object | Tuples.cs:40:14:40:21 | access to field Item10 | $@ | Tuples.cs:35:18:35:34 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| Tuples.cs:47:14:47:20 | access to field Item1 | Tuples.cs:45:17:45:33 | call to method Source<String> : String | Tuples.cs:47:14:47:20 | access to field Item1 | $@ | Tuples.cs:45:17:45:33 | call to method Source<String> : String | call to method Source<String> : String |
 | Tuples.cs:47:14:47:20 | access to field Item1 | Tuples.cs:45:17:45:33 | call to method Source<String> : String | Tuples.cs:47:14:47:20 | access to field Item1 | $@ | Tuples.cs:45:17:45:33 | call to method Source<String> : String | call to method Source<String> : String |
 | Tuples.cs:63:22:63:28 | access to field Item1 | Tuples.cs:57:18:57:34 | call to method Source<String> : String | Tuples.cs:63:22:63:28 | access to field Item1 | $@ | Tuples.cs:57:18:57:34 | call to method Source<String> : String | call to method Source<String> : String |
+| Tuples.cs:63:22:63:28 | access to field Item1 | Tuples.cs:57:18:57:34 | call to method Source<String> : String | Tuples.cs:63:22:63:28 | access to field Item1 | $@ | Tuples.cs:57:18:57:34 | call to method Source<String> : String | call to method Source<String> : String |
+| Tuples.cs:64:22:64:34 | access to field Item2 | Tuples.cs:58:18:58:34 | call to method Source<String> : String | Tuples.cs:64:22:64:34 | access to field Item2 | $@ | Tuples.cs:58:18:58:34 | call to method Source<String> : String | call to method Source<String> : String |
 | Tuples.cs:64:22:64:34 | access to field Item2 | Tuples.cs:58:18:58:34 | call to method Source<String> : String | Tuples.cs:64:22:64:34 | access to field Item2 | $@ | Tuples.cs:58:18:58:34 | call to method Source<String> : String | call to method Source<String> : String |
 | Tuples.cs:68:22:68:22 | access to local variable a | Tuples.cs:57:18:57:34 | call to method Source<String> : String | Tuples.cs:68:22:68:22 | access to local variable a | $@ | Tuples.cs:57:18:57:34 | call to method Source<String> : String | call to method Source<String> : String |
+| Tuples.cs:68:22:68:22 | access to local variable a | Tuples.cs:57:18:57:34 | call to method Source<String> : String | Tuples.cs:68:22:68:22 | access to local variable a | $@ | Tuples.cs:57:18:57:34 | call to method Source<String> : String | call to method Source<String> : String |
+| Tuples.cs:69:22:69:22 | access to local variable c | Tuples.cs:58:18:58:34 | call to method Source<String> : String | Tuples.cs:69:22:69:22 | access to local variable c | $@ | Tuples.cs:58:18:58:34 | call to method Source<String> : String | call to method Source<String> : String |
 | Tuples.cs:69:22:69:22 | access to local variable c | Tuples.cs:58:18:58:34 | call to method Source<String> : String | Tuples.cs:69:22:69:22 | access to local variable c | $@ | Tuples.cs:58:18:58:34 | call to method Source<String> : String | call to method Source<String> : String |
 | Tuples.cs:89:18:89:18 | access to local variable p | Tuples.cs:57:18:57:34 | call to method Source<String> : String | Tuples.cs:89:18:89:18 | access to local variable p | $@ | Tuples.cs:57:18:57:34 | call to method Source<String> : String | call to method Source<String> : String |
+| Tuples.cs:89:18:89:18 | access to local variable p | Tuples.cs:57:18:57:34 | call to method Source<String> : String | Tuples.cs:89:18:89:18 | access to local variable p | $@ | Tuples.cs:57:18:57:34 | call to method Source<String> : String | call to method Source<String> : String |
+| Tuples.cs:90:18:90:18 | access to local variable r | Tuples.cs:58:18:58:34 | call to method Source<String> : String | Tuples.cs:90:18:90:18 | access to local variable r | $@ | Tuples.cs:58:18:58:34 | call to method Source<String> : String | call to method Source<String> : String |
 | Tuples.cs:90:18:90:18 | access to local variable r | Tuples.cs:58:18:58:34 | call to method Source<String> : String | Tuples.cs:90:18:90:18 | access to local variable r | $@ | Tuples.cs:58:18:58:34 | call to method Source<String> : String | call to method Source<String> : String |
 | Tuples.cs:101:14:101:16 | access to property i | Tuples.cs:99:17:99:33 | call to method Source<String> : String | Tuples.cs:101:14:101:16 | access to property i | $@ | Tuples.cs:99:17:99:33 | call to method Source<String> : String | call to method Source<String> : String |
+| Tuples.cs:101:14:101:16 | access to property i | Tuples.cs:99:17:99:33 | call to method Source<String> : String | Tuples.cs:101:14:101:16 | access to property i | $@ | Tuples.cs:99:17:99:33 | call to method Source<String> : String | call to method Source<String> : String |
+| Tuples.cs:122:14:122:15 | access to local variable x1 | Tuples.cs:118:17:118:33 | call to method Source<Object> : Object | Tuples.cs:122:14:122:15 | access to local variable x1 | $@ | Tuples.cs:118:17:118:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | Tuples.cs:122:14:122:15 | access to local variable x1 | Tuples.cs:118:17:118:33 | call to method Source<Object> : Object | Tuples.cs:122:14:122:15 | access to local variable x1 | $@ | Tuples.cs:118:17:118:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | Tuples.cs:126:14:126:15 | access to local variable x2 | Tuples.cs:118:17:118:33 | call to method Source<Object> : Object | Tuples.cs:126:14:126:15 | access to local variable x2 | $@ | Tuples.cs:118:17:118:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| Tuples.cs:126:14:126:15 | access to local variable x2 | Tuples.cs:118:17:118:33 | call to method Source<Object> : Object | Tuples.cs:126:14:126:15 | access to local variable x2 | $@ | Tuples.cs:118:17:118:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | Tuples.cs:130:14:130:15 | access to local variable y3 | Tuples.cs:118:17:118:33 | call to method Source<Object> : Object | Tuples.cs:130:14:130:15 | access to local variable y3 | $@ | Tuples.cs:118:17:118:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| Tuples.cs:130:14:130:15 | access to local variable y3 | Tuples.cs:118:17:118:33 | call to method Source<Object> : Object | Tuples.cs:130:14:130:15 | access to local variable y3 | $@ | Tuples.cs:118:17:118:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| Tuples.cs:134:14:134:15 | access to local variable y4 | Tuples.cs:118:17:118:33 | call to method Source<Object> : Object | Tuples.cs:134:14:134:15 | access to local variable y4 | $@ | Tuples.cs:118:17:118:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | Tuples.cs:134:14:134:15 | access to local variable y4 | Tuples.cs:118:17:118:33 | call to method Source<Object> : Object | Tuples.cs:134:14:134:15 | access to local variable y4 | $@ | Tuples.cs:118:17:118:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |

--- a/csharp/ql/test/library-tests/dataflow/tuples/Tuples.ql
+++ b/csharp/ql/test/library-tests/dataflow/tuples/Tuples.ql
@@ -3,9 +3,10 @@
  */
 
 import csharp
-import DefaultValueFlow::PathGraph
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest
+import ValueFlow::PathGraph
 
-from DefaultValueFlow::PathNode source, DefaultValueFlow::PathNode sink
-where DefaultValueFlow::flowPath(source, sink)
+from ValueFlow::PathNode source, ValueFlow::PathNode sink
+where ValueFlow::flowPath(source, sink)
 select sink, source, sink, "$@", source, source.toString()

--- a/csharp/ql/test/library-tests/dataflow/tuples/Tuples.ql
+++ b/csharp/ql/test/library-tests/dataflow/tuples/Tuples.ql
@@ -5,8 +5,8 @@
 import csharp
 import TestUtilities.InlineFlowTest
 import DefaultFlowTest
-import ValueFlow::PathGraph
+import PathGraph
 
-from ValueFlow::PathNode source, ValueFlow::PathNode sink
-where ValueFlow::flowPath(source, sink)
+from PathNode source, PathNode sink
+where flowPath(source, sink)
 select sink, source, sink, "$@", source, source.toString()

--- a/go/ql/lib/change-notes/2023-06-14-log-injection-deprecation.md
+++ b/go/ql/lib/change-notes/2023-06-14-log-injection-deprecation.md
@@ -1,0 +1,4 @@
+---
+category: deprecated
+---
+* The `LogInjection::Configuration` taint flow configuration class has been deprecated. Use the `LogInjection::Flow` module instead.

--- a/go/ql/lib/semmle/go/security/LogInjection.qll
+++ b/go/ql/lib/semmle/go/security/LogInjection.qll
@@ -17,7 +17,7 @@ module LogInjection {
   /**
    * A taint-tracking configuration for reasoning about log injection vulnerabilities.
    */
-  class Configuration extends TaintTracking::Configuration {
+  deprecated class Configuration extends TaintTracking::Configuration {
     Configuration() { this = "LogInjection" }
 
     override predicate isSource(DataFlow::Node source) { source instanceof Source }
@@ -30,4 +30,17 @@ module LogInjection {
       guard instanceof SanitizerGuard
     }
   }
+
+  /**
+   * A taint-tracking configuration for reasoning about log injection vulnerabilities.
+   */
+  module Config implements DataFlow::ConfigSig {
+    predicate isSource(DataFlow::Node source) { source instanceof Source }
+
+    predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
+
+    predicate isBarrier(DataFlow::Node sanitizer) { sanitizer instanceof Sanitizer }
+  }
+
+  module Flow = TaintTracking::Global<Config>;
 }

--- a/go/ql/src/Security/CWE-117/LogInjection.ql
+++ b/go/ql/src/Security/CWE-117/LogInjection.ql
@@ -13,9 +13,9 @@
 
 import go
 import semmle.go.security.LogInjection
-import DataFlow::PathGraph
+import LogInjection::Flow::PathGraph
 
-from LogInjection::Configuration c, DataFlow::PathNode source, DataFlow::PathNode sink
-where c.hasFlowPath(source, sink)
+from LogInjection::Flow::PathNode source, LogInjection::Flow::PathNode sink
+where LogInjection::Flow::flowPath(source, sink)
 select sink.getNode(), source, sink, "This log entry depends on a $@.", source.getNode(),
   "user-provided value"

--- a/go/ql/test/TestUtilities/InlineFlowTest.qll
+++ b/go/ql/test/TestUtilities/InlineFlowTest.qll
@@ -3,37 +3,30 @@
  *
  * Example for a test.ql:
  * ```ql
- * import java
+ * import go
  * import TestUtilities.InlineFlowTest
+ * import DefaultFlowTest
  * ```
  *
  * To declare expectations, you can use the $hasTaintFlow or $hasValueFlow comments within the test source files.
- * Example of the corresponding test file, e.g. Test.java
+ * Example of the corresponding test file, e.g. Test.go
  * ```go
- * public class Test {
+ * func source() string { return ""; }
+ * func taint() string { return ""; }
+ * func sink(s string) { }
  *
- * 	Object source() { return null; }
- * 	String taint() { return null; }
- * 	void sink(Object o) { }
- *
- * 	public void test() {
- * 		Object s = source();
- * 		sink(s); //$hasValueFlow
- * 		String t = "foo" + taint();
- * 		sink(t); //$hasTaintFlow
- * 	}
- *
+ * func test() {
+ *   s := source()
+ *   sink(s) // $ hasValueFlow="s"
+ *   t := "foo" + taint()
+ *   sink(t) // $ hasTaintFlow="t"
  * }
  * ```
  *
- * If you're not interested in a specific flow type, you can disable either value or taint flow expectations as follows:
- * ```ql
- * class HasFlowTest extends InlineFlowTest {
- *   override DataFlow::Configuration getTaintFlowConfig() { none() }
- *
- *   override DataFlow::Configuration getValueFlowConfig() { none() }
- * }
- * ```
+ * If you are only interested in value flow, then instead of importing `DefaultFlowTest`, you can import
+ * `ValueFlowTest<DefaultFlowConfig>`. Similarly, if you are only interested in taint flow, then instead of
+ * importing `DefaultFlowTest`, you can import `TaintFlowTest<DefaultFlowConfig>`. In both cases
+ * `DefaultFlowConfig` can be replaced by another implementation of `DataFlow::ConfigSig`.
  *
  * If you need more fine-grained tuning, consider implementing a test using `InlineExpectationsTest`.
  */
@@ -47,57 +40,62 @@ private predicate defaultSource(DataFlow::Node source) {
   )
 }
 
-class DefaultValueFlowConf extends DataFlow::Configuration {
-  DefaultValueFlowConf() { this = "qltest:defaultValueFlowConf" }
-
-  override predicate isSource(DataFlow::Node source) { defaultSource(source) }
-
-  override predicate isSink(DataFlow::Node sink) {
-    exists(Function fn | fn.hasQualifiedName(_, "sink") | sink = fn.getACall().getAnArgument())
-  }
-
-  override int fieldFlowBranchLimit() { result = 1000 }
+private predicate defaultSink(DataFlow::Node sink) {
+  exists(Function fn | fn.hasQualifiedName(_, "sink") | sink = fn.getACall().getAnArgument())
 }
 
-class DefaultTaintFlowConf extends TaintTracking::Configuration {
-  DefaultTaintFlowConf() { this = "qltest:defaultTaintFlowConf" }
+module DefaultFlowConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { defaultSource(source) }
 
-  override predicate isSource(DataFlow::Node source) { defaultSource(source) }
+  predicate isSink(DataFlow::Node sink) { defaultSink(sink) }
 
-  override predicate isSink(DataFlow::Node sink) {
-    exists(Function fn | fn.hasQualifiedName(_, "sink") | sink = fn.getACall().getAnArgument())
-  }
-
-  override int fieldFlowBranchLimit() { result = 1000 }
+  int fieldFlowBranchLimit() { result = 1000 }
 }
 
-class InlineFlowTest extends InlineExpectationsTest {
-  InlineFlowTest() { this = "HasFlowTest" }
+private module NoFlowConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { none() }
 
-  override string getARelevantTag() { result = ["hasValueFlow", "hasTaintFlow"] }
+  predicate isSink(DataFlow::Node sink) { none() }
+}
 
-  override predicate hasActualResult(Location location, string element, string tag, string value) {
-    tag = "hasValueFlow" and
-    exists(DataFlow::Node sink | this.getValueFlowConfig().hasFlowTo(sink) |
-      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
-        location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
-      element = sink.toString() and
-      value = "\"" + sink.toString() + "\""
-    )
-    or
-    tag = "hasTaintFlow" and
-    exists(DataFlow::Node src, DataFlow::Node sink |
-      this.getTaintFlowConfig().hasFlow(src, sink) and
-      not this.getValueFlowConfig().hasFlow(src, sink)
-    |
-      sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
-        location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
-      element = sink.toString() and
-      value = "\"" + sink.toString() + "\""
-    )
+module FlowTest<DataFlow::ConfigSig ValueFlowConfig, DataFlow::ConfigSig TaintFlowConfig> {
+  module ValueFlow = DataFlow::Global<ValueFlowConfig>;
+
+  module TaintFlow = TaintTracking::Global<TaintFlowConfig>;
+
+  private module InlineTest implements TestSig {
+    string getARelevantTag() { result = ["hasValueFlow", "hasTaintFlow"] }
+
+    predicate hasActualResult(Location location, string element, string tag, string value) {
+      tag = "hasValueFlow" and
+      exists(DataFlow::Node sink | ValueFlow::flowTo(sink) |
+        sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
+          location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
+        element = sink.toString() and
+        value = "\"" + sink.toString() + "\""
+      )
+      or
+      tag = "hasTaintFlow" and
+      exists(DataFlow::Node src, DataFlow::Node sink |
+        TaintFlow::flow(src, sink) and not ValueFlow::flow(src, sink)
+      |
+        sink.hasLocationInfo(location.getFile().getAbsolutePath(), location.getStartLine(),
+          location.getStartColumn(), location.getEndLine(), location.getEndColumn()) and
+        element = sink.toString() and
+        value = "\"" + sink.toString() + "\""
+      )
+    }
   }
 
-  DataFlow::Configuration getValueFlowConfig() { result = any(DefaultValueFlowConf config) }
+  import MakeTest<InlineTest>
+}
 
-  DataFlow::Configuration getTaintFlowConfig() { result = any(DefaultTaintFlowConf config) }
+module DefaultFlowTest = FlowTest<DefaultFlowConfig, DefaultFlowConfig>;
+
+module ValueFlowTest<DataFlow::ConfigSig ValueFlowConfig> {
+  import FlowTest<ValueFlowConfig, NoFlowConfig>
+}
+
+module TaintFlowTest<DataFlow::ConfigSig TaintFlowConfig> {
+  import FlowTest<NoFlowConfig, TaintFlowConfig>
 }

--- a/go/ql/test/TestUtilities/InlineFlowTest.qll
+++ b/go/ql/test/TestUtilities/InlineFlowTest.qll
@@ -6,6 +6,11 @@
  * import go
  * import TestUtilities.InlineFlowTest
  * import DefaultFlowTest
+ * import PathGraph
+ *
+ * from PathNode source, PathNode sink
+ * where flowPath(source, sink)
+ * select sink, source, sink, "$@", source, source.toString()
  * ```
  *
  * To declare expectations, you can use the $hasTaintFlow or $hasValueFlow comments within the test source files.
@@ -88,6 +93,12 @@ module FlowTest<DataFlow::ConfigSig ValueFlowConfig, DataFlow::ConfigSig TaintFl
   }
 
   import MakeTest<InlineTest>
+  import DataFlow::MergePathGraph<ValueFlow::PathNode, TaintFlow::PathNode, ValueFlow::PathGraph, TaintFlow::PathGraph>
+
+  predicate flowPath(PathNode source, PathNode sink) {
+    ValueFlow::flowPath(source.asPathNode1(), sink.asPathNode1()) or
+    TaintFlow::flowPath(source.asPathNode2(), sink.asPathNode2())
+  }
 }
 
 module DefaultFlowTest = FlowTest<DefaultFlowConfig, DefaultFlowConfig>;

--- a/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlow/completetest.expected
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlow/completetest.expected
@@ -1,2 +1,3 @@
 failures
 invalidModelRow
+testFailures

--- a/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlow/completetest.ql
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlow/completetest.ql
@@ -8,16 +8,10 @@ import ModelValidation
 import semmle.go.dataflow.internal.FlowSummaryImpl as FlowSummaryImpl
 import TestUtilities.InlineFlowTest
 
-class Config extends TaintTracking::Configuration {
-  Config() { this = "external-flow-test" }
+module Config implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node src) { sourceNode(src, "qltest") }
 
-  override predicate isSource(DataFlow::Node src) { sourceNode(src, "qltest") }
-
-  override predicate isSink(DataFlow::Node src) { sinkNode(src, "qltest") }
+  predicate isSink(DataFlow::Node src) { sinkNode(src, "qltest") }
 }
 
-class ExternalFlowTest extends InlineFlowTest {
-  override DataFlow::Configuration getValueFlowConfig() { none() }
-
-  override DataFlow::Configuration getTaintFlowConfig() { result = any(Config config) }
-}
+import TaintFlowTest<Config>

--- a/go/ql/test/library-tests/semmle/go/dataflow/GenericFunctionsAndTypes/Flows.expected
+++ b/go/ql/test/library-tests/semmle/go/dataflow/GenericFunctionsAndTypes/Flows.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/go/ql/test/library-tests/semmle/go/dataflow/GenericFunctionsAndTypes/Flows.ql
+++ b/go/ql/test/library-tests/semmle/go/dataflow/GenericFunctionsAndTypes/Flows.ql
@@ -1,2 +1,3 @@
 import go
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest

--- a/go/ql/test/query-tests/Security/CWE-117/LogInjectionTest.expected
+++ b/go/ql/test/query-tests/Security/CWE-117/LogInjectionTest.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/go/ql/test/query-tests/Security/CWE-117/LogInjectionTest.ql
+++ b/go/ql/test/query-tests/Security/CWE-117/LogInjectionTest.ql
@@ -1,11 +1,4 @@
 import go
 import TestUtilities.InlineFlowTest
 import semmle.go.security.LogInjection
-
-class LogInjectionTest extends InlineFlowTest {
-  override DataFlow::Configuration getTaintFlowConfig() {
-    result = any(LogInjection::Configuration config)
-  }
-
-  override DataFlow::Configuration getValueFlowConfig() { none() }
-}
+import TaintFlowTest<LogInjection::Config>

--- a/java/ql/lib/semmle/code/java/security/SensitiveLoggingQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/SensitiveLoggingQuery.qll
@@ -5,7 +5,6 @@ private import semmle.code.java.dataflow.ExternalFlow
 import semmle.code.java.dataflow.TaintTracking
 import semmle.code.java.security.SensitiveActions
 import semmle.code.java.frameworks.android.Compose
-import DataFlow
 
 /** A variable that may hold sensitive information, judging by its name. */
 class CredentialExpr extends Expr {
@@ -45,7 +44,7 @@ deprecated class SensitiveLoggerConfiguration extends TaintTracking::Configurati
     sanitizer.getType() instanceof TypeType
   }
 
-  override predicate isSanitizerIn(Node node) { this.isSource(node) }
+  override predicate isSanitizerIn(DataFlow::Node node) { this.isSource(node) }
 }
 
 /** A data-flow configuration for identifying potentially-sensitive data flowing to a log output. */
@@ -62,7 +61,7 @@ module SensitiveLoggerConfig implements DataFlow::ConfigSig {
     sanitizer.getType() instanceof TypeType
   }
 
-  predicate isBarrierIn(Node node) { isSource(node) }
+  predicate isBarrierIn(DataFlow::Node node) { isSource(node) }
 }
 
 module SensitiveLoggerFlow = TaintTracking::Global<SensitiveLoggerConfig>;

--- a/java/ql/src/utils/flowtestcasegenerator/testHeader.qlfrag
+++ b/java/ql/src/utils/flowtestcasegenerator/testHeader.qlfrag
@@ -1,2 +1,3 @@
 import java
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest

--- a/java/ql/test/TestUtilities/InlineFlowTest.qll
+++ b/java/ql/test/TestUtilities/InlineFlowTest.qll
@@ -5,6 +5,7 @@
  * ```ql
  * import java
  * import TestUtilities.InlineFlowTest
+ * import DefaultFlowTest
  * ```
  *
  * To declare expectations, you can use the $hasTaintFlow or $hasValueFlow comments within the test source files.
@@ -18,22 +19,18 @@
  *
  * 	public void test() {
  * 		Object s = source();
- * 		sink(s); //$hasValueFlow
+ * 		sink(s); // $ hasValueFlow
  * 		String t = "foo" + taint();
- * 		sink(t); //$hasTaintFlow
+ * 		sink(t); // $ hasTaintFlow
  * 	}
  *
  * }
  * ```
  *
- * If you're not interested in a specific flow type, you can disable either value or taint flow expectations as follows:
- * ```ql
- * class HasFlowTest extends InlineFlowTest {
- *   override DataFlow::Configuration getTaintFlowConfig() { none() }
- *
- *   override DataFlow::Configuration getValueFlowConfig() { none() }
- * }
- * ```
+ * If you are only interested in value flow, then instead of importing `DefaultFlowTest`, you can import
+ * `ValueFlowTest<DefaultFlowConfig>`. Similarly, if you are only interested in taint flow, then instead of
+ * importing `DefaultFlowTest`, you can import `TaintFlowTest<DefaultFlowConfig>`. In both cases
+ * `DefaultFlowConfig` can be replaced by another implementation of `DataFlow::ConfigSig`.
  *
  * If you need more fine-grained tuning, consider implementing a test using `InlineExpectationsTest`.
  */
@@ -43,57 +40,69 @@ import semmle.code.java.dataflow.ExternalFlow
 import semmle.code.java.dataflow.TaintTracking
 import TestUtilities.InlineExpectationsTest
 
-private predicate defaultSource(DataFlow::Node src) {
-  src.asExpr().(MethodAccess).getMethod().getName() = ["source", "taint"]
+private predicate defaultSource(DataFlow::Node source) {
+  source.asExpr().(MethodAccess).getMethod().getName() = ["source", "taint"]
+}
+
+private predicate defaultSink(DataFlow::Node sink) {
+  exists(MethodAccess ma | ma.getMethod().hasName("sink") | sink.asExpr() = ma.getAnArgument())
 }
 
 module DefaultFlowConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node n) { defaultSource(n) }
+  predicate isSource(DataFlow::Node source) { defaultSource(source) }
 
-  predicate isSink(DataFlow::Node n) {
-    exists(MethodAccess ma | ma.getMethod().hasName("sink") | n.asExpr() = ma.getAnArgument())
-  }
+  predicate isSink(DataFlow::Node sink) { defaultSink(sink) }
 
   int fieldFlowBranchLimit() { result = 1000 }
 }
 
-private module DefaultValueFlow = DataFlow::Global<DefaultFlowConfig>;
+private module NoFlowConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { none() }
 
-private module DefaultTaintFlow = TaintTracking::Global<DefaultFlowConfig>;
+  predicate isSink(DataFlow::Node sink) { none() }
+}
 
 private string getSourceArgString(DataFlow::Node src) {
   defaultSource(src) and
   src.asExpr().(MethodAccess).getAnArgument().(StringLiteral).getValue() = result
 }
 
-class InlineFlowTest extends InlineExpectationsTest {
-  InlineFlowTest() { this = "HasFlowTest" }
+module FlowTest<DataFlow::ConfigSig ValueFlowConfig, DataFlow::ConfigSig TaintFlowConfig> {
+  module ValueFlow = DataFlow::Global<ValueFlowConfig>;
 
-  override string getARelevantTag() { result = ["hasValueFlow", "hasTaintFlow"] }
+  module TaintFlow = TaintTracking::Global<TaintFlowConfig>;
 
-  override predicate hasActualResult(Location location, string element, string tag, string value) {
-    tag = "hasValueFlow" and
-    exists(DataFlow::Node src, DataFlow::Node sink | this.hasValueFlow(src, sink) |
-      sink.getLocation() = location and
-      element = sink.toString() and
-      if exists(getSourceArgString(src)) then value = getSourceArgString(src) else value = ""
-    )
-    or
-    tag = "hasTaintFlow" and
-    exists(DataFlow::Node src, DataFlow::Node sink |
-      this.hasTaintFlow(src, sink) and not this.hasValueFlow(src, sink)
-    |
-      sink.getLocation() = location and
-      element = sink.toString() and
-      if exists(getSourceArgString(src)) then value = getSourceArgString(src) else value = ""
-    )
+  private module InlineTest implements TestSig {
+    string getARelevantTag() { result = ["hasValueFlow", "hasTaintFlow"] }
+
+    predicate hasActualResult(Location location, string element, string tag, string value) {
+      tag = "hasValueFlow" and
+      exists(DataFlow::Node src, DataFlow::Node sink | ValueFlow::flow(src, sink) |
+        sink.getLocation() = location and
+        element = sink.toString() and
+        if exists(getSourceArgString(src)) then value = getSourceArgString(src) else value = ""
+      )
+      or
+      tag = "hasTaintFlow" and
+      exists(DataFlow::Node src, DataFlow::Node sink |
+        TaintFlow::flow(src, sink) and not ValueFlow::flow(src, sink)
+      |
+        sink.getLocation() = location and
+        element = sink.toString() and
+        if exists(getSourceArgString(src)) then value = getSourceArgString(src) else value = ""
+      )
+    }
   }
 
-  predicate hasValueFlow(DataFlow::Node src, DataFlow::Node sink) {
-    DefaultValueFlow::flow(src, sink)
-  }
+  import MakeTest<InlineTest>
+}
 
-  predicate hasTaintFlow(DataFlow::Node src, DataFlow::Node sink) {
-    DefaultTaintFlow::flow(src, sink)
-  }
+module DefaultFlowTest = FlowTest<DefaultFlowConfig, DefaultFlowConfig>;
+
+module ValueFlowTest<DataFlow::ConfigSig ValueFlowConfig> {
+  import FlowTest<ValueFlowConfig, NoFlowConfig>
+}
+
+module TaintFlowTest<DataFlow::ConfigSig TaintFlowConfig> {
+  import FlowTest<NoFlowConfig, TaintFlowConfig>
 }

--- a/java/ql/test/TestUtilities/InlineFlowTest.qll
+++ b/java/ql/test/TestUtilities/InlineFlowTest.qll
@@ -6,6 +6,12 @@
  * import java
  * import TestUtilities.InlineFlowTest
  * import DefaultFlowTest
+ * import PathGraph
+ *
+ * from PathNode source, PathNode sink
+ * where flowPath(source, sink)
+ * select sink, source, sink, "$@", source, source.toString()
+
  * ```
  *
  * To declare expectations, you can use the $hasTaintFlow or $hasValueFlow comments within the test source files.
@@ -95,6 +101,12 @@ module FlowTest<DataFlow::ConfigSig ValueFlowConfig, DataFlow::ConfigSig TaintFl
   }
 
   import MakeTest<InlineTest>
+  import DataFlow::MergePathGraph<ValueFlow::PathNode, TaintFlow::PathNode, ValueFlow::PathGraph, TaintFlow::PathGraph>
+
+  predicate flowPath(PathNode source, PathNode sink) {
+    ValueFlow::flowPath(source.asPathNode1(), sink.asPathNode1()) or
+    TaintFlow::flowPath(source.asPathNode2(), sink.asPathNode2())
+  }
 }
 
 module DefaultFlowTest = FlowTest<DefaultFlowConfig, DefaultFlowConfig>;

--- a/java/ql/test/TestUtilities/InlineFlowTest.qll
+++ b/java/ql/test/TestUtilities/InlineFlowTest.qll
@@ -11,7 +11,6 @@
  * from PathNode source, PathNode sink
  * where flowPath(source, sink)
  * select sink, source, sink, "$@", source, source.toString()
-
  * ```
  *
  * To declare expectations, you can use the $hasTaintFlow or $hasValueFlow comments within the test source files.

--- a/java/ql/test/ext/TestModels/test.expected
+++ b/java/ql/test/ext/TestModels/test.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/ext/TestModels/test.ql
+++ b/java/ql/test/ext/TestModels/test.ql
@@ -1,2 +1,3 @@
 import java
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest

--- a/java/ql/test/kotlin/library-tests/dataflow/summaries/test.expected
+++ b/java/ql/test/kotlin/library-tests/dataflow/summaries/test.expected
@@ -1,3 +1,5 @@
+failures
+testFailures
 | test.kt:28:14:28:21 | getSecond(...) | Unexpected result: hasTaintFlow=a |
 | test.kt:35:14:35:27 | component1(...) | Unexpected result: hasTaintFlow=d |
 | test.kt:41:14:41:22 | getSecond(...) | Unexpected result: hasTaintFlow=e |

--- a/java/ql/test/kotlin/library-tests/dataflow/summaries/test.ql
+++ b/java/ql/test/kotlin/library-tests/dataflow/summaries/test.ql
@@ -1,2 +1,3 @@
 import java
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest

--- a/java/ql/test/library-tests/dataflow/callctx/test.expected
+++ b/java/ql/test/library-tests/dataflow/callctx/test.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/dataflow/callctx/test.ql
+++ b/java/ql/test/library-tests/dataflow/callctx/test.ql
@@ -1,2 +1,3 @@
 import java
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest

--- a/java/ql/test/library-tests/dataflow/collections/containerflow.expected
+++ b/java/ql/test/library-tests/dataflow/collections/containerflow.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/dataflow/collections/containerflow.ql
+++ b/java/ql/test/library-tests/dataflow/collections/containerflow.ql
@@ -1,3 +1,4 @@
 import java
 import semmle.code.java.dataflow.DataFlow
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest

--- a/java/ql/test/library-tests/dataflow/fluent-methods/flow.expected
+++ b/java/ql/test/library-tests/dataflow/fluent-methods/flow.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/dataflow/fluent-methods/flow.ql
+++ b/java/ql/test/library-tests/dataflow/fluent-methods/flow.ql
@@ -2,6 +2,7 @@ import java
 import semmle.code.java.dataflow.DataFlow
 import semmle.code.java.dataflow.FlowSteps
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest
 
 class Model extends FluentMethod {
   Model() { this.getName() = "modelledFluentMethod" }

--- a/java/ql/test/library-tests/dataflow/stream-collect/test.expected
+++ b/java/ql/test/library-tests/dataflow/stream-collect/test.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/dataflow/stream-collect/test.ql
+++ b/java/ql/test/library-tests/dataflow/stream-collect/test.ql
@@ -1,1 +1,2 @@
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest

--- a/java/ql/test/library-tests/dataflow/synth-global/test.expected
+++ b/java/ql/test/library-tests/dataflow/synth-global/test.expected
@@ -1,2 +1,3 @@
 failures
+testFailures
 invalidModelRow

--- a/java/ql/test/library-tests/dataflow/synth-global/test.ql
+++ b/java/ql/test/library-tests/dataflow/synth-global/test.ql
@@ -1,3 +1,4 @@
 import java
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest
 import ModelValidation

--- a/java/ql/test/library-tests/dataflow/taint-format/test.expected
+++ b/java/ql/test/library-tests/dataflow/taint-format/test.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/dataflow/taint-format/test.ql
+++ b/java/ql/test/library-tests/dataflow/taint-format/test.ql
@@ -1,2 +1,3 @@
 import java
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest

--- a/java/ql/test/library-tests/dataflow/taint-gson/dataFlow.expected
+++ b/java/ql/test/library-tests/dataflow/taint-gson/dataFlow.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/dataflow/taint-gson/dataFlow.ql
+++ b/java/ql/test/library-tests/dataflow/taint-gson/dataFlow.ql
@@ -1,2 +1,3 @@
 import java
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest

--- a/java/ql/test/library-tests/dataflow/taint-jackson/dataFlow.expected
+++ b/java/ql/test/library-tests/dataflow/taint-jackson/dataFlow.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/dataflow/taint-jackson/dataFlow.ql
+++ b/java/ql/test/library-tests/dataflow/taint-jackson/dataFlow.ql
@@ -1,2 +1,3 @@
 import java
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest

--- a/java/ql/test/library-tests/frameworks/JaxWs/JaxRsFlow.expected
+++ b/java/ql/test/library-tests/frameworks/JaxWs/JaxRsFlow.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/frameworks/JaxWs/JaxRsFlow.ql
+++ b/java/ql/test/library-tests/frameworks/JaxWs/JaxRsFlow.ql
@@ -13,16 +13,4 @@ module Config implements DataFlow::ConfigSig {
   predicate isSink = DefaultFlowConfig::isSink/1;
 }
 
-module TaintFlow = TaintTracking::Global<Config>;
-
-module ValueFlow = DataFlow::Global<Config>;
-
-class Test extends InlineFlowTest {
-  override predicate hasTaintFlow(DataFlow::Node source, DataFlow::Node sink) {
-    TaintFlow::flow(source, sink)
-  }
-
-  override predicate hasValueFlow(DataFlow::Node source, DataFlow::Node sink) {
-    ValueFlow::flow(source, sink)
-  }
-}
+import FlowTest<Config, Config>

--- a/java/ql/test/library-tests/frameworks/android/asynctask/test.expected
+++ b/java/ql/test/library-tests/frameworks/android/asynctask/test.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/frameworks/android/asynctask/test.ql
+++ b/java/ql/test/library-tests/frameworks/android/asynctask/test.ql
@@ -1,2 +1,3 @@
 import java
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest

--- a/java/ql/test/library-tests/frameworks/android/content-provider-summaries/test.expected
+++ b/java/ql/test/library-tests/frameworks/android/content-provider-summaries/test.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/frameworks/android/content-provider-summaries/test.ql
+++ b/java/ql/test/library-tests/frameworks/android/content-provider-summaries/test.ql
@@ -1,2 +1,3 @@
 import java
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest

--- a/java/ql/test/library-tests/frameworks/android/content-provider/test.expected
+++ b/java/ql/test/library-tests/frameworks/android/content-provider/test.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/frameworks/android/content-provider/test.ql
+++ b/java/ql/test/library-tests/frameworks/android/content-provider/test.ql
@@ -10,12 +10,4 @@ module ProviderTaintFlowConfig implements DataFlow::ConfigSig {
   int fieldFlowBranchLimit() { result = DefaultFlowConfig::fieldFlowBranchLimit() }
 }
 
-module ProviderTaintFlow = TaintTracking::Global<ProviderTaintFlowConfig>;
-
-class ProviderInlineFlowTest extends InlineFlowTest {
-  override predicate hasValueFlow(DataFlow::Node src, DataFlow::Node sink) { none() }
-
-  override predicate hasTaintFlow(DataFlow::Node src, DataFlow::Node sink) {
-    ProviderTaintFlow::flow(src, sink)
-  }
-}
+import TaintFlowTest<ProviderTaintFlowConfig>

--- a/java/ql/test/library-tests/frameworks/android/external-storage/test.expected
+++ b/java/ql/test/library-tests/frameworks/android/external-storage/test.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/frameworks/android/external-storage/test.ql
+++ b/java/ql/test/library-tests/frameworks/android/external-storage/test.ql
@@ -11,10 +11,4 @@ module Config implements DataFlow::ConfigSig {
   }
 }
 
-module Flow = TaintTracking::Global<Config>;
-
-class ExternalStorageTest extends InlineFlowTest {
-  override predicate hasValueFlow(DataFlow::Node src, DataFlow::Node sink) { none() }
-
-  override predicate hasTaintFlow(DataFlow::Node src, DataFlow::Node sink) { Flow::flow(src, sink) }
-}
+import TaintFlowTest<Config>

--- a/java/ql/test/library-tests/frameworks/android/flow-steps/test.expected
+++ b/java/ql/test/library-tests/frameworks/android/flow-steps/test.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/frameworks/android/flow-steps/test.ql
+++ b/java/ql/test/library-tests/frameworks/android/flow-steps/test.ql
@@ -1,2 +1,3 @@
 import java
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest

--- a/java/ql/test/library-tests/frameworks/android/intent/test.expected
+++ b/java/ql/test/library-tests/frameworks/android/intent/test.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/frameworks/android/intent/test.ql
+++ b/java/ql/test/library-tests/frameworks/android/intent/test.ql
@@ -1,2 +1,3 @@
 import java
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest

--- a/java/ql/test/library-tests/frameworks/android/notification/test.expected
+++ b/java/ql/test/library-tests/frameworks/android/notification/test.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/frameworks/android/notification/test.ql
+++ b/java/ql/test/library-tests/frameworks/android/notification/test.ql
@@ -1,3 +1,4 @@
 import java
 import semmle.code.java.frameworks.android.Intent
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest

--- a/java/ql/test/library-tests/frameworks/android/slice/test.expected
+++ b/java/ql/test/library-tests/frameworks/android/slice/test.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/frameworks/android/slice/test.ql
+++ b/java/ql/test/library-tests/frameworks/android/slice/test.ql
@@ -11,8 +11,6 @@ module SliceValueFlowConfig implements DataFlow::ConfigSig {
   predicate isSink = DefaultFlowConfig::isSink/1;
 }
 
-module SliceValueFlow = DataFlow::Global<SliceValueFlowConfig>;
-
 module SliceTaintFlowConfig implements DataFlow::ConfigSig {
   predicate isSource = DefaultFlowConfig::isSource/1;
 
@@ -24,14 +22,4 @@ module SliceTaintFlowConfig implements DataFlow::ConfigSig {
   }
 }
 
-module SliceTaintFlow = TaintTracking::Global<SliceTaintFlowConfig>;
-
-class SliceFlowTest extends InlineFlowTest {
-  override predicate hasValueFlow(DataFlow::Node source, DataFlow::Node sink) {
-    SliceValueFlow::flow(source, sink)
-  }
-
-  override predicate hasTaintFlow(DataFlow::Node source, DataFlow::Node sink) {
-    SliceTaintFlow::flow(source, sink)
-  }
-}
+import FlowTest<SliceValueFlowConfig, SliceTaintFlowConfig>

--- a/java/ql/test/library-tests/frameworks/android/sources/OnActivityResultSourceTest.expected
+++ b/java/ql/test/library-tests/frameworks/android/sources/OnActivityResultSourceTest.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/frameworks/android/sources/OnActivityResultSourceTest.ql
+++ b/java/ql/test/library-tests/frameworks/android/sources/OnActivityResultSourceTest.ql
@@ -10,12 +10,4 @@ module SourceValueFlowConfig implements DataFlow::ConfigSig {
   int fieldFlowBranchLimit() { result = DefaultFlowConfig::fieldFlowBranchLimit() }
 }
 
-module SourceValueFlow = DataFlow::Global<SourceValueFlowConfig>;
-
-class SourceInlineFlowTest extends InlineFlowTest {
-  override predicate hasValueFlow(DataFlow::Node src, DataFlow::Node sink) {
-    SourceValueFlow::flow(src, sink)
-  }
-
-  override predicate hasTaintFlow(DataFlow::Node src, DataFlow::Node sink) { none() }
-}
+import ValueFlowTest<SourceValueFlowConfig>

--- a/java/ql/test/library-tests/frameworks/android/uri/test.expected
+++ b/java/ql/test/library-tests/frameworks/android/uri/test.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/frameworks/android/uri/test.ql
+++ b/java/ql/test/library-tests/frameworks/android/uri/test.ql
@@ -1,2 +1,3 @@
 import java
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest

--- a/java/ql/test/library-tests/frameworks/android/widget/test.expected
+++ b/java/ql/test/library-tests/frameworks/android/widget/test.expected
@@ -1,2 +1,3 @@
 failures
+testFailures
 valueOf

--- a/java/ql/test/library-tests/frameworks/android/widget/test.ql
+++ b/java/ql/test/library-tests/frameworks/android/widget/test.ql
@@ -1,6 +1,7 @@
 import java
 import semmle.code.java.dataflow.FlowSources
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest
 
 query predicate valueOf(MethodAccess ma) {
   ma.getMethod().hasQualifiedName("java.lang", "String", "valueOf")

--- a/java/ql/test/library-tests/frameworks/apache-ant/test.expected
+++ b/java/ql/test/library-tests/frameworks/apache-ant/test.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/frameworks/apache-ant/test.ql
+++ b/java/ql/test/library-tests/frameworks/apache-ant/test.ql
@@ -1,2 +1,3 @@
 import java
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest

--- a/java/ql/test/library-tests/frameworks/apache-collections/test.expected
+++ b/java/ql/test/library-tests/frameworks/apache-collections/test.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/frameworks/apache-collections/test.ql
+++ b/java/ql/test/library-tests/frameworks/apache-collections/test.ql
@@ -1,2 +1,3 @@
 import java
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest

--- a/java/ql/test/library-tests/frameworks/apache-commons-compress/test.expected
+++ b/java/ql/test/library-tests/frameworks/apache-commons-compress/test.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/frameworks/apache-commons-compress/test.ql
+++ b/java/ql/test/library-tests/frameworks/apache-commons-compress/test.ql
@@ -1,2 +1,3 @@
 import java
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest

--- a/java/ql/test/library-tests/frameworks/apache-commons-lang3/flow.expected
+++ b/java/ql/test/library-tests/frameworks/apache-commons-lang3/flow.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/frameworks/apache-commons-lang3/flow.ql
+++ b/java/ql/test/library-tests/frameworks/apache-commons-lang3/flow.ql
@@ -1,2 +1,3 @@
 import java
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest

--- a/java/ql/test/library-tests/frameworks/apache-http/flow.expected
+++ b/java/ql/test/library-tests/frameworks/apache-http/flow.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/frameworks/apache-http/flow.ql
+++ b/java/ql/test/library-tests/frameworks/apache-http/flow.ql
@@ -21,10 +21,4 @@ module Config implements DataFlow::ConfigSig {
   }
 }
 
-module Flow = TaintTracking::Global<Config>;
-
-class HasFlowTest extends InlineFlowTest {
-  override predicate hasValueFlow(DataFlow::Node src, DataFlow::Node sink) { none() }
-
-  override predicate hasTaintFlow(DataFlow::Node src, DataFlow::Node sink) { Flow::flow(src, sink) }
-}
+import TaintFlowTest<Config>

--- a/java/ql/test/library-tests/frameworks/gson/test.expected
+++ b/java/ql/test/library-tests/frameworks/gson/test.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/frameworks/gson/test.ql
+++ b/java/ql/test/library-tests/frameworks/gson/test.ql
@@ -1,2 +1,3 @@
 import java
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest

--- a/java/ql/test/library-tests/frameworks/guava/generated/cache/test.expected
+++ b/java/ql/test/library-tests/frameworks/guava/generated/cache/test.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/frameworks/guava/generated/cache/test.ql
+++ b/java/ql/test/library-tests/frameworks/guava/generated/cache/test.ql
@@ -1,2 +1,3 @@
 import java
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest

--- a/java/ql/test/library-tests/frameworks/guava/generated/collect/test.expected
+++ b/java/ql/test/library-tests/frameworks/guava/generated/collect/test.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/frameworks/guava/generated/collect/test.ql
+++ b/java/ql/test/library-tests/frameworks/guava/generated/collect/test.ql
@@ -1,2 +1,3 @@
 import java
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest

--- a/java/ql/test/library-tests/frameworks/hudson/test.expected
+++ b/java/ql/test/library-tests/frameworks/hudson/test.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/frameworks/hudson/test.ql
+++ b/java/ql/test/library-tests/frameworks/hudson/test.ql
@@ -1,2 +1,3 @@
 import java
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest

--- a/java/ql/test/library-tests/frameworks/jackson/test.expected
+++ b/java/ql/test/library-tests/frameworks/jackson/test.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/frameworks/jackson/test.ql
+++ b/java/ql/test/library-tests/frameworks/jackson/test.ql
@@ -1,2 +1,3 @@
 import java
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest

--- a/java/ql/test/library-tests/frameworks/javax-json/test.expected
+++ b/java/ql/test/library-tests/frameworks/javax-json/test.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/frameworks/javax-json/test.ql
+++ b/java/ql/test/library-tests/frameworks/javax-json/test.ql
@@ -1,2 +1,3 @@
 import java
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest

--- a/java/ql/test/library-tests/frameworks/jdk/java.io/test.expected
+++ b/java/ql/test/library-tests/frameworks/jdk/java.io/test.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/frameworks/jdk/java.io/test.ql
+++ b/java/ql/test/library-tests/frameworks/jdk/java.io/test.ql
@@ -1,2 +1,3 @@
 import java
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest

--- a/java/ql/test/library-tests/frameworks/jdk/java.net/test.expected
+++ b/java/ql/test/library-tests/frameworks/jdk/java.net/test.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/frameworks/jdk/java.net/test.ql
+++ b/java/ql/test/library-tests/frameworks/jdk/java.net/test.ql
@@ -1,2 +1,3 @@
 import java
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest

--- a/java/ql/test/library-tests/frameworks/jdk/java.nio.file/test.expected
+++ b/java/ql/test/library-tests/frameworks/jdk/java.nio.file/test.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/frameworks/jdk/java.nio.file/test.ql
+++ b/java/ql/test/library-tests/frameworks/jdk/java.nio.file/test.ql
@@ -1,2 +1,3 @@
 import java
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest

--- a/java/ql/test/library-tests/frameworks/json-java/test.expected
+++ b/java/ql/test/library-tests/frameworks/json-java/test.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/frameworks/json-java/test.ql
+++ b/java/ql/test/library-tests/frameworks/json-java/test.ql
@@ -1,2 +1,3 @@
 import java
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest

--- a/java/ql/test/library-tests/frameworks/netty/generated/test.expected
+++ b/java/ql/test/library-tests/frameworks/netty/generated/test.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/frameworks/netty/generated/test.ql
+++ b/java/ql/test/library-tests/frameworks/netty/generated/test.ql
@@ -1,2 +1,3 @@
 import java
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest

--- a/java/ql/test/library-tests/frameworks/netty/manual/test.expected
+++ b/java/ql/test/library-tests/frameworks/netty/manual/test.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/frameworks/netty/manual/test.ql
+++ b/java/ql/test/library-tests/frameworks/netty/manual/test.ql
@@ -13,10 +13,4 @@ module Config implements DataFlow::ConfigSig {
   predicate isSink = DefaultFlowConfig::isSink/1;
 }
 
-module Flow = TaintTracking::Global<Config>;
-
-class Test extends InlineFlowTest {
-  override predicate hasTaintFlow(DataFlow::Node source, DataFlow::Node sink) {
-    Flow::flow(source, sink)
-  }
-}
+import FlowTest<DefaultFlowConfig, Config>

--- a/java/ql/test/library-tests/frameworks/okhttp/test.expected
+++ b/java/ql/test/library-tests/frameworks/okhttp/test.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/frameworks/okhttp/test.ql
+++ b/java/ql/test/library-tests/frameworks/okhttp/test.ql
@@ -10,10 +10,4 @@ module OkHttpFlowConfig implements DataFlow::ConfigSig {
   }
 }
 
-module OkHttpFlow = DataFlow::Global<OkHttpFlowConfig>;
-
-class OkHttpTest extends InlineFlowTest {
-  override predicate hasValueFlow(DataFlow::Node src, DataFlow::Node sink) {
-    OkHttpFlow::flow(src, sink)
-  }
-}
+import FlowTest<OkHttpFlowConfig, DefaultFlowConfig>

--- a/java/ql/test/library-tests/frameworks/play/test.expected
+++ b/java/ql/test/library-tests/frameworks/play/test.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/frameworks/play/test.ql
+++ b/java/ql/test/library-tests/frameworks/play/test.ql
@@ -1,2 +1,3 @@
 import java
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest

--- a/java/ql/test/library-tests/frameworks/rabbitmq/FlowTest.expected
+++ b/java/ql/test/library-tests/frameworks/rabbitmq/FlowTest.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/frameworks/rabbitmq/FlowTest.ql
+++ b/java/ql/test/library-tests/frameworks/rabbitmq/FlowTest.ql
@@ -11,10 +11,4 @@ module Config implements DataFlow::ConfigSig {
   }
 }
 
-module Flow = TaintTracking::Global<Config>;
-
-class HasFlowTest extends InlineFlowTest {
-  override predicate hasValueFlow(DataFlow::Node src, DataFlow::Node sink) { none() }
-
-  override predicate hasTaintFlow(DataFlow::Node src, DataFlow::Node sink) { Flow::flow(src, sink) }
-}
+import TaintFlowTest<Config>

--- a/java/ql/test/library-tests/frameworks/ratpack/flow.expected
+++ b/java/ql/test/library-tests/frameworks/ratpack/flow.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/frameworks/ratpack/flow.ql
+++ b/java/ql/test/library-tests/frameworks/ratpack/flow.ql
@@ -15,12 +15,4 @@ module Config implements DataFlow::ConfigSig {
   }
 }
 
-module Flow = TaintTracking::Global<Config>;
-
-class HasFlowTest extends InlineFlowTest {
-  HasFlowTest() { this = "HasFlowTest" }
-
-  override predicate hasValueFlow(DataFlow::Node src, DataFlow::Node sink) { none() }
-
-  override predicate hasTaintFlow(DataFlow::Node src, DataFlow::Node sink) { Flow::flow(src, sink) }
-}
+import TaintFlowTest<Config>

--- a/java/ql/test/library-tests/frameworks/retrofit/test.expected
+++ b/java/ql/test/library-tests/frameworks/retrofit/test.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/frameworks/retrofit/test.ql
+++ b/java/ql/test/library-tests/frameworks/retrofit/test.ql
@@ -10,8 +10,4 @@ module FlowConfig implements DataFlow::ConfigSig {
   }
 }
 
-module Flow = DataFlow::Global<FlowConfig>;
-
-class RetrofitFlowTest extends InlineFlowTest {
-  override predicate hasValueFlow(DataFlow::Node src, DataFlow::Node sink) { Flow::flow(src, sink) }
-}
+import FlowTest<FlowConfig, DefaultFlowConfig>

--- a/java/ql/test/library-tests/frameworks/spring/beans/test.expected
+++ b/java/ql/test/library-tests/frameworks/spring/beans/test.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/frameworks/spring/beans/test.ql
+++ b/java/ql/test/library-tests/frameworks/spring/beans/test.ql
@@ -1,2 +1,3 @@
 import java
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest

--- a/java/ql/test/library-tests/frameworks/spring/cache/test.expected
+++ b/java/ql/test/library-tests/frameworks/spring/cache/test.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/frameworks/spring/cache/test.ql
+++ b/java/ql/test/library-tests/frameworks/spring/cache/test.ql
@@ -1,2 +1,3 @@
 import java
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest

--- a/java/ql/test/library-tests/frameworks/spring/context/flow.expected
+++ b/java/ql/test/library-tests/frameworks/spring/context/flow.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/frameworks/spring/context/flow.ql
+++ b/java/ql/test/library-tests/frameworks/spring/context/flow.ql
@@ -1,2 +1,3 @@
 import java
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest

--- a/java/ql/test/library-tests/frameworks/spring/controller/test.expected
+++ b/java/ql/test/library-tests/frameworks/spring/controller/test.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/frameworks/spring/controller/test.ql
+++ b/java/ql/test/library-tests/frameworks/spring/controller/test.ql
@@ -10,10 +10,4 @@ module ValueFlowConfig implements DataFlow::ConfigSig {
   }
 }
 
-module ValueFlow = DataFlow::Global<ValueFlowConfig>;
-
-class Test extends InlineFlowTest {
-  override predicate hasValueFlow(DataFlow::Node src, DataFlow::Node sink) {
-    ValueFlow::flow(src, sink)
-  }
-}
+import FlowTest<ValueFlowConfig, DefaultFlowConfig>

--- a/java/ql/test/library-tests/frameworks/spring/data/test.expected
+++ b/java/ql/test/library-tests/frameworks/spring/data/test.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/frameworks/spring/data/test.ql
+++ b/java/ql/test/library-tests/frameworks/spring/data/test.ql
@@ -1,2 +1,3 @@
 import java
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest

--- a/java/ql/test/library-tests/frameworks/spring/http/flow.expected
+++ b/java/ql/test/library-tests/frameworks/spring/http/flow.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/frameworks/spring/http/flow.ql
+++ b/java/ql/test/library-tests/frameworks/spring/http/flow.ql
@@ -1,2 +1,3 @@
 import java
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest

--- a/java/ql/test/library-tests/frameworks/spring/ui/test.expected
+++ b/java/ql/test/library-tests/frameworks/spring/ui/test.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/frameworks/spring/ui/test.ql
+++ b/java/ql/test/library-tests/frameworks/spring/ui/test.ql
@@ -1,2 +1,3 @@
 import java
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest

--- a/java/ql/test/library-tests/frameworks/spring/util/test.expected
+++ b/java/ql/test/library-tests/frameworks/spring/util/test.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/frameworks/spring/util/test.ql
+++ b/java/ql/test/library-tests/frameworks/spring/util/test.ql
@@ -1,2 +1,3 @@
 import java
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest

--- a/java/ql/test/library-tests/frameworks/spring/validation/test.expected
+++ b/java/ql/test/library-tests/frameworks/spring/validation/test.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/frameworks/spring/validation/test.ql
+++ b/java/ql/test/library-tests/frameworks/spring/validation/test.ql
@@ -1,2 +1,3 @@
 import java
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest

--- a/java/ql/test/library-tests/frameworks/spring/webmultipart/test.expected
+++ b/java/ql/test/library-tests/frameworks/spring/webmultipart/test.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/frameworks/spring/webmultipart/test.ql
+++ b/java/ql/test/library-tests/frameworks/spring/webmultipart/test.ql
@@ -1,2 +1,3 @@
 import java
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest

--- a/java/ql/test/library-tests/frameworks/spring/webutil/test.expected
+++ b/java/ql/test/library-tests/frameworks/spring/webutil/test.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/frameworks/spring/webutil/test.ql
+++ b/java/ql/test/library-tests/frameworks/spring/webutil/test.ql
@@ -1,2 +1,3 @@
 import java
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest

--- a/java/ql/test/library-tests/frameworks/stapler/test.expected
+++ b/java/ql/test/library-tests/frameworks/stapler/test.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/frameworks/stapler/test.ql
+++ b/java/ql/test/library-tests/frameworks/stapler/test.ql
@@ -1,2 +1,3 @@
 import java
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest

--- a/java/ql/test/library-tests/frameworks/stream/test.expected
+++ b/java/ql/test/library-tests/frameworks/stream/test.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/frameworks/stream/test.ql
+++ b/java/ql/test/library-tests/frameworks/stream/test.ql
@@ -1,2 +1,3 @@
 import java
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest

--- a/java/ql/test/library-tests/frameworks/thymeleaf/test.expected
+++ b/java/ql/test/library-tests/frameworks/thymeleaf/test.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/frameworks/thymeleaf/test.ql
+++ b/java/ql/test/library-tests/frameworks/thymeleaf/test.ql
@@ -1,2 +1,3 @@
 import java
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest

--- a/java/ql/test/library-tests/logging/test.expected
+++ b/java/ql/test/library-tests/logging/test.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/logging/test.ql
+++ b/java/ql/test/library-tests/logging/test.ql
@@ -1,2 +1,3 @@
 import java
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest

--- a/java/ql/test/library-tests/optional/test.expected
+++ b/java/ql/test/library-tests/optional/test.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/optional/test.ql
+++ b/java/ql/test/library-tests/optional/test.ql
@@ -1,2 +1,3 @@
 import java
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest

--- a/java/ql/test/library-tests/paths/test.expected
+++ b/java/ql/test/library-tests/paths/test.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/paths/test.ql
+++ b/java/ql/test/library-tests/paths/test.ql
@@ -1,2 +1,3 @@
 import java
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest

--- a/java/ql/test/library-tests/pathsanitizer/test.expected
+++ b/java/ql/test/library-tests/pathsanitizer/test.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/pathsanitizer/test.ql
+++ b/java/ql/test/library-tests/pathsanitizer/test.ql
@@ -10,12 +10,4 @@ module PathSanitizerConfig implements DataFlow::ConfigSig {
   predicate isBarrier(DataFlow::Node sanitizer) { sanitizer instanceof PathInjectionSanitizer }
 }
 
-module PathSanitizerFlow = TaintTracking::Global<PathSanitizerConfig>;
-
-class Test extends InlineFlowTest {
-  override predicate hasValueFlow(DataFlow::Node src, DataFlow::Node sink) { none() }
-
-  override predicate hasTaintFlow(DataFlow::Node src, DataFlow::Node sink) {
-    PathSanitizerFlow::flow(src, sink)
-  }
-}
+import TaintFlowTest<PathSanitizerConfig>

--- a/java/ql/test/library-tests/regex/test.expected
+++ b/java/ql/test/library-tests/regex/test.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/regex/test.ql
+++ b/java/ql/test/library-tests/regex/test.ql
@@ -1,2 +1,3 @@
 import java
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest

--- a/java/ql/test/library-tests/scanner/test.expected
+++ b/java/ql/test/library-tests/scanner/test.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/library-tests/scanner/test.ql
+++ b/java/ql/test/library-tests/scanner/test.ql
@@ -1,2 +1,3 @@
 import java
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest

--- a/java/ql/test/query-tests/security/CWE-117/LogInjectionTest.expected
+++ b/java/ql/test/query-tests/security/CWE-117/LogInjectionTest.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/query-tests/security/CWE-117/LogInjectionTest.ql
+++ b/java/ql/test/query-tests/security/CWE-117/LogInjectionTest.ql
@@ -8,10 +8,4 @@ private class TestSource extends RemoteFlowSource {
   override string getSourceType() { result = "test source" }
 }
 
-private class LogInjectionTest extends InlineFlowTest {
-  override predicate hasValueFlow(DataFlow::Node src, DataFlow::Node sink) { none() }
-
-  override predicate hasTaintFlow(DataFlow::Node src, DataFlow::Node sink) {
-    LogInjectionFlow::flow(src, sink)
-  }
-}
+import TaintFlowTest<LogInjectionConfig>

--- a/java/ql/test/query-tests/security/CWE-266/IntentUriPermissionManipulationTest.expected
+++ b/java/ql/test/query-tests/security/CWE-266/IntentUriPermissionManipulationTest.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/query-tests/security/CWE-266/IntentUriPermissionManipulationTest.ql
+++ b/java/ql/test/query-tests/security/CWE-266/IntentUriPermissionManipulationTest.ql
@@ -1,11 +1,4 @@
 import java
 import TestUtilities.InlineFlowTest
 import semmle.code.java.security.IntentUriPermissionManipulationQuery
-
-class IntentUriPermissionManipulationTest extends InlineFlowTest {
-  override predicate hasValueFlow(DataFlow::Node src, DataFlow::Node sink) { none() }
-
-  override predicate hasTaintFlow(DataFlow::Node src, DataFlow::Node sink) {
-    IntentUriPermissionManipulationFlow::flow(src, sink)
-  }
-}
+import TaintFlowTest<IntentUriPermissionManipulationConfig>

--- a/java/ql/test/query-tests/security/CWE-441/UnsafeContentUriResolutionTest.expected
+++ b/java/ql/test/query-tests/security/CWE-441/UnsafeContentUriResolutionTest.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/query-tests/security/CWE-441/UnsafeContentUriResolutionTest.ql
+++ b/java/ql/test/query-tests/security/CWE-441/UnsafeContentUriResolutionTest.ql
@@ -1,11 +1,4 @@
 import java
 import TestUtilities.InlineFlowTest
 import semmle.code.java.security.UnsafeContentUriResolutionQuery
-
-class Test extends InlineFlowTest {
-  override predicate hasValueFlow(DataFlow::Node src, DataFlow::Node sink) { none() }
-
-  override predicate hasTaintFlow(DataFlow::Node src, DataFlow::Node sink) {
-    UnsafeContentResolutionFlow::flow(src, sink)
-  }
-}
+import TaintFlowTest<UnsafeContentResolutionConfig>

--- a/java/ql/test/query-tests/security/CWE-470/FragmentInjectionTest.expected
+++ b/java/ql/test/query-tests/security/CWE-470/FragmentInjectionTest.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/query-tests/security/CWE-470/FragmentInjectionTest.ql
+++ b/java/ql/test/query-tests/security/CWE-470/FragmentInjectionTest.ql
@@ -1,11 +1,4 @@
 import java
 import semmle.code.java.security.FragmentInjectionQuery
 import TestUtilities.InlineFlowTest
-
-class Test extends InlineFlowTest {
-  override predicate hasValueFlow(DataFlow::Node src, DataFlow::Node sink) { none() }
-
-  override predicate hasTaintFlow(DataFlow::Node src, DataFlow::Node sink) {
-    FragmentInjectionTaintFlow::flow(src, sink)
-  }
-}
+import TaintFlowTest<FragmentInjectionTaintConfig>

--- a/java/ql/test/query-tests/security/CWE-489/webview-debugging/WebviewDebuggingEnabled.expected
+++ b/java/ql/test/query-tests/security/CWE-489/webview-debugging/WebviewDebuggingEnabled.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/query-tests/security/CWE-489/webview-debugging/WebviewDebuggingEnabled.ql
+++ b/java/ql/test/query-tests/security/CWE-489/webview-debugging/WebviewDebuggingEnabled.ql
@@ -1,11 +1,4 @@
 import java
 import TestUtilities.InlineFlowTest
 import semmle.code.java.security.WebviewDebuggingEnabledQuery
-
-class HasFlowTest extends InlineFlowTest {
-  override predicate hasTaintFlow(DataFlow::Node src, DataFlow::Node sink) { none() }
-
-  override predicate hasValueFlow(DataFlow::Node src, DataFlow::Node sink) {
-    WebviewDebugEnabledFlow::flow(src, sink)
-  }
-}
+import ValueFlowTest<WebviewDebugEnabledConfig>

--- a/java/ql/test/query-tests/security/CWE-532/SensitiveLogInfo.expected
+++ b/java/ql/test/query-tests/security/CWE-532/SensitiveLogInfo.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/query-tests/security/CWE-532/SensitiveLogInfo.ql
+++ b/java/ql/test/query-tests/security/CWE-532/SensitiveLogInfo.ql
@@ -1,11 +1,4 @@
 import java
 import TestUtilities.InlineFlowTest
 import semmle.code.java.security.SensitiveLoggingQuery
-
-class HasFlowTest extends InlineFlowTest {
-  override predicate hasTaintFlow(DataFlow::Node src, DataFlow::Node sink) {
-    SensitiveLoggerFlow::flow(src, sink)
-  }
-
-  override predicate hasValueFlow(DataFlow::Node src, DataFlow::Node sink) { none() }
-}
+import TaintFlowTest<SensitiveLoggerConfig>

--- a/java/ql/test/query-tests/security/CWE-611/XXE.expected
+++ b/java/ql/test/query-tests/security/CWE-611/XXE.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/query-tests/security/CWE-611/XXE.ql
+++ b/java/ql/test/query-tests/security/CWE-611/XXE.ql
@@ -1,11 +1,4 @@
 import java
 import TestUtilities.InlineFlowTest
 import semmle.code.java.security.XxeRemoteQuery
-
-class HasFlowTest extends InlineFlowTest {
-  override predicate hasTaintFlow(DataFlow::Node src, DataFlow::Node sink) {
-    XxeFlow::flow(src, sink)
-  }
-
-  override predicate hasValueFlow(DataFlow::Node src, DataFlow::Node sink) { none() }
-}
+import TaintFlowTest<XxeConfig>

--- a/java/ql/test/query-tests/security/CWE-780/RsaWithoutOaepTest.expected
+++ b/java/ql/test/query-tests/security/CWE-780/RsaWithoutOaepTest.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/query-tests/security/CWE-780/RsaWithoutOaepTest.ql
+++ b/java/ql/test/query-tests/security/CWE-780/RsaWithoutOaepTest.ql
@@ -2,11 +2,4 @@ import java
 import TestUtilities.InlineExpectationsTest
 import TestUtilities.InlineFlowTest
 import semmle.code.java.security.RsaWithoutOaepQuery
-
-class HasFlowTest extends InlineFlowTest {
-  override predicate hasValueFlow(DataFlow::Node src, DataFlow::Node sink) { none() }
-
-  override predicate hasTaintFlow(DataFlow::Node src, DataFlow::Node sink) {
-    RsaWithoutOaepFlow::flow(src, sink)
-  }
-}
+import TaintFlowTest<RsaWithoutOaepConfig>

--- a/java/ql/test/query-tests/security/CWE-927/SensitiveCommunication.expected
+++ b/java/ql/test/query-tests/security/CWE-927/SensitiveCommunication.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/java/ql/test/query-tests/security/CWE-927/SensitiveCommunication.ql
+++ b/java/ql/test/query-tests/security/CWE-927/SensitiveCommunication.ql
@@ -2,11 +2,4 @@ import java
 import semmle.code.java.security.AndroidSensitiveCommunicationQuery
 import TestUtilities.InlineExpectationsTest
 import TestUtilities.InlineFlowTest
-
-class HasFlowTest extends InlineFlowTest {
-  override predicate hasValueFlow(DataFlow::Node src, DataFlow::Node sink) { none() }
-
-  override predicate hasTaintFlow(DataFlow::Node src, DataFlow::Node sink) {
-    SensitiveCommunicationFlow::flow(src, sink)
-  }
-}
+import TaintFlowTest<SensitiveCommunicationConfig>

--- a/ruby/ql/lib/change-notes/2023-06-14-insecure-download-config.md
+++ b/ruby/ql/lib/change-notes/2023-06-14-insecure-download-config.md
@@ -1,0 +1,4 @@
+---
+category: deprecated
+---
+* The `Configuration` taint flow configuration class from `codeql.ruby.security.InsecureDownloadQuery` has been deprecated. Use the `Flow` module instead.

--- a/ruby/ql/lib/codeql/ruby/security/InsecureDownloadQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/InsecureDownloadQuery.qll
@@ -13,7 +13,7 @@ import InsecureDownloadCustomizations::InsecureDownload
 /**
  * A taint tracking configuration for download of sensitive file through insecure connection.
  */
-class Configuration extends DataFlow::Configuration {
+deprecated class Configuration extends DataFlow::Configuration {
   Configuration() { this = "InsecureDownload" }
 
   override predicate isSource(DataFlow::Node source, DataFlow::FlowState label) {
@@ -29,3 +29,30 @@ class Configuration extends DataFlow::Configuration {
     node instanceof Sanitizer
   }
 }
+
+/**
+ * A taint tracking configuration for download of sensitive file through insecure connection.
+ */
+module Config implements DataFlow::StateConfigSig {
+  class FlowState = string;
+
+  predicate isSource(DataFlow::Node source, DataFlow::FlowState label) {
+    source.(Source).getALabel() = label
+  }
+
+  predicate isSink(DataFlow::Node sink, DataFlow::FlowState label) {
+    sink.(Sink).getALabel() = label
+  }
+
+  predicate isBarrier(DataFlow::Node node) { node instanceof Sanitizer }
+
+  predicate isBarrier(DataFlow::Node node, FlowState state) { none() }
+
+  predicate isAdditionalFlowStep(
+    DataFlow::Node node1, FlowState state1, DataFlow::Node node2, FlowState state2
+  ) {
+    none()
+  }
+}
+
+module Flow = DataFlow::GlobalWithState<Config>;

--- a/ruby/ql/src/queries/security/cwe-829/InsecureDownload.ql
+++ b/ruby/ql/src/queries/security/cwe-829/InsecureDownload.ql
@@ -14,9 +14,9 @@
 import codeql.ruby.AST
 import codeql.ruby.DataFlow
 import codeql.ruby.security.InsecureDownloadQuery
-import DataFlow::PathGraph
+import Flow::PathGraph
 
-from Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink
-where cfg.hasFlowPath(source, sink)
+from Flow::PathNode source, Flow::PathNode sink
+where Flow::flowPath(source, sink)
 select sink.getNode(), source, sink, "$@ of sensitive file from $@.",
   sink.getNode().(Sink).getDownloadCall(), "Download", source.getNode(), "HTTP source"

--- a/ruby/ql/test/TestUtilities/InlineFlowTest.qll
+++ b/ruby/ql/test/TestUtilities/InlineFlowTest.qll
@@ -4,10 +4,11 @@
  * Example for a test.ql:
  * ```ql
  * import TestUtilities.InlineFlowTest
+ * import DefaultFlowTest
  * import PathGraph
  *
- * from DataFlow::PathNode source, DataFlow::PathNode sink, DefaultValueFlowConf conf
- * where conf.hasFlowPath(source, sink)
+ * from ValueFlow::PathNode source, ValueFlow::PathNode sink
+ * where ValueFlow::flowPath(source, sink)
  * select sink, source, sink, "$@", source, source.toString()
  * ```
  *
@@ -20,14 +21,10 @@
  * sink(t); // $ hasTaintFlow=2
  * ```
  *
- * If you're not interested in a specific flow type, you can disable either value or taint flow expectations as follows:
- * ```ql
- * class HasFlowTest extends InlineFlowTest {
- *   override DataFlow::Configuration getTaintFlowConfig() { none() }
- *
- *   override DataFlow::Configuration getValueFlowConfig() { none() }
- * }
- * ```
+ * If you are only interested in value flow, then instead of importing `DefaultFlowTest`, you can import
+ * `ValueFlowTest<DefaultFlowConfig>`. Similarly, if you are only interested in taint flow, then instead of
+ * importing `DefaultFlowTest`, you can import `TaintFlowTest<DefaultFlowConfig>`. In both cases
+ * `DefaultFlowConfig` can be replaced by another implementation of `DataFlow::ConfigSig`.
  *
  * If you need more fine-grained tuning, consider implementing a test using `InlineExpectationsTest`.
  */
@@ -38,72 +35,62 @@ import codeql.ruby.TaintTracking
 import TestUtilities.InlineExpectationsTest
 import TestUtilities.InlineFlowTestUtil
 
-class DefaultValueFlowConf extends DataFlow::Configuration {
-  DefaultValueFlowConf() { this = "qltest:defaultValueFlowConf" }
+module DefaultFlowConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { defaultSource(source) }
 
-  override predicate isSource(DataFlow::Node n) { defaultSource(n) }
+  predicate isSink(DataFlow::Node sink) { defaultSink(sink) }
 
-  override predicate isSink(DataFlow::Node n) { defaultSink(n) }
-
-  override int fieldFlowBranchLimit() { result = 1000 }
+  int fieldFlowBranchLimit() { result = 1000 }
 }
 
-class DefaultTaintFlowConf extends TaintTracking::Configuration {
-  DefaultTaintFlowConf() { this = "qltest:defaultTaintFlowConf" }
+private module NoFlowConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { none() }
 
-  override predicate isSource(DataFlow::Node n) { defaultSource(n) }
-
-  override predicate isSink(DataFlow::Node n) { defaultSink(n) }
-
-  override int fieldFlowBranchLimit() { result = 1000 }
+  predicate isSink(DataFlow::Node sink) { none() }
 }
 
-class InlineFlowTest extends InlineExpectationsTest {
-  InlineFlowTest() { this = "HasFlowTest" }
+module FlowTest<DataFlow::ConfigSig ValueFlowConfig, DataFlow::ConfigSig TaintFlowConfig> {
+  module ValueFlow = DataFlow::Global<ValueFlowConfig>;
 
-  override string getARelevantTag() { result = ["hasValueFlow", "hasTaintFlow"] }
+  module TaintFlow = TaintTracking::Global<TaintFlowConfig>;
 
-  override predicate hasActualResult(Location location, string element, string tag, string value) {
-    tag = "hasValueFlow" and
-    exists(DataFlow::Node src, DataFlow::Node sink | this.getValueFlowConfig().hasFlow(src, sink) |
-      sink.getLocation() = location and
-      element = sink.toString() and
-      if exists(getSourceArgString(src)) then value = getSourceArgString(src) else value = ""
-    )
-    or
-    tag = "hasTaintFlow" and
-    exists(DataFlow::Node src, DataFlow::Node sink |
-      this.getTaintFlowConfig().hasFlow(src, sink) and
-      not this.getValueFlowConfig().hasFlow(src, sink)
-    |
-      sink.getLocation() = location and
-      element = sink.toString() and
-      if exists(getSourceArgString(src)) then value = getSourceArgString(src) else value = ""
-    )
-  }
+  private module InlineTest implements TestSig {
+    string getARelevantTag() { result = ["hasValueFlow", "hasTaintFlow"] }
 
-  DataFlow::Configuration getValueFlowConfig() { result = any(DefaultValueFlowConf config) }
-
-  DataFlow::Configuration getTaintFlowConfig() { result = any(DefaultTaintFlowConf config) }
-}
-
-module PathGraph {
-  private import DataFlow::PathGraph as PG
-
-  private class PathNode extends DataFlow::PathNode {
-    PathNode() {
-      this.getConfiguration() =
-        [any(InlineFlowTest t).getValueFlowConfig(), any(InlineFlowTest t).getTaintFlowConfig()]
+    predicate hasActualResult(Location location, string element, string tag, string value) {
+      tag = "hasValueFlow" and
+      exists(DataFlow::Node src, DataFlow::Node sink | ValueFlow::flow(src, sink) |
+        sink.getLocation() = location and
+        element = sink.toString() and
+        if exists(getSourceArgString(src)) then value = getSourceArgString(src) else value = ""
+      )
+      or
+      tag = "hasTaintFlow" and
+      exists(DataFlow::Node src, DataFlow::Node sink |
+        TaintFlow::flow(src, sink) and not ValueFlow::flow(src, sink)
+      |
+        sink.getLocation() = location and
+        element = sink.toString() and
+        if exists(getSourceArgString(src)) then value = getSourceArgString(src) else value = ""
+      )
     }
   }
 
-  /** Holds if `(a,b)` is an edge in the graph of data flow path explanations. */
-  query predicate edges(PathNode a, PathNode b) { PG::edges(a, b) }
+  import MakeTest<InlineTest>
+  import DataFlow::MergePathGraph<ValueFlow::PathNode, TaintFlow::PathNode, ValueFlow::PathGraph, TaintFlow::PathGraph>
 
-  /** Holds if `n` is a node in the graph of data flow path explanations. */
-  query predicate nodes(PathNode n, string key, string val) { PG::nodes(n, key, val) }
-
-  query predicate subpaths(PathNode arg, PathNode par, PathNode ret, PathNode out) {
-    PG::subpaths(arg, par, ret, out)
+  predicate flowPath(PathNode source, PathNode sink) {
+    ValueFlow::flowPath(source.asPathNode1(), sink.asPathNode1()) or
+    TaintFlow::flowPath(source.asPathNode2(), sink.asPathNode2())
   }
+}
+
+module DefaultFlowTest = FlowTest<DefaultFlowConfig, DefaultFlowConfig>;
+
+module ValueFlowTest<DataFlow::ConfigSig ValueFlowConfig> {
+  import FlowTest<ValueFlowConfig, NoFlowConfig>
+}
+
+module TaintFlowTest<DataFlow::ConfigSig TaintFlowConfig> {
+  import FlowTest<NoFlowConfig, TaintFlowConfig>
 }

--- a/ruby/ql/test/TestUtilities/InlineFlowTest.qll
+++ b/ruby/ql/test/TestUtilities/InlineFlowTest.qll
@@ -7,8 +7,8 @@
  * import DefaultFlowTest
  * import PathGraph
  *
- * from ValueFlow::PathNode source, ValueFlow::PathNode sink
- * where ValueFlow::flowPath(source, sink)
+ * from PathNode source, PathNode sink
+ * where flowPath(source, sink)
  * select sink, source, sink, "$@", source, source.toString()
  * ```
  *

--- a/ruby/ql/test/library-tests/dataflow/array-flow/array-flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/array-flow/array-flow.expected
@@ -1,4 +1,5 @@
 failures
+testFailures
 edges
 | array_flow.rb:2:5:2:5 | a [element 0] | array_flow.rb:3:10:3:10 | a [element 0] |
 | array_flow.rb:2:5:2:5 | a [element 0] | array_flow.rb:3:10:3:10 | a [element 0] |

--- a/ruby/ql/test/library-tests/dataflow/array-flow/array-flow.ql
+++ b/ruby/ql/test/library-tests/dataflow/array-flow/array-flow.ql
@@ -4,8 +4,9 @@
 
 import codeql.ruby.AST
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest
 import PathGraph
 
-from DataFlow::PathNode source, DataFlow::PathNode sink, DefaultValueFlowConf conf
-where conf.hasFlowPath(source, sink)
+from ValueFlow::PathNode source, ValueFlow::PathNode sink
+where ValueFlow::flowPath(source, sink)
 select sink, source, sink, "$@", source, source.toString()

--- a/ruby/ql/test/library-tests/dataflow/call-sensitivity/call-sensitivity.expected
+++ b/ruby/ql/test/library-tests/dataflow/call-sensitivity/call-sensitivity.expected
@@ -1,4 +1,5 @@
 failures
+testFailures
 edges
 | call_sensitivity.rb:9:7:9:13 | call to taint | call_sensitivity.rb:9:6:9:14 | ( ... ) |
 | call_sensitivity.rb:9:7:9:13 | call to taint | call_sensitivity.rb:9:6:9:14 | ( ... ) |

--- a/ruby/ql/test/library-tests/dataflow/call-sensitivity/call-sensitivity.ql
+++ b/ruby/ql/test/library-tests/dataflow/call-sensitivity/call-sensitivity.ql
@@ -5,13 +5,14 @@
 import codeql.ruby.AST
 import codeql.ruby.DataFlow
 import TestUtilities.InlineFlowTest
-import DataFlow::PathGraph
+import DefaultFlowTest
+import PathGraph
 import codeql.ruby.dataflow.internal.DataFlowDispatch as DataFlowDispatch
 
 query predicate mayBenefitFromCallContext = DataFlowDispatch::mayBenefitFromCallContext/2;
 
 query predicate viableImplInCallContext = DataFlowDispatch::viableImplInCallContext/2;
 
-from DataFlow::PathNode source, DataFlow::PathNode sink, DefaultTaintFlowConf conf
-where conf.hasFlowPath(source, sink)
+from TaintFlow::PathNode source, TaintFlow::PathNode sink
+where TaintFlow::flowPath(source, sink)
 select sink, source, sink, "$@", source, source.toString()

--- a/ruby/ql/test/library-tests/dataflow/flow-summaries/semantics.expected
+++ b/ruby/ql/test/library-tests/dataflow/flow-summaries/semantics.expected
@@ -1,4 +1,5 @@
 failures
+testFailures
 edges
 | semantics.rb:2:5:2:5 | a | semantics.rb:3:9:3:9 | a |
 | semantics.rb:2:5:2:5 | a | semantics.rb:3:9:3:9 | a |

--- a/ruby/ql/test/library-tests/dataflow/flow-summaries/semantics.ql
+++ b/ruby/ql/test/library-tests/dataflow/flow-summaries/semantics.ql
@@ -5,6 +5,7 @@
 
 import codeql.ruby.AST
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest
 import PathGraph
 private import codeql.ruby.dataflow.FlowSummary
 

--- a/ruby/ql/test/library-tests/dataflow/global/Flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/global/Flow.expected
@@ -1,4 +1,5 @@
 failures
+testFailures
 edges
 | captured_variables.rb:1:24:1:24 | x | captured_variables.rb:2:20:2:20 | x |
 | captured_variables.rb:1:24:1:24 | x | captured_variables.rb:2:20:2:20 | x |

--- a/ruby/ql/test/library-tests/dataflow/global/Flow.ql
+++ b/ruby/ql/test/library-tests/dataflow/global/Flow.ql
@@ -5,8 +5,9 @@
 import codeql.ruby.AST
 import codeql.ruby.DataFlow
 private import TestUtilities.InlineFlowTest
-import DataFlow::PathGraph
+import DefaultFlowTest
+import PathGraph
 
-from DataFlow::PathNode source, DataFlow::PathNode sink, DefaultTaintFlowConf conf
-where conf.hasFlowPath(source, sink)
+from TaintFlow::PathNode source, TaintFlow::PathNode sink
+where TaintFlow::flowPath(source, sink)
 select sink, source, sink, "$@", source, source.toString()

--- a/ruby/ql/test/library-tests/dataflow/hash-flow/hash-flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/hash-flow/hash-flow.expected
@@ -1,4 +1,5 @@
 failures
+testFailures
 edges
 | hash_flow.rb:10:5:10:8 | hash [element 0] | hash_flow.rb:30:10:30:13 | hash [element 0] |
 | hash_flow.rb:10:5:10:8 | hash [element :a] | hash_flow.rb:22:10:22:13 | hash [element :a] |

--- a/ruby/ql/test/library-tests/dataflow/hash-flow/hash-flow.ql
+++ b/ruby/ql/test/library-tests/dataflow/hash-flow/hash-flow.ql
@@ -4,12 +4,9 @@
 
 import codeql.ruby.AST
 import TestUtilities.InlineFlowTest
+import ValueFlowTest<DefaultFlowConfig>
 import PathGraph
 
-class HasFlowTest extends InlineFlowTest {
-  override DataFlow::Configuration getTaintFlowConfig() { none() }
-}
-
-from DataFlow::PathNode source, DataFlow::PathNode sink, DefaultValueFlowConf conf
-where conf.hasFlowPath(source, sink)
+from ValueFlow::PathNode source, ValueFlow::PathNode sink
+where ValueFlow::flowPath(source, sink)
 select sink, source, sink, "$@", source, source.toString()

--- a/ruby/ql/test/library-tests/dataflow/local/InlineFlowTest.expected
+++ b/ruby/ql/test/library-tests/dataflow/local/InlineFlowTest.expected
@@ -1,4 +1,5 @@
 failures
+testFailures
 edges
 | local_dataflow.rb:78:3:78:3 | z | local_dataflow.rb:89:8:89:8 | z |
 | local_dataflow.rb:78:12:78:20 | call to source | local_dataflow.rb:79:13:79:13 | b |

--- a/ruby/ql/test/library-tests/dataflow/local/InlineFlowTest.ql
+++ b/ruby/ql/test/library-tests/dataflow/local/InlineFlowTest.ql
@@ -4,8 +4,9 @@
 
 import codeql.ruby.AST
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest
 import PathGraph
 
-from DataFlow::PathNode source, DataFlow::PathNode sink, DefaultTaintFlowConf conf
-where conf.hasFlowPath(source, sink)
+from TaintFlow::PathNode source, TaintFlow::PathNode sink
+where TaintFlow::flowPath(source, sink)
 select sink, source, sink, "$@", source, source.toString()

--- a/ruby/ql/test/library-tests/dataflow/params/params-flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/params/params-flow.expected
@@ -1,4 +1,5 @@
 failures
+testFailures
 edges
 | params_flow.rb:9:16:9:17 | p1 | params_flow.rb:10:10:10:11 | p1 |
 | params_flow.rb:9:20:9:21 | p2 | params_flow.rb:11:10:11:11 | p2 |

--- a/ruby/ql/test/library-tests/dataflow/params/params-flow.ql
+++ b/ruby/ql/test/library-tests/dataflow/params/params-flow.ql
@@ -4,12 +4,9 @@
 
 import codeql.ruby.AST
 import TestUtilities.InlineFlowTest
+import ValueFlowTest<DefaultFlowConfig>
 import PathGraph
 
-class HasFlowTest extends InlineFlowTest {
-  override DataFlow::Configuration getTaintFlowConfig() { none() }
-}
-
-from DataFlow::PathNode source, DataFlow::PathNode sink, DefaultValueFlowConf conf
-where conf.hasFlowPath(source, sink)
+from ValueFlow::PathNode source, ValueFlow::PathNode sink
+where ValueFlow::flowPath(source, sink)
 select sink, source, sink, "$@", source, source.toString()

--- a/ruby/ql/test/library-tests/dataflow/pathname-flow/pathame-flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/pathname-flow/pathame-flow.expected
@@ -1,4 +1,5 @@
 failures
+testFailures
 edges
 | pathname_flow.rb:4:5:4:6 | pn | pathname_flow.rb:5:10:5:11 | pn |
 | pathname_flow.rb:4:10:4:33 | call to new | pathname_flow.rb:4:5:4:6 | pn |

--- a/ruby/ql/test/library-tests/dataflow/pathname-flow/pathame-flow.ql
+++ b/ruby/ql/test/library-tests/dataflow/pathname-flow/pathame-flow.ql
@@ -4,8 +4,9 @@
 
 import codeql.ruby.AST
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest
 import PathGraph
 
-from DataFlow::PathNode source, DataFlow::PathNode sink, DefaultValueFlowConf conf
-where conf.hasFlowPath(source, sink)
+from ValueFlow::PathNode source, ValueFlow::PathNode sink
+where ValueFlow::flowPath(source, sink)
 select sink, source, sink, "$@", source, source.toString()

--- a/ruby/ql/test/library-tests/dataflow/ssa-flow/ssa-flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/ssa-flow/ssa-flow.expected
@@ -1,4 +1,5 @@
 failures
+testFailures
 edges
 | ssa_flow.rb:12:9:12:9 | [post] a [element 0] | ssa_flow.rb:16:10:16:10 | a [element 0] |
 | ssa_flow.rb:12:9:12:9 | [post] a [element 0] | ssa_flow.rb:16:10:16:10 | a [element 0] |

--- a/ruby/ql/test/library-tests/dataflow/ssa-flow/ssa-flow.ql
+++ b/ruby/ql/test/library-tests/dataflow/ssa-flow/ssa-flow.ql
@@ -4,8 +4,9 @@
 
 import codeql.ruby.AST
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest
 import PathGraph
 
-from DataFlow::PathNode source, DataFlow::PathNode sink, DefaultValueFlowConf conf
-where conf.hasFlowPath(source, sink)
+from ValueFlow::PathNode source, ValueFlow::PathNode sink
+where ValueFlow::flowPath(source, sink)
 select sink, source, sink, "$@", source, source.toString()

--- a/ruby/ql/test/library-tests/dataflow/string-flow/string-flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/string-flow/string-flow.expected
@@ -1,4 +1,5 @@
 failures
+testFailures
 | string_flow.rb:85:10:85:10 | a | Unexpected result: hasValueFlow=a |
 | string_flow.rb:227:10:227:10 | a | Unexpected result: hasValueFlow=a |
 edges

--- a/ruby/ql/test/library-tests/dataflow/string-flow/string-flow.ql
+++ b/ruby/ql/test/library-tests/dataflow/string-flow/string-flow.ql
@@ -4,8 +4,9 @@
 
 import codeql.ruby.AST
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest
 import PathGraph
 
-from DataFlow::PathNode source, DataFlow::PathNode sink, DefaultValueFlowConf conf
-where conf.hasFlowPath(source, sink)
+from ValueFlow::PathNode source, ValueFlow::PathNode sink
+where ValueFlow::flowPath(source, sink)
 select sink, source, sink, "$@", source, source.toString()

--- a/ruby/ql/test/library-tests/dataflow/summaries/Summaries.expected
+++ b/ruby/ql/test/library-tests/dataflow/summaries/Summaries.expected
@@ -1,4 +1,5 @@
 failures
+testFailures
 edges
 | summaries.rb:1:1:1:7 | tainted | summaries.rb:2:6:2:12 | tainted |
 | summaries.rb:1:1:1:7 | tainted | summaries.rb:2:6:2:12 | tainted |

--- a/ruby/ql/test/library-tests/dataflow/summaries/Summaries.ql
+++ b/ruby/ql/test/library-tests/dataflow/summaries/Summaries.ql
@@ -10,7 +10,7 @@ import codeql.ruby.dataflow.internal.FlowSummaryImpl
 import codeql.ruby.dataflow.internal.AccessPathSyntax
 import codeql.ruby.frameworks.data.ModelsAsData
 import TestUtilities.InlineFlowTest
-import DataFlow::PathGraph
+import PathGraph
 
 query predicate invalidSpecComponent(SummarizedCallable sc, string s, string c) {
   (sc.propagatesFlowExt(s, _, _) or sc.propagatesFlowExt(_, s, _)) and
@@ -149,22 +149,18 @@ private class SinkFromModel extends ModelInput::SinkModelCsv {
   }
 }
 
-class CustomValueSink extends DefaultValueFlowConf {
-  override predicate isSink(DataFlow::Node sink) {
-    super.isSink(sink)
+module CustomConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { DefaultFlowConfig::isSource(source) }
+
+  predicate isSink(DataFlow::Node sink) {
+    DefaultFlowConfig::isSink(sink)
     or
     sink = ModelOutput::getASinkNode("test-sink").asSink()
   }
 }
 
-class CustomTaintSink extends DefaultTaintFlowConf {
-  override predicate isSink(DataFlow::Node sink) {
-    super.isSink(sink)
-    or
-    sink = ModelOutput::getASinkNode("test-sink").asSink()
-  }
-}
+import FlowTest<CustomConfig, CustomConfig>
 
-from DataFlow::PathNode source, DataFlow::PathNode sink, DataFlow::Configuration conf
-where conf.hasFlowPath(source, sink)
+from PathNode source, PathNode sink
+where flowPath(source, sink)
 select sink, source, sink, "$@", source, source.toString()

--- a/ruby/ql/test/library-tests/frameworks/action_controller/params-flow.expected
+++ b/ruby/ql/test/library-tests/frameworks/action_controller/params-flow.expected
@@ -1,4 +1,5 @@
 failures
+testFailures
 | filter_flow.rb:21:10:21:13 | @foo | Unexpected result: hasTaintFlow= |
 | filter_flow.rb:38:10:38:13 | @foo | Unexpected result: hasTaintFlow= |
 | filter_flow.rb:55:10:55:13 | @foo | Unexpected result: hasTaintFlow= |

--- a/ruby/ql/test/library-tests/frameworks/action_controller/params-flow.ql
+++ b/ruby/ql/test/library-tests/frameworks/action_controller/params-flow.ql
@@ -7,12 +7,14 @@ import TestUtilities.InlineFlowTest
 import PathGraph
 import codeql.ruby.frameworks.Rails
 
-class ParamsTaintFlowConf extends DefaultTaintFlowConf {
-  override predicate isSource(DataFlow::Node n) {
-    n.asExpr().getExpr() instanceof Rails::ParamsCall
-  }
+module ParamsTaintFlowConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node n) { n.asExpr().getExpr() instanceof Rails::ParamsCall }
+
+  predicate isSink(DataFlow::Node n) { DefaultFlowConfig::isSink(n) }
 }
 
-from DataFlow::PathNode source, DataFlow::PathNode sink, ParamsTaintFlowConf conf
-where conf.hasFlowPath(source, sink)
+import FlowTest<DefaultFlowConfig, ParamsTaintFlowConfig>
+
+from TaintFlow::PathNode source, TaintFlow::PathNode sink
+where TaintFlow::flowPath(source, sink)
 select sink, source, sink, "$@", source, source.toString()

--- a/ruby/ql/test/library-tests/frameworks/action_mailer/params-flow.expected
+++ b/ruby/ql/test/library-tests/frameworks/action_mailer/params-flow.expected
@@ -1,4 +1,5 @@
 failures
+testFailures
 edges
 | mailer.rb:3:10:3:15 | call to params | mailer.rb:3:10:3:21 | ...[...] |
 nodes

--- a/ruby/ql/test/library-tests/frameworks/action_mailer/params-flow.ql
+++ b/ruby/ql/test/library-tests/frameworks/action_mailer/params-flow.ql
@@ -7,12 +7,14 @@ import TestUtilities.InlineFlowTest
 import PathGraph
 import codeql.ruby.frameworks.Rails
 
-class ParamsTaintFlowConf extends DefaultTaintFlowConf {
-  override predicate isSource(DataFlow::Node n) {
-    n.asExpr().getExpr() instanceof Rails::ParamsCall
-  }
+module ParamsTaintFlowConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node n) { n.asExpr().getExpr() instanceof Rails::ParamsCall }
+
+  predicate isSink(DataFlow::Node n) { DefaultFlowConfig::isSink(n) }
 }
 
-from DataFlow::PathNode source, DataFlow::PathNode sink, ParamsTaintFlowConf conf
-where conf.hasFlowPath(source, sink)
+import FlowTest<DefaultFlowConfig, ParamsTaintFlowConfig>
+
+from TaintFlow::PathNode source, TaintFlow::PathNode sink
+where TaintFlow::flowPath(source, sink)
 select sink, source, sink, "$@", source, source.toString()

--- a/ruby/ql/test/library-tests/frameworks/active_support/ActiveSupportDataFlow.expected
+++ b/ruby/ql/test/library-tests/frameworks/active_support/ActiveSupportDataFlow.expected
@@ -1,4 +1,5 @@
 failures
+testFailures
 | hash_extensions.rb:126:10:126:19 | call to sole | Unexpected result: hasValueFlow=b |
 edges
 | active_support.rb:10:5:10:5 | x | active_support.rb:11:10:11:10 | x |

--- a/ruby/ql/test/library-tests/frameworks/active_support/ActiveSupportDataFlow.ql
+++ b/ruby/ql/test/library-tests/frameworks/active_support/ActiveSupportDataFlow.ql
@@ -5,8 +5,9 @@
 import codeql.ruby.AST
 import TestUtilities.InlineFlowTest
 import codeql.ruby.Frameworks
+import DefaultFlowTest
 import PathGraph
 
-from DataFlow::PathNode source, DataFlow::PathNode sink, DefaultValueFlowConf conf
-where conf.hasFlowPath(source, sink)
+from ValueFlow::PathNode source, ValueFlow::PathNode sink
+where ValueFlow::flowPath(source, sink)
 select sink, source, sink, "$@", source, source.toString()

--- a/ruby/ql/test/library-tests/frameworks/arel/Arel.expected
+++ b/ruby/ql/test/library-tests/frameworks/arel/Arel.expected
@@ -1,3 +1,4 @@
 failures
+testFailures
 #select
 | arel.rb:3:8:3:18 | call to sql | arel.rb:2:7:2:14 | call to source | arel.rb:3:8:3:18 | call to sql | $@ | arel.rb:2:7:2:14 | call to source | call to source |

--- a/ruby/ql/test/library-tests/frameworks/arel/Arel.ql
+++ b/ruby/ql/test/library-tests/frameworks/arel/Arel.ql
@@ -5,7 +5,8 @@
 import codeql.ruby.frameworks.Arel
 import codeql.ruby.AST
 import TestUtilities.InlineFlowTest
+import DefaultFlowTest
 
-from DataFlow::PathNode source, DataFlow::PathNode sink, DefaultTaintFlowConf conf
-where conf.hasFlowPath(source, sink)
+from TaintFlow::PathNode source, TaintFlow::PathNode sink
+where TaintFlow::flowPath(source, sink)
 select sink, source, sink, "$@", source, source.toString()

--- a/ruby/ql/test/library-tests/frameworks/json/JsonDataFlow.expected
+++ b/ruby/ql/test/library-tests/frameworks/json/JsonDataFlow.expected
@@ -1,4 +1,5 @@
 failures
+testFailures
 edges
 | json.rb:1:17:1:26 | call to source | json.rb:1:6:1:27 | call to parse |
 | json.rb:2:18:2:27 | call to source | json.rb:2:6:2:28 | call to parse! |

--- a/ruby/ql/test/library-tests/frameworks/json/JsonDataFlow.ql
+++ b/ruby/ql/test/library-tests/frameworks/json/JsonDataFlow.ql
@@ -4,4 +4,5 @@
 
 import TestUtilities.InlineFlowTest
 import codeql.ruby.Frameworks
+import DefaultFlowTest
 import PathGraph

--- a/ruby/ql/test/library-tests/frameworks/sinatra/Flow.expected
+++ b/ruby/ql/test/library-tests/frameworks/sinatra/Flow.expected
@@ -1,4 +1,5 @@
 failures
+testFailures
 | views/index.erb:2:10:2:12 | call to foo | Unexpected result: hasTaintFlow= |
 edges
 | app.rb:75:5:75:8 | [post] self [@foo] | app.rb:76:32:76:35 | self [@foo] |

--- a/ruby/ql/test/library-tests/frameworks/sinatra/Flow.ql
+++ b/ruby/ql/test/library-tests/frameworks/sinatra/Flow.ql
@@ -8,12 +8,16 @@ import PathGraph
 import codeql.ruby.frameworks.Sinatra
 import codeql.ruby.Concepts
 
-class SinatraConf extends DefaultTaintFlowConf {
-  override predicate isSource(DataFlow::Node source) {
+module SinatraConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) {
     source instanceof Http::Server::RequestInputAccess::Range
   }
+
+  predicate isSink(DataFlow::Node sink) { DefaultFlowConfig::isSink(sink) }
 }
 
-from DataFlow::PathNode source, DataFlow::PathNode sink, SinatraConf conf
-where conf.hasFlowPath(source, sink)
+import FlowTest<DefaultFlowConfig, SinatraConfig>
+
+from TaintFlow::PathNode source, TaintFlow::PathNode sink
+where TaintFlow::flowPath(source, sink)
 select sink, source, sink, "$@", source, source.toString()

--- a/ruby/ql/test/query-tests/security/cwe-829/InsecureDownload.expected
+++ b/ruby/ql/test/query-tests/security/cwe-829/InsecureDownload.expected
@@ -18,6 +18,7 @@ nodes
 | insecure_download.rb:43:22:43:56 | "http://example.org/unsafe.unk..." | semmle.label | "http://example.org/unsafe.unk..." |
 | insecure_download.rb:53:65:53:78 | "/myscript.sh" | semmle.label | "/myscript.sh" |
 subpaths
+testFailures
 #select
 | insecure_download.rb:27:15:27:45 | "http://example.org/unsafe.APK" | insecure_download.rb:27:15:27:45 | "http://example.org/unsafe.APK" | insecure_download.rb:27:15:27:45 | "http://example.org/unsafe.APK" | $@ | insecure_download.rb:27:15:27:45 | "http://example.org/unsafe.APK" | "http://example.org/unsafe.APK" |
 | insecure_download.rb:27:15:27:45 | "http://example.org/unsafe.APK" | insecure_download.rb:27:15:27:45 | "http://example.org/unsafe.APK" | insecure_download.rb:27:15:27:45 | "http://example.org/unsafe.APK" | $@ | insecure_download.rb:27:15:27:45 | "http://example.org/unsafe.APK" | "http://example.org/unsafe.APK" |

--- a/ruby/ql/test/query-tests/security/cwe-829/InsecureDownload.ql
+++ b/ruby/ql/test/query-tests/security/cwe-829/InsecureDownload.ql
@@ -1,22 +1,25 @@
 import codeql.ruby.AST
 import codeql.ruby.DataFlow
-import PathGraph
-import TestUtilities.InlineFlowTest
 import codeql.ruby.security.InsecureDownloadQuery
+import Flow::PathGraph
+import TestUtilities.InlineExpectationsTest
+import TestUtilities.InlineFlowTestUtil
 
-class FlowTest extends InlineFlowTest {
-  override DataFlow::Configuration getValueFlowConfig() { result = any(Configuration config) }
+module FlowTest implements TestSig {
+  string getARelevantTag() { result = "BAD" }
 
-  override DataFlow::Configuration getTaintFlowConfig() { none() }
-
-  override string getARelevantTag() { result = "BAD" }
-
-  override predicate hasActualResult(Location location, string element, string tag, string value) {
+  predicate hasActualResult(Location location, string element, string tag, string value) {
     tag = "BAD" and
-    super.hasActualResult(location, element, "hasValueFlow", value)
+    exists(DataFlow::Node src, DataFlow::Node sink | Flow::flow(src, sink) |
+      sink.getLocation() = location and
+      element = sink.toString() and
+      if exists(getSourceArgString(src)) then value = getSourceArgString(src) else value = ""
+    )
   }
 }
 
-from DataFlow::PathNode source, DataFlow::PathNode sink, Configuration conf
-where conf.hasFlowPath(source, sink)
+import MakeTest<FlowTest>
+
+from Flow::PathNode source, Flow::PathNode sink
+where Flow::flowPath(source, sink)
 select sink, source, sink, "$@", source, source.toString()


### PR DESCRIPTION
Follow up to https://github.com/github/codeql/pull/12789 and https://github.com/github/codeql/pull/13346. This rewrites the `InlineFlowTest` classes as a parameterized module and makes them use the `InlineExpectationsTest` parameterized module instead of the class. There's one commit per language.

The various versions of `InlineFlowTest` had diverged somewhat. I've tried to bring them more inline with each other, which should make it easier to turn this into a shared library. Note that latter is not quite possible yet, as dataflow is not yet a shared library and there are dependencies on data flow.

**Note to Go and Ruby reviewers**: I modernized one of you dataflow configurations, so this will not only affect tests but also your queries. I've accordingly started a DCA experiment for both or your languages.

As far as I can tell, I can ignore all CI failures, but please have a look at those.