### PR TITLE
Javascript: Enable implicit this warnings for remaining packs

### DIFF
--- a/javascript/downgrades/qlpack.yml
+++ b/javascript/downgrades/qlpack.yml
@@ -2,3 +2,4 @@ name: codeql/javascript-downgrades
 groups: javascript
 downgrades: .
 library: true
+warnOnImplicitThis: true

--- a/javascript/ql/examples/qlpack.yml
+++ b/javascript/ql/examples/qlpack.yml
@@ -4,3 +4,4 @@ groups:
   - examples
 dependencies:
   codeql/javascript-all: ${workspace}
+warnOnImplicitThis: true

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/qlpack.yml
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/qlpack.yml
@@ -8,3 +8,4 @@ groups:
     - experimental
 dependencies:
     codeql/javascript-all: ${workspace}
+warnOnImplicitThis: true

--- a/javascript/ql/experimental/adaptivethreatmodeling/model/qlpack.yml
+++ b/javascript/ql/experimental/adaptivethreatmodeling/model/qlpack.yml
@@ -6,3 +6,4 @@ groups:
     - experimental
 mlModels:
     - "resources/*.codeqlmodel"
+warnOnImplicitThis: true

--- a/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/qlpack.yml
+++ b/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/qlpack.yml
@@ -8,3 +8,4 @@ groups:
 dependencies:
     codeql/javascript-experimental-atm-lib: ${workspace}
     codeql/javascript-experimental-atm-model: "0.3.1-2023-03-01-12h42m43s.strong-turtle-1xp3dqvv.ecb17d40286d14132b481c065a43459a7f0ba9059015b7a49c909c9f9ce5fec5"
+warnOnImplicitThis: true

--- a/javascript/ql/experimental/adaptivethreatmodeling/src/qlpack.yml
+++ b/javascript/ql/experimental/adaptivethreatmodeling/src/qlpack.yml
@@ -10,3 +10,4 @@ groups:
 dependencies:
     codeql/javascript-experimental-atm-lib: ${workspace}
     codeql/javascript-experimental-atm-model: "0.3.1-2023-03-01-12h42m43s.strong-turtle-1xp3dqvv.ecb17d40286d14132b481c065a43459a7f0ba9059015b7a49c909c9f9ce5fec5"
+warnOnImplicitThis: true

--- a/javascript/ql/experimental/adaptivethreatmodeling/test/qlpack.yml
+++ b/javascript/ql/experimental/adaptivethreatmodeling/test/qlpack.yml
@@ -2,3 +2,4 @@ name: codeql/javascript-experimental-atm-tests
 extractor: javascript
 dependencies:
     codeql/javascript-experimental-atm-model-building: ${workspace}
+warnOnImplicitThis: true

--- a/javascript/ql/integration-tests/all-platforms/qlpack.yml
+++ b/javascript/ql/integration-tests/all-platforms/qlpack.yml
@@ -1,3 +1,4 @@
 dependencies:
   codeql/javascript-all: '*'
   codeql/javascript-queries: '*'
+warnOnImplicitThis: true


### PR DESCRIPTION
This PR enables implicit this warnings for remaining Javascript QL packs.