### PR TITLE
Kotlin: Handle Kotlin 2 parents better

### DIFF
--- a/java/kotlin-extractor/src/main/kotlin/ExternalDeclExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/ExternalDeclExtractor.kt
@@ -88,12 +88,10 @@ class ExternalDeclExtractor(val logger: FileLogger, val invocationTrapFile: Stri
             nextBatch.forEach { workPair ->
                 val (irDecl, possiblyLongSignature) = workPair
                 extractElement(irDecl, possiblyLongSignature, false) { trapFileBW, signature, manager ->
-                    val containingClass = getContainingClassOrSelf(irDecl)
-                    if (containingClass == null) {
-                        logger.errorElement("Unable to get containing class", irDecl)
+                    val binaryPath = getIrDeclarationBinaryPath(irDecl)
+                    if (binaryPath == null) {
+                        logger.errorElement("Unable to get binary path", irDecl)
                     } else {
-                        val binaryPath = getIrClassBinaryPath(containingClass)
-
                         // We want our comments to be the first thing in the file,
                         // so start off with a PlainTrapWriter
                         val tw = PlainTrapWriter(logger.loggerBase, TrapLabelManager(), trapFileBW, diagnosticTrapWriter)

--- a/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
@@ -192,7 +192,7 @@ open class KotlinFileExtractor(
                     }
                 }
                 is IrFunction -> {
-                    val parentId = useDeclarationParent(declaration.parent, false)?.cast<DbReftype>()
+                    val parentId = useDeclarationParentOf(declaration, false)?.cast<DbReftype>()
                     if (parentId != null) {
                         extractFunction(declaration, parentId, extractBody = extractFunctionBodies, extractMethodAndParameterTypeAccesses = extractFunctionBodies, extractAnnotations = extractAnnotations, null, listOf())
                     }
@@ -202,21 +202,21 @@ open class KotlinFileExtractor(
                     // Leaving this intentionally empty. init blocks are extracted during class extraction.
                 }
                 is IrProperty -> {
-                    val parentId = useDeclarationParent(declaration.parent, false)?.cast<DbReftype>()
+                    val parentId = useDeclarationParentOf(declaration, false)?.cast<DbReftype>()
                     if (parentId != null) {
                         extractProperty(declaration, parentId, extractBackingField = true, extractFunctionBodies = extractFunctionBodies, extractPrivateMembers = extractPrivateMembers, extractAnnotations = extractAnnotations, null, listOf())
                     }
                     Unit
                 }
                 is IrEnumEntry -> {
-                    val parentId = useDeclarationParent(declaration.parent, false)?.cast<DbReftype>()
+                    val parentId = useDeclarationParentOf(declaration, false)?.cast<DbReftype>()
                     if (parentId != null) {
                         extractEnumEntry(declaration, parentId, extractPrivateMembers, extractFunctionBodies)
                     }
                     Unit
                 }
                 is IrField -> {
-                    val parentId = useDeclarationParent(getFieldParent(declaration), false)?.cast<DbReftype>()
+                    val parentId = useDeclarationParentOf(declaration, false)?.cast<DbReftype>()
                     if (parentId != null) {
                         // For consistency with the Java extractor, enum entries get type accesses only if we're extracting from .kt source (i.e., when `extractFunctionBodies` is set)
                         extractField(declaration, parentId, extractAnnotationEnumTypeAccesses = extractFunctionBodies)
@@ -1286,7 +1286,7 @@ open class KotlinFileExtractor(
             val sourceParentId =
                 maybeSourceParentId ?:
                     if (typeSubstitution != null)
-                        useDeclarationParent(f.parent, false)
+                        useDeclarationParentOf(f, false)
                     else
                         parentId
             if (sourceParentId == null) {
@@ -1618,7 +1618,7 @@ open class KotlinFileExtractor(
                 }
 
                 if (bf != null && extractBackingField) {
-                    val fieldParentId = useDeclarationParent(getFieldParent(bf), false)
+                    val fieldParentId = useDeclarationParentOf(bf, false)
                     if (fieldParentId != null) {
                         val fieldId = extractField(bf, fieldParentId.cast(), extractFunctionBodies)
                         tw.writeKtPropertyBackingFields(id, fieldId)
@@ -2092,7 +2092,7 @@ open class KotlinFileExtractor(
 
     private fun getDefaultsMethodLabel(f: IrFunction): Label<out DbCallable>? {
         val classTypeArgsIncludingOuterClasses = null
-        val parentId = useDeclarationParent(f.parent, false, classTypeArgsIncludingOuterClasses, true)
+        val parentId = useDeclarationParentOf(f, false, classTypeArgsIncludingOuterClasses, true)
         if (parentId == null) {
             logger.errorElement("Couldn't get parent ID for defaults method", f)
             return null
@@ -3863,7 +3863,7 @@ open class KotlinFileExtractor(
                         val type = useType(pluginContext.irBuiltIns.unitType)
                         val locId = tw.getLocation(e)
                         val parentClass = irConstructor.parentAsClass
-                        val parentId = useDeclarationParent(parentClass, false, null, true)
+                        val parentId = useDeclarationParentOf(irConstructor, false, null, true)
                         if (parentId == null) {
                             logger.errorElement("Cannot get parent ID for obinit", e)
                             return

--- a/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
@@ -409,11 +409,10 @@ open class KotlinFileExtractor(
 
     private fun getLocation(decl: IrDeclaration, typeArgs: List<IrTypeArgument>?): Label<DbLocation> {
         return if (typeArgs != null && typeArgs.isNotEmpty()) {
-            val c = getContainingClassOrSelf(decl)
-            if (c == null) {
+            val binaryPath = getIrDeclarationBinaryPath(decl)
+            if (binaryPath == null) {
                 tw.getLocation(decl)
             } else {
-                val binaryPath = getIrClassBinaryPath(c)
                 val newTrapWriter = tw.makeFileTrapWriter(binaryPath, true)
                 newTrapWriter.getWholeFileLocation()
             }

--- a/java/kotlin-extractor/src/main/kotlin/KotlinUsesExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/KotlinUsesExtractor.kt
@@ -77,7 +77,7 @@ open class KotlinUsesExtractor(
         TypeResult(fakeKotlinType(), "", "")
     )
 
-    fun useFileClassType(pkg: String, jvmName: String) = TypeResults(
+    private fun useFileClassType(pkg: String, jvmName: String) = TypeResults(
         TypeResult(extractFileClass(pkg, jvmName), "", ""),
         TypeResult(fakeKotlinType(), "", "")
     )
@@ -94,13 +94,13 @@ open class KotlinUsesExtractor(
         return id
     }
 
-    fun extractFileClass(fqName: FqName): Label<out DbClassorinterface> {
+    private fun extractFileClass(fqName: FqName): Label<out DbClassorinterface> {
         val pkg = if (fqName.isRoot()) "" else fqName.parent().asString()
         val jvmName = fqName.shortName().asString()
         return extractFileClass(pkg, jvmName)
     }
 
-    fun extractFileClass(pkg: String, jvmName: String): Label<out DbClassorinterface> {
+    private fun extractFileClass(pkg: String, jvmName: String): Label<out DbClassorinterface> {
         val qualClassName = if (pkg.isEmpty()) jvmName else "$pkg.$jvmName"
         val label = "@\"class;$qualClassName\""
         val id: Label<DbClassorinterface> = tw.getLabelFor(label) {
@@ -799,7 +799,7 @@ open class KotlinUsesExtractor(
         }
     }
 
-    fun parentOf(d: IrDeclaration): IrDeclarationParent {
+    private fun parentOf(d: IrDeclaration): IrDeclarationParent {
         if (d is IrField) {
             return getFieldParent(d)
         }
@@ -1739,7 +1739,7 @@ open class KotlinUsesExtractor(
             it.isConst || it.isLateinit
         } ?: false
 
-    fun getFieldParent(f: IrField) =
+    private fun getFieldParent(f: IrField) =
         f.parentClassOrNull?.let {
             if (it.isCompanion && isDirectlyExposableCompanionObjectField(f))
                 it.parent

--- a/java/kotlin-extractor/src/main/kotlin/TrapWriter.kt
+++ b/java/kotlin-extractor/src/main/kotlin/TrapWriter.kt
@@ -48,6 +48,15 @@ class TrapLabelManager {
      * duplication.
      */
     val genericSpecialisationsExtracted = HashSet<String>()
+
+    /**
+     * Sometimes, when we extract a file class we don't have the IrFile
+     * for it, so we are not able to give it a location. This means that
+     * the location is written outside of the label creation.
+     * This allows us to keep track of whether we've written the location
+     * already in this TRAP file, to avoid duplication.
+     */
+    val fileClassLocationsExtracted = HashSet<IrFile>()
 }
 
 /**

--- a/java/kotlin-extractor/src/main/kotlin/utils/ClassNames.kt
+++ b/java/kotlin-extractor/src/main/kotlin/utils/ClassNames.kt
@@ -130,7 +130,7 @@ fun getIrDeclarationBinaryPath(d: IrDeclaration): String? {
     return null
 }
 
-fun getUnknownBinaryLocation(s: String): String {
+private fun getUnknownBinaryLocation(s: String): String {
     return "/!unknown-binary-location/${s.replace(".", "/")}.class"
 }
 

--- a/java/kotlin-extractor/src/main/kotlin/utils/ClassNames.kt
+++ b/java/kotlin-extractor/src/main/kotlin/utils/ClassNames.kt
@@ -1,6 +1,7 @@
 package com.github.codeql
 
 import com.github.codeql.utils.getJvmName
+import com.github.codeql.utils.versions.getFileClassFqName
 import com.intellij.openapi.vfs.StandardFileSystems
 import org.jetbrains.kotlin.load.java.sources.JavaSourceElement
 import org.jetbrains.kotlin.load.java.structure.impl.classFiles.BinaryJavaClass
@@ -13,7 +14,6 @@ import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.util.fqNameWhenAvailable
 import org.jetbrains.kotlin.ir.util.parentClassOrNull
-import org.jetbrains.kotlin.load.kotlin.FacadeClassSource
 import org.jetbrains.kotlin.load.kotlin.JvmPackagePartSource
 
 // Adapted from Kotlin's interpreter/Utils.kt function 'internalName'
@@ -122,20 +122,9 @@ fun getIrDeclarationBinaryPath(d: IrDeclaration): String? {
     }
     if (d.parent is IrExternalPackageFragment) {
         // This is in a file class.
-        // Get the name in a similar way to the compiler's ExternalPackageParentPatcherLowering
-        // visitMemberAccess/generateOrGetFacadeClass.
-        if (d is IrMemberWithContainerSource) {
-            val containerSource = d.containerSource
-            if (containerSource is FacadeClassSource) {
-                val facadeClassName = containerSource.facadeClassName
-                if (facadeClassName != null) {
-                    // This is a multifile-class
-                    return getUnknownBinaryLocation(facadeClassName.fqNameForTopLevelClassMaybeWithDollars.asString())
-                } else {
-                    // This is a file-class
-                    return getUnknownBinaryLocation(containerSource.className.fqNameForTopLevelClassMaybeWithDollars.asString())
-                }
-            }
+        val fqName = getFileClassFqName(d)
+        if (fqName != null) {
+            return getUnknownBinaryLocation(fqName.asString())
         }
     }
     return null

--- a/java/kotlin-extractor/src/main/kotlin/utils/ExternalDecls.kt
+++ b/java/kotlin-extractor/src/main/kotlin/utils/ExternalDecls.kt
@@ -7,9 +7,31 @@ import org.jetbrains.kotlin.ir.util.isFileClass
 import org.jetbrains.kotlin.ir.util.parentClassOrNull
 
 fun isExternalDeclaration(d: IrDeclaration): Boolean {
-    return d.origin == IrDeclarationOrigin.IR_EXTERNAL_DECLARATION_STUB ||
-           d.origin == IrDeclarationOrigin.IR_EXTERNAL_JAVA_DECLARATION_STUB ||
-           d.origin.toString() == "FUNCTION_INTERFACE_CLASS" // Treat kotlin.coroutines.* like ordinary library classes
+    /*
+    With Kotlin 1 we get things like (from .dump()):
+        PROPERTY IR_EXTERNAL_JAVA_DECLARATION_STUB name:MIN_VALUE visibility:public modality:FINAL [const,val]
+          FIELD IR_EXTERNAL_JAVA_DECLARATION_STUB name:MIN_VALUE type:kotlin.Int visibility:public [final,static]
+            EXPRESSION_BODY
+              CONST Int type=kotlin.Int value=-2147483648
+    */
+    if (d.origin == IrDeclarationOrigin.IR_EXTERNAL_DECLARATION_STUB ||
+        d.origin == IrDeclarationOrigin.IR_EXTERNAL_JAVA_DECLARATION_STUB ||
+        d.origin.toString() == "FUNCTION_INTERFACE_CLASS") { // Treat kotlin.coroutines.* like ordinary library classes
+        return true
+    }
+    /*
+    With Kotlin 2, the property itself is not marked as an external stub, but it parent is:
+        CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Companion modality:OPEN visibility:public [companion] superTypes:[]
+          PROPERTY name:MIN_VALUE visibility:public modality:FINAL [const,val]
+            FIELD PROPERTY_BACKING_FIELD name:MIN_VALUE type:kotlin.Int visibility:public [final]
+              EXPRESSION_BODY
+                CONST Int type=kotlin.Int value=-2147483648
+    */
+    val p = d.parent
+    if (p is IrDeclaration) {
+        return isExternalDeclaration(p)
+    }
+    return false
 }
 
 /**

--- a/java/kotlin-extractor/src/main/kotlin/utils/ExternalDecls.kt
+++ b/java/kotlin-extractor/src/main/kotlin/utils/ExternalDecls.kt
@@ -3,6 +3,7 @@ package com.github.codeql.utils
 import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrDeclaration
 import org.jetbrains.kotlin.ir.declarations.IrDeclarationOrigin
+import org.jetbrains.kotlin.ir.declarations.IrExternalPackageFragment
 import org.jetbrains.kotlin.ir.util.isFileClass
 import org.jetbrains.kotlin.ir.util.parentClassOrNull
 
@@ -28,6 +29,10 @@ fun isExternalDeclaration(d: IrDeclaration): Boolean {
                 CONST Int type=kotlin.Int value=-2147483648
     */
     val p = d.parent
+    if (p is IrExternalPackageFragment) {
+        // This is an external declaration in a (multi)file class
+        return true
+    }
     if (p is IrDeclaration) {
         return isExternalDeclaration(p)
     }
@@ -37,5 +42,15 @@ fun isExternalDeclaration(d: IrDeclaration): Boolean {
 /**
  * Returns true if `d` is not itself a class, but is a member of an external file class.
  */
-fun isExternalFileClassMember(d: IrDeclaration) = d !is IrClass && (d.parentClassOrNull?.let { it.isFileClass } ?: false)
+fun isExternalFileClassMember(d: IrDeclaration): Boolean {
+    if (d is IrClass) { return false }
+    val p = d.parent
+    when (p) {
+        is IrClass -> return p.isFileClass
+        is IrExternalPackageFragment ->
+            // This is an external declaration in a (multi)file class
+            return true
+    }
+    return false
+}
 

--- a/java/kotlin-extractor/src/main/kotlin/utils/versions/v_1_4_32/getFileClassFqName.kt
+++ b/java/kotlin-extractor/src/main/kotlin/utils/versions/v_1_4_32/getFileClassFqName.kt
@@ -1,0 +1,8 @@
+package com.github.codeql.utils.versions
+
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.ir.declarations.IrDeclaration
+
+fun getFileClassFqName(@Suppress("UNUSED_PARAMETER") d: IrDeclaration): FqName? {
+    return null
+}

--- a/java/kotlin-extractor/src/main/kotlin/utils/versions/v_1_7_0/getFileClassFqName.kt
+++ b/java/kotlin-extractor/src/main/kotlin/utils/versions/v_1_7_0/getFileClassFqName.kt
@@ -1,0 +1,29 @@
+package com.github.codeql.utils.versions
+
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.ir.declarations.IrDeclaration
+import org.jetbrains.kotlin.ir.declarations.IrMemberWithContainerSource
+import org.jetbrains.kotlin.load.kotlin.FacadeClassSource
+
+fun getFileClassFqName(d: IrDeclaration): FqName? {
+    // d is in a file class.
+    // Get the name in a similar way to the compiler's ExternalPackageParentPatcherLowering
+    // visitMemberAccess/generateOrGetFacadeClass.
+    if (d is IrMemberWithContainerSource) {
+        val containerSource = d.containerSource
+        if (containerSource is FacadeClassSource) {
+            val facadeClassName = containerSource.facadeClassName
+            if (facadeClassName != null) {
+                // TODO: This is really a multifile-class rather than a file-class,
+                // but for now we treat them the same.
+                return facadeClassName.fqNameForTopLevelClassMaybeWithDollars
+            } else {
+                return containerSource.className.fqNameForTopLevelClassMaybeWithDollars
+            }
+        } else {
+            return null
+        }
+    } else {
+        return null
+    }
+}


### PR DESCRIPTION
In Kotlin 2 mode, when the parent is a (multi)file class, we see the parent as just an `IrExternalPackageFragment` and have to do some extra work to extract it.