### PR TITLE
C++: Add a predicate for getting dataflow nodes whose value has been constant folded

### DIFF
--- a/cpp/ql/test/library-tests/dataflow/folded-constant/folded-constant.expected
+++ b/cpp/ql/test/library-tests/dataflow/folded-constant/folded-constant.expected
@@ -1,0 +1,2 @@
+failures
+testFailures

--- a/cpp/ql/test/library-tests/dataflow/folded-constant/folded-constant.ql
+++ b/cpp/ql/test/library-tests/dataflow/folded-constant/folded-constant.ql
@@ -1,0 +1,21 @@
+import TestUtilities.dataflow.FlowTestCommon
+private import semmle.code.cpp.ir.IR
+private import semmle.code.cpp.ir.dataflow.TaintTracking
+
+/** Common data flow configuration to be used by tests. */
+module TestFoldedConstantConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) {
+    source.asFoldedConstant() = any(MacroInvocation mi).getExpr().getValue()
+  }
+
+  predicate isSink(DataFlow::Node sink) {
+    exists(FunctionCall call |
+      call.getTarget().getName() = "sink" and
+      sink.asExpr() = call.getAnArgument()
+    )
+  }
+}
+
+module TestFoldedConstant = TaintTracking::Global<TestFoldedConstantConfig>;
+
+import MakeTest<IRFlowTest<TestFoldedConstant>>

--- a/cpp/ql/test/library-tests/dataflow/folded-constant/test.cpp
+++ b/cpp/ql/test/library-tests/dataflow/folded-constant/test.cpp
@@ -1,0 +1,28 @@
+enum Constants
+{
+    ONE = 1,
+    TWO = 2,
+    LARGE = 0xff00,
+};
+
+#define SOURCE 1
+
+void sink(int x);
+
+void test_constants() {
+  sink(SOURCE | ONE); // $ ir
+  sink(SOURCE | TWO); // $ ir
+  sink(SOURCE | LARGE); // $ ir
+
+  int x1 = SOURCE | TWO;
+  sink(x1); // $ ir
+
+  int x2 = TWO | SOURCE;
+  sink(x2); // $ ir
+
+  int x3 = TWO | LARGE;
+  sink(x3); // clean
+
+  int x4 = ((SOURCE | ONE) | TWO) | LARGE;
+  sink(x4); // $ ir
+}


### PR DESCRIPTION
Consider the following program:
```cpp
enum MY_ENUM
{
    A = 1,
    B = 2,
    C = 0xff00,
};

void sink(int x);

void test() {
  int x = 1 | C;
  sink(x);
}
```

if one writes the expected taint-tracking query to identify flow from the constant `1` to an argument of `sink`:
```ql
/**
 * @kind path-problem
 */

import cpp
import semmle.code.cpp.dataflow.new.TaintTracking
import TestFlow::PathGraph

module TestConfig implements DataFlow::ConfigSig {
  predicate isSource(DataFlow::Node source) { source.asExpr().getValue().toInt() = 1 }

  predicate isSink(DataFlow::Node sink) {
    sink.asExpr() = any(Call call | call.getTarget().hasName("sink")).getAnArgument()
  }
}

module TestFlow = TaintTracking::Global<TestConfig>;

from TestFlow::PathNode source, TestFlow::PathNode sink
where TestFlow::flowPath(source, sink)
select sink.getNode(), source, sink, ""
```
then this won't work because `1` has been constant folded during IR construction into the value of the expression `1 | C`. Thus, even though taint-tracking allows flow through bitwise OR, this won't have any result.

This PR adds a new predicate on `DataFlow::Node`s called `asFoldedConstant`. The expression `node.asFoldedConstant()` gives all the constants that has been folded into the node's underlying `IntegerConstantInstruction`. This allows one to find flow in the above example by replacing
```ql
predicate isSource(DataFlow::Node source) { source.asExpr().getValue().toInt() = 1 }
```
with
```ql
predicate isSource(DataFlow::Node source) { source.asFoldedConstant().toInt() = 1 }
```