### PR TITLE
Py: add sanitizer guard for `url_has_allowed_host_and_scheme`

### DIFF
--- a/python/ql/lib/semmle/python/frameworks/Django.qll
+++ b/python/ql/lib/semmle/python/frameworks/Django.qll
@@ -15,6 +15,7 @@ private import semmle.python.regex
 private import semmle.python.frameworks.internal.PoorMansFunctionResolution
 private import semmle.python.frameworks.internal.SelfRefMixin
 private import semmle.python.frameworks.internal.InstanceTaintStepsHelper
+private import semmle.python.security.dataflow.UrlRedirectCustomizations
 
 /**
  * INTERNAL: Do not use.
@@ -2787,5 +2788,32 @@ module PrivateDjango {
     override Function getRequestHandler() { result = function }
 
     override predicate csrfEnabled() { decoratorName in ["csrf_protect", "requires_csrf_token"] }
+  }
+
+  private predicate djangoUrlHasAllowedHostAndScheme(
+    DataFlow::GuardNode g, ControlFlowNode node, boolean branch
+  ) {
+    exists(API::CallNode call |
+      call =
+        API::moduleImport("django")
+            .getMember("utils")
+            .getMember("http")
+            .getMember("url_has_allowed_host_and_scheme")
+            .getACall() and
+      g = call.asCfgNode() and
+      node = call.getParameter(0, "url").asSink().asCfgNode() and
+      branch = true
+    )
+  }
+
+  /**
+   * A call to `django.utils.http.url_has_allowed_host_and_scheme`, considered as a sanitizer-guard for URL redirection.
+   *
+   * See https://docs.djangoproject.com/en/4.2/_modules/django/utils/http/
+   */
+  private class DjangoAllowedUrl extends UrlRedirect::Sanitizer {
+    DjangoAllowedUrl() {
+      this = DataFlow::BarrierGuard<djangoUrlHasAllowedHostAndScheme/3>::getABarrierNode()
+    }
   }
 }

--- a/python/ql/lib/semmle/python/security/dataflow/UrlRedirectCustomizations.qll
+++ b/python/ql/lib/semmle/python/security/dataflow/UrlRedirectCustomizations.qll
@@ -70,31 +70,4 @@ module UrlRedirect {
    * A comparison with a constant string, considered as a sanitizer-guard.
    */
   class StringConstCompareAsSanitizerGuard extends Sanitizer, StringConstCompareBarrier { }
-
-  private import semmle.python.ApiGraphs
-
-  private predicate djangoUrlHasAllowedHostAndScheme(
-    DataFlow::GuardNode g, ControlFlowNode node, boolean branch
-  ) {
-    exists(API::CallNode call |
-      call =
-        API::moduleImport("django")
-            .getMember("utils")
-            .getMember("http")
-            .getMember("url_has_allowed_host_and_scheme")
-            .getACall() and
-      g = call.asCfgNode() and
-      node = call.getParameter(0, "url").asSink().asCfgNode() and
-      branch = true
-    )
-  }
-
-  /**
-   * A call to `django.utils.http.url_has_allowed_host_and_scheme`, considered as a sanitizer-guard.
-   */
-  private class DjangoAllowedUrl extends Sanitizer {
-    DjangoAllowedUrl() {
-      this = DataFlow::BarrierGuard<djangoUrlHasAllowedHostAndScheme/3>::getABarrierNode()
-    }
-  }
 }

--- a/python/ql/lib/semmle/python/security/dataflow/UrlRedirectCustomizations.qll
+++ b/python/ql/lib/semmle/python/security/dataflow/UrlRedirectCustomizations.qll
@@ -70,4 +70,31 @@ module UrlRedirect {
    * A comparison with a constant string, considered as a sanitizer-guard.
    */
   class StringConstCompareAsSanitizerGuard extends Sanitizer, StringConstCompareBarrier { }
+
+  private import semmle.python.ApiGraphs
+
+  private predicate djangoUrlHasAllowedHostAndScheme(
+    DataFlow::GuardNode g, ControlFlowNode node, boolean branch
+  ) {
+    exists(API::CallNode call |
+      call =
+        API::moduleImport("django")
+            .getMember("utils")
+            .getMember("http")
+            .getMember("url_has_allowed_host_and_scheme")
+            .getACall() and
+      g = call.asCfgNode() and
+      node = call.getParameter(0, "url").asSink().asCfgNode() and
+      branch = true
+    )
+  }
+
+  /**
+   * A call to `django.utils.http.url_has_allowed_host_and_scheme`, considered as a sanitizer-guard.
+   */
+  private class DjangoAllowedUrl extends Sanitizer {
+    DjangoAllowedUrl() {
+      this = DataFlow::BarrierGuard<djangoUrlHasAllowedHostAndScheme/3>::getABarrierNode()
+    }
+  }
 }

--- a/python/ql/src/change-notes/2023-09-13-django-url-allowed-host.md
+++ b/python/ql/src/change-notes/2023-09-13-django-url-allowed-host.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Improved _URL redirection from remote source_ (`py/url-redirection`) query to not alert when URL has been checked with `django.utils.http. url_has_allowed_host_and_scheme`.

--- a/python/ql/test/query-tests/Security/CWE-601-UrlRedirect/UrlRedirect.expected
+++ b/python/ql/test/query-tests/Security/CWE-601-UrlRedirect/UrlRedirect.expected
@@ -49,7 +49,6 @@ edges
 | test.py:81:17:81:46 | ControlFlowNode for Attribute() | test.py:81:5:81:13 | SSA variable untrusted |
 | test.py:82:5:82:10 | SSA variable unsafe | test.py:83:21:83:26 | ControlFlowNode for unsafe |
 | test.py:90:5:90:13 | SSA variable untrusted | test.py:93:18:93:26 | ControlFlowNode for untrusted |
-| test.py:90:5:90:13 | SSA variable untrusted | test.py:95:25:95:33 | ControlFlowNode for untrusted |
 | test.py:90:17:90:23 | ControlFlowNode for request | test.py:90:17:90:28 | ControlFlowNode for Attribute |
 | test.py:90:17:90:28 | ControlFlowNode for Attribute | test.py:90:17:90:46 | ControlFlowNode for Attribute() |
 | test.py:90:17:90:46 | ControlFlowNode for Attribute() | test.py:90:5:90:13 | SSA variable untrusted |
@@ -108,7 +107,6 @@ nodes
 | test.py:90:17:90:28 | ControlFlowNode for Attribute | semmle.label | ControlFlowNode for Attribute |
 | test.py:90:17:90:46 | ControlFlowNode for Attribute() | semmle.label | ControlFlowNode for Attribute() |
 | test.py:93:18:93:26 | ControlFlowNode for untrusted | semmle.label | ControlFlowNode for untrusted |
-| test.py:95:25:95:33 | ControlFlowNode for untrusted | semmle.label | ControlFlowNode for untrusted |
 subpaths
 #select
 | test.py:8:21:8:26 | ControlFlowNode for target | test.py:1:26:1:32 | ControlFlowNode for ImportMember | test.py:8:21:8:26 | ControlFlowNode for target | Untrusted URL redirection depends on a $@. | test.py:1:26:1:32 | ControlFlowNode for ImportMember | user-provided value |
@@ -120,4 +118,3 @@ subpaths
 | test.py:76:21:76:26 | ControlFlowNode for unsafe | test.py:1:26:1:32 | ControlFlowNode for ImportMember | test.py:76:21:76:26 | ControlFlowNode for unsafe | Untrusted URL redirection depends on a $@. | test.py:1:26:1:32 | ControlFlowNode for ImportMember | user-provided value |
 | test.py:83:21:83:26 | ControlFlowNode for unsafe | test.py:1:26:1:32 | ControlFlowNode for ImportMember | test.py:83:21:83:26 | ControlFlowNode for unsafe | Untrusted URL redirection depends on a $@. | test.py:1:26:1:32 | ControlFlowNode for ImportMember | user-provided value |
 | test.py:93:18:93:26 | ControlFlowNode for untrusted | test.py:1:26:1:32 | ControlFlowNode for ImportMember | test.py:93:18:93:26 | ControlFlowNode for untrusted | Untrusted URL redirection depends on a $@. | test.py:1:26:1:32 | ControlFlowNode for ImportMember | user-provided value |
-| test.py:95:25:95:33 | ControlFlowNode for untrusted | test.py:1:26:1:32 | ControlFlowNode for ImportMember | test.py:95:25:95:33 | ControlFlowNode for untrusted | Untrusted URL redirection depends on a $@. | test.py:1:26:1:32 | ControlFlowNode for ImportMember | user-provided value |

--- a/python/ql/test/query-tests/Security/CWE-601-UrlRedirect/UrlRedirect.expected
+++ b/python/ql/test/query-tests/Security/CWE-601-UrlRedirect/UrlRedirect.expected
@@ -8,6 +8,7 @@ edges
 | test.py:1:26:1:32 | GSSA Variable request | test.py:67:17:67:23 | ControlFlowNode for request |
 | test.py:1:26:1:32 | GSSA Variable request | test.py:74:17:74:23 | ControlFlowNode for request |
 | test.py:1:26:1:32 | GSSA Variable request | test.py:81:17:81:23 | ControlFlowNode for request |
+| test.py:1:26:1:32 | GSSA Variable request | test.py:90:17:90:23 | ControlFlowNode for request |
 | test.py:7:5:7:10 | SSA variable target | test.py:8:21:8:26 | ControlFlowNode for target |
 | test.py:7:14:7:20 | ControlFlowNode for request | test.py:7:14:7:25 | ControlFlowNode for Attribute |
 | test.py:7:14:7:25 | ControlFlowNode for Attribute | test.py:7:14:7:43 | ControlFlowNode for Attribute() |
@@ -47,6 +48,11 @@ edges
 | test.py:81:17:81:28 | ControlFlowNode for Attribute | test.py:81:17:81:46 | ControlFlowNode for Attribute() |
 | test.py:81:17:81:46 | ControlFlowNode for Attribute() | test.py:81:5:81:13 | SSA variable untrusted |
 | test.py:82:5:82:10 | SSA variable unsafe | test.py:83:21:83:26 | ControlFlowNode for unsafe |
+| test.py:90:5:90:13 | SSA variable untrusted | test.py:93:18:93:26 | ControlFlowNode for untrusted |
+| test.py:90:5:90:13 | SSA variable untrusted | test.py:95:25:95:33 | ControlFlowNode for untrusted |
+| test.py:90:17:90:23 | ControlFlowNode for request | test.py:90:17:90:28 | ControlFlowNode for Attribute |
+| test.py:90:17:90:28 | ControlFlowNode for Attribute | test.py:90:17:90:46 | ControlFlowNode for Attribute() |
+| test.py:90:17:90:46 | ControlFlowNode for Attribute() | test.py:90:5:90:13 | SSA variable untrusted |
 nodes
 | test.py:1:26:1:32 | ControlFlowNode for ImportMember | semmle.label | ControlFlowNode for ImportMember |
 | test.py:1:26:1:32 | GSSA Variable request | semmle.label | GSSA Variable request |
@@ -97,6 +103,12 @@ nodes
 | test.py:81:17:81:46 | ControlFlowNode for Attribute() | semmle.label | ControlFlowNode for Attribute() |
 | test.py:82:5:82:10 | SSA variable unsafe | semmle.label | SSA variable unsafe |
 | test.py:83:21:83:26 | ControlFlowNode for unsafe | semmle.label | ControlFlowNode for unsafe |
+| test.py:90:5:90:13 | SSA variable untrusted | semmle.label | SSA variable untrusted |
+| test.py:90:17:90:23 | ControlFlowNode for request | semmle.label | ControlFlowNode for request |
+| test.py:90:17:90:28 | ControlFlowNode for Attribute | semmle.label | ControlFlowNode for Attribute |
+| test.py:90:17:90:46 | ControlFlowNode for Attribute() | semmle.label | ControlFlowNode for Attribute() |
+| test.py:93:18:93:26 | ControlFlowNode for untrusted | semmle.label | ControlFlowNode for untrusted |
+| test.py:95:25:95:33 | ControlFlowNode for untrusted | semmle.label | ControlFlowNode for untrusted |
 subpaths
 #select
 | test.py:8:21:8:26 | ControlFlowNode for target | test.py:1:26:1:32 | ControlFlowNode for ImportMember | test.py:8:21:8:26 | ControlFlowNode for target | Untrusted URL redirection depends on a $@. | test.py:1:26:1:32 | ControlFlowNode for ImportMember | user-provided value |
@@ -107,3 +119,5 @@ subpaths
 | test.py:69:21:69:26 | ControlFlowNode for unsafe | test.py:1:26:1:32 | ControlFlowNode for ImportMember | test.py:69:21:69:26 | ControlFlowNode for unsafe | Untrusted URL redirection depends on a $@. | test.py:1:26:1:32 | ControlFlowNode for ImportMember | user-provided value |
 | test.py:76:21:76:26 | ControlFlowNode for unsafe | test.py:1:26:1:32 | ControlFlowNode for ImportMember | test.py:76:21:76:26 | ControlFlowNode for unsafe | Untrusted URL redirection depends on a $@. | test.py:1:26:1:32 | ControlFlowNode for ImportMember | user-provided value |
 | test.py:83:21:83:26 | ControlFlowNode for unsafe | test.py:1:26:1:32 | ControlFlowNode for ImportMember | test.py:83:21:83:26 | ControlFlowNode for unsafe | Untrusted URL redirection depends on a $@. | test.py:1:26:1:32 | ControlFlowNode for ImportMember | user-provided value |
+| test.py:93:18:93:26 | ControlFlowNode for untrusted | test.py:1:26:1:32 | ControlFlowNode for ImportMember | test.py:93:18:93:26 | ControlFlowNode for untrusted | Untrusted URL redirection depends on a $@. | test.py:1:26:1:32 | ControlFlowNode for ImportMember | user-provided value |
+| test.py:95:25:95:33 | ControlFlowNode for untrusted | test.py:1:26:1:32 | ControlFlowNode for ImportMember | test.py:95:25:95:33 | ControlFlowNode for untrusted | Untrusted URL redirection depends on a $@. | test.py:1:26:1:32 | ControlFlowNode for ImportMember | user-provided value |

--- a/python/ql/test/query-tests/Security/CWE-601-UrlRedirect/test.py
+++ b/python/ql/test/query-tests/Security/CWE-601-UrlRedirect/test.py
@@ -92,6 +92,6 @@ def ok6():
     if math.random() > 0.5:
         redirect(untrusted, code=302) # NOT OK
     if url_has_allowed_host_and_scheme(untrusted, allowed_hosts=None):
-        return redirect(untrusted, code=302) # OK - but is flagged!
+        return redirect(untrusted, code=302) # OK
     
     return redirect("https://example.com", code=302) # OK

--- a/python/ql/test/query-tests/Security/CWE-601-UrlRedirect/test.py
+++ b/python/ql/test/query-tests/Security/CWE-601-UrlRedirect/test.py
@@ -81,3 +81,17 @@ def not_ok4():
     untrusted = request.args.get('target', '')
     unsafe = "%s?login=success" % untrusted
     return redirect(unsafe, code=302)
+
+from django.utils.http import url_has_allowed_host_and_scheme
+import math 
+
+@app.route('/ok6')
+def ok6():
+    untrusted = request.args.get('target', '')
+    # random chance. 
+    if math.random() > 0.5:
+        redirect(untrusted, code=302) # NOT OK
+    if url_has_allowed_host_and_scheme(untrusted, allowed_hosts=None):
+        return redirect(untrusted, code=302) # OK - but is flagged!
+    
+    return redirect("https://example.com", code=302) # OK


### PR DESCRIPTION
Inspired by what to me looks like a clear FP ([MRVA link](https://gist.github.com/erik-krogh/362438a56ed66c2f79916bbfd0799104)).  

The sanitizer seems decently used: https://github.com/search?type=code&q=%22url_has_allowed_host_and_scheme%22+path%3A*.py

Do you usually put implementations like this in the framework models, or directly in the `*Query.qll` file? 
I can move it to `Django.qll` if you want to, but to follow the existing format I would have to create a new `utils` module in `Django.qll`. 

[Evaluation looks good](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/PR-14112-0-python/reports), and seems to remove an FP. 