### PR TITLE
Add option to filter automodel queries

### DIFF
--- a/java/ql/src/Telemetry/AutomodelApplicationModeExtractCandidates.ql
+++ b/java/ql/src/Telemetry/AutomodelApplicationModeExtractCandidates.ql
@@ -66,6 +66,7 @@ where
   // modeled in a MaD model, then it doesn't belong to any additional sink types, and we don't need to reexamine it.
   not CharacteristicsImpl::isSink(endpoint, _, _) and
   meta.hasMetadata(endpoint, package, type, subtypes, name, signature, input) and
+  automodelCandidateFilter(package) and
   // The message is the concatenation of all sink types for which this endpoint is known neither to be a sink nor to be
   // a non-sink, and we surface only endpoints that have at least one such sink type.
   message =

--- a/java/ql/src/Telemetry/AutomodelApplicationModeExtractCandidates.ql
+++ b/java/ql/src/Telemetry/AutomodelApplicationModeExtractCandidates.ql
@@ -66,7 +66,7 @@ where
   // modeled in a MaD model, then it doesn't belong to any additional sink types, and we don't need to reexamine it.
   not CharacteristicsImpl::isSink(endpoint, _, _) and
   meta.hasMetadata(endpoint, package, type, subtypes, name, signature, input) and
-  automodelCandidateFilter(package) and
+  includeAutomodelCandidate(package, type, name, signature) and
   // The message is the concatenation of all sink types for which this endpoint is known neither to be a sink nor to be
   // a non-sink, and we surface only endpoints that have at least one such sink type.
   message =

--- a/java/ql/src/Telemetry/AutomodelCandidateFilter.yml
+++ b/java/ql/src/Telemetry/AutomodelCandidateFilter.yml
@@ -1,0 +1,5 @@
+extensions:
+  - addsTo:
+      pack: codeql/java-queries
+      extensible: automodelCandidatePackageFilter
+    data: []

--- a/java/ql/src/Telemetry/AutomodelCandidateFilter.yml
+++ b/java/ql/src/Telemetry/AutomodelCandidateFilter.yml
@@ -1,5 +1,5 @@
 extensions:
   - addsTo:
       pack: codeql/java-queries
-      extensible: automodelCandidatePackageFilter
+      extensible: automodelCandidateFilter
     data: []

--- a/java/ql/src/Telemetry/AutomodelFrameworkModeExtractCandidates.ql
+++ b/java/ql/src/Telemetry/AutomodelFrameworkModeExtractCandidates.ql
@@ -30,7 +30,7 @@ where
   // modeled in a MaD model, then it doesn't belong to any additional sink types, and we don't need to reexamine it.
   not CharacteristicsImpl::isSink(endpoint, _, _) and
   meta.hasMetadata(endpoint, package, type, subtypes, name, signature, input, parameterName) and
-  automodelCandidateFilter(package) and
+  includeAutomodelCandidate(package, type, name, signature) and
   // The message is the concatenation of all sink types for which this endpoint is known neither to be a sink nor to be
   // a non-sink, and we surface only endpoints that have at least one such sink type.
   message =

--- a/java/ql/src/Telemetry/AutomodelFrameworkModeExtractCandidates.ql
+++ b/java/ql/src/Telemetry/AutomodelFrameworkModeExtractCandidates.ql
@@ -30,6 +30,7 @@ where
   // modeled in a MaD model, then it doesn't belong to any additional sink types, and we don't need to reexamine it.
   not CharacteristicsImpl::isSink(endpoint, _, _) and
   meta.hasMetadata(endpoint, package, type, subtypes, name, signature, input, parameterName) and
+  automodelCandidateFilter(package) and
   // The message is the concatenation of all sink types for which this endpoint is known neither to be a sink nor to be
   // a non-sink, and we surface only endpoints that have at least one such sink type.
   message =

--- a/java/ql/src/Telemetry/AutomodelJavaUtil.qll
+++ b/java/ql/src/Telemetry/AutomodelJavaUtil.qll
@@ -68,20 +68,22 @@ boolean considerSubtypes(Callable callable) {
 }
 
 /**
- * Holds if the given package is a candidate for automodeling.
+ * Holds if the given package, type, name and signature is a candidate for automodeling.
  *
- * This predicate is extensible, so that different packages can be selected at runtime.
+ * This predicate is extensible, so that different endpoints can be selected at runtime.
  */
-extensible predicate automodelCandidatePackageFilter(string package);
+extensible predicate automodelCandidateFilter(
+  string package, string type, string name, string signature
+);
 
 /**
- * Holds if the given package is a candidate for automodeling.
+ * Holds if the given package, type, name and signature is a candidate for automodeling.
  *
  * This relies on an extensible predicate, and if that is not supplied then
- * all packages are considered candidates.
+ * all endpoints are considered candidates.
  */
-bindingset[package]
-predicate automodelCandidateFilter(string package) {
-  not automodelCandidatePackageFilter(_) or
-  automodelCandidatePackageFilter(package)
+bindingset[package, type, name, signature]
+predicate includeAutomodelCandidate(string package, string type, string name, string signature) {
+  not automodelCandidateFilter(_, _, _, _) or
+  automodelCandidateFilter(package, type, name, signature)
 }

--- a/java/ql/src/Telemetry/AutomodelJavaUtil.qll
+++ b/java/ql/src/Telemetry/AutomodelJavaUtil.qll
@@ -66,3 +66,22 @@ boolean considerSubtypes(Callable callable) {
   then result = false
   else result = true
 }
+
+/**
+ * Holds if the given package is a candidate for automodeling.
+ *
+ * This predicate is extensible, so that different packages can be selected at runtime.
+ */
+extensible predicate automodelCandidatePackageFilter(string package);
+
+/**
+ * Holds if the given package is a candidate for automodeling.
+ *
+ * This relies on an extensible predicate, and if that is not supplied then
+ * all packages are considered candidates.
+ */
+bindingset[package]
+predicate automodelCandidateFilter(string package) {
+  not automodelCandidatePackageFilter(_) or
+  automodelCandidatePackageFilter(package)
+}

--- a/java/ql/src/qlpack.yml
+++ b/java/ql/src/qlpack.yml
@@ -12,4 +12,5 @@ dependencies:
   codeql/util: ${workspace}
 dataExtensions:
   - Telemetry/ExtractorInformation.yml
+  - Telemetry/AutomodelCandidateFilter.yml
 warnOnImplicitThis: true


### PR DESCRIPTION
This is a first tak at how to add runtime filtering to the automodel candidate queries. I am not super up to speed in CodeQL so feedback is welcome.

This is used by the data extension as seen here: https://github.com/github/vscode-codeql/pull/2670