### PR TITLE
Kotlin: Remove a use of ObsoleteDescriptorBasedAPI

### DIFF
--- a/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
@@ -157,21 +157,10 @@ open class KotlinFileExtractor(
             else -> false
         }
 
-    @OptIn(ObsoleteDescriptorBasedAPI::class)
     private fun isFake(d: IrDeclarationWithVisibility): Boolean {
         val hasFakeVisibility = d.visibility.let { it is DelegatedDescriptorVisibility && it.delegate == Visibilities.InvisibleFake } || d.isFakeOverride
         if (hasFakeVisibility && !isJavaBinaryObjectMethodRedeclaration(d))
             return true
-        try {
-            if ((d as? IrFunction)?.descriptor?.isHiddenToOvercomeSignatureClash == true) {
-                return true
-            }
-        }
-        catch (e: NotImplementedError) {
-            // `org.jetbrains.kotlin.ir.descriptors.IrBasedClassConstructorDescriptor.isHiddenToOvercomeSignatureClash` throws the exception
-            logger.warnElement("Couldn't query if element is fake, deciding it's not.", d, e)
-            return false
-        }
         return false
     }
 


### PR DESCRIPTION
This isn't supported in Kotlin 2 mode, but removing this code doesn't affect any tests.