### PR TITLE
Python: fix nice locations for import aliases

### DIFF
--- a/python/ql/lib/analysis/DefinitionTracking.qll
+++ b/python/ql/lib/analysis/DefinitionTracking.qll
@@ -492,9 +492,14 @@ class NiceLocationExpr extends Expr {
     // for `import xxx` or for `import xxx as yyy`.
     this.(ImportExpr).getLocation().hasLocationInfo(f, bl, bc, el, ec)
     or
-    /* Show y for `y` in `from xxx import y` */
-    exists(string name |
-      name = this.(ImportMember).getName() and
+    // Show y for `y` in `from xxx import y`
+    // and y for `yyy as y` in `from xxx import yyy as y`.
+    exists(string name, Alias alias |
+      // This alias will always exist, as `from xxx import y`
+      // is expanded to `from xxx imprt y as y`.
+      this = alias.getValue() and
+      name = alias.getAsname().(Name).getId()
+    |
       this.(ImportMember).getLocation().hasLocationInfo(f, _, _, el, ec) and
       bl = el and
       bc = ec - name.length() + 1

--- a/python/ql/lib/change-notes/2023-08-10-fix-alias-locations.md
+++ b/python/ql/lib/change-notes/2023-08-10-fix-alias-locations.md
@@ -1,0 +1,4 @@
+---
+category: fix
+---
+* Fixed the computation of display locations for imports with aliases.

--- a/python/ql/lib/change-notes/2023-08-10-fix-alias-locations.md
+++ b/python/ql/lib/change-notes/2023-08-10-fix-alias-locations.md
@@ -1,4 +1,4 @@
 ---
 category: fix
 ---
-* Fixed the computation of display locations for imports with aliases.
+* Fixed the computation of locations for imports with aliases in jump-to-definition.

--- a/python/ql/test/library-tests/locations/imports/import_statements.py
+++ b/python/ql/test/library-tests/locations/imports/import_statements.py
@@ -1,0 +1,4 @@
+from nova.api.openstack.placement import microversion
+from nova.api.openstack.placement.objects import resource_provider as rp_obj
+from nova.api.openstack.placement.policies import allocation_candidate as \
+    policies

--- a/python/ql/test/library-tests/locations/imports/imports.expected
+++ b/python/ql/test/library-tests/locations/imports/imports.expected
@@ -1,0 +1,8 @@
+| import_statements.py | 1 | 6 | 1 | 33 |
+| import_statements.py | 1 | 42 | 1 | 53 |
+| import_statements.py | 2 | 6 | 2 | 41 |
+| import_statements.py | 2 | 60 | 2 | 76 |
+| import_statements.py | 2 | 71 | 2 | 76 |
+| import_statements.py | 3 | 6 | 3 | 42 |
+| import_statements.py | 4 | 5 | 4 | 12 |
+| import_statements.py | 4 | -7 | 4 | 12 |

--- a/python/ql/test/library-tests/locations/imports/imports.expected
+++ b/python/ql/test/library-tests/locations/imports/imports.expected
@@ -1,8 +1,6 @@
 | import_statements.py | 1 | 6 | 1 | 33 |
 | import_statements.py | 1 | 42 | 1 | 53 |
 | import_statements.py | 2 | 6 | 2 | 41 |
-| import_statements.py | 2 | 60 | 2 | 76 |
 | import_statements.py | 2 | 71 | 2 | 76 |
 | import_statements.py | 3 | 6 | 3 | 42 |
 | import_statements.py | 4 | 5 | 4 | 12 |
-| import_statements.py | 4 | -7 | 4 | 12 |

--- a/python/ql/test/library-tests/locations/imports/imports.ql
+++ b/python/ql/test/library-tests/locations/imports/imports.ql
@@ -1,0 +1,6 @@
+import python
+import analysis.DefinitionTracking
+
+from NiceLocationExpr expr, string f, int bl, int bc, int el, int ec
+where expr.hasLocationInfo(f, bl, bc, el, ec)
+select f, bl, bc, el, ec


### PR DESCRIPTION
The computation of nice location for import statements did not take aliases into account.
This has causes problems for some of our downstream CI.

See also https://github.com/github/codeql-team/issues/2260