### PR TITLE
Kotlin: Make it possible to build with master

### DIFF
--- a/java/kotlin-extractor/build.py
+++ b/java/kotlin-extractor/build.py
@@ -92,6 +92,7 @@ def compile_to_dir(build_dir, srcs, classpath, java_classpath, output):
     kotlin_arg_file = build_dir + '/kotlin.args'
     kotlin_args = ['-Werror',
                    '-opt-in=kotlin.RequiresOptIn',
+                   '-opt-in=org.jetbrains.kotlin.ir.symbols.IrSymbolInternals',
                    '-d', output,
                    '-module-name', 'codeql-kotlin-extractor',
                    '-no-reflect', '-no-stdlib',

--- a/java/kotlin-extractor/build.py
+++ b/java/kotlin-extractor/build.py
@@ -169,7 +169,7 @@ def compile(jars, java_jars, dependency_folder, transform_to_embeddable, output,
         shutil.rmtree(tmp_src_dir)
     shutil.copytree('src', tmp_src_dir)
 
-    include_version_folder = tmp_src_dir + '/main/kotlin/utils/versions/to_include'
+    include_version_folder = tmp_src_dir + '/main/kotlin/utils/this_version'
     os.makedirs(include_version_folder)
 
     resource_dir = tmp_src_dir + '/main/resources/com/github/codeql'
@@ -193,11 +193,7 @@ def compile(jars, java_jars, dependency_folder, transform_to_embeddable, output,
                 shutil.copytree(d, include_version_folder, dirs_exist_ok=True)
 
     # remove all version folders:
-    for version in kotlin_plugin_versions.many_versions:
-        d = tmp_src_dir + '/main/kotlin/utils/versions/v_' + \
-            version.replace('.', '_')
-        if os.path.exists(d):
-            shutil.rmtree(d)
+    shutil.rmtree(tmp_src_dir + '/main/kotlin/utils/versions')
 
     srcs = find_sources(tmp_src_dir)
 

--- a/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
@@ -107,7 +107,7 @@ open class KotlinFileExtractor(
     fun extractFileContents(file: IrFile, id: Label<DbFile>) {
         with("file", file) {
             val locId = tw.getWholeFileLocation()
-            val pkg = file.fqName.asString()
+            val pkg = file.packageFqName.asString()
             val pkgId = extractPackage(pkg)
             tw.writeHasLocation(id, locId)
             tw.writeCupackage(id, pkgId)
@@ -1901,8 +1901,9 @@ open class KotlinFileExtractor(
             verboseln("No match as didn't find target package")
             return false
         }
-        if (targetPkg.fqName.asString() != pName) {
-            verboseln("No match as package name is ${targetPkg.fqName.asString()}")
+        val targetName = targetPkg.packageFqName.asString()
+        if (targetName != pName) {
+            verboseln("No match as package name is $targetName")
             return false
         }
         verboseln("Match")
@@ -2556,8 +2557,9 @@ open class KotlinFileExtractor(
             verboseln("No match as didn't find target package")
             return false
         }
-        if (targetPkg.fqName.asString() != pkgName) {
-            verboseln("No match as package name is ${targetPkg.fqName.asString()} not $pkgName")
+        val targetName = targetPkg.packageFqName.asString()
+        if (targetName != pkgName) {
+            verboseln("No match as package name is $targetName not $pkgName")
             return false
         }
         verboseln("Match")

--- a/java/kotlin-extractor/src/main/kotlin/KotlinUsesExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/KotlinUsesExtractor.kt
@@ -5,6 +5,7 @@ import com.github.codeql.utils.versions.codeQlWithHasQuestionMark
 import com.github.codeql.utils.versions.getFileClassFqName
 import com.github.codeql.utils.versions.getKotlinType
 import com.github.codeql.utils.versions.isRawType
+import com.github.codeql.utils.versions.packageFqName
 import com.semmle.extractor.java.OdasaOutput
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.backend.common.ir.*

--- a/java/kotlin-extractor/src/main/kotlin/KotlinUsesExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/KotlinUsesExtractor.kt
@@ -83,7 +83,7 @@ open class KotlinUsesExtractor(
     )
 
     fun extractFileClass(f: IrFile): Label<out DbClassorinterface> {
-        val pkg = f.fqName.asString()
+        val pkg = f.packageFqName.asString()
         val jvmName = getFileClassName(f)
         val id = extractFileClass(pkg, jvmName)
         if (tw.lm.fileClassLocationsExtracted.add(f)) {
@@ -848,7 +848,7 @@ open class KotlinUsesExtractor(
         when(dp) {
             is IrFile ->
                 if(canBeTopLevel) {
-                    usePackage(dp.fqName.asString())
+                    usePackage(dp.packageFqName.asString())
                 } else {
                     extractFileClass(dp)
                 }

--- a/java/kotlin-extractor/src/main/kotlin/MetaAnnotationSupport.kt
+++ b/java/kotlin-extractor/src/main/kotlin/MetaAnnotationSupport.kt
@@ -276,8 +276,8 @@ class MetaAnnotationSupport(private val logger: FileLogger, private val pluginCo
             run { logger.warnElement("Expected property's parent class to have a receiver parameter", parentClass); return }
             val newParam = copyParameterToFunction(thisReceiever, this)
             dispatchReceiverParameter = newParam
-            body = factory.createBlockBody(
-                UNDEFINED_OFFSET, UNDEFINED_OFFSET, listOf(
+            body = factory.createBlockBody(UNDEFINED_OFFSET, UNDEFINED_OFFSET).apply({
+                this.statements.add(
                     IrReturnImpl(
                         UNDEFINED_OFFSET, UNDEFINED_OFFSET,
                         pluginContext.irBuiltIns.nothingType,
@@ -294,7 +294,7 @@ class MetaAnnotationSupport(private val logger: FileLogger, private val pluginCo
                         )
                     )
                 )
-            )
+            })
         }
     }
 

--- a/java/kotlin-extractor/src/main/kotlin/PrimitiveTypeInfo.kt
+++ b/java/kotlin-extractor/src/main/kotlin/PrimitiveTypeInfo.kt
@@ -8,6 +8,7 @@ import org.jetbrains.kotlin.ir.types.IrSimpleType
 import org.jetbrains.kotlin.ir.types.classOrNull
 import org.jetbrains.kotlin.name.FqName
 import com.github.codeql.utils.*
+import com.github.codeql.utils.versions.packageFqName
 
 class PrimitiveTypeMapping(val logger: Logger, val pluginContext: IrPluginContext) {
     fun getPrimitiveInfo(s: IrSimpleType) =

--- a/java/kotlin-extractor/src/main/kotlin/PrimitiveTypeInfo.kt
+++ b/java/kotlin-extractor/src/main/kotlin/PrimitiveTypeInfo.kt
@@ -12,7 +12,7 @@ import com.github.codeql.utils.*
 class PrimitiveTypeMapping(val logger: Logger, val pluginContext: IrPluginContext) {
     fun getPrimitiveInfo(s: IrSimpleType) =
         s.classOrNull?.let {
-            if ((it.owner.parent as? IrPackageFragment)?.fqName == StandardNames.BUILT_INS_PACKAGE_FQ_NAME)
+            if ((it.owner.parent as? IrPackageFragment)?.packageFqName == StandardNames.BUILT_INS_PACKAGE_FQ_NAME)
                 mapping[it.owner.name]
             else
                 null

--- a/java/kotlin-extractor/src/main/kotlin/comments/CommentExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/comments/CommentExtractor.kt
@@ -3,8 +3,8 @@ package com.github.codeql.comments
 import com.github.codeql.*
 import com.github.codeql.utils.IrVisitorLookup
 import com.github.codeql.utils.isLocalFunction
+import com.github.codeql.utils.Psi2IrFacade
 import com.github.codeql.utils.versions.getPsi2Ir
-import com.github.codeql.utils.versions.Psi2IrFacade
 import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.config.KotlinCompilerVersion

--- a/java/kotlin-extractor/src/main/kotlin/utils/ClassNames.kt
+++ b/java/kotlin-extractor/src/main/kotlin/utils/ClassNames.kt
@@ -33,7 +33,7 @@ fun getFileClassName(f: IrFile) =
 fun getIrElementBinaryName(that: IrElement): String {
     if (that is IrFile) {
         val shortName = getFileClassName(that)
-        val pkg = that.fqName.asString()
+        val pkg = that.packageFqName.asString()
         return if (pkg.isEmpty()) shortName else "$pkg.$shortName"
     }
 
@@ -59,7 +59,7 @@ fun getIrElementBinaryName(that: IrElement): String {
         .forEach {
             when (it) {
                 is IrClass -> internalName.insert(0, getName(it) + "$")
-                is IrPackageFragment -> it.fqName.asString().takeIf { fqName -> fqName.isNotEmpty() }?.let { fqName -> internalName.insert(0, "$fqName.") }
+                is IrPackageFragment -> it.packageFqName.asString().takeIf { fqName -> fqName.isNotEmpty() }?.let { fqName -> internalName.insert(0, "$fqName.") }
             }
         }
     return internalName.toString()

--- a/java/kotlin-extractor/src/main/kotlin/utils/ClassNames.kt
+++ b/java/kotlin-extractor/src/main/kotlin/utils/ClassNames.kt
@@ -2,6 +2,7 @@ package com.github.codeql
 
 import com.github.codeql.utils.getJvmName
 import com.github.codeql.utils.versions.getFileClassFqName
+import com.github.codeql.utils.versions.packageFqName
 import com.intellij.openapi.vfs.StandardFileSystems
 import org.jetbrains.kotlin.load.java.sources.JavaSourceElement
 import org.jetbrains.kotlin.load.java.structure.impl.classFiles.BinaryJavaClass

--- a/java/kotlin-extractor/src/main/kotlin/utils/IrVisitorLookup.kt
+++ b/java/kotlin-extractor/src/main/kotlin/utils/IrVisitorLookup.kt
@@ -1,6 +1,6 @@
 package com.github.codeql.utils
 
-import com.github.codeql.utils.versions.Psi2IrFacade
+import com.github.codeql.utils.Psi2IrFacade
 import com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.declarations.IrDeclaration

--- a/java/kotlin-extractor/src/main/kotlin/utils/Psi2IrFacade.kt
+++ b/java/kotlin-extractor/src/main/kotlin/utils/Psi2IrFacade.kt
@@ -1,4 +1,4 @@
-package com.github.codeql.utils.versions
+package com.github.codeql.utils
 
 import com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.ir.IrElement

--- a/java/kotlin-extractor/src/main/kotlin/utils/versions/v_1_4_32/IrSymbolInternals.kt
+++ b/java/kotlin-extractor/src/main/kotlin/utils/versions/v_1_4_32/IrSymbolInternals.kt
@@ -1,0 +1,4 @@
+package org.jetbrains.kotlin.ir.symbols
+
+@RequiresOptIn(level = RequiresOptIn.Level.WARNING)
+annotation class IrSymbolInternals

--- a/java/kotlin-extractor/src/main/kotlin/utils/versions/v_1_4_32/Psi2Ir.kt
+++ b/java/kotlin-extractor/src/main/kotlin/utils/versions/v_1_4_32/Psi2Ir.kt
@@ -1,3 +1,5 @@
 package com.github.codeql.utils.versions
 
+import com.github.codeql.utils.Psi2IrFacade
+
 fun getPsi2Ir(): Psi2IrFacade? = null

--- a/java/kotlin-extractor/src/main/kotlin/utils/versions/v_1_4_32/packageFqName.kt
+++ b/java/kotlin-extractor/src/main/kotlin/utils/versions/v_1_4_32/packageFqName.kt
@@ -1,0 +1,10 @@
+package com.github.codeql.utils.versions
+
+import org.jetbrains.kotlin.ir.declarations.*
+import org.jetbrains.kotlin.name.FqName
+
+val IrFile.packageFqName: FqName
+    get() = this.fqName
+
+val IrPackageFragment.packageFqName: FqName
+    get() = this.fqName

--- a/java/kotlin-extractor/src/main/kotlin/utils/versions/v_1_5_20/Psi2Ir.kt
+++ b/java/kotlin-extractor/src/main/kotlin/utils/versions/v_1_5_20/Psi2Ir.kt
@@ -6,6 +6,7 @@ import org.jetbrains.kotlin.backend.jvm.ir.getKtFile
 import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.declarations.IrFile
 import org.jetbrains.kotlin.psi.KtFile
+import com.github.codeql.utils.Psi2IrFacade
 
 fun getPsi2Ir(): Psi2IrFacade? = Psi2Ir()
 

--- a/java/kotlin-extractor/src/main/kotlin/utils/versions/v_1_9_255/IrSymbolInternals.kt
+++ b/java/kotlin-extractor/src/main/kotlin/utils/versions/v_1_9_255/IrSymbolInternals.kt
@@ -1,0 +1,4 @@
+package com.github.codeql
+
+// The compiler provides the annotation class, so we don't need to do
+// anything

--- a/java/kotlin-extractor/src/main/kotlin/utils/versions/v_1_9_255/packageFqName.kt
+++ b/java/kotlin-extractor/src/main/kotlin/utils/versions/v_1_9_255/packageFqName.kt
@@ -1,0 +1,3 @@
+package com.github.codeql
+
+// The compiler provides packageFqName, so we don't need to do anything


### PR DESCRIPTION
Fixes `error: using 'fqName: FqName' is an error. Please use `packageFqName` instead`, stops us using a deprecated `createBlockBody`, and opts us in to `IrSymbolInternals`.