### PR TITLE
Swift: Use enum content in withContiguousStorageIfAvailable model.

### DIFF
--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/Sequence.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/Sequence.qll
@@ -26,7 +26,7 @@ private class SequenceSummaries extends SummaryModelCsv {
         ";Sequence;true;joined(separator:);;;Argument[-1..0];ReturnValue;taint",
         ";Sequence;true;first(where:);;;Argument[-1];ReturnValue;taint",
         ";Sequence;true;withContiguousStorageIfAvailable(_:);;;Argument[-1];Argument[0].Parameter[0];taint",
-        ";Sequence;true;withContiguousStorageIfAvailable(_:);;;Argument[0].ReturnValue;ReturnValue;taint",
+        ";Sequence;true;withContiguousStorageIfAvailable(_:);;;Argument[0].ReturnValue;ReturnValue.OptionalSome;taint",
       ]
   }
 }

--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/Sequence.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/Sequence.qll
@@ -26,7 +26,7 @@ private class SequenceSummaries extends SummaryModelCsv {
         ";Sequence;true;joined(separator:);;;Argument[-1..0];ReturnValue;taint",
         ";Sequence;true;first(where:);;;Argument[-1];ReturnValue;taint",
         ";Sequence;true;withContiguousStorageIfAvailable(_:);;;Argument[-1];Argument[0].Parameter[0];taint",
-        ";Sequence;true;withContiguousStorageIfAvailable(_:);;;Argument[0].ReturnValue;ReturnValue.OptionalSome;taint",
+        ";Sequence;true;withContiguousStorageIfAvailable(_:);;;Argument[0].ReturnValue;ReturnValue.OptionalSome;value",
       ]
   }
 }

--- a/swift/ql/test/library-tests/dataflow/taint/libraries/string.swift
+++ b/swift/ql/test/library-tests/dataflow/taint/libraries/string.swift
@@ -639,7 +639,7 @@ func furtherTaintThroughCallbacks() {
     ptr in
     return source()
   }) {
-    sink(arg: result4) // $ MISSING: tainted=640
+    sink(arg: result4) // $ tainted=640
   }
 
   // using a non-closure function


### PR DESCRIPTION
Use enum content in `withContiguousStorageIfAvailable` model.  This (and similar models to come) was the motivation for https://github.com/github/codeql/pull/13795/ , but could not be done in https://github.com/github/codeql/pull/12416/ as that was not available then.