### PR TITLE
C#: Remove the renaming of `Directory.Build.props` from standalone extraction

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp.Standalone/BuildAnalysis.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.Standalone/BuildAnalysis.cs
@@ -100,9 +100,8 @@ namespace Semmle.BuildAnalyser
                 dllDirNames.Add(runtimeLocation);
             }
 
-            // These files can sometimes prevent `dotnet restore` from working correctly.
+            // TODO: remove the below when the required SDK is installed
             using (new FileRenamer(sourceDir.GetFiles("global.json", SearchOption.AllDirectories)))
-            using (new FileRenamer(sourceDir.GetFiles("Directory.Build.props", SearchOption.AllDirectories)))
             {
                 var solutions = options.SolutionFile is not null ?
                         new[] { options.SolutionFile } :


### PR DESCRIPTION
`Directory.Build.props` is oftentimes required for `dotnet restore` to succeed. The comment on top of the renaming logic says it was renamed to help `dotnet restore`, but I haven't found projects where I could repro the failure when the file is not removed. On the other hand I found many where it causes issues.

This change has significant impact on the standalone-traced dependency comparison query results. The below results ignore assembly versions (just the names are considered). 9 out of the 30 top MRVA projects show similar changes. The values show the number of assembly names that are in both/only traced/only standalone DBs. 

```diff
 Results for JamesNK/Newtonsoft.Json
  Query Dependencies.ql:
-  Result count - both/traced/standalone: 185/13/327
+  Result count - both/traced/standalone: 198/0/330
 Results for moq/moq4
  Query Dependencies.ql:
-  Result count - both/traced/standalone: 161/33/49
+  Result count - both/traced/standalone: 193/1/311
 Results for mongodb/mongo-csharp-driver
  Query Dependencies.ql:
-  Result count - both/traced/standalone: 161/51/48
+  Result count - both/traced/standalone: 212/0/318
```