### PR TITLE
C#: Add "c#" alias to language pack

### DIFF
--- a/csharp/codeql-extractor.yml
+++ b/csharp/codeql-extractor.yml
@@ -1,4 +1,6 @@
 name: "csharp"
+aliases:
+  - "c#"
 display_name: "C#"
 version: 1.22.1
 column_kind: "utf16"


### PR DESCRIPTION
This will allow users to reference the C# extractor using `--language c#` in future versions of the CLI.