### PR TITLE
C#: Avoid explicitly restoring projects in solution files.

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependencyManager.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependencyManager.cs
@@ -360,6 +360,9 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
 
         /// <summary>
         /// Executes `dotnet restore` on all solution files in solutions.
+        /// As opposed to RestoreProjects this is not run in parallel using PLINQ
+        /// as `dotnet restore` on a solution already uses multiple threads for restoring
+        /// the projects (this can be disabled with the `--disable-parallel` flag).
         /// Returns a list of projects that are up to date with respect to restore.
         /// </summary>
         /// <param name="solutions">A list of paths to solution files.</param>
@@ -370,6 +373,13 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
                     return restoredProjects;
                 });
 
+        /// <summary>
+        /// Executes `dotnet restore` on all projects in projects.
+        /// This is done in parallel for performance reasons.
+        /// To ensure that output is not interleaved, the output of each
+        /// restore is collected and printed.
+        /// </summary>
+        /// <param name="projects">A list of paths to project files.</param>
         private void RestoreProjects(IEnumerable<string> projects)
         {
             var stdoutLines = projects

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DotNet.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DotNet.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
 using Semmle.Util;
 
 namespace Semmle.Extraction.CSharp.DependencyFetching
@@ -9,7 +11,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
     /// <summary>
     /// Utilities to run the "dotnet" command.
     /// </summary>
-    internal class DotNet : IDotNet
+    internal partial class DotNet : IDotNet
     {
         private readonly ProgressMonitor progressMonitor;
         private readonly string dotnet;
@@ -41,7 +43,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         private bool RunCommand(string args)
         {
             progressMonitor.RunningProcess($"{dotnet} {args}");
-            using var proc = Process.Start(this.MakeDotnetStartInfo(args, redirectStandardOutput: false));
+            using var proc = Process.Start(MakeDotnetStartInfo(args, redirectStandardOutput: false));
             proc?.WaitForExit();
             var exitCode = proc?.ExitCode ?? -1;
             if (exitCode != 0)
@@ -52,12 +54,49 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             return true;
         }
 
-        public bool RestoreToDirectory(string projectOrSolutionFile, string packageDirectory, string? pathToNugetConfig = null)
+        private bool RunCommand(string args, out IList<string> output)
         {
-            var args = $"restore --no-dependencies \"{projectOrSolutionFile}\" --packages \"{packageDirectory}\" /p:DisableImplicitNuGetFallbackFolder=true";
+            progressMonitor.RunningProcess($"{dotnet} {args}");
+            var pi = MakeDotnetStartInfo(args, redirectStandardOutput: true);
+            var exitCode = pi.ReadOutput(out output);
+            if (exitCode != 0)
+            {
+                progressMonitor.CommandFailed(dotnet, args, exitCode);
+                return false;
+            }
+            return true;
+        }
+
+        private static string GetRestoreArgs(string projectOrSolutionFile, string packageDirectory) =>
+            $"restore --no-dependencies \"{projectOrSolutionFile}\" --packages \"{packageDirectory}\" /p:DisableImplicitNuGetFallbackFolder=true";
+
+        public bool RestoreProjectToDirectory(string projectFile, string packageDirectory, string? pathToNugetConfig = null)
+        {
+            var args = GetRestoreArgs(projectFile, packageDirectory);
             if (pathToNugetConfig != null)
+            {
                 args += $" --configfile \"{pathToNugetConfig}\"";
+            }
             return RunCommand(args);
+        }
+
+        public bool RestoreSolutionToDirectory(string solutionFile, string packageDirectory, out IList<string> projects)
+        {
+            var args = GetRestoreArgs(solutionFile, packageDirectory);
+            args += " --verbosity normal";
+            if (RunCommand(args, out var output))
+            {
+                var regex = RestoreProjectRegex();
+                projects = output
+                    .Select(line => regex.Match(line))
+                    .Where(match => match.Success)
+                    .Select(match => match.Groups[1].Value)
+                    .ToList();
+                return true;
+            }
+
+            projects = new List<string>();
+            return false;
         }
 
         public bool New(string folder)
@@ -78,16 +117,12 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
 
         private IList<string> GetListed(string args, string artifact)
         {
-            progressMonitor.RunningProcess($"{dotnet} {args}");
-            var pi = this.MakeDotnetStartInfo(args, redirectStandardOutput: true);
-            var exitCode = pi.ReadOutput(out var artifacts);
-            if (exitCode != 0)
+            if (RunCommand(args, out var artifacts))
             {
-                progressMonitor.CommandFailed(dotnet, args, exitCode);
-                return new List<string>();
+                progressMonitor.LogInfo($"Found {artifact}s: {string.Join("\n", artifacts)}");
+                return artifacts;
             }
-            progressMonitor.LogInfo($"Found {artifact}s: {string.Join("\n", artifacts)}");
-            return artifacts;
+            return new List<string>();
         }
 
         public bool Exec(string execArgs)
@@ -95,5 +130,8 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             var args = $"exec {execArgs}";
             return RunCommand(args);
         }
+
+        [GeneratedRegex("Restored\\s+(.+\\.csproj)", RegexOptions.Compiled)]
+        private static partial Regex RestoreProjectRegex();
     }
 }

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/IDotNet.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/IDotNet.cs
@@ -4,7 +4,8 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
 {
     internal interface IDotNet
     {
-        bool RestoreToDirectory(string project, string directory, string? pathToNugetConfig = null);
+        bool RestoreProjectToDirectory(string project, string directory, string? pathToNugetConfig = null);
+        bool RestoreSolutionToDirectory(string solution, string directory, out IList<string> projects);
         bool New(string folder);
         bool AddPackage(string folder, string package);
         IList<string> GetListedRuntimes();

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/IDotNet.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/IDotNet.cs
@@ -4,8 +4,8 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
 {
     internal interface IDotNet
     {
-        bool RestoreProjectToDirectory(string project, string directory, string? pathToNugetConfig = null);
-        bool RestoreSolutionToDirectory(string solution, string directory, out IList<string> projects);
+        bool RestoreProjectToDirectory(string project, string directory, out string stdout, string? pathToNugetConfig = null);
+        bool RestoreSolutionToDirectory(string solutionFile, string packageDirectory, out IEnumerable<string> projects);
         bool New(string folder);
         bool AddPackage(string folder, string package);
         IList<string> GetListedRuntimes();

--- a/csharp/extractor/Semmle.Extraction.Tests/FileContent.cs
+++ b/csharp/extractor/Semmle.Extraction.Tests/FileContent.cs
@@ -1,6 +1,5 @@
 using Xunit;
 using System.Collections.Generic;
-using System.Linq;
 using Semmle.Util.Logging;
 using Semmle.Extraction.CSharp.DependencyFetching;
 

--- a/csharp/extractor/Semmle.Extraction.Tests/Runtime.cs
+++ b/csharp/extractor/Semmle.Extraction.Tests/Runtime.cs
@@ -18,7 +18,13 @@ namespace Semmle.Extraction.Tests
 
         public bool New(string folder) => true;
 
-        public bool RestoreToDirectory(string project, string directory, string? pathToNugetConfig = null) => true;
+        public bool RestoreProjectToDirectory(string project, string directory, string? pathToNugetConfig = null) => true;
+
+        public bool RestoreSolutionToDirectory(string solution, string directory, out IList<string> projects)
+        {
+            projects = new List<string>();
+            return true;
+        }
 
         public IList<string> GetListedRuntimes() => runtimes;
 

--- a/csharp/extractor/Semmle.Extraction.Tests/Runtime.cs
+++ b/csharp/extractor/Semmle.Extraction.Tests/Runtime.cs
@@ -1,4 +1,5 @@
 using Xunit;
+using System;
 using System.Collections.Generic;
 using Semmle.Extraction.CSharp.DependencyFetching;
 
@@ -18,11 +19,15 @@ namespace Semmle.Extraction.Tests
 
         public bool New(string folder) => true;
 
-        public bool RestoreProjectToDirectory(string project, string directory, string? pathToNugetConfig = null) => true;
-
-        public bool RestoreSolutionToDirectory(string solution, string directory, out IList<string> projects)
+        public bool RestoreProjectToDirectory(string project, string directory, out string stdout, string? pathToNugetConfig = null)
         {
-            projects = new List<string>();
+            stdout = "";
+            return true;
+        }
+
+        public bool RestoreSolutionToDirectory(string solution, string directory, out IEnumerable<string> projects)
+        {
+            projects = Array.Empty<string>();
             return true;
         }
 


### PR DESCRIPTION
In this PR we do the following performance optimisations to the *dependency manager*.
- If solution file(s) are restored then we don't explictly restore projects that are up to date with respect to `dotnet restore` (after restoring the solution).
- `dotnet restore` on projects are executed in parallel.

A couple of implementation details
- We need to change the `dotnet restore` verbosity level to `normal` when restoring solutions to get all the relevant information related to restored projects.
- The `DotNet.cs` file is starting to contain business logic. In https://github.com/github/codeql/pull/14142 we re-factor `DotNet.cs` to enable unit testing.


The changes have been tested on `OrchardCMS/OrchardCore` as it contains a solution file.
The numbers below show that we get the same accuracy for the comparison queries, but the wall clock time drops from approximately 16m to 9m (on my machine).

On *main* we have:
----------------------------------------

Results for OrchardCMS/OrchardCore
 Query Files.ql:
  Result count - both/traced/standalone: 4151/3692/20
 Query Declarations.ql:
  Result count - both/traced/standalone: 69128/84740/113
  Result count in the matching 4151 files - both/traced/standalone: 69128/0/0
   Matching 100.0%
 Query Dependencies.ql:
  Result count - both/traced/standalone: 491/2/229
 Query CallTargets.ql:
  Result count - both/traced/standalone: 87430/264261/213
  Result count in the matching 4151 files - both/traced/standalone: 87430/1523/154
   Matching 98.12%
 Query TypeHierarchy.ql:
  Result count - both/traced/standalone: 6351/4027/23
  Result count in the matching 4151 files - both/traced/standalone: 6351/7/5
   Matching 99.81%
 Query Expressions.ql:
  Result count - both/traced/standalone: 311660/1070097/1049
  Result count in the matching 4151 files - both/traced/standalone: 311660/6370/870
   Matching 97.73%
 Query VariableAccesses.ql:
  Result count - both/traced/standalone: 86270/193815/39
  Result count in the matching 4151 files - both/traced/standalone: 86270/363/0
   Matching 99.58%
 Query TypeMentions.ql:
  Result count - both/traced/standalone: 86709/131893/396
  Result count in the matching 4151 files - both/traced/standalone: 86709/1439/319
   Matching 98.01%

python3 diff_standalone.py  1510.23s user 299.76s system 188% cpu 15:58.18 total


On the *feature* branch including the unit test re-factor we have
----------------------------------------

Results for OrchardCMS/OrchardCore
 Query Files.ql:
  Result count - both/traced/standalone: 4151/3692/20
 Query Declarations.ql:
  Result count - both/traced/standalone: 69128/84740/113
  Result count in the matching 4151 files - both/traced/standalone: 69128/0/0
   Matching 100.0%
 Query Dependencies.ql:
  Result count - both/traced/standalone: 491/2/229
 Query CallTargets.ql:
  Result count - both/traced/standalone: 87439/264252/206
  Result count in the matching 4151 files - both/traced/standalone: 87439/1514/147
   Matching 98.14%
 Query TypeHierarchy.ql:
  Result count - both/traced/standalone: 6351/4027/23
  Result count in the matching 4151 files - both/traced/standalone: 6351/7/5
   Matching 99.81%
 Query Expressions.ql:
  Result count - both/traced/standalone: 311657/1070100/1056
  Result count in the matching 4151 files - both/traced/standalone: 311657/6373/877
   Matching 97.73%
 Query VariableAccesses.ql:
  Result count - both/traced/standalone: 86271/193814/39
  Result count in the matching 4151 files - both/traced/standalone: 86271/362/0
   Matching 99.58%
 Query TypeMentions.ql:
  Result count - both/traced/standalone: 86709/131893/396
  Result count in the matching 4151 files - both/traced/standalone: 86709/1439/319
   Matching 98.01%

python3 diff_standalone.py  1107.11s user 143.95s system 234% cpu 8:53.80 total

