### PR TITLE
Python: Add `shlex.quote` as `py/shell-command-constructed-from-input` sanitizer

### DIFF
--- a/python/ql/lib/change-notes/2023-07-20-shlex-quote-sanitizer.md
+++ b/python/ql/lib/change-notes/2023-07-20-shlex-quote-sanitizer.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Added `shlex.quote` as a sanitizer for the `py/shell-command-constructed-from-input` query.

--- a/python/ql/lib/semmle/python/security/dataflow/UnsafeShellCommandConstructionCustomizations.qll
+++ b/python/ql/lib/semmle/python/security/dataflow/UnsafeShellCommandConstructionCustomizations.qll
@@ -9,6 +9,7 @@ private import semmle.python.dataflow.new.DataFlow
 private import semmle.python.dataflow.new.TaintTracking
 private import CommandInjectionCustomizations::CommandInjection as CommandInjection
 private import semmle.python.Concepts as Concepts
+private import semmle.python.ApiGraphs
 
 /**
  * Module containing sources, sinks, and sanitizers for shell command constructed from library input.
@@ -16,6 +17,9 @@ private import semmle.python.Concepts as Concepts
 module UnsafeShellCommandConstruction {
   /** A source for shell command constructed from library input vulnerabilities. */
   abstract class Source extends DataFlow::Node { }
+
+  /** A sanitizer for shell command constructed from library input vulnerabilities. */
+  abstract class Sanitizer extends DataFlow::Node { }
 
   private import semmle.python.frameworks.Setuptools
 
@@ -155,5 +159,14 @@ module UnsafeShellCommandConstruction {
     override DataFlow::Node getCommandExecution() { result = s }
 
     override DataFlow::Node getStringConstruction() { result = formatCall }
+  }
+
+  /**
+   * A call to `shlex.quote`, considered as a sanitizer.
+   */
+  class ShlexQuoteAsSanitizer extends Sanitizer, DataFlow::Node {
+    ShlexQuoteAsSanitizer() {
+      this = API::moduleImport("shlex").getMember("quote").getACall().getArg(0)
+    }
   }
 }

--- a/python/ql/lib/semmle/python/security/dataflow/UnsafeShellCommandConstructionQuery.qll
+++ b/python/ql/lib/semmle/python/security/dataflow/UnsafeShellCommandConstructionQuery.qll
@@ -24,7 +24,8 @@ class Configuration extends TaintTracking::Configuration {
   override predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
 
   override predicate isSanitizer(DataFlow::Node node) {
-    node instanceof CommandInjection::Sanitizer // using all sanitizers from `rb/command-injection`
+    node instanceof Sanitizer or
+    node instanceof CommandInjection::Sanitizer // using all sanitizers from `py/command-injection`
   }
 
   // override to require the path doesn't have unmatched return steps

--- a/python/ql/test/query-tests/Security/CWE-078-UnsafeShellCommandConstruction/src/unsafe_shell_test.py
+++ b/python/ql/test/query-tests/Security/CWE-078-UnsafeShellCommandConstruction/src/unsafe_shell_test.py
@@ -1,8 +1,12 @@
 import os
 import subprocess
+import shlex
 
 def unsafe_shell_one(name):
     os.system("ping " + name) # $result=BAD
+
+    # shlex.quote sanitizer
+    os.system("ping " + shlex.quote(name)) # $result=OK
 
     # f-strings
     os.system(f"ping {name}") # $result=BAD

--- a/python/ql/test/query-tests/Security/CWE-078-UnsafeShellCommandConstruction/src/unsafe_shell_test.py
+++ b/python/ql/test/query-tests/Security/CWE-078-UnsafeShellCommandConstruction/src/unsafe_shell_test.py
@@ -1,12 +1,8 @@
 import os
 import subprocess
-import shlex
 
 def unsafe_shell_one(name):
     os.system("ping " + name) # $result=BAD
-
-    # shlex.quote sanitizer
-    os.system("ping " + shlex.quote(name)) # $result=OK
 
     # f-strings
     os.system(f"ping {name}") # $result=BAD
@@ -51,3 +47,7 @@ def subprocess_flag (name):
 
 def intentional(command): 
     os.system("fish -ic " + command) # $result=OK - intentional
+
+import shlex
+def unsafe_shell_sanitized(name): 
+    os.system("ping " + shlex.quote(name)) # $result=OK - sanitized


### PR DESCRIPTION
While `shlex.quote` wouldn't be a perfect sanitizer for `py/command-line-injection` ([see](https://github.com/github/codeql/blob/075633a8172d842f9a90a230bf10fd4ba2199233/python/ql/test/library-tests/frameworks/stdlib/SystemCommandExecution.py#L157)), it should be for `py/shell-command-constructed-from-input`, as the query covers the argument being formatted into the command.