### PR TITLE
C#: Improve GetFiles in the Dependency Manager.

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/FileContent.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/FileContent.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text.RegularExpressions;
 using Semmle.Util;
 
@@ -18,7 +17,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
     {
         private readonly ProgressMonitor progressMonitor;
         private readonly IUnsafeFileReader unsafeFileReader;
-        private readonly Func<IEnumerable<string>> getFiles;
+        private readonly IEnumerable<string> files;
         private readonly HashSet<string> allPackages = new HashSet<string>();
         private readonly Initializer initialize;
 
@@ -50,17 +49,17 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         }
 
         internal FileContent(ProgressMonitor progressMonitor,
-            Func<IEnumerable<string>> getFiles,
+            IEnumerable<string> files,
             IUnsafeFileReader unsafeFileReader)
         {
             this.progressMonitor = progressMonitor;
-            this.getFiles = getFiles;
+            this.files = files;
             this.unsafeFileReader = unsafeFileReader;
             this.initialize = new Initializer(DoInitialize);
         }
 
 
-        public FileContent(ProgressMonitor progressMonitor, Func<IEnumerable<string>> getFiles) : this(progressMonitor, getFiles, new UnsafeFileReader())
+        public FileContent(ProgressMonitor progressMonitor, IEnumerable<string> files) : this(progressMonitor, files, new UnsafeFileReader())
         { }
 
         private static string GetGroup(ReadOnlySpan<char> input, ValueMatch valueMatch, string groupPrefix)
@@ -95,7 +94,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
 
         private void DoInitialize()
         {
-            foreach (var file in getFiles())
+            foreach (var file in files)
             {
                 try
                 {

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/FileInfoExtensions.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/FileInfoExtensions.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Semmle.Extraction.CSharp.DependencyFetching
+{
+    public static class FileInfoExtensions
+    {
+        private static IEnumerable<string> SelectFilesAux(this IEnumerable<FileInfo> files, Predicate<FileInfo> p) =>
+            files.Where(f => p(f)).Select(fi => fi.FullName);
+
+        public static IEnumerable<FileInfo> SelectRootFiles(this IEnumerable<FileInfo> files, DirectoryInfo dir) =>
+            files.Where(file => file.DirectoryName == dir.FullName);
+
+        internal static IEnumerable<FileInfo> SelectSmallFiles(this IEnumerable<FileInfo> files, ProgressMonitor progressMonitor)
+        {
+            const int oneMb = 1_048_576;
+            return files.Where(file =>
+            {
+                if (file.Length > oneMb)
+                {
+                    progressMonitor.LogDebug($"Skipping {file.FullName} because it is bigger than 1MB.");
+                    return false;
+                }
+                return true;
+            });
+        }
+
+        public static IEnumerable<string> SelectFileNamesByExtension(this IEnumerable<FileInfo> files, params string[] extensions) =>
+            files.SelectFilesAux(fi => extensions.Contains(fi.Extension));
+
+        public static IEnumerable<string> SelectFileNamesByName(this IEnumerable<FileInfo> files, params string[] names) =>
+            files.SelectFilesAux(fi => names.Any(name => string.Compare(name, fi.Name, true) == 0));
+
+        public static IEnumerable<string> SelectFileNames(this IEnumerable<FileInfo> files) =>
+            files.SelectFilesAux(_ => true);
+    }
+}

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/ProgressMonitor.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/ProgressMonitor.cs
@@ -18,7 +18,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         public void LogInfo(string message) =>
             logger.Log(Severity.Info, message);
 
-        private void LogDebug(string message) =>
+        public void LogDebug(string message) =>
             logger.Log(Severity.Debug, message);
 
         private void LogError(string message) =>

--- a/csharp/extractor/Semmle.Extraction.Tests/FileContent.cs
+++ b/csharp/extractor/Semmle.Extraction.Tests/FileContent.cs
@@ -35,7 +35,7 @@ namespace Semmle.Extraction.Tests
     internal class TestFileContent : FileContent
     {
         public TestFileContent(List<string> lines) : base(new ProgressMonitor(new LoggerStub()),
-            () => new List<string>() { "test1.cs" },
+            new List<string>() { "test1.cs" },
             new UnsafeFileReaderStub(lines))
         { }
     }


### PR DESCRIPTION
In this PR we restrict the files that is scanned for packages references and ASP.NET framework dependency to files smaller than 1 MB. Furthermore, we fetch the source dir file info fewer times.
On my machine this had a positive performance impact, especially when source directory contains compressed files and large log files.