### PR TITLE
Java: Improve `JaxWsEndpoint::getARemoteMethod`

### DIFF
--- a/java/ql/lib/change-notes/2023-08-07-jaxrs-webmethod-improvements.md
+++ b/java/ql/lib/change-notes/2023-08-07-jaxrs-webmethod-improvements.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The predicate `JaxWsEndpoint::getARemoteMethod` no longer requires the result to be annotated with `@WebMethod`. Instead, the requirements listed in the JAX-RPC Specification 1.1 for required parameter and return types are used. Applications using JAX-RS may see an increase in results.

--- a/java/ql/lib/semmle/code/java/frameworks/JaxWS.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/JaxWS.qll
@@ -25,7 +25,7 @@ string getAJaxRsPackage(string subpackage) { result = getAJaxRsPackage() + "." +
  */
 class JaxWsEndpoint extends Class {
   JaxWsEndpoint() {
-    exists(AnnotationType a | a = this.getAnAnnotation().getType() |
+    exists(AnnotationType a | a = this.getAnAncestor().getAnAnnotation().getType() |
       a.hasName(["WebService", "WebServiceProvider", "WebServiceClient"])
     )
   }
@@ -37,6 +37,7 @@ class JaxWsEndpoint extends Class {
    */
   Method getARemoteMethod() {
     result = this.getACallable() and
+    result.isPublic() and
     not result instanceof InitializerMethod and
     not exists(Annotation a | a = result.getAnAnnotation() |
       a.getType().hasQualifiedName(["javax", "jakarta"] + ".jws", "WebMethod") and

--- a/java/ql/lib/semmle/code/java/frameworks/JaxWS.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/JaxWS.qll
@@ -4,6 +4,8 @@
  */
 
 import java
+private import semmle.code.java.frameworks.Networking
+private import semmle.code.java.frameworks.Rmi
 private import semmle.code.java.security.XSS
 
 /**
@@ -28,11 +30,106 @@ class JaxWsEndpoint extends Class {
     )
   }
 
-  /** Gets a method annotated with `@WebMethod` or `@WebEndpoint`. */
-  Callable getARemoteMethod() {
+  /**
+   * Gets a method of this class that is not an excluded `@WebMethod`,
+   * and the parameters and return value of which are either of an acceptable type,
+   * or are annotated with `@XmlJavaTypeAdapter`.
+   */
+  Method getARemoteMethod() {
     result = this.getACallable() and
-    exists(AnnotationType a | a = result.getAnAnnotation().getType() |
-      a.hasName(["WebMethod", "WebEndpoint"])
+    not result instanceof InitializerMethod and
+    not exists(Annotation a | a = result.getAnAnnotation() |
+      a.getType().hasQualifiedName(["javax", "jakarta"] + ".jws", "WebMethod") and
+      a.getValue("exclude").(BooleanLiteral).getBooleanValue() = true
+    ) and
+    forex(ParamOrReturn paramOrRet | paramOrRet = result.getAParameter() or paramOrRet = result |
+      exists(Type t | t = paramOrRet.getType() |
+        t instanceof JaxAcceptableType
+        or
+        t.(Annotatable).getAnAnnotation().getType() instanceof XmlJavaTypeAdapter
+        or
+        t instanceof VoidType
+      )
+      or
+      paramOrRet.getInheritedAnnotation().getType() instanceof XmlJavaTypeAdapter
+    )
+  }
+}
+
+/** The annotation type `@XmlJavaTypeAdapter`. */
+class XmlJavaTypeAdapter extends AnnotationType {
+  XmlJavaTypeAdapter() {
+    this.hasQualifiedName(["javax", "jakarta"] + ".xml.bind.annotation.adapters",
+      "XmlJavaTypeAdapter")
+  }
+}
+
+private class ParamOrReturn extends Annotatable {
+  ParamOrReturn() { this instanceof Parameter or this instanceof Method }
+
+  Type getType() {
+    result = this.(Parameter).getType()
+    or
+    result = this.(Method).getReturnType()
+  }
+
+  Annotation getInheritedAnnotation() {
+    result = this.getAnAnnotation()
+    or
+    result = this.(Method).getAnOverride*().getAnAnnotation()
+    or
+    result =
+      this.(Parameter)
+          .getCallable()
+          .(Method)
+          .getAnOverride*()
+          .getParameter(this.(Parameter).getPosition())
+          .getAnAnnotation()
+  }
+}
+
+// JAX-RPC 1.1, section 5
+private class JaxAcceptableType extends Type {
+  JaxAcceptableType() {
+    // JAX-RPC 1.1, section 5.1.1
+    this instanceof PrimitiveType
+    or
+    // JAX-RPC 1.1, section 5.1.2
+    this.(Array).getElementType() instanceof JaxAcceptableType
+    or
+    // JAX-RPC 1.1, section 5.1.3
+    this instanceof JaxAcceptableStandardClass
+    or
+    // JAX-RPC 1.1, section 5.1.4
+    this instanceof JaxValueType
+  }
+}
+
+private class JaxAcceptableStandardClass extends RefType {
+  JaxAcceptableStandardClass() {
+    this instanceof TypeString or
+    this.hasQualifiedName("java.util", "Date") or
+    this.hasQualifiedName("java.util", "Calendar") or
+    this.hasQualifiedName("java.math", "BigInteger") or
+    this.hasQualifiedName("java.math", "BigDecimal") or
+    this.hasQualifiedName("javax.xml.namespace", "QName") or
+    this instanceof TypeUri
+  }
+}
+
+// JAX-RPC 1.1, section 5.4
+private class JaxValueType extends RefType {
+  JaxValueType() {
+    not this instanceof Wildcard and
+    // Mutually exclusive with other `JaxAcceptableType`s
+    not this instanceof Array and
+    not this instanceof JaxAcceptableStandardClass and
+    not this.getPackage().getName().matches("java.%") and
+    // Must not implement (directly or indirectly) the java.rmi.Remote interface.
+    not this.getAnAncestor() instanceof TypeRemote and
+    // The Java type of a public field must be a supported JAX-RPC type as specified in the section 5.1.
+    forall(Field f | this.getAMember() = f and f.isPublic() |
+      f.getType() instanceof JaxAcceptableType
     )
   }
 }

--- a/java/ql/test/library-tests/frameworks/JaxWs/JaxWsEndpoint.java
+++ b/java/ql/test/library-tests/frameworks/JaxWs/JaxWsEndpoint.java
@@ -1,5 +1,8 @@
+import java.io.File;
+
 import javax.jws.WebMethod;
 import javax.jws.WebService;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import javax.xml.ws.WebEndpoint;
 import javax.xml.ws.WebServiceClient;
 import javax.xml.ws.WebServiceProvider;
@@ -15,7 +18,24 @@ class WebServiceClass { // $ JaxWsEndpoint
   void WebEndpointMethod() { // $ JaxWsEndpointRemoteMethod
   }
 
+  String acceptableTypes(String param) { // $ JaxWsEndpointRemoteMethod
+    return null;
+  }
+
+  String unacceptableParamType(File param) { // not an endpoint
+    return null;
+  }
+
+  File unacceptableReturnType() { // not an endpoint
+    return null;
+  }
+
+  @XmlJavaTypeAdapter
+  File annotatedTypes(@XmlJavaTypeAdapter File param) { // $ JaxWsEndpointRemoteMethod
+    return null;
+  }
 }
+
 
 @WebServiceProvider
 class WebServiceProviderClass { // $ JaxWsEndpoint
@@ -28,7 +48,24 @@ class WebServiceProviderClass { // $ JaxWsEndpoint
   void WebEndpointMethod() { // $ JaxWsEndpointRemoteMethod
   }
 
+  String acceptableTypes(String param) { // $ JaxWsEndpointRemoteMethod
+    return null;
+  }
+
+  String unacceptableParamType(File param) { // not an endpoint
+    return null;
+  }
+
+  File unacceptableReturnType() { // not an endpoint
+    return null;
+  }
+
+  @XmlJavaTypeAdapter
+  File annotatedTypes(@XmlJavaTypeAdapter File param) { // $ JaxWsEndpointRemoteMethod
+    return null;
+  }
 }
+
 
 @WebServiceClient
 class WebServiceClientClass { // $ JaxWsEndpoint
@@ -39,6 +76,23 @@ class WebServiceClientClass { // $ JaxWsEndpoint
 
   @WebEndpoint
   void WebEndpointMethod() { // $ JaxWsEndpointRemoteMethod
+  }
+
+  String acceptableTypes(String param) { // $ JaxWsEndpointRemoteMethod
+    return null;
+  }
+
+  String unacceptableParamType(File param) { // not an endpoint
+    return null;
+  }
+
+  File unacceptableReturnType() { // not an endpoint
+    return null;
+  }
+
+  @XmlJavaTypeAdapter
+  File annotatedTypes(@XmlJavaTypeAdapter File param) { // $ JaxWsEndpointRemoteMethod
+    return null;
   }
 
 }

--- a/java/ql/test/library-tests/frameworks/JaxWs/JaxWsEndpoint.java
+++ b/java/ql/test/library-tests/frameworks/JaxWs/JaxWsEndpoint.java
@@ -11,27 +11,27 @@ import javax.xml.ws.WebServiceProvider;
 class WebServiceClass { // $ JaxWsEndpoint
 
   @WebMethod
-  void WebMethodMethod() { // $ JaxWsEndpointRemoteMethod
+  public void WebMethodMethod() { // $ JaxWsEndpointRemoteMethod
   }
 
   @WebEndpoint
-  void WebEndpointMethod() { // $ JaxWsEndpointRemoteMethod
+  public void WebEndpointMethod() { // $ JaxWsEndpointRemoteMethod
   }
 
-  String acceptableTypes(String param) { // $ JaxWsEndpointRemoteMethod
+  public String acceptableTypes(String param) { // $ JaxWsEndpointRemoteMethod
     return null;
   }
 
-  String unacceptableParamType(File param) { // not an endpoint
+  public String unacceptableParamType(File param) { // not an endpoint
     return null;
   }
 
-  File unacceptableReturnType() { // not an endpoint
+  public File unacceptableReturnType() { // not an endpoint
     return null;
   }
 
   @XmlJavaTypeAdapter
-  File annotatedTypes(@XmlJavaTypeAdapter File param) { // $ JaxWsEndpointRemoteMethod
+  public File annotatedTypes(@XmlJavaTypeAdapter File param) { // $ JaxWsEndpointRemoteMethod
     return null;
   }
 }
@@ -41,27 +41,27 @@ class WebServiceClass { // $ JaxWsEndpoint
 class WebServiceProviderClass { // $ JaxWsEndpoint
 
   @WebMethod
-  void WebMethodMethod() { // $ JaxWsEndpointRemoteMethod
+  public void WebMethodMethod() { // $ JaxWsEndpointRemoteMethod
   }
 
   @WebEndpoint
-  void WebEndpointMethod() { // $ JaxWsEndpointRemoteMethod
+  public void WebEndpointMethod() { // $ JaxWsEndpointRemoteMethod
   }
 
-  String acceptableTypes(String param) { // $ JaxWsEndpointRemoteMethod
+  public String acceptableTypes(String param) { // $ JaxWsEndpointRemoteMethod
     return null;
   }
 
-  String unacceptableParamType(File param) { // not an endpoint
+  public String unacceptableParamType(File param) { // not an endpoint
     return null;
   }
 
-  File unacceptableReturnType() { // not an endpoint
+  public File unacceptableReturnType() { // not an endpoint
     return null;
   }
 
   @XmlJavaTypeAdapter
-  File annotatedTypes(@XmlJavaTypeAdapter File param) { // $ JaxWsEndpointRemoteMethod
+  public File annotatedTypes(@XmlJavaTypeAdapter File param) { // $ JaxWsEndpointRemoteMethod
     return null;
   }
 }
@@ -71,27 +71,27 @@ class WebServiceProviderClass { // $ JaxWsEndpoint
 class WebServiceClientClass { // $ JaxWsEndpoint
 
   @WebMethod
-  void WebMethodMethod() { // $ JaxWsEndpointRemoteMethod
+  public void WebMethodMethod() { // $ JaxWsEndpointRemoteMethod
   }
 
   @WebEndpoint
-  void WebEndpointMethod() { // $ JaxWsEndpointRemoteMethod
+  public void WebEndpointMethod() { // $ JaxWsEndpointRemoteMethod
   }
 
-  String acceptableTypes(String param) { // $ JaxWsEndpointRemoteMethod
+  public String acceptableTypes(String param) { // $ JaxWsEndpointRemoteMethod
     return null;
   }
 
-  String unacceptableParamType(File param) { // not an endpoint
+  public String unacceptableParamType(File param) { // not an endpoint
     return null;
   }
 
-  File unacceptableReturnType() { // not an endpoint
+  public File unacceptableReturnType() { // not an endpoint
     return null;
   }
 
   @XmlJavaTypeAdapter
-  File annotatedTypes(@XmlJavaTypeAdapter File param) { // $ JaxWsEndpointRemoteMethod
+  public File annotatedTypes(@XmlJavaTypeAdapter File param) { // $ JaxWsEndpointRemoteMethod
     return null;
   }
 

--- a/java/ql/test/stubs/jaxws-api-2.0/javax/xml/bind/annotation/adapters/XmlJavaTypeAdapter.java
+++ b/java/ql/test/stubs/jaxws-api-2.0/javax/xml/bind/annotation/adapters/XmlJavaTypeAdapter.java
@@ -1,0 +1,15 @@
+package javax.xml.bind.annotation.adapters;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.PACKAGE;
+
+@Retention(RUNTIME)
+@Target({PACKAGE, FIELD, METHOD, TYPE, PARAMETER})
+public @interface XmlJavaTypeAdapter {
+}


### PR DESCRIPTION
`JaxWsEndpoint::getARemoteMethod` required its methods to be annotated with `@WebMethod` or `@WebEndpoint` to be considered sources. This is inconsistent with certain implementations of JAX-RS (like Apache CXF), where `@WebService` methods are still externally accessible if their parameter and return types meet certain conditions. This PR expands our support of JAX-RS to include this.

The logic for acceptable types was obtained from the [JAX-RPC Specification 1.1](https://download.oracle.com/otn-pub/jcp/7228-jaxrpc-1.1-mrd-spec-oth-JSpec/jaxrpc-1_1-mrd-spec.pdf).