### PR TITLE
Add Jsonify (Flask) As Sanitizer for XSS

### DIFF
--- a/python/ql/lib/semmle/python/security/dataflow/ReflectedXSSCustomizations.qll
+++ b/python/ql/lib/semmle/python/security/dataflow/ReflectedXSSCustomizations.qll
@@ -5,6 +5,7 @@
  */
 
 private import python
+private import semmle.python.ApiGraphs
 private import semmle.python.dataflow.new.DataFlow
 private import semmle.python.Concepts
 private import semmle.python.frameworks.data.ModelsAsData
@@ -85,4 +86,10 @@ module ReflectedXss {
    * A comparison with a constant string, considered as a sanitizer-guard.
    */
   class StringConstCompareAsSanitizerGuard extends Sanitizer, StringConstCompareBarrier { }
+
+   class FlaskJsonify extends Sanitizer {
+     FlaskJsonify() {
+       this = [API::moduleImport("flask"), API::moduleImport("flask").getMember("Flask")].getMember("jsonify").getParameter(0).asSink()
+     }
+   }
 }


### PR DESCRIPTION
The jsonify() function in flask returns a flask.Response() object that already has the appropriate content-type header 'application/json' for use with json responses.