### PR TITLE
Swift: Recognize regular expression parse mode flags

### DIFF
--- a/swift/ql/lib/change-notes/2023-07-10-regex-mode-flags.md
+++ b/swift/ql/lib/change-notes/2023-07-10-regex-mode-flags.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The regular expression library now understands mode flags specified at the beginning of a regular expression (for example `(?is)`).

--- a/swift/ql/lib/codeql/swift/regex/internal/ParseRegex.qll
+++ b/swift/ql/lib/codeql/swift/regex/internal/ParseRegex.qll
@@ -708,6 +708,8 @@ abstract class RegExp extends Expr {
     this.commentGroupStart(start, end)
     or
     this.simpleGroupStart(start, end)
+    or
+    this.flagGroupStart(start, end, _)
   }
 
   /** Matches the start of a non-capturing group, e.g. `(?:` */

--- a/swift/ql/lib/codeql/swift/regex/internal/ParseRegex.qll
+++ b/swift/ql/lib/codeql/swift/regex/internal/ParseRegex.qll
@@ -24,7 +24,7 @@ abstract class RegExp extends Expr {
   predicate isIgnoreCase() { this.getAMode() = "IGNORECASE" }
 
   /**
-   * Gets a string repreenting the flags for this `RegExp`, or the empty string if it has no flags.
+   * Gets a string representing the flags for this `RegExp`, or the empty string if it has no flags.
    */
   string getFlags() { result = concat(string mode | mode = this.getAMode() | mode, " | ") }
 
@@ -275,10 +275,7 @@ abstract class RegExp extends Expr {
   private predicate isGroupStart(int i) { this.nonEscapedCharAt(i) = "(" and not this.inCharSet(i) }
 
   /**
-   * Holds if a parse mode prefix starts between `start` and `end`. For example:
-   * ```
-   * (?i)
-   * ```
+   * Holds if a parse mode starts between `start` and `end`.
    */
   private predicate flagGroupStart(int start, int end) {
     this.isGroupStart(start) and
@@ -288,8 +285,11 @@ abstract class RegExp extends Expr {
   }
 
   /**
-   * Holds if a parse mode prefix group is between `start` and `end`, and includes the
-   * mode flag `c`.
+   * Holds if a parse mode group is between `start` and `end`, and includes the
+   * mode flag `c`. For example the following span, with mode flag `i`:
+   * ```
+   * (?i)
+   * ```
    */
   private predicate flagGroup(int start, int end, string c) {
     exists(int inStart, int inEnd |

--- a/swift/ql/lib/codeql/swift/regex/internal/ParseRegex.qll
+++ b/swift/ql/lib/codeql/swift/regex/internal/ParseRegex.qll
@@ -303,41 +303,27 @@ abstract class RegExp extends Expr {
    */
   string getModeFromPrefix() {
     exists(string c | this.flagGroup(_, _, c) |
-      // TODO: are these correct in Swift?
-      c = "i" and result = "IGNORECASE"
+      c = "i" and result = "IGNORECASE" // case insensitive
       or
-      c = "m" and result = "MULTILINE"
+      c = "x" and result = "VERBOSE" // ignores whitespace and `#` comments within patterns
       or
-      c = "s" and result = "DOTALL"
+      c = "s" and result = "DOTALL" // dot matches all characters, including line terminators
       or
-      c = "u" and result = "UNICODE"
+      c = "m" and result = "MULTILINE" // `^` and `$` also match beginning and end of lines
       or
-      c = "x" and result = "VERBOSE"
-      or
-      c = "U" and result = "UNICODECLASS"
+      c = "w" and result = "UNICODE" // Unicode UAX 29 word boundary mode
     )
   }
 
   /**
    * Gets a mode (if any) of this regular expression. Can be any of:
-   * DEBUG
    * IGNORECASE
-   * MULTILINE
-   * DOTALL
-   * UNICODE
    * VERBOSE
-   * UNICODECLASS
+   * DOTALL
+   * MULTILINE
+   * UNICODE
    */
-  string getAMode() {
-    /*
-     * TODO
-     *    result != "None" and
-     *    usedAsRegex(this, result, _)
-     *    or
-     */
-
-    result = this.getModeFromPrefix()
-  }
+  string getAMode() { result = this.getModeFromPrefix() }
 
   /**
    * Holds if the `i`th character could not be parsed.

--- a/swift/ql/lib/codeql/swift/regex/internal/ParseRegex.qll
+++ b/swift/ql/lib/codeql/swift/regex/internal/ParseRegex.qll
@@ -283,6 +283,7 @@ abstract class RegExp extends Expr {
   private predicate flagGroupStart(int start, int end) {
     this.isGroupStart(start) and
     this.getChar(start + 1) = "?" and
+    this.getChar(start + 2) in ["i", "x", "s", "m", "w"] and
     end = start + 2
   }
 

--- a/swift/ql/test/library-tests/regex/parse.expected
+++ b/swift/ql/test/library-tests/regex/parse.expected
@@ -1618,12 +1618,15 @@ redos_variants.swift:
 
 #  142| [RegExpConstant, RegExpNormalChar] !
 
-#  146| [RegExpZeroWidthMatch] (?s)
+#  146| [RegExpGroup] (?s)
+#-----| 0 -> [RegExpConstant, RegExpNormalChar] s
 
 #  146| [RegExpSequence] (?s)(.|\n)*!
-#-----| 0 -> [RegExpZeroWidthMatch] (?s)
+#-----| 0 -> [RegExpGroup] (?s)
 #-----| 1 -> [RegExpStar] (.|\n)*
 #-----| 2 -> [RegExpConstant, RegExpNormalChar] !
+
+#  146| [RegExpConstant, RegExpNormalChar] s
 
 #  146| [RegExpGroup] (.|\n)
 #-----| 0 -> [RegExpAlt] .|\n
@@ -6489,30 +6492,36 @@ regex.swift:
 
 #  205| [RegExpNamedCharacterProperty] [:aaaaa:]
 
-#  209| [RegExpZeroWidthMatch] (?i)
+#  209| [RegExpGroup] (?i)
+#-----| 0 -> [RegExpConstant, RegExpNormalChar] i
 
 #  209| [RegExpSequence] (?i)abc
-#-----| 0 -> [RegExpZeroWidthMatch] (?i)
+#-----| 0 -> [RegExpGroup] (?i)
 #-----| 1 -> [RegExpConstant, RegExpNormalChar] abc
+
+#  209| [RegExpConstant, RegExpNormalChar] i
 
 #  209| [RegExpConstant, RegExpNormalChar] abc
 
-#  210| [RegExpZeroWidthMatch] (?s)
+#  210| [RegExpGroup] (?s)
+#-----| 0 -> [RegExpConstant, RegExpNormalChar] s
 
 #  210| [RegExpSequence] (?s)abc
-#-----| 0 -> [RegExpZeroWidthMatch] (?s)
+#-----| 0 -> [RegExpGroup] (?s)
 #-----| 1 -> [RegExpConstant, RegExpNormalChar] abc
+
+#  210| [RegExpConstant, RegExpNormalChar] s
 
 #  210| [RegExpConstant, RegExpNormalChar] abc
 
 #  211| [RegExpGroup] (?is)
-#-----| 0 -> [RegExpConstant, RegExpNormalChar] s
+#-----| 0 -> [RegExpConstant, RegExpNormalChar] is
 
 #  211| [RegExpSequence] (?is)abc
 #-----| 0 -> [RegExpGroup] (?is)
 #-----| 1 -> [RegExpConstant, RegExpNormalChar] abc
 
-#  211| [RegExpConstant, RegExpNormalChar] s
+#  211| [RegExpConstant, RegExpNormalChar] is
 
 #  211| [RegExpConstant, RegExpNormalChar] abc
 

--- a/swift/ql/test/library-tests/regex/parse.expected
+++ b/swift/ql/test/library-tests/regex/parse.expected
@@ -6319,167 +6319,204 @@ redos_variants.swift:
 #  579| [RegExpConstant, RegExpNormalChar] c
 
 regex.swift:
-#  103| [RegExpDot] .
+#  110| [RegExpDot] .
 
-#  103| [RegExpStar] .*
+#  110| [RegExpStar] .*
 #-----| 0 -> [RegExpDot] .
 
-#  125| [RegExpDot] .
+#  132| [RegExpDot] .
 
-#  125| [RegExpStar] .*
+#  132| [RegExpStar] .*
 #-----| 0 -> [RegExpDot] .
 
-#  142| [RegExpDot] .
+#  149| [RegExpDot] .
 
-#  142| [RegExpStar] .*
+#  149| [RegExpStar] .*
 #-----| 0 -> [RegExpDot] .
 
-#  142| [RegExpDot] .
+#  149| [RegExpDot] .
 
-#  142| [RegExpPlus] .+
+#  149| [RegExpPlus] .+
 #-----| 0 -> [RegExpDot] .
 
-#  149| [RegExpGroup] ([\w.]+)
+#  156| [RegExpGroup] ([\w.]+)
 #-----| 0 -> [RegExpPlus] [\w.]+
 
-#  149| [RegExpStar] ([\w.]+)*
+#  156| [RegExpStar] ([\w.]+)*
 #-----| 0 -> [RegExpGroup] ([\w.]+)
 
-#  149| [RegExpCharacterClass] [\w.]
+#  156| [RegExpCharacterClass] [\w.]
 #-----| 0 -> [RegExpCharacterClassEscape] \w
 #-----| 1 -> [RegExpConstant, RegExpNormalChar] .
 
-#  149| [RegExpPlus] [\w.]+
+#  156| [RegExpPlus] [\w.]+
 #-----| 0 -> [RegExpCharacterClass] [\w.]
 
-#  149| [RegExpCharacterClassEscape] \w
+#  156| [RegExpCharacterClassEscape] \w
 
-#  149| [RegExpConstant, RegExpNormalChar] .
+#  156| [RegExpConstant, RegExpNormalChar] .
 
-#  156| [RegExpConstant, RegExpNormalChar] 
-#  156| 
+#  163| [RegExpConstant, RegExpNormalChar] 
+#  163| 
 
-#  157| [RegExpConstant, RegExpEscape] \n
+#  164| [RegExpConstant, RegExpEscape] \n
 
-#  158| [RegExpConstant, RegExpEscape] \n
+#  165| [RegExpConstant, RegExpEscape] \n
 
-#  168| [RegExpConstant, RegExpNormalChar] aa
+#  175| [RegExpConstant, RegExpNormalChar] aa
 
-#  168| [RegExpAlt] aa|bb
+#  175| [RegExpAlt] aa|bb
 #-----| 0 -> [RegExpConstant, RegExpNormalChar] aa
 #-----| 1 -> [RegExpConstant, RegExpNormalChar] bb
 
-#  168| [RegExpConstant, RegExpNormalChar] bb
+#  175| [RegExpConstant, RegExpNormalChar] bb
 
-#  172| [RegExpConstant, RegExpNormalChar] aa
+#  179| [RegExpConstant, RegExpNormalChar] aa
 
-#  172| [RegExpAlt] aa|
-#  172| bb
+#  179| [RegExpAlt] aa|
+#  179| bb
 #-----| 0 -> [RegExpConstant, RegExpNormalChar] aa
 #-----| 1 -> [RegExpConstant, RegExpNormalChar] 
 #-----| bb
 
-#  172| [RegExpConstant, RegExpNormalChar] 
-#  172| bb
+#  179| [RegExpConstant, RegExpNormalChar] 
+#  179| bb
 
-#  180| [RegExpCharacterClass] [a-z]
+#  187| [RegExpCharacterClass] [a-z]
 #-----| 0 -> [RegExpCharacterRange] a-z
 
-#  180| [RegExpConstant, RegExpNormalChar] a
+#  187| [RegExpConstant, RegExpNormalChar] a
 
-#  180| [RegExpCharacterRange] a-z
+#  187| [RegExpCharacterRange] a-z
 #-----| 0 -> [RegExpConstant, RegExpNormalChar] a
 #-----| 1 -> [RegExpConstant, RegExpNormalChar] z
 
-#  180| [RegExpConstant, RegExpNormalChar] z
+#  187| [RegExpConstant, RegExpNormalChar] z
 
-#  181| [RegExpCharacterClass] [a-zA-Z]
+#  188| [RegExpCharacterClass] [a-zA-Z]
 #-----| 0 -> [RegExpCharacterRange] a-z
 #-----| 1 -> [RegExpCharacterRange] A-Z
 
-#  181| [RegExpConstant, RegExpNormalChar] a
+#  188| [RegExpConstant, RegExpNormalChar] a
 
-#  181| [RegExpCharacterRange] a-z
+#  188| [RegExpCharacterRange] a-z
 #-----| 0 -> [RegExpConstant, RegExpNormalChar] a
 #-----| 1 -> [RegExpConstant, RegExpNormalChar] z
 
-#  181| [RegExpConstant, RegExpNormalChar] z
+#  188| [RegExpConstant, RegExpNormalChar] z
 
-#  181| [RegExpConstant, RegExpNormalChar] A
+#  188| [RegExpConstant, RegExpNormalChar] A
 
-#  181| [RegExpCharacterRange] A-Z
+#  188| [RegExpCharacterRange] A-Z
 #-----| 0 -> [RegExpConstant, RegExpNormalChar] A
 #-----| 1 -> [RegExpConstant, RegExpNormalChar] Z
 
-#  181| [RegExpConstant, RegExpNormalChar] Z
+#  188| [RegExpConstant, RegExpNormalChar] Z
 
-#  184| [RegExpCharacterClass] [a-]
+#  191| [RegExpCharacterClass] [a-]
 #-----| 0 -> [RegExpConstant, RegExpNormalChar] a
 #-----| 1 -> [RegExpConstant, RegExpNormalChar] -
 
-#  184| [RegExpConstant, RegExpNormalChar] a
+#  191| [RegExpConstant, RegExpNormalChar] a
 
-#  184| [RegExpConstant, RegExpNormalChar] -
+#  191| [RegExpConstant, RegExpNormalChar] -
 
-#  185| [RegExpCharacterClass] [-a]
+#  192| [RegExpCharacterClass] [-a]
 #-----| 0 -> [RegExpConstant, RegExpNormalChar] -
 #-----| 1 -> [RegExpConstant, RegExpNormalChar] a
 
-#  185| [RegExpConstant, RegExpNormalChar] -
+#  192| [RegExpConstant, RegExpNormalChar] -
 
-#  185| [RegExpConstant, RegExpNormalChar] a
+#  192| [RegExpConstant, RegExpNormalChar] a
 
-#  186| [RegExpCharacterClass] [-]
+#  193| [RegExpCharacterClass] [-]
 #-----| 0 -> [RegExpConstant, RegExpNormalChar] -
 
-#  186| [RegExpConstant, RegExpNormalChar] -
+#  193| [RegExpConstant, RegExpNormalChar] -
 
-#  187| [RegExpCharacterClass] [*]
+#  194| [RegExpCharacterClass] [*]
 #-----| 0 -> [RegExpConstant, RegExpNormalChar] *
 
-#  187| [RegExpConstant, RegExpNormalChar] *
+#  194| [RegExpConstant, RegExpNormalChar] *
 
-#  188| [RegExpCharacterClass] [^a]
+#  195| [RegExpCharacterClass] [^a]
 #-----| 0 -> [RegExpConstant, RegExpNormalChar] a
 
-#  188| [RegExpConstant, RegExpNormalChar] a
+#  195| [RegExpConstant, RegExpNormalChar] a
 
-#  189| [RegExpCharacterClass] [a^]
+#  196| [RegExpCharacterClass] [a^]
 #-----| 0 -> [RegExpConstant, RegExpNormalChar] a
 #-----| 1 -> [RegExpConstant, RegExpNormalChar] ^
 
-#  189| [RegExpConstant, RegExpNormalChar] a
+#  196| [RegExpConstant, RegExpNormalChar] a
 
-#  189| [RegExpConstant, RegExpNormalChar] ^
+#  196| [RegExpConstant, RegExpNormalChar] ^
 
-#  190| [RegExpCharacterClass] [\\]
+#  197| [RegExpCharacterClass] [\\]
 #-----| 0 -> [RegExpConstant, RegExpEscape] \\
 
-#  190| [RegExpConstant, RegExpEscape] \\
+#  197| [RegExpConstant, RegExpEscape] \\
 
-#  191| [RegExpCharacterClass] [\\\]]
+#  198| [RegExpCharacterClass] [\\\]]
 #-----| 0 -> [RegExpConstant, RegExpEscape] \\
 #-----| 1 -> [RegExpConstant, RegExpEscape] \]
 
-#  191| [RegExpConstant, RegExpEscape] \\
+#  198| [RegExpConstant, RegExpEscape] \\
 
-#  191| [RegExpConstant, RegExpEscape] \]
+#  198| [RegExpConstant, RegExpEscape] \]
 
-#  192| [RegExpCharacterClass] [:]
+#  199| [RegExpCharacterClass] [:]
 #-----| 0 -> [RegExpConstant, RegExpNormalChar] :
 
-#  192| [RegExpConstant, RegExpNormalChar] :
+#  199| [RegExpConstant, RegExpNormalChar] :
 
-#  193| [RegExpNamedCharacterProperty] [:digit:]
+#  200| [RegExpNamedCharacterProperty] [:digit:]
 
-#  194| [RegExpNamedCharacterProperty] [:alnum:]
+#  201| [RegExpNamedCharacterProperty] [:alnum:]
 
-#  197| [RegExpCharacterClass] []a]
+#  204| [RegExpCharacterClass] []a]
 #-----| 0 -> [RegExpConstant, RegExpNormalChar] ]
 #-----| 1 -> [RegExpConstant, RegExpNormalChar] a
 
-#  197| [RegExpConstant, RegExpNormalChar] ]
+#  204| [RegExpConstant, RegExpNormalChar] ]
 
-#  197| [RegExpConstant, RegExpNormalChar] a
+#  204| [RegExpConstant, RegExpNormalChar] a
 
-#  198| [RegExpNamedCharacterProperty] [:aaaaa:]
+#  205| [RegExpNamedCharacterProperty] [:aaaaa:]
+
+#  209| [RegExpConstant, RegExpNormalChar] i
+
+#  209| [RegExpConstant, RegExpNormalChar] abc
+
+#  210| [RegExpConstant, RegExpNormalChar] s
+
+#  210| [RegExpConstant, RegExpNormalChar] abc
+
+#  211| [RegExpConstant, RegExpNormalChar] is
+
+#  211| [RegExpConstant, RegExpNormalChar] abc
+
+#  213| [RegExpConstant, RegExpNormalChar] abc
+
+#  214| [RegExpConstant, RegExpNormalChar] abc
+
+#  215| [RegExpConstant, RegExpNormalChar] abc
+
+#  216| [RegExpConstant, RegExpNormalChar] abc
+
+#  217| [RegExpConstant, RegExpNormalChar] abc
+
+#  219| [RegExpDot] .
+
+#  219| [RegExpStar] .*
+#-----| 0 -> [RegExpDot] .
+
+#  220| [RegExpDot] .
+
+#  220| [RegExpStar] .*
+#-----| 0 -> [RegExpDot] .
+
+#  221| [RegExpDot] .
+
+#  221| [RegExpStar] .*
+#-----| 0 -> [RegExpDot] .

--- a/swift/ql/test/library-tests/regex/parse.expected
+++ b/swift/ql/test/library-tests/regex/parse.expected
@@ -1618,7 +1618,12 @@ redos_variants.swift:
 
 #  142| [RegExpConstant, RegExpNormalChar] !
 
-#  146| [RegExpConstant, RegExpNormalChar] s
+#  146| [RegExpZeroWidthMatch] (?s)
+
+#  146| [RegExpSequence] (?s)(.|\n)*!
+#-----| 0 -> [RegExpZeroWidthMatch] (?s)
+#-----| 1 -> [RegExpStar] (.|\n)*
+#-----| 2 -> [RegExpConstant, RegExpNormalChar] !
 
 #  146| [RegExpGroup] (.|\n)
 #-----| 0 -> [RegExpAlt] .|\n
@@ -6484,15 +6489,30 @@ regex.swift:
 
 #  205| [RegExpNamedCharacterProperty] [:aaaaa:]
 
-#  209| [RegExpConstant, RegExpNormalChar] i
+#  209| [RegExpZeroWidthMatch] (?i)
+
+#  209| [RegExpSequence] (?i)abc
+#-----| 0 -> [RegExpZeroWidthMatch] (?i)
+#-----| 1 -> [RegExpConstant, RegExpNormalChar] abc
 
 #  209| [RegExpConstant, RegExpNormalChar] abc
 
-#  210| [RegExpConstant, RegExpNormalChar] s
+#  210| [RegExpZeroWidthMatch] (?s)
+
+#  210| [RegExpSequence] (?s)abc
+#-----| 0 -> [RegExpZeroWidthMatch] (?s)
+#-----| 1 -> [RegExpConstant, RegExpNormalChar] abc
 
 #  210| [RegExpConstant, RegExpNormalChar] abc
 
-#  211| [RegExpConstant, RegExpNormalChar] is
+#  211| [RegExpGroup] (?is)
+#-----| 0 -> [RegExpConstant, RegExpNormalChar] s
+
+#  211| [RegExpSequence] (?is)abc
+#-----| 0 -> [RegExpGroup] (?is)
+#-----| 1 -> [RegExpConstant, RegExpNormalChar] abc
+
+#  211| [RegExpConstant, RegExpNormalChar] s
 
 #  211| [RegExpConstant, RegExpNormalChar] abc
 

--- a/swift/ql/test/library-tests/regex/parse.expected
+++ b/swift/ql/test/library-tests/regex/parse.expected
@@ -6549,3 +6549,53 @@ regex.swift:
 
 #  221| [RegExpStar] .*
 #-----| 0 -> [RegExpDot] .
+
+#  227| [RegExpGroup] (?i-s)
+#-----| 0 -> [RegExpConstant, RegExpNormalChar] i-s
+
+#  227| [RegExpSequence] (?i-s)abc
+#-----| 0 -> [RegExpGroup] (?i-s)
+#-----| 1 -> [RegExpConstant, RegExpNormalChar] abc
+
+#  227| [RegExpConstant, RegExpNormalChar] i-s
+
+#  227| [RegExpConstant, RegExpNormalChar] abc
+
+#  230| [RegExpConstant, RegExpNormalChar] abc
+
+#  230| [RegExpSequence] abc(?i)def
+#-----| 0 -> [RegExpConstant, RegExpNormalChar] abc
+#-----| 1 -> [RegExpGroup] (?i)
+#-----| 2 -> [RegExpConstant, RegExpNormalChar] def
+
+#  230| [RegExpGroup] (?i)
+#-----| 0 -> [RegExpConstant, RegExpNormalChar] i
+
+#  230| [RegExpConstant, RegExpNormalChar] i
+
+#  230| [RegExpConstant, RegExpNormalChar] def
+
+#  231| [RegExpConstant, RegExpNormalChar] abc
+
+#  231| [RegExpSequence] abc(?i:def)ghi
+#-----| 0 -> [RegExpConstant, RegExpNormalChar] abc
+#-----| 1 -> [RegExpGroup] (?i:def)
+#-----| 2 -> [RegExpConstant, RegExpNormalChar] ghi
+
+#  231| [RegExpGroup] (?i:def)
+#-----| 0 -> [RegExpConstant, RegExpNormalChar] i:def
+
+#  231| [RegExpConstant, RegExpNormalChar] i:def
+
+#  231| [RegExpConstant, RegExpNormalChar] ghi
+
+#  232| [RegExpGroup] (?i)
+#-----| 0 -> [RegExpConstant, RegExpNormalChar] i
+
+#  232| [RegExpConstant, RegExpNormalChar] i
+
+#  232| [RegExpConstant, RegExpNormalChar] abc
+
+#  232| [RegExpConstant, RegExpNormalChar] -i
+
+#  232| [RegExpConstant, RegExpNormalChar] def

--- a/swift/ql/test/library-tests/regex/redos_variants.swift
+++ b/swift/ql/test/library-tests/regex/redos_variants.swift
@@ -143,7 +143,7 @@ func myRegexpVariantsTests(myUrl: URL) throws {
 
     // BAD
     // attack string: "\n".repeat(100) + "."
-    _ = try Regex(#"(?s)(.|\n)*!"#).firstMatch(in: tainted) // $ hasParseFailure MISSING: redos-vulnerable=
+    _ = try Regex(#"(?s)(.|\n)*!"#).firstMatch(in: tainted) // $ hasParseFailure modes=DOTALL MISSING: redos-vulnerable=
 
     // GOOD
     _ = try Regex(#"([\w.]+)*"#).firstMatch(in: tainted)

--- a/swift/ql/test/library-tests/regex/redos_variants.swift
+++ b/swift/ql/test/library-tests/regex/redos_variants.swift
@@ -143,7 +143,7 @@ func myRegexpVariantsTests(myUrl: URL) throws {
 
     // BAD
     // attack string: "\n".repeat(100) + "."
-    _ = try Regex(#"(?s)(.|\n)*!"#).firstMatch(in: tainted) // $ hasParseFailure modes=DOTALL MISSING: redos-vulnerable=
+    _ = try Regex(#"(?s)(.|\n)*!"#).firstMatch(in: tainted) // $ modes=DOTALL redos-vulnerable=
 
     // GOOD
     _ = try Regex(#"([\w.]+)*"#).firstMatch(in: tainted)

--- a/swift/ql/test/library-tests/regex/regex.ql
+++ b/swift/ql/test/library-tests/regex/regex.ql
@@ -9,7 +9,9 @@ bindingset[s]
 string quote(string s) { if s.matches("% %") then result = "\"" + s + "\"" else result = s }
 
 module RegexTest implements TestSig {
-  string getARelevantTag() { result = ["regex", "input", "redos-vulnerable", "hasParseFailure", "modes"] }
+  string getARelevantTag() {
+    result = ["regex", "input", "redos-vulnerable", "hasParseFailure", "modes"]
+  }
 
   predicate hasActualResult(Location location, string element, string tag, string value) {
     exists(TreeView::RegExpTerm t |

--- a/swift/ql/test/library-tests/regex/regex.ql
+++ b/swift/ql/test/library-tests/regex/regex.ql
@@ -34,7 +34,7 @@ module RegexTest implements TestSig {
       location = eval.getLocation() and
       element = eval.toString() and
       tag = "modes" and
-      value = regex.getFlags() and
+      value = quote(regex.getFlags()) and
       value != ""
     )
   }

--- a/swift/ql/test/library-tests/regex/regex.ql
+++ b/swift/ql/test/library-tests/regex/regex.ql
@@ -9,7 +9,7 @@ bindingset[s]
 string quote(string s) { if s.matches("% %") then result = "\"" + s + "\"" else result = s }
 
 module RegexTest implements TestSig {
-  string getARelevantTag() { result = ["regex", "input", "redos-vulnerable", "hasParseFailure"] }
+  string getARelevantTag() { result = ["regex", "input", "redos-vulnerable", "hasParseFailure", "modes"] }
 
   predicate hasActualResult(Location location, string element, string tag, string value) {
     exists(TreeView::RegExpTerm t |
@@ -27,6 +27,15 @@ module RegexTest implements TestSig {
       element = eval.toString() and
       tag = "hasParseFailure" and
       value = ""
+    )
+    or
+    exists(RegexEval eval, RegExp regex |
+      eval.getARegex() = regex and
+      location = eval.getLocation() and
+      element = eval.toString() and
+      tag = "modes" and
+      value = regex.getFlags() and
+      value != ""
     )
   }
 

--- a/swift/ql/test/library-tests/regex/regex.swift
+++ b/swift/ql/test/library-tests/regex/regex.swift
@@ -17,9 +17,12 @@ struct Regex<Output> : RegexComponent {
 
 	init(_ pattern: String) throws where Output == AnyRegexOutput { }
 
-	func firstMatch(in string: String) throws -> Regex<Output>.Match? { return nil}
-	func prefixMatch(in string: String) throws -> Regex<Output>.Match? { return nil}
-	func wholeMatch(in string: String) throws -> Regex<Output>.Match? { return nil}
+	func ignoresCase(_ ignoresCase: Bool = true) -> Regex<Regex<Output>.RegexOutput> { return self }
+	func dotMatchesNewlines(_ dotMatchesNewlines: Bool = true) -> Regex<Regex<Output>.RegexOutput> { return self }
+
+	func firstMatch(in string: String) throws -> Regex<Output>.Match? { return nil }
+	func prefixMatch(in string: String) throws -> Regex<Output>.Match? { return nil }
+	func wholeMatch(in string: String) throws -> Regex<Output>.Match? { return nil }
 
 	typealias RegexOutput = Output
 }
@@ -49,6 +52,7 @@ class NSString : NSObject {
 	    var rawValue: UInt
 
 		static var regularExpression: NSString.CompareOptions { get { return CompareOptions(rawValue: 1) } }
+		static var caseInsensitive: NSString.CompareOptions { get { return CompareOptions(rawValue: 2) } }
 	}
 
 	convenience init(string aString: String) { self.init() }
@@ -76,6 +80,9 @@ class NSTextCheckingResult : NSObject {
 class NSRegularExpression : NSObject {
 	struct Options : OptionSet {
 	    var rawValue: UInt
+
+		static var caseInsensitive: NSRegularExpression.Options { get { return Options(rawValue: 1) } }
+		static var dotMatchesLineSeparators: NSRegularExpression.Options { get { return Options(rawValue: 2) } }
 	}
 
 	struct MatchingOptions : OptionSet {
@@ -196,4 +203,24 @@ func myRegexpMethodsTests(b: Bool, str_unknown: String) throws {
 	// invalid (Swift doesn't like these regexs)
     _ = try Regex("[]a]").firstMatch(in: input) // this is valid in other regex implementations, and is likely harmless to accept
     _ = try Regex("[:aaaaa:]").firstMatch(in: input) // $ hasParseFailure
+
+	// --- parse modes ---
+
+    _ = try Regex("(?i)abc").firstMatch(in: input) // $ input=input modes=IGNORECASE regex=(?i)abc SPURIOUS: hasParseFailure
+    _ = try Regex("(?s)abc").firstMatch(in: input) // $ input=input modes=DOTALL regex=(?s)abc SPURIOUS: $hasParseFailure
+    _ = try Regex("(?is)abc").firstMatch(in: input) // $ input=input regex=(?is)abc MISSING: modes="DOTALL | IGNORECASE" SPURIOUS: modes=IGNORECASE $hasParseFailure
+
+    _ = try Regex("abc").dotMatchesNewlines(true).firstMatch(in: input) // $ input=input regex=abc MISSING: modes=DOTALL
+    _ = try Regex("abc").dotMatchesNewlines(false).firstMatch(in: input) // $ input=input regex=abc
+    _ = try Regex("abc").dotMatchesNewlines(true).dotMatchesNewlines(false).firstMatch(in: input) // $ input=input regex=abc
+    _ = try Regex("abc").dotMatchesNewlines(false).dotMatchesNewlines(true).firstMatch(in: input) // $ input=input regex=abc MISSING: modes=DOTALL
+    _ = try Regex("abc").dotMatchesNewlines().ignoresCase().firstMatch(in: input) // $ input=input regex=abc MISSING: modes="DOTALL | IGNORECASE"
+
+    _ = try NSRegularExpression(pattern: ".*", options: .caseInsensitive).firstMatch(in: input, range: NSMakeRange(0, input.utf16.count)) // $ regex=.* input=input MISSING: modes=IGNORECASE
+    _ = try NSRegularExpression(pattern: ".*", options: .dotMatchesLineSeparators).firstMatch(in: input, range: NSMakeRange(0, input.utf16.count)) // $ regex=.* input=input MISSING: modes=DOTALL
+    _ = try NSRegularExpression(pattern: ".*", options: [.caseInsensitive, .dotMatchesLineSeparators]).firstMatch(in: input, range: NSMakeRange(0, input.utf16.count)) // $ regex=.* input=input MISSING: modes="DOTALL | IGNORECASE"
+
+    _ = input.replacingOccurrences(of: ".*", with: "", options: [.regularExpression, .caseInsensitive]) // $ MISSING: regex=.* input=input modes=IGNORECASE
+
+    _ = NSString(string: "abc").replacingOccurrences(of: ".*", with: "", options: [.regularExpression, .caseInsensitive], range: NSMakeRange(0, inputNS.length)) // $ MISSING: regex=.* input=inputNS modes=IGNORECASE
 }

--- a/swift/ql/test/library-tests/regex/regex.swift
+++ b/swift/ql/test/library-tests/regex/regex.swift
@@ -223,4 +223,11 @@ func myRegexpMethodsTests(b: Bool, str_unknown: String) throws {
     _ = input.replacingOccurrences(of: ".*", with: "", options: [.regularExpression, .caseInsensitive]) // $ MISSING: regex=.* input=input modes=IGNORECASE
 
     _ = NSString(string: "abc").replacingOccurrences(of: ".*", with: "", options: [.regularExpression, .caseInsensitive], range: NSMakeRange(0, inputNS.length)) // $ MISSING: regex=.* input=inputNS modes=IGNORECASE
+
+    _ = try Regex("(?i-s)abc").firstMatch(in: input) // $ input=input regex=(?i-s)abc MISSING: modes=IGNORECASE SPURIOUS: modes="DOTALL | IGNORECASE"
+
+    // these cases use parse modes on localized areas of the regex, which we don't currently support
+    _ = try Regex("abc(?i)def").firstMatch(in: input) // $ input=input modes=IGNORECASE regex=abc(?i)def
+    _ = try Regex("abc(?i:def)ghi").firstMatch(in: input) // $ input=input modes=IGNORECASE regex=abc(?i:def)ghi
+    _ = try Regex("(?i)abc(?-i)def").firstMatch(in: input) // $ input=input modes=IGNORECASE regex=(?i)abc(?-i)def SPURIOUS: hasParseFailure=
 }

--- a/swift/ql/test/library-tests/regex/regex.swift
+++ b/swift/ql/test/library-tests/regex/regex.swift
@@ -206,9 +206,9 @@ func myRegexpMethodsTests(b: Bool, str_unknown: String) throws {
 
 	// --- parse modes ---
 
-    _ = try Regex("(?i)abc").firstMatch(in: input) // $ input=input modes=IGNORECASE regex=(?i)abc SPURIOUS: hasParseFailure
-    _ = try Regex("(?s)abc").firstMatch(in: input) // $ input=input modes=DOTALL regex=(?s)abc SPURIOUS: $hasParseFailure
-    _ = try Regex("(?is)abc").firstMatch(in: input) // $ input=input regex=(?is)abc MISSING: modes="DOTALL | IGNORECASE" SPURIOUS: modes=IGNORECASE $hasParseFailure
+    _ = try Regex("(?i)abc").firstMatch(in: input) // $ input=input modes=IGNORECASE regex=(?i)abc
+    _ = try Regex("(?s)abc").firstMatch(in: input) // $ input=input modes=DOTALL regex=(?s)abc
+    _ = try Regex("(?is)abc").firstMatch(in: input) // $ input=input regex=(?is)abc MISSING: modes="DOTALL | IGNORECASE" SPURIOUS: modes=IGNORECASE
 
     _ = try Regex("abc").dotMatchesNewlines(true).firstMatch(in: input) // $ input=input regex=abc MISSING: modes=DOTALL
     _ = try Regex("abc").dotMatchesNewlines(false).firstMatch(in: input) // $ input=input regex=abc

--- a/swift/ql/test/library-tests/regex/regex.swift
+++ b/swift/ql/test/library-tests/regex/regex.swift
@@ -208,7 +208,7 @@ func myRegexpMethodsTests(b: Bool, str_unknown: String) throws {
 
     _ = try Regex("(?i)abc").firstMatch(in: input) // $ input=input modes=IGNORECASE regex=(?i)abc
     _ = try Regex("(?s)abc").firstMatch(in: input) // $ input=input modes=DOTALL regex=(?s)abc
-    _ = try Regex("(?is)abc").firstMatch(in: input) // $ input=input regex=(?is)abc MISSING: modes="DOTALL | IGNORECASE" SPURIOUS: modes=IGNORECASE
+    _ = try Regex("(?is)abc").firstMatch(in: input) // $ input=input modes="DOTALL | IGNORECASE" regex=(?is)abc
 
     _ = try Regex("abc").dotMatchesNewlines(true).firstMatch(in: input) // $ input=input regex=abc MISSING: modes=DOTALL
     _ = try Regex("abc").dotMatchesNewlines(false).firstMatch(in: input) // $ input=input regex=abc


### PR DESCRIPTION
Recognize regular expression parse mode flags in Swift.  For example in `(?i)foo`, the `(?i)` specifies a case-insensitive match of the rest of the regular expression `foo`.

This improves the accuracy of the REDOS and bad HTML filtering queries (and others to come).

Limitations:
1. does not support alternative ways of setting the parse mode, i.e. using function calls / parameters outside of the regex string itself (this will be high priority follow-up work)
2. does not support modes specified in regex literals (because we don't support regex literals yet)
3. does not support setting the mode in the middle of a regex `foo(?i)bar`, which is allowed in Swift
4. does not support setting the mode only for a portion of a regex `(?i:foo)bar`, which is allowed in Swift
5. does not support turning flags off `(?i-s)`, which is allowed in Swift

@erik-krogh @joefarebrother the initial version of this was based on code from Java and is also very similar to Python.  I found that we were failing to recognize multiple mode flags (e.g. `(?is)`), which I fixed with https://github.com/github/codeql/commit/6e80021c4e460be0d7304f18c566eee423b140a4.  Please could you review those changes with a view to both correctness for Swift, and whether or not it would be desirable for me to port that fix to Java and/or Python?

I'm also curious whether we support any of what I described in limitations 3-5 above in other languages.  I suspect we do not, which makes it a pretty low priority for Swift where we're currently playing catch-up - but if we do it would be a starting point to solving them.