### PR TITLE
Swift: remove `std::result_of` from swift headers

### DIFF
--- a/swift/third_party/load.bzl
+++ b/swift/third_party/load.bzl
@@ -39,6 +39,8 @@ def load_dependencies(workspace_name):
             ),
             build_file = _build(workspace_name, "swift-llvm-support"),
             sha256 = sha256,
+            patch_args = ["-p1"],
+            patches = ["@%s//swift/third_party/swift-llvm-support:patches/remove-result-of.patch" % workspace_name],
         )
 
     _github_archive(

--- a/swift/third_party/load.bzl
+++ b/swift/third_party/load.bzl
@@ -1,6 +1,9 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
+# TODO: remove `remove-result-of.patch` once we update to a Swift version containing
+# https://github.com/apple/swift/commit/2ed2cea2
+# (probably when updating to 5.9)
 _swift_prebuilt_version = "swift-5.8.1-RELEASE.208"
 _swift_sha_map = {
     "Linux-X64": "1d93286d6219e5c5746938ab9287d90efea98039f022cb1433296ccbc1684bc0",

--- a/swift/third_party/swift-llvm-support/patches/remove-result-of.patch
+++ b/swift/third_party/swift-llvm-support/patches/remove-result-of.patch
@@ -1,0 +1,30 @@
+`std::result_of` was removed in C++20, but is still used in the Swift headers. We can't
+remove it from there before prebuilding, as that is still done with C++14, but we can
+replace it with `std::invoke_result` for compiling the extractor.
+
+diff --git a/include/swift/Basic/RelativePointer.h b/include/swift/Basic/RelativePointer.h
+index 73f91262afa..bdaa304c804 100644
+--- a/include/swift/Basic/RelativePointer.h
++++ b/include/swift/Basic/RelativePointer.h
+@@ -551,7 +551,7 @@ public:
+   }
+
+   template <typename... ArgTy>
+-  typename std::result_of<T *(ArgTy...)>::type operator()(ArgTy... arg) const {
++  typename std::invoke_result<T*, ArgTy...>::type operator()(ArgTy... arg) const {
+ #if SWIFT_PTRAUTH
+     void *ptr = this->super::getWithoutCast();
+     return reinterpret_cast<T *>(ptrauth_sign_unauthenticated(
+diff --git a/include/swift/Basic/STLExtras.h b/include/swift/Basic/STLExtras.h
+index 7fa3d0c8890..6bc891a9b63 100644
+--- a/include/swift/Basic/STLExtras.h
++++ b/include/swift/Basic/STLExtras.h
+@@ -405,7 +405,7 @@ class OptionalTransformIterator {
+       typename std::iterator_traits<Iterator>::reference;
+
+   using ResultReference =
+-      typename std::result_of<OptionalTransform(UnderlyingReference)>::type;
++      typename std::invoke_result<OptionalTransform, UnderlyingReference>::type;
+
+ public:
+   /// Used to indicate when the current iterator has already been


### PR DESCRIPTION
`std::result_of` was removed in C++20, though the actual removal from the STL library implementations seems to depend on the version. For example using xcode 14.2 one gets away with a deprecation warning, but xcode 14.3 will fail.

As Swift 5.8.1 is still compiled with C++14, we cannot replace `std::result_of` with `std::invoke_result` in the prebuilding patches just yet, but we can do that for the extractor itself, patching the prebuilt package.