### PR TITLE
Data flow: Use call contexts in stage 3

### DIFF
--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -2375,7 +2375,8 @@ module MakeImpl<InputSig Lang> {
 
       ApOption apSome(Ap ap) { result = TApproxAccessPathFrontSome(ap) }
 
-      import BooleanCallContext
+      import Level1CallContext
+      import NoLocalCallContext
 
       predicate localStep(
         NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,


### PR DESCRIPTION
Needed to get acceptable performance when doing flow through captured variables in Ruby (https://github.com/github/codeql/pull/11725).