### PR TITLE
JS: Fix FP in js/incomplete-multi-character-sanitization

### DIFF
--- a/javascript/ql/lib/semmle/javascript/security/IncompleteMultiCharacterSanitizationQuery.qll
+++ b/javascript/ql/lib/semmle/javascript/security/IncompleteMultiCharacterSanitizationQuery.qll
@@ -15,6 +15,14 @@ private class DangerousPrefix extends string {
     this = "<!--" or
     this = "<" + ["iframe", "script", "cript", "scrip", "style"]
   }
+
+  /**
+   * Gets a character that is important to the dangerous prefix.
+   * That is, a char that should be mentioned in a regular expression that explicitly sanitizes the dangerous prefix.
+   */
+  string getAnImportantChar() {
+    if this = ["/..", "../"] then result = ["/", "."] else result = "<"
+  }
 }
 
 /**
@@ -62,7 +70,11 @@ private DangerousPrefixSubstring getADangerousMatchedChar(EmptyReplaceRegExpTerm
  */
 private DangerousPrefix getADangerousMatchedPrefix(EmptyReplaceRegExpTerm t) {
   result = getADangerousMatchedPrefixSubstring(t) and
-  not exists(EmptyReplaceRegExpTerm pred | pred = t.getPredecessor+() and not pred.isNullable())
+  not exists(EmptyReplaceRegExpTerm pred | pred = t.getPredecessor+() and not pred.isNullable()) and
+  // the regex must explicitly mention a char important to the prefix.
+  forex(string char | char = result.getAnImportantChar() |
+    t.getRootTerm().getAChild*().(RegExpConstant).getValue().matches("%" + char + "%")
+  )
 }
 
 /**

--- a/javascript/ql/test/query-tests/Security/CWE-116/IncompleteSanitization/IncompleteMultiCharacterSanitization.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-116/IncompleteSanitization/IncompleteMultiCharacterSanitization.expected
@@ -39,3 +39,4 @@
 | tst-multi-character-sanitization.js:145:13:145:90 | content ... /g, '') | This string may still contain $@, which may cause an HTML element injection vulnerability. | tst-multi-character-sanitization.js:145:30:145:30 | < | <script |
 | tst-multi-character-sanitization.js:148:3:148:99 | n.clone ... gi, '') | This string may still contain $@, which may cause an HTML element injection vulnerability. | tst-multi-character-sanitization.js:148:41:148:41 | < | <script |
 | tst-multi-character-sanitization.js:152:3:152:99 | n.clone ... gi, '') | This string may still contain $@, which may cause an HTML element injection vulnerability. | tst-multi-character-sanitization.js:152:41:152:41 | < | <script |
+| tst-multi-character-sanitization.js:156:13:156:44 | content ... )/, '') | This string may still contain $@, which may cause an HTML element injection vulnerability. | tst-multi-character-sanitization.js:156:30:156:32 | .+? | <script |

--- a/javascript/ql/test/query-tests/Security/CWE-116/IncompleteSanitization/IncompleteMultiCharacterSanitization.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-116/IncompleteSanitization/IncompleteMultiCharacterSanitization.expected
@@ -39,4 +39,3 @@
 | tst-multi-character-sanitization.js:145:13:145:90 | content ... /g, '') | This string may still contain $@, which may cause an HTML element injection vulnerability. | tst-multi-character-sanitization.js:145:30:145:30 | < | <script |
 | tst-multi-character-sanitization.js:148:3:148:99 | n.clone ... gi, '') | This string may still contain $@, which may cause an HTML element injection vulnerability. | tst-multi-character-sanitization.js:148:41:148:41 | < | <script |
 | tst-multi-character-sanitization.js:152:3:152:99 | n.clone ... gi, '') | This string may still contain $@, which may cause an HTML element injection vulnerability. | tst-multi-character-sanitization.js:152:41:152:41 | < | <script |
-| tst-multi-character-sanitization.js:156:13:156:44 | content ... )/, '') | This string may still contain $@, which may cause an HTML element injection vulnerability. | tst-multi-character-sanitization.js:156:30:156:32 | .+? | <script |

--- a/javascript/ql/test/query-tests/Security/CWE-116/IncompleteSanitization/tst-multi-character-sanitization.js
+++ b/javascript/ql/test/query-tests/Security/CWE-116/IncompleteSanitization/tst-multi-character-sanitization.js
@@ -152,4 +152,6 @@
   n.cloneNode(false).outerHTML.replace(/<\/?[\w:\-]+ ?|=[\"][^\"]+\"|=\'[^\']+\'|=[\w\-]+|>/gi, '').replace(/[\w:\-]+/gi, function(a) { // NOT OK
     o.push({specified : 1, nodeName : a});
   });  
+
+  content = content.replace(/.+?(?=\s)/, ''); // OK - but flagged as not sanitizing <script> tags [INCONSISTENCY]
 });

--- a/javascript/ql/test/query-tests/Security/CWE-116/IncompleteSanitization/tst-multi-character-sanitization.js
+++ b/javascript/ql/test/query-tests/Security/CWE-116/IncompleteSanitization/tst-multi-character-sanitization.js
@@ -153,5 +153,5 @@
     o.push({specified : 1, nodeName : a});
   });  
 
-  content = content.replace(/.+?(?=\s)/, ''); // OK - but flagged as not sanitizing <script> tags [INCONSISTENCY]
+  content = content.replace(/.+?(?=\s)/, ''); // OK
 });


### PR DESCRIPTION
Consider the below piece of JavaScript:  
```JavaScript
content = content.replace(/.+?(?=\s)/, ''); // OK
```

Getting an alert that `This string may still contain <script, which may cause an HTML element injection vulnerability` is technically correct, but extremely likely to be a false positive, as there is no indication that the regex is meant to sanitize HTML-tags at all. 

**WIP** Something will probably break. I except performance to blow up due to very naive implementation. 