### PR TITLE
Go: make parameter nodes for unused parameters #3 (Base ParameterNode on IR::InitParameterInstruction instead of SsaNode)

### DIFF
--- a/go/ql/lib/change-notes/2023-07-05-parameter-nodes-for-unused-parameters.md
+++ b/go/ql/lib/change-notes/2023-07-05-parameter-nodes-for-unused-parameters.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Parameter nodes now exist for unused parameters as well as used parameters.

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowNodes.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowNodes.qll
@@ -680,12 +680,15 @@ module Public {
     }
   }
 
-  /** A representation of a parameter initialization, defined in source via an SSA node. */
-  class SsaParameterNode extends ParameterNode, SsaNode {
-    override SsaExplicitDefinition ssa;
+  /**
+   * A representation of a parameter, defined in source via an
+   * InitParameterInstruction instruction node.
+   */
+  class InsnParameterNode extends ParameterNode, InstructionNode {
+    override IR::InitParameterInstruction insn;
     Parameter parm;
 
-    SsaParameterNode() { ssa.getInstruction() = IR::initParamInstruction(parm) }
+    InsnParameterNode() { insn = IR::initParamInstruction(parm) }
 
     /** Gets the parameter this node initializes. */
     override Parameter asParameter() { result = parm }
@@ -693,10 +696,12 @@ module Public {
     override predicate isParameterOf(DataFlowCallable c, int i) {
       parm.isParameterOf(c.asCallable().getFuncDef(), i)
     }
+
+    SsaNode getSsaNode() { result.getDefinition().(SsaExplicitDefinition).getInstruction() = insn }
   }
 
   /** A representation of a receiver initialization. */
-  class ReceiverNode extends SsaParameterNode {
+  class ReceiverNode extends InsnParameterNode {
     override ReceiverVariable parm;
 
     /** Gets the receiver variable this node initializes. */

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowPrivate.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowPrivate.qll
@@ -356,11 +356,11 @@ private class ConstantBooleanArgumentNode extends ArgumentNode, ExprNode {
  */
 pragma[noinline]
 private ControlFlow::ConditionGuardNode getAFalsifiedGuard(DataFlowCall call) {
-  exists(SsaParameterNode param, ConstantBooleanArgumentNode arg |
+  exists(InsnParameterNode param, ConstantBooleanArgumentNode arg |
     // get constant bool argument and parameter for this call
     viableParamArg(call, pragma[only_bind_into](param), pragma[only_bind_into](arg)) and
     // which is used in a guard controlling `n` with the opposite value of `arg`
-    result.ensures(param.getAUse(), arg.getBooleanValue().booleanNot())
+    result.ensures(param.getSsaNode().getAUse(), arg.getBooleanValue().booleanNot())
   )
 }
 

--- a/go/ql/test/library-tests/semmle/go/dataflow/FunctionInputsAndOutputs/FunctionInput_getExitNode.expected
+++ b/go/ql/test/library-tests/semmle/go/dataflow/FunctionInputsAndOutputs/FunctionInput_getExitNode.expected
@@ -1,13 +1,14 @@
-| parameter 0 | main.go:5:1:11:1 | function declaration | main.go:5:9:5:10 | definition of op |
-| parameter 0 | main.go:13:1:20:1 | function declaration | main.go:13:10:13:11 | definition of op |
-| parameter 0 | main.go:40:1:48:1 | function declaration | main.go:40:12:40:12 | definition of b |
-| parameter 0 | reset.go:8:1:16:1 | function declaration | reset.go:8:27:8:27 | definition of r |
-| parameter 0 | tst2.go:8:1:12:1 | function declaration | tst2.go:8:12:8:15 | definition of data |
-| parameter 0 | tst.go:8:1:11:1 | function declaration | tst.go:8:12:8:17 | definition of reader |
-| parameter 0 | tst.go:15:1:19:1 | function declaration | tst.go:15:12:15:12 | definition of x |
-| parameter 1 | main.go:5:1:11:1 | function declaration | main.go:5:20:5:20 | definition of x |
-| parameter 1 | main.go:13:1:20:1 | function declaration | main.go:13:21:13:21 | definition of x |
-| parameter 1 | tst.go:15:1:19:1 | function declaration | tst.go:15:15:15:15 | definition of y |
-| parameter 2 | main.go:5:1:11:1 | function declaration | main.go:5:27:5:27 | definition of y |
-| parameter 2 | main.go:13:1:20:1 | function declaration | main.go:13:28:13:28 | definition of y |
-| receiver | main.go:26:1:29:1 | function declaration | main.go:26:7:26:7 | definition of c |
+| parameter 0 | main.go:5:1:11:1 | function declaration | main.go:5:9:5:10 | initialization of op |
+| parameter 0 | main.go:13:1:20:1 | function declaration | main.go:13:10:13:11 | initialization of op |
+| parameter 0 | main.go:40:1:48:1 | function declaration | main.go:40:12:40:12 | initialization of b |
+| parameter 0 | reset.go:8:1:16:1 | function declaration | reset.go:8:27:8:27 | initialization of r |
+| parameter 0 | tst2.go:8:1:12:1 | function declaration | tst2.go:8:12:8:15 | initialization of data |
+| parameter 0 | tst.go:8:1:11:1 | function declaration | tst.go:8:12:8:17 | initialization of reader |
+| parameter 0 | tst.go:13:1:13:25 | function declaration | tst.go:13:12:13:13 | initialization of xs |
+| parameter 0 | tst.go:15:1:19:1 | function declaration | tst.go:15:12:15:12 | initialization of x |
+| parameter 1 | main.go:5:1:11:1 | function declaration | main.go:5:20:5:20 | initialization of x |
+| parameter 1 | main.go:13:1:20:1 | function declaration | main.go:13:21:13:21 | initialization of x |
+| parameter 1 | tst.go:15:1:19:1 | function declaration | tst.go:15:15:15:15 | initialization of y |
+| parameter 2 | main.go:5:1:11:1 | function declaration | main.go:5:27:5:27 | initialization of y |
+| parameter 2 | main.go:13:1:20:1 | function declaration | main.go:13:28:13:28 | initialization of y |
+| receiver | main.go:26:1:29:1 | function declaration | main.go:26:7:26:7 | initialization of c |


### PR DESCRIPTION
An alternative approach to https://github.com/github/codeql/pull/13664