### PR TITLE
Don't treat logrus' WithContext method as a logging function

### DIFF
--- a/go/ql/lib/change-notes/2023-07-28-logrus-with-context.md
+++ b/go/ql/lib/change-notes/2023-07-28-logrus-with-context.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Logrus' `WithContext` methods are no longer treated as if they output the values stored in that context to a log message.

--- a/go/ql/lib/semmle/go/frameworks/Logrus.qll
+++ b/go/ql/lib/semmle/go/frameworks/Logrus.qll
@@ -15,9 +15,7 @@ module Logrus {
   }
 
   bindingset[result]
-  private string getAnEntryUpdatingMethodName() {
-    result.regexpMatch("With(Error|Fields?|Time)")
-  }
+  private string getAnEntryUpdatingMethodName() { result.regexpMatch("With(Error|Fields?|Time)") }
 
   private class LogFunction extends Function {
     LogFunction() {

--- a/go/ql/lib/semmle/go/frameworks/Logrus.qll
+++ b/go/ql/lib/semmle/go/frameworks/Logrus.qll
@@ -16,7 +16,7 @@ module Logrus {
 
   bindingset[result]
   private string getAnEntryUpdatingMethodName() {
-    result.regexpMatch("With(Context|Error|Fields?|Time)")
+    result.regexpMatch("With(Error|Fields?|Time)")
   }
 
   private class LogFunction extends Function {

--- a/go/ql/test/library-tests/semmle/go/concepts/LoggerCall/logrus.go
+++ b/go/ql/test/library-tests/semmle/go/concepts/LoggerCall/logrus.go
@@ -18,7 +18,7 @@ func logrusCalls() {
 	var fields logrus.Fields = nil
 	var fn logrus.LogFunction = nil
 	var ctx context.Context
-	tmp := logrus.WithContext(ctx)  // $ logger=ctx
+	tmp := logrus.WithContext(ctx)  // ctx isn't output, so no match here
 	tmp.Debugf(fmt, text)           // $ logger=fmt logger=text
 	tmp = logrus.WithError(err)     // $ logger=err
 	tmp.Warn(text)                  // $ logger=text


### PR DESCRIPTION
This isn't output by the default formatters (though a custom formatter could potentially output things stored in it)

Fixes https://github.com/github/codeql/issues/13828