### PR TITLE
Java: Add dashes to SHA algorithm names in `Encryption.qll`

### DIFF
--- a/java/ql/lib/change-notes/2023-08-15-add-dashes-to-sha-algorithms.md
+++ b/java/ql/lib/change-notes/2023-08-15-add-dashes-to-sha-algorithms.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Modified the `getSecureAlgorithmName` predicate in `Encryption.qll` to also include `SHA-256` and `SHA-512`. Previously only the versions of the names without dashes were considered secure.

--- a/java/ql/lib/semmle/code/java/security/Encryption.qll
+++ b/java/ql/lib/semmle/code/java/security/Encryption.qll
@@ -270,7 +270,7 @@ string getInsecureAlgorithmRegex() {
 string getASecureAlgorithmName() {
   result =
     [
-      "RSA", "SHA256", "SHA512", "CCM", "GCM", "AES(?![^a-zA-Z](ECB|CBC/PKCS[57]Padding))",
+      "RSA", "SHA-?256", "SHA-?512", "CCM", "GCM", "AES(?![^a-zA-Z](ECB|CBC/PKCS[57]Padding))",
       "Blowfish", "ECIES"
     ]
 }


### PR DESCRIPTION
Update `getSecureAlgorithmName` to accommodate dashes in the name of the `SHA` algorithms.