### PR TITLE
CPP: Add parent class for delete and delete[]

### DIFF
--- a/cpp/ql/lib/change-notes/2023-08-25-delete-or-delete-array.md
+++ b/cpp/ql/lib/change-notes/2023-08-25-delete-or-delete-array.md
@@ -1,0 +1,4 @@
+---
+category: feature
+---
+* Added `DeleteOrDeleteArrayExpr` as a super type of `DeleteExpr` and `DeleteArrayExpr`

--- a/cpp/ql/lib/change-notes/2023-08-25-getAllocatorCall-deprecated.md
+++ b/cpp/ql/lib/change-notes/2023-08-25-getAllocatorCall-deprecated.md
@@ -1,0 +1,4 @@
+---
+category: deprecated
+---
+* `getAllocatorCall` on `DeleteExpr` and `DeleteArrayExpr` has been deprecated. `getDeallocatorCall` should be used instead.

--- a/cpp/ql/lib/semmle/code/cpp/PrintAST.qll
+++ b/cpp/ql/lib/semmle/code/cpp/PrintAST.qll
@@ -826,17 +826,11 @@ private predicate namedExprChildPredicates(Expr expr, Element ele, string pred) 
     or
     expr.(Conversion).getExpr() = ele and pred = "getExpr()"
     or
-    expr.(DeleteArrayExpr).getAllocatorCall() = ele and pred = "getAllocatorCall()"
+    expr.(DeleteOrDeleteArrayExpr).getAllocatorCall() = ele and pred = "getAllocatorCall()"
     or
-    expr.(DeleteArrayExpr).getDestructorCall() = ele and pred = "getDestructorCall()"
+    expr.(DeleteOrDeleteArrayExpr).getDestructorCall() = ele and pred = "getDestructorCall()"
     or
-    expr.(DeleteArrayExpr).getExpr() = ele and pred = "getExpr()"
-    or
-    expr.(DeleteExpr).getAllocatorCall() = ele and pred = "getAllocatorCall()"
-    or
-    expr.(DeleteExpr).getDestructorCall() = ele and pred = "getDestructorCall()"
-    or
-    expr.(DeleteExpr).getExpr() = ele and pred = "getExpr()"
+    expr.(DeleteOrDeleteArrayExpr).getExpr() = ele and pred = "getExpr()"
     or
     expr.(DestructorFieldDestruction).getExpr() = ele and pred = "getExpr()"
     or

--- a/cpp/ql/lib/semmle/code/cpp/PrintAST.qll
+++ b/cpp/ql/lib/semmle/code/cpp/PrintAST.qll
@@ -826,7 +826,7 @@ private predicate namedExprChildPredicates(Expr expr, Element ele, string pred) 
     or
     expr.(Conversion).getExpr() = ele and pred = "getExpr()"
     or
-    expr.(DeleteOrDeleteArrayExpr).getAllocatorCall() = ele and pred = "getAllocatorCall()"
+    expr.(DeleteOrDeleteArrayExpr).getDeallocatorCall() = ele and pred = "getDeallocatorCall()"
     or
     expr.(DeleteOrDeleteArrayExpr).getDestructorCall() = ele and pred = "getDestructorCall()"
     or

--- a/cpp/ql/lib/semmle/code/cpp/controlflow/internal/CFG.qll
+++ b/cpp/ql/lib/semmle/code/cpp/controlflow/internal/CFG.qll
@@ -332,16 +332,7 @@ private Node getControlOrderChildSparse(Node n, int i) {
   n = any(ConditionDeclExpr cd | i = 0 and result = cd.getInitializingExpr())
   or
   n =
-    any(DeleteExpr del |
-      i = 0 and result = del.getExpr()
-      or
-      i = 1 and result = del.getDestructorCall()
-      or
-      i = 2 and result = del.getDeallocatorCall()
-    )
-  or
-  n =
-    any(DeleteArrayExpr del |
+    any(DeleteOrDeleteArrayExpr del |
       i = 0 and result = del.getExpr()
       or
       i = 1 and result = del.getDestructorCall()

--- a/cpp/ql/lib/semmle/code/cpp/controlflow/internal/CFG.qll
+++ b/cpp/ql/lib/semmle/code/cpp/controlflow/internal/CFG.qll
@@ -337,7 +337,7 @@ private Node getControlOrderChildSparse(Node n, int i) {
       or
       i = 1 and result = del.getDestructorCall()
       or
-      i = 2 and result = del.getAllocatorCall()
+      i = 2 and result = del.getDeallocatorCall()
     )
   or
   n =
@@ -346,7 +346,7 @@ private Node getControlOrderChildSparse(Node n, int i) {
       or
       i = 1 and result = del.getDestructorCall()
       or
-      i = 2 and result = del.getAllocatorCall()
+      i = 2 and result = del.getDeallocatorCall()
     )
   or
   n =

--- a/cpp/ql/lib/semmle/code/cpp/exprs/Expr.qll
+++ b/cpp/ql/lib/semmle/code/cpp/exprs/Expr.qll
@@ -949,7 +949,7 @@ class DeleteOrDeleteArrayExpr extends Expr, TDeleteOrDeleteArrayExpr {
   DestructorCall getDestructorCall() { result = this.getChild(1) }
 
   /**
-   * Gets the destructor to be called to destroy the object/array, if any.
+   * Gets the destructor to be called to destroy the object or array, if any.
    */
   Destructor getDestructor() { result = this.getDestructorCall().getTarget() }
 
@@ -997,10 +997,10 @@ class DeleteOrDeleteArrayExpr extends Expr, TDeleteOrDeleteArrayExpr {
   }
 
   /**
-   * Gets the object/array being deleted.
+   * Gets the object or array being deleted.
    */
   Expr getExpr() {
-    // If there is a destuctor call, the object being deleted is the qualifier
+    // If there is a destructor call, the object being deleted is the qualifier
     // otherwise it is the third child.
     result = this.getChild(3) or result = this.getDestructorCall().getQualifier()
   }

--- a/cpp/ql/lib/semmle/code/cpp/exprs/Expr.qll
+++ b/cpp/ql/lib/semmle/code/cpp/exprs/Expr.qll
@@ -949,13 +949,13 @@ class DeleteOrDeleteArrayExpr extends Expr, TDeleteOrDeleteArrayExpr {
   DestructorCall getDestructorCall() { result = this.getChild(1) }
 
   /**
-   * Gets the destructor to be called to destroy the object(s), if any.
+   * Gets the destructor to be called to destroy the object/array, if any.
    */
   Destructor getDestructor() { result = this.getDestructorCall().getTarget() }
 
   /**
-   * Gets the `operator delete` that deallocates storage. Does not hold
-   * if the type being destroyed has a virtual destructor. In that case, the
+   * Gets the `operator delete` or `operator delete[]` that deallocates storage.
+   * Does not hold if the type being destroyed has a virtual destructor. In that case, the
    * `operator delete` that will be called is determined at runtime based on the
    * dynamic type of the object.
    */
@@ -969,10 +969,10 @@ class DeleteOrDeleteArrayExpr extends Expr, TDeleteOrDeleteArrayExpr {
   deprecated FunctionCall getAllocatorCall() { result = this.getChild(0) }
 
   /**
-   * Gets the call to a non-default `operator delete` that deallocates storage, if any.
+   * Gets the call to a non-default `operator delete`/`delete[]` that deallocates storage, if any.
    *
    * This will only be present when the type being deleted has a custom `operator delete` and
-   * is not a class with a virtual destructor.
+   * does not have a virtual destructor.
    */
   FunctionCall getDeallocatorCall() { result = this.getChild(0) }
 
@@ -997,12 +997,13 @@ class DeleteOrDeleteArrayExpr extends Expr, TDeleteOrDeleteArrayExpr {
   }
 
   /**
-   * Gets the object being deleted.
+   * Gets the object/array being deleted.
    */
-  Expr getExpr() { 
+  Expr getExpr() {
     // If there is a destuctor call, the object being deleted is the qualifier
     // otherwise it is the third child.
-    result = this.getChild(3) or result = this.getDestructorCall().getQualifier() }
+    result = this.getChild(3) or result = this.getDestructorCall().getQualifier()
+  }
 }
 
 /**

--- a/cpp/ql/lib/semmle/code/cpp/exprs/Expr.qll
+++ b/cpp/ql/lib/semmle/code/cpp/exprs/Expr.qll
@@ -964,12 +964,17 @@ class DeleteOrDeleteArrayExpr extends Expr, TDeleteOrDeleteArrayExpr {
   }
 
   /**
+   * DEPRECATED: use `getDeallocatorCall` instead.
+   */
+  deprecated FunctionCall getAllocatorCall() { result = this.getChild(0) }
+
+  /**
    * Gets the call to a non-default `operator delete` that deallocates storage, if any.
    *
    * This will only be present when the type being deleted has a custom `operator delete` and
    * is not a class with a virtual destructor.
    */
-  FunctionCall getAllocatorCall() { result = this.getChild(0) }
+  FunctionCall getDeallocatorCall() { result = this.getChild(0) }
 
   /**
    * Holds if the deallocation function expects a size argument.

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/internal/TranslatedElement.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/internal/TranslatedElement.qll
@@ -84,9 +84,9 @@ private predicate ignoreExprAndDescendants(Expr expr) {
   or
   // We do not yet translate destructors properly, so for now we ignore any
   // custom deallocator call, if present.
-  exists(DeleteExpr deleteExpr | deleteExpr.getAllocatorCall() = expr)
+  exists(DeleteExpr deleteExpr | deleteExpr.getDeallocatorCall() = expr)
   or
-  exists(DeleteArrayExpr deleteArrayExpr | deleteArrayExpr.getAllocatorCall() = expr)
+  exists(DeleteArrayExpr deleteArrayExpr | deleteArrayExpr.getDeallocatorCall() = expr)
   or
   exists(BuiltInVarArgsStart vaStartExpr |
     vaStartExpr.getLastNamedParameter().getFullyConverted() = expr

--- a/cpp/ql/src/Security/CWE/CWE-570/IncorrectAllocationErrorHandling.ql
+++ b/cpp/ql/src/Security/CWE/CWE-570/IncorrectAllocationErrorHandling.ql
@@ -17,21 +17,6 @@ import cpp
 import semmle.code.cpp.valuenumbering.GlobalValueNumbering
 import semmle.code.cpp.controlflow.Guards
 
-/**
- * A C++ `delete` or `delete[]` expression.
- */
-class DeleteOrDeleteArrayExpr extends Expr {
-  DeleteOrDeleteArrayExpr() { this instanceof DeleteExpr or this instanceof DeleteArrayExpr }
-
-  DeallocationFunction getDeallocator() {
-    result = [this.(DeleteExpr).getDeallocator(), this.(DeleteArrayExpr).getDeallocator()]
-  }
-
-  Destructor getDestructor() {
-    result = [this.(DeleteExpr).getDestructor(), this.(DeleteArrayExpr).getDestructor()]
-  }
-}
-
 /** Gets the `Constructor` invoked when `newExpr` allocates memory. */
 Constructor getConstructorForAllocation(NewOrNewArrayExpr newExpr) {
   result.getACallToThisFunction() = newExpr.getInitializer()

--- a/cpp/ql/test/library-tests/allocators/allocators.expected
+++ b/cpp/ql/test/library-tests/allocators/allocators.expected
@@ -34,11 +34,11 @@ newArrayExprDeallocators
 | allocators.cpp:108:3:108:19 | new[] | FailedInit | void FailedInit::operator delete[](void*, size_t) | 1 | 1 | sized  |
 | allocators.cpp:110:3:110:37 | new[] | FailedInitOveraligned | void FailedInitOveraligned::operator delete[](void*, std::align_val_t, float) | 128 | 128 |  aligned |
 deleteExprs
-| allocators.cpp:59:3:59:35 | delete | int | void operator delete(void*, unsigned long) | 4 | 4 | sized  |
-| allocators.cpp:60:3:60:38 | delete | String | void operator delete(void*, unsigned long) | 8 | 8 | sized  |
-| allocators.cpp:61:3:61:44 | delete | SizedDealloc | void SizedDealloc::operator delete(void*, size_t) | 32 | 1 | sized  |
-| allocators.cpp:62:3:62:43 | delete | Overaligned | void operator delete(void*, unsigned long, std::align_val_t) | 256 | 128 | sized aligned |
-| allocators.cpp:64:3:64:44 | delete | const String | void operator delete(void*, unsigned long) | 8 | 8 | sized  |
+| allocators.cpp:59:3:59:35 | delete | int | void operator delete(void*, unsigned long) | 4 | 4 | sized  | false |
+| allocators.cpp:60:3:60:38 | delete | String | void operator delete(void*, unsigned long) | 8 | 8 | sized  | false |
+| allocators.cpp:61:3:61:44 | delete | SizedDealloc | void SizedDealloc::operator delete(void*, size_t) | 32 | 1 | sized  | true |
+| allocators.cpp:62:3:62:43 | delete | Overaligned | void operator delete(void*, unsigned long, std::align_val_t) | 256 | 128 | sized aligned | false |
+| allocators.cpp:64:3:64:44 | delete | const String | void operator delete(void*, unsigned long) | 8 | 8 | sized  | false |
 deleteArrayExprs
 | allocators.cpp:78:3:78:37 | delete[] | int | void operator delete[](void*, unsigned long) | 4 | 4 | sized  |
 | allocators.cpp:79:3:79:40 | delete[] | String | void operator delete[](void*, unsigned long) | 8 | 8 | sized  |

--- a/cpp/ql/test/library-tests/allocators/allocators.ql
+++ b/cpp/ql/test/library-tests/allocators/allocators.ql
@@ -77,7 +77,8 @@ query predicate newArrayExprDeallocators(
 }
 
 query predicate deleteExprs(
-  DeleteExpr expr, string type, string sig, int size, int alignment, string form
+  DeleteExpr expr, string type, string sig, int size, int alignment, string form,
+  boolean hasDeallocatorCall
 ) {
   exists(Function deallocator, Type deletedType |
     expr.getDeallocator() = deallocator and
@@ -90,7 +91,10 @@ query predicate deleteExprs(
       (if expr.hasAlignedDeallocation() then aligned = "aligned" else aligned = "") and
       (if expr.hasSizedDeallocation() then sized = "sized" else sized = "") and
       form = sized + " " + aligned
-    )
+    ) and
+    if exists(expr.getDeallocatorCall())
+    then hasDeallocatorCall = true
+    else hasDeallocatorCall = false
   )
 }
 

--- a/cpp/ql/test/library-tests/ir/ir/PrintAST.expected
+++ b/cpp/ql/test/library-tests/ir/ir/PrintAST.expected
@@ -8477,7 +8477,7 @@ ir.cpp:
 # 1018|       getExpr(): [DeleteExpr] delete
 # 1018|           Type = [VoidType] void
 # 1018|           ValueCategory = prvalue
-# 1018|         getAllocatorCall(): [FunctionCall] call to operator delete
+# 1018|         getDeallocatorCall(): [FunctionCall] call to operator delete
 # 1018|             Type = [VoidType] void
 # 1018|             ValueCategory = prvalue
 # 1018|         getExpr(): [Literal] 0
@@ -8555,7 +8555,7 @@ ir.cpp:
 # 1027|       getExpr(): [DeleteArrayExpr] delete[]
 # 1027|           Type = [VoidType] void
 # 1027|           ValueCategory = prvalue
-# 1027|         getAllocatorCall(): [FunctionCall] call to operator delete[]
+# 1027|         getDeallocatorCall(): [FunctionCall] call to operator delete[]
 # 1027|             Type = [VoidType] void
 # 1027|             ValueCategory = prvalue
 # 1027|         getExpr(): [Literal] 0


### PR DESCRIPTION
This adds a parent to `delete` and `delete[]` so that they can be handled together. This also renames `getAllocatorCall` into `getDeallocatorCall` and fixes some incorrect documentation.

I split this out of the IR work.