### PR TITLE
Swift: Add dataflow model for 'swap'

### DIFF
--- a/swift/ql/lib/change-notes/2023-07-04-swap.md
+++ b/swift/ql/lib/change-notes/2023-07-04-swap.md
@@ -1,0 +1,5 @@
+---
+category: minorAnalysis
+---
+
+* Added a data flow model for `swap(_:_:)`.

--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/ManualMemoryManagement.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/ManualMemoryManagement.qll
@@ -1,0 +1,16 @@
+/**
+ * Provides models for Swift "Manual Memory Management" functions.
+ */
+
+import swift
+private import codeql.swift.dataflow.ExternalFlow
+
+private class ManualMemoryManagementSummaries extends SummaryModelCsv {
+  override predicate row(string row) {
+    row =
+      [
+        ";;false;swap(_:_:);;;Argument[0];Argument[1];value",
+        ";;false;swap(_:_:);;;Argument[1];Argument[0];value",
+      ]
+  }
+}

--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/StandardLibrary.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/StandardLibrary.qll
@@ -8,6 +8,7 @@ private import Data
 private import FileManager
 private import FilePath
 private import InputStream
+private import ManualMemoryManagement
 private import NsData
 private import NsObject
 private import NsString

--- a/swift/ql/test/library-tests/dataflow/dataflow/DataFlow.expected
+++ b/swift/ql/test/library-tests/dataflow/dataflow/DataFlow.expected
@@ -270,7 +270,10 @@ edges
 | test.swift:593:13:593:13 | s2 [s, x] | test.swift:592:11:592:17 | enter #keyPath(...) [s, x] |
 | test.swift:593:13:593:13 | s2 [s, x] | test.swift:593:13:593:26 | \\...[...] |
 | test.swift:618:13:618:20 | call to source() | test.swift:626:15:626:15 | y |
+| test.swift:628:9:628:16 | call to source() | test.swift:630:10:630:11 | &... |
 | test.swift:628:9:628:16 | call to source() | test.swift:631:15:631:15 | x |
+| test.swift:630:10:630:11 | &... | test.swift:630:14:630:15 | [post] &... |
+| test.swift:630:14:630:15 | [post] &... | test.swift:632:15:632:15 | y |
 nodes
 | file://:0:0:0:0 | .a [x] | semmle.label | .a [x] |
 | file://:0:0:0:0 | .str | semmle.label | .str |
@@ -567,7 +570,10 @@ nodes
 | test.swift:618:13:618:20 | call to source() | semmle.label | call to source() |
 | test.swift:626:15:626:15 | y | semmle.label | y |
 | test.swift:628:9:628:16 | call to source() | semmle.label | call to source() |
+| test.swift:630:10:630:11 | &... | semmle.label | &... |
+| test.swift:630:14:630:15 | [post] &... | semmle.label | [post] &... |
 | test.swift:631:15:631:15 | x | semmle.label | x |
+| test.swift:632:15:632:15 | y | semmle.label | y |
 subpaths
 | test.swift:75:21:75:22 | &... | test.swift:65:16:65:28 | arg1 | test.swift:65:1:70:1 | arg2[return] | test.swift:75:31:75:32 | [post] &... |
 | test.swift:114:19:114:19 | arg | test.swift:109:9:109:14 | arg | test.swift:110:12:110:12 | arg | test.swift:114:12:114:22 | call to ... |
@@ -681,3 +687,4 @@ subpaths
 | test.swift:593:13:593:26 | \\...[...] | test.swift:590:16:590:23 | call to source() | test.swift:593:13:593:26 | \\...[...] | result |
 | test.swift:626:15:626:15 | y | test.swift:618:13:618:20 | call to source() | test.swift:626:15:626:15 | y | result |
 | test.swift:631:15:631:15 | x | test.swift:628:9:628:16 | call to source() | test.swift:631:15:631:15 | x | result |
+| test.swift:632:15:632:15 | y | test.swift:628:9:628:16 | call to source() | test.swift:632:15:632:15 | y | result |

--- a/swift/ql/test/library-tests/dataflow/dataflow/DataFlow.expected
+++ b/swift/ql/test/library-tests/dataflow/dataflow/DataFlow.expected
@@ -269,6 +269,8 @@ edges
 | test.swift:592:17:592:17 | KeyPathComponent [x] | test.swift:592:11:592:17 | exit #keyPath(...) |
 | test.swift:593:13:593:13 | s2 [s, x] | test.swift:592:11:592:17 | enter #keyPath(...) [s, x] |
 | test.swift:593:13:593:13 | s2 [s, x] | test.swift:593:13:593:26 | \\...[...] |
+| test.swift:618:13:618:20 | call to source() | test.swift:626:15:626:15 | y |
+| test.swift:628:9:628:16 | call to source() | test.swift:631:15:631:15 | x |
 nodes
 | file://:0:0:0:0 | .a [x] | semmle.label | .a [x] |
 | file://:0:0:0:0 | .str | semmle.label | .str |
@@ -562,6 +564,10 @@ nodes
 | test.swift:592:17:592:17 | KeyPathComponent [x] | semmle.label | KeyPathComponent [x] |
 | test.swift:593:13:593:13 | s2 [s, x] | semmle.label | s2 [s, x] |
 | test.swift:593:13:593:26 | \\...[...] | semmle.label | \\...[...] |
+| test.swift:618:13:618:20 | call to source() | semmle.label | call to source() |
+| test.swift:626:15:626:15 | y | semmle.label | y |
+| test.swift:628:9:628:16 | call to source() | semmle.label | call to source() |
+| test.swift:631:15:631:15 | x | semmle.label | x |
 subpaths
 | test.swift:75:21:75:22 | &... | test.swift:65:16:65:28 | arg1 | test.swift:65:1:70:1 | arg2[return] | test.swift:75:31:75:32 | [post] &... |
 | test.swift:114:19:114:19 | arg | test.swift:109:9:109:14 | arg | test.swift:110:12:110:12 | arg | test.swift:114:12:114:22 | call to ... |
@@ -673,3 +679,5 @@ subpaths
 | test.swift:575:13:575:25 | \\...[...] | test.swift:573:16:573:23 | call to source() | test.swift:575:13:575:25 | \\...[...] | result |
 | test.swift:578:13:578:32 | \\...[...] | test.swift:573:16:573:23 | call to source() | test.swift:578:13:578:32 | \\...[...] | result |
 | test.swift:593:13:593:26 | \\...[...] | test.swift:590:16:590:23 | call to source() | test.swift:593:13:593:26 | \\...[...] | result |
+| test.swift:626:15:626:15 | y | test.swift:618:13:618:20 | call to source() | test.swift:626:15:626:15 | y | result |
+| test.swift:631:15:631:15 | x | test.swift:628:9:628:16 | call to source() | test.swift:631:15:631:15 | x | result |

--- a/swift/ql/test/library-tests/dataflow/dataflow/LocalFlow.expected
+++ b/swift/ql/test/library-tests/dataflow/dataflow/LocalFlow.expected
@@ -662,3 +662,26 @@
 | test.swift:613:9:613:9 | f | test.swift:613:9:613:9 | SSA def(f) |
 | test.swift:613:13:613:29 | #keyPath(...) | test.swift:613:9:613:9 | f |
 | test.swift:613:13:613:29 | enter #keyPath(...) | test.swift:613:26:613:26 | KeyPathComponent |
+| test.swift:618:9:618:9 | SSA def(x) | test.swift:622:9:622:9 | x |
+| test.swift:618:9:618:9 | x | test.swift:618:9:618:9 | SSA def(x) |
+| test.swift:618:13:618:20 | call to source() | test.swift:618:9:618:9 | x |
+| test.swift:619:9:619:9 | SSA def(y) | test.swift:623:9:623:9 | y |
+| test.swift:619:9:619:9 | y | test.swift:619:9:619:9 | SSA def(y) |
+| test.swift:619:13:619:13 | 0 | test.swift:619:9:619:9 | y |
+| test.swift:620:9:620:12 | ... as ... | test.swift:620:9:620:9 | t |
+| test.swift:622:5:622:9 | SSA def(t) | test.swift:624:9:624:9 | t |
+| test.swift:622:9:622:9 | x | test.swift:622:5:622:9 | SSA def(t) |
+| test.swift:623:5:623:9 | SSA def(x) | test.swift:625:15:625:15 | x |
+| test.swift:623:9:623:9 | y | test.swift:623:5:623:9 | SSA def(x) |
+| test.swift:624:5:624:9 | SSA def(y) | test.swift:626:15:626:15 | y |
+| test.swift:624:9:624:9 | t | test.swift:624:5:624:9 | SSA def(y) |
+| test.swift:628:5:628:16 | SSA def(x) | test.swift:630:11:630:11 | x |
+| test.swift:628:9:628:16 | call to source() | test.swift:628:5:628:16 | SSA def(x) |
+| test.swift:629:5:629:9 | SSA def(y) | test.swift:630:15:630:15 | y |
+| test.swift:629:9:629:9 | 0 | test.swift:629:5:629:9 | SSA def(y) |
+| test.swift:630:10:630:11 | &... | test.swift:631:15:631:15 | x |
+| test.swift:630:10:630:11 | [post] &... | test.swift:631:15:631:15 | x |
+| test.swift:630:11:630:11 | x | test.swift:630:10:630:11 | &... |
+| test.swift:630:14:630:15 | &... | test.swift:632:15:632:15 | y |
+| test.swift:630:14:630:15 | [post] &... | test.swift:632:15:632:15 | y |
+| test.swift:630:15:630:15 | y | test.swift:630:14:630:15 | &... |

--- a/swift/ql/test/library-tests/dataflow/dataflow/test.swift
+++ b/swift/ql/test/library-tests/dataflow/dataflow/test.swift
@@ -629,5 +629,5 @@ func testSwap() {
     y = 0
     swap(&x, &y)
     sink(arg: x) // $ SPURIOUS: flow=628
-    sink(arg: y) // $ MISSING: flow=628
+    sink(arg: y) // $ flow=628
 }

--- a/swift/ql/test/library-tests/dataflow/dataflow/test.swift
+++ b/swift/ql/test/library-tests/dataflow/dataflow/test.swift
@@ -613,3 +613,21 @@ func testOptionalKeyPath() {
     let f = \S2_Optional.s?.x
     sink(opt: s2[keyPath: f]) // $ MISSING: flow=611
 }
+
+func testSwap() {
+    var x = source()
+    var y = 0
+    var t: Int
+
+    t = x
+    x = y
+    y = t
+    sink(arg: x)
+    sink(arg: y) // $ flow=618
+
+    x = source()
+    y = 0
+    swap(&x, &y)
+    sink(arg: x) // $ SPURIOUS: flow=628
+    sink(arg: y) // $ MISSING: flow=628
+}


### PR DESCRIPTION
Add a dataflow model for [`swap(_:_:)`](https://developer.apple.com/documentation/swift/swap(_:_:)).