### PR TITLE
CPP:Only taint argv indirections

### DIFF
--- a/cpp/ql/lib/change-notes/2023-08-24-no-taint-argv-indirections.md
+++ b/cpp/ql/lib/change-notes/2023-08-24-no-taint-argv-indirections.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Only the 2 level indirection of `argv` (corresponding to `**argv`) is consided for `FlowSource`.

--- a/cpp/ql/lib/semmle/code/cpp/security/FlowSources.qll
+++ b/cpp/ql/lib/semmle/code/cpp/security/FlowSources.qll
@@ -53,7 +53,7 @@ private class ArgvSource extends LocalFlowSource {
     exists(Function main, Parameter argv |
       main.hasGlobalName("main") and
       main.getParameter(1) = argv and
-      this.asParameter(_) = argv
+      this.asParameter(2) = argv
     )
   }
 

--- a/cpp/ql/src/change-notes/2023-08-24-no-taint-argv-indirections.md
+++ b/cpp/ql/src/change-notes/2023-08-24-no-taint-argv-indirections.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Some queries that had repeated results corresponding to different levels of indirection for `argv` now only have a single result.

--- a/cpp/ql/src/experimental/Security/CWE/CWE-078/WordexpTainted.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-078/WordexpTainted.ql
@@ -40,7 +40,7 @@ module WordexpTaintConfig implements DataFlow::ConfigSig {
 
   predicate isSink(DataFlow::Node sink) {
     exists(FunctionCall fc | fc.getTarget() instanceof WordexpFunction |
-      fc.getArgument(0) = sink.asExpr() and
+      fc.getArgument(0) = sink.asIndirectArgument(1) and
       not isCommandSubstitutionDisabled(fc)
     )
   }

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-078/WordexpTainted.expected
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-078/WordexpTainted.expected
@@ -1,16 +1,8 @@
 edges
-| test.cpp:22:27:22:30 | argv | test.cpp:29:13:29:20 | filePath |
-| test.cpp:22:27:22:30 | argv | test.cpp:29:13:29:20 | filePath |
-| test.cpp:22:27:22:30 | argv indirection | test.cpp:29:13:29:20 | filePath |
-| test.cpp:22:27:22:30 | argv indirection | test.cpp:29:13:29:20 | filePath |
+| test.cpp:22:27:22:30 | argv indirection | test.cpp:29:13:29:20 | filePath indirection |
 nodes
-| test.cpp:22:27:22:30 | argv | semmle.label | argv |
 | test.cpp:22:27:22:30 | argv indirection | semmle.label | argv indirection |
-| test.cpp:29:13:29:20 | filePath | semmle.label | filePath |
-| test.cpp:29:13:29:20 | filePath | semmle.label | filePath |
+| test.cpp:29:13:29:20 | filePath indirection | semmle.label | filePath indirection |
 subpaths
 #select
-| test.cpp:29:13:29:20 | filePath | test.cpp:22:27:22:30 | argv | test.cpp:29:13:29:20 | filePath | Using user-supplied data in a `wordexp` command, without disabling command substitution, can make code vulnerable to command injection. |
-| test.cpp:29:13:29:20 | filePath | test.cpp:22:27:22:30 | argv | test.cpp:29:13:29:20 | filePath | Using user-supplied data in a `wordexp` command, without disabling command substitution, can make code vulnerable to command injection. |
-| test.cpp:29:13:29:20 | filePath | test.cpp:22:27:22:30 | argv indirection | test.cpp:29:13:29:20 | filePath | Using user-supplied data in a `wordexp` command, without disabling command substitution, can make code vulnerable to command injection. |
-| test.cpp:29:13:29:20 | filePath | test.cpp:22:27:22:30 | argv indirection | test.cpp:29:13:29:20 | filePath | Using user-supplied data in a `wordexp` command, without disabling command substitution, can make code vulnerable to command injection. |
+| test.cpp:29:13:29:20 | filePath indirection | test.cpp:22:27:22:30 | argv indirection | test.cpp:29:13:29:20 | filePath indirection | Using user-supplied data in a `wordexp` command, without disabling command substitution, can make code vulnerable to command injection. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-022/semmle/tests/TaintedPath.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-022/semmle/tests/TaintedPath.expected
@@ -1,16 +1,10 @@
 edges
-| test.c:8:27:8:30 | argv | test.c:17:11:17:18 | fileName indirection |
-| test.c:8:27:8:30 | argv indirection | test.c:17:11:17:18 | fileName indirection |
 | test.c:8:27:8:30 | argv indirection | test.c:17:11:17:18 | fileName indirection |
 | test.c:8:27:8:30 | argv indirection | test.c:32:11:32:18 | fileName indirection |
-| test.c:8:27:8:30 | argv indirection | test.c:32:11:32:18 | fileName indirection |
-| test.c:8:27:8:30 | argv indirection | test.c:57:10:57:16 | access to array indirection |
 | test.c:8:27:8:30 | argv indirection | test.c:57:10:57:16 | access to array indirection |
 | test.c:37:17:37:24 | scanf output argument | test.c:38:11:38:18 | fileName indirection |
 | test.c:43:17:43:24 | scanf output argument | test.c:44:11:44:18 | fileName indirection |
 nodes
-| test.c:8:27:8:30 | argv | semmle.label | argv |
-| test.c:8:27:8:30 | argv indirection | semmle.label | argv indirection |
 | test.c:8:27:8:30 | argv indirection | semmle.label | argv indirection |
 | test.c:17:11:17:18 | fileName indirection | semmle.label | fileName indirection |
 | test.c:32:11:32:18 | fileName indirection | semmle.label | fileName indirection |
@@ -21,12 +15,8 @@ nodes
 | test.c:57:10:57:16 | access to array indirection | semmle.label | access to array indirection |
 subpaths
 #select
-| test.c:17:11:17:18 | fileName | test.c:8:27:8:30 | argv | test.c:17:11:17:18 | fileName indirection | This argument to a file access function is derived from $@ and then passed to fopen(filename). | test.c:8:27:8:30 | argv | user input (a command-line argument) |
 | test.c:17:11:17:18 | fileName | test.c:8:27:8:30 | argv indirection | test.c:17:11:17:18 | fileName indirection | This argument to a file access function is derived from $@ and then passed to fopen(filename). | test.c:8:27:8:30 | argv indirection | user input (a command-line argument) |
-| test.c:17:11:17:18 | fileName | test.c:8:27:8:30 | argv indirection | test.c:17:11:17:18 | fileName indirection | This argument to a file access function is derived from $@ and then passed to fopen(filename). | test.c:8:27:8:30 | argv indirection | user input (a command-line argument) |
-| test.c:32:11:32:18 | fileName | test.c:8:27:8:30 | argv indirection | test.c:32:11:32:18 | fileName indirection | This argument to a file access function is derived from $@ and then passed to fopen(filename). | test.c:8:27:8:30 | argv indirection | user input (a command-line argument) |
 | test.c:32:11:32:18 | fileName | test.c:8:27:8:30 | argv indirection | test.c:32:11:32:18 | fileName indirection | This argument to a file access function is derived from $@ and then passed to fopen(filename). | test.c:8:27:8:30 | argv indirection | user input (a command-line argument) |
 | test.c:38:11:38:18 | fileName | test.c:37:17:37:24 | scanf output argument | test.c:38:11:38:18 | fileName indirection | This argument to a file access function is derived from $@ and then passed to fopen(filename). | test.c:37:17:37:24 | scanf output argument | user input (value read by scanf) |
 | test.c:44:11:44:18 | fileName | test.c:43:17:43:24 | scanf output argument | test.c:44:11:44:18 | fileName indirection | This argument to a file access function is derived from $@ and then passed to fopen(filename). | test.c:43:17:43:24 | scanf output argument | user input (value read by scanf) |
-| test.c:57:10:57:16 | access to array | test.c:8:27:8:30 | argv indirection | test.c:57:10:57:16 | access to array indirection | This argument to a file access function is derived from $@ and then passed to read(fileName), which calls fopen(filename). | test.c:8:27:8:30 | argv indirection | user input (a command-line argument) |
 | test.c:57:10:57:16 | access to array | test.c:8:27:8:30 | argv indirection | test.c:57:10:57:16 | access to array indirection | This argument to a file access function is derived from $@ and then passed to read(fileName), which calls fopen(filename). | test.c:8:27:8:30 | argv indirection | user input (a command-line argument) |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-078/semmle/ExecTainted/ExecTainted.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-078/semmle/ExecTainted/ExecTainted.expected
@@ -1,6 +1,5 @@
 edges
 | test.cpp:15:27:15:30 | argv indirection | test.cpp:22:45:22:52 | userName indirection |
-| test.cpp:15:27:15:30 | argv indirection | test.cpp:22:45:22:52 | userName indirection |
 | test.cpp:22:13:22:20 | sprintf output argument | test.cpp:23:12:23:19 | command1 indirection |
 | test.cpp:22:45:22:52 | userName indirection | test.cpp:22:13:22:20 | sprintf output argument |
 | test.cpp:47:21:47:26 | call to getenv indirection | test.cpp:50:35:50:43 | envCflags indirection |
@@ -70,7 +69,6 @@ edges
 | test.cpp:220:19:220:26 | filename indirection | test.cpp:220:10:220:16 | strncat output argument |
 | test.cpp:220:19:220:26 | filename indirection | test.cpp:220:19:220:26 | filename indirection |
 nodes
-| test.cpp:15:27:15:30 | argv indirection | semmle.label | argv indirection |
 | test.cpp:15:27:15:30 | argv indirection | semmle.label | argv indirection |
 | test.cpp:22:13:22:20 | sprintf output argument | semmle.label | sprintf output argument |
 | test.cpp:22:45:22:52 | userName indirection | semmle.label | userName indirection |
@@ -153,7 +151,6 @@ subpaths
 | test.cpp:196:26:196:33 | filename indirection | test.cpp:186:47:186:54 | filename indirection | test.cpp:188:11:188:17 | strncat output argument | test.cpp:196:10:196:16 | concat output argument |
 | test.cpp:196:26:196:33 | filename indirection | test.cpp:186:47:186:54 | filename indirection | test.cpp:188:11:188:17 | strncat output argument | test.cpp:196:10:196:16 | concat output argument |
 #select
-| test.cpp:23:12:23:19 | command1 | test.cpp:15:27:15:30 | argv indirection | test.cpp:23:12:23:19 | command1 indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to system(string). | test.cpp:15:27:15:30 | argv indirection | user input (a command-line argument) | test.cpp:22:13:22:20 | sprintf output argument | sprintf output argument |
 | test.cpp:23:12:23:19 | command1 | test.cpp:15:27:15:30 | argv indirection | test.cpp:23:12:23:19 | command1 indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to system(string). | test.cpp:15:27:15:30 | argv indirection | user input (a command-line argument) | test.cpp:22:13:22:20 | sprintf output argument | sprintf output argument |
 | test.cpp:51:10:51:16 | command | test.cpp:47:21:47:26 | call to getenv indirection | test.cpp:51:10:51:16 | command indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to system(string). | test.cpp:47:21:47:26 | call to getenv indirection | user input (an environment variable) | test.cpp:50:11:50:17 | sprintf output argument | sprintf output argument |
 | test.cpp:65:10:65:16 | command | test.cpp:62:9:62:16 | fread output argument | test.cpp:65:10:65:16 | command indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to system(string). | test.cpp:62:9:62:16 | fread output argument | user input (string read by fread) | test.cpp:64:11:64:17 | strncat output argument | strncat output argument |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-089/SqlTainted/SqlTainted.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-089/SqlTainted/SqlTainted.expected
@@ -1,27 +1,12 @@
 edges
-| test.c:14:27:14:30 | argv | test.c:21:18:21:23 | query1 indirection |
 | test.c:14:27:14:30 | argv indirection | test.c:21:18:21:23 | query1 indirection |
-| test.c:14:27:14:30 | argv indirection | test.c:21:18:21:23 | query1 indirection |
-| test.cpp:39:27:39:30 | argv | test.cpp:43:27:43:33 | access to array |
-| test.cpp:39:27:39:30 | argv indirection | test.cpp:43:27:43:33 | access to array |
-| test.cpp:39:27:39:30 | argv indirection | test.cpp:43:27:43:33 | access to array indirection |
 | test.cpp:39:27:39:30 | argv indirection | test.cpp:43:27:43:33 | access to array indirection |
 nodes
-| test.c:14:27:14:30 | argv | semmle.label | argv |
-| test.c:14:27:14:30 | argv indirection | semmle.label | argv indirection |
 | test.c:14:27:14:30 | argv indirection | semmle.label | argv indirection |
 | test.c:21:18:21:23 | query1 indirection | semmle.label | query1 indirection |
-| test.cpp:39:27:39:30 | argv | semmle.label | argv |
 | test.cpp:39:27:39:30 | argv indirection | semmle.label | argv indirection |
-| test.cpp:39:27:39:30 | argv indirection | semmle.label | argv indirection |
-| test.cpp:43:27:43:33 | access to array | semmle.label | access to array |
 | test.cpp:43:27:43:33 | access to array indirection | semmle.label | access to array indirection |
 subpaths
 #select
-| test.c:21:18:21:23 | query1 | test.c:14:27:14:30 | argv | test.c:21:18:21:23 | query1 indirection | This argument to a SQL query function is derived from $@ and then passed to mysql_query(sqlArg). | test.c:14:27:14:30 | argv | user input (a command-line argument) |
 | test.c:21:18:21:23 | query1 | test.c:14:27:14:30 | argv indirection | test.c:21:18:21:23 | query1 indirection | This argument to a SQL query function is derived from $@ and then passed to mysql_query(sqlArg). | test.c:14:27:14:30 | argv indirection | user input (a command-line argument) |
-| test.c:21:18:21:23 | query1 | test.c:14:27:14:30 | argv indirection | test.c:21:18:21:23 | query1 indirection | This argument to a SQL query function is derived from $@ and then passed to mysql_query(sqlArg). | test.c:14:27:14:30 | argv indirection | user input (a command-line argument) |
-| test.cpp:43:27:43:33 | access to array | test.cpp:39:27:39:30 | argv | test.cpp:43:27:43:33 | access to array | This argument to a SQL query function is derived from $@ and then passed to pqxx::work::exec1((unnamed parameter 0)). | test.cpp:39:27:39:30 | argv | user input (a command-line argument) |
-| test.cpp:43:27:43:33 | access to array | test.cpp:39:27:39:30 | argv indirection | test.cpp:43:27:43:33 | access to array | This argument to a SQL query function is derived from $@ and then passed to pqxx::work::exec1((unnamed parameter 0)). | test.cpp:39:27:39:30 | argv indirection | user input (a command-line argument) |
-| test.cpp:43:27:43:33 | access to array | test.cpp:39:27:39:30 | argv indirection | test.cpp:43:27:43:33 | access to array indirection | This argument to a SQL query function is derived from $@ and then passed to pqxx::work::exec1((unnamed parameter 0)). | test.cpp:39:27:39:30 | argv indirection | user input (a command-line argument) |
 | test.cpp:43:27:43:33 | access to array | test.cpp:39:27:39:30 | argv indirection | test.cpp:43:27:43:33 | access to array indirection | This argument to a SQL query function is derived from $@ and then passed to pqxx::work::exec1((unnamed parameter 0)). | test.cpp:39:27:39:30 | argv indirection | user input (a command-line argument) |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-119/semmle/tests/OverflowDestination.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-119/semmle/tests/OverflowDestination.expected
@@ -1,10 +1,6 @@
 edges
 | main.cpp:6:27:6:30 | argv indirection | main.cpp:7:33:7:36 | argv indirection |
-| main.cpp:6:27:6:30 | argv indirection | main.cpp:7:33:7:36 | argv indirection |
 | main.cpp:7:33:7:36 | argv indirection | overflowdestination.cpp:23:45:23:48 | argv indirection |
-| main.cpp:7:33:7:36 | argv indirection | overflowdestination.cpp:23:45:23:48 | argv indirection |
-| overflowdestination.cpp:23:45:23:48 | argv indirection | overflowdestination.cpp:30:17:30:20 | arg1 indirection |
-| overflowdestination.cpp:23:45:23:48 | argv indirection | overflowdestination.cpp:30:17:30:20 | arg1 indirection |
 | overflowdestination.cpp:23:45:23:48 | argv indirection | overflowdestination.cpp:30:17:30:20 | arg1 indirection |
 | overflowdestination.cpp:23:45:23:48 | argv indirection | overflowdestination.cpp:30:17:30:20 | arg1 indirection |
 | overflowdestination.cpp:43:8:43:10 | fgets output argument | overflowdestination.cpp:46:15:46:17 | src indirection |
@@ -24,10 +20,7 @@ edges
 | overflowdestination.cpp:76:30:76:32 | src indirection | overflowdestination.cpp:57:52:57:54 | src indirection |
 nodes
 | main.cpp:6:27:6:30 | argv indirection | semmle.label | argv indirection |
-| main.cpp:6:27:6:30 | argv indirection | semmle.label | argv indirection |
 | main.cpp:7:33:7:36 | argv indirection | semmle.label | argv indirection |
-| main.cpp:7:33:7:36 | argv indirection | semmle.label | argv indirection |
-| overflowdestination.cpp:23:45:23:48 | argv indirection | semmle.label | argv indirection |
 | overflowdestination.cpp:23:45:23:48 | argv indirection | semmle.label | argv indirection |
 | overflowdestination.cpp:30:17:30:20 | arg1 indirection | semmle.label | arg1 indirection |
 | overflowdestination.cpp:30:17:30:20 | arg1 indirection | semmle.label | arg1 indirection |
@@ -49,8 +42,6 @@ subpaths
 | overflowdestination.cpp:75:30:75:32 | src indirection | overflowdestination.cpp:50:52:50:54 | src indirection | overflowdestination.cpp:53:9:53:12 | memcpy output argument | overflowdestination.cpp:75:30:75:32 | overflowdest_test2 output argument |
 | overflowdestination.cpp:75:30:75:32 | src indirection | overflowdestination.cpp:50:52:50:54 | src indirection | overflowdestination.cpp:54:9:54:12 | memcpy output argument | overflowdestination.cpp:75:30:75:32 | overflowdest_test2 output argument |
 #select
-| overflowdestination.cpp:30:2:30:8 | call to strncpy | main.cpp:6:27:6:30 | argv indirection | overflowdestination.cpp:30:17:30:20 | arg1 indirection | To avoid overflow, this operation should be bounded by destination-buffer size, not source-buffer size. |
-| overflowdestination.cpp:30:2:30:8 | call to strncpy | main.cpp:6:27:6:30 | argv indirection | overflowdestination.cpp:30:17:30:20 | arg1 indirection | To avoid overflow, this operation should be bounded by destination-buffer size, not source-buffer size. |
 | overflowdestination.cpp:30:2:30:8 | call to strncpy | main.cpp:6:27:6:30 | argv indirection | overflowdestination.cpp:30:17:30:20 | arg1 indirection | To avoid overflow, this operation should be bounded by destination-buffer size, not source-buffer size. |
 | overflowdestination.cpp:30:2:30:8 | call to strncpy | main.cpp:6:27:6:30 | argv indirection | overflowdestination.cpp:30:17:30:20 | arg1 indirection | To avoid overflow, this operation should be bounded by destination-buffer size, not source-buffer size. |
 | overflowdestination.cpp:46:2:46:7 | call to memcpy | overflowdestination.cpp:43:8:43:10 | fgets output argument | overflowdestination.cpp:46:15:46:17 | src indirection | To avoid overflow, this operation should be bounded by destination-buffer size, not source-buffer size. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-129/semmle/ImproperArrayIndexValidation/ImproperArrayIndexValidation.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-129/semmle/ImproperArrayIndexValidation/ImproperArrayIndexValidation.expected
@@ -1,12 +1,6 @@
 edges
-| test1.c:7:26:7:29 | argv | test1.c:9:9:9:9 | i |
-| test1.c:7:26:7:29 | argv | test1.c:11:9:11:9 | i |
-| test1.c:7:26:7:29 | argv | test1.c:13:9:13:9 | i |
-| test1.c:7:26:7:29 | argv indirection | test1.c:9:9:9:9 | i |
 | test1.c:7:26:7:29 | argv indirection | test1.c:9:9:9:9 | i |
 | test1.c:7:26:7:29 | argv indirection | test1.c:11:9:11:9 | i |
-| test1.c:7:26:7:29 | argv indirection | test1.c:11:9:11:9 | i |
-| test1.c:7:26:7:29 | argv indirection | test1.c:13:9:13:9 | i |
 | test1.c:7:26:7:29 | argv indirection | test1.c:13:9:13:9 | i |
 | test1.c:9:9:9:9 | i | test1.c:16:16:16:16 | i |
 | test1.c:11:9:11:9 | i | test1.c:32:16:32:16 | i |
@@ -15,8 +9,6 @@ edges
 | test1.c:32:16:32:16 | i | test1.c:33:11:33:11 | i |
 | test1.c:48:16:48:16 | i | test1.c:53:15:53:15 | j |
 nodes
-| test1.c:7:26:7:29 | argv | semmle.label | argv |
-| test1.c:7:26:7:29 | argv indirection | semmle.label | argv indirection |
 | test1.c:7:26:7:29 | argv indirection | semmle.label | argv indirection |
 | test1.c:9:9:9:9 | i | semmle.label | i |
 | test1.c:11:9:11:9 | i | semmle.label | i |
@@ -29,12 +21,6 @@ nodes
 | test1.c:53:15:53:15 | j | semmle.label | j |
 subpaths
 #select
-| test1.c:18:16:18:16 | i | test1.c:7:26:7:29 | argv | test1.c:18:16:18:16 | i | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | argv | a command-line argument |
 | test1.c:18:16:18:16 | i | test1.c:7:26:7:29 | argv indirection | test1.c:18:16:18:16 | i | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | argv indirection | a command-line argument |
-| test1.c:18:16:18:16 | i | test1.c:7:26:7:29 | argv indirection | test1.c:18:16:18:16 | i | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | argv indirection | a command-line argument |
-| test1.c:33:11:33:11 | i | test1.c:7:26:7:29 | argv | test1.c:33:11:33:11 | i | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | argv | a command-line argument |
 | test1.c:33:11:33:11 | i | test1.c:7:26:7:29 | argv indirection | test1.c:33:11:33:11 | i | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | argv indirection | a command-line argument |
-| test1.c:33:11:33:11 | i | test1.c:7:26:7:29 | argv indirection | test1.c:33:11:33:11 | i | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | argv indirection | a command-line argument |
-| test1.c:53:15:53:15 | j | test1.c:7:26:7:29 | argv | test1.c:53:15:53:15 | j | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | argv | a command-line argument |
-| test1.c:53:15:53:15 | j | test1.c:7:26:7:29 | argv indirection | test1.c:53:15:53:15 | j | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | argv indirection | a command-line argument |
 | test1.c:53:15:53:15 | j | test1.c:7:26:7:29 | argv indirection | test1.c:53:15:53:15 | j | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | argv indirection | a command-line argument |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/TaintedAllocationSize/TaintedAllocationSize.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/TaintedAllocationSize/TaintedAllocationSize.expected
@@ -1,21 +1,9 @@
 edges
-| test.cpp:39:27:39:30 | argv | test.cpp:43:38:43:44 | tainted |
-| test.cpp:39:27:39:30 | argv | test.cpp:44:38:44:63 | ... * ... |
-| test.cpp:39:27:39:30 | argv | test.cpp:46:38:46:63 | ... + ... |
-| test.cpp:39:27:39:30 | argv | test.cpp:49:32:49:35 | size |
-| test.cpp:39:27:39:30 | argv | test.cpp:50:26:50:29 | size |
-| test.cpp:39:27:39:30 | argv | test.cpp:53:35:53:60 | ... * ... |
-| test.cpp:39:27:39:30 | argv indirection | test.cpp:43:38:43:44 | tainted |
 | test.cpp:39:27:39:30 | argv indirection | test.cpp:43:38:43:44 | tainted |
 | test.cpp:39:27:39:30 | argv indirection | test.cpp:44:38:44:63 | ... * ... |
-| test.cpp:39:27:39:30 | argv indirection | test.cpp:44:38:44:63 | ... * ... |
-| test.cpp:39:27:39:30 | argv indirection | test.cpp:46:38:46:63 | ... + ... |
 | test.cpp:39:27:39:30 | argv indirection | test.cpp:46:38:46:63 | ... + ... |
 | test.cpp:39:27:39:30 | argv indirection | test.cpp:49:32:49:35 | size |
-| test.cpp:39:27:39:30 | argv indirection | test.cpp:49:32:49:35 | size |
 | test.cpp:39:27:39:30 | argv indirection | test.cpp:50:26:50:29 | size |
-| test.cpp:39:27:39:30 | argv indirection | test.cpp:50:26:50:29 | size |
-| test.cpp:39:27:39:30 | argv indirection | test.cpp:53:35:53:60 | ... * ... |
 | test.cpp:39:27:39:30 | argv indirection | test.cpp:53:35:53:60 | ... * ... |
 | test.cpp:124:18:124:23 | call to getenv | test.cpp:128:24:128:41 | ... * ... |
 | test.cpp:124:18:124:31 | call to getenv indirection | test.cpp:128:24:128:41 | ... * ... |
@@ -47,8 +35,6 @@ edges
 | test.cpp:353:18:353:31 | call to getenv indirection | test.cpp:355:35:355:38 | size |
 | test.cpp:353:18:353:31 | call to getenv indirection | test.cpp:356:35:356:38 | size |
 nodes
-| test.cpp:39:27:39:30 | argv | semmle.label | argv |
-| test.cpp:39:27:39:30 | argv indirection | semmle.label | argv indirection |
 | test.cpp:39:27:39:30 | argv indirection | semmle.label | argv indirection |
 | test.cpp:43:38:43:44 | tainted | semmle.label | tainted |
 | test.cpp:44:38:44:63 | ... * ... | semmle.label | ... * ... |
@@ -92,23 +78,11 @@ nodes
 | test.cpp:356:35:356:38 | size | semmle.label | size |
 subpaths
 #select
-| test.cpp:43:31:43:36 | call to malloc | test.cpp:39:27:39:30 | argv | test.cpp:43:38:43:44 | tainted | This allocation size is derived from $@ and might overflow. | test.cpp:39:27:39:30 | argv | user input (a command-line argument) |
 | test.cpp:43:31:43:36 | call to malloc | test.cpp:39:27:39:30 | argv indirection | test.cpp:43:38:43:44 | tainted | This allocation size is derived from $@ and might overflow. | test.cpp:39:27:39:30 | argv indirection | user input (a command-line argument) |
-| test.cpp:43:31:43:36 | call to malloc | test.cpp:39:27:39:30 | argv indirection | test.cpp:43:38:43:44 | tainted | This allocation size is derived from $@ and might overflow. | test.cpp:39:27:39:30 | argv indirection | user input (a command-line argument) |
-| test.cpp:44:31:44:36 | call to malloc | test.cpp:39:27:39:30 | argv | test.cpp:44:38:44:63 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:39:27:39:30 | argv | user input (a command-line argument) |
 | test.cpp:44:31:44:36 | call to malloc | test.cpp:39:27:39:30 | argv indirection | test.cpp:44:38:44:63 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:39:27:39:30 | argv indirection | user input (a command-line argument) |
-| test.cpp:44:31:44:36 | call to malloc | test.cpp:39:27:39:30 | argv indirection | test.cpp:44:38:44:63 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:39:27:39:30 | argv indirection | user input (a command-line argument) |
-| test.cpp:46:31:46:36 | call to malloc | test.cpp:39:27:39:30 | argv | test.cpp:46:38:46:63 | ... + ... | This allocation size is derived from $@ and might overflow. | test.cpp:39:27:39:30 | argv | user input (a command-line argument) |
 | test.cpp:46:31:46:36 | call to malloc | test.cpp:39:27:39:30 | argv indirection | test.cpp:46:38:46:63 | ... + ... | This allocation size is derived from $@ and might overflow. | test.cpp:39:27:39:30 | argv indirection | user input (a command-line argument) |
-| test.cpp:46:31:46:36 | call to malloc | test.cpp:39:27:39:30 | argv indirection | test.cpp:46:38:46:63 | ... + ... | This allocation size is derived from $@ and might overflow. | test.cpp:39:27:39:30 | argv indirection | user input (a command-line argument) |
-| test.cpp:49:25:49:30 | call to malloc | test.cpp:39:27:39:30 | argv | test.cpp:49:32:49:35 | size | This allocation size is derived from $@ and might overflow. | test.cpp:39:27:39:30 | argv | user input (a command-line argument) |
 | test.cpp:49:25:49:30 | call to malloc | test.cpp:39:27:39:30 | argv indirection | test.cpp:49:32:49:35 | size | This allocation size is derived from $@ and might overflow. | test.cpp:39:27:39:30 | argv indirection | user input (a command-line argument) |
-| test.cpp:49:25:49:30 | call to malloc | test.cpp:39:27:39:30 | argv indirection | test.cpp:49:32:49:35 | size | This allocation size is derived from $@ and might overflow. | test.cpp:39:27:39:30 | argv indirection | user input (a command-line argument) |
-| test.cpp:50:17:50:30 | new[] | test.cpp:39:27:39:30 | argv | test.cpp:50:26:50:29 | size | This allocation size is derived from $@ and might overflow. | test.cpp:39:27:39:30 | argv | user input (a command-line argument) |
 | test.cpp:50:17:50:30 | new[] | test.cpp:39:27:39:30 | argv indirection | test.cpp:50:26:50:29 | size | This allocation size is derived from $@ and might overflow. | test.cpp:39:27:39:30 | argv indirection | user input (a command-line argument) |
-| test.cpp:50:17:50:30 | new[] | test.cpp:39:27:39:30 | argv indirection | test.cpp:50:26:50:29 | size | This allocation size is derived from $@ and might overflow. | test.cpp:39:27:39:30 | argv indirection | user input (a command-line argument) |
-| test.cpp:53:21:53:27 | call to realloc | test.cpp:39:27:39:30 | argv | test.cpp:53:35:53:60 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:39:27:39:30 | argv | user input (a command-line argument) |
-| test.cpp:53:21:53:27 | call to realloc | test.cpp:39:27:39:30 | argv indirection | test.cpp:53:35:53:60 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:39:27:39:30 | argv indirection | user input (a command-line argument) |
 | test.cpp:53:21:53:27 | call to realloc | test.cpp:39:27:39:30 | argv indirection | test.cpp:53:35:53:60 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:39:27:39:30 | argv indirection | user input (a command-line argument) |
 | test.cpp:128:17:128:22 | call to malloc | test.cpp:124:18:124:23 | call to getenv | test.cpp:128:24:128:41 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:124:18:124:23 | call to getenv | user input (an environment variable) |
 | test.cpp:128:17:128:22 | call to malloc | test.cpp:124:18:124:31 | call to getenv indirection | test.cpp:128:24:128:41 | ... * ... | This allocation size is derived from $@ and might overflow. | test.cpp:124:18:124:31 | call to getenv indirection | user input (an environment variable) |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextBufferWrite.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextBufferWrite.expected
@@ -1,18 +1,13 @@
 edges
 | test.cpp:53:27:53:30 | argv indirection | test.cpp:58:25:58:29 | input indirection |
 | test.cpp:53:27:53:30 | argv indirection | test.cpp:58:25:58:29 | input indirection |
-| test.cpp:53:27:53:30 | argv indirection | test.cpp:58:25:58:29 | input indirection |
-| test.cpp:53:27:53:30 | argv indirection | test.cpp:58:25:58:29 | input indirection |
 nodes
 | test2.cpp:110:3:110:6 | call to gets indirection | semmle.label | call to gets indirection |
-| test.cpp:53:27:53:30 | argv indirection | semmle.label | argv indirection |
 | test.cpp:53:27:53:30 | argv indirection | semmle.label | argv indirection |
 | test.cpp:58:25:58:29 | input indirection | semmle.label | input indirection |
 | test.cpp:58:25:58:29 | input indirection | semmle.label | input indirection |
 subpaths
 #select
 | test2.cpp:110:3:110:6 | call to gets | test2.cpp:110:3:110:6 | call to gets indirection | test2.cpp:110:3:110:6 | call to gets indirection | This write into buffer 'password' may contain unencrypted data from $@. | test2.cpp:110:3:110:6 | call to gets indirection | user input (string read by gets) |
-| test.cpp:58:3:58:9 | call to sprintf | test.cpp:53:27:53:30 | argv indirection | test.cpp:58:25:58:29 | input indirection | This write into buffer 'passwd' may contain unencrypted data from $@. | test.cpp:53:27:53:30 | argv indirection | user input (a command-line argument) |
-| test.cpp:58:3:58:9 | call to sprintf | test.cpp:53:27:53:30 | argv indirection | test.cpp:58:25:58:29 | input indirection | This write into buffer 'passwd' may contain unencrypted data from $@. | test.cpp:53:27:53:30 | argv indirection | user input (a command-line argument) |
 | test.cpp:58:3:58:9 | call to sprintf | test.cpp:53:27:53:30 | argv indirection | test.cpp:58:25:58:29 | input indirection | This write into buffer 'passwd' may contain unencrypted data from $@. | test.cpp:53:27:53:30 | argv indirection | user input (a command-line argument) |
 | test.cpp:58:3:58:9 | call to sprintf | test.cpp:53:27:53:30 | argv indirection | test.cpp:58:25:58:29 | input indirection | This write into buffer 'passwd' may contain unencrypted data from $@. | test.cpp:53:27:53:30 | argv indirection | user input (a command-line argument) |


### PR DESCRIPTION
Rather than considering all indirections of `argv` as tainted,  this only considers the actual arguments to be tainted. This reduces duplicate results where we had a source for each level of indirection.

There are lots of changes to the numbers of results but not changes to which databases have results. I tested some of the largest changes to see that the set of alert locations is identical and it was (but I can't think of an easy way to test on a larger scale).

I had to fix `cpp/wordexp-injection` injection as it reported if the argument was tainted rather than an indirection of it so it stopped reporting any results. 