### PR TITLE
C#: Fix external API name for nested types

### DIFF
--- a/csharp/ql/src/Telemetry/ExternalApi.qll
+++ b/csharp/ql/src/Telemetry/ExternalApi.qll
@@ -50,7 +50,7 @@ class ExternalApi extends DotNet::Callable {
   bindingset[this]
   private string getSignature() {
     result =
-      this.getDeclaringType().getUnboundDeclaration() + "." + this.getName() + "(" +
+      nestedName(this.getDeclaringType().getUnboundDeclaration()) + "." + this.getName() + "(" +
         parameterQualifiedTypeNamesToString(this) + ")"
   }
 
@@ -116,6 +116,21 @@ class ExternalApi extends DotNet::Callable {
   predicate isSupported() {
     this.hasSummary() or this.isSource() or this.isSink() or this.isNeutral()
   }
+}
+
+/**
+ * Gets the nested name of the declaration.
+ *
+ * If the declaration is not a nested type, the result is the same as \`getName()\`.
+ * Otherwise the name of the nested type is prefixed with a \`+\` and appended to
+ * the name of the enclosing type, which might be a nested type as well.
+ */
+private string nestedName(Declaration declaration) {
+  not exists(declaration.getDeclaringType().getUnboundDeclaration()) and
+  result = declaration.getName()
+  or
+  nestedName(declaration.getDeclaringType().getUnboundDeclaration()) + "+" + declaration.getName() =
+    result
 }
 
 /**

--- a/csharp/ql/test/query-tests/Telemetry/LibraryUsage/ExternalLibraryUsage.cs
+++ b/csharp/ql/test/query-tests/Telemetry/LibraryUsage/ExternalLibraryUsage.cs
@@ -25,4 +25,10 @@ public class LibraryUsage
     {
         var guid1 = Guid.Parse("{12345678-1234-1234-1234-123456789012}"); // Has no flow summary
     }
+
+    public void M4()
+    {
+        var d = new Dictionary<string, object>(); // Uninteresting parameterless constructor
+        var e = d.Keys.GetEnumerator().MoveNext(); // Methods on nested classes
+    }
 }

--- a/csharp/ql/test/query-tests/Telemetry/LibraryUsage/ExternalLibraryUsage.expected
+++ b/csharp/ql/test/query-tests/Telemetry/LibraryUsage/ExternalLibraryUsage.expected
@@ -1,2 +1,2 @@
 | System | 5 |
-| System.Collections.Generic | 2 |
+| System.Collections.Generic | 5 |

--- a/csharp/ql/test/query-tests/Telemetry/LibraryUsage/SupportedExternalTaint.expected
+++ b/csharp/ql/test/query-tests/Telemetry/LibraryUsage/SupportedExternalTaint.expected
@@ -1,1 +1,3 @@
 | System.Collections.Generic#List<>.Add(T) | 2 |
+| System.Collections.Generic#Dictionary<,>+KeyCollection.GetEnumerator() | 1 |
+| System.Collections.Generic#Dictionary<,>.get_Keys() | 1 |


### PR DESCRIPTION
This fixes the name of reported external APIs for nested types. The `getDeclaringType().getUnboundDeclaration()`'s `toString()` method reports the name of the type, but not the name of the declaring type. This results in missing information in the `UnsupportedExternalAPIs.ql` query.

For example, previously it would report:

```
GitHub.Nested#NestedClass.Test()
```

However, the `NestedClass` class does not exist in the namespace and is only a nested type within `MyFirstClass`. The correct name should be:

```
GitHub.Nested#MyFirstClass+NestedClass.Test()
```

This name also matches the format of MaD.