### PR TITLE
Release preparation for Swift

### DIFF
--- a/swift/ql/lib/CHANGELOG.md
+++ b/swift/ql/lib/CHANGELOG.md
@@ -1,0 +1,13 @@
+## 0.1.1
+
+### Major Analysis Improvements
+
+* Incorporated the cross-language `SensitiveDataHeuristics.qll` heuristics library into the Swift `SensitiveExprs.qll` library. This adds a number of new heuristics enhancing detection from the library.
+
+### Minor Analysis Improvements
+
+* Some models for the `Data` class have been generalized to `DataProtocol` so that they apply more widely.
+
+### Bug Fixes
+
+* Fixed a number of inconsistencies in the abstract syntax tree (AST) and in the control-flow graph (CFG). This may lead to more results in queries that use these libraries, or libraries that depend on them (such as dataflow).

--- a/swift/ql/lib/change-notes/2023-05-25-dataprotocol-models.md
+++ b/swift/ql/lib/change-notes/2023-05-25-dataprotocol-models.md
@@ -1,4 +1,0 @@
----
-category: minorAnalysis
----
-* Some models for the `Data` class have been generalized to `DataProtocol` so that they apply more widely.

--- a/swift/ql/lib/change-notes/2023-05-25-fix-ast-and-cfg-inconsistencies.md
+++ b/swift/ql/lib/change-notes/2023-05-25-fix-ast-and-cfg-inconsistencies.md
@@ -1,5 +1,0 @@
----
-category: fix
----
-
-* Fixed a number of inconsistencies in the abstract syntax tree (AST) and in the control-flow graph (CFG). This may lead to more results in queries that use these libraries, or libraries that depend on them (such as dataflow).

--- a/swift/ql/lib/change-notes/2023-05-30-shared-sensitive.md
+++ b/swift/ql/lib/change-notes/2023-05-30-shared-sensitive.md
@@ -1,4 +1,0 @@
----
-category: majorAnalysis
----
-* Incorporated the cross-language `SensitiveDataHeuristics.qll` heuristics library into the Swift `SensitiveExprs.qll` library. This adds a number of new heuristics enhancing detection from the library.

--- a/swift/ql/lib/change-notes/released/0.1.1.md
+++ b/swift/ql/lib/change-notes/released/0.1.1.md
@@ -1,0 +1,13 @@
+## 0.1.1
+
+### Major Analysis Improvements
+
+* Incorporated the cross-language `SensitiveDataHeuristics.qll` heuristics library into the Swift `SensitiveExprs.qll` library. This adds a number of new heuristics enhancing detection from the library.
+
+### Minor Analysis Improvements
+
+* Some models for the `Data` class have been generalized to `DataProtocol` so that they apply more widely.
+
+### Bug Fixes
+
+* Fixed a number of inconsistencies in the abstract syntax tree (AST) and in the control-flow graph (CFG). This may lead to more results in queries that use these libraries, or libraries that depend on them (such as dataflow).

--- a/swift/ql/lib/codeql-pack.release.yml
+++ b/swift/ql/lib/codeql-pack.release.yml
@@ -1,0 +1,2 @@
+---
+lastReleaseVersion: 0.1.1

--- a/swift/ql/lib/qlpack.yml
+++ b/swift/ql/lib/qlpack.yml
@@ -1,5 +1,5 @@
 name: codeql/swift-all
-version: 0.1.1-dev
+version: 0.1.1
 groups: swift
 extractor: swift
 dbscheme: swift.dbscheme

--- a/swift/ql/lib/qlpack.yml
+++ b/swift/ql/lib/qlpack.yml
@@ -1,5 +1,5 @@
 name: codeql/swift-all
-version: 0.1.0
+version: 0.1.1-dev
 groups: swift
 extractor: swift
 dbscheme: swift.dbscheme

--- a/swift/ql/src/CHANGELOG.md
+++ b/swift/ql/src/CHANGELOG.md
@@ -1,4 +1,5 @@
----
-category: minorAnalysis
----
+## 0.1.1
+
+### Minor Analysis Improvements
+
 * Fixed some false positive results from the `swift/string-length-conflation` query, caused by imprecise sinks.

--- a/swift/ql/src/change-notes/released/0.1.1.md
+++ b/swift/ql/src/change-notes/released/0.1.1.md
@@ -1,0 +1,5 @@
+## 0.1.1
+
+### Minor Analysis Improvements
+
+* Fixed some false positive results from the `swift/string-length-conflation` query, caused by imprecise sinks.

--- a/swift/ql/src/codeql-pack.release.yml
+++ b/swift/ql/src/codeql-pack.release.yml
@@ -1,0 +1,2 @@
+---
+lastReleaseVersion: 0.1.1

--- a/swift/ql/src/qlpack.yml
+++ b/swift/ql/src/qlpack.yml
@@ -1,5 +1,5 @@
 name: codeql/swift-queries
-version: 0.1.0
+version: 0.1.1-dev
 groups:
   - swift
   - queries

--- a/swift/ql/src/qlpack.yml
+++ b/swift/ql/src/qlpack.yml
@@ -1,5 +1,5 @@
 name: codeql/swift-queries
-version: 0.1.1-dev
+version: 0.1.1
 groups:
   - swift
   - queries


### PR DESCRIPTION
The release preparation and post-release workflows were not updated for the Swift beta, in which Swift was promoted out of experimental.  This PR runs the post-release step for 2.13.3 and the release step for 2.13.4 manually, to prepare new versions of the Swift packs for 2.13.4.