### PR TITLE
Revert "Swift: use C++20 constraints and concepts to simplify code"

### DIFF
--- a/misc/codegen/templates/trap_tags_h.mustache
+++ b/misc/codegen/templates/trap_tags_h.mustache
@@ -6,7 +6,7 @@ namespace codeql {
 {{#tags}}
 
 // {{id}}
-struct {{name}}Tag {{#has_bases}}: {{#bases}}{{^first}}, {{/first}}virtual {{base}}Tag{{/bases}} {{/has_bases}}{
+struct {{name}}Tag {{#has_bases}}: {{#bases}}{{^first}}, {{/first}}{{base}}Tag{{/bases}} {{/has_bases}}{
   static constexpr const char* prefix = "{{name}}";
 };
 {{/tags}}

--- a/swift/extractor/infra/SwiftLocationExtractor.h
+++ b/swift/extractor/infra/SwiftLocationExtractor.h
@@ -15,93 +15,90 @@ namespace codeql {
 
 class TrapDomain;
 
-namespace detail {
-template <typename T>
-concept HasSourceRange = requires(T e) {
-  e.getSourceRange();
-};
-
-template <typename T>
-concept HasStartAndEndLoc = requires(T e) {
-  e.getStartLoc();
-  e.getEndLoc();
-}
-&&!(HasSourceRange<T>);
-
-template <typename T>
-concept HasOneLoc = requires(T e) {
-  e.getLoc();
-}
-&&!(HasSourceRange<T>)&&(!HasStartAndEndLoc<T>);
-
-template <typename T>
-concept HasOneLocField = requires(T e) {
-  e.Loc;
-};
-
-swift::SourceRange getSourceRange(const HasSourceRange auto& locatable) {
-  return locatable.getSourceRange();
-}
-
-swift::SourceRange getSourceRange(const HasStartAndEndLoc auto& locatable) {
-  if (locatable.getStartLoc() && locatable.getEndLoc()) {
-    return {locatable.getStartLoc(), locatable.getEndLoc()};
-  }
-  return {locatable.getStartLoc()};
-}
-
-swift::SourceRange getSourceRange(const HasOneLoc auto& locatable) {
-  return {locatable.getLoc()};
-}
-
-swift::SourceRange getSourceRange(const HasOneLocField auto& locatable) {
-  return {locatable.Loc};
-}
-
-swift::SourceRange getSourceRange(const swift::Token& token);
-
-template <typename Locatable>
-swift::SourceRange getSourceRange(const llvm::MutableArrayRef<Locatable>& locatables) {
-  if (locatables.empty()) {
-    return {};
-  }
-  auto startRange = getSourceRange(locatables.front());
-  auto endRange = getSourceRange(locatables.back());
-  if (startRange.Start && endRange.End) {
-    return {startRange.Start, endRange.End};
-  }
-  return {startRange.Start};
-}
-}  // namespace detail
-
-template <typename E>
-concept IsLocatable = requires(E e) {
-  detail::getSourceRange(e);
-};
-
 class SwiftLocationExtractor {
+  template <typename Locatable, typename = void>
+  struct HasSpecializedImplementation : std::false_type {};
+
  public:
   explicit SwiftLocationExtractor(TrapDomain& trap) : trap(trap) {}
 
   TrapLabel<FileTag> emitFile(swift::SourceFile* file);
   TrapLabel<FileTag> emitFile(const std::filesystem::path& file);
 
-  // Emits a Location TRAP entry and attaches it to a `Locatable` trap label
+  template <typename Locatable>
   void attachLocation(const swift::SourceManager& sourceManager,
-                      const IsLocatable auto& locatable,
+                      const Locatable& locatable,
                       TrapLabel<LocatableTag> locatableLabel) {
-    attachLocationImpl(sourceManager, detail::getSourceRange(locatable), locatableLabel);
+    attachLocation(sourceManager, &locatable, locatableLabel);
   }
 
+  // Emits a Location TRAP entry and attaches it to a `Locatable` trap label
+  template <typename Locatable,
+            std::enable_if_t<!HasSpecializedImplementation<Locatable>::value>* = nullptr>
   void attachLocation(const swift::SourceManager& sourceManager,
-                      const IsLocatable auto* locatable,
+                      const Locatable* locatable,
                       TrapLabel<LocatableTag> locatableLabel) {
-    attachLocation(sourceManager, *locatable, locatableLabel);
+    attachLocationImpl(sourceManager, locatable->getStartLoc(), locatable->getEndLoc(),
+                       locatableLabel);
+  }
+
+  template <typename Locatable,
+            std::enable_if_t<HasSpecializedImplementation<Locatable>::value>* = nullptr>
+  void attachLocation(const swift::SourceManager& sourceManager,
+                      const Locatable* locatable,
+                      TrapLabel<LocatableTag> locatableLabel) {
+    attachLocationImpl(sourceManager, locatable, locatableLabel);
   }
 
  private:
+  // Emits a Location TRAP entry for a list of swift entities and attaches it to a `Locatable` trap
+  // label
+  template <typename Locatable>
+  void attachLocationImpl(const swift::SourceManager& sourceManager,
+                          const llvm::MutableArrayRef<Locatable>* locatables,
+                          TrapLabel<LocatableTag> locatableLabel) {
+    if (locatables->empty()) {
+      return;
+    }
+    attachLocationImpl(sourceManager, locatables->front().getStartLoc(),
+                       locatables->back().getEndLoc(), locatableLabel);
+  }
+
+  void attachLocationImpl(const swift::SourceManager& sourceManager,
+                          swift::SourceLoc start,
+                          swift::SourceLoc end,
+                          TrapLabel<LocatableTag> locatableLabel);
+
+  void attachLocationImpl(const swift::SourceManager& sourceManager,
+                          swift::SourceLoc loc,
+                          TrapLabel<LocatableTag> locatableLabel);
+
   void attachLocationImpl(const swift::SourceManager& sourceManager,
                           const swift::SourceRange& range,
+                          TrapLabel<LocatableTag> locatableLabel);
+
+  void attachLocationImpl(const swift::SourceManager& sourceManager,
+                          const swift::CapturedValue* capture,
+                          TrapLabel<LocatableTag> locatableLabel);
+
+  void attachLocationImpl(const swift::SourceManager& sourceManager,
+                          const swift::IfConfigClause* clause,
+                          TrapLabel<LocatableTag> locatableLabel);
+
+  void attachLocationImpl(const swift::SourceManager& sourceManager,
+                          const swift::AvailabilitySpec* spec,
+                          TrapLabel<LocatableTag> locatableLabel);
+
+  void attachLocationImpl(const swift::SourceManager& sourceManager,
+                          const swift::Token* token,
+                          TrapLabel<LocatableTag> locatableLabel);
+
+  void attachLocationImpl(const swift::SourceManager& sourceManager,
+                          const swift::DiagnosticInfo* token,
+                          TrapLabel<LocatableTag> locatableLabel);
+
+  void attachLocationImpl(const swift::SourceManager& sourceManager,
+                          const swift::KeyPathExpr::Component* component,
                           TrapLabel<LocatableTag> locatableLabel);
 
  private:
@@ -109,5 +106,13 @@ class SwiftLocationExtractor {
   TrapDomain& trap;
   std::unordered_map<std::filesystem::path, TrapLabel<FileTag>, codeql::PathHash> store;
 };
+
+template <typename Locatable>
+struct SwiftLocationExtractor::HasSpecializedImplementation<
+    Locatable,
+    decltype(std::declval<SwiftLocationExtractor>().attachLocationImpl(
+        std::declval<const swift::SourceManager&>(),
+        std::declval<const Locatable*>(),
+        std::declval<TrapLabel<LocatableTag>>()))> : std::true_type {};
 
 }  // namespace codeql

--- a/swift/extractor/print_unextracted/main.cpp
+++ b/swift/extractor/print_unextracted/main.cpp
@@ -13,9 +13,9 @@ using namespace codeql;
 int main() {
   std::map<const char*, std::vector<const char*>> unextracted;
 
-#define CHECK_CLASS(KIND, CLASS, PARENT)                                                          \
-  if constexpr (KIND##Translator::getPolicyFor##CLASS##KIND() == TranslatorPolicy::emitUnknown) { \
-    unextracted[#KIND].push_back(#CLASS #KIND);                                                   \
+#define CHECK_CLASS(KIND, CLASS, PARENT)                                                \
+  if (KIND##Translator::getPolicyFor##CLASS##KIND() == TranslatorPolicy::emitUnknown) { \
+    unextracted[#KIND].push_back(#CLASS #KIND);                                         \
   }
 
 #define DECL(CLASS, PARENT) CHECK_CLASS(Decl, CLASS, PARENT)

--- a/swift/extractor/translators/TranslatorBase.h
+++ b/swift/extractor/translators/TranslatorBase.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <concepts>
-
 #include <swift/AST/ASTVisitor.h>
 #include <swift/AST/TypeVisitor.h>
 
@@ -20,6 +18,45 @@ class TranslatorBase {
       : dispatcher{dispatcher}, logger{"translator/" + std::string(name)} {}
 };
 
+// define by macro metaprogramming member checkers
+// see https://fekir.info/post/detect-member-variables/ for technical details
+#define DEFINE_TRANSLATE_CHECKER(KIND, CLASS, PARENT)                                          \
+  template <typename T, typename = void>                                                       \
+  struct HasTranslate##CLASS##KIND : std::false_type {};                                       \
+                                                                                               \
+  template <typename T>                                                                        \
+  struct HasTranslate##CLASS##KIND<T, decltype((void)std::declval<T>().translate##CLASS##KIND( \
+                                                   std::declval<const swift::CLASS##KIND&>()), \
+                                               void())> : std::true_type {};
+
+DEFINE_TRANSLATE_CHECKER(Decl, , )
+#define DECL(CLASS, PARENT) DEFINE_TRANSLATE_CHECKER(Decl, CLASS, PARENT)
+#define ABSTRACT_DECL(CLASS, PARENT) DEFINE_TRANSLATE_CHECKER(Decl, CLASS, PARENT)
+#include "swift/AST/DeclNodes.def"
+
+DEFINE_TRANSLATE_CHECKER(Stmt, , )
+#define STMT(CLASS, PARENT) DEFINE_TRANSLATE_CHECKER(Stmt, CLASS, PARENT)
+#define ABSTRACT_STMT(CLASS, PARENT) DEFINE_TRANSLATE_CHECKER(Stmt, CLASS, PARENT)
+#include "swift/AST/StmtNodes.def"
+
+DEFINE_TRANSLATE_CHECKER(Expr, , )
+#define EXPR(CLASS, PARENT) DEFINE_TRANSLATE_CHECKER(Expr, CLASS, PARENT)
+#define ABSTRACT_EXPR(CLASS, PARENT) DEFINE_TRANSLATE_CHECKER(Expr, CLASS, PARENT)
+#include "swift/AST/ExprNodes.def"
+
+DEFINE_TRANSLATE_CHECKER(Pattern, , )
+#define PATTERN(CLASS, PARENT) DEFINE_TRANSLATE_CHECKER(Pattern, CLASS, PARENT)
+#include "swift/AST/PatternNodes.def"
+
+DEFINE_TRANSLATE_CHECKER(Type, , )
+#define TYPE(CLASS, PARENT) DEFINE_TRANSLATE_CHECKER(Type, CLASS, PARENT)
+#define ABSTRACT_TYPE(CLASS, PARENT) DEFINE_TRANSLATE_CHECKER(Type, CLASS, PARENT)
+#include "swift/AST/TypeNodes.def"
+
+DEFINE_TRANSLATE_CHECKER(TypeRepr, , )
+#define TYPEREPR(CLASS, PARENT) DEFINE_TRANSLATE_CHECKER(TypeRepr, CLASS, PARENT)
+#define ABSTRACT_TYPEREPR(CLASS, PARENT) DEFINE_TRANSLATE_CHECKER(TypeRepr, CLASS, PARENT)
+#include "swift/AST/TypeReprNodes.def"
 }  // namespace detail
 
 enum class TranslatorPolicy {
@@ -39,15 +76,11 @@ enum class TranslatorPolicy {
 #define DEFINE_VISIT(KIND, CLASS, PARENT)                                            \
  public:                                                                             \
   static constexpr TranslatorPolicy getPolicyFor##CLASS##KIND() {                    \
-    if constexpr (std::same_as<TrapTagOf<swift::CLASS##KIND>, void>) {               \
+    if constexpr (std::is_same_v<TrapTagOf<swift::CLASS##KIND>, void>) {             \
       return TranslatorPolicy::ignore;                                               \
-    } else if constexpr (requires(CrtpSubclass x, swift::CLASS##KIND e) {            \
-                           x.translate##CLASS##KIND(e);                              \
-                         }) {                                                        \
+    } else if constexpr (detail::HasTranslate##CLASS##KIND<CrtpSubclass>::value) {   \
       return TranslatorPolicy::translate;                                            \
-    } else if constexpr (requires(CrtpSubclass x, swift::CLASS##KIND e) {            \
-                           x.translate##PARENT(e);                                   \
-                         }) {                                                        \
+    } else if constexpr (detail::HasTranslate##PARENT<CrtpSubclass>::value) {        \
       return TranslatorPolicy::translateParent;                                      \
     } else {                                                                         \
       return TranslatorPolicy::emitUnknown;                                          \
@@ -59,6 +92,7 @@ enum class TranslatorPolicy {
     constexpr auto policy = getPolicyFor##CLASS##KIND();                             \
     if constexpr (policy == TranslatorPolicy::ignore) {                              \
       LOG_ERROR("Unexpected " #CLASS #KIND);                                         \
+      return;                                                                        \
     } else if constexpr (policy == TranslatorPolicy::translate) {                    \
       dispatcher.emit(static_cast<CrtpSubclass*>(this)->translate##CLASS##KIND(*e)); \
     } else if constexpr (policy == TranslatorPolicy::translateParent) {              \

--- a/swift/extractor/trap/TrapLabel.h
+++ b/swift/extractor/trap/TrapLabel.h
@@ -9,7 +9,6 @@
 #include <binlog/binlog.hpp>
 #include <cmath>
 #include <charconv>
-#include <concepts>
 
 namespace codeql {
 
@@ -83,8 +82,9 @@ class TrapLabel : public UntypedTrapLabel {
   static TrapLabel unsafeCreateFromUntyped(UntypedTrapLabel label) { return TrapLabel{label.id_}; }
 
   template <typename SourceTag>
-  requires std::derived_from<SourceTag, Tag> TrapLabel(const TrapLabel<SourceTag>& other)
-      : UntypedTrapLabel(other) {}
+  TrapLabel(const TrapLabel<SourceTag>& other) : UntypedTrapLabel(other) {
+    static_assert(std::is_base_of_v<Tag, SourceTag>, "wrong label assignment!");
+  }
 };
 
 // wrapper class to allow directly assigning a vector of TrapLabel<A> to a vector of
@@ -96,8 +96,8 @@ struct TrapLabelVectorWrapper {
   std::vector<TrapLabel<TagParam>> data;
 
   template <typename DestinationTag>
-  requires std::derived_from<Tag, DestinationTag>
   operator std::vector<TrapLabel<DestinationTag>>() && {
+    static_assert(std::is_base_of_v<DestinationTag, Tag>, "wrong label assignment!");
     // reinterpret_cast is safe because TrapLabel instances differ only on the type, not the
     // underlying data
     return std::move(reinterpret_cast<std::vector<TrapLabel<DestinationTag>>&>(data));


### PR DESCRIPTION
Reverts github/codeql#13991

Unfortunately, it seems the `<concepts>` library is not available on macOS 11. For the moment it's best to revert this.