### PR TITLE
Swift: Models-as-data support for tuple content

### DIFF
--- a/swift/ql/lib/codeql/swift/dataflow/ExternalFlow.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/ExternalFlow.qll
@@ -476,17 +476,24 @@ private predicate parseField(AccessPathToken c, Content::FieldContent f) {
   )
 }
 
-private predicate parseEnum(AccessPathToken c, Content::EnumContent f) {
+private predicate parseTuple(AccessPathToken c, Content::TupleContent t) {
+  c.getName() = "TupleElement" and
+  t.getIndex() = c.getAnArgument().toInt()
+}
+
+private predicate parseEnum(AccessPathToken c, Content::EnumContent e) {
   c.getName() = "EnumElement" and
-  c.getAnArgument() = f.getSignature()
+  c.getAnArgument() = e.getSignature()
   or
   c.getName() = "OptionalSome" and
-  f.getSignature() = "some:0"
+  e.getSignature() = "some:0"
 }
 
 /** Holds if the specification component parses as a `Content`. */
 predicate parseContent(AccessPathToken component, Content content) {
   parseField(component, content)
+  or
+  parseTuple(component, content)
   or
   parseEnum(component, content)
   or

--- a/swift/ql/lib/codeql/swift/dataflow/internal/FlowSummaryImplSpecific.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/FlowSummaryImplSpecific.qll
@@ -110,6 +110,11 @@ private string getContentSpecific(ContentSet cs) {
     result = "Field[" + c.getField().getName() + "]"
   )
   or
+  exists(Content::TupleContent c |
+    cs.isSingleton(c) and
+    result = "TupleElement[" + c.getIndex().toString() + "]"
+  )
+  or
   exists(Content::EnumContent c |
     cs.isSingleton(c) and
     result = "EnumElement[" + c.getSignature() + "]"

--- a/swift/ql/test/library-tests/dataflow/dataflow/CONSISTENCY/CfgConsistency.expected
+++ b/swift/ql/test/library-tests/dataflow/dataflow/CONSISTENCY/CfgConsistency.expected
@@ -1,3 +1,3 @@
 multipleSuccessors
-| test.swift:519:8:519:12 | let ...? | no-match | test.swift:519:27:519:27 | y |
-| test.swift:519:8:519:12 | let ...? | no-match | test.swift:524:9:524:9 | tuple1 |
+| test.swift:538:8:538:12 | let ...? | no-match | test.swift:538:27:538:27 | y |
+| test.swift:538:8:538:12 | let ...? | no-match | test.swift:543:9:543:9 | tuple1 |

--- a/swift/ql/test/library-tests/dataflow/dataflow/DataFlow.expected
+++ b/swift/ql/test/library-tests/dataflow/dataflow/DataFlow.expected
@@ -110,8 +110,8 @@ edges
 | test.swift:259:12:259:19 | call to source() | test.swift:259:12:259:19 | call to source() [some:0] |
 | test.swift:259:12:259:19 | call to source() | test.swift:263:13:263:28 | call to optionalSource() |
 | test.swift:259:12:259:19 | call to source() [some:0] | test.swift:263:13:263:28 | call to optionalSource() [some:0] |
-| test.swift:259:12:259:19 | call to source() [some:0] | test.swift:517:13:517:28 | call to optionalSource() [some:0] |
-| test.swift:259:12:259:19 | call to source() [some:0] | test.swift:544:13:544:28 | call to optionalSource() [some:0] |
+| test.swift:259:12:259:19 | call to source() [some:0] | test.swift:536:13:536:28 | call to optionalSource() [some:0] |
+| test.swift:259:12:259:19 | call to source() [some:0] | test.swift:563:13:563:28 | call to optionalSource() [some:0] |
 | test.swift:263:13:263:28 | call to optionalSource() | test.swift:265:15:265:15 | x |
 | test.swift:263:13:263:28 | call to optionalSource() | test.swift:267:15:267:16 | ...! |
 | test.swift:263:13:263:28 | call to optionalSource() | test.swift:271:15:271:16 | ...? |
@@ -178,217 +178,228 @@ edges
 | test.swift:357:15:357:15 | t1 [Tuple element at index 1] | test.swift:357:15:357:18 | .1 |
 | test.swift:360:15:360:15 | t2 [Tuple element at index 0] | test.swift:360:15:360:18 | .0 |
 | test.swift:361:15:361:15 | t2 [Tuple element at index 1] | test.swift:361:15:361:18 | .1 |
-| test.swift:375:16:375:21 | v | test.swift:375:61:375:61 | v |
-| test.swift:375:61:375:61 | v | test.swift:375:45:375:62 | call to ... [mySingle:0] |
-| test.swift:377:18:377:23 | v | test.swift:377:59:377:59 | v |
-| test.swift:377:59:377:59 | v | test.swift:377:45:377:60 | call to ... [some:0] |
-| test.swift:403:9:403:27 | call to ... [mySingle:0] | test.swift:408:10:408:25 | .mySingle(...) [mySingle:0] |
-| test.swift:403:9:403:27 | call to ... [mySingle:0] | test.swift:417:13:417:28 | .mySingle(...) [mySingle:0] |
-| test.swift:403:19:403:26 | call to source() | test.swift:403:9:403:27 | call to ... [mySingle:0] |
-| test.swift:408:10:408:25 | .mySingle(...) [mySingle:0] | test.swift:408:24:408:24 | a |
-| test.swift:408:24:408:24 | a | test.swift:409:19:409:19 | a |
-| test.swift:417:13:417:28 | .mySingle(...) [mySingle:0] | test.swift:417:27:417:27 | x |
-| test.swift:417:27:417:27 | x | test.swift:418:19:418:19 | x |
-| test.swift:425:9:425:34 | call to ... [myPair:1] | test.swift:432:10:432:30 | .myPair(...) [myPair:1] |
-| test.swift:425:9:425:34 | call to ... [myPair:1] | test.swift:442:13:442:33 | .myPair(...) [myPair:1] |
-| test.swift:425:9:425:34 | call to ... [myPair:1] | test.swift:447:33:447:33 | a [myPair:1] |
-| test.swift:425:9:425:34 | call to ... [myPair:1] | test.swift:476:13:476:13 | a [myPair:1] |
-| test.swift:425:26:425:33 | call to source() | test.swift:425:9:425:34 | call to ... [myPair:1] |
-| test.swift:432:10:432:30 | .myPair(...) [myPair:1] | test.swift:432:29:432:29 | b |
-| test.swift:432:29:432:29 | b | test.swift:434:19:434:19 | b |
-| test.swift:442:13:442:33 | .myPair(...) [myPair:1] | test.swift:442:32:442:32 | y |
-| test.swift:442:32:442:32 | y | test.swift:444:19:444:19 | y |
-| test.swift:447:21:447:34 | call to ... [myCons:1, myPair:1] | test.swift:457:14:457:38 | .myCons(...) [myCons:1, myPair:1] |
-| test.swift:447:21:447:34 | call to ... [myCons:1, myPair:1] | test.swift:472:17:472:41 | .myCons(...) [myCons:1, myPair:1] |
-| test.swift:447:21:447:34 | call to ... [myCons:1, myPair:1] | test.swift:476:16:476:16 | b [myCons:1, myPair:1] |
-| test.swift:447:33:447:33 | a [myPair:1] | test.swift:447:21:447:34 | call to ... [myCons:1, myPair:1] |
-| test.swift:457:14:457:38 | .myCons(...) [myCons:1, myPair:1] | test.swift:457:25:457:37 | .myPair(...) [myPair:1] |
-| test.swift:457:25:457:37 | .myPair(...) [myPair:1] | test.swift:457:36:457:36 | c |
-| test.swift:457:36:457:36 | c | test.swift:460:19:460:19 | c |
-| test.swift:468:13:468:39 | .myPair(...) [myPair:0] | test.swift:468:31:468:31 | x |
-| test.swift:468:31:468:31 | x | test.swift:469:19:469:19 | x |
-| test.swift:468:43:468:62 | call to ... [myPair:0] | test.swift:468:13:468:39 | .myPair(...) [myPair:0] |
-| test.swift:468:51:468:58 | call to source() | test.swift:468:43:468:62 | call to ... [myPair:0] |
-| test.swift:472:17:472:41 | .myCons(...) [myCons:1, myPair:1] | test.swift:472:28:472:40 | .myPair(...) [myPair:1] |
-| test.swift:472:28:472:40 | .myPair(...) [myPair:1] | test.swift:472:39:472:39 | c |
-| test.swift:472:39:472:39 | c | test.swift:473:19:473:19 | c |
-| test.swift:476:12:476:17 | (...) [Tuple element at index 0, myPair:1] | test.swift:477:14:477:55 | (...) [Tuple element at index 0, myPair:1] |
-| test.swift:476:12:476:17 | (...) [Tuple element at index 1, myCons:1, myPair:1] | test.swift:477:14:477:55 | (...) [Tuple element at index 1, myCons:1, myPair:1] |
-| test.swift:476:13:476:13 | a [myPair:1] | test.swift:476:12:476:17 | (...) [Tuple element at index 0, myPair:1] |
-| test.swift:476:16:476:16 | b [myCons:1, myPair:1] | test.swift:476:12:476:17 | (...) [Tuple element at index 1, myCons:1, myPair:1] |
-| test.swift:477:14:477:55 | (...) [Tuple element at index 0, myPair:1] | test.swift:477:15:477:27 | .myPair(...) [myPair:1] |
-| test.swift:477:14:477:55 | (...) [Tuple element at index 1, myCons:1, myPair:1] | test.swift:477:30:477:54 | .myCons(...) [myCons:1, myPair:1] |
-| test.swift:477:15:477:27 | .myPair(...) [myPair:1] | test.swift:477:26:477:26 | b |
-| test.swift:477:26:477:26 | b | test.swift:479:19:479:19 | b |
-| test.swift:477:30:477:54 | .myCons(...) [myCons:1, myPair:1] | test.swift:477:41:477:53 | .myPair(...) [myPair:1] |
-| test.swift:477:41:477:53 | .myPair(...) [myPair:1] | test.swift:477:52:477:52 | e |
-| test.swift:477:52:477:52 | e | test.swift:482:19:482:19 | e |
-| test.swift:488:14:488:38 | call to ... [mySingle:0] | test.swift:494:13:494:35 | .mySingle(...) [mySingle:0] |
-| test.swift:488:30:488:37 | call to source() | test.swift:488:14:488:38 | call to ... [mySingle:0] |
-| test.swift:490:14:490:32 | call to mkMyEnum1(_:) [mySingle:0] | test.swift:496:13:496:35 | .mySingle(...) [mySingle:0] |
-| test.swift:490:24:490:31 | call to source() | test.swift:375:16:375:21 | v |
-| test.swift:490:24:490:31 | call to source() | test.swift:490:14:490:32 | call to mkMyEnum1(_:) [mySingle:0] |
-| test.swift:492:14:492:32 | call to mkMyEnum2(_:) [mySingle:0] | test.swift:498:13:498:35 | .mySingle(...) [mySingle:0] |
-| test.swift:492:24:492:31 | call to source() | test.swift:492:14:492:32 | call to mkMyEnum2(_:) [mySingle:0] |
-| test.swift:494:13:494:35 | .mySingle(...) [mySingle:0] | test.swift:494:33:494:33 | d2 |
-| test.swift:494:33:494:33 | d2 | test.swift:494:54:494:54 | d2 |
-| test.swift:496:13:496:35 | .mySingle(...) [mySingle:0] | test.swift:496:33:496:33 | d4 |
-| test.swift:496:33:496:33 | d4 | test.swift:496:54:496:54 | d4 |
-| test.swift:498:13:498:35 | .mySingle(...) [mySingle:0] | test.swift:498:33:498:33 | d6 |
-| test.swift:498:33:498:33 | d6 | test.swift:498:54:498:54 | d6 |
-| test.swift:501:14:501:36 | call to ... [some:0] | test.swift:507:15:507:15 | e2 [some:0] |
-| test.swift:501:28:501:35 | call to source() | test.swift:501:14:501:36 | call to ... [some:0] |
-| test.swift:503:14:503:34 | call to mkOptional1(_:) [some:0] | test.swift:509:15:509:15 | e4 [some:0] |
-| test.swift:503:26:503:33 | call to source() | test.swift:377:18:377:23 | v |
-| test.swift:503:26:503:33 | call to source() | test.swift:503:14:503:34 | call to mkOptional1(_:) [some:0] |
-| test.swift:505:14:505:34 | call to mkOptional2(_:) [some:0] | test.swift:511:15:511:15 | e6 [some:0] |
-| test.swift:505:26:505:33 | call to source() | test.swift:505:14:505:34 | call to mkOptional2(_:) [some:0] |
-| test.swift:507:15:507:15 | e2 [some:0] | test.swift:507:15:507:17 | ...! |
-| test.swift:509:15:509:15 | e4 [some:0] | test.swift:509:15:509:17 | ...! |
-| test.swift:511:15:511:15 | e6 [some:0] | test.swift:511:15:511:17 | ...! |
-| test.swift:517:13:517:28 | call to optionalSource() [some:0] | test.swift:519:8:519:12 | let ...? [some:0] |
-| test.swift:517:13:517:28 | call to optionalSource() [some:0] | test.swift:524:19:524:19 | x [some:0] |
-| test.swift:519:8:519:12 | let ...? [some:0] | test.swift:519:12:519:12 | a |
-| test.swift:519:12:519:12 | a | test.swift:520:19:520:19 | a |
-| test.swift:524:18:524:23 | (...) [Tuple element at index 0, some:0] | test.swift:526:10:526:37 | (...) [Tuple element at index 0, some:0] |
-| test.swift:524:19:524:19 | x [some:0] | test.swift:524:18:524:23 | (...) [Tuple element at index 0, some:0] |
-| test.swift:526:10:526:37 | (...) [Tuple element at index 0, some:0] | test.swift:526:11:526:22 | .some(...) [some:0] |
-| test.swift:526:11:526:22 | .some(...) [some:0] | test.swift:526:21:526:21 | a |
-| test.swift:526:21:526:21 | a | test.swift:527:19:527:19 | a |
-| test.swift:540:9:540:9 | self [x, some:0] | file://:0:0:0:0 | self [x, some:0] |
-| test.swift:540:9:540:9 | value [some:0] | file://:0:0:0:0 | value [some:0] |
-| test.swift:544:13:544:28 | call to optionalSource() [some:0] | test.swift:546:12:546:12 | x [some:0] |
-| test.swift:546:5:546:5 | [post] cx [x, some:0] | test.swift:550:20:550:20 | cx [x, some:0] |
-| test.swift:546:12:546:12 | x [some:0] | test.swift:540:9:540:9 | value [some:0] |
-| test.swift:546:12:546:12 | x [some:0] | test.swift:546:5:546:5 | [post] cx [x, some:0] |
-| test.swift:550:11:550:15 | let ...? [some:0] | test.swift:550:15:550:15 | z1 |
-| test.swift:550:15:550:15 | z1 | test.swift:551:15:551:15 | z1 |
-| test.swift:550:20:550:20 | cx [x, some:0] | test.swift:540:9:540:9 | self [x, some:0] |
-| test.swift:550:20:550:20 | cx [x, some:0] | test.swift:550:20:550:23 | .x [some:0] |
-| test.swift:550:20:550:23 | .x [some:0] | test.swift:550:11:550:15 | let ...? [some:0] |
-| test.swift:557:14:557:21 | call to source() | test.swift:557:13:557:21 | call to +(_:) |
-| test.swift:566:9:566:9 | self [str] | file://:0:0:0:0 | self [str] |
-| test.swift:567:10:567:13 | s | test.swift:568:13:568:13 | s |
-| test.swift:568:7:568:7 | [post] self [str] | test.swift:567:5:569:5 | self[return] [str] |
-| test.swift:568:13:568:13 | s | test.swift:568:7:568:7 | [post] self [str] |
-| test.swift:573:17:576:5 | self[return] [str] | test.swift:581:13:581:41 | call to MyClass.init(contentsOfFile:) [str] |
-| test.swift:574:7:574:7 | [post] self [str] | test.swift:573:17:576:5 | self[return] [str] |
-| test.swift:574:7:574:7 | [post] self [str] | test.swift:575:17:575:17 | self [str] |
-| test.swift:574:20:574:28 | call to source3() | test.swift:567:10:567:13 | s |
-| test.swift:574:20:574:28 | call to source3() | test.swift:574:7:574:7 | [post] self [str] |
-| test.swift:575:17:575:17 | self [str] | test.swift:575:17:575:17 | .str |
-| test.swift:580:13:580:33 | call to MyClass.init(s:) [str] | test.swift:566:9:566:9 | self [str] |
-| test.swift:580:13:580:33 | call to MyClass.init(s:) [str] | test.swift:580:13:580:35 | .str |
-| test.swift:580:24:580:32 | call to source3() | test.swift:567:10:567:13 | s |
-| test.swift:580:24:580:32 | call to source3() | test.swift:580:13:580:33 | call to MyClass.init(s:) [str] |
-| test.swift:581:13:581:41 | call to MyClass.init(contentsOfFile:) [str] | test.swift:566:9:566:9 | self [str] |
-| test.swift:581:13:581:41 | call to MyClass.init(contentsOfFile:) [str] | test.swift:581:13:581:43 | .str |
-| test.swift:598:8:598:11 | x | test.swift:599:14:599:14 | x |
-| test.swift:599:5:599:5 | [post] self [x] | test.swift:598:3:600:3 | self[return] [x] |
-| test.swift:599:14:599:14 | x | test.swift:599:5:599:5 | [post] self [x] |
-| test.swift:604:11:604:24 | call to S.init(x:) [x] | test.swift:606:13:606:13 | s [x] |
-| test.swift:604:11:604:24 | call to S.init(x:) [x] | test.swift:609:13:609:13 | s [x] |
-| test.swift:604:16:604:23 | call to source() | test.swift:598:8:598:11 | x |
-| test.swift:604:16:604:23 | call to source() | test.swift:604:11:604:24 | call to S.init(x:) [x] |
-| test.swift:605:11:605:14 | enter #keyPath(...) [x] | test.swift:605:14:605:14 | KeyPathComponent [x] |
-| test.swift:605:14:605:14 | KeyPathComponent [x] | test.swift:605:11:605:14 | exit #keyPath(...) |
-| test.swift:606:13:606:13 | s [x] | test.swift:605:11:605:14 | enter #keyPath(...) [x] |
-| test.swift:606:13:606:13 | s [x] | test.swift:606:13:606:25 | \\...[...] |
-| test.swift:608:36:608:38 | enter #keyPath(...) [x] | test.swift:608:38:608:38 | KeyPathComponent [x] |
-| test.swift:608:38:608:38 | KeyPathComponent [x] | test.swift:608:36:608:38 | exit #keyPath(...) |
-| test.swift:609:13:609:13 | s [x] | test.swift:608:36:608:38 | enter #keyPath(...) [x] |
-| test.swift:609:13:609:13 | s [x] | test.swift:609:13:609:32 | \\...[...] |
-| test.swift:615:8:615:11 | s [x] | test.swift:616:14:616:14 | s [x] |
-| test.swift:616:5:616:5 | [post] self [s, x] | test.swift:615:3:617:3 | self[return] [s, x] |
-| test.swift:616:14:616:14 | s [x] | test.swift:616:5:616:5 | [post] self [s, x] |
-| test.swift:621:11:621:24 | call to S.init(x:) [x] | test.swift:622:18:622:18 | s [x] |
-| test.swift:621:16:621:23 | call to source() | test.swift:598:8:598:11 | x |
-| test.swift:621:16:621:23 | call to source() | test.swift:621:11:621:24 | call to S.init(x:) [x] |
-| test.swift:622:12:622:19 | call to S2.init(s:) [s, x] | test.swift:624:13:624:13 | s2 [s, x] |
-| test.swift:622:18:622:18 | s [x] | test.swift:615:8:615:11 | s [x] |
-| test.swift:622:18:622:18 | s [x] | test.swift:622:12:622:19 | call to S2.init(s:) [s, x] |
-| test.swift:623:11:623:17 | enter #keyPath(...) [s, x] | test.swift:623:15:623:15 | KeyPathComponent [s, x] |
-| test.swift:623:15:623:15 | KeyPathComponent [s, x] | test.swift:623:17:623:17 | KeyPathComponent [x] |
-| test.swift:623:17:623:17 | KeyPathComponent [x] | test.swift:623:11:623:17 | exit #keyPath(...) |
-| test.swift:624:13:624:13 | s2 [s, x] | test.swift:623:11:623:17 | enter #keyPath(...) [s, x] |
-| test.swift:624:13:624:13 | s2 [s, x] | test.swift:624:13:624:26 | \\...[...] |
-| test.swift:628:17:628:26 | [...] [Array element] | test.swift:630:15:630:15 | array [Array element] |
-| test.swift:628:18:628:25 | call to source() | test.swift:628:17:628:26 | [...] [Array element] |
-| test.swift:629:13:629:22 | enter #keyPath(...) [Array element] | test.swift:629:20:629:22 | KeyPathComponent [Array element] |
-| test.swift:629:20:629:22 | KeyPathComponent [Array element] | test.swift:629:13:629:22 | exit #keyPath(...) |
-| test.swift:630:15:630:15 | array [Array element] | test.swift:629:13:629:22 | enter #keyPath(...) [Array element] |
-| test.swift:630:15:630:15 | array [Array element] | test.swift:630:15:630:31 | \\...[...] |
-| test.swift:649:13:649:20 | call to source() | test.swift:657:15:657:15 | y |
-| test.swift:659:9:659:16 | call to source() | test.swift:661:11:661:11 | x |
-| test.swift:659:9:659:16 | call to source() | test.swift:662:15:662:15 | x |
-| test.swift:661:11:661:11 | x | test.swift:661:15:661:15 | [post] y |
-| test.swift:661:15:661:15 | [post] y | test.swift:663:15:663:15 | y |
-| test.swift:669:5:669:5 | [post] arr1 [Array element] | test.swift:670:15:670:15 | arr1 [Array element] |
-| test.swift:669:15:669:22 | call to source() | test.swift:669:5:669:5 | [post] arr1 [Array element] |
-| test.swift:670:15:670:15 | arr1 [Array element] | test.swift:670:15:670:21 | ...[...] |
-| test.swift:673:16:673:25 | [...] [Array element] | test.swift:674:15:674:15 | arr2 [Array element] |
-| test.swift:673:17:673:24 | call to source() | test.swift:673:16:673:25 | [...] [Array element] |
-| test.swift:674:15:674:15 | arr2 [Array element] | test.swift:674:15:674:21 | ...[...] |
-| test.swift:676:18:676:29 | [...] [Array element, Array element] | test.swift:678:15:678:15 | matrix [Array element, Array element] |
-| test.swift:676:19:676:28 | [...] [Array element] | test.swift:676:18:676:29 | [...] [Array element, Array element] |
-| test.swift:676:20:676:27 | call to source() | test.swift:676:19:676:28 | [...] [Array element] |
-| test.swift:678:15:678:15 | matrix [Array element, Array element] | test.swift:678:15:678:23 | ...[...] [Array element] |
-| test.swift:678:15:678:23 | ...[...] [Array element] | test.swift:678:15:678:26 | ...[...] |
-| test.swift:681:5:681:5 | [post] matrix2 [Array element, Array element] | test.swift:682:15:682:15 | matrix2 [Array element, Array element] |
-| test.swift:681:5:681:14 | [post] getter for ...[...] [Array element] | test.swift:681:5:681:5 | [post] matrix2 [Array element, Array element] |
-| test.swift:681:21:681:28 | call to source() | test.swift:681:5:681:14 | [post] getter for ...[...] [Array element] |
-| test.swift:682:15:682:15 | matrix2 [Array element, Array element] | test.swift:682:15:682:24 | ...[...] [Array element] |
-| test.swift:682:15:682:24 | ...[...] [Array element] | test.swift:682:15:682:27 | ...[...] |
-| test.swift:693:5:693:5 | [post] arr6 [Array element] | test.swift:694:15:694:15 | arr6 [Array element] |
-| test.swift:693:17:693:24 | call to source() | test.swift:693:5:693:5 | [post] arr6 [Array element] |
-| test.swift:694:15:694:15 | arr6 [Array element] | test.swift:694:15:694:21 | ...[...] |
-| test.swift:696:16:696:25 | [...] [Array element] | test.swift:697:15:697:15 | arr7 [Array element] |
-| test.swift:696:17:696:24 | call to source() | test.swift:696:16:696:25 | [...] [Array element] |
-| test.swift:697:15:697:15 | arr7 [Array element] | test.swift:697:15:697:34 | call to randomElement() [some:0] |
-| test.swift:697:15:697:34 | call to randomElement() [some:0] | test.swift:697:15:697:35 | ...! |
-| test.swift:703:5:703:5 | [post] set1 [Collection element] | test.swift:704:15:704:15 | set1 [Collection element] |
-| test.swift:703:17:703:24 | call to source() | test.swift:703:5:703:5 | [post] set1 [Collection element] |
-| test.swift:704:15:704:15 | set1 [Collection element] | test.swift:704:15:704:34 | call to randomElement() [some:0] |
-| test.swift:704:15:704:34 | call to randomElement() [some:0] | test.swift:704:15:704:35 | ...! |
-| test.swift:706:16:706:30 | call to Set<Element>.init(_:) [Collection element] | test.swift:707:15:707:15 | set2 [Collection element] |
-| test.swift:706:20:706:29 | [...] [Array element] | test.swift:706:16:706:30 | call to Set<Element>.init(_:) [Collection element] |
-| test.swift:706:21:706:28 | call to source() | test.swift:706:20:706:29 | [...] [Array element] |
-| test.swift:707:15:707:15 | set2 [Collection element] | test.swift:707:15:707:34 | call to randomElement() [some:0] |
-| test.swift:707:15:707:34 | call to randomElement() [some:0] | test.swift:707:15:707:35 | ...! |
-| test.swift:712:9:712:9 | self [v2, some:0] | file://:0:0:0:0 | self [v2, some:0] |
-| test.swift:712:9:712:9 | self [v2] | file://:0:0:0:0 | self [v2] |
-| test.swift:712:9:712:9 | value | file://:0:0:0:0 | value |
-| test.swift:712:9:712:9 | value [some:0] | file://:0:0:0:0 | value [some:0] |
-| test.swift:713:9:713:9 | self [v3] | file://:0:0:0:0 | self [v3] |
-| test.swift:713:9:713:9 | value | file://:0:0:0:0 | value |
-| test.swift:723:5:723:5 | v1 [some:0] | test.swift:733:15:733:15 | v1 [some:0] |
-| test.swift:723:11:723:18 | call to source() | test.swift:723:5:723:5 | v1 [some:0] |
-| test.swift:724:10:724:17 | call to source() | test.swift:724:10:724:17 | call to source() [some:0] |
-| test.swift:724:10:724:17 | call to source() | test.swift:734:15:734:17 | ...! |
-| test.swift:724:10:724:17 | call to source() [some:0] | test.swift:734:15:734:15 | v2 [some:0] |
-| test.swift:725:10:725:17 | call to source() | test.swift:735:15:735:15 | v3 |
-| test.swift:727:5:727:5 | [post] mo1 [v2, some:0] | test.swift:728:5:728:5 | mo1 [v2, some:0] |
-| test.swift:727:5:727:5 | [post] mo1 [v2] | test.swift:728:5:728:5 | mo1 [v2] |
-| test.swift:727:14:727:21 | call to source() | test.swift:712:9:712:9 | value |
-| test.swift:727:14:727:21 | call to source() | test.swift:727:5:727:5 | [post] mo1 [v2] |
-| test.swift:727:14:727:21 | call to source() | test.swift:727:14:727:21 | call to source() [some:0] |
-| test.swift:727:14:727:21 | call to source() [some:0] | test.swift:712:9:712:9 | value [some:0] |
-| test.swift:727:14:727:21 | call to source() [some:0] | test.swift:727:5:727:5 | [post] mo1 [v2, some:0] |
-| test.swift:728:5:728:5 | [post] mo1 [v3] | test.swift:738:15:738:15 | mo1 [v3] |
-| test.swift:728:5:728:5 | mo1 [v2, some:0] | test.swift:737:15:737:15 | mo1 [v2, some:0] |
-| test.swift:728:5:728:5 | mo1 [v2] | test.swift:737:15:737:15 | mo1 [v2] |
-| test.swift:728:14:728:21 | call to source() | test.swift:713:9:713:9 | value |
-| test.swift:728:14:728:21 | call to source() | test.swift:728:5:728:5 | [post] mo1 [v3] |
-| test.swift:733:15:733:15 | v1 [some:0] | test.swift:733:15:733:17 | ...! |
-| test.swift:734:15:734:15 | v2 [some:0] | test.swift:734:15:734:17 | ...! |
-| test.swift:737:15:737:15 | mo1 [v2, some:0] | test.swift:712:9:712:9 | self [v2, some:0] |
-| test.swift:737:15:737:15 | mo1 [v2, some:0] | test.swift:737:15:737:19 | .v2 [some:0] |
-| test.swift:737:15:737:15 | mo1 [v2] | test.swift:712:9:712:9 | self [v2] |
-| test.swift:737:15:737:15 | mo1 [v2] | test.swift:737:15:737:19 | .v2 |
-| test.swift:737:15:737:19 | .v2 | test.swift:737:15:737:21 | ...! |
-| test.swift:737:15:737:19 | .v2 [some:0] | test.swift:737:15:737:21 | ...! |
-| test.swift:738:15:738:15 | mo1 [v3] | test.swift:713:9:713:9 | self [v3] |
-| test.swift:738:15:738:15 | mo1 [v3] | test.swift:738:15:738:19 | .v3 |
+| test.swift:368:22:368:36 | t [Tuple element at index 1] | test.swift:369:13:369:13 | t [Tuple element at index 1] |
+| test.swift:369:13:369:13 | t [Tuple element at index 1] | test.swift:369:13:369:15 | .1 |
+| test.swift:369:13:369:15 | .1 | test.swift:369:12:369:19 | (...) [Tuple element at index 0] |
+| test.swift:375:14:375:26 | (...) [Tuple element at index 1] | test.swift:376:30:376:30 | t1 [Tuple element at index 1] |
+| test.swift:375:14:375:26 | (...) [Tuple element at index 1] | test.swift:380:15:380:15 | t1 [Tuple element at index 1] |
+| test.swift:375:18:375:25 | call to source() | test.swift:375:14:375:26 | (...) [Tuple element at index 1] |
+| test.swift:376:14:376:32 | call to tupleShiftLeft1(_:) [Tuple element at index 0] | test.swift:381:15:381:15 | t2 [Tuple element at index 0] |
+| test.swift:376:30:376:30 | t1 [Tuple element at index 1] | test.swift:368:22:368:36 | t [Tuple element at index 1] |
+| test.swift:376:30:376:30 | t1 [Tuple element at index 1] | test.swift:376:14:376:32 | call to tupleShiftLeft1(_:) [Tuple element at index 0] |
+| test.swift:380:15:380:15 | t1 [Tuple element at index 1] | test.swift:380:15:380:18 | .1 |
+| test.swift:381:15:381:15 | t2 [Tuple element at index 0] | test.swift:381:15:381:18 | .0 |
+| test.swift:394:16:394:21 | v | test.swift:394:61:394:61 | v |
+| test.swift:394:61:394:61 | v | test.swift:394:45:394:62 | call to ... [mySingle:0] |
+| test.swift:396:18:396:23 | v | test.swift:396:59:396:59 | v |
+| test.swift:396:59:396:59 | v | test.swift:396:45:396:60 | call to ... [some:0] |
+| test.swift:422:9:422:27 | call to ... [mySingle:0] | test.swift:427:10:427:25 | .mySingle(...) [mySingle:0] |
+| test.swift:422:9:422:27 | call to ... [mySingle:0] | test.swift:436:13:436:28 | .mySingle(...) [mySingle:0] |
+| test.swift:422:19:422:26 | call to source() | test.swift:422:9:422:27 | call to ... [mySingle:0] |
+| test.swift:427:10:427:25 | .mySingle(...) [mySingle:0] | test.swift:427:24:427:24 | a |
+| test.swift:427:24:427:24 | a | test.swift:428:19:428:19 | a |
+| test.swift:436:13:436:28 | .mySingle(...) [mySingle:0] | test.swift:436:27:436:27 | x |
+| test.swift:436:27:436:27 | x | test.swift:437:19:437:19 | x |
+| test.swift:444:9:444:34 | call to ... [myPair:1] | test.swift:451:10:451:30 | .myPair(...) [myPair:1] |
+| test.swift:444:9:444:34 | call to ... [myPair:1] | test.swift:461:13:461:33 | .myPair(...) [myPair:1] |
+| test.swift:444:9:444:34 | call to ... [myPair:1] | test.swift:466:33:466:33 | a [myPair:1] |
+| test.swift:444:9:444:34 | call to ... [myPair:1] | test.swift:495:13:495:13 | a [myPair:1] |
+| test.swift:444:26:444:33 | call to source() | test.swift:444:9:444:34 | call to ... [myPair:1] |
+| test.swift:451:10:451:30 | .myPair(...) [myPair:1] | test.swift:451:29:451:29 | b |
+| test.swift:451:29:451:29 | b | test.swift:453:19:453:19 | b |
+| test.swift:461:13:461:33 | .myPair(...) [myPair:1] | test.swift:461:32:461:32 | y |
+| test.swift:461:32:461:32 | y | test.swift:463:19:463:19 | y |
+| test.swift:466:21:466:34 | call to ... [myCons:1, myPair:1] | test.swift:476:14:476:38 | .myCons(...) [myCons:1, myPair:1] |
+| test.swift:466:21:466:34 | call to ... [myCons:1, myPair:1] | test.swift:491:17:491:41 | .myCons(...) [myCons:1, myPair:1] |
+| test.swift:466:21:466:34 | call to ... [myCons:1, myPair:1] | test.swift:495:16:495:16 | b [myCons:1, myPair:1] |
+| test.swift:466:33:466:33 | a [myPair:1] | test.swift:466:21:466:34 | call to ... [myCons:1, myPair:1] |
+| test.swift:476:14:476:38 | .myCons(...) [myCons:1, myPair:1] | test.swift:476:25:476:37 | .myPair(...) [myPair:1] |
+| test.swift:476:25:476:37 | .myPair(...) [myPair:1] | test.swift:476:36:476:36 | c |
+| test.swift:476:36:476:36 | c | test.swift:479:19:479:19 | c |
+| test.swift:487:13:487:39 | .myPair(...) [myPair:0] | test.swift:487:31:487:31 | x |
+| test.swift:487:31:487:31 | x | test.swift:488:19:488:19 | x |
+| test.swift:487:43:487:62 | call to ... [myPair:0] | test.swift:487:13:487:39 | .myPair(...) [myPair:0] |
+| test.swift:487:51:487:58 | call to source() | test.swift:487:43:487:62 | call to ... [myPair:0] |
+| test.swift:491:17:491:41 | .myCons(...) [myCons:1, myPair:1] | test.swift:491:28:491:40 | .myPair(...) [myPair:1] |
+| test.swift:491:28:491:40 | .myPair(...) [myPair:1] | test.swift:491:39:491:39 | c |
+| test.swift:491:39:491:39 | c | test.swift:492:19:492:19 | c |
+| test.swift:495:12:495:17 | (...) [Tuple element at index 0, myPair:1] | test.swift:496:14:496:55 | (...) [Tuple element at index 0, myPair:1] |
+| test.swift:495:12:495:17 | (...) [Tuple element at index 1, myCons:1, myPair:1] | test.swift:496:14:496:55 | (...) [Tuple element at index 1, myCons:1, myPair:1] |
+| test.swift:495:13:495:13 | a [myPair:1] | test.swift:495:12:495:17 | (...) [Tuple element at index 0, myPair:1] |
+| test.swift:495:16:495:16 | b [myCons:1, myPair:1] | test.swift:495:12:495:17 | (...) [Tuple element at index 1, myCons:1, myPair:1] |
+| test.swift:496:14:496:55 | (...) [Tuple element at index 0, myPair:1] | test.swift:496:15:496:27 | .myPair(...) [myPair:1] |
+| test.swift:496:14:496:55 | (...) [Tuple element at index 1, myCons:1, myPair:1] | test.swift:496:30:496:54 | .myCons(...) [myCons:1, myPair:1] |
+| test.swift:496:15:496:27 | .myPair(...) [myPair:1] | test.swift:496:26:496:26 | b |
+| test.swift:496:26:496:26 | b | test.swift:498:19:498:19 | b |
+| test.swift:496:30:496:54 | .myCons(...) [myCons:1, myPair:1] | test.swift:496:41:496:53 | .myPair(...) [myPair:1] |
+| test.swift:496:41:496:53 | .myPair(...) [myPair:1] | test.swift:496:52:496:52 | e |
+| test.swift:496:52:496:52 | e | test.swift:501:19:501:19 | e |
+| test.swift:507:14:507:38 | call to ... [mySingle:0] | test.swift:513:13:513:35 | .mySingle(...) [mySingle:0] |
+| test.swift:507:30:507:37 | call to source() | test.swift:507:14:507:38 | call to ... [mySingle:0] |
+| test.swift:509:14:509:32 | call to mkMyEnum1(_:) [mySingle:0] | test.swift:515:13:515:35 | .mySingle(...) [mySingle:0] |
+| test.swift:509:24:509:31 | call to source() | test.swift:394:16:394:21 | v |
+| test.swift:509:24:509:31 | call to source() | test.swift:509:14:509:32 | call to mkMyEnum1(_:) [mySingle:0] |
+| test.swift:511:14:511:32 | call to mkMyEnum2(_:) [mySingle:0] | test.swift:517:13:517:35 | .mySingle(...) [mySingle:0] |
+| test.swift:511:24:511:31 | call to source() | test.swift:511:14:511:32 | call to mkMyEnum2(_:) [mySingle:0] |
+| test.swift:513:13:513:35 | .mySingle(...) [mySingle:0] | test.swift:513:33:513:33 | d2 |
+| test.swift:513:33:513:33 | d2 | test.swift:513:54:513:54 | d2 |
+| test.swift:515:13:515:35 | .mySingle(...) [mySingle:0] | test.swift:515:33:515:33 | d4 |
+| test.swift:515:33:515:33 | d4 | test.swift:515:54:515:54 | d4 |
+| test.swift:517:13:517:35 | .mySingle(...) [mySingle:0] | test.swift:517:33:517:33 | d6 |
+| test.swift:517:33:517:33 | d6 | test.swift:517:54:517:54 | d6 |
+| test.swift:520:14:520:36 | call to ... [some:0] | test.swift:526:15:526:15 | e2 [some:0] |
+| test.swift:520:28:520:35 | call to source() | test.swift:520:14:520:36 | call to ... [some:0] |
+| test.swift:522:14:522:34 | call to mkOptional1(_:) [some:0] | test.swift:528:15:528:15 | e4 [some:0] |
+| test.swift:522:26:522:33 | call to source() | test.swift:396:18:396:23 | v |
+| test.swift:522:26:522:33 | call to source() | test.swift:522:14:522:34 | call to mkOptional1(_:) [some:0] |
+| test.swift:524:14:524:34 | call to mkOptional2(_:) [some:0] | test.swift:530:15:530:15 | e6 [some:0] |
+| test.swift:524:26:524:33 | call to source() | test.swift:524:14:524:34 | call to mkOptional2(_:) [some:0] |
+| test.swift:526:15:526:15 | e2 [some:0] | test.swift:526:15:526:17 | ...! |
+| test.swift:528:15:528:15 | e4 [some:0] | test.swift:528:15:528:17 | ...! |
+| test.swift:530:15:530:15 | e6 [some:0] | test.swift:530:15:530:17 | ...! |
+| test.swift:536:13:536:28 | call to optionalSource() [some:0] | test.swift:538:8:538:12 | let ...? [some:0] |
+| test.swift:536:13:536:28 | call to optionalSource() [some:0] | test.swift:543:19:543:19 | x [some:0] |
+| test.swift:538:8:538:12 | let ...? [some:0] | test.swift:538:12:538:12 | a |
+| test.swift:538:12:538:12 | a | test.swift:539:19:539:19 | a |
+| test.swift:543:18:543:23 | (...) [Tuple element at index 0, some:0] | test.swift:545:10:545:37 | (...) [Tuple element at index 0, some:0] |
+| test.swift:543:19:543:19 | x [some:0] | test.swift:543:18:543:23 | (...) [Tuple element at index 0, some:0] |
+| test.swift:545:10:545:37 | (...) [Tuple element at index 0, some:0] | test.swift:545:11:545:22 | .some(...) [some:0] |
+| test.swift:545:11:545:22 | .some(...) [some:0] | test.swift:545:21:545:21 | a |
+| test.swift:545:21:545:21 | a | test.swift:546:19:546:19 | a |
+| test.swift:559:9:559:9 | self [x, some:0] | file://:0:0:0:0 | self [x, some:0] |
+| test.swift:559:9:559:9 | value [some:0] | file://:0:0:0:0 | value [some:0] |
+| test.swift:563:13:563:28 | call to optionalSource() [some:0] | test.swift:565:12:565:12 | x [some:0] |
+| test.swift:565:5:565:5 | [post] cx [x, some:0] | test.swift:569:20:569:20 | cx [x, some:0] |
+| test.swift:565:12:565:12 | x [some:0] | test.swift:559:9:559:9 | value [some:0] |
+| test.swift:565:12:565:12 | x [some:0] | test.swift:565:5:565:5 | [post] cx [x, some:0] |
+| test.swift:569:11:569:15 | let ...? [some:0] | test.swift:569:15:569:15 | z1 |
+| test.swift:569:15:569:15 | z1 | test.swift:570:15:570:15 | z1 |
+| test.swift:569:20:569:20 | cx [x, some:0] | test.swift:559:9:559:9 | self [x, some:0] |
+| test.swift:569:20:569:20 | cx [x, some:0] | test.swift:569:20:569:23 | .x [some:0] |
+| test.swift:569:20:569:23 | .x [some:0] | test.swift:569:11:569:15 | let ...? [some:0] |
+| test.swift:576:14:576:21 | call to source() | test.swift:576:13:576:21 | call to +(_:) |
+| test.swift:585:9:585:9 | self [str] | file://:0:0:0:0 | self [str] |
+| test.swift:586:10:586:13 | s | test.swift:587:13:587:13 | s |
+| test.swift:587:7:587:7 | [post] self [str] | test.swift:586:5:588:5 | self[return] [str] |
+| test.swift:587:13:587:13 | s | test.swift:587:7:587:7 | [post] self [str] |
+| test.swift:592:17:595:5 | self[return] [str] | test.swift:600:13:600:41 | call to MyClass.init(contentsOfFile:) [str] |
+| test.swift:593:7:593:7 | [post] self [str] | test.swift:592:17:595:5 | self[return] [str] |
+| test.swift:593:7:593:7 | [post] self [str] | test.swift:594:17:594:17 | self [str] |
+| test.swift:593:20:593:28 | call to source3() | test.swift:586:10:586:13 | s |
+| test.swift:593:20:593:28 | call to source3() | test.swift:593:7:593:7 | [post] self [str] |
+| test.swift:594:17:594:17 | self [str] | test.swift:594:17:594:17 | .str |
+| test.swift:599:13:599:33 | call to MyClass.init(s:) [str] | test.swift:585:9:585:9 | self [str] |
+| test.swift:599:13:599:33 | call to MyClass.init(s:) [str] | test.swift:599:13:599:35 | .str |
+| test.swift:599:24:599:32 | call to source3() | test.swift:586:10:586:13 | s |
+| test.swift:599:24:599:32 | call to source3() | test.swift:599:13:599:33 | call to MyClass.init(s:) [str] |
+| test.swift:600:13:600:41 | call to MyClass.init(contentsOfFile:) [str] | test.swift:585:9:585:9 | self [str] |
+| test.swift:600:13:600:41 | call to MyClass.init(contentsOfFile:) [str] | test.swift:600:13:600:43 | .str |
+| test.swift:617:8:617:11 | x | test.swift:618:14:618:14 | x |
+| test.swift:618:5:618:5 | [post] self [x] | test.swift:617:3:619:3 | self[return] [x] |
+| test.swift:618:14:618:14 | x | test.swift:618:5:618:5 | [post] self [x] |
+| test.swift:623:11:623:24 | call to S.init(x:) [x] | test.swift:625:13:625:13 | s [x] |
+| test.swift:623:11:623:24 | call to S.init(x:) [x] | test.swift:628:13:628:13 | s [x] |
+| test.swift:623:16:623:23 | call to source() | test.swift:617:8:617:11 | x |
+| test.swift:623:16:623:23 | call to source() | test.swift:623:11:623:24 | call to S.init(x:) [x] |
+| test.swift:624:11:624:14 | enter #keyPath(...) [x] | test.swift:624:14:624:14 | KeyPathComponent [x] |
+| test.swift:624:14:624:14 | KeyPathComponent [x] | test.swift:624:11:624:14 | exit #keyPath(...) |
+| test.swift:625:13:625:13 | s [x] | test.swift:624:11:624:14 | enter #keyPath(...) [x] |
+| test.swift:625:13:625:13 | s [x] | test.swift:625:13:625:25 | \\...[...] |
+| test.swift:627:36:627:38 | enter #keyPath(...) [x] | test.swift:627:38:627:38 | KeyPathComponent [x] |
+| test.swift:627:38:627:38 | KeyPathComponent [x] | test.swift:627:36:627:38 | exit #keyPath(...) |
+| test.swift:628:13:628:13 | s [x] | test.swift:627:36:627:38 | enter #keyPath(...) [x] |
+| test.swift:628:13:628:13 | s [x] | test.swift:628:13:628:32 | \\...[...] |
+| test.swift:634:8:634:11 | s [x] | test.swift:635:14:635:14 | s [x] |
+| test.swift:635:5:635:5 | [post] self [s, x] | test.swift:634:3:636:3 | self[return] [s, x] |
+| test.swift:635:14:635:14 | s [x] | test.swift:635:5:635:5 | [post] self [s, x] |
+| test.swift:640:11:640:24 | call to S.init(x:) [x] | test.swift:641:18:641:18 | s [x] |
+| test.swift:640:16:640:23 | call to source() | test.swift:617:8:617:11 | x |
+| test.swift:640:16:640:23 | call to source() | test.swift:640:11:640:24 | call to S.init(x:) [x] |
+| test.swift:641:12:641:19 | call to S2.init(s:) [s, x] | test.swift:643:13:643:13 | s2 [s, x] |
+| test.swift:641:18:641:18 | s [x] | test.swift:634:8:634:11 | s [x] |
+| test.swift:641:18:641:18 | s [x] | test.swift:641:12:641:19 | call to S2.init(s:) [s, x] |
+| test.swift:642:11:642:17 | enter #keyPath(...) [s, x] | test.swift:642:15:642:15 | KeyPathComponent [s, x] |
+| test.swift:642:15:642:15 | KeyPathComponent [s, x] | test.swift:642:17:642:17 | KeyPathComponent [x] |
+| test.swift:642:17:642:17 | KeyPathComponent [x] | test.swift:642:11:642:17 | exit #keyPath(...) |
+| test.swift:643:13:643:13 | s2 [s, x] | test.swift:642:11:642:17 | enter #keyPath(...) [s, x] |
+| test.swift:643:13:643:13 | s2 [s, x] | test.swift:643:13:643:26 | \\...[...] |
+| test.swift:647:17:647:26 | [...] [Array element] | test.swift:649:15:649:15 | array [Array element] |
+| test.swift:647:18:647:25 | call to source() | test.swift:647:17:647:26 | [...] [Array element] |
+| test.swift:648:13:648:22 | enter #keyPath(...) [Array element] | test.swift:648:20:648:22 | KeyPathComponent [Array element] |
+| test.swift:648:20:648:22 | KeyPathComponent [Array element] | test.swift:648:13:648:22 | exit #keyPath(...) |
+| test.swift:649:15:649:15 | array [Array element] | test.swift:648:13:648:22 | enter #keyPath(...) [Array element] |
+| test.swift:649:15:649:15 | array [Array element] | test.swift:649:15:649:31 | \\...[...] |
+| test.swift:668:13:668:20 | call to source() | test.swift:676:15:676:15 | y |
+| test.swift:678:9:678:16 | call to source() | test.swift:680:11:680:11 | x |
+| test.swift:678:9:678:16 | call to source() | test.swift:681:15:681:15 | x |
+| test.swift:680:11:680:11 | x | test.swift:680:15:680:15 | [post] y |
+| test.swift:680:15:680:15 | [post] y | test.swift:682:15:682:15 | y |
+| test.swift:688:5:688:5 | [post] arr1 [Array element] | test.swift:689:15:689:15 | arr1 [Array element] |
+| test.swift:688:15:688:22 | call to source() | test.swift:688:5:688:5 | [post] arr1 [Array element] |
+| test.swift:689:15:689:15 | arr1 [Array element] | test.swift:689:15:689:21 | ...[...] |
+| test.swift:692:16:692:25 | [...] [Array element] | test.swift:693:15:693:15 | arr2 [Array element] |
+| test.swift:692:17:692:24 | call to source() | test.swift:692:16:692:25 | [...] [Array element] |
+| test.swift:693:15:693:15 | arr2 [Array element] | test.swift:693:15:693:21 | ...[...] |
+| test.swift:695:18:695:29 | [...] [Array element, Array element] | test.swift:697:15:697:15 | matrix [Array element, Array element] |
+| test.swift:695:19:695:28 | [...] [Array element] | test.swift:695:18:695:29 | [...] [Array element, Array element] |
+| test.swift:695:20:695:27 | call to source() | test.swift:695:19:695:28 | [...] [Array element] |
+| test.swift:697:15:697:15 | matrix [Array element, Array element] | test.swift:697:15:697:23 | ...[...] [Array element] |
+| test.swift:697:15:697:23 | ...[...] [Array element] | test.swift:697:15:697:26 | ...[...] |
+| test.swift:700:5:700:5 | [post] matrix2 [Array element, Array element] | test.swift:701:15:701:15 | matrix2 [Array element, Array element] |
+| test.swift:700:5:700:14 | [post] getter for ...[...] [Array element] | test.swift:700:5:700:5 | [post] matrix2 [Array element, Array element] |
+| test.swift:700:21:700:28 | call to source() | test.swift:700:5:700:14 | [post] getter for ...[...] [Array element] |
+| test.swift:701:15:701:15 | matrix2 [Array element, Array element] | test.swift:701:15:701:24 | ...[...] [Array element] |
+| test.swift:701:15:701:24 | ...[...] [Array element] | test.swift:701:15:701:27 | ...[...] |
+| test.swift:712:5:712:5 | [post] arr6 [Array element] | test.swift:713:15:713:15 | arr6 [Array element] |
+| test.swift:712:17:712:24 | call to source() | test.swift:712:5:712:5 | [post] arr6 [Array element] |
+| test.swift:713:15:713:15 | arr6 [Array element] | test.swift:713:15:713:21 | ...[...] |
+| test.swift:715:16:715:25 | [...] [Array element] | test.swift:716:15:716:15 | arr7 [Array element] |
+| test.swift:715:17:715:24 | call to source() | test.swift:715:16:715:25 | [...] [Array element] |
+| test.swift:716:15:716:15 | arr7 [Array element] | test.swift:716:15:716:34 | call to randomElement() [some:0] |
+| test.swift:716:15:716:34 | call to randomElement() [some:0] | test.swift:716:15:716:35 | ...! |
+| test.swift:722:5:722:5 | [post] set1 [Collection element] | test.swift:723:15:723:15 | set1 [Collection element] |
+| test.swift:722:17:722:24 | call to source() | test.swift:722:5:722:5 | [post] set1 [Collection element] |
+| test.swift:723:15:723:15 | set1 [Collection element] | test.swift:723:15:723:34 | call to randomElement() [some:0] |
+| test.swift:723:15:723:34 | call to randomElement() [some:0] | test.swift:723:15:723:35 | ...! |
+| test.swift:725:16:725:30 | call to Set<Element>.init(_:) [Collection element] | test.swift:726:15:726:15 | set2 [Collection element] |
+| test.swift:725:20:725:29 | [...] [Array element] | test.swift:725:16:725:30 | call to Set<Element>.init(_:) [Collection element] |
+| test.swift:725:21:725:28 | call to source() | test.swift:725:20:725:29 | [...] [Array element] |
+| test.swift:726:15:726:15 | set2 [Collection element] | test.swift:726:15:726:34 | call to randomElement() [some:0] |
+| test.swift:726:15:726:34 | call to randomElement() [some:0] | test.swift:726:15:726:35 | ...! |
+| test.swift:731:9:731:9 | self [v2, some:0] | file://:0:0:0:0 | self [v2, some:0] |
+| test.swift:731:9:731:9 | self [v2] | file://:0:0:0:0 | self [v2] |
+| test.swift:731:9:731:9 | value | file://:0:0:0:0 | value |
+| test.swift:731:9:731:9 | value [some:0] | file://:0:0:0:0 | value [some:0] |
+| test.swift:732:9:732:9 | self [v3] | file://:0:0:0:0 | self [v3] |
+| test.swift:732:9:732:9 | value | file://:0:0:0:0 | value |
+| test.swift:742:5:742:5 | v1 [some:0] | test.swift:752:15:752:15 | v1 [some:0] |
+| test.swift:742:11:742:18 | call to source() | test.swift:742:5:742:5 | v1 [some:0] |
+| test.swift:743:10:743:17 | call to source() | test.swift:743:10:743:17 | call to source() [some:0] |
+| test.swift:743:10:743:17 | call to source() | test.swift:753:15:753:17 | ...! |
+| test.swift:743:10:743:17 | call to source() [some:0] | test.swift:753:15:753:15 | v2 [some:0] |
+| test.swift:744:10:744:17 | call to source() | test.swift:754:15:754:15 | v3 |
+| test.swift:746:5:746:5 | [post] mo1 [v2, some:0] | test.swift:747:5:747:5 | mo1 [v2, some:0] |
+| test.swift:746:5:746:5 | [post] mo1 [v2] | test.swift:747:5:747:5 | mo1 [v2] |
+| test.swift:746:14:746:21 | call to source() | test.swift:731:9:731:9 | value |
+| test.swift:746:14:746:21 | call to source() | test.swift:746:5:746:5 | [post] mo1 [v2] |
+| test.swift:746:14:746:21 | call to source() | test.swift:746:14:746:21 | call to source() [some:0] |
+| test.swift:746:14:746:21 | call to source() [some:0] | test.swift:731:9:731:9 | value [some:0] |
+| test.swift:746:14:746:21 | call to source() [some:0] | test.swift:746:5:746:5 | [post] mo1 [v2, some:0] |
+| test.swift:747:5:747:5 | [post] mo1 [v3] | test.swift:757:15:757:15 | mo1 [v3] |
+| test.swift:747:5:747:5 | mo1 [v2, some:0] | test.swift:756:15:756:15 | mo1 [v2, some:0] |
+| test.swift:747:5:747:5 | mo1 [v2] | test.swift:756:15:756:15 | mo1 [v2] |
+| test.swift:747:14:747:21 | call to source() | test.swift:732:9:732:9 | value |
+| test.swift:747:14:747:21 | call to source() | test.swift:747:5:747:5 | [post] mo1 [v3] |
+| test.swift:752:15:752:15 | v1 [some:0] | test.swift:752:15:752:17 | ...! |
+| test.swift:753:15:753:15 | v2 [some:0] | test.swift:753:15:753:17 | ...! |
+| test.swift:756:15:756:15 | mo1 [v2, some:0] | test.swift:731:9:731:9 | self [v2, some:0] |
+| test.swift:756:15:756:15 | mo1 [v2, some:0] | test.swift:756:15:756:19 | .v2 [some:0] |
+| test.swift:756:15:756:15 | mo1 [v2] | test.swift:731:9:731:9 | self [v2] |
+| test.swift:756:15:756:15 | mo1 [v2] | test.swift:756:15:756:19 | .v2 |
+| test.swift:756:15:756:19 | .v2 | test.swift:756:15:756:21 | ...! |
+| test.swift:756:15:756:19 | .v2 [some:0] | test.swift:756:15:756:21 | ...! |
+| test.swift:757:15:757:15 | mo1 [v3] | test.swift:732:9:732:9 | self [v3] |
+| test.swift:757:15:757:15 | mo1 [v3] | test.swift:757:15:757:19 | .v3 |
 nodes
 | file://:0:0:0:0 | .a [x] | semmle.label | .a [x] |
 | file://:0:0:0:0 | .str | semmle.label | .str |
@@ -588,236 +599,248 @@ nodes
 | test.swift:361:15:361:18 | .1 | semmle.label | .1 |
 | test.swift:363:15:363:15 | a | semmle.label | a |
 | test.swift:364:15:364:15 | b | semmle.label | b |
-| test.swift:375:16:375:21 | v | semmle.label | v |
-| test.swift:375:45:375:62 | call to ... [mySingle:0] | semmle.label | call to ... [mySingle:0] |
-| test.swift:375:61:375:61 | v | semmle.label | v |
-| test.swift:377:18:377:23 | v | semmle.label | v |
-| test.swift:377:45:377:60 | call to ... [some:0] | semmle.label | call to ... [some:0] |
-| test.swift:377:59:377:59 | v | semmle.label | v |
-| test.swift:403:9:403:27 | call to ... [mySingle:0] | semmle.label | call to ... [mySingle:0] |
-| test.swift:403:19:403:26 | call to source() | semmle.label | call to source() |
-| test.swift:408:10:408:25 | .mySingle(...) [mySingle:0] | semmle.label | .mySingle(...) [mySingle:0] |
-| test.swift:408:24:408:24 | a | semmle.label | a |
-| test.swift:409:19:409:19 | a | semmle.label | a |
-| test.swift:417:13:417:28 | .mySingle(...) [mySingle:0] | semmle.label | .mySingle(...) [mySingle:0] |
-| test.swift:417:27:417:27 | x | semmle.label | x |
-| test.swift:418:19:418:19 | x | semmle.label | x |
-| test.swift:425:9:425:34 | call to ... [myPair:1] | semmle.label | call to ... [myPair:1] |
-| test.swift:425:26:425:33 | call to source() | semmle.label | call to source() |
-| test.swift:432:10:432:30 | .myPair(...) [myPair:1] | semmle.label | .myPair(...) [myPair:1] |
-| test.swift:432:29:432:29 | b | semmle.label | b |
-| test.swift:434:19:434:19 | b | semmle.label | b |
-| test.swift:442:13:442:33 | .myPair(...) [myPair:1] | semmle.label | .myPair(...) [myPair:1] |
-| test.swift:442:32:442:32 | y | semmle.label | y |
-| test.swift:444:19:444:19 | y | semmle.label | y |
-| test.swift:447:21:447:34 | call to ... [myCons:1, myPair:1] | semmle.label | call to ... [myCons:1, myPair:1] |
-| test.swift:447:33:447:33 | a [myPair:1] | semmle.label | a [myPair:1] |
-| test.swift:457:14:457:38 | .myCons(...) [myCons:1, myPair:1] | semmle.label | .myCons(...) [myCons:1, myPair:1] |
-| test.swift:457:25:457:37 | .myPair(...) [myPair:1] | semmle.label | .myPair(...) [myPair:1] |
-| test.swift:457:36:457:36 | c | semmle.label | c |
-| test.swift:460:19:460:19 | c | semmle.label | c |
-| test.swift:468:13:468:39 | .myPair(...) [myPair:0] | semmle.label | .myPair(...) [myPair:0] |
-| test.swift:468:31:468:31 | x | semmle.label | x |
-| test.swift:468:43:468:62 | call to ... [myPair:0] | semmle.label | call to ... [myPair:0] |
-| test.swift:468:51:468:58 | call to source() | semmle.label | call to source() |
-| test.swift:469:19:469:19 | x | semmle.label | x |
-| test.swift:472:17:472:41 | .myCons(...) [myCons:1, myPair:1] | semmle.label | .myCons(...) [myCons:1, myPair:1] |
-| test.swift:472:28:472:40 | .myPair(...) [myPair:1] | semmle.label | .myPair(...) [myPair:1] |
-| test.swift:472:39:472:39 | c | semmle.label | c |
-| test.swift:473:19:473:19 | c | semmle.label | c |
-| test.swift:476:12:476:17 | (...) [Tuple element at index 0, myPair:1] | semmle.label | (...) [Tuple element at index 0, myPair:1] |
-| test.swift:476:12:476:17 | (...) [Tuple element at index 1, myCons:1, myPair:1] | semmle.label | (...) [Tuple element at index 1, myCons:1, myPair:1] |
-| test.swift:476:13:476:13 | a [myPair:1] | semmle.label | a [myPair:1] |
-| test.swift:476:16:476:16 | b [myCons:1, myPair:1] | semmle.label | b [myCons:1, myPair:1] |
-| test.swift:477:14:477:55 | (...) [Tuple element at index 0, myPair:1] | semmle.label | (...) [Tuple element at index 0, myPair:1] |
-| test.swift:477:14:477:55 | (...) [Tuple element at index 1, myCons:1, myPair:1] | semmle.label | (...) [Tuple element at index 1, myCons:1, myPair:1] |
-| test.swift:477:15:477:27 | .myPair(...) [myPair:1] | semmle.label | .myPair(...) [myPair:1] |
-| test.swift:477:26:477:26 | b | semmle.label | b |
-| test.swift:477:30:477:54 | .myCons(...) [myCons:1, myPair:1] | semmle.label | .myCons(...) [myCons:1, myPair:1] |
-| test.swift:477:41:477:53 | .myPair(...) [myPair:1] | semmle.label | .myPair(...) [myPair:1] |
-| test.swift:477:52:477:52 | e | semmle.label | e |
-| test.swift:479:19:479:19 | b | semmle.label | b |
-| test.swift:482:19:482:19 | e | semmle.label | e |
-| test.swift:488:14:488:38 | call to ... [mySingle:0] | semmle.label | call to ... [mySingle:0] |
-| test.swift:488:30:488:37 | call to source() | semmle.label | call to source() |
-| test.swift:490:14:490:32 | call to mkMyEnum1(_:) [mySingle:0] | semmle.label | call to mkMyEnum1(_:) [mySingle:0] |
-| test.swift:490:24:490:31 | call to source() | semmle.label | call to source() |
-| test.swift:492:14:492:32 | call to mkMyEnum2(_:) [mySingle:0] | semmle.label | call to mkMyEnum2(_:) [mySingle:0] |
-| test.swift:492:24:492:31 | call to source() | semmle.label | call to source() |
-| test.swift:494:13:494:35 | .mySingle(...) [mySingle:0] | semmle.label | .mySingle(...) [mySingle:0] |
-| test.swift:494:33:494:33 | d2 | semmle.label | d2 |
-| test.swift:494:54:494:54 | d2 | semmle.label | d2 |
-| test.swift:496:13:496:35 | .mySingle(...) [mySingle:0] | semmle.label | .mySingle(...) [mySingle:0] |
-| test.swift:496:33:496:33 | d4 | semmle.label | d4 |
-| test.swift:496:54:496:54 | d4 | semmle.label | d4 |
-| test.swift:498:13:498:35 | .mySingle(...) [mySingle:0] | semmle.label | .mySingle(...) [mySingle:0] |
-| test.swift:498:33:498:33 | d6 | semmle.label | d6 |
-| test.swift:498:54:498:54 | d6 | semmle.label | d6 |
-| test.swift:501:14:501:36 | call to ... [some:0] | semmle.label | call to ... [some:0] |
-| test.swift:501:28:501:35 | call to source() | semmle.label | call to source() |
-| test.swift:503:14:503:34 | call to mkOptional1(_:) [some:0] | semmle.label | call to mkOptional1(_:) [some:0] |
-| test.swift:503:26:503:33 | call to source() | semmle.label | call to source() |
-| test.swift:505:14:505:34 | call to mkOptional2(_:) [some:0] | semmle.label | call to mkOptional2(_:) [some:0] |
-| test.swift:505:26:505:33 | call to source() | semmle.label | call to source() |
-| test.swift:507:15:507:15 | e2 [some:0] | semmle.label | e2 [some:0] |
-| test.swift:507:15:507:17 | ...! | semmle.label | ...! |
-| test.swift:509:15:509:15 | e4 [some:0] | semmle.label | e4 [some:0] |
-| test.swift:509:15:509:17 | ...! | semmle.label | ...! |
-| test.swift:511:15:511:15 | e6 [some:0] | semmle.label | e6 [some:0] |
-| test.swift:511:15:511:17 | ...! | semmle.label | ...! |
-| test.swift:517:13:517:28 | call to optionalSource() [some:0] | semmle.label | call to optionalSource() [some:0] |
-| test.swift:519:8:519:12 | let ...? [some:0] | semmle.label | let ...? [some:0] |
-| test.swift:519:12:519:12 | a | semmle.label | a |
-| test.swift:520:19:520:19 | a | semmle.label | a |
-| test.swift:524:18:524:23 | (...) [Tuple element at index 0, some:0] | semmle.label | (...) [Tuple element at index 0, some:0] |
-| test.swift:524:19:524:19 | x [some:0] | semmle.label | x [some:0] |
-| test.swift:526:10:526:37 | (...) [Tuple element at index 0, some:0] | semmle.label | (...) [Tuple element at index 0, some:0] |
-| test.swift:526:11:526:22 | .some(...) [some:0] | semmle.label | .some(...) [some:0] |
-| test.swift:526:21:526:21 | a | semmle.label | a |
-| test.swift:527:19:527:19 | a | semmle.label | a |
-| test.swift:540:9:540:9 | self [x, some:0] | semmle.label | self [x, some:0] |
-| test.swift:540:9:540:9 | value [some:0] | semmle.label | value [some:0] |
-| test.swift:544:13:544:28 | call to optionalSource() [some:0] | semmle.label | call to optionalSource() [some:0] |
-| test.swift:546:5:546:5 | [post] cx [x, some:0] | semmle.label | [post] cx [x, some:0] |
-| test.swift:546:12:546:12 | x [some:0] | semmle.label | x [some:0] |
-| test.swift:550:11:550:15 | let ...? [some:0] | semmle.label | let ...? [some:0] |
-| test.swift:550:15:550:15 | z1 | semmle.label | z1 |
-| test.swift:550:20:550:20 | cx [x, some:0] | semmle.label | cx [x, some:0] |
-| test.swift:550:20:550:23 | .x [some:0] | semmle.label | .x [some:0] |
-| test.swift:551:15:551:15 | z1 | semmle.label | z1 |
-| test.swift:557:13:557:21 | call to +(_:) | semmle.label | call to +(_:) |
-| test.swift:557:14:557:21 | call to source() | semmle.label | call to source() |
-| test.swift:558:14:558:21 | call to source() | semmle.label | call to source() |
-| test.swift:566:9:566:9 | self [str] | semmle.label | self [str] |
-| test.swift:567:5:569:5 | self[return] [str] | semmle.label | self[return] [str] |
-| test.swift:567:10:567:13 | s | semmle.label | s |
-| test.swift:568:7:568:7 | [post] self [str] | semmle.label | [post] self [str] |
-| test.swift:568:13:568:13 | s | semmle.label | s |
-| test.swift:573:17:576:5 | self[return] [str] | semmle.label | self[return] [str] |
-| test.swift:574:7:574:7 | [post] self [str] | semmle.label | [post] self [str] |
-| test.swift:574:20:574:28 | call to source3() | semmle.label | call to source3() |
-| test.swift:575:17:575:17 | .str | semmle.label | .str |
-| test.swift:575:17:575:17 | self [str] | semmle.label | self [str] |
-| test.swift:580:13:580:33 | call to MyClass.init(s:) [str] | semmle.label | call to MyClass.init(s:) [str] |
-| test.swift:580:13:580:35 | .str | semmle.label | .str |
-| test.swift:580:24:580:32 | call to source3() | semmle.label | call to source3() |
-| test.swift:581:13:581:41 | call to MyClass.init(contentsOfFile:) [str] | semmle.label | call to MyClass.init(contentsOfFile:) [str] |
-| test.swift:581:13:581:43 | .str | semmle.label | .str |
-| test.swift:598:3:600:3 | self[return] [x] | semmle.label | self[return] [x] |
-| test.swift:598:8:598:11 | x | semmle.label | x |
-| test.swift:599:5:599:5 | [post] self [x] | semmle.label | [post] self [x] |
-| test.swift:599:14:599:14 | x | semmle.label | x |
-| test.swift:604:11:604:24 | call to S.init(x:) [x] | semmle.label | call to S.init(x:) [x] |
-| test.swift:604:16:604:23 | call to source() | semmle.label | call to source() |
-| test.swift:605:11:605:14 | enter #keyPath(...) [x] | semmle.label | enter #keyPath(...) [x] |
-| test.swift:605:11:605:14 | exit #keyPath(...) | semmle.label | exit #keyPath(...) |
-| test.swift:605:14:605:14 | KeyPathComponent [x] | semmle.label | KeyPathComponent [x] |
-| test.swift:606:13:606:13 | s [x] | semmle.label | s [x] |
-| test.swift:606:13:606:25 | \\...[...] | semmle.label | \\...[...] |
-| test.swift:608:36:608:38 | enter #keyPath(...) [x] | semmle.label | enter #keyPath(...) [x] |
-| test.swift:608:36:608:38 | exit #keyPath(...) | semmle.label | exit #keyPath(...) |
-| test.swift:608:38:608:38 | KeyPathComponent [x] | semmle.label | KeyPathComponent [x] |
-| test.swift:609:13:609:13 | s [x] | semmle.label | s [x] |
-| test.swift:609:13:609:32 | \\...[...] | semmle.label | \\...[...] |
-| test.swift:615:3:617:3 | self[return] [s, x] | semmle.label | self[return] [s, x] |
-| test.swift:615:8:615:11 | s [x] | semmle.label | s [x] |
-| test.swift:616:5:616:5 | [post] self [s, x] | semmle.label | [post] self [s, x] |
-| test.swift:616:14:616:14 | s [x] | semmle.label | s [x] |
-| test.swift:621:11:621:24 | call to S.init(x:) [x] | semmle.label | call to S.init(x:) [x] |
-| test.swift:621:16:621:23 | call to source() | semmle.label | call to source() |
-| test.swift:622:12:622:19 | call to S2.init(s:) [s, x] | semmle.label | call to S2.init(s:) [s, x] |
-| test.swift:622:18:622:18 | s [x] | semmle.label | s [x] |
-| test.swift:623:11:623:17 | enter #keyPath(...) [s, x] | semmle.label | enter #keyPath(...) [s, x] |
-| test.swift:623:11:623:17 | exit #keyPath(...) | semmle.label | exit #keyPath(...) |
-| test.swift:623:15:623:15 | KeyPathComponent [s, x] | semmle.label | KeyPathComponent [s, x] |
-| test.swift:623:17:623:17 | KeyPathComponent [x] | semmle.label | KeyPathComponent [x] |
-| test.swift:624:13:624:13 | s2 [s, x] | semmle.label | s2 [s, x] |
-| test.swift:624:13:624:26 | \\...[...] | semmle.label | \\...[...] |
-| test.swift:628:17:628:26 | [...] [Array element] | semmle.label | [...] [Array element] |
-| test.swift:628:18:628:25 | call to source() | semmle.label | call to source() |
-| test.swift:629:13:629:22 | enter #keyPath(...) [Array element] | semmle.label | enter #keyPath(...) [Array element] |
-| test.swift:629:13:629:22 | exit #keyPath(...) | semmle.label | exit #keyPath(...) |
-| test.swift:629:20:629:22 | KeyPathComponent [Array element] | semmle.label | KeyPathComponent [Array element] |
-| test.swift:630:15:630:15 | array [Array element] | semmle.label | array [Array element] |
-| test.swift:630:15:630:31 | \\...[...] | semmle.label | \\...[...] |
-| test.swift:649:13:649:20 | call to source() | semmle.label | call to source() |
-| test.swift:657:15:657:15 | y | semmle.label | y |
-| test.swift:659:9:659:16 | call to source() | semmle.label | call to source() |
-| test.swift:661:11:661:11 | x | semmle.label | x |
-| test.swift:661:15:661:15 | [post] y | semmle.label | [post] y |
-| test.swift:662:15:662:15 | x | semmle.label | x |
-| test.swift:663:15:663:15 | y | semmle.label | y |
-| test.swift:669:5:669:5 | [post] arr1 [Array element] | semmle.label | [post] arr1 [Array element] |
-| test.swift:669:15:669:22 | call to source() | semmle.label | call to source() |
-| test.swift:670:15:670:15 | arr1 [Array element] | semmle.label | arr1 [Array element] |
-| test.swift:670:15:670:21 | ...[...] | semmle.label | ...[...] |
-| test.swift:673:16:673:25 | [...] [Array element] | semmle.label | [...] [Array element] |
-| test.swift:673:17:673:24 | call to source() | semmle.label | call to source() |
-| test.swift:674:15:674:15 | arr2 [Array element] | semmle.label | arr2 [Array element] |
-| test.swift:674:15:674:21 | ...[...] | semmle.label | ...[...] |
-| test.swift:676:18:676:29 | [...] [Array element, Array element] | semmle.label | [...] [Array element, Array element] |
-| test.swift:676:19:676:28 | [...] [Array element] | semmle.label | [...] [Array element] |
-| test.swift:676:20:676:27 | call to source() | semmle.label | call to source() |
-| test.swift:678:15:678:15 | matrix [Array element, Array element] | semmle.label | matrix [Array element, Array element] |
-| test.swift:678:15:678:23 | ...[...] [Array element] | semmle.label | ...[...] [Array element] |
-| test.swift:678:15:678:26 | ...[...] | semmle.label | ...[...] |
-| test.swift:681:5:681:5 | [post] matrix2 [Array element, Array element] | semmle.label | [post] matrix2 [Array element, Array element] |
-| test.swift:681:5:681:14 | [post] getter for ...[...] [Array element] | semmle.label | [post] getter for ...[...] [Array element] |
-| test.swift:681:21:681:28 | call to source() | semmle.label | call to source() |
-| test.swift:682:15:682:15 | matrix2 [Array element, Array element] | semmle.label | matrix2 [Array element, Array element] |
-| test.swift:682:15:682:24 | ...[...] [Array element] | semmle.label | ...[...] [Array element] |
-| test.swift:682:15:682:27 | ...[...] | semmle.label | ...[...] |
-| test.swift:693:5:693:5 | [post] arr6 [Array element] | semmle.label | [post] arr6 [Array element] |
-| test.swift:693:17:693:24 | call to source() | semmle.label | call to source() |
-| test.swift:694:15:694:15 | arr6 [Array element] | semmle.label | arr6 [Array element] |
-| test.swift:694:15:694:21 | ...[...] | semmle.label | ...[...] |
-| test.swift:696:16:696:25 | [...] [Array element] | semmle.label | [...] [Array element] |
-| test.swift:696:17:696:24 | call to source() | semmle.label | call to source() |
-| test.swift:697:15:697:15 | arr7 [Array element] | semmle.label | arr7 [Array element] |
-| test.swift:697:15:697:34 | call to randomElement() [some:0] | semmle.label | call to randomElement() [some:0] |
-| test.swift:697:15:697:35 | ...! | semmle.label | ...! |
-| test.swift:703:5:703:5 | [post] set1 [Collection element] | semmle.label | [post] set1 [Collection element] |
-| test.swift:703:17:703:24 | call to source() | semmle.label | call to source() |
-| test.swift:704:15:704:15 | set1 [Collection element] | semmle.label | set1 [Collection element] |
-| test.swift:704:15:704:34 | call to randomElement() [some:0] | semmle.label | call to randomElement() [some:0] |
-| test.swift:704:15:704:35 | ...! | semmle.label | ...! |
-| test.swift:706:16:706:30 | call to Set<Element>.init(_:) [Collection element] | semmle.label | call to Set<Element>.init(_:) [Collection element] |
-| test.swift:706:20:706:29 | [...] [Array element] | semmle.label | [...] [Array element] |
-| test.swift:706:21:706:28 | call to source() | semmle.label | call to source() |
-| test.swift:707:15:707:15 | set2 [Collection element] | semmle.label | set2 [Collection element] |
-| test.swift:707:15:707:34 | call to randomElement() [some:0] | semmle.label | call to randomElement() [some:0] |
-| test.swift:707:15:707:35 | ...! | semmle.label | ...! |
-| test.swift:712:9:712:9 | self [v2, some:0] | semmle.label | self [v2, some:0] |
-| test.swift:712:9:712:9 | self [v2] | semmle.label | self [v2] |
-| test.swift:712:9:712:9 | value | semmle.label | value |
-| test.swift:712:9:712:9 | value [some:0] | semmle.label | value [some:0] |
-| test.swift:713:9:713:9 | self [v3] | semmle.label | self [v3] |
-| test.swift:713:9:713:9 | value | semmle.label | value |
-| test.swift:723:5:723:5 | v1 [some:0] | semmle.label | v1 [some:0] |
-| test.swift:723:11:723:18 | call to source() | semmle.label | call to source() |
-| test.swift:724:10:724:17 | call to source() | semmle.label | call to source() |
-| test.swift:724:10:724:17 | call to source() [some:0] | semmle.label | call to source() [some:0] |
-| test.swift:725:10:725:17 | call to source() | semmle.label | call to source() |
-| test.swift:727:5:727:5 | [post] mo1 [v2, some:0] | semmle.label | [post] mo1 [v2, some:0] |
-| test.swift:727:5:727:5 | [post] mo1 [v2] | semmle.label | [post] mo1 [v2] |
-| test.swift:727:14:727:21 | call to source() | semmle.label | call to source() |
-| test.swift:727:14:727:21 | call to source() [some:0] | semmle.label | call to source() [some:0] |
-| test.swift:728:5:728:5 | [post] mo1 [v3] | semmle.label | [post] mo1 [v3] |
-| test.swift:728:5:728:5 | mo1 [v2, some:0] | semmle.label | mo1 [v2, some:0] |
-| test.swift:728:5:728:5 | mo1 [v2] | semmle.label | mo1 [v2] |
-| test.swift:728:14:728:21 | call to source() | semmle.label | call to source() |
-| test.swift:733:15:733:15 | v1 [some:0] | semmle.label | v1 [some:0] |
-| test.swift:733:15:733:17 | ...! | semmle.label | ...! |
-| test.swift:734:15:734:15 | v2 [some:0] | semmle.label | v2 [some:0] |
-| test.swift:734:15:734:17 | ...! | semmle.label | ...! |
-| test.swift:735:15:735:15 | v3 | semmle.label | v3 |
-| test.swift:737:15:737:15 | mo1 [v2, some:0] | semmle.label | mo1 [v2, some:0] |
-| test.swift:737:15:737:15 | mo1 [v2] | semmle.label | mo1 [v2] |
-| test.swift:737:15:737:19 | .v2 | semmle.label | .v2 |
-| test.swift:737:15:737:19 | .v2 [some:0] | semmle.label | .v2 [some:0] |
-| test.swift:737:15:737:21 | ...! | semmle.label | ...! |
-| test.swift:738:15:738:15 | mo1 [v3] | semmle.label | mo1 [v3] |
-| test.swift:738:15:738:19 | .v3 | semmle.label | .v3 |
+| test.swift:368:22:368:36 | t [Tuple element at index 1] | semmle.label | t [Tuple element at index 1] |
+| test.swift:369:12:369:19 | (...) [Tuple element at index 0] | semmle.label | (...) [Tuple element at index 0] |
+| test.swift:369:13:369:13 | t [Tuple element at index 1] | semmle.label | t [Tuple element at index 1] |
+| test.swift:369:13:369:15 | .1 | semmle.label | .1 |
+| test.swift:375:14:375:26 | (...) [Tuple element at index 1] | semmle.label | (...) [Tuple element at index 1] |
+| test.swift:375:18:375:25 | call to source() | semmle.label | call to source() |
+| test.swift:376:14:376:32 | call to tupleShiftLeft1(_:) [Tuple element at index 0] | semmle.label | call to tupleShiftLeft1(_:) [Tuple element at index 0] |
+| test.swift:376:30:376:30 | t1 [Tuple element at index 1] | semmle.label | t1 [Tuple element at index 1] |
+| test.swift:380:15:380:15 | t1 [Tuple element at index 1] | semmle.label | t1 [Tuple element at index 1] |
+| test.swift:380:15:380:18 | .1 | semmle.label | .1 |
+| test.swift:381:15:381:15 | t2 [Tuple element at index 0] | semmle.label | t2 [Tuple element at index 0] |
+| test.swift:381:15:381:18 | .0 | semmle.label | .0 |
+| test.swift:394:16:394:21 | v | semmle.label | v |
+| test.swift:394:45:394:62 | call to ... [mySingle:0] | semmle.label | call to ... [mySingle:0] |
+| test.swift:394:61:394:61 | v | semmle.label | v |
+| test.swift:396:18:396:23 | v | semmle.label | v |
+| test.swift:396:45:396:60 | call to ... [some:0] | semmle.label | call to ... [some:0] |
+| test.swift:396:59:396:59 | v | semmle.label | v |
+| test.swift:422:9:422:27 | call to ... [mySingle:0] | semmle.label | call to ... [mySingle:0] |
+| test.swift:422:19:422:26 | call to source() | semmle.label | call to source() |
+| test.swift:427:10:427:25 | .mySingle(...) [mySingle:0] | semmle.label | .mySingle(...) [mySingle:0] |
+| test.swift:427:24:427:24 | a | semmle.label | a |
+| test.swift:428:19:428:19 | a | semmle.label | a |
+| test.swift:436:13:436:28 | .mySingle(...) [mySingle:0] | semmle.label | .mySingle(...) [mySingle:0] |
+| test.swift:436:27:436:27 | x | semmle.label | x |
+| test.swift:437:19:437:19 | x | semmle.label | x |
+| test.swift:444:9:444:34 | call to ... [myPair:1] | semmle.label | call to ... [myPair:1] |
+| test.swift:444:26:444:33 | call to source() | semmle.label | call to source() |
+| test.swift:451:10:451:30 | .myPair(...) [myPair:1] | semmle.label | .myPair(...) [myPair:1] |
+| test.swift:451:29:451:29 | b | semmle.label | b |
+| test.swift:453:19:453:19 | b | semmle.label | b |
+| test.swift:461:13:461:33 | .myPair(...) [myPair:1] | semmle.label | .myPair(...) [myPair:1] |
+| test.swift:461:32:461:32 | y | semmle.label | y |
+| test.swift:463:19:463:19 | y | semmle.label | y |
+| test.swift:466:21:466:34 | call to ... [myCons:1, myPair:1] | semmle.label | call to ... [myCons:1, myPair:1] |
+| test.swift:466:33:466:33 | a [myPair:1] | semmle.label | a [myPair:1] |
+| test.swift:476:14:476:38 | .myCons(...) [myCons:1, myPair:1] | semmle.label | .myCons(...) [myCons:1, myPair:1] |
+| test.swift:476:25:476:37 | .myPair(...) [myPair:1] | semmle.label | .myPair(...) [myPair:1] |
+| test.swift:476:36:476:36 | c | semmle.label | c |
+| test.swift:479:19:479:19 | c | semmle.label | c |
+| test.swift:487:13:487:39 | .myPair(...) [myPair:0] | semmle.label | .myPair(...) [myPair:0] |
+| test.swift:487:31:487:31 | x | semmle.label | x |
+| test.swift:487:43:487:62 | call to ... [myPair:0] | semmle.label | call to ... [myPair:0] |
+| test.swift:487:51:487:58 | call to source() | semmle.label | call to source() |
+| test.swift:488:19:488:19 | x | semmle.label | x |
+| test.swift:491:17:491:41 | .myCons(...) [myCons:1, myPair:1] | semmle.label | .myCons(...) [myCons:1, myPair:1] |
+| test.swift:491:28:491:40 | .myPair(...) [myPair:1] | semmle.label | .myPair(...) [myPair:1] |
+| test.swift:491:39:491:39 | c | semmle.label | c |
+| test.swift:492:19:492:19 | c | semmle.label | c |
+| test.swift:495:12:495:17 | (...) [Tuple element at index 0, myPair:1] | semmle.label | (...) [Tuple element at index 0, myPair:1] |
+| test.swift:495:12:495:17 | (...) [Tuple element at index 1, myCons:1, myPair:1] | semmle.label | (...) [Tuple element at index 1, myCons:1, myPair:1] |
+| test.swift:495:13:495:13 | a [myPair:1] | semmle.label | a [myPair:1] |
+| test.swift:495:16:495:16 | b [myCons:1, myPair:1] | semmle.label | b [myCons:1, myPair:1] |
+| test.swift:496:14:496:55 | (...) [Tuple element at index 0, myPair:1] | semmle.label | (...) [Tuple element at index 0, myPair:1] |
+| test.swift:496:14:496:55 | (...) [Tuple element at index 1, myCons:1, myPair:1] | semmle.label | (...) [Tuple element at index 1, myCons:1, myPair:1] |
+| test.swift:496:15:496:27 | .myPair(...) [myPair:1] | semmle.label | .myPair(...) [myPair:1] |
+| test.swift:496:26:496:26 | b | semmle.label | b |
+| test.swift:496:30:496:54 | .myCons(...) [myCons:1, myPair:1] | semmle.label | .myCons(...) [myCons:1, myPair:1] |
+| test.swift:496:41:496:53 | .myPair(...) [myPair:1] | semmle.label | .myPair(...) [myPair:1] |
+| test.swift:496:52:496:52 | e | semmle.label | e |
+| test.swift:498:19:498:19 | b | semmle.label | b |
+| test.swift:501:19:501:19 | e | semmle.label | e |
+| test.swift:507:14:507:38 | call to ... [mySingle:0] | semmle.label | call to ... [mySingle:0] |
+| test.swift:507:30:507:37 | call to source() | semmle.label | call to source() |
+| test.swift:509:14:509:32 | call to mkMyEnum1(_:) [mySingle:0] | semmle.label | call to mkMyEnum1(_:) [mySingle:0] |
+| test.swift:509:24:509:31 | call to source() | semmle.label | call to source() |
+| test.swift:511:14:511:32 | call to mkMyEnum2(_:) [mySingle:0] | semmle.label | call to mkMyEnum2(_:) [mySingle:0] |
+| test.swift:511:24:511:31 | call to source() | semmle.label | call to source() |
+| test.swift:513:13:513:35 | .mySingle(...) [mySingle:0] | semmle.label | .mySingle(...) [mySingle:0] |
+| test.swift:513:33:513:33 | d2 | semmle.label | d2 |
+| test.swift:513:54:513:54 | d2 | semmle.label | d2 |
+| test.swift:515:13:515:35 | .mySingle(...) [mySingle:0] | semmle.label | .mySingle(...) [mySingle:0] |
+| test.swift:515:33:515:33 | d4 | semmle.label | d4 |
+| test.swift:515:54:515:54 | d4 | semmle.label | d4 |
+| test.swift:517:13:517:35 | .mySingle(...) [mySingle:0] | semmle.label | .mySingle(...) [mySingle:0] |
+| test.swift:517:33:517:33 | d6 | semmle.label | d6 |
+| test.swift:517:54:517:54 | d6 | semmle.label | d6 |
+| test.swift:520:14:520:36 | call to ... [some:0] | semmle.label | call to ... [some:0] |
+| test.swift:520:28:520:35 | call to source() | semmle.label | call to source() |
+| test.swift:522:14:522:34 | call to mkOptional1(_:) [some:0] | semmle.label | call to mkOptional1(_:) [some:0] |
+| test.swift:522:26:522:33 | call to source() | semmle.label | call to source() |
+| test.swift:524:14:524:34 | call to mkOptional2(_:) [some:0] | semmle.label | call to mkOptional2(_:) [some:0] |
+| test.swift:524:26:524:33 | call to source() | semmle.label | call to source() |
+| test.swift:526:15:526:15 | e2 [some:0] | semmle.label | e2 [some:0] |
+| test.swift:526:15:526:17 | ...! | semmle.label | ...! |
+| test.swift:528:15:528:15 | e4 [some:0] | semmle.label | e4 [some:0] |
+| test.swift:528:15:528:17 | ...! | semmle.label | ...! |
+| test.swift:530:15:530:15 | e6 [some:0] | semmle.label | e6 [some:0] |
+| test.swift:530:15:530:17 | ...! | semmle.label | ...! |
+| test.swift:536:13:536:28 | call to optionalSource() [some:0] | semmle.label | call to optionalSource() [some:0] |
+| test.swift:538:8:538:12 | let ...? [some:0] | semmle.label | let ...? [some:0] |
+| test.swift:538:12:538:12 | a | semmle.label | a |
+| test.swift:539:19:539:19 | a | semmle.label | a |
+| test.swift:543:18:543:23 | (...) [Tuple element at index 0, some:0] | semmle.label | (...) [Tuple element at index 0, some:0] |
+| test.swift:543:19:543:19 | x [some:0] | semmle.label | x [some:0] |
+| test.swift:545:10:545:37 | (...) [Tuple element at index 0, some:0] | semmle.label | (...) [Tuple element at index 0, some:0] |
+| test.swift:545:11:545:22 | .some(...) [some:0] | semmle.label | .some(...) [some:0] |
+| test.swift:545:21:545:21 | a | semmle.label | a |
+| test.swift:546:19:546:19 | a | semmle.label | a |
+| test.swift:559:9:559:9 | self [x, some:0] | semmle.label | self [x, some:0] |
+| test.swift:559:9:559:9 | value [some:0] | semmle.label | value [some:0] |
+| test.swift:563:13:563:28 | call to optionalSource() [some:0] | semmle.label | call to optionalSource() [some:0] |
+| test.swift:565:5:565:5 | [post] cx [x, some:0] | semmle.label | [post] cx [x, some:0] |
+| test.swift:565:12:565:12 | x [some:0] | semmle.label | x [some:0] |
+| test.swift:569:11:569:15 | let ...? [some:0] | semmle.label | let ...? [some:0] |
+| test.swift:569:15:569:15 | z1 | semmle.label | z1 |
+| test.swift:569:20:569:20 | cx [x, some:0] | semmle.label | cx [x, some:0] |
+| test.swift:569:20:569:23 | .x [some:0] | semmle.label | .x [some:0] |
+| test.swift:570:15:570:15 | z1 | semmle.label | z1 |
+| test.swift:576:13:576:21 | call to +(_:) | semmle.label | call to +(_:) |
+| test.swift:576:14:576:21 | call to source() | semmle.label | call to source() |
+| test.swift:577:14:577:21 | call to source() | semmle.label | call to source() |
+| test.swift:585:9:585:9 | self [str] | semmle.label | self [str] |
+| test.swift:586:5:588:5 | self[return] [str] | semmle.label | self[return] [str] |
+| test.swift:586:10:586:13 | s | semmle.label | s |
+| test.swift:587:7:587:7 | [post] self [str] | semmle.label | [post] self [str] |
+| test.swift:587:13:587:13 | s | semmle.label | s |
+| test.swift:592:17:595:5 | self[return] [str] | semmle.label | self[return] [str] |
+| test.swift:593:7:593:7 | [post] self [str] | semmle.label | [post] self [str] |
+| test.swift:593:20:593:28 | call to source3() | semmle.label | call to source3() |
+| test.swift:594:17:594:17 | .str | semmle.label | .str |
+| test.swift:594:17:594:17 | self [str] | semmle.label | self [str] |
+| test.swift:599:13:599:33 | call to MyClass.init(s:) [str] | semmle.label | call to MyClass.init(s:) [str] |
+| test.swift:599:13:599:35 | .str | semmle.label | .str |
+| test.swift:599:24:599:32 | call to source3() | semmle.label | call to source3() |
+| test.swift:600:13:600:41 | call to MyClass.init(contentsOfFile:) [str] | semmle.label | call to MyClass.init(contentsOfFile:) [str] |
+| test.swift:600:13:600:43 | .str | semmle.label | .str |
+| test.swift:617:3:619:3 | self[return] [x] | semmle.label | self[return] [x] |
+| test.swift:617:8:617:11 | x | semmle.label | x |
+| test.swift:618:5:618:5 | [post] self [x] | semmle.label | [post] self [x] |
+| test.swift:618:14:618:14 | x | semmle.label | x |
+| test.swift:623:11:623:24 | call to S.init(x:) [x] | semmle.label | call to S.init(x:) [x] |
+| test.swift:623:16:623:23 | call to source() | semmle.label | call to source() |
+| test.swift:624:11:624:14 | enter #keyPath(...) [x] | semmle.label | enter #keyPath(...) [x] |
+| test.swift:624:11:624:14 | exit #keyPath(...) | semmle.label | exit #keyPath(...) |
+| test.swift:624:14:624:14 | KeyPathComponent [x] | semmle.label | KeyPathComponent [x] |
+| test.swift:625:13:625:13 | s [x] | semmle.label | s [x] |
+| test.swift:625:13:625:25 | \\...[...] | semmle.label | \\...[...] |
+| test.swift:627:36:627:38 | enter #keyPath(...) [x] | semmle.label | enter #keyPath(...) [x] |
+| test.swift:627:36:627:38 | exit #keyPath(...) | semmle.label | exit #keyPath(...) |
+| test.swift:627:38:627:38 | KeyPathComponent [x] | semmle.label | KeyPathComponent [x] |
+| test.swift:628:13:628:13 | s [x] | semmle.label | s [x] |
+| test.swift:628:13:628:32 | \\...[...] | semmle.label | \\...[...] |
+| test.swift:634:3:636:3 | self[return] [s, x] | semmle.label | self[return] [s, x] |
+| test.swift:634:8:634:11 | s [x] | semmle.label | s [x] |
+| test.swift:635:5:635:5 | [post] self [s, x] | semmle.label | [post] self [s, x] |
+| test.swift:635:14:635:14 | s [x] | semmle.label | s [x] |
+| test.swift:640:11:640:24 | call to S.init(x:) [x] | semmle.label | call to S.init(x:) [x] |
+| test.swift:640:16:640:23 | call to source() | semmle.label | call to source() |
+| test.swift:641:12:641:19 | call to S2.init(s:) [s, x] | semmle.label | call to S2.init(s:) [s, x] |
+| test.swift:641:18:641:18 | s [x] | semmle.label | s [x] |
+| test.swift:642:11:642:17 | enter #keyPath(...) [s, x] | semmle.label | enter #keyPath(...) [s, x] |
+| test.swift:642:11:642:17 | exit #keyPath(...) | semmle.label | exit #keyPath(...) |
+| test.swift:642:15:642:15 | KeyPathComponent [s, x] | semmle.label | KeyPathComponent [s, x] |
+| test.swift:642:17:642:17 | KeyPathComponent [x] | semmle.label | KeyPathComponent [x] |
+| test.swift:643:13:643:13 | s2 [s, x] | semmle.label | s2 [s, x] |
+| test.swift:643:13:643:26 | \\...[...] | semmle.label | \\...[...] |
+| test.swift:647:17:647:26 | [...] [Array element] | semmle.label | [...] [Array element] |
+| test.swift:647:18:647:25 | call to source() | semmle.label | call to source() |
+| test.swift:648:13:648:22 | enter #keyPath(...) [Array element] | semmle.label | enter #keyPath(...) [Array element] |
+| test.swift:648:13:648:22 | exit #keyPath(...) | semmle.label | exit #keyPath(...) |
+| test.swift:648:20:648:22 | KeyPathComponent [Array element] | semmle.label | KeyPathComponent [Array element] |
+| test.swift:649:15:649:15 | array [Array element] | semmle.label | array [Array element] |
+| test.swift:649:15:649:31 | \\...[...] | semmle.label | \\...[...] |
+| test.swift:668:13:668:20 | call to source() | semmle.label | call to source() |
+| test.swift:676:15:676:15 | y | semmle.label | y |
+| test.swift:678:9:678:16 | call to source() | semmle.label | call to source() |
+| test.swift:680:11:680:11 | x | semmle.label | x |
+| test.swift:680:15:680:15 | [post] y | semmle.label | [post] y |
+| test.swift:681:15:681:15 | x | semmle.label | x |
+| test.swift:682:15:682:15 | y | semmle.label | y |
+| test.swift:688:5:688:5 | [post] arr1 [Array element] | semmle.label | [post] arr1 [Array element] |
+| test.swift:688:15:688:22 | call to source() | semmle.label | call to source() |
+| test.swift:689:15:689:15 | arr1 [Array element] | semmle.label | arr1 [Array element] |
+| test.swift:689:15:689:21 | ...[...] | semmle.label | ...[...] |
+| test.swift:692:16:692:25 | [...] [Array element] | semmle.label | [...] [Array element] |
+| test.swift:692:17:692:24 | call to source() | semmle.label | call to source() |
+| test.swift:693:15:693:15 | arr2 [Array element] | semmle.label | arr2 [Array element] |
+| test.swift:693:15:693:21 | ...[...] | semmle.label | ...[...] |
+| test.swift:695:18:695:29 | [...] [Array element, Array element] | semmle.label | [...] [Array element, Array element] |
+| test.swift:695:19:695:28 | [...] [Array element] | semmle.label | [...] [Array element] |
+| test.swift:695:20:695:27 | call to source() | semmle.label | call to source() |
+| test.swift:697:15:697:15 | matrix [Array element, Array element] | semmle.label | matrix [Array element, Array element] |
+| test.swift:697:15:697:23 | ...[...] [Array element] | semmle.label | ...[...] [Array element] |
+| test.swift:697:15:697:26 | ...[...] | semmle.label | ...[...] |
+| test.swift:700:5:700:5 | [post] matrix2 [Array element, Array element] | semmle.label | [post] matrix2 [Array element, Array element] |
+| test.swift:700:5:700:14 | [post] getter for ...[...] [Array element] | semmle.label | [post] getter for ...[...] [Array element] |
+| test.swift:700:21:700:28 | call to source() | semmle.label | call to source() |
+| test.swift:701:15:701:15 | matrix2 [Array element, Array element] | semmle.label | matrix2 [Array element, Array element] |
+| test.swift:701:15:701:24 | ...[...] [Array element] | semmle.label | ...[...] [Array element] |
+| test.swift:701:15:701:27 | ...[...] | semmle.label | ...[...] |
+| test.swift:712:5:712:5 | [post] arr6 [Array element] | semmle.label | [post] arr6 [Array element] |
+| test.swift:712:17:712:24 | call to source() | semmle.label | call to source() |
+| test.swift:713:15:713:15 | arr6 [Array element] | semmle.label | arr6 [Array element] |
+| test.swift:713:15:713:21 | ...[...] | semmle.label | ...[...] |
+| test.swift:715:16:715:25 | [...] [Array element] | semmle.label | [...] [Array element] |
+| test.swift:715:17:715:24 | call to source() | semmle.label | call to source() |
+| test.swift:716:15:716:15 | arr7 [Array element] | semmle.label | arr7 [Array element] |
+| test.swift:716:15:716:34 | call to randomElement() [some:0] | semmle.label | call to randomElement() [some:0] |
+| test.swift:716:15:716:35 | ...! | semmle.label | ...! |
+| test.swift:722:5:722:5 | [post] set1 [Collection element] | semmle.label | [post] set1 [Collection element] |
+| test.swift:722:17:722:24 | call to source() | semmle.label | call to source() |
+| test.swift:723:15:723:15 | set1 [Collection element] | semmle.label | set1 [Collection element] |
+| test.swift:723:15:723:34 | call to randomElement() [some:0] | semmle.label | call to randomElement() [some:0] |
+| test.swift:723:15:723:35 | ...! | semmle.label | ...! |
+| test.swift:725:16:725:30 | call to Set<Element>.init(_:) [Collection element] | semmle.label | call to Set<Element>.init(_:) [Collection element] |
+| test.swift:725:20:725:29 | [...] [Array element] | semmle.label | [...] [Array element] |
+| test.swift:725:21:725:28 | call to source() | semmle.label | call to source() |
+| test.swift:726:15:726:15 | set2 [Collection element] | semmle.label | set2 [Collection element] |
+| test.swift:726:15:726:34 | call to randomElement() [some:0] | semmle.label | call to randomElement() [some:0] |
+| test.swift:726:15:726:35 | ...! | semmle.label | ...! |
+| test.swift:731:9:731:9 | self [v2, some:0] | semmle.label | self [v2, some:0] |
+| test.swift:731:9:731:9 | self [v2] | semmle.label | self [v2] |
+| test.swift:731:9:731:9 | value | semmle.label | value |
+| test.swift:731:9:731:9 | value [some:0] | semmle.label | value [some:0] |
+| test.swift:732:9:732:9 | self [v3] | semmle.label | self [v3] |
+| test.swift:732:9:732:9 | value | semmle.label | value |
+| test.swift:742:5:742:5 | v1 [some:0] | semmle.label | v1 [some:0] |
+| test.swift:742:11:742:18 | call to source() | semmle.label | call to source() |
+| test.swift:743:10:743:17 | call to source() | semmle.label | call to source() |
+| test.swift:743:10:743:17 | call to source() [some:0] | semmle.label | call to source() [some:0] |
+| test.swift:744:10:744:17 | call to source() | semmle.label | call to source() |
+| test.swift:746:5:746:5 | [post] mo1 [v2, some:0] | semmle.label | [post] mo1 [v2, some:0] |
+| test.swift:746:5:746:5 | [post] mo1 [v2] | semmle.label | [post] mo1 [v2] |
+| test.swift:746:14:746:21 | call to source() | semmle.label | call to source() |
+| test.swift:746:14:746:21 | call to source() [some:0] | semmle.label | call to source() [some:0] |
+| test.swift:747:5:747:5 | [post] mo1 [v3] | semmle.label | [post] mo1 [v3] |
+| test.swift:747:5:747:5 | mo1 [v2, some:0] | semmle.label | mo1 [v2, some:0] |
+| test.swift:747:5:747:5 | mo1 [v2] | semmle.label | mo1 [v2] |
+| test.swift:747:14:747:21 | call to source() | semmle.label | call to source() |
+| test.swift:752:15:752:15 | v1 [some:0] | semmle.label | v1 [some:0] |
+| test.swift:752:15:752:17 | ...! | semmle.label | ...! |
+| test.swift:753:15:753:15 | v2 [some:0] | semmle.label | v2 [some:0] |
+| test.swift:753:15:753:17 | ...! | semmle.label | ...! |
+| test.swift:754:15:754:15 | v3 | semmle.label | v3 |
+| test.swift:756:15:756:15 | mo1 [v2, some:0] | semmle.label | mo1 [v2, some:0] |
+| test.swift:756:15:756:15 | mo1 [v2] | semmle.label | mo1 [v2] |
+| test.swift:756:15:756:19 | .v2 | semmle.label | .v2 |
+| test.swift:756:15:756:19 | .v2 [some:0] | semmle.label | .v2 [some:0] |
+| test.swift:756:15:756:21 | ...! | semmle.label | ...! |
+| test.swift:757:15:757:15 | mo1 [v3] | semmle.label | mo1 [v3] |
+| test.swift:757:15:757:19 | .v3 | semmle.label | .v3 |
 subpaths
 | test.swift:75:22:75:22 | x | test.swift:65:16:65:28 | arg1 | test.swift:65:1:70:1 | arg2[return] | test.swift:75:32:75:32 | [post] y |
 | test.swift:114:19:114:19 | arg | test.swift:109:9:109:14 | arg | test.swift:110:12:110:12 | arg | test.swift:114:12:114:22 | call to ... |
@@ -844,27 +867,28 @@ subpaths
 | test.swift:218:11:218:18 | call to source() | test.swift:169:12:169:22 | value | test.swift:170:5:170:5 | [post] self [x] | test.swift:218:3:218:5 | [post] getter for .a [x] |
 | test.swift:219:13:219:13 | b [a, x] | test.swift:185:7:185:7 | self [a, x] | file://:0:0:0:0 | .a [x] | test.swift:219:13:219:15 | .a [x] |
 | test.swift:219:13:219:15 | .a [x] | test.swift:163:7:163:7 | self [x] | file://:0:0:0:0 | .x | test.swift:219:13:219:17 | .x |
-| test.swift:490:24:490:31 | call to source() | test.swift:375:16:375:21 | v | test.swift:375:45:375:62 | call to ... [mySingle:0] | test.swift:490:14:490:32 | call to mkMyEnum1(_:) [mySingle:0] |
-| test.swift:503:26:503:33 | call to source() | test.swift:377:18:377:23 | v | test.swift:377:45:377:60 | call to ... [some:0] | test.swift:503:14:503:34 | call to mkOptional1(_:) [some:0] |
-| test.swift:546:12:546:12 | x [some:0] | test.swift:540:9:540:9 | value [some:0] | file://:0:0:0:0 | [post] self [x, some:0] | test.swift:546:5:546:5 | [post] cx [x, some:0] |
-| test.swift:550:20:550:20 | cx [x, some:0] | test.swift:540:9:540:9 | self [x, some:0] | file://:0:0:0:0 | .x [some:0] | test.swift:550:20:550:23 | .x [some:0] |
-| test.swift:574:20:574:28 | call to source3() | test.swift:567:10:567:13 | s | test.swift:568:7:568:7 | [post] self [str] | test.swift:574:7:574:7 | [post] self [str] |
-| test.swift:580:13:580:33 | call to MyClass.init(s:) [str] | test.swift:566:9:566:9 | self [str] | file://:0:0:0:0 | .str | test.swift:580:13:580:35 | .str |
-| test.swift:580:24:580:32 | call to source3() | test.swift:567:10:567:13 | s | test.swift:567:5:569:5 | self[return] [str] | test.swift:580:13:580:33 | call to MyClass.init(s:) [str] |
-| test.swift:581:13:581:41 | call to MyClass.init(contentsOfFile:) [str] | test.swift:566:9:566:9 | self [str] | file://:0:0:0:0 | .str | test.swift:581:13:581:43 | .str |
-| test.swift:604:16:604:23 | call to source() | test.swift:598:8:598:11 | x | test.swift:598:3:600:3 | self[return] [x] | test.swift:604:11:604:24 | call to S.init(x:) [x] |
-| test.swift:606:13:606:13 | s [x] | test.swift:605:11:605:14 | enter #keyPath(...) [x] | test.swift:605:11:605:14 | exit #keyPath(...) | test.swift:606:13:606:25 | \\...[...] |
-| test.swift:609:13:609:13 | s [x] | test.swift:608:36:608:38 | enter #keyPath(...) [x] | test.swift:608:36:608:38 | exit #keyPath(...) | test.swift:609:13:609:32 | \\...[...] |
-| test.swift:621:16:621:23 | call to source() | test.swift:598:8:598:11 | x | test.swift:598:3:600:3 | self[return] [x] | test.swift:621:11:621:24 | call to S.init(x:) [x] |
-| test.swift:622:18:622:18 | s [x] | test.swift:615:8:615:11 | s [x] | test.swift:615:3:617:3 | self[return] [s, x] | test.swift:622:12:622:19 | call to S2.init(s:) [s, x] |
-| test.swift:624:13:624:13 | s2 [s, x] | test.swift:623:11:623:17 | enter #keyPath(...) [s, x] | test.swift:623:11:623:17 | exit #keyPath(...) | test.swift:624:13:624:26 | \\...[...] |
-| test.swift:630:15:630:15 | array [Array element] | test.swift:629:13:629:22 | enter #keyPath(...) [Array element] | test.swift:629:13:629:22 | exit #keyPath(...) | test.swift:630:15:630:31 | \\...[...] |
-| test.swift:727:14:727:21 | call to source() | test.swift:712:9:712:9 | value | file://:0:0:0:0 | [post] self [v2] | test.swift:727:5:727:5 | [post] mo1 [v2] |
-| test.swift:727:14:727:21 | call to source() [some:0] | test.swift:712:9:712:9 | value [some:0] | file://:0:0:0:0 | [post] self [v2, some:0] | test.swift:727:5:727:5 | [post] mo1 [v2, some:0] |
-| test.swift:728:14:728:21 | call to source() | test.swift:713:9:713:9 | value | file://:0:0:0:0 | [post] self [v3] | test.swift:728:5:728:5 | [post] mo1 [v3] |
-| test.swift:737:15:737:15 | mo1 [v2, some:0] | test.swift:712:9:712:9 | self [v2, some:0] | file://:0:0:0:0 | .v2 [some:0] | test.swift:737:15:737:19 | .v2 [some:0] |
-| test.swift:737:15:737:15 | mo1 [v2] | test.swift:712:9:712:9 | self [v2] | file://:0:0:0:0 | .v2 | test.swift:737:15:737:19 | .v2 |
-| test.swift:738:15:738:15 | mo1 [v3] | test.swift:713:9:713:9 | self [v3] | file://:0:0:0:0 | .v3 | test.swift:738:15:738:19 | .v3 |
+| test.swift:376:30:376:30 | t1 [Tuple element at index 1] | test.swift:368:22:368:36 | t [Tuple element at index 1] | test.swift:369:12:369:19 | (...) [Tuple element at index 0] | test.swift:376:14:376:32 | call to tupleShiftLeft1(_:) [Tuple element at index 0] |
+| test.swift:509:24:509:31 | call to source() | test.swift:394:16:394:21 | v | test.swift:394:45:394:62 | call to ... [mySingle:0] | test.swift:509:14:509:32 | call to mkMyEnum1(_:) [mySingle:0] |
+| test.swift:522:26:522:33 | call to source() | test.swift:396:18:396:23 | v | test.swift:396:45:396:60 | call to ... [some:0] | test.swift:522:14:522:34 | call to mkOptional1(_:) [some:0] |
+| test.swift:565:12:565:12 | x [some:0] | test.swift:559:9:559:9 | value [some:0] | file://:0:0:0:0 | [post] self [x, some:0] | test.swift:565:5:565:5 | [post] cx [x, some:0] |
+| test.swift:569:20:569:20 | cx [x, some:0] | test.swift:559:9:559:9 | self [x, some:0] | file://:0:0:0:0 | .x [some:0] | test.swift:569:20:569:23 | .x [some:0] |
+| test.swift:593:20:593:28 | call to source3() | test.swift:586:10:586:13 | s | test.swift:587:7:587:7 | [post] self [str] | test.swift:593:7:593:7 | [post] self [str] |
+| test.swift:599:13:599:33 | call to MyClass.init(s:) [str] | test.swift:585:9:585:9 | self [str] | file://:0:0:0:0 | .str | test.swift:599:13:599:35 | .str |
+| test.swift:599:24:599:32 | call to source3() | test.swift:586:10:586:13 | s | test.swift:586:5:588:5 | self[return] [str] | test.swift:599:13:599:33 | call to MyClass.init(s:) [str] |
+| test.swift:600:13:600:41 | call to MyClass.init(contentsOfFile:) [str] | test.swift:585:9:585:9 | self [str] | file://:0:0:0:0 | .str | test.swift:600:13:600:43 | .str |
+| test.swift:623:16:623:23 | call to source() | test.swift:617:8:617:11 | x | test.swift:617:3:619:3 | self[return] [x] | test.swift:623:11:623:24 | call to S.init(x:) [x] |
+| test.swift:625:13:625:13 | s [x] | test.swift:624:11:624:14 | enter #keyPath(...) [x] | test.swift:624:11:624:14 | exit #keyPath(...) | test.swift:625:13:625:25 | \\...[...] |
+| test.swift:628:13:628:13 | s [x] | test.swift:627:36:627:38 | enter #keyPath(...) [x] | test.swift:627:36:627:38 | exit #keyPath(...) | test.swift:628:13:628:32 | \\...[...] |
+| test.swift:640:16:640:23 | call to source() | test.swift:617:8:617:11 | x | test.swift:617:3:619:3 | self[return] [x] | test.swift:640:11:640:24 | call to S.init(x:) [x] |
+| test.swift:641:18:641:18 | s [x] | test.swift:634:8:634:11 | s [x] | test.swift:634:3:636:3 | self[return] [s, x] | test.swift:641:12:641:19 | call to S2.init(s:) [s, x] |
+| test.swift:643:13:643:13 | s2 [s, x] | test.swift:642:11:642:17 | enter #keyPath(...) [s, x] | test.swift:642:11:642:17 | exit #keyPath(...) | test.swift:643:13:643:26 | \\...[...] |
+| test.swift:649:15:649:15 | array [Array element] | test.swift:648:13:648:22 | enter #keyPath(...) [Array element] | test.swift:648:13:648:22 | exit #keyPath(...) | test.swift:649:15:649:31 | \\...[...] |
+| test.swift:746:14:746:21 | call to source() | test.swift:731:9:731:9 | value | file://:0:0:0:0 | [post] self [v2] | test.swift:746:5:746:5 | [post] mo1 [v2] |
+| test.swift:746:14:746:21 | call to source() [some:0] | test.swift:731:9:731:9 | value [some:0] | file://:0:0:0:0 | [post] self [v2, some:0] | test.swift:746:5:746:5 | [post] mo1 [v2, some:0] |
+| test.swift:747:14:747:21 | call to source() | test.swift:732:9:732:9 | value | file://:0:0:0:0 | [post] self [v3] | test.swift:747:5:747:5 | [post] mo1 [v3] |
+| test.swift:756:15:756:15 | mo1 [v2, some:0] | test.swift:731:9:731:9 | self [v2, some:0] | file://:0:0:0:0 | .v2 [some:0] | test.swift:756:15:756:19 | .v2 [some:0] |
+| test.swift:756:15:756:15 | mo1 [v2] | test.swift:731:9:731:9 | self [v2] | file://:0:0:0:0 | .v2 | test.swift:756:15:756:19 | .v2 |
+| test.swift:757:15:757:15 | mo1 [v3] | test.swift:732:9:732:9 | self [v3] | file://:0:0:0:0 | .v3 | test.swift:757:15:757:19 | .v3 |
 #select
 | test.swift:7:15:7:15 | t1 | test.swift:6:19:6:26 | call to source() | test.swift:7:15:7:15 | t1 | result |
 | test.swift:9:15:9:15 | t1 | test.swift:6:19:6:26 | call to source() | test.swift:9:15:9:15 | t1 | result |
@@ -918,46 +942,48 @@ subpaths
 | test.swift:361:15:361:18 | .1 | test.swift:351:31:351:38 | call to source() | test.swift:361:15:361:18 | .1 | result |
 | test.swift:363:15:363:15 | a | test.swift:351:18:351:25 | call to source() | test.swift:363:15:363:15 | a | result |
 | test.swift:364:15:364:15 | b | test.swift:351:31:351:38 | call to source() | test.swift:364:15:364:15 | b | result |
-| test.swift:409:19:409:19 | a | test.swift:403:19:403:26 | call to source() | test.swift:409:19:409:19 | a | result |
-| test.swift:418:19:418:19 | x | test.swift:403:19:403:26 | call to source() | test.swift:418:19:418:19 | x | result |
-| test.swift:434:19:434:19 | b | test.swift:425:26:425:33 | call to source() | test.swift:434:19:434:19 | b | result |
-| test.swift:444:19:444:19 | y | test.swift:425:26:425:33 | call to source() | test.swift:444:19:444:19 | y | result |
-| test.swift:460:19:460:19 | c | test.swift:425:26:425:33 | call to source() | test.swift:460:19:460:19 | c | result |
-| test.swift:469:19:469:19 | x | test.swift:468:51:468:58 | call to source() | test.swift:469:19:469:19 | x | result |
-| test.swift:473:19:473:19 | c | test.swift:425:26:425:33 | call to source() | test.swift:473:19:473:19 | c | result |
-| test.swift:479:19:479:19 | b | test.swift:425:26:425:33 | call to source() | test.swift:479:19:479:19 | b | result |
-| test.swift:482:19:482:19 | e | test.swift:425:26:425:33 | call to source() | test.swift:482:19:482:19 | e | result |
-| test.swift:494:54:494:54 | d2 | test.swift:488:30:488:37 | call to source() | test.swift:494:54:494:54 | d2 | result |
-| test.swift:496:54:496:54 | d4 | test.swift:490:24:490:31 | call to source() | test.swift:496:54:496:54 | d4 | result |
-| test.swift:498:54:498:54 | d6 | test.swift:492:24:492:31 | call to source() | test.swift:498:54:498:54 | d6 | result |
-| test.swift:507:15:507:17 | ...! | test.swift:501:28:501:35 | call to source() | test.swift:507:15:507:17 | ...! | result |
-| test.swift:509:15:509:17 | ...! | test.swift:503:26:503:33 | call to source() | test.swift:509:15:509:17 | ...! | result |
-| test.swift:511:15:511:17 | ...! | test.swift:505:26:505:33 | call to source() | test.swift:511:15:511:17 | ...! | result |
-| test.swift:520:19:520:19 | a | test.swift:259:12:259:19 | call to source() | test.swift:520:19:520:19 | a | result |
-| test.swift:527:19:527:19 | a | test.swift:259:12:259:19 | call to source() | test.swift:527:19:527:19 | a | result |
-| test.swift:551:15:551:15 | z1 | test.swift:259:12:259:19 | call to source() | test.swift:551:15:551:15 | z1 | result |
-| test.swift:557:13:557:21 | call to +(_:) | test.swift:557:14:557:21 | call to source() | test.swift:557:13:557:21 | call to +(_:) | result |
-| test.swift:558:14:558:21 | call to source() | test.swift:558:14:558:21 | call to source() | test.swift:558:14:558:21 | call to source() | result |
-| test.swift:575:17:575:17 | .str | test.swift:574:20:574:28 | call to source3() | test.swift:575:17:575:17 | .str | result |
-| test.swift:580:13:580:35 | .str | test.swift:580:24:580:32 | call to source3() | test.swift:580:13:580:35 | .str | result |
-| test.swift:581:13:581:43 | .str | test.swift:574:20:574:28 | call to source3() | test.swift:581:13:581:43 | .str | result |
-| test.swift:606:13:606:25 | \\...[...] | test.swift:604:16:604:23 | call to source() | test.swift:606:13:606:25 | \\...[...] | result |
-| test.swift:609:13:609:32 | \\...[...] | test.swift:604:16:604:23 | call to source() | test.swift:609:13:609:32 | \\...[...] | result |
-| test.swift:624:13:624:26 | \\...[...] | test.swift:621:16:621:23 | call to source() | test.swift:624:13:624:26 | \\...[...] | result |
-| test.swift:630:15:630:31 | \\...[...] | test.swift:628:18:628:25 | call to source() | test.swift:630:15:630:31 | \\...[...] | result |
-| test.swift:657:15:657:15 | y | test.swift:649:13:649:20 | call to source() | test.swift:657:15:657:15 | y | result |
-| test.swift:662:15:662:15 | x | test.swift:659:9:659:16 | call to source() | test.swift:662:15:662:15 | x | result |
-| test.swift:663:15:663:15 | y | test.swift:659:9:659:16 | call to source() | test.swift:663:15:663:15 | y | result |
-| test.swift:670:15:670:21 | ...[...] | test.swift:669:15:669:22 | call to source() | test.swift:670:15:670:21 | ...[...] | result |
-| test.swift:674:15:674:21 | ...[...] | test.swift:673:17:673:24 | call to source() | test.swift:674:15:674:21 | ...[...] | result |
-| test.swift:678:15:678:26 | ...[...] | test.swift:676:20:676:27 | call to source() | test.swift:678:15:678:26 | ...[...] | result |
-| test.swift:682:15:682:27 | ...[...] | test.swift:681:21:681:28 | call to source() | test.swift:682:15:682:27 | ...[...] | result |
-| test.swift:694:15:694:21 | ...[...] | test.swift:693:17:693:24 | call to source() | test.swift:694:15:694:21 | ...[...] | result |
-| test.swift:697:15:697:35 | ...! | test.swift:696:17:696:24 | call to source() | test.swift:697:15:697:35 | ...! | result |
-| test.swift:704:15:704:35 | ...! | test.swift:703:17:703:24 | call to source() | test.swift:704:15:704:35 | ...! | result |
-| test.swift:707:15:707:35 | ...! | test.swift:706:21:706:28 | call to source() | test.swift:707:15:707:35 | ...! | result |
-| test.swift:733:15:733:17 | ...! | test.swift:723:11:723:18 | call to source() | test.swift:733:15:733:17 | ...! | result |
-| test.swift:734:15:734:17 | ...! | test.swift:724:10:724:17 | call to source() | test.swift:734:15:734:17 | ...! | result |
-| test.swift:735:15:735:15 | v3 | test.swift:725:10:725:17 | call to source() | test.swift:735:15:735:15 | v3 | result |
-| test.swift:737:15:737:21 | ...! | test.swift:727:14:727:21 | call to source() | test.swift:737:15:737:21 | ...! | result |
-| test.swift:738:15:738:19 | .v3 | test.swift:728:14:728:21 | call to source() | test.swift:738:15:738:19 | .v3 | result |
+| test.swift:380:15:380:18 | .1 | test.swift:375:18:375:25 | call to source() | test.swift:380:15:380:18 | .1 | result |
+| test.swift:381:15:381:18 | .0 | test.swift:375:18:375:25 | call to source() | test.swift:381:15:381:18 | .0 | result |
+| test.swift:428:19:428:19 | a | test.swift:422:19:422:26 | call to source() | test.swift:428:19:428:19 | a | result |
+| test.swift:437:19:437:19 | x | test.swift:422:19:422:26 | call to source() | test.swift:437:19:437:19 | x | result |
+| test.swift:453:19:453:19 | b | test.swift:444:26:444:33 | call to source() | test.swift:453:19:453:19 | b | result |
+| test.swift:463:19:463:19 | y | test.swift:444:26:444:33 | call to source() | test.swift:463:19:463:19 | y | result |
+| test.swift:479:19:479:19 | c | test.swift:444:26:444:33 | call to source() | test.swift:479:19:479:19 | c | result |
+| test.swift:488:19:488:19 | x | test.swift:487:51:487:58 | call to source() | test.swift:488:19:488:19 | x | result |
+| test.swift:492:19:492:19 | c | test.swift:444:26:444:33 | call to source() | test.swift:492:19:492:19 | c | result |
+| test.swift:498:19:498:19 | b | test.swift:444:26:444:33 | call to source() | test.swift:498:19:498:19 | b | result |
+| test.swift:501:19:501:19 | e | test.swift:444:26:444:33 | call to source() | test.swift:501:19:501:19 | e | result |
+| test.swift:513:54:513:54 | d2 | test.swift:507:30:507:37 | call to source() | test.swift:513:54:513:54 | d2 | result |
+| test.swift:515:54:515:54 | d4 | test.swift:509:24:509:31 | call to source() | test.swift:515:54:515:54 | d4 | result |
+| test.swift:517:54:517:54 | d6 | test.swift:511:24:511:31 | call to source() | test.swift:517:54:517:54 | d6 | result |
+| test.swift:526:15:526:17 | ...! | test.swift:520:28:520:35 | call to source() | test.swift:526:15:526:17 | ...! | result |
+| test.swift:528:15:528:17 | ...! | test.swift:522:26:522:33 | call to source() | test.swift:528:15:528:17 | ...! | result |
+| test.swift:530:15:530:17 | ...! | test.swift:524:26:524:33 | call to source() | test.swift:530:15:530:17 | ...! | result |
+| test.swift:539:19:539:19 | a | test.swift:259:12:259:19 | call to source() | test.swift:539:19:539:19 | a | result |
+| test.swift:546:19:546:19 | a | test.swift:259:12:259:19 | call to source() | test.swift:546:19:546:19 | a | result |
+| test.swift:570:15:570:15 | z1 | test.swift:259:12:259:19 | call to source() | test.swift:570:15:570:15 | z1 | result |
+| test.swift:576:13:576:21 | call to +(_:) | test.swift:576:14:576:21 | call to source() | test.swift:576:13:576:21 | call to +(_:) | result |
+| test.swift:577:14:577:21 | call to source() | test.swift:577:14:577:21 | call to source() | test.swift:577:14:577:21 | call to source() | result |
+| test.swift:594:17:594:17 | .str | test.swift:593:20:593:28 | call to source3() | test.swift:594:17:594:17 | .str | result |
+| test.swift:599:13:599:35 | .str | test.swift:599:24:599:32 | call to source3() | test.swift:599:13:599:35 | .str | result |
+| test.swift:600:13:600:43 | .str | test.swift:593:20:593:28 | call to source3() | test.swift:600:13:600:43 | .str | result |
+| test.swift:625:13:625:25 | \\...[...] | test.swift:623:16:623:23 | call to source() | test.swift:625:13:625:25 | \\...[...] | result |
+| test.swift:628:13:628:32 | \\...[...] | test.swift:623:16:623:23 | call to source() | test.swift:628:13:628:32 | \\...[...] | result |
+| test.swift:643:13:643:26 | \\...[...] | test.swift:640:16:640:23 | call to source() | test.swift:643:13:643:26 | \\...[...] | result |
+| test.swift:649:15:649:31 | \\...[...] | test.swift:647:18:647:25 | call to source() | test.swift:649:15:649:31 | \\...[...] | result |
+| test.swift:676:15:676:15 | y | test.swift:668:13:668:20 | call to source() | test.swift:676:15:676:15 | y | result |
+| test.swift:681:15:681:15 | x | test.swift:678:9:678:16 | call to source() | test.swift:681:15:681:15 | x | result |
+| test.swift:682:15:682:15 | y | test.swift:678:9:678:16 | call to source() | test.swift:682:15:682:15 | y | result |
+| test.swift:689:15:689:21 | ...[...] | test.swift:688:15:688:22 | call to source() | test.swift:689:15:689:21 | ...[...] | result |
+| test.swift:693:15:693:21 | ...[...] | test.swift:692:17:692:24 | call to source() | test.swift:693:15:693:21 | ...[...] | result |
+| test.swift:697:15:697:26 | ...[...] | test.swift:695:20:695:27 | call to source() | test.swift:697:15:697:26 | ...[...] | result |
+| test.swift:701:15:701:27 | ...[...] | test.swift:700:21:700:28 | call to source() | test.swift:701:15:701:27 | ...[...] | result |
+| test.swift:713:15:713:21 | ...[...] | test.swift:712:17:712:24 | call to source() | test.swift:713:15:713:21 | ...[...] | result |
+| test.swift:716:15:716:35 | ...! | test.swift:715:17:715:24 | call to source() | test.swift:716:15:716:35 | ...! | result |
+| test.swift:723:15:723:35 | ...! | test.swift:722:17:722:24 | call to source() | test.swift:723:15:723:35 | ...! | result |
+| test.swift:726:15:726:35 | ...! | test.swift:725:21:725:28 | call to source() | test.swift:726:15:726:35 | ...! | result |
+| test.swift:752:15:752:17 | ...! | test.swift:742:11:742:18 | call to source() | test.swift:752:15:752:17 | ...! | result |
+| test.swift:753:15:753:17 | ...! | test.swift:743:10:743:17 | call to source() | test.swift:753:15:753:17 | ...! | result |
+| test.swift:754:15:754:15 | v3 | test.swift:744:10:744:17 | call to source() | test.swift:754:15:754:15 | v3 | result |
+| test.swift:756:15:756:21 | ...! | test.swift:746:14:746:21 | call to source() | test.swift:756:15:756:21 | ...! | result |
+| test.swift:757:15:757:19 | .v3 | test.swift:747:14:747:21 | call to source() | test.swift:757:15:757:19 | .v3 | result |

--- a/swift/ql/test/library-tests/dataflow/dataflow/DataFlow.expected
+++ b/swift/ql/test/library-tests/dataflow/dataflow/DataFlow.expected
@@ -182,13 +182,17 @@ edges
 | test.swift:369:13:369:13 | t [Tuple element at index 1] | test.swift:369:13:369:15 | .1 |
 | test.swift:369:13:369:15 | .1 | test.swift:369:12:369:19 | (...) [Tuple element at index 0] |
 | test.swift:375:14:375:26 | (...) [Tuple element at index 1] | test.swift:376:30:376:30 | t1 [Tuple element at index 1] |
+| test.swift:375:14:375:26 | (...) [Tuple element at index 1] | test.swift:377:30:377:30 | t1 [Tuple element at index 1] |
 | test.swift:375:14:375:26 | (...) [Tuple element at index 1] | test.swift:380:15:380:15 | t1 [Tuple element at index 1] |
 | test.swift:375:18:375:25 | call to source() | test.swift:375:14:375:26 | (...) [Tuple element at index 1] |
 | test.swift:376:14:376:32 | call to tupleShiftLeft1(_:) [Tuple element at index 0] | test.swift:381:15:381:15 | t2 [Tuple element at index 0] |
 | test.swift:376:30:376:30 | t1 [Tuple element at index 1] | test.swift:368:22:368:36 | t [Tuple element at index 1] |
 | test.swift:376:30:376:30 | t1 [Tuple element at index 1] | test.swift:376:14:376:32 | call to tupleShiftLeft1(_:) [Tuple element at index 0] |
+| test.swift:377:14:377:32 | call to tupleShiftLeft2(_:) [Tuple element at index 0] | test.swift:383:15:383:15 | t3 [Tuple element at index 0] |
+| test.swift:377:30:377:30 | t1 [Tuple element at index 1] | test.swift:377:14:377:32 | call to tupleShiftLeft2(_:) [Tuple element at index 0] |
 | test.swift:380:15:380:15 | t1 [Tuple element at index 1] | test.swift:380:15:380:18 | .1 |
 | test.swift:381:15:381:15 | t2 [Tuple element at index 0] | test.swift:381:15:381:18 | .0 |
+| test.swift:383:15:383:15 | t3 [Tuple element at index 0] | test.swift:383:15:383:18 | .0 |
 | test.swift:394:16:394:21 | v | test.swift:394:61:394:61 | v |
 | test.swift:394:61:394:61 | v | test.swift:394:45:394:62 | call to ... [mySingle:0] |
 | test.swift:396:18:396:23 | v | test.swift:396:59:396:59 | v |
@@ -607,10 +611,14 @@ nodes
 | test.swift:375:18:375:25 | call to source() | semmle.label | call to source() |
 | test.swift:376:14:376:32 | call to tupleShiftLeft1(_:) [Tuple element at index 0] | semmle.label | call to tupleShiftLeft1(_:) [Tuple element at index 0] |
 | test.swift:376:30:376:30 | t1 [Tuple element at index 1] | semmle.label | t1 [Tuple element at index 1] |
+| test.swift:377:14:377:32 | call to tupleShiftLeft2(_:) [Tuple element at index 0] | semmle.label | call to tupleShiftLeft2(_:) [Tuple element at index 0] |
+| test.swift:377:30:377:30 | t1 [Tuple element at index 1] | semmle.label | t1 [Tuple element at index 1] |
 | test.swift:380:15:380:15 | t1 [Tuple element at index 1] | semmle.label | t1 [Tuple element at index 1] |
 | test.swift:380:15:380:18 | .1 | semmle.label | .1 |
 | test.swift:381:15:381:15 | t2 [Tuple element at index 0] | semmle.label | t2 [Tuple element at index 0] |
 | test.swift:381:15:381:18 | .0 | semmle.label | .0 |
+| test.swift:383:15:383:15 | t3 [Tuple element at index 0] | semmle.label | t3 [Tuple element at index 0] |
+| test.swift:383:15:383:18 | .0 | semmle.label | .0 |
 | test.swift:394:16:394:21 | v | semmle.label | v |
 | test.swift:394:45:394:62 | call to ... [mySingle:0] | semmle.label | call to ... [mySingle:0] |
 | test.swift:394:61:394:61 | v | semmle.label | v |
@@ -944,6 +952,7 @@ subpaths
 | test.swift:364:15:364:15 | b | test.swift:351:31:351:38 | call to source() | test.swift:364:15:364:15 | b | result |
 | test.swift:380:15:380:18 | .1 | test.swift:375:18:375:25 | call to source() | test.swift:380:15:380:18 | .1 | result |
 | test.swift:381:15:381:18 | .0 | test.swift:375:18:375:25 | call to source() | test.swift:381:15:381:18 | .0 | result |
+| test.swift:383:15:383:18 | .0 | test.swift:375:18:375:25 | call to source() | test.swift:383:15:383:18 | .0 | result |
 | test.swift:428:19:428:19 | a | test.swift:422:19:422:26 | call to source() | test.swift:428:19:428:19 | a | result |
 | test.swift:437:19:437:19 | x | test.swift:422:19:422:26 | call to source() | test.swift:437:19:437:19 | x | result |
 | test.swift:453:19:453:19 | b | test.swift:444:26:444:33 | call to source() | test.swift:453:19:453:19 | b | result |

--- a/swift/ql/test/library-tests/dataflow/dataflow/FlowConfig.qll
+++ b/swift/ql/test/library-tests/dataflow/dataflow/FlowConfig.qll
@@ -26,6 +26,8 @@ private class TestSummaries extends SummaryModelCsv {
       [
         // model to allow data flow through `signum()` as though it were an identity function, for the benefit of testing flow through optional chaining (`x?.`).
         ";Int;true;signum();;;Argument[-1];ReturnValue;value",
+        // test Tuple content in MAD
+        ";;false;tupleShiftLeft2(_:);;;Argument[0].TupleElement[1];ReturnValue.TupleElement[0];value",
         // test Enum content in MAD
         ";;false;mkMyEnum2(_:);;;Argument[0];ReturnValue.EnumElement[mySingle:0];value",
         ";;false;mkOptional2(_:);;;Argument[0];ReturnValue.OptionalSome;value"

--- a/swift/ql/test/library-tests/dataflow/dataflow/LocalFlow.expected
+++ b/swift/ql/test/library-tests/dataflow/dataflow/LocalFlow.expected
@@ -374,523 +374,542 @@
 | test.swift:360:15:360:15 | t2 | test.swift:361:15:361:15 | t2 |
 | test.swift:361:15:361:15 | [post] t2 | test.swift:362:15:362:15 | t2 |
 | test.swift:361:15:361:15 | t2 | test.swift:362:15:362:15 | t2 |
-| test.swift:375:16:375:21 | SSA def(v) | test.swift:375:61:375:61 | v |
-| test.swift:375:16:375:21 | v | test.swift:375:16:375:21 | SSA def(v) |
-| test.swift:377:18:377:23 | SSA def(v) | test.swift:377:59:377:59 | v |
-| test.swift:377:18:377:23 | v | test.swift:377:18:377:23 | SSA def(v) |
-| test.swift:381:9:381:9 | SSA def(a) | test.swift:383:12:383:12 | a |
-| test.swift:381:9:381:9 | a | test.swift:381:9:381:9 | SSA def(a) |
-| test.swift:381:9:381:13 | ... as ... | test.swift:381:9:381:9 | a |
-| test.swift:381:22:381:23 | .myNone | test.swift:381:9:381:13 | ... as ... |
-| test.swift:383:12:383:12 | a | test.swift:384:10:384:11 | .myNone |
-| test.swift:383:12:383:12 | a | test.swift:386:10:386:25 | .mySingle(...) |
-| test.swift:383:12:383:12 | a | test.swift:388:10:388:30 | .myPair(...) |
-| test.swift:383:12:383:12 | a | test.swift:391:14:391:26 | .myCons(...) |
-| test.swift:383:12:383:12 | a | test.swift:395:32:395:32 | a |
-| test.swift:386:24:386:24 | SSA def(a) | test.swift:387:19:387:19 | a |
-| test.swift:386:24:386:24 | a | test.swift:386:24:386:24 | SSA def(a) |
-| test.swift:388:22:388:22 | SSA def(a) | test.swift:389:19:389:19 | a |
-| test.swift:388:22:388:22 | a | test.swift:388:22:388:22 | SSA def(a) |
-| test.swift:388:29:388:29 | SSA def(b) | test.swift:390:19:390:19 | b |
-| test.swift:388:29:388:29 | b | test.swift:388:29:388:29 | SSA def(b) |
-| test.swift:391:10:391:26 | SSA phi(a) | test.swift:392:19:392:19 | a |
-| test.swift:391:22:391:22 | SSA def(a) | test.swift:391:10:391:26 | SSA phi(a) |
-| test.swift:391:22:391:22 | a | test.swift:391:22:391:22 | SSA def(a) |
-| test.swift:395:27:395:27 | SSA def(x) | test.swift:396:19:396:19 | x |
-| test.swift:395:27:395:27 | x | test.swift:395:27:395:27 | SSA def(x) |
-| test.swift:395:32:395:32 | a | test.swift:395:13:395:28 | .mySingle(...) |
-| test.swift:395:32:395:32 | a | test.swift:398:37:398:37 | a |
-| test.swift:398:25:398:25 | SSA def(x) | test.swift:399:19:399:19 | x |
-| test.swift:398:25:398:25 | x | test.swift:398:25:398:25 | SSA def(x) |
-| test.swift:398:32:398:32 | SSA def(y) | test.swift:400:19:400:19 | y |
-| test.swift:398:32:398:32 | y | test.swift:398:32:398:32 | SSA def(y) |
-| test.swift:398:37:398:37 | a | test.swift:398:13:398:33 | .myPair(...) |
-| test.swift:403:5:403:27 | SSA def(a) | test.swift:405:12:405:12 | a |
-| test.swift:403:9:403:27 | call to ... | test.swift:403:5:403:27 | SSA def(a) |
-| test.swift:405:12:405:12 | a | test.swift:406:10:406:11 | .myNone |
-| test.swift:405:12:405:12 | a | test.swift:408:10:408:25 | .mySingle(...) |
-| test.swift:405:12:405:12 | a | test.swift:410:10:410:30 | .myPair(...) |
-| test.swift:405:12:405:12 | a | test.swift:413:14:413:26 | .myCons(...) |
-| test.swift:405:12:405:12 | a | test.swift:417:32:417:32 | a |
-| test.swift:408:24:408:24 | SSA def(a) | test.swift:409:19:409:19 | a |
-| test.swift:408:24:408:24 | a | test.swift:408:24:408:24 | SSA def(a) |
-| test.swift:410:22:410:22 | SSA def(a) | test.swift:411:19:411:19 | a |
+| test.swift:368:22:368:36 | SSA def(t) | test.swift:369:13:369:13 | t |
+| test.swift:368:22:368:36 | t | test.swift:368:22:368:36 | SSA def(t) |
+| test.swift:375:9:375:9 | SSA def(t1) | test.swift:376:30:376:30 | t1 |
+| test.swift:375:9:375:9 | t1 | test.swift:375:9:375:9 | SSA def(t1) |
+| test.swift:375:14:375:26 | (...) | test.swift:375:9:375:9 | t1 |
+| test.swift:376:9:376:9 | SSA def(t2) | test.swift:381:15:381:15 | t2 |
+| test.swift:376:9:376:9 | t2 | test.swift:376:9:376:9 | SSA def(t2) |
+| test.swift:376:14:376:32 | call to tupleShiftLeft1(_:) | test.swift:376:9:376:9 | t2 |
+| test.swift:376:30:376:30 | t1 | test.swift:377:30:377:30 | t1 |
+| test.swift:377:9:377:9 | SSA def(t3) | test.swift:383:15:383:15 | t3 |
+| test.swift:377:9:377:9 | t3 | test.swift:377:9:377:9 | SSA def(t3) |
+| test.swift:377:14:377:32 | call to tupleShiftLeft2(_:) | test.swift:377:9:377:9 | t3 |
+| test.swift:377:30:377:30 | t1 | test.swift:379:15:379:15 | t1 |
+| test.swift:379:15:379:15 | [post] t1 | test.swift:380:15:380:15 | t1 |
+| test.swift:379:15:379:15 | t1 | test.swift:380:15:380:15 | t1 |
+| test.swift:381:15:381:15 | [post] t2 | test.swift:382:15:382:15 | t2 |
+| test.swift:381:15:381:15 | t2 | test.swift:382:15:382:15 | t2 |
+| test.swift:383:15:383:15 | [post] t3 | test.swift:384:15:384:15 | t3 |
+| test.swift:383:15:383:15 | t3 | test.swift:384:15:384:15 | t3 |
+| test.swift:394:16:394:21 | SSA def(v) | test.swift:394:61:394:61 | v |
+| test.swift:394:16:394:21 | v | test.swift:394:16:394:21 | SSA def(v) |
+| test.swift:396:18:396:23 | SSA def(v) | test.swift:396:59:396:59 | v |
+| test.swift:396:18:396:23 | v | test.swift:396:18:396:23 | SSA def(v) |
+| test.swift:400:9:400:9 | SSA def(a) | test.swift:402:12:402:12 | a |
+| test.swift:400:9:400:9 | a | test.swift:400:9:400:9 | SSA def(a) |
+| test.swift:400:9:400:13 | ... as ... | test.swift:400:9:400:9 | a |
+| test.swift:400:22:400:23 | .myNone | test.swift:400:9:400:13 | ... as ... |
+| test.swift:402:12:402:12 | a | test.swift:403:10:403:11 | .myNone |
+| test.swift:402:12:402:12 | a | test.swift:405:10:405:25 | .mySingle(...) |
+| test.swift:402:12:402:12 | a | test.swift:407:10:407:30 | .myPair(...) |
+| test.swift:402:12:402:12 | a | test.swift:410:14:410:26 | .myCons(...) |
+| test.swift:402:12:402:12 | a | test.swift:414:32:414:32 | a |
+| test.swift:405:24:405:24 | SSA def(a) | test.swift:406:19:406:19 | a |
+| test.swift:405:24:405:24 | a | test.swift:405:24:405:24 | SSA def(a) |
+| test.swift:407:22:407:22 | SSA def(a) | test.swift:408:19:408:19 | a |
+| test.swift:407:22:407:22 | a | test.swift:407:22:407:22 | SSA def(a) |
+| test.swift:407:29:407:29 | SSA def(b) | test.swift:409:19:409:19 | b |
+| test.swift:407:29:407:29 | b | test.swift:407:29:407:29 | SSA def(b) |
+| test.swift:410:10:410:26 | SSA phi(a) | test.swift:411:19:411:19 | a |
+| test.swift:410:22:410:22 | SSA def(a) | test.swift:410:10:410:26 | SSA phi(a) |
 | test.swift:410:22:410:22 | a | test.swift:410:22:410:22 | SSA def(a) |
-| test.swift:410:29:410:29 | SSA def(b) | test.swift:412:19:412:19 | b |
-| test.swift:410:29:410:29 | b | test.swift:410:29:410:29 | SSA def(b) |
-| test.swift:413:10:413:26 | SSA phi(a) | test.swift:414:19:414:19 | a |
-| test.swift:413:22:413:22 | SSA def(a) | test.swift:413:10:413:26 | SSA phi(a) |
-| test.swift:413:22:413:22 | a | test.swift:413:22:413:22 | SSA def(a) |
-| test.swift:417:27:417:27 | SSA def(x) | test.swift:418:19:418:19 | x |
-| test.swift:417:27:417:27 | x | test.swift:417:27:417:27 | SSA def(x) |
-| test.swift:417:32:417:32 | a | test.swift:417:13:417:28 | .mySingle(...) |
-| test.swift:417:32:417:32 | a | test.swift:420:37:420:37 | a |
-| test.swift:420:25:420:25 | SSA def(x) | test.swift:421:19:421:19 | x |
-| test.swift:420:25:420:25 | x | test.swift:420:25:420:25 | SSA def(x) |
-| test.swift:420:32:420:32 | SSA def(y) | test.swift:422:19:422:19 | y |
-| test.swift:420:32:420:32 | y | test.swift:420:32:420:32 | SSA def(y) |
-| test.swift:420:37:420:37 | a | test.swift:420:13:420:33 | .myPair(...) |
-| test.swift:425:5:425:34 | SSA def(a) | test.swift:427:12:427:12 | a |
-| test.swift:425:9:425:34 | call to ... | test.swift:425:5:425:34 | SSA def(a) |
-| test.swift:427:12:427:12 | a | test.swift:428:10:428:11 | .myNone |
-| test.swift:427:12:427:12 | a | test.swift:430:10:430:25 | .mySingle(...) |
-| test.swift:427:12:427:12 | a | test.swift:432:10:432:30 | .myPair(...) |
-| test.swift:427:12:427:12 | a | test.swift:435:14:435:26 | .myCons(...) |
-| test.swift:427:12:427:12 | a | test.swift:439:32:439:32 | a |
-| test.swift:430:24:430:24 | SSA def(a) | test.swift:431:19:431:19 | a |
-| test.swift:430:24:430:24 | a | test.swift:430:24:430:24 | SSA def(a) |
-| test.swift:432:22:432:22 | SSA def(a) | test.swift:433:19:433:19 | a |
+| test.swift:414:27:414:27 | SSA def(x) | test.swift:415:19:415:19 | x |
+| test.swift:414:27:414:27 | x | test.swift:414:27:414:27 | SSA def(x) |
+| test.swift:414:32:414:32 | a | test.swift:414:13:414:28 | .mySingle(...) |
+| test.swift:414:32:414:32 | a | test.swift:417:37:417:37 | a |
+| test.swift:417:25:417:25 | SSA def(x) | test.swift:418:19:418:19 | x |
+| test.swift:417:25:417:25 | x | test.swift:417:25:417:25 | SSA def(x) |
+| test.swift:417:32:417:32 | SSA def(y) | test.swift:419:19:419:19 | y |
+| test.swift:417:32:417:32 | y | test.swift:417:32:417:32 | SSA def(y) |
+| test.swift:417:37:417:37 | a | test.swift:417:13:417:33 | .myPair(...) |
+| test.swift:422:5:422:27 | SSA def(a) | test.swift:424:12:424:12 | a |
+| test.swift:422:9:422:27 | call to ... | test.swift:422:5:422:27 | SSA def(a) |
+| test.swift:424:12:424:12 | a | test.swift:425:10:425:11 | .myNone |
+| test.swift:424:12:424:12 | a | test.swift:427:10:427:25 | .mySingle(...) |
+| test.swift:424:12:424:12 | a | test.swift:429:10:429:30 | .myPair(...) |
+| test.swift:424:12:424:12 | a | test.swift:432:14:432:26 | .myCons(...) |
+| test.swift:424:12:424:12 | a | test.swift:436:32:436:32 | a |
+| test.swift:427:24:427:24 | SSA def(a) | test.swift:428:19:428:19 | a |
+| test.swift:427:24:427:24 | a | test.swift:427:24:427:24 | SSA def(a) |
+| test.swift:429:22:429:22 | SSA def(a) | test.swift:430:19:430:19 | a |
+| test.swift:429:22:429:22 | a | test.swift:429:22:429:22 | SSA def(a) |
+| test.swift:429:29:429:29 | SSA def(b) | test.swift:431:19:431:19 | b |
+| test.swift:429:29:429:29 | b | test.swift:429:29:429:29 | SSA def(b) |
+| test.swift:432:10:432:26 | SSA phi(a) | test.swift:433:19:433:19 | a |
+| test.swift:432:22:432:22 | SSA def(a) | test.swift:432:10:432:26 | SSA phi(a) |
 | test.swift:432:22:432:22 | a | test.swift:432:22:432:22 | SSA def(a) |
-| test.swift:432:29:432:29 | SSA def(b) | test.swift:434:19:434:19 | b |
-| test.swift:432:29:432:29 | b | test.swift:432:29:432:29 | SSA def(b) |
-| test.swift:435:10:435:26 | SSA phi(a) | test.swift:436:19:436:19 | a |
-| test.swift:435:22:435:22 | SSA def(a) | test.swift:435:10:435:26 | SSA phi(a) |
-| test.swift:435:22:435:22 | a | test.swift:435:22:435:22 | SSA def(a) |
-| test.swift:439:27:439:27 | SSA def(x) | test.swift:440:19:440:19 | x |
-| test.swift:439:27:439:27 | x | test.swift:439:27:439:27 | SSA def(x) |
-| test.swift:439:32:439:32 | a | test.swift:439:13:439:28 | .mySingle(...) |
-| test.swift:439:32:439:32 | a | test.swift:442:37:442:37 | a |
-| test.swift:442:25:442:25 | SSA def(x) | test.swift:443:19:443:19 | x |
-| test.swift:442:25:442:25 | x | test.swift:442:25:442:25 | SSA def(x) |
-| test.swift:442:32:442:32 | SSA def(y) | test.swift:444:19:444:19 | y |
-| test.swift:442:32:442:32 | y | test.swift:442:32:442:32 | SSA def(y) |
-| test.swift:442:37:442:37 | a | test.swift:442:13:442:33 | .myPair(...) |
-| test.swift:442:37:442:37 | a | test.swift:447:33:447:33 | a |
-| test.swift:447:9:447:9 | SSA def(b) | test.swift:449:12:449:12 | b |
-| test.swift:447:9:447:9 | b | test.swift:447:9:447:9 | SSA def(b) |
-| test.swift:447:9:447:12 | ... as ... | test.swift:447:9:447:9 | b |
-| test.swift:447:21:447:34 | call to ... | test.swift:447:9:447:12 | ... as ... |
-| test.swift:447:33:447:33 | [post] a | test.swift:476:13:476:13 | a |
-| test.swift:447:33:447:33 | a | test.swift:476:13:476:13 | a |
-| test.swift:449:12:449:12 | b | test.swift:450:10:450:11 | .myNone |
-| test.swift:449:12:449:12 | b | test.swift:452:10:452:25 | .mySingle(...) |
-| test.swift:449:12:449:12 | b | test.swift:454:10:454:30 | .myPair(...) |
-| test.swift:449:12:449:12 | b | test.swift:457:14:457:38 | .myCons(...) |
-| test.swift:449:12:449:12 | b | test.swift:461:14:461:26 | .myCons(...) |
-| test.swift:449:12:449:12 | b | test.swift:472:45:472:45 | b |
-| test.swift:452:24:452:24 | SSA def(a) | test.swift:453:19:453:19 | a |
-| test.swift:452:24:452:24 | a | test.swift:452:24:452:24 | SSA def(a) |
-| test.swift:454:22:454:22 | SSA def(a) | test.swift:455:19:455:19 | a |
+| test.swift:436:27:436:27 | SSA def(x) | test.swift:437:19:437:19 | x |
+| test.swift:436:27:436:27 | x | test.swift:436:27:436:27 | SSA def(x) |
+| test.swift:436:32:436:32 | a | test.swift:436:13:436:28 | .mySingle(...) |
+| test.swift:436:32:436:32 | a | test.swift:439:37:439:37 | a |
+| test.swift:439:25:439:25 | SSA def(x) | test.swift:440:19:440:19 | x |
+| test.swift:439:25:439:25 | x | test.swift:439:25:439:25 | SSA def(x) |
+| test.swift:439:32:439:32 | SSA def(y) | test.swift:441:19:441:19 | y |
+| test.swift:439:32:439:32 | y | test.swift:439:32:439:32 | SSA def(y) |
+| test.swift:439:37:439:37 | a | test.swift:439:13:439:33 | .myPair(...) |
+| test.swift:444:5:444:34 | SSA def(a) | test.swift:446:12:446:12 | a |
+| test.swift:444:9:444:34 | call to ... | test.swift:444:5:444:34 | SSA def(a) |
+| test.swift:446:12:446:12 | a | test.swift:447:10:447:11 | .myNone |
+| test.swift:446:12:446:12 | a | test.swift:449:10:449:25 | .mySingle(...) |
+| test.swift:446:12:446:12 | a | test.swift:451:10:451:30 | .myPair(...) |
+| test.swift:446:12:446:12 | a | test.swift:454:14:454:26 | .myCons(...) |
+| test.swift:446:12:446:12 | a | test.swift:458:32:458:32 | a |
+| test.swift:449:24:449:24 | SSA def(a) | test.swift:450:19:450:19 | a |
+| test.swift:449:24:449:24 | a | test.swift:449:24:449:24 | SSA def(a) |
+| test.swift:451:22:451:22 | SSA def(a) | test.swift:452:19:452:19 | a |
+| test.swift:451:22:451:22 | a | test.swift:451:22:451:22 | SSA def(a) |
+| test.swift:451:29:451:29 | SSA def(b) | test.swift:453:19:453:19 | b |
+| test.swift:451:29:451:29 | b | test.swift:451:29:451:29 | SSA def(b) |
+| test.swift:454:10:454:26 | SSA phi(a) | test.swift:455:19:455:19 | a |
+| test.swift:454:22:454:22 | SSA def(a) | test.swift:454:10:454:26 | SSA phi(a) |
 | test.swift:454:22:454:22 | a | test.swift:454:22:454:22 | SSA def(a) |
-| test.swift:454:29:454:29 | SSA def(b) | test.swift:456:19:456:19 | b |
-| test.swift:454:29:454:29 | b | test.swift:454:29:454:29 | SSA def(b) |
-| test.swift:457:10:457:38 | SSA phi(a) | test.swift:458:19:458:19 | a |
-| test.swift:457:10:457:38 | SSA phi(b) | test.swift:459:19:459:19 | b |
-| test.swift:457:10:457:38 | SSA phi(c) | test.swift:460:19:460:19 | c |
-| test.swift:457:22:457:22 | SSA def(a) | test.swift:457:10:457:38 | SSA phi(a) |
-| test.swift:457:22:457:22 | a | test.swift:457:22:457:22 | SSA def(a) |
-| test.swift:457:33:457:33 | SSA def(b) | test.swift:457:10:457:38 | SSA phi(b) |
-| test.swift:457:33:457:33 | b | test.swift:457:33:457:33 | SSA def(b) |
-| test.swift:457:36:457:36 | SSA def(c) | test.swift:457:10:457:38 | SSA phi(c) |
-| test.swift:457:36:457:36 | c | test.swift:457:36:457:36 | SSA def(c) |
-| test.swift:461:10:461:26 | SSA phi(a) | test.swift:462:19:462:19 | a |
-| test.swift:461:22:461:22 | SSA def(a) | test.swift:461:10:461:26 | SSA phi(a) |
-| test.swift:461:22:461:22 | a | test.swift:461:22:461:22 | SSA def(a) |
-| test.swift:465:27:465:27 | SSA def(x) | test.swift:466:19:466:19 | x |
-| test.swift:465:27:465:27 | x | test.swift:465:27:465:27 | SSA def(x) |
-| test.swift:465:32:465:57 | call to ... | test.swift:465:13:465:28 | .mySingle(...) |
-| test.swift:468:31:468:31 | SSA def(x) | test.swift:469:19:469:19 | x |
-| test.swift:468:31:468:31 | x | test.swift:468:31:468:31 | SSA def(x) |
-| test.swift:468:38:468:38 | SSA def(y) | test.swift:470:19:470:19 | y |
-| test.swift:468:38:468:38 | y | test.swift:468:38:468:38 | SSA def(y) |
-| test.swift:468:43:468:62 | call to ... | test.swift:468:13:468:39 | .myPair(...) |
-| test.swift:472:13:472:41 | SSA phi(c) | test.swift:473:19:473:19 | c |
-| test.swift:472:39:472:39 | SSA def(c) | test.swift:472:13:472:41 | SSA phi(c) |
-| test.swift:472:39:472:39 | c | test.swift:472:39:472:39 | SSA def(c) |
-| test.swift:472:45:472:45 | b | test.swift:472:17:472:41 | .myCons(...) |
-| test.swift:472:45:472:45 | b | test.swift:476:16:476:16 | b |
-| test.swift:476:12:476:17 | (...) | test.swift:477:14:477:55 | (...) |
-| test.swift:476:12:476:17 | (...) | test.swift:483:5:483:5 | _ |
-| test.swift:477:10:477:55 | SSA phi(a) | test.swift:478:19:478:19 | a |
-| test.swift:477:10:477:55 | SSA phi(b) | test.swift:479:19:479:19 | b |
-| test.swift:477:10:477:55 | SSA phi(c) | test.swift:480:19:480:19 | c |
-| test.swift:477:10:477:55 | SSA phi(d) | test.swift:481:19:481:19 | d |
-| test.swift:477:10:477:55 | SSA phi(e) | test.swift:482:19:482:19 | e |
-| test.swift:477:23:477:23 | SSA def(a) | test.swift:477:10:477:55 | SSA phi(a) |
-| test.swift:477:23:477:23 | a | test.swift:477:23:477:23 | SSA def(a) |
-| test.swift:477:26:477:26 | SSA def(b) | test.swift:477:10:477:55 | SSA phi(b) |
-| test.swift:477:26:477:26 | b | test.swift:477:26:477:26 | SSA def(b) |
-| test.swift:477:38:477:38 | SSA def(c) | test.swift:477:10:477:55 | SSA phi(c) |
-| test.swift:477:38:477:38 | c | test.swift:477:38:477:38 | SSA def(c) |
-| test.swift:477:49:477:49 | SSA def(d) | test.swift:477:10:477:55 | SSA phi(d) |
-| test.swift:477:49:477:49 | d | test.swift:477:49:477:49 | SSA def(d) |
-| test.swift:477:52:477:52 | SSA def(e) | test.swift:477:10:477:55 | SSA phi(e) |
-| test.swift:477:52:477:52 | e | test.swift:477:52:477:52 | SSA def(e) |
-| test.swift:487:9:487:9 | SSA def(c1) | test.swift:493:39:493:39 | c1 |
-| test.swift:487:9:487:9 | c1 | test.swift:487:9:487:9 | SSA def(c1) |
-| test.swift:487:14:487:31 | call to ... | test.swift:487:9:487:9 | c1 |
-| test.swift:488:9:488:9 | SSA def(c2) | test.swift:494:39:494:39 | c2 |
-| test.swift:488:9:488:9 | c2 | test.swift:488:9:488:9 | SSA def(c2) |
-| test.swift:488:14:488:38 | call to ... | test.swift:488:9:488:9 | c2 |
-| test.swift:489:9:489:9 | SSA def(c3) | test.swift:495:39:495:39 | c3 |
-| test.swift:489:9:489:9 | c3 | test.swift:489:9:489:9 | SSA def(c3) |
-| test.swift:489:14:489:25 | call to mkMyEnum1(_:) | test.swift:489:9:489:9 | c3 |
-| test.swift:490:9:490:9 | SSA def(c4) | test.swift:496:39:496:39 | c4 |
-| test.swift:490:9:490:9 | c4 | test.swift:490:9:490:9 | SSA def(c4) |
-| test.swift:490:14:490:32 | call to mkMyEnum1(_:) | test.swift:490:9:490:9 | c4 |
-| test.swift:491:9:491:9 | SSA def(c5) | test.swift:497:39:497:39 | c5 |
-| test.swift:491:9:491:9 | c5 | test.swift:491:9:491:9 | SSA def(c5) |
-| test.swift:491:14:491:25 | call to mkMyEnum2(_:) | test.swift:491:9:491:9 | c5 |
-| test.swift:492:9:492:9 | SSA def(c6) | test.swift:498:39:498:39 | c6 |
-| test.swift:492:9:492:9 | c6 | test.swift:492:9:492:9 | SSA def(c6) |
-| test.swift:492:14:492:32 | call to mkMyEnum2(_:) | test.swift:492:9:492:9 | c6 |
-| test.swift:493:33:493:33 | SSA def(d1) | test.swift:493:54:493:54 | d1 |
-| test.swift:493:33:493:33 | d1 | test.swift:493:33:493:33 | SSA def(d1) |
-| test.swift:493:39:493:39 | c1 | test.swift:493:13:493:35 | .mySingle(...) |
-| test.swift:494:33:494:33 | SSA def(d2) | test.swift:494:54:494:54 | d2 |
-| test.swift:494:33:494:33 | d2 | test.swift:494:33:494:33 | SSA def(d2) |
-| test.swift:494:39:494:39 | c2 | test.swift:494:13:494:35 | .mySingle(...) |
-| test.swift:495:33:495:33 | SSA def(d3) | test.swift:495:54:495:54 | d3 |
-| test.swift:495:33:495:33 | d3 | test.swift:495:33:495:33 | SSA def(d3) |
-| test.swift:495:39:495:39 | c3 | test.swift:495:13:495:35 | .mySingle(...) |
-| test.swift:496:33:496:33 | SSA def(d4) | test.swift:496:54:496:54 | d4 |
-| test.swift:496:33:496:33 | d4 | test.swift:496:33:496:33 | SSA def(d4) |
-| test.swift:496:39:496:39 | c4 | test.swift:496:13:496:35 | .mySingle(...) |
-| test.swift:497:33:497:33 | SSA def(d5) | test.swift:497:54:497:54 | d5 |
-| test.swift:497:33:497:33 | d5 | test.swift:497:33:497:33 | SSA def(d5) |
-| test.swift:497:39:497:39 | c5 | test.swift:497:13:497:35 | .mySingle(...) |
-| test.swift:498:33:498:33 | SSA def(d6) | test.swift:498:54:498:54 | d6 |
-| test.swift:498:33:498:33 | d6 | test.swift:498:33:498:33 | SSA def(d6) |
-| test.swift:498:39:498:39 | c6 | test.swift:498:13:498:35 | .mySingle(...) |
-| test.swift:500:9:500:9 | SSA def(e1) | test.swift:506:15:506:15 | e1 |
-| test.swift:500:9:500:9 | e1 | test.swift:500:9:500:9 | SSA def(e1) |
-| test.swift:500:14:500:29 | call to ... | test.swift:500:9:500:9 | e1 |
-| test.swift:501:9:501:9 | SSA def(e2) | test.swift:507:15:507:15 | e2 |
-| test.swift:501:9:501:9 | e2 | test.swift:501:9:501:9 | SSA def(e2) |
-| test.swift:501:14:501:36 | call to ... | test.swift:501:9:501:9 | e2 |
-| test.swift:502:9:502:9 | SSA def(e3) | test.swift:508:15:508:15 | e3 |
-| test.swift:502:9:502:9 | e3 | test.swift:502:9:502:9 | SSA def(e3) |
-| test.swift:502:14:502:27 | call to mkOptional1(_:) | test.swift:502:9:502:9 | e3 |
-| test.swift:503:9:503:9 | SSA def(e4) | test.swift:509:15:509:15 | e4 |
-| test.swift:503:9:503:9 | e4 | test.swift:503:9:503:9 | SSA def(e4) |
-| test.swift:503:14:503:34 | call to mkOptional1(_:) | test.swift:503:9:503:9 | e4 |
-| test.swift:504:9:504:9 | SSA def(e5) | test.swift:510:15:510:15 | e5 |
-| test.swift:504:9:504:9 | e5 | test.swift:504:9:504:9 | SSA def(e5) |
-| test.swift:504:14:504:27 | call to mkOptional2(_:) | test.swift:504:9:504:9 | e5 |
-| test.swift:505:9:505:9 | SSA def(e6) | test.swift:511:15:511:15 | e6 |
-| test.swift:505:9:505:9 | e6 | test.swift:505:9:505:9 | SSA def(e6) |
-| test.swift:505:14:505:34 | call to mkOptional2(_:) | test.swift:505:9:505:9 | e6 |
-| test.swift:506:15:506:15 | e1 | test.swift:506:15:506:17 | ...! |
-| test.swift:507:15:507:15 | e2 | test.swift:507:15:507:17 | ...! |
-| test.swift:508:15:508:15 | e3 | test.swift:508:15:508:17 | ...! |
-| test.swift:509:15:509:15 | e4 | test.swift:509:15:509:17 | ...! |
-| test.swift:510:15:510:15 | e5 | test.swift:510:15:510:17 | ...! |
-| test.swift:511:15:511:15 | e6 | test.swift:511:15:511:17 | ...! |
-| test.swift:516:21:516:27 | SSA def(y) | test.swift:519:27:519:27 | y |
-| test.swift:516:21:516:27 | SSA def(y) | test.swift:524:22:524:22 | y |
-| test.swift:516:21:516:27 | y | test.swift:516:21:516:27 | SSA def(y) |
-| test.swift:517:9:517:9 | SSA def(x) | test.swift:519:16:519:16 | x |
-| test.swift:517:9:517:9 | x | test.swift:517:9:517:9 | SSA def(x) |
-| test.swift:517:13:517:28 | call to optionalSource() | test.swift:517:9:517:9 | x |
-| test.swift:519:12:519:12 | SSA def(a) | test.swift:519:27:519:27 | SSA phi(a) |
-| test.swift:519:12:519:12 | a | test.swift:519:12:519:12 | SSA def(a) |
-| test.swift:519:16:519:16 | x | test.swift:519:8:519:12 | let ...? |
-| test.swift:519:16:519:16 | x | test.swift:524:19:524:19 | x |
-| test.swift:519:23:519:23 | SSA def(b) | test.swift:521:19:521:19 | b |
-| test.swift:519:23:519:23 | b | test.swift:519:23:519:23 | SSA def(b) |
-| test.swift:519:27:519:27 | SSA phi(a) | test.swift:520:19:520:19 | a |
-| test.swift:519:27:519:27 | y | test.swift:519:19:519:23 | let ...? |
-| test.swift:519:27:519:27 | y | test.swift:524:22:524:22 | y |
-| test.swift:524:9:524:9 | SSA def(tuple1) | test.swift:525:12:525:12 | tuple1 |
-| test.swift:524:9:524:9 | tuple1 | test.swift:524:9:524:9 | SSA def(tuple1) |
-| test.swift:524:18:524:23 | (...) | test.swift:524:9:524:9 | tuple1 |
-| test.swift:525:12:525:12 | tuple1 | test.swift:526:10:526:37 | (...) |
-| test.swift:525:12:525:12 | tuple1 | test.swift:529:5:529:5 | _ |
-| test.swift:526:21:526:21 | SSA def(a) | test.swift:527:19:527:19 | a |
-| test.swift:526:21:526:21 | a | test.swift:526:21:526:21 | SSA def(a) |
-| test.swift:526:35:526:35 | SSA def(b) | test.swift:528:19:528:19 | b |
-| test.swift:526:35:526:35 | b | test.swift:526:35:526:35 | SSA def(b) |
-| test.swift:533:13:533:13 | SSA def(x) | test.swift:534:19:534:19 | x |
-| test.swift:533:13:533:13 | x | test.swift:533:13:533:13 | SSA def(x) |
-| test.swift:533:16:533:16 | SSA def(y) | test.swift:535:19:535:19 | y |
-| test.swift:533:16:533:16 | y | test.swift:533:16:533:16 | SSA def(y) |
-| test.swift:533:21:533:29 | call to source2() | test.swift:533:8:533:17 | let ...? |
-| test.swift:539:7:539:7 | SSA def(self) | test.swift:539:7:539:7 | self[return] |
-| test.swift:539:7:539:7 | SSA def(self) | test.swift:539:7:539:7 | self[return] |
-| test.swift:539:7:539:7 | self | test.swift:539:7:539:7 | SSA def(self) |
-| test.swift:539:7:539:7 | self | test.swift:539:7:539:7 | SSA def(self) |
-| test.swift:540:9:540:9 | self | test.swift:540:9:540:9 | SSA def(self) |
-| test.swift:540:9:540:9 | self | test.swift:540:9:540:9 | SSA def(self) |
-| test.swift:540:9:540:9 | self | test.swift:540:9:540:9 | SSA def(self) |
-| test.swift:540:9:540:9 | value | test.swift:540:9:540:9 | SSA def(value) |
-| test.swift:543:33:543:39 | SSA def(y) | test.swift:548:12:548:12 | y |
-| test.swift:543:33:543:39 | y | test.swift:543:33:543:39 | SSA def(y) |
-| test.swift:544:9:544:9 | SSA def(x) | test.swift:546:12:546:12 | x |
-| test.swift:544:9:544:9 | x | test.swift:544:9:544:9 | SSA def(x) |
-| test.swift:544:13:544:28 | call to optionalSource() | test.swift:544:9:544:9 | x |
-| test.swift:545:9:545:9 | SSA def(cx) | test.swift:546:5:546:5 | cx |
-| test.swift:545:9:545:9 | cx | test.swift:545:9:545:9 | SSA def(cx) |
-| test.swift:545:14:545:16 | call to C.init() | test.swift:545:9:545:9 | cx |
-| test.swift:546:5:546:5 | [post] cx | test.swift:550:20:550:20 | cx |
-| test.swift:546:5:546:5 | cx | test.swift:550:20:550:20 | cx |
-| test.swift:547:9:547:9 | SSA def(cy) | test.swift:548:5:548:5 | cy |
-| test.swift:547:9:547:9 | cy | test.swift:547:9:547:9 | SSA def(cy) |
-| test.swift:547:14:547:16 | call to C.init() | test.swift:547:9:547:9 | cy |
-| test.swift:548:5:548:5 | [post] cy | test.swift:552:20:552:20 | cy |
-| test.swift:548:5:548:5 | cy | test.swift:552:20:552:20 | cy |
-| test.swift:550:15:550:15 | SSA def(z1) | test.swift:551:15:551:15 | z1 |
-| test.swift:550:15:550:15 | z1 | test.swift:550:15:550:15 | SSA def(z1) |
-| test.swift:550:20:550:23 | .x | test.swift:550:11:550:15 | let ...? |
-| test.swift:552:15:552:15 | SSA def(z2) | test.swift:553:15:553:15 | z2 |
-| test.swift:552:15:552:15 | z2 | test.swift:552:15:552:15 | SSA def(z2) |
-| test.swift:552:20:552:23 | .x | test.swift:552:11:552:15 | let ...? |
-| test.swift:557:14:557:21 | call to source() | test.swift:557:13:557:21 | call to +(_:) |
-| test.swift:565:7:565:7 | SSA def(self) | test.swift:565:7:565:7 | self[return] |
-| test.swift:565:7:565:7 | self | test.swift:565:7:565:7 | SSA def(self) |
-| test.swift:566:9:566:9 | self | test.swift:566:9:566:9 | SSA def(self) |
-| test.swift:566:9:566:9 | self | test.swift:566:9:566:9 | SSA def(self) |
-| test.swift:566:9:566:9 | self | test.swift:566:9:566:9 | SSA def(self) |
-| test.swift:566:9:566:9 | value | test.swift:566:9:566:9 | SSA def(value) |
-| test.swift:567:5:567:5 | SSA def(self) | test.swift:568:7:568:7 | self |
-| test.swift:567:5:567:5 | self | test.swift:567:5:567:5 | SSA def(self) |
-| test.swift:567:10:567:13 | SSA def(s) | test.swift:568:13:568:13 | s |
-| test.swift:567:10:567:13 | s | test.swift:567:10:567:13 | SSA def(s) |
-| test.swift:568:7:568:7 | [post] self | test.swift:567:5:569:5 | self[return] |
-| test.swift:568:7:568:7 | self | test.swift:567:5:569:5 | self[return] |
-| test.swift:573:17:573:17 | SSA def(self) | test.swift:574:7:574:7 | self |
-| test.swift:573:17:573:17 | self | test.swift:573:17:573:17 | SSA def(self) |
-| test.swift:574:7:574:7 | [post] self | test.swift:575:17:575:17 | self |
-| test.swift:574:7:574:7 | self | test.swift:575:17:575:17 | self |
-| test.swift:575:17:575:17 | [post] self | test.swift:573:17:576:5 | self[return] |
-| test.swift:575:17:575:17 | self | test.swift:573:17:576:5 | self[return] |
-| test.swift:579:21:579:27 | SSA def(path) | test.swift:581:37:581:37 | path |
-| test.swift:579:21:579:27 | path | test.swift:579:21:579:27 | SSA def(path) |
+| test.swift:458:27:458:27 | SSA def(x) | test.swift:459:19:459:19 | x |
+| test.swift:458:27:458:27 | x | test.swift:458:27:458:27 | SSA def(x) |
+| test.swift:458:32:458:32 | a | test.swift:458:13:458:28 | .mySingle(...) |
+| test.swift:458:32:458:32 | a | test.swift:461:37:461:37 | a |
+| test.swift:461:25:461:25 | SSA def(x) | test.swift:462:19:462:19 | x |
+| test.swift:461:25:461:25 | x | test.swift:461:25:461:25 | SSA def(x) |
+| test.swift:461:32:461:32 | SSA def(y) | test.swift:463:19:463:19 | y |
+| test.swift:461:32:461:32 | y | test.swift:461:32:461:32 | SSA def(y) |
+| test.swift:461:37:461:37 | a | test.swift:461:13:461:33 | .myPair(...) |
+| test.swift:461:37:461:37 | a | test.swift:466:33:466:33 | a |
+| test.swift:466:9:466:9 | SSA def(b) | test.swift:468:12:468:12 | b |
+| test.swift:466:9:466:9 | b | test.swift:466:9:466:9 | SSA def(b) |
+| test.swift:466:9:466:12 | ... as ... | test.swift:466:9:466:9 | b |
+| test.swift:466:21:466:34 | call to ... | test.swift:466:9:466:12 | ... as ... |
+| test.swift:466:33:466:33 | [post] a | test.swift:495:13:495:13 | a |
+| test.swift:466:33:466:33 | a | test.swift:495:13:495:13 | a |
+| test.swift:468:12:468:12 | b | test.swift:469:10:469:11 | .myNone |
+| test.swift:468:12:468:12 | b | test.swift:471:10:471:25 | .mySingle(...) |
+| test.swift:468:12:468:12 | b | test.swift:473:10:473:30 | .myPair(...) |
+| test.swift:468:12:468:12 | b | test.swift:476:14:476:38 | .myCons(...) |
+| test.swift:468:12:468:12 | b | test.swift:480:14:480:26 | .myCons(...) |
+| test.swift:468:12:468:12 | b | test.swift:491:45:491:45 | b |
+| test.swift:471:24:471:24 | SSA def(a) | test.swift:472:19:472:19 | a |
+| test.swift:471:24:471:24 | a | test.swift:471:24:471:24 | SSA def(a) |
+| test.swift:473:22:473:22 | SSA def(a) | test.swift:474:19:474:19 | a |
+| test.swift:473:22:473:22 | a | test.swift:473:22:473:22 | SSA def(a) |
+| test.swift:473:29:473:29 | SSA def(b) | test.swift:475:19:475:19 | b |
+| test.swift:473:29:473:29 | b | test.swift:473:29:473:29 | SSA def(b) |
+| test.swift:476:10:476:38 | SSA phi(a) | test.swift:477:19:477:19 | a |
+| test.swift:476:10:476:38 | SSA phi(b) | test.swift:478:19:478:19 | b |
+| test.swift:476:10:476:38 | SSA phi(c) | test.swift:479:19:479:19 | c |
+| test.swift:476:22:476:22 | SSA def(a) | test.swift:476:10:476:38 | SSA phi(a) |
+| test.swift:476:22:476:22 | a | test.swift:476:22:476:22 | SSA def(a) |
+| test.swift:476:33:476:33 | SSA def(b) | test.swift:476:10:476:38 | SSA phi(b) |
+| test.swift:476:33:476:33 | b | test.swift:476:33:476:33 | SSA def(b) |
+| test.swift:476:36:476:36 | SSA def(c) | test.swift:476:10:476:38 | SSA phi(c) |
+| test.swift:476:36:476:36 | c | test.swift:476:36:476:36 | SSA def(c) |
+| test.swift:480:10:480:26 | SSA phi(a) | test.swift:481:19:481:19 | a |
+| test.swift:480:22:480:22 | SSA def(a) | test.swift:480:10:480:26 | SSA phi(a) |
+| test.swift:480:22:480:22 | a | test.swift:480:22:480:22 | SSA def(a) |
+| test.swift:484:27:484:27 | SSA def(x) | test.swift:485:19:485:19 | x |
+| test.swift:484:27:484:27 | x | test.swift:484:27:484:27 | SSA def(x) |
+| test.swift:484:32:484:57 | call to ... | test.swift:484:13:484:28 | .mySingle(...) |
+| test.swift:487:31:487:31 | SSA def(x) | test.swift:488:19:488:19 | x |
+| test.swift:487:31:487:31 | x | test.swift:487:31:487:31 | SSA def(x) |
+| test.swift:487:38:487:38 | SSA def(y) | test.swift:489:19:489:19 | y |
+| test.swift:487:38:487:38 | y | test.swift:487:38:487:38 | SSA def(y) |
+| test.swift:487:43:487:62 | call to ... | test.swift:487:13:487:39 | .myPair(...) |
+| test.swift:491:13:491:41 | SSA phi(c) | test.swift:492:19:492:19 | c |
+| test.swift:491:39:491:39 | SSA def(c) | test.swift:491:13:491:41 | SSA phi(c) |
+| test.swift:491:39:491:39 | c | test.swift:491:39:491:39 | SSA def(c) |
+| test.swift:491:45:491:45 | b | test.swift:491:17:491:41 | .myCons(...) |
+| test.swift:491:45:491:45 | b | test.swift:495:16:495:16 | b |
+| test.swift:495:12:495:17 | (...) | test.swift:496:14:496:55 | (...) |
+| test.swift:495:12:495:17 | (...) | test.swift:502:5:502:5 | _ |
+| test.swift:496:10:496:55 | SSA phi(a) | test.swift:497:19:497:19 | a |
+| test.swift:496:10:496:55 | SSA phi(b) | test.swift:498:19:498:19 | b |
+| test.swift:496:10:496:55 | SSA phi(c) | test.swift:499:19:499:19 | c |
+| test.swift:496:10:496:55 | SSA phi(d) | test.swift:500:19:500:19 | d |
+| test.swift:496:10:496:55 | SSA phi(e) | test.swift:501:19:501:19 | e |
+| test.swift:496:23:496:23 | SSA def(a) | test.swift:496:10:496:55 | SSA phi(a) |
+| test.swift:496:23:496:23 | a | test.swift:496:23:496:23 | SSA def(a) |
+| test.swift:496:26:496:26 | SSA def(b) | test.swift:496:10:496:55 | SSA phi(b) |
+| test.swift:496:26:496:26 | b | test.swift:496:26:496:26 | SSA def(b) |
+| test.swift:496:38:496:38 | SSA def(c) | test.swift:496:10:496:55 | SSA phi(c) |
+| test.swift:496:38:496:38 | c | test.swift:496:38:496:38 | SSA def(c) |
+| test.swift:496:49:496:49 | SSA def(d) | test.swift:496:10:496:55 | SSA phi(d) |
+| test.swift:496:49:496:49 | d | test.swift:496:49:496:49 | SSA def(d) |
+| test.swift:496:52:496:52 | SSA def(e) | test.swift:496:10:496:55 | SSA phi(e) |
+| test.swift:496:52:496:52 | e | test.swift:496:52:496:52 | SSA def(e) |
+| test.swift:506:9:506:9 | SSA def(c1) | test.swift:512:39:512:39 | c1 |
+| test.swift:506:9:506:9 | c1 | test.swift:506:9:506:9 | SSA def(c1) |
+| test.swift:506:14:506:31 | call to ... | test.swift:506:9:506:9 | c1 |
+| test.swift:507:9:507:9 | SSA def(c2) | test.swift:513:39:513:39 | c2 |
+| test.swift:507:9:507:9 | c2 | test.swift:507:9:507:9 | SSA def(c2) |
+| test.swift:507:14:507:38 | call to ... | test.swift:507:9:507:9 | c2 |
+| test.swift:508:9:508:9 | SSA def(c3) | test.swift:514:39:514:39 | c3 |
+| test.swift:508:9:508:9 | c3 | test.swift:508:9:508:9 | SSA def(c3) |
+| test.swift:508:14:508:25 | call to mkMyEnum1(_:) | test.swift:508:9:508:9 | c3 |
+| test.swift:509:9:509:9 | SSA def(c4) | test.swift:515:39:515:39 | c4 |
+| test.swift:509:9:509:9 | c4 | test.swift:509:9:509:9 | SSA def(c4) |
+| test.swift:509:14:509:32 | call to mkMyEnum1(_:) | test.swift:509:9:509:9 | c4 |
+| test.swift:510:9:510:9 | SSA def(c5) | test.swift:516:39:516:39 | c5 |
+| test.swift:510:9:510:9 | c5 | test.swift:510:9:510:9 | SSA def(c5) |
+| test.swift:510:14:510:25 | call to mkMyEnum2(_:) | test.swift:510:9:510:9 | c5 |
+| test.swift:511:9:511:9 | SSA def(c6) | test.swift:517:39:517:39 | c6 |
+| test.swift:511:9:511:9 | c6 | test.swift:511:9:511:9 | SSA def(c6) |
+| test.swift:511:14:511:32 | call to mkMyEnum2(_:) | test.swift:511:9:511:9 | c6 |
+| test.swift:512:33:512:33 | SSA def(d1) | test.swift:512:54:512:54 | d1 |
+| test.swift:512:33:512:33 | d1 | test.swift:512:33:512:33 | SSA def(d1) |
+| test.swift:512:39:512:39 | c1 | test.swift:512:13:512:35 | .mySingle(...) |
+| test.swift:513:33:513:33 | SSA def(d2) | test.swift:513:54:513:54 | d2 |
+| test.swift:513:33:513:33 | d2 | test.swift:513:33:513:33 | SSA def(d2) |
+| test.swift:513:39:513:39 | c2 | test.swift:513:13:513:35 | .mySingle(...) |
+| test.swift:514:33:514:33 | SSA def(d3) | test.swift:514:54:514:54 | d3 |
+| test.swift:514:33:514:33 | d3 | test.swift:514:33:514:33 | SSA def(d3) |
+| test.swift:514:39:514:39 | c3 | test.swift:514:13:514:35 | .mySingle(...) |
+| test.swift:515:33:515:33 | SSA def(d4) | test.swift:515:54:515:54 | d4 |
+| test.swift:515:33:515:33 | d4 | test.swift:515:33:515:33 | SSA def(d4) |
+| test.swift:515:39:515:39 | c4 | test.swift:515:13:515:35 | .mySingle(...) |
+| test.swift:516:33:516:33 | SSA def(d5) | test.swift:516:54:516:54 | d5 |
+| test.swift:516:33:516:33 | d5 | test.swift:516:33:516:33 | SSA def(d5) |
+| test.swift:516:39:516:39 | c5 | test.swift:516:13:516:35 | .mySingle(...) |
+| test.swift:517:33:517:33 | SSA def(d6) | test.swift:517:54:517:54 | d6 |
+| test.swift:517:33:517:33 | d6 | test.swift:517:33:517:33 | SSA def(d6) |
+| test.swift:517:39:517:39 | c6 | test.swift:517:13:517:35 | .mySingle(...) |
+| test.swift:519:9:519:9 | SSA def(e1) | test.swift:525:15:525:15 | e1 |
+| test.swift:519:9:519:9 | e1 | test.swift:519:9:519:9 | SSA def(e1) |
+| test.swift:519:14:519:29 | call to ... | test.swift:519:9:519:9 | e1 |
+| test.swift:520:9:520:9 | SSA def(e2) | test.swift:526:15:526:15 | e2 |
+| test.swift:520:9:520:9 | e2 | test.swift:520:9:520:9 | SSA def(e2) |
+| test.swift:520:14:520:36 | call to ... | test.swift:520:9:520:9 | e2 |
+| test.swift:521:9:521:9 | SSA def(e3) | test.swift:527:15:527:15 | e3 |
+| test.swift:521:9:521:9 | e3 | test.swift:521:9:521:9 | SSA def(e3) |
+| test.swift:521:14:521:27 | call to mkOptional1(_:) | test.swift:521:9:521:9 | e3 |
+| test.swift:522:9:522:9 | SSA def(e4) | test.swift:528:15:528:15 | e4 |
+| test.swift:522:9:522:9 | e4 | test.swift:522:9:522:9 | SSA def(e4) |
+| test.swift:522:14:522:34 | call to mkOptional1(_:) | test.swift:522:9:522:9 | e4 |
+| test.swift:523:9:523:9 | SSA def(e5) | test.swift:529:15:529:15 | e5 |
+| test.swift:523:9:523:9 | e5 | test.swift:523:9:523:9 | SSA def(e5) |
+| test.swift:523:14:523:27 | call to mkOptional2(_:) | test.swift:523:9:523:9 | e5 |
+| test.swift:524:9:524:9 | SSA def(e6) | test.swift:530:15:530:15 | e6 |
+| test.swift:524:9:524:9 | e6 | test.swift:524:9:524:9 | SSA def(e6) |
+| test.swift:524:14:524:34 | call to mkOptional2(_:) | test.swift:524:9:524:9 | e6 |
+| test.swift:525:15:525:15 | e1 | test.swift:525:15:525:17 | ...! |
+| test.swift:526:15:526:15 | e2 | test.swift:526:15:526:17 | ...! |
+| test.swift:527:15:527:15 | e3 | test.swift:527:15:527:17 | ...! |
+| test.swift:528:15:528:15 | e4 | test.swift:528:15:528:17 | ...! |
+| test.swift:529:15:529:15 | e5 | test.swift:529:15:529:17 | ...! |
+| test.swift:530:15:530:15 | e6 | test.swift:530:15:530:17 | ...! |
+| test.swift:535:21:535:27 | SSA def(y) | test.swift:538:27:538:27 | y |
+| test.swift:535:21:535:27 | SSA def(y) | test.swift:543:22:543:22 | y |
+| test.swift:535:21:535:27 | y | test.swift:535:21:535:27 | SSA def(y) |
+| test.swift:536:9:536:9 | SSA def(x) | test.swift:538:16:538:16 | x |
+| test.swift:536:9:536:9 | x | test.swift:536:9:536:9 | SSA def(x) |
+| test.swift:536:13:536:28 | call to optionalSource() | test.swift:536:9:536:9 | x |
+| test.swift:538:12:538:12 | SSA def(a) | test.swift:538:27:538:27 | SSA phi(a) |
+| test.swift:538:12:538:12 | a | test.swift:538:12:538:12 | SSA def(a) |
+| test.swift:538:16:538:16 | x | test.swift:538:8:538:12 | let ...? |
+| test.swift:538:16:538:16 | x | test.swift:543:19:543:19 | x |
+| test.swift:538:23:538:23 | SSA def(b) | test.swift:540:19:540:19 | b |
+| test.swift:538:23:538:23 | b | test.swift:538:23:538:23 | SSA def(b) |
+| test.swift:538:27:538:27 | SSA phi(a) | test.swift:539:19:539:19 | a |
+| test.swift:538:27:538:27 | y | test.swift:538:19:538:23 | let ...? |
+| test.swift:538:27:538:27 | y | test.swift:543:22:543:22 | y |
+| test.swift:543:9:543:9 | SSA def(tuple1) | test.swift:544:12:544:12 | tuple1 |
+| test.swift:543:9:543:9 | tuple1 | test.swift:543:9:543:9 | SSA def(tuple1) |
+| test.swift:543:18:543:23 | (...) | test.swift:543:9:543:9 | tuple1 |
+| test.swift:544:12:544:12 | tuple1 | test.swift:545:10:545:37 | (...) |
+| test.swift:544:12:544:12 | tuple1 | test.swift:548:5:548:5 | _ |
+| test.swift:545:21:545:21 | SSA def(a) | test.swift:546:19:546:19 | a |
+| test.swift:545:21:545:21 | a | test.swift:545:21:545:21 | SSA def(a) |
+| test.swift:545:35:545:35 | SSA def(b) | test.swift:547:19:547:19 | b |
+| test.swift:545:35:545:35 | b | test.swift:545:35:545:35 | SSA def(b) |
+| test.swift:552:13:552:13 | SSA def(x) | test.swift:553:19:553:19 | x |
+| test.swift:552:13:552:13 | x | test.swift:552:13:552:13 | SSA def(x) |
+| test.swift:552:16:552:16 | SSA def(y) | test.swift:554:19:554:19 | y |
+| test.swift:552:16:552:16 | y | test.swift:552:16:552:16 | SSA def(y) |
+| test.swift:552:21:552:29 | call to source2() | test.swift:552:8:552:17 | let ...? |
+| test.swift:558:7:558:7 | SSA def(self) | test.swift:558:7:558:7 | self[return] |
+| test.swift:558:7:558:7 | SSA def(self) | test.swift:558:7:558:7 | self[return] |
+| test.swift:558:7:558:7 | self | test.swift:558:7:558:7 | SSA def(self) |
+| test.swift:558:7:558:7 | self | test.swift:558:7:558:7 | SSA def(self) |
+| test.swift:559:9:559:9 | self | test.swift:559:9:559:9 | SSA def(self) |
+| test.swift:559:9:559:9 | self | test.swift:559:9:559:9 | SSA def(self) |
+| test.swift:559:9:559:9 | self | test.swift:559:9:559:9 | SSA def(self) |
+| test.swift:559:9:559:9 | value | test.swift:559:9:559:9 | SSA def(value) |
+| test.swift:562:33:562:39 | SSA def(y) | test.swift:567:12:567:12 | y |
+| test.swift:562:33:562:39 | y | test.swift:562:33:562:39 | SSA def(y) |
+| test.swift:563:9:563:9 | SSA def(x) | test.swift:565:12:565:12 | x |
+| test.swift:563:9:563:9 | x | test.swift:563:9:563:9 | SSA def(x) |
+| test.swift:563:13:563:28 | call to optionalSource() | test.swift:563:9:563:9 | x |
+| test.swift:564:9:564:9 | SSA def(cx) | test.swift:565:5:565:5 | cx |
+| test.swift:564:9:564:9 | cx | test.swift:564:9:564:9 | SSA def(cx) |
+| test.swift:564:14:564:16 | call to C.init() | test.swift:564:9:564:9 | cx |
+| test.swift:565:5:565:5 | [post] cx | test.swift:569:20:569:20 | cx |
+| test.swift:565:5:565:5 | cx | test.swift:569:20:569:20 | cx |
+| test.swift:566:9:566:9 | SSA def(cy) | test.swift:567:5:567:5 | cy |
+| test.swift:566:9:566:9 | cy | test.swift:566:9:566:9 | SSA def(cy) |
+| test.swift:566:14:566:16 | call to C.init() | test.swift:566:9:566:9 | cy |
+| test.swift:567:5:567:5 | [post] cy | test.swift:571:20:571:20 | cy |
+| test.swift:567:5:567:5 | cy | test.swift:571:20:571:20 | cy |
+| test.swift:569:15:569:15 | SSA def(z1) | test.swift:570:15:570:15 | z1 |
+| test.swift:569:15:569:15 | z1 | test.swift:569:15:569:15 | SSA def(z1) |
+| test.swift:569:20:569:23 | .x | test.swift:569:11:569:15 | let ...? |
+| test.swift:571:15:571:15 | SSA def(z2) | test.swift:572:15:572:15 | z2 |
+| test.swift:571:15:571:15 | z2 | test.swift:571:15:571:15 | SSA def(z2) |
+| test.swift:571:20:571:23 | .x | test.swift:571:11:571:15 | let ...? |
+| test.swift:576:14:576:21 | call to source() | test.swift:576:13:576:21 | call to +(_:) |
 | test.swift:584:7:584:7 | SSA def(self) | test.swift:584:7:584:7 | self[return] |
 | test.swift:584:7:584:7 | self | test.swift:584:7:584:7 | SSA def(self) |
-| test.swift:585:3:585:3 | SSA def(self) | test.swift:585:3:585:40 | self[return] |
-| test.swift:585:3:585:3 | self | test.swift:585:3:585:3 | SSA def(self) |
-| test.swift:585:27:585:38 | SSA def(n) | test.swift:585:3:585:40 | n[return] |
-| test.swift:585:31:585:38 | call to source() | test.swift:585:27:585:38 | SSA def(n) |
-| test.swift:591:7:591:7 | SSA def(n) | test.swift:592:36:592:36 | n |
-| test.swift:591:7:591:7 | n | test.swift:591:7:591:7 | SSA def(n) |
-| test.swift:591:11:591:11 | 0 | test.swift:591:7:591:7 | n |
-| test.swift:592:36:592:36 | [post] n | test.swift:592:35:592:36 | &... |
-| test.swift:592:36:592:36 | n | test.swift:592:35:592:36 | &... |
-| test.swift:596:7:596:7 | self | test.swift:596:7:596:7 | SSA def(self) |
-| test.swift:598:3:598:3 | SSA def(self) | test.swift:599:5:599:5 | self |
-| test.swift:598:3:598:3 | self | test.swift:598:3:598:3 | SSA def(self) |
-| test.swift:598:8:598:11 | SSA def(x) | test.swift:599:14:599:14 | x |
-| test.swift:598:8:598:11 | x | test.swift:598:8:598:11 | SSA def(x) |
-| test.swift:599:5:599:5 | [post] self | test.swift:598:3:600:3 | self[return] |
-| test.swift:599:5:599:5 | self | test.swift:598:3:600:3 | self[return] |
-| test.swift:604:7:604:7 | SSA def(s) | test.swift:606:13:606:13 | s |
-| test.swift:604:7:604:7 | s | test.swift:604:7:604:7 | SSA def(s) |
-| test.swift:604:11:604:24 | call to S.init(x:) | test.swift:604:7:604:7 | s |
-| test.swift:605:7:605:7 | SSA def(f) | test.swift:606:24:606:24 | f |
-| test.swift:605:7:605:7 | f | test.swift:605:7:605:7 | SSA def(f) |
-| test.swift:605:11:605:14 | #keyPath(...) | test.swift:605:7:605:7 | f |
-| test.swift:605:11:605:14 | enter #keyPath(...) | test.swift:605:14:605:14 | KeyPathComponent |
-| test.swift:606:13:606:13 | s | test.swift:609:13:609:13 | s |
-| test.swift:608:7:608:7 | SSA def(inferred) | test.swift:609:24:609:24 | inferred |
-| test.swift:608:7:608:7 | inferred | test.swift:608:7:608:7 | SSA def(inferred) |
-| test.swift:608:7:608:32 | ... as ... | test.swift:608:7:608:7 | inferred |
-| test.swift:608:36:608:38 | #keyPath(...) | test.swift:608:7:608:32 | ... as ... |
-| test.swift:608:36:608:38 | enter #keyPath(...) | test.swift:608:38:608:38 | KeyPathComponent |
-| test.swift:613:7:613:7 | self | test.swift:613:7:613:7 | SSA def(self) |
-| test.swift:615:3:615:3 | SSA def(self) | test.swift:616:5:616:5 | self |
-| test.swift:615:3:615:3 | self | test.swift:615:3:615:3 | SSA def(self) |
-| test.swift:615:8:615:11 | SSA def(s) | test.swift:616:14:616:14 | s |
-| test.swift:615:8:615:11 | s | test.swift:615:8:615:11 | SSA def(s) |
-| test.swift:616:5:616:5 | [post] self | test.swift:615:3:617:3 | self[return] |
-| test.swift:616:5:616:5 | self | test.swift:615:3:617:3 | self[return] |
-| test.swift:621:7:621:7 | SSA def(s) | test.swift:622:18:622:18 | s |
-| test.swift:621:7:621:7 | s | test.swift:621:7:621:7 | SSA def(s) |
-| test.swift:621:11:621:24 | call to S.init(x:) | test.swift:621:7:621:7 | s |
-| test.swift:622:7:622:7 | SSA def(s2) | test.swift:624:13:624:13 | s2 |
-| test.swift:622:7:622:7 | s2 | test.swift:622:7:622:7 | SSA def(s2) |
-| test.swift:622:12:622:19 | call to S2.init(s:) | test.swift:622:7:622:7 | s2 |
-| test.swift:623:7:623:7 | SSA def(f) | test.swift:624:25:624:25 | f |
-| test.swift:623:7:623:7 | f | test.swift:623:7:623:7 | SSA def(f) |
-| test.swift:623:11:623:17 | #keyPath(...) | test.swift:623:7:623:7 | f |
-| test.swift:623:11:623:17 | enter #keyPath(...) | test.swift:623:15:623:15 | KeyPathComponent |
-| test.swift:628:9:628:9 | SSA def(array) | test.swift:630:15:630:15 | array |
-| test.swift:628:9:628:9 | array | test.swift:628:9:628:9 | SSA def(array) |
-| test.swift:628:17:628:26 | [...] | test.swift:628:9:628:9 | array |
-| test.swift:629:9:629:9 | SSA def(f) | test.swift:630:30:630:30 | f |
-| test.swift:629:9:629:9 | f | test.swift:629:9:629:9 | SSA def(f) |
-| test.swift:629:13:629:22 | #keyPath(...) | test.swift:629:9:629:9 | f |
-| test.swift:629:13:629:22 | enter #keyPath(...) | test.swift:629:20:629:22 | KeyPathComponent |
-| test.swift:634:7:634:7 | self | test.swift:634:7:634:7 | SSA def(self) |
-| test.swift:636:3:636:3 | SSA def(self) | test.swift:637:5:637:5 | self |
-| test.swift:636:3:636:3 | self | test.swift:636:3:636:3 | SSA def(self) |
-| test.swift:636:8:636:12 | SSA def(s) | test.swift:637:14:637:14 | s |
-| test.swift:636:8:636:12 | s | test.swift:636:8:636:12 | SSA def(s) |
-| test.swift:637:5:637:5 | [post] self | test.swift:636:3:638:3 | self[return] |
-| test.swift:637:5:637:5 | self | test.swift:636:3:638:3 | self[return] |
-| test.swift:642:9:642:9 | SSA def(s) | test.swift:643:29:643:29 | s |
-| test.swift:642:9:642:9 | s | test.swift:642:9:642:9 | SSA def(s) |
-| test.swift:642:13:642:26 | call to S.init(x:) | test.swift:642:9:642:9 | s |
-| test.swift:643:9:643:9 | SSA def(s2) | test.swift:645:15:645:15 | s2 |
-| test.swift:643:9:643:9 | s2 | test.swift:643:9:643:9 | SSA def(s2) |
-| test.swift:643:14:643:30 | call to S2_Optional.init(s:) | test.swift:643:9:643:9 | s2 |
-| test.swift:644:9:644:9 | SSA def(f) | test.swift:645:27:645:27 | f |
-| test.swift:644:9:644:9 | f | test.swift:644:9:644:9 | SSA def(f) |
-| test.swift:644:13:644:29 | #keyPath(...) | test.swift:644:9:644:9 | f |
-| test.swift:644:13:644:29 | enter #keyPath(...) | test.swift:644:26:644:26 | KeyPathComponent |
-| test.swift:649:9:649:9 | SSA def(x) | test.swift:653:9:653:9 | x |
-| test.swift:649:9:649:9 | x | test.swift:649:9:649:9 | SSA def(x) |
-| test.swift:649:13:649:20 | call to source() | test.swift:649:9:649:9 | x |
-| test.swift:650:9:650:9 | SSA def(y) | test.swift:654:9:654:9 | y |
-| test.swift:650:9:650:9 | y | test.swift:650:9:650:9 | SSA def(y) |
-| test.swift:650:13:650:13 | 0 | test.swift:650:9:650:9 | y |
-| test.swift:651:9:651:12 | ... as ... | test.swift:651:9:651:9 | t |
-| test.swift:653:5:653:9 | SSA def(t) | test.swift:655:9:655:9 | t |
-| test.swift:653:9:653:9 | x | test.swift:653:5:653:9 | SSA def(t) |
-| test.swift:654:5:654:9 | SSA def(x) | test.swift:656:15:656:15 | x |
-| test.swift:654:9:654:9 | y | test.swift:654:5:654:9 | SSA def(x) |
-| test.swift:655:5:655:9 | SSA def(y) | test.swift:657:15:657:15 | y |
-| test.swift:655:9:655:9 | t | test.swift:655:5:655:9 | SSA def(y) |
-| test.swift:659:5:659:16 | SSA def(x) | test.swift:661:11:661:11 | x |
-| test.swift:659:9:659:16 | call to source() | test.swift:659:5:659:16 | SSA def(x) |
-| test.swift:660:5:660:9 | SSA def(y) | test.swift:661:15:661:15 | y |
-| test.swift:660:9:660:9 | 0 | test.swift:660:5:660:9 | SSA def(y) |
-| test.swift:661:10:661:11 | &... | test.swift:662:15:662:15 | x |
-| test.swift:661:11:661:11 | [post] x | test.swift:661:10:661:11 | &... |
-| test.swift:661:11:661:11 | x | test.swift:661:10:661:11 | &... |
-| test.swift:661:14:661:15 | &... | test.swift:663:15:663:15 | y |
-| test.swift:661:15:661:15 | [post] y | test.swift:661:14:661:15 | &... |
-| test.swift:661:15:661:15 | y | test.swift:661:14:661:15 | &... |
-| test.swift:667:9:667:9 | SSA def(arr1) | test.swift:668:15:668:15 | arr1 |
-| test.swift:667:9:667:9 | arr1 | test.swift:667:9:667:9 | SSA def(arr1) |
-| test.swift:667:16:667:22 | [...] | test.swift:667:9:667:9 | arr1 |
-| test.swift:668:15:668:15 | &... | test.swift:669:5:669:5 | arr1 |
-| test.swift:668:15:668:15 | [post] arr1 | test.swift:668:15:668:15 | &... |
-| test.swift:668:15:668:15 | arr1 | test.swift:668:15:668:15 | &... |
-| test.swift:669:5:669:5 | &... | test.swift:670:15:670:15 | arr1 |
-| test.swift:669:5:669:5 | [post] arr1 | test.swift:669:5:669:5 | &... |
-| test.swift:669:5:669:5 | arr1 | test.swift:669:5:669:5 | &... |
-| test.swift:670:15:670:15 | &... | test.swift:671:15:671:15 | arr1 |
-| test.swift:670:15:670:15 | [post] arr1 | test.swift:670:15:670:15 | &... |
-| test.swift:670:15:670:15 | arr1 | test.swift:670:15:670:15 | &... |
-| test.swift:673:9:673:9 | SSA def(arr2) | test.swift:674:15:674:15 | arr2 |
-| test.swift:673:9:673:9 | arr2 | test.swift:673:9:673:9 | SSA def(arr2) |
-| test.swift:673:16:673:25 | [...] | test.swift:673:9:673:9 | arr2 |
-| test.swift:674:15:674:15 | &... | test.swift:685:16:685:16 | arr2 |
-| test.swift:674:15:674:15 | [post] arr2 | test.swift:674:15:674:15 | &... |
-| test.swift:674:15:674:15 | arr2 | test.swift:674:15:674:15 | &... |
-| test.swift:676:9:676:9 | SSA def(matrix) | test.swift:677:15:677:15 | matrix |
-| test.swift:676:9:676:9 | matrix | test.swift:676:9:676:9 | SSA def(matrix) |
-| test.swift:676:18:676:29 | [...] | test.swift:676:9:676:9 | matrix |
-| test.swift:677:15:677:15 | &... | test.swift:678:15:678:15 | matrix |
-| test.swift:677:15:677:15 | [post] matrix | test.swift:677:15:677:15 | &... |
-| test.swift:677:15:677:15 | matrix | test.swift:677:15:677:15 | &... |
-| test.swift:678:15:678:15 | [post] matrix | test.swift:678:15:678:15 | &... |
-| test.swift:678:15:678:15 | matrix | test.swift:678:15:678:15 | &... |
-| test.swift:678:15:678:23 | ...[...] | test.swift:678:15:678:23 | &... |
-| test.swift:680:9:680:9 | SSA def(matrix2) | test.swift:681:5:681:5 | matrix2 |
-| test.swift:680:9:680:9 | matrix2 | test.swift:680:9:680:9 | SSA def(matrix2) |
-| test.swift:680:19:680:23 | [...] | test.swift:680:9:680:9 | matrix2 |
-| test.swift:681:5:681:5 | &... | test.swift:682:15:682:15 | matrix2 |
-| test.swift:681:5:681:5 | [post] matrix2 | test.swift:681:5:681:5 | &... |
-| test.swift:681:5:681:5 | matrix2 | test.swift:681:5:681:5 | &... |
-| test.swift:681:5:681:14 | ...[...] | test.swift:681:5:681:14 | &... |
-| test.swift:682:15:682:15 | [post] matrix2 | test.swift:682:15:682:15 | &... |
-| test.swift:682:15:682:15 | matrix2 | test.swift:682:15:682:15 | &... |
-| test.swift:682:15:682:24 | ...[...] | test.swift:682:15:682:24 | &... |
-| test.swift:684:9:684:9 | SSA def(arr3) | test.swift:685:23:685:23 | arr3 |
-| test.swift:684:9:684:9 | arr3 | test.swift:684:9:684:9 | SSA def(arr3) |
-| test.swift:684:16:684:18 | [...] | test.swift:684:9:684:9 | arr3 |
-| test.swift:685:9:685:9 | SSA def(arr4) | test.swift:687:15:687:15 | arr4 |
-| test.swift:685:9:685:9 | arr4 | test.swift:685:9:685:9 | SSA def(arr4) |
-| test.swift:685:16:685:23 | ... .+(_:_:) ... | test.swift:685:9:685:9 | arr4 |
-| test.swift:685:23:685:23 | arr3 | test.swift:686:15:686:15 | arr3 |
-| test.swift:686:15:686:15 | [post] arr3 | test.swift:686:15:686:15 | &... |
-| test.swift:686:15:686:15 | arr3 | test.swift:686:15:686:15 | &... |
-| test.swift:687:15:687:15 | [post] arr4 | test.swift:687:15:687:15 | &... |
-| test.swift:687:15:687:15 | arr4 | test.swift:687:15:687:15 | &... |
-| test.swift:689:9:689:9 | SSA def(arr5) | test.swift:690:15:690:15 | arr5 |
-| test.swift:689:9:689:9 | arr5 | test.swift:689:9:689:9 | SSA def(arr5) |
-| test.swift:689:16:689:51 | call to Array<Element>.init(repeating:count:) | test.swift:689:9:689:9 | arr5 |
-| test.swift:690:15:690:15 | [post] arr5 | test.swift:690:15:690:15 | &... |
-| test.swift:690:15:690:15 | arr5 | test.swift:690:15:690:15 | &... |
-| test.swift:692:9:692:9 | SSA def(arr6) | test.swift:693:5:693:5 | arr6 |
-| test.swift:692:9:692:9 | arr6 | test.swift:692:9:692:9 | SSA def(arr6) |
-| test.swift:692:16:692:22 | [...] | test.swift:692:9:692:9 | arr6 |
-| test.swift:693:5:693:5 | &... | test.swift:694:15:694:15 | arr6 |
-| test.swift:693:5:693:5 | [post] arr6 | test.swift:693:5:693:5 | &... |
-| test.swift:693:5:693:5 | arr6 | test.swift:693:5:693:5 | &... |
-| test.swift:694:15:694:15 | [post] arr6 | test.swift:694:15:694:15 | &... |
-| test.swift:694:15:694:15 | arr6 | test.swift:694:15:694:15 | &... |
-| test.swift:696:9:696:9 | SSA def(arr7) | test.swift:697:15:697:15 | arr7 |
-| test.swift:696:9:696:9 | arr7 | test.swift:696:9:696:9 | SSA def(arr7) |
-| test.swift:696:16:696:25 | [...] | test.swift:696:9:696:9 | arr7 |
-| test.swift:697:15:697:34 | call to randomElement() | test.swift:697:15:697:35 | ...! |
-| test.swift:701:9:701:9 | SSA def(set1) | test.swift:702:15:702:15 | set1 |
-| test.swift:701:9:701:9 | set1 | test.swift:701:9:701:9 | SSA def(set1) |
-| test.swift:701:9:701:15 | ... as ... | test.swift:701:9:701:9 | set1 |
-| test.swift:701:21:701:27 | [...] | test.swift:701:9:701:15 | ... as ... |
-| test.swift:702:15:702:15 | [post] set1 | test.swift:703:5:703:5 | set1 |
-| test.swift:702:15:702:15 | set1 | test.swift:703:5:703:5 | set1 |
-| test.swift:702:15:702:34 | call to randomElement() | test.swift:702:15:702:35 | ...! |
-| test.swift:703:5:703:5 | &... | test.swift:704:15:704:15 | set1 |
-| test.swift:703:5:703:5 | [post] set1 | test.swift:703:5:703:5 | &... |
-| test.swift:703:5:703:5 | set1 | test.swift:703:5:703:5 | &... |
-| test.swift:704:15:704:34 | call to randomElement() | test.swift:704:15:704:35 | ...! |
-| test.swift:706:9:706:9 | SSA def(set2) | test.swift:707:15:707:15 | set2 |
-| test.swift:706:9:706:9 | set2 | test.swift:706:9:706:9 | SSA def(set2) |
-| test.swift:706:16:706:30 | call to Set<Element>.init(_:) | test.swift:706:9:706:9 | set2 |
-| test.swift:707:15:707:34 | call to randomElement() | test.swift:707:15:707:35 | ...! |
-| test.swift:710:8:710:8 | SSA def(self) | test.swift:710:8:710:8 | self[return] |
-| test.swift:710:8:710:8 | self | test.swift:710:8:710:8 | SSA def(self) |
-| test.swift:711:9:711:9 | self | test.swift:711:9:711:9 | SSA def(self) |
-| test.swift:711:9:711:9 | self | test.swift:711:9:711:9 | SSA def(self) |
-| test.swift:711:9:711:9 | self | test.swift:711:9:711:9 | SSA def(self) |
-| test.swift:711:9:711:9 | value | test.swift:711:9:711:9 | SSA def(value) |
-| test.swift:712:9:712:9 | self | test.swift:712:9:712:9 | SSA def(self) |
-| test.swift:712:9:712:9 | self | test.swift:712:9:712:9 | SSA def(self) |
-| test.swift:712:9:712:9 | self | test.swift:712:9:712:9 | SSA def(self) |
-| test.swift:712:9:712:9 | value | test.swift:712:9:712:9 | SSA def(value) |
-| test.swift:713:9:713:9 | self | test.swift:713:9:713:9 | SSA def(self) |
-| test.swift:713:9:713:9 | self | test.swift:713:9:713:9 | SSA def(self) |
-| test.swift:713:9:713:9 | self | test.swift:713:9:713:9 | SSA def(self) |
-| test.swift:713:9:713:9 | value | test.swift:713:9:713:9 | SSA def(value) |
-| test.swift:717:9:717:9 | SSA def(v1) | test.swift:723:5:723:5 | v1 |
-| test.swift:717:9:717:9 | v1 | test.swift:717:9:717:9 | SSA def(v1) |
-| test.swift:717:9:717:17 | ... as ... | test.swift:717:9:717:9 | v1 |
-| test.swift:717:21:717:21 | 0 | test.swift:717:9:717:17 | ... as ... |
-| test.swift:718:9:718:17 | ... as ... | test.swift:718:9:718:9 | v2 |
-| test.swift:718:21:718:21 | 0 | test.swift:718:9:718:17 | ... as ... |
-| test.swift:719:9:719:17 | ... as ... | test.swift:719:9:719:9 | v3 |
-| test.swift:719:21:719:21 | 0 | test.swift:719:9:719:17 | ... as ... |
-| test.swift:720:9:720:9 | SSA def(mo1) | test.swift:726:5:726:5 | mo1 |
-| test.swift:720:9:720:9 | mo1 | test.swift:720:9:720:9 | SSA def(mo1) |
-| test.swift:720:15:720:27 | call to MyOptionals.init() | test.swift:720:9:720:9 | mo1 |
-| test.swift:721:9:721:9 | SSA def(mo2) | test.swift:729:5:729:5 | mo2 |
-| test.swift:721:9:721:9 | mo2 | test.swift:721:9:721:9 | SSA def(mo2) |
-| test.swift:721:9:721:26 | ... as ... | test.swift:721:9:721:9 | mo2 |
-| test.swift:721:30:721:42 | call to MyOptionals.init() | test.swift:721:9:721:26 | ... as ... |
-| test.swift:723:5:723:5 | v1 | test.swift:723:5:723:7 | ...! |
-| test.swift:723:5:723:5 | v1 | test.swift:733:15:733:15 | v1 |
-| test.swift:724:5:724:17 | SSA def(v2) | test.swift:734:15:734:15 | v2 |
-| test.swift:724:10:724:17 | call to source() | test.swift:724:5:724:17 | SSA def(v2) |
-| test.swift:725:5:725:17 | SSA def(v3) | test.swift:735:15:735:15 | v3 |
-| test.swift:725:10:725:17 | call to source() | test.swift:725:5:725:17 | SSA def(v3) |
-| test.swift:726:5:726:5 | [post] mo1 | test.swift:727:5:727:5 | mo1 |
-| test.swift:726:5:726:5 | mo1 | test.swift:727:5:727:5 | mo1 |
-| test.swift:726:5:726:9 | .v1 | test.swift:726:5:726:11 | ...! |
-| test.swift:727:5:727:5 | [post] mo1 | test.swift:728:5:728:5 | mo1 |
-| test.swift:727:5:727:5 | mo1 | test.swift:728:5:728:5 | mo1 |
-| test.swift:728:5:728:5 | [post] mo1 | test.swift:736:15:736:15 | mo1 |
-| test.swift:728:5:728:5 | mo1 | test.swift:736:15:736:15 | mo1 |
-| test.swift:729:5:729:5 | mo2 | test.swift:729:5:729:8 | ...! |
-| test.swift:729:5:729:5 | mo2 | test.swift:730:5:730:5 | mo2 |
-| test.swift:729:5:729:10 | .v1 | test.swift:729:5:729:12 | ...! |
-| test.swift:730:5:730:5 | mo2 | test.swift:730:5:730:8 | ...! |
-| test.swift:730:5:730:5 | mo2 | test.swift:731:5:731:5 | mo2 |
-| test.swift:731:5:731:5 | mo2 | test.swift:731:5:731:8 | ...! |
-| test.swift:731:5:731:5 | mo2 | test.swift:739:15:739:15 | mo2 |
-| test.swift:733:15:733:15 | v1 | test.swift:733:15:733:17 | ...! |
-| test.swift:734:15:734:15 | v2 | test.swift:734:15:734:17 | ...! |
-| test.swift:736:15:736:15 | [post] mo1 | test.swift:737:15:737:15 | mo1 |
-| test.swift:736:15:736:15 | mo1 | test.swift:737:15:737:15 | mo1 |
-| test.swift:736:15:736:19 | .v1 | test.swift:736:15:736:21 | ...! |
-| test.swift:737:15:737:15 | [post] mo1 | test.swift:738:15:738:15 | mo1 |
-| test.swift:737:15:737:15 | mo1 | test.swift:738:15:738:15 | mo1 |
-| test.swift:737:15:737:19 | .v2 | test.swift:737:15:737:21 | ...! |
-| test.swift:739:15:739:15 | mo2 | test.swift:739:15:739:18 | ...! |
-| test.swift:739:15:739:15 | mo2 | test.swift:740:15:740:15 | mo2 |
-| test.swift:739:15:739:20 | .v1 | test.swift:739:15:739:22 | ...! |
-| test.swift:740:15:740:15 | mo2 | test.swift:740:15:740:18 | ...! |
-| test.swift:740:15:740:15 | mo2 | test.swift:741:15:741:15 | mo2 |
-| test.swift:740:15:740:20 | .v2 | test.swift:740:15:740:22 | ...! |
-| test.swift:741:15:741:15 | mo2 | test.swift:741:15:741:18 | ...! |
+| test.swift:585:9:585:9 | self | test.swift:585:9:585:9 | SSA def(self) |
+| test.swift:585:9:585:9 | self | test.swift:585:9:585:9 | SSA def(self) |
+| test.swift:585:9:585:9 | self | test.swift:585:9:585:9 | SSA def(self) |
+| test.swift:585:9:585:9 | value | test.swift:585:9:585:9 | SSA def(value) |
+| test.swift:586:5:586:5 | SSA def(self) | test.swift:587:7:587:7 | self |
+| test.swift:586:5:586:5 | self | test.swift:586:5:586:5 | SSA def(self) |
+| test.swift:586:10:586:13 | SSA def(s) | test.swift:587:13:587:13 | s |
+| test.swift:586:10:586:13 | s | test.swift:586:10:586:13 | SSA def(s) |
+| test.swift:587:7:587:7 | [post] self | test.swift:586:5:588:5 | self[return] |
+| test.swift:587:7:587:7 | self | test.swift:586:5:588:5 | self[return] |
+| test.swift:592:17:592:17 | SSA def(self) | test.swift:593:7:593:7 | self |
+| test.swift:592:17:592:17 | self | test.swift:592:17:592:17 | SSA def(self) |
+| test.swift:593:7:593:7 | [post] self | test.swift:594:17:594:17 | self |
+| test.swift:593:7:593:7 | self | test.swift:594:17:594:17 | self |
+| test.swift:594:17:594:17 | [post] self | test.swift:592:17:595:5 | self[return] |
+| test.swift:594:17:594:17 | self | test.swift:592:17:595:5 | self[return] |
+| test.swift:598:21:598:27 | SSA def(path) | test.swift:600:37:600:37 | path |
+| test.swift:598:21:598:27 | path | test.swift:598:21:598:27 | SSA def(path) |
+| test.swift:603:7:603:7 | SSA def(self) | test.swift:603:7:603:7 | self[return] |
+| test.swift:603:7:603:7 | self | test.swift:603:7:603:7 | SSA def(self) |
+| test.swift:604:3:604:3 | SSA def(self) | test.swift:604:3:604:40 | self[return] |
+| test.swift:604:3:604:3 | self | test.swift:604:3:604:3 | SSA def(self) |
+| test.swift:604:27:604:38 | SSA def(n) | test.swift:604:3:604:40 | n[return] |
+| test.swift:604:31:604:38 | call to source() | test.swift:604:27:604:38 | SSA def(n) |
+| test.swift:610:7:610:7 | SSA def(n) | test.swift:611:36:611:36 | n |
+| test.swift:610:7:610:7 | n | test.swift:610:7:610:7 | SSA def(n) |
+| test.swift:610:11:610:11 | 0 | test.swift:610:7:610:7 | n |
+| test.swift:611:36:611:36 | [post] n | test.swift:611:35:611:36 | &... |
+| test.swift:611:36:611:36 | n | test.swift:611:35:611:36 | &... |
+| test.swift:615:7:615:7 | self | test.swift:615:7:615:7 | SSA def(self) |
+| test.swift:617:3:617:3 | SSA def(self) | test.swift:618:5:618:5 | self |
+| test.swift:617:3:617:3 | self | test.swift:617:3:617:3 | SSA def(self) |
+| test.swift:617:8:617:11 | SSA def(x) | test.swift:618:14:618:14 | x |
+| test.swift:617:8:617:11 | x | test.swift:617:8:617:11 | SSA def(x) |
+| test.swift:618:5:618:5 | [post] self | test.swift:617:3:619:3 | self[return] |
+| test.swift:618:5:618:5 | self | test.swift:617:3:619:3 | self[return] |
+| test.swift:623:7:623:7 | SSA def(s) | test.swift:625:13:625:13 | s |
+| test.swift:623:7:623:7 | s | test.swift:623:7:623:7 | SSA def(s) |
+| test.swift:623:11:623:24 | call to S.init(x:) | test.swift:623:7:623:7 | s |
+| test.swift:624:7:624:7 | SSA def(f) | test.swift:625:24:625:24 | f |
+| test.swift:624:7:624:7 | f | test.swift:624:7:624:7 | SSA def(f) |
+| test.swift:624:11:624:14 | #keyPath(...) | test.swift:624:7:624:7 | f |
+| test.swift:624:11:624:14 | enter #keyPath(...) | test.swift:624:14:624:14 | KeyPathComponent |
+| test.swift:625:13:625:13 | s | test.swift:628:13:628:13 | s |
+| test.swift:627:7:627:7 | SSA def(inferred) | test.swift:628:24:628:24 | inferred |
+| test.swift:627:7:627:7 | inferred | test.swift:627:7:627:7 | SSA def(inferred) |
+| test.swift:627:7:627:32 | ... as ... | test.swift:627:7:627:7 | inferred |
+| test.swift:627:36:627:38 | #keyPath(...) | test.swift:627:7:627:32 | ... as ... |
+| test.swift:627:36:627:38 | enter #keyPath(...) | test.swift:627:38:627:38 | KeyPathComponent |
+| test.swift:632:7:632:7 | self | test.swift:632:7:632:7 | SSA def(self) |
+| test.swift:634:3:634:3 | SSA def(self) | test.swift:635:5:635:5 | self |
+| test.swift:634:3:634:3 | self | test.swift:634:3:634:3 | SSA def(self) |
+| test.swift:634:8:634:11 | SSA def(s) | test.swift:635:14:635:14 | s |
+| test.swift:634:8:634:11 | s | test.swift:634:8:634:11 | SSA def(s) |
+| test.swift:635:5:635:5 | [post] self | test.swift:634:3:636:3 | self[return] |
+| test.swift:635:5:635:5 | self | test.swift:634:3:636:3 | self[return] |
+| test.swift:640:7:640:7 | SSA def(s) | test.swift:641:18:641:18 | s |
+| test.swift:640:7:640:7 | s | test.swift:640:7:640:7 | SSA def(s) |
+| test.swift:640:11:640:24 | call to S.init(x:) | test.swift:640:7:640:7 | s |
+| test.swift:641:7:641:7 | SSA def(s2) | test.swift:643:13:643:13 | s2 |
+| test.swift:641:7:641:7 | s2 | test.swift:641:7:641:7 | SSA def(s2) |
+| test.swift:641:12:641:19 | call to S2.init(s:) | test.swift:641:7:641:7 | s2 |
+| test.swift:642:7:642:7 | SSA def(f) | test.swift:643:25:643:25 | f |
+| test.swift:642:7:642:7 | f | test.swift:642:7:642:7 | SSA def(f) |
+| test.swift:642:11:642:17 | #keyPath(...) | test.swift:642:7:642:7 | f |
+| test.swift:642:11:642:17 | enter #keyPath(...) | test.swift:642:15:642:15 | KeyPathComponent |
+| test.swift:647:9:647:9 | SSA def(array) | test.swift:649:15:649:15 | array |
+| test.swift:647:9:647:9 | array | test.swift:647:9:647:9 | SSA def(array) |
+| test.swift:647:17:647:26 | [...] | test.swift:647:9:647:9 | array |
+| test.swift:648:9:648:9 | SSA def(f) | test.swift:649:30:649:30 | f |
+| test.swift:648:9:648:9 | f | test.swift:648:9:648:9 | SSA def(f) |
+| test.swift:648:13:648:22 | #keyPath(...) | test.swift:648:9:648:9 | f |
+| test.swift:648:13:648:22 | enter #keyPath(...) | test.swift:648:20:648:22 | KeyPathComponent |
+| test.swift:653:7:653:7 | self | test.swift:653:7:653:7 | SSA def(self) |
+| test.swift:655:3:655:3 | SSA def(self) | test.swift:656:5:656:5 | self |
+| test.swift:655:3:655:3 | self | test.swift:655:3:655:3 | SSA def(self) |
+| test.swift:655:8:655:12 | SSA def(s) | test.swift:656:14:656:14 | s |
+| test.swift:655:8:655:12 | s | test.swift:655:8:655:12 | SSA def(s) |
+| test.swift:656:5:656:5 | [post] self | test.swift:655:3:657:3 | self[return] |
+| test.swift:656:5:656:5 | self | test.swift:655:3:657:3 | self[return] |
+| test.swift:661:9:661:9 | SSA def(s) | test.swift:662:29:662:29 | s |
+| test.swift:661:9:661:9 | s | test.swift:661:9:661:9 | SSA def(s) |
+| test.swift:661:13:661:26 | call to S.init(x:) | test.swift:661:9:661:9 | s |
+| test.swift:662:9:662:9 | SSA def(s2) | test.swift:664:15:664:15 | s2 |
+| test.swift:662:9:662:9 | s2 | test.swift:662:9:662:9 | SSA def(s2) |
+| test.swift:662:14:662:30 | call to S2_Optional.init(s:) | test.swift:662:9:662:9 | s2 |
+| test.swift:663:9:663:9 | SSA def(f) | test.swift:664:27:664:27 | f |
+| test.swift:663:9:663:9 | f | test.swift:663:9:663:9 | SSA def(f) |
+| test.swift:663:13:663:29 | #keyPath(...) | test.swift:663:9:663:9 | f |
+| test.swift:663:13:663:29 | enter #keyPath(...) | test.swift:663:26:663:26 | KeyPathComponent |
+| test.swift:668:9:668:9 | SSA def(x) | test.swift:672:9:672:9 | x |
+| test.swift:668:9:668:9 | x | test.swift:668:9:668:9 | SSA def(x) |
+| test.swift:668:13:668:20 | call to source() | test.swift:668:9:668:9 | x |
+| test.swift:669:9:669:9 | SSA def(y) | test.swift:673:9:673:9 | y |
+| test.swift:669:9:669:9 | y | test.swift:669:9:669:9 | SSA def(y) |
+| test.swift:669:13:669:13 | 0 | test.swift:669:9:669:9 | y |
+| test.swift:670:9:670:12 | ... as ... | test.swift:670:9:670:9 | t |
+| test.swift:672:5:672:9 | SSA def(t) | test.swift:674:9:674:9 | t |
+| test.swift:672:9:672:9 | x | test.swift:672:5:672:9 | SSA def(t) |
+| test.swift:673:5:673:9 | SSA def(x) | test.swift:675:15:675:15 | x |
+| test.swift:673:9:673:9 | y | test.swift:673:5:673:9 | SSA def(x) |
+| test.swift:674:5:674:9 | SSA def(y) | test.swift:676:15:676:15 | y |
+| test.swift:674:9:674:9 | t | test.swift:674:5:674:9 | SSA def(y) |
+| test.swift:678:5:678:16 | SSA def(x) | test.swift:680:11:680:11 | x |
+| test.swift:678:9:678:16 | call to source() | test.swift:678:5:678:16 | SSA def(x) |
+| test.swift:679:5:679:9 | SSA def(y) | test.swift:680:15:680:15 | y |
+| test.swift:679:9:679:9 | 0 | test.swift:679:5:679:9 | SSA def(y) |
+| test.swift:680:10:680:11 | &... | test.swift:681:15:681:15 | x |
+| test.swift:680:11:680:11 | [post] x | test.swift:680:10:680:11 | &... |
+| test.swift:680:11:680:11 | x | test.swift:680:10:680:11 | &... |
+| test.swift:680:14:680:15 | &... | test.swift:682:15:682:15 | y |
+| test.swift:680:15:680:15 | [post] y | test.swift:680:14:680:15 | &... |
+| test.swift:680:15:680:15 | y | test.swift:680:14:680:15 | &... |
+| test.swift:686:9:686:9 | SSA def(arr1) | test.swift:687:15:687:15 | arr1 |
+| test.swift:686:9:686:9 | arr1 | test.swift:686:9:686:9 | SSA def(arr1) |
+| test.swift:686:16:686:22 | [...] | test.swift:686:9:686:9 | arr1 |
+| test.swift:687:15:687:15 | &... | test.swift:688:5:688:5 | arr1 |
+| test.swift:687:15:687:15 | [post] arr1 | test.swift:687:15:687:15 | &... |
+| test.swift:687:15:687:15 | arr1 | test.swift:687:15:687:15 | &... |
+| test.swift:688:5:688:5 | &... | test.swift:689:15:689:15 | arr1 |
+| test.swift:688:5:688:5 | [post] arr1 | test.swift:688:5:688:5 | &... |
+| test.swift:688:5:688:5 | arr1 | test.swift:688:5:688:5 | &... |
+| test.swift:689:15:689:15 | &... | test.swift:690:15:690:15 | arr1 |
+| test.swift:689:15:689:15 | [post] arr1 | test.swift:689:15:689:15 | &... |
+| test.swift:689:15:689:15 | arr1 | test.swift:689:15:689:15 | &... |
+| test.swift:692:9:692:9 | SSA def(arr2) | test.swift:693:15:693:15 | arr2 |
+| test.swift:692:9:692:9 | arr2 | test.swift:692:9:692:9 | SSA def(arr2) |
+| test.swift:692:16:692:25 | [...] | test.swift:692:9:692:9 | arr2 |
+| test.swift:693:15:693:15 | &... | test.swift:704:16:704:16 | arr2 |
+| test.swift:693:15:693:15 | [post] arr2 | test.swift:693:15:693:15 | &... |
+| test.swift:693:15:693:15 | arr2 | test.swift:693:15:693:15 | &... |
+| test.swift:695:9:695:9 | SSA def(matrix) | test.swift:696:15:696:15 | matrix |
+| test.swift:695:9:695:9 | matrix | test.swift:695:9:695:9 | SSA def(matrix) |
+| test.swift:695:18:695:29 | [...] | test.swift:695:9:695:9 | matrix |
+| test.swift:696:15:696:15 | &... | test.swift:697:15:697:15 | matrix |
+| test.swift:696:15:696:15 | [post] matrix | test.swift:696:15:696:15 | &... |
+| test.swift:696:15:696:15 | matrix | test.swift:696:15:696:15 | &... |
+| test.swift:697:15:697:15 | [post] matrix | test.swift:697:15:697:15 | &... |
+| test.swift:697:15:697:15 | matrix | test.swift:697:15:697:15 | &... |
+| test.swift:697:15:697:23 | ...[...] | test.swift:697:15:697:23 | &... |
+| test.swift:699:9:699:9 | SSA def(matrix2) | test.swift:700:5:700:5 | matrix2 |
+| test.swift:699:9:699:9 | matrix2 | test.swift:699:9:699:9 | SSA def(matrix2) |
+| test.swift:699:19:699:23 | [...] | test.swift:699:9:699:9 | matrix2 |
+| test.swift:700:5:700:5 | &... | test.swift:701:15:701:15 | matrix2 |
+| test.swift:700:5:700:5 | [post] matrix2 | test.swift:700:5:700:5 | &... |
+| test.swift:700:5:700:5 | matrix2 | test.swift:700:5:700:5 | &... |
+| test.swift:700:5:700:14 | ...[...] | test.swift:700:5:700:14 | &... |
+| test.swift:701:15:701:15 | [post] matrix2 | test.swift:701:15:701:15 | &... |
+| test.swift:701:15:701:15 | matrix2 | test.swift:701:15:701:15 | &... |
+| test.swift:701:15:701:24 | ...[...] | test.swift:701:15:701:24 | &... |
+| test.swift:703:9:703:9 | SSA def(arr3) | test.swift:704:23:704:23 | arr3 |
+| test.swift:703:9:703:9 | arr3 | test.swift:703:9:703:9 | SSA def(arr3) |
+| test.swift:703:16:703:18 | [...] | test.swift:703:9:703:9 | arr3 |
+| test.swift:704:9:704:9 | SSA def(arr4) | test.swift:706:15:706:15 | arr4 |
+| test.swift:704:9:704:9 | arr4 | test.swift:704:9:704:9 | SSA def(arr4) |
+| test.swift:704:16:704:23 | ... .+(_:_:) ... | test.swift:704:9:704:9 | arr4 |
+| test.swift:704:23:704:23 | arr3 | test.swift:705:15:705:15 | arr3 |
+| test.swift:705:15:705:15 | [post] arr3 | test.swift:705:15:705:15 | &... |
+| test.swift:705:15:705:15 | arr3 | test.swift:705:15:705:15 | &... |
+| test.swift:706:15:706:15 | [post] arr4 | test.swift:706:15:706:15 | &... |
+| test.swift:706:15:706:15 | arr4 | test.swift:706:15:706:15 | &... |
+| test.swift:708:9:708:9 | SSA def(arr5) | test.swift:709:15:709:15 | arr5 |
+| test.swift:708:9:708:9 | arr5 | test.swift:708:9:708:9 | SSA def(arr5) |
+| test.swift:708:16:708:51 | call to Array<Element>.init(repeating:count:) | test.swift:708:9:708:9 | arr5 |
+| test.swift:709:15:709:15 | [post] arr5 | test.swift:709:15:709:15 | &... |
+| test.swift:709:15:709:15 | arr5 | test.swift:709:15:709:15 | &... |
+| test.swift:711:9:711:9 | SSA def(arr6) | test.swift:712:5:712:5 | arr6 |
+| test.swift:711:9:711:9 | arr6 | test.swift:711:9:711:9 | SSA def(arr6) |
+| test.swift:711:16:711:22 | [...] | test.swift:711:9:711:9 | arr6 |
+| test.swift:712:5:712:5 | &... | test.swift:713:15:713:15 | arr6 |
+| test.swift:712:5:712:5 | [post] arr6 | test.swift:712:5:712:5 | &... |
+| test.swift:712:5:712:5 | arr6 | test.swift:712:5:712:5 | &... |
+| test.swift:713:15:713:15 | [post] arr6 | test.swift:713:15:713:15 | &... |
+| test.swift:713:15:713:15 | arr6 | test.swift:713:15:713:15 | &... |
+| test.swift:715:9:715:9 | SSA def(arr7) | test.swift:716:15:716:15 | arr7 |
+| test.swift:715:9:715:9 | arr7 | test.swift:715:9:715:9 | SSA def(arr7) |
+| test.swift:715:16:715:25 | [...] | test.swift:715:9:715:9 | arr7 |
+| test.swift:716:15:716:34 | call to randomElement() | test.swift:716:15:716:35 | ...! |
+| test.swift:720:9:720:9 | SSA def(set1) | test.swift:721:15:721:15 | set1 |
+| test.swift:720:9:720:9 | set1 | test.swift:720:9:720:9 | SSA def(set1) |
+| test.swift:720:9:720:15 | ... as ... | test.swift:720:9:720:9 | set1 |
+| test.swift:720:21:720:27 | [...] | test.swift:720:9:720:15 | ... as ... |
+| test.swift:721:15:721:15 | [post] set1 | test.swift:722:5:722:5 | set1 |
+| test.swift:721:15:721:15 | set1 | test.swift:722:5:722:5 | set1 |
+| test.swift:721:15:721:34 | call to randomElement() | test.swift:721:15:721:35 | ...! |
+| test.swift:722:5:722:5 | &... | test.swift:723:15:723:15 | set1 |
+| test.swift:722:5:722:5 | [post] set1 | test.swift:722:5:722:5 | &... |
+| test.swift:722:5:722:5 | set1 | test.swift:722:5:722:5 | &... |
+| test.swift:723:15:723:34 | call to randomElement() | test.swift:723:15:723:35 | ...! |
+| test.swift:725:9:725:9 | SSA def(set2) | test.swift:726:15:726:15 | set2 |
+| test.swift:725:9:725:9 | set2 | test.swift:725:9:725:9 | SSA def(set2) |
+| test.swift:725:16:725:30 | call to Set<Element>.init(_:) | test.swift:725:9:725:9 | set2 |
+| test.swift:726:15:726:34 | call to randomElement() | test.swift:726:15:726:35 | ...! |
+| test.swift:729:8:729:8 | SSA def(self) | test.swift:729:8:729:8 | self[return] |
+| test.swift:729:8:729:8 | self | test.swift:729:8:729:8 | SSA def(self) |
+| test.swift:730:9:730:9 | self | test.swift:730:9:730:9 | SSA def(self) |
+| test.swift:730:9:730:9 | self | test.swift:730:9:730:9 | SSA def(self) |
+| test.swift:730:9:730:9 | self | test.swift:730:9:730:9 | SSA def(self) |
+| test.swift:730:9:730:9 | value | test.swift:730:9:730:9 | SSA def(value) |
+| test.swift:731:9:731:9 | self | test.swift:731:9:731:9 | SSA def(self) |
+| test.swift:731:9:731:9 | self | test.swift:731:9:731:9 | SSA def(self) |
+| test.swift:731:9:731:9 | self | test.swift:731:9:731:9 | SSA def(self) |
+| test.swift:731:9:731:9 | value | test.swift:731:9:731:9 | SSA def(value) |
+| test.swift:732:9:732:9 | self | test.swift:732:9:732:9 | SSA def(self) |
+| test.swift:732:9:732:9 | self | test.swift:732:9:732:9 | SSA def(self) |
+| test.swift:732:9:732:9 | self | test.swift:732:9:732:9 | SSA def(self) |
+| test.swift:732:9:732:9 | value | test.swift:732:9:732:9 | SSA def(value) |
+| test.swift:736:9:736:9 | SSA def(v1) | test.swift:742:5:742:5 | v1 |
+| test.swift:736:9:736:9 | v1 | test.swift:736:9:736:9 | SSA def(v1) |
+| test.swift:736:9:736:17 | ... as ... | test.swift:736:9:736:9 | v1 |
+| test.swift:736:21:736:21 | 0 | test.swift:736:9:736:17 | ... as ... |
+| test.swift:737:9:737:17 | ... as ... | test.swift:737:9:737:9 | v2 |
+| test.swift:737:21:737:21 | 0 | test.swift:737:9:737:17 | ... as ... |
+| test.swift:738:9:738:17 | ... as ... | test.swift:738:9:738:9 | v3 |
+| test.swift:738:21:738:21 | 0 | test.swift:738:9:738:17 | ... as ... |
+| test.swift:739:9:739:9 | SSA def(mo1) | test.swift:745:5:745:5 | mo1 |
+| test.swift:739:9:739:9 | mo1 | test.swift:739:9:739:9 | SSA def(mo1) |
+| test.swift:739:15:739:27 | call to MyOptionals.init() | test.swift:739:9:739:9 | mo1 |
+| test.swift:740:9:740:9 | SSA def(mo2) | test.swift:748:5:748:5 | mo2 |
+| test.swift:740:9:740:9 | mo2 | test.swift:740:9:740:9 | SSA def(mo2) |
+| test.swift:740:9:740:26 | ... as ... | test.swift:740:9:740:9 | mo2 |
+| test.swift:740:30:740:42 | call to MyOptionals.init() | test.swift:740:9:740:26 | ... as ... |
+| test.swift:742:5:742:5 | v1 | test.swift:742:5:742:7 | ...! |
+| test.swift:742:5:742:5 | v1 | test.swift:752:15:752:15 | v1 |
+| test.swift:743:5:743:17 | SSA def(v2) | test.swift:753:15:753:15 | v2 |
+| test.swift:743:10:743:17 | call to source() | test.swift:743:5:743:17 | SSA def(v2) |
+| test.swift:744:5:744:17 | SSA def(v3) | test.swift:754:15:754:15 | v3 |
+| test.swift:744:10:744:17 | call to source() | test.swift:744:5:744:17 | SSA def(v3) |
+| test.swift:745:5:745:5 | [post] mo1 | test.swift:746:5:746:5 | mo1 |
+| test.swift:745:5:745:5 | mo1 | test.swift:746:5:746:5 | mo1 |
+| test.swift:745:5:745:9 | .v1 | test.swift:745:5:745:11 | ...! |
+| test.swift:746:5:746:5 | [post] mo1 | test.swift:747:5:747:5 | mo1 |
+| test.swift:746:5:746:5 | mo1 | test.swift:747:5:747:5 | mo1 |
+| test.swift:747:5:747:5 | [post] mo1 | test.swift:755:15:755:15 | mo1 |
+| test.swift:747:5:747:5 | mo1 | test.swift:755:15:755:15 | mo1 |
+| test.swift:748:5:748:5 | mo2 | test.swift:748:5:748:8 | ...! |
+| test.swift:748:5:748:5 | mo2 | test.swift:749:5:749:5 | mo2 |
+| test.swift:748:5:748:10 | .v1 | test.swift:748:5:748:12 | ...! |
+| test.swift:749:5:749:5 | mo2 | test.swift:749:5:749:8 | ...! |
+| test.swift:749:5:749:5 | mo2 | test.swift:750:5:750:5 | mo2 |
+| test.swift:750:5:750:5 | mo2 | test.swift:750:5:750:8 | ...! |
+| test.swift:750:5:750:5 | mo2 | test.swift:758:15:758:15 | mo2 |
+| test.swift:752:15:752:15 | v1 | test.swift:752:15:752:17 | ...! |
+| test.swift:753:15:753:15 | v2 | test.swift:753:15:753:17 | ...! |
+| test.swift:755:15:755:15 | [post] mo1 | test.swift:756:15:756:15 | mo1 |
+| test.swift:755:15:755:15 | mo1 | test.swift:756:15:756:15 | mo1 |
+| test.swift:755:15:755:19 | .v1 | test.swift:755:15:755:21 | ...! |
+| test.swift:756:15:756:15 | [post] mo1 | test.swift:757:15:757:15 | mo1 |
+| test.swift:756:15:756:15 | mo1 | test.swift:757:15:757:15 | mo1 |
+| test.swift:756:15:756:19 | .v2 | test.swift:756:15:756:21 | ...! |
+| test.swift:758:15:758:15 | mo2 | test.swift:758:15:758:18 | ...! |
+| test.swift:758:15:758:15 | mo2 | test.swift:759:15:759:15 | mo2 |
+| test.swift:758:15:758:20 | .v1 | test.swift:758:15:758:22 | ...! |
+| test.swift:759:15:759:15 | mo2 | test.swift:759:15:759:18 | ...! |
+| test.swift:759:15:759:15 | mo2 | test.swift:760:15:760:15 | mo2 |
+| test.swift:759:15:759:20 | .v2 | test.swift:759:15:759:22 | ...! |
+| test.swift:760:15:760:15 | mo2 | test.swift:760:15:760:18 | ...! |

--- a/swift/ql/test/library-tests/dataflow/dataflow/test.swift
+++ b/swift/ql/test/library-tests/dataflow/dataflow/test.swift
@@ -365,6 +365,25 @@ func testTuples2() {
     sink(arg: c)
 }
 
+func tupleShiftLeft1(_ t: (Int, Int)) -> (Int, Int) {
+    return (t.1, 0)
+}
+
+func tupleShiftLeft2(_ t: (Int, Int)) -> (Int, Int) { return (0, 0) } // modelled flow
+
+func testTuples3() {
+    let t1 = (1, source())
+    let t2 = tupleShiftLeft1(t1)
+    let t3 = tupleShiftLeft2(t1)
+
+    sink(arg: t1.0)
+    sink(arg: t1.1) // $ flow=375
+    sink(arg: t2.0) // $ flow=375
+    sink(arg: t2.1)
+    sink(arg: t3.0) // $ MISSING: flow=375
+    sink(arg: t3.1)
+}
+
 indirect enum MyEnum {
     case myNone
     case mySingle(Int)
@@ -406,7 +425,7 @@ func testEnums() {
     case .myNone:
         ()
     case .mySingle(let a):
-        sink(arg: a) // $ flow=403
+        sink(arg: a) // $ flow=422
     case .myPair(let a, let b):
         sink(arg: a)
         sink(arg: b)
@@ -415,7 +434,7 @@ func testEnums() {
     }
 
     if case .mySingle(let x) = a {
-        sink(arg: x) // $ flow=403
+        sink(arg: x) // $ flow=422
     }
     if case .myPair(let x, let y) = a {
         sink(arg: x)
@@ -431,7 +450,7 @@ func testEnums() {
         sink(arg: a)
     case .myPair(let a, let b):
         sink(arg: a)
-        sink(arg: b) // $ flow=425
+        sink(arg: b) // $ flow=444
     case let .myCons(a, _):
         sink(arg: a)
     }
@@ -441,7 +460,7 @@ func testEnums() {
     }
     if case .myPair(let x, let y) = a {
         sink(arg: x)
-        sink(arg: y) // $ flow=425
+        sink(arg: y) // $ flow=444
     }
 
     let b: MyEnum = .myCons(42, a)
@@ -457,7 +476,7 @@ func testEnums() {
     case let .myCons(a, .myPair(b, c)):
         sink(arg: a)
         sink(arg: b)
-        sink(arg: c) // $ flow=425
+        sink(arg: c) // $ flow=444
     case let .myCons(a, _):
         sink(arg: a)
     }
@@ -466,20 +485,20 @@ func testEnums() {
         sink(arg: x)
     }
     if case MyEnum.myPair(let x, let y) = .myPair(source(), 0) {
-        sink(arg: x) // $ flow=468
+        sink(arg: x) // $ flow=487
         sink(arg: y)
     }
     if case let .myCons(_, .myPair(_, c)) = b {
-        sink(arg: c) // $ flow=425
+        sink(arg: c) // $ flow=444
     }
 
     switch (a, b) {
     case let (.myPair(a, b), .myCons(c, .myPair(d, e))):
         sink(arg: a)
-        sink(arg: b) // $ flow=425
+        sink(arg: b) // $ flow=444
         sink(arg: c)
         sink(arg: d)
-        sink(arg: e) // $ flow=425
+        sink(arg: e) // $ flow=444
     default:
         ()
     }
@@ -491,11 +510,11 @@ func testEnums() {
     let c5 = mkMyEnum2(0)
     let c6 = mkMyEnum2(source())
     if case MyEnum.mySingle(let d1) = c1 { sink(arg: d1) }
-    if case MyEnum.mySingle(let d2) = c2 { sink(arg: d2) } // $ flow=488
+    if case MyEnum.mySingle(let d2) = c2 { sink(arg: d2) } // $ flow=507
     if case MyEnum.mySingle(let d3) = c3 { sink(arg: d3) }
-    if case MyEnum.mySingle(let d4) = c4 { sink(arg: d4) } // $ flow=490
+    if case MyEnum.mySingle(let d4) = c4 { sink(arg: d4) } // $ flow=509
     if case MyEnum.mySingle(let d5) = c5 { sink(arg: d5) }
-    if case MyEnum.mySingle(let d6) = c6 { sink(arg: d6) } // $ flow=492
+    if case MyEnum.mySingle(let d6) = c6 { sink(arg: d6) } // $ flow=511
 
     let e1 = Optional.some(0)
     let e2 = Optional.some(source())
@@ -504,11 +523,11 @@ func testEnums() {
     let e5 = mkOptional2(0)
     let e6 = mkOptional2(source())
     sink(arg: e1!)
-    sink(arg: e2!) // $ flow=501
+    sink(arg: e2!) // $ flow=520
     sink(arg: e3!)
-    sink(arg: e4!) // $ flow=503
+    sink(arg: e4!) // $ flow=522
     sink(arg: e5!)
-    sink(arg: e6!) // $ flow=505
+    sink(arg: e6!) // $ flow=524
 }
 
 func source2() -> (Int, Int)? { return nil }
@@ -554,8 +573,8 @@ func testOptionalPropertyAccess(y: Int?) {
 }
 
 func testIdentityArithmetic() {
-  sink(arg: +source()) // $ flow=557
-  sink(arg: (source())) // $ flow=558
+  sink(arg: +source()) // $ flow=576
+  sink(arg: (source())) // $ flow=577
 }
 
 func sink(str: String) {}
@@ -572,13 +591,13 @@ class MyClass {
 extension MyClass {
     convenience init(contentsOfFile: String) {
       self.init(s: source3())
-      sink(str: str) // $ flow=574
+      sink(str: str) // $ flow=593
     }
 }
 
 func extensionInits(path: String) {
-  sink(str: MyClass(s: source3()).str) // $ flow=580
-  sink(str: MyClass(contentsOfFile: path).str) // $ flow=574
+  sink(str: MyClass(s: source3()).str) // $ flow=599
+  sink(str: MyClass(contentsOfFile: path).str) // $ flow=593
 }
 
 class InoutConstructorClass {
@@ -603,10 +622,10 @@ struct S {
 func testKeyPath() {
   let s = S(x: source())
   let f = \S.x
-  sink(arg: s[keyPath: f]) // $ flow=604
+  sink(arg: s[keyPath: f]) // $ flow=623
 
   let inferred : KeyPath<S, Int> = \.x
-  sink(arg: s[keyPath: inferred]) // $ flow=604
+  sink(arg: s[keyPath: inferred]) // $ flow=623
 }
 
 struct S2 {
@@ -621,13 +640,13 @@ func testNestedKeyPath() {
   let s = S(x: source())
   let s2 = S2(s: s)
   let f = \S2.s.x
-  sink(arg: s2[keyPath: f]) // $ flow=621
+  sink(arg: s2[keyPath: f]) // $ flow=640
 }
 
 func testArrayKeyPath() {
     let array = [source()]
     let f = \[Int].[0]
-    sink(arg: array[keyPath: f]) // $ flow=628
+    sink(arg: array[keyPath: f]) // $ flow=647
 }
 
 struct S2_Optional {
@@ -642,7 +661,7 @@ func testOptionalKeyPath() {
     let s = S(x: source())
     let s2 = S2_Optional(s: s)
     let f = \S2_Optional.s?.x
-    sink(opt: s2[keyPath: f]) // $ MISSING: flow=642
+    sink(opt: s2[keyPath: f]) // $ MISSING: flow=661
 }
 
 func testSwap() {
@@ -654,57 +673,57 @@ func testSwap() {
     x = y
     y = t
     sink(arg: x)
-    sink(arg: y) // $ flow=649
+    sink(arg: y) // $ flow=668
 
     x = source()
     y = 0
     swap(&x, &y)
-    sink(arg: x) // $ SPURIOUS: flow=659
-    sink(arg: y) // $ flow=659
+    sink(arg: x) // $ SPURIOUS: flow=678
+    sink(arg: y) // $ flow=678
 }
 
 func testArray() {
     var arr1 = [1,2,3]
     sink(arg: arr1[0])
     arr1[1] = source()
-    sink(arg: arr1[0]) // $ flow=669
+    sink(arg: arr1[0]) // $ flow=688
     sink(arg: arr1)
 
     var arr2 = [source()]
-    sink(arg: arr2[0]) // $ flow=673
+    sink(arg: arr2[0]) // $ flow=692
 
     var matrix = [[source()]]
     sink(arg: matrix[0])
-    sink(arg: matrix[0][0]) // $ flow=676
+    sink(arg: matrix[0][0]) // $ flow=695
 
     var matrix2 = [[1]]
     matrix2[0][0] = source()
-    sink(arg: matrix2[0][0]) // $ flow=681
+    sink(arg: matrix2[0][0]) // $ flow=700
 
     var arr3 = [1]
     var arr4 = arr2 + arr3
     sink(arg: arr3[0])
-    sink(arg: arr4[0]) // $ MISSING: flow=673
+    sink(arg: arr4[0]) // $ MISSING: flow=692
 
     var arr5 = Array(repeating: source(), count: 2)
-    sink(arg: arr5[0]) // $ MISSING: flow=689
+    sink(arg: arr5[0]) // $ MISSING: flow=708
 
     var arr6 = [1,2,3]
     arr6.insert(source(), at: 2)
-    sink(arg: arr6[0]) // $ flow=693
+    sink(arg: arr6[0]) // $ flow=712
 
     var arr7 = [source()]
-    sink(arg: arr7.randomElement()!) // $ flow=696
+    sink(arg: arr7.randomElement()!) // $ flow=715
 }
 
 func testSetCollections() {
     var set1: Set = [1,2,3]
     sink(arg: set1.randomElement()!)
     set1.insert(source())
-    sink(arg: set1.randomElement()!) // $flow=703
+    sink(arg: set1.randomElement()!) // $ flow=722
 
     let set2 = Set([source()])
-    sink(arg: set2.randomElement()!) // $ flow=706
+    sink(arg: set2.randomElement()!) // $ flow=725
 }
 
 struct MyOptionals {
@@ -730,13 +749,13 @@ func testWriteOptional() {
     mo2!.v2 = source()
     mo2!.v3 = source()
 
-    sink(arg: v1!) // $ flow=723
-    sink(arg: v2!) // $ flow=724
-    sink(arg: v3) // $ flow=725
-    sink(arg: mo1.v1!) // $ MISSING:flow=726
-    sink(arg: mo1.v2!) // $ flow=727
-    sink(arg: mo1.v3) // $ flow=728
-    sink(arg: mo2!.v1!) // $ MISSING:flow=729
-    sink(arg: mo2!.v2!) // $ MISSING:flow=730
-    sink(arg: mo2!.v3) // $ MISSING:flow=731
+    sink(arg: v1!) // $ flow=742
+    sink(arg: v2!) // $ flow=743
+    sink(arg: v3) // $ flow=744
+    sink(arg: mo1.v1!) // $ MISSING:flow=745
+    sink(arg: mo1.v2!) // $ flow=746
+    sink(arg: mo1.v3) // $ flow=747
+    sink(arg: mo2!.v1!) // $ MISSING:flow=748
+    sink(arg: mo2!.v2!) // $ MISSING:flow=749
+    sink(arg: mo2!.v3) // $ MISSING:flow=750
 }

--- a/swift/ql/test/library-tests/dataflow/dataflow/test.swift
+++ b/swift/ql/test/library-tests/dataflow/dataflow/test.swift
@@ -380,7 +380,7 @@ func testTuples3() {
     sink(arg: t1.1) // $ flow=375
     sink(arg: t2.0) // $ flow=375
     sink(arg: t2.1)
-    sink(arg: t3.0) // $ MISSING: flow=375
+    sink(arg: t3.0) // $ flow=375
     sink(arg: t3.1)
 }
 


### PR DESCRIPTION
I noticed we were missing models-as-data syntax for tuple content.  This isn't actually used in any models yet (outside of the test), but it seems good to fill the gap.