### PR TITLE
Fix space handling in Golang configure-baseline scripts

### DIFF
--- a/go/codeql-tools/configure-baseline.cmd
+++ b/go/codeql-tools/configure-baseline.cmd
@@ -1,6 +1,6 @@
 @echo off
 if exist vendor\modules.txt (
-  type %CODEQL_EXTRACTOR_GO_ROOT%\tools\baseline-config-vendor.json
+  type "%CODEQL_EXTRACTOR_GO_ROOT%\tools\baseline-config-vendor.json"
 ) else (
-  type %CODEQL_EXTRACTOR_GO_ROOT%\tools\baseline-config-empty.json
+  type "%CODEQL_EXTRACTOR_GO_ROOT%\tools\baseline-config-empty.json"
 )

--- a/go/codeql-tools/configure-baseline.sh
+++ b/go/codeql-tools/configure-baseline.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if [ -f vendor/modules.txt ]; then
-  cat $CODEQL_EXTRACTOR_GO_ROOT/tools/baseline-config-vendor.json
+  cat "$CODEQL_EXTRACTOR_GO_ROOT/tools/baseline-config-vendor.json"
 else
-  cat $CODEQL_EXTRACTOR_GO_ROOT/tools/baseline-config-empty.json
+  cat "$CODEQL_EXTRACTOR_GO_ROOT/tools/baseline-config-empty.json"
 fi


### PR DESCRIPTION
I noticed in integration tests we were seeing

```
Initializing database at /Users/mbg/Code/GitHub/codeql/semmle-code/target/codeql-go-integration-tests/ql/go/ql/integration-tests/all-platforms/go/diagnostics/newer-go-version-needed/test-db.
cat: /Users/mbg/Code/GitHub/codeql/semmle-code/target/intree/codeql: No such file or directory
cat: integration: No such file or directory
cat: tests: No such file or directory
cat: dist: No such file or directory
cat: go/go/tools/baseline-config-empty.json: No such file or directory
Failed to run the configure-baseline script for Go. Proceeding with no baseline configuration, baseline information for Go may be degraded as a result.
```