### PR TITLE
Kotlin: Support apply

### DIFF
--- a/java/ql/lib/change-notes/2023-07-10-kotlin-apply.md
+++ b/java/ql/lib/change-notes/2023-07-10-kotlin-apply.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Added support for the Kotlin method `apply`.

--- a/java/ql/lib/ext/kotlin.model.yml
+++ b/java/ql/lib/ext/kotlin.model.yml
@@ -3,5 +3,7 @@ extensions:
       pack: codeql/java-all
       extensible: summaryModel
     data:
+      - ["kotlin", "StandardKt", False, "apply", "", "", "Argument[0]", "Argument[1].Parameter[0]", "value", "manual"]
+      - ["kotlin", "StandardKt", False, "apply", "", "", "Argument[0]", "ReturnValue", "value", "manual"]
       - ["kotlin", "StandardKt", False, "with", "", "", "Argument[0]", "Argument[1].Parameter[0]", "value", "manual"]
       - ["kotlin", "StandardKt", False, "with", "", "", "Argument[1].ReturnValue", "ReturnValue", "value", "manual"]

--- a/java/ql/lib/semmle/code/java/frameworks/kotlin/Kotlin.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/kotlin/Kotlin.qll
@@ -1,0 +1,21 @@
+/** Provides classes and predicates related to `kotlin`. */
+
+import java
+
+/** A call to Kotlin's `apply` method. */
+class KotlinApply extends MethodAccess {
+  ExtensionMethod m;
+
+  KotlinApply() {
+    this.getMethod() = m and
+    m.hasQualifiedName("kotlin", "StandardKt", "apply")
+  }
+
+  /** Gets the function block argument of this call. */
+  LambdaExpr getLambdaArg() {
+    result = this.getArgument(m.getExtensionReceiverParameterIndex() + 1)
+  }
+
+  /** Gets the receiver argument of this call. */
+  Argument getReceiver() { result = this.getArgument(m.getExtensionReceiverParameterIndex()) }
+}

--- a/java/ql/test/kotlin/library-tests/dataflow/summaries/apply.expected
+++ b/java/ql/test/kotlin/library-tests/dataflow/summaries/apply.expected
@@ -1,0 +1,2 @@
+| apply.kt:6:9:6:41 | apply(...) |
+| apply.kt:7:14:7:40 | apply(...) |

--- a/java/ql/test/kotlin/library-tests/dataflow/summaries/apply.kt
+++ b/java/ql/test/kotlin/library-tests/dataflow/summaries/apply.kt
@@ -1,0 +1,9 @@
+class ApplyFlowTest {
+    fun <T> taint(t: T) = t
+    fun sink(s: String) { }
+
+    fun test(input: String) {
+        taint(input).apply { sink(this) } // $ hasValueFlow
+        sink(taint(input).apply { this }) // $ hasValueFlow
+    }
+}

--- a/java/ql/test/kotlin/library-tests/dataflow/summaries/apply.ql
+++ b/java/ql/test/kotlin/library-tests/dataflow/summaries/apply.ql
@@ -1,0 +1,5 @@
+import java
+import semmle.code.java.frameworks.kotlin.Kotlin
+
+from KotlinApply a
+select a


### PR DESCRIPTION
Adds support for Kotlin's [`apply`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/apply.html).