### PR TITLE
CPP: Add a location to TranslatedElement to help with debugging IR creation

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/internal/TranslatedElement.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/internal/TranslatedElement.qll
@@ -824,6 +824,9 @@ abstract class TranslatedElement extends TTranslatedElement {
   /** DEPRECATED: Alias for getAst */
   deprecated Locatable getAST() { result = this.getAst() }
 
+  /** Gets the location of this element. */
+  Location getLocation() { result = this.getAst().getLocation() }
+
   /**
    * Get the first instruction to be executed in the evaluation of this element.
    */

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/internal/TranslatedGlobalVar.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/internal/TranslatedGlobalVar.qll
@@ -22,8 +22,6 @@ class TranslatedStaticStorageDurationVarInit extends TranslatedRootElement,
 
   final override Declaration getFunction() { result = var }
 
-  final Location getLocation() { result = var.getLocation() }
-
   override Instruction getFirstInstruction() { result = this.getInstruction(EnterFunctionTag()) }
 
   override TranslatedElement getChild(int n) {


### PR DESCRIPTION
I have done this a few times. As this is not public it shouldn't make any differences other than when debugging.