### PR TITLE
Java: limit field flow when tracking regex strings

### DIFF
--- a/java/ql/lib/semmle/code/java/regex/RegexFlowConfigs.qll
+++ b/java/ql/lib/semmle/code/java/regex/RegexFlowConfigs.qll
@@ -148,6 +148,8 @@ private module RegexFlowConfig implements DataFlow::ConfigSig {
   predicate isBarrier(DataFlow::Node node) {
     node.getEnclosingCallable().getDeclaringType() instanceof NonSecurityTestClass
   }
+
+  int fieldFlowBranchLimit() { result = 1 }
 }
 
 private module RegexFlow = DataFlow::Global<RegexFlowConfig>;


### PR DESCRIPTION
This seems to fix https://github.com/github/codeql/discussions/13752 
(Someone else confirm that?) 

Other languages already have a similar limitation in how they track regular expressions.  

[An evaluation](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/PR-13916-0-java/reports) looks slightly weird, but I think it's good. 