### PR TITLE
JS: Recognize 'fs/promises' alias and handle spread arguments in path.join()

### DIFF
--- a/javascript/ql/lib/semmle/javascript/frameworks/NodeJSLib.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/NodeJSLib.qll
@@ -554,7 +554,11 @@ module NodeJSLib {
       t.start()
       or
       t.start() and
-      result = DataFlow::moduleMember("fs", "promises")
+      (
+        result = DataFlow::moduleMember("fs", "promises")
+        or
+        result = DataFlow::moduleImport("fs/promises")
+      )
       or
       exists(DataFlow::TypeTracker t2, DataFlow::SourceNode pred | pred = fsModule(t2) |
         result = pred.track(t2, t)

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/TaintedPathCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/TaintedPathCustomizations.qll
@@ -847,6 +847,22 @@ module TaintedPath {
       dst = call and
       srclabel = dstlabel
     )
+    or
+    exists(DataFlow::CallNode join |
+      // path.join() with spread argument
+      join = NodeJSLib::Path::moduleMember("join").getACall() and
+      src = join.getASpreadArgument() and
+      dst = join and
+      (
+        srclabel.(Label::PosixPath).canContainDotDotSlash()
+        or
+        srclabel instanceof Label::SplitPath
+      ) and
+      dstlabel.(Label::PosixPath).isNormalized() and
+      if isRelative(join.getArgument(0).getStringValue())
+      then dstlabel.(Label::PosixPath).isRelative()
+      else dstlabel.(Label::PosixPath).isAbsolute()
+    )
   }
 
   /**

--- a/javascript/ql/src/change-notes/2023-07-10-path-join-spread.md
+++ b/javascript/ql/src/change-notes/2023-07-10-path-join-spread.md
@@ -1,0 +1,5 @@
+---
+category: minorAnalysis
+---
+* The `fs/promises` package is now recognised as an alias for `require('fs').promises`.
+* The `js/path-injection` query can now track taint through calls to `path.join()` with a spread argument, such as `path.join(baseDir, ...args)`.

--- a/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/TaintedPath.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/TaintedPath.expected
@@ -2163,6 +2163,28 @@ nodes
 | normalizedPaths.js:399:21:399:24 | path |
 | normalizedPaths.js:399:21:399:24 | path |
 | normalizedPaths.js:399:21:399:24 | path |
+| normalizedPaths.js:407:19:407:67 | pathMod ... t('/')) |
+| normalizedPaths.js:407:19:407:67 | pathMod ... t('/')) |
+| normalizedPaths.js:407:19:407:67 | pathMod ... t('/')) |
+| normalizedPaths.js:407:19:407:67 | pathMod ... t('/')) |
+| normalizedPaths.js:407:45:407:55 | req.query.x |
+| normalizedPaths.js:407:45:407:55 | req.query.x |
+| normalizedPaths.js:407:45:407:55 | req.query.x |
+| normalizedPaths.js:407:45:407:55 | req.query.x |
+| normalizedPaths.js:407:45:407:66 | req.que ... it('/') |
+| normalizedPaths.js:407:45:407:66 | req.que ... it('/') |
+| normalizedPaths.js:407:45:407:66 | req.que ... it('/') |
+| normalizedPaths.js:408:19:408:60 | pathMod ... t('/')) |
+| normalizedPaths.js:408:19:408:60 | pathMod ... t('/')) |
+| normalizedPaths.js:408:19:408:60 | pathMod ... t('/')) |
+| normalizedPaths.js:408:19:408:60 | pathMod ... t('/')) |
+| normalizedPaths.js:408:38:408:48 | req.query.x |
+| normalizedPaths.js:408:38:408:48 | req.query.x |
+| normalizedPaths.js:408:38:408:48 | req.query.x |
+| normalizedPaths.js:408:38:408:48 | req.query.x |
+| normalizedPaths.js:408:38:408:59 | req.que ... it('/') |
+| normalizedPaths.js:408:38:408:59 | req.que ... it('/') |
+| normalizedPaths.js:408:38:408:59 | req.que ... it('/') |
 | other-fs-libraries.js:9:7:9:48 | path |
 | other-fs-libraries.js:9:7:9:48 | path |
 | other-fs-libraries.js:9:7:9:48 | path |
@@ -7350,6 +7372,30 @@ edges
 | normalizedPaths.js:385:35:385:45 | req.query.x | normalizedPaths.js:385:14:385:46 | pathMod ... uery.x) |
 | normalizedPaths.js:385:35:385:45 | req.query.x | normalizedPaths.js:385:14:385:46 | pathMod ... uery.x) |
 | normalizedPaths.js:385:35:385:45 | req.query.x | normalizedPaths.js:385:14:385:46 | pathMod ... uery.x) |
+| normalizedPaths.js:407:45:407:55 | req.query.x | normalizedPaths.js:407:45:407:66 | req.que ... it('/') |
+| normalizedPaths.js:407:45:407:55 | req.query.x | normalizedPaths.js:407:45:407:66 | req.que ... it('/') |
+| normalizedPaths.js:407:45:407:55 | req.query.x | normalizedPaths.js:407:45:407:66 | req.que ... it('/') |
+| normalizedPaths.js:407:45:407:55 | req.query.x | normalizedPaths.js:407:45:407:66 | req.que ... it('/') |
+| normalizedPaths.js:407:45:407:55 | req.query.x | normalizedPaths.js:407:45:407:66 | req.que ... it('/') |
+| normalizedPaths.js:407:45:407:55 | req.query.x | normalizedPaths.js:407:45:407:66 | req.que ... it('/') |
+| normalizedPaths.js:407:45:407:66 | req.que ... it('/') | normalizedPaths.js:407:19:407:67 | pathMod ... t('/')) |
+| normalizedPaths.js:407:45:407:66 | req.que ... it('/') | normalizedPaths.js:407:19:407:67 | pathMod ... t('/')) |
+| normalizedPaths.js:407:45:407:66 | req.que ... it('/') | normalizedPaths.js:407:19:407:67 | pathMod ... t('/')) |
+| normalizedPaths.js:407:45:407:66 | req.que ... it('/') | normalizedPaths.js:407:19:407:67 | pathMod ... t('/')) |
+| normalizedPaths.js:407:45:407:66 | req.que ... it('/') | normalizedPaths.js:407:19:407:67 | pathMod ... t('/')) |
+| normalizedPaths.js:407:45:407:66 | req.que ... it('/') | normalizedPaths.js:407:19:407:67 | pathMod ... t('/')) |
+| normalizedPaths.js:408:38:408:48 | req.query.x | normalizedPaths.js:408:38:408:59 | req.que ... it('/') |
+| normalizedPaths.js:408:38:408:48 | req.query.x | normalizedPaths.js:408:38:408:59 | req.que ... it('/') |
+| normalizedPaths.js:408:38:408:48 | req.query.x | normalizedPaths.js:408:38:408:59 | req.que ... it('/') |
+| normalizedPaths.js:408:38:408:48 | req.query.x | normalizedPaths.js:408:38:408:59 | req.que ... it('/') |
+| normalizedPaths.js:408:38:408:48 | req.query.x | normalizedPaths.js:408:38:408:59 | req.que ... it('/') |
+| normalizedPaths.js:408:38:408:48 | req.query.x | normalizedPaths.js:408:38:408:59 | req.que ... it('/') |
+| normalizedPaths.js:408:38:408:59 | req.que ... it('/') | normalizedPaths.js:408:19:408:60 | pathMod ... t('/')) |
+| normalizedPaths.js:408:38:408:59 | req.que ... it('/') | normalizedPaths.js:408:19:408:60 | pathMod ... t('/')) |
+| normalizedPaths.js:408:38:408:59 | req.que ... it('/') | normalizedPaths.js:408:19:408:60 | pathMod ... t('/')) |
+| normalizedPaths.js:408:38:408:59 | req.que ... it('/') | normalizedPaths.js:408:19:408:60 | pathMod ... t('/')) |
+| normalizedPaths.js:408:38:408:59 | req.que ... it('/') | normalizedPaths.js:408:19:408:60 | pathMod ... t('/')) |
+| normalizedPaths.js:408:38:408:59 | req.que ... it('/') | normalizedPaths.js:408:19:408:60 | pathMod ... t('/')) |
 | other-fs-libraries.js:9:7:9:48 | path | other-fs-libraries.js:11:19:11:22 | path |
 | other-fs-libraries.js:9:7:9:48 | path | other-fs-libraries.js:11:19:11:22 | path |
 | other-fs-libraries.js:9:7:9:48 | path | other-fs-libraries.js:11:19:11:22 | path |
@@ -10363,6 +10409,8 @@ edges
 | normalizedPaths.js:381:19:381:29 | slash(path) | normalizedPaths.js:377:14:377:27 | req.query.path | normalizedPaths.js:381:19:381:29 | slash(path) | This path depends on a $@. | normalizedPaths.js:377:14:377:27 | req.query.path | user-provided value |
 | normalizedPaths.js:388:19:388:22 | path | normalizedPaths.js:385:35:385:45 | req.query.x | normalizedPaths.js:388:19:388:22 | path | This path depends on a $@. | normalizedPaths.js:385:35:385:45 | req.query.x | user-provided value |
 | normalizedPaths.js:399:21:399:24 | path | normalizedPaths.js:385:35:385:45 | req.query.x | normalizedPaths.js:399:21:399:24 | path | This path depends on a $@. | normalizedPaths.js:385:35:385:45 | req.query.x | user-provided value |
+| normalizedPaths.js:407:19:407:67 | pathMod ... t('/')) | normalizedPaths.js:407:45:407:55 | req.query.x | normalizedPaths.js:407:19:407:67 | pathMod ... t('/')) | This path depends on a $@. | normalizedPaths.js:407:45:407:55 | req.query.x | user-provided value |
+| normalizedPaths.js:408:19:408:60 | pathMod ... t('/')) | normalizedPaths.js:408:38:408:48 | req.query.x | normalizedPaths.js:408:19:408:60 | pathMod ... t('/')) | This path depends on a $@. | normalizedPaths.js:408:38:408:48 | req.query.x | user-provided value |
 | other-fs-libraries.js:11:19:11:22 | path | other-fs-libraries.js:9:24:9:30 | req.url | other-fs-libraries.js:11:19:11:22 | path | This path depends on a $@. | other-fs-libraries.js:9:24:9:30 | req.url | user-provided value |
 | other-fs-libraries.js:12:27:12:30 | path | other-fs-libraries.js:9:24:9:30 | req.url | other-fs-libraries.js:12:27:12:30 | path | This path depends on a $@. | other-fs-libraries.js:9:24:9:30 | req.url | user-provided value |
 | other-fs-libraries.js:13:24:13:27 | path | other-fs-libraries.js:9:24:9:30 | req.url | other-fs-libraries.js:13:24:13:27 | path | This path depends on a $@. | other-fs-libraries.js:9:24:9:30 | req.url | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/TaintedPath.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/TaintedPath.expected
@@ -2813,6 +2813,92 @@ nodes
 | other-fs-libraries.js:72:15:72:18 | path |
 | other-fs-libraries.js:72:15:72:18 | path |
 | other-fs-libraries.js:72:15:72:18 | path |
+| other-fs-libraries.js:77:7:77:48 | path |
+| other-fs-libraries.js:77:7:77:48 | path |
+| other-fs-libraries.js:77:7:77:48 | path |
+| other-fs-libraries.js:77:7:77:48 | path |
+| other-fs-libraries.js:77:7:77:48 | path |
+| other-fs-libraries.js:77:7:77:48 | path |
+| other-fs-libraries.js:77:7:77:48 | path |
+| other-fs-libraries.js:77:7:77:48 | path |
+| other-fs-libraries.js:77:7:77:48 | path |
+| other-fs-libraries.js:77:7:77:48 | path |
+| other-fs-libraries.js:77:7:77:48 | path |
+| other-fs-libraries.js:77:7:77:48 | path |
+| other-fs-libraries.js:77:7:77:48 | path |
+| other-fs-libraries.js:77:7:77:48 | path |
+| other-fs-libraries.js:77:7:77:48 | path |
+| other-fs-libraries.js:77:7:77:48 | path |
+| other-fs-libraries.js:77:14:77:37 | url.par ... , true) |
+| other-fs-libraries.js:77:14:77:37 | url.par ... , true) |
+| other-fs-libraries.js:77:14:77:37 | url.par ... , true) |
+| other-fs-libraries.js:77:14:77:37 | url.par ... , true) |
+| other-fs-libraries.js:77:14:77:37 | url.par ... , true) |
+| other-fs-libraries.js:77:14:77:37 | url.par ... , true) |
+| other-fs-libraries.js:77:14:77:37 | url.par ... , true) |
+| other-fs-libraries.js:77:14:77:37 | url.par ... , true) |
+| other-fs-libraries.js:77:14:77:37 | url.par ... , true) |
+| other-fs-libraries.js:77:14:77:37 | url.par ... , true) |
+| other-fs-libraries.js:77:14:77:37 | url.par ... , true) |
+| other-fs-libraries.js:77:14:77:37 | url.par ... , true) |
+| other-fs-libraries.js:77:14:77:37 | url.par ... , true) |
+| other-fs-libraries.js:77:14:77:37 | url.par ... , true) |
+| other-fs-libraries.js:77:14:77:37 | url.par ... , true) |
+| other-fs-libraries.js:77:14:77:37 | url.par ... , true) |
+| other-fs-libraries.js:77:14:77:43 | url.par ... ).query |
+| other-fs-libraries.js:77:14:77:43 | url.par ... ).query |
+| other-fs-libraries.js:77:14:77:43 | url.par ... ).query |
+| other-fs-libraries.js:77:14:77:43 | url.par ... ).query |
+| other-fs-libraries.js:77:14:77:43 | url.par ... ).query |
+| other-fs-libraries.js:77:14:77:43 | url.par ... ).query |
+| other-fs-libraries.js:77:14:77:43 | url.par ... ).query |
+| other-fs-libraries.js:77:14:77:43 | url.par ... ).query |
+| other-fs-libraries.js:77:14:77:43 | url.par ... ).query |
+| other-fs-libraries.js:77:14:77:43 | url.par ... ).query |
+| other-fs-libraries.js:77:14:77:43 | url.par ... ).query |
+| other-fs-libraries.js:77:14:77:43 | url.par ... ).query |
+| other-fs-libraries.js:77:14:77:43 | url.par ... ).query |
+| other-fs-libraries.js:77:14:77:43 | url.par ... ).query |
+| other-fs-libraries.js:77:14:77:43 | url.par ... ).query |
+| other-fs-libraries.js:77:14:77:43 | url.par ... ).query |
+| other-fs-libraries.js:77:14:77:48 | url.par ... ry.path |
+| other-fs-libraries.js:77:14:77:48 | url.par ... ry.path |
+| other-fs-libraries.js:77:14:77:48 | url.par ... ry.path |
+| other-fs-libraries.js:77:14:77:48 | url.par ... ry.path |
+| other-fs-libraries.js:77:14:77:48 | url.par ... ry.path |
+| other-fs-libraries.js:77:14:77:48 | url.par ... ry.path |
+| other-fs-libraries.js:77:14:77:48 | url.par ... ry.path |
+| other-fs-libraries.js:77:14:77:48 | url.par ... ry.path |
+| other-fs-libraries.js:77:14:77:48 | url.par ... ry.path |
+| other-fs-libraries.js:77:14:77:48 | url.par ... ry.path |
+| other-fs-libraries.js:77:14:77:48 | url.par ... ry.path |
+| other-fs-libraries.js:77:14:77:48 | url.par ... ry.path |
+| other-fs-libraries.js:77:14:77:48 | url.par ... ry.path |
+| other-fs-libraries.js:77:14:77:48 | url.par ... ry.path |
+| other-fs-libraries.js:77:14:77:48 | url.par ... ry.path |
+| other-fs-libraries.js:77:14:77:48 | url.par ... ry.path |
+| other-fs-libraries.js:77:24:77:30 | req.url |
+| other-fs-libraries.js:77:24:77:30 | req.url |
+| other-fs-libraries.js:77:24:77:30 | req.url |
+| other-fs-libraries.js:77:24:77:30 | req.url |
+| other-fs-libraries.js:77:24:77:30 | req.url |
+| other-fs-libraries.js:79:16:79:19 | path |
+| other-fs-libraries.js:79:16:79:19 | path |
+| other-fs-libraries.js:79:16:79:19 | path |
+| other-fs-libraries.js:79:16:79:19 | path |
+| other-fs-libraries.js:79:16:79:19 | path |
+| other-fs-libraries.js:79:16:79:19 | path |
+| other-fs-libraries.js:79:16:79:19 | path |
+| other-fs-libraries.js:79:16:79:19 | path |
+| other-fs-libraries.js:79:16:79:19 | path |
+| other-fs-libraries.js:79:16:79:19 | path |
+| other-fs-libraries.js:79:16:79:19 | path |
+| other-fs-libraries.js:79:16:79:19 | path |
+| other-fs-libraries.js:79:16:79:19 | path |
+| other-fs-libraries.js:79:16:79:19 | path |
+| other-fs-libraries.js:79:16:79:19 | path |
+| other-fs-libraries.js:79:16:79:19 | path |
+| other-fs-libraries.js:79:16:79:19 | path |
 | prettier.js:6:11:6:28 | p |
 | prettier.js:6:11:6:28 | p |
 | prettier.js:6:11:6:28 | p |
@@ -8288,6 +8374,118 @@ edges
 | other-fs-libraries.js:68:24:68:30 | req.url | other-fs-libraries.js:68:14:68:37 | url.par ... , true) |
 | other-fs-libraries.js:68:24:68:30 | req.url | other-fs-libraries.js:68:14:68:37 | url.par ... , true) |
 | other-fs-libraries.js:68:24:68:30 | req.url | other-fs-libraries.js:68:14:68:37 | url.par ... , true) |
+| other-fs-libraries.js:77:7:77:48 | path | other-fs-libraries.js:79:16:79:19 | path |
+| other-fs-libraries.js:77:7:77:48 | path | other-fs-libraries.js:79:16:79:19 | path |
+| other-fs-libraries.js:77:7:77:48 | path | other-fs-libraries.js:79:16:79:19 | path |
+| other-fs-libraries.js:77:7:77:48 | path | other-fs-libraries.js:79:16:79:19 | path |
+| other-fs-libraries.js:77:7:77:48 | path | other-fs-libraries.js:79:16:79:19 | path |
+| other-fs-libraries.js:77:7:77:48 | path | other-fs-libraries.js:79:16:79:19 | path |
+| other-fs-libraries.js:77:7:77:48 | path | other-fs-libraries.js:79:16:79:19 | path |
+| other-fs-libraries.js:77:7:77:48 | path | other-fs-libraries.js:79:16:79:19 | path |
+| other-fs-libraries.js:77:7:77:48 | path | other-fs-libraries.js:79:16:79:19 | path |
+| other-fs-libraries.js:77:7:77:48 | path | other-fs-libraries.js:79:16:79:19 | path |
+| other-fs-libraries.js:77:7:77:48 | path | other-fs-libraries.js:79:16:79:19 | path |
+| other-fs-libraries.js:77:7:77:48 | path | other-fs-libraries.js:79:16:79:19 | path |
+| other-fs-libraries.js:77:7:77:48 | path | other-fs-libraries.js:79:16:79:19 | path |
+| other-fs-libraries.js:77:7:77:48 | path | other-fs-libraries.js:79:16:79:19 | path |
+| other-fs-libraries.js:77:7:77:48 | path | other-fs-libraries.js:79:16:79:19 | path |
+| other-fs-libraries.js:77:7:77:48 | path | other-fs-libraries.js:79:16:79:19 | path |
+| other-fs-libraries.js:77:7:77:48 | path | other-fs-libraries.js:79:16:79:19 | path |
+| other-fs-libraries.js:77:7:77:48 | path | other-fs-libraries.js:79:16:79:19 | path |
+| other-fs-libraries.js:77:7:77:48 | path | other-fs-libraries.js:79:16:79:19 | path |
+| other-fs-libraries.js:77:7:77:48 | path | other-fs-libraries.js:79:16:79:19 | path |
+| other-fs-libraries.js:77:7:77:48 | path | other-fs-libraries.js:79:16:79:19 | path |
+| other-fs-libraries.js:77:7:77:48 | path | other-fs-libraries.js:79:16:79:19 | path |
+| other-fs-libraries.js:77:7:77:48 | path | other-fs-libraries.js:79:16:79:19 | path |
+| other-fs-libraries.js:77:7:77:48 | path | other-fs-libraries.js:79:16:79:19 | path |
+| other-fs-libraries.js:77:7:77:48 | path | other-fs-libraries.js:79:16:79:19 | path |
+| other-fs-libraries.js:77:7:77:48 | path | other-fs-libraries.js:79:16:79:19 | path |
+| other-fs-libraries.js:77:7:77:48 | path | other-fs-libraries.js:79:16:79:19 | path |
+| other-fs-libraries.js:77:7:77:48 | path | other-fs-libraries.js:79:16:79:19 | path |
+| other-fs-libraries.js:77:7:77:48 | path | other-fs-libraries.js:79:16:79:19 | path |
+| other-fs-libraries.js:77:7:77:48 | path | other-fs-libraries.js:79:16:79:19 | path |
+| other-fs-libraries.js:77:7:77:48 | path | other-fs-libraries.js:79:16:79:19 | path |
+| other-fs-libraries.js:77:7:77:48 | path | other-fs-libraries.js:79:16:79:19 | path |
+| other-fs-libraries.js:77:14:77:37 | url.par ... , true) | other-fs-libraries.js:77:14:77:43 | url.par ... ).query |
+| other-fs-libraries.js:77:14:77:37 | url.par ... , true) | other-fs-libraries.js:77:14:77:43 | url.par ... ).query |
+| other-fs-libraries.js:77:14:77:37 | url.par ... , true) | other-fs-libraries.js:77:14:77:43 | url.par ... ).query |
+| other-fs-libraries.js:77:14:77:37 | url.par ... , true) | other-fs-libraries.js:77:14:77:43 | url.par ... ).query |
+| other-fs-libraries.js:77:14:77:37 | url.par ... , true) | other-fs-libraries.js:77:14:77:43 | url.par ... ).query |
+| other-fs-libraries.js:77:14:77:37 | url.par ... , true) | other-fs-libraries.js:77:14:77:43 | url.par ... ).query |
+| other-fs-libraries.js:77:14:77:37 | url.par ... , true) | other-fs-libraries.js:77:14:77:43 | url.par ... ).query |
+| other-fs-libraries.js:77:14:77:37 | url.par ... , true) | other-fs-libraries.js:77:14:77:43 | url.par ... ).query |
+| other-fs-libraries.js:77:14:77:37 | url.par ... , true) | other-fs-libraries.js:77:14:77:43 | url.par ... ).query |
+| other-fs-libraries.js:77:14:77:37 | url.par ... , true) | other-fs-libraries.js:77:14:77:43 | url.par ... ).query |
+| other-fs-libraries.js:77:14:77:37 | url.par ... , true) | other-fs-libraries.js:77:14:77:43 | url.par ... ).query |
+| other-fs-libraries.js:77:14:77:37 | url.par ... , true) | other-fs-libraries.js:77:14:77:43 | url.par ... ).query |
+| other-fs-libraries.js:77:14:77:37 | url.par ... , true) | other-fs-libraries.js:77:14:77:43 | url.par ... ).query |
+| other-fs-libraries.js:77:14:77:37 | url.par ... , true) | other-fs-libraries.js:77:14:77:43 | url.par ... ).query |
+| other-fs-libraries.js:77:14:77:37 | url.par ... , true) | other-fs-libraries.js:77:14:77:43 | url.par ... ).query |
+| other-fs-libraries.js:77:14:77:37 | url.par ... , true) | other-fs-libraries.js:77:14:77:43 | url.par ... ).query |
+| other-fs-libraries.js:77:14:77:43 | url.par ... ).query | other-fs-libraries.js:77:14:77:48 | url.par ... ry.path |
+| other-fs-libraries.js:77:14:77:43 | url.par ... ).query | other-fs-libraries.js:77:14:77:48 | url.par ... ry.path |
+| other-fs-libraries.js:77:14:77:43 | url.par ... ).query | other-fs-libraries.js:77:14:77:48 | url.par ... ry.path |
+| other-fs-libraries.js:77:14:77:43 | url.par ... ).query | other-fs-libraries.js:77:14:77:48 | url.par ... ry.path |
+| other-fs-libraries.js:77:14:77:43 | url.par ... ).query | other-fs-libraries.js:77:14:77:48 | url.par ... ry.path |
+| other-fs-libraries.js:77:14:77:43 | url.par ... ).query | other-fs-libraries.js:77:14:77:48 | url.par ... ry.path |
+| other-fs-libraries.js:77:14:77:43 | url.par ... ).query | other-fs-libraries.js:77:14:77:48 | url.par ... ry.path |
+| other-fs-libraries.js:77:14:77:43 | url.par ... ).query | other-fs-libraries.js:77:14:77:48 | url.par ... ry.path |
+| other-fs-libraries.js:77:14:77:43 | url.par ... ).query | other-fs-libraries.js:77:14:77:48 | url.par ... ry.path |
+| other-fs-libraries.js:77:14:77:43 | url.par ... ).query | other-fs-libraries.js:77:14:77:48 | url.par ... ry.path |
+| other-fs-libraries.js:77:14:77:43 | url.par ... ).query | other-fs-libraries.js:77:14:77:48 | url.par ... ry.path |
+| other-fs-libraries.js:77:14:77:43 | url.par ... ).query | other-fs-libraries.js:77:14:77:48 | url.par ... ry.path |
+| other-fs-libraries.js:77:14:77:43 | url.par ... ).query | other-fs-libraries.js:77:14:77:48 | url.par ... ry.path |
+| other-fs-libraries.js:77:14:77:43 | url.par ... ).query | other-fs-libraries.js:77:14:77:48 | url.par ... ry.path |
+| other-fs-libraries.js:77:14:77:43 | url.par ... ).query | other-fs-libraries.js:77:14:77:48 | url.par ... ry.path |
+| other-fs-libraries.js:77:14:77:43 | url.par ... ).query | other-fs-libraries.js:77:14:77:48 | url.par ... ry.path |
+| other-fs-libraries.js:77:14:77:48 | url.par ... ry.path | other-fs-libraries.js:77:7:77:48 | path |
+| other-fs-libraries.js:77:14:77:48 | url.par ... ry.path | other-fs-libraries.js:77:7:77:48 | path |
+| other-fs-libraries.js:77:14:77:48 | url.par ... ry.path | other-fs-libraries.js:77:7:77:48 | path |
+| other-fs-libraries.js:77:14:77:48 | url.par ... ry.path | other-fs-libraries.js:77:7:77:48 | path |
+| other-fs-libraries.js:77:14:77:48 | url.par ... ry.path | other-fs-libraries.js:77:7:77:48 | path |
+| other-fs-libraries.js:77:14:77:48 | url.par ... ry.path | other-fs-libraries.js:77:7:77:48 | path |
+| other-fs-libraries.js:77:14:77:48 | url.par ... ry.path | other-fs-libraries.js:77:7:77:48 | path |
+| other-fs-libraries.js:77:14:77:48 | url.par ... ry.path | other-fs-libraries.js:77:7:77:48 | path |
+| other-fs-libraries.js:77:14:77:48 | url.par ... ry.path | other-fs-libraries.js:77:7:77:48 | path |
+| other-fs-libraries.js:77:14:77:48 | url.par ... ry.path | other-fs-libraries.js:77:7:77:48 | path |
+| other-fs-libraries.js:77:14:77:48 | url.par ... ry.path | other-fs-libraries.js:77:7:77:48 | path |
+| other-fs-libraries.js:77:14:77:48 | url.par ... ry.path | other-fs-libraries.js:77:7:77:48 | path |
+| other-fs-libraries.js:77:14:77:48 | url.par ... ry.path | other-fs-libraries.js:77:7:77:48 | path |
+| other-fs-libraries.js:77:14:77:48 | url.par ... ry.path | other-fs-libraries.js:77:7:77:48 | path |
+| other-fs-libraries.js:77:14:77:48 | url.par ... ry.path | other-fs-libraries.js:77:7:77:48 | path |
+| other-fs-libraries.js:77:14:77:48 | url.par ... ry.path | other-fs-libraries.js:77:7:77:48 | path |
+| other-fs-libraries.js:77:24:77:30 | req.url | other-fs-libraries.js:77:14:77:37 | url.par ... , true) |
+| other-fs-libraries.js:77:24:77:30 | req.url | other-fs-libraries.js:77:14:77:37 | url.par ... , true) |
+| other-fs-libraries.js:77:24:77:30 | req.url | other-fs-libraries.js:77:14:77:37 | url.par ... , true) |
+| other-fs-libraries.js:77:24:77:30 | req.url | other-fs-libraries.js:77:14:77:37 | url.par ... , true) |
+| other-fs-libraries.js:77:24:77:30 | req.url | other-fs-libraries.js:77:14:77:37 | url.par ... , true) |
+| other-fs-libraries.js:77:24:77:30 | req.url | other-fs-libraries.js:77:14:77:37 | url.par ... , true) |
+| other-fs-libraries.js:77:24:77:30 | req.url | other-fs-libraries.js:77:14:77:37 | url.par ... , true) |
+| other-fs-libraries.js:77:24:77:30 | req.url | other-fs-libraries.js:77:14:77:37 | url.par ... , true) |
+| other-fs-libraries.js:77:24:77:30 | req.url | other-fs-libraries.js:77:14:77:37 | url.par ... , true) |
+| other-fs-libraries.js:77:24:77:30 | req.url | other-fs-libraries.js:77:14:77:37 | url.par ... , true) |
+| other-fs-libraries.js:77:24:77:30 | req.url | other-fs-libraries.js:77:14:77:37 | url.par ... , true) |
+| other-fs-libraries.js:77:24:77:30 | req.url | other-fs-libraries.js:77:14:77:37 | url.par ... , true) |
+| other-fs-libraries.js:77:24:77:30 | req.url | other-fs-libraries.js:77:14:77:37 | url.par ... , true) |
+| other-fs-libraries.js:77:24:77:30 | req.url | other-fs-libraries.js:77:14:77:37 | url.par ... , true) |
+| other-fs-libraries.js:77:24:77:30 | req.url | other-fs-libraries.js:77:14:77:37 | url.par ... , true) |
+| other-fs-libraries.js:77:24:77:30 | req.url | other-fs-libraries.js:77:14:77:37 | url.par ... , true) |
+| other-fs-libraries.js:77:24:77:30 | req.url | other-fs-libraries.js:77:14:77:37 | url.par ... , true) |
+| other-fs-libraries.js:77:24:77:30 | req.url | other-fs-libraries.js:77:14:77:37 | url.par ... , true) |
+| other-fs-libraries.js:77:24:77:30 | req.url | other-fs-libraries.js:77:14:77:37 | url.par ... , true) |
+| other-fs-libraries.js:77:24:77:30 | req.url | other-fs-libraries.js:77:14:77:37 | url.par ... , true) |
+| other-fs-libraries.js:77:24:77:30 | req.url | other-fs-libraries.js:77:14:77:37 | url.par ... , true) |
+| other-fs-libraries.js:77:24:77:30 | req.url | other-fs-libraries.js:77:14:77:37 | url.par ... , true) |
+| other-fs-libraries.js:77:24:77:30 | req.url | other-fs-libraries.js:77:14:77:37 | url.par ... , true) |
+| other-fs-libraries.js:77:24:77:30 | req.url | other-fs-libraries.js:77:14:77:37 | url.par ... , true) |
+| other-fs-libraries.js:77:24:77:30 | req.url | other-fs-libraries.js:77:14:77:37 | url.par ... , true) |
+| other-fs-libraries.js:77:24:77:30 | req.url | other-fs-libraries.js:77:14:77:37 | url.par ... , true) |
+| other-fs-libraries.js:77:24:77:30 | req.url | other-fs-libraries.js:77:14:77:37 | url.par ... , true) |
+| other-fs-libraries.js:77:24:77:30 | req.url | other-fs-libraries.js:77:14:77:37 | url.par ... , true) |
+| other-fs-libraries.js:77:24:77:30 | req.url | other-fs-libraries.js:77:14:77:37 | url.par ... , true) |
+| other-fs-libraries.js:77:24:77:30 | req.url | other-fs-libraries.js:77:14:77:37 | url.par ... , true) |
+| other-fs-libraries.js:77:24:77:30 | req.url | other-fs-libraries.js:77:14:77:37 | url.par ... , true) |
+| other-fs-libraries.js:77:24:77:30 | req.url | other-fs-libraries.js:77:14:77:37 | url.par ... , true) |
 | prettier.js:6:11:6:28 | p | prettier.js:7:28:7:28 | p |
 | prettier.js:6:11:6:28 | p | prettier.js:7:28:7:28 | p |
 | prettier.js:6:11:6:28 | p | prettier.js:7:28:7:28 | p |
@@ -10187,6 +10385,7 @@ edges
 | other-fs-libraries.js:70:19:70:22 | path | other-fs-libraries.js:68:24:68:30 | req.url | other-fs-libraries.js:70:19:70:22 | path | This path depends on a $@. | other-fs-libraries.js:68:24:68:30 | req.url | user-provided value |
 | other-fs-libraries.js:71:10:71:13 | path | other-fs-libraries.js:68:24:68:30 | req.url | other-fs-libraries.js:71:10:71:13 | path | This path depends on a $@. | other-fs-libraries.js:68:24:68:30 | req.url | user-provided value |
 | other-fs-libraries.js:72:15:72:18 | path | other-fs-libraries.js:68:24:68:30 | req.url | other-fs-libraries.js:72:15:72:18 | path | This path depends on a $@. | other-fs-libraries.js:68:24:68:30 | req.url | user-provided value |
+| other-fs-libraries.js:79:16:79:19 | path | other-fs-libraries.js:77:24:77:30 | req.url | other-fs-libraries.js:79:16:79:19 | path | This path depends on a $@. | other-fs-libraries.js:77:24:77:30 | req.url | user-provided value |
 | prettier.js:7:28:7:28 | p | prettier.js:6:13:6:13 | p | prettier.js:7:28:7:28 | p | This path depends on a $@. | prettier.js:6:13:6:13 | p | user-provided value |
 | prettier.js:11:44:11:44 | p | prettier.js:6:13:6:13 | p | prettier.js:11:44:11:44 | p | This path depends on a $@. | prettier.js:6:13:6:13 | p | user-provided value |
 | pupeteer.js:9:28:9:34 | tainted | pupeteer.js:5:28:5:53 | parseTo ... t).name | pupeteer.js:9:28:9:34 | tainted | This path depends on a $@. | pupeteer.js:5:28:5:53 | parseTo ... t).name | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/fs.js
+++ b/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/fs.js
@@ -45,4 +45,12 @@ var fs = {};
  */
 fs.readFileSync = function(filename, encoding) {};
 
+/**
+ * @param {string} filename
+ * @param {string} encoding
+ * @param {(function(NodeJS.ErrnoException, string): void)} callback
+ * @return {void}
+ */
+fs.readFile = function(filename, encoding, callback) {};
+
 module.exports = fs;

--- a/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/normalizedPaths.js
+++ b/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/normalizedPaths.js
@@ -402,3 +402,8 @@ app.get('/dotdot-regexp', (req, res) => {
     fs.readFileSync(path); // OK
   }
 });
+
+app.get('/join-spread', (req, res) => {
+  fs.readFileSync(pathModule.join('foo', ...req.query.x.split('/'))); // NOT OK
+  fs.readFileSync(pathModule.join(...req.query.x.split('/'))); // NOT OK
+});

--- a/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/normalizedPaths.js
+++ b/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/normalizedPaths.js
@@ -32,17 +32,17 @@ app.get('/normalize-notAbsolute', (req, res) => {
 
   if (pathModule.isAbsolute(path))
     return;
-   
+
   fs.readFileSync(path); // NOT OK
 
   if (!path.startsWith("."))
     fs.readFileSync(path); // OK
   else
     fs.readFileSync(path); // NOT OK - wrong polarity
-  
+
   if (!path.startsWith(".."))
     fs.readFileSync(path); // OK
-  
+
   if (!path.startsWith("../"))
     fs.readFileSync(path); // OK
 
@@ -52,7 +52,7 @@ app.get('/normalize-notAbsolute', (req, res) => {
 
 app.get('/normalize-noInitialDotDot', (req, res) => {
   let path = pathModule.normalize(req.query.path);
-  
+
   if (path.startsWith(".."))
     return;
 
@@ -80,7 +80,7 @@ app.get('/prepend-normalize', (req, res) => {
 
 app.get('/absolute', (req, res) => {
   let path = req.query.path;
-  
+
   if (!pathModule.isAbsolute(path))
     return;
 
@@ -92,10 +92,10 @@ app.get('/absolute', (req, res) => {
 
 app.get('/normalized-absolute', (req, res) => {
   let path = pathModule.normalize(req.query.path);
-  
+
   if (!pathModule.isAbsolute(path))
     return;
-  
+
   res.write(fs.readFileSync(path)); // NOT OK
 
   if (path.startsWith('/home/user/www'))
@@ -104,7 +104,7 @@ app.get('/normalized-absolute', (req, res) => {
 
 app.get('/combined-check', (req, res) => {
   let path = pathModule.normalize(req.query.path);
-  
+
   // Combined absoluteness and folder check in one startsWith call
   if (path.startsWith("/home/user/www"))
     fs.readFileSync(path); // OK
@@ -121,7 +121,7 @@ app.get('/realpath', (req, res) => {
 
   if (path.startsWith("/home/user/www"))
     fs.readFileSync(path); // OK - both absolute and normalized before check
-    
+
   fs.readFileSync(pathModule.join('.', path)); // OK - normalized and coerced to relative
   fs.readFileSync(pathModule.join('/home/user/www', path)); // OK
 });
@@ -212,7 +212,7 @@ app.get('/join-regression', (req, res) => {
 
 app.get('/decode-after-normalization', (req, res) => {
   let path = pathModule.normalize(req.query.path);
-  
+
   if (!pathModule.isAbsolute(path) && !path.startsWith('..'))
     fs.readFileSync(path); // OK
 
@@ -238,7 +238,7 @@ app.get('/resolve-path', (req, res) => {
   fs.readFileSync(path); // NOT OK
 
   var self = something();
-	
+
   if (path.substring(0, self.dir.length) === self.dir)
     fs.readFileSync(path); // OK
   else
@@ -256,12 +256,12 @@ app.get('/relative-startswith', (req, res) => {
   fs.readFileSync(path); // NOT OK
 
   var self = something();
-	
+
   var relative = pathModule.relative(self.webroot, path);
   if(relative.startsWith(".." + pathModule.sep) || relative == "..") {
-    fs.readFileSync(path); // NOT OK! 
+    fs.readFileSync(path); // NOT OK!
   } else {
-    fs.readFileSync(path); // OK! 
+    fs.readFileSync(path); // OK!
   }
 
   let newpath = pathModule.normalize(path);
@@ -277,7 +277,7 @@ app.get('/relative-startswith', (req, res) => {
   if (relativePath.indexOf('../') === 0) {
     fs.readFileSync(newpath); // NOT OK!
   } else {
-    fs.readFileSync(newpath); // OK! 
+    fs.readFileSync(newpath); // OK!
   }
 
   let newpath = pathModule.normalize(path);
@@ -285,7 +285,7 @@ app.get('/relative-startswith', (req, res) => {
   if (pathModule.normalize(relativePath).indexOf('../') === 0) {
     fs.readFileSync(newpath); // NOT OK!
   } else {
-    fs.readFileSync(newpath); // OK! 
+    fs.readFileSync(newpath); // OK!
   }
 
   let newpath = pathModule.normalize(path);
@@ -293,7 +293,7 @@ app.get('/relative-startswith', (req, res) => {
   if (pathModule.normalize(relativePath).indexOf('../')) {
     fs.readFileSync(newpath); // OK!
   } else {
-    fs.readFileSync(newpath); // NOT OK! 
+    fs.readFileSync(newpath); // NOT OK!
   }
 });
 
@@ -340,7 +340,7 @@ app.get('/yet-another-prefix', (req, res) => {
 
 	fs.readFileSync(path); // NOT OK
 
-	var abs = pathModule.resolve(path); 
+	var abs = pathModule.resolve(path);
 
 	if (abs.indexOf(root) !== 0) {
 		fs.readFileSync(path); // NOT OK

--- a/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/other-fs-libraries.js
+++ b/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/other-fs-libraries.js
@@ -71,3 +71,10 @@ http.createServer(function(req, res) {
   mkdirp(path); // NOT OK
   mkdirp.sync(path); // NOT OK
 });
+
+const fsp = require("fs/promises");
+http.createServer(function(req, res) {
+  var path = url.parse(req.url, true).query.path;
+
+  fsp.readFile(path); // NOT OK
+});


### PR DESCRIPTION
Fixes two bugs related to this contribution https://github.com/github/codeql/pull/13593:
- The `fs` model was missing the `fs/promises` package name
- The model for `path.join()` did not handle spread arguments

Thanks to @amammad for bringing these bugs to our attention. ✨ 

[Evaluation](https://github.com/github/codeql-dca-main/issues/14432) was quiet