### PR TITLE
JS: Single quote was preventing the shell from expanding the BODY variable in Expression injection in Actions example

### DIFF
--- a/javascript/ql/src/Security/CWE-094/examples/comment_issue_good.yml
+++ b/javascript/ql/src/Security/CWE-094/examples/comment_issue_good.yml
@@ -7,4 +7,4 @@ jobs:
     - env:
         BODY: ${{ github.event.issue.body }}
       run: |
-        echo '$BODY'
+        echo "$BODY"


### PR DESCRIPTION
The use of the single quote effectively prevents the attack highlighted in the Expression injection in Actions [query](https://github.com/github/codeql/blob/main/javascript/ql/src/Security/CWE-094/ExpressionInjection.qhelp) help it also prevents it from working effectively since using single quotes will effectively print `$BODY` because the variable is not expanded.

Double quotes will allow the expansion of the variable while still preventing the attack