### PR TITLE
C#: Explicitly quote arguments in the LUA tracer on windows.

### DIFF
--- a/csharp/ql/integration-tests/all-platforms/dotnet_run/test.py
+++ b/csharp/ql/integration-tests/all-platforms/dotnet_run/test.py
@@ -54,7 +54,6 @@ s = run_codeql_database_create_stdout(['dotnet clean', 'rm -rf test7-db', 'dotne
 check_build_out("hello, world", s)
 check_diagnostics(test_db="test8-db")
 
-
 # two arguments, no '--' (first argument quoted)
 s = run_codeql_database_create_stdout(['dotnet clean', 'rm -rf test8-db', 'dotnet run "hello world part1" part2'], "test9-db")
 check_build_out("hello world part1, part2", s)

--- a/csharp/tools/tracing-config.lua
+++ b/csharp/tools/tracing-config.lua
@@ -84,10 +84,6 @@ function RegisterExtractorPack(id)
                 dotnetRunNeedsSeparator = false
                 dotnetRunInjectionIndex = i
             end
-            -- if we encounter a whitespace, we explicitly need to quote the argument.
-            if OperatingSystem == 'windows' and arg:match('%s') then
-                argv[i] = '"' .. arg .. '"'
-            end
         end
         if match then
             local injections = { '-p:UseSharedCompilation=false', '-p:EmitCompilerGeneratedFiles=true' }

--- a/csharp/tools/tracing-config.lua
+++ b/csharp/tools/tracing-config.lua
@@ -64,7 +64,7 @@ function RegisterExtractorPack(id)
 
                 -- for `dotnet test`, we should not append `-p:UseSharedCompilation=false` to the command line
                 -- if an `exe` or `dll` is passed as an argument as the call is forwarded to vstest.
-                if testMatch and (arg:match('%.exe$') or arg:match('%.dll'))  then
+                if testMatch and (arg:match('%.exe$') or arg:match('%.dll')) then
                     match = false
                     break
                 end
@@ -110,7 +110,7 @@ function RegisterExtractorPack(id)
                     invocation = {
                         path = AbsolutifyExtractorPath(id, compilerPath),
                         arguments = {
-                            commandLineString = table.concat(argv, " ")
+                            commandLineString = ArgvToCommandLineString(argv)
                         }
                     }
                 }
@@ -174,7 +174,7 @@ function RegisterExtractorPack(id)
                     seenCompilerCall = true
                 end
                 if seenCompilerCall then
-                    table.insert(extractorArgs, '"' .. arg .. '"')
+                    table.insert(extractorArgs, arg)
                 end
             end
 
@@ -184,7 +184,7 @@ function RegisterExtractorPack(id)
                     invocation = {
                         path = AbsolutifyExtractorPath(id, extractor),
                         arguments = {
-                            commandLineString = table.concat(extractorArgs, " ")
+                            commandLineString = ArgvToCommandLineString(extractorArgs)
                         }
                     }
                 }


### PR DESCRIPTION
If quoted arguments are used these will not be respected by the LUA tracer on windows.
In this PR we explicitly quote all compiler arguments containing whitespaces (windows only) in the `dotnet` matcher.

Something similar is already being done in the `dotnet exec` matcher: https://github.com/github/codeql/blob/main/csharp/tools/tracing-config.lua#L177

