### PR TITLE
Py: add new qhelp for clear-text-logging

### DIFF
--- a/python/ql/src/Security/CWE-312/CleartextLogging.qhelp
+++ b/python/ql/src/Security/CWE-312/CleartextLogging.qhelp
@@ -2,4 +2,33 @@
   "-//Semmle//qhelp//EN"
   "qhelp.dtd">
 <qhelp>
-<include src="CleartextStorage.qhelp" /></qhelp>
+
+<overview>
+
+<p>If sensitive data is written to a log entry it could be exposed to an attacker
+who gains access to the logs.</p>
+
+<p>Potential attackers can obtain sensitive user data when the log output is displayed. Additionally that data may
+expose system information such as full path names, system information, and sometimes usernames and passwords.</p>
+</overview>
+
+<recommendation>
+<p>
+Sensitive data should not be logged.
+</p>
+</recommendation>
+
+<example>
+<p>In the example the entire process environment is logged using `print`. Regular users of the production deployed application
+should not have access to this much information about the environment configuration.
+</p>
+<sample src="examples/CleartextLogging.py" />
+
+<p> In the second example the data that is logged is not sensitive.</p>
+<sample src="examples/CleartextLoggingGood.py" />
+</example>
+
+<references>
+<li>OWASP: <a href="https://owasp.org/Top10/A09_2021-Security_Logging_and_Monitoring_Failures/">Insertion of Sensitive Information into Log File</a>.</li>
+</references>
+</qhelp>

--- a/python/ql/src/Security/CWE-312/examples/CleartextLogging.py
+++ b/python/ql/src/Security/CWE-312/examples/CleartextLogging.py
@@ -1,0 +1,3 @@
+# BAD: Logging cleartext sensitive data
+import os
+print(f"[INFO] Environment: {os.environ}")

--- a/python/ql/src/Security/CWE-312/examples/CleartextLoggingGood.py
+++ b/python/ql/src/Security/CWE-312/examples/CleartextLoggingGood.py
@@ -1,0 +1,3 @@
+not_sensitive_data = {'a': 1, 'b': 2}
+# GOOD: it is fine to log data that is not sensitive
+print(f"[INFO] Some object contains: {not_sensitive_data}")


### PR DESCRIPTION
A friend of mine was trying to fix an instance of clear-text-logging in Python.  
The QHelp talked about encrypting the information, and that caused confusion.  

The QHelp for clear-text-logging is the exact same as for clear-text-storage, but I think that's wrong.  
For storage of sensitive data it makes sense to encrypt.  
But for logging of sensitive data it's better advice to just not log sensitive data at all.  

The new QHelp is copy-pasted from JavaScript, and I asked Copilot Chat to translate the examples from JS to Python.  
The result seemed good to me.  