### PR TITLE
Ruby: Add `toString` functionality consistency queries

### DIFF
--- a/ruby/ql/consistency-queries/AstConsistency.ql
+++ b/ruby/ql/consistency-queries/AstConsistency.ql
@@ -23,3 +23,8 @@ query predicate multipleParents(AstNode node, AstNode parent, string cls) {
     one != two
   )
 }
+
+query predicate multipleToString(AstNode n, string s) {
+  s = strictconcat(n.toString(), ",") and
+  strictcount(n.toString()) > 1
+}

--- a/ruby/ql/consistency-queries/CfgConsistency.ql
+++ b/ruby/ql/consistency-queries/CfgConsistency.ql
@@ -1,5 +1,6 @@
 import codeql.ruby.controlflow.internal.ControlFlowGraphImplShared::Consistency
 import codeql.ruby.AST
+import codeql.ruby.CFG
 import codeql.ruby.controlflow.internal.Completion
 import codeql.ruby.controlflow.internal.ControlFlowGraphImpl
 
@@ -17,4 +18,9 @@ query predicate nonPostOrderExpr(Expr e, string cls) {
     last != e and
     c instanceof NormalCompletion
   )
+}
+
+query predicate multipleToString(CfgNode n, string s) {
+  s = strictconcat(n.toString(), ",") and
+  strictcount(n.toString()) > 1
 }

--- a/ruby/ql/consistency-queries/DataFlowConsistency.ql
+++ b/ruby/ql/consistency-queries/DataFlowConsistency.ql
@@ -33,3 +33,8 @@ private class MyConsistencyConfiguration extends ConsistencyConfiguration {
     )
   }
 }
+
+query predicate multipleToString(Node n, string s) {
+  s = strictconcat(n.toString(), ",") and
+  strictcount(n.toString()) > 1
+}


### PR DESCRIPTION
Flags nodes with multiple `toString`s.