### PR TITLE
C++: Fix back-edge detection in range analysis

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/rangeanalysis/new/internal/semantic/SemanticExprSpecific.qll
+++ b/cpp/ql/lib/semmle/code/cpp/rangeanalysis/new/internal/semantic/SemanticExprSpecific.qll
@@ -358,6 +358,8 @@ module SemanticExprConfig {
 
   predicate readBlock(SsaReadPosition pos, BasicBlock block) { pos = TReadPositionBlock(block) }
 
+  predicate semBackEdge(SemBasicBlock b1, SemBasicBlock b2) { b1.getBackEdgeSuccessor(_) = b2 }
+
   predicate phiInputEdge(SsaReadPosition pos, BasicBlock origBlock, BasicBlock phiBlock) {
     pos = TReadPositionPhiInputEdge(origBlock, phiBlock)
   }

--- a/cpp/ql/lib/semmle/code/cpp/rangeanalysis/new/internal/semantic/SemanticSSA.qll
+++ b/cpp/ql/lib/semmle/code/cpp/rangeanalysis/new/internal/semantic/SemanticSSA.qll
@@ -69,7 +69,7 @@ predicate semBackEdge(SemSsaPhiNode phi, SemSsaVariable inp, SemSsaReadPositionP
   edge.phiInput(phi, inp) and
   // Conservatively assume that every edge is a back edge if we don't have dominance information.
   (
-    phi.getBasicBlock().bbDominates(edge.getOrigBlock()) or
+    Specific::semBackEdge(edge.getOrigBlock(), phi.getBasicBlock()) or
     not edge.getOrigBlock().hasDominanceInformation()
   )
 }

--- a/cpp/ql/test/library-tests/ir/range-analysis/test.cpp
+++ b/cpp/ql/test/library-tests/ir/range-analysis/test.cpp
@@ -92,5 +92,5 @@ void loopy(bool b1, bool b2)
       goto loopy_label;
     }
   }
-  range(j); // $ MISSING: range=<=10 range=>=0
+  range(j); // $ range=<=10 range=>=0
 }

--- a/cpp/ql/test/library-tests/ir/range-analysis/test.cpp
+++ b/cpp/ql/test/library-tests/ir/range-analysis/test.cpp
@@ -70,3 +70,27 @@ int f4(int x) {
     }
   }
 }
+
+void loopy(bool b1, bool b2)
+{
+  int j;
+
+  if (b1)
+    return;
+
+  if (b2)
+  {
+    for (j = 0; j < 10; ++j)
+    {
+    loopy_label:
+    }
+  }
+  else
+  {
+    for (j = 0; j < 10; ++j)
+    {
+      goto loopy_label;
+    }
+  }
+  range(j); // $ MISSING: range=<=10 range=>=0
+}


### PR DESCRIPTION
Consider this example:
```cpp
void loopy(bool b1, bool b2)
{
  int j;

  if (b1)
    return;

  if (b2)
  {
    for (j = 0; j < 10; ++j)
    {
    /* (2) */ main_decode_loop:
    }
  }
  else
  {
    for (/* (1) */ j = 0; j < 10; ++j)
    {
      goto main_decode_loop;
    }
  }
}
```
the back edge from the basic block starting at (1) to the basic block starting at (2) doesn't satisfy the usual criteria that the (2) dominates (1) and so we fail to deduce that this is a back-edge. This causes infinite recursion in the new range analysis.