### PR TITLE
Swift: use C++20 constraints and concepts to simplify code

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
         exclude: /test/.*$(?<!\.ql)(?<!\.qll)(?<!\.qlref)|.*\.patch
 
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v13.0.1
+    rev: v15.0.7
     hooks:
       - id: clang-format
         files: ^swift/.*\.(h|c|cpp)$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
         exclude: /test/.*$(?<!\.ql)(?<!\.qll)(?<!\.qlref)|.*\.patch
 
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v15.0.7
+    rev: v13.0.1
     hooks:
       - id: clang-format
         files: ^swift/.*\.(h|c|cpp)$

--- a/misc/codegen/templates/trap_tags_h.mustache
+++ b/misc/codegen/templates/trap_tags_h.mustache
@@ -6,7 +6,7 @@ namespace codeql {
 {{#tags}}
 
 // {{id}}
-struct {{name}}Tag {{#has_bases}}: {{#bases}}{{^first}}, {{/first}}{{base}}Tag{{/bases}} {{/has_bases}}{
+struct {{name}}Tag {{#has_bases}}: {{#bases}}{{^first}}, {{/first}}virtual {{base}}Tag{{/bases}} {{/has_bases}}{
   static constexpr const char* prefix = "{{name}}";
 };
 {{/tags}}

--- a/swift/extractor/infra/SwiftDispatcher.h
+++ b/swift/extractor/infra/SwiftDispatcher.h
@@ -130,8 +130,8 @@ class SwiftDispatcher {
   // If the AST node was not emitted yet, then the emission is dispatched to a corresponding
   // visitor (see `visit(T *)` methods below).
   template <typename E>
-  requires std::constructible_from<Handle, E> TrapLabelOf<E> fetchLabel(const E& e,
-                                                                        swift::Type type = {}) {
+    requires std::constructible_from<Handle, E>
+  TrapLabelOf<E> fetchLabel(const E& e, swift::Type type = {}) {
     if constexpr (std::constructible_from<bool, const E&>) {
       if (!e) {
         // this will be treated on emission
@@ -163,7 +163,8 @@ class SwiftDispatcher {
   }
 
   template <typename E>
-  requires std::constructible_from<Handle, E*> TrapLabelOf<E> fetchLabel(const E& e) {
+    requires std::constructible_from<Handle, E*>
+  TrapLabelOf<E> fetchLabel(const E& e) {
     return fetchLabel(&e);
   }
 
@@ -327,7 +328,10 @@ class SwiftDispatcher {
   virtual void visit(const swift::CapturedValue* capture) = 0;
 
   template <typename T>
-  requires(!std::derived_from<T, swift::TypeRepr>) void visit(const T* e, swift::Type) { visit(e); }
+    requires(!std::derived_from<T, swift::TypeRepr>)
+  void visit(const T* e, swift::Type) {
+    visit(e);
+  }
 
   const swift::SourceManager& sourceManager;
   SwiftExtractorState& state;

--- a/swift/extractor/infra/SwiftDispatcher.h
+++ b/swift/extractor/infra/SwiftDispatcher.h
@@ -38,19 +38,6 @@ class SwiftDispatcher {
                               const swift::PoundAvailableInfo*,
                               const swift::AvailabilitySpec*>;
 
-  template <typename E>
-  static constexpr bool IsFetchable = std::is_constructible_v<Handle, const E&>;
-
-  template <typename E>
-  static constexpr bool IsLocatable =
-      std::is_base_of_v<LocatableTag, TrapTagOf<E>> && !std::is_base_of_v<TypeTag, TrapTagOf<E>>;
-
-  template <typename E>
-  static constexpr bool IsDeclPointer = std::is_convertible_v<E, const swift::Decl*>;
-
-  template <typename E>
-  static constexpr bool IsTypePointer = std::is_convertible_v<E, const swift::TypeBase*>;
-
  public:
   // all references and pointers passed as parameters to this constructor are supposed to outlive
   // the SwiftDispatcher
@@ -76,7 +63,7 @@ class SwiftDispatcher {
       using Label = std::remove_reference_t<decltype(label)>;
       if (!label.valid()) {
         const char* action;
-        if constexpr (std::is_base_of_v<typename Label::Tag, UnspecifiedElementTag>) {
+        if constexpr (std::derived_from<UnspecifiedElementTag, typename Label::Tag>) {
           action = "replacing with unspecified element";
           label = emitUnspecified(idOf(entry), field, index);
         } else {
@@ -132,7 +119,7 @@ class SwiftDispatcher {
 
   template <typename E>
   std::optional<TrapLabel<ElementTag>> idOf(const E& entry) {
-    if constexpr (HasId<E>::value) {
+    if constexpr (requires { entry.id; }) {
       return entry.id;
     } else {
       return std::nullopt;
@@ -142,9 +129,10 @@ class SwiftDispatcher {
   // This method gives a TRAP label for already emitted AST node.
   // If the AST node was not emitted yet, then the emission is dispatched to a corresponding
   // visitor (see `visit(T *)` methods below).
-  template <typename E, std::enable_if_t<IsFetchable<E>>* = nullptr>
-  TrapLabelOf<E> fetchLabel(const E& e, swift::Type type = {}) {
-    if constexpr (std::is_constructible_v<bool, const E&>) {
+  template <typename E>
+  requires std::constructible_from<Handle, E> TrapLabelOf<E> fetchLabel(const E& e,
+                                                                        swift::Type type = {}) {
+    if constexpr (std::constructible_from<bool, const E&>) {
       if (!e) {
         // this will be treated on emission
         return undefined_label;
@@ -174,8 +162,8 @@ class SwiftDispatcher {
     return ret;
   }
 
-  template <typename E, std::enable_if_t<IsFetchable<E*>>* = nullptr>
-  TrapLabelOf<E> fetchLabel(const E& e) {
+  template <typename E>
+  requires std::constructible_from<Handle, E*> TrapLabelOf<E> fetchLabel(const E& e) {
     return fetchLabel(&e);
   }
 
@@ -184,8 +172,9 @@ class SwiftDispatcher {
   auto createEntry(const E& e) {
     auto found = store.find(&e);
     CODEQL_ASSERT(found != store.end(), "createEntry called on non-fetched label");
-    auto label = TrapLabel<ConcreteTrapTagOf<E>>::unsafeCreateFromUntyped(found->second);
-    if constexpr (IsLocatable<E>) {
+    using Tag = ConcreteTrapTagOf<E>;
+    auto label = TrapLabel<Tag>::unsafeCreateFromUntyped(found->second);
+    if constexpr (requires { locationExtractor.attachLocation(sourceManager, e, label); }) {
       locationExtractor.attachLocation(sourceManager, e, label);
     }
     return TrapClassOf<E>{label};
@@ -195,7 +184,8 @@ class SwiftDispatcher {
   // an example is swift::Argument, that are created on the fly and thus have no stable pointer
   template <typename E>
   auto createUncachedEntry(const E& e) {
-    auto label = trap.createTypedLabel<TrapTagOf<E>>();
+    using Tag = TrapTagOf<E>;
+    auto label = trap.createTypedLabel<Tag>();
     locationExtractor.attachLocation(sourceManager, &e, label);
     return TrapClassOf<E>{label};
   }
@@ -218,7 +208,7 @@ class SwiftDispatcher {
   auto fetchRepeatedLabels(Iterable&& arg) {
     using Label = decltype(fetchLabel(*arg.begin()));
     TrapLabelVectorWrapper<typename Label::Tag> ret;
-    if constexpr (HasSize<Iterable>::value) {
+    if constexpr (std::ranges::sized_range<Iterable>) {
       ret.data.reserve(arg.size());
     }
     for (auto&& e : arg) {
@@ -251,7 +241,7 @@ class SwiftDispatcher {
  private:
   template <typename E>
   UntypedTrapLabel createLabel(const E& e, swift::Type type) {
-    if constexpr (IsDeclPointer<E> || IsTypePointer<E>) {
+    if constexpr (requires { name(e); }) {
       if (auto mangledName = name(e)) {
         if (shouldVisit(e)) {
           toBeVisited.emplace_back(e, type);
@@ -266,7 +256,7 @@ class SwiftDispatcher {
 
   template <typename E>
   bool shouldVisit(const E& e) {
-    if constexpr (IsDeclPointer<E>) {
+    if constexpr (std::convertible_to<E, const swift::Decl*>) {
       encounteredModules.insert(e->getModuleContext());
       if (bodyEmissionStrategy.shouldEmitDeclBody(*e)) {
         extractedDeclaration(e);
@@ -295,18 +285,6 @@ class SwiftDispatcher {
            module->isNonSwiftModule();
   }
 
-  template <typename T, typename = void>
-  struct HasSize : std::false_type {};
-
-  template <typename T>
-  struct HasSize<T, decltype(std::declval<T>().size(), void())> : std::true_type {};
-
-  template <typename T, typename = void>
-  struct HasId : std::false_type {};
-
-  template <typename T>
-  struct HasId<T, decltype(std::declval<T>().id, void())> : std::true_type {};
-
   template <typename Tag, typename... Ts>
   TrapLabel<Tag> fetchLabelFromUnion(const llvm::PointerUnion<Ts...> u) {
     TrapLabel<Tag> ret{};
@@ -324,7 +302,7 @@ class SwiftDispatcher {
     // on `BraceStmt`/`IfConfigDecl` elements), we cannot encounter a standalone `TypeRepr` there,
     // so we skip this case; extracting `TypeRepr`s here would be problematic as we would not be
     // able to provide the corresponding type
-    if constexpr (!std::is_same_v<T, swift::TypeRepr*>) {
+    if constexpr (!std::same_as<T, swift::TypeRepr*>) {
       if (auto e = u.template dyn_cast<T>()) {
         output = fetchLabel(e);
         return true;
@@ -348,10 +326,8 @@ class SwiftDispatcher {
   virtual void visit(const swift::TypeBase* type) = 0;
   virtual void visit(const swift::CapturedValue* capture) = 0;
 
-  template <typename T, std::enable_if<!std::is_base_of_v<swift::TypeRepr, T>>* = nullptr>
-  void visit(const T* e, swift::Type) {
-    visit(e);
-  }
+  template <typename T>
+  requires(!std::derived_from<T, swift::TypeRepr>) void visit(const T* e, swift::Type) { visit(e); }
 
   const swift::SourceManager& sourceManager;
   SwiftExtractorState& state;

--- a/swift/extractor/infra/SwiftDispatcher.h
+++ b/swift/extractor/infra/SwiftDispatcher.h
@@ -130,8 +130,8 @@ class SwiftDispatcher {
   // If the AST node was not emitted yet, then the emission is dispatched to a corresponding
   // visitor (see `visit(T *)` methods below).
   template <typename E>
-    requires std::constructible_from<Handle, E>
-  TrapLabelOf<E> fetchLabel(const E& e, swift::Type type = {}) {
+  requires std::constructible_from<Handle, E> TrapLabelOf<E> fetchLabel(const E& e,
+                                                                        swift::Type type = {}) {
     if constexpr (std::constructible_from<bool, const E&>) {
       if (!e) {
         // this will be treated on emission
@@ -163,8 +163,7 @@ class SwiftDispatcher {
   }
 
   template <typename E>
-    requires std::constructible_from<Handle, E*>
-  TrapLabelOf<E> fetchLabel(const E& e) {
+  requires std::constructible_from<Handle, E*> TrapLabelOf<E> fetchLabel(const E& e) {
     return fetchLabel(&e);
   }
 
@@ -328,10 +327,7 @@ class SwiftDispatcher {
   virtual void visit(const swift::CapturedValue* capture) = 0;
 
   template <typename T>
-    requires(!std::derived_from<T, swift::TypeRepr>)
-  void visit(const T* e, swift::Type) {
-    visit(e);
-  }
+  requires(!std::derived_from<T, swift::TypeRepr>) void visit(const T* e, swift::Type) { visit(e); }
 
   const swift::SourceManager& sourceManager;
   SwiftExtractorState& state;

--- a/swift/extractor/infra/SwiftDispatcher.h
+++ b/swift/extractor/infra/SwiftDispatcher.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <filesystem>
-#include <ranges>
 
 #include <swift/AST/SourceFile.h>
 #include <swift/Basic/SourceManager.h>
@@ -210,7 +209,7 @@ class SwiftDispatcher {
   auto fetchRepeatedLabels(Iterable&& arg) {
     using Label = decltype(fetchLabel(*arg.begin()));
     TrapLabelVectorWrapper<typename Label::Tag> ret;
-    if constexpr (std::ranges::sized_range<Iterable>) {
+    if constexpr (requires { arg.size(); }) {
       ret.data.reserve(arg.size());
     }
     for (auto&& e : arg) {

--- a/swift/extractor/infra/SwiftDispatcher.h
+++ b/swift/extractor/infra/SwiftDispatcher.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <filesystem>
+#include <ranges>
 
 #include <swift/AST/SourceFile.h>
 #include <swift/Basic/SourceManager.h>

--- a/swift/extractor/infra/SwiftDispatcher.h
+++ b/swift/extractor/infra/SwiftDispatcher.h
@@ -129,14 +129,14 @@ class SwiftDispatcher {
   // This method gives a TRAP label for already emitted AST node.
   // If the AST node was not emitted yet, then the emission is dispatched to a corresponding
   // visitor (see `visit(T *)` methods below).
+  // clang-format off
   template <typename E>
-  requires std::constructible_from<Handle, E> TrapLabelOf<E> fetchLabel(const E& e,
-                                                                        swift::Type type = {}) {
-    if constexpr (std::constructible_from<bool, const E&>) {
-      if (!e) {
-        // this will be treated on emission
-        return undefined_label;
-      }
+    requires std::constructible_from<Handle, E*>
+  TrapLabelOf<E> fetchLabel(const E* e, swift::Type type = {}) {
+    // clang-format on
+    if (!e) {
+      // this will be treated on emission
+      return undefined_label;
     }
     auto& stored = store[e];
     if (!stored.valid()) {
@@ -162,8 +162,11 @@ class SwiftDispatcher {
     return ret;
   }
 
+  // clang-format off
   template <typename E>
-  requires std::constructible_from<Handle, E*> TrapLabelOf<E> fetchLabel(const E& e) {
+    requires std::constructible_from<Handle, E*>
+  TrapLabelOf<E> fetchLabel(const E& e) {
+    // clang-format on
     return fetchLabel(&e);
   }
 

--- a/swift/extractor/infra/SwiftDispatcher.h
+++ b/swift/extractor/infra/SwiftDispatcher.h
@@ -175,7 +175,7 @@ class SwiftDispatcher {
     CODEQL_ASSERT(found != store.end(), "createEntry called on non-fetched label");
     using Tag = ConcreteTrapTagOf<E>;
     auto label = TrapLabel<Tag>::unsafeCreateFromUntyped(found->second);
-    if constexpr (requires { locationExtractor.attachLocation(sourceManager, e, label); }) {
+    if constexpr (IsLocatable<E>) {
       locationExtractor.attachLocation(sourceManager, e, label);
     }
     return TrapClassOf<E>{label};

--- a/swift/extractor/infra/SwiftLocationExtractor.cpp
+++ b/swift/extractor/infra/SwiftLocationExtractor.cpp
@@ -12,19 +12,24 @@
 
 using namespace codeql;
 
+swift::SourceRange detail::getSourceRange(const swift::Token& token) {
+  const auto charRange = token.getRange();
+  return {charRange.getStart(), charRange.getEnd()};
+}
+
 void SwiftLocationExtractor::attachLocationImpl(const swift::SourceManager& sourceManager,
-                                                swift::SourceLoc start,
-                                                swift::SourceLoc end,
+                                                const swift::SourceRange& range,
                                                 TrapLabel<LocatableTag> locatableLabel) {
-  if (!start.isValid() || !end.isValid()) {
+  if (!range) {
     // invalid locations seem to come from entities synthesized by the compiler
     return;
   }
-  auto file = resolvePath(sourceManager.getDisplayNameForLoc(start));
+  auto file = resolvePath(sourceManager.getDisplayNameForLoc(range.Start));
   DbLocation entry{{}};
   entry.file = fetchFileLabel(file);
-  std::tie(entry.start_line, entry.start_column) = sourceManager.getLineAndColumnInBuffer(start);
-  std::tie(entry.end_line, entry.end_column) = sourceManager.getLineAndColumnInBuffer(end);
+  std::tie(entry.start_line, entry.start_column) =
+      sourceManager.getLineAndColumnInBuffer(range.Start);
+  std::tie(entry.end_line, entry.end_column) = sourceManager.getLineAndColumnInBuffer(range.End);
   SwiftMangledName locName{"loc", entry.file,     ':', entry.start_line, ':', entry.start_column,
                            ':',   entry.end_line, ':', entry.end_column};
   entry.id = trap.createTypedLabel<DbLocationTag>(locName);
@@ -41,56 +46,6 @@ TrapLabel<FileTag> SwiftLocationExtractor::emitFile(swift::SourceFile* file) {
 
 TrapLabel<FileTag> SwiftLocationExtractor::emitFile(const std::filesystem::path& file) {
   return fetchFileLabel(resolvePath(file));
-}
-
-void SwiftLocationExtractor::attachLocationImpl(const swift::SourceManager& sourceManager,
-                                                const swift::SourceRange& range,
-                                                TrapLabel<LocatableTag> locatableLabel) {
-  attachLocationImpl(sourceManager, range.Start, range.End, locatableLabel);
-}
-
-void SwiftLocationExtractor::attachLocationImpl(const swift::SourceManager& sourceManager,
-                                                const swift::CapturedValue* capture,
-                                                TrapLabel<LocatableTag> locatableLabel) {
-  attachLocationImpl(sourceManager, capture->getLoc(), locatableLabel);
-}
-
-void SwiftLocationExtractor::attachLocationImpl(const swift::SourceManager& sourceManager,
-                                                const swift::IfConfigClause* clause,
-                                                TrapLabel<LocatableTag> locatableLabel) {
-  attachLocationImpl(sourceManager, clause->Loc, locatableLabel);
-}
-
-void SwiftLocationExtractor::attachLocationImpl(const swift::SourceManager& sourceManager,
-                                                const swift::AvailabilitySpec* spec,
-                                                TrapLabel<LocatableTag> locatableLabel) {
-  attachLocationImpl(sourceManager, spec->getSourceRange(), locatableLabel);
-}
-
-void SwiftLocationExtractor::attachLocationImpl(const swift::SourceManager& sourceManager,
-                                                const swift::KeyPathExpr::Component* component,
-                                                TrapLabel<LocatableTag> locatableLabel) {
-  attachLocationImpl(sourceManager, component->getSourceRange().Start,
-                     component->getSourceRange().End, locatableLabel);
-}
-
-void SwiftLocationExtractor::attachLocationImpl(const swift::SourceManager& sourceManager,
-                                                const swift::Token* token,
-                                                TrapLabel<LocatableTag> locatableLabel) {
-  attachLocationImpl(sourceManager, token->getRange().getStart(), token->getRange().getEnd(),
-                     locatableLabel);
-}
-
-void SwiftLocationExtractor::attachLocationImpl(const swift::SourceManager& sourceManager,
-                                                swift::SourceLoc loc,
-                                                TrapLabel<LocatableTag> locatableLabel) {
-  attachLocationImpl(sourceManager, loc, loc, locatableLabel);
-}
-
-void SwiftLocationExtractor::attachLocationImpl(const swift::SourceManager& sourceManager,
-                                                const swift::DiagnosticInfo* diagInfo,
-                                                TrapLabel<LocatableTag> locatableLabel) {
-  attachLocationImpl(sourceManager, diagInfo->Loc, locatableLabel);
 }
 
 TrapLabel<FileTag> SwiftLocationExtractor::fetchFileLabel(const std::filesystem::path& file) {

--- a/swift/extractor/infra/SwiftLocationExtractor.h
+++ b/swift/extractor/infra/SwiftLocationExtractor.h
@@ -18,19 +18,26 @@ class TrapDomain;
 namespace detail {
 template <typename T>
 concept HasStartAndEndLoc = requires(T e) {
-                              e.getStartLoc();
-                              e.getEndLoc();
-                            };
+  e.getStartLoc();
+  e.getEndLoc();
+};
 
 template <typename T>
-concept HasOneLoc = requires(T e) { e.getLoc(); } && (!HasStartAndEndLoc<T>);
+concept HasOneLoc = requires(T e) {
+  e.getLoc();
+}
+&&(!HasStartAndEndLoc<T>);
 
 template <typename T>
-concept HasOneLocField = requires(T e) { e.Loc; };
+concept HasOneLocField = requires(T e) {
+  e.Loc;
+};
 
 template <typename T>
-concept HasSourceRangeOnly = requires(T e) { e.getSourceRange(); } && (!HasStartAndEndLoc<T>) &&
-                             (!HasOneLoc<T>);
+concept HasSourceRangeOnly = requires(T e) {
+  e.getSourceRange();
+}
+&&(!HasStartAndEndLoc<T>)&&(!HasOneLoc<T>);
 
 swift::SourceRange getSourceRange(const HasStartAndEndLoc auto& locatable) {
   return {locatable.getStartLoc(), locatable.getEndLoc()};
@@ -62,7 +69,9 @@ swift::SourceRange getSourceRange(const llvm::MutableArrayRef<Locatable>& locata
 }  // namespace detail
 
 template <typename E>
-concept IsLocatable = requires(E e) { detail::getSourceRange(e); };
+concept IsLocatable = requires(E e) {
+  detail::getSourceRange(e);
+};
 
 class SwiftLocationExtractor {
  public:

--- a/swift/extractor/infra/SwiftLocationExtractor.h
+++ b/swift/extractor/infra/SwiftLocationExtractor.h
@@ -18,26 +18,19 @@ class TrapDomain;
 namespace detail {
 template <typename T>
 concept HasStartAndEndLoc = requires(T e) {
-  e.getStartLoc();
-  e.getEndLoc();
-};
+                              e.getStartLoc();
+                              e.getEndLoc();
+                            };
 
 template <typename T>
-concept HasOneLoc = requires(T e) {
-  e.getLoc();
-}
-&&(!HasStartAndEndLoc<T>);
+concept HasOneLoc = requires(T e) { e.getLoc(); } && (!HasStartAndEndLoc<T>);
 
 template <typename T>
-concept HasOneLocField = requires(T e) {
-  e.Loc;
-};
+concept HasOneLocField = requires(T e) { e.Loc; };
 
 template <typename T>
-concept HasSourceRangeOnly = requires(T e) {
-  e.getSourceRange();
-}
-&&(!HasStartAndEndLoc<T>)&&(!HasOneLoc<T>);
+concept HasSourceRangeOnly = requires(T e) { e.getSourceRange(); } && (!HasStartAndEndLoc<T>) &&
+                             (!HasOneLoc<T>);
 
 swift::SourceRange getSourceRange(const HasStartAndEndLoc auto& locatable) {
   return {locatable.getStartLoc(), locatable.getEndLoc()};

--- a/swift/extractor/infra/SwiftLocationExtractor.h
+++ b/swift/extractor/infra/SwiftLocationExtractor.h
@@ -15,90 +15,87 @@ namespace codeql {
 
 class TrapDomain;
 
-class SwiftLocationExtractor {
-  template <typename Locatable, typename = void>
-  struct HasSpecializedImplementation : std::false_type {};
+namespace detail {
+template <typename T>
+concept HasStartAndEndLoc = requires(T e) {
+  e.getStartLoc();
+  e.getEndLoc();
+};
 
+template <typename T>
+concept HasOneLoc = requires(T e) {
+  e.getLoc();
+}
+&&(!HasStartAndEndLoc<T>);
+
+template <typename T>
+concept HasOneLocField = requires(T e) {
+  e.Loc;
+};
+
+template <typename T>
+concept HasSourceRangeOnly = requires(T e) {
+  e.getSourceRange();
+}
+&&(!HasStartAndEndLoc<T>)&&(!HasOneLoc<T>);
+
+swift::SourceRange getSourceRange(const HasStartAndEndLoc auto& locatable) {
+  return {locatable.getStartLoc(), locatable.getEndLoc()};
+}
+
+swift::SourceRange getSourceRange(const HasOneLoc auto& locatable) {
+  return {locatable.getLoc()};
+}
+
+swift::SourceRange getSourceRange(const HasOneLocField auto& locatable) {
+  return {locatable.Loc};
+}
+
+swift::SourceRange getSourceRange(const HasSourceRangeOnly auto& locatable) {
+  return locatable.getSourceRange();
+}
+
+swift::SourceRange getSourceRange(const swift::Token& token);
+
+template <typename Locatable>
+swift::SourceRange getSourceRange(const llvm::MutableArrayRef<Locatable>& locatables) {
+  if (locatables.empty()) {
+    return {};
+  }
+  auto startRange = getSourceRange(locatables.front());
+  auto endRange = getSourceRange(locatables.back());
+  return {startRange.Start, endRange.End};
+}
+
+// default case, no location
+swift::SourceRange getSourceRange(const auto&) {
+  return {};
+}
+}  // namespace detail
+
+class SwiftLocationExtractor {
  public:
   explicit SwiftLocationExtractor(TrapDomain& trap) : trap(trap) {}
 
   TrapLabel<FileTag> emitFile(swift::SourceFile* file);
   TrapLabel<FileTag> emitFile(const std::filesystem::path& file);
 
-  template <typename Locatable>
-  void attachLocation(const swift::SourceManager& sourceManager,
-                      const Locatable& locatable,
-                      TrapLabel<LocatableTag> locatableLabel) {
-    attachLocation(sourceManager, &locatable, locatableLabel);
-  }
-
   // Emits a Location TRAP entry and attaches it to a `Locatable` trap label
-  template <typename Locatable,
-            std::enable_if_t<!HasSpecializedImplementation<Locatable>::value>* = nullptr>
   void attachLocation(const swift::SourceManager& sourceManager,
-                      const Locatable* locatable,
+                      const auto& locatable,
                       TrapLabel<LocatableTag> locatableLabel) {
-    attachLocationImpl(sourceManager, locatable->getStartLoc(), locatable->getEndLoc(),
-                       locatableLabel);
+    attachLocationImpl(sourceManager, detail::getSourceRange(locatable), locatableLabel);
   }
 
-  template <typename Locatable,
-            std::enable_if_t<HasSpecializedImplementation<Locatable>::value>* = nullptr>
   void attachLocation(const swift::SourceManager& sourceManager,
-                      const Locatable* locatable,
+                      const auto* locatable,
                       TrapLabel<LocatableTag> locatableLabel) {
-    attachLocationImpl(sourceManager, locatable, locatableLabel);
+    attachLocation(sourceManager, *locatable, locatableLabel);
   }
 
  private:
-  // Emits a Location TRAP entry for a list of swift entities and attaches it to a `Locatable` trap
-  // label
-  template <typename Locatable>
-  void attachLocationImpl(const swift::SourceManager& sourceManager,
-                          const llvm::MutableArrayRef<Locatable>* locatables,
-                          TrapLabel<LocatableTag> locatableLabel) {
-    if (locatables->empty()) {
-      return;
-    }
-    attachLocationImpl(sourceManager, locatables->front().getStartLoc(),
-                       locatables->back().getEndLoc(), locatableLabel);
-  }
-
-  void attachLocationImpl(const swift::SourceManager& sourceManager,
-                          swift::SourceLoc start,
-                          swift::SourceLoc end,
-                          TrapLabel<LocatableTag> locatableLabel);
-
-  void attachLocationImpl(const swift::SourceManager& sourceManager,
-                          swift::SourceLoc loc,
-                          TrapLabel<LocatableTag> locatableLabel);
-
   void attachLocationImpl(const swift::SourceManager& sourceManager,
                           const swift::SourceRange& range,
-                          TrapLabel<LocatableTag> locatableLabel);
-
-  void attachLocationImpl(const swift::SourceManager& sourceManager,
-                          const swift::CapturedValue* capture,
-                          TrapLabel<LocatableTag> locatableLabel);
-
-  void attachLocationImpl(const swift::SourceManager& sourceManager,
-                          const swift::IfConfigClause* clause,
-                          TrapLabel<LocatableTag> locatableLabel);
-
-  void attachLocationImpl(const swift::SourceManager& sourceManager,
-                          const swift::AvailabilitySpec* spec,
-                          TrapLabel<LocatableTag> locatableLabel);
-
-  void attachLocationImpl(const swift::SourceManager& sourceManager,
-                          const swift::Token* token,
-                          TrapLabel<LocatableTag> locatableLabel);
-
-  void attachLocationImpl(const swift::SourceManager& sourceManager,
-                          const swift::DiagnosticInfo* token,
-                          TrapLabel<LocatableTag> locatableLabel);
-
-  void attachLocationImpl(const swift::SourceManager& sourceManager,
-                          const swift::KeyPathExpr::Component* component,
                           TrapLabel<LocatableTag> locatableLabel);
 
  private:
@@ -106,13 +103,5 @@ class SwiftLocationExtractor {
   TrapDomain& trap;
   std::unordered_map<std::filesystem::path, TrapLabel<FileTag>, codeql::PathHash> store;
 };
-
-template <typename Locatable>
-struct SwiftLocationExtractor::HasSpecializedImplementation<
-    Locatable,
-    decltype(std::declval<SwiftLocationExtractor>().attachLocationImpl(
-        std::declval<const swift::SourceManager&>(),
-        std::declval<const Locatable*>(),
-        std::declval<TrapLabel<LocatableTag>>()))> : std::true_type {};
 
 }  // namespace codeql

--- a/swift/extractor/infra/SwiftLocationExtractor.h
+++ b/swift/extractor/infra/SwiftLocationExtractor.h
@@ -59,12 +59,10 @@ swift::SourceRange getSourceRange(const llvm::MutableArrayRef<Locatable>& locata
   auto endRange = getSourceRange(locatables.back());
   return {startRange.Start, endRange.End};
 }
-
-// default case, no location
-swift::SourceRange getSourceRange(const auto&) {
-  return {};
-}
 }  // namespace detail
+
+template <typename E>
+concept IsLocatable = requires(E e) { detail::getSourceRange(e); };
 
 class SwiftLocationExtractor {
  public:
@@ -75,13 +73,13 @@ class SwiftLocationExtractor {
 
   // Emits a Location TRAP entry and attaches it to a `Locatable` trap label
   void attachLocation(const swift::SourceManager& sourceManager,
-                      const auto& locatable,
+                      const IsLocatable auto& locatable,
                       TrapLabel<LocatableTag> locatableLabel) {
     attachLocationImpl(sourceManager, detail::getSourceRange(locatable), locatableLabel);
   }
 
   void attachLocation(const swift::SourceManager& sourceManager,
-                      const auto* locatable,
+                      const IsLocatable auto* locatable,
                       TrapLabel<LocatableTag> locatableLabel) {
     attachLocation(sourceManager, *locatable, locatableLabel);
   }

--- a/swift/extractor/infra/SwiftLocationExtractor.h
+++ b/swift/extractor/infra/SwiftLocationExtractor.h
@@ -40,7 +40,10 @@ concept HasSourceRangeOnly = requires(T e) {
 &&(!HasStartAndEndLoc<T>)&&(!HasOneLoc<T>);
 
 swift::SourceRange getSourceRange(const HasStartAndEndLoc auto& locatable) {
-  return {locatable.getStartLoc(), locatable.getEndLoc()};
+  if (locatable.getStartLoc() && locatable.getEndLoc()) {
+    return {locatable.getStartLoc(), locatable.getEndLoc()};
+  }
+  return {};
 }
 
 swift::SourceRange getSourceRange(const HasOneLoc auto& locatable) {
@@ -64,7 +67,10 @@ swift::SourceRange getSourceRange(const llvm::MutableArrayRef<Locatable>& locata
   }
   auto startRange = getSourceRange(locatables.front());
   auto endRange = getSourceRange(locatables.back());
-  return {startRange.Start, endRange.End};
+  if (startRange.Start && endRange.End) {
+    return {startRange.Start, endRange.End};
+  }
+  return {};
 }
 }  // namespace detail
 

--- a/swift/extractor/print_unextracted/main.cpp
+++ b/swift/extractor/print_unextracted/main.cpp
@@ -13,9 +13,9 @@ using namespace codeql;
 int main() {
   std::map<const char*, std::vector<const char*>> unextracted;
 
-#define CHECK_CLASS(KIND, CLASS, PARENT)                                                \
-  if (KIND##Translator::getPolicyFor##CLASS##KIND() == TranslatorPolicy::emitUnknown) { \
-    unextracted[#KIND].push_back(#CLASS #KIND);                                         \
+#define CHECK_CLASS(KIND, CLASS, PARENT)                                                          \
+  if constexpr (KIND##Translator::getPolicyFor##CLASS##KIND() == TranslatorPolicy::emitUnknown) { \
+    unextracted[#KIND].push_back(#CLASS #KIND);                                                   \
   }
 
 #define DECL(CLASS, PARENT) CHECK_CLASS(Decl, CLASS, PARENT)

--- a/swift/extractor/trap/TrapLabel.h
+++ b/swift/extractor/trap/TrapLabel.h
@@ -9,6 +9,8 @@
 #include <binlog/binlog.hpp>
 #include <cmath>
 #include <charconv>
+#include <concepts>
+#include <optional>
 
 namespace codeql {
 
@@ -82,9 +84,8 @@ class TrapLabel : public UntypedTrapLabel {
   static TrapLabel unsafeCreateFromUntyped(UntypedTrapLabel label) { return TrapLabel{label.id_}; }
 
   template <typename SourceTag>
-  TrapLabel(const TrapLabel<SourceTag>& other) : UntypedTrapLabel(other) {
-    static_assert(std::is_base_of_v<Tag, SourceTag>, "wrong label assignment!");
-  }
+  requires std::derived_from<SourceTag, Tag> TrapLabel(const TrapLabel<SourceTag>& other)
+      : UntypedTrapLabel(other) {}
 };
 
 // wrapper class to allow directly assigning a vector of TrapLabel<A> to a vector of
@@ -96,8 +97,8 @@ struct TrapLabelVectorWrapper {
   std::vector<TrapLabel<TagParam>> data;
 
   template <typename DestinationTag>
+  requires std::derived_from<Tag, DestinationTag>
   operator std::vector<TrapLabel<DestinationTag>>() && {
-    static_assert(std::is_base_of_v<DestinationTag, Tag>, "wrong label assignment!");
     // reinterpret_cast is safe because TrapLabel instances differ only on the type, not the
     // underlying data
     return std::move(reinterpret_cast<std::vector<TrapLabel<DestinationTag>>&>(data));

--- a/swift/extractor/trap/TrapLabel.h
+++ b/swift/extractor/trap/TrapLabel.h
@@ -84,8 +84,8 @@ class TrapLabel : public UntypedTrapLabel {
   static TrapLabel unsafeCreateFromUntyped(UntypedTrapLabel label) { return TrapLabel{label.id_}; }
 
   template <typename SourceTag>
-  requires std::derived_from<SourceTag, Tag> TrapLabel(const TrapLabel<SourceTag>& other)
-      : UntypedTrapLabel(other) {}
+    requires std::derived_from<SourceTag, Tag>
+  TrapLabel(const TrapLabel<SourceTag>& other) : UntypedTrapLabel(other) {}
 };
 
 // wrapper class to allow directly assigning a vector of TrapLabel<A> to a vector of
@@ -97,7 +97,7 @@ struct TrapLabelVectorWrapper {
   std::vector<TrapLabel<TagParam>> data;
 
   template <typename DestinationTag>
-  requires std::derived_from<Tag, DestinationTag>
+    requires std::derived_from<Tag, DestinationTag>
   operator std::vector<TrapLabel<DestinationTag>>() && {
     // reinterpret_cast is safe because TrapLabel instances differ only on the type, not the
     // underlying data

--- a/swift/extractor/trap/TrapLabel.h
+++ b/swift/extractor/trap/TrapLabel.h
@@ -83,8 +83,8 @@ class TrapLabel : public UntypedTrapLabel {
   static TrapLabel unsafeCreateFromUntyped(UntypedTrapLabel label) { return TrapLabel{label.id_}; }
 
   template <typename SourceTag>
-    requires std::derived_from<SourceTag, Tag>
-  TrapLabel(const TrapLabel<SourceTag>& other) : UntypedTrapLabel(other) {}
+  requires std::derived_from<SourceTag, Tag> TrapLabel(const TrapLabel<SourceTag>& other)
+      : UntypedTrapLabel(other) {}
 };
 
 // wrapper class to allow directly assigning a vector of TrapLabel<A> to a vector of
@@ -96,7 +96,7 @@ struct TrapLabelVectorWrapper {
   std::vector<TrapLabel<TagParam>> data;
 
   template <typename DestinationTag>
-    requires std::derived_from<Tag, DestinationTag>
+  requires std::derived_from<Tag, DestinationTag>
   operator std::vector<TrapLabel<DestinationTag>>() && {
     // reinterpret_cast is safe because TrapLabel instances differ only on the type, not the
     // underlying data

--- a/swift/extractor/trap/TrapLabel.h
+++ b/swift/extractor/trap/TrapLabel.h
@@ -10,7 +10,6 @@
 #include <cmath>
 #include <charconv>
 #include <concepts>
-#include <optional>
 
 namespace codeql {
 


### PR DESCRIPTION
This simplifies several instances of metaprogramming by leveraging [constraints and concepts from C++20][1]. This:
* gets rid of `std::enable_if` by usage of `requires`, making it more readable and yield better compiler messages.
* uses `requires` instead of `static_assert` to enforce `TrapLabel` typing
* _greatly_ simplifies all compile-time tests for validity of a given expression, by use of simple `requires` constraints
* uses some standard library concepts where possible
* generalizes and simplifies `SwiftLocationExtractor`

Notice that in order to use the `std::derived_from` concept, `virtual` inheritance had to be added to the label tags, because diamond inheritance is a problem otherwise. That's because `std::derived_from<T, U>` requires that `T*` be convertible to `U*`, which is false if there are multiple non-virtual inheritance paths from `U` to `T`. As tags never get actually instantiated, there is no runtime performance penalty in using `virtual` inheritance.

Notice that concept and constraint formatting is quite off in `clang-format` up to and including version 14. Bumping that up is left for future work.

[1]: https://en.cppreference.com/w/cpp/language/constraints