### PR TITLE
Enable warnOnImplicitThis for all remaining QL packs

### DIFF
--- a/cpp/ql/examples/qlpack.yml
+++ b/cpp/ql/examples/qlpack.yml
@@ -4,3 +4,4 @@ groups:
   - examples
 dependencies:
   codeql/cpp-all: ${workspace}
+warnOnImplicitThis: true

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/tainted/qlpack.yml
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/tainted/qlpack.yml
@@ -6,3 +6,4 @@ dependencies:
   codeql/cpp-queries: ${workspace}
 extractor: cpp
 tests: .
+warnOnImplicitThis: true

--- a/csharp/ql/campaigns/Solorigate/lib/qlpack.yml
+++ b/csharp/ql/campaigns/Solorigate/lib/qlpack.yml
@@ -6,3 +6,4 @@ groups:
 library: true
 dependencies:
     codeql/csharp-all: ${workspace}
+warnOnImplicitThis: true

--- a/csharp/ql/campaigns/Solorigate/src/qlpack.yml
+++ b/csharp/ql/campaigns/Solorigate/src/qlpack.yml
@@ -7,3 +7,4 @@ defaultSuiteFile: codeql-suites/solorigate.qls
 dependencies:
     codeql/csharp-all: ${workspace}
     codeql/csharp-solorigate-all: ${workspace}
+warnOnImplicitThis: true

--- a/csharp/ql/campaigns/Solorigate/test/qlpack.yml
+++ b/csharp/ql/campaigns/Solorigate/test/qlpack.yml
@@ -10,3 +10,4 @@ dependencies:
   codeql/csharp-solorigate-queries: ${workspace}
 extractor: csharp
 tests: .
+warnOnImplicitThis: true

--- a/csharp/ql/consistency-queries/qlpack.yml
+++ b/csharp/ql/consistency-queries/qlpack.yml
@@ -3,3 +3,4 @@ groups: [csharp, test, consistency-queries]
 dependencies:
   codeql/csharp-all: ${workspace}
 extractor: csharp
+warnOnImplicitThis: true

--- a/csharp/ql/examples/qlpack.yml
+++ b/csharp/ql/examples/qlpack.yml
@@ -4,3 +4,4 @@ groups:
   - examples
 dependencies:
   codeql/csharp-all: ${workspace}
+warnOnImplicitThis: true

--- a/go/external-packs/codeql/suite-helpers/0.0.2/qlpack.yml
+++ b/go/external-packs/codeql/suite-helpers/0.0.2/qlpack.yml
@@ -1,3 +1,4 @@
 name: codeql/suite-helpers
 version: 0.0.2
 library: true
+warnOnImplicitThis: true

--- a/go/ql/config/legacy-support/qlpack.yml
+++ b/go/ql/config/legacy-support/qlpack.yml
@@ -2,3 +2,4 @@ name: legacy-libraries-go
 version: 0.0.0
 # Note libraryPathDependencies is obsolete and should not be used in new qlpacks.
 libraryPathDependencies: codeql-go
+warnOnImplicitThis: true

--- a/go/ql/examples/qlpack.yml
+++ b/go/ql/examples/qlpack.yml
@@ -4,3 +4,4 @@ groups:
   - examples
 dependencies:
   codeql/go-all: ${workspace}
+warnOnImplicitThis: true

--- a/java/ql/consistency-queries/qlpack.yml
+++ b/java/ql/consistency-queries/qlpack.yml
@@ -2,3 +2,4 @@ name: codeql-java-consistency-queries
 version: 0.0.0
 dependencies:
   codeql/java-all: '*'
+warnOnImplicitThis: true

--- a/java/ql/examples/qlpack.yml
+++ b/java/ql/examples/qlpack.yml
@@ -4,3 +4,4 @@ groups:
   - examples
 dependencies:
   codeql/java-all: ${workspace}
+warnOnImplicitThis: true

--- a/javascript/ql/examples/qlpack.yml
+++ b/javascript/ql/examples/qlpack.yml
@@ -4,3 +4,4 @@ groups:
   - examples
 dependencies:
   codeql/javascript-all: ${workspace}
+warnOnImplicitThis: true

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/qlpack.yml
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/qlpack.yml
@@ -8,3 +8,4 @@ groups:
     - experimental
 dependencies:
     codeql/javascript-all: ${workspace}
+warnOnImplicitThis: true

--- a/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/qlpack.yml
+++ b/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/qlpack.yml
@@ -8,3 +8,4 @@ groups:
 dependencies:
     codeql/javascript-experimental-atm-lib: ${workspace}
     codeql/javascript-experimental-atm-model: "0.3.1-2023-03-01-12h42m43s.strong-turtle-1xp3dqvv.ecb17d40286d14132b481c065a43459a7f0ba9059015b7a49c909c9f9ce5fec5"
+warnOnImplicitThis: true

--- a/javascript/ql/experimental/adaptivethreatmodeling/src/qlpack.yml
+++ b/javascript/ql/experimental/adaptivethreatmodeling/src/qlpack.yml
@@ -10,3 +10,4 @@ groups:
 dependencies:
     codeql/javascript-experimental-atm-lib: ${workspace}
     codeql/javascript-experimental-atm-model: "0.3.1-2023-03-01-12h42m43s.strong-turtle-1xp3dqvv.ecb17d40286d14132b481c065a43459a7f0ba9059015b7a49c909c9f9ce5fec5"
+warnOnImplicitThis: true

--- a/javascript/ql/experimental/adaptivethreatmodeling/test/qlpack.yml
+++ b/javascript/ql/experimental/adaptivethreatmodeling/test/qlpack.yml
@@ -2,3 +2,4 @@ name: codeql/javascript-experimental-atm-tests
 extractor: javascript
 dependencies:
     codeql/javascript-experimental-atm-model-building: ${workspace}
+warnOnImplicitThis: true

--- a/misc/legacy-support/cpp/qlpack.yml
+++ b/misc/legacy-support/cpp/qlpack.yml
@@ -3,3 +3,4 @@ version: 0.0.0
 # Note libraryPathDependencies is obsolete and should not be used in new qlpacks.
 libraryPathDependencies:
   - codeql/cpp-all
+warnOnImplicitThis: true

--- a/misc/legacy-support/csharp/qlpack.yml
+++ b/misc/legacy-support/csharp/qlpack.yml
@@ -3,3 +3,4 @@ version: 0.0.0
 # Note libraryPathDependencies is obsolete and should not be used in new qlpacks.
 libraryPathDependencies:
   - codeql/csharp-all
+warnOnImplicitThis: true

--- a/misc/legacy-support/java/qlpack.yml
+++ b/misc/legacy-support/java/qlpack.yml
@@ -3,3 +3,4 @@ version: 0.0.0
 # Note libraryPathDependencies is obsolete and should not be used in new qlpacks.
 libraryPathDependencies:
   - codeql/java-all
+warnOnImplicitThis: true

--- a/misc/legacy-support/javascript/qlpack.yml
+++ b/misc/legacy-support/javascript/qlpack.yml
@@ -3,3 +3,4 @@ version: 0.0.0
 # Note libraryPathDependencies is obsolete and should not be used in new qlpacks.
 libraryPathDependencies:
   - codeql-javascript
+warnOnImplicitThis: true

--- a/misc/legacy-support/python/qlpack.yml
+++ b/misc/legacy-support/python/qlpack.yml
@@ -3,3 +3,4 @@ version: 0.0.0
 # Note libraryPathDependencies is obsolete and should not be used in new qlpacks.
 libraryPathDependencies:
   - codeql/python-all
+warnOnImplicitThis: true

--- a/misc/suite-helpers/qlpack.yml
+++ b/misc/suite-helpers/qlpack.yml
@@ -1,3 +1,4 @@
 name: codeql/suite-helpers
 version: 0.5.3-dev
 groups: shared
+warnOnImplicitThis: true

--- a/python/ql/consistency-queries/qlpack.yml
+++ b/python/ql/consistency-queries/qlpack.yml
@@ -3,3 +3,4 @@ groups: [python, test, consistency-queries]
 dependencies:
     codeql/python-all: ${workspace}
 extractor: python
+warnOnImplicitThis: true

--- a/python/ql/examples/qlpack.yml
+++ b/python/ql/examples/qlpack.yml
@@ -4,3 +4,4 @@ groups:
   - examples
 dependencies:
   codeql/python-all: ${workspace}
+warnOnImplicitThis: true

--- a/ql/ql/consistency-queries/qlpack.yml
+++ b/ql/ql/consistency-queries/qlpack.yml
@@ -3,3 +3,4 @@ groups: [ql, test, consistency-queries]
 dependencies:
   codeql/ql: ${workspace}
 extractor: ql
+warnOnImplicitThis: true

--- a/ql/ql/examples/qlpack.yml
+++ b/ql/ql/examples/qlpack.yml
@@ -2,3 +2,4 @@ name: codeql/ql-examples
 groups: [ql, examples]
 dependencies:
     codeql/ql: ${workspace}
+warnOnImplicitThis: true

--- a/ql/ql/test/qlpack.yml
+++ b/ql/ql/test/qlpack.yml
@@ -5,3 +5,4 @@ dependencies:
     codeql/ql-examples: ${workspace}
 extractor: ql
 tests: .
+warnOnImplicitThis: true

--- a/ruby/ql/consistency-queries/qlpack.yml
+++ b/ruby/ql/consistency-queries/qlpack.yml
@@ -2,3 +2,4 @@ name: codeql/ruby-consistency-queries
 groups: [ruby, test, consistency-queries]
 dependencies:
   codeql/ruby-all: ${workspace}
+warnOnImplicitThis: true

--- a/ruby/ql/examples/qlpack.yml
+++ b/ruby/ql/examples/qlpack.yml
@@ -4,3 +4,4 @@ groups:
   - examples
 dependencies:
   codeql/ruby-all: ${workspace}
+warnOnImplicitThis: true

--- a/swift/integration-tests/qlpack.yml
+++ b/swift/integration-tests/qlpack.yml
@@ -4,3 +4,4 @@ dependencies:
   codeql/swift-all: ${workspace}
 tests: .
 extractor: swift
+warnOnImplicitThis: true

--- a/swift/ql/consistency-queries/qlpack.yml
+++ b/swift/ql/consistency-queries/qlpack.yml
@@ -2,3 +2,4 @@ name: codeql/swift-consistency-queries
 groups: [swift, test, consistency-queries]
 dependencies:
   codeql/swift-all: ${workspace}
+warnOnImplicitThis: true

--- a/swift/ql/examples/qlpack.yml
+++ b/swift/ql/examples/qlpack.yml
@@ -4,3 +4,4 @@ groups:
   - examples
 dependencies:
   codeql/swift-all: ${workspace}
+warnOnImplicitThis: true


### PR DESCRIPTION
Enable `warnOnImplicitThis` for all remaining QL packs. Most of them are QL packs for tests, examples and legacy libraries. 