### PR TITLE
Go: Add sanitizer to remove paths passing through http.Error

### DIFF
--- a/go/ql/lib/change-notes/2023-08-28--add-error-sanitizer-for-xss.md
+++ b/go/ql/lib/change-notes/2023-08-28--add-error-sanitizer-for-xss.md
@@ -1,2 +1,0 @@
-lgtm,codescanning
-* Added [http.Error](https://pkg.go.dev/net/http#Error) to XSS sanitzers.

--- a/go/ql/lib/change-notes/2023-08-28--add-error-sanitizer-for-xss.md
+++ b/go/ql/lib/change-notes/2023-08-28--add-error-sanitizer-for-xss.md
@@ -1,0 +1,2 @@
+lgtm,codescanning
+* Added [http.Error](https://pkg.go.dev/net/http#Error) to XSS sanitzers.

--- a/go/ql/lib/change-notes/2023-08-28-add-error-sanitizer-for-xss.md
+++ b/go/ql/lib/change-notes/2023-08-28-add-error-sanitizer-for-xss.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Added [http.Error](https://pkg.go.dev/net/http#Error) to XSS sanitzers.

--- a/go/ql/lib/semmle/go/security/Xss.qll
+++ b/go/ql/lib/semmle/go/security/Xss.qll
@@ -108,13 +108,16 @@ module SharedXss {
       )
     }
   }
-/**
- * A http.Error function returns with the ContentType of text/plain, and is not a valid XSS sink
- */
-  class ErrorSanitizer extends Sanitizer{
+
+  /**
+   * A http.Error function returns with the ContentType of text/plain, and is not a valid XSS sink
+   */
+  class ErrorSanitizer extends Sanitizer {
     ErrorSanitizer() {
-    exists(Function f, DataFlow::CallNode call | f = call.getCall().getTarget() | f.hasQualifiedName("net/http", "Error")
-    and call.getArgument(1) = this)
+      exists(Function f, DataFlow::CallNode call | call = f.getACall() |
+        f.hasQualifiedName("net/http", "Error") and
+        call.getArgument(1) = this
+      )
     }
   }
 

--- a/go/ql/lib/semmle/go/security/Xss.qll
+++ b/go/ql/lib/semmle/go/security/Xss.qll
@@ -108,6 +108,15 @@ module SharedXss {
       )
     }
   }
+/**
+ * A http.Error function returns with the ContentType of text/plain, and is not a valid XSS sink
+ */
+  class ErrorSanitizer extends Sanitizer{
+    ErrorSanitizer() {
+    exists(Function f, DataFlow::CallNode call | f = call.getCall().getTarget() | f.hasQualifiedName("net/http", "Error")
+    and call.getArgument(1) = this)
+    }
+  }
 
   /**
    * A regexp replacement involving an HTML meta-character, or a call to an escape

--- a/go/ql/test/query-tests/Security/CWE-079/reflectedxsstest.go
+++ b/go/ql/test/query-tests/Security/CWE-079/reflectedxsstest.go
@@ -25,9 +25,9 @@ func ServeJsonDirect(w http.ResponseWriter, r http.Request) {
 
 func ErrTest(w http.ResponseWriter, r http.Request) {
 	cookie, err := r.Cookie("somecookie")
-	w.Write([]byte(fmt.Sprintf("Cookie result: %v", cookie)))   // BAD: Cookie's value is user-controlled
-	w.Write([]byte(fmt.Sprintf("Cookie check error: %v", err))) // GOOD: Cookie's err return is harmless
-
+	w.Write([]byte(fmt.Sprintf("Cookie result: %v", cookie)))    // BAD: Cookie's value is user-controlled
+	w.Write([]byte(fmt.Sprintf("Cookie check error: %v", err)))  // GOOD: Cookie's err return is harmless
+	http.Error(w, fmt.Sprintf("Cookie result: %v", cookie), 500) // Good: only plain text is written.
 	file, header, err := r.FormFile("someFile")
 	content, err2 := ioutil.ReadAll(file)
 	w.Write([]byte(fmt.Sprintf("File content: %v", content)))      // BAD: file content is user-controlled


### PR DESCRIPTION
When using MRVA with the Reflected XSS query, I noticed that http.Error is often the last step of a path to http.ResponseWriter, but Errors are reported as plaintext not html and thus are do not result in valid XSS. In fact, this False positive is very common, being around half of the total results. I have opened this PR to help remove http.Error FP.