### PR TITLE
C#: Use dotnet --list-runtimes to find runtime locations.

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp.Standalone/BuildAnalysis.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.Standalone/BuildAnalysis.cs
@@ -66,7 +66,7 @@ namespace Semmle.BuildAnalyser
             // Find DLLs in the .Net Framework
             if (options.ScanNetFrameworkDlls)
             {
-                var runtimeLocation = Runtime.GetRuntime(options.UseSelfContainedDotnet);
+                var runtimeLocation = new Runtime(dotnet).GetRuntime(options.UseSelfContainedDotnet);
                 progressMonitor.Log(Util.Logging.Severity.Debug, $"Runtime location selected: {runtimeLocation}");
                 dllDirNames.Add(runtimeLocation);
             }

--- a/csharp/extractor/Semmle.Extraction.CSharp.Standalone/DotNet.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.Standalone/DotNet.cs
@@ -5,10 +5,18 @@ using Semmle.Util;
 
 namespace Semmle.BuildAnalyser
 {
+    internal interface IDotNet
+    {
+        bool RestoreToDirectory(string project, string directory);
+        bool New(string folder);
+        bool AddPackage(string folder, string package);
+        public IList<string> GetListedRuntimes();
+    }
+
     /// <summary>
     /// Utilities to run the "dotnet" command.
     /// </summary>
-    internal class DotNet
+    internal class DotNet : IDotNet
     {
         private const string dotnet = "dotnet";
         private readonly ProgressMonitor progressMonitor;

--- a/csharp/extractor/Semmle.Extraction.CSharp.Standalone/Properties/AssemblyInfo.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.Standalone/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following
@@ -12,6 +13,9 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright("Copyright © Semmle 2016")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
+
+// Expose internals for testing purposes.
+[assembly: InternalsVisibleTo("Semmle.Extraction.Tests")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/csharp/extractor/Semmle.Extraction.CSharp.Standalone/Runtime.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.Standalone/Runtime.cs
@@ -17,12 +17,12 @@ namespace Semmle.Extraction.CSharp.Standalone
         private const string netCoreApp = "Microsoft.NETCore.App";
         private const string aspNetCoreApp = "Microsoft.AspNetCore.App";
 
-        private readonly DotNet dotNet;
+        private readonly IDotNet dotNet;
         private static string ExecutingRuntime => RuntimeEnvironment.GetRuntimeDirectory();
 
-        public Runtime(DotNet dotNet) => this.dotNet = dotNet;
+        public Runtime(IDotNet dotNet) => this.dotNet = dotNet;
 
-        private sealed class RuntimeVersion : IComparable<RuntimeVersion>
+        internal sealed class RuntimeVersion : IComparable<RuntimeVersion>
         {
             private readonly string dir;
             private Version Version { get; }
@@ -97,7 +97,10 @@ namespace Semmle.Extraction.CSharp.Standalone
             return runtimes;
         }
 
-        private Dictionary<string, RuntimeVersion> GetNewestRuntimes()
+        /// <summary>
+        /// Returns a dictionary mapping runtimes to their newest version.
+        /// </summary>
+        internal Dictionary<string, RuntimeVersion> GetNewestRuntimes()
         {
             var listed = dotNet.GetListedRuntimes();
             return ParseRuntimes(listed);

--- a/csharp/extractor/Semmle.Extraction.CSharp.Standalone/Runtime.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.Standalone/Runtime.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
+using Semmle.BuildAnalyser;
 using Semmle.Util;
 
 namespace Semmle.Extraction.CSharp.Standalone
@@ -10,32 +12,96 @@ namespace Semmle.Extraction.CSharp.Standalone
     /// <summary>
     /// Locates .NET Runtimes.
     /// </summary>
-    internal static class Runtime
+    internal partial class Runtime
     {
+        private readonly DotNet dotNet;
+        public Runtime(DotNet dotNet) => this.dotNet = dotNet;
+
+        private sealed class Version : IComparable<Version>
+        {
+            private readonly string Dir;
+            public int Major { get; }
+            public int Minor { get; }
+            public int Patch { get; }
+
+
+            public string FullPath => Path.Combine(Dir, this.ToString());
+
+
+            public Version(string version, string dir)
+            {
+                var parts = version.Split('.');
+                Major = int.Parse(parts[0]);
+                Minor = int.Parse(parts[1]);
+                Patch = int.Parse(parts[2]);
+                Dir = dir;
+            }
+
+            public int CompareTo(Version? other) =>
+                other is null ? 1 : GetHashCode().CompareTo(other.GetHashCode());
+
+            public override bool Equals(object? obj) =>
+                obj is not null && obj is Version other && other.FullPath == FullPath;
+
+            public override int GetHashCode() =>
+                (Major * 1000 + Minor) * 1000 + Patch;
+
+            public override string ToString() =>
+                $"{Major}.{Minor}.{Patch}";
+        }
+
         private static string ExecutingRuntime => RuntimeEnvironment.GetRuntimeDirectory();
 
-        /// <summary>
-        /// Locates .NET Core Runtimes.
-        /// </summary>
-        private static IEnumerable<string> CoreRuntimes
+        private static readonly string NetCoreApp = "Microsoft.NETCore.App";
+        private static readonly string AspNetCoreApp = "Microsoft.AspNetCore.App";
+
+        private static void AddOrUpdate(Dictionary<string, Version> dict, string framework, Version version)
         {
-            get
+            if (!dict.TryGetValue(framework, out var existing) || existing.CompareTo(version) < 0)
             {
-                var dotnetPath = FileUtils.FindProgramOnPath(Win32.IsWindows() ? "dotnet.exe" : "dotnet");
-                var dotnetDirs = dotnetPath is not null
-                    ? new[] { dotnetPath }
-                    : new[] { "/usr/share/dotnet", @"C:\Program Files\dotnet" };
-                var coreDirs = dotnetDirs.Select(d => Path.Combine(d, "shared", "Microsoft.NETCore.App"));
-
-                var dir = coreDirs.FirstOrDefault(Directory.Exists);
-                if (dir is not null)
-                {
-                    return Directory.EnumerateDirectories(dir).OrderByDescending(Path.GetFileName);
-                }
-
-                return Enumerable.Empty<string>();
+                dict[framework] = version;
             }
         }
+
+        [GeneratedRegex(@"^(\S+)\s(\d+\.\d+\.\d+)\s\[(\S+)\]$")]
+        private static partial Regex RuntimeRegex();
+
+        /// <summary>
+        /// Parses the output of `dotnet --list-runtimes` to get a map from a runtime to the location of
+        /// the newest version of the runtime.
+        /// It is assume that the format of a listed runtime is something like:
+        /// Microsoft.NETCore.App 7.0.2 [/usr/share/dotnet/shared/Microsoft.NETCore.App]
+        /// </summary>
+        private static Dictionary<string, Version> ParseRuntimes(IList<string> listed)
+        {
+            // Parse listed runtimes.
+            var runtimes = new Dictionary<string, Version>();
+            listed.ForEach(r =>
+            {
+                var match = RuntimeRegex().Match(r);
+                if (match.Success)
+                {
+                    AddOrUpdate(runtimes, match.Groups[1].Value, new Version(match.Groups[2].Value, match.Groups[3].Value));
+                }
+            });
+
+            return runtimes;
+        }
+
+        private Dictionary<string, Version> GetNewestRuntimes()
+        {
+            try
+            {
+                var listed = dotNet.GetListedRuntimes();
+                return ParseRuntimes(listed);
+            }
+            catch (Exception ex)
+                when (ex is System.ComponentModel.Win32Exception || ex is FileNotFoundException)
+            {
+                return new Dictionary<string, Version>();
+            }
+        }
+
 
         /// <summary>
         /// Locates .NET Desktop Runtimes.
@@ -69,24 +135,33 @@ namespace Semmle.Extraction.CSharp.Standalone
             }
         }
 
+        private IEnumerable<string> GetRuntimes()
+        {
+            // Gets the newest version of the installed runtimes.
+            var newestRuntimes = GetNewestRuntimes();
+
+            // Location of the newest .NET Core Runtime.
+            if (newestRuntimes.TryGetValue(NetCoreApp, out var netCoreApp))
+            {
+                yield return netCoreApp.FullPath;
+            }
+
+            // Location of the newest ASP.NET Core Runtime.
+            if (newestRuntimes.TryGetValue(AspNetCoreApp, out var aspNetCoreApp))
+            {
+                yield return aspNetCoreApp.FullPath;
+            }
+
+            foreach (var r in DesktopRuntimes)
+                yield return r;
+
+            // A bad choice if it's the self-contained runtime distributed in codeql dist.
+            yield return ExecutingRuntime;
+        }
+
         /// <summary>
         /// Gets the .NET runtime location to use for extraction
         /// </summary>
-        public static string GetRuntime(bool useSelfContained) => useSelfContained ? ExecutingRuntime : Runtimes.First();
-
-        private static IEnumerable<string> Runtimes
-        {
-            get
-            {
-                foreach (var r in CoreRuntimes)
-                    yield return r;
-
-                foreach (var r in DesktopRuntimes)
-                    yield return r;
-
-                // A bad choice if it's the self-contained runtime distributed in codeql dist.
-                yield return ExecutingRuntime;
-            }
-        }
+        public string GetRuntime(bool useSelfContained) => useSelfContained ? ExecutingRuntime : GetRuntimes().First();
     }
 }

--- a/csharp/extractor/Semmle.Extraction.Tests/Runtime.cs
+++ b/csharp/extractor/Semmle.Extraction.Tests/Runtime.cs
@@ -1,0 +1,78 @@
+using Xunit;
+using System.Collections.Generic;
+using Semmle.BuildAnalyser;
+using Semmle.Extraction.CSharp.Standalone;
+
+namespace Semmle.Extraction.Tests
+{
+    internal class DotNetStub : IDotNet
+    {
+        private readonly IList<string> runtimes;
+
+        public DotNetStub(IList<string> runtimes) => this.runtimes = runtimes;
+
+        public bool AddPackage(string folder, string package) => true;
+
+        public bool New(string folder) => true;
+
+        public bool RestoreToDirectory(string project, string directory) => true;
+
+        public IList<string> GetListedRuntimes() => runtimes;
+    }
+
+    public class RuntimeTests
+    {
+        [Fact]
+        public void TestRuntime1()
+        {
+            // Setup
+            var listedRuntimes = new List<string> {
+                "Microsoft.AspNetCore.App 5.0.12 [/path/dotnet/shared/Microsoft.AspNetCore.App]",
+                "Microsoft.AspNetCore.App 6.0.4 [/path/dotnet/shared/Microsoft.AspNetCore.App]",
+                "Microsoft.AspNetCore.App 7.0.0 [/path/dotnet/shared/Microsoft.AspNetCore.App]",
+                "Microsoft.AspNetCore.App 7.0.2 [/path/dotnet/shared/Microsoft.AspNetCore.App]",
+                "Microsoft.NETCore.App 5.0.12 [/path/dotnet/shared/Microsoft.NETCore.App]",
+                "Microsoft.NETCore.App 6.0.4 [/path/dotnet/shared/Microsoft.NETCore.App]",
+                "Microsoft.NETCore.App 7.0.0 [/path/dotnet/shared/Microsoft.NETCore.App]",
+                "Microsoft.NETCore.App 7.0.2 [/path/dotnet/shared/Microsoft.NETCore.App]"
+                };
+            var dotnet = new DotNetStub(listedRuntimes);
+            var runtime = new Runtime(dotnet);
+
+            // Execute
+            var runtimes = runtime.GetNewestRuntimes();
+
+            // Verify
+            Assert.Equal(2, runtimes.Count);
+
+            Assert.True(runtimes.TryGetValue("Microsoft.AspNetCore.App", out var aspNetCoreApp));
+            Assert.Equal("/path/dotnet/shared/Microsoft.AspNetCore.App/7.0.2", aspNetCoreApp.FullPath);
+
+            Assert.True(runtimes.TryGetValue("Microsoft.NETCore.App", out var netCoreApp));
+            Assert.Equal("/path/dotnet/shared/Microsoft.NETCore.App/7.0.2", netCoreApp.FullPath);
+        }
+
+        [Fact]
+        public void TestRuntime2()
+        {
+            // Setup
+            var listedRuntimes = new List<string>
+            {
+                "Microsoft.NETCore.App 7.0.2 [/path/dotnet/shared/Microsoft.NETCore.App]",
+                "Microsoft.NETCore.App 8.0.0-preview.5.23280.8 [/path/dotnet/shared/Microsoft.NETCore.App]",
+                "Microsoft.NETCore.App 8.0.0-preview.5.43280.8 [/path/dotnet/shared/Microsoft.NETCore.App]"
+            };
+            var dotnet = new DotNetStub(listedRuntimes);
+            var runtime = new Runtime(dotnet);
+
+            // Execute
+            var runtimes = runtime.GetNewestRuntimes();
+
+            // Verify
+            Assert.Single(runtimes);
+
+            Assert.True(runtimes.TryGetValue("Microsoft.NETCore.App", out var netCoreApp));
+            Assert.Equal("/path/dotnet/shared/Microsoft.NETCore.App/8.0.0-preview.5.43280.8", netCoreApp.FullPath);
+        }
+    }
+}

--- a/csharp/extractor/Semmle.Extraction.Tests/Runtime.cs
+++ b/csharp/extractor/Semmle.Extraction.Tests/Runtime.cs
@@ -59,8 +59,8 @@ namespace Semmle.Extraction.Tests
             var listedRuntimes = new List<string>
             {
                 "Microsoft.NETCore.App 7.0.2 [/path/dotnet/shared/Microsoft.NETCore.App]",
-                "Microsoft.NETCore.App 8.0.0-preview.5.23280.8 [/path/dotnet/shared/Microsoft.NETCore.App]",
-                "Microsoft.NETCore.App 8.0.0-preview.5.43280.8 [/path/dotnet/shared/Microsoft.NETCore.App]"
+                "Microsoft.NETCore.App 8.0.0-preview.5.43280.8 [/path/dotnet/shared/Microsoft.NETCore.App]",
+                "Microsoft.NETCore.App 8.0.0-preview.5.23280.8 [/path/dotnet/shared/Microsoft.NETCore.App]"
             };
             var dotnet = new DotNetStub(listedRuntimes);
             var runtime = new Runtime(dotnet);
@@ -74,5 +74,29 @@ namespace Semmle.Extraction.Tests
             Assert.True(runtimes.TryGetValue("Microsoft.NETCore.App", out var netCoreApp));
             Assert.Equal("/path/dotnet/shared/Microsoft.NETCore.App/8.0.0-preview.5.43280.8", netCoreApp.FullPath);
         }
+
+        [Fact]
+        public void TestRuntime3()
+        {
+            // Setup
+            var listedRuntimes = new List<string>
+            {
+                "Microsoft.NETCore.App 7.0.2 [/path/dotnet/shared/Microsoft.NETCore.App]",
+                "Microsoft.NETCore.App 8.0.0-rc.4.43280.8 [/path/dotnet/shared/Microsoft.NETCore.App]",
+                "Microsoft.NETCore.App 8.0.0-preview.5.23280.8 [/path/dotnet/shared/Microsoft.NETCore.App]"
+            };
+            var dotnet = new DotNetStub(listedRuntimes);
+            var runtime = new Runtime(dotnet);
+
+            // Execute
+            var runtimes = runtime.GetNewestRuntimes();
+
+            // Verify
+            Assert.Single(runtimes);
+
+            Assert.True(runtimes.TryGetValue("Microsoft.NETCore.App", out var netCoreApp));
+            Assert.Equal("/path/dotnet/shared/Microsoft.NETCore.App/8.0.0-rc.4.43280.8", netCoreApp.FullPath);
+        }
+
     }
 }

--- a/csharp/extractor/Semmle.Util/DictionaryExtensions.cs
+++ b/csharp/extractor/Semmle.Util/DictionaryExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace Semmle.Util
 {
@@ -17,6 +18,18 @@ namespace Semmle.Util
                 dict[key] = list;
             }
             list.Add(element);
+        }
+
+        /// <summary>
+        /// Adds a new value or replaces the existing value (if the new value is greater than the existing) 
+        /// in dictionary for the given key.
+        /// </summary>
+        public static void AddOrUpdate<T1, T2>(this Dictionary<T1, T2> dict, T1 key, T2 value) where T1 : notnull where T2 : IComparable<T2>
+        {
+            if (!dict.TryGetValue(key, out var existing) || existing.CompareTo(value) < 0)
+            {
+                dict[key] = value;
+            }
         }
     }
 }


### PR DESCRIPTION
In this PR we re-write how the standalone extractor finds the .NET runtime DLLs that will be included in the extraction.
Prior to this change, the standalone extractor tried to derive, where the runtime DLLs were located by inspecting the location of the `dotnet` executable based on the `$PATH`.

It is probably a better solution to use `dotnet --list-runtimes` to get the locations of all installed runtimes (also including ASP.NET Core).
In this PR the standalone extractor is rewritten to use the information from `dotnet --list-runtimes` to pick the *newest* .NET Runtime and include it in the extraction.
If a project is a ASP.NET Core project, we would like to also include the ASP.NET Core DLLs. This PR prepares for this change.