### PR TITLE
C++: Dataflow fix for the self-iterators issue

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternalsCommon.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternalsCommon.qll
@@ -117,6 +117,16 @@ private int countIndirections(Type t) {
   else (
     result = any(Indirection ind | ind.getType() = t).getNumberOfIndirections()
     or
+    // If there is an indirection for the type, but we cannot count the number of indirections
+    // it means we couldn't reach a non-indirection type by stripping off indirections. This
+    // can occur if an iterator specifies itself as the value type. In this case we default to
+    // 1 indirection fore the type.
+    exists(Indirection ind |
+      ind.getType() = t and
+      not exists(ind.getNumberOfIndirections()) and
+      result = 1
+    )
+    or
     not exists(Indirection ind | ind.getType() = t) and
     result = 0
   )

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/self-Iterator.cpp
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/self-Iterator.cpp
@@ -1,0 +1,21 @@
+#include "../../../include/iterator.h"
+int source();
+
+template<typename T>
+void sink(T);
+
+template<> struct std::iterator_traits<unsigned long>
+{   // get traits from integer type
+    typedef std::input_iterator_tag iterator_category;
+    typedef unsigned long value_type;
+    typedef unsigned long difference_type;
+    typedef unsigned long distance_type;
+    typedef unsigned long * pointer;
+    typedef unsigned long& reference;
+};
+
+
+int test() {
+    unsigned long x = source();
+    sink(x); // $ ast MISSING: ir
+}

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/self-Iterator.cpp
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/self-Iterator.cpp
@@ -17,5 +17,5 @@ template<> struct std::iterator_traits<unsigned long>
 
 int test() {
     unsigned long x = source();
-    sink(x); // $ ast MISSING: ir
+    sink(x); // $ ast ir
 }


### PR DESCRIPTION
As an alternative to https://github.com/github/codeql/pull/13445. Instead of excluding iterators whose `value_type` is itself, we recognize the case in dataflow and provide a sensible default.

@rdmarsh2 what do you think of this approach instead?