### PR TITLE
Enable implicit this warning CI checks

### DIFF
--- a/.github/workflows/check-implicit-this.yml
+++ b/.github/workflows/check-implicit-this.yml
@@ -1,6 +1,13 @@
 name: "Check implicit this warnings"
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "**qlpack.yml"
+    branches:
+      - main
+      - "rc/*"
 
 jobs:
   check:
@@ -15,7 +22,7 @@ jobs:
           for pack_file in ${packs}; do
             option="$(yq '.warnOnImplicitThis' ${pack_file})"
             if [ "${option}" != "true" ]; then
-              echo "warnOnImplicitThis property must be set to 'true' for pack ${pack_file}"
+              echo "::error file=${pack_file}::warnOnImplicitThis property must be set to 'true' for pack ${pack_file}"
               EXIT_CODE=1
             fi
           done


### PR DESCRIPTION
Enable CI check for implicit this warnings for all PRs that modify `qlpack.yml` files. 

Test run to validate failure: https://github.com/github/codeql/actions/runs/5412179604/jobs/9835932651.
Test run to validate success: https://github.com/github/codeql/actions/runs/5411315549/jobs/9833893355