### PR TITLE
DataFlow: Add default implementations of isBarrier/2 and isAddiitonalFlowStep/4

### DIFF
--- a/cpp/ql/lib/change-notes/2023-07-12-default-stateconfigsig-predicates.md
+++ b/cpp/ql/lib/change-notes/2023-07-12-default-stateconfigsig-predicates.md
@@ -1,0 +1,6 @@
+---
+category: feature
+---
+* The `DataFlow::StateConfigSig` signature module has gained default implementations for `isBarrier/2` and `isAdditionalFlowStep/4`. 
+  Hence it is no longer needed to provide `none()` implementations of these predicates if they are not needed.
+  

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlow.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlow.qll
@@ -131,7 +131,9 @@ signature module StateConfigSig {
    * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
-  predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2);
+  default predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {
+    none()
+  }
 
   /**
    * Holds if an arbitrary number of implicit read steps of content `c` may be

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlow.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlow.qll
@@ -114,7 +114,7 @@ signature module StateConfigSig {
    * Holds if data flow through `node` is prohibited when the flow state is
    * `state`.
    */
-  predicate isBarrier(Node node, FlowState state);
+  default predicate isBarrier(Node node, FlowState state) { none() }
 
   /** Holds if data flow into `node` is prohibited. */
   default predicate isBarrierIn(Node node) { none() }

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlow.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlow.qll
@@ -131,7 +131,9 @@ signature module StateConfigSig {
    * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
-  predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2);
+  default predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {
+    none()
+  }
 
   /**
    * Holds if an arbitrary number of implicit read steps of content `c` may be

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlow.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlow.qll
@@ -114,7 +114,7 @@ signature module StateConfigSig {
    * Holds if data flow through `node` is prohibited when the flow state is
    * `state`.
    */
-  predicate isBarrier(Node node, FlowState state);
+  default predicate isBarrier(Node node, FlowState state) { none() }
 
   /** Holds if data flow into `node` is prohibited. */
   default predicate isBarrierIn(Node node) { none() }

--- a/csharp/ql/lib/change-notes/2023-07-12-default-stateconfigsig-predicates.md
+++ b/csharp/ql/lib/change-notes/2023-07-12-default-stateconfigsig-predicates.md
@@ -1,0 +1,6 @@
+---
+category: feature
+---
+* The `DataFlow::StateConfigSig` signature module has gained default implementations for `isBarrier/2` and `isAdditionalFlowStep/4`. 
+  Hence it is no longer needed to provide `none()` implementations of these predicates if they are not needed.
+  

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlow.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlow.qll
@@ -131,7 +131,9 @@ signature module StateConfigSig {
    * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
-  predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2);
+  default predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {
+    none()
+  }
 
   /**
    * Holds if an arbitrary number of implicit read steps of content `c` may be

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlow.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlow.qll
@@ -114,7 +114,7 @@ signature module StateConfigSig {
    * Holds if data flow through `node` is prohibited when the flow state is
    * `state`.
    */
-  predicate isBarrier(Node node, FlowState state);
+  default predicate isBarrier(Node node, FlowState state) { none() }
 
   /** Holds if data flow into `node` is prohibited. */
   default predicate isBarrierIn(Node node) { none() }

--- a/go/ql/lib/change-notes/2023-07-12-default-stateconfigsig-predicates.md
+++ b/go/ql/lib/change-notes/2023-07-12-default-stateconfigsig-predicates.md
@@ -1,0 +1,6 @@
+---
+category: feature
+---
+* The `DataFlow::StateConfigSig` signature module has gained default implementations for `isBarrier/2` and `isAdditionalFlowStep/4`. 
+  Hence it is no longer needed to provide `none()` implementations of these predicates if they are not needed.
+  

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlow.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlow.qll
@@ -131,7 +131,9 @@ signature module StateConfigSig {
    * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
-  predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2);
+  default predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {
+    none()
+  }
 
   /**
    * Holds if an arbitrary number of implicit read steps of content `c` may be

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlow.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlow.qll
@@ -114,7 +114,7 @@ signature module StateConfigSig {
    * Holds if data flow through `node` is prohibited when the flow state is
    * `state`.
    */
-  predicate isBarrier(Node node, FlowState state);
+  default predicate isBarrier(Node node, FlowState state) { none() }
 
   /** Holds if data flow into `node` is prohibited. */
   default predicate isBarrierIn(Node node) { none() }

--- a/java/ql/lib/change-notes/2023-07-12-default-stateconfigsig-predicates.md
+++ b/java/ql/lib/change-notes/2023-07-12-default-stateconfigsig-predicates.md
@@ -1,0 +1,6 @@
+---
+category: feature
+---
+* The `DataFlow::StateConfigSig` signature module has gained default implementations for `isBarrier/2` and `isAdditionalFlowStep/4`. 
+  Hence it is no longer needed to provide `none()` implementations of these predicates if they are not needed.
+  

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlow.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlow.qll
@@ -131,7 +131,9 @@ signature module StateConfigSig {
    * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
-  predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2);
+  default predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {
+    none()
+  }
 
   /**
    * Holds if an arbitrary number of implicit read steps of content `c` may be

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlow.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlow.qll
@@ -114,7 +114,7 @@ signature module StateConfigSig {
    * Holds if data flow through `node` is prohibited when the flow state is
    * `state`.
    */
-  predicate isBarrier(Node node, FlowState state);
+  default predicate isBarrier(Node node, FlowState state) { none() }
 
   /** Holds if data flow into `node` is prohibited. */
   default predicate isBarrierIn(Node node) { none() }

--- a/python/ql/lib/change-notes/2023-07-12-default-stateconfigsig-predicates.md
+++ b/python/ql/lib/change-notes/2023-07-12-default-stateconfigsig-predicates.md
@@ -1,0 +1,6 @@
+---
+category: feature
+---
+* The `DataFlow::StateConfigSig` signature module has gained default implementations for `isBarrier/2` and `isAdditionalFlowStep/4`. 
+  Hence it is no longer needed to provide `none()` implementations of these predicates if they are not needed.
+  

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlow.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlow.qll
@@ -131,7 +131,9 @@ signature module StateConfigSig {
    * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
-  predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2);
+  default predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {
+    none()
+  }
 
   /**
    * Holds if an arbitrary number of implicit read steps of content `c` may be

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlow.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlow.qll
@@ -114,7 +114,7 @@ signature module StateConfigSig {
    * Holds if data flow through `node` is prohibited when the flow state is
    * `state`.
    */
-  predicate isBarrier(Node node, FlowState state);
+  default predicate isBarrier(Node node, FlowState state) { none() }
 
   /** Holds if data flow into `node` is prohibited. */
   default predicate isBarrierIn(Node node) { none() }

--- a/ruby/ql/lib/change-notes/2023-07-12-default-stateconfigsig-predicates.md
+++ b/ruby/ql/lib/change-notes/2023-07-12-default-stateconfigsig-predicates.md
@@ -1,0 +1,6 @@
+---
+category: feature
+---
+* The `DataFlow::StateConfigSig` signature module has gained default implementations for `isBarrier/2` and `isAdditionalFlowStep/4`. 
+  Hence it is no longer needed to provide `none()` implementations of these predicates if they are not needed.
+  

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlow.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlow.qll
@@ -131,7 +131,9 @@ signature module StateConfigSig {
    * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
-  predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2);
+  default predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {
+    none()
+  }
 
   /**
    * Holds if an arbitrary number of implicit read steps of content `c` may be

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlow.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlow.qll
@@ -114,7 +114,7 @@ signature module StateConfigSig {
    * Holds if data flow through `node` is prohibited when the flow state is
    * `state`.
    */
-  predicate isBarrier(Node node, FlowState state);
+  default predicate isBarrier(Node node, FlowState state) { none() }
 
   /** Holds if data flow into `node` is prohibited. */
   default predicate isBarrierIn(Node node) { none() }

--- a/swift/ql/lib/change-notes/2023-07-12-default-stateconfigsig-predicates.md
+++ b/swift/ql/lib/change-notes/2023-07-12-default-stateconfigsig-predicates.md
@@ -1,0 +1,6 @@
+---
+category: feature
+---
+* The `DataFlow::StateConfigSig` signature module has gained default implementations for `isBarrier/2` and `isAdditionalFlowStep/4`. 
+  Hence it is no longer needed to provide `none()` implementations of these predicates if they are not needed.
+  

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlow.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlow.qll
@@ -131,7 +131,9 @@ signature module StateConfigSig {
    * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
-  predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2);
+  default predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {
+    none()
+  }
 
   /**
    * Holds if an arbitrary number of implicit read steps of content `c` may be

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlow.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlow.qll
@@ -114,7 +114,7 @@ signature module StateConfigSig {
    * Holds if data flow through `node` is prohibited when the flow state is
    * `state`.
    */
-  predicate isBarrier(Node node, FlowState state);
+  default predicate isBarrier(Node node, FlowState state) { none() }
 
   /** Holds if data flow into `node` is prohibited. */
   default predicate isBarrierIn(Node node) { none() }


### PR DESCRIPTION
Adds default implementations of the `isBarrier/2` and `isAdditionalFlowStep/4` predicates of `StateConfigSig` in the DataFlow library.

CodeQL now supports default predicates that use parameters in module signatures. Previously this was not supported and it was necessary to add default implementations to modules implementing `StateConfigSig` manually.