### PR TITLE
Ruby: Make type tracking flow-insensitive for captured variables

### DIFF
--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPublic.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPublic.qll
@@ -363,10 +363,9 @@ private module Cached {
     source = sink and
     source instanceof LocalSourceNode
     or
-    exists(Node mid | hasLocalSource(mid, source) |
+    exists(Node mid |
+      hasLocalSource(mid, source) and
       localFlowStepTypeTracker(mid, sink)
-      or
-      LocalFlow::localFlowSsaParamCaptureInput(mid, sink)
     )
   }
 

--- a/ruby/ql/lib/codeql/ruby/typetracking/TypeTrackerSpecific.qll
+++ b/ruby/ql/lib/codeql/ruby/typetracking/TypeTrackerSpecific.qll
@@ -74,7 +74,7 @@ predicate simpleLocalFlowStep = DataFlowPrivate::localFlowStepTypeTracker/2;
 /**
  * Holds if data can flow from `node1` to `node2` in a way that discards call contexts.
  */
-predicate jumpStep = DataFlowPrivate::jumpStep/2;
+predicate jumpStep = DataFlowPrivate::jumpStepTypeTracker/2;
 
 /** Holds if there is direct flow from `param` to a return. */
 pragma[nomagic]

--- a/ruby/ql/test/library-tests/dataflow/array-flow/type-tracking-array-flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/array-flow/type-tracking-array-flow.expected
@@ -15,7 +15,6 @@ testFailures
 | array_flow.rb:376:10:376:13 | ...[...] | Unexpected result: hasValueFlow=42.3 |
 | array_flow.rb:377:10:377:13 | ...[...] | Unexpected result: hasValueFlow=42.3 |
 | array_flow.rb:378:10:378:13 | ...[...] | Unexpected result: hasValueFlow=42.3 |
-| array_flow.rb:407:12:407:30 | # $ hasValueFlow=45 | Missing result:hasValueFlow=45 |
 | array_flow.rb:484:10:484:13 | ...[...] | Unexpected result: hasValueFlow=54.3 |
 | array_flow.rb:484:10:484:13 | ...[...] | Unexpected result: hasValueFlow=54.4 |
 | array_flow.rb:484:10:484:13 | ...[...] | Unexpected result: hasValueFlow=54.5 |


### PR DESCRIPTION
Extracted from https://github.com/github/codeql/pull/11725. Aligns Ruby with how JavaScript handles captured variables in type tracking.