### PR TITLE
C#: Re-factor order of usings.

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CIL.Driver/ExtractorOptions.cs
+++ b/csharp/extractor/Semmle.Extraction.CIL.Driver/ExtractorOptions.cs
@@ -1,13 +1,12 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
-using System.IO;
-using System.Reflection.PortableExecutable;
-using System.Reflection.Metadata;
-using System.Reflection;
-using System.Runtime.InteropServices;
 using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using System.Runtime.InteropServices;
 using Semmle.Util;
-using Semmle.Util.Logging;
 
 namespace Semmle.Extraction.CIL.Driver
 {

--- a/csharp/extractor/Semmle.Extraction.CIL.Driver/Program.cs
+++ b/csharp/extractor/Semmle.Extraction.CIL.Driver/Program.cs
@@ -1,8 +1,8 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Semmle.Util.Logging;
-using System.Diagnostics;
 
 namespace Semmle.Extraction.CIL.Driver
 {

--- a/csharp/extractor/Semmle.Extraction.CIL/Analyser.cs
+++ b/csharp/extractor/Semmle.Extraction.CIL/Analyser.cs
@@ -1,6 +1,6 @@
-using Semmle.Util.Logging;
 using System;
 using Semmle.Util;
+using Semmle.Util.Logging;
 using Semmle.Extraction.CIL.Entities;
 
 namespace Semmle.Extraction.CIL

--- a/csharp/extractor/Semmle.Extraction.CIL/Context.Factories.cs
+++ b/csharp/extractor/Semmle.Extraction.CIL/Context.Factories.cs
@@ -1,8 +1,7 @@
-﻿using Semmle.Extraction.CIL.Entities;
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Reflection.Metadata;
+using Semmle.Extraction.CIL.Entities;
 
 namespace Semmle.Extraction.CIL
 {

--- a/csharp/extractor/Semmle.Extraction.CIL/Entities/Assembly.cs
+++ b/csharp/extractor/Semmle.Extraction.CIL/Entities/Assembly.cs
@@ -1,8 +1,7 @@
-﻿using System.Reflection;
+﻿using System.Collections.Generic;
 using System.Globalization;
-using System.Collections.Generic;
+using System.Reflection;
 using Semmle.Extraction.Entities;
-using System.IO;
 
 namespace Semmle.Extraction.CIL.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CIL/Entities/Attribute.cs
+++ b/csharp/extractor/Semmle.Extraction.CIL/Entities/Attribute.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection.Metadata;
 

--- a/csharp/extractor/Semmle.Extraction.CIL/Entities/Base/LabelledEntity.cs
+++ b/csharp/extractor/Semmle.Extraction.CIL/Entities/Base/LabelledEntity.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 
 namespace Semmle.Extraction.CIL
 {

--- a/csharp/extractor/Semmle.Extraction.CIL/Entities/ConstructedType.cs
+++ b/csharp/extractor/Semmle.Extraction.CIL/Entities/ConstructedType.cs
@@ -1,7 +1,7 @@
 using System;
-using System.Linq;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Semmle.Util;
 
 namespace Semmle.Extraction.CIL.Entities

--- a/csharp/extractor/Semmle.Extraction.CIL/Entities/DefinitionField.cs
+++ b/csharp/extractor/Semmle.Extraction.CIL/Entities/DefinitionField.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
-using System.Reflection.Metadata;
 using System.Reflection;
+using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 
 namespace Semmle.Extraction.CIL.Entities

--- a/csharp/extractor/Semmle.Extraction.CIL/Entities/DefinitionMethod.cs
+++ b/csharp/extractor/Semmle.Extraction.CIL/Entities/DefinitionMethod.cs
@@ -1,7 +1,7 @@
-using System.Reflection.Metadata;
 using System.Collections.Generic;
-using System.Reflection;
 using System.Linq;
+using System.Reflection;
+using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 
 namespace Semmle.Extraction.CIL.Entities

--- a/csharp/extractor/Semmle.Extraction.CIL/Entities/Event.cs
+++ b/csharp/extractor/Semmle.Extraction.CIL/Entities/Event.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.IO;
 using System.Reflection.Metadata;
 
 namespace Semmle.Extraction.CIL.Entities

--- a/csharp/extractor/Semmle.Extraction.CIL/Entities/File.cs
+++ b/csharp/extractor/Semmle.Extraction.CIL/Entities/File.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.IO;
 
 namespace Semmle.Extraction.CIL.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CIL/Entities/Folder.cs
+++ b/csharp/extractor/Semmle.Extraction.CIL/Entities/Folder.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.IO;
 
 namespace Semmle.Extraction.CIL.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CIL/Entities/ITypeSignature.cs
+++ b/csharp/extractor/Semmle.Extraction.CIL/Entities/ITypeSignature.cs
@@ -1,5 +1,3 @@
-using System.IO;
-
 namespace Semmle.Extraction.CIL.Entities
 {
     internal interface ITypeSignature

--- a/csharp/extractor/Semmle.Extraction.CIL/Entities/LocalVariable.cs
+++ b/csharp/extractor/Semmle.Extraction.CIL/Entities/LocalVariable.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.IO;
 
 namespace Semmle.Extraction.CIL.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CIL/Entities/MemberReferenceMethod.cs
+++ b/csharp/extractor/Semmle.Extraction.CIL/Entities/MemberReferenceMethod.cs
@@ -1,6 +1,6 @@
-using System.Reflection.Metadata;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection.Metadata;
 
 namespace Semmle.Extraction.CIL.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CIL/Entities/Method.cs
+++ b/csharp/extractor/Semmle.Extraction.CIL/Entities/Method.cs
@@ -1,8 +1,7 @@
 ﻿using System;
-using System.Reflection.Metadata;
 using System.Collections.Generic;
 using System.Linq;
-using System.IO;
+using System.Reflection.Metadata;
 
 namespace Semmle.Extraction.CIL.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CIL/Entities/MethodSpecificationMethod.cs
+++ b/csharp/extractor/Semmle.Extraction.CIL/Entities/MethodSpecificationMethod.cs
@@ -1,9 +1,8 @@
 using System;
-using System.Collections.Immutable;
-using System.Reflection.Metadata;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
-using System.IO;
+using System.Reflection.Metadata;
 using Semmle.Util;
 
 namespace Semmle.Extraction.CIL.Entities

--- a/csharp/extractor/Semmle.Extraction.CIL/Entities/MethodTypeParameter.cs
+++ b/csharp/extractor/Semmle.Extraction.CIL/Entities/MethodTypeParameter.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 
 namespace Semmle.Extraction.CIL.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CIL/Entities/NamedTypeIdWriter.cs
+++ b/csharp/extractor/Semmle.Extraction.CIL/Entities/NamedTypeIdWriter.cs
@@ -1,5 +1,4 @@
 using System.Linq;
-using System.IO;
 
 namespace Semmle.Extraction.CIL.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CIL/Entities/Namespace.cs
+++ b/csharp/extractor/Semmle.Extraction.CIL/Entities/Namespace.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 
 namespace Semmle.Extraction.CIL.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CIL/Entities/NoMetadataHandleType.FullyQualifiedNameParser.cs
+++ b/csharp/extractor/Semmle.Extraction.CIL/Entities/NoMetadataHandleType.FullyQualifiedNameParser.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using Semmle.Util;

--- a/csharp/extractor/Semmle.Extraction.CIL/Entities/Parameter.cs
+++ b/csharp/extractor/Semmle.Extraction.CIL/Entities/Parameter.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.IO;
 
 namespace Semmle.Extraction.CIL.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CIL/Entities/PrimitiveType.cs
+++ b/csharp/extractor/Semmle.Extraction.CIL/Entities/PrimitiveType.cs
@@ -1,7 +1,7 @@
 using System;
-using System.Reflection.Metadata;
 using System.Collections.Generic;
 using System.IO;
+using System.Reflection.Metadata;
 
 namespace Semmle.Extraction.CIL.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CIL/Entities/Property.cs
+++ b/csharp/extractor/Semmle.Extraction.CIL/Entities/Property.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
-using System.IO;
 
 namespace Semmle.Extraction.CIL.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CIL/Entities/SignatureDecoder.cs
+++ b/csharp/extractor/Semmle.Extraction.CIL/Entities/SignatureDecoder.cs
@@ -1,6 +1,5 @@
-using System.Reflection.Metadata;
 using System.Collections.Immutable;
-using System.IO;
+using System.Reflection.Metadata;
 
 namespace Semmle.Extraction.CIL.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CIL/Entities/SourceLocation.cs
+++ b/csharp/extractor/Semmle.Extraction.CIL/Entities/SourceLocation.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.IO;
 using Semmle.Extraction.PDB;
 
 namespace Semmle.Extraction.CIL.Entities

--- a/csharp/extractor/Semmle.Extraction.CIL/Entities/Type.cs
+++ b/csharp/extractor/Semmle.Extraction.CIL/Entities/Type.cs
@@ -1,8 +1,8 @@
-﻿using System.Reflection.Metadata;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Linq;
+using System.Reflection.Metadata;
 
 namespace Semmle.Extraction.CIL.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CIL/Entities/TypeContainer.cs
+++ b/csharp/extractor/Semmle.Extraction.CIL/Entities/TypeContainer.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.IO;
 
 namespace Semmle.Extraction.CIL.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CIL/Entities/TypeDefinitionType.cs
+++ b/csharp/extractor/Semmle.Extraction.CIL/Entities/TypeDefinitionType.cs
@@ -1,10 +1,10 @@
 using System;
-using System.Linq;
 using System.Collections.Generic;
-using System.Reflection;
 using System.IO;
-using System.Reflection.Metadata.Ecma335;
+using System.Linq;
+using System.Reflection;
 using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
 
 namespace Semmle.Extraction.CIL.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CIL/Entities/TypeParameter.cs
+++ b/csharp/extractor/Semmle.Extraction.CIL/Entities/TypeParameter.cs
@@ -1,9 +1,9 @@
 using System;
-using System.Reflection.Metadata;
-using System.Linq;
 using System.Collections.Generic;
-using System.Reflection;
 using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Metadata;
 
 namespace Semmle.Extraction.CIL.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CIL/Entities/TypeReferenceType.cs
+++ b/csharp/extractor/Semmle.Extraction.CIL/Entities/TypeReferenceType.cs
@@ -1,8 +1,8 @@
 using System;
-using System.Reflection.Metadata;
-using System.Linq;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Reflection.Metadata;
 
 namespace Semmle.Extraction.CIL.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CIL/Entities/TypeSignatureDecoder.cs
+++ b/csharp/extractor/Semmle.Extraction.CIL/Entities/TypeSignatureDecoder.cs
@@ -1,7 +1,7 @@
 using System;
-using System.Reflection.Metadata;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Reflection.Metadata;
 
 namespace Semmle.Extraction.CIL.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CIL/Entities/TypeTypeParameter.cs
+++ b/csharp/extractor/Semmle.Extraction.CIL/Entities/TypeTypeParameter.cs
@@ -1,6 +1,5 @@
-using System.Linq;
 using System.Collections.Generic;
-using System.IO;
+using System.Linq;
 
 namespace Semmle.Extraction.CIL.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CIL/PDB/MdProvider.cs
+++ b/csharp/extractor/Semmle.Extraction.CIL/PDB/MdProvider.cs
@@ -1,6 +1,6 @@
 using System;
-using Microsoft.DiaSymReader;
 using System.Reflection;
+using Microsoft.DiaSymReader;
 
 #pragma warning disable IDE0060, CA1822
 

--- a/csharp/extractor/Semmle.Extraction.CIL/PDB/NativePdbReader.cs
+++ b/csharp/extractor/Semmle.Extraction.CIL/PDB/NativePdbReader.cs
@@ -1,11 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 using Microsoft.DiaSymReader;
-using System.Reflection.Metadata.Ecma335;
-using System.Reflection.Metadata;
-using System.IO;
 
 namespace Semmle.Extraction.PDB
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp.Driver/Driver.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.Driver/Driver.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Text.RegularExpressions;
-using System.Collections.Generic;
-
 namespace Semmle.Extraction.CSharp
 {
     /// <summary>

--- a/csharp/extractor/Semmle.Extraction.CSharp.Standalone/StandaloneAnalyser.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.Standalone/StandaloneAnalyser.cs
@@ -1,5 +1,5 @@
-using Microsoft.CodeAnalysis.CSharp;
 using System.Collections.Generic;
+using Microsoft.CodeAnalysis.CSharp;
 using Semmle.Util.Logging;
 
 namespace Semmle.Extraction.CSharp

--- a/csharp/extractor/Semmle.Extraction.CSharp/Comments/CommentBlock.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Comments/CommentBlock.cs
@@ -1,8 +1,8 @@
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
 using Semmle.Extraction.CSharp.Entities;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace Semmle.Extraction.CSharp.Comments
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Comments/CommentProcessor.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Comments/CommentProcessor.cs
@@ -1,8 +1,8 @@
-using Microsoft.CodeAnalysis;
-using Semmle.Extraction.CSharp.Entities;
-using Semmle.Util;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.CodeAnalysis;
+using Semmle.Util;
+using Semmle.Extraction.CSharp.Entities;
 
 namespace Semmle.Extraction.CSharp
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Accessor.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Accessor.cs
@@ -1,6 +1,6 @@
-using Microsoft.CodeAnalysis;
 using System.IO;
 using System.Linq;
+using Microsoft.CodeAnalysis;
 
 namespace Semmle.Extraction.CSharp.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Assembly.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Assembly.cs
@@ -1,6 +1,5 @@
-using Microsoft.CodeAnalysis;
-using Semmle.Extraction.CSharp;
 using System.IO;
+using Microsoft.CodeAnalysis;
 
 namespace Semmle.Extraction.CSharp.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Attribute.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Attribute.cs
@@ -1,10 +1,8 @@
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Semmle.Extraction.Entities;
 
 namespace Semmle.Extraction.CSharp.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/CachedSymbol.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/CachedSymbol.cs
@@ -1,11 +1,10 @@
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Semmle.Extraction.Entities;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Semmle.Extraction.CSharp.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/CommentLine.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/CommentLine.cs
@@ -1,6 +1,5 @@
-using Semmle.Extraction.Entities;
 using System.IO;
-using System;
+using Semmle.Extraction.Entities;
 
 namespace Semmle.Extraction.CSharp.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Compilations/Compilation.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Compilations/Compilation.cs
@@ -1,7 +1,7 @@
-﻿using Microsoft.CodeAnalysis;
-using System;
+﻿using System;
 using System.IO;
 using System.Linq;
+using Microsoft.CodeAnalysis;
 using Semmle.Util;
 
 namespace Semmle.Extraction.CSharp.Entities

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Constructor.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Constructor.cs
@@ -1,11 +1,10 @@
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Semmle.Util;
-using System.Linq;
-using Microsoft.CodeAnalysis.CSharp;
-using Semmle.Extraction.Entities;
-using System.IO;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Semmle.Extraction.CSharp.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Conversion.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Conversion.cs
@@ -1,7 +1,7 @@
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Semmle.Extraction.CSharp.Populators;
-using System.Linq;
 
 namespace Semmle.Extraction.CSharp.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Destructor.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Destructor.cs
@@ -1,5 +1,5 @@
-using Microsoft.CodeAnalysis;
 using System.IO;
+using Microsoft.CodeAnalysis;
 
 namespace Semmle.Extraction.CSharp.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Event.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Event.cs
@@ -1,7 +1,7 @@
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.IO;
 using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Semmle.Extraction.CSharp.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/EventAccessor.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/EventAccessor.cs
@@ -1,5 +1,5 @@
-using Microsoft.CodeAnalysis;
 using System.IO;
+using Microsoft.CodeAnalysis;
 
 namespace Semmle.Extraction.CSharp.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expression.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expression.cs
@@ -1,12 +1,12 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Semmle.Extraction.CSharp.Entities.Expressions;
 using Semmle.Extraction.Kinds;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 
 namespace Semmle.Extraction.CSharp.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expression`1.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expression`1.cs
@@ -1,6 +1,6 @@
+using System.IO;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using System.IO;
 
 namespace Semmle.Extraction.CSharp.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/ArgList.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/ArgList.cs
@@ -1,7 +1,7 @@
-﻿using Semmle.Extraction.Kinds;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using System;
+﻿using System;
 using System.IO;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Semmle.Extraction.Kinds;
 
 namespace Semmle.Extraction.CSharp.Entities.Expressions
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/ArrayCreation.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/ArrayCreation.cs
@@ -1,11 +1,11 @@
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Semmle.Extraction.Kinds;
-using Semmle.Util;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Semmle.Util;
+using Semmle.Extraction.Kinds;
 
 namespace Semmle.Extraction.CSharp.Entities.Expressions
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Assignment.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Assignment.cs
@@ -1,8 +1,8 @@
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.CSharp;
-using Semmle.Extraction.Kinds;
-using Microsoft.CodeAnalysis;
 using System.IO;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Semmle.Extraction.Kinds;
 
 namespace Semmle.Extraction.CSharp.Entities.Expressions
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Await.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Await.cs
@@ -1,6 +1,6 @@
-using Microsoft.CodeAnalysis.CSharp.Syntax; // lgtm[cs/similar-file]
+using System.IO; // lgtm[cs/similar-file]
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Semmle.Extraction.Kinds;
-using System.IO;
 
 namespace Semmle.Extraction.CSharp.Entities.Expressions
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Binary.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Binary.cs
@@ -1,7 +1,7 @@
+using System.IO;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Semmle.Extraction.Kinds;
-using System.IO;
 
 namespace Semmle.Extraction.CSharp.Entities.Expressions
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Cast.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Cast.cs
@@ -1,7 +1,7 @@
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Semmle.Extraction.Kinds;
 using System;
 using System.IO;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Semmle.Extraction.Kinds;
 
 namespace Semmle.Extraction.CSharp.Entities.Expressions
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Checked.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Checked.cs
@@ -1,6 +1,6 @@
-using Microsoft.CodeAnalysis.CSharp.Syntax; // lgtm[cs/similar-file]
+using System.IO; // lgtm[cs/similar-file]
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Semmle.Extraction.Kinds;
-using System.IO;
 
 namespace Semmle.Extraction.CSharp.Entities.Expressions
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Conditional.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Conditional.cs
@@ -1,6 +1,6 @@
+using System.IO;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Semmle.Extraction.Kinds;
-using System.IO;
 
 namespace Semmle.Extraction.CSharp.Entities.Expressions
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Default.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Default.cs
@@ -1,6 +1,6 @@
-using Microsoft.CodeAnalysis.CSharp.Syntax; // lgtm[cs/similar-file]
+using System.IO; // lgtm[cs/similar-file]
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Semmle.Extraction.Kinds;
-using System.IO;
 
 namespace Semmle.Extraction.CSharp.Entities.Expressions
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/DefineSymbol.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/DefineSymbol.cs
@@ -1,6 +1,6 @@
+using System.IO;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Semmle.Extraction.Kinds;
-using System.IO;
 
 namespace Semmle.Extraction.CSharp.Entities.Expressions
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Discard.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Discard.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Semmle.Extraction.Entities;
 using Semmle.Extraction.Kinds;
 
 namespace Semmle.Extraction.CSharp.Entities.Expressions

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/ElementAccess.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/ElementAccess.cs
@@ -1,8 +1,7 @@
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Semmle.Extraction.CSharp.Populators;
-using Semmle.Extraction.Kinds;
-using Microsoft.CodeAnalysis;
 using System.IO;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Semmle.Extraction.Kinds;
 
 namespace Semmle.Extraction.CSharp.Entities.Expressions
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Initializer.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Initializer.cs
@@ -1,9 +1,9 @@
+using System.IO;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Semmle.Extraction.Kinds;
 using Semmle.Util;
-using System.IO;
+using Semmle.Extraction.Kinds;
 
 namespace Semmle.Extraction.CSharp.Entities.Expressions
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/InterpolatedString.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/InterpolatedString.cs
@@ -1,9 +1,7 @@
-﻿using Microsoft.CodeAnalysis;
+﻿using System.IO;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Semmle.Extraction.Entities;
 using Semmle.Extraction.Kinds;
-using System.IO;
 
 namespace Semmle.Extraction.CSharp.Entities.Expressions
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Invocation.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Invocation.cs
@@ -1,10 +1,10 @@
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using System.Linq;
-using Microsoft.CodeAnalysis.CSharp;
-using Semmle.Extraction.Kinds;
-using System.IO;
 using System;
+using System.IO;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Semmle.Extraction.Kinds;
 
 namespace Semmle.Extraction.CSharp.Entities.Expressions
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/IsPattern.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/IsPattern.cs
@@ -1,6 +1,6 @@
-﻿using Microsoft.CodeAnalysis.CSharp.Syntax;
+﻿using System.IO;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Semmle.Extraction.Kinds;
-using System.IO;
 
 namespace Semmle.Extraction.CSharp.Entities.Expressions
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Lambda.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Lambda.cs
@@ -1,11 +1,11 @@
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Semmle.Extraction.Kinds;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis;
 using System.Collections.Generic;
-using Semmle.Util;
-using System.Linq;
 using System.IO;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Semmle.Util;
+using Semmle.Extraction.Kinds;
 
 namespace Semmle.Extraction.CSharp.Entities.Expressions
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Literal.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Literal.cs
@@ -1,8 +1,8 @@
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Semmle.Extraction.Kinds;
+using System.IO;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using System.IO;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Semmle.Extraction.Kinds;
 
 namespace Semmle.Extraction.CSharp.Entities.Expressions
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/MakeRef.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/MakeRef.cs
@@ -1,6 +1,6 @@
-﻿using Semmle.Extraction.Kinds; // lgtm[cs/similar-file]
+﻿using System.IO; // lgtm[cs/similar-file]
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using System.IO;
+using Semmle.Extraction.Kinds;
 
 namespace Semmle.Extraction.CSharp.Entities.Expressions
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Name.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Name.cs
@@ -1,7 +1,7 @@
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using System.Linq;
 
 namespace Semmle.Extraction.CSharp.Entities.Expressions
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/ObjectCreation/AnonymousObjectCreation.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/ObjectCreation/AnonymousObjectCreation.cs
@@ -1,9 +1,8 @@
+using System.IO;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Semmle.Extraction.Entities;
 using Semmle.Extraction.Kinds;
-using System.IO;
 
 namespace Semmle.Extraction.CSharp.Entities.Expressions
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/ObjectCreation/DateTimeObjectCreation.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/ObjectCreation/DateTimeObjectCreation.cs
@@ -1,6 +1,6 @@
-using Microsoft.CodeAnalysis;
-using System.Linq;
 using System.IO;
+using System.Linq;
+using Microsoft.CodeAnalysis;
 using Semmle.Extraction.Kinds;
 
 namespace Semmle.Extraction.CSharp.Entities.Expressions

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/ObjectCreation/ExplicitObjectCreation.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/ObjectCreation/ExplicitObjectCreation.cs
@@ -1,5 +1,6 @@
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.IO;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
 
 namespace Semmle.Extraction.CSharp.Entities.Expressions
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Patterns/ListPattern.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Patterns/ListPattern.cs
@@ -1,6 +1,6 @@
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Semmle.Extraction.Kinds;
 using Semmle.Util;
+using Semmle.Extraction.Kinds;
 
 namespace Semmle.Extraction.CSharp.Entities.Expressions
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Patterns/Pattern.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Patterns/Pattern.cs
@@ -1,6 +1,6 @@
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Semmle.Extraction.CSharp.Entities.Expressions
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Patterns/PositionalPattern.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Patterns/PositionalPattern.cs
@@ -1,6 +1,6 @@
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Semmle.Extraction.Kinds;
 using Semmle.Util;
+using Semmle.Extraction.Kinds;
 
 namespace Semmle.Extraction.CSharp.Entities.Expressions
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Patterns/RecursivePattern.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Patterns/RecursivePattern.cs
@@ -1,6 +1,6 @@
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Semmle.Extraction.Kinds;
 
 namespace Semmle.Extraction.CSharp.Entities.Expressions

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Patterns/RelationalPattern.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Patterns/RelationalPattern.cs
@@ -1,6 +1,6 @@
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Semmle.Extraction.Kinds;
 
 namespace Semmle.Extraction.CSharp.Entities.Expressions

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/PointerMemberAccess.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/PointerMemberAccess.cs
@@ -1,6 +1,6 @@
+using System.IO;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Semmle.Extraction.Kinds;
-using System.IO;
 
 namespace Semmle.Extraction.CSharp.Entities.Expressions
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/PostfixUnary.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/PostfixUnary.cs
@@ -1,6 +1,6 @@
+using System.IO;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Semmle.Extraction.Kinds;
-using System.IO;
 
 namespace Semmle.Extraction.CSharp.Entities.Expressions
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Query.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Query.cs
@@ -1,10 +1,9 @@
-﻿using Microsoft.CodeAnalysis;
+﻿using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using System.Linq;
 using Semmle.Extraction.Kinds;
-using System.Collections.Generic;
-using Semmle.Extraction.Entities;
 
 namespace Semmle.Extraction.CSharp.Entities.Expressions
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/RangeExpression.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/RangeExpression.cs
@@ -1,6 +1,6 @@
-﻿using Microsoft.CodeAnalysis.CSharp.Syntax;
+﻿using System.IO;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Semmle.Extraction.Kinds;
-using System.IO;
 
 namespace Semmle.Extraction.CSharp.Entities.Expressions
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Ref.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Ref.cs
@@ -1,6 +1,6 @@
-﻿using Microsoft.CodeAnalysis.CSharp.Syntax; // lgtm[cs/similar-file]
+﻿using System.IO; // lgtm[cs/similar-file]
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Semmle.Extraction.Kinds;
-using System.IO;
 
 namespace Semmle.Extraction.CSharp.Entities.Expressions
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/RefType.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/RefType.cs
@@ -1,6 +1,6 @@
-﻿using Semmle.Extraction.Kinds; // lgtm[cs/similar-file]
+﻿using System.IO; // lgtm[cs/similar-file]
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using System.IO;
+using Semmle.Extraction.Kinds;
 
 namespace Semmle.Extraction.CSharp.Entities.Expressions
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/RefValue.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/RefValue.cs
@@ -1,6 +1,6 @@
-﻿using Semmle.Extraction.Kinds;
+﻿using System.IO;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using System.IO;
+using Semmle.Extraction.Kinds;
 
 namespace Semmle.Extraction.CSharp.Entities.Expressions
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Sizeof.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Sizeof.cs
@@ -1,6 +1,6 @@
-using Microsoft.CodeAnalysis.CSharp.Syntax; // lgtm[cs/similar-file]
+using System.IO; // lgtm[cs/similar-file]
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Semmle.Extraction.Kinds;
-using System.IO;
 
 namespace Semmle.Extraction.CSharp.Entities.Expressions
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Switch.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Switch.cs
@@ -1,7 +1,6 @@
-﻿using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Semmle.Extraction.Entities;
+﻿using System.IO;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Semmle.Extraction.Kinds;
-using System.IO;
 
 namespace Semmle.Extraction.CSharp.Entities.Expressions
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Throw.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Throw.cs
@@ -1,6 +1,6 @@
-using Microsoft.CodeAnalysis.CSharp.Syntax; // lgtm[cs/similar-file]
+using System.IO; // lgtm[cs/similar-file]
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Semmle.Extraction.Kinds;
-using System.IO;
 
 namespace Semmle.Extraction.CSharp.Entities.Expressions
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Tuple.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Tuple.cs
@@ -1,7 +1,6 @@
-﻿using Microsoft.CodeAnalysis.CSharp.Syntax;
+﻿using System.IO;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Semmle.Extraction.Kinds;
-using System.IO;
-using System.Linq;
 
 namespace Semmle.Extraction.CSharp.Entities.Expressions
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/TypeAccess.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/TypeAccess.cs
@@ -1,7 +1,7 @@
+using System.IO;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Semmle.Extraction.Kinds;
-using System.IO;
 
 namespace Semmle.Extraction.CSharp.Entities.Expressions
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/TypeOf.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/TypeOf.cs
@@ -1,6 +1,6 @@
-using Microsoft.CodeAnalysis.CSharp.Syntax; // lgtm[cs/similar-file]
+using System.IO; // lgtm[cs/similar-file]
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Semmle.Extraction.Kinds;
-using System.IO;
 
 namespace Semmle.Extraction.CSharp.Entities.Expressions
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Unary.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Unary.cs
@@ -1,6 +1,6 @@
+using System.IO;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Semmle.Extraction.Kinds;
-using System.IO;
 
 namespace Semmle.Extraction.CSharp.Entities.Expressions
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Unchecked.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Unchecked.cs
@@ -1,6 +1,6 @@
-using Microsoft.CodeAnalysis.CSharp.Syntax; // lgtm[cs/similar-file]
+using System.IO; // lgtm[cs/similar-file]
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Semmle.Extraction.Kinds;
-using System.IO;
 
 namespace Semmle.Extraction.CSharp.Entities.Expressions
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/VariableDeclaration.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/VariableDeclaration.cs
@@ -1,11 +1,11 @@
+using System.Collections.Immutable;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Semmle.Extraction.CSharp.Populators;
 using Semmle.Extraction.Kinds;
-using System.Collections.Generic;
-using System.Linq;
-using System.Collections.Immutable;
 
 namespace Semmle.Extraction.CSharp.Entities.Expressions
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/WithExpression.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/WithExpression.cs
@@ -1,6 +1,6 @@
+using System.IO;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Semmle.Extraction.Kinds;
-using System.IO;
 
 namespace Semmle.Extraction.CSharp.Entities.Expressions
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Field.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Field.cs
@@ -1,11 +1,11 @@
-using Microsoft.CodeAnalysis;
-using System.Linq;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System;
+using System.IO;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Semmle.Extraction.CSharp.Entities.Expressions;
 using Semmle.Extraction.Entities;
 using Semmle.Extraction.Kinds;
-using Semmle.Extraction.CSharp.Entities.Expressions;
-using System.IO;
 
 namespace Semmle.Extraction.CSharp.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/File.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/File.cs
@@ -1,8 +1,8 @@
-using Microsoft.CodeAnalysis;
-using Semmle.Util;
 using System;
 using System.IO;
 using System.Linq;
+using Microsoft.CodeAnalysis;
+using Semmle.Util;
 
 namespace Semmle.Extraction.CSharp.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/ImplicitMainMethod.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/ImplicitMainMethod.cs
@@ -1,8 +1,8 @@
+using System.Collections.Generic;
+using System.IO;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Semmle.Extraction.CSharp.Entities.Statements;
-using System.Collections.Generic;
-using System.IO;
 
 namespace Semmle.Extraction.CSharp.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Indexer.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Indexer.cs
@@ -1,7 +1,7 @@
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.IO;
 using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Semmle.Extraction.CSharp.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/LocalFunction.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/LocalFunction.cs
@@ -1,6 +1,6 @@
-﻿using Microsoft.CodeAnalysis;
-using System;
+﻿using System;
 using System.IO;
+using Microsoft.CodeAnalysis;
 
 namespace Semmle.Extraction.CSharp.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Method.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Method.cs
@@ -1,11 +1,11 @@
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Semmle.Extraction.CSharp.Populators;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Semmle.Extraction.CSharp.Populators;
 
 namespace Semmle.Extraction.CSharp.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Modifier.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Modifier.cs
@@ -1,5 +1,5 @@
-using Microsoft.CodeAnalysis;
 using System.IO;
+using Microsoft.CodeAnalysis;
 
 namespace Semmle.Extraction.CSharp.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/NamespaceDeclaration.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/NamespaceDeclaration.cs
@@ -1,10 +1,9 @@
 
+using System.IO;
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Semmle.Extraction.Entities;
-using System.IO;
-using System.Linq;
 
 namespace Semmle.Extraction.CSharp.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/NonGeneratedSourceLocation.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/NonGeneratedSourceLocation.cs
@@ -1,5 +1,5 @@
-using Microsoft.CodeAnalysis;
 using System.IO;
+using Microsoft.CodeAnalysis;
 
 namespace Semmle.Extraction.CSharp.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/OrdinaryMethod.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/OrdinaryMethod.cs
@@ -1,8 +1,9 @@
+using System.IO;
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Semmle.Extraction.CSharp.Populators;
-using System.IO;
-using System.Linq;
+
 
 namespace Semmle.Extraction.CSharp.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Parameter.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Parameter.cs
@@ -1,10 +1,10 @@
-using Microsoft.CodeAnalysis;
-using Semmle.Extraction.CSharp.Populators;
-using System.Linq;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Semmle.Extraction.Entities;
-using System.IO;
 using System;
+using System.IO;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Semmle.Extraction.CSharp.Populators;
+using Semmle.Extraction.Entities;
 
 namespace Semmle.Extraction.CSharp.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/PreprocessorDirectives/DefineDirective.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/PreprocessorDirectives/DefineDirective.cs
@@ -1,5 +1,5 @@
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.IO;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Semmle.Extraction.CSharp.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/PreprocessorDirectives/ElifDirective.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/PreprocessorDirectives/ElifDirective.cs
@@ -1,5 +1,5 @@
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.IO;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Semmle.Extraction.CSharp.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/PreprocessorDirectives/ElseDirective.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/PreprocessorDirectives/ElseDirective.cs
@@ -1,5 +1,5 @@
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.IO;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Semmle.Extraction.CSharp.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/PreprocessorDirectives/EndIfDirective.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/PreprocessorDirectives/EndIfDirective.cs
@@ -1,5 +1,5 @@
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.IO;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Semmle.Extraction.CSharp.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/PreprocessorDirectives/EndRegionDirective.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/PreprocessorDirectives/EndRegionDirective.cs
@@ -1,5 +1,5 @@
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.IO;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Semmle.Extraction.CSharp.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/PreprocessorDirectives/ErrorDirective.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/PreprocessorDirectives/ErrorDirective.cs
@@ -1,5 +1,5 @@
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.IO;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Semmle.Extraction.CSharp.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/PreprocessorDirectives/IfDirective.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/PreprocessorDirectives/IfDirective.cs
@@ -1,5 +1,5 @@
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.IO;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Semmle.Extraction.CSharp.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/PreprocessorDirectives/LineDirective.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/PreprocessorDirectives/LineDirective.cs
@@ -1,7 +1,7 @@
+using System.IO;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using System.IO;
 
 namespace Semmle.Extraction.CSharp.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/PreprocessorDirectives/LineOrSpanDirective.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/PreprocessorDirectives/LineOrSpanDirective.cs
@@ -1,7 +1,5 @@
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.IO;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Semmle.Extraction.CSharp.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/PreprocessorDirectives/LineSpanDirective.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/PreprocessorDirectives/LineSpanDirective.cs
@@ -1,7 +1,5 @@
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.IO;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Semmle.Extraction.CSharp.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/PreprocessorDirectives/NullableDirective.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/PreprocessorDirectives/NullableDirective.cs
@@ -1,6 +1,6 @@
+using System.IO;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using System.IO;
 
 namespace Semmle.Extraction.CSharp.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/PreprocessorDirectives/PragmaChecksumDirective.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/PreprocessorDirectives/PragmaChecksumDirective.cs
@@ -1,5 +1,5 @@
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.IO;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Semmle.Extraction.CSharp.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/PreprocessorDirectives/PragmaWarningDirective.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/PreprocessorDirectives/PragmaWarningDirective.cs
@@ -1,8 +1,8 @@
+using System.IO;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Semmle.Util;
-using System.IO;
 
 namespace Semmle.Extraction.CSharp.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/PreprocessorDirectives/PreprocessorDirective.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/PreprocessorDirectives/PreprocessorDirective.cs
@@ -1,6 +1,5 @@
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Semmle.Extraction.Entities;
 using System.IO;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Semmle.Extraction.CSharp.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/PreprocessorDirectives/RegionDirective.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/PreprocessorDirectives/RegionDirective.cs
@@ -1,6 +1,5 @@
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using System;
 using System.IO;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Semmle.Extraction.CSharp.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/PreprocessorDirectives/UndefineDirective.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/PreprocessorDirectives/UndefineDirective.cs
@@ -1,5 +1,5 @@
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.IO;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Semmle.Extraction.CSharp.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/PreprocessorDirectives/WarningDirective.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/PreprocessorDirectives/WarningDirective.cs
@@ -1,5 +1,5 @@
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.IO;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Semmle.Extraction.CSharp.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Property.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Property.cs
@@ -1,10 +1,10 @@
 using System;
+using System.IO;
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Semmle.Extraction.CSharp.Entities.Expressions;
 using Semmle.Extraction.Kinds;
-using System.IO;
-using System.Linq;
 
 namespace Semmle.Extraction.CSharp.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statement.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statement.cs
@@ -1,6 +1,5 @@
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.CSharp;
 using System.IO;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Semmle.Extraction.CSharp.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statement`1.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statement`1.cs
@@ -1,7 +1,7 @@
-using Semmle.Extraction.CSharp.Populators;
-using Microsoft.CodeAnalysis.CSharp;
-using Semmle.Extraction.Entities;
 using System.IO;
+using Microsoft.CodeAnalysis.CSharp;
+using Semmle.Extraction.CSharp.Populators;
+using Semmle.Extraction.Entities;
 
 namespace Semmle.Extraction.CSharp.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/Block.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/Block.cs
@@ -1,7 +1,7 @@
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Semmle.Extraction.Kinds;
 using System.IO;
 using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Semmle.Extraction.Kinds;
 
 namespace Semmle.Extraction.CSharp.Entities.Statements
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/Break.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/Break.cs
@@ -1,6 +1,6 @@
+using System.IO;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Semmle.Extraction.Kinds;
-using System.IO;
 
 namespace Semmle.Extraction.CSharp.Entities.Statements
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/Case.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/Case.cs
@@ -1,9 +1,7 @@
+using System.IO;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Semmle.Extraction.Kinds;
-using Microsoft.CodeAnalysis;
-using Semmle.Extraction.Entities;
-using System.IO;
 
 namespace Semmle.Extraction.CSharp.Entities.Statements
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/Catch.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/Catch.cs
@@ -1,7 +1,6 @@
+using System.IO;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Semmle.Extraction.Kinds;
-using Semmle.Extraction.Entities;
-using System.IO;
 
 namespace Semmle.Extraction.CSharp.Entities.Statements
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/Checked.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/Checked.cs
@@ -1,6 +1,6 @@
-using Microsoft.CodeAnalysis.CSharp.Syntax;  // lgtm[cs/similar-file]
+using System.IO; // lgtm[cs/similar-file]
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Semmle.Extraction.Kinds;
-using System.IO;
 
 namespace Semmle.Extraction.CSharp.Entities.Statements
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/Continue.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/Continue.cs
@@ -1,6 +1,6 @@
+using System.IO;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Semmle.Extraction.Kinds;
-using System.IO;
 
 namespace Semmle.Extraction.CSharp.Entities.Statements
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/Do.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/Do.cs
@@ -1,7 +1,6 @@
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Semmle.Extraction.Entities;
-using Semmle.Extraction.Kinds;
 using System.IO;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Semmle.Extraction.Kinds;
 
 namespace Semmle.Extraction.CSharp.Entities.Statements
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/Empty.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/Empty.cs
@@ -1,6 +1,6 @@
+using System.IO;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Semmle.Extraction.Kinds;
-using System.IO;
 
 namespace Semmle.Extraction.CSharp.Entities.Statements
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/ExpressionStatement.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/ExpressionStatement.cs
@@ -1,5 +1,5 @@
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.IO;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Semmle.Extraction.CSharp.Entities.Statements
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/Fixed.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/Fixed.cs
@@ -1,7 +1,7 @@
-using Microsoft.CodeAnalysis.CSharp.Syntax; // lgtm[cs/similar-file]
+using System.IO; // lgtm[cs/similar-file]
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Semmle.Extraction.CSharp.Entities.Expressions;
 using Semmle.Extraction.Kinds;
-using System.IO;
 
 namespace Semmle.Extraction.CSharp.Entities.Statements
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/For.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/For.cs
@@ -1,7 +1,7 @@
+using System.IO;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Semmle.Extraction.CSharp.Entities.Expressions;
 using Semmle.Extraction.Kinds;
-using System.IO;
 
 namespace Semmle.Extraction.CSharp.Entities.Statements
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/ForEach.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/ForEach.cs
@@ -1,8 +1,7 @@
+using System.IO;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Semmle.Extraction.Kinds;
-using Microsoft.CodeAnalysis.CSharp;
-using Semmle.Extraction.Entities;
-using System.IO;
 
 namespace Semmle.Extraction.CSharp.Entities.Statements
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/GlobalStatementsBlock.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/GlobalStatementsBlock.cs
@@ -1,10 +1,8 @@
-using Semmle.Extraction.Kinds;
-using System.Linq;
-using System.IO;
-using Semmle.Extraction.Entities;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using System;
+using Semmle.Extraction.Kinds;
 
 namespace Semmle.Extraction.CSharp.Entities.Statements
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/Goto.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/Goto.cs
@@ -1,7 +1,7 @@
+using System.IO;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Semmle.Extraction.Kinds;
-using Microsoft.CodeAnalysis.CSharp;
-using System.IO;
 
 namespace Semmle.Extraction.CSharp.Entities.Statements
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/If.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/If.cs
@@ -1,6 +1,6 @@
+using System.IO;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Semmle.Extraction.Kinds;
-using System.IO;
 
 namespace Semmle.Extraction.CSharp.Entities.Statements
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/Labeled.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/Labeled.cs
@@ -1,6 +1,6 @@
+using System.IO;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Semmle.Extraction.Kinds;
-using System.IO;
 
 namespace Semmle.Extraction.CSharp.Entities.Statements
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/LocalDeclaration.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/LocalDeclaration.cs
@@ -1,7 +1,7 @@
+using System.IO;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Semmle.Extraction.CSharp.Entities.Expressions;
 using Semmle.Extraction.Kinds;
-using System.IO;
 
 namespace Semmle.Extraction.CSharp.Entities.Statements
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/LocalFunction.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/LocalFunction.cs
@@ -1,9 +1,8 @@
-﻿using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Semmle.Extraction.Kinds;
-using Microsoft.CodeAnalysis.CSharp;
+﻿using System.IO;
 using Microsoft.CodeAnalysis;
-using Semmle.Extraction.Entities;
-using System.IO;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Semmle.Extraction.Kinds;
 
 namespace Semmle.Extraction.CSharp.Entities.Statements
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/Lock.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/Lock.cs
@@ -1,6 +1,6 @@
+using System.IO;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Semmle.Extraction.Kinds;
-using System.IO;
 
 namespace Semmle.Extraction.CSharp.Entities.Statements
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/Return.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/Return.cs
@@ -1,6 +1,6 @@
-using Microsoft.CodeAnalysis.CSharp.Syntax;  // lgtm[cs/similar-file]
+using System.IO; // lgtm[cs/similar-file]
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Semmle.Extraction.Kinds;
-using System.IO;
 
 namespace Semmle.Extraction.CSharp.Entities.Statements
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/Throw.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/Throw.cs
@@ -1,6 +1,6 @@
-using Microsoft.CodeAnalysis.CSharp.Syntax;  // lgtm[cs/similar-file]
+using System.IO; // lgtm[cs/similar-file]
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Semmle.Extraction.Kinds;
-using System.IO;
 
 namespace Semmle.Extraction.CSharp.Entities.Statements
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/Try.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/Try.cs
@@ -1,7 +1,6 @@
+using System.IO;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Semmle.Extraction.Kinds;
-using Microsoft.CodeAnalysis;
-using System.IO;
 
 namespace Semmle.Extraction.CSharp.Entities.Statements
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/Unchecked.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/Unchecked.cs
@@ -1,6 +1,6 @@
-using Microsoft.CodeAnalysis.CSharp.Syntax;  // lgtm[cs/similar-file]
+using System.IO; // lgtm[cs/similar-file]
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Semmle.Extraction.Kinds;
-using System.IO;
 
 namespace Semmle.Extraction.CSharp.Entities.Statements
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/Unsafe.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/Unsafe.cs
@@ -1,6 +1,6 @@
-﻿using Microsoft.CodeAnalysis.CSharp.Syntax;
+﻿using System.IO;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Semmle.Extraction.Kinds;
-using System.IO;
 
 namespace Semmle.Extraction.CSharp.Entities.Statements
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/Using.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/Using.cs
@@ -1,7 +1,7 @@
+using System.IO;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Semmle.Extraction.CSharp.Entities.Expressions;
 using Semmle.Extraction.Kinds;
-using System.IO;
 
 namespace Semmle.Extraction.CSharp.Entities.Statements
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/While.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/While.cs
@@ -1,6 +1,6 @@
+using System.IO;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Semmle.Extraction.Kinds;
-using System.IO;
 
 namespace Semmle.Extraction.CSharp.Entities.Statements
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/Yield.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/Yield.cs
@@ -1,6 +1,6 @@
+using System.IO;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Semmle.Extraction.Kinds;
-using System.IO;
 
 namespace Semmle.Extraction.CSharp.Entities.Statements
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/TypeMention.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/TypeMention.cs
@@ -1,9 +1,8 @@
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Semmle.Extraction.Entities;
-using Semmle.Util;
 using System.IO;
 using System.Linq;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Semmle.Util;
 
 namespace Semmle.Extraction.CSharp.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/DynamicType.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/DynamicType.cs
@@ -1,6 +1,6 @@
-using Microsoft.CodeAnalysis;
 using System.IO;
 using System.Linq;
+using Microsoft.CodeAnalysis;
 
 namespace Semmle.Extraction.CSharp.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/NamedType.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/NamedType.cs
@@ -1,10 +1,10 @@
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Semmle.Extraction.CSharp.Populators;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Semmle.Extraction.CSharp.Populators;
 
 namespace Semmle.Extraction.CSharp.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/Nullability.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/Nullability.cs
@@ -1,7 +1,7 @@
-﻿using Microsoft.CodeAnalysis;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Microsoft.CodeAnalysis;
 
 namespace Semmle.Extraction.CSharp.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/TupleType.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/TupleType.cs
@@ -1,9 +1,8 @@
-﻿using Microsoft.CodeAnalysis;
-using Semmle.Extraction.Entities;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Microsoft.CodeAnalysis;
 
 namespace Semmle.Extraction.CSharp.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/Type.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/Type.cs
@@ -1,9 +1,9 @@
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Semmle.Extraction.CSharp.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/TypeParameter.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/TypeParameter.cs
@@ -1,7 +1,7 @@
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.IO;
 using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Semmle.Extraction.CSharp.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/TypeParameterConstraints.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/TypeParameterConstraints.cs
@@ -1,5 +1,5 @@
-using Microsoft.CodeAnalysis;
 using System.IO;
+using Microsoft.CodeAnalysis;
 
 namespace Semmle.Extraction.CSharp.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/UserOperator.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/UserOperator.cs
@@ -1,8 +1,8 @@
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Semmle.Extraction.CSharp.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/UsingDirective.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/UsingDirective.cs
@@ -1,8 +1,7 @@
+using System.IO;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Semmle.Extraction.Entities;
-using System.IO;
 
 namespace Semmle.Extraction.CSharp.Entities
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Extractor/Analyser.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Extractor/Analyser.cs
@@ -1,13 +1,13 @@
 using System;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using Semmle.Extraction.CSharp.Populators;
-using System.Collections.Generic;
 using System.Threading.Tasks;
-using System.Diagnostics;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Semmle.Util.Logging;
+using Semmle.Extraction.CSharp.Populators;
 
 namespace Semmle.Extraction.CSharp
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Extractor/Context.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Extractor/Context.cs
@@ -1,8 +1,8 @@
-using Microsoft.CodeAnalysis;
 using System;
-using System.Diagnostics.CodeAnalysis;
-using Semmle.Extraction.Entities;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis;
+using Semmle.Extraction.Entities;
 
 namespace Semmle.Extraction.CSharp
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Extractor/TracingAnalyser.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Extractor/TracingAnalyser.cs
@@ -1,12 +1,11 @@
 using System;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Collections.Generic;
-using Semmle.Util.Logging;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Semmle.Util;
-
+using Semmle.Util.Logging;
 
 namespace Semmle.Extraction.CSharp
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Populators/CommentPopulator.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Populators/CommentPopulator.cs
@@ -1,7 +1,7 @@
+using System;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Semmle.Extraction.CSharp.Entities;
-using System;
 
 namespace Semmle.Extraction.CSharp.Populators
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Populators/CompilationUnitVisitor.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Populators/CompilationUnitVisitor.cs
@@ -1,9 +1,9 @@
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Semmle.Util.Logging;
 using Semmle.Extraction.CSharp.Entities;
-using System.Linq;
 
 namespace Semmle.Extraction.CSharp.Populators
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Populators/DirectiveVisitor.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Populators/DirectiveVisitor.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;

--- a/csharp/extractor/Semmle.Extraction.CSharp/Populators/Locations.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Populators/Locations.cs
@@ -1,7 +1,7 @@
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using System.Linq;
 
 namespace Semmle.Extraction.CSharp.Populators
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Populators/TypeContainerVisitor.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Populators/TypeContainerVisitor.cs
@@ -1,11 +1,11 @@
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Semmle.Extraction.CSharp.Entities;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Semmle.Extraction.CSharp.Entities;
 
 namespace Semmle.Extraction.CSharp.Populators
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Populators/TypeOrNamespaceVisitor.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Populators/TypeOrNamespaceVisitor.cs
@@ -1,6 +1,6 @@
+using System.IO;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Semmle.Extraction.CSharp.Entities;
-using System.IO;
 
 namespace Semmle.Extraction.CSharp.Populators
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/SymbolExtensions.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/SymbolExtensions.cs
@@ -1,10 +1,10 @@
-using Microsoft.CodeAnalysis;
-using Semmle.Extraction.CSharp.Entities;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
+using Microsoft.CodeAnalysis;
+using Semmle.Extraction.CSharp.Entities;
 
 namespace Semmle.Extraction.CSharp
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Tuples.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Tuples.cs
@@ -1,10 +1,10 @@
+using System.IO;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Semmle.Util;
 using Semmle.Extraction.CSharp.Entities;
 using Semmle.Extraction.CSharp.Entities.Expressions;
 using Semmle.Extraction.Entities;
 using Semmle.Extraction.Kinds;
-using Semmle.Util;
-using System.IO;
 
 namespace Semmle.Extraction.CSharp
 {

--- a/csharp/extractor/Semmle.Extraction.Tests/PathTransformer.cs
+++ b/csharp/extractor/Semmle.Extraction.Tests/PathTransformer.cs
@@ -1,5 +1,5 @@
-﻿using Semmle.Util;
-using Xunit;
+﻿using Xunit;
+using Semmle.Util;
 
 namespace Semmle.Extraction.Tests
 {

--- a/csharp/extractor/Semmle.Extraction/Context.cs
+++ b/csharp/extractor/Semmle.Extraction/Context.cs
@@ -1,11 +1,11 @@
-using Microsoft.CodeAnalysis;
-using Semmle.Extraction.Entities;
-using Semmle.Util.Logging;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
+using Microsoft.CodeAnalysis;
+using Semmle.Util.Logging;
+using Semmle.Extraction.Entities;
 
 namespace Semmle.Extraction
 {

--- a/csharp/extractor/Semmle.Extraction/Entities/Base/CachedEntityFactory.cs
+++ b/csharp/extractor/Semmle.Extraction/Entities/Base/CachedEntityFactory.cs
@@ -1,5 +1,3 @@
-using Microsoft.CodeAnalysis;
-
 namespace Semmle.Extraction
 {
     /// <summary>

--- a/csharp/extractor/Semmle.Extraction/Entities/Base/Entity.cs
+++ b/csharp/extractor/Semmle.Extraction/Entities/Base/Entity.cs
@@ -1,6 +1,6 @@
-using Microsoft.CodeAnalysis;
 using System;
 using System.IO;
+using Microsoft.CodeAnalysis;
 
 namespace Semmle.Extraction
 {

--- a/csharp/extractor/Semmle.Extraction/Entities/Base/IEntity.cs
+++ b/csharp/extractor/Semmle.Extraction/Entities/Base/IEntity.cs
@@ -1,5 +1,5 @@
-using Microsoft.CodeAnalysis;
 using System.IO;
+using Microsoft.CodeAnalysis;
 
 namespace Semmle.Extraction
 {

--- a/csharp/extractor/Semmle.Extraction/Entities/Base/LabelledEntity.cs
+++ b/csharp/extractor/Semmle.Extraction/Entities/Base/LabelledEntity.cs
@@ -1,5 +1,3 @@
-using System.IO;
-
 namespace Semmle.Extraction
 {
     public abstract class LabelledEntity : Entity

--- a/csharp/extractor/Semmle.Extraction/Entities/Base/UnlabelledEntity.cs
+++ b/csharp/extractor/Semmle.Extraction/Entities/Base/UnlabelledEntity.cs
@@ -1,5 +1,3 @@
-using System.IO;
-
 namespace Semmle.Extraction
 {
     public abstract class UnlabelledEntity : Entity

--- a/csharp/extractor/Semmle.Extraction/Entities/Location.cs
+++ b/csharp/extractor/Semmle.Extraction/Entities/Location.cs
@@ -1,6 +1,3 @@
-
-using Microsoft.CodeAnalysis.Text;
-
 namespace Semmle.Extraction.Entities
 {
 #nullable disable warnings

--- a/csharp/extractor/Semmle.Extraction/FilePattern.cs
+++ b/csharp/extractor/Semmle.Extraction/FilePattern.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
-using System.Diagnostics.CodeAnalysis;
 using Semmle.Util;
 
 namespace Semmle.Extraction

--- a/csharp/extractor/Semmle.Extraction/InternalError.cs
+++ b/csharp/extractor/Semmle.Extraction/InternalError.cs
@@ -1,6 +1,6 @@
-using Microsoft.CodeAnalysis;
 using System;
 using System.Linq;
+using Microsoft.CodeAnalysis;
 
 namespace Semmle.Extraction
 {

--- a/csharp/extractor/Semmle.Extraction/Message.cs
+++ b/csharp/extractor/Semmle.Extraction/Message.cs
@@ -1,8 +1,7 @@
-﻿using Microsoft.CodeAnalysis;
-using Semmle.Util.Logging;
-using System;
-using System.Linq;
+﻿using System.Linq;
 using System.Text;
+using Microsoft.CodeAnalysis;
+using Semmle.Util.Logging;
 
 namespace Semmle.Extraction
 {

--- a/csharp/extractor/Semmle.Extraction/Options.cs
+++ b/csharp/extractor/Semmle.Extraction/Options.cs
@@ -1,6 +1,6 @@
 using System;
-using Semmle.Util.Logging;
 using Semmle.Util;
+using Semmle.Util.Logging;
 
 namespace Semmle.Extraction
 {

--- a/csharp/extractor/Semmle.Extraction/PathTransformer.cs
+++ b/csharp/extractor/Semmle.Extraction/PathTransformer.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using Semmle.Util;
 using Semmle.Util.Logging;
 

--- a/csharp/extractor/Semmle.Extraction/SourceScope.cs
+++ b/csharp/extractor/Semmle.Extraction/SourceScope.cs
@@ -1,5 +1,6 @@
-﻿using Microsoft.CodeAnalysis;
-using System.Linq;
+﻿using System.Linq;
+using Microsoft.CodeAnalysis;
+
 
 namespace Semmle.Extraction
 {

--- a/csharp/extractor/Semmle.Extraction/TrapWriter.cs
+++ b/csharp/extractor/Semmle.Extraction/TrapWriter.cs
@@ -1,9 +1,9 @@
-using Semmle.Util;
-using Semmle.Util.Logging;
 using System;
 using System.IO;
 using System.IO.Compression;
 using System.Text;
+using Semmle.Util;
+using Semmle.Util.Logging;
 
 namespace Semmle.Extraction
 {

--- a/csharp/extractor/Semmle.Extraction/Tuples.cs
+++ b/csharp/extractor/Semmle.Extraction/Tuples.cs
@@ -1,5 +1,4 @@
 using Semmle.Extraction.Entities;
-using Semmle.Util;
 
 namespace Semmle.Extraction
 {

--- a/csharp/extractor/Semmle.Util.Tests/ActionMap.cs
+++ b/csharp/extractor/Semmle.Util.Tests/ActionMap.cs
@@ -1,6 +1,7 @@
 using Xunit;
-using Assert = Xunit.Assert;
 using Semmle.Util;
+
+using Assert = Xunit.Assert;
 
 namespace SemmleTests.Semmle.Util
 {

--- a/csharp/extractor/Semmle.Util.Tests/CanonicalPathCache.cs
+++ b/csharp/extractor/Semmle.Util.Tests/CanonicalPathCache.cs
@@ -1,8 +1,8 @@
 using Xunit;
-using Semmle.Util;
-using System.IO;
-using Semmle.Util.Logging;
 using System;
+using System.IO;
+using Semmle.Util;
+using Semmle.Util.Logging;
 
 namespace SemmleTests.Semmle.Util
 {

--- a/csharp/extractor/Semmle.Util.Tests/LineCounterTest.cs
+++ b/csharp/extractor/Semmle.Util.Tests/LineCounterTest.cs
@@ -1,5 +1,4 @@
 using Xunit;
-
 using Semmle.Util;
 
 namespace SemmleTests

--- a/csharp/extractor/Semmle.Util.Tests/LongPaths.cs
+++ b/csharp/extractor/Semmle.Util.Tests/LongPaths.cs
@@ -1,8 +1,8 @@
 using Xunit;
-using Semmle.Util;
+using System;
 using System.IO;
 using System.Linq;
-using System;
+using Semmle.Util;
 
 namespace SemmleTests.Semmle.Util
 {

--- a/csharp/extractor/Semmle.Util.Tests/TextTest.cs
+++ b/csharp/extractor/Semmle.Util.Tests/TextTest.cs
@@ -1,8 +1,8 @@
-using System;
 using Xunit;
-using Assert = Xunit.Assert;
-
+using System;
 using Semmle.Util;
+
+using Assert = Xunit.Assert;
 
 namespace SemmleTests
 {

--- a/csharp/extractor/Semmle.Util/CanonicalPathCache.cs
+++ b/csharp/extractor/Semmle.Util/CanonicalPathCache.cs
@@ -1,10 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
-using System.IO;
-using Semmle.Util.Logging;
 using Mono.Unix;
+using Semmle.Util.Logging;
 
 namespace Semmle.Util
 {

--- a/csharp/extractor/Semmle.Util/LineCounter.cs
+++ b/csharp/extractor/Semmle.Util/LineCounter.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Semmle.Util
 {
     /// <summary>

--- a/csharp/extractor/Semmle.Util/LoggerUtils.cs
+++ b/csharp/extractor/Semmle.Util/LoggerUtils.cs
@@ -1,4 +1,3 @@
-using System;
 using System.IO;
 using System.Diagnostics;
 

--- a/csharp/extractor/Semmle.Util/ToolStatusPage.cs
+++ b/csharp/extractor/Semmle.Util/ToolStatusPage.cs
@@ -1,4 +1,3 @@
-
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/csharp/extractor/Semmle.Util/Win32.cs
+++ b/csharp/extractor/Semmle.Util/Win32.cs
@@ -1,7 +1,7 @@
-using Microsoft.Win32.SafeHandles;
 using System;
 using System.Runtime.InteropServices;
 using System.Text;
+using Microsoft.Win32.SafeHandles;
 
 namespace Semmle.Util
 {


### PR DESCRIPTION
In this PR we introduce the following standard for `using` statements in our C# extractor source code files.
The order is
- `System*` (the standard library).
- Third party libraries (eg. `Microsoft.CodeAnalysis`).
- `Semmle*` (out own namespaces), starting with `Semmle.Util*` (the remaining is in alphabetical order) 
- Type abbreviations (using X = Y).

Unit test projects follows the same pattern except that the first using statement is `using Xunit`.