### PR TITLE
Docs: Fix indentation in tutorial examples

### DIFF
--- a/docs/codeql/writing-codeql-queries/catch-the-fire-starter.rst
+++ b/docs/codeql/writing-codeql-queries/catch-the-fire-starter.rst
@@ -168,16 +168,16 @@ Exercise 1
    predicate isSouthern(Person p) { p.getLocation() = "south" }
 
    class Southerner extends Person {
-   /* the characteristic predicate */
-   Southerner() { isSouthern(this) }
+     /* the characteristic predicate */
+     Southerner() { isSouthern(this) }
    }
 
    class Child extends Person {
-   /* the characteristic predicate */
-   Child() { this.getAge() < 10 }
+     /* the characteristic predicate */
+     Child() { this.getAge() < 10 }
 
-   /* a member predicate */
-   override predicate isAllowedIn(string region) { region = this.getLocation() }
+     /* a member predicate */
+     override predicate isAllowedIn(string region) { region = this.getLocation() }
    }
 
    from Southerner s
@@ -194,16 +194,16 @@ Exercise 2
    predicate isSouthern(Person p) { p.getLocation() = "south" }
 
    class Southerner extends Person {
-   /* the characteristic predicate */
-   Southerner() { isSouthern(this) }
+     /* the characteristic predicate */
+     Southerner() { isSouthern(this) }
    }
 
    class Child extends Person {
-   /* the characteristic predicate */
-   Child() { this.getAge() < 10 }
+     /* the characteristic predicate */
+     Child() { this.getAge() < 10 }
 
-   /* a member predicate */
-   override predicate isAllowedIn(string region) { region = this.getLocation() }
+     /* a member predicate */
+     override predicate isAllowedIn(string region) { region = this.getLocation() }
    }
 
    predicate isBald(Person p) { not exists(string c | p.getHairColor() = c) }

--- a/docs/codeql/writing-codeql-queries/crown-the-rightful-heir.rst
+++ b/docs/codeql/writing-codeql-queries/crown-the-rightful-heir.rst
@@ -183,8 +183,8 @@ Exercise 1
 
    from Person p
    where
-   not p.isDeceased() and
-   p = relativeOf("King Basil")
+     not p.isDeceased() and
+     p = relativeOf("King Basil")
    select p
 
 Exercise 2
@@ -197,14 +197,14 @@ Exercise 2
    Person relativeOf(Person p) { parentOf*(result) = parentOf*(p) }
 
    predicate hasCriminalRecord(Person p) {
-   p = "Hester" or
-   p = "Hugh" or
-   p = "Charlie"
+     p = "Hester" or
+     p = "Hugh" or
+     p = "Charlie"
    }
 
    from Person p
    where
-   not p.isDeceased() and
-   p = relativeOf("King Basil") and
-   not hasCriminalRecord(p)
+     not p.isDeceased() and
+     p = relativeOf("King Basil") and
+     not hasCriminalRecord(p)
    select p

--- a/docs/codeql/writing-codeql-queries/find-the-thief.rst
+++ b/docs/codeql/writing-codeql-queries/find-the-thief.rst
@@ -307,14 +307,14 @@ Exercise 1
 
    from Person t
    where
-   /* 1 */ t.getHeight() > 150 and
-   /* 2 */ not t.getHairColor() = "blond" and
-   /* 3 */ exists (string c | t.getHairColor() = c) and
-   /* 4 */ not t.getAge() < 30 and
-   /* 5 */ t.getLocation() = "east" and
-   /* 6 */ (t.getHairColor() = "black" or t.getHairColor() = "brown") and
-   /* 7 */ not (t.getHeight() > 180 and t.getHeight() < 190) and
-   /* 8 */ exists(Person p | p.getAge() > t.getAge())
+     /* 1 */ t.getHeight() > 150 and
+     /* 2 */ not t.getHairColor() = "blond" and
+     /* 3 */ exists (string c | t.getHairColor() = c) and
+     /* 4 */ not t.getAge() < 30 and
+     /* 5 */ t.getLocation() = "east" and
+     /* 6 */ (t.getHairColor() = "black" or t.getHairColor() = "brown") and
+     /* 7 */ not (t.getHeight() > 180 and t.getHeight() < 190) and
+     /* 8 */ exists(Person p | p.getAge() > t.getAge())
    select t
 
 Exercise 2
@@ -326,16 +326,16 @@ Exercise 2
 
    from Person t
    where
-   /* 1 */ t.getHeight() > 150 and
-   /* 2 */ not t.getHairColor() = "blond" and
-   /* 3 */ exists (string c | t.getHairColor() = c) and
-   /* 4 */ not t.getAge() < 30 and
-   /* 5 */ t.getLocation() = "east" and
-   /* 6 */ (t.getHairColor() = "black" or t.getHairColor() = "brown") and
-   /* 7 */ not (t.getHeight() > 180 and t.getHeight() < 190) and
-   /* 8 */ exists(Person p | p.getAge() > t.getAge()) and
-   /* 9 */ not t = max(Person p | | p order by p.getHeight()) and
-   /* 10 */ t.getHeight() < avg(float i | exists(Person p | p.getHeight() = i) | i) and
-   /* 11 */ t = max(Person p | p.getLocation() = "east" | p order by p.getAge())
+     /* 1 */ t.getHeight() > 150 and
+     /* 2 */ not t.getHairColor() = "blond" and
+     /* 3 */ exists (string c | t.getHairColor() = c) and
+     /* 4 */ not t.getAge() < 30 and
+     /* 5 */ t.getLocation() = "east" and
+     /* 6 */ (t.getHairColor() = "black" or t.getHairColor() = "brown") and
+     /* 7 */ not (t.getHeight() > 180 and t.getHeight() < 190) and
+     /* 8 */ exists(Person p | p.getAge() > t.getAge()) and
+     /* 9 */ not t = max(Person p | | p order by p.getHeight()) and
+     /* 10 */ t.getHeight() < avg(float i | exists(Person p | p.getHeight() = i) | i) and
+     /* 11 */ t = max(Person p | p.getLocation() = "east" | p order by p.getAge())
    select "The thief is " + t + "!"
    


### PR DESCRIPTION
Minor fix to the indentation in the answers to some of the QL tutorials! 📝
For example, the current unindented answers on https://codeql.github.com/docs/writing-codeql-queries/crown-the-rightful-heir/#exercise-2 are difficult to read 📖 

