### PR TITLE
C++: Accept regression in test after evaluator fix

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-120/BadlyBoundedWrite.ql
+++ b/cpp/ql/src/Security/CWE/CWE-120/BadlyBoundedWrite.ql
@@ -24,7 +24,7 @@ import semmle.code.cpp.security.BufferWrite
 from BufferWrite bw, int destSize
 where
   bw.hasExplicitLimit() and // has an explicit size limit
-  destSize = max(getBufferSize(bw.getDest(), _)) and
+  destSize = getBufferSize(bw.getDest(), _) and
   bw.getExplicitLimit() > destSize // but it's larger than the destination
 select bw,
   "This '" + bw.getBWDesc() + "' operation is limited to " + bw.getExplicitLimit() +

--- a/cpp/ql/src/change-notes/2023-08-09-badly-bounded-write.md
+++ b/cpp/ql/src/change-notes/2023-08-09-badly-bounded-write.md
@@ -1,4 +1,0 @@
----
-category: minorAnalysis
----
-* The `cpp/badly-bounded-write` query could report false positives when a pointer was first initialized with a literal and later assigned a dynamically allocated array. These false positives now no longer occur.

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-120/semmle/tests/BadlyBoundedWrite.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-120/semmle/tests/BadlyBoundedWrite.expected
@@ -1,3 +1,6 @@
+| tests2.cpp:59:3:59:10 | call to snprintf | This 'call to snprintf' operation is limited to 13 bytes but the destination is only 0 bytes. |
 | tests2.cpp:59:3:59:10 | call to snprintf | This 'call to snprintf' operation is limited to 13 bytes but the destination is only 2 bytes. |
+| tests2.cpp:63:3:63:10 | call to snprintf | This 'call to snprintf' operation is limited to 13 bytes but the destination is only 0 bytes. |
+| tests2.cpp:63:3:63:10 | call to snprintf | This 'call to snprintf' operation is limited to 13 bytes but the destination is only 3 bytes. |
 | tests.c:43:3:43:10 | call to snprintf | This 'call to snprintf' operation is limited to 111 bytes but the destination is only 110 bytes. |
 | tests.c:46:3:46:10 | call to snprintf | This 'call to snprintf' operation is limited to 111 bytes but the destination is only 110 bytes. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-120/semmle/tests/BadlyBoundedWrite.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-120/semmle/tests/BadlyBoundedWrite.expected
@@ -1,2 +1,3 @@
+| tests2.cpp:59:3:59:10 | call to snprintf | This 'call to snprintf' operation is limited to 13 bytes but the destination is only 2 bytes. |
 | tests.c:43:3:43:10 | call to snprintf | This 'call to snprintf' operation is limited to 111 bytes but the destination is only 110 bytes. |
 | tests.c:46:3:46:10 | call to snprintf | This 'call to snprintf' operation is limited to 111 bytes but the destination is only 110 bytes. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-120/semmle/tests/tests2.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-120/semmle/tests/tests2.cpp
@@ -60,5 +60,5 @@ void test3() {
   dest2 = (char*)malloc(3);
   if (!dest2)
     return;
-  snprintf(dest2, sizeof(src), "%s", src); // BAD [NOT DETECTED]: buffer overflow
+  snprintf(dest2, sizeof(src), "%s", src); // BAD (but with duplicate alerts)
 }

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-120/semmle/tests/tests2.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-120/semmle/tests/tests2.cpp
@@ -56,7 +56,7 @@ void test3() {
   dest1 = (char*)malloc(sizeof(src));
   if (!dest1)
     return;
-  snprintf(dest1, sizeof(src), "%s", src); // GOOD
+  snprintf(dest1, sizeof(src), "%s", src); // GOOD [FALSE POSITIVE]
   dest2 = (char*)malloc(3);
   if (!dest2)
     return;


### PR DESCRIPTION
A recent fix to the CodeQL evaluator broke the FP fix to `BadlyBoundedWrite` that was introduced in https://github.com/github/codeql/pull/13929. The `BadlyBoundedWrite` fix will have to be re-done in another way, but for now I'm rolling back the expected test output so we get all tests on `main` passing.

It's not obviously a good idea to delete the change note. The change may still have an effect but just not an effect that can be observed on the test case. What do you all think?