### PR TITLE
JS: tolerate out of order requests in TypeScript extractor

### DIFF
--- a/javascript/extractor/lib/typescript/src/main.ts
+++ b/javascript/extractor/lib/typescript/src/main.ts
@@ -361,7 +361,10 @@ function handleParseCommand(command: ParseCommand, checkPending = true) {
     let filename = command.filename;
     let expectedFilename = state.pendingFiles[state.pendingFileIndex];
     if (expectedFilename !== filename && checkPending) {
-        throw new Error("File requested out of order. Expected '" + expectedFilename + "' but got '" + filename + "'");
+        // File was requested out of order. This happens in rare cases because the Java process decided against extracting it,
+        // for example because it was too large. Just recover and accept that some work was wasted.
+        state.pendingResponse = null;
+        state.pendingFileIndex = state.pendingFiles.indexOf(filename);
     }
     ++state.pendingFileIndex;
     let response = state.pendingResponse || extractFile(command.filename);

--- a/javascript/ql/src/change-notes/2023-09-08-tolerate-out-of-order-requests.md
+++ b/javascript/ql/src/change-notes/2023-09-08-tolerate-out-of-order-requests.md
@@ -1,0 +1,4 @@
+---
+category: fix
+---
+* Fixed an extractor crash that could occur in projects containing TypeScript files larger than 10 MB.


### PR DESCRIPTION
The TypeScript extractor expects that all files are requested in a predetermined order. However, this conflicted with the recent change to exclude large files, where this filtering occurs only at a later stage.

This is the second time this out-of-order check has caused extraction failures due to an otherwise benign change in the Java part of the extractor. I'd like to remove the hard failure and instead regard the queue as speculative optimization that misses in rare cases.