### PR TITLE
Ruby: fix sqlite3 `PreparedStatementExecution.getSql()` predicate

### DIFF
--- a/ruby/ql/lib/codeql/ruby/frameworks/Sqlite3.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/Sqlite3.qll
@@ -47,7 +47,7 @@ module Sqlite3 {
       this.getMethodName() = ["columns", "execute", "execute!", "get_metadata", "types"]
     }
 
-    override DataFlow::Node getSql() { result = stmt.getReceiver() }
+    override DataFlow::Node getSql() { result = stmt.getSql() }
   }
 
   /** Gets the name of a method called against a database that executes an SQL statement. */

--- a/ruby/ql/test/library-tests/frameworks/sqlite3/Sqlite3.expected
+++ b/ruby/ql/test/library-tests/frameworks/sqlite3/Sqlite3.expected
@@ -5,6 +5,6 @@ sqlite3SqlConstruction
 | sqlite3.rb:29:7:29:40 | call to execute | sqlite3.rb:29:19:29:39 | "select * from table" |
 sqlite3SqlExecution
 | sqlite3.rb:5:1:5:17 | call to execute | sqlite3.rb:5:12:5:17 | <<-SQL |
-| sqlite3.rb:14:1:14:12 | call to execute | sqlite3.rb:12:8:12:9 | db |
+| sqlite3.rb:14:1:14:12 | call to execute | sqlite3.rb:12:19:12:41 | "select * from numbers" |
 | sqlite3.rb:17:3:19:5 | call to execute | sqlite3.rb:17:15:17:35 | "select * from table" |
 | sqlite3.rb:29:7:29:40 | call to execute | sqlite3.rb:29:19:29:39 | "select * from table" |


### PR DESCRIPTION
This pointed to the database instance rather than the SQL statement. In practice I don't think that this would have caused us to lose results in most cases since the statement preparation also counts as a sink.