### PR TITLE
Python: Enable implicit this warnings for remaining packs

### DIFF
--- a/python/downgrades/qlpack.yml
+++ b/python/downgrades/qlpack.yml
@@ -2,3 +2,4 @@ name: codeql/python-downgrades
 groups: python
 downgrades: .
 library: true
+warnOnImplicitThis: true

--- a/python/ql/consistency-queries/qlpack.yml
+++ b/python/ql/consistency-queries/qlpack.yml
@@ -3,3 +3,4 @@ groups: [python, test, consistency-queries]
 dependencies:
     codeql/python-all: ${workspace}
 extractor: python
+warnOnImplicitThis: true

--- a/python/ql/examples/qlpack.yml
+++ b/python/ql/examples/qlpack.yml
@@ -4,3 +4,4 @@ groups:
   - examples
 dependencies:
   codeql/python-all: ${workspace}
+warnOnImplicitThis: true

--- a/python/tools/recorded-call-graph-metrics/ql/qlpack.yml
+++ b/python/tools/recorded-call-graph-metrics/ql/qlpack.yml
@@ -3,3 +3,4 @@ version: 0.0.1
 extractor: python
 dependencies:
   codeql/python-all: '*'
+warnOnImplicitThis: true


### PR DESCRIPTION
This PR enables implicit this warnings for remaining Python QL packs. 