### PR TITLE
C++: Deprecate AST dataflow

### DIFF
--- a/cpp/ql/lib/change-notes/2023-06-29-deprecate-ast-dataflow.md
+++ b/cpp/ql/lib/change-notes/2023-06-29-deprecate-ast-dataflow.md
@@ -1,0 +1,4 @@
+---
+category: deprecated
+---
+* The library `semmle.code.cpp.dataflow.DataFlow` has been deprecated. Please use `semmle.code.cpp.dataflow.new.DataFlow` instead.

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/DataFlow.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/DataFlow.qll
@@ -20,10 +20,12 @@
 import cpp
 
 /**
+ * DEPRECATED: Use `semmle.code.cpp.dataflow.new.DataFlow` instead.
+ *
  * Provides classes for performing local (intra-procedural) and
  * global (inter-procedural) data flow analyses.
  */
-module DataFlow {
+deprecated module DataFlow {
   import semmle.code.cpp.dataflow.internal.DataFlow
   import semmle.code.cpp.dataflow.internal.DataFlowImpl1
 }

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/DataFlow2.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/DataFlow2.qll
@@ -12,9 +12,11 @@
 import cpp
 
 /**
+ * DEPRECATED: Use `semmle.code.cpp.dataflow.new.DataFlow2` instead.
+ *
  * Provides classes for performing local (intra-procedural) and
  * global (inter-procedural) data flow analyses.
  */
-module DataFlow2 {
+deprecated module DataFlow2 {
   import semmle.code.cpp.dataflow.internal.DataFlowImpl2
 }

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/DataFlow3.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/DataFlow3.qll
@@ -12,9 +12,11 @@
 import cpp
 
 /**
+ * DEPRECATED: Use `semmle.code.cpp.dataflow.new.DataFlow3` instead.
+ *
  * Provides classes for performing local (intra-procedural) and
  * global (inter-procedural) data flow analyses.
  */
-module DataFlow3 {
+deprecated module DataFlow3 {
   import semmle.code.cpp.dataflow.internal.DataFlowImpl3
 }

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/DataFlow4.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/DataFlow4.qll
@@ -12,9 +12,11 @@
 import cpp
 
 /**
+ * DEPRECATED: Use `semmle.code.cpp.dataflow.new.DataFlow4` instead.
+ *
  * Provides classes for performing local (intra-procedural) and
  * global (inter-procedural) data flow analyses.
  */
-module DataFlow4 {
+deprecated module DataFlow4 {
   import semmle.code.cpp.dataflow.internal.DataFlowImpl4
 }

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/TaintTracking.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/TaintTracking.qll
@@ -19,10 +19,12 @@ import semmle.code.cpp.dataflow.DataFlow
 import semmle.code.cpp.dataflow.DataFlow2
 
 /**
+ * DEPRECATED: Use `semmle.code.cpp.dataflow.new.TaintTracking` instead.
+ *
  * Provides classes for performing local (intra-procedural) and
  * global (inter-procedural) taint-tracking analyses.
  */
-module TaintTracking {
+deprecated module TaintTracking {
   import semmle.code.cpp.dataflow.internal.tainttracking1.TaintTracking
   import semmle.code.cpp.dataflow.internal.tainttracking1.TaintTrackingImpl
 }

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/TaintTracking2.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/TaintTracking2.qll
@@ -12,9 +12,11 @@
  */
 
 /**
+ * DEPRECATED: Use `semmle.code.cpp.dataflow.new.TaintTracking2` instead.
+ *
  * Provides classes for performing local (intra-procedural) and
  * global (inter-procedural) taint-tracking analyses.
  */
-module TaintTracking2 {
+deprecated module TaintTracking2 {
   import semmle.code.cpp.dataflow.internal.tainttracking2.TaintTrackingImpl
 }

--- a/cpp/ql/test/library-tests/dataflow/dataflow-edge-tests/additionalEdges.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-edge-tests/additionalEdges.expected
@@ -1,3 +1,6 @@
+WARNING: Module DataFlow has been deprecated and may be removed in future (additionalEdges.ql:31,6-14)
+WARNING: Module DataFlow has been deprecated and may be removed in future (additionalEdges.ql:31,31-39)
+WARNING: Module DataFlow has been deprecated and may be removed in future (additionalEdges.ql:32,7-15)
 | tryExcept.c:7:7:7:7 | x | tryExcept.c:14:10:14:10 | x |
 | tryExcept.c:7:13:7:14 | 0 | tryExcept.c:10:9:10:9 | y |
 | tryExcept.c:10:9:10:9 | y | tryExcept.c:10:5:10:9 | ... = ... |

--- a/cpp/ql/test/library-tests/dataflow/dataflow-edge-tests/standardEdges.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-edge-tests/standardEdges.expected
@@ -1,2 +1,5 @@
+WARNING: Module DataFlow has been deprecated and may be removed in future (standardEdges.ql:4,6-14)
+WARNING: Module DataFlow has been deprecated and may be removed in future (standardEdges.ql:4,31-39)
+WARNING: Module DataFlow has been deprecated and may be removed in future (standardEdges.ql:5,7-15)
 | tryExcept.c:7:13:7:14 | 0 | tryExcept.c:10:9:10:9 | y |
 | tryExcept.c:10:9:10:9 | y | tryExcept.c:10:5:10:9 | ... = ... |

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/has-parameter-flow-out.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/has-parameter-flow-out.expected
@@ -1,2 +1,3 @@
+WARNING: Module DataFlow has been deprecated and may be removed in future (has-parameter-flow-out.ql:5,18-61)
 failures
 testFailures

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/localFlow.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/localFlow.expected
@@ -1,3 +1,6 @@
+WARNING: Module DataFlow has been deprecated and may be removed in future (localFlow.ql:4,6-14)
+WARNING: Module DataFlow has been deprecated and may be removed in future (localFlow.ql:4,31-39)
+WARNING: Module DataFlow has been deprecated and may be removed in future (localFlow.ql:6,3-11)
 | example.c:15:37:15:37 | b | example.c:15:37:15:37 | b |
 | example.c:15:37:15:37 | b | example.c:19:6:19:6 | b |
 | example.c:15:44:15:46 | pos | example.c:24:24:24:26 | pos |

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test-number-of-outnodes.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test-number-of-outnodes.expected
@@ -1,2 +1,3 @@
+WARNING: Module DataFlow has been deprecated and may be removed in future (test-number-of-outnodes.ql:5,18-61)
 failures
 testFailures

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.expected
@@ -1,2 +1,9 @@
+WARNING: Module DataFlow has been deprecated and may be removed in future (test.ql:19,45-53)
+WARNING: Module DataFlow has been deprecated and may be removed in future (test.ql:20,24-32)
+WARNING: Module DataFlow has been deprecated and may be removed in future (test.ql:27,15-23)
+WARNING: Module DataFlow has been deprecated and may be removed in future (test.ql:33,22-30)
+WARNING: Module DataFlow has been deprecated and may be removed in future (test.ql:40,25-33)
+WARNING: Module DataFlow has been deprecated and may be removed in future (test.ql:42,17-25)
+WARNING: Module DataFlow has been deprecated and may be removed in future (test.ql:46,20-28)
 failures
 testFailures

--- a/cpp/ql/test/library-tests/dataflow/fields/partial-definition-diff.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/partial-definition-diff.expected
@@ -1,3 +1,4 @@
+WARNING: Module DataFlow has been deprecated and may be removed in future (partial-definition-diff.ql:7,8-51)
 | A.cpp:25:13:25:13 | c | AST only |
 | A.cpp:27:28:27:28 | c | AST only |
 | A.cpp:28:29:28:29 | this | IR only |

--- a/cpp/ql/test/library-tests/dataflow/fields/partial-definition.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/partial-definition.expected
@@ -1,3 +1,4 @@
+WARNING: Module DataFlow has been deprecated and may be removed in future (partial-definition.ql:6,8-51)
 | A.cpp:25:7:25:10 | this |
 | A.cpp:25:13:25:13 | c |
 | A.cpp:27:22:27:25 | this |

--- a/cpp/ql/test/library-tests/dataflow/smart-pointers-taint/taint.expected
+++ b/cpp/ql/test/library-tests/dataflow/smart-pointers-taint/taint.expected
@@ -1,2 +1,6 @@
+WARNING: Module DataFlow has been deprecated and may be removed in future (taint.ql:6,48-56)
+WARNING: Module DataFlow has been deprecated and may be removed in future (taint.ql:7,24-32)
+WARNING: Module DataFlow has been deprecated and may be removed in future (taint.ql:11,22-30)
+WARNING: Module TaintTracking has been deprecated and may be removed in future (taint.ql:19,20-33)
 failures
 testFailures

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
@@ -1,3 +1,7 @@
+WARNING: Module DataFlow has been deprecated and may be removed in future (localTaint.ql:4,6-14)
+WARNING: Module DataFlow has been deprecated and may be removed in future (localTaint.ql:4,31-39)
+WARNING: Module DataFlow has been deprecated and may be removed in future (localTaint.ql:7,6-14)
+WARNING: Module TaintTracking has been deprecated and may be removed in future (localTaint.ql:6,3-16)
 | arrayassignment.cpp:9:9:9:10 | 0 | arrayassignment.cpp:10:14:10:14 | x |  |
 | arrayassignment.cpp:9:9:9:10 | 0 | arrayassignment.cpp:11:15:11:15 | x |  |
 | arrayassignment.cpp:9:9:9:10 | 0 | arrayassignment.cpp:12:13:12:13 | x |  |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.expected
@@ -1,2 +1,7 @@
+WARNING: Module DataFlow has been deprecated and may be removed in future (taint.ql:46,45-53)
+WARNING: Module DataFlow has been deprecated and may be removed in future (taint.ql:47,24-32)
+WARNING: Module DataFlow has been deprecated and may be removed in future (taint.ql:61,22-30)
+WARNING: Module DataFlow has been deprecated and may be removed in future (taint.ql:68,25-33)
+WARNING: Module TaintTracking has been deprecated and may be removed in future (taint.ql:73,20-33)
 failures
 testFailures

--- a/docs/codeql/codeql-language-guides/analyzing-data-flow-in-cpp.rst
+++ b/docs/codeql/codeql-language-guides/analyzing-data-flow-in-cpp.rst
@@ -2,7 +2,7 @@
 
 .. pull-quote:: Note
 
-   The data flow library used in this article has been replaced with an improved library which is available from CodeQL 2.12.5 onwards, see :ref:`Analyzing data flow in C and C++ (new) <analyzing-data-flow-in-cpp-new>`. The old library has been deprecated in CodeQL 2.14.0 and will be removed in a later release.
+   The data flow library used in this article has been replaced with an improved library which is available from CodeQL 2.12.5 onwards, see :ref:`Analyzing data flow in C and C++ (new) <analyzing-data-flow-in-cpp-new>`. The old library has been deprecated in CodeQL 2.14.1 and will be removed in a later release.
 
 Analyzing data flow in C and C++
 ================================

--- a/docs/codeql/codeql-language-guides/analyzing-data-flow-in-cpp.rst
+++ b/docs/codeql/codeql-language-guides/analyzing-data-flow-in-cpp.rst
@@ -2,7 +2,7 @@
 
 .. pull-quote:: Note
 
-   The data flow library used in this article has been replaced with an improved library which is available from CodeQL 2.12.5 onwards, see :ref:`Analyzing data flow in C and C++ (new) <analyzing-data-flow-in-cpp-new>`. The old library will be deprecated in the near future and removed a year after deprecation.
+   The data flow library used in this article has been replaced with an improved library which is available from CodeQL 2.12.5 onwards, see :ref:`Analyzing data flow in C and C++ (new) <analyzing-data-flow-in-cpp-new>`. The old library has been deprecated in CodeQL 2.14.0 and will be removed in a later release.
 
 Analyzing data flow in C and C++
 ================================


### PR DESCRIPTION
All of our queries use IR dataflow now (hopefully!).