### PR TITLE
Go: improve path summary by changing post update nodes

### DIFF
--- a/go/ql/lib/semmle/go/controlflow/ControlFlowGraph.qll
+++ b/go/ql/lib/semmle/go/controlflow/ControlFlowGraph.qll
@@ -135,7 +135,7 @@ module ControlFlow {
       exists(IR::FieldTarget trg | trg = super.getLhs() |
         (
           trg.getBase() = base.asInstruction() or
-          trg.getBase() = MkImplicitDeref(base.asExpr())
+          trg.getBase() = IR::implicitDerefInstruction(base.asExpr())
         ) and
         trg.getField() = f and
         super.getRhs() = rhs.asInstruction()
@@ -155,7 +155,7 @@ module ControlFlow {
       exists(IR::ElementTarget trg | trg = super.getLhs() |
         (
           trg.getBase() = base.asInstruction() or
-          trg.getBase() = MkImplicitDeref(base.asExpr())
+          trg.getBase() = IR::implicitDerefInstruction(base.asExpr())
         ) and
         trg.getIndex() = index.asInstruction() and
         super.getRhs() = rhs.asInstruction()

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowNodes.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowNodes.qll
@@ -12,7 +12,7 @@ private newtype TNode =
   MkGlobalFunctionNode(Function f) or
   MkImplicitVarargsSlice(CallExpr c) { c.hasImplicitVarargs() } or
   MkFlowSummaryNode(FlowSummaryImpl::Private::SummaryNode sn) or
-  MkPostUpdateNode(IR::Instruction insn) { insn = updatedInstruction() }
+  MkPostUpdateNode(IR::Instruction insn) { insn = getAnUpdatedInstruction() }
 
 private IR::Instruction getADirectlyWrittenInstruction() {
   exists(IR::WriteTarget target, IR::Instruction base |
@@ -26,7 +26,7 @@ private IR::Instruction getADirectlyWrittenInstruction() {
   result = IR::evalExprInstruction(any(SendStmt s).getChannel())
 }
 
-private IR::Instruction getAccessPathPredecessor2(IR::Instruction insn) {
+private IR::Instruction getAccessPathPredecessor(IR::Instruction insn) {
   exists(Expr e | result = IR::evalExprInstruction(e) |
     e = insn.(IR::EvalInstruction).getExpr().(UnaryExpr).getOperand()
     or
@@ -39,16 +39,16 @@ private IR::Instruction getAccessPathPredecessor2(IR::Instruction insn) {
 }
 
 private IR::Instruction getAWrittenInstruction() {
-  result = getAccessPathPredecessor2*(getADirectlyWrittenInstruction())
+  result = getAccessPathPredecessor*(getADirectlyWrittenInstruction())
 }
 
-private IR::Instruction updatedInstruction() {
-  result = IR::evalExprInstruction(updatedExpr()) or
+private IR::Instruction getAnUpdatedInstruction() {
+  result = IR::evalExprInstruction(getAnUpdatedExpr()) or
   result instanceof IR::EvalImplicitDerefInstruction or
   result = getAWrittenInstruction()
 }
 
-private Expr updatedExpr() {
+private Expr getAnUpdatedExpr() {
   result instanceof AddressExpr
   or
   result = any(AddressExpr e).getOperand()
@@ -769,7 +769,7 @@ module Public {
   }
 
   private class UpdateNode extends InstructionNode {
-    UpdateNode() { insn = updatedInstruction() }
+    UpdateNode() { insn = getAnUpdatedInstruction() }
   }
 
   /**

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowPrivate.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowPrivate.qll
@@ -41,9 +41,10 @@ OutNode getAnOutNode(DataFlowCall call, ReturnKind kind) {
 
 /**
  * Holds if data flows from `nodeFrom` to `nodeTo` in exactly one local
- * (intra-procedural) step, not taking function models into account.
+ * (intra-procedural) step, not taking function models into account, and also
+ * excluding flow from post-update nodes to their successors.
  */
-predicate basicLocalFlowStep(Node nodeFrom, Node nodeTo) {
+predicate basicLocalFlowStep0(Node nodeFrom, Node nodeTo) {
   // Instruction -> Instruction
   exists(Expr pred, Expr succ |
     succ.(LogicalBinaryExpr).getAnOperand() = pred or
@@ -87,6 +88,17 @@ predicate basicLocalFlowStep(Node nodeFrom, Node nodeTo) {
   // GlobalFunctionNode -> use
   nodeFrom =
     any(GlobalFunctionNode fn | fn.getFunction() = nodeTo.asExpr().(FunctionName).getTarget())
+}
+
+/**
+ * Holds if data flows from `nodeFrom` to `nodeTo` in exactly one local
+ * (intra-procedural) step, not taking function models into account.
+ */
+predicate basicLocalFlowStep(Node nodeFrom, Node nodeTo) {
+  basicLocalFlowStep0(nodeFrom, nodeTo)
+  or
+  // post-update node -> successor
+  nodeTo = nodeFrom.(DefaultPostUpdateNode).getSuccessor()
 }
 
 pragma[noinline]


### PR DESCRIPTION
Cf. [this comment](https://github.com/github/codeql/discussions/13415#discussioncomment-6177268) and the surrounding discussion. 

This PR adds new data-flow nodes which are used for post-update nodes. This means that the post-update node will now be in the expected place. This should make path summaries easier to understand.
