### PR TITLE
Go: Add failing tests for MaD with pointer content

### DIFF
--- a/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlow/completetest.ext.yml
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlow/completetest.ext.yml
@@ -22,7 +22,9 @@ extensions:
       - ["github.com/nonexistent/test", "", False, "GetMapKey", "", "", "Argument[0].MapKey", "ReturnValue", "value", "manual"]
       - ["github.com/nonexistent/test", "", False, "SetElement", "", "", "Argument[0]", "ReturnValue.Element", "value", "manual"]
       - ["github.com/nonexistent/test", "C", False, "Get", "", "", "Argument[-1].Field[github.com/nonexistent/test.C.F]", "ReturnValue", "value", "manual"]
+      - ["github.com/nonexistent/test", "C", False, "GetThroughPointer", "", "", "Argument[-1].Field[github.com/nonexistent/test.C.F]", "ReturnValue", "value", "manual"]
       - ["github.com/nonexistent/test", "C", False, "Set", "", "", "Argument[0]", "Argument[-1].Field[github.com/nonexistent/test.C.F]", "value", "manual"]
+      - ["github.com/nonexistent/test", "C", False, "SetThroughPointer", "", "", "Argument[0]", "Argument[-1].Field[github.com/nonexistent/test.C.F]", "value", "manual"]
 
   - addsTo:
       pack: codeql/go-all

--- a/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlow/sinks.expected
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlow/sinks.expected
@@ -26,6 +26,10 @@ invalidModelRow
 | test.go:133:10:133:17 | call to Get | qltest |
 | test.go:137:10:137:17 | call to Get | qltest |
 | test.go:142:10:142:17 | call to Get | qltest |
-| test.go:148:17:148:20 | arg1 | qltest |
-| test.go:148:23:148:26 | arg2 | qltest |
-| test.go:148:29:148:32 | arg3 | qltest |
+| test.go:146:10:146:14 | selection of F | qltest |
+| test.go:149:10:149:32 | call to GetThroughPointer | qltest |
+| test.go:153:10:153:32 | call to GetThroughPointer | qltest |
+| test.go:158:10:158:32 | call to GetThroughPointer | qltest |
+| test.go:164:17:164:20 | arg1 | qltest |
+| test.go:164:23:164:26 | arg2 | qltest |
+| test.go:164:29:164:32 | arg3 | qltest |

--- a/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlow/srcs.expected
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlow/srcs.expected
@@ -17,3 +17,7 @@ invalidModelRow
 | test.go:132:15:132:22 | call to Src1 | qltest |
 | test.go:136:9:136:16 | call to Src1 | qltest |
 | test.go:140:9:140:16 | call to Src1 | qltest |
+| test.go:145:24:145:31 | call to Src1 | qltest |
+| test.go:148:17:148:24 | call to Src1 | qltest |
+| test.go:152:24:152:31 | call to Src1 | qltest |
+| test.go:156:24:156:31 | call to Src1 | qltest |

--- a/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlow/test.go
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlow/test.go
@@ -141,6 +141,22 @@ func simpleflow() {
 	c4.Set("")
 	b.Sink1(c4.Get()) // $ SPURIOUS: hasTaintFlow="call to Get" // because we currently don't clear content
 
+	cp1 := &test.C{""}
+	cp1.SetThroughPointer(a.Src1().(string))
+	b.Sink1(cp1.F) // $ MISSING: hasTaintFlow="selection of F"
+
+	cp2 := &test.C{a.Src1().(string)}
+	b.Sink1(cp2.GetThroughPointer()) // $ MISSING: hasTaintFlow="call to GetThroughPointer"
+
+	cp3 := &test.C{""}
+	cp3.SetThroughPointer(a.Src1().(string))
+	b.Sink1(cp3.GetThroughPointer()) // $ hasTaintFlow="call to GetThroughPointer"
+
+	cp4 := &test.C{""}
+	cp4.SetThroughPointer(a.Src1().(string))
+	cp4.SetThroughPointer("")
+	b.Sink1(cp4.GetThroughPointer()) // $ SPURIOUS: hasTaintFlow="call to GetThroughPointer" // because we currently don't clear content
+
 	arg1 := src
 	arg2 := src
 	arg3 := src

--- a/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlow/vendor/github.com/nonexistent/test/stub.go
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlow/vendor/github.com/nonexistent/test/stub.go
@@ -67,3 +67,6 @@ type C struct {
 
 func (c C) Set(f string) {}
 func (c C) Get() string  { return "" }
+
+func (c *C) SetThroughPointer(f string) {}
+func (c *C) GetThroughPointer() string  { return "" }


### PR DESCRIPTION
The failure of models-as-data to deal with pointer content was highlighted in https://github.com/github/codeql/discussions/13415. This PR adds tests showing the problem.