### PR TITLE
Ruby: Restrict GraphQL remote flow sources

### DIFF
--- a/ruby/ql/lib/change-notes/2023-09-18-graphql-sources.md
+++ b/ruby/ql/lib/change-notes/2023-09-18-graphql-sources.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* GraphQL enums are no longer considered remote flow sources.

--- a/ruby/ql/lib/codeql/ruby/frameworks/GraphQL.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/GraphQL.qll
@@ -443,7 +443,7 @@ private DataFlow::CallNode parameterAccess(
   GraphqlFieldResolutionMethod method, GraphqlFieldArgumentDefinitionMethodCall def,
   HashSplatParameter param, string key, GraphqlType type
 ) {
-  param = method.getARoutedParameter() and
+  param = method.getAParameter() and
   def = method.getDefinition().getAnArgumentCall() and
   (
     // Direct access to the params hash

--- a/ruby/ql/test/library-tests/frameworks/graphql/GraphQL.expected
+++ b/ruby/ql/test/library-tests/frameworks/graphql/GraphQL.expected
@@ -1,14 +1,20 @@
 graphqlSchemaObjectClass
 | app/graphql/types/base_object.rb:2:3:4:5 | BaseObject |
 | app/graphql/types/mutation_type.rb:2:3:4:5 | MutationType |
-| app/graphql/types/query_type.rb:2:3:45:5 | QueryType |
+| app/graphql/types/post.rb:1:1:5:5 | Post |
+| app/graphql/types/query_type.rb:2:3:63:5 | QueryType |
 graphqlSchemaObjectFieldDefinition
 | app/graphql/types/mutation_type.rb:2:3:4:5 | MutationType | app/graphql/types/mutation_type.rb:3:5:3:44 | call to field |
-| app/graphql/types/query_type.rb:2:3:45:5 | QueryType | app/graphql/types/query_type.rb:3:5:5:40 | call to field |
-| app/graphql/types/query_type.rb:2:3:45:5 | QueryType | app/graphql/types/query_type.rb:7:5:9:7 | call to field |
-| app/graphql/types/query_type.rb:2:3:45:5 | QueryType | app/graphql/types/query_type.rb:15:5:17:7 | call to field |
-| app/graphql/types/query_type.rb:2:3:45:5 | QueryType | app/graphql/types/query_type.rb:24:5:26:7 | call to field |
-| app/graphql/types/query_type.rb:2:3:45:5 | QueryType | app/graphql/types/query_type.rb:32:5:35:7 | call to field |
+| app/graphql/types/post.rb:1:1:5:5 | Post | app/graphql/types/post.rb:2:5:2:24 | call to field |
+| app/graphql/types/post.rb:1:1:5:5 | Post | app/graphql/types/post.rb:3:5:3:36 | call to field |
+| app/graphql/types/post.rb:1:1:5:5 | Post | app/graphql/types/post.rb:4:5:4:60 | call to field |
+| app/graphql/types/query_type.rb:2:3:63:5 | QueryType | app/graphql/types/query_type.rb:3:5:5:40 | call to field |
+| app/graphql/types/query_type.rb:2:3:63:5 | QueryType | app/graphql/types/query_type.rb:7:5:9:7 | call to field |
+| app/graphql/types/query_type.rb:2:3:63:5 | QueryType | app/graphql/types/query_type.rb:15:5:17:7 | call to field |
+| app/graphql/types/query_type.rb:2:3:63:5 | QueryType | app/graphql/types/query_type.rb:24:5:26:7 | call to field |
+| app/graphql/types/query_type.rb:2:3:63:5 | QueryType | app/graphql/types/query_type.rb:32:5:35:7 | call to field |
+| app/graphql/types/query_type.rb:2:3:63:5 | QueryType | app/graphql/types/query_type.rb:46:5:49:7 | call to field |
+| app/graphql/types/query_type.rb:2:3:63:5 | QueryType | app/graphql/types/query_type.rb:55:5:57:7 | call to field |
 graphqlResolveMethod
 | app/graphql/mutations/dummy.rb:9:5:12:7 | resolve |
 | app/graphql/resolvers/dummy_resolver.rb:10:5:13:7 | resolve |
@@ -23,24 +29,39 @@ graphqlLoadMethodRoutedParameter
 | app/graphql/resolvers/dummy_resolver.rb:6:5:8:7 | load_something | app/graphql/resolvers/dummy_resolver.rb:6:24:6:25 | id |
 graphqlFieldDefinitionMethodCall
 | app/graphql/types/mutation_type.rb:3:5:3:44 | call to field |
+| app/graphql/types/post.rb:2:5:2:24 | call to field |
+| app/graphql/types/post.rb:3:5:3:36 | call to field |
+| app/graphql/types/post.rb:4:5:4:60 | call to field |
 | app/graphql/types/query_type.rb:3:5:5:40 | call to field |
 | app/graphql/types/query_type.rb:7:5:9:7 | call to field |
 | app/graphql/types/query_type.rb:15:5:17:7 | call to field |
 | app/graphql/types/query_type.rb:24:5:26:7 | call to field |
 | app/graphql/types/query_type.rb:32:5:35:7 | call to field |
+| app/graphql/types/query_type.rb:46:5:49:7 | call to field |
+| app/graphql/types/query_type.rb:55:5:57:7 | call to field |
 graphqlFieldResolutionMethod
 | app/graphql/types/query_type.rb:10:5:13:7 | with_arg |
 | app/graphql/types/query_type.rb:18:5:22:7 | custom_method |
 | app/graphql/types/query_type.rb:27:5:30:7 | with_splat |
 | app/graphql/types/query_type.rb:36:5:40:7 | with_splat_and_named_arg |
+| app/graphql/types/query_type.rb:50:5:53:7 | with_enum |
+| app/graphql/types/query_type.rb:58:5:62:7 | with_nested_enum |
 graphqlFieldResolutionRoutedParameter
 | app/graphql/types/query_type.rb:10:5:13:7 | with_arg | app/graphql/types/query_type.rb:10:18:10:23 | number |
 | app/graphql/types/query_type.rb:18:5:22:7 | custom_method | app/graphql/types/query_type.rb:18:23:18:33 | blah_number |
-| app/graphql/types/query_type.rb:27:5:30:7 | with_splat | app/graphql/types/query_type.rb:27:20:27:25 | **args |
 | app/graphql/types/query_type.rb:36:5:40:7 | with_splat_and_named_arg | app/graphql/types/query_type.rb:36:34:36:37 | arg1 |
-| app/graphql/types/query_type.rb:36:5:40:7 | with_splat_and_named_arg | app/graphql/types/query_type.rb:36:41:36:46 | **rest |
 graphqlFieldResolutionDefinition
 | app/graphql/types/query_type.rb:10:5:13:7 | with_arg | app/graphql/types/query_type.rb:7:5:9:7 | call to field |
 | app/graphql/types/query_type.rb:18:5:22:7 | custom_method | app/graphql/types/query_type.rb:15:5:17:7 | call to field |
 | app/graphql/types/query_type.rb:27:5:30:7 | with_splat | app/graphql/types/query_type.rb:24:5:26:7 | call to field |
 | app/graphql/types/query_type.rb:36:5:40:7 | with_splat_and_named_arg | app/graphql/types/query_type.rb:32:5:35:7 | call to field |
+| app/graphql/types/query_type.rb:50:5:53:7 | with_enum | app/graphql/types/query_type.rb:46:5:49:7 | call to field |
+| app/graphql/types/query_type.rb:58:5:62:7 | with_nested_enum | app/graphql/types/query_type.rb:55:5:57:7 | call to field |
+graphqlRemoteFlowSources
+| app/graphql/mutations/dummy.rb:5:24:5:25 | id |
+| app/graphql/mutations/dummy.rb:9:17:9:25 | something |
+| app/graphql/resolvers/dummy_resolver.rb:6:24:6:25 | id |
+| app/graphql/resolvers/dummy_resolver.rb:10:17:10:25 | something |
+| app/graphql/types/query_type.rb:10:18:10:23 | number |
+| app/graphql/types/query_type.rb:18:23:18:33 | blah_number |
+| app/graphql/types/query_type.rb:36:34:36:37 | arg1 |

--- a/ruby/ql/test/library-tests/frameworks/graphql/GraphQL.expected
+++ b/ruby/ql/test/library-tests/frameworks/graphql/GraphQL.expected
@@ -2,21 +2,22 @@ graphqlSchemaObjectClass
 | app/graphql/types/base_object.rb:2:3:4:5 | BaseObject |
 | app/graphql/types/mutation_type.rb:2:3:4:5 | MutationType |
 | app/graphql/types/post.rb:1:1:6:5 | Post |
-| app/graphql/types/query_type.rb:2:3:71:5 | QueryType |
+| app/graphql/types/query_type.rb:2:3:85:5 | QueryType |
 graphqlSchemaObjectFieldDefinition
 | app/graphql/types/mutation_type.rb:2:3:4:5 | MutationType | app/graphql/types/mutation_type.rb:3:5:3:44 | call to field |
 | app/graphql/types/post.rb:1:1:6:5 | Post | app/graphql/types/post.rb:2:5:2:24 | call to field |
 | app/graphql/types/post.rb:1:1:6:5 | Post | app/graphql/types/post.rb:3:5:3:36 | call to field |
 | app/graphql/types/post.rb:1:1:6:5 | Post | app/graphql/types/post.rb:4:5:4:60 | call to field |
 | app/graphql/types/post.rb:1:1:6:5 | Post | app/graphql/types/post.rb:5:5:5:51 | call to field |
-| app/graphql/types/query_type.rb:2:3:71:5 | QueryType | app/graphql/types/query_type.rb:3:5:5:40 | call to field |
-| app/graphql/types/query_type.rb:2:3:71:5 | QueryType | app/graphql/types/query_type.rb:7:5:9:7 | call to field |
-| app/graphql/types/query_type.rb:2:3:71:5 | QueryType | app/graphql/types/query_type.rb:15:5:17:7 | call to field |
-| app/graphql/types/query_type.rb:2:3:71:5 | QueryType | app/graphql/types/query_type.rb:24:5:26:7 | call to field |
-| app/graphql/types/query_type.rb:2:3:71:5 | QueryType | app/graphql/types/query_type.rb:32:5:35:7 | call to field |
-| app/graphql/types/query_type.rb:2:3:71:5 | QueryType | app/graphql/types/query_type.rb:46:5:49:7 | call to field |
-| app/graphql/types/query_type.rb:2:3:71:5 | QueryType | app/graphql/types/query_type.rb:55:5:57:7 | call to field |
-| app/graphql/types/query_type.rb:2:3:71:5 | QueryType | app/graphql/types/query_type.rb:65:5:67:7 | call to field |
+| app/graphql/types/query_type.rb:2:3:85:5 | QueryType | app/graphql/types/query_type.rb:3:5:5:40 | call to field |
+| app/graphql/types/query_type.rb:2:3:85:5 | QueryType | app/graphql/types/query_type.rb:7:5:9:7 | call to field |
+| app/graphql/types/query_type.rb:2:3:85:5 | QueryType | app/graphql/types/query_type.rb:15:5:17:7 | call to field |
+| app/graphql/types/query_type.rb:2:3:85:5 | QueryType | app/graphql/types/query_type.rb:24:5:26:7 | call to field |
+| app/graphql/types/query_type.rb:2:3:85:5 | QueryType | app/graphql/types/query_type.rb:32:5:35:7 | call to field |
+| app/graphql/types/query_type.rb:2:3:85:5 | QueryType | app/graphql/types/query_type.rb:46:5:49:7 | call to field |
+| app/graphql/types/query_type.rb:2:3:85:5 | QueryType | app/graphql/types/query_type.rb:55:5:57:7 | call to field |
+| app/graphql/types/query_type.rb:2:3:85:5 | QueryType | app/graphql/types/query_type.rb:65:5:67:7 | call to field |
+| app/graphql/types/query_type.rb:2:3:85:5 | QueryType | app/graphql/types/query_type.rb:72:5:76:7 | call to field |
 graphqlResolveMethod
 | app/graphql/mutations/dummy.rb:9:5:12:7 | resolve |
 | app/graphql/resolvers/dummy_resolver.rb:10:5:13:7 | resolve |
@@ -43,6 +44,7 @@ graphqlFieldDefinitionMethodCall
 | app/graphql/types/query_type.rb:46:5:49:7 | call to field |
 | app/graphql/types/query_type.rb:55:5:57:7 | call to field |
 | app/graphql/types/query_type.rb:65:5:67:7 | call to field |
+| app/graphql/types/query_type.rb:72:5:76:7 | call to field |
 graphqlFieldResolutionMethod
 | app/graphql/types/query_type.rb:10:5:13:7 | with_arg |
 | app/graphql/types/query_type.rb:18:5:22:7 | custom_method |
@@ -51,11 +53,13 @@ graphqlFieldResolutionMethod
 | app/graphql/types/query_type.rb:50:5:53:7 | with_enum |
 | app/graphql/types/query_type.rb:58:5:63:7 | with_nested_enum |
 | app/graphql/types/query_type.rb:68:5:70:7 | with_array |
+| app/graphql/types/query_type.rb:77:5:84:7 | with_named_params |
 graphqlFieldResolutionRoutedParameter
 | app/graphql/types/query_type.rb:10:5:13:7 | with_arg | app/graphql/types/query_type.rb:10:18:10:23 | number |
 | app/graphql/types/query_type.rb:18:5:22:7 | custom_method | app/graphql/types/query_type.rb:18:23:18:33 | blah_number |
 | app/graphql/types/query_type.rb:36:5:40:7 | with_splat_and_named_arg | app/graphql/types/query_type.rb:36:34:36:37 | arg1 |
 | app/graphql/types/query_type.rb:68:5:70:7 | with_array | app/graphql/types/query_type.rb:68:20:68:23 | list |
+| app/graphql/types/query_type.rb:77:5:84:7 | with_named_params | app/graphql/types/query_type.rb:77:27:77:30 | arg1 |
 graphqlFieldResolutionDefinition
 | app/graphql/types/query_type.rb:10:5:13:7 | with_arg | app/graphql/types/query_type.rb:7:5:9:7 | call to field |
 | app/graphql/types/query_type.rb:18:5:22:7 | custom_method | app/graphql/types/query_type.rb:15:5:17:7 | call to field |
@@ -64,6 +68,7 @@ graphqlFieldResolutionDefinition
 | app/graphql/types/query_type.rb:50:5:53:7 | with_enum | app/graphql/types/query_type.rb:46:5:49:7 | call to field |
 | app/graphql/types/query_type.rb:58:5:63:7 | with_nested_enum | app/graphql/types/query_type.rb:55:5:57:7 | call to field |
 | app/graphql/types/query_type.rb:68:5:70:7 | with_array | app/graphql/types/query_type.rb:65:5:67:7 | call to field |
+| app/graphql/types/query_type.rb:77:5:84:7 | with_named_params | app/graphql/types/query_type.rb:72:5:76:7 | call to field |
 graphqlRemoteFlowSources
 | app/graphql/mutations/dummy.rb:5:24:5:25 | id |
 | app/graphql/mutations/dummy.rb:9:17:9:25 | something |
@@ -78,3 +83,5 @@ graphqlRemoteFlowSources
 | app/graphql/types/query_type.rb:52:22:52:32 | ...[...] |
 | app/graphql/types/query_type.rb:60:22:60:41 | ...[...] |
 | app/graphql/types/query_type.rb:68:20:68:23 | list |
+| app/graphql/types/query_type.rb:77:27:77:30 | arg1 |
+| app/graphql/types/query_type.rb:80:22:80:33 | ...[...] |

--- a/ruby/ql/test/library-tests/frameworks/graphql/GraphQL.expected
+++ b/ruby/ql/test/library-tests/frameworks/graphql/GraphQL.expected
@@ -1,20 +1,21 @@
 graphqlSchemaObjectClass
 | app/graphql/types/base_object.rb:2:3:4:5 | BaseObject |
 | app/graphql/types/mutation_type.rb:2:3:4:5 | MutationType |
-| app/graphql/types/post.rb:1:1:5:5 | Post |
-| app/graphql/types/query_type.rb:2:3:63:5 | QueryType |
+| app/graphql/types/post.rb:1:1:6:5 | Post |
+| app/graphql/types/query_type.rb:2:3:64:5 | QueryType |
 graphqlSchemaObjectFieldDefinition
 | app/graphql/types/mutation_type.rb:2:3:4:5 | MutationType | app/graphql/types/mutation_type.rb:3:5:3:44 | call to field |
-| app/graphql/types/post.rb:1:1:5:5 | Post | app/graphql/types/post.rb:2:5:2:24 | call to field |
-| app/graphql/types/post.rb:1:1:5:5 | Post | app/graphql/types/post.rb:3:5:3:36 | call to field |
-| app/graphql/types/post.rb:1:1:5:5 | Post | app/graphql/types/post.rb:4:5:4:60 | call to field |
-| app/graphql/types/query_type.rb:2:3:63:5 | QueryType | app/graphql/types/query_type.rb:3:5:5:40 | call to field |
-| app/graphql/types/query_type.rb:2:3:63:5 | QueryType | app/graphql/types/query_type.rb:7:5:9:7 | call to field |
-| app/graphql/types/query_type.rb:2:3:63:5 | QueryType | app/graphql/types/query_type.rb:15:5:17:7 | call to field |
-| app/graphql/types/query_type.rb:2:3:63:5 | QueryType | app/graphql/types/query_type.rb:24:5:26:7 | call to field |
-| app/graphql/types/query_type.rb:2:3:63:5 | QueryType | app/graphql/types/query_type.rb:32:5:35:7 | call to field |
-| app/graphql/types/query_type.rb:2:3:63:5 | QueryType | app/graphql/types/query_type.rb:46:5:49:7 | call to field |
-| app/graphql/types/query_type.rb:2:3:63:5 | QueryType | app/graphql/types/query_type.rb:55:5:57:7 | call to field |
+| app/graphql/types/post.rb:1:1:6:5 | Post | app/graphql/types/post.rb:2:5:2:24 | call to field |
+| app/graphql/types/post.rb:1:1:6:5 | Post | app/graphql/types/post.rb:3:5:3:36 | call to field |
+| app/graphql/types/post.rb:1:1:6:5 | Post | app/graphql/types/post.rb:4:5:4:60 | call to field |
+| app/graphql/types/post.rb:1:1:6:5 | Post | app/graphql/types/post.rb:5:5:5:51 | call to field |
+| app/graphql/types/query_type.rb:2:3:64:5 | QueryType | app/graphql/types/query_type.rb:3:5:5:40 | call to field |
+| app/graphql/types/query_type.rb:2:3:64:5 | QueryType | app/graphql/types/query_type.rb:7:5:9:7 | call to field |
+| app/graphql/types/query_type.rb:2:3:64:5 | QueryType | app/graphql/types/query_type.rb:15:5:17:7 | call to field |
+| app/graphql/types/query_type.rb:2:3:64:5 | QueryType | app/graphql/types/query_type.rb:24:5:26:7 | call to field |
+| app/graphql/types/query_type.rb:2:3:64:5 | QueryType | app/graphql/types/query_type.rb:32:5:35:7 | call to field |
+| app/graphql/types/query_type.rb:2:3:64:5 | QueryType | app/graphql/types/query_type.rb:46:5:49:7 | call to field |
+| app/graphql/types/query_type.rb:2:3:64:5 | QueryType | app/graphql/types/query_type.rb:55:5:57:7 | call to field |
 graphqlResolveMethod
 | app/graphql/mutations/dummy.rb:9:5:12:7 | resolve |
 | app/graphql/resolvers/dummy_resolver.rb:10:5:13:7 | resolve |
@@ -32,6 +33,7 @@ graphqlFieldDefinitionMethodCall
 | app/graphql/types/post.rb:2:5:2:24 | call to field |
 | app/graphql/types/post.rb:3:5:3:36 | call to field |
 | app/graphql/types/post.rb:4:5:4:60 | call to field |
+| app/graphql/types/post.rb:5:5:5:51 | call to field |
 | app/graphql/types/query_type.rb:3:5:5:40 | call to field |
 | app/graphql/types/query_type.rb:7:5:9:7 | call to field |
 | app/graphql/types/query_type.rb:15:5:17:7 | call to field |
@@ -45,7 +47,7 @@ graphqlFieldResolutionMethod
 | app/graphql/types/query_type.rb:27:5:30:7 | with_splat |
 | app/graphql/types/query_type.rb:36:5:40:7 | with_splat_and_named_arg |
 | app/graphql/types/query_type.rb:50:5:53:7 | with_enum |
-| app/graphql/types/query_type.rb:58:5:62:7 | with_nested_enum |
+| app/graphql/types/query_type.rb:58:5:63:7 | with_nested_enum |
 graphqlFieldResolutionRoutedParameter
 | app/graphql/types/query_type.rb:10:5:13:7 | with_arg | app/graphql/types/query_type.rb:10:18:10:23 | number |
 | app/graphql/types/query_type.rb:18:5:22:7 | custom_method | app/graphql/types/query_type.rb:18:23:18:33 | blah_number |
@@ -56,7 +58,7 @@ graphqlFieldResolutionDefinition
 | app/graphql/types/query_type.rb:27:5:30:7 | with_splat | app/graphql/types/query_type.rb:24:5:26:7 | call to field |
 | app/graphql/types/query_type.rb:36:5:40:7 | with_splat_and_named_arg | app/graphql/types/query_type.rb:32:5:35:7 | call to field |
 | app/graphql/types/query_type.rb:50:5:53:7 | with_enum | app/graphql/types/query_type.rb:46:5:49:7 | call to field |
-| app/graphql/types/query_type.rb:58:5:62:7 | with_nested_enum | app/graphql/types/query_type.rb:55:5:57:7 | call to field |
+| app/graphql/types/query_type.rb:58:5:63:7 | with_nested_enum | app/graphql/types/query_type.rb:55:5:57:7 | call to field |
 graphqlRemoteFlowSources
 | app/graphql/mutations/dummy.rb:5:24:5:25 | id |
 | app/graphql/mutations/dummy.rb:9:17:9:25 | something |
@@ -64,4 +66,9 @@ graphqlRemoteFlowSources
 | app/graphql/resolvers/dummy_resolver.rb:10:17:10:25 | something |
 | app/graphql/types/query_type.rb:10:18:10:23 | number |
 | app/graphql/types/query_type.rb:18:23:18:33 | blah_number |
+| app/graphql/types/query_type.rb:28:22:28:37 | ...[...] |
+| app/graphql/types/query_type.rb:29:7:29:22 | ...[...] |
 | app/graphql/types/query_type.rb:36:34:36:37 | arg1 |
+| app/graphql/types/query_type.rb:38:22:38:32 | ...[...] |
+| app/graphql/types/query_type.rb:52:22:52:32 | ...[...] |
+| app/graphql/types/query_type.rb:60:22:60:41 | ...[...] |

--- a/ruby/ql/test/library-tests/frameworks/graphql/GraphQL.expected
+++ b/ruby/ql/test/library-tests/frameworks/graphql/GraphQL.expected
@@ -2,20 +2,21 @@ graphqlSchemaObjectClass
 | app/graphql/types/base_object.rb:2:3:4:5 | BaseObject |
 | app/graphql/types/mutation_type.rb:2:3:4:5 | MutationType |
 | app/graphql/types/post.rb:1:1:6:5 | Post |
-| app/graphql/types/query_type.rb:2:3:64:5 | QueryType |
+| app/graphql/types/query_type.rb:2:3:71:5 | QueryType |
 graphqlSchemaObjectFieldDefinition
 | app/graphql/types/mutation_type.rb:2:3:4:5 | MutationType | app/graphql/types/mutation_type.rb:3:5:3:44 | call to field |
 | app/graphql/types/post.rb:1:1:6:5 | Post | app/graphql/types/post.rb:2:5:2:24 | call to field |
 | app/graphql/types/post.rb:1:1:6:5 | Post | app/graphql/types/post.rb:3:5:3:36 | call to field |
 | app/graphql/types/post.rb:1:1:6:5 | Post | app/graphql/types/post.rb:4:5:4:60 | call to field |
 | app/graphql/types/post.rb:1:1:6:5 | Post | app/graphql/types/post.rb:5:5:5:51 | call to field |
-| app/graphql/types/query_type.rb:2:3:64:5 | QueryType | app/graphql/types/query_type.rb:3:5:5:40 | call to field |
-| app/graphql/types/query_type.rb:2:3:64:5 | QueryType | app/graphql/types/query_type.rb:7:5:9:7 | call to field |
-| app/graphql/types/query_type.rb:2:3:64:5 | QueryType | app/graphql/types/query_type.rb:15:5:17:7 | call to field |
-| app/graphql/types/query_type.rb:2:3:64:5 | QueryType | app/graphql/types/query_type.rb:24:5:26:7 | call to field |
-| app/graphql/types/query_type.rb:2:3:64:5 | QueryType | app/graphql/types/query_type.rb:32:5:35:7 | call to field |
-| app/graphql/types/query_type.rb:2:3:64:5 | QueryType | app/graphql/types/query_type.rb:46:5:49:7 | call to field |
-| app/graphql/types/query_type.rb:2:3:64:5 | QueryType | app/graphql/types/query_type.rb:55:5:57:7 | call to field |
+| app/graphql/types/query_type.rb:2:3:71:5 | QueryType | app/graphql/types/query_type.rb:3:5:5:40 | call to field |
+| app/graphql/types/query_type.rb:2:3:71:5 | QueryType | app/graphql/types/query_type.rb:7:5:9:7 | call to field |
+| app/graphql/types/query_type.rb:2:3:71:5 | QueryType | app/graphql/types/query_type.rb:15:5:17:7 | call to field |
+| app/graphql/types/query_type.rb:2:3:71:5 | QueryType | app/graphql/types/query_type.rb:24:5:26:7 | call to field |
+| app/graphql/types/query_type.rb:2:3:71:5 | QueryType | app/graphql/types/query_type.rb:32:5:35:7 | call to field |
+| app/graphql/types/query_type.rb:2:3:71:5 | QueryType | app/graphql/types/query_type.rb:46:5:49:7 | call to field |
+| app/graphql/types/query_type.rb:2:3:71:5 | QueryType | app/graphql/types/query_type.rb:55:5:57:7 | call to field |
+| app/graphql/types/query_type.rb:2:3:71:5 | QueryType | app/graphql/types/query_type.rb:65:5:67:7 | call to field |
 graphqlResolveMethod
 | app/graphql/mutations/dummy.rb:9:5:12:7 | resolve |
 | app/graphql/resolvers/dummy_resolver.rb:10:5:13:7 | resolve |
@@ -41,6 +42,7 @@ graphqlFieldDefinitionMethodCall
 | app/graphql/types/query_type.rb:32:5:35:7 | call to field |
 | app/graphql/types/query_type.rb:46:5:49:7 | call to field |
 | app/graphql/types/query_type.rb:55:5:57:7 | call to field |
+| app/graphql/types/query_type.rb:65:5:67:7 | call to field |
 graphqlFieldResolutionMethod
 | app/graphql/types/query_type.rb:10:5:13:7 | with_arg |
 | app/graphql/types/query_type.rb:18:5:22:7 | custom_method |
@@ -48,10 +50,12 @@ graphqlFieldResolutionMethod
 | app/graphql/types/query_type.rb:36:5:40:7 | with_splat_and_named_arg |
 | app/graphql/types/query_type.rb:50:5:53:7 | with_enum |
 | app/graphql/types/query_type.rb:58:5:63:7 | with_nested_enum |
+| app/graphql/types/query_type.rb:68:5:70:7 | with_array |
 graphqlFieldResolutionRoutedParameter
 | app/graphql/types/query_type.rb:10:5:13:7 | with_arg | app/graphql/types/query_type.rb:10:18:10:23 | number |
 | app/graphql/types/query_type.rb:18:5:22:7 | custom_method | app/graphql/types/query_type.rb:18:23:18:33 | blah_number |
 | app/graphql/types/query_type.rb:36:5:40:7 | with_splat_and_named_arg | app/graphql/types/query_type.rb:36:34:36:37 | arg1 |
+| app/graphql/types/query_type.rb:68:5:70:7 | with_array | app/graphql/types/query_type.rb:68:20:68:23 | list |
 graphqlFieldResolutionDefinition
 | app/graphql/types/query_type.rb:10:5:13:7 | with_arg | app/graphql/types/query_type.rb:7:5:9:7 | call to field |
 | app/graphql/types/query_type.rb:18:5:22:7 | custom_method | app/graphql/types/query_type.rb:15:5:17:7 | call to field |
@@ -59,6 +63,7 @@ graphqlFieldResolutionDefinition
 | app/graphql/types/query_type.rb:36:5:40:7 | with_splat_and_named_arg | app/graphql/types/query_type.rb:32:5:35:7 | call to field |
 | app/graphql/types/query_type.rb:50:5:53:7 | with_enum | app/graphql/types/query_type.rb:46:5:49:7 | call to field |
 | app/graphql/types/query_type.rb:58:5:63:7 | with_nested_enum | app/graphql/types/query_type.rb:55:5:57:7 | call to field |
+| app/graphql/types/query_type.rb:68:5:70:7 | with_array | app/graphql/types/query_type.rb:65:5:67:7 | call to field |
 graphqlRemoteFlowSources
 | app/graphql/mutations/dummy.rb:5:24:5:25 | id |
 | app/graphql/mutations/dummy.rb:9:17:9:25 | something |
@@ -72,3 +77,4 @@ graphqlRemoteFlowSources
 | app/graphql/types/query_type.rb:38:22:38:32 | ...[...] |
 | app/graphql/types/query_type.rb:52:22:52:32 | ...[...] |
 | app/graphql/types/query_type.rb:60:22:60:41 | ...[...] |
+| app/graphql/types/query_type.rb:68:20:68:23 | list |

--- a/ruby/ql/test/library-tests/frameworks/graphql/GraphQL.ql
+++ b/ruby/ql/test/library-tests/frameworks/graphql/GraphQL.ql
@@ -1,5 +1,6 @@
 private import codeql.ruby.frameworks.GraphQL
 private import codeql.ruby.AST
+private import codeql.ruby.dataflow.RemoteFlowSources
 
 query predicate graphqlSchemaObjectClass(GraphqlSchemaObjectClass cls) { any() }
 
@@ -34,3 +35,5 @@ query predicate graphqlFieldResolutionDefinition(
 ) {
   meth.getDefinition() = def
 }
+
+query predicate graphqlRemoteFlowSources(RemoteFlowSource src) { any() }

--- a/ruby/ql/test/library-tests/frameworks/graphql/app/graphql/types/base_enum.rb
+++ b/ruby/ql/test/library-tests/frameworks/graphql/app/graphql/types/base_enum.rb
@@ -1,0 +1,2 @@
+class Types::BaseEnum < GraphQL::Schema::Enum
+end

--- a/ruby/ql/test/library-tests/frameworks/graphql/app/graphql/types/direction.rb
+++ b/ruby/ql/test/library-tests/frameworks/graphql/app/graphql/types/direction.rb
@@ -1,0 +1,6 @@
+module Types
+    class Direction < Types::BaseEnum
+        value "asc", "Ascending order", value: "asc"
+        value "desc", "Descending order", value: "desc"
+    end
+end

--- a/ruby/ql/test/library-tests/frameworks/graphql/app/graphql/types/media_category.rb
+++ b/ruby/ql/test/library-tests/frameworks/graphql/app/graphql/types/media_category.rb
@@ -1,0 +1,8 @@
+module Types
+  class MediaCategory < Types::BaseEnum
+    value "AUDIO", "An audio file, such as music or spoken word"
+    value "IMAGE", "A still image, such as a photo or graphic"
+    value "TEXT", "Written words"
+    value "VIDEO", "Motion picture, may have audio"
+  end
+end

--- a/ruby/ql/test/library-tests/frameworks/graphql/app/graphql/types/post.rb
+++ b/ruby/ql/test/library-tests/frameworks/graphql/app/graphql/types/post.rb
@@ -1,0 +1,7 @@
+class Types::Post < GraphQL::Schema::Object
+    field :title, String
+    field :body, String, null: false
+    field :media_category, Types::MediaCategory, null: false
+  end
+end
+  

--- a/ruby/ql/test/library-tests/frameworks/graphql/app/graphql/types/post.rb
+++ b/ruby/ql/test/library-tests/frameworks/graphql/app/graphql/types/post.rb
@@ -2,6 +2,7 @@ class Types::Post < GraphQL::Schema::Object
     field :title, String
     field :body, String, null: false
     field :media_category, Types::MediaCategory, null: false
+    field :direction, Types::Direction, null: false
   end
 end
   

--- a/ruby/ql/test/library-tests/frameworks/graphql/app/graphql/types/post_order.rb
+++ b/ruby/ql/test/library-tests/frameworks/graphql/app/graphql/types/post_order.rb
@@ -1,0 +1,5 @@
+module Types
+    class PostOrder < Types::BaseInputObject
+        argument :direction, Types::Direction, "The ordering direction", required: true
+    end
+end

--- a/ruby/ql/test/library-tests/frameworks/graphql/app/graphql/types/query_type.rb
+++ b/ruby/ql/test/library-tests/frameworks/graphql/app/graphql/types/query_type.rb
@@ -61,5 +61,12 @@ module Types
       system("echo #{args[:inner][:media_category]}")
       system("echo #{args[:inner][:direction]}")
     end
+
+    field :with_array, String do
+      argument :list, [String], "Names"
+    end
+    def with_array(list:)
+      system("echo #{list[0]}")
+    end
   end
 end

--- a/ruby/ql/test/library-tests/frameworks/graphql/app/graphql/types/query_type.rb
+++ b/ruby/ql/test/library-tests/frameworks/graphql/app/graphql/types/query_type.rb
@@ -42,5 +42,23 @@ module Types
     def foo(arg)
       system("echo #{arg}")
     end
+
+    field :with_enum, String, null: false, description: "A field with an enum argument" do
+      argument :enum, Types::MediaCategory, "An enum", required: true
+      argument :arg2, String, "Another arg", required: true
+    end
+    def with_enum(**args)
+      system("echo #{args[:enum]}")
+      system("echo #{args[:arg2]}")
+    end
+
+    field :with_nested_enum, String, null: false, description: "A field with a nested enum argument" do
+      argument :inner, Types::Post, "Post", required: true
+    end
+    def with_nested_enum(**args)
+      system("echo #{args[:inner]}")
+      system("echo #{args[:inner][:title]}")
+      system("echo #{args[:inner][:media_category]}")
+    end
   end
 end

--- a/ruby/ql/test/library-tests/frameworks/graphql/app/graphql/types/query_type.rb
+++ b/ruby/ql/test/library-tests/frameworks/graphql/app/graphql/types/query_type.rb
@@ -59,6 +59,7 @@ module Types
       system("echo #{args[:inner]}")
       system("echo #{args[:inner][:title]}")
       system("echo #{args[:inner][:media_category]}")
+      system("echo #{args[:inner][:direction]}")
     end
   end
 end

--- a/ruby/ql/test/library-tests/frameworks/graphql/app/graphql/types/query_type.rb
+++ b/ruby/ql/test/library-tests/frameworks/graphql/app/graphql/types/query_type.rb
@@ -68,5 +68,19 @@ module Types
     def with_array(list:)
       system("echo #{list[0]}")
     end
+
+    field :with_named_params, String do
+      argument :arg1, String, "Arg 1"
+      argument :arg2, Types::Post, "Arg 2"
+      argument :arg3, Types::MediaCategory, "Arg 3"
+    end
+    def with_named_params(arg1:, arg2:, **args)
+      system("echo #{arg1}")
+      system("echo #{arg2}")
+      system("echo #{arg2[:title]}")
+      system("echo #{arg2[:media_category]}")
+      system("echo #{args[:arg3]}")
+      system("echo #{args[:not_an_arg]}")
+    end
   end
 end

--- a/ruby/ql/test/query-tests/security/cwe-078/CommandInjection/CommandInjection.expected
+++ b/ruby/ql/test/query-tests/security/cwe-078/CommandInjection/CommandInjection.expected
@@ -17,8 +17,6 @@ edges
 | CommandInjection.rb:54:13:54:24 | ...[...] | CommandInjection.rb:54:7:54:9 | cmd |
 | CommandInjection.rb:73:18:73:23 | number | CommandInjection.rb:74:14:74:29 | "echo #{...}" |
 | CommandInjection.rb:81:23:81:33 | blah_number | CommandInjection.rb:82:14:82:34 | "echo #{...}" |
-| CommandInjection.rb:90:20:90:25 | **args | CommandInjection.rb:91:22:91:25 | args |
-| CommandInjection.rb:91:22:91:25 | args | CommandInjection.rb:91:22:91:37 | ...[...] |
 | CommandInjection.rb:91:22:91:37 | ...[...] | CommandInjection.rb:91:14:91:39 | "echo #{...}" |
 | CommandInjection.rb:103:9:103:12 | file | CommandInjection.rb:104:16:104:28 | "cat #{...}" |
 | CommandInjection.rb:103:16:103:21 | call to params | CommandInjection.rb:103:16:103:28 | ...[...] |
@@ -47,9 +45,7 @@ nodes
 | CommandInjection.rb:74:14:74:29 | "echo #{...}" | semmle.label | "echo #{...}" |
 | CommandInjection.rb:81:23:81:33 | blah_number | semmle.label | blah_number |
 | CommandInjection.rb:82:14:82:34 | "echo #{...}" | semmle.label | "echo #{...}" |
-| CommandInjection.rb:90:20:90:25 | **args | semmle.label | **args |
 | CommandInjection.rb:91:14:91:39 | "echo #{...}" | semmle.label | "echo #{...}" |
-| CommandInjection.rb:91:22:91:25 | args | semmle.label | args |
 | CommandInjection.rb:91:22:91:37 | ...[...] | semmle.label | ...[...] |
 | CommandInjection.rb:103:9:103:12 | file | semmle.label | file |
 | CommandInjection.rb:103:16:103:21 | call to params | semmle.label | call to params |
@@ -69,5 +65,5 @@ subpaths
 | CommandInjection.rb:59:14:59:16 | cmd | CommandInjection.rb:54:13:54:18 | call to params | CommandInjection.rb:59:14:59:16 | cmd | This command depends on a $@. | CommandInjection.rb:54:13:54:18 | call to params | user-provided value |
 | CommandInjection.rb:74:14:74:29 | "echo #{...}" | CommandInjection.rb:73:18:73:23 | number | CommandInjection.rb:74:14:74:29 | "echo #{...}" | This command depends on a $@. | CommandInjection.rb:73:18:73:23 | number | user-provided value |
 | CommandInjection.rb:82:14:82:34 | "echo #{...}" | CommandInjection.rb:81:23:81:33 | blah_number | CommandInjection.rb:82:14:82:34 | "echo #{...}" | This command depends on a $@. | CommandInjection.rb:81:23:81:33 | blah_number | user-provided value |
-| CommandInjection.rb:91:14:91:39 | "echo #{...}" | CommandInjection.rb:90:20:90:25 | **args | CommandInjection.rb:91:14:91:39 | "echo #{...}" | This command depends on a $@. | CommandInjection.rb:90:20:90:25 | **args | user-provided value |
+| CommandInjection.rb:91:14:91:39 | "echo #{...}" | CommandInjection.rb:91:22:91:37 | ...[...] | CommandInjection.rb:91:14:91:39 | "echo #{...}" | This command depends on a $@. | CommandInjection.rb:91:22:91:37 | ...[...] | user-provided value |
 | CommandInjection.rb:104:16:104:28 | "cat #{...}" | CommandInjection.rb:103:16:103:21 | call to params | CommandInjection.rb:104:16:104:28 | "cat #{...}" | This command depends on a $@. | CommandInjection.rb:103:16:103:21 | call to params | user-provided value |


### PR DESCRIPTION
Previously we considered any parameter in a graphql resolver to be
a remote flow source. Now we limit that to parameters (and reads of hash splat parameters) which yield scalar types (e.g. String), as defined by the GraphQL schema.

This should reduce GraphQL false positives.


In general, the idea is to ignore sources which are constrained by GraphQL types. For example:

```rb
class class MediaCategory < GraphQL::Schema::Enum
  value "AUDIO", "An audio file, such as music or spoken word"
  value "IMAGE", "A still image, such as a photo or graphic"
  value "TEXT", "Written words"
  value "VIDEO", "Motion picture, may have audio"
end

class Post < GraphQL::Schema::Object
  field :title, String
  field :body, String
  field :media_category, Types::MediaCategory
end

class QueryType < GraphQL::Schema::Object
  field :my_field, String do
    argument :post, Post, "A post"
  end
  def my_field(**args)
    sink args[:post][:title] # NOT OK - remote input reaches sink
    sink args[:post][:media_category] # OK - input is constrained by the `MediaCategory` enum
  end
end
```