### PR TITLE
C++: exclude uninitialized uses inside pure expression statements

### DIFF
--- a/cpp/ql/src/Likely Bugs/Memory Management/UninitializedLocal.ql
+++ b/cpp/ql/src/Likely Bugs/Memory Management/UninitializedLocal.ql
@@ -72,6 +72,13 @@ VariableAccess commonException() {
   or
   result.getParent() instanceof BuiltInOperation
   or
+  // Ignore the uninitialized use that is explicitly cast to void and
+  // is also an expression statement.
+  (
+    result.getActualType() instanceof VoidType and
+    result.getParent() instanceof ExprStmt
+  )
+  or
   // Finally, exclude functions that contain assembly blocks. It's
   // anyone's guess what happens in those.
   containsInlineAssembly(result.getEnclosingFunction())

--- a/cpp/ql/src/Likely Bugs/Memory Management/UninitializedLocal.ql
+++ b/cpp/ql/src/Likely Bugs/Memory Management/UninitializedLocal.ql
@@ -72,12 +72,10 @@ VariableAccess commonException() {
   or
   result.getParent() instanceof BuiltInOperation
   or
-  // Ignore the uninitialized use that is explicitly cast to void and
-  // is also an expression statement.
-  (
-    result.getActualType() instanceof VoidType and
-    result.getParent() instanceof ExprStmt
-  )
+  // Ignore any uninitialized use that is explicitly cast to void and
+  // is an expression statement.
+  result.getActualType() instanceof VoidType and
+  result.getParent() instanceof ExprStmt
   or
   // Finally, exclude functions that contain assembly blocks. It's
   // anyone's guess what happens in those.

--- a/cpp/ql/src/change-notes/2023-07-03-improve-uninitialized-local.md
+++ b/cpp/ql/src/change-notes/2023-07-03-improve-uninitialized-local.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The `cpp/uninitialized-local` query now excludes uninitialized uses that are explicitly cast to void and are expression statements. As a result, the query will report less false positives.

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-457/semmle/tests/UninitializedLocal.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-457/semmle/tests/UninitializedLocal.expected
@@ -14,3 +14,7 @@
 | test.cpp:378:9:378:11 | val | The variable $@ may not be initialized at this access. | test.cpp:359:6:359:8 | val | val |
 | test.cpp:417:10:417:10 | j | The variable $@ may not be initialized at this access. | test.cpp:414:9:414:9 | j | j |
 | test.cpp:436:9:436:9 | j | The variable $@ may not be initialized at this access. | test.cpp:431:9:431:9 | j | j |
+| test.cpp:454:2:454:2 | x | The variable $@ may not be initialized at this access. | test.cpp:452:6:452:6 | x | x |
+| test.cpp:460:7:460:7 | x | The variable $@ may not be initialized at this access. | test.cpp:458:6:458:6 | x | x |
+| test.cpp:467:2:467:2 | x | The variable $@ may not be initialized at this access. | test.cpp:464:6:464:6 | x | x |
+| test.cpp:474:7:474:7 | x | The variable $@ may not be initialized at this access. | test.cpp:471:6:471:6 | x | x |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-457/semmle/tests/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-457/semmle/tests/test.cpp
@@ -435,3 +435,41 @@ int test38() {
 
 	return j; // BAD
 }
+
+void test39() {
+	int x;
+
+	x; // GOOD, in void context
+}
+
+void test40() {
+	int x;
+
+	(void)x; // GOOD, explicitly cast to void
+}
+
+void test41() {
+	int x;
+
+	x++; // BAD
+}
+
+void test42() {
+	int x;
+
+	void(x++); // BAD
+}
+
+void test43() {
+	int x;
+	int y = 1;
+
+	x + y; // BAD
+}
+
+void test44() {
+	int x;
+	int y = 1;
+
+	void(x + y); // BAD
+}


### PR DESCRIPTION
This eliminates FPs such as casting a variable explicitly to void type. E.g.
``` C
   (void) x;
```
Developers use this cast to supress compiler warnings on unused variables.