### PR TITLE
Swift: CustomUrlSchemes test enhancements and minor model improvement

### DIFF
--- a/swift/ql/lib/change-notes/2023-07-17-nsuseractivity-referrer-url.md
+++ b/swift/ql/lib/change-notes/2023-07-17-nsuseractivity-referrer-url.md
@@ -1,0 +1,5 @@
+---
+category: minorAnalysis
+---
+
+* Added taint flow for `NSUserActivity.referrerURL`.

--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/CustomUrlSchemes.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/CustomUrlSchemes.qll
@@ -81,7 +81,7 @@ private class UserActivityUrlInheritTaint extends TaintInheritingContent,
 {
   UserActivityUrlInheritTaint() {
     this.getField().getEnclosingDecl().asNominalTypeDecl().getName() = "NSUserActivity" and
-    this.getField().getName() = "webpageURL"
+    this.getField().getName() = ["webpageURL", "referrerURL"]
   }
 }
 

--- a/swift/ql/test/library-tests/dataflow/flowsources/CONSISTENCY/CfgConsistency.expected
+++ b/swift/ql/test/library-tests/dataflow/flowsources/CONSISTENCY/CfgConsistency.expected
@@ -1,3 +1,3 @@
 deadEnd
-| customurlschemes.swift:92:59:92:76 | options |
-| customurlschemes.swift:131:59:131:76 | options |
+| customurlschemes.swift:94:59:94:76 | options |
+| customurlschemes.swift:133:59:133:76 | options |

--- a/swift/ql/test/library-tests/dataflow/flowsources/CONSISTENCY/CfgConsistency.expected
+++ b/swift/ql/test/library-tests/dataflow/flowsources/CONSISTENCY/CfgConsistency.expected
@@ -1,0 +1,3 @@
+deadEnd
+| customurlschemes.swift:92:59:92:76 | options |
+| customurlschemes.swift:131:59:131:76 | options |

--- a/swift/ql/test/library-tests/dataflow/flowsources/FlowSourcesInline.ql
+++ b/swift/ql/test/library-tests/dataflow/flowsources/FlowSourcesInline.ql
@@ -35,10 +35,10 @@ module FlowSourcesTest implements TestSig {
       value = describe(source)
     )
     or
-    exists(DataFlow::Node source, DataFlow::Node sink |
+    exists(DataFlow::Node sink |
       // this is not really what the "flowsources" test is about, but sometimes it's helpful to
       // have sinks and confirm that taint reaches obvious points in the flow source test code.
-      TestFlow::flow(source, sink) and
+      TestFlow::flow(_, sink) and
       location = sink.getLocation() and
       element = sink.toString() and
       tag = "tainted" and

--- a/swift/ql/test/library-tests/dataflow/flowsources/FlowSourcesInline.ql
+++ b/swift/ql/test/library-tests/dataflow/flowsources/FlowSourcesInline.ql
@@ -38,7 +38,7 @@ module FlowSourcesTest implements TestSig {
     exists(DataFlow::Node sink |
       // this is not really what the "flowsources" test is about, but sometimes it's helpful to
       // have sinks and confirm that taint reaches obvious points in the flow source test code.
-      TestFlow::flow(_, sink) and
+      TestFlow::flowTo(sink) and
       location = sink.getLocation() and
       element = sink.toString() and
       tag = "tainted" and

--- a/swift/ql/test/library-tests/dataflow/flowsources/FlowSourcesInline.ql
+++ b/swift/ql/test/library-tests/dataflow/flowsources/FlowSourcesInline.ql
@@ -1,6 +1,16 @@
 import swift
 import TestUtilities.InlineExpectationsTest
 import FlowConfig
+import codeql.swift.dataflow.TaintTracking
+import codeql.swift.dataflow.DataFlow
+
+module TaintReachConfiguration implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node src) { src instanceof FlowSource }
+
+  predicate isSink(DataFlow::Node sink) { any() }
+}
+
+module TaintReachFlow = TaintTracking::Global<TaintReachConfiguration>;
 
 string describe(FlowSource source) {
   source instanceof RemoteFlowSource and result = "remote"
@@ -9,7 +19,7 @@ string describe(FlowSource source) {
 }
 
 module FlowSourcesTest implements TestSig {
-  string getARelevantTag() { result = "source" }
+  string getARelevantTag() { result = ["source", "tainted"] }
 
   predicate hasActualResult(Location location, string element, string tag, string value) {
     exists(FlowSource source |
@@ -18,6 +28,19 @@ module FlowSourcesTest implements TestSig {
       element = source.toString() and
       tag = "source" and
       value = describe(source)
+    )
+  }
+
+  predicate hasOptionalResult(Location location, string element, string tag, string value) {
+    // this is not really what the "flowsources" test is about, but sometimes it's helpful to
+    // confirm that taint reaches certain obvious points in the flow source test code.
+    exists(DataFlow::Node n |
+      TaintReachFlow::flowTo(n) and
+      location = n.getLocation() and
+      location.getFile().getBaseName() != "" and
+      element = n.toString() and
+      tag = "tainted" and
+      value = ""
     )
   }
 }

--- a/swift/ql/test/library-tests/dataflow/flowsources/customurlschemes.swift
+++ b/swift/ql/test/library-tests/dataflow/flowsources/customurlschemes.swift
@@ -107,14 +107,14 @@ class SceneDelegate : UISceneDelegate {
       let x = `continue`.webpageURL
       x // $ tainted
       let y = `continue`.referrerURL
-      y // $ MISSING: tainted
+      y // $ tainted
     }
 
     func scene(_: UIScene, didUpdate: NSUserActivity) { // $ source=remote
       let x = didUpdate.webpageURL
       x // $ tainted
       let y = didUpdate.referrerURL
-      y // $ MISSING: tainted
+      y // $ tainted
     }
 
     func scene(_: UIScene, openURLContexts: Set<UIOpenURLContext>) { // $ source=remote
@@ -146,14 +146,14 @@ extension Extended : UISceneDelegate {
       let x = `continue`.webpageURL
       x // $ tainted
       let y = `continue`.referrerURL
-      y // $ MISSING: tainted
+      y // $ tainted
     }
 
     func scene(_: UIScene, didUpdate: NSUserActivity) { // $ source=remote
       let x = didUpdate.webpageURL
       x // $ tainted
       let y = didUpdate.referrerURL
-      y // $ MISSING: tainted
+      y // $ tainted
     }
 
     func scene(_: UIScene, openURLContexts: Set<UIOpenURLContext>) { // $ source=remote

--- a/swift/ql/test/library-tests/dataflow/flowsources/customurlschemes.swift
+++ b/swift/ql/test/library-tests/dataflow/flowsources/customurlschemes.swift
@@ -62,6 +62,8 @@ protocol UISceneDelegate {
     func scene(_: UIScene, openURLContexts: Set<UIOpenURLContext>)
 }
 
+func sink(arg: Any) {}
+
 // --- tests ---
 
 class AppDelegate: UIApplicationDelegate {
@@ -92,35 +94,35 @@ class SceneDelegate : UISceneDelegate {
     func scene(_: UIScene, willConnectTo: UISceneSession, options: UIScene.ConnectionOptions) { // $ source=remote
       for userActivity in options.userActivities {
         let x = userActivity.webpageURL
-        x // $ MISSING: tainted
+        sink(arg: x) // $ MISSING: tainted
         let y = userActivity.referrerURL
-        y // $ MISSING: tainted
+        sink(arg: y) // $ MISSING: tainted
       }
 
       for urlContext in options.urlContexts {
         let z = urlContext.url
-        z // $ MISSING: tainted
+        sink(arg: z) // $ MISSING: tainted
       }
     }
 
     func scene(_: UIScene, continue: NSUserActivity) { // $ source=remote
       let x = `continue`.webpageURL
-      x // $ tainted
+      sink(arg: x) // $ tainted
       let y = `continue`.referrerURL
-      y // $ tainted
+      sink(arg: y) // $ tainted
     }
 
     func scene(_: UIScene, didUpdate: NSUserActivity) { // $ source=remote
       let x = didUpdate.webpageURL
-      x // $ tainted
+      sink(arg: x) // $ tainted
       let y = didUpdate.referrerURL
-      y // $ tainted
+      sink(arg: y) // $ tainted
     }
 
     func scene(_: UIScene, openURLContexts: Set<UIOpenURLContext>) { // $ source=remote
       for openURLContext in openURLContexts {
         let x = openURLContext.url
-        x // $ MISSING: tainted
+        sink(arg: x) // $ MISSING: tainted
       }
     }
 }
@@ -131,35 +133,35 @@ extension Extended : UISceneDelegate {
     func scene(_: UIScene, willConnectTo: UISceneSession, options: UIScene.ConnectionOptions) { // $ source=remote
       for userActivity in options.userActivities {
         let x = userActivity.webpageURL
-        x // $ MISSING: tainted
+        sink(arg: x) // $ MISSING: tainted
         let y = userActivity.referrerURL
-        y // $ MISSING: tainted
+        sink(arg: y) // $ MISSING: tainted
       }
 
       for urlContext in options.urlContexts {
         let z = urlContext.url
-        z // $ MISSING: tainted
+        sink(arg: z) // $ MISSING: tainted
       }
     }
 
     func scene(_: UIScene, continue: NSUserActivity) { // $ source=remote
       let x = `continue`.webpageURL
-      x // $ tainted
+      sink(arg: x) // $ tainted
       let y = `continue`.referrerURL
-      y // $ tainted
+      sink(arg: y) // $ tainted
     }
 
     func scene(_: UIScene, didUpdate: NSUserActivity) { // $ source=remote
       let x = didUpdate.webpageURL
-      x // $ tainted
+      sink(arg: x) // $ tainted
       let y = didUpdate.referrerURL
-      y // $ tainted
+      sink(arg: y) // $ tainted
     }
 
     func scene(_: UIScene, openURLContexts: Set<UIOpenURLContext>) { // $ source=remote
       for openURLContext in openURLContexts {
         let x = openURLContext.url
-        x // $ MISSING: tainted
+        sink(arg: x) // $ MISSING: tainted
       }
     }
 }

--- a/swift/ql/test/library-tests/dataflow/flowsources/customurlschemes.swift
+++ b/swift/ql/test/library-tests/dataflow/flowsources/customurlschemes.swift
@@ -26,12 +26,24 @@ protocol UIApplicationDelegate {
 }
 
 class UIScene {
-    class ConnectionOptions {}
+    class ConnectionOptions {
+        var userActivities: Set<NSUserActivity> { get { return Set() } }
+        var urlContexts: Set<UIOpenURLContext> { get { return Set() } }
+    }
 }
 
 class UISceneSession {}
 
-class NSUserActivity {}
+class NSUserActivity: Hashable {
+    static func == (lhs: NSUserActivity, rhs: NSUserActivity) -> Bool {
+        return true;
+    }
+
+    func hash(into hasher: inout Hasher) {}
+
+    var webpageURL: URL? { get { return nil } set { } }
+    var referrerURL: URL? { get { return nil } set { } }
+}
 
 class UIOpenURLContext: Hashable {
     static func == (lhs: UIOpenURLContext, rhs: UIOpenURLContext) -> Bool {
@@ -39,6 +51,8 @@ class UIOpenURLContext: Hashable {
     }
 
     func hash(into hasher: inout Hasher) {}
+
+    var url: URL { get { return URL() } }
 }
 
 protocol UISceneDelegate {
@@ -64,28 +78,88 @@ class AppDelegate: UIApplicationDelegate {
     }
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]?) -> Bool {
-        launchOptions?[.url] // $ source=remote
+        _ = launchOptions?[.url] // $ source=remote
         return true
     }
 
     func application(_ application: UIApplication, willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]?) -> Bool {
-        launchOptions?[.url] // $ source=remote
+        _ = launchOptions?[.url] // $ source=remote
         return true
     }
 }
 
 class SceneDelegate : UISceneDelegate {
-    func scene(_: UIScene, willConnectTo: UISceneSession, options: UIScene.ConnectionOptions) {} // $ source=remote
-    func scene(_: UIScene, continue: NSUserActivity) {} // $ source=remote
-    func scene(_: UIScene, didUpdate: NSUserActivity) {} // $ source=remote
-    func scene(_: UIScene, openURLContexts: Set<UIOpenURLContext>) {} // $ source=remote
+    func scene(_: UIScene, willConnectTo: UISceneSession, options: UIScene.ConnectionOptions) { // $ source=remote
+      for userActivity in options.userActivities {
+        let x = userActivity.webpageURL
+        x // $ MISSING: tainted
+        let y = userActivity.referrerURL
+        y // $ MISSING: tainted
+      }
+
+      for urlContext in options.urlContexts {
+        let z = urlContext.url
+        z // $ MISSING: tainted
+      }
+    }
+
+    func scene(_: UIScene, continue: NSUserActivity) { // $ source=remote
+      let x = `continue`.webpageURL
+      x // $ tainted
+      let y = `continue`.referrerURL
+      y // $ MISSING: tainted
+    }
+
+    func scene(_: UIScene, didUpdate: NSUserActivity) { // $ source=remote
+      let x = didUpdate.webpageURL
+      x // $ tainted
+      let y = didUpdate.referrerURL
+      y // $ MISSING: tainted
+    }
+
+    func scene(_: UIScene, openURLContexts: Set<UIOpenURLContext>) { // $ source=remote
+      for openURLContext in openURLContexts {
+        let x = openURLContext.url
+        x // $ MISSING: tainted
+      }
+    }
 }
 
 class Extended {}
 
 extension Extended : UISceneDelegate {
-    func scene(_: UIScene, willConnectTo: UISceneSession, options: UIScene.ConnectionOptions) {} // $ source=remote
-    func scene(_: UIScene, continue: NSUserActivity) {} // $ source=remote
-    func scene(_: UIScene, didUpdate: NSUserActivity) {} // $ source=remote
-    func scene(_: UIScene, openURLContexts: Set<UIOpenURLContext>) {} // $ source=remote
+    func scene(_: UIScene, willConnectTo: UISceneSession, options: UIScene.ConnectionOptions) { // $ source=remote
+      for userActivity in options.userActivities {
+        let x = userActivity.webpageURL
+        x // $ MISSING: tainted
+        let y = userActivity.referrerURL
+        y // $ MISSING: tainted
+      }
+
+      for urlContext in options.urlContexts {
+        let z = urlContext.url
+        z // $ MISSING: tainted
+      }
+    }
+
+    func scene(_: UIScene, continue: NSUserActivity) { // $ source=remote
+      let x = `continue`.webpageURL
+      x // $ tainted
+      let y = `continue`.referrerURL
+      y // $ MISSING: tainted
+    }
+
+    func scene(_: UIScene, didUpdate: NSUserActivity) { // $ source=remote
+      let x = didUpdate.webpageURL
+      x // $ tainted
+      let y = didUpdate.referrerURL
+      y // $ MISSING: tainted
+    }
+
+    func scene(_: UIScene, openURLContexts: Set<UIOpenURLContext>) { // $ source=remote
+      for openURLContext in openURLContexts {
+        let x = openURLContext.url
+        x // $ MISSING: tainted
+      }
+    }
 }


### PR DESCRIPTION
Add tests for the `TaintInheritingContent` defined in `CustomUrlSchemes.qll`.

Add one case I think was missing - [`NSUserActivity.referrerURL`](https://developer.apple.com/documentation/foundation/nsuseractivity/2875762-referrerurl).  @atorralba do you agree with this change or was it left our for a reason?

More significantly, these tests draw attention to the fact we don't model Swift `Set`s properly yet.  This will probably come after array and dictionary improvements but we need to get around to it.