### PR TITLE
Swift: Fix path hash workaround.

### DIFF
--- a/swift/extractor/infra/file/BUILD.bazel
+++ b/swift/extractor/infra/file/BUILD.bazel
@@ -21,10 +21,11 @@ genrule(
         "PathHash.h.fixed",
     ],
     outs = ["PathHash.h"],
+    toolchains = ["@bazel_tools//tools/cpp:current_cc_toolchain"],
     # see if https://cplusplus.github.io/LWG/issue3657 is fixed with the current compiler or not
     # if fixed, PathHash.h.workaround will not compile
     cmd = "\n".join([
-        "if clang -c -x c++ -std=c++20 -Wno-pragma-once-outside-header \\",
+        "if $(CC) -c -x c++ -std=c++20 -Wno-pragma-once-outside-header \\",
         "    $(rootpath PathHash.h.workaround) -o /dev/null &> /dev/null; then",
         "  cp $(rootpath PathHash.h.workaround) $@",
         "else",


### PR DESCRIPTION
This was previously using a hardcoded `clang` rather than the Bazel compiler (e.g. `clang-12`).