### PR TITLE
Dataflow: add language-specific hook for breaking up big step relation

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -2021,7 +2021,8 @@ module Impl<FullStateConfigSig Config> {
       FlowCheckNode() {
         castNode(this.asNode()) or
         clearsContentCached(this.asNode(), _) or
-        expectsContentCached(this.asNode(), _)
+        expectsContentCached(this.asNode(), _) or
+        flowCheckNodeSpecific(this.asNode())
       }
     }
 

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -2022,7 +2022,7 @@ module Impl<FullStateConfigSig Config> {
         castNode(this.asNode()) or
         clearsContentCached(this.asNode(), _) or
         expectsContentCached(this.asNode(), _) or
-        flowCheckNodeSpecific(this.asNode())
+        neverSkipInPathGraph(this.asNode())
       }
     }
 

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowPrivate.qll
@@ -236,9 +236,10 @@ class CastNode extends Node {
 }
 
 /**
- * Holds if `n` should be a FlowCheckNode, which will appear in path summaries.
+ * Holds if `n` should never be skipped over in the `PathGraph` and in path
+ * explanations.
  */
-predicate flowCheckNodeSpecific(Node n) { none() }
+predicate neverSkipInPathGraph(Node n) { none() }
 
 class DataFlowCallable = Function;
 

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowPrivate.qll
@@ -235,6 +235,11 @@ class CastNode extends Node {
   CastNode() { none() } // stub implementation
 }
 
+/**
+ * Holds if `n` should be a FlowCheckNode, which will appear in path summaries.
+ */
+predicate flowCheckNodeSpecific(Node n) { none() }
+
 class DataFlowCallable = Function;
 
 class DataFlowExpr = Expr;

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -2021,7 +2021,8 @@ module Impl<FullStateConfigSig Config> {
       FlowCheckNode() {
         castNode(this.asNode()) or
         clearsContentCached(this.asNode(), _) or
-        expectsContentCached(this.asNode(), _)
+        expectsContentCached(this.asNode(), _) or
+        flowCheckNodeSpecific(this.asNode())
       }
     }
 

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -2022,7 +2022,7 @@ module Impl<FullStateConfigSig Config> {
         castNode(this.asNode()) or
         clearsContentCached(this.asNode(), _) or
         expectsContentCached(this.asNode(), _) or
-        flowCheckNodeSpecific(this.asNode())
+        neverSkipInPathGraph(this.asNode())
       }
     }
 

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -784,9 +784,10 @@ class CastNode extends Node {
 }
 
 /**
- * Holds if `n` should be a FlowCheckNode, which will appear in path summaries.
+ * Holds if `n` should never be skipped over in the `PathGraph` and in path
+ * explanations.
  */
-predicate flowCheckNodeSpecific(Node n) { none() }
+predicate neverSkipInPathGraph(Node n) { none() }
 
 /**
  * A function that may contain code or a variable that may contain itself. When

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -784,6 +784,11 @@ class CastNode extends Node {
 }
 
 /**
+ * Holds if `n` should be a FlowCheckNode, which will appear in path summaries.
+ */
+predicate flowCheckNodeSpecific(Node n) { none() }
+
+/**
  * A function that may contain code or a variable that may contain itself. When
  * flow crosses from one _enclosing callable_ to another, the interprocedural
  * data-flow library discards call contexts and inserts a node in the big-step

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -2021,7 +2021,8 @@ module Impl<FullStateConfigSig Config> {
       FlowCheckNode() {
         castNode(this.asNode()) or
         clearsContentCached(this.asNode(), _) or
-        expectsContentCached(this.asNode(), _)
+        expectsContentCached(this.asNode(), _) or
+        flowCheckNodeSpecific(this.asNode())
       }
     }
 

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -2022,7 +2022,7 @@ module Impl<FullStateConfigSig Config> {
         castNode(this.asNode()) or
         clearsContentCached(this.asNode(), _) or
         expectsContentCached(this.asNode(), _) or
-        flowCheckNodeSpecific(this.asNode())
+        neverSkipInPathGraph(this.asNode())
       }
     }
 

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -2147,6 +2147,11 @@ class CastNode extends Node {
   }
 }
 
+/**
+ * Holds if `n` should be a FlowCheckNode, which will appear in path summaries.
+ */
+predicate flowCheckNodeSpecific(Node n) { none() }
+
 class DataFlowExpr = DotNet::Expr;
 
 /** Holds if `e` is an expression that always has the same Boolean value `val`. */

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -2148,9 +2148,10 @@ class CastNode extends Node {
 }
 
 /**
- * Holds if `n` should be a FlowCheckNode, which will appear in path summaries.
+ * Holds if `n` should never be skipped over in the `PathGraph` and in path
+ * explanations.
  */
-predicate flowCheckNodeSpecific(Node n) { none() }
+predicate neverSkipInPathGraph(Node n) { none() }
 
 class DataFlowExpr = DotNet::Expr;
 

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowImpl.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowImpl.qll
@@ -2021,7 +2021,8 @@ module Impl<FullStateConfigSig Config> {
       FlowCheckNode() {
         castNode(this.asNode()) or
         clearsContentCached(this.asNode(), _) or
-        expectsContentCached(this.asNode(), _)
+        expectsContentCached(this.asNode(), _) or
+        flowCheckNodeSpecific(this.asNode())
       }
     }
 

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowImpl.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowImpl.qll
@@ -2022,7 +2022,7 @@ module Impl<FullStateConfigSig Config> {
         castNode(this.asNode()) or
         clearsContentCached(this.asNode(), _) or
         expectsContentCached(this.asNode(), _) or
-        flowCheckNodeSpecific(this.asNode())
+        neverSkipInPathGraph(this.asNode())
       }
     }
 

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowPrivate.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowPrivate.qll
@@ -228,6 +228,11 @@ class CastNode extends ExprNode {
   override ConversionExpr expr;
 }
 
+/**
+ * Holds if `n` should be a FlowCheckNode, which will appear in path summaries.
+ */
+predicate flowCheckNodeSpecific(Node n) { none() }
+
 class DataFlowExpr = Expr;
 
 private newtype TDataFlowType =

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowPrivate.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowPrivate.qll
@@ -229,9 +229,10 @@ class CastNode extends ExprNode {
 }
 
 /**
- * Holds if `n` should be a FlowCheckNode, which will appear in path summaries.
+ * Holds if `n` should never be skipped over in the `PathGraph` and in path
+ * explanations.
  */
-predicate flowCheckNodeSpecific(Node n) { none() }
+predicate neverSkipInPathGraph(Node n) { none() }
 
 class DataFlowExpr = Expr;
 

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -2021,7 +2021,8 @@ module Impl<FullStateConfigSig Config> {
       FlowCheckNode() {
         castNode(this.asNode()) or
         clearsContentCached(this.asNode(), _) or
-        expectsContentCached(this.asNode(), _)
+        expectsContentCached(this.asNode(), _) or
+        flowCheckNodeSpecific(this.asNode())
       }
     }
 

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -2022,7 +2022,7 @@ module Impl<FullStateConfigSig Config> {
         castNode(this.asNode()) or
         clearsContentCached(this.asNode(), _) or
         expectsContentCached(this.asNode(), _) or
-        flowCheckNodeSpecific(this.asNode())
+        neverSkipInPathGraph(this.asNode())
       }
     }
 

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowPrivate.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowPrivate.qll
@@ -242,6 +242,11 @@ class CastNode extends ExprNode {
   CastNode() { this.getExpr() instanceof CastingExpr }
 }
 
+/**
+ * Holds if `n` should be a FlowCheckNode, which will appear in path summaries.
+ */
+predicate flowCheckNodeSpecific(Node n) { none() }
+
 private newtype TDataFlowCallable =
   TSrcCallable(Callable c) or
   TSummarizedCallable(SummarizedCallable c) or

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowPrivate.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowPrivate.qll
@@ -243,9 +243,10 @@ class CastNode extends ExprNode {
 }
 
 /**
- * Holds if `n` should be a FlowCheckNode, which will appear in path summaries.
+ * Holds if `n` should never be skipped over in the `PathGraph` and in path
+ * explanations.
  */
-predicate flowCheckNodeSpecific(Node n) { none() }
+predicate neverSkipInPathGraph(Node n) { none() }
 
 private newtype TDataFlowCallable =
   TSrcCallable(Callable c) or

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl.qll
@@ -2021,7 +2021,8 @@ module Impl<FullStateConfigSig Config> {
       FlowCheckNode() {
         castNode(this.asNode()) or
         clearsContentCached(this.asNode(), _) or
-        expectsContentCached(this.asNode(), _)
+        expectsContentCached(this.asNode(), _) or
+        flowCheckNodeSpecific(this.asNode())
       }
     }
 

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl.qll
@@ -2022,7 +2022,7 @@ module Impl<FullStateConfigSig Config> {
         castNode(this.asNode()) or
         clearsContentCached(this.asNode(), _) or
         expectsContentCached(this.asNode(), _) or
-        flowCheckNodeSpecific(this.asNode())
+        neverSkipInPathGraph(this.asNode())
       }
     }
 

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
@@ -490,9 +490,10 @@ class CastNode extends Node {
 }
 
 /**
- * Holds if `n` should be a FlowCheckNode, which will appear in path summaries.
+ * Holds if `n` should never be skipped over in the `PathGraph` and in path
+ * explanations.
  */
-predicate flowCheckNodeSpecific(Node n) {
+predicate neverSkipInPathGraph(Node n) {
   // We include read- and store steps here to force them to be
   // shown in path explanations.
   // This hack is necessary, because we have included some of these

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
@@ -498,6 +498,11 @@ class CastNode extends Node {
 }
 
 /**
+ * Holds if `n` should be a FlowCheckNode, which will appear in path summaries.
+ */
+predicate flowCheckNodeSpecific(Node n) { none() }
+
+/**
  * Holds if `t1` and `t2` are compatible, that is, whether data can flow from
  * a node of type `t1` to a node of type `t2`.
  */

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
@@ -486,6 +486,13 @@ class DataFlowType extends TDataFlowType {
 
 /** A node that performs a type cast. */
 class CastNode extends Node {
+  CastNode() { none() }
+}
+
+/**
+ * Holds if `n` should be a FlowCheckNode, which will appear in path summaries.
+ */
+predicate flowCheckNodeSpecific(Node n) {
   // We include read- and store steps here to force them to be
   // shown in path explanations.
   // This hack is necessary, because we have included some of these
@@ -494,13 +501,8 @@ class CastNode extends Node {
   // We should revert this once, we can remove this steps from the
   // default taint steps; this should be possible once we have
   // implemented flow summaries and recursive content.
-  CastNode() { readStep(_, _, this) or storeStep(_, _, this) }
+  readStep(_, _, n) or storeStep(_, _, n)
 }
-
-/**
- * Holds if `n` should be a FlowCheckNode, which will appear in path summaries.
- */
-predicate flowCheckNodeSpecific(Node n) { none() }
 
 /**
  * Holds if `t1` and `t2` are compatible, that is, whether data can flow from

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl.qll
@@ -2021,7 +2021,8 @@ module Impl<FullStateConfigSig Config> {
       FlowCheckNode() {
         castNode(this.asNode()) or
         clearsContentCached(this.asNode(), _) or
-        expectsContentCached(this.asNode(), _)
+        expectsContentCached(this.asNode(), _) or
+        flowCheckNodeSpecific(this.asNode())
       }
     }
 

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl.qll
@@ -2022,7 +2022,7 @@ module Impl<FullStateConfigSig Config> {
         castNode(this.asNode()) or
         clearsContentCached(this.asNode(), _) or
         expectsContentCached(this.asNode(), _) or
-        flowCheckNodeSpecific(this.asNode())
+        neverSkipInPathGraph(this.asNode())
       }
     }
 

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
@@ -1294,9 +1294,10 @@ class CastNode extends Node {
 }
 
 /**
- * Holds if `n` should be a FlowCheckNode, which will appear in path summaries.
+ * Holds if `n` should never be skipped over in the `PathGraph` and in path
+ * explanations.
  */
-predicate flowCheckNodeSpecific(Node n) {
+predicate neverSkipInPathGraph(Node n) {
   // ensure that all variable assignments are included in the path graph
   n.(SsaDefinitionExtNode).getDefinitionExt() instanceof Ssa::WriteDefinition
 }

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
@@ -1290,16 +1290,16 @@ private import PostUpdateNodes
 
 /** A node that performs a type cast. */
 class CastNode extends Node {
-  CastNode() {
-    // ensure that all variable assignments are included in the path graph
-    this.(SsaDefinitionExtNode).getDefinitionExt() instanceof Ssa::WriteDefinition
-  }
+  CastNode() { none() }
 }
 
 /**
  * Holds if `n` should be a FlowCheckNode, which will appear in path summaries.
  */
-predicate flowCheckNodeSpecific(Node n) { none() }
+predicate flowCheckNodeSpecific(Node n) {
+  // ensure that all variable assignments are included in the path graph
+  n.(SsaDefinitionExtNode).getDefinitionExt() instanceof Ssa::WriteDefinition
+}
 
 class DataFlowExpr = CfgNodes::ExprCfgNode;
 

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
@@ -1296,6 +1296,11 @@ class CastNode extends Node {
   }
 }
 
+/**
+ * Holds if `n` should be a FlowCheckNode, which will appear in path summaries.
+ */
+predicate flowCheckNodeSpecific(Node n) { none() }
+
 class DataFlowExpr = CfgNodes::ExprCfgNode;
 
 int accessPathLimit() { result = 5 }

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImpl.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImpl.qll
@@ -2021,7 +2021,8 @@ module Impl<FullStateConfigSig Config> {
       FlowCheckNode() {
         castNode(this.asNode()) or
         clearsContentCached(this.asNode(), _) or
-        expectsContentCached(this.asNode(), _)
+        expectsContentCached(this.asNode(), _) or
+        flowCheckNodeSpecific(this.asNode())
       }
     }
 

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImpl.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImpl.qll
@@ -2022,7 +2022,7 @@ module Impl<FullStateConfigSig Config> {
         castNode(this.asNode()) or
         clearsContentCached(this.asNode(), _) or
         expectsContentCached(this.asNode(), _) or
-        flowCheckNodeSpecific(this.asNode())
+        neverSkipInPathGraph(this.asNode())
       }
     }
 

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPrivate.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPrivate.qll
@@ -850,9 +850,10 @@ class CastNode extends Node {
 }
 
 /**
- * Holds if `n` should be a FlowCheckNode, which will appear in path summaries.
+ * Holds if `n` should never be skipped over in the `PathGraph` and in path
+ * explanations.
  */
-predicate flowCheckNodeSpecific(Node n) { none() }
+predicate neverSkipInPathGraph(Node n) { none() }
 
 class DataFlowExpr = Expr;
 

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPrivate.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPrivate.qll
@@ -849,6 +849,11 @@ class CastNode extends Node {
   CastNode() { none() }
 }
 
+/**
+ * Holds if `n` should be a FlowCheckNode, which will appear in path summaries.
+ */
+predicate flowCheckNodeSpecific(Node n) { none() }
+
 class DataFlowExpr = Expr;
 
 class DataFlowParameter = ParamDecl;


### PR DESCRIPTION
Python and Ruby have been (ab)using `CastNode` to do this. Go now has a use-case as well, so I have made a proper language-specific hook.