### PR TITLE
Backport: Compiler error messages changed in Go 1.20.6

### DIFF
--- a/go/ql/test/query-tests/Diagnostics/CONSISTENCY/UnexpectedFrontendErrors.expected
+++ b/go/ql/test/query-tests/Diagnostics/CONSISTENCY/UnexpectedFrontendErrors.expected
@@ -5,5 +5,4 @@
 | bad.go:3:5:3:5 | expected 'IDENT', found newline |
 | bad.go:5:1:5:1 | expected ';', found wnvwun |
 | badimport.go:6:2:6:2 | invalid import path (invalid character U+007B '{') |
-| badimport.go:6:2:6:2 | malformed import path "github.com/pkg{}": invalid char '{' |
 | type.go:11:9:11:9 | cannot use v (variable of type V) as T value in argument to takesT |

--- a/go/ql/test/query-tests/Diagnostics/ExtractionErrors.expected
+++ b/go/ql/test/query-tests/Diagnostics/ExtractionErrors.expected
@@ -1,5 +1,4 @@
 | Extraction failed in query-tests/Diagnostics/badimport.go with error invalid import path (invalid character U+007B '{') | 2 |
-| Extraction failed in query-tests/Diagnostics/badimport.go with error malformed import path "github.com/pkg{}": invalid char '{' | 2 |
 | Extraction failed in query-tests/Diagnostics/type.go with error cannot use v (variable of type V) as T value in argument to takesT | 2 |
 | Extraction failed with error expected ';', found wnvwun | 2 |
 | Extraction failed with error expected 'IDENT', found newline | 2 |


### PR DESCRIPTION
This is a backport of https://github.com/github/codeql/pull/13824.