### PR TITLE
Ruby: Improve support for explicit proc-creation

### DIFF
--- a/ruby/ql/lib/codeql/ruby/ApiGraphs.qll
+++ b/ruby/ql/lib/codeql/ruby/ApiGraphs.qll
@@ -978,6 +978,12 @@ module API {
         pred = Impl::MkModuleInstanceUp(mod) and
         succ = getBackwardEndNode(mod.getOwnInstanceMethod("call"))
       )
+      or
+      // Step through callable wrappers like `proc` and `lambda` calls.
+      exists(DataFlow::Node node |
+        pred = getBackwardEndNode(node) and
+        succ = getBackwardStartNode(node.asCallable())
+      )
     }
 
     pragma[nomagic]

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
@@ -1333,14 +1333,18 @@ predicate lambdaCreation(Node creation, LambdaCallKind kind, DataFlowCallable c)
     creation.asExpr() =
       any(CfgNodes::ExprNodes::MethodCallCfgNode mc |
         c.asCallable() = mc.getBlock().getExpr() and
-        (
-          mc.getExpr().getMethodName() = ["lambda", "proc"]
-          or
-          mc.getExpr().getMethodName() = "new" and
-          mc.getReceiver().getExpr().(ConstantReadAccess).getAQualifiedName() = "Proc"
-        )
+        isProcCreationCall(mc.getExpr())
       )
   )
+}
+
+/** Holds if `call` is a call to `lambda`, `proc`, or `Proc.new` */
+pragma[nomagic]
+private predicate isProcCreationCall(MethodCall call) {
+  call.getMethodName() = ["proc", "lambda"]
+  or
+  call.getMethodName() = "new" and
+  call.getReceiver().(ConstantReadAccess).getAQualifiedName() = "Proc"
 }
 
 /**

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
@@ -1333,7 +1333,12 @@ predicate lambdaCreation(Node creation, LambdaCallKind kind, DataFlowCallable c)
     creation.asExpr() =
       any(CfgNodes::ExprNodes::MethodCallCfgNode mc |
         c.asCallable() = mc.getBlock().getExpr() and
-        mc.getExpr().getMethodName() = ["lambda", "proc"]
+        (
+          mc.getExpr().getMethodName() = ["lambda", "proc"]
+          or
+          mc.getExpr().getMethodName() = "new" and
+          mc.getReceiver().getExpr().(ConstantReadAccess).getAQualifiedName() = "Proc"
+        )
       )
   )
 }

--- a/ruby/ql/src/change-notes/2023-06-29-api-graph-explicit-proc-lambda.md
+++ b/ruby/ql/src/change-notes/2023-06-29-api-graph-explicit-proc-lambda.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Improved resolution of calls performed on an object created with `Proc.new`.

--- a/ruby/ql/test/library-tests/dataflow/api-graphs/VerifyApiGraphExpectations.expected
+++ b/ruby/ql/test/library-tests/dataflow/api-graphs/VerifyApiGraphExpectations.expected
@@ -1,2 +1,5 @@
 failures
 testFailures
+| explicit-proc.rb:2:7:2:78 | # $ reachableFromSource=Member[Foo].Method[bar].Argument[0].Parameter[0] | Missing result:reachableFromSource=Member[Foo].Method[bar].Argument[0].Parameter[0] |
+| explicit-proc.rb:6:7:6:78 | # $ reachableFromSource=Member[Foo].Method[bar].Argument[0].Parameter[0] | Missing result:reachableFromSource=Member[Foo].Method[bar].Argument[0].Parameter[0] |
+| explicit-proc.rb:10:7:10:78 | # $ reachableFromSource=Member[Foo].Method[bar].Argument[0].Parameter[0] | Missing result:reachableFromSource=Member[Foo].Method[bar].Argument[0].Parameter[0] |

--- a/ruby/ql/test/library-tests/dataflow/api-graphs/VerifyApiGraphExpectations.expected
+++ b/ruby/ql/test/library-tests/dataflow/api-graphs/VerifyApiGraphExpectations.expected
@@ -1,3 +1,2 @@
 failures
 testFailures
-| explicit-proc.rb:10:7:10:78 | # $ reachableFromSource=Member[Foo].Method[bar].Argument[0].Parameter[0] | Missing result:reachableFromSource=Member[Foo].Method[bar].Argument[0].Parameter[0] |

--- a/ruby/ql/test/library-tests/dataflow/api-graphs/VerifyApiGraphExpectations.expected
+++ b/ruby/ql/test/library-tests/dataflow/api-graphs/VerifyApiGraphExpectations.expected
@@ -1,5 +1,3 @@
 failures
 testFailures
-| explicit-proc.rb:2:7:2:78 | # $ reachableFromSource=Member[Foo].Method[bar].Argument[0].Parameter[0] | Missing result:reachableFromSource=Member[Foo].Method[bar].Argument[0].Parameter[0] |
-| explicit-proc.rb:6:7:6:78 | # $ reachableFromSource=Member[Foo].Method[bar].Argument[0].Parameter[0] | Missing result:reachableFromSource=Member[Foo].Method[bar].Argument[0].Parameter[0] |
 | explicit-proc.rb:10:7:10:78 | # $ reachableFromSource=Member[Foo].Method[bar].Argument[0].Parameter[0] | Missing result:reachableFromSource=Member[Foo].Method[bar].Argument[0].Parameter[0] |

--- a/ruby/ql/test/library-tests/dataflow/api-graphs/explicit-proc.rb
+++ b/ruby/ql/test/library-tests/dataflow/api-graphs/explicit-proc.rb
@@ -1,0 +1,11 @@
+Foo.bar proc { |x|
+    x # $ reachableFromSource=Member[Foo].Method[bar].Argument[0].Parameter[0]
+}
+
+Foo.bar lambda { |x|
+    x # $ reachableFromSource=Member[Foo].Method[bar].Argument[0].Parameter[0]
+}
+
+Foo.bar Proc.new { |x|
+    x # $ reachableFromSource=Member[Foo].Method[bar].Argument[0].Parameter[0]
+}


### PR DESCRIPTION
- Treats `Proc.new` as an explicit lambda creation, alongside `proc` and `lambda` calls.
- Makes API graphs step through such lambda creations when backtracking

Should fix the issue brought up here: https://github.com/github/codeql/pull/13483/files#diff-4eabe9f52cd51fcb0f830d178af3fb1a36df1e623ae2acbf4a2b25f968e9ee7fR25