### PR TITLE
Java: Make the barrier in java/potentially-weak-cryptographic-algorithm less restrictive

### DIFF
--- a/java/ql/lib/semmle/code/java/security/MaybeBrokenCryptoAlgorithmQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/MaybeBrokenCryptoAlgorithmQuery.qll
@@ -34,15 +34,6 @@ private predicate objectToString(MethodAccess ma) {
   )
 }
 
-private class StringContainer extends RefType {
-  StringContainer() {
-    this instanceof TypeString or
-    this instanceof StringBuildingType or
-    this.hasQualifiedName("java.util", "StringTokenizer") or
-    this.(Array).getComponentType() instanceof StringContainer
-  }
-}
-
 /**
  * A taint-tracking configuration to reason about the use of potentially insecure cryptographic algorithms.
  */
@@ -53,7 +44,7 @@ module InsecureCryptoConfig implements DataFlow::ConfigSig {
 
   predicate isBarrier(DataFlow::Node n) {
     objectToString(n.asExpr()) or
-    not n.getType().getErasure() instanceof StringContainer
+    n.getType().getErasure() instanceof TypeObject
   }
 }
 

--- a/java/ql/src/change-notes/2023-08-01-maybebrokencrypto-barrier.md
+++ b/java/ql/src/change-notes/2023-08-01-maybebrokencrypto-barrier.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The sanitizer in `java/potentially-weak-cryptographic-algorithm` has been improved, so the query may yield additional results.


### PR DESCRIPTION
The current barrier was phrased negatively, so it was catching and blocking all sorts of nodes - in particular it was effectively disabling field flow, which in the context of https://github.com/github/codeql/pull/13478 also means disabling capture flow. This seems unintentional, and I hope we can achieve most of the intended effect with a less restrictive and positively phrased barrier that similarly blocks flow through very generic code without getting into performance trouble.