### PR TITLE
JS: Follow immediate predecessors in path resolution

### DIFF
--- a/javascript/ql/src/change-notes/2023-08-23-import-path-string.md
+++ b/javascript/ql/src/change-notes/2023-08-23-import-path-string.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Imports can now be resolved in more cases, where a non-constant string expression is passed to a `require()` call.

--- a/javascript/ql/test/library-tests/Modules/import-indirect-path.js
+++ b/javascript/ql/test/library-tests/Modules/import-indirect-path.js
@@ -1,0 +1,5 @@
+require(__dirname + '/a');
+
+var x = __dirname;
+var y = '/a';
+require(x + y);

--- a/javascript/ql/test/library-tests/Modules/tests.expected
+++ b/javascript/ql/test/library-tests/Modules/tests.expected
@@ -90,6 +90,8 @@ test_NamedImportSpecifier
 | reExportNamespaceClient.js:1:10:1:11 | ns |
 test_OtherImports
 | es2015_require.js:1:11:1:24 | require('./d') | d.js:1:1:5:0 | <toplevel> |
+| import-indirect-path.js:1:1:1:25 | require ... + '/a') | a.js:1:1:5:32 | <toplevel> |
+| import-indirect-path.js:5:1:5:14 | require(x + y) | a.js:1:1:5:32 | <toplevel> |
 test_ReExportDeclarations
 | b.js:7:1:7:21 | export  ...  './a'; | b.js:7:16:7:20 | './a' |
 | d.js:4:1:4:20 | export * from 'm/c'; | d.js:4:15:4:19 | 'm/c' |
@@ -103,6 +105,7 @@ test_getAnImportedModule
 | library-tests/Modules/es2015_require.js | library-tests/Modules/d.js |
 | library-tests/Modules/f.ts | library-tests/Modules/e.js |
 | library-tests/Modules/g.ts | library-tests/Modules/f.ts |
+| library-tests/Modules/import-indirect-path.js | library-tests/Modules/a.js |
 | library-tests/Modules/import-ts-with-js-extension.ts | library-tests/Modules/f.ts |
 | library-tests/Modules/m/c.js | library-tests/Modules/b.js |
 | library-tests/Modules/reExportNamespaceClient.js | library-tests/Modules/reExportNamespace.js |


### PR DESCRIPTION
Use more data flow during path resolution, so we can resolve imports like
```js
var x = __dirname;
var y = '/a';
require(x + y);
```