### PR TITLE
Lua: Tracing of `dotnet dotnet`.

### DIFF
--- a/csharp/ql/integration-tests/all-platforms/dotnet_run/test.py
+++ b/csharp/ql/integration-tests/all-platforms/dotnet_run/test.py
@@ -58,3 +58,8 @@ check_diagnostics(test_db="test8-db")
 s = run_codeql_database_create_stdout(['dotnet clean', 'rm -rf test8-db', 'dotnet run "hello world part1" part2'], "test9-db")
 check_build_out("hello world part1, part2", s)
 check_diagnostics(test_db="test9-db")
+
+# two arguments, no '--' (second argument quoted) and using dotnet to execute dotnet
+s = run_codeql_database_create_stdout(['dotnet clean', 'rm -rf test9-db', 'dotnet dotnet run part1 "hello world part2"'], "test10-db")
+check_build_out("part1, hello world part2", s)
+check_diagnostics(test_db="test10-db")


### PR DESCRIPTION
From the `dotnet --help` we can see that it is possible run to run applications using `dotnet` using the following syntax
```
dotnet [runtime-options] [path-to-application] [arguments]
```
It turns out that `dotnet` can be used to invoke `dotnet` - but only nested once. That is, `dotnet dotnet build` is perfectly valid. However, it appears that the tracer is only able to intercept the outer `dotnet` call. To fix this we explicitly *disregard* `dotnet` as a possible subcommand and just look for the next possible `subcommand` - and then re-write the arguments to the dotnet application call. That is, we re-write
```
dotnet dotnet build -> dotnet dotnet build -p:UseSharedCompilation=false
```
then `dotnet` still invokes `dotnet` with `build -p:UseSharedCompilation=false` which is required for tracing.