### PR TITLE
JS: Add Node.js File system Promises API

### DIFF
--- a/javascript/ql/src/experimental/Security/CWE-022/ReadableAdditionalStep.qll
+++ b/javascript/ql/src/experimental/Security/CWE-022/ReadableAdditionalStep.qll
@@ -1,0 +1,76 @@
+import javascript
+import API
+
+predicate readablePipeAdditionalTaintStep(DataFlow::Node pred, DataFlow::Node succ) {
+  exists(API::Node receiver |
+    receiver =
+      [
+        API::moduleImport("fs").getMember("createReadStream"),
+        API::moduleImport("stream").getMember("Readable")
+      ]
+  |
+    genaralStreamPipeAdditionalTaintStep(receiver, pred, succ)
+  )
+}
+
+predicate promisesFileHandlePipeAdditionalTaintStep(DataFlow::Node pred, DataFlow::Node succ) {
+  exists(API::Node receiver |
+    receiver =
+      nodeJsPromisesFileSystem()
+          .getMember("open")
+          .getASuccessor*()
+          .getMember(["createReadStream", "createWriteStream"])
+          .getReturn()
+  |
+    genaralStreamPipeAdditionalTaintStep(receiver, pred, succ)
+  )
+}
+
+// git receiver which we'll have receiver(pred).pipe(succ) and other succerssor pipe methods
+predicate genaralStreamPipeAdditionalTaintStep(
+  API::Node receiver, DataFlow::Node pred, DataFlow::Node succ
+) {
+  // this step connect the first pipe parameter to the last pipe parameter
+  pred = [receiver.getParameter(0).asSink(), receiver.asSource()] and
+  succ = receiver.getASuccessor*().getMember("pipe").getParameter(0).asSink()
+  or
+  // this step connect the a pipe parameter to the next pipe parameter
+  exists(API::Node cn | cn = receiver.getASuccessor*() |
+    pred = cn.getParameter(0).asSink() and
+    succ = cn.getReturn().getMember("pipe").getParameter(0).asSink()
+  )
+}
+
+predicate streamPipelineAdditionalTaintStep(DataFlow::Node pred, DataFlow::Node succ) {
+  // this step connect the a pipe parameter to the next parameter
+  exists(API::Node cn, int i |
+    i in [0 .. 10] and
+    cn = nodeJsStream().getMember("pipeline")
+  |
+    pred = cn.getParameter(i).asSink() and
+    succ = cn.getParameter(i + 1).asSink()
+  )
+  or
+  // this step connect the first pipe parameter to the next parameter
+  exists(API::Node cn, int i |
+    i in [1 .. 10] and
+    cn = nodeJsStream().getMember("pipeline")
+  |
+    pred = cn.getParameter(0).asSink() and
+    succ = cn.getParameter(i).asSink()
+  )
+}
+
+/**
+ * Promises API
+ */
+API::Node nodeJsPromisesFileSystem() {
+  result = [API::moduleImport("fs").getMember("promises"), API::moduleImport("fs/promises")]
+}
+
+/**
+ * Stream Promises API
+ */
+API::Node nodeJsStream() {
+  result = [API::moduleImport("stream/promises"), API::moduleImport("stream").getMember("promises")]
+}

--- a/javascript/ql/src/experimental/Security/CWE-022/TaintedPathDemo.ql
+++ b/javascript/ql/src/experimental/Security/CWE-022/TaintedPathDemo.ql
@@ -1,0 +1,177 @@
+/**
+ * @name Uncontrolled data used in path expression
+ * @description Demo of Accessing paths influenced by users can allow an attacker to access
+ *              unexpected resources.
+ * @kind path-problem
+ * @problem.severity error
+ * @security-severity 7.5
+ * @precision high
+ * @id js/path-injectiondemo
+ * @tags security
+ *       external/cwe/cwe-022
+ */
+
+import javascript
+import DataFlow::PathGraph
+import javascript
+import DOM
+import ReadableAdditionalStep
+
+/**
+ * A write to the file system.
+ * I can't extends  NodeJSFileSystemAccess
+ */
+class NodeJSPromisesFileSystemAccessWrite extends FileSystemWriteAccess, DataFlow::Node {
+  string methodName;
+  API::Node methodNode;
+
+  NodeJSPromisesFileSystemAccessWrite() {
+    methodName = ["open", "appendFile", "writeFile", "copyFile"] and
+    methodNode = nodeJsPromisesFileSystem().getMember(methodName) and
+    this = methodNode.asSource()
+  }
+
+  override DataFlow::Node getAPathArgument() { result = methodNode.getParameter(0).asSink() }
+
+  override DataFlow::Node getADataNode() {
+    methodName = ["appendFile", "writeFile", "copyFile"] and
+    result = methodNode.getParameter(1).asSink()
+    or
+    methodName = "open" and
+    result =
+      [
+        methodNode
+            .getASuccessor*()
+            .getMember(["appendFile", "write", "writeFile", "writev"])
+            .getParameter(0)
+            .asSink(),
+        methodNode.getASuccessor*().getMember("write").getASuccessor*().getMember("buffer").asSink(),
+        methodNode
+            .getASuccessor*()
+            .getMember("writev")
+            .getASuccessor*()
+            .getMember("buffers")
+            .asSink()
+      ]
+  }
+}
+
+/**
+ * A file system read.
+ * I can't extends NodeJSFileSystemAccess
+ */
+class NodeJSPromisesFileSystemAccessRead extends FileSystemReadAccess, DataFlow::Node {
+  string methodName;
+  API::Node methodNode;
+
+  NodeJSPromisesFileSystemAccessRead() {
+    methodName = ["open", "readdir", "readFile", "readlink"] and
+    methodNode = nodeJsPromisesFileSystem().getMember(methodName) and
+    this = methodNode.asSource()
+  }
+
+  override DataFlow::Node getADataNode() {
+    methodName = "open" and
+    result =
+      [
+        methodNode.getASuccessor*().getMember(["read", "readv"]).getParameter(0).asSink(),
+        // or the followings
+        methodNode
+            .getASuccessor*()
+            .getMember("read")
+            .getReturn()
+            .getASuccessor*()
+            .getMember("buffer")
+            .asSource(),
+        methodNode
+            .getASuccessor*()
+            .getMember("readv")
+            .getReturn()
+            .getASuccessor*()
+            .getMember("buffers")
+            .asSource(),
+        // readFile returns Buffer Object, idk how to proccess after that ??
+        methodNode.getASuccessor*().getMember("readFile").getASuccessor*().asSource()
+      ]
+    or
+    // the return value can be a parameter of promises or return value so I have to use getASuccessor*()
+    methodName = ["readdir", "readFile", "readlink"] and
+    result = methodNode.getReturn().getASuccessor*().asSource()
+  }
+
+  override DataFlow::Node getAPathArgument() { result = methodNode.getParameter(0).asSink() }
+}
+
+/**
+ * Promises API
+ */
+API::Node nodeJsPromisesFileSystem() {
+  result = [API::moduleImport("fs").getMember("promises"), API::moduleImport("fs/promises")]
+}
+
+class Configuration extends TaintTracking::Configuration {
+  Configuration() { this = "PathTraversal" }
+
+  override predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+
+  override predicate isSink(DataFlow::Node sink) {
+    sink = any(FileSystemReadAccess a).getAPathArgument()
+  }
+
+  override predicate isAdditionalTaintStep(DataFlow::Node pred, DataFlow::Node succ) {
+    // currently there is a Class named JoinedPath which idk why it it only working with path methods
+    // that only their first arg is constant and the number of args are 2 ??
+    // also there isn't any additional steps from a SpreadElement childs to SpreadElement itself
+    // e.g this CVE-2023-35844 vulnerability was detected because there is a path.join('/tmp',req.params.sth) in its DataFlow Path
+    // but this CVE-2023-35843 vulnerability was not detected(of course the fs/promises.readFile sink didn't exist too)
+    exists(API::Node n | n = API::moduleImport("path").getMember("join") |
+      pred = n.getAParameter().asSink() and
+      succ = n.getReturn().asSource()
+      // It is really wierd that I cant get second arg of pat.join in following
+      // `path.join("a/", ...filePath.split('/'))`
+      // with API::moduleImport("path").getMember("join").getAParameter()
+      // note that if there was filepath instead of second arg I could get the second parameter
+      // so I'm using following exists instead of using of API graphs
+    )
+    or
+    exists(MethodCallExpr call, VarAccess receiver | receiver = call.getReceiver().(VarAccess) |
+      receiver.getName() = "path" and
+      call.getMethodName() = "join" and
+      pred.asExpr() = call.getAnArgument() and
+      succ.asExpr() = receiver
+    )
+    or
+    // succ = filePath.split('/')
+    // pred = filePath
+    exists(DataFlow::MethodCallNode method |
+      method.getMethodName() = "split" and
+      pred = method.getReceiver() and
+      succ = method
+    )
+    or
+    // // succ = ...aMethodCall
+    // // pred = aMethodCall
+    exists(SpreadElement spread |
+      succ.asExpr() = spread and
+      pred.asExpr() = any(Expr e | e = spread.getAChild*() and not e instanceof Literal)
+    )
+    or
+    // https://www.npmjs.com/package/slash 65M d/w :))
+    // it exists in the DataFlow Path of related CVE
+    exists(DataFlow::CallNode slash | slash = DataFlow::moduleImport("slash").getACall() |
+      pred = slash.getArgument(0) and
+      succ = slash
+    )
+    or
+    promisesFileHandlePipeAdditionalTaintStep(pred, succ)
+    or
+    streamPipelineAdditionalTaintStep(pred, succ)
+    or
+    readablePipeAdditionalTaintStep(pred, succ)
+  }
+}
+
+from Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink
+where cfg.hasFlowPath(source, sink)
+select sink.getNode(), source, sink, "This path depends on a $@.", source.getNode(),
+  "user-provided value"

--- a/javascript/ql/src/experimental/Security/CWE-022/TaintedPathDemo.ql
+++ b/javascript/ql/src/experimental/Security/CWE-022/TaintedPathDemo.ql
@@ -115,7 +115,9 @@ class Configuration extends TaintTracking::Configuration {
   override predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
 
   override predicate isSink(DataFlow::Node sink) {
-    sink = any(FileSystemReadAccess a).getAPathArgument()
+    sink = any(NodeJSPromisesFileSystemAccessRead a).getAPathArgument()
+    or
+    sink = any(NodeJSPromisesFileSystemAccessWrite a).getAPathArgument()
   }
 
   override predicate isAdditionalTaintStep(DataFlow::Node pred, DataFlow::Node succ) {

--- a/javascript/ql/src/experimental/Security/CWE-022/example_CVE.ts
+++ b/javascript/ql/src/experimental/Security/CWE-022/example_CVE.ts
@@ -1,0 +1,48 @@
+import { Controller, Get, Param, Response, } from '@nestjs/common';
+import { AppService } from './app.service';
+import path from "path";
+import fs from 'node:fs';
+//or import fs from 'fs';
+import { readFile } from 'node:fs/promises';
+
+@Controller()
+export class AppController {
+    constructor(private readonly appService: AppService) {
+    }
+
+    @Get()
+    getHello(): string {
+        return this.appService.getHello();
+    }
+
+    // @Get(/^\/download\/(.+)$/)
+    // , getCacheMiddleware(), catchError(fileRead));
+    @Get('/download/:filename(*)')
+    // This route will match any URL that starts with
+    async fileRead(@Param('filename') filename: string, @Response() res) {
+        try {
+            const { img, type } = await this.fileReadHelper(
+                path.join('nc', 'uploads', filename)
+            );
+
+            res.writeHead(200, { 'Content-Type': type });
+            res.end(img, 'binary');
+        } catch (e) {
+            console.log(e);
+            res.status(404).send('Not found');
+        }
+    }
+
+    public async fileReadHelper(filePath: string): Promise<any> {
+        try {
+            await readFile(
+                path.join("a/", ...filePath.split('/')),
+            );
+            return await fs.promises.readFile(
+                path.join("a/", ...filePath.split('/')),
+            );
+        } catch (e) {
+            throw e;
+        }
+    }
+}

--- a/javascript/ql/src/experimental/Security/CWE-022/example_promisesFileAccess.js
+++ b/javascript/ql/src/experimental/Security/CWE-022/example_promisesFileAccess.js
@@ -1,0 +1,37 @@
+import fsPromises from "fs/promises";
+import fs from 'node:fs';
+import { Buffer } from 'node:buffer';
+import zlib from "zlib";
+
+const buf = Buffer.alloc(5);
+await fs.promises.open('/dev/input/event0');
+fsPromises.open("path").then((filehandle) => {
+    // FileSystemAccessWrite
+    filehandle.appendFile("dataaaaaaa")
+    filehandle.write(buf).then(r => r.buffer);
+    filehandle.writev(buf).then(r => r.buffers);
+    filehandle.writeFile("dataNode");
+    // FileSystemReadAccess
+    filehandle.read(buf).then(r => r.buffer);
+    filehandle.readv(buf).then(r => r.buffers);
+    filehandle.readFile().then(r => r);
+    filehandle.readLines();
+})
+
+const result = await fs.promises.open("src")
+// FileSystemReadAccess
+const readStream = result.promises.createReadStream();
+// FileSystemAccessWrite
+const writeStream = result.promises.createWriteStream();
+readStream.pipe(zlib.createGzip()).pipe(writeStream);
+import { pipeline } from 'stream/promises';
+
+await pipeline(
+    readStream,
+    zlib.createGzip(),
+    writeStream
+)
+fsPromises.readFile("src").then((r) => r.buffer);
+const readFileResult = await fsPromises.readFile("src");
+readFileResult.buffer;
+fsPromises.writeFile("src", "dataNode");


### PR DESCRIPTION
This is part of All for one, one for all query submission and there is a CVE already assigned to these sinks, I'm going to submit an issue in github/securitylab for this pull request too.
I tried my best to add many additional steps as possible for File system promises API.
I added some additional taint steps and customized predicates to work with Readable pipe from [Streams Promises API](https://nodejs.org/api/stream.html#readablepipedestination-options)
the `ReadableAdditionalStep.qll` is the updated version of [this](https://github.com/github/codeql/pull/13554/files#diff-413d58d9c22099f1d766305be090a1914805d51d1bccffc458607610d2ecaf13) from my current Decompression bomb pull request, I didn't update that pull request until I get permission to push another commit.
The query file is just for demonstration, I'm not allowed to push in not experimental directories so I've created a demo Path traversal query file.