### PR TITLE
C++: Rewrite `cpp/constant-array-overflow` and add barriers

### DIFF
--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/constant-size/ConstantSizeArrayOffByOne.expected
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/constant-size/ConstantSizeArrayOffByOne.expected
@@ -1,35 +1,17 @@
 edges
-| test.cpp:34:10:34:12 | buf | test.cpp:34:5:34:24 | access to array |
 | test.cpp:35:10:35:12 | buf | test.cpp:35:5:35:22 | access to array |
 | test.cpp:36:10:36:12 | buf | test.cpp:36:5:36:24 | access to array |
-| test.cpp:39:14:39:16 | buf | test.cpp:39:9:39:19 | access to array |
 | test.cpp:43:14:43:16 | buf | test.cpp:43:9:43:19 | access to array |
-| test.cpp:48:10:48:12 | buf | test.cpp:48:5:48:24 | access to array |
 | test.cpp:49:10:49:12 | buf | test.cpp:49:5:49:22 | access to array |
 | test.cpp:50:10:50:12 | buf | test.cpp:50:5:50:24 | access to array |
-| test.cpp:53:14:53:16 | buf | test.cpp:53:9:53:19 | access to array |
 | test.cpp:57:14:57:16 | buf | test.cpp:57:9:57:19 | access to array |
 | test.cpp:61:14:61:16 | buf | test.cpp:61:9:61:19 | access to array |
-| test.cpp:70:33:70:33 | p | test.cpp:71:5:71:17 | access to array |
 | test.cpp:70:33:70:33 | p | test.cpp:72:5:72:15 | access to array |
-| test.cpp:76:26:76:46 | & ... | test.cpp:66:32:66:32 | p |
-| test.cpp:76:32:76:34 | buf | test.cpp:76:26:76:46 | & ... |
 | test.cpp:77:26:77:44 | & ... | test.cpp:66:32:66:32 | p |
 | test.cpp:77:32:77:34 | buf | test.cpp:77:26:77:44 | & ... |
 | test.cpp:79:27:79:34 | buf | test.cpp:70:33:70:33 | p |
 | test.cpp:79:32:79:34 | buf | test.cpp:79:27:79:34 | buf |
-| test.cpp:85:34:85:36 | buf | test.cpp:87:5:87:31 | access to array |
 | test.cpp:85:34:85:36 | buf | test.cpp:88:5:88:27 | access to array |
-| test.cpp:96:13:96:15 | arr | test.cpp:96:13:96:18 | access to array |
-| test.cpp:111:17:111:19 | arr | test.cpp:111:17:111:22 | access to array |
-| test.cpp:111:17:111:19 | arr | test.cpp:115:35:115:40 | access to array |
-| test.cpp:111:17:111:19 | arr | test.cpp:119:17:119:22 | access to array |
-| test.cpp:115:35:115:37 | arr | test.cpp:111:17:111:22 | access to array |
-| test.cpp:115:35:115:37 | arr | test.cpp:115:35:115:40 | access to array |
-| test.cpp:115:35:115:37 | arr | test.cpp:119:17:119:22 | access to array |
-| test.cpp:119:17:119:19 | arr | test.cpp:111:17:111:22 | access to array |
-| test.cpp:119:17:119:19 | arr | test.cpp:115:35:115:40 | access to array |
-| test.cpp:119:17:119:19 | arr | test.cpp:119:17:119:22 | access to array |
 | test.cpp:128:9:128:11 | arr | test.cpp:128:9:128:14 | access to array |
 | test.cpp:134:25:134:27 | arr | test.cpp:136:9:136:16 | ... += ... |
 | test.cpp:136:9:136:16 | ... += ... | test.cpp:138:13:138:15 | arr |
@@ -39,67 +21,38 @@ edges
 | test.cpp:156:12:156:14 | buf | test.cpp:156:12:156:18 | ... + ... |
 | test.cpp:156:12:156:18 | ... + ... | test.cpp:158:17:158:18 | & ... indirection |
 | test.cpp:158:17:158:18 | & ... indirection | test.cpp:146:26:146:26 | p indirection |
-| test.cpp:218:23:218:28 | buffer | test.cpp:220:5:220:11 | access to array |
 | test.cpp:218:23:218:28 | buffer | test.cpp:221:5:221:11 | access to array |
-| test.cpp:229:25:229:29 | array | test.cpp:231:5:231:10 | access to array |
 | test.cpp:229:25:229:29 | array | test.cpp:232:5:232:10 | access to array |
+| test.cpp:237:25:237:29 | array | test.cpp:240:5:240:10 | access to array |
 | test.cpp:245:30:245:30 | p | test.cpp:261:27:261:30 | access to array |
-| test.cpp:245:30:245:30 | p | test.cpp:261:27:261:30 | access to array |
-| test.cpp:274:14:274:20 | buffer3 | test.cpp:245:30:245:30 | p |
-| test.cpp:274:14:274:20 | buffer3 | test.cpp:274:14:274:20 | buffer3 |
 | test.cpp:277:35:277:35 | p | test.cpp:278:14:278:14 | p |
 | test.cpp:278:14:278:14 | p | test.cpp:245:30:245:30 | p |
-| test.cpp:283:19:283:25 | buffer1 | test.cpp:277:35:277:35 | p |
-| test.cpp:283:19:283:25 | buffer1 | test.cpp:283:19:283:25 | buffer1 |
 | test.cpp:286:19:286:25 | buffer2 | test.cpp:277:35:277:35 | p |
 | test.cpp:286:19:286:25 | buffer2 | test.cpp:286:19:286:25 | buffer2 |
-| test.cpp:289:19:289:25 | buffer3 | test.cpp:277:35:277:35 | p |
-| test.cpp:289:19:289:25 | buffer3 | test.cpp:289:19:289:25 | buffer3 |
 nodes
-| test.cpp:34:5:34:24 | access to array | semmle.label | access to array |
-| test.cpp:34:10:34:12 | buf | semmle.label | buf |
 | test.cpp:35:5:35:22 | access to array | semmle.label | access to array |
 | test.cpp:35:10:35:12 | buf | semmle.label | buf |
 | test.cpp:36:5:36:24 | access to array | semmle.label | access to array |
 | test.cpp:36:10:36:12 | buf | semmle.label | buf |
-| test.cpp:39:9:39:19 | access to array | semmle.label | access to array |
-| test.cpp:39:14:39:16 | buf | semmle.label | buf |
 | test.cpp:43:9:43:19 | access to array | semmle.label | access to array |
 | test.cpp:43:14:43:16 | buf | semmle.label | buf |
-| test.cpp:48:5:48:24 | access to array | semmle.label | access to array |
-| test.cpp:48:10:48:12 | buf | semmle.label | buf |
 | test.cpp:49:5:49:22 | access to array | semmle.label | access to array |
 | test.cpp:49:10:49:12 | buf | semmle.label | buf |
 | test.cpp:50:5:50:24 | access to array | semmle.label | access to array |
 | test.cpp:50:10:50:12 | buf | semmle.label | buf |
-| test.cpp:53:9:53:19 | access to array | semmle.label | access to array |
-| test.cpp:53:14:53:16 | buf | semmle.label | buf |
 | test.cpp:57:9:57:19 | access to array | semmle.label | access to array |
 | test.cpp:57:14:57:16 | buf | semmle.label | buf |
 | test.cpp:61:9:61:19 | access to array | semmle.label | access to array |
 | test.cpp:61:14:61:16 | buf | semmle.label | buf |
 | test.cpp:66:32:66:32 | p | semmle.label | p |
-| test.cpp:66:32:66:32 | p | semmle.label | p |
 | test.cpp:70:33:70:33 | p | semmle.label | p |
-| test.cpp:71:5:71:17 | access to array | semmle.label | access to array |
 | test.cpp:72:5:72:15 | access to array | semmle.label | access to array |
-| test.cpp:76:26:76:46 | & ... | semmle.label | & ... |
-| test.cpp:76:32:76:34 | buf | semmle.label | buf |
 | test.cpp:77:26:77:44 | & ... | semmle.label | & ... |
 | test.cpp:77:32:77:34 | buf | semmle.label | buf |
 | test.cpp:79:27:79:34 | buf | semmle.label | buf |
 | test.cpp:79:32:79:34 | buf | semmle.label | buf |
 | test.cpp:85:34:85:36 | buf | semmle.label | buf |
-| test.cpp:87:5:87:31 | access to array | semmle.label | access to array |
 | test.cpp:88:5:88:27 | access to array | semmle.label | access to array |
-| test.cpp:96:13:96:15 | arr | semmle.label | arr |
-| test.cpp:96:13:96:18 | access to array | semmle.label | access to array |
-| test.cpp:111:17:111:19 | arr | semmle.label | arr |
-| test.cpp:111:17:111:22 | access to array | semmle.label | access to array |
-| test.cpp:115:35:115:37 | arr | semmle.label | arr |
-| test.cpp:115:35:115:40 | access to array | semmle.label | access to array |
-| test.cpp:119:17:119:19 | arr | semmle.label | arr |
-| test.cpp:119:17:119:22 | access to array | semmle.label | access to array |
 | test.cpp:128:9:128:11 | arr | semmle.label | arr |
 | test.cpp:128:9:128:14 | access to array | semmle.label | access to array |
 | test.cpp:134:25:134:27 | arr | semmle.label | arr |
@@ -113,24 +66,17 @@ nodes
 | test.cpp:156:12:156:18 | ... + ... | semmle.label | ... + ... |
 | test.cpp:158:17:158:18 | & ... indirection | semmle.label | & ... indirection |
 | test.cpp:218:23:218:28 | buffer | semmle.label | buffer |
-| test.cpp:220:5:220:11 | access to array | semmle.label | access to array |
 | test.cpp:221:5:221:11 | access to array | semmle.label | access to array |
 | test.cpp:229:25:229:29 | array | semmle.label | array |
-| test.cpp:231:5:231:10 | access to array | semmle.label | access to array |
 | test.cpp:232:5:232:10 | access to array | semmle.label | access to array |
-| test.cpp:245:30:245:30 | p | semmle.label | p |
+| test.cpp:237:25:237:29 | array | semmle.label | array |
+| test.cpp:240:5:240:10 | access to array | semmle.label | access to array |
 | test.cpp:245:30:245:30 | p | semmle.label | p |
 | test.cpp:261:27:261:30 | access to array | semmle.label | access to array |
-| test.cpp:274:14:274:20 | buffer3 | semmle.label | buffer3 |
-| test.cpp:274:14:274:20 | buffer3 | semmle.label | buffer3 |
 | test.cpp:277:35:277:35 | p | semmle.label | p |
 | test.cpp:278:14:278:14 | p | semmle.label | p |
-| test.cpp:283:19:283:25 | buffer1 | semmle.label | buffer1 |
-| test.cpp:283:19:283:25 | buffer1 | semmle.label | buffer1 |
 | test.cpp:286:19:286:25 | buffer2 | semmle.label | buffer2 |
 | test.cpp:286:19:286:25 | buffer2 | semmle.label | buffer2 |
-| test.cpp:289:19:289:25 | buffer3 | semmle.label | buffer3 |
-| test.cpp:289:19:289:25 | buffer3 | semmle.label | buffer3 |
 subpaths
 #select
 | test.cpp:35:5:35:22 | PointerAdd: access to array | test.cpp:35:10:35:12 | buf | test.cpp:35:5:35:22 | access to array | This pointer arithmetic may have an off-by-1 error allowing it to overrun $@ at this $@. | test.cpp:15:9:15:11 | buf | buf | test.cpp:35:5:35:26 | Store: ... = ... | write |
@@ -148,4 +94,5 @@ subpaths
 | test.cpp:156:12:156:18 | PointerAdd: ... + ... | test.cpp:156:12:156:14 | buf | test.cpp:148:6:148:9 | * ... | This pointer arithmetic may have an off-by-1 error allowing it to overrun $@ at this $@. | test.cpp:154:7:154:9 | buf | buf | test.cpp:147:3:147:13 | Store: ... = ... | write |
 | test.cpp:221:5:221:11 | PointerAdd: access to array | test.cpp:218:23:218:28 | buffer | test.cpp:221:5:221:11 | access to array | This pointer arithmetic may have an off-by-1 error allowing it to overrun $@ at this $@. | test.cpp:217:19:217:24 | buffer | buffer | test.cpp:221:5:221:15 | Store: ... = ... | write |
 | test.cpp:232:5:232:10 | PointerAdd: access to array | test.cpp:229:25:229:29 | array | test.cpp:232:5:232:10 | access to array | This pointer arithmetic may have an off-by-1 error allowing it to overrun $@ at this $@. | test.cpp:228:10:228:14 | array | array | test.cpp:232:5:232:19 | Store: ... = ... | write |
+| test.cpp:240:5:240:10 | PointerAdd: access to array | test.cpp:237:25:237:29 | array | test.cpp:240:5:240:10 | access to array | This pointer arithmetic may have an off-by-1 error allowing it to overrun $@ at this $@. | test.cpp:236:10:236:14 | array | array | test.cpp:240:5:240:19 | Store: ... = ... | write |
 | test.cpp:261:27:261:30 | PointerAdd: access to array | test.cpp:286:19:286:25 | buffer2 | test.cpp:261:27:261:30 | access to array | This pointer arithmetic may have an off-by-1 error allowing it to overrun $@ at this $@. | test.cpp:285:19:285:25 | buffer2 | buffer2 | test.cpp:261:27:261:30 | Load: access to array | read |

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/constant-size/test.cpp
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/constant-size/test.cpp
@@ -237,7 +237,7 @@ void pointer_size_larger_than_array_element_size_and_does_not_divide_it() {
     vec3 *ptr = (vec3 *)array; // pai.getElementSize() will be 3 * sizeof(int) -> size = 1
 
     ptr[0] = vec3{}; // GOOD: writes ints 0, 1, 2
-    ptr[1] = vec3{}; // BAD: writes ints 3, 4, 5 [NOT DETECTED]
+    ptr[1] = vec3{}; // BAD: writes ints 3, 4, 5
 }
 
 void use(...);
@@ -287,4 +287,17 @@ void test_call_use2() {
 
     unsigned char buffer3[3];
     call_call_use(buffer3,3);
+}
+
+void foo(unsigned char* p, unsigned n) {
+  unsigned char* q = nullptr;
+  if(n < 10) {
+    q = &p[n];
+  }
+  unsigned char x = *q; // OK (There's a null pointer deref, but we don't care about that one here.)
+}
+
+void test(unsigned n) {
+  unsigned char buffer[10];
+  foo(buffer, n);
 }


### PR DESCRIPTION
This PR splits the dataflow traversals in `cpp/constant-array-overflow` into multiple stages so that we can track the `ArrayType` as a flow state without introducing a cartesian product, and then adds a barrier that blocks flow in cases such as:
```cpp
void foo(unsigned char* p, unsigned n) {
  if(n < 10) {
    unsigned char q = p[n]; // This is safe because the index is guarded to be less than 10 which happens to equal the size of buffer in `test`.
  }
}

void test(unsigned n) {
  unsigned char buffer[10];
  foo(buffer, n);
}
```

[The first commit](87d4541df416c75f35a29d6d07c1ba51408429d3) rewrites the query to track the array type as a `FlowState`, and [the second commit](b412873a64662eb60b68a72031c39a69f69b2c73) adds the barrier that blocks out this flow.