### PR TITLE
C++: Revert #13792

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/security/InvalidPointerDereference/InvalidPointerToDereference.qll
+++ b/cpp/ql/lib/semmle/code/cpp/security/InvalidPointerDereference/InvalidPointerToDereference.qll
@@ -171,11 +171,9 @@ private predicate invalidPointerToDerefSource(
     // `deltaDerefSourceAndPai` is the constant difference between the pointer-arithmetic instruction
     // and the instruction computing the address for which we will search for a dereference.
     AllocToInvalidPointer::pointerAddInstructionHasBounds(allocSource, pai, _, rhsSizeDelta) and
-    // pai <= derefSource + deltaDerefSourceAndPai and deltaDerefSourceAndPai <= 0 is equivalent to
-    // derefSource >= pai + deltaDerefSourceAndPai and deltaDerefSourceAndPai >= 0
-    bounded1(pai, derefSource.asInstruction(), deltaDerefSourceAndPai) and
-    deltaDerefSourceAndPai <= 0 and
-    // TODO: This condition will go away once #13725 is merged, and then we can make `Barrier2`
+    bounded2(derefSource.asInstruction(), pai, deltaDerefSourceAndPai) and
+    deltaDerefSourceAndPai >= 0 and
+    // TODO: This condition will go away once #13725 is merged, and then we can make `SizeBarrier`
     // private to `AllocationToInvalidPointer.qll`.
     not derefSource.getBasicBlock() =
       AllocToInvalidPointer::SizeBarrier::getABarrierBlock(rhsSizeDelta)

--- a/cpp/ql/lib/semmle/code/cpp/security/InvalidPointerDereference/RangeAnalysisUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/security/InvalidPointerDereference/RangeAnalysisUtil.qll
@@ -35,5 +35,14 @@ bindingset[i]
 pragma[inline_late]
 predicate bounded1(Instruction i, Instruction b, int delta) { boundedImpl(i, b, delta) }
 
+/**
+ * Holds if `i <= b + delta`.
+ *
+ * This predicate enforces a join-order that ensures that `b` has already been bound.
+ */
+bindingset[b]
+pragma[inline_late]
+predicate bounded2(Instruction i, Instruction b, int delta) { boundedImpl(i, b, delta) }
+
 /** Holds if `i <= b + delta`. */
 predicate bounded = boundedImpl/3;

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/InvalidPointerDeref.expected
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/InvalidPointerDeref.expected
@@ -132,6 +132,8 @@ edges
 | test.cpp:304:15:304:26 | new[] | test.cpp:308:5:308:29 | ... = ... |
 | test.cpp:355:14:355:27 | new[] | test.cpp:356:15:356:23 | ... + ... |
 | test.cpp:355:14:355:27 | new[] | test.cpp:356:15:356:23 | ... + ... |
+| test.cpp:355:14:355:27 | new[] | test.cpp:357:24:357:30 | ... + ... |
+| test.cpp:355:14:355:27 | new[] | test.cpp:357:24:357:30 | ... + ... |
 | test.cpp:355:14:355:27 | new[] | test.cpp:358:14:358:26 | * ... |
 | test.cpp:355:14:355:27 | new[] | test.cpp:359:14:359:32 | * ... |
 | test.cpp:356:15:356:23 | ... + ... | test.cpp:356:15:356:23 | ... + ... |
@@ -139,46 +141,88 @@ edges
 | test.cpp:356:15:356:23 | ... + ... | test.cpp:358:14:358:26 | * ... |
 | test.cpp:356:15:356:23 | ... + ... | test.cpp:359:14:359:32 | * ... |
 | test.cpp:356:15:356:23 | ... + ... | test.cpp:359:14:359:32 | * ... |
+| test.cpp:357:24:357:30 | ... + ... | test.cpp:357:24:357:30 | ... + ... |
+| test.cpp:357:24:357:30 | ... + ... | test.cpp:358:14:358:26 | * ... |
+| test.cpp:357:24:357:30 | ... + ... | test.cpp:358:14:358:26 | * ... |
+| test.cpp:357:24:357:30 | ... + ... | test.cpp:359:14:359:32 | * ... |
+| test.cpp:357:24:357:30 | ... + ... | test.cpp:359:14:359:32 | * ... |
 | test.cpp:377:14:377:27 | new[] | test.cpp:378:15:378:23 | ... + ... |
 | test.cpp:377:14:377:27 | new[] | test.cpp:378:15:378:23 | ... + ... |
+| test.cpp:377:14:377:27 | new[] | test.cpp:381:5:381:9 | ... ++ |
+| test.cpp:377:14:377:27 | new[] | test.cpp:381:5:381:9 | ... ++ |
 | test.cpp:377:14:377:27 | new[] | test.cpp:384:13:384:16 | * ... |
 | test.cpp:378:15:378:23 | ... + ... | test.cpp:378:15:378:23 | ... + ... |
 | test.cpp:378:15:378:23 | ... + ... | test.cpp:384:13:384:16 | * ... |
 | test.cpp:378:15:378:23 | ... + ... | test.cpp:384:13:384:16 | * ... |
+| test.cpp:381:5:381:9 | ... ++ | test.cpp:381:5:381:9 | ... ++ |
+| test.cpp:381:5:381:9 | ... ++ | test.cpp:384:13:384:16 | * ... |
 | test.cpp:410:14:410:27 | new[] | test.cpp:411:15:411:23 | & ... |
 | test.cpp:410:14:410:27 | new[] | test.cpp:411:15:411:23 | & ... |
+| test.cpp:410:14:410:27 | new[] | test.cpp:413:5:413:8 | ... ++ |
+| test.cpp:410:14:410:27 | new[] | test.cpp:413:5:413:8 | ... ++ |
 | test.cpp:410:14:410:27 | new[] | test.cpp:415:7:415:15 | ... = ... |
 | test.cpp:411:15:411:23 | & ... | test.cpp:411:15:411:23 | & ... |
 | test.cpp:411:15:411:23 | & ... | test.cpp:415:7:415:15 | ... = ... |
 | test.cpp:411:15:411:23 | & ... | test.cpp:415:7:415:15 | ... = ... |
+| test.cpp:413:5:413:8 | ... ++ | test.cpp:413:5:413:8 | ... ++ |
+| test.cpp:413:5:413:8 | ... ++ | test.cpp:415:7:415:15 | ... = ... |
+| test.cpp:413:5:413:8 | ... ++ | test.cpp:415:7:415:15 | ... = ... |
 | test.cpp:421:14:421:27 | new[] | test.cpp:422:15:422:23 | & ... |
 | test.cpp:421:14:421:27 | new[] | test.cpp:422:15:422:23 | & ... |
+| test.cpp:421:14:421:27 | new[] | test.cpp:424:5:424:8 | ... ++ |
+| test.cpp:421:14:421:27 | new[] | test.cpp:424:5:424:8 | ... ++ |
 | test.cpp:421:14:421:27 | new[] | test.cpp:426:7:426:15 | ... = ... |
 | test.cpp:422:15:422:23 | & ... | test.cpp:422:15:422:23 | & ... |
 | test.cpp:422:15:422:23 | & ... | test.cpp:426:7:426:15 | ... = ... |
 | test.cpp:422:15:422:23 | & ... | test.cpp:426:7:426:15 | ... = ... |
+| test.cpp:424:5:424:8 | ... ++ | test.cpp:424:5:424:8 | ... ++ |
+| test.cpp:424:5:424:8 | ... ++ | test.cpp:426:7:426:15 | ... = ... |
+| test.cpp:424:5:424:8 | ... ++ | test.cpp:426:7:426:15 | ... = ... |
 | test.cpp:432:14:432:27 | new[] | test.cpp:433:15:433:23 | & ... |
 | test.cpp:432:14:432:27 | new[] | test.cpp:433:15:433:23 | & ... |
+| test.cpp:432:14:432:27 | new[] | test.cpp:436:5:436:8 | ... ++ |
+| test.cpp:432:14:432:27 | new[] | test.cpp:436:5:436:8 | ... ++ |
 | test.cpp:432:14:432:27 | new[] | test.cpp:438:7:438:15 | ... = ... |
 | test.cpp:433:15:433:23 | & ... | test.cpp:433:15:433:23 | & ... |
 | test.cpp:433:15:433:23 | & ... | test.cpp:438:7:438:15 | ... = ... |
 | test.cpp:433:15:433:23 | & ... | test.cpp:438:7:438:15 | ... = ... |
+| test.cpp:436:5:436:8 | ... ++ | test.cpp:436:5:436:8 | ... ++ |
+| test.cpp:436:5:436:8 | ... ++ | test.cpp:438:7:438:15 | ... = ... |
+| test.cpp:436:5:436:8 | ... ++ | test.cpp:438:7:438:15 | ... = ... |
 | test.cpp:444:14:444:27 | new[] | test.cpp:445:15:445:23 | & ... |
 | test.cpp:444:14:444:27 | new[] | test.cpp:445:15:445:23 | & ... |
+| test.cpp:444:14:444:27 | new[] | test.cpp:448:5:448:8 | ... ++ |
+| test.cpp:444:14:444:27 | new[] | test.cpp:448:5:448:8 | ... ++ |
 | test.cpp:444:14:444:27 | new[] | test.cpp:450:7:450:15 | ... = ... |
 | test.cpp:445:15:445:23 | & ... | test.cpp:445:15:445:23 | & ... |
 | test.cpp:445:15:445:23 | & ... | test.cpp:450:7:450:15 | ... = ... |
 | test.cpp:445:15:445:23 | & ... | test.cpp:450:7:450:15 | ... = ... |
+| test.cpp:448:5:448:8 | ... ++ | test.cpp:448:5:448:8 | ... ++ |
+| test.cpp:448:5:448:8 | ... ++ | test.cpp:450:7:450:15 | ... = ... |
+| test.cpp:448:5:448:8 | ... ++ | test.cpp:450:7:450:15 | ... = ... |
 | test.cpp:480:14:480:27 | new[] | test.cpp:481:15:481:23 | & ... |
 | test.cpp:480:14:480:27 | new[] | test.cpp:481:15:481:23 | & ... |
+| test.cpp:480:14:480:27 | new[] | test.cpp:484:5:484:8 | ... ++ |
+| test.cpp:480:14:480:27 | new[] | test.cpp:484:5:484:8 | ... ++ |
 | test.cpp:480:14:480:27 | new[] | test.cpp:486:7:486:15 | ... = ... |
 | test.cpp:481:15:481:23 | & ... | test.cpp:481:15:481:23 | & ... |
 | test.cpp:481:15:481:23 | & ... | test.cpp:486:7:486:15 | ... = ... |
 | test.cpp:481:15:481:23 | & ... | test.cpp:486:7:486:15 | ... = ... |
+| test.cpp:484:5:484:8 | ... ++ | test.cpp:484:5:484:8 | ... ++ |
+| test.cpp:484:5:484:8 | ... ++ | test.cpp:486:7:486:15 | ... = ... |
+| test.cpp:484:5:484:8 | ... ++ | test.cpp:486:7:486:15 | ... = ... |
 | test.cpp:543:14:543:27 | new[] | test.cpp:548:5:548:19 | ... = ... |
 | test.cpp:554:14:554:27 | new[] | test.cpp:559:5:559:19 | ... = ... |
 | test.cpp:642:14:642:31 | new[] | test.cpp:647:5:647:19 | ... = ... |
+| test.cpp:652:14:652:27 | new[] | test.cpp:656:3:656:6 | ... ++ |
+| test.cpp:652:14:652:27 | new[] | test.cpp:656:3:656:6 | ... ++ |
+| test.cpp:652:14:652:27 | new[] | test.cpp:662:3:662:11 | ... = ... |
+| test.cpp:656:3:656:6 | ... ++ | test.cpp:656:3:656:6 | ... ++ |
+| test.cpp:656:3:656:6 | ... ++ | test.cpp:662:3:662:11 | ... = ... |
+| test.cpp:656:3:656:6 | ... ++ | test.cpp:662:3:662:11 | ... = ... |
 | test.cpp:667:14:667:31 | new[] | test.cpp:675:7:675:23 | ... = ... |
+| test.cpp:695:13:695:26 | new[] | test.cpp:698:5:698:10 | ... += ... |
+| test.cpp:698:5:698:10 | ... += ... | test.cpp:701:15:701:16 | * ... |
 nodes
 | test.cpp:4:15:4:20 | call to malloc | semmle.label | call to malloc |
 | test.cpp:5:15:5:22 | ... + ... | semmle.label | ... + ... |
@@ -276,31 +320,45 @@ nodes
 | test.cpp:355:14:355:27 | new[] | semmle.label | new[] |
 | test.cpp:356:15:356:23 | ... + ... | semmle.label | ... + ... |
 | test.cpp:356:15:356:23 | ... + ... | semmle.label | ... + ... |
+| test.cpp:357:24:357:30 | ... + ... | semmle.label | ... + ... |
+| test.cpp:357:24:357:30 | ... + ... | semmle.label | ... + ... |
 | test.cpp:358:14:358:26 | * ... | semmle.label | * ... |
 | test.cpp:359:14:359:32 | * ... | semmle.label | * ... |
 | test.cpp:377:14:377:27 | new[] | semmle.label | new[] |
 | test.cpp:378:15:378:23 | ... + ... | semmle.label | ... + ... |
 | test.cpp:378:15:378:23 | ... + ... | semmle.label | ... + ... |
+| test.cpp:381:5:381:9 | ... ++ | semmle.label | ... ++ |
+| test.cpp:381:5:381:9 | ... ++ | semmle.label | ... ++ |
 | test.cpp:384:13:384:16 | * ... | semmle.label | * ... |
 | test.cpp:410:14:410:27 | new[] | semmle.label | new[] |
 | test.cpp:411:15:411:23 | & ... | semmle.label | & ... |
 | test.cpp:411:15:411:23 | & ... | semmle.label | & ... |
+| test.cpp:413:5:413:8 | ... ++ | semmle.label | ... ++ |
+| test.cpp:413:5:413:8 | ... ++ | semmle.label | ... ++ |
 | test.cpp:415:7:415:15 | ... = ... | semmle.label | ... = ... |
 | test.cpp:421:14:421:27 | new[] | semmle.label | new[] |
 | test.cpp:422:15:422:23 | & ... | semmle.label | & ... |
 | test.cpp:422:15:422:23 | & ... | semmle.label | & ... |
+| test.cpp:424:5:424:8 | ... ++ | semmle.label | ... ++ |
+| test.cpp:424:5:424:8 | ... ++ | semmle.label | ... ++ |
 | test.cpp:426:7:426:15 | ... = ... | semmle.label | ... = ... |
 | test.cpp:432:14:432:27 | new[] | semmle.label | new[] |
 | test.cpp:433:15:433:23 | & ... | semmle.label | & ... |
 | test.cpp:433:15:433:23 | & ... | semmle.label | & ... |
+| test.cpp:436:5:436:8 | ... ++ | semmle.label | ... ++ |
+| test.cpp:436:5:436:8 | ... ++ | semmle.label | ... ++ |
 | test.cpp:438:7:438:15 | ... = ... | semmle.label | ... = ... |
 | test.cpp:444:14:444:27 | new[] | semmle.label | new[] |
 | test.cpp:445:15:445:23 | & ... | semmle.label | & ... |
 | test.cpp:445:15:445:23 | & ... | semmle.label | & ... |
+| test.cpp:448:5:448:8 | ... ++ | semmle.label | ... ++ |
+| test.cpp:448:5:448:8 | ... ++ | semmle.label | ... ++ |
 | test.cpp:450:7:450:15 | ... = ... | semmle.label | ... = ... |
 | test.cpp:480:14:480:27 | new[] | semmle.label | new[] |
 | test.cpp:481:15:481:23 | & ... | semmle.label | & ... |
 | test.cpp:481:15:481:23 | & ... | semmle.label | & ... |
+| test.cpp:484:5:484:8 | ... ++ | semmle.label | ... ++ |
+| test.cpp:484:5:484:8 | ... ++ | semmle.label | ... ++ |
 | test.cpp:486:7:486:15 | ... = ... | semmle.label | ... = ... |
 | test.cpp:543:14:543:27 | new[] | semmle.label | new[] |
 | test.cpp:548:5:548:19 | ... = ... | semmle.label | ... = ... |
@@ -308,8 +366,15 @@ nodes
 | test.cpp:559:5:559:19 | ... = ... | semmle.label | ... = ... |
 | test.cpp:642:14:642:31 | new[] | semmle.label | new[] |
 | test.cpp:647:5:647:19 | ... = ... | semmle.label | ... = ... |
+| test.cpp:652:14:652:27 | new[] | semmle.label | new[] |
+| test.cpp:656:3:656:6 | ... ++ | semmle.label | ... ++ |
+| test.cpp:656:3:656:6 | ... ++ | semmle.label | ... ++ |
+| test.cpp:662:3:662:11 | ... = ... | semmle.label | ... = ... |
 | test.cpp:667:14:667:31 | new[] | semmle.label | new[] |
 | test.cpp:675:7:675:23 | ... = ... | semmle.label | ... = ... |
+| test.cpp:695:13:695:26 | new[] | semmle.label | new[] |
+| test.cpp:698:5:698:10 | ... += ... | semmle.label | ... += ... |
+| test.cpp:701:15:701:16 | * ... | semmle.label | * ... |
 subpaths
 #select
 | test.cpp:6:14:6:15 | * ... | test.cpp:4:15:4:20 | call to malloc | test.cpp:6:14:6:15 | * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:4:15:4:20 | call to malloc | call to malloc | test.cpp:5:19:5:22 | size | size |
@@ -343,4 +408,6 @@ subpaths
 | test.cpp:548:5:548:19 | ... = ... | test.cpp:543:14:543:27 | new[] | test.cpp:548:5:548:19 | ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:543:14:543:27 | new[] | new[] | test.cpp:548:8:548:14 | src_pos | src_pos |
 | test.cpp:559:5:559:19 | ... = ... | test.cpp:554:14:554:27 | new[] | test.cpp:559:5:559:19 | ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:554:14:554:27 | new[] | new[] | test.cpp:559:8:559:14 | src_pos | src_pos |
 | test.cpp:647:5:647:19 | ... = ... | test.cpp:642:14:642:31 | new[] | test.cpp:647:5:647:19 | ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:642:14:642:31 | new[] | new[] | test.cpp:647:8:647:14 | src_pos | src_pos |
+| test.cpp:662:3:662:11 | ... = ... | test.cpp:652:14:652:27 | new[] | test.cpp:662:3:662:11 | ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@ + 1. | test.cpp:652:14:652:27 | new[] | new[] | test.cpp:653:19:653:22 | size | size |
 | test.cpp:675:7:675:23 | ... = ... | test.cpp:667:14:667:31 | new[] | test.cpp:675:7:675:23 | ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:667:14:667:31 | new[] | new[] | test.cpp:675:10:675:18 | ... ++ | ... ++ |
+| test.cpp:701:15:701:16 | * ... | test.cpp:695:13:695:26 | new[] | test.cpp:701:15:701:16 | * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:695:13:695:26 | new[] | new[] | test.cpp:696:19:696:22 | size | size |

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/InvalidPointerDeref.expected
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/InvalidPointerDeref.expected
@@ -223,6 +223,11 @@ edges
 | test.cpp:667:14:667:31 | new[] | test.cpp:675:7:675:23 | ... = ... |
 | test.cpp:695:13:695:26 | new[] | test.cpp:698:5:698:10 | ... += ... |
 | test.cpp:698:5:698:10 | ... += ... | test.cpp:701:15:701:16 | * ... |
+| test.cpp:705:18:705:18 | q | test.cpp:705:18:705:18 | q |
+| test.cpp:705:18:705:18 | q | test.cpp:706:12:706:13 | * ... |
+| test.cpp:705:18:705:18 | q | test.cpp:706:12:706:13 | * ... |
+| test.cpp:711:13:711:26 | new[] | test.cpp:714:11:714:11 | q |
+| test.cpp:714:11:714:11 | q | test.cpp:705:18:705:18 | q |
 nodes
 | test.cpp:4:15:4:20 | call to malloc | semmle.label | call to malloc |
 | test.cpp:5:15:5:22 | ... + ... | semmle.label | ... + ... |
@@ -375,6 +380,11 @@ nodes
 | test.cpp:695:13:695:26 | new[] | semmle.label | new[] |
 | test.cpp:698:5:698:10 | ... += ... | semmle.label | ... += ... |
 | test.cpp:701:15:701:16 | * ... | semmle.label | * ... |
+| test.cpp:705:18:705:18 | q | semmle.label | q |
+| test.cpp:705:18:705:18 | q | semmle.label | q |
+| test.cpp:706:12:706:13 | * ... | semmle.label | * ... |
+| test.cpp:711:13:711:26 | new[] | semmle.label | new[] |
+| test.cpp:714:11:714:11 | q | semmle.label | q |
 subpaths
 #select
 | test.cpp:6:14:6:15 | * ... | test.cpp:4:15:4:20 | call to malloc | test.cpp:6:14:6:15 | * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:4:15:4:20 | call to malloc | call to malloc | test.cpp:5:19:5:22 | size | size |
@@ -411,3 +421,4 @@ subpaths
 | test.cpp:662:3:662:11 | ... = ... | test.cpp:652:14:652:27 | new[] | test.cpp:662:3:662:11 | ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@ + 1. | test.cpp:652:14:652:27 | new[] | new[] | test.cpp:653:19:653:22 | size | size |
 | test.cpp:675:7:675:23 | ... = ... | test.cpp:667:14:667:31 | new[] | test.cpp:675:7:675:23 | ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:667:14:667:31 | new[] | new[] | test.cpp:675:10:675:18 | ... ++ | ... ++ |
 | test.cpp:701:15:701:16 | * ... | test.cpp:695:13:695:26 | new[] | test.cpp:701:15:701:16 | * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:695:13:695:26 | new[] | new[] | test.cpp:696:19:696:22 | size | size |
+| test.cpp:706:12:706:13 | * ... | test.cpp:711:13:711:26 | new[] | test.cpp:706:12:706:13 | * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:711:13:711:26 | new[] | new[] | test.cpp:712:19:712:22 | size | size |

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/test.cpp
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/test.cpp
@@ -703,7 +703,7 @@ void test34(unsigned size) {
 }
 
 void deref(char* q) {
-  char x = *q; // $ MISSING: deref=L712->L706 deref=L713->L706
+  char x = *q; // $ deref=L714->L705->L706 // BAD
 }
 
 void test35(unsigned long size, char* q)

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/test.cpp
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/test.cpp
@@ -17,7 +17,7 @@ void test2(int size) {
     char* q = p + size - 1; // $ alloc=L16
     char a = *q; // GOOD
     char b = *(q - 1); // GOOD
-    char c = *(q + 1); // $ deref=L17->L20 // BAD
+    char c = *(q + 1); // $ deref=L20 // BAD
     char d = *(q + size); // BAD [NOT DETECTED]
     char e = *(q - size); // GOOD
     char f = *(q + size + 1); // BAD [NOT DETECTED]
@@ -198,7 +198,7 @@ void test12(unsigned len, unsigned index) {
         return;
     }
     
-    p[index] = '\0'; // $ deref=L195->L201 deref=L197->L201 // BAD
+    p[index] = '\0'; // $ deref=L201 // BAD
 }
 
 void test13(unsigned len, unsigned index) {
@@ -210,7 +210,7 @@ void test13(unsigned len, unsigned index) {
         return;
     }
     
-    *q = '\0'; // $ deref=L206->L213 deref=L209->L213 // BAD
+    *q = '\0'; // $ deref=L213 // BAD
 }
 
 bool unknown();
@@ -261,7 +261,7 @@ void test17(unsigned len)
   int *end = xs + len; // $ alloc=L260
   for (int *x = xs; x <= end; x++)
   {
-    int i = *x; // $ deref=L261->L264 deref=L262->L264 // BAD
+    int i = *x; // $ deref=L264 // BAD
   }
 }
 
@@ -271,7 +271,7 @@ void test18(unsigned len)
   int *end = xs + len; // $ alloc=L270
   for (int *x = xs; x <= end; x++)
   {
-    *x = 0; // $ deref=L271->L274 deref=L272->L274 // BAD
+    *x = 0; // $ deref=L274 // BAD
   }
 }
 
@@ -355,8 +355,8 @@ void test25(unsigned size) {
   char *xs = new char[size];
   char *end = xs + size; // $ alloc=L355
   char *end_plus_one = end + 1;
-  int val1 = *end_plus_one; // $ deref=L356->L358+1 deref=L357->L358+1 // BAD
-  int val2 = *(end_plus_one + 1); // $ deref=L356->L359+2 deref=L357->L359+2 // BAD
+  int val1 = *end_plus_one; // $ deref=L358+1 // BAD
+  int val2 = *(end_plus_one + 1); // $ deref=L359+2 // BAD
 }
 
 void test26(unsigned size) {
@@ -381,7 +381,7 @@ void test27(unsigned size, bool b) {
     end++;
   }
 
-  int val = *end; // $ deref=L378->L384+1 deref=L381->L384+1 // BAD
+  int val = *end; // $ deref=L384+1 // BAD
 }
 
 void test28(unsigned size) {
@@ -412,7 +412,7 @@ void test28_simple2(unsigned size) {
   if (xs < end) {
     xs++;
     if (xs < end + 1) {
-      xs[0] = 0; // $ deref=L411->L415 deref=L412->L415 deref=L414->L415 // BAD
+      xs[0] = 0; // $ deref=L415 // BAD
     }
   }
 }
@@ -423,7 +423,7 @@ void test28_simple3(unsigned size) {
   if (xs < end) {
     xs++;
     if (xs - 1 < end) {
-      xs[0] = 0; // $ deref=L422->L426 deref=L423->L426 deref=L425->L426 // BAD
+      xs[0] = 0; // $ deref=L426 // BAD
     }
   }
 }
@@ -435,7 +435,7 @@ void test28_simple4(unsigned size) {
     end++;
     xs++;
     if (xs < end) {
-      xs[0] = 0; // $ deref=L433->L438 deref=L434->L438 deref=L435->L438 // BAD
+      xs[0] = 0; // $ deref=L438 // BAD
     }
   }
 }
@@ -447,7 +447,7 @@ void test28_simple5(unsigned size) {
   if (xs < end) {
     xs++;
     if (xs < end) {
-      xs[0] = 0; // $ deref=L445->L450 deref=L446->L450 // BAD
+      xs[0] = 0; // $ deref=L450 // BAD
     }
   }
 }
@@ -483,7 +483,7 @@ void test28_simple8(unsigned size) {
   if (xs < end) {
     xs++;
     if (xs < end - 1) {
-      xs[0] = 0; // $ deref=L481->L486+498 deref=L482->L486+498 // BAD
+      xs[0] = 0; // $ deref=L486+498 // BAD
     }
   }
 }
@@ -659,7 +659,7 @@ void test32(unsigned size) {
   xs++;
   if (xs >= end)
     return;
-  xs[0] = 0; // $ GOOD
+  xs[0] = 0; // $ deref=L656->L662+1 deref=L657->L662+1 GOOD [FALSE POSITIVE]
 }
 
 void test33(unsigned size, unsigned src_pos)
@@ -698,7 +698,7 @@ void test34(unsigned size) {
     p += 1;
   }
   if (p + 1 < end) {
-    int val = *p; // GOOD
+    int val = *p; // $ deref=L698->L700->L701 // GOOD [FALSE POSITIVE]
   }
 }
 


### PR DESCRIPTION
The FN added in https://github.com/github/codeql/pull/13815 demonstrates that the changes in https://github.com/github/codeql/pull/13792 was not the way to go. This PR reverts that PR. I have another PR ready locally that fixes the FPs that were also fixed by this now-reverted PR which I'll open once this has been merged.

cc @jketema.