### PR TITLE
Java: add sanitizer to command injection query

### DIFF
--- a/java/ql/lib/change-notes/2023-08-21-java-command-injection-sanitizer.md
+++ b/java/ql/lib/change-notes/2023-08-21-java-command-injection-sanitizer.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Added new sanitizer to Java command injection model

--- a/java/ql/lib/semmle/code/java/security/CommandLineQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/CommandLineQuery.qll
@@ -42,6 +42,8 @@ private class DefaultCommandInjectionSanitizer extends CommandInjectionSanitizer
     or
     this.getType() instanceof BoxedType
     or
+    this.getType() instanceof NumberType
+    or
     isSafeCommandArgument(this.asExpr())
   }
 }


### PR DESCRIPTION
Similar to the [sql injection query](https://github.com/github/codeql/blob/main/java/ql/lib/semmle/code/java/security/SqlInjectionQuery.qll#L25), a numeric sanitizer seems to make sense here