### PR TITLE
C++: Improve use-after-free example code

### DIFF
--- a/cpp/ql/src/Critical/UseAfterFree.cpp
+++ b/cpp/ql/src/Critical/UseAfterFree.cpp
@@ -1,9 +1,10 @@
-int f() {
+void f() {
 	char* buf = new char[SIZE];
-	....
+	...
 	if (error) {
-		free(buf); //error handling has freed the buffer
+		delete buf; //error handling has freed the buffer
 	}
 	...
 	log_contents(buf); //but it is still used here for logging
+	...
 }


### PR DESCRIPTION
* Remove the mismatch between `new` and `free` and use `delete` instead
* Make the function `void`, so people copying the code will not forget to add a `return`.
* Balance out the `...` for omitted code.

This was flagged up by a user on the GHSL slack.