### PR TITLE
Go: Add `ParameterNode`s for unused parameters (always made SsaNode for parameters, even if unused)

### DIFF
--- a/go/ql/lib/change-notes/2023-07-05-parameter-nodes-for-unused-parameters.md
+++ b/go/ql/lib/change-notes/2023-07-05-parameter-nodes-for-unused-parameters.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Parameter nodes now exist for unused parameters as well as used parameters.

--- a/go/ql/lib/semmle/go/dataflow/SSA.qll
+++ b/go/ql/lib/semmle/go/dataflow/SSA.qll
@@ -187,6 +187,13 @@ class SsaExplicitDefinition extends SsaDefinition, TExplicitDef {
   ) {
     this.getInstruction().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
+
+  /** Holds if this definition is either used or captured. */
+  predicate mayBeUsed() {
+    exists(BasicBlock bb, int i, SsaSourceVariable v | this = TExplicitDef(bb, i, v) |
+      mayBeUsed(bb, i, v)
+    )
+  }
 }
 
 /** Provides a helper predicate for working with explicit SSA definitions. */

--- a/go/ql/lib/semmle/go/dataflow/SsaImpl.qll
+++ b/go/ql/lib/semmle/go/dataflow/SsaImpl.qll
@@ -21,6 +21,16 @@ private module Internal {
   }
 
   /**
+   * Holds if the `i`th node of `bb` defines `v`, and `v` is either used or
+   * captured.
+   */
+  cached
+  predicate mayBeUsed(ReachableBasicBlock bb, int i, SsaSourceVariable v) {
+    defAt(bb, i, v) and
+    (liveAfterDef(bb, i, v) or v.isCaptured())
+  }
+
+  /**
    * A data type representing SSA definitions.
    *
    * We distinguish three kinds of SSA definitions:
@@ -42,8 +52,9 @@ private module Internal {
      * An SSA definition that corresponds to an explicit assignment or other variable definition.
      */
     TExplicitDef(ReachableBasicBlock bb, int i, SsaSourceVariable v) {
-      defAt(bb, i, v) and
-      (liveAfterDef(bb, i, v) or v.isCaptured() or v instanceof Parameter)
+      mayBeUsed(bb, i, v)
+      or
+      defAt(bb, i, v) and v instanceof Parameter
     } or
     /**
      * An SSA definition representing the capturing of an SSA-convertible variable

--- a/go/ql/lib/semmle/go/dataflow/SsaImpl.qll
+++ b/go/ql/lib/semmle/go/dataflow/SsaImpl.qll
@@ -33,6 +33,8 @@ private module Internal {
    * SSA definitions are only introduced where necessary. In particular,
    * unreachable code has no SSA definitions associated with it, and neither
    * have dead assignments (that is, assignments whose value is never read).
+   * The one exception is that we always make SSA definitions for parameters,
+   * even if they are not used, so that we can easily define parameter nodes.
    */
   cached
   newtype TSsaDefinition =
@@ -41,7 +43,7 @@ private module Internal {
      */
     TExplicitDef(ReachableBasicBlock bb, int i, SsaSourceVariable v) {
       defAt(bb, i, v) and
-      (liveAfterDef(bb, i, v) or v.isCaptured())
+      (liveAfterDef(bb, i, v) or v.isCaptured() or v instanceof Parameter)
     } or
     /**
      * An SSA definition representing the capturing of an SSA-convertible variable

--- a/go/ql/src/RedundantCode/DeadStoreOfLocal.ql
+++ b/go/ql/src/RedundantCode/DeadStoreOfLocal.ql
@@ -29,8 +29,9 @@ predicate isSimple(IR::Instruction nd) {
 
 from IR::Instruction def, SsaSourceVariable target, IR::Instruction rhs
 where
+  // def.hasLocationInfo(_, 25, _, _, _) and
   def.writes(target, rhs) and
-  not exists(SsaExplicitDefinition ssa | ssa.getInstruction() = def) and
+  not exists(SsaExplicitDefinition ssa | ssa.mayBeUsed() | ssa.getInstruction() = def) and
   // exclude assignments in dead code
   def.getBasicBlock() instanceof ReachableBasicBlock and
   // exclude assignments with default values or simple expressions

--- a/go/ql/test/library-tests/semmle/go/dataflow/FunctionInputsAndOutputs/FunctionInput_getExitNode.expected
+++ b/go/ql/test/library-tests/semmle/go/dataflow/FunctionInputsAndOutputs/FunctionInput_getExitNode.expected
@@ -4,6 +4,7 @@
 | parameter 0 | reset.go:8:1:16:1 | function declaration | reset.go:8:27:8:27 | definition of r |
 | parameter 0 | tst2.go:8:1:12:1 | function declaration | tst2.go:8:12:8:15 | definition of data |
 | parameter 0 | tst.go:8:1:11:1 | function declaration | tst.go:8:12:8:17 | definition of reader |
+| parameter 0 | tst.go:13:1:13:25 | function declaration | tst.go:13:12:13:13 | definition of xs |
 | parameter 0 | tst.go:15:1:19:1 | function declaration | tst.go:15:12:15:12 | definition of x |
 | parameter 1 | main.go:5:1:11:1 | function declaration | main.go:5:20:5:20 | definition of x |
 | parameter 1 | main.go:13:1:20:1 | function declaration | main.go:13:21:13:21 | definition of x |

--- a/go/ql/test/library-tests/semmle/go/dataflow/PromotedFields/LocalFlowStep.expected
+++ b/go/ql/test/library-tests/semmle/go/dataflow/PromotedFields/LocalFlowStep.expected
@@ -78,6 +78,7 @@
 | main.go:7:6:7:9 | function sink | main.go:148:2:148:5 | sink |
 | main.go:7:6:7:9 | function sink | main.go:149:2:149:5 | sink |
 | main.go:7:6:7:9 | function sink | main.go:150:2:150:5 | sink |
+| main.go:7:11:7:11 | argument corresponding to s | main.go:7:11:7:11 | definition of s |
 | main.go:22:2:22:6 | definition of outer | main.go:25:7:25:11 | outer |
 | main.go:22:2:22:6 | definition of outer | main.go:26:7:26:11 | outer |
 | main.go:22:2:22:6 | definition of outer | main.go:27:7:27:11 | outer |

--- a/go/ql/test/library-tests/semmle/go/dataflow/SSA/SsaDefinition.expected
+++ b/go/ql/test/library-tests/semmle/go/dataflow/SSA/SsaDefinition.expected
@@ -32,6 +32,7 @@
 | main.go:82:25:82:25 | definition of b |
 | main.go:83:2:83:2 | definition of x |
 | main.go:84:5:84:5 | definition of a |
+| main.go:93:15:93:16 | definition of cb |
 | main.go:95:22:95:28 | definition of wrapper |
 | main.go:96:2:96:2 | definition of x |
 | main.go:97:2:99:3 | capture variable x |

--- a/go/ql/test/library-tests/semmle/go/dataflow/SSA/SsaWithFields.expected
+++ b/go/ql/test/library-tests/semmle/go/dataflow/SSA/SsaWithFields.expected
@@ -32,6 +32,7 @@
 | main.go:82:25:82:25 | (def@82:25) | b |
 | main.go:83:2:83:2 | (def@83:2) | x |
 | main.go:84:5:84:5 | (def@84:5) | a |
+| main.go:93:15:93:16 | (def@93:15) | cb |
 | main.go:95:22:95:28 | (def@95:22) | wrapper |
 | main.go:95:22:95:28 | (def@95:22).s | wrapper.s |
 | main.go:96:2:96:2 | (def@96:2) | x |


### PR DESCRIPTION
It was confusing that no `ParameterNode` was created if a parameter wasn't used. This was because `ParameterNode`s are linked to `SsaNode`s. We slightly expand the definition of `SsaNode` so that parameters always get them, even if they aren't used. We have to make a predicate with the old definition to keep "Dead store of local" working.