### PR TITLE
Ruby: Include more (hash) splat flow in type tracking

### DIFF
--- a/ruby/ql/lib/codeql/ruby/typetracking/TypeTrackerSpecific.qll
+++ b/ruby/ql/lib/codeql/ruby/typetracking/TypeTrackerSpecific.qll
@@ -327,7 +327,7 @@ predicate basicLoadStoreStep(
 }
 
 /**
- * Holds if a read+store step `nodeFrom -> nodeTo`, where the destination node
+ * Holds if a read+store step `nodeFrom -> nodeTo` exists, where the destination node
  * should be treated as a local source node.
  */
 predicate readStoreStepIntoSourceNode(

--- a/ruby/ql/lib/codeql/ruby/typetracking/TypeTrackerSpecific.qll
+++ b/ruby/ql/lib/codeql/ruby/typetracking/TypeTrackerSpecific.qll
@@ -295,6 +295,8 @@ predicate storeStepIntoSourceNode(Node nodeFrom, Node nodeTo, DataFlow::ContentS
  * Holds if `nodeTo` is the result of accessing the `content` content of `nodeFrom`.
  */
 predicate basicLoadStep(Node nodeFrom, Node nodeTo, DataFlow::ContentSet contents) {
+  readStepIntoSourceNode(nodeFrom, nodeTo, contents)
+  or
   exists(ExprNodes::MethodCallCfgNode call |
     call.getExpr().getNumberOfArguments() = 0 and
     contents.isSingleton(DataFlowPublic::Content::getAttributeName(call.getExpr().getMethodName())) and
@@ -306,12 +308,39 @@ predicate basicLoadStep(Node nodeFrom, Node nodeTo, DataFlow::ContentSet content
 }
 
 /**
+ * Holds if a read step `nodeFrom -> nodeTo` with `contents` exists, where the destination node
+ * should be treated as a local source node.
+ */
+predicate readStepIntoSourceNode(Node nodeFrom, Node nodeTo, DataFlow::ContentSet contents) {
+  DataFlowPrivate::readStepCommon(nodeFrom, contents, nodeTo)
+}
+
+/**
  * Holds if the `loadContent` of `nodeFrom` is stored in the `storeContent` of `nodeTo`.
  */
 predicate basicLoadStoreStep(
   Node nodeFrom, Node nodeTo, DataFlow::ContentSet loadContent, DataFlow::ContentSet storeContent
 ) {
+  readStoreStepIntoSourceNode(nodeFrom, nodeTo, loadContent, storeContent)
+  or
   TypeTrackerSummaryFlow::basicLoadStoreStep(nodeFrom, nodeTo, loadContent, storeContent)
+}
+
+/**
+ * Holds if a read+store step `nodeFrom -> nodeTo`, where the destination node
+ * should be treated as a local source node.
+ */
+predicate readStoreStepIntoSourceNode(
+  Node nodeFrom, Node nodeTo, DataFlow::ContentSet loadContent, DataFlow::ContentSet storeContent
+) {
+  exists(DataFlowPrivate::SynthSplatParameterElementNode mid |
+    nodeFrom
+        .(DataFlowPrivate::SynthSplatArgParameterNode)
+        .isParameterOf(mid.getEnclosingCallable(), _) and
+    loadContent = DataFlowPrivate::getPositionalContent(mid.getReadPosition()) and
+    nodeTo = mid.getSplatParameterNode(_) and
+    storeContent = DataFlowPrivate::getPositionalContent(mid.getStorePosition())
+  )
 }
 
 /**

--- a/ruby/ql/test/library-tests/dataflow/params/TypeTracker.expected
+++ b/ruby/ql/test/library-tests/dataflow/params/TypeTracker.expected
@@ -1,0 +1,4053 @@
+track
+| params_flow.rb:1:1:3:3 | &block | type tracker without call steps | params_flow.rb:1:1:3:3 | &block |
+| params_flow.rb:1:1:3:3 | self in taint | type tracker without call steps | params_flow.rb:1:1:3:3 | self in taint |
+| params_flow.rb:1:1:3:3 | synthetic *args | type tracker without call steps | params_flow.rb:1:1:3:3 | synthetic *args |
+| params_flow.rb:1:1:3:3 | taint | type tracker without call steps | params_flow.rb:1:1:3:3 | taint |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | type tracker with call steps | params_flow.rb:1:1:3:3 | self in taint |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | type tracker with call steps | params_flow.rb:5:1:7:3 | self in sink |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | type tracker with call steps | params_flow.rb:9:1:12:3 | self in positional |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | type tracker with call steps | params_flow.rb:16:1:19:3 | self in keyword |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | type tracker with call steps | params_flow.rb:25:1:31:3 | self in kwargs |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | type tracker with call steps | params_flow.rb:49:1:53:3 | self in posargs |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | type tracker with call steps | params_flow.rb:64:1:66:3 | self in splatstuff |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | type tracker with call steps | params_flow.rb:69:1:76:3 | self in splatmid |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | type tracker with call steps | params_flow.rb:83:1:91:3 | self in pos_many |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | type tracker with call steps | params_flow.rb:98:1:103:3 | self in splatmidsmall |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | type tracker with call steps | params_flow.rb:108:1:112:3 | self in splat_followed_by_keyword_param |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | type tracker with call steps | params_flow.rb:120:1:126:3 | self in destruct |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | type tracker without call steps | params_flow.rb:1:1:128:62 | self (params_flow.rb) |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps | params_flow.rb:9:16:9:17 | p1 |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps | params_flow.rb:9:20:9:21 | p2 |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps | params_flow.rb:16:13:16:14 | p1 |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps | params_flow.rb:16:18:16:19 | p2 |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps | params_flow.rb:25:12:25:13 | p1 |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps | params_flow.rb:27:11:27:21 | ...[...] |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps | params_flow.rb:28:11:28:21 | ...[...] |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps | params_flow.rb:29:11:29:21 | ...[...] |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps | params_flow.rb:49:13:49:14 | p1 |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps | params_flow.rb:51:11:51:20 | ...[...] |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps | params_flow.rb:65:10:65:13 | ...[...] |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps | params_flow.rb:69:14:69:14 | x |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps | params_flow.rb:69:17:69:17 | y |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps | params_flow.rb:69:24:69:24 | w |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps | params_flow.rb:69:27:69:27 | r |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps | params_flow.rb:83:14:83:14 | t |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps | params_flow.rb:83:17:83:17 | u |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps | params_flow.rb:83:23:83:23 | w |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps | params_flow.rb:98:19:98:19 | a |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps | params_flow.rb:98:31:98:31 | b |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps | params_flow.rb:108:37:108:37 | a |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps | params_flow.rb:108:44:108:44 | c |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element | params_flow.rb:9:1:12:3 | synthetic *args |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:10:5:10:11 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:11:5:11:11 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:17:5:17:11 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:18:5:18:11 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:26:5:26:11 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:27:5:27:22 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:28:5:28:22 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:29:5:29:22 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:49:1:53:3 | synthetic *args |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:50:5:50:11 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:51:5:51:21 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:65:5:65:13 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:70:5:70:10 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:71:5:71:10 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:74:5:74:10 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:75:5:75:10 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:84:5:84:10 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:85:5:85:10 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:87:5:87:10 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:99:5:99:10 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:102:5:102:10 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:108:1:112:3 | synthetic *args |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:109:5:109:10 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:111:5:111:10 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 or unknown | params_flow.rb:9:1:12:3 | synthetic *args |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 or unknown | params_flow.rb:49:1:53:3 | synthetic *args |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 or unknown | params_flow.rb:49:17:49:24 | *posargs |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 or unknown | params_flow.rb:64:16:64:17 | *x |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 1 | params_flow.rb:49:1:53:3 | synthetic *args |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 1 | params_flow.rb:108:1:112:3 | synthetic *args |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 1 or unknown | params_flow.rb:9:1:12:3 | synthetic *args |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 1 or unknown | params_flow.rb:49:1:53:3 | synthetic *args |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element :c | params_flow.rb:108:1:112:3 | **kwargs |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element :p1 | params_flow.rb:16:1:19:3 | **kwargs |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element :p1 | params_flow.rb:25:1:31:3 | **kwargs |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element :p1 | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element :p2 | params_flow.rb:16:1:19:3 | **kwargs |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element :p2 | params_flow.rb:25:1:31:3 | **kwargs |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element :p2 | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element :p3 | params_flow.rb:25:1:31:3 | **kwargs |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element :p3 | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:14:12:14:19 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:14:22:14:29 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:21:13:21:20 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:21:27:21:34 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:22:13:22:20 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:22:27:22:34 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:23:16:23:23 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:23:33:23:40 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:33:12:33:19 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:33:26:33:34 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:33:41:33:49 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:34:14:34:22 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:35:12:35:20 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:37:16:37:24 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:37:34:37:42 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:40:16:40:24 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:41:13:41:21 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:43:9:43:17 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:44:12:44:20 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:46:9:46:17 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:46:20:46:28 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:55:9:55:17 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:55:20:55:28 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:57:9:57:17 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:58:9:58:17 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:60:9:60:17 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:60:20:60:28 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:63:8:63:16 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:78:10:78:18 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:78:21:78:29 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:78:32:78:40 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:78:43:78:51 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:78:54:78:62 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:80:9:80:17 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:80:20:80:28 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:80:31:80:39 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:80:42:80:50 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:81:10:81:18 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:81:28:81:36 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:93:9:93:17 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:93:20:93:28 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:93:31:93:39 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:93:42:93:50 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:94:10:94:18 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:94:21:94:29 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:94:39:94:47 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:96:10:96:18 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:96:21:96:29 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:96:34:96:42 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:96:45:96:53 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:96:56:96:64 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:96:68:96:76 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:96:79:96:87 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:105:15:105:23 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:105:28:105:36 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:105:39:105:47 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:106:15:106:23 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:106:26:106:34 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:106:37:106:45 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:114:33:114:41 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:114:44:114:52 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:114:58:114:66 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:117:19:117:27 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:128:11:128:19 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:128:22:128:30 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:128:35:128:43 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps | params_flow.rb:128:50:128:58 | call to taint |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content attribute [] | params_flow.rb:117:1:117:1 | [post] x |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element | params_flow.rb:116:5:116:6 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element | params_flow.rb:118:12:118:13 | * ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:14:1:14:30 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:43:8:43:18 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:46:8:46:29 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:55:1:55:29 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:57:8:57:18 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:60:8:60:29 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:78:1:78:63 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:80:8:80:51 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:93:8:93:51 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:96:33:96:65 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:105:27:105:48 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:106:1:106:46 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:114:1:114:67 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:128:10:128:31 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 | params_flow.rb:128:34:128:60 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 or unknown | params_flow.rb:43:8:43:18 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 or unknown | params_flow.rb:44:23:44:27 | * ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 or unknown | params_flow.rb:46:8:46:29 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 or unknown | params_flow.rb:47:12:47:16 | * ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 or unknown | params_flow.rb:57:8:57:18 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 or unknown | params_flow.rb:58:20:58:24 | * ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 or unknown | params_flow.rb:60:8:60:29 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 or unknown | params_flow.rb:61:9:61:13 | * ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 or unknown | params_flow.rb:67:12:67:16 | * ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 or unknown | params_flow.rb:80:8:80:51 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 or unknown | params_flow.rb:81:21:81:25 | * ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 or unknown | params_flow.rb:93:8:93:51 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 or unknown | params_flow.rb:94:32:94:36 | * ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 or unknown | params_flow.rb:96:32:96:65 | * ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 or unknown | params_flow.rb:96:33:96:65 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 or unknown | params_flow.rb:105:26:105:48 | * ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 or unknown | params_flow.rb:105:27:105:48 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 or unknown | params_flow.rb:128:10:128:31 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 0 or unknown | params_flow.rb:128:34:128:60 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:14:1:14:30 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:46:8:46:29 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:55:1:55:29 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:60:8:60:29 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:78:1:78:63 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:80:8:80:51 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:93:8:93:51 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:96:33:96:65 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:105:27:105:48 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:106:1:106:46 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:114:1:114:67 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:117:1:117:15 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:128:10:128:31 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 | params_flow.rb:128:46:128:59 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 or unknown | params_flow.rb:46:8:46:29 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 or unknown | params_flow.rb:47:12:47:16 | * ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 or unknown | params_flow.rb:60:8:60:29 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 or unknown | params_flow.rb:61:9:61:13 | * ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 or unknown | params_flow.rb:80:8:80:51 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 or unknown | params_flow.rb:81:21:81:25 | * ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 or unknown | params_flow.rb:93:8:93:51 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 or unknown | params_flow.rb:94:32:94:36 | * ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 or unknown | params_flow.rb:96:32:96:65 | * ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 or unknown | params_flow.rb:96:33:96:65 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 or unknown | params_flow.rb:105:26:105:48 | * ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 or unknown | params_flow.rb:105:27:105:48 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 or unknown | params_flow.rb:128:10:128:31 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 1 or unknown | params_flow.rb:128:46:128:59 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 2 | params_flow.rb:78:1:78:63 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 2 | params_flow.rb:80:8:80:51 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 2 | params_flow.rb:93:8:93:51 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 2 | params_flow.rb:96:33:96:65 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 2 | params_flow.rb:106:1:106:46 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 2 or unknown | params_flow.rb:80:8:80:51 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 2 or unknown | params_flow.rb:81:21:81:25 | * ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 2 or unknown | params_flow.rb:93:8:93:51 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 2 or unknown | params_flow.rb:94:32:94:36 | * ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 2 or unknown | params_flow.rb:96:32:96:65 | * ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 2 or unknown | params_flow.rb:96:33:96:65 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 3 | params_flow.rb:78:1:78:63 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 3 | params_flow.rb:80:8:80:51 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 3 | params_flow.rb:93:8:93:51 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 3 or unknown | params_flow.rb:80:8:80:51 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 3 or unknown | params_flow.rb:81:21:81:25 | * ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 3 or unknown | params_flow.rb:93:8:93:51 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 3 or unknown | params_flow.rb:94:32:94:36 | * ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element 4 | params_flow.rb:78:1:78:63 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :c | params_flow.rb:114:1:114:67 | ** |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p1 | params_flow.rb:21:1:21:35 | ** |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p1 | params_flow.rb:22:1:22:35 | ** |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p1 | params_flow.rb:23:1:23:41 | ** |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p1 | params_flow.rb:33:1:33:58 | ** |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p1 | params_flow.rb:35:1:35:29 | ** |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p1 | params_flow.rb:37:8:37:44 | ** |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p1 | params_flow.rb:37:8:37:44 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p1 | params_flow.rb:38:8:38:13 | ** ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p1 | params_flow.rb:40:8:40:26 | ** |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p1 | params_flow.rb:40:8:40:26 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p1 | params_flow.rb:41:24:41:29 | ** ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p2 | params_flow.rb:21:1:21:35 | ** |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p2 | params_flow.rb:22:1:22:35 | ** |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p2 | params_flow.rb:23:1:23:41 | ** |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p2 | params_flow.rb:33:1:33:58 | ** |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p2 | params_flow.rb:37:8:37:44 | ** |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p2 | params_flow.rb:37:8:37:44 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p2 | params_flow.rb:38:8:38:13 | ** ... |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p2 | params_flow.rb:41:1:41:30 | ** |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p3 | params_flow.rb:33:1:33:58 | ** |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p3 | params_flow.rb:34:8:34:32 | ** |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p3 | params_flow.rb:34:8:34:32 | call to [] |
+| params_flow.rb:1:11:1:11 | x | type tracker without call steps with content element :p3 | params_flow.rb:35:23:35:28 | ** ... |
+| params_flow.rb:5:1:7:3 | &block | type tracker without call steps | params_flow.rb:5:1:7:3 | &block |
+| params_flow.rb:5:1:7:3 | self in sink | type tracker without call steps | params_flow.rb:5:1:7:3 | self in sink |
+| params_flow.rb:5:1:7:3 | sink | type tracker without call steps | params_flow.rb:5:1:7:3 | sink |
+| params_flow.rb:5:1:7:3 | synthetic *args | type tracker without call steps | params_flow.rb:5:1:7:3 | synthetic *args |
+| params_flow.rb:5:10:5:10 | x | type tracker without call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:5:10:5:10 | x | type tracker without call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:5:10:5:10 | x | type tracker without call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:6:5:6:10 | * | type tracker without call steps | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:6:5:6:10 | call to puts |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:10:5:10:11 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:11:5:11:11 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:14:1:14:30 | call to positional |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:17:5:17:11 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:18:5:18:11 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:21:1:21:35 | call to keyword |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:22:1:22:35 | call to keyword |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:23:1:23:41 | call to keyword |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:26:5:26:11 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:27:5:27:22 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:28:5:28:22 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:29:5:29:22 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:30:5:30:22 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:33:1:33:58 | call to kwargs |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:35:1:35:29 | call to kwargs |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:38:1:38:14 | call to kwargs |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:41:1:41:30 | call to keyword |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:44:1:44:28 | call to positional |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:47:1:47:17 | call to positional |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:50:5:50:11 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:51:5:51:21 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:52:5:52:21 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:55:1:55:29 | call to posargs |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:58:1:58:25 | call to posargs |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:61:1:61:14 | call to posargs |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:65:5:65:13 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:67:1:67:17 | call to splatstuff |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:70:5:70:10 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:71:5:71:10 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:72:5:72:13 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:73:5:73:13 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:74:5:74:10 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:75:5:75:10 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:78:1:78:63 | call to splatmid |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:81:1:81:37 | call to splatmid |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:84:5:84:10 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:85:5:85:10 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:86:5:86:10 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:87:5:87:10 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:88:5:88:10 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:89:5:89:10 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:90:5:90:10 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:94:1:94:48 | call to pos_many |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:96:1:96:88 | call to splatmid |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:99:5:99:10 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:100:5:100:18 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:101:5:101:18 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:102:5:102:10 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:105:1:105:49 | call to splatmidsmall |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:106:1:106:46 | call to splatmidsmall |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:109:5:109:10 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:110:5:110:13 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:111:5:111:10 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:114:1:114:67 | call to splat_followed_by_keyword_param |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:118:1:118:14 | call to positional |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:121:5:121:10 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:122:5:122:10 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:123:5:123:10 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:124:5:124:10 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:125:5:125:10 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | type tracker without call steps | params_flow.rb:128:1:128:61 | call to destruct |
+| params_flow.rb:9:1:12:3 | &block | type tracker without call steps | params_flow.rb:9:1:12:3 | &block |
+| params_flow.rb:9:1:12:3 | positional | type tracker without call steps | params_flow.rb:9:1:12:3 | positional |
+| params_flow.rb:9:1:12:3 | self in positional | type tracker with call steps | params_flow.rb:5:1:7:3 | self in sink |
+| params_flow.rb:9:1:12:3 | self in positional | type tracker without call steps | params_flow.rb:9:1:12:3 | self in positional |
+| params_flow.rb:9:1:12:3 | synthetic *args | type tracker without call steps | params_flow.rb:9:1:12:3 | synthetic *args |
+| params_flow.rb:9:16:9:17 | p1 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:9:16:9:17 | p1 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:9:16:9:17 | p1 | type tracker without call steps | params_flow.rb:9:16:9:17 | p1 |
+| params_flow.rb:9:16:9:17 | p1 | type tracker without call steps | params_flow.rb:9:16:9:17 | p1 |
+| params_flow.rb:9:16:9:17 | p1 | type tracker without call steps with content element 0 | params_flow.rb:10:5:10:11 | * |
+| params_flow.rb:9:20:9:21 | p2 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:9:20:9:21 | p2 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:9:20:9:21 | p2 | type tracker without call steps | params_flow.rb:9:20:9:21 | p2 |
+| params_flow.rb:9:20:9:21 | p2 | type tracker without call steps | params_flow.rb:9:20:9:21 | p2 |
+| params_flow.rb:9:20:9:21 | p2 | type tracker without call steps with content element 0 | params_flow.rb:11:5:11:11 | * |
+| params_flow.rb:10:5:10:11 | * | type tracker without call steps | params_flow.rb:10:5:10:11 | * |
+| params_flow.rb:10:5:10:11 | call to sink | type tracker without call steps | params_flow.rb:10:5:10:11 | call to sink |
+| params_flow.rb:11:5:11:11 | * | type tracker without call steps | params_flow.rb:11:5:11:11 | * |
+| params_flow.rb:11:5:11:11 | call to sink | type tracker without call steps | params_flow.rb:11:5:11:11 | call to sink |
+| params_flow.rb:11:5:11:11 | call to sink | type tracker without call steps | params_flow.rb:14:1:14:30 | call to positional |
+| params_flow.rb:11:5:11:11 | call to sink | type tracker without call steps | params_flow.rb:44:1:44:28 | call to positional |
+| params_flow.rb:11:5:11:11 | call to sink | type tracker without call steps | params_flow.rb:47:1:47:17 | call to positional |
+| params_flow.rb:11:5:11:11 | call to sink | type tracker without call steps | params_flow.rb:118:1:118:14 | call to positional |
+| params_flow.rb:14:1:14:30 | * | type tracker without call steps | params_flow.rb:14:1:14:30 | * |
+| params_flow.rb:14:1:14:30 | call to positional | type tracker without call steps | params_flow.rb:14:1:14:30 | call to positional |
+| params_flow.rb:14:12:14:19 | * | type tracker without call steps | params_flow.rb:14:12:14:19 | * |
+| params_flow.rb:14:12:14:19 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:14:12:14:19 | call to taint | type tracker with call steps | params_flow.rb:9:16:9:17 | p1 |
+| params_flow.rb:14:12:14:19 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:14:12:14:19 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:10:5:10:11 | * |
+| params_flow.rb:14:12:14:19 | call to taint | type tracker without call steps | params_flow.rb:14:12:14:19 | call to taint |
+| params_flow.rb:14:12:14:19 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:14:1:14:30 | * |
+| params_flow.rb:14:18:14:18 | 1 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:14:18:14:18 | 1 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:14:18:14:18 | 1 | type tracker with call steps | params_flow.rb:9:16:9:17 | p1 |
+| params_flow.rb:14:18:14:18 | 1 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:14:18:14:18 | 1 | type tracker with call steps with content element 0 | params_flow.rb:10:5:10:11 | * |
+| params_flow.rb:14:18:14:18 | 1 | type tracker without call steps | params_flow.rb:14:12:14:19 | call to taint |
+| params_flow.rb:14:18:14:18 | 1 | type tracker without call steps | params_flow.rb:14:18:14:18 | 1 |
+| params_flow.rb:14:18:14:18 | 1 | type tracker without call steps with content element 0 | params_flow.rb:14:1:14:30 | * |
+| params_flow.rb:14:18:14:18 | 1 | type tracker without call steps with content element 0 | params_flow.rb:14:12:14:19 | * |
+| params_flow.rb:14:22:14:29 | * | type tracker without call steps | params_flow.rb:14:22:14:29 | * |
+| params_flow.rb:14:22:14:29 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:14:22:14:29 | call to taint | type tracker with call steps | params_flow.rb:9:20:9:21 | p2 |
+| params_flow.rb:14:22:14:29 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:14:22:14:29 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:11:5:11:11 | * |
+| params_flow.rb:14:22:14:29 | call to taint | type tracker without call steps | params_flow.rb:14:22:14:29 | call to taint |
+| params_flow.rb:14:22:14:29 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:14:1:14:30 | * |
+| params_flow.rb:14:28:14:28 | 2 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:14:28:14:28 | 2 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:14:28:14:28 | 2 | type tracker with call steps | params_flow.rb:9:20:9:21 | p2 |
+| params_flow.rb:14:28:14:28 | 2 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:14:28:14:28 | 2 | type tracker with call steps with content element 0 | params_flow.rb:11:5:11:11 | * |
+| params_flow.rb:14:28:14:28 | 2 | type tracker without call steps | params_flow.rb:14:22:14:29 | call to taint |
+| params_flow.rb:14:28:14:28 | 2 | type tracker without call steps | params_flow.rb:14:28:14:28 | 2 |
+| params_flow.rb:14:28:14:28 | 2 | type tracker without call steps with content element 0 | params_flow.rb:14:22:14:29 | * |
+| params_flow.rb:14:28:14:28 | 2 | type tracker without call steps with content element 1 | params_flow.rb:14:1:14:30 | * |
+| params_flow.rb:16:1:19:3 | &block | type tracker without call steps | params_flow.rb:16:1:19:3 | &block |
+| params_flow.rb:16:1:19:3 | **kwargs | type tracker without call steps | params_flow.rb:16:1:19:3 | **kwargs |
+| params_flow.rb:16:1:19:3 | keyword | type tracker without call steps | params_flow.rb:16:1:19:3 | keyword |
+| params_flow.rb:16:1:19:3 | self in keyword | type tracker with call steps | params_flow.rb:5:1:7:3 | self in sink |
+| params_flow.rb:16:1:19:3 | self in keyword | type tracker without call steps | params_flow.rb:16:1:19:3 | self in keyword |
+| params_flow.rb:16:13:16:14 | p1 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:16:13:16:14 | p1 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:16:13:16:14 | p1 | type tracker without call steps | params_flow.rb:16:13:16:14 | p1 |
+| params_flow.rb:16:13:16:14 | p1 | type tracker without call steps | params_flow.rb:16:13:16:14 | p1 |
+| params_flow.rb:16:13:16:14 | p1 | type tracker without call steps with content element 0 | params_flow.rb:17:5:17:11 | * |
+| params_flow.rb:16:18:16:19 | p2 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:16:18:16:19 | p2 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:16:18:16:19 | p2 | type tracker without call steps | params_flow.rb:16:18:16:19 | p2 |
+| params_flow.rb:16:18:16:19 | p2 | type tracker without call steps | params_flow.rb:16:18:16:19 | p2 |
+| params_flow.rb:16:18:16:19 | p2 | type tracker without call steps with content element 0 | params_flow.rb:18:5:18:11 | * |
+| params_flow.rb:17:5:17:11 | * | type tracker without call steps | params_flow.rb:17:5:17:11 | * |
+| params_flow.rb:17:5:17:11 | call to sink | type tracker without call steps | params_flow.rb:17:5:17:11 | call to sink |
+| params_flow.rb:18:5:18:11 | * | type tracker without call steps | params_flow.rb:18:5:18:11 | * |
+| params_flow.rb:18:5:18:11 | call to sink | type tracker without call steps | params_flow.rb:18:5:18:11 | call to sink |
+| params_flow.rb:18:5:18:11 | call to sink | type tracker without call steps | params_flow.rb:21:1:21:35 | call to keyword |
+| params_flow.rb:18:5:18:11 | call to sink | type tracker without call steps | params_flow.rb:22:1:22:35 | call to keyword |
+| params_flow.rb:18:5:18:11 | call to sink | type tracker without call steps | params_flow.rb:23:1:23:41 | call to keyword |
+| params_flow.rb:18:5:18:11 | call to sink | type tracker without call steps | params_flow.rb:41:1:41:30 | call to keyword |
+| params_flow.rb:21:1:21:35 | ** | type tracker with call steps | params_flow.rb:16:1:19:3 | **kwargs |
+| params_flow.rb:21:1:21:35 | ** | type tracker without call steps | params_flow.rb:21:1:21:35 | ** |
+| params_flow.rb:21:1:21:35 | call to keyword | type tracker without call steps | params_flow.rb:21:1:21:35 | call to keyword |
+| params_flow.rb:21:9:21:10 | :p1 | type tracker without call steps | params_flow.rb:21:9:21:10 | :p1 |
+| params_flow.rb:21:9:21:20 | Pair | type tracker without call steps | params_flow.rb:21:9:21:20 | Pair |
+| params_flow.rb:21:13:21:20 | * | type tracker without call steps | params_flow.rb:21:13:21:20 | * |
+| params_flow.rb:21:13:21:20 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:21:13:21:20 | call to taint | type tracker with call steps | params_flow.rb:16:13:16:14 | p1 |
+| params_flow.rb:21:13:21:20 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:21:13:21:20 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:17:5:17:11 | * |
+| params_flow.rb:21:13:21:20 | call to taint | type tracker with call steps with content element :p1 | params_flow.rb:16:1:19:3 | **kwargs |
+| params_flow.rb:21:13:21:20 | call to taint | type tracker without call steps | params_flow.rb:21:13:21:20 | call to taint |
+| params_flow.rb:21:13:21:20 | call to taint | type tracker without call steps with content element :p1 | params_flow.rb:21:1:21:35 | ** |
+| params_flow.rb:21:19:21:19 | 3 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:21:19:21:19 | 3 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:21:19:21:19 | 3 | type tracker with call steps | params_flow.rb:16:13:16:14 | p1 |
+| params_flow.rb:21:19:21:19 | 3 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:21:19:21:19 | 3 | type tracker with call steps with content element 0 | params_flow.rb:17:5:17:11 | * |
+| params_flow.rb:21:19:21:19 | 3 | type tracker with call steps with content element :p1 | params_flow.rb:16:1:19:3 | **kwargs |
+| params_flow.rb:21:19:21:19 | 3 | type tracker without call steps | params_flow.rb:21:13:21:20 | call to taint |
+| params_flow.rb:21:19:21:19 | 3 | type tracker without call steps | params_flow.rb:21:19:21:19 | 3 |
+| params_flow.rb:21:19:21:19 | 3 | type tracker without call steps with content element 0 | params_flow.rb:21:13:21:20 | * |
+| params_flow.rb:21:19:21:19 | 3 | type tracker without call steps with content element :p1 | params_flow.rb:21:1:21:35 | ** |
+| params_flow.rb:21:23:21:24 | :p2 | type tracker without call steps | params_flow.rb:21:23:21:24 | :p2 |
+| params_flow.rb:21:23:21:34 | Pair | type tracker without call steps | params_flow.rb:21:23:21:34 | Pair |
+| params_flow.rb:21:27:21:34 | * | type tracker without call steps | params_flow.rb:21:27:21:34 | * |
+| params_flow.rb:21:27:21:34 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:21:27:21:34 | call to taint | type tracker with call steps | params_flow.rb:16:18:16:19 | p2 |
+| params_flow.rb:21:27:21:34 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:21:27:21:34 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:18:5:18:11 | * |
+| params_flow.rb:21:27:21:34 | call to taint | type tracker with call steps with content element :p2 | params_flow.rb:16:1:19:3 | **kwargs |
+| params_flow.rb:21:27:21:34 | call to taint | type tracker without call steps | params_flow.rb:21:27:21:34 | call to taint |
+| params_flow.rb:21:27:21:34 | call to taint | type tracker without call steps with content element :p2 | params_flow.rb:21:1:21:35 | ** |
+| params_flow.rb:21:33:21:33 | 4 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:21:33:21:33 | 4 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:21:33:21:33 | 4 | type tracker with call steps | params_flow.rb:16:18:16:19 | p2 |
+| params_flow.rb:21:33:21:33 | 4 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:21:33:21:33 | 4 | type tracker with call steps with content element 0 | params_flow.rb:18:5:18:11 | * |
+| params_flow.rb:21:33:21:33 | 4 | type tracker with call steps with content element :p2 | params_flow.rb:16:1:19:3 | **kwargs |
+| params_flow.rb:21:33:21:33 | 4 | type tracker without call steps | params_flow.rb:21:27:21:34 | call to taint |
+| params_flow.rb:21:33:21:33 | 4 | type tracker without call steps | params_flow.rb:21:33:21:33 | 4 |
+| params_flow.rb:21:33:21:33 | 4 | type tracker without call steps with content element 0 | params_flow.rb:21:27:21:34 | * |
+| params_flow.rb:21:33:21:33 | 4 | type tracker without call steps with content element :p2 | params_flow.rb:21:1:21:35 | ** |
+| params_flow.rb:22:1:22:35 | ** | type tracker with call steps | params_flow.rb:16:1:19:3 | **kwargs |
+| params_flow.rb:22:1:22:35 | ** | type tracker without call steps | params_flow.rb:22:1:22:35 | ** |
+| params_flow.rb:22:1:22:35 | call to keyword | type tracker without call steps | params_flow.rb:22:1:22:35 | call to keyword |
+| params_flow.rb:22:9:22:10 | :p2 | type tracker without call steps | params_flow.rb:22:9:22:10 | :p2 |
+| params_flow.rb:22:9:22:20 | Pair | type tracker without call steps | params_flow.rb:22:9:22:20 | Pair |
+| params_flow.rb:22:13:22:20 | * | type tracker without call steps | params_flow.rb:22:13:22:20 | * |
+| params_flow.rb:22:13:22:20 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:22:13:22:20 | call to taint | type tracker with call steps | params_flow.rb:16:18:16:19 | p2 |
+| params_flow.rb:22:13:22:20 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:22:13:22:20 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:18:5:18:11 | * |
+| params_flow.rb:22:13:22:20 | call to taint | type tracker with call steps with content element :p2 | params_flow.rb:16:1:19:3 | **kwargs |
+| params_flow.rb:22:13:22:20 | call to taint | type tracker without call steps | params_flow.rb:22:13:22:20 | call to taint |
+| params_flow.rb:22:13:22:20 | call to taint | type tracker without call steps with content element :p2 | params_flow.rb:22:1:22:35 | ** |
+| params_flow.rb:22:19:22:19 | 5 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:22:19:22:19 | 5 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:22:19:22:19 | 5 | type tracker with call steps | params_flow.rb:16:18:16:19 | p2 |
+| params_flow.rb:22:19:22:19 | 5 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:22:19:22:19 | 5 | type tracker with call steps with content element 0 | params_flow.rb:18:5:18:11 | * |
+| params_flow.rb:22:19:22:19 | 5 | type tracker with call steps with content element :p2 | params_flow.rb:16:1:19:3 | **kwargs |
+| params_flow.rb:22:19:22:19 | 5 | type tracker without call steps | params_flow.rb:22:13:22:20 | call to taint |
+| params_flow.rb:22:19:22:19 | 5 | type tracker without call steps | params_flow.rb:22:19:22:19 | 5 |
+| params_flow.rb:22:19:22:19 | 5 | type tracker without call steps with content element 0 | params_flow.rb:22:13:22:20 | * |
+| params_flow.rb:22:19:22:19 | 5 | type tracker without call steps with content element :p2 | params_flow.rb:22:1:22:35 | ** |
+| params_flow.rb:22:23:22:24 | :p1 | type tracker without call steps | params_flow.rb:22:23:22:24 | :p1 |
+| params_flow.rb:22:23:22:34 | Pair | type tracker without call steps | params_flow.rb:22:23:22:34 | Pair |
+| params_flow.rb:22:27:22:34 | * | type tracker without call steps | params_flow.rb:22:27:22:34 | * |
+| params_flow.rb:22:27:22:34 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:22:27:22:34 | call to taint | type tracker with call steps | params_flow.rb:16:13:16:14 | p1 |
+| params_flow.rb:22:27:22:34 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:22:27:22:34 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:17:5:17:11 | * |
+| params_flow.rb:22:27:22:34 | call to taint | type tracker with call steps with content element :p1 | params_flow.rb:16:1:19:3 | **kwargs |
+| params_flow.rb:22:27:22:34 | call to taint | type tracker without call steps | params_flow.rb:22:27:22:34 | call to taint |
+| params_flow.rb:22:27:22:34 | call to taint | type tracker without call steps with content element :p1 | params_flow.rb:22:1:22:35 | ** |
+| params_flow.rb:22:33:22:33 | 6 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:22:33:22:33 | 6 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:22:33:22:33 | 6 | type tracker with call steps | params_flow.rb:16:13:16:14 | p1 |
+| params_flow.rb:22:33:22:33 | 6 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:22:33:22:33 | 6 | type tracker with call steps with content element 0 | params_flow.rb:17:5:17:11 | * |
+| params_flow.rb:22:33:22:33 | 6 | type tracker with call steps with content element :p1 | params_flow.rb:16:1:19:3 | **kwargs |
+| params_flow.rb:22:33:22:33 | 6 | type tracker without call steps | params_flow.rb:22:27:22:34 | call to taint |
+| params_flow.rb:22:33:22:33 | 6 | type tracker without call steps | params_flow.rb:22:33:22:33 | 6 |
+| params_flow.rb:22:33:22:33 | 6 | type tracker without call steps with content element 0 | params_flow.rb:22:27:22:34 | * |
+| params_flow.rb:22:33:22:33 | 6 | type tracker without call steps with content element :p1 | params_flow.rb:22:1:22:35 | ** |
+| params_flow.rb:23:1:23:41 | ** | type tracker with call steps | params_flow.rb:16:1:19:3 | **kwargs |
+| params_flow.rb:23:1:23:41 | ** | type tracker without call steps | params_flow.rb:23:1:23:41 | ** |
+| params_flow.rb:23:1:23:41 | call to keyword | type tracker without call steps | params_flow.rb:23:1:23:41 | call to keyword |
+| params_flow.rb:23:9:23:11 | :p2 | type tracker without call steps | params_flow.rb:23:9:23:11 | :p2 |
+| params_flow.rb:23:9:23:23 | Pair | type tracker without call steps | params_flow.rb:23:9:23:23 | Pair |
+| params_flow.rb:23:16:23:23 | * | type tracker without call steps | params_flow.rb:23:16:23:23 | * |
+| params_flow.rb:23:16:23:23 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:23:16:23:23 | call to taint | type tracker with call steps | params_flow.rb:16:18:16:19 | p2 |
+| params_flow.rb:23:16:23:23 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:23:16:23:23 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:18:5:18:11 | * |
+| params_flow.rb:23:16:23:23 | call to taint | type tracker with call steps with content element :p2 | params_flow.rb:16:1:19:3 | **kwargs |
+| params_flow.rb:23:16:23:23 | call to taint | type tracker without call steps | params_flow.rb:23:16:23:23 | call to taint |
+| params_flow.rb:23:16:23:23 | call to taint | type tracker without call steps with content element :p2 | params_flow.rb:23:1:23:41 | ** |
+| params_flow.rb:23:22:23:22 | 7 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:23:22:23:22 | 7 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:23:22:23:22 | 7 | type tracker with call steps | params_flow.rb:16:18:16:19 | p2 |
+| params_flow.rb:23:22:23:22 | 7 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:23:22:23:22 | 7 | type tracker with call steps with content element 0 | params_flow.rb:18:5:18:11 | * |
+| params_flow.rb:23:22:23:22 | 7 | type tracker with call steps with content element :p2 | params_flow.rb:16:1:19:3 | **kwargs |
+| params_flow.rb:23:22:23:22 | 7 | type tracker without call steps | params_flow.rb:23:16:23:23 | call to taint |
+| params_flow.rb:23:22:23:22 | 7 | type tracker without call steps | params_flow.rb:23:22:23:22 | 7 |
+| params_flow.rb:23:22:23:22 | 7 | type tracker without call steps with content element 0 | params_flow.rb:23:16:23:23 | * |
+| params_flow.rb:23:22:23:22 | 7 | type tracker without call steps with content element :p2 | params_flow.rb:23:1:23:41 | ** |
+| params_flow.rb:23:26:23:28 | :p1 | type tracker without call steps | params_flow.rb:23:26:23:28 | :p1 |
+| params_flow.rb:23:26:23:40 | Pair | type tracker without call steps | params_flow.rb:23:26:23:40 | Pair |
+| params_flow.rb:23:33:23:40 | * | type tracker without call steps | params_flow.rb:23:33:23:40 | * |
+| params_flow.rb:23:33:23:40 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:23:33:23:40 | call to taint | type tracker with call steps | params_flow.rb:16:13:16:14 | p1 |
+| params_flow.rb:23:33:23:40 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:23:33:23:40 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:17:5:17:11 | * |
+| params_flow.rb:23:33:23:40 | call to taint | type tracker with call steps with content element :p1 | params_flow.rb:16:1:19:3 | **kwargs |
+| params_flow.rb:23:33:23:40 | call to taint | type tracker without call steps | params_flow.rb:23:33:23:40 | call to taint |
+| params_flow.rb:23:33:23:40 | call to taint | type tracker without call steps with content element :p1 | params_flow.rb:23:1:23:41 | ** |
+| params_flow.rb:23:39:23:39 | 8 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:23:39:23:39 | 8 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:23:39:23:39 | 8 | type tracker with call steps | params_flow.rb:16:13:16:14 | p1 |
+| params_flow.rb:23:39:23:39 | 8 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:23:39:23:39 | 8 | type tracker with call steps with content element 0 | params_flow.rb:17:5:17:11 | * |
+| params_flow.rb:23:39:23:39 | 8 | type tracker with call steps with content element :p1 | params_flow.rb:16:1:19:3 | **kwargs |
+| params_flow.rb:23:39:23:39 | 8 | type tracker without call steps | params_flow.rb:23:33:23:40 | call to taint |
+| params_flow.rb:23:39:23:39 | 8 | type tracker without call steps | params_flow.rb:23:39:23:39 | 8 |
+| params_flow.rb:23:39:23:39 | 8 | type tracker without call steps with content element 0 | params_flow.rb:23:33:23:40 | * |
+| params_flow.rb:23:39:23:39 | 8 | type tracker without call steps with content element :p1 | params_flow.rb:23:1:23:41 | ** |
+| params_flow.rb:25:1:31:3 | &block | type tracker without call steps | params_flow.rb:25:1:31:3 | &block |
+| params_flow.rb:25:1:31:3 | **kwargs | type tracker without call steps | params_flow.rb:25:1:31:3 | **kwargs |
+| params_flow.rb:25:1:31:3 | kwargs | type tracker without call steps | params_flow.rb:25:1:31:3 | kwargs |
+| params_flow.rb:25:1:31:3 | self in kwargs | type tracker with call steps | params_flow.rb:5:1:7:3 | self in sink |
+| params_flow.rb:25:1:31:3 | self in kwargs | type tracker without call steps | params_flow.rb:25:1:31:3 | self in kwargs |
+| params_flow.rb:25:12:25:13 | p1 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:25:12:25:13 | p1 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:25:12:25:13 | p1 | type tracker without call steps | params_flow.rb:25:12:25:13 | p1 |
+| params_flow.rb:25:12:25:13 | p1 | type tracker without call steps | params_flow.rb:25:12:25:13 | p1 |
+| params_flow.rb:25:12:25:13 | p1 | type tracker without call steps with content element 0 | params_flow.rb:26:5:26:11 | * |
+| params_flow.rb:25:17:25:24 | **kwargs | type tracker without call steps | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:25:19:25:24 | kwargs | type tracker without call steps | params_flow.rb:25:19:25:24 | kwargs |
+| params_flow.rb:26:5:26:11 | * | type tracker without call steps | params_flow.rb:26:5:26:11 | * |
+| params_flow.rb:26:5:26:11 | call to sink | type tracker without call steps | params_flow.rb:26:5:26:11 | call to sink |
+| params_flow.rb:27:5:27:22 | * | type tracker without call steps | params_flow.rb:27:5:27:22 | * |
+| params_flow.rb:27:5:27:22 | call to sink | type tracker without call steps | params_flow.rb:27:5:27:22 | call to sink |
+| params_flow.rb:27:11:27:21 | * | type tracker without call steps | params_flow.rb:27:11:27:21 | * |
+| params_flow.rb:27:11:27:21 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:27:11:27:21 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:27:11:27:21 | ...[...] | type tracker without call steps | params_flow.rb:27:11:27:21 | ...[...] |
+| params_flow.rb:27:11:27:21 | ...[...] | type tracker without call steps with content element 0 | params_flow.rb:27:5:27:22 | * |
+| params_flow.rb:27:18:27:20 | :p1 | type tracker without call steps | params_flow.rb:27:18:27:20 | :p1 |
+| params_flow.rb:27:18:27:20 | :p1 | type tracker without call steps with content element 0 | params_flow.rb:27:11:27:21 | * |
+| params_flow.rb:28:5:28:22 | * | type tracker without call steps | params_flow.rb:28:5:28:22 | * |
+| params_flow.rb:28:5:28:22 | call to sink | type tracker without call steps | params_flow.rb:28:5:28:22 | call to sink |
+| params_flow.rb:28:11:28:21 | * | type tracker without call steps | params_flow.rb:28:11:28:21 | * |
+| params_flow.rb:28:11:28:21 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:28:11:28:21 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:28:11:28:21 | ...[...] | type tracker without call steps | params_flow.rb:28:11:28:21 | ...[...] |
+| params_flow.rb:28:11:28:21 | ...[...] | type tracker without call steps with content element 0 | params_flow.rb:28:5:28:22 | * |
+| params_flow.rb:28:18:28:20 | :p2 | type tracker without call steps | params_flow.rb:28:18:28:20 | :p2 |
+| params_flow.rb:28:18:28:20 | :p2 | type tracker without call steps with content element 0 | params_flow.rb:28:11:28:21 | * |
+| params_flow.rb:29:5:29:22 | * | type tracker without call steps | params_flow.rb:29:5:29:22 | * |
+| params_flow.rb:29:5:29:22 | call to sink | type tracker without call steps | params_flow.rb:29:5:29:22 | call to sink |
+| params_flow.rb:29:11:29:21 | * | type tracker without call steps | params_flow.rb:29:11:29:21 | * |
+| params_flow.rb:29:11:29:21 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:29:11:29:21 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:29:11:29:21 | ...[...] | type tracker without call steps | params_flow.rb:29:11:29:21 | ...[...] |
+| params_flow.rb:29:11:29:21 | ...[...] | type tracker without call steps with content element 0 | params_flow.rb:29:5:29:22 | * |
+| params_flow.rb:29:18:29:20 | :p3 | type tracker without call steps | params_flow.rb:29:18:29:20 | :p3 |
+| params_flow.rb:29:18:29:20 | :p3 | type tracker without call steps with content element 0 | params_flow.rb:29:11:29:21 | * |
+| params_flow.rb:30:5:30:22 | * | type tracker without call steps | params_flow.rb:30:5:30:22 | * |
+| params_flow.rb:30:5:30:22 | call to sink | type tracker without call steps | params_flow.rb:30:5:30:22 | call to sink |
+| params_flow.rb:30:5:30:22 | call to sink | type tracker without call steps | params_flow.rb:33:1:33:58 | call to kwargs |
+| params_flow.rb:30:5:30:22 | call to sink | type tracker without call steps | params_flow.rb:35:1:35:29 | call to kwargs |
+| params_flow.rb:30:5:30:22 | call to sink | type tracker without call steps | params_flow.rb:38:1:38:14 | call to kwargs |
+| params_flow.rb:30:11:30:21 | * | type tracker without call steps | params_flow.rb:30:11:30:21 | * |
+| params_flow.rb:30:11:30:21 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:30:11:30:21 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:30:11:30:21 | ...[...] | type tracker without call steps | params_flow.rb:30:11:30:21 | ...[...] |
+| params_flow.rb:30:11:30:21 | ...[...] | type tracker without call steps with content element 0 | params_flow.rb:30:5:30:22 | * |
+| params_flow.rb:30:18:30:20 | :p4 | type tracker without call steps | params_flow.rb:30:18:30:20 | :p4 |
+| params_flow.rb:30:18:30:20 | :p4 | type tracker without call steps with content element 0 | params_flow.rb:30:11:30:21 | * |
+| params_flow.rb:33:1:33:58 | ** | type tracker with call steps | params_flow.rb:25:1:31:3 | **kwargs |
+| params_flow.rb:33:1:33:58 | ** | type tracker with call steps | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:33:1:33:58 | ** | type tracker without call steps | params_flow.rb:33:1:33:58 | ** |
+| params_flow.rb:33:1:33:58 | call to kwargs | type tracker without call steps | params_flow.rb:33:1:33:58 | call to kwargs |
+| params_flow.rb:33:8:33:9 | :p1 | type tracker without call steps | params_flow.rb:33:8:33:9 | :p1 |
+| params_flow.rb:33:8:33:19 | Pair | type tracker without call steps | params_flow.rb:33:8:33:19 | Pair |
+| params_flow.rb:33:12:33:19 | * | type tracker without call steps | params_flow.rb:33:12:33:19 | * |
+| params_flow.rb:33:12:33:19 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:33:12:33:19 | call to taint | type tracker with call steps | params_flow.rb:25:12:25:13 | p1 |
+| params_flow.rb:33:12:33:19 | call to taint | type tracker with call steps | params_flow.rb:27:11:27:21 | ...[...] |
+| params_flow.rb:33:12:33:19 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:33:12:33:19 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:26:5:26:11 | * |
+| params_flow.rb:33:12:33:19 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:27:5:27:22 | * |
+| params_flow.rb:33:12:33:19 | call to taint | type tracker with call steps with content element :p1 | params_flow.rb:25:1:31:3 | **kwargs |
+| params_flow.rb:33:12:33:19 | call to taint | type tracker with call steps with content element :p1 | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:33:12:33:19 | call to taint | type tracker without call steps | params_flow.rb:33:12:33:19 | call to taint |
+| params_flow.rb:33:12:33:19 | call to taint | type tracker without call steps with content element :p1 | params_flow.rb:33:1:33:58 | ** |
+| params_flow.rb:33:18:33:18 | 9 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:33:18:33:18 | 9 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:33:18:33:18 | 9 | type tracker with call steps | params_flow.rb:25:12:25:13 | p1 |
+| params_flow.rb:33:18:33:18 | 9 | type tracker with call steps | params_flow.rb:27:11:27:21 | ...[...] |
+| params_flow.rb:33:18:33:18 | 9 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:33:18:33:18 | 9 | type tracker with call steps with content element 0 | params_flow.rb:26:5:26:11 | * |
+| params_flow.rb:33:18:33:18 | 9 | type tracker with call steps with content element 0 | params_flow.rb:27:5:27:22 | * |
+| params_flow.rb:33:18:33:18 | 9 | type tracker with call steps with content element :p1 | params_flow.rb:25:1:31:3 | **kwargs |
+| params_flow.rb:33:18:33:18 | 9 | type tracker with call steps with content element :p1 | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:33:18:33:18 | 9 | type tracker without call steps | params_flow.rb:33:12:33:19 | call to taint |
+| params_flow.rb:33:18:33:18 | 9 | type tracker without call steps | params_flow.rb:33:18:33:18 | 9 |
+| params_flow.rb:33:18:33:18 | 9 | type tracker without call steps with content element 0 | params_flow.rb:33:12:33:19 | * |
+| params_flow.rb:33:18:33:18 | 9 | type tracker without call steps with content element :p1 | params_flow.rb:33:1:33:58 | ** |
+| params_flow.rb:33:22:33:23 | :p2 | type tracker without call steps | params_flow.rb:33:22:33:23 | :p2 |
+| params_flow.rb:33:22:33:34 | Pair | type tracker without call steps | params_flow.rb:33:22:33:34 | Pair |
+| params_flow.rb:33:26:33:34 | * | type tracker without call steps | params_flow.rb:33:26:33:34 | * |
+| params_flow.rb:33:26:33:34 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:33:26:33:34 | call to taint | type tracker with call steps | params_flow.rb:28:11:28:21 | ...[...] |
+| params_flow.rb:33:26:33:34 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:33:26:33:34 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:28:5:28:22 | * |
+| params_flow.rb:33:26:33:34 | call to taint | type tracker with call steps with content element :p2 | params_flow.rb:25:1:31:3 | **kwargs |
+| params_flow.rb:33:26:33:34 | call to taint | type tracker with call steps with content element :p2 | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:33:26:33:34 | call to taint | type tracker without call steps | params_flow.rb:33:26:33:34 | call to taint |
+| params_flow.rb:33:26:33:34 | call to taint | type tracker without call steps with content element :p2 | params_flow.rb:33:1:33:58 | ** |
+| params_flow.rb:33:32:33:33 | 10 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:33:32:33:33 | 10 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:33:32:33:33 | 10 | type tracker with call steps | params_flow.rb:28:11:28:21 | ...[...] |
+| params_flow.rb:33:32:33:33 | 10 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:33:32:33:33 | 10 | type tracker with call steps with content element 0 | params_flow.rb:28:5:28:22 | * |
+| params_flow.rb:33:32:33:33 | 10 | type tracker with call steps with content element :p2 | params_flow.rb:25:1:31:3 | **kwargs |
+| params_flow.rb:33:32:33:33 | 10 | type tracker with call steps with content element :p2 | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:33:32:33:33 | 10 | type tracker without call steps | params_flow.rb:33:26:33:34 | call to taint |
+| params_flow.rb:33:32:33:33 | 10 | type tracker without call steps | params_flow.rb:33:32:33:33 | 10 |
+| params_flow.rb:33:32:33:33 | 10 | type tracker without call steps with content element 0 | params_flow.rb:33:26:33:34 | * |
+| params_flow.rb:33:32:33:33 | 10 | type tracker without call steps with content element :p2 | params_flow.rb:33:1:33:58 | ** |
+| params_flow.rb:33:37:33:38 | :p3 | type tracker without call steps | params_flow.rb:33:37:33:38 | :p3 |
+| params_flow.rb:33:37:33:49 | Pair | type tracker without call steps | params_flow.rb:33:37:33:49 | Pair |
+| params_flow.rb:33:41:33:49 | * | type tracker without call steps | params_flow.rb:33:41:33:49 | * |
+| params_flow.rb:33:41:33:49 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:33:41:33:49 | call to taint | type tracker with call steps | params_flow.rb:29:11:29:21 | ...[...] |
+| params_flow.rb:33:41:33:49 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:33:41:33:49 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:29:5:29:22 | * |
+| params_flow.rb:33:41:33:49 | call to taint | type tracker with call steps with content element :p3 | params_flow.rb:25:1:31:3 | **kwargs |
+| params_flow.rb:33:41:33:49 | call to taint | type tracker with call steps with content element :p3 | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:33:41:33:49 | call to taint | type tracker without call steps | params_flow.rb:33:41:33:49 | call to taint |
+| params_flow.rb:33:41:33:49 | call to taint | type tracker without call steps with content element :p3 | params_flow.rb:33:1:33:58 | ** |
+| params_flow.rb:33:47:33:48 | 11 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:33:47:33:48 | 11 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:33:47:33:48 | 11 | type tracker with call steps | params_flow.rb:29:11:29:21 | ...[...] |
+| params_flow.rb:33:47:33:48 | 11 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:33:47:33:48 | 11 | type tracker with call steps with content element 0 | params_flow.rb:29:5:29:22 | * |
+| params_flow.rb:33:47:33:48 | 11 | type tracker with call steps with content element :p3 | params_flow.rb:25:1:31:3 | **kwargs |
+| params_flow.rb:33:47:33:48 | 11 | type tracker with call steps with content element :p3 | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:33:47:33:48 | 11 | type tracker without call steps | params_flow.rb:33:41:33:49 | call to taint |
+| params_flow.rb:33:47:33:48 | 11 | type tracker without call steps | params_flow.rb:33:47:33:48 | 11 |
+| params_flow.rb:33:47:33:48 | 11 | type tracker without call steps with content element 0 | params_flow.rb:33:41:33:49 | * |
+| params_flow.rb:33:47:33:48 | 11 | type tracker without call steps with content element :p3 | params_flow.rb:33:1:33:58 | ** |
+| params_flow.rb:33:52:33:53 | :p4 | type tracker without call steps | params_flow.rb:33:52:33:53 | :p4 |
+| params_flow.rb:33:52:33:57 | Pair | type tracker without call steps | params_flow.rb:33:52:33:57 | Pair |
+| params_flow.rb:33:56:33:57 | "" | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:33:56:33:57 | "" | type tracker with call steps | params_flow.rb:30:11:30:21 | ...[...] |
+| params_flow.rb:33:56:33:57 | "" | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:33:56:33:57 | "" | type tracker with call steps with content element 0 | params_flow.rb:30:5:30:22 | * |
+| params_flow.rb:33:56:33:57 | "" | type tracker with call steps with content element :p4 | params_flow.rb:25:1:31:3 | **kwargs |
+| params_flow.rb:33:56:33:57 | "" | type tracker with call steps with content element :p4 | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:33:56:33:57 | "" | type tracker without call steps | params_flow.rb:33:56:33:57 | "" |
+| params_flow.rb:33:56:33:57 | "" | type tracker without call steps with content element :p4 | params_flow.rb:33:1:33:58 | ** |
+| params_flow.rb:34:1:34:4 | args | type tracker without call steps | params_flow.rb:34:1:34:4 | args |
+| params_flow.rb:34:8:34:32 | ** | type tracker without call steps | params_flow.rb:34:8:34:32 | ** |
+| params_flow.rb:34:8:34:32 | Hash | type tracker without call steps | params_flow.rb:34:8:34:32 | Hash |
+| params_flow.rb:34:8:34:32 | call to [] | type tracker without call steps | params_flow.rb:34:8:34:32 | call to [] |
+| params_flow.rb:34:10:34:11 | :p3 | type tracker without call steps | params_flow.rb:34:10:34:11 | :p3 |
+| params_flow.rb:34:10:34:22 | Pair | type tracker without call steps | params_flow.rb:34:10:34:22 | Pair |
+| params_flow.rb:34:14:34:22 | * | type tracker without call steps | params_flow.rb:34:14:34:22 | * |
+| params_flow.rb:34:14:34:22 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:34:14:34:22 | call to taint | type tracker with call steps | params_flow.rb:29:11:29:21 | ...[...] |
+| params_flow.rb:34:14:34:22 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:34:14:34:22 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:29:5:29:22 | * |
+| params_flow.rb:34:14:34:22 | call to taint | type tracker with call steps with content element :p3 | params_flow.rb:25:1:31:3 | **kwargs |
+| params_flow.rb:34:14:34:22 | call to taint | type tracker with call steps with content element :p3 | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:34:14:34:22 | call to taint | type tracker without call steps | params_flow.rb:34:14:34:22 | call to taint |
+| params_flow.rb:34:14:34:22 | call to taint | type tracker without call steps with content element :p3 | params_flow.rb:34:8:34:32 | ** |
+| params_flow.rb:34:14:34:22 | call to taint | type tracker without call steps with content element :p3 | params_flow.rb:34:8:34:32 | call to [] |
+| params_flow.rb:34:14:34:22 | call to taint | type tracker without call steps with content element :p3 | params_flow.rb:35:23:35:28 | ** ... |
+| params_flow.rb:34:20:34:21 | 12 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:34:20:34:21 | 12 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:34:20:34:21 | 12 | type tracker with call steps | params_flow.rb:29:11:29:21 | ...[...] |
+| params_flow.rb:34:20:34:21 | 12 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:34:20:34:21 | 12 | type tracker with call steps with content element 0 | params_flow.rb:29:5:29:22 | * |
+| params_flow.rb:34:20:34:21 | 12 | type tracker with call steps with content element :p3 | params_flow.rb:25:1:31:3 | **kwargs |
+| params_flow.rb:34:20:34:21 | 12 | type tracker with call steps with content element :p3 | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:34:20:34:21 | 12 | type tracker without call steps | params_flow.rb:34:14:34:22 | call to taint |
+| params_flow.rb:34:20:34:21 | 12 | type tracker without call steps | params_flow.rb:34:20:34:21 | 12 |
+| params_flow.rb:34:20:34:21 | 12 | type tracker without call steps with content element 0 | params_flow.rb:34:14:34:22 | * |
+| params_flow.rb:34:20:34:21 | 12 | type tracker without call steps with content element :p3 | params_flow.rb:34:8:34:32 | ** |
+| params_flow.rb:34:20:34:21 | 12 | type tracker without call steps with content element :p3 | params_flow.rb:34:8:34:32 | call to [] |
+| params_flow.rb:34:20:34:21 | 12 | type tracker without call steps with content element :p3 | params_flow.rb:35:23:35:28 | ** ... |
+| params_flow.rb:34:25:34:26 | :p4 | type tracker without call steps | params_flow.rb:34:25:34:26 | :p4 |
+| params_flow.rb:34:25:34:30 | Pair | type tracker without call steps | params_flow.rb:34:25:34:30 | Pair |
+| params_flow.rb:34:29:34:30 | "" | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:34:29:34:30 | "" | type tracker with call steps | params_flow.rb:30:11:30:21 | ...[...] |
+| params_flow.rb:34:29:34:30 | "" | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:34:29:34:30 | "" | type tracker with call steps with content element 0 | params_flow.rb:30:5:30:22 | * |
+| params_flow.rb:34:29:34:30 | "" | type tracker with call steps with content element :p4 | params_flow.rb:25:1:31:3 | **kwargs |
+| params_flow.rb:34:29:34:30 | "" | type tracker with call steps with content element :p4 | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:34:29:34:30 | "" | type tracker without call steps | params_flow.rb:34:29:34:30 | "" |
+| params_flow.rb:34:29:34:30 | "" | type tracker without call steps with content element :p4 | params_flow.rb:34:8:34:32 | ** |
+| params_flow.rb:34:29:34:30 | "" | type tracker without call steps with content element :p4 | params_flow.rb:34:8:34:32 | call to [] |
+| params_flow.rb:34:29:34:30 | "" | type tracker without call steps with content element :p4 | params_flow.rb:35:23:35:28 | ** ... |
+| params_flow.rb:35:1:35:29 | ** | type tracker with call steps | params_flow.rb:25:1:31:3 | **kwargs |
+| params_flow.rb:35:1:35:29 | ** | type tracker with call steps | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:35:1:35:29 | ** | type tracker without call steps | params_flow.rb:35:1:35:29 | ** |
+| params_flow.rb:35:1:35:29 | call to kwargs | type tracker without call steps | params_flow.rb:35:1:35:29 | call to kwargs |
+| params_flow.rb:35:8:35:9 | :p1 | type tracker without call steps | params_flow.rb:35:8:35:9 | :p1 |
+| params_flow.rb:35:8:35:20 | Pair | type tracker without call steps | params_flow.rb:35:8:35:20 | Pair |
+| params_flow.rb:35:12:35:20 | * | type tracker without call steps | params_flow.rb:35:12:35:20 | * |
+| params_flow.rb:35:12:35:20 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:35:12:35:20 | call to taint | type tracker with call steps | params_flow.rb:25:12:25:13 | p1 |
+| params_flow.rb:35:12:35:20 | call to taint | type tracker with call steps | params_flow.rb:27:11:27:21 | ...[...] |
+| params_flow.rb:35:12:35:20 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:35:12:35:20 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:26:5:26:11 | * |
+| params_flow.rb:35:12:35:20 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:27:5:27:22 | * |
+| params_flow.rb:35:12:35:20 | call to taint | type tracker with call steps with content element :p1 | params_flow.rb:25:1:31:3 | **kwargs |
+| params_flow.rb:35:12:35:20 | call to taint | type tracker with call steps with content element :p1 | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:35:12:35:20 | call to taint | type tracker without call steps | params_flow.rb:35:12:35:20 | call to taint |
+| params_flow.rb:35:12:35:20 | call to taint | type tracker without call steps with content element :p1 | params_flow.rb:35:1:35:29 | ** |
+| params_flow.rb:35:18:35:19 | 13 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:35:18:35:19 | 13 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:35:18:35:19 | 13 | type tracker with call steps | params_flow.rb:25:12:25:13 | p1 |
+| params_flow.rb:35:18:35:19 | 13 | type tracker with call steps | params_flow.rb:27:11:27:21 | ...[...] |
+| params_flow.rb:35:18:35:19 | 13 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:35:18:35:19 | 13 | type tracker with call steps with content element 0 | params_flow.rb:26:5:26:11 | * |
+| params_flow.rb:35:18:35:19 | 13 | type tracker with call steps with content element 0 | params_flow.rb:27:5:27:22 | * |
+| params_flow.rb:35:18:35:19 | 13 | type tracker with call steps with content element :p1 | params_flow.rb:25:1:31:3 | **kwargs |
+| params_flow.rb:35:18:35:19 | 13 | type tracker with call steps with content element :p1 | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:35:18:35:19 | 13 | type tracker without call steps | params_flow.rb:35:12:35:20 | call to taint |
+| params_flow.rb:35:18:35:19 | 13 | type tracker without call steps | params_flow.rb:35:18:35:19 | 13 |
+| params_flow.rb:35:18:35:19 | 13 | type tracker without call steps with content element 0 | params_flow.rb:35:12:35:20 | * |
+| params_flow.rb:35:18:35:19 | 13 | type tracker without call steps with content element :p1 | params_flow.rb:35:1:35:29 | ** |
+| params_flow.rb:35:23:35:28 | ** ... | type tracker with call steps | params_flow.rb:25:1:31:3 | **kwargs |
+| params_flow.rb:35:23:35:28 | ** ... | type tracker with call steps | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:35:23:35:28 | ** ... | type tracker without call steps | params_flow.rb:35:23:35:28 | ** ... |
+| params_flow.rb:37:1:37:4 | args | type tracker without call steps | params_flow.rb:37:1:37:4 | args |
+| params_flow.rb:37:8:37:44 | ** | type tracker without call steps | params_flow.rb:37:8:37:44 | ** |
+| params_flow.rb:37:8:37:44 | Hash | type tracker without call steps | params_flow.rb:37:8:37:44 | Hash |
+| params_flow.rb:37:8:37:44 | call to [] | type tracker without call steps | params_flow.rb:37:8:37:44 | call to [] |
+| params_flow.rb:37:9:37:11 | :p1 | type tracker without call steps | params_flow.rb:37:9:37:11 | :p1 |
+| params_flow.rb:37:9:37:24 | Pair | type tracker without call steps | params_flow.rb:37:9:37:24 | Pair |
+| params_flow.rb:37:16:37:24 | * | type tracker without call steps | params_flow.rb:37:16:37:24 | * |
+| params_flow.rb:37:16:37:24 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:37:16:37:24 | call to taint | type tracker with call steps | params_flow.rb:27:11:27:21 | ...[...] |
+| params_flow.rb:37:16:37:24 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:37:16:37:24 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:27:5:27:22 | * |
+| params_flow.rb:37:16:37:24 | call to taint | type tracker with call steps with content element :p1 | params_flow.rb:25:1:31:3 | **kwargs |
+| params_flow.rb:37:16:37:24 | call to taint | type tracker with call steps with content element :p1 | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:37:16:37:24 | call to taint | type tracker without call steps | params_flow.rb:37:16:37:24 | call to taint |
+| params_flow.rb:37:16:37:24 | call to taint | type tracker without call steps with content element :p1 | params_flow.rb:37:8:37:44 | ** |
+| params_flow.rb:37:16:37:24 | call to taint | type tracker without call steps with content element :p1 | params_flow.rb:37:8:37:44 | call to [] |
+| params_flow.rb:37:16:37:24 | call to taint | type tracker without call steps with content element :p1 | params_flow.rb:38:8:38:13 | ** ... |
+| params_flow.rb:37:22:37:23 | 14 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:37:22:37:23 | 14 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:37:22:37:23 | 14 | type tracker with call steps | params_flow.rb:27:11:27:21 | ...[...] |
+| params_flow.rb:37:22:37:23 | 14 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:37:22:37:23 | 14 | type tracker with call steps with content element 0 | params_flow.rb:27:5:27:22 | * |
+| params_flow.rb:37:22:37:23 | 14 | type tracker with call steps with content element :p1 | params_flow.rb:25:1:31:3 | **kwargs |
+| params_flow.rb:37:22:37:23 | 14 | type tracker with call steps with content element :p1 | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:37:22:37:23 | 14 | type tracker without call steps | params_flow.rb:37:16:37:24 | call to taint |
+| params_flow.rb:37:22:37:23 | 14 | type tracker without call steps | params_flow.rb:37:22:37:23 | 14 |
+| params_flow.rb:37:22:37:23 | 14 | type tracker without call steps with content element 0 | params_flow.rb:37:16:37:24 | * |
+| params_flow.rb:37:22:37:23 | 14 | type tracker without call steps with content element :p1 | params_flow.rb:37:8:37:44 | ** |
+| params_flow.rb:37:22:37:23 | 14 | type tracker without call steps with content element :p1 | params_flow.rb:37:8:37:44 | call to [] |
+| params_flow.rb:37:22:37:23 | 14 | type tracker without call steps with content element :p1 | params_flow.rb:38:8:38:13 | ** ... |
+| params_flow.rb:37:27:37:29 | :p2 | type tracker without call steps | params_flow.rb:37:27:37:29 | :p2 |
+| params_flow.rb:37:27:37:42 | Pair | type tracker without call steps | params_flow.rb:37:27:37:42 | Pair |
+| params_flow.rb:37:34:37:42 | * | type tracker without call steps | params_flow.rb:37:34:37:42 | * |
+| params_flow.rb:37:34:37:42 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:37:34:37:42 | call to taint | type tracker with call steps | params_flow.rb:28:11:28:21 | ...[...] |
+| params_flow.rb:37:34:37:42 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:37:34:37:42 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:28:5:28:22 | * |
+| params_flow.rb:37:34:37:42 | call to taint | type tracker with call steps with content element :p2 | params_flow.rb:25:1:31:3 | **kwargs |
+| params_flow.rb:37:34:37:42 | call to taint | type tracker with call steps with content element :p2 | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:37:34:37:42 | call to taint | type tracker without call steps | params_flow.rb:37:34:37:42 | call to taint |
+| params_flow.rb:37:34:37:42 | call to taint | type tracker without call steps with content element :p2 | params_flow.rb:37:8:37:44 | ** |
+| params_flow.rb:37:34:37:42 | call to taint | type tracker without call steps with content element :p2 | params_flow.rb:37:8:37:44 | call to [] |
+| params_flow.rb:37:34:37:42 | call to taint | type tracker without call steps with content element :p2 | params_flow.rb:38:8:38:13 | ** ... |
+| params_flow.rb:37:40:37:41 | 15 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:37:40:37:41 | 15 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:37:40:37:41 | 15 | type tracker with call steps | params_flow.rb:28:11:28:21 | ...[...] |
+| params_flow.rb:37:40:37:41 | 15 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:37:40:37:41 | 15 | type tracker with call steps with content element 0 | params_flow.rb:28:5:28:22 | * |
+| params_flow.rb:37:40:37:41 | 15 | type tracker with call steps with content element :p2 | params_flow.rb:25:1:31:3 | **kwargs |
+| params_flow.rb:37:40:37:41 | 15 | type tracker with call steps with content element :p2 | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:37:40:37:41 | 15 | type tracker without call steps | params_flow.rb:37:34:37:42 | call to taint |
+| params_flow.rb:37:40:37:41 | 15 | type tracker without call steps | params_flow.rb:37:40:37:41 | 15 |
+| params_flow.rb:37:40:37:41 | 15 | type tracker without call steps with content element 0 | params_flow.rb:37:34:37:42 | * |
+| params_flow.rb:37:40:37:41 | 15 | type tracker without call steps with content element :p2 | params_flow.rb:37:8:37:44 | ** |
+| params_flow.rb:37:40:37:41 | 15 | type tracker without call steps with content element :p2 | params_flow.rb:37:8:37:44 | call to [] |
+| params_flow.rb:37:40:37:41 | 15 | type tracker without call steps with content element :p2 | params_flow.rb:38:8:38:13 | ** ... |
+| params_flow.rb:38:1:38:14 | call to kwargs | type tracker without call steps | params_flow.rb:38:1:38:14 | call to kwargs |
+| params_flow.rb:38:8:38:13 | ** ... | type tracker with call steps | params_flow.rb:25:1:31:3 | **kwargs |
+| params_flow.rb:38:8:38:13 | ** ... | type tracker with call steps | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:38:8:38:13 | ** ... | type tracker without call steps | params_flow.rb:38:8:38:13 | ** ... |
+| params_flow.rb:40:1:40:4 | args | type tracker without call steps | params_flow.rb:40:1:40:4 | args |
+| params_flow.rb:40:8:40:26 | ** | type tracker without call steps | params_flow.rb:40:8:40:26 | ** |
+| params_flow.rb:40:8:40:26 | Hash | type tracker without call steps | params_flow.rb:40:8:40:26 | Hash |
+| params_flow.rb:40:8:40:26 | call to [] | type tracker without call steps | params_flow.rb:40:8:40:26 | call to [] |
+| params_flow.rb:40:9:40:11 | :p1 | type tracker without call steps | params_flow.rb:40:9:40:11 | :p1 |
+| params_flow.rb:40:9:40:24 | Pair | type tracker without call steps | params_flow.rb:40:9:40:24 | Pair |
+| params_flow.rb:40:16:40:24 | * | type tracker without call steps | params_flow.rb:40:16:40:24 | * |
+| params_flow.rb:40:16:40:24 | call to taint | type tracker with call steps with content element :p1 | params_flow.rb:16:1:19:3 | **kwargs |
+| params_flow.rb:40:16:40:24 | call to taint | type tracker without call steps | params_flow.rb:40:16:40:24 | call to taint |
+| params_flow.rb:40:16:40:24 | call to taint | type tracker without call steps with content element :p1 | params_flow.rb:40:8:40:26 | ** |
+| params_flow.rb:40:16:40:24 | call to taint | type tracker without call steps with content element :p1 | params_flow.rb:40:8:40:26 | call to [] |
+| params_flow.rb:40:16:40:24 | call to taint | type tracker without call steps with content element :p1 | params_flow.rb:41:24:41:29 | ** ... |
+| params_flow.rb:40:22:40:23 | 16 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:40:22:40:23 | 16 | type tracker with call steps with content element :p1 | params_flow.rb:16:1:19:3 | **kwargs |
+| params_flow.rb:40:22:40:23 | 16 | type tracker without call steps | params_flow.rb:40:16:40:24 | call to taint |
+| params_flow.rb:40:22:40:23 | 16 | type tracker without call steps | params_flow.rb:40:22:40:23 | 16 |
+| params_flow.rb:40:22:40:23 | 16 | type tracker without call steps with content element 0 | params_flow.rb:40:16:40:24 | * |
+| params_flow.rb:40:22:40:23 | 16 | type tracker without call steps with content element :p1 | params_flow.rb:40:8:40:26 | ** |
+| params_flow.rb:40:22:40:23 | 16 | type tracker without call steps with content element :p1 | params_flow.rb:40:8:40:26 | call to [] |
+| params_flow.rb:40:22:40:23 | 16 | type tracker without call steps with content element :p1 | params_flow.rb:41:24:41:29 | ** ... |
+| params_flow.rb:41:1:41:30 | ** | type tracker with call steps | params_flow.rb:16:1:19:3 | **kwargs |
+| params_flow.rb:41:1:41:30 | ** | type tracker without call steps | params_flow.rb:41:1:41:30 | ** |
+| params_flow.rb:41:1:41:30 | call to keyword | type tracker without call steps | params_flow.rb:41:1:41:30 | call to keyword |
+| params_flow.rb:41:9:41:10 | :p2 | type tracker without call steps | params_flow.rb:41:9:41:10 | :p2 |
+| params_flow.rb:41:9:41:21 | Pair | type tracker without call steps | params_flow.rb:41:9:41:21 | Pair |
+| params_flow.rb:41:13:41:21 | * | type tracker without call steps | params_flow.rb:41:13:41:21 | * |
+| params_flow.rb:41:13:41:21 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:41:13:41:21 | call to taint | type tracker with call steps | params_flow.rb:16:18:16:19 | p2 |
+| params_flow.rb:41:13:41:21 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:41:13:41:21 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:18:5:18:11 | * |
+| params_flow.rb:41:13:41:21 | call to taint | type tracker with call steps with content element :p2 | params_flow.rb:16:1:19:3 | **kwargs |
+| params_flow.rb:41:13:41:21 | call to taint | type tracker without call steps | params_flow.rb:41:13:41:21 | call to taint |
+| params_flow.rb:41:13:41:21 | call to taint | type tracker without call steps with content element :p2 | params_flow.rb:41:1:41:30 | ** |
+| params_flow.rb:41:19:41:20 | 17 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:41:19:41:20 | 17 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:41:19:41:20 | 17 | type tracker with call steps | params_flow.rb:16:18:16:19 | p2 |
+| params_flow.rb:41:19:41:20 | 17 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:41:19:41:20 | 17 | type tracker with call steps with content element 0 | params_flow.rb:18:5:18:11 | * |
+| params_flow.rb:41:19:41:20 | 17 | type tracker with call steps with content element :p2 | params_flow.rb:16:1:19:3 | **kwargs |
+| params_flow.rb:41:19:41:20 | 17 | type tracker without call steps | params_flow.rb:41:13:41:21 | call to taint |
+| params_flow.rb:41:19:41:20 | 17 | type tracker without call steps | params_flow.rb:41:19:41:20 | 17 |
+| params_flow.rb:41:19:41:20 | 17 | type tracker without call steps with content element 0 | params_flow.rb:41:13:41:21 | * |
+| params_flow.rb:41:19:41:20 | 17 | type tracker without call steps with content element :p2 | params_flow.rb:41:1:41:30 | ** |
+| params_flow.rb:41:24:41:29 | ** ... | type tracker with call steps | params_flow.rb:16:1:19:3 | **kwargs |
+| params_flow.rb:41:24:41:29 | ** ... | type tracker without call steps | params_flow.rb:41:24:41:29 | ** ... |
+| params_flow.rb:43:1:43:4 | args | type tracker without call steps | params_flow.rb:43:1:43:4 | args |
+| params_flow.rb:43:8:43:18 | * | type tracker without call steps | params_flow.rb:43:8:43:18 | * |
+| params_flow.rb:43:8:43:18 | Array | type tracker without call steps | params_flow.rb:43:8:43:18 | Array |
+| params_flow.rb:43:8:43:18 | call to [] | type tracker without call steps | params_flow.rb:43:8:43:18 | call to [] |
+| params_flow.rb:43:8:43:18 | call to [] | type tracker without call steps with content element 0 or unknown | params_flow.rb:44:23:44:27 | * ... |
+| params_flow.rb:43:9:43:17 | * | type tracker without call steps | params_flow.rb:43:9:43:17 | * |
+| params_flow.rb:43:9:43:17 | call to taint | type tracker without call steps | params_flow.rb:43:9:43:17 | call to taint |
+| params_flow.rb:43:9:43:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:43:8:43:18 | * |
+| params_flow.rb:43:9:43:17 | call to taint | type tracker without call steps with content element 0 or unknown | params_flow.rb:43:8:43:18 | call to [] |
+| params_flow.rb:43:9:43:17 | call to taint | type tracker without call steps with content element 0 or unknown | params_flow.rb:44:23:44:27 | * ... |
+| params_flow.rb:43:15:43:16 | 17 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:43:15:43:16 | 17 | type tracker without call steps | params_flow.rb:43:9:43:17 | call to taint |
+| params_flow.rb:43:15:43:16 | 17 | type tracker without call steps | params_flow.rb:43:15:43:16 | 17 |
+| params_flow.rb:43:15:43:16 | 17 | type tracker without call steps with content element 0 | params_flow.rb:43:8:43:18 | * |
+| params_flow.rb:43:15:43:16 | 17 | type tracker without call steps with content element 0 | params_flow.rb:43:9:43:17 | * |
+| params_flow.rb:43:15:43:16 | 17 | type tracker without call steps with content element 0 or unknown | params_flow.rb:43:8:43:18 | call to [] |
+| params_flow.rb:43:15:43:16 | 17 | type tracker without call steps with content element 0 or unknown | params_flow.rb:44:23:44:27 | * ... |
+| params_flow.rb:44:1:44:28 | call to positional | type tracker without call steps | params_flow.rb:44:1:44:28 | call to positional |
+| params_flow.rb:44:12:44:20 | * | type tracker without call steps | params_flow.rb:44:12:44:20 | * |
+| params_flow.rb:44:12:44:20 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:44:12:44:20 | call to taint | type tracker with call steps | params_flow.rb:9:16:9:17 | p1 |
+| params_flow.rb:44:12:44:20 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:44:12:44:20 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:10:5:10:11 | * |
+| params_flow.rb:44:12:44:20 | call to taint | type tracker without call steps | params_flow.rb:44:12:44:20 | call to taint |
+| params_flow.rb:44:18:44:19 | 16 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:44:18:44:19 | 16 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:44:18:44:19 | 16 | type tracker with call steps | params_flow.rb:9:16:9:17 | p1 |
+| params_flow.rb:44:18:44:19 | 16 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:44:18:44:19 | 16 | type tracker with call steps with content element 0 | params_flow.rb:10:5:10:11 | * |
+| params_flow.rb:44:18:44:19 | 16 | type tracker without call steps | params_flow.rb:44:12:44:20 | call to taint |
+| params_flow.rb:44:18:44:19 | 16 | type tracker without call steps | params_flow.rb:44:18:44:19 | 16 |
+| params_flow.rb:44:18:44:19 | 16 | type tracker without call steps with content element 0 | params_flow.rb:44:12:44:20 | * |
+| params_flow.rb:44:23:44:27 | * ... | type tracker without call steps | params_flow.rb:44:23:44:27 | * ... |
+| params_flow.rb:46:1:46:4 | args | type tracker without call steps | params_flow.rb:46:1:46:4 | args |
+| params_flow.rb:46:8:46:29 | * | type tracker without call steps | params_flow.rb:46:8:46:29 | * |
+| params_flow.rb:46:8:46:29 | Array | type tracker without call steps | params_flow.rb:46:8:46:29 | Array |
+| params_flow.rb:46:8:46:29 | call to [] | type tracker with call steps with content element 0 or unknown | params_flow.rb:9:1:12:3 | synthetic *args |
+| params_flow.rb:46:8:46:29 | call to [] | type tracker without call steps | params_flow.rb:46:8:46:29 | call to [] |
+| params_flow.rb:46:8:46:29 | call to [] | type tracker without call steps with content element 0 or unknown | params_flow.rb:47:12:47:16 | * ... |
+| params_flow.rb:46:9:46:17 | * | type tracker without call steps | params_flow.rb:46:9:46:17 | * |
+| params_flow.rb:46:9:46:17 | call to taint | type tracker with call steps with content element 0 or unknown | params_flow.rb:9:1:12:3 | synthetic *args |
+| params_flow.rb:46:9:46:17 | call to taint | type tracker without call steps | params_flow.rb:46:9:46:17 | call to taint |
+| params_flow.rb:46:9:46:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:46:8:46:29 | * |
+| params_flow.rb:46:9:46:17 | call to taint | type tracker without call steps with content element 0 or unknown | params_flow.rb:46:8:46:29 | call to [] |
+| params_flow.rb:46:9:46:17 | call to taint | type tracker without call steps with content element 0 or unknown | params_flow.rb:47:12:47:16 | * ... |
+| params_flow.rb:46:15:46:16 | 18 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:46:15:46:16 | 18 | type tracker with call steps with content element 0 or unknown | params_flow.rb:9:1:12:3 | synthetic *args |
+| params_flow.rb:46:15:46:16 | 18 | type tracker without call steps | params_flow.rb:46:9:46:17 | call to taint |
+| params_flow.rb:46:15:46:16 | 18 | type tracker without call steps | params_flow.rb:46:15:46:16 | 18 |
+| params_flow.rb:46:15:46:16 | 18 | type tracker without call steps with content element 0 | params_flow.rb:46:8:46:29 | * |
+| params_flow.rb:46:15:46:16 | 18 | type tracker without call steps with content element 0 | params_flow.rb:46:9:46:17 | * |
+| params_flow.rb:46:15:46:16 | 18 | type tracker without call steps with content element 0 or unknown | params_flow.rb:46:8:46:29 | call to [] |
+| params_flow.rb:46:15:46:16 | 18 | type tracker without call steps with content element 0 or unknown | params_flow.rb:47:12:47:16 | * ... |
+| params_flow.rb:46:20:46:28 | * | type tracker without call steps | params_flow.rb:46:20:46:28 | * |
+| params_flow.rb:46:20:46:28 | call to taint | type tracker with call steps with content element 1 or unknown | params_flow.rb:9:1:12:3 | synthetic *args |
+| params_flow.rb:46:20:46:28 | call to taint | type tracker without call steps | params_flow.rb:46:20:46:28 | call to taint |
+| params_flow.rb:46:20:46:28 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:46:8:46:29 | * |
+| params_flow.rb:46:20:46:28 | call to taint | type tracker without call steps with content element 1 or unknown | params_flow.rb:46:8:46:29 | call to [] |
+| params_flow.rb:46:20:46:28 | call to taint | type tracker without call steps with content element 1 or unknown | params_flow.rb:47:12:47:16 | * ... |
+| params_flow.rb:46:26:46:27 | 19 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:46:26:46:27 | 19 | type tracker with call steps with content element 1 or unknown | params_flow.rb:9:1:12:3 | synthetic *args |
+| params_flow.rb:46:26:46:27 | 19 | type tracker without call steps | params_flow.rb:46:20:46:28 | call to taint |
+| params_flow.rb:46:26:46:27 | 19 | type tracker without call steps | params_flow.rb:46:26:46:27 | 19 |
+| params_flow.rb:46:26:46:27 | 19 | type tracker without call steps with content element 0 | params_flow.rb:46:20:46:28 | * |
+| params_flow.rb:46:26:46:27 | 19 | type tracker without call steps with content element 1 | params_flow.rb:46:8:46:29 | * |
+| params_flow.rb:46:26:46:27 | 19 | type tracker without call steps with content element 1 or unknown | params_flow.rb:46:8:46:29 | call to [] |
+| params_flow.rb:46:26:46:27 | 19 | type tracker without call steps with content element 1 or unknown | params_flow.rb:47:12:47:16 | * ... |
+| params_flow.rb:47:1:47:17 | call to positional | type tracker without call steps | params_flow.rb:47:1:47:17 | call to positional |
+| params_flow.rb:47:12:47:16 | * ... | type tracker with call steps | params_flow.rb:9:1:12:3 | synthetic *args |
+| params_flow.rb:47:12:47:16 | * ... | type tracker without call steps | params_flow.rb:47:12:47:16 | * ... |
+| params_flow.rb:49:1:53:3 | &block | type tracker without call steps | params_flow.rb:49:1:53:3 | &block |
+| params_flow.rb:49:1:53:3 | posargs | type tracker without call steps | params_flow.rb:49:1:53:3 | posargs |
+| params_flow.rb:49:1:53:3 | self in posargs | type tracker with call steps | params_flow.rb:5:1:7:3 | self in sink |
+| params_flow.rb:49:1:53:3 | self in posargs | type tracker without call steps | params_flow.rb:49:1:53:3 | self in posargs |
+| params_flow.rb:49:1:53:3 | synthetic *args | type tracker without call steps | params_flow.rb:49:1:53:3 | synthetic *args |
+| params_flow.rb:49:1:53:3 | synthetic *args | type tracker without call steps | params_flow.rb:49:1:53:3 | synthetic *args |
+| params_flow.rb:49:1:53:3 | synthetic *args[0] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:49:1:53:3 | synthetic *args[0] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:49:1:53:3 | synthetic *args[0] | type tracker without call steps | params_flow.rb:49:1:53:3 | synthetic *args[0] |
+| params_flow.rb:49:1:53:3 | synthetic *args[0] | type tracker without call steps | params_flow.rb:51:11:51:20 | ...[...] |
+| params_flow.rb:49:1:53:3 | synthetic *args[0] | type tracker without call steps with content element 0 | params_flow.rb:49:17:49:24 | *posargs |
+| params_flow.rb:49:1:53:3 | synthetic *args[0] | type tracker without call steps with content element 0 | params_flow.rb:51:5:51:21 | * |
+| params_flow.rb:49:1:53:3 | synthetic *args[1] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:49:1:53:3 | synthetic *args[1] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:49:1:53:3 | synthetic *args[1] | type tracker without call steps | params_flow.rb:49:1:53:3 | synthetic *args[1] |
+| params_flow.rb:49:1:53:3 | synthetic *args[1] | type tracker without call steps | params_flow.rb:52:11:52:20 | ...[...] |
+| params_flow.rb:49:1:53:3 | synthetic *args[1] | type tracker without call steps with content element 0 | params_flow.rb:52:5:52:21 | * |
+| params_flow.rb:49:1:53:3 | synthetic *args[1] | type tracker without call steps with content element 1 | params_flow.rb:49:17:49:24 | *posargs |
+| params_flow.rb:49:1:53:3 | synthetic *args[2] | type tracker without call steps | params_flow.rb:49:1:53:3 | synthetic *args[2] |
+| params_flow.rb:49:1:53:3 | synthetic *args[2] | type tracker without call steps with content element 2 | params_flow.rb:49:17:49:24 | *posargs |
+| params_flow.rb:49:1:53:3 | synthetic *args[3] | type tracker without call steps | params_flow.rb:49:1:53:3 | synthetic *args[3] |
+| params_flow.rb:49:1:53:3 | synthetic *args[3] | type tracker without call steps with content element 3 | params_flow.rb:49:17:49:24 | *posargs |
+| params_flow.rb:49:1:53:3 | synthetic *args[4] | type tracker without call steps | params_flow.rb:49:1:53:3 | synthetic *args[4] |
+| params_flow.rb:49:1:53:3 | synthetic *args[4] | type tracker without call steps with content element 4 | params_flow.rb:49:17:49:24 | *posargs |
+| params_flow.rb:49:1:53:3 | synthetic *args[5] | type tracker without call steps | params_flow.rb:49:1:53:3 | synthetic *args[5] |
+| params_flow.rb:49:1:53:3 | synthetic *args[5] | type tracker without call steps with content element 5 | params_flow.rb:49:17:49:24 | *posargs |
+| params_flow.rb:49:1:53:3 | synthetic *args[6] | type tracker without call steps | params_flow.rb:49:1:53:3 | synthetic *args[6] |
+| params_flow.rb:49:1:53:3 | synthetic *args[6] | type tracker without call steps with content element 6 | params_flow.rb:49:17:49:24 | *posargs |
+| params_flow.rb:49:1:53:3 | synthetic *args[7] | type tracker without call steps | params_flow.rb:49:1:53:3 | synthetic *args[7] |
+| params_flow.rb:49:1:53:3 | synthetic *args[7] | type tracker without call steps with content element 7 | params_flow.rb:49:17:49:24 | *posargs |
+| params_flow.rb:49:1:53:3 | synthetic *args[8] | type tracker without call steps | params_flow.rb:49:1:53:3 | synthetic *args[8] |
+| params_flow.rb:49:1:53:3 | synthetic *args[8] | type tracker without call steps with content element 8 | params_flow.rb:49:17:49:24 | *posargs |
+| params_flow.rb:49:1:53:3 | synthetic *args[9] | type tracker without call steps | params_flow.rb:49:1:53:3 | synthetic *args[9] |
+| params_flow.rb:49:1:53:3 | synthetic *args[9] | type tracker without call steps with content element 9 | params_flow.rb:49:17:49:24 | *posargs |
+| params_flow.rb:49:1:53:3 | synthetic *args[10] | type tracker without call steps | params_flow.rb:49:1:53:3 | synthetic *args[10] |
+| params_flow.rb:49:1:53:3 | synthetic *args[10] | type tracker without call steps with content element 10 | params_flow.rb:49:17:49:24 | *posargs |
+| params_flow.rb:49:13:49:14 | p1 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:49:13:49:14 | p1 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:49:13:49:14 | p1 | type tracker without call steps | params_flow.rb:49:13:49:14 | p1 |
+| params_flow.rb:49:13:49:14 | p1 | type tracker without call steps | params_flow.rb:49:13:49:14 | p1 |
+| params_flow.rb:49:13:49:14 | p1 | type tracker without call steps with content element 0 | params_flow.rb:50:5:50:11 | * |
+| params_flow.rb:49:17:49:24 | *posargs | type tracker without call steps | params_flow.rb:49:17:49:24 | *posargs |
+| params_flow.rb:49:18:49:24 | posargs | type tracker without call steps | params_flow.rb:49:18:49:24 | posargs |
+| params_flow.rb:50:5:50:11 | * | type tracker without call steps | params_flow.rb:50:5:50:11 | * |
+| params_flow.rb:50:5:50:11 | call to sink | type tracker without call steps | params_flow.rb:50:5:50:11 | call to sink |
+| params_flow.rb:51:5:51:21 | * | type tracker without call steps | params_flow.rb:51:5:51:21 | * |
+| params_flow.rb:51:5:51:21 | call to sink | type tracker without call steps | params_flow.rb:51:5:51:21 | call to sink |
+| params_flow.rb:51:11:51:20 | * | type tracker without call steps | params_flow.rb:51:11:51:20 | * |
+| params_flow.rb:51:11:51:20 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:51:11:51:20 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:51:11:51:20 | ...[...] | type tracker without call steps | params_flow.rb:51:11:51:20 | ...[...] |
+| params_flow.rb:51:11:51:20 | ...[...] | type tracker without call steps with content element 0 | params_flow.rb:51:5:51:21 | * |
+| params_flow.rb:51:19:51:19 | 0 | type tracker without call steps | params_flow.rb:51:19:51:19 | 0 |
+| params_flow.rb:51:19:51:19 | 0 | type tracker without call steps with content element 0 | params_flow.rb:51:11:51:20 | * |
+| params_flow.rb:52:5:52:21 | * | type tracker without call steps | params_flow.rb:52:5:52:21 | * |
+| params_flow.rb:52:5:52:21 | call to sink | type tracker without call steps | params_flow.rb:52:5:52:21 | call to sink |
+| params_flow.rb:52:5:52:21 | call to sink | type tracker without call steps | params_flow.rb:55:1:55:29 | call to posargs |
+| params_flow.rb:52:5:52:21 | call to sink | type tracker without call steps | params_flow.rb:58:1:58:25 | call to posargs |
+| params_flow.rb:52:5:52:21 | call to sink | type tracker without call steps | params_flow.rb:61:1:61:14 | call to posargs |
+| params_flow.rb:52:11:52:20 | * | type tracker without call steps | params_flow.rb:52:11:52:20 | * |
+| params_flow.rb:52:11:52:20 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:52:11:52:20 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:52:11:52:20 | ...[...] | type tracker without call steps | params_flow.rb:52:11:52:20 | ...[...] |
+| params_flow.rb:52:11:52:20 | ...[...] | type tracker without call steps with content element 0 | params_flow.rb:52:5:52:21 | * |
+| params_flow.rb:52:19:52:19 | 1 | type tracker without call steps | params_flow.rb:52:19:52:19 | 1 |
+| params_flow.rb:52:19:52:19 | 1 | type tracker without call steps with content element 0 | params_flow.rb:52:11:52:20 | * |
+| params_flow.rb:55:1:55:29 | * | type tracker with call steps | params_flow.rb:49:1:53:3 | synthetic *args |
+| params_flow.rb:55:1:55:29 | * | type tracker without call steps | params_flow.rb:55:1:55:29 | * |
+| params_flow.rb:55:1:55:29 | call to posargs | type tracker without call steps | params_flow.rb:55:1:55:29 | call to posargs |
+| params_flow.rb:55:9:55:17 | * | type tracker without call steps | params_flow.rb:55:9:55:17 | * |
+| params_flow.rb:55:9:55:17 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:55:9:55:17 | call to taint | type tracker with call steps | params_flow.rb:49:13:49:14 | p1 |
+| params_flow.rb:55:9:55:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:55:9:55:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:49:1:53:3 | synthetic *args |
+| params_flow.rb:55:9:55:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:50:5:50:11 | * |
+| params_flow.rb:55:9:55:17 | call to taint | type tracker without call steps | params_flow.rb:55:9:55:17 | call to taint |
+| params_flow.rb:55:9:55:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:55:1:55:29 | * |
+| params_flow.rb:55:15:55:16 | 20 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:55:15:55:16 | 20 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:55:15:55:16 | 20 | type tracker with call steps | params_flow.rb:49:13:49:14 | p1 |
+| params_flow.rb:55:15:55:16 | 20 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:55:15:55:16 | 20 | type tracker with call steps with content element 0 | params_flow.rb:49:1:53:3 | synthetic *args |
+| params_flow.rb:55:15:55:16 | 20 | type tracker with call steps with content element 0 | params_flow.rb:50:5:50:11 | * |
+| params_flow.rb:55:15:55:16 | 20 | type tracker without call steps | params_flow.rb:55:9:55:17 | call to taint |
+| params_flow.rb:55:15:55:16 | 20 | type tracker without call steps | params_flow.rb:55:15:55:16 | 20 |
+| params_flow.rb:55:15:55:16 | 20 | type tracker without call steps with content element 0 | params_flow.rb:55:1:55:29 | * |
+| params_flow.rb:55:15:55:16 | 20 | type tracker without call steps with content element 0 | params_flow.rb:55:9:55:17 | * |
+| params_flow.rb:55:20:55:28 | * | type tracker without call steps | params_flow.rb:55:20:55:28 | * |
+| params_flow.rb:55:20:55:28 | call to taint | type tracker with call steps with content element 1 | params_flow.rb:49:1:53:3 | synthetic *args |
+| params_flow.rb:55:20:55:28 | call to taint | type tracker without call steps | params_flow.rb:55:20:55:28 | call to taint |
+| params_flow.rb:55:20:55:28 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:55:1:55:29 | * |
+| params_flow.rb:55:26:55:27 | 21 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:55:26:55:27 | 21 | type tracker with call steps with content element 1 | params_flow.rb:49:1:53:3 | synthetic *args |
+| params_flow.rb:55:26:55:27 | 21 | type tracker without call steps | params_flow.rb:55:20:55:28 | call to taint |
+| params_flow.rb:55:26:55:27 | 21 | type tracker without call steps | params_flow.rb:55:26:55:27 | 21 |
+| params_flow.rb:55:26:55:27 | 21 | type tracker without call steps with content element 0 | params_flow.rb:55:20:55:28 | * |
+| params_flow.rb:55:26:55:27 | 21 | type tracker without call steps with content element 1 | params_flow.rb:55:1:55:29 | * |
+| params_flow.rb:57:1:57:4 | args | type tracker without call steps | params_flow.rb:57:1:57:4 | args |
+| params_flow.rb:57:8:57:18 | * | type tracker without call steps | params_flow.rb:57:8:57:18 | * |
+| params_flow.rb:57:8:57:18 | Array | type tracker without call steps | params_flow.rb:57:8:57:18 | Array |
+| params_flow.rb:57:8:57:18 | call to [] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:57:8:57:18 | call to [] | type tracker with call steps | params_flow.rb:51:11:51:20 | ...[...] |
+| params_flow.rb:57:8:57:18 | call to [] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:57:8:57:18 | call to [] | type tracker with call steps with content element 0 | params_flow.rb:51:5:51:21 | * |
+| params_flow.rb:57:8:57:18 | call to [] | type tracker with call steps with content element 0 or unknown | params_flow.rb:49:17:49:24 | *posargs |
+| params_flow.rb:57:8:57:18 | call to [] | type tracker without call steps | params_flow.rb:57:8:57:18 | call to [] |
+| params_flow.rb:57:8:57:18 | call to [] | type tracker without call steps with content element 0 or unknown | params_flow.rb:58:20:58:24 | * ... |
+| params_flow.rb:57:9:57:17 | * | type tracker without call steps | params_flow.rb:57:9:57:17 | * |
+| params_flow.rb:57:9:57:17 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:57:9:57:17 | call to taint | type tracker with call steps | params_flow.rb:51:11:51:20 | ...[...] |
+| params_flow.rb:57:9:57:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:57:9:57:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:51:5:51:21 | * |
+| params_flow.rb:57:9:57:17 | call to taint | type tracker with call steps with content element 0 or unknown | params_flow.rb:49:17:49:24 | *posargs |
+| params_flow.rb:57:9:57:17 | call to taint | type tracker without call steps | params_flow.rb:57:9:57:17 | call to taint |
+| params_flow.rb:57:9:57:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:57:8:57:18 | * |
+| params_flow.rb:57:9:57:17 | call to taint | type tracker without call steps with content element 0 or unknown | params_flow.rb:57:8:57:18 | call to [] |
+| params_flow.rb:57:9:57:17 | call to taint | type tracker without call steps with content element 0 or unknown | params_flow.rb:58:20:58:24 | * ... |
+| params_flow.rb:57:15:57:16 | 22 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:57:15:57:16 | 22 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:57:15:57:16 | 22 | type tracker with call steps | params_flow.rb:51:11:51:20 | ...[...] |
+| params_flow.rb:57:15:57:16 | 22 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:57:15:57:16 | 22 | type tracker with call steps with content element 0 | params_flow.rb:51:5:51:21 | * |
+| params_flow.rb:57:15:57:16 | 22 | type tracker with call steps with content element 0 or unknown | params_flow.rb:49:17:49:24 | *posargs |
+| params_flow.rb:57:15:57:16 | 22 | type tracker without call steps | params_flow.rb:57:9:57:17 | call to taint |
+| params_flow.rb:57:15:57:16 | 22 | type tracker without call steps | params_flow.rb:57:15:57:16 | 22 |
+| params_flow.rb:57:15:57:16 | 22 | type tracker without call steps with content element 0 | params_flow.rb:57:8:57:18 | * |
+| params_flow.rb:57:15:57:16 | 22 | type tracker without call steps with content element 0 | params_flow.rb:57:9:57:17 | * |
+| params_flow.rb:57:15:57:16 | 22 | type tracker without call steps with content element 0 or unknown | params_flow.rb:57:8:57:18 | call to [] |
+| params_flow.rb:57:15:57:16 | 22 | type tracker without call steps with content element 0 or unknown | params_flow.rb:58:20:58:24 | * ... |
+| params_flow.rb:58:1:58:25 | call to posargs | type tracker without call steps | params_flow.rb:58:1:58:25 | call to posargs |
+| params_flow.rb:58:9:58:17 | * | type tracker without call steps | params_flow.rb:58:9:58:17 | * |
+| params_flow.rb:58:9:58:17 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:58:9:58:17 | call to taint | type tracker with call steps | params_flow.rb:49:13:49:14 | p1 |
+| params_flow.rb:58:9:58:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:58:9:58:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:50:5:50:11 | * |
+| params_flow.rb:58:9:58:17 | call to taint | type tracker without call steps | params_flow.rb:58:9:58:17 | call to taint |
+| params_flow.rb:58:15:58:16 | 23 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:58:15:58:16 | 23 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:58:15:58:16 | 23 | type tracker with call steps | params_flow.rb:49:13:49:14 | p1 |
+| params_flow.rb:58:15:58:16 | 23 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:58:15:58:16 | 23 | type tracker with call steps with content element 0 | params_flow.rb:50:5:50:11 | * |
+| params_flow.rb:58:15:58:16 | 23 | type tracker without call steps | params_flow.rb:58:9:58:17 | call to taint |
+| params_flow.rb:58:15:58:16 | 23 | type tracker without call steps | params_flow.rb:58:15:58:16 | 23 |
+| params_flow.rb:58:15:58:16 | 23 | type tracker without call steps with content element 0 | params_flow.rb:58:9:58:17 | * |
+| params_flow.rb:58:20:58:24 | * ... | type tracker with call steps | params_flow.rb:49:17:49:24 | *posargs |
+| params_flow.rb:58:20:58:24 | * ... | type tracker without call steps | params_flow.rb:58:20:58:24 | * ... |
+| params_flow.rb:60:1:60:4 | args | type tracker without call steps | params_flow.rb:60:1:60:4 | args |
+| params_flow.rb:60:8:60:29 | * | type tracker without call steps | params_flow.rb:60:8:60:29 | * |
+| params_flow.rb:60:8:60:29 | Array | type tracker without call steps | params_flow.rb:60:8:60:29 | Array |
+| params_flow.rb:60:8:60:29 | call to [] | type tracker with call steps with content element 0 or unknown | params_flow.rb:49:1:53:3 | synthetic *args |
+| params_flow.rb:60:8:60:29 | call to [] | type tracker without call steps | params_flow.rb:60:8:60:29 | call to [] |
+| params_flow.rb:60:8:60:29 | call to [] | type tracker without call steps with content element 0 or unknown | params_flow.rb:61:9:61:13 | * ... |
+| params_flow.rb:60:9:60:17 | * | type tracker without call steps | params_flow.rb:60:9:60:17 | * |
+| params_flow.rb:60:9:60:17 | call to taint | type tracker with call steps with content element 0 or unknown | params_flow.rb:49:1:53:3 | synthetic *args |
+| params_flow.rb:60:9:60:17 | call to taint | type tracker without call steps | params_flow.rb:60:9:60:17 | call to taint |
+| params_flow.rb:60:9:60:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:60:8:60:29 | * |
+| params_flow.rb:60:9:60:17 | call to taint | type tracker without call steps with content element 0 or unknown | params_flow.rb:60:8:60:29 | call to [] |
+| params_flow.rb:60:9:60:17 | call to taint | type tracker without call steps with content element 0 or unknown | params_flow.rb:61:9:61:13 | * ... |
+| params_flow.rb:60:15:60:16 | 24 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:60:15:60:16 | 24 | type tracker with call steps with content element 0 or unknown | params_flow.rb:49:1:53:3 | synthetic *args |
+| params_flow.rb:60:15:60:16 | 24 | type tracker without call steps | params_flow.rb:60:9:60:17 | call to taint |
+| params_flow.rb:60:15:60:16 | 24 | type tracker without call steps | params_flow.rb:60:15:60:16 | 24 |
+| params_flow.rb:60:15:60:16 | 24 | type tracker without call steps with content element 0 | params_flow.rb:60:8:60:29 | * |
+| params_flow.rb:60:15:60:16 | 24 | type tracker without call steps with content element 0 | params_flow.rb:60:9:60:17 | * |
+| params_flow.rb:60:15:60:16 | 24 | type tracker without call steps with content element 0 or unknown | params_flow.rb:60:8:60:29 | call to [] |
+| params_flow.rb:60:15:60:16 | 24 | type tracker without call steps with content element 0 or unknown | params_flow.rb:61:9:61:13 | * ... |
+| params_flow.rb:60:20:60:28 | * | type tracker without call steps | params_flow.rb:60:20:60:28 | * |
+| params_flow.rb:60:20:60:28 | call to taint | type tracker with call steps with content element 1 or unknown | params_flow.rb:49:1:53:3 | synthetic *args |
+| params_flow.rb:60:20:60:28 | call to taint | type tracker without call steps | params_flow.rb:60:20:60:28 | call to taint |
+| params_flow.rb:60:20:60:28 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:60:8:60:29 | * |
+| params_flow.rb:60:20:60:28 | call to taint | type tracker without call steps with content element 1 or unknown | params_flow.rb:60:8:60:29 | call to [] |
+| params_flow.rb:60:20:60:28 | call to taint | type tracker without call steps with content element 1 or unknown | params_flow.rb:61:9:61:13 | * ... |
+| params_flow.rb:60:26:60:27 | 25 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:60:26:60:27 | 25 | type tracker with call steps with content element 1 or unknown | params_flow.rb:49:1:53:3 | synthetic *args |
+| params_flow.rb:60:26:60:27 | 25 | type tracker without call steps | params_flow.rb:60:20:60:28 | call to taint |
+| params_flow.rb:60:26:60:27 | 25 | type tracker without call steps | params_flow.rb:60:26:60:27 | 25 |
+| params_flow.rb:60:26:60:27 | 25 | type tracker without call steps with content element 0 | params_flow.rb:60:20:60:28 | * |
+| params_flow.rb:60:26:60:27 | 25 | type tracker without call steps with content element 1 | params_flow.rb:60:8:60:29 | * |
+| params_flow.rb:60:26:60:27 | 25 | type tracker without call steps with content element 1 or unknown | params_flow.rb:60:8:60:29 | call to [] |
+| params_flow.rb:60:26:60:27 | 25 | type tracker without call steps with content element 1 or unknown | params_flow.rb:61:9:61:13 | * ... |
+| params_flow.rb:61:1:61:14 | call to posargs | type tracker without call steps | params_flow.rb:61:1:61:14 | call to posargs |
+| params_flow.rb:61:9:61:13 | * ... | type tracker with call steps | params_flow.rb:49:1:53:3 | synthetic *args |
+| params_flow.rb:61:9:61:13 | * ... | type tracker without call steps | params_flow.rb:61:9:61:13 | * ... |
+| params_flow.rb:63:1:63:4 | args | type tracker without call steps | params_flow.rb:63:1:63:4 | args |
+| params_flow.rb:63:8:63:16 | * | type tracker without call steps | params_flow.rb:63:8:63:16 | * |
+| params_flow.rb:63:8:63:16 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:63:8:63:16 | call to taint | type tracker with call steps | params_flow.rb:65:10:65:13 | ...[...] |
+| params_flow.rb:63:8:63:16 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:63:8:63:16 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:65:5:65:13 | * |
+| params_flow.rb:63:8:63:16 | call to taint | type tracker with call steps with content element 0 or unknown | params_flow.rb:64:16:64:17 | *x |
+| params_flow.rb:63:8:63:16 | call to taint | type tracker without call steps | params_flow.rb:63:8:63:16 | call to taint |
+| params_flow.rb:63:8:63:16 | call to taint | type tracker without call steps with content element 0 or unknown | params_flow.rb:67:12:67:16 | * ... |
+| params_flow.rb:63:14:63:15 | 26 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:63:14:63:15 | 26 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:63:14:63:15 | 26 | type tracker with call steps | params_flow.rb:65:10:65:13 | ...[...] |
+| params_flow.rb:63:14:63:15 | 26 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:63:14:63:15 | 26 | type tracker with call steps with content element 0 | params_flow.rb:65:5:65:13 | * |
+| params_flow.rb:63:14:63:15 | 26 | type tracker with call steps with content element 0 or unknown | params_flow.rb:64:16:64:17 | *x |
+| params_flow.rb:63:14:63:15 | 26 | type tracker without call steps | params_flow.rb:63:8:63:16 | call to taint |
+| params_flow.rb:63:14:63:15 | 26 | type tracker without call steps | params_flow.rb:63:14:63:15 | 26 |
+| params_flow.rb:63:14:63:15 | 26 | type tracker without call steps with content element 0 | params_flow.rb:63:8:63:16 | * |
+| params_flow.rb:63:14:63:15 | 26 | type tracker without call steps with content element 0 or unknown | params_flow.rb:67:12:67:16 | * ... |
+| params_flow.rb:64:1:66:3 | &block | type tracker without call steps | params_flow.rb:64:1:66:3 | &block |
+| params_flow.rb:64:1:66:3 | self in splatstuff | type tracker with call steps | params_flow.rb:5:1:7:3 | self in sink |
+| params_flow.rb:64:1:66:3 | self in splatstuff | type tracker without call steps | params_flow.rb:64:1:66:3 | self in splatstuff |
+| params_flow.rb:64:1:66:3 | splatstuff | type tracker without call steps | params_flow.rb:64:1:66:3 | splatstuff |
+| params_flow.rb:64:16:64:17 | *x | type tracker without call steps | params_flow.rb:64:16:64:17 | *x |
+| params_flow.rb:64:17:64:17 | x | type tracker without call steps | params_flow.rb:64:17:64:17 | x |
+| params_flow.rb:65:5:65:13 | * | type tracker without call steps | params_flow.rb:65:5:65:13 | * |
+| params_flow.rb:65:5:65:13 | call to sink | type tracker without call steps | params_flow.rb:65:5:65:13 | call to sink |
+| params_flow.rb:65:5:65:13 | call to sink | type tracker without call steps | params_flow.rb:67:1:67:17 | call to splatstuff |
+| params_flow.rb:65:10:65:13 | * | type tracker without call steps | params_flow.rb:65:10:65:13 | * |
+| params_flow.rb:65:10:65:13 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:65:10:65:13 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:65:10:65:13 | ...[...] | type tracker without call steps | params_flow.rb:65:10:65:13 | ...[...] |
+| params_flow.rb:65:10:65:13 | ...[...] | type tracker without call steps with content element 0 | params_flow.rb:65:5:65:13 | * |
+| params_flow.rb:65:12:65:12 | 0 | type tracker without call steps | params_flow.rb:65:12:65:12 | 0 |
+| params_flow.rb:65:12:65:12 | 0 | type tracker without call steps with content element 0 | params_flow.rb:65:10:65:13 | * |
+| params_flow.rb:67:1:67:17 | call to splatstuff | type tracker without call steps | params_flow.rb:67:1:67:17 | call to splatstuff |
+| params_flow.rb:67:12:67:16 | * ... | type tracker with call steps | params_flow.rb:64:16:64:17 | *x |
+| params_flow.rb:67:12:67:16 | * ... | type tracker without call steps | params_flow.rb:67:12:67:16 | * ... |
+| params_flow.rb:69:1:76:3 | &block | type tracker without call steps | params_flow.rb:69:1:76:3 | &block |
+| params_flow.rb:69:1:76:3 | self in splatmid | type tracker with call steps | params_flow.rb:5:1:7:3 | self in sink |
+| params_flow.rb:69:1:76:3 | self in splatmid | type tracker without call steps | params_flow.rb:69:1:76:3 | self in splatmid |
+| params_flow.rb:69:1:76:3 | splatmid | type tracker without call steps | params_flow.rb:69:1:76:3 | splatmid |
+| params_flow.rb:69:1:76:3 | synthetic *args | type tracker without call steps | params_flow.rb:69:1:76:3 | synthetic *args |
+| params_flow.rb:69:14:69:14 | x | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:69:14:69:14 | x | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:69:14:69:14 | x | type tracker without call steps | params_flow.rb:69:14:69:14 | x |
+| params_flow.rb:69:14:69:14 | x | type tracker without call steps | params_flow.rb:69:14:69:14 | x |
+| params_flow.rb:69:14:69:14 | x | type tracker without call steps with content element 0 | params_flow.rb:70:5:70:10 | * |
+| params_flow.rb:69:17:69:17 | y | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:69:17:69:17 | y | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:69:17:69:17 | y | type tracker without call steps | params_flow.rb:69:17:69:17 | y |
+| params_flow.rb:69:17:69:17 | y | type tracker without call steps | params_flow.rb:69:17:69:17 | y |
+| params_flow.rb:69:17:69:17 | y | type tracker without call steps with content element 0 | params_flow.rb:71:5:71:10 | * |
+| params_flow.rb:69:20:69:21 | *z | type tracker without call steps | params_flow.rb:69:20:69:21 | *z |
+| params_flow.rb:69:21:69:21 | z | type tracker without call steps | params_flow.rb:69:21:69:21 | z |
+| params_flow.rb:69:24:69:24 | w | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:69:24:69:24 | w | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:69:24:69:24 | w | type tracker without call steps | params_flow.rb:69:24:69:24 | w |
+| params_flow.rb:69:24:69:24 | w | type tracker without call steps | params_flow.rb:69:24:69:24 | w |
+| params_flow.rb:69:24:69:24 | w | type tracker without call steps with content element 0 | params_flow.rb:74:5:74:10 | * |
+| params_flow.rb:69:27:69:27 | r | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:69:27:69:27 | r | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:69:27:69:27 | r | type tracker without call steps | params_flow.rb:69:27:69:27 | r |
+| params_flow.rb:69:27:69:27 | r | type tracker without call steps | params_flow.rb:69:27:69:27 | r |
+| params_flow.rb:69:27:69:27 | r | type tracker without call steps with content element 0 | params_flow.rb:75:5:75:10 | * |
+| params_flow.rb:70:5:70:10 | * | type tracker without call steps | params_flow.rb:70:5:70:10 | * |
+| params_flow.rb:70:5:70:10 | call to sink | type tracker without call steps | params_flow.rb:70:5:70:10 | call to sink |
+| params_flow.rb:71:5:71:10 | * | type tracker without call steps | params_flow.rb:71:5:71:10 | * |
+| params_flow.rb:71:5:71:10 | call to sink | type tracker without call steps | params_flow.rb:71:5:71:10 | call to sink |
+| params_flow.rb:72:5:72:13 | * | type tracker without call steps | params_flow.rb:72:5:72:13 | * |
+| params_flow.rb:72:5:72:13 | call to sink | type tracker without call steps | params_flow.rb:72:5:72:13 | call to sink |
+| params_flow.rb:72:10:72:13 | * | type tracker without call steps | params_flow.rb:72:10:72:13 | * |
+| params_flow.rb:72:10:72:13 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:72:10:72:13 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:72:10:72:13 | ...[...] | type tracker without call steps | params_flow.rb:72:10:72:13 | ...[...] |
+| params_flow.rb:72:10:72:13 | ...[...] | type tracker without call steps with content element 0 | params_flow.rb:72:5:72:13 | * |
+| params_flow.rb:72:12:72:12 | 0 | type tracker without call steps | params_flow.rb:72:12:72:12 | 0 |
+| params_flow.rb:72:12:72:12 | 0 | type tracker without call steps with content element 0 | params_flow.rb:72:10:72:13 | * |
+| params_flow.rb:73:5:73:13 | * | type tracker without call steps | params_flow.rb:73:5:73:13 | * |
+| params_flow.rb:73:5:73:13 | call to sink | type tracker without call steps | params_flow.rb:73:5:73:13 | call to sink |
+| params_flow.rb:73:10:73:13 | * | type tracker without call steps | params_flow.rb:73:10:73:13 | * |
+| params_flow.rb:73:10:73:13 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:73:10:73:13 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:73:10:73:13 | ...[...] | type tracker without call steps | params_flow.rb:73:10:73:13 | ...[...] |
+| params_flow.rb:73:10:73:13 | ...[...] | type tracker without call steps with content element 0 | params_flow.rb:73:5:73:13 | * |
+| params_flow.rb:73:12:73:12 | 1 | type tracker without call steps | params_flow.rb:73:12:73:12 | 1 |
+| params_flow.rb:73:12:73:12 | 1 | type tracker without call steps with content element 0 | params_flow.rb:73:10:73:13 | * |
+| params_flow.rb:74:5:74:10 | * | type tracker without call steps | params_flow.rb:74:5:74:10 | * |
+| params_flow.rb:74:5:74:10 | call to sink | type tracker without call steps | params_flow.rb:74:5:74:10 | call to sink |
+| params_flow.rb:75:5:75:10 | * | type tracker without call steps | params_flow.rb:75:5:75:10 | * |
+| params_flow.rb:75:5:75:10 | call to sink | type tracker without call steps | params_flow.rb:75:5:75:10 | call to sink |
+| params_flow.rb:75:5:75:10 | call to sink | type tracker without call steps | params_flow.rb:78:1:78:63 | call to splatmid |
+| params_flow.rb:75:5:75:10 | call to sink | type tracker without call steps | params_flow.rb:81:1:81:37 | call to splatmid |
+| params_flow.rb:75:5:75:10 | call to sink | type tracker without call steps | params_flow.rb:96:1:96:88 | call to splatmid |
+| params_flow.rb:78:1:78:63 | * | type tracker without call steps | params_flow.rb:78:1:78:63 | * |
+| params_flow.rb:78:1:78:63 | call to splatmid | type tracker without call steps | params_flow.rb:78:1:78:63 | call to splatmid |
+| params_flow.rb:78:10:78:18 | * | type tracker without call steps | params_flow.rb:78:10:78:18 | * |
+| params_flow.rb:78:10:78:18 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:78:10:78:18 | call to taint | type tracker with call steps | params_flow.rb:69:14:69:14 | x |
+| params_flow.rb:78:10:78:18 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:78:10:78:18 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:70:5:70:10 | * |
+| params_flow.rb:78:10:78:18 | call to taint | type tracker without call steps | params_flow.rb:78:10:78:18 | call to taint |
+| params_flow.rb:78:10:78:18 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:78:1:78:63 | * |
+| params_flow.rb:78:16:78:17 | 27 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:78:16:78:17 | 27 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:78:16:78:17 | 27 | type tracker with call steps | params_flow.rb:69:14:69:14 | x |
+| params_flow.rb:78:16:78:17 | 27 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:78:16:78:17 | 27 | type tracker with call steps with content element 0 | params_flow.rb:70:5:70:10 | * |
+| params_flow.rb:78:16:78:17 | 27 | type tracker without call steps | params_flow.rb:78:10:78:18 | call to taint |
+| params_flow.rb:78:16:78:17 | 27 | type tracker without call steps | params_flow.rb:78:16:78:17 | 27 |
+| params_flow.rb:78:16:78:17 | 27 | type tracker without call steps with content element 0 | params_flow.rb:78:1:78:63 | * |
+| params_flow.rb:78:16:78:17 | 27 | type tracker without call steps with content element 0 | params_flow.rb:78:10:78:18 | * |
+| params_flow.rb:78:21:78:29 | * | type tracker without call steps | params_flow.rb:78:21:78:29 | * |
+| params_flow.rb:78:21:78:29 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:78:21:78:29 | call to taint | type tracker with call steps | params_flow.rb:69:17:69:17 | y |
+| params_flow.rb:78:21:78:29 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:78:21:78:29 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:71:5:71:10 | * |
+| params_flow.rb:78:21:78:29 | call to taint | type tracker without call steps | params_flow.rb:78:21:78:29 | call to taint |
+| params_flow.rb:78:21:78:29 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:78:1:78:63 | * |
+| params_flow.rb:78:27:78:28 | 28 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:78:27:78:28 | 28 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:78:27:78:28 | 28 | type tracker with call steps | params_flow.rb:69:17:69:17 | y |
+| params_flow.rb:78:27:78:28 | 28 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:78:27:78:28 | 28 | type tracker with call steps with content element 0 | params_flow.rb:71:5:71:10 | * |
+| params_flow.rb:78:27:78:28 | 28 | type tracker without call steps | params_flow.rb:78:21:78:29 | call to taint |
+| params_flow.rb:78:27:78:28 | 28 | type tracker without call steps | params_flow.rb:78:27:78:28 | 28 |
+| params_flow.rb:78:27:78:28 | 28 | type tracker without call steps with content element 0 | params_flow.rb:78:21:78:29 | * |
+| params_flow.rb:78:27:78:28 | 28 | type tracker without call steps with content element 1 | params_flow.rb:78:1:78:63 | * |
+| params_flow.rb:78:32:78:40 | * | type tracker without call steps | params_flow.rb:78:32:78:40 | * |
+| params_flow.rb:78:32:78:40 | call to taint | type tracker without call steps | params_flow.rb:78:32:78:40 | call to taint |
+| params_flow.rb:78:32:78:40 | call to taint | type tracker without call steps with content element 2 | params_flow.rb:78:1:78:63 | * |
+| params_flow.rb:78:38:78:39 | 29 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:78:38:78:39 | 29 | type tracker without call steps | params_flow.rb:78:32:78:40 | call to taint |
+| params_flow.rb:78:38:78:39 | 29 | type tracker without call steps | params_flow.rb:78:38:78:39 | 29 |
+| params_flow.rb:78:38:78:39 | 29 | type tracker without call steps with content element 0 | params_flow.rb:78:32:78:40 | * |
+| params_flow.rb:78:38:78:39 | 29 | type tracker without call steps with content element 2 | params_flow.rb:78:1:78:63 | * |
+| params_flow.rb:78:43:78:51 | * | type tracker without call steps | params_flow.rb:78:43:78:51 | * |
+| params_flow.rb:78:43:78:51 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:78:43:78:51 | call to taint | type tracker with call steps | params_flow.rb:69:24:69:24 | w |
+| params_flow.rb:78:43:78:51 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:78:43:78:51 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:74:5:74:10 | * |
+| params_flow.rb:78:43:78:51 | call to taint | type tracker without call steps | params_flow.rb:78:43:78:51 | call to taint |
+| params_flow.rb:78:43:78:51 | call to taint | type tracker without call steps with content element 3 | params_flow.rb:78:1:78:63 | * |
+| params_flow.rb:78:49:78:50 | 30 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:78:49:78:50 | 30 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:78:49:78:50 | 30 | type tracker with call steps | params_flow.rb:69:24:69:24 | w |
+| params_flow.rb:78:49:78:50 | 30 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:78:49:78:50 | 30 | type tracker with call steps with content element 0 | params_flow.rb:74:5:74:10 | * |
+| params_flow.rb:78:49:78:50 | 30 | type tracker without call steps | params_flow.rb:78:43:78:51 | call to taint |
+| params_flow.rb:78:49:78:50 | 30 | type tracker without call steps | params_flow.rb:78:49:78:50 | 30 |
+| params_flow.rb:78:49:78:50 | 30 | type tracker without call steps with content element 0 | params_flow.rb:78:43:78:51 | * |
+| params_flow.rb:78:49:78:50 | 30 | type tracker without call steps with content element 3 | params_flow.rb:78:1:78:63 | * |
+| params_flow.rb:78:54:78:62 | * | type tracker without call steps | params_flow.rb:78:54:78:62 | * |
+| params_flow.rb:78:54:78:62 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:78:54:78:62 | call to taint | type tracker with call steps | params_flow.rb:69:27:69:27 | r |
+| params_flow.rb:78:54:78:62 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:78:54:78:62 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:75:5:75:10 | * |
+| params_flow.rb:78:54:78:62 | call to taint | type tracker without call steps | params_flow.rb:78:54:78:62 | call to taint |
+| params_flow.rb:78:54:78:62 | call to taint | type tracker without call steps with content element 4 | params_flow.rb:78:1:78:63 | * |
+| params_flow.rb:78:60:78:61 | 31 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:78:60:78:61 | 31 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:78:60:78:61 | 31 | type tracker with call steps | params_flow.rb:69:27:69:27 | r |
+| params_flow.rb:78:60:78:61 | 31 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:78:60:78:61 | 31 | type tracker with call steps with content element 0 | params_flow.rb:75:5:75:10 | * |
+| params_flow.rb:78:60:78:61 | 31 | type tracker without call steps | params_flow.rb:78:54:78:62 | call to taint |
+| params_flow.rb:78:60:78:61 | 31 | type tracker without call steps | params_flow.rb:78:60:78:61 | 31 |
+| params_flow.rb:78:60:78:61 | 31 | type tracker without call steps with content element 0 | params_flow.rb:78:54:78:62 | * |
+| params_flow.rb:78:60:78:61 | 31 | type tracker without call steps with content element 4 | params_flow.rb:78:1:78:63 | * |
+| params_flow.rb:80:1:80:4 | args | type tracker without call steps | params_flow.rb:80:1:80:4 | args |
+| params_flow.rb:80:8:80:51 | * | type tracker without call steps | params_flow.rb:80:8:80:51 | * |
+| params_flow.rb:80:8:80:51 | Array | type tracker without call steps | params_flow.rb:80:8:80:51 | Array |
+| params_flow.rb:80:8:80:51 | call to [] | type tracker without call steps | params_flow.rb:80:8:80:51 | call to [] |
+| params_flow.rb:80:8:80:51 | call to [] | type tracker without call steps with content element 0 or unknown | params_flow.rb:81:21:81:25 | * ... |
+| params_flow.rb:80:9:80:17 | * | type tracker without call steps | params_flow.rb:80:9:80:17 | * |
+| params_flow.rb:80:9:80:17 | call to taint | type tracker without call steps | params_flow.rb:80:9:80:17 | call to taint |
+| params_flow.rb:80:9:80:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:80:8:80:51 | * |
+| params_flow.rb:80:9:80:17 | call to taint | type tracker without call steps with content element 0 or unknown | params_flow.rb:80:8:80:51 | call to [] |
+| params_flow.rb:80:9:80:17 | call to taint | type tracker without call steps with content element 0 or unknown | params_flow.rb:81:21:81:25 | * ... |
+| params_flow.rb:80:15:80:16 | 33 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:80:15:80:16 | 33 | type tracker without call steps | params_flow.rb:80:9:80:17 | call to taint |
+| params_flow.rb:80:15:80:16 | 33 | type tracker without call steps | params_flow.rb:80:15:80:16 | 33 |
+| params_flow.rb:80:15:80:16 | 33 | type tracker without call steps with content element 0 | params_flow.rb:80:8:80:51 | * |
+| params_flow.rb:80:15:80:16 | 33 | type tracker without call steps with content element 0 | params_flow.rb:80:9:80:17 | * |
+| params_flow.rb:80:15:80:16 | 33 | type tracker without call steps with content element 0 or unknown | params_flow.rb:80:8:80:51 | call to [] |
+| params_flow.rb:80:15:80:16 | 33 | type tracker without call steps with content element 0 or unknown | params_flow.rb:81:21:81:25 | * ... |
+| params_flow.rb:80:20:80:28 | * | type tracker without call steps | params_flow.rb:80:20:80:28 | * |
+| params_flow.rb:80:20:80:28 | call to taint | type tracker without call steps | params_flow.rb:80:20:80:28 | call to taint |
+| params_flow.rb:80:20:80:28 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:80:8:80:51 | * |
+| params_flow.rb:80:20:80:28 | call to taint | type tracker without call steps with content element 1 or unknown | params_flow.rb:80:8:80:51 | call to [] |
+| params_flow.rb:80:20:80:28 | call to taint | type tracker without call steps with content element 1 or unknown | params_flow.rb:81:21:81:25 | * ... |
+| params_flow.rb:80:26:80:27 | 34 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:80:26:80:27 | 34 | type tracker without call steps | params_flow.rb:80:20:80:28 | call to taint |
+| params_flow.rb:80:26:80:27 | 34 | type tracker without call steps | params_flow.rb:80:26:80:27 | 34 |
+| params_flow.rb:80:26:80:27 | 34 | type tracker without call steps with content element 0 | params_flow.rb:80:20:80:28 | * |
+| params_flow.rb:80:26:80:27 | 34 | type tracker without call steps with content element 1 | params_flow.rb:80:8:80:51 | * |
+| params_flow.rb:80:26:80:27 | 34 | type tracker without call steps with content element 1 or unknown | params_flow.rb:80:8:80:51 | call to [] |
+| params_flow.rb:80:26:80:27 | 34 | type tracker without call steps with content element 1 or unknown | params_flow.rb:81:21:81:25 | * ... |
+| params_flow.rb:80:31:80:39 | * | type tracker without call steps | params_flow.rb:80:31:80:39 | * |
+| params_flow.rb:80:31:80:39 | call to taint | type tracker without call steps | params_flow.rb:80:31:80:39 | call to taint |
+| params_flow.rb:80:31:80:39 | call to taint | type tracker without call steps with content element 2 | params_flow.rb:80:8:80:51 | * |
+| params_flow.rb:80:31:80:39 | call to taint | type tracker without call steps with content element 2 or unknown | params_flow.rb:80:8:80:51 | call to [] |
+| params_flow.rb:80:31:80:39 | call to taint | type tracker without call steps with content element 2 or unknown | params_flow.rb:81:21:81:25 | * ... |
+| params_flow.rb:80:37:80:38 | 35 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:80:37:80:38 | 35 | type tracker without call steps | params_flow.rb:80:31:80:39 | call to taint |
+| params_flow.rb:80:37:80:38 | 35 | type tracker without call steps | params_flow.rb:80:37:80:38 | 35 |
+| params_flow.rb:80:37:80:38 | 35 | type tracker without call steps with content element 0 | params_flow.rb:80:31:80:39 | * |
+| params_flow.rb:80:37:80:38 | 35 | type tracker without call steps with content element 2 | params_flow.rb:80:8:80:51 | * |
+| params_flow.rb:80:37:80:38 | 35 | type tracker without call steps with content element 2 or unknown | params_flow.rb:80:8:80:51 | call to [] |
+| params_flow.rb:80:37:80:38 | 35 | type tracker without call steps with content element 2 or unknown | params_flow.rb:81:21:81:25 | * ... |
+| params_flow.rb:80:42:80:50 | * | type tracker without call steps | params_flow.rb:80:42:80:50 | * |
+| params_flow.rb:80:42:80:50 | call to taint | type tracker without call steps | params_flow.rb:80:42:80:50 | call to taint |
+| params_flow.rb:80:42:80:50 | call to taint | type tracker without call steps with content element 3 | params_flow.rb:80:8:80:51 | * |
+| params_flow.rb:80:42:80:50 | call to taint | type tracker without call steps with content element 3 or unknown | params_flow.rb:80:8:80:51 | call to [] |
+| params_flow.rb:80:42:80:50 | call to taint | type tracker without call steps with content element 3 or unknown | params_flow.rb:81:21:81:25 | * ... |
+| params_flow.rb:80:48:80:49 | 36 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:80:48:80:49 | 36 | type tracker without call steps | params_flow.rb:80:42:80:50 | call to taint |
+| params_flow.rb:80:48:80:49 | 36 | type tracker without call steps | params_flow.rb:80:48:80:49 | 36 |
+| params_flow.rb:80:48:80:49 | 36 | type tracker without call steps with content element 0 | params_flow.rb:80:42:80:50 | * |
+| params_flow.rb:80:48:80:49 | 36 | type tracker without call steps with content element 3 | params_flow.rb:80:8:80:51 | * |
+| params_flow.rb:80:48:80:49 | 36 | type tracker without call steps with content element 3 or unknown | params_flow.rb:80:8:80:51 | call to [] |
+| params_flow.rb:80:48:80:49 | 36 | type tracker without call steps with content element 3 or unknown | params_flow.rb:81:21:81:25 | * ... |
+| params_flow.rb:81:1:81:37 | call to splatmid | type tracker without call steps | params_flow.rb:81:1:81:37 | call to splatmid |
+| params_flow.rb:81:10:81:18 | * | type tracker without call steps | params_flow.rb:81:10:81:18 | * |
+| params_flow.rb:81:10:81:18 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:81:10:81:18 | call to taint | type tracker with call steps | params_flow.rb:69:14:69:14 | x |
+| params_flow.rb:81:10:81:18 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:81:10:81:18 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:70:5:70:10 | * |
+| params_flow.rb:81:10:81:18 | call to taint | type tracker without call steps | params_flow.rb:81:10:81:18 | call to taint |
+| params_flow.rb:81:16:81:17 | 32 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:81:16:81:17 | 32 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:81:16:81:17 | 32 | type tracker with call steps | params_flow.rb:69:14:69:14 | x |
+| params_flow.rb:81:16:81:17 | 32 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:81:16:81:17 | 32 | type tracker with call steps with content element 0 | params_flow.rb:70:5:70:10 | * |
+| params_flow.rb:81:16:81:17 | 32 | type tracker without call steps | params_flow.rb:81:10:81:18 | call to taint |
+| params_flow.rb:81:16:81:17 | 32 | type tracker without call steps | params_flow.rb:81:16:81:17 | 32 |
+| params_flow.rb:81:16:81:17 | 32 | type tracker without call steps with content element 0 | params_flow.rb:81:10:81:18 | * |
+| params_flow.rb:81:21:81:25 | * ... | type tracker without call steps | params_flow.rb:81:21:81:25 | * ... |
+| params_flow.rb:81:28:81:36 | * | type tracker without call steps | params_flow.rb:81:28:81:36 | * |
+| params_flow.rb:81:28:81:36 | call to taint | type tracker without call steps | params_flow.rb:81:28:81:36 | call to taint |
+| params_flow.rb:81:34:81:35 | 37 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:81:34:81:35 | 37 | type tracker without call steps | params_flow.rb:81:28:81:36 | call to taint |
+| params_flow.rb:81:34:81:35 | 37 | type tracker without call steps | params_flow.rb:81:34:81:35 | 37 |
+| params_flow.rb:81:34:81:35 | 37 | type tracker without call steps with content element 0 | params_flow.rb:81:28:81:36 | * |
+| params_flow.rb:83:1:91:3 | &block | type tracker without call steps | params_flow.rb:83:1:91:3 | &block |
+| params_flow.rb:83:1:91:3 | pos_many | type tracker without call steps | params_flow.rb:83:1:91:3 | pos_many |
+| params_flow.rb:83:1:91:3 | self in pos_many | type tracker with call steps | params_flow.rb:5:1:7:3 | self in sink |
+| params_flow.rb:83:1:91:3 | self in pos_many | type tracker without call steps | params_flow.rb:83:1:91:3 | self in pos_many |
+| params_flow.rb:83:1:91:3 | synthetic *args | type tracker without call steps | params_flow.rb:83:1:91:3 | synthetic *args |
+| params_flow.rb:83:14:83:14 | t | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:83:14:83:14 | t | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:83:14:83:14 | t | type tracker without call steps | params_flow.rb:83:14:83:14 | t |
+| params_flow.rb:83:14:83:14 | t | type tracker without call steps | params_flow.rb:83:14:83:14 | t |
+| params_flow.rb:83:14:83:14 | t | type tracker without call steps with content element 0 | params_flow.rb:84:5:84:10 | * |
+| params_flow.rb:83:17:83:17 | u | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:83:17:83:17 | u | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:83:17:83:17 | u | type tracker without call steps | params_flow.rb:83:17:83:17 | u |
+| params_flow.rb:83:17:83:17 | u | type tracker without call steps | params_flow.rb:83:17:83:17 | u |
+| params_flow.rb:83:17:83:17 | u | type tracker without call steps with content element 0 | params_flow.rb:85:5:85:10 | * |
+| params_flow.rb:83:20:83:20 | v | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:83:20:83:20 | v | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:83:20:83:20 | v | type tracker without call steps | params_flow.rb:83:20:83:20 | v |
+| params_flow.rb:83:20:83:20 | v | type tracker without call steps | params_flow.rb:83:20:83:20 | v |
+| params_flow.rb:83:20:83:20 | v | type tracker without call steps with content element 0 | params_flow.rb:86:5:86:10 | * |
+| params_flow.rb:83:23:83:23 | w | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:83:23:83:23 | w | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:83:23:83:23 | w | type tracker without call steps | params_flow.rb:83:23:83:23 | w |
+| params_flow.rb:83:23:83:23 | w | type tracker without call steps | params_flow.rb:83:23:83:23 | w |
+| params_flow.rb:83:23:83:23 | w | type tracker without call steps with content element 0 | params_flow.rb:87:5:87:10 | * |
+| params_flow.rb:83:26:83:26 | x | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:83:26:83:26 | x | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:83:26:83:26 | x | type tracker without call steps | params_flow.rb:83:26:83:26 | x |
+| params_flow.rb:83:26:83:26 | x | type tracker without call steps | params_flow.rb:83:26:83:26 | x |
+| params_flow.rb:83:26:83:26 | x | type tracker without call steps with content element 0 | params_flow.rb:88:5:88:10 | * |
+| params_flow.rb:83:29:83:29 | y | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:83:29:83:29 | y | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:83:29:83:29 | y | type tracker without call steps | params_flow.rb:83:29:83:29 | y |
+| params_flow.rb:83:29:83:29 | y | type tracker without call steps | params_flow.rb:83:29:83:29 | y |
+| params_flow.rb:83:29:83:29 | y | type tracker without call steps with content element 0 | params_flow.rb:89:5:89:10 | * |
+| params_flow.rb:83:32:83:32 | z | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:83:32:83:32 | z | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:83:32:83:32 | z | type tracker without call steps | params_flow.rb:83:32:83:32 | z |
+| params_flow.rb:83:32:83:32 | z | type tracker without call steps | params_flow.rb:83:32:83:32 | z |
+| params_flow.rb:83:32:83:32 | z | type tracker without call steps with content element 0 | params_flow.rb:90:5:90:10 | * |
+| params_flow.rb:84:5:84:10 | * | type tracker without call steps | params_flow.rb:84:5:84:10 | * |
+| params_flow.rb:84:5:84:10 | call to sink | type tracker without call steps | params_flow.rb:84:5:84:10 | call to sink |
+| params_flow.rb:85:5:85:10 | * | type tracker without call steps | params_flow.rb:85:5:85:10 | * |
+| params_flow.rb:85:5:85:10 | call to sink | type tracker without call steps | params_flow.rb:85:5:85:10 | call to sink |
+| params_flow.rb:86:5:86:10 | * | type tracker without call steps | params_flow.rb:86:5:86:10 | * |
+| params_flow.rb:86:5:86:10 | call to sink | type tracker without call steps | params_flow.rb:86:5:86:10 | call to sink |
+| params_flow.rb:87:5:87:10 | * | type tracker without call steps | params_flow.rb:87:5:87:10 | * |
+| params_flow.rb:87:5:87:10 | call to sink | type tracker without call steps | params_flow.rb:87:5:87:10 | call to sink |
+| params_flow.rb:88:5:88:10 | * | type tracker without call steps | params_flow.rb:88:5:88:10 | * |
+| params_flow.rb:88:5:88:10 | call to sink | type tracker without call steps | params_flow.rb:88:5:88:10 | call to sink |
+| params_flow.rb:89:5:89:10 | * | type tracker without call steps | params_flow.rb:89:5:89:10 | * |
+| params_flow.rb:89:5:89:10 | call to sink | type tracker without call steps | params_flow.rb:89:5:89:10 | call to sink |
+| params_flow.rb:90:5:90:10 | * | type tracker without call steps | params_flow.rb:90:5:90:10 | * |
+| params_flow.rb:90:5:90:10 | call to sink | type tracker without call steps | params_flow.rb:90:5:90:10 | call to sink |
+| params_flow.rb:90:5:90:10 | call to sink | type tracker without call steps | params_flow.rb:94:1:94:48 | call to pos_many |
+| params_flow.rb:93:1:93:4 | args | type tracker without call steps | params_flow.rb:93:1:93:4 | args |
+| params_flow.rb:93:8:93:51 | * | type tracker without call steps | params_flow.rb:93:8:93:51 | * |
+| params_flow.rb:93:8:93:51 | Array | type tracker without call steps | params_flow.rb:93:8:93:51 | Array |
+| params_flow.rb:93:8:93:51 | call to [] | type tracker without call steps | params_flow.rb:93:8:93:51 | call to [] |
+| params_flow.rb:93:8:93:51 | call to [] | type tracker without call steps with content element 0 or unknown | params_flow.rb:94:32:94:36 | * ... |
+| params_flow.rb:93:9:93:17 | * | type tracker without call steps | params_flow.rb:93:9:93:17 | * |
+| params_flow.rb:93:9:93:17 | call to taint | type tracker without call steps | params_flow.rb:93:9:93:17 | call to taint |
+| params_flow.rb:93:9:93:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:93:8:93:51 | * |
+| params_flow.rb:93:9:93:17 | call to taint | type tracker without call steps with content element 0 or unknown | params_flow.rb:93:8:93:51 | call to [] |
+| params_flow.rb:93:9:93:17 | call to taint | type tracker without call steps with content element 0 or unknown | params_flow.rb:94:32:94:36 | * ... |
+| params_flow.rb:93:15:93:16 | 40 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:93:15:93:16 | 40 | type tracker without call steps | params_flow.rb:93:9:93:17 | call to taint |
+| params_flow.rb:93:15:93:16 | 40 | type tracker without call steps | params_flow.rb:93:15:93:16 | 40 |
+| params_flow.rb:93:15:93:16 | 40 | type tracker without call steps with content element 0 | params_flow.rb:93:8:93:51 | * |
+| params_flow.rb:93:15:93:16 | 40 | type tracker without call steps with content element 0 | params_flow.rb:93:9:93:17 | * |
+| params_flow.rb:93:15:93:16 | 40 | type tracker without call steps with content element 0 or unknown | params_flow.rb:93:8:93:51 | call to [] |
+| params_flow.rb:93:15:93:16 | 40 | type tracker without call steps with content element 0 or unknown | params_flow.rb:94:32:94:36 | * ... |
+| params_flow.rb:93:20:93:28 | * | type tracker without call steps | params_flow.rb:93:20:93:28 | * |
+| params_flow.rb:93:20:93:28 | call to taint | type tracker without call steps | params_flow.rb:93:20:93:28 | call to taint |
+| params_flow.rb:93:20:93:28 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:93:8:93:51 | * |
+| params_flow.rb:93:20:93:28 | call to taint | type tracker without call steps with content element 1 or unknown | params_flow.rb:93:8:93:51 | call to [] |
+| params_flow.rb:93:20:93:28 | call to taint | type tracker without call steps with content element 1 or unknown | params_flow.rb:94:32:94:36 | * ... |
+| params_flow.rb:93:26:93:27 | 41 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:93:26:93:27 | 41 | type tracker without call steps | params_flow.rb:93:20:93:28 | call to taint |
+| params_flow.rb:93:26:93:27 | 41 | type tracker without call steps | params_flow.rb:93:26:93:27 | 41 |
+| params_flow.rb:93:26:93:27 | 41 | type tracker without call steps with content element 0 | params_flow.rb:93:20:93:28 | * |
+| params_flow.rb:93:26:93:27 | 41 | type tracker without call steps with content element 1 | params_flow.rb:93:8:93:51 | * |
+| params_flow.rb:93:26:93:27 | 41 | type tracker without call steps with content element 1 or unknown | params_flow.rb:93:8:93:51 | call to [] |
+| params_flow.rb:93:26:93:27 | 41 | type tracker without call steps with content element 1 or unknown | params_flow.rb:94:32:94:36 | * ... |
+| params_flow.rb:93:31:93:39 | * | type tracker without call steps | params_flow.rb:93:31:93:39 | * |
+| params_flow.rb:93:31:93:39 | call to taint | type tracker without call steps | params_flow.rb:93:31:93:39 | call to taint |
+| params_flow.rb:93:31:93:39 | call to taint | type tracker without call steps with content element 2 | params_flow.rb:93:8:93:51 | * |
+| params_flow.rb:93:31:93:39 | call to taint | type tracker without call steps with content element 2 or unknown | params_flow.rb:93:8:93:51 | call to [] |
+| params_flow.rb:93:31:93:39 | call to taint | type tracker without call steps with content element 2 or unknown | params_flow.rb:94:32:94:36 | * ... |
+| params_flow.rb:93:37:93:38 | 42 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:93:37:93:38 | 42 | type tracker without call steps | params_flow.rb:93:31:93:39 | call to taint |
+| params_flow.rb:93:37:93:38 | 42 | type tracker without call steps | params_flow.rb:93:37:93:38 | 42 |
+| params_flow.rb:93:37:93:38 | 42 | type tracker without call steps with content element 0 | params_flow.rb:93:31:93:39 | * |
+| params_flow.rb:93:37:93:38 | 42 | type tracker without call steps with content element 2 | params_flow.rb:93:8:93:51 | * |
+| params_flow.rb:93:37:93:38 | 42 | type tracker without call steps with content element 2 or unknown | params_flow.rb:93:8:93:51 | call to [] |
+| params_flow.rb:93:37:93:38 | 42 | type tracker without call steps with content element 2 or unknown | params_flow.rb:94:32:94:36 | * ... |
+| params_flow.rb:93:42:93:50 | * | type tracker without call steps | params_flow.rb:93:42:93:50 | * |
+| params_flow.rb:93:42:93:50 | call to taint | type tracker without call steps | params_flow.rb:93:42:93:50 | call to taint |
+| params_flow.rb:93:42:93:50 | call to taint | type tracker without call steps with content element 3 | params_flow.rb:93:8:93:51 | * |
+| params_flow.rb:93:42:93:50 | call to taint | type tracker without call steps with content element 3 or unknown | params_flow.rb:93:8:93:51 | call to [] |
+| params_flow.rb:93:42:93:50 | call to taint | type tracker without call steps with content element 3 or unknown | params_flow.rb:94:32:94:36 | * ... |
+| params_flow.rb:93:48:93:49 | 43 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:93:48:93:49 | 43 | type tracker without call steps | params_flow.rb:93:42:93:50 | call to taint |
+| params_flow.rb:93:48:93:49 | 43 | type tracker without call steps | params_flow.rb:93:48:93:49 | 43 |
+| params_flow.rb:93:48:93:49 | 43 | type tracker without call steps with content element 0 | params_flow.rb:93:42:93:50 | * |
+| params_flow.rb:93:48:93:49 | 43 | type tracker without call steps with content element 3 | params_flow.rb:93:8:93:51 | * |
+| params_flow.rb:93:48:93:49 | 43 | type tracker without call steps with content element 3 or unknown | params_flow.rb:93:8:93:51 | call to [] |
+| params_flow.rb:93:48:93:49 | 43 | type tracker without call steps with content element 3 or unknown | params_flow.rb:94:32:94:36 | * ... |
+| params_flow.rb:94:1:94:48 | call to pos_many | type tracker without call steps | params_flow.rb:94:1:94:48 | call to pos_many |
+| params_flow.rb:94:10:94:18 | * | type tracker without call steps | params_flow.rb:94:10:94:18 | * |
+| params_flow.rb:94:10:94:18 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:94:10:94:18 | call to taint | type tracker with call steps | params_flow.rb:83:14:83:14 | t |
+| params_flow.rb:94:10:94:18 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:94:10:94:18 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:84:5:84:10 | * |
+| params_flow.rb:94:10:94:18 | call to taint | type tracker without call steps | params_flow.rb:94:10:94:18 | call to taint |
+| params_flow.rb:94:16:94:17 | 38 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:94:16:94:17 | 38 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:94:16:94:17 | 38 | type tracker with call steps | params_flow.rb:83:14:83:14 | t |
+| params_flow.rb:94:16:94:17 | 38 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:94:16:94:17 | 38 | type tracker with call steps with content element 0 | params_flow.rb:84:5:84:10 | * |
+| params_flow.rb:94:16:94:17 | 38 | type tracker without call steps | params_flow.rb:94:10:94:18 | call to taint |
+| params_flow.rb:94:16:94:17 | 38 | type tracker without call steps | params_flow.rb:94:16:94:17 | 38 |
+| params_flow.rb:94:16:94:17 | 38 | type tracker without call steps with content element 0 | params_flow.rb:94:10:94:18 | * |
+| params_flow.rb:94:21:94:29 | * | type tracker without call steps | params_flow.rb:94:21:94:29 | * |
+| params_flow.rb:94:21:94:29 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:94:21:94:29 | call to taint | type tracker with call steps | params_flow.rb:83:17:83:17 | u |
+| params_flow.rb:94:21:94:29 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:94:21:94:29 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:85:5:85:10 | * |
+| params_flow.rb:94:21:94:29 | call to taint | type tracker without call steps | params_flow.rb:94:21:94:29 | call to taint |
+| params_flow.rb:94:27:94:28 | 39 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:94:27:94:28 | 39 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:94:27:94:28 | 39 | type tracker with call steps | params_flow.rb:83:17:83:17 | u |
+| params_flow.rb:94:27:94:28 | 39 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:94:27:94:28 | 39 | type tracker with call steps with content element 0 | params_flow.rb:85:5:85:10 | * |
+| params_flow.rb:94:27:94:28 | 39 | type tracker without call steps | params_flow.rb:94:21:94:29 | call to taint |
+| params_flow.rb:94:27:94:28 | 39 | type tracker without call steps | params_flow.rb:94:27:94:28 | 39 |
+| params_flow.rb:94:27:94:28 | 39 | type tracker without call steps with content element 0 | params_flow.rb:94:21:94:29 | * |
+| params_flow.rb:94:32:94:36 | * ... | type tracker without call steps | params_flow.rb:94:32:94:36 | * ... |
+| params_flow.rb:94:39:94:47 | * | type tracker without call steps | params_flow.rb:94:39:94:47 | * |
+| params_flow.rb:94:39:94:47 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:94:39:94:47 | call to taint | type tracker with call steps | params_flow.rb:83:23:83:23 | w |
+| params_flow.rb:94:39:94:47 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:94:39:94:47 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:87:5:87:10 | * |
+| params_flow.rb:94:39:94:47 | call to taint | type tracker without call steps | params_flow.rb:94:39:94:47 | call to taint |
+| params_flow.rb:94:45:94:46 | 44 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:94:45:94:46 | 44 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:94:45:94:46 | 44 | type tracker with call steps | params_flow.rb:83:23:83:23 | w |
+| params_flow.rb:94:45:94:46 | 44 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:94:45:94:46 | 44 | type tracker with call steps with content element 0 | params_flow.rb:87:5:87:10 | * |
+| params_flow.rb:94:45:94:46 | 44 | type tracker without call steps | params_flow.rb:94:39:94:47 | call to taint |
+| params_flow.rb:94:45:94:46 | 44 | type tracker without call steps | params_flow.rb:94:45:94:46 | 44 |
+| params_flow.rb:94:45:94:46 | 44 | type tracker without call steps with content element 0 | params_flow.rb:94:39:94:47 | * |
+| params_flow.rb:96:1:96:88 | call to splatmid | type tracker without call steps | params_flow.rb:96:1:96:88 | call to splatmid |
+| params_flow.rb:96:10:96:18 | * | type tracker without call steps | params_flow.rb:96:10:96:18 | * |
+| params_flow.rb:96:10:96:18 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:96:10:96:18 | call to taint | type tracker with call steps | params_flow.rb:69:14:69:14 | x |
+| params_flow.rb:96:10:96:18 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:96:10:96:18 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:70:5:70:10 | * |
+| params_flow.rb:96:10:96:18 | call to taint | type tracker without call steps | params_flow.rb:96:10:96:18 | call to taint |
+| params_flow.rb:96:16:96:17 | 45 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:96:16:96:17 | 45 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:96:16:96:17 | 45 | type tracker with call steps | params_flow.rb:69:14:69:14 | x |
+| params_flow.rb:96:16:96:17 | 45 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:96:16:96:17 | 45 | type tracker with call steps with content element 0 | params_flow.rb:70:5:70:10 | * |
+| params_flow.rb:96:16:96:17 | 45 | type tracker without call steps | params_flow.rb:96:10:96:18 | call to taint |
+| params_flow.rb:96:16:96:17 | 45 | type tracker without call steps | params_flow.rb:96:16:96:17 | 45 |
+| params_flow.rb:96:16:96:17 | 45 | type tracker without call steps with content element 0 | params_flow.rb:96:10:96:18 | * |
+| params_flow.rb:96:21:96:29 | * | type tracker without call steps | params_flow.rb:96:21:96:29 | * |
+| params_flow.rb:96:21:96:29 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:96:21:96:29 | call to taint | type tracker with call steps | params_flow.rb:69:17:69:17 | y |
+| params_flow.rb:96:21:96:29 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:96:21:96:29 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:71:5:71:10 | * |
+| params_flow.rb:96:21:96:29 | call to taint | type tracker without call steps | params_flow.rb:96:21:96:29 | call to taint |
+| params_flow.rb:96:27:96:28 | 46 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:96:27:96:28 | 46 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:96:27:96:28 | 46 | type tracker with call steps | params_flow.rb:69:17:69:17 | y |
+| params_flow.rb:96:27:96:28 | 46 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:96:27:96:28 | 46 | type tracker with call steps with content element 0 | params_flow.rb:71:5:71:10 | * |
+| params_flow.rb:96:27:96:28 | 46 | type tracker without call steps | params_flow.rb:96:21:96:29 | call to taint |
+| params_flow.rb:96:27:96:28 | 46 | type tracker without call steps | params_flow.rb:96:27:96:28 | 46 |
+| params_flow.rb:96:27:96:28 | 46 | type tracker without call steps with content element 0 | params_flow.rb:96:21:96:29 | * |
+| params_flow.rb:96:32:96:65 | * ... | type tracker without call steps | params_flow.rb:96:32:96:65 | * ... |
+| params_flow.rb:96:33:96:65 | * | type tracker without call steps | params_flow.rb:96:33:96:65 | * |
+| params_flow.rb:96:33:96:65 | Array | type tracker without call steps | params_flow.rb:96:33:96:65 | Array |
+| params_flow.rb:96:33:96:65 | call to [] | type tracker without call steps | params_flow.rb:96:33:96:65 | call to [] |
+| params_flow.rb:96:33:96:65 | call to [] | type tracker without call steps with content element 0 or unknown | params_flow.rb:96:32:96:65 | * ... |
+| params_flow.rb:96:34:96:42 | * | type tracker without call steps | params_flow.rb:96:34:96:42 | * |
+| params_flow.rb:96:34:96:42 | call to taint | type tracker without call steps | params_flow.rb:96:34:96:42 | call to taint |
+| params_flow.rb:96:34:96:42 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:96:33:96:65 | * |
+| params_flow.rb:96:34:96:42 | call to taint | type tracker without call steps with content element 0 or unknown | params_flow.rb:96:32:96:65 | * ... |
+| params_flow.rb:96:34:96:42 | call to taint | type tracker without call steps with content element 0 or unknown | params_flow.rb:96:33:96:65 | call to [] |
+| params_flow.rb:96:40:96:41 | 47 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:96:40:96:41 | 47 | type tracker without call steps | params_flow.rb:96:34:96:42 | call to taint |
+| params_flow.rb:96:40:96:41 | 47 | type tracker without call steps | params_flow.rb:96:40:96:41 | 47 |
+| params_flow.rb:96:40:96:41 | 47 | type tracker without call steps with content element 0 | params_flow.rb:96:33:96:65 | * |
+| params_flow.rb:96:40:96:41 | 47 | type tracker without call steps with content element 0 | params_flow.rb:96:34:96:42 | * |
+| params_flow.rb:96:40:96:41 | 47 | type tracker without call steps with content element 0 or unknown | params_flow.rb:96:32:96:65 | * ... |
+| params_flow.rb:96:40:96:41 | 47 | type tracker without call steps with content element 0 or unknown | params_flow.rb:96:33:96:65 | call to [] |
+| params_flow.rb:96:45:96:53 | * | type tracker without call steps | params_flow.rb:96:45:96:53 | * |
+| params_flow.rb:96:45:96:53 | call to taint | type tracker without call steps | params_flow.rb:96:45:96:53 | call to taint |
+| params_flow.rb:96:45:96:53 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:96:33:96:65 | * |
+| params_flow.rb:96:45:96:53 | call to taint | type tracker without call steps with content element 1 or unknown | params_flow.rb:96:32:96:65 | * ... |
+| params_flow.rb:96:45:96:53 | call to taint | type tracker without call steps with content element 1 or unknown | params_flow.rb:96:33:96:65 | call to [] |
+| params_flow.rb:96:51:96:52 | 48 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:96:51:96:52 | 48 | type tracker without call steps | params_flow.rb:96:45:96:53 | call to taint |
+| params_flow.rb:96:51:96:52 | 48 | type tracker without call steps | params_flow.rb:96:51:96:52 | 48 |
+| params_flow.rb:96:51:96:52 | 48 | type tracker without call steps with content element 0 | params_flow.rb:96:45:96:53 | * |
+| params_flow.rb:96:51:96:52 | 48 | type tracker without call steps with content element 1 | params_flow.rb:96:33:96:65 | * |
+| params_flow.rb:96:51:96:52 | 48 | type tracker without call steps with content element 1 or unknown | params_flow.rb:96:32:96:65 | * ... |
+| params_flow.rb:96:51:96:52 | 48 | type tracker without call steps with content element 1 or unknown | params_flow.rb:96:33:96:65 | call to [] |
+| params_flow.rb:96:56:96:64 | * | type tracker without call steps | params_flow.rb:96:56:96:64 | * |
+| params_flow.rb:96:56:96:64 | call to taint | type tracker without call steps | params_flow.rb:96:56:96:64 | call to taint |
+| params_flow.rb:96:56:96:64 | call to taint | type tracker without call steps with content element 2 | params_flow.rb:96:33:96:65 | * |
+| params_flow.rb:96:56:96:64 | call to taint | type tracker without call steps with content element 2 or unknown | params_flow.rb:96:32:96:65 | * ... |
+| params_flow.rb:96:56:96:64 | call to taint | type tracker without call steps with content element 2 or unknown | params_flow.rb:96:33:96:65 | call to [] |
+| params_flow.rb:96:62:96:63 | 49 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:96:62:96:63 | 49 | type tracker without call steps | params_flow.rb:96:56:96:64 | call to taint |
+| params_flow.rb:96:62:96:63 | 49 | type tracker without call steps | params_flow.rb:96:62:96:63 | 49 |
+| params_flow.rb:96:62:96:63 | 49 | type tracker without call steps with content element 0 | params_flow.rb:96:56:96:64 | * |
+| params_flow.rb:96:62:96:63 | 49 | type tracker without call steps with content element 2 | params_flow.rb:96:33:96:65 | * |
+| params_flow.rb:96:62:96:63 | 49 | type tracker without call steps with content element 2 or unknown | params_flow.rb:96:32:96:65 | * ... |
+| params_flow.rb:96:62:96:63 | 49 | type tracker without call steps with content element 2 or unknown | params_flow.rb:96:33:96:65 | call to [] |
+| params_flow.rb:96:68:96:76 | * | type tracker without call steps | params_flow.rb:96:68:96:76 | * |
+| params_flow.rb:96:68:96:76 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:96:68:96:76 | call to taint | type tracker with call steps | params_flow.rb:69:24:69:24 | w |
+| params_flow.rb:96:68:96:76 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:96:68:96:76 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:74:5:74:10 | * |
+| params_flow.rb:96:68:96:76 | call to taint | type tracker without call steps | params_flow.rb:96:68:96:76 | call to taint |
+| params_flow.rb:96:74:96:75 | 50 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:96:74:96:75 | 50 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:96:74:96:75 | 50 | type tracker with call steps | params_flow.rb:69:24:69:24 | w |
+| params_flow.rb:96:74:96:75 | 50 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:96:74:96:75 | 50 | type tracker with call steps with content element 0 | params_flow.rb:74:5:74:10 | * |
+| params_flow.rb:96:74:96:75 | 50 | type tracker without call steps | params_flow.rb:96:68:96:76 | call to taint |
+| params_flow.rb:96:74:96:75 | 50 | type tracker without call steps | params_flow.rb:96:74:96:75 | 50 |
+| params_flow.rb:96:74:96:75 | 50 | type tracker without call steps with content element 0 | params_flow.rb:96:68:96:76 | * |
+| params_flow.rb:96:79:96:87 | * | type tracker without call steps | params_flow.rb:96:79:96:87 | * |
+| params_flow.rb:96:79:96:87 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:96:79:96:87 | call to taint | type tracker with call steps | params_flow.rb:69:27:69:27 | r |
+| params_flow.rb:96:79:96:87 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:96:79:96:87 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:75:5:75:10 | * |
+| params_flow.rb:96:79:96:87 | call to taint | type tracker without call steps | params_flow.rb:96:79:96:87 | call to taint |
+| params_flow.rb:96:85:96:86 | 51 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:96:85:96:86 | 51 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:96:85:96:86 | 51 | type tracker with call steps | params_flow.rb:69:27:69:27 | r |
+| params_flow.rb:96:85:96:86 | 51 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:96:85:96:86 | 51 | type tracker with call steps with content element 0 | params_flow.rb:75:5:75:10 | * |
+| params_flow.rb:96:85:96:86 | 51 | type tracker without call steps | params_flow.rb:96:79:96:87 | call to taint |
+| params_flow.rb:96:85:96:86 | 51 | type tracker without call steps | params_flow.rb:96:85:96:86 | 51 |
+| params_flow.rb:96:85:96:86 | 51 | type tracker without call steps with content element 0 | params_flow.rb:96:79:96:87 | * |
+| params_flow.rb:98:1:103:3 | &block | type tracker without call steps | params_flow.rb:98:1:103:3 | &block |
+| params_flow.rb:98:1:103:3 | self in splatmidsmall | type tracker with call steps | params_flow.rb:5:1:7:3 | self in sink |
+| params_flow.rb:98:1:103:3 | self in splatmidsmall | type tracker without call steps | params_flow.rb:98:1:103:3 | self in splatmidsmall |
+| params_flow.rb:98:1:103:3 | splatmidsmall | type tracker without call steps | params_flow.rb:98:1:103:3 | splatmidsmall |
+| params_flow.rb:98:1:103:3 | synthetic *args | type tracker without call steps | params_flow.rb:98:1:103:3 | synthetic *args |
+| params_flow.rb:98:19:98:19 | a | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:98:19:98:19 | a | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:98:19:98:19 | a | type tracker without call steps | params_flow.rb:98:19:98:19 | a |
+| params_flow.rb:98:19:98:19 | a | type tracker without call steps | params_flow.rb:98:19:98:19 | a |
+| params_flow.rb:98:19:98:19 | a | type tracker without call steps with content element 0 | params_flow.rb:99:5:99:10 | * |
+| params_flow.rb:98:22:98:28 | *splats | type tracker without call steps | params_flow.rb:98:22:98:28 | *splats |
+| params_flow.rb:98:23:98:28 | splats | type tracker without call steps | params_flow.rb:98:23:98:28 | splats |
+| params_flow.rb:98:31:98:31 | b | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:98:31:98:31 | b | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:98:31:98:31 | b | type tracker without call steps | params_flow.rb:98:31:98:31 | b |
+| params_flow.rb:98:31:98:31 | b | type tracker without call steps | params_flow.rb:98:31:98:31 | b |
+| params_flow.rb:98:31:98:31 | b | type tracker without call steps with content element 0 | params_flow.rb:102:5:102:10 | * |
+| params_flow.rb:99:5:99:10 | * | type tracker without call steps | params_flow.rb:99:5:99:10 | * |
+| params_flow.rb:99:5:99:10 | call to sink | type tracker without call steps | params_flow.rb:99:5:99:10 | call to sink |
+| params_flow.rb:100:5:100:18 | * | type tracker without call steps | params_flow.rb:100:5:100:18 | * |
+| params_flow.rb:100:5:100:18 | call to sink | type tracker without call steps | params_flow.rb:100:5:100:18 | call to sink |
+| params_flow.rb:100:10:100:18 | * | type tracker without call steps | params_flow.rb:100:10:100:18 | * |
+| params_flow.rb:100:10:100:18 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:100:10:100:18 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:100:10:100:18 | ...[...] | type tracker without call steps | params_flow.rb:100:10:100:18 | ...[...] |
+| params_flow.rb:100:10:100:18 | ...[...] | type tracker without call steps with content element 0 | params_flow.rb:100:5:100:18 | * |
+| params_flow.rb:100:17:100:17 | 0 | type tracker without call steps | params_flow.rb:100:17:100:17 | 0 |
+| params_flow.rb:100:17:100:17 | 0 | type tracker without call steps with content element 0 | params_flow.rb:100:10:100:18 | * |
+| params_flow.rb:101:5:101:18 | * | type tracker without call steps | params_flow.rb:101:5:101:18 | * |
+| params_flow.rb:101:5:101:18 | call to sink | type tracker without call steps | params_flow.rb:101:5:101:18 | call to sink |
+| params_flow.rb:101:10:101:18 | * | type tracker without call steps | params_flow.rb:101:10:101:18 | * |
+| params_flow.rb:101:10:101:18 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:101:10:101:18 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:101:10:101:18 | ...[...] | type tracker without call steps | params_flow.rb:101:10:101:18 | ...[...] |
+| params_flow.rb:101:10:101:18 | ...[...] | type tracker without call steps with content element 0 | params_flow.rb:101:5:101:18 | * |
+| params_flow.rb:101:17:101:17 | 1 | type tracker without call steps | params_flow.rb:101:17:101:17 | 1 |
+| params_flow.rb:101:17:101:17 | 1 | type tracker without call steps with content element 0 | params_flow.rb:101:10:101:18 | * |
+| params_flow.rb:102:5:102:10 | * | type tracker without call steps | params_flow.rb:102:5:102:10 | * |
+| params_flow.rb:102:5:102:10 | call to sink | type tracker without call steps | params_flow.rb:102:5:102:10 | call to sink |
+| params_flow.rb:102:5:102:10 | call to sink | type tracker without call steps | params_flow.rb:105:1:105:49 | call to splatmidsmall |
+| params_flow.rb:102:5:102:10 | call to sink | type tracker without call steps | params_flow.rb:106:1:106:46 | call to splatmidsmall |
+| params_flow.rb:105:1:105:49 | call to splatmidsmall | type tracker without call steps | params_flow.rb:105:1:105:49 | call to splatmidsmall |
+| params_flow.rb:105:15:105:23 | * | type tracker without call steps | params_flow.rb:105:15:105:23 | * |
+| params_flow.rb:105:15:105:23 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:105:15:105:23 | call to taint | type tracker with call steps | params_flow.rb:98:19:98:19 | a |
+| params_flow.rb:105:15:105:23 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:105:15:105:23 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:99:5:99:10 | * |
+| params_flow.rb:105:15:105:23 | call to taint | type tracker without call steps | params_flow.rb:105:15:105:23 | call to taint |
+| params_flow.rb:105:21:105:22 | 52 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:105:21:105:22 | 52 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:105:21:105:22 | 52 | type tracker with call steps | params_flow.rb:98:19:98:19 | a |
+| params_flow.rb:105:21:105:22 | 52 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:105:21:105:22 | 52 | type tracker with call steps with content element 0 | params_flow.rb:99:5:99:10 | * |
+| params_flow.rb:105:21:105:22 | 52 | type tracker without call steps | params_flow.rb:105:15:105:23 | call to taint |
+| params_flow.rb:105:21:105:22 | 52 | type tracker without call steps | params_flow.rb:105:21:105:22 | 52 |
+| params_flow.rb:105:21:105:22 | 52 | type tracker without call steps with content element 0 | params_flow.rb:105:15:105:23 | * |
+| params_flow.rb:105:26:105:48 | * ... | type tracker without call steps | params_flow.rb:105:26:105:48 | * ... |
+| params_flow.rb:105:27:105:48 | * | type tracker without call steps | params_flow.rb:105:27:105:48 | * |
+| params_flow.rb:105:27:105:48 | Array | type tracker without call steps | params_flow.rb:105:27:105:48 | Array |
+| params_flow.rb:105:27:105:48 | call to [] | type tracker without call steps | params_flow.rb:105:27:105:48 | call to [] |
+| params_flow.rb:105:27:105:48 | call to [] | type tracker without call steps with content element 0 or unknown | params_flow.rb:105:26:105:48 | * ... |
+| params_flow.rb:105:28:105:36 | * | type tracker without call steps | params_flow.rb:105:28:105:36 | * |
+| params_flow.rb:105:28:105:36 | call to taint | type tracker without call steps | params_flow.rb:105:28:105:36 | call to taint |
+| params_flow.rb:105:28:105:36 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:105:27:105:48 | * |
+| params_flow.rb:105:28:105:36 | call to taint | type tracker without call steps with content element 0 or unknown | params_flow.rb:105:26:105:48 | * ... |
+| params_flow.rb:105:28:105:36 | call to taint | type tracker without call steps with content element 0 or unknown | params_flow.rb:105:27:105:48 | call to [] |
+| params_flow.rb:105:34:105:35 | 53 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:105:34:105:35 | 53 | type tracker without call steps | params_flow.rb:105:28:105:36 | call to taint |
+| params_flow.rb:105:34:105:35 | 53 | type tracker without call steps | params_flow.rb:105:34:105:35 | 53 |
+| params_flow.rb:105:34:105:35 | 53 | type tracker without call steps with content element 0 | params_flow.rb:105:27:105:48 | * |
+| params_flow.rb:105:34:105:35 | 53 | type tracker without call steps with content element 0 | params_flow.rb:105:28:105:36 | * |
+| params_flow.rb:105:34:105:35 | 53 | type tracker without call steps with content element 0 or unknown | params_flow.rb:105:26:105:48 | * ... |
+| params_flow.rb:105:34:105:35 | 53 | type tracker without call steps with content element 0 or unknown | params_flow.rb:105:27:105:48 | call to [] |
+| params_flow.rb:105:39:105:47 | * | type tracker without call steps | params_flow.rb:105:39:105:47 | * |
+| params_flow.rb:105:39:105:47 | call to taint | type tracker without call steps | params_flow.rb:105:39:105:47 | call to taint |
+| params_flow.rb:105:39:105:47 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:105:27:105:48 | * |
+| params_flow.rb:105:39:105:47 | call to taint | type tracker without call steps with content element 1 or unknown | params_flow.rb:105:26:105:48 | * ... |
+| params_flow.rb:105:39:105:47 | call to taint | type tracker without call steps with content element 1 or unknown | params_flow.rb:105:27:105:48 | call to [] |
+| params_flow.rb:105:45:105:46 | 54 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:105:45:105:46 | 54 | type tracker without call steps | params_flow.rb:105:39:105:47 | call to taint |
+| params_flow.rb:105:45:105:46 | 54 | type tracker without call steps | params_flow.rb:105:45:105:46 | 54 |
+| params_flow.rb:105:45:105:46 | 54 | type tracker without call steps with content element 0 | params_flow.rb:105:39:105:47 | * |
+| params_flow.rb:105:45:105:46 | 54 | type tracker without call steps with content element 1 | params_flow.rb:105:27:105:48 | * |
+| params_flow.rb:105:45:105:46 | 54 | type tracker without call steps with content element 1 or unknown | params_flow.rb:105:26:105:48 | * ... |
+| params_flow.rb:105:45:105:46 | 54 | type tracker without call steps with content element 1 or unknown | params_flow.rb:105:27:105:48 | call to [] |
+| params_flow.rb:106:1:106:46 | * | type tracker without call steps | params_flow.rb:106:1:106:46 | * |
+| params_flow.rb:106:1:106:46 | call to splatmidsmall | type tracker without call steps | params_flow.rb:106:1:106:46 | call to splatmidsmall |
+| params_flow.rb:106:15:106:23 | * | type tracker without call steps | params_flow.rb:106:15:106:23 | * |
+| params_flow.rb:106:15:106:23 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:106:15:106:23 | call to taint | type tracker with call steps | params_flow.rb:98:19:98:19 | a |
+| params_flow.rb:106:15:106:23 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:106:15:106:23 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:99:5:99:10 | * |
+| params_flow.rb:106:15:106:23 | call to taint | type tracker without call steps | params_flow.rb:106:15:106:23 | call to taint |
+| params_flow.rb:106:15:106:23 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:106:1:106:46 | * |
+| params_flow.rb:106:21:106:22 | 55 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:106:21:106:22 | 55 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:106:21:106:22 | 55 | type tracker with call steps | params_flow.rb:98:19:98:19 | a |
+| params_flow.rb:106:21:106:22 | 55 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:106:21:106:22 | 55 | type tracker with call steps with content element 0 | params_flow.rb:99:5:99:10 | * |
+| params_flow.rb:106:21:106:22 | 55 | type tracker without call steps | params_flow.rb:106:15:106:23 | call to taint |
+| params_flow.rb:106:21:106:22 | 55 | type tracker without call steps | params_flow.rb:106:21:106:22 | 55 |
+| params_flow.rb:106:21:106:22 | 55 | type tracker without call steps with content element 0 | params_flow.rb:106:1:106:46 | * |
+| params_flow.rb:106:21:106:22 | 55 | type tracker without call steps with content element 0 | params_flow.rb:106:15:106:23 | * |
+| params_flow.rb:106:26:106:34 | * | type tracker without call steps | params_flow.rb:106:26:106:34 | * |
+| params_flow.rb:106:26:106:34 | call to taint | type tracker without call steps | params_flow.rb:106:26:106:34 | call to taint |
+| params_flow.rb:106:26:106:34 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:106:1:106:46 | * |
+| params_flow.rb:106:32:106:33 | 56 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:106:32:106:33 | 56 | type tracker without call steps | params_flow.rb:106:26:106:34 | call to taint |
+| params_flow.rb:106:32:106:33 | 56 | type tracker without call steps | params_flow.rb:106:32:106:33 | 56 |
+| params_flow.rb:106:32:106:33 | 56 | type tracker without call steps with content element 0 | params_flow.rb:106:26:106:34 | * |
+| params_flow.rb:106:32:106:33 | 56 | type tracker without call steps with content element 1 | params_flow.rb:106:1:106:46 | * |
+| params_flow.rb:106:37:106:45 | * | type tracker without call steps | params_flow.rb:106:37:106:45 | * |
+| params_flow.rb:106:37:106:45 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:106:37:106:45 | call to taint | type tracker with call steps | params_flow.rb:98:31:98:31 | b |
+| params_flow.rb:106:37:106:45 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:106:37:106:45 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:102:5:102:10 | * |
+| params_flow.rb:106:37:106:45 | call to taint | type tracker without call steps | params_flow.rb:106:37:106:45 | call to taint |
+| params_flow.rb:106:37:106:45 | call to taint | type tracker without call steps with content element 2 | params_flow.rb:106:1:106:46 | * |
+| params_flow.rb:106:43:106:44 | 57 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:106:43:106:44 | 57 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:106:43:106:44 | 57 | type tracker with call steps | params_flow.rb:98:31:98:31 | b |
+| params_flow.rb:106:43:106:44 | 57 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:106:43:106:44 | 57 | type tracker with call steps with content element 0 | params_flow.rb:102:5:102:10 | * |
+| params_flow.rb:106:43:106:44 | 57 | type tracker without call steps | params_flow.rb:106:37:106:45 | call to taint |
+| params_flow.rb:106:43:106:44 | 57 | type tracker without call steps | params_flow.rb:106:43:106:44 | 57 |
+| params_flow.rb:106:43:106:44 | 57 | type tracker without call steps with content element 0 | params_flow.rb:106:37:106:45 | * |
+| params_flow.rb:106:43:106:44 | 57 | type tracker without call steps with content element 2 | params_flow.rb:106:1:106:46 | * |
+| params_flow.rb:108:1:112:3 | &block | type tracker without call steps | params_flow.rb:108:1:112:3 | &block |
+| params_flow.rb:108:1:112:3 | **kwargs | type tracker without call steps | params_flow.rb:108:1:112:3 | **kwargs |
+| params_flow.rb:108:1:112:3 | self in splat_followed_by_keyword_param | type tracker with call steps | params_flow.rb:5:1:7:3 | self in sink |
+| params_flow.rb:108:1:112:3 | self in splat_followed_by_keyword_param | type tracker without call steps | params_flow.rb:108:1:112:3 | self in splat_followed_by_keyword_param |
+| params_flow.rb:108:1:112:3 | splat_followed_by_keyword_param | type tracker without call steps | params_flow.rb:108:1:112:3 | splat_followed_by_keyword_param |
+| params_flow.rb:108:1:112:3 | synthetic *args | type tracker without call steps | params_flow.rb:108:1:112:3 | synthetic *args |
+| params_flow.rb:108:1:112:3 | synthetic *args | type tracker without call steps | params_flow.rb:108:1:112:3 | synthetic *args |
+| params_flow.rb:108:1:112:3 | synthetic *args[0] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:108:1:112:3 | synthetic *args[0] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:108:1:112:3 | synthetic *args[0] | type tracker without call steps | params_flow.rb:108:1:112:3 | synthetic *args[0] |
+| params_flow.rb:108:1:112:3 | synthetic *args[0] | type tracker without call steps | params_flow.rb:110:10:110:13 | ...[...] |
+| params_flow.rb:108:1:112:3 | synthetic *args[0] | type tracker without call steps with content element 0 | params_flow.rb:108:40:108:41 | *b |
+| params_flow.rb:108:1:112:3 | synthetic *args[0] | type tracker without call steps with content element 0 | params_flow.rb:110:5:110:13 | * |
+| params_flow.rb:108:1:112:3 | synthetic *args[1] | type tracker without call steps | params_flow.rb:108:1:112:3 | synthetic *args[1] |
+| params_flow.rb:108:1:112:3 | synthetic *args[1] | type tracker without call steps with content element 1 | params_flow.rb:108:40:108:41 | *b |
+| params_flow.rb:108:1:112:3 | synthetic *args[2] | type tracker without call steps | params_flow.rb:108:1:112:3 | synthetic *args[2] |
+| params_flow.rb:108:1:112:3 | synthetic *args[2] | type tracker without call steps with content element 2 | params_flow.rb:108:40:108:41 | *b |
+| params_flow.rb:108:1:112:3 | synthetic *args[3] | type tracker without call steps | params_flow.rb:108:1:112:3 | synthetic *args[3] |
+| params_flow.rb:108:1:112:3 | synthetic *args[3] | type tracker without call steps with content element 3 | params_flow.rb:108:40:108:41 | *b |
+| params_flow.rb:108:1:112:3 | synthetic *args[4] | type tracker without call steps | params_flow.rb:108:1:112:3 | synthetic *args[4] |
+| params_flow.rb:108:1:112:3 | synthetic *args[4] | type tracker without call steps with content element 4 | params_flow.rb:108:40:108:41 | *b |
+| params_flow.rb:108:1:112:3 | synthetic *args[5] | type tracker without call steps | params_flow.rb:108:1:112:3 | synthetic *args[5] |
+| params_flow.rb:108:1:112:3 | synthetic *args[5] | type tracker without call steps with content element 5 | params_flow.rb:108:40:108:41 | *b |
+| params_flow.rb:108:1:112:3 | synthetic *args[6] | type tracker without call steps | params_flow.rb:108:1:112:3 | synthetic *args[6] |
+| params_flow.rb:108:1:112:3 | synthetic *args[6] | type tracker without call steps with content element 6 | params_flow.rb:108:40:108:41 | *b |
+| params_flow.rb:108:1:112:3 | synthetic *args[7] | type tracker without call steps | params_flow.rb:108:1:112:3 | synthetic *args[7] |
+| params_flow.rb:108:1:112:3 | synthetic *args[7] | type tracker without call steps with content element 7 | params_flow.rb:108:40:108:41 | *b |
+| params_flow.rb:108:1:112:3 | synthetic *args[8] | type tracker without call steps | params_flow.rb:108:1:112:3 | synthetic *args[8] |
+| params_flow.rb:108:1:112:3 | synthetic *args[8] | type tracker without call steps with content element 8 | params_flow.rb:108:40:108:41 | *b |
+| params_flow.rb:108:1:112:3 | synthetic *args[9] | type tracker without call steps | params_flow.rb:108:1:112:3 | synthetic *args[9] |
+| params_flow.rb:108:1:112:3 | synthetic *args[9] | type tracker without call steps with content element 9 | params_flow.rb:108:40:108:41 | *b |
+| params_flow.rb:108:1:112:3 | synthetic *args[10] | type tracker without call steps | params_flow.rb:108:1:112:3 | synthetic *args[10] |
+| params_flow.rb:108:1:112:3 | synthetic *args[10] | type tracker without call steps with content element 10 | params_flow.rb:108:40:108:41 | *b |
+| params_flow.rb:108:37:108:37 | a | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:108:37:108:37 | a | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:108:37:108:37 | a | type tracker without call steps | params_flow.rb:108:37:108:37 | a |
+| params_flow.rb:108:37:108:37 | a | type tracker without call steps | params_flow.rb:108:37:108:37 | a |
+| params_flow.rb:108:37:108:37 | a | type tracker without call steps with content element 0 | params_flow.rb:109:5:109:10 | * |
+| params_flow.rb:108:40:108:41 | *b | type tracker without call steps | params_flow.rb:108:40:108:41 | *b |
+| params_flow.rb:108:41:108:41 | b | type tracker without call steps | params_flow.rb:108:41:108:41 | b |
+| params_flow.rb:108:44:108:44 | c | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:108:44:108:44 | c | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:108:44:108:44 | c | type tracker without call steps | params_flow.rb:108:44:108:44 | c |
+| params_flow.rb:108:44:108:44 | c | type tracker without call steps | params_flow.rb:108:44:108:44 | c |
+| params_flow.rb:108:44:108:44 | c | type tracker without call steps with content element 0 | params_flow.rb:111:5:111:10 | * |
+| params_flow.rb:109:5:109:10 | * | type tracker without call steps | params_flow.rb:109:5:109:10 | * |
+| params_flow.rb:109:5:109:10 | call to sink | type tracker without call steps | params_flow.rb:109:5:109:10 | call to sink |
+| params_flow.rb:110:5:110:13 | * | type tracker without call steps | params_flow.rb:110:5:110:13 | * |
+| params_flow.rb:110:5:110:13 | call to sink | type tracker without call steps | params_flow.rb:110:5:110:13 | call to sink |
+| params_flow.rb:110:10:110:13 | * | type tracker without call steps | params_flow.rb:110:10:110:13 | * |
+| params_flow.rb:110:10:110:13 | ...[...] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:110:10:110:13 | ...[...] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:110:10:110:13 | ...[...] | type tracker without call steps | params_flow.rb:110:10:110:13 | ...[...] |
+| params_flow.rb:110:10:110:13 | ...[...] | type tracker without call steps with content element 0 | params_flow.rb:110:5:110:13 | * |
+| params_flow.rb:110:12:110:12 | 0 | type tracker without call steps | params_flow.rb:110:12:110:12 | 0 |
+| params_flow.rb:110:12:110:12 | 0 | type tracker without call steps with content element 0 | params_flow.rb:110:10:110:13 | * |
+| params_flow.rb:111:5:111:10 | * | type tracker without call steps | params_flow.rb:111:5:111:10 | * |
+| params_flow.rb:111:5:111:10 | call to sink | type tracker without call steps | params_flow.rb:111:5:111:10 | call to sink |
+| params_flow.rb:111:5:111:10 | call to sink | type tracker without call steps | params_flow.rb:114:1:114:67 | call to splat_followed_by_keyword_param |
+| params_flow.rb:114:1:114:67 | * | type tracker with call steps | params_flow.rb:108:1:112:3 | synthetic *args |
+| params_flow.rb:114:1:114:67 | * | type tracker without call steps | params_flow.rb:114:1:114:67 | * |
+| params_flow.rb:114:1:114:67 | ** | type tracker with call steps | params_flow.rb:108:1:112:3 | **kwargs |
+| params_flow.rb:114:1:114:67 | ** | type tracker without call steps | params_flow.rb:114:1:114:67 | ** |
+| params_flow.rb:114:1:114:67 | call to splat_followed_by_keyword_param | type tracker without call steps | params_flow.rb:114:1:114:67 | call to splat_followed_by_keyword_param |
+| params_flow.rb:114:33:114:41 | * | type tracker without call steps | params_flow.rb:114:33:114:41 | * |
+| params_flow.rb:114:33:114:41 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:114:33:114:41 | call to taint | type tracker with call steps | params_flow.rb:108:37:108:37 | a |
+| params_flow.rb:114:33:114:41 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:114:33:114:41 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:108:1:112:3 | synthetic *args |
+| params_flow.rb:114:33:114:41 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:109:5:109:10 | * |
+| params_flow.rb:114:33:114:41 | call to taint | type tracker without call steps | params_flow.rb:114:33:114:41 | call to taint |
+| params_flow.rb:114:33:114:41 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:114:1:114:67 | * |
+| params_flow.rb:114:39:114:40 | 58 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:114:39:114:40 | 58 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:114:39:114:40 | 58 | type tracker with call steps | params_flow.rb:108:37:108:37 | a |
+| params_flow.rb:114:39:114:40 | 58 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:114:39:114:40 | 58 | type tracker with call steps with content element 0 | params_flow.rb:108:1:112:3 | synthetic *args |
+| params_flow.rb:114:39:114:40 | 58 | type tracker with call steps with content element 0 | params_flow.rb:109:5:109:10 | * |
+| params_flow.rb:114:39:114:40 | 58 | type tracker without call steps | params_flow.rb:114:33:114:41 | call to taint |
+| params_flow.rb:114:39:114:40 | 58 | type tracker without call steps | params_flow.rb:114:39:114:40 | 58 |
+| params_flow.rb:114:39:114:40 | 58 | type tracker without call steps with content element 0 | params_flow.rb:114:1:114:67 | * |
+| params_flow.rb:114:39:114:40 | 58 | type tracker without call steps with content element 0 | params_flow.rb:114:33:114:41 | * |
+| params_flow.rb:114:44:114:52 | * | type tracker without call steps | params_flow.rb:114:44:114:52 | * |
+| params_flow.rb:114:44:114:52 | call to taint | type tracker with call steps with content element 1 | params_flow.rb:108:1:112:3 | synthetic *args |
+| params_flow.rb:114:44:114:52 | call to taint | type tracker without call steps | params_flow.rb:114:44:114:52 | call to taint |
+| params_flow.rb:114:44:114:52 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:114:1:114:67 | * |
+| params_flow.rb:114:50:114:51 | 59 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:114:50:114:51 | 59 | type tracker with call steps with content element 1 | params_flow.rb:108:1:112:3 | synthetic *args |
+| params_flow.rb:114:50:114:51 | 59 | type tracker without call steps | params_flow.rb:114:44:114:52 | call to taint |
+| params_flow.rb:114:50:114:51 | 59 | type tracker without call steps | params_flow.rb:114:50:114:51 | 59 |
+| params_flow.rb:114:50:114:51 | 59 | type tracker without call steps with content element 0 | params_flow.rb:114:44:114:52 | * |
+| params_flow.rb:114:50:114:51 | 59 | type tracker without call steps with content element 1 | params_flow.rb:114:1:114:67 | * |
+| params_flow.rb:114:55:114:55 | :c | type tracker without call steps | params_flow.rb:114:55:114:55 | :c |
+| params_flow.rb:114:55:114:66 | Pair | type tracker without call steps | params_flow.rb:114:55:114:66 | Pair |
+| params_flow.rb:114:58:114:66 | * | type tracker without call steps | params_flow.rb:114:58:114:66 | * |
+| params_flow.rb:114:58:114:66 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:114:58:114:66 | call to taint | type tracker with call steps | params_flow.rb:108:44:108:44 | c |
+| params_flow.rb:114:58:114:66 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:114:58:114:66 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:111:5:111:10 | * |
+| params_flow.rb:114:58:114:66 | call to taint | type tracker with call steps with content element :c | params_flow.rb:108:1:112:3 | **kwargs |
+| params_flow.rb:114:58:114:66 | call to taint | type tracker without call steps | params_flow.rb:114:58:114:66 | call to taint |
+| params_flow.rb:114:58:114:66 | call to taint | type tracker without call steps with content element :c | params_flow.rb:114:1:114:67 | ** |
+| params_flow.rb:114:64:114:65 | 60 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:114:64:114:65 | 60 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:114:64:114:65 | 60 | type tracker with call steps | params_flow.rb:108:44:108:44 | c |
+| params_flow.rb:114:64:114:65 | 60 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:114:64:114:65 | 60 | type tracker with call steps with content element 0 | params_flow.rb:111:5:111:10 | * |
+| params_flow.rb:114:64:114:65 | 60 | type tracker with call steps with content element :c | params_flow.rb:108:1:112:3 | **kwargs |
+| params_flow.rb:114:64:114:65 | 60 | type tracker without call steps | params_flow.rb:114:58:114:66 | call to taint |
+| params_flow.rb:114:64:114:65 | 60 | type tracker without call steps | params_flow.rb:114:64:114:65 | 60 |
+| params_flow.rb:114:64:114:65 | 60 | type tracker without call steps with content element 0 | params_flow.rb:114:58:114:66 | * |
+| params_flow.rb:114:64:114:65 | 60 | type tracker without call steps with content element :c | params_flow.rb:114:1:114:67 | ** |
+| params_flow.rb:116:1:116:1 | x | type tracker without call steps | params_flow.rb:116:1:116:1 | x |
+| params_flow.rb:116:5:116:6 | Array | type tracker without call steps | params_flow.rb:116:5:116:6 | Array |
+| params_flow.rb:116:5:116:6 | call to [] | type tracker with call steps with content element 0 or unknown | params_flow.rb:9:1:12:3 | synthetic *args |
+| params_flow.rb:116:5:116:6 | call to [] | type tracker without call steps | params_flow.rb:116:5:116:6 | call to [] |
+| params_flow.rb:116:5:116:6 | call to [] | type tracker without call steps with content element 0 or unknown | params_flow.rb:118:12:118:13 | * ... |
+| params_flow.rb:117:1:117:1 | [post] x | type tracker with call steps with content element 0 or unknown | params_flow.rb:9:1:12:3 | synthetic *args |
+| params_flow.rb:117:1:117:1 | [post] x | type tracker without call steps | params_flow.rb:117:1:117:1 | [post] x |
+| params_flow.rb:117:1:117:1 | [post] x | type tracker without call steps with content element 0 or unknown | params_flow.rb:118:12:118:13 | * ... |
+| params_flow.rb:117:1:117:15 | * | type tracker without call steps | params_flow.rb:117:1:117:15 | * |
+| params_flow.rb:117:1:117:15 | call to []= | type tracker without call steps | params_flow.rb:117:1:117:15 | call to []= |
+| params_flow.rb:117:3:117:14 | call to some_index | type tracker without call steps | params_flow.rb:117:3:117:14 | call to some_index |
+| params_flow.rb:117:3:117:14 | call to some_index | type tracker without call steps with content element 0 | params_flow.rb:117:1:117:15 | * |
+| params_flow.rb:117:19:117:27 | * | type tracker without call steps | params_flow.rb:117:19:117:27 | * |
+| params_flow.rb:117:19:117:27 | __synth__0 | type tracker without call steps | params_flow.rb:117:19:117:27 | __synth__0 |
+| params_flow.rb:117:19:117:27 | call to taint | type tracker with call steps with content element | params_flow.rb:9:1:12:3 | synthetic *args |
+| params_flow.rb:117:19:117:27 | call to taint | type tracker without call steps | params_flow.rb:117:19:117:27 | call to taint |
+| params_flow.rb:117:19:117:27 | call to taint | type tracker without call steps with content attribute [] | params_flow.rb:117:1:117:1 | [post] x |
+| params_flow.rb:117:19:117:27 | call to taint | type tracker without call steps with content element | params_flow.rb:116:5:116:6 | call to [] |
+| params_flow.rb:117:19:117:27 | call to taint | type tracker without call steps with content element | params_flow.rb:118:12:118:13 | * ... |
+| params_flow.rb:117:19:117:27 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:117:1:117:15 | * |
+| params_flow.rb:117:25:117:26 | 61 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:117:25:117:26 | 61 | type tracker with call steps with content element | params_flow.rb:9:1:12:3 | synthetic *args |
+| params_flow.rb:117:25:117:26 | 61 | type tracker without call steps | params_flow.rb:117:19:117:27 | call to taint |
+| params_flow.rb:117:25:117:26 | 61 | type tracker without call steps | params_flow.rb:117:25:117:26 | 61 |
+| params_flow.rb:117:25:117:26 | 61 | type tracker without call steps with content attribute [] | params_flow.rb:117:1:117:1 | [post] x |
+| params_flow.rb:117:25:117:26 | 61 | type tracker without call steps with content element | params_flow.rb:116:5:116:6 | call to [] |
+| params_flow.rb:117:25:117:26 | 61 | type tracker without call steps with content element | params_flow.rb:118:12:118:13 | * ... |
+| params_flow.rb:117:25:117:26 | 61 | type tracker without call steps with content element 0 | params_flow.rb:117:19:117:27 | * |
+| params_flow.rb:117:25:117:26 | 61 | type tracker without call steps with content element 1 | params_flow.rb:117:1:117:15 | * |
+| params_flow.rb:118:1:118:14 | call to positional | type tracker without call steps | params_flow.rb:118:1:118:14 | call to positional |
+| params_flow.rb:118:12:118:13 | * ... | type tracker with call steps | params_flow.rb:9:1:12:3 | synthetic *args |
+| params_flow.rb:118:12:118:13 | * ... | type tracker without call steps | params_flow.rb:118:12:118:13 | * ... |
+| params_flow.rb:120:1:126:3 | &block | type tracker without call steps | params_flow.rb:120:1:126:3 | &block |
+| params_flow.rb:120:1:126:3 | destruct | type tracker without call steps | params_flow.rb:120:1:126:3 | destruct |
+| params_flow.rb:120:1:126:3 | self in destruct | type tracker with call steps | params_flow.rb:5:1:7:3 | self in sink |
+| params_flow.rb:120:1:126:3 | self in destruct | type tracker without call steps | params_flow.rb:120:1:126:3 | self in destruct |
+| params_flow.rb:120:15:120:15 | a | type tracker without call steps | params_flow.rb:120:15:120:15 | a |
+| params_flow.rb:120:17:120:17 | b | type tracker without call steps | params_flow.rb:120:17:120:17 | b |
+| params_flow.rb:120:22:120:22 | c | type tracker without call steps | params_flow.rb:120:22:120:22 | c |
+| params_flow.rb:120:25:120:25 | d | type tracker without call steps | params_flow.rb:120:25:120:25 | d |
+| params_flow.rb:120:27:120:27 | e | type tracker without call steps | params_flow.rb:120:27:120:27 | e |
+| params_flow.rb:121:5:121:10 | * | type tracker without call steps | params_flow.rb:121:5:121:10 | * |
+| params_flow.rb:121:5:121:10 | call to sink | type tracker without call steps | params_flow.rb:121:5:121:10 | call to sink |
+| params_flow.rb:121:10:121:10 | a | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:121:10:121:10 | a | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:121:10:121:10 | a | type tracker without call steps | params_flow.rb:121:10:121:10 | a |
+| params_flow.rb:121:10:121:10 | a | type tracker without call steps with content element 0 | params_flow.rb:121:5:121:10 | * |
+| params_flow.rb:122:5:122:10 | * | type tracker without call steps | params_flow.rb:122:5:122:10 | * |
+| params_flow.rb:122:5:122:10 | call to sink | type tracker without call steps | params_flow.rb:122:5:122:10 | call to sink |
+| params_flow.rb:122:10:122:10 | b | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:122:10:122:10 | b | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:122:10:122:10 | b | type tracker without call steps | params_flow.rb:122:10:122:10 | b |
+| params_flow.rb:122:10:122:10 | b | type tracker without call steps with content element 0 | params_flow.rb:122:5:122:10 | * |
+| params_flow.rb:123:5:123:10 | * | type tracker without call steps | params_flow.rb:123:5:123:10 | * |
+| params_flow.rb:123:5:123:10 | call to sink | type tracker without call steps | params_flow.rb:123:5:123:10 | call to sink |
+| params_flow.rb:123:10:123:10 | c | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:123:10:123:10 | c | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:123:10:123:10 | c | type tracker without call steps | params_flow.rb:123:10:123:10 | c |
+| params_flow.rb:123:10:123:10 | c | type tracker without call steps with content element 0 | params_flow.rb:123:5:123:10 | * |
+| params_flow.rb:124:5:124:10 | * | type tracker without call steps | params_flow.rb:124:5:124:10 | * |
+| params_flow.rb:124:5:124:10 | call to sink | type tracker without call steps | params_flow.rb:124:5:124:10 | call to sink |
+| params_flow.rb:124:10:124:10 | d | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:124:10:124:10 | d | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:124:10:124:10 | d | type tracker without call steps | params_flow.rb:124:10:124:10 | d |
+| params_flow.rb:124:10:124:10 | d | type tracker without call steps with content element 0 | params_flow.rb:124:5:124:10 | * |
+| params_flow.rb:125:5:125:10 | * | type tracker without call steps | params_flow.rb:125:5:125:10 | * |
+| params_flow.rb:125:5:125:10 | call to sink | type tracker without call steps | params_flow.rb:125:5:125:10 | call to sink |
+| params_flow.rb:125:5:125:10 | call to sink | type tracker without call steps | params_flow.rb:128:1:128:61 | call to destruct |
+| params_flow.rb:125:10:125:10 | e | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:125:10:125:10 | e | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:125:10:125:10 | e | type tracker without call steps | params_flow.rb:125:10:125:10 | e |
+| params_flow.rb:125:10:125:10 | e | type tracker without call steps with content element 0 | params_flow.rb:125:5:125:10 | * |
+| params_flow.rb:128:1:128:61 | * | type tracker without call steps | params_flow.rb:128:1:128:61 | * |
+| params_flow.rb:128:1:128:61 | call to destruct | type tracker without call steps | params_flow.rb:128:1:128:61 | call to destruct |
+| params_flow.rb:128:10:128:31 | * | type tracker without call steps | params_flow.rb:128:10:128:31 | * |
+| params_flow.rb:128:10:128:31 | Array | type tracker without call steps | params_flow.rb:128:10:128:31 | Array |
+| params_flow.rb:128:10:128:31 | call to [] | type tracker without call steps | params_flow.rb:128:10:128:31 | call to [] |
+| params_flow.rb:128:10:128:31 | call to [] | type tracker without call steps with content element 0 | params_flow.rb:128:1:128:61 | * |
+| params_flow.rb:128:11:128:19 | * | type tracker without call steps | params_flow.rb:128:11:128:19 | * |
+| params_flow.rb:128:11:128:19 | call to taint | type tracker without call steps | params_flow.rb:128:11:128:19 | call to taint |
+| params_flow.rb:128:11:128:19 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:128:10:128:31 | * |
+| params_flow.rb:128:11:128:19 | call to taint | type tracker without call steps with content element 0 or unknown | params_flow.rb:128:10:128:31 | call to [] |
+| params_flow.rb:128:17:128:18 | 62 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:128:17:128:18 | 62 | type tracker without call steps | params_flow.rb:128:11:128:19 | call to taint |
+| params_flow.rb:128:17:128:18 | 62 | type tracker without call steps | params_flow.rb:128:17:128:18 | 62 |
+| params_flow.rb:128:17:128:18 | 62 | type tracker without call steps with content element 0 | params_flow.rb:128:10:128:31 | * |
+| params_flow.rb:128:17:128:18 | 62 | type tracker without call steps with content element 0 | params_flow.rb:128:11:128:19 | * |
+| params_flow.rb:128:17:128:18 | 62 | type tracker without call steps with content element 0 or unknown | params_flow.rb:128:10:128:31 | call to [] |
+| params_flow.rb:128:22:128:30 | * | type tracker without call steps | params_flow.rb:128:22:128:30 | * |
+| params_flow.rb:128:22:128:30 | call to taint | type tracker without call steps | params_flow.rb:128:22:128:30 | call to taint |
+| params_flow.rb:128:22:128:30 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:128:10:128:31 | * |
+| params_flow.rb:128:22:128:30 | call to taint | type tracker without call steps with content element 1 or unknown | params_flow.rb:128:10:128:31 | call to [] |
+| params_flow.rb:128:28:128:29 | 63 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:128:28:128:29 | 63 | type tracker without call steps | params_flow.rb:128:22:128:30 | call to taint |
+| params_flow.rb:128:28:128:29 | 63 | type tracker without call steps | params_flow.rb:128:28:128:29 | 63 |
+| params_flow.rb:128:28:128:29 | 63 | type tracker without call steps with content element 0 | params_flow.rb:128:22:128:30 | * |
+| params_flow.rb:128:28:128:29 | 63 | type tracker without call steps with content element 1 | params_flow.rb:128:10:128:31 | * |
+| params_flow.rb:128:28:128:29 | 63 | type tracker without call steps with content element 1 or unknown | params_flow.rb:128:10:128:31 | call to [] |
+| params_flow.rb:128:34:128:60 | * | type tracker without call steps | params_flow.rb:128:34:128:60 | * |
+| params_flow.rb:128:34:128:60 | Array | type tracker without call steps | params_flow.rb:128:34:128:60 | Array |
+| params_flow.rb:128:34:128:60 | call to [] | type tracker without call steps | params_flow.rb:128:34:128:60 | call to [] |
+| params_flow.rb:128:34:128:60 | call to [] | type tracker without call steps with content element 1 | params_flow.rb:128:1:128:61 | * |
+| params_flow.rb:128:35:128:43 | * | type tracker without call steps | params_flow.rb:128:35:128:43 | * |
+| params_flow.rb:128:35:128:43 | call to taint | type tracker without call steps | params_flow.rb:128:35:128:43 | call to taint |
+| params_flow.rb:128:35:128:43 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:128:34:128:60 | * |
+| params_flow.rb:128:35:128:43 | call to taint | type tracker without call steps with content element 0 or unknown | params_flow.rb:128:34:128:60 | call to [] |
+| params_flow.rb:128:41:128:42 | 64 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:128:41:128:42 | 64 | type tracker without call steps | params_flow.rb:128:35:128:43 | call to taint |
+| params_flow.rb:128:41:128:42 | 64 | type tracker without call steps | params_flow.rb:128:41:128:42 | 64 |
+| params_flow.rb:128:41:128:42 | 64 | type tracker without call steps with content element 0 | params_flow.rb:128:34:128:60 | * |
+| params_flow.rb:128:41:128:42 | 64 | type tracker without call steps with content element 0 | params_flow.rb:128:35:128:43 | * |
+| params_flow.rb:128:41:128:42 | 64 | type tracker without call steps with content element 0 or unknown | params_flow.rb:128:34:128:60 | call to [] |
+| params_flow.rb:128:46:128:59 | * | type tracker without call steps | params_flow.rb:128:46:128:59 | * |
+| params_flow.rb:128:46:128:59 | Array | type tracker without call steps | params_flow.rb:128:46:128:59 | Array |
+| params_flow.rb:128:46:128:59 | call to [] | type tracker without call steps | params_flow.rb:128:46:128:59 | call to [] |
+| params_flow.rb:128:46:128:59 | call to [] | type tracker without call steps with content element 1 | params_flow.rb:128:34:128:60 | * |
+| params_flow.rb:128:46:128:59 | call to [] | type tracker without call steps with content element 1 or unknown | params_flow.rb:128:34:128:60 | call to [] |
+| params_flow.rb:128:47:128:47 | 0 | type tracker without call steps | params_flow.rb:128:47:128:47 | 0 |
+| params_flow.rb:128:47:128:47 | 0 | type tracker without call steps with content element 0 | params_flow.rb:128:46:128:59 | * |
+| params_flow.rb:128:47:128:47 | 0 | type tracker without call steps with content element 0 or unknown | params_flow.rb:128:46:128:59 | call to [] |
+| params_flow.rb:128:50:128:58 | * | type tracker without call steps | params_flow.rb:128:50:128:58 | * |
+| params_flow.rb:128:50:128:58 | call to taint | type tracker without call steps | params_flow.rb:128:50:128:58 | call to taint |
+| params_flow.rb:128:50:128:58 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:128:46:128:59 | * |
+| params_flow.rb:128:50:128:58 | call to taint | type tracker without call steps with content element 1 or unknown | params_flow.rb:128:46:128:59 | call to [] |
+| params_flow.rb:128:56:128:57 | 65 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:128:56:128:57 | 65 | type tracker without call steps | params_flow.rb:128:50:128:58 | call to taint |
+| params_flow.rb:128:56:128:57 | 65 | type tracker without call steps | params_flow.rb:128:56:128:57 | 65 |
+| params_flow.rb:128:56:128:57 | 65 | type tracker without call steps with content element 0 | params_flow.rb:128:50:128:58 | * |
+| params_flow.rb:128:56:128:57 | 65 | type tracker without call steps with content element 1 | params_flow.rb:128:46:128:59 | * |
+| params_flow.rb:128:56:128:57 | 65 | type tracker without call steps with content element 1 or unknown | params_flow.rb:128:46:128:59 | call to [] |
+trackEnd
+| params_flow.rb:1:1:3:3 | &block | params_flow.rb:1:1:3:3 | &block |
+| params_flow.rb:1:1:3:3 | self in taint | params_flow.rb:1:1:3:3 | self in taint |
+| params_flow.rb:1:1:3:3 | synthetic *args | params_flow.rb:1:1:3:3 | synthetic *args |
+| params_flow.rb:1:1:3:3 | taint | params_flow.rb:1:1:3:3 | taint |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:1:1:3:3 | self in taint |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:1:1:128:62 | self (params_flow.rb) |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:5:1:7:3 | self (sink) |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:5:1:7:3 | self in sink |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:6:5:6:10 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:9:1:12:3 | self (positional) |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:9:1:12:3 | self in positional |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:10:5:10:11 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:11:5:11:11 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:14:1:14:30 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:14:12:14:19 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:14:22:14:29 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:16:1:19:3 | self (keyword) |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:16:1:19:3 | self in keyword |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:17:5:17:11 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:18:5:18:11 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:21:1:21:35 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:21:13:21:20 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:21:27:21:34 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:22:1:22:35 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:22:13:22:20 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:22:27:22:34 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:23:1:23:41 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:23:16:23:23 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:23:33:23:40 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:25:1:31:3 | self (kwargs) |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:25:1:31:3 | self in kwargs |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:26:5:26:11 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:27:5:27:22 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:28:5:28:22 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:29:5:29:22 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:30:5:30:22 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:33:1:33:58 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:33:12:33:19 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:33:26:33:34 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:33:41:33:49 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:34:14:34:22 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:35:1:35:29 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:35:12:35:20 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:37:16:37:24 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:37:34:37:42 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:38:1:38:14 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:40:16:40:24 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:41:1:41:30 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:41:13:41:21 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:43:9:43:17 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:44:1:44:28 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:44:12:44:20 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:46:9:46:17 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:46:20:46:28 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:47:1:47:17 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:49:1:53:3 | self (posargs) |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:49:1:53:3 | self in posargs |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:50:5:50:11 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:51:5:51:21 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:52:5:52:21 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:55:1:55:29 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:55:9:55:17 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:55:20:55:28 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:57:9:57:17 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:58:1:58:25 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:58:9:58:17 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:60:9:60:17 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:60:20:60:28 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:61:1:61:14 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:63:8:63:16 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:64:1:66:3 | self (splatstuff) |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:64:1:66:3 | self in splatstuff |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:65:5:65:13 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:67:1:67:17 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:69:1:76:3 | self (splatmid) |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:69:1:76:3 | self in splatmid |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:70:5:70:10 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:71:5:71:10 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:72:5:72:13 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:73:5:73:13 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:74:5:74:10 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:75:5:75:10 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:78:1:78:63 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:78:10:78:18 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:78:21:78:29 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:78:32:78:40 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:78:43:78:51 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:78:54:78:62 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:80:9:80:17 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:80:20:80:28 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:80:31:80:39 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:80:42:80:50 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:81:1:81:37 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:81:10:81:18 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:81:28:81:36 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:83:1:91:3 | self (pos_many) |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:83:1:91:3 | self in pos_many |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:84:5:84:10 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:85:5:85:10 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:86:5:86:10 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:87:5:87:10 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:88:5:88:10 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:89:5:89:10 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:90:5:90:10 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:93:9:93:17 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:93:20:93:28 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:93:31:93:39 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:93:42:93:50 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:94:1:94:48 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:94:10:94:18 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:94:21:94:29 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:94:39:94:47 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:96:1:96:88 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:96:10:96:18 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:96:21:96:29 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:96:34:96:42 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:96:45:96:53 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:96:56:96:64 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:96:68:96:76 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:96:79:96:87 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:98:1:103:3 | self (splatmidsmall) |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:98:1:103:3 | self in splatmidsmall |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:99:5:99:10 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:100:5:100:18 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:101:5:101:18 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:102:5:102:10 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:105:1:105:49 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:105:15:105:23 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:105:28:105:36 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:105:39:105:47 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:106:1:106:46 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:106:15:106:23 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:106:26:106:34 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:106:37:106:45 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:108:1:112:3 | self (splat_followed_by_keyword_param) |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:108:1:112:3 | self in splat_followed_by_keyword_param |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:109:5:109:10 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:110:5:110:13 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:111:5:111:10 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:114:1:114:67 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:114:33:114:41 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:114:44:114:52 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:114:58:114:66 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:117:3:117:14 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:117:19:117:27 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:118:1:118:14 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:120:1:126:3 | self (destruct) |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:120:1:126:3 | self in destruct |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:121:5:121:10 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:122:5:122:10 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:123:5:123:10 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:124:5:124:10 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:125:5:125:10 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:128:1:128:61 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:128:11:128:19 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:128:22:128:30 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:128:35:128:43 | self |
+| params_flow.rb:1:1:128:62 | self (params_flow.rb) | params_flow.rb:128:50:128:58 | self |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:9:16:9:17 | p1 |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:9:16:9:17 | p1 |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:9:20:9:21 | p2 |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:9:20:9:21 | p2 |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:10:10:10:11 | p1 |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:11:10:11:11 | p2 |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:14:12:14:19 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:14:22:14:29 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:16:13:16:14 | p1 |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:16:13:16:14 | p1 |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:16:18:16:19 | p2 |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:16:18:16:19 | p2 |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:17:10:17:11 | p1 |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:18:10:18:11 | p2 |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:21:13:21:20 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:21:27:21:34 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:22:13:22:20 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:22:27:22:34 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:23:16:23:23 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:23:33:23:40 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:25:12:25:13 | p1 |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:25:12:25:13 | p1 |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:26:10:26:11 | p1 |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:27:10:27:22 | ( ... ) |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:27:11:27:21 | ...[...] |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:28:10:28:22 | ( ... ) |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:28:11:28:21 | ...[...] |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:29:10:29:22 | ( ... ) |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:29:11:29:21 | ...[...] |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:33:12:33:19 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:33:26:33:34 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:33:41:33:49 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:34:14:34:22 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:35:12:35:20 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:37:16:37:24 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:37:34:37:42 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:40:16:40:24 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:41:13:41:21 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:43:9:43:17 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:44:12:44:20 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:46:9:46:17 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:46:20:46:28 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:49:13:49:14 | p1 |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:49:13:49:14 | p1 |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:50:10:50:11 | p1 |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:51:10:51:21 | ( ... ) |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:51:11:51:20 | ...[...] |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:55:9:55:17 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:55:20:55:28 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:57:9:57:17 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:58:9:58:17 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:60:9:60:17 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:60:20:60:28 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:63:1:63:4 | args |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:63:1:63:16 | ... = ... |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:63:8:63:16 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:65:10:65:13 | ...[...] |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:67:13:67:16 | args |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:69:14:69:14 | x |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:69:14:69:14 | x |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:69:17:69:17 | y |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:69:17:69:17 | y |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:69:24:69:24 | w |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:69:24:69:24 | w |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:69:27:69:27 | r |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:69:27:69:27 | r |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:70:10:70:10 | x |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:71:10:71:10 | y |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:74:10:74:10 | w |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:75:10:75:10 | r |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:78:10:78:18 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:78:21:78:29 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:78:32:78:40 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:78:43:78:51 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:78:54:78:62 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:80:9:80:17 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:80:20:80:28 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:80:31:80:39 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:80:42:80:50 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:81:10:81:18 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:81:28:81:36 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:83:14:83:14 | t |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:83:14:83:14 | t |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:83:17:83:17 | u |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:83:17:83:17 | u |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:83:23:83:23 | w |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:83:23:83:23 | w |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:84:10:84:10 | t |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:85:10:85:10 | u |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:87:10:87:10 | w |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:93:9:93:17 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:93:20:93:28 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:93:31:93:39 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:93:42:93:50 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:94:10:94:18 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:94:21:94:29 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:94:39:94:47 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:96:10:96:18 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:96:21:96:29 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:96:34:96:42 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:96:45:96:53 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:96:56:96:64 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:96:68:96:76 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:96:79:96:87 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:98:19:98:19 | a |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:98:19:98:19 | a |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:98:31:98:31 | b |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:98:31:98:31 | b |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:99:10:99:10 | a |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:102:10:102:10 | b |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:105:15:105:23 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:105:28:105:36 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:105:39:105:47 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:106:15:106:23 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:106:26:106:34 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:106:37:106:45 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:108:37:108:37 | a |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:108:37:108:37 | a |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:108:44:108:44 | c |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:108:44:108:44 | c |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:109:10:109:10 | a |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:111:10:111:10 | c |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:114:33:114:41 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:114:44:114:52 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:114:58:114:66 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:117:1:117:15 | __synth__0 |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:117:1:117:27 | ... |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:117:19:117:27 | ... = ... |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:117:19:117:27 | __synth__0 |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:117:19:117:27 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:128:11:128:19 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:128:22:128:30 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:128:35:128:43 | call to taint |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:128:50:128:58 | call to taint |
+| params_flow.rb:5:1:7:3 | &block | params_flow.rb:5:1:7:3 | &block |
+| params_flow.rb:5:1:7:3 | self in sink | params_flow.rb:5:1:7:3 | self (sink) |
+| params_flow.rb:5:1:7:3 | self in sink | params_flow.rb:5:1:7:3 | self in sink |
+| params_flow.rb:5:1:7:3 | self in sink | params_flow.rb:6:5:6:10 | self |
+| params_flow.rb:5:1:7:3 | sink | params_flow.rb:5:1:7:3 | sink |
+| params_flow.rb:5:1:7:3 | synthetic *args | params_flow.rb:5:1:7:3 | synthetic *args |
+| params_flow.rb:5:10:5:10 | x | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:5:10:5:10 | x | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:5:10:5:10 | x | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:5:10:5:10 | x | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:6:5:6:10 | * | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:6:5:6:10 | call to puts |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:10:5:10:11 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:11:5:11:11 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:14:1:14:30 | call to positional |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:17:5:17:11 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:18:5:18:11 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:21:1:21:35 | call to keyword |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:22:1:22:35 | call to keyword |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:23:1:23:41 | call to keyword |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:26:5:26:11 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:27:5:27:22 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:28:5:28:22 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:29:5:29:22 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:30:5:30:22 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:33:1:33:58 | call to kwargs |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:35:1:35:29 | call to kwargs |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:38:1:38:14 | call to kwargs |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:41:1:41:30 | call to keyword |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:44:1:44:28 | call to positional |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:47:1:47:17 | call to positional |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:50:5:50:11 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:51:5:51:21 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:52:5:52:21 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:55:1:55:29 | call to posargs |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:58:1:58:25 | call to posargs |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:61:1:61:14 | call to posargs |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:65:5:65:13 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:67:1:67:17 | call to splatstuff |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:70:5:70:10 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:71:5:71:10 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:72:5:72:13 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:73:5:73:13 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:74:5:74:10 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:75:5:75:10 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:78:1:78:63 | call to splatmid |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:81:1:81:37 | call to splatmid |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:84:5:84:10 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:85:5:85:10 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:86:5:86:10 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:87:5:87:10 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:88:5:88:10 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:89:5:89:10 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:90:5:90:10 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:94:1:94:48 | call to pos_many |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:96:1:96:88 | call to splatmid |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:99:5:99:10 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:100:5:100:18 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:101:5:101:18 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:102:5:102:10 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:105:1:105:49 | call to splatmidsmall |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:106:1:106:46 | call to splatmidsmall |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:109:5:109:10 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:110:5:110:13 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:111:5:111:10 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:114:1:114:67 | call to splat_followed_by_keyword_param |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:118:1:118:14 | call to positional |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:121:5:121:10 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:122:5:122:10 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:123:5:123:10 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:124:5:124:10 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:125:5:125:10 | call to sink |
+| params_flow.rb:6:5:6:10 | call to puts | params_flow.rb:128:1:128:61 | call to destruct |
+| params_flow.rb:9:1:12:3 | &block | params_flow.rb:9:1:12:3 | &block |
+| params_flow.rb:9:1:12:3 | positional | params_flow.rb:9:1:12:3 | positional |
+| params_flow.rb:9:1:12:3 | self in positional | params_flow.rb:5:1:7:3 | self (sink) |
+| params_flow.rb:9:1:12:3 | self in positional | params_flow.rb:5:1:7:3 | self in sink |
+| params_flow.rb:9:1:12:3 | self in positional | params_flow.rb:6:5:6:10 | self |
+| params_flow.rb:9:1:12:3 | self in positional | params_flow.rb:9:1:12:3 | self (positional) |
+| params_flow.rb:9:1:12:3 | self in positional | params_flow.rb:9:1:12:3 | self in positional |
+| params_flow.rb:9:1:12:3 | self in positional | params_flow.rb:10:5:10:11 | self |
+| params_flow.rb:9:1:12:3 | self in positional | params_flow.rb:11:5:11:11 | self |
+| params_flow.rb:9:1:12:3 | synthetic *args | params_flow.rb:9:1:12:3 | synthetic *args |
+| params_flow.rb:9:16:9:17 | p1 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:9:16:9:17 | p1 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:9:16:9:17 | p1 | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:9:16:9:17 | p1 | params_flow.rb:9:16:9:17 | p1 |
+| params_flow.rb:9:16:9:17 | p1 | params_flow.rb:9:16:9:17 | p1 |
+| params_flow.rb:9:16:9:17 | p1 | params_flow.rb:9:16:9:17 | p1 |
+| params_flow.rb:9:16:9:17 | p1 | params_flow.rb:10:10:10:11 | p1 |
+| params_flow.rb:9:20:9:21 | p2 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:9:20:9:21 | p2 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:9:20:9:21 | p2 | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:9:20:9:21 | p2 | params_flow.rb:9:20:9:21 | p2 |
+| params_flow.rb:9:20:9:21 | p2 | params_flow.rb:9:20:9:21 | p2 |
+| params_flow.rb:9:20:9:21 | p2 | params_flow.rb:9:20:9:21 | p2 |
+| params_flow.rb:9:20:9:21 | p2 | params_flow.rb:11:10:11:11 | p2 |
+| params_flow.rb:10:5:10:11 | * | params_flow.rb:10:5:10:11 | * |
+| params_flow.rb:10:5:10:11 | call to sink | params_flow.rb:10:5:10:11 | call to sink |
+| params_flow.rb:11:5:11:11 | * | params_flow.rb:11:5:11:11 | * |
+| params_flow.rb:11:5:11:11 | call to sink | params_flow.rb:11:5:11:11 | call to sink |
+| params_flow.rb:11:5:11:11 | call to sink | params_flow.rb:14:1:14:30 | call to positional |
+| params_flow.rb:11:5:11:11 | call to sink | params_flow.rb:44:1:44:28 | call to positional |
+| params_flow.rb:11:5:11:11 | call to sink | params_flow.rb:47:1:47:17 | call to positional |
+| params_flow.rb:11:5:11:11 | call to sink | params_flow.rb:118:1:118:14 | call to positional |
+| params_flow.rb:14:1:14:30 | * | params_flow.rb:14:1:14:30 | * |
+| params_flow.rb:14:1:14:30 | call to positional | params_flow.rb:14:1:14:30 | call to positional |
+| params_flow.rb:14:12:14:19 | * | params_flow.rb:14:12:14:19 | * |
+| params_flow.rb:14:12:14:19 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:14:12:14:19 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:14:12:14:19 | call to taint | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:14:12:14:19 | call to taint | params_flow.rb:9:16:9:17 | p1 |
+| params_flow.rb:14:12:14:19 | call to taint | params_flow.rb:9:16:9:17 | p1 |
+| params_flow.rb:14:12:14:19 | call to taint | params_flow.rb:10:10:10:11 | p1 |
+| params_flow.rb:14:12:14:19 | call to taint | params_flow.rb:14:12:14:19 | call to taint |
+| params_flow.rb:14:18:14:18 | 1 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:14:18:14:18 | 1 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:14:18:14:18 | 1 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:14:18:14:18 | 1 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:14:18:14:18 | 1 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:14:18:14:18 | 1 | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:14:18:14:18 | 1 | params_flow.rb:9:16:9:17 | p1 |
+| params_flow.rb:14:18:14:18 | 1 | params_flow.rb:9:16:9:17 | p1 |
+| params_flow.rb:14:18:14:18 | 1 | params_flow.rb:10:10:10:11 | p1 |
+| params_flow.rb:14:18:14:18 | 1 | params_flow.rb:14:12:14:19 | call to taint |
+| params_flow.rb:14:18:14:18 | 1 | params_flow.rb:14:18:14:18 | 1 |
+| params_flow.rb:14:22:14:29 | * | params_flow.rb:14:22:14:29 | * |
+| params_flow.rb:14:22:14:29 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:14:22:14:29 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:14:22:14:29 | call to taint | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:14:22:14:29 | call to taint | params_flow.rb:9:20:9:21 | p2 |
+| params_flow.rb:14:22:14:29 | call to taint | params_flow.rb:9:20:9:21 | p2 |
+| params_flow.rb:14:22:14:29 | call to taint | params_flow.rb:11:10:11:11 | p2 |
+| params_flow.rb:14:22:14:29 | call to taint | params_flow.rb:14:22:14:29 | call to taint |
+| params_flow.rb:14:28:14:28 | 2 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:14:28:14:28 | 2 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:14:28:14:28 | 2 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:14:28:14:28 | 2 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:14:28:14:28 | 2 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:14:28:14:28 | 2 | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:14:28:14:28 | 2 | params_flow.rb:9:20:9:21 | p2 |
+| params_flow.rb:14:28:14:28 | 2 | params_flow.rb:9:20:9:21 | p2 |
+| params_flow.rb:14:28:14:28 | 2 | params_flow.rb:11:10:11:11 | p2 |
+| params_flow.rb:14:28:14:28 | 2 | params_flow.rb:14:22:14:29 | call to taint |
+| params_flow.rb:14:28:14:28 | 2 | params_flow.rb:14:28:14:28 | 2 |
+| params_flow.rb:16:1:19:3 | &block | params_flow.rb:16:1:19:3 | &block |
+| params_flow.rb:16:1:19:3 | **kwargs | params_flow.rb:16:1:19:3 | **kwargs |
+| params_flow.rb:16:1:19:3 | keyword | params_flow.rb:16:1:19:3 | keyword |
+| params_flow.rb:16:1:19:3 | self in keyword | params_flow.rb:5:1:7:3 | self (sink) |
+| params_flow.rb:16:1:19:3 | self in keyword | params_flow.rb:5:1:7:3 | self in sink |
+| params_flow.rb:16:1:19:3 | self in keyword | params_flow.rb:6:5:6:10 | self |
+| params_flow.rb:16:1:19:3 | self in keyword | params_flow.rb:16:1:19:3 | self (keyword) |
+| params_flow.rb:16:1:19:3 | self in keyword | params_flow.rb:16:1:19:3 | self in keyword |
+| params_flow.rb:16:1:19:3 | self in keyword | params_flow.rb:17:5:17:11 | self |
+| params_flow.rb:16:1:19:3 | self in keyword | params_flow.rb:18:5:18:11 | self |
+| params_flow.rb:16:13:16:14 | p1 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:16:13:16:14 | p1 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:16:13:16:14 | p1 | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:16:13:16:14 | p1 | params_flow.rb:16:13:16:14 | p1 |
+| params_flow.rb:16:13:16:14 | p1 | params_flow.rb:16:13:16:14 | p1 |
+| params_flow.rb:16:13:16:14 | p1 | params_flow.rb:16:13:16:14 | p1 |
+| params_flow.rb:16:13:16:14 | p1 | params_flow.rb:17:10:17:11 | p1 |
+| params_flow.rb:16:18:16:19 | p2 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:16:18:16:19 | p2 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:16:18:16:19 | p2 | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:16:18:16:19 | p2 | params_flow.rb:16:18:16:19 | p2 |
+| params_flow.rb:16:18:16:19 | p2 | params_flow.rb:16:18:16:19 | p2 |
+| params_flow.rb:16:18:16:19 | p2 | params_flow.rb:16:18:16:19 | p2 |
+| params_flow.rb:16:18:16:19 | p2 | params_flow.rb:18:10:18:11 | p2 |
+| params_flow.rb:17:5:17:11 | * | params_flow.rb:17:5:17:11 | * |
+| params_flow.rb:17:5:17:11 | call to sink | params_flow.rb:17:5:17:11 | call to sink |
+| params_flow.rb:18:5:18:11 | * | params_flow.rb:18:5:18:11 | * |
+| params_flow.rb:18:5:18:11 | call to sink | params_flow.rb:18:5:18:11 | call to sink |
+| params_flow.rb:18:5:18:11 | call to sink | params_flow.rb:21:1:21:35 | call to keyword |
+| params_flow.rb:18:5:18:11 | call to sink | params_flow.rb:22:1:22:35 | call to keyword |
+| params_flow.rb:18:5:18:11 | call to sink | params_flow.rb:23:1:23:41 | call to keyword |
+| params_flow.rb:18:5:18:11 | call to sink | params_flow.rb:41:1:41:30 | call to keyword |
+| params_flow.rb:21:1:21:35 | ** | params_flow.rb:16:1:19:3 | **kwargs |
+| params_flow.rb:21:1:21:35 | ** | params_flow.rb:21:1:21:35 | ** |
+| params_flow.rb:21:1:21:35 | call to keyword | params_flow.rb:21:1:21:35 | call to keyword |
+| params_flow.rb:21:9:21:10 | :p1 | params_flow.rb:21:9:21:10 | :p1 |
+| params_flow.rb:21:9:21:20 | Pair | params_flow.rb:21:9:21:20 | Pair |
+| params_flow.rb:21:13:21:20 | * | params_flow.rb:21:13:21:20 | * |
+| params_flow.rb:21:13:21:20 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:21:13:21:20 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:21:13:21:20 | call to taint | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:21:13:21:20 | call to taint | params_flow.rb:16:13:16:14 | p1 |
+| params_flow.rb:21:13:21:20 | call to taint | params_flow.rb:16:13:16:14 | p1 |
+| params_flow.rb:21:13:21:20 | call to taint | params_flow.rb:17:10:17:11 | p1 |
+| params_flow.rb:21:13:21:20 | call to taint | params_flow.rb:21:13:21:20 | call to taint |
+| params_flow.rb:21:19:21:19 | 3 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:21:19:21:19 | 3 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:21:19:21:19 | 3 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:21:19:21:19 | 3 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:21:19:21:19 | 3 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:21:19:21:19 | 3 | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:21:19:21:19 | 3 | params_flow.rb:16:13:16:14 | p1 |
+| params_flow.rb:21:19:21:19 | 3 | params_flow.rb:16:13:16:14 | p1 |
+| params_flow.rb:21:19:21:19 | 3 | params_flow.rb:17:10:17:11 | p1 |
+| params_flow.rb:21:19:21:19 | 3 | params_flow.rb:21:13:21:20 | call to taint |
+| params_flow.rb:21:19:21:19 | 3 | params_flow.rb:21:19:21:19 | 3 |
+| params_flow.rb:21:23:21:24 | :p2 | params_flow.rb:21:23:21:24 | :p2 |
+| params_flow.rb:21:23:21:34 | Pair | params_flow.rb:21:23:21:34 | Pair |
+| params_flow.rb:21:27:21:34 | * | params_flow.rb:21:27:21:34 | * |
+| params_flow.rb:21:27:21:34 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:21:27:21:34 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:21:27:21:34 | call to taint | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:21:27:21:34 | call to taint | params_flow.rb:16:18:16:19 | p2 |
+| params_flow.rb:21:27:21:34 | call to taint | params_flow.rb:16:18:16:19 | p2 |
+| params_flow.rb:21:27:21:34 | call to taint | params_flow.rb:18:10:18:11 | p2 |
+| params_flow.rb:21:27:21:34 | call to taint | params_flow.rb:21:27:21:34 | call to taint |
+| params_flow.rb:21:33:21:33 | 4 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:21:33:21:33 | 4 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:21:33:21:33 | 4 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:21:33:21:33 | 4 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:21:33:21:33 | 4 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:21:33:21:33 | 4 | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:21:33:21:33 | 4 | params_flow.rb:16:18:16:19 | p2 |
+| params_flow.rb:21:33:21:33 | 4 | params_flow.rb:16:18:16:19 | p2 |
+| params_flow.rb:21:33:21:33 | 4 | params_flow.rb:18:10:18:11 | p2 |
+| params_flow.rb:21:33:21:33 | 4 | params_flow.rb:21:27:21:34 | call to taint |
+| params_flow.rb:21:33:21:33 | 4 | params_flow.rb:21:33:21:33 | 4 |
+| params_flow.rb:22:1:22:35 | ** | params_flow.rb:16:1:19:3 | **kwargs |
+| params_flow.rb:22:1:22:35 | ** | params_flow.rb:22:1:22:35 | ** |
+| params_flow.rb:22:1:22:35 | call to keyword | params_flow.rb:22:1:22:35 | call to keyword |
+| params_flow.rb:22:9:22:10 | :p2 | params_flow.rb:22:9:22:10 | :p2 |
+| params_flow.rb:22:9:22:20 | Pair | params_flow.rb:22:9:22:20 | Pair |
+| params_flow.rb:22:13:22:20 | * | params_flow.rb:22:13:22:20 | * |
+| params_flow.rb:22:13:22:20 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:22:13:22:20 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:22:13:22:20 | call to taint | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:22:13:22:20 | call to taint | params_flow.rb:16:18:16:19 | p2 |
+| params_flow.rb:22:13:22:20 | call to taint | params_flow.rb:16:18:16:19 | p2 |
+| params_flow.rb:22:13:22:20 | call to taint | params_flow.rb:18:10:18:11 | p2 |
+| params_flow.rb:22:13:22:20 | call to taint | params_flow.rb:22:13:22:20 | call to taint |
+| params_flow.rb:22:19:22:19 | 5 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:22:19:22:19 | 5 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:22:19:22:19 | 5 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:22:19:22:19 | 5 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:22:19:22:19 | 5 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:22:19:22:19 | 5 | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:22:19:22:19 | 5 | params_flow.rb:16:18:16:19 | p2 |
+| params_flow.rb:22:19:22:19 | 5 | params_flow.rb:16:18:16:19 | p2 |
+| params_flow.rb:22:19:22:19 | 5 | params_flow.rb:18:10:18:11 | p2 |
+| params_flow.rb:22:19:22:19 | 5 | params_flow.rb:22:13:22:20 | call to taint |
+| params_flow.rb:22:19:22:19 | 5 | params_flow.rb:22:19:22:19 | 5 |
+| params_flow.rb:22:23:22:24 | :p1 | params_flow.rb:22:23:22:24 | :p1 |
+| params_flow.rb:22:23:22:34 | Pair | params_flow.rb:22:23:22:34 | Pair |
+| params_flow.rb:22:27:22:34 | * | params_flow.rb:22:27:22:34 | * |
+| params_flow.rb:22:27:22:34 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:22:27:22:34 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:22:27:22:34 | call to taint | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:22:27:22:34 | call to taint | params_flow.rb:16:13:16:14 | p1 |
+| params_flow.rb:22:27:22:34 | call to taint | params_flow.rb:16:13:16:14 | p1 |
+| params_flow.rb:22:27:22:34 | call to taint | params_flow.rb:17:10:17:11 | p1 |
+| params_flow.rb:22:27:22:34 | call to taint | params_flow.rb:22:27:22:34 | call to taint |
+| params_flow.rb:22:33:22:33 | 6 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:22:33:22:33 | 6 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:22:33:22:33 | 6 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:22:33:22:33 | 6 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:22:33:22:33 | 6 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:22:33:22:33 | 6 | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:22:33:22:33 | 6 | params_flow.rb:16:13:16:14 | p1 |
+| params_flow.rb:22:33:22:33 | 6 | params_flow.rb:16:13:16:14 | p1 |
+| params_flow.rb:22:33:22:33 | 6 | params_flow.rb:17:10:17:11 | p1 |
+| params_flow.rb:22:33:22:33 | 6 | params_flow.rb:22:27:22:34 | call to taint |
+| params_flow.rb:22:33:22:33 | 6 | params_flow.rb:22:33:22:33 | 6 |
+| params_flow.rb:23:1:23:41 | ** | params_flow.rb:16:1:19:3 | **kwargs |
+| params_flow.rb:23:1:23:41 | ** | params_flow.rb:23:1:23:41 | ** |
+| params_flow.rb:23:1:23:41 | call to keyword | params_flow.rb:23:1:23:41 | call to keyword |
+| params_flow.rb:23:9:23:11 | :p2 | params_flow.rb:23:9:23:11 | :p2 |
+| params_flow.rb:23:9:23:23 | Pair | params_flow.rb:23:9:23:23 | Pair |
+| params_flow.rb:23:16:23:23 | * | params_flow.rb:23:16:23:23 | * |
+| params_flow.rb:23:16:23:23 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:23:16:23:23 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:23:16:23:23 | call to taint | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:23:16:23:23 | call to taint | params_flow.rb:16:18:16:19 | p2 |
+| params_flow.rb:23:16:23:23 | call to taint | params_flow.rb:16:18:16:19 | p2 |
+| params_flow.rb:23:16:23:23 | call to taint | params_flow.rb:18:10:18:11 | p2 |
+| params_flow.rb:23:16:23:23 | call to taint | params_flow.rb:23:16:23:23 | call to taint |
+| params_flow.rb:23:22:23:22 | 7 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:23:22:23:22 | 7 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:23:22:23:22 | 7 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:23:22:23:22 | 7 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:23:22:23:22 | 7 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:23:22:23:22 | 7 | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:23:22:23:22 | 7 | params_flow.rb:16:18:16:19 | p2 |
+| params_flow.rb:23:22:23:22 | 7 | params_flow.rb:16:18:16:19 | p2 |
+| params_flow.rb:23:22:23:22 | 7 | params_flow.rb:18:10:18:11 | p2 |
+| params_flow.rb:23:22:23:22 | 7 | params_flow.rb:23:16:23:23 | call to taint |
+| params_flow.rb:23:22:23:22 | 7 | params_flow.rb:23:22:23:22 | 7 |
+| params_flow.rb:23:26:23:28 | :p1 | params_flow.rb:23:26:23:28 | :p1 |
+| params_flow.rb:23:26:23:40 | Pair | params_flow.rb:23:26:23:40 | Pair |
+| params_flow.rb:23:33:23:40 | * | params_flow.rb:23:33:23:40 | * |
+| params_flow.rb:23:33:23:40 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:23:33:23:40 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:23:33:23:40 | call to taint | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:23:33:23:40 | call to taint | params_flow.rb:16:13:16:14 | p1 |
+| params_flow.rb:23:33:23:40 | call to taint | params_flow.rb:16:13:16:14 | p1 |
+| params_flow.rb:23:33:23:40 | call to taint | params_flow.rb:17:10:17:11 | p1 |
+| params_flow.rb:23:33:23:40 | call to taint | params_flow.rb:23:33:23:40 | call to taint |
+| params_flow.rb:23:39:23:39 | 8 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:23:39:23:39 | 8 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:23:39:23:39 | 8 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:23:39:23:39 | 8 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:23:39:23:39 | 8 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:23:39:23:39 | 8 | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:23:39:23:39 | 8 | params_flow.rb:16:13:16:14 | p1 |
+| params_flow.rb:23:39:23:39 | 8 | params_flow.rb:16:13:16:14 | p1 |
+| params_flow.rb:23:39:23:39 | 8 | params_flow.rb:17:10:17:11 | p1 |
+| params_flow.rb:23:39:23:39 | 8 | params_flow.rb:23:33:23:40 | call to taint |
+| params_flow.rb:23:39:23:39 | 8 | params_flow.rb:23:39:23:39 | 8 |
+| params_flow.rb:25:1:31:3 | &block | params_flow.rb:25:1:31:3 | &block |
+| params_flow.rb:25:1:31:3 | **kwargs | params_flow.rb:25:1:31:3 | **kwargs |
+| params_flow.rb:25:1:31:3 | kwargs | params_flow.rb:25:1:31:3 | kwargs |
+| params_flow.rb:25:1:31:3 | self in kwargs | params_flow.rb:5:1:7:3 | self (sink) |
+| params_flow.rb:25:1:31:3 | self in kwargs | params_flow.rb:5:1:7:3 | self in sink |
+| params_flow.rb:25:1:31:3 | self in kwargs | params_flow.rb:6:5:6:10 | self |
+| params_flow.rb:25:1:31:3 | self in kwargs | params_flow.rb:25:1:31:3 | self (kwargs) |
+| params_flow.rb:25:1:31:3 | self in kwargs | params_flow.rb:25:1:31:3 | self in kwargs |
+| params_flow.rb:25:1:31:3 | self in kwargs | params_flow.rb:26:5:26:11 | self |
+| params_flow.rb:25:1:31:3 | self in kwargs | params_flow.rb:27:5:27:22 | self |
+| params_flow.rb:25:1:31:3 | self in kwargs | params_flow.rb:28:5:28:22 | self |
+| params_flow.rb:25:1:31:3 | self in kwargs | params_flow.rb:29:5:29:22 | self |
+| params_flow.rb:25:1:31:3 | self in kwargs | params_flow.rb:30:5:30:22 | self |
+| params_flow.rb:25:12:25:13 | p1 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:25:12:25:13 | p1 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:25:12:25:13 | p1 | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:25:12:25:13 | p1 | params_flow.rb:25:12:25:13 | p1 |
+| params_flow.rb:25:12:25:13 | p1 | params_flow.rb:25:12:25:13 | p1 |
+| params_flow.rb:25:12:25:13 | p1 | params_flow.rb:25:12:25:13 | p1 |
+| params_flow.rb:25:12:25:13 | p1 | params_flow.rb:26:10:26:11 | p1 |
+| params_flow.rb:25:17:25:24 | **kwargs | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:25:17:25:24 | **kwargs | params_flow.rb:25:19:25:24 | kwargs |
+| params_flow.rb:25:17:25:24 | **kwargs | params_flow.rb:27:11:27:16 | kwargs |
+| params_flow.rb:25:17:25:24 | **kwargs | params_flow.rb:28:11:28:16 | kwargs |
+| params_flow.rb:25:17:25:24 | **kwargs | params_flow.rb:29:11:29:16 | kwargs |
+| params_flow.rb:25:17:25:24 | **kwargs | params_flow.rb:30:11:30:16 | kwargs |
+| params_flow.rb:25:19:25:24 | kwargs | params_flow.rb:25:19:25:24 | kwargs |
+| params_flow.rb:26:5:26:11 | * | params_flow.rb:26:5:26:11 | * |
+| params_flow.rb:26:5:26:11 | call to sink | params_flow.rb:26:5:26:11 | call to sink |
+| params_flow.rb:27:5:27:22 | * | params_flow.rb:27:5:27:22 | * |
+| params_flow.rb:27:5:27:22 | call to sink | params_flow.rb:27:5:27:22 | call to sink |
+| params_flow.rb:27:11:27:21 | * | params_flow.rb:27:11:27:21 | * |
+| params_flow.rb:27:11:27:21 | ...[...] | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:27:11:27:21 | ...[...] | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:27:11:27:21 | ...[...] | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:27:11:27:21 | ...[...] | params_flow.rb:27:10:27:22 | ( ... ) |
+| params_flow.rb:27:11:27:21 | ...[...] | params_flow.rb:27:11:27:21 | ...[...] |
+| params_flow.rb:27:18:27:20 | :p1 | params_flow.rb:27:18:27:20 | :p1 |
+| params_flow.rb:28:5:28:22 | * | params_flow.rb:28:5:28:22 | * |
+| params_flow.rb:28:5:28:22 | call to sink | params_flow.rb:28:5:28:22 | call to sink |
+| params_flow.rb:28:11:28:21 | * | params_flow.rb:28:11:28:21 | * |
+| params_flow.rb:28:11:28:21 | ...[...] | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:28:11:28:21 | ...[...] | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:28:11:28:21 | ...[...] | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:28:11:28:21 | ...[...] | params_flow.rb:28:10:28:22 | ( ... ) |
+| params_flow.rb:28:11:28:21 | ...[...] | params_flow.rb:28:11:28:21 | ...[...] |
+| params_flow.rb:28:18:28:20 | :p2 | params_flow.rb:28:18:28:20 | :p2 |
+| params_flow.rb:29:5:29:22 | * | params_flow.rb:29:5:29:22 | * |
+| params_flow.rb:29:5:29:22 | call to sink | params_flow.rb:29:5:29:22 | call to sink |
+| params_flow.rb:29:11:29:21 | * | params_flow.rb:29:11:29:21 | * |
+| params_flow.rb:29:11:29:21 | ...[...] | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:29:11:29:21 | ...[...] | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:29:11:29:21 | ...[...] | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:29:11:29:21 | ...[...] | params_flow.rb:29:10:29:22 | ( ... ) |
+| params_flow.rb:29:11:29:21 | ...[...] | params_flow.rb:29:11:29:21 | ...[...] |
+| params_flow.rb:29:18:29:20 | :p3 | params_flow.rb:29:18:29:20 | :p3 |
+| params_flow.rb:30:5:30:22 | * | params_flow.rb:30:5:30:22 | * |
+| params_flow.rb:30:5:30:22 | call to sink | params_flow.rb:30:5:30:22 | call to sink |
+| params_flow.rb:30:5:30:22 | call to sink | params_flow.rb:33:1:33:58 | call to kwargs |
+| params_flow.rb:30:5:30:22 | call to sink | params_flow.rb:35:1:35:29 | call to kwargs |
+| params_flow.rb:30:5:30:22 | call to sink | params_flow.rb:38:1:38:14 | call to kwargs |
+| params_flow.rb:30:11:30:21 | * | params_flow.rb:30:11:30:21 | * |
+| params_flow.rb:30:11:30:21 | ...[...] | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:30:11:30:21 | ...[...] | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:30:11:30:21 | ...[...] | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:30:11:30:21 | ...[...] | params_flow.rb:30:10:30:22 | ( ... ) |
+| params_flow.rb:30:11:30:21 | ...[...] | params_flow.rb:30:11:30:21 | ...[...] |
+| params_flow.rb:30:18:30:20 | :p4 | params_flow.rb:30:18:30:20 | :p4 |
+| params_flow.rb:33:1:33:58 | ** | params_flow.rb:25:1:31:3 | **kwargs |
+| params_flow.rb:33:1:33:58 | ** | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:33:1:33:58 | ** | params_flow.rb:25:19:25:24 | kwargs |
+| params_flow.rb:33:1:33:58 | ** | params_flow.rb:27:11:27:16 | kwargs |
+| params_flow.rb:33:1:33:58 | ** | params_flow.rb:28:11:28:16 | kwargs |
+| params_flow.rb:33:1:33:58 | ** | params_flow.rb:29:11:29:16 | kwargs |
+| params_flow.rb:33:1:33:58 | ** | params_flow.rb:30:11:30:16 | kwargs |
+| params_flow.rb:33:1:33:58 | ** | params_flow.rb:33:1:33:58 | ** |
+| params_flow.rb:33:1:33:58 | call to kwargs | params_flow.rb:33:1:33:58 | call to kwargs |
+| params_flow.rb:33:8:33:9 | :p1 | params_flow.rb:33:8:33:9 | :p1 |
+| params_flow.rb:33:8:33:19 | Pair | params_flow.rb:33:8:33:19 | Pair |
+| params_flow.rb:33:12:33:19 | * | params_flow.rb:33:12:33:19 | * |
+| params_flow.rb:33:12:33:19 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:33:12:33:19 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:33:12:33:19 | call to taint | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:33:12:33:19 | call to taint | params_flow.rb:25:12:25:13 | p1 |
+| params_flow.rb:33:12:33:19 | call to taint | params_flow.rb:25:12:25:13 | p1 |
+| params_flow.rb:33:12:33:19 | call to taint | params_flow.rb:26:10:26:11 | p1 |
+| params_flow.rb:33:12:33:19 | call to taint | params_flow.rb:27:10:27:22 | ( ... ) |
+| params_flow.rb:33:12:33:19 | call to taint | params_flow.rb:27:11:27:21 | ...[...] |
+| params_flow.rb:33:12:33:19 | call to taint | params_flow.rb:33:12:33:19 | call to taint |
+| params_flow.rb:33:18:33:18 | 9 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:33:18:33:18 | 9 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:33:18:33:18 | 9 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:33:18:33:18 | 9 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:33:18:33:18 | 9 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:33:18:33:18 | 9 | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:33:18:33:18 | 9 | params_flow.rb:25:12:25:13 | p1 |
+| params_flow.rb:33:18:33:18 | 9 | params_flow.rb:25:12:25:13 | p1 |
+| params_flow.rb:33:18:33:18 | 9 | params_flow.rb:26:10:26:11 | p1 |
+| params_flow.rb:33:18:33:18 | 9 | params_flow.rb:27:10:27:22 | ( ... ) |
+| params_flow.rb:33:18:33:18 | 9 | params_flow.rb:27:11:27:21 | ...[...] |
+| params_flow.rb:33:18:33:18 | 9 | params_flow.rb:33:12:33:19 | call to taint |
+| params_flow.rb:33:18:33:18 | 9 | params_flow.rb:33:18:33:18 | 9 |
+| params_flow.rb:33:22:33:23 | :p2 | params_flow.rb:33:22:33:23 | :p2 |
+| params_flow.rb:33:22:33:34 | Pair | params_flow.rb:33:22:33:34 | Pair |
+| params_flow.rb:33:26:33:34 | * | params_flow.rb:33:26:33:34 | * |
+| params_flow.rb:33:26:33:34 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:33:26:33:34 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:33:26:33:34 | call to taint | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:33:26:33:34 | call to taint | params_flow.rb:28:10:28:22 | ( ... ) |
+| params_flow.rb:33:26:33:34 | call to taint | params_flow.rb:28:11:28:21 | ...[...] |
+| params_flow.rb:33:26:33:34 | call to taint | params_flow.rb:33:26:33:34 | call to taint |
+| params_flow.rb:33:32:33:33 | 10 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:33:32:33:33 | 10 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:33:32:33:33 | 10 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:33:32:33:33 | 10 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:33:32:33:33 | 10 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:33:32:33:33 | 10 | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:33:32:33:33 | 10 | params_flow.rb:28:10:28:22 | ( ... ) |
+| params_flow.rb:33:32:33:33 | 10 | params_flow.rb:28:11:28:21 | ...[...] |
+| params_flow.rb:33:32:33:33 | 10 | params_flow.rb:33:26:33:34 | call to taint |
+| params_flow.rb:33:32:33:33 | 10 | params_flow.rb:33:32:33:33 | 10 |
+| params_flow.rb:33:37:33:38 | :p3 | params_flow.rb:33:37:33:38 | :p3 |
+| params_flow.rb:33:37:33:49 | Pair | params_flow.rb:33:37:33:49 | Pair |
+| params_flow.rb:33:41:33:49 | * | params_flow.rb:33:41:33:49 | * |
+| params_flow.rb:33:41:33:49 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:33:41:33:49 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:33:41:33:49 | call to taint | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:33:41:33:49 | call to taint | params_flow.rb:29:10:29:22 | ( ... ) |
+| params_flow.rb:33:41:33:49 | call to taint | params_flow.rb:29:11:29:21 | ...[...] |
+| params_flow.rb:33:41:33:49 | call to taint | params_flow.rb:33:41:33:49 | call to taint |
+| params_flow.rb:33:47:33:48 | 11 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:33:47:33:48 | 11 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:33:47:33:48 | 11 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:33:47:33:48 | 11 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:33:47:33:48 | 11 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:33:47:33:48 | 11 | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:33:47:33:48 | 11 | params_flow.rb:29:10:29:22 | ( ... ) |
+| params_flow.rb:33:47:33:48 | 11 | params_flow.rb:29:11:29:21 | ...[...] |
+| params_flow.rb:33:47:33:48 | 11 | params_flow.rb:33:41:33:49 | call to taint |
+| params_flow.rb:33:47:33:48 | 11 | params_flow.rb:33:47:33:48 | 11 |
+| params_flow.rb:33:52:33:53 | :p4 | params_flow.rb:33:52:33:53 | :p4 |
+| params_flow.rb:33:52:33:57 | Pair | params_flow.rb:33:52:33:57 | Pair |
+| params_flow.rb:33:56:33:57 | "" | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:33:56:33:57 | "" | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:33:56:33:57 | "" | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:33:56:33:57 | "" | params_flow.rb:30:10:30:22 | ( ... ) |
+| params_flow.rb:33:56:33:57 | "" | params_flow.rb:30:11:30:21 | ...[...] |
+| params_flow.rb:33:56:33:57 | "" | params_flow.rb:33:56:33:57 | "" |
+| params_flow.rb:34:1:34:4 | args | params_flow.rb:34:1:34:4 | args |
+| params_flow.rb:34:8:34:32 | ** | params_flow.rb:34:8:34:32 | ** |
+| params_flow.rb:34:8:34:32 | Hash | params_flow.rb:34:8:34:32 | Hash |
+| params_flow.rb:34:8:34:32 | call to [] | params_flow.rb:34:1:34:4 | args |
+| params_flow.rb:34:8:34:32 | call to [] | params_flow.rb:34:1:34:32 | ... = ... |
+| params_flow.rb:34:8:34:32 | call to [] | params_flow.rb:34:8:34:32 | call to [] |
+| params_flow.rb:34:8:34:32 | call to [] | params_flow.rb:35:25:35:28 | args |
+| params_flow.rb:34:10:34:11 | :p3 | params_flow.rb:34:10:34:11 | :p3 |
+| params_flow.rb:34:10:34:22 | Pair | params_flow.rb:34:10:34:22 | Pair |
+| params_flow.rb:34:14:34:22 | * | params_flow.rb:34:14:34:22 | * |
+| params_flow.rb:34:14:34:22 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:34:14:34:22 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:34:14:34:22 | call to taint | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:34:14:34:22 | call to taint | params_flow.rb:29:10:29:22 | ( ... ) |
+| params_flow.rb:34:14:34:22 | call to taint | params_flow.rb:29:11:29:21 | ...[...] |
+| params_flow.rb:34:14:34:22 | call to taint | params_flow.rb:34:14:34:22 | call to taint |
+| params_flow.rb:34:20:34:21 | 12 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:34:20:34:21 | 12 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:34:20:34:21 | 12 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:34:20:34:21 | 12 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:34:20:34:21 | 12 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:34:20:34:21 | 12 | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:34:20:34:21 | 12 | params_flow.rb:29:10:29:22 | ( ... ) |
+| params_flow.rb:34:20:34:21 | 12 | params_flow.rb:29:11:29:21 | ...[...] |
+| params_flow.rb:34:20:34:21 | 12 | params_flow.rb:34:14:34:22 | call to taint |
+| params_flow.rb:34:20:34:21 | 12 | params_flow.rb:34:20:34:21 | 12 |
+| params_flow.rb:34:25:34:26 | :p4 | params_flow.rb:34:25:34:26 | :p4 |
+| params_flow.rb:34:25:34:30 | Pair | params_flow.rb:34:25:34:30 | Pair |
+| params_flow.rb:34:29:34:30 | "" | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:34:29:34:30 | "" | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:34:29:34:30 | "" | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:34:29:34:30 | "" | params_flow.rb:30:10:30:22 | ( ... ) |
+| params_flow.rb:34:29:34:30 | "" | params_flow.rb:30:11:30:21 | ...[...] |
+| params_flow.rb:34:29:34:30 | "" | params_flow.rb:34:29:34:30 | "" |
+| params_flow.rb:35:1:35:29 | ** | params_flow.rb:25:1:31:3 | **kwargs |
+| params_flow.rb:35:1:35:29 | ** | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:35:1:35:29 | ** | params_flow.rb:25:19:25:24 | kwargs |
+| params_flow.rb:35:1:35:29 | ** | params_flow.rb:27:11:27:16 | kwargs |
+| params_flow.rb:35:1:35:29 | ** | params_flow.rb:28:11:28:16 | kwargs |
+| params_flow.rb:35:1:35:29 | ** | params_flow.rb:29:11:29:16 | kwargs |
+| params_flow.rb:35:1:35:29 | ** | params_flow.rb:30:11:30:16 | kwargs |
+| params_flow.rb:35:1:35:29 | ** | params_flow.rb:35:1:35:29 | ** |
+| params_flow.rb:35:1:35:29 | call to kwargs | params_flow.rb:35:1:35:29 | call to kwargs |
+| params_flow.rb:35:8:35:9 | :p1 | params_flow.rb:35:8:35:9 | :p1 |
+| params_flow.rb:35:8:35:20 | Pair | params_flow.rb:35:8:35:20 | Pair |
+| params_flow.rb:35:12:35:20 | * | params_flow.rb:35:12:35:20 | * |
+| params_flow.rb:35:12:35:20 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:35:12:35:20 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:35:12:35:20 | call to taint | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:35:12:35:20 | call to taint | params_flow.rb:25:12:25:13 | p1 |
+| params_flow.rb:35:12:35:20 | call to taint | params_flow.rb:25:12:25:13 | p1 |
+| params_flow.rb:35:12:35:20 | call to taint | params_flow.rb:26:10:26:11 | p1 |
+| params_flow.rb:35:12:35:20 | call to taint | params_flow.rb:27:10:27:22 | ( ... ) |
+| params_flow.rb:35:12:35:20 | call to taint | params_flow.rb:27:11:27:21 | ...[...] |
+| params_flow.rb:35:12:35:20 | call to taint | params_flow.rb:35:12:35:20 | call to taint |
+| params_flow.rb:35:18:35:19 | 13 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:35:18:35:19 | 13 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:35:18:35:19 | 13 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:35:18:35:19 | 13 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:35:18:35:19 | 13 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:35:18:35:19 | 13 | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:35:18:35:19 | 13 | params_flow.rb:25:12:25:13 | p1 |
+| params_flow.rb:35:18:35:19 | 13 | params_flow.rb:25:12:25:13 | p1 |
+| params_flow.rb:35:18:35:19 | 13 | params_flow.rb:26:10:26:11 | p1 |
+| params_flow.rb:35:18:35:19 | 13 | params_flow.rb:27:10:27:22 | ( ... ) |
+| params_flow.rb:35:18:35:19 | 13 | params_flow.rb:27:11:27:21 | ...[...] |
+| params_flow.rb:35:18:35:19 | 13 | params_flow.rb:35:12:35:20 | call to taint |
+| params_flow.rb:35:18:35:19 | 13 | params_flow.rb:35:18:35:19 | 13 |
+| params_flow.rb:35:23:35:28 | ** ... | params_flow.rb:25:1:31:3 | **kwargs |
+| params_flow.rb:35:23:35:28 | ** ... | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:35:23:35:28 | ** ... | params_flow.rb:25:19:25:24 | kwargs |
+| params_flow.rb:35:23:35:28 | ** ... | params_flow.rb:27:11:27:16 | kwargs |
+| params_flow.rb:35:23:35:28 | ** ... | params_flow.rb:28:11:28:16 | kwargs |
+| params_flow.rb:35:23:35:28 | ** ... | params_flow.rb:29:11:29:16 | kwargs |
+| params_flow.rb:35:23:35:28 | ** ... | params_flow.rb:30:11:30:16 | kwargs |
+| params_flow.rb:35:23:35:28 | ** ... | params_flow.rb:35:23:35:28 | ** ... |
+| params_flow.rb:37:1:37:4 | args | params_flow.rb:37:1:37:4 | args |
+| params_flow.rb:37:8:37:44 | ** | params_flow.rb:37:8:37:44 | ** |
+| params_flow.rb:37:8:37:44 | Hash | params_flow.rb:37:8:37:44 | Hash |
+| params_flow.rb:37:8:37:44 | call to [] | params_flow.rb:37:1:37:4 | args |
+| params_flow.rb:37:8:37:44 | call to [] | params_flow.rb:37:1:37:44 | ... = ... |
+| params_flow.rb:37:8:37:44 | call to [] | params_flow.rb:37:8:37:44 | call to [] |
+| params_flow.rb:37:8:37:44 | call to [] | params_flow.rb:38:10:38:13 | args |
+| params_flow.rb:37:9:37:11 | :p1 | params_flow.rb:37:9:37:11 | :p1 |
+| params_flow.rb:37:9:37:24 | Pair | params_flow.rb:37:9:37:24 | Pair |
+| params_flow.rb:37:16:37:24 | * | params_flow.rb:37:16:37:24 | * |
+| params_flow.rb:37:16:37:24 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:37:16:37:24 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:37:16:37:24 | call to taint | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:37:16:37:24 | call to taint | params_flow.rb:27:10:27:22 | ( ... ) |
+| params_flow.rb:37:16:37:24 | call to taint | params_flow.rb:27:11:27:21 | ...[...] |
+| params_flow.rb:37:16:37:24 | call to taint | params_flow.rb:37:16:37:24 | call to taint |
+| params_flow.rb:37:22:37:23 | 14 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:37:22:37:23 | 14 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:37:22:37:23 | 14 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:37:22:37:23 | 14 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:37:22:37:23 | 14 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:37:22:37:23 | 14 | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:37:22:37:23 | 14 | params_flow.rb:27:10:27:22 | ( ... ) |
+| params_flow.rb:37:22:37:23 | 14 | params_flow.rb:27:11:27:21 | ...[...] |
+| params_flow.rb:37:22:37:23 | 14 | params_flow.rb:37:16:37:24 | call to taint |
+| params_flow.rb:37:22:37:23 | 14 | params_flow.rb:37:22:37:23 | 14 |
+| params_flow.rb:37:27:37:29 | :p2 | params_flow.rb:37:27:37:29 | :p2 |
+| params_flow.rb:37:27:37:42 | Pair | params_flow.rb:37:27:37:42 | Pair |
+| params_flow.rb:37:34:37:42 | * | params_flow.rb:37:34:37:42 | * |
+| params_flow.rb:37:34:37:42 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:37:34:37:42 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:37:34:37:42 | call to taint | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:37:34:37:42 | call to taint | params_flow.rb:28:10:28:22 | ( ... ) |
+| params_flow.rb:37:34:37:42 | call to taint | params_flow.rb:28:11:28:21 | ...[...] |
+| params_flow.rb:37:34:37:42 | call to taint | params_flow.rb:37:34:37:42 | call to taint |
+| params_flow.rb:37:40:37:41 | 15 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:37:40:37:41 | 15 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:37:40:37:41 | 15 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:37:40:37:41 | 15 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:37:40:37:41 | 15 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:37:40:37:41 | 15 | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:37:40:37:41 | 15 | params_flow.rb:28:10:28:22 | ( ... ) |
+| params_flow.rb:37:40:37:41 | 15 | params_flow.rb:28:11:28:21 | ...[...] |
+| params_flow.rb:37:40:37:41 | 15 | params_flow.rb:37:34:37:42 | call to taint |
+| params_flow.rb:37:40:37:41 | 15 | params_flow.rb:37:40:37:41 | 15 |
+| params_flow.rb:38:1:38:14 | call to kwargs | params_flow.rb:38:1:38:14 | call to kwargs |
+| params_flow.rb:38:8:38:13 | ** ... | params_flow.rb:25:1:31:3 | **kwargs |
+| params_flow.rb:38:8:38:13 | ** ... | params_flow.rb:25:17:25:24 | **kwargs |
+| params_flow.rb:38:8:38:13 | ** ... | params_flow.rb:25:19:25:24 | kwargs |
+| params_flow.rb:38:8:38:13 | ** ... | params_flow.rb:27:11:27:16 | kwargs |
+| params_flow.rb:38:8:38:13 | ** ... | params_flow.rb:28:11:28:16 | kwargs |
+| params_flow.rb:38:8:38:13 | ** ... | params_flow.rb:29:11:29:16 | kwargs |
+| params_flow.rb:38:8:38:13 | ** ... | params_flow.rb:30:11:30:16 | kwargs |
+| params_flow.rb:38:8:38:13 | ** ... | params_flow.rb:38:8:38:13 | ** ... |
+| params_flow.rb:40:1:40:4 | args | params_flow.rb:40:1:40:4 | args |
+| params_flow.rb:40:8:40:26 | ** | params_flow.rb:40:8:40:26 | ** |
+| params_flow.rb:40:8:40:26 | Hash | params_flow.rb:40:8:40:26 | Hash |
+| params_flow.rb:40:8:40:26 | call to [] | params_flow.rb:40:1:40:4 | args |
+| params_flow.rb:40:8:40:26 | call to [] | params_flow.rb:40:1:40:26 | ... = ... |
+| params_flow.rb:40:8:40:26 | call to [] | params_flow.rb:40:8:40:26 | call to [] |
+| params_flow.rb:40:8:40:26 | call to [] | params_flow.rb:41:26:41:29 | args |
+| params_flow.rb:40:9:40:11 | :p1 | params_flow.rb:40:9:40:11 | :p1 |
+| params_flow.rb:40:9:40:24 | Pair | params_flow.rb:40:9:40:24 | Pair |
+| params_flow.rb:40:16:40:24 | * | params_flow.rb:40:16:40:24 | * |
+| params_flow.rb:40:16:40:24 | call to taint | params_flow.rb:40:16:40:24 | call to taint |
+| params_flow.rb:40:22:40:23 | 16 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:40:22:40:23 | 16 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:40:22:40:23 | 16 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:40:22:40:23 | 16 | params_flow.rb:40:16:40:24 | call to taint |
+| params_flow.rb:40:22:40:23 | 16 | params_flow.rb:40:22:40:23 | 16 |
+| params_flow.rb:41:1:41:30 | ** | params_flow.rb:16:1:19:3 | **kwargs |
+| params_flow.rb:41:1:41:30 | ** | params_flow.rb:41:1:41:30 | ** |
+| params_flow.rb:41:1:41:30 | call to keyword | params_flow.rb:41:1:41:30 | call to keyword |
+| params_flow.rb:41:9:41:10 | :p2 | params_flow.rb:41:9:41:10 | :p2 |
+| params_flow.rb:41:9:41:21 | Pair | params_flow.rb:41:9:41:21 | Pair |
+| params_flow.rb:41:13:41:21 | * | params_flow.rb:41:13:41:21 | * |
+| params_flow.rb:41:13:41:21 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:41:13:41:21 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:41:13:41:21 | call to taint | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:41:13:41:21 | call to taint | params_flow.rb:16:18:16:19 | p2 |
+| params_flow.rb:41:13:41:21 | call to taint | params_flow.rb:16:18:16:19 | p2 |
+| params_flow.rb:41:13:41:21 | call to taint | params_flow.rb:18:10:18:11 | p2 |
+| params_flow.rb:41:13:41:21 | call to taint | params_flow.rb:41:13:41:21 | call to taint |
+| params_flow.rb:41:19:41:20 | 17 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:41:19:41:20 | 17 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:41:19:41:20 | 17 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:41:19:41:20 | 17 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:41:19:41:20 | 17 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:41:19:41:20 | 17 | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:41:19:41:20 | 17 | params_flow.rb:16:18:16:19 | p2 |
+| params_flow.rb:41:19:41:20 | 17 | params_flow.rb:16:18:16:19 | p2 |
+| params_flow.rb:41:19:41:20 | 17 | params_flow.rb:18:10:18:11 | p2 |
+| params_flow.rb:41:19:41:20 | 17 | params_flow.rb:41:13:41:21 | call to taint |
+| params_flow.rb:41:19:41:20 | 17 | params_flow.rb:41:19:41:20 | 17 |
+| params_flow.rb:41:24:41:29 | ** ... | params_flow.rb:16:1:19:3 | **kwargs |
+| params_flow.rb:41:24:41:29 | ** ... | params_flow.rb:41:24:41:29 | ** ... |
+| params_flow.rb:43:1:43:4 | args | params_flow.rb:43:1:43:4 | args |
+| params_flow.rb:43:8:43:18 | * | params_flow.rb:43:8:43:18 | * |
+| params_flow.rb:43:8:43:18 | Array | params_flow.rb:43:8:43:18 | Array |
+| params_flow.rb:43:8:43:18 | call to [] | params_flow.rb:43:1:43:4 | args |
+| params_flow.rb:43:8:43:18 | call to [] | params_flow.rb:43:1:43:18 | ... = ... |
+| params_flow.rb:43:8:43:18 | call to [] | params_flow.rb:43:8:43:18 | call to [] |
+| params_flow.rb:43:8:43:18 | call to [] | params_flow.rb:44:24:44:27 | args |
+| params_flow.rb:43:9:43:17 | * | params_flow.rb:43:9:43:17 | * |
+| params_flow.rb:43:9:43:17 | call to taint | params_flow.rb:43:9:43:17 | call to taint |
+| params_flow.rb:43:15:43:16 | 17 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:43:15:43:16 | 17 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:43:15:43:16 | 17 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:43:15:43:16 | 17 | params_flow.rb:43:9:43:17 | call to taint |
+| params_flow.rb:43:15:43:16 | 17 | params_flow.rb:43:15:43:16 | 17 |
+| params_flow.rb:44:1:44:28 | call to positional | params_flow.rb:44:1:44:28 | call to positional |
+| params_flow.rb:44:12:44:20 | * | params_flow.rb:44:12:44:20 | * |
+| params_flow.rb:44:12:44:20 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:44:12:44:20 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:44:12:44:20 | call to taint | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:44:12:44:20 | call to taint | params_flow.rb:9:16:9:17 | p1 |
+| params_flow.rb:44:12:44:20 | call to taint | params_flow.rb:9:16:9:17 | p1 |
+| params_flow.rb:44:12:44:20 | call to taint | params_flow.rb:10:10:10:11 | p1 |
+| params_flow.rb:44:12:44:20 | call to taint | params_flow.rb:44:12:44:20 | call to taint |
+| params_flow.rb:44:18:44:19 | 16 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:44:18:44:19 | 16 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:44:18:44:19 | 16 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:44:18:44:19 | 16 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:44:18:44:19 | 16 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:44:18:44:19 | 16 | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:44:18:44:19 | 16 | params_flow.rb:9:16:9:17 | p1 |
+| params_flow.rb:44:18:44:19 | 16 | params_flow.rb:9:16:9:17 | p1 |
+| params_flow.rb:44:18:44:19 | 16 | params_flow.rb:10:10:10:11 | p1 |
+| params_flow.rb:44:18:44:19 | 16 | params_flow.rb:44:12:44:20 | call to taint |
+| params_flow.rb:44:18:44:19 | 16 | params_flow.rb:44:18:44:19 | 16 |
+| params_flow.rb:44:23:44:27 | * ... | params_flow.rb:44:23:44:27 | * ... |
+| params_flow.rb:46:1:46:4 | args | params_flow.rb:46:1:46:4 | args |
+| params_flow.rb:46:8:46:29 | * | params_flow.rb:46:8:46:29 | * |
+| params_flow.rb:46:8:46:29 | Array | params_flow.rb:46:8:46:29 | Array |
+| params_flow.rb:46:8:46:29 | call to [] | params_flow.rb:46:1:46:4 | args |
+| params_flow.rb:46:8:46:29 | call to [] | params_flow.rb:46:1:46:29 | ... = ... |
+| params_flow.rb:46:8:46:29 | call to [] | params_flow.rb:46:8:46:29 | call to [] |
+| params_flow.rb:46:8:46:29 | call to [] | params_flow.rb:47:13:47:16 | args |
+| params_flow.rb:46:9:46:17 | * | params_flow.rb:46:9:46:17 | * |
+| params_flow.rb:46:9:46:17 | call to taint | params_flow.rb:46:9:46:17 | call to taint |
+| params_flow.rb:46:15:46:16 | 18 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:46:15:46:16 | 18 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:46:15:46:16 | 18 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:46:15:46:16 | 18 | params_flow.rb:46:9:46:17 | call to taint |
+| params_flow.rb:46:15:46:16 | 18 | params_flow.rb:46:15:46:16 | 18 |
+| params_flow.rb:46:20:46:28 | * | params_flow.rb:46:20:46:28 | * |
+| params_flow.rb:46:20:46:28 | call to taint | params_flow.rb:46:20:46:28 | call to taint |
+| params_flow.rb:46:26:46:27 | 19 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:46:26:46:27 | 19 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:46:26:46:27 | 19 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:46:26:46:27 | 19 | params_flow.rb:46:20:46:28 | call to taint |
+| params_flow.rb:46:26:46:27 | 19 | params_flow.rb:46:26:46:27 | 19 |
+| params_flow.rb:47:1:47:17 | call to positional | params_flow.rb:47:1:47:17 | call to positional |
+| params_flow.rb:47:12:47:16 | * ... | params_flow.rb:9:1:12:3 | synthetic *args |
+| params_flow.rb:47:12:47:16 | * ... | params_flow.rb:47:12:47:16 | * ... |
+| params_flow.rb:49:1:53:3 | &block | params_flow.rb:49:1:53:3 | &block |
+| params_flow.rb:49:1:53:3 | posargs | params_flow.rb:49:1:53:3 | posargs |
+| params_flow.rb:49:1:53:3 | self in posargs | params_flow.rb:5:1:7:3 | self (sink) |
+| params_flow.rb:49:1:53:3 | self in posargs | params_flow.rb:5:1:7:3 | self in sink |
+| params_flow.rb:49:1:53:3 | self in posargs | params_flow.rb:6:5:6:10 | self |
+| params_flow.rb:49:1:53:3 | self in posargs | params_flow.rb:49:1:53:3 | self (posargs) |
+| params_flow.rb:49:1:53:3 | self in posargs | params_flow.rb:49:1:53:3 | self in posargs |
+| params_flow.rb:49:1:53:3 | self in posargs | params_flow.rb:50:5:50:11 | self |
+| params_flow.rb:49:1:53:3 | self in posargs | params_flow.rb:51:5:51:21 | self |
+| params_flow.rb:49:1:53:3 | self in posargs | params_flow.rb:52:5:52:21 | self |
+| params_flow.rb:49:1:53:3 | synthetic *args | params_flow.rb:49:1:53:3 | synthetic *args |
+| params_flow.rb:49:1:53:3 | synthetic *args | params_flow.rb:49:1:53:3 | synthetic *args |
+| params_flow.rb:49:1:53:3 | synthetic *args[0] | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:49:1:53:3 | synthetic *args[0] | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:49:1:53:3 | synthetic *args[0] | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:49:1:53:3 | synthetic *args[0] | params_flow.rb:49:1:53:3 | synthetic *args[0] |
+| params_flow.rb:49:1:53:3 | synthetic *args[0] | params_flow.rb:51:10:51:21 | ( ... ) |
+| params_flow.rb:49:1:53:3 | synthetic *args[0] | params_flow.rb:51:11:51:20 | ...[...] |
+| params_flow.rb:49:1:53:3 | synthetic *args[1] | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:49:1:53:3 | synthetic *args[1] | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:49:1:53:3 | synthetic *args[1] | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:49:1:53:3 | synthetic *args[1] | params_flow.rb:49:1:53:3 | synthetic *args[1] |
+| params_flow.rb:49:1:53:3 | synthetic *args[1] | params_flow.rb:52:10:52:21 | ( ... ) |
+| params_flow.rb:49:1:53:3 | synthetic *args[1] | params_flow.rb:52:11:52:20 | ...[...] |
+| params_flow.rb:49:1:53:3 | synthetic *args[2] | params_flow.rb:49:1:53:3 | synthetic *args[2] |
+| params_flow.rb:49:1:53:3 | synthetic *args[3] | params_flow.rb:49:1:53:3 | synthetic *args[3] |
+| params_flow.rb:49:1:53:3 | synthetic *args[4] | params_flow.rb:49:1:53:3 | synthetic *args[4] |
+| params_flow.rb:49:1:53:3 | synthetic *args[5] | params_flow.rb:49:1:53:3 | synthetic *args[5] |
+| params_flow.rb:49:1:53:3 | synthetic *args[6] | params_flow.rb:49:1:53:3 | synthetic *args[6] |
+| params_flow.rb:49:1:53:3 | synthetic *args[7] | params_flow.rb:49:1:53:3 | synthetic *args[7] |
+| params_flow.rb:49:1:53:3 | synthetic *args[8] | params_flow.rb:49:1:53:3 | synthetic *args[8] |
+| params_flow.rb:49:1:53:3 | synthetic *args[9] | params_flow.rb:49:1:53:3 | synthetic *args[9] |
+| params_flow.rb:49:1:53:3 | synthetic *args[10] | params_flow.rb:49:1:53:3 | synthetic *args[10] |
+| params_flow.rb:49:13:49:14 | p1 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:49:13:49:14 | p1 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:49:13:49:14 | p1 | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:49:13:49:14 | p1 | params_flow.rb:49:13:49:14 | p1 |
+| params_flow.rb:49:13:49:14 | p1 | params_flow.rb:49:13:49:14 | p1 |
+| params_flow.rb:49:13:49:14 | p1 | params_flow.rb:49:13:49:14 | p1 |
+| params_flow.rb:49:13:49:14 | p1 | params_flow.rb:50:10:50:11 | p1 |
+| params_flow.rb:49:17:49:24 | *posargs | params_flow.rb:49:17:49:24 | *posargs |
+| params_flow.rb:49:17:49:24 | *posargs | params_flow.rb:49:18:49:24 | posargs |
+| params_flow.rb:49:17:49:24 | *posargs | params_flow.rb:51:11:51:17 | posargs |
+| params_flow.rb:49:17:49:24 | *posargs | params_flow.rb:52:11:52:17 | posargs |
+| params_flow.rb:49:18:49:24 | posargs | params_flow.rb:49:18:49:24 | posargs |
+| params_flow.rb:50:5:50:11 | * | params_flow.rb:50:5:50:11 | * |
+| params_flow.rb:50:5:50:11 | call to sink | params_flow.rb:50:5:50:11 | call to sink |
+| params_flow.rb:51:5:51:21 | * | params_flow.rb:51:5:51:21 | * |
+| params_flow.rb:51:5:51:21 | call to sink | params_flow.rb:51:5:51:21 | call to sink |
+| params_flow.rb:51:11:51:20 | * | params_flow.rb:51:11:51:20 | * |
+| params_flow.rb:51:11:51:20 | ...[...] | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:51:11:51:20 | ...[...] | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:51:11:51:20 | ...[...] | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:51:11:51:20 | ...[...] | params_flow.rb:51:10:51:21 | ( ... ) |
+| params_flow.rb:51:11:51:20 | ...[...] | params_flow.rb:51:11:51:20 | ...[...] |
+| params_flow.rb:51:19:51:19 | 0 | params_flow.rb:51:19:51:19 | 0 |
+| params_flow.rb:52:5:52:21 | * | params_flow.rb:52:5:52:21 | * |
+| params_flow.rb:52:5:52:21 | call to sink | params_flow.rb:52:5:52:21 | call to sink |
+| params_flow.rb:52:5:52:21 | call to sink | params_flow.rb:55:1:55:29 | call to posargs |
+| params_flow.rb:52:5:52:21 | call to sink | params_flow.rb:58:1:58:25 | call to posargs |
+| params_flow.rb:52:5:52:21 | call to sink | params_flow.rb:61:1:61:14 | call to posargs |
+| params_flow.rb:52:11:52:20 | * | params_flow.rb:52:11:52:20 | * |
+| params_flow.rb:52:11:52:20 | ...[...] | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:52:11:52:20 | ...[...] | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:52:11:52:20 | ...[...] | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:52:11:52:20 | ...[...] | params_flow.rb:52:10:52:21 | ( ... ) |
+| params_flow.rb:52:11:52:20 | ...[...] | params_flow.rb:52:11:52:20 | ...[...] |
+| params_flow.rb:52:19:52:19 | 1 | params_flow.rb:52:19:52:19 | 1 |
+| params_flow.rb:55:1:55:29 | * | params_flow.rb:49:1:53:3 | synthetic *args |
+| params_flow.rb:55:1:55:29 | * | params_flow.rb:55:1:55:29 | * |
+| params_flow.rb:55:1:55:29 | call to posargs | params_flow.rb:55:1:55:29 | call to posargs |
+| params_flow.rb:55:9:55:17 | * | params_flow.rb:55:9:55:17 | * |
+| params_flow.rb:55:9:55:17 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:55:9:55:17 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:55:9:55:17 | call to taint | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:55:9:55:17 | call to taint | params_flow.rb:49:13:49:14 | p1 |
+| params_flow.rb:55:9:55:17 | call to taint | params_flow.rb:49:13:49:14 | p1 |
+| params_flow.rb:55:9:55:17 | call to taint | params_flow.rb:50:10:50:11 | p1 |
+| params_flow.rb:55:9:55:17 | call to taint | params_flow.rb:55:9:55:17 | call to taint |
+| params_flow.rb:55:15:55:16 | 20 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:55:15:55:16 | 20 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:55:15:55:16 | 20 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:55:15:55:16 | 20 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:55:15:55:16 | 20 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:55:15:55:16 | 20 | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:55:15:55:16 | 20 | params_flow.rb:49:13:49:14 | p1 |
+| params_flow.rb:55:15:55:16 | 20 | params_flow.rb:49:13:49:14 | p1 |
+| params_flow.rb:55:15:55:16 | 20 | params_flow.rb:50:10:50:11 | p1 |
+| params_flow.rb:55:15:55:16 | 20 | params_flow.rb:55:9:55:17 | call to taint |
+| params_flow.rb:55:15:55:16 | 20 | params_flow.rb:55:15:55:16 | 20 |
+| params_flow.rb:55:20:55:28 | * | params_flow.rb:55:20:55:28 | * |
+| params_flow.rb:55:20:55:28 | call to taint | params_flow.rb:55:20:55:28 | call to taint |
+| params_flow.rb:55:26:55:27 | 21 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:55:26:55:27 | 21 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:55:26:55:27 | 21 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:55:26:55:27 | 21 | params_flow.rb:55:20:55:28 | call to taint |
+| params_flow.rb:55:26:55:27 | 21 | params_flow.rb:55:26:55:27 | 21 |
+| params_flow.rb:57:1:57:4 | args | params_flow.rb:57:1:57:4 | args |
+| params_flow.rb:57:8:57:18 | * | params_flow.rb:57:8:57:18 | * |
+| params_flow.rb:57:8:57:18 | Array | params_flow.rb:57:8:57:18 | Array |
+| params_flow.rb:57:8:57:18 | call to [] | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:57:8:57:18 | call to [] | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:57:8:57:18 | call to [] | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:57:8:57:18 | call to [] | params_flow.rb:51:10:51:21 | ( ... ) |
+| params_flow.rb:57:8:57:18 | call to [] | params_flow.rb:51:11:51:20 | ...[...] |
+| params_flow.rb:57:8:57:18 | call to [] | params_flow.rb:57:1:57:4 | args |
+| params_flow.rb:57:8:57:18 | call to [] | params_flow.rb:57:1:57:18 | ... = ... |
+| params_flow.rb:57:8:57:18 | call to [] | params_flow.rb:57:8:57:18 | call to [] |
+| params_flow.rb:57:8:57:18 | call to [] | params_flow.rb:58:21:58:24 | args |
+| params_flow.rb:57:9:57:17 | * | params_flow.rb:57:9:57:17 | * |
+| params_flow.rb:57:9:57:17 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:57:9:57:17 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:57:9:57:17 | call to taint | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:57:9:57:17 | call to taint | params_flow.rb:51:10:51:21 | ( ... ) |
+| params_flow.rb:57:9:57:17 | call to taint | params_flow.rb:51:11:51:20 | ...[...] |
+| params_flow.rb:57:9:57:17 | call to taint | params_flow.rb:57:9:57:17 | call to taint |
+| params_flow.rb:57:15:57:16 | 22 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:57:15:57:16 | 22 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:57:15:57:16 | 22 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:57:15:57:16 | 22 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:57:15:57:16 | 22 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:57:15:57:16 | 22 | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:57:15:57:16 | 22 | params_flow.rb:51:10:51:21 | ( ... ) |
+| params_flow.rb:57:15:57:16 | 22 | params_flow.rb:51:11:51:20 | ...[...] |
+| params_flow.rb:57:15:57:16 | 22 | params_flow.rb:57:9:57:17 | call to taint |
+| params_flow.rb:57:15:57:16 | 22 | params_flow.rb:57:15:57:16 | 22 |
+| params_flow.rb:58:1:58:25 | call to posargs | params_flow.rb:58:1:58:25 | call to posargs |
+| params_flow.rb:58:9:58:17 | * | params_flow.rb:58:9:58:17 | * |
+| params_flow.rb:58:9:58:17 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:58:9:58:17 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:58:9:58:17 | call to taint | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:58:9:58:17 | call to taint | params_flow.rb:49:13:49:14 | p1 |
+| params_flow.rb:58:9:58:17 | call to taint | params_flow.rb:49:13:49:14 | p1 |
+| params_flow.rb:58:9:58:17 | call to taint | params_flow.rb:50:10:50:11 | p1 |
+| params_flow.rb:58:9:58:17 | call to taint | params_flow.rb:58:9:58:17 | call to taint |
+| params_flow.rb:58:15:58:16 | 23 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:58:15:58:16 | 23 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:58:15:58:16 | 23 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:58:15:58:16 | 23 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:58:15:58:16 | 23 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:58:15:58:16 | 23 | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:58:15:58:16 | 23 | params_flow.rb:49:13:49:14 | p1 |
+| params_flow.rb:58:15:58:16 | 23 | params_flow.rb:49:13:49:14 | p1 |
+| params_flow.rb:58:15:58:16 | 23 | params_flow.rb:50:10:50:11 | p1 |
+| params_flow.rb:58:15:58:16 | 23 | params_flow.rb:58:9:58:17 | call to taint |
+| params_flow.rb:58:15:58:16 | 23 | params_flow.rb:58:15:58:16 | 23 |
+| params_flow.rb:58:20:58:24 | * ... | params_flow.rb:49:17:49:24 | *posargs |
+| params_flow.rb:58:20:58:24 | * ... | params_flow.rb:49:18:49:24 | posargs |
+| params_flow.rb:58:20:58:24 | * ... | params_flow.rb:51:11:51:17 | posargs |
+| params_flow.rb:58:20:58:24 | * ... | params_flow.rb:52:11:52:17 | posargs |
+| params_flow.rb:58:20:58:24 | * ... | params_flow.rb:58:20:58:24 | * ... |
+| params_flow.rb:60:1:60:4 | args | params_flow.rb:60:1:60:4 | args |
+| params_flow.rb:60:8:60:29 | * | params_flow.rb:60:8:60:29 | * |
+| params_flow.rb:60:8:60:29 | Array | params_flow.rb:60:8:60:29 | Array |
+| params_flow.rb:60:8:60:29 | call to [] | params_flow.rb:60:1:60:4 | args |
+| params_flow.rb:60:8:60:29 | call to [] | params_flow.rb:60:1:60:29 | ... = ... |
+| params_flow.rb:60:8:60:29 | call to [] | params_flow.rb:60:8:60:29 | call to [] |
+| params_flow.rb:60:8:60:29 | call to [] | params_flow.rb:61:10:61:13 | args |
+| params_flow.rb:60:9:60:17 | * | params_flow.rb:60:9:60:17 | * |
+| params_flow.rb:60:9:60:17 | call to taint | params_flow.rb:60:9:60:17 | call to taint |
+| params_flow.rb:60:15:60:16 | 24 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:60:15:60:16 | 24 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:60:15:60:16 | 24 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:60:15:60:16 | 24 | params_flow.rb:60:9:60:17 | call to taint |
+| params_flow.rb:60:15:60:16 | 24 | params_flow.rb:60:15:60:16 | 24 |
+| params_flow.rb:60:20:60:28 | * | params_flow.rb:60:20:60:28 | * |
+| params_flow.rb:60:20:60:28 | call to taint | params_flow.rb:60:20:60:28 | call to taint |
+| params_flow.rb:60:26:60:27 | 25 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:60:26:60:27 | 25 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:60:26:60:27 | 25 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:60:26:60:27 | 25 | params_flow.rb:60:20:60:28 | call to taint |
+| params_flow.rb:60:26:60:27 | 25 | params_flow.rb:60:26:60:27 | 25 |
+| params_flow.rb:61:1:61:14 | call to posargs | params_flow.rb:61:1:61:14 | call to posargs |
+| params_flow.rb:61:9:61:13 | * ... | params_flow.rb:49:1:53:3 | synthetic *args |
+| params_flow.rb:61:9:61:13 | * ... | params_flow.rb:61:9:61:13 | * ... |
+| params_flow.rb:63:1:63:4 | args | params_flow.rb:63:1:63:4 | args |
+| params_flow.rb:63:8:63:16 | * | params_flow.rb:63:8:63:16 | * |
+| params_flow.rb:63:8:63:16 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:63:8:63:16 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:63:8:63:16 | call to taint | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:63:8:63:16 | call to taint | params_flow.rb:63:1:63:4 | args |
+| params_flow.rb:63:8:63:16 | call to taint | params_flow.rb:63:1:63:16 | ... = ... |
+| params_flow.rb:63:8:63:16 | call to taint | params_flow.rb:63:8:63:16 | call to taint |
+| params_flow.rb:63:8:63:16 | call to taint | params_flow.rb:65:10:65:13 | ...[...] |
+| params_flow.rb:63:8:63:16 | call to taint | params_flow.rb:67:13:67:16 | args |
+| params_flow.rb:63:14:63:15 | 26 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:63:14:63:15 | 26 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:63:14:63:15 | 26 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:63:14:63:15 | 26 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:63:14:63:15 | 26 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:63:14:63:15 | 26 | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:63:14:63:15 | 26 | params_flow.rb:63:1:63:4 | args |
+| params_flow.rb:63:14:63:15 | 26 | params_flow.rb:63:1:63:16 | ... = ... |
+| params_flow.rb:63:14:63:15 | 26 | params_flow.rb:63:8:63:16 | call to taint |
+| params_flow.rb:63:14:63:15 | 26 | params_flow.rb:63:14:63:15 | 26 |
+| params_flow.rb:63:14:63:15 | 26 | params_flow.rb:65:10:65:13 | ...[...] |
+| params_flow.rb:63:14:63:15 | 26 | params_flow.rb:67:13:67:16 | args |
+| params_flow.rb:64:1:66:3 | &block | params_flow.rb:64:1:66:3 | &block |
+| params_flow.rb:64:1:66:3 | self in splatstuff | params_flow.rb:5:1:7:3 | self (sink) |
+| params_flow.rb:64:1:66:3 | self in splatstuff | params_flow.rb:5:1:7:3 | self in sink |
+| params_flow.rb:64:1:66:3 | self in splatstuff | params_flow.rb:6:5:6:10 | self |
+| params_flow.rb:64:1:66:3 | self in splatstuff | params_flow.rb:64:1:66:3 | self (splatstuff) |
+| params_flow.rb:64:1:66:3 | self in splatstuff | params_flow.rb:64:1:66:3 | self in splatstuff |
+| params_flow.rb:64:1:66:3 | self in splatstuff | params_flow.rb:65:5:65:13 | self |
+| params_flow.rb:64:1:66:3 | splatstuff | params_flow.rb:64:1:66:3 | splatstuff |
+| params_flow.rb:64:16:64:17 | *x | params_flow.rb:64:16:64:17 | *x |
+| params_flow.rb:64:16:64:17 | *x | params_flow.rb:64:17:64:17 | x |
+| params_flow.rb:64:16:64:17 | *x | params_flow.rb:65:10:65:10 | x |
+| params_flow.rb:64:17:64:17 | x | params_flow.rb:64:17:64:17 | x |
+| params_flow.rb:65:5:65:13 | * | params_flow.rb:65:5:65:13 | * |
+| params_flow.rb:65:5:65:13 | call to sink | params_flow.rb:65:5:65:13 | call to sink |
+| params_flow.rb:65:5:65:13 | call to sink | params_flow.rb:67:1:67:17 | call to splatstuff |
+| params_flow.rb:65:10:65:13 | * | params_flow.rb:65:10:65:13 | * |
+| params_flow.rb:65:10:65:13 | ...[...] | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:65:10:65:13 | ...[...] | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:65:10:65:13 | ...[...] | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:65:10:65:13 | ...[...] | params_flow.rb:65:10:65:13 | ...[...] |
+| params_flow.rb:65:12:65:12 | 0 | params_flow.rb:65:12:65:12 | 0 |
+| params_flow.rb:67:1:67:17 | call to splatstuff | params_flow.rb:67:1:67:17 | call to splatstuff |
+| params_flow.rb:67:12:67:16 | * ... | params_flow.rb:64:16:64:17 | *x |
+| params_flow.rb:67:12:67:16 | * ... | params_flow.rb:64:17:64:17 | x |
+| params_flow.rb:67:12:67:16 | * ... | params_flow.rb:65:10:65:10 | x |
+| params_flow.rb:67:12:67:16 | * ... | params_flow.rb:67:12:67:16 | * ... |
+| params_flow.rb:69:1:76:3 | &block | params_flow.rb:69:1:76:3 | &block |
+| params_flow.rb:69:1:76:3 | self in splatmid | params_flow.rb:5:1:7:3 | self (sink) |
+| params_flow.rb:69:1:76:3 | self in splatmid | params_flow.rb:5:1:7:3 | self in sink |
+| params_flow.rb:69:1:76:3 | self in splatmid | params_flow.rb:6:5:6:10 | self |
+| params_flow.rb:69:1:76:3 | self in splatmid | params_flow.rb:69:1:76:3 | self (splatmid) |
+| params_flow.rb:69:1:76:3 | self in splatmid | params_flow.rb:69:1:76:3 | self in splatmid |
+| params_flow.rb:69:1:76:3 | self in splatmid | params_flow.rb:70:5:70:10 | self |
+| params_flow.rb:69:1:76:3 | self in splatmid | params_flow.rb:71:5:71:10 | self |
+| params_flow.rb:69:1:76:3 | self in splatmid | params_flow.rb:72:5:72:13 | self |
+| params_flow.rb:69:1:76:3 | self in splatmid | params_flow.rb:73:5:73:13 | self |
+| params_flow.rb:69:1:76:3 | self in splatmid | params_flow.rb:74:5:74:10 | self |
+| params_flow.rb:69:1:76:3 | self in splatmid | params_flow.rb:75:5:75:10 | self |
+| params_flow.rb:69:1:76:3 | splatmid | params_flow.rb:69:1:76:3 | splatmid |
+| params_flow.rb:69:1:76:3 | synthetic *args | params_flow.rb:69:1:76:3 | synthetic *args |
+| params_flow.rb:69:14:69:14 | x | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:69:14:69:14 | x | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:69:14:69:14 | x | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:69:14:69:14 | x | params_flow.rb:69:14:69:14 | x |
+| params_flow.rb:69:14:69:14 | x | params_flow.rb:69:14:69:14 | x |
+| params_flow.rb:69:14:69:14 | x | params_flow.rb:69:14:69:14 | x |
+| params_flow.rb:69:14:69:14 | x | params_flow.rb:70:10:70:10 | x |
+| params_flow.rb:69:17:69:17 | y | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:69:17:69:17 | y | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:69:17:69:17 | y | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:69:17:69:17 | y | params_flow.rb:69:17:69:17 | y |
+| params_flow.rb:69:17:69:17 | y | params_flow.rb:69:17:69:17 | y |
+| params_flow.rb:69:17:69:17 | y | params_flow.rb:69:17:69:17 | y |
+| params_flow.rb:69:17:69:17 | y | params_flow.rb:71:10:71:10 | y |
+| params_flow.rb:69:20:69:21 | *z | params_flow.rb:69:20:69:21 | *z |
+| params_flow.rb:69:20:69:21 | *z | params_flow.rb:69:21:69:21 | z |
+| params_flow.rb:69:20:69:21 | *z | params_flow.rb:72:10:72:10 | z |
+| params_flow.rb:69:20:69:21 | *z | params_flow.rb:73:10:73:10 | z |
+| params_flow.rb:69:21:69:21 | z | params_flow.rb:69:21:69:21 | z |
+| params_flow.rb:69:24:69:24 | w | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:69:24:69:24 | w | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:69:24:69:24 | w | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:69:24:69:24 | w | params_flow.rb:69:24:69:24 | w |
+| params_flow.rb:69:24:69:24 | w | params_flow.rb:69:24:69:24 | w |
+| params_flow.rb:69:24:69:24 | w | params_flow.rb:69:24:69:24 | w |
+| params_flow.rb:69:24:69:24 | w | params_flow.rb:74:10:74:10 | w |
+| params_flow.rb:69:27:69:27 | r | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:69:27:69:27 | r | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:69:27:69:27 | r | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:69:27:69:27 | r | params_flow.rb:69:27:69:27 | r |
+| params_flow.rb:69:27:69:27 | r | params_flow.rb:69:27:69:27 | r |
+| params_flow.rb:69:27:69:27 | r | params_flow.rb:69:27:69:27 | r |
+| params_flow.rb:69:27:69:27 | r | params_flow.rb:75:10:75:10 | r |
+| params_flow.rb:70:5:70:10 | * | params_flow.rb:70:5:70:10 | * |
+| params_flow.rb:70:5:70:10 | call to sink | params_flow.rb:70:5:70:10 | call to sink |
+| params_flow.rb:71:5:71:10 | * | params_flow.rb:71:5:71:10 | * |
+| params_flow.rb:71:5:71:10 | call to sink | params_flow.rb:71:5:71:10 | call to sink |
+| params_flow.rb:72:5:72:13 | * | params_flow.rb:72:5:72:13 | * |
+| params_flow.rb:72:5:72:13 | call to sink | params_flow.rb:72:5:72:13 | call to sink |
+| params_flow.rb:72:10:72:13 | * | params_flow.rb:72:10:72:13 | * |
+| params_flow.rb:72:10:72:13 | ...[...] | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:72:10:72:13 | ...[...] | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:72:10:72:13 | ...[...] | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:72:10:72:13 | ...[...] | params_flow.rb:72:10:72:13 | ...[...] |
+| params_flow.rb:72:12:72:12 | 0 | params_flow.rb:72:12:72:12 | 0 |
+| params_flow.rb:73:5:73:13 | * | params_flow.rb:73:5:73:13 | * |
+| params_flow.rb:73:5:73:13 | call to sink | params_flow.rb:73:5:73:13 | call to sink |
+| params_flow.rb:73:10:73:13 | * | params_flow.rb:73:10:73:13 | * |
+| params_flow.rb:73:10:73:13 | ...[...] | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:73:10:73:13 | ...[...] | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:73:10:73:13 | ...[...] | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:73:10:73:13 | ...[...] | params_flow.rb:73:10:73:13 | ...[...] |
+| params_flow.rb:73:12:73:12 | 1 | params_flow.rb:73:12:73:12 | 1 |
+| params_flow.rb:74:5:74:10 | * | params_flow.rb:74:5:74:10 | * |
+| params_flow.rb:74:5:74:10 | call to sink | params_flow.rb:74:5:74:10 | call to sink |
+| params_flow.rb:75:5:75:10 | * | params_flow.rb:75:5:75:10 | * |
+| params_flow.rb:75:5:75:10 | call to sink | params_flow.rb:75:5:75:10 | call to sink |
+| params_flow.rb:75:5:75:10 | call to sink | params_flow.rb:78:1:78:63 | call to splatmid |
+| params_flow.rb:75:5:75:10 | call to sink | params_flow.rb:81:1:81:37 | call to splatmid |
+| params_flow.rb:75:5:75:10 | call to sink | params_flow.rb:96:1:96:88 | call to splatmid |
+| params_flow.rb:78:1:78:63 | * | params_flow.rb:78:1:78:63 | * |
+| params_flow.rb:78:1:78:63 | call to splatmid | params_flow.rb:78:1:78:63 | call to splatmid |
+| params_flow.rb:78:10:78:18 | * | params_flow.rb:78:10:78:18 | * |
+| params_flow.rb:78:10:78:18 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:78:10:78:18 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:78:10:78:18 | call to taint | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:78:10:78:18 | call to taint | params_flow.rb:69:14:69:14 | x |
+| params_flow.rb:78:10:78:18 | call to taint | params_flow.rb:69:14:69:14 | x |
+| params_flow.rb:78:10:78:18 | call to taint | params_flow.rb:70:10:70:10 | x |
+| params_flow.rb:78:10:78:18 | call to taint | params_flow.rb:78:10:78:18 | call to taint |
+| params_flow.rb:78:16:78:17 | 27 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:78:16:78:17 | 27 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:78:16:78:17 | 27 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:78:16:78:17 | 27 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:78:16:78:17 | 27 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:78:16:78:17 | 27 | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:78:16:78:17 | 27 | params_flow.rb:69:14:69:14 | x |
+| params_flow.rb:78:16:78:17 | 27 | params_flow.rb:69:14:69:14 | x |
+| params_flow.rb:78:16:78:17 | 27 | params_flow.rb:70:10:70:10 | x |
+| params_flow.rb:78:16:78:17 | 27 | params_flow.rb:78:10:78:18 | call to taint |
+| params_flow.rb:78:16:78:17 | 27 | params_flow.rb:78:16:78:17 | 27 |
+| params_flow.rb:78:21:78:29 | * | params_flow.rb:78:21:78:29 | * |
+| params_flow.rb:78:21:78:29 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:78:21:78:29 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:78:21:78:29 | call to taint | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:78:21:78:29 | call to taint | params_flow.rb:69:17:69:17 | y |
+| params_flow.rb:78:21:78:29 | call to taint | params_flow.rb:69:17:69:17 | y |
+| params_flow.rb:78:21:78:29 | call to taint | params_flow.rb:71:10:71:10 | y |
+| params_flow.rb:78:21:78:29 | call to taint | params_flow.rb:78:21:78:29 | call to taint |
+| params_flow.rb:78:27:78:28 | 28 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:78:27:78:28 | 28 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:78:27:78:28 | 28 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:78:27:78:28 | 28 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:78:27:78:28 | 28 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:78:27:78:28 | 28 | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:78:27:78:28 | 28 | params_flow.rb:69:17:69:17 | y |
+| params_flow.rb:78:27:78:28 | 28 | params_flow.rb:69:17:69:17 | y |
+| params_flow.rb:78:27:78:28 | 28 | params_flow.rb:71:10:71:10 | y |
+| params_flow.rb:78:27:78:28 | 28 | params_flow.rb:78:21:78:29 | call to taint |
+| params_flow.rb:78:27:78:28 | 28 | params_flow.rb:78:27:78:28 | 28 |
+| params_flow.rb:78:32:78:40 | * | params_flow.rb:78:32:78:40 | * |
+| params_flow.rb:78:32:78:40 | call to taint | params_flow.rb:78:32:78:40 | call to taint |
+| params_flow.rb:78:38:78:39 | 29 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:78:38:78:39 | 29 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:78:38:78:39 | 29 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:78:38:78:39 | 29 | params_flow.rb:78:32:78:40 | call to taint |
+| params_flow.rb:78:38:78:39 | 29 | params_flow.rb:78:38:78:39 | 29 |
+| params_flow.rb:78:43:78:51 | * | params_flow.rb:78:43:78:51 | * |
+| params_flow.rb:78:43:78:51 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:78:43:78:51 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:78:43:78:51 | call to taint | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:78:43:78:51 | call to taint | params_flow.rb:69:24:69:24 | w |
+| params_flow.rb:78:43:78:51 | call to taint | params_flow.rb:69:24:69:24 | w |
+| params_flow.rb:78:43:78:51 | call to taint | params_flow.rb:74:10:74:10 | w |
+| params_flow.rb:78:43:78:51 | call to taint | params_flow.rb:78:43:78:51 | call to taint |
+| params_flow.rb:78:49:78:50 | 30 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:78:49:78:50 | 30 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:78:49:78:50 | 30 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:78:49:78:50 | 30 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:78:49:78:50 | 30 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:78:49:78:50 | 30 | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:78:49:78:50 | 30 | params_flow.rb:69:24:69:24 | w |
+| params_flow.rb:78:49:78:50 | 30 | params_flow.rb:69:24:69:24 | w |
+| params_flow.rb:78:49:78:50 | 30 | params_flow.rb:74:10:74:10 | w |
+| params_flow.rb:78:49:78:50 | 30 | params_flow.rb:78:43:78:51 | call to taint |
+| params_flow.rb:78:49:78:50 | 30 | params_flow.rb:78:49:78:50 | 30 |
+| params_flow.rb:78:54:78:62 | * | params_flow.rb:78:54:78:62 | * |
+| params_flow.rb:78:54:78:62 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:78:54:78:62 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:78:54:78:62 | call to taint | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:78:54:78:62 | call to taint | params_flow.rb:69:27:69:27 | r |
+| params_flow.rb:78:54:78:62 | call to taint | params_flow.rb:69:27:69:27 | r |
+| params_flow.rb:78:54:78:62 | call to taint | params_flow.rb:75:10:75:10 | r |
+| params_flow.rb:78:54:78:62 | call to taint | params_flow.rb:78:54:78:62 | call to taint |
+| params_flow.rb:78:60:78:61 | 31 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:78:60:78:61 | 31 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:78:60:78:61 | 31 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:78:60:78:61 | 31 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:78:60:78:61 | 31 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:78:60:78:61 | 31 | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:78:60:78:61 | 31 | params_flow.rb:69:27:69:27 | r |
+| params_flow.rb:78:60:78:61 | 31 | params_flow.rb:69:27:69:27 | r |
+| params_flow.rb:78:60:78:61 | 31 | params_flow.rb:75:10:75:10 | r |
+| params_flow.rb:78:60:78:61 | 31 | params_flow.rb:78:54:78:62 | call to taint |
+| params_flow.rb:78:60:78:61 | 31 | params_flow.rb:78:60:78:61 | 31 |
+| params_flow.rb:80:1:80:4 | args | params_flow.rb:80:1:80:4 | args |
+| params_flow.rb:80:8:80:51 | * | params_flow.rb:80:8:80:51 | * |
+| params_flow.rb:80:8:80:51 | Array | params_flow.rb:80:8:80:51 | Array |
+| params_flow.rb:80:8:80:51 | call to [] | params_flow.rb:80:1:80:4 | args |
+| params_flow.rb:80:8:80:51 | call to [] | params_flow.rb:80:1:80:51 | ... = ... |
+| params_flow.rb:80:8:80:51 | call to [] | params_flow.rb:80:8:80:51 | call to [] |
+| params_flow.rb:80:8:80:51 | call to [] | params_flow.rb:81:22:81:25 | args |
+| params_flow.rb:80:9:80:17 | * | params_flow.rb:80:9:80:17 | * |
+| params_flow.rb:80:9:80:17 | call to taint | params_flow.rb:80:9:80:17 | call to taint |
+| params_flow.rb:80:15:80:16 | 33 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:80:15:80:16 | 33 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:80:15:80:16 | 33 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:80:15:80:16 | 33 | params_flow.rb:80:9:80:17 | call to taint |
+| params_flow.rb:80:15:80:16 | 33 | params_flow.rb:80:15:80:16 | 33 |
+| params_flow.rb:80:20:80:28 | * | params_flow.rb:80:20:80:28 | * |
+| params_flow.rb:80:20:80:28 | call to taint | params_flow.rb:80:20:80:28 | call to taint |
+| params_flow.rb:80:26:80:27 | 34 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:80:26:80:27 | 34 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:80:26:80:27 | 34 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:80:26:80:27 | 34 | params_flow.rb:80:20:80:28 | call to taint |
+| params_flow.rb:80:26:80:27 | 34 | params_flow.rb:80:26:80:27 | 34 |
+| params_flow.rb:80:31:80:39 | * | params_flow.rb:80:31:80:39 | * |
+| params_flow.rb:80:31:80:39 | call to taint | params_flow.rb:80:31:80:39 | call to taint |
+| params_flow.rb:80:37:80:38 | 35 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:80:37:80:38 | 35 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:80:37:80:38 | 35 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:80:37:80:38 | 35 | params_flow.rb:80:31:80:39 | call to taint |
+| params_flow.rb:80:37:80:38 | 35 | params_flow.rb:80:37:80:38 | 35 |
+| params_flow.rb:80:42:80:50 | * | params_flow.rb:80:42:80:50 | * |
+| params_flow.rb:80:42:80:50 | call to taint | params_flow.rb:80:42:80:50 | call to taint |
+| params_flow.rb:80:48:80:49 | 36 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:80:48:80:49 | 36 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:80:48:80:49 | 36 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:80:48:80:49 | 36 | params_flow.rb:80:42:80:50 | call to taint |
+| params_flow.rb:80:48:80:49 | 36 | params_flow.rb:80:48:80:49 | 36 |
+| params_flow.rb:81:1:81:37 | call to splatmid | params_flow.rb:81:1:81:37 | call to splatmid |
+| params_flow.rb:81:10:81:18 | * | params_flow.rb:81:10:81:18 | * |
+| params_flow.rb:81:10:81:18 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:81:10:81:18 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:81:10:81:18 | call to taint | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:81:10:81:18 | call to taint | params_flow.rb:69:14:69:14 | x |
+| params_flow.rb:81:10:81:18 | call to taint | params_flow.rb:69:14:69:14 | x |
+| params_flow.rb:81:10:81:18 | call to taint | params_flow.rb:70:10:70:10 | x |
+| params_flow.rb:81:10:81:18 | call to taint | params_flow.rb:81:10:81:18 | call to taint |
+| params_flow.rb:81:16:81:17 | 32 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:81:16:81:17 | 32 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:81:16:81:17 | 32 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:81:16:81:17 | 32 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:81:16:81:17 | 32 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:81:16:81:17 | 32 | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:81:16:81:17 | 32 | params_flow.rb:69:14:69:14 | x |
+| params_flow.rb:81:16:81:17 | 32 | params_flow.rb:69:14:69:14 | x |
+| params_flow.rb:81:16:81:17 | 32 | params_flow.rb:70:10:70:10 | x |
+| params_flow.rb:81:16:81:17 | 32 | params_flow.rb:81:10:81:18 | call to taint |
+| params_flow.rb:81:16:81:17 | 32 | params_flow.rb:81:16:81:17 | 32 |
+| params_flow.rb:81:21:81:25 | * ... | params_flow.rb:81:21:81:25 | * ... |
+| params_flow.rb:81:28:81:36 | * | params_flow.rb:81:28:81:36 | * |
+| params_flow.rb:81:28:81:36 | call to taint | params_flow.rb:81:28:81:36 | call to taint |
+| params_flow.rb:81:34:81:35 | 37 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:81:34:81:35 | 37 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:81:34:81:35 | 37 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:81:34:81:35 | 37 | params_flow.rb:81:28:81:36 | call to taint |
+| params_flow.rb:81:34:81:35 | 37 | params_flow.rb:81:34:81:35 | 37 |
+| params_flow.rb:83:1:91:3 | &block | params_flow.rb:83:1:91:3 | &block |
+| params_flow.rb:83:1:91:3 | pos_many | params_flow.rb:83:1:91:3 | pos_many |
+| params_flow.rb:83:1:91:3 | self in pos_many | params_flow.rb:5:1:7:3 | self (sink) |
+| params_flow.rb:83:1:91:3 | self in pos_many | params_flow.rb:5:1:7:3 | self in sink |
+| params_flow.rb:83:1:91:3 | self in pos_many | params_flow.rb:6:5:6:10 | self |
+| params_flow.rb:83:1:91:3 | self in pos_many | params_flow.rb:83:1:91:3 | self (pos_many) |
+| params_flow.rb:83:1:91:3 | self in pos_many | params_flow.rb:83:1:91:3 | self in pos_many |
+| params_flow.rb:83:1:91:3 | self in pos_many | params_flow.rb:84:5:84:10 | self |
+| params_flow.rb:83:1:91:3 | self in pos_many | params_flow.rb:85:5:85:10 | self |
+| params_flow.rb:83:1:91:3 | self in pos_many | params_flow.rb:86:5:86:10 | self |
+| params_flow.rb:83:1:91:3 | self in pos_many | params_flow.rb:87:5:87:10 | self |
+| params_flow.rb:83:1:91:3 | self in pos_many | params_flow.rb:88:5:88:10 | self |
+| params_flow.rb:83:1:91:3 | self in pos_many | params_flow.rb:89:5:89:10 | self |
+| params_flow.rb:83:1:91:3 | self in pos_many | params_flow.rb:90:5:90:10 | self |
+| params_flow.rb:83:1:91:3 | synthetic *args | params_flow.rb:83:1:91:3 | synthetic *args |
+| params_flow.rb:83:14:83:14 | t | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:83:14:83:14 | t | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:83:14:83:14 | t | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:83:14:83:14 | t | params_flow.rb:83:14:83:14 | t |
+| params_flow.rb:83:14:83:14 | t | params_flow.rb:83:14:83:14 | t |
+| params_flow.rb:83:14:83:14 | t | params_flow.rb:83:14:83:14 | t |
+| params_flow.rb:83:14:83:14 | t | params_flow.rb:84:10:84:10 | t |
+| params_flow.rb:83:17:83:17 | u | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:83:17:83:17 | u | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:83:17:83:17 | u | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:83:17:83:17 | u | params_flow.rb:83:17:83:17 | u |
+| params_flow.rb:83:17:83:17 | u | params_flow.rb:83:17:83:17 | u |
+| params_flow.rb:83:17:83:17 | u | params_flow.rb:83:17:83:17 | u |
+| params_flow.rb:83:17:83:17 | u | params_flow.rb:85:10:85:10 | u |
+| params_flow.rb:83:20:83:20 | v | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:83:20:83:20 | v | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:83:20:83:20 | v | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:83:20:83:20 | v | params_flow.rb:83:20:83:20 | v |
+| params_flow.rb:83:20:83:20 | v | params_flow.rb:83:20:83:20 | v |
+| params_flow.rb:83:20:83:20 | v | params_flow.rb:83:20:83:20 | v |
+| params_flow.rb:83:20:83:20 | v | params_flow.rb:86:10:86:10 | v |
+| params_flow.rb:83:23:83:23 | w | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:83:23:83:23 | w | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:83:23:83:23 | w | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:83:23:83:23 | w | params_flow.rb:83:23:83:23 | w |
+| params_flow.rb:83:23:83:23 | w | params_flow.rb:83:23:83:23 | w |
+| params_flow.rb:83:23:83:23 | w | params_flow.rb:83:23:83:23 | w |
+| params_flow.rb:83:23:83:23 | w | params_flow.rb:87:10:87:10 | w |
+| params_flow.rb:83:26:83:26 | x | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:83:26:83:26 | x | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:83:26:83:26 | x | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:83:26:83:26 | x | params_flow.rb:83:26:83:26 | x |
+| params_flow.rb:83:26:83:26 | x | params_flow.rb:83:26:83:26 | x |
+| params_flow.rb:83:26:83:26 | x | params_flow.rb:83:26:83:26 | x |
+| params_flow.rb:83:26:83:26 | x | params_flow.rb:88:10:88:10 | x |
+| params_flow.rb:83:29:83:29 | y | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:83:29:83:29 | y | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:83:29:83:29 | y | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:83:29:83:29 | y | params_flow.rb:83:29:83:29 | y |
+| params_flow.rb:83:29:83:29 | y | params_flow.rb:83:29:83:29 | y |
+| params_flow.rb:83:29:83:29 | y | params_flow.rb:83:29:83:29 | y |
+| params_flow.rb:83:29:83:29 | y | params_flow.rb:89:10:89:10 | y |
+| params_flow.rb:83:32:83:32 | z | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:83:32:83:32 | z | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:83:32:83:32 | z | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:83:32:83:32 | z | params_flow.rb:83:32:83:32 | z |
+| params_flow.rb:83:32:83:32 | z | params_flow.rb:83:32:83:32 | z |
+| params_flow.rb:83:32:83:32 | z | params_flow.rb:83:32:83:32 | z |
+| params_flow.rb:83:32:83:32 | z | params_flow.rb:90:10:90:10 | z |
+| params_flow.rb:84:5:84:10 | * | params_flow.rb:84:5:84:10 | * |
+| params_flow.rb:84:5:84:10 | call to sink | params_flow.rb:84:5:84:10 | call to sink |
+| params_flow.rb:85:5:85:10 | * | params_flow.rb:85:5:85:10 | * |
+| params_flow.rb:85:5:85:10 | call to sink | params_flow.rb:85:5:85:10 | call to sink |
+| params_flow.rb:86:5:86:10 | * | params_flow.rb:86:5:86:10 | * |
+| params_flow.rb:86:5:86:10 | call to sink | params_flow.rb:86:5:86:10 | call to sink |
+| params_flow.rb:87:5:87:10 | * | params_flow.rb:87:5:87:10 | * |
+| params_flow.rb:87:5:87:10 | call to sink | params_flow.rb:87:5:87:10 | call to sink |
+| params_flow.rb:88:5:88:10 | * | params_flow.rb:88:5:88:10 | * |
+| params_flow.rb:88:5:88:10 | call to sink | params_flow.rb:88:5:88:10 | call to sink |
+| params_flow.rb:89:5:89:10 | * | params_flow.rb:89:5:89:10 | * |
+| params_flow.rb:89:5:89:10 | call to sink | params_flow.rb:89:5:89:10 | call to sink |
+| params_flow.rb:90:5:90:10 | * | params_flow.rb:90:5:90:10 | * |
+| params_flow.rb:90:5:90:10 | call to sink | params_flow.rb:90:5:90:10 | call to sink |
+| params_flow.rb:90:5:90:10 | call to sink | params_flow.rb:94:1:94:48 | call to pos_many |
+| params_flow.rb:93:1:93:4 | args | params_flow.rb:93:1:93:4 | args |
+| params_flow.rb:93:8:93:51 | * | params_flow.rb:93:8:93:51 | * |
+| params_flow.rb:93:8:93:51 | Array | params_flow.rb:93:8:93:51 | Array |
+| params_flow.rb:93:8:93:51 | call to [] | params_flow.rb:93:1:93:4 | args |
+| params_flow.rb:93:8:93:51 | call to [] | params_flow.rb:93:1:93:51 | ... = ... |
+| params_flow.rb:93:8:93:51 | call to [] | params_flow.rb:93:8:93:51 | call to [] |
+| params_flow.rb:93:8:93:51 | call to [] | params_flow.rb:94:33:94:36 | args |
+| params_flow.rb:93:9:93:17 | * | params_flow.rb:93:9:93:17 | * |
+| params_flow.rb:93:9:93:17 | call to taint | params_flow.rb:93:9:93:17 | call to taint |
+| params_flow.rb:93:15:93:16 | 40 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:93:15:93:16 | 40 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:93:15:93:16 | 40 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:93:15:93:16 | 40 | params_flow.rb:93:9:93:17 | call to taint |
+| params_flow.rb:93:15:93:16 | 40 | params_flow.rb:93:15:93:16 | 40 |
+| params_flow.rb:93:20:93:28 | * | params_flow.rb:93:20:93:28 | * |
+| params_flow.rb:93:20:93:28 | call to taint | params_flow.rb:93:20:93:28 | call to taint |
+| params_flow.rb:93:26:93:27 | 41 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:93:26:93:27 | 41 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:93:26:93:27 | 41 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:93:26:93:27 | 41 | params_flow.rb:93:20:93:28 | call to taint |
+| params_flow.rb:93:26:93:27 | 41 | params_flow.rb:93:26:93:27 | 41 |
+| params_flow.rb:93:31:93:39 | * | params_flow.rb:93:31:93:39 | * |
+| params_flow.rb:93:31:93:39 | call to taint | params_flow.rb:93:31:93:39 | call to taint |
+| params_flow.rb:93:37:93:38 | 42 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:93:37:93:38 | 42 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:93:37:93:38 | 42 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:93:37:93:38 | 42 | params_flow.rb:93:31:93:39 | call to taint |
+| params_flow.rb:93:37:93:38 | 42 | params_flow.rb:93:37:93:38 | 42 |
+| params_flow.rb:93:42:93:50 | * | params_flow.rb:93:42:93:50 | * |
+| params_flow.rb:93:42:93:50 | call to taint | params_flow.rb:93:42:93:50 | call to taint |
+| params_flow.rb:93:48:93:49 | 43 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:93:48:93:49 | 43 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:93:48:93:49 | 43 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:93:48:93:49 | 43 | params_flow.rb:93:42:93:50 | call to taint |
+| params_flow.rb:93:48:93:49 | 43 | params_flow.rb:93:48:93:49 | 43 |
+| params_flow.rb:94:1:94:48 | call to pos_many | params_flow.rb:94:1:94:48 | call to pos_many |
+| params_flow.rb:94:10:94:18 | * | params_flow.rb:94:10:94:18 | * |
+| params_flow.rb:94:10:94:18 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:94:10:94:18 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:94:10:94:18 | call to taint | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:94:10:94:18 | call to taint | params_flow.rb:83:14:83:14 | t |
+| params_flow.rb:94:10:94:18 | call to taint | params_flow.rb:83:14:83:14 | t |
+| params_flow.rb:94:10:94:18 | call to taint | params_flow.rb:84:10:84:10 | t |
+| params_flow.rb:94:10:94:18 | call to taint | params_flow.rb:94:10:94:18 | call to taint |
+| params_flow.rb:94:16:94:17 | 38 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:94:16:94:17 | 38 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:94:16:94:17 | 38 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:94:16:94:17 | 38 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:94:16:94:17 | 38 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:94:16:94:17 | 38 | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:94:16:94:17 | 38 | params_flow.rb:83:14:83:14 | t |
+| params_flow.rb:94:16:94:17 | 38 | params_flow.rb:83:14:83:14 | t |
+| params_flow.rb:94:16:94:17 | 38 | params_flow.rb:84:10:84:10 | t |
+| params_flow.rb:94:16:94:17 | 38 | params_flow.rb:94:10:94:18 | call to taint |
+| params_flow.rb:94:16:94:17 | 38 | params_flow.rb:94:16:94:17 | 38 |
+| params_flow.rb:94:21:94:29 | * | params_flow.rb:94:21:94:29 | * |
+| params_flow.rb:94:21:94:29 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:94:21:94:29 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:94:21:94:29 | call to taint | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:94:21:94:29 | call to taint | params_flow.rb:83:17:83:17 | u |
+| params_flow.rb:94:21:94:29 | call to taint | params_flow.rb:83:17:83:17 | u |
+| params_flow.rb:94:21:94:29 | call to taint | params_flow.rb:85:10:85:10 | u |
+| params_flow.rb:94:21:94:29 | call to taint | params_flow.rb:94:21:94:29 | call to taint |
+| params_flow.rb:94:27:94:28 | 39 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:94:27:94:28 | 39 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:94:27:94:28 | 39 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:94:27:94:28 | 39 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:94:27:94:28 | 39 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:94:27:94:28 | 39 | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:94:27:94:28 | 39 | params_flow.rb:83:17:83:17 | u |
+| params_flow.rb:94:27:94:28 | 39 | params_flow.rb:83:17:83:17 | u |
+| params_flow.rb:94:27:94:28 | 39 | params_flow.rb:85:10:85:10 | u |
+| params_flow.rb:94:27:94:28 | 39 | params_flow.rb:94:21:94:29 | call to taint |
+| params_flow.rb:94:27:94:28 | 39 | params_flow.rb:94:27:94:28 | 39 |
+| params_flow.rb:94:32:94:36 | * ... | params_flow.rb:94:32:94:36 | * ... |
+| params_flow.rb:94:39:94:47 | * | params_flow.rb:94:39:94:47 | * |
+| params_flow.rb:94:39:94:47 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:94:39:94:47 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:94:39:94:47 | call to taint | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:94:39:94:47 | call to taint | params_flow.rb:83:23:83:23 | w |
+| params_flow.rb:94:39:94:47 | call to taint | params_flow.rb:83:23:83:23 | w |
+| params_flow.rb:94:39:94:47 | call to taint | params_flow.rb:87:10:87:10 | w |
+| params_flow.rb:94:39:94:47 | call to taint | params_flow.rb:94:39:94:47 | call to taint |
+| params_flow.rb:94:45:94:46 | 44 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:94:45:94:46 | 44 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:94:45:94:46 | 44 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:94:45:94:46 | 44 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:94:45:94:46 | 44 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:94:45:94:46 | 44 | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:94:45:94:46 | 44 | params_flow.rb:83:23:83:23 | w |
+| params_flow.rb:94:45:94:46 | 44 | params_flow.rb:83:23:83:23 | w |
+| params_flow.rb:94:45:94:46 | 44 | params_flow.rb:87:10:87:10 | w |
+| params_flow.rb:94:45:94:46 | 44 | params_flow.rb:94:39:94:47 | call to taint |
+| params_flow.rb:94:45:94:46 | 44 | params_flow.rb:94:45:94:46 | 44 |
+| params_flow.rb:96:1:96:88 | call to splatmid | params_flow.rb:96:1:96:88 | call to splatmid |
+| params_flow.rb:96:10:96:18 | * | params_flow.rb:96:10:96:18 | * |
+| params_flow.rb:96:10:96:18 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:96:10:96:18 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:96:10:96:18 | call to taint | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:96:10:96:18 | call to taint | params_flow.rb:69:14:69:14 | x |
+| params_flow.rb:96:10:96:18 | call to taint | params_flow.rb:69:14:69:14 | x |
+| params_flow.rb:96:10:96:18 | call to taint | params_flow.rb:70:10:70:10 | x |
+| params_flow.rb:96:10:96:18 | call to taint | params_flow.rb:96:10:96:18 | call to taint |
+| params_flow.rb:96:16:96:17 | 45 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:96:16:96:17 | 45 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:96:16:96:17 | 45 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:96:16:96:17 | 45 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:96:16:96:17 | 45 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:96:16:96:17 | 45 | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:96:16:96:17 | 45 | params_flow.rb:69:14:69:14 | x |
+| params_flow.rb:96:16:96:17 | 45 | params_flow.rb:69:14:69:14 | x |
+| params_flow.rb:96:16:96:17 | 45 | params_flow.rb:70:10:70:10 | x |
+| params_flow.rb:96:16:96:17 | 45 | params_flow.rb:96:10:96:18 | call to taint |
+| params_flow.rb:96:16:96:17 | 45 | params_flow.rb:96:16:96:17 | 45 |
+| params_flow.rb:96:21:96:29 | * | params_flow.rb:96:21:96:29 | * |
+| params_flow.rb:96:21:96:29 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:96:21:96:29 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:96:21:96:29 | call to taint | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:96:21:96:29 | call to taint | params_flow.rb:69:17:69:17 | y |
+| params_flow.rb:96:21:96:29 | call to taint | params_flow.rb:69:17:69:17 | y |
+| params_flow.rb:96:21:96:29 | call to taint | params_flow.rb:71:10:71:10 | y |
+| params_flow.rb:96:21:96:29 | call to taint | params_flow.rb:96:21:96:29 | call to taint |
+| params_flow.rb:96:27:96:28 | 46 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:96:27:96:28 | 46 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:96:27:96:28 | 46 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:96:27:96:28 | 46 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:96:27:96:28 | 46 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:96:27:96:28 | 46 | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:96:27:96:28 | 46 | params_flow.rb:69:17:69:17 | y |
+| params_flow.rb:96:27:96:28 | 46 | params_flow.rb:69:17:69:17 | y |
+| params_flow.rb:96:27:96:28 | 46 | params_flow.rb:71:10:71:10 | y |
+| params_flow.rb:96:27:96:28 | 46 | params_flow.rb:96:21:96:29 | call to taint |
+| params_flow.rb:96:27:96:28 | 46 | params_flow.rb:96:27:96:28 | 46 |
+| params_flow.rb:96:32:96:65 | * ... | params_flow.rb:96:32:96:65 | * ... |
+| params_flow.rb:96:33:96:65 | * | params_flow.rb:96:33:96:65 | * |
+| params_flow.rb:96:33:96:65 | Array | params_flow.rb:96:33:96:65 | Array |
+| params_flow.rb:96:33:96:65 | call to [] | params_flow.rb:96:33:96:65 | call to [] |
+| params_flow.rb:96:34:96:42 | * | params_flow.rb:96:34:96:42 | * |
+| params_flow.rb:96:34:96:42 | call to taint | params_flow.rb:96:34:96:42 | call to taint |
+| params_flow.rb:96:40:96:41 | 47 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:96:40:96:41 | 47 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:96:40:96:41 | 47 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:96:40:96:41 | 47 | params_flow.rb:96:34:96:42 | call to taint |
+| params_flow.rb:96:40:96:41 | 47 | params_flow.rb:96:40:96:41 | 47 |
+| params_flow.rb:96:45:96:53 | * | params_flow.rb:96:45:96:53 | * |
+| params_flow.rb:96:45:96:53 | call to taint | params_flow.rb:96:45:96:53 | call to taint |
+| params_flow.rb:96:51:96:52 | 48 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:96:51:96:52 | 48 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:96:51:96:52 | 48 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:96:51:96:52 | 48 | params_flow.rb:96:45:96:53 | call to taint |
+| params_flow.rb:96:51:96:52 | 48 | params_flow.rb:96:51:96:52 | 48 |
+| params_flow.rb:96:56:96:64 | * | params_flow.rb:96:56:96:64 | * |
+| params_flow.rb:96:56:96:64 | call to taint | params_flow.rb:96:56:96:64 | call to taint |
+| params_flow.rb:96:62:96:63 | 49 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:96:62:96:63 | 49 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:96:62:96:63 | 49 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:96:62:96:63 | 49 | params_flow.rb:96:56:96:64 | call to taint |
+| params_flow.rb:96:62:96:63 | 49 | params_flow.rb:96:62:96:63 | 49 |
+| params_flow.rb:96:68:96:76 | * | params_flow.rb:96:68:96:76 | * |
+| params_flow.rb:96:68:96:76 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:96:68:96:76 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:96:68:96:76 | call to taint | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:96:68:96:76 | call to taint | params_flow.rb:69:24:69:24 | w |
+| params_flow.rb:96:68:96:76 | call to taint | params_flow.rb:69:24:69:24 | w |
+| params_flow.rb:96:68:96:76 | call to taint | params_flow.rb:74:10:74:10 | w |
+| params_flow.rb:96:68:96:76 | call to taint | params_flow.rb:96:68:96:76 | call to taint |
+| params_flow.rb:96:74:96:75 | 50 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:96:74:96:75 | 50 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:96:74:96:75 | 50 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:96:74:96:75 | 50 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:96:74:96:75 | 50 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:96:74:96:75 | 50 | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:96:74:96:75 | 50 | params_flow.rb:69:24:69:24 | w |
+| params_flow.rb:96:74:96:75 | 50 | params_flow.rb:69:24:69:24 | w |
+| params_flow.rb:96:74:96:75 | 50 | params_flow.rb:74:10:74:10 | w |
+| params_flow.rb:96:74:96:75 | 50 | params_flow.rb:96:68:96:76 | call to taint |
+| params_flow.rb:96:74:96:75 | 50 | params_flow.rb:96:74:96:75 | 50 |
+| params_flow.rb:96:79:96:87 | * | params_flow.rb:96:79:96:87 | * |
+| params_flow.rb:96:79:96:87 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:96:79:96:87 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:96:79:96:87 | call to taint | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:96:79:96:87 | call to taint | params_flow.rb:69:27:69:27 | r |
+| params_flow.rb:96:79:96:87 | call to taint | params_flow.rb:69:27:69:27 | r |
+| params_flow.rb:96:79:96:87 | call to taint | params_flow.rb:75:10:75:10 | r |
+| params_flow.rb:96:79:96:87 | call to taint | params_flow.rb:96:79:96:87 | call to taint |
+| params_flow.rb:96:85:96:86 | 51 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:96:85:96:86 | 51 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:96:85:96:86 | 51 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:96:85:96:86 | 51 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:96:85:96:86 | 51 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:96:85:96:86 | 51 | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:96:85:96:86 | 51 | params_flow.rb:69:27:69:27 | r |
+| params_flow.rb:96:85:96:86 | 51 | params_flow.rb:69:27:69:27 | r |
+| params_flow.rb:96:85:96:86 | 51 | params_flow.rb:75:10:75:10 | r |
+| params_flow.rb:96:85:96:86 | 51 | params_flow.rb:96:79:96:87 | call to taint |
+| params_flow.rb:96:85:96:86 | 51 | params_flow.rb:96:85:96:86 | 51 |
+| params_flow.rb:98:1:103:3 | &block | params_flow.rb:98:1:103:3 | &block |
+| params_flow.rb:98:1:103:3 | self in splatmidsmall | params_flow.rb:5:1:7:3 | self (sink) |
+| params_flow.rb:98:1:103:3 | self in splatmidsmall | params_flow.rb:5:1:7:3 | self in sink |
+| params_flow.rb:98:1:103:3 | self in splatmidsmall | params_flow.rb:6:5:6:10 | self |
+| params_flow.rb:98:1:103:3 | self in splatmidsmall | params_flow.rb:98:1:103:3 | self (splatmidsmall) |
+| params_flow.rb:98:1:103:3 | self in splatmidsmall | params_flow.rb:98:1:103:3 | self in splatmidsmall |
+| params_flow.rb:98:1:103:3 | self in splatmidsmall | params_flow.rb:99:5:99:10 | self |
+| params_flow.rb:98:1:103:3 | self in splatmidsmall | params_flow.rb:100:5:100:18 | self |
+| params_flow.rb:98:1:103:3 | self in splatmidsmall | params_flow.rb:101:5:101:18 | self |
+| params_flow.rb:98:1:103:3 | self in splatmidsmall | params_flow.rb:102:5:102:10 | self |
+| params_flow.rb:98:1:103:3 | splatmidsmall | params_flow.rb:98:1:103:3 | splatmidsmall |
+| params_flow.rb:98:1:103:3 | synthetic *args | params_flow.rb:98:1:103:3 | synthetic *args |
+| params_flow.rb:98:19:98:19 | a | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:98:19:98:19 | a | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:98:19:98:19 | a | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:98:19:98:19 | a | params_flow.rb:98:19:98:19 | a |
+| params_flow.rb:98:19:98:19 | a | params_flow.rb:98:19:98:19 | a |
+| params_flow.rb:98:19:98:19 | a | params_flow.rb:98:19:98:19 | a |
+| params_flow.rb:98:19:98:19 | a | params_flow.rb:99:10:99:10 | a |
+| params_flow.rb:98:22:98:28 | *splats | params_flow.rb:98:22:98:28 | *splats |
+| params_flow.rb:98:22:98:28 | *splats | params_flow.rb:98:23:98:28 | splats |
+| params_flow.rb:98:22:98:28 | *splats | params_flow.rb:100:10:100:15 | splats |
+| params_flow.rb:98:22:98:28 | *splats | params_flow.rb:101:10:101:15 | splats |
+| params_flow.rb:98:23:98:28 | splats | params_flow.rb:98:23:98:28 | splats |
+| params_flow.rb:98:31:98:31 | b | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:98:31:98:31 | b | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:98:31:98:31 | b | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:98:31:98:31 | b | params_flow.rb:98:31:98:31 | b |
+| params_flow.rb:98:31:98:31 | b | params_flow.rb:98:31:98:31 | b |
+| params_flow.rb:98:31:98:31 | b | params_flow.rb:98:31:98:31 | b |
+| params_flow.rb:98:31:98:31 | b | params_flow.rb:102:10:102:10 | b |
+| params_flow.rb:99:5:99:10 | * | params_flow.rb:99:5:99:10 | * |
+| params_flow.rb:99:5:99:10 | call to sink | params_flow.rb:99:5:99:10 | call to sink |
+| params_flow.rb:100:5:100:18 | * | params_flow.rb:100:5:100:18 | * |
+| params_flow.rb:100:5:100:18 | call to sink | params_flow.rb:100:5:100:18 | call to sink |
+| params_flow.rb:100:10:100:18 | * | params_flow.rb:100:10:100:18 | * |
+| params_flow.rb:100:10:100:18 | ...[...] | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:100:10:100:18 | ...[...] | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:100:10:100:18 | ...[...] | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:100:10:100:18 | ...[...] | params_flow.rb:100:10:100:18 | ...[...] |
+| params_flow.rb:100:17:100:17 | 0 | params_flow.rb:100:17:100:17 | 0 |
+| params_flow.rb:101:5:101:18 | * | params_flow.rb:101:5:101:18 | * |
+| params_flow.rb:101:5:101:18 | call to sink | params_flow.rb:101:5:101:18 | call to sink |
+| params_flow.rb:101:10:101:18 | * | params_flow.rb:101:10:101:18 | * |
+| params_flow.rb:101:10:101:18 | ...[...] | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:101:10:101:18 | ...[...] | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:101:10:101:18 | ...[...] | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:101:10:101:18 | ...[...] | params_flow.rb:101:10:101:18 | ...[...] |
+| params_flow.rb:101:17:101:17 | 1 | params_flow.rb:101:17:101:17 | 1 |
+| params_flow.rb:102:5:102:10 | * | params_flow.rb:102:5:102:10 | * |
+| params_flow.rb:102:5:102:10 | call to sink | params_flow.rb:102:5:102:10 | call to sink |
+| params_flow.rb:102:5:102:10 | call to sink | params_flow.rb:105:1:105:49 | call to splatmidsmall |
+| params_flow.rb:102:5:102:10 | call to sink | params_flow.rb:106:1:106:46 | call to splatmidsmall |
+| params_flow.rb:105:1:105:49 | call to splatmidsmall | params_flow.rb:105:1:105:49 | call to splatmidsmall |
+| params_flow.rb:105:15:105:23 | * | params_flow.rb:105:15:105:23 | * |
+| params_flow.rb:105:15:105:23 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:105:15:105:23 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:105:15:105:23 | call to taint | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:105:15:105:23 | call to taint | params_flow.rb:98:19:98:19 | a |
+| params_flow.rb:105:15:105:23 | call to taint | params_flow.rb:98:19:98:19 | a |
+| params_flow.rb:105:15:105:23 | call to taint | params_flow.rb:99:10:99:10 | a |
+| params_flow.rb:105:15:105:23 | call to taint | params_flow.rb:105:15:105:23 | call to taint |
+| params_flow.rb:105:21:105:22 | 52 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:105:21:105:22 | 52 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:105:21:105:22 | 52 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:105:21:105:22 | 52 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:105:21:105:22 | 52 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:105:21:105:22 | 52 | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:105:21:105:22 | 52 | params_flow.rb:98:19:98:19 | a |
+| params_flow.rb:105:21:105:22 | 52 | params_flow.rb:98:19:98:19 | a |
+| params_flow.rb:105:21:105:22 | 52 | params_flow.rb:99:10:99:10 | a |
+| params_flow.rb:105:21:105:22 | 52 | params_flow.rb:105:15:105:23 | call to taint |
+| params_flow.rb:105:21:105:22 | 52 | params_flow.rb:105:21:105:22 | 52 |
+| params_flow.rb:105:26:105:48 | * ... | params_flow.rb:105:26:105:48 | * ... |
+| params_flow.rb:105:27:105:48 | * | params_flow.rb:105:27:105:48 | * |
+| params_flow.rb:105:27:105:48 | Array | params_flow.rb:105:27:105:48 | Array |
+| params_flow.rb:105:27:105:48 | call to [] | params_flow.rb:105:27:105:48 | call to [] |
+| params_flow.rb:105:28:105:36 | * | params_flow.rb:105:28:105:36 | * |
+| params_flow.rb:105:28:105:36 | call to taint | params_flow.rb:105:28:105:36 | call to taint |
+| params_flow.rb:105:34:105:35 | 53 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:105:34:105:35 | 53 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:105:34:105:35 | 53 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:105:34:105:35 | 53 | params_flow.rb:105:28:105:36 | call to taint |
+| params_flow.rb:105:34:105:35 | 53 | params_flow.rb:105:34:105:35 | 53 |
+| params_flow.rb:105:39:105:47 | * | params_flow.rb:105:39:105:47 | * |
+| params_flow.rb:105:39:105:47 | call to taint | params_flow.rb:105:39:105:47 | call to taint |
+| params_flow.rb:105:45:105:46 | 54 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:105:45:105:46 | 54 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:105:45:105:46 | 54 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:105:45:105:46 | 54 | params_flow.rb:105:39:105:47 | call to taint |
+| params_flow.rb:105:45:105:46 | 54 | params_flow.rb:105:45:105:46 | 54 |
+| params_flow.rb:106:1:106:46 | * | params_flow.rb:106:1:106:46 | * |
+| params_flow.rb:106:1:106:46 | call to splatmidsmall | params_flow.rb:106:1:106:46 | call to splatmidsmall |
+| params_flow.rb:106:15:106:23 | * | params_flow.rb:106:15:106:23 | * |
+| params_flow.rb:106:15:106:23 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:106:15:106:23 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:106:15:106:23 | call to taint | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:106:15:106:23 | call to taint | params_flow.rb:98:19:98:19 | a |
+| params_flow.rb:106:15:106:23 | call to taint | params_flow.rb:98:19:98:19 | a |
+| params_flow.rb:106:15:106:23 | call to taint | params_flow.rb:99:10:99:10 | a |
+| params_flow.rb:106:15:106:23 | call to taint | params_flow.rb:106:15:106:23 | call to taint |
+| params_flow.rb:106:21:106:22 | 55 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:106:21:106:22 | 55 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:106:21:106:22 | 55 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:106:21:106:22 | 55 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:106:21:106:22 | 55 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:106:21:106:22 | 55 | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:106:21:106:22 | 55 | params_flow.rb:98:19:98:19 | a |
+| params_flow.rb:106:21:106:22 | 55 | params_flow.rb:98:19:98:19 | a |
+| params_flow.rb:106:21:106:22 | 55 | params_flow.rb:99:10:99:10 | a |
+| params_flow.rb:106:21:106:22 | 55 | params_flow.rb:106:15:106:23 | call to taint |
+| params_flow.rb:106:21:106:22 | 55 | params_flow.rb:106:21:106:22 | 55 |
+| params_flow.rb:106:26:106:34 | * | params_flow.rb:106:26:106:34 | * |
+| params_flow.rb:106:26:106:34 | call to taint | params_flow.rb:106:26:106:34 | call to taint |
+| params_flow.rb:106:32:106:33 | 56 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:106:32:106:33 | 56 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:106:32:106:33 | 56 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:106:32:106:33 | 56 | params_flow.rb:106:26:106:34 | call to taint |
+| params_flow.rb:106:32:106:33 | 56 | params_flow.rb:106:32:106:33 | 56 |
+| params_flow.rb:106:37:106:45 | * | params_flow.rb:106:37:106:45 | * |
+| params_flow.rb:106:37:106:45 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:106:37:106:45 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:106:37:106:45 | call to taint | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:106:37:106:45 | call to taint | params_flow.rb:98:31:98:31 | b |
+| params_flow.rb:106:37:106:45 | call to taint | params_flow.rb:98:31:98:31 | b |
+| params_flow.rb:106:37:106:45 | call to taint | params_flow.rb:102:10:102:10 | b |
+| params_flow.rb:106:37:106:45 | call to taint | params_flow.rb:106:37:106:45 | call to taint |
+| params_flow.rb:106:43:106:44 | 57 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:106:43:106:44 | 57 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:106:43:106:44 | 57 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:106:43:106:44 | 57 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:106:43:106:44 | 57 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:106:43:106:44 | 57 | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:106:43:106:44 | 57 | params_flow.rb:98:31:98:31 | b |
+| params_flow.rb:106:43:106:44 | 57 | params_flow.rb:98:31:98:31 | b |
+| params_flow.rb:106:43:106:44 | 57 | params_flow.rb:102:10:102:10 | b |
+| params_flow.rb:106:43:106:44 | 57 | params_flow.rb:106:37:106:45 | call to taint |
+| params_flow.rb:106:43:106:44 | 57 | params_flow.rb:106:43:106:44 | 57 |
+| params_flow.rb:108:1:112:3 | &block | params_flow.rb:108:1:112:3 | &block |
+| params_flow.rb:108:1:112:3 | **kwargs | params_flow.rb:108:1:112:3 | **kwargs |
+| params_flow.rb:108:1:112:3 | self in splat_followed_by_keyword_param | params_flow.rb:5:1:7:3 | self (sink) |
+| params_flow.rb:108:1:112:3 | self in splat_followed_by_keyword_param | params_flow.rb:5:1:7:3 | self in sink |
+| params_flow.rb:108:1:112:3 | self in splat_followed_by_keyword_param | params_flow.rb:6:5:6:10 | self |
+| params_flow.rb:108:1:112:3 | self in splat_followed_by_keyword_param | params_flow.rb:108:1:112:3 | self (splat_followed_by_keyword_param) |
+| params_flow.rb:108:1:112:3 | self in splat_followed_by_keyword_param | params_flow.rb:108:1:112:3 | self in splat_followed_by_keyword_param |
+| params_flow.rb:108:1:112:3 | self in splat_followed_by_keyword_param | params_flow.rb:109:5:109:10 | self |
+| params_flow.rb:108:1:112:3 | self in splat_followed_by_keyword_param | params_flow.rb:110:5:110:13 | self |
+| params_flow.rb:108:1:112:3 | self in splat_followed_by_keyword_param | params_flow.rb:111:5:111:10 | self |
+| params_flow.rb:108:1:112:3 | splat_followed_by_keyword_param | params_flow.rb:108:1:112:3 | splat_followed_by_keyword_param |
+| params_flow.rb:108:1:112:3 | synthetic *args | params_flow.rb:108:1:112:3 | synthetic *args |
+| params_flow.rb:108:1:112:3 | synthetic *args | params_flow.rb:108:1:112:3 | synthetic *args |
+| params_flow.rb:108:1:112:3 | synthetic *args[0] | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:108:1:112:3 | synthetic *args[0] | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:108:1:112:3 | synthetic *args[0] | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:108:1:112:3 | synthetic *args[0] | params_flow.rb:108:1:112:3 | synthetic *args[0] |
+| params_flow.rb:108:1:112:3 | synthetic *args[0] | params_flow.rb:110:10:110:13 | ...[...] |
+| params_flow.rb:108:1:112:3 | synthetic *args[1] | params_flow.rb:108:1:112:3 | synthetic *args[1] |
+| params_flow.rb:108:1:112:3 | synthetic *args[2] | params_flow.rb:108:1:112:3 | synthetic *args[2] |
+| params_flow.rb:108:1:112:3 | synthetic *args[3] | params_flow.rb:108:1:112:3 | synthetic *args[3] |
+| params_flow.rb:108:1:112:3 | synthetic *args[4] | params_flow.rb:108:1:112:3 | synthetic *args[4] |
+| params_flow.rb:108:1:112:3 | synthetic *args[5] | params_flow.rb:108:1:112:3 | synthetic *args[5] |
+| params_flow.rb:108:1:112:3 | synthetic *args[6] | params_flow.rb:108:1:112:3 | synthetic *args[6] |
+| params_flow.rb:108:1:112:3 | synthetic *args[7] | params_flow.rb:108:1:112:3 | synthetic *args[7] |
+| params_flow.rb:108:1:112:3 | synthetic *args[8] | params_flow.rb:108:1:112:3 | synthetic *args[8] |
+| params_flow.rb:108:1:112:3 | synthetic *args[9] | params_flow.rb:108:1:112:3 | synthetic *args[9] |
+| params_flow.rb:108:1:112:3 | synthetic *args[10] | params_flow.rb:108:1:112:3 | synthetic *args[10] |
+| params_flow.rb:108:37:108:37 | a | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:108:37:108:37 | a | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:108:37:108:37 | a | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:108:37:108:37 | a | params_flow.rb:108:37:108:37 | a |
+| params_flow.rb:108:37:108:37 | a | params_flow.rb:108:37:108:37 | a |
+| params_flow.rb:108:37:108:37 | a | params_flow.rb:108:37:108:37 | a |
+| params_flow.rb:108:37:108:37 | a | params_flow.rb:109:10:109:10 | a |
+| params_flow.rb:108:40:108:41 | *b | params_flow.rb:108:40:108:41 | *b |
+| params_flow.rb:108:40:108:41 | *b | params_flow.rb:108:41:108:41 | b |
+| params_flow.rb:108:40:108:41 | *b | params_flow.rb:110:10:110:10 | b |
+| params_flow.rb:108:41:108:41 | b | params_flow.rb:108:41:108:41 | b |
+| params_flow.rb:108:44:108:44 | c | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:108:44:108:44 | c | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:108:44:108:44 | c | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:108:44:108:44 | c | params_flow.rb:108:44:108:44 | c |
+| params_flow.rb:108:44:108:44 | c | params_flow.rb:108:44:108:44 | c |
+| params_flow.rb:108:44:108:44 | c | params_flow.rb:108:44:108:44 | c |
+| params_flow.rb:108:44:108:44 | c | params_flow.rb:111:10:111:10 | c |
+| params_flow.rb:109:5:109:10 | * | params_flow.rb:109:5:109:10 | * |
+| params_flow.rb:109:5:109:10 | call to sink | params_flow.rb:109:5:109:10 | call to sink |
+| params_flow.rb:110:5:110:13 | * | params_flow.rb:110:5:110:13 | * |
+| params_flow.rb:110:5:110:13 | call to sink | params_flow.rb:110:5:110:13 | call to sink |
+| params_flow.rb:110:10:110:13 | * | params_flow.rb:110:10:110:13 | * |
+| params_flow.rb:110:10:110:13 | ...[...] | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:110:10:110:13 | ...[...] | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:110:10:110:13 | ...[...] | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:110:10:110:13 | ...[...] | params_flow.rb:110:10:110:13 | ...[...] |
+| params_flow.rb:110:12:110:12 | 0 | params_flow.rb:110:12:110:12 | 0 |
+| params_flow.rb:111:5:111:10 | * | params_flow.rb:111:5:111:10 | * |
+| params_flow.rb:111:5:111:10 | call to sink | params_flow.rb:111:5:111:10 | call to sink |
+| params_flow.rb:111:5:111:10 | call to sink | params_flow.rb:114:1:114:67 | call to splat_followed_by_keyword_param |
+| params_flow.rb:114:1:114:67 | * | params_flow.rb:108:1:112:3 | synthetic *args |
+| params_flow.rb:114:1:114:67 | * | params_flow.rb:114:1:114:67 | * |
+| params_flow.rb:114:1:114:67 | ** | params_flow.rb:108:1:112:3 | **kwargs |
+| params_flow.rb:114:1:114:67 | ** | params_flow.rb:114:1:114:67 | ** |
+| params_flow.rb:114:1:114:67 | call to splat_followed_by_keyword_param | params_flow.rb:114:1:114:67 | call to splat_followed_by_keyword_param |
+| params_flow.rb:114:33:114:41 | * | params_flow.rb:114:33:114:41 | * |
+| params_flow.rb:114:33:114:41 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:114:33:114:41 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:114:33:114:41 | call to taint | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:114:33:114:41 | call to taint | params_flow.rb:108:37:108:37 | a |
+| params_flow.rb:114:33:114:41 | call to taint | params_flow.rb:108:37:108:37 | a |
+| params_flow.rb:114:33:114:41 | call to taint | params_flow.rb:109:10:109:10 | a |
+| params_flow.rb:114:33:114:41 | call to taint | params_flow.rb:114:33:114:41 | call to taint |
+| params_flow.rb:114:39:114:40 | 58 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:114:39:114:40 | 58 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:114:39:114:40 | 58 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:114:39:114:40 | 58 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:114:39:114:40 | 58 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:114:39:114:40 | 58 | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:114:39:114:40 | 58 | params_flow.rb:108:37:108:37 | a |
+| params_flow.rb:114:39:114:40 | 58 | params_flow.rb:108:37:108:37 | a |
+| params_flow.rb:114:39:114:40 | 58 | params_flow.rb:109:10:109:10 | a |
+| params_flow.rb:114:39:114:40 | 58 | params_flow.rb:114:33:114:41 | call to taint |
+| params_flow.rb:114:39:114:40 | 58 | params_flow.rb:114:39:114:40 | 58 |
+| params_flow.rb:114:44:114:52 | * | params_flow.rb:114:44:114:52 | * |
+| params_flow.rb:114:44:114:52 | call to taint | params_flow.rb:114:44:114:52 | call to taint |
+| params_flow.rb:114:50:114:51 | 59 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:114:50:114:51 | 59 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:114:50:114:51 | 59 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:114:50:114:51 | 59 | params_flow.rb:114:44:114:52 | call to taint |
+| params_flow.rb:114:50:114:51 | 59 | params_flow.rb:114:50:114:51 | 59 |
+| params_flow.rb:114:55:114:55 | :c | params_flow.rb:114:55:114:55 | :c |
+| params_flow.rb:114:55:114:66 | Pair | params_flow.rb:114:55:114:66 | Pair |
+| params_flow.rb:114:58:114:66 | * | params_flow.rb:114:58:114:66 | * |
+| params_flow.rb:114:58:114:66 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:114:58:114:66 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:114:58:114:66 | call to taint | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:114:58:114:66 | call to taint | params_flow.rb:108:44:108:44 | c |
+| params_flow.rb:114:58:114:66 | call to taint | params_flow.rb:108:44:108:44 | c |
+| params_flow.rb:114:58:114:66 | call to taint | params_flow.rb:111:10:111:10 | c |
+| params_flow.rb:114:58:114:66 | call to taint | params_flow.rb:114:58:114:66 | call to taint |
+| params_flow.rb:114:64:114:65 | 60 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:114:64:114:65 | 60 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:114:64:114:65 | 60 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:114:64:114:65 | 60 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:114:64:114:65 | 60 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:114:64:114:65 | 60 | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:114:64:114:65 | 60 | params_flow.rb:108:44:108:44 | c |
+| params_flow.rb:114:64:114:65 | 60 | params_flow.rb:108:44:108:44 | c |
+| params_flow.rb:114:64:114:65 | 60 | params_flow.rb:111:10:111:10 | c |
+| params_flow.rb:114:64:114:65 | 60 | params_flow.rb:114:58:114:66 | call to taint |
+| params_flow.rb:114:64:114:65 | 60 | params_flow.rb:114:64:114:65 | 60 |
+| params_flow.rb:116:1:116:1 | x | params_flow.rb:116:1:116:1 | x |
+| params_flow.rb:116:5:116:6 | Array | params_flow.rb:116:5:116:6 | Array |
+| params_flow.rb:116:5:116:6 | call to [] | params_flow.rb:116:1:116:1 | x |
+| params_flow.rb:116:5:116:6 | call to [] | params_flow.rb:116:1:116:6 | ... = ... |
+| params_flow.rb:116:5:116:6 | call to [] | params_flow.rb:116:5:116:6 | call to [] |
+| params_flow.rb:116:5:116:6 | call to [] | params_flow.rb:117:1:117:1 | x |
+| params_flow.rb:116:5:116:6 | call to [] | params_flow.rb:118:13:118:13 | x |
+| params_flow.rb:117:1:117:1 | [post] x | params_flow.rb:117:1:117:1 | [post] x |
+| params_flow.rb:117:1:117:1 | [post] x | params_flow.rb:118:13:118:13 | x |
+| params_flow.rb:117:1:117:15 | * | params_flow.rb:117:1:117:15 | * |
+| params_flow.rb:117:1:117:15 | call to []= | params_flow.rb:117:1:117:15 | call to []= |
+| params_flow.rb:117:3:117:14 | call to some_index | params_flow.rb:117:3:117:14 | call to some_index |
+| params_flow.rb:117:19:117:27 | * | params_flow.rb:117:19:117:27 | * |
+| params_flow.rb:117:19:117:27 | __synth__0 | params_flow.rb:117:19:117:27 | __synth__0 |
+| params_flow.rb:117:19:117:27 | call to taint | params_flow.rb:117:1:117:15 | __synth__0 |
+| params_flow.rb:117:19:117:27 | call to taint | params_flow.rb:117:1:117:27 | ... |
+| params_flow.rb:117:19:117:27 | call to taint | params_flow.rb:117:19:117:27 | ... = ... |
+| params_flow.rb:117:19:117:27 | call to taint | params_flow.rb:117:19:117:27 | __synth__0 |
+| params_flow.rb:117:19:117:27 | call to taint | params_flow.rb:117:19:117:27 | call to taint |
+| params_flow.rb:117:25:117:26 | 61 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:117:25:117:26 | 61 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:117:25:117:26 | 61 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:117:25:117:26 | 61 | params_flow.rb:117:1:117:15 | __synth__0 |
+| params_flow.rb:117:25:117:26 | 61 | params_flow.rb:117:1:117:27 | ... |
+| params_flow.rb:117:25:117:26 | 61 | params_flow.rb:117:19:117:27 | ... = ... |
+| params_flow.rb:117:25:117:26 | 61 | params_flow.rb:117:19:117:27 | __synth__0 |
+| params_flow.rb:117:25:117:26 | 61 | params_flow.rb:117:19:117:27 | call to taint |
+| params_flow.rb:117:25:117:26 | 61 | params_flow.rb:117:25:117:26 | 61 |
+| params_flow.rb:118:1:118:14 | call to positional | params_flow.rb:118:1:118:14 | call to positional |
+| params_flow.rb:118:12:118:13 | * ... | params_flow.rb:9:1:12:3 | synthetic *args |
+| params_flow.rb:118:12:118:13 | * ... | params_flow.rb:118:12:118:13 | * ... |
+| params_flow.rb:120:1:126:3 | &block | params_flow.rb:120:1:126:3 | &block |
+| params_flow.rb:120:1:126:3 | destruct | params_flow.rb:120:1:126:3 | destruct |
+| params_flow.rb:120:1:126:3 | self in destruct | params_flow.rb:5:1:7:3 | self (sink) |
+| params_flow.rb:120:1:126:3 | self in destruct | params_flow.rb:5:1:7:3 | self in sink |
+| params_flow.rb:120:1:126:3 | self in destruct | params_flow.rb:6:5:6:10 | self |
+| params_flow.rb:120:1:126:3 | self in destruct | params_flow.rb:120:1:126:3 | self (destruct) |
+| params_flow.rb:120:1:126:3 | self in destruct | params_flow.rb:120:1:126:3 | self in destruct |
+| params_flow.rb:120:1:126:3 | self in destruct | params_flow.rb:121:5:121:10 | self |
+| params_flow.rb:120:1:126:3 | self in destruct | params_flow.rb:122:5:122:10 | self |
+| params_flow.rb:120:1:126:3 | self in destruct | params_flow.rb:123:5:123:10 | self |
+| params_flow.rb:120:1:126:3 | self in destruct | params_flow.rb:124:5:124:10 | self |
+| params_flow.rb:120:1:126:3 | self in destruct | params_flow.rb:125:5:125:10 | self |
+| params_flow.rb:120:15:120:15 | a | params_flow.rb:120:15:120:15 | a |
+| params_flow.rb:120:17:120:17 | b | params_flow.rb:120:17:120:17 | b |
+| params_flow.rb:120:22:120:22 | c | params_flow.rb:120:22:120:22 | c |
+| params_flow.rb:120:25:120:25 | d | params_flow.rb:120:25:120:25 | d |
+| params_flow.rb:120:27:120:27 | e | params_flow.rb:120:27:120:27 | e |
+| params_flow.rb:121:5:121:10 | * | params_flow.rb:121:5:121:10 | * |
+| params_flow.rb:121:5:121:10 | call to sink | params_flow.rb:121:5:121:10 | call to sink |
+| params_flow.rb:121:10:121:10 | a | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:121:10:121:10 | a | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:121:10:121:10 | a | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:121:10:121:10 | a | params_flow.rb:121:10:121:10 | a |
+| params_flow.rb:122:5:122:10 | * | params_flow.rb:122:5:122:10 | * |
+| params_flow.rb:122:5:122:10 | call to sink | params_flow.rb:122:5:122:10 | call to sink |
+| params_flow.rb:122:10:122:10 | b | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:122:10:122:10 | b | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:122:10:122:10 | b | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:122:10:122:10 | b | params_flow.rb:122:10:122:10 | b |
+| params_flow.rb:123:5:123:10 | * | params_flow.rb:123:5:123:10 | * |
+| params_flow.rb:123:5:123:10 | call to sink | params_flow.rb:123:5:123:10 | call to sink |
+| params_flow.rb:123:10:123:10 | c | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:123:10:123:10 | c | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:123:10:123:10 | c | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:123:10:123:10 | c | params_flow.rb:123:10:123:10 | c |
+| params_flow.rb:124:5:124:10 | * | params_flow.rb:124:5:124:10 | * |
+| params_flow.rb:124:5:124:10 | call to sink | params_flow.rb:124:5:124:10 | call to sink |
+| params_flow.rb:124:10:124:10 | d | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:124:10:124:10 | d | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:124:10:124:10 | d | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:124:10:124:10 | d | params_flow.rb:124:10:124:10 | d |
+| params_flow.rb:125:5:125:10 | * | params_flow.rb:125:5:125:10 | * |
+| params_flow.rb:125:5:125:10 | call to sink | params_flow.rb:125:5:125:10 | call to sink |
+| params_flow.rb:125:5:125:10 | call to sink | params_flow.rb:128:1:128:61 | call to destruct |
+| params_flow.rb:125:10:125:10 | e | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:125:10:125:10 | e | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:125:10:125:10 | e | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:125:10:125:10 | e | params_flow.rb:125:10:125:10 | e |
+| params_flow.rb:128:1:128:61 | * | params_flow.rb:128:1:128:61 | * |
+| params_flow.rb:128:1:128:61 | call to destruct | params_flow.rb:128:1:128:61 | call to destruct |
+| params_flow.rb:128:10:128:31 | * | params_flow.rb:128:10:128:31 | * |
+| params_flow.rb:128:10:128:31 | Array | params_flow.rb:128:10:128:31 | Array |
+| params_flow.rb:128:10:128:31 | call to [] | params_flow.rb:128:10:128:31 | call to [] |
+| params_flow.rb:128:11:128:19 | * | params_flow.rb:128:11:128:19 | * |
+| params_flow.rb:128:11:128:19 | call to taint | params_flow.rb:128:11:128:19 | call to taint |
+| params_flow.rb:128:17:128:18 | 62 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:128:17:128:18 | 62 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:128:17:128:18 | 62 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:128:17:128:18 | 62 | params_flow.rb:128:11:128:19 | call to taint |
+| params_flow.rb:128:17:128:18 | 62 | params_flow.rb:128:17:128:18 | 62 |
+| params_flow.rb:128:22:128:30 | * | params_flow.rb:128:22:128:30 | * |
+| params_flow.rb:128:22:128:30 | call to taint | params_flow.rb:128:22:128:30 | call to taint |
+| params_flow.rb:128:28:128:29 | 63 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:128:28:128:29 | 63 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:128:28:128:29 | 63 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:128:28:128:29 | 63 | params_flow.rb:128:22:128:30 | call to taint |
+| params_flow.rb:128:28:128:29 | 63 | params_flow.rb:128:28:128:29 | 63 |
+| params_flow.rb:128:34:128:60 | * | params_flow.rb:128:34:128:60 | * |
+| params_flow.rb:128:34:128:60 | Array | params_flow.rb:128:34:128:60 | Array |
+| params_flow.rb:128:34:128:60 | call to [] | params_flow.rb:128:34:128:60 | call to [] |
+| params_flow.rb:128:35:128:43 | * | params_flow.rb:128:35:128:43 | * |
+| params_flow.rb:128:35:128:43 | call to taint | params_flow.rb:128:35:128:43 | call to taint |
+| params_flow.rb:128:41:128:42 | 64 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:128:41:128:42 | 64 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:128:41:128:42 | 64 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:128:41:128:42 | 64 | params_flow.rb:128:35:128:43 | call to taint |
+| params_flow.rb:128:41:128:42 | 64 | params_flow.rb:128:41:128:42 | 64 |
+| params_flow.rb:128:46:128:59 | * | params_flow.rb:128:46:128:59 | * |
+| params_flow.rb:128:46:128:59 | Array | params_flow.rb:128:46:128:59 | Array |
+| params_flow.rb:128:46:128:59 | call to [] | params_flow.rb:128:46:128:59 | call to [] |
+| params_flow.rb:128:47:128:47 | 0 | params_flow.rb:128:47:128:47 | 0 |
+| params_flow.rb:128:50:128:58 | * | params_flow.rb:128:50:128:58 | * |
+| params_flow.rb:128:50:128:58 | call to taint | params_flow.rb:128:50:128:58 | call to taint |
+| params_flow.rb:128:56:128:57 | 65 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:128:56:128:57 | 65 | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:128:56:128:57 | 65 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:128:56:128:57 | 65 | params_flow.rb:128:50:128:58 | call to taint |
+| params_flow.rb:128:56:128:57 | 65 | params_flow.rb:128:56:128:57 | 65 |
+forwardButNoBackwardFlow
+backwardButNoForwardFlow

--- a/ruby/ql/test/library-tests/dataflow/params/TypeTracker.expected
+++ b/ruby/ql/test/library-tests/dataflow/params/TypeTracker.expected
@@ -39,6 +39,7 @@ track
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps | params_flow.rb:98:31:98:31 | b |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps | params_flow.rb:108:37:108:37 | a |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps | params_flow.rb:108:44:108:44 | c |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps | params_flow.rb:110:10:110:13 | ...[...] |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element | params_flow.rb:9:1:12:3 | synthetic *args |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:10:5:10:11 | * |
@@ -50,6 +51,7 @@ track
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:28:5:28:22 | * |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:29:5:29:22 | * |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:49:1:53:3 | synthetic *args |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:49:17:49:24 | *posargs |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:50:5:50:11 | * |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:51:5:51:21 | * |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:65:5:65:13 | * |
@@ -63,7 +65,9 @@ track
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:99:5:99:10 | * |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:102:5:102:10 | * |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:108:1:112:3 | synthetic *args |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:108:40:108:41 | *b |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:109:5:109:10 | * |
+| params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:110:5:110:13 | * |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 | params_flow.rb:111:5:111:10 | * |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 or unknown | params_flow.rb:9:1:12:3 | synthetic *args |
 | params_flow.rb:1:11:1:11 | x | type tracker with call steps with content element 0 or unknown | params_flow.rb:49:1:53:3 | synthetic *args |
@@ -758,8 +762,10 @@ track
 | params_flow.rb:37:9:37:24 | Pair | type tracker without call steps | params_flow.rb:37:9:37:24 | Pair |
 | params_flow.rb:37:16:37:24 | * | type tracker without call steps | params_flow.rb:37:16:37:24 | * |
 | params_flow.rb:37:16:37:24 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:37:16:37:24 | call to taint | type tracker with call steps | params_flow.rb:25:12:25:13 | p1 |
 | params_flow.rb:37:16:37:24 | call to taint | type tracker with call steps | params_flow.rb:27:11:27:21 | ...[...] |
 | params_flow.rb:37:16:37:24 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:37:16:37:24 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:26:5:26:11 | * |
 | params_flow.rb:37:16:37:24 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:27:5:27:22 | * |
 | params_flow.rb:37:16:37:24 | call to taint | type tracker with call steps with content element :p1 | params_flow.rb:25:1:31:3 | **kwargs |
 | params_flow.rb:37:16:37:24 | call to taint | type tracker with call steps with content element :p1 | params_flow.rb:25:17:25:24 | **kwargs |
@@ -769,8 +775,10 @@ track
 | params_flow.rb:37:16:37:24 | call to taint | type tracker without call steps with content element :p1 | params_flow.rb:38:8:38:13 | ** ... |
 | params_flow.rb:37:22:37:23 | 14 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:37:22:37:23 | 14 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:37:22:37:23 | 14 | type tracker with call steps | params_flow.rb:25:12:25:13 | p1 |
 | params_flow.rb:37:22:37:23 | 14 | type tracker with call steps | params_flow.rb:27:11:27:21 | ...[...] |
 | params_flow.rb:37:22:37:23 | 14 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:37:22:37:23 | 14 | type tracker with call steps with content element 0 | params_flow.rb:26:5:26:11 | * |
 | params_flow.rb:37:22:37:23 | 14 | type tracker with call steps with content element 0 | params_flow.rb:27:5:27:22 | * |
 | params_flow.rb:37:22:37:23 | 14 | type tracker with call steps with content element :p1 | params_flow.rb:25:1:31:3 | **kwargs |
 | params_flow.rb:37:22:37:23 | 14 | type tracker with call steps with content element :p1 | params_flow.rb:25:17:25:24 | **kwargs |
@@ -817,12 +825,20 @@ track
 | params_flow.rb:40:9:40:11 | :p1 | type tracker without call steps | params_flow.rb:40:9:40:11 | :p1 |
 | params_flow.rb:40:9:40:24 | Pair | type tracker without call steps | params_flow.rb:40:9:40:24 | Pair |
 | params_flow.rb:40:16:40:24 | * | type tracker without call steps | params_flow.rb:40:16:40:24 | * |
+| params_flow.rb:40:16:40:24 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:40:16:40:24 | call to taint | type tracker with call steps | params_flow.rb:16:13:16:14 | p1 |
+| params_flow.rb:40:16:40:24 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:40:16:40:24 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:17:5:17:11 | * |
 | params_flow.rb:40:16:40:24 | call to taint | type tracker with call steps with content element :p1 | params_flow.rb:16:1:19:3 | **kwargs |
 | params_flow.rb:40:16:40:24 | call to taint | type tracker without call steps | params_flow.rb:40:16:40:24 | call to taint |
 | params_flow.rb:40:16:40:24 | call to taint | type tracker without call steps with content element :p1 | params_flow.rb:40:8:40:26 | ** |
 | params_flow.rb:40:16:40:24 | call to taint | type tracker without call steps with content element :p1 | params_flow.rb:40:8:40:26 | call to [] |
 | params_flow.rb:40:16:40:24 | call to taint | type tracker without call steps with content element :p1 | params_flow.rb:41:24:41:29 | ** ... |
 | params_flow.rb:40:22:40:23 | 16 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:40:22:40:23 | 16 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:40:22:40:23 | 16 | type tracker with call steps | params_flow.rb:16:13:16:14 | p1 |
+| params_flow.rb:40:22:40:23 | 16 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:40:22:40:23 | 16 | type tracker with call steps with content element 0 | params_flow.rb:17:5:17:11 | * |
 | params_flow.rb:40:22:40:23 | 16 | type tracker with call steps with content element :p1 | params_flow.rb:16:1:19:3 | **kwargs |
 | params_flow.rb:40:22:40:23 | 16 | type tracker without call steps | params_flow.rb:40:16:40:24 | call to taint |
 | params_flow.rb:40:22:40:23 | 16 | type tracker without call steps | params_flow.rb:40:22:40:23 | 16 |
@@ -891,16 +907,28 @@ track
 | params_flow.rb:46:1:46:4 | args | type tracker without call steps | params_flow.rb:46:1:46:4 | args |
 | params_flow.rb:46:8:46:29 | * | type tracker without call steps | params_flow.rb:46:8:46:29 | * |
 | params_flow.rb:46:8:46:29 | Array | type tracker without call steps | params_flow.rb:46:8:46:29 | Array |
+| params_flow.rb:46:8:46:29 | call to [] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:46:8:46:29 | call to [] | type tracker with call steps | params_flow.rb:9:16:9:17 | p1 |
+| params_flow.rb:46:8:46:29 | call to [] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:46:8:46:29 | call to [] | type tracker with call steps with content element 0 | params_flow.rb:10:5:10:11 | * |
 | params_flow.rb:46:8:46:29 | call to [] | type tracker with call steps with content element 0 or unknown | params_flow.rb:9:1:12:3 | synthetic *args |
 | params_flow.rb:46:8:46:29 | call to [] | type tracker without call steps | params_flow.rb:46:8:46:29 | call to [] |
 | params_flow.rb:46:8:46:29 | call to [] | type tracker without call steps with content element 0 or unknown | params_flow.rb:47:12:47:16 | * ... |
 | params_flow.rb:46:9:46:17 | * | type tracker without call steps | params_flow.rb:46:9:46:17 | * |
+| params_flow.rb:46:9:46:17 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:46:9:46:17 | call to taint | type tracker with call steps | params_flow.rb:9:16:9:17 | p1 |
+| params_flow.rb:46:9:46:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:46:9:46:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:10:5:10:11 | * |
 | params_flow.rb:46:9:46:17 | call to taint | type tracker with call steps with content element 0 or unknown | params_flow.rb:9:1:12:3 | synthetic *args |
 | params_flow.rb:46:9:46:17 | call to taint | type tracker without call steps | params_flow.rb:46:9:46:17 | call to taint |
 | params_flow.rb:46:9:46:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:46:8:46:29 | * |
 | params_flow.rb:46:9:46:17 | call to taint | type tracker without call steps with content element 0 or unknown | params_flow.rb:46:8:46:29 | call to [] |
 | params_flow.rb:46:9:46:17 | call to taint | type tracker without call steps with content element 0 or unknown | params_flow.rb:47:12:47:16 | * ... |
 | params_flow.rb:46:15:46:16 | 18 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:46:15:46:16 | 18 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:46:15:46:16 | 18 | type tracker with call steps | params_flow.rb:9:16:9:17 | p1 |
+| params_flow.rb:46:15:46:16 | 18 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:46:15:46:16 | 18 | type tracker with call steps with content element 0 | params_flow.rb:10:5:10:11 | * |
 | params_flow.rb:46:15:46:16 | 18 | type tracker with call steps with content element 0 or unknown | params_flow.rb:9:1:12:3 | synthetic *args |
 | params_flow.rb:46:15:46:16 | 18 | type tracker without call steps | params_flow.rb:46:9:46:17 | call to taint |
 | params_flow.rb:46:15:46:16 | 18 | type tracker without call steps | params_flow.rb:46:15:46:16 | 18 |
@@ -909,12 +937,20 @@ track
 | params_flow.rb:46:15:46:16 | 18 | type tracker without call steps with content element 0 or unknown | params_flow.rb:46:8:46:29 | call to [] |
 | params_flow.rb:46:15:46:16 | 18 | type tracker without call steps with content element 0 or unknown | params_flow.rb:47:12:47:16 | * ... |
 | params_flow.rb:46:20:46:28 | * | type tracker without call steps | params_flow.rb:46:20:46:28 | * |
+| params_flow.rb:46:20:46:28 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:46:20:46:28 | call to taint | type tracker with call steps | params_flow.rb:9:20:9:21 | p2 |
+| params_flow.rb:46:20:46:28 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:46:20:46:28 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:11:5:11:11 | * |
 | params_flow.rb:46:20:46:28 | call to taint | type tracker with call steps with content element 1 or unknown | params_flow.rb:9:1:12:3 | synthetic *args |
 | params_flow.rb:46:20:46:28 | call to taint | type tracker without call steps | params_flow.rb:46:20:46:28 | call to taint |
 | params_flow.rb:46:20:46:28 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:46:8:46:29 | * |
 | params_flow.rb:46:20:46:28 | call to taint | type tracker without call steps with content element 1 or unknown | params_flow.rb:46:8:46:29 | call to [] |
 | params_flow.rb:46:20:46:28 | call to taint | type tracker without call steps with content element 1 or unknown | params_flow.rb:47:12:47:16 | * ... |
 | params_flow.rb:46:26:46:27 | 19 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:46:26:46:27 | 19 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:46:26:46:27 | 19 | type tracker with call steps | params_flow.rb:9:20:9:21 | p2 |
+| params_flow.rb:46:26:46:27 | 19 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:46:26:46:27 | 19 | type tracker with call steps with content element 0 | params_flow.rb:11:5:11:11 | * |
 | params_flow.rb:46:26:46:27 | 19 | type tracker with call steps with content element 1 or unknown | params_flow.rb:9:1:12:3 | synthetic *args |
 | params_flow.rb:46:26:46:27 | 19 | type tracker without call steps | params_flow.rb:46:20:46:28 | call to taint |
 | params_flow.rb:46:26:46:27 | 19 | type tracker without call steps | params_flow.rb:46:26:46:27 | 19 |
@@ -931,36 +967,6 @@ track
 | params_flow.rb:49:1:53:3 | self in posargs | type tracker without call steps | params_flow.rb:49:1:53:3 | self in posargs |
 | params_flow.rb:49:1:53:3 | synthetic *args | type tracker without call steps | params_flow.rb:49:1:53:3 | synthetic *args |
 | params_flow.rb:49:1:53:3 | synthetic *args | type tracker without call steps | params_flow.rb:49:1:53:3 | synthetic *args |
-| params_flow.rb:49:1:53:3 | synthetic *args[0] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:49:1:53:3 | synthetic *args[0] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:49:1:53:3 | synthetic *args[0] | type tracker without call steps | params_flow.rb:49:1:53:3 | synthetic *args[0] |
-| params_flow.rb:49:1:53:3 | synthetic *args[0] | type tracker without call steps | params_flow.rb:51:11:51:20 | ...[...] |
-| params_flow.rb:49:1:53:3 | synthetic *args[0] | type tracker without call steps with content element 0 | params_flow.rb:49:17:49:24 | *posargs |
-| params_flow.rb:49:1:53:3 | synthetic *args[0] | type tracker without call steps with content element 0 | params_flow.rb:51:5:51:21 | * |
-| params_flow.rb:49:1:53:3 | synthetic *args[1] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:49:1:53:3 | synthetic *args[1] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:49:1:53:3 | synthetic *args[1] | type tracker without call steps | params_flow.rb:49:1:53:3 | synthetic *args[1] |
-| params_flow.rb:49:1:53:3 | synthetic *args[1] | type tracker without call steps | params_flow.rb:52:11:52:20 | ...[...] |
-| params_flow.rb:49:1:53:3 | synthetic *args[1] | type tracker without call steps with content element 0 | params_flow.rb:52:5:52:21 | * |
-| params_flow.rb:49:1:53:3 | synthetic *args[1] | type tracker without call steps with content element 1 | params_flow.rb:49:17:49:24 | *posargs |
-| params_flow.rb:49:1:53:3 | synthetic *args[2] | type tracker without call steps | params_flow.rb:49:1:53:3 | synthetic *args[2] |
-| params_flow.rb:49:1:53:3 | synthetic *args[2] | type tracker without call steps with content element 2 | params_flow.rb:49:17:49:24 | *posargs |
-| params_flow.rb:49:1:53:3 | synthetic *args[3] | type tracker without call steps | params_flow.rb:49:1:53:3 | synthetic *args[3] |
-| params_flow.rb:49:1:53:3 | synthetic *args[3] | type tracker without call steps with content element 3 | params_flow.rb:49:17:49:24 | *posargs |
-| params_flow.rb:49:1:53:3 | synthetic *args[4] | type tracker without call steps | params_flow.rb:49:1:53:3 | synthetic *args[4] |
-| params_flow.rb:49:1:53:3 | synthetic *args[4] | type tracker without call steps with content element 4 | params_flow.rb:49:17:49:24 | *posargs |
-| params_flow.rb:49:1:53:3 | synthetic *args[5] | type tracker without call steps | params_flow.rb:49:1:53:3 | synthetic *args[5] |
-| params_flow.rb:49:1:53:3 | synthetic *args[5] | type tracker without call steps with content element 5 | params_flow.rb:49:17:49:24 | *posargs |
-| params_flow.rb:49:1:53:3 | synthetic *args[6] | type tracker without call steps | params_flow.rb:49:1:53:3 | synthetic *args[6] |
-| params_flow.rb:49:1:53:3 | synthetic *args[6] | type tracker without call steps with content element 6 | params_flow.rb:49:17:49:24 | *posargs |
-| params_flow.rb:49:1:53:3 | synthetic *args[7] | type tracker without call steps | params_flow.rb:49:1:53:3 | synthetic *args[7] |
-| params_flow.rb:49:1:53:3 | synthetic *args[7] | type tracker without call steps with content element 7 | params_flow.rb:49:17:49:24 | *posargs |
-| params_flow.rb:49:1:53:3 | synthetic *args[8] | type tracker without call steps | params_flow.rb:49:1:53:3 | synthetic *args[8] |
-| params_flow.rb:49:1:53:3 | synthetic *args[8] | type tracker without call steps with content element 8 | params_flow.rb:49:17:49:24 | *posargs |
-| params_flow.rb:49:1:53:3 | synthetic *args[9] | type tracker without call steps | params_flow.rb:49:1:53:3 | synthetic *args[9] |
-| params_flow.rb:49:1:53:3 | synthetic *args[9] | type tracker without call steps with content element 9 | params_flow.rb:49:17:49:24 | *posargs |
-| params_flow.rb:49:1:53:3 | synthetic *args[10] | type tracker without call steps | params_flow.rb:49:1:53:3 | synthetic *args[10] |
-| params_flow.rb:49:1:53:3 | synthetic *args[10] | type tracker without call steps with content element 10 | params_flow.rb:49:17:49:24 | *posargs |
 | params_flow.rb:49:13:49:14 | p1 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:49:13:49:14 | p1 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
 | params_flow.rb:49:13:49:14 | p1 | type tracker without call steps | params_flow.rb:49:13:49:14 | p1 |
@@ -1013,10 +1019,20 @@ track
 | params_flow.rb:55:15:55:16 | 20 | type tracker without call steps with content element 0 | params_flow.rb:55:1:55:29 | * |
 | params_flow.rb:55:15:55:16 | 20 | type tracker without call steps with content element 0 | params_flow.rb:55:9:55:17 | * |
 | params_flow.rb:55:20:55:28 | * | type tracker without call steps | params_flow.rb:55:20:55:28 | * |
+| params_flow.rb:55:20:55:28 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:55:20:55:28 | call to taint | type tracker with call steps | params_flow.rb:51:11:51:20 | ...[...] |
+| params_flow.rb:55:20:55:28 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:55:20:55:28 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:49:17:49:24 | *posargs |
+| params_flow.rb:55:20:55:28 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:51:5:51:21 | * |
 | params_flow.rb:55:20:55:28 | call to taint | type tracker with call steps with content element 1 | params_flow.rb:49:1:53:3 | synthetic *args |
 | params_flow.rb:55:20:55:28 | call to taint | type tracker without call steps | params_flow.rb:55:20:55:28 | call to taint |
 | params_flow.rb:55:20:55:28 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:55:1:55:29 | * |
 | params_flow.rb:55:26:55:27 | 21 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:55:26:55:27 | 21 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:55:26:55:27 | 21 | type tracker with call steps | params_flow.rb:51:11:51:20 | ...[...] |
+| params_flow.rb:55:26:55:27 | 21 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:55:26:55:27 | 21 | type tracker with call steps with content element 0 | params_flow.rb:49:17:49:24 | *posargs |
+| params_flow.rb:55:26:55:27 | 21 | type tracker with call steps with content element 0 | params_flow.rb:51:5:51:21 | * |
 | params_flow.rb:55:26:55:27 | 21 | type tracker with call steps with content element 1 | params_flow.rb:49:1:53:3 | synthetic *args |
 | params_flow.rb:55:26:55:27 | 21 | type tracker without call steps | params_flow.rb:55:20:55:28 | call to taint |
 | params_flow.rb:55:26:55:27 | 21 | type tracker without call steps | params_flow.rb:55:26:55:27 | 21 |
@@ -1074,16 +1090,28 @@ track
 | params_flow.rb:60:1:60:4 | args | type tracker without call steps | params_flow.rb:60:1:60:4 | args |
 | params_flow.rb:60:8:60:29 | * | type tracker without call steps | params_flow.rb:60:8:60:29 | * |
 | params_flow.rb:60:8:60:29 | Array | type tracker without call steps | params_flow.rb:60:8:60:29 | Array |
+| params_flow.rb:60:8:60:29 | call to [] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:60:8:60:29 | call to [] | type tracker with call steps | params_flow.rb:49:13:49:14 | p1 |
+| params_flow.rb:60:8:60:29 | call to [] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:60:8:60:29 | call to [] | type tracker with call steps with content element 0 | params_flow.rb:50:5:50:11 | * |
 | params_flow.rb:60:8:60:29 | call to [] | type tracker with call steps with content element 0 or unknown | params_flow.rb:49:1:53:3 | synthetic *args |
 | params_flow.rb:60:8:60:29 | call to [] | type tracker without call steps | params_flow.rb:60:8:60:29 | call to [] |
 | params_flow.rb:60:8:60:29 | call to [] | type tracker without call steps with content element 0 or unknown | params_flow.rb:61:9:61:13 | * ... |
 | params_flow.rb:60:9:60:17 | * | type tracker without call steps | params_flow.rb:60:9:60:17 | * |
+| params_flow.rb:60:9:60:17 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:60:9:60:17 | call to taint | type tracker with call steps | params_flow.rb:49:13:49:14 | p1 |
+| params_flow.rb:60:9:60:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:60:9:60:17 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:50:5:50:11 | * |
 | params_flow.rb:60:9:60:17 | call to taint | type tracker with call steps with content element 0 or unknown | params_flow.rb:49:1:53:3 | synthetic *args |
 | params_flow.rb:60:9:60:17 | call to taint | type tracker without call steps | params_flow.rb:60:9:60:17 | call to taint |
 | params_flow.rb:60:9:60:17 | call to taint | type tracker without call steps with content element 0 | params_flow.rb:60:8:60:29 | * |
 | params_flow.rb:60:9:60:17 | call to taint | type tracker without call steps with content element 0 or unknown | params_flow.rb:60:8:60:29 | call to [] |
 | params_flow.rb:60:9:60:17 | call to taint | type tracker without call steps with content element 0 or unknown | params_flow.rb:61:9:61:13 | * ... |
 | params_flow.rb:60:15:60:16 | 24 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:60:15:60:16 | 24 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:60:15:60:16 | 24 | type tracker with call steps | params_flow.rb:49:13:49:14 | p1 |
+| params_flow.rb:60:15:60:16 | 24 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:60:15:60:16 | 24 | type tracker with call steps with content element 0 | params_flow.rb:50:5:50:11 | * |
 | params_flow.rb:60:15:60:16 | 24 | type tracker with call steps with content element 0 or unknown | params_flow.rb:49:1:53:3 | synthetic *args |
 | params_flow.rb:60:15:60:16 | 24 | type tracker without call steps | params_flow.rb:60:9:60:17 | call to taint |
 | params_flow.rb:60:15:60:16 | 24 | type tracker without call steps | params_flow.rb:60:15:60:16 | 24 |
@@ -1735,32 +1763,6 @@ track
 | params_flow.rb:108:1:112:3 | splat_followed_by_keyword_param | type tracker without call steps | params_flow.rb:108:1:112:3 | splat_followed_by_keyword_param |
 | params_flow.rb:108:1:112:3 | synthetic *args | type tracker without call steps | params_flow.rb:108:1:112:3 | synthetic *args |
 | params_flow.rb:108:1:112:3 | synthetic *args | type tracker without call steps | params_flow.rb:108:1:112:3 | synthetic *args |
-| params_flow.rb:108:1:112:3 | synthetic *args[0] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:108:1:112:3 | synthetic *args[0] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
-| params_flow.rb:108:1:112:3 | synthetic *args[0] | type tracker without call steps | params_flow.rb:108:1:112:3 | synthetic *args[0] |
-| params_flow.rb:108:1:112:3 | synthetic *args[0] | type tracker without call steps | params_flow.rb:110:10:110:13 | ...[...] |
-| params_flow.rb:108:1:112:3 | synthetic *args[0] | type tracker without call steps with content element 0 | params_flow.rb:108:40:108:41 | *b |
-| params_flow.rb:108:1:112:3 | synthetic *args[0] | type tracker without call steps with content element 0 | params_flow.rb:110:5:110:13 | * |
-| params_flow.rb:108:1:112:3 | synthetic *args[1] | type tracker without call steps | params_flow.rb:108:1:112:3 | synthetic *args[1] |
-| params_flow.rb:108:1:112:3 | synthetic *args[1] | type tracker without call steps with content element 1 | params_flow.rb:108:40:108:41 | *b |
-| params_flow.rb:108:1:112:3 | synthetic *args[2] | type tracker without call steps | params_flow.rb:108:1:112:3 | synthetic *args[2] |
-| params_flow.rb:108:1:112:3 | synthetic *args[2] | type tracker without call steps with content element 2 | params_flow.rb:108:40:108:41 | *b |
-| params_flow.rb:108:1:112:3 | synthetic *args[3] | type tracker without call steps | params_flow.rb:108:1:112:3 | synthetic *args[3] |
-| params_flow.rb:108:1:112:3 | synthetic *args[3] | type tracker without call steps with content element 3 | params_flow.rb:108:40:108:41 | *b |
-| params_flow.rb:108:1:112:3 | synthetic *args[4] | type tracker without call steps | params_flow.rb:108:1:112:3 | synthetic *args[4] |
-| params_flow.rb:108:1:112:3 | synthetic *args[4] | type tracker without call steps with content element 4 | params_flow.rb:108:40:108:41 | *b |
-| params_flow.rb:108:1:112:3 | synthetic *args[5] | type tracker without call steps | params_flow.rb:108:1:112:3 | synthetic *args[5] |
-| params_flow.rb:108:1:112:3 | synthetic *args[5] | type tracker without call steps with content element 5 | params_flow.rb:108:40:108:41 | *b |
-| params_flow.rb:108:1:112:3 | synthetic *args[6] | type tracker without call steps | params_flow.rb:108:1:112:3 | synthetic *args[6] |
-| params_flow.rb:108:1:112:3 | synthetic *args[6] | type tracker without call steps with content element 6 | params_flow.rb:108:40:108:41 | *b |
-| params_flow.rb:108:1:112:3 | synthetic *args[7] | type tracker without call steps | params_flow.rb:108:1:112:3 | synthetic *args[7] |
-| params_flow.rb:108:1:112:3 | synthetic *args[7] | type tracker without call steps with content element 7 | params_flow.rb:108:40:108:41 | *b |
-| params_flow.rb:108:1:112:3 | synthetic *args[8] | type tracker without call steps | params_flow.rb:108:1:112:3 | synthetic *args[8] |
-| params_flow.rb:108:1:112:3 | synthetic *args[8] | type tracker without call steps with content element 8 | params_flow.rb:108:40:108:41 | *b |
-| params_flow.rb:108:1:112:3 | synthetic *args[9] | type tracker without call steps | params_flow.rb:108:1:112:3 | synthetic *args[9] |
-| params_flow.rb:108:1:112:3 | synthetic *args[9] | type tracker without call steps with content element 9 | params_flow.rb:108:40:108:41 | *b |
-| params_flow.rb:108:1:112:3 | synthetic *args[10] | type tracker without call steps | params_flow.rb:108:1:112:3 | synthetic *args[10] |
-| params_flow.rb:108:1:112:3 | synthetic *args[10] | type tracker without call steps with content element 10 | params_flow.rb:108:40:108:41 | *b |
 | params_flow.rb:108:37:108:37 | a | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:108:37:108:37 | a | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
 | params_flow.rb:108:37:108:37 | a | type tracker without call steps | params_flow.rb:108:37:108:37 | a |
@@ -1811,10 +1813,20 @@ track
 | params_flow.rb:114:39:114:40 | 58 | type tracker without call steps with content element 0 | params_flow.rb:114:1:114:67 | * |
 | params_flow.rb:114:39:114:40 | 58 | type tracker without call steps with content element 0 | params_flow.rb:114:33:114:41 | * |
 | params_flow.rb:114:44:114:52 | * | type tracker without call steps | params_flow.rb:114:44:114:52 | * |
+| params_flow.rb:114:44:114:52 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:114:44:114:52 | call to taint | type tracker with call steps | params_flow.rb:110:10:110:13 | ...[...] |
+| params_flow.rb:114:44:114:52 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:114:44:114:52 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:108:40:108:41 | *b |
+| params_flow.rb:114:44:114:52 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:110:5:110:13 | * |
 | params_flow.rb:114:44:114:52 | call to taint | type tracker with call steps with content element 1 | params_flow.rb:108:1:112:3 | synthetic *args |
 | params_flow.rb:114:44:114:52 | call to taint | type tracker without call steps | params_flow.rb:114:44:114:52 | call to taint |
 | params_flow.rb:114:44:114:52 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:114:1:114:67 | * |
 | params_flow.rb:114:50:114:51 | 59 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:114:50:114:51 | 59 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:114:50:114:51 | 59 | type tracker with call steps | params_flow.rb:110:10:110:13 | ...[...] |
+| params_flow.rb:114:50:114:51 | 59 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:114:50:114:51 | 59 | type tracker with call steps with content element 0 | params_flow.rb:108:40:108:41 | *b |
+| params_flow.rb:114:50:114:51 | 59 | type tracker with call steps with content element 0 | params_flow.rb:110:5:110:13 | * |
 | params_flow.rb:114:50:114:51 | 59 | type tracker with call steps with content element 1 | params_flow.rb:108:1:112:3 | synthetic *args |
 | params_flow.rb:114:50:114:51 | 59 | type tracker without call steps | params_flow.rb:114:44:114:52 | call to taint |
 | params_flow.rb:114:50:114:51 | 59 | type tracker without call steps | params_flow.rb:114:50:114:51 | 59 |
@@ -1842,9 +1854,17 @@ track
 | params_flow.rb:114:64:114:65 | 60 | type tracker without call steps with content element :c | params_flow.rb:114:1:114:67 | ** |
 | params_flow.rb:116:1:116:1 | x | type tracker without call steps | params_flow.rb:116:1:116:1 | x |
 | params_flow.rb:116:5:116:6 | Array | type tracker without call steps | params_flow.rb:116:5:116:6 | Array |
+| params_flow.rb:116:5:116:6 | call to [] | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:116:5:116:6 | call to [] | type tracker with call steps | params_flow.rb:9:16:9:17 | p1 |
+| params_flow.rb:116:5:116:6 | call to [] | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:116:5:116:6 | call to [] | type tracker with call steps with content element 0 | params_flow.rb:10:5:10:11 | * |
 | params_flow.rb:116:5:116:6 | call to [] | type tracker with call steps with content element 0 or unknown | params_flow.rb:9:1:12:3 | synthetic *args |
 | params_flow.rb:116:5:116:6 | call to [] | type tracker without call steps | params_flow.rb:116:5:116:6 | call to [] |
 | params_flow.rb:116:5:116:6 | call to [] | type tracker without call steps with content element 0 or unknown | params_flow.rb:118:12:118:13 | * ... |
+| params_flow.rb:117:1:117:1 | [post] x | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:117:1:117:1 | [post] x | type tracker with call steps | params_flow.rb:9:16:9:17 | p1 |
+| params_flow.rb:117:1:117:1 | [post] x | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:117:1:117:1 | [post] x | type tracker with call steps with content element 0 | params_flow.rb:10:5:10:11 | * |
 | params_flow.rb:117:1:117:1 | [post] x | type tracker with call steps with content element 0 or unknown | params_flow.rb:9:1:12:3 | synthetic *args |
 | params_flow.rb:117:1:117:1 | [post] x | type tracker without call steps | params_flow.rb:117:1:117:1 | [post] x |
 | params_flow.rb:117:1:117:1 | [post] x | type tracker without call steps with content element 0 or unknown | params_flow.rb:118:12:118:13 | * ... |
@@ -1854,14 +1874,26 @@ track
 | params_flow.rb:117:3:117:14 | call to some_index | type tracker without call steps with content element 0 | params_flow.rb:117:1:117:15 | * |
 | params_flow.rb:117:19:117:27 | * | type tracker without call steps | params_flow.rb:117:19:117:27 | * |
 | params_flow.rb:117:19:117:27 | __synth__0 | type tracker without call steps | params_flow.rb:117:19:117:27 | __synth__0 |
+| params_flow.rb:117:19:117:27 | call to taint | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:117:19:117:27 | call to taint | type tracker with call steps | params_flow.rb:9:16:9:17 | p1 |
+| params_flow.rb:117:19:117:27 | call to taint | type tracker with call steps | params_flow.rb:9:20:9:21 | p2 |
 | params_flow.rb:117:19:117:27 | call to taint | type tracker with call steps with content element | params_flow.rb:9:1:12:3 | synthetic *args |
+| params_flow.rb:117:19:117:27 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:117:19:117:27 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:10:5:10:11 | * |
+| params_flow.rb:117:19:117:27 | call to taint | type tracker with call steps with content element 0 | params_flow.rb:11:5:11:11 | * |
 | params_flow.rb:117:19:117:27 | call to taint | type tracker without call steps | params_flow.rb:117:19:117:27 | call to taint |
 | params_flow.rb:117:19:117:27 | call to taint | type tracker without call steps with content attribute [] | params_flow.rb:117:1:117:1 | [post] x |
 | params_flow.rb:117:19:117:27 | call to taint | type tracker without call steps with content element | params_flow.rb:116:5:116:6 | call to [] |
 | params_flow.rb:117:19:117:27 | call to taint | type tracker without call steps with content element | params_flow.rb:118:12:118:13 | * ... |
 | params_flow.rb:117:19:117:27 | call to taint | type tracker without call steps with content element 1 | params_flow.rb:117:1:117:15 | * |
 | params_flow.rb:117:25:117:26 | 61 | type tracker with call steps | params_flow.rb:1:11:1:11 | x |
+| params_flow.rb:117:25:117:26 | 61 | type tracker with call steps | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:117:25:117:26 | 61 | type tracker with call steps | params_flow.rb:9:16:9:17 | p1 |
+| params_flow.rb:117:25:117:26 | 61 | type tracker with call steps | params_flow.rb:9:20:9:21 | p2 |
 | params_flow.rb:117:25:117:26 | 61 | type tracker with call steps with content element | params_flow.rb:9:1:12:3 | synthetic *args |
+| params_flow.rb:117:25:117:26 | 61 | type tracker with call steps with content element 0 | params_flow.rb:6:5:6:10 | * |
+| params_flow.rb:117:25:117:26 | 61 | type tracker with call steps with content element 0 | params_flow.rb:10:5:10:11 | * |
+| params_flow.rb:117:25:117:26 | 61 | type tracker with call steps with content element 0 | params_flow.rb:11:5:11:11 | * |
 | params_flow.rb:117:25:117:26 | 61 | type tracker without call steps | params_flow.rb:117:19:117:27 | call to taint |
 | params_flow.rb:117:25:117:26 | 61 | type tracker without call steps | params_flow.rb:117:25:117:26 | 61 |
 | params_flow.rb:117:25:117:26 | 61 | type tracker without call steps with content attribute [] | params_flow.rb:117:1:117:1 | [post] x |
@@ -2257,6 +2289,7 @@ trackEnd
 | params_flow.rb:1:11:1:11 | x | params_flow.rb:108:44:108:44 | c |
 | params_flow.rb:1:11:1:11 | x | params_flow.rb:108:44:108:44 | c |
 | params_flow.rb:1:11:1:11 | x | params_flow.rb:109:10:109:10 | a |
+| params_flow.rb:1:11:1:11 | x | params_flow.rb:110:10:110:13 | ...[...] |
 | params_flow.rb:1:11:1:11 | x | params_flow.rb:111:10:111:10 | c |
 | params_flow.rb:1:11:1:11 | x | params_flow.rb:114:33:114:41 | call to taint |
 | params_flow.rb:1:11:1:11 | x | params_flow.rb:114:44:114:52 | call to taint |
@@ -2819,6 +2852,9 @@ trackEnd
 | params_flow.rb:37:16:37:24 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:37:16:37:24 | call to taint | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:37:16:37:24 | call to taint | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:37:16:37:24 | call to taint | params_flow.rb:25:12:25:13 | p1 |
+| params_flow.rb:37:16:37:24 | call to taint | params_flow.rb:25:12:25:13 | p1 |
+| params_flow.rb:37:16:37:24 | call to taint | params_flow.rb:26:10:26:11 | p1 |
 | params_flow.rb:37:16:37:24 | call to taint | params_flow.rb:27:10:27:22 | ( ... ) |
 | params_flow.rb:37:16:37:24 | call to taint | params_flow.rb:27:11:27:21 | ...[...] |
 | params_flow.rb:37:16:37:24 | call to taint | params_flow.rb:37:16:37:24 | call to taint |
@@ -2828,6 +2864,9 @@ trackEnd
 | params_flow.rb:37:22:37:23 | 14 | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:37:22:37:23 | 14 | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:37:22:37:23 | 14 | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:37:22:37:23 | 14 | params_flow.rb:25:12:25:13 | p1 |
+| params_flow.rb:37:22:37:23 | 14 | params_flow.rb:25:12:25:13 | p1 |
+| params_flow.rb:37:22:37:23 | 14 | params_flow.rb:26:10:26:11 | p1 |
 | params_flow.rb:37:22:37:23 | 14 | params_flow.rb:27:10:27:22 | ( ... ) |
 | params_flow.rb:37:22:37:23 | 14 | params_flow.rb:27:11:27:21 | ...[...] |
 | params_flow.rb:37:22:37:23 | 14 | params_flow.rb:37:16:37:24 | call to taint |
@@ -2870,10 +2909,22 @@ trackEnd
 | params_flow.rb:40:9:40:11 | :p1 | params_flow.rb:40:9:40:11 | :p1 |
 | params_flow.rb:40:9:40:24 | Pair | params_flow.rb:40:9:40:24 | Pair |
 | params_flow.rb:40:16:40:24 | * | params_flow.rb:40:16:40:24 | * |
+| params_flow.rb:40:16:40:24 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:40:16:40:24 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:40:16:40:24 | call to taint | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:40:16:40:24 | call to taint | params_flow.rb:16:13:16:14 | p1 |
+| params_flow.rb:40:16:40:24 | call to taint | params_flow.rb:16:13:16:14 | p1 |
+| params_flow.rb:40:16:40:24 | call to taint | params_flow.rb:17:10:17:11 | p1 |
 | params_flow.rb:40:16:40:24 | call to taint | params_flow.rb:40:16:40:24 | call to taint |
 | params_flow.rb:40:22:40:23 | 16 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:40:22:40:23 | 16 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:40:22:40:23 | 16 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:40:22:40:23 | 16 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:40:22:40:23 | 16 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:40:22:40:23 | 16 | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:40:22:40:23 | 16 | params_flow.rb:16:13:16:14 | p1 |
+| params_flow.rb:40:22:40:23 | 16 | params_flow.rb:16:13:16:14 | p1 |
+| params_flow.rb:40:22:40:23 | 16 | params_flow.rb:17:10:17:11 | p1 |
 | params_flow.rb:40:22:40:23 | 16 | params_flow.rb:40:16:40:24 | call to taint |
 | params_flow.rb:40:22:40:23 | 16 | params_flow.rb:40:22:40:23 | 16 |
 | params_flow.rb:41:1:41:30 | ** | params_flow.rb:16:1:19:3 | **kwargs |
@@ -2940,22 +2991,52 @@ trackEnd
 | params_flow.rb:46:1:46:4 | args | params_flow.rb:46:1:46:4 | args |
 | params_flow.rb:46:8:46:29 | * | params_flow.rb:46:8:46:29 | * |
 | params_flow.rb:46:8:46:29 | Array | params_flow.rb:46:8:46:29 | Array |
+| params_flow.rb:46:8:46:29 | call to [] | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:46:8:46:29 | call to [] | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:46:8:46:29 | call to [] | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:46:8:46:29 | call to [] | params_flow.rb:9:16:9:17 | p1 |
+| params_flow.rb:46:8:46:29 | call to [] | params_flow.rb:9:16:9:17 | p1 |
+| params_flow.rb:46:8:46:29 | call to [] | params_flow.rb:10:10:10:11 | p1 |
 | params_flow.rb:46:8:46:29 | call to [] | params_flow.rb:46:1:46:4 | args |
 | params_flow.rb:46:8:46:29 | call to [] | params_flow.rb:46:1:46:29 | ... = ... |
 | params_flow.rb:46:8:46:29 | call to [] | params_flow.rb:46:8:46:29 | call to [] |
 | params_flow.rb:46:8:46:29 | call to [] | params_flow.rb:47:13:47:16 | args |
 | params_flow.rb:46:9:46:17 | * | params_flow.rb:46:9:46:17 | * |
+| params_flow.rb:46:9:46:17 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:46:9:46:17 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:46:9:46:17 | call to taint | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:46:9:46:17 | call to taint | params_flow.rb:9:16:9:17 | p1 |
+| params_flow.rb:46:9:46:17 | call to taint | params_flow.rb:9:16:9:17 | p1 |
+| params_flow.rb:46:9:46:17 | call to taint | params_flow.rb:10:10:10:11 | p1 |
 | params_flow.rb:46:9:46:17 | call to taint | params_flow.rb:46:9:46:17 | call to taint |
 | params_flow.rb:46:15:46:16 | 18 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:46:15:46:16 | 18 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:46:15:46:16 | 18 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:46:15:46:16 | 18 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:46:15:46:16 | 18 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:46:15:46:16 | 18 | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:46:15:46:16 | 18 | params_flow.rb:9:16:9:17 | p1 |
+| params_flow.rb:46:15:46:16 | 18 | params_flow.rb:9:16:9:17 | p1 |
+| params_flow.rb:46:15:46:16 | 18 | params_flow.rb:10:10:10:11 | p1 |
 | params_flow.rb:46:15:46:16 | 18 | params_flow.rb:46:9:46:17 | call to taint |
 | params_flow.rb:46:15:46:16 | 18 | params_flow.rb:46:15:46:16 | 18 |
 | params_flow.rb:46:20:46:28 | * | params_flow.rb:46:20:46:28 | * |
+| params_flow.rb:46:20:46:28 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:46:20:46:28 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:46:20:46:28 | call to taint | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:46:20:46:28 | call to taint | params_flow.rb:9:20:9:21 | p2 |
+| params_flow.rb:46:20:46:28 | call to taint | params_flow.rb:9:20:9:21 | p2 |
+| params_flow.rb:46:20:46:28 | call to taint | params_flow.rb:11:10:11:11 | p2 |
 | params_flow.rb:46:20:46:28 | call to taint | params_flow.rb:46:20:46:28 | call to taint |
 | params_flow.rb:46:26:46:27 | 19 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:46:26:46:27 | 19 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:46:26:46:27 | 19 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:46:26:46:27 | 19 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:46:26:46:27 | 19 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:46:26:46:27 | 19 | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:46:26:46:27 | 19 | params_flow.rb:9:20:9:21 | p2 |
+| params_flow.rb:46:26:46:27 | 19 | params_flow.rb:9:20:9:21 | p2 |
+| params_flow.rb:46:26:46:27 | 19 | params_flow.rb:11:10:11:11 | p2 |
 | params_flow.rb:46:26:46:27 | 19 | params_flow.rb:46:20:46:28 | call to taint |
 | params_flow.rb:46:26:46:27 | 19 | params_flow.rb:46:26:46:27 | 19 |
 | params_flow.rb:47:1:47:17 | call to positional | params_flow.rb:47:1:47:17 | call to positional |
@@ -2973,27 +3054,6 @@ trackEnd
 | params_flow.rb:49:1:53:3 | self in posargs | params_flow.rb:52:5:52:21 | self |
 | params_flow.rb:49:1:53:3 | synthetic *args | params_flow.rb:49:1:53:3 | synthetic *args |
 | params_flow.rb:49:1:53:3 | synthetic *args | params_flow.rb:49:1:53:3 | synthetic *args |
-| params_flow.rb:49:1:53:3 | synthetic *args[0] | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:49:1:53:3 | synthetic *args[0] | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:49:1:53:3 | synthetic *args[0] | params_flow.rb:6:10:6:10 | x |
-| params_flow.rb:49:1:53:3 | synthetic *args[0] | params_flow.rb:49:1:53:3 | synthetic *args[0] |
-| params_flow.rb:49:1:53:3 | synthetic *args[0] | params_flow.rb:51:10:51:21 | ( ... ) |
-| params_flow.rb:49:1:53:3 | synthetic *args[0] | params_flow.rb:51:11:51:20 | ...[...] |
-| params_flow.rb:49:1:53:3 | synthetic *args[1] | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:49:1:53:3 | synthetic *args[1] | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:49:1:53:3 | synthetic *args[1] | params_flow.rb:6:10:6:10 | x |
-| params_flow.rb:49:1:53:3 | synthetic *args[1] | params_flow.rb:49:1:53:3 | synthetic *args[1] |
-| params_flow.rb:49:1:53:3 | synthetic *args[1] | params_flow.rb:52:10:52:21 | ( ... ) |
-| params_flow.rb:49:1:53:3 | synthetic *args[1] | params_flow.rb:52:11:52:20 | ...[...] |
-| params_flow.rb:49:1:53:3 | synthetic *args[2] | params_flow.rb:49:1:53:3 | synthetic *args[2] |
-| params_flow.rb:49:1:53:3 | synthetic *args[3] | params_flow.rb:49:1:53:3 | synthetic *args[3] |
-| params_flow.rb:49:1:53:3 | synthetic *args[4] | params_flow.rb:49:1:53:3 | synthetic *args[4] |
-| params_flow.rb:49:1:53:3 | synthetic *args[5] | params_flow.rb:49:1:53:3 | synthetic *args[5] |
-| params_flow.rb:49:1:53:3 | synthetic *args[6] | params_flow.rb:49:1:53:3 | synthetic *args[6] |
-| params_flow.rb:49:1:53:3 | synthetic *args[7] | params_flow.rb:49:1:53:3 | synthetic *args[7] |
-| params_flow.rb:49:1:53:3 | synthetic *args[8] | params_flow.rb:49:1:53:3 | synthetic *args[8] |
-| params_flow.rb:49:1:53:3 | synthetic *args[9] | params_flow.rb:49:1:53:3 | synthetic *args[9] |
-| params_flow.rb:49:1:53:3 | synthetic *args[10] | params_flow.rb:49:1:53:3 | synthetic *args[10] |
 | params_flow.rb:49:13:49:14 | p1 | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:49:13:49:14 | p1 | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:49:13:49:14 | p1 | params_flow.rb:6:10:6:10 | x |
@@ -3052,10 +3112,20 @@ trackEnd
 | params_flow.rb:55:15:55:16 | 20 | params_flow.rb:55:9:55:17 | call to taint |
 | params_flow.rb:55:15:55:16 | 20 | params_flow.rb:55:15:55:16 | 20 |
 | params_flow.rb:55:20:55:28 | * | params_flow.rb:55:20:55:28 | * |
+| params_flow.rb:55:20:55:28 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:55:20:55:28 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:55:20:55:28 | call to taint | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:55:20:55:28 | call to taint | params_flow.rb:51:10:51:21 | ( ... ) |
+| params_flow.rb:55:20:55:28 | call to taint | params_flow.rb:51:11:51:20 | ...[...] |
 | params_flow.rb:55:20:55:28 | call to taint | params_flow.rb:55:20:55:28 | call to taint |
 | params_flow.rb:55:26:55:27 | 21 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:55:26:55:27 | 21 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:55:26:55:27 | 21 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:55:26:55:27 | 21 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:55:26:55:27 | 21 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:55:26:55:27 | 21 | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:55:26:55:27 | 21 | params_flow.rb:51:10:51:21 | ( ... ) |
+| params_flow.rb:55:26:55:27 | 21 | params_flow.rb:51:11:51:20 | ...[...] |
 | params_flow.rb:55:26:55:27 | 21 | params_flow.rb:55:20:55:28 | call to taint |
 | params_flow.rb:55:26:55:27 | 21 | params_flow.rb:55:26:55:27 | 21 |
 | params_flow.rb:57:1:57:4 | args | params_flow.rb:57:1:57:4 | args |
@@ -3115,15 +3185,33 @@ trackEnd
 | params_flow.rb:60:1:60:4 | args | params_flow.rb:60:1:60:4 | args |
 | params_flow.rb:60:8:60:29 | * | params_flow.rb:60:8:60:29 | * |
 | params_flow.rb:60:8:60:29 | Array | params_flow.rb:60:8:60:29 | Array |
+| params_flow.rb:60:8:60:29 | call to [] | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:60:8:60:29 | call to [] | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:60:8:60:29 | call to [] | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:60:8:60:29 | call to [] | params_flow.rb:49:13:49:14 | p1 |
+| params_flow.rb:60:8:60:29 | call to [] | params_flow.rb:49:13:49:14 | p1 |
+| params_flow.rb:60:8:60:29 | call to [] | params_flow.rb:50:10:50:11 | p1 |
 | params_flow.rb:60:8:60:29 | call to [] | params_flow.rb:60:1:60:4 | args |
 | params_flow.rb:60:8:60:29 | call to [] | params_flow.rb:60:1:60:29 | ... = ... |
 | params_flow.rb:60:8:60:29 | call to [] | params_flow.rb:60:8:60:29 | call to [] |
 | params_flow.rb:60:8:60:29 | call to [] | params_flow.rb:61:10:61:13 | args |
 | params_flow.rb:60:9:60:17 | * | params_flow.rb:60:9:60:17 | * |
+| params_flow.rb:60:9:60:17 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:60:9:60:17 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:60:9:60:17 | call to taint | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:60:9:60:17 | call to taint | params_flow.rb:49:13:49:14 | p1 |
+| params_flow.rb:60:9:60:17 | call to taint | params_flow.rb:49:13:49:14 | p1 |
+| params_flow.rb:60:9:60:17 | call to taint | params_flow.rb:50:10:50:11 | p1 |
 | params_flow.rb:60:9:60:17 | call to taint | params_flow.rb:60:9:60:17 | call to taint |
 | params_flow.rb:60:15:60:16 | 24 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:60:15:60:16 | 24 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:60:15:60:16 | 24 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:60:15:60:16 | 24 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:60:15:60:16 | 24 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:60:15:60:16 | 24 | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:60:15:60:16 | 24 | params_flow.rb:49:13:49:14 | p1 |
+| params_flow.rb:60:15:60:16 | 24 | params_flow.rb:49:13:49:14 | p1 |
+| params_flow.rb:60:15:60:16 | 24 | params_flow.rb:50:10:50:11 | p1 |
 | params_flow.rb:60:15:60:16 | 24 | params_flow.rb:60:9:60:17 | call to taint |
 | params_flow.rb:60:15:60:16 | 24 | params_flow.rb:60:15:60:16 | 24 |
 | params_flow.rb:60:20:60:28 | * | params_flow.rb:60:20:60:28 | * |
@@ -3832,21 +3920,6 @@ trackEnd
 | params_flow.rb:108:1:112:3 | splat_followed_by_keyword_param | params_flow.rb:108:1:112:3 | splat_followed_by_keyword_param |
 | params_flow.rb:108:1:112:3 | synthetic *args | params_flow.rb:108:1:112:3 | synthetic *args |
 | params_flow.rb:108:1:112:3 | synthetic *args | params_flow.rb:108:1:112:3 | synthetic *args |
-| params_flow.rb:108:1:112:3 | synthetic *args[0] | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:108:1:112:3 | synthetic *args[0] | params_flow.rb:5:10:5:10 | x |
-| params_flow.rb:108:1:112:3 | synthetic *args[0] | params_flow.rb:6:10:6:10 | x |
-| params_flow.rb:108:1:112:3 | synthetic *args[0] | params_flow.rb:108:1:112:3 | synthetic *args[0] |
-| params_flow.rb:108:1:112:3 | synthetic *args[0] | params_flow.rb:110:10:110:13 | ...[...] |
-| params_flow.rb:108:1:112:3 | synthetic *args[1] | params_flow.rb:108:1:112:3 | synthetic *args[1] |
-| params_flow.rb:108:1:112:3 | synthetic *args[2] | params_flow.rb:108:1:112:3 | synthetic *args[2] |
-| params_flow.rb:108:1:112:3 | synthetic *args[3] | params_flow.rb:108:1:112:3 | synthetic *args[3] |
-| params_flow.rb:108:1:112:3 | synthetic *args[4] | params_flow.rb:108:1:112:3 | synthetic *args[4] |
-| params_flow.rb:108:1:112:3 | synthetic *args[5] | params_flow.rb:108:1:112:3 | synthetic *args[5] |
-| params_flow.rb:108:1:112:3 | synthetic *args[6] | params_flow.rb:108:1:112:3 | synthetic *args[6] |
-| params_flow.rb:108:1:112:3 | synthetic *args[7] | params_flow.rb:108:1:112:3 | synthetic *args[7] |
-| params_flow.rb:108:1:112:3 | synthetic *args[8] | params_flow.rb:108:1:112:3 | synthetic *args[8] |
-| params_flow.rb:108:1:112:3 | synthetic *args[9] | params_flow.rb:108:1:112:3 | synthetic *args[9] |
-| params_flow.rb:108:1:112:3 | synthetic *args[10] | params_flow.rb:108:1:112:3 | synthetic *args[10] |
 | params_flow.rb:108:37:108:37 | a | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:108:37:108:37 | a | params_flow.rb:5:10:5:10 | x |
 | params_flow.rb:108:37:108:37 | a | params_flow.rb:6:10:6:10 | x |
@@ -3903,10 +3976,18 @@ trackEnd
 | params_flow.rb:114:39:114:40 | 58 | params_flow.rb:114:33:114:41 | call to taint |
 | params_flow.rb:114:39:114:40 | 58 | params_flow.rb:114:39:114:40 | 58 |
 | params_flow.rb:114:44:114:52 | * | params_flow.rb:114:44:114:52 | * |
+| params_flow.rb:114:44:114:52 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:114:44:114:52 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:114:44:114:52 | call to taint | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:114:44:114:52 | call to taint | params_flow.rb:110:10:110:13 | ...[...] |
 | params_flow.rb:114:44:114:52 | call to taint | params_flow.rb:114:44:114:52 | call to taint |
 | params_flow.rb:114:50:114:51 | 59 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:114:50:114:51 | 59 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:114:50:114:51 | 59 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:114:50:114:51 | 59 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:114:50:114:51 | 59 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:114:50:114:51 | 59 | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:114:50:114:51 | 59 | params_flow.rb:110:10:110:13 | ...[...] |
 | params_flow.rb:114:50:114:51 | 59 | params_flow.rb:114:44:114:52 | call to taint |
 | params_flow.rb:114:50:114:51 | 59 | params_flow.rb:114:50:114:51 | 59 |
 | params_flow.rb:114:55:114:55 | :c | params_flow.rb:114:55:114:55 | :c |
@@ -3932,11 +4013,23 @@ trackEnd
 | params_flow.rb:114:64:114:65 | 60 | params_flow.rb:114:64:114:65 | 60 |
 | params_flow.rb:116:1:116:1 | x | params_flow.rb:116:1:116:1 | x |
 | params_flow.rb:116:5:116:6 | Array | params_flow.rb:116:5:116:6 | Array |
+| params_flow.rb:116:5:116:6 | call to [] | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:116:5:116:6 | call to [] | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:116:5:116:6 | call to [] | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:116:5:116:6 | call to [] | params_flow.rb:9:16:9:17 | p1 |
+| params_flow.rb:116:5:116:6 | call to [] | params_flow.rb:9:16:9:17 | p1 |
+| params_flow.rb:116:5:116:6 | call to [] | params_flow.rb:10:10:10:11 | p1 |
 | params_flow.rb:116:5:116:6 | call to [] | params_flow.rb:116:1:116:1 | x |
 | params_flow.rb:116:5:116:6 | call to [] | params_flow.rb:116:1:116:6 | ... = ... |
 | params_flow.rb:116:5:116:6 | call to [] | params_flow.rb:116:5:116:6 | call to [] |
 | params_flow.rb:116:5:116:6 | call to [] | params_flow.rb:117:1:117:1 | x |
 | params_flow.rb:116:5:116:6 | call to [] | params_flow.rb:118:13:118:13 | x |
+| params_flow.rb:117:1:117:1 | [post] x | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:117:1:117:1 | [post] x | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:117:1:117:1 | [post] x | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:117:1:117:1 | [post] x | params_flow.rb:9:16:9:17 | p1 |
+| params_flow.rb:117:1:117:1 | [post] x | params_flow.rb:9:16:9:17 | p1 |
+| params_flow.rb:117:1:117:1 | [post] x | params_flow.rb:10:10:10:11 | p1 |
 | params_flow.rb:117:1:117:1 | [post] x | params_flow.rb:117:1:117:1 | [post] x |
 | params_flow.rb:117:1:117:1 | [post] x | params_flow.rb:118:13:118:13 | x |
 | params_flow.rb:117:1:117:15 | * | params_flow.rb:117:1:117:15 | * |
@@ -3944,6 +4037,15 @@ trackEnd
 | params_flow.rb:117:3:117:14 | call to some_index | params_flow.rb:117:3:117:14 | call to some_index |
 | params_flow.rb:117:19:117:27 | * | params_flow.rb:117:19:117:27 | * |
 | params_flow.rb:117:19:117:27 | __synth__0 | params_flow.rb:117:19:117:27 | __synth__0 |
+| params_flow.rb:117:19:117:27 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:117:19:117:27 | call to taint | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:117:19:117:27 | call to taint | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:117:19:117:27 | call to taint | params_flow.rb:9:16:9:17 | p1 |
+| params_flow.rb:117:19:117:27 | call to taint | params_flow.rb:9:16:9:17 | p1 |
+| params_flow.rb:117:19:117:27 | call to taint | params_flow.rb:9:20:9:21 | p2 |
+| params_flow.rb:117:19:117:27 | call to taint | params_flow.rb:9:20:9:21 | p2 |
+| params_flow.rb:117:19:117:27 | call to taint | params_flow.rb:10:10:10:11 | p1 |
+| params_flow.rb:117:19:117:27 | call to taint | params_flow.rb:11:10:11:11 | p2 |
 | params_flow.rb:117:19:117:27 | call to taint | params_flow.rb:117:1:117:15 | __synth__0 |
 | params_flow.rb:117:19:117:27 | call to taint | params_flow.rb:117:1:117:27 | ... |
 | params_flow.rb:117:19:117:27 | call to taint | params_flow.rb:117:19:117:27 | ... = ... |
@@ -3952,6 +4054,15 @@ trackEnd
 | params_flow.rb:117:25:117:26 | 61 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:117:25:117:26 | 61 | params_flow.rb:1:11:1:11 | x |
 | params_flow.rb:117:25:117:26 | 61 | params_flow.rb:2:5:2:5 | x |
+| params_flow.rb:117:25:117:26 | 61 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:117:25:117:26 | 61 | params_flow.rb:5:10:5:10 | x |
+| params_flow.rb:117:25:117:26 | 61 | params_flow.rb:6:10:6:10 | x |
+| params_flow.rb:117:25:117:26 | 61 | params_flow.rb:9:16:9:17 | p1 |
+| params_flow.rb:117:25:117:26 | 61 | params_flow.rb:9:16:9:17 | p1 |
+| params_flow.rb:117:25:117:26 | 61 | params_flow.rb:9:20:9:21 | p2 |
+| params_flow.rb:117:25:117:26 | 61 | params_flow.rb:9:20:9:21 | p2 |
+| params_flow.rb:117:25:117:26 | 61 | params_flow.rb:10:10:10:11 | p1 |
+| params_flow.rb:117:25:117:26 | 61 | params_flow.rb:11:10:11:11 | p2 |
 | params_flow.rb:117:25:117:26 | 61 | params_flow.rb:117:1:117:15 | __synth__0 |
 | params_flow.rb:117:25:117:26 | 61 | params_flow.rb:117:1:117:27 | ... |
 | params_flow.rb:117:25:117:26 | 61 | params_flow.rb:117:19:117:27 | ... = ... |

--- a/ruby/ql/test/library-tests/dataflow/params/TypeTracker.qlref
+++ b/ruby/ql/test/library-tests/dataflow/params/TypeTracker.qlref
@@ -1,0 +1,1 @@
+library-tests/dataflow/type-tracker/TypeTracker.ql


### PR DESCRIPTION
Whilst reviewing https://github.com/github/codeql/pull/13938, it occurred to me that we don't include the read/store steps used to model flow into (hash) splat parameters in type tracking. This PR does that, but a bit differently, as we use type tracking's ability to define read-store steps, to avoid having `SynthSplatParameterElementNode`s be `LocalSourceNode`s.