### PR TITLE
Swift: Track regular expression parse modes set in code

### DIFF
--- a/swift/ql/lib/change-notes/2023-07-19-regex-mode-flags -more.md
+++ b/swift/ql/lib/change-notes/2023-07-19-regex-mode-flags -more.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The regular expression library now understands mode flags specified by `Regex` methods and the `NSRegularExpression` initializer.

--- a/swift/ql/lib/codeql/swift/regex/Regex.qll
+++ b/swift/ql/lib/codeql/swift/regex/Regex.qll
@@ -110,6 +110,9 @@ class RegexParseMode extends TRegexParseMode {
     this = MkUnicode() and result = "UNICODE"
   }
 
+  /**
+   * Gets a textual representation of this `RegexParseMode`.
+   */
   string toString() { result = this.getName() }
 }
 

--- a/swift/ql/lib/codeql/swift/regex/Regex.qll
+++ b/swift/ql/lib/codeql/swift/regex/Regex.qll
@@ -84,14 +84,20 @@ private class NSRegularExpressionRegexCreation extends RegexCreation {
   }
 }
 
-newtype TRegexParseMode =
+private newtype TRegexParseMode =
   MkIgnoreCase() or // case insensitive
   MkVerbose() or // ignores whitespace and `#` comments within patterns
   MkDotAll() or // dot matches all characters, including line terminators
   MkMultiLine() or // `^` and `$` also match beginning and end of lines
   MkUnicode() // Unicode UAX 29 word boundary mode
 
+/**
+ * A regular expression parse mode flag.
+ */
 class RegexParseMode extends TRegexParseMode {
+  /**
+   * Gets the name of this parse mode flag.
+   */
   string getName() {
     this = MkIgnoreCase() and result = "IGNORECASE"
     or
@@ -120,7 +126,7 @@ class RegexAdditionalFlowStep extends Unit {
   /**
    * Holds if a regular expression parse mode is either set (`isSet` = true)
    * or unset (`isSet` = false) at `node`. Parse modes propagate through
-   * array construction and regex constuction.
+   * array construction and regex construction.
    */
   abstract predicate setsParseMode(DataFlow::Node node, RegexParseMode mode, boolean isSet);
 }

--- a/swift/ql/lib/codeql/swift/regex/Regex.qll
+++ b/swift/ql/lib/codeql/swift/regex/Regex.qll
@@ -140,7 +140,7 @@ class RegexRegexAdditionalFlowStep extends RegexAdditionalFlowStep {
   private predicate setsParseModeEdge(
     DataFlow::Node nodeFrom, DataFlow::Node nodeTo, RegexParseMode mode, boolean isSet
   ) {
-    // `Regex` methods that modify parse mode
+    // `Regex` methods that modify the parse mode of an existing `Regex` object.
     exists(CallExpr ce |
       nodeFrom.asExpr() = ce.getQualifier() and
       nodeTo.asExpr() = ce and
@@ -166,11 +166,12 @@ class RegexRegexAdditionalFlowStep extends RegexAdditionalFlowStep {
 /**
  * An additional flow step for `NSRegularExpression`.
  */
-class StandardRegexAdditionalFlowStep extends RegexAdditionalFlowStep {
+class NSRegularExpressionRegexAdditionalFlowStep extends RegexAdditionalFlowStep {
   override predicate step(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) { none() }
 
   override predicate setsParseMode(DataFlow::Node node, RegexParseMode mode, boolean isSet) {
-    // `NSRegularExpression.Options` values
+    // `NSRegularExpression.Options` values (these are typically combined, then passed into
+    // the `NSRegularExpression` initializer).
     node.asExpr()
         .(MemberRefExpr)
         .getMember()

--- a/swift/ql/lib/codeql/swift/regex/internal/ParseRegex.qll
+++ b/swift/ql/lib/codeql/swift/regex/internal/ParseRegex.qll
@@ -6,6 +6,8 @@
  */
 
 import swift
+private import RegexTracking
+private import codeql.swift.regex.Regex
 
 /**
  * A `Expr` containing a regular expression term, that is, either
@@ -324,7 +326,17 @@ abstract class RegExp extends Expr {
    * MULTILINE
    * UNICODE
    */
-  string getAMode() { result = this.getModeFromPrefix() }
+  string getAMode() {
+    // mode flags from inside the regex string
+    result = this.getModeFromPrefix()
+    or
+    // mode flags applied to the regex object before evaluation
+    exists(RegexEval e |
+      e.getARegex() = this and
+      RegexParseModeFlow::flow(_, DataFlow::exprNode(e.getRegexInput())) and
+      result = "DOTALL" // TODO
+    )
+  }
 
   /**
    * Holds if the `i`th character could not be parsed.

--- a/swift/ql/lib/codeql/swift/regex/internal/ParseRegex.qll
+++ b/swift/ql/lib/codeql/swift/regex/internal/ParseRegex.qll
@@ -333,8 +333,7 @@ abstract class RegExp extends Expr {
     // mode flags applied to the regex object before evaluation
     exists(RegexEval e |
       e.getARegex() = this and
-      RegexParseModeFlow::flow(_, DataFlow::exprNode(e.getRegexInput())) and
-      result = "DOTALL" // TODO
+      result = e.getAParseMode().toString() // TODO: temp toString()
     )
   }
 

--- a/swift/ql/lib/codeql/swift/regex/internal/ParseRegex.qll
+++ b/swift/ql/lib/codeql/swift/regex/internal/ParseRegex.qll
@@ -319,7 +319,8 @@ abstract class RegExp extends Expr {
   }
 
   /**
-   * Gets a mode (if any) of this regular expression. Can be any of:
+   * Gets a mode (if any) of this regular expression in any evaluation. Can be
+   * any of:
    * IGNORECASE
    * VERBOSE
    * DOTALL
@@ -333,7 +334,7 @@ abstract class RegExp extends Expr {
     // mode flags applied to the regex object before evaluation
     exists(RegexEval e |
       e.getARegex() = this and
-      result = e.getAParseMode().toString() // TODO: temp toString()
+      result = e.getAParseMode().getName()
     )
   }
 

--- a/swift/ql/lib/codeql/swift/regex/internal/RegexTracking.qll
+++ b/swift/ql/lib/codeql/swift/regex/internal/RegexTracking.qll
@@ -67,7 +67,7 @@ private module RegexParseModeConfig implements DataFlow::StateConfigSig {
   predicate isSink(DataFlow::Node node, FlowState flowstate) {
     // evaluation of the regex
     node.asExpr() = any(RegexEval eval).getRegexInput() and
-    flowstate = any(FlowState fs)
+    exists(flowstate)
   }
 
   predicate isBarrier(DataFlow::Node node) { none() }

--- a/swift/ql/lib/codeql/swift/regex/internal/RegexTracking.qll
+++ b/swift/ql/lib/codeql/swift/regex/internal/RegexTracking.qll
@@ -6,7 +6,7 @@
 
 import swift
 import codeql.swift.regex.RegexTreeView
-private import codeql.swift.dataflow.DataFlow
+import codeql.swift.dataflow.DataFlow
 private import ParseRegex
 private import codeql.swift.regex.Regex
 
@@ -37,7 +37,6 @@ private module RegexUseConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node node) {
     // creation of the regex
     node instanceof RegexCreation
-    // TODO: track parse mode flags.
   }
 
   predicate isSink(DataFlow::Node node) {
@@ -46,9 +45,36 @@ private module RegexUseConfig implements DataFlow::ConfigSig {
   }
 
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
-    // TODO: flow through regex methods that return a modified regex.
-    none()
+    any(RegexAdditionalFlowStep s).step(nodeFrom, nodeTo)
   }
 }
 
 module RegexUseFlow = DataFlow::Global<RegexUseConfig>;
+
+/**
+ * A data flow configuration for tracking regular expression parse mode
+ * flags from the point they are set to the point of use. The flow state
+ * encodes which parse mode flag was set.
+ */
+private module RegexParseModeConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node node) {
+    // parse mode flag is set
+    any(RegexAdditionalFlowStep s).modifiesParseMode(_, node, MkDotAll(), true)
+  }
+
+  predicate isBarrierIn(DataFlow::Node node) {
+    // parse mode flag is set or unset
+    any(RegexAdditionalFlowStep s).modifiesParseMode(_, node, MkDotAll(), _)
+  }
+
+  predicate isSink(DataFlow::Node node) {
+    // evaluation of the regex
+    node.asExpr() = any(RegexEval eval).getRegexInput()
+  }
+
+  predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
+    any(RegexAdditionalFlowStep s).step(nodeFrom, nodeTo)
+  }
+}
+
+module RegexParseModeFlow = DataFlow::Global<RegexParseModeConfig>;

--- a/swift/ql/lib/codeql/swift/regex/internal/RegexTracking.qll
+++ b/swift/ql/lib/codeql/swift/regex/internal/RegexTracking.qll
@@ -66,14 +66,11 @@ private module RegexParseModeConfig implements DataFlow::StateConfigSig {
 
   predicate isSink(DataFlow::Node node, FlowState flowstate) {
     // evaluation of the regex
-    node.asExpr() = any(RegexEval eval).getRegexInput()
-    and
+    node.asExpr() = any(RegexEval eval).getRegexInput() and
     flowstate = any(FlowState fs)
   }
 
-  predicate isBarrier(DataFlow::Node node) {
-    none()
-  }
+  predicate isBarrier(DataFlow::Node node) { none() }
 
   predicate isBarrier(DataFlow::Node node, FlowState flowstate) {
     // parse mode flag is set or unset

--- a/swift/ql/test/library-tests/regex/parse.expected
+++ b/swift/ql/test/library-tests/regex/parse.expected
@@ -6327,83 +6327,71 @@ redos_variants.swift:
 #  579| [RegExpConstant, RegExpNormalChar] c
 
 regex.swift:
-#  110| [RegExpDot] .
+#  111| [RegExpDot] .
 
-#  110| [RegExpStar] .*
+#  111| [RegExpStar] .*
 #-----| 0 -> [RegExpDot] .
 
-#  132| [RegExpDot] .
+#  133| [RegExpDot] .
 
-#  132| [RegExpStar] .*
+#  133| [RegExpStar] .*
 #-----| 0 -> [RegExpDot] .
 
-#  149| [RegExpDot] .
+#  150| [RegExpDot] .
 
-#  149| [RegExpStar] .*
+#  150| [RegExpStar] .*
 #-----| 0 -> [RegExpDot] .
 
-#  149| [RegExpDot] .
+#  150| [RegExpDot] .
 
-#  149| [RegExpPlus] .+
+#  150| [RegExpPlus] .+
 #-----| 0 -> [RegExpDot] .
 
-#  156| [RegExpGroup] ([\w.]+)
+#  157| [RegExpGroup] ([\w.]+)
 #-----| 0 -> [RegExpPlus] [\w.]+
 
-#  156| [RegExpStar] ([\w.]+)*
+#  157| [RegExpStar] ([\w.]+)*
 #-----| 0 -> [RegExpGroup] ([\w.]+)
 
-#  156| [RegExpCharacterClass] [\w.]
+#  157| [RegExpCharacterClass] [\w.]
 #-----| 0 -> [RegExpCharacterClassEscape] \w
 #-----| 1 -> [RegExpConstant, RegExpNormalChar] .
 
-#  156| [RegExpPlus] [\w.]+
+#  157| [RegExpPlus] [\w.]+
 #-----| 0 -> [RegExpCharacterClass] [\w.]
 
-#  156| [RegExpCharacterClassEscape] \w
+#  157| [RegExpCharacterClassEscape] \w
 
-#  156| [RegExpConstant, RegExpNormalChar] .
+#  157| [RegExpConstant, RegExpNormalChar] .
 
-#  163| [RegExpConstant, RegExpNormalChar] 
-#  163| 
-
-#  164| [RegExpConstant, RegExpEscape] \n
+#  164| [RegExpConstant, RegExpNormalChar] 
+#  164| 
 
 #  165| [RegExpConstant, RegExpEscape] \n
 
-#  175| [RegExpConstant, RegExpNormalChar] aa
+#  166| [RegExpConstant, RegExpEscape] \n
 
-#  175| [RegExpAlt] aa|bb
+#  176| [RegExpConstant, RegExpNormalChar] aa
+
+#  176| [RegExpAlt] aa|bb
 #-----| 0 -> [RegExpConstant, RegExpNormalChar] aa
 #-----| 1 -> [RegExpConstant, RegExpNormalChar] bb
 
-#  175| [RegExpConstant, RegExpNormalChar] bb
+#  176| [RegExpConstant, RegExpNormalChar] bb
 
-#  179| [RegExpConstant, RegExpNormalChar] aa
+#  180| [RegExpConstant, RegExpNormalChar] aa
 
-#  179| [RegExpAlt] aa|
-#  179| bb
+#  180| [RegExpAlt] aa|
+#  180| bb
 #-----| 0 -> [RegExpConstant, RegExpNormalChar] aa
 #-----| 1 -> [RegExpConstant, RegExpNormalChar] 
 #-----| bb
 
-#  179| [RegExpConstant, RegExpNormalChar] 
-#  179| bb
+#  180| [RegExpConstant, RegExpNormalChar] 
+#  180| bb
 
-#  187| [RegExpCharacterClass] [a-z]
+#  188| [RegExpCharacterClass] [a-z]
 #-----| 0 -> [RegExpCharacterRange] a-z
-
-#  187| [RegExpConstant, RegExpNormalChar] a
-
-#  187| [RegExpCharacterRange] a-z
-#-----| 0 -> [RegExpConstant, RegExpNormalChar] a
-#-----| 1 -> [RegExpConstant, RegExpNormalChar] z
-
-#  187| [RegExpConstant, RegExpNormalChar] z
-
-#  188| [RegExpCharacterClass] [a-zA-Z]
-#-----| 0 -> [RegExpCharacterRange] a-z
-#-----| 1 -> [RegExpCharacterRange] A-Z
 
 #  188| [RegExpConstant, RegExpNormalChar] a
 
@@ -6413,119 +6401,129 @@ regex.swift:
 
 #  188| [RegExpConstant, RegExpNormalChar] z
 
-#  188| [RegExpConstant, RegExpNormalChar] A
+#  189| [RegExpCharacterClass] [a-zA-Z]
+#-----| 0 -> [RegExpCharacterRange] a-z
+#-----| 1 -> [RegExpCharacterRange] A-Z
 
-#  188| [RegExpCharacterRange] A-Z
+#  189| [RegExpConstant, RegExpNormalChar] a
+
+#  189| [RegExpCharacterRange] a-z
+#-----| 0 -> [RegExpConstant, RegExpNormalChar] a
+#-----| 1 -> [RegExpConstant, RegExpNormalChar] z
+
+#  189| [RegExpConstant, RegExpNormalChar] z
+
+#  189| [RegExpConstant, RegExpNormalChar] A
+
+#  189| [RegExpCharacterRange] A-Z
 #-----| 0 -> [RegExpConstant, RegExpNormalChar] A
 #-----| 1 -> [RegExpConstant, RegExpNormalChar] Z
 
-#  188| [RegExpConstant, RegExpNormalChar] Z
+#  189| [RegExpConstant, RegExpNormalChar] Z
 
-#  191| [RegExpCharacterClass] [a-]
+#  192| [RegExpCharacterClass] [a-]
 #-----| 0 -> [RegExpConstant, RegExpNormalChar] a
 #-----| 1 -> [RegExpConstant, RegExpNormalChar] -
 
-#  191| [RegExpConstant, RegExpNormalChar] a
-
-#  191| [RegExpConstant, RegExpNormalChar] -
-
-#  192| [RegExpCharacterClass] [-a]
-#-----| 0 -> [RegExpConstant, RegExpNormalChar] -
-#-----| 1 -> [RegExpConstant, RegExpNormalChar] a
+#  192| [RegExpConstant, RegExpNormalChar] a
 
 #  192| [RegExpConstant, RegExpNormalChar] -
 
-#  192| [RegExpConstant, RegExpNormalChar] a
-
-#  193| [RegExpCharacterClass] [-]
+#  193| [RegExpCharacterClass] [-a]
 #-----| 0 -> [RegExpConstant, RegExpNormalChar] -
+#-----| 1 -> [RegExpConstant, RegExpNormalChar] a
 
 #  193| [RegExpConstant, RegExpNormalChar] -
 
-#  194| [RegExpCharacterClass] [*]
+#  193| [RegExpConstant, RegExpNormalChar] a
+
+#  194| [RegExpCharacterClass] [-]
+#-----| 0 -> [RegExpConstant, RegExpNormalChar] -
+
+#  194| [RegExpConstant, RegExpNormalChar] -
+
+#  195| [RegExpCharacterClass] [*]
 #-----| 0 -> [RegExpConstant, RegExpNormalChar] *
 
-#  194| [RegExpConstant, RegExpNormalChar] *
+#  195| [RegExpConstant, RegExpNormalChar] *
 
-#  195| [RegExpCharacterClass] [^a]
+#  196| [RegExpCharacterClass] [^a]
 #-----| 0 -> [RegExpConstant, RegExpNormalChar] a
-
-#  195| [RegExpConstant, RegExpNormalChar] a
-
-#  196| [RegExpCharacterClass] [a^]
-#-----| 0 -> [RegExpConstant, RegExpNormalChar] a
-#-----| 1 -> [RegExpConstant, RegExpNormalChar] ^
 
 #  196| [RegExpConstant, RegExpNormalChar] a
 
-#  196| [RegExpConstant, RegExpNormalChar] ^
+#  197| [RegExpCharacterClass] [a^]
+#-----| 0 -> [RegExpConstant, RegExpNormalChar] a
+#-----| 1 -> [RegExpConstant, RegExpNormalChar] ^
 
-#  197| [RegExpCharacterClass] [\\]
+#  197| [RegExpConstant, RegExpNormalChar] a
+
+#  197| [RegExpConstant, RegExpNormalChar] ^
+
+#  198| [RegExpCharacterClass] [\\]
 #-----| 0 -> [RegExpConstant, RegExpEscape] \\
-
-#  197| [RegExpConstant, RegExpEscape] \\
-
-#  198| [RegExpCharacterClass] [\\\]]
-#-----| 0 -> [RegExpConstant, RegExpEscape] \\
-#-----| 1 -> [RegExpConstant, RegExpEscape] \]
 
 #  198| [RegExpConstant, RegExpEscape] \\
 
-#  198| [RegExpConstant, RegExpEscape] \]
+#  199| [RegExpCharacterClass] [\\\]]
+#-----| 0 -> [RegExpConstant, RegExpEscape] \\
+#-----| 1 -> [RegExpConstant, RegExpEscape] \]
 
-#  199| [RegExpCharacterClass] [:]
+#  199| [RegExpConstant, RegExpEscape] \\
+
+#  199| [RegExpConstant, RegExpEscape] \]
+
+#  200| [RegExpCharacterClass] [:]
 #-----| 0 -> [RegExpConstant, RegExpNormalChar] :
 
-#  199| [RegExpConstant, RegExpNormalChar] :
+#  200| [RegExpConstant, RegExpNormalChar] :
 
-#  200| [RegExpNamedCharacterProperty] [:digit:]
+#  201| [RegExpNamedCharacterProperty] [:digit:]
 
-#  201| [RegExpNamedCharacterProperty] [:alnum:]
+#  202| [RegExpNamedCharacterProperty] [:alnum:]
 
-#  204| [RegExpCharacterClass] []a]
+#  205| [RegExpCharacterClass] []a]
 #-----| 0 -> [RegExpConstant, RegExpNormalChar] ]
 #-----| 1 -> [RegExpConstant, RegExpNormalChar] a
 
-#  204| [RegExpConstant, RegExpNormalChar] ]
+#  205| [RegExpConstant, RegExpNormalChar] ]
 
-#  204| [RegExpConstant, RegExpNormalChar] a
+#  205| [RegExpConstant, RegExpNormalChar] a
 
-#  205| [RegExpNamedCharacterProperty] [:aaaaa:]
+#  206| [RegExpNamedCharacterProperty] [:aaaaa:]
 
-#  209| [RegExpGroup] (?i)
+#  210| [RegExpGroup] (?i)
 #-----| 0 -> [RegExpConstant, RegExpNormalChar] i
 
-#  209| [RegExpSequence] (?i)abc
+#  210| [RegExpSequence] (?i)abc
 #-----| 0 -> [RegExpGroup] (?i)
 #-----| 1 -> [RegExpConstant, RegExpNormalChar] abc
 
-#  209| [RegExpConstant, RegExpNormalChar] i
-
-#  209| [RegExpConstant, RegExpNormalChar] abc
-
-#  210| [RegExpGroup] (?s)
-#-----| 0 -> [RegExpConstant, RegExpNormalChar] s
-
-#  210| [RegExpSequence] (?s)abc
-#-----| 0 -> [RegExpGroup] (?s)
-#-----| 1 -> [RegExpConstant, RegExpNormalChar] abc
-
-#  210| [RegExpConstant, RegExpNormalChar] s
+#  210| [RegExpConstant, RegExpNormalChar] i
 
 #  210| [RegExpConstant, RegExpNormalChar] abc
 
-#  211| [RegExpGroup] (?is)
-#-----| 0 -> [RegExpConstant, RegExpNormalChar] is
+#  211| [RegExpGroup] (?s)
+#-----| 0 -> [RegExpConstant, RegExpNormalChar] s
 
-#  211| [RegExpSequence] (?is)abc
-#-----| 0 -> [RegExpGroup] (?is)
+#  211| [RegExpSequence] (?s)abc
+#-----| 0 -> [RegExpGroup] (?s)
 #-----| 1 -> [RegExpConstant, RegExpNormalChar] abc
 
-#  211| [RegExpConstant, RegExpNormalChar] is
+#  211| [RegExpConstant, RegExpNormalChar] s
 
 #  211| [RegExpConstant, RegExpNormalChar] abc
 
-#  213| [RegExpConstant, RegExpNormalChar] abc
+#  212| [RegExpGroup] (?is)
+#-----| 0 -> [RegExpConstant, RegExpNormalChar] is
+
+#  212| [RegExpSequence] (?is)abc
+#-----| 0 -> [RegExpGroup] (?is)
+#-----| 1 -> [RegExpConstant, RegExpNormalChar] abc
+
+#  212| [RegExpConstant, RegExpNormalChar] is
+
+#  212| [RegExpConstant, RegExpNormalChar] abc
 
 #  214| [RegExpConstant, RegExpNormalChar] abc
 
@@ -6535,67 +6533,71 @@ regex.swift:
 
 #  217| [RegExpConstant, RegExpNormalChar] abc
 
-#  219| [RegExpDot] .
+#  218| [RegExpConstant, RegExpNormalChar] abc
 
-#  219| [RegExpStar] .*
-#-----| 0 -> [RegExpDot] .
-
-#  220| [RegExpDot] .
-
-#  220| [RegExpStar] .*
-#-----| 0 -> [RegExpDot] .
+#  219| [RegExpConstant, RegExpNormalChar] abc
 
 #  221| [RegExpDot] .
 
 #  221| [RegExpStar] .*
 #-----| 0 -> [RegExpDot] .
 
-#  227| [RegExpGroup] (?i-s)
+#  222| [RegExpDot] .
+
+#  222| [RegExpStar] .*
+#-----| 0 -> [RegExpDot] .
+
+#  223| [RegExpDot] .
+
+#  223| [RegExpStar] .*
+#-----| 0 -> [RegExpDot] .
+
+#  229| [RegExpGroup] (?i-s)
 #-----| 0 -> [RegExpConstant, RegExpNormalChar] i-s
 
-#  227| [RegExpSequence] (?i-s)abc
+#  229| [RegExpSequence] (?i-s)abc
 #-----| 0 -> [RegExpGroup] (?i-s)
 #-----| 1 -> [RegExpConstant, RegExpNormalChar] abc
 
-#  227| [RegExpConstant, RegExpNormalChar] i-s
+#  229| [RegExpConstant, RegExpNormalChar] i-s
 
-#  227| [RegExpConstant, RegExpNormalChar] abc
+#  229| [RegExpConstant, RegExpNormalChar] abc
 
-#  230| [RegExpConstant, RegExpNormalChar] abc
+#  232| [RegExpConstant, RegExpNormalChar] abc
 
-#  230| [RegExpSequence] abc(?i)def
+#  232| [RegExpSequence] abc(?i)def
 #-----| 0 -> [RegExpConstant, RegExpNormalChar] abc
 #-----| 1 -> [RegExpGroup] (?i)
 #-----| 2 -> [RegExpConstant, RegExpNormalChar] def
-
-#  230| [RegExpGroup] (?i)
-#-----| 0 -> [RegExpConstant, RegExpNormalChar] i
-
-#  230| [RegExpConstant, RegExpNormalChar] i
-
-#  230| [RegExpConstant, RegExpNormalChar] def
-
-#  231| [RegExpConstant, RegExpNormalChar] abc
-
-#  231| [RegExpSequence] abc(?i:def)ghi
-#-----| 0 -> [RegExpConstant, RegExpNormalChar] abc
-#-----| 1 -> [RegExpGroup] (?i:def)
-#-----| 2 -> [RegExpConstant, RegExpNormalChar] ghi
-
-#  231| [RegExpGroup] (?i:def)
-#-----| 0 -> [RegExpConstant, RegExpNormalChar] i:def
-
-#  231| [RegExpConstant, RegExpNormalChar] i:def
-
-#  231| [RegExpConstant, RegExpNormalChar] ghi
 
 #  232| [RegExpGroup] (?i)
 #-----| 0 -> [RegExpConstant, RegExpNormalChar] i
 
 #  232| [RegExpConstant, RegExpNormalChar] i
 
-#  232| [RegExpConstant, RegExpNormalChar] abc
-
-#  232| [RegExpConstant, RegExpNormalChar] -i
-
 #  232| [RegExpConstant, RegExpNormalChar] def
+
+#  233| [RegExpConstant, RegExpNormalChar] abc
+
+#  233| [RegExpSequence] abc(?i:def)ghi
+#-----| 0 -> [RegExpConstant, RegExpNormalChar] abc
+#-----| 1 -> [RegExpGroup] (?i:def)
+#-----| 2 -> [RegExpConstant, RegExpNormalChar] ghi
+
+#  233| [RegExpGroup] (?i:def)
+#-----| 0 -> [RegExpConstant, RegExpNormalChar] i:def
+
+#  233| [RegExpConstant, RegExpNormalChar] i:def
+
+#  233| [RegExpConstant, RegExpNormalChar] ghi
+
+#  234| [RegExpGroup] (?i)
+#-----| 0 -> [RegExpConstant, RegExpNormalChar] i
+
+#  234| [RegExpConstant, RegExpNormalChar] i
+
+#  234| [RegExpConstant, RegExpNormalChar] abc
+
+#  234| [RegExpConstant, RegExpNormalChar] -i
+
+#  234| [RegExpConstant, RegExpNormalChar] def

--- a/swift/ql/test/library-tests/regex/parse.expected
+++ b/swift/ql/test/library-tests/regex/parse.expected
@@ -6492,112 +6492,117 @@ regex.swift:
 
 #  206| [RegExpNamedCharacterProperty] [:aaaaa:]
 
-#  210| [RegExpGroup] (?i)
+#  211| [RegExpGroup] (?i)
 #-----| 0 -> [RegExpConstant, RegExpNormalChar] i
 
-#  210| [RegExpSequence] (?i)abc
+#  211| [RegExpSequence] (?i)abc
 #-----| 0 -> [RegExpGroup] (?i)
 #-----| 1 -> [RegExpConstant, RegExpNormalChar] abc
 
-#  210| [RegExpConstant, RegExpNormalChar] i
-
-#  210| [RegExpConstant, RegExpNormalChar] abc
-
-#  211| [RegExpGroup] (?s)
-#-----| 0 -> [RegExpConstant, RegExpNormalChar] s
-
-#  211| [RegExpSequence] (?s)abc
-#-----| 0 -> [RegExpGroup] (?s)
-#-----| 1 -> [RegExpConstant, RegExpNormalChar] abc
-
-#  211| [RegExpConstant, RegExpNormalChar] s
+#  211| [RegExpConstant, RegExpNormalChar] i
 
 #  211| [RegExpConstant, RegExpNormalChar] abc
 
-#  212| [RegExpGroup] (?is)
-#-----| 0 -> [RegExpConstant, RegExpNormalChar] is
+#  212| [RegExpGroup] (?s)
+#-----| 0 -> [RegExpConstant, RegExpNormalChar] s
 
-#  212| [RegExpSequence] (?is)abc
-#-----| 0 -> [RegExpGroup] (?is)
+#  212| [RegExpSequence] (?s)abc
+#-----| 0 -> [RegExpGroup] (?s)
 #-----| 1 -> [RegExpConstant, RegExpNormalChar] abc
 
-#  212| [RegExpConstant, RegExpNormalChar] is
+#  212| [RegExpConstant, RegExpNormalChar] s
 
 #  212| [RegExpConstant, RegExpNormalChar] abc
 
-#  214| [RegExpConstant, RegExpNormalChar] abc
+#  213| [RegExpGroup] (?is)
+#-----| 0 -> [RegExpConstant, RegExpNormalChar] is
 
-#  215| [RegExpConstant, RegExpNormalChar] abc
+#  213| [RegExpSequence] (?is)abc
+#-----| 0 -> [RegExpGroup] (?is)
+#-----| 1 -> [RegExpConstant, RegExpNormalChar] abc
 
-#  216| [RegExpConstant, RegExpNormalChar] abc
+#  213| [RegExpConstant, RegExpNormalChar] is
 
-#  217| [RegExpConstant, RegExpNormalChar] abc
+#  213| [RegExpConstant, RegExpNormalChar] abc
 
-#  218| [RegExpConstant, RegExpNormalChar] abc
-
-#  219| [RegExpConstant, RegExpNormalChar] abc
-
-#  221| [RegExpDot] .
-
-#  221| [RegExpStar] .*
-#-----| 0 -> [RegExpDot] .
-
-#  222| [RegExpDot] .
-
-#  222| [RegExpStar] .*
-#-----| 0 -> [RegExpDot] .
-
-#  223| [RegExpDot] .
-
-#  223| [RegExpStar] .*
-#-----| 0 -> [RegExpDot] .
-
-#  229| [RegExpGroup] (?i-s)
+#  214| [RegExpGroup] (?i-s)
 #-----| 0 -> [RegExpConstant, RegExpNormalChar] i-s
 
-#  229| [RegExpSequence] (?i-s)abc
+#  214| [RegExpSequence] (?i-s)abc
 #-----| 0 -> [RegExpGroup] (?i-s)
 #-----| 1 -> [RegExpConstant, RegExpNormalChar] abc
 
-#  229| [RegExpConstant, RegExpNormalChar] i-s
+#  214| [RegExpConstant, RegExpNormalChar] i-s
 
-#  229| [RegExpConstant, RegExpNormalChar] abc
+#  214| [RegExpConstant, RegExpNormalChar] abc
 
-#  232| [RegExpConstant, RegExpNormalChar] abc
+#  217| [RegExpConstant, RegExpNormalChar] abc
 
-#  232| [RegExpSequence] abc(?i)def
+#  217| [RegExpSequence] abc(?i)def
 #-----| 0 -> [RegExpConstant, RegExpNormalChar] abc
 #-----| 1 -> [RegExpGroup] (?i)
 #-----| 2 -> [RegExpConstant, RegExpNormalChar] def
 
-#  232| [RegExpGroup] (?i)
+#  217| [RegExpGroup] (?i)
 #-----| 0 -> [RegExpConstant, RegExpNormalChar] i
 
-#  232| [RegExpConstant, RegExpNormalChar] i
+#  217| [RegExpConstant, RegExpNormalChar] i
 
-#  232| [RegExpConstant, RegExpNormalChar] def
+#  217| [RegExpConstant, RegExpNormalChar] def
 
-#  233| [RegExpConstant, RegExpNormalChar] abc
+#  218| [RegExpConstant, RegExpNormalChar] abc
 
-#  233| [RegExpSequence] abc(?i:def)ghi
+#  218| [RegExpSequence] abc(?i:def)ghi
 #-----| 0 -> [RegExpConstant, RegExpNormalChar] abc
 #-----| 1 -> [RegExpGroup] (?i:def)
 #-----| 2 -> [RegExpConstant, RegExpNormalChar] ghi
 
-#  233| [RegExpGroup] (?i:def)
+#  218| [RegExpGroup] (?i:def)
 #-----| 0 -> [RegExpConstant, RegExpNormalChar] i:def
 
-#  233| [RegExpConstant, RegExpNormalChar] i:def
+#  218| [RegExpConstant, RegExpNormalChar] i:def
 
-#  233| [RegExpConstant, RegExpNormalChar] ghi
+#  218| [RegExpConstant, RegExpNormalChar] ghi
 
-#  234| [RegExpGroup] (?i)
+#  219| [RegExpGroup] (?i)
 #-----| 0 -> [RegExpConstant, RegExpNormalChar] i
 
-#  234| [RegExpConstant, RegExpNormalChar] i
+#  219| [RegExpConstant, RegExpNormalChar] i
 
-#  234| [RegExpConstant, RegExpNormalChar] abc
+#  219| [RegExpConstant, RegExpNormalChar] abc
 
-#  234| [RegExpConstant, RegExpNormalChar] -i
+#  219| [RegExpConstant, RegExpNormalChar] -i
 
-#  234| [RegExpConstant, RegExpNormalChar] def
+#  219| [RegExpConstant, RegExpNormalChar] def
+
+#  222| [RegExpConstant, RegExpNormalChar] abc
+
+#  223| [RegExpConstant, RegExpNormalChar] abc
+
+#  224| [RegExpConstant, RegExpNormalChar] abc
+
+#  225| [RegExpConstant, RegExpNormalChar] abc
+
+#  226| [RegExpConstant, RegExpNormalChar] abc
+
+#  227| [RegExpConstant, RegExpNormalChar] abc
+
+#  230| [RegExpDot] .
+
+#  230| [RegExpStar] .*
+#-----| 0 -> [RegExpDot] .
+
+#  231| [RegExpDot] .
+
+#  231| [RegExpStar] .*
+#-----| 0 -> [RegExpDot] .
+
+#  232| [RegExpDot] .
+
+#  232| [RegExpStar] .*
+#-----| 0 -> [RegExpDot] .
+
+#  235| [RegExpDot] .
+
+#  235| [RegExpStar] .*
+#-----| 0 -> [RegExpDot] .

--- a/swift/ql/test/library-tests/regex/regex.swift
+++ b/swift/ql/test/library-tests/regex/regex.swift
@@ -210,11 +210,11 @@ func myRegexpMethodsTests(b: Bool, str_unknown: String) throws {
     _ = try Regex("(?s)abc").firstMatch(in: input) // $ input=input modes=DOTALL regex=(?s)abc
     _ = try Regex("(?is)abc").firstMatch(in: input) // $ input=input modes="DOTALL | IGNORECASE" regex=(?is)abc
 
-    _ = try Regex("abc").dotMatchesNewlines(true).firstMatch(in: input) // $ input=input regex=abc MISSING: modes=DOTALL
+    _ = try Regex("abc").dotMatchesNewlines(true).firstMatch(in: input) // $ input=input regex=abc modes=DOTALL
     _ = try Regex("abc").dotMatchesNewlines(false).firstMatch(in: input) // $ input=input regex=abc
     _ = try Regex("abc").dotMatchesNewlines(true).dotMatchesNewlines(false).firstMatch(in: input) // $ input=input regex=abc
-    _ = try Regex("abc").dotMatchesNewlines(false).dotMatchesNewlines(true).firstMatch(in: input) // $ input=input regex=abc MISSING: modes=DOTALL
-    _ = try Regex("abc").dotMatchesNewlines().ignoresCase().firstMatch(in: input) // $ input=input regex=abc MISSING: modes="DOTALL | IGNORECASE"
+    _ = try Regex("abc").dotMatchesNewlines(false).dotMatchesNewlines(true).firstMatch(in: input) // $ input=input regex=abc modes=DOTALL
+    _ = try Regex("abc").dotMatchesNewlines().ignoresCase().firstMatch(in: input) // $ input=input regex=abc SPURIOUS: modes=DOTALL MISSING: modes="DOTALL | IGNORECASE"
 
     _ = try NSRegularExpression(pattern: ".*", options: .caseInsensitive).firstMatch(in: input, range: NSMakeRange(0, input.utf16.count)) // $ regex=.* input=input MISSING: modes=IGNORECASE
     _ = try NSRegularExpression(pattern: ".*", options: .dotMatchesLineSeparators).firstMatch(in: input, range: NSMakeRange(0, input.utf16.count)) // $ regex=.* input=input MISSING: modes=DOTALL

--- a/swift/ql/test/library-tests/regex/regex.swift
+++ b/swift/ql/test/library-tests/regex/regex.swift
@@ -17,9 +17,9 @@ struct Regex<Output> : RegexComponent {
 
 	init(_ pattern: String) throws where Output == AnyRegexOutput { }
 
-	func ignoresCase(_ ignoresCase: Bool = true) -> Regex<Regex<Output>.RegexOutput> { return self }
-	func dotMatchesNewlines(_ dotMatchesNewlines: Bool = true) -> Regex<Regex<Output>.RegexOutput> { return self }
-	func anchorsMatchLineEndings(_ matchLineEndings: Bool = true) -> Regex<Regex<Output>.RegexOutput> { return self }
+	func ignoresCase(_ ignoresCase: Bool = true) -> Regex<Regex<Output>.RegexOutput> { return 0 as! Self }
+	func dotMatchesNewlines(_ dotMatchesNewlines: Bool = true) -> Regex<Regex<Output>.RegexOutput> { return 0 as! Self }
+	func anchorsMatchLineEndings(_ matchLineEndings: Bool = true) -> Regex<Regex<Output>.RegexOutput> { return 0 as! Self }
 
 	func firstMatch(in string: String) throws -> Regex<Output>.Match? { return nil }
 	func prefixMatch(in string: String) throws -> Regex<Output>.Match? { return nil }

--- a/swift/ql/test/library-tests/regex/regex.swift
+++ b/swift/ql/test/library-tests/regex/regex.swift
@@ -19,6 +19,7 @@ struct Regex<Output> : RegexComponent {
 
 	func ignoresCase(_ ignoresCase: Bool = true) -> Regex<Regex<Output>.RegexOutput> { return self }
 	func dotMatchesNewlines(_ dotMatchesNewlines: Bool = true) -> Regex<Regex<Output>.RegexOutput> { return self }
+	func anchorsMatchLineEndings(_ matchLineEndings: Bool = true) -> Regex<Regex<Output>.RegexOutput> { return self }
 
 	func firstMatch(in string: String) throws -> Regex<Output>.Match? { return nil }
 	func prefixMatch(in string: String) throws -> Regex<Output>.Match? { return nil }
@@ -215,6 +216,7 @@ func myRegexpMethodsTests(b: Bool, str_unknown: String) throws {
     _ = try Regex("abc").dotMatchesNewlines(true).dotMatchesNewlines(false).firstMatch(in: input) // $ input=input regex=abc
     _ = try Regex("abc").dotMatchesNewlines(false).dotMatchesNewlines(true).firstMatch(in: input) // $ input=input regex=abc modes=DOTALL
     _ = try Regex("abc").dotMatchesNewlines().ignoresCase().firstMatch(in: input) // $ input=input regex=abc modes="DOTALL | IGNORECASE"
+    _ = try Regex("abc").anchorsMatchLineEndings().firstMatch(in: input) // $ input=input regex=abc modes=MULTILINE
 
     _ = try NSRegularExpression(pattern: ".*", options: .caseInsensitive).firstMatch(in: input, range: NSMakeRange(0, input.utf16.count)) // $ regex=.* input=input MISSING: modes=IGNORECASE
     _ = try NSRegularExpression(pattern: ".*", options: .dotMatchesLineSeparators).firstMatch(in: input, range: NSMakeRange(0, input.utf16.count)) // $ regex=.* input=input MISSING: modes=DOTALL

--- a/swift/ql/test/library-tests/regex/regex.swift
+++ b/swift/ql/test/library-tests/regex/regex.swift
@@ -214,7 +214,7 @@ func myRegexpMethodsTests(b: Bool, str_unknown: String) throws {
     _ = try Regex("abc").dotMatchesNewlines(false).firstMatch(in: input) // $ input=input regex=abc
     _ = try Regex("abc").dotMatchesNewlines(true).dotMatchesNewlines(false).firstMatch(in: input) // $ input=input regex=abc
     _ = try Regex("abc").dotMatchesNewlines(false).dotMatchesNewlines(true).firstMatch(in: input) // $ input=input regex=abc modes=DOTALL
-    _ = try Regex("abc").dotMatchesNewlines().ignoresCase().firstMatch(in: input) // $ input=input regex=abc SPURIOUS: modes=DOTALL MISSING: modes="DOTALL | IGNORECASE"
+    _ = try Regex("abc").dotMatchesNewlines().ignoresCase().firstMatch(in: input) // $ input=input regex=abc modes="DOTALL | IGNORECASE"
 
     _ = try NSRegularExpression(pattern: ".*", options: .caseInsensitive).firstMatch(in: input, range: NSMakeRange(0, input.utf16.count)) // $ regex=.* input=input MISSING: modes=IGNORECASE
     _ = try NSRegularExpression(pattern: ".*", options: .dotMatchesLineSeparators).firstMatch(in: input, range: NSMakeRange(0, input.utf16.count)) // $ regex=.* input=input MISSING: modes=DOTALL

--- a/swift/ql/test/library-tests/regex/regex.swift
+++ b/swift/ql/test/library-tests/regex/regex.swift
@@ -227,12 +227,12 @@ func myRegexpMethodsTests(b: Bool, str_unknown: String) throws {
     _ = try Regex("abc").anchorsMatchLineEndings().firstMatch(in: input) // $ input=input regex=abc modes=MULTILINE
 
 	// parse modes set through NSRegularExpression
-    _ = try NSRegularExpression(pattern: ".*", options: .caseInsensitive).firstMatch(in: input, range: NSMakeRange(0, input.utf16.count)) // $ regex=.* input=input MISSING: modes=IGNORECASE
-    _ = try NSRegularExpression(pattern: ".*", options: .dotMatchesLineSeparators).firstMatch(in: input, range: NSMakeRange(0, input.utf16.count)) // $ regex=.* input=input MISSING: modes=DOTALL
-    _ = try NSRegularExpression(pattern: ".*", options: [.caseInsensitive, .dotMatchesLineSeparators]).firstMatch(in: input, range: NSMakeRange(0, input.utf16.count)) // $ regex=.* input=input MISSING: modes="DOTALL | IGNORECASE"
+    _ = try NSRegularExpression(pattern: ".*", options: .caseInsensitive).firstMatch(in: input, range: NSMakeRange(0, input.utf16.count)) // $ regex=.* input=input modes=IGNORECASE
+    _ = try NSRegularExpression(pattern: ".*", options: .dotMatchesLineSeparators).firstMatch(in: input, range: NSMakeRange(0, input.utf16.count)) // $ regex=.* input=input modes=DOTALL
+    _ = try NSRegularExpression(pattern: ".*", options: [.caseInsensitive, .dotMatchesLineSeparators]).firstMatch(in: input, range: NSMakeRange(0, input.utf16.count)) // $ regex=.* input=input modes="DOTALL | IGNORECASE"
 
 	let myOptions1 : NSRegularExpression.Options = [.caseInsensitive, .dotMatchesLineSeparators]
-    _ = try NSRegularExpression(pattern: ".*", options: myOptions1).firstMatch(in: input, range: NSMakeRange(0, input.utf16.count)) // $ regex=.* input=input MISSING: modes="DOTALL | IGNORECASE"
+    _ = try NSRegularExpression(pattern: ".*", options: myOptions1).firstMatch(in: input, range: NSMakeRange(0, input.utf16.count)) // $ regex=.* input=input modes="DOTALL | IGNORECASE"
 
 	// parse modes set through other methods
 


### PR DESCRIPTION
Track regular expression parse modes set in code (we already support parse modes set with special syntax inside the regular expression string itself).

There's quite a lot here.  Everything is complicated by the fact these flags work in two different ways:
- for `Regex`, you create the `Regex` object first then set the flags using method calls on it.
  - `Regex(...).ignoresCase(true).firstMatch(...)`
- for `NSRegularExpression` objects, the flags are values which pass into the `NSRegularExpression` initializer (via an array argument).
  - `NSRegularExpression(..., options: [.caseInsensitive]).firstMatch(...)`

I suggest readers begin at `RegexParseModeConfig` in `RegexTracking.qll`, which tracks parse mode flags themselves from wherever they are created or set (i.e. either method above) all the way to regular expression evaluation.  This depends quite strongly on `RegexAdditionalFlowStep`, which is stretched with the additional role of modelling where parse modes are set and unset (this is a bit of an overload but the two purposes are often related).

Additional changes:
- flow through [`.ignoresCase`](https://developer.apple.com/documentation/swift/regex/ignorescase(_:)) and similar methods is now modelled with an additional flow step.  Previously this omission was obscured in the tests because the methods happened to be defined as `return self`, a simplification which we can compute data flow through.  We can't rely on that in the wild.
- `StandardRegexCreation` is now divided into `RegexRegexCreation` and `NSRegularExpressionRegexCreation`; the latter has a `getOptionsInput` for the argument that specifies regex parse mode options.
- a new type `RegexParseMode` is used for storing parse modes.  Previously (and in the shared library still) they were strings, but this was getting increasingly ugly.
- the changes in `RegexEval` and `ParseRegex.qll` are just wiring so that results of the `RegexParseModeConfig` flow get used.

Please do ask questions.