### PR TITLE
C++: Fix `phi` -> `phi` flow

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
@@ -757,13 +757,16 @@ private predicate fromPhiNodeToUse(PhiNode phi, SourceVariable sv, IRBlock bb1, 
 
 /** Holds if `nodeTo` receives flow from the phi node `nodeFrom`. */
 predicate fromPhiNode(SsaPhiNode nodeFrom, Node nodeTo) {
-  exists(PhiNode phi, SourceVariable sv, IRBlock bb1, int i1, UseOrPhi use |
+  exists(PhiNode phi, SourceVariable sv, IRBlock bb1, int i1 |
     phi = nodeFrom.getPhiNode() and
-    phi.definesAt(sv, bb1, i1, _) and
-    useToNode(use, nodeTo)
+    phi.definesAt(sv, bb1, i1, _)
   |
-    fromPhiNodeToUse(phi, sv, bb1, i1, use)
+    exists(UseOrPhi use |
+      useToNode(use, nodeTo) and
+      fromPhiNodeToUse(phi, sv, bb1, i1, use)
+    )
     or
+    not fromPhiNodeToUse(phi, sv, _, _, _) and
     exists(PhiNode phiTo |
       phi != phiTo and
       lastRefRedefExt(phi, _, _, phiTo) and

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/guard-condition-regression-test.cpp
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/guard-condition-regression-test.cpp
@@ -1,0 +1,19 @@
+int source();
+void gard_condition_sink(int);
+void use(int);
+/*
+  This test checks that we hit the node corresponding to the expression node that wraps `source`
+  in the condition `source >= 0`. 
+*/
+void test_guard_condition(int source, bool b)
+{
+  if (b) {
+    use(source);
+  }
+
+  if (source >= 0) {
+    use(source);
+  }
+
+  gard_condition_sink(source); // $ SPURIOUS: guard-condition-regression
+}

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/guard-condition-regression-test.cpp
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/guard-condition-regression-test.cpp
@@ -15,5 +15,5 @@ void test_guard_condition(int source, bool b)
     use(source);
   }
 
-  gard_condition_sink(source); // $ SPURIOUS: guard-condition-regression
+  gard_condition_sink(source); // clean
 }

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/guard-condition-regression-test.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/guard-condition-regression-test.expected
@@ -1,0 +1,2 @@
+testFailures
+failures

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/guard-condition-regression-test.ql
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/guard-condition-regression-test.ql
@@ -1,0 +1,40 @@
+import TestUtilities.InlineExpectationsTest
+private import cpp
+private import semmle.code.cpp.ir.dataflow.DataFlow
+private import semmle.code.cpp.controlflow.IRGuards
+
+module IRTestAllocationConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) {
+    source.asParameter().getName().matches("source%") and
+    source.getLocation().getFile().getBaseName() = "guard-condition-regression-test.cpp"
+  }
+
+  predicate isSink(DataFlow::Node sink) {
+    exists(FunctionCall call, Expr e | e = call.getAnArgument() |
+      call.getTarget().getName() = "gard_condition_sink" and
+      sink.asExpr() = e
+    )
+  }
+
+  predicate isBarrier(DataFlow::Node node) {
+    exists(GuardCondition gc | node.asExpr() = gc.getAChild*())
+  }
+}
+
+private module Flow = DataFlow::Global<IRTestAllocationConfig>;
+
+module GuardConditionRegressionTest implements TestSig {
+  string getARelevantTag() { result = "guard-condition-regression" }
+
+  predicate hasActualResult(Location location, string element, string tag, string value) {
+    exists(DataFlow::Node sink |
+      Flow::flowTo(sink) and
+      location = sink.getLocation() and
+      element = sink.toString() and
+      tag = "guard-condition-regression" and
+      value = ""
+    )
+  }
+}
+
+import MakeTest<GuardConditionRegressionTest>

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.expected
@@ -5,5 +5,5 @@ WARNING: Module DataFlow has been deprecated and may be removed in future (test.
 WARNING: Module DataFlow has been deprecated and may be removed in future (test.ql:40,25-33)
 WARNING: Module DataFlow has been deprecated and may be removed in future (test.ql:42,17-25)
 WARNING: Module DataFlow has been deprecated and may be removed in future (test.ql:46,20-28)
-failures
 testFailures
+failures


### PR DESCRIPTION
Fixes https://github.com/github/codeql/issues/14183.

Consider a snippet such as:
```cpp
void foo(int x)
{
  if (...)
  {
    use(x);
  } else {
    use(x);
  }
  // 1

  if (x) // 2
  {
    use(x); // 3
  }
  // 4

  sink(x); // 5
}
```
Since we have phi nodes the flow from the parameter `x` to `sink(x)` should follow the following chain:
- Flow will eventually arrive at the phi node at `// 1`.
- Flow to the use of `x` at `// 2`
- Flow to the expression at `// 3`
- Flow to the phi node at `// 4`
- Flow to the expression at `// 5`

However, in the `fromPhiNode` predicate we were flowing from `// 1` to both `// 2` _and_ directly to `// 4`. This meant that the barrier in https://github.com/github/codeql/issues/14183 didn't block the flow from the parameter `x` to `sink(x)`.

