### PR TITLE
Swift: Refactor regex library

### DIFF
--- a/swift/ql/lib/codeql/swift/regex/Regex.qll
+++ b/swift/ql/lib/codeql/swift/regex/Regex.qll
@@ -19,7 +19,7 @@ private class ParsedStringRegex extends RegExp, StringLiteralExpr {
   RegexEval eval;
 
   ParsedStringRegex() {
-    RegexUseFlow::flow(DataFlow::exprNode(this), DataFlow::exprNode(eval.getRegexInput()))
+    StringLiteralUseFlow::flow(DataFlow::exprNode(this), DataFlow::exprNode(eval.getRegexInput()))
   }
 
   /**

--- a/swift/ql/lib/codeql/swift/regex/Regex.qll
+++ b/swift/ql/lib/codeql/swift/regex/Regex.qll
@@ -6,32 +6,7 @@ import swift
 import codeql.swift.regex.RegexTreeView
 private import codeql.swift.dataflow.DataFlow
 private import internal.ParseRegex
-
-/**
- * A data flow configuration for tracking string literals that are used as
- * regular expressions.
- */
-private module RegexUseConfig implements DataFlow::ConfigSig {
-  predicate isSource(DataFlow::Node node) { node.asExpr() instanceof StringLiteralExpr }
-
-  predicate isSink(DataFlow::Node node) { node.asExpr() = any(RegexEval eval).getRegexInput() }
-
-  predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
-    // flow through `Regex` initializer, i.e. from a string to a `Regex` object.
-    exists(CallExpr call |
-      (
-        call.getStaticTarget().(Method).hasQualifiedName("Regex", ["init(_:)", "init(_:as:)"]) or
-        call.getStaticTarget()
-            .(Method)
-            .hasQualifiedName("NSRegularExpression", "init(pattern:options:)")
-      ) and
-      nodeFrom.asExpr() = call.getArgument(0).getExpr() and
-      nodeTo.asExpr() = call
-    )
-  }
-}
-
-private module RegexUseFlow = DataFlow::Global<RegexUseConfig>;
+private import internal.RegexTracking
 
 /**
  * A string literal that is used as a regular expression in a regular

--- a/swift/ql/lib/codeql/swift/regex/internal/RegexTracking.qll
+++ b/swift/ql/lib/codeql/swift/regex/internal/RegexTracking.qll
@@ -21,15 +21,9 @@ private module StringLiteralUseConfig implements DataFlow::ConfigSig {
 
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
     // flow through `Regex` initializer, i.e. from a string to a `Regex` object.
-    exists(CallExpr call |
-      (
-        call.getStaticTarget().(Method).hasQualifiedName("Regex", ["init(_:)", "init(_:as:)"]) or
-        call.getStaticTarget()
-            .(Method)
-            .hasQualifiedName("NSRegularExpression", "init(pattern:options:)")
-      ) and
-      nodeFrom.asExpr() = call.getArgument(0).getExpr() and
-      nodeTo.asExpr() = call
+    exists(RegexCreation regexCreation |
+      nodeFrom = regexCreation.getStringInput() and
+      nodeTo = regexCreation
     )
   }
 }

--- a/swift/ql/lib/codeql/swift/regex/internal/RegexTracking.qll
+++ b/swift/ql/lib/codeql/swift/regex/internal/RegexTracking.qll
@@ -36,9 +36,7 @@ module StringLiteralUseFlow = DataFlow::Global<StringLiteralUseConfig>;
 private module RegexUseConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node node) {
     // creation of the regex
-    exists(RegexCreation regexCreation |
-      node = regexCreation
-    )
+    node instanceof RegexCreation
     // TODO: track parse mode flags.
   }
 

--- a/swift/ql/lib/codeql/swift/regex/internal/RegexTracking.qll
+++ b/swift/ql/lib/codeql/swift/regex/internal/RegexTracking.qll
@@ -1,0 +1,37 @@
+/**
+ * Provides classes and predicates that track strings and regular expressions
+ * to where they are used, along with properties of the regex such as parse
+ * mode flags that have been set.
+ */
+
+import swift
+import codeql.swift.regex.RegexTreeView
+private import codeql.swift.dataflow.DataFlow
+private import ParseRegex
+private import codeql.swift.regex.Regex
+
+/**
+ * A data flow configuration for tracking string literals that are used as
+ * regular expressions.
+ */
+private module RegexUseConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node node) { node.asExpr() instanceof StringLiteralExpr }
+
+  predicate isSink(DataFlow::Node node) { node.asExpr() = any(RegexEval eval).getRegexInput() }
+
+  predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
+    // flow through `Regex` initializer, i.e. from a string to a `Regex` object.
+    exists(CallExpr call |
+      (
+        call.getStaticTarget().(Method).hasQualifiedName("Regex", ["init(_:)", "init(_:as:)"]) or
+        call.getStaticTarget()
+            .(Method)
+            .hasQualifiedName("NSRegularExpression", "init(pattern:options:)")
+      ) and
+      nodeFrom.asExpr() = call.getArgument(0).getExpr() and
+      nodeTo.asExpr() = call
+    )
+  }
+}
+
+module RegexUseFlow = DataFlow::Global<RegexUseConfig>;

--- a/swift/ql/lib/codeql/swift/regex/internal/RegexTracking.qll
+++ b/swift/ql/lib/codeql/swift/regex/internal/RegexTracking.qll
@@ -14,7 +14,7 @@ private import codeql.swift.regex.Regex
  * A data flow configuration for tracking string literals that are used as
  * regular expressions.
  */
-private module RegexUseConfig implements DataFlow::ConfigSig {
+private module StringLiteralUseConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node node) { node.asExpr() instanceof StringLiteralExpr }
 
   predicate isSink(DataFlow::Node node) { node.asExpr() = any(RegexEval eval).getRegexInput() }
@@ -34,4 +34,4 @@ private module RegexUseConfig implements DataFlow::ConfigSig {
   }
 }
 
-module RegexUseFlow = DataFlow::Global<RegexUseConfig>;
+module StringLiteralUseFlow = DataFlow::Global<StringLiteralUseConfig>;

--- a/swift/ql/test/query-tests/Security/CWE-1333/ReDoS.expected
+++ b/swift/ql/test/query-tests/Security/CWE-1333/ReDoS.expected
@@ -1,5 +1,7 @@
+| ReDoS.swift:64:22:64:22 | a* | This part of the regular expression may cause exponential backtracking on strings containing many repetitions of 'a'. |
 | ReDoS.swift:65:22:65:22 | a* | This part of the regular expression may cause exponential backtracking on strings containing many repetitions of 'a'. |
 | ReDoS.swift:66:22:66:22 | a* | This part of the regular expression may cause exponential backtracking on strings containing many repetitions of 'a'. |
 | ReDoS.swift:69:18:69:18 | a* | This part of the regular expression may cause exponential backtracking on strings containing many repetitions of 'a'. |
+| ReDoS.swift:75:46:75:46 | a* | This part of the regular expression may cause exponential backtracking on strings containing many repetitions of 'a'. |
 | ReDoS.swift:77:57:77:57 | a* | This part of the regular expression may cause exponential backtracking on strings containing many repetitions of 'a'. |
 | ReDoS.swift:80:57:80:57 | a* | This part of the regular expression may cause exponential backtracking on strings containing many repetitions of 'a'. |

--- a/swift/ql/test/query-tests/Security/CWE-1333/ReDoS.swift
+++ b/swift/ql/test/query-tests/Security/CWE-1333/ReDoS.swift
@@ -61,7 +61,7 @@ func myRegexpTests(myUrl: URL) throws {
     // Regex
 
     _ = "((a*)*b)" // GOOD (never used)
-    _ = try Regex("((a*)*b)") // DUBIOUS (never used)
+    _ = try Regex("((a*)*b)") // DUBIOUS (never used) [FLAGGED]
     _ = try Regex("((a*)*b)").firstMatch(in: untainted) // DUBIOUS (never used on tainted input) [FLAGGED]
     _ = try Regex("((a*)*b)").firstMatch(in: tainted) // BAD
     _ = try Regex(".*").firstMatch(in: tainted) // GOOD (safe regex)
@@ -72,7 +72,7 @@ func myRegexpTests(myUrl: URL) throws {
 
     // NSRegularExpression
 
-    _ = try? NSRegularExpression(pattern: "((a*)*b)") // DUBIOUS (never used)
+    _ = try? NSRegularExpression(pattern: "((a*)*b)") // DUBIOUS (never used) [FLAGGED]
 
     let nsregex1 = try? NSRegularExpression(pattern: "((a*)*b)") // DUBIOUS (never used on tainted input) [FLAGGED]
     _ = nsregex1?.stringByReplacingMatches(in: untainted, range: NSRange(location: 0, length: untainted.utf16.count), withTemplate: "")


### PR DESCRIPTION
Refactor the regex library data flow tracking.  This is necessary in order to (in a future PR) track mode flags through regular expression objects cleanly.

Before:
- `RegexUseConfig` tracked flow from string literals -> regex evaluation.
  - in some cases regex evaluation occurs directly on the string: `string literal --> RegexEval`.
  - more commonly a `Regex` object is created from the string, to be evaluated later; this was treated as an additional flow step, so the config actually tracked flow through both string and `Regex` objects: `string literal --> Regex constructor --> RegexEval`.

After:
- a new `RegexTracking.qll` file is introduced for the data flow configs.
- a new `RegexCreation` class models the creation of `Regex` objects, rather than being modelled ad-hoc.
- data flow is broken into two parts:
  - `StringLiteralUseFlow` for the string literal: `string literal -> RegexCreation OR RegexEval`.
  - `RegexUseConfig` for the `Regex` objects `RegexCreation -> RegexEval`.

There's a small change in results from the REDOS query, since we now assume any string reaching a `RegexCreation` is a regular expression, regardless of whether that `Regex` object goes on to be evaluated.  I think this is reasonable (an unevaluated `Regex` might be a code bug or just a failure of our data flow tracking to find the evaluation).