### PR TITLE
C++: Also handle `PhiInstruction`s in `Expr::getInstruction`

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/rangeanalysis/new/internal/semantic/SemanticExprSpecific.qll
+++ b/cpp/ql/lib/semmle/code/cpp/rangeanalysis/new/internal/semantic/SemanticExprSpecific.qll
@@ -61,7 +61,13 @@ module SemanticExprConfig {
     private IR::Instruction getInstruction(int n) {
       result =
         rank[n + 1](IR::Instruction instr, int i, IR::IRBlock block |
-          this = Equiv::getEquivalenceClass(instr) and block.getInstruction(i) = instr
+          this = Equiv::getEquivalenceClass(instr) and
+          (
+            block.getInstruction(i) = instr
+            or
+            i = -1 and
+            instr = block.getAPhiInstruction()
+          )
         |
           instr order by i
         )

--- a/cpp/ql/test/library-tests/ir/range-analysis/SimpleRangeAnalysis_tests.cpp
+++ b/cpp/ql/test/library-tests/ir/range-analysis/SimpleRangeAnalysis_tests.cpp
@@ -18,7 +18,7 @@ int test2(struct List* p) {
   int count = 0;
   for (; p; p = p->next) {
     count = (count+1) % 10;
-    range(count); // $ range=<=9 range=>=-9 range="<=Phi: p | Store: count+1"
+    range(count); // $ range=<=9 range=>=-9
   }
   range(count); // $ range=>=-9 range=<=9
   return count;
@@ -29,7 +29,7 @@ int test3(struct List* p) {
   for (; p; p = p->next) {
     range(count++); // $ range=>=-9 range=<=9
     count = count % 10;
-    range(count); // $ range=<=9 range=>=-9 range="<=Store: ... +++0" range="<=Phi: p | Store: count+1" 
+    range(count); // $ range=<=9 range=>=-9
   }
   range(count); // $ range=>=-9 range=<=9
   return count;
@@ -317,7 +317,7 @@ int test_mult01(int a, int b) {
     range(b); // $ range=<=23 range=>=-13
     int r = a*b;  // $ overflow=+- -143 .. 253
     range(r);
-    total += r; // $ overflow=+
+    total += r; // $ overflow=+-
     range(total); // $ MISSING: range=">=... * ...+0"
   }
   if (3 <= a && a <= 11 && -13 <= b && b <= 0) {
@@ -365,7 +365,7 @@ int test_mult02(int a, int b) {
     range(b); // $ range=<=23 range=>=-13
     int r = a*b;  // $ overflow=+- -143 .. 253
     range(r);
-    total += r; // $ overflow=+
+    total += r; // $ overflow=+-
     range(total); // $ MISSING: range=">=... * ...+0"
   }
   if (0 <= a && a <= 11 && -13 <= b && b <= 0) {
@@ -460,7 +460,7 @@ int test_mult04(int a, int b) {
     range(b); // $ range=<=23 range=>=-13
     int r = a*b;  // $ overflow=+- -391 .. 221
     range(r);
-    total += r; // $ overflow=-
+    total += r; // $ overflow=+-
     range(total); // $ MISSING: range="<=... * ...+0"
   }
   if (-17 <= a && a <= 0 && -13 <= b && b <= 0) {
@@ -508,7 +508,7 @@ int test_mult05(int a, int b) {
     range(b); // $ range=<=23 range=>=-13
     int r = a*b;  // $ overflow=+- -391 .. 221
     range(r);
-    total += r; // $ overflow=-
+    total += r; // $ overflow=+-
     range(total); // $ MISSING: range="<=... * ...+0"
   }
   if (-17 <= a && a <= -2 && -13 <= b && b <= 0) {
@@ -974,7 +974,7 @@ void test_mod_neg(int s) {
 
 void test_mod_ternary(int s, bool b) {
   int s2 = s % (b ? 5 : 500);
-  range(s2); // $ range=>=-499 range=<=499 range="<=Phi: ... ? ... : ...-1"
+  range(s2); // $ range=>=-499 range=<=499
 }
 
 void test_mod_ternary2(int s, bool b1, bool b2) {


### PR DESCRIPTION
I had this in a local branch from when I was debugging something else, and I figured I should really get this merged as it was confusing me quite a bit earlier.

Since `IRBlock.getInstruction` only gives back non-phi instructions it wasn't possible to return a `PhiInstruction` from this predicate even though the instruction was assigned to the equivalence class.

I still need to fully understand the test changes 🤔. Do they make sense to you @rdmarsh2?