### PR TITLE
C++: Add `cpp/invalid-pointer-deref` false negative

### DIFF
--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/test.cpp
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/test.cpp
@@ -701,3 +701,16 @@ void test34(unsigned size) {
     int val = *p; // GOOD
   }
 }
+
+void deref(char* q) {
+  char x = *q; // $ MISSING: deref=L712->L706 deref=L713->L706
+}
+
+void test35(unsigned long size, char* q)
+{
+  char* p = new char[size];
+  char* end = p + size; // $ alloc=L711
+  if(q <= end) {
+    deref(q);
+  }
+}


### PR DESCRIPTION
This may be related to the discussion we had [here](https://github.com/github/codeql/pull/13792#issuecomment-1647460792).