### PR TITLE
Add workflow to check for warnOnImplicitThis

### DIFF
--- a/.github/workflows/check-implicit-this.yml
+++ b/.github/workflows/check-implicit-this.yml
@@ -1,0 +1,22 @@
+name: "Check implicit this warnings"
+
+on: workflow_dispatch
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Check that implicit this warnings is enabled for all packs
+        shell: bash
+        run: |
+          EXIT_CODE=0
+          packs="$(find . -iname 'qlpack.yml')"
+          for pack_file in ${packs}; do
+            option="$(yq '.warnOnImplicitThis' ${pack_file})"
+            if [ "${option}" != "true" ]; then
+              echo "warnOnImplicitThis property must be set to 'true' for pack ${pack_file}"
+              EXIT_CODE=1
+            fi
+          done
+          exit "${EXIT_CODE}"


### PR DESCRIPTION
This PR adds a workflow to verify that all QL packs in `github/codeql` have the `warnOnImplicitThis` property configured to `true`. The workflow is initially configured to trigger manually, until I have verified the workflow and `warnOnImplicitThis` has been configured to `true` for all remaining packs. 