### PR TITLE
C++: Add `cpp/invalid-pointer-deref` false positive

### DIFF
--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/InvalidPointerDeref.expected
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/InvalidPointerDeref.expected
@@ -228,6 +228,11 @@ edges
 | test.cpp:732:16:732:26 | ... + ... | test.cpp:732:16:732:26 | ... + ... |
 | test.cpp:732:16:732:26 | ... + ... | test.cpp:733:5:733:12 | ... = ... |
 | test.cpp:732:16:732:26 | ... + ... | test.cpp:733:5:733:12 | ... = ... |
+| test.cpp:754:18:754:31 | new[] | test.cpp:767:16:767:29 | access to array |
+| test.cpp:754:18:754:31 | new[] | test.cpp:767:16:767:29 | access to array |
+| test.cpp:754:18:754:31 | new[] | test.cpp:772:16:772:29 | access to array |
+| test.cpp:754:18:754:31 | new[] | test.cpp:772:16:772:29 | access to array |
+| test.cpp:781:14:781:27 | new[] | test.cpp:786:18:786:27 | access to array |
 nodes
 | test.cpp:4:15:4:20 | call to malloc | semmle.label | call to malloc |
 | test.cpp:5:15:5:22 | ... + ... | semmle.label | ... + ... |
@@ -382,6 +387,13 @@ nodes
 | test.cpp:732:16:732:26 | ... + ... | semmle.label | ... + ... |
 | test.cpp:732:16:732:26 | ... + ... | semmle.label | ... + ... |
 | test.cpp:733:5:733:12 | ... = ... | semmle.label | ... = ... |
+| test.cpp:754:18:754:31 | new[] | semmle.label | new[] |
+| test.cpp:767:16:767:29 | access to array | semmle.label | access to array |
+| test.cpp:767:16:767:29 | access to array | semmle.label | access to array |
+| test.cpp:772:16:772:29 | access to array | semmle.label | access to array |
+| test.cpp:772:16:772:29 | access to array | semmle.label | access to array |
+| test.cpp:781:14:781:27 | new[] | semmle.label | new[] |
+| test.cpp:786:18:786:27 | access to array | semmle.label | access to array |
 subpaths
 #select
 | test.cpp:6:14:6:15 | * ... | test.cpp:4:15:4:20 | call to malloc | test.cpp:6:14:6:15 | * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:4:15:4:20 | call to malloc | call to malloc | test.cpp:5:19:5:22 | size | size |
@@ -417,3 +429,8 @@ subpaths
 | test.cpp:701:15:701:16 | * ... | test.cpp:695:13:695:26 | new[] | test.cpp:701:15:701:16 | * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:695:13:695:26 | new[] | new[] | test.cpp:696:19:696:22 | size | size |
 | test.cpp:706:12:706:13 | * ... | test.cpp:711:13:711:26 | new[] | test.cpp:706:12:706:13 | * ... | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:711:13:711:26 | new[] | new[] | test.cpp:712:19:712:22 | size | size |
 | test.cpp:733:5:733:12 | ... = ... | test.cpp:730:12:730:28 | new[] | test.cpp:733:5:733:12 | ... = ... | This write might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:730:12:730:28 | new[] | new[] | test.cpp:732:21:732:25 | ... + ... | ... + ... |
+| test.cpp:767:16:767:29 | access to array | test.cpp:754:18:754:31 | new[] | test.cpp:767:16:767:29 | access to array | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:754:18:754:31 | new[] | new[] | test.cpp:767:22:767:28 | ... + ... | ... + ... |
+| test.cpp:767:16:767:29 | access to array | test.cpp:754:18:754:31 | new[] | test.cpp:767:16:767:29 | access to array | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:754:18:754:31 | new[] | new[] | test.cpp:772:22:772:28 | ... + ... | ... + ... |
+| test.cpp:772:16:772:29 | access to array | test.cpp:754:18:754:31 | new[] | test.cpp:772:16:772:29 | access to array | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:754:18:754:31 | new[] | new[] | test.cpp:767:22:767:28 | ... + ... | ... + ... |
+| test.cpp:772:16:772:29 | access to array | test.cpp:754:18:754:31 | new[] | test.cpp:772:16:772:29 | access to array | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:754:18:754:31 | new[] | new[] | test.cpp:772:22:772:28 | ... + ... | ... + ... |
+| test.cpp:786:18:786:27 | access to array | test.cpp:781:14:781:27 | new[] | test.cpp:786:18:786:27 | access to array | This read might be out of bounds, as the pointer might be equal to $@ + $@. | test.cpp:781:14:781:27 | new[] | new[] | test.cpp:786:20:786:26 | ... + ... | ... + ... |

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/test.cpp
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/pointer-deref/test.cpp
@@ -742,3 +742,49 @@ void test37(unsigned long n)
     p[n - i] = 0; // GOOD
   }
 }
+
+unsigned get(char);
+void exit(int);
+
+void error(const char * msg) {
+  exit(1);
+}
+
+void test38(unsigned size) {
+  char * alloc = new char[size];
+
+  unsigned pos = 0;
+  while (pos < size) {
+    char kind = alloc[pos];
+    unsigned n = get(alloc[pos]);
+    if (pos + n >= size) {
+      error("");
+    }
+    switch (kind) {
+    case '0':
+      if (n != 1)
+        error("");
+      char x = alloc[pos + 1]; // $ alloc=L754 deref=L767 // GOOD [FALSE POSITIVE]
+      break;
+    case '1':
+      if (n != 2)
+        error("");
+      char a = alloc[pos + 1]; // $ alloc=L754 deref=L772 // GOOD [FALSE POSITIVE]
+      char b = alloc[pos + 2];
+      break;
+    }
+    pos += 1 + n;
+  }
+}
+
+void test38_simple(unsigned size, unsigned pos, unsigned numParams) {
+  char * p = new char[size];
+
+  if (pos < size) {
+    if (pos + numParams < size) {
+      if (numParams == 1) {
+        char x = p[pos + 1]; // $ alloc=L781 deref=L786 // GOOD [FALSE POSITIVE]
+      }
+    }
+  }
+}


### PR DESCRIPTION
`test38` is a somewhat realistic testcase that represents a false positive on a project with many `cpp/invalid-pointer-deref` results, and `test38_simple` is a minimal testcase that seems to reproduce this.