### PR TITLE
C++: Support subtraction in the new range analysis

### DIFF
--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/constant-size/ConstantSizeArrayOffByOne.expected
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/constant-size/ConstantSizeArrayOffByOne.expected
@@ -69,12 +69,6 @@ edges
 | test.cpp:322:19:322:27 | ... + ... | test.cpp:325:24:325:26 | end |
 | test.cpp:324:23:324:26 | temp | test.cpp:324:23:324:32 | ... + ... |
 | test.cpp:324:23:324:32 | ... + ... | test.cpp:325:15:325:19 | temp2 |
-| test.cpp:351:9:351:11 | arr | test.cpp:351:9:351:14 | access to array |
-| test.cpp:351:9:351:11 | arr | test.cpp:351:18:351:25 | access to array |
-| test.cpp:351:18:351:20 | arr | test.cpp:351:9:351:14 | access to array |
-| test.cpp:351:18:351:20 | arr | test.cpp:351:18:351:25 | access to array |
-| test.cpp:351:29:351:31 | arr | test.cpp:351:9:351:14 | access to array |
-| test.cpp:351:29:351:31 | arr | test.cpp:351:18:351:25 | access to array |
 nodes
 | test.cpp:34:5:34:24 | access to array | semmle.label | access to array |
 | test.cpp:34:10:34:12 | buf | semmle.label | buf |
@@ -167,11 +161,6 @@ nodes
 | test.cpp:325:15:325:19 | temp2 | semmle.label | temp2 |
 | test.cpp:325:24:325:26 | end | semmle.label | end |
 | test.cpp:325:24:325:26 | end | semmle.label | end |
-| test.cpp:351:9:351:11 | arr | semmle.label | arr |
-| test.cpp:351:9:351:14 | access to array | semmle.label | access to array |
-| test.cpp:351:18:351:20 | arr | semmle.label | arr |
-| test.cpp:351:18:351:25 | access to array | semmle.label | access to array |
-| test.cpp:351:29:351:31 | arr | semmle.label | arr |
 subpaths
 #select
 | test.cpp:35:5:35:22 | PointerAdd: access to array | test.cpp:35:10:35:12 | buf | test.cpp:35:5:35:22 | access to array | This pointer arithmetic may have an off-by-1 error allowing it to overrun $@ at this $@. | test.cpp:15:9:15:11 | buf | buf | test.cpp:35:5:35:26 | Store: ... = ... | write |
@@ -194,6 +183,3 @@ subpaths
 | test.cpp:322:19:322:27 | PointerAdd: ... + ... | test.cpp:322:19:322:22 | temp | test.cpp:325:24:325:26 | end | This pointer arithmetic may have an off-by-1 error allowing it to overrun $@ at this $@. | test.cpp:314:10:314:13 | temp | temp | test.cpp:330:13:330:24 | Store: ... = ... | write |
 | test.cpp:322:19:322:27 | PointerAdd: ... + ... | test.cpp:322:19:322:22 | temp | test.cpp:325:24:325:26 | end | This pointer arithmetic may have an off-by-1 error allowing it to overrun $@ at this $@. | test.cpp:314:10:314:13 | temp | temp | test.cpp:331:13:331:24 | Store: ... = ... | write |
 | test.cpp:322:19:322:27 | PointerAdd: ... + ... | test.cpp:322:19:322:22 | temp | test.cpp:325:24:325:26 | end | This pointer arithmetic may have an off-by-1 error allowing it to overrun $@ at this $@. | test.cpp:314:10:314:13 | temp | temp | test.cpp:333:13:333:24 | Store: ... = ... | write |
-| test.cpp:351:18:351:25 | PointerAdd: access to array | test.cpp:351:9:351:11 | arr | test.cpp:351:18:351:25 | access to array | This pointer arithmetic may have an off-by-1 error allowing it to overrun $@ at this $@. | test.cpp:348:9:348:11 | arr | arr | test.cpp:351:18:351:25 | Load: access to array | read |
-| test.cpp:351:18:351:25 | PointerAdd: access to array | test.cpp:351:18:351:20 | arr | test.cpp:351:18:351:25 | access to array | This pointer arithmetic may have an off-by-1 error allowing it to overrun $@ at this $@. | test.cpp:348:9:348:11 | arr | arr | test.cpp:351:18:351:25 | Load: access to array | read |
-| test.cpp:351:18:351:25 | PointerAdd: access to array | test.cpp:351:29:351:31 | arr | test.cpp:351:18:351:25 | access to array | This pointer arithmetic may have an off-by-1 error allowing it to overrun $@ at this $@. | test.cpp:348:9:348:11 | arr | arr | test.cpp:351:18:351:25 | Load: access to array | read |

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/constant-size/test.cpp
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/constant-size/test.cpp
@@ -348,7 +348,7 @@ int positiveRange(int x) {
     int arr[128];
 
     for(int i=127-offset; i>= 0; i--) {
-        arr[i] = arr[i+1] + arr[i+offset]; // GOOD [FALSE POSITIVE]
+        arr[i] = arr[i+1] + arr[i+offset]; // GOOD
     }
     return arr[0];
 }

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/InvalidPointerDeref.expected
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/InvalidPointerDeref.expected
@@ -228,6 +228,7 @@ edges
 | test.cpp:732:16:732:26 | ... + ... | test.cpp:732:16:732:26 | ... + ... |
 | test.cpp:732:16:732:26 | ... + ... | test.cpp:733:5:733:12 | ... = ... |
 | test.cpp:732:16:732:26 | ... + ... | test.cpp:733:5:733:12 | ... = ... |
+| test.cpp:739:12:739:21 | new[] | test.cpp:742:5:742:16 | ... = ... |
 nodes
 | test.cpp:4:15:4:20 | call to malloc | semmle.label | call to malloc |
 | test.cpp:5:15:5:22 | ... + ... | semmle.label | ... + ... |
@@ -382,6 +383,8 @@ nodes
 | test.cpp:732:16:732:26 | ... + ... | semmle.label | ... + ... |
 | test.cpp:732:16:732:26 | ... + ... | semmle.label | ... + ... |
 | test.cpp:733:5:733:12 | ... = ... | semmle.label | ... = ... |
+| test.cpp:739:12:739:21 | new[] | semmle.label | new[] |
+| test.cpp:742:5:742:16 | ... = ... | semmle.label | ... = ... |
 subpaths
 #select
 | test.cpp:6:14:6:15 | * ... | test.cpp:4:15:4:20 | call to malloc | test.cpp:6:14:6:15 | * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:4:15:4:20 | call to malloc | call to malloc | test.cpp:5:19:5:22 | size | size |
@@ -417,3 +420,4 @@ subpaths
 | test.cpp:701:15:701:16 | * ... | test.cpp:695:13:695:26 | new[] | test.cpp:701:15:701:16 | * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:695:13:695:26 | new[] | new[] | test.cpp:696:19:696:22 | size | size |
 | test.cpp:706:12:706:13 | * ... | test.cpp:711:13:711:26 | new[] | test.cpp:706:12:706:13 | * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:711:13:711:26 | new[] | new[] | test.cpp:712:19:712:22 | size | size |
 | test.cpp:733:5:733:12 | ... = ... | test.cpp:730:12:730:28 | new[] | test.cpp:733:5:733:12 | ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:730:12:730:28 | new[] | new[] | test.cpp:732:21:732:25 | ... + ... | ... + ... |
+| test.cpp:742:5:742:16 | ... = ... | test.cpp:739:12:739:21 | new[] | test.cpp:742:5:742:16 | ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:739:12:739:21 | new[] | new[] | test.cpp:742:7:742:11 | ... - ... | ... - ... |

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/InvalidPointerDeref.expected
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/InvalidPointerDeref.expected
@@ -228,7 +228,6 @@ edges
 | test.cpp:732:16:732:26 | ... + ... | test.cpp:732:16:732:26 | ... + ... |
 | test.cpp:732:16:732:26 | ... + ... | test.cpp:733:5:733:12 | ... = ... |
 | test.cpp:732:16:732:26 | ... + ... | test.cpp:733:5:733:12 | ... = ... |
-| test.cpp:739:12:739:21 | new[] | test.cpp:742:5:742:16 | ... = ... |
 nodes
 | test.cpp:4:15:4:20 | call to malloc | semmle.label | call to malloc |
 | test.cpp:5:15:5:22 | ... + ... | semmle.label | ... + ... |
@@ -383,8 +382,6 @@ nodes
 | test.cpp:732:16:732:26 | ... + ... | semmle.label | ... + ... |
 | test.cpp:732:16:732:26 | ... + ... | semmle.label | ... + ... |
 | test.cpp:733:5:733:12 | ... = ... | semmle.label | ... = ... |
-| test.cpp:739:12:739:21 | new[] | semmle.label | new[] |
-| test.cpp:742:5:742:16 | ... = ... | semmle.label | ... = ... |
 subpaths
 #select
 | test.cpp:6:14:6:15 | * ... | test.cpp:4:15:4:20 | call to malloc | test.cpp:6:14:6:15 | * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:4:15:4:20 | call to malloc | call to malloc | test.cpp:5:19:5:22 | size | size |
@@ -420,4 +417,3 @@ subpaths
 | test.cpp:701:15:701:16 | * ... | test.cpp:695:13:695:26 | new[] | test.cpp:701:15:701:16 | * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:695:13:695:26 | new[] | new[] | test.cpp:696:19:696:22 | size | size |
 | test.cpp:706:12:706:13 | * ... | test.cpp:711:13:711:26 | new[] | test.cpp:706:12:706:13 | * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:711:13:711:26 | new[] | new[] | test.cpp:712:19:712:22 | size | size |
 | test.cpp:733:5:733:12 | ... = ... | test.cpp:730:12:730:28 | new[] | test.cpp:733:5:733:12 | ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:730:12:730:28 | new[] | new[] | test.cpp:732:21:732:25 | ... + ... | ... + ... |
-| test.cpp:742:5:742:16 | ... = ... | test.cpp:739:12:739:21 | new[] | test.cpp:742:5:742:16 | ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:739:12:739:21 | new[] | new[] | test.cpp:742:7:742:11 | ... - ... | ... - ... |

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/test.cpp
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/test.cpp
@@ -733,3 +733,12 @@ void test36(unsigned size, unsigned n) {
     *end = 0; // $ deref=L733 // BAD
   }
 }
+
+void test37(unsigned long n)
+{
+  int *p = new int[n];
+  for (unsigned long i = n; i != 0u; i--)
+  {
+    p[n - i] = 0; // $ alloc=L739 deref=L742 // GOOD [FALSE POSITIVE]
+  }
+}

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/test.cpp
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/test.cpp
@@ -739,6 +739,6 @@ void test37(unsigned long n)
   int *p = new int[n];
   for (unsigned long i = n; i != 0u; i--)
   {
-    p[n - i] = 0; // $ alloc=L739 deref=L742 // GOOD [FALSE POSITIVE]
+    p[n - i] = 0; // GOOD
   }
 }

--- a/cpp/ql/test/library-tests/ir/range-analysis/test.cpp
+++ b/cpp/ql/test/library-tests/ir/range-analysis/test.cpp
@@ -95,3 +95,25 @@ void gotoLoop(bool b1, bool b2)
     }
   }
 }
+
+void test_sub(int x, int y, int n) {
+  if(x > 0 && x < 500) {
+    if(y > 0 && y < 10) {
+      range(x - y); // $ range="<=InitializeParameter: x-1" range=<=498
+    }
+
+    if(n > 0 && n < 100) {
+      for (int i = 0; i < n; i++)
+      {
+        range(n - i); // $ range=<=99 range="<=InitializeParameter: n | Store: n+0"
+        range(i - n); // $ range="<=InitializeParameter: n | Store: n-2" range=<=97 range="<=Phi: i-1"
+      }
+
+      for (int i = n; i != 0; i--)
+      {
+        range(n - i); // $ SPURIOUS: overflow=+
+        range(i - n); // $ range="<=Phi: i-1" SPURIOUS: overflow=-
+      }
+    }
+  }
+}

--- a/cpp/ql/test/library-tests/ir/range-analysis/test.cpp
+++ b/cpp/ql/test/library-tests/ir/range-analysis/test.cpp
@@ -99,20 +99,20 @@ void gotoLoop(bool b1, bool b2)
 void test_sub(int x, int y, int n) {
   if(x > 0 && x < 500) {
     if(y > 0 && y < 10) {
-      range(x - y); // $ range="<=InitializeParameter: x-1" range=<=498
+      range(x - y); // $ range=<=498 range=>=-8
     }
 
     if(n > 0 && n < 100) {
       for (int i = 0; i < n; i++)
       {
-        range(n - i); // $ range=<=99 range="<=InitializeParameter: n | Store: n+0"
-        range(i - n); // $ range="<=InitializeParameter: n | Store: n-2" range=<=97 range="<=Phi: i-1"
+        range(n - i); // $ range=">=Phi: i-97" range=<=99 range=>=-97
+        range(i - n); // $ range="<=Phi: i-1" range=">=Phi: i-99" range=<=97 range=>=-99 
       }
 
       for (int i = n; i != 0; i--)
       {
         range(n - i); // $ SPURIOUS: overflow=+
-        range(i - n); // $ range="<=Phi: i-1" SPURIOUS: overflow=-
+        range(i - n); // $ range=">=Phi: i-99"
       }
     }
   }


### PR DESCRIPTION
I was seeing a lot of FPs related to subtraction on the `cpp/invalid-pointer-deref` query on MRVA. This turned out to be because we still inferred very imprecise ranges similar to what we removed in the case of addition [in an earlier PR](https://github.com/github/codeql/pull/12673).

This PR replaces those imprecise ranges with much more precise ranges computed by non-linear recursion.