### PR TITLE
Ruby: Enable implicit this warnings for remaining packs

### DIFF
--- a/ruby/downgrades/qlpack.yml
+++ b/ruby/downgrades/qlpack.yml
@@ -2,3 +2,4 @@ name: codeql/ruby-downgrades
 groups: ruby
 downgrades: .
 library: true
+warnOnImplicitThis: true

--- a/ruby/ql/consistency-queries/qlpack.yml
+++ b/ruby/ql/consistency-queries/qlpack.yml
@@ -2,3 +2,4 @@ name: codeql/ruby-consistency-queries
 groups: [ruby, test, consistency-queries]
 dependencies:
   codeql/ruby-all: ${workspace}
+warnOnImplicitThis: true

--- a/ruby/ql/examples/qlpack.yml
+++ b/ruby/ql/examples/qlpack.yml
@@ -4,3 +4,4 @@ groups:
   - examples
 dependencies:
   codeql/ruby-all: ${workspace}
+warnOnImplicitThis: true

--- a/ruby/ql/integration-tests/all-platforms/qlpack.yml
+++ b/ruby/ql/integration-tests/all-platforms/qlpack.yml
@@ -1,3 +1,4 @@
 dependencies:
   codeql/ruby-all: '*'
   codeql/ruby-queries: '*'
+warnOnImplicitThis: true


### PR DESCRIPTION
This PR enables implicit this warnings for remaining Ruby QL packs.