### PR TITLE
Document assume_small_delta deprecation

### DIFF
--- a/docs/codeql/ql-language-reference/annotations.rst
+++ b/docs/codeql/ql-language-reference/annotations.rst
@@ -435,9 +435,11 @@ For more information, see ":ref:`Binding <binding>`."
 
 **Available for**: |characteristic predicates|, |member predicates|, |non-member predicates|
 
-The ``pragma[assume_small_delta]`` annotation changes the compilation of the annotated recursive predicate.
-If the compiler normally generates the join orders ``order_<1>``, ``order_<2>``, ``order_<3>``, and ``standard_order``,
-applying this annotation makes ``standard_order`` the same as ``order_<3>`` and removes the (now redundant) ``order_<3>`` join order.
+.. pull-quote:: Important
+
+   This annotation is deprecated.
+
+The ``pragma[assume_small_delta]`` annotation has no effect and can be safely removed.
 
 .. _language:
 


### PR DESCRIPTION
This PR updates `pragma[assume_small_delta]` documentation to state that it is deprecated.