### PR TITLE
Java: Avoid low-confidence dispatch to InputStream methods

### DIFF
--- a/java/ql/lib/change-notes/2023-07-19-inputstream-dispatch.md
+++ b/java/ql/lib/change-notes/2023-07-19-inputstream-dispatch.md
@@ -1,0 +1,5 @@
+---
+category: minorAnalysis
+---
+* Improved the precision of virtual dispatch of `java.io.InputStream` methods. Now, calls to these methods will not dispatch to arbitrary implementations of `InputStream` if there is a high-confidence alternative (like a models-as-data summary).
+  

--- a/java/ql/lib/ext/java.io.model.yml
+++ b/java/ql/lib/ext/java.io.model.yml
@@ -116,6 +116,7 @@ extensions:
       - ["java.io", "File", "isDirectory", "()", "summary", "manual"]
       - ["java.io", "File", "mkdirs", "()", "summary", "manual"]
       - ["java.io", "FileInputStream", "FileInputStream", "(File)", "summary", "manual"]
+      - ["java.io", "InputStream", "read", "()", "summary", "manual"]
       - ["java.io", "InputStream", "close", "()", "summary", "manual"]
       - ["java.io", "OutputStream", "flush", "()", "summary", "manual"]
       # The below APIs have numeric flow and are currently being stored as neutral models.

--- a/java/ql/lib/ext/java.io.model.yml
+++ b/java/ql/lib/ext/java.io.model.yml
@@ -84,6 +84,7 @@ extensions:
       - ["java.io", "File", True, "toString", "", "", "Argument[this]", "ReturnValue", "taint", "manual"]
       - ["java.io", "File", True, "toURI", "", "", "Argument[this]", "ReturnValue", "taint", "manual"]
       - ["java.io", "FilterOutputStream", True, "FilterOutputStream", "(OutputStream)", "", "Argument[0]", "Argument[this]", "taint", "manual"]
+      - ["java.io", "InputStream", True, "read", "()", "", "Argument[this]", "ReturnValue", "taint", "manual"]
       - ["java.io", "InputStream", True, "read", "(byte[])", "", "Argument[this]", "Argument[0]", "taint", "manual"]
       - ["java.io", "InputStream", True, "read", "(byte[],int,int)", "", "Argument[this]", "Argument[0]", "taint", "manual"]
       - ["java.io", "InputStream", True, "readAllBytes", "", "", "Argument[this]", "ReturnValue", "taint", "manual"]
@@ -116,7 +117,6 @@ extensions:
       - ["java.io", "File", "isDirectory", "()", "summary", "manual"]
       - ["java.io", "File", "mkdirs", "()", "summary", "manual"]
       - ["java.io", "FileInputStream", "FileInputStream", "(File)", "summary", "manual"]
-      - ["java.io", "InputStream", "read", "()", "summary", "manual"]
       - ["java.io", "InputStream", "close", "()", "summary", "manual"]
       - ["java.io", "OutputStream", "flush", "()", "summary", "manual"]
       # The below APIs have numeric flow and are currently being stored as neutral models.

--- a/java/ql/lib/semmle/code/java/dispatch/VirtualDispatch.qll
+++ b/java/ql/lib/semmle/code/java/dispatch/VirtualDispatch.qll
@@ -102,6 +102,8 @@ private module Dispatch {
     or
     t instanceof Interface and not t.fromSource()
     or
+    t.hasQualifiedName("java.io", "InputStream")
+    or
     t.hasQualifiedName("java.io", "Serializable")
     or
     t.hasQualifiedName("java.lang", "Iterable")


### PR DESCRIPTION
Adds `java.io.InputStream` as a valid target class for low-confidence dispatch consideration.

Also adds a summary model for `InputStream.read()`, which offers a high-confidence alternative for this method.