### PR TITLE
C#: Poor mans quoting.

### DIFF
--- a/csharp/ql/integration-tests/all-platforms/dotnet_run/test.py
+++ b/csharp/ql/integration-tests/all-platforms/dotnet_run/test.py
@@ -53,3 +53,9 @@ check_diagnostics(test_db="test7-db")
 s = run_codeql_database_create_stdout(['dotnet clean', 'rm -rf test7-db', 'dotnet build', 'dotnet run --no-build hello world'], "test8-db")
 check_build_out("hello, world", s)
 check_diagnostics(test_db="test8-db")
+
+
+# two arguments, no '--' (first argument quoted)
+s = run_codeql_database_create_stdout(['dotnet clean', 'rm -rf test8-db', 'dotnet run "hello world part1" part2'], "test9-db")
+check_build_out("hello world part1, part2", s)
+check_diagnostics(test_db="test9-db")

--- a/csharp/tools/tracing-config.lua
+++ b/csharp/tools/tracing-config.lua
@@ -84,6 +84,10 @@ function RegisterExtractorPack(id)
                 dotnetRunNeedsSeparator = false
                 dotnetRunInjectionIndex = i
             end
+            -- if we encounter a whitespace, we explicitly need to quote the argument.
+            if OperatingSystem == 'windows' and arg:match('%s') then
+                argv[i] = '"' .. arg .. '"'
+            end
         end
         if match then
             local injections = { '-p:UseSharedCompilation=false', '-p:EmitCompilerGeneratedFiles=true' }


### PR DESCRIPTION
If quoted arguments are used these will not be respected by the LUA tracer on windows.
In this PR we explicitly quote all compiler arguments containing whitespaces (windows only) in the dotnet matcher.
This is an initial fix. The full fix, which also depends on an internal PR will be merged here: https://github.com/github/codeql/pull/14150
