### PR TITLE
C++: Fix off-by-one in `asDefiningArgument`

### DIFF
--- a/cpp/ql/lib/change-notes/2023-09-06-as-defining-argument-off-by-one-fix.md
+++ b/cpp/ql/lib/change-notes/2023-09-06-as-defining-argument-off-by-one-fix.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The `DataFlow::asDefiningArgument` predicate now takes its argument from the range starting at `1` instead of `2`. Queries that depend on the single-parameter version of `DataFlow::asDefiningArgument` should have their arguments arguments accordingly.

--- a/cpp/ql/lib/change-notes/2023-09-06-as-defining-argument-off-by-one-fix.md
+++ b/cpp/ql/lib/change-notes/2023-09-06-as-defining-argument-off-by-one-fix.md
@@ -1,4 +1,4 @@
 ---
 category: minorAnalysis
 ---
-* The `DataFlow::asDefiningArgument` predicate now takes its argument from the range starting at `1` instead of `2`. Queries that depend on the single-parameter version of `DataFlow::asDefiningArgument` should have their arguments arguments accordingly.
+* The `DataFlow::asDefiningArgument` predicate now takes its argument from the range starting at `1` instead of `2`. Queries that depend on the single-parameter version of `DataFlow::asDefiningArgument` should have their arguments updated accordingly.

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -254,9 +254,7 @@ class Node extends TIRDataFlowNode {
    * after the `f` has returned.
    */
   Expr asDefiningArgument(int index) {
-    // Subtract one because `DefinitionByReferenceNode` is defined to be in
-    // the range `[0 ... n - 1]` for some `n` instead of `[1 ... n]`.
-    this.(DefinitionByReferenceNode).getIndirectionIndex() = index - 1 and
+    this.(DefinitionByReferenceNode).getIndirectionIndex() = index and
     result = this.(DefinitionByReferenceNode).getArgument()
   }
 


### PR DESCRIPTION
Previously, the domain of the parameter was `[2 ..]` instead of `[1 ..]`. This was confusing since all the other indirect concepts are defined in the range `[1 ..]`.

Since all of our queries and models use the version that takes 0 arguments this won't affect any results (but I'll run DCA anyway just to be safe 🤞).