### PR TITLE
Go: Add models-as-data content for pointer content

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/dataflow/ExternalFlow.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/ExternalFlow.qll
@@ -62,8 +62,8 @@
  *      in the given range. The range is inclusive at both ends.
  *    - "ReturnValue": Selects the return value of a call to the selected element.
  *
- *    For summaries, `input` and `output` may be prefixed by one of the following,
- *    separated by the "of" keyword:
+ *    For summaries, `input` and `output` may be suffixed by any number of the
+ *    following, separated by ".":
  *    - "Element": Selects an element in a collection.
  *    - "Field[f]": Selects the contents of field `f`.
  *    - "Property[p]": Selects the contents of property `p`.

--- a/go/ql/lib/semmle/go/dataflow/ExternalFlow.qll
+++ b/go/ql/lib/semmle/go/dataflow/ExternalFlow.qll
@@ -54,6 +54,18 @@
  *      return value. The return values are zero-indexed
  *    - "ReturnValue[n1..n2]": Similar to "ReturnValue[n]" but selects any
  *      return value in the given range. The range is inclusive at both ends.
+ *
+ *    For summaries, `input` and `output` may be suffixed by any number of the
+ *    following, separated by ".":
+ *    - "Field[pkg.className.fieldname]": Selects the contents of the field `f`
+ *      which satisfies `f.hasQualifiedName(pkg, className, fieldname)`.
+ *    - "SyntheticField[f]": Selects the contents of the synthetic field `f`.
+ *    - "ArrayElement": Selects an element in an array or slice.
+ *    - "Element": Selects an element in a collection.
+ *    - "MapKey": Selects a key in a map.
+ *    - "MapValue": Selects a value in a map.
+ *    - "Dereference": Selects the value referenced by a pointer.
+ *
  * 8. The `kind` column is a tag that can be referenced from QL to determine to
  *    which classes the interpreted elements should be added. For example, for
  *    sources "remote" indicates a default remote flow source, and for summaries

--- a/go/ql/lib/semmle/go/dataflow/ExternalFlow.qll
+++ b/go/ql/lib/semmle/go/dataflow/ExternalFlow.qll
@@ -342,6 +342,8 @@ predicate parseContent(string component, DataFlow::Content content) {
   component = "MapKey" and content instanceof DataFlow::MapKeyContent
   or
   component = "MapValue" and content instanceof DataFlow::MapValueContent
+  or
+  component = "Dereference" and content instanceof DataFlow::PointerContent
 }
 
 cached

--- a/go/ql/lib/semmle/go/dataflow/internal/FlowSummaryImplSpecific.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/FlowSummaryImplSpecific.qll
@@ -106,6 +106,8 @@ private string getContentSpecific(Content c) {
   c instanceof MapKeyContent and result = "MapKey"
   or
   c instanceof MapValueContent and result = "MapValue"
+  or
+  c instanceof PointerContent and result = "Dereference"
 }
 
 /** Gets the textual representation of the content in the format used for flow summaries. */

--- a/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlow/completetest.ext.yml
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlow/completetest.ext.yml
@@ -22,9 +22,9 @@ extensions:
       - ["github.com/nonexistent/test", "", False, "GetMapKey", "", "", "Argument[0].MapKey", "ReturnValue", "value", "manual"]
       - ["github.com/nonexistent/test", "", False, "SetElement", "", "", "Argument[0]", "ReturnValue.Element", "value", "manual"]
       - ["github.com/nonexistent/test", "C", False, "Get", "", "", "Argument[-1].Field[github.com/nonexistent/test.C.F]", "ReturnValue", "value", "manual"]
-      - ["github.com/nonexistent/test", "C", False, "GetThroughPointer", "", "", "Argument[-1].Field[github.com/nonexistent/test.C.F]", "ReturnValue", "value", "manual"]
+      - ["github.com/nonexistent/test", "C", False, "GetThroughPointer", "", "", "Argument[-1].Dereference.Field[github.com/nonexistent/test.C.F]", "ReturnValue", "value", "manual"]
       - ["github.com/nonexistent/test", "C", False, "Set", "", "", "Argument[0]", "Argument[-1].Field[github.com/nonexistent/test.C.F]", "value", "manual"]
-      - ["github.com/nonexistent/test", "C", False, "SetThroughPointer", "", "", "Argument[0]", "Argument[-1].Field[github.com/nonexistent/test.C.F]", "value", "manual"]
+      - ["github.com/nonexistent/test", "C", False, "SetThroughPointer", "", "", "Argument[0]", "Argument[-1].Dereference.Field[github.com/nonexistent/test.C.F]", "value", "manual"]
 
   - addsTo:
       pack: codeql/go-all

--- a/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlow/test.go
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlow/test.go
@@ -143,10 +143,10 @@ func simpleflow() {
 
 	cp1 := &test.C{""}
 	cp1.SetThroughPointer(a.Src1().(string))
-	b.Sink1(cp1.F) // $ MISSING: hasTaintFlow="selection of F"
+	b.Sink1(cp1.F) // $ hasTaintFlow="selection of F"
 
 	cp2 := &test.C{a.Src1().(string)}
-	b.Sink1(cp2.GetThroughPointer()) // $ MISSING: hasTaintFlow="call to GetThroughPointer"
+	b.Sink1(cp2.GetThroughPointer()) // $ hasTaintFlow="call to GetThroughPointer"
 
 	cp3 := &test.C{""}
 	cp3.SetThroughPointer(a.Src1().(string))


### PR DESCRIPTION
This is based on https://github.com/github/codeql/pull/13453 and fixes the failing tests added in that PR.