### PR TITLE
C#: Add `toString` functionality consistency queries

### DIFF
--- a/csharp/ql/consistency-queries/AstConsistency.qll
+++ b/csharp/ql/consistency-queries/AstConsistency.qll
@@ -17,3 +17,8 @@ query predicate missingLocation(Element e) {
   not exists(TupleType t | e = t or e = t.getAField()) and
   not exists(e.getLocation())
 }
+
+query predicate multipleToString(Element e, string s) {
+  s = strictconcat(e.toString(), ",") and
+  strictcount(e.toString()) > 1
+}

--- a/csharp/ql/consistency-queries/CfgConsistency.ql
+++ b/csharp/ql/consistency-queries/CfgConsistency.ql
@@ -62,3 +62,8 @@ query predicate preBasicBlockConsistency(ControlFlowElement cfe1, ControlFlowEle
   bbIntraSuccInconsistency(cfe1, cfe2) and
   s = "intra succ inconsistency"
 }
+
+query predicate multipleToString(Node n, string s) {
+  s = strictconcat(n.toString(), ",") and
+  strictcount(n.toString()) > 1
+}

--- a/csharp/ql/consistency-queries/DataFlowConsistency.ql
+++ b/csharp/ql/consistency-queries/DataFlowConsistency.ql
@@ -74,3 +74,8 @@ private class MyConsistencyConfiguration extends ConsistencyConfiguration {
 
   override predicate identityLocalStepExclude(Node n) { none() }
 }
+
+query predicate multipleToString(Node n, string s) {
+  s = strictconcat(n.toString(), ",") and
+  strictcount(n.toString()) > 1
+}


### PR DESCRIPTION
Flags nodes with multiple `toString`s.