### PR TITLE
Kotlin: Handle null parent IDs in getFunctionLabel correctly

### DIFF
--- a/java/kotlin-extractor/src/main/kotlin/KotlinUsesExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/KotlinUsesExtractor.kt
@@ -1034,8 +1034,13 @@ open class KotlinUsesExtractor(
      * enclosing classes to get the instantiation that this function is
      * in.
      */
-    fun getFunctionLabel(f: IrFunction, classTypeArgsIncludingOuterClasses: List<IrTypeArgument>?) : String {
-        return getFunctionLabel(f, null, classTypeArgsIncludingOuterClasses)
+    fun getFunctionLabel(f: IrFunction, classTypeArgsIncludingOuterClasses: List<IrTypeArgument>?): String? {
+        val parentId = useDeclarationParent(f.parent, false, classTypeArgsIncludingOuterClasses, true)
+        if (parentId == null) {
+            logger.error("Couldn't get parent ID for function label")
+            return null
+        }
+        return getFunctionLabel(f, parentId, classTypeArgsIncludingOuterClasses)
     }
 
     /*
@@ -1052,10 +1057,10 @@ open class KotlinUsesExtractor(
      * that omit one or more parameters that has a default value specified.
      */
     @OptIn(ObsoleteDescriptorBasedAPI::class)
-    fun getFunctionLabel(f: IrFunction, maybeParentId: Label<out DbElement>?, classTypeArgsIncludingOuterClasses: List<IrTypeArgument>?, maybeParameterList: List<IrValueParameter>? = null) =
+    fun getFunctionLabel(f: IrFunction, parentId: Label<out DbElement>, classTypeArgsIncludingOuterClasses: List<IrTypeArgument>?, maybeParameterList: List<IrValueParameter>? = null): String =
         getFunctionLabel(
             f.parent,
-            maybeParentId,
+            parentId,
             getFunctionShortName(f).nameInDB,
             (maybeParameterList ?: f.valueParameters).map { it.type },
             getAdjustedReturnType(f),
@@ -1078,7 +1083,7 @@ open class KotlinUsesExtractor(
         // The parent of the function; normally f.parent.
         parent: IrDeclarationParent,
         // The ID of the function's parent, or null if we should work it out ourselves.
-        maybeParentId: Label<out DbElement>?,
+        parentId: Label<out DbElement>,
         // The name of the function; normally f.name.asString().
         name: String,
         // The types of the value parameters that the functions takes; normally f.valueParameters.map { it.type }.
@@ -1102,7 +1107,6 @@ open class KotlinUsesExtractor(
         // The prefix used in the label. "callable", unless a property label is created, then it's "property".
         prefix: String = "callable"
     ): String {
-        val parentId = maybeParentId ?: useDeclarationParent(parent, false, classTypeArgsIncludingOuterClasses, true)
         val allParamTypes = if (extensionParamType == null) parameterTypes else listOf(extensionParamType) + parameterTypes
 
         val substitutionMap = classTypeArgsIncludingOuterClasses?.let { notNullArgs ->


### PR DESCRIPTION
They were being stringified into `null` strings before. Now we check for nullness, and return null if appropriate.