### PR TITLE
Go: Better determine Go versions in Go 1.21+

### DIFF
--- a/go/extractor/cli/go-autobuilder/go-autobuilder.go
+++ b/go/extractor/cli/go-autobuilder/go-autobuilder.go
@@ -808,7 +808,9 @@ func installDependenciesAndBuild() {
 
 	goVersionInfo, _ := tryReadGoDirective(buildInfo)
 
-	if goVersionInfo.Found && semver.Compare("v"+goVersionInfo.Version, getEnvGoSemVer()) > 0 {
+	// This diagnostic is not required if the system Go version is 1.21 or greater, since the
+	// Go tooling should install required Go versions as needed.
+	if semver.Compare(getEnvGoSemVer(), "v1.21.0") < 0 && goVersionInfo.Found && semver.Compare("v"+goVersionInfo.Version, getEnvGoSemVer()) > 0 {
 		diagnostics.EmitNewerGoVersionNeeded()
 	}
 

--- a/go/extractor/cli/go-autobuilder/go-autobuilder.go
+++ b/go/extractor/cli/go-autobuilder/go-autobuilder.go
@@ -390,7 +390,7 @@ func tryReadGoDirective(buildInfo BuildInfo) (GoVersionInfo, GoVersionInfo) {
 
 	if buildInfo.DepMode == GoGetWithModules {
 		versionRe := regexp.MustCompile(`(?m)^go[ \t\r]+([0-9]+\.[0-9]+(\.[0-9]+)?)$`)
-		toolchainRe := regexp.MustCompile(`(?m)^toolchain[ \t\r]+([0-9]+\.[0-9]+(\.[0-9]+)?)$`)
+		toolchainRe := regexp.MustCompile(`(?m)^toolchain[ \t\r]+go([0-9]+\.[0-9]+(\.[0-9]+)?)$`)
 		goMod, err := os.ReadFile(filepath.Join(buildInfo.BaseDir, "go.mod"))
 		if err != nil {
 			log.Println("Failed to read go.mod to check for missing Go version")

--- a/go/extractor/cli/go-autobuilder/go-autobuilder.go
+++ b/go/extractor/cli/go-autobuilder/go-autobuilder.go
@@ -389,8 +389,8 @@ func tryReadGoDirective(buildInfo BuildInfo) (GoVersionInfo, GoVersionInfo) {
 	toolchainVersion := noVersionInfo
 
 	if buildInfo.DepMode == GoGetWithModules {
-		versionRe := regexp.MustCompile(`(?m)^go[ \t\r]+([0-9]+\.[0-9]+(\.[0-9]+)?)$`)
-		toolchainRe := regexp.MustCompile(`(?m)^toolchain[ \t\r]+go([0-9]+\.[0-9]+(\.[0-9]+)?)$`)
+		versionRe := regexp.MustCompile(`(?m)^go[ \t\r]+([0-9]+\.[0-9]+(\.[0-9]+)?)`)
+		toolchainRe := regexp.MustCompile(`(?m)^toolchain[ \t\r]+go([0-9]+\.[0-9]+(\.[0-9]+)?)`)
 		goMod, err := os.ReadFile(filepath.Join(buildInfo.BaseDir, "go.mod"))
 		if err != nil {
 			log.Println("Failed to read go.mod to check for missing Go version")

--- a/go/extractor/cli/go-autobuilder/go-autobuilder.go
+++ b/go/extractor/cli/go-autobuilder/go-autobuilder.go
@@ -383,11 +383,7 @@ type GoVersionInfo struct {
 }
 
 // Tries to open `go.mod` and read a go directive, returning the version and whether it was found.
-func tryReadGoDirective(buildInfo BuildInfo) (GoVersionInfo, GoVersionInfo) {
-	noVersionInfo := GoVersionInfo{"", false}
-	compilerVersion := noVersionInfo
-	toolchainVersion := noVersionInfo
-
+func tryReadGoDirective(buildInfo BuildInfo) (compilerVersion GoVersionInfo, toolchainVersion GoVersionInfo) {
 	if buildInfo.DepMode == GoGetWithModules {
 		versionRe := regexp.MustCompile(`(?m)^go[ \t\r]+([0-9]+\.[0-9]+(\.[0-9]+)?)`)
 		toolchainRe := regexp.MustCompile(`(?m)^toolchain[ \t\r]+go([0-9]+\.[0-9]+(\.[0-9]+)?)`)

--- a/go/ql/integration-tests/all-platforms/go/diagnostics/newer-go-version-needed/diagnostics.expected
+++ b/go/ql/integration-tests/all-platforms/go/diagnostics/newer-go-version-needed/diagnostics.expected
@@ -12,17 +12,3 @@
     "telemetry": true
   }
 }
-{
-  "markdownMessage": "The detected version of Go is lower than the version specified in `go.mod`. [Install a newer version](https://github.com/actions/setup-go#basic).",
-  "severity": "error",
-  "source": {
-    "extractorName": "go",
-    "id": "go/autobuilder/newer-go-version-needed",
-    "name": "Newer Go version needed"
-  },
-  "visibility": {
-    "cliSummaryTable": true,
-    "statusPage": true,
-    "telemetry": true
-  }
-}

--- a/go/ql/integration-tests/all-platforms/go/diagnostics/newer-go-version-needed/test.py
+++ b/go/ql/integration-tests/all-platforms/go/diagnostics/newer-go-version-needed/test.py
@@ -4,6 +4,6 @@ from create_database_utils import *
 from diagnostics_test_utils import *
 
 os.environ['LGTM_INDEX_IMPORT_PATH'] = "test"
-run_codeql_database_create([], lang="go", source="work", db=None)
+run_codeql_database_create([], lang="go", source="work", db=None, runFunction=runUnsuccessfully)
 
 check_diagnostics()

--- a/go/ql/integration-tests/all-platforms/go/diagnostics/newer-go-version-needed/work/go.mod
+++ b/go/ql/integration-tests/all-platforms/go/diagnostics/newer-go-version-needed/work/go.mod
@@ -1,3 +1,3 @@
-go 999.0
+go 1.999.0
 
 module test


### PR DESCRIPTION
**Summary**

In Go 1.21 and above, `go` commands will try to download the version of Go that is specified in the `go.mod` file. This means that running e.g. `go version` in a folder with a `go.mod` file won't actually return the version of the Go tools installed on the system, but will instead cause them to try and download the version specified in `go.mod` and then invoke the downloaded toolchain's `version` command. 

We now work around this by invoking `go version` ~outside of the working directory in a location where we assume no `go.mod` file is present, as this will cause the `go` tool to print its own version.~ with `GOTOOLCHAIN=local` (thanks @smowton!)

We further lay some groundwork for understanding the new Go version format and `toolchain` directives. 

The `newer-go-version-needed` test / diagnostic essentially no longer applies to Go 1.21 and above. We do not currently have the test infrastructure to test with multiple system versions of Go in place, so I have removed the expected diagnostic output.