### PR TITLE
Swift: fix all upstream headers for C++20

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,9 +5,9 @@ repos:
     rev: v3.2.0
     hooks:
       - id: trailing-whitespace
-        exclude: /test/.*$(?<!\.ql)(?<!\.qll)(?<!\.qlref)
+        exclude: /test/.*$(?<!\.ql)(?<!\.qll)(?<!\.qlref)|.*\.patch
       - id: end-of-file-fixer
-        exclude: /test/.*$(?<!\.ql)(?<!\.qll)(?<!\.qlref)
+        exclude: /test/.*$(?<!\.ql)(?<!\.qll)(?<!\.qlref)|.*\.patch
 
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v13.0.1

--- a/swift/third_party/load.bzl
+++ b/swift/third_party/load.bzl
@@ -43,7 +43,14 @@ def load_dependencies(workspace_name):
             build_file = _build(workspace_name, "swift-llvm-support"),
             sha256 = sha256,
             patch_args = ["-p1"],
-            patches = ["@%s//swift/third_party/swift-llvm-support:patches/remove-result-of.patch" % workspace_name],
+            patches = [
+                "@%s//swift/third_party/swift-llvm-support:patches/%s.patch" % (workspace_name, patch_name)
+                for patch_name in (
+                    "remove-result-of",
+                    "remove-redundant-operators",
+                    "add-constructor-to-Compilation",
+                )
+            ],
         )
 
     _github_archive(

--- a/swift/third_party/swift-llvm-support/patches/add-constructor-to-Compilation.patch
+++ b/swift/third_party/swift-llvm-support/patches/add-constructor-to-Compilation.patch
@@ -1,0 +1,17 @@
+In C++20 aggregate initialization on classes with user-declared constructor is not
+available, while in C++11-C++17 it was available if they were defaulted or deleted.
+
+diff --git a/include/swift/Driver/Compilation.h b/include/swift/Driver/Compilation.h
+index ee76f92e0de..bd987157593 100644
+--- a/include/swift/Driver/Compilation.h
++++ b/include/swift/Driver/Compilation.h
+@@ -89,6 +89,9 @@ public:
+     /// This data is used for cross-module module dependencies.
+     fine_grained_dependencies::ModuleDepGraph depGraph;
+
++    Result(bool hadAbnormalExit = false, int exitCode = 0, fine_grained_dependencies::ModuleDepGraph depGraph = {})
++        : hadAbnormalExit{hadAbnormalExit}, exitCode{exitCode}, depGraph{std::move(depGraph)} {}
++
+     Result(const Result &) = delete;
+     Result &operator=(const Result &) = delete;
+

--- a/swift/third_party/swift-llvm-support/patches/remove-redundant-operators.patch
+++ b/swift/third_party/swift-llvm-support/patches/remove-redundant-operators.patch
@@ -1,0 +1,24 @@
+In C++20 the removed operators are available via operator rewriting and
+implicit constructors, providing them leads to ambiguity.
+
+diff --git a/include/swift/SIL/SILValue.h b/include/swift/SIL/SILValue.h
+index 378ca039c7e..37c119c50c1 100644
+--- a/include/swift/SIL/SILValue.h
++++ b/include/swift/SIL/SILValue.h
+@@ -271,16 +271,6 @@ struct ValueOwnershipKind {
+
+   explicit operator bool() const { return value != OwnershipKind::Any; }
+
+-  bool operator==(ValueOwnershipKind other) const {
+-    return value == other.value;
+-  }
+-  bool operator!=(ValueOwnershipKind other) const {
+-    return !(value == other.value);
+-  }
+-
+-  bool operator==(innerty other) const { return value == other; }
+-  bool operator!=(innerty other) const { return !(value == other); }
+-
+   /// We merge by moving down the lattice.
+   ValueOwnershipKind merge(ValueOwnershipKind rhs) const {
+     return value.meet(rhs.value);


### PR DESCRIPTION
This is not required yet, but may be as soon as we start including SIL headers.