### PR TITLE
Make `CompareIdenticalValues` test work on arm64

### DIFF
--- a/go/ql/test/query-tests/RedundantCode/CompareIdenticalValues/constants.go
+++ b/go/ql/test/query-tests/RedundantCode/CompareIdenticalValues/constants.go
@@ -1,5 +1,5 @@
-//go:build (linux && ignore) || amd64
-// +build linux,ignore amd64
+//go:build (linux && ignore) || amd64 || arm64
+// +build linux,ignore amd64 arm64
 
 package main
 


### PR DESCRIPTION
The `constants.go` file has a build tag which means that it doesn't get compiled on `arm64` and therefore the `ptrsize` constant is undefined in `tst.go`, causing the consistency test to fail.

This PR updates the build tags for `constants.go` so that it gets included on `arm64` as well.