### PR TITLE
Swift: Flow sources for UITextInput

### DIFF
--- a/docs/codeql/reusables/supported-frameworks.rst
+++ b/docs/codeql/reusables/supported-frameworks.rst
@@ -310,3 +310,4 @@ and the CodeQL library pack ``codeql/swift-all`` (`changelog <https://github.com
    `SQLite3 <https://sqlite.org/index.html>`__, Database
    `SQLite.swift <https://github.com/stephencelis/SQLite.swift>`__, Database
    `WebKit <https://developer.apple.com/documentation/webkit>`__, User interface library
+   `UIKit <https://developer.apple.com/documentation/uikit>`__, User interface library

--- a/swift/ql/lib/change-notes/2023-08-08-ui-text-input.md
+++ b/swift/ql/lib/change-notes/2023-08-08-ui-text-input.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Added local flow sources for `UITextInput` and related classes.

--- a/swift/ql/lib/codeql/swift/frameworks/UIKit/UITextField.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/UIKit/UITextField.qll
@@ -6,7 +6,7 @@ import swift
 private import codeql.swift.dataflow.ExternalFlow
 
 /**
- * A model for `UITextField` and `UITextInput` members that are flow sources.
+ * A model for `UITextField`, `UITextInput` and related class members that are flow sources.
  */
 private class UITextFieldSource extends SourceModelCsv {
   override predicate row(string row) {

--- a/swift/ql/lib/codeql/swift/frameworks/UIKit/UITextField.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/UIKit/UITextField.qll
@@ -1,15 +1,22 @@
 /**
- * Provides models for the `UITextField` Swift class.
+ * Provides models for the `UITextField` and related Swift class.
  */
 
 import swift
 private import codeql.swift.dataflow.ExternalFlow
 
 /**
- * A model for `UITextField` members that are flow sources.
+ * A model for `UITextField` and `UITextInput` members that are flow sources.
  */
 private class UITextFieldSource extends SourceModelCsv {
   override predicate row(string row) {
-    row = [";UITextField;true;text;;;;local", ";UITextField;true;attributedText;;;;local"]
+    row =
+      [
+        ";UITextField;true;text;;;;local", ";UITextField;true;attributedText;;;;local",
+        ";UITextFieldDelegate;true;textField(_:shouldChangeCharactersIn:replacementString:);;;Parameter[2];local",
+        ";UITextViewDelegate;true;textView(_:shouldChangeTextIn:replacementText:);;;Parameter[2];local",
+        ";UITextInput;true;text(in:);;;ReturnValue;local",
+        ";UITextInput;true;shouldChangeText(in:replacementText:);;;Parameter[1];local",
+      ]
   }
 }

--- a/swift/ql/test/library-tests/dataflow/flowsources/uikit.swift
+++ b/swift/ql/test/library-tests/dataflow/flowsources/uikit.swift
@@ -1,33 +1,82 @@
 // --- stubs ---
 
 class NSObject { }
-class NSAttributedString: NSObject {}
-class UIResponder: NSObject {}
-class UIView: UIResponder {}
-class UIControl: UIView {}
+
+struct _NSRange { }
+
+typealias NSRange = _NSRange
+
+class NSAttributedString: NSObject { }
+
+class UIResponder: NSObject { }
+
+class UIView: UIResponder { }
+
+class UIControl: UIView { }
+
+class UITextRange : NSObject {
+}
+
+protocol UITextInput {
+	func text(in range: UITextRange) -> String?
+
+  func shouldChangeText(in range: UITextRange, replacementText text: String) -> Bool
+}
+
 class UITextField: UIControl {
   var text: String? {
     get { nil }
     set { }
   }
+
   var attributedText: NSAttributedString? {
     get { nil }
     set { }
   }
+
   var placeholder: String? {
     get { nil }
     set { }
   }
 }
+
 class UISearchTextField : UITextField {
+}
+
+protocol UITextFieldDelegate {
+	func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool
 }
 
 // --- tests ---
 
-func testUITextField(textField: UITextField, searchTextField: UISearchTextField) {
+func sink(arg: Any) { }
+
+class MyTextInput : UITextInput {
+	func text(in range: UITextRange) -> String? { return nil }
+	func harmless(in range: UITextRange) -> String? { return nil }
+
+	func shouldChangeText(in range: UITextRange, replacementText text: String) -> Bool { // $ MISSING: source=local
+		sink(arg: text) // $ MISSING: tainted=
+
+		return true
+	}
+}
+
+class MyUITextFieldDelegate : UITextFieldDelegate {
+	func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool { // $ MISSING: source=local
+		sink(arg: string) // $ MISSING: tainted=
+
+		return true
+	}
+}
+
+func test(textField: UITextField, searchTextField: UISearchTextField, myTextInput: MyTextInput, range: UITextRange) {
   _ = textField.text // $ source=local
   _ = textField.attributedText // $ source=local
   _ = textField.placeholder // GOOD (not input)
   _ = textField.text?.uppercased() // $ source=local
   _ = searchTextField.text // $ source=local
+
+  _ = myTextInput.text(in: range)! // $ MISSING: source=local
+  _ = myTextInput.harmless(in: range)! // GOOD (not input)
 }

--- a/swift/ql/test/library-tests/dataflow/flowsources/uikit.swift
+++ b/swift/ql/test/library-tests/dataflow/flowsources/uikit.swift
@@ -55,16 +55,16 @@ class MyTextInput : UITextInput {
 	func text(in range: UITextRange) -> String? { return nil }
 	func harmless(in range: UITextRange) -> String? { return nil }
 
-	func shouldChangeText(in range: UITextRange, replacementText text: String) -> Bool { // $ MISSING: source=local
-		sink(arg: text) // $ MISSING: tainted=
+	func shouldChangeText(in range: UITextRange, replacementText text: String) -> Bool { // $ source=local
+		sink(arg: text) // $ tainted
 
 		return true
 	}
 }
 
 class MyUITextFieldDelegate : UITextFieldDelegate {
-	func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool { // $ MISSING: source=local
-		sink(arg: string) // $ MISSING: tainted=
+	func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool { // $ source=local
+		sink(arg: string) // $ tainted
 
 		return true
 	}
@@ -77,6 +77,6 @@ func test(textField: UITextField, searchTextField: UISearchTextField, myTextInpu
   _ = textField.text?.uppercased() // $ source=local
   _ = searchTextField.text // $ source=local
 
-  _ = myTextInput.text(in: range)! // $ MISSING: source=local
+  _ = myTextInput.text(in: range)! // $ source=local
   _ = myTextInput.harmless(in: range)! // GOOD (not input)
 }


### PR DESCRIPTION
Add flow sources for [`UITextInput`](https://developer.apple.com/documentation/uikit/uitextinput), [`UITextFieldDelegate`](https://developer.apple.com/documentation/uikit/uitextfielddelegate) and [`UITextViewDelegate`](https://developer.apple.com/documentation/uikit/uitextviewdelegate).

I've also added `UIKit` to `supported-frameworks.rst` since, I think, we now model enough of it to claim coverage (and there's likely more to come).

On the MRVA top 1000, we find 94 new taint sources - a sample of which LGTM (though only perhaps half use the data anywhere).  DCA run to follow...