### PR TITLE
Swift: Enable implicit this warnings for remaining packs

### DIFF
--- a/swift/downgrades/qlpack.yml
+++ b/swift/downgrades/qlpack.yml
@@ -2,3 +2,4 @@ name: codeql/swift-downgrades
 groups: swift
 downgrades: .
 library: true
+warnOnImplicitThis: true

--- a/swift/integration-tests/qlpack.yml
+++ b/swift/integration-tests/qlpack.yml
@@ -4,3 +4,4 @@ dependencies:
   codeql/swift-all: ${workspace}
 tests: .
 extractor: swift
+warnOnImplicitThis: true

--- a/swift/ql/consistency-queries/qlpack.yml
+++ b/swift/ql/consistency-queries/qlpack.yml
@@ -2,3 +2,4 @@ name: codeql/swift-consistency-queries
 groups: [swift, test, consistency-queries]
 dependencies:
   codeql/swift-all: ${workspace}
+warnOnImplicitThis: true

--- a/swift/ql/examples/qlpack.yml
+++ b/swift/ql/examples/qlpack.yml
@@ -4,3 +4,4 @@ groups:
   - examples
 dependencies:
   codeql/swift-all: ${workspace}
+warnOnImplicitThis: true


### PR DESCRIPTION
This PR enables implicit this warnings for remaining Swift QL packs.