### PR TITLE
Java: Exclude source-to-source flow in 5 queries.

### DIFF
--- a/java/ql/lib/semmle/code/java/security/ArithmeticTaintedQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/ArithmeticTaintedQuery.qll
@@ -11,6 +11,8 @@ module RemoteUserInputOverflowConfig implements DataFlow::ConfigSig {
   predicate isSink(DataFlow::Node sink) { overflowSink(_, sink.asExpr()) }
 
   predicate isBarrier(DataFlow::Node n) { overflowBarrier(n) }
+
+  predicate isBarrierIn(DataFlow::Node node) { isSource(node) }
 }
 
 /** A taint-tracking configuration to reason about underflow from unvalidated user input. */
@@ -20,6 +22,8 @@ module RemoteUserInputUnderflowConfig implements DataFlow::ConfigSig {
   predicate isSink(DataFlow::Node sink) { underflowSink(_, sink.asExpr()) }
 
   predicate isBarrier(DataFlow::Node n) { underflowBarrier(n) }
+
+  predicate isBarrierIn(DataFlow::Node node) { isSource(node) }
 }
 
 /** Taint-tracking flow for overflow from unvalidated user input. */

--- a/java/ql/lib/semmle/code/java/security/ImproperValidationOfArrayIndexQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/ImproperValidationOfArrayIndexQuery.qll
@@ -15,6 +15,8 @@ module ImproperValidationOfArrayIndexConfig implements DataFlow::ConfigSig {
   }
 
   predicate isBarrier(DataFlow::Node node) { node.getType() instanceof BooleanType }
+
+  predicate isBarrierIn(DataFlow::Node node) { isSource(node) }
 }
 
 /**

--- a/java/ql/lib/semmle/code/java/security/LogInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/LogInjectionQuery.qll
@@ -36,6 +36,8 @@ module LogInjectionConfig implements DataFlow::ConfigSig {
   predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
     any(LogInjectionAdditionalTaintStep c).step(node1, node2)
   }
+
+  predicate isBarrierIn(DataFlow::Node node) { isSource(node) }
 }
 
 /**

--- a/java/ql/lib/semmle/code/java/security/NumericCastTaintedQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/NumericCastTaintedQuery.qll
@@ -100,6 +100,8 @@ module NumericCastFlowConfig implements DataFlow::ConfigSig {
     node.getEnclosingCallable() instanceof HashCodeMethod or
     exists(RightShiftOp e | e.getShiftedVariable().getAnAccess() = node.asExpr())
   }
+
+  predicate isBarrierIn(DataFlow::Node node) { isSource(node) }
 }
 
 /**

--- a/java/ql/lib/semmle/code/java/security/RequestForgeryConfig.qll
+++ b/java/ql/lib/semmle/code/java/security/RequestForgeryConfig.qll
@@ -51,6 +51,8 @@ module RequestForgeryConfig implements DataFlow::ConfigSig {
   }
 
   predicate isBarrier(DataFlow::Node node) { node instanceof RequestForgerySanitizer }
+
+  predicate isBarrierIn(DataFlow::Node node) { isSource(node) }
 }
 
 module RequestForgeryFlow = TaintTracking::Global<RequestForgeryConfig>;


### PR DESCRIPTION
In certain projects there can be a lot of source-to-source flow, which can cause a cartesian explosion in the number of results for queries that already tends to have many results for such projects. A recent QA run identified these 5 queries to be the worst offenders in this regard.

Should fix https://github.com/github/codeql-java-team/issues/325