### PR TITLE
CPP: Enable implicit this warnings for remaining packs

### DIFF
--- a/cpp/downgrades/qlpack.yml
+++ b/cpp/downgrades/qlpack.yml
@@ -2,3 +2,4 @@ name: codeql/cpp-downgrades
 groups: cpp
 downgrades: .
 library: true
+warnOnImplicitThis: true

--- a/cpp/ql/examples/qlpack.yml
+++ b/cpp/ql/examples/qlpack.yml
@@ -4,3 +4,4 @@ groups:
   - examples
 dependencies:
   codeql/cpp-all: ${workspace}
+warnOnImplicitThis: true

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/tainted/qlpack.yml
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/tainted/qlpack.yml
@@ -6,3 +6,4 @@ dependencies:
   codeql/cpp-queries: ${workspace}
 extractor: cpp
 tests: .
+warnOnImplicitThis: true


### PR DESCRIPTION
This PR enables implicit this warnings for remaining CPP QL packs.