### PR TITLE
Go: show FunctionModel steps in path summaries

### DIFF
--- a/go/ql/lib/change-notes/2023-06-20-function-model-path-nodes.md
+++ b/go/ql/lib/change-notes/2023-06-20-function-model-path-nodes.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* When a result of path query flows through a function modeled using `DataFlow::FunctionModel` or `TaintTracking::FunctionModel`, the path now includes nodes corresponding to the input and output to the function. This brings it in line with functions modeled using Models-as-Data.

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowPrivate.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowPrivate.qll
@@ -232,7 +232,11 @@ class CastNode extends ExprNode {
  * Holds if `n` should never be skipped over in the `PathGraph` and in path
  * explanations.
  */
-predicate neverSkipInPathGraph(Node n) { none() }
+predicate neverSkipInPathGraph(Node n) {
+  exists(DataFlow::FunctionModel fm | fm.getAnInputNode(_) = n or fm.getAnOutputNode(_) = n)
+  or
+  exists(TaintTracking::FunctionModel fm | fm.getAnInputNode(_) = n or fm.getAnOutputNode(_) = n)
+}
 
 class DataFlowExpr = Expr;
 

--- a/go/ql/test/experimental/CWE-134/DsnInjection.expected
+++ b/go/ql/test/experimental/CWE-134/DsnInjection.expected
@@ -1,7 +1,11 @@
 edges
-| Dsn.go:47:10:47:30 | call to FormValue | Dsn.go:50:29:50:33 | dbDSN |
+| Dsn.go:47:10:47:30 | call to FormValue | Dsn.go:49:102:49:105 | name |
+| Dsn.go:49:11:49:106 | call to Sprintf | Dsn.go:50:29:50:33 | dbDSN |
+| Dsn.go:49:102:49:105 | name | Dsn.go:49:11:49:106 | call to Sprintf |
 nodes
 | Dsn.go:47:10:47:30 | call to FormValue | semmle.label | call to FormValue |
+| Dsn.go:49:11:49:106 | call to Sprintf | semmle.label | call to Sprintf |
+| Dsn.go:49:102:49:105 | name | semmle.label | name |
 | Dsn.go:50:29:50:33 | dbDSN | semmle.label | dbDSN |
 subpaths
 #select

--- a/go/ql/test/experimental/CWE-134/DsnInjectionLocal.expected
+++ b/go/ql/test/experimental/CWE-134/DsnInjectionLocal.expected
@@ -1,25 +1,34 @@
 edges
-| Dsn.go:26:11:26:17 | selection of Args | Dsn.go:29:29:29:33 | dbDSN |
+| Dsn.go:26:11:26:17 | selection of Args | Dsn.go:28:102:28:109 | index expression |
+| Dsn.go:28:11:28:110 | call to Sprintf | Dsn.go:29:29:29:33 | dbDSN |
+| Dsn.go:28:102:28:109 | index expression | Dsn.go:28:11:28:110 | call to Sprintf |
 | Dsn.go:62:2:62:4 | definition of cfg [pointer] | Dsn.go:63:9:63:11 | cfg [pointer] |
 | Dsn.go:62:2:62:4 | definition of cfg [pointer] | Dsn.go:67:102:67:104 | cfg [pointer] |
 | Dsn.go:63:9:63:11 | cfg [pointer] | Dsn.go:63:9:63:11 | implicit dereference |
 | Dsn.go:63:9:63:11 | implicit dereference | Dsn.go:62:2:62:4 | definition of cfg [pointer] |
 | Dsn.go:63:9:63:11 | implicit dereference | Dsn.go:63:9:63:11 | implicit dereference |
-| Dsn.go:63:9:63:11 | implicit dereference | Dsn.go:68:29:68:33 | dbDSN |
-| Dsn.go:63:19:63:25 | selection of Args | Dsn.go:63:9:63:11 | implicit dereference |
-| Dsn.go:63:19:63:25 | selection of Args | Dsn.go:68:29:68:33 | dbDSN |
+| Dsn.go:63:9:63:11 | implicit dereference | Dsn.go:67:102:67:108 | selection of dsn |
+| Dsn.go:63:19:63:25 | selection of Args | Dsn.go:63:19:63:29 | slice expression |
+| Dsn.go:63:19:63:29 | slice expression | Dsn.go:63:9:63:11 | implicit dereference |
+| Dsn.go:67:11:67:109 | call to Sprintf | Dsn.go:68:29:68:33 | dbDSN |
 | Dsn.go:67:102:67:104 | cfg [pointer] | Dsn.go:67:102:67:104 | implicit dereference |
 | Dsn.go:67:102:67:104 | implicit dereference | Dsn.go:63:9:63:11 | implicit dereference |
-| Dsn.go:67:102:67:104 | implicit dereference | Dsn.go:68:29:68:33 | dbDSN |
+| Dsn.go:67:102:67:104 | implicit dereference | Dsn.go:67:102:67:108 | selection of dsn |
+| Dsn.go:67:102:67:108 | selection of dsn | Dsn.go:67:11:67:109 | call to Sprintf |
 nodes
 | Dsn.go:26:11:26:17 | selection of Args | semmle.label | selection of Args |
+| Dsn.go:28:11:28:110 | call to Sprintf | semmle.label | call to Sprintf |
+| Dsn.go:28:102:28:109 | index expression | semmle.label | index expression |
 | Dsn.go:29:29:29:33 | dbDSN | semmle.label | dbDSN |
 | Dsn.go:62:2:62:4 | definition of cfg [pointer] | semmle.label | definition of cfg [pointer] |
 | Dsn.go:63:9:63:11 | cfg [pointer] | semmle.label | cfg [pointer] |
 | Dsn.go:63:9:63:11 | implicit dereference | semmle.label | implicit dereference |
 | Dsn.go:63:19:63:25 | selection of Args | semmle.label | selection of Args |
+| Dsn.go:63:19:63:29 | slice expression | semmle.label | slice expression |
+| Dsn.go:67:11:67:109 | call to Sprintf | semmle.label | call to Sprintf |
 | Dsn.go:67:102:67:104 | cfg [pointer] | semmle.label | cfg [pointer] |
 | Dsn.go:67:102:67:104 | implicit dereference | semmle.label | implicit dereference |
+| Dsn.go:67:102:67:108 | selection of dsn | semmle.label | selection of dsn |
 | Dsn.go:68:29:68:33 | dbDSN | semmle.label | dbDSN |
 subpaths
 #select

--- a/go/ql/test/experimental/CWE-918/SSRF.expected
+++ b/go/ql/test/experimental/CWE-918/SSRF.expected
@@ -4,17 +4,23 @@ edges
 | builtin.go:97:21:97:31 | call to Referer | builtin.go:101:36:101:49 | untrustedInput |
 | builtin.go:111:21:111:31 | call to Referer | builtin.go:114:15:114:28 | untrustedInput |
 | builtin.go:129:21:129:31 | call to Referer | builtin.go:132:38:132:51 | untrustedInput |
-| new-tests.go:26:26:26:30 | &... | new-tests.go:31:11:31:57 | call to Sprintf |
-| new-tests.go:26:26:26:30 | &... | new-tests.go:32:11:32:57 | call to Sprintf |
-| new-tests.go:26:26:26:30 | &... | new-tests.go:35:12:35:58 | call to Sprintf |
+| new-tests.go:26:26:26:30 | &... | new-tests.go:31:48:31:56 | selection of word |
+| new-tests.go:26:26:26:30 | &... | new-tests.go:32:48:32:56 | selection of safe |
+| new-tests.go:26:26:26:30 | &... | new-tests.go:35:49:35:57 | selection of word |
+| new-tests.go:31:48:31:56 | selection of word | new-tests.go:31:11:31:57 | call to Sprintf |
+| new-tests.go:32:48:32:56 | selection of safe | new-tests.go:32:11:32:57 | call to Sprintf |
+| new-tests.go:35:49:35:57 | selection of word | new-tests.go:35:12:35:58 | call to Sprintf |
 | new-tests.go:39:18:39:30 | call to Param | new-tests.go:47:11:47:46 | ...+... |
 | new-tests.go:49:18:49:30 | call to Query | new-tests.go:50:11:50:46 | ...+... |
 | new-tests.go:62:2:62:39 | ... := ...[0] | new-tests.go:63:17:63:23 | reqBody |
 | new-tests.go:62:31:62:38 | selection of Body | new-tests.go:62:2:62:39 | ... := ...[0] |
 | new-tests.go:63:17:63:23 | reqBody | new-tests.go:63:26:63:30 | &... |
-| new-tests.go:63:26:63:30 | &... | new-tests.go:68:11:68:57 | call to Sprintf |
-| new-tests.go:63:26:63:30 | &... | new-tests.go:69:11:69:57 | call to Sprintf |
-| new-tests.go:63:26:63:30 | &... | new-tests.go:74:12:74:58 | call to Sprintf |
+| new-tests.go:63:26:63:30 | &... | new-tests.go:68:48:68:56 | selection of word |
+| new-tests.go:63:26:63:30 | &... | new-tests.go:69:48:69:56 | selection of safe |
+| new-tests.go:63:26:63:30 | &... | new-tests.go:74:49:74:57 | selection of word |
+| new-tests.go:68:48:68:56 | selection of word | new-tests.go:68:11:68:57 | call to Sprintf |
+| new-tests.go:69:48:69:56 | selection of safe | new-tests.go:69:11:69:57 | call to Sprintf |
+| new-tests.go:74:49:74:57 | selection of word | new-tests.go:74:12:74:58 | call to Sprintf |
 | new-tests.go:78:18:78:24 | selection of URL | new-tests.go:78:18:78:32 | call to Query |
 | new-tests.go:78:18:78:32 | call to Query | new-tests.go:78:18:78:46 | call to Get |
 | new-tests.go:78:18:78:46 | call to Get | new-tests.go:79:11:79:46 | ...+... |
@@ -36,8 +42,11 @@ nodes
 | builtin.go:132:38:132:51 | untrustedInput | semmle.label | untrustedInput |
 | new-tests.go:26:26:26:30 | &... | semmle.label | &... |
 | new-tests.go:31:11:31:57 | call to Sprintf | semmle.label | call to Sprintf |
+| new-tests.go:31:48:31:56 | selection of word | semmle.label | selection of word |
 | new-tests.go:32:11:32:57 | call to Sprintf | semmle.label | call to Sprintf |
+| new-tests.go:32:48:32:56 | selection of safe | semmle.label | selection of safe |
 | new-tests.go:35:12:35:58 | call to Sprintf | semmle.label | call to Sprintf |
+| new-tests.go:35:49:35:57 | selection of word | semmle.label | selection of word |
 | new-tests.go:39:18:39:30 | call to Param | semmle.label | call to Param |
 | new-tests.go:47:11:47:46 | ...+... | semmle.label | ...+... |
 | new-tests.go:49:18:49:30 | call to Query | semmle.label | call to Query |
@@ -47,8 +56,11 @@ nodes
 | new-tests.go:63:17:63:23 | reqBody | semmle.label | reqBody |
 | new-tests.go:63:26:63:30 | &... | semmle.label | &... |
 | new-tests.go:68:11:68:57 | call to Sprintf | semmle.label | call to Sprintf |
+| new-tests.go:68:48:68:56 | selection of word | semmle.label | selection of word |
 | new-tests.go:69:11:69:57 | call to Sprintf | semmle.label | call to Sprintf |
+| new-tests.go:69:48:69:56 | selection of safe | semmle.label | selection of safe |
 | new-tests.go:74:12:74:58 | call to Sprintf | semmle.label | call to Sprintf |
+| new-tests.go:74:49:74:57 | selection of word | semmle.label | selection of word |
 | new-tests.go:78:18:78:24 | selection of URL | semmle.label | selection of URL |
 | new-tests.go:78:18:78:32 | call to Query | semmle.label | call to Query |
 | new-tests.go:78:18:78:46 | call to Get | semmle.label | call to Get |

--- a/go/ql/test/library-tests/semmle/go/frameworks/Beego/ReflectedXss.expected
+++ b/go/ql/test/library-tests/semmle/go/frameworks/Beego/ReflectedXss.expected
@@ -47,7 +47,7 @@ edges
 | test.go:240:15:240:36 | call to GetString | test.go:243:21:243:29 | untrusted |
 | test.go:253:23:253:44 | call to GetCookie | test.go:253:16:253:45 | type conversion |
 | test.go:264:62:264:83 | call to GetCookie | test.go:264:55:264:84 | type conversion |
-| test.go:269:2:269:40 | ... := ...[0] | test.go:277:21:277:61 | call to GetDisplayString |
+| test.go:269:2:269:40 | ... := ...[0] | test.go:277:44:277:60 | selection of Filename |
 | test.go:269:2:269:40 | ... := ...[0] | test.go:278:38:278:49 | genericFiles |
 | test.go:269:2:269:40 | ... := ...[0] | test.go:279:37:279:48 | genericFiles |
 | test.go:269:2:269:40 | ... := ...[0] | test.go:285:4:285:15 | genericFiles |
@@ -61,6 +61,7 @@ edges
 | test.go:269:2:269:40 | ... := ...[0] | test.go:295:39:295:50 | genericFiles |
 | test.go:269:2:269:40 | ... := ...[0] | test.go:296:40:296:51 | genericFiles |
 | test.go:269:2:269:40 | ... := ...[0] | test.go:297:39:297:50 | genericFiles |
+| test.go:277:44:277:60 | selection of Filename | test.go:277:21:277:61 | call to GetDisplayString |
 | test.go:278:21:278:53 | call to SliceChunk | test.go:278:21:278:92 | selection of Filename |
 | test.go:278:38:278:49 | genericFiles | test.go:278:21:278:53 | call to SliceChunk |
 | test.go:279:21:279:60 | call to SliceDiff | test.go:279:21:279:96 | selection of Filename |
@@ -177,6 +178,7 @@ nodes
 | test.go:264:62:264:83 | call to GetCookie | semmle.label | call to GetCookie |
 | test.go:269:2:269:40 | ... := ...[0] | semmle.label | ... := ...[0] |
 | test.go:277:21:277:61 | call to GetDisplayString | semmle.label | call to GetDisplayString |
+| test.go:277:44:277:60 | selection of Filename | semmle.label | selection of Filename |
 | test.go:278:21:278:53 | call to SliceChunk | semmle.label | call to SliceChunk |
 | test.go:278:21:278:92 | selection of Filename | semmle.label | selection of Filename |
 | test.go:278:38:278:49 | genericFiles | semmle.label | genericFiles |

--- a/go/ql/test/query-tests/Security/CWE-022/TaintedPath.expected
+++ b/go/ql/test/query-tests/Security/CWE-022/TaintedPath.expected
@@ -1,13 +1,15 @@
 edges
 | TaintedPath.go:13:18:13:22 | selection of URL | TaintedPath.go:13:18:13:30 | call to Query |
 | TaintedPath.go:13:18:13:30 | call to Query | TaintedPath.go:16:29:16:40 | tainted_path |
-| TaintedPath.go:13:18:13:30 | call to Query | TaintedPath.go:20:28:20:69 | call to Join |
+| TaintedPath.go:13:18:13:30 | call to Query | TaintedPath.go:20:57:20:68 | tainted_path |
+| TaintedPath.go:20:57:20:68 | tainted_path | TaintedPath.go:20:28:20:69 | call to Join |
 | tst.go:14:2:14:39 | ... := ...[1] | tst.go:17:41:17:56 | selection of Filename |
 nodes
 | TaintedPath.go:13:18:13:22 | selection of URL | semmle.label | selection of URL |
 | TaintedPath.go:13:18:13:30 | call to Query | semmle.label | call to Query |
 | TaintedPath.go:16:29:16:40 | tainted_path | semmle.label | tainted_path |
 | TaintedPath.go:20:28:20:69 | call to Join | semmle.label | call to Join |
+| TaintedPath.go:20:57:20:68 | tainted_path | semmle.label | tainted_path |
 | tst.go:14:2:14:39 | ... := ...[1] | semmle.label | ... := ...[1] |
 | tst.go:17:41:17:56 | selection of Filename | semmle.label | selection of Filename |
 subpaths

--- a/go/ql/test/query-tests/Security/CWE-022/ZipSlip.expected
+++ b/go/ql/test/query-tests/Security/CWE-022/ZipSlip.expected
@@ -1,5 +1,6 @@
 edges
-| UnsafeUnzipSymlinkGood.go:52:24:52:32 | definition of candidate | UnsafeUnzipSymlinkGood.go:61:31:61:62 | call to Join |
+| UnsafeUnzipSymlinkGood.go:52:24:52:32 | definition of candidate | UnsafeUnzipSymlinkGood.go:61:53:61:61 | candidate |
+| UnsafeUnzipSymlinkGood.go:61:53:61:61 | candidate | UnsafeUnzipSymlinkGood.go:61:31:61:62 | call to Join |
 | UnsafeUnzipSymlinkGood.go:72:3:72:25 | ... := ...[0] | UnsafeUnzipSymlinkGood.go:76:24:76:38 | selection of Linkname |
 | UnsafeUnzipSymlinkGood.go:72:3:72:25 | ... := ...[0] | UnsafeUnzipSymlinkGood.go:76:70:76:80 | selection of Name |
 | UnsafeUnzipSymlinkGood.go:76:24:76:38 | selection of Linkname | UnsafeUnzipSymlinkGood.go:52:24:52:32 | definition of candidate |
@@ -13,6 +14,7 @@ edges
 nodes
 | UnsafeUnzipSymlinkGood.go:52:24:52:32 | definition of candidate | semmle.label | definition of candidate |
 | UnsafeUnzipSymlinkGood.go:61:31:61:62 | call to Join | semmle.label | call to Join |
+| UnsafeUnzipSymlinkGood.go:61:53:61:61 | candidate | semmle.label | candidate |
 | UnsafeUnzipSymlinkGood.go:72:3:72:25 | ... := ...[0] | semmle.label | ... := ...[0] |
 | UnsafeUnzipSymlinkGood.go:76:24:76:38 | selection of Linkname | semmle.label | selection of Linkname |
 | UnsafeUnzipSymlinkGood.go:76:70:76:80 | selection of Name | semmle.label | selection of Name |

--- a/go/ql/test/query-tests/Security/CWE-078/CommandInjection.expected
+++ b/go/ql/test/query-tests/Security/CWE-078/CommandInjection.expected
@@ -11,25 +11,47 @@ edges
 | GitSubcommands.go:10:13:10:27 | call to Query | GitSubcommands.go:16:36:16:42 | tainted |
 | SanitizingDoubleDash.go:9:13:9:19 | selection of URL | SanitizingDoubleDash.go:9:13:9:27 | call to Query |
 | SanitizingDoubleDash.go:9:13:9:27 | call to Query | SanitizingDoubleDash.go:14:23:14:33 | slice expression |
-| SanitizingDoubleDash.go:9:13:9:27 | call to Query | SanitizingDoubleDash.go:40:23:40:30 | arrayLit |
-| SanitizingDoubleDash.go:9:13:9:27 | call to Query | SanitizingDoubleDash.go:54:23:54:30 | arrayLit |
-| SanitizingDoubleDash.go:9:13:9:27 | call to Query | SanitizingDoubleDash.go:70:23:70:30 | arrayLit |
+| SanitizingDoubleDash.go:9:13:9:27 | call to Query | SanitizingDoubleDash.go:39:31:39:37 | tainted |
+| SanitizingDoubleDash.go:9:13:9:27 | call to Query | SanitizingDoubleDash.go:53:21:53:28 | arrayLit |
+| SanitizingDoubleDash.go:9:13:9:27 | call to Query | SanitizingDoubleDash.go:68:31:68:37 | tainted |
 | SanitizingDoubleDash.go:9:13:9:27 | call to Query | SanitizingDoubleDash.go:80:23:80:29 | tainted |
+| SanitizingDoubleDash.go:39:14:39:44 | call to append | SanitizingDoubleDash.go:40:23:40:30 | arrayLit |
+| SanitizingDoubleDash.go:39:31:39:37 | tainted | SanitizingDoubleDash.go:39:14:39:44 | call to append |
+| SanitizingDoubleDash.go:53:14:53:35 | call to append | SanitizingDoubleDash.go:54:23:54:30 | arrayLit |
+| SanitizingDoubleDash.go:53:21:53:28 | arrayLit | SanitizingDoubleDash.go:53:14:53:35 | call to append |
+| SanitizingDoubleDash.go:68:14:68:38 | call to append | SanitizingDoubleDash.go:69:21:69:28 | arrayLit |
+| SanitizingDoubleDash.go:68:31:68:37 | tainted | SanitizingDoubleDash.go:68:14:68:38 | call to append |
+| SanitizingDoubleDash.go:69:14:69:35 | call to append | SanitizingDoubleDash.go:70:23:70:30 | arrayLit |
+| SanitizingDoubleDash.go:69:21:69:28 | arrayLit | SanitizingDoubleDash.go:69:14:69:35 | call to append |
 | SanitizingDoubleDash.go:92:13:92:19 | selection of URL | SanitizingDoubleDash.go:92:13:92:27 | call to Query |
 | SanitizingDoubleDash.go:92:13:92:27 | call to Query | SanitizingDoubleDash.go:96:24:96:34 | slice expression |
 | SanitizingDoubleDash.go:92:13:92:27 | call to Query | SanitizingDoubleDash.go:101:24:101:34 | slice expression |
 | SanitizingDoubleDash.go:92:13:92:27 | call to Query | SanitizingDoubleDash.go:105:30:105:36 | tainted |
 | SanitizingDoubleDash.go:92:13:92:27 | call to Query | SanitizingDoubleDash.go:106:24:106:31 | arrayLit |
-| SanitizingDoubleDash.go:92:13:92:27 | call to Query | SanitizingDoubleDash.go:112:24:112:31 | arrayLit |
-| SanitizingDoubleDash.go:92:13:92:27 | call to Query | SanitizingDoubleDash.go:118:24:118:31 | arrayLit |
-| SanitizingDoubleDash.go:92:13:92:27 | call to Query | SanitizingDoubleDash.go:124:24:124:31 | arrayLit |
-| SanitizingDoubleDash.go:92:13:92:27 | call to Query | SanitizingDoubleDash.go:130:24:130:31 | arrayLit |
-| SanitizingDoubleDash.go:92:13:92:27 | call to Query | SanitizingDoubleDash.go:137:24:137:31 | arrayLit |
-| SanitizingDoubleDash.go:92:13:92:27 | call to Query | SanitizingDoubleDash.go:144:24:144:31 | arrayLit |
+| SanitizingDoubleDash.go:92:13:92:27 | call to Query | SanitizingDoubleDash.go:111:37:111:43 | tainted |
+| SanitizingDoubleDash.go:92:13:92:27 | call to Query | SanitizingDoubleDash.go:117:31:117:37 | tainted |
+| SanitizingDoubleDash.go:92:13:92:27 | call to Query | SanitizingDoubleDash.go:123:31:123:37 | tainted |
+| SanitizingDoubleDash.go:92:13:92:27 | call to Query | SanitizingDoubleDash.go:129:21:129:28 | arrayLit |
+| SanitizingDoubleDash.go:92:13:92:27 | call to Query | SanitizingDoubleDash.go:136:31:136:37 | tainted |
+| SanitizingDoubleDash.go:92:13:92:27 | call to Query | SanitizingDoubleDash.go:142:31:142:37 | tainted |
 | SanitizingDoubleDash.go:92:13:92:27 | call to Query | SanitizingDoubleDash.go:148:30:148:36 | tainted |
 | SanitizingDoubleDash.go:92:13:92:27 | call to Query | SanitizingDoubleDash.go:152:24:152:30 | tainted |
 | SanitizingDoubleDash.go:105:15:105:37 | slice literal [array] | SanitizingDoubleDash.go:106:24:106:31 | arrayLit |
 | SanitizingDoubleDash.go:105:30:105:36 | tainted | SanitizingDoubleDash.go:105:15:105:37 | slice literal [array] |
+| SanitizingDoubleDash.go:111:14:111:44 | call to append | SanitizingDoubleDash.go:112:24:112:31 | arrayLit |
+| SanitizingDoubleDash.go:111:37:111:43 | tainted | SanitizingDoubleDash.go:111:14:111:44 | call to append |
+| SanitizingDoubleDash.go:117:14:117:44 | call to append | SanitizingDoubleDash.go:118:24:118:31 | arrayLit |
+| SanitizingDoubleDash.go:117:31:117:37 | tainted | SanitizingDoubleDash.go:117:14:117:44 | call to append |
+| SanitizingDoubleDash.go:123:14:123:38 | call to append | SanitizingDoubleDash.go:124:24:124:31 | arrayLit |
+| SanitizingDoubleDash.go:123:31:123:37 | tainted | SanitizingDoubleDash.go:123:14:123:38 | call to append |
+| SanitizingDoubleDash.go:129:14:129:35 | call to append | SanitizingDoubleDash.go:130:24:130:31 | arrayLit |
+| SanitizingDoubleDash.go:129:21:129:28 | arrayLit | SanitizingDoubleDash.go:129:14:129:35 | call to append |
+| SanitizingDoubleDash.go:136:14:136:38 | call to append | SanitizingDoubleDash.go:137:24:137:31 | arrayLit |
+| SanitizingDoubleDash.go:136:31:136:37 | tainted | SanitizingDoubleDash.go:136:14:136:38 | call to append |
+| SanitizingDoubleDash.go:142:14:142:38 | call to append | SanitizingDoubleDash.go:143:21:143:28 | arrayLit |
+| SanitizingDoubleDash.go:142:31:142:37 | tainted | SanitizingDoubleDash.go:142:14:142:38 | call to append |
+| SanitizingDoubleDash.go:143:14:143:35 | call to append | SanitizingDoubleDash.go:144:24:144:31 | arrayLit |
+| SanitizingDoubleDash.go:143:21:143:28 | arrayLit | SanitizingDoubleDash.go:143:14:143:35 | call to append |
 nodes
 | ArgumentInjection.go:9:10:9:16 | selection of URL | semmle.label | selection of URL |
 | ArgumentInjection.go:9:10:9:24 | call to Query | semmle.label | call to Query |
@@ -47,8 +69,16 @@ nodes
 | SanitizingDoubleDash.go:9:13:9:19 | selection of URL | semmle.label | selection of URL |
 | SanitizingDoubleDash.go:9:13:9:27 | call to Query | semmle.label | call to Query |
 | SanitizingDoubleDash.go:14:23:14:33 | slice expression | semmle.label | slice expression |
+| SanitizingDoubleDash.go:39:14:39:44 | call to append | semmle.label | call to append |
+| SanitizingDoubleDash.go:39:31:39:37 | tainted | semmle.label | tainted |
 | SanitizingDoubleDash.go:40:23:40:30 | arrayLit | semmle.label | arrayLit |
+| SanitizingDoubleDash.go:53:14:53:35 | call to append | semmle.label | call to append |
+| SanitizingDoubleDash.go:53:21:53:28 | arrayLit | semmle.label | arrayLit |
 | SanitizingDoubleDash.go:54:23:54:30 | arrayLit | semmle.label | arrayLit |
+| SanitizingDoubleDash.go:68:14:68:38 | call to append | semmle.label | call to append |
+| SanitizingDoubleDash.go:68:31:68:37 | tainted | semmle.label | tainted |
+| SanitizingDoubleDash.go:69:14:69:35 | call to append | semmle.label | call to append |
+| SanitizingDoubleDash.go:69:21:69:28 | arrayLit | semmle.label | arrayLit |
 | SanitizingDoubleDash.go:70:23:70:30 | arrayLit | semmle.label | arrayLit |
 | SanitizingDoubleDash.go:80:23:80:29 | tainted | semmle.label | tainted |
 | SanitizingDoubleDash.go:92:13:92:19 | selection of URL | semmle.label | selection of URL |
@@ -58,11 +88,25 @@ nodes
 | SanitizingDoubleDash.go:105:15:105:37 | slice literal [array] | semmle.label | slice literal [array] |
 | SanitizingDoubleDash.go:105:30:105:36 | tainted | semmle.label | tainted |
 | SanitizingDoubleDash.go:106:24:106:31 | arrayLit | semmle.label | arrayLit |
+| SanitizingDoubleDash.go:111:14:111:44 | call to append | semmle.label | call to append |
+| SanitizingDoubleDash.go:111:37:111:43 | tainted | semmle.label | tainted |
 | SanitizingDoubleDash.go:112:24:112:31 | arrayLit | semmle.label | arrayLit |
+| SanitizingDoubleDash.go:117:14:117:44 | call to append | semmle.label | call to append |
+| SanitizingDoubleDash.go:117:31:117:37 | tainted | semmle.label | tainted |
 | SanitizingDoubleDash.go:118:24:118:31 | arrayLit | semmle.label | arrayLit |
+| SanitizingDoubleDash.go:123:14:123:38 | call to append | semmle.label | call to append |
+| SanitizingDoubleDash.go:123:31:123:37 | tainted | semmle.label | tainted |
 | SanitizingDoubleDash.go:124:24:124:31 | arrayLit | semmle.label | arrayLit |
+| SanitizingDoubleDash.go:129:14:129:35 | call to append | semmle.label | call to append |
+| SanitizingDoubleDash.go:129:21:129:28 | arrayLit | semmle.label | arrayLit |
 | SanitizingDoubleDash.go:130:24:130:31 | arrayLit | semmle.label | arrayLit |
+| SanitizingDoubleDash.go:136:14:136:38 | call to append | semmle.label | call to append |
+| SanitizingDoubleDash.go:136:31:136:37 | tainted | semmle.label | tainted |
 | SanitizingDoubleDash.go:137:24:137:31 | arrayLit | semmle.label | arrayLit |
+| SanitizingDoubleDash.go:142:14:142:38 | call to append | semmle.label | call to append |
+| SanitizingDoubleDash.go:142:31:142:37 | tainted | semmle.label | tainted |
+| SanitizingDoubleDash.go:143:14:143:35 | call to append | semmle.label | call to append |
+| SanitizingDoubleDash.go:143:21:143:28 | arrayLit | semmle.label | arrayLit |
 | SanitizingDoubleDash.go:144:24:144:31 | arrayLit | semmle.label | arrayLit |
 | SanitizingDoubleDash.go:148:30:148:36 | tainted | semmle.label | tainted |
 | SanitizingDoubleDash.go:152:24:152:30 | tainted | semmle.label | tainted |

--- a/go/ql/test/query-tests/Security/CWE-078/StoredCommand.expected
+++ b/go/ql/test/query-tests/Security/CWE-078/StoredCommand.expected
@@ -1,7 +1,12 @@
 edges
-| StoredCommand.go:11:2:11:27 | ... := ...[0] | StoredCommand.go:14:22:14:28 | cmdName |
+| StoredCommand.go:11:2:11:27 | ... := ...[0] | StoredCommand.go:13:2:13:5 | rows |
+| StoredCommand.go:13:2:13:5 | rows | StoredCommand.go:13:12:13:19 | &... |
+| StoredCommand.go:13:12:13:19 | &... | StoredCommand.go:13:12:13:19 | &... |
+| StoredCommand.go:13:12:13:19 | &... | StoredCommand.go:14:22:14:28 | cmdName |
 nodes
 | StoredCommand.go:11:2:11:27 | ... := ...[0] | semmle.label | ... := ...[0] |
+| StoredCommand.go:13:2:13:5 | rows | semmle.label | rows |
+| StoredCommand.go:13:12:13:19 | &... | semmle.label | &... |
 | StoredCommand.go:14:22:14:28 | cmdName | semmle.label | cmdName |
 subpaths
 #select

--- a/go/ql/test/query-tests/Security/CWE-079/ReflectedXss.expected
+++ b/go/ql/test/query-tests/Security/CWE-079/ReflectedXss.expected
@@ -9,19 +9,27 @@ edges
 | contenttype.go:73:10:73:28 | call to FormValue | contenttype.go:79:11:79:14 | data |
 | contenttype.go:88:10:88:28 | call to FormValue | contenttype.go:91:4:91:7 | data |
 | contenttype.go:113:10:113:28 | call to FormValue | contenttype.go:114:50:114:53 | data |
-| reflectedxsstest.go:27:2:27:38 | ... := ...[0] | reflectedxsstest.go:28:10:28:57 | type conversion |
+| reflectedxsstest.go:27:2:27:38 | ... := ...[0] | reflectedxsstest.go:28:50:28:55 | cookie |
+| reflectedxsstest.go:28:17:28:56 | call to Sprintf | reflectedxsstest.go:28:10:28:57 | type conversion |
+| reflectedxsstest.go:28:50:28:55 | cookie | reflectedxsstest.go:28:17:28:56 | call to Sprintf |
 | reflectedxsstest.go:31:2:31:44 | ... := ...[0] | reflectedxsstest.go:32:34:32:37 | file |
-| reflectedxsstest.go:31:2:31:44 | ... := ...[1] | reflectedxsstest.go:34:10:34:62 | type conversion |
-| reflectedxsstest.go:32:2:32:38 | ... := ...[0] | reflectedxsstest.go:33:10:33:57 | type conversion |
+| reflectedxsstest.go:31:2:31:44 | ... := ...[1] | reflectedxsstest.go:34:46:34:60 | selection of Filename |
+| reflectedxsstest.go:32:2:32:38 | ... := ...[0] | reflectedxsstest.go:33:49:33:55 | content |
 | reflectedxsstest.go:32:34:32:37 | file | reflectedxsstest.go:32:2:32:38 | ... := ...[0] |
+| reflectedxsstest.go:33:17:33:56 | call to Sprintf | reflectedxsstest.go:33:10:33:57 | type conversion |
+| reflectedxsstest.go:33:49:33:55 | content | reflectedxsstest.go:33:17:33:56 | call to Sprintf |
+| reflectedxsstest.go:34:17:34:61 | call to Sprintf | reflectedxsstest.go:34:10:34:62 | type conversion |
+| reflectedxsstest.go:34:46:34:60 | selection of Filename | reflectedxsstest.go:34:17:34:61 | call to Sprintf |
 | reflectedxsstest.go:38:2:38:35 | ... := ...[0] | reflectedxsstest.go:39:16:39:21 | reader |
 | reflectedxsstest.go:39:2:39:32 | ... := ...[0] | reflectedxsstest.go:40:14:40:17 | part |
 | reflectedxsstest.go:39:2:39:32 | ... := ...[0] | reflectedxsstest.go:42:2:42:5 | part |
 | reflectedxsstest.go:39:16:39:21 | reader | reflectedxsstest.go:39:2:39:32 | ... := ...[0] |
 | reflectedxsstest.go:40:14:40:17 | part | reflectedxsstest.go:40:14:40:28 | call to FileName |
-| reflectedxsstest.go:40:14:40:28 | call to FileName | reflectedxsstest.go:44:10:44:55 | type conversion |
+| reflectedxsstest.go:40:14:40:28 | call to FileName | reflectedxsstest.go:44:46:44:53 | partName |
 | reflectedxsstest.go:41:2:41:10 | definition of byteSlice | reflectedxsstest.go:45:10:45:18 | byteSlice |
 | reflectedxsstest.go:42:2:42:5 | part | reflectedxsstest.go:41:2:41:10 | definition of byteSlice |
+| reflectedxsstest.go:44:17:44:54 | call to Sprintf | reflectedxsstest.go:44:10:44:55 | type conversion |
+| reflectedxsstest.go:44:46:44:53 | partName | reflectedxsstest.go:44:17:44:54 | call to Sprintf |
 | reflectedxsstest.go:51:14:51:18 | selection of URL | reflectedxsstest.go:51:14:51:26 | call to Query |
 | reflectedxsstest.go:51:14:51:26 | call to Query | reflectedxsstest.go:54:11:54:21 | type conversion |
 | tst.go:14:15:14:20 | selection of Form | tst.go:14:15:14:36 | call to Get |
@@ -56,12 +64,18 @@ nodes
 | contenttype.go:114:50:114:53 | data | semmle.label | data |
 | reflectedxsstest.go:27:2:27:38 | ... := ...[0] | semmle.label | ... := ...[0] |
 | reflectedxsstest.go:28:10:28:57 | type conversion | semmle.label | type conversion |
+| reflectedxsstest.go:28:17:28:56 | call to Sprintf | semmle.label | call to Sprintf |
+| reflectedxsstest.go:28:50:28:55 | cookie | semmle.label | cookie |
 | reflectedxsstest.go:31:2:31:44 | ... := ...[0] | semmle.label | ... := ...[0] |
 | reflectedxsstest.go:31:2:31:44 | ... := ...[1] | semmle.label | ... := ...[1] |
 | reflectedxsstest.go:32:2:32:38 | ... := ...[0] | semmle.label | ... := ...[0] |
 | reflectedxsstest.go:32:34:32:37 | file | semmle.label | file |
 | reflectedxsstest.go:33:10:33:57 | type conversion | semmle.label | type conversion |
+| reflectedxsstest.go:33:17:33:56 | call to Sprintf | semmle.label | call to Sprintf |
+| reflectedxsstest.go:33:49:33:55 | content | semmle.label | content |
 | reflectedxsstest.go:34:10:34:62 | type conversion | semmle.label | type conversion |
+| reflectedxsstest.go:34:17:34:61 | call to Sprintf | semmle.label | call to Sprintf |
+| reflectedxsstest.go:34:46:34:60 | selection of Filename | semmle.label | selection of Filename |
 | reflectedxsstest.go:38:2:38:35 | ... := ...[0] | semmle.label | ... := ...[0] |
 | reflectedxsstest.go:39:2:39:32 | ... := ...[0] | semmle.label | ... := ...[0] |
 | reflectedxsstest.go:39:16:39:21 | reader | semmle.label | reader |
@@ -70,6 +84,8 @@ nodes
 | reflectedxsstest.go:41:2:41:10 | definition of byteSlice | semmle.label | definition of byteSlice |
 | reflectedxsstest.go:42:2:42:5 | part | semmle.label | part |
 | reflectedxsstest.go:44:10:44:55 | type conversion | semmle.label | type conversion |
+| reflectedxsstest.go:44:17:44:54 | call to Sprintf | semmle.label | call to Sprintf |
+| reflectedxsstest.go:44:46:44:53 | partName | semmle.label | partName |
 | reflectedxsstest.go:45:10:45:18 | byteSlice | semmle.label | byteSlice |
 | reflectedxsstest.go:51:14:51:18 | selection of URL | semmle.label | selection of URL |
 | reflectedxsstest.go:51:14:51:26 | call to Query | semmle.label | call to Query |

--- a/go/ql/test/query-tests/Security/CWE-079/StoredXss.expected
+++ b/go/ql/test/query-tests/Security/CWE-079/StoredXss.expected
@@ -1,11 +1,16 @@
 edges
 | StoredXss.go:13:21:13:31 | call to Name | StoredXss.go:13:21:13:36 | ...+... |
-| stored.go:18:3:18:28 | ... := ...[0] | stored.go:30:22:30:25 | name |
+| stored.go:18:3:18:28 | ... := ...[0] | stored.go:25:14:25:17 | rows |
+| stored.go:25:14:25:17 | rows | stored.go:25:29:25:33 | &... |
+| stored.go:25:29:25:33 | &... | stored.go:25:29:25:33 | &... |
+| stored.go:25:29:25:33 | &... | stored.go:30:22:30:25 | name |
 | stored.go:59:30:59:33 | definition of path | stored.go:61:22:61:25 | path |
 nodes
 | StoredXss.go:13:21:13:31 | call to Name | semmle.label | call to Name |
 | StoredXss.go:13:21:13:36 | ...+... | semmle.label | ...+... |
 | stored.go:18:3:18:28 | ... := ...[0] | semmle.label | ... := ...[0] |
+| stored.go:25:14:25:17 | rows | semmle.label | rows |
+| stored.go:25:29:25:33 | &... | semmle.label | &... |
 | stored.go:30:22:30:25 | name | semmle.label | name |
 | stored.go:59:30:59:33 | definition of path | semmle.label | definition of path |
 | stored.go:61:22:61:25 | path | semmle.label | path |

--- a/go/ql/test/query-tests/Security/CWE-089/SqlInjection.expected
+++ b/go/ql/test/query-tests/Security/CWE-089/SqlInjection.expected
@@ -1,21 +1,30 @@
 edges
+| SqlInjection.go:10:7:11:30 | call to Sprintf | SqlInjection.go:12:11:12:11 | q |
 | SqlInjection.go:11:3:11:9 | selection of URL | SqlInjection.go:11:3:11:17 | call to Query |
-| SqlInjection.go:11:3:11:17 | call to Query | SqlInjection.go:12:11:12:11 | q |
+| SqlInjection.go:11:3:11:17 | call to Query | SqlInjection.go:11:3:11:29 | index expression |
+| SqlInjection.go:11:3:11:29 | index expression | SqlInjection.go:10:7:11:30 | call to Sprintf |
 | issue48.go:17:2:17:33 | ... := ...[0] | issue48.go:18:17:18:17 | b |
 | issue48.go:17:25:17:32 | selection of Body | issue48.go:17:2:17:33 | ... := ...[0] |
 | issue48.go:18:17:18:17 | b | issue48.go:18:20:18:39 | &... |
-| issue48.go:18:20:18:39 | &... | issue48.go:22:11:22:12 | q3 |
+| issue48.go:18:20:18:39 | &... | issue48.go:21:3:21:33 | index expression |
+| issue48.go:20:8:21:34 | call to Sprintf | issue48.go:22:11:22:12 | q3 |
+| issue48.go:21:3:21:33 | index expression | issue48.go:20:8:21:34 | call to Sprintf |
 | issue48.go:27:2:27:34 | ... := ...[0] | issue48.go:28:17:28:18 | b2 |
 | issue48.go:27:26:27:33 | selection of Body | issue48.go:27:2:27:34 | ... := ...[0] |
 | issue48.go:28:17:28:18 | b2 | issue48.go:28:21:28:41 | &... |
-| issue48.go:28:21:28:41 | &... | issue48.go:32:11:32:12 | q4 |
+| issue48.go:28:21:28:41 | &... | issue48.go:31:3:31:31 | selection of Category |
+| issue48.go:30:8:31:32 | call to Sprintf | issue48.go:32:11:32:12 | q4 |
+| issue48.go:31:3:31:31 | selection of Category | issue48.go:30:8:31:32 | call to Sprintf |
 | issue48.go:37:17:37:50 | type conversion | issue48.go:37:53:37:73 | &... |
 | issue48.go:37:24:37:30 | selection of URL | issue48.go:37:24:37:38 | call to Query |
 | issue48.go:37:24:37:38 | call to Query | issue48.go:37:17:37:50 | type conversion |
-| issue48.go:37:53:37:73 | &... | issue48.go:41:11:41:12 | q5 |
+| issue48.go:37:53:37:73 | &... | issue48.go:40:3:40:31 | selection of Category |
+| issue48.go:39:8:40:32 | call to Sprintf | issue48.go:41:11:41:12 | q5 |
+| issue48.go:40:3:40:31 | selection of Category | issue48.go:39:8:40:32 | call to Sprintf |
 | main.go:10:11:10:16 | selection of Form | main.go:10:11:10:28 | index expression |
 | main.go:14:63:14:67 | selection of URL | main.go:14:63:14:75 | call to Query |
-| main.go:14:63:14:75 | call to Query | main.go:14:11:14:84 | call to Sprintf |
+| main.go:14:63:14:75 | call to Query | main.go:14:63:14:83 | index expression |
+| main.go:14:63:14:83 | index expression | main.go:14:11:14:84 | call to Sprintf |
 | main.go:15:63:15:70 | selection of Header | main.go:15:63:15:84 | call to Get |
 | main.go:15:63:15:84 | call to Get | main.go:15:11:15:85 | call to Sprintf |
 | main.go:27:17:30:2 | &... [pointer, Category] | main.go:33:3:33:13 | RequestData [pointer, Category] |
@@ -23,9 +32,10 @@ edges
 | main.go:29:13:29:19 | selection of URL | main.go:29:13:29:27 | call to Query |
 | main.go:29:13:29:27 | call to Query | main.go:29:13:29:39 | index expression |
 | main.go:29:13:29:39 | index expression | main.go:27:18:30:2 | struct literal [Category] |
+| main.go:32:7:33:23 | call to Sprintf | main.go:34:11:34:11 | q |
 | main.go:33:3:33:13 | RequestData [pointer, Category] | main.go:33:3:33:13 | implicit dereference [Category] |
 | main.go:33:3:33:13 | implicit dereference [Category] | main.go:33:3:33:22 | selection of Category |
-| main.go:33:3:33:22 | selection of Category | main.go:34:11:34:11 | q |
+| main.go:33:3:33:22 | selection of Category | main.go:32:7:33:23 | call to Sprintf |
 | main.go:38:2:38:12 | definition of RequestData [pointer, Category] | main.go:39:2:39:12 | RequestData [pointer, Category] |
 | main.go:38:2:38:12 | definition of RequestData [pointer, Category] | main.go:42:3:42:13 | RequestData [pointer, Category] |
 | main.go:39:2:39:12 | RequestData [pointer, Category] | main.go:39:2:39:12 | implicit dereference [Category] |
@@ -33,9 +43,10 @@ edges
 | main.go:39:25:39:31 | selection of URL | main.go:39:25:39:39 | call to Query |
 | main.go:39:25:39:39 | call to Query | main.go:39:25:39:51 | index expression |
 | main.go:39:25:39:51 | index expression | main.go:39:2:39:12 | implicit dereference [Category] |
+| main.go:41:7:42:23 | call to Sprintf | main.go:43:11:43:11 | q |
 | main.go:42:3:42:13 | RequestData [pointer, Category] | main.go:42:3:42:13 | implicit dereference [Category] |
 | main.go:42:3:42:13 | implicit dereference [Category] | main.go:42:3:42:22 | selection of Category |
-| main.go:42:3:42:22 | selection of Category | main.go:43:11:43:11 | q |
+| main.go:42:3:42:22 | selection of Category | main.go:41:7:42:23 | call to Sprintf |
 | main.go:47:2:47:12 | definition of RequestData [pointer, Category] | main.go:48:4:48:14 | RequestData [pointer, Category] |
 | main.go:47:2:47:12 | definition of RequestData [pointer, Category] | main.go:51:3:51:13 | RequestData [pointer, Category] |
 | main.go:48:3:48:14 | star expression [Category] | main.go:47:2:47:12 | definition of RequestData [pointer, Category] |
@@ -43,9 +54,10 @@ edges
 | main.go:48:28:48:34 | selection of URL | main.go:48:28:48:42 | call to Query |
 | main.go:48:28:48:42 | call to Query | main.go:48:28:48:54 | index expression |
 | main.go:48:28:48:54 | index expression | main.go:48:3:48:14 | star expression [Category] |
+| main.go:50:7:51:23 | call to Sprintf | main.go:52:11:52:11 | q |
 | main.go:51:3:51:13 | RequestData [pointer, Category] | main.go:51:3:51:13 | implicit dereference [Category] |
 | main.go:51:3:51:13 | implicit dereference [Category] | main.go:51:3:51:22 | selection of Category |
-| main.go:51:3:51:22 | selection of Category | main.go:52:11:52:11 | q |
+| main.go:51:3:51:22 | selection of Category | main.go:50:7:51:23 | call to Sprintf |
 | main.go:56:2:56:12 | definition of RequestData [pointer, Category] | main.go:57:4:57:14 | RequestData [pointer, Category] |
 | main.go:56:2:56:12 | definition of RequestData [pointer, Category] | main.go:60:5:60:15 | RequestData [pointer, Category] |
 | main.go:57:3:57:14 | star expression [Category] | main.go:56:2:56:12 | definition of RequestData [pointer, Category] |
@@ -53,7 +65,8 @@ edges
 | main.go:57:28:57:34 | selection of URL | main.go:57:28:57:42 | call to Query |
 | main.go:57:28:57:42 | call to Query | main.go:57:28:57:54 | index expression |
 | main.go:57:28:57:54 | index expression | main.go:57:3:57:14 | star expression [Category] |
-| main.go:60:3:60:25 | selection of Category | main.go:61:11:61:11 | q |
+| main.go:59:7:60:26 | call to Sprintf | main.go:61:11:61:11 | q |
+| main.go:60:3:60:25 | selection of Category | main.go:59:7:60:26 | call to Sprintf |
 | main.go:60:4:60:15 | star expression [Category] | main.go:60:3:60:25 | selection of Category |
 | main.go:60:5:60:15 | RequestData [pointer, Category] | main.go:60:4:60:15 | star expression [Category] |
 | mongoDB.go:40:20:40:30 | call to Referer | mongoDB.go:57:22:57:29 | pipeline |
@@ -71,29 +84,38 @@ edges
 | mongoDB.go:40:20:40:30 | call to Referer | mongoDB.go:80:22:80:27 | filter |
 | mongoDB.go:40:20:40:30 | call to Referer | mongoDB.go:81:18:81:25 | pipeline |
 nodes
+| SqlInjection.go:10:7:11:30 | call to Sprintf | semmle.label | call to Sprintf |
 | SqlInjection.go:11:3:11:9 | selection of URL | semmle.label | selection of URL |
 | SqlInjection.go:11:3:11:17 | call to Query | semmle.label | call to Query |
+| SqlInjection.go:11:3:11:29 | index expression | semmle.label | index expression |
 | SqlInjection.go:12:11:12:11 | q | semmle.label | q |
 | issue48.go:17:2:17:33 | ... := ...[0] | semmle.label | ... := ...[0] |
 | issue48.go:17:25:17:32 | selection of Body | semmle.label | selection of Body |
 | issue48.go:18:17:18:17 | b | semmle.label | b |
 | issue48.go:18:20:18:39 | &... | semmle.label | &... |
+| issue48.go:20:8:21:34 | call to Sprintf | semmle.label | call to Sprintf |
+| issue48.go:21:3:21:33 | index expression | semmle.label | index expression |
 | issue48.go:22:11:22:12 | q3 | semmle.label | q3 |
 | issue48.go:27:2:27:34 | ... := ...[0] | semmle.label | ... := ...[0] |
 | issue48.go:27:26:27:33 | selection of Body | semmle.label | selection of Body |
 | issue48.go:28:17:28:18 | b2 | semmle.label | b2 |
 | issue48.go:28:21:28:41 | &... | semmle.label | &... |
+| issue48.go:30:8:31:32 | call to Sprintf | semmle.label | call to Sprintf |
+| issue48.go:31:3:31:31 | selection of Category | semmle.label | selection of Category |
 | issue48.go:32:11:32:12 | q4 | semmle.label | q4 |
 | issue48.go:37:17:37:50 | type conversion | semmle.label | type conversion |
 | issue48.go:37:24:37:30 | selection of URL | semmle.label | selection of URL |
 | issue48.go:37:24:37:38 | call to Query | semmle.label | call to Query |
 | issue48.go:37:53:37:73 | &... | semmle.label | &... |
+| issue48.go:39:8:40:32 | call to Sprintf | semmle.label | call to Sprintf |
+| issue48.go:40:3:40:31 | selection of Category | semmle.label | selection of Category |
 | issue48.go:41:11:41:12 | q5 | semmle.label | q5 |
 | main.go:10:11:10:16 | selection of Form | semmle.label | selection of Form |
 | main.go:10:11:10:28 | index expression | semmle.label | index expression |
 | main.go:14:11:14:84 | call to Sprintf | semmle.label | call to Sprintf |
 | main.go:14:63:14:67 | selection of URL | semmle.label | selection of URL |
 | main.go:14:63:14:75 | call to Query | semmle.label | call to Query |
+| main.go:14:63:14:83 | index expression | semmle.label | index expression |
 | main.go:15:11:15:85 | call to Sprintf | semmle.label | call to Sprintf |
 | main.go:15:63:15:70 | selection of Header | semmle.label | selection of Header |
 | main.go:15:63:15:84 | call to Get | semmle.label | call to Get |
@@ -102,6 +124,7 @@ nodes
 | main.go:29:13:29:19 | selection of URL | semmle.label | selection of URL |
 | main.go:29:13:29:27 | call to Query | semmle.label | call to Query |
 | main.go:29:13:29:39 | index expression | semmle.label | index expression |
+| main.go:32:7:33:23 | call to Sprintf | semmle.label | call to Sprintf |
 | main.go:33:3:33:13 | RequestData [pointer, Category] | semmle.label | RequestData [pointer, Category] |
 | main.go:33:3:33:13 | implicit dereference [Category] | semmle.label | implicit dereference [Category] |
 | main.go:33:3:33:22 | selection of Category | semmle.label | selection of Category |
@@ -112,6 +135,7 @@ nodes
 | main.go:39:25:39:31 | selection of URL | semmle.label | selection of URL |
 | main.go:39:25:39:39 | call to Query | semmle.label | call to Query |
 | main.go:39:25:39:51 | index expression | semmle.label | index expression |
+| main.go:41:7:42:23 | call to Sprintf | semmle.label | call to Sprintf |
 | main.go:42:3:42:13 | RequestData [pointer, Category] | semmle.label | RequestData [pointer, Category] |
 | main.go:42:3:42:13 | implicit dereference [Category] | semmle.label | implicit dereference [Category] |
 | main.go:42:3:42:22 | selection of Category | semmle.label | selection of Category |
@@ -122,6 +146,7 @@ nodes
 | main.go:48:28:48:34 | selection of URL | semmle.label | selection of URL |
 | main.go:48:28:48:42 | call to Query | semmle.label | call to Query |
 | main.go:48:28:48:54 | index expression | semmle.label | index expression |
+| main.go:50:7:51:23 | call to Sprintf | semmle.label | call to Sprintf |
 | main.go:51:3:51:13 | RequestData [pointer, Category] | semmle.label | RequestData [pointer, Category] |
 | main.go:51:3:51:13 | implicit dereference [Category] | semmle.label | implicit dereference [Category] |
 | main.go:51:3:51:22 | selection of Category | semmle.label | selection of Category |
@@ -132,6 +157,7 @@ nodes
 | main.go:57:28:57:34 | selection of URL | semmle.label | selection of URL |
 | main.go:57:28:57:42 | call to Query | semmle.label | call to Query |
 | main.go:57:28:57:54 | index expression | semmle.label | index expression |
+| main.go:59:7:60:26 | call to Sprintf | semmle.label | call to Sprintf |
 | main.go:60:3:60:25 | selection of Category | semmle.label | selection of Category |
 | main.go:60:4:60:15 | star expression [Category] | semmle.label | star expression [Category] |
 | main.go:60:5:60:15 | RequestData [pointer, Category] | semmle.label | RequestData [pointer, Category] |

--- a/go/ql/test/query-tests/Security/CWE-327/UnsafeTLS.expected
+++ b/go/ql/test/query-tests/Security/CWE-327/UnsafeTLS.expected
@@ -14,9 +14,18 @@ edges
 | UnsafeTLS.go:305:5:305:47 | selection of TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256 | UnsafeTLS.go:304:18:306:4 | slice literal |
 | UnsafeTLS.go:313:5:313:45 | selection of TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 | UnsafeTLS.go:312:18:314:4 | slice literal |
 | UnsafeTLS.go:329:53:329:93 | selection of TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 | UnsafeTLS.go:329:25:329:94 | call to append |
-| UnsafeTLS.go:334:13:334:38 | call to InsecureCipherSuites | UnsafeTLS.go:336:26:336:58 | call to append |
-| UnsafeTLS.go:342:13:342:38 | call to InsecureCipherSuites | UnsafeTLS.go:346:25:346:36 | cipherSuites |
-| UnsafeTLS.go:351:13:351:38 | call to InsecureCipherSuites | UnsafeTLS.go:355:25:355:36 | cipherSuites |
+| UnsafeTLS.go:334:13:334:38 | call to InsecureCipherSuites | UnsafeTLS.go:336:54:336:57 | selection of ID |
+| UnsafeTLS.go:336:54:336:57 | selection of ID | UnsafeTLS.go:336:26:336:58 | call to append |
+| UnsafeTLS.go:342:13:342:38 | call to InsecureCipherSuites | UnsafeTLS.go:344:40:344:43 | selection of ID |
+| UnsafeTLS.go:344:19:344:44 | call to append | UnsafeTLS.go:344:26:344:37 | cipherSuites |
+| UnsafeTLS.go:344:19:344:44 | call to append | UnsafeTLS.go:346:25:346:36 | cipherSuites |
+| UnsafeTLS.go:344:26:344:37 | cipherSuites | UnsafeTLS.go:344:19:344:44 | call to append |
+| UnsafeTLS.go:344:40:344:43 | selection of ID | UnsafeTLS.go:344:19:344:44 | call to append |
+| UnsafeTLS.go:351:13:351:38 | call to InsecureCipherSuites | UnsafeTLS.go:353:40:353:51 | selection of ID |
+| UnsafeTLS.go:353:19:353:52 | call to append | UnsafeTLS.go:353:26:353:37 | cipherSuites |
+| UnsafeTLS.go:353:19:353:52 | call to append | UnsafeTLS.go:355:25:355:36 | cipherSuites |
+| UnsafeTLS.go:353:26:353:37 | cipherSuites | UnsafeTLS.go:353:19:353:52 | call to append |
+| UnsafeTLS.go:353:40:353:51 | selection of ID | UnsafeTLS.go:353:19:353:52 | call to append |
 | UnsafeTLS.go:363:5:363:47 | selection of TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256 | UnsafeTLS.go:362:18:364:4 | slice literal |
 | UnsafeTLS.go:371:5:371:47 | selection of TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256 | UnsafeTLS.go:370:18:372:4 | slice literal |
 | UnsafeTLS.go:379:5:379:47 | selection of TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256 | UnsafeTLS.go:378:18:380:4 | slice literal |
@@ -94,9 +103,16 @@ nodes
 | UnsafeTLS.go:329:53:329:93 | selection of TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 | semmle.label | selection of TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 |
 | UnsafeTLS.go:334:13:334:38 | call to InsecureCipherSuites | semmle.label | call to InsecureCipherSuites |
 | UnsafeTLS.go:336:26:336:58 | call to append | semmle.label | call to append |
+| UnsafeTLS.go:336:54:336:57 | selection of ID | semmle.label | selection of ID |
 | UnsafeTLS.go:342:13:342:38 | call to InsecureCipherSuites | semmle.label | call to InsecureCipherSuites |
+| UnsafeTLS.go:344:19:344:44 | call to append | semmle.label | call to append |
+| UnsafeTLS.go:344:26:344:37 | cipherSuites | semmle.label | cipherSuites |
+| UnsafeTLS.go:344:40:344:43 | selection of ID | semmle.label | selection of ID |
 | UnsafeTLS.go:346:25:346:36 | cipherSuites | semmle.label | cipherSuites |
 | UnsafeTLS.go:351:13:351:38 | call to InsecureCipherSuites | semmle.label | call to InsecureCipherSuites |
+| UnsafeTLS.go:353:19:353:52 | call to append | semmle.label | call to append |
+| UnsafeTLS.go:353:26:353:37 | cipherSuites | semmle.label | cipherSuites |
+| UnsafeTLS.go:353:40:353:51 | selection of ID | semmle.label | selection of ID |
 | UnsafeTLS.go:355:25:355:36 | cipherSuites | semmle.label | cipherSuites |
 | UnsafeTLS.go:362:18:364:4 | slice literal | semmle.label | slice literal |
 | UnsafeTLS.go:363:5:363:47 | selection of TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256 | semmle.label | selection of TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256 |

--- a/go/ql/test/query-tests/Security/CWE-338/InsecureRandomness/InsecureRandomness.expected
+++ b/go/ql/test/query-tests/Security/CWE-338/InsecureRandomness/InsecureRandomness.expected
@@ -1,6 +1,8 @@
 edges
-| sample.go:15:24:15:63 | type conversion | sample.go:16:9:16:15 | slice expression |
-| sample.go:15:49:15:61 | call to Uint32 | sample.go:15:24:15:63 | type conversion |
+| sample.go:15:10:15:64 | call to Sum256 | sample.go:16:9:16:15 | slice expression |
+| sample.go:15:24:15:63 | type conversion | sample.go:15:10:15:64 | call to Sum256 |
+| sample.go:15:31:15:62 | call to Sprintf | sample.go:15:24:15:63 | type conversion |
+| sample.go:15:49:15:61 | call to Uint32 | sample.go:15:31:15:62 | call to Sprintf |
 | sample.go:16:9:16:15 | slice expression | sample.go:26:25:26:30 | call to Guid |
 | sample.go:33:2:33:6 | definition of nonce | sample.go:37:25:37:29 | nonce |
 | sample.go:33:2:33:6 | definition of nonce | sample.go:37:32:37:36 | nonce |
@@ -8,7 +10,9 @@ edges
 | sample.go:35:14:35:19 | random | sample.go:33:2:33:6 | definition of nonce |
 nodes
 | InsecureRandomness.go:12:18:12:40 | call to Intn | semmle.label | call to Intn |
+| sample.go:15:10:15:64 | call to Sum256 | semmle.label | call to Sum256 |
 | sample.go:15:24:15:63 | type conversion | semmle.label | type conversion |
+| sample.go:15:31:15:62 | call to Sprintf | semmle.label | call to Sprintf |
 | sample.go:15:49:15:61 | call to Uint32 | semmle.label | call to Uint32 |
 | sample.go:16:9:16:15 | slice expression | semmle.label | slice expression |
 | sample.go:26:25:26:30 | call to Guid | semmle.label | call to Guid |

--- a/go/ql/test/query-tests/Security/CWE-352/ConstantOauth2State.expected
+++ b/go/ql/test/query-tests/Security/CWE-352/ConstantOauth2State.expected
@@ -17,7 +17,8 @@ edges
 | ConstantOauth2State.go:210:9:210:42 | call to AuthCodeURL | ConstantOauth2State.go:211:54:211:56 | url |
 | ConstantOauth2State.go:232:9:232:42 | call to AuthCodeURL | ConstantOauth2State.go:233:28:233:30 | url |
 | ConstantOauth2State.go:239:17:239:39 | "http://localhost:8080" | ConstantOauth2State.go:249:9:249:12 | conf |
-| ConstantOauth2State.go:256:38:256:60 | "http://localhost:8080" | ConstantOauth2State.go:266:9:266:12 | conf |
+| ConstantOauth2State.go:256:17:256:67 | call to Sprintf | ConstantOauth2State.go:266:9:266:12 | conf |
+| ConstantOauth2State.go:256:38:256:60 | "http://localhost:8080" | ConstantOauth2State.go:256:17:256:67 | call to Sprintf |
 | ConstantOauth2State.go:272:17:272:21 | "oob" | ConstantOauth2State.go:282:9:282:12 | conf |
 nodes
 | ConstantOauth2State.go:20:26:20:32 | "state" | semmle.label | "state" |
@@ -46,6 +47,7 @@ nodes
 | ConstantOauth2State.go:239:17:239:39 | "http://localhost:8080" | semmle.label | "http://localhost:8080" |
 | ConstantOauth2State.go:249:9:249:12 | conf | semmle.label | conf |
 | ConstantOauth2State.go:249:26:249:41 | stateStringConst | semmle.label | stateStringConst |
+| ConstantOauth2State.go:256:17:256:67 | call to Sprintf | semmle.label | call to Sprintf |
 | ConstantOauth2State.go:256:38:256:60 | "http://localhost:8080" | semmle.label | "http://localhost:8080" |
 | ConstantOauth2State.go:266:9:266:12 | conf | semmle.label | conf |
 | ConstantOauth2State.go:266:26:266:41 | stateStringConst | semmle.label | stateStringConst |


### PR DESCRIPTION
It was highlighted in https://github.com/github/codeql/discussions/13415 that we don't put steps from functions modeled using `DataFlow::FunctionModel` or `TaintTracking::FunctionModel` in path summaries, which can be confusing. This PR does that, showing both inputs and outputs. Here are screenshots showing the option of just inputs as well.

Inputs only:
<img width="1793" alt="input-only" src="https://github.com/github/codeql/assets/62447351/e651bfe7-bd66-4721-8e18-45b42deb1888">

Both inputs and outputs:
<img width="1793" alt="both" src="https://github.com/github/codeql/assets/62447351/3ba66b19-9bf7-487a-b078-4be5105fd6ae">

Note: as discussed in https://github.com/github/codeql/discussions/13415, step 3 in the second picture goes back to the definition of the variable being tainted, in a way which is quite counter-intuitive. This is a consequence of our use of def-use flow.

The downside of doing both is that any path which goes through the definition of sample (step 3 in the second picture) will have it in the path explanation, even if the path doesn't go through the function that has been modeled. This should be fixed by https://github.com/github/codeql/pull/13473.