### PR TITLE
Java/C#: Reduce the amount of telemetry being produced.

### DIFF
--- a/csharp/ql/src/Telemetry/ExternalApi.qll
+++ b/csharp/ql/src/Telemetry/ExternalApi.qll
@@ -136,7 +136,7 @@ private string nestedName(Declaration declaration) {
 /**
  * Gets the limit for the number of results produced by a telemetry query.
  */
-int resultLimit() { result = 1000 }
+int resultLimit() { result = 100 }
 
 /**
  * Holds if it is relevant to count usages of `api`.

--- a/java/ql/src/Telemetry/ExternalApi.qll
+++ b/java/ql/src/Telemetry/ExternalApi.qll
@@ -96,7 +96,7 @@ deprecated class ExternalAPI = ExternalApi;
 /**
  * Gets the limit for the number of results produced by a telemetry query.
  */
-int resultLimit() { result = 1000 }
+int resultLimit() { result = 100 }
 
 /**
  * Holds if it is relevant to count usages of `api`.


### PR DESCRIPTION
It turns out that the Java and C# Telemetry queries on API usage still produces to much data.
In this PR we limit the number of APIs being reported only to the top-100 that matches the reporting criteria.