### PR TITLE
Java: Support Argument[this] and parameters of bodiless interface methods in framework mode metadata extraction

### DIFF
--- a/java/ql/src/Telemetry/AutomodelFrameworkModeCharacteristics.qll
+++ b/java/ql/src/Telemetry/AutomodelFrameworkModeCharacteristics.qll
@@ -125,13 +125,19 @@ class FrameworkModeMetadataExtractor extends string {
     string input, string parameterName
   ) {
     exists(Callable callable, int paramIdx |
-      e.asParameter() = callable.getParameter(paramIdx) and
+      (
+        e.(DataFlow::ExplicitParameterNode).asParameter() = callable.getParameter(paramIdx) and
+        parameterName = e.asParameter().getName()
+        or
+        e.(DataFlow::InstanceParameterNode).getCallable() = callable and
+        paramIdx = -1 and
+        parameterName = "this"
+      ) and
       input = AutomodelJavaUtil::getArgumentForIndex(paramIdx) and
       package = callable.getDeclaringType().getPackage().getName() and
       type = callable.getDeclaringType().getErasure().(RefType).nestedName() and
       subtypes = AutomodelJavaUtil::considerSubtypes(callable).toString() and
       name = callable.getName() and
-      parameterName = e.asParameter().getName() and
       signature = ExternalFlow::paramsString(callable)
     )
   }

--- a/java/ql/src/Telemetry/AutomodelFrameworkModeCharacteristics.qll
+++ b/java/ql/src/Telemetry/AutomodelFrameworkModeCharacteristics.qll
@@ -254,7 +254,7 @@ private class NotAModelApiParameter extends CharacteristicsImpl::UninterestingTo
   NotAModelApiParameter() { this = "not a model API parameter" }
 
   override predicate appliesToEndpoint(Endpoint e) {
-    not exists(ModelExclusions::ModelApi api | api = e.getEnclosingCallable())
+    not e.getEnclosingCallable() instanceof ModelExclusions::ModelApi
   }
 }
 

--- a/java/ql/src/Telemetry/AutomodelFrameworkModeCharacteristics.qll
+++ b/java/ql/src/Telemetry/AutomodelFrameworkModeCharacteristics.qll
@@ -48,16 +48,12 @@ abstract class FrameworkModeEndpoint extends TFrameworkModeEndpoint {
 
   abstract Top asTop();
 
-  string toString() {
-    result = this.asTop().toString()
-  }
+  string toString() { result = this.asTop().toString() }
 
-  Location getLocation() {
-    result = this.asTop().getLocation()
-  }
+  Location getLocation() { result = this.asTop().getLocation() }
 }
 
-class ExplicitParameterEndpoint extends FrameworkModeEndpoint, TExplicitParameter  {
+class ExplicitParameterEndpoint extends FrameworkModeEndpoint, TExplicitParameter {
   Parameter param;
 
   ExplicitParameterEndpoint() { this = TExplicitParameter(param) }
@@ -68,9 +64,7 @@ class ExplicitParameterEndpoint extends FrameworkModeEndpoint, TExplicitParamete
 
   override Callable getEnclosingCallable() { result = param.getCallable() }
 
-  override Top asTop() {
-    result = param 
-  }
+  override Top asTop() { result = param }
 }
 
 class QualifierEndpoint extends FrameworkModeEndpoint, TQualifier {
@@ -84,9 +78,7 @@ class QualifierEndpoint extends FrameworkModeEndpoint, TQualifier {
 
   override Callable getEnclosingCallable() { result = callable }
 
-  override Top asTop() {
-    result = callable
-  }
+  override Top asTop() { result = callable }
 }
 
 /**

--- a/java/ql/src/Telemetry/AutomodelFrameworkModeCharacteristics.qll
+++ b/java/ql/src/Telemetry/AutomodelFrameworkModeCharacteristics.qll
@@ -262,7 +262,7 @@ private class NotAModelApiParameter extends CharacteristicsImpl::UninterestingTo
   NotAModelApiParameter() { this = "not a model API parameter" }
 
   override predicate appliesToEndpoint(Endpoint e) {
-    not exists(ModelExclusions::ModelApi api | api.getAParameter() = e.asTop())
+    not exists(ModelExclusions::ModelApi api | api = e.getEnclosingCallable())
   }
 }
 


### PR DESCRIPTION
1. There was an unintended limitation to only consider `ExplicitParameterNode`s in framework mode, but skipped the `this` parameter. This PR fixes the problem. I'll add a test case to the currently open [test PR](https://github.com/github/codeql/pull/13788) once this is merged.
2. In framework mode we also skipped the parameters of interface methods without bodies — this PR fixes the problem as well. However, I'm not 100% sure this is the best way to fix this (it might have unintended consequences) and would appreciate thoughts from the Java team. We could, for instance, try to keep our changes to the `DataFlow::ParameterNode` types local to the automodel code (if needed).