### PR TITLE
DataFlow: Support stateless `isSink` in `StateConfigSig`s

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl1.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl1.qll
@@ -276,6 +276,8 @@ private module Config implements FullStateConfigSig {
     getConfig(state).isSource(source) and getState(state) instanceof FlowStateEmpty
   }
 
+  predicate isSink(Node sink) { none() }
+
   predicate isSink(Node sink, FlowState state) {
     getConfig(state).isSink(sink, getState(state))
     or

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
@@ -276,6 +276,8 @@ private module Config implements FullStateConfigSig {
     getConfig(state).isSource(source) and getState(state) instanceof FlowStateEmpty
   }
 
+  predicate isSink(Node sink) { none() }
+
   predicate isSink(Node sink, FlowState state) {
     getConfig(state).isSink(sink, getState(state))
     or

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
@@ -276,6 +276,8 @@ private module Config implements FullStateConfigSig {
     getConfig(state).isSource(source) and getState(state) instanceof FlowStateEmpty
   }
 
+  predicate isSink(Node sink) { none() }
+
   predicate isSink(Node sink, FlowState state) {
     getConfig(state).isSink(sink, getState(state))
     or

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
@@ -276,6 +276,8 @@ private module Config implements FullStateConfigSig {
     getConfig(state).isSource(source) and getState(state) instanceof FlowStateEmpty
   }
 
+  predicate isSink(Node sink) { none() }
+
   predicate isSink(Node sink, FlowState state) {
     getConfig(state).isSink(sink, getState(state))
     or

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
@@ -276,6 +276,8 @@ private module Config implements FullStateConfigSig {
     getConfig(state).isSource(source) and getState(state) instanceof FlowStateEmpty
   }
 
+  predicate isSink(Node sink) { none() }
+
   predicate isSink(Node sink, FlowState state) {
     getConfig(state).isSink(sink, getState(state))
     or

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/tainttracking1/TaintTracking.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/tainttracking1/TaintTracking.qll
@@ -24,6 +24,7 @@ private module AddTaintDefaults<DataFlowInternal::FullStateConfigSig Config> imp
     Config::allowImplicitRead(node, c)
     or
     (
+      Config::isSink(node) or
       Config::isSink(node, _) or
       Config::isAdditionalFlowStep(node, _) or
       Config::isAdditionalFlowStep(node, _, _, _)

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl1.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl1.qll
@@ -276,6 +276,8 @@ private module Config implements FullStateConfigSig {
     getConfig(state).isSource(source) and getState(state) instanceof FlowStateEmpty
   }
 
+  predicate isSink(Node sink) { none() }
+
   predicate isSink(Node sink, FlowState state) {
     getConfig(state).isSink(sink, getState(state))
     or

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -276,6 +276,8 @@ private module Config implements FullStateConfigSig {
     getConfig(state).isSource(source) and getState(state) instanceof FlowStateEmpty
   }
 
+  predicate isSink(Node sink) { none() }
+
   predicate isSink(Node sink, FlowState state) {
     getConfig(state).isSink(sink, getState(state))
     or

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -276,6 +276,8 @@ private module Config implements FullStateConfigSig {
     getConfig(state).isSource(source) and getState(state) instanceof FlowStateEmpty
   }
 
+  predicate isSink(Node sink) { none() }
+
   predicate isSink(Node sink, FlowState state) {
     getConfig(state).isSink(sink, getState(state))
     or

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -276,6 +276,8 @@ private module Config implements FullStateConfigSig {
     getConfig(state).isSource(source) and getState(state) instanceof FlowStateEmpty
   }
 
+  predicate isSink(Node sink) { none() }
+
   predicate isSink(Node sink, FlowState state) {
     getConfig(state).isSink(sink, getState(state))
     or

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/tainttracking1/TaintTracking.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/tainttracking1/TaintTracking.qll
@@ -24,6 +24,7 @@ private module AddTaintDefaults<DataFlowInternal::FullStateConfigSig Config> imp
     Config::allowImplicitRead(node, c)
     or
     (
+      Config::isSink(node) or
       Config::isSink(node, _) or
       Config::isAdditionalFlowStep(node, _) or
       Config::isAdditionalFlowStep(node, _, _, _)

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl1.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl1.qll
@@ -276,6 +276,8 @@ private module Config implements FullStateConfigSig {
     getConfig(state).isSource(source) and getState(state) instanceof FlowStateEmpty
   }
 
+  predicate isSink(Node sink) { none() }
+
   predicate isSink(Node sink, FlowState state) {
     getConfig(state).isSink(sink, getState(state))
     or

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
@@ -276,6 +276,8 @@ private module Config implements FullStateConfigSig {
     getConfig(state).isSource(source) and getState(state) instanceof FlowStateEmpty
   }
 
+  predicate isSink(Node sink) { none() }
+
   predicate isSink(Node sink, FlowState state) {
     getConfig(state).isSink(sink, getState(state))
     or

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
@@ -276,6 +276,8 @@ private module Config implements FullStateConfigSig {
     getConfig(state).isSource(source) and getState(state) instanceof FlowStateEmpty
   }
 
+  predicate isSink(Node sink) { none() }
+
   predicate isSink(Node sink, FlowState state) {
     getConfig(state).isSink(sink, getState(state))
     or

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
@@ -276,6 +276,8 @@ private module Config implements FullStateConfigSig {
     getConfig(state).isSource(source) and getState(state) instanceof FlowStateEmpty
   }
 
+  predicate isSink(Node sink) { none() }
+
   predicate isSink(Node sink, FlowState state) {
     getConfig(state).isSink(sink, getState(state))
     or

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
@@ -276,6 +276,8 @@ private module Config implements FullStateConfigSig {
     getConfig(state).isSource(source) and getState(state) instanceof FlowStateEmpty
   }
 
+  predicate isSink(Node sink) { none() }
+
   predicate isSink(Node sink, FlowState state) {
     getConfig(state).isSink(sink, getState(state))
     or

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/tainttracking1/TaintTracking.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/tainttracking1/TaintTracking.qll
@@ -24,6 +24,7 @@ private module AddTaintDefaults<DataFlowInternal::FullStateConfigSig Config> imp
     Config::allowImplicitRead(node, c)
     or
     (
+      Config::isSink(node) or
       Config::isSink(node, _) or
       Config::isAdditionalFlowStep(node, _) or
       Config::isAdditionalFlowStep(node, _, _, _)

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowImpl1.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowImpl1.qll
@@ -276,6 +276,8 @@ private module Config implements FullStateConfigSig {
     getConfig(state).isSource(source) and getState(state) instanceof FlowStateEmpty
   }
 
+  predicate isSink(Node sink) { none() }
+
   predicate isSink(Node sink, FlowState state) {
     getConfig(state).isSink(sink, getState(state))
     or

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowImpl2.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowImpl2.qll
@@ -276,6 +276,8 @@ private module Config implements FullStateConfigSig {
     getConfig(state).isSource(source) and getState(state) instanceof FlowStateEmpty
   }
 
+  predicate isSink(Node sink) { none() }
+
   predicate isSink(Node sink, FlowState state) {
     getConfig(state).isSink(sink, getState(state))
     or

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowImplForStringsNewReplacer.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowImplForStringsNewReplacer.qll
@@ -276,6 +276,8 @@ private module Config implements FullStateConfigSig {
     getConfig(state).isSource(source) and getState(state) instanceof FlowStateEmpty
   }
 
+  predicate isSink(Node sink) { none() }
+
   predicate isSink(Node sink, FlowState state) {
     getConfig(state).isSink(sink, getState(state))
     or

--- a/go/ql/lib/semmle/go/dataflow/internal/tainttracking1/TaintTracking.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/tainttracking1/TaintTracking.qll
@@ -24,6 +24,7 @@ private module AddTaintDefaults<DataFlowInternal::FullStateConfigSig Config> imp
     Config::allowImplicitRead(node, c)
     or
     (
+      Config::isSink(node) or
       Config::isSink(node, _) or
       Config::isAdditionalFlowStep(node, _) or
       Config::isAdditionalFlowStep(node, _, _, _)

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl1.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl1.qll
@@ -276,6 +276,8 @@ private module Config implements FullStateConfigSig {
     getConfig(state).isSource(source) and getState(state) instanceof FlowStateEmpty
   }
 
+  predicate isSink(Node sink) { none() }
+
   predicate isSink(Node sink, FlowState state) {
     getConfig(state).isSink(sink, getState(state))
     or

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
@@ -276,6 +276,8 @@ private module Config implements FullStateConfigSig {
     getConfig(state).isSource(source) and getState(state) instanceof FlowStateEmpty
   }
 
+  predicate isSink(Node sink) { none() }
+
   predicate isSink(Node sink, FlowState state) {
     getConfig(state).isSink(sink, getState(state))
     or

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
@@ -276,6 +276,8 @@ private module Config implements FullStateConfigSig {
     getConfig(state).isSource(source) and getState(state) instanceof FlowStateEmpty
   }
 
+  predicate isSink(Node sink) { none() }
+
   predicate isSink(Node sink, FlowState state) {
     getConfig(state).isSink(sink, getState(state))
     or

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
@@ -276,6 +276,8 @@ private module Config implements FullStateConfigSig {
     getConfig(state).isSource(source) and getState(state) instanceof FlowStateEmpty
   }
 
+  predicate isSink(Node sink) { none() }
+
   predicate isSink(Node sink, FlowState state) {
     getConfig(state).isSink(sink, getState(state))
     or

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
@@ -276,6 +276,8 @@ private module Config implements FullStateConfigSig {
     getConfig(state).isSource(source) and getState(state) instanceof FlowStateEmpty
   }
 
+  predicate isSink(Node sink) { none() }
+
   predicate isSink(Node sink, FlowState state) {
     getConfig(state).isSink(sink, getState(state))
     or

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl6.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl6.qll
@@ -276,6 +276,8 @@ private module Config implements FullStateConfigSig {
     getConfig(state).isSource(source) and getState(state) instanceof FlowStateEmpty
   }
 
+  predicate isSink(Node sink) { none() }
+
   predicate isSink(Node sink, FlowState state) {
     getConfig(state).isSink(sink, getState(state))
     or

--- a/java/ql/lib/semmle/code/java/dataflow/internal/tainttracking1/TaintTracking.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/tainttracking1/TaintTracking.qll
@@ -24,6 +24,7 @@ private module AddTaintDefaults<DataFlowInternal::FullStateConfigSig Config> imp
     Config::allowImplicitRead(node, c)
     or
     (
+      Config::isSink(node) or
       Config::isSink(node, _) or
       Config::isAdditionalFlowStep(node, _) or
       Config::isAdditionalFlowStep(node, _, _, _)

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl1.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl1.qll
@@ -276,6 +276,8 @@ private module Config implements FullStateConfigSig {
     getConfig(state).isSource(source) and getState(state) instanceof FlowStateEmpty
   }
 
+  predicate isSink(Node sink) { none() }
+
   predicate isSink(Node sink, FlowState state) {
     getConfig(state).isSink(sink, getState(state))
     or

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl2.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl2.qll
@@ -276,6 +276,8 @@ private module Config implements FullStateConfigSig {
     getConfig(state).isSource(source) and getState(state) instanceof FlowStateEmpty
   }
 
+  predicate isSink(Node sink) { none() }
+
   predicate isSink(Node sink, FlowState state) {
     getConfig(state).isSink(sink, getState(state))
     or

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl3.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl3.qll
@@ -276,6 +276,8 @@ private module Config implements FullStateConfigSig {
     getConfig(state).isSource(source) and getState(state) instanceof FlowStateEmpty
   }
 
+  predicate isSink(Node sink) { none() }
+
   predicate isSink(Node sink, FlowState state) {
     getConfig(state).isSink(sink, getState(state))
     or

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl4.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl4.qll
@@ -276,6 +276,8 @@ private module Config implements FullStateConfigSig {
     getConfig(state).isSource(source) and getState(state) instanceof FlowStateEmpty
   }
 
+  predicate isSink(Node sink) { none() }
+
   predicate isSink(Node sink, FlowState state) {
     getConfig(state).isSink(sink, getState(state))
     or

--- a/python/ql/lib/semmle/python/dataflow/new/internal/tainttracking1/TaintTracking.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/tainttracking1/TaintTracking.qll
@@ -24,6 +24,7 @@ private module AddTaintDefaults<DataFlowInternal::FullStateConfigSig Config> imp
     Config::allowImplicitRead(node, c)
     or
     (
+      Config::isSink(node) or
       Config::isSink(node, _) or
       Config::isAdditionalFlowStep(node, _) or
       Config::isAdditionalFlowStep(node, _, _, _)

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl1.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl1.qll
@@ -276,6 +276,8 @@ private module Config implements FullStateConfigSig {
     getConfig(state).isSource(source) and getState(state) instanceof FlowStateEmpty
   }
 
+  predicate isSink(Node sink) { none() }
+
   predicate isSink(Node sink, FlowState state) {
     getConfig(state).isSink(sink, getState(state))
     or

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl2.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl2.qll
@@ -276,6 +276,8 @@ private module Config implements FullStateConfigSig {
     getConfig(state).isSource(source) and getState(state) instanceof FlowStateEmpty
   }
 
+  predicate isSink(Node sink) { none() }
+
   predicate isSink(Node sink, FlowState state) {
     getConfig(state).isSink(sink, getState(state))
     or

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplForHttpClientLibraries.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplForHttpClientLibraries.qll
@@ -276,6 +276,8 @@ private module Config implements FullStateConfigSig {
     getConfig(state).isSource(source) and getState(state) instanceof FlowStateEmpty
   }
 
+  predicate isSink(Node sink) { none() }
+
   predicate isSink(Node sink, FlowState state) {
     getConfig(state).isSink(sink, getState(state))
     or

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplForPathname.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplForPathname.qll
@@ -276,6 +276,8 @@ private module Config implements FullStateConfigSig {
     getConfig(state).isSource(source) and getState(state) instanceof FlowStateEmpty
   }
 
+  predicate isSink(Node sink) { none() }
+
   predicate isSink(Node sink, FlowState state) {
     getConfig(state).isSink(sink, getState(state))
     or

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/tainttracking1/TaintTracking.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/tainttracking1/TaintTracking.qll
@@ -24,6 +24,7 @@ private module AddTaintDefaults<DataFlowInternal::FullStateConfigSig Config> imp
     Config::allowImplicitRead(node, c)
     or
     (
+      Config::isSink(node) or
       Config::isSink(node, _) or
       Config::isAdditionalFlowStep(node, _) or
       Config::isAdditionalFlowStep(node, _, _, _)

--- a/shared/dataflow/change-notes/2023-08-02-dataflow-isSink.md
+++ b/shared/dataflow/change-notes/2023-08-02-dataflow-isSink.md
@@ -1,4 +1,4 @@
 ---
 category: feature
 ---
-* The `StateConfigSig` signature now supports an `isSink/1` predicate that does not specify the `FlowState` for which the given node is a sink. Instead, any `FlowState` is considered a valid `FlowState` for the sink.
+* The `StateConfigSig` signature now supports a unary `isSink` predicate that does not specify the `FlowState` for which the given node is a sink. Instead, any `FlowState` is considered a valid `FlowState` for such a sink.

--- a/shared/dataflow/change-notes/2023-08-02-dataflow-isSink.md
+++ b/shared/dataflow/change-notes/2023-08-02-dataflow-isSink.md
@@ -1,0 +1,4 @@
+---
+category: feature
+---
+* The `StateConfigSig` signature now supports an `isSink/1` predicate that does not specify the `FlowState` for which the given node is a sink. Instead, any `FlowState` is considered a valid `FlowState` for the sink.

--- a/shared/dataflow/codeql/dataflow/DataFlow.qll
+++ b/shared/dataflow/codeql/dataflow/DataFlow.qll
@@ -114,6 +114,11 @@ module Configs<DataFlowParameter Lang> {
     predicate isSink(Node sink, FlowState state);
 
     /**
+     * Holds if `sink` is a relevant data flow sink.
+     */
+    default predicate isSink(Node sink) { none() }
+
+    /**
      * Holds if data flow through `node` is prohibited. This completely removes
      * `node` from the data flow graph.
      */

--- a/shared/dataflow/codeql/dataflow/DataFlow.qll
+++ b/shared/dataflow/codeql/dataflow/DataFlow.qll
@@ -114,7 +114,7 @@ module Configs<DataFlowParameter Lang> {
     predicate isSink(Node sink, FlowState state);
 
     /**
-     * Holds if `sink` is a relevant data flow sink.
+     * Holds if `sink` is a relevant data flow sink for any state.
      */
     default predicate isSink(Node sink) { none() }
 

--- a/shared/dataflow/codeql/dataflow/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/DataFlowImpl.qll
@@ -4003,11 +4003,20 @@ module MakeImpl<DataFlowParameter Lang> {
 
       private predicate relevantState(FlowState state) {
         sourceNode(_, state) or
-        sinkNodeWithState(_, state) or
+        revSinkNode(_, state) or
         additionalLocalStateStep(_, state, _, _) or
         additionalLocalStateStep(_, _, _, state) or
         additionalJumpStateStep(_, state, _, _) or
         additionalJumpStateStep(_, _, _, state)
+      }
+
+      private predicate revSinkNode(NodeEx node, FlowState state) {
+        sinkNodeWithState(node, state)
+        or
+        Config::isSink(node.asNode()) and
+        relevantState(state) and
+        not fullBarrier(node) and
+        not stateBarrier(node, state)
       }
 
       private newtype TSummaryCtx1 =

--- a/shared/dataflow/codeql/dataflow/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/DataFlowImpl.qll
@@ -34,6 +34,11 @@ module MakeImpl<DataFlowParameter Lang> {
     predicate isSink(Node sink, FlowState state);
 
     /**
+     * Holds if `sink` is a relevant data flow sink for any state.
+     */
+    predicate isSink(Node sink);
+
+    /**
      * Holds if data flow through `node` is prohibited. This completely removes
      * `node` from the data flow graph.
      */
@@ -216,8 +221,11 @@ module MakeImpl<DataFlowParameter Lang> {
     private predicate outBarrier(NodeEx node) {
       exists(Node n |
         node.asNode() = n and
-        Config::isBarrierOut(n) and
+        Config::isBarrierOut(n)
+      |
         Config::isSink(n, _)
+        or
+        Config::isSink(n)
       )
     }
 
@@ -230,7 +238,8 @@ module MakeImpl<DataFlowParameter Lang> {
         not Config::isSource(n, _)
         or
         Config::isBarrierOut(n) and
-        not Config::isSink(n, _)
+        not Config::isSink(n, _) and
+        not Config::isSink(n)
       )
     }
 
@@ -247,7 +256,7 @@ module MakeImpl<DataFlowParameter Lang> {
     }
 
     pragma[nomagic]
-    private predicate sinkNode(NodeEx node, FlowState state) {
+    private predicate sinkNodeWithState(NodeEx node, FlowState state) {
       Config::isSink(node.asNode(), state) and
       not fullBarrier(node) and
       not stateBarrier(node, state)
@@ -645,6 +654,16 @@ module MakeImpl<DataFlowParameter Lang> {
         )
       }
 
+      additional predicate sinkNode(NodeEx node, FlowState state) {
+        fwdFlow(node) and
+        fwdFlowState(state) and
+        Config::isSink(node.asNode())
+        or
+        fwdFlow(node) and
+        fwdFlowState(state) and
+        sinkNodeWithState(node, state)
+      }
+
       /**
        * Holds if `node` is part of a path from a source to a sink.
        *
@@ -659,12 +678,8 @@ module MakeImpl<DataFlowParameter Lang> {
 
       pragma[nomagic]
       private predicate revFlow0(NodeEx node, boolean toReturn) {
-        exists(FlowState state |
-          fwdFlow(node) and
-          sinkNode(node, state) and
-          fwdFlowState(state) and
-          if hasSinkCallCtx() then toReturn = true else toReturn = false
-        )
+        sinkNode(node, _) and
+        if hasSinkCallCtx() then toReturn = true else toReturn = false
         or
         exists(NodeEx mid | revFlow(mid, toReturn) |
           localFlowStepEx(node, mid) or
@@ -919,6 +934,8 @@ module MakeImpl<DataFlowParameter Lang> {
       }
       /* End: Stage 1 logic. */
     }
+
+    private predicate sinkNode = Stage1::sinkNode/2;
 
     pragma[noinline]
     private predicate localFlowStepNodeCand1(NodeEx node1, NodeEx node2) {
@@ -3894,7 +3911,10 @@ module MakeImpl<DataFlowParameter Lang> {
       }
 
       private predicate interestingCallableSink(DataFlowCallable c) {
-        exists(Node n | Config::isSink(n, _) and c = getNodeEnclosingCallable(n))
+        exists(Node n | c = getNodeEnclosingCallable(n) |
+          Config::isSink(n, _) or
+          Config::isSink(n)
+        )
         or
         exists(DataFlowCallable mid | interestingCallableSink(mid) and callableStep(c, mid))
       }
@@ -3926,8 +3946,10 @@ module MakeImpl<DataFlowParameter Lang> {
         or
         exists(Node n |
           ce2 = TCallableSink() and
-          Config::isSink(n, _) and
           ce1 = TCallable(getNodeEnclosingCallable(n))
+        |
+          Config::isSink(n, _) or
+          Config::isSink(n)
         )
       }
 

--- a/shared/dataflow/codeql/dataflow/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/DataFlowImpl.qll
@@ -4003,7 +4003,7 @@ module MakeImpl<DataFlowParameter Lang> {
 
       private predicate relevantState(FlowState state) {
         sourceNode(_, state) or
-        sinkNode(_, state) or
+        sinkNodeWithState(_, state) or
         additionalLocalStateStep(_, state, _, _) or
         additionalLocalStateStep(_, _, _, state) or
         additionalJumpStateStep(_, state, _, _) or
@@ -4060,7 +4060,7 @@ module MakeImpl<DataFlowParameter Lang> {
           NodeEx node, FlowState state, TRevSummaryCtx1 sc1, TRevSummaryCtx2 sc2,
           TRevSummaryCtx3 sc3, PartialAccessPath ap
         ) {
-          sinkNode(node, state) and
+          sinkNodeWithState(node, state) and
           sc1 = TRevSummaryCtx1None() and
           sc2 = TRevSummaryCtx2None() and
           sc3 = TRevSummaryCtx3None() and
@@ -4278,7 +4278,7 @@ module MakeImpl<DataFlowParameter Lang> {
         }
 
         predicate isSink() {
-          sinkNode(node, state) and
+          sinkNodeWithState(node, state) and
           sc1 = TRevSummaryCtx1None() and
           sc2 = TRevSummaryCtx2None() and
           sc3 = TRevSummaryCtx3None() and

--- a/shared/dataflow/codeql/dataflow/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/DataFlowImpl.qll
@@ -4003,7 +4003,7 @@ module MakeImpl<DataFlowParameter Lang> {
 
       private predicate relevantState(FlowState state) {
         sourceNode(_, state) or
-        revSinkNode(_, state) or
+        sinkNodeWithState(_, state) or
         additionalLocalStateStep(_, state, _, _) or
         additionalLocalStateStep(_, _, _, state) or
         additionalJumpStateStep(_, state, _, _) or

--- a/shared/dataflow/codeql/dataflow/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/DataFlowImpl.qll
@@ -4069,7 +4069,7 @@ module MakeImpl<DataFlowParameter Lang> {
           NodeEx node, FlowState state, TRevSummaryCtx1 sc1, TRevSummaryCtx2 sc2,
           TRevSummaryCtx3 sc3, PartialAccessPath ap
         ) {
-          sinkNodeWithState(node, state) and
+          revSinkNode(node, state) and
           sc1 = TRevSummaryCtx1None() and
           sc2 = TRevSummaryCtx2None() and
           sc3 = TRevSummaryCtx3None() and
@@ -4287,7 +4287,7 @@ module MakeImpl<DataFlowParameter Lang> {
         }
 
         predicate isSink() {
-          sinkNodeWithState(node, state) and
+          revSinkNode(node, state) and
           sc1 = TRevSummaryCtx1None() and
           sc2 = TRevSummaryCtx2None() and
           sc3 = TRevSummaryCtx3None() and

--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImpl1.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowImpl1.qll
@@ -276,6 +276,8 @@ private module Config implements FullStateConfigSig {
     getConfig(state).isSource(source) and getState(state) instanceof FlowStateEmpty
   }
 
+  predicate isSink(Node sink) { none() }
+
   predicate isSink(Node sink, FlowState state) {
     getConfig(state).isSink(sink, getState(state))
     or

--- a/swift/ql/lib/codeql/swift/dataflow/internal/tainttracking1/TaintTracking.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/tainttracking1/TaintTracking.qll
@@ -24,6 +24,7 @@ private module AddTaintDefaults<DataFlowInternal::FullStateConfigSig Config> imp
     Config::allowImplicitRead(node, c)
     or
     (
+      Config::isSink(node) or
       Config::isSink(node, _) or
       Config::isAdditionalFlowStep(node, _) or
       Config::isAdditionalFlowStep(node, _, _, _)


### PR DESCRIPTION
Sometimes it's necessary to have a state-based configuration to define the correct `isBarrier`, but if data then does manage to reach a sink, any state should be accepted. Prior to this PR, the only way to prevent a cartesian product would be to do something like:
```ql
module PruningConfig implements ConfigSig {
  predicate isSource(Node source) {
    exists(MyState state | isSourceImpl(source, state))
  }

  predicate isSink(Node sink) { ... }
}

module PruningFlow = Global<PruningConfig>;

FlowState viableStateForSink(Node sink) {
  exists(PruningFlow::PathNode pSource, PruningFlow::PathNode pSink |
    PruningFlow::flowPath(pSource, pSink) and
    pSink.getNode() = sink and
    isSourceImpl(pSource.getNode(), result)
  )
}

module RealConfig implements StateConfigSig {
  class FlowState = MyState

  predicate isSource(Node source, FlowState state) { isSourceImpl(source, state) }

  predicate isSink(Node sink, FlowState state) {
    ... and state = viableStateForSink(sink) // <-- to prevent CP with all flow states.
  }

  predicate isBarrier(Node barrier, FlowState state) { ... }
}
```

because there was no `isSink/1` on `StateConfigSig`. With this PR we can now do:
```ql
module RealConfig implements StateConfigSig {
  predicate isSource(Node source, FlowState state) { ... }

  predicate isSink(Node sink) { ... }

  predicate isBarrier(Node barrier, FlowState state) { ... }
}
```
with no `PruningFlow` mess.

cc @aschackmull I hope this isn't too controversial?