### PR TITLE
Swift: Pragmatic fix for CustomUrlSchemes.qll.

### DIFF
--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/CustomUrlSchemes.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/CustomUrlSchemes.qll
@@ -58,7 +58,7 @@ private class LaunchOptionsUrlVarDecl extends VarDecl {
   LaunchOptionsUrlVarDecl() {
     // ideally this would be the more accurate, but currently less robust:
     // this.getEnclosingDecl().asNominalTypeDecl().getFullName() = "UIApplication.LaunchOptionsKey" and
-    this.getType().getName() = "UIApplication.LaunchOptionsKey" and
+    this.getType().(NominalType).getFullName() = "UIApplication.LaunchOptionsKey" and
     this.getName() = "url"
   }
 }

--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/CustomUrlSchemes.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/CustomUrlSchemes.qll
@@ -56,7 +56,9 @@ private class ApplicationWithLaunchOptionsFunc extends Function {
 
 private class LaunchOptionsUrlVarDecl extends VarDecl {
   LaunchOptionsUrlVarDecl() {
-    this.getEnclosingDecl().asNominalTypeDecl().getFullName() = "UIApplication.LaunchOptionsKey" and
+    // ideally this would be the more accurate, but currently less robust:
+    // this.getEnclosingDecl().asNominalTypeDecl().getFullName() = "UIApplication.LaunchOptionsKey" and
+    this.getType().getName() = "UIApplication.LaunchOptionsKey" and
     this.getName() = "url"
   }
 }


### PR DESCRIPTION
We don't recognize [`UIApplication.LaunchOptionsKey.url`](https://developer.apple.com/documentation/uikit/uiapplication/launchoptionskey/1622996-url) correctly for the purposes of a taint source in [`OversecuredVulnerableiOSApp`](https://github.com/oversecured/OversecuredVulnerableiOSApp/blob/deaec03a80483bb6cac782610f38cbbbdb920e20/OVIA/AppDelegate.swift#LL10C1-L10C1) (and likely other projects) because the enclosing struct `UIApplication.LaunchOptionsKey` is not associated with `url`.  Handily, the type of `url` also equals `UIApplication.LaunchOptionsKey`.  So for the time being, lets use that instead to make sure we're looking at the right thing called `url`.

I'll do some further experiments (including a DCA run) to verify this really does improve real world results...