### PR TITLE
C#: Enable implicit this warnings for remaining packs

### DIFF
--- a/csharp/downgrades/qlpack.yml
+++ b/csharp/downgrades/qlpack.yml
@@ -2,3 +2,4 @@ name: codeql/csharp-downgrades
 groups: csharp
 downgrades: .
 library: true
+warnOnImplicitThis: true

--- a/csharp/ql/campaigns/Solorigate/lib/qlpack.yml
+++ b/csharp/ql/campaigns/Solorigate/lib/qlpack.yml
@@ -6,3 +6,4 @@ groups:
 library: true
 dependencies:
     codeql/csharp-all: ${workspace}
+warnOnImplicitThis: true

--- a/csharp/ql/campaigns/Solorigate/src/qlpack.yml
+++ b/csharp/ql/campaigns/Solorigate/src/qlpack.yml
@@ -7,3 +7,4 @@ defaultSuiteFile: codeql-suites/solorigate.qls
 dependencies:
     codeql/csharp-all: ${workspace}
     codeql/csharp-solorigate-all: ${workspace}
+warnOnImplicitThis: true

--- a/csharp/ql/campaigns/Solorigate/test/qlpack.yml
+++ b/csharp/ql/campaigns/Solorigate/test/qlpack.yml
@@ -10,3 +10,4 @@ dependencies:
   codeql/csharp-solorigate-queries: ${workspace}
 extractor: csharp
 tests: .
+warnOnImplicitThis: true

--- a/csharp/ql/consistency-queries/qlpack.yml
+++ b/csharp/ql/consistency-queries/qlpack.yml
@@ -3,3 +3,4 @@ groups: [csharp, test, consistency-queries]
 dependencies:
   codeql/csharp-all: ${workspace}
 extractor: csharp
+warnOnImplicitThis: true

--- a/csharp/ql/examples/qlpack.yml
+++ b/csharp/ql/examples/qlpack.yml
@@ -4,3 +4,4 @@ groups:
   - examples
 dependencies:
   codeql/csharp-all: ${workspace}
+warnOnImplicitThis: true

--- a/csharp/ql/integration-tests/qlpack.yml
+++ b/csharp/ql/integration-tests/qlpack.yml
@@ -1,2 +1,3 @@
 dependencies:
   codeql/csharp-all: '*'
+warnOnImplicitThis: true


### PR DESCRIPTION
This PR enables implicit this warnings for remaining C# QL packs. 