### PR TITLE
Swift: Support EnumContent in models-as-data

### DIFF
--- a/swift/ql/lib/change-notes/2023-07-24-forced-unwrap.md
+++ b/swift/ql/lib/change-notes/2023-07-24-forced-unwrap.md
@@ -1,0 +1,5 @@
+---
+category: minorAnalysis
+---
+
+* Flow through forced optional unwrapping (`!`) is modelled more accurately.

--- a/swift/ql/lib/codeql/swift/dataflow/ExternalFlow.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/ExternalFlow.qll
@@ -476,9 +476,15 @@ private predicate parseField(AccessPathToken c, Content::FieldContent f) {
   )
 }
 
+private predicate parseEnum(AccessPathToken c, Content::EnumContent f) {
+  c.getName() = "Enum" and
+  c.getAnArgument() = f.getSignature()
+}
+
 /** Holds if the specification component parses as a `Content`. */
 predicate parseContent(AccessPathToken component, Content content) {
-  parseField(component, content)
+  parseField(component, content) or
+  parseEnum(component, content)
 }
 
 cached

--- a/swift/ql/lib/codeql/swift/dataflow/ExternalFlow.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/ExternalFlow.qll
@@ -477,8 +477,11 @@ private predicate parseField(AccessPathToken c, Content::FieldContent f) {
 }
 
 private predicate parseEnum(AccessPathToken c, Content::EnumContent f) {
-  c.getName() = "Enum" and
+  c.getName() = "EnumElement" and
   c.getAnArgument() = f.getSignature()
+  or
+  c.getName() = "OptionalSome" and
+  f.getSignature() = "some:0"
 }
 
 /** Holds if the specification component parses as a `Content`. */

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPrivate.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPrivate.qll
@@ -170,6 +170,10 @@ private module Cached {
     nodeFrom.asExpr() = nodeTo.asExpr().(AnyTryExpr).getSubExpr()
     or
     // flow through `!`
+    // note: there's a case in `readStep` that handles when the source is the
+    //   `OptionalSomeContentSet` within the RHS. This case is for when the
+    //   `Optional` itself is tainted (which it usually shouldn't be, but
+    //   retaining this case increases robustness of flow).
     nodeFrom.asExpr() = nodeTo.asExpr().(ForceValueExpr).getSubExpr()
     or
     // flow through `?` and `?.`
@@ -724,6 +728,10 @@ predicate readStep(Node node1, ContentSet c, Node node2) {
       enumPat.getSubPattern(idx) = subPat
     )
   )
+  or
+  // read of an enum (`Optional.Some`) member via `!`
+  node1.asExpr() = node2.asExpr().(ForceValueExpr).getSubExpr() and
+  c instanceof OptionalSomeContentSet
   or
   // read of a tuple member via `case let (v1, v2)` pattern matching
   exists(TuplePattern tupPat, int idx, Pattern subPat |

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPublic.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPublic.qll
@@ -217,9 +217,7 @@ module Content {
       exists(EnumElementDecl d, int pos | d.getParam(pos) = p | result = d.toString() + ":" + pos)
     }
 
-    override string toString() {
-      result = this.getSignature()
-    }
+    override string toString() { result = this.getSignature() }
   }
 }
 

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPublic.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPublic.qll
@@ -202,8 +202,23 @@ module Content {
     /** Gets the declaration of the enum parameter. */
     ParamDecl getParam() { result = p }
 
-    override string toString() {
+    /**
+     * Gets a string describing this enum content, of the form: `EnumElementName:N` where `EnumElementName`
+     * is the name of the enum element declaration within the enum, and `N` is the 0-based index of the
+     * parameter that this content is for. For example in the following code there is only one `EnumContent`
+     * and it's signature is `myValue:0`:
+     * ```
+     * enum MyEnum {
+     *   case myValue(Int)
+     * }
+     * ```
+     */
+    string getSignature() {
       exists(EnumElementDecl d, int pos | d.getParam(pos) = p | result = d.toString() + ":" + pos)
+    }
+
+    override string toString() {
+      result = this.getSignature()
     }
   }
 }

--- a/swift/ql/test/library-tests/dataflow/dataflow/CONSISTENCY/CfgConsistency.expected
+++ b/swift/ql/test/library-tests/dataflow/dataflow/CONSISTENCY/CfgConsistency.expected
@@ -1,3 +1,3 @@
 multipleSuccessors
-| test.swift:488:8:488:12 | let ...? | no-match | test.swift:488:27:488:27 | y |
-| test.swift:488:8:488:12 | let ...? | no-match | test.swift:493:9:493:9 | tuple1 |
+| test.swift:519:8:519:12 | let ...? | no-match | test.swift:519:27:519:27 | y |
+| test.swift:519:8:519:12 | let ...? | no-match | test.swift:524:9:524:9 | tuple1 |

--- a/swift/ql/test/library-tests/dataflow/dataflow/DataFlow.expected
+++ b/swift/ql/test/library-tests/dataflow/dataflow/DataFlow.expected
@@ -104,8 +104,8 @@ edges
 | test.swift:259:12:259:19 | call to source() | test.swift:259:12:259:19 | call to source() [some:0] |
 | test.swift:259:12:259:19 | call to source() | test.swift:263:13:263:28 | call to optionalSource() |
 | test.swift:259:12:259:19 | call to source() [some:0] | test.swift:263:13:263:28 | call to optionalSource() [some:0] |
-| test.swift:259:12:259:19 | call to source() [some:0] | test.swift:486:13:486:28 | call to optionalSource() [some:0] |
-| test.swift:259:12:259:19 | call to source() [some:0] | test.swift:513:13:513:28 | call to optionalSource() [some:0] |
+| test.swift:259:12:259:19 | call to source() [some:0] | test.swift:517:13:517:28 | call to optionalSource() [some:0] |
+| test.swift:259:12:259:19 | call to source() [some:0] | test.swift:544:13:544:28 | call to optionalSource() [some:0] |
 | test.swift:263:13:263:28 | call to optionalSource() | test.swift:265:15:265:15 | x |
 | test.swift:263:13:263:28 | call to optionalSource() | test.swift:267:15:267:16 | ...! |
 | test.swift:263:13:263:28 | call to optionalSource() | test.swift:271:15:271:16 | ...? |
@@ -162,118 +162,129 @@ edges
 | test.swift:357:15:357:15 | t1 [Tuple element at index 1] | test.swift:357:15:357:18 | .1 |
 | test.swift:360:15:360:15 | t2 [Tuple element at index 0] | test.swift:360:15:360:18 | .0 |
 | test.swift:361:15:361:15 | t2 [Tuple element at index 1] | test.swift:361:15:361:18 | .1 |
-| test.swift:398:9:398:27 | call to ... [mySingle:0] | test.swift:403:10:403:25 | .mySingle(...) [mySingle:0] |
-| test.swift:398:9:398:27 | call to ... [mySingle:0] | test.swift:412:13:412:28 | .mySingle(...) [mySingle:0] |
-| test.swift:398:19:398:26 | call to source() | test.swift:398:9:398:27 | call to ... [mySingle:0] |
-| test.swift:403:10:403:25 | .mySingle(...) [mySingle:0] | test.swift:403:24:403:24 | a |
-| test.swift:403:24:403:24 | a | test.swift:404:19:404:19 | a |
-| test.swift:412:13:412:28 | .mySingle(...) [mySingle:0] | test.swift:412:27:412:27 | x |
-| test.swift:412:27:412:27 | x | test.swift:413:19:413:19 | x |
-| test.swift:420:9:420:34 | call to ... [myPair:1] | test.swift:427:10:427:30 | .myPair(...) [myPair:1] |
-| test.swift:420:9:420:34 | call to ... [myPair:1] | test.swift:437:13:437:33 | .myPair(...) [myPair:1] |
-| test.swift:420:9:420:34 | call to ... [myPair:1] | test.swift:442:33:442:33 | a [myPair:1] |
-| test.swift:420:9:420:34 | call to ... [myPair:1] | test.swift:471:13:471:13 | a [myPair:1] |
-| test.swift:420:26:420:33 | call to source() | test.swift:420:9:420:34 | call to ... [myPair:1] |
-| test.swift:427:10:427:30 | .myPair(...) [myPair:1] | test.swift:427:29:427:29 | b |
-| test.swift:427:29:427:29 | b | test.swift:429:19:429:19 | b |
-| test.swift:437:13:437:33 | .myPair(...) [myPair:1] | test.swift:437:32:437:32 | y |
-| test.swift:437:32:437:32 | y | test.swift:439:19:439:19 | y |
-| test.swift:442:21:442:34 | call to ... [myCons:1, myPair:1] | test.swift:452:14:452:38 | .myCons(...) [myCons:1, myPair:1] |
-| test.swift:442:21:442:34 | call to ... [myCons:1, myPair:1] | test.swift:467:17:467:41 | .myCons(...) [myCons:1, myPair:1] |
-| test.swift:442:21:442:34 | call to ... [myCons:1, myPair:1] | test.swift:471:16:471:16 | b [myCons:1, myPair:1] |
-| test.swift:442:33:442:33 | a [myPair:1] | test.swift:442:21:442:34 | call to ... [myCons:1, myPair:1] |
-| test.swift:452:14:452:38 | .myCons(...) [myCons:1, myPair:1] | test.swift:452:25:452:37 | .myPair(...) [myPair:1] |
-| test.swift:452:25:452:37 | .myPair(...) [myPair:1] | test.swift:452:36:452:36 | c |
-| test.swift:452:36:452:36 | c | test.swift:455:19:455:19 | c |
-| test.swift:463:13:463:39 | .myPair(...) [myPair:0] | test.swift:463:31:463:31 | x |
-| test.swift:463:31:463:31 | x | test.swift:464:19:464:19 | x |
-| test.swift:463:43:463:62 | call to ... [myPair:0] | test.swift:463:13:463:39 | .myPair(...) [myPair:0] |
-| test.swift:463:51:463:58 | call to source() | test.swift:463:43:463:62 | call to ... [myPair:0] |
-| test.swift:467:17:467:41 | .myCons(...) [myCons:1, myPair:1] | test.swift:467:28:467:40 | .myPair(...) [myPair:1] |
-| test.swift:467:28:467:40 | .myPair(...) [myPair:1] | test.swift:467:39:467:39 | c |
-| test.swift:467:39:467:39 | c | test.swift:468:19:468:19 | c |
-| test.swift:471:12:471:17 | (...) [Tuple element at index 0, myPair:1] | test.swift:472:14:472:55 | (...) [Tuple element at index 0, myPair:1] |
-| test.swift:471:12:471:17 | (...) [Tuple element at index 1, myCons:1, myPair:1] | test.swift:472:14:472:55 | (...) [Tuple element at index 1, myCons:1, myPair:1] |
-| test.swift:471:13:471:13 | a [myPair:1] | test.swift:471:12:471:17 | (...) [Tuple element at index 0, myPair:1] |
-| test.swift:471:16:471:16 | b [myCons:1, myPair:1] | test.swift:471:12:471:17 | (...) [Tuple element at index 1, myCons:1, myPair:1] |
-| test.swift:472:14:472:55 | (...) [Tuple element at index 0, myPair:1] | test.swift:472:15:472:27 | .myPair(...) [myPair:1] |
-| test.swift:472:14:472:55 | (...) [Tuple element at index 1, myCons:1, myPair:1] | test.swift:472:30:472:54 | .myCons(...) [myCons:1, myPair:1] |
-| test.swift:472:15:472:27 | .myPair(...) [myPair:1] | test.swift:472:26:472:26 | b |
-| test.swift:472:26:472:26 | b | test.swift:474:19:474:19 | b |
-| test.swift:472:30:472:54 | .myCons(...) [myCons:1, myPair:1] | test.swift:472:41:472:53 | .myPair(...) [myPair:1] |
-| test.swift:472:41:472:53 | .myPair(...) [myPair:1] | test.swift:472:52:472:52 | e |
-| test.swift:472:52:472:52 | e | test.swift:477:19:477:19 | e |
-| test.swift:486:13:486:28 | call to optionalSource() [some:0] | test.swift:488:8:488:12 | let ...? [some:0] |
-| test.swift:486:13:486:28 | call to optionalSource() [some:0] | test.swift:493:19:493:19 | x [some:0] |
-| test.swift:488:8:488:12 | let ...? [some:0] | test.swift:488:12:488:12 | a |
-| test.swift:488:12:488:12 | a | test.swift:489:19:489:19 | a |
-| test.swift:493:18:493:23 | (...) [Tuple element at index 0, some:0] | test.swift:495:10:495:37 | (...) [Tuple element at index 0, some:0] |
-| test.swift:493:19:493:19 | x [some:0] | test.swift:493:18:493:23 | (...) [Tuple element at index 0, some:0] |
-| test.swift:495:10:495:37 | (...) [Tuple element at index 0, some:0] | test.swift:495:11:495:22 | .some(...) [some:0] |
-| test.swift:495:11:495:22 | .some(...) [some:0] | test.swift:495:21:495:21 | a |
-| test.swift:495:21:495:21 | a | test.swift:496:19:496:19 | a |
-| test.swift:509:9:509:9 | self [x, some:0] | file://:0:0:0:0 | self [x, some:0] |
-| test.swift:509:9:509:9 | value [some:0] | file://:0:0:0:0 | value [some:0] |
-| test.swift:513:13:513:28 | call to optionalSource() [some:0] | test.swift:515:12:515:12 | x [some:0] |
-| test.swift:515:5:515:5 | [post] cx [x, some:0] | test.swift:519:20:519:20 | cx [x, some:0] |
-| test.swift:515:12:515:12 | x [some:0] | test.swift:509:9:509:9 | value [some:0] |
-| test.swift:515:12:515:12 | x [some:0] | test.swift:515:5:515:5 | [post] cx [x, some:0] |
-| test.swift:519:11:519:15 | let ...? [some:0] | test.swift:519:15:519:15 | z1 |
-| test.swift:519:15:519:15 | z1 | test.swift:520:15:520:15 | z1 |
-| test.swift:519:20:519:20 | cx [x, some:0] | test.swift:509:9:509:9 | self [x, some:0] |
-| test.swift:519:20:519:20 | cx [x, some:0] | test.swift:519:20:519:23 | .x [some:0] |
-| test.swift:519:20:519:23 | .x [some:0] | test.swift:519:11:519:15 | let ...? [some:0] |
-| test.swift:526:14:526:21 | call to source() | test.swift:526:13:526:21 | call to +(_:) |
-| test.swift:535:9:535:9 | self [str] | file://:0:0:0:0 | self [str] |
-| test.swift:536:10:536:13 | s | test.swift:537:13:537:13 | s |
-| test.swift:537:7:537:7 | [post] self [str] | test.swift:536:5:538:5 | self[return] [str] |
-| test.swift:537:13:537:13 | s | test.swift:537:7:537:7 | [post] self [str] |
-| test.swift:542:17:545:5 | self[return] [str] | test.swift:550:13:550:41 | call to MyClass.init(contentsOfFile:) [str] |
-| test.swift:543:7:543:7 | [post] self [str] | test.swift:542:17:545:5 | self[return] [str] |
-| test.swift:543:7:543:7 | [post] self [str] | test.swift:544:17:544:17 | self [str] |
-| test.swift:543:20:543:28 | call to source3() | test.swift:536:10:536:13 | s |
-| test.swift:543:20:543:28 | call to source3() | test.swift:543:7:543:7 | [post] self [str] |
-| test.swift:544:17:544:17 | self [str] | test.swift:544:17:544:17 | .str |
-| test.swift:549:13:549:33 | call to MyClass.init(s:) [str] | test.swift:535:9:535:9 | self [str] |
-| test.swift:549:13:549:33 | call to MyClass.init(s:) [str] | test.swift:549:13:549:35 | .str |
-| test.swift:549:24:549:32 | call to source3() | test.swift:536:10:536:13 | s |
-| test.swift:549:24:549:32 | call to source3() | test.swift:549:13:549:33 | call to MyClass.init(s:) [str] |
-| test.swift:550:13:550:41 | call to MyClass.init(contentsOfFile:) [str] | test.swift:535:9:535:9 | self [str] |
-| test.swift:550:13:550:41 | call to MyClass.init(contentsOfFile:) [str] | test.swift:550:13:550:43 | .str |
-| test.swift:567:8:567:11 | x | test.swift:568:14:568:14 | x |
-| test.swift:568:5:568:5 | [post] self [x] | test.swift:567:3:569:3 | self[return] [x] |
-| test.swift:568:14:568:14 | x | test.swift:568:5:568:5 | [post] self [x] |
-| test.swift:573:11:573:24 | call to S.init(x:) [x] | test.swift:575:13:575:13 | s [x] |
-| test.swift:573:11:573:24 | call to S.init(x:) [x] | test.swift:578:13:578:13 | s [x] |
-| test.swift:573:16:573:23 | call to source() | test.swift:567:8:567:11 | x |
-| test.swift:573:16:573:23 | call to source() | test.swift:573:11:573:24 | call to S.init(x:) [x] |
-| test.swift:574:11:574:14 | enter #keyPath(...) [x] | test.swift:574:14:574:14 | KeyPathComponent [x] |
-| test.swift:574:14:574:14 | KeyPathComponent [x] | test.swift:574:11:574:14 | exit #keyPath(...) |
-| test.swift:575:13:575:13 | s [x] | test.swift:574:11:574:14 | enter #keyPath(...) [x] |
-| test.swift:575:13:575:13 | s [x] | test.swift:575:13:575:25 | \\...[...] |
-| test.swift:577:36:577:38 | enter #keyPath(...) [x] | test.swift:577:38:577:38 | KeyPathComponent [x] |
-| test.swift:577:38:577:38 | KeyPathComponent [x] | test.swift:577:36:577:38 | exit #keyPath(...) |
-| test.swift:578:13:578:13 | s [x] | test.swift:577:36:577:38 | enter #keyPath(...) [x] |
-| test.swift:578:13:578:13 | s [x] | test.swift:578:13:578:32 | \\...[...] |
-| test.swift:584:8:584:11 | s [x] | test.swift:585:14:585:14 | s [x] |
-| test.swift:585:5:585:5 | [post] self [s, x] | test.swift:584:3:586:3 | self[return] [s, x] |
-| test.swift:585:14:585:14 | s [x] | test.swift:585:5:585:5 | [post] self [s, x] |
-| test.swift:590:11:590:24 | call to S.init(x:) [x] | test.swift:591:18:591:18 | s [x] |
-| test.swift:590:16:590:23 | call to source() | test.swift:567:8:567:11 | x |
-| test.swift:590:16:590:23 | call to source() | test.swift:590:11:590:24 | call to S.init(x:) [x] |
-| test.swift:591:12:591:19 | call to S2.init(s:) [s, x] | test.swift:593:13:593:13 | s2 [s, x] |
-| test.swift:591:18:591:18 | s [x] | test.swift:584:8:584:11 | s [x] |
-| test.swift:591:18:591:18 | s [x] | test.swift:591:12:591:19 | call to S2.init(s:) [s, x] |
-| test.swift:592:11:592:17 | enter #keyPath(...) [s, x] | test.swift:592:15:592:15 | KeyPathComponent [s, x] |
-| test.swift:592:15:592:15 | KeyPathComponent [s, x] | test.swift:592:17:592:17 | KeyPathComponent [x] |
-| test.swift:592:17:592:17 | KeyPathComponent [x] | test.swift:592:11:592:17 | exit #keyPath(...) |
-| test.swift:593:13:593:13 | s2 [s, x] | test.swift:592:11:592:17 | enter #keyPath(...) [s, x] |
-| test.swift:593:13:593:13 | s2 [s, x] | test.swift:593:13:593:26 | \\...[...] |
-| test.swift:618:13:618:20 | call to source() | test.swift:626:15:626:15 | y |
-| test.swift:628:9:628:16 | call to source() | test.swift:630:10:630:11 | &... |
-| test.swift:628:9:628:16 | call to source() | test.swift:631:15:631:15 | x |
-| test.swift:630:10:630:11 | &... | test.swift:630:14:630:15 | [post] &... |
-| test.swift:630:14:630:15 | [post] &... | test.swift:632:15:632:15 | y |
+| test.swift:375:16:375:21 | v | test.swift:375:61:375:61 | v |
+| test.swift:375:61:375:61 | v | test.swift:375:45:375:62 | call to ... [mySingle:0] |
+| test.swift:403:9:403:27 | call to ... [mySingle:0] | test.swift:408:10:408:25 | .mySingle(...) [mySingle:0] |
+| test.swift:403:9:403:27 | call to ... [mySingle:0] | test.swift:417:13:417:28 | .mySingle(...) [mySingle:0] |
+| test.swift:403:19:403:26 | call to source() | test.swift:403:9:403:27 | call to ... [mySingle:0] |
+| test.swift:408:10:408:25 | .mySingle(...) [mySingle:0] | test.swift:408:24:408:24 | a |
+| test.swift:408:24:408:24 | a | test.swift:409:19:409:19 | a |
+| test.swift:417:13:417:28 | .mySingle(...) [mySingle:0] | test.swift:417:27:417:27 | x |
+| test.swift:417:27:417:27 | x | test.swift:418:19:418:19 | x |
+| test.swift:425:9:425:34 | call to ... [myPair:1] | test.swift:432:10:432:30 | .myPair(...) [myPair:1] |
+| test.swift:425:9:425:34 | call to ... [myPair:1] | test.swift:442:13:442:33 | .myPair(...) [myPair:1] |
+| test.swift:425:9:425:34 | call to ... [myPair:1] | test.swift:447:33:447:33 | a [myPair:1] |
+| test.swift:425:9:425:34 | call to ... [myPair:1] | test.swift:476:13:476:13 | a [myPair:1] |
+| test.swift:425:26:425:33 | call to source() | test.swift:425:9:425:34 | call to ... [myPair:1] |
+| test.swift:432:10:432:30 | .myPair(...) [myPair:1] | test.swift:432:29:432:29 | b |
+| test.swift:432:29:432:29 | b | test.swift:434:19:434:19 | b |
+| test.swift:442:13:442:33 | .myPair(...) [myPair:1] | test.swift:442:32:442:32 | y |
+| test.swift:442:32:442:32 | y | test.swift:444:19:444:19 | y |
+| test.swift:447:21:447:34 | call to ... [myCons:1, myPair:1] | test.swift:457:14:457:38 | .myCons(...) [myCons:1, myPair:1] |
+| test.swift:447:21:447:34 | call to ... [myCons:1, myPair:1] | test.swift:472:17:472:41 | .myCons(...) [myCons:1, myPair:1] |
+| test.swift:447:21:447:34 | call to ... [myCons:1, myPair:1] | test.swift:476:16:476:16 | b [myCons:1, myPair:1] |
+| test.swift:447:33:447:33 | a [myPair:1] | test.swift:447:21:447:34 | call to ... [myCons:1, myPair:1] |
+| test.swift:457:14:457:38 | .myCons(...) [myCons:1, myPair:1] | test.swift:457:25:457:37 | .myPair(...) [myPair:1] |
+| test.swift:457:25:457:37 | .myPair(...) [myPair:1] | test.swift:457:36:457:36 | c |
+| test.swift:457:36:457:36 | c | test.swift:460:19:460:19 | c |
+| test.swift:468:13:468:39 | .myPair(...) [myPair:0] | test.swift:468:31:468:31 | x |
+| test.swift:468:31:468:31 | x | test.swift:469:19:469:19 | x |
+| test.swift:468:43:468:62 | call to ... [myPair:0] | test.swift:468:13:468:39 | .myPair(...) [myPair:0] |
+| test.swift:468:51:468:58 | call to source() | test.swift:468:43:468:62 | call to ... [myPair:0] |
+| test.swift:472:17:472:41 | .myCons(...) [myCons:1, myPair:1] | test.swift:472:28:472:40 | .myPair(...) [myPair:1] |
+| test.swift:472:28:472:40 | .myPair(...) [myPair:1] | test.swift:472:39:472:39 | c |
+| test.swift:472:39:472:39 | c | test.swift:473:19:473:19 | c |
+| test.swift:476:12:476:17 | (...) [Tuple element at index 0, myPair:1] | test.swift:477:14:477:55 | (...) [Tuple element at index 0, myPair:1] |
+| test.swift:476:12:476:17 | (...) [Tuple element at index 1, myCons:1, myPair:1] | test.swift:477:14:477:55 | (...) [Tuple element at index 1, myCons:1, myPair:1] |
+| test.swift:476:13:476:13 | a [myPair:1] | test.swift:476:12:476:17 | (...) [Tuple element at index 0, myPair:1] |
+| test.swift:476:16:476:16 | b [myCons:1, myPair:1] | test.swift:476:12:476:17 | (...) [Tuple element at index 1, myCons:1, myPair:1] |
+| test.swift:477:14:477:55 | (...) [Tuple element at index 0, myPair:1] | test.swift:477:15:477:27 | .myPair(...) [myPair:1] |
+| test.swift:477:14:477:55 | (...) [Tuple element at index 1, myCons:1, myPair:1] | test.swift:477:30:477:54 | .myCons(...) [myCons:1, myPair:1] |
+| test.swift:477:15:477:27 | .myPair(...) [myPair:1] | test.swift:477:26:477:26 | b |
+| test.swift:477:26:477:26 | b | test.swift:479:19:479:19 | b |
+| test.swift:477:30:477:54 | .myCons(...) [myCons:1, myPair:1] | test.swift:477:41:477:53 | .myPair(...) [myPair:1] |
+| test.swift:477:41:477:53 | .myPair(...) [myPair:1] | test.swift:477:52:477:52 | e |
+| test.swift:477:52:477:52 | e | test.swift:482:19:482:19 | e |
+| test.swift:488:14:488:38 | call to ... [mySingle:0] | test.swift:494:13:494:35 | .mySingle(...) [mySingle:0] |
+| test.swift:488:30:488:37 | call to source() | test.swift:488:14:488:38 | call to ... [mySingle:0] |
+| test.swift:490:14:490:32 | call to mkMyEnum1(_:) [mySingle:0] | test.swift:496:13:496:35 | .mySingle(...) [mySingle:0] |
+| test.swift:490:24:490:31 | call to source() | test.swift:375:16:375:21 | v |
+| test.swift:490:24:490:31 | call to source() | test.swift:490:14:490:32 | call to mkMyEnum1(_:) [mySingle:0] |
+| test.swift:494:13:494:35 | .mySingle(...) [mySingle:0] | test.swift:494:33:494:33 | d2 |
+| test.swift:494:33:494:33 | d2 | test.swift:494:54:494:54 | d2 |
+| test.swift:496:13:496:35 | .mySingle(...) [mySingle:0] | test.swift:496:33:496:33 | d4 |
+| test.swift:496:33:496:33 | d4 | test.swift:496:54:496:54 | d4 |
+| test.swift:517:13:517:28 | call to optionalSource() [some:0] | test.swift:519:8:519:12 | let ...? [some:0] |
+| test.swift:517:13:517:28 | call to optionalSource() [some:0] | test.swift:524:19:524:19 | x [some:0] |
+| test.swift:519:8:519:12 | let ...? [some:0] | test.swift:519:12:519:12 | a |
+| test.swift:519:12:519:12 | a | test.swift:520:19:520:19 | a |
+| test.swift:524:18:524:23 | (...) [Tuple element at index 0, some:0] | test.swift:526:10:526:37 | (...) [Tuple element at index 0, some:0] |
+| test.swift:524:19:524:19 | x [some:0] | test.swift:524:18:524:23 | (...) [Tuple element at index 0, some:0] |
+| test.swift:526:10:526:37 | (...) [Tuple element at index 0, some:0] | test.swift:526:11:526:22 | .some(...) [some:0] |
+| test.swift:526:11:526:22 | .some(...) [some:0] | test.swift:526:21:526:21 | a |
+| test.swift:526:21:526:21 | a | test.swift:527:19:527:19 | a |
+| test.swift:540:9:540:9 | self [x, some:0] | file://:0:0:0:0 | self [x, some:0] |
+| test.swift:540:9:540:9 | value [some:0] | file://:0:0:0:0 | value [some:0] |
+| test.swift:544:13:544:28 | call to optionalSource() [some:0] | test.swift:546:12:546:12 | x [some:0] |
+| test.swift:546:5:546:5 | [post] cx [x, some:0] | test.swift:550:20:550:20 | cx [x, some:0] |
+| test.swift:546:12:546:12 | x [some:0] | test.swift:540:9:540:9 | value [some:0] |
+| test.swift:546:12:546:12 | x [some:0] | test.swift:546:5:546:5 | [post] cx [x, some:0] |
+| test.swift:550:11:550:15 | let ...? [some:0] | test.swift:550:15:550:15 | z1 |
+| test.swift:550:15:550:15 | z1 | test.swift:551:15:551:15 | z1 |
+| test.swift:550:20:550:20 | cx [x, some:0] | test.swift:540:9:540:9 | self [x, some:0] |
+| test.swift:550:20:550:20 | cx [x, some:0] | test.swift:550:20:550:23 | .x [some:0] |
+| test.swift:550:20:550:23 | .x [some:0] | test.swift:550:11:550:15 | let ...? [some:0] |
+| test.swift:557:14:557:21 | call to source() | test.swift:557:13:557:21 | call to +(_:) |
+| test.swift:566:9:566:9 | self [str] | file://:0:0:0:0 | self [str] |
+| test.swift:567:10:567:13 | s | test.swift:568:13:568:13 | s |
+| test.swift:568:7:568:7 | [post] self [str] | test.swift:567:5:569:5 | self[return] [str] |
+| test.swift:568:13:568:13 | s | test.swift:568:7:568:7 | [post] self [str] |
+| test.swift:573:17:576:5 | self[return] [str] | test.swift:581:13:581:41 | call to MyClass.init(contentsOfFile:) [str] |
+| test.swift:574:7:574:7 | [post] self [str] | test.swift:573:17:576:5 | self[return] [str] |
+| test.swift:574:7:574:7 | [post] self [str] | test.swift:575:17:575:17 | self [str] |
+| test.swift:574:20:574:28 | call to source3() | test.swift:567:10:567:13 | s |
+| test.swift:574:20:574:28 | call to source3() | test.swift:574:7:574:7 | [post] self [str] |
+| test.swift:575:17:575:17 | self [str] | test.swift:575:17:575:17 | .str |
+| test.swift:580:13:580:33 | call to MyClass.init(s:) [str] | test.swift:566:9:566:9 | self [str] |
+| test.swift:580:13:580:33 | call to MyClass.init(s:) [str] | test.swift:580:13:580:35 | .str |
+| test.swift:580:24:580:32 | call to source3() | test.swift:567:10:567:13 | s |
+| test.swift:580:24:580:32 | call to source3() | test.swift:580:13:580:33 | call to MyClass.init(s:) [str] |
+| test.swift:581:13:581:41 | call to MyClass.init(contentsOfFile:) [str] | test.swift:566:9:566:9 | self [str] |
+| test.swift:581:13:581:41 | call to MyClass.init(contentsOfFile:) [str] | test.swift:581:13:581:43 | .str |
+| test.swift:598:8:598:11 | x | test.swift:599:14:599:14 | x |
+| test.swift:599:5:599:5 | [post] self [x] | test.swift:598:3:600:3 | self[return] [x] |
+| test.swift:599:14:599:14 | x | test.swift:599:5:599:5 | [post] self [x] |
+| test.swift:604:11:604:24 | call to S.init(x:) [x] | test.swift:606:13:606:13 | s [x] |
+| test.swift:604:11:604:24 | call to S.init(x:) [x] | test.swift:609:13:609:13 | s [x] |
+| test.swift:604:16:604:23 | call to source() | test.swift:598:8:598:11 | x |
+| test.swift:604:16:604:23 | call to source() | test.swift:604:11:604:24 | call to S.init(x:) [x] |
+| test.swift:605:11:605:14 | enter #keyPath(...) [x] | test.swift:605:14:605:14 | KeyPathComponent [x] |
+| test.swift:605:14:605:14 | KeyPathComponent [x] | test.swift:605:11:605:14 | exit #keyPath(...) |
+| test.swift:606:13:606:13 | s [x] | test.swift:605:11:605:14 | enter #keyPath(...) [x] |
+| test.swift:606:13:606:13 | s [x] | test.swift:606:13:606:25 | \\...[...] |
+| test.swift:608:36:608:38 | enter #keyPath(...) [x] | test.swift:608:38:608:38 | KeyPathComponent [x] |
+| test.swift:608:38:608:38 | KeyPathComponent [x] | test.swift:608:36:608:38 | exit #keyPath(...) |
+| test.swift:609:13:609:13 | s [x] | test.swift:608:36:608:38 | enter #keyPath(...) [x] |
+| test.swift:609:13:609:13 | s [x] | test.swift:609:13:609:32 | \\...[...] |
+| test.swift:615:8:615:11 | s [x] | test.swift:616:14:616:14 | s [x] |
+| test.swift:616:5:616:5 | [post] self [s, x] | test.swift:615:3:617:3 | self[return] [s, x] |
+| test.swift:616:14:616:14 | s [x] | test.swift:616:5:616:5 | [post] self [s, x] |
+| test.swift:621:11:621:24 | call to S.init(x:) [x] | test.swift:622:18:622:18 | s [x] |
+| test.swift:621:16:621:23 | call to source() | test.swift:598:8:598:11 | x |
+| test.swift:621:16:621:23 | call to source() | test.swift:621:11:621:24 | call to S.init(x:) [x] |
+| test.swift:622:12:622:19 | call to S2.init(s:) [s, x] | test.swift:624:13:624:13 | s2 [s, x] |
+| test.swift:622:18:622:18 | s [x] | test.swift:615:8:615:11 | s [x] |
+| test.swift:622:18:622:18 | s [x] | test.swift:622:12:622:19 | call to S2.init(s:) [s, x] |
+| test.swift:623:11:623:17 | enter #keyPath(...) [s, x] | test.swift:623:15:623:15 | KeyPathComponent [s, x] |
+| test.swift:623:15:623:15 | KeyPathComponent [s, x] | test.swift:623:17:623:17 | KeyPathComponent [x] |
+| test.swift:623:17:623:17 | KeyPathComponent [x] | test.swift:623:11:623:17 | exit #keyPath(...) |
+| test.swift:624:13:624:13 | s2 [s, x] | test.swift:623:11:623:17 | enter #keyPath(...) [s, x] |
+| test.swift:624:13:624:13 | s2 [s, x] | test.swift:624:13:624:26 | \\...[...] |
+| test.swift:649:13:649:20 | call to source() | test.swift:657:15:657:15 | y |
+| test.swift:659:9:659:16 | call to source() | test.swift:661:10:661:11 | &... |
+| test.swift:659:9:659:16 | call to source() | test.swift:662:15:662:15 | x |
+| test.swift:661:10:661:11 | &... | test.swift:661:14:661:15 | [post] &... |
+| test.swift:661:14:661:15 | [post] &... | test.swift:663:15:663:15 | y |
 nodes
 | file://:0:0:0:0 | .a [x] | semmle.label | .a [x] |
 | file://:0:0:0:0 | .str | semmle.label | .str |
@@ -455,125 +466,138 @@ nodes
 | test.swift:361:15:361:18 | .1 | semmle.label | .1 |
 | test.swift:363:15:363:15 | a | semmle.label | a |
 | test.swift:364:15:364:15 | b | semmle.label | b |
-| test.swift:398:9:398:27 | call to ... [mySingle:0] | semmle.label | call to ... [mySingle:0] |
-| test.swift:398:19:398:26 | call to source() | semmle.label | call to source() |
-| test.swift:403:10:403:25 | .mySingle(...) [mySingle:0] | semmle.label | .mySingle(...) [mySingle:0] |
-| test.swift:403:24:403:24 | a | semmle.label | a |
-| test.swift:404:19:404:19 | a | semmle.label | a |
-| test.swift:412:13:412:28 | .mySingle(...) [mySingle:0] | semmle.label | .mySingle(...) [mySingle:0] |
-| test.swift:412:27:412:27 | x | semmle.label | x |
-| test.swift:413:19:413:19 | x | semmle.label | x |
-| test.swift:420:9:420:34 | call to ... [myPair:1] | semmle.label | call to ... [myPair:1] |
-| test.swift:420:26:420:33 | call to source() | semmle.label | call to source() |
-| test.swift:427:10:427:30 | .myPair(...) [myPair:1] | semmle.label | .myPair(...) [myPair:1] |
-| test.swift:427:29:427:29 | b | semmle.label | b |
-| test.swift:429:19:429:19 | b | semmle.label | b |
-| test.swift:437:13:437:33 | .myPair(...) [myPair:1] | semmle.label | .myPair(...) [myPair:1] |
-| test.swift:437:32:437:32 | y | semmle.label | y |
-| test.swift:439:19:439:19 | y | semmle.label | y |
-| test.swift:442:21:442:34 | call to ... [myCons:1, myPair:1] | semmle.label | call to ... [myCons:1, myPair:1] |
-| test.swift:442:33:442:33 | a [myPair:1] | semmle.label | a [myPair:1] |
-| test.swift:452:14:452:38 | .myCons(...) [myCons:1, myPair:1] | semmle.label | .myCons(...) [myCons:1, myPair:1] |
-| test.swift:452:25:452:37 | .myPair(...) [myPair:1] | semmle.label | .myPair(...) [myPair:1] |
-| test.swift:452:36:452:36 | c | semmle.label | c |
-| test.swift:455:19:455:19 | c | semmle.label | c |
-| test.swift:463:13:463:39 | .myPair(...) [myPair:0] | semmle.label | .myPair(...) [myPair:0] |
-| test.swift:463:31:463:31 | x | semmle.label | x |
-| test.swift:463:43:463:62 | call to ... [myPair:0] | semmle.label | call to ... [myPair:0] |
-| test.swift:463:51:463:58 | call to source() | semmle.label | call to source() |
-| test.swift:464:19:464:19 | x | semmle.label | x |
-| test.swift:467:17:467:41 | .myCons(...) [myCons:1, myPair:1] | semmle.label | .myCons(...) [myCons:1, myPair:1] |
-| test.swift:467:28:467:40 | .myPair(...) [myPair:1] | semmle.label | .myPair(...) [myPair:1] |
-| test.swift:467:39:467:39 | c | semmle.label | c |
-| test.swift:468:19:468:19 | c | semmle.label | c |
-| test.swift:471:12:471:17 | (...) [Tuple element at index 0, myPair:1] | semmle.label | (...) [Tuple element at index 0, myPair:1] |
-| test.swift:471:12:471:17 | (...) [Tuple element at index 1, myCons:1, myPair:1] | semmle.label | (...) [Tuple element at index 1, myCons:1, myPair:1] |
-| test.swift:471:13:471:13 | a [myPair:1] | semmle.label | a [myPair:1] |
-| test.swift:471:16:471:16 | b [myCons:1, myPair:1] | semmle.label | b [myCons:1, myPair:1] |
-| test.swift:472:14:472:55 | (...) [Tuple element at index 0, myPair:1] | semmle.label | (...) [Tuple element at index 0, myPair:1] |
-| test.swift:472:14:472:55 | (...) [Tuple element at index 1, myCons:1, myPair:1] | semmle.label | (...) [Tuple element at index 1, myCons:1, myPair:1] |
-| test.swift:472:15:472:27 | .myPair(...) [myPair:1] | semmle.label | .myPair(...) [myPair:1] |
-| test.swift:472:26:472:26 | b | semmle.label | b |
-| test.swift:472:30:472:54 | .myCons(...) [myCons:1, myPair:1] | semmle.label | .myCons(...) [myCons:1, myPair:1] |
-| test.swift:472:41:472:53 | .myPair(...) [myPair:1] | semmle.label | .myPair(...) [myPair:1] |
-| test.swift:472:52:472:52 | e | semmle.label | e |
-| test.swift:474:19:474:19 | b | semmle.label | b |
-| test.swift:477:19:477:19 | e | semmle.label | e |
-| test.swift:486:13:486:28 | call to optionalSource() [some:0] | semmle.label | call to optionalSource() [some:0] |
-| test.swift:488:8:488:12 | let ...? [some:0] | semmle.label | let ...? [some:0] |
-| test.swift:488:12:488:12 | a | semmle.label | a |
-| test.swift:489:19:489:19 | a | semmle.label | a |
-| test.swift:493:18:493:23 | (...) [Tuple element at index 0, some:0] | semmle.label | (...) [Tuple element at index 0, some:0] |
-| test.swift:493:19:493:19 | x [some:0] | semmle.label | x [some:0] |
-| test.swift:495:10:495:37 | (...) [Tuple element at index 0, some:0] | semmle.label | (...) [Tuple element at index 0, some:0] |
-| test.swift:495:11:495:22 | .some(...) [some:0] | semmle.label | .some(...) [some:0] |
-| test.swift:495:21:495:21 | a | semmle.label | a |
-| test.swift:496:19:496:19 | a | semmle.label | a |
-| test.swift:509:9:509:9 | self [x, some:0] | semmle.label | self [x, some:0] |
-| test.swift:509:9:509:9 | value [some:0] | semmle.label | value [some:0] |
-| test.swift:513:13:513:28 | call to optionalSource() [some:0] | semmle.label | call to optionalSource() [some:0] |
-| test.swift:515:5:515:5 | [post] cx [x, some:0] | semmle.label | [post] cx [x, some:0] |
-| test.swift:515:12:515:12 | x [some:0] | semmle.label | x [some:0] |
-| test.swift:519:11:519:15 | let ...? [some:0] | semmle.label | let ...? [some:0] |
-| test.swift:519:15:519:15 | z1 | semmle.label | z1 |
-| test.swift:519:20:519:20 | cx [x, some:0] | semmle.label | cx [x, some:0] |
-| test.swift:519:20:519:23 | .x [some:0] | semmle.label | .x [some:0] |
-| test.swift:520:15:520:15 | z1 | semmle.label | z1 |
-| test.swift:526:13:526:21 | call to +(_:) | semmle.label | call to +(_:) |
-| test.swift:526:14:526:21 | call to source() | semmle.label | call to source() |
-| test.swift:527:14:527:21 | call to source() | semmle.label | call to source() |
-| test.swift:535:9:535:9 | self [str] | semmle.label | self [str] |
-| test.swift:536:5:538:5 | self[return] [str] | semmle.label | self[return] [str] |
-| test.swift:536:10:536:13 | s | semmle.label | s |
-| test.swift:537:7:537:7 | [post] self [str] | semmle.label | [post] self [str] |
-| test.swift:537:13:537:13 | s | semmle.label | s |
-| test.swift:542:17:545:5 | self[return] [str] | semmle.label | self[return] [str] |
-| test.swift:543:7:543:7 | [post] self [str] | semmle.label | [post] self [str] |
-| test.swift:543:20:543:28 | call to source3() | semmle.label | call to source3() |
-| test.swift:544:17:544:17 | .str | semmle.label | .str |
-| test.swift:544:17:544:17 | self [str] | semmle.label | self [str] |
-| test.swift:549:13:549:33 | call to MyClass.init(s:) [str] | semmle.label | call to MyClass.init(s:) [str] |
-| test.swift:549:13:549:35 | .str | semmle.label | .str |
-| test.swift:549:24:549:32 | call to source3() | semmle.label | call to source3() |
-| test.swift:550:13:550:41 | call to MyClass.init(contentsOfFile:) [str] | semmle.label | call to MyClass.init(contentsOfFile:) [str] |
-| test.swift:550:13:550:43 | .str | semmle.label | .str |
-| test.swift:567:3:569:3 | self[return] [x] | semmle.label | self[return] [x] |
-| test.swift:567:8:567:11 | x | semmle.label | x |
-| test.swift:568:5:568:5 | [post] self [x] | semmle.label | [post] self [x] |
-| test.swift:568:14:568:14 | x | semmle.label | x |
-| test.swift:573:11:573:24 | call to S.init(x:) [x] | semmle.label | call to S.init(x:) [x] |
-| test.swift:573:16:573:23 | call to source() | semmle.label | call to source() |
-| test.swift:574:11:574:14 | enter #keyPath(...) [x] | semmle.label | enter #keyPath(...) [x] |
-| test.swift:574:11:574:14 | exit #keyPath(...) | semmle.label | exit #keyPath(...) |
-| test.swift:574:14:574:14 | KeyPathComponent [x] | semmle.label | KeyPathComponent [x] |
-| test.swift:575:13:575:13 | s [x] | semmle.label | s [x] |
-| test.swift:575:13:575:25 | \\...[...] | semmle.label | \\...[...] |
-| test.swift:577:36:577:38 | enter #keyPath(...) [x] | semmle.label | enter #keyPath(...) [x] |
-| test.swift:577:36:577:38 | exit #keyPath(...) | semmle.label | exit #keyPath(...) |
-| test.swift:577:38:577:38 | KeyPathComponent [x] | semmle.label | KeyPathComponent [x] |
-| test.swift:578:13:578:13 | s [x] | semmle.label | s [x] |
-| test.swift:578:13:578:32 | \\...[...] | semmle.label | \\...[...] |
-| test.swift:584:3:586:3 | self[return] [s, x] | semmle.label | self[return] [s, x] |
-| test.swift:584:8:584:11 | s [x] | semmle.label | s [x] |
-| test.swift:585:5:585:5 | [post] self [s, x] | semmle.label | [post] self [s, x] |
-| test.swift:585:14:585:14 | s [x] | semmle.label | s [x] |
-| test.swift:590:11:590:24 | call to S.init(x:) [x] | semmle.label | call to S.init(x:) [x] |
-| test.swift:590:16:590:23 | call to source() | semmle.label | call to source() |
-| test.swift:591:12:591:19 | call to S2.init(s:) [s, x] | semmle.label | call to S2.init(s:) [s, x] |
-| test.swift:591:18:591:18 | s [x] | semmle.label | s [x] |
-| test.swift:592:11:592:17 | enter #keyPath(...) [s, x] | semmle.label | enter #keyPath(...) [s, x] |
-| test.swift:592:11:592:17 | exit #keyPath(...) | semmle.label | exit #keyPath(...) |
-| test.swift:592:15:592:15 | KeyPathComponent [s, x] | semmle.label | KeyPathComponent [s, x] |
-| test.swift:592:17:592:17 | KeyPathComponent [x] | semmle.label | KeyPathComponent [x] |
-| test.swift:593:13:593:13 | s2 [s, x] | semmle.label | s2 [s, x] |
-| test.swift:593:13:593:26 | \\...[...] | semmle.label | \\...[...] |
-| test.swift:618:13:618:20 | call to source() | semmle.label | call to source() |
-| test.swift:626:15:626:15 | y | semmle.label | y |
-| test.swift:628:9:628:16 | call to source() | semmle.label | call to source() |
-| test.swift:630:10:630:11 | &... | semmle.label | &... |
-| test.swift:630:14:630:15 | [post] &... | semmle.label | [post] &... |
-| test.swift:631:15:631:15 | x | semmle.label | x |
-| test.swift:632:15:632:15 | y | semmle.label | y |
+| test.swift:375:16:375:21 | v | semmle.label | v |
+| test.swift:375:45:375:62 | call to ... [mySingle:0] | semmle.label | call to ... [mySingle:0] |
+| test.swift:375:61:375:61 | v | semmle.label | v |
+| test.swift:403:9:403:27 | call to ... [mySingle:0] | semmle.label | call to ... [mySingle:0] |
+| test.swift:403:19:403:26 | call to source() | semmle.label | call to source() |
+| test.swift:408:10:408:25 | .mySingle(...) [mySingle:0] | semmle.label | .mySingle(...) [mySingle:0] |
+| test.swift:408:24:408:24 | a | semmle.label | a |
+| test.swift:409:19:409:19 | a | semmle.label | a |
+| test.swift:417:13:417:28 | .mySingle(...) [mySingle:0] | semmle.label | .mySingle(...) [mySingle:0] |
+| test.swift:417:27:417:27 | x | semmle.label | x |
+| test.swift:418:19:418:19 | x | semmle.label | x |
+| test.swift:425:9:425:34 | call to ... [myPair:1] | semmle.label | call to ... [myPair:1] |
+| test.swift:425:26:425:33 | call to source() | semmle.label | call to source() |
+| test.swift:432:10:432:30 | .myPair(...) [myPair:1] | semmle.label | .myPair(...) [myPair:1] |
+| test.swift:432:29:432:29 | b | semmle.label | b |
+| test.swift:434:19:434:19 | b | semmle.label | b |
+| test.swift:442:13:442:33 | .myPair(...) [myPair:1] | semmle.label | .myPair(...) [myPair:1] |
+| test.swift:442:32:442:32 | y | semmle.label | y |
+| test.swift:444:19:444:19 | y | semmle.label | y |
+| test.swift:447:21:447:34 | call to ... [myCons:1, myPair:1] | semmle.label | call to ... [myCons:1, myPair:1] |
+| test.swift:447:33:447:33 | a [myPair:1] | semmle.label | a [myPair:1] |
+| test.swift:457:14:457:38 | .myCons(...) [myCons:1, myPair:1] | semmle.label | .myCons(...) [myCons:1, myPair:1] |
+| test.swift:457:25:457:37 | .myPair(...) [myPair:1] | semmle.label | .myPair(...) [myPair:1] |
+| test.swift:457:36:457:36 | c | semmle.label | c |
+| test.swift:460:19:460:19 | c | semmle.label | c |
+| test.swift:468:13:468:39 | .myPair(...) [myPair:0] | semmle.label | .myPair(...) [myPair:0] |
+| test.swift:468:31:468:31 | x | semmle.label | x |
+| test.swift:468:43:468:62 | call to ... [myPair:0] | semmle.label | call to ... [myPair:0] |
+| test.swift:468:51:468:58 | call to source() | semmle.label | call to source() |
+| test.swift:469:19:469:19 | x | semmle.label | x |
+| test.swift:472:17:472:41 | .myCons(...) [myCons:1, myPair:1] | semmle.label | .myCons(...) [myCons:1, myPair:1] |
+| test.swift:472:28:472:40 | .myPair(...) [myPair:1] | semmle.label | .myPair(...) [myPair:1] |
+| test.swift:472:39:472:39 | c | semmle.label | c |
+| test.swift:473:19:473:19 | c | semmle.label | c |
+| test.swift:476:12:476:17 | (...) [Tuple element at index 0, myPair:1] | semmle.label | (...) [Tuple element at index 0, myPair:1] |
+| test.swift:476:12:476:17 | (...) [Tuple element at index 1, myCons:1, myPair:1] | semmle.label | (...) [Tuple element at index 1, myCons:1, myPair:1] |
+| test.swift:476:13:476:13 | a [myPair:1] | semmle.label | a [myPair:1] |
+| test.swift:476:16:476:16 | b [myCons:1, myPair:1] | semmle.label | b [myCons:1, myPair:1] |
+| test.swift:477:14:477:55 | (...) [Tuple element at index 0, myPair:1] | semmle.label | (...) [Tuple element at index 0, myPair:1] |
+| test.swift:477:14:477:55 | (...) [Tuple element at index 1, myCons:1, myPair:1] | semmle.label | (...) [Tuple element at index 1, myCons:1, myPair:1] |
+| test.swift:477:15:477:27 | .myPair(...) [myPair:1] | semmle.label | .myPair(...) [myPair:1] |
+| test.swift:477:26:477:26 | b | semmle.label | b |
+| test.swift:477:30:477:54 | .myCons(...) [myCons:1, myPair:1] | semmle.label | .myCons(...) [myCons:1, myPair:1] |
+| test.swift:477:41:477:53 | .myPair(...) [myPair:1] | semmle.label | .myPair(...) [myPair:1] |
+| test.swift:477:52:477:52 | e | semmle.label | e |
+| test.swift:479:19:479:19 | b | semmle.label | b |
+| test.swift:482:19:482:19 | e | semmle.label | e |
+| test.swift:488:14:488:38 | call to ... [mySingle:0] | semmle.label | call to ... [mySingle:0] |
+| test.swift:488:30:488:37 | call to source() | semmle.label | call to source() |
+| test.swift:490:14:490:32 | call to mkMyEnum1(_:) [mySingle:0] | semmle.label | call to mkMyEnum1(_:) [mySingle:0] |
+| test.swift:490:24:490:31 | call to source() | semmle.label | call to source() |
+| test.swift:494:13:494:35 | .mySingle(...) [mySingle:0] | semmle.label | .mySingle(...) [mySingle:0] |
+| test.swift:494:33:494:33 | d2 | semmle.label | d2 |
+| test.swift:494:54:494:54 | d2 | semmle.label | d2 |
+| test.swift:496:13:496:35 | .mySingle(...) [mySingle:0] | semmle.label | .mySingle(...) [mySingle:0] |
+| test.swift:496:33:496:33 | d4 | semmle.label | d4 |
+| test.swift:496:54:496:54 | d4 | semmle.label | d4 |
+| test.swift:517:13:517:28 | call to optionalSource() [some:0] | semmle.label | call to optionalSource() [some:0] |
+| test.swift:519:8:519:12 | let ...? [some:0] | semmle.label | let ...? [some:0] |
+| test.swift:519:12:519:12 | a | semmle.label | a |
+| test.swift:520:19:520:19 | a | semmle.label | a |
+| test.swift:524:18:524:23 | (...) [Tuple element at index 0, some:0] | semmle.label | (...) [Tuple element at index 0, some:0] |
+| test.swift:524:19:524:19 | x [some:0] | semmle.label | x [some:0] |
+| test.swift:526:10:526:37 | (...) [Tuple element at index 0, some:0] | semmle.label | (...) [Tuple element at index 0, some:0] |
+| test.swift:526:11:526:22 | .some(...) [some:0] | semmle.label | .some(...) [some:0] |
+| test.swift:526:21:526:21 | a | semmle.label | a |
+| test.swift:527:19:527:19 | a | semmle.label | a |
+| test.swift:540:9:540:9 | self [x, some:0] | semmle.label | self [x, some:0] |
+| test.swift:540:9:540:9 | value [some:0] | semmle.label | value [some:0] |
+| test.swift:544:13:544:28 | call to optionalSource() [some:0] | semmle.label | call to optionalSource() [some:0] |
+| test.swift:546:5:546:5 | [post] cx [x, some:0] | semmle.label | [post] cx [x, some:0] |
+| test.swift:546:12:546:12 | x [some:0] | semmle.label | x [some:0] |
+| test.swift:550:11:550:15 | let ...? [some:0] | semmle.label | let ...? [some:0] |
+| test.swift:550:15:550:15 | z1 | semmle.label | z1 |
+| test.swift:550:20:550:20 | cx [x, some:0] | semmle.label | cx [x, some:0] |
+| test.swift:550:20:550:23 | .x [some:0] | semmle.label | .x [some:0] |
+| test.swift:551:15:551:15 | z1 | semmle.label | z1 |
+| test.swift:557:13:557:21 | call to +(_:) | semmle.label | call to +(_:) |
+| test.swift:557:14:557:21 | call to source() | semmle.label | call to source() |
+| test.swift:558:14:558:21 | call to source() | semmle.label | call to source() |
+| test.swift:566:9:566:9 | self [str] | semmle.label | self [str] |
+| test.swift:567:5:569:5 | self[return] [str] | semmle.label | self[return] [str] |
+| test.swift:567:10:567:13 | s | semmle.label | s |
+| test.swift:568:7:568:7 | [post] self [str] | semmle.label | [post] self [str] |
+| test.swift:568:13:568:13 | s | semmle.label | s |
+| test.swift:573:17:576:5 | self[return] [str] | semmle.label | self[return] [str] |
+| test.swift:574:7:574:7 | [post] self [str] | semmle.label | [post] self [str] |
+| test.swift:574:20:574:28 | call to source3() | semmle.label | call to source3() |
+| test.swift:575:17:575:17 | .str | semmle.label | .str |
+| test.swift:575:17:575:17 | self [str] | semmle.label | self [str] |
+| test.swift:580:13:580:33 | call to MyClass.init(s:) [str] | semmle.label | call to MyClass.init(s:) [str] |
+| test.swift:580:13:580:35 | .str | semmle.label | .str |
+| test.swift:580:24:580:32 | call to source3() | semmle.label | call to source3() |
+| test.swift:581:13:581:41 | call to MyClass.init(contentsOfFile:) [str] | semmle.label | call to MyClass.init(contentsOfFile:) [str] |
+| test.swift:581:13:581:43 | .str | semmle.label | .str |
+| test.swift:598:3:600:3 | self[return] [x] | semmle.label | self[return] [x] |
+| test.swift:598:8:598:11 | x | semmle.label | x |
+| test.swift:599:5:599:5 | [post] self [x] | semmle.label | [post] self [x] |
+| test.swift:599:14:599:14 | x | semmle.label | x |
+| test.swift:604:11:604:24 | call to S.init(x:) [x] | semmle.label | call to S.init(x:) [x] |
+| test.swift:604:16:604:23 | call to source() | semmle.label | call to source() |
+| test.swift:605:11:605:14 | enter #keyPath(...) [x] | semmle.label | enter #keyPath(...) [x] |
+| test.swift:605:11:605:14 | exit #keyPath(...) | semmle.label | exit #keyPath(...) |
+| test.swift:605:14:605:14 | KeyPathComponent [x] | semmle.label | KeyPathComponent [x] |
+| test.swift:606:13:606:13 | s [x] | semmle.label | s [x] |
+| test.swift:606:13:606:25 | \\...[...] | semmle.label | \\...[...] |
+| test.swift:608:36:608:38 | enter #keyPath(...) [x] | semmle.label | enter #keyPath(...) [x] |
+| test.swift:608:36:608:38 | exit #keyPath(...) | semmle.label | exit #keyPath(...) |
+| test.swift:608:38:608:38 | KeyPathComponent [x] | semmle.label | KeyPathComponent [x] |
+| test.swift:609:13:609:13 | s [x] | semmle.label | s [x] |
+| test.swift:609:13:609:32 | \\...[...] | semmle.label | \\...[...] |
+| test.swift:615:3:617:3 | self[return] [s, x] | semmle.label | self[return] [s, x] |
+| test.swift:615:8:615:11 | s [x] | semmle.label | s [x] |
+| test.swift:616:5:616:5 | [post] self [s, x] | semmle.label | [post] self [s, x] |
+| test.swift:616:14:616:14 | s [x] | semmle.label | s [x] |
+| test.swift:621:11:621:24 | call to S.init(x:) [x] | semmle.label | call to S.init(x:) [x] |
+| test.swift:621:16:621:23 | call to source() | semmle.label | call to source() |
+| test.swift:622:12:622:19 | call to S2.init(s:) [s, x] | semmle.label | call to S2.init(s:) [s, x] |
+| test.swift:622:18:622:18 | s [x] | semmle.label | s [x] |
+| test.swift:623:11:623:17 | enter #keyPath(...) [s, x] | semmle.label | enter #keyPath(...) [s, x] |
+| test.swift:623:11:623:17 | exit #keyPath(...) | semmle.label | exit #keyPath(...) |
+| test.swift:623:15:623:15 | KeyPathComponent [s, x] | semmle.label | KeyPathComponent [s, x] |
+| test.swift:623:17:623:17 | KeyPathComponent [x] | semmle.label | KeyPathComponent [x] |
+| test.swift:624:13:624:13 | s2 [s, x] | semmle.label | s2 [s, x] |
+| test.swift:624:13:624:26 | \\...[...] | semmle.label | \\...[...] |
+| test.swift:649:13:649:20 | call to source() | semmle.label | call to source() |
+| test.swift:657:15:657:15 | y | semmle.label | y |
+| test.swift:659:9:659:16 | call to source() | semmle.label | call to source() |
+| test.swift:661:10:661:11 | &... | semmle.label | &... |
+| test.swift:661:14:661:15 | [post] &... | semmle.label | [post] &... |
+| test.swift:662:15:662:15 | x | semmle.label | x |
+| test.swift:663:15:663:15 | y | semmle.label | y |
 subpaths
 | test.swift:75:21:75:22 | &... | test.swift:65:16:65:28 | arg1 | test.swift:65:1:70:1 | arg2[return] | test.swift:75:31:75:32 | [post] &... |
 | test.swift:114:19:114:19 | arg | test.swift:109:9:109:14 | arg | test.swift:110:12:110:12 | arg | test.swift:114:12:114:22 | call to ... |
@@ -600,18 +624,19 @@ subpaths
 | test.swift:218:11:218:18 | call to source() | test.swift:169:12:169:22 | value | test.swift:170:5:170:5 | [post] self [x] | test.swift:218:3:218:5 | [post] getter for .a [x] |
 | test.swift:219:13:219:13 | b [a, x] | test.swift:185:7:185:7 | self [a, x] | file://:0:0:0:0 | .a [x] | test.swift:219:13:219:15 | .a [x] |
 | test.swift:219:13:219:15 | .a [x] | test.swift:163:7:163:7 | self [x] | file://:0:0:0:0 | .x | test.swift:219:13:219:17 | .x |
-| test.swift:515:12:515:12 | x [some:0] | test.swift:509:9:509:9 | value [some:0] | file://:0:0:0:0 | [post] self [x, some:0] | test.swift:515:5:515:5 | [post] cx [x, some:0] |
-| test.swift:519:20:519:20 | cx [x, some:0] | test.swift:509:9:509:9 | self [x, some:0] | file://:0:0:0:0 | .x [some:0] | test.swift:519:20:519:23 | .x [some:0] |
-| test.swift:543:20:543:28 | call to source3() | test.swift:536:10:536:13 | s | test.swift:537:7:537:7 | [post] self [str] | test.swift:543:7:543:7 | [post] self [str] |
-| test.swift:549:13:549:33 | call to MyClass.init(s:) [str] | test.swift:535:9:535:9 | self [str] | file://:0:0:0:0 | .str | test.swift:549:13:549:35 | .str |
-| test.swift:549:24:549:32 | call to source3() | test.swift:536:10:536:13 | s | test.swift:536:5:538:5 | self[return] [str] | test.swift:549:13:549:33 | call to MyClass.init(s:) [str] |
-| test.swift:550:13:550:41 | call to MyClass.init(contentsOfFile:) [str] | test.swift:535:9:535:9 | self [str] | file://:0:0:0:0 | .str | test.swift:550:13:550:43 | .str |
-| test.swift:573:16:573:23 | call to source() | test.swift:567:8:567:11 | x | test.swift:567:3:569:3 | self[return] [x] | test.swift:573:11:573:24 | call to S.init(x:) [x] |
-| test.swift:575:13:575:13 | s [x] | test.swift:574:11:574:14 | enter #keyPath(...) [x] | test.swift:574:11:574:14 | exit #keyPath(...) | test.swift:575:13:575:25 | \\...[...] |
-| test.swift:578:13:578:13 | s [x] | test.swift:577:36:577:38 | enter #keyPath(...) [x] | test.swift:577:36:577:38 | exit #keyPath(...) | test.swift:578:13:578:32 | \\...[...] |
-| test.swift:590:16:590:23 | call to source() | test.swift:567:8:567:11 | x | test.swift:567:3:569:3 | self[return] [x] | test.swift:590:11:590:24 | call to S.init(x:) [x] |
-| test.swift:591:18:591:18 | s [x] | test.swift:584:8:584:11 | s [x] | test.swift:584:3:586:3 | self[return] [s, x] | test.swift:591:12:591:19 | call to S2.init(s:) [s, x] |
-| test.swift:593:13:593:13 | s2 [s, x] | test.swift:592:11:592:17 | enter #keyPath(...) [s, x] | test.swift:592:11:592:17 | exit #keyPath(...) | test.swift:593:13:593:26 | \\...[...] |
+| test.swift:490:24:490:31 | call to source() | test.swift:375:16:375:21 | v | test.swift:375:45:375:62 | call to ... [mySingle:0] | test.swift:490:14:490:32 | call to mkMyEnum1(_:) [mySingle:0] |
+| test.swift:546:12:546:12 | x [some:0] | test.swift:540:9:540:9 | value [some:0] | file://:0:0:0:0 | [post] self [x, some:0] | test.swift:546:5:546:5 | [post] cx [x, some:0] |
+| test.swift:550:20:550:20 | cx [x, some:0] | test.swift:540:9:540:9 | self [x, some:0] | file://:0:0:0:0 | .x [some:0] | test.swift:550:20:550:23 | .x [some:0] |
+| test.swift:574:20:574:28 | call to source3() | test.swift:567:10:567:13 | s | test.swift:568:7:568:7 | [post] self [str] | test.swift:574:7:574:7 | [post] self [str] |
+| test.swift:580:13:580:33 | call to MyClass.init(s:) [str] | test.swift:566:9:566:9 | self [str] | file://:0:0:0:0 | .str | test.swift:580:13:580:35 | .str |
+| test.swift:580:24:580:32 | call to source3() | test.swift:567:10:567:13 | s | test.swift:567:5:569:5 | self[return] [str] | test.swift:580:13:580:33 | call to MyClass.init(s:) [str] |
+| test.swift:581:13:581:41 | call to MyClass.init(contentsOfFile:) [str] | test.swift:566:9:566:9 | self [str] | file://:0:0:0:0 | .str | test.swift:581:13:581:43 | .str |
+| test.swift:604:16:604:23 | call to source() | test.swift:598:8:598:11 | x | test.swift:598:3:600:3 | self[return] [x] | test.swift:604:11:604:24 | call to S.init(x:) [x] |
+| test.swift:606:13:606:13 | s [x] | test.swift:605:11:605:14 | enter #keyPath(...) [x] | test.swift:605:11:605:14 | exit #keyPath(...) | test.swift:606:13:606:25 | \\...[...] |
+| test.swift:609:13:609:13 | s [x] | test.swift:608:36:608:38 | enter #keyPath(...) [x] | test.swift:608:36:608:38 | exit #keyPath(...) | test.swift:609:13:609:32 | \\...[...] |
+| test.swift:621:16:621:23 | call to source() | test.swift:598:8:598:11 | x | test.swift:598:3:600:3 | self[return] [x] | test.swift:621:11:621:24 | call to S.init(x:) [x] |
+| test.swift:622:18:622:18 | s [x] | test.swift:615:8:615:11 | s [x] | test.swift:615:3:617:3 | self[return] [s, x] | test.swift:622:12:622:19 | call to S2.init(s:) [s, x] |
+| test.swift:624:13:624:13 | s2 [s, x] | test.swift:623:11:623:17 | enter #keyPath(...) [s, x] | test.swift:623:11:623:17 | exit #keyPath(...) | test.swift:624:13:624:26 | \\...[...] |
 #select
 | test.swift:7:15:7:15 | t1 | test.swift:6:19:6:26 | call to source() | test.swift:7:15:7:15 | t1 | result |
 | test.swift:9:15:9:15 | t1 | test.swift:6:19:6:26 | call to source() | test.swift:9:15:9:15 | t1 | result |
@@ -665,26 +690,28 @@ subpaths
 | test.swift:361:15:361:18 | .1 | test.swift:351:31:351:38 | call to source() | test.swift:361:15:361:18 | .1 | result |
 | test.swift:363:15:363:15 | a | test.swift:351:18:351:25 | call to source() | test.swift:363:15:363:15 | a | result |
 | test.swift:364:15:364:15 | b | test.swift:351:31:351:38 | call to source() | test.swift:364:15:364:15 | b | result |
-| test.swift:404:19:404:19 | a | test.swift:398:19:398:26 | call to source() | test.swift:404:19:404:19 | a | result |
-| test.swift:413:19:413:19 | x | test.swift:398:19:398:26 | call to source() | test.swift:413:19:413:19 | x | result |
-| test.swift:429:19:429:19 | b | test.swift:420:26:420:33 | call to source() | test.swift:429:19:429:19 | b | result |
-| test.swift:439:19:439:19 | y | test.swift:420:26:420:33 | call to source() | test.swift:439:19:439:19 | y | result |
-| test.swift:455:19:455:19 | c | test.swift:420:26:420:33 | call to source() | test.swift:455:19:455:19 | c | result |
-| test.swift:464:19:464:19 | x | test.swift:463:51:463:58 | call to source() | test.swift:464:19:464:19 | x | result |
-| test.swift:468:19:468:19 | c | test.swift:420:26:420:33 | call to source() | test.swift:468:19:468:19 | c | result |
-| test.swift:474:19:474:19 | b | test.swift:420:26:420:33 | call to source() | test.swift:474:19:474:19 | b | result |
-| test.swift:477:19:477:19 | e | test.swift:420:26:420:33 | call to source() | test.swift:477:19:477:19 | e | result |
-| test.swift:489:19:489:19 | a | test.swift:259:12:259:19 | call to source() | test.swift:489:19:489:19 | a | result |
-| test.swift:496:19:496:19 | a | test.swift:259:12:259:19 | call to source() | test.swift:496:19:496:19 | a | result |
-| test.swift:520:15:520:15 | z1 | test.swift:259:12:259:19 | call to source() | test.swift:520:15:520:15 | z1 | result |
-| test.swift:526:13:526:21 | call to +(_:) | test.swift:526:14:526:21 | call to source() | test.swift:526:13:526:21 | call to +(_:) | result |
-| test.swift:527:14:527:21 | call to source() | test.swift:527:14:527:21 | call to source() | test.swift:527:14:527:21 | call to source() | result |
-| test.swift:544:17:544:17 | .str | test.swift:543:20:543:28 | call to source3() | test.swift:544:17:544:17 | .str | result |
-| test.swift:549:13:549:35 | .str | test.swift:549:24:549:32 | call to source3() | test.swift:549:13:549:35 | .str | result |
-| test.swift:550:13:550:43 | .str | test.swift:543:20:543:28 | call to source3() | test.swift:550:13:550:43 | .str | result |
-| test.swift:575:13:575:25 | \\...[...] | test.swift:573:16:573:23 | call to source() | test.swift:575:13:575:25 | \\...[...] | result |
-| test.swift:578:13:578:32 | \\...[...] | test.swift:573:16:573:23 | call to source() | test.swift:578:13:578:32 | \\...[...] | result |
-| test.swift:593:13:593:26 | \\...[...] | test.swift:590:16:590:23 | call to source() | test.swift:593:13:593:26 | \\...[...] | result |
-| test.swift:626:15:626:15 | y | test.swift:618:13:618:20 | call to source() | test.swift:626:15:626:15 | y | result |
-| test.swift:631:15:631:15 | x | test.swift:628:9:628:16 | call to source() | test.swift:631:15:631:15 | x | result |
-| test.swift:632:15:632:15 | y | test.swift:628:9:628:16 | call to source() | test.swift:632:15:632:15 | y | result |
+| test.swift:409:19:409:19 | a | test.swift:403:19:403:26 | call to source() | test.swift:409:19:409:19 | a | result |
+| test.swift:418:19:418:19 | x | test.swift:403:19:403:26 | call to source() | test.swift:418:19:418:19 | x | result |
+| test.swift:434:19:434:19 | b | test.swift:425:26:425:33 | call to source() | test.swift:434:19:434:19 | b | result |
+| test.swift:444:19:444:19 | y | test.swift:425:26:425:33 | call to source() | test.swift:444:19:444:19 | y | result |
+| test.swift:460:19:460:19 | c | test.swift:425:26:425:33 | call to source() | test.swift:460:19:460:19 | c | result |
+| test.swift:469:19:469:19 | x | test.swift:468:51:468:58 | call to source() | test.swift:469:19:469:19 | x | result |
+| test.swift:473:19:473:19 | c | test.swift:425:26:425:33 | call to source() | test.swift:473:19:473:19 | c | result |
+| test.swift:479:19:479:19 | b | test.swift:425:26:425:33 | call to source() | test.swift:479:19:479:19 | b | result |
+| test.swift:482:19:482:19 | e | test.swift:425:26:425:33 | call to source() | test.swift:482:19:482:19 | e | result |
+| test.swift:494:54:494:54 | d2 | test.swift:488:30:488:37 | call to source() | test.swift:494:54:494:54 | d2 | result |
+| test.swift:496:54:496:54 | d4 | test.swift:490:24:490:31 | call to source() | test.swift:496:54:496:54 | d4 | result |
+| test.swift:520:19:520:19 | a | test.swift:259:12:259:19 | call to source() | test.swift:520:19:520:19 | a | result |
+| test.swift:527:19:527:19 | a | test.swift:259:12:259:19 | call to source() | test.swift:527:19:527:19 | a | result |
+| test.swift:551:15:551:15 | z1 | test.swift:259:12:259:19 | call to source() | test.swift:551:15:551:15 | z1 | result |
+| test.swift:557:13:557:21 | call to +(_:) | test.swift:557:14:557:21 | call to source() | test.swift:557:13:557:21 | call to +(_:) | result |
+| test.swift:558:14:558:21 | call to source() | test.swift:558:14:558:21 | call to source() | test.swift:558:14:558:21 | call to source() | result |
+| test.swift:575:17:575:17 | .str | test.swift:574:20:574:28 | call to source3() | test.swift:575:17:575:17 | .str | result |
+| test.swift:580:13:580:35 | .str | test.swift:580:24:580:32 | call to source3() | test.swift:580:13:580:35 | .str | result |
+| test.swift:581:13:581:43 | .str | test.swift:574:20:574:28 | call to source3() | test.swift:581:13:581:43 | .str | result |
+| test.swift:606:13:606:25 | \\...[...] | test.swift:604:16:604:23 | call to source() | test.swift:606:13:606:25 | \\...[...] | result |
+| test.swift:609:13:609:32 | \\...[...] | test.swift:604:16:604:23 | call to source() | test.swift:609:13:609:32 | \\...[...] | result |
+| test.swift:624:13:624:26 | \\...[...] | test.swift:621:16:621:23 | call to source() | test.swift:624:13:624:26 | \\...[...] | result |
+| test.swift:657:15:657:15 | y | test.swift:649:13:649:20 | call to source() | test.swift:657:15:657:15 | y | result |
+| test.swift:662:15:662:15 | x | test.swift:659:9:659:16 | call to source() | test.swift:662:15:662:15 | x | result |
+| test.swift:663:15:663:15 | y | test.swift:659:9:659:16 | call to source() | test.swift:663:15:663:15 | y | result |

--- a/swift/ql/test/library-tests/dataflow/dataflow/DataFlow.expected
+++ b/swift/ql/test/library-tests/dataflow/dataflow/DataFlow.expected
@@ -210,10 +210,14 @@ edges
 | test.swift:490:14:490:32 | call to mkMyEnum1(_:) [mySingle:0] | test.swift:496:13:496:35 | .mySingle(...) [mySingle:0] |
 | test.swift:490:24:490:31 | call to source() | test.swift:375:16:375:21 | v |
 | test.swift:490:24:490:31 | call to source() | test.swift:490:14:490:32 | call to mkMyEnum1(_:) [mySingle:0] |
+| test.swift:492:14:492:32 | call to mkMyEnum2(_:) [mySingle:0] | test.swift:498:13:498:35 | .mySingle(...) [mySingle:0] |
+| test.swift:492:24:492:31 | call to source() | test.swift:492:14:492:32 | call to mkMyEnum2(_:) [mySingle:0] |
 | test.swift:494:13:494:35 | .mySingle(...) [mySingle:0] | test.swift:494:33:494:33 | d2 |
 | test.swift:494:33:494:33 | d2 | test.swift:494:54:494:54 | d2 |
 | test.swift:496:13:496:35 | .mySingle(...) [mySingle:0] | test.swift:496:33:496:33 | d4 |
 | test.swift:496:33:496:33 | d4 | test.swift:496:54:496:54 | d4 |
+| test.swift:498:13:498:35 | .mySingle(...) [mySingle:0] | test.swift:498:33:498:33 | d6 |
+| test.swift:498:33:498:33 | d6 | test.swift:498:54:498:54 | d6 |
 | test.swift:517:13:517:28 | call to optionalSource() [some:0] | test.swift:519:8:519:12 | let ...? [some:0] |
 | test.swift:517:13:517:28 | call to optionalSource() [some:0] | test.swift:524:19:524:19 | x [some:0] |
 | test.swift:519:8:519:12 | let ...? [some:0] | test.swift:519:12:519:12 | a |
@@ -517,12 +521,17 @@ nodes
 | test.swift:488:30:488:37 | call to source() | semmle.label | call to source() |
 | test.swift:490:14:490:32 | call to mkMyEnum1(_:) [mySingle:0] | semmle.label | call to mkMyEnum1(_:) [mySingle:0] |
 | test.swift:490:24:490:31 | call to source() | semmle.label | call to source() |
+| test.swift:492:14:492:32 | call to mkMyEnum2(_:) [mySingle:0] | semmle.label | call to mkMyEnum2(_:) [mySingle:0] |
+| test.swift:492:24:492:31 | call to source() | semmle.label | call to source() |
 | test.swift:494:13:494:35 | .mySingle(...) [mySingle:0] | semmle.label | .mySingle(...) [mySingle:0] |
 | test.swift:494:33:494:33 | d2 | semmle.label | d2 |
 | test.swift:494:54:494:54 | d2 | semmle.label | d2 |
 | test.swift:496:13:496:35 | .mySingle(...) [mySingle:0] | semmle.label | .mySingle(...) [mySingle:0] |
 | test.swift:496:33:496:33 | d4 | semmle.label | d4 |
 | test.swift:496:54:496:54 | d4 | semmle.label | d4 |
+| test.swift:498:13:498:35 | .mySingle(...) [mySingle:0] | semmle.label | .mySingle(...) [mySingle:0] |
+| test.swift:498:33:498:33 | d6 | semmle.label | d6 |
+| test.swift:498:54:498:54 | d6 | semmle.label | d6 |
 | test.swift:517:13:517:28 | call to optionalSource() [some:0] | semmle.label | call to optionalSource() [some:0] |
 | test.swift:519:8:519:12 | let ...? [some:0] | semmle.label | let ...? [some:0] |
 | test.swift:519:12:519:12 | a | semmle.label | a |
@@ -701,6 +710,7 @@ subpaths
 | test.swift:482:19:482:19 | e | test.swift:425:26:425:33 | call to source() | test.swift:482:19:482:19 | e | result |
 | test.swift:494:54:494:54 | d2 | test.swift:488:30:488:37 | call to source() | test.swift:494:54:494:54 | d2 | result |
 | test.swift:496:54:496:54 | d4 | test.swift:490:24:490:31 | call to source() | test.swift:496:54:496:54 | d4 | result |
+| test.swift:498:54:498:54 | d6 | test.swift:492:24:492:31 | call to source() | test.swift:498:54:498:54 | d6 | result |
 | test.swift:520:19:520:19 | a | test.swift:259:12:259:19 | call to source() | test.swift:520:19:520:19 | a | result |
 | test.swift:527:19:527:19 | a | test.swift:259:12:259:19 | call to source() | test.swift:527:19:527:19 | a | result |
 | test.swift:551:15:551:15 | z1 | test.swift:259:12:259:19 | call to source() | test.swift:551:15:551:15 | z1 | result |

--- a/swift/ql/test/library-tests/dataflow/dataflow/DataFlow.expected
+++ b/swift/ql/test/library-tests/dataflow/dataflow/DataFlow.expected
@@ -115,14 +115,23 @@ edges
 | test.swift:263:13:263:28 | call to optionalSource() | test.swift:280:15:280:38 | ... ? ... : ... |
 | test.swift:263:13:263:28 | call to optionalSource() | test.swift:291:16:291:17 | ...? |
 | test.swift:263:13:263:28 | call to optionalSource() | test.swift:303:15:303:16 | ...! |
+| test.swift:263:13:263:28 | call to optionalSource() [some:0] | test.swift:267:15:267:15 | x [some:0] |
+| test.swift:263:13:263:28 | call to optionalSource() [some:0] | test.swift:279:26:279:26 | x [some:0] |
+| test.swift:263:13:263:28 | call to optionalSource() [some:0] | test.swift:280:26:280:26 | x [some:0] |
 | test.swift:263:13:263:28 | call to optionalSource() [some:0] | test.swift:284:8:284:12 | let ...? [some:0] |
 | test.swift:263:13:263:28 | call to optionalSource() [some:0] | test.swift:291:16:291:17 | ...? [some:0] |
 | test.swift:263:13:263:28 | call to optionalSource() [some:0] | test.swift:298:11:298:15 | let ...? [some:0] |
+| test.swift:263:13:263:28 | call to optionalSource() [some:0] | test.swift:303:15:303:15 | x [some:0] |
 | test.swift:263:13:263:28 | call to optionalSource() [some:0] | test.swift:306:13:306:24 | .some(...) [some:0] |
 | test.swift:263:13:263:28 | call to optionalSource() [some:0] | test.swift:314:10:314:21 | .some(...) [some:0] |
+| test.swift:267:15:267:15 | x [some:0] | test.swift:267:15:267:16 | ...! |
 | test.swift:270:15:270:22 | call to source() | test.swift:270:15:270:31 | call to signum() |
 | test.swift:271:15:271:16 | ...? | test.swift:271:15:271:25 | call to signum() |
 | test.swift:271:15:271:25 | call to signum() | test.swift:271:15:271:25 | OptionalEvaluationExpr |
+| test.swift:279:26:279:26 | x [some:0] | test.swift:279:26:279:27 | ...! |
+| test.swift:279:26:279:27 | ...! | test.swift:279:15:279:31 | ... ? ... : ... |
+| test.swift:280:26:280:26 | x [some:0] | test.swift:280:26:280:27 | ...! |
+| test.swift:280:26:280:27 | ...! | test.swift:280:15:280:38 | ... ? ... : ... |
 | test.swift:280:31:280:38 | call to source() | test.swift:280:15:280:38 | ... ? ... : ... |
 | test.swift:282:31:282:38 | call to source() | test.swift:282:15:282:38 | ... ? ... : ... |
 | test.swift:284:8:284:12 | let ...? [some:0] | test.swift:284:12:284:12 | z |
@@ -135,6 +144,7 @@ edges
 | test.swift:291:16:291:26 | call to signum() [some:0] | test.swift:291:8:291:12 | let ...? [some:0] |
 | test.swift:298:11:298:15 | let ...? [some:0] | test.swift:298:15:298:15 | z1 |
 | test.swift:298:15:298:15 | z1 | test.swift:300:15:300:15 | z1 |
+| test.swift:303:15:303:15 | x [some:0] | test.swift:303:15:303:16 | ...! |
 | test.swift:303:15:303:16 | ...! | test.swift:303:15:303:25 | call to signum() |
 | test.swift:306:13:306:24 | .some(...) [some:0] | test.swift:306:23:306:23 | z |
 | test.swift:306:23:306:23 | z | test.swift:307:19:307:19 | z |
@@ -164,6 +174,8 @@ edges
 | test.swift:361:15:361:15 | t2 [Tuple element at index 1] | test.swift:361:15:361:18 | .1 |
 | test.swift:375:16:375:21 | v | test.swift:375:61:375:61 | v |
 | test.swift:375:61:375:61 | v | test.swift:375:45:375:62 | call to ... [mySingle:0] |
+| test.swift:377:18:377:23 | v | test.swift:377:59:377:59 | v |
+| test.swift:377:59:377:59 | v | test.swift:377:45:377:60 | call to ... [some:0] |
 | test.swift:403:9:403:27 | call to ... [mySingle:0] | test.swift:408:10:408:25 | .mySingle(...) [mySingle:0] |
 | test.swift:403:9:403:27 | call to ... [mySingle:0] | test.swift:417:13:417:28 | .mySingle(...) [mySingle:0] |
 | test.swift:403:19:403:26 | call to source() | test.swift:403:9:403:27 | call to ... [mySingle:0] |
@@ -218,6 +230,16 @@ edges
 | test.swift:496:33:496:33 | d4 | test.swift:496:54:496:54 | d4 |
 | test.swift:498:13:498:35 | .mySingle(...) [mySingle:0] | test.swift:498:33:498:33 | d6 |
 | test.swift:498:33:498:33 | d6 | test.swift:498:54:498:54 | d6 |
+| test.swift:501:14:501:36 | call to ... [some:0] | test.swift:507:15:507:15 | e2 [some:0] |
+| test.swift:501:28:501:35 | call to source() | test.swift:501:14:501:36 | call to ... [some:0] |
+| test.swift:503:14:503:34 | call to mkOptional1(_:) [some:0] | test.swift:509:15:509:15 | e4 [some:0] |
+| test.swift:503:26:503:33 | call to source() | test.swift:377:18:377:23 | v |
+| test.swift:503:26:503:33 | call to source() | test.swift:503:14:503:34 | call to mkOptional1(_:) [some:0] |
+| test.swift:505:14:505:34 | call to mkOptional2(_:) [some:0] | test.swift:511:15:511:15 | e6 [some:0] |
+| test.swift:505:26:505:33 | call to source() | test.swift:505:14:505:34 | call to mkOptional2(_:) [some:0] |
+| test.swift:507:15:507:15 | e2 [some:0] | test.swift:507:15:507:17 | ...! |
+| test.swift:509:15:509:15 | e4 [some:0] | test.swift:509:15:509:17 | ...! |
+| test.swift:511:15:511:15 | e6 [some:0] | test.swift:511:15:511:17 | ...! |
 | test.swift:517:13:517:28 | call to optionalSource() [some:0] | test.swift:519:8:519:12 | let ...? [some:0] |
 | test.swift:517:13:517:28 | call to optionalSource() [some:0] | test.swift:524:19:524:19 | x [some:0] |
 | test.swift:519:8:519:12 | let ...? [some:0] | test.swift:519:12:519:12 | a |
@@ -410,6 +432,7 @@ nodes
 | test.swift:263:13:263:28 | call to optionalSource() | semmle.label | call to optionalSource() |
 | test.swift:263:13:263:28 | call to optionalSource() [some:0] | semmle.label | call to optionalSource() [some:0] |
 | test.swift:265:15:265:15 | x | semmle.label | x |
+| test.swift:267:15:267:15 | x [some:0] | semmle.label | x [some:0] |
 | test.swift:267:15:267:16 | ...! | semmle.label | ...! |
 | test.swift:270:15:270:22 | call to source() | semmle.label | call to source() |
 | test.swift:270:15:270:31 | call to signum() | semmle.label | call to signum() |
@@ -419,7 +442,11 @@ nodes
 | test.swift:274:15:274:20 | ... ??(_:_:) ... | semmle.label | ... ??(_:_:) ... |
 | test.swift:275:15:275:27 | ... ??(_:_:) ... | semmle.label | ... ??(_:_:) ... |
 | test.swift:279:15:279:31 | ... ? ... : ... | semmle.label | ... ? ... : ... |
+| test.swift:279:26:279:26 | x [some:0] | semmle.label | x [some:0] |
+| test.swift:279:26:279:27 | ...! | semmle.label | ...! |
 | test.swift:280:15:280:38 | ... ? ... : ... | semmle.label | ... ? ... : ... |
+| test.swift:280:26:280:26 | x [some:0] | semmle.label | x [some:0] |
+| test.swift:280:26:280:27 | ...! | semmle.label | ...! |
 | test.swift:280:31:280:38 | call to source() | semmle.label | call to source() |
 | test.swift:282:15:282:38 | ... ? ... : ... | semmle.label | ... ? ... : ... |
 | test.swift:282:31:282:38 | call to source() | semmle.label | call to source() |
@@ -436,6 +463,7 @@ nodes
 | test.swift:298:11:298:15 | let ...? [some:0] | semmle.label | let ...? [some:0] |
 | test.swift:298:15:298:15 | z1 | semmle.label | z1 |
 | test.swift:300:15:300:15 | z1 | semmle.label | z1 |
+| test.swift:303:15:303:15 | x [some:0] | semmle.label | x [some:0] |
 | test.swift:303:15:303:16 | ...! | semmle.label | ...! |
 | test.swift:303:15:303:25 | call to signum() | semmle.label | call to signum() |
 | test.swift:306:13:306:24 | .some(...) [some:0] | semmle.label | .some(...) [some:0] |
@@ -473,6 +501,9 @@ nodes
 | test.swift:375:16:375:21 | v | semmle.label | v |
 | test.swift:375:45:375:62 | call to ... [mySingle:0] | semmle.label | call to ... [mySingle:0] |
 | test.swift:375:61:375:61 | v | semmle.label | v |
+| test.swift:377:18:377:23 | v | semmle.label | v |
+| test.swift:377:45:377:60 | call to ... [some:0] | semmle.label | call to ... [some:0] |
+| test.swift:377:59:377:59 | v | semmle.label | v |
 | test.swift:403:9:403:27 | call to ... [mySingle:0] | semmle.label | call to ... [mySingle:0] |
 | test.swift:403:19:403:26 | call to source() | semmle.label | call to source() |
 | test.swift:408:10:408:25 | .mySingle(...) [mySingle:0] | semmle.label | .mySingle(...) [mySingle:0] |
@@ -532,6 +563,18 @@ nodes
 | test.swift:498:13:498:35 | .mySingle(...) [mySingle:0] | semmle.label | .mySingle(...) [mySingle:0] |
 | test.swift:498:33:498:33 | d6 | semmle.label | d6 |
 | test.swift:498:54:498:54 | d6 | semmle.label | d6 |
+| test.swift:501:14:501:36 | call to ... [some:0] | semmle.label | call to ... [some:0] |
+| test.swift:501:28:501:35 | call to source() | semmle.label | call to source() |
+| test.swift:503:14:503:34 | call to mkOptional1(_:) [some:0] | semmle.label | call to mkOptional1(_:) [some:0] |
+| test.swift:503:26:503:33 | call to source() | semmle.label | call to source() |
+| test.swift:505:14:505:34 | call to mkOptional2(_:) [some:0] | semmle.label | call to mkOptional2(_:) [some:0] |
+| test.swift:505:26:505:33 | call to source() | semmle.label | call to source() |
+| test.swift:507:15:507:15 | e2 [some:0] | semmle.label | e2 [some:0] |
+| test.swift:507:15:507:17 | ...! | semmle.label | ...! |
+| test.swift:509:15:509:15 | e4 [some:0] | semmle.label | e4 [some:0] |
+| test.swift:509:15:509:17 | ...! | semmle.label | ...! |
+| test.swift:511:15:511:15 | e6 [some:0] | semmle.label | e6 [some:0] |
+| test.swift:511:15:511:17 | ...! | semmle.label | ...! |
 | test.swift:517:13:517:28 | call to optionalSource() [some:0] | semmle.label | call to optionalSource() [some:0] |
 | test.swift:519:8:519:12 | let ...? [some:0] | semmle.label | let ...? [some:0] |
 | test.swift:519:12:519:12 | a | semmle.label | a |
@@ -634,6 +677,7 @@ subpaths
 | test.swift:219:13:219:13 | b [a, x] | test.swift:185:7:185:7 | self [a, x] | file://:0:0:0:0 | .a [x] | test.swift:219:13:219:15 | .a [x] |
 | test.swift:219:13:219:15 | .a [x] | test.swift:163:7:163:7 | self [x] | file://:0:0:0:0 | .x | test.swift:219:13:219:17 | .x |
 | test.swift:490:24:490:31 | call to source() | test.swift:375:16:375:21 | v | test.swift:375:45:375:62 | call to ... [mySingle:0] | test.swift:490:14:490:32 | call to mkMyEnum1(_:) [mySingle:0] |
+| test.swift:503:26:503:33 | call to source() | test.swift:377:18:377:23 | v | test.swift:377:45:377:60 | call to ... [some:0] | test.swift:503:14:503:34 | call to mkOptional1(_:) [some:0] |
 | test.swift:546:12:546:12 | x [some:0] | test.swift:540:9:540:9 | value [some:0] | file://:0:0:0:0 | [post] self [x, some:0] | test.swift:546:5:546:5 | [post] cx [x, some:0] |
 | test.swift:550:20:550:20 | cx [x, some:0] | test.swift:540:9:540:9 | self [x, some:0] | file://:0:0:0:0 | .x [some:0] | test.swift:550:20:550:23 | .x [some:0] |
 | test.swift:574:20:574:28 | call to source3() | test.swift:567:10:567:13 | s | test.swift:568:7:568:7 | [post] self [str] | test.swift:574:7:574:7 | [post] self [str] |
@@ -711,6 +755,9 @@ subpaths
 | test.swift:494:54:494:54 | d2 | test.swift:488:30:488:37 | call to source() | test.swift:494:54:494:54 | d2 | result |
 | test.swift:496:54:496:54 | d4 | test.swift:490:24:490:31 | call to source() | test.swift:496:54:496:54 | d4 | result |
 | test.swift:498:54:498:54 | d6 | test.swift:492:24:492:31 | call to source() | test.swift:498:54:498:54 | d6 | result |
+| test.swift:507:15:507:17 | ...! | test.swift:501:28:501:35 | call to source() | test.swift:507:15:507:17 | ...! | result |
+| test.swift:509:15:509:17 | ...! | test.swift:503:26:503:33 | call to source() | test.swift:509:15:509:17 | ...! | result |
+| test.swift:511:15:511:17 | ...! | test.swift:505:26:505:33 | call to source() | test.swift:511:15:511:17 | ...! | result |
 | test.swift:520:19:520:19 | a | test.swift:259:12:259:19 | call to source() | test.swift:520:19:520:19 | a | result |
 | test.swift:527:19:527:19 | a | test.swift:259:12:259:19 | call to source() | test.swift:527:19:527:19 | a | result |
 | test.swift:551:15:551:15 | z1 | test.swift:259:12:259:19 | call to source() | test.swift:551:15:551:15 | z1 | result |

--- a/swift/ql/test/library-tests/dataflow/dataflow/FlowConfig.qll
+++ b/swift/ql/test/library-tests/dataflow/dataflow/FlowConfig.qll
@@ -26,8 +26,8 @@ private class TestSummaries extends SummaryModelCsv {
         // model to allow data flow through `signum()` as though it were an identity function, for the benefit of testing flow through optional chaining (`x?.`).
         ";Int;true;signum();;;Argument[-1];ReturnValue;value",
         // test Enum content in MAD
-        ";;false;mkMyEnum2(_:);;;Argument[0];ReturnValue.Enum[mySingle:0];value",
-        ";;false;mkOptional2(_:);;;Argument[0];ReturnValue.Enum[some:0];value"
+        ";;false;mkMyEnum2(_:);;;Argument[0];ReturnValue.EnumElement[mySingle:0];value",
+        ";;false;mkOptional2(_:);;;Argument[0];ReturnValue.OptionalSome;value"
       ]
   }
 }

--- a/swift/ql/test/library-tests/dataflow/dataflow/FlowConfig.qll
+++ b/swift/ql/test/library-tests/dataflow/dataflow/FlowConfig.qll
@@ -21,8 +21,14 @@ module TestConfiguration implements DataFlow::ConfigSig {
 
 private class TestSummaries extends SummaryModelCsv {
   override predicate row(string row) {
-    // model to allow data flow through `signum()` as though it were an identity function, for the benefit of testing flow through optional chaining (`x?.`).
-    row = ";Int;true;signum();;;Argument[-1];ReturnValue;value"
+    row =
+      [
+        // model to allow data flow through `signum()` as though it were an identity function, for the benefit of testing flow through optional chaining (`x?.`).
+        ";Int;true;signum();;;Argument[-1];ReturnValue;value",
+        // test Enum content in MAD
+        ";;false;mkMyEnum2(_:);;;Argument[0];ReturnValue.Enum[mySingle:0];value",
+        ";;false;mkOptional2(_:);;;Argument[0];ReturnValue.Enum[some:0];value"
+      ]
   }
 }
 

--- a/swift/ql/test/library-tests/dataflow/dataflow/LocalFlow.expected
+++ b/swift/ql/test/library-tests/dataflow/dataflow/LocalFlow.expected
@@ -374,314 +374,378 @@
 | test.swift:360:15:360:15 | t2 | test.swift:361:15:361:15 | t2 |
 | test.swift:361:15:361:15 | [post] t2 | test.swift:362:15:362:15 | t2 |
 | test.swift:361:15:361:15 | t2 | test.swift:362:15:362:15 | t2 |
-| test.swift:376:9:376:9 | SSA def(a) | test.swift:378:12:378:12 | a |
-| test.swift:376:9:376:9 | a | test.swift:376:9:376:9 | SSA def(a) |
-| test.swift:376:9:376:13 | ... as ... | test.swift:376:9:376:9 | a |
-| test.swift:376:22:376:23 | .myNone | test.swift:376:9:376:13 | ... as ... |
-| test.swift:378:12:378:12 | a | test.swift:379:10:379:11 | .myNone |
-| test.swift:378:12:378:12 | a | test.swift:381:10:381:25 | .mySingle(...) |
-| test.swift:378:12:378:12 | a | test.swift:383:10:383:30 | .myPair(...) |
-| test.swift:378:12:378:12 | a | test.swift:386:14:386:26 | .myCons(...) |
-| test.swift:378:12:378:12 | a | test.swift:390:32:390:32 | a |
-| test.swift:381:24:381:24 | SSA def(a) | test.swift:382:19:382:19 | a |
-| test.swift:381:24:381:24 | a | test.swift:381:24:381:24 | SSA def(a) |
-| test.swift:383:22:383:22 | SSA def(a) | test.swift:384:19:384:19 | a |
-| test.swift:383:22:383:22 | a | test.swift:383:22:383:22 | SSA def(a) |
-| test.swift:383:29:383:29 | SSA def(b) | test.swift:385:19:385:19 | b |
-| test.swift:383:29:383:29 | b | test.swift:383:29:383:29 | SSA def(b) |
-| test.swift:386:10:386:26 | SSA phi(a) | test.swift:387:19:387:19 | a |
-| test.swift:386:22:386:22 | SSA def(a) | test.swift:386:10:386:26 | SSA phi(a) |
-| test.swift:386:22:386:22 | a | test.swift:386:22:386:22 | SSA def(a) |
-| test.swift:390:27:390:27 | SSA def(x) | test.swift:391:19:391:19 | x |
-| test.swift:390:27:390:27 | x | test.swift:390:27:390:27 | SSA def(x) |
-| test.swift:390:32:390:32 | a | test.swift:390:13:390:28 | .mySingle(...) |
-| test.swift:390:32:390:32 | a | test.swift:393:37:393:37 | a |
-| test.swift:393:25:393:25 | SSA def(x) | test.swift:394:19:394:19 | x |
-| test.swift:393:25:393:25 | x | test.swift:393:25:393:25 | SSA def(x) |
-| test.swift:393:32:393:32 | SSA def(y) | test.swift:395:19:395:19 | y |
-| test.swift:393:32:393:32 | y | test.swift:393:32:393:32 | SSA def(y) |
-| test.swift:393:37:393:37 | a | test.swift:393:13:393:33 | .myPair(...) |
-| test.swift:398:5:398:27 | SSA def(a) | test.swift:400:12:400:12 | a |
-| test.swift:398:9:398:27 | call to ... | test.swift:398:5:398:27 | SSA def(a) |
-| test.swift:400:12:400:12 | a | test.swift:401:10:401:11 | .myNone |
-| test.swift:400:12:400:12 | a | test.swift:403:10:403:25 | .mySingle(...) |
-| test.swift:400:12:400:12 | a | test.swift:405:10:405:30 | .myPair(...) |
-| test.swift:400:12:400:12 | a | test.swift:408:14:408:26 | .myCons(...) |
-| test.swift:400:12:400:12 | a | test.swift:412:32:412:32 | a |
-| test.swift:403:24:403:24 | SSA def(a) | test.swift:404:19:404:19 | a |
-| test.swift:403:24:403:24 | a | test.swift:403:24:403:24 | SSA def(a) |
-| test.swift:405:22:405:22 | SSA def(a) | test.swift:406:19:406:19 | a |
-| test.swift:405:22:405:22 | a | test.swift:405:22:405:22 | SSA def(a) |
-| test.swift:405:29:405:29 | SSA def(b) | test.swift:407:19:407:19 | b |
-| test.swift:405:29:405:29 | b | test.swift:405:29:405:29 | SSA def(b) |
-| test.swift:408:10:408:26 | SSA phi(a) | test.swift:409:19:409:19 | a |
-| test.swift:408:22:408:22 | SSA def(a) | test.swift:408:10:408:26 | SSA phi(a) |
-| test.swift:408:22:408:22 | a | test.swift:408:22:408:22 | SSA def(a) |
-| test.swift:412:27:412:27 | SSA def(x) | test.swift:413:19:413:19 | x |
-| test.swift:412:27:412:27 | x | test.swift:412:27:412:27 | SSA def(x) |
-| test.swift:412:32:412:32 | a | test.swift:412:13:412:28 | .mySingle(...) |
-| test.swift:412:32:412:32 | a | test.swift:415:37:415:37 | a |
-| test.swift:415:25:415:25 | SSA def(x) | test.swift:416:19:416:19 | x |
-| test.swift:415:25:415:25 | x | test.swift:415:25:415:25 | SSA def(x) |
-| test.swift:415:32:415:32 | SSA def(y) | test.swift:417:19:417:19 | y |
-| test.swift:415:32:415:32 | y | test.swift:415:32:415:32 | SSA def(y) |
-| test.swift:415:37:415:37 | a | test.swift:415:13:415:33 | .myPair(...) |
-| test.swift:420:5:420:34 | SSA def(a) | test.swift:422:12:422:12 | a |
-| test.swift:420:9:420:34 | call to ... | test.swift:420:5:420:34 | SSA def(a) |
-| test.swift:422:12:422:12 | a | test.swift:423:10:423:11 | .myNone |
-| test.swift:422:12:422:12 | a | test.swift:425:10:425:25 | .mySingle(...) |
-| test.swift:422:12:422:12 | a | test.swift:427:10:427:30 | .myPair(...) |
-| test.swift:422:12:422:12 | a | test.swift:430:14:430:26 | .myCons(...) |
-| test.swift:422:12:422:12 | a | test.swift:434:32:434:32 | a |
-| test.swift:425:24:425:24 | SSA def(a) | test.swift:426:19:426:19 | a |
-| test.swift:425:24:425:24 | a | test.swift:425:24:425:24 | SSA def(a) |
-| test.swift:427:22:427:22 | SSA def(a) | test.swift:428:19:428:19 | a |
-| test.swift:427:22:427:22 | a | test.swift:427:22:427:22 | SSA def(a) |
-| test.swift:427:29:427:29 | SSA def(b) | test.swift:429:19:429:19 | b |
-| test.swift:427:29:427:29 | b | test.swift:427:29:427:29 | SSA def(b) |
-| test.swift:430:10:430:26 | SSA phi(a) | test.swift:431:19:431:19 | a |
-| test.swift:430:22:430:22 | SSA def(a) | test.swift:430:10:430:26 | SSA phi(a) |
-| test.swift:430:22:430:22 | a | test.swift:430:22:430:22 | SSA def(a) |
-| test.swift:434:27:434:27 | SSA def(x) | test.swift:435:19:435:19 | x |
-| test.swift:434:27:434:27 | x | test.swift:434:27:434:27 | SSA def(x) |
-| test.swift:434:32:434:32 | a | test.swift:434:13:434:28 | .mySingle(...) |
-| test.swift:434:32:434:32 | a | test.swift:437:37:437:37 | a |
-| test.swift:437:25:437:25 | SSA def(x) | test.swift:438:19:438:19 | x |
-| test.swift:437:25:437:25 | x | test.swift:437:25:437:25 | SSA def(x) |
-| test.swift:437:32:437:32 | SSA def(y) | test.swift:439:19:439:19 | y |
-| test.swift:437:32:437:32 | y | test.swift:437:32:437:32 | SSA def(y) |
-| test.swift:437:37:437:37 | a | test.swift:437:13:437:33 | .myPair(...) |
-| test.swift:437:37:437:37 | a | test.swift:442:33:442:33 | a |
-| test.swift:442:9:442:9 | SSA def(b) | test.swift:444:12:444:12 | b |
-| test.swift:442:9:442:9 | b | test.swift:442:9:442:9 | SSA def(b) |
-| test.swift:442:9:442:12 | ... as ... | test.swift:442:9:442:9 | b |
-| test.swift:442:21:442:34 | call to ... | test.swift:442:9:442:12 | ... as ... |
-| test.swift:442:33:442:33 | [post] a | test.swift:471:13:471:13 | a |
-| test.swift:442:33:442:33 | a | test.swift:471:13:471:13 | a |
-| test.swift:444:12:444:12 | b | test.swift:445:10:445:11 | .myNone |
-| test.swift:444:12:444:12 | b | test.swift:447:10:447:25 | .mySingle(...) |
-| test.swift:444:12:444:12 | b | test.swift:449:10:449:30 | .myPair(...) |
-| test.swift:444:12:444:12 | b | test.swift:452:14:452:38 | .myCons(...) |
-| test.swift:444:12:444:12 | b | test.swift:456:14:456:26 | .myCons(...) |
-| test.swift:444:12:444:12 | b | test.swift:467:45:467:45 | b |
-| test.swift:447:24:447:24 | SSA def(a) | test.swift:448:19:448:19 | a |
-| test.swift:447:24:447:24 | a | test.swift:447:24:447:24 | SSA def(a) |
-| test.swift:449:22:449:22 | SSA def(a) | test.swift:450:19:450:19 | a |
-| test.swift:449:22:449:22 | a | test.swift:449:22:449:22 | SSA def(a) |
-| test.swift:449:29:449:29 | SSA def(b) | test.swift:451:19:451:19 | b |
-| test.swift:449:29:449:29 | b | test.swift:449:29:449:29 | SSA def(b) |
-| test.swift:452:10:452:38 | SSA phi(a) | test.swift:453:19:453:19 | a |
-| test.swift:452:10:452:38 | SSA phi(b) | test.swift:454:19:454:19 | b |
-| test.swift:452:10:452:38 | SSA phi(c) | test.swift:455:19:455:19 | c |
-| test.swift:452:22:452:22 | SSA def(a) | test.swift:452:10:452:38 | SSA phi(a) |
-| test.swift:452:22:452:22 | a | test.swift:452:22:452:22 | SSA def(a) |
-| test.swift:452:33:452:33 | SSA def(b) | test.swift:452:10:452:38 | SSA phi(b) |
-| test.swift:452:33:452:33 | b | test.swift:452:33:452:33 | SSA def(b) |
-| test.swift:452:36:452:36 | SSA def(c) | test.swift:452:10:452:38 | SSA phi(c) |
-| test.swift:452:36:452:36 | c | test.swift:452:36:452:36 | SSA def(c) |
-| test.swift:456:10:456:26 | SSA phi(a) | test.swift:457:19:457:19 | a |
-| test.swift:456:22:456:22 | SSA def(a) | test.swift:456:10:456:26 | SSA phi(a) |
-| test.swift:456:22:456:22 | a | test.swift:456:22:456:22 | SSA def(a) |
-| test.swift:460:27:460:27 | SSA def(x) | test.swift:461:19:461:19 | x |
-| test.swift:460:27:460:27 | x | test.swift:460:27:460:27 | SSA def(x) |
-| test.swift:460:32:460:57 | call to ... | test.swift:460:13:460:28 | .mySingle(...) |
-| test.swift:463:31:463:31 | SSA def(x) | test.swift:464:19:464:19 | x |
-| test.swift:463:31:463:31 | x | test.swift:463:31:463:31 | SSA def(x) |
-| test.swift:463:38:463:38 | SSA def(y) | test.swift:465:19:465:19 | y |
-| test.swift:463:38:463:38 | y | test.swift:463:38:463:38 | SSA def(y) |
-| test.swift:463:43:463:62 | call to ... | test.swift:463:13:463:39 | .myPair(...) |
-| test.swift:467:13:467:41 | SSA phi(c) | test.swift:468:19:468:19 | c |
-| test.swift:467:39:467:39 | SSA def(c) | test.swift:467:13:467:41 | SSA phi(c) |
-| test.swift:467:39:467:39 | c | test.swift:467:39:467:39 | SSA def(c) |
-| test.swift:467:45:467:45 | b | test.swift:467:17:467:41 | .myCons(...) |
-| test.swift:467:45:467:45 | b | test.swift:471:16:471:16 | b |
-| test.swift:471:12:471:17 | (...) | test.swift:472:14:472:55 | (...) |
-| test.swift:471:12:471:17 | (...) | test.swift:478:5:478:5 | _ |
-| test.swift:472:10:472:55 | SSA phi(a) | test.swift:473:19:473:19 | a |
-| test.swift:472:10:472:55 | SSA phi(b) | test.swift:474:19:474:19 | b |
-| test.swift:472:10:472:55 | SSA phi(c) | test.swift:475:19:475:19 | c |
-| test.swift:472:10:472:55 | SSA phi(d) | test.swift:476:19:476:19 | d |
-| test.swift:472:10:472:55 | SSA phi(e) | test.swift:477:19:477:19 | e |
-| test.swift:472:23:472:23 | SSA def(a) | test.swift:472:10:472:55 | SSA phi(a) |
-| test.swift:472:23:472:23 | a | test.swift:472:23:472:23 | SSA def(a) |
-| test.swift:472:26:472:26 | SSA def(b) | test.swift:472:10:472:55 | SSA phi(b) |
-| test.swift:472:26:472:26 | b | test.swift:472:26:472:26 | SSA def(b) |
-| test.swift:472:38:472:38 | SSA def(c) | test.swift:472:10:472:55 | SSA phi(c) |
-| test.swift:472:38:472:38 | c | test.swift:472:38:472:38 | SSA def(c) |
-| test.swift:472:49:472:49 | SSA def(d) | test.swift:472:10:472:55 | SSA phi(d) |
-| test.swift:472:49:472:49 | d | test.swift:472:49:472:49 | SSA def(d) |
-| test.swift:472:52:472:52 | SSA def(e) | test.swift:472:10:472:55 | SSA phi(e) |
-| test.swift:472:52:472:52 | e | test.swift:472:52:472:52 | SSA def(e) |
-| test.swift:485:21:485:27 | SSA def(y) | test.swift:488:27:488:27 | y |
-| test.swift:485:21:485:27 | SSA def(y) | test.swift:493:22:493:22 | y |
-| test.swift:485:21:485:27 | y | test.swift:485:21:485:27 | SSA def(y) |
-| test.swift:486:9:486:9 | SSA def(x) | test.swift:488:16:488:16 | x |
-| test.swift:486:9:486:9 | x | test.swift:486:9:486:9 | SSA def(x) |
-| test.swift:486:13:486:28 | call to optionalSource() | test.swift:486:9:486:9 | x |
-| test.swift:488:12:488:12 | SSA def(a) | test.swift:488:27:488:27 | SSA phi(a) |
-| test.swift:488:12:488:12 | a | test.swift:488:12:488:12 | SSA def(a) |
-| test.swift:488:16:488:16 | x | test.swift:488:8:488:12 | let ...? |
-| test.swift:488:16:488:16 | x | test.swift:493:19:493:19 | x |
-| test.swift:488:23:488:23 | SSA def(b) | test.swift:490:19:490:19 | b |
-| test.swift:488:23:488:23 | b | test.swift:488:23:488:23 | SSA def(b) |
-| test.swift:488:27:488:27 | SSA phi(a) | test.swift:489:19:489:19 | a |
-| test.swift:488:27:488:27 | y | test.swift:488:19:488:23 | let ...? |
-| test.swift:488:27:488:27 | y | test.swift:493:22:493:22 | y |
-| test.swift:493:9:493:9 | SSA def(tuple1) | test.swift:494:12:494:12 | tuple1 |
-| test.swift:493:9:493:9 | tuple1 | test.swift:493:9:493:9 | SSA def(tuple1) |
-| test.swift:493:18:493:23 | (...) | test.swift:493:9:493:9 | tuple1 |
-| test.swift:494:12:494:12 | tuple1 | test.swift:495:10:495:37 | (...) |
-| test.swift:494:12:494:12 | tuple1 | test.swift:498:5:498:5 | _ |
-| test.swift:495:21:495:21 | SSA def(a) | test.swift:496:19:496:19 | a |
-| test.swift:495:21:495:21 | a | test.swift:495:21:495:21 | SSA def(a) |
-| test.swift:495:35:495:35 | SSA def(b) | test.swift:497:19:497:19 | b |
-| test.swift:495:35:495:35 | b | test.swift:495:35:495:35 | SSA def(b) |
-| test.swift:502:13:502:13 | SSA def(x) | test.swift:503:19:503:19 | x |
-| test.swift:502:13:502:13 | x | test.swift:502:13:502:13 | SSA def(x) |
-| test.swift:502:16:502:16 | SSA def(y) | test.swift:504:19:504:19 | y |
-| test.swift:502:16:502:16 | y | test.swift:502:16:502:16 | SSA def(y) |
-| test.swift:502:21:502:29 | call to source2() | test.swift:502:8:502:17 | let ...? |
-| test.swift:508:7:508:7 | SSA def(self) | test.swift:508:7:508:7 | self[return] |
-| test.swift:508:7:508:7 | SSA def(self) | test.swift:508:7:508:7 | self[return] |
-| test.swift:508:7:508:7 | self | test.swift:508:7:508:7 | SSA def(self) |
-| test.swift:508:7:508:7 | self | test.swift:508:7:508:7 | SSA def(self) |
-| test.swift:509:9:509:9 | self | test.swift:509:9:509:9 | SSA def(self) |
-| test.swift:509:9:509:9 | self | test.swift:509:9:509:9 | SSA def(self) |
-| test.swift:509:9:509:9 | self | test.swift:509:9:509:9 | SSA def(self) |
-| test.swift:509:9:509:9 | value | test.swift:509:9:509:9 | SSA def(value) |
-| test.swift:512:33:512:39 | SSA def(y) | test.swift:517:12:517:12 | y |
-| test.swift:512:33:512:39 | y | test.swift:512:33:512:39 | SSA def(y) |
-| test.swift:513:9:513:9 | SSA def(x) | test.swift:515:12:515:12 | x |
-| test.swift:513:9:513:9 | x | test.swift:513:9:513:9 | SSA def(x) |
-| test.swift:513:13:513:28 | call to optionalSource() | test.swift:513:9:513:9 | x |
-| test.swift:514:9:514:9 | SSA def(cx) | test.swift:515:5:515:5 | cx |
-| test.swift:514:9:514:9 | cx | test.swift:514:9:514:9 | SSA def(cx) |
-| test.swift:514:14:514:16 | call to C.init() | test.swift:514:9:514:9 | cx |
-| test.swift:515:5:515:5 | [post] cx | test.swift:519:20:519:20 | cx |
-| test.swift:515:5:515:5 | cx | test.swift:519:20:519:20 | cx |
-| test.swift:516:9:516:9 | SSA def(cy) | test.swift:517:5:517:5 | cy |
-| test.swift:516:9:516:9 | cy | test.swift:516:9:516:9 | SSA def(cy) |
-| test.swift:516:14:516:16 | call to C.init() | test.swift:516:9:516:9 | cy |
-| test.swift:517:5:517:5 | [post] cy | test.swift:521:20:521:20 | cy |
-| test.swift:517:5:517:5 | cy | test.swift:521:20:521:20 | cy |
-| test.swift:519:15:519:15 | SSA def(z1) | test.swift:520:15:520:15 | z1 |
-| test.swift:519:15:519:15 | z1 | test.swift:519:15:519:15 | SSA def(z1) |
-| test.swift:519:20:519:23 | .x | test.swift:519:11:519:15 | let ...? |
-| test.swift:521:15:521:15 | SSA def(z2) | test.swift:522:15:522:15 | z2 |
-| test.swift:521:15:521:15 | z2 | test.swift:521:15:521:15 | SSA def(z2) |
-| test.swift:521:20:521:23 | .x | test.swift:521:11:521:15 | let ...? |
-| test.swift:526:14:526:21 | call to source() | test.swift:526:13:526:21 | call to +(_:) |
-| test.swift:534:7:534:7 | SSA def(self) | test.swift:534:7:534:7 | self[return] |
-| test.swift:534:7:534:7 | self | test.swift:534:7:534:7 | SSA def(self) |
-| test.swift:535:9:535:9 | self | test.swift:535:9:535:9 | SSA def(self) |
-| test.swift:535:9:535:9 | self | test.swift:535:9:535:9 | SSA def(self) |
-| test.swift:535:9:535:9 | self | test.swift:535:9:535:9 | SSA def(self) |
-| test.swift:535:9:535:9 | value | test.swift:535:9:535:9 | SSA def(value) |
-| test.swift:536:5:536:5 | SSA def(self) | test.swift:537:7:537:7 | self |
-| test.swift:536:5:536:5 | self | test.swift:536:5:536:5 | SSA def(self) |
-| test.swift:536:10:536:13 | SSA def(s) | test.swift:537:13:537:13 | s |
-| test.swift:536:10:536:13 | s | test.swift:536:10:536:13 | SSA def(s) |
-| test.swift:537:7:537:7 | [post] self | test.swift:536:5:538:5 | self[return] |
-| test.swift:537:7:537:7 | self | test.swift:536:5:538:5 | self[return] |
-| test.swift:542:17:542:17 | SSA def(self) | test.swift:543:7:543:7 | self |
-| test.swift:542:17:542:17 | self | test.swift:542:17:542:17 | SSA def(self) |
-| test.swift:543:7:543:7 | [post] self | test.swift:544:17:544:17 | self |
-| test.swift:543:7:543:7 | self | test.swift:544:17:544:17 | self |
-| test.swift:544:17:544:17 | [post] self | test.swift:542:17:545:5 | self[return] |
-| test.swift:544:17:544:17 | self | test.swift:542:17:545:5 | self[return] |
-| test.swift:548:21:548:27 | SSA def(path) | test.swift:550:37:550:37 | path |
-| test.swift:548:21:548:27 | path | test.swift:548:21:548:27 | SSA def(path) |
-| test.swift:553:7:553:7 | SSA def(self) | test.swift:553:7:553:7 | self[return] |
-| test.swift:553:7:553:7 | self | test.swift:553:7:553:7 | SSA def(self) |
-| test.swift:554:3:554:3 | SSA def(self) | test.swift:554:3:554:40 | self[return] |
-| test.swift:554:3:554:3 | self | test.swift:554:3:554:3 | SSA def(self) |
-| test.swift:554:27:554:38 | SSA def(n) | test.swift:554:3:554:40 | n[return] |
-| test.swift:554:31:554:38 | call to source() | test.swift:554:27:554:38 | SSA def(n) |
-| test.swift:560:7:560:7 | SSA def(n) | test.swift:561:36:561:36 | n |
-| test.swift:560:7:560:7 | n | test.swift:560:7:560:7 | SSA def(n) |
-| test.swift:560:11:560:11 | 0 | test.swift:560:7:560:7 | n |
-| test.swift:561:36:561:36 | n | test.swift:561:35:561:36 | &... |
+| test.swift:375:16:375:21 | SSA def(v) | test.swift:375:61:375:61 | v |
+| test.swift:375:16:375:21 | v | test.swift:375:16:375:21 | SSA def(v) |
+| test.swift:377:18:377:23 | SSA def(v) | test.swift:377:59:377:59 | v |
+| test.swift:377:18:377:23 | v | test.swift:377:18:377:23 | SSA def(v) |
+| test.swift:381:9:381:9 | SSA def(a) | test.swift:383:12:383:12 | a |
+| test.swift:381:9:381:9 | a | test.swift:381:9:381:9 | SSA def(a) |
+| test.swift:381:9:381:13 | ... as ... | test.swift:381:9:381:9 | a |
+| test.swift:381:22:381:23 | .myNone | test.swift:381:9:381:13 | ... as ... |
+| test.swift:383:12:383:12 | a | test.swift:384:10:384:11 | .myNone |
+| test.swift:383:12:383:12 | a | test.swift:386:10:386:25 | .mySingle(...) |
+| test.swift:383:12:383:12 | a | test.swift:388:10:388:30 | .myPair(...) |
+| test.swift:383:12:383:12 | a | test.swift:391:14:391:26 | .myCons(...) |
+| test.swift:383:12:383:12 | a | test.swift:395:32:395:32 | a |
+| test.swift:386:24:386:24 | SSA def(a) | test.swift:387:19:387:19 | a |
+| test.swift:386:24:386:24 | a | test.swift:386:24:386:24 | SSA def(a) |
+| test.swift:388:22:388:22 | SSA def(a) | test.swift:389:19:389:19 | a |
+| test.swift:388:22:388:22 | a | test.swift:388:22:388:22 | SSA def(a) |
+| test.swift:388:29:388:29 | SSA def(b) | test.swift:390:19:390:19 | b |
+| test.swift:388:29:388:29 | b | test.swift:388:29:388:29 | SSA def(b) |
+| test.swift:391:10:391:26 | SSA phi(a) | test.swift:392:19:392:19 | a |
+| test.swift:391:22:391:22 | SSA def(a) | test.swift:391:10:391:26 | SSA phi(a) |
+| test.swift:391:22:391:22 | a | test.swift:391:22:391:22 | SSA def(a) |
+| test.swift:395:27:395:27 | SSA def(x) | test.swift:396:19:396:19 | x |
+| test.swift:395:27:395:27 | x | test.swift:395:27:395:27 | SSA def(x) |
+| test.swift:395:32:395:32 | a | test.swift:395:13:395:28 | .mySingle(...) |
+| test.swift:395:32:395:32 | a | test.swift:398:37:398:37 | a |
+| test.swift:398:25:398:25 | SSA def(x) | test.swift:399:19:399:19 | x |
+| test.swift:398:25:398:25 | x | test.swift:398:25:398:25 | SSA def(x) |
+| test.swift:398:32:398:32 | SSA def(y) | test.swift:400:19:400:19 | y |
+| test.swift:398:32:398:32 | y | test.swift:398:32:398:32 | SSA def(y) |
+| test.swift:398:37:398:37 | a | test.swift:398:13:398:33 | .myPair(...) |
+| test.swift:403:5:403:27 | SSA def(a) | test.swift:405:12:405:12 | a |
+| test.swift:403:9:403:27 | call to ... | test.swift:403:5:403:27 | SSA def(a) |
+| test.swift:405:12:405:12 | a | test.swift:406:10:406:11 | .myNone |
+| test.swift:405:12:405:12 | a | test.swift:408:10:408:25 | .mySingle(...) |
+| test.swift:405:12:405:12 | a | test.swift:410:10:410:30 | .myPair(...) |
+| test.swift:405:12:405:12 | a | test.swift:413:14:413:26 | .myCons(...) |
+| test.swift:405:12:405:12 | a | test.swift:417:32:417:32 | a |
+| test.swift:408:24:408:24 | SSA def(a) | test.swift:409:19:409:19 | a |
+| test.swift:408:24:408:24 | a | test.swift:408:24:408:24 | SSA def(a) |
+| test.swift:410:22:410:22 | SSA def(a) | test.swift:411:19:411:19 | a |
+| test.swift:410:22:410:22 | a | test.swift:410:22:410:22 | SSA def(a) |
+| test.swift:410:29:410:29 | SSA def(b) | test.swift:412:19:412:19 | b |
+| test.swift:410:29:410:29 | b | test.swift:410:29:410:29 | SSA def(b) |
+| test.swift:413:10:413:26 | SSA phi(a) | test.swift:414:19:414:19 | a |
+| test.swift:413:22:413:22 | SSA def(a) | test.swift:413:10:413:26 | SSA phi(a) |
+| test.swift:413:22:413:22 | a | test.swift:413:22:413:22 | SSA def(a) |
+| test.swift:417:27:417:27 | SSA def(x) | test.swift:418:19:418:19 | x |
+| test.swift:417:27:417:27 | x | test.swift:417:27:417:27 | SSA def(x) |
+| test.swift:417:32:417:32 | a | test.swift:417:13:417:28 | .mySingle(...) |
+| test.swift:417:32:417:32 | a | test.swift:420:37:420:37 | a |
+| test.swift:420:25:420:25 | SSA def(x) | test.swift:421:19:421:19 | x |
+| test.swift:420:25:420:25 | x | test.swift:420:25:420:25 | SSA def(x) |
+| test.swift:420:32:420:32 | SSA def(y) | test.swift:422:19:422:19 | y |
+| test.swift:420:32:420:32 | y | test.swift:420:32:420:32 | SSA def(y) |
+| test.swift:420:37:420:37 | a | test.swift:420:13:420:33 | .myPair(...) |
+| test.swift:425:5:425:34 | SSA def(a) | test.swift:427:12:427:12 | a |
+| test.swift:425:9:425:34 | call to ... | test.swift:425:5:425:34 | SSA def(a) |
+| test.swift:427:12:427:12 | a | test.swift:428:10:428:11 | .myNone |
+| test.swift:427:12:427:12 | a | test.swift:430:10:430:25 | .mySingle(...) |
+| test.swift:427:12:427:12 | a | test.swift:432:10:432:30 | .myPair(...) |
+| test.swift:427:12:427:12 | a | test.swift:435:14:435:26 | .myCons(...) |
+| test.swift:427:12:427:12 | a | test.swift:439:32:439:32 | a |
+| test.swift:430:24:430:24 | SSA def(a) | test.swift:431:19:431:19 | a |
+| test.swift:430:24:430:24 | a | test.swift:430:24:430:24 | SSA def(a) |
+| test.swift:432:22:432:22 | SSA def(a) | test.swift:433:19:433:19 | a |
+| test.swift:432:22:432:22 | a | test.swift:432:22:432:22 | SSA def(a) |
+| test.swift:432:29:432:29 | SSA def(b) | test.swift:434:19:434:19 | b |
+| test.swift:432:29:432:29 | b | test.swift:432:29:432:29 | SSA def(b) |
+| test.swift:435:10:435:26 | SSA phi(a) | test.swift:436:19:436:19 | a |
+| test.swift:435:22:435:22 | SSA def(a) | test.swift:435:10:435:26 | SSA phi(a) |
+| test.swift:435:22:435:22 | a | test.swift:435:22:435:22 | SSA def(a) |
+| test.swift:439:27:439:27 | SSA def(x) | test.swift:440:19:440:19 | x |
+| test.swift:439:27:439:27 | x | test.swift:439:27:439:27 | SSA def(x) |
+| test.swift:439:32:439:32 | a | test.swift:439:13:439:28 | .mySingle(...) |
+| test.swift:439:32:439:32 | a | test.swift:442:37:442:37 | a |
+| test.swift:442:25:442:25 | SSA def(x) | test.swift:443:19:443:19 | x |
+| test.swift:442:25:442:25 | x | test.swift:442:25:442:25 | SSA def(x) |
+| test.swift:442:32:442:32 | SSA def(y) | test.swift:444:19:444:19 | y |
+| test.swift:442:32:442:32 | y | test.swift:442:32:442:32 | SSA def(y) |
+| test.swift:442:37:442:37 | a | test.swift:442:13:442:33 | .myPair(...) |
+| test.swift:442:37:442:37 | a | test.swift:447:33:447:33 | a |
+| test.swift:447:9:447:9 | SSA def(b) | test.swift:449:12:449:12 | b |
+| test.swift:447:9:447:9 | b | test.swift:447:9:447:9 | SSA def(b) |
+| test.swift:447:9:447:12 | ... as ... | test.swift:447:9:447:9 | b |
+| test.swift:447:21:447:34 | call to ... | test.swift:447:9:447:12 | ... as ... |
+| test.swift:447:33:447:33 | [post] a | test.swift:476:13:476:13 | a |
+| test.swift:447:33:447:33 | a | test.swift:476:13:476:13 | a |
+| test.swift:449:12:449:12 | b | test.swift:450:10:450:11 | .myNone |
+| test.swift:449:12:449:12 | b | test.swift:452:10:452:25 | .mySingle(...) |
+| test.swift:449:12:449:12 | b | test.swift:454:10:454:30 | .myPair(...) |
+| test.swift:449:12:449:12 | b | test.swift:457:14:457:38 | .myCons(...) |
+| test.swift:449:12:449:12 | b | test.swift:461:14:461:26 | .myCons(...) |
+| test.swift:449:12:449:12 | b | test.swift:472:45:472:45 | b |
+| test.swift:452:24:452:24 | SSA def(a) | test.swift:453:19:453:19 | a |
+| test.swift:452:24:452:24 | a | test.swift:452:24:452:24 | SSA def(a) |
+| test.swift:454:22:454:22 | SSA def(a) | test.swift:455:19:455:19 | a |
+| test.swift:454:22:454:22 | a | test.swift:454:22:454:22 | SSA def(a) |
+| test.swift:454:29:454:29 | SSA def(b) | test.swift:456:19:456:19 | b |
+| test.swift:454:29:454:29 | b | test.swift:454:29:454:29 | SSA def(b) |
+| test.swift:457:10:457:38 | SSA phi(a) | test.swift:458:19:458:19 | a |
+| test.swift:457:10:457:38 | SSA phi(b) | test.swift:459:19:459:19 | b |
+| test.swift:457:10:457:38 | SSA phi(c) | test.swift:460:19:460:19 | c |
+| test.swift:457:22:457:22 | SSA def(a) | test.swift:457:10:457:38 | SSA phi(a) |
+| test.swift:457:22:457:22 | a | test.swift:457:22:457:22 | SSA def(a) |
+| test.swift:457:33:457:33 | SSA def(b) | test.swift:457:10:457:38 | SSA phi(b) |
+| test.swift:457:33:457:33 | b | test.swift:457:33:457:33 | SSA def(b) |
+| test.swift:457:36:457:36 | SSA def(c) | test.swift:457:10:457:38 | SSA phi(c) |
+| test.swift:457:36:457:36 | c | test.swift:457:36:457:36 | SSA def(c) |
+| test.swift:461:10:461:26 | SSA phi(a) | test.swift:462:19:462:19 | a |
+| test.swift:461:22:461:22 | SSA def(a) | test.swift:461:10:461:26 | SSA phi(a) |
+| test.swift:461:22:461:22 | a | test.swift:461:22:461:22 | SSA def(a) |
+| test.swift:465:27:465:27 | SSA def(x) | test.swift:466:19:466:19 | x |
+| test.swift:465:27:465:27 | x | test.swift:465:27:465:27 | SSA def(x) |
+| test.swift:465:32:465:57 | call to ... | test.swift:465:13:465:28 | .mySingle(...) |
+| test.swift:468:31:468:31 | SSA def(x) | test.swift:469:19:469:19 | x |
+| test.swift:468:31:468:31 | x | test.swift:468:31:468:31 | SSA def(x) |
+| test.swift:468:38:468:38 | SSA def(y) | test.swift:470:19:470:19 | y |
+| test.swift:468:38:468:38 | y | test.swift:468:38:468:38 | SSA def(y) |
+| test.swift:468:43:468:62 | call to ... | test.swift:468:13:468:39 | .myPair(...) |
+| test.swift:472:13:472:41 | SSA phi(c) | test.swift:473:19:473:19 | c |
+| test.swift:472:39:472:39 | SSA def(c) | test.swift:472:13:472:41 | SSA phi(c) |
+| test.swift:472:39:472:39 | c | test.swift:472:39:472:39 | SSA def(c) |
+| test.swift:472:45:472:45 | b | test.swift:472:17:472:41 | .myCons(...) |
+| test.swift:472:45:472:45 | b | test.swift:476:16:476:16 | b |
+| test.swift:476:12:476:17 | (...) | test.swift:477:14:477:55 | (...) |
+| test.swift:476:12:476:17 | (...) | test.swift:483:5:483:5 | _ |
+| test.swift:477:10:477:55 | SSA phi(a) | test.swift:478:19:478:19 | a |
+| test.swift:477:10:477:55 | SSA phi(b) | test.swift:479:19:479:19 | b |
+| test.swift:477:10:477:55 | SSA phi(c) | test.swift:480:19:480:19 | c |
+| test.swift:477:10:477:55 | SSA phi(d) | test.swift:481:19:481:19 | d |
+| test.swift:477:10:477:55 | SSA phi(e) | test.swift:482:19:482:19 | e |
+| test.swift:477:23:477:23 | SSA def(a) | test.swift:477:10:477:55 | SSA phi(a) |
+| test.swift:477:23:477:23 | a | test.swift:477:23:477:23 | SSA def(a) |
+| test.swift:477:26:477:26 | SSA def(b) | test.swift:477:10:477:55 | SSA phi(b) |
+| test.swift:477:26:477:26 | b | test.swift:477:26:477:26 | SSA def(b) |
+| test.swift:477:38:477:38 | SSA def(c) | test.swift:477:10:477:55 | SSA phi(c) |
+| test.swift:477:38:477:38 | c | test.swift:477:38:477:38 | SSA def(c) |
+| test.swift:477:49:477:49 | SSA def(d) | test.swift:477:10:477:55 | SSA phi(d) |
+| test.swift:477:49:477:49 | d | test.swift:477:49:477:49 | SSA def(d) |
+| test.swift:477:52:477:52 | SSA def(e) | test.swift:477:10:477:55 | SSA phi(e) |
+| test.swift:477:52:477:52 | e | test.swift:477:52:477:52 | SSA def(e) |
+| test.swift:487:9:487:9 | SSA def(c1) | test.swift:493:39:493:39 | c1 |
+| test.swift:487:9:487:9 | c1 | test.swift:487:9:487:9 | SSA def(c1) |
+| test.swift:487:14:487:31 | call to ... | test.swift:487:9:487:9 | c1 |
+| test.swift:488:9:488:9 | SSA def(c2) | test.swift:494:39:494:39 | c2 |
+| test.swift:488:9:488:9 | c2 | test.swift:488:9:488:9 | SSA def(c2) |
+| test.swift:488:14:488:38 | call to ... | test.swift:488:9:488:9 | c2 |
+| test.swift:489:9:489:9 | SSA def(c3) | test.swift:495:39:495:39 | c3 |
+| test.swift:489:9:489:9 | c3 | test.swift:489:9:489:9 | SSA def(c3) |
+| test.swift:489:14:489:25 | call to mkMyEnum1(_:) | test.swift:489:9:489:9 | c3 |
+| test.swift:490:9:490:9 | SSA def(c4) | test.swift:496:39:496:39 | c4 |
+| test.swift:490:9:490:9 | c4 | test.swift:490:9:490:9 | SSA def(c4) |
+| test.swift:490:14:490:32 | call to mkMyEnum1(_:) | test.swift:490:9:490:9 | c4 |
+| test.swift:491:9:491:9 | SSA def(c5) | test.swift:497:39:497:39 | c5 |
+| test.swift:491:9:491:9 | c5 | test.swift:491:9:491:9 | SSA def(c5) |
+| test.swift:491:14:491:25 | call to mkMyEnum2(_:) | test.swift:491:9:491:9 | c5 |
+| test.swift:492:9:492:9 | SSA def(c6) | test.swift:498:39:498:39 | c6 |
+| test.swift:492:9:492:9 | c6 | test.swift:492:9:492:9 | SSA def(c6) |
+| test.swift:492:14:492:32 | call to mkMyEnum2(_:) | test.swift:492:9:492:9 | c6 |
+| test.swift:493:33:493:33 | SSA def(d1) | test.swift:493:54:493:54 | d1 |
+| test.swift:493:33:493:33 | d1 | test.swift:493:33:493:33 | SSA def(d1) |
+| test.swift:493:39:493:39 | c1 | test.swift:493:13:493:35 | .mySingle(...) |
+| test.swift:494:33:494:33 | SSA def(d2) | test.swift:494:54:494:54 | d2 |
+| test.swift:494:33:494:33 | d2 | test.swift:494:33:494:33 | SSA def(d2) |
+| test.swift:494:39:494:39 | c2 | test.swift:494:13:494:35 | .mySingle(...) |
+| test.swift:495:33:495:33 | SSA def(d3) | test.swift:495:54:495:54 | d3 |
+| test.swift:495:33:495:33 | d3 | test.swift:495:33:495:33 | SSA def(d3) |
+| test.swift:495:39:495:39 | c3 | test.swift:495:13:495:35 | .mySingle(...) |
+| test.swift:496:33:496:33 | SSA def(d4) | test.swift:496:54:496:54 | d4 |
+| test.swift:496:33:496:33 | d4 | test.swift:496:33:496:33 | SSA def(d4) |
+| test.swift:496:39:496:39 | c4 | test.swift:496:13:496:35 | .mySingle(...) |
+| test.swift:497:33:497:33 | SSA def(d5) | test.swift:497:54:497:54 | d5 |
+| test.swift:497:33:497:33 | d5 | test.swift:497:33:497:33 | SSA def(d5) |
+| test.swift:497:39:497:39 | c5 | test.swift:497:13:497:35 | .mySingle(...) |
+| test.swift:498:33:498:33 | SSA def(d6) | test.swift:498:54:498:54 | d6 |
+| test.swift:498:33:498:33 | d6 | test.swift:498:33:498:33 | SSA def(d6) |
+| test.swift:498:39:498:39 | c6 | test.swift:498:13:498:35 | .mySingle(...) |
+| test.swift:500:9:500:9 | SSA def(e1) | test.swift:506:15:506:15 | e1 |
+| test.swift:500:9:500:9 | e1 | test.swift:500:9:500:9 | SSA def(e1) |
+| test.swift:500:14:500:29 | call to ... | test.swift:500:9:500:9 | e1 |
+| test.swift:501:9:501:9 | SSA def(e2) | test.swift:507:15:507:15 | e2 |
+| test.swift:501:9:501:9 | e2 | test.swift:501:9:501:9 | SSA def(e2) |
+| test.swift:501:14:501:36 | call to ... | test.swift:501:9:501:9 | e2 |
+| test.swift:502:9:502:9 | SSA def(e3) | test.swift:508:15:508:15 | e3 |
+| test.swift:502:9:502:9 | e3 | test.swift:502:9:502:9 | SSA def(e3) |
+| test.swift:502:14:502:27 | call to mkOptional1(_:) | test.swift:502:9:502:9 | e3 |
+| test.swift:503:9:503:9 | SSA def(e4) | test.swift:509:15:509:15 | e4 |
+| test.swift:503:9:503:9 | e4 | test.swift:503:9:503:9 | SSA def(e4) |
+| test.swift:503:14:503:34 | call to mkOptional1(_:) | test.swift:503:9:503:9 | e4 |
+| test.swift:504:9:504:9 | SSA def(e5) | test.swift:510:15:510:15 | e5 |
+| test.swift:504:9:504:9 | e5 | test.swift:504:9:504:9 | SSA def(e5) |
+| test.swift:504:14:504:27 | call to mkOptional2(_:) | test.swift:504:9:504:9 | e5 |
+| test.swift:505:9:505:9 | SSA def(e6) | test.swift:511:15:511:15 | e6 |
+| test.swift:505:9:505:9 | e6 | test.swift:505:9:505:9 | SSA def(e6) |
+| test.swift:505:14:505:34 | call to mkOptional2(_:) | test.swift:505:9:505:9 | e6 |
+| test.swift:506:15:506:15 | e1 | test.swift:506:15:506:17 | ...! |
+| test.swift:507:15:507:15 | e2 | test.swift:507:15:507:17 | ...! |
+| test.swift:508:15:508:15 | e3 | test.swift:508:15:508:17 | ...! |
+| test.swift:509:15:509:15 | e4 | test.swift:509:15:509:17 | ...! |
+| test.swift:510:15:510:15 | e5 | test.swift:510:15:510:17 | ...! |
+| test.swift:511:15:511:15 | e6 | test.swift:511:15:511:17 | ...! |
+| test.swift:516:21:516:27 | SSA def(y) | test.swift:519:27:519:27 | y |
+| test.swift:516:21:516:27 | SSA def(y) | test.swift:524:22:524:22 | y |
+| test.swift:516:21:516:27 | y | test.swift:516:21:516:27 | SSA def(y) |
+| test.swift:517:9:517:9 | SSA def(x) | test.swift:519:16:519:16 | x |
+| test.swift:517:9:517:9 | x | test.swift:517:9:517:9 | SSA def(x) |
+| test.swift:517:13:517:28 | call to optionalSource() | test.swift:517:9:517:9 | x |
+| test.swift:519:12:519:12 | SSA def(a) | test.swift:519:27:519:27 | SSA phi(a) |
+| test.swift:519:12:519:12 | a | test.swift:519:12:519:12 | SSA def(a) |
+| test.swift:519:16:519:16 | x | test.swift:519:8:519:12 | let ...? |
+| test.swift:519:16:519:16 | x | test.swift:524:19:524:19 | x |
+| test.swift:519:23:519:23 | SSA def(b) | test.swift:521:19:521:19 | b |
+| test.swift:519:23:519:23 | b | test.swift:519:23:519:23 | SSA def(b) |
+| test.swift:519:27:519:27 | SSA phi(a) | test.swift:520:19:520:19 | a |
+| test.swift:519:27:519:27 | y | test.swift:519:19:519:23 | let ...? |
+| test.swift:519:27:519:27 | y | test.swift:524:22:524:22 | y |
+| test.swift:524:9:524:9 | SSA def(tuple1) | test.swift:525:12:525:12 | tuple1 |
+| test.swift:524:9:524:9 | tuple1 | test.swift:524:9:524:9 | SSA def(tuple1) |
+| test.swift:524:18:524:23 | (...) | test.swift:524:9:524:9 | tuple1 |
+| test.swift:525:12:525:12 | tuple1 | test.swift:526:10:526:37 | (...) |
+| test.swift:525:12:525:12 | tuple1 | test.swift:529:5:529:5 | _ |
+| test.swift:526:21:526:21 | SSA def(a) | test.swift:527:19:527:19 | a |
+| test.swift:526:21:526:21 | a | test.swift:526:21:526:21 | SSA def(a) |
+| test.swift:526:35:526:35 | SSA def(b) | test.swift:528:19:528:19 | b |
+| test.swift:526:35:526:35 | b | test.swift:526:35:526:35 | SSA def(b) |
+| test.swift:533:13:533:13 | SSA def(x) | test.swift:534:19:534:19 | x |
+| test.swift:533:13:533:13 | x | test.swift:533:13:533:13 | SSA def(x) |
+| test.swift:533:16:533:16 | SSA def(y) | test.swift:535:19:535:19 | y |
+| test.swift:533:16:533:16 | y | test.swift:533:16:533:16 | SSA def(y) |
+| test.swift:533:21:533:29 | call to source2() | test.swift:533:8:533:17 | let ...? |
+| test.swift:539:7:539:7 | SSA def(self) | test.swift:539:7:539:7 | self[return] |
+| test.swift:539:7:539:7 | SSA def(self) | test.swift:539:7:539:7 | self[return] |
+| test.swift:539:7:539:7 | self | test.swift:539:7:539:7 | SSA def(self) |
+| test.swift:539:7:539:7 | self | test.swift:539:7:539:7 | SSA def(self) |
+| test.swift:540:9:540:9 | self | test.swift:540:9:540:9 | SSA def(self) |
+| test.swift:540:9:540:9 | self | test.swift:540:9:540:9 | SSA def(self) |
+| test.swift:540:9:540:9 | self | test.swift:540:9:540:9 | SSA def(self) |
+| test.swift:540:9:540:9 | value | test.swift:540:9:540:9 | SSA def(value) |
+| test.swift:543:33:543:39 | SSA def(y) | test.swift:548:12:548:12 | y |
+| test.swift:543:33:543:39 | y | test.swift:543:33:543:39 | SSA def(y) |
+| test.swift:544:9:544:9 | SSA def(x) | test.swift:546:12:546:12 | x |
+| test.swift:544:9:544:9 | x | test.swift:544:9:544:9 | SSA def(x) |
+| test.swift:544:13:544:28 | call to optionalSource() | test.swift:544:9:544:9 | x |
+| test.swift:545:9:545:9 | SSA def(cx) | test.swift:546:5:546:5 | cx |
+| test.swift:545:9:545:9 | cx | test.swift:545:9:545:9 | SSA def(cx) |
+| test.swift:545:14:545:16 | call to C.init() | test.swift:545:9:545:9 | cx |
+| test.swift:546:5:546:5 | [post] cx | test.swift:550:20:550:20 | cx |
+| test.swift:546:5:546:5 | cx | test.swift:550:20:550:20 | cx |
+| test.swift:547:9:547:9 | SSA def(cy) | test.swift:548:5:548:5 | cy |
+| test.swift:547:9:547:9 | cy | test.swift:547:9:547:9 | SSA def(cy) |
+| test.swift:547:14:547:16 | call to C.init() | test.swift:547:9:547:9 | cy |
+| test.swift:548:5:548:5 | [post] cy | test.swift:552:20:552:20 | cy |
+| test.swift:548:5:548:5 | cy | test.swift:552:20:552:20 | cy |
+| test.swift:550:15:550:15 | SSA def(z1) | test.swift:551:15:551:15 | z1 |
+| test.swift:550:15:550:15 | z1 | test.swift:550:15:550:15 | SSA def(z1) |
+| test.swift:550:20:550:23 | .x | test.swift:550:11:550:15 | let ...? |
+| test.swift:552:15:552:15 | SSA def(z2) | test.swift:553:15:553:15 | z2 |
+| test.swift:552:15:552:15 | z2 | test.swift:552:15:552:15 | SSA def(z2) |
+| test.swift:552:20:552:23 | .x | test.swift:552:11:552:15 | let ...? |
+| test.swift:557:14:557:21 | call to source() | test.swift:557:13:557:21 | call to +(_:) |
+| test.swift:565:7:565:7 | SSA def(self) | test.swift:565:7:565:7 | self[return] |
 | test.swift:565:7:565:7 | self | test.swift:565:7:565:7 | SSA def(self) |
-| test.swift:567:3:567:3 | SSA def(self) | test.swift:568:5:568:5 | self |
-| test.swift:567:3:567:3 | self | test.swift:567:3:567:3 | SSA def(self) |
-| test.swift:567:8:567:11 | SSA def(x) | test.swift:568:14:568:14 | x |
-| test.swift:567:8:567:11 | x | test.swift:567:8:567:11 | SSA def(x) |
-| test.swift:568:5:568:5 | [post] self | test.swift:567:3:569:3 | self[return] |
-| test.swift:568:5:568:5 | self | test.swift:567:3:569:3 | self[return] |
-| test.swift:573:7:573:7 | SSA def(s) | test.swift:575:13:575:13 | s |
-| test.swift:573:7:573:7 | s | test.swift:573:7:573:7 | SSA def(s) |
-| test.swift:573:11:573:24 | call to S.init(x:) | test.swift:573:7:573:7 | s |
-| test.swift:574:7:574:7 | SSA def(f) | test.swift:575:24:575:24 | f |
-| test.swift:574:7:574:7 | f | test.swift:574:7:574:7 | SSA def(f) |
-| test.swift:574:11:574:14 | #keyPath(...) | test.swift:574:7:574:7 | f |
-| test.swift:574:11:574:14 | enter #keyPath(...) | test.swift:574:14:574:14 | KeyPathComponent |
-| test.swift:575:13:575:13 | s | test.swift:578:13:578:13 | s |
-| test.swift:577:7:577:7 | SSA def(inferred) | test.swift:578:24:578:24 | inferred |
-| test.swift:577:7:577:7 | inferred | test.swift:577:7:577:7 | SSA def(inferred) |
-| test.swift:577:7:577:32 | ... as ... | test.swift:577:7:577:7 | inferred |
-| test.swift:577:36:577:38 | #keyPath(...) | test.swift:577:7:577:32 | ... as ... |
-| test.swift:577:36:577:38 | enter #keyPath(...) | test.swift:577:38:577:38 | KeyPathComponent |
-| test.swift:582:7:582:7 | self | test.swift:582:7:582:7 | SSA def(self) |
-| test.swift:584:3:584:3 | SSA def(self) | test.swift:585:5:585:5 | self |
-| test.swift:584:3:584:3 | self | test.swift:584:3:584:3 | SSA def(self) |
-| test.swift:584:8:584:11 | SSA def(s) | test.swift:585:14:585:14 | s |
-| test.swift:584:8:584:11 | s | test.swift:584:8:584:11 | SSA def(s) |
-| test.swift:585:5:585:5 | [post] self | test.swift:584:3:586:3 | self[return] |
-| test.swift:585:5:585:5 | self | test.swift:584:3:586:3 | self[return] |
-| test.swift:590:7:590:7 | SSA def(s) | test.swift:591:18:591:18 | s |
-| test.swift:590:7:590:7 | s | test.swift:590:7:590:7 | SSA def(s) |
-| test.swift:590:11:590:24 | call to S.init(x:) | test.swift:590:7:590:7 | s |
-| test.swift:591:7:591:7 | SSA def(s2) | test.swift:593:13:593:13 | s2 |
-| test.swift:591:7:591:7 | s2 | test.swift:591:7:591:7 | SSA def(s2) |
-| test.swift:591:12:591:19 | call to S2.init(s:) | test.swift:591:7:591:7 | s2 |
-| test.swift:592:7:592:7 | SSA def(f) | test.swift:593:25:593:25 | f |
-| test.swift:592:7:592:7 | f | test.swift:592:7:592:7 | SSA def(f) |
-| test.swift:592:11:592:17 | #keyPath(...) | test.swift:592:7:592:7 | f |
-| test.swift:592:11:592:17 | enter #keyPath(...) | test.swift:592:15:592:15 | KeyPathComponent |
-| test.swift:597:9:597:9 | SSA def(array) | test.swift:599:15:599:15 | array |
-| test.swift:597:9:597:9 | array | test.swift:597:9:597:9 | SSA def(array) |
-| test.swift:597:17:597:26 | [...] | test.swift:597:9:597:9 | array |
-| test.swift:598:9:598:9 | SSA def(f) | test.swift:599:30:599:30 | f |
-| test.swift:598:9:598:9 | f | test.swift:598:9:598:9 | SSA def(f) |
-| test.swift:598:13:598:22 | #keyPath(...) | test.swift:598:9:598:9 | f |
-| test.swift:598:13:598:22 | enter #keyPath(...) | test.swift:598:20:598:22 | KeyPathComponent |
-| test.swift:603:7:603:7 | self | test.swift:603:7:603:7 | SSA def(self) |
-| test.swift:605:3:605:3 | SSA def(self) | test.swift:606:5:606:5 | self |
-| test.swift:605:3:605:3 | self | test.swift:605:3:605:3 | SSA def(self) |
-| test.swift:605:8:605:12 | SSA def(s) | test.swift:606:14:606:14 | s |
-| test.swift:605:8:605:12 | s | test.swift:605:8:605:12 | SSA def(s) |
-| test.swift:606:5:606:5 | [post] self | test.swift:605:3:607:3 | self[return] |
-| test.swift:606:5:606:5 | self | test.swift:605:3:607:3 | self[return] |
-| test.swift:611:9:611:9 | SSA def(s) | test.swift:612:29:612:29 | s |
-| test.swift:611:9:611:9 | s | test.swift:611:9:611:9 | SSA def(s) |
-| test.swift:611:13:611:26 | call to S.init(x:) | test.swift:611:9:611:9 | s |
-| test.swift:612:9:612:9 | SSA def(s2) | test.swift:614:15:614:15 | s2 |
-| test.swift:612:9:612:9 | s2 | test.swift:612:9:612:9 | SSA def(s2) |
-| test.swift:612:14:612:30 | call to S2_Optional.init(s:) | test.swift:612:9:612:9 | s2 |
-| test.swift:613:9:613:9 | SSA def(f) | test.swift:614:27:614:27 | f |
-| test.swift:613:9:613:9 | f | test.swift:613:9:613:9 | SSA def(f) |
-| test.swift:613:13:613:29 | #keyPath(...) | test.swift:613:9:613:9 | f |
-| test.swift:613:13:613:29 | enter #keyPath(...) | test.swift:613:26:613:26 | KeyPathComponent |
-| test.swift:618:9:618:9 | SSA def(x) | test.swift:622:9:622:9 | x |
-| test.swift:618:9:618:9 | x | test.swift:618:9:618:9 | SSA def(x) |
-| test.swift:618:13:618:20 | call to source() | test.swift:618:9:618:9 | x |
-| test.swift:619:9:619:9 | SSA def(y) | test.swift:623:9:623:9 | y |
-| test.swift:619:9:619:9 | y | test.swift:619:9:619:9 | SSA def(y) |
-| test.swift:619:13:619:13 | 0 | test.swift:619:9:619:9 | y |
-| test.swift:620:9:620:12 | ... as ... | test.swift:620:9:620:9 | t |
-| test.swift:622:5:622:9 | SSA def(t) | test.swift:624:9:624:9 | t |
-| test.swift:622:9:622:9 | x | test.swift:622:5:622:9 | SSA def(t) |
-| test.swift:623:5:623:9 | SSA def(x) | test.swift:625:15:625:15 | x |
-| test.swift:623:9:623:9 | y | test.swift:623:5:623:9 | SSA def(x) |
-| test.swift:624:5:624:9 | SSA def(y) | test.swift:626:15:626:15 | y |
-| test.swift:624:9:624:9 | t | test.swift:624:5:624:9 | SSA def(y) |
-| test.swift:628:5:628:16 | SSA def(x) | test.swift:630:11:630:11 | x |
-| test.swift:628:9:628:16 | call to source() | test.swift:628:5:628:16 | SSA def(x) |
-| test.swift:629:5:629:9 | SSA def(y) | test.swift:630:15:630:15 | y |
-| test.swift:629:9:629:9 | 0 | test.swift:629:5:629:9 | SSA def(y) |
-| test.swift:630:10:630:11 | &... | test.swift:631:15:631:15 | x |
-| test.swift:630:10:630:11 | [post] &... | test.swift:631:15:631:15 | x |
-| test.swift:630:11:630:11 | x | test.swift:630:10:630:11 | &... |
-| test.swift:630:14:630:15 | &... | test.swift:632:15:632:15 | y |
-| test.swift:630:14:630:15 | [post] &... | test.swift:632:15:632:15 | y |
-| test.swift:630:15:630:15 | y | test.swift:630:14:630:15 | &... |
+| test.swift:566:9:566:9 | self | test.swift:566:9:566:9 | SSA def(self) |
+| test.swift:566:9:566:9 | self | test.swift:566:9:566:9 | SSA def(self) |
+| test.swift:566:9:566:9 | self | test.swift:566:9:566:9 | SSA def(self) |
+| test.swift:566:9:566:9 | value | test.swift:566:9:566:9 | SSA def(value) |
+| test.swift:567:5:567:5 | SSA def(self) | test.swift:568:7:568:7 | self |
+| test.swift:567:5:567:5 | self | test.swift:567:5:567:5 | SSA def(self) |
+| test.swift:567:10:567:13 | SSA def(s) | test.swift:568:13:568:13 | s |
+| test.swift:567:10:567:13 | s | test.swift:567:10:567:13 | SSA def(s) |
+| test.swift:568:7:568:7 | [post] self | test.swift:567:5:569:5 | self[return] |
+| test.swift:568:7:568:7 | self | test.swift:567:5:569:5 | self[return] |
+| test.swift:573:17:573:17 | SSA def(self) | test.swift:574:7:574:7 | self |
+| test.swift:573:17:573:17 | self | test.swift:573:17:573:17 | SSA def(self) |
+| test.swift:574:7:574:7 | [post] self | test.swift:575:17:575:17 | self |
+| test.swift:574:7:574:7 | self | test.swift:575:17:575:17 | self |
+| test.swift:575:17:575:17 | [post] self | test.swift:573:17:576:5 | self[return] |
+| test.swift:575:17:575:17 | self | test.swift:573:17:576:5 | self[return] |
+| test.swift:579:21:579:27 | SSA def(path) | test.swift:581:37:581:37 | path |
+| test.swift:579:21:579:27 | path | test.swift:579:21:579:27 | SSA def(path) |
+| test.swift:584:7:584:7 | SSA def(self) | test.swift:584:7:584:7 | self[return] |
+| test.swift:584:7:584:7 | self | test.swift:584:7:584:7 | SSA def(self) |
+| test.swift:585:3:585:3 | SSA def(self) | test.swift:585:3:585:40 | self[return] |
+| test.swift:585:3:585:3 | self | test.swift:585:3:585:3 | SSA def(self) |
+| test.swift:585:27:585:38 | SSA def(n) | test.swift:585:3:585:40 | n[return] |
+| test.swift:585:31:585:38 | call to source() | test.swift:585:27:585:38 | SSA def(n) |
+| test.swift:591:7:591:7 | SSA def(n) | test.swift:592:36:592:36 | n |
+| test.swift:591:7:591:7 | n | test.swift:591:7:591:7 | SSA def(n) |
+| test.swift:591:11:591:11 | 0 | test.swift:591:7:591:7 | n |
+| test.swift:592:36:592:36 | n | test.swift:592:35:592:36 | &... |
+| test.swift:596:7:596:7 | self | test.swift:596:7:596:7 | SSA def(self) |
+| test.swift:598:3:598:3 | SSA def(self) | test.swift:599:5:599:5 | self |
+| test.swift:598:3:598:3 | self | test.swift:598:3:598:3 | SSA def(self) |
+| test.swift:598:8:598:11 | SSA def(x) | test.swift:599:14:599:14 | x |
+| test.swift:598:8:598:11 | x | test.swift:598:8:598:11 | SSA def(x) |
+| test.swift:599:5:599:5 | [post] self | test.swift:598:3:600:3 | self[return] |
+| test.swift:599:5:599:5 | self | test.swift:598:3:600:3 | self[return] |
+| test.swift:604:7:604:7 | SSA def(s) | test.swift:606:13:606:13 | s |
+| test.swift:604:7:604:7 | s | test.swift:604:7:604:7 | SSA def(s) |
+| test.swift:604:11:604:24 | call to S.init(x:) | test.swift:604:7:604:7 | s |
+| test.swift:605:7:605:7 | SSA def(f) | test.swift:606:24:606:24 | f |
+| test.swift:605:7:605:7 | f | test.swift:605:7:605:7 | SSA def(f) |
+| test.swift:605:11:605:14 | #keyPath(...) | test.swift:605:7:605:7 | f |
+| test.swift:605:11:605:14 | enter #keyPath(...) | test.swift:605:14:605:14 | KeyPathComponent |
+| test.swift:606:13:606:13 | s | test.swift:609:13:609:13 | s |
+| test.swift:608:7:608:7 | SSA def(inferred) | test.swift:609:24:609:24 | inferred |
+| test.swift:608:7:608:7 | inferred | test.swift:608:7:608:7 | SSA def(inferred) |
+| test.swift:608:7:608:32 | ... as ... | test.swift:608:7:608:7 | inferred |
+| test.swift:608:36:608:38 | #keyPath(...) | test.swift:608:7:608:32 | ... as ... |
+| test.swift:608:36:608:38 | enter #keyPath(...) | test.swift:608:38:608:38 | KeyPathComponent |
+| test.swift:613:7:613:7 | self | test.swift:613:7:613:7 | SSA def(self) |
+| test.swift:615:3:615:3 | SSA def(self) | test.swift:616:5:616:5 | self |
+| test.swift:615:3:615:3 | self | test.swift:615:3:615:3 | SSA def(self) |
+| test.swift:615:8:615:11 | SSA def(s) | test.swift:616:14:616:14 | s |
+| test.swift:615:8:615:11 | s | test.swift:615:8:615:11 | SSA def(s) |
+| test.swift:616:5:616:5 | [post] self | test.swift:615:3:617:3 | self[return] |
+| test.swift:616:5:616:5 | self | test.swift:615:3:617:3 | self[return] |
+| test.swift:621:7:621:7 | SSA def(s) | test.swift:622:18:622:18 | s |
+| test.swift:621:7:621:7 | s | test.swift:621:7:621:7 | SSA def(s) |
+| test.swift:621:11:621:24 | call to S.init(x:) | test.swift:621:7:621:7 | s |
+| test.swift:622:7:622:7 | SSA def(s2) | test.swift:624:13:624:13 | s2 |
+| test.swift:622:7:622:7 | s2 | test.swift:622:7:622:7 | SSA def(s2) |
+| test.swift:622:12:622:19 | call to S2.init(s:) | test.swift:622:7:622:7 | s2 |
+| test.swift:623:7:623:7 | SSA def(f) | test.swift:624:25:624:25 | f |
+| test.swift:623:7:623:7 | f | test.swift:623:7:623:7 | SSA def(f) |
+| test.swift:623:11:623:17 | #keyPath(...) | test.swift:623:7:623:7 | f |
+| test.swift:623:11:623:17 | enter #keyPath(...) | test.swift:623:15:623:15 | KeyPathComponent |
+| test.swift:628:9:628:9 | SSA def(array) | test.swift:630:15:630:15 | array |
+| test.swift:628:9:628:9 | array | test.swift:628:9:628:9 | SSA def(array) |
+| test.swift:628:17:628:26 | [...] | test.swift:628:9:628:9 | array |
+| test.swift:629:9:629:9 | SSA def(f) | test.swift:630:30:630:30 | f |
+| test.swift:629:9:629:9 | f | test.swift:629:9:629:9 | SSA def(f) |
+| test.swift:629:13:629:22 | #keyPath(...) | test.swift:629:9:629:9 | f |
+| test.swift:629:13:629:22 | enter #keyPath(...) | test.swift:629:20:629:22 | KeyPathComponent |
+| test.swift:634:7:634:7 | self | test.swift:634:7:634:7 | SSA def(self) |
+| test.swift:636:3:636:3 | SSA def(self) | test.swift:637:5:637:5 | self |
+| test.swift:636:3:636:3 | self | test.swift:636:3:636:3 | SSA def(self) |
+| test.swift:636:8:636:12 | SSA def(s) | test.swift:637:14:637:14 | s |
+| test.swift:636:8:636:12 | s | test.swift:636:8:636:12 | SSA def(s) |
+| test.swift:637:5:637:5 | [post] self | test.swift:636:3:638:3 | self[return] |
+| test.swift:637:5:637:5 | self | test.swift:636:3:638:3 | self[return] |
+| test.swift:642:9:642:9 | SSA def(s) | test.swift:643:29:643:29 | s |
+| test.swift:642:9:642:9 | s | test.swift:642:9:642:9 | SSA def(s) |
+| test.swift:642:13:642:26 | call to S.init(x:) | test.swift:642:9:642:9 | s |
+| test.swift:643:9:643:9 | SSA def(s2) | test.swift:645:15:645:15 | s2 |
+| test.swift:643:9:643:9 | s2 | test.swift:643:9:643:9 | SSA def(s2) |
+| test.swift:643:14:643:30 | call to S2_Optional.init(s:) | test.swift:643:9:643:9 | s2 |
+| test.swift:644:9:644:9 | SSA def(f) | test.swift:645:27:645:27 | f |
+| test.swift:644:9:644:9 | f | test.swift:644:9:644:9 | SSA def(f) |
+| test.swift:644:13:644:29 | #keyPath(...) | test.swift:644:9:644:9 | f |
+| test.swift:644:13:644:29 | enter #keyPath(...) | test.swift:644:26:644:26 | KeyPathComponent |
+| test.swift:649:9:649:9 | SSA def(x) | test.swift:653:9:653:9 | x |
+| test.swift:649:9:649:9 | x | test.swift:649:9:649:9 | SSA def(x) |
+| test.swift:649:13:649:20 | call to source() | test.swift:649:9:649:9 | x |
+| test.swift:650:9:650:9 | SSA def(y) | test.swift:654:9:654:9 | y |
+| test.swift:650:9:650:9 | y | test.swift:650:9:650:9 | SSA def(y) |
+| test.swift:650:13:650:13 | 0 | test.swift:650:9:650:9 | y |
+| test.swift:651:9:651:12 | ... as ... | test.swift:651:9:651:9 | t |
+| test.swift:653:5:653:9 | SSA def(t) | test.swift:655:9:655:9 | t |
+| test.swift:653:9:653:9 | x | test.swift:653:5:653:9 | SSA def(t) |
+| test.swift:654:5:654:9 | SSA def(x) | test.swift:656:15:656:15 | x |
+| test.swift:654:9:654:9 | y | test.swift:654:5:654:9 | SSA def(x) |
+| test.swift:655:5:655:9 | SSA def(y) | test.swift:657:15:657:15 | y |
+| test.swift:655:9:655:9 | t | test.swift:655:5:655:9 | SSA def(y) |
+| test.swift:659:5:659:16 | SSA def(x) | test.swift:661:11:661:11 | x |
+| test.swift:659:9:659:16 | call to source() | test.swift:659:5:659:16 | SSA def(x) |
+| test.swift:660:5:660:9 | SSA def(y) | test.swift:661:15:661:15 | y |
+| test.swift:660:9:660:9 | 0 | test.swift:660:5:660:9 | SSA def(y) |
+| test.swift:661:10:661:11 | &... | test.swift:662:15:662:15 | x |
+| test.swift:661:10:661:11 | [post] &... | test.swift:662:15:662:15 | x |
+| test.swift:661:11:661:11 | x | test.swift:661:10:661:11 | &... |
+| test.swift:661:14:661:15 | &... | test.swift:663:15:663:15 | y |
+| test.swift:661:14:661:15 | [post] &... | test.swift:663:15:663:15 | y |
+| test.swift:661:15:661:15 | y | test.swift:661:14:661:15 | &... |

--- a/swift/ql/test/library-tests/dataflow/dataflow/test.swift
+++ b/swift/ql/test/library-tests/dataflow/dataflow/test.swift
@@ -495,7 +495,7 @@ func testEnums() {
     if case MyEnum.mySingle(let d3) = c3 { sink(arg: d3) }
     if case MyEnum.mySingle(let d4) = c4 { sink(arg: d4) } // $ flow=490
     if case MyEnum.mySingle(let d5) = c5 { sink(arg: d5) }
-    if case MyEnum.mySingle(let d6) = c6 { sink(arg: d6) } // $ MISSING: flow=492
+    if case MyEnum.mySingle(let d6) = c6 { sink(arg: d6) } // $ flow=492
 
     let e1 = Optional.some(0)
     let e2 = Optional.some(source())

--- a/swift/ql/test/library-tests/dataflow/dataflow/test.swift
+++ b/swift/ql/test/library-tests/dataflow/dataflow/test.swift
@@ -504,11 +504,11 @@ func testEnums() {
     let e5 = mkOptional2(0)
     let e6 = mkOptional2(source())
     sink(arg: e1!)
-    sink(arg: e2!) // $ MISSING: flow=501
+    sink(arg: e2!) // $ flow=501
     sink(arg: e3!)
-    sink(arg: e4!) // $ MISSING: flow=503
+    sink(arg: e4!) // $ flow=503
     sink(arg: e5!)
-    sink(arg: e6!) // $ MISSING: flow=505
+    sink(arg: e6!) // $ flow=505
 }
 
 func source2() -> (Int, Int)? { return nil }

--- a/swift/ql/test/library-tests/dataflow/dataflow/test.swift
+++ b/swift/ql/test/library-tests/dataflow/dataflow/test.swift
@@ -372,6 +372,11 @@ indirect enum MyEnum {
     case myCons(Int, MyEnum)
 }
 
+func mkMyEnum1(_ v: Int) -> MyEnum { return MyEnum.mySingle(v) }
+func mkMyEnum2(_ v: Int) -> MyEnum { return MyEnum.myNone } // modelled flow
+func mkOptional1(_ v: Int) -> Int? { return Optional.some(v) }
+func mkOptional2(_ v: Int) -> Int? { return nil } // modelled flow
+
 func testEnums() {
     var a : MyEnum = .myNone
 
@@ -401,7 +406,7 @@ func testEnums() {
     case .myNone:
         ()
     case .mySingle(let a):
-        sink(arg: a) // $ flow=398
+        sink(arg: a) // $ flow=403
     case .myPair(let a, let b):
         sink(arg: a)
         sink(arg: b)
@@ -410,7 +415,7 @@ func testEnums() {
     }
 
     if case .mySingle(let x) = a {
-        sink(arg: x) // $ flow=398
+        sink(arg: x) // $ flow=403
     }
     if case .myPair(let x, let y) = a {
         sink(arg: x)
@@ -426,7 +431,7 @@ func testEnums() {
         sink(arg: a)
     case .myPair(let a, let b):
         sink(arg: a)
-        sink(arg: b) // $ flow=420
+        sink(arg: b) // $ flow=425
     case let .myCons(a, _):
         sink(arg: a)
     }
@@ -436,7 +441,7 @@ func testEnums() {
     }
     if case .myPair(let x, let y) = a {
         sink(arg: x)
-        sink(arg: y) // $ flow=420
+        sink(arg: y) // $ flow=425
     }
 
     let b: MyEnum = .myCons(42, a)
@@ -452,7 +457,7 @@ func testEnums() {
     case let .myCons(a, .myPair(b, c)):
         sink(arg: a)
         sink(arg: b)
-        sink(arg: c) // $ flow=420
+        sink(arg: c) // $ flow=425
     case let .myCons(a, _):
         sink(arg: a)
     }
@@ -461,23 +466,49 @@ func testEnums() {
         sink(arg: x)
     }
     if case MyEnum.myPair(let x, let y) = .myPair(source(), 0) {
-        sink(arg: x) // $ flow=463
+        sink(arg: x) // $ flow=468
         sink(arg: y)
     }
     if case let .myCons(_, .myPair(_, c)) = b {
-        sink(arg: c) // $ flow=420
+        sink(arg: c) // $ flow=425
     }
 
     switch (a, b) {
     case let (.myPair(a, b), .myCons(c, .myPair(d, e))):
         sink(arg: a)
-        sink(arg: b) // $ flow=420
+        sink(arg: b) // $ flow=425
         sink(arg: c)
         sink(arg: d)
-        sink(arg: e) // $ flow=420
+        sink(arg: e) // $ flow=425
     default:
         ()
     }
+
+    let c1 = MyEnum.mySingle(0)
+    let c2 = MyEnum.mySingle(source())
+    let c3 = mkMyEnum1(0)
+    let c4 = mkMyEnum1(source())
+    let c5 = mkMyEnum2(0)
+    let c6 = mkMyEnum2(source())
+    if case MyEnum.mySingle(let d1) = c1 { sink(arg: d1) }
+    if case MyEnum.mySingle(let d2) = c2 { sink(arg: d2) } // $ flow=488
+    if case MyEnum.mySingle(let d3) = c3 { sink(arg: d3) }
+    if case MyEnum.mySingle(let d4) = c4 { sink(arg: d4) } // $ flow=490
+    if case MyEnum.mySingle(let d5) = c5 { sink(arg: d5) }
+    if case MyEnum.mySingle(let d6) = c6 { sink(arg: d6) } // $ MISSING: flow=492
+
+    let e1 = Optional.some(0)
+    let e2 = Optional.some(source())
+    let e3 = mkOptional1(0)
+    let e4 = mkOptional1(source())
+    let e5 = mkOptional2(0)
+    let e6 = mkOptional2(source())
+    sink(arg: e1!)
+    sink(arg: e2!) // $ MISSING: flow=501
+    sink(arg: e3!)
+    sink(arg: e4!) // $ MISSING: flow=503
+    sink(arg: e5!)
+    sink(arg: e6!) // $ MISSING: flow=505
 }
 
 func source2() -> (Int, Int)? { return nil }
@@ -523,8 +554,8 @@ func testOptionalPropertyAccess(y: Int?) {
 }
 
 func testIdentityArithmetic() {
-  sink(arg: +source()) // $ flow=526
-  sink(arg: (source())) // $ flow=527
+  sink(arg: +source()) // $ flow=557
+  sink(arg: (source())) // $ flow=558
 }
 
 func sink(str: String) {}
@@ -541,13 +572,13 @@ class MyClass {
 extension MyClass {
     convenience init(contentsOfFile: String) {
       self.init(s: source3())
-      sink(str: str) // $ flow=543
+      sink(str: str) // $ flow=574
     }
 }
 
 func extensionInits(path: String) {
-  sink(str: MyClass(s: source3()).str) // $ flow=549
-  sink(str: MyClass(contentsOfFile: path).str) // $ flow=543
+  sink(str: MyClass(s: source3()).str) // $ flow=580
+  sink(str: MyClass(contentsOfFile: path).str) // $ flow=574
 }
 
 class InoutConstructorClass {
@@ -572,10 +603,10 @@ struct S {
 func testKeyPath() {
   let s = S(x: source())
   let f = \S.x
-  sink(arg: s[keyPath: f]) // $ flow=573
+  sink(arg: s[keyPath: f]) // $ flow=604
 
   let inferred : KeyPath<S, Int> = \.x
-  sink(arg: s[keyPath: inferred]) // $ flow=573
+  sink(arg: s[keyPath: inferred]) // $ flow=604
 }
 
 struct S2 {
@@ -590,13 +621,13 @@ func testNestedKeyPath() {
   let s = S(x: source())
   let s2 = S2(s: s)
   let f = \S2.s.x
-  sink(arg: s2[keyPath: f]) // $ flow=590
+  sink(arg: s2[keyPath: f]) // $ flow=621
 }
 
 func testArrayKeyPath() {
     let array = [source()]
     let f = \[Int].[0]
-    sink(arg: array[keyPath: f]) // $ MISSING: flow=597
+    sink(arg: array[keyPath: f]) // $ MISSING: flow=628
 }
 
 struct S2_Optional {
@@ -611,7 +642,7 @@ func testOptionalKeyPath() {
     let s = S(x: source())
     let s2 = S2_Optional(s: s)
     let f = \S2_Optional.s?.x
-    sink(opt: s2[keyPath: f]) // $ MISSING: flow=611
+    sink(opt: s2[keyPath: f]) // $ MISSING: flow=642
 }
 
 func testSwap() {
@@ -623,11 +654,11 @@ func testSwap() {
     x = y
     y = t
     sink(arg: x)
-    sink(arg: y) // $ flow=618
+    sink(arg: y) // $ flow=649
 
     x = source()
     y = 0
     swap(&x, &y)
-    sink(arg: x) // $ SPURIOUS: flow=628
-    sink(arg: y) // $ flow=628
+    sink(arg: x) // $ SPURIOUS: flow=659
+    sink(arg: y) // $ flow=659
 }

--- a/swift/ql/test/library-tests/dataflow/taint/core/Taint.expected
+++ b/swift/ql/test/library-tests/dataflow/taint/core/Taint.expected
@@ -72,7 +72,10 @@ edges
 | subscript.swift:14:15:14:23 | call to source2() | subscript.swift:14:15:14:26 | ...[...] |
 | try.swift:9:17:9:24 | call to source() | try.swift:9:13:9:24 | try ... |
 | try.swift:15:17:15:24 | call to source() | try.swift:15:12:15:24 | try! ... |
+| try.swift:18:13:18:25 | try? ... [some:0] | try.swift:18:12:18:27 | ...! |
 | try.swift:18:18:18:25 | call to source() | try.swift:18:12:18:27 | ...! |
+| try.swift:18:18:18:25 | call to source() | try.swift:18:18:18:25 | call to source() [some:0] |
+| try.swift:18:18:18:25 | call to source() [some:0] | try.swift:18:13:18:25 | try? ... [some:0] |
 nodes
 | file://:0:0:0:0 | .first | semmle.label | .first |
 | file://:0:0:0:0 | .second | semmle.label | .second |
@@ -185,7 +188,9 @@ nodes
 | try.swift:15:12:15:24 | try! ... | semmle.label | try! ... |
 | try.swift:15:17:15:24 | call to source() | semmle.label | call to source() |
 | try.swift:18:12:18:27 | ...! | semmle.label | ...! |
+| try.swift:18:13:18:25 | try? ... [some:0] | semmle.label | try? ... [some:0] |
 | try.swift:18:18:18:25 | call to source() | semmle.label | call to source() |
+| try.swift:18:18:18:25 | call to source() [some:0] | semmle.label | call to source() [some:0] |
 subpaths
 | stringinterpolation.swift:13:36:13:36 | pair [first] | stringinterpolation.swift:6:6:6:6 | self [first] | file://:0:0:0:0 | .first | stringinterpolation.swift:13:36:13:41 | .first |
 | stringinterpolation.swift:19:13:19:20 | call to source() | stringinterpolation.swift:6:6:6:6 | value | file://:0:0:0:0 | [post] self [first] | stringinterpolation.swift:19:2:19:2 | [post] p1 [first] |

--- a/swift/ql/test/query-tests/Security/CWE-079/UnsafeWebViewFetch.expected
+++ b/swift/ql/test/query-tests/Security/CWE-079/UnsafeWebViewFetch.expected
@@ -17,18 +17,32 @@ edges
 | UnsafeWebViewFetch.swift:117:21:117:35 | call to getRemoteData() | UnsafeWebViewFetch.swift:139:25:139:25 | remoteString |
 | UnsafeWebViewFetch.swift:117:21:117:35 | call to getRemoteData() | UnsafeWebViewFetch.swift:141:25:141:25 | remoteString |
 | UnsafeWebViewFetch.swift:117:21:117:35 | call to getRemoteData() | UnsafeWebViewFetch.swift:150:24:150:37 | .utf8 |
+| UnsafeWebViewFetch.swift:131:18:131:42 | call to URL.init(string:) | UnsafeWebViewFetch.swift:131:18:131:42 | call to URL.init(string:) [some:0] |
 | UnsafeWebViewFetch.swift:131:18:131:42 | call to URL.init(string:) | UnsafeWebViewFetch.swift:132:52:132:52 | remoteURL |
 | UnsafeWebViewFetch.swift:131:18:131:42 | call to URL.init(string:) | UnsafeWebViewFetch.swift:138:47:138:56 | ...! |
 | UnsafeWebViewFetch.swift:131:18:131:42 | call to URL.init(string:) | UnsafeWebViewFetch.swift:139:48:139:57 | ...! |
 | UnsafeWebViewFetch.swift:131:18:131:42 | call to URL.init(string:) | UnsafeWebViewFetch.swift:153:85:153:94 | ...! |
 | UnsafeWebViewFetch.swift:131:18:131:42 | call to URL.init(string:) | UnsafeWebViewFetch.swift:154:86:154:95 | ...! |
+| UnsafeWebViewFetch.swift:131:18:131:42 | call to URL.init(string:) [some:0] | UnsafeWebViewFetch.swift:138:47:138:47 | remoteURL [some:0] |
+| UnsafeWebViewFetch.swift:131:18:131:42 | call to URL.init(string:) [some:0] | UnsafeWebViewFetch.swift:139:48:139:48 | remoteURL [some:0] |
+| UnsafeWebViewFetch.swift:131:18:131:42 | call to URL.init(string:) [some:0] | UnsafeWebViewFetch.swift:153:85:153:85 | remoteURL [some:0] |
+| UnsafeWebViewFetch.swift:131:18:131:42 | call to URL.init(string:) [some:0] | UnsafeWebViewFetch.swift:154:86:154:86 | remoteURL [some:0] |
 | UnsafeWebViewFetch.swift:131:30:131:30 | remoteString | UnsafeWebViewFetch.swift:131:18:131:42 | call to URL.init(string:) |
+| UnsafeWebViewFetch.swift:132:19:132:61 | call to URL.init(string:relativeTo:) | UnsafeWebViewFetch.swift:132:19:132:61 | call to URL.init(string:relativeTo:) [some:0] |
 | UnsafeWebViewFetch.swift:132:19:132:61 | call to URL.init(string:relativeTo:) | UnsafeWebViewFetch.swift:140:47:140:57 | ...! |
 | UnsafeWebViewFetch.swift:132:19:132:61 | call to URL.init(string:relativeTo:) | UnsafeWebViewFetch.swift:141:48:141:58 | ...! |
+| UnsafeWebViewFetch.swift:132:19:132:61 | call to URL.init(string:relativeTo:) [some:0] | UnsafeWebViewFetch.swift:140:47:140:47 | remoteURL2 [some:0] |
+| UnsafeWebViewFetch.swift:132:19:132:61 | call to URL.init(string:relativeTo:) [some:0] | UnsafeWebViewFetch.swift:141:48:141:48 | remoteURL2 [some:0] |
 | UnsafeWebViewFetch.swift:132:52:132:52 | remoteURL | UnsafeWebViewFetch.swift:132:19:132:61 | call to URL.init(string:relativeTo:) |
+| UnsafeWebViewFetch.swift:138:47:138:47 | remoteURL [some:0] | UnsafeWebViewFetch.swift:138:47:138:56 | ...! |
+| UnsafeWebViewFetch.swift:139:48:139:48 | remoteURL [some:0] | UnsafeWebViewFetch.swift:139:48:139:57 | ...! |
+| UnsafeWebViewFetch.swift:140:47:140:47 | remoteURL2 [some:0] | UnsafeWebViewFetch.swift:140:47:140:57 | ...! |
+| UnsafeWebViewFetch.swift:141:48:141:48 | remoteURL2 [some:0] | UnsafeWebViewFetch.swift:141:48:141:58 | ...! |
 | UnsafeWebViewFetch.swift:150:19:150:41 | call to Data.init(_:) | UnsafeWebViewFetch.swift:152:15:152:15 | remoteData |
 | UnsafeWebViewFetch.swift:150:19:150:41 | call to Data.init(_:) | UnsafeWebViewFetch.swift:154:15:154:15 | remoteData |
 | UnsafeWebViewFetch.swift:150:24:150:37 | .utf8 | UnsafeWebViewFetch.swift:150:19:150:41 | call to Data.init(_:) |
+| UnsafeWebViewFetch.swift:153:85:153:85 | remoteURL [some:0] | UnsafeWebViewFetch.swift:153:85:153:94 | ...! |
+| UnsafeWebViewFetch.swift:154:86:154:86 | remoteURL [some:0] | UnsafeWebViewFetch.swift:154:86:154:95 | ...! |
 | UnsafeWebViewFetch.swift:164:21:164:35 | call to getRemoteData() | UnsafeWebViewFetch.swift:168:25:168:25 | remoteString |
 | UnsafeWebViewFetch.swift:164:21:164:35 | call to getRemoteData() | UnsafeWebViewFetch.swift:171:25:171:51 | ... .+(_:_:) ... |
 | UnsafeWebViewFetch.swift:164:21:164:35 | call to getRemoteData() | UnsafeWebViewFetch.swift:174:25:174:25 | "..." |
@@ -38,18 +52,32 @@ edges
 | UnsafeWebViewFetch.swift:164:21:164:35 | call to getRemoteData() | UnsafeWebViewFetch.swift:186:25:186:25 | remoteString |
 | UnsafeWebViewFetch.swift:164:21:164:35 | call to getRemoteData() | UnsafeWebViewFetch.swift:188:25:188:25 | remoteString |
 | UnsafeWebViewFetch.swift:164:21:164:35 | call to getRemoteData() | UnsafeWebViewFetch.swift:197:24:197:37 | .utf8 |
+| UnsafeWebViewFetch.swift:178:18:178:42 | call to URL.init(string:) | UnsafeWebViewFetch.swift:178:18:178:42 | call to URL.init(string:) [some:0] |
 | UnsafeWebViewFetch.swift:178:18:178:42 | call to URL.init(string:) | UnsafeWebViewFetch.swift:179:52:179:52 | remoteURL |
 | UnsafeWebViewFetch.swift:178:18:178:42 | call to URL.init(string:) | UnsafeWebViewFetch.swift:185:47:185:56 | ...! |
 | UnsafeWebViewFetch.swift:178:18:178:42 | call to URL.init(string:) | UnsafeWebViewFetch.swift:186:48:186:57 | ...! |
 | UnsafeWebViewFetch.swift:178:18:178:42 | call to URL.init(string:) | UnsafeWebViewFetch.swift:200:90:200:99 | ...! |
 | UnsafeWebViewFetch.swift:178:18:178:42 | call to URL.init(string:) | UnsafeWebViewFetch.swift:201:91:201:100 | ...! |
+| UnsafeWebViewFetch.swift:178:18:178:42 | call to URL.init(string:) [some:0] | UnsafeWebViewFetch.swift:185:47:185:47 | remoteURL [some:0] |
+| UnsafeWebViewFetch.swift:178:18:178:42 | call to URL.init(string:) [some:0] | UnsafeWebViewFetch.swift:186:48:186:48 | remoteURL [some:0] |
+| UnsafeWebViewFetch.swift:178:18:178:42 | call to URL.init(string:) [some:0] | UnsafeWebViewFetch.swift:200:90:200:90 | remoteURL [some:0] |
+| UnsafeWebViewFetch.swift:178:18:178:42 | call to URL.init(string:) [some:0] | UnsafeWebViewFetch.swift:201:91:201:91 | remoteURL [some:0] |
 | UnsafeWebViewFetch.swift:178:30:178:30 | remoteString | UnsafeWebViewFetch.swift:178:18:178:42 | call to URL.init(string:) |
+| UnsafeWebViewFetch.swift:179:19:179:61 | call to URL.init(string:relativeTo:) | UnsafeWebViewFetch.swift:179:19:179:61 | call to URL.init(string:relativeTo:) [some:0] |
 | UnsafeWebViewFetch.swift:179:19:179:61 | call to URL.init(string:relativeTo:) | UnsafeWebViewFetch.swift:187:47:187:57 | ...! |
 | UnsafeWebViewFetch.swift:179:19:179:61 | call to URL.init(string:relativeTo:) | UnsafeWebViewFetch.swift:188:48:188:58 | ...! |
+| UnsafeWebViewFetch.swift:179:19:179:61 | call to URL.init(string:relativeTo:) [some:0] | UnsafeWebViewFetch.swift:187:47:187:47 | remoteURL2 [some:0] |
+| UnsafeWebViewFetch.swift:179:19:179:61 | call to URL.init(string:relativeTo:) [some:0] | UnsafeWebViewFetch.swift:188:48:188:48 | remoteURL2 [some:0] |
 | UnsafeWebViewFetch.swift:179:52:179:52 | remoteURL | UnsafeWebViewFetch.swift:179:19:179:61 | call to URL.init(string:relativeTo:) |
+| UnsafeWebViewFetch.swift:185:47:185:47 | remoteURL [some:0] | UnsafeWebViewFetch.swift:185:47:185:56 | ...! |
+| UnsafeWebViewFetch.swift:186:48:186:48 | remoteURL [some:0] | UnsafeWebViewFetch.swift:186:48:186:57 | ...! |
+| UnsafeWebViewFetch.swift:187:47:187:47 | remoteURL2 [some:0] | UnsafeWebViewFetch.swift:187:47:187:57 | ...! |
+| UnsafeWebViewFetch.swift:188:48:188:48 | remoteURL2 [some:0] | UnsafeWebViewFetch.swift:188:48:188:58 | ...! |
 | UnsafeWebViewFetch.swift:197:19:197:41 | call to Data.init(_:) | UnsafeWebViewFetch.swift:199:15:199:15 | remoteData |
 | UnsafeWebViewFetch.swift:197:19:197:41 | call to Data.init(_:) | UnsafeWebViewFetch.swift:201:15:201:15 | remoteData |
 | UnsafeWebViewFetch.swift:197:24:197:37 | .utf8 | UnsafeWebViewFetch.swift:197:19:197:41 | call to Data.init(_:) |
+| UnsafeWebViewFetch.swift:200:90:200:90 | remoteURL [some:0] | UnsafeWebViewFetch.swift:200:90:200:99 | ...! |
+| UnsafeWebViewFetch.swift:201:91:201:91 | remoteURL [some:0] | UnsafeWebViewFetch.swift:201:91:201:100 | ...! |
 | UnsafeWebViewFetch.swift:206:17:206:31 | call to getRemoteData() | UnsafeWebViewFetch.swift:210:25:210:25 | htmlData |
 | UnsafeWebViewFetch.swift:206:17:206:31 | call to getRemoteData() | UnsafeWebViewFetch.swift:211:25:211:25 | htmlData |
 nodes
@@ -67,22 +95,30 @@ nodes
 | UnsafeWebViewFetch.swift:124:25:124:51 | ... .+(_:_:) ... | semmle.label | ... .+(_:_:) ... |
 | UnsafeWebViewFetch.swift:127:25:127:25 | "..." | semmle.label | "..." |
 | UnsafeWebViewFetch.swift:131:18:131:42 | call to URL.init(string:) | semmle.label | call to URL.init(string:) |
+| UnsafeWebViewFetch.swift:131:18:131:42 | call to URL.init(string:) [some:0] | semmle.label | call to URL.init(string:) [some:0] |
 | UnsafeWebViewFetch.swift:131:30:131:30 | remoteString | semmle.label | remoteString |
 | UnsafeWebViewFetch.swift:132:19:132:61 | call to URL.init(string:relativeTo:) | semmle.label | call to URL.init(string:relativeTo:) |
+| UnsafeWebViewFetch.swift:132:19:132:61 | call to URL.init(string:relativeTo:) [some:0] | semmle.label | call to URL.init(string:relativeTo:) [some:0] |
 | UnsafeWebViewFetch.swift:132:52:132:52 | remoteURL | semmle.label | remoteURL |
 | UnsafeWebViewFetch.swift:135:25:135:25 | remoteString | semmle.label | remoteString |
 | UnsafeWebViewFetch.swift:137:25:137:25 | remoteString | semmle.label | remoteString |
+| UnsafeWebViewFetch.swift:138:47:138:47 | remoteURL [some:0] | semmle.label | remoteURL [some:0] |
 | UnsafeWebViewFetch.swift:138:47:138:56 | ...! | semmle.label | ...! |
 | UnsafeWebViewFetch.swift:139:25:139:25 | remoteString | semmle.label | remoteString |
+| UnsafeWebViewFetch.swift:139:48:139:48 | remoteURL [some:0] | semmle.label | remoteURL [some:0] |
 | UnsafeWebViewFetch.swift:139:48:139:57 | ...! | semmle.label | ...! |
+| UnsafeWebViewFetch.swift:140:47:140:47 | remoteURL2 [some:0] | semmle.label | remoteURL2 [some:0] |
 | UnsafeWebViewFetch.swift:140:47:140:57 | ...! | semmle.label | ...! |
 | UnsafeWebViewFetch.swift:141:25:141:25 | remoteString | semmle.label | remoteString |
+| UnsafeWebViewFetch.swift:141:48:141:48 | remoteURL2 [some:0] | semmle.label | remoteURL2 [some:0] |
 | UnsafeWebViewFetch.swift:141:48:141:58 | ...! | semmle.label | ...! |
 | UnsafeWebViewFetch.swift:150:19:150:41 | call to Data.init(_:) | semmle.label | call to Data.init(_:) |
 | UnsafeWebViewFetch.swift:150:24:150:37 | .utf8 | semmle.label | .utf8 |
 | UnsafeWebViewFetch.swift:152:15:152:15 | remoteData | semmle.label | remoteData |
+| UnsafeWebViewFetch.swift:153:85:153:85 | remoteURL [some:0] | semmle.label | remoteURL [some:0] |
 | UnsafeWebViewFetch.swift:153:85:153:94 | ...! | semmle.label | ...! |
 | UnsafeWebViewFetch.swift:154:15:154:15 | remoteData | semmle.label | remoteData |
+| UnsafeWebViewFetch.swift:154:86:154:86 | remoteURL [some:0] | semmle.label | remoteURL [some:0] |
 | UnsafeWebViewFetch.swift:154:86:154:95 | ...! | semmle.label | ...! |
 | UnsafeWebViewFetch.swift:164:21:164:35 | call to getRemoteData() | semmle.label | call to getRemoteData() |
 | UnsafeWebViewFetch.swift:167:25:167:39 | call to getRemoteData() | semmle.label | call to getRemoteData() |
@@ -90,22 +126,30 @@ nodes
 | UnsafeWebViewFetch.swift:171:25:171:51 | ... .+(_:_:) ... | semmle.label | ... .+(_:_:) ... |
 | UnsafeWebViewFetch.swift:174:25:174:25 | "..." | semmle.label | "..." |
 | UnsafeWebViewFetch.swift:178:18:178:42 | call to URL.init(string:) | semmle.label | call to URL.init(string:) |
+| UnsafeWebViewFetch.swift:178:18:178:42 | call to URL.init(string:) [some:0] | semmle.label | call to URL.init(string:) [some:0] |
 | UnsafeWebViewFetch.swift:178:30:178:30 | remoteString | semmle.label | remoteString |
 | UnsafeWebViewFetch.swift:179:19:179:61 | call to URL.init(string:relativeTo:) | semmle.label | call to URL.init(string:relativeTo:) |
+| UnsafeWebViewFetch.swift:179:19:179:61 | call to URL.init(string:relativeTo:) [some:0] | semmle.label | call to URL.init(string:relativeTo:) [some:0] |
 | UnsafeWebViewFetch.swift:179:52:179:52 | remoteURL | semmle.label | remoteURL |
 | UnsafeWebViewFetch.swift:182:25:182:25 | remoteString | semmle.label | remoteString |
 | UnsafeWebViewFetch.swift:184:25:184:25 | remoteString | semmle.label | remoteString |
+| UnsafeWebViewFetch.swift:185:47:185:47 | remoteURL [some:0] | semmle.label | remoteURL [some:0] |
 | UnsafeWebViewFetch.swift:185:47:185:56 | ...! | semmle.label | ...! |
 | UnsafeWebViewFetch.swift:186:25:186:25 | remoteString | semmle.label | remoteString |
+| UnsafeWebViewFetch.swift:186:48:186:48 | remoteURL [some:0] | semmle.label | remoteURL [some:0] |
 | UnsafeWebViewFetch.swift:186:48:186:57 | ...! | semmle.label | ...! |
+| UnsafeWebViewFetch.swift:187:47:187:47 | remoteURL2 [some:0] | semmle.label | remoteURL2 [some:0] |
 | UnsafeWebViewFetch.swift:187:47:187:57 | ...! | semmle.label | ...! |
 | UnsafeWebViewFetch.swift:188:25:188:25 | remoteString | semmle.label | remoteString |
+| UnsafeWebViewFetch.swift:188:48:188:48 | remoteURL2 [some:0] | semmle.label | remoteURL2 [some:0] |
 | UnsafeWebViewFetch.swift:188:48:188:58 | ...! | semmle.label | ...! |
 | UnsafeWebViewFetch.swift:197:19:197:41 | call to Data.init(_:) | semmle.label | call to Data.init(_:) |
 | UnsafeWebViewFetch.swift:197:24:197:37 | .utf8 | semmle.label | .utf8 |
 | UnsafeWebViewFetch.swift:199:15:199:15 | remoteData | semmle.label | remoteData |
+| UnsafeWebViewFetch.swift:200:90:200:90 | remoteURL [some:0] | semmle.label | remoteURL [some:0] |
 | UnsafeWebViewFetch.swift:200:90:200:99 | ...! | semmle.label | ...! |
 | UnsafeWebViewFetch.swift:201:15:201:15 | remoteData | semmle.label | remoteData |
+| UnsafeWebViewFetch.swift:201:91:201:91 | remoteURL [some:0] | semmle.label | remoteURL [some:0] |
 | UnsafeWebViewFetch.swift:201:91:201:100 | ...! | semmle.label | ...! |
 | UnsafeWebViewFetch.swift:206:17:206:31 | call to getRemoteData() | semmle.label | call to getRemoteData() |
 | UnsafeWebViewFetch.swift:210:25:210:25 | htmlData | semmle.label | htmlData |


### PR DESCRIPTION
We have `EnumContent` in Swift dataflow now.  It's not supported in models-as-data.  This PR addresses this, and also adds proper flow through `!` for unwrapping optional content (which is a kind of `EnumContent`).

The latter part may well affect other tests I haven't run locally so I'm relying on the PR checks to catch that.  I also will do a DCA run once the tests are passing.