### PR TITLE
QL: Fix FP in `ql/missing-noinline`

### DIFF
--- a/ql/ql/src/queries/performance/MissingNoinline.ql
+++ b/ql/ql/src/queries/performance/MissingNoinline.ql
@@ -18,7 +18,9 @@ where
   not decl.getAnAnnotation() instanceof NoMagic and
   not decl.getAnAnnotation() instanceof NoOpt and
   not decl.getAnAnnotation().getName() = "cached" and
-  // If it's marked as inline it's probably because the QLDoc says something like
-  // "this predicate is inlined because it gives a better join-order".
-  not decl.getAnAnnotation() instanceof Inline
+  // If it's marked as inline (or has at least one bindingset annotation)
+  // it's probably because the QLDoc says something like "this predicate
+  // is inlined because it gives a better join-order".
+  not decl.getAnAnnotation() instanceof Inline and
+  not decl.getAnAnnotation() instanceof BindingSet
 select decl, "This predicate might be inlined."

--- a/ql/ql/src/queries/performance/MissingNoinline.ql
+++ b/ql/ql/src/queries/performance/MissingNoinline.ql
@@ -23,4 +23,4 @@ where
   // is inlined because it gives a better join-order".
   not decl.getAnAnnotation() instanceof Inline and
   not decl.getAnAnnotation() instanceof BindingSet
-select decl, "This predicate might be inlined."
+select decl, "This predicate should probably be marked pragma[noinline] to prevent inlining."

--- a/ql/ql/test/queries/performance/MissingNoInline/MissingNoInline.expected
+++ b/ql/ql/test/queries/performance/MissingNoInline/MissingNoInline.expected
@@ -1,0 +1,1 @@
+| Test.qll:8:11:8:25 | ClasslessPredicate missingNoInline | This predicate might be inlined. |

--- a/ql/ql/test/queries/performance/MissingNoInline/MissingNoInline.expected
+++ b/ql/ql/test/queries/performance/MissingNoInline/MissingNoInline.expected
@@ -1,1 +1,1 @@
-| Test.qll:8:11:8:25 | ClasslessPredicate missingNoInline | This predicate might be inlined. |
+| Test.qll:8:11:8:25 | ClasslessPredicate missingNoInline | This predicate should probably be marked pragma[noinline] to prevent inlining. |

--- a/ql/ql/test/queries/performance/MissingNoInline/MissingNoInline.qlref
+++ b/ql/ql/test/queries/performance/MissingNoInline/MissingNoInline.qlref
@@ -1,0 +1,1 @@
+queries/performance/MissingNoinline.ql

--- a/ql/ql/test/queries/performance/MissingNoInline/Test.qll
+++ b/ql/ql/test/queries/performance/MissingNoInline/Test.qll
@@ -1,0 +1,73 @@
+import ql
+
+/**
+ * Holds if `add.getLeftOperand() = e1` and `add.getRightOperand() = e2`.
+ *
+ * This predicate exists to fix a join order.
+ */
+predicate missingNoInline(AddExpr add, Expr e1, Expr e2) {
+  // BAD
+  add.getLeftOperand() = e1 and
+  add.getRightOperand() = e2
+}
+
+/**
+ * Holds if `add.getLeftOperand() = e1` and `add.getRightOperand() = e2`.
+ *
+ * This predicate exists to fix a join order.
+ */
+pragma[noinline]
+predicate noInlined(AddExpr add, Expr e1, Expr e2) {
+  // GOOD
+  add.getLeftOperand() = e1 and
+  add.getRightOperand() = e2
+}
+
+/**
+ * Holds if `add.getLeftOperand() = e1` and `add.getRightOperand() = e2`.
+ *
+ * This predicate exists to fix a join order.
+ */
+pragma[nomagic]
+predicate nomagicd(AddExpr add, Expr e1, Expr e2) {
+  // GOOD
+  add.getLeftOperand() = e1 and
+  add.getRightOperand() = e2
+}
+
+/**
+ * Holds if `add.getLeftOperand() = e1` and `add.getRightOperand() = e2`.
+ *
+ * This predicate exists to fix a join order.
+ */
+pragma[inline]
+predicate inlined(AddExpr add, Expr e1, Expr e2) {
+  // GOOD
+  add.getLeftOperand() = e1 and
+  add.getRightOperand() = e2
+}
+
+/**
+ * Holds if `add.getLeftOperand() = e1` and `add.getRightOperand() = e2`.
+ *
+ * This predicate exists to fix a join order.
+ */
+bindingset[add]
+predicate hasBindingset(AddExpr add, Expr e1, Expr e2) {
+  // GOOD
+  add.getLeftOperand() = e1 and
+  add.getRightOperand() = e2
+}
+
+/**
+ * Holds if `add.getLeftOperand() = e1` and `add.getRightOperand() = e2`.
+ *
+ * This predicate exists to fix a join order.
+ */
+pragma[noopt]
+predicate noOpted(AddExpr add, Expr e1, Expr e2) {
+  // GOOD
+  add instanceof AddExpr and
+  add.getLeftOperand() = e1 and
+  add.getRightOperand() = e2
+}


### PR DESCRIPTION
Fixes the FP surfaced [here](https://github.com/github/codeql/security/code-scanning/84853).