### PR TITLE
C++: ignore iterators that are their own value type

### DIFF
--- a/cpp/ql/lib/change-notes/2023-06-14-self-valued-terator.md
+++ b/cpp/ql/lib/change-notes/2023-06-14-self-valued-terator.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Iterators which are their own value type are now ignored by the iterator model. This should fix a rare situation where no dataflow was generated for these types.

--- a/cpp/ql/lib/semmle/code/cpp/models/implementations/Iterator.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/implementations/Iterator.qll
@@ -24,6 +24,14 @@ private class IteratorTraits extends Class {
   }
 
   Type getIteratorType() { result = this.getTemplateArgument(0) }
+
+  Type getValueType() {
+    exists(TypedefType t |
+      this.getAMember() = t and
+      t.getName() = "value_type" and
+      result = t.getUnderlyingType()
+    )
+  }
 }
 
 /**
@@ -33,15 +41,12 @@ private class IteratorTraits extends Class {
 private class IteratorByTraits extends Iterator {
   IteratorTraits trait;
 
-  IteratorByTraits() { trait.getIteratorType() = this }
-
-  override Type getValueType() {
-    exists(TypedefType t |
-      trait.getAMember() = t and
-      t.getName() = "value_type" and
-      result = t.getUnderlyingType()
-    )
+  IteratorByTraits() {
+    trait.getIteratorType() = this and
+    not trait.getValueType() = this
   }
+
+  override Type getValueType() { result = trait.getValueType() }
 }
 
 /**

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/self-Iterator.cpp
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/self-Iterator.cpp
@@ -1,0 +1,21 @@
+#include "../../../include/iterator.h"
+int source();
+
+template<typename T>
+void sink(T);
+
+template<> struct std::iterator_traits<unsigned long>
+{   // get traits from integer type
+    typedef std::input_iterator_tag iterator_category;
+    typedef unsigned long value_type;
+    typedef unsigned long difference_type;
+    typedef unsigned long distance_type;
+    typedef unsigned long * pointer;
+    typedef unsigned long& reference;
+};
+
+
+int test() {
+    unsigned long x = source();
+    sink(x); // $ ast MISSING: ir
+}

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/self-Iterator.cpp
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/self-Iterator.cpp
@@ -17,5 +17,5 @@ template<> struct std::iterator_traits<unsigned long>
 
 int test() {
     unsigned long x = source();
-    sink(x); // $ ast MISSING: ir
+    sink(x); // $ ast,ir
 }


### PR DESCRIPTION
This fixes a rare case where IR-based data flow won't have appropriate edges for these types.