### PR TITLE
C++: Speed up `cpp/overrun-write`

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-119/OverrunWriteProductFlow.ql
+++ b/cpp/ql/src/Security/CWE/CWE-119/OverrunWriteProductFlow.ql
@@ -120,6 +120,10 @@ module ValidState {
 
     predicate isBarrier(DataFlow::Node node, FlowState state) { none() }
 
+    predicate isBarrierOut(DataFlow::Node node) {
+      node = any(DataFlow::SsaPhiNode phi).getAnInput(true)
+    }
+
     predicate isAdditionalFlowStep(
       DataFlow::Node node1, FlowState state1, DataFlow::Node node2, FlowState state2
     ) {
@@ -233,7 +237,8 @@ module StringSizeConfig implements ProductFlow::StateConfigSig {
     // we use `state2` to remember that there was an offset (in this case an offset of `1`) added
     // to the size of the allocation. This state is then checked in `isSinkPair`.
     exists(state1) and
-    hasSize(bufSource.asConvertedExpr(), sizeSource, state2)
+    hasSize(bufSource.asConvertedExpr(), sizeSource, state2) and
+    validState(sizeSource, state2)
   }
 
   predicate isSinkPair(

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-119/SAMATE/OverrunWriteProductFlow.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-119/SAMATE/OverrunWriteProductFlow.expected
@@ -75,7 +75,6 @@ edges
 | test.cpp:214:24:214:24 | p | test.cpp:216:10:216:10 | p |
 | test.cpp:220:43:220:48 | call to malloc | test.cpp:222:15:222:20 | buffer |
 | test.cpp:222:15:222:20 | buffer | test.cpp:214:24:214:24 | p |
-| test.cpp:228:43:228:48 | call to malloc | test.cpp:232:10:232:15 | buffer |
 | test.cpp:235:40:235:45 | buffer | test.cpp:236:5:236:26 | ... = ... |
 | test.cpp:236:5:236:26 | ... = ... | test.cpp:236:12:236:17 | p_str indirection [post update] [string] |
 | test.cpp:241:27:241:32 | call to malloc | test.cpp:242:22:242:27 | buffer |
@@ -86,7 +85,6 @@ edges
 | test.cpp:243:12:243:14 | str indirection [string] | test.cpp:243:16:243:21 | string indirection |
 | test.cpp:243:16:243:21 | string indirection | test.cpp:243:12:243:21 | string |
 | test.cpp:249:20:249:27 | call to my_alloc | test.cpp:250:12:250:12 | p |
-| test.cpp:256:17:256:22 | call to malloc | test.cpp:257:12:257:12 | p |
 | test.cpp:262:22:262:27 | call to malloc | test.cpp:266:12:266:12 | p |
 | test.cpp:264:20:264:25 | call to malloc | test.cpp:266:12:266:12 | p |
 nodes
@@ -155,8 +153,6 @@ nodes
 | test.cpp:216:10:216:10 | p | semmle.label | p |
 | test.cpp:220:43:220:48 | call to malloc | semmle.label | call to malloc |
 | test.cpp:222:15:222:20 | buffer | semmle.label | buffer |
-| test.cpp:228:43:228:48 | call to malloc | semmle.label | call to malloc |
-| test.cpp:232:10:232:15 | buffer | semmle.label | buffer |
 | test.cpp:235:40:235:45 | buffer | semmle.label | buffer |
 | test.cpp:236:5:236:26 | ... = ... | semmle.label | ... = ... |
 | test.cpp:236:12:236:17 | p_str indirection [post update] [string] | semmle.label | p_str indirection [post update] [string] |
@@ -168,8 +164,6 @@ nodes
 | test.cpp:243:16:243:21 | string indirection | semmle.label | string indirection |
 | test.cpp:249:20:249:27 | call to my_alloc | semmle.label | call to my_alloc |
 | test.cpp:250:12:250:12 | p | semmle.label | p |
-| test.cpp:256:17:256:22 | call to malloc | semmle.label | call to malloc |
-| test.cpp:257:12:257:12 | p | semmle.label | p |
 | test.cpp:262:22:262:27 | call to malloc | semmle.label | call to malloc |
 | test.cpp:264:20:264:25 | call to malloc | semmle.label | call to malloc |
 | test.cpp:266:12:266:12 | p | semmle.label | p |


### PR DESCRIPTION
Two performance improvements:
- First, we add a barrier to the configuration that computes the set of valid states. This is valid because the set barrier is also present in the product-flow configuration (which consumes those states). This speeds up the stage that computes the set of states for the product-flow configuration.
- Second, we use the above dataflow configuration to prune the product-flow configuration.

This last point fixes a timeout I was seeing on a project locally.