### PR TITLE
C++: fix irreducible control flow logic

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/rangeanalysis/new/internal/semantic/SemanticSSA.qll
+++ b/cpp/ql/lib/semmle/code/cpp/rangeanalysis/new/internal/semantic/SemanticSSA.qll
@@ -70,7 +70,7 @@ predicate semBackEdge(SemSsaPhiNode phi, SemSsaVariable inp, SemSsaReadPositionP
   // Conservatively assume that every edge is a back edge if we don't have dominance information.
   (
     phi.getBasicBlock().bbDominates(edge.getOrigBlock()) or
-    irreducibleSccEdge(phi.getBasicBlock(), edge.getOrigBlock()) or
+    irreducibleSccEdge(edge.getOrigBlock(), phi.getBasicBlock()) or
     not edge.getOrigBlock().hasDominanceInformation()
   )
 }

--- a/cpp/ql/test/library-tests/ir/range-analysis/test.cpp
+++ b/cpp/ql/test/library-tests/ir/range-analysis/test.cpp
@@ -90,6 +90,7 @@ void gotoLoop(bool b1, bool b2)
   {
     for (j = 0; j < 10; ++j)
     {
+      int x;
       main_decode_loop:
     }
   }


### PR DESCRIPTION
This modifies the test to add an additional basic block to the loop, exposing a bug in the previous logic where the source and destination edges were reversed.