### PR TITLE
Revert "Swift: Pragmatic fix for CustomUrlSchemes.qll."

### DIFF
--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/CustomUrlSchemes.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/CustomUrlSchemes.qll
@@ -56,9 +56,7 @@ private class ApplicationWithLaunchOptionsFunc extends Function {
 
 private class LaunchOptionsUrlVarDecl extends VarDecl {
   LaunchOptionsUrlVarDecl() {
-    // ideally this would be the more accurate, but currently less robust:
-    // this.getEnclosingDecl().asNominalTypeDecl().getFullName() = "UIApplication.LaunchOptionsKey" and
-    this.getType().(NominalType).getFullName() = "UIApplication.LaunchOptionsKey" and
+    this.getEnclosingDecl().asNominalTypeDecl().getFullName() = "UIApplication.LaunchOptionsKey" and
     this.getName() = "url"
   }
 }


### PR DESCRIPTION
Reverts github/codeql#13757 since the underlying issue appears to have been fixed.