### PR TITLE
QL: Exclude overridden fields from `FieldOnlyUsedInCharPred.ql`

### DIFF
--- a/ql/ql/src/queries/style/FieldOnlyUsedInCharPred.ql
+++ b/ql/ql/src/queries/style/FieldOnlyUsedInCharPred.ql
@@ -21,5 +21,6 @@ where
     any(PredicateCall call |
       call.getEnclosingPredicate() = c.getCharPred() and call.getTarget() instanceof NewTypeBranch
     ).getAnArgument() and
-  not f.getVarDecl().overrides(_)
+  not f.getVarDecl().overrides(_) and
+  not any(FieldDecl other).getVarDecl().overrides(f.getVarDecl())
 select f, "Field is only used in CharPred."

--- a/ql/ql/test/queries/style/FieldOnlyUsedInCharPred/FieldOnlyUsedInCharPred.expected
+++ b/ql/ql/test/queries/style/FieldOnlyUsedInCharPred/FieldOnlyUsedInCharPred.expected
@@ -1,0 +1,2 @@
+| FieldOnlyUsedInCharPred.qll:2:3:2:12 | FieldDecl | Field is only used in CharPred. |
+| FieldOnlyUsedInCharPred.qll:22:3:22:11 | FieldDecl | Field is only used in CharPred. |

--- a/ql/ql/test/queries/style/FieldOnlyUsedInCharPred/FieldOnlyUsedInCharPred.expected
+++ b/ql/ql/test/queries/style/FieldOnlyUsedInCharPred/FieldOnlyUsedInCharPred.expected
@@ -1,2 +1,1 @@
 | FieldOnlyUsedInCharPred.qll:2:3:2:12 | FieldDecl | Field is only used in CharPred. |
-| FieldOnlyUsedInCharPred.qll:22:3:22:11 | FieldDecl | Field is only used in CharPred. |

--- a/ql/ql/test/queries/style/FieldOnlyUsedInCharPred/FieldOnlyUsedInCharPred.qll
+++ b/ql/ql/test/queries/style/FieldOnlyUsedInCharPred/FieldOnlyUsedInCharPred.qll
@@ -1,0 +1,29 @@
+class C1 extends int {
+  int field; // BAD
+
+  C1() {
+    this = field and
+    this = 0
+  }
+}
+
+class C2 extends C1 {
+  int field2; // GOOD
+
+  C2() {
+    this = field2 and
+    this = 0
+  }
+
+  int getField() { result = field2 }
+}
+
+class C3 extends int {
+  C1 field; // GOOD (overridden)
+
+  C3() { this = field }
+}
+
+class C4 extends C3 {
+  override C2 field; // GOOD (overriding)
+}

--- a/ql/ql/test/queries/style/FieldOnlyUsedInCharPred/FieldOnlyUsedInCharPred.qlref
+++ b/ql/ql/test/queries/style/FieldOnlyUsedInCharPred/FieldOnlyUsedInCharPred.qlref
@@ -1,0 +1,1 @@
+queries/style/FieldOnlyUsedInCharPred.ql


### PR DESCRIPTION
FP spotted on https://github.com/github/codeql/pull/13509.