### PR TITLE
C++: Fix join in `argumentOf`

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -321,9 +321,11 @@ private class PrimaryArgumentNode extends ArgumentNode, OperandNode {
 
 private class SideEffectArgumentNode extends ArgumentNode, SideEffectOperandNode {
   override predicate argumentOf(DataFlowCall dfCall, ArgumentPosition pos) {
-    this.getCallInstruction() = dfCall and
-    pos.(IndirectionPosition).getArgumentIndex() = this.getArgumentIndex() and
-    super.hasAddressOperandAndIndirectionIndex(_, pos.(IndirectionPosition).getIndirectionIndex())
+    exists(int indirectionIndex |
+      pos = TIndirectionPosition(argumentIndex, pragma[only_bind_into](indirectionIndex)) and
+      this.getCallInstruction() = dfCall and
+      super.hasAddressOperandAndIndirectionIndex(_, pragma[only_bind_into](indirectionIndex))
+    )
   }
 }
 


### PR DESCRIPTION
Before:
```ql
[2023-06-28 09:29:51] Evaluated non-recursive predicate DataFlowImplCommon#59e7a193::Cached::argumentNode#3#fff@8606bd35 in 1945ms (size: 1366058).
Evaluated relational algebra for predicate DataFlowImplCommon#59e7a193::Cached::argumentNode#3#fff@8606bd35 with tuple counts:
      764401   ~0%    {3} r1 = JOIN DataFlowPrivate#fbdd7bd7::DirectPosition#ff_10#join_rhs WITH Instruction#577b6a83::CallInstruction::getArgumentOperand#fff_102#join_rhs ON FIRST 1 OUTPUT Rhs.2, Lhs.1, Rhs.1
      764401   ~0%    {3} r2 = JOIN r1 WITH DataFlowPrivate#fbdd7bd7::PrimaryArgumentNode#fff_20#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.2, Lhs.1

          65   ~0%    {3} r3 = SCAN DataFlowPrivate#fbdd7bd7::IndirectionPosition#fff OUTPUT In.2, In.0, In.1
  180518864   ~0%    {3} r4 = JOIN r3 WITH project#DataFlowPrivate#fbdd7bd7::IndirectOperands::IndirectOperand::hasOperandAndIndirectionIndex#2#dispred#fff#3_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.2, Lhs.1
      601657   ~1%    {2} r5 = JOIN r4 WITH project#DataFlowUtil#47741e1f::SideEffectOperandNode#fff#2 ON FIRST 2 OUTPUT Lhs.0, Lhs.2
      601657   ~0%    {3} r6 = JOIN r5 WITH project#DataFlowUtil#47741e1f::SideEffectOperandNode#fff#3 ON FIRST 1 OUTPUT Lhs.0, Rhs.1, Lhs.1

    1366058   ~0%    {3} r7 = r2 UNION r6
                      return r7
```

After:
```ql
Tuple counts for DataFlowImplCommon#59e7a193::Cached::argumentNode#3#fff/3@d2b091vc after 1.1s:
  764381  ~2%     {3} r1 = JOIN DataFlowPrivate#fbdd7bd7::DirectPosition#ff_10#join_rhs WITH Instruction#577b6a83::CallInstruction::getArgumentOperand#fff_102#join_rhs ON FIRST 1 OUTPUT Rhs.2, Lhs.1 'pos', Rhs.1 'call'
  764381  ~0%     {3} r2 = JOIN r1 WITH DataFlowPrivate#fbdd7bd7::PrimaryArgumentNode#fff_20#join_rhs ON FIRST 1 OUTPUT Rhs.1 'n', Lhs.2 'call', Lhs.1 'pos'

  65      ~3%     {3} r3 = SCAN num#DataFlowPrivate#fbdd7bd7::TIndirectionPosition#fff OUTPUT In.0, In.2 'pos', In.1
  1798930 ~1%     {3} r4 = JOIN r3 WITH project#DataFlowUtil#47741e1f::SideEffectOperandNode#fff#2_10#join_rhs ON FIRST 1 OUTPUT Rhs.1 'n', Lhs.2, Lhs.1 'pos'
  601641  ~1%     {2} r5 = JOIN r4 WITH project#DataFlowPrivate#fbdd7bd7::IndirectOperands::IndirectOperand::hasOperandAndIndirectionIndex#2#dispred#fff#3 ON FIRST 2 OUTPUT Lhs.0 'n', Lhs.2 'pos'
  601641  ~0%     {3} r6 = JOIN r5 WITH project#DataFlowUtil#47741e1f::SideEffectOperandNode#fff#3 ON FIRST 1 OUTPUT Lhs.0 'n', Rhs.1 'call', Lhs.1 'pos'

  1366022 ~1%     {3} r7 = r2 UNION r6
                  return r7
```