### PR TITLE
Java: Join-order fix in RangeAnalysis.

### DIFF
--- a/java/ql/lib/semmle/code/java/dataflow/RangeAnalysis.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/RangeAnalysis.qll
@@ -257,11 +257,21 @@ private Guard boundFlowCond(SsaVariable v, Expr e, int delta, boolean upper, boo
   or
   // guard that tests whether `v2` is bounded by `e + delta + d1 - d2` and
   // exists a guard `guardEq` such that `v = v2 - d1 + d2`.
-  exists(SsaVariable v2, Guard guardEq, boolean eqIsTrue, int d1, int d2 |
-    guardEq = eqFlowCond(v, ssaRead(v2, d1), d2, true, eqIsTrue) and
-    result = boundFlowCond(v2, e, delta + d1 - d2, upper, testIsTrue) and
-    // guardEq needs to control guard
-    guardEq.directlyControls(result.getBasicBlock(), eqIsTrue)
+  exists(SsaVariable v2, int d |
+    // equality needs to control guard
+    result.getBasicBlock() = eqSsaCondDirectlyControls(v, v2, d) and
+    result = boundFlowCond(v2, e, delta - d, upper, testIsTrue)
+  )
+}
+
+/**
+ * Gets a basic block in which `v1` equals `v2 + delta`.
+ */
+private BasicBlock eqSsaCondDirectlyControls(SsaVariable v1, SsaVariable v2, int delta) {
+  exists(Guard guardEq, int d1, int d2, boolean eqIsTrue |
+    guardEq = eqFlowCond(v1, ssaRead(v2, d1), d2, true, eqIsTrue) and
+    delta = d2 - d1 and
+    guardEq.directlyControls(result, eqIsTrue)
   )
 }
 

--- a/java/ql/lib/semmle/code/java/dataflow/RangeAnalysis.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/RangeAnalysis.qll
@@ -267,6 +267,7 @@ private Guard boundFlowCond(SsaVariable v, Expr e, int delta, boolean upper, boo
 /**
  * Gets a basic block in which `v1` equals `v2 + delta`.
  */
+pragma[nomagic]
 private BasicBlock eqSsaCondDirectlyControls(SsaVariable v1, SsaVariable v2, int delta) {
   exists(Guard guardEq, int d1, int d2, boolean eqIsTrue |
     guardEq = eqFlowCond(v1, ssaRead(v2, d1), d2, true, eqIsTrue) and


### PR DESCRIPTION
Before:
```
Evaluated recursive predicate RangeAnalysis#2dea8027::boundFlowCond#5#ffffff@cf4ddf18 in 788999ms on iteration 2 (delta size: 100).
Evaluated relational algebra for predicate RangeAnalysis#2dea8027::boundFlowCond#5#ffffff@cf4ddf18 on iteration 2 running pipeline standard with tuple counts:
             301830   ~0%    {6} r1 = SCAN RangeAnalysis#2dea8027::boundFlowCond#5#ffffff#prev_delta OUTPUT In.5, In.4, In.0, In.1, In.2, In.3
              12734   ~0%    {6} r2 = JOIN r1 WITH GuardsLogic#2bffeb61::implies_v2#4#ffff_2301#join_rhs ON FIRST 2 OUTPUT Rhs.2, Lhs.2, Lhs.3, Lhs.4, Lhs.5, Rhs.3
              12734   ~0%    {6} r3 = JOIN r2 WITH Guards#69cd2c5b::Guard#f ON FIRST 1 OUTPUT Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5, Lhs.0
                         
             301830   ~3%    {6} r4 = SCAN RangeAnalysis#2dea8027::boundFlowCond#5#ffffff#prev_delta OUTPUT In.5, In.0, In.1, In.2, In.3, In.4
             301830   ~3%    {6} r5 = JOIN r4 WITH Guards#69cd2c5b::Guard#f ON FIRST 1 OUTPUT Lhs.0, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5
             301830   ~3%    {7} r6 = JOIN r5 WITH Guards#69cd2c5b::Guard::getBasicBlock#0#dispred#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5, Lhs.0
           21702434   ~0%    {8} r7 = JOIN r6 WITH Guards#69cd2c5b::Guard::directlyControls#2#dispred#fff_102#join_rhs ON FIRST 1 OUTPUT Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5, Lhs.6, Rhs.1, Rhs.2
        15193668178   ~0%    {10} r8 = JOIN r7 WITH RangeUtils#746f57ef::ssaRead#2#fff ON FIRST 1 OUTPUT Rhs.2, true, Lhs.7, Lhs.6, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5, Rhs.1
                  6  ~20%    {6} r9 = JOIN r8 WITH RangeUtils#746f57ef::eqFlowCond#5#ffffff_134502#join_rhs ON FIRST 4 OUTPUT Rhs.4, Lhs.4, ((Rhs.5 + Lhs.5) - Lhs.9), Lhs.6, Lhs.7, Lhs.8
                         
              12740   ~0%    {6} r10 = r3 UNION r9
                100   ~1%    {6} r11 = r10 AND NOT RangeAnalysis#2dea8027::boundFlowCond#5#ffffff#prev(Lhs.0, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5)
                             return r11
```
After
```
Evaluated non-recursive predicate RangeAnalysis#2dea8027::eqSsaCondDirectlyControls#3#ffff@d8e131gf in 469ms (size: 45326).
Evaluated relational algebra for predicate RangeAnalysis#2dea8027::eqSsaCondDirectlyControls#3#ffff@d8e131gf with tuple counts:
        16916517  ~0%    {4} r1 = SCAN Guards#69cd2c5b::Guard::directlyControls#2#dispred#fff OUTPUT true, In.2, In.0, In.1
          166200  ~1%    {4} r2 = JOIN r1 WITH RangeUtils#746f57ef::eqFlowCond#5#ffffff_345012#join_rhs ON FIRST 3 OUTPUT Rhs.4, Lhs.3, Rhs.3, Rhs.5
           45326  ~6%    {5} r3 = JOIN r2 WITH RangeUtils#746f57ef::ssaRead#2#fff_201#join_rhs ON FIRST 1 OUTPUT Lhs.2, Rhs.1, Lhs.3, Rhs.2, Lhs.1
           45326  ~0%    {4} r4 = SCAN r3 OUTPUT In.0, In.1, (In.2 - In.3), In.4
                         return r4

Evaluated recursive predicate RangeAnalysis#2dea8027::boundFlowCond#5#ffffff@de6a5ah1 in 114ms on iteration 2 (delta size: 100).
Evaluated relational algebra for predicate RangeAnalysis#2dea8027::boundFlowCond#5#ffffff@de6a5ah1 on iteration 2 running pipeline standard with tuple counts:
        301830   ~0%    {6} r1 = SCAN RangeAnalysis#2dea8027::boundFlowCond#5#ffffff#prev_delta OUTPUT In.5, In.4, In.0, In.1, In.2, In.3
         12734   ~0%    {6} r2 = JOIN r1 WITH GuardsLogic#2bffeb61::implies_v2#4#ffff_2301#join_rhs ON FIRST 2 OUTPUT Rhs.2, Lhs.2, Lhs.3, Lhs.4, Lhs.5, Rhs.3
         12734   ~0%    {6} r3 = JOIN r2 WITH Guards#69cd2c5b::Guard#f ON FIRST 1 OUTPUT Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5, Lhs.0
                    
        301830   ~1%    {6} r4 = SCAN RangeAnalysis#2dea8027::boundFlowCond#5#ffffff#prev_delta OUTPUT In.5, In.0, In.1, In.2, In.3, In.4
        301830   ~1%    {6} r5 = JOIN r4 WITH Guards#69cd2c5b::Guard#f ON FIRST 1 OUTPUT Lhs.0, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5
        301830   ~5%    {7} r6 = JOIN r5 WITH Guards#69cd2c5b::Guard::getBasicBlock#0#dispred#ff ON FIRST 1 OUTPUT Lhs.1, Rhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5, Lhs.0
             6   ~0%    {7} r7 = JOIN r6 WITH RangeAnalysis#2dea8027::eqSsaCondDirectlyControls#3#ffff_1302#join_rhs ON FIRST 2 OUTPUT Rhs.2, Lhs.2, Rhs.3, Lhs.3, Lhs.4, Lhs.5, Lhs.6
             6   ~0%    {6} r8 = SCAN r7 OUTPUT In.0, In.1, (In.2 + In.3), In.4, In.5, In.6
                    
         12740   ~0%    {6} r9 = r3 UNION r8
           100   ~1%    {6} r10 = r9 AND NOT RangeAnalysis#2dea8027::boundFlowCond#5#ffffff#prev(Lhs.0, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5)
                        return r10
```