### PR TITLE
Dynamic: add TypeModel.isTypeUsed

### DIFF
--- a/javascript/ql/lib/semmle/javascript/dataflow/internal/DataFlowNode.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/internal/DataFlowNode.qll
@@ -5,6 +5,7 @@
  */
 
 private import javascript
+private import semmle.javascript.frameworks.data.ModelsAsData
 
 /**
  * The raw data type underlying `DataFlow::Node`.
@@ -32,4 +33,10 @@ newtype TNode =
   TExceptionalInvocationReturnNode(InvokeExpr e) or
   TGlobalAccessPathRoot() or
   TTemplatePlaceholderTag(Templating::TemplatePlaceholderTag tag) or
-  TReflectiveParametersNode(Function f)
+  TReflectiveParametersNode(Function f) or
+  TForbiddenRecursionGuard() {
+    none() and
+    // We want to prune irrelevant models before materialising data flow nodes, so types contributed
+    // directly from CodeQL must expose their pruning info without depending on data flow nodes.
+    (any(ModelInput::TypeModel tm).isTypeUsed("") implies any())
+  }

--- a/javascript/ql/lib/semmle/javascript/frameworks/data/internal/ApiGraphModels.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/data/internal/ApiGraphModels.qll
@@ -160,7 +160,18 @@ module ModelInput {
    */
   class TypeModel extends Unit {
     /**
+     * Holds if any of the other predicates in this class might have a result
+     * for the given `type`.
+     *
+     * The implementation of this predicate should not depend on `DataFlow::Node`.
+     */
+    bindingset[type]
+    predicate isTypeUsed(string type) { none() }
+
+    /**
      * Gets a data-flow node that is a source of the given `type`.
+     *
+     * Note that `type` should also be included in `isTypeUsed`.
      *
      * This must not depend on API graphs, but ensures that an API node is generated for
      * the source.
@@ -171,6 +182,8 @@ module ModelInput {
      * Gets a data-flow node that is a sink of the given `type`,
      * usually because it is an argument passed to a parameter of that type.
      *
+     * Note that `type` should also be included in `isTypeUsed`.
+     *
      * This must not depend on API graphs, but ensures that an API node is generated for
      * the sink.
      */
@@ -178,6 +191,8 @@ module ModelInput {
 
     /**
      * Gets an API node that is a source or sink of the given `type`.
+     *
+     * Note that `type` should also be included in `isTypeUsed`.
      *
      * Unlike `getASource` and `getASink`, this may depend on API graphs.
      */
@@ -301,6 +316,8 @@ predicate isRelevantType(string type) {
   ) and
   (
     Specific::isTypeUsed(type)
+    or
+    any(TypeModel model).isTypeUsed(type)
     or
     exists(TestAllModels t)
   )

--- a/javascript/ql/test/library-tests/frameworks/data/test.expected
+++ b/javascript/ql/test/library-tests/frameworks/data/test.expected
@@ -1,4 +1,5 @@
 consistencyIssue
+| library-tests/frameworks/data/test.js:261 | expected an alert, but found none | NOT OK |  |
 taintFlow
 | paramDecorator.ts:6:54:6:54 | x | paramDecorator.ts:7:10:7:10 | x |
 | test.js:5:30:5:37 | source() | test.js:5:8:5:38 | testlib ... urce()) |

--- a/javascript/ql/test/library-tests/frameworks/data/test.expected
+++ b/javascript/ql/test/library-tests/frameworks/data/test.expected
@@ -1,5 +1,4 @@
 consistencyIssue
-| library-tests/frameworks/data/test.js:261 | expected an alert, but found none | NOT OK |  |
 taintFlow
 | paramDecorator.ts:6:54:6:54 | x | paramDecorator.ts:7:10:7:10 | x |
 | test.js:5:30:5:37 | source() | test.js:5:8:5:38 | testlib ... urce()) |
@@ -75,6 +74,7 @@ taintFlow
 | test.js:249:28:249:35 | source() | test.js:249:28:249:35 | source() |
 | test.js:252:15:252:22 | source() | test.js:252:15:252:22 | source() |
 | test.js:254:32:254:39 | source() | test.js:254:32:254:39 | source() |
+| test.js:261:8:261:31 | "danger ... .danger | test.js:261:8:261:31 | "danger ... .danger |
 isSink
 | test.js:54:18:54:25 | source() | test-sink |
 | test.js:55:22:55:29 | source() | test-sink |

--- a/javascript/ql/test/library-tests/frameworks/data/test.js
+++ b/javascript/ql/test/library-tests/frameworks/data/test.js
@@ -256,3 +256,9 @@ function fuzzy() {
   fuzzyCall(source()); // OK - does not come from 'testlib'
   require('blah').fuzzyCall(source()); // OK - does not come from 'testlib'
 }
+
+function dangerConstant() {
+  sink("danger-constant".danger); // NOT OK
+  sink("danger-constant".safe); // OK
+  sink("danger-constant"); // OK
+}

--- a/javascript/ql/test/library-tests/frameworks/data/test.ql
+++ b/javascript/ql/test/library-tests/frameworks/data/test.ql
@@ -85,6 +85,8 @@ class Sources extends ModelInput::SourceModelCsv {
 }
 
 class TypeModelFromCodeQL extends ModelInput::TypeModel {
+  override predicate isTypeUsed(string type) { type = "danger-constant" }
+
   override DataFlow::Node getASource(string type) {
     type = "danger-constant" and
     result.getStringValue() = "danger-constant"

--- a/javascript/ql/test/library-tests/frameworks/data/test.ql
+++ b/javascript/ql/test/library-tests/frameworks/data/test.ql
@@ -84,6 +84,17 @@ class Sources extends ModelInput::SourceModelCsv {
   }
 }
 
+class TypeModelFromCodeQL extends ModelInput::TypeModel {
+  override DataFlow::Node getASource(string type) {
+    type = "danger-constant" and
+    result.getStringValue() = "danger-constant"
+  }
+}
+
+class SourceFromDangerConstant extends ModelInput::SourceModelCsv {
+  override predicate row(string row) { row = "danger-constant;Member[danger];test-source" }
+}
+
 class BasicTaintTracking extends TaintTracking::Configuration {
   BasicTaintTracking() { this = "BasicTaintTracking" }
 

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowPublic.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowPublic.qll
@@ -9,6 +9,7 @@ import Attributes
 import LocalSources
 private import semmle.python.essa.SsaCompute
 private import semmle.python.dataflow.new.internal.ImportStar
+private import semmle.python.frameworks.data.ModelsAsData
 private import FlowSummaryImpl as FlowSummaryImpl
 
 /**
@@ -115,6 +116,12 @@ newtype TNode =
   /** A synthetic node to allow flow to keyword parameters from a `**kwargs` argument. */
   TSynthDictSplatParameterNode(DataFlowCallable callable) {
     exists(ParameterPosition ppos | ppos.isKeyword(_) | exists(callable.getParameter(ppos)))
+  } or
+  TForbiddenRecursionGuard() {
+    none() and
+    // We want to prune irrelevant models before materialising data flow nodes, so types contributed
+    // directly from CodeQL must expose their pruning info without depending on data flow nodes.
+    (any(ModelInput::TypeModel tm).isTypeUsed("") implies any())
   }
 
 /** Helper for `Node::getEnclosingCallable`. */

--- a/python/ql/lib/semmle/python/frameworks/data/internal/ApiGraphModels.qll
+++ b/python/ql/lib/semmle/python/frameworks/data/internal/ApiGraphModels.qll
@@ -160,7 +160,18 @@ module ModelInput {
    */
   class TypeModel extends Unit {
     /**
+     * Holds if any of the other predicates in this class might have a result
+     * for the given `type`.
+     *
+     * The implementation of this predicate should not depend on `DataFlow::Node`.
+     */
+    bindingset[type]
+    predicate isTypeUsed(string type) { none() }
+
+    /**
      * Gets a data-flow node that is a source of the given `type`.
+     *
+     * Note that `type` should also be included in `isTypeUsed`.
      *
      * This must not depend on API graphs, but ensures that an API node is generated for
      * the source.
@@ -171,6 +182,8 @@ module ModelInput {
      * Gets a data-flow node that is a sink of the given `type`,
      * usually because it is an argument passed to a parameter of that type.
      *
+     * Note that `type` should also be included in `isTypeUsed`.
+     *
      * This must not depend on API graphs, but ensures that an API node is generated for
      * the sink.
      */
@@ -178,6 +191,8 @@ module ModelInput {
 
     /**
      * Gets an API node that is a source or sink of the given `type`.
+     *
+     * Note that `type` should also be included in `isTypeUsed`.
      *
      * Unlike `getASource` and `getASink`, this may depend on API graphs.
      */
@@ -301,6 +316,8 @@ predicate isRelevantType(string type) {
   ) and
   (
     Specific::isTypeUsed(type)
+    or
+    any(TypeModel model).isTypeUsed(type)
     or
     exists(TestAllModels t)
   )

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
@@ -366,6 +366,12 @@ private module Cached {
     TSynthSplatArgumentNode(CfgNodes::ExprNodes::CallCfgNode c) {
       exists(Argument arg, ArgumentPosition pos | pos.isPositional(_) | arg.isArgumentOf(c, pos)) and
       not exists(Argument arg, ArgumentPosition pos | pos.isSplat(_) | arg.isArgumentOf(c, pos))
+    } or
+    TForbiddenRecursionGuard() {
+      none() and
+      // We want to prune irrelevant models before materialising data flow nodes, so types contributed
+      // directly from CodeQL must expose their pruning info without depending on data flow nodes.
+      (any(ModelInput::TypeModel tm).isTypeUsed("") implies any())
     }
 
   class TSourceParameterNode =

--- a/ruby/ql/lib/codeql/ruby/frameworks/data/internal/ApiGraphModels.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/data/internal/ApiGraphModels.qll
@@ -160,7 +160,18 @@ module ModelInput {
    */
   class TypeModel extends Unit {
     /**
+     * Holds if any of the other predicates in this class might have a result
+     * for the given `type`.
+     *
+     * The implementation of this predicate should not depend on `DataFlow::Node`.
+     */
+    bindingset[type]
+    predicate isTypeUsed(string type) { none() }
+
+    /**
      * Gets a data-flow node that is a source of the given `type`.
+     *
+     * Note that `type` should also be included in `isTypeUsed`.
      *
      * This must not depend on API graphs, but ensures that an API node is generated for
      * the source.
@@ -171,6 +182,8 @@ module ModelInput {
      * Gets a data-flow node that is a sink of the given `type`,
      * usually because it is an argument passed to a parameter of that type.
      *
+     * Note that `type` should also be included in `isTypeUsed`.
+     *
      * This must not depend on API graphs, but ensures that an API node is generated for
      * the sink.
      */
@@ -178,6 +191,8 @@ module ModelInput {
 
     /**
      * Gets an API node that is a source or sink of the given `type`.
+     *
+     * Note that `type` should also be included in `isTypeUsed`.
      *
      * Unlike `getASource` and `getASink`, this may depend on API graphs.
      */
@@ -301,6 +316,8 @@ predicate isRelevantType(string type) {
   ) and
   (
     Specific::isTypeUsed(type)
+    or
+    any(TypeModel model).isTypeUsed(type)
     or
     exists(TestAllModels t)
   )


### PR DESCRIPTION
There was a bug in the design of `TypeModel`, that meant when pruning models we have no way of knowing which types might be contributed via a `TypeModel`.

This PR adds a predicate `TypeModel.isTypeUsed(type)` and then implementors must use it to expose this information.
To simplify its use in simple cases, the implementor is able to use the body `any()` to disable all pruning.

We want to be able to prune irrelevant models, and in order to generate flow summaries from a model, the pruning information cannot depend on data-flow nodes. For that reason, each language now has a recursion guard that prevents `isTypeUsed` from depending on `DataFlow::Node`.