### PR TITLE
Java: Fix typo in `StdlibRandomSource::getOutput`

### DIFF
--- a/java/ql/lib/change-notes/2023-08-07-randomdatasource-typo-fix.md
+++ b/java/ql/lib/change-notes/2023-08-07-randomdatasource-typo-fix.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Fixed a typo in the `StdlibRandomSource` class in `RandomDataSource.qll`, which caused the class to improperly model calls to the `nextBytes` method. Queries relying on `StdlibRandomSource` may see an increase in results.

--- a/java/ql/lib/semmle/code/java/security/RandomDataSource.qll
+++ b/java/ql/lib/semmle/code/java/security/RandomDataSource.qll
@@ -103,7 +103,7 @@ class StdlibRandomSource extends RandomDataSource {
   }
 
   override Expr getOutput() {
-    if m.hasName("getBytes") then result = this.getArgument(0) else result = this
+    if m.hasName("nextBytes") then result = this.getArgument(0) else result = this
   }
 }
 


### PR DESCRIPTION
In `RandomDataSource.qll`, `StdlibRandomSource::getOutput` contains a typo which makes queries relying on `StdlibRandomSource` improperly model calls to `java.util.Random#nextBytes`. This fixes the typo to the correct method name.