### PR TITLE
Dataflow: MergePathGraph3 signature fix

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlow.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlow.qll
@@ -429,5 +429,22 @@ module MergePathGraph3<
   /**
    * Provides the query predicates needed to include a graph in a path-problem query.
    */
-  module PathGraph = Merged::PathGraph;
+  module PathGraph implements PathGraphSig<PathNode> {
+    /** Holds if `(a,b)` is an edge in the graph of data flow path explanations. */
+    query predicate edges(PathNode a, PathNode b) { Merged::PathGraph::edges(a, b) }
+
+    /** Holds if `n` is a node in the graph of data flow path explanations. */
+    query predicate nodes(PathNode n, string key, string val) {
+      Merged::PathGraph::nodes(n, key, val)
+    }
+
+    /**
+     * Holds if `(arg, par, ret, out)` forms a subpath-tuple, that is, flow through
+     * a subpath between `par` and `ret` with the connecting edges `arg -> par` and
+     * `ret -> out` is summarized as the edge `arg -> out`.
+     */
+    query predicate subpaths(PathNode arg, PathNode par, PathNode ret, PathNode out) {
+      Merged::PathGraph::subpaths(arg, par, ret, out)
+    }
+  }
 }

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlow.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlow.qll
@@ -429,5 +429,22 @@ module MergePathGraph3<
   /**
    * Provides the query predicates needed to include a graph in a path-problem query.
    */
-  module PathGraph = Merged::PathGraph;
+  module PathGraph implements PathGraphSig<PathNode> {
+    /** Holds if `(a,b)` is an edge in the graph of data flow path explanations. */
+    query predicate edges(PathNode a, PathNode b) { Merged::PathGraph::edges(a, b) }
+
+    /** Holds if `n` is a node in the graph of data flow path explanations. */
+    query predicate nodes(PathNode n, string key, string val) {
+      Merged::PathGraph::nodes(n, key, val)
+    }
+
+    /**
+     * Holds if `(arg, par, ret, out)` forms a subpath-tuple, that is, flow through
+     * a subpath between `par` and `ret` with the connecting edges `arg -> par` and
+     * `ret -> out` is summarized as the edge `arg -> out`.
+     */
+    query predicate subpaths(PathNode arg, PathNode par, PathNode ret, PathNode out) {
+      Merged::PathGraph::subpaths(arg, par, ret, out)
+    }
+  }
 }

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlow.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlow.qll
@@ -429,5 +429,22 @@ module MergePathGraph3<
   /**
    * Provides the query predicates needed to include a graph in a path-problem query.
    */
-  module PathGraph = Merged::PathGraph;
+  module PathGraph implements PathGraphSig<PathNode> {
+    /** Holds if `(a,b)` is an edge in the graph of data flow path explanations. */
+    query predicate edges(PathNode a, PathNode b) { Merged::PathGraph::edges(a, b) }
+
+    /** Holds if `n` is a node in the graph of data flow path explanations. */
+    query predicate nodes(PathNode n, string key, string val) {
+      Merged::PathGraph::nodes(n, key, val)
+    }
+
+    /**
+     * Holds if `(arg, par, ret, out)` forms a subpath-tuple, that is, flow through
+     * a subpath between `par` and `ret` with the connecting edges `arg -> par` and
+     * `ret -> out` is summarized as the edge `arg -> out`.
+     */
+    query predicate subpaths(PathNode arg, PathNode par, PathNode ret, PathNode out) {
+      Merged::PathGraph::subpaths(arg, par, ret, out)
+    }
+  }
 }

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlow.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlow.qll
@@ -429,5 +429,22 @@ module MergePathGraph3<
   /**
    * Provides the query predicates needed to include a graph in a path-problem query.
    */
-  module PathGraph = Merged::PathGraph;
+  module PathGraph implements PathGraphSig<PathNode> {
+    /** Holds if `(a,b)` is an edge in the graph of data flow path explanations. */
+    query predicate edges(PathNode a, PathNode b) { Merged::PathGraph::edges(a, b) }
+
+    /** Holds if `n` is a node in the graph of data flow path explanations. */
+    query predicate nodes(PathNode n, string key, string val) {
+      Merged::PathGraph::nodes(n, key, val)
+    }
+
+    /**
+     * Holds if `(arg, par, ret, out)` forms a subpath-tuple, that is, flow through
+     * a subpath between `par` and `ret` with the connecting edges `arg -> par` and
+     * `ret -> out` is summarized as the edge `arg -> out`.
+     */
+    query predicate subpaths(PathNode arg, PathNode par, PathNode ret, PathNode out) {
+      Merged::PathGraph::subpaths(arg, par, ret, out)
+    }
+  }
 }

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlow.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlow.qll
@@ -429,5 +429,22 @@ module MergePathGraph3<
   /**
    * Provides the query predicates needed to include a graph in a path-problem query.
    */
-  module PathGraph = Merged::PathGraph;
+  module PathGraph implements PathGraphSig<PathNode> {
+    /** Holds if `(a,b)` is an edge in the graph of data flow path explanations. */
+    query predicate edges(PathNode a, PathNode b) { Merged::PathGraph::edges(a, b) }
+
+    /** Holds if `n` is a node in the graph of data flow path explanations. */
+    query predicate nodes(PathNode n, string key, string val) {
+      Merged::PathGraph::nodes(n, key, val)
+    }
+
+    /**
+     * Holds if `(arg, par, ret, out)` forms a subpath-tuple, that is, flow through
+     * a subpath between `par` and `ret` with the connecting edges `arg -> par` and
+     * `ret -> out` is summarized as the edge `arg -> out`.
+     */
+    query predicate subpaths(PathNode arg, PathNode par, PathNode ret, PathNode out) {
+      Merged::PathGraph::subpaths(arg, par, ret, out)
+    }
+  }
 }

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlow.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlow.qll
@@ -429,5 +429,22 @@ module MergePathGraph3<
   /**
    * Provides the query predicates needed to include a graph in a path-problem query.
    */
-  module PathGraph = Merged::PathGraph;
+  module PathGraph implements PathGraphSig<PathNode> {
+    /** Holds if `(a,b)` is an edge in the graph of data flow path explanations. */
+    query predicate edges(PathNode a, PathNode b) { Merged::PathGraph::edges(a, b) }
+
+    /** Holds if `n` is a node in the graph of data flow path explanations. */
+    query predicate nodes(PathNode n, string key, string val) {
+      Merged::PathGraph::nodes(n, key, val)
+    }
+
+    /**
+     * Holds if `(arg, par, ret, out)` forms a subpath-tuple, that is, flow through
+     * a subpath between `par` and `ret` with the connecting edges `arg -> par` and
+     * `ret -> out` is summarized as the edge `arg -> out`.
+     */
+    query predicate subpaths(PathNode arg, PathNode par, PathNode ret, PathNode out) {
+      Merged::PathGraph::subpaths(arg, par, ret, out)
+    }
+  }
 }

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlow.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlow.qll
@@ -429,5 +429,22 @@ module MergePathGraph3<
   /**
    * Provides the query predicates needed to include a graph in a path-problem query.
    */
-  module PathGraph = Merged::PathGraph;
+  module PathGraph implements PathGraphSig<PathNode> {
+    /** Holds if `(a,b)` is an edge in the graph of data flow path explanations. */
+    query predicate edges(PathNode a, PathNode b) { Merged::PathGraph::edges(a, b) }
+
+    /** Holds if `n` is a node in the graph of data flow path explanations. */
+    query predicate nodes(PathNode n, string key, string val) {
+      Merged::PathGraph::nodes(n, key, val)
+    }
+
+    /**
+     * Holds if `(arg, par, ret, out)` forms a subpath-tuple, that is, flow through
+     * a subpath between `par` and `ret` with the connecting edges `arg -> par` and
+     * `ret -> out` is summarized as the edge `arg -> out`.
+     */
+    query predicate subpaths(PathNode arg, PathNode par, PathNode ret, PathNode out) {
+      Merged::PathGraph::subpaths(arg, par, ret, out)
+    }
+  }
 }

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlow.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlow.qll
@@ -429,5 +429,22 @@ module MergePathGraph3<
   /**
    * Provides the query predicates needed to include a graph in a path-problem query.
    */
-  module PathGraph = Merged::PathGraph;
+  module PathGraph implements PathGraphSig<PathNode> {
+    /** Holds if `(a,b)` is an edge in the graph of data flow path explanations. */
+    query predicate edges(PathNode a, PathNode b) { Merged::PathGraph::edges(a, b) }
+
+    /** Holds if `n` is a node in the graph of data flow path explanations. */
+    query predicate nodes(PathNode n, string key, string val) {
+      Merged::PathGraph::nodes(n, key, val)
+    }
+
+    /**
+     * Holds if `(arg, par, ret, out)` forms a subpath-tuple, that is, flow through
+     * a subpath between `par` and `ret` with the connecting edges `arg -> par` and
+     * `ret -> out` is summarized as the edge `arg -> out`.
+     */
+    query predicate subpaths(PathNode arg, PathNode par, PathNode ret, PathNode out) {
+      Merged::PathGraph::subpaths(arg, par, ret, out)
+    }
+  }
 }


### PR DESCRIPTION
`MergePathGraph3::PathGraph` wasn't compatible with `MergePathGraph3::PathNode`. This created a problem when making a `MergePathGraph3` of a `MergePathGraph3`, for example.