### PR TITLE
Java: clean up mad kinds use

### DIFF
--- a/java/ql/src/Telemetry/AutomodelApplicationModeCharacteristics.qll
+++ b/java/ql/src/Telemetry/AutomodelApplicationModeCharacteristics.qll
@@ -59,13 +59,13 @@ module ApplicationCandidatesImpl implements SharedCharacteristics::CandidateSig 
       e.getType() instanceof NumberType
     )
     or
-    t instanceof AutomodelEndpointTypes::TaintedPathSinkType and
+    t instanceof AutomodelEndpointTypes::PathInjectionSinkType and
     e instanceof PathSanitizer::PathInjectionSanitizer
   }
 
   RelatedLocation asLocation(Endpoint e) { result = e.asExpr() }
 
-  predicate isKnownKind = AutomodelJavaUtil::isKnownKind/3;
+  predicate isKnownKind = AutomodelJavaUtil::isKnownKind/2;
 
   predicate isSink(Endpoint e, string kind) {
     exists(string package, string type, string name, string signature, string ext, string input |

--- a/java/ql/src/Telemetry/AutomodelApplicationModeCharacteristics.qll
+++ b/java/ql/src/Telemetry/AutomodelApplicationModeCharacteristics.qll
@@ -79,7 +79,7 @@ module ApplicationCandidatesImpl implements SharedCharacteristics::CandidateSig 
   predicate isNeutral(Endpoint e) {
     exists(string package, string type, string name, string signature |
       sinkSpec(e, package, type, name, signature, _, _) and
-      ExternalFlow::neutralModel(package, type, name, [signature, ""], _, _)
+      ExternalFlow::neutralModel(package, type, name, [signature, ""], "sink", _)
     )
   }
 

--- a/java/ql/src/Telemetry/AutomodelEndpointTypes.qll
+++ b/java/ql/src/Telemetry/AutomodelEndpointTypes.qll
@@ -40,18 +40,18 @@ class NegativeSinkType extends SinkType {
 }
 
 /** A sink relevant to the SQL injection query */
-class SqlSinkType extends SinkType {
-  SqlSinkType() { this = "sql" }
+class SqlInjectionSinkType extends SinkType {
+  SqlInjectionSinkType() { this = "sql-injection" }
 }
 
 /** A sink relevant to the tainted path injection query. */
-class TaintedPathSinkType extends SinkType {
-  TaintedPathSinkType() { this = "tainted-path" }
+class PathInjectionSinkType extends SinkType {
+  PathInjectionSinkType() { this = "path-injection" }
 }
 
 /** A sink relevant to the SSRF query. */
 class RequestForgerySinkType extends SinkType {
-  RequestForgerySinkType() { this = "ssrf" }
+  RequestForgerySinkType() { this = "request-forgery" }
 }
 
 /** A sink relevant to the command injection query. */

--- a/java/ql/src/Telemetry/AutomodelFrameworkModeCharacteristics.qll
+++ b/java/ql/src/Telemetry/AutomodelFrameworkModeCharacteristics.qll
@@ -60,7 +60,7 @@ module FrameworkCandidatesImpl implements SharedCharacteristics::CandidateSig {
   predicate isNeutral(Endpoint e) {
     exists(string package, string type, string name, string signature |
       sinkSpec(e, package, type, name, signature, _, _) and
-      ExternalFlow::neutralModel(package, type, name, [signature, ""], _, _)
+      ExternalFlow::neutralModel(package, type, name, [signature, ""], "sink", _)
     )
   }
 

--- a/java/ql/src/Telemetry/AutomodelFrameworkModeCharacteristics.qll
+++ b/java/ql/src/Telemetry/AutomodelFrameworkModeCharacteristics.qll
@@ -48,7 +48,7 @@ module FrameworkCandidatesImpl implements SharedCharacteristics::CandidateSig {
 
   RelatedLocation asLocation(Endpoint e) { result = e.asParameter() }
 
-  predicate isKnownKind = AutomodelJavaUtil::isKnownKind/3;
+  predicate isKnownKind = AutomodelJavaUtil::isKnownKind/2;
 
   predicate isSink(Endpoint e, string kind) {
     exists(string package, string type, string name, string signature, string ext, string input |

--- a/java/ql/src/Telemetry/AutomodelJavaUtil.qll
+++ b/java/ql/src/Telemetry/AutomodelJavaUtil.qll
@@ -27,31 +27,17 @@ class DollarAtString extends string {
  * Holds for all combinations of MaD kinds (`kind`) and their human readable
  * descriptions.
  */
-predicate isKnownKind(
-  string kind, string humanReadableKind, AutomodelEndpointTypes::EndpointType type
-) {
-  kind = "read-file" and
-  humanReadableKind = "read file" and
-  type instanceof AutomodelEndpointTypes::TaintedPathSinkType
+predicate isKnownKind(string kind, AutomodelEndpointTypes::EndpointType type) {
+  kind = "path-injection" and
+  type instanceof AutomodelEndpointTypes::PathInjectionSinkType
   or
-  kind = "create-file" and
-  humanReadableKind = "create file" and
-  type instanceof AutomodelEndpointTypes::TaintedPathSinkType
+  kind = "sql-injection" and
+  type instanceof AutomodelEndpointTypes::SqlInjectionSinkType
   or
-  kind = "sql" and
-  humanReadableKind = "mad modeled sql" and
-  type instanceof AutomodelEndpointTypes::SqlSinkType
-  or
-  kind = "open-url" and
-  humanReadableKind = "open url" and
-  type instanceof AutomodelEndpointTypes::RequestForgerySinkType
-  or
-  kind = "jdbc-url" and
-  humanReadableKind = "jdbc url" and
+  kind = "request-forgery" and
   type instanceof AutomodelEndpointTypes::RequestForgerySinkType
   or
   kind = "command-injection" and
-  humanReadableKind = "command injection" and
   type instanceof AutomodelEndpointTypes::CommandInjectionSinkType
 }
 

--- a/java/ql/src/Telemetry/AutomodelSharedCharacteristics.qll
+++ b/java/ql/src/Telemetry/AutomodelSharedCharacteristics.qll
@@ -50,7 +50,7 @@ signature module CandidateSig {
   /**
    * Defines what MaD kinds are known, and what endpoint type they correspond to.
    */
-  predicate isKnownKind(string kind, string humanReadableLabel, EndpointType type);
+  predicate isKnownKind(string kind, EndpointType type);
 
   /**
    * Holds if `e` is a flow sanitizer, and has type `t`.
@@ -276,7 +276,11 @@ module SharedCharacteristics<CandidateSig Candidate> {
       string madKind;
       Candidate::EndpointType endpointType;
 
-      KnownSinkCharacteristic() { Candidate::isKnownKind(madKind, this, endpointType) }
+      KnownSinkCharacteristic() {
+        Candidate::isKnownKind(madKind, endpointType) and
+        // bind "this" to a unique string differing from that of the SinkType classes
+        this = madKind + "-characteristic"
+      }
 
       override predicate appliesToEndpoint(Candidate::Endpoint e) { Candidate::isSink(e, madKind) }
 


### PR DESCRIPTION
This PR refactors code relevant to `automodel` to only use the native mad kinds.

I wonder: should we put in test for the existing queries with `.expected` files for the extraction queries?