### PR TITLE
Java: Understand multiple parse mode flags specified in a regular expression string

### DIFF
--- a/java/ql/lib/change-notes/2023-07-20-regex-parse-modes.md
+++ b/java/ql/lib/change-notes/2023-07-20-regex-parse-modes.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Regular expressions containing multiple parse mode flags are now interpretted correctly. For example `"(?is)abc.*"` with both the `i` and `s` flags.

--- a/java/ql/lib/change-notes/2023-09-12-regex-mode-flag-groups.md
+++ b/java/ql/lib/change-notes/2023-09-12-regex-mode-flag-groups.md
@@ -1,0 +1,4 @@
+---
+category: fix
+---
+* The regular expressions library no longer incorrectly matches mode flag characters against the input.

--- a/java/ql/lib/semmle/code/java/regex/regex.qll
+++ b/java/ql/lib/semmle/code/java/regex/regex.qll
@@ -472,12 +472,19 @@ abstract class RegexString extends StringLiteral {
     )
   }
 
-  private predicate flagGroupStart(int start, int end, string c) {
+  private predicate flagGroupStart(int start, int end) {
     this.isGroupStart(start) and
     this.getChar(start + 1) = "?" and
-    end = start + 3 and
-    c = this.getChar(start + 2) and
-    c in ["i", "m", "s", "u", "x", "U"]
+    this.getChar(start + 2) in ["i", "m", "s", "u", "x", "U"] and
+    end = start + 2
+  }
+
+  private predicate flagGroup(int start, int end, string c) {
+    exists(int inStart, int inEnd |
+      this.flagGroupStart(start, inStart) and
+      this.groupContents(start, end, inStart, inEnd) and
+      this.getChar([inStart .. inEnd - 1]) = c
+    )
   }
 
   /**
@@ -485,7 +492,7 @@ abstract class RegexString extends StringLiteral {
    * it is defined by a prefix.
    */
   string getModeFromPrefix() {
-    exists(string c | this.flagGroupStart(_, _, c) |
+    exists(string c | this.flagGroup(_, _, c) |
       c = "i" and result = "IGNORECASE"
       or
       c = "m" and result = "MULTILINE"
@@ -540,7 +547,7 @@ abstract class RegexString extends StringLiteral {
   private predicate groupStart(int start, int end) {
     this.nonCapturingGroupStart(start, end)
     or
-    this.flagGroupStart(start, end, _)
+    this.flagGroupStart(start, end)
     or
     this.namedGroupStart(start, end)
     or

--- a/java/ql/lib/semmle/code/java/regex/regex.qll
+++ b/java/ql/lib/semmle/code/java/regex/regex.qll
@@ -473,9 +473,10 @@ abstract class RegexString extends StringLiteral {
   }
 
   /**
-   * Holds if a parse mode starts between `start` and `end`.
+   * Holds if the initial part of a parse mode, not containing any
+   * mode characters is between `start` and `end`.
    */
-  private predicate flagGroupStart(int start, int end) {
+  private predicate flagGroupStartNoModes(int start, int end) {
     this.isGroupStart(start) and
     this.getChar(start + 1) = "?" and
     this.getChar(start + 2) in ["i", "m", "s", "u", "x", "U"] and
@@ -483,17 +484,35 @@ abstract class RegexString extends StringLiteral {
   }
 
   /**
-   * Holds if a parse mode group is between `start` and `end`, and includes the
-   * mode flag `c`. For example the following span, with mode flag `i`:
+   * Holds if `pos` contains a mode character from the
+   * flag group starting at `start`.
+   */
+  private predicate modeCharacter(int start, int pos) {
+    this.flagGroupStartNoModes(start, pos)
+    or
+    this.modeCharacter(start, pos - 1) and
+    this.getChar(pos) in ["i", "m", "s", "u", "x", "U"]
+  }
+
+  /**
+   * Holds if a parse mode group is between `start` and `end`.
+   */
+  private predicate flagGroupStart(int start, int end) {
+    this.flagGroupStartNoModes(start, _) and
+    end = max(int i | this.modeCharacter(start, i) | i + 1)
+  }
+
+  /**
+   * Holds if a parse mode group of this regex includes the mode flag `c`.
+   * For example the following parse mode group, with mode flag `i`:
    * ```
    * (?i)
    * ```
    */
-  private predicate flagGroup(int start, int end, string c) {
-    exists(int inStart, int inEnd |
-      this.flagGroupStart(start, inStart) and
-      this.groupContents(start, end, inStart, inEnd) and
-      this.getChar([inStart .. inEnd - 1]) = c
+  private predicate flag(string c) {
+    exists(int pos |
+      this.modeCharacter(_, pos) and
+      this.getChar(pos) = c
     )
   }
 
@@ -502,7 +521,7 @@ abstract class RegexString extends StringLiteral {
    * it is defined by a prefix.
    */
   string getModeFromPrefix() {
-    exists(string c | this.flagGroup(_, _, c) |
+    exists(string c | this.flag(c) |
       c = "i" and result = "IGNORECASE"
       or
       c = "m" and result = "MULTILINE"

--- a/java/ql/lib/semmle/code/java/regex/regex.qll
+++ b/java/ql/lib/semmle/code/java/regex/regex.qll
@@ -472,6 +472,9 @@ abstract class RegexString extends StringLiteral {
     )
   }
 
+  /**
+   * Holds if a parse mode starts between `start` and `end`.
+   */
   private predicate flagGroupStart(int start, int end) {
     this.isGroupStart(start) and
     this.getChar(start + 1) = "?" and
@@ -479,6 +482,13 @@ abstract class RegexString extends StringLiteral {
     end = start + 2
   }
 
+  /**
+   * Holds if a parse mode group is between `start` and `end`, and includes the
+   * mode flag `c`. For example the following span, with mode flag `i`:
+   * ```
+   * (?i)
+   * ```
+   */
   private predicate flagGroup(int start, int end, string c) {
     exists(int inStart, int inEnd |
       this.flagGroupStart(start, inStart) and

--- a/java/ql/test/query-tests/security/CWE-730/ExpRedosTest.java
+++ b/java/ql/test/query-tests/security/CWE-730/ExpRedosTest.java
@@ -87,7 +87,7 @@ class ExpRedosTest {
         "(?s)(.|\\n)*!", // $ hasExpRedos
 
         // NOT GOOD; attack: "\n".repeat(100) + "."
-        "(?is)(.|\\n)*!", // $ MISSING: hasExpRedos
+        "(?is)(.|\\n)*!", // $ hasExpRedos
 
         // GOOD
         "([\\w.]+)*",

--- a/java/ql/test/query-tests/security/CWE-730/ExpRedosTest.java
+++ b/java/ql/test/query-tests/security/CWE-730/ExpRedosTest.java
@@ -431,7 +431,10 @@ class ExpRedosTest {
         "(a*)*b", // $ hasExpRedos
 
         // BAD - but not detected due to the way possessive quantifiers are approximated
-        "((aa|a*+)b)*c" // $ MISSING: hasExpRedos
+        "((aa|a*+)b)*c", // $ MISSING: hasExpRedos
+
+        // BAD - testsing
+        "(?is)(a|aa?)*b" // $ hasExpRedos hasPrefixMsg="starting with 'is' and " hasPump=a
     };
 
     void test() {

--- a/java/ql/test/query-tests/security/CWE-730/ExpRedosTest.java
+++ b/java/ql/test/query-tests/security/CWE-730/ExpRedosTest.java
@@ -433,7 +433,7 @@ class ExpRedosTest {
         // BAD - but not detected due to the way possessive quantifiers are approximated
         "((aa|a*+)b)*c", // $ MISSING: hasExpRedos
 
-        // BAD - testsing
+        // BAD - testing mode flag groups
         "(?is)(a|aa?)*b" // $ hasExpRedos hasPrefixMsg= hasPump=a
     };
 

--- a/java/ql/test/query-tests/security/CWE-730/ExpRedosTest.java
+++ b/java/ql/test/query-tests/security/CWE-730/ExpRedosTest.java
@@ -86,6 +86,9 @@ class ExpRedosTest {
         // NOT GOOD; attack: "\n".repeat(100) + "."
         "(?s)(.|\\n)*!", // $ hasExpRedos
 
+        // NOT GOOD; attack: "\n".repeat(100) + "."
+        "(?is)(.|\\n)*!", // $ MISSING: hasExpRedos
+
         // GOOD
         "([\\w.]+)*",
 
@@ -120,7 +123,7 @@ class ExpRedosTest {
         "\"((?:\\\\[\\x00-\\x7f]|[^\\x00-\\x08\\x0a-\\x1f\\x7f\"])*)\"", // $ MISSING: hasExpRedos
 
         // GOOD
-        "\"((?:\\\\[\\x00-\\x7f]|[^\\x00-\\x08\\x0a-\\x1f\\x7f\"\\\\])*)\"", 
+        "\"((?:\\\\[\\x00-\\x7f]|[^\\x00-\\x08\\x0a-\\x1f\\x7f\"\\\\])*)\"",
 
         // NOT GOOD
         "(([a-z]|[d-h])*)\"", // $ hasExpRedos

--- a/java/ql/test/query-tests/security/CWE-730/ExpRedosTest.java
+++ b/java/ql/test/query-tests/security/CWE-730/ExpRedosTest.java
@@ -434,7 +434,7 @@ class ExpRedosTest {
         "((aa|a*+)b)*c", // $ MISSING: hasExpRedos
 
         // BAD - testsing
-        "(?is)(a|aa?)*b" // $ hasExpRedos hasPrefixMsg="starting with 'is' and " hasPump=a
+        "(?is)(a|aa?)*b" // $ hasExpRedos hasPrefixMsg= hasPump=a
     };
 
     void test() {


### PR DESCRIPTION
Understand / correctly parse multiple parse mode flags specified in a regular expression string, for example `i` and `s` in:
```
(?is)abc.*
```
Previously we were only recognizing the first flag (`i`).

This is a backport of part of the Swift PR https://github.com/github/codeql/pull/13715 .