### PR TITLE
Data flow: Add `ArgumentNode` consistency checks

### DIFF
--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/dataflow-consistency.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/dataflow-consistency.expected
@@ -4,7 +4,6 @@ uniqueType
 uniqueNodeLocation
 missingLocation
 uniqueNodeToString
-missingToString
 parameterCallable
 localFlowIsLocal
 readStepIsLocal
@@ -139,3 +138,5 @@ uniqueParameterNodeAtPosition
 uniqueParameterNodePosition
 uniqueContentApprox
 identityLocalStep
+missingArgumentCall
+multipleArgumentCall

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/dataflow-ir-consistency.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/dataflow-ir-consistency.expected
@@ -4,7 +4,6 @@ uniqueType
 uniqueNodeLocation
 missingLocation
 uniqueNodeToString
-missingToString
 parameterCallable
 localFlowIsLocal
 readStepIsLocal
@@ -32,3 +31,5 @@ uniqueParameterNodeAtPosition
 uniqueParameterNodePosition
 uniqueContentApprox
 identityLocalStep
+missingArgumentCall
+multipleArgumentCall

--- a/cpp/ql/test/library-tests/dataflow/fields/dataflow-consistency.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/dataflow-consistency.expected
@@ -10,7 +10,6 @@ uniqueType
 uniqueNodeLocation
 missingLocation
 uniqueNodeToString
-missingToString
 parameterCallable
 localFlowIsLocal
 readStepIsLocal
@@ -192,3 +191,5 @@ uniqueParameterNodeAtPosition
 uniqueParameterNodePosition
 uniqueContentApprox
 identityLocalStep
+missingArgumentCall
+multipleArgumentCall

--- a/cpp/ql/test/library-tests/dataflow/fields/dataflow-ir-consistency.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/dataflow-ir-consistency.expected
@@ -4,7 +4,6 @@ uniqueType
 uniqueNodeLocation
 missingLocation
 uniqueNodeToString
-missingToString
 parameterCallable
 localFlowIsLocal
 readStepIsLocal
@@ -53,3 +52,5 @@ uniqueParameterNodeAtPosition
 uniqueParameterNodePosition
 uniqueContentApprox
 identityLocalStep
+missingArgumentCall
+multipleArgumentCall

--- a/cpp/ql/test/library-tests/syntax-zoo/dataflow-consistency.expected
+++ b/cpp/ql/test/library-tests/syntax-zoo/dataflow-consistency.expected
@@ -16,7 +16,6 @@ uniqueNodeLocation
 missingLocation
 | Nodes without location: 2 |
 uniqueNodeToString
-missingToString
 parameterCallable
 localFlowIsLocal
 readStepIsLocal
@@ -98,3 +97,5 @@ uniqueParameterNodeAtPosition
 uniqueParameterNodePosition
 uniqueContentApprox
 identityLocalStep
+missingArgumentCall
+multipleArgumentCall

--- a/cpp/ql/test/library-tests/syntax-zoo/dataflow-ir-consistency.expected
+++ b/cpp/ql/test/library-tests/syntax-zoo/dataflow-ir-consistency.expected
@@ -5,8 +5,6 @@ uniqueNodeLocation
 missingLocation
 uniqueNodeToString
 | cpp11.cpp:50:15:50:16 | (no string representation) | Node should have one toString but has 0. |
-missingToString
-| Nodes without toString: 1 |
 parameterCallable
 localFlowIsLocal
 readStepIsLocal
@@ -54,3 +52,5 @@ uniqueParameterNodeAtPosition
 uniqueParameterNodePosition
 uniqueContentApprox
 identityLocalStep
+missingArgumentCall
+multipleArgumentCall

--- a/csharp/ql/consistency-queries/DataFlowConsistency.ql
+++ b/csharp/ql/consistency-queries/DataFlowConsistency.ql
@@ -75,8 +75,3 @@ private module Input implements InputSig<CsharpDataFlow> {
 }
 
 import MakeConsistency<CsharpDataFlow, CsharpTaintTracking, Input>
-
-query predicate multipleToString(DataFlow::Node n, string s) {
-  s = strictconcat(n.toString(), ",") and
-  strictcount(n.toString()) > 1
-}

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -2032,7 +2032,7 @@ abstract class PostUpdateNode extends Node {
   abstract Node getPreUpdateNode();
 }
 
-private module PostUpdateNodes {
+module PostUpdateNodes {
   class ObjectCreationNode extends PostUpdateNode, ExprNode, TExprNode {
     private ObjectCreation oc;
 

--- a/csharp/ql/lib/semmle/code/csharp/dispatch/Dispatch.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dispatch/Dispatch.qll
@@ -50,6 +50,9 @@ class DispatchCall extends Internal::TDispatchCall {
   RuntimeCallable getADynamicTargetInCallContext(DispatchCall ctx) {
     result = Internal::getADynamicTargetInCallContext(this, ctx)
   }
+
+  /** Holds if this call uses reflection. */
+  predicate isReflection() { this instanceof Internal::TDispatchReflectionCall }
 }
 
 /** Internal implementation details. */

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImplConsistency.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImplConsistency.qll
@@ -47,6 +47,10 @@ private module Input implements InputSig<PythonDataFlow> {
   predicate identityLocalStepExclude(Node n) {
     not exists(n.getLocation().getFile().getRelativePath())
   }
+
+  predicate multipleArgumentCallExclude(ArgumentNode arg, DataFlowCall call) {
+    isArgumentNode(arg, call, _)
+  }
 }
 
 module Consistency = MakeConsistency<PythonDataFlow, PythonTaintTracking, Input>;

--- a/python/ql/test/experimental/dataflow/basic/dataflow-consistency.expected
+++ b/python/ql/test/experimental/dataflow/basic/dataflow-consistency.expected
@@ -4,7 +4,6 @@ uniqueType
 uniqueNodeLocation
 missingLocation
 uniqueNodeToString
-missingToString
 parameterCallable
 localFlowIsLocal
 readStepIsLocal
@@ -24,3 +23,5 @@ uniqueParameterNodeAtPosition
 uniqueParameterNodePosition
 uniqueContentApprox
 identityLocalStep
+missingArgumentCall
+multipleArgumentCall

--- a/python/ql/test/experimental/dataflow/callgraph_crosstalk/dataflow-consistency.expected
+++ b/python/ql/test/experimental/dataflow/callgraph_crosstalk/dataflow-consistency.expected
@@ -4,7 +4,6 @@ uniqueType
 uniqueNodeLocation
 missingLocation
 uniqueNodeToString
-missingToString
 parameterCallable
 localFlowIsLocal
 readStepIsLocal
@@ -24,3 +23,5 @@ uniqueParameterNodeAtPosition
 uniqueParameterNodePosition
 uniqueContentApprox
 identityLocalStep
+missingArgumentCall
+multipleArgumentCall

--- a/python/ql/test/experimental/dataflow/calls/dataflow-consistency.expected
+++ b/python/ql/test/experimental/dataflow/calls/dataflow-consistency.expected
@@ -8,7 +8,6 @@ uniqueType
 uniqueNodeLocation
 missingLocation
 uniqueNodeToString
-missingToString
 parameterCallable
 localFlowIsLocal
 readStepIsLocal
@@ -28,3 +27,5 @@ uniqueParameterNodeAtPosition
 uniqueParameterNodePosition
 uniqueContentApprox
 identityLocalStep
+missingArgumentCall
+multipleArgumentCall

--- a/python/ql/test/experimental/dataflow/consistency/dataflow-consistency.expected
+++ b/python/ql/test/experimental/dataflow/consistency/dataflow-consistency.expected
@@ -4,7 +4,6 @@ uniqueType
 uniqueNodeLocation
 missingLocation
 uniqueNodeToString
-missingToString
 parameterCallable
 localFlowIsLocal
 readStepIsLocal
@@ -24,3 +23,5 @@ uniqueParameterNodeAtPosition
 uniqueParameterNodePosition
 uniqueContentApprox
 identityLocalStep
+missingArgumentCall
+multipleArgumentCall

--- a/python/ql/test/experimental/dataflow/coverage/dataflow-consistency.expected
+++ b/python/ql/test/experimental/dataflow/coverage/dataflow-consistency.expected
@@ -6,7 +6,6 @@ uniqueType
 uniqueNodeLocation
 missingLocation
 uniqueNodeToString
-missingToString
 parameterCallable
 localFlowIsLocal
 readStepIsLocal
@@ -39,3 +38,5 @@ identityLocalStep
 | test.py:678:9:678:12 | ControlFlowNode for SINK | Node steps to itself |
 | test.py:686:9:686:12 | ControlFlowNode for SINK | Node steps to itself |
 | test.py:692:5:692:8 | ControlFlowNode for SINK | Node steps to itself |
+missingArgumentCall
+multipleArgumentCall

--- a/python/ql/test/experimental/dataflow/exceptions/dataflow-consistency.expected
+++ b/python/ql/test/experimental/dataflow/exceptions/dataflow-consistency.expected
@@ -4,7 +4,6 @@ uniqueType
 uniqueNodeLocation
 missingLocation
 uniqueNodeToString
-missingToString
 parameterCallable
 localFlowIsLocal
 readStepIsLocal
@@ -24,3 +23,5 @@ uniqueParameterNodeAtPosition
 uniqueParameterNodePosition
 uniqueContentApprox
 identityLocalStep
+missingArgumentCall
+multipleArgumentCall

--- a/python/ql/test/experimental/dataflow/fieldflow/dataflow-consistency.expected
+++ b/python/ql/test/experimental/dataflow/fieldflow/dataflow-consistency.expected
@@ -4,7 +4,6 @@ uniqueType
 uniqueNodeLocation
 missingLocation
 uniqueNodeToString
-missingToString
 parameterCallable
 localFlowIsLocal
 readStepIsLocal
@@ -24,3 +23,5 @@ uniqueParameterNodeAtPosition
 uniqueParameterNodePosition
 uniqueContentApprox
 identityLocalStep
+missingArgumentCall
+multipleArgumentCall

--- a/python/ql/test/experimental/dataflow/global-flow/dataflow-consistency.expected
+++ b/python/ql/test/experimental/dataflow/global-flow/dataflow-consistency.expected
@@ -4,7 +4,6 @@ uniqueType
 uniqueNodeLocation
 missingLocation
 uniqueNodeToString
-missingToString
 parameterCallable
 localFlowIsLocal
 readStepIsLocal
@@ -24,3 +23,5 @@ uniqueParameterNodeAtPosition
 uniqueParameterNodePosition
 uniqueContentApprox
 identityLocalStep
+missingArgumentCall
+multipleArgumentCall

--- a/python/ql/test/experimental/dataflow/match/dataflow-consistency.expected
+++ b/python/ql/test/experimental/dataflow/match/dataflow-consistency.expected
@@ -4,7 +4,6 @@ uniqueType
 uniqueNodeLocation
 missingLocation
 uniqueNodeToString
-missingToString
 parameterCallable
 localFlowIsLocal
 readStepIsLocal
@@ -24,3 +23,5 @@ uniqueParameterNodeAtPosition
 uniqueParameterNodePosition
 uniqueContentApprox
 identityLocalStep
+missingArgumentCall
+multipleArgumentCall

--- a/python/ql/test/experimental/dataflow/pep_328/dataflow-consistency.expected
+++ b/python/ql/test/experimental/dataflow/pep_328/dataflow-consistency.expected
@@ -4,7 +4,6 @@ uniqueType
 uniqueNodeLocation
 missingLocation
 uniqueNodeToString
-missingToString
 parameterCallable
 localFlowIsLocal
 readStepIsLocal
@@ -24,3 +23,5 @@ uniqueParameterNodeAtPosition
 uniqueParameterNodePosition
 uniqueContentApprox
 identityLocalStep
+missingArgumentCall
+multipleArgumentCall

--- a/python/ql/test/experimental/dataflow/regression/dataflow-consistency.expected
+++ b/python/ql/test/experimental/dataflow/regression/dataflow-consistency.expected
@@ -4,7 +4,6 @@ uniqueType
 uniqueNodeLocation
 missingLocation
 uniqueNodeToString
-missingToString
 parameterCallable
 localFlowIsLocal
 readStepIsLocal
@@ -24,3 +23,5 @@ uniqueParameterNodeAtPosition
 uniqueParameterNodePosition
 uniqueContentApprox
 identityLocalStep
+missingArgumentCall
+multipleArgumentCall

--- a/python/ql/test/experimental/dataflow/strange-essaflow/dataflow-consistency.expected
+++ b/python/ql/test/experimental/dataflow/strange-essaflow/dataflow-consistency.expected
@@ -4,7 +4,6 @@ uniqueType
 uniqueNodeLocation
 missingLocation
 uniqueNodeToString
-missingToString
 parameterCallable
 localFlowIsLocal
 readStepIsLocal
@@ -24,3 +23,5 @@ uniqueParameterNodeAtPosition
 uniqueParameterNodePosition
 uniqueContentApprox
 identityLocalStep
+missingArgumentCall
+multipleArgumentCall

--- a/python/ql/test/experimental/dataflow/tainttracking/basic/dataflow-consistency.expected
+++ b/python/ql/test/experimental/dataflow/tainttracking/basic/dataflow-consistency.expected
@@ -4,7 +4,6 @@ uniqueType
 uniqueNodeLocation
 missingLocation
 uniqueNodeToString
-missingToString
 parameterCallable
 localFlowIsLocal
 readStepIsLocal
@@ -24,3 +23,5 @@ uniqueParameterNodeAtPosition
 uniqueParameterNodePosition
 uniqueContentApprox
 identityLocalStep
+missingArgumentCall
+multipleArgumentCall

--- a/python/ql/test/experimental/dataflow/tainttracking/commonSanitizer/dataflow-consistency.expected
+++ b/python/ql/test/experimental/dataflow/tainttracking/commonSanitizer/dataflow-consistency.expected
@@ -4,7 +4,6 @@ uniqueType
 uniqueNodeLocation
 missingLocation
 uniqueNodeToString
-missingToString
 parameterCallable
 localFlowIsLocal
 readStepIsLocal
@@ -24,3 +23,5 @@ uniqueParameterNodeAtPosition
 uniqueParameterNodePosition
 uniqueContentApprox
 identityLocalStep
+missingArgumentCall
+multipleArgumentCall

--- a/python/ql/test/experimental/dataflow/tainttracking/customSanitizer/dataflow-consistency.expected
+++ b/python/ql/test/experimental/dataflow/tainttracking/customSanitizer/dataflow-consistency.expected
@@ -4,7 +4,6 @@ uniqueType
 uniqueNodeLocation
 missingLocation
 uniqueNodeToString
-missingToString
 parameterCallable
 localFlowIsLocal
 readStepIsLocal
@@ -24,3 +23,5 @@ uniqueParameterNodeAtPosition
 uniqueParameterNodePosition
 uniqueContentApprox
 identityLocalStep
+missingArgumentCall
+multipleArgumentCall

--- a/python/ql/test/experimental/dataflow/tainttracking/defaultAdditionalTaintStep-py3/dataflow-consistency.expected
+++ b/python/ql/test/experimental/dataflow/tainttracking/defaultAdditionalTaintStep-py3/dataflow-consistency.expected
@@ -4,7 +4,6 @@ uniqueType
 uniqueNodeLocation
 missingLocation
 uniqueNodeToString
-missingToString
 parameterCallable
 localFlowIsLocal
 readStepIsLocal
@@ -26,3 +25,5 @@ uniqueContentApprox
 identityLocalStep
 | test_collections.py:20:9:20:22 | ControlFlowNode for ensure_tainted | Node steps to itself |
 | test_unpacking.py:31:9:31:22 | ControlFlowNode for ensure_tainted | Node steps to itself |
+missingArgumentCall
+multipleArgumentCall

--- a/python/ql/test/experimental/dataflow/tainttracking/defaultAdditionalTaintStep/dataflow-consistency.expected
+++ b/python/ql/test/experimental/dataflow/tainttracking/defaultAdditionalTaintStep/dataflow-consistency.expected
@@ -4,7 +4,6 @@ uniqueType
 uniqueNodeLocation
 missingLocation
 uniqueNodeToString
-missingToString
 parameterCallable
 localFlowIsLocal
 readStepIsLocal
@@ -39,3 +38,5 @@ identityLocalStep
 | test_collections.py:246:9:246:15 | ControlFlowNode for my_dict | Node steps to itself |
 | test_collections.py:246:22:246:33 | ControlFlowNode for tainted_dict | Node steps to itself |
 | test_for.py:24:9:24:22 | ControlFlowNode for ensure_tainted | Node steps to itself |
+missingArgumentCall
+multipleArgumentCall

--- a/python/ql/test/experimental/dataflow/tainttracking/generator-flow/dataflow-consistency.expected
+++ b/python/ql/test/experimental/dataflow/tainttracking/generator-flow/dataflow-consistency.expected
@@ -4,7 +4,6 @@ uniqueType
 uniqueNodeLocation
 missingLocation
 uniqueNodeToString
-missingToString
 parameterCallable
 localFlowIsLocal
 readStepIsLocal
@@ -24,3 +23,5 @@ uniqueParameterNodeAtPosition
 uniqueParameterNodePosition
 uniqueContentApprox
 identityLocalStep
+missingArgumentCall
+multipleArgumentCall

--- a/python/ql/test/experimental/dataflow/tainttracking/unwanted-global-flow/dataflow-consistency.expected
+++ b/python/ql/test/experimental/dataflow/tainttracking/unwanted-global-flow/dataflow-consistency.expected
@@ -4,7 +4,6 @@ uniqueType
 uniqueNodeLocation
 missingLocation
 uniqueNodeToString
-missingToString
 parameterCallable
 localFlowIsLocal
 readStepIsLocal
@@ -24,3 +23,5 @@ uniqueParameterNodeAtPosition
 uniqueParameterNodePosition
 uniqueContentApprox
 identityLocalStep
+missingArgumentCall
+multipleArgumentCall

--- a/python/ql/test/experimental/dataflow/typetracking/dataflow-consistency.expected
+++ b/python/ql/test/experimental/dataflow/typetracking/dataflow-consistency.expected
@@ -4,7 +4,6 @@ uniqueType
 uniqueNodeLocation
 missingLocation
 uniqueNodeToString
-missingToString
 parameterCallable
 localFlowIsLocal
 readStepIsLocal
@@ -24,3 +23,5 @@ uniqueParameterNodeAtPosition
 uniqueParameterNodePosition
 uniqueContentApprox
 identityLocalStep
+missingArgumentCall
+multipleArgumentCall

--- a/python/ql/test/experimental/dataflow/variable-capture/dataflow-consistency.expected
+++ b/python/ql/test/experimental/dataflow/variable-capture/dataflow-consistency.expected
@@ -10,7 +10,6 @@ uniqueType
 uniqueNodeLocation
 missingLocation
 uniqueNodeToString
-missingToString
 parameterCallable
 localFlowIsLocal
 readStepIsLocal
@@ -33,3 +32,5 @@ identityLocalStep
 | test_collections.py:36:10:36:15 | ControlFlowNode for SOURCE | Node steps to itself |
 | test_collections.py:45:19:45:21 | ControlFlowNode for mod | Node steps to itself |
 | test_collections.py:52:13:52:21 | ControlFlowNode for mod_local | Node steps to itself |
+missingArgumentCall
+multipleArgumentCall

--- a/python/ql/test/experimental/library-tests/CallGraph/dataflow-consistency.expected
+++ b/python/ql/test/experimental/library-tests/CallGraph/dataflow-consistency.expected
@@ -35,7 +35,6 @@ uniqueType
 uniqueNodeLocation
 missingLocation
 uniqueNodeToString
-missingToString
 parameterCallable
 localFlowIsLocal
 readStepIsLocal
@@ -55,3 +54,5 @@ uniqueParameterNodeAtPosition
 uniqueParameterNodePosition
 uniqueContentApprox
 identityLocalStep
+missingArgumentCall
+multipleArgumentCall

--- a/python/ql/test/library-tests/ApiGraphs/py3/dataflow-consistency.expected
+++ b/python/ql/test/library-tests/ApiGraphs/py3/dataflow-consistency.expected
@@ -8,7 +8,6 @@ uniqueType
 uniqueNodeLocation
 missingLocation
 uniqueNodeToString
-missingToString
 parameterCallable
 localFlowIsLocal
 readStepIsLocal
@@ -30,3 +29,5 @@ uniqueContentApprox
 identityLocalStep
 | test_captured.py:7:22:7:22 | ControlFlowNode for p | Node steps to itself |
 | test_captured.py:14:26:14:27 | ControlFlowNode for pp | Node steps to itself |
+missingArgumentCall
+multipleArgumentCall

--- a/python/ql/test/library-tests/frameworks/django-orm/dataflow-consistency.expected
+++ b/python/ql/test/library-tests/frameworks/django-orm/dataflow-consistency.expected
@@ -39,7 +39,6 @@ uniqueType
 uniqueNodeLocation
 missingLocation
 uniqueNodeToString
-missingToString
 parameterCallable
 localFlowIsLocal
 readStepIsLocal
@@ -125,3 +124,5 @@ identityLocalStep
 | testapp/tests.py:16:9:16:18 | ControlFlowNode for test_names | Node steps to itself |
 | testapp/tests.py:25:13:25:14 | ControlFlowNode for re | Node steps to itself |
 | testapp/tests.py:31:9:31:18 | ControlFlowNode for test_names | Node steps to itself |
+missingArgumentCall
+multipleArgumentCall

--- a/ruby/ql/consistency-queries/DataFlowConsistency.ql
+++ b/ruby/ql/consistency-queries/DataFlowConsistency.ql
@@ -35,11 +35,11 @@ private module Input implements InputSig<RubyDataFlow> {
       n.asExpr() = arg
     )
   }
+
+  predicate multipleArgumentCallExclude(ArgumentNode arg, DataFlowCall call) {
+    arg.asExpr().getASuccessor(any(SuccessorTypes::ConditionalSuccessor c)).getASuccessor() =
+      call.asCall()
+  }
 }
 
 import MakeConsistency<RubyDataFlow, RubyTaintTracking, Input>
-
-query predicate multipleToString(DataFlow::Node n, string s) {
-  s = strictconcat(n.toString(), ",") and
-  strictcount(n.toString()) > 1
-}

--- a/ruby/ql/consistency-queries/DataFlowConsistency.ql
+++ b/ruby/ql/consistency-queries/DataFlowConsistency.ql
@@ -37,8 +37,14 @@ private module Input implements InputSig<RubyDataFlow> {
   }
 
   predicate multipleArgumentCallExclude(ArgumentNode arg, DataFlowCall call) {
-    arg.asExpr().getASuccessor(any(SuccessorTypes::ConditionalSuccessor c)).getASuccessor() =
-      call.asCall()
+    // An argument such as `x` in `if not x then ...` has two successors (and hence
+    // two calls); one for each Boolean outcome of `x`.
+    exists(CfgNodes::ExprCfgNode n |
+      arg.argumentOf(call, _) and
+      n = call.asCall() and
+      arg.asExpr().getASuccessor(any(SuccessorTypes::ConditionalSuccessor c)).getASuccessor*() = n and
+      n.getASplit() instanceof Split::ConditionalCompletionSplit
+    )
   }
 }
 

--- a/ruby/ql/lib/codeql/ruby/controlflow/CfgNodes.qll
+++ b/ruby/ql/lib/codeql/ruby/controlflow/CfgNodes.qll
@@ -7,7 +7,6 @@ private import codeql.ruby.ast.internal.Constant
 private import codeql.ruby.ast.internal.Literal
 private import ControlFlowGraph
 private import internal.ControlFlowGraphImpl as CfgImpl
-private import internal.Splitting
 
 /** An entry node for a given scope. */
 class EntryNode extends CfgNode, CfgImpl::EntryNode {

--- a/ruby/ql/lib/codeql/ruby/controlflow/ControlFlowGraph.qll
+++ b/ruby/ql/lib/codeql/ruby/controlflow/ControlFlowGraph.qll
@@ -4,7 +4,7 @@ private import codeql.ruby.AST
 private import codeql.ruby.controlflow.BasicBlocks
 private import SuccessorTypes
 private import internal.ControlFlowGraphImpl as CfgImpl
-private import internal.Splitting
+private import internal.Splitting as Splitting
 private import internal.Completion
 
 /**
@@ -292,4 +292,11 @@ module SuccessorTypes {
   class ExitSuccessor extends SuccessorType, CfgImpl::TExitSuccessor {
     final override string toString() { result = "exit" }
   }
+}
+
+class Split = Splitting::Split;
+
+/** Provides different kinds of control flow graph splittings. */
+module Split {
+  class ConditionalCompletionSplit = Splitting::ConditionalCompletionSplit;
 }

--- a/ruby/ql/lib/codeql/ruby/controlflow/internal/Splitting.qll
+++ b/ruby/ql/lib/codeql/ruby/controlflow/internal/Splitting.qll
@@ -115,6 +115,8 @@ private module ConditionalCompletionSplitting {
   }
 }
 
+class ConditionalCompletionSplit = ConditionalCompletionSplitting::ConditionalCompletionSplit;
+
 module EnsureSplitting {
   /**
    * The type of a split `ensure` node.


### PR DESCRIPTION
Adds two consistency checks for checking uniqueness and existence of `DataFlowCall`s associated to `ArgumentNode`s. While the data flow library can handle `ArgumentNode`s belonging to multiple `DataFlowCall`s, it is good to check that this was indeed the intention. For C#, this would have highlighted https://github.com/github/codeql/pull/14099, and it also revealed four other kinds of inconsistencies ([two](https://github.com/github/codeql/pull/14132) of [which](https://github.com/github/codeql/pull/14170) have been fixed).