### PR TITLE
CodeQL library update to use modular API interface - Add note and include in articles

### DIFF
--- a/docs/codeql/codeql-language-guides/analyzing-data-flow-in-cpp-new.rst
+++ b/docs/codeql/codeql-language-guides/analyzing-data-flow-in-cpp-new.rst
@@ -2,7 +2,7 @@
 
 .. pull-quote:: Note
 
-   The data flow library described here is available from CodeQL 2.12.5 onwards. For information on the previous version of the library, see :ref:`Analyzing data flow in C and C++ <analyzing-data-flow-in-cpp>`.
+   The data flow library described here is available from CodeQL 2.12.5 onwards. With the release of CodeQL 2.13.0 the library uses the new modular API for data flow. For information on the previous version of the library, see ref:`Analyzing data flow in C and C++ <analyzing-data-flow-in-cpp>` and for information about the new modular API and how to migrate any existing queries to the updated data flow library, see LINK-TO-CHANGELOG.
 
 Analyzing data flow in C and C++ (new)
 ======================================

--- a/docs/codeql/codeql-language-guides/analyzing-data-flow-in-cpp.rst
+++ b/docs/codeql/codeql-language-guides/analyzing-data-flow-in-cpp.rst
@@ -2,7 +2,7 @@
 
 .. pull-quote:: Note
 
-   The data flow library used in this article has been replaced with an improved library which is available from CodeQL 2.12.5 onwards, see :ref:`Analyzing data flow in C and C++ (new) <analyzing-data-flow-in-cpp-new>`. The old library has been deprecated in CodeQL 2.14.1 and will be removed in a later release.
+   The data flow library used in this article has been replaced with an improved library which is available from CodeQL 2.12.5 onwards, see :ref:`Analyzing data flow in C and C++ (new) <analyzing-data-flow-in-cpp-new>`. The old library has been deprecated in CodeQL 2.14.1 and will be removed in a later release. With the release of CodeQL 2.13.0 both libraries use the new modular API for data flow.
 
 Analyzing data flow in C and C++
 ================================

--- a/docs/codeql/codeql-language-guides/analyzing-data-flow-in-csharp.rst
+++ b/docs/codeql/codeql-language-guides/analyzing-data-flow-in-csharp.rst
@@ -12,6 +12,8 @@ This article describes how data flow analysis is implemented in the CodeQL libra
 The following sections describe how to use the libraries for local data flow, global data flow, and taint tracking.
 For a more general introduction to modeling data flow, see ":ref:`About data flow analysis <about-data-flow-analysis>`."
 
+.. include:: ../reusables/new-data-flow-api.rst
+
 Local data flow
 ---------------
 

--- a/docs/codeql/codeql-language-guides/analyzing-data-flow-in-java.rst
+++ b/docs/codeql/codeql-language-guides/analyzing-data-flow-in-java.rst
@@ -17,6 +17,8 @@ The following sections describe how to use the libraries for local data flow, gl
 
 For a more general introduction to modeling data flow, see ":ref:`About data flow analysis <about-data-flow-analysis>`."
 
+.. include:: ../reusables/new-data-flow-api.rst
+
 Local data flow
 ---------------
 

--- a/docs/codeql/codeql-language-guides/analyzing-data-flow-in-python.rst
+++ b/docs/codeql/codeql-language-guides/analyzing-data-flow-in-python.rst
@@ -12,6 +12,8 @@ This article describes how data flow analysis is implemented in the CodeQL libra
 The following sections describe how to use the libraries for local data flow, global data flow, and taint tracking.
 For a more general introduction to modeling data flow, see ":ref:`About data flow analysis <about-data-flow-analysis>`."
 
+.. include:: ../reusables/new-data-flow-api.rst
+
 Local data flow
 ---------------
 

--- a/docs/codeql/codeql-language-guides/analyzing-data-flow-in-ruby.rst
+++ b/docs/codeql/codeql-language-guides/analyzing-data-flow-in-ruby.rst
@@ -12,6 +12,8 @@ This article describes how data flow analysis is implemented in the CodeQL libra
 The following sections describe how to use the libraries for local data flow, global data flow, and taint tracking.
 For a more general introduction to modeling data flow, see ":ref:`About data flow analysis <about-data-flow-analysis>`."
 
+.. include:: ../reusables/new-data-flow-api.rst
+
 Local data flow
 ---------------
 

--- a/docs/codeql/reusables/new-data-flow-api.rst
+++ b/docs/codeql/reusables/new-data-flow-api.rst
@@ -1,0 +1,4 @@
+.. pull-quote:: Note
+
+   The new modular API for data flow described here is available alongside the previous library from CodeQL 2.13.0 onwards. For information about how the library has changed and how to migrate any existing queries to the modular API, see LINK-TO-CHANGELOG.
+   

--- a/docs/codeql/writing-codeql-queries/creating-path-queries.rst
+++ b/docs/codeql/writing-codeql-queries/creating-path-queries.rst
@@ -5,6 +5,8 @@ Creating path queries
 
 You can create path queries to visualize the flow of information through a codebase.
 
+.. include:: ../reusables/new-data-flow-api.rst
+
 Overview
 ========
 

--- a/docs/codeql/writing-codeql-queries/debugging-data-flow-queries-using-partial-flow.rst
+++ b/docs/codeql/writing-codeql-queries/debugging-data-flow-queries-using-partial-flow.rst
@@ -3,6 +3,8 @@
 Debugging data-flow queries using partial flow
 ==============================================
 
+.. include:: ../reusables/new-data-flow-api.rst
+
 If a data-flow query doesn't produce the results you expect to see, you can use partial flow to debug the problem.
 
 In CodeQL, you can use :ref:`data flow analysis <about-data-flow-analysis>` to compute the possible values that a variable can hold at various points in a program.


### PR DESCRIPTION
This is related to the docs update in:

- https://github.com/github/codeql/pull/13743

This can be merged into `main` anytime before the next CodeQL CLI release branch is created.

@coadaflorin - Before this PR can be merged, we need either to know the URL for the planned blog post, or to create a suitable short URL that we can update when we have this information.