### PR TITLE
Go: Enable implicit this warnings for remaining packs

### DIFF
--- a/go/downgrades/qlpack.yml
+++ b/go/downgrades/qlpack.yml
@@ -2,3 +2,4 @@ name: codeql/go-downgrades
 groups: go
 downgrades: .
 library: true
+warnOnImplicitThis: true

--- a/go/external-packs/codeql/suite-helpers/0.0.2/qlpack.yml
+++ b/go/external-packs/codeql/suite-helpers/0.0.2/qlpack.yml
@@ -1,3 +1,4 @@
 name: codeql/suite-helpers
 version: 0.0.2
 library: true
+warnOnImplicitThis: true

--- a/go/ql/config/legacy-support/qlpack.yml
+++ b/go/ql/config/legacy-support/qlpack.yml
@@ -2,3 +2,4 @@ name: legacy-libraries-go
 version: 0.0.0
 # Note libraryPathDependencies is obsolete and should not be used in new qlpacks.
 libraryPathDependencies: codeql-go
+warnOnImplicitThis: true

--- a/go/ql/examples/qlpack.yml
+++ b/go/ql/examples/qlpack.yml
@@ -4,3 +4,4 @@ groups:
   - examples
 dependencies:
   codeql/go-all: ${workspace}
+warnOnImplicitThis: true

--- a/go/ql/integration-tests/all-platforms/go/qlpack.yml
+++ b/go/ql/integration-tests/all-platforms/go/qlpack.yml
@@ -2,3 +2,4 @@ dependencies:
   codeql/go-all: '*'
   codeql/go-tests: '*'
   codeql/go-queries: '*'
+warnOnImplicitThis: true

--- a/go/ql/integration-tests/linux-only/go/qlpack.yml
+++ b/go/ql/integration-tests/linux-only/go/qlpack.yml
@@ -2,3 +2,4 @@ dependencies:
   codeql/go-all: '*'
   codeql/go-tests: '*'
   codeql/go-queries: '*'
+warnOnImplicitThis: true


### PR DESCRIPTION
This PR enables implicit this warnings for remaining Go QL packs.