### PR TITLE
ReDoS: limit concretize to strings of at most length 100

### DIFF
--- a/shared/regex/codeql/regex/nfa/NfaUtils.qll
+++ b/shared/regex/codeql/regex/nfa/NfaUtils.qll
@@ -862,12 +862,9 @@ module Make<RegexTreeViewSig TreeImpl> {
     RegExpTerm repr;
 
     State() {
-      (
-        this = Match(repr, _) or
-        this = Accept(repr) or
-        this = AcceptAnySuffix(repr)
-      ) and
-      repr instanceof RelevantRegExpTerm
+      this = Match(repr, _) or
+      this = Accept(repr) or
+      this = AcceptAnySuffix(repr)
     }
 
     /**

--- a/shared/regex/codeql/regex/nfa/NfaUtils.qll
+++ b/shared/regex/codeql/regex/nfa/NfaUtils.qll
@@ -862,9 +862,12 @@ module Make<RegexTreeViewSig TreeImpl> {
     RegExpTerm repr;
 
     State() {
-      this = Match(repr, _) or
-      this = Accept(repr) or
-      this = AcceptAnySuffix(repr)
+      (
+        this = Match(repr, _) or
+        this = Accept(repr) or
+        this = AcceptAnySuffix(repr)
+      ) and
+      repr instanceof RelevantRegExpTerm
     }
 
     /**
@@ -1457,7 +1460,8 @@ module Make<RegexTreeViewSig TreeImpl> {
         result = getChar(ancestor) and
         ancestor = getAnAncestor(n) and
         i = nodeDepth(ancestor)
-      )
+      ) and
+      nodeDepth(n) < 100
     }
 
     /** Gets a string corresponding to `node`. */


### PR DESCRIPTION
Fixes a performance problem in a Python project, and seems to have no change in results🤞

Evaluations: [Python](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/PR-14027-2-python/reports), [Ruby](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/PR-14027-3-ruby/reports), [Java](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/PR-14027-0-java/reports), [JavaScript](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/PR-14027-1-javascript/reports). 
Only a single lost result in the Ruby evaluation, but I think we can live with that. 
Otherwise seemingly no change, just some DCA noise.