### PR TITLE
JS: change the defaults in the qhelp for missing-rate-limit to something more reasonable

### DIFF
--- a/javascript/ql/src/Security/CWE-770/examples/MissingRateLimitingGood.js
+++ b/javascript/ql/src/Security/CWE-770/examples/MissingRateLimitingGood.js
@@ -4,8 +4,8 @@ var app = express();
 // set up rate limiter: maximum of five requests per minute
 var RateLimit = require('express-rate-limit');
 var limiter = RateLimit({
-  windowMs: 1*60*1000, // 1 minute
-  max: 5
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // max 100 requests per windowMs
 });
 
 // apply rate limiter to all requests


### PR DESCRIPTION
My friend likes to copy-paste the default values presented in the QHelp when he fixes an error, so I think it's best if the default values presented are reasonable.  
And we saw an example where the previous defaults were so low that a test-suite started failing, and the issue therefore took longer to fix. 

The new defaults are taken from the express-rate-limit documentation: https://github.com/express-rate-limit/express-rate-limit#examples 

My friend doesn't seem to appreciate the new QHelp, he likes it just as much as the previous one.  
But I think these new defaults are more reasonable, and less likely to cause failures if people are copy-pasting our suggested defaults. 