### PR TITLE
C#: Fix `getMadRepresentationSpecific`

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/FlowSummaryImplSpecific.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/FlowSummaryImplSpecific.qll
@@ -205,10 +205,9 @@ string getMadRepresentationSpecific(SummaryComponent sc) {
   or
   sc = TWithContentSummaryComponent(_) and result = "WithElement"
   or
-  exists(ReturnKind rk |
+  exists(OutRefReturnKind rk |
     sc = TReturnSummaryComponent(rk) and
-    not rk = getReturnValueKind() and
-    result = "ReturnValue[" + rk + "]"
+    result = "Argument[" + rk.getPosition() + "]"
   )
 }
 


### PR DESCRIPTION
MaD for C# uses `Argument[x]` for `out/ref` returns (see `summaryPostUpdateNodeIsOutOrRef`), so this PR aligns `getMadRepresentationSpecific` with that format.