### PR TITLE
Swift: Update the weak sensitive data hashing examples and qhelp

### DIFF
--- a/swift/ql/src/queries/Security/CWE-328/WeakSensitiveDataHashing.qhelp
+++ b/swift/ql/src/queries/Security/CWE-328/WeakSensitiveDataHashing.qhelp
@@ -52,7 +52,7 @@
         </ul>
 
         <p>
-            Note that special purpose algorithms, which are usually used to ensure that a message comes from a particular sender, exist for message authentication. These algorithms should be used when appropriate, as they address common vulnerabilities of simple hashing schemes in this context.
+            Note that special purpose algorithms, which are used to ensure that a message comes from a particular sender, exist for message authentication. These algorithms should be used when appropriate, as they address common vulnerabilities of simple hashing schemes in this context.
         </p>
 
     </recommendation>

--- a/swift/ql/src/queries/Security/CWE-328/WeakSensitiveDataHashing.qhelp
+++ b/swift/ql/src/queries/Security/CWE-328/WeakSensitiveDataHashing.qhelp
@@ -62,12 +62,14 @@
             The following examples show a function for fetching data from a
             URL along with a hash of the data, perhaps to check the data has
             not been tampered with.
+        </p>
 
+        <p>
             In the first case the MD5 hashing algorithm is used that is known to be vulnerable to collision attacks.
         </p>
         <sample src="WeakSensitiveDataHashingBad.swift"/>
-        <p>
 
+        <p>
             Here is the same function using SHA-512, which is a strong cryptographic hashing function.
         </p>
         <sample src="WeakSensitiveDataHashingGood.swift"/>

--- a/swift/ql/src/queries/Security/CWE-328/WeakSensitiveDataHashing.qhelp
+++ b/swift/ql/src/queries/Security/CWE-328/WeakSensitiveDataHashing.qhelp
@@ -52,7 +52,7 @@
         </ul>
 
         <p>
-            Note that special purpose algorithms exist for message authentication (ensuring that a message comes from a particular sender). These algorithms should be used when appropriate, as they address common vulnerabilities of simple hashing schemes in this context.
+            Note that special purpose algorithms, which are usually used to ensure that a message comes from a particular sender, exist for message authentication. These algorithms should be used when appropriate, as they address common vulnerabilities of simple hashing schemes in this context.
         </p>
 
     </recommendation>

--- a/swift/ql/src/queries/Security/CWE-328/WeakSensitiveDataHashing.qhelp
+++ b/swift/ql/src/queries/Security/CWE-328/WeakSensitiveDataHashing.qhelp
@@ -51,12 +51,17 @@
             </li>
         </ul>
 
+        <p>
+            Note that special purpose algorithms exist for message authentication (ensuring that a message comes from a particular sender). These algorithms should be used when appropriate, as they address common vulnerabilities of simple hashing schemes in this context.
+        </p>
+
     </recommendation>
     <example>
 
         <p>
-            The following examples show a function for checking whether the hash
-            of a certificate matches a known value -- to prevent tampering.
+            The following examples show a function for fetching data from a
+            URL along with a hash of the data, perhaps to check the data has
+            not been tampered with.
 
             In the first case the MD5 hashing algorithm is used that is known to be vulnerable to collision attacks.
         </p>

--- a/swift/ql/src/queries/Security/CWE-328/WeakSensitiveDataHashingBad.swift
+++ b/swift/ql/src/queries/Security/CWE-328/WeakSensitiveDataHashingBad.swift
@@ -1,5 +1,10 @@
-typealias Hasher = Crypto.Insecure.MD5
+func getContentsAndHash(url: URL) -> (Data, String)? {
+    guard let data = try? Data(contentsOf: url) else {
+        return nil
+    }
 
-func checkCertificate(cert: Array[UInt8], hash: Array[UInt8]) -> Bool
-  return Hasher.hash(data: cert) == hash  // BAD
+    let digest = Insecure.MD5.hash(data: data)
+    let hash = digest.map { String(format: "%02hhx", $0) }.joined()
+
+    return (data, hash)
 }

--- a/swift/ql/src/queries/Security/CWE-328/WeakSensitiveDataHashingGood.swift
+++ b/swift/ql/src/queries/Security/CWE-328/WeakSensitiveDataHashingGood.swift
@@ -1,4 +1,10 @@
-typealias Hasher = Crypto.SHA512
+func getContentsAndHash(url: URL) -> (Data, String)? {
+    guard let data = try? Data(contentsOf: url) else {
+        return nil
+    }
 
-func checkCertificate(cert: Array[UInt8], hash: Array[UInt8]) -> Bool
-  return Hasher.hash(data: cert) == hash  // GOOD
+    let digest = SHA512.hash(data: data)
+    let hash = digest.map { String(format: "%02hhx", $0) }.joined()
+
+    return (data, hash)
+}


### PR DESCRIPTION
Update the weak sensitive data hashing examples and qhelp to:

1. encourage use of message authentication algorithms where appropriate (for passwords, computationally expensive hashes are already recommended) and
2. not provide an example that uses a SHA-512 hash on a 'certificate'

---

@aegilops (who first pointed out the problem)
@d10c (who is following this issue)

I'm open to suggestions and corrections - I'm only moderately informed on this subject - after which I will request a docs review on the changes as well.

In the longer term, we have plans to implement a Swift version of [`csharp/weak-password-hashing`](https://github.com/advanced-security/codeql-queries/blob/main/csharp/CWE-328/WeakPasswordHashing.ql), which will provide a  much stronger push towards safe password hashing and an example of correct password hashing in Swift.

---

Note that I'm a little unclear on the difference between deliberately computationally expensive cryptographic hash functions (e.g. PBKDF2) and key derivation algorithms (such as HKDF, which _is_ available in the standard Swift CryptoKit library).  I'd appreciate if someone could clear this up for me.