### PR TITLE
Go: Add diagnostic for 1.21 `toolchain` error

### DIFF
--- a/go/extractor/diagnostics/diagnostics.go
+++ b/go/extractor/diagnostics/diagnostics.go
@@ -482,3 +482,14 @@ func EmitGoModVersionSupportedLowerEqualGoEnv(msg string) {
 		noLocation,
 	)
 }
+
+func EmitNewerSystemGoRequired(requiredVersion string) {
+	emitDiagnostic(
+		"go/autobuilder/newer-system-go-version-required",
+		"The Go version installed on the system is too old to support this project",
+		"At least Go version `"+requiredVersion+"` is required to build this project, but the version installed on the system is older. [Install a newer version](https://github.com/actions/setup-go#basic).",
+		severityError,
+		fullVisibility,
+		noLocation,
+	)
+}

--- a/go/extractor/extractor.go
+++ b/go/extractor/extractor.go
@@ -91,6 +91,10 @@ func ExtractWithFlags(buildFlags []string, patterns []string) error {
 	}
 	pkgs, err := packages.Load(cfg, patterns...)
 	if err != nil {
+		// the toolchain directive is only supported in Go 1.21 and above
+		if strings.Contains(err.Error(), "unknown directive: toolchain") {
+			diagnostics.EmitNewerSystemGoRequired("1.21.0")
+		}
 		return err
 	}
 	log.Println("Done running packages.Load.")


### PR DESCRIPTION
**Summary**

We keep seeing customers using advanced workflows who run into problems with their Go 1.21 projects and CodeQL in GHA environments:

- The current default version of Go on GHA images is still 1.20.
- We use the system Go toolchain under the hood to perform the build.
- Consequently, Go 1.21 projects fail to build if Go 1.21 is not explicitly installed.

This PR introduces a new diagnostic which is emitted if the `unknown directive: toolchain` error is detected to advise users that a new system version of Go is required along with a link to instructions on how to do that in a GHA workflow.