### PR TITLE
Remove pragma[assume_small_delta]

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -460,7 +460,6 @@ module Impl<FullStateConfigSig Config> {
      * The Boolean `cc` records whether the node is reached through an
      * argument in a call.
      */
-    pragma[assume_small_delta]
     private predicate fwdFlow(NodeEx node, Cc cc) {
       sourceNode(node, _) and
       if hasSourceCallCtx() then cc = true else cc = false
@@ -570,7 +569,6 @@ module Impl<FullStateConfigSig Config> {
     /**
      * Holds if `c` is the target of a store in the flow covered by `fwdFlow`.
      */
-    pragma[assume_small_delta]
     pragma[nomagic]
     private predicate fwdFlowConsCand(Content c) {
       exists(NodeEx mid, NodeEx node |
@@ -1216,7 +1214,6 @@ module Impl<FullStateConfigSig Config> {
         fwdFlow1(_, _, _, _, _, _, t0, t, ap, _) and t0 != t
       }
 
-      pragma[assume_small_delta]
       pragma[nomagic]
       private predicate fwdFlow0(
         NodeEx node, FlowState state, Cc cc, ParamNodeOption summaryCtx, TypOption argT,
@@ -2777,7 +2774,6 @@ module Impl<FullStateConfigSig Config> {
   /**
    * Gets the number of `AccessPath`s that correspond to `apa`.
    */
-  pragma[assume_small_delta]
   private int countAps(AccessPathApprox apa) {
     evalUnfold(apa, false) and
     result = 1 and
@@ -2796,7 +2792,6 @@ module Impl<FullStateConfigSig Config> {
    * that it is expanded to a precise head-tail representation.
    */
   language[monotonicAggregates]
-  pragma[assume_small_delta]
   private int countPotentialAps(AccessPathApprox apa) {
     apa instanceof AccessPathApproxNil and result = 1
     or
@@ -2833,7 +2828,6 @@ module Impl<FullStateConfigSig Config> {
     }
 
   private newtype TPathNode =
-    pragma[assume_small_delta]
     TPathNodeMid(
       NodeEx node, FlowState state, CallContext cc, SummaryCtx sc, DataFlowType t, AccessPath ap
     ) {
@@ -2918,7 +2912,6 @@ module Impl<FullStateConfigSig Config> {
 
     override AccessPathFrontHead getFront() { result = TFrontHead(head_) }
 
-    pragma[assume_small_delta]
     override AccessPathApproxCons getApprox() {
       result = TConsNil(head_, t) and tail_ = TAccessPathNil()
       or
@@ -2927,7 +2920,6 @@ module Impl<FullStateConfigSig Config> {
       result = TCons1(head_, this.length())
     }
 
-    pragma[assume_small_delta]
     override int length() { result = 1 + tail_.length() }
 
     private string toStringImpl(boolean needsSuffix) {
@@ -3379,7 +3371,6 @@ module Impl<FullStateConfigSig Config> {
    * Holds if data may flow from `mid` to `node`. The last step in or out of
    * a callable is recorded by `cc`.
    */
-  pragma[assume_small_delta]
   pragma[nomagic]
   private predicate pathStep0(
     PathNodeMid mid, NodeEx node, FlowState state, CallContext cc, SummaryCtx sc, DataFlowType t,
@@ -3592,7 +3583,6 @@ module Impl<FullStateConfigSig Config> {
     )
   }
 
-  pragma[assume_small_delta]
   pragma[nomagic]
   private predicate pathThroughCallable0(
     DataFlowCall call, PathNodeMid mid, ReturnKindExt kind, FlowState state, CallContext cc,

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplCommon.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplCommon.qll
@@ -187,7 +187,6 @@ private module LambdaFlow {
     else any()
   }
 
-  pragma[assume_small_delta]
   pragma[nomagic]
   predicate revLambdaFlow0(
     DataFlowCall lambdaCall, LambdaCallKind kind, Node node, DataFlowType t, boolean toReturn,
@@ -274,7 +273,6 @@ private module LambdaFlow {
     )
   }
 
-  pragma[assume_small_delta]
   pragma[nomagic]
   predicate revLambdaFlowOut(
     DataFlowCall lambdaCall, LambdaCallKind kind, TReturnPositionSimple pos, DataFlowType t,

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -460,7 +460,6 @@ module Impl<FullStateConfigSig Config> {
      * The Boolean `cc` records whether the node is reached through an
      * argument in a call.
      */
-    pragma[assume_small_delta]
     private predicate fwdFlow(NodeEx node, Cc cc) {
       sourceNode(node, _) and
       if hasSourceCallCtx() then cc = true else cc = false
@@ -570,7 +569,6 @@ module Impl<FullStateConfigSig Config> {
     /**
      * Holds if `c` is the target of a store in the flow covered by `fwdFlow`.
      */
-    pragma[assume_small_delta]
     pragma[nomagic]
     private predicate fwdFlowConsCand(Content c) {
       exists(NodeEx mid, NodeEx node |
@@ -1216,7 +1214,6 @@ module Impl<FullStateConfigSig Config> {
         fwdFlow1(_, _, _, _, _, _, t0, t, ap, _) and t0 != t
       }
 
-      pragma[assume_small_delta]
       pragma[nomagic]
       private predicate fwdFlow0(
         NodeEx node, FlowState state, Cc cc, ParamNodeOption summaryCtx, TypOption argT,
@@ -2777,7 +2774,6 @@ module Impl<FullStateConfigSig Config> {
   /**
    * Gets the number of `AccessPath`s that correspond to `apa`.
    */
-  pragma[assume_small_delta]
   private int countAps(AccessPathApprox apa) {
     evalUnfold(apa, false) and
     result = 1 and
@@ -2796,7 +2792,6 @@ module Impl<FullStateConfigSig Config> {
    * that it is expanded to a precise head-tail representation.
    */
   language[monotonicAggregates]
-  pragma[assume_small_delta]
   private int countPotentialAps(AccessPathApprox apa) {
     apa instanceof AccessPathApproxNil and result = 1
     or
@@ -2833,7 +2828,6 @@ module Impl<FullStateConfigSig Config> {
     }
 
   private newtype TPathNode =
-    pragma[assume_small_delta]
     TPathNodeMid(
       NodeEx node, FlowState state, CallContext cc, SummaryCtx sc, DataFlowType t, AccessPath ap
     ) {
@@ -2918,7 +2912,6 @@ module Impl<FullStateConfigSig Config> {
 
     override AccessPathFrontHead getFront() { result = TFrontHead(head_) }
 
-    pragma[assume_small_delta]
     override AccessPathApproxCons getApprox() {
       result = TConsNil(head_, t) and tail_ = TAccessPathNil()
       or
@@ -2927,7 +2920,6 @@ module Impl<FullStateConfigSig Config> {
       result = TCons1(head_, this.length())
     }
 
-    pragma[assume_small_delta]
     override int length() { result = 1 + tail_.length() }
 
     private string toStringImpl(boolean needsSuffix) {
@@ -3379,7 +3371,6 @@ module Impl<FullStateConfigSig Config> {
    * Holds if data may flow from `mid` to `node`. The last step in or out of
    * a callable is recorded by `cc`.
    */
-  pragma[assume_small_delta]
   pragma[nomagic]
   private predicate pathStep0(
     PathNodeMid mid, NodeEx node, FlowState state, CallContext cc, SummaryCtx sc, DataFlowType t,
@@ -3592,7 +3583,6 @@ module Impl<FullStateConfigSig Config> {
     )
   }
 
-  pragma[assume_small_delta]
   pragma[nomagic]
   private predicate pathThroughCallable0(
     DataFlowCall call, PathNodeMid mid, ReturnKindExt kind, FlowState state, CallContext cc,

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImplCommon.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImplCommon.qll
@@ -187,7 +187,6 @@ private module LambdaFlow {
     else any()
   }
 
-  pragma[assume_small_delta]
   pragma[nomagic]
   predicate revLambdaFlow0(
     DataFlowCall lambdaCall, LambdaCallKind kind, Node node, DataFlowType t, boolean toReturn,
@@ -274,7 +273,6 @@ private module LambdaFlow {
     )
   }
 
-  pragma[assume_small_delta]
   pragma[nomagic]
   predicate revLambdaFlowOut(
     DataFlowCall lambdaCall, LambdaCallKind kind, TReturnPositionSimple pos, DataFlowType t,

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/ProductFlow.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/ProductFlow.qll
@@ -359,7 +359,6 @@ module ProductFlow {
       Config::isSinkPair(node1.getNode(), node1.getState(), node2.getNode(), node2.getState())
     }
 
-    pragma[assume_small_delta]
     pragma[nomagic]
     private predicate fwdReachableInterprocEntry(Flow1::PathNode node1, Flow2::PathNode node2) {
       isSourcePair(node1, node2)
@@ -396,7 +395,6 @@ module ProductFlow {
       fwdIsSuccessorExit(pragma[only_bind_into](mid1), pragma[only_bind_into](mid2), succ1, succ2)
     }
 
-    pragma[assume_small_delta]
     private predicate fwdIsSuccessor(
       Flow1::PathNode pred1, Flow2::PathNode pred2, Flow1::PathNode succ1, Flow2::PathNode succ2
     ) {
@@ -406,7 +404,6 @@ module ProductFlow {
       )
     }
 
-    pragma[assume_small_delta]
     pragma[nomagic]
     private predicate revReachableInterprocEntry(Flow1::PathNode node1, Flow2::PathNode node2) {
       fwdReachableInterprocEntry(node1, node2) and

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternalsCommon.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternalsCommon.qll
@@ -588,7 +588,6 @@ private module Cached {
     )
   }
 
-  pragma[assume_small_delta]
   private predicate convertsIntoArgumentRev(Instruction instr) {
     convertsIntoArgumentFwd(instr) and
     (

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/gvn/internal/ValueNumberingInternal.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/gvn/internal/ValueNumberingInternal.qll
@@ -176,7 +176,6 @@ private predicate binaryValueNumber0(
   )
 }
 
-pragma[assume_small_delta]
 private predicate binaryValueNumber(
   BinaryInstruction instr, IRFunction irFunc, Opcode opcode, TValueNumber leftOperand,
   TValueNumber rightOperand
@@ -202,7 +201,6 @@ private predicate pointerArithmeticValueNumber0(
   )
 }
 
-pragma[assume_small_delta]
 private predicate pointerArithmeticValueNumber(
   PointerArithmeticInstruction instr, IRFunction irFunc, Opcode opcode, int elementSize,
   TValueNumber leftOperand, TValueNumber rightOperand
@@ -249,7 +247,6 @@ private predicate loadTotalOverlapValueNumber0(
   )
 }
 
-pragma[assume_small_delta]
 private predicate loadTotalOverlapValueNumber(
   LoadTotalOverlapInstruction instr, IRFunction irFunc, IRType type, TValueNumber memOperand,
   TValueNumber operand

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/gvn/internal/ValueNumberingInternal.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/gvn/internal/ValueNumberingInternal.qll
@@ -176,7 +176,6 @@ private predicate binaryValueNumber0(
   )
 }
 
-pragma[assume_small_delta]
 private predicate binaryValueNumber(
   BinaryInstruction instr, IRFunction irFunc, Opcode opcode, TValueNumber leftOperand,
   TValueNumber rightOperand
@@ -202,7 +201,6 @@ private predicate pointerArithmeticValueNumber0(
   )
 }
 
-pragma[assume_small_delta]
 private predicate pointerArithmeticValueNumber(
   PointerArithmeticInstruction instr, IRFunction irFunc, Opcode opcode, int elementSize,
   TValueNumber leftOperand, TValueNumber rightOperand
@@ -249,7 +247,6 @@ private predicate loadTotalOverlapValueNumber0(
   )
 }
 
-pragma[assume_small_delta]
 private predicate loadTotalOverlapValueNumber(
   LoadTotalOverlapInstruction instr, IRFunction irFunc, IRType type, TValueNumber memOperand,
   TValueNumber operand

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/gvn/internal/ValueNumberingInternal.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/gvn/internal/ValueNumberingInternal.qll
@@ -176,7 +176,6 @@ private predicate binaryValueNumber0(
   )
 }
 
-pragma[assume_small_delta]
 private predicate binaryValueNumber(
   BinaryInstruction instr, IRFunction irFunc, Opcode opcode, TValueNumber leftOperand,
   TValueNumber rightOperand
@@ -202,7 +201,6 @@ private predicate pointerArithmeticValueNumber0(
   )
 }
 
-pragma[assume_small_delta]
 private predicate pointerArithmeticValueNumber(
   PointerArithmeticInstruction instr, IRFunction irFunc, Opcode opcode, int elementSize,
   TValueNumber leftOperand, TValueNumber rightOperand
@@ -249,7 +247,6 @@ private predicate loadTotalOverlapValueNumber0(
   )
 }
 
-pragma[assume_small_delta]
 private predicate loadTotalOverlapValueNumber(
   LoadTotalOverlapInstruction instr, IRFunction irFunc, IRType type, TValueNumber memOperand,
   TValueNumber operand

--- a/cpp/ql/lib/semmle/code/cpp/rangeanalysis/new/internal/semantic/analysis/RangeAnalysisStage.qll
+++ b/cpp/ql/lib/semmle/code/cpp/rangeanalysis/new/internal/semantic/analysis/RangeAnalysisStage.qll
@@ -877,7 +877,6 @@ module RangeStage<
     )
   }
 
-  pragma[assume_small_delta]
   pragma[nomagic]
   private predicate boundedPhiRankStep(
     SemSsaPhiNode phi, SemBound b, D::Delta delta, boolean upper, boolean fromBackEdge,

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -460,7 +460,6 @@ module Impl<FullStateConfigSig Config> {
      * The Boolean `cc` records whether the node is reached through an
      * argument in a call.
      */
-    pragma[assume_small_delta]
     private predicate fwdFlow(NodeEx node, Cc cc) {
       sourceNode(node, _) and
       if hasSourceCallCtx() then cc = true else cc = false
@@ -570,7 +569,6 @@ module Impl<FullStateConfigSig Config> {
     /**
      * Holds if `c` is the target of a store in the flow covered by `fwdFlow`.
      */
-    pragma[assume_small_delta]
     pragma[nomagic]
     private predicate fwdFlowConsCand(Content c) {
       exists(NodeEx mid, NodeEx node |
@@ -1216,7 +1214,6 @@ module Impl<FullStateConfigSig Config> {
         fwdFlow1(_, _, _, _, _, _, t0, t, ap, _) and t0 != t
       }
 
-      pragma[assume_small_delta]
       pragma[nomagic]
       private predicate fwdFlow0(
         NodeEx node, FlowState state, Cc cc, ParamNodeOption summaryCtx, TypOption argT,
@@ -2777,7 +2774,6 @@ module Impl<FullStateConfigSig Config> {
   /**
    * Gets the number of `AccessPath`s that correspond to `apa`.
    */
-  pragma[assume_small_delta]
   private int countAps(AccessPathApprox apa) {
     evalUnfold(apa, false) and
     result = 1 and
@@ -2796,7 +2792,6 @@ module Impl<FullStateConfigSig Config> {
    * that it is expanded to a precise head-tail representation.
    */
   language[monotonicAggregates]
-  pragma[assume_small_delta]
   private int countPotentialAps(AccessPathApprox apa) {
     apa instanceof AccessPathApproxNil and result = 1
     or
@@ -2833,7 +2828,6 @@ module Impl<FullStateConfigSig Config> {
     }
 
   private newtype TPathNode =
-    pragma[assume_small_delta]
     TPathNodeMid(
       NodeEx node, FlowState state, CallContext cc, SummaryCtx sc, DataFlowType t, AccessPath ap
     ) {
@@ -2918,7 +2912,6 @@ module Impl<FullStateConfigSig Config> {
 
     override AccessPathFrontHead getFront() { result = TFrontHead(head_) }
 
-    pragma[assume_small_delta]
     override AccessPathApproxCons getApprox() {
       result = TConsNil(head_, t) and tail_ = TAccessPathNil()
       or
@@ -2927,7 +2920,6 @@ module Impl<FullStateConfigSig Config> {
       result = TCons1(head_, this.length())
     }
 
-    pragma[assume_small_delta]
     override int length() { result = 1 + tail_.length() }
 
     private string toStringImpl(boolean needsSuffix) {
@@ -3379,7 +3371,6 @@ module Impl<FullStateConfigSig Config> {
    * Holds if data may flow from `mid` to `node`. The last step in or out of
    * a callable is recorded by `cc`.
    */
-  pragma[assume_small_delta]
   pragma[nomagic]
   private predicate pathStep0(
     PathNodeMid mid, NodeEx node, FlowState state, CallContext cc, SummaryCtx sc, DataFlowType t,
@@ -3592,7 +3583,6 @@ module Impl<FullStateConfigSig Config> {
     )
   }
 
-  pragma[assume_small_delta]
   pragma[nomagic]
   private predicate pathThroughCallable0(
     DataFlowCall call, PathNodeMid mid, ReturnKindExt kind, FlowState state, CallContext cc,

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImplCommon.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImplCommon.qll
@@ -187,7 +187,6 @@ private module LambdaFlow {
     else any()
   }
 
-  pragma[assume_small_delta]
   pragma[nomagic]
   predicate revLambdaFlow0(
     DataFlowCall lambdaCall, LambdaCallKind kind, Node node, DataFlowType t, boolean toReturn,
@@ -274,7 +273,6 @@ private module LambdaFlow {
     )
   }
 
-  pragma[assume_small_delta]
   pragma[nomagic]
   predicate revLambdaFlowOut(
     DataFlowCall lambdaCall, LambdaCallKind kind, TReturnPositionSimple pos, DataFlowType t,

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/FlowSummaryImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/FlowSummaryImpl.qll
@@ -110,7 +110,6 @@ module Public {
     }
 
     /** Gets the stack obtained by dropping the first `i` elements, if any. */
-    pragma[assume_small_delta]
     SummaryComponentStack drop(int i) {
       i = 0 and result = this
       or

--- a/csharp/ql/src/experimental/ir/implementation/raw/gvn/internal/ValueNumberingInternal.qll
+++ b/csharp/ql/src/experimental/ir/implementation/raw/gvn/internal/ValueNumberingInternal.qll
@@ -176,7 +176,6 @@ private predicate binaryValueNumber0(
   )
 }
 
-pragma[assume_small_delta]
 private predicate binaryValueNumber(
   BinaryInstruction instr, IRFunction irFunc, Opcode opcode, TValueNumber leftOperand,
   TValueNumber rightOperand
@@ -202,7 +201,6 @@ private predicate pointerArithmeticValueNumber0(
   )
 }
 
-pragma[assume_small_delta]
 private predicate pointerArithmeticValueNumber(
   PointerArithmeticInstruction instr, IRFunction irFunc, Opcode opcode, int elementSize,
   TValueNumber leftOperand, TValueNumber rightOperand
@@ -249,7 +247,6 @@ private predicate loadTotalOverlapValueNumber0(
   )
 }
 
-pragma[assume_small_delta]
 private predicate loadTotalOverlapValueNumber(
   LoadTotalOverlapInstruction instr, IRFunction irFunc, IRType type, TValueNumber memOperand,
   TValueNumber operand

--- a/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/gvn/internal/ValueNumberingInternal.qll
+++ b/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/gvn/internal/ValueNumberingInternal.qll
@@ -176,7 +176,6 @@ private predicate binaryValueNumber0(
   )
 }
 
-pragma[assume_small_delta]
 private predicate binaryValueNumber(
   BinaryInstruction instr, IRFunction irFunc, Opcode opcode, TValueNumber leftOperand,
   TValueNumber rightOperand
@@ -202,7 +201,6 @@ private predicate pointerArithmeticValueNumber0(
   )
 }
 
-pragma[assume_small_delta]
 private predicate pointerArithmeticValueNumber(
   PointerArithmeticInstruction instr, IRFunction irFunc, Opcode opcode, int elementSize,
   TValueNumber leftOperand, TValueNumber rightOperand
@@ -249,7 +247,6 @@ private predicate loadTotalOverlapValueNumber0(
   )
 }
 
-pragma[assume_small_delta]
 private predicate loadTotalOverlapValueNumber(
   LoadTotalOverlapInstruction instr, IRFunction irFunc, IRType type, TValueNumber memOperand,
   TValueNumber operand

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowImpl.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowImpl.qll
@@ -460,7 +460,6 @@ module Impl<FullStateConfigSig Config> {
      * The Boolean `cc` records whether the node is reached through an
      * argument in a call.
      */
-    pragma[assume_small_delta]
     private predicate fwdFlow(NodeEx node, Cc cc) {
       sourceNode(node, _) and
       if hasSourceCallCtx() then cc = true else cc = false
@@ -570,7 +569,6 @@ module Impl<FullStateConfigSig Config> {
     /**
      * Holds if `c` is the target of a store in the flow covered by `fwdFlow`.
      */
-    pragma[assume_small_delta]
     pragma[nomagic]
     private predicate fwdFlowConsCand(Content c) {
       exists(NodeEx mid, NodeEx node |
@@ -1216,7 +1214,6 @@ module Impl<FullStateConfigSig Config> {
         fwdFlow1(_, _, _, _, _, _, t0, t, ap, _) and t0 != t
       }
 
-      pragma[assume_small_delta]
       pragma[nomagic]
       private predicate fwdFlow0(
         NodeEx node, FlowState state, Cc cc, ParamNodeOption summaryCtx, TypOption argT,
@@ -2777,7 +2774,6 @@ module Impl<FullStateConfigSig Config> {
   /**
    * Gets the number of `AccessPath`s that correspond to `apa`.
    */
-  pragma[assume_small_delta]
   private int countAps(AccessPathApprox apa) {
     evalUnfold(apa, false) and
     result = 1 and
@@ -2796,7 +2792,6 @@ module Impl<FullStateConfigSig Config> {
    * that it is expanded to a precise head-tail representation.
    */
   language[monotonicAggregates]
-  pragma[assume_small_delta]
   private int countPotentialAps(AccessPathApprox apa) {
     apa instanceof AccessPathApproxNil and result = 1
     or
@@ -2833,7 +2828,6 @@ module Impl<FullStateConfigSig Config> {
     }
 
   private newtype TPathNode =
-    pragma[assume_small_delta]
     TPathNodeMid(
       NodeEx node, FlowState state, CallContext cc, SummaryCtx sc, DataFlowType t, AccessPath ap
     ) {
@@ -2918,7 +2912,6 @@ module Impl<FullStateConfigSig Config> {
 
     override AccessPathFrontHead getFront() { result = TFrontHead(head_) }
 
-    pragma[assume_small_delta]
     override AccessPathApproxCons getApprox() {
       result = TConsNil(head_, t) and tail_ = TAccessPathNil()
       or
@@ -2927,7 +2920,6 @@ module Impl<FullStateConfigSig Config> {
       result = TCons1(head_, this.length())
     }
 
-    pragma[assume_small_delta]
     override int length() { result = 1 + tail_.length() }
 
     private string toStringImpl(boolean needsSuffix) {
@@ -3379,7 +3371,6 @@ module Impl<FullStateConfigSig Config> {
    * Holds if data may flow from `mid` to `node`. The last step in or out of
    * a callable is recorded by `cc`.
    */
-  pragma[assume_small_delta]
   pragma[nomagic]
   private predicate pathStep0(
     PathNodeMid mid, NodeEx node, FlowState state, CallContext cc, SummaryCtx sc, DataFlowType t,
@@ -3592,7 +3583,6 @@ module Impl<FullStateConfigSig Config> {
     )
   }
 
-  pragma[assume_small_delta]
   pragma[nomagic]
   private predicate pathThroughCallable0(
     DataFlowCall call, PathNodeMid mid, ReturnKindExt kind, FlowState state, CallContext cc,

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowImplCommon.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowImplCommon.qll
@@ -187,7 +187,6 @@ private module LambdaFlow {
     else any()
   }
 
-  pragma[assume_small_delta]
   pragma[nomagic]
   predicate revLambdaFlow0(
     DataFlowCall lambdaCall, LambdaCallKind kind, Node node, DataFlowType t, boolean toReturn,
@@ -274,7 +273,6 @@ private module LambdaFlow {
     )
   }
 
-  pragma[assume_small_delta]
   pragma[nomagic]
   predicate revLambdaFlowOut(
     DataFlowCall lambdaCall, LambdaCallKind kind, TReturnPositionSimple pos, DataFlowType t,

--- a/go/ql/lib/semmle/go/dataflow/internal/FlowSummaryImpl.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/FlowSummaryImpl.qll
@@ -110,7 +110,6 @@ module Public {
     }
 
     /** Gets the stack obtained by dropping the first `i` elements, if any. */
-    pragma[assume_small_delta]
     SummaryComponentStack drop(int i) {
       i = 0 and result = this
       or

--- a/java/ql/lib/semmle/code/java/Constants.qll
+++ b/java/ql/lib/semmle/code/java/Constants.qll
@@ -17,7 +17,6 @@ signature int getIntValSig(Expr e);
  */
 module CalculateConstants<getBoolValSig/1 getBoolVal, getIntValSig/1 getIntVal> {
   /** Gets the value of a constant boolean expression. */
-  pragma[assume_small_delta]
   boolean calculateBooleanValue(Expr e) {
     // No casts relevant to booleans.
     // `!` is the only unary operator that evaluates to a boolean.
@@ -99,7 +98,6 @@ module CalculateConstants<getBoolValSig/1 getBoolVal, getIntValSig/1 getIntVal> 
   }
 
   /** Gets the value of a constant integer expression. */
-  pragma[assume_small_delta]
   int calculateIntValue(Expr e) {
     exists(IntegralType t | e.getType() = t | t.getName().toLowerCase() != "long") and
     (

--- a/java/ql/lib/semmle/code/java/ControlFlowGraph.qll
+++ b/java/ql/lib/semmle/code/java/ControlFlowGraph.qll
@@ -365,7 +365,6 @@ private module ControlFlowGraphImpl {
   /**
    * Gets a non-overridable method that always throws an exception or calls `exit`.
    */
-  pragma[assume_small_delta]
   private Method nonReturningMethod() {
     result instanceof MethodExit
     or
@@ -382,7 +381,6 @@ private module ControlFlowGraphImpl {
   /**
    * Gets a virtual method that always throws an exception or calls `exit`.
    */
-  pragma[assume_small_delta]
   private EffectivelyNonVirtualMethod likelyNonReturningMethod() {
     result.getReturnType() instanceof VoidType and
     not exists(ReturnStmt ret | ret.getEnclosingCallable() = result) and
@@ -402,7 +400,6 @@ private module ControlFlowGraphImpl {
   /**
    * Gets a statement that always throws an exception or calls `exit`.
    */
-  pragma[assume_small_delta]
   private Stmt nonReturningStmt() {
     result instanceof ThrowStmt
     or
@@ -424,7 +421,6 @@ private module ControlFlowGraphImpl {
   /**
    * Gets an expression that always throws an exception or calls `exit`.
    */
-  pragma[assume_small_delta]
   private Expr nonReturningExpr() {
     result = nonReturningMethodAccess()
     or

--- a/java/ql/lib/semmle/code/java/Expr.qll
+++ b/java/ql/lib/semmle/code/java/Expr.qll
@@ -131,7 +131,6 @@ private predicate primitiveOrString(Type t) {
  * See JLS v8, section 15.28 (Constant Expressions).
  */
 class CompileTimeConstantExpr extends Expr {
-  pragma[assume_small_delta]
   CompileTimeConstantExpr() {
     primitiveOrString(this.getType()) and
     (
@@ -181,7 +180,6 @@ class CompileTimeConstantExpr extends Expr {
   /**
    * Gets the string value of this expression, where possible.
    */
-  pragma[assume_small_delta]
   pragma[nomagic]
   string getStringValue() {
     result = this.(StringLiteral).getValue()
@@ -207,7 +205,6 @@ class CompileTimeConstantExpr extends Expr {
   /**
    * Gets the boolean value of this expression, where possible.
    */
-  pragma[assume_small_delta]
   pragma[nomagic]
   boolean getBooleanValue() {
     // Literal value.
@@ -1910,7 +1907,6 @@ class TypeAccess extends Expr, Annotatable, @typeaccess {
   override CompilationUnit getCompilationUnit() { result = Expr.super.getCompilationUnit() }
 
   /** Gets a printable representation of this expression. */
-  pragma[assume_small_delta]
   override string toString() {
     result = this.getQualifier().toString() + "." + this.getType().toString()
     or

--- a/java/ql/lib/semmle/code/java/Member.qll
+++ b/java/ql/lib/semmle/code/java/Member.qll
@@ -736,7 +736,6 @@ class FieldDeclaration extends ExprParent, @fielddecl, Annotatable {
   /** Gets the number of fields declared in this declaration. */
   int getNumField() { result = max(int idx | fieldDeclaredIn(_, this, idx) | idx) + 1 }
 
-  pragma[assume_small_delta]
   override string toString() {
     if this.getNumField() = 1
     then result = this.getTypeAccess() + " " + this.getField(0) + ";"

--- a/java/ql/lib/semmle/code/java/Type.qll
+++ b/java/ql/lib/semmle/code/java/Type.qll
@@ -309,7 +309,6 @@ private predicate hasSubtypeStar1(RefType t, RefType sub) {
 /**
  * Holds if `hasSubtype*(t, sub)`, but manual-magic'ed with `getAWildcardLowerBound(sub)`.
  */
-pragma[assume_small_delta]
 pragma[nomagic]
 private predicate hasSubtypeStar2(RefType t, RefType sub) {
   sub = t and getAWildcardLowerBound(sub)

--- a/java/ql/lib/semmle/code/java/dataflow/NullGuards.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/NullGuards.qll
@@ -42,7 +42,6 @@ EqualityTest varEqualityTestExpr(SsaVariable v1, SsaVariable v2, boolean isEqual
 }
 
 /** Gets an expression that is provably not `null`. */
-pragma[assume_small_delta]
 Expr clearlyNotNullExpr(Expr reason) {
   result instanceof ClassInstanceExpr and reason = result
   or
@@ -237,7 +236,6 @@ Expr directNullGuard(SsaVariable v, boolean branch, boolean isnull) {
  * If `result` evaluates to `branch`, then `v` is guaranteed to be null if `isnull`
  * is true, and non-null if `isnull` is false.
  */
-pragma[assume_small_delta]
 Guard nullGuard(SsaVariable v, boolean branch, boolean isnull) {
   result = directNullGuard(v, branch, isnull) or
   exists(boolean branch0 | implies_v3(result, branch, nullGuard(v, branch0, isnull), branch0))

--- a/java/ql/lib/semmle/code/java/dataflow/SSA.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/SSA.qll
@@ -61,7 +61,6 @@ class SsaSourceVariable extends TSsaSourceVariable {
    * accessed from nested callables are therefore associated with several
    * `SsaSourceVariable`s.
    */
-  pragma[assume_small_delta]
   cached
   VarAccess getAnAccess() {
     exists(LocalScopeVariable v, Callable c |
@@ -451,7 +450,6 @@ private module SsaImpl {
    * Holds if `f` is live in `b` at index `i`. The rank of `i` is `rankix` as
    * defined by `callDefUseRank`.
    */
-  pragma[assume_small_delta]
   private predicate liveAtRank(TrackedField f, BasicBlock b, int rankix, int i) {
     callDefUseRank(f, b, rankix, i) and
     (
@@ -565,7 +563,6 @@ private module SsaImpl {
   }
 
   /** Holds if a phi node for `v` is needed at the beginning of basic block `b`. */
-  pragma[assume_small_delta]
   cached
   predicate phiNode(TrackedVar v, BasicBlock b) {
     liveAtEntry(v, b) and

--- a/java/ql/lib/semmle/code/java/dataflow/TypeFlow.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/TypeFlow.qll
@@ -241,7 +241,6 @@ private module ForAll<NodeSig Node, RankedEdge<Node> E, TypePropagation T> {
    * Holds if `t` is a candidate bound for `n` that is also valid for data coming
    * through the edges into `n` ranked from `1` to `r`.
    */
-  pragma[assume_small_delta]
   private predicate flowJoin(int r, Node n, T::Typ t) {
     (
       r = 1 and candJoinType(n, t)

--- a/java/ql/lib/semmle/code/java/dataflow/internal/BaseSSA.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/BaseSSA.qll
@@ -151,7 +151,6 @@ private module SsaImpl {
   }
 
   /** Holds if a phi node for `v` is needed at the beginning of basic block `b`. */
-  pragma[assume_small_delta]
   cached
   predicate phiNode(BaseSsaSourceVariable v, BasicBlock b) {
     liveAtEntry(v, b) and

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -460,7 +460,6 @@ module Impl<FullStateConfigSig Config> {
      * The Boolean `cc` records whether the node is reached through an
      * argument in a call.
      */
-    pragma[assume_small_delta]
     private predicate fwdFlow(NodeEx node, Cc cc) {
       sourceNode(node, _) and
       if hasSourceCallCtx() then cc = true else cc = false
@@ -570,7 +569,6 @@ module Impl<FullStateConfigSig Config> {
     /**
      * Holds if `c` is the target of a store in the flow covered by `fwdFlow`.
      */
-    pragma[assume_small_delta]
     pragma[nomagic]
     private predicate fwdFlowConsCand(Content c) {
       exists(NodeEx mid, NodeEx node |
@@ -1216,7 +1214,6 @@ module Impl<FullStateConfigSig Config> {
         fwdFlow1(_, _, _, _, _, _, t0, t, ap, _) and t0 != t
       }
 
-      pragma[assume_small_delta]
       pragma[nomagic]
       private predicate fwdFlow0(
         NodeEx node, FlowState state, Cc cc, ParamNodeOption summaryCtx, TypOption argT,
@@ -2777,7 +2774,6 @@ module Impl<FullStateConfigSig Config> {
   /**
    * Gets the number of `AccessPath`s that correspond to `apa`.
    */
-  pragma[assume_small_delta]
   private int countAps(AccessPathApprox apa) {
     evalUnfold(apa, false) and
     result = 1 and
@@ -2796,7 +2792,6 @@ module Impl<FullStateConfigSig Config> {
    * that it is expanded to a precise head-tail representation.
    */
   language[monotonicAggregates]
-  pragma[assume_small_delta]
   private int countPotentialAps(AccessPathApprox apa) {
     apa instanceof AccessPathApproxNil and result = 1
     or
@@ -2833,7 +2828,6 @@ module Impl<FullStateConfigSig Config> {
     }
 
   private newtype TPathNode =
-    pragma[assume_small_delta]
     TPathNodeMid(
       NodeEx node, FlowState state, CallContext cc, SummaryCtx sc, DataFlowType t, AccessPath ap
     ) {
@@ -2918,7 +2912,6 @@ module Impl<FullStateConfigSig Config> {
 
     override AccessPathFrontHead getFront() { result = TFrontHead(head_) }
 
-    pragma[assume_small_delta]
     override AccessPathApproxCons getApprox() {
       result = TConsNil(head_, t) and tail_ = TAccessPathNil()
       or
@@ -2927,7 +2920,6 @@ module Impl<FullStateConfigSig Config> {
       result = TCons1(head_, this.length())
     }
 
-    pragma[assume_small_delta]
     override int length() { result = 1 + tail_.length() }
 
     private string toStringImpl(boolean needsSuffix) {
@@ -3379,7 +3371,6 @@ module Impl<FullStateConfigSig Config> {
    * Holds if data may flow from `mid` to `node`. The last step in or out of
    * a callable is recorded by `cc`.
    */
-  pragma[assume_small_delta]
   pragma[nomagic]
   private predicate pathStep0(
     PathNodeMid mid, NodeEx node, FlowState state, CallContext cc, SummaryCtx sc, DataFlowType t,
@@ -3592,7 +3583,6 @@ module Impl<FullStateConfigSig Config> {
     )
   }
 
-  pragma[assume_small_delta]
   pragma[nomagic]
   private predicate pathThroughCallable0(
     DataFlowCall call, PathNodeMid mid, ReturnKindExt kind, FlowState state, CallContext cc,

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplCommon.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplCommon.qll
@@ -187,7 +187,6 @@ private module LambdaFlow {
     else any()
   }
 
-  pragma[assume_small_delta]
   pragma[nomagic]
   predicate revLambdaFlow0(
     DataFlowCall lambdaCall, LambdaCallKind kind, Node node, DataFlowType t, boolean toReturn,
@@ -274,7 +273,6 @@ private module LambdaFlow {
     )
   }
 
-  pragma[assume_small_delta]
   pragma[nomagic]
   predicate revLambdaFlowOut(
     DataFlowCall lambdaCall, LambdaCallKind kind, TReturnPositionSimple pos, DataFlowType t,

--- a/java/ql/lib/semmle/code/java/dataflow/internal/FlowSummaryImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/FlowSummaryImpl.qll
@@ -110,7 +110,6 @@ module Public {
     }
 
     /** Gets the stack obtained by dropping the first `i` elements, if any. */
-    pragma[assume_small_delta]
     SummaryComponentStack drop(int i) {
       i = 0 and result = this
       or

--- a/java/ql/lib/semmle/code/java/dataflow/internal/TaintTrackingUtil.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/TaintTrackingUtil.qll
@@ -617,7 +617,6 @@ private MethodAccess callReturningSameType(Expr ref) {
   result.getMethod().getReturnType() = ref.getType()
 }
 
-pragma[assume_small_delta]
 private SrcRefType entrypointType() {
   exists(RemoteFlowSource s, RefType t |
     s instanceof DataFlow::ExplicitParameterNode and

--- a/java/ql/lib/semmle/code/java/dispatch/DispatchFlow.qll
+++ b/java/ql/lib/semmle/code/java/dispatch/DispatchFlow.qll
@@ -31,7 +31,6 @@ private Callable dispatchCand(Call c) {
 /**
  * Holds if `t` and all its enclosing types are public.
  */
-pragma[assume_small_delta]
 private predicate veryPublic(RefType t) {
   t.isPublic() and
   (

--- a/java/ql/lib/semmle/code/java/dispatch/ObjFlow.qll
+++ b/java/ql/lib/semmle/code/java/dispatch/ObjFlow.qll
@@ -206,7 +206,6 @@ private predicate relevantNodeBack(ObjNode n) {
   exists(ObjNode mid | objStep(n, mid) and relevantNodeBack(mid))
 }
 
-pragma[assume_small_delta]
 private predicate relevantNode(ObjNode n) {
   source(_, n) and relevantNodeBack(n)
   or

--- a/java/ql/lib/semmle/code/java/frameworks/JaxWS.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/JaxWS.qll
@@ -53,7 +53,6 @@ private predicate hasPathAnnotation(Annotatable annotatable) {
  * A method which is annotated with one or more JaxRS resource type annotations e.g. `@GET`, `@POST` etc.
  */
 class JaxRsResourceMethod extends Method {
-  pragma[assume_small_delta]
   JaxRsResourceMethod() {
     exists(AnnotationType a |
       a = this.getAnAnnotation().getType() and
@@ -92,7 +91,6 @@ class JaxRsResourceMethod extends Method {
  * This class contains resource methods, which are executed in response to requests.
  */
 class JaxRsResourceClass extends Class {
-  pragma[assume_small_delta]
   JaxRsResourceClass() {
     // A root resource class has a @Path annotation on the class.
     hasPathAnnotation(this)

--- a/java/ql/lib/semmle/code/java/frameworks/Rmi.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/Rmi.qll
@@ -12,7 +12,6 @@ class RemoteCallableMethod extends Method {
   RemoteCallableMethod() { remoteCallableMethod(this) }
 }
 
-pragma[assume_small_delta]
 private predicate remoteCallableMethod(Method method) {
   method.getDeclaringType().getASupertype() instanceof TypeRemote
   or

--- a/java/ql/lib/semmle/code/java/frameworks/google/GsonSerializability.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/google/GsonSerializability.qll
@@ -45,7 +45,6 @@ private class FieldReferencedGsonDeserializableType extends GsonDeserializableTy
 
 /** A field that may be deserialized using the Gson JSON framework. */
 private class GsonDeserializableField extends DeserializableField {
-  pragma[assume_small_delta]
   GsonDeserializableField() {
     exists(GsonDeserializableType superType |
       superType = this.getDeclaringType().getAnAncestor() and

--- a/java/ql/lib/semmle/code/java/frameworks/jackson/JacksonSerializability.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/jackson/JacksonSerializability.qll
@@ -146,7 +146,6 @@ class JacksonSerializableField extends SerializableField {
 
 /** A field that may be deserialized using the Jackson JSON framework. */
 class JacksonDeserializableField extends DeserializableField {
-  pragma[assume_small_delta]
   JacksonDeserializableField() {
     exists(JacksonDeserializableType superType |
       superType = this.getDeclaringType().getAnAncestor() and

--- a/javascript/ql/lib/semmle/javascript/InclusionTests.qll
+++ b/javascript/ql/lib/semmle/javascript/InclusionTests.qll
@@ -69,7 +69,6 @@ module InclusionTest {
       inner.getContainerNode().getALocalSource() = DataFlow::parameterNode(callee.getAParameter())
     }
 
-    pragma[assume_small_delta]
     override DataFlow::Node getContainerNode() {
       exists(int arg |
         inner.getContainerNode().getALocalSource() =
@@ -78,7 +77,6 @@ module InclusionTest {
       )
     }
 
-    pragma[assume_small_delta]
     override DataFlow::Node getContainedNode() {
       exists(int arg |
         inner.getContainedNode().getALocalSource() =

--- a/javascript/ql/lib/semmle/javascript/StringOps.qll
+++ b/javascript/ql/lib/semmle/javascript/StringOps.qll
@@ -67,7 +67,6 @@ module StringOps {
         inner.getSubstring().getALocalSource().getEnclosingExpr() = callee.getAParameter()
       }
 
-      pragma[assume_small_delta]
       override DataFlow::Node getBaseString() {
         exists(int arg |
           inner.getBaseString().getALocalSource().getEnclosingExpr() = callee.getParameter(arg) and
@@ -75,7 +74,6 @@ module StringOps {
         )
       }
 
-      pragma[assume_small_delta]
       override DataFlow::Node getSubstring() {
         exists(int arg |
           inner.getSubstring().getALocalSource().getEnclosingExpr() = callee.getParameter(arg) and
@@ -294,7 +292,6 @@ module StringOps {
         inner.getSubstring().getALocalSource().getEnclosingExpr() = callee.getAParameter()
       }
 
-      pragma[assume_small_delta]
       override DataFlow::Node getBaseString() {
         exists(int arg |
           inner.getBaseString().getALocalSource().getEnclosingExpr() = callee.getParameter(arg) and
@@ -302,7 +299,6 @@ module StringOps {
         )
       }
 
-      pragma[assume_small_delta]
       override DataFlow::Node getSubstring() {
         exists(int arg |
           inner.getSubstring().getALocalSource().getEnclosingExpr() = callee.getParameter(arg) and

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/SecondOrderCommandInjectionCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/SecondOrderCommandInjectionCustomizations.qll
@@ -117,7 +117,6 @@ module SecondOrderCommandInjection {
     int cmdIndex;
     int argIndex;
 
-    pragma[assume_small_delta]
     IndirectCmdFunc() {
       exists(CommandExecutingCall call |
         this.getParameter(cmdIndex).flowsTo(call.getCommandArg()) and

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowDispatch.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowDispatch.qll
@@ -1227,7 +1227,6 @@ predicate normalCallArg(CallNode call, Node arg, ArgumentPosition apos) {
  * time the bound method is used, such that the `clear()` call would essentially be
  * translated into `l.clear()`, and we can still have use-use flow.
  */
-pragma[assume_small_delta]
 cached
 predicate getCallArg(CallNode call, Function target, CallType type, Node arg, ArgumentPosition apos) {
   Stages::DataFlow::ref() and

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl.qll
@@ -460,7 +460,6 @@ module Impl<FullStateConfigSig Config> {
      * The Boolean `cc` records whether the node is reached through an
      * argument in a call.
      */
-    pragma[assume_small_delta]
     private predicate fwdFlow(NodeEx node, Cc cc) {
       sourceNode(node, _) and
       if hasSourceCallCtx() then cc = true else cc = false
@@ -570,7 +569,6 @@ module Impl<FullStateConfigSig Config> {
     /**
      * Holds if `c` is the target of a store in the flow covered by `fwdFlow`.
      */
-    pragma[assume_small_delta]
     pragma[nomagic]
     private predicate fwdFlowConsCand(Content c) {
       exists(NodeEx mid, NodeEx node |
@@ -1216,7 +1214,6 @@ module Impl<FullStateConfigSig Config> {
         fwdFlow1(_, _, _, _, _, _, t0, t, ap, _) and t0 != t
       }
 
-      pragma[assume_small_delta]
       pragma[nomagic]
       private predicate fwdFlow0(
         NodeEx node, FlowState state, Cc cc, ParamNodeOption summaryCtx, TypOption argT,
@@ -2777,7 +2774,6 @@ module Impl<FullStateConfigSig Config> {
   /**
    * Gets the number of `AccessPath`s that correspond to `apa`.
    */
-  pragma[assume_small_delta]
   private int countAps(AccessPathApprox apa) {
     evalUnfold(apa, false) and
     result = 1 and
@@ -2796,7 +2792,6 @@ module Impl<FullStateConfigSig Config> {
    * that it is expanded to a precise head-tail representation.
    */
   language[monotonicAggregates]
-  pragma[assume_small_delta]
   private int countPotentialAps(AccessPathApprox apa) {
     apa instanceof AccessPathApproxNil and result = 1
     or
@@ -2833,7 +2828,6 @@ module Impl<FullStateConfigSig Config> {
     }
 
   private newtype TPathNode =
-    pragma[assume_small_delta]
     TPathNodeMid(
       NodeEx node, FlowState state, CallContext cc, SummaryCtx sc, DataFlowType t, AccessPath ap
     ) {
@@ -2918,7 +2912,6 @@ module Impl<FullStateConfigSig Config> {
 
     override AccessPathFrontHead getFront() { result = TFrontHead(head_) }
 
-    pragma[assume_small_delta]
     override AccessPathApproxCons getApprox() {
       result = TConsNil(head_, t) and tail_ = TAccessPathNil()
       or
@@ -2927,7 +2920,6 @@ module Impl<FullStateConfigSig Config> {
       result = TCons1(head_, this.length())
     }
 
-    pragma[assume_small_delta]
     override int length() { result = 1 + tail_.length() }
 
     private string toStringImpl(boolean needsSuffix) {
@@ -3379,7 +3371,6 @@ module Impl<FullStateConfigSig Config> {
    * Holds if data may flow from `mid` to `node`. The last step in or out of
    * a callable is recorded by `cc`.
    */
-  pragma[assume_small_delta]
   pragma[nomagic]
   private predicate pathStep0(
     PathNodeMid mid, NodeEx node, FlowState state, CallContext cc, SummaryCtx sc, DataFlowType t,
@@ -3592,7 +3583,6 @@ module Impl<FullStateConfigSig Config> {
     )
   }
 
-  pragma[assume_small_delta]
   pragma[nomagic]
   private predicate pathThroughCallable0(
     DataFlowCall call, PathNodeMid mid, ReturnKindExt kind, FlowState state, CallContext cc,

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImplCommon.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImplCommon.qll
@@ -187,7 +187,6 @@ private module LambdaFlow {
     else any()
   }
 
-  pragma[assume_small_delta]
   pragma[nomagic]
   predicate revLambdaFlow0(
     DataFlowCall lambdaCall, LambdaCallKind kind, Node node, DataFlowType t, boolean toReturn,
@@ -274,7 +273,6 @@ private module LambdaFlow {
     )
   }
 
-  pragma[assume_small_delta]
   pragma[nomagic]
   predicate revLambdaFlowOut(
     DataFlowCall lambdaCall, LambdaCallKind kind, TReturnPositionSimple pos, DataFlowType t,

--- a/python/ql/lib/semmle/python/dataflow/new/internal/FlowSummaryImpl.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/FlowSummaryImpl.qll
@@ -110,7 +110,6 @@ module Public {
     }
 
     /** Gets the stack obtained by dropping the first `i` elements, if any. */
-    pragma[assume_small_delta]
     SummaryComponentStack drop(int i) {
       i = 0 and result = this
       or

--- a/ql/ql/test/printAst/Foo.qll
+++ b/ql/ql/test/printAst/Foo.qll
@@ -26,11 +26,8 @@ predicate calls(Foo f) {
   true = false
 }
 
-newtype TPathNode =
-  pragma[assume_small_delta]
-  TPathNodeMid()
+newtype TPathNode = TPathNodeMid()
 
 private newtype TPathNode2 =
-  pragma[assume_small_delta]
   TPathNodeMid2(boolean foo) { foo = true } or
   TPathNodeSink(string bar) { bar = "bar" }

--- a/ql/ql/test/printAst/printAst.expected
+++ b/ql/ql/test/printAst/printAst.expected
@@ -1,8 +1,8 @@
 nodes
 | Foo.qll:1:1:1:17 | Import | semmle.label | [Import] Import |
 | Foo.qll:1:1:1:17 | Import | semmle.order | 1 |
-| Foo.qll:1:1:36:44 | TopLevel | semmle.label | [TopLevel] TopLevel |
-| Foo.qll:1:1:36:44 | TopLevel | semmle.order | 1 |
+| Foo.qll:1:1:33:44 | TopLevel | semmle.label | [TopLevel] TopLevel |
+| Foo.qll:1:1:33:44 | TopLevel | semmle.order | 1 |
 | Foo.qll:1:8:1:17 | javascript | semmle.label | [ModuleExpr] javascript |
 | Foo.qll:1:8:1:17 | javascript | semmle.order | 3 |
 | Foo.qll:3:7:3:9 | Class Foo | semmle.label | [Class] Class Foo |
@@ -155,44 +155,36 @@ nodes
 | Foo.qll:26:10:26:14 | Boolean | semmle.order | 77 |
 | Foo.qll:29:9:29:17 | NewType TPathNode | semmle.label | [NewType] NewType TPathNode |
 | Foo.qll:29:9:29:17 | NewType TPathNode | semmle.order | 78 |
-| Foo.qll:30:3:30:28 | annotation | semmle.label | [Annotation] annotation |
-| Foo.qll:30:3:30:28 | annotation | semmle.order | 79 |
-| Foo.qll:30:10:30:27 | assume_small_delta | semmle.label | [AnnotationArg] assume_small_delta |
-| Foo.qll:30:10:30:27 | assume_small_delta | semmle.order | 80 |
-| Foo.qll:31:3:31:14 | NewTypeBranch TPathNodeMid | semmle.label | [NewTypeBranch] NewTypeBranch TPathNodeMid |
-| Foo.qll:31:3:31:14 | NewTypeBranch TPathNodeMid | semmle.order | 81 |
-| Foo.qll:33:1:33:7 | annotation | semmle.label | [Annotation] annotation |
-| Foo.qll:33:1:33:7 | annotation | semmle.order | 82 |
-| Foo.qll:33:17:33:26 | NewType TPathNode2 | semmle.label | [NewType] NewType TPathNode2 |
-| Foo.qll:33:17:33:26 | NewType TPathNode2 | semmle.order | 83 |
-| Foo.qll:34:3:34:28 | annotation | semmle.label | [Annotation] annotation |
-| Foo.qll:34:3:34:28 | annotation | semmle.order | 84 |
-| Foo.qll:34:10:34:27 | assume_small_delta | semmle.label | [AnnotationArg] assume_small_delta |
-| Foo.qll:34:10:34:27 | assume_small_delta | semmle.order | 85 |
-| Foo.qll:35:3:35:15 | NewTypeBranch TPathNodeMid2 | semmle.label | [NewTypeBranch] NewTypeBranch TPathNodeMid2 |
-| Foo.qll:35:3:35:15 | NewTypeBranch TPathNodeMid2 | semmle.order | 86 |
-| Foo.qll:35:17:35:23 | TypeExpr | semmle.label | [TypeExpr] TypeExpr |
-| Foo.qll:35:17:35:23 | TypeExpr | semmle.order | 87 |
-| Foo.qll:35:17:35:27 | foo | semmle.label | [VarDecl] foo |
-| Foo.qll:35:17:35:27 | foo | semmle.order | 87 |
-| Foo.qll:35:32:35:34 | foo | semmle.label | [VarAccess] foo |
-| Foo.qll:35:32:35:34 | foo | semmle.order | 89 |
-| Foo.qll:35:32:35:41 | ComparisonFormula | semmle.label | [ComparisonFormula] ComparisonFormula |
-| Foo.qll:35:32:35:41 | ComparisonFormula | semmle.order | 89 |
-| Foo.qll:35:38:35:41 | Boolean | semmle.label | [Boolean] Boolean |
-| Foo.qll:35:38:35:41 | Boolean | semmle.order | 91 |
-| Foo.qll:36:3:36:15 | NewTypeBranch TPathNodeSink | semmle.label | [NewTypeBranch] NewTypeBranch TPathNodeSink |
-| Foo.qll:36:3:36:15 | NewTypeBranch TPathNodeSink | semmle.order | 92 |
-| Foo.qll:36:17:36:22 | TypeExpr | semmle.label | [TypeExpr] TypeExpr |
-| Foo.qll:36:17:36:22 | TypeExpr | semmle.order | 93 |
-| Foo.qll:36:17:36:26 | bar | semmle.label | [VarDecl] bar |
-| Foo.qll:36:17:36:26 | bar | semmle.order | 93 |
-| Foo.qll:36:31:36:33 | bar | semmle.label | [VarAccess] bar |
-| Foo.qll:36:31:36:33 | bar | semmle.order | 95 |
-| Foo.qll:36:31:36:41 | ComparisonFormula | semmle.label | [ComparisonFormula] ComparisonFormula |
-| Foo.qll:36:31:36:41 | ComparisonFormula | semmle.order | 95 |
-| Foo.qll:36:37:36:41 | String | semmle.label | [String] String |
-| Foo.qll:36:37:36:41 | String | semmle.order | 97 |
+| Foo.qll:29:21:29:32 | NewTypeBranch TPathNodeMid | semmle.label | [NewTypeBranch] NewTypeBranch TPathNodeMid |
+| Foo.qll:29:21:29:32 | NewTypeBranch TPathNodeMid | semmle.order | 79 |
+| Foo.qll:31:1:31:7 | annotation | semmle.label | [Annotation] annotation |
+| Foo.qll:31:1:31:7 | annotation | semmle.order | 80 |
+| Foo.qll:31:17:31:26 | NewType TPathNode2 | semmle.label | [NewType] NewType TPathNode2 |
+| Foo.qll:31:17:31:26 | NewType TPathNode2 | semmle.order | 81 |
+| Foo.qll:32:3:32:15 | NewTypeBranch TPathNodeMid2 | semmle.label | [NewTypeBranch] NewTypeBranch TPathNodeMid2 |
+| Foo.qll:32:3:32:15 | NewTypeBranch TPathNodeMid2 | semmle.order | 82 |
+| Foo.qll:32:17:32:23 | TypeExpr | semmle.label | [TypeExpr] TypeExpr |
+| Foo.qll:32:17:32:23 | TypeExpr | semmle.order | 83 |
+| Foo.qll:32:17:32:27 | foo | semmle.label | [VarDecl] foo |
+| Foo.qll:32:17:32:27 | foo | semmle.order | 83 |
+| Foo.qll:32:32:32:34 | foo | semmle.label | [VarAccess] foo |
+| Foo.qll:32:32:32:34 | foo | semmle.order | 85 |
+| Foo.qll:32:32:32:41 | ComparisonFormula | semmle.label | [ComparisonFormula] ComparisonFormula |
+| Foo.qll:32:32:32:41 | ComparisonFormula | semmle.order | 85 |
+| Foo.qll:32:38:32:41 | Boolean | semmle.label | [Boolean] Boolean |
+| Foo.qll:32:38:32:41 | Boolean | semmle.order | 87 |
+| Foo.qll:33:3:33:15 | NewTypeBranch TPathNodeSink | semmle.label | [NewTypeBranch] NewTypeBranch TPathNodeSink |
+| Foo.qll:33:3:33:15 | NewTypeBranch TPathNodeSink | semmle.order | 88 |
+| Foo.qll:33:17:33:22 | TypeExpr | semmle.label | [TypeExpr] TypeExpr |
+| Foo.qll:33:17:33:22 | TypeExpr | semmle.order | 89 |
+| Foo.qll:33:17:33:26 | bar | semmle.label | [VarDecl] bar |
+| Foo.qll:33:17:33:26 | bar | semmle.order | 89 |
+| Foo.qll:33:31:33:33 | bar | semmle.label | [VarAccess] bar |
+| Foo.qll:33:31:33:33 | bar | semmle.order | 91 |
+| Foo.qll:33:31:33:41 | ComparisonFormula | semmle.label | [ComparisonFormula] ComparisonFormula |
+| Foo.qll:33:31:33:41 | ComparisonFormula | semmle.order | 91 |
+| Foo.qll:33:37:33:41 | String | semmle.label | [String] String |
+| Foo.qll:33:37:33:41 | String | semmle.order | 93 |
 | file://:0:0:0:0 | abs | semmle.label | [BuiltinPredicate] abs |
 | file://:0:0:0:0 | abs | semmle.label | [BuiltinPredicate] abs |
 | file://:0:0:0:0 | acos | semmle.label | [BuiltinPredicate] acos |
@@ -275,26 +267,26 @@ nodes
 | file://:0:0:0:0 | trim | semmle.label | [BuiltinPredicate] trim |
 | file://:0:0:0:0 | ulp | semmle.label | [BuiltinPredicate] ulp |
 | printAst.ql:1:1:1:28 | Import | semmle.label | [Import] Import |
-| printAst.ql:1:1:1:28 | Import | semmle.order | 98 |
+| printAst.ql:1:1:1:28 | Import | semmle.order | 94 |
 | printAst.ql:1:1:1:29 | TopLevel | semmle.label | [TopLevel] TopLevel |
-| printAst.ql:1:1:1:29 | TopLevel | semmle.order | 98 |
+| printAst.ql:1:1:1:29 | TopLevel | semmle.order | 94 |
 | printAst.ql:1:18:1:28 | printAstAst | semmle.label | [ModuleExpr] printAstAst |
-| printAst.ql:1:18:1:28 | printAstAst | semmle.order | 100 |
+| printAst.ql:1:18:1:28 | printAstAst | semmle.order | 96 |
 edges
 | Foo.qll:1:1:1:17 | Import | Foo.qll:1:8:1:17 | javascript | semmle.label | getModuleExpr() |
 | Foo.qll:1:1:1:17 | Import | Foo.qll:1:8:1:17 | javascript | semmle.order | 3 |
-| Foo.qll:1:1:36:44 | TopLevel | Foo.qll:1:1:1:17 | Import | semmle.label | getAnImport() |
-| Foo.qll:1:1:36:44 | TopLevel | Foo.qll:1:1:1:17 | Import | semmle.order | 1 |
-| Foo.qll:1:1:36:44 | TopLevel | Foo.qll:3:7:3:9 | Class Foo | semmle.label | getAClass() |
-| Foo.qll:1:1:36:44 | TopLevel | Foo.qll:3:7:3:9 | Class Foo | semmle.order | 4 |
-| Foo.qll:1:1:36:44 | TopLevel | Foo.qll:9:17:9:19 | ClasslessPredicate foo | semmle.label | getAPredicate() |
-| Foo.qll:1:1:36:44 | TopLevel | Foo.qll:9:17:9:19 | ClasslessPredicate foo | semmle.order | 16 |
-| Foo.qll:1:1:36:44 | TopLevel | Foo.qll:13:11:13:15 | ClasslessPredicate calls | semmle.label | getAPredicate() |
-| Foo.qll:1:1:36:44 | TopLevel | Foo.qll:13:11:13:15 | ClasslessPredicate calls | semmle.order | 32 |
-| Foo.qll:1:1:36:44 | TopLevel | Foo.qll:29:9:29:17 | NewType TPathNode | semmle.label | getANewType() |
-| Foo.qll:1:1:36:44 | TopLevel | Foo.qll:29:9:29:17 | NewType TPathNode | semmle.order | 78 |
-| Foo.qll:1:1:36:44 | TopLevel | Foo.qll:33:17:33:26 | NewType TPathNode2 | semmle.label | getANewType() |
-| Foo.qll:1:1:36:44 | TopLevel | Foo.qll:33:17:33:26 | NewType TPathNode2 | semmle.order | 83 |
+| Foo.qll:1:1:33:44 | TopLevel | Foo.qll:1:1:1:17 | Import | semmle.label | getAnImport() |
+| Foo.qll:1:1:33:44 | TopLevel | Foo.qll:1:1:1:17 | Import | semmle.order | 1 |
+| Foo.qll:1:1:33:44 | TopLevel | Foo.qll:3:7:3:9 | Class Foo | semmle.label | getAClass() |
+| Foo.qll:1:1:33:44 | TopLevel | Foo.qll:3:7:3:9 | Class Foo | semmle.order | 4 |
+| Foo.qll:1:1:33:44 | TopLevel | Foo.qll:9:17:9:19 | ClasslessPredicate foo | semmle.label | getAPredicate() |
+| Foo.qll:1:1:33:44 | TopLevel | Foo.qll:9:17:9:19 | ClasslessPredicate foo | semmle.order | 16 |
+| Foo.qll:1:1:33:44 | TopLevel | Foo.qll:13:11:13:15 | ClasslessPredicate calls | semmle.label | getAPredicate() |
+| Foo.qll:1:1:33:44 | TopLevel | Foo.qll:13:11:13:15 | ClasslessPredicate calls | semmle.order | 32 |
+| Foo.qll:1:1:33:44 | TopLevel | Foo.qll:29:9:29:17 | NewType TPathNode | semmle.label | getANewType() |
+| Foo.qll:1:1:33:44 | TopLevel | Foo.qll:29:9:29:17 | NewType TPathNode | semmle.order | 78 |
+| Foo.qll:1:1:33:44 | TopLevel | Foo.qll:31:17:31:26 | NewType TPathNode2 | semmle.label | getANewType() |
+| Foo.qll:1:1:33:44 | TopLevel | Foo.qll:31:17:31:26 | NewType TPathNode2 | semmle.order | 81 |
 | Foo.qll:3:7:3:9 | Class Foo | Foo.qll:3:19:3:22 | TypeExpr | semmle.label | getASuperType() |
 | Foo.qll:3:7:3:9 | Class Foo | Foo.qll:3:19:3:22 | TypeExpr | semmle.order | 5 |
 | Foo.qll:3:7:3:9 | Class Foo | Foo.qll:4:3:4:17 | CharPred Foo | semmle.label | getCharPred() |
@@ -437,45 +429,37 @@ edges
 | Foo.qll:26:3:26:14 | ComparisonFormula | Foo.qll:26:3:26:6 | Boolean | semmle.order | 75 |
 | Foo.qll:26:3:26:14 | ComparisonFormula | Foo.qll:26:10:26:14 | Boolean | semmle.label | getRightOperand() |
 | Foo.qll:26:3:26:14 | ComparisonFormula | Foo.qll:26:10:26:14 | Boolean | semmle.order | 77 |
-| Foo.qll:29:9:29:17 | NewType TPathNode | Foo.qll:31:3:31:14 | NewTypeBranch TPathNodeMid | semmle.label | getABranch() |
-| Foo.qll:29:9:29:17 | NewType TPathNode | Foo.qll:31:3:31:14 | NewTypeBranch TPathNodeMid | semmle.order | 81 |
-| Foo.qll:30:3:30:28 | annotation | Foo.qll:30:10:30:27 | assume_small_delta | semmle.label | getArgs(_) |
-| Foo.qll:30:3:30:28 | annotation | Foo.qll:30:10:30:27 | assume_small_delta | semmle.order | 80 |
-| Foo.qll:31:3:31:14 | NewTypeBranch TPathNodeMid | Foo.qll:30:3:30:28 | annotation | semmle.label | getAnAnnotation() |
-| Foo.qll:31:3:31:14 | NewTypeBranch TPathNodeMid | Foo.qll:30:3:30:28 | annotation | semmle.order | 79 |
-| Foo.qll:33:17:33:26 | NewType TPathNode2 | Foo.qll:33:1:33:7 | annotation | semmle.label | getAnAnnotation() |
-| Foo.qll:33:17:33:26 | NewType TPathNode2 | Foo.qll:33:1:33:7 | annotation | semmle.order | 82 |
-| Foo.qll:33:17:33:26 | NewType TPathNode2 | Foo.qll:35:3:35:15 | NewTypeBranch TPathNodeMid2 | semmle.label | getABranch() |
-| Foo.qll:33:17:33:26 | NewType TPathNode2 | Foo.qll:35:3:35:15 | NewTypeBranch TPathNodeMid2 | semmle.order | 86 |
-| Foo.qll:33:17:33:26 | NewType TPathNode2 | Foo.qll:36:3:36:15 | NewTypeBranch TPathNodeSink | semmle.label | getABranch() |
-| Foo.qll:33:17:33:26 | NewType TPathNode2 | Foo.qll:36:3:36:15 | NewTypeBranch TPathNodeSink | semmle.order | 92 |
-| Foo.qll:34:3:34:28 | annotation | Foo.qll:34:10:34:27 | assume_small_delta | semmle.label | getArgs(_) |
-| Foo.qll:34:3:34:28 | annotation | Foo.qll:34:10:34:27 | assume_small_delta | semmle.order | 85 |
-| Foo.qll:35:3:35:15 | NewTypeBranch TPathNodeMid2 | Foo.qll:34:3:34:28 | annotation | semmle.label | getAnAnnotation() |
-| Foo.qll:35:3:35:15 | NewTypeBranch TPathNodeMid2 | Foo.qll:34:3:34:28 | annotation | semmle.order | 84 |
-| Foo.qll:35:3:35:15 | NewTypeBranch TPathNodeMid2 | Foo.qll:35:17:35:27 | foo | semmle.label | getField(_) |
-| Foo.qll:35:3:35:15 | NewTypeBranch TPathNodeMid2 | Foo.qll:35:17:35:27 | foo | semmle.order | 87 |
-| Foo.qll:35:3:35:15 | NewTypeBranch TPathNodeMid2 | Foo.qll:35:32:35:41 | ComparisonFormula | semmle.label | getBody() |
-| Foo.qll:35:3:35:15 | NewTypeBranch TPathNodeMid2 | Foo.qll:35:32:35:41 | ComparisonFormula | semmle.order | 89 |
-| Foo.qll:35:17:35:27 | foo | Foo.qll:35:17:35:23 | TypeExpr | semmle.label | getTypeExpr() |
-| Foo.qll:35:17:35:27 | foo | Foo.qll:35:17:35:23 | TypeExpr | semmle.order | 87 |
-| Foo.qll:35:32:35:41 | ComparisonFormula | Foo.qll:35:32:35:34 | foo | semmle.label | getLeftOperand() |
-| Foo.qll:35:32:35:41 | ComparisonFormula | Foo.qll:35:32:35:34 | foo | semmle.order | 89 |
-| Foo.qll:35:32:35:41 | ComparisonFormula | Foo.qll:35:38:35:41 | Boolean | semmle.label | getRightOperand() |
-| Foo.qll:35:32:35:41 | ComparisonFormula | Foo.qll:35:38:35:41 | Boolean | semmle.order | 91 |
-| Foo.qll:36:3:36:15 | NewTypeBranch TPathNodeSink | Foo.qll:36:17:36:26 | bar | semmle.label | getField(_) |
-| Foo.qll:36:3:36:15 | NewTypeBranch TPathNodeSink | Foo.qll:36:17:36:26 | bar | semmle.order | 93 |
-| Foo.qll:36:3:36:15 | NewTypeBranch TPathNodeSink | Foo.qll:36:31:36:41 | ComparisonFormula | semmle.label | getBody() |
-| Foo.qll:36:3:36:15 | NewTypeBranch TPathNodeSink | Foo.qll:36:31:36:41 | ComparisonFormula | semmle.order | 95 |
-| Foo.qll:36:17:36:26 | bar | Foo.qll:36:17:36:22 | TypeExpr | semmle.label | getTypeExpr() |
-| Foo.qll:36:17:36:26 | bar | Foo.qll:36:17:36:22 | TypeExpr | semmle.order | 93 |
-| Foo.qll:36:31:36:41 | ComparisonFormula | Foo.qll:36:31:36:33 | bar | semmle.label | getLeftOperand() |
-| Foo.qll:36:31:36:41 | ComparisonFormula | Foo.qll:36:31:36:33 | bar | semmle.order | 95 |
-| Foo.qll:36:31:36:41 | ComparisonFormula | Foo.qll:36:37:36:41 | String | semmle.label | getRightOperand() |
-| Foo.qll:36:31:36:41 | ComparisonFormula | Foo.qll:36:37:36:41 | String | semmle.order | 97 |
+| Foo.qll:29:9:29:17 | NewType TPathNode | Foo.qll:29:21:29:32 | NewTypeBranch TPathNodeMid | semmle.label | getABranch() |
+| Foo.qll:29:9:29:17 | NewType TPathNode | Foo.qll:29:21:29:32 | NewTypeBranch TPathNodeMid | semmle.order | 79 |
+| Foo.qll:31:17:31:26 | NewType TPathNode2 | Foo.qll:31:1:31:7 | annotation | semmle.label | getAnAnnotation() |
+| Foo.qll:31:17:31:26 | NewType TPathNode2 | Foo.qll:31:1:31:7 | annotation | semmle.order | 80 |
+| Foo.qll:31:17:31:26 | NewType TPathNode2 | Foo.qll:32:3:32:15 | NewTypeBranch TPathNodeMid2 | semmle.label | getABranch() |
+| Foo.qll:31:17:31:26 | NewType TPathNode2 | Foo.qll:32:3:32:15 | NewTypeBranch TPathNodeMid2 | semmle.order | 82 |
+| Foo.qll:31:17:31:26 | NewType TPathNode2 | Foo.qll:33:3:33:15 | NewTypeBranch TPathNodeSink | semmle.label | getABranch() |
+| Foo.qll:31:17:31:26 | NewType TPathNode2 | Foo.qll:33:3:33:15 | NewTypeBranch TPathNodeSink | semmle.order | 88 |
+| Foo.qll:32:3:32:15 | NewTypeBranch TPathNodeMid2 | Foo.qll:32:17:32:27 | foo | semmle.label | getField(_) |
+| Foo.qll:32:3:32:15 | NewTypeBranch TPathNodeMid2 | Foo.qll:32:17:32:27 | foo | semmle.order | 83 |
+| Foo.qll:32:3:32:15 | NewTypeBranch TPathNodeMid2 | Foo.qll:32:32:32:41 | ComparisonFormula | semmle.label | getBody() |
+| Foo.qll:32:3:32:15 | NewTypeBranch TPathNodeMid2 | Foo.qll:32:32:32:41 | ComparisonFormula | semmle.order | 85 |
+| Foo.qll:32:17:32:27 | foo | Foo.qll:32:17:32:23 | TypeExpr | semmle.label | getTypeExpr() |
+| Foo.qll:32:17:32:27 | foo | Foo.qll:32:17:32:23 | TypeExpr | semmle.order | 83 |
+| Foo.qll:32:32:32:41 | ComparisonFormula | Foo.qll:32:32:32:34 | foo | semmle.label | getLeftOperand() |
+| Foo.qll:32:32:32:41 | ComparisonFormula | Foo.qll:32:32:32:34 | foo | semmle.order | 85 |
+| Foo.qll:32:32:32:41 | ComparisonFormula | Foo.qll:32:38:32:41 | Boolean | semmle.label | getRightOperand() |
+| Foo.qll:32:32:32:41 | ComparisonFormula | Foo.qll:32:38:32:41 | Boolean | semmle.order | 87 |
+| Foo.qll:33:3:33:15 | NewTypeBranch TPathNodeSink | Foo.qll:33:17:33:26 | bar | semmle.label | getField(_) |
+| Foo.qll:33:3:33:15 | NewTypeBranch TPathNodeSink | Foo.qll:33:17:33:26 | bar | semmle.order | 89 |
+| Foo.qll:33:3:33:15 | NewTypeBranch TPathNodeSink | Foo.qll:33:31:33:41 | ComparisonFormula | semmle.label | getBody() |
+| Foo.qll:33:3:33:15 | NewTypeBranch TPathNodeSink | Foo.qll:33:31:33:41 | ComparisonFormula | semmle.order | 91 |
+| Foo.qll:33:17:33:26 | bar | Foo.qll:33:17:33:22 | TypeExpr | semmle.label | getTypeExpr() |
+| Foo.qll:33:17:33:26 | bar | Foo.qll:33:17:33:22 | TypeExpr | semmle.order | 89 |
+| Foo.qll:33:31:33:41 | ComparisonFormula | Foo.qll:33:31:33:33 | bar | semmle.label | getLeftOperand() |
+| Foo.qll:33:31:33:41 | ComparisonFormula | Foo.qll:33:31:33:33 | bar | semmle.order | 91 |
+| Foo.qll:33:31:33:41 | ComparisonFormula | Foo.qll:33:37:33:41 | String | semmle.label | getRightOperand() |
+| Foo.qll:33:31:33:41 | ComparisonFormula | Foo.qll:33:37:33:41 | String | semmle.order | 93 |
 | printAst.ql:1:1:1:28 | Import | printAst.ql:1:18:1:28 | printAstAst | semmle.label | getModuleExpr() |
-| printAst.ql:1:1:1:28 | Import | printAst.ql:1:18:1:28 | printAstAst | semmle.order | 100 |
+| printAst.ql:1:1:1:28 | Import | printAst.ql:1:18:1:28 | printAstAst | semmle.order | 96 |
 | printAst.ql:1:1:1:29 | TopLevel | printAst.ql:1:1:1:28 | Import | semmle.label | getAnImport() |
-| printAst.ql:1:1:1:29 | TopLevel | printAst.ql:1:1:1:28 | Import | semmle.order | 98 |
+| printAst.ql:1:1:1:29 | TopLevel | printAst.ql:1:1:1:28 | Import | semmle.order | 94 |
 graphProperties
 | semmle.graphKind | tree |

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl.qll
@@ -460,7 +460,6 @@ module Impl<FullStateConfigSig Config> {
      * The Boolean `cc` records whether the node is reached through an
      * argument in a call.
      */
-    pragma[assume_small_delta]
     private predicate fwdFlow(NodeEx node, Cc cc) {
       sourceNode(node, _) and
       if hasSourceCallCtx() then cc = true else cc = false
@@ -570,7 +569,6 @@ module Impl<FullStateConfigSig Config> {
     /**
      * Holds if `c` is the target of a store in the flow covered by `fwdFlow`.
      */
-    pragma[assume_small_delta]
     pragma[nomagic]
     private predicate fwdFlowConsCand(Content c) {
       exists(NodeEx mid, NodeEx node |
@@ -1216,7 +1214,6 @@ module Impl<FullStateConfigSig Config> {
         fwdFlow1(_, _, _, _, _, _, t0, t, ap, _) and t0 != t
       }
 
-      pragma[assume_small_delta]
       pragma[nomagic]
       private predicate fwdFlow0(
         NodeEx node, FlowState state, Cc cc, ParamNodeOption summaryCtx, TypOption argT,
@@ -2777,7 +2774,6 @@ module Impl<FullStateConfigSig Config> {
   /**
    * Gets the number of `AccessPath`s that correspond to `apa`.
    */
-  pragma[assume_small_delta]
   private int countAps(AccessPathApprox apa) {
     evalUnfold(apa, false) and
     result = 1 and
@@ -2796,7 +2792,6 @@ module Impl<FullStateConfigSig Config> {
    * that it is expanded to a precise head-tail representation.
    */
   language[monotonicAggregates]
-  pragma[assume_small_delta]
   private int countPotentialAps(AccessPathApprox apa) {
     apa instanceof AccessPathApproxNil and result = 1
     or
@@ -2833,7 +2828,6 @@ module Impl<FullStateConfigSig Config> {
     }
 
   private newtype TPathNode =
-    pragma[assume_small_delta]
     TPathNodeMid(
       NodeEx node, FlowState state, CallContext cc, SummaryCtx sc, DataFlowType t, AccessPath ap
     ) {
@@ -2918,7 +2912,6 @@ module Impl<FullStateConfigSig Config> {
 
     override AccessPathFrontHead getFront() { result = TFrontHead(head_) }
 
-    pragma[assume_small_delta]
     override AccessPathApproxCons getApprox() {
       result = TConsNil(head_, t) and tail_ = TAccessPathNil()
       or
@@ -2927,7 +2920,6 @@ module Impl<FullStateConfigSig Config> {
       result = TCons1(head_, this.length())
     }
 
-    pragma[assume_small_delta]
     override int length() { result = 1 + tail_.length() }
 
     private string toStringImpl(boolean needsSuffix) {
@@ -3379,7 +3371,6 @@ module Impl<FullStateConfigSig Config> {
    * Holds if data may flow from `mid` to `node`. The last step in or out of
    * a callable is recorded by `cc`.
    */
-  pragma[assume_small_delta]
   pragma[nomagic]
   private predicate pathStep0(
     PathNodeMid mid, NodeEx node, FlowState state, CallContext cc, SummaryCtx sc, DataFlowType t,
@@ -3592,7 +3583,6 @@ module Impl<FullStateConfigSig Config> {
     )
   }
 
-  pragma[assume_small_delta]
   pragma[nomagic]
   private predicate pathThroughCallable0(
     DataFlowCall call, PathNodeMid mid, ReturnKindExt kind, FlowState state, CallContext cc,

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplCommon.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplCommon.qll
@@ -187,7 +187,6 @@ private module LambdaFlow {
     else any()
   }
 
-  pragma[assume_small_delta]
   pragma[nomagic]
   predicate revLambdaFlow0(
     DataFlowCall lambdaCall, LambdaCallKind kind, Node node, DataFlowType t, boolean toReturn,
@@ -274,7 +273,6 @@ private module LambdaFlow {
     )
   }
 
-  pragma[assume_small_delta]
   pragma[nomagic]
   predicate revLambdaFlowOut(
     DataFlowCall lambdaCall, LambdaCallKind kind, TReturnPositionSimple pos, DataFlowType t,

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImpl.qll
@@ -110,7 +110,6 @@ module Public {
     }
 
     /** Gets the stack obtained by dropping the first `i` elements, if any. */
-    pragma[assume_small_delta]
     SummaryComponentStack drop(int i) {
       i = 0 and result = this
       or

--- a/shared/typetracking/codeql/typetracking/TypeTracking.qll
+++ b/shared/typetracking/codeql/typetracking/TypeTracking.qll
@@ -803,7 +803,6 @@ module TypeTracking<TypeTrackingInput I> {
    * those sources.
    */
   module TypeTrack<endpoint/1 source> {
-    pragma[assume_small_delta]
     private Node flow(TypeTracker tt) {
       tt.start() and source(result)
       or

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImpl.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImpl.qll
@@ -460,7 +460,6 @@ module Impl<FullStateConfigSig Config> {
      * The Boolean `cc` records whether the node is reached through an
      * argument in a call.
      */
-    pragma[assume_small_delta]
     private predicate fwdFlow(NodeEx node, Cc cc) {
       sourceNode(node, _) and
       if hasSourceCallCtx() then cc = true else cc = false
@@ -570,7 +569,6 @@ module Impl<FullStateConfigSig Config> {
     /**
      * Holds if `c` is the target of a store in the flow covered by `fwdFlow`.
      */
-    pragma[assume_small_delta]
     pragma[nomagic]
     private predicate fwdFlowConsCand(Content c) {
       exists(NodeEx mid, NodeEx node |
@@ -1216,7 +1214,6 @@ module Impl<FullStateConfigSig Config> {
         fwdFlow1(_, _, _, _, _, _, t0, t, ap, _) and t0 != t
       }
 
-      pragma[assume_small_delta]
       pragma[nomagic]
       private predicate fwdFlow0(
         NodeEx node, FlowState state, Cc cc, ParamNodeOption summaryCtx, TypOption argT,
@@ -2777,7 +2774,6 @@ module Impl<FullStateConfigSig Config> {
   /**
    * Gets the number of `AccessPath`s that correspond to `apa`.
    */
-  pragma[assume_small_delta]
   private int countAps(AccessPathApprox apa) {
     evalUnfold(apa, false) and
     result = 1 and
@@ -2796,7 +2792,6 @@ module Impl<FullStateConfigSig Config> {
    * that it is expanded to a precise head-tail representation.
    */
   language[monotonicAggregates]
-  pragma[assume_small_delta]
   private int countPotentialAps(AccessPathApprox apa) {
     apa instanceof AccessPathApproxNil and result = 1
     or
@@ -2833,7 +2828,6 @@ module Impl<FullStateConfigSig Config> {
     }
 
   private newtype TPathNode =
-    pragma[assume_small_delta]
     TPathNodeMid(
       NodeEx node, FlowState state, CallContext cc, SummaryCtx sc, DataFlowType t, AccessPath ap
     ) {
@@ -2918,7 +2912,6 @@ module Impl<FullStateConfigSig Config> {
 
     override AccessPathFrontHead getFront() { result = TFrontHead(head_) }
 
-    pragma[assume_small_delta]
     override AccessPathApproxCons getApprox() {
       result = TConsNil(head_, t) and tail_ = TAccessPathNil()
       or
@@ -2927,7 +2920,6 @@ module Impl<FullStateConfigSig Config> {
       result = TCons1(head_, this.length())
     }
 
-    pragma[assume_small_delta]
     override int length() { result = 1 + tail_.length() }
 
     private string toStringImpl(boolean needsSuffix) {
@@ -3379,7 +3371,6 @@ module Impl<FullStateConfigSig Config> {
    * Holds if data may flow from `mid` to `node`. The last step in or out of
    * a callable is recorded by `cc`.
    */
-  pragma[assume_small_delta]
   pragma[nomagic]
   private predicate pathStep0(
     PathNodeMid mid, NodeEx node, FlowState state, CallContext cc, SummaryCtx sc, DataFlowType t,
@@ -3592,7 +3583,6 @@ module Impl<FullStateConfigSig Config> {
     )
   }
 
-  pragma[assume_small_delta]
   pragma[nomagic]
   private predicate pathThroughCallable0(
     DataFlowCall call, PathNodeMid mid, ReturnKindExt kind, FlowState state, CallContext cc,

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImplCommon.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImplCommon.qll
@@ -187,7 +187,6 @@ private module LambdaFlow {
     else any()
   }
 
-  pragma[assume_small_delta]
   pragma[nomagic]
   predicate revLambdaFlow0(
     DataFlowCall lambdaCall, LambdaCallKind kind, Node node, DataFlowType t, boolean toReturn,
@@ -274,7 +273,6 @@ private module LambdaFlow {
     )
   }
 
-  pragma[assume_small_delta]
   pragma[nomagic]
   predicate revLambdaFlowOut(
     DataFlowCall lambdaCall, LambdaCallKind kind, TReturnPositionSimple pos, DataFlowType t,

--- a/swift/ql/lib/codeql/swift/dataflow/internal/FlowSummaryImpl.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/FlowSummaryImpl.qll
@@ -110,7 +110,6 @@ module Public {
     }
 
     /** Gets the stack obtained by dropping the first `i` elements, if any. */
-    pragma[assume_small_delta]
     SummaryComponentStack drop(int i) {
       i = 0 and result = this
       or


### PR DESCRIPTION
This PR removes `pragma[assume_small_delta]`, which has no effect and is no longer needed.

See referenced issue for details.