### PR TITLE
Java: Improve the diagnostics consistency query

### DIFF
--- a/java/ql/consistency-queries/diags.ql
+++ b/java/ql/consistency-queries/diags.ql
@@ -28,7 +28,8 @@ string diagnosticMessage(Diagnostic d) {
 // something is fixed.
 query predicate unusedDiagnosticException(DiagnosticException de) { not exists(de.getException()) }
 
-query predicate unexpectedDiagnostic(Diagnostic d, string s) {
+query predicate unexpectedDiagnostic(Compilation c, int f, int i, Diagnostic d, string s) {
+  d.getCompilationInfo(c, f, i) and
   s = diagnosticMessage(d) and
   not d = any(DiagnosticException de).getException()
 }

--- a/java/ql/lib/change-notes/2023-07-14-getCompilationInfo.md
+++ b/java/ql/lib/change-notes/2023-07-14-getCompilationInfo.md
@@ -1,0 +1,4 @@
+---
+category: feature
+---
+* A `Diagnostic.getCompilationInfo()` predicate has been added.

--- a/java/ql/lib/semmle/code/java/Diagnostics.qll
+++ b/java/ql/lib/semmle/code/java/Diagnostics.qll
@@ -9,6 +9,11 @@ class Diagnostic extends @diagnostic {
   /** Gets the compilation that generated this diagnostic. */
   Compilation getCompilation() { diagnostic_for(this, result, _, _) }
 
+  /** Gets the compilation information for this diagnostic. */
+  predicate getCompilationInfo(Compilation c, int fileNumber, int diagnosticNumber) {
+    diagnostic_for(this, c, fileNumber, diagnosticNumber)
+  }
+
   /**
    * Gets the program that generated this diagnostic.
    */


### PR DESCRIPTION
Diagnostics can be easier to read if you see them in the order in which they were generated. By selecting the compilation and indexes, they get sorted by the testsuite driver.

`d.getCompilationInfo(c, f, i)` would be a bit more natural as `d = c.getDiagnostic(f, i)`, but currently we don't import Diagnostic into the default ('import java') namespace, and I don't think it's worth changing that for this.