### PR TITLE
C++: Fix taint-flow in preparation for frontend upgrade

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
@@ -193,7 +193,7 @@ abstract private class DefOrUseImpl extends TDefOrUseImpl {
 
   /**
    * Gets the instruction that computes the base of this definition or use.
-   * This is always a `VariableAddressInstruction` or an `AllocationInstruction`.
+   * This is always a `VariableAddressInstruction` or an `CallInstruction`.
    */
   abstract BaseSourceVariableInstruction getBase();
 

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternalsCommon.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternalsCommon.qll
@@ -146,14 +146,6 @@ int countIndirectionsForCppType(LanguageType langType) {
   )
 }
 
-/**
- * A `CallInstruction` that calls an allocation function such
- * as `malloc` or `operator new`.
- */
-class AllocationInstruction extends CallInstruction {
-  AllocationInstruction() { this.getStaticCallTarget() instanceof Cpp::AllocationFunction }
-}
-
 private predicate isIndirectionType(Type t) { t instanceof Indirection }
 
 private predicate hasUnspecifiedBaseType(Indirection t, Type base) {
@@ -368,7 +360,7 @@ newtype TBaseSourceVariable =
   // Each IR variable gets its own source variable
   TBaseIRVariable(IRVariable var) or
   // Each allocation gets its own source variable
-  TBaseCallVariable(AllocationInstruction call)
+  TBaseCallVariable(CallInstruction call) { not call.getResultIRType() instanceof IRVoidType }
 
 abstract private class AbstractBaseSourceVariable extends TBaseSourceVariable {
   /** Gets a textual representation of this element. */
@@ -396,11 +388,11 @@ class BaseIRVariable extends AbstractBaseSourceVariable, TBaseIRVariable {
 }
 
 class BaseCallVariable extends AbstractBaseSourceVariable, TBaseCallVariable {
-  AllocationInstruction call;
+  CallInstruction call;
 
   BaseCallVariable() { this = TBaseCallVariable(call) }
 
-  AllocationInstruction getCallInstruction() { result = call }
+  CallInstruction getCallInstruction() { result = call }
 
   override string toString() { result = call.toString() }
 
@@ -504,8 +496,7 @@ private class BaseIRVariableInstruction extends BaseSourceVariableInstruction,
   override BaseIRVariable getBaseSourceVariable() { result.getIRVariable() = this.getIRVariable() }
 }
 
-private class BaseAllocationInstruction extends BaseSourceVariableInstruction, AllocationInstruction
-{
+private class BaseCallInstruction extends BaseSourceVariableInstruction, CallInstruction {
   override BaseCallVariable getBaseSourceVariable() { result.getCallInstruction() = this }
 }
 


### PR DESCRIPTION
This PR fixes the taint-regressions surfaced by the upgrade of the C/C++ frontend [here](https://github.com/github/codeql/pull/13716). It should be safe to merge this PR before merging https://github.com/github/codeql/pull/13716.

Commit-by-commit review recommended.