### PR TITLE
C#: Use `nuget.config` file for `dotnet restore` fallback logic

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp.Standalone/DotNet.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.Standalone/DotNet.cs
@@ -45,9 +45,11 @@ namespace Semmle.BuildAnalyser
             return true;
         }
 
-        public bool RestoreToDirectory(string projectOrSolutionFile, string packageDirectory)
+        public bool RestoreToDirectory(string projectOrSolutionFile, string packageDirectory, string? pathToNugetConfig = null)
         {
             var args = $"restore --no-dependencies \"{projectOrSolutionFile}\" --packages \"{packageDirectory}\" /p:DisableImplicitNuGetFallbackFolder=true";
+            if (pathToNugetConfig != null)
+                args += $" --configfile \"{pathToNugetConfig}\"";
             return RunCommand(args);
         }
 

--- a/csharp/extractor/Semmle.Extraction.CSharp.Standalone/ProgressMonitor.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.Standalone/ProgressMonitor.cs
@@ -118,5 +118,15 @@ namespace Semmle.BuildAnalyser
             logger.Log(Severity.Info, $"Failed to read file {file}");
             logger.Log(Severity.Debug, $"Failed to read file {file}, exception: {ex}");
         }
+
+        public void MultipleNugetConfig(string[] nugetConfigs)
+        {
+            logger.Log(Severity.Info, $"Found multiple nuget.config files: {string.Join(", ", nugetConfigs)}.");
+        }
+
+        internal void NoTopLevelNugetConfig()
+        {
+            logger.Log(Severity.Info, $"Could not find a top-level nuget.config file.");
+        }
     }
 }


### PR DESCRIPTION
The PR takes into account the `nuget.config` file in the repo, when doing `dotnet restore` on individual packages. If there are multiple `nuget.config` files, we're looking for one in the root folder.

On `dotnet/wcf`, this change helps restore 3 out of the 7 previously not restored packages. 