### PR TITLE
C++: Add IR SSA test case for the ternary operator

### DIFF
--- a/cpp/ql/test/library-tests/ir/ssa/aliased_ssa_ir.expected
+++ b/cpp/ql/test/library-tests/ir/ssa/aliased_ssa_ir.expected
@@ -2157,3 +2157,46 @@ ssa.cpp:
 #  431|     v431_9(void)       = ReturnValue              : &:r431_8, m435_4
 #  431|     v431_10(void)      = AliasedUse               : m431_3
 #  431|     v431_11(void)      = ExitFunction             : 
+
+#  438| void Conditional(bool, int, int)
+#  438|   Block 0
+#  438|     v438_1(void)        = EnterFunction          : 
+#  438|     m438_2(unknown)     = AliasedDefinition      : 
+#  438|     m438_3(unknown)     = InitializeNonLocal     : 
+#  438|     m438_4(unknown)     = Chi                    : total:m438_2, partial:m438_3
+#  438|     r438_5(glval<bool>) = VariableAddress[a]     : 
+#  438|     m438_6(bool)        = InitializeParameter[a] : &:r438_5
+#  438|     r438_7(glval<int>)  = VariableAddress[x]     : 
+#  438|     m438_8(int)         = InitializeParameter[x] : &:r438_7
+#  438|     r438_9(glval<int>)  = VariableAddress[y]     : 
+#  438|     m438_10(int)        = InitializeParameter[y] : &:r438_9
+#  439|     r439_1(glval<int>)  = VariableAddress[z]     : 
+#  439|     r439_2(glval<bool>) = VariableAddress[a]     : 
+#  439|     r439_3(bool)        = Load[a]                : &:r439_2, m438_6
+#  439|     v439_4(void)        = ConditionalBranch      : r439_3
+#-----|   False -> Block 3
+#-----|   True -> Block 2
+
+#  439|   Block 1
+#  439|     m439_5(int)        = Phi                          : from 2:m439_12, from 3:m439_16
+#  439|     r439_6(glval<int>) = VariableAddress[#temp439:13] : 
+#  439|     r439_7(int)        = Load[#temp439:13]            : &:r439_6, m439_5
+#  439|     m439_8(int)        = Store[z]                     : &:r439_1, r439_7
+#  440|     v440_1(void)       = NoOp                         : 
+#  438|     v438_11(void)      = ReturnVoid                   : 
+#  438|     v438_12(void)      = AliasedUse                   : m438_3
+#  438|     v438_13(void)      = ExitFunction                 : 
+
+#  439|   Block 2
+#  439|     r439_9(glval<int>)  = VariableAddress[x]           : 
+#  439|     r439_10(int)        = Load[x]                      : &:r439_9, m438_8
+#  439|     r439_11(glval<int>) = VariableAddress[#temp439:13] : 
+#  439|     m439_12(int)        = Store[#temp439:13]           : &:r439_11, r439_10
+#-----|   Goto -> Block 1
+
+#  439|   Block 3
+#  439|     r439_13(glval<int>) = VariableAddress[y]           : 
+#  439|     r439_14(int)        = Load[y]                      : &:r439_13, m438_10
+#  439|     r439_15(glval<int>) = VariableAddress[#temp439:13] : 
+#  439|     m439_16(int)        = Store[#temp439:13]           : &:r439_15, r439_14
+#-----|   Goto -> Block 1

--- a/cpp/ql/test/library-tests/ir/ssa/aliased_ssa_ir_unsound.expected
+++ b/cpp/ql/test/library-tests/ir/ssa/aliased_ssa_ir_unsound.expected
@@ -2146,3 +2146,46 @@ ssa.cpp:
 #  431|     v431_9(void)       = ReturnValue              : &:r431_8, m435_4
 #  431|     v431_10(void)      = AliasedUse               : m431_3
 #  431|     v431_11(void)      = ExitFunction             : 
+
+#  438| void Conditional(bool, int, int)
+#  438|   Block 0
+#  438|     v438_1(void)        = EnterFunction          : 
+#  438|     m438_2(unknown)     = AliasedDefinition      : 
+#  438|     m438_3(unknown)     = InitializeNonLocal     : 
+#  438|     m438_4(unknown)     = Chi                    : total:m438_2, partial:m438_3
+#  438|     r438_5(glval<bool>) = VariableAddress[a]     : 
+#  438|     m438_6(bool)        = InitializeParameter[a] : &:r438_5
+#  438|     r438_7(glval<int>)  = VariableAddress[x]     : 
+#  438|     m438_8(int)         = InitializeParameter[x] : &:r438_7
+#  438|     r438_9(glval<int>)  = VariableAddress[y]     : 
+#  438|     m438_10(int)        = InitializeParameter[y] : &:r438_9
+#  439|     r439_1(glval<int>)  = VariableAddress[z]     : 
+#  439|     r439_2(glval<bool>) = VariableAddress[a]     : 
+#  439|     r439_3(bool)        = Load[a]                : &:r439_2, m438_6
+#  439|     v439_4(void)        = ConditionalBranch      : r439_3
+#-----|   False -> Block 3
+#-----|   True -> Block 2
+
+#  439|   Block 1
+#  439|     m439_5(int)        = Phi                          : from 2:m439_12, from 3:m439_16
+#  439|     r439_6(glval<int>) = VariableAddress[#temp439:13] : 
+#  439|     r439_7(int)        = Load[#temp439:13]            : &:r439_6, m439_5
+#  439|     m439_8(int)        = Store[z]                     : &:r439_1, r439_7
+#  440|     v440_1(void)       = NoOp                         : 
+#  438|     v438_11(void)      = ReturnVoid                   : 
+#  438|     v438_12(void)      = AliasedUse                   : m438_3
+#  438|     v438_13(void)      = ExitFunction                 : 
+
+#  439|   Block 2
+#  439|     r439_9(glval<int>)  = VariableAddress[x]           : 
+#  439|     r439_10(int)        = Load[x]                      : &:r439_9, m438_8
+#  439|     r439_11(glval<int>) = VariableAddress[#temp439:13] : 
+#  439|     m439_12(int)        = Store[#temp439:13]           : &:r439_11, r439_10
+#-----|   Goto -> Block 1
+
+#  439|   Block 3
+#  439|     r439_13(glval<int>) = VariableAddress[y]           : 
+#  439|     r439_14(int)        = Load[y]                      : &:r439_13, m438_10
+#  439|     r439_15(glval<int>) = VariableAddress[#temp439:13] : 
+#  439|     m439_16(int)        = Store[#temp439:13]           : &:r439_15, r439_14
+#-----|   Goto -> Block 1

--- a/cpp/ql/test/library-tests/ir/ssa/ssa.cpp
+++ b/cpp/ql/test/library-tests/ir/ssa/ssa.cpp
@@ -434,3 +434,7 @@ int noreturnTest2(int x) {
     }
     return x;
 }
+
+void Conditional(bool a, int x, int y) {
+    int z = a ? x : y;
+}

--- a/cpp/ql/test/library-tests/ir/ssa/unaliased_ssa_ir.expected
+++ b/cpp/ql/test/library-tests/ir/ssa/unaliased_ssa_ir.expected
@@ -2002,3 +2002,45 @@ ssa.cpp:
 #  431|     v431_8(void)       = ReturnValue              : &:r431_7, m435_4
 #  431|     v431_9(void)       = AliasedUse               : ~m?
 #  431|     v431_10(void)      = ExitFunction             : 
+
+#  438| void Conditional(bool, int, int)
+#  438|   Block 0
+#  438|     v438_1(void)        = EnterFunction          : 
+#  438|     mu438_2(unknown)    = AliasedDefinition      : 
+#  438|     mu438_3(unknown)    = InitializeNonLocal     : 
+#  438|     r438_4(glval<bool>) = VariableAddress[a]     : 
+#  438|     m438_5(bool)        = InitializeParameter[a] : &:r438_4
+#  438|     r438_6(glval<int>)  = VariableAddress[x]     : 
+#  438|     m438_7(int)         = InitializeParameter[x] : &:r438_6
+#  438|     r438_8(glval<int>)  = VariableAddress[y]     : 
+#  438|     m438_9(int)         = InitializeParameter[y] : &:r438_8
+#  439|     r439_1(glval<int>)  = VariableAddress[z]     : 
+#  439|     r439_2(glval<bool>) = VariableAddress[a]     : 
+#  439|     r439_3(bool)        = Load[a]                : &:r439_2, m438_5
+#  439|     v439_4(void)        = ConditionalBranch      : r439_3
+#-----|   False -> Block 3
+#-----|   True -> Block 2
+
+#  439|   Block 1
+#  439|     m439_5(int)        = Phi                          : from 2:m439_12, from 3:m439_16
+#  439|     r439_6(glval<int>) = VariableAddress[#temp439:13] : 
+#  439|     r439_7(int)        = Load[#temp439:13]            : &:r439_6, m439_5
+#  439|     m439_8(int)        = Store[z]                     : &:r439_1, r439_7
+#  440|     v440_1(void)       = NoOp                         : 
+#  438|     v438_10(void)      = ReturnVoid                   : 
+#  438|     v438_11(void)      = AliasedUse                   : ~m?
+#  438|     v438_12(void)      = ExitFunction                 : 
+
+#  439|   Block 2
+#  439|     r439_9(glval<int>)  = VariableAddress[x]           : 
+#  439|     r439_10(int)        = Load[x]                      : &:r439_9, m438_7
+#  439|     r439_11(glval<int>) = VariableAddress[#temp439:13] : 
+#  439|     m439_12(int)        = Store[#temp439:13]           : &:r439_11, r439_10
+#-----|   Goto -> Block 1
+
+#  439|   Block 3
+#  439|     r439_13(glval<int>) = VariableAddress[y]           : 
+#  439|     r439_14(int)        = Load[y]                      : &:r439_13, m438_9
+#  439|     r439_15(glval<int>) = VariableAddress[#temp439:13] : 
+#  439|     m439_16(int)        = Store[#temp439:13]           : &:r439_15, r439_14
+#-----|   Goto -> Block 1

--- a/cpp/ql/test/library-tests/ir/ssa/unaliased_ssa_ir_unsound.expected
+++ b/cpp/ql/test/library-tests/ir/ssa/unaliased_ssa_ir_unsound.expected
@@ -2002,3 +2002,45 @@ ssa.cpp:
 #  431|     v431_8(void)       = ReturnValue              : &:r431_7, m435_4
 #  431|     v431_9(void)       = AliasedUse               : ~m?
 #  431|     v431_10(void)      = ExitFunction             : 
+
+#  438| void Conditional(bool, int, int)
+#  438|   Block 0
+#  438|     v438_1(void)        = EnterFunction          : 
+#  438|     mu438_2(unknown)    = AliasedDefinition      : 
+#  438|     mu438_3(unknown)    = InitializeNonLocal     : 
+#  438|     r438_4(glval<bool>) = VariableAddress[a]     : 
+#  438|     m438_5(bool)        = InitializeParameter[a] : &:r438_4
+#  438|     r438_6(glval<int>)  = VariableAddress[x]     : 
+#  438|     m438_7(int)         = InitializeParameter[x] : &:r438_6
+#  438|     r438_8(glval<int>)  = VariableAddress[y]     : 
+#  438|     m438_9(int)         = InitializeParameter[y] : &:r438_8
+#  439|     r439_1(glval<int>)  = VariableAddress[z]     : 
+#  439|     r439_2(glval<bool>) = VariableAddress[a]     : 
+#  439|     r439_3(bool)        = Load[a]                : &:r439_2, m438_5
+#  439|     v439_4(void)        = ConditionalBranch      : r439_3
+#-----|   False -> Block 3
+#-----|   True -> Block 2
+
+#  439|   Block 1
+#  439|     m439_5(int)        = Phi                          : from 2:m439_12, from 3:m439_16
+#  439|     r439_6(glval<int>) = VariableAddress[#temp439:13] : 
+#  439|     r439_7(int)        = Load[#temp439:13]            : &:r439_6, m439_5
+#  439|     m439_8(int)        = Store[z]                     : &:r439_1, r439_7
+#  440|     v440_1(void)       = NoOp                         : 
+#  438|     v438_10(void)      = ReturnVoid                   : 
+#  438|     v438_11(void)      = AliasedUse                   : ~m?
+#  438|     v438_12(void)      = ExitFunction                 : 
+
+#  439|   Block 2
+#  439|     r439_9(glval<int>)  = VariableAddress[x]           : 
+#  439|     r439_10(int)        = Load[x]                      : &:r439_9, m438_7
+#  439|     r439_11(glval<int>) = VariableAddress[#temp439:13] : 
+#  439|     m439_12(int)        = Store[#temp439:13]           : &:r439_11, r439_10
+#-----|   Goto -> Block 1
+
+#  439|   Block 3
+#  439|     r439_13(glval<int>) = VariableAddress[y]           : 
+#  439|     r439_14(int)        = Load[y]                      : &:r439_13, m438_9
+#  439|     r439_15(glval<int>) = VariableAddress[#temp439:13] : 
+#  439|     m439_16(int)        = Store[#temp439:13]           : &:r439_15, r439_14
+#-----|   Goto -> Block 1


### PR DESCRIPTION
This is technically already covered by the raw IR tests, but the frontend update is giving me regressions on the Phi and Chi nodes, so I'd like to have an explicit SSA test for this.