### PR TITLE
C++: Non-certain definitions should always be uses

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
@@ -108,7 +108,7 @@ private newtype TDefOrUseImpl =
   } or
   TUseImpl(BaseSourceVariableInstruction base, Operand operand, int indirectionIndex) {
     isUse(_, operand, base, _, indirectionIndex) and
-    not isDef(_, _, operand, _, _, _)
+    not isDef(true, _, operand, _, _, _)
   } or
   TGlobalUse(GlobalLikeVariable v, IRFunction f, int indirectionIndex) {
     // Represents a final "use" of a global variable to ensure that


### PR DESCRIPTION
This _should_ be identical to the branch [here](https://github.com/github/codeql/blob/main/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/ssa0/SsaInternals.qll#L32) (which has a `true` in this case).

I haven't been able to construct a meaningful testcase where this makes a difference right now, but once I open the final PR for deduplicating dataflow results this is required.

The semantics of this change is that it'll make more things an SSA use: Previously, no SSA definitions were considered a use of the underlying SSA variable. After this change, non-certain SSA definitions are also considered uses.