### PR TITLE
Swift: remove FallthroughStmt assertion

### DIFF
--- a/swift/third_party/load.bzl
+++ b/swift/third_party/load.bzl
@@ -49,6 +49,7 @@ def load_dependencies(workspace_name):
                     "remove-result-of",
                     "remove-redundant-operators",
                     "add-constructor-to-Compilation",
+                    "remove-fallthrough-assertion",
                 )
             ],
         )

--- a/swift/third_party/swift-llvm-support/patches/remove-fallthrough-assertion.patch
+++ b/swift/third_party/swift-llvm-support/patches/remove-fallthrough-assertion.patch
@@ -1,0 +1,12 @@
+diff --git a/include/swift/AST/Stmt.h b/include/swift/AST/Stmt.h
+index 56f8769a502..4d1ea5f84c1 100644
+--- a/include/swift/AST/Stmt.h
++++ b/include/swift/AST/Stmt.h
+@@ -1049,7 +1049,6 @@ public:
+   /// Get the CaseStmt block to which the fallthrough transfers control.
+   /// Set during Sema.
+   CaseStmt *getFallthroughDest() const {
+-    assert(FallthroughDest && "fallthrough dest is not set until Sema");
+     return FallthroughDest;
+   }
+   void setFallthroughDest(CaseStmt *C) {


### PR DESCRIPTION
The extractor hits this one in case of errors/malformed AST.