### PR TITLE
Go: Don't warn when Go version exactly matches go.mod

### DIFF
--- a/go/extractor/cli/go-autobuilder/go-autobuilder.go
+++ b/go/extractor/cli/go-autobuilder/go-autobuilder.go
@@ -773,7 +773,7 @@ func installDependenciesAndBuild() {
 
 	goModVersion, goModVersionFound := tryReadGoDirective(buildInfo)
 
-	if goModVersionFound && semver.Compare("v"+goModVersion, getEnvGoSemVer()) >= 0 {
+	if goModVersionFound && semver.Compare("v"+goModVersion, getEnvGoSemVer()) > 0 {
 		diagnostics.EmitNewerGoVersionNeeded()
 	}
 


### PR DESCRIPTION
We had only previously tested this with e.g. installed go 1.20.5 >= go.mod request `go 1.20`; now we have go 1.21.0 which shouldn't elicit a warning because 1.21.0 is equal to the go.mod request `go 1.21`.