### PR TITLE
Shared: use final class aliases to use `extends` instead of `instanceof` in the shared libraries

### DIFF
--- a/shared/regex/codeql/regex/OverlyLargeRangeQuery.qll
+++ b/shared/regex/codeql/regex/OverlyLargeRangeQuery.qll
@@ -82,8 +82,10 @@ module Make<RegexTreeViewSig TreeImpl> {
   bindingset[char]
   int toCodePoint(string char) { result.toUnicode() = char }
 
+  final private class FinalRegExpCharacterRange = RegExpCharacterRange;
+
   /** A character range that appears to be overly wide. */
-  class OverlyWideRange instanceof RegExpCharacterRange {
+  class OverlyWideRange extends FinalRegExpCharacterRange {
     OverlyWideRange() {
       exists(int low, int high, int numChars |
         isRange(this, low, high) and
@@ -111,12 +113,6 @@ module Make<RegexTreeViewSig TreeImpl> {
 
     /** Gets a string representation of a character class that matches the same chars as this range. */
     string printEquivalent() { result = RangePrinter::printEquivalentCharClass(this) }
-
-    /** Gets a string representation of this range. */
-    string toString() { result = super.toString() }
-
-    /** Holds if `lo` is the lower bound of this character range and `hi` the upper bound. */
-    predicate isRange(string lo, string hi) { super.isRange(lo, hi) }
   }
 
   /** Gets a range that should not be reported as an overly wide range. */

--- a/shared/regex/codeql/regex/nfa/BadTagFilterQuery.qll
+++ b/shared/regex/codeql/regex/nfa/BadTagFilterQuery.qll
@@ -55,7 +55,7 @@ module Make<RegexTreeViewSig TreeImpl> {
   /**
    * A regexp that matches some string from the `isBadTagFilterCandidate` predicate.
    */
-  class HtmlMatchingRegExp instanceof RootTerm {
+  class HtmlMatchingRegExp extends RootTerm {
     HtmlMatchingRegExp() { RegexpMatching<isBadTagFilterCandidate/4>::matches(this, _) }
 
     /** Holds if this regexp matched `str`, where `str` is one of the string from `isBadTagFilterCandidate`. */
@@ -64,16 +64,6 @@ module Make<RegexTreeViewSig TreeImpl> {
     /** Holds if this regexp fills capture group `g' when matching `str', where `str` is one of the string from `isBadTagFilterCandidate`. */
     predicate fillsCaptureGroup(string str, int g) {
       RegexpMatching<isBadTagFilterCandidate/4>::fillsCaptureGroup(this, str, g)
-    }
-
-    /** Gets a string representation of this term. */
-    string toString() { result = super.toString() }
-
-    /** Holds if this term has the specified location. */
-    predicate hasLocationInfo(
-      string filepath, int startline, int startcolumn, int endline, int endcolumn
-    ) {
-      super.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
     }
   }
 

--- a/shared/regex/codeql/regex/nfa/NfaUtils.qll
+++ b/shared/regex/codeql/regex/nfa/NfaUtils.qll
@@ -74,10 +74,12 @@ module Make<RegexTreeViewSig TreeImpl> {
     forex(RegExpTerm child | child = t.(RegExpSequence).getAChild() | matchesEpsilon(child))
   }
 
+  final private class FinalRegExpSubPattern = RegExpSubPattern;
+
   /**
    * A lookahead/lookbehind that matches the empty string.
    */
-  class EmptyPositiveSubPattern instanceof RegExpSubPattern {
+  class EmptyPositiveSubPattern extends FinalRegExpSubPattern {
     EmptyPositiveSubPattern() {
       (
         this instanceof RegExpPositiveLookahead
@@ -86,19 +88,18 @@ module Make<RegexTreeViewSig TreeImpl> {
       ) and
       matchesEpsilon(this.getOperand())
     }
-
-    /** Gets a string representation of this sub-pattern. */
-    string toString() { result = super.toString() }
   }
 
   /** DEPRECATED: Use `EmptyPositiveSubPattern` instead. */
   deprecated class EmptyPositiveSubPatttern = EmptyPositiveSubPattern;
 
+  final private class FinalRegExpTerm = RegExpTerm;
+
   /**
    * A branch in a disjunction that is the root node in a literal, or a literal
    * whose root node is not a disjunction.
    */
-  class RegExpRoot instanceof RegExpTerm {
+  class RegExpRoot extends FinalRegExpTerm {
     RegExpRoot() {
       exists(RegExpParent parent |
         exists(RegExpAlt alt |
@@ -122,12 +123,6 @@ module Make<RegexTreeViewSig TreeImpl> {
       // not excluded for library specific reasons
       not isExcluded(super.getRootTerm().getParent())
     }
-
-    /** Gets a string representation of this root term. */
-    string toString() { result = this.(RegExpTerm).toString() }
-
-    /** Gets the outermost term of this regular expression. */
-    RegExpTerm getRootTerm() { result = super.getRootTerm() }
   }
 
   /**
@@ -146,17 +141,8 @@ module Make<RegexTreeViewSig TreeImpl> {
   /**
    * A regexp term that is relevant for this ReDoS analysis.
    */
-  class RelevantRegExpTerm instanceof RegExpTerm {
+  class RelevantRegExpTerm extends FinalRegExpTerm {
     RelevantRegExpTerm() { getRoot(this).isRelevant() }
-
-    /** Gets a string representation of this term. */
-    string toString() { result = super.toString() }
-
-    /** Gets the raw source text of this term. */
-    string getRawValue() { result = super.getRawValue() }
-
-    /** Gets the outermost term of this regular expression. */
-    RegExpTerm getRootTerm() { result = super.getRootTerm() }
   }
 
   /**
@@ -864,7 +850,7 @@ module Make<RegexTreeViewSig TreeImpl> {
    * which represents the state of the NFA before starting to
    * match `t`, or the `i`th character in `t` if `t` is a constant.
    */
-  class State extends TState {
+  final class State extends TState {
     RegExpTerm repr;
 
     State() {
@@ -1056,16 +1042,10 @@ module Make<RegexTreeViewSig TreeImpl> {
     }
 
     /** A state within a regular expression that contains a candidate state. */
-    class RelevantState instanceof State {
+    class RelevantState extends State {
       RelevantState() {
         exists(State s | isCandidate(s) | getRoot(s.getRepr()) = getRoot(this.getRepr()))
       }
-
-      /** Gets a string representation for this state in a regular expression. */
-      string toString() { result = State.super.toString() }
-
-      /** Gets the term represented by this state. */
-      RegExpTerm getRepr() { result = State.super.getRepr() }
     }
   }
 

--- a/shared/regex/codeql/regex/nfa/RegexpMatching.qll
+++ b/shared/regex/codeql/regex/nfa/RegexpMatching.qll
@@ -13,19 +13,11 @@ module Make<RegexTreeViewSig TreeImpl> {
   private import TreeImpl
   import NfaUtils::Make<TreeImpl>
 
+  final private class FinalRegExpTerm = RegExpTerm;
+
   /** A root term */
-  class RootTerm instanceof RegExpTerm {
+  final class RootTerm extends FinalRegExpTerm {
     RootTerm() { this.isRootTerm() }
-
-    /** Gets a string representation of this term. */
-    string toString() { result = super.toString() }
-
-    /** Holds if this term has the specified location. */
-    predicate hasLocationInfo(
-      string filepath, int startline, int startcolumn, int endline, int endcolumn
-    ) {
-      super.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
-    }
   }
 
   /**

--- a/shared/regex/codeql/regex/nfa/SuperlinearBackTracking.qll
+++ b/shared/regex/codeql/regex/nfa/SuperlinearBackTracking.qll
@@ -418,11 +418,13 @@ module Make<RegexTreeViewSig TreeImpl> {
         "' can start matching anywhere after the start of the preceeding " + prev
   }
 
+  final private class FinalInfiniteRepetitionQuantifier = InfiniteRepetitionQuantifier;
+
   /**
    * A term that may cause a regular expression engine to perform a
    * polynomial number of match attempts, relative to the input length.
    */
-  class PolynomialBackTrackingTerm instanceof InfiniteRepetitionQuantifier {
+  class PolynomialBackTrackingTerm extends FinalInfiniteRepetitionQuantifier {
     string reason;
     string pump;
     string prefixMsg;
@@ -463,18 +465,5 @@ module Make<RegexTreeViewSig TreeImpl> {
      * Gets the reason for the number of match attempts.
      */
     string getReason() { result = reason }
-
-    /** Gets a string representation of this term. */
-    string toString() { result = super.toString() }
-
-    /** Gets the outermost term of this regular expression. */
-    RegExpTerm getRootTerm() { result = super.getRootTerm() }
-
-    /** Holds if this term has the specific location. */
-    predicate hasLocationInfo(
-      string filepath, int startline, int startcolumn, int endline, int endcolumn
-    ) {
-      super.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
-    }
   }
 }

--- a/shared/util/codeql/util/suppression/AlertSuppression.qll
+++ b/shared/util/codeql/util/suppression/AlertSuppression.qll
@@ -5,12 +5,23 @@ signature class AstNode {
 }
 
 signature class SingleLineComment {
+  /** Gets a textual representation of this element. */
   string toString();
 
+  /**
+   * Holds if this element is at the specified location.
+   * The location spans column `startcolumn` of line `startline` to
+   * column `endcolumn` of line `endline` in file `filepath`.
+   * For more information, see
+   * [Locations](https://codeql.github.com/docs/writing-codeql-queries/providing-locations-in-codeql-queries/).
+   */
   predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   );
 
+  /**
+   * Gets the text of this suppression comment.
+   */
   string getText();
 }
 
@@ -18,28 +29,12 @@ signature class SingleLineComment {
  * Constructs an alert suppression query.
  */
 module Make<AstNode Node, SingleLineComment Comment> {
+  final private class FinalCommnent = Comment;
+
   /**
    * An alert suppression comment.
    */
-  abstract class SuppressionComment instanceof Comment {
-    /**
-     * Gets the text of this suppression comment.
-     */
-    string getText() { result = super.getText() }
-
-    /**
-     * Holds if this element is at the specified location.
-     * The location spans column `startcolumn` of line `startline` to
-     * column `endcolumn` of line `endline` in file `filepath`.
-     * For more information, see
-     * [Locations](https://codeql.github.com/docs/writing-codeql-queries/providing-locations-in-codeql-queries/).
-     */
-    predicate hasLocationInfo(
-      string filepath, int startline, int startcolumn, int endline, int endcolumn
-    ) {
-      super.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
-    }
-
+  abstract class SuppressionComment extends FinalCommnent {
     /** Gets the suppression annotation in this comment. */
     abstract string getAnnotation();
 
@@ -53,9 +48,6 @@ module Make<AstNode Node, SingleLineComment Comment> {
 
     /** Gets the scope of this suppression. */
     SuppressionScope getScope() { this = result.getSuppressionComment() }
-
-    /** Gets a textual representation of this element. */
-    string toString() { result = super.toString() }
   }
 
   private class LgtmSuppressionComment extends SuppressionComment {


### PR DESCRIPTION
This allows the implementation to inherit the implementations from the super class, instead of having to insert predicates like:  
```CodeQL
string toString() { result = super.toString() }
```