### PR TITLE
C++/Swift: Remove `none()` dataflow configuration predicates

### DIFF
--- a/cpp/ql/src/Critical/FlowAfterFree.qll
+++ b/cpp/ql/src/Critical/FlowAfterFree.qll
@@ -88,14 +88,6 @@ module FlowFromFree<isSinkSig/2 isASink, isExcludedSig/2 isExcluded> {
         e = any(StoreInstruction store).getDestinationAddress().getUnconvertedResultExpression()
       )
     }
-
-    predicate isBarrier(DataFlow::Node n, FlowState state) { none() }
-
-    predicate isAdditionalFlowStep(
-      DataFlow::Node n1, FlowState state1, DataFlow::Node n2, FlowState state2
-    ) {
-      none()
-    }
   }
 
   import DataFlow::GlobalWithState<FlowFromFreeConfig>

--- a/cpp/ql/src/Likely Bugs/Conversion/CastArrayPointerArithmetic.ql
+++ b/cpp/ql/src/Likely Bugs/Conversion/CastArrayPointerArithmetic.ql
@@ -44,14 +44,6 @@ module CastToPointerArithFlowConfig implements DataFlow::StateConfigSig {
     ) and
     getFullyConvertedType(node) = state
   }
-
-  predicate isBarrier(DataFlow::Node node, FlowState state) { none() }
-
-  predicate isAdditionalFlowStep(
-    DataFlow::Node node1, FlowState state1, DataFlow::Node node2, FlowState state2
-  ) {
-    none()
-  }
 }
 
 /**

--- a/cpp/ql/src/Security/CWE/CWE-078/ExecTainted.ql
+++ b/cpp/ql/src/Security/CWE/CWE-078/ExecTainted.ql
@@ -134,8 +134,6 @@ module ExecTaintConfig implements DataFlow::StateConfigSig {
 
   predicate isBarrier(DataFlow::Node node) { isBarrierImpl(node) }
 
-  predicate isBarrier(DataFlow::Node node, FlowState state) { none() }
-
   predicate isBarrierOut(DataFlow::Node node) {
     isSink(node, _) // Prevent duplicates along a call chain, since `shellCommand` will include wrappers
   }

--- a/cpp/ql/src/Security/CWE/CWE-119/OverrunWriteProductFlow.ql
+++ b/cpp/ql/src/Security/CWE/CWE-119/OverrunWriteProductFlow.ql
@@ -118,8 +118,6 @@ module ValidState {
       state = [false, true]
     }
 
-    predicate isBarrier(DataFlow::Node node, FlowState state) { none() }
-
     predicate isAdditionalFlowStep(
       DataFlow::Node node1, FlowState state1, DataFlow::Node node2, FlowState state2
     ) {

--- a/cpp/ql/src/experimental/Security/CWE/CWE-193/ConstantSizeArrayOffByOne.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-193/ConstantSizeArrayOffByOne.ql
@@ -168,8 +168,6 @@ module ArrayAddressToDerefConfig implements DataFlow::StateConfigSig {
     )
   }
 
-  predicate isBarrier(DataFlow::Node node, FlowState state) { none() }
-
   predicate isBarrierIn(DataFlow::Node node) { isSource(node, _) }
 
   predicate isBarrierOut(DataFlow::Node node) { isSink(node, _) }

--- a/swift/ql/lib/codeql/swift/security/StringLengthConflationQuery.qll
+++ b/swift/ql/lib/codeql/swift/security/StringLengthConflationQuery.qll
@@ -31,16 +31,8 @@ module StringLengthConflationConfig implements DataFlow::StateConfigSig {
 
   predicate isBarrier(DataFlow::Node barrier) { barrier instanceof StringLengthConflationBarrier }
 
-  predicate isBarrier(DataFlow::Node barrier, FlowState flowstate) { none() }
-
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
     any(StringLengthConflationAdditionalFlowStep s).step(nodeFrom, nodeTo)
-  }
-
-  predicate isAdditionalFlowStep(
-    DataFlow::Node nodeFrom, FlowState flowstateFrom, DataFlow::Node nodeTo, FlowState flowStateTo
-  ) {
-    none()
   }
 }
 


### PR DESCRIPTION
These now have default implementations that are also `none()`