### PR TITLE
Java: Fix alert message

### DIFF
--- a/java/ql/src/Security/CWE/CWE-347/MissingJWTSignatureCheck.ql
+++ b/java/ql/src/Security/CWE/CWE-347/MissingJWTSignatureCheck.ql
@@ -16,5 +16,5 @@ import MissingJwtSignatureCheckFlow::PathGraph
 
 from MissingJwtSignatureCheckFlow::PathNode source, MissingJwtSignatureCheckFlow::PathNode sink
 where MissingJwtSignatureCheckFlow::flowPath(source, sink)
-select sink.getNode(), source, sink, "This sets a $@, but the signature is not verified.",
+select sink.getNode(), source, sink, "This parser sets a $@, but the signature is not verified.",
   source.getNode(), "JWT signing key"

--- a/java/ql/src/Security/CWE/CWE-347/MissingJWTSignatureCheck.ql
+++ b/java/ql/src/Security/CWE/CWE-347/MissingJWTSignatureCheck.ql
@@ -16,5 +16,5 @@ import MissingJwtSignatureCheckFlow::PathGraph
 
 from MissingJwtSignatureCheckFlow::PathNode source, MissingJwtSignatureCheckFlow::PathNode sink
 where MissingJwtSignatureCheckFlow::flowPath(source, sink)
-select sink.getNode(), source, sink, "This parses a $@, but the signature is not verified.",
+select sink.getNode(), source, sink, "This sets a $@, but the signature is not verified.",
   source.getNode(), "JWT signing key"


### PR DESCRIPTION
The signing key that is being set, is _not_ what is being parsed.
A _JWT_ is being parsed, that will then be verified using the set key.
(Or in our case not, because we're looking for security problems :P)

CC: @erik-krogh 