### PR TITLE
C#: Download `nuget.exe` in the dependency manager (if not present).

### DIFF
--- a/csharp/autobuilder/Semmle.Autobuild.Shared/BuildActions.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.Shared/BuildActions.cs
@@ -1,13 +1,11 @@
-﻿using Semmle.Util;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
-using System.Xml;
-using System.Net.Http;
 using System.Diagnostics.CodeAnalysis;
-using System.Threading.Tasks;
+using System.IO;
 using System.Runtime.InteropServices;
+using System.Xml;
+using Semmle.Util;
 
 namespace Semmle.Autobuild.Shared
 {
@@ -283,17 +281,8 @@ namespace Semmle.Autobuild.Shared
 
         public string EnvironmentExpandEnvironmentVariables(string s) => Environment.ExpandEnvironmentVariables(s);
 
-        private static async Task DownloadFileAsync(string address, string filename)
-        {
-            using var httpClient = new HttpClient();
-            using var request = new HttpRequestMessage(HttpMethod.Get, address);
-            using var contentStream = await (await httpClient.SendAsync(request)).Content.ReadAsStreamAsync();
-            using var stream = new FileStream(filename, FileMode.Create, FileAccess.Write, FileShare.None, 4096, true);
-            await contentStream.CopyToAsync(stream);
-        }
-
         public void DownloadFile(string address, string fileName) =>
-            DownloadFileAsync(address, fileName).Wait();
+            FileUtils.DownloadFile(address, fileName);
 
         public IDiagnosticsWriter CreateDiagnosticsWriter(string filename) => new DiagnosticsStream(filename);
 

--- a/csharp/autobuilder/Semmle.Autobuild.Shared/MsBuildRule.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.Shared/MsBuildRule.cs
@@ -1,6 +1,7 @@
-using Semmle.Util.Logging;
 using System.Collections.Generic;
 using System.Linq;
+using Semmle.Util;
+using Semmle.Util.Logging;
 
 namespace Semmle.Autobuild.Shared
 {
@@ -190,7 +191,7 @@ namespace Semmle.Autobuild.Shared
             })
             &
             BuildScript.DownloadFile(
-                "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe",
+                FileUtils.nugetExeUrl,
                 path,
                 e => builder.Log(Severity.Warning, $"Failed to download 'nuget.exe': {e.Message}"))
             &

--- a/csharp/autobuilder/Semmle.Autobuild.Shared/MsBuildRule.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.Shared/MsBuildRule.cs
@@ -191,7 +191,7 @@ namespace Semmle.Autobuild.Shared
             })
             &
             BuildScript.DownloadFile(
-                FileUtils.nugetExeUrl,
+                FileUtils.NugetExeUrl,
                 path,
                 e => builder.Log(Severity.Warning, $"Failed to download 'nuget.exe': {e.Message}"))
             &

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/NugetPackages.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/NugetPackages.cs
@@ -83,7 +83,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             progressMonitor.LogInfo("Attempting to download nuget.exe");
             try
             {
-                FileUtils.DownloadFile(FileUtils.nugetExeUrl, nuget);
+                FileUtils.DownloadFile(FileUtils.NugetExeUrl, nuget);
                 progressMonitor.LogInfo($"Downloaded nuget.exe to {nuget}");
                 return nuget;
             }

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/NugetPackages.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/NugetPackages.cs
@@ -14,6 +14,26 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
     /// </summary>
     internal class NugetPackages
     {
+        private readonly string nugetExe;
+        private readonly ProgressMonitor progressMonitor;
+
+        /// <summary>
+        /// The list of package files.
+        /// </summary>
+        public FileInfo[] PackageFiles { get; }
+
+        /// <summary>
+        /// The source directory used.
+        /// </summary>
+        public string SourceDirectory { get; }
+
+        /// <summary>
+        /// The computed packages directory.
+        /// This will be in the Temp location
+        /// so as to not trample the source tree.
+        /// </summary>
+        public TemporaryDirectory PackageDirectory { get; }
+
         /// <summary>
         /// Create the package manager for a specified source tree.
         /// </summary>
@@ -32,46 +52,10 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             if (!File.Exists(nugetExe))
                 throw new FileNotFoundException(string.Format("NuGet could not be found at {0}", nugetExe));
 
-            packages = new DirectoryInfo(SourceDirectory)
+            PackageFiles = new DirectoryInfo(SourceDirectory)
                 .EnumerateFiles("packages.config", SearchOption.AllDirectories)
                 .ToArray();
         }
-
-        // List of package files to download.
-        private readonly FileInfo[] packages;
-
-        /// <summary>
-        /// The list of package files.
-        /// </summary>
-        public IEnumerable<FileInfo> PackageFiles => packages;
-
-        /// <summary>
-        /// Download the packages to the temp folder.
-        /// </summary>
-        /// <param name="pm">The progress monitor used for reporting errors etc.</param>
-        public void InstallPackages()
-        {
-            foreach (var package in packages)
-            {
-                RestoreNugetPackage(package.FullName);
-            }
-        }
-
-        /// <summary>
-        /// The source directory used.
-        /// </summary>
-        public string SourceDirectory
-        {
-            get;
-            private set;
-        }
-
-        /// <summary>
-        /// The computed packages directory.
-        /// This will be in the Temp location
-        /// so as to not trample the source tree.
-        /// </summary>
-        public TemporaryDirectory PackageDirectory { get; }
 
         /// <summary>
         /// Restore all files in a specified package.
@@ -133,7 +117,16 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             }
         }
 
-        private readonly string nugetExe;
-        private readonly ProgressMonitor progressMonitor;
+        /// <summary>
+        /// Download the packages to the temp folder.
+        /// </summary>
+        /// <param name="pm">The progress monitor used for reporting errors etc.</param>
+        public void InstallPackages()
+        {
+            foreach (var package in PackageFiles)
+            {
+                RestoreNugetPackage(package.FullName);
+            }
+        }
     }
 }

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/ProgressMonitor.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/ProgressMonitor.cs
@@ -88,6 +88,9 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         public void MissingNuGet() =>
             LogError("Missing nuget.exe");
 
+        public void FoundNuGet(string path) =>
+            LogInfo($"Found nuget.exe at {path}");
+
         public void MissingDotNet() =>
             LogError("Missing dotnet CLI");
 

--- a/csharp/extractor/Semmle.Util/FileUtils.cs
+++ b/csharp/extractor/Semmle.Util/FileUtils.cs
@@ -10,6 +10,8 @@ namespace Semmle.Util
 {
     public static class FileUtils
     {
+        public const string nugetExeUrl = "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe";
+
         public static string ConvertToWindows(string path)
         {
             return path.Replace('/', '\\');

--- a/csharp/extractor/Semmle.Util/FileUtils.cs
+++ b/csharp/extractor/Semmle.Util/FileUtils.cs
@@ -1,8 +1,10 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Security.Cryptography;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace Semmle.Util
 {
@@ -91,5 +93,20 @@ namespace Semmle.Util
                 hex.AppendFormat("{0:x2}", b);
             return hex.ToString();
         }
+
+        private static async Task DownloadFileAsync(string address, string filename)
+        {
+            using var httpClient = new HttpClient();
+            using var request = new HttpRequestMessage(HttpMethod.Get, address);
+            using var contentStream = await (await httpClient.SendAsync(request)).Content.ReadAsStreamAsync();
+            using var stream = new FileStream(filename, FileMode.Create, FileAccess.Write, FileShare.None, 4096, true);
+            await contentStream.CopyToAsync(stream);
+        }
+
+        /// <summary>
+        /// Downloads the file at <paramref name="address"/> to <paramref name="fileName"/>.
+        /// </summary>
+        public static void DownloadFile(string address, string fileName) =>
+           DownloadFileAsync(address, fileName).Wait();
     }
 }

--- a/csharp/extractor/Semmle.Util/FileUtils.cs
+++ b/csharp/extractor/Semmle.Util/FileUtils.cs
@@ -10,7 +10,7 @@ namespace Semmle.Util
 {
     public static class FileUtils
     {
-        public const string nugetExeUrl = "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe";
+        public const string NugetExeUrl = "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe";
 
         public static string ConvertToWindows(string path)
         {


### PR DESCRIPTION
In this PR we improve the *dependency manager*, such that `nuget.exe` is downloaded if it is not found.

The change has been manually tested on the GitHub repo `FluentValidation/FluentValidation`. This repo contains a `packages.config` file and the nuget package dependencies listed here are downloaded to the temporary package folder after the download of `nuget.exe`.