### PR TITLE
Swift: Consistent additional taint steps between the cleartext-* queries

### DIFF
--- a/swift/ql/lib/codeql/swift/security/CleartextLoggingExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/CleartextLoggingExtensions.qll
@@ -83,6 +83,16 @@ private class OsLogPrivacyRef extends MemberRefExpr {
   predicate isPublic() { optionName = "public" }
 }
 
+/**
+ * An additional taint step for cleartext logging vulnerabilities.
+ */
+private class CleartextLoggingFieldAdditionalFlowStep extends CleartextLoggingAdditionalFlowStep {
+  override predicate step(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
+    // if an object is sensitive, its fields are always sensitive.
+    nodeTo.asExpr().(MemberRefExpr).getBase() = nodeFrom.asExpr()
+  }
+}
+
 private class LoggingSinks extends SinkModelCsv {
   override predicate row(string row) {
     row =

--- a/swift/ql/lib/codeql/swift/security/CleartextStoragePreferencesExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/CleartextStoragePreferencesExtensions.qll
@@ -33,7 +33,9 @@ class CleartextStoragePreferencesAdditionalFlowStep extends Unit {
   abstract predicate step(DataFlow::Node nodeFrom, DataFlow::Node nodeTo);
 }
 
-/** The `DataFlow::Node` of an expression that gets written to the user defaults database */
+/**
+ * The `DataFlow::Node` of an expression that gets written to the user defaults database.
+ */
 private class UserDefaultsStore extends CleartextStoragePreferencesSink {
   UserDefaultsStore() {
     exists(CallExpr call |
@@ -45,7 +47,9 @@ private class UserDefaultsStore extends CleartextStoragePreferencesSink {
   override string getStoreName() { result = "the user defaults database" }
 }
 
-/** The `DataFlow::Node` of an expression that gets written to the iCloud-backed NSUbiquitousKeyValueStore */
+/**
+ * The `DataFlow::Node` of an expression that gets written to the iCloud-backed `NSUbiquitousKeyValueStore`.
+ */
 private class NSUbiquitousKeyValueStore extends CleartextStoragePreferencesSink {
   NSUbiquitousKeyValueStore() {
     exists(CallExpr call |

--- a/swift/ql/lib/codeql/swift/security/CleartextStoragePreferencesExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/CleartextStoragePreferencesExtensions.qll
@@ -90,6 +90,17 @@ private class CleartextStoragePreferencesDefaultBarrier extends CleartextStorage
 }
 
 /**
+ * An additional taint step for cleartext preferences storage vulnerabilities.
+ */
+private class CleartextStoragePreferencesFieldAdditionalFlowStep extends CleartextStoragePreferencesAdditionalFlowStep
+{
+  override predicate step(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
+    // if an object is sensitive, its fields are always sensitive.
+    nodeTo.asExpr().(MemberRefExpr).getBase() = nodeFrom.asExpr()
+  }
+}
+
+/**
  * A sink defined in a CSV model.
  */
 private class DefaultCleartextStoragePreferencesSink extends CleartextStoragePreferencesSink {

--- a/swift/ql/lib/codeql/swift/security/CleartextTransmissionExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/CleartextTransmissionExtensions.qll
@@ -31,38 +31,6 @@ class CleartextTransmissionAdditionalFlowStep extends Unit {
 }
 
 /**
- * An `Expr` that is transmitted with `NWConnection.send`.
- */
-private class NWConnectionSendSink extends CleartextTransmissionSink {
-  NWConnectionSendSink() {
-    // `content` arg to `NWConnection.send` is a sink
-    exists(CallExpr call |
-      call.getStaticTarget()
-          .(Method)
-          .hasQualifiedName("NWConnection", "send(content:contentContext:isComplete:completion:)") and
-      call.getArgument(0).getExpr() = this.asExpr()
-    )
-  }
-}
-
-/**
- * An `Expr` that is used to form a `URL`. Such expressions are very likely to
- * be transmitted over a network, because that's what URLs are for.
- */
-private class UrlSink extends CleartextTransmissionSink {
-  UrlSink() {
-    // `string` arg in `URL.init` is a sink
-    // (we assume here that the URL goes on to be used in a network operation)
-    exists(CallExpr call |
-      call.getStaticTarget()
-          .(Method)
-          .hasQualifiedName("URL", ["init(string:)", "init(string:relativeTo:)"]) and
-      call.getArgument(0).getExpr() = this.asExpr()
-    )
-  }
-}
-
-/**
  * An `Expr` that transmitted through the Alamofire library.
  */
 private class AlamofireTransmittedSink extends CleartextTransmissionSink {
@@ -97,4 +65,17 @@ private class CleartextTransmissionDefaultBarrier extends CleartextTransmissionB
  */
 private class DefaultCleartextTransmissionSink extends CleartextTransmissionSink {
   DefaultCleartextTransmissionSink() { sinkNode(this, "transmission") }
+}
+
+private class TransmissionSinks extends SinkModelCsv {
+  override predicate row(string row) {
+    row =
+      [
+        ";NWConnection;true;send(content:contentContext:isComplete:completion:);;;Argument[0];transmission",
+        // an `Expr` that is used to form a `URL` is very likely to be transmitted over a network, because
+        // that's what URLs are for.
+        ";URL;true;init(string:);;;Argument[0];transmission",
+        ";URL;true;init(string:relativeTo:);;;Argument[0];transmission",
+      ]
+  }
 }

--- a/swift/ql/lib/codeql/swift/security/CleartextTransmissionExtensions.qll
+++ b/swift/ql/lib/codeql/swift/security/CleartextTransmissionExtensions.qll
@@ -61,6 +61,17 @@ private class CleartextTransmissionDefaultBarrier extends CleartextTransmissionB
 }
 
 /**
+ * An additional taint step for cleartext transmission vulnerabilities.
+ */
+private class CleartextTransmissionFieldAdditionalFlowStep extends CleartextTransmissionAdditionalFlowStep
+{
+  override predicate step(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
+    // if an object is sensitive, its fields are always sensitive.
+    nodeTo.asExpr().(MemberRefExpr).getBase() = nodeFrom.asExpr()
+  }
+}
+
+/**
  * A sink defined in a CSV model.
  */
 private class DefaultCleartextTransmissionSink extends CleartextTransmissionSink {

--- a/swift/ql/src/change-notes/2023-09-12-cleartext.md
+++ b/swift/ql/src/change-notes/2023-09-12-cleartext.md
@@ -1,0 +1,5 @@
+---
+category: minorAnalysis
+---
+
+* Added additional taint steps to the `swift/cleartext-transmission`, `swift/cleartext-logging` and `swift/cleartext-storage-preferences` queries to identify data within sensitive containers. This is similar to an existing additional taint step in the `swift/cleartext-storage-database` query.

--- a/swift/ql/test/query-tests/Security/CWE-311/CleartextTransmission.expected
+++ b/swift/ql/test/query-tests/Security/CWE-311/CleartextTransmission.expected
@@ -1,4 +1,5 @@
 edges
+| file://:0:0:0:0 | self | file://:0:0:0:0 | .value |
 | testAlamofire.swift:150:45:150:45 | password | testAlamofire.swift:150:13:150:45 | ... .+(_:_:) ... |
 | testAlamofire.swift:152:51:152:51 | password | testAlamofire.swift:152:19:152:51 | ... .+(_:_:) ... |
 | testAlamofire.swift:154:38:154:38 | email | testAlamofire.swift:154:14:154:46 | ... .+(_:_:) ... |
@@ -10,6 +11,9 @@ edges
 | testSend.swift:60:13:60:25 | call to pad(_:) | testSend.swift:67:27:67:27 | str3 |
 | testSend.swift:60:17:60:17 | password | testSend.swift:41:10:41:18 | data |
 | testSend.swift:60:17:60:17 | password | testSend.swift:60:13:60:25 | call to pad(_:) |
+| testSend.swift:86:7:86:7 | self | file://:0:0:0:0 | self |
+| testSend.swift:94:27:94:30 | .password | testSend.swift:86:7:86:7 | self |
+| testSend.swift:94:27:94:30 | .password | testSend.swift:94:27:94:39 | .value |
 | testURL.swift:17:54:17:54 | passwd | testURL.swift:17:22:17:54 | ... .+(_:_:) ... |
 | testURL.swift:19:55:19:55 | account_no | testURL.swift:19:22:19:55 | ... .+(_:_:) ... |
 | testURL.swift:20:55:20:55 | credit_card_no | testURL.swift:20:22:20:55 | ... .+(_:_:) ... |
@@ -17,6 +21,8 @@ edges
 | testURL.swift:30:57:30:57 | a_homeaddr_z | testURL.swift:30:22:30:57 | ... .+(_:_:) ... |
 | testURL.swift:32:55:32:55 | resident_ID | testURL.swift:32:22:32:55 | ... .+(_:_:) ... |
 nodes
+| file://:0:0:0:0 | .value | semmle.label | .value |
+| file://:0:0:0:0 | self | semmle.label | self |
 | testAlamofire.swift:150:13:150:45 | ... .+(_:_:) ... | semmle.label | ... .+(_:_:) ... |
 | testAlamofire.swift:150:45:150:45 | password | semmle.label | password |
 | testAlamofire.swift:152:19:152:51 | ... .+(_:_:) ... | semmle.label | ... .+(_:_:) ... |
@@ -43,6 +49,9 @@ nodes
 | testSend.swift:78:27:78:30 | .CarePlanID | semmle.label | .CarePlanID |
 | testSend.swift:79:27:79:30 | .BankCardNo | semmle.label | .BankCardNo |
 | testSend.swift:80:27:80:30 | .MyCreditRating | semmle.label | .MyCreditRating |
+| testSend.swift:86:7:86:7 | self | semmle.label | self |
+| testSend.swift:94:27:94:30 | .password | semmle.label | .password |
+| testSend.swift:94:27:94:39 | .value | semmle.label | .value |
 | testURL.swift:17:22:17:54 | ... .+(_:_:) ... | semmle.label | ... .+(_:_:) ... |
 | testURL.swift:17:54:17:54 | passwd | semmle.label | passwd |
 | testURL.swift:19:22:19:55 | ... .+(_:_:) ... | semmle.label | ... .+(_:_:) ... |
@@ -58,6 +67,7 @@ nodes
 | testURL.swift:32:55:32:55 | resident_ID | semmle.label | resident_ID |
 subpaths
 | testSend.swift:60:17:60:17 | password | testSend.swift:41:10:41:18 | data | testSend.swift:41:45:41:45 | data | testSend.swift:60:13:60:25 | call to pad(_:) |
+| testSend.swift:94:27:94:30 | .password | testSend.swift:86:7:86:7 | self | file://:0:0:0:0 | .value | testSend.swift:94:27:94:39 | .value |
 #select
 | testAlamofire.swift:150:13:150:45 | ... .+(_:_:) ... | testAlamofire.swift:150:45:150:45 | password | testAlamofire.swift:150:13:150:45 | ... .+(_:_:) ... | This operation transmits '... .+(_:_:) ...', which may contain unencrypted sensitive data from $@. | testAlamofire.swift:150:45:150:45 | password | password |
 | testAlamofire.swift:152:19:152:51 | ... .+(_:_:) ... | testAlamofire.swift:152:51:152:51 | password | testAlamofire.swift:152:19:152:51 | ... .+(_:_:) ... | This operation transmits '... .+(_:_:) ...', which may contain unencrypted sensitive data from $@. | testAlamofire.swift:152:51:152:51 | password | password |
@@ -74,6 +84,7 @@ subpaths
 | testSend.swift:78:27:78:30 | .CarePlanID | testSend.swift:78:27:78:30 | .CarePlanID | testSend.swift:78:27:78:30 | .CarePlanID | This operation transmits '.CarePlanID', which may contain unencrypted sensitive data from $@. | testSend.swift:78:27:78:30 | .CarePlanID | .CarePlanID |
 | testSend.swift:79:27:79:30 | .BankCardNo | testSend.swift:79:27:79:30 | .BankCardNo | testSend.swift:79:27:79:30 | .BankCardNo | This operation transmits '.BankCardNo', which may contain unencrypted sensitive data from $@. | testSend.swift:79:27:79:30 | .BankCardNo | .BankCardNo |
 | testSend.swift:80:27:80:30 | .MyCreditRating | testSend.swift:80:27:80:30 | .MyCreditRating | testSend.swift:80:27:80:30 | .MyCreditRating | This operation transmits '.MyCreditRating', which may contain unencrypted sensitive data from $@. | testSend.swift:80:27:80:30 | .MyCreditRating | .MyCreditRating |
+| testSend.swift:94:27:94:39 | .value | testSend.swift:94:27:94:30 | .password | testSend.swift:94:27:94:39 | .value | This operation transmits '.value', which may contain unencrypted sensitive data from $@. | testSend.swift:94:27:94:30 | .password | .password |
 | testURL.swift:17:22:17:54 | ... .+(_:_:) ... | testURL.swift:17:54:17:54 | passwd | testURL.swift:17:22:17:54 | ... .+(_:_:) ... | This operation transmits '... .+(_:_:) ...', which may contain unencrypted sensitive data from $@. | testURL.swift:17:54:17:54 | passwd | passwd |
 | testURL.swift:19:22:19:55 | ... .+(_:_:) ... | testURL.swift:19:55:19:55 | account_no | testURL.swift:19:22:19:55 | ... .+(_:_:) ... | This operation transmits '... .+(_:_:) ...', which may contain unencrypted sensitive data from $@. | testURL.swift:19:55:19:55 | account_no | account_no |
 | testURL.swift:20:22:20:55 | ... .+(_:_:) ... | testURL.swift:20:55:20:55 | credit_card_no | testURL.swift:20:22:20:55 | ... .+(_:_:) ... | This operation transmits '... .+(_:_:) ...', which may contain unencrypted sensitive data from $@. | testURL.swift:20:55:20:55 | credit_card_no | credit_card_no |

--- a/swift/ql/test/query-tests/Security/CWE-311/SensitiveExprs.expected
+++ b/swift/ql/test/query-tests/Security/CWE-311/SensitiveExprs.expected
@@ -133,6 +133,7 @@
 | testSend.swift:78:27:78:30 | .CarePlanID | label:CarePlanID, type:private information |
 | testSend.swift:79:27:79:30 | .BankCardNo | label:BankCardNo, type:private information |
 | testSend.swift:80:27:80:30 | .MyCreditRating | label:MyCreditRating, type:private information |
+| testSend.swift:94:27:94:30 | .password | label:password, type:credential |
 | testURL.swift:17:54:17:54 | passwd | label:passwd, type:credential |
 | testURL.swift:19:55:19:55 | account_no | label:account_no, type:private information |
 | testURL.swift:20:55:20:55 | credit_card_no | label:credit_card_no, type:private information |

--- a/swift/ql/test/query-tests/Security/CWE-311/testSend.swift
+++ b/swift/ql/test/query-tests/Security/CWE-311/testSend.swift
@@ -80,3 +80,17 @@ func test2(password : String, license_key: String, ms: MyStruct, connection : NW
 	connection.send(content: ms.MyCreditRating, completion: .idempotent) // BAD
 	connection.send(content: ms.OneTimeCode, completion: .idempotent) // BAD [NOT DETECTED]
 }
+
+struct MyOuter {
+	struct MyInner {
+		var value: String
+	}
+
+	var password: MyInner
+	var harmless: MyInner
+}
+
+func test3(mo : MyOuter, connection : NWConnection) {
+	connection.send(content: mo.password.value, completion: .idempotent) // BAD [NOT DETECTED]
+	connection.send(content: mo.harmless.value, completion: .idempotent) // GOOD
+}

--- a/swift/ql/test/query-tests/Security/CWE-311/testSend.swift
+++ b/swift/ql/test/query-tests/Security/CWE-311/testSend.swift
@@ -91,6 +91,6 @@ struct MyOuter {
 }
 
 func test3(mo : MyOuter, connection : NWConnection) {
-	connection.send(content: mo.password.value, completion: .idempotent) // BAD [NOT DETECTED]
+	connection.send(content: mo.password.value, completion: .idempotent) // BAD
 	connection.send(content: mo.harmless.value, completion: .idempotent) // GOOD
 }

--- a/swift/ql/test/query-tests/Security/CWE-312/CleartextStoragePreferences.expected
+++ b/swift/ql/test/query-tests/Security/CWE-312/CleartextStoragePreferences.expected
@@ -1,4 +1,5 @@
 edges
+| file://:0:0:0:0 | self | file://:0:0:0:0 | .value |
 | testNSUbiquitousKeyValueStore.swift:41:24:41:24 | x | testNSUbiquitousKeyValueStore.swift:42:40:42:40 | x |
 | testNSUbiquitousKeyValueStore.swift:44:10:44:22 | call to getPassword() | testNSUbiquitousKeyValueStore.swift:45:40:45:40 | y |
 | testNSUbiquitousKeyValueStore.swift:55:10:55:10 | passwd | testNSUbiquitousKeyValueStore.swift:59:40:59:40 | x |
@@ -9,7 +10,12 @@ edges
 | testUserDefaults.swift:55:10:55:10 | passwd | testUserDefaults.swift:59:28:59:28 | x |
 | testUserDefaults.swift:56:10:56:10 | passwd | testUserDefaults.swift:60:28:60:28 | y |
 | testUserDefaults.swift:57:10:57:10 | passwd | testUserDefaults.swift:61:28:61:28 | z |
+| testUserDefaults.swift:74:7:74:7 | self | file://:0:0:0:0 | self |
+| testUserDefaults.swift:82:28:82:31 | .password | testUserDefaults.swift:74:7:74:7 | self |
+| testUserDefaults.swift:82:28:82:31 | .password | testUserDefaults.swift:82:28:82:40 | .value |
 nodes
+| file://:0:0:0:0 | .value | semmle.label | .value |
+| file://:0:0:0:0 | self | semmle.label | self |
 | testNSUbiquitousKeyValueStore.swift:28:12:28:12 | password | semmle.label | password |
 | testNSUbiquitousKeyValueStore.swift:41:24:41:24 | x | semmle.label | x |
 | testNSUbiquitousKeyValueStore.swift:42:40:42:40 | x | semmle.label | x |
@@ -34,7 +40,11 @@ nodes
 | testUserDefaults.swift:59:28:59:28 | x | semmle.label | x |
 | testUserDefaults.swift:60:28:60:28 | y | semmle.label | y |
 | testUserDefaults.swift:61:28:61:28 | z | semmle.label | z |
+| testUserDefaults.swift:74:7:74:7 | self | semmle.label | self |
+| testUserDefaults.swift:82:28:82:31 | .password | semmle.label | .password |
+| testUserDefaults.swift:82:28:82:40 | .value | semmle.label | .value |
 subpaths
+| testUserDefaults.swift:82:28:82:31 | .password | testUserDefaults.swift:74:7:74:7 | self | file://:0:0:0:0 | .value | testUserDefaults.swift:82:28:82:40 | .value |
 #select
 | testNSUbiquitousKeyValueStore.swift:28:12:28:12 | password | testNSUbiquitousKeyValueStore.swift:28:12:28:12 | password | testNSUbiquitousKeyValueStore.swift:28:12:28:12 | password | This operation stores 'password' in iCloud. It may contain unencrypted sensitive data from $@. | testNSUbiquitousKeyValueStore.swift:28:12:28:12 | password | password |
 | testNSUbiquitousKeyValueStore.swift:42:40:42:40 | x | testNSUbiquitousKeyValueStore.swift:41:24:41:24 | x | testNSUbiquitousKeyValueStore.swift:42:40:42:40 | x | This operation stores 'x' in iCloud. It may contain unencrypted sensitive data from $@. | testNSUbiquitousKeyValueStore.swift:41:24:41:24 | x | x |
@@ -50,3 +60,4 @@ subpaths
 | testUserDefaults.swift:59:28:59:28 | x | testUserDefaults.swift:55:10:55:10 | passwd | testUserDefaults.swift:59:28:59:28 | x | This operation stores 'x' in the user defaults database. It may contain unencrypted sensitive data from $@. | testUserDefaults.swift:55:10:55:10 | passwd | passwd |
 | testUserDefaults.swift:60:28:60:28 | y | testUserDefaults.swift:56:10:56:10 | passwd | testUserDefaults.swift:60:28:60:28 | y | This operation stores 'y' in the user defaults database. It may contain unencrypted sensitive data from $@. | testUserDefaults.swift:56:10:56:10 | passwd | passwd |
 | testUserDefaults.swift:61:28:61:28 | z | testUserDefaults.swift:57:10:57:10 | passwd | testUserDefaults.swift:61:28:61:28 | z | This operation stores 'z' in the user defaults database. It may contain unencrypted sensitive data from $@. | testUserDefaults.swift:57:10:57:10 | passwd | passwd |
+| testUserDefaults.swift:82:28:82:40 | .value | testUserDefaults.swift:82:28:82:31 | .password | testUserDefaults.swift:82:28:82:40 | .value | This operation stores '.value' in the user defaults database. It may contain unencrypted sensitive data from $@. | testUserDefaults.swift:82:28:82:31 | .password | .password |

--- a/swift/ql/test/query-tests/Security/CWE-312/cleartextLoggingTest.swift
+++ b/swift/ql/test/query-tests/Security/CWE-312/cleartextLoggingTest.swift
@@ -170,6 +170,6 @@ struct MyOuter {
 }
 
 func test3(mo : MyOuter) {
-	NSLog(mo.password.value) // BAD [NOT DETECTED]
-	NSLog(mo.harmless.value) // GOOD
+	NSLog(mo.password.value) // $ hasCleartextLogging=173
+	NSLog(mo.harmless.value) // Safe
 }

--- a/swift/ql/test/query-tests/Security/CWE-312/cleartextLoggingTest.swift
+++ b/swift/ql/test/query-tests/Security/CWE-312/cleartextLoggingTest.swift
@@ -159,3 +159,17 @@ func test3(x: String) {
 	NSLog(z.harmless) // Safe
 	NSLog(z.password) // $ hasCleartextLogging=160
 }
+
+struct MyOuter {
+	struct MyInner {
+		var value: String
+	}
+
+	var password: MyInner
+	var harmless: MyInner
+}
+
+func test3(mo : MyOuter) {
+	NSLog(mo.password.value) // BAD [NOT DETECTED]
+	NSLog(mo.harmless.value) // GOOD
+}

--- a/swift/ql/test/query-tests/Security/CWE-312/testUserDefaults.swift
+++ b/swift/ql/test/query-tests/Security/CWE-312/testUserDefaults.swift
@@ -68,3 +68,17 @@ func test4(passwd: String) {
 	UserDefaults.standard.set(y, forKey: "myKey") // GOOD (not sensitive)
 	UserDefaults.standard.set(z, forKey: "myKey") // GOOD (not sensitive)
 }
+
+struct MyOuter {
+	struct MyInner {
+		var value: String
+	}
+
+	var password: MyInner
+	var harmless: MyInner
+}
+
+func test5(mo : MyOuter) {
+	UserDefaults.standard.set(mo.password.value, forKey: "myKey") // BAD [NOT DETECTED]
+	UserDefaults.standard.set(mo.harmless.value, forKey: "myKey") // GOOD
+}

--- a/swift/ql/test/query-tests/Security/CWE-312/testUserDefaults.swift
+++ b/swift/ql/test/query-tests/Security/CWE-312/testUserDefaults.swift
@@ -79,6 +79,6 @@ struct MyOuter {
 }
 
 func test5(mo : MyOuter) {
-	UserDefaults.standard.set(mo.password.value, forKey: "myKey") // BAD [NOT DETECTED]
+	UserDefaults.standard.set(mo.password.value, forKey: "myKey") // BAD
 	UserDefaults.standard.set(mo.harmless.value, forKey: "myKey") // GOOD
 }


### PR DESCRIPTION
Added additional taint steps to the `swift/cleartext-transmission`, `swift/cleartext-logging` and `swift/cleartext-storage-preferences` queries similar to an existing additional taint step in the `swift/cleartext-storage-database` query.  This identifies data within a container that matches the sensitive data heuristic as sensitive as well, for example `value` in:
```
myObject.password.value
```
I've also added some tests and converted a couple of existing sinks to CSV.