### PR TITLE
Swift: 5.9 preparation

### DIFF
--- a/swift/extractor/infra/SwiftTagTraits.h
+++ b/swift/extractor/infra/SwiftTagTraits.h
@@ -12,6 +12,7 @@
 #include <swift/AST/Pattern.h>
 #include <swift/AST/TypeRepr.h>
 #include <swift/AST/Type.h>
+#include <swift/CodeQLSwiftVersion.h>
 
 namespace codeql {
 
@@ -25,6 +26,9 @@ namespace codeql {
   struct detail::ToTagConcreteOverride<TYPE> { \
     using type = TAG;                          \
   };
+
+#define CODEQL_SWIFT_VERSION_GE(MAJOR, MINOR) \
+  CODEQL_SWIFT_VERSION_MAJOR >= (MAJOR) && CODEQL_SWIFT_VERSION_MINOR >= (MINOR)
 
 // clang-format off
 // use indentation to recreate all involved type hierarchies
@@ -56,6 +60,9 @@ MAP(swift::Stmt, StmtTag)
   MAP(swift::FailStmt, FailStmtTag)
   MAP(swift::ThrowStmt, ThrowStmtTag)
   MAP(swift::PoundAssertStmt, PoundAssertStmtTag)
+#if CODEQL_SWIFT_VERSION_GE(5, 9)
+  MAP(swift::DiscardStmt, void) // TODO (introduced in 5.9)
+#endif
 
 MAP(swift::Argument, ArgumentTag)
 MAP(swift::KeyPathExpr::Component, KeyPathComponentTag)
@@ -95,7 +102,11 @@ MAP(swift::Expr, ExprTag)
   MAP(swift::IdentityExpr, IdentityExprTag)
     MAP(swift::ParenExpr, ParenExprTag)
     MAP(swift::DotSelfExpr, DotSelfExprTag)
-    MAP(swift::MoveExpr, void)  // TODO (introduced in 5.8)
+#if CODEQL_SWIFT_VERSION_GE(5, 9)
+    MAP(swift::BorrowExpr, void) // TODO (introduced in 5.9)
+#else
+    MAP(swift::MoveExpr, void)  // TODO (introduced in 5.8, gone in 5.9)
+#endif
     MAP(swift::AwaitExpr, AwaitExprTag)
     MAP(swift::UnresolvedMemberChainResultExpr, UnresolvedMemberChainResultExprTag)
   MAP(swift::AnyTryExpr, AnyTryExprTag)
@@ -189,6 +200,13 @@ MAP(swift::Expr, ExprTag)
   MAP(swift::TapExpr, TapExprTag)
   MAP(swift::TypeJoinExpr, void)  // TODO (introduced in 5.8)
   MAP(swift::MacroExpansionExpr, void)  // TODO (introduced in 5.8)
+#if CODEQL_SWIFT_VERSION_GE(5, 9)
+  MAP(swift::CopyExpr, void)  // TODO (introduced in 5.9)
+  MAP(swift::ConsumeExpr, void)  // TODO (introduced in 5.9)
+  MAP(swift::MaterializePackExpr, void)  // TODO (introduced in 5.9)
+  MAP(swift::SingleValueStmtExpr, void)  // TODO (introduced in 5.9)
+#endif
+
 MAP(swift::Decl, DeclTag)
   MAP(swift::ValueDecl, ValueDeclTag)
     MAP(swift::TypeDecl, TypeDeclTag)
@@ -231,6 +249,9 @@ MAP(swift::Decl, DeclTag)
     MAP(swift::PrefixOperatorDecl, PrefixOperatorDeclTag)
     MAP(swift::PostfixOperatorDecl, PostfixOperatorDeclTag)
   MAP(swift::MacroExpansionDecl, void)  // TODO (introduced in 5.8)
+#if CODEQL_SWIFT_VERSION_GE(5, 9)
+  MAP(swift::MissingDecl, void)  // TODO (introduced in 5.9)
+#endif
 
 MAP(swift::Pattern, PatternTag)
   MAP(swift::ParenPattern, ParenPatternTag)
@@ -266,6 +287,10 @@ MAP(swift::TypeBase, TypeTag)
     MAP(swift::BuiltinUnsafeValueBufferType, BuiltinUnsafeValueBufferTypeTag)
     MAP(swift::BuiltinDefaultActorStorageType, BuiltinDefaultActorStorageTypeTag)
     MAP(swift::BuiltinVectorType, BuiltinVectorTypeTag)
+#if CODEQL_SWIFT_VERSION_GE(5, 9)
+    MAP(swift::BuiltinPackIndexType, void) // TODO: (introduced in 5.9)
+    MAP(swift::BuiltinNonDefaultDistributedActorStorageType, void) // TODO: (introduced in 5.9)
+#endif
   MAP(swift::TupleType, TupleTypeTag)
   MAP(swift::ReferenceStorageType, ReferenceStorageTypeTag)
   MAP(swift::WeakStorageType, WeakStorageTypeTag)
@@ -307,6 +332,9 @@ MAP(swift::TypeBase, TypeTag)
   MAP(swift::SILBoxType, void)  // SIL types cannot really appear in the frontend run)
   MAP(swift::SILMoveOnlyWrappedType, void)  // SIL types cannot really appear in the frontend run)
   MAP(swift::SILTokenType, void)  // SIL types cannot really appear in the frontend run)
+#if CODEQL_SWIFT_VERSION_GE(5, 9)
+  MAP(swift::SILPackType, void)  // TODO: (introduced in 5.9)
+#endif
   MAP(swift::ProtocolCompositionType, ProtocolCompositionTypeTag)
   MAP(swift::ParameterizedProtocolType, ParameterizedProtocolTypeTag)
   MAP(swift::ExistentialType, ExistentialTypeTag)
@@ -314,6 +342,9 @@ MAP(swift::TypeBase, TypeTag)
   MAP(swift::InOutType, InOutTypeTag)
   MAP(swift::PackType, void)  // experimental variadic generics
   MAP(swift::PackExpansionType, void)  // experimental variadic generics
+#if CODEQL_SWIFT_VERSION_GE(5, 9)
+  MAP(swift::PackElementType, void) // TODO: (introduced in 5.9)
+#endif
   MAP(swift::TypeVariableType, void)  // created during type checking and only used for constraint checking
   MAP(swift::SugarType, SugarTypeTag)
     MAP(swift::ParenType, ParenTypeTag)

--- a/swift/third_party/load.bzl
+++ b/swift/third_party/load.bzl
@@ -4,11 +4,11 @@ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 # TODO: remove `remove-result-of.patch` once we update to a Swift version containing
 # https://github.com/apple/swift/commit/2ed2cea2
 # (probably when updating to 5.9)
-_swift_prebuilt_version = "swift-5.8.1-RELEASE.212"
+_swift_prebuilt_version = "swift-5.8.1-RELEASE.214"
 _swift_sha_map = {
-    "Linux-X64": "3e902cc9dbf02129f6bcac84902524a235df0e36d30f3ac54e642b64d3f95a2b",
-    "macOS-ARM64": "4d93f326bd8a41c89bcf593676407fab2dd84b665f6bfb7ab667a9673084bcda",
-    "macOS-X64": "988cd193a0590abd282d8d8f3ec2489583d3d2b34162a4e91208fb91e5fb5981",
+    "Linux-X64": "009594131d2f6327e0033c4b7b0479a5730427575eb59a81a439fe0e343aa777",
+    "macOS-ARM64": "304a918e3699d404f57e967eff79b982388d8c5330c2135272c9f3a825920a39",
+    "macOS-X64": "c763c493e5782869b54887dc72df2aad00d59af7272c6d96377f1debb98741f2",
 }
 
 _swift_arch_map = {


### PR DESCRIPTION
The prebuild binary change adds `CodeQLSwiftVersion.h` header, see https://github.com/dsp-testing/codeql-swift-artifacts/pull/18