### PR TITLE
Java: Add support for Kotlin's `apply` to java/android/unsafe-android-wevbiew-fetch

### DIFF
--- a/java/ql/lib/ext/android.webkit.model.yml
+++ b/java/ql/lib/ext/android.webkit.model.yml
@@ -3,13 +3,13 @@ extensions:
       pack: codeql/java-all
       extensible: sourceModel
     data:
-      - ["android.webkit", "WebView", False, "getOriginalUrl", "()", "", "ReturnValue", "remote", "manual"]
-      - ["android.webkit", "WebView", False, "getUrl", "()", "", "ReturnValue", "remote", "manual"]
+      - ["android.webkit", "WebView", True, "getOriginalUrl", "()", "", "ReturnValue", "remote", "manual"]
+      - ["android.webkit", "WebView", True, "getUrl", "()", "", "ReturnValue", "remote", "manual"]
   - addsTo:
       pack: codeql/java-all
       extensible: sinkModel
     data:
       # Models representing methods susceptible to XSS attacks.
-      - ["android.webkit", "WebView", False, "evaluateJavascript", "", "", "Argument[0]", "js-injection", "manual"]
-      - ["android.webkit", "WebView", False, "loadData", "", "", "Argument[0]", "html-injection", "manual"]
-      - ["android.webkit", "WebView", False, "loadDataWithBaseURL", "", "", "Argument[1]", "html-injection", "manual"]
+      - ["android.webkit", "WebView", True, "evaluateJavascript", "", "", "Argument[0]", "js-injection", "manual"]
+      - ["android.webkit", "WebView", True, "loadData", "", "", "Argument[0]", "html-injection", "manual"]
+      - ["android.webkit", "WebView", True, "loadDataWithBaseURL", "", "", "Argument[1]", "html-injection", "manual"]

--- a/java/ql/src/change-notes/2023-07-10-unsafe-android-access-apply.md
+++ b/java/ql/src/change-notes/2023-07-10-unsafe-android-access-apply.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The query "Unsafe resource fetching in Android WebView" (`java/android/unsafe-android-webview-fetch`) now recognizes WebViews where `setJavascriptEnabled`, `setAllowFileAccess`, `setAllowUniversalAccessFromFileURLs`, and/or `setAllowFileAccessFromFileURLs` are set inside the function block of the Kotlin `apply` function.

--- a/java/ql/test/query-tests/security/CWE-749/UnsafeActivityKt.kt
+++ b/java/ql/test/query-tests/security/CWE-749/UnsafeActivityKt.kt
@@ -9,12 +9,19 @@ import android.webkit.WebViewClient
 class UnsafeActivityKt : Activity() {
     override fun onCreate(savedInstanceState : Bundle) {
 
+		val src : String = intent.extras.getString("url")
+
 		val wv = findViewById<WebView>(-1)
 		// Implicit not-nulls happening here
 		wv.settings.setJavaScriptEnabled(true)
 		wv.settings.setAllowFileAccessFromFileURLs(true)
 
-		val thisUrl : String = intent.extras.getString("url")
-		wv.loadUrl(thisUrl) // $ hasUnsafeAndroidAccess
+		wv.loadUrl(src) // $ hasUnsafeAndroidAccess
+
+		val wv2 = findViewById<WebView>(-1)
+		wv2.apply {
+			settings.setJavaScriptEnabled(true)
+		}
+		wv2.loadUrl(src) // $ hasUnsafeAndroidAccess
     }
 }


### PR DESCRIPTION
After https://github.com/github/codeql/pull/13702, we can now support WebViews that get their dangerous attributes set inside an `apply` block in Kotlin.

This also expands some `WebView` models by allowing subtypes.