### PR TITLE
C++: Omit assign case from `cpp/non-constant-format`

### DIFF
--- a/cpp/ql/src/Likely Bugs/Format/NonConstantFormat.ql
+++ b/cpp/ql/src/Likely Bugs/Format/NonConstantFormat.ql
@@ -105,8 +105,6 @@ predicate isNonConst(DataFlow::Node node, boolean isIndirect) {
     or
     e instanceof NewArrayExpr
     or
-    e instanceof AssignExpr
-    or
     exists(Variable v | v = e.(VariableAccess).getTarget() |
       v.getType().(ArrayType).getBaseType() instanceof CharType and
       exists(AssignExpr ae |

--- a/cpp/ql/src/change-notes/2023-08-24-remove-non-constant-assign-sources.md
+++ b/cpp/ql/src/change-notes/2023-08-24-remove-non-constant-assign-sources.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The `cpp/non-constant-format` query no longer considers an assignment on the right-hand side of another assignment to be a source of non-constant format strings.

--- a/cpp/ql/src/change-notes/2023-08-24-remove-non-constant-assign-sources.md
+++ b/cpp/ql/src/change-notes/2023-08-24-remove-non-constant-assign-sources.md
@@ -1,4 +1,4 @@
 ---
 category: minorAnalysis
 ---
-* The `cpp/non-constant-format` query no longer considers an assignment on the right-hand side of another assignment to be a source of non-constant format strings.
+* The `cpp/non-constant-format` query no longer considers an assignment on the right-hand side of another assignment to be a source of non-constant format strings. As a result, the query may now produce fewer results.


### PR DESCRIPTION
Running the following on ~1000~ 996 MRVA projects gave 1 result:
```ql
from FormattingFunctionCall call, Expr formatString
where
  call.getArgument(call.getFormatParameterIndex()) = formatString and
  not exists(DataFlow::Node sink |
    B::NonConstFlow::flowTo(sink) and
    B::isSinkImpl(sink, formatString)
  )
  and
  exists(DataFlow::Node sink |
    A::NonConstFlow::flowTo(sink) and
    A::isSinkImpl(sink, formatString)
  )
select formatString,
  "The format string argument to " + call.getTarget().getName() +
    " should be constant to prevent security issues and other potential errors."
```
Where both A and B are modules that both contain all the non-constant format code, except that B omits the  lines also omitted in this PR. The one result comes from [here](https://github.com/cyberbotics/webots/blob/8aba6eaae76989facf3442305c8089d3cc366bcf/src/ode/ode/src/collision_trimesh_opcode.cpp#L62C27-L62C29) with the source being the assignment in the `if` one line above it. However, this is an FP as the (virtual) function only ever returns constant strings without any formatting directives.

DCA shows one missing result on Nelson, but it seems that one is not being flagged up for the reason it should be:
```cpp
tostring(register char *s, int n)
...
{
    ...
    sf = str_fmt;
    ... [ omitted code includes stores to elements of sf ]
    for(s = s0; s < se; s++)
    {
        t = *(unsigned char *)s;
        sprintf(s1, sf[t], t);
        s1 += strlen(s1);
    }
   ...
}
```
The query (after modification) highlights two sources:
* https://github.com/Nelson-numerical-software/nelson/blob/3479d3b1b3a8a7fa5e4dc246546b967bdbc8631a/modules/f2c/src/c/f2c/sysdep.c#L359
* https://github.com/Nelson-numerical-software/nelson/blob/3479d3b1b3a8a7fa5e4dc246546b967bdbc8631a/modules/f2c/src/c/f2c/sysdep.c#L414

I agree that this is a TF. However, the reason it's being flagged up is silly, i.e., because an assignment occurs on the right hand side of the the assignment to the element of `str_fmt`. It seems that the query should actually try to detect whether mutable arrays are used as format strings instead of relying on an accidental occurring assignment on the right-hand side.