### PR TITLE
C#/Go/Java/JS/Python/Ruby: Update the description and qhelp of the Zipslip query

### DIFF
--- a/csharp/ql/src/Security Features/CWE-022/ZipSlip.qhelp
+++ b/csharp/ql/src/Security Features/CWE-022/ZipSlip.qhelp
@@ -3,10 +3,9 @@
   "qhelp.dtd">
 <qhelp>
 <overview>
-<p>Accessing filesystem paths built from the name of an archive entry without validating that the
-destination file path is within the destination directory can allow an attacker to access 
-unexpected resources, due to the possible presence of directory traversal elements (<code>..</code>) in
-archive paths.</p>
+<p>Extracting files from a malicious zip file, or similar type of archive,
+is at risk of directory traversal attacks if filenames from the archive are
+not properly validated.</p>
 
 <p>Zip archives contain archive entries representing each file in the archive. These entries
 include a file path for the entry, but these file paths are not restricted and may contain

--- a/csharp/ql/src/Security Features/CWE-022/ZipSlip.qhelp
+++ b/csharp/ql/src/Security Features/CWE-022/ZipSlip.qhelp
@@ -3,16 +3,16 @@
   "qhelp.dtd">
 <qhelp>
 <overview>
-<p>Extracting files from a malicious zip archive without validating that the destination file path
-is within the destination directory can cause files outside the destination directory to be
-overwritten, due to the possible presence of directory traversal elements (<code>..</code>) in
+<p>Accessing filesystem paths built from the name of an archive entry without validating that the
+destination file path is within the destination directory can allow an attacker to access 
+unexpected resources, due to the possible presence of directory traversal elements (<code>..</code>) in
 archive paths.</p>
 
 <p>Zip archives contain archive entries representing each file in the archive. These entries
 include a file path for the entry, but these file paths are not restricted and may contain
 unexpected special elements such as the directory traversal element (<code>..</code>). If these
-file paths are used to determine an output file to write the contents of the archive item to, then
-the file may be written to an unexpected location. This can result in sensitive information being
+file paths are used to create a filesystem path, then a file operation may happen in an 
+unexpected location. This can result in sensitive information being
 revealed or deleted, or an attacker being able to influence behavior by modifying unexpected
 files.</p>
 

--- a/csharp/ql/src/Security Features/CWE-022/ZipSlip.ql
+++ b/csharp/ql/src/Security Features/CWE-022/ZipSlip.ql
@@ -1,8 +1,8 @@
 /**
  * @name Arbitrary file access during archive extraction ("Zip Slip")
- * @description Accessing filesystem paths built from the name of an archive entry without
+ * @description Extracting files from a malicious ZIP file, or similar type of archive, without
  *              validating that the destination file path is within the destination directory
- *              can allow an attacker to access unexpected resources.
+ *              can allow an attacker to unexpectedly gain access to resources.
  * @kind path-problem
  * @id cs/zipslip
  * @problem.severity error

--- a/csharp/ql/src/Security Features/CWE-022/ZipSlip.ql
+++ b/csharp/ql/src/Security Features/CWE-022/ZipSlip.ql
@@ -1,8 +1,8 @@
 /**
- * @name Arbitrary file write during zip extraction ("Zip Slip")
- * @description Extracting files from a malicious zip archive without validating that the
- *              destination file path is within the destination directory can cause files outside
- *              the destination directory to be overwritten.
+ * @name Arbitrary file access during archive extraction ("Zip Slip")
+ * @description Accessing filesystem paths built from the name of an archive entry without
+ *              validating that the destination file path is within the destination directory
+ *              can allow an attacker to access unexpected resources.
  * @kind path-problem
  * @id cs/zipslip
  * @problem.severity error

--- a/csharp/ql/src/change-notes/2023-06-16-zipslip-rename.md
+++ b/csharp/ql/src/change-notes/2023-06-16-zipslip-rename.md
@@ -1,0 +1,4 @@
+---
+category: fix
+---
+* The query "Arbitrary file write during zip extraction ("Zip Slip")" (`cs/zipslip`) has been renamed to "Arbitrary file access during archive extraction ("Zip Slip")".

--- a/csharp/ql/src/change-notes/2023-06-16-zipslip-rename.md
+++ b/csharp/ql/src/change-notes/2023-06-16-zipslip-rename.md
@@ -1,4 +1,4 @@
 ---
 category: fix
 ---
-* The query "Arbitrary file write during zip extraction ("Zip Slip")" (`cs/zipslip`) has been renamed to "Arbitrary file access during archive extraction ("Zip Slip")".
+* The query "Arbitrary file write during zip extraction ("Zip Slip")" (`cs/zipslip`) has been renamed to "Arbitrary file access during archive extraction ("Zip Slip")."

--- a/go/ql/src/Security/CWE-022/ZipSlip.qhelp
+++ b/go/ql/src/Security/CWE-022/ZipSlip.qhelp
@@ -5,9 +5,9 @@
 
 <overview>
 <p>
-Extracting files from a malicious zip archive without validating that the destination file path
-is within the destination directory can cause files outside the destination directory to be
-overwritten, due to the possible presence of directory traversal elements (<code>..</code>) in
+Accessing filesystem paths built from the name of an archive entry without validating that the
+destination file path is within the destination directory can allow an attacker to access 
+unexpected resources, due to the possible presence of directory traversal elements (<code>..</code>) in
 archive paths.
 </p>
 
@@ -15,8 +15,8 @@ archive paths.
 Zip archives contain archive entries representing each file in the archive. These entries
 include a file path for the entry, but these file paths are not restricted and may contain
 unexpected special elements such as the directory traversal element (<code>..</code>). If these
-file paths are used to determine which output file the contents of an archive item should be written to, then
-the file may be written to an unexpected location. This can result in sensitive information being
+file paths are used to create a filesystem path, then a file operation may happen in an 
+unexpected location. This can result in sensitive information being
 revealed or deleted, or an attacker being able to influence behavior by modifying unexpected
 files.
 </p>

--- a/go/ql/src/Security/CWE-022/ZipSlip.qhelp
+++ b/go/ql/src/Security/CWE-022/ZipSlip.qhelp
@@ -5,9 +5,9 @@
 
 <overview>
 <p>
-Accessing filesystem paths built from the name of an archive entry without validating that the
-destination file path is within the destination directory can allow an attacker to access 
-unexpected resources, due to the possible presence of directory traversal elements (<code>..</code>) in
+Extracting files from a malicious zip file, or similar type of archive,
+is at risk of directory traversal attacks if filenames from the archive are
+not properly validated.
 archive paths.
 </p>
 

--- a/go/ql/src/Security/CWE-022/ZipSlip.ql
+++ b/go/ql/src/Security/CWE-022/ZipSlip.ql
@@ -1,8 +1,8 @@
 /**
- * @name Arbitrary file write during zip extraction ("zip slip")
- * @description Extracting files from a malicious zip archive without validating that the
- *              destination file path is within the destination directory can cause files outside
- *              the destination directory to be overwritten.
+ * @name Arbitrary file access during archive extraction ("Zip Slip")
+ * @description Accessing filesystem paths built from the name of an archive entry without
+ *              validating that the destination file path is within the destination directory
+ *              can allow an attacker to access unexpected resources.
  * @kind path-problem
  * @id go/zipslip
  * @problem.severity error

--- a/go/ql/src/Security/CWE-022/ZipSlip.ql
+++ b/go/ql/src/Security/CWE-022/ZipSlip.ql
@@ -1,8 +1,8 @@
 /**
  * @name Arbitrary file access during archive extraction ("Zip Slip")
- * @description Accessing filesystem paths built from the name of an archive entry without
+ * @description Extracting files from a malicious ZIP file, or similar type of archive, without
  *              validating that the destination file path is within the destination directory
- *              can allow an attacker to access unexpected resources.
+ *              can allow an attacker to unexpectedly gain access to resources.
  * @kind path-problem
  * @id go/zipslip
  * @problem.severity error

--- a/go/ql/src/change-notes/2023-06-16-zipslip-rename.md
+++ b/go/ql/src/change-notes/2023-06-16-zipslip-rename.md
@@ -1,0 +1,4 @@
+---
+category: fix
+---
+* The query "Arbitrary file write during zip extraction ("zip slip")" (`go/zipslip`) has been renamed to "Arbitrary file access during archive extraction ("Zip Slip")".

--- a/go/ql/src/change-notes/2023-06-16-zipslip-rename.md
+++ b/go/ql/src/change-notes/2023-06-16-zipslip-rename.md
@@ -1,4 +1,4 @@
 ---
 category: fix
 ---
-* The query "Arbitrary file write during zip extraction ("zip slip")" (`go/zipslip`) has been renamed to "Arbitrary file access during archive extraction ("Zip Slip")".
+* The query "Arbitrary file write during zip extraction ("zip slip")" (`go/zipslip`) has been renamed to "Arbitrary file access during archive extraction ("Zip Slip")."

--- a/java/ql/src/Security/CWE/CWE-022/ZipSlip.qhelp
+++ b/java/ql/src/Security/CWE/CWE-022/ZipSlip.qhelp
@@ -3,10 +3,9 @@
   "qhelp.dtd">
 <qhelp>
 <overview>
-<p>Accessing filesystem paths built from the name of an archive entry without validating that the
-destination file path is within the destination directory can allow an attacker to access 
-unexpected resources, due to the possible presence of directory traversal elements (<code>..</code>) in
-archive paths.</p>
+<p>Extracting files from a malicious zip file, or similar type of archive,
+is at risk of directory traversal attacks if filenames from the archive are
+not properly validated.</p>
 
 <p>Zip archives contain archive entries representing each file in the archive. These entries
 include a file path for the entry, but these file paths are not restricted and may contain

--- a/java/ql/src/Security/CWE/CWE-022/ZipSlip.qhelp
+++ b/java/ql/src/Security/CWE/CWE-022/ZipSlip.qhelp
@@ -3,17 +3,16 @@
   "qhelp.dtd">
 <qhelp>
 <overview>
-<p>Extracting files from a malicious zip archive (or another archive format)
-without validating that the destination file path
-is within the destination directory can cause files outside the destination directory to be
-overwritten, due to the possible presence of directory traversal elements (<code>..</code>) in
+<p>Accessing filesystem paths built from the name of an archive entry without validating that the
+destination file path is within the destination directory can allow an attacker to access 
+unexpected resources, due to the possible presence of directory traversal elements (<code>..</code>) in
 archive paths.</p>
 
 <p>Zip archives contain archive entries representing each file in the archive. These entries
 include a file path for the entry, but these file paths are not restricted and may contain
 unexpected special elements such as the directory traversal element (<code>..</code>). If these
-file paths are used to determine an output file to write the contents of the archive item to, then
-the file may be written to an unexpected location. This can result in sensitive information being
+file paths are used to create a filesystem path, then a file operation may happen in an 
+unexpected location. This can result in sensitive information being
 revealed or deleted, or an attacker being able to influence behavior by modifying unexpected
 files.</p>
 

--- a/java/ql/src/Security/CWE/CWE-022/ZipSlip.ql
+++ b/java/ql/src/Security/CWE/CWE-022/ZipSlip.ql
@@ -1,8 +1,8 @@
 /**
  * @name Arbitrary file access during archive extraction ("Zip Slip")
- * @description Accessing filesystem paths built from the name of an archive entry without
+ * @description Extracting files from a malicious ZIP file, or similar type of archive, without
  *              validating that the destination file path is within the destination directory
- *              can allow an attacker to access unexpected resources.
+ *              can allow an attacker to unexpectedly gain access to resources.
  * @kind path-problem
  * @id java/zipslip
  * @problem.severity error

--- a/java/ql/src/Security/CWE/CWE-022/ZipSlip.ql
+++ b/java/ql/src/Security/CWE/CWE-022/ZipSlip.ql
@@ -1,8 +1,8 @@
 /**
- * @name Arbitrary file write during archive extraction ("Zip Slip")
- * @description Extracting files from a malicious archive without validating that the
- *              destination file path is within the destination directory can cause files outside
- *              the destination directory to be overwritten.
+ * @name Arbitrary file access during archive extraction ("Zip Slip")
+ * @description Accessing filesystem paths built from the name of an archive entry without
+ *              validating that the destination file path is within the destination directory
+ *              can allow an attacker to access unexpected resources.
  * @kind path-problem
  * @id java/zipslip
  * @problem.severity error

--- a/java/ql/src/change-notes/2023-06-16-zipslip-rename.md
+++ b/java/ql/src/change-notes/2023-06-16-zipslip-rename.md
@@ -1,0 +1,4 @@
+---
+category: fix
+---
+* The query "Arbitrary file write during archive extraction ("Zip Slip")" (`java/zipslip`) has been renamed to "Arbitrary file access during archive extraction ("Zip Slip")".

--- a/java/ql/src/change-notes/2023-06-16-zipslip-rename.md
+++ b/java/ql/src/change-notes/2023-06-16-zipslip-rename.md
@@ -1,4 +1,4 @@
 ---
 category: fix
 ---
-* The query "Arbitrary file write during archive extraction ("Zip Slip")" (`java/zipslip`) has been renamed to "Arbitrary file access during archive extraction ("Zip Slip")".
+* The query "Arbitrary file write during archive extraction ("Zip Slip")" (`java/zipslip`) has been renamed to "Arbitrary file access during archive extraction ("Zip Slip")."

--- a/javascript/ql/src/Security/CWE-022/ZipSlip.qhelp
+++ b/javascript/ql/src/Security/CWE-022/ZipSlip.qhelp
@@ -4,9 +4,9 @@
 <qhelp>
 
 <overview>
-<p>Accessing filesystem paths built from the name of an archive entry without validating that the
-destination file path is within the destination directory can allow an attacker to access 
-unexpected resources, due to the possible presence of directory traversal elements (<code>..</code>) in
+<p>Extracting files from a malicious zip file, or similar type of archive,
+is at risk of directory traversal attacks if filenames from the archive are
+not properly validated.
 archive paths.</p>
 
 <p>Zip archives contain archive entries representing each file in the archive. These entries

--- a/javascript/ql/src/Security/CWE-022/ZipSlip.qhelp
+++ b/javascript/ql/src/Security/CWE-022/ZipSlip.qhelp
@@ -4,16 +4,16 @@
 <qhelp>
 
 <overview>
-<p>Extracting files from a malicious zip archive without validating that the destination file path
-is within the destination directory can cause files outside the destination directory to be
-overwritten, due to the possible presence of directory traversal elements (<code>..</code>) in
+<p>Accessing filesystem paths built from the name of an archive entry without validating that the
+destination file path is within the destination directory can allow an attacker to access 
+unexpected resources, due to the possible presence of directory traversal elements (<code>..</code>) in
 archive paths.</p>
 
 <p>Zip archives contain archive entries representing each file in the archive. These entries
 include a file path for the entry, but these file paths are not restricted and may contain
 unexpected special elements such as the directory traversal element (<code>..</code>). If these
-file paths are used to determine an output file to write the contents of the archive item to, then
-the file may be written to an unexpected location. This can result in sensitive information being
+file paths are used to create a filesystem path, then a file operation may happen in an 
+unexpected location. This can result in sensitive information being
 revealed or deleted, or an attacker being able to influence behavior by modifying unexpected
 files.</p>
 

--- a/javascript/ql/src/Security/CWE-022/ZipSlip.ql
+++ b/javascript/ql/src/Security/CWE-022/ZipSlip.ql
@@ -1,8 +1,8 @@
 /**
  * @name Arbitrary file access during archive extraction ("Zip Slip")
- * @description Accessing filesystem paths built from the name of an archive entry without
+ * @description Extracting files from a malicious ZIP file, or similar type of archive, without
  *              validating that the destination file path is within the destination directory
- *              can allow an attacker to access unexpected resources.
+ *              can allow an attacker to unexpectedly gain access to resources.
  * @kind path-problem
  * @id js/zipslip
  * @problem.severity error

--- a/javascript/ql/src/Security/CWE-022/ZipSlip.ql
+++ b/javascript/ql/src/Security/CWE-022/ZipSlip.ql
@@ -1,8 +1,8 @@
 /**
- * @name Arbitrary file write during zip extraction ("Zip Slip")
- * @description Extracting files from a malicious zip archive without validating that the
- *              destination file path is within the destination directory can cause files outside
- *              the destination directory to be overwritten.
+ * @name Arbitrary file access during archive extraction ("Zip Slip")
+ * @description Accessing filesystem paths built from the name of an archive entry without
+ *              validating that the destination file path is within the destination directory
+ *              can allow an attacker to access unexpected resources.
  * @kind path-problem
  * @id js/zipslip
  * @problem.severity error

--- a/javascript/ql/src/change-notes/2023-06-16-zipslip-rename.md
+++ b/javascript/ql/src/change-notes/2023-06-16-zipslip-rename.md
@@ -1,4 +1,4 @@
 ---
 category: fix
 ---
-* The query "Arbitrary file write during zip extraction ("Zip Slip")" (`js/zipslip`) has been renamed to "Arbitrary file access during archive extraction ("Zip Slip")".
+* The query "Arbitrary file write during zip extraction ("Zip Slip")" (`js/zipslip`) has been renamed to "Arbitrary file access during archive extraction ("Zip Slip")."

--- a/javascript/ql/src/change-notes/2023-06-16-zipslip-rename.md
+++ b/javascript/ql/src/change-notes/2023-06-16-zipslip-rename.md
@@ -1,0 +1,4 @@
+---
+category: fix
+---
+* The query "Arbitrary file write during zip extraction ("Zip Slip")" (`js/zipslip`) has been renamed to "Arbitrary file access during archive extraction ("Zip Slip")".

--- a/python/ql/src/change-notes/2023-06-16-zipslip-rename.md
+++ b/python/ql/src/change-notes/2023-06-16-zipslip-rename.md
@@ -1,4 +1,4 @@
 ---
 category: fix
 ---
-* The query "Arbitrary file write during archive extraction ("Zip Slip")" (`py/zipslip`) has been renamed to "Arbitrary file access during archive extraction ("Zip Slip")".
+* The query "Arbitrary file write during archive extraction ("Zip Slip")" (`py/zipslip`) has been renamed to "Arbitrary file access during archive extraction ("Zip Slip")."

--- a/python/ql/src/change-notes/2023-06-16-zipslip-rename.md
+++ b/python/ql/src/change-notes/2023-06-16-zipslip-rename.md
@@ -1,0 +1,4 @@
+---
+category: fix
+---
+* The query "Arbitrary file write during archive extraction ("Zip Slip")" (`py/zipslip`) has been renamed to "Arbitrary file access during archive extraction ("Zip Slip")".

--- a/python/ql/src/experimental/Security/CWE-022/ZipSlip.qhelp
+++ b/python/ql/src/experimental/Security/CWE-022/ZipSlip.qhelp
@@ -4,16 +4,16 @@
 <qhelp>
 
 <overview>
-<p>Extracting files from a malicious zip archive without validating that the destination file path
-is within the destination directory can cause files outside the destination directory to be
-overwritten, due to the possible presence of directory traversal elements (<code>..</code>) in
+<p>Accessing filesystem paths built from the name of an archive entry without validating that the
+destination file path is within the destination directory can allow an attacker to access 
+unexpected resources, due to the possible presence of directory traversal elements (<code>..</code>) in
 archive paths.</p>
 
 <p>Zip archives contain archive entries representing each file in the archive. These entries
 include a file path for the entry, but these file paths are not restricted and may contain
 unexpected special elements such as the directory traversal element (<code>..</code>). If these
-file paths are used to determine an output file to write the contents of the archive item to, then
-the file may be written to an unexpected location. This can result in sensitive information being
+file paths are used to create a filesystem path, then a file operation may happen in an 
+unexpected location. This can result in sensitive information being
 revealed or deleted, or an attacker being able to influence behavior by modifying unexpected
 files.</p>
 

--- a/python/ql/src/experimental/Security/CWE-022/ZipSlip.qhelp
+++ b/python/ql/src/experimental/Security/CWE-022/ZipSlip.qhelp
@@ -4,10 +4,9 @@
 <qhelp>
 
 <overview>
-<p>Accessing filesystem paths built from the name of an archive entry without validating that the
-destination file path is within the destination directory can allow an attacker to access 
-unexpected resources, due to the possible presence of directory traversal elements (<code>..</code>) in
-archive paths.</p>
+<p>Extracting files from a malicious zip file, or similar type of archive,
+is at risk of directory traversal attacks if filenames from the archive are
+not properly validated.</p>
 
 <p>Zip archives contain archive entries representing each file in the archive. These entries
 include a file path for the entry, but these file paths are not restricted and may contain

--- a/python/ql/src/experimental/Security/CWE-022/ZipSlip.ql
+++ b/python/ql/src/experimental/Security/CWE-022/ZipSlip.ql
@@ -1,8 +1,8 @@
 /**
  * @name Arbitrary file access during archive extraction ("Zip Slip")
- * @description Accessing filesystem paths built from the name of an archive entry without
+ * @description Extracting files from a malicious ZIP file, or similar type of archive, without
  *              validating that the destination file path is within the destination directory
- *              can allow an attacker to access unexpected resources.
+ *              can allow an attacker to unexpectedly gain access to resources.
  * @kind path-problem
  * @id py/zipslip
  * @problem.severity error

--- a/python/ql/src/experimental/Security/CWE-022/ZipSlip.ql
+++ b/python/ql/src/experimental/Security/CWE-022/ZipSlip.ql
@@ -1,8 +1,8 @@
 /**
- * @name Arbitrary file write during archive extraction ("Zip Slip")
- * @description Extracting files from a malicious archive without validating that the
- *              destination file path is within the destination directory can cause files outside
- *              the destination directory to be overwritten.
+ * @name Arbitrary file access during archive extraction ("Zip Slip")
+ * @description Accessing filesystem paths built from the name of an archive entry without
+ *              validating that the destination file path is within the destination directory
+ *              can allow an attacker to access unexpected resources.
  * @kind path-problem
  * @id py/zipslip
  * @problem.severity error

--- a/ruby/ql/src/change-notes/2023-06-16-zipslip-rename.md
+++ b/ruby/ql/src/change-notes/2023-06-16-zipslip-rename.md
@@ -1,4 +1,4 @@
 ---
 category: fix
 ---
-* The experimental query "Arbitrary file write during zipfile/tarfile extraction" (`ruby/zipslip`) has been renamed to "Arbitrary file access during archive extraction ("Zip Slip")".
+* The experimental query "Arbitrary file write during zipfile/tarfile extraction" (`ruby/zipslip`) has been renamed to "Arbitrary file access during archive extraction ("Zip Slip")."

--- a/ruby/ql/src/change-notes/2023-06-16-zipslip-rename.md
+++ b/ruby/ql/src/change-notes/2023-06-16-zipslip-rename.md
@@ -1,0 +1,4 @@
+---
+category: fix
+---
+* The experimental query "Arbitrary file write during zipfile/tarfile extraction" (`ruby/zipslip`) has been renamed to "Arbitrary file access during archive extraction ("Zip Slip")".

--- a/ruby/ql/src/experimental/cwe-022-zipslip/ZipSlip.qhelp
+++ b/ruby/ql/src/experimental/cwe-022-zipslip/ZipSlip.qhelp
@@ -4,16 +4,16 @@
 <qhelp>
 
 <overview>
-<p>Extracting files from a malicious tar archive without validating that the destination file path
-is within the destination directory can cause files outside the destination directory to be
-overwritten, due to the possible presence of directory traversal elements (<code>..</code>) in
+<p>Accessing filesystem paths built from the name of an archive entry without validating that the
+destination file path is within the destination directory can allow an attacker to access 
+unexpected resources, due to the possible presence of directory traversal elements (<code>..</code>) in
 archive paths.</p>
 
 <p>Tar archives contain archive entries representing each file in the archive. These entries
 include a file path for the entry, but these file paths are not restricted and may contain
 unexpected special elements such as the directory traversal element (<code>..</code>). If these
-file paths are used to determine an output file to write the contents of the archive item to, then
-the file may be written to an unexpected location. This can result in sensitive information being
+file paths are used to create a filesystem path, then a file operation may happen in an 
+unexpected location. This can result in sensitive information being
 revealed or deleted, or an attacker being able to influence behavior by modifying unexpected
 files.</p>
 

--- a/ruby/ql/src/experimental/cwe-022-zipslip/ZipSlip.qhelp
+++ b/ruby/ql/src/experimental/cwe-022-zipslip/ZipSlip.qhelp
@@ -4,10 +4,9 @@
 <qhelp>
 
 <overview>
-<p>Accessing filesystem paths built from the name of an archive entry without validating that the
-destination file path is within the destination directory can allow an attacker to access 
-unexpected resources, due to the possible presence of directory traversal elements (<code>..</code>) in
-archive paths.</p>
+<p>Extracting files from a malicious zip file, or similar type of archive,
+is at risk of directory traversal attacks if filenames from the archive are
+not properly validated.</p>
 
 <p>Tar archives contain archive entries representing each file in the archive. These entries
 include a file path for the entry, but these file paths are not restricted and may contain

--- a/ruby/ql/src/experimental/cwe-022-zipslip/ZipSlip.ql
+++ b/ruby/ql/src/experimental/cwe-022-zipslip/ZipSlip.ql
@@ -1,8 +1,8 @@
 /**
- * @name Arbitrary file write during zipfile/tarfile extraction
- * @description Extracting files from a malicious tar archive without validating that the
- *              destination file path is within the destination directory can cause files outside
- *              the destination directory to be overwritten.
+ * @name Arbitrary file access during archive extraction ("Zip Slip")
+ * @description Accessing filesystem paths built from the name of an archive entry without
+ *              validating that the destination file path is within the destination directory
+ *              can allow an attacker to access unexpected resources.
  * @kind path-problem
  * @id rb/zip-slip
  * @problem.severity error

--- a/ruby/ql/src/experimental/cwe-022-zipslip/ZipSlip.ql
+++ b/ruby/ql/src/experimental/cwe-022-zipslip/ZipSlip.ql
@@ -1,8 +1,8 @@
 /**
  * @name Arbitrary file access during archive extraction ("Zip Slip")
- * @description Accessing filesystem paths built from the name of an archive entry without
+ * @description Extracting files from a malicious ZIP file, or similar type of archive, without
  *              validating that the destination file path is within the destination directory
- *              can allow an attacker to access unexpected resources.
+ *              can allow an attacker to unexpectedly gain access to resources.
  * @kind path-problem
  * @id rb/zip-slip
  * @problem.severity error


### PR DESCRIPTION
All filesystem operations, not just writes, with paths built from untrusted archive entry names are dangerous.