### PR TITLE
Py: deprecate the old dataflow library

### DIFF
--- a/python/ql/lib/semmle/python/dataflow/old/Configuration.qll
+++ b/python/ql/lib/semmle/python/dataflow/old/Configuration.qll
@@ -3,7 +3,7 @@ import semmle.python.dataflow.TaintTracking
 private import semmle.python.objects.ObjectInternal
 private import semmle.python.dataflow.Implementation
 
-module TaintTracking {
+deprecated module TaintTracking {
   class Source = TaintSource;
 
   class Sink = TaintSink;

--- a/python/ql/lib/semmle/python/dataflow/old/Files.qll
+++ b/python/ql/lib/semmle/python/dataflow/old/Files.qll
@@ -1,13 +1,13 @@
 import python
 import semmle.python.dataflow.TaintTracking
 
-class OpenFile extends TaintKind {
+deprecated class OpenFile extends TaintKind {
   OpenFile() { this = "file.open" }
 
   override string repr() { result = "an open file" }
 }
 
-class OpenFileConfiguration extends TaintTracking::Configuration {
+deprecated class OpenFileConfiguration extends TaintTracking::Configuration {
   OpenFileConfiguration() { this = "Open file configuration" }
 
   override predicate isSource(DataFlow::Node src, TaintKind kind) {

--- a/python/ql/lib/semmle/python/dataflow/old/Implementation.qll
+++ b/python/ql/lib/semmle/python/dataflow/old/Implementation.qll
@@ -10,7 +10,7 @@ import semmle.python.dataflow.Legacy
  * including attribute paths, contexts and edges.
  */
 
-newtype TTaintTrackingContext =
+deprecated newtype TTaintTrackingContext =
   TNoParam() or
   TParamContext(TaintKind param, AttributePath path, int n) {
     any(TaintTrackingImplementation impl).callWithTaintedArgument(_, _, _, _, n, path, param)
@@ -23,7 +23,7 @@ newtype TTaintTrackingContext =
  *  * Tainted parameter; tracks the taint and attribute-path for a parameter
  *    Used to track taint through calls accurately and reasonably efficiently.
  */
-class TaintTrackingContext extends TTaintTrackingContext {
+deprecated class TaintTrackingContext extends TTaintTrackingContext {
   /** Gets a textual representation of this element. */
   string toString() {
     this = TNoParam() and result = ""
@@ -66,7 +66,7 @@ private newtype TAttributePath =
  * This is usually "no attribute".
  * Used for tracking tainted attributes of objects.
  */
-abstract class AttributePath extends TAttributePath {
+abstract deprecated class AttributePath extends TAttributePath {
   /** Gets a textual representation of this element. */
   abstract string toString();
 
@@ -80,7 +80,7 @@ abstract class AttributePath extends TAttributePath {
 }
 
 /** The `AttributePath` for no attribute. */
-class NoAttribute extends TNoAttribute, AttributePath {
+deprecated class NoAttribute extends TNoAttribute, AttributePath {
   override string toString() { result = "no attribute" }
 
   override string extension() { result = "" }
@@ -89,7 +89,7 @@ class NoAttribute extends TNoAttribute, AttributePath {
 }
 
 /** The `AttributePath` for an attribute. */
-class NamedAttributePath extends TAttribute, AttributePath {
+deprecated class NamedAttributePath extends TAttribute, AttributePath {
   override string toString() {
     exists(string attr |
       this = TAttribute(attr) and
@@ -113,7 +113,7 @@ class NamedAttributePath extends TAttribute, AttributePath {
  * Type representing the (node, context, path, kind) tuple.
  * Construction of this type is mutually recursive with `TaintTrackingImplementation.flowStep(...)`
  */
-newtype TTaintTrackingNode =
+deprecated newtype TTaintTrackingNode =
   TTaintTrackingNode_(
     DataFlow::Node node, TaintTrackingContext context, AttributePath path, TaintKind kind,
     TaintTracking::Configuration config
@@ -127,7 +127,7 @@ newtype TTaintTrackingNode =
  * A class representing the (node, context, path, kind) tuple.
  * Used for context-sensitive path-aware taint-tracking.
  */
-class TaintTrackingNode extends TTaintTrackingNode {
+deprecated class TaintTrackingNode extends TTaintTrackingNode {
   /** Gets a textual representation of this element. */
   string toString() {
     if this.getPath() instanceof NoAttribute
@@ -197,7 +197,7 @@ class TaintTrackingNode extends TTaintTrackingNode {
  * It is implemented as a separate class for clarity and to keep the code
  * in `TaintTracking::Configuration` simpler.
  */
-class TaintTrackingImplementation extends string instanceof TaintTracking::Configuration {
+deprecated class TaintTrackingImplementation extends string instanceof TaintTracking::Configuration {
   /**
    * Hold if there is a flow from `source`, which is a taint source, to
    * `sink`, which is a taint sink, with this configuration.
@@ -644,7 +644,7 @@ class TaintTrackingImplementation extends string instanceof TaintTracking::Confi
  * Another taint-tracking class to help partition the code for clarity
  * This class handle tracking of ESSA variables.
  */
-private class EssaTaintTracking extends string instanceof TaintTracking::Configuration {
+deprecated private class EssaTaintTracking extends string instanceof TaintTracking::Configuration {
   pragma[noinline]
   predicate taintedDefinition(
     TaintTrackingNode src, EssaDefinition defn, TaintTrackingContext context, AttributePath path,
@@ -930,7 +930,7 @@ private predicate piNodeTestAndUse(PyEdgeRefinement defn, ControlFlowNode test, 
 }
 
 /** Helper predicate for taintedMultiAssignment */
-private TaintKind taint_at_depth(SequenceKind parent_kind, int depth) {
+deprecated private TaintKind taint_at_depth(SequenceKind parent_kind, int depth) {
   depth >= 0 and
   (
     // base-case #0
@@ -959,7 +959,7 @@ private TaintKind taint_at_depth(SequenceKind parent_kind, int depth) {
  * - with `left_defn` = `*y`, `left_parent` = `(x, *y)`, result = 0
  * - with `left_defn` = `*y`, `left_parent` = `((x, *y), ...)`, result = 1
  */
-int iterable_unpacking_descent(SequenceNode left_parent, ControlFlowNode left_defn) {
+deprecated int iterable_unpacking_descent(SequenceNode left_parent, ControlFlowNode left_defn) {
   exists(Assign a | a.getATarget().getASubExpression*().getAFlowNode() = left_parent) and
   left_parent.getAnElement() = left_defn and
   // Handle `a, *b = some_iterable`
@@ -968,7 +968,7 @@ int iterable_unpacking_descent(SequenceNode left_parent, ControlFlowNode left_de
   result = 1 + iterable_unpacking_descent(left_parent.getAnElement(), left_defn)
 }
 
-module Implementation {
+deprecated module Implementation {
   /** Holds if `tonode` is a call that returns a copy (or similar) of the argument `fromnode` */
   predicate copyCall(ControlFlowNode fromnode, CallNode tonode) {
     tonode.getFunction().(AttrNode).getObject("copy") = fromnode

--- a/python/ql/lib/semmle/python/dataflow/old/Legacy.qll
+++ b/python/ql/lib/semmle/python/dataflow/old/Legacy.qll
@@ -3,7 +3,7 @@ private import semmle.python.objects.ObjectInternal
 import semmle.python.dataflow.Implementation
 
 /** A configuration that provides backwards compatibility with config-less taint-tracking */
-private class LegacyConfiguration extends TaintTracking::Configuration {
+deprecated private class LegacyConfiguration extends TaintTracking::Configuration {
   LegacyConfiguration() {
     /* A name that won't be accidentally chosen by users */
     this = "Semmle: Internal legacy configuration"

--- a/python/ql/lib/semmle/python/dataflow/old/StateTracking.qll
+++ b/python/ql/lib/semmle/python/dataflow/old/StateTracking.qll
@@ -14,7 +14,7 @@ private import semmle.python.pointsto.PointsToContext
 private import semmle.python.objects.ObjectInternal
 
 /** A state that should be tracked. */
-abstract class TrackableState extends string {
+abstract deprecated class TrackableState extends string {
   bindingset[this]
   TrackableState() { this = this }
 
@@ -73,7 +73,7 @@ abstract class TrackableState extends string {
   predicate endsAt(ControlFlowNode f, Context ctx) { ctx.appliesTo(f) and this.endsAt(f) }
 }
 
-module StateTracking {
+deprecated module StateTracking {
   private predicate not_allowed(TrackableState state, ControlFlowNode f, Context ctx, boolean sense) {
     state.endsAt(f, ctx) and sense = true
     or

--- a/python/ql/lib/semmle/python/dataflow/old/TaintTracking.qll
+++ b/python/ql/lib/semmle/python/dataflow/old/TaintTracking.qll
@@ -100,7 +100,7 @@ import semmle.python.dataflow.Configuration
  * or, for a super secure system, environment variables or
  * the local file system.
  */
-abstract class TaintKind extends string {
+abstract deprecated class TaintKind extends string {
   bindingset[this]
   TaintKind() { any() }
 
@@ -179,7 +179,7 @@ abstract class TaintKind extends string {
 /**
  * An Alias of `TaintKind`, so the two types can be used interchangeably.
  */
-class FlowLabel = TaintKind;
+deprecated class FlowLabel = TaintKind;
 
 /**
  * Taint kinds representing collections of other taint kind.
@@ -189,7 +189,7 @@ class FlowLabel = TaintKind;
  * in Python. We choose a single character prefix and suffix for simplicity
  * and ease of preventing infinite recursion.
  */
-abstract class CollectionKind extends TaintKind {
+abstract deprecated class CollectionKind extends TaintKind {
   bindingset[this]
   CollectionKind() {
     (this.charAt(0) = "[" or this.charAt(0) = "{") and
@@ -209,7 +209,7 @@ abstract class CollectionKind extends TaintKind {
  * A taint kind representing a flat collections of kinds.
  * Typically a sequence, but can include sets.
  */
-class SequenceKind extends CollectionKind {
+deprecated class SequenceKind extends CollectionKind {
   TaintKind itemKind;
 
   SequenceKind() { this = "[" + itemKind + "]" }
@@ -245,7 +245,7 @@ class SequenceKind extends CollectionKind {
   }
 }
 
-module SequenceKind {
+deprecated module SequenceKind {
   predicate flowStep(ControlFlowNode fromnode, ControlFlowNode tonode, string edgeLabel) {
     tonode.(BinaryExprNode).getAnOperand() = fromnode and edgeLabel = "binary operation"
     or
@@ -262,7 +262,7 @@ module SequenceKind {
   }
 }
 
-module DictKind {
+deprecated module DictKind {
   predicate flowStep(ControlFlowNode fromnode, ControlFlowNode tonode, string edgeLabel) {
     Implementation::copyCall(fromnode, tonode) and
     edgeLabel = "dict copy"
@@ -292,7 +292,7 @@ private predicate subscript_slice(ControlFlowNode obj, SubscriptNode sub) {
  * A taint kind representing a mapping of objects to kinds.
  * Typically a dict, but can include other mappings.
  */
-class DictKind extends CollectionKind {
+deprecated class DictKind extends CollectionKind {
   TaintKind valueKind;
 
   DictKind() { this = "{" + valueKind + "}" }
@@ -326,7 +326,7 @@ class DictKind extends CollectionKind {
  * Usually a sanitizer can only sanitize data for one particular use.
  * For example, a sanitizer for DB commands would not be safe to use for http responses.
  */
-abstract class Sanitizer extends string {
+abstract deprecated class Sanitizer extends string {
   bindingset[this]
   Sanitizer() { any() }
 
@@ -351,7 +351,7 @@ abstract class Sanitizer extends string {
  * Users of the taint tracking library should override this
  * class to provide their own sources.
  */
-abstract class TaintSource extends @py_flow_node {
+abstract deprecated class TaintSource extends @py_flow_node {
   /** Gets a textual representation of this element. */
   string toString() { result = "Taint source" }
 
@@ -420,7 +420,7 @@ abstract class TaintSource extends @py_flow_node {
  * Users of the taint tracking library can override this
  * class to provide their own sources on the ESSA graph.
  */
-abstract class TaintedDefinition extends EssaNodeDefinition {
+abstract deprecated class TaintedDefinition extends EssaNodeDefinition {
   /**
    * Holds if `this` is a source of taint kind `kind`
    *
@@ -476,7 +476,7 @@ private class SequenceExtends extends DataFlowExtension::DataFlowNode {
  * Users of the taint tracking library should extend this
  * class to provide their own sink nodes.
  */
-abstract class TaintSink extends @py_flow_node {
+abstract deprecated class TaintSink extends @py_flow_node {
   /** Gets a textual representation of this element. */
   string toString() { result = "Taint sink" }
 
@@ -509,7 +509,7 @@ abstract class TaintSink extends @py_flow_node {
  * library or framework specific and cannot be inferred by the general
  * data-flow machinery.
  */
-module DataFlowExtension {
+deprecated module DataFlowExtension {
   /** A control flow node that modifies the basic data-flow. */
   abstract class DataFlowNode extends @py_flow_node {
     /** Gets a textual representation of this element. */
@@ -581,20 +581,20 @@ module DataFlowExtension {
   }
 }
 
-class TaintedPathSource extends TaintTrackingNode {
+deprecated class TaintedPathSource extends TaintTrackingNode {
   TaintedPathSource() { this.isSource() }
 
   DataFlow::Node getSource() { result = this.getNode() }
 }
 
-class TaintedPathSink extends TaintTrackingNode {
+deprecated class TaintedPathSink extends TaintTrackingNode {
   TaintedPathSink() { this.isSink() }
 
   DataFlow::Node getSink() { result = this.getNode() }
 }
 
 /* Backwards compatible name */
-class TaintedNode = TaintTrackingNode;
+deprecated class TaintedNode = TaintTrackingNode;
 
 /* Helpers for Validating classes */
 private import semmle.python.pointsto.PointsTo
@@ -603,7 +603,7 @@ private import semmle.python.pointsto.PointsTo
  * Data flow module providing an interface compatible with
  * the other language implementations.
  */
-module DataFlow {
+deprecated module DataFlow {
   /**
    * The generic taint kind, source and sink classes for convenience and
    * compatibility with other language libraries


### PR DESCRIPTION
**TODO:** Add a big change-note, after I've confirmed that the CI is otherwise green.  

It's not used anymore after we've deleted old deprecations, so time to deprecate it? 

