### PR TITLE
C++: Move `cpp/overrun-write` back to `medium` precision

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-119/OverrunWriteProductFlow.ql
+++ b/cpp/ql/src/Security/CWE/CWE-119/OverrunWriteProductFlow.ql
@@ -5,7 +5,7 @@
  * @kind path-problem
  * @problem.severity error
  * @security-severity 9.3
- * @precision low
+ * @precision medium
  * @id cpp/overrun-write
  * @tags reliability
  *       security


### PR DESCRIPTION
The issue that caused us to revert the earlier PR has now been fixed and we're seeing no new timeouts when running on QA 🎉.