### PR TITLE
Variable capture: synchronize with aliases in nested scopes

### DIFF
--- a/java/ql/test/library-tests/dataflow/capture/B.java
+++ b/java/ql/test/library-tests/dataflow/capture/B.java
@@ -210,7 +210,7 @@ public class B {
       r1.run();
     };
     r2.run();
-    sink(out.get(0)); // $ MISSING: hasValueFlow=double.capture.out
+    sink(out.get(0)); // $ hasValueFlow=double.capture.out
   }
 
   void testEnhancedForStmtCapture() {

--- a/shared/dataflow/codeql/dataflow/VariableCapture.qll
+++ b/shared/dataflow/codeql/dataflow/VariableCapture.qll
@@ -583,7 +583,7 @@ module Flow<InputSig Input> implements OutputSig<Input> {
 
   /**
    * Holds if `access` is a reference to `ce` evaluated in the `i`th node of `bb`.
-   * The reference is restricted to be in the same callable as `ce` as a
+   * The reference is restricted to be nested within the same callable as `ce` as a
    * precaution, even though this is expected to hold for all the given aliased
    * accesses.
    */


### PR DESCRIPTION
When a variable refers to a closure, we emulate what would happen if that closure had been inlined at that point.

```
var x
fun one() {
  use x;
}
fun two() {
  one() // if 'one' was to be inlined here, then 'two' would also capture 'x'
}
```
