### PR TITLE
Java: Automodel Fix, Prevent Some Erroneous Endpoints

### DIFF
--- a/java/ql/src/Telemetry/AutomodelApplicationModeCharacteristics.qll
+++ b/java/ql/src/Telemetry/AutomodelApplicationModeCharacteristics.qll
@@ -88,7 +88,7 @@ module ApplicationCandidatesImpl implements SharedCharacteristics::CandidateSig 
   predicate isNeutral(Endpoint e) {
     exists(string package, string type, string name, string signature |
       sinkSpec(e, package, type, name, signature, _, _) and
-      ExternalFlow::neutralModel(package, type, name, [signature, ""], _, _)
+      ExternalFlow::neutralModel(package, type, name, [signature, ""], "sink", _)
     )
   }
 

--- a/java/ql/src/Telemetry/AutomodelFrameworkModeCharacteristics.qll
+++ b/java/ql/src/Telemetry/AutomodelFrameworkModeCharacteristics.qll
@@ -60,7 +60,7 @@ module FrameworkCandidatesImpl implements SharedCharacteristics::CandidateSig {
   predicate isNeutral(Endpoint e) {
     exists(string package, string type, string name, string signature |
       sinkSpec(e, package, type, name, signature, _, _) and
-      ExternalFlow::neutralModel(package, type, name, [signature, ""], _, _)
+      ExternalFlow::neutralModel(package, type, name, [signature, ""], "sink", _)
     )
   }
 


### PR DESCRIPTION
The problem was that endpoints that are modeled as both sinks, as well as _not a summary_ were treated as erroneous. In fact, this is not a contradiction at all.
