### PR TITLE
Ruby: Fix bug in excon model

### DIFF
--- a/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Excon.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Excon.qll
@@ -64,10 +64,8 @@ class ExconHttpRequest extends Http::Client::Request::Range, DataFlow::CallNode 
 
   /** Gets the value that controls certificate validation, if any. */
   DataFlow::Node getCertificateValidationControllingValue() {
-    exists(DataFlow::CallNode newCall | newCall = connectionNode.getAValueReachableFromSource() |
-      // Check for `ssl_verify_peer: false`
-      result = newCall.getKeywordArgumentIncludeHashArgument("ssl_verify_peer")
-    )
+    result =
+      connectionUse.(DataFlow::CallNode).getKeywordArgumentIncludeHashArgument("ssl_verify_peer")
   }
 
   cached

--- a/ruby/ql/test/query-tests/security/cwe-295/Excon.rb
+++ b/ruby/ql/test/query-tests/security/cwe-295/Excon.rb
@@ -47,3 +47,22 @@ def method8
   Excon.defaults[:ssl_verify_peer] = false
   Excon.new("http://example.com/", ssl_verify_peer: true)
 end
+
+# Regression test for excon
+
+class Excon
+  def self.new(params)
+    Excon::Connection.new(params)
+  end
+end
+
+def method9
+  # GOOD: connection is not used
+  Excon.new("foo", ssl_verify_peer: false)
+end
+
+def method10
+  # GOOD
+  connection = Excon.new("foo")
+  connection.get("bar")
+end


### PR DESCRIPTION
If a codebase included a definition for `Excon.new`, we matched connection nodes to unrelated request nodes.