### PR TITLE
Misc: Fixup for `accept-expected-changes-from-ci.py`

### DIFF
--- a/misc/scripts/accept-expected-changes-from-ci.py
+++ b/misc/scripts/accept-expected-changes-from-ci.py
@@ -114,7 +114,7 @@ def make_patches_from_log_file(log_file_lines) -> List[Patch]:
             while True:
                 next_line = parse_log_line(next(lines))
                 # it can be the case that
-                if next_line[0] in (" ", "-", "+", "@"):
+                if next_line and next_line[0] in (" ", "-", "+", "@"):
                     lines_changed.append(next_line)
                 if "FAILED" in next_line:
                     break


### PR DESCRIPTION
Allow empty lines while looking for diff (between `---expected` and `FAILED`). This can happen when there is `Locations outside the test directory` since an empty line is printed after that warning message (this output can be interleaved with the diff due to parallel execution).

An example can be seen here: https://github.com/github/semmle-code/actions/runs/6037086053/job/16380700287#step:29:25078