### PR TITLE
Go: Avoid using getTarget() as it may not exist

### DIFF
--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowDispatch.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowDispatch.qll
@@ -134,10 +134,6 @@ class ArgumentPosition extends int {
 pragma[inline]
 predicate parameterMatch(ParameterPosition ppos, ArgumentPosition apos) { ppos = apos }
 
-private predicate isInterfaceMethod(Method c) {
-  c.getReceiverBaseType().getUnderlyingType() instanceof InterfaceType
-}
-
 /**
  * Holds if `call` is passing `arg` to param `p` in any circumstance except passing
  * a receiver parameter to a concrete method.
@@ -149,9 +145,8 @@ predicate golangSpecificParamArgFilter(
   // Interface methods calls may be passed strictly to that exact method's model receiver:
   arg.getPosition() != -1
   or
-  exists(Function callTarget | callTarget = call.getNode().(DataFlow::CallNode).getTarget() |
-    not isInterfaceMethod(callTarget)
-    or
-    callTarget = p.getCallable().asSummarizedCallable().asFunction()
-  )
+  p instanceof DataFlow::SummarizedParameterNode
+  or
+  not call.getNode().(DataFlow::CallNode).getReceiver().getType().getUnderlyingType() instanceof
+    InterfaceType
 }

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowDispatch.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowDispatch.qll
@@ -156,12 +156,3 @@ predicate golangSpecificParamArgFilter(
         .getACalleeWithoutVirtualDispatch()
         .asFunction())
 }
-
-predicate foo(DataFlowCall call, DataFlow::Node rec0) {
-  exists(DataFlow::Node rec | rec = call.getNode().(DataFlow::CallNode).getReceiver() |
-    rec = rec0 and rec.getType().getUnderlyingType() instanceof InterfaceType
-  ) and
-  not exists(Function callTarget | callTarget = call.getNode().(DataFlow::CallNode).getTarget() |
-    not isInterfaceMethod(callTarget)
-  )
-}

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowNodes.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowNodes.qll
@@ -489,13 +489,9 @@ module Public {
      * interface type.
      */
     Callable getACalleeIncludingExternals() {
-      result.asFunction() = this.getTarget()
+      result = this.getACalleeWithoutVirtualDispatch()
       or
       exists(DataFlow::Node calleeSource | calleeSource = this.getACalleeSource() |
-        result.asFuncLit() = calleeSource.asExpr()
-        or
-        calleeSource = result.asFunction().getARead()
-        or
         exists(Method declared, Method actual |
           calleeSource = declared.getARead() and
           actual.implements(declared) and
@@ -509,6 +505,20 @@ module Public {
      * we lack a definition, such as standard library functions).
      */
     FuncDef getACallee() { result = this.getACalleeIncludingExternals().getFuncDef() }
+
+    /**
+     * As `getACalleeIncludingExternals`, except excluding external functions (those for which
+     * we lack a definition, such as standard library functions).
+     */
+    Callable getACalleeWithoutVirtualDispatch() {
+      result.asFunction() = this.getTarget()
+      or
+      exists(DataFlow::Node calleeSource | calleeSource = this.getACalleeSource() |
+        result.asFuncLit() = calleeSource.asExpr()
+        or
+        calleeSource = result.asFunction().getARead()
+      )
+    }
 
     /**
      * Gets the name of the function, method or variable that is being called.

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowNodes.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowNodes.qll
@@ -507,8 +507,7 @@ module Public {
     FuncDef getACallee() { result = this.getACalleeIncludingExternals().getFuncDef() }
 
     /**
-     * As `getACalleeIncludingExternals`, except excluding external functions (those for which
-     * we lack a definition, such as standard library functions).
+     * Gets the definition of a possible target of this call, excluding targets reachable via virtual dispatch.
      */
     Callable getACalleeWithoutVirtualDispatch() {
       result.asFunction() = this.getTarget()


### PR DESCRIPTION
Try to also deal with the case that we are calling a function through a variable that it has been assigned to.