### PR TITLE
C++: Add EmscriptenRunScriptTaint query

### DIFF
--- a/cpp/ql/src/experimental/Security/CWE/CVE-094/EmscriptenRunScriptTaint.cpp
+++ b/cpp/ql/src/experimental/Security/CWE/CVE-094/EmscriptenRunScriptTaint.cpp
@@ -1,0 +1,5 @@
+void ExportedWebAssemblyFunction(const char *text)
+{
+    emscripten_run_script(TextFormat("navigator.clipboard.writeText('%s')", text)); // BAD
+    emscripten_run_script("alert('FIXED CONSTANT')"); // GOOD
+}

--- a/cpp/ql/src/experimental/Security/CWE/CVE-094/EmscriptenRunScriptTaint.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CVE-094/EmscriptenRunScriptTaint.ql
@@ -1,0 +1,54 @@
+/**
+ * @name Uncontrolled data used in Emscripten run script commands
+ * @description Using user-supplied data in Emscripten run script
+ *              commands, without proper sanitization, can make code
+ *              vulnerable to JavaScript code injection.
+ * @kind path-problem
+ * @problem.severity error
+ * @precision high
+ * @id cpp/emscripten/run-script-injection
+ * @tags security
+ *       experimental
+ *       external/cwe/cwe-094
+ */
+
+import cpp
+import semmle.code.cpp.dataflow.new.TaintTracking
+import DataFlow::PathGraph
+
+class EmscriptenRunScriptTaintConfig extends TaintTracking::Configuration {
+  EmscriptenRunScriptTaintConfig() { this = "EmscriptenRunScriptTaintConfig" }
+
+  override predicate isSource(DataFlow::Node source) {
+    exists(Parameter p | source.asParameter() = p)
+  }
+
+  override predicate isSink(DataFlow::Node sink) {
+    exists(FunctionCall fc |
+      sink.asExpr() = fc.getArgument(0) and
+      (
+        fc.getTarget().hasGlobalName("emscripten_run_script") or
+        fc.getTarget().hasGlobalName("emscripten_run_script_int") or
+        fc.getTarget().hasGlobalName("emscripten_run_script_string") or
+        fc.getTarget().hasGlobalName("emscripten_async_run_script") or
+        fc.getTarget().hasGlobalName("emscripten_async_load_script")
+      ) and
+      not sink.asExpr().isConstant()
+    )
+  }
+
+  override predicate isAdditionalTaintStep(DataFlow::Node fromNode, DataFlow::Node toNode) {
+    exists(FunctionCall fc |
+      fc.getTarget().hasGlobalName("TextFormat") and
+      fc.getArgument(1) = fromNode.asExpr() and
+      fc.getEnclosingFunction() = fromNode.getEnclosingCallable() and
+      fc = toNode.asExpr()
+    )
+  }
+}
+
+from EmscriptenRunScriptTaintConfig cfg, DataFlow::PathNode source, DataFlow::PathNode sink
+where cfg.hasFlowPath(source, sink)
+select sink.getNode(), source, sink,
+  "The argument to an Emscripten run script command " + sink +
+    "is derived from a function parameter " + source + "."

--- a/cpp/ql/src/experimental/Security/CWE/CVE-094/EmscriptenRunScriptTaint.qlhelp
+++ b/cpp/ql/src/experimental/Security/CWE/CVE-094/EmscriptenRunScriptTaint.qlhelp
@@ -1,0 +1,21 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+<overview>
+<p>Finding for C++ WebAssembly function declarations that pass their parameters to Emscripten run script functions. If exported WebAssembly functions use user-supplied data in Emscripten run script commands without proper sanitization, this can make the code vulnerable to JavaScript code injection.</p>
+</overview>
+
+<example>
+<p>The following example demonstrates erroneous and fixed ways to use functions.</p>
+<sample src="EmscriptenRunScriptTaint.cpp" />
+
+</example>
+<references>
+
+<li>
+  <a href="https://emscripten.org/docs/api_reference/emscripten.h.html">Emscripten run script functions.</a>.
+</li>
+
+</references>
+</qhelp>


### PR DESCRIPTION
Adds an experimental EmscriptenRunScriptTaint query to detect unsanitized user-input flows to Emscripten run script functions for exported WebAssembly functions.

Submitted for All for one, one for all bounty.