### PR TITLE
Go: Basic Go 1.21 support

### DIFF
--- a/.github/workflows/go-tests-other-os.yml
+++ b/.github/workflows/go-tests-other-os.yml
@@ -7,15 +7,17 @@ on:
       - .github/workflows/go-tests-other-os.yml
       - .github/actions/**
       - codeql-workspace.yml
+env:
+  GO_VERSION: '1.21.0'
 jobs:
   test-mac:
     name: Test MacOS
     runs-on: macos-latest
     steps:
-      - name: Set up Go 1.20
+      - name: Set up Go ${{ env.GO_VERSION }}
         uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: ${{ env.GO_VERSION }}
         id: go
 
       - name: Check out code
@@ -47,10 +49,10 @@ jobs:
     name: Test Windows
     runs-on: windows-latest-xl
     steps:
-      - name: Set up Go 1.20
+      - name: Set up Go ${{ env.GO_VERSION }}
         uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: ${{ env.GO_VERSION }}
         id: go
 
       - name: Check out code

--- a/.github/workflows/go-tests-other-os.yml
+++ b/.github/workflows/go-tests-other-os.yml
@@ -8,7 +8,7 @@ on:
       - .github/actions/**
       - codeql-workspace.yml
 env:
-  GO_VERSION: '1.21.0'
+  GO_VERSION: '~1.21.0'
 jobs:
   test-mac:
     name: Test MacOS

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -15,15 +15,17 @@ on:
       - .github/workflows/go-tests.yml
       - .github/actions/**
       - codeql-workspace.yml
+env:
+  GO_VERSION: '1.21.0'
 jobs:
   test-linux:
     name: Test Linux (Ubuntu)
     runs-on: ubuntu-latest-xl
     steps:
-      - name: Set up Go 1.20
+      - name: Set up Go ${{ env.GO_VERSION }}
         uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: ${{ env.GO_VERSION }}
         id: go
 
       - name: Check out code

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -16,7 +16,7 @@ on:
       - .github/actions/**
       - codeql-workspace.yml
 env:
-  GO_VERSION: '1.21.0'
+  GO_VERSION: '~1.21.0'
 jobs:
   test-linux:
     name: Test Linux (Ubuntu)

--- a/go/extractor/cli/go-autobuilder/go-autobuilder.go
+++ b/go/extractor/cli/go-autobuilder/go-autobuilder.go
@@ -830,7 +830,7 @@ func installDependenciesAndBuild() {
 }
 
 const minGoVersion = "1.11"
-const maxGoVersion = "1.20"
+const maxGoVersion = "1.21"
 
 // Check if `version` is lower than `minGoVersion`. Note that for this comparison we ignore the
 // patch part of the version, so 1.20.1 and 1.20 are considered equal.

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/github/codeql-go
 
-go 1.20
+go 1.21
 
 require (
 	golang.org/x/mod v0.12.0

--- a/go/ql/lib/semmle/go/Scopes.qll
+++ b/go/ql/lib/semmle/go/Scopes.qll
@@ -795,6 +795,9 @@ module Builtin {
   /** Gets the built-in function `cap`. */
   BuiltinFunction cap() { result.getName() = "cap" }
 
+  /** Gets the built-in function `clear`. */
+  BuiltinFunction clear() { result.getName() = "clear" }
+
   /** Gets the built-in function `close`. */
   BuiltinFunction close() { result.getName() = "close" }
 
@@ -815,6 +818,12 @@ module Builtin {
 
   /** Gets the built-in function `make`. */
   BuiltinFunction make() { result.getName() = "make" }
+
+  /** Gets the built-in function `max`. */
+  BuiltinFunction max_() { result.getName() = "max" }
+
+  /** Gets the built-in function `min`. */
+  BuiltinFunction min_() { result.getName() = "min" }
 
   /** Gets the built-in function `new`. */
   BuiltinFunction new() { result.getName() = "new" }

--- a/go/ql/lib/semmle/go/Scopes.qll
+++ b/go/ql/lib/semmle/go/Scopes.qll
@@ -678,6 +678,8 @@ private predicate builtinFunction(
   or
   name = "cap" and pure = true and mayPanic = false and mustPanic = false and variadic = false
   or
+  name = "clear" and pure = false and mayPanic = false and mustPanic = false and variadic = false
+  or
   name = "close" and pure = false and mayPanic = true and mustPanic = false and variadic = false
   or
   name = "complex" and pure = true and mayPanic = true and mustPanic = false and variadic = false
@@ -691,6 +693,10 @@ private predicate builtinFunction(
   name = "len" and pure = true and mayPanic = false and mustPanic = false and variadic = false
   or
   name = "make" and pure = true and mayPanic = true and mustPanic = false and variadic = true
+  or
+  name = "max" and pure = true and mayPanic = false and mustPanic = false and variadic = true
+  or
+  name = "min" and pure = true and mayPanic = false and mustPanic = false and variadic = true
   or
   name = "new" and pure = true and mayPanic = false and mustPanic = false and variadic = false
   or

--- a/go/ql/lib/semmle/go/dataflow/internal/TaintTrackingUtil.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/TaintTrackingUtil.qll
@@ -408,3 +408,19 @@ class ListOfConstantsComparisonSanitizerGuard extends TaintTracking::DefaultTain
     this = DataFlow::BarrierGuard<listOfConstantsComparisonSanitizerGuard/3>::getABarrierNode()
   }
 }
+
+/**
+ * The `clear` built-in function deletes or zeroes out all elements of a map or slice
+ * and therefore acts as a general sanitizer for taint flow to any uses dominated by it.
+ */
+private class ClearSanitizer extends DefaultTaintSanitizer {
+  ClearSanitizer() {
+    exists(SsaWithFields var, DataFlow::CallNode call, DataFlow::Node arg | this = var.getAUse() |
+      call = Builtin::clear().getACall() and
+      arg = call.getAnArgument() and
+      arg = var.getAUse() and
+      arg != this and
+      this.getBasicBlock().(ReachableBasicBlock).dominates(this.getBasicBlock())
+    )
+  }
+}

--- a/go/ql/lib/semmle/go/frameworks/Stdlib.qll
+++ b/go/ql/lib/semmle/go/frameworks/Stdlib.qll
@@ -70,6 +70,32 @@ private class CopyFunction extends TaintTracking::FunctionModel {
   }
 }
 
+/**
+ * A model of the built-in `min` function, which computes the smallest value of a fixed number of
+ * arguments of ordered types. There is at least one argument and "ordered types" includes e.g.
+ * strings, so we care about data flow through `min`.
+ */
+private class MinFunction extends DataFlow::FunctionModel {
+  MinFunction() { this = Builtin::min_() }
+
+  override predicate hasDataFlow(FunctionInput inp, FunctionOutput outp) {
+    inp.isParameter(_) and outp.isResult()
+  }
+}
+
+/**
+ * A model of the built-in `max` function, which computes the largest value of a fixed number of
+ * arguments of ordered types. There is at least one argument and "ordered types" includes e.g.
+ * strings, so we care about data flow through `max`.
+ */
+private class MaxFunction extends DataFlow::FunctionModel {
+  MaxFunction() { this = Builtin::max_() }
+
+  override predicate hasDataFlow(FunctionInput inp, FunctionOutput outp) {
+    inp.isParameter(_) and outp.isResult()
+  }
+}
+
 /** Provides a class for modeling functions which convert strings into integers. */
 module IntegerParser {
   /**

--- a/go/ql/test/library-tests/semmle/go/Function/TypeParamType.expected
+++ b/go/ql/test/library-tests/semmle/go/Function/TypeParamType.expected
@@ -1,5 +1,6 @@
 | Edge | EdgeConstraint |
 | Edge | interface { } |
+| F | floaty |
 | K | comparable |
 | Node | NodeConstraint |
 | Node | interface { } |
@@ -7,6 +8,8 @@
 | SF2 | interface { } |
 | SG2 | interface { } |
 | T | interface { } |
+| T1 | interface { } |
+| T2 | interface { } |
 | TF1 | interface { } |
 | TF2 | interface { } |
 | TG1 | interface { } |

--- a/go/ql/test/library-tests/semmle/go/dataflow/DefaultTaintSanitizer/Builtin.go
+++ b/go/ql/test/library-tests/semmle/go/dataflow/DefaultTaintSanitizer/Builtin.go
@@ -1,0 +1,16 @@
+package main
+
+import "net/http"
+
+func clearTestBad(sourceReq *http.Request) string {
+	b := make([]byte, 8)
+	sourceReq.Body.Read(b)
+	return string(b)
+}
+
+func clearTestGood(sourceReq *http.Request) string {
+	b := make([]byte, 8)
+	sourceReq.Body.Read(b)
+	clear(b) // should prevent taint flow
+	return string(b)
+}

--- a/go/ql/test/library-tests/semmle/go/dataflow/DefaultTaintSanitizer/DefaultSanitizer.expected
+++ b/go/ql/test/library-tests/semmle/go/dataflow/DefaultTaintSanitizer/DefaultSanitizer.expected
@@ -1,0 +1,10 @@
+edges
+| Builtin.go:6:2:6:2 | definition of b | Builtin.go:8:9:8:17 | type conversion |
+| Builtin.go:7:2:7:15 | selection of Body | Builtin.go:6:2:6:2 | definition of b |
+nodes
+| Builtin.go:6:2:6:2 | definition of b | semmle.label | definition of b |
+| Builtin.go:7:2:7:15 | selection of Body | semmle.label | selection of Body |
+| Builtin.go:8:9:8:17 | type conversion | semmle.label | type conversion |
+subpaths
+#select
+| Builtin.go:8:9:8:17 | type conversion | Builtin.go:7:2:7:15 | selection of Body | Builtin.go:8:9:8:17 | type conversion | Found taint flow |

--- a/go/ql/test/library-tests/semmle/go/dataflow/DefaultTaintSanitizer/DefaultSanitizer.ql
+++ b/go/ql/test/library-tests/semmle/go/dataflow/DefaultTaintSanitizer/DefaultSanitizer.ql
@@ -1,0 +1,20 @@
+/**
+ * @description Check that DefaultTaintSanitizer instances prevent taint flow.
+ * @kind path-problem
+ */
+
+import go
+
+module Config implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node n) { n instanceof UntrustedFlowSource }
+
+  predicate isSink(DataFlow::Node n) { any(ReturnStmt s).getAnExpr() = n.asExpr() }
+}
+
+module Flow = TaintTracking::Global<Config>;
+
+import Flow::PathGraph
+
+from Flow::PathNode source, Flow::PathNode sink
+where Flow::flowPath(source, sink)
+select sink.getNode(), source, sink, "Found taint flow"

--- a/go/ql/test/library-tests/semmle/go/dataflow/FlowSteps/LocalFlowStep.expected
+++ b/go/ql/test/library-tests/semmle/go/dataflow/FlowSteps/LocalFlowStep.expected
@@ -44,6 +44,8 @@
 | file://:0:0:0:0 | function append | main.go:40:8:40:13 | append |
 | file://:0:0:0:0 | function copy | main.go:42:2:42:5 | copy |
 | file://:0:0:0:0 | function make | main.go:41:8:41:11 | make |
+| file://:0:0:0:0 | function max | main.go:65:7:65:9 | max |
+| file://:0:0:0:0 | function min | main.go:64:7:64:9 | min |
 | main.go:3:6:3:10 | function test1 | main.go:34:2:34:6 | test1 |
 | main.go:3:12:3:12 | argument corresponding to x | main.go:3:12:3:12 | definition of x |
 | main.go:3:12:3:12 | definition of x | main.go:5:5:5:5 | x |
@@ -112,6 +114,25 @@
 | main.go:55:6:55:7 | definition of ch | main.go:56:2:56:3 | ch |
 | main.go:55:6:55:7 | definition of ch | main.go:57:4:57:5 | ch |
 | main.go:55:6:55:7 | zero value for ch | main.go:55:6:55:7 | definition of ch |
+| main.go:61:2:61:2 | definition of x | main.go:64:11:64:11 | x |
+| main.go:61:2:61:2 | definition of x | main.go:65:11:65:11 | x |
+| main.go:61:7:61:7 | 1 | main.go:61:2:61:2 | definition of x |
+| main.go:62:2:62:2 | definition of y | main.go:64:14:64:14 | y |
+| main.go:62:2:62:2 | definition of y | main.go:65:14:65:14 | y |
+| main.go:62:7:62:7 | 2 | main.go:62:2:62:2 | definition of y |
+| main.go:63:2:63:2 | definition of z | main.go:64:17:64:17 | z |
+| main.go:63:2:63:2 | definition of z | main.go:65:17:65:17 | z |
+| main.go:63:7:63:7 | 3 | main.go:63:2:63:2 | definition of z |
+| main.go:64:2:64:2 | definition of a | main.go:66:9:66:9 | a |
+| main.go:64:7:64:18 | call to min | main.go:64:2:64:2 | definition of a |
+| main.go:64:11:64:11 | x | main.go:64:7:64:18 | call to min |
+| main.go:64:14:64:14 | y | main.go:64:7:64:18 | call to min |
+| main.go:64:17:64:17 | z | main.go:64:7:64:18 | call to min |
+| main.go:65:2:65:2 | definition of b | main.go:66:12:66:12 | b |
+| main.go:65:7:65:18 | call to max | main.go:65:2:65:2 | definition of b |
+| main.go:65:11:65:11 | x | main.go:65:7:65:18 | call to max |
+| main.go:65:14:65:14 | y | main.go:65:7:65:18 | call to max |
+| main.go:65:17:65:17 | z | main.go:65:7:65:18 | call to max |
 | strings.go:8:12:8:12 | argument corresponding to s | strings.go:8:12:8:12 | definition of s |
 | strings.go:8:12:8:12 | definition of s | strings.go:9:24:9:24 | s |
 | strings.go:8:12:8:12 | definition of s | strings.go:10:27:10:27 | s |

--- a/go/ql/test/library-tests/semmle/go/dataflow/FlowSteps/LocalTaintStep.expected
+++ b/go/ql/test/library-tests/semmle/go/dataflow/FlowSteps/LocalTaintStep.expected
@@ -231,6 +231,8 @@
 | file://:0:0:0:0 | [summary param] -1 in ReadAt | file://:0:0:0:0 | [summary] to write: Argument[0] in ReadAt |
 | file://:0:0:0:0 | [summary param] -1 in ReadDir | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadDir |
 | file://:0:0:0:0 | [summary param] -1 in ReadDir | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadDir |
+| file://:0:0:0:0 | [summary param] -1 in ReadDir | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadDir |
+| file://:0:0:0:0 | [summary param] -1 in ReadFile | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadFile |
 | file://:0:0:0:0 | [summary param] -1 in ReadFile | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadFile |
 | file://:0:0:0:0 | [summary param] -1 in ReadFile | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadFile |
 | file://:0:0:0:0 | [summary param] -1 in Recv | file://:0:0:0:0 | [summary] to write: ReturnValue in Recv |
@@ -238,6 +240,10 @@
 | file://:0:0:0:0 | [summary param] -1 in ResolveReference | file://:0:0:0:0 | [summary] to write: ReturnValue in ResolveReference |
 | file://:0:0:0:0 | [summary param] -1 in Slice | file://:0:0:0:0 | [summary] to write: ReturnValue in Slice |
 | file://:0:0:0:0 | [summary param] -1 in Slice3 | file://:0:0:0:0 | [summary] to write: ReturnValue in Slice3 |
+| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
 | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
 | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
 | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |

--- a/go/ql/test/library-tests/semmle/go/dataflow/FlowSteps/main.go
+++ b/go/ql/test/library-tests/semmle/go/dataflow/FlowSteps/main.go
@@ -56,3 +56,12 @@ func testch() {
 	ch <- true
 	<-ch
 }
+
+func testMinMax() (int, int) {
+	x := 1
+	y := 2
+	z := 3
+	a := min(x, y, z)
+	b := max(x, y, z)
+	return a, b
+}

--- a/go/ql/test/library-tests/semmle/go/frameworks/TaintSteps/TaintStep.expected
+++ b/go/ql/test/library-tests/semmle/go/frameworks/TaintSteps/TaintStep.expected
@@ -509,6 +509,10 @@
 | main.go | main.go:28:2:28:4 | implicit dereference | main.go:28:2:28:9 | selection of Body |
 | main.go | main.go:28:2:28:4 | req | main.go:28:2:28:4 | implicit dereference |
 | main.go | main.go:28:2:28:9 | selection of Body | main.go:27:2:27:2 | definition of b |
+| main.go | main.go:34:2:34:4 | implicit dereference | main.go:32:16:32:18 | definition of req |
+| main.go | main.go:34:2:34:4 | implicit dereference | main.go:34:2:34:9 | selection of Body |
+| main.go | main.go:34:2:34:4 | req | main.go:34:2:34:4 | implicit dereference |
+| main.go | main.go:34:2:34:9 | selection of Body | main.go:33:2:33:2 | definition of b |
 | math/big.Accuracy.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
 | math/big.Float.MarshalText | file://:0:0:0:0 | [summary param] -1 in MarshalText | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalText |
 | math/big.Float.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |

--- a/go/ql/test/library-tests/semmle/go/frameworks/TaintSteps/TaintStep.expected
+++ b/go/ql/test/library-tests/semmle/go/frameworks/TaintSteps/TaintStep.expected
@@ -864,7 +864,6 @@
 | os.fileWithoutReadFrom.WriteString | file://:0:0:0:0 | [summary param] 0 in WriteString | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteString |
 | os.rawConn.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
 | os.rawConn.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| os.unixDirent.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
 | path.Base | file://:0:0:0:0 | [summary param] 0 in Base | file://:0:0:0:0 | [summary] to write: ReturnValue in Base |
 | path.Clean | file://:0:0:0:0 | [summary param] 0 in Clean | file://:0:0:0:0 | [summary] to write: ReturnValue in Clean |
 | path.Dir | file://:0:0:0:0 | [summary param] 0 in Dir | file://:0:0:0:0 | [summary] to write: ReturnValue in Dir |

--- a/go/ql/test/library-tests/semmle/go/frameworks/TaintSteps/TaintStep.expected
+++ b/go/ql/test/library-tests/semmle/go/frameworks/TaintSteps/TaintStep.expected
@@ -1,959 +1,1099 @@
-| crypto.go:9:14:9:31 | call to NewCipher | crypto.go:9:2:9:31 | ... := ...[0] |
-| crypto.go:9:14:9:31 | call to NewCipher | crypto.go:9:2:9:31 | ... := ...[1] |
-| crypto.go:10:15:10:34 | call to NewGCM | crypto.go:10:2:10:34 | ... := ...[0] |
-| crypto.go:10:15:10:34 | call to NewGCM | crypto.go:10:2:10:34 | ... := ...[1] |
-| crypto.go:11:18:11:57 | call to Open | crypto.go:11:2:11:57 | ... := ...[0] |
-| crypto.go:11:18:11:57 | call to Open | crypto.go:11:2:11:57 | ... := ...[1] |
-| crypto.go:11:42:11:51 | ciphertext | crypto.go:11:2:11:57 | ... := ...[0] |
-| file://:0:0:0:0 | [summary param] 0 in Abs | file://:0:0:0:0 | [summary] to write: ReturnValue in Abs |
-| file://:0:0:0:0 | [summary param] 0 in Add | file://:0:0:0:0 | [summary] to write: Argument[-1] in Add |
-| file://:0:0:0:0 | [summary param] 0 in Add | file://:0:0:0:0 | [summary] to write: Argument[-1] in Add |
-| file://:0:0:0:0 | [summary param] 0 in AddCookie | file://:0:0:0:0 | [summary] to write: Argument[-1] in AddCookie |
-| file://:0:0:0:0 | [summary param] 0 in AppendQuote | file://:0:0:0:0 | [summary] to write: ReturnValue in AppendQuote |
-| file://:0:0:0:0 | [summary param] 0 in AppendQuoteToASCII | file://:0:0:0:0 | [summary] to write: ReturnValue in AppendQuoteToASCII |
-| file://:0:0:0:0 | [summary param] 0 in AppendQuoteToGraphic | file://:0:0:0:0 | [summary] to write: ReturnValue in AppendQuoteToGraphic |
-| file://:0:0:0:0 | [summary param] 0 in AppendSlice | file://:0:0:0:0 | [summary] to write: ReturnValue in AppendSlice |
-| file://:0:0:0:0 | [summary param] 0 in As | file://:0:0:0:0 | [summary] to write: Argument[1] in As |
-| file://:0:0:0:0 | [summary param] 0 in Base | file://:0:0:0:0 | [summary] to write: ReturnValue in Base |
-| file://:0:0:0:0 | [summary param] 0 in Base | file://:0:0:0:0 | [summary] to write: ReturnValue in Base |
-| file://:0:0:0:0 | [summary param] 0 in BytePtrFromString | file://:0:0:0:0 | [summary] to write: ReturnValue in BytePtrFromString |
-| file://:0:0:0:0 | [summary param] 0 in ByteSliceFromString | file://:0:0:0:0 | [summary] to write: ReturnValue in ByteSliceFromString |
-| file://:0:0:0:0 | [summary param] 0 in CanonicalHeaderKey | file://:0:0:0:0 | [summary] to write: ReturnValue in CanonicalHeaderKey |
-| file://:0:0:0:0 | [summary param] 0 in CanonicalMIMEHeaderKey | file://:0:0:0:0 | [summary] to write: ReturnValue in CanonicalMIMEHeaderKey |
-| file://:0:0:0:0 | [summary param] 0 in Clean | file://:0:0:0:0 | [summary] to write: ReturnValue in Clean |
-| file://:0:0:0:0 | [summary param] 0 in Clean | file://:0:0:0:0 | [summary] to write: ReturnValue in Clean |
-| file://:0:0:0:0 | [summary param] 0 in Client | file://:0:0:0:0 | [summary] to write: ReturnValue in Client |
-| file://:0:0:0:0 | [summary param] 0 in Clone | file://:0:0:0:0 | [summary] to write: ReturnValue in Clone |
-| file://:0:0:0:0 | [summary param] 0 in Cut | file://:0:0:0:0 | [summary] to write: ReturnValue in Cut |
-| file://:0:0:0:0 | [summary param] 0 in Cut | file://:0:0:0:0 | [summary] to write: ReturnValue[1] in Cut |
-| file://:0:0:0:0 | [summary param] 0 in CutPrefix | file://:0:0:0:0 | [summary] to write: ReturnValue in CutPrefix |
-| file://:0:0:0:0 | [summary param] 0 in CutSuffix | file://:0:0:0:0 | [summary] to write: ReturnValue in CutSuffix |
-| file://:0:0:0:0 | [summary param] 0 in Decode | file://:0:0:0:0 | [summary] to write: ReturnValue in Decode |
-| file://:0:0:0:0 | [summary param] 0 in Decode | file://:0:0:0:0 | [summary] to write: ReturnValue in Decode |
-| file://:0:0:0:0 | [summary param] 0 in Decode | file://:0:0:0:0 | [summary] to write: ReturnValue[1] in Decode |
-| file://:0:0:0:0 | [summary param] 0 in DecodeHeader | file://:0:0:0:0 | [summary] to write: ReturnValue in DecodeHeader |
-| file://:0:0:0:0 | [summary param] 0 in DecodeString | file://:0:0:0:0 | [summary] to write: ReturnValue in DecodeString |
-| file://:0:0:0:0 | [summary param] 0 in DecodeString | file://:0:0:0:0 | [summary] to write: ReturnValue in DecodeString |
-| file://:0:0:0:0 | [summary param] 0 in DecryptPEMBlock | file://:0:0:0:0 | [summary] to write: ReturnValue in DecryptPEMBlock |
-| file://:0:0:0:0 | [summary param] 0 in Dir | file://:0:0:0:0 | [summary] to write: ReturnValue in Dir |
-| file://:0:0:0:0 | [summary param] 0 in Dir | file://:0:0:0:0 | [summary] to write: ReturnValue in Dir |
-| file://:0:0:0:0 | [summary param] 0 in Encode | file://:0:0:0:0 | [summary] to write: Argument[-1] in Encode |
-| file://:0:0:0:0 | [summary param] 0 in EncodeToMemory | file://:0:0:0:0 | [summary] to write: ReturnValue in EncodeToMemory |
-| file://:0:0:0:0 | [summary param] 0 in EvalSymlinks | file://:0:0:0:0 | [summary] to write: ReturnValue in EvalSymlinks |
-| file://:0:0:0:0 | [summary param] 0 in Expand | file://:0:0:0:0 | [summary] to write: ReturnValue in Expand |
-| file://:0:0:0:0 | [summary param] 0 in ExpandEnv | file://:0:0:0:0 | [summary] to write: ReturnValue in ExpandEnv |
-| file://:0:0:0:0 | [summary param] 0 in Ext | file://:0:0:0:0 | [summary] to write: ReturnValue in Ext |
-| file://:0:0:0:0 | [summary param] 0 in Ext | file://:0:0:0:0 | [summary] to write: ReturnValue in Ext |
-| file://:0:0:0:0 | [summary param] 0 in Fields | file://:0:0:0:0 | [summary] to write: ReturnValue in Fields |
-| file://:0:0:0:0 | [summary param] 0 in Fields | file://:0:0:0:0 | [summary] to write: ReturnValue in Fields |
-| file://:0:0:0:0 | [summary param] 0 in FieldsFunc | file://:0:0:0:0 | [summary] to write: ReturnValue in FieldsFunc |
-| file://:0:0:0:0 | [summary param] 0 in FieldsFunc | file://:0:0:0:0 | [summary] to write: ReturnValue in FieldsFunc |
-| file://:0:0:0:0 | [summary param] 0 in FileConn | file://:0:0:0:0 | [summary] to write: ReturnValue in FileConn |
-| file://:0:0:0:0 | [summary param] 0 in FileInfoToDirEntry | file://:0:0:0:0 | [summary] to write: ReturnValue in FileInfoToDirEntry |
-| file://:0:0:0:0 | [summary param] 0 in FilePacketConn | file://:0:0:0:0 | [summary] to write: ReturnValue in FilePacketConn |
-| file://:0:0:0:0 | [summary param] 0 in FormatMediaType | file://:0:0:0:0 | [summary] to write: ReturnValue in FormatMediaType |
-| file://:0:0:0:0 | [summary param] 0 in FromSlash | file://:0:0:0:0 | [summary] to write: ReturnValue in FromSlash |
-| file://:0:0:0:0 | [summary param] 0 in Glob | file://:0:0:0:0 | [summary] to write: ReturnValue in Glob |
-| file://:0:0:0:0 | [summary param] 0 in Glob | file://:0:0:0:0 | [summary] to write: ReturnValue in Glob |
-| file://:0:0:0:0 | [summary param] 0 in Indirect | file://:0:0:0:0 | [summary] to write: ReturnValue in Indirect |
-| file://:0:0:0:0 | [summary param] 0 in InsertAfter | file://:0:0:0:0 | [summary] to write: Argument[-1] in InsertAfter |
-| file://:0:0:0:0 | [summary param] 0 in InsertAfter | file://:0:0:0:0 | [summary] to write: ReturnValue in InsertAfter |
-| file://:0:0:0:0 | [summary param] 0 in InsertBefore | file://:0:0:0:0 | [summary] to write: Argument[-1] in InsertBefore |
-| file://:0:0:0:0 | [summary param] 0 in InsertBefore | file://:0:0:0:0 | [summary] to write: ReturnValue in InsertBefore |
-| file://:0:0:0:0 | [summary param] 0 in Join | file://:0:0:0:0 | [summary] to write: ReturnValue in Join |
-| file://:0:0:0:0 | [summary param] 0 in Join | file://:0:0:0:0 | [summary] to write: ReturnValue in Join |
-| file://:0:0:0:0 | [summary param] 0 in JoinHostPort | file://:0:0:0:0 | [summary] to write: ReturnValue in JoinHostPort |
-| file://:0:0:0:0 | [summary param] 0 in LimitReader | file://:0:0:0:0 | [summary] to write: ReturnValue in LimitReader |
-| file://:0:0:0:0 | [summary param] 0 in LoadOrStore | file://:0:0:0:0 | [summary] to write: Argument[-1] in LoadOrStore |
-| file://:0:0:0:0 | [summary param] 0 in LoadOrStore | file://:0:0:0:0 | [summary] to write: ReturnValue in LoadOrStore |
-| file://:0:0:0:0 | [summary param] 0 in LoadPointer | file://:0:0:0:0 | [summary] to write: ReturnValue in LoadPointer |
-| file://:0:0:0:0 | [summary param] 0 in LoadUintptr | file://:0:0:0:0 | [summary] to write: ReturnValue in LoadUintptr |
-| file://:0:0:0:0 | [summary param] 0 in Marshal | file://:0:0:0:0 | [summary] to write: ReturnValue in Marshal |
-| file://:0:0:0:0 | [summary param] 0 in Marshal | file://:0:0:0:0 | [summary] to write: ReturnValue in Marshal |
-| file://:0:0:0:0 | [summary param] 0 in MarshalIndent | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalIndent |
-| file://:0:0:0:0 | [summary param] 0 in MarshalWithParams | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalWithParams |
-| file://:0:0:0:0 | [summary param] 0 in MoveAfter | file://:0:0:0:0 | [summary] to write: Argument[-1] in MoveAfter |
-| file://:0:0:0:0 | [summary param] 0 in MoveBefore | file://:0:0:0:0 | [summary] to write: Argument[-1] in MoveBefore |
-| file://:0:0:0:0 | [summary param] 0 in MoveToBack | file://:0:0:0:0 | [summary] to write: Argument[-1] in MoveToBack |
-| file://:0:0:0:0 | [summary param] 0 in MoveToFront | file://:0:0:0:0 | [summary] to write: Argument[-1] in MoveToFront |
-| file://:0:0:0:0 | [summary param] 0 in New | file://:0:0:0:0 | [summary] to write: ReturnValue in New |
-| file://:0:0:0:0 | [summary param] 0 in NewBuffer | file://:0:0:0:0 | [summary] to write: ReturnValue in NewBuffer |
-| file://:0:0:0:0 | [summary param] 0 in NewBufferString | file://:0:0:0:0 | [summary] to write: ReturnValue in NewBufferString |
-| file://:0:0:0:0 | [summary param] 0 in NewConn | file://:0:0:0:0 | [summary] to write: ReturnValue in NewConn |
-| file://:0:0:0:0 | [summary param] 0 in NewDecoder | file://:0:0:0:0 | [summary] to write: ReturnValue in NewDecoder |
-| file://:0:0:0:0 | [summary param] 0 in NewDecoder | file://:0:0:0:0 | [summary] to write: ReturnValue in NewDecoder |
-| file://:0:0:0:0 | [summary param] 0 in NewFile | file://:0:0:0:0 | [summary] to write: ReturnValue in NewFile |
-| file://:0:0:0:0 | [summary param] 0 in NewListener | file://:0:0:0:0 | [summary] to write: ReturnValue in NewListener |
-| file://:0:0:0:0 | [summary param] 0 in NewReadWriter | file://:0:0:0:0 | [summary] to write: ReturnValue in NewReadWriter |
-| file://:0:0:0:0 | [summary param] 0 in NewReader | file://:0:0:0:0 | [summary] to write: ReturnValue in NewReader |
-| file://:0:0:0:0 | [summary param] 0 in NewReader | file://:0:0:0:0 | [summary] to write: ReturnValue in NewReader |
-| file://:0:0:0:0 | [summary param] 0 in NewReader | file://:0:0:0:0 | [summary] to write: ReturnValue in NewReader |
-| file://:0:0:0:0 | [summary param] 0 in NewReader | file://:0:0:0:0 | [summary] to write: ReturnValue in NewReader |
-| file://:0:0:0:0 | [summary param] 0 in NewReader | file://:0:0:0:0 | [summary] to write: ReturnValue in NewReader |
-| file://:0:0:0:0 | [summary param] 0 in NewReader | file://:0:0:0:0 | [summary] to write: ReturnValue in NewReader |
-| file://:0:0:0:0 | [summary param] 0 in NewReader | file://:0:0:0:0 | [summary] to write: ReturnValue in NewReader |
-| file://:0:0:0:0 | [summary param] 0 in NewReader | file://:0:0:0:0 | [summary] to write: ReturnValue in NewReader |
-| file://:0:0:0:0 | [summary param] 0 in NewReaderDict | file://:0:0:0:0 | [summary] to write: ReturnValue in NewReaderDict |
-| file://:0:0:0:0 | [summary param] 0 in NewReaderSize | file://:0:0:0:0 | [summary] to write: ReturnValue in NewReaderSize |
-| file://:0:0:0:0 | [summary param] 0 in NewScanner | file://:0:0:0:0 | [summary] to write: ReturnValue in NewScanner |
-| file://:0:0:0:0 | [summary param] 0 in NewSectionReader | file://:0:0:0:0 | [summary] to write: ReturnValue in NewSectionReader |
-| file://:0:0:0:0 | [summary param] 0 in NopCloser | file://:0:0:0:0 | [summary] to write: ReturnValue in NopCloser |
-| file://:0:0:0:0 | [summary param] 0 in NopCloser | file://:0:0:0:0 | [summary] to write: ReturnValue in NopCloser |
-| file://:0:0:0:0 | [summary param] 0 in Parse | file://:0:0:0:0 | [summary] to write: ReturnValue in Parse |
-| file://:0:0:0:0 | [summary param] 0 in Parse | file://:0:0:0:0 | [summary] to write: ReturnValue in Parse |
-| file://:0:0:0:0 | [summary param] 0 in ParseMediaType | file://:0:0:0:0 | [summary] to write: ReturnValue in ParseMediaType |
-| file://:0:0:0:0 | [summary param] 0 in ParseMediaType | file://:0:0:0:0 | [summary] to write: ReturnValue[1] in ParseMediaType |
-| file://:0:0:0:0 | [summary param] 0 in ParseQuery | file://:0:0:0:0 | [summary] to write: ReturnValue in ParseQuery |
-| file://:0:0:0:0 | [summary param] 0 in ParseRequestURI | file://:0:0:0:0 | [summary] to write: ReturnValue in ParseRequestURI |
-| file://:0:0:0:0 | [summary param] 0 in PathEscape | file://:0:0:0:0 | [summary] to write: ReturnValue in PathEscape |
-| file://:0:0:0:0 | [summary param] 0 in PathUnescape | file://:0:0:0:0 | [summary] to write: ReturnValue in PathUnescape |
-| file://:0:0:0:0 | [summary param] 0 in PushBack | file://:0:0:0:0 | [summary] to write: Argument[-1] in PushBack |
-| file://:0:0:0:0 | [summary param] 0 in PushBack | file://:0:0:0:0 | [summary] to write: ReturnValue in PushBack |
-| file://:0:0:0:0 | [summary param] 0 in PushBackList | file://:0:0:0:0 | [summary] to write: Argument[-1] in PushBackList |
-| file://:0:0:0:0 | [summary param] 0 in PushFront | file://:0:0:0:0 | [summary] to write: Argument[-1] in PushFront |
-| file://:0:0:0:0 | [summary param] 0 in PushFront | file://:0:0:0:0 | [summary] to write: ReturnValue in PushFront |
-| file://:0:0:0:0 | [summary param] 0 in PushFrontList | file://:0:0:0:0 | [summary] to write: Argument[-1] in PushFrontList |
-| file://:0:0:0:0 | [summary param] 0 in Put | file://:0:0:0:0 | [summary] to write: Argument[-1] in Put |
-| file://:0:0:0:0 | [summary param] 0 in QueryEscape | file://:0:0:0:0 | [summary] to write: ReturnValue in QueryEscape |
-| file://:0:0:0:0 | [summary param] 0 in QueryUnescape | file://:0:0:0:0 | [summary] to write: ReturnValue in QueryUnescape |
-| file://:0:0:0:0 | [summary param] 0 in Quote | file://:0:0:0:0 | [summary] to write: ReturnValue in Quote |
-| file://:0:0:0:0 | [summary param] 0 in QuoteToASCII | file://:0:0:0:0 | [summary] to write: ReturnValue in QuoteToASCII |
-| file://:0:0:0:0 | [summary param] 0 in QuoteToGraphic | file://:0:0:0:0 | [summary] to write: ReturnValue in QuoteToGraphic |
-| file://:0:0:0:0 | [summary param] 0 in QuotedPrefix | file://:0:0:0:0 | [summary] to write: ReturnValue in QuotedPrefix |
-| file://:0:0:0:0 | [summary param] 0 in Read | file://:0:0:0:0 | [summary] to write: Argument[2] in Read |
-| file://:0:0:0:0 | [summary param] 0 in ReadAll | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadAll |
-| file://:0:0:0:0 | [summary param] 0 in ReadAll | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadAll |
-| file://:0:0:0:0 | [summary param] 0 in ReadAtLeast | file://:0:0:0:0 | [summary] to write: Argument[1] in ReadAtLeast |
-| file://:0:0:0:0 | [summary param] 0 in ReadDir | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadDir |
-| file://:0:0:0:0 | [summary param] 0 in ReadFile | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadFile |
-| file://:0:0:0:0 | [summary param] 0 in ReadFrom | file://:0:0:0:0 | [summary] to write: Argument[-1] in ReadFrom |
-| file://:0:0:0:0 | [summary param] 0 in ReadFrom | file://:0:0:0:0 | [summary] to write: Argument[-1] in ReadFrom |
-| file://:0:0:0:0 | [summary param] 0 in ReadFrom | file://:0:0:0:0 | [summary] to write: Argument[-1] in ReadFrom |
-| file://:0:0:0:0 | [summary param] 0 in ReadFrom | file://:0:0:0:0 | [summary] to write: Argument[-1] in ReadFrom |
-| file://:0:0:0:0 | [summary param] 0 in ReadFrom | file://:0:0:0:0 | [summary] to write: Argument[-1] in ReadFrom |
-| file://:0:0:0:0 | [summary param] 0 in ReadFrom | file://:0:0:0:0 | [summary] to write: Argument[-1] in ReadFrom |
-| file://:0:0:0:0 | [summary param] 0 in ReadFrom | file://:0:0:0:0 | [summary] to write: Argument[-1] in ReadFrom |
-| file://:0:0:0:0 | [summary param] 0 in ReadFrom | file://:0:0:0:0 | [summary] to write: Argument[-1] in ReadFrom |
-| file://:0:0:0:0 | [summary param] 0 in ReadFull | file://:0:0:0:0 | [summary] to write: Argument[1] in ReadFull |
-| file://:0:0:0:0 | [summary param] 0 in ReadRequest | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadRequest |
-| file://:0:0:0:0 | [summary param] 0 in ReadResponse | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadResponse |
-| file://:0:0:0:0 | [summary param] 0 in Rel | file://:0:0:0:0 | [summary] to write: ReturnValue in Rel |
-| file://:0:0:0:0 | [summary param] 0 in Remove | file://:0:0:0:0 | [summary] to write: ReturnValue in Remove |
-| file://:0:0:0:0 | [summary param] 0 in Repeat | file://:0:0:0:0 | [summary] to write: ReturnValue in Repeat |
-| file://:0:0:0:0 | [summary param] 0 in Repeat | file://:0:0:0:0 | [summary] to write: ReturnValue in Repeat |
-| file://:0:0:0:0 | [summary param] 0 in Replace | file://:0:0:0:0 | [summary] to write: ReturnValue in Replace |
-| file://:0:0:0:0 | [summary param] 0 in Replace | file://:0:0:0:0 | [summary] to write: ReturnValue in Replace |
-| file://:0:0:0:0 | [summary param] 0 in Replace | file://:0:0:0:0 | [summary] to write: ReturnValue in Replace |
-| file://:0:0:0:0 | [summary param] 0 in ReplaceAll | file://:0:0:0:0 | [summary] to write: ReturnValue in ReplaceAll |
-| file://:0:0:0:0 | [summary param] 0 in ReplaceAll | file://:0:0:0:0 | [summary] to write: ReturnValue in ReplaceAll |
-| file://:0:0:0:0 | [summary param] 0 in Reset | file://:0:0:0:0 | [summary] to write: Argument[-1] in Reset |
-| file://:0:0:0:0 | [summary param] 0 in Reset | file://:0:0:0:0 | [summary] to write: Argument[-1] in Reset |
-| file://:0:0:0:0 | [summary param] 0 in Reset | file://:0:0:0:0 | [summary] to write: Argument[-1] in Reset |
-| file://:0:0:0:0 | [summary param] 0 in Reset | file://:0:0:0:0 | [summary] to write: Argument[-1] in Reset |
-| file://:0:0:0:0 | [summary param] 0 in Reset | file://:0:0:0:0 | [summary] to write: Argument[-1] in Reset |
-| file://:0:0:0:0 | [summary param] 0 in Reset | file://:0:0:0:0 | [summary] to write: Argument[-1] in Reset |
-| file://:0:0:0:0 | [summary param] 0 in ResolveReference | file://:0:0:0:0 | [summary] to write: ReturnValue in ResolveReference |
-| file://:0:0:0:0 | [summary param] 0 in Reverse | file://:0:0:0:0 | [summary] to write: ReturnValue in Reverse |
-| file://:0:0:0:0 | [summary param] 0 in Runes | file://:0:0:0:0 | [summary] to write: ReturnValue in Runes |
-| file://:0:0:0:0 | [summary param] 0 in ScanBytes | file://:0:0:0:0 | [summary] to write: ReturnValue[1] in ScanBytes |
-| file://:0:0:0:0 | [summary param] 0 in ScanLines | file://:0:0:0:0 | [summary] to write: ReturnValue[1] in ScanLines |
-| file://:0:0:0:0 | [summary param] 0 in ScanRunes | file://:0:0:0:0 | [summary] to write: ReturnValue[1] in ScanRunes |
-| file://:0:0:0:0 | [summary param] 0 in ScanWords | file://:0:0:0:0 | [summary] to write: ReturnValue[1] in ScanWords |
-| file://:0:0:0:0 | [summary param] 0 in Send | file://:0:0:0:0 | [summary] to write: Argument[-1] in Send |
-| file://:0:0:0:0 | [summary param] 0 in Server | file://:0:0:0:0 | [summary] to write: ReturnValue in Server |
-| file://:0:0:0:0 | [summary param] 0 in Set | file://:0:0:0:0 | [summary] to write: Argument[-1] in Set |
-| file://:0:0:0:0 | [summary param] 0 in Set | file://:0:0:0:0 | [summary] to write: Argument[-1] in Set |
-| file://:0:0:0:0 | [summary param] 0 in Set | file://:0:0:0:0 | [summary] to write: Argument[-1] in Set |
-| file://:0:0:0:0 | [summary param] 0 in SetBytes | file://:0:0:0:0 | [summary] to write: Argument[-1] in SetBytes |
-| file://:0:0:0:0 | [summary param] 0 in SetIndent | file://:0:0:0:0 | [summary] to write: Argument[-1] in SetIndent |
-| file://:0:0:0:0 | [summary param] 0 in SetMapIndex | file://:0:0:0:0 | [summary] to write: Argument[-1] in SetMapIndex |
-| file://:0:0:0:0 | [summary param] 0 in SetPointer | file://:0:0:0:0 | [summary] to write: Argument[-1] in SetPointer |
-| file://:0:0:0:0 | [summary param] 0 in SetPrefix | file://:0:0:0:0 | [summary] to write: Argument[-1] in SetPrefix |
-| file://:0:0:0:0 | [summary param] 0 in SetString | file://:0:0:0:0 | [summary] to write: Argument[-1] in SetString |
-| file://:0:0:0:0 | [summary param] 0 in Split | file://:0:0:0:0 | [summary] to write: ReturnValue in Split |
-| file://:0:0:0:0 | [summary param] 0 in Split | file://:0:0:0:0 | [summary] to write: ReturnValue in Split |
-| file://:0:0:0:0 | [summary param] 0 in Split | file://:0:0:0:0 | [summary] to write: ReturnValue in Split |
-| file://:0:0:0:0 | [summary param] 0 in Split | file://:0:0:0:0 | [summary] to write: ReturnValue in Split |
-| file://:0:0:0:0 | [summary param] 0 in Split | file://:0:0:0:0 | [summary] to write: ReturnValue[1] in Split |
-| file://:0:0:0:0 | [summary param] 0 in Split | file://:0:0:0:0 | [summary] to write: ReturnValue[1] in Split |
-| file://:0:0:0:0 | [summary param] 0 in SplitAfter | file://:0:0:0:0 | [summary] to write: ReturnValue in SplitAfter |
-| file://:0:0:0:0 | [summary param] 0 in SplitAfter | file://:0:0:0:0 | [summary] to write: ReturnValue in SplitAfter |
-| file://:0:0:0:0 | [summary param] 0 in SplitAfterN | file://:0:0:0:0 | [summary] to write: ReturnValue in SplitAfterN |
-| file://:0:0:0:0 | [summary param] 0 in SplitAfterN | file://:0:0:0:0 | [summary] to write: ReturnValue in SplitAfterN |
-| file://:0:0:0:0 | [summary param] 0 in SplitHostPort | file://:0:0:0:0 | [summary] to write: ReturnValue in SplitHostPort |
-| file://:0:0:0:0 | [summary param] 0 in SplitHostPort | file://:0:0:0:0 | [summary] to write: ReturnValue[1] in SplitHostPort |
-| file://:0:0:0:0 | [summary param] 0 in SplitList | file://:0:0:0:0 | [summary] to write: ReturnValue in SplitList |
-| file://:0:0:0:0 | [summary param] 0 in SplitN | file://:0:0:0:0 | [summary] to write: ReturnValue in SplitN |
-| file://:0:0:0:0 | [summary param] 0 in SplitN | file://:0:0:0:0 | [summary] to write: ReturnValue in SplitN |
-| file://:0:0:0:0 | [summary param] 0 in Store | file://:0:0:0:0 | [summary] to write: Argument[-1] in Store |
-| file://:0:0:0:0 | [summary param] 0 in Store | file://:0:0:0:0 | [summary] to write: Argument[-1] in Store |
-| file://:0:0:0:0 | [summary param] 0 in Store | file://:0:0:0:0 | [summary] to write: Argument[-1] in Store |
-| file://:0:0:0:0 | [summary param] 0 in Store | file://:0:0:0:0 | [summary] to write: Argument[-1] in Store |
-| file://:0:0:0:0 | [summary param] 0 in StringBytePtr | file://:0:0:0:0 | [summary] to write: ReturnValue in StringBytePtr |
-| file://:0:0:0:0 | [summary param] 0 in StringByteSlice | file://:0:0:0:0 | [summary] to write: ReturnValue in StringByteSlice |
-| file://:0:0:0:0 | [summary param] 0 in Sub | file://:0:0:0:0 | [summary] to write: ReturnValue in Sub |
-| file://:0:0:0:0 | [summary param] 0 in Swap | file://:0:0:0:0 | [summary] to write: Argument[-1] in Swap |
-| file://:0:0:0:0 | [summary param] 0 in Swap | file://:0:0:0:0 | [summary] to write: Argument[-1] in Swap |
-| file://:0:0:0:0 | [summary param] 0 in Swap | file://:0:0:0:0 | [summary] to write: Argument[-1] in Swap |
-| file://:0:0:0:0 | [summary param] 0 in Swap | file://:0:0:0:0 | [summary] to write: Argument[-1] in Swap |
-| file://:0:0:0:0 | [summary param] 0 in SwapPointer | file://:0:0:0:0 | [summary] to write: ReturnValue in SwapPointer |
-| file://:0:0:0:0 | [summary param] 0 in SwapUintptr | file://:0:0:0:0 | [summary] to write: ReturnValue in SwapUintptr |
-| file://:0:0:0:0 | [summary param] 0 in TeeReader | file://:0:0:0:0 | [summary] to write: Argument[1] in TeeReader |
-| file://:0:0:0:0 | [summary param] 0 in TeeReader | file://:0:0:0:0 | [summary] to write: ReturnValue in TeeReader |
-| file://:0:0:0:0 | [summary param] 0 in Title | file://:0:0:0:0 | [summary] to write: ReturnValue in Title |
-| file://:0:0:0:0 | [summary param] 0 in Title | file://:0:0:0:0 | [summary] to write: ReturnValue in Title |
-| file://:0:0:0:0 | [summary param] 0 in ToLower | file://:0:0:0:0 | [summary] to write: ReturnValue in ToLower |
-| file://:0:0:0:0 | [summary param] 0 in ToLower | file://:0:0:0:0 | [summary] to write: ReturnValue in ToLower |
-| file://:0:0:0:0 | [summary param] 0 in ToSlash | file://:0:0:0:0 | [summary] to write: ReturnValue in ToSlash |
-| file://:0:0:0:0 | [summary param] 0 in ToTitle | file://:0:0:0:0 | [summary] to write: ReturnValue in ToTitle |
-| file://:0:0:0:0 | [summary param] 0 in ToTitle | file://:0:0:0:0 | [summary] to write: ReturnValue in ToTitle |
-| file://:0:0:0:0 | [summary param] 0 in ToUpper | file://:0:0:0:0 | [summary] to write: ReturnValue in ToUpper |
-| file://:0:0:0:0 | [summary param] 0 in ToUpper | file://:0:0:0:0 | [summary] to write: ReturnValue in ToUpper |
-| file://:0:0:0:0 | [summary param] 0 in ToValidUTF8 | file://:0:0:0:0 | [summary] to write: ReturnValue in ToValidUTF8 |
-| file://:0:0:0:0 | [summary param] 0 in ToValidUTF8 | file://:0:0:0:0 | [summary] to write: ReturnValue in ToValidUTF8 |
-| file://:0:0:0:0 | [summary param] 0 in Trim | file://:0:0:0:0 | [summary] to write: ReturnValue in Trim |
-| file://:0:0:0:0 | [summary param] 0 in Trim | file://:0:0:0:0 | [summary] to write: ReturnValue in Trim |
-| file://:0:0:0:0 | [summary param] 0 in TrimBytes | file://:0:0:0:0 | [summary] to write: ReturnValue in TrimBytes |
-| file://:0:0:0:0 | [summary param] 0 in TrimFunc | file://:0:0:0:0 | [summary] to write: ReturnValue in TrimFunc |
-| file://:0:0:0:0 | [summary param] 0 in TrimFunc | file://:0:0:0:0 | [summary] to write: ReturnValue in TrimFunc |
-| file://:0:0:0:0 | [summary param] 0 in TrimLeft | file://:0:0:0:0 | [summary] to write: ReturnValue in TrimLeft |
-| file://:0:0:0:0 | [summary param] 0 in TrimLeft | file://:0:0:0:0 | [summary] to write: ReturnValue in TrimLeft |
-| file://:0:0:0:0 | [summary param] 0 in TrimLeftFunc | file://:0:0:0:0 | [summary] to write: ReturnValue in TrimLeftFunc |
-| file://:0:0:0:0 | [summary param] 0 in TrimLeftFunc | file://:0:0:0:0 | [summary] to write: ReturnValue in TrimLeftFunc |
-| file://:0:0:0:0 | [summary param] 0 in TrimPrefix | file://:0:0:0:0 | [summary] to write: ReturnValue in TrimPrefix |
-| file://:0:0:0:0 | [summary param] 0 in TrimPrefix | file://:0:0:0:0 | [summary] to write: ReturnValue in TrimPrefix |
-| file://:0:0:0:0 | [summary param] 0 in TrimRight | file://:0:0:0:0 | [summary] to write: ReturnValue in TrimRight |
-| file://:0:0:0:0 | [summary param] 0 in TrimRight | file://:0:0:0:0 | [summary] to write: ReturnValue in TrimRight |
-| file://:0:0:0:0 | [summary param] 0 in TrimRightFunc | file://:0:0:0:0 | [summary] to write: ReturnValue in TrimRightFunc |
-| file://:0:0:0:0 | [summary param] 0 in TrimRightFunc | file://:0:0:0:0 | [summary] to write: ReturnValue in TrimRightFunc |
-| file://:0:0:0:0 | [summary param] 0 in TrimSpace | file://:0:0:0:0 | [summary] to write: ReturnValue in TrimSpace |
-| file://:0:0:0:0 | [summary param] 0 in TrimSpace | file://:0:0:0:0 | [summary] to write: ReturnValue in TrimSpace |
-| file://:0:0:0:0 | [summary param] 0 in TrimString | file://:0:0:0:0 | [summary] to write: ReturnValue in TrimString |
-| file://:0:0:0:0 | [summary param] 0 in TrimSuffix | file://:0:0:0:0 | [summary] to write: ReturnValue in TrimSuffix |
-| file://:0:0:0:0 | [summary param] 0 in TrimSuffix | file://:0:0:0:0 | [summary] to write: ReturnValue in TrimSuffix |
-| file://:0:0:0:0 | [summary param] 0 in TrySend | file://:0:0:0:0 | [summary] to write: Argument[-1] in TrySend |
-| file://:0:0:0:0 | [summary param] 0 in Unmarshal | file://:0:0:0:0 | [summary] to write: Argument[1] in Unmarshal |
-| file://:0:0:0:0 | [summary param] 0 in Unmarshal | file://:0:0:0:0 | [summary] to write: Argument[1] in Unmarshal |
-| file://:0:0:0:0 | [summary param] 0 in Unmarshal | file://:0:0:0:0 | [summary] to write: ReturnValue in Unmarshal |
-| file://:0:0:0:0 | [summary param] 0 in UnmarshalBinary | file://:0:0:0:0 | [summary] to write: Argument[-1] in UnmarshalBinary |
-| file://:0:0:0:0 | [summary param] 0 in UnmarshalBinary | file://:0:0:0:0 | [summary] to write: Argument[-1] in UnmarshalBinary |
-| file://:0:0:0:0 | [summary param] 0 in UnmarshalBinary | file://:0:0:0:0 | [summary] to write: Argument[-1] in UnmarshalBinary |
-| file://:0:0:0:0 | [summary param] 0 in UnmarshalBinary | file://:0:0:0:0 | [summary] to write: Argument[-1] in UnmarshalBinary |
-| file://:0:0:0:0 | [summary param] 0 in UnmarshalBinary | file://:0:0:0:0 | [summary] to write: Argument[-1] in UnmarshalBinary |
-| file://:0:0:0:0 | [summary param] 0 in UnmarshalBinary | file://:0:0:0:0 | [summary] to write: Argument[-1] in UnmarshalBinary |
-| file://:0:0:0:0 | [summary param] 0 in UnmarshalBinary | file://:0:0:0:0 | [summary] to write: Argument[-1] in UnmarshalBinary |
-| file://:0:0:0:0 | [summary param] 0 in UnmarshalBinary | file://:0:0:0:0 | [summary] to write: Argument[-1] in UnmarshalBinary |
-| file://:0:0:0:0 | [summary param] 0 in UnmarshalBinary | file://:0:0:0:0 | [summary] to write: Argument[-1] in UnmarshalBinary |
-| file://:0:0:0:0 | [summary param] 0 in UnmarshalBinary | file://:0:0:0:0 | [summary] to write: Argument[-1] in UnmarshalBinary |
-| file://:0:0:0:0 | [summary param] 0 in UnmarshalBinary | file://:0:0:0:0 | [summary] to write: Argument[-1] in UnmarshalBinary |
-| file://:0:0:0:0 | [summary param] 0 in UnmarshalBinary | file://:0:0:0:0 | [summary] to write: Argument[-1] in UnmarshalBinary |
-| file://:0:0:0:0 | [summary param] 0 in UnmarshalJSON | file://:0:0:0:0 | [summary] to write: Argument[-1] in UnmarshalJSON |
-| file://:0:0:0:0 | [summary param] 0 in UnmarshalJSON | file://:0:0:0:0 | [summary] to write: Argument[-1] in UnmarshalJSON |
-| file://:0:0:0:0 | [summary param] 0 in UnmarshalJSON | file://:0:0:0:0 | [summary] to write: Argument[-1] in UnmarshalJSON |
-| file://:0:0:0:0 | [summary param] 0 in UnmarshalJSON | file://:0:0:0:0 | [summary] to write: Argument[-1] in UnmarshalJSON |
-| file://:0:0:0:0 | [summary param] 0 in UnmarshalText | file://:0:0:0:0 | [summary] to write: Argument[-1] in UnmarshalText |
-| file://:0:0:0:0 | [summary param] 0 in UnmarshalText | file://:0:0:0:0 | [summary] to write: Argument[-1] in UnmarshalText |
-| file://:0:0:0:0 | [summary param] 0 in UnmarshalText | file://:0:0:0:0 | [summary] to write: Argument[-1] in UnmarshalText |
-| file://:0:0:0:0 | [summary param] 0 in UnmarshalText | file://:0:0:0:0 | [summary] to write: Argument[-1] in UnmarshalText |
-| file://:0:0:0:0 | [summary param] 0 in UnmarshalText | file://:0:0:0:0 | [summary] to write: Argument[-1] in UnmarshalText |
-| file://:0:0:0:0 | [summary param] 0 in UnmarshalText | file://:0:0:0:0 | [summary] to write: Argument[-1] in UnmarshalText |
-| file://:0:0:0:0 | [summary param] 0 in UnmarshalText | file://:0:0:0:0 | [summary] to write: Argument[-1] in UnmarshalText |
-| file://:0:0:0:0 | [summary param] 0 in UnmarshalText | file://:0:0:0:0 | [summary] to write: Argument[-1] in UnmarshalText |
-| file://:0:0:0:0 | [summary param] 0 in UnmarshalText | file://:0:0:0:0 | [summary] to write: Argument[-1] in UnmarshalText |
-| file://:0:0:0:0 | [summary param] 0 in UnmarshalWithParams | file://:0:0:0:0 | [summary] to write: Argument[1] in UnmarshalWithParams |
-| file://:0:0:0:0 | [summary param] 0 in UnmarshalWithParams | file://:0:0:0:0 | [summary] to write: ReturnValue in UnmarshalWithParams |
-| file://:0:0:0:0 | [summary param] 0 in Unquote | file://:0:0:0:0 | [summary] to write: ReturnValue in Unquote |
-| file://:0:0:0:0 | [summary param] 0 in UnquoteChar | file://:0:0:0:0 | [summary] to write: ReturnValue[2] in UnquoteChar |
-| file://:0:0:0:0 | [summary param] 0 in Unwrap | file://:0:0:0:0 | [summary] to write: ReturnValue in Unwrap |
-| file://:0:0:0:0 | [summary param] 0 in User | file://:0:0:0:0 | [summary] to write: ReturnValue in User |
-| file://:0:0:0:0 | [summary param] 0 in UserPassword | file://:0:0:0:0 | [summary] to write: ReturnValue in UserPassword |
-| file://:0:0:0:0 | [summary param] 0 in ValueOf | file://:0:0:0:0 | [summary] to write: ReturnValue in ValueOf |
-| file://:0:0:0:0 | [summary param] 0 in VolumeName | file://:0:0:0:0 | [summary] to write: ReturnValue in VolumeName |
-| file://:0:0:0:0 | [summary param] 0 in WithCancel | file://:0:0:0:0 | [summary] to write: ReturnValue in WithCancel |
-| file://:0:0:0:0 | [summary param] 0 in WithDeadline | file://:0:0:0:0 | [summary] to write: ReturnValue in WithDeadline |
-| file://:0:0:0:0 | [summary param] 0 in WithTimeout | file://:0:0:0:0 | [summary] to write: ReturnValue in WithTimeout |
-| file://:0:0:0:0 | [summary param] 0 in WithValue | file://:0:0:0:0 | [summary] to write: ReturnValue in WithValue |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
-| file://:0:0:0:0 | [summary param] 0 in WriteAt | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteAt |
-| file://:0:0:0:0 | [summary param] 0 in WriteAt | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteAt |
-| file://:0:0:0:0 | [summary param] 0 in WriteAt | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteAt |
-| file://:0:0:0:0 | [summary param] 0 in WriteField | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteField |
-| file://:0:0:0:0 | [summary param] 0 in WriteMsgIP | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteMsgIP |
-| file://:0:0:0:0 | [summary param] 0 in WriteMsgUDP | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteMsgUDP |
-| file://:0:0:0:0 | [summary param] 0 in WriteMsgUnix | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteMsgUnix |
-| file://:0:0:0:0 | [summary param] 0 in WriteString | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteString |
-| file://:0:0:0:0 | [summary param] 0 in WriteString | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteString |
-| file://:0:0:0:0 | [summary param] 0 in WriteString | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteString |
-| file://:0:0:0:0 | [summary param] 0 in WriteString | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteString |
-| file://:0:0:0:0 | [summary param] 0 in WriteString | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteString |
-| file://:0:0:0:0 | [summary param] 0 in WriteString | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteString |
-| file://:0:0:0:0 | [summary param] 0 in WriteString | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteString |
-| file://:0:0:0:0 | [summary param] 0 in WriteString | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteString |
-| file://:0:0:0:0 | [summary param] 0 in WriteString | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteString |
-| file://:0:0:0:0 | [summary param] 0 in WriteString | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteString |
-| file://:0:0:0:0 | [summary param] 0 in WriteString | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteString |
-| file://:0:0:0:0 | [summary param] 0 in WriteString | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteString |
-| file://:0:0:0:0 | [summary param] 0 in WriteString | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteString |
-| file://:0:0:0:0 | [summary param] 0 in WriteString | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteString |
-| file://:0:0:0:0 | [summary param] 0 in WriteTo | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteTo |
-| file://:0:0:0:0 | [summary param] 0 in WriteTo | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteTo |
-| file://:0:0:0:0 | [summary param] 0 in WriteTo | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteTo |
-| file://:0:0:0:0 | [summary param] 0 in WriteTo | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteTo |
-| file://:0:0:0:0 | [summary param] 0 in WriteToIP | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteToIP |
-| file://:0:0:0:0 | [summary param] 0 in WriteToUDP | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteToUDP |
-| file://:0:0:0:0 | [summary param] 0 in WriteToUnix | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteToUnix |
-| file://:0:0:0:0 | [summary param] 1 in Add | file://:0:0:0:0 | [summary] to write: Argument[-1] in Add |
-| file://:0:0:0:0 | [summary param] 1 in Add | file://:0:0:0:0 | [summary] to write: Argument[-1] in Add |
-| file://:0:0:0:0 | [summary param] 1 in AddUintptr | file://:0:0:0:0 | [summary] to write: Argument[0] in AddUintptr |
-| file://:0:0:0:0 | [summary param] 1 in AddUintptr | file://:0:0:0:0 | [summary] to write: ReturnValue in AddUintptr |
-| file://:0:0:0:0 | [summary param] 1 in AppendQuote | file://:0:0:0:0 | [summary] to write: ReturnValue in AppendQuote |
-| file://:0:0:0:0 | [summary param] 1 in AppendQuoteToASCII | file://:0:0:0:0 | [summary] to write: ReturnValue in AppendQuoteToASCII |
-| file://:0:0:0:0 | [summary param] 1 in AppendQuoteToGraphic | file://:0:0:0:0 | [summary] to write: ReturnValue in AppendQuoteToGraphic |
-| file://:0:0:0:0 | [summary param] 1 in AppendSlice | file://:0:0:0:0 | [summary] to write: ReturnValue in AppendSlice |
-| file://:0:0:0:0 | [summary param] 1 in Compact | file://:0:0:0:0 | [summary] to write: Argument[0] in Compact |
-| file://:0:0:0:0 | [summary param] 1 in Copy | file://:0:0:0:0 | [summary] to write: Argument[0] in Copy |
-| file://:0:0:0:0 | [summary param] 1 in Copy | file://:0:0:0:0 | [summary] to write: Argument[0] in Copy |
-| file://:0:0:0:0 | [summary param] 1 in CopyBuffer | file://:0:0:0:0 | [summary] to write: Argument[0] in CopyBuffer |
-| file://:0:0:0:0 | [summary param] 1 in CopyN | file://:0:0:0:0 | [summary] to write: Argument[0] in CopyN |
-| file://:0:0:0:0 | [summary param] 1 in Decode | file://:0:0:0:0 | [summary] to write: Argument[0] in Decode |
-| file://:0:0:0:0 | [summary param] 1 in Decode | file://:0:0:0:0 | [summary] to write: Argument[0] in Decode |
-| file://:0:0:0:0 | [summary param] 1 in Decrypt | file://:0:0:0:0 | [summary] to write: Argument[0] in Decrypt |
-| file://:0:0:0:0 | [summary param] 1 in Decrypt | file://:0:0:0:0 | [summary] to write: Argument[0] in Decrypt |
-| file://:0:0:0:0 | [summary param] 1 in Decrypt | file://:0:0:0:0 | [summary] to write: Argument[0] in Decrypt |
-| file://:0:0:0:0 | [summary param] 1 in Decrypt | file://:0:0:0:0 | [summary] to write: Argument[0] in Decrypt |
-| file://:0:0:0:0 | [summary param] 1 in Decrypt | file://:0:0:0:0 | [summary] to write: Argument[0] in Decrypt |
-| file://:0:0:0:0 | [summary param] 1 in Decrypt | file://:0:0:0:0 | [summary] to write: ReturnValue in Decrypt |
-| file://:0:0:0:0 | [summary param] 1 in Decrypt | file://:0:0:0:0 | [summary] to write: ReturnValue in Decrypt |
-| file://:0:0:0:0 | [summary param] 1 in Encode | file://:0:0:0:0 | [summary] to write: Argument[0] in Encode |
-| file://:0:0:0:0 | [summary param] 1 in Encode | file://:0:0:0:0 | [summary] to write: ReturnValue in Encode |
-| file://:0:0:0:0 | [summary param] 1 in Error | file://:0:0:0:0 | [summary] to write: Argument[0] in Error |
-| file://:0:0:0:0 | [summary param] 1 in FormatMediaType | file://:0:0:0:0 | [summary] to write: ReturnValue in FormatMediaType |
-| file://:0:0:0:0 | [summary param] 1 in HTMLEscape | file://:0:0:0:0 | [summary] to write: Argument[0] in HTMLEscape |
-| file://:0:0:0:0 | [summary param] 1 in Indent | file://:0:0:0:0 | [summary] to write: Argument[0] in Indent |
-| file://:0:0:0:0 | [summary param] 1 in Join | file://:0:0:0:0 | [summary] to write: ReturnValue in Join |
-| file://:0:0:0:0 | [summary param] 1 in Join | file://:0:0:0:0 | [summary] to write: ReturnValue in Join |
-| file://:0:0:0:0 | [summary param] 1 in JoinHostPort | file://:0:0:0:0 | [summary] to write: ReturnValue in JoinHostPort |
-| file://:0:0:0:0 | [summary param] 1 in LoadOrStore | file://:0:0:0:0 | [summary] to write: Argument[-1] in LoadOrStore |
-| file://:0:0:0:0 | [summary param] 1 in LoadOrStore | file://:0:0:0:0 | [summary] to write: ReturnValue in LoadOrStore |
-| file://:0:0:0:0 | [summary param] 1 in Map | file://:0:0:0:0 | [summary] to write: ReturnValue in Map |
-| file://:0:0:0:0 | [summary param] 1 in Map | file://:0:0:0:0 | [summary] to write: ReturnValue in Map |
-| file://:0:0:0:0 | [summary param] 1 in MarshalIndent | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalIndent |
-| file://:0:0:0:0 | [summary param] 1 in MarshalWithParams | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalWithParams |
-| file://:0:0:0:0 | [summary param] 1 in MaxBytesReader | file://:0:0:0:0 | [summary] to write: ReturnValue in MaxBytesReader |
-| file://:0:0:0:0 | [summary param] 1 in NewDecoder | file://:0:0:0:0 | [summary] to write: ReturnValue in NewDecoder |
-| file://:0:0:0:0 | [summary param] 1 in NewRequest | file://:0:0:0:0 | [summary] to write: ReturnValue in NewRequest |
-| file://:0:0:0:0 | [summary param] 1 in Rel | file://:0:0:0:0 | [summary] to write: ReturnValue in Rel |
-| file://:0:0:0:0 | [summary param] 1 in Set | file://:0:0:0:0 | [summary] to write: Argument[-1] in Set |
-| file://:0:0:0:0 | [summary param] 1 in Set | file://:0:0:0:0 | [summary] to write: Argument[-1] in Set |
-| file://:0:0:0:0 | [summary param] 1 in SetCookie | file://:0:0:0:0 | [summary] to write: Argument[0] in SetCookie |
-| file://:0:0:0:0 | [summary param] 1 in SetIndent | file://:0:0:0:0 | [summary] to write: Argument[-1] in SetIndent |
-| file://:0:0:0:0 | [summary param] 1 in SetMapIndex | file://:0:0:0:0 | [summary] to write: Argument[-1] in SetMapIndex |
-| file://:0:0:0:0 | [summary param] 1 in Store | file://:0:0:0:0 | [summary] to write: Argument[-1] in Store |
-| file://:0:0:0:0 | [summary param] 1 in StorePointer | file://:0:0:0:0 | [summary] to write: Argument[0] in StorePointer |
-| file://:0:0:0:0 | [summary param] 1 in StoreUintptr | file://:0:0:0:0 | [summary] to write: Argument[0] in StoreUintptr |
-| file://:0:0:0:0 | [summary param] 1 in Swap | file://:0:0:0:0 | [summary] to write: Argument[-1] in Swap |
-| file://:0:0:0:0 | [summary param] 1 in SwapPointer | file://:0:0:0:0 | [summary] to write: Argument[0] in SwapPointer |
-| file://:0:0:0:0 | [summary param] 1 in SwapUintptr | file://:0:0:0:0 | [summary] to write: Argument[0] in SwapUintptr |
-| file://:0:0:0:0 | [summary param] 1 in ToLowerSpecial | file://:0:0:0:0 | [summary] to write: ReturnValue in ToLowerSpecial |
-| file://:0:0:0:0 | [summary param] 1 in ToLowerSpecial | file://:0:0:0:0 | [summary] to write: ReturnValue in ToLowerSpecial |
-| file://:0:0:0:0 | [summary param] 1 in ToTitleSpecial | file://:0:0:0:0 | [summary] to write: ReturnValue in ToTitleSpecial |
-| file://:0:0:0:0 | [summary param] 1 in ToTitleSpecial | file://:0:0:0:0 | [summary] to write: ReturnValue in ToTitleSpecial |
-| file://:0:0:0:0 | [summary param] 1 in ToUpperSpecial | file://:0:0:0:0 | [summary] to write: ReturnValue in ToUpperSpecial |
-| file://:0:0:0:0 | [summary param] 1 in ToUpperSpecial | file://:0:0:0:0 | [summary] to write: ReturnValue in ToUpperSpecial |
-| file://:0:0:0:0 | [summary param] 1 in ToValidUTF8 | file://:0:0:0:0 | [summary] to write: ReturnValue in ToValidUTF8 |
-| file://:0:0:0:0 | [summary param] 1 in ToValidUTF8 | file://:0:0:0:0 | [summary] to write: ReturnValue in ToValidUTF8 |
-| file://:0:0:0:0 | [summary param] 1 in UserPassword | file://:0:0:0:0 | [summary] to write: ReturnValue in UserPassword |
-| file://:0:0:0:0 | [summary param] 1 in WithValue | file://:0:0:0:0 | [summary] to write: ReturnValue in WithValue |
-| file://:0:0:0:0 | [summary param] 1 in WriteField | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteField |
-| file://:0:0:0:0 | [summary param] 1 in WriteMsgIP | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteMsgIP |
-| file://:0:0:0:0 | [summary param] 1 in WriteMsgUDP | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteMsgUDP |
-| file://:0:0:0:0 | [summary param] 1 in WriteMsgUnix | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteMsgUnix |
-| file://:0:0:0:0 | [summary param] 1 in WriteString | file://:0:0:0:0 | [summary] to write: Argument[0] in WriteString |
-| file://:0:0:0:0 | [summary param] 1 in WriteString | file://:0:0:0:0 | [summary] to write: Argument[0] in WriteString |
-| file://:0:0:0:0 | [summary param] 2 in CompareAndSwap | file://:0:0:0:0 | [summary] to write: Argument[-1] in CompareAndSwap |
-| file://:0:0:0:0 | [summary param] 2 in CompareAndSwapPointer | file://:0:0:0:0 | [summary] to write: Argument[0] in CompareAndSwapPointer |
-| file://:0:0:0:0 | [summary param] 2 in CompareAndSwapUintptr | file://:0:0:0:0 | [summary] to write: Argument[0] in CompareAndSwapUintptr |
-| file://:0:0:0:0 | [summary param] 2 in DecryptPKCS1v15 | file://:0:0:0:0 | [summary] to write: ReturnValue in DecryptPKCS1v15 |
-| file://:0:0:0:0 | [summary param] 2 in Indent | file://:0:0:0:0 | [summary] to write: Argument[0] in Indent |
-| file://:0:0:0:0 | [summary param] 2 in MarshalIndent | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalIndent |
-| file://:0:0:0:0 | [summary param] 2 in NewRequestWithContext | file://:0:0:0:0 | [summary] to write: ReturnValue in NewRequestWithContext |
-| file://:0:0:0:0 | [summary param] 2 in Open | file://:0:0:0:0 | [summary] to write: Argument[0] in Open |
-| file://:0:0:0:0 | [summary param] 2 in Open | file://:0:0:0:0 | [summary] to write: Argument[0] in Open |
-| file://:0:0:0:0 | [summary param] 2 in Open | file://:0:0:0:0 | [summary] to write: Argument[0] in Open |
-| file://:0:0:0:0 | [summary param] 2 in Open | file://:0:0:0:0 | [summary] to write: Argument[0] in Open |
-| file://:0:0:0:0 | [summary param] 2 in Open | file://:0:0:0:0 | [summary] to write: Argument[0] in Open |
-| file://:0:0:0:0 | [summary param] 2 in Open | file://:0:0:0:0 | [summary] to write: Argument[0] in Open |
-| file://:0:0:0:0 | [summary param] 2 in Open | file://:0:0:0:0 | [summary] to write: Argument[0] in Open |
-| file://:0:0:0:0 | [summary param] 2 in Open | file://:0:0:0:0 | [summary] to write: ReturnValue in Open |
-| file://:0:0:0:0 | [summary param] 2 in Open | file://:0:0:0:0 | [summary] to write: ReturnValue in Open |
-| file://:0:0:0:0 | [summary param] 2 in Open | file://:0:0:0:0 | [summary] to write: ReturnValue in Open |
-| file://:0:0:0:0 | [summary param] 2 in Open | file://:0:0:0:0 | [summary] to write: ReturnValue in Open |
-| file://:0:0:0:0 | [summary param] 2 in Open | file://:0:0:0:0 | [summary] to write: ReturnValue in Open |
-| file://:0:0:0:0 | [summary param] 2 in Open | file://:0:0:0:0 | [summary] to write: ReturnValue in Open |
-| file://:0:0:0:0 | [summary param] 2 in Open | file://:0:0:0:0 | [summary] to write: ReturnValue in Open |
-| file://:0:0:0:0 | [summary param] 2 in Replace | file://:0:0:0:0 | [summary] to write: ReturnValue in Replace |
-| file://:0:0:0:0 | [summary param] 2 in Replace | file://:0:0:0:0 | [summary] to write: ReturnValue in Replace |
-| file://:0:0:0:0 | [summary param] 2 in ReplaceAll | file://:0:0:0:0 | [summary] to write: ReturnValue in ReplaceAll |
-| file://:0:0:0:0 | [summary param] 2 in ReplaceAll | file://:0:0:0:0 | [summary] to write: ReturnValue in ReplaceAll |
-| file://:0:0:0:0 | [summary param] 2 in UnmarshalWithParams | file://:0:0:0:0 | [summary] to write: Argument[1] in UnmarshalWithParams |
-| file://:0:0:0:0 | [summary param] 2 in UnmarshalWithParams | file://:0:0:0:0 | [summary] to write: ReturnValue in UnmarshalWithParams |
-| file://:0:0:0:0 | [summary param] 2 in WithValue | file://:0:0:0:0 | [summary] to write: ReturnValue in WithValue |
-| file://:0:0:0:0 | [summary param] 2 in Write | file://:0:0:0:0 | [summary] to write: Argument[0] in Write |
-| file://:0:0:0:0 | [summary param] 3 in DecryptOAEP | file://:0:0:0:0 | [summary] to write: ReturnValue in DecryptOAEP |
-| file://:0:0:0:0 | [summary param] 3 in Indent | file://:0:0:0:0 | [summary] to write: Argument[0] in Indent |
-| file://:0:0:0:0 | [summary param] -1 in Addr | file://:0:0:0:0 | [summary] to write: ReturnValue in Addr |
-| file://:0:0:0:0 | [summary param] -1 in Back | file://:0:0:0:0 | [summary] to write: ReturnValue in Back |
-| file://:0:0:0:0 | [summary param] -1 in Buffered | file://:0:0:0:0 | [summary] to write: ReturnValue in Buffered |
-| file://:0:0:0:0 | [summary param] -1 in Bytes | file://:0:0:0:0 | [summary] to write: ReturnValue in Bytes |
-| file://:0:0:0:0 | [summary param] -1 in Bytes | file://:0:0:0:0 | [summary] to write: ReturnValue in Bytes |
-| file://:0:0:0:0 | [summary param] -1 in Bytes | file://:0:0:0:0 | [summary] to write: ReturnValue in Bytes |
-| file://:0:0:0:0 | [summary param] -1 in Clone | file://:0:0:0:0 | [summary] to write: ReturnValue in Clone |
-| file://:0:0:0:0 | [summary param] -1 in Clone | file://:0:0:0:0 | [summary] to write: ReturnValue in Clone |
-| file://:0:0:0:0 | [summary param] -1 in Clone | file://:0:0:0:0 | [summary] to write: ReturnValue in Clone |
-| file://:0:0:0:0 | [summary param] -1 in Convert | file://:0:0:0:0 | [summary] to write: ReturnValue in Convert |
-| file://:0:0:0:0 | [summary param] -1 in Decode | file://:0:0:0:0 | [summary] to write: Argument[0] in Decode |
-| file://:0:0:0:0 | [summary param] -1 in DotReader | file://:0:0:0:0 | [summary] to write: ReturnValue in DotReader |
-| file://:0:0:0:0 | [summary param] -1 in Elem | file://:0:0:0:0 | [summary] to write: ReturnValue in Elem |
-| file://:0:0:0:0 | [summary param] -1 in Encode | file://:0:0:0:0 | [summary] to write: ReturnValue in Encode |
-| file://:0:0:0:0 | [summary param] -1 in EscapedPath | file://:0:0:0:0 | [summary] to write: ReturnValue in EscapedPath |
-| file://:0:0:0:0 | [summary param] -1 in Fd | file://:0:0:0:0 | [summary] to write: ReturnValue in Fd |
-| file://:0:0:0:0 | [summary param] -1 in Field | file://:0:0:0:0 | [summary] to write: ReturnValue in Field |
-| file://:0:0:0:0 | [summary param] -1 in FieldByIndex | file://:0:0:0:0 | [summary] to write: ReturnValue in FieldByIndex |
-| file://:0:0:0:0 | [summary param] -1 in FieldByName | file://:0:0:0:0 | [summary] to write: ReturnValue in FieldByName |
-| file://:0:0:0:0 | [summary param] -1 in FieldByNameFunc | file://:0:0:0:0 | [summary] to write: ReturnValue in FieldByNameFunc |
-| file://:0:0:0:0 | [summary param] -1 in File | file://:0:0:0:0 | [summary] to write: ReturnValue in File |
-| file://:0:0:0:0 | [summary param] -1 in File | file://:0:0:0:0 | [summary] to write: ReturnValue in File |
-| file://:0:0:0:0 | [summary param] -1 in FileName | file://:0:0:0:0 | [summary] to write: ReturnValue in FileName |
-| file://:0:0:0:0 | [summary param] -1 in FormName | file://:0:0:0:0 | [summary] to write: ReturnValue in FormName |
-| file://:0:0:0:0 | [summary param] -1 in Front | file://:0:0:0:0 | [summary] to write: ReturnValue in Front |
-| file://:0:0:0:0 | [summary param] -1 in Get | file://:0:0:0:0 | [summary] to write: ReturnValue in Get |
-| file://:0:0:0:0 | [summary param] -1 in Get | file://:0:0:0:0 | [summary] to write: ReturnValue in Get |
-| file://:0:0:0:0 | [summary param] -1 in Get | file://:0:0:0:0 | [summary] to write: ReturnValue in Get |
-| file://:0:0:0:0 | [summary param] -1 in Get | file://:0:0:0:0 | [summary] to write: ReturnValue in Get |
-| file://:0:0:0:0 | [summary param] -1 in Get | file://:0:0:0:0 | [summary] to write: ReturnValue in Get |
-| file://:0:0:0:0 | [summary param] -1 in Glob | file://:0:0:0:0 | [summary] to write: ReturnValue in Glob |
-| file://:0:0:0:0 | [summary param] -1 in Glob | file://:0:0:0:0 | [summary] to write: ReturnValue in Glob |
-| file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
-| file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
-| file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
-| file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
-| file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
-| file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
-| file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
-| file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
-| file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
-| file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
-| file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
-| file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
-| file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
-| file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
-| file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
-| file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
-| file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
-| file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
-| file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
-| file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
-| file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
-| file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
-| file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
-| file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
-| file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
-| file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
-| file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
-| file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
-| file://:0:0:0:0 | [summary param] -1 in Hijack | file://:0:0:0:0 | [summary] to write: ReturnValue in Hijack |
-| file://:0:0:0:0 | [summary param] -1 in Hijack | file://:0:0:0:0 | [summary] to write: ReturnValue in Hijack |
-| file://:0:0:0:0 | [summary param] -1 in Hijack | file://:0:0:0:0 | [summary] to write: ReturnValue in Hijack |
-| file://:0:0:0:0 | [summary param] -1 in Hijack | file://:0:0:0:0 | [summary] to write: ReturnValue[1] in Hijack |
-| file://:0:0:0:0 | [summary param] -1 in Hijack | file://:0:0:0:0 | [summary] to write: ReturnValue[1] in Hijack |
-| file://:0:0:0:0 | [summary param] -1 in Hijack | file://:0:0:0:0 | [summary] to write: ReturnValue[1] in Hijack |
-| file://:0:0:0:0 | [summary param] -1 in Hostname | file://:0:0:0:0 | [summary] to write: ReturnValue in Hostname |
-| file://:0:0:0:0 | [summary param] -1 in Index | file://:0:0:0:0 | [summary] to write: ReturnValue in Index |
-| file://:0:0:0:0 | [summary param] -1 in Info | file://:0:0:0:0 | [summary] to write: ReturnValue in Info |
-| file://:0:0:0:0 | [summary param] -1 in Info | file://:0:0:0:0 | [summary] to write: ReturnValue in Info |
-| file://:0:0:0:0 | [summary param] -1 in Info | file://:0:0:0:0 | [summary] to write: ReturnValue in Info |
-| file://:0:0:0:0 | [summary param] -1 in Info | file://:0:0:0:0 | [summary] to write: ReturnValue in Info |
-| file://:0:0:0:0 | [summary param] -1 in Info | file://:0:0:0:0 | [summary] to write: ReturnValue in Info |
-| file://:0:0:0:0 | [summary param] -1 in Init | file://:0:0:0:0 | [summary] to write: ReturnValue in Init |
-| file://:0:0:0:0 | [summary param] -1 in Interface | file://:0:0:0:0 | [summary] to write: ReturnValue in Interface |
-| file://:0:0:0:0 | [summary param] -1 in InterfaceData | file://:0:0:0:0 | [summary] to write: ReturnValue in InterfaceData |
-| file://:0:0:0:0 | [summary param] -1 in Key | file://:0:0:0:0 | [summary] to write: ReturnValue in Key |
-| file://:0:0:0:0 | [summary param] -1 in Load | file://:0:0:0:0 | [summary] to write: ReturnValue in Load |
-| file://:0:0:0:0 | [summary param] -1 in Load | file://:0:0:0:0 | [summary] to write: ReturnValue in Load |
-| file://:0:0:0:0 | [summary param] -1 in Load | file://:0:0:0:0 | [summary] to write: ReturnValue in Load |
-| file://:0:0:0:0 | [summary param] -1 in Load | file://:0:0:0:0 | [summary] to write: ReturnValue in Load |
-| file://:0:0:0:0 | [summary param] -1 in LoadOrStore | file://:0:0:0:0 | [summary] to write: ReturnValue in LoadOrStore |
-| file://:0:0:0:0 | [summary param] -1 in Lookup | file://:0:0:0:0 | [summary] to write: ReturnValue in Lookup |
-| file://:0:0:0:0 | [summary param] -1 in MapIndex | file://:0:0:0:0 | [summary] to write: ReturnValue in MapIndex |
-| file://:0:0:0:0 | [summary param] -1 in MapKeys | file://:0:0:0:0 | [summary] to write: ReturnValue in MapKeys |
-| file://:0:0:0:0 | [summary param] -1 in MapRange | file://:0:0:0:0 | [summary] to write: ReturnValue in MapRange |
-| file://:0:0:0:0 | [summary param] -1 in MarshalBinary | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalBinary |
-| file://:0:0:0:0 | [summary param] -1 in MarshalBinary | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalBinary |
-| file://:0:0:0:0 | [summary param] -1 in MarshalBinary | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalBinary |
-| file://:0:0:0:0 | [summary param] -1 in MarshalBinary | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalBinary |
-| file://:0:0:0:0 | [summary param] -1 in MarshalBinary | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalBinary |
-| file://:0:0:0:0 | [summary param] -1 in MarshalBinary | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalBinary |
-| file://:0:0:0:0 | [summary param] -1 in MarshalBinary | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalBinary |
-| file://:0:0:0:0 | [summary param] -1 in MarshalBinary | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalBinary |
-| file://:0:0:0:0 | [summary param] -1 in MarshalBinary | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalBinary |
-| file://:0:0:0:0 | [summary param] -1 in MarshalBinary | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalBinary |
-| file://:0:0:0:0 | [summary param] -1 in MarshalBinary | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalBinary |
-| file://:0:0:0:0 | [summary param] -1 in MarshalBinary | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalBinary |
-| file://:0:0:0:0 | [summary param] -1 in MarshalJSON | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalJSON |
-| file://:0:0:0:0 | [summary param] -1 in MarshalJSON | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalJSON |
-| file://:0:0:0:0 | [summary param] -1 in MarshalJSON | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalJSON |
-| file://:0:0:0:0 | [summary param] -1 in MarshalJSON | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalJSON |
-| file://:0:0:0:0 | [summary param] -1 in MarshalText | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalText |
-| file://:0:0:0:0 | [summary param] -1 in MarshalText | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalText |
-| file://:0:0:0:0 | [summary param] -1 in MarshalText | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalText |
-| file://:0:0:0:0 | [summary param] -1 in MarshalText | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalText |
-| file://:0:0:0:0 | [summary param] -1 in MarshalText | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalText |
-| file://:0:0:0:0 | [summary param] -1 in MarshalText | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalText |
-| file://:0:0:0:0 | [summary param] -1 in MarshalText | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalText |
-| file://:0:0:0:0 | [summary param] -1 in MarshalText | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalText |
-| file://:0:0:0:0 | [summary param] -1 in MarshalText | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalText |
-| file://:0:0:0:0 | [summary param] -1 in Method | file://:0:0:0:0 | [summary] to write: ReturnValue in Method |
-| file://:0:0:0:0 | [summary param] -1 in MethodByName | file://:0:0:0:0 | [summary] to write: ReturnValue in MethodByName |
-| file://:0:0:0:0 | [summary param] -1 in Name | file://:0:0:0:0 | [summary] to write: ReturnValue in Name |
-| file://:0:0:0:0 | [summary param] -1 in Name | file://:0:0:0:0 | [summary] to write: ReturnValue in Name |
-| file://:0:0:0:0 | [summary param] -1 in Name | file://:0:0:0:0 | [summary] to write: ReturnValue in Name |
-| file://:0:0:0:0 | [summary param] -1 in Name | file://:0:0:0:0 | [summary] to write: ReturnValue in Name |
-| file://:0:0:0:0 | [summary param] -1 in Name | file://:0:0:0:0 | [summary] to write: ReturnValue in Name |
-| file://:0:0:0:0 | [summary param] -1 in Next | file://:0:0:0:0 | [summary] to write: ReturnValue in Next |
-| file://:0:0:0:0 | [summary param] -1 in Next | file://:0:0:0:0 | [summary] to write: ReturnValue in Next |
-| file://:0:0:0:0 | [summary param] -1 in NextPart | file://:0:0:0:0 | [summary] to write: ReturnValue in NextPart |
-| file://:0:0:0:0 | [summary param] -1 in NextRawPart | file://:0:0:0:0 | [summary] to write: ReturnValue in NextRawPart |
-| file://:0:0:0:0 | [summary param] -1 in Open | file://:0:0:0:0 | [summary] to write: ReturnValue in Open |
-| file://:0:0:0:0 | [summary param] -1 in Open | file://:0:0:0:0 | [summary] to write: ReturnValue in Open |
-| file://:0:0:0:0 | [summary param] -1 in Open | file://:0:0:0:0 | [summary] to write: ReturnValue in Open |
-| file://:0:0:0:0 | [summary param] -1 in Open | file://:0:0:0:0 | [summary] to write: ReturnValue in Open |
-| file://:0:0:0:0 | [summary param] -1 in Open | file://:0:0:0:0 | [summary] to write: ReturnValue in Open |
-| file://:0:0:0:0 | [summary param] -1 in Parse | file://:0:0:0:0 | [summary] to write: ReturnValue in Parse |
-| file://:0:0:0:0 | [summary param] -1 in Password | file://:0:0:0:0 | [summary] to write: ReturnValue in Password |
-| file://:0:0:0:0 | [summary param] -1 in Peek | file://:0:0:0:0 | [summary] to write: ReturnValue in Peek |
-| file://:0:0:0:0 | [summary param] -1 in Pointer | file://:0:0:0:0 | [summary] to write: ReturnValue in Pointer |
-| file://:0:0:0:0 | [summary param] -1 in Port | file://:0:0:0:0 | [summary] to write: ReturnValue in Port |
-| file://:0:0:0:0 | [summary param] -1 in Prev | file://:0:0:0:0 | [summary] to write: ReturnValue in Prev |
-| file://:0:0:0:0 | [summary param] -1 in Query | file://:0:0:0:0 | [summary] to write: ReturnValue in Query |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
-| file://:0:0:0:0 | [summary param] -1 in ReadAt | file://:0:0:0:0 | [summary] to write: Argument[0] in ReadAt |
-| file://:0:0:0:0 | [summary param] -1 in ReadAt | file://:0:0:0:0 | [summary] to write: Argument[0] in ReadAt |
-| file://:0:0:0:0 | [summary param] -1 in ReadAt | file://:0:0:0:0 | [summary] to write: Argument[0] in ReadAt |
-| file://:0:0:0:0 | [summary param] -1 in ReadAt | file://:0:0:0:0 | [summary] to write: Argument[0] in ReadAt |
-| file://:0:0:0:0 | [summary param] -1 in ReadAt | file://:0:0:0:0 | [summary] to write: Argument[0] in ReadAt |
-| file://:0:0:0:0 | [summary param] -1 in ReadAt | file://:0:0:0:0 | [summary] to write: Argument[0] in ReadAt |
-| file://:0:0:0:0 | [summary param] -1 in ReadBytes | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadBytes |
-| file://:0:0:0:0 | [summary param] -1 in ReadBytes | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadBytes |
-| file://:0:0:0:0 | [summary param] -1 in ReadCodeLine | file://:0:0:0:0 | [summary] to write: ReturnValue[1] in ReadCodeLine |
-| file://:0:0:0:0 | [summary param] -1 in ReadContinuedLine | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadContinuedLine |
-| file://:0:0:0:0 | [summary param] -1 in ReadContinuedLineBytes | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadContinuedLineBytes |
-| file://:0:0:0:0 | [summary param] -1 in ReadDir | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadDir |
-| file://:0:0:0:0 | [summary param] -1 in ReadDir | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadDir |
-| file://:0:0:0:0 | [summary param] -1 in ReadDir | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadDir |
-| file://:0:0:0:0 | [summary param] -1 in ReadDir | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadDir |
-| file://:0:0:0:0 | [summary param] -1 in ReadDotBytes | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadDotBytes |
-| file://:0:0:0:0 | [summary param] -1 in ReadDotLines | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadDotLines |
-| file://:0:0:0:0 | [summary param] -1 in ReadFile | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadFile |
-| file://:0:0:0:0 | [summary param] -1 in ReadFile | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadFile |
-| file://:0:0:0:0 | [summary param] -1 in ReadFile | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadFile |
-| file://:0:0:0:0 | [summary param] -1 in ReadFile | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadFile |
-| file://:0:0:0:0 | [summary param] -1 in ReadForm | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadForm |
-| file://:0:0:0:0 | [summary param] -1 in ReadFrom | file://:0:0:0:0 | [summary] to write: Argument[0] in ReadFrom |
-| file://:0:0:0:0 | [summary param] -1 in ReadFrom | file://:0:0:0:0 | [summary] to write: Argument[0] in ReadFrom |
-| file://:0:0:0:0 | [summary param] -1 in ReadFrom | file://:0:0:0:0 | [summary] to write: Argument[0] in ReadFrom |
-| file://:0:0:0:0 | [summary param] -1 in ReadFrom | file://:0:0:0:0 | [summary] to write: Argument[0] in ReadFrom |
-| file://:0:0:0:0 | [summary param] -1 in ReadFromIP | file://:0:0:0:0 | [summary] to write: Argument[0] in ReadFromIP |
-| file://:0:0:0:0 | [summary param] -1 in ReadFromUDP | file://:0:0:0:0 | [summary] to write: Argument[0] in ReadFromUDP |
-| file://:0:0:0:0 | [summary param] -1 in ReadFromUnix | file://:0:0:0:0 | [summary] to write: Argument[0] in ReadFromUnix |
-| file://:0:0:0:0 | [summary param] -1 in ReadLine | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadLine |
-| file://:0:0:0:0 | [summary param] -1 in ReadLine | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadLine |
-| file://:0:0:0:0 | [summary param] -1 in ReadLineBytes | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadLineBytes |
-| file://:0:0:0:0 | [summary param] -1 in ReadMIMEHeader | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadMIMEHeader |
-| file://:0:0:0:0 | [summary param] -1 in ReadMsgIP | file://:0:0:0:0 | [summary] to write: Argument[0] in ReadMsgIP |
-| file://:0:0:0:0 | [summary param] -1 in ReadMsgIP | file://:0:0:0:0 | [summary] to write: Argument[1] in ReadMsgIP |
-| file://:0:0:0:0 | [summary param] -1 in ReadMsgUDP | file://:0:0:0:0 | [summary] to write: Argument[0] in ReadMsgUDP |
-| file://:0:0:0:0 | [summary param] -1 in ReadMsgUDP | file://:0:0:0:0 | [summary] to write: Argument[1] in ReadMsgUDP |
-| file://:0:0:0:0 | [summary param] -1 in ReadMsgUnix | file://:0:0:0:0 | [summary] to write: Argument[0] in ReadMsgUnix |
-| file://:0:0:0:0 | [summary param] -1 in ReadMsgUnix | file://:0:0:0:0 | [summary] to write: Argument[1] in ReadMsgUnix |
-| file://:0:0:0:0 | [summary param] -1 in ReadResponse | file://:0:0:0:0 | [summary] to write: ReturnValue[1] in ReadResponse |
-| file://:0:0:0:0 | [summary param] -1 in ReadSlice | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadSlice |
-| file://:0:0:0:0 | [summary param] -1 in ReadString | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadString |
-| file://:0:0:0:0 | [summary param] -1 in ReadString | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadString |
-| file://:0:0:0:0 | [summary param] -1 in Recv | file://:0:0:0:0 | [summary] to write: ReturnValue in Recv |
-| file://:0:0:0:0 | [summary param] -1 in RequestURI | file://:0:0:0:0 | [summary] to write: ReturnValue in RequestURI |
-| file://:0:0:0:0 | [summary param] -1 in Reset | file://:0:0:0:0 | [summary] to write: Argument[0] in Reset |
-| file://:0:0:0:0 | [summary param] -1 in Reset | file://:0:0:0:0 | [summary] to write: Argument[0] in Reset |
-| file://:0:0:0:0 | [summary param] -1 in Reset | file://:0:0:0:0 | [summary] to write: Argument[0] in Reset |
-| file://:0:0:0:0 | [summary param] -1 in ResolveReference | file://:0:0:0:0 | [summary] to write: ReturnValue in ResolveReference |
-| file://:0:0:0:0 | [summary param] -1 in SetOutput | file://:0:0:0:0 | [summary] to write: Argument[0] in SetOutput |
-| file://:0:0:0:0 | [summary param] -1 in Slice | file://:0:0:0:0 | [summary] to write: ReturnValue in Slice |
-| file://:0:0:0:0 | [summary param] -1 in Slice3 | file://:0:0:0:0 | [summary] to write: ReturnValue in Slice3 |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
-| file://:0:0:0:0 | [summary param] -1 in Sub | file://:0:0:0:0 | [summary] to write: ReturnValue in Sub |
-| file://:0:0:0:0 | [summary param] -1 in Sub | file://:0:0:0:0 | [summary] to write: ReturnValue in Sub |
-| file://:0:0:0:0 | [summary param] -1 in Swap | file://:0:0:0:0 | [summary] to write: ReturnValue in Swap |
-| file://:0:0:0:0 | [summary param] -1 in Swap | file://:0:0:0:0 | [summary] to write: ReturnValue in Swap |
-| file://:0:0:0:0 | [summary param] -1 in Swap | file://:0:0:0:0 | [summary] to write: ReturnValue in Swap |
-| file://:0:0:0:0 | [summary param] -1 in Swap | file://:0:0:0:0 | [summary] to write: ReturnValue in Swap |
-| file://:0:0:0:0 | [summary param] -1 in SyscallConn | file://:0:0:0:0 | [summary] to write: ReturnValue in SyscallConn |
-| file://:0:0:0:0 | [summary param] -1 in SyscallConn | file://:0:0:0:0 | [summary] to write: ReturnValue in SyscallConn |
-| file://:0:0:0:0 | [summary param] -1 in SyscallConn | file://:0:0:0:0 | [summary] to write: ReturnValue in SyscallConn |
-| file://:0:0:0:0 | [summary param] -1 in SyscallConn | file://:0:0:0:0 | [summary] to write: ReturnValue in SyscallConn |
-| file://:0:0:0:0 | [summary param] -1 in SyscallConn | file://:0:0:0:0 | [summary] to write: ReturnValue in SyscallConn |
-| file://:0:0:0:0 | [summary param] -1 in SyscallConn | file://:0:0:0:0 | [summary] to write: ReturnValue in SyscallConn |
-| file://:0:0:0:0 | [summary param] -1 in SyscallConn | file://:0:0:0:0 | [summary] to write: ReturnValue in SyscallConn |
-| file://:0:0:0:0 | [summary param] -1 in SyscallConn | file://:0:0:0:0 | [summary] to write: ReturnValue in SyscallConn |
-| file://:0:0:0:0 | [summary param] -1 in Text | file://:0:0:0:0 | [summary] to write: ReturnValue in Text |
-| file://:0:0:0:0 | [summary param] -1 in Token | file://:0:0:0:0 | [summary] to write: ReturnValue in Token |
-| file://:0:0:0:0 | [summary param] -1 in Token | file://:0:0:0:0 | [summary] to write: ReturnValue in Token |
-| file://:0:0:0:0 | [summary param] -1 in Token | file://:0:0:0:0 | [summary] to write: ReturnValue in Token |
-| file://:0:0:0:0 | [summary param] -1 in TryRecv | file://:0:0:0:0 | [summary] to write: ReturnValue in TryRecv |
-| file://:0:0:0:0 | [summary param] -1 in UnsafeAddr | file://:0:0:0:0 | [summary] to write: ReturnValue in UnsafeAddr |
-| file://:0:0:0:0 | [summary param] -1 in Username | file://:0:0:0:0 | [summary] to write: ReturnValue in Username |
-| file://:0:0:0:0 | [summary param] -1 in Value | file://:0:0:0:0 | [summary] to write: ReturnValue in Value |
-| file://:0:0:0:0 | [summary param] -1 in Value | file://:0:0:0:0 | [summary] to write: ReturnValue in Value |
-| file://:0:0:0:0 | [summary param] -1 in Value | file://:0:0:0:0 | [summary] to write: ReturnValue in Value |
-| file://:0:0:0:0 | [summary param] -1 in Value | file://:0:0:0:0 | [summary] to write: ReturnValue in Value |
-| file://:0:0:0:0 | [summary param] -1 in Value | file://:0:0:0:0 | [summary] to write: ReturnValue in Value |
-| file://:0:0:0:0 | [summary param] -1 in Value | file://:0:0:0:0 | [summary] to write: ReturnValue in Value |
-| file://:0:0:0:0 | [summary param] -1 in Value | file://:0:0:0:0 | [summary] to write: ReturnValue in Value |
-| file://:0:0:0:0 | [summary param] -1 in Values | file://:0:0:0:0 | [summary] to write: ReturnValue in Values |
-| file://:0:0:0:0 | [summary param] -1 in Values | file://:0:0:0:0 | [summary] to write: ReturnValue in Values |
-| file://:0:0:0:0 | [summary param] -1 in Write | file://:0:0:0:0 | [summary] to write: Argument[0] in Write |
-| file://:0:0:0:0 | [summary param] -1 in Write | file://:0:0:0:0 | [summary] to write: Argument[0] in Write |
-| file://:0:0:0:0 | [summary param] -1 in Write | file://:0:0:0:0 | [summary] to write: Argument[0] in Write |
-| file://:0:0:0:0 | [summary param] -1 in WriteProxy | file://:0:0:0:0 | [summary] to write: Argument[0] in WriteProxy |
-| file://:0:0:0:0 | [summary param] -1 in WriteSubset | file://:0:0:0:0 | [summary] to write: Argument[0] in WriteSubset |
-| file://:0:0:0:0 | [summary param] -1 in WriteTo | file://:0:0:0:0 | [summary] to write: Argument[0] in WriteTo |
-| file://:0:0:0:0 | [summary param] -1 in WriteTo | file://:0:0:0:0 | [summary] to write: Argument[0] in WriteTo |
-| file://:0:0:0:0 | [summary param] -1 in WriteTo | file://:0:0:0:0 | [summary] to write: Argument[0] in WriteTo |
-| file://:0:0:0:0 | [summary param] -1 in WriteTo | file://:0:0:0:0 | [summary] to write: Argument[0] in WriteTo |
-| file://:0:0:0:0 | [summary param] -1 in WriteTo | file://:0:0:0:0 | [summary] to write: Argument[0] in WriteTo |
-| file://:0:0:0:0 | [summary param] -1 in WriteTo | file://:0:0:0:0 | [summary] to write: Argument[0] in WriteTo |
-| file://:0:0:0:0 | [summary param] -1 in WriteTo | file://:0:0:0:0 | [summary] to write: Argument[0] in WriteTo |
-| file://:0:0:0:0 | [summary param] -1 in WriteTo | file://:0:0:0:0 | [summary] to write: Argument[0] in WriteTo |
-| file://:0:0:0:0 | [summary param] -1 in WriteTo | file://:0:0:0:0 | [summary] to write: Argument[0] in WriteTo |
-| file://:0:0:0:0 | [summary param] -1 in Writer | file://:0:0:0:0 | [summary] to write: ReturnValue in Writer |
-| io.go:14:31:14:43 | "some string" | io.go:14:13:14:44 | call to NewReader |
-| io.go:16:3:16:3 | definition of w | io.go:16:23:16:27 | &... |
-| io.go:16:3:16:3 | definition of w | io.go:16:30:16:34 | &... |
-| io.go:16:23:16:27 | &... | io.go:15:7:15:10 | definition of buf1 |
-| io.go:16:24:16:27 | buf1 | io.go:16:23:16:27 | &... |
-| io.go:16:30:16:34 | &... | io.go:15:13:15:16 | definition of buf2 |
-| io.go:16:31:16:34 | buf2 | io.go:16:30:16:34 | &... |
-| io.go:18:14:18:19 | reader | io.go:16:3:16:3 | definition of w |
-| io.go:22:31:22:43 | "some string" | io.go:22:13:22:44 | call to NewReader |
-| io.go:25:19:25:23 | &... | io.go:23:7:23:10 | definition of buf1 |
-| io.go:25:20:25:23 | buf1 | io.go:25:19:25:23 | &... |
-| io.go:27:21:27:26 | reader | io.go:25:3:25:4 | definition of w2 |
-| io.go:31:31:31:43 | "some string" | io.go:31:13:31:44 | call to NewReader |
-| io.go:33:19:33:23 | &... | io.go:32:7:32:10 | definition of buf1 |
-| io.go:33:20:33:23 | buf1 | io.go:33:19:33:23 | &... |
-| io.go:35:16:35:21 | reader | io.go:33:3:33:4 | definition of w2 |
-| io.go:39:6:39:6 | definition of w | io.go:39:3:39:19 | ... := ...[0] |
-| io.go:39:11:39:19 | call to Pipe | io.go:39:3:39:19 | ... := ...[0] |
-| io.go:39:11:39:19 | call to Pipe | io.go:39:3:39:19 | ... := ...[1] |
-| io.go:40:17:40:31 | "some string\\n" | io.go:39:6:39:6 | definition of w |
-| io.go:43:16:43:16 | r | io.go:42:3:42:5 | definition of buf |
-| io.go:44:13:44:15 | buf | io.go:44:13:44:24 | call to String |
-| io.go:48:31:48:43 | "some string" | io.go:48:13:48:44 | call to NewReader |
-| io.go:50:18:50:23 | reader | io.go:49:3:49:5 | definition of buf |
-| io.go:54:31:54:43 | "some string" | io.go:54:13:54:44 | call to NewReader |
-| io.go:56:15:56:20 | reader | io.go:55:3:55:5 | definition of buf |
-| io.go:61:18:61:21 | &... | io.go:60:7:60:9 | definition of buf |
-| io.go:61:19:61:21 | buf | io.go:61:18:61:21 | &... |
-| io.go:62:21:62:26 | "test" | io.go:61:3:61:3 | definition of w |
-| io.go:65:31:65:43 | "some string" | io.go:65:13:65:44 | call to NewReader |
-| io.go:67:3:67:8 | reader | io.go:66:3:66:5 | definition of buf |
-| io.go:70:31:70:43 | "some string" | io.go:70:13:70:44 | call to NewReader |
-| io.go:72:3:72:8 | reader | io.go:71:3:71:5 | definition of buf |
-| io.go:76:31:76:43 | "some string" | io.go:76:13:76:44 | call to NewReader |
-| io.go:77:24:77:29 | reader | io.go:77:9:77:33 | call to LimitReader |
-| io.go:78:22:78:23 | lr | io.go:78:11:78:19 | selection of Stdout |
-| io.go:82:27:82:36 | "reader1 " | io.go:82:9:82:37 | call to NewReader |
-| io.go:83:27:83:36 | "reader2 " | io.go:83:9:83:37 | call to NewReader |
-| io.go:84:27:84:35 | "reader3" | io.go:84:9:84:36 | call to NewReader |
-| io.go:85:23:85:24 | r1 | io.go:85:8:85:33 | call to MultiReader |
-| io.go:85:27:85:28 | r2 | io.go:85:8:85:33 | call to MultiReader |
-| io.go:85:31:85:32 | r3 | io.go:85:8:85:33 | call to MultiReader |
-| io.go:86:22:86:22 | r | io.go:86:11:86:19 | selection of Stdout |
-| io.go:89:26:89:38 | "some string" | io.go:89:8:89:39 | call to NewReader |
-| io.go:91:23:91:23 | r | io.go:91:10:91:30 | call to TeeReader |
-| io.go:91:23:91:23 | r | io.go:91:26:91:29 | &... |
-| io.go:91:26:91:29 | &... | io.go:90:7:90:9 | definition of buf |
-| io.go:91:27:91:29 | buf | io.go:91:26:91:29 | &... |
-| io.go:93:22:93:24 | tee | io.go:93:11:93:19 | selection of Stdout |
-| io.go:96:26:96:38 | "some string" | io.go:96:8:96:39 | call to NewReader |
-| io.go:97:28:97:28 | r | io.go:97:8:97:36 | call to NewSectionReader |
-| io.go:98:22:98:22 | s | io.go:98:11:98:19 | selection of Stdout |
-| io.go:101:26:101:38 | "some string" | io.go:101:8:101:39 | call to NewReader |
-| io.go:102:3:102:3 | r | io.go:102:13:102:21 | selection of Stdout |
-| io.go:108:30:108:42 | "some string" | io.go:108:12:108:43 | call to NewReader |
-| io.go:109:12:109:33 | call to ReadAll | io.go:109:2:109:33 | ... := ...[0] |
-| io.go:109:12:109:33 | call to ReadAll | io.go:109:2:109:33 | ... := ...[1] |
-| io.go:109:27:109:32 | reader | io.go:109:2:109:33 | ... := ...[0] |
-| io.go:110:18:110:20 | buf | io.go:110:2:110:10 | selection of Stdout |
-| main.go:11:12:11:26 | call to Marshal | main.go:11:2:11:26 | ... := ...[0] |
-| main.go:11:12:11:26 | call to Marshal | main.go:11:2:11:26 | ... := ...[1] |
-| main.go:11:25:11:25 | v | main.go:11:2:11:26 | ... := ...[0] |
-| main.go:13:14:13:52 | call to MarshalIndent | main.go:13:2:13:52 | ... := ...[0] |
-| main.go:13:14:13:52 | call to MarshalIndent | main.go:13:2:13:52 | ... := ...[1] |
-| main.go:13:33:13:33 | v | main.go:13:2:13:52 | ... := ...[0] |
-| main.go:13:36:13:45 | "/*JSON*/" | main.go:13:2:13:52 | ... := ...[0] |
-| main.go:13:48:13:51 | "  " | main.go:13:2:13:52 | ... := ...[0] |
-| main.go:14:25:14:25 | b | main.go:14:9:14:41 | slice literal |
-| main.go:14:28:14:30 | err | main.go:14:9:14:41 | slice literal |
-| main.go:14:33:14:34 | b2 | main.go:14:9:14:41 | slice literal |
-| main.go:14:37:14:40 | err2 | main.go:14:9:14:41 | slice literal |
-| main.go:19:18:19:42 | call to DecodeString | main.go:19:2:19:42 | ... := ...[0] |
-| main.go:19:18:19:42 | call to DecodeString | main.go:19:2:19:42 | ... := ...[1] |
-| main.go:19:35:19:41 | encoded | main.go:19:2:19:42 | ... := ...[0] |
-| main.go:23:25:23:31 | decoded | main.go:23:9:23:48 | slice literal |
-| main.go:23:34:23:36 | err | main.go:23:9:23:48 | slice literal |
-| main.go:23:39:23:47 | reEncoded | main.go:23:9:23:48 | slice literal |
-| main.go:28:2:28:4 | implicit dereference | main.go:26:15:26:17 | definition of req |
-| main.go:28:2:28:4 | implicit dereference | main.go:28:2:28:9 | selection of Body |
-| main.go:28:2:28:4 | req | main.go:28:2:28:4 | implicit dereference |
-| main.go:28:2:28:9 | selection of Body | main.go:27:2:27:2 | definition of b |
+| bufio.NewReadWriter | file://:0:0:0:0 | [summary param] 0 in NewReadWriter | file://:0:0:0:0 | [summary] to write: ReturnValue in NewReadWriter |
+| bufio.NewReader | file://:0:0:0:0 | [summary param] 0 in NewReader | file://:0:0:0:0 | [summary] to write: ReturnValue in NewReader |
+| bufio.NewReaderSize | file://:0:0:0:0 | [summary param] 0 in NewReaderSize | file://:0:0:0:0 | [summary] to write: ReturnValue in NewReaderSize |
+| bufio.NewScanner | file://:0:0:0:0 | [summary param] 0 in NewScanner | file://:0:0:0:0 | [summary] to write: ReturnValue in NewScanner |
+| bufio.ReadWriter.Peek | file://:0:0:0:0 | [summary param] -1 in Peek | file://:0:0:0:0 | [summary] to write: ReturnValue in Peek |
+| bufio.ReadWriter.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| bufio.ReadWriter.ReadBytes | file://:0:0:0:0 | [summary param] -1 in ReadBytes | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadBytes |
+| bufio.ReadWriter.ReadFrom | file://:0:0:0:0 | [summary param] 0 in ReadFrom | file://:0:0:0:0 | [summary] to write: Argument[-1] in ReadFrom |
+| bufio.ReadWriter.ReadLine | file://:0:0:0:0 | [summary param] -1 in ReadLine | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadLine |
+| bufio.ReadWriter.ReadSlice | file://:0:0:0:0 | [summary param] -1 in ReadSlice | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadSlice |
+| bufio.ReadWriter.ReadString | file://:0:0:0:0 | [summary param] -1 in ReadString | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadString |
+| bufio.ReadWriter.Reset | file://:0:0:0:0 | [summary param] 0 in Reset | file://:0:0:0:0 | [summary] to write: Argument[-1] in Reset |
+| bufio.ReadWriter.Reset | file://:0:0:0:0 | [summary param] -1 in Reset | file://:0:0:0:0 | [summary] to write: Argument[0] in Reset |
+| bufio.ReadWriter.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| bufio.ReadWriter.WriteString | file://:0:0:0:0 | [summary param] 0 in WriteString | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteString |
+| bufio.ReadWriter.WriteTo | file://:0:0:0:0 | [summary param] -1 in WriteTo | file://:0:0:0:0 | [summary] to write: Argument[0] in WriteTo |
+| bufio.Reader.Peek | file://:0:0:0:0 | [summary param] -1 in Peek | file://:0:0:0:0 | [summary] to write: ReturnValue in Peek |
+| bufio.Reader.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| bufio.Reader.ReadBytes | file://:0:0:0:0 | [summary param] -1 in ReadBytes | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadBytes |
+| bufio.Reader.ReadLine | file://:0:0:0:0 | [summary param] -1 in ReadLine | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadLine |
+| bufio.Reader.ReadSlice | file://:0:0:0:0 | [summary param] -1 in ReadSlice | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadSlice |
+| bufio.Reader.ReadString | file://:0:0:0:0 | [summary param] -1 in ReadString | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadString |
+| bufio.Reader.Reset | file://:0:0:0:0 | [summary param] 0 in Reset | file://:0:0:0:0 | [summary] to write: Argument[-1] in Reset |
+| bufio.Reader.WriteTo | file://:0:0:0:0 | [summary param] -1 in WriteTo | file://:0:0:0:0 | [summary] to write: Argument[0] in WriteTo |
+| bufio.ScanBytes | file://:0:0:0:0 | [summary param] 0 in ScanBytes | file://:0:0:0:0 | [summary] to write: ReturnValue[1] in ScanBytes |
+| bufio.ScanLines | file://:0:0:0:0 | [summary param] 0 in ScanLines | file://:0:0:0:0 | [summary] to write: ReturnValue[1] in ScanLines |
+| bufio.ScanRunes | file://:0:0:0:0 | [summary param] 0 in ScanRunes | file://:0:0:0:0 | [summary] to write: ReturnValue[1] in ScanRunes |
+| bufio.ScanWords | file://:0:0:0:0 | [summary param] 0 in ScanWords | file://:0:0:0:0 | [summary] to write: ReturnValue[1] in ScanWords |
+| bufio.Scanner.Bytes | file://:0:0:0:0 | [summary param] -1 in Bytes | file://:0:0:0:0 | [summary] to write: ReturnValue in Bytes |
+| bufio.Scanner.Text | file://:0:0:0:0 | [summary param] -1 in Text | file://:0:0:0:0 | [summary] to write: ReturnValue in Text |
+| bufio.Writer.ReadFrom | file://:0:0:0:0 | [summary param] 0 in ReadFrom | file://:0:0:0:0 | [summary] to write: Argument[-1] in ReadFrom |
+| bufio.Writer.Reset | file://:0:0:0:0 | [summary param] -1 in Reset | file://:0:0:0:0 | [summary] to write: Argument[0] in Reset |
+| bufio.Writer.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| bufio.Writer.WriteString | file://:0:0:0:0 | [summary param] 0 in WriteString | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteString |
+| bytes.Buffer.Bytes | file://:0:0:0:0 | [summary param] -1 in Bytes | file://:0:0:0:0 | [summary] to write: ReturnValue in Bytes |
+| bytes.Buffer.Next | file://:0:0:0:0 | [summary param] -1 in Next | file://:0:0:0:0 | [summary] to write: ReturnValue in Next |
+| bytes.Buffer.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| bytes.Buffer.ReadBytes | file://:0:0:0:0 | [summary param] -1 in ReadBytes | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadBytes |
+| bytes.Buffer.ReadFrom | file://:0:0:0:0 | [summary param] 0 in ReadFrom | file://:0:0:0:0 | [summary] to write: Argument[-1] in ReadFrom |
+| bytes.Buffer.ReadString | file://:0:0:0:0 | [summary param] -1 in ReadString | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadString |
+| bytes.Buffer.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| bytes.Buffer.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| bytes.Buffer.WriteString | file://:0:0:0:0 | [summary param] 0 in WriteString | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteString |
+| bytes.Buffer.WriteTo | file://:0:0:0:0 | [summary param] -1 in WriteTo | file://:0:0:0:0 | [summary] to write: Argument[0] in WriteTo |
+| bytes.Clone | file://:0:0:0:0 | [summary param] 0 in Clone | file://:0:0:0:0 | [summary] to write: ReturnValue in Clone |
+| bytes.Cut | file://:0:0:0:0 | [summary param] 0 in Cut | file://:0:0:0:0 | [summary] to write: ReturnValue in Cut |
+| bytes.Cut | file://:0:0:0:0 | [summary param] 0 in Cut | file://:0:0:0:0 | [summary] to write: ReturnValue[1] in Cut |
+| bytes.CutPrefix | file://:0:0:0:0 | [summary param] 0 in CutPrefix | file://:0:0:0:0 | [summary] to write: ReturnValue in CutPrefix |
+| bytes.CutSuffix | file://:0:0:0:0 | [summary param] 0 in CutSuffix | file://:0:0:0:0 | [summary] to write: ReturnValue in CutSuffix |
+| bytes.Fields | file://:0:0:0:0 | [summary param] 0 in Fields | file://:0:0:0:0 | [summary] to write: ReturnValue in Fields |
+| bytes.FieldsFunc | file://:0:0:0:0 | [summary param] 0 in FieldsFunc | file://:0:0:0:0 | [summary] to write: ReturnValue in FieldsFunc |
+| bytes.Join | file://:0:0:0:0 | [summary param] 0 in Join | file://:0:0:0:0 | [summary] to write: ReturnValue in Join |
+| bytes.Join | file://:0:0:0:0 | [summary param] 1 in Join | file://:0:0:0:0 | [summary] to write: ReturnValue in Join |
+| bytes.Map | file://:0:0:0:0 | [summary param] 1 in Map | file://:0:0:0:0 | [summary] to write: ReturnValue in Map |
+| bytes.NewBuffer | file://:0:0:0:0 | [summary param] 0 in NewBuffer | file://:0:0:0:0 | [summary] to write: ReturnValue in NewBuffer |
+| bytes.NewBufferString | file://:0:0:0:0 | [summary param] 0 in NewBufferString | file://:0:0:0:0 | [summary] to write: ReturnValue in NewBufferString |
+| bytes.NewReader | file://:0:0:0:0 | [summary param] 0 in NewReader | file://:0:0:0:0 | [summary] to write: ReturnValue in NewReader |
+| bytes.Reader.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| bytes.Reader.ReadAt | file://:0:0:0:0 | [summary param] -1 in ReadAt | file://:0:0:0:0 | [summary] to write: Argument[0] in ReadAt |
+| bytes.Reader.Reset | file://:0:0:0:0 | [summary param] 0 in Reset | file://:0:0:0:0 | [summary] to write: Argument[-1] in Reset |
+| bytes.Reader.WriteTo | file://:0:0:0:0 | [summary param] -1 in WriteTo | file://:0:0:0:0 | [summary] to write: Argument[0] in WriteTo |
+| bytes.Repeat | file://:0:0:0:0 | [summary param] 0 in Repeat | file://:0:0:0:0 | [summary] to write: ReturnValue in Repeat |
+| bytes.Replace | file://:0:0:0:0 | [summary param] 0 in Replace | file://:0:0:0:0 | [summary] to write: ReturnValue in Replace |
+| bytes.Replace | file://:0:0:0:0 | [summary param] 2 in Replace | file://:0:0:0:0 | [summary] to write: ReturnValue in Replace |
+| bytes.ReplaceAll | file://:0:0:0:0 | [summary param] 0 in ReplaceAll | file://:0:0:0:0 | [summary] to write: ReturnValue in ReplaceAll |
+| bytes.ReplaceAll | file://:0:0:0:0 | [summary param] 2 in ReplaceAll | file://:0:0:0:0 | [summary] to write: ReturnValue in ReplaceAll |
+| bytes.Runes | file://:0:0:0:0 | [summary param] 0 in Runes | file://:0:0:0:0 | [summary] to write: ReturnValue in Runes |
+| bytes.Split | file://:0:0:0:0 | [summary param] 0 in Split | file://:0:0:0:0 | [summary] to write: ReturnValue in Split |
+| bytes.SplitAfter | file://:0:0:0:0 | [summary param] 0 in SplitAfter | file://:0:0:0:0 | [summary] to write: ReturnValue in SplitAfter |
+| bytes.SplitAfterN | file://:0:0:0:0 | [summary param] 0 in SplitAfterN | file://:0:0:0:0 | [summary] to write: ReturnValue in SplitAfterN |
+| bytes.SplitN | file://:0:0:0:0 | [summary param] 0 in SplitN | file://:0:0:0:0 | [summary] to write: ReturnValue in SplitN |
+| bytes.Title | file://:0:0:0:0 | [summary param] 0 in Title | file://:0:0:0:0 | [summary] to write: ReturnValue in Title |
+| bytes.ToLower | file://:0:0:0:0 | [summary param] 0 in ToLower | file://:0:0:0:0 | [summary] to write: ReturnValue in ToLower |
+| bytes.ToLowerSpecial | file://:0:0:0:0 | [summary param] 1 in ToLowerSpecial | file://:0:0:0:0 | [summary] to write: ReturnValue in ToLowerSpecial |
+| bytes.ToTitle | file://:0:0:0:0 | [summary param] 0 in ToTitle | file://:0:0:0:0 | [summary] to write: ReturnValue in ToTitle |
+| bytes.ToTitleSpecial | file://:0:0:0:0 | [summary param] 1 in ToTitleSpecial | file://:0:0:0:0 | [summary] to write: ReturnValue in ToTitleSpecial |
+| bytes.ToUpper | file://:0:0:0:0 | [summary param] 0 in ToUpper | file://:0:0:0:0 | [summary] to write: ReturnValue in ToUpper |
+| bytes.ToUpperSpecial | file://:0:0:0:0 | [summary param] 1 in ToUpperSpecial | file://:0:0:0:0 | [summary] to write: ReturnValue in ToUpperSpecial |
+| bytes.ToValidUTF8 | file://:0:0:0:0 | [summary param] 0 in ToValidUTF8 | file://:0:0:0:0 | [summary] to write: ReturnValue in ToValidUTF8 |
+| bytes.ToValidUTF8 | file://:0:0:0:0 | [summary param] 1 in ToValidUTF8 | file://:0:0:0:0 | [summary] to write: ReturnValue in ToValidUTF8 |
+| bytes.Trim | file://:0:0:0:0 | [summary param] 0 in Trim | file://:0:0:0:0 | [summary] to write: ReturnValue in Trim |
+| bytes.TrimFunc | file://:0:0:0:0 | [summary param] 0 in TrimFunc | file://:0:0:0:0 | [summary] to write: ReturnValue in TrimFunc |
+| bytes.TrimLeft | file://:0:0:0:0 | [summary param] 0 in TrimLeft | file://:0:0:0:0 | [summary] to write: ReturnValue in TrimLeft |
+| bytes.TrimLeftFunc | file://:0:0:0:0 | [summary param] 0 in TrimLeftFunc | file://:0:0:0:0 | [summary] to write: ReturnValue in TrimLeftFunc |
+| bytes.TrimPrefix | file://:0:0:0:0 | [summary param] 0 in TrimPrefix | file://:0:0:0:0 | [summary] to write: ReturnValue in TrimPrefix |
+| bytes.TrimRight | file://:0:0:0:0 | [summary param] 0 in TrimRight | file://:0:0:0:0 | [summary] to write: ReturnValue in TrimRight |
+| bytes.TrimRightFunc | file://:0:0:0:0 | [summary param] 0 in TrimRightFunc | file://:0:0:0:0 | [summary] to write: ReturnValue in TrimRightFunc |
+| bytes.TrimSpace | file://:0:0:0:0 | [summary param] 0 in TrimSpace | file://:0:0:0:0 | [summary] to write: ReturnValue in TrimSpace |
+| bytes.TrimSuffix | file://:0:0:0:0 | [summary param] 0 in TrimSuffix | file://:0:0:0:0 | [summary] to write: ReturnValue in TrimSuffix |
+| compress/flate.NewReader | file://:0:0:0:0 | [summary param] 0 in NewReader | file://:0:0:0:0 | [summary] to write: ReturnValue in NewReader |
+| compress/flate.NewReaderDict | file://:0:0:0:0 | [summary param] 0 in NewReaderDict | file://:0:0:0:0 | [summary] to write: ReturnValue in NewReaderDict |
+| compress/flate.Reader.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| compress/flate.Resetter.Reset | file://:0:0:0:0 | [summary param] 0 in Reset | file://:0:0:0:0 | [summary] to write: Argument[-1] in Reset |
+| compress/flate.Writer.Reset | file://:0:0:0:0 | [summary param] -1 in Reset | file://:0:0:0:0 | [summary] to write: Argument[0] in Reset |
+| compress/flate.Writer.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| compress/flate.decompressor.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| compress/flate.decompressor.Reset | file://:0:0:0:0 | [summary param] 0 in Reset | file://:0:0:0:0 | [summary] to write: Argument[-1] in Reset |
+| compress/flate.dictWriter.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| compress/gzip.NewReader | file://:0:0:0:0 | [summary param] 0 in NewReader | file://:0:0:0:0 | [summary] to write: ReturnValue in NewReader |
+| compress/gzip.Reader.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| compress/gzip.Reader.Reset | file://:0:0:0:0 | [summary param] 0 in Reset | file://:0:0:0:0 | [summary] to write: Argument[-1] in Reset |
+| compress/gzip.Writer.Reset | file://:0:0:0:0 | [summary param] -1 in Reset | file://:0:0:0:0 | [summary] to write: Argument[0] in Reset |
+| compress/gzip.Writer.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| container/list.Element.Next | file://:0:0:0:0 | [summary param] -1 in Next | file://:0:0:0:0 | [summary] to write: ReturnValue in Next |
+| container/list.Element.Prev | file://:0:0:0:0 | [summary param] -1 in Prev | file://:0:0:0:0 | [summary] to write: ReturnValue in Prev |
+| container/list.List.Back | file://:0:0:0:0 | [summary param] -1 in Back | file://:0:0:0:0 | [summary] to write: ReturnValue in Back |
+| container/list.List.Front | file://:0:0:0:0 | [summary param] -1 in Front | file://:0:0:0:0 | [summary] to write: ReturnValue in Front |
+| container/list.List.Init | file://:0:0:0:0 | [summary param] -1 in Init | file://:0:0:0:0 | [summary] to write: ReturnValue in Init |
+| container/list.List.InsertAfter | file://:0:0:0:0 | [summary param] 0 in InsertAfter | file://:0:0:0:0 | [summary] to write: Argument[-1] in InsertAfter |
+| container/list.List.InsertAfter | file://:0:0:0:0 | [summary param] 0 in InsertAfter | file://:0:0:0:0 | [summary] to write: ReturnValue in InsertAfter |
+| container/list.List.InsertBefore | file://:0:0:0:0 | [summary param] 0 in InsertBefore | file://:0:0:0:0 | [summary] to write: Argument[-1] in InsertBefore |
+| container/list.List.InsertBefore | file://:0:0:0:0 | [summary param] 0 in InsertBefore | file://:0:0:0:0 | [summary] to write: ReturnValue in InsertBefore |
+| container/list.List.MoveAfter | file://:0:0:0:0 | [summary param] 0 in MoveAfter | file://:0:0:0:0 | [summary] to write: Argument[-1] in MoveAfter |
+| container/list.List.MoveBefore | file://:0:0:0:0 | [summary param] 0 in MoveBefore | file://:0:0:0:0 | [summary] to write: Argument[-1] in MoveBefore |
+| container/list.List.MoveToBack | file://:0:0:0:0 | [summary param] 0 in MoveToBack | file://:0:0:0:0 | [summary] to write: Argument[-1] in MoveToBack |
+| container/list.List.MoveToFront | file://:0:0:0:0 | [summary param] 0 in MoveToFront | file://:0:0:0:0 | [summary] to write: Argument[-1] in MoveToFront |
+| container/list.List.PushBack | file://:0:0:0:0 | [summary param] 0 in PushBack | file://:0:0:0:0 | [summary] to write: Argument[-1] in PushBack |
+| container/list.List.PushBack | file://:0:0:0:0 | [summary param] 0 in PushBack | file://:0:0:0:0 | [summary] to write: ReturnValue in PushBack |
+| container/list.List.PushBackList | file://:0:0:0:0 | [summary param] 0 in PushBackList | file://:0:0:0:0 | [summary] to write: Argument[-1] in PushBackList |
+| container/list.List.PushFront | file://:0:0:0:0 | [summary param] 0 in PushFront | file://:0:0:0:0 | [summary] to write: Argument[-1] in PushFront |
+| container/list.List.PushFront | file://:0:0:0:0 | [summary param] 0 in PushFront | file://:0:0:0:0 | [summary] to write: ReturnValue in PushFront |
+| container/list.List.PushFrontList | file://:0:0:0:0 | [summary param] 0 in PushFrontList | file://:0:0:0:0 | [summary] to write: Argument[-1] in PushFrontList |
+| container/list.List.Remove | file://:0:0:0:0 | [summary param] 0 in Remove | file://:0:0:0:0 | [summary] to write: ReturnValue in Remove |
+| context.Context.Value | file://:0:0:0:0 | [summary param] -1 in Value | file://:0:0:0:0 | [summary] to write: ReturnValue in Value |
+| context.WithCancel | file://:0:0:0:0 | [summary param] 0 in WithCancel | file://:0:0:0:0 | [summary] to write: ReturnValue in WithCancel |
+| context.WithDeadline | file://:0:0:0:0 | [summary param] 0 in WithDeadline | file://:0:0:0:0 | [summary] to write: ReturnValue in WithDeadline |
+| context.WithTimeout | file://:0:0:0:0 | [summary param] 0 in WithTimeout | file://:0:0:0:0 | [summary] to write: ReturnValue in WithTimeout |
+| context.WithValue | file://:0:0:0:0 | [summary param] 0 in WithValue | file://:0:0:0:0 | [summary] to write: ReturnValue in WithValue |
+| context.WithValue | file://:0:0:0:0 | [summary param] 1 in WithValue | file://:0:0:0:0 | [summary] to write: ReturnValue in WithValue |
+| context.WithValue | file://:0:0:0:0 | [summary param] 2 in WithValue | file://:0:0:0:0 | [summary] to write: ReturnValue in WithValue |
+| context.afterFuncCtx.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| context.afterFuncCtx.Value | file://:0:0:0:0 | [summary param] -1 in Value | file://:0:0:0:0 | [summary] to write: ReturnValue in Value |
+| context.afterFuncCtx.Value | file://:0:0:0:0 | [summary param] -1 in Value | file://:0:0:0:0 | [summary] to write: ReturnValue in Value |
+| context.backgroundCtx.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| context.backgroundCtx.Value | file://:0:0:0:0 | [summary param] -1 in Value | file://:0:0:0:0 | [summary] to write: ReturnValue in Value |
+| context.cancelCtx.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| context.cancelCtx.Value | file://:0:0:0:0 | [summary param] -1 in Value | file://:0:0:0:0 | [summary] to write: ReturnValue in Value |
+| context.cancelCtx.Value | file://:0:0:0:0 | [summary param] -1 in Value | file://:0:0:0:0 | [summary] to write: ReturnValue in Value |
+| context.emptyCtx.Value | file://:0:0:0:0 | [summary param] -1 in Value | file://:0:0:0:0 | [summary] to write: ReturnValue in Value |
+| context.stopCtx.Value | file://:0:0:0:0 | [summary param] -1 in Value | file://:0:0:0:0 | [summary] to write: ReturnValue in Value |
+| context.stringer.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| context.timerCtx.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| context.timerCtx.Value | file://:0:0:0:0 | [summary param] -1 in Value | file://:0:0:0:0 | [summary] to write: ReturnValue in Value |
+| context.timerCtx.Value | file://:0:0:0:0 | [summary param] -1 in Value | file://:0:0:0:0 | [summary] to write: ReturnValue in Value |
+| context.todoCtx.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| context.todoCtx.Value | file://:0:0:0:0 | [summary param] -1 in Value | file://:0:0:0:0 | [summary] to write: ReturnValue in Value |
+| context.valueCtx.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| context.valueCtx.Value | file://:0:0:0:0 | [summary param] -1 in Value | file://:0:0:0:0 | [summary] to write: ReturnValue in Value |
+| context.valueCtx.Value | file://:0:0:0:0 | [summary param] -1 in Value | file://:0:0:0:0 | [summary] to write: ReturnValue in Value |
+| context.withoutCancelCtx.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| context.withoutCancelCtx.Value | file://:0:0:0:0 | [summary param] -1 in Value | file://:0:0:0:0 | [summary] to write: ReturnValue in Value |
+| crypto.Decrypter.Decrypt | file://:0:0:0:0 | [summary param] 1 in Decrypt | file://:0:0:0:0 | [summary] to write: ReturnValue in Decrypt |
+| crypto.Hash.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| crypto.go | crypto.go:9:14:9:31 | call to NewCipher | crypto.go:9:2:9:31 | ... := ...[0] |
+| crypto.go | crypto.go:9:14:9:31 | call to NewCipher | crypto.go:9:2:9:31 | ... := ...[1] |
+| crypto.go | crypto.go:10:15:10:34 | call to NewGCM | crypto.go:10:2:10:34 | ... := ...[0] |
+| crypto.go | crypto.go:10:15:10:34 | call to NewGCM | crypto.go:10:2:10:34 | ... := ...[1] |
+| crypto.go | crypto.go:11:18:11:57 | call to Open | crypto.go:11:2:11:57 | ... := ...[0] |
+| crypto.go | crypto.go:11:18:11:57 | call to Open | crypto.go:11:2:11:57 | ... := ...[1] |
+| crypto.go | crypto.go:11:42:11:51 | ciphertext | crypto.go:11:2:11:57 | ... := ...[0] |
+| crypto/aes.aesCipher.Decrypt | file://:0:0:0:0 | [summary param] 1 in Decrypt | file://:0:0:0:0 | [summary] to write: Argument[0] in Decrypt |
+| crypto/aes.aesCipherAsm.Decrypt | file://:0:0:0:0 | [summary param] 1 in Decrypt | file://:0:0:0:0 | [summary] to write: Argument[0] in Decrypt |
+| crypto/aes.aesCipherGCM.Decrypt | file://:0:0:0:0 | [summary param] 1 in Decrypt | file://:0:0:0:0 | [summary] to write: Argument[0] in Decrypt |
+| crypto/aes.gcmAsm.Open | file://:0:0:0:0 | [summary param] 2 in Open | file://:0:0:0:0 | [summary] to write: Argument[0] in Open |
+| crypto/aes.gcmAsm.Open | file://:0:0:0:0 | [summary param] 2 in Open | file://:0:0:0:0 | [summary] to write: ReturnValue in Open |
+| crypto/cipher.AEAD.Open | file://:0:0:0:0 | [summary param] 2 in Open | file://:0:0:0:0 | [summary] to write: Argument[0] in Open |
+| crypto/cipher.AEAD.Open | file://:0:0:0:0 | [summary param] 2 in Open | file://:0:0:0:0 | [summary] to write: ReturnValue in Open |
+| crypto/cipher.Block.Decrypt | file://:0:0:0:0 | [summary param] 1 in Decrypt | file://:0:0:0:0 | [summary] to write: Argument[0] in Decrypt |
+| crypto/cipher.StreamReader.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| crypto/cipher.StreamWriter.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| crypto/cipher.gcm.Open | file://:0:0:0:0 | [summary param] 2 in Open | file://:0:0:0:0 | [summary] to write: Argument[0] in Open |
+| crypto/cipher.gcm.Open | file://:0:0:0:0 | [summary param] 2 in Open | file://:0:0:0:0 | [summary] to write: ReturnValue in Open |
+| crypto/des.desCipher.Decrypt | file://:0:0:0:0 | [summary param] 1 in Decrypt | file://:0:0:0:0 | [summary] to write: Argument[0] in Decrypt |
+| crypto/des.tripleDESCipher.Decrypt | file://:0:0:0:0 | [summary param] 1 in Decrypt | file://:0:0:0:0 | [summary] to write: Argument[0] in Decrypt |
+| crypto/ecdh.nistCurve.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| crypto/ecdh.x25519Curve.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| crypto/ecdsa.zr.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| crypto/hmac.hmac.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| crypto/hmac.marshalable.MarshalBinary | file://:0:0:0:0 | [summary param] -1 in MarshalBinary | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalBinary |
+| crypto/hmac.marshalable.UnmarshalBinary | file://:0:0:0:0 | [summary param] 0 in UnmarshalBinary | file://:0:0:0:0 | [summary] to write: Argument[-1] in UnmarshalBinary |
+| crypto/internal/boring.randReader.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| crypto/md5.digest.MarshalBinary | file://:0:0:0:0 | [summary param] -1 in MarshalBinary | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalBinary |
+| crypto/md5.digest.UnmarshalBinary | file://:0:0:0:0 | [summary param] 0 in UnmarshalBinary | file://:0:0:0:0 | [summary] to write: Argument[-1] in UnmarshalBinary |
+| crypto/md5.digest.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| crypto/rsa.DecryptOAEP | file://:0:0:0:0 | [summary param] 3 in DecryptOAEP | file://:0:0:0:0 | [summary] to write: ReturnValue in DecryptOAEP |
+| crypto/rsa.DecryptPKCS1v15 | file://:0:0:0:0 | [summary param] 2 in DecryptPKCS1v15 | file://:0:0:0:0 | [summary] to write: ReturnValue in DecryptPKCS1v15 |
+| crypto/rsa.PrivateKey.Decrypt | file://:0:0:0:0 | [summary param] 1 in Decrypt | file://:0:0:0:0 | [summary] to write: ReturnValue in Decrypt |
+| crypto/sha1.digest.MarshalBinary | file://:0:0:0:0 | [summary param] -1 in MarshalBinary | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalBinary |
+| crypto/sha1.digest.UnmarshalBinary | file://:0:0:0:0 | [summary param] 0 in UnmarshalBinary | file://:0:0:0:0 | [summary] to write: Argument[-1] in UnmarshalBinary |
+| crypto/sha1.digest.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| crypto/sha256.digest.MarshalBinary | file://:0:0:0:0 | [summary param] -1 in MarshalBinary | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalBinary |
+| crypto/sha256.digest.UnmarshalBinary | file://:0:0:0:0 | [summary param] 0 in UnmarshalBinary | file://:0:0:0:0 | [summary] to write: Argument[-1] in UnmarshalBinary |
+| crypto/sha256.digest.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| crypto/sha512.digest.MarshalBinary | file://:0:0:0:0 | [summary param] -1 in MarshalBinary | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalBinary |
+| crypto/sha512.digest.UnmarshalBinary | file://:0:0:0:0 | [summary param] 0 in UnmarshalBinary | file://:0:0:0:0 | [summary] to write: Argument[-1] in UnmarshalBinary |
+| crypto/sha512.digest.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| crypto/tls.Client | file://:0:0:0:0 | [summary param] 0 in Client | file://:0:0:0:0 | [summary] to write: ReturnValue in Client |
+| crypto/tls.ClientAuthType.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| crypto/tls.Conn.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| crypto/tls.Conn.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| crypto/tls.CurveID.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| crypto/tls.NewListener | file://:0:0:0:0 | [summary param] 0 in NewListener | file://:0:0:0:0 | [summary] to write: ReturnValue in NewListener |
+| crypto/tls.QUICEncryptionLevel.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| crypto/tls.Server | file://:0:0:0:0 | [summary param] 0 in Server | file://:0:0:0:0 | [summary] to write: ReturnValue in Server |
+| crypto/tls.SignatureScheme.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| crypto/tls.aead.Open | file://:0:0:0:0 | [summary param] 2 in Open | file://:0:0:0:0 | [summary] to write: Argument[0] in Open |
+| crypto/tls.aead.Open | file://:0:0:0:0 | [summary param] 2 in Open | file://:0:0:0:0 | [summary] to write: ReturnValue in Open |
+| crypto/tls.alert.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| crypto/tls.atLeastReader.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| crypto/tls.certCache.CompareAndSwap | file://:0:0:0:0 | [summary param] 2 in CompareAndSwap | file://:0:0:0:0 | [summary] to write: Argument[-1] in CompareAndSwap |
+| crypto/tls.certCache.Load | file://:0:0:0:0 | [summary param] -1 in Load | file://:0:0:0:0 | [summary] to write: ReturnValue in Load |
+| crypto/tls.certCache.LoadOrStore | file://:0:0:0:0 | [summary param] 0 in LoadOrStore | file://:0:0:0:0 | [summary] to write: Argument[-1] in LoadOrStore |
+| crypto/tls.certCache.LoadOrStore | file://:0:0:0:0 | [summary param] 0 in LoadOrStore | file://:0:0:0:0 | [summary] to write: ReturnValue in LoadOrStore |
+| crypto/tls.certCache.LoadOrStore | file://:0:0:0:0 | [summary param] 1 in LoadOrStore | file://:0:0:0:0 | [summary] to write: Argument[-1] in LoadOrStore |
+| crypto/tls.certCache.LoadOrStore | file://:0:0:0:0 | [summary param] 1 in LoadOrStore | file://:0:0:0:0 | [summary] to write: ReturnValue in LoadOrStore |
+| crypto/tls.certCache.LoadOrStore | file://:0:0:0:0 | [summary param] -1 in LoadOrStore | file://:0:0:0:0 | [summary] to write: ReturnValue in LoadOrStore |
+| crypto/tls.certCache.Store | file://:0:0:0:0 | [summary param] 0 in Store | file://:0:0:0:0 | [summary] to write: Argument[-1] in Store |
+| crypto/tls.certCache.Store | file://:0:0:0:0 | [summary param] 1 in Store | file://:0:0:0:0 | [summary] to write: Argument[-1] in Store |
+| crypto/tls.certCache.Swap | file://:0:0:0:0 | [summary param] 0 in Swap | file://:0:0:0:0 | [summary] to write: Argument[-1] in Swap |
+| crypto/tls.certCache.Swap | file://:0:0:0:0 | [summary param] 1 in Swap | file://:0:0:0:0 | [summary] to write: Argument[-1] in Swap |
+| crypto/tls.certCache.Swap | file://:0:0:0:0 | [summary param] -1 in Swap | file://:0:0:0:0 | [summary] to write: ReturnValue in Swap |
+| crypto/tls.constantTimeHash.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| crypto/tls.cthWrapper.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| crypto/tls.finishedHash.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| crypto/tls.prefixNonceAEAD.Open | file://:0:0:0:0 | [summary param] 2 in Open | file://:0:0:0:0 | [summary] to write: Argument[0] in Open |
+| crypto/tls.prefixNonceAEAD.Open | file://:0:0:0:0 | [summary param] 2 in Open | file://:0:0:0:0 | [summary] to write: ReturnValue in Open |
+| crypto/tls.transcriptHash.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| crypto/tls.xorNonceAEAD.Open | file://:0:0:0:0 | [summary param] 2 in Open | file://:0:0:0:0 | [summary] to write: Argument[0] in Open |
+| crypto/tls.xorNonceAEAD.Open | file://:0:0:0:0 | [summary param] 2 in Open | file://:0:0:0:0 | [summary] to write: ReturnValue in Open |
+| crypto/x509.DecryptPEMBlock | file://:0:0:0:0 | [summary param] 0 in DecryptPEMBlock | file://:0:0:0:0 | [summary] to write: ReturnValue in DecryptPEMBlock |
+| crypto/x509.PublicKeyAlgorithm.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| crypto/x509.SignatureAlgorithm.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| crypto/x509/pkix.Name.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| crypto/x509/pkix.RDNSequence.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| embed.FS.Open | file://:0:0:0:0 | [summary param] -1 in Open | file://:0:0:0:0 | [summary] to write: ReturnValue in Open |
+| embed.FS.ReadDir | file://:0:0:0:0 | [summary param] -1 in ReadDir | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadDir |
+| embed.FS.ReadFile | file://:0:0:0:0 | [summary param] -1 in ReadFile | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadFile |
+| embed.file.Info | file://:0:0:0:0 | [summary param] -1 in Info | file://:0:0:0:0 | [summary] to write: ReturnValue in Info |
+| embed.file.Name | file://:0:0:0:0 | [summary param] -1 in Name | file://:0:0:0:0 | [summary] to write: ReturnValue in Name |
+| embed.file.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| embed.openDir.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| embed.openFile.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| embed.openFile.ReadAt | file://:0:0:0:0 | [summary param] -1 in ReadAt | file://:0:0:0:0 | [summary] to write: Argument[0] in ReadAt |
+| encoding.BinaryMarshaler.MarshalBinary | file://:0:0:0:0 | [summary param] -1 in MarshalBinary | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalBinary |
+| encoding.BinaryUnmarshaler.UnmarshalBinary | file://:0:0:0:0 | [summary param] 0 in UnmarshalBinary | file://:0:0:0:0 | [summary] to write: Argument[-1] in UnmarshalBinary |
+| encoding.TextMarshaler.MarshalText | file://:0:0:0:0 | [summary param] -1 in MarshalText | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalText |
+| encoding.TextUnmarshaler.UnmarshalText | file://:0:0:0:0 | [summary param] 0 in UnmarshalText | file://:0:0:0:0 | [summary] to write: Argument[-1] in UnmarshalText |
+| encoding/asn1.Marshal | file://:0:0:0:0 | [summary param] 0 in Marshal | file://:0:0:0:0 | [summary] to write: ReturnValue in Marshal |
+| encoding/asn1.MarshalWithParams | file://:0:0:0:0 | [summary param] 0 in MarshalWithParams | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalWithParams |
+| encoding/asn1.MarshalWithParams | file://:0:0:0:0 | [summary param] 1 in MarshalWithParams | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalWithParams |
+| encoding/asn1.ObjectIdentifier.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| encoding/asn1.Unmarshal | file://:0:0:0:0 | [summary param] 0 in Unmarshal | file://:0:0:0:0 | [summary] to write: Argument[1] in Unmarshal |
+| encoding/asn1.Unmarshal | file://:0:0:0:0 | [summary param] 0 in Unmarshal | file://:0:0:0:0 | [summary] to write: ReturnValue in Unmarshal |
+| encoding/asn1.UnmarshalWithParams | file://:0:0:0:0 | [summary param] 0 in UnmarshalWithParams | file://:0:0:0:0 | [summary] to write: Argument[1] in UnmarshalWithParams |
+| encoding/asn1.UnmarshalWithParams | file://:0:0:0:0 | [summary param] 0 in UnmarshalWithParams | file://:0:0:0:0 | [summary] to write: ReturnValue in UnmarshalWithParams |
+| encoding/asn1.UnmarshalWithParams | file://:0:0:0:0 | [summary param] 2 in UnmarshalWithParams | file://:0:0:0:0 | [summary] to write: Argument[1] in UnmarshalWithParams |
+| encoding/asn1.UnmarshalWithParams | file://:0:0:0:0 | [summary param] 2 in UnmarshalWithParams | file://:0:0:0:0 | [summary] to write: ReturnValue in UnmarshalWithParams |
+| encoding/base64.Encoding.Decode | file://:0:0:0:0 | [summary param] 1 in Decode | file://:0:0:0:0 | [summary] to write: Argument[0] in Decode |
+| encoding/base64.Encoding.DecodeString | file://:0:0:0:0 | [summary param] 0 in DecodeString | file://:0:0:0:0 | [summary] to write: ReturnValue in DecodeString |
+| encoding/base64.NewDecoder | file://:0:0:0:0 | [summary param] 1 in NewDecoder | file://:0:0:0:0 | [summary] to write: ReturnValue in NewDecoder |
+| encoding/base64.decoder.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| encoding/base64.encoder.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| encoding/base64.newlineFilteringReader.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| encoding/binary.AppendByteOrder.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| encoding/binary.ByteOrder.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| encoding/binary.Read | file://:0:0:0:0 | [summary param] 0 in Read | file://:0:0:0:0 | [summary] to write: Argument[2] in Read |
+| encoding/binary.Write | file://:0:0:0:0 | [summary param] 2 in Write | file://:0:0:0:0 | [summary] to write: Argument[0] in Write |
+| encoding/binary.bigEndian.GoString | file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
+| encoding/binary.bigEndian.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| encoding/binary.littleEndian.GoString | file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
+| encoding/binary.littleEndian.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| encoding/binary.nativeEndian.GoString | file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
+| encoding/binary.nativeEndian.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| encoding/hex.Decode | file://:0:0:0:0 | [summary param] 1 in Decode | file://:0:0:0:0 | [summary] to write: Argument[0] in Decode |
+| encoding/hex.DecodeString | file://:0:0:0:0 | [summary param] 0 in DecodeString | file://:0:0:0:0 | [summary] to write: ReturnValue in DecodeString |
+| encoding/hex.NewDecoder | file://:0:0:0:0 | [summary param] 0 in NewDecoder | file://:0:0:0:0 | [summary] to write: ReturnValue in NewDecoder |
+| encoding/hex.decoder.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| encoding/hex.dumper.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| encoding/hex.encoder.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| encoding/json.Compact | file://:0:0:0:0 | [summary param] 1 in Compact | file://:0:0:0:0 | [summary] to write: Argument[0] in Compact |
+| encoding/json.Decoder.Buffered | file://:0:0:0:0 | [summary param] -1 in Buffered | file://:0:0:0:0 | [summary] to write: ReturnValue in Buffered |
+| encoding/json.Decoder.Decode | file://:0:0:0:0 | [summary param] -1 in Decode | file://:0:0:0:0 | [summary] to write: Argument[0] in Decode |
+| encoding/json.Decoder.Token | file://:0:0:0:0 | [summary param] -1 in Token | file://:0:0:0:0 | [summary] to write: ReturnValue in Token |
+| encoding/json.Delim.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| encoding/json.Encoder.Encode | file://:0:0:0:0 | [summary param] 0 in Encode | file://:0:0:0:0 | [summary] to write: Argument[-1] in Encode |
+| encoding/json.Encoder.SetIndent | file://:0:0:0:0 | [summary param] 0 in SetIndent | file://:0:0:0:0 | [summary] to write: Argument[-1] in SetIndent |
+| encoding/json.Encoder.SetIndent | file://:0:0:0:0 | [summary param] 1 in SetIndent | file://:0:0:0:0 | [summary] to write: Argument[-1] in SetIndent |
+| encoding/json.HTMLEscape | file://:0:0:0:0 | [summary param] 1 in HTMLEscape | file://:0:0:0:0 | [summary] to write: Argument[0] in HTMLEscape |
+| encoding/json.Indent | file://:0:0:0:0 | [summary param] 1 in Indent | file://:0:0:0:0 | [summary] to write: Argument[0] in Indent |
+| encoding/json.Indent | file://:0:0:0:0 | [summary param] 2 in Indent | file://:0:0:0:0 | [summary] to write: Argument[0] in Indent |
+| encoding/json.Indent | file://:0:0:0:0 | [summary param] 3 in Indent | file://:0:0:0:0 | [summary] to write: Argument[0] in Indent |
+| encoding/json.Marshal | file://:0:0:0:0 | [summary param] 0 in Marshal | file://:0:0:0:0 | [summary] to write: ReturnValue in Marshal |
+| encoding/json.MarshalIndent | file://:0:0:0:0 | [summary param] 0 in MarshalIndent | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalIndent |
+| encoding/json.MarshalIndent | file://:0:0:0:0 | [summary param] 1 in MarshalIndent | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalIndent |
+| encoding/json.MarshalIndent | file://:0:0:0:0 | [summary param] 2 in MarshalIndent | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalIndent |
+| encoding/json.Marshaler.MarshalJSON | file://:0:0:0:0 | [summary param] -1 in MarshalJSON | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalJSON |
+| encoding/json.NewDecoder | file://:0:0:0:0 | [summary param] 0 in NewDecoder | file://:0:0:0:0 | [summary] to write: ReturnValue in NewDecoder |
+| encoding/json.Number.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| encoding/json.RawMessage.MarshalJSON | file://:0:0:0:0 | [summary param] -1 in MarshalJSON | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalJSON |
+| encoding/json.RawMessage.UnmarshalJSON | file://:0:0:0:0 | [summary param] 0 in UnmarshalJSON | file://:0:0:0:0 | [summary] to write: Argument[-1] in UnmarshalJSON |
+| encoding/json.Unmarshal | file://:0:0:0:0 | [summary param] 0 in Unmarshal | file://:0:0:0:0 | [summary] to write: Argument[1] in Unmarshal |
+| encoding/json.Unmarshaler.UnmarshalJSON | file://:0:0:0:0 | [summary param] 0 in UnmarshalJSON | file://:0:0:0:0 | [summary] to write: Argument[-1] in UnmarshalJSON |
+| encoding/json.encodeState.Bytes | file://:0:0:0:0 | [summary param] -1 in Bytes | file://:0:0:0:0 | [summary] to write: ReturnValue in Bytes |
+| encoding/json.encodeState.Next | file://:0:0:0:0 | [summary param] -1 in Next | file://:0:0:0:0 | [summary] to write: ReturnValue in Next |
+| encoding/json.encodeState.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| encoding/json.encodeState.ReadBytes | file://:0:0:0:0 | [summary param] -1 in ReadBytes | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadBytes |
+| encoding/json.encodeState.ReadFrom | file://:0:0:0:0 | [summary param] 0 in ReadFrom | file://:0:0:0:0 | [summary] to write: Argument[-1] in ReadFrom |
+| encoding/json.encodeState.ReadString | file://:0:0:0:0 | [summary param] -1 in ReadString | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadString |
+| encoding/json.encodeState.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| encoding/json.encodeState.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| encoding/json.encodeState.WriteString | file://:0:0:0:0 | [summary param] 0 in WriteString | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteString |
+| encoding/json.encodeState.WriteTo | file://:0:0:0:0 | [summary param] -1 in WriteTo | file://:0:0:0:0 | [summary] to write: Argument[0] in WriteTo |
+| encoding/pem.Decode | file://:0:0:0:0 | [summary param] 0 in Decode | file://:0:0:0:0 | [summary] to write: ReturnValue in Decode |
+| encoding/pem.Decode | file://:0:0:0:0 | [summary param] 0 in Decode | file://:0:0:0:0 | [summary] to write: ReturnValue[1] in Decode |
+| encoding/pem.Encode | file://:0:0:0:0 | [summary param] 1 in Encode | file://:0:0:0:0 | [summary] to write: Argument[0] in Encode |
+| encoding/pem.EncodeToMemory | file://:0:0:0:0 | [summary param] 0 in EncodeToMemory | file://:0:0:0:0 | [summary] to write: ReturnValue in EncodeToMemory |
+| encoding/pem.lineBreaker.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| errors.As | file://:0:0:0:0 | [summary param] 0 in As | file://:0:0:0:0 | [summary] to write: Argument[1] in As |
+| errors.New | file://:0:0:0:0 | [summary param] 0 in New | file://:0:0:0:0 | [summary] to write: ReturnValue in New |
+| errors.Unwrap | file://:0:0:0:0 | [summary param] 0 in Unwrap | file://:0:0:0:0 | [summary] to write: ReturnValue in Unwrap |
+| fmt.GoStringer.GoString | file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
+| fmt.ScanState.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| fmt.ScanState.Token | file://:0:0:0:0 | [summary param] -1 in Token | file://:0:0:0:0 | [summary] to write: ReturnValue in Token |
+| fmt.State.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| fmt.Stringer.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| fmt.pp.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| fmt.pp.WriteString | file://:0:0:0:0 | [summary param] 0 in WriteString | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteString |
+| fmt.ss.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| fmt.ss.Token | file://:0:0:0:0 | [summary param] -1 in Token | file://:0:0:0:0 | [summary] to write: ReturnValue in Token |
+| fmt.stringReader.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| hash.Hash32.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| hash.Hash64.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| hash.Hash.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| hash/crc32.digest.MarshalBinary | file://:0:0:0:0 | [summary param] -1 in MarshalBinary | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalBinary |
+| hash/crc32.digest.UnmarshalBinary | file://:0:0:0:0 | [summary param] 0 in UnmarshalBinary | file://:0:0:0:0 | [summary] to write: Argument[-1] in UnmarshalBinary |
+| hash/crc32.digest.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| internal/abi.Kind.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| internal/bisect.Writer.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| internal/godebug.Setting.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| internal/godebug.runtimeStderr.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| internal/poll.FD.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| internal/poll.FD.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| internal/reflectlite.Type.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| internal/reflectlite.mapType.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| internal/reflectlite.rtype.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| io.Copy | file://:0:0:0:0 | [summary param] 1 in Copy | file://:0:0:0:0 | [summary] to write: Argument[0] in Copy |
+| io.CopyBuffer | file://:0:0:0:0 | [summary param] 1 in CopyBuffer | file://:0:0:0:0 | [summary] to write: Argument[0] in CopyBuffer |
+| io.CopyN | file://:0:0:0:0 | [summary param] 1 in CopyN | file://:0:0:0:0 | [summary] to write: Argument[0] in CopyN |
+| io.LimitReader | file://:0:0:0:0 | [summary param] 0 in LimitReader | file://:0:0:0:0 | [summary] to write: ReturnValue in LimitReader |
+| io.LimitedReader.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| io.NewSectionReader | file://:0:0:0:0 | [summary param] 0 in NewSectionReader | file://:0:0:0:0 | [summary] to write: ReturnValue in NewSectionReader |
+| io.NopCloser | file://:0:0:0:0 | [summary param] 0 in NopCloser | file://:0:0:0:0 | [summary] to write: ReturnValue in NopCloser |
+| io.OffsetWriter.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| io.OffsetWriter.WriteAt | file://:0:0:0:0 | [summary param] 0 in WriteAt | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteAt |
+| io.PipeReader.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| io.PipeWriter.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| io.ReadAll | file://:0:0:0:0 | [summary param] 0 in ReadAll | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadAll |
+| io.ReadAtLeast | file://:0:0:0:0 | [summary param] 0 in ReadAtLeast | file://:0:0:0:0 | [summary] to write: Argument[1] in ReadAtLeast |
+| io.ReadCloser.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| io.ReadFull | file://:0:0:0:0 | [summary param] 0 in ReadFull | file://:0:0:0:0 | [summary] to write: Argument[1] in ReadFull |
+| io.ReadSeekCloser.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| io.ReadSeeker.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| io.ReadWriteCloser.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| io.ReadWriteCloser.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| io.ReadWriteSeeker.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| io.ReadWriteSeeker.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| io.ReadWriter.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| io.ReadWriter.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| io.Reader.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| io.ReaderAt.ReadAt | file://:0:0:0:0 | [summary param] -1 in ReadAt | file://:0:0:0:0 | [summary] to write: Argument[0] in ReadAt |
+| io.ReaderFrom.ReadFrom | file://:0:0:0:0 | [summary param] 0 in ReadFrom | file://:0:0:0:0 | [summary] to write: Argument[-1] in ReadFrom |
+| io.SectionReader.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| io.SectionReader.ReadAt | file://:0:0:0:0 | [summary param] -1 in ReadAt | file://:0:0:0:0 | [summary] to write: Argument[0] in ReadAt |
+| io.StringWriter.WriteString | file://:0:0:0:0 | [summary param] 0 in WriteString | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteString |
+| io.TeeReader | file://:0:0:0:0 | [summary param] 0 in TeeReader | file://:0:0:0:0 | [summary] to write: Argument[1] in TeeReader |
+| io.TeeReader | file://:0:0:0:0 | [summary param] 0 in TeeReader | file://:0:0:0:0 | [summary] to write: ReturnValue in TeeReader |
+| io.WriteCloser.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| io.WriteSeeker.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| io.WriteString | file://:0:0:0:0 | [summary param] 1 in WriteString | file://:0:0:0:0 | [summary] to write: Argument[0] in WriteString |
+| io.Writer.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| io.WriterAt.WriteAt | file://:0:0:0:0 | [summary param] 0 in WriteAt | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteAt |
+| io.WriterTo.WriteTo | file://:0:0:0:0 | [summary param] -1 in WriteTo | file://:0:0:0:0 | [summary] to write: Argument[0] in WriteTo |
+| io.discard.ReadFrom | file://:0:0:0:0 | [summary param] 0 in ReadFrom | file://:0:0:0:0 | [summary] to write: Argument[-1] in ReadFrom |
+| io.discard.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| io.discard.WriteString | file://:0:0:0:0 | [summary param] 0 in WriteString | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteString |
+| io.eofReader.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| io.go | io.go:14:31:14:43 | "some string" | io.go:14:13:14:44 | call to NewReader |
+| io.go | io.go:16:3:16:3 | definition of w | io.go:16:23:16:27 | &... |
+| io.go | io.go:16:3:16:3 | definition of w | io.go:16:30:16:34 | &... |
+| io.go | io.go:16:23:16:27 | &... | io.go:15:7:15:10 | definition of buf1 |
+| io.go | io.go:16:24:16:27 | buf1 | io.go:16:23:16:27 | &... |
+| io.go | io.go:16:30:16:34 | &... | io.go:15:13:15:16 | definition of buf2 |
+| io.go | io.go:16:31:16:34 | buf2 | io.go:16:30:16:34 | &... |
+| io.go | io.go:18:14:18:19 | reader | io.go:16:3:16:3 | definition of w |
+| io.go | io.go:22:31:22:43 | "some string" | io.go:22:13:22:44 | call to NewReader |
+| io.go | io.go:25:19:25:23 | &... | io.go:23:7:23:10 | definition of buf1 |
+| io.go | io.go:25:20:25:23 | buf1 | io.go:25:19:25:23 | &... |
+| io.go | io.go:27:21:27:26 | reader | io.go:25:3:25:4 | definition of w2 |
+| io.go | io.go:31:31:31:43 | "some string" | io.go:31:13:31:44 | call to NewReader |
+| io.go | io.go:33:19:33:23 | &... | io.go:32:7:32:10 | definition of buf1 |
+| io.go | io.go:33:20:33:23 | buf1 | io.go:33:19:33:23 | &... |
+| io.go | io.go:35:16:35:21 | reader | io.go:33:3:33:4 | definition of w2 |
+| io.go | io.go:39:6:39:6 | definition of w | io.go:39:3:39:19 | ... := ...[0] |
+| io.go | io.go:39:11:39:19 | call to Pipe | io.go:39:3:39:19 | ... := ...[0] |
+| io.go | io.go:39:11:39:19 | call to Pipe | io.go:39:3:39:19 | ... := ...[1] |
+| io.go | io.go:40:17:40:31 | "some string\\n" | io.go:39:6:39:6 | definition of w |
+| io.go | io.go:43:16:43:16 | r | io.go:42:3:42:5 | definition of buf |
+| io.go | io.go:44:13:44:15 | buf | io.go:44:13:44:24 | call to String |
+| io.go | io.go:48:31:48:43 | "some string" | io.go:48:13:48:44 | call to NewReader |
+| io.go | io.go:50:18:50:23 | reader | io.go:49:3:49:5 | definition of buf |
+| io.go | io.go:54:31:54:43 | "some string" | io.go:54:13:54:44 | call to NewReader |
+| io.go | io.go:56:15:56:20 | reader | io.go:55:3:55:5 | definition of buf |
+| io.go | io.go:61:18:61:21 | &... | io.go:60:7:60:9 | definition of buf |
+| io.go | io.go:61:19:61:21 | buf | io.go:61:18:61:21 | &... |
+| io.go | io.go:62:21:62:26 | "test" | io.go:61:3:61:3 | definition of w |
+| io.go | io.go:65:31:65:43 | "some string" | io.go:65:13:65:44 | call to NewReader |
+| io.go | io.go:67:3:67:8 | reader | io.go:66:3:66:5 | definition of buf |
+| io.go | io.go:70:31:70:43 | "some string" | io.go:70:13:70:44 | call to NewReader |
+| io.go | io.go:72:3:72:8 | reader | io.go:71:3:71:5 | definition of buf |
+| io.go | io.go:76:31:76:43 | "some string" | io.go:76:13:76:44 | call to NewReader |
+| io.go | io.go:77:24:77:29 | reader | io.go:77:9:77:33 | call to LimitReader |
+| io.go | io.go:78:22:78:23 | lr | io.go:78:11:78:19 | selection of Stdout |
+| io.go | io.go:82:27:82:36 | "reader1 " | io.go:82:9:82:37 | call to NewReader |
+| io.go | io.go:83:27:83:36 | "reader2 " | io.go:83:9:83:37 | call to NewReader |
+| io.go | io.go:84:27:84:35 | "reader3" | io.go:84:9:84:36 | call to NewReader |
+| io.go | io.go:85:23:85:24 | r1 | io.go:85:8:85:33 | call to MultiReader |
+| io.go | io.go:85:27:85:28 | r2 | io.go:85:8:85:33 | call to MultiReader |
+| io.go | io.go:85:31:85:32 | r3 | io.go:85:8:85:33 | call to MultiReader |
+| io.go | io.go:86:22:86:22 | r | io.go:86:11:86:19 | selection of Stdout |
+| io.go | io.go:89:26:89:38 | "some string" | io.go:89:8:89:39 | call to NewReader |
+| io.go | io.go:91:23:91:23 | r | io.go:91:10:91:30 | call to TeeReader |
+| io.go | io.go:91:23:91:23 | r | io.go:91:26:91:29 | &... |
+| io.go | io.go:91:26:91:29 | &... | io.go:90:7:90:9 | definition of buf |
+| io.go | io.go:91:27:91:29 | buf | io.go:91:26:91:29 | &... |
+| io.go | io.go:93:22:93:24 | tee | io.go:93:11:93:19 | selection of Stdout |
+| io.go | io.go:96:26:96:38 | "some string" | io.go:96:8:96:39 | call to NewReader |
+| io.go | io.go:97:28:97:28 | r | io.go:97:8:97:36 | call to NewSectionReader |
+| io.go | io.go:98:22:98:22 | s | io.go:98:11:98:19 | selection of Stdout |
+| io.go | io.go:101:26:101:38 | "some string" | io.go:101:8:101:39 | call to NewReader |
+| io.go | io.go:102:3:102:3 | r | io.go:102:13:102:21 | selection of Stdout |
+| io.go | io.go:108:30:108:42 | "some string" | io.go:108:12:108:43 | call to NewReader |
+| io.go | io.go:109:12:109:33 | call to ReadAll | io.go:109:2:109:33 | ... := ...[0] |
+| io.go | io.go:109:12:109:33 | call to ReadAll | io.go:109:2:109:33 | ... := ...[1] |
+| io.go | io.go:109:27:109:32 | reader | io.go:109:2:109:33 | ... := ...[0] |
+| io.go | io.go:110:18:110:20 | buf | io.go:110:2:110:10 | selection of Stdout |
+| io.multiReader.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| io.multiReader.WriteTo | file://:0:0:0:0 | [summary param] -1 in WriteTo | file://:0:0:0:0 | [summary] to write: Argument[0] in WriteTo |
+| io.multiWriter.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| io.multiWriter.WriteString | file://:0:0:0:0 | [summary param] 0 in WriteString | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteString |
+| io.nopCloser.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| io.nopCloserWriterTo.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| io.nopCloserWriterTo.WriteTo | file://:0:0:0:0 | [summary param] -1 in WriteTo | file://:0:0:0:0 | [summary] to write: Argument[0] in WriteTo |
+| io.teeReader.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| io/fs.DirEntry.Info | file://:0:0:0:0 | [summary param] -1 in Info | file://:0:0:0:0 | [summary] to write: ReturnValue in Info |
+| io/fs.DirEntry.Name | file://:0:0:0:0 | [summary param] -1 in Name | file://:0:0:0:0 | [summary] to write: ReturnValue in Name |
+| io/fs.FS.Open | file://:0:0:0:0 | [summary param] -1 in Open | file://:0:0:0:0 | [summary] to write: ReturnValue in Open |
+| io/fs.File.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| io/fs.FileInfoToDirEntry | file://:0:0:0:0 | [summary param] 0 in FileInfoToDirEntry | file://:0:0:0:0 | [summary] to write: ReturnValue in FileInfoToDirEntry |
+| io/fs.FileMode.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| io/fs.Glob | file://:0:0:0:0 | [summary param] 0 in Glob | file://:0:0:0:0 | [summary] to write: ReturnValue in Glob |
+| io/fs.GlobFS.Glob | file://:0:0:0:0 | [summary param] -1 in Glob | file://:0:0:0:0 | [summary] to write: ReturnValue in Glob |
+| io/fs.GlobFS.Open | file://:0:0:0:0 | [summary param] -1 in Open | file://:0:0:0:0 | [summary] to write: ReturnValue in Open |
+| io/fs.ReadDir | file://:0:0:0:0 | [summary param] 0 in ReadDir | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadDir |
+| io/fs.ReadDirFS.Open | file://:0:0:0:0 | [summary param] -1 in Open | file://:0:0:0:0 | [summary] to write: ReturnValue in Open |
+| io/fs.ReadDirFS.ReadDir | file://:0:0:0:0 | [summary param] -1 in ReadDir | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadDir |
+| io/fs.ReadDirFile.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| io/fs.ReadFile | file://:0:0:0:0 | [summary param] 0 in ReadFile | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadFile |
+| io/fs.ReadFileFS.Open | file://:0:0:0:0 | [summary param] -1 in Open | file://:0:0:0:0 | [summary] to write: ReturnValue in Open |
+| io/fs.ReadFileFS.ReadFile | file://:0:0:0:0 | [summary param] -1 in ReadFile | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadFile |
+| io/fs.StatFS.Open | file://:0:0:0:0 | [summary param] -1 in Open | file://:0:0:0:0 | [summary] to write: ReturnValue in Open |
+| io/fs.Sub | file://:0:0:0:0 | [summary param] 0 in Sub | file://:0:0:0:0 | [summary] to write: ReturnValue in Sub |
+| io/fs.SubFS.Open | file://:0:0:0:0 | [summary param] -1 in Open | file://:0:0:0:0 | [summary] to write: ReturnValue in Open |
+| io/fs.SubFS.Sub | file://:0:0:0:0 | [summary param] -1 in Sub | file://:0:0:0:0 | [summary] to write: ReturnValue in Sub |
+| io/fs.dirInfo.Info | file://:0:0:0:0 | [summary param] -1 in Info | file://:0:0:0:0 | [summary] to write: ReturnValue in Info |
+| io/fs.dirInfo.Name | file://:0:0:0:0 | [summary param] -1 in Name | file://:0:0:0:0 | [summary] to write: ReturnValue in Name |
+| io/fs.dirInfo.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| io/fs.statDirEntry.Info | file://:0:0:0:0 | [summary param] -1 in Info | file://:0:0:0:0 | [summary] to write: ReturnValue in Info |
+| io/fs.statDirEntry.Name | file://:0:0:0:0 | [summary param] -1 in Name | file://:0:0:0:0 | [summary] to write: ReturnValue in Name |
+| io/fs.statDirEntry.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| io/fs.subFS.Glob | file://:0:0:0:0 | [summary param] -1 in Glob | file://:0:0:0:0 | [summary] to write: ReturnValue in Glob |
+| io/fs.subFS.Open | file://:0:0:0:0 | [summary param] -1 in Open | file://:0:0:0:0 | [summary] to write: ReturnValue in Open |
+| io/fs.subFS.ReadDir | file://:0:0:0:0 | [summary param] -1 in ReadDir | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadDir |
+| io/fs.subFS.ReadFile | file://:0:0:0:0 | [summary param] -1 in ReadFile | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadFile |
+| io/fs.subFS.Sub | file://:0:0:0:0 | [summary param] -1 in Sub | file://:0:0:0:0 | [summary] to write: ReturnValue in Sub |
+| io/ioutil.NopCloser | file://:0:0:0:0 | [summary param] 0 in NopCloser | file://:0:0:0:0 | [summary] to write: ReturnValue in NopCloser |
+| io/ioutil.ReadAll | file://:0:0:0:0 | [summary param] 0 in ReadAll | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadAll |
+| log.Logger.SetOutput | file://:0:0:0:0 | [summary param] -1 in SetOutput | file://:0:0:0:0 | [summary] to write: Argument[0] in SetOutput |
+| log.Logger.SetPrefix | file://:0:0:0:0 | [summary param] 0 in SetPrefix | file://:0:0:0:0 | [summary] to write: Argument[-1] in SetPrefix |
+| log.Logger.Writer | file://:0:0:0:0 | [summary param] -1 in Writer | file://:0:0:0:0 | [summary] to write: ReturnValue in Writer |
+| main.go | main.go:11:12:11:26 | call to Marshal | main.go:11:2:11:26 | ... := ...[0] |
+| main.go | main.go:11:12:11:26 | call to Marshal | main.go:11:2:11:26 | ... := ...[1] |
+| main.go | main.go:11:25:11:25 | v | main.go:11:2:11:26 | ... := ...[0] |
+| main.go | main.go:13:14:13:52 | call to MarshalIndent | main.go:13:2:13:52 | ... := ...[0] |
+| main.go | main.go:13:14:13:52 | call to MarshalIndent | main.go:13:2:13:52 | ... := ...[1] |
+| main.go | main.go:13:33:13:33 | v | main.go:13:2:13:52 | ... := ...[0] |
+| main.go | main.go:13:36:13:45 | "/*JSON*/" | main.go:13:2:13:52 | ... := ...[0] |
+| main.go | main.go:13:48:13:51 | "  " | main.go:13:2:13:52 | ... := ...[0] |
+| main.go | main.go:14:25:14:25 | b | main.go:14:9:14:41 | slice literal |
+| main.go | main.go:14:28:14:30 | err | main.go:14:9:14:41 | slice literal |
+| main.go | main.go:14:33:14:34 | b2 | main.go:14:9:14:41 | slice literal |
+| main.go | main.go:14:37:14:40 | err2 | main.go:14:9:14:41 | slice literal |
+| main.go | main.go:19:18:19:42 | call to DecodeString | main.go:19:2:19:42 | ... := ...[0] |
+| main.go | main.go:19:18:19:42 | call to DecodeString | main.go:19:2:19:42 | ... := ...[1] |
+| main.go | main.go:19:35:19:41 | encoded | main.go:19:2:19:42 | ... := ...[0] |
+| main.go | main.go:23:25:23:31 | decoded | main.go:23:9:23:48 | slice literal |
+| main.go | main.go:23:34:23:36 | err | main.go:23:9:23:48 | slice literal |
+| main.go | main.go:23:39:23:47 | reEncoded | main.go:23:9:23:48 | slice literal |
+| main.go | main.go:28:2:28:4 | implicit dereference | main.go:26:15:26:17 | definition of req |
+| main.go | main.go:28:2:28:4 | implicit dereference | main.go:28:2:28:9 | selection of Body |
+| main.go | main.go:28:2:28:4 | req | main.go:28:2:28:4 | implicit dereference |
+| main.go | main.go:28:2:28:9 | selection of Body | main.go:27:2:27:2 | definition of b |
+| math/big.Accuracy.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| math/big.Float.MarshalText | file://:0:0:0:0 | [summary param] -1 in MarshalText | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalText |
+| math/big.Float.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| math/big.Float.UnmarshalText | file://:0:0:0:0 | [summary param] 0 in UnmarshalText | file://:0:0:0:0 | [summary] to write: Argument[-1] in UnmarshalText |
+| math/big.Int.MarshalJSON | file://:0:0:0:0 | [summary param] -1 in MarshalJSON | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalJSON |
+| math/big.Int.MarshalText | file://:0:0:0:0 | [summary param] -1 in MarshalText | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalText |
+| math/big.Int.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| math/big.Int.UnmarshalJSON | file://:0:0:0:0 | [summary param] 0 in UnmarshalJSON | file://:0:0:0:0 | [summary] to write: Argument[-1] in UnmarshalJSON |
+| math/big.Int.UnmarshalText | file://:0:0:0:0 | [summary param] 0 in UnmarshalText | file://:0:0:0:0 | [summary] to write: Argument[-1] in UnmarshalText |
+| math/big.Rat.MarshalText | file://:0:0:0:0 | [summary param] -1 in MarshalText | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalText |
+| math/big.Rat.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| math/big.Rat.UnmarshalText | file://:0:0:0:0 | [summary param] 0 in UnmarshalText | file://:0:0:0:0 | [summary] to write: Argument[-1] in UnmarshalText |
+| math/big.RoundingMode.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| math/big.byteReader.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| math/big.byteReader.Token | file://:0:0:0:0 | [summary param] -1 in Token | file://:0:0:0:0 | [summary] to write: ReturnValue in Token |
+| math/big.decimal.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| math/big.nat.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| math/rand.Rand.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| mime.FormatMediaType | file://:0:0:0:0 | [summary param] 0 in FormatMediaType | file://:0:0:0:0 | [summary] to write: ReturnValue in FormatMediaType |
+| mime.FormatMediaType | file://:0:0:0:0 | [summary param] 1 in FormatMediaType | file://:0:0:0:0 | [summary] to write: ReturnValue in FormatMediaType |
+| mime.ParseMediaType | file://:0:0:0:0 | [summary param] 0 in ParseMediaType | file://:0:0:0:0 | [summary] to write: ReturnValue in ParseMediaType |
+| mime.ParseMediaType | file://:0:0:0:0 | [summary param] 0 in ParseMediaType | file://:0:0:0:0 | [summary] to write: ReturnValue[1] in ParseMediaType |
+| mime.WordDecoder.Decode | file://:0:0:0:0 | [summary param] 0 in Decode | file://:0:0:0:0 | [summary] to write: ReturnValue in Decode |
+| mime.WordDecoder.DecodeHeader | file://:0:0:0:0 | [summary param] 0 in DecodeHeader | file://:0:0:0:0 | [summary] to write: ReturnValue in DecodeHeader |
+| mime.WordEncoder.Encode | file://:0:0:0:0 | [summary param] 1 in Encode | file://:0:0:0:0 | [summary] to write: ReturnValue in Encode |
+| mime/multipart.File.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| mime/multipart.File.ReadAt | file://:0:0:0:0 | [summary param] -1 in ReadAt | file://:0:0:0:0 | [summary] to write: Argument[0] in ReadAt |
+| mime/multipart.FileHeader.Open | file://:0:0:0:0 | [summary param] -1 in Open | file://:0:0:0:0 | [summary] to write: ReturnValue in Open |
+| mime/multipart.NewReader | file://:0:0:0:0 | [summary param] 0 in NewReader | file://:0:0:0:0 | [summary] to write: ReturnValue in NewReader |
+| mime/multipart.Part.FileName | file://:0:0:0:0 | [summary param] -1 in FileName | file://:0:0:0:0 | [summary] to write: ReturnValue in FileName |
+| mime/multipart.Part.FormName | file://:0:0:0:0 | [summary param] -1 in FormName | file://:0:0:0:0 | [summary] to write: ReturnValue in FormName |
+| mime/multipart.Part.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| mime/multipart.Reader.NextPart | file://:0:0:0:0 | [summary param] -1 in NextPart | file://:0:0:0:0 | [summary] to write: ReturnValue in NextPart |
+| mime/multipart.Reader.NextRawPart | file://:0:0:0:0 | [summary param] -1 in NextRawPart | file://:0:0:0:0 | [summary] to write: ReturnValue in NextRawPart |
+| mime/multipart.Reader.ReadForm | file://:0:0:0:0 | [summary param] -1 in ReadForm | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadForm |
+| mime/multipart.Writer.WriteField | file://:0:0:0:0 | [summary param] 0 in WriteField | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteField |
+| mime/multipart.Writer.WriteField | file://:0:0:0:0 | [summary param] 1 in WriteField | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteField |
+| mime/multipart.part.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| mime/multipart.partReader.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| mime/multipart.sectionReadCloser.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| mime/multipart.sectionReadCloser.ReadAt | file://:0:0:0:0 | [summary param] -1 in ReadAt | file://:0:0:0:0 | [summary] to write: Argument[0] in ReadAt |
+| mime/multipart.stickyErrorReader.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| mime/quotedprintable.NewReader | file://:0:0:0:0 | [summary param] 0 in NewReader | file://:0:0:0:0 | [summary] to write: ReturnValue in NewReader |
+| mime/quotedprintable.Reader.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| mime/quotedprintable.Writer.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| net.Addr.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| net.Buffers.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| net.Buffers.WriteTo | file://:0:0:0:0 | [summary param] -1 in WriteTo | file://:0:0:0:0 | [summary] to write: Argument[0] in WriteTo |
+| net.Conn.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| net.Conn.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| net.FileConn | file://:0:0:0:0 | [summary param] 0 in FileConn | file://:0:0:0:0 | [summary] to write: ReturnValue in FileConn |
+| net.FilePacketConn | file://:0:0:0:0 | [summary param] 0 in FilePacketConn | file://:0:0:0:0 | [summary] to write: ReturnValue in FilePacketConn |
+| net.Flags.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| net.HardwareAddr.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| net.IP.MarshalText | file://:0:0:0:0 | [summary param] -1 in MarshalText | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalText |
+| net.IP.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| net.IP.UnmarshalText | file://:0:0:0:0 | [summary param] 0 in UnmarshalText | file://:0:0:0:0 | [summary] to write: Argument[-1] in UnmarshalText |
+| net.IPAddr.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| net.IPConn.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| net.IPConn.ReadFrom | file://:0:0:0:0 | [summary param] -1 in ReadFrom | file://:0:0:0:0 | [summary] to write: Argument[0] in ReadFrom |
+| net.IPConn.ReadFromIP | file://:0:0:0:0 | [summary param] -1 in ReadFromIP | file://:0:0:0:0 | [summary] to write: Argument[0] in ReadFromIP |
+| net.IPConn.ReadMsgIP | file://:0:0:0:0 | [summary param] -1 in ReadMsgIP | file://:0:0:0:0 | [summary] to write: Argument[0] in ReadMsgIP |
+| net.IPConn.ReadMsgIP | file://:0:0:0:0 | [summary param] -1 in ReadMsgIP | file://:0:0:0:0 | [summary] to write: Argument[1] in ReadMsgIP |
+| net.IPConn.SyscallConn | file://:0:0:0:0 | [summary param] -1 in SyscallConn | file://:0:0:0:0 | [summary] to write: ReturnValue in SyscallConn |
+| net.IPConn.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| net.IPConn.WriteMsgIP | file://:0:0:0:0 | [summary param] 0 in WriteMsgIP | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteMsgIP |
+| net.IPConn.WriteMsgIP | file://:0:0:0:0 | [summary param] 1 in WriteMsgIP | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteMsgIP |
+| net.IPConn.WriteTo | file://:0:0:0:0 | [summary param] 0 in WriteTo | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteTo |
+| net.IPConn.WriteToIP | file://:0:0:0:0 | [summary param] 0 in WriteToIP | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteToIP |
+| net.IPMask.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| net.IPNet.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| net.JoinHostPort | file://:0:0:0:0 | [summary param] 0 in JoinHostPort | file://:0:0:0:0 | [summary] to write: ReturnValue in JoinHostPort |
+| net.JoinHostPort | file://:0:0:0:0 | [summary param] 1 in JoinHostPort | file://:0:0:0:0 | [summary] to write: ReturnValue in JoinHostPort |
+| net.PacketConn.ReadFrom | file://:0:0:0:0 | [summary param] -1 in ReadFrom | file://:0:0:0:0 | [summary] to write: Argument[0] in ReadFrom |
+| net.PacketConn.WriteTo | file://:0:0:0:0 | [summary param] 0 in WriteTo | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteTo |
+| net.SplitHostPort | file://:0:0:0:0 | [summary param] 0 in SplitHostPort | file://:0:0:0:0 | [summary] to write: ReturnValue in SplitHostPort |
+| net.SplitHostPort | file://:0:0:0:0 | [summary param] 0 in SplitHostPort | file://:0:0:0:0 | [summary] to write: ReturnValue[1] in SplitHostPort |
+| net.TCPAddr.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| net.TCPConn.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| net.TCPConn.ReadFrom | file://:0:0:0:0 | [summary param] 0 in ReadFrom | file://:0:0:0:0 | [summary] to write: Argument[-1] in ReadFrom |
+| net.TCPConn.SyscallConn | file://:0:0:0:0 | [summary param] -1 in SyscallConn | file://:0:0:0:0 | [summary] to write: ReturnValue in SyscallConn |
+| net.TCPConn.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| net.TCPListener.File | file://:0:0:0:0 | [summary param] -1 in File | file://:0:0:0:0 | [summary] to write: ReturnValue in File |
+| net.TCPListener.SyscallConn | file://:0:0:0:0 | [summary param] -1 in SyscallConn | file://:0:0:0:0 | [summary] to write: ReturnValue in SyscallConn |
+| net.UDPAddr.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| net.UDPConn.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| net.UDPConn.ReadFrom | file://:0:0:0:0 | [summary param] -1 in ReadFrom | file://:0:0:0:0 | [summary] to write: Argument[0] in ReadFrom |
+| net.UDPConn.ReadFromUDP | file://:0:0:0:0 | [summary param] -1 in ReadFromUDP | file://:0:0:0:0 | [summary] to write: Argument[0] in ReadFromUDP |
+| net.UDPConn.ReadMsgUDP | file://:0:0:0:0 | [summary param] -1 in ReadMsgUDP | file://:0:0:0:0 | [summary] to write: Argument[0] in ReadMsgUDP |
+| net.UDPConn.ReadMsgUDP | file://:0:0:0:0 | [summary param] -1 in ReadMsgUDP | file://:0:0:0:0 | [summary] to write: Argument[1] in ReadMsgUDP |
+| net.UDPConn.SyscallConn | file://:0:0:0:0 | [summary param] -1 in SyscallConn | file://:0:0:0:0 | [summary] to write: ReturnValue in SyscallConn |
+| net.UDPConn.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| net.UDPConn.WriteMsgUDP | file://:0:0:0:0 | [summary param] 0 in WriteMsgUDP | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteMsgUDP |
+| net.UDPConn.WriteMsgUDP | file://:0:0:0:0 | [summary param] 1 in WriteMsgUDP | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteMsgUDP |
+| net.UDPConn.WriteTo | file://:0:0:0:0 | [summary param] 0 in WriteTo | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteTo |
+| net.UDPConn.WriteToUDP | file://:0:0:0:0 | [summary param] 0 in WriteToUDP | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteToUDP |
+| net.UnixAddr.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| net.UnixConn.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| net.UnixConn.ReadFrom | file://:0:0:0:0 | [summary param] -1 in ReadFrom | file://:0:0:0:0 | [summary] to write: Argument[0] in ReadFrom |
+| net.UnixConn.ReadFromUnix | file://:0:0:0:0 | [summary param] -1 in ReadFromUnix | file://:0:0:0:0 | [summary] to write: Argument[0] in ReadFromUnix |
+| net.UnixConn.ReadMsgUnix | file://:0:0:0:0 | [summary param] -1 in ReadMsgUnix | file://:0:0:0:0 | [summary] to write: Argument[0] in ReadMsgUnix |
+| net.UnixConn.ReadMsgUnix | file://:0:0:0:0 | [summary param] -1 in ReadMsgUnix | file://:0:0:0:0 | [summary] to write: Argument[1] in ReadMsgUnix |
+| net.UnixConn.SyscallConn | file://:0:0:0:0 | [summary param] -1 in SyscallConn | file://:0:0:0:0 | [summary] to write: ReturnValue in SyscallConn |
+| net.UnixConn.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| net.UnixConn.WriteMsgUnix | file://:0:0:0:0 | [summary param] 0 in WriteMsgUnix | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteMsgUnix |
+| net.UnixConn.WriteMsgUnix | file://:0:0:0:0 | [summary param] 1 in WriteMsgUnix | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteMsgUnix |
+| net.UnixConn.WriteTo | file://:0:0:0:0 | [summary param] 0 in WriteTo | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteTo |
+| net.UnixConn.WriteToUnix | file://:0:0:0:0 | [summary param] 0 in WriteToUnix | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteToUnix |
+| net.UnixListener.File | file://:0:0:0:0 | [summary param] -1 in File | file://:0:0:0:0 | [summary] to write: ReturnValue in File |
+| net.UnixListener.SyscallConn | file://:0:0:0:0 | [summary param] -1 in SyscallConn | file://:0:0:0:0 | [summary] to write: ReturnValue in SyscallConn |
+| net.addrPortUDPAddr.MarshalBinary | file://:0:0:0:0 | [summary param] -1 in MarshalBinary | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalBinary |
+| net.addrPortUDPAddr.MarshalText | file://:0:0:0:0 | [summary param] -1 in MarshalText | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalText |
+| net.addrPortUDPAddr.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| net.conn.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| net.conn.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| net.fileAddr.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| net.hostLookupOrder.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| net.netFD.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| net.netFD.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| net.onlyValuesCtx.Value | file://:0:0:0:0 | [summary param] -1 in Value | file://:0:0:0:0 | [summary] to write: ReturnValue in Value |
+| net.onlyValuesCtx.Value | file://:0:0:0:0 | [summary param] -1 in Value | file://:0:0:0:0 | [summary] to write: ReturnValue in Value |
+| net.pipe.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| net.pipe.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| net.pipeAddr.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| net.rawConn.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| net.rawConn.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| net.rawListener.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| net.rawListener.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| net.sockaddr.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| net.writerOnly.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| net/http.CanonicalHeaderKey | file://:0:0:0:0 | [summary param] 0 in CanonicalHeaderKey | file://:0:0:0:0 | [summary] to write: ReturnValue in CanonicalHeaderKey |
+| net/http.ConnState.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| net/http.Cookie.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| net/http.Error | file://:0:0:0:0 | [summary param] 1 in Error | file://:0:0:0:0 | [summary] to write: Argument[0] in Error |
+| net/http.File.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| net/http.Header.Add | file://:0:0:0:0 | [summary param] 0 in Add | file://:0:0:0:0 | [summary] to write: Argument[-1] in Add |
+| net/http.Header.Add | file://:0:0:0:0 | [summary param] 1 in Add | file://:0:0:0:0 | [summary] to write: Argument[-1] in Add |
+| net/http.Header.Clone | file://:0:0:0:0 | [summary param] -1 in Clone | file://:0:0:0:0 | [summary] to write: ReturnValue in Clone |
+| net/http.Header.Get | file://:0:0:0:0 | [summary param] -1 in Get | file://:0:0:0:0 | [summary] to write: ReturnValue in Get |
+| net/http.Header.Set | file://:0:0:0:0 | [summary param] 0 in Set | file://:0:0:0:0 | [summary] to write: Argument[-1] in Set |
+| net/http.Header.Set | file://:0:0:0:0 | [summary param] 1 in Set | file://:0:0:0:0 | [summary] to write: Argument[-1] in Set |
+| net/http.Header.Values | file://:0:0:0:0 | [summary param] -1 in Values | file://:0:0:0:0 | [summary] to write: ReturnValue in Values |
+| net/http.Header.Write | file://:0:0:0:0 | [summary param] -1 in Write | file://:0:0:0:0 | [summary] to write: Argument[0] in Write |
+| net/http.Header.WriteSubset | file://:0:0:0:0 | [summary param] -1 in WriteSubset | file://:0:0:0:0 | [summary] to write: Argument[0] in WriteSubset |
+| net/http.Hijacker.Hijack | file://:0:0:0:0 | [summary param] -1 in Hijack | file://:0:0:0:0 | [summary] to write: ReturnValue in Hijack |
+| net/http.Hijacker.Hijack | file://:0:0:0:0 | [summary param] -1 in Hijack | file://:0:0:0:0 | [summary] to write: ReturnValue[1] in Hijack |
+| net/http.MaxBytesReader | file://:0:0:0:0 | [summary param] 1 in MaxBytesReader | file://:0:0:0:0 | [summary] to write: ReturnValue in MaxBytesReader |
+| net/http.NewRequest | file://:0:0:0:0 | [summary param] 1 in NewRequest | file://:0:0:0:0 | [summary] to write: ReturnValue in NewRequest |
+| net/http.NewRequestWithContext | file://:0:0:0:0 | [summary param] 2 in NewRequestWithContext | file://:0:0:0:0 | [summary] to write: ReturnValue in NewRequestWithContext |
+| net/http.ReadRequest | file://:0:0:0:0 | [summary param] 0 in ReadRequest | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadRequest |
+| net/http.ReadResponse | file://:0:0:0:0 | [summary param] 0 in ReadResponse | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadResponse |
+| net/http.Request.AddCookie | file://:0:0:0:0 | [summary param] 0 in AddCookie | file://:0:0:0:0 | [summary] to write: Argument[-1] in AddCookie |
+| net/http.Request.Clone | file://:0:0:0:0 | [summary param] -1 in Clone | file://:0:0:0:0 | [summary] to write: ReturnValue in Clone |
+| net/http.Request.Write | file://:0:0:0:0 | [summary param] -1 in Write | file://:0:0:0:0 | [summary] to write: Argument[0] in Write |
+| net/http.Request.WriteProxy | file://:0:0:0:0 | [summary param] -1 in WriteProxy | file://:0:0:0:0 | [summary] to write: Argument[0] in WriteProxy |
+| net/http.Response.Write | file://:0:0:0:0 | [summary param] -1 in Write | file://:0:0:0:0 | [summary] to write: Argument[0] in Write |
+| net/http.ResponseController.Hijack | file://:0:0:0:0 | [summary param] -1 in Hijack | file://:0:0:0:0 | [summary] to write: ReturnValue in Hijack |
+| net/http.ResponseController.Hijack | file://:0:0:0:0 | [summary param] -1 in Hijack | file://:0:0:0:0 | [summary] to write: ReturnValue[1] in Hijack |
+| net/http.ResponseWriter.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| net/http.SetCookie | file://:0:0:0:0 | [summary param] 1 in SetCookie | file://:0:0:0:0 | [summary] to write: Argument[0] in SetCookie |
+| net/http.Transport.Clone | file://:0:0:0:0 | [summary param] -1 in Clone | file://:0:0:0:0 | [summary] to write: ReturnValue in Clone |
+| net/http.body.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| net/http.bodyEOFSignal.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| net/http.bodyLocked.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| net/http.bufioFlushWriter.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| net/http.byteReader.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| net/http.cancelTimerBody.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| net/http.checkConnErrorWriter.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| net/http.chunkWriter.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| net/http.connReader.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| net/http.connectMethodKey.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| net/http.contextKey.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| net/http.countingWriter.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| net/http.errorReader.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| net/http.expectContinueReader.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| net/http.finishAsyncByteRead.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| net/http.gzipReader.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| net/http.http2ContinuationFrame.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| net/http.http2DataFrame.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| net/http.http2ErrCode.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| net/http.http2FrameHeader.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| net/http.http2FrameType.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| net/http.http2FrameWriteRequest.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| net/http.http2GoAwayFrame.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| net/http.http2HeadersFrame.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| net/http.http2MetaHeadersFrame.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| net/http.http2PingFrame.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| net/http.http2PriorityFrame.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| net/http.http2PushPromiseFrame.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| net/http.http2RSTStreamFrame.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| net/http.http2Setting.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| net/http.http2SettingID.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| net/http.http2SettingsFrame.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| net/http.http2UnknownFrame.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| net/http.http2WindowUpdateFrame.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| net/http.http2bufferedWriter.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| net/http.http2chunkWriter.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| net/http.http2dataBuffer.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| net/http.http2dataBuffer.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| net/http.http2errorReader.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| net/http.http2gzipReader.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| net/http.http2missingBody.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| net/http.http2noBodyReader.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| net/http.http2pipe.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| net/http.http2pipe.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| net/http.http2pipeBuffer.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| net/http.http2pipeBuffer.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| net/http.http2requestBody.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| net/http.http2responseWriter.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| net/http.http2responseWriter.WriteString | file://:0:0:0:0 | [summary param] 0 in WriteString | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteString |
+| net/http.http2stickyErrWriter.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| net/http.http2streamState.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| net/http.http2stringWriter.WriteString | file://:0:0:0:0 | [summary param] 0 in WriteString | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteString |
+| net/http.http2transportResponseBody.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| net/http.http2writeData.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| net/http.ioFile.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| net/http.loggingConn.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| net/http.loggingConn.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| net/http.loggingConn.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| net/http.loggingConn.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| net/http.maxBytesReader.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| net/http.noBody.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| net/http.noBody.WriteTo | file://:0:0:0:0 | [summary param] -1 in WriteTo | file://:0:0:0:0 | [summary] to write: Argument[0] in WriteTo |
+| net/http.persistConn.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| net/http.persistConnWriter.ReadFrom | file://:0:0:0:0 | [summary param] 0 in ReadFrom | file://:0:0:0:0 | [summary] to write: Argument[-1] in ReadFrom |
+| net/http.persistConnWriter.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| net/http.populateResponse.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| net/http.readTrackingBody.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| net/http.readTrackingBody.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| net/http.readWriteCloserBody.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| net/http.readWriteCloserBody.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| net/http.readWriteCloserBody.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| net/http.response.Hijack | file://:0:0:0:0 | [summary param] -1 in Hijack | file://:0:0:0:0 | [summary] to write: ReturnValue in Hijack |
+| net/http.response.Hijack | file://:0:0:0:0 | [summary param] -1 in Hijack | file://:0:0:0:0 | [summary] to write: ReturnValue[1] in Hijack |
+| net/http.response.ReadFrom | file://:0:0:0:0 | [summary param] 0 in ReadFrom | file://:0:0:0:0 | [summary] to write: Argument[-1] in ReadFrom |
+| net/http.response.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| net/http.response.WriteString | file://:0:0:0:0 | [summary param] 0 in WriteString | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteString |
+| net/http.socksAddr.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| net/http.socksCommand.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| net/http.socksConn.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| net/http.socksConn.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| net/http.socksReply.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| net/http.stringWriter.WriteString | file://:0:0:0:0 | [summary param] 0 in WriteString | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteString |
+| net/http.timeoutWriter.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| net/http.transportRequest.AddCookie | file://:0:0:0:0 | [summary param] 0 in AddCookie | file://:0:0:0:0 | [summary] to write: Argument[-1] in AddCookie |
+| net/http.transportRequest.Clone | file://:0:0:0:0 | [summary param] -1 in Clone | file://:0:0:0:0 | [summary] to write: ReturnValue in Clone |
+| net/http.transportRequest.Write | file://:0:0:0:0 | [summary param] -1 in Write | file://:0:0:0:0 | [summary] to write: Argument[0] in Write |
+| net/http.transportRequest.WriteProxy | file://:0:0:0:0 | [summary param] -1 in WriteProxy | file://:0:0:0:0 | [summary] to write: Argument[0] in WriteProxy |
+| net/http.writerOnly.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| net/http/internal.FlushAfterChunkWriter.ReadFrom | file://:0:0:0:0 | [summary param] 0 in ReadFrom | file://:0:0:0:0 | [summary] to write: Argument[-1] in ReadFrom |
+| net/http/internal.FlushAfterChunkWriter.Reset | file://:0:0:0:0 | [summary param] -1 in Reset | file://:0:0:0:0 | [summary] to write: Argument[0] in Reset |
+| net/http/internal.FlushAfterChunkWriter.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| net/http/internal.FlushAfterChunkWriter.WriteString | file://:0:0:0:0 | [summary param] 0 in WriteString | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteString |
+| net/http/internal.chunkedReader.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| net/http/internal.chunkedWriter.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| net/netip.Addr.MarshalBinary | file://:0:0:0:0 | [summary param] -1 in MarshalBinary | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalBinary |
+| net/netip.Addr.MarshalText | file://:0:0:0:0 | [summary param] -1 in MarshalText | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalText |
+| net/netip.Addr.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| net/netip.Addr.UnmarshalBinary | file://:0:0:0:0 | [summary param] 0 in UnmarshalBinary | file://:0:0:0:0 | [summary] to write: Argument[-1] in UnmarshalBinary |
+| net/netip.Addr.UnmarshalText | file://:0:0:0:0 | [summary param] 0 in UnmarshalText | file://:0:0:0:0 | [summary] to write: Argument[-1] in UnmarshalText |
+| net/netip.AddrPort.MarshalBinary | file://:0:0:0:0 | [summary param] -1 in MarshalBinary | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalBinary |
+| net/netip.AddrPort.MarshalText | file://:0:0:0:0 | [summary param] -1 in MarshalText | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalText |
+| net/netip.AddrPort.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| net/netip.AddrPort.UnmarshalBinary | file://:0:0:0:0 | [summary param] 0 in UnmarshalBinary | file://:0:0:0:0 | [summary] to write: Argument[-1] in UnmarshalBinary |
+| net/netip.AddrPort.UnmarshalText | file://:0:0:0:0 | [summary param] 0 in UnmarshalText | file://:0:0:0:0 | [summary] to write: Argument[-1] in UnmarshalText |
+| net/netip.Prefix.MarshalBinary | file://:0:0:0:0 | [summary param] -1 in MarshalBinary | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalBinary |
+| net/netip.Prefix.MarshalText | file://:0:0:0:0 | [summary param] -1 in MarshalText | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalText |
+| net/netip.Prefix.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| net/netip.Prefix.UnmarshalBinary | file://:0:0:0:0 | [summary param] 0 in UnmarshalBinary | file://:0:0:0:0 | [summary] to write: Argument[-1] in UnmarshalBinary |
+| net/netip.Prefix.UnmarshalText | file://:0:0:0:0 | [summary param] 0 in UnmarshalText | file://:0:0:0:0 | [summary] to write: Argument[-1] in UnmarshalText |
+| net/textproto.CanonicalMIMEHeaderKey | file://:0:0:0:0 | [summary param] 0 in CanonicalMIMEHeaderKey | file://:0:0:0:0 | [summary] to write: ReturnValue in CanonicalMIMEHeaderKey |
+| net/textproto.Conn.DotReader | file://:0:0:0:0 | [summary param] -1 in DotReader | file://:0:0:0:0 | [summary] to write: ReturnValue in DotReader |
+| net/textproto.Conn.ReadCodeLine | file://:0:0:0:0 | [summary param] -1 in ReadCodeLine | file://:0:0:0:0 | [summary] to write: ReturnValue[1] in ReadCodeLine |
+| net/textproto.Conn.ReadContinuedLine | file://:0:0:0:0 | [summary param] -1 in ReadContinuedLine | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadContinuedLine |
+| net/textproto.Conn.ReadContinuedLineBytes | file://:0:0:0:0 | [summary param] -1 in ReadContinuedLineBytes | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadContinuedLineBytes |
+| net/textproto.Conn.ReadDotBytes | file://:0:0:0:0 | [summary param] -1 in ReadDotBytes | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadDotBytes |
+| net/textproto.Conn.ReadDotLines | file://:0:0:0:0 | [summary param] -1 in ReadDotLines | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadDotLines |
+| net/textproto.Conn.ReadLine | file://:0:0:0:0 | [summary param] -1 in ReadLine | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadLine |
+| net/textproto.Conn.ReadLineBytes | file://:0:0:0:0 | [summary param] -1 in ReadLineBytes | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadLineBytes |
+| net/textproto.Conn.ReadMIMEHeader | file://:0:0:0:0 | [summary param] -1 in ReadMIMEHeader | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadMIMEHeader |
+| net/textproto.Conn.ReadResponse | file://:0:0:0:0 | [summary param] -1 in ReadResponse | file://:0:0:0:0 | [summary] to write: ReturnValue[1] in ReadResponse |
+| net/textproto.MIMEHeader.Add | file://:0:0:0:0 | [summary param] 0 in Add | file://:0:0:0:0 | [summary] to write: Argument[-1] in Add |
+| net/textproto.MIMEHeader.Add | file://:0:0:0:0 | [summary param] 1 in Add | file://:0:0:0:0 | [summary] to write: Argument[-1] in Add |
+| net/textproto.MIMEHeader.Get | file://:0:0:0:0 | [summary param] -1 in Get | file://:0:0:0:0 | [summary] to write: ReturnValue in Get |
+| net/textproto.MIMEHeader.Set | file://:0:0:0:0 | [summary param] 0 in Set | file://:0:0:0:0 | [summary] to write: Argument[-1] in Set |
+| net/textproto.MIMEHeader.Set | file://:0:0:0:0 | [summary param] 1 in Set | file://:0:0:0:0 | [summary] to write: Argument[-1] in Set |
+| net/textproto.MIMEHeader.Values | file://:0:0:0:0 | [summary param] -1 in Values | file://:0:0:0:0 | [summary] to write: ReturnValue in Values |
+| net/textproto.NewConn | file://:0:0:0:0 | [summary param] 0 in NewConn | file://:0:0:0:0 | [summary] to write: ReturnValue in NewConn |
+| net/textproto.NewReader | file://:0:0:0:0 | [summary param] 0 in NewReader | file://:0:0:0:0 | [summary] to write: ReturnValue in NewReader |
+| net/textproto.Reader.DotReader | file://:0:0:0:0 | [summary param] -1 in DotReader | file://:0:0:0:0 | [summary] to write: ReturnValue in DotReader |
+| net/textproto.Reader.ReadCodeLine | file://:0:0:0:0 | [summary param] -1 in ReadCodeLine | file://:0:0:0:0 | [summary] to write: ReturnValue[1] in ReadCodeLine |
+| net/textproto.Reader.ReadContinuedLine | file://:0:0:0:0 | [summary param] -1 in ReadContinuedLine | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadContinuedLine |
+| net/textproto.Reader.ReadContinuedLineBytes | file://:0:0:0:0 | [summary param] -1 in ReadContinuedLineBytes | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadContinuedLineBytes |
+| net/textproto.Reader.ReadDotBytes | file://:0:0:0:0 | [summary param] -1 in ReadDotBytes | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadDotBytes |
+| net/textproto.Reader.ReadDotLines | file://:0:0:0:0 | [summary param] -1 in ReadDotLines | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadDotLines |
+| net/textproto.Reader.ReadLine | file://:0:0:0:0 | [summary param] -1 in ReadLine | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadLine |
+| net/textproto.Reader.ReadLineBytes | file://:0:0:0:0 | [summary param] -1 in ReadLineBytes | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadLineBytes |
+| net/textproto.Reader.ReadMIMEHeader | file://:0:0:0:0 | [summary param] -1 in ReadMIMEHeader | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadMIMEHeader |
+| net/textproto.Reader.ReadResponse | file://:0:0:0:0 | [summary param] -1 in ReadResponse | file://:0:0:0:0 | [summary] to write: ReturnValue[1] in ReadResponse |
+| net/textproto.TrimBytes | file://:0:0:0:0 | [summary param] 0 in TrimBytes | file://:0:0:0:0 | [summary] to write: ReturnValue in TrimBytes |
+| net/textproto.TrimString | file://:0:0:0:0 | [summary param] 0 in TrimString | file://:0:0:0:0 | [summary] to write: ReturnValue in TrimString |
+| net/textproto.dotReader.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| net/textproto.dotWriter.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| net/url.Parse | file://:0:0:0:0 | [summary param] 0 in Parse | file://:0:0:0:0 | [summary] to write: ReturnValue in Parse |
+| net/url.ParseQuery | file://:0:0:0:0 | [summary param] 0 in ParseQuery | file://:0:0:0:0 | [summary] to write: ReturnValue in ParseQuery |
+| net/url.ParseRequestURI | file://:0:0:0:0 | [summary param] 0 in ParseRequestURI | file://:0:0:0:0 | [summary] to write: ReturnValue in ParseRequestURI |
+| net/url.PathEscape | file://:0:0:0:0 | [summary param] 0 in PathEscape | file://:0:0:0:0 | [summary] to write: ReturnValue in PathEscape |
+| net/url.PathUnescape | file://:0:0:0:0 | [summary param] 0 in PathUnescape | file://:0:0:0:0 | [summary] to write: ReturnValue in PathUnescape |
+| net/url.QueryEscape | file://:0:0:0:0 | [summary param] 0 in QueryEscape | file://:0:0:0:0 | [summary] to write: ReturnValue in QueryEscape |
+| net/url.QueryUnescape | file://:0:0:0:0 | [summary param] 0 in QueryUnescape | file://:0:0:0:0 | [summary] to write: ReturnValue in QueryUnescape |
+| net/url.URL.EscapedPath | file://:0:0:0:0 | [summary param] -1 in EscapedPath | file://:0:0:0:0 | [summary] to write: ReturnValue in EscapedPath |
+| net/url.URL.Hostname | file://:0:0:0:0 | [summary param] -1 in Hostname | file://:0:0:0:0 | [summary] to write: ReturnValue in Hostname |
+| net/url.URL.MarshalBinary | file://:0:0:0:0 | [summary param] -1 in MarshalBinary | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalBinary |
+| net/url.URL.Parse | file://:0:0:0:0 | [summary param] 0 in Parse | file://:0:0:0:0 | [summary] to write: ReturnValue in Parse |
+| net/url.URL.Parse | file://:0:0:0:0 | [summary param] -1 in Parse | file://:0:0:0:0 | [summary] to write: ReturnValue in Parse |
+| net/url.URL.Port | file://:0:0:0:0 | [summary param] -1 in Port | file://:0:0:0:0 | [summary] to write: ReturnValue in Port |
+| net/url.URL.Query | file://:0:0:0:0 | [summary param] -1 in Query | file://:0:0:0:0 | [summary] to write: ReturnValue in Query |
+| net/url.URL.RequestURI | file://:0:0:0:0 | [summary param] -1 in RequestURI | file://:0:0:0:0 | [summary] to write: ReturnValue in RequestURI |
+| net/url.URL.ResolveReference | file://:0:0:0:0 | [summary param] 0 in ResolveReference | file://:0:0:0:0 | [summary] to write: ReturnValue in ResolveReference |
+| net/url.URL.ResolveReference | file://:0:0:0:0 | [summary param] -1 in ResolveReference | file://:0:0:0:0 | [summary] to write: ReturnValue in ResolveReference |
+| net/url.URL.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| net/url.URL.UnmarshalBinary | file://:0:0:0:0 | [summary param] 0 in UnmarshalBinary | file://:0:0:0:0 | [summary] to write: Argument[-1] in UnmarshalBinary |
+| net/url.User | file://:0:0:0:0 | [summary param] 0 in User | file://:0:0:0:0 | [summary] to write: ReturnValue in User |
+| net/url.UserPassword | file://:0:0:0:0 | [summary param] 0 in UserPassword | file://:0:0:0:0 | [summary] to write: ReturnValue in UserPassword |
+| net/url.UserPassword | file://:0:0:0:0 | [summary param] 1 in UserPassword | file://:0:0:0:0 | [summary] to write: ReturnValue in UserPassword |
+| net/url.Userinfo.Password | file://:0:0:0:0 | [summary param] -1 in Password | file://:0:0:0:0 | [summary] to write: ReturnValue in Password |
+| net/url.Userinfo.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| net/url.Userinfo.Username | file://:0:0:0:0 | [summary param] -1 in Username | file://:0:0:0:0 | [summary] to write: ReturnValue in Username |
+| net/url.Values.Encode | file://:0:0:0:0 | [summary param] -1 in Encode | file://:0:0:0:0 | [summary] to write: ReturnValue in Encode |
+| net/url.Values.Get | file://:0:0:0:0 | [summary param] -1 in Get | file://:0:0:0:0 | [summary] to write: ReturnValue in Get |
+| os.Expand | file://:0:0:0:0 | [summary param] 0 in Expand | file://:0:0:0:0 | [summary] to write: ReturnValue in Expand |
+| os.ExpandEnv | file://:0:0:0:0 | [summary param] 0 in ExpandEnv | file://:0:0:0:0 | [summary] to write: ReturnValue in ExpandEnv |
+| os.File.Fd | file://:0:0:0:0 | [summary param] -1 in Fd | file://:0:0:0:0 | [summary] to write: ReturnValue in Fd |
+| os.File.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| os.File.ReadAt | file://:0:0:0:0 | [summary param] -1 in ReadAt | file://:0:0:0:0 | [summary] to write: Argument[0] in ReadAt |
+| os.File.ReadFrom | file://:0:0:0:0 | [summary param] 0 in ReadFrom | file://:0:0:0:0 | [summary] to write: Argument[-1] in ReadFrom |
+| os.File.SyscallConn | file://:0:0:0:0 | [summary param] -1 in SyscallConn | file://:0:0:0:0 | [summary] to write: ReturnValue in SyscallConn |
+| os.File.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| os.File.WriteAt | file://:0:0:0:0 | [summary param] 0 in WriteAt | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteAt |
+| os.File.WriteString | file://:0:0:0:0 | [summary param] 0 in WriteString | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteString |
+| os.NewFile | file://:0:0:0:0 | [summary param] 0 in NewFile | file://:0:0:0:0 | [summary] to write: ReturnValue in NewFile |
+| os.ProcessState.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| os.Signal.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| os.dirFS.Open | file://:0:0:0:0 | [summary param] -1 in Open | file://:0:0:0:0 | [summary] to write: ReturnValue in Open |
+| os.dirFS.ReadDir | file://:0:0:0:0 | [summary param] -1 in ReadDir | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadDir |
+| os.dirFS.ReadFile | file://:0:0:0:0 | [summary param] -1 in ReadFile | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadFile |
+| os.fileWithoutReadFrom.Fd | file://:0:0:0:0 | [summary param] -1 in Fd | file://:0:0:0:0 | [summary] to write: ReturnValue in Fd |
+| os.fileWithoutReadFrom.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| os.fileWithoutReadFrom.ReadAt | file://:0:0:0:0 | [summary param] -1 in ReadAt | file://:0:0:0:0 | [summary] to write: Argument[0] in ReadAt |
+| os.fileWithoutReadFrom.SyscallConn | file://:0:0:0:0 | [summary param] -1 in SyscallConn | file://:0:0:0:0 | [summary] to write: ReturnValue in SyscallConn |
+| os.fileWithoutReadFrom.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| os.fileWithoutReadFrom.WriteAt | file://:0:0:0:0 | [summary param] 0 in WriteAt | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteAt |
+| os.fileWithoutReadFrom.WriteString | file://:0:0:0:0 | [summary param] 0 in WriteString | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteString |
+| os.rawConn.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| os.rawConn.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| os.unixDirent.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| path.Base | file://:0:0:0:0 | [summary param] 0 in Base | file://:0:0:0:0 | [summary] to write: ReturnValue in Base |
+| path.Clean | file://:0:0:0:0 | [summary param] 0 in Clean | file://:0:0:0:0 | [summary] to write: ReturnValue in Clean |
+| path.Dir | file://:0:0:0:0 | [summary param] 0 in Dir | file://:0:0:0:0 | [summary] to write: ReturnValue in Dir |
+| path.Ext | file://:0:0:0:0 | [summary param] 0 in Ext | file://:0:0:0:0 | [summary] to write: ReturnValue in Ext |
+| path.Split | file://:0:0:0:0 | [summary param] 0 in Split | file://:0:0:0:0 | [summary] to write: ReturnValue in Split |
+| path.Split | file://:0:0:0:0 | [summary param] 0 in Split | file://:0:0:0:0 | [summary] to write: ReturnValue[1] in Split |
+| path/filepath.Abs | file://:0:0:0:0 | [summary param] 0 in Abs | file://:0:0:0:0 | [summary] to write: ReturnValue in Abs |
+| path/filepath.Base | file://:0:0:0:0 | [summary param] 0 in Base | file://:0:0:0:0 | [summary] to write: ReturnValue in Base |
+| path/filepath.Clean | file://:0:0:0:0 | [summary param] 0 in Clean | file://:0:0:0:0 | [summary] to write: ReturnValue in Clean |
+| path/filepath.Dir | file://:0:0:0:0 | [summary param] 0 in Dir | file://:0:0:0:0 | [summary] to write: ReturnValue in Dir |
+| path/filepath.EvalSymlinks | file://:0:0:0:0 | [summary param] 0 in EvalSymlinks | file://:0:0:0:0 | [summary] to write: ReturnValue in EvalSymlinks |
+| path/filepath.Ext | file://:0:0:0:0 | [summary param] 0 in Ext | file://:0:0:0:0 | [summary] to write: ReturnValue in Ext |
+| path/filepath.FromSlash | file://:0:0:0:0 | [summary param] 0 in FromSlash | file://:0:0:0:0 | [summary] to write: ReturnValue in FromSlash |
+| path/filepath.Glob | file://:0:0:0:0 | [summary param] 0 in Glob | file://:0:0:0:0 | [summary] to write: ReturnValue in Glob |
+| path/filepath.Rel | file://:0:0:0:0 | [summary param] 0 in Rel | file://:0:0:0:0 | [summary] to write: ReturnValue in Rel |
+| path/filepath.Rel | file://:0:0:0:0 | [summary param] 1 in Rel | file://:0:0:0:0 | [summary] to write: ReturnValue in Rel |
+| path/filepath.Split | file://:0:0:0:0 | [summary param] 0 in Split | file://:0:0:0:0 | [summary] to write: ReturnValue in Split |
+| path/filepath.Split | file://:0:0:0:0 | [summary param] 0 in Split | file://:0:0:0:0 | [summary] to write: ReturnValue[1] in Split |
+| path/filepath.SplitList | file://:0:0:0:0 | [summary param] 0 in SplitList | file://:0:0:0:0 | [summary] to write: ReturnValue in SplitList |
+| path/filepath.ToSlash | file://:0:0:0:0 | [summary param] 0 in ToSlash | file://:0:0:0:0 | [summary] to write: ReturnValue in ToSlash |
+| path/filepath.VolumeName | file://:0:0:0:0 | [summary param] 0 in VolumeName | file://:0:0:0:0 | [summary] to write: ReturnValue in VolumeName |
+| path/filepath.statDirEntry.Info | file://:0:0:0:0 | [summary param] -1 in Info | file://:0:0:0:0 | [summary] to write: ReturnValue in Info |
+| path/filepath.statDirEntry.Name | file://:0:0:0:0 | [summary param] -1 in Name | file://:0:0:0:0 | [summary] to write: ReturnValue in Name |
+| path/filepath.statDirEntry.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| reflect.AppendSlice | file://:0:0:0:0 | [summary param] 0 in AppendSlice | file://:0:0:0:0 | [summary] to write: ReturnValue in AppendSlice |
+| reflect.AppendSlice | file://:0:0:0:0 | [summary param] 1 in AppendSlice | file://:0:0:0:0 | [summary] to write: ReturnValue in AppendSlice |
+| reflect.ChanDir.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| reflect.Copy | file://:0:0:0:0 | [summary param] 1 in Copy | file://:0:0:0:0 | [summary] to write: Argument[0] in Copy |
+| reflect.Indirect | file://:0:0:0:0 | [summary param] 0 in Indirect | file://:0:0:0:0 | [summary] to write: ReturnValue in Indirect |
+| reflect.Kind.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| reflect.MapIter.Key | file://:0:0:0:0 | [summary param] -1 in Key | file://:0:0:0:0 | [summary] to write: ReturnValue in Key |
+| reflect.MapIter.Value | file://:0:0:0:0 | [summary param] -1 in Value | file://:0:0:0:0 | [summary] to write: ReturnValue in Value |
+| reflect.StructTag.Get | file://:0:0:0:0 | [summary param] -1 in Get | file://:0:0:0:0 | [summary] to write: ReturnValue in Get |
+| reflect.StructTag.Lookup | file://:0:0:0:0 | [summary param] -1 in Lookup | file://:0:0:0:0 | [summary] to write: ReturnValue in Lookup |
+| reflect.Type.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| reflect.Value.Addr | file://:0:0:0:0 | [summary param] -1 in Addr | file://:0:0:0:0 | [summary] to write: ReturnValue in Addr |
+| reflect.Value.Bytes | file://:0:0:0:0 | [summary param] -1 in Bytes | file://:0:0:0:0 | [summary] to write: ReturnValue in Bytes |
+| reflect.Value.Convert | file://:0:0:0:0 | [summary param] -1 in Convert | file://:0:0:0:0 | [summary] to write: ReturnValue in Convert |
+| reflect.Value.Elem | file://:0:0:0:0 | [summary param] -1 in Elem | file://:0:0:0:0 | [summary] to write: ReturnValue in Elem |
+| reflect.Value.Field | file://:0:0:0:0 | [summary param] -1 in Field | file://:0:0:0:0 | [summary] to write: ReturnValue in Field |
+| reflect.Value.FieldByIndex | file://:0:0:0:0 | [summary param] -1 in FieldByIndex | file://:0:0:0:0 | [summary] to write: ReturnValue in FieldByIndex |
+| reflect.Value.FieldByName | file://:0:0:0:0 | [summary param] -1 in FieldByName | file://:0:0:0:0 | [summary] to write: ReturnValue in FieldByName |
+| reflect.Value.FieldByNameFunc | file://:0:0:0:0 | [summary param] -1 in FieldByNameFunc | file://:0:0:0:0 | [summary] to write: ReturnValue in FieldByNameFunc |
+| reflect.Value.Index | file://:0:0:0:0 | [summary param] -1 in Index | file://:0:0:0:0 | [summary] to write: ReturnValue in Index |
+| reflect.Value.Interface | file://:0:0:0:0 | [summary param] -1 in Interface | file://:0:0:0:0 | [summary] to write: ReturnValue in Interface |
+| reflect.Value.InterfaceData | file://:0:0:0:0 | [summary param] -1 in InterfaceData | file://:0:0:0:0 | [summary] to write: ReturnValue in InterfaceData |
+| reflect.Value.MapIndex | file://:0:0:0:0 | [summary param] -1 in MapIndex | file://:0:0:0:0 | [summary] to write: ReturnValue in MapIndex |
+| reflect.Value.MapKeys | file://:0:0:0:0 | [summary param] -1 in MapKeys | file://:0:0:0:0 | [summary] to write: ReturnValue in MapKeys |
+| reflect.Value.MapRange | file://:0:0:0:0 | [summary param] -1 in MapRange | file://:0:0:0:0 | [summary] to write: ReturnValue in MapRange |
+| reflect.Value.Method | file://:0:0:0:0 | [summary param] -1 in Method | file://:0:0:0:0 | [summary] to write: ReturnValue in Method |
+| reflect.Value.MethodByName | file://:0:0:0:0 | [summary param] -1 in MethodByName | file://:0:0:0:0 | [summary] to write: ReturnValue in MethodByName |
+| reflect.Value.Pointer | file://:0:0:0:0 | [summary param] -1 in Pointer | file://:0:0:0:0 | [summary] to write: ReturnValue in Pointer |
+| reflect.Value.Recv | file://:0:0:0:0 | [summary param] -1 in Recv | file://:0:0:0:0 | [summary] to write: ReturnValue in Recv |
+| reflect.Value.Send | file://:0:0:0:0 | [summary param] 0 in Send | file://:0:0:0:0 | [summary] to write: Argument[-1] in Send |
+| reflect.Value.Set | file://:0:0:0:0 | [summary param] 0 in Set | file://:0:0:0:0 | [summary] to write: Argument[-1] in Set |
+| reflect.Value.SetBytes | file://:0:0:0:0 | [summary param] 0 in SetBytes | file://:0:0:0:0 | [summary] to write: Argument[-1] in SetBytes |
+| reflect.Value.SetMapIndex | file://:0:0:0:0 | [summary param] 0 in SetMapIndex | file://:0:0:0:0 | [summary] to write: Argument[-1] in SetMapIndex |
+| reflect.Value.SetMapIndex | file://:0:0:0:0 | [summary param] 1 in SetMapIndex | file://:0:0:0:0 | [summary] to write: Argument[-1] in SetMapIndex |
+| reflect.Value.SetPointer | file://:0:0:0:0 | [summary param] 0 in SetPointer | file://:0:0:0:0 | [summary] to write: Argument[-1] in SetPointer |
+| reflect.Value.SetString | file://:0:0:0:0 | [summary param] 0 in SetString | file://:0:0:0:0 | [summary] to write: Argument[-1] in SetString |
+| reflect.Value.Slice | file://:0:0:0:0 | [summary param] -1 in Slice | file://:0:0:0:0 | [summary] to write: ReturnValue in Slice |
+| reflect.Value.Slice3 | file://:0:0:0:0 | [summary param] -1 in Slice3 | file://:0:0:0:0 | [summary] to write: ReturnValue in Slice3 |
+| reflect.Value.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| reflect.Value.TryRecv | file://:0:0:0:0 | [summary param] -1 in TryRecv | file://:0:0:0:0 | [summary] to write: ReturnValue in TryRecv |
+| reflect.Value.TrySend | file://:0:0:0:0 | [summary param] 0 in TrySend | file://:0:0:0:0 | [summary] to write: Argument[-1] in TrySend |
+| reflect.Value.UnsafeAddr | file://:0:0:0:0 | [summary param] -1 in UnsafeAddr | file://:0:0:0:0 | [summary] to write: ReturnValue in UnsafeAddr |
+| reflect.ValueOf | file://:0:0:0:0 | [summary param] 0 in ValueOf | file://:0:0:0:0 | [summary] to write: ReturnValue in ValueOf |
+| reflect.rtype.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| runtime.lockRank.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| runtime.stringer.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| runtime.stwReason.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| runtime.waitReason.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| sort.Reverse | file://:0:0:0:0 | [summary param] 0 in Reverse | file://:0:0:0:0 | [summary] to write: ReturnValue in Reverse |
+| strconv.AppendQuote | file://:0:0:0:0 | [summary param] 0 in AppendQuote | file://:0:0:0:0 | [summary] to write: ReturnValue in AppendQuote |
+| strconv.AppendQuote | file://:0:0:0:0 | [summary param] 1 in AppendQuote | file://:0:0:0:0 | [summary] to write: ReturnValue in AppendQuote |
+| strconv.AppendQuoteToASCII | file://:0:0:0:0 | [summary param] 0 in AppendQuoteToASCII | file://:0:0:0:0 | [summary] to write: ReturnValue in AppendQuoteToASCII |
+| strconv.AppendQuoteToASCII | file://:0:0:0:0 | [summary param] 1 in AppendQuoteToASCII | file://:0:0:0:0 | [summary] to write: ReturnValue in AppendQuoteToASCII |
+| strconv.AppendQuoteToGraphic | file://:0:0:0:0 | [summary param] 0 in AppendQuoteToGraphic | file://:0:0:0:0 | [summary] to write: ReturnValue in AppendQuoteToGraphic |
+| strconv.AppendQuoteToGraphic | file://:0:0:0:0 | [summary param] 1 in AppendQuoteToGraphic | file://:0:0:0:0 | [summary] to write: ReturnValue in AppendQuoteToGraphic |
+| strconv.Quote | file://:0:0:0:0 | [summary param] 0 in Quote | file://:0:0:0:0 | [summary] to write: ReturnValue in Quote |
+| strconv.QuoteToASCII | file://:0:0:0:0 | [summary param] 0 in QuoteToASCII | file://:0:0:0:0 | [summary] to write: ReturnValue in QuoteToASCII |
+| strconv.QuoteToGraphic | file://:0:0:0:0 | [summary param] 0 in QuoteToGraphic | file://:0:0:0:0 | [summary] to write: ReturnValue in QuoteToGraphic |
+| strconv.QuotedPrefix | file://:0:0:0:0 | [summary param] 0 in QuotedPrefix | file://:0:0:0:0 | [summary] to write: ReturnValue in QuotedPrefix |
+| strconv.Unquote | file://:0:0:0:0 | [summary param] 0 in Unquote | file://:0:0:0:0 | [summary] to write: ReturnValue in Unquote |
+| strconv.UnquoteChar | file://:0:0:0:0 | [summary param] 0 in UnquoteChar | file://:0:0:0:0 | [summary] to write: ReturnValue[2] in UnquoteChar |
+| strconv.decimal.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| strings.Builder.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| strings.Builder.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| strings.Builder.WriteString | file://:0:0:0:0 | [summary param] 0 in WriteString | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteString |
+| strings.Fields | file://:0:0:0:0 | [summary param] 0 in Fields | file://:0:0:0:0 | [summary] to write: ReturnValue in Fields |
+| strings.FieldsFunc | file://:0:0:0:0 | [summary param] 0 in FieldsFunc | file://:0:0:0:0 | [summary] to write: ReturnValue in FieldsFunc |
+| strings.Join | file://:0:0:0:0 | [summary param] 0 in Join | file://:0:0:0:0 | [summary] to write: ReturnValue in Join |
+| strings.Join | file://:0:0:0:0 | [summary param] 1 in Join | file://:0:0:0:0 | [summary] to write: ReturnValue in Join |
+| strings.Map | file://:0:0:0:0 | [summary param] 1 in Map | file://:0:0:0:0 | [summary] to write: ReturnValue in Map |
+| strings.NewReader | file://:0:0:0:0 | [summary param] 0 in NewReader | file://:0:0:0:0 | [summary] to write: ReturnValue in NewReader |
+| strings.Reader.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| strings.Reader.ReadAt | file://:0:0:0:0 | [summary param] -1 in ReadAt | file://:0:0:0:0 | [summary] to write: Argument[0] in ReadAt |
+| strings.Reader.Reset | file://:0:0:0:0 | [summary param] 0 in Reset | file://:0:0:0:0 | [summary] to write: Argument[-1] in Reset |
+| strings.Reader.WriteTo | file://:0:0:0:0 | [summary param] -1 in WriteTo | file://:0:0:0:0 | [summary] to write: Argument[0] in WriteTo |
+| strings.Repeat | file://:0:0:0:0 | [summary param] 0 in Repeat | file://:0:0:0:0 | [summary] to write: ReturnValue in Repeat |
+| strings.Replace | file://:0:0:0:0 | [summary param] 0 in Replace | file://:0:0:0:0 | [summary] to write: ReturnValue in Replace |
+| strings.Replace | file://:0:0:0:0 | [summary param] 2 in Replace | file://:0:0:0:0 | [summary] to write: ReturnValue in Replace |
+| strings.ReplaceAll | file://:0:0:0:0 | [summary param] 0 in ReplaceAll | file://:0:0:0:0 | [summary] to write: ReturnValue in ReplaceAll |
+| strings.ReplaceAll | file://:0:0:0:0 | [summary param] 2 in ReplaceAll | file://:0:0:0:0 | [summary] to write: ReturnValue in ReplaceAll |
+| strings.Replacer.Replace | file://:0:0:0:0 | [summary param] 0 in Replace | file://:0:0:0:0 | [summary] to write: ReturnValue in Replace |
+| strings.Replacer.WriteString | file://:0:0:0:0 | [summary param] 1 in WriteString | file://:0:0:0:0 | [summary] to write: Argument[0] in WriteString |
+| strings.Split | file://:0:0:0:0 | [summary param] 0 in Split | file://:0:0:0:0 | [summary] to write: ReturnValue in Split |
+| strings.SplitAfter | file://:0:0:0:0 | [summary param] 0 in SplitAfter | file://:0:0:0:0 | [summary] to write: ReturnValue in SplitAfter |
+| strings.SplitAfterN | file://:0:0:0:0 | [summary param] 0 in SplitAfterN | file://:0:0:0:0 | [summary] to write: ReturnValue in SplitAfterN |
+| strings.SplitN | file://:0:0:0:0 | [summary param] 0 in SplitN | file://:0:0:0:0 | [summary] to write: ReturnValue in SplitN |
+| strings.Title | file://:0:0:0:0 | [summary param] 0 in Title | file://:0:0:0:0 | [summary] to write: ReturnValue in Title |
+| strings.ToLower | file://:0:0:0:0 | [summary param] 0 in ToLower | file://:0:0:0:0 | [summary] to write: ReturnValue in ToLower |
+| strings.ToLowerSpecial | file://:0:0:0:0 | [summary param] 1 in ToLowerSpecial | file://:0:0:0:0 | [summary] to write: ReturnValue in ToLowerSpecial |
+| strings.ToTitle | file://:0:0:0:0 | [summary param] 0 in ToTitle | file://:0:0:0:0 | [summary] to write: ReturnValue in ToTitle |
+| strings.ToTitleSpecial | file://:0:0:0:0 | [summary param] 1 in ToTitleSpecial | file://:0:0:0:0 | [summary] to write: ReturnValue in ToTitleSpecial |
+| strings.ToUpper | file://:0:0:0:0 | [summary param] 0 in ToUpper | file://:0:0:0:0 | [summary] to write: ReturnValue in ToUpper |
+| strings.ToUpperSpecial | file://:0:0:0:0 | [summary param] 1 in ToUpperSpecial | file://:0:0:0:0 | [summary] to write: ReturnValue in ToUpperSpecial |
+| strings.ToValidUTF8 | file://:0:0:0:0 | [summary param] 0 in ToValidUTF8 | file://:0:0:0:0 | [summary] to write: ReturnValue in ToValidUTF8 |
+| strings.ToValidUTF8 | file://:0:0:0:0 | [summary param] 1 in ToValidUTF8 | file://:0:0:0:0 | [summary] to write: ReturnValue in ToValidUTF8 |
+| strings.Trim | file://:0:0:0:0 | [summary param] 0 in Trim | file://:0:0:0:0 | [summary] to write: ReturnValue in Trim |
+| strings.TrimFunc | file://:0:0:0:0 | [summary param] 0 in TrimFunc | file://:0:0:0:0 | [summary] to write: ReturnValue in TrimFunc |
+| strings.TrimLeft | file://:0:0:0:0 | [summary param] 0 in TrimLeft | file://:0:0:0:0 | [summary] to write: ReturnValue in TrimLeft |
+| strings.TrimLeftFunc | file://:0:0:0:0 | [summary param] 0 in TrimLeftFunc | file://:0:0:0:0 | [summary] to write: ReturnValue in TrimLeftFunc |
+| strings.TrimPrefix | file://:0:0:0:0 | [summary param] 0 in TrimPrefix | file://:0:0:0:0 | [summary] to write: ReturnValue in TrimPrefix |
+| strings.TrimRight | file://:0:0:0:0 | [summary param] 0 in TrimRight | file://:0:0:0:0 | [summary] to write: ReturnValue in TrimRight |
+| strings.TrimRightFunc | file://:0:0:0:0 | [summary param] 0 in TrimRightFunc | file://:0:0:0:0 | [summary] to write: ReturnValue in TrimRightFunc |
+| strings.TrimSpace | file://:0:0:0:0 | [summary param] 0 in TrimSpace | file://:0:0:0:0 | [summary] to write: ReturnValue in TrimSpace |
+| strings.TrimSuffix | file://:0:0:0:0 | [summary param] 0 in TrimSuffix | file://:0:0:0:0 | [summary] to write: ReturnValue in TrimSuffix |
+| strings.appendSliceWriter.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| strings.appendSliceWriter.WriteString | file://:0:0:0:0 | [summary param] 0 in WriteString | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteString |
+| strings.stringWriter.WriteString | file://:0:0:0:0 | [summary param] 0 in WriteString | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteString |
+| sync.Map.CompareAndSwap | file://:0:0:0:0 | [summary param] 2 in CompareAndSwap | file://:0:0:0:0 | [summary] to write: Argument[-1] in CompareAndSwap |
+| sync.Map.Load | file://:0:0:0:0 | [summary param] -1 in Load | file://:0:0:0:0 | [summary] to write: ReturnValue in Load |
+| sync.Map.LoadOrStore | file://:0:0:0:0 | [summary param] 0 in LoadOrStore | file://:0:0:0:0 | [summary] to write: Argument[-1] in LoadOrStore |
+| sync.Map.LoadOrStore | file://:0:0:0:0 | [summary param] 0 in LoadOrStore | file://:0:0:0:0 | [summary] to write: ReturnValue in LoadOrStore |
+| sync.Map.LoadOrStore | file://:0:0:0:0 | [summary param] 1 in LoadOrStore | file://:0:0:0:0 | [summary] to write: Argument[-1] in LoadOrStore |
+| sync.Map.LoadOrStore | file://:0:0:0:0 | [summary param] 1 in LoadOrStore | file://:0:0:0:0 | [summary] to write: ReturnValue in LoadOrStore |
+| sync.Map.LoadOrStore | file://:0:0:0:0 | [summary param] -1 in LoadOrStore | file://:0:0:0:0 | [summary] to write: ReturnValue in LoadOrStore |
+| sync.Map.Store | file://:0:0:0:0 | [summary param] 0 in Store | file://:0:0:0:0 | [summary] to write: Argument[-1] in Store |
+| sync.Map.Store | file://:0:0:0:0 | [summary param] 1 in Store | file://:0:0:0:0 | [summary] to write: Argument[-1] in Store |
+| sync.Map.Swap | file://:0:0:0:0 | [summary param] 0 in Swap | file://:0:0:0:0 | [summary] to write: Argument[-1] in Swap |
+| sync.Map.Swap | file://:0:0:0:0 | [summary param] 1 in Swap | file://:0:0:0:0 | [summary] to write: Argument[-1] in Swap |
+| sync.Map.Swap | file://:0:0:0:0 | [summary param] -1 in Swap | file://:0:0:0:0 | [summary] to write: ReturnValue in Swap |
+| sync.Pool.Get | file://:0:0:0:0 | [summary param] -1 in Get | file://:0:0:0:0 | [summary] to write: ReturnValue in Get |
+| sync.Pool.Put | file://:0:0:0:0 | [summary param] 0 in Put | file://:0:0:0:0 | [summary] to write: Argument[-1] in Put |
+| sync/atomic.AddUintptr | file://:0:0:0:0 | [summary param] 1 in AddUintptr | file://:0:0:0:0 | [summary] to write: Argument[0] in AddUintptr |
+| sync/atomic.AddUintptr | file://:0:0:0:0 | [summary param] 1 in AddUintptr | file://:0:0:0:0 | [summary] to write: ReturnValue in AddUintptr |
+| sync/atomic.CompareAndSwapPointer | file://:0:0:0:0 | [summary param] 2 in CompareAndSwapPointer | file://:0:0:0:0 | [summary] to write: Argument[0] in CompareAndSwapPointer |
+| sync/atomic.CompareAndSwapUintptr | file://:0:0:0:0 | [summary param] 2 in CompareAndSwapUintptr | file://:0:0:0:0 | [summary] to write: Argument[0] in CompareAndSwapUintptr |
+| sync/atomic.LoadPointer | file://:0:0:0:0 | [summary param] 0 in LoadPointer | file://:0:0:0:0 | [summary] to write: ReturnValue in LoadPointer |
+| sync/atomic.LoadUintptr | file://:0:0:0:0 | [summary param] 0 in LoadUintptr | file://:0:0:0:0 | [summary] to write: ReturnValue in LoadUintptr |
+| sync/atomic.Pointer.Load | file://:0:0:0:0 | [summary param] -1 in Load | file://:0:0:0:0 | [summary] to write: ReturnValue in Load |
+| sync/atomic.Pointer.Store | file://:0:0:0:0 | [summary param] 0 in Store | file://:0:0:0:0 | [summary] to write: Argument[-1] in Store |
+| sync/atomic.Pointer.Swap | file://:0:0:0:0 | [summary param] 0 in Swap | file://:0:0:0:0 | [summary] to write: Argument[-1] in Swap |
+| sync/atomic.Pointer.Swap | file://:0:0:0:0 | [summary param] -1 in Swap | file://:0:0:0:0 | [summary] to write: ReturnValue in Swap |
+| sync/atomic.StorePointer | file://:0:0:0:0 | [summary param] 1 in StorePointer | file://:0:0:0:0 | [summary] to write: Argument[0] in StorePointer |
+| sync/atomic.StoreUintptr | file://:0:0:0:0 | [summary param] 1 in StoreUintptr | file://:0:0:0:0 | [summary] to write: Argument[0] in StoreUintptr |
+| sync/atomic.SwapPointer | file://:0:0:0:0 | [summary param] 0 in SwapPointer | file://:0:0:0:0 | [summary] to write: ReturnValue in SwapPointer |
+| sync/atomic.SwapPointer | file://:0:0:0:0 | [summary param] 1 in SwapPointer | file://:0:0:0:0 | [summary] to write: Argument[0] in SwapPointer |
+| sync/atomic.SwapUintptr | file://:0:0:0:0 | [summary param] 0 in SwapUintptr | file://:0:0:0:0 | [summary] to write: ReturnValue in SwapUintptr |
+| sync/atomic.SwapUintptr | file://:0:0:0:0 | [summary param] 1 in SwapUintptr | file://:0:0:0:0 | [summary] to write: Argument[0] in SwapUintptr |
+| sync/atomic.Uintptr.Load | file://:0:0:0:0 | [summary param] -1 in Load | file://:0:0:0:0 | [summary] to write: ReturnValue in Load |
+| sync/atomic.Uintptr.Store | file://:0:0:0:0 | [summary param] 0 in Store | file://:0:0:0:0 | [summary] to write: Argument[-1] in Store |
+| sync/atomic.Uintptr.Swap | file://:0:0:0:0 | [summary param] 0 in Swap | file://:0:0:0:0 | [summary] to write: Argument[-1] in Swap |
+| sync/atomic.Uintptr.Swap | file://:0:0:0:0 | [summary param] -1 in Swap | file://:0:0:0:0 | [summary] to write: ReturnValue in Swap |
+| sync/atomic.Value.Load | file://:0:0:0:0 | [summary param] -1 in Load | file://:0:0:0:0 | [summary] to write: ReturnValue in Load |
+| sync/atomic.Value.Store | file://:0:0:0:0 | [summary param] 0 in Store | file://:0:0:0:0 | [summary] to write: Argument[-1] in Store |
+| sync/atomic.Value.Swap | file://:0:0:0:0 | [summary param] 0 in Swap | file://:0:0:0:0 | [summary] to write: Argument[-1] in Swap |
+| sync/atomic.Value.Swap | file://:0:0:0:0 | [summary param] -1 in Swap | file://:0:0:0:0 | [summary] to write: ReturnValue in Swap |
+| syscall.BytePtrFromString | file://:0:0:0:0 | [summary param] 0 in BytePtrFromString | file://:0:0:0:0 | [summary] to write: ReturnValue in BytePtrFromString |
+| syscall.ByteSliceFromString | file://:0:0:0:0 | [summary param] 0 in ByteSliceFromString | file://:0:0:0:0 | [summary] to write: ReturnValue in ByteSliceFromString |
+| syscall.Conn.SyscallConn | file://:0:0:0:0 | [summary param] -1 in SyscallConn | file://:0:0:0:0 | [summary] to write: ReturnValue in SyscallConn |
+| syscall.RawConn.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| syscall.RawConn.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| syscall.Signal.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| syscall.StringBytePtr | file://:0:0:0:0 | [summary param] 0 in StringBytePtr | file://:0:0:0:0 | [summary] to write: ReturnValue in StringBytePtr |
+| syscall.StringByteSlice | file://:0:0:0:0 | [summary param] 0 in StringByteSlice | file://:0:0:0:0 | [summary] to write: ReturnValue in StringByteSlice |
+| time.Duration.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| time.Location.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| time.Month.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| time.Time.GoString | file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
+| time.Time.MarshalBinary | file://:0:0:0:0 | [summary param] -1 in MarshalBinary | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalBinary |
+| time.Time.MarshalJSON | file://:0:0:0:0 | [summary param] -1 in MarshalJSON | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalJSON |
+| time.Time.MarshalText | file://:0:0:0:0 | [summary param] -1 in MarshalText | file://:0:0:0:0 | [summary] to write: ReturnValue in MarshalText |
+| time.Time.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| time.Time.UnmarshalBinary | file://:0:0:0:0 | [summary param] 0 in UnmarshalBinary | file://:0:0:0:0 | [summary] to write: Argument[-1] in UnmarshalBinary |
+| time.Time.UnmarshalJSON | file://:0:0:0:0 | [summary param] 0 in UnmarshalJSON | file://:0:0:0:0 | [summary] to write: Argument[-1] in UnmarshalJSON |
+| time.Time.UnmarshalText | file://:0:0:0:0 | [summary param] 0 in UnmarshalText | file://:0:0:0:0 | [summary] to write: Argument[-1] in UnmarshalText |
+| time.Weekday.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| vendor/golang.org/x/crypto/chacha20poly1305.chacha20poly1305.Open | file://:0:0:0:0 | [summary param] 2 in Open | file://:0:0:0:0 | [summary] to write: Argument[0] in Open |
+| vendor/golang.org/x/crypto/chacha20poly1305.chacha20poly1305.Open | file://:0:0:0:0 | [summary param] 2 in Open | file://:0:0:0:0 | [summary] to write: ReturnValue in Open |
+| vendor/golang.org/x/crypto/chacha20poly1305.xchacha20poly1305.Open | file://:0:0:0:0 | [summary param] 2 in Open | file://:0:0:0:0 | [summary] to write: Argument[0] in Open |
+| vendor/golang.org/x/crypto/chacha20poly1305.xchacha20poly1305.Open | file://:0:0:0:0 | [summary param] 2 in Open | file://:0:0:0:0 | [summary] to write: ReturnValue in Open |
+| vendor/golang.org/x/crypto/hkdf.hkdf.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| vendor/golang.org/x/crypto/internal/poly1305.MAC.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| vendor/golang.org/x/crypto/internal/poly1305.macGeneric.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| vendor/golang.org/x/net/dns/dnsmessage.AAAAResource.GoString | file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
+| vendor/golang.org/x/net/dns/dnsmessage.AResource.GoString | file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
+| vendor/golang.org/x/net/dns/dnsmessage.CNAMEResource.GoString | file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
+| vendor/golang.org/x/net/dns/dnsmessage.Class.GoString | file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
+| vendor/golang.org/x/net/dns/dnsmessage.Class.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| vendor/golang.org/x/net/dns/dnsmessage.Header.GoString | file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
+| vendor/golang.org/x/net/dns/dnsmessage.MXResource.GoString | file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
+| vendor/golang.org/x/net/dns/dnsmessage.Message.GoString | file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
+| vendor/golang.org/x/net/dns/dnsmessage.NSResource.GoString | file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
+| vendor/golang.org/x/net/dns/dnsmessage.Name.GoString | file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
+| vendor/golang.org/x/net/dns/dnsmessage.Name.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| vendor/golang.org/x/net/dns/dnsmessage.OPTResource.GoString | file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
+| vendor/golang.org/x/net/dns/dnsmessage.OpCode.GoString | file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
+| vendor/golang.org/x/net/dns/dnsmessage.Option.GoString | file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
+| vendor/golang.org/x/net/dns/dnsmessage.PTRResource.GoString | file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
+| vendor/golang.org/x/net/dns/dnsmessage.Question.GoString | file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
+| vendor/golang.org/x/net/dns/dnsmessage.RCode.GoString | file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
+| vendor/golang.org/x/net/dns/dnsmessage.RCode.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| vendor/golang.org/x/net/dns/dnsmessage.Resource.GoString | file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
+| vendor/golang.org/x/net/dns/dnsmessage.ResourceBody.GoString | file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
+| vendor/golang.org/x/net/dns/dnsmessage.ResourceHeader.GoString | file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
+| vendor/golang.org/x/net/dns/dnsmessage.SOAResource.GoString | file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
+| vendor/golang.org/x/net/dns/dnsmessage.SRVResource.GoString | file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
+| vendor/golang.org/x/net/dns/dnsmessage.TXTResource.GoString | file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
+| vendor/golang.org/x/net/dns/dnsmessage.Type.GoString | file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
+| vendor/golang.org/x/net/dns/dnsmessage.Type.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| vendor/golang.org/x/net/dns/dnsmessage.UnknownResource.GoString | file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
+| vendor/golang.org/x/net/http2/hpack.Decoder.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| vendor/golang.org/x/net/http2/hpack.HeaderField.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| vendor/golang.org/x/net/idna.Profile.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| vendor/golang.org/x/text/transform.Reader.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| vendor/golang.org/x/text/transform.Writer.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| vendor/golang.org/x/text/unicode/bidi.Run.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| vendor/golang.org/x/text/unicode/bidi.bracketPair.String | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| vendor/golang.org/x/text/unicode/norm.normReader.Read | file://:0:0:0:0 | [summary param] -1 in Read | file://:0:0:0:0 | [summary] to write: Argument[0] in Read |
+| vendor/golang.org/x/text/unicode/norm.normWriter.Write | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |

--- a/go/ql/test/library-tests/semmle/go/frameworks/TaintSteps/TaintStep.expected
+++ b/go/ql/test/library-tests/semmle/go/frameworks/TaintSteps/TaintStep.expected
@@ -338,6 +338,7 @@
 | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
 | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
 | file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
+| file://:0:0:0:0 | [summary param] 0 in Write | file://:0:0:0:0 | [summary] to write: Argument[-1] in Write |
 | file://:0:0:0:0 | [summary param] 0 in WriteAt | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteAt |
 | file://:0:0:0:0 | [summary param] 0 in WriteAt | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteAt |
 | file://:0:0:0:0 | [summary param] 0 in WriteAt | file://:0:0:0:0 | [summary] to write: Argument[-1] in WriteAt |
@@ -524,6 +525,7 @@
 | file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
 | file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
 | file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
+| file://:0:0:0:0 | [summary param] -1 in GoString | file://:0:0:0:0 | [summary] to write: ReturnValue in GoString |
 | file://:0:0:0:0 | [summary param] -1 in Hijack | file://:0:0:0:0 | [summary] to write: ReturnValue in Hijack |
 | file://:0:0:0:0 | [summary param] -1 in Hijack | file://:0:0:0:0 | [summary] to write: ReturnValue in Hijack |
 | file://:0:0:0:0 | [summary param] -1 in Hijack | file://:0:0:0:0 | [summary] to write: ReturnValue in Hijack |
@@ -676,6 +678,7 @@
 | file://:0:0:0:0 | [summary param] -1 in ReadAt | file://:0:0:0:0 | [summary] to write: Argument[0] in ReadAt |
 | file://:0:0:0:0 | [summary param] -1 in ReadAt | file://:0:0:0:0 | [summary] to write: Argument[0] in ReadAt |
 | file://:0:0:0:0 | [summary param] -1 in ReadAt | file://:0:0:0:0 | [summary] to write: Argument[0] in ReadAt |
+| file://:0:0:0:0 | [summary param] -1 in ReadAt | file://:0:0:0:0 | [summary] to write: Argument[0] in ReadAt |
 | file://:0:0:0:0 | [summary param] -1 in ReadBytes | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadBytes |
 | file://:0:0:0:0 | [summary param] -1 in ReadBytes | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadBytes |
 | file://:0:0:0:0 | [summary param] -1 in ReadCodeLine | file://:0:0:0:0 | [summary] to write: ReturnValue[1] in ReadCodeLine |
@@ -684,8 +687,10 @@
 | file://:0:0:0:0 | [summary param] -1 in ReadDir | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadDir |
 | file://:0:0:0:0 | [summary param] -1 in ReadDir | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadDir |
 | file://:0:0:0:0 | [summary param] -1 in ReadDir | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadDir |
+| file://:0:0:0:0 | [summary param] -1 in ReadDir | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadDir |
 | file://:0:0:0:0 | [summary param] -1 in ReadDotBytes | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadDotBytes |
 | file://:0:0:0:0 | [summary param] -1 in ReadDotLines | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadDotLines |
+| file://:0:0:0:0 | [summary param] -1 in ReadFile | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadFile |
 | file://:0:0:0:0 | [summary param] -1 in ReadFile | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadFile |
 | file://:0:0:0:0 | [summary param] -1 in ReadFile | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadFile |
 | file://:0:0:0:0 | [summary param] -1 in ReadFile | file://:0:0:0:0 | [summary] to write: ReturnValue in ReadFile |
@@ -816,6 +821,16 @@
 | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
 | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
 | file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
+| file://:0:0:0:0 | [summary param] -1 in String | file://:0:0:0:0 | [summary] to write: ReturnValue in String |
 | file://:0:0:0:0 | [summary param] -1 in Sub | file://:0:0:0:0 | [summary] to write: ReturnValue in Sub |
 | file://:0:0:0:0 | [summary param] -1 in Sub | file://:0:0:0:0 | [summary] to write: ReturnValue in Sub |
 | file://:0:0:0:0 | [summary param] -1 in Swap | file://:0:0:0:0 | [summary] to write: ReturnValue in Swap |
@@ -837,6 +852,7 @@
 | file://:0:0:0:0 | [summary param] -1 in TryRecv | file://:0:0:0:0 | [summary] to write: ReturnValue in TryRecv |
 | file://:0:0:0:0 | [summary param] -1 in UnsafeAddr | file://:0:0:0:0 | [summary] to write: ReturnValue in UnsafeAddr |
 | file://:0:0:0:0 | [summary param] -1 in Username | file://:0:0:0:0 | [summary] to write: ReturnValue in Username |
+| file://:0:0:0:0 | [summary param] -1 in Value | file://:0:0:0:0 | [summary] to write: ReturnValue in Value |
 | file://:0:0:0:0 | [summary param] -1 in Value | file://:0:0:0:0 | [summary] to write: ReturnValue in Value |
 | file://:0:0:0:0 | [summary param] -1 in Value | file://:0:0:0:0 | [summary] to write: ReturnValue in Value |
 | file://:0:0:0:0 | [summary param] -1 in Value | file://:0:0:0:0 | [summary] to write: ReturnValue in Value |

--- a/go/ql/test/library-tests/semmle/go/frameworks/TaintSteps/TaintStep.ql
+++ b/go/ql/test/library-tests/semmle/go/frameworks/TaintSteps/TaintStep.ql
@@ -30,7 +30,7 @@ where
     pkg.matches("crypto/rand.%") and
     name = "Read"
     or
-    pkg = ["os.dirEntry", "os.unixDirent"] and name = ["Info", "Name"]
+    pkg = ["os.dirEntry", "os.unixDirent"] and name = ["Info", "Name", "String"]
     or
     // Not available on arm64
     pkg = "vendor/golang.org/x/crypto/internal/poly1305.mac" and name = "Write"

--- a/go/ql/test/library-tests/semmle/go/frameworks/TaintSteps/TaintStep.ql
+++ b/go/ql/test/library-tests/semmle/go/frameworks/TaintSteps/TaintStep.ql
@@ -1,3 +1,5 @@
+// This test finds taint tracking steps which are not data flow steps
+// to illustrate which steps are added specifically by taint tracking
 import go
 
 predicate hasLocation(DataFlow::Node node, string loc) {

--- a/go/ql/test/library-tests/semmle/go/frameworks/TaintSteps/TaintStep.ql
+++ b/go/ql/test/library-tests/semmle/go/frameworks/TaintSteps/TaintStep.ql
@@ -31,6 +31,9 @@ where
     name = "Read"
     or
     pkg = ["os.dirEntry", "os.unixDirent"] and name = ["Info", "Name"]
+    or
+    // Not available on arm64
+    pkg = "vendor/golang.org/x/crypto/internal/poly1305.mac" and name = "Write"
   ) and
   getLocation(pred, predLoc)
 select predLoc, pred, succ

--- a/go/ql/test/library-tests/semmle/go/frameworks/TaintSteps/TaintStep.ql
+++ b/go/ql/test/library-tests/semmle/go/frameworks/TaintSteps/TaintStep.ql
@@ -1,6 +1,6 @@
 import go
 
-predicate getLocation(DataFlow::Node node, string loc) {
+predicate hasLocation(DataFlow::Node node, string loc) {
   node.hasLocationInfo(loc, _, _, _, _) and loc != ""
   or
   exists(string pkg, string name |
@@ -35,5 +35,5 @@ where
     // Not available on arm64
     pkg = "vendor/golang.org/x/crypto/internal/poly1305.mac" and name = "Write"
   ) and
-  getLocation(pred, predLoc)
+  hasLocation(pred, predLoc)
 select predLoc, pred, succ

--- a/go/ql/test/library-tests/semmle/go/frameworks/TaintSteps/main.go
+++ b/go/ql/test/library-tests/semmle/go/frameworks/TaintSteps/main.go
@@ -28,3 +28,10 @@ func readTest(req *http.Request) string {
 	req.Body.Read(b)
 	return string(b)
 }
+
+func clearTest(req *http.Request) string {
+	b := make([]byte, 8)
+	req.Body.Read(b)
+	clear(b) // should prevent taint flow
+	return string(b)
+}


### PR DESCRIPTION
Go 1.21 was released recently. This PR updates our CI to use Go 1.21 and makes the Go extractor aware of Go 1.21. It also adds support for the new built-in functions: `min`, `max`, and `clear`. 