### PR TITLE
QL: Enable implicit this warnings for remaining packs

### DIFF
--- a/ql/ql/consistency-queries/qlpack.yml
+++ b/ql/ql/consistency-queries/qlpack.yml
@@ -3,3 +3,4 @@ groups: [ql, test, consistency-queries]
 dependencies:
   codeql/ql: ${workspace}
 extractor: ql
+warnOnImplicitThis: true

--- a/ql/ql/examples/qlpack.yml
+++ b/ql/ql/examples/qlpack.yml
@@ -2,3 +2,4 @@ name: codeql/ql-examples
 groups: [ql, examples]
 dependencies:
     codeql/ql: ${workspace}
+warnOnImplicitThis: true

--- a/ql/ql/test/callgraph/packs/lib/qlpack.yml
+++ b/ql/ql/test/callgraph/packs/lib/qlpack.yml
@@ -1,3 +1,4 @@
 name: ql-testing-lib-pack
 version: 0.1.0
 extractor: ql-test-stuff
+warnOnImplicitThis: true

--- a/ql/ql/test/callgraph/packs/other/qlpack.yml
+++ b/ql/ql/test/callgraph/packs/other/qlpack.yml
@@ -2,3 +2,4 @@ name: ql-other-pack-thing
 version: 0.1.0
 dependencies:
   ql-testing-src-pack: '*'
+warnOnImplicitThis: true

--- a/ql/ql/test/callgraph/packs/src/qlpack.yml
+++ b/ql/ql/test/callgraph/packs/src/qlpack.yml
@@ -2,3 +2,4 @@ name: ql-testing-src-pack
 version: 0.1.0
 dependencies: 
   ql-testing-lib-pack: ${workspace}
+warnOnImplicitThis: true

--- a/ql/ql/test/qlpack.yml
+++ b/ql/ql/test/qlpack.yml
@@ -5,3 +5,4 @@ dependencies:
     codeql/ql-examples: ${workspace}
 extractor: ql
 tests: .
+warnOnImplicitThis: true


### PR DESCRIPTION
This PR enables implicit this warnings for remaining QL-for-QL packs.