### PR TITLE
Java: Tweak some android tests

### DIFF
--- a/java/ql/integration-tests/all-platforms/java/android-sample-old-style-kotlin-build-script-no-wrapper/project/build.gradle.kts
+++ b/java/ql/integration-tests/all-platforms/java/android-sample-old-style-kotlin-build-script-no-wrapper/project/build.gradle.kts
@@ -54,6 +54,9 @@ android {
         versionName = "1.0"
     }
 
+    lintOptions {
+        disable("Instantiatable")
+    }
 }
 
 androidComponents {

--- a/java/ql/integration-tests/all-platforms/java/android-sample-old-style-kotlin-build-script-no-wrapper/test.expected
+++ b/java/ql/integration-tests/all-platforms/java/android-sample-old-style-kotlin-build-script-no-wrapper/test.expected
@@ -13,6 +13,7 @@ xmlFiles
 | project/build/intermediates/incremental/mergeReleaseJniLibFolders/merger.xml:0:0:0:0 | project/build/intermediates/incremental/mergeReleaseJniLibFolders/merger.xml |
 | project/build/intermediates/incremental/mergeReleaseResources/merger.xml:0:0:0:0 | project/build/intermediates/incremental/mergeReleaseResources/merger.xml |
 | project/build/intermediates/incremental/mergeReleaseShaders/merger.xml:0:0:0:0 | project/build/intermediates/incremental/mergeReleaseShaders/merger.xml |
+| project/build/intermediates/lint_vital_partial_results/release/out/lint-issues-release.xml:0:0:0:0 | project/build/intermediates/lint_vital_partial_results/release/out/lint-issues-release.xml |
 | project/build/intermediates/merged_manifest/release/AndroidManifest.xml:0:0:0:0 | project/build/intermediates/merged_manifest/release/AndroidManifest.xml |
 | project/build/intermediates/merged_manifests/release/AndroidManifest.xml:0:0:0:0 | project/build/intermediates/merged_manifests/release/AndroidManifest.xml |
 | project/build/intermediates/packaged_manifests/release/AndroidManifest.xml:0:0:0:0 | project/build/intermediates/packaged_manifests/release/AndroidManifest.xml |

--- a/java/ql/integration-tests/all-platforms/java/android-sample-old-style-kotlin-build-script/project/build.gradle.kts
+++ b/java/ql/integration-tests/all-platforms/java/android-sample-old-style-kotlin-build-script/project/build.gradle.kts
@@ -54,6 +54,9 @@ android {
         versionName = "1.0"
     }
 
+    lintOptions {
+        disable("Instantiatable")
+    }
 }
 
 androidComponents {

--- a/java/ql/integration-tests/all-platforms/java/android-sample-old-style-kotlin-build-script/test.expected
+++ b/java/ql/integration-tests/all-platforms/java/android-sample-old-style-kotlin-build-script/test.expected
@@ -13,6 +13,7 @@ xmlFiles
 | project/build/intermediates/incremental/mergeReleaseJniLibFolders/merger.xml:0:0:0:0 | project/build/intermediates/incremental/mergeReleaseJniLibFolders/merger.xml |
 | project/build/intermediates/incremental/mergeReleaseResources/merger.xml:0:0:0:0 | project/build/intermediates/incremental/mergeReleaseResources/merger.xml |
 | project/build/intermediates/incremental/mergeReleaseShaders/merger.xml:0:0:0:0 | project/build/intermediates/incremental/mergeReleaseShaders/merger.xml |
+| project/build/intermediates/lint_vital_partial_results/release/out/lint-issues-release.xml:0:0:0:0 | project/build/intermediates/lint_vital_partial_results/release/out/lint-issues-release.xml |
 | project/build/intermediates/merged_manifest/release/AndroidManifest.xml:0:0:0:0 | project/build/intermediates/merged_manifest/release/AndroidManifest.xml |
 | project/build/intermediates/merged_manifests/release/AndroidManifest.xml:0:0:0:0 | project/build/intermediates/merged_manifests/release/AndroidManifest.xml |
 | project/build/intermediates/packaged_manifests/release/AndroidManifest.xml:0:0:0:0 | project/build/intermediates/packaged_manifests/release/AndroidManifest.xml |

--- a/java/ql/integration-tests/all-platforms/java/android-sample-old-style-no-wrapper/project/build.gradle
+++ b/java/ql/integration-tests/all-platforms/java/android-sample-old-style-no-wrapper/project/build.gradle
@@ -55,4 +55,8 @@ android {
     }
 
     variantFilter { variant -> if (variant.buildType.name == "debug") { setIgnore(true) } }
+
+    lintOptions {
+        disable "Instantiatable"
+    }
 }

--- a/java/ql/integration-tests/all-platforms/java/android-sample-old-style-no-wrapper/test.expected
+++ b/java/ql/integration-tests/all-platforms/java/android-sample-old-style-no-wrapper/test.expected
@@ -13,6 +13,7 @@ xmlFiles
 | project/build/intermediates/incremental/mergeReleaseJniLibFolders/merger.xml:0:0:0:0 | project/build/intermediates/incremental/mergeReleaseJniLibFolders/merger.xml |
 | project/build/intermediates/incremental/mergeReleaseResources/merger.xml:0:0:0:0 | project/build/intermediates/incremental/mergeReleaseResources/merger.xml |
 | project/build/intermediates/incremental/mergeReleaseShaders/merger.xml:0:0:0:0 | project/build/intermediates/incremental/mergeReleaseShaders/merger.xml |
+| project/build/intermediates/lint_vital_partial_results/release/out/lint-issues-release.xml:0:0:0:0 | project/build/intermediates/lint_vital_partial_results/release/out/lint-issues-release.xml |
 | project/build/intermediates/merged_manifest/release/AndroidManifest.xml:0:0:0:0 | project/build/intermediates/merged_manifest/release/AndroidManifest.xml |
 | project/build/intermediates/merged_manifests/release/AndroidManifest.xml:0:0:0:0 | project/build/intermediates/merged_manifests/release/AndroidManifest.xml |
 | project/build/intermediates/packaged_manifests/release/AndroidManifest.xml:0:0:0:0 | project/build/intermediates/packaged_manifests/release/AndroidManifest.xml |

--- a/java/ql/integration-tests/all-platforms/java/android-sample-old-style/project/build.gradle
+++ b/java/ql/integration-tests/all-platforms/java/android-sample-old-style/project/build.gradle
@@ -55,4 +55,8 @@ android {
     }
 
     variantFilter { variant -> if (variant.buildType.name == "debug") { setIgnore(true) } }
+
+    lintOptions {
+        disable "Instantiatable"
+    }
 }

--- a/java/ql/integration-tests/all-platforms/java/android-sample-old-style/test.expected
+++ b/java/ql/integration-tests/all-platforms/java/android-sample-old-style/test.expected
@@ -13,6 +13,7 @@ xmlFiles
 | project/build/intermediates/incremental/mergeReleaseJniLibFolders/merger.xml:0:0:0:0 | project/build/intermediates/incremental/mergeReleaseJniLibFolders/merger.xml |
 | project/build/intermediates/incremental/mergeReleaseResources/merger.xml:0:0:0:0 | project/build/intermediates/incremental/mergeReleaseResources/merger.xml |
 | project/build/intermediates/incremental/mergeReleaseShaders/merger.xml:0:0:0:0 | project/build/intermediates/incremental/mergeReleaseShaders/merger.xml |
+| project/build/intermediates/lint_vital_partial_results/release/out/lint-issues-release.xml:0:0:0:0 | project/build/intermediates/lint_vital_partial_results/release/out/lint-issues-release.xml |
 | project/build/intermediates/merged_manifest/release/AndroidManifest.xml:0:0:0:0 | project/build/intermediates/merged_manifest/release/AndroidManifest.xml |
 | project/build/intermediates/merged_manifests/release/AndroidManifest.xml:0:0:0:0 | project/build/intermediates/merged_manifests/release/AndroidManifest.xml |
 | project/build/intermediates/packaged_manifests/release/AndroidManifest.xml:0:0:0:0 | project/build/intermediates/packaged_manifests/release/AndroidManifest.xml |


### PR DESCRIPTION
They were all failing for me like:
```
[autobuild] /home/ian/code/dev/target/codeql-java-integration-tests/ql/java/ql/integration-tests/all-platforms/java/android-sample-old-style-no-wrapper/project/src/main/AndroidManifest.xml:5: Error: Main must extend android.app.Activity [Instantiatable]
[autobuild]         <activity android:name="Main" android:exported="true">
[autobuild]                                 ~~~~
[autobuild]    Explanation for issues of type "Instantiatable":
[autobuild]    Activities, services, broadcast receivers etc. registered in the manifest
[autobuild]    file (or for custom views, in a layout file) must be "instantiatable" by
[autobuild]    the system, which means that the class must be public, it must have an
[autobuild]    empty public constructor, and if it's an inner class, it must be a static
[autobuild]    inner class.
```
I'm not sure why it works on CI but not locally, but either way this works around the issue.