### PR TITLE
C#: Fix lazy evaluation of not yet downloaded packages

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependencyManager.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependencyManager.cs
@@ -60,7 +60,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
 
             packageDirectory = new TemporaryDirectory(ComputeTempDirectory(sourceDir.FullName));
 
-            this.fileContent = new FileContent(packageDirectory, progressMonitor, () => GetFiles("*.*"));
+            this.fileContent = new FileContent(progressMonitor, () => GetFiles("*.*"));
             this.allSources = GetFiles("*.cs").ToList();
             var allProjects = GetFiles("*.csproj");
             var solutions = options.SolutionFile is not null
@@ -388,7 +388,11 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
                 nugetConfig = nugetConfigs.FirstOrDefault();
             }
 
-            foreach (var package in fileContent.NotYetDownloadedPackages)
+            var alreadyDownloadedPackages = Directory.GetDirectories(packageDirectory.DirInfo.FullName)
+                .Select(d => Path.GetFileName(d)
+                .ToLowerInvariant());
+            var notYetDownloadedPackages = fileContent.AllPackages.Except(alreadyDownloadedPackages);
+            foreach (var package in notYetDownloadedPackages)
             {
                 progressMonitor.NugetInstall(package);
                 using var tempDir = new TemporaryDirectory(ComputeTempDirectory(package));

--- a/csharp/extractor/Semmle.Extraction.Tests/FileContent.cs
+++ b/csharp/extractor/Semmle.Extraction.Tests/FileContent.cs
@@ -1,5 +1,6 @@
 using Xunit;
 using System.Collections.Generic;
+using System.Linq;
 using Semmle.Util.Logging;
 using Semmle.Extraction.CSharp.DependencyFetching;
 
@@ -62,7 +63,7 @@ namespace Semmle.Extraction.Tests
 
             // Verify
             Assert.False(useAspNetDlls);
-            Assert.Equal(3, notYetDownloadedPackages.Count);
+            Assert.Equal(3, notYetDownloadedPackages.Count());
             Assert.Contains("DotNetAnalyzers.DocumentationAnalyzers".ToLowerInvariant(), notYetDownloadedPackages);
             Assert.Contains("Microsoft.CodeAnalysis.NetAnalyzers".ToLowerInvariant(), notYetDownloadedPackages);
             Assert.Contains("StyleCop.Analyzers".ToLowerInvariant(), notYetDownloadedPackages);
@@ -87,7 +88,7 @@ namespace Semmle.Extraction.Tests
 
             // Verify
             Assert.True(useAspNetDlls);
-            Assert.Equal(2, notYetDownloadedPackages.Count);
+            Assert.Equal(2, notYetDownloadedPackages.Count());
             Assert.Contains("Microsoft.CodeAnalysis.NetAnalyzers".ToLowerInvariant(), notYetDownloadedPackages);
             Assert.Contains("StyleCop.Analyzers".ToLowerInvariant(), notYetDownloadedPackages);
         }

--- a/csharp/extractor/Semmle.Extraction.Tests/FileContent.cs
+++ b/csharp/extractor/Semmle.Extraction.Tests/FileContent.cs
@@ -34,8 +34,7 @@ namespace Semmle.Extraction.Tests
 
     internal class TestFileContent : FileContent
     {
-        public TestFileContent(List<string> lines) : base(() => new HashSet<string>(),
-            new ProgressMonitor(new LoggerStub()),
+        public TestFileContent(List<string> lines) : base(new ProgressMonitor(new LoggerStub()),
             () => new List<string>() { "test1.cs" },
             new UnsafeFileReaderStub(lines))
         { }
@@ -58,15 +57,15 @@ namespace Semmle.Extraction.Tests
             var fileContent = new TestFileContent(lines);
 
             // Execute
-            var notYetDownloadedPackages = fileContent.NotYetDownloadedPackages;
+            var allPackages = fileContent.AllPackages;
             var useAspNetDlls = fileContent.UseAspNetDlls;
 
             // Verify
             Assert.False(useAspNetDlls);
-            Assert.Equal(3, notYetDownloadedPackages.Count());
-            Assert.Contains("DotNetAnalyzers.DocumentationAnalyzers".ToLowerInvariant(), notYetDownloadedPackages);
-            Assert.Contains("Microsoft.CodeAnalysis.NetAnalyzers".ToLowerInvariant(), notYetDownloadedPackages);
-            Assert.Contains("StyleCop.Analyzers".ToLowerInvariant(), notYetDownloadedPackages);
+            Assert.Equal(3, allPackages.Count);
+            Assert.Contains("DotNetAnalyzers.DocumentationAnalyzers".ToLowerInvariant(), allPackages);
+            Assert.Contains("Microsoft.CodeAnalysis.NetAnalyzers".ToLowerInvariant(), allPackages);
+            Assert.Contains("StyleCop.Analyzers".ToLowerInvariant(), allPackages);
         }
 
         [Fact]
@@ -84,13 +83,13 @@ namespace Semmle.Extraction.Tests
 
             // Execute
             var useAspNetDlls = fileContent.UseAspNetDlls;
-            var notYetDownloadedPackages = fileContent.NotYetDownloadedPackages;
+            var allPackages = fileContent.AllPackages;
 
             // Verify
             Assert.True(useAspNetDlls);
-            Assert.Equal(2, notYetDownloadedPackages.Count());
-            Assert.Contains("Microsoft.CodeAnalysis.NetAnalyzers".ToLowerInvariant(), notYetDownloadedPackages);
-            Assert.Contains("StyleCop.Analyzers".ToLowerInvariant(), notYetDownloadedPackages);
+            Assert.Equal(2, allPackages.Count);
+            Assert.Contains("Microsoft.CodeAnalysis.NetAnalyzers".ToLowerInvariant(), allPackages);
+            Assert.Contains("StyleCop.Analyzers".ToLowerInvariant(), allPackages);
         }
     }
 }


### PR DESCRIPTION
The computation of `NotYetDownloadedPackages` needs to be delayed after we have tried to download packages through sln and csproj files. This PR makes `NotYetDownloadedPackages` lazy.