### PR TITLE
Java: Fix external API name for nested types

### DIFF
--- a/java/ql/src/Telemetry/ExternalApi.qll
+++ b/java/ql/src/Telemetry/ExternalApi.qll
@@ -27,8 +27,9 @@ class ExternalApi extends Callable {
    */
   string getApiName() {
     result =
-      this.getDeclaringType().getPackage() + "." + this.getDeclaringType().nestedName() + "#" +
-        this.getName() + paramsString(this)
+      this.getDeclaringType().getPackage() + "." +
+        this.getDeclaringType().getSourceDeclaration().nestedName() + "#" + this.getName() +
+        paramsString(this)
   }
 
   private string getJarName() {

--- a/java/ql/src/Telemetry/ExternalApi.qll
+++ b/java/ql/src/Telemetry/ExternalApi.qll
@@ -27,8 +27,8 @@ class ExternalApi extends Callable {
    */
   string getApiName() {
     result =
-      this.getDeclaringType().getPackage() + "." + this.getDeclaringType().getSourceDeclaration() +
-        "#" + this.getName() + paramsString(this)
+      this.getDeclaringType().getPackage() + "." + this.getDeclaringType().nestedName() + "#" +
+        this.getName() + paramsString(this)
   }
 
   private string getJarName() {

--- a/java/ql/test/query-tests/Telemetry/SupportedExternalApis/SupportedExternalApis.expected
+++ b/java/ql/test/query-tests/Telemetry/SupportedExternalApis/SupportedExternalApis.expected
@@ -7,5 +7,9 @@
 | java.net.URL#openStream() | 1 |
 | java.net.URLConnection#getInputStream() | 1 |
 | java.time.Duration#ofMillis(long) | 1 |
+| java.util.Iterator#next() | 1 |
+| java.util.Map#entrySet() | 1 |
 | java.util.Map#put(Object,Object) | 1 |
+| java.util.Map$Entry#getKey() | 1 |
+| java.util.Set#iterator() | 1 |
 | org.apache.commons.io.FileUtils#deleteDirectory(File) | 1 |

--- a/java/ql/test/query-tests/Telemetry/SupportedExternalApis/SupportedExternalApis.java
+++ b/java/ql/test/query-tests/Telemetry/SupportedExternalApis/SupportedExternalApis.java
@@ -15,6 +15,7 @@ class SupportedExternalApis {
 
 		Map<String, Object> map = new HashMap<>(); // uninteresting (parameterless constructor)
 		map.put("foo", new Object()); // supported summary
+		map.entrySet().iterator().next().getKey(); // nested class (Map.Entry), supported summaries (entrySet, iterator, next, getKey)
 
 		Duration d = java.time.Duration.ofMillis(1000); // supported neutral
 


### PR DESCRIPTION
This fixes the name of reported external APIs for nested types. The `toString()` method of `getSourceDeclaration()` would report the name of a type, but not the name of the enclosing type. This results in missing information in the `UnsupportedExternalAPIs.ql` query.

For example, previously it would report:

```
org.zapodot.junit.db.Builder#build()
```

However, the `Builder` class does not exist in the package and is only a nested type within `EmbeddedDatabaseRule`. The correct name should be:

```
org.zapodot.junit.db.EmbeddedDatabaseRule$Builder#build()
```

This name also matches the format of MaD.