### PR TITLE
Java: Threat Models

### DIFF
--- a/java/ql/lib/ext/threatmodels/supported-threat-models.model.yml
+++ b/java/ql/lib/ext/threatmodels/supported-threat-models.model.yml
@@ -1,0 +1,7 @@
+extensions:
+
+  - addsTo:
+      pack: codeql/java-all
+      extensible: supportedThreatModels
+    data:
+      - ["default"] # The "default" threat model is always included.

--- a/java/ql/lib/ext/threatmodels/threat-model-grouping.model.yml
+++ b/java/ql/lib/ext/threatmodels/threat-model-grouping.model.yml
@@ -1,0 +1,25 @@
+extensions:
+
+  - addsTo:
+      pack: codeql/java-all
+      extensible: threatModelGrouping
+    data:
+      # Default threat model
+      - ["remote", "default"]
+      - ["uri-path", "default"]
+
+      # Android threat models
+      - ["android-widget", "android"]
+      - ["android-external-storage-dir", "android"]
+      - ["contentprovider", "android"]
+      - ["android-external-storage-dir", "android"]
+
+      # Remote threat models
+      - ["request", "remote"]
+      - ["response", "remote"]
+
+      # Local threat models
+      - ["database", "local"]
+      - ["cli", "local"]
+      - ["environment", "local"]
+      - ["file", "local"]

--- a/java/ql/lib/ext/threatmodels/threat-model-grouping.model.yml
+++ b/java/ql/lib/ext/threatmodels/threat-model-grouping.model.yml
@@ -9,10 +9,8 @@ extensions:
       - ["uri-path", "default"]
 
       # Android threat models
-      - ["android-widget", "android"]
       - ["android-external-storage-dir", "android"]
       - ["contentprovider", "android"]
-      - ["android-external-storage-dir", "android"]
 
       # Remote threat models
       - ["request", "remote"]

--- a/java/ql/lib/qlpack.yml
+++ b/java/ql/lib/qlpack.yml
@@ -15,4 +15,5 @@ dataExtensions:
   - ext/*.model.yml
   - ext/generated/*.model.yml
   - ext/experimental/*.model.yml
+  - ext/threatmodels/*.model.yml
 warnOnImplicitThis: true

--- a/java/ql/lib/semmle/code/java/dataflow/ExternalFlowConfiguration.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/ExternalFlowConfiguration.qll
@@ -1,0 +1,31 @@
+/**
+ * INTERNAL use only. This is an experimental API subject to change without notice.
+ *
+ * This module provides extensible predicates for configuring which kinds of MaD models
+ * are applicable to generic queries.
+ */
+
+private import ExternalFlowExtensions
+
+/**
+ * Holds if the specified kind of source model is supported for the current query.
+ */
+extensible private predicate supportedThreatModels(string kind);
+
+/**
+ * Holds if the specified kind of source model is containted within the specified group.
+ */
+extensible private predicate threatModelGrouping(string kind, string group);
+
+/**
+ * Gets the threat models that are direct descendants of the specified kind/group.
+ */
+private string getChildThreatModel(string group) { threatModelGrouping(result, group) }
+
+/**
+ * Holds if the source model kind `kind` is relevant for generic queries
+ * under the current threat model configuration.
+ */
+predicate sourceModelKindConfig(string kind) {
+  exists(string group | supportedThreatModels(group) and kind = getChildThreatModel*(group))
+}

--- a/java/ql/test/library-tests/dataflow/threat-models/Empty.java
+++ b/java/ql/test/library-tests/dataflow/threat-models/Empty.java
@@ -1,0 +1,1 @@
+class Empty { }

--- a/java/ql/test/library-tests/dataflow/threat-models/threat-models1.expected
+++ b/java/ql/test/library-tests/dataflow/threat-models/threat-models1.expected
@@ -1,0 +1,5 @@
+| default |
+| remote |
+| request |
+| response |
+| uri-path |

--- a/java/ql/test/library-tests/dataflow/threat-models/threat-models1.ql
+++ b/java/ql/test/library-tests/dataflow/threat-models/threat-models1.ql
@@ -1,0 +1,5 @@
+import semmle.code.java.dataflow.ExternalFlowConfiguration as ExternalFlowConfiguration
+
+query predicate supportedThreatModels(string kind) {
+  ExternalFlowConfiguration::sourceModelKindConfig(kind)
+}

--- a/java/ql/test/library-tests/dataflow/threat-models/threat-models2.expected
+++ b/java/ql/test/library-tests/dataflow/threat-models/threat-models2.expected
@@ -1,0 +1,10 @@
+| cli |
+| database |
+| default |
+| environment |
+| file |
+| local |
+| remote |
+| request |
+| response |
+| uri-path |

--- a/java/ql/test/library-tests/dataflow/threat-models/threat-models2.ext.yml
+++ b/java/ql/test/library-tests/dataflow/threat-models/threat-models2.ext.yml
@@ -1,0 +1,8 @@
+extensions:
+extensions:
+
+  - addsTo:
+      pack: codeql/java-all
+      extensible: supportedThreatModels
+    data:
+      - ["local"] # Add the "local" group threat model.

--- a/java/ql/test/library-tests/dataflow/threat-models/threat-models2.ext.yml
+++ b/java/ql/test/library-tests/dataflow/threat-models/threat-models2.ext.yml
@@ -1,5 +1,4 @@
 extensions:
-extensions:
 
   - addsTo:
       pack: codeql/java-all

--- a/java/ql/test/library-tests/dataflow/threat-models/threat-models2.ql
+++ b/java/ql/test/library-tests/dataflow/threat-models/threat-models2.ql
@@ -1,0 +1,5 @@
+import semmle.code.java.dataflow.ExternalFlowConfiguration as ExternalFlowConfiguration
+
+query predicate supportedThreatModels(string kind) {
+  ExternalFlowConfiguration::sourceModelKindConfig(kind)
+}


### PR DESCRIPTION
This PR covers the very initial work on supported threat models as describes in: https://github.com/github/code-scanning/pull/10356

In this PR we introduce some of the extensible predicates (and small helper predicates) needed to *glue* together the work made by CodeQL Experiences team and the CodeQL static languages teams.
The CodeQL experiences team will work on populating the extensible `supportedThreatModel` predicate with tuples via the workflow configuration.
The CodeQL static languages team will work on incorporating the support threat models into the existing framework (and some queries).

Even though the code is *dead* as it is now, it would be good to have it merged to allow CodeQL experiences and the CodeQL static team to work in parallel.
For now we just add some basic testing of the helper predicates.